### PR TITLE
Fix sign compare warning

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -30,6 +30,7 @@ Philipp Wagner
 Richard Myers
 Sebastien Van Cauwenberghe
 Stefan Wallentowitz
+Tobias Rosenkranz
 Todd Strader
 Wilson Snyder
 Yutetsu TAKATSUKASA

--- a/include/verilated.cpp
+++ b/include/verilated.cpp
@@ -618,7 +618,7 @@ void _vl_vsformat(std::string& output, const char* formatp, va_list ap) VL_MT_SA
     const char* pctp = NULL;  // Most recent %##.##g format
     bool inPct = false;
     bool widthSet = false;
-    int width = 0;
+    size_t width = 0;
     for (const char* pos = formatp; *pos; ++pos) {
         if (!inPct && pos[0]=='%') {
             pctp = pos;


### PR DESCRIPTION
Changed type to reduce warning with "-Wsign-compare"

When compiling verilated code with "-Wsign-compare" warnings like
"warning: comparison of integer expressions of different signedness:
 ‘int’ and ‘std::__cxx11::basic_string<char>::size_type’ {aka ‘long unsigned int’} [-Wsign-compare]"
were given. This patch removes them.