### PR TITLE
Enable output to stdout if needed.

### DIFF
--- a/src/V3File.h
+++ b/src/V3File.h
@@ -57,6 +57,7 @@ public:
         }
     }
     static FILE* new_fopen_w(const string& filename) {
+        if (filename == "stdout") return stdout;
         createMakeDirFor(filename);
         addTgtDepend(filename);
         return fopen(filename.c_str(), "w");


### PR DESCRIPTION
If a file's manually specified name is equal to "stdout", the output is directed to actual stdout, not a file called stdout.

Not sure if there's a nicer way to do this.