### PR TITLE
V3Number: Use stoi for conversion

### DIFF
--- a/src/V3Number.cpp
+++ b/src/V3Number.cpp
@@ -32,7 +32,6 @@
 #include <iomanip>
 
 #define MAX_SPRINTF_DOUBLE_SIZE 100  // Maximum characters with a sprintf %e/%f/%g (probably < 30)
-#define MAX_WIDTH 5*1024  // Maximum width before error
 
 // Number operations build output in-place so can't call e.g. foo.opX(foo)
 #define NUM_ASSERT_OP_ARGS1(arg1)  \
@@ -124,14 +123,10 @@ void V3Number::V3NumberCreate(AstNode* nodep, const char* sourcep, FileLine* fl)
         if (*cp) { base=*cp; cp++; }
         value_startp = cp;
 
-        if (atoi(widthn.c_str())) {
-            if (atoi(widthn.c_str()) < 0 || atoi(widthn.c_str()) > MAX_WIDTH) {
-                // atoi might convert large number to negative, so can't tell which
-                v3error("Unsupported: Width of number exceeds implementation limit: "<<sourcep);
-                width(MAX_WIDTH, true);
-            } else {
-                width(atoi(widthn.c_str()), true);
-            }
+        try {
+            width(std::stoi(widthn.c_str()), true);
+        } catch (...) {
+            v3error("Width cannot be converted: "<<sourcep);
         }
     } else {
         unbased = true;


### PR DESCRIPTION
Convert using stoi and catch exceptions. This allows for large widths
and avoids the issues with atoi.

Fixes #2082
