### PR TITLE
Threading fixes

### DIFF
--- a/include/verilated.h
+++ b/include/verilated.h
@@ -141,7 +141,7 @@ class VL_CAPABILITY("mutex") VerilatedMutex {
     bool try_lock() VL_TRY_ACQUIRE(true) { return m_mutex.try_lock(); }
 };
 
-/// Lock guard for mutex (ala std::lock_guard), wrapped to allow -fthread_safety checks
+/// Lock guard for mutex (ala std::unique_lock), wrapped to allow -fthread_safety checks
 class VL_SCOPED_CAPABILITY VerilatedLockGuard {
     VL_UNCOPYABLE(VerilatedLockGuard);
   private:
@@ -154,6 +154,8 @@ class VL_SCOPED_CAPABILITY VerilatedLockGuard {
     ~VerilatedLockGuard() VL_RELEASE() {
         m_mutexr.unlock();
     }
+    void lock() VL_ACQUIRE(mutexr) { m_mutexr.lock(); }
+    void unlock() VL_RELEASE() { m_mutexr.unlock(); }
 };
 
 #else  // !VL_THREADED
@@ -171,6 +173,8 @@ class VerilatedLockGuard {
 public:
     explicit VerilatedLockGuard(VerilatedMutex&) {}
     ~VerilatedLockGuard() {}
+    void lock() {}
+    void unlock() {}
 };
 
 #endif  // VL_THREADED

--- a/include/verilated_threads.h
+++ b/include/verilated_threads.h
@@ -25,9 +25,11 @@
 #include "verilatedos.h"
 #include "verilated.h"  // for VerilatedMutex and clang annotations
 
-#include <sched.h>  // For sched_getcpu()
 #include <set>
 #include <vector>
+#if defined(__linux)
+#include <sched.h>  // For sched_getcpu()
+#endif
 #if defined(__APPLE__)
 # include <cpuid.h>  // For __cpuid_count()
 #endif
@@ -210,6 +212,8 @@ public:
         } else {
             return (unsigned)info[1] >> 24;
         }
+#elif defined(_WIN32)
+        return GetCurrentProcessorNumber();
 #else
         return 0;
 #endif

--- a/include/verilatedos.h
+++ b/include/verilatedos.h
@@ -122,7 +122,9 @@
 #endif
 
 #ifdef VL_THREADED
-# ifdef __GNUC__
+# if defined(_MSC_VER) && _MSC_VER >= 1900
+#  define VL_THREAD_LOCAL thread_local
+# elif defined(__GNUC__)
 #  if (__cplusplus < 201103L) && !defined(VL_THREADED_NO_C11_WARNING)
 #    error "VL_THREADED/--threads support requires C++-11 or newer only; use newer compiler"
 #  endif
@@ -390,7 +392,12 @@ typedef unsigned long long      vluint64_t;     ///< 64-bit unsigned type
 // Threading related OS-specific functions
 
 #if VL_THREADED
-# if defined(__i386__) || defined(__x86_64__)
+# ifdef _WIN32
+#  define WIN32_LEAN_AND_MEAN
+#  define NOMINMAX
+#  include "Windows.h"
+#  define VL_CPU_RELAX() YieldProcessor()
+# elif defined(__i386__) || defined(__x86_64__)
 /// For more efficient busy waiting on SMT CPUs, let the processor know
 /// we're just waiting so it can let another thread run
 #  define VL_CPU_RELAX() asm volatile("rep; nop" ::: "memory")


### PR DESCRIPTION
The first commit just enables threading on windows.
The second might be more controversial. I've changed the way the worker threads wait, so they now use a condition variable to sleep while there's no work available. This fixes the reported issue where the background threads consume 100% CPU while at the python prompt with the python support that's being worked on elsewhere. This isn't specific to python though, it would manifest with any code that waited for user input or did other non-verilator work. With my test workload this has identical performance to the original code, to within random error, but YMMV. The spinlock at the top of dequeWork was necessary for this, without it performance is much worse for me. The test to avoid notify_one when the worker isn't waiting makes a little difference, but it doesn't hurt.