### PR TITLE
Add missing <algorithm> header.

### DIFF
--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -77,6 +77,7 @@
 #include "V3String.h"
 #include "V3Task.h"
 
+#include <algorithm>
 #include <cstdarg>
 
 // More code; this file was getting too large; see actions there


### PR DESCRIPTION
V3Width uses std::min/max but doesn't include the header where they are defined. This happens to work with gcc, but not with MSVC.