### PR TITLE
No assign alias for unpacked public variables

### DIFF
--- a/src/V3Inline.cpp
+++ b/src/V3Inline.cpp
@@ -322,6 +322,15 @@ private:
                     new AstAssignW(nodep->fileline(),
                                    new AstVarRef(nodep->fileline(), exprvarrefp->varp(), true),
                                    new AstVarRef(nodep->fileline(), nodep, false)));
+            } else if (nodep->isSigPublic() && VN_IS(nodep->dtypep(), UnpackArrayDType)) {
+                // Public variable at this end and it is an unpacked array. We need to assign
+                // instead of aliased, because otherwise it will pass V3Slice and invalid
+                // code will be emitted.
+                UINFO(9,"assign to public and unpacked: "<<nodep<<endl);
+                m_modp->addStmtp(
+                    new AstAssignW(nodep->fileline(),
+                                   new AstVarRef(nodep->fileline(), exprvarrefp->varp(), true),
+                                   new AstVarRef(nodep->fileline(), nodep, false)));
             } else if (nodep->isIfaceRef()) {
                 m_modp->addStmtp(
                     new AstAssignVarScope(nodep->fileline(),

--- a/test_regress/t/t_array_unpacked_public.pl
+++ b/test_regress/t/t_array_unpacked_public.pl
@@ -1,0 +1,21 @@
+#!/usr/bin/perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2003 by Wilson Snyder. This program is free software; you can
+# redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+
+scenarios(simulator => 1);
+
+compile(
+    verilator_flags2 => ["--public-flat-rw"],
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_array_unpacked_public.v
+++ b/test_regress/t/t_array_unpacked_public.v
@@ -1,0 +1,21 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed into the Public Domain, for any use,
+// without warranty, 2020 by Stefan Wallentowitz
+
+module t();
+  logic din [0:15];
+
+  array_test array_test_inst(.din(din));
+
+  initial begin
+    $write("*-* All Finished *-*\n");
+    $finish;
+  end
+endmodule
+
+module array_test(
+    input din [0:15]
+);
+
+endmodule


### PR DESCRIPTION
Public variables are all emitted in the C code and unpacked arrays
arrays are sliced up for this. After inlining public unpacked array
assignments should not be alias assignments but actual assignments, so
that they are sliced and hence emitted properly.

Fixes #2073
