### PR TITLE
Fix typo in help output

### DIFF
--- a/bin/verilator
+++ b/bin/verilator
@@ -1078,7 +1078,7 @@ and the remaining files can be compiled on parallel machines.  Using
 design --output-split 20000 resulted in splitting into approximately
 one-minute-compile chunks.
 
-Typically when using this, make with VM_PARALLEL_BUILD=1, and use
+Typically when using this, make with VM_PARALLEL_BUILDS=1, and use
 I<ccache>.
 
 =item --output-split-cfuncs I<statements>


### PR DESCRIPTION
The variable is named VM_PARALLEL_BUILDS, not VM_PARALLEL_BUILD.