### PR TITLE
Use alloca instead of the variable-size automatic array gcc extension.

### DIFF
--- a/src/V3Options.cpp
+++ b/src/V3Options.cpp
@@ -34,6 +34,7 @@
 #ifndef _WIN32
 # include <sys/utsname.h>
 #endif
+#include <alloca.h>
 #include <cctype>
 #include <dirent.h>
 #include <fcntl.h>
@@ -1364,7 +1365,10 @@ void V3Options::parseOptsFile(FileLine* fl, const string& filename, bool rel) {
     string optdir = (rel ? V3Os::filenameDir(filename) : ".");
 
     // Convert to argv style arg list and parse them
-    char* argv [args.size()+1];
+    char** argv = reinterpret_cast<char**>(alloca(sizeof(char*) * (args.size()+1)));
+    if (!argv) {
+        v3fatal("Could not allocate a temporary buffer for command line arguments: the stack is full.");
+    }
     for (unsigned i=0; i<args.size(); ++i) {
         argv[i] = const_cast<char*>(args[i].c_str());
     }

--- a/src/V3Os.cpp
+++ b/src/V3Os.cpp
@@ -26,6 +26,7 @@
 #include "V3String.h"
 #include "V3Os.h"
 
+#include <alloca.h>
 #include <cerrno>
 #include <climits>
 #include <cstdarg>
@@ -221,8 +222,11 @@ vluint64_t V3Os::rand64(vluint64_t* statep) {
 
 string V3Os::trueRandom(size_t size) {
     string data; data.reserve(size);
+    char *bytes = reinterpret_cast<char*>(alloca(sizeof(char) * size));
+    if (!bytes) {
+        v3fatal("Could not allocate a temporary buffer for random data: the stack is full.");
+    }
     std::ifstream is ("/dev/urandom", std::ios::in | std::ios::binary);
-    char bytes[size];
     if (!is.read(bytes, size)) {
         v3fatal("Could not open /dev/urandom, no source of randomness. Try specifing a key instead.");
         return "";


### PR DESCRIPTION
MSVC does not support the variable-size automatic array extension.