### PR TITLE
Add compile_commands.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 README
 TAGS
 autom4te.cache
+compile_commands.json
 config.cache
 config.status
 configure


### PR DESCRIPTION
When running make with the "bear" command, the generated
compile_commands.json file shouldn't be considered new source. This file
allows clangd-based code completion tools (e.g. YouCompleteMe) to know
the flags that each file was compiled with.