### PR TITLE
Update .clang-format so that recent clang-format such as  LLVM-8 works.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -91,7 +91,8 @@ PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 60
 PointerAlignment: Left
 RawStringFormats: 
-  - Delimiter:       pb
+  - Delimiters:
+        - 'pb'
     Language:        TextProto
     BasedOnStyle:    google
 ReflowComments:  true
@@ -108,7 +109,7 @@ SpacesInContainerLiterals: true
 SpacesInCStyleCastParentheses: false
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
-Standard:        Cpp11
+Standard:        Cpp03
 TabWidth:        8
 UseTab:          Never
 ...


### PR DESCRIPTION
I'd like to respect the coding style, but I encountered some troubles when running clang-fomat.

### recent clang-format can not read .clang-format
I see the error as below.
```
$ llvm/8/bin/clang-format --style=file src/V3Ast.h  
YAML:94:22: error: unknown key 'Delimiter'
  - Delimiter:       pb
                     ^~
Error reading /home/yutetsu/prj/verilator/.clang-format: Invalid argument
```
Or if you could specify which version of clang-format to be used, that is appreciated.

### Language standard
I understand this project is still C++03 (basically).
Setting `Standard:        Cpp11`  seems not good because the setting removes space between KETs .
Then the code is not C++03 compatible anymore.

e.g.  std::vector<std::pair<int, int>` `> to std::vector<std::pair<int, int>> 

