### PR TITLE
Moving V3Global function definitions to their own files

### DIFF
--- a/src/Makefile_obj.in
+++ b/src/Makefile_obj.in
@@ -193,6 +193,7 @@ RAW_OBJS = \
 	V3FileLine.o \
 	V3Gate.o \
 	V3GenClk.o \
+	V3Global.o \
 	V3Graph.o \
 	V3GraphAlg.o \
 	V3GraphAcyc.o \

--- a/src/V3Global.cpp
+++ b/src/V3Global.cpp
@@ -1,6 +1,6 @@
 // -*- mode: C++; c-file-style: "cc-mode" -*-
 //*************************************************************************
-// DESCRIPTION: Verilator: Emit Verilog from tree
+// DESCRIPTION: Verilator: Common implemenetations
 //
 // Code available from: https://verilator.org
 //

--- a/src/V3Global.cpp
+++ b/src/V3Global.cpp
@@ -1,0 +1,90 @@
+// -*- mode: C++; c-file-style: "cc-mode" -*-
+//*************************************************************************
+// DESCRIPTION: Verilator: Emit Verilog from tree
+//
+// Code available from: https://verilator.org
+//
+//*************************************************************************
+//
+// Copyright 2004-2020 by Wilson Snyder.  This program is free software; you can
+// redistribute it and/or modify it under the terms of either the GNU
+// Lesser General Public License Version 3 or the Perl Artistic License
+// Version 2.0.
+//
+// Verilator is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+//*************************************************************************
+
+#include "config_build.h"
+#include "verilatedos.h"
+
+#include "V3Global.h"
+#include "V3Ast.h"
+#include "V3File.h"
+#include "V3LinkCells.h"
+#include "V3Parse.h"
+#include "V3ParseSym.h"
+#include "V3Stats.h"
+
+//######################################################################
+// V3 Class -- top level
+
+AstNetlist* V3Global::makeNetlist() {
+    AstNetlist* newp = new AstNetlist();
+    newp->addTypeTablep(new AstTypeTable(newp->fileline()));
+    return newp;
+}
+
+void V3Global::checkTree() { rootp()->checkTree(); }
+
+void V3Global::clear() {
+    if (m_rootp) VL_DO_CLEAR(m_rootp->deleteTree(), m_rootp = NULL);
+}
+
+void V3Global::readFiles() {
+    // NODE STATE
+    //   AstNode::user4p()      // VSymEnt*    Package and typedef symbol names
+    AstUser4InUse       inuser4;
+
+    VInFilter filter (v3Global.opt.pipeFilter());
+    V3ParseSym parseSyms (v3Global.rootp());  // Symbol table must be common across all parsing
+
+    V3Parse parser (v3Global.rootp(), &filter, &parseSyms);
+    // Read top module
+    const V3StringList& vFiles = v3Global.opt.vFiles();
+    for (V3StringList::const_iterator it = vFiles.begin(); it != vFiles.end(); ++it) {
+        string filename = *it;
+        parser.parseFile(new FileLine(FileLine::commandLineFilename()),
+                         filename, false,
+                         "Cannot find file containing module: ");
+    }
+
+    // Read libraries
+    // To be compatible with other simulators,
+    // this needs to be done after the top file is read
+    const V3StringSet& libraryFiles = v3Global.opt.libraryFiles();
+    for (V3StringSet::const_iterator it = libraryFiles.begin(); it != libraryFiles.end(); ++it) {
+        string filename = *it;
+        parser.parseFile(new FileLine(FileLine::commandLineFilename()),
+                         filename, true,
+                         "Cannot find file containing library module: ");
+    }
+    //v3Global.rootp()->dumpTreeFile(v3Global.debugFilename("parse.tree"));
+    V3Error::abortIfErrors();
+
+    if (!v3Global.opt.preprocOnly()) {
+        // Resolve all modules cells refer to
+        V3LinkCells::link(v3Global.rootp(), &filter, &parseSyms);
+    }
+}
+
+void V3Global::dumpCheckGlobalTree(const string& stagename, int newNumber, bool doDump) {
+    v3Global.rootp()->dumpTreeFile(v3Global.debugFilename(stagename+".tree", newNumber),
+                                   false, doDump);
+    if (v3Global.opt.stats()) V3Stats::statsStage(stagename);
+}
+
+//######################################################################

--- a/src/Verilator.cpp
+++ b/src/Verilator.cpp
@@ -100,67 +100,7 @@
 
 V3Global v3Global;
 
-//######################################################################
-// V3 Class -- top level
-
-AstNetlist* V3Global::makeNetlist() {
-    AstNetlist* newp = new AstNetlist();
-    newp->addTypeTablep(new AstTypeTable(newp->fileline()));
-    return newp;
-}
-
-void V3Global::checkTree() { rootp()->checkTree(); }
-
-void V3Global::clear() {
-    if (m_rootp) VL_DO_CLEAR(m_rootp->deleteTree(), m_rootp = NULL);
-}
-
-void V3Global::readFiles() {
-    // NODE STATE
-    //   AstNode::user4p()      // VSymEnt*    Package and typedef symbol names
-    AstUser4InUse       inuser4;
-
-    VInFilter filter (v3Global.opt.pipeFilter());
-    V3ParseSym parseSyms (v3Global.rootp());  // Symbol table must be common across all parsing
-
-    V3Parse parser (v3Global.rootp(), &filter, &parseSyms);
-    // Read top module
-    const V3StringList& vFiles = v3Global.opt.vFiles();
-    for (V3StringList::const_iterator it = vFiles.begin(); it != vFiles.end(); ++it) {
-        string filename = *it;
-        parser.parseFile(new FileLine(FileLine::commandLineFilename()),
-                         filename, false,
-                         "Cannot find file containing module: ");
-    }
-
-    // Read libraries
-    // To be compatible with other simulators,
-    // this needs to be done after the top file is read
-    const V3StringSet& libraryFiles = v3Global.opt.libraryFiles();
-    for (V3StringSet::const_iterator it = libraryFiles.begin(); it != libraryFiles.end(); ++it) {
-        string filename = *it;
-        parser.parseFile(new FileLine(FileLine::commandLineFilename()),
-                         filename, true,
-                         "Cannot find file containing library module: ");
-    }
-    //v3Global.rootp()->dumpTreeFile(v3Global.debugFilename("parse.tree"));
-    V3Error::abortIfErrors();
-
-    if (!v3Global.opt.preprocOnly()) {
-        // Resolve all modules cells refer to
-        V3LinkCells::link(v3Global.rootp(), &filter, &parseSyms);
-    }
-}
-
-void V3Global::dumpCheckGlobalTree(const string& stagename, int newNumber, bool doDump) {
-    v3Global.rootp()->dumpTreeFile(v3Global.debugFilename(stagename+".tree", newNumber),
-                                   false, doDump);
-    if (v3Global.opt.stats()) V3Stats::statsStage(stagename);
-}
-
-//######################################################################
-
-void process() {
+static void process() {
     // Sort modules by level so later algorithms don't need to care
     V3LinkLevel::modSortByLevel();
     V3Error::abortIfErrors();


### PR DESCRIPTION
Verilator.cpp contains main(), but also some implementations of the V3Global class. This PR moves those to their own file. This should help when writing programs that use Verilator classes as a library instead of using the compiled executable.