### PR TITLE
Add detailed location to XML output

### DIFF
--- a/Changes
+++ b/Changes
@@ -15,6 +15,8 @@ The contributors that suggested a given feature are shown in []. Thanks!
 
 ****  Add parameter values in XML. #2110. [Pieter Kapsenberg]
 
+****  Add loc column location in XML (replaces fl). #2122. [Pieter Kapsenberg]
+
 ****  Add error on misused define. [Topa Tota]
 
 

--- a/bin/verilator
+++ b/bin/verilator
@@ -4669,6 +4669,11 @@ variable attribute will be removed no sooner than July 2020.
 The -msg argument to lint_off has been replaced with -rule.  -msg is
 planned for removal no sooner than January 2021.
 
+=item XML locations
+
+The XML C<fl> attribute has been replaced with C<loc>.  C<fl> is planned
+for removal no sooner than January 2021.
+
 =back
 
 

--- a/src/V3EmitXml.cpp
+++ b/src/V3EmitXml.cpp
@@ -71,6 +71,7 @@ class EmitXmlFileVisitor : public AstNVisitor {
     void outputTag(AstNode* nodep, string tag) {
         if (tag=="") tag = VString::downcase(nodep->typeName());
         puts("<"+tag+" "+nodep->fileline()->xml());
+        puts(" "+nodep->fileline()->xmlDetailedLocation());
         if (VN_IS(nodep, NodeDType)) { puts(" id="); outputId(nodep); }
         if (nodep->name()!="") { puts(" name="); putsQuoted(nodep->prettyName()); }
         if (nodep->tag()!="") { puts(" tag="); putsQuoted(nodep->tag()); }

--- a/src/V3FileLine.cpp
+++ b/src/V3FileLine.cpp
@@ -158,6 +158,14 @@ FileLine::FileLine(FileLine::EmptySecret) {
     }
 }
 
+const string FileLine::xmlDetailedLocation() const {
+    return "loc=\"" + 
+      cvtToStr(firstLineno()) + "," +
+      cvtToStr(firstColumn()) + "," +
+      cvtToStr(lastLineno()) + "," +
+      cvtToStr(lastColumn()) + "\"";
+}
+
 string FileLine::lineDirectiveStrg(int enterExit) const {
     char numbuf[20]; sprintf(numbuf, "%d", lastLineno());
     char levelbuf[20]; sprintf(levelbuf, "%d", enterExit);

--- a/src/V3FileLine.cpp
+++ b/src/V3FileLine.cpp
@@ -160,6 +160,7 @@ FileLine::FileLine(FileLine::EmptySecret) {
 
 const string FileLine::xmlDetailedLocation() const {
     return "loc=\"" +
+      cvtToStr(filenameLetters()) + "," +
       cvtToStr(firstLineno()) + "," +
       cvtToStr(firstColumn()) + "," +
       cvtToStr(lastLineno()) + "," +

--- a/src/V3FileLine.cpp
+++ b/src/V3FileLine.cpp
@@ -160,11 +160,11 @@ FileLine::FileLine(FileLine::EmptySecret) {
 
 const string FileLine::xmlDetailedLocation() const {
     return "loc=\"" +
-      cvtToStr(filenameLetters()) + "," +
-      cvtToStr(firstLineno()) + "," +
-      cvtToStr(firstColumn()) + "," +
-      cvtToStr(lastLineno()) + "," +
-      cvtToStr(lastColumn()) + "\"";
+        cvtToStr(filenameLetters()) + "," +
+        cvtToStr(firstLineno()) + "," +
+        cvtToStr(firstColumn()) + "," +
+        cvtToStr(lastLineno()) + "," +
+        cvtToStr(lastColumn()) + "\"";
 }
 
 string FileLine::lineDirectiveStrg(int enterExit) const {

--- a/src/V3FileLine.cpp
+++ b/src/V3FileLine.cpp
@@ -159,7 +159,7 @@ FileLine::FileLine(FileLine::EmptySecret) {
 }
 
 const string FileLine::xmlDetailedLocation() const {
-    return "loc=\"" + 
+    return "loc=\"" +
       cvtToStr(firstLineno()) + "," +
       cvtToStr(firstColumn()) + "," +
       cvtToStr(lastLineno()) + "," +

--- a/src/V3FileLine.h
+++ b/src/V3FileLine.h
@@ -183,6 +183,7 @@ public:
     const string filebasenameNoExt() const;
     const string profileFuncname() const;
     const string xml() const { return "fl=\""+filenameLetters()+cvtToStr(lastLineno())+"\""; }
+    const string xmlDetailedLocation() const;
     string lineDirectiveStrg(int enterExit) const;
 
     // Turn on/off warning messages on this line.

--- a/test_regress/t/t_clk_concat.pl
+++ b/test_regress/t/t_clk_concat.pl
@@ -16,9 +16,9 @@ compile(
     );
 
 if ($Self->{vlt_all}) {
-    file_grep("$out_filename", qr/\<var fl="d74" loc="\d+,\d+,\d+,\d+" name="clk0" dtype_id="1" dir="input" vartype="logic" origName="clk0" clocker="true" public="true"\/\>/i);
-    file_grep("$out_filename", qr/\<var fl="d75" loc="\d+,\d+,\d+,\d+" name="clk1" dtype_id="1" dir="input" vartype="logic" origName="clk1" clocker="true" public="true"\/\>/i);
-    file_grep("$out_filename", qr/\<var fl="d76" loc="\d+,\d+,\d+,\d+" name="clk2" dtype_id="1" dir="input" vartype="logic" origName="clk2" clocker="true" public="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="d74" loc=".*?" name="clk0" dtype_id="1" dir="input" vartype="logic" origName="clk0" clocker="true" public="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="d75" loc=".*?" name="clk1" dtype_id="1" dir="input" vartype="logic" origName="clk1" clocker="true" public="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="d76" loc=".*?" name="clk2" dtype_id="1" dir="input" vartype="logic" origName="clk2" clocker="true" public="true"\/\>/i);
 }
 
 execute(

--- a/test_regress/t/t_clk_concat.pl
+++ b/test_regress/t/t_clk_concat.pl
@@ -16,9 +16,9 @@ compile(
     );
 
 if ($Self->{vlt_all}) {
-    file_grep("$out_filename", qr/\<var fl="d74" name="clk0" dtype_id="1" dir="input" vartype="logic" origName="clk0" clocker="true" public="true"\/\>/i);
-    file_grep("$out_filename", qr/\<var fl="d75" name="clk1" dtype_id="1" dir="input" vartype="logic" origName="clk1" clocker="true" public="true"\/\>/i);
-    file_grep("$out_filename", qr/\<var fl="d76" name="clk2" dtype_id="1" dir="input" vartype="logic" origName="clk2" clocker="true" public="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="d74" loc="(\d+,){3}\d+" name="clk0" dtype_id="1" dir="input" vartype="logic" origName="clk0" clocker="true" public="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="d75" loc="(\d+,){3}\d+" name="clk1" dtype_id="1" dir="input" vartype="logic" origName="clk1" clocker="true" public="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="d76" loc="(\d+,){3}\d+" name="clk2" dtype_id="1" dir="input" vartype="logic" origName="clk2" clocker="true" public="true"\/\>/i);
 }
 
 execute(

--- a/test_regress/t/t_clk_concat.pl
+++ b/test_regress/t/t_clk_concat.pl
@@ -16,9 +16,9 @@ compile(
     );
 
 if ($Self->{vlt_all}) {
-    file_grep("$out_filename", qr/\<var fl="d74" loc="(\d+,){3}\d+" name="clk0" dtype_id="1" dir="input" vartype="logic" origName="clk0" clocker="true" public="true"\/\>/i);
-    file_grep("$out_filename", qr/\<var fl="d75" loc="(\d+,){3}\d+" name="clk1" dtype_id="1" dir="input" vartype="logic" origName="clk1" clocker="true" public="true"\/\>/i);
-    file_grep("$out_filename", qr/\<var fl="d76" loc="(\d+,){3}\d+" name="clk2" dtype_id="1" dir="input" vartype="logic" origName="clk2" clocker="true" public="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="d74" loc="\d+,\d+,\d+,\d+" name="clk0" dtype_id="1" dir="input" vartype="logic" origName="clk0" clocker="true" public="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="d75" loc="\d+,\d+,\d+,\d+" name="clk1" dtype_id="1" dir="input" vartype="logic" origName="clk1" clocker="true" public="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="d76" loc="\d+,\d+,\d+,\d+" name="clk2" dtype_id="1" dir="input" vartype="logic" origName="clk2" clocker="true" public="true"\/\>/i);
 }
 
 execute(

--- a/test_regress/t/t_clk_concat_vlt.pl
+++ b/test_regress/t/t_clk_concat_vlt.pl
@@ -17,10 +17,10 @@ compile(
     );
 
 if ($Self->{vlt_all}) {
-    file_grep("$out_filename", qr/\<var fl="e78" name="clk0" dtype_id="1" dir="input" vartype="logic" origName="clk0" clocker="true" public="true"\/\>/i);
-    file_grep("$out_filename", qr/\<var fl="e79" name="clk1" dtype_id="1" dir="input" vartype="logic" origName="clk1" clocker="true" public="true"\/\>/i);
-    file_grep("$out_filename", qr/\<var fl="e80" name="clk2" dtype_id="1" dir="input" vartype="logic" origName="clk2" clocker="true" public="true"\/\>/i);
-    file_grep("$out_filename", qr/\<var fl="e82" name="data_in" dtype_id="1" dir="input" vartype="logic" origName="data_in" clocker="false" public="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="e78" loc="(\d+,){3}\d+" name="clk0" dtype_id="1" dir="input" vartype="logic" origName="clk0" clocker="true" public="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="e79" loc="(\d+,){3}\d+" name="clk1" dtype_id="1" dir="input" vartype="logic" origName="clk1" clocker="true" public="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="e80" loc="(\d+,){3}\d+" name="clk2" dtype_id="1" dir="input" vartype="logic" origName="clk2" clocker="true" public="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="e82" loc="(\d+,){3}\d+" name="data_in" dtype_id="1" dir="input" vartype="logic" origName="data_in" clocker="false" public="true"\/\>/i);
 }
 
 execute(

--- a/test_regress/t/t_clk_concat_vlt.pl
+++ b/test_regress/t/t_clk_concat_vlt.pl
@@ -17,10 +17,10 @@ compile(
     );
 
 if ($Self->{vlt_all}) {
-    file_grep("$out_filename", qr/\<var fl="e78" loc="(\d+,){3}\d+" name="clk0" dtype_id="1" dir="input" vartype="logic" origName="clk0" clocker="true" public="true"\/\>/i);
-    file_grep("$out_filename", qr/\<var fl="e79" loc="(\d+,){3}\d+" name="clk1" dtype_id="1" dir="input" vartype="logic" origName="clk1" clocker="true" public="true"\/\>/i);
-    file_grep("$out_filename", qr/\<var fl="e80" loc="(\d+,){3}\d+" name="clk2" dtype_id="1" dir="input" vartype="logic" origName="clk2" clocker="true" public="true"\/\>/i);
-    file_grep("$out_filename", qr/\<var fl="e82" loc="(\d+,){3}\d+" name="data_in" dtype_id="1" dir="input" vartype="logic" origName="data_in" clocker="false" public="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="e78" loc="\d+,\d+,\d+,\d+" name="clk0" dtype_id="1" dir="input" vartype="logic" origName="clk0" clocker="true" public="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="e79" loc="\d+,\d+,\d+,\d+" name="clk1" dtype_id="1" dir="input" vartype="logic" origName="clk1" clocker="true" public="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="e80" loc="\d+,\d+,\d+,\d+" name="clk2" dtype_id="1" dir="input" vartype="logic" origName="clk2" clocker="true" public="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="e82" loc="\d+,\d+,\d+,\d+" name="data_in" dtype_id="1" dir="input" vartype="logic" origName="data_in" clocker="false" public="true"\/\>/i);
 }
 
 execute(

--- a/test_regress/t/t_clk_concat_vlt.pl
+++ b/test_regress/t/t_clk_concat_vlt.pl
@@ -17,10 +17,10 @@ compile(
     );
 
 if ($Self->{vlt_all}) {
-    file_grep("$out_filename", qr/\<var fl="e78" loc="\d+,\d+,\d+,\d+" name="clk0" dtype_id="1" dir="input" vartype="logic" origName="clk0" clocker="true" public="true"\/\>/i);
-    file_grep("$out_filename", qr/\<var fl="e79" loc="\d+,\d+,\d+,\d+" name="clk1" dtype_id="1" dir="input" vartype="logic" origName="clk1" clocker="true" public="true"\/\>/i);
-    file_grep("$out_filename", qr/\<var fl="e80" loc="\d+,\d+,\d+,\d+" name="clk2" dtype_id="1" dir="input" vartype="logic" origName="clk2" clocker="true" public="true"\/\>/i);
-    file_grep("$out_filename", qr/\<var fl="e82" loc="\d+,\d+,\d+,\d+" name="data_in" dtype_id="1" dir="input" vartype="logic" origName="data_in" clocker="false" public="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="e78" loc=".*?" name="clk0" dtype_id="1" dir="input" vartype="logic" origName="clk0" clocker="true" public="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="e79" loc=".*?" name="clk1" dtype_id="1" dir="input" vartype="logic" origName="clk1" clocker="true" public="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="e80" loc=".*?" name="clk2" dtype_id="1" dir="input" vartype="logic" origName="clk2" clocker="true" public="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="e82" loc=".*?" name="data_in" dtype_id="1" dir="input" vartype="logic" origName="data_in" clocker="false" public="true"\/\>/i);
 }
 
 execute(

--- a/test_regress/t/t_dedupe_clk_gate.pl
+++ b/test_regress/t/t_dedupe_clk_gate.pl
@@ -16,7 +16,7 @@ compile(
     );
 
 if ($Self->{vlt_all}) {
-    file_grep("$out_filename", qr/\<var fl="e43" loc="(\d+,){3}\d+" name="t.f0.clock_gate.clken_latched" dtype_id="1" vartype="logic" origName="clken_latched" clock_enable="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="e43" loc="\d+,\d+,\d+,\d+" name="t.f0.clock_gate.clken_latched" dtype_id="1" vartype="logic" origName="clken_latched" clock_enable="true"\/\>/i);
     file_grep($Self->{stats}, qr/Optimizations, Gate sigs deduped\s+(\d+)/i, 4);
 }
 

--- a/test_regress/t/t_dedupe_clk_gate.pl
+++ b/test_regress/t/t_dedupe_clk_gate.pl
@@ -16,7 +16,7 @@ compile(
     );
 
 if ($Self->{vlt_all}) {
-    file_grep("$out_filename", qr/\<var fl="e43" name="t.f0.clock_gate.clken_latched" dtype_id="1" vartype="logic" origName="clken_latched" clock_enable="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="e43" loc="(\d+,){3}\d+" name="t.f0.clock_gate.clken_latched" dtype_id="1" vartype="logic" origName="clken_latched" clock_enable="true"\/\>/i);
     file_grep($Self->{stats}, qr/Optimizations, Gate sigs deduped\s+(\d+)/i, 4);
 }
 

--- a/test_regress/t/t_dedupe_clk_gate.pl
+++ b/test_regress/t/t_dedupe_clk_gate.pl
@@ -16,7 +16,7 @@ compile(
     );
 
 if ($Self->{vlt_all}) {
-    file_grep("$out_filename", qr/\<var fl="e43" loc="\d+,\d+,\d+,\d+" name="t.f0.clock_gate.clken_latched" dtype_id="1" vartype="logic" origName="clken_latched" clock_enable="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="e43" loc=".*?" name="t.f0.clock_gate.clken_latched" dtype_id="1" vartype="logic" origName="clken_latched" clock_enable="true"\/\>/i);
     file_grep($Self->{stats}, qr/Optimizations, Gate sigs deduped\s+(\d+)/i, 4);
 }
 

--- a/test_regress/t/t_dpi_var.pl
+++ b/test_regress/t/t_dpi_var.pl
@@ -17,10 +17,10 @@ compile(
     );
 
 if ($Self->{vlt_all}) {
-    file_grep("$out_filename", qr/\<var fl="d55" name="formatted" dtype_id="4" dir="input" vartype="string" origName="formatted" sformat="true"\/\>/i);
-    file_grep("$out_filename", qr/\<var fl="d76" name="t.sub.in" dtype_id="3" vartype="int" origName="in" public="true" public_flat_rd="true"\/\>/i);
-    file_grep("$out_filename", qr/\<var fl="d77" name="t.sub.fr_a" dtype_id="3" vartype="int" origName="fr_a" public="true" public_flat_rd="true" public_flat_rw="true"\/\>/i);
-    file_grep("$out_filename", qr/\<var fl="d78" name="t.sub.fr_b" dtype_id="3" vartype="int" origName="fr_b" public="true" public_flat_rd="true" public_flat_rw="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="d55" loc="(\d+,){3}\d+" name="formatted" dtype_id="4" dir="input" vartype="string" origName="formatted" sformat="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="d76" loc="(\d+,){3}\d+" name="t.sub.in" dtype_id="3" vartype="int" origName="in" public="true" public_flat_rd="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="d77" loc="(\d+,){3}\d+" name="t.sub.fr_a" dtype_id="3" vartype="int" origName="fr_a" public="true" public_flat_rd="true" public_flat_rw="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="d78" loc="(\d+,){3}\d+" name="t.sub.fr_b" dtype_id="3" vartype="int" origName="fr_b" public="true" public_flat_rd="true" public_flat_rw="true"\/\>/i);
 }
 
 execute(

--- a/test_regress/t/t_dpi_var.pl
+++ b/test_regress/t/t_dpi_var.pl
@@ -17,10 +17,10 @@ compile(
     );
 
 if ($Self->{vlt_all}) {
-    file_grep("$out_filename", qr/\<var fl="d55" loc="\d+,\d+,\d+,\d+" name="formatted" dtype_id="4" dir="input" vartype="string" origName="formatted" sformat="true"\/\>/i);
-    file_grep("$out_filename", qr/\<var fl="d76" loc="\d+,\d+,\d+,\d+" name="t.sub.in" dtype_id="3" vartype="int" origName="in" public="true" public_flat_rd="true"\/\>/i);
-    file_grep("$out_filename", qr/\<var fl="d77" loc="\d+,\d+,\d+,\d+" name="t.sub.fr_a" dtype_id="3" vartype="int" origName="fr_a" public="true" public_flat_rd="true" public_flat_rw="true"\/\>/i);
-    file_grep("$out_filename", qr/\<var fl="d78" loc="\d+,\d+,\d+,\d+" name="t.sub.fr_b" dtype_id="3" vartype="int" origName="fr_b" public="true" public_flat_rd="true" public_flat_rw="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="d55" loc=".*?" name="formatted" dtype_id="4" dir="input" vartype="string" origName="formatted" sformat="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="d76" loc=".*?" name="t.sub.in" dtype_id="3" vartype="int" origName="in" public="true" public_flat_rd="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="d77" loc=".*?" name="t.sub.fr_a" dtype_id="3" vartype="int" origName="fr_a" public="true" public_flat_rd="true" public_flat_rw="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="d78" loc=".*?" name="t.sub.fr_b" dtype_id="3" vartype="int" origName="fr_b" public="true" public_flat_rd="true" public_flat_rw="true"\/\>/i);
 }
 
 execute(

--- a/test_regress/t/t_dpi_var.pl
+++ b/test_regress/t/t_dpi_var.pl
@@ -17,10 +17,10 @@ compile(
     );
 
 if ($Self->{vlt_all}) {
-    file_grep("$out_filename", qr/\<var fl="d55" loc="(\d+,){3}\d+" name="formatted" dtype_id="4" dir="input" vartype="string" origName="formatted" sformat="true"\/\>/i);
-    file_grep("$out_filename", qr/\<var fl="d76" loc="(\d+,){3}\d+" name="t.sub.in" dtype_id="3" vartype="int" origName="in" public="true" public_flat_rd="true"\/\>/i);
-    file_grep("$out_filename", qr/\<var fl="d77" loc="(\d+,){3}\d+" name="t.sub.fr_a" dtype_id="3" vartype="int" origName="fr_a" public="true" public_flat_rd="true" public_flat_rw="true"\/\>/i);
-    file_grep("$out_filename", qr/\<var fl="d78" loc="(\d+,){3}\d+" name="t.sub.fr_b" dtype_id="3" vartype="int" origName="fr_b" public="true" public_flat_rd="true" public_flat_rw="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="d55" loc="\d+,\d+,\d+,\d+" name="formatted" dtype_id="4" dir="input" vartype="string" origName="formatted" sformat="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="d76" loc="\d+,\d+,\d+,\d+" name="t.sub.in" dtype_id="3" vartype="int" origName="in" public="true" public_flat_rd="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="d77" loc="\d+,\d+,\d+,\d+" name="t.sub.fr_a" dtype_id="3" vartype="int" origName="fr_a" public="true" public_flat_rd="true" public_flat_rw="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="d78" loc="\d+,\d+,\d+,\d+" name="t.sub.fr_b" dtype_id="3" vartype="int" origName="fr_b" public="true" public_flat_rd="true" public_flat_rw="true"\/\>/i);
 }
 
 execute(

--- a/test_regress/t/t_dpi_var_vlt.pl
+++ b/test_regress/t/t_dpi_var_vlt.pl
@@ -19,10 +19,10 @@ compile(
     );
 
 if ($Self->{vlt_all}) {
-    file_grep("$out_filename", qr/\<var fl="e57" name="formatted" dtype_id="4" dir="input" vartype="string" origName="formatted" sformat="true"\/\>/i);
-    file_grep("$out_filename", qr/\<var fl="e80" name="t.sub.in" dtype_id="3" vartype="int" origName="in" public="true" public_flat_rd="true"\/\>/i);
-    file_grep("$out_filename", qr/\<var fl="e81" name="t.sub.fr_a" dtype_id="3" vartype="int" origName="fr_a" public="true" public_flat_rd="true" public_flat_rw="true"\/\>/i);
-    file_grep("$out_filename", qr/\<var fl="e82" name="t.sub.fr_b" dtype_id="3" vartype="int" origName="fr_b" public="true" public_flat_rd="true" public_flat_rw="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="e57" loc="(\d+,){3}\d+" name="formatted" dtype_id="4" dir="input" vartype="string" origName="formatted" sformat="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="e80" loc="(\d+,){3}\d+" name="t.sub.in" dtype_id="3" vartype="int" origName="in" public="true" public_flat_rd="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="e81" loc="(\d+,){3}\d+" name="t.sub.fr_a" dtype_id="3" vartype="int" origName="fr_a" public="true" public_flat_rd="true" public_flat_rw="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="e82" loc="(\d+,){3}\d+" name="t.sub.fr_b" dtype_id="3" vartype="int" origName="fr_b" public="true" public_flat_rd="true" public_flat_rw="true"\/\>/i);
 }
 
 execute(

--- a/test_regress/t/t_dpi_var_vlt.pl
+++ b/test_regress/t/t_dpi_var_vlt.pl
@@ -19,10 +19,10 @@ compile(
     );
 
 if ($Self->{vlt_all}) {
-    file_grep("$out_filename", qr/\<var fl="e57" loc="\d+,\d+,\d+,\d+" name="formatted" dtype_id="4" dir="input" vartype="string" origName="formatted" sformat="true"\/\>/i);
-    file_grep("$out_filename", qr/\<var fl="e80" loc="\d+,\d+,\d+,\d+" name="t.sub.in" dtype_id="3" vartype="int" origName="in" public="true" public_flat_rd="true"\/\>/i);
-    file_grep("$out_filename", qr/\<var fl="e81" loc="\d+,\d+,\d+,\d+" name="t.sub.fr_a" dtype_id="3" vartype="int" origName="fr_a" public="true" public_flat_rd="true" public_flat_rw="true"\/\>/i);
-    file_grep("$out_filename", qr/\<var fl="e82" loc="\d+,\d+,\d+,\d+" name="t.sub.fr_b" dtype_id="3" vartype="int" origName="fr_b" public="true" public_flat_rd="true" public_flat_rw="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="e57" loc=".*?" name="formatted" dtype_id="4" dir="input" vartype="string" origName="formatted" sformat="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="e80" loc=".*?" name="t.sub.in" dtype_id="3" vartype="int" origName="in" public="true" public_flat_rd="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="e81" loc=".*?" name="t.sub.fr_a" dtype_id="3" vartype="int" origName="fr_a" public="true" public_flat_rd="true" public_flat_rw="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="e82" loc=".*?" name="t.sub.fr_b" dtype_id="3" vartype="int" origName="fr_b" public="true" public_flat_rd="true" public_flat_rw="true"\/\>/i);
 }
 
 execute(

--- a/test_regress/t/t_dpi_var_vlt.pl
+++ b/test_regress/t/t_dpi_var_vlt.pl
@@ -19,10 +19,10 @@ compile(
     );
 
 if ($Self->{vlt_all}) {
-    file_grep("$out_filename", qr/\<var fl="e57" loc="(\d+,){3}\d+" name="formatted" dtype_id="4" dir="input" vartype="string" origName="formatted" sformat="true"\/\>/i);
-    file_grep("$out_filename", qr/\<var fl="e80" loc="(\d+,){3}\d+" name="t.sub.in" dtype_id="3" vartype="int" origName="in" public="true" public_flat_rd="true"\/\>/i);
-    file_grep("$out_filename", qr/\<var fl="e81" loc="(\d+,){3}\d+" name="t.sub.fr_a" dtype_id="3" vartype="int" origName="fr_a" public="true" public_flat_rd="true" public_flat_rw="true"\/\>/i);
-    file_grep("$out_filename", qr/\<var fl="e82" loc="(\d+,){3}\d+" name="t.sub.fr_b" dtype_id="3" vartype="int" origName="fr_b" public="true" public_flat_rd="true" public_flat_rw="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="e57" loc="\d+,\d+,\d+,\d+" name="formatted" dtype_id="4" dir="input" vartype="string" origName="formatted" sformat="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="e80" loc="\d+,\d+,\d+,\d+" name="t.sub.in" dtype_id="3" vartype="int" origName="in" public="true" public_flat_rd="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="e81" loc="\d+,\d+,\d+,\d+" name="t.sub.fr_a" dtype_id="3" vartype="int" origName="fr_a" public="true" public_flat_rd="true" public_flat_rw="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="e82" loc="\d+,\d+,\d+,\d+" name="t.sub.fr_b" dtype_id="3" vartype="int" origName="fr_b" public="true" public_flat_rd="true" public_flat_rw="true"\/\>/i);
 }
 
 execute(

--- a/test_regress/t/t_func_dotted_inl0.pl
+++ b/test_regress/t/t_func_dotted_inl0.pl
@@ -17,10 +17,10 @@ compile(
     );
 
 if ($Self->{vlt_all}) {
-    file_grep("$out_filename", qr/\<module fl="d83" name="ma" origName="ma" public="true"\>/i);
-    file_grep("$out_filename", qr/\<module fl="d98" name="mb" origName="mb" public="true"\>/i);
-    file_grep("$out_filename", qr/\<module fl="d126" name="mc" origName="mc" public="true"\>/i);
-    file_grep("$out_filename", qr/\<module fl="d126" name="mc__PB1" origName="mc" public="true"\>/i);
+    file_grep("$out_filename", qr/\<module fl="d83" loc="(\d+,){3}\d+" name="ma" origName="ma" public="true"\>/i);
+    file_grep("$out_filename", qr/\<module fl="d98" loc="(\d+,){3}\d+" name="mb" origName="mb" public="true"\>/i);
+    file_grep("$out_filename", qr/\<module fl="d126" loc="(\d+,){3}\d+" name="mc" origName="mc" public="true"\>/i);
+    file_grep("$out_filename", qr/\<module fl="d126" loc="(\d+,){3}\d+" name="mc__PB1" origName="mc" public="true"\>/i);
 }
 
 execute(

--- a/test_regress/t/t_func_dotted_inl0.pl
+++ b/test_regress/t/t_func_dotted_inl0.pl
@@ -17,10 +17,10 @@ compile(
     );
 
 if ($Self->{vlt_all}) {
-    file_grep("$out_filename", qr/\<module fl="d83" loc="(\d+,){3}\d+" name="ma" origName="ma" public="true"\>/i);
-    file_grep("$out_filename", qr/\<module fl="d98" loc="(\d+,){3}\d+" name="mb" origName="mb" public="true"\>/i);
-    file_grep("$out_filename", qr/\<module fl="d126" loc="(\d+,){3}\d+" name="mc" origName="mc" public="true"\>/i);
-    file_grep("$out_filename", qr/\<module fl="d126" loc="(\d+,){3}\d+" name="mc__PB1" origName="mc" public="true"\>/i);
+    file_grep("$out_filename", qr/\<module fl="d83" loc="\d+,\d+,\d+,\d+" name="ma" origName="ma" public="true"\>/i);
+    file_grep("$out_filename", qr/\<module fl="d98" loc="\d+,\d+,\d+,\d+" name="mb" origName="mb" public="true"\>/i);
+    file_grep("$out_filename", qr/\<module fl="d126" loc="\d+,\d+,\d+,\d+" name="mc" origName="mc" public="true"\>/i);
+    file_grep("$out_filename", qr/\<module fl="d126" loc="\d+,\d+,\d+,\d+" name="mc__PB1" origName="mc" public="true"\>/i);
 }
 
 execute(

--- a/test_regress/t/t_func_dotted_inl0.pl
+++ b/test_regress/t/t_func_dotted_inl0.pl
@@ -17,10 +17,10 @@ compile(
     );
 
 if ($Self->{vlt_all}) {
-    file_grep("$out_filename", qr/\<module fl="d83" loc="\d+,\d+,\d+,\d+" name="ma" origName="ma" public="true"\>/i);
-    file_grep("$out_filename", qr/\<module fl="d98" loc="\d+,\d+,\d+,\d+" name="mb" origName="mb" public="true"\>/i);
-    file_grep("$out_filename", qr/\<module fl="d126" loc="\d+,\d+,\d+,\d+" name="mc" origName="mc" public="true"\>/i);
-    file_grep("$out_filename", qr/\<module fl="d126" loc="\d+,\d+,\d+,\d+" name="mc__PB1" origName="mc" public="true"\>/i);
+    file_grep("$out_filename", qr/\<module fl="d83" loc=".*?" name="ma" origName="ma" public="true"\>/i);
+    file_grep("$out_filename", qr/\<module fl="d98" loc=".*?" name="mb" origName="mb" public="true"\>/i);
+    file_grep("$out_filename", qr/\<module fl="d126" loc=".*?" name="mc" origName="mc" public="true"\>/i);
+    file_grep("$out_filename", qr/\<module fl="d126" loc=".*?" name="mc__PB1" origName="mc" public="true"\>/i);
 }
 
 execute(

--- a/test_regress/t/t_func_dotted_inl0_vlt.pl
+++ b/test_regress/t/t_func_dotted_inl0_vlt.pl
@@ -17,10 +17,10 @@ compile(
     );
 
 if ($Self->{vlt_all}) {
-    file_grep("$out_filename", qr/\<module fl="e83" loc="(\d+,){3}\d+" name="ma" origName="ma" public="true"\>/i);
-    file_grep("$out_filename", qr/\<module fl="e98" loc="(\d+,){3}\d+" name="mb" origName="mb" public="true"\>/i);
-    file_grep("$out_filename", qr/\<module fl="e126" loc="(\d+,){3}\d+" name="mc" origName="mc" public="true"\>/i);
-    file_grep("$out_filename", qr/\<module fl="e126" loc="(\d+,){3}\d+" name="mc__PB1" origName="mc" public="true"\>/i);
+    file_grep("$out_filename", qr/\<module fl="e83" loc="\d+,\d+,\d+,\d+" name="ma" origName="ma" public="true"\>/i);
+    file_grep("$out_filename", qr/\<module fl="e98" loc="\d+,\d+,\d+,\d+" name="mb" origName="mb" public="true"\>/i);
+    file_grep("$out_filename", qr/\<module fl="e126" loc="\d+,\d+,\d+,\d+" name="mc" origName="mc" public="true"\>/i);
+    file_grep("$out_filename", qr/\<module fl="e126" loc="\d+,\d+,\d+,\d+" name="mc__PB1" origName="mc" public="true"\>/i);
 }
 
 execute(

--- a/test_regress/t/t_func_dotted_inl0_vlt.pl
+++ b/test_regress/t/t_func_dotted_inl0_vlt.pl
@@ -17,10 +17,10 @@ compile(
     );
 
 if ($Self->{vlt_all}) {
-    file_grep("$out_filename", qr/\<module fl="e83" name="ma" origName="ma" public="true"\>/i);
-    file_grep("$out_filename", qr/\<module fl="e98" name="mb" origName="mb" public="true"\>/i);
-    file_grep("$out_filename", qr/\<module fl="e126" name="mc" origName="mc" public="true"\>/i);
-    file_grep("$out_filename", qr/\<module fl="e126" name="mc__PB1" origName="mc" public="true"\>/i);
+    file_grep("$out_filename", qr/\<module fl="e83" loc="(\d+,){3}\d+" name="ma" origName="ma" public="true"\>/i);
+    file_grep("$out_filename", qr/\<module fl="e98" loc="(\d+,){3}\d+" name="mb" origName="mb" public="true"\>/i);
+    file_grep("$out_filename", qr/\<module fl="e126" loc="(\d+,){3}\d+" name="mc" origName="mc" public="true"\>/i);
+    file_grep("$out_filename", qr/\<module fl="e126" loc="(\d+,){3}\d+" name="mc__PB1" origName="mc" public="true"\>/i);
 }
 
 execute(

--- a/test_regress/t/t_func_dotted_inl0_vlt.pl
+++ b/test_regress/t/t_func_dotted_inl0_vlt.pl
@@ -17,10 +17,10 @@ compile(
     );
 
 if ($Self->{vlt_all}) {
-    file_grep("$out_filename", qr/\<module fl="e83" loc="\d+,\d+,\d+,\d+" name="ma" origName="ma" public="true"\>/i);
-    file_grep("$out_filename", qr/\<module fl="e98" loc="\d+,\d+,\d+,\d+" name="mb" origName="mb" public="true"\>/i);
-    file_grep("$out_filename", qr/\<module fl="e126" loc="\d+,\d+,\d+,\d+" name="mc" origName="mc" public="true"\>/i);
-    file_grep("$out_filename", qr/\<module fl="e126" loc="\d+,\d+,\d+,\d+" name="mc__PB1" origName="mc" public="true"\>/i);
+    file_grep("$out_filename", qr/\<module fl="e83" loc=".*?" name="ma" origName="ma" public="true"\>/i);
+    file_grep("$out_filename", qr/\<module fl="e98" loc=".*?" name="mb" origName="mb" public="true"\>/i);
+    file_grep("$out_filename", qr/\<module fl="e126" loc=".*?" name="mc" origName="mc" public="true"\>/i);
+    file_grep("$out_filename", qr/\<module fl="e126" loc=".*?" name="mc__PB1" origName="mc" public="true"\>/i);
 }
 
 execute(

--- a/test_regress/t/t_func_dotted_inl2.pl
+++ b/test_regress/t/t_func_dotted_inl2.pl
@@ -17,8 +17,8 @@ compile(
     );
 
 if ($Self->{vlt_all}) {
-    file_grep("$out_filename", qr/\<instance fl="d86" name="t.ma0.mb0" defName="mb" origName="mb0"\/\>/i);
-    file_grep("$out_filename", qr/\<module fl="d98" name="mb" origName="mb"\>/i);
+    file_grep("$out_filename", qr/\<instance fl="d86" loc="(\d+,){3}\d+" name="t.ma0.mb0" defName="mb" origName="mb0"\/\>/i);
+    file_grep("$out_filename", qr/\<module fl="d98" loc="(\d+,){3}\d+" name="mb" origName="mb"\>/i);
 }
 
 execute(

--- a/test_regress/t/t_func_dotted_inl2.pl
+++ b/test_regress/t/t_func_dotted_inl2.pl
@@ -17,8 +17,8 @@ compile(
     );
 
 if ($Self->{vlt_all}) {
-    file_grep("$out_filename", qr/\<instance fl="d86" loc="(\d+,){3}\d+" name="t.ma0.mb0" defName="mb" origName="mb0"\/\>/i);
-    file_grep("$out_filename", qr/\<module fl="d98" loc="(\d+,){3}\d+" name="mb" origName="mb"\>/i);
+    file_grep("$out_filename", qr/\<instance fl="d86" loc="\d+,\d+,\d+,\d+" name="t.ma0.mb0" defName="mb" origName="mb0"\/\>/i);
+    file_grep("$out_filename", qr/\<module fl="d98" loc="\d+,\d+,\d+,\d+" name="mb" origName="mb"\>/i);
 }
 
 execute(

--- a/test_regress/t/t_func_dotted_inl2.pl
+++ b/test_regress/t/t_func_dotted_inl2.pl
@@ -17,8 +17,8 @@ compile(
     );
 
 if ($Self->{vlt_all}) {
-    file_grep("$out_filename", qr/\<instance fl="d86" loc="\d+,\d+,\d+,\d+" name="t.ma0.mb0" defName="mb" origName="mb0"\/\>/i);
-    file_grep("$out_filename", qr/\<module fl="d98" loc="\d+,\d+,\d+,\d+" name="mb" origName="mb"\>/i);
+    file_grep("$out_filename", qr/\<instance fl="d86" loc=".*?" name="t.ma0.mb0" defName="mb" origName="mb0"\/\>/i);
+    file_grep("$out_filename", qr/\<module fl="d98" loc=".*?" name="mb" origName="mb"\>/i);
 }
 
 execute(

--- a/test_regress/t/t_func_dotted_inl2_vlt.pl
+++ b/test_regress/t/t_func_dotted_inl2_vlt.pl
@@ -17,8 +17,8 @@ compile(
     );
 
 if ($Self->{vlt_all}) {
-    file_grep("$out_filename", qr/\<instance fl="e86" name="t.ma0.mb0" defName="mb" origName="mb0"\/\>/i);
-    file_grep("$out_filename", qr/\<module fl="e98" name="mb" origName="mb"\>/i);
+    file_grep("$out_filename", qr/\<instance fl="e86" loc="(\d+,){3}\d+" name="t.ma0.mb0" defName="mb" origName="mb0"\/\>/i);
+    file_grep("$out_filename", qr/\<module fl="e98" loc="(\d+,){3}\d+" name="mb" origName="mb"\>/i);
 }
 
 execute(

--- a/test_regress/t/t_func_dotted_inl2_vlt.pl
+++ b/test_regress/t/t_func_dotted_inl2_vlt.pl
@@ -17,8 +17,8 @@ compile(
     );
 
 if ($Self->{vlt_all}) {
-    file_grep("$out_filename", qr/\<instance fl="e86" loc="\d+,\d+,\d+,\d+" name="t.ma0.mb0" defName="mb" origName="mb0"\/\>/i);
-    file_grep("$out_filename", qr/\<module fl="e98" loc="\d+,\d+,\d+,\d+" name="mb" origName="mb"\>/i);
+    file_grep("$out_filename", qr/\<instance fl="e86" loc=".*?" name="t.ma0.mb0" defName="mb" origName="mb0"\/\>/i);
+    file_grep("$out_filename", qr/\<module fl="e98" loc=".*?" name="mb" origName="mb"\>/i);
 }
 
 execute(

--- a/test_regress/t/t_func_dotted_inl2_vlt.pl
+++ b/test_regress/t/t_func_dotted_inl2_vlt.pl
@@ -17,8 +17,8 @@ compile(
     );
 
 if ($Self->{vlt_all}) {
-    file_grep("$out_filename", qr/\<instance fl="e86" loc="(\d+,){3}\d+" name="t.ma0.mb0" defName="mb" origName="mb0"\/\>/i);
-    file_grep("$out_filename", qr/\<module fl="e98" loc="(\d+,){3}\d+" name="mb" origName="mb"\>/i);
+    file_grep("$out_filename", qr/\<instance fl="e86" loc="\d+,\d+,\d+,\d+" name="t.ma0.mb0" defName="mb" origName="mb0"\/\>/i);
+    file_grep("$out_filename", qr/\<module fl="e98" loc="\d+,\d+,\d+,\d+" name="mb" origName="mb"\>/i);
 }
 
 execute(

--- a/test_regress/t/t_inst_tree_inl0_pub0.pl
+++ b/test_regress/t/t_inst_tree_inl0_pub0.pl
@@ -17,12 +17,12 @@ compile(
 );
 
 if ($Self->{vlt_all}) {
-    file_grep("$out_filename", qr/\<module fl="e55" name="l1" origName="l1"\>/i);
-    file_grep("$out_filename", qr/\<module fl="e61" name="l2" origName="l2"\>/i);
-    file_grep("$out_filename", qr/\<module fl="e68" name="l3" origName="l3"\>/i);
-    file_grep("$out_filename", qr/\<module fl="e75" name="l4" origName="l4"\>/i);
-    file_grep("$out_filename", qr/\<module fl="e82" name="l5__P2" origName="l5"\>/i);
-    file_grep("$out_filename", qr/\<module fl="e82" name="l5__P1" origName="l5"\>/i);
+    file_grep("$out_filename", qr/\<module fl="e55" loc="(\d+,){3}\d+" name="l1" origName="l1"\>/i);
+    file_grep("$out_filename", qr/\<module fl="e61" loc="(\d+,){3}\d+" name="l2" origName="l2"\>/i);
+    file_grep("$out_filename", qr/\<module fl="e68" loc="(\d+,){3}\d+" name="l3" origName="l3"\>/i);
+    file_grep("$out_filename", qr/\<module fl="e75" loc="(\d+,){3}\d+" name="l4" origName="l4"\>/i);
+    file_grep("$out_filename", qr/\<module fl="e82" loc="(\d+,){3}\d+" name="l5__P2" origName="l5"\>/i);
+    file_grep("$out_filename", qr/\<module fl="e82" loc="(\d+,){3}\d+" name="l5__P1" origName="l5"\>/i);
 }
 
 execute(

--- a/test_regress/t/t_inst_tree_inl0_pub0.pl
+++ b/test_regress/t/t_inst_tree_inl0_pub0.pl
@@ -17,12 +17,12 @@ compile(
 );
 
 if ($Self->{vlt_all}) {
-    file_grep("$out_filename", qr/\<module fl="e55" loc="\d+,\d+,\d+,\d+" name="l1" origName="l1"\>/i);
-    file_grep("$out_filename", qr/\<module fl="e61" loc="\d+,\d+,\d+,\d+" name="l2" origName="l2"\>/i);
-    file_grep("$out_filename", qr/\<module fl="e68" loc="\d+,\d+,\d+,\d+" name="l3" origName="l3"\>/i);
-    file_grep("$out_filename", qr/\<module fl="e75" loc="\d+,\d+,\d+,\d+" name="l4" origName="l4"\>/i);
-    file_grep("$out_filename", qr/\<module fl="e82" loc="\d+,\d+,\d+,\d+" name="l5__P2" origName="l5"\>/i);
-    file_grep("$out_filename", qr/\<module fl="e82" loc="\d+,\d+,\d+,\d+" name="l5__P1" origName="l5"\>/i);
+    file_grep("$out_filename", qr/\<module fl="e55" loc=".*?" name="l1" origName="l1"\>/i);
+    file_grep("$out_filename", qr/\<module fl="e61" loc=".*?" name="l2" origName="l2"\>/i);
+    file_grep("$out_filename", qr/\<module fl="e68" loc=".*?" name="l3" origName="l3"\>/i);
+    file_grep("$out_filename", qr/\<module fl="e75" loc=".*?" name="l4" origName="l4"\>/i);
+    file_grep("$out_filename", qr/\<module fl="e82" loc=".*?" name="l5__P2" origName="l5"\>/i);
+    file_grep("$out_filename", qr/\<module fl="e82" loc=".*?" name="l5__P1" origName="l5"\>/i);
 }
 
 execute(

--- a/test_regress/t/t_inst_tree_inl0_pub0.pl
+++ b/test_regress/t/t_inst_tree_inl0_pub0.pl
@@ -17,12 +17,12 @@ compile(
 );
 
 if ($Self->{vlt_all}) {
-    file_grep("$out_filename", qr/\<module fl="e55" loc="(\d+,){3}\d+" name="l1" origName="l1"\>/i);
-    file_grep("$out_filename", qr/\<module fl="e61" loc="(\d+,){3}\d+" name="l2" origName="l2"\>/i);
-    file_grep("$out_filename", qr/\<module fl="e68" loc="(\d+,){3}\d+" name="l3" origName="l3"\>/i);
-    file_grep("$out_filename", qr/\<module fl="e75" loc="(\d+,){3}\d+" name="l4" origName="l4"\>/i);
-    file_grep("$out_filename", qr/\<module fl="e82" loc="(\d+,){3}\d+" name="l5__P2" origName="l5"\>/i);
-    file_grep("$out_filename", qr/\<module fl="e82" loc="(\d+,){3}\d+" name="l5__P1" origName="l5"\>/i);
+    file_grep("$out_filename", qr/\<module fl="e55" loc="\d+,\d+,\d+,\d+" name="l1" origName="l1"\>/i);
+    file_grep("$out_filename", qr/\<module fl="e61" loc="\d+,\d+,\d+,\d+" name="l2" origName="l2"\>/i);
+    file_grep("$out_filename", qr/\<module fl="e68" loc="\d+,\d+,\d+,\d+" name="l3" origName="l3"\>/i);
+    file_grep("$out_filename", qr/\<module fl="e75" loc="\d+,\d+,\d+,\d+" name="l4" origName="l4"\>/i);
+    file_grep("$out_filename", qr/\<module fl="e82" loc="\d+,\d+,\d+,\d+" name="l5__P2" origName="l5"\>/i);
+    file_grep("$out_filename", qr/\<module fl="e82" loc="\d+,\d+,\d+,\d+" name="l5__P1" origName="l5"\>/i);
 }
 
 execute(

--- a/test_regress/t/t_inst_tree_inl1_pub0.pl
+++ b/test_regress/t/t_inst_tree_inl1_pub0.pl
@@ -17,9 +17,9 @@ compile(
     );
 
 if ($Self->{vlt_all}) {
-    file_grep("$out_filename", qr/\<var fl="e69" loc="(\d+,){3}\d+" name="t.u.u0.u0.z1" dtype_id="3" vartype="logic" origName="z1"\/\>/i);
-    file_grep("$out_filename", qr/\<var fl="e69" loc="(\d+,){3}\d+" name="t.u.u0.u1.z1" dtype_id="3" vartype="logic" origName="z1"\/\>/i);
-    file_grep("$out_filename", qr/\<var fl="e69" loc="(\d+,){3}\d+" name="t.u.u1.u0.z0" dtype_id="3" vartype="logic" origName="z0"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="e69" loc="\d+,\d+,\d+,\d+" name="t.u.u0.u0.z1" dtype_id="3" vartype="logic" origName="z1"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="e69" loc="\d+,\d+,\d+,\d+" name="t.u.u0.u1.z1" dtype_id="3" vartype="logic" origName="z1"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="e69" loc="\d+,\d+,\d+,\d+" name="t.u.u1.u0.z0" dtype_id="3" vartype="logic" origName="z0"\/\>/i);
 }
 
 execute(

--- a/test_regress/t/t_inst_tree_inl1_pub0.pl
+++ b/test_regress/t/t_inst_tree_inl1_pub0.pl
@@ -17,9 +17,9 @@ compile(
     );
 
 if ($Self->{vlt_all}) {
-    file_grep("$out_filename", qr/\<var fl="e69" loc="\d+,\d+,\d+,\d+" name="t.u.u0.u0.z1" dtype_id="3" vartype="logic" origName="z1"\/\>/i);
-    file_grep("$out_filename", qr/\<var fl="e69" loc="\d+,\d+,\d+,\d+" name="t.u.u0.u1.z1" dtype_id="3" vartype="logic" origName="z1"\/\>/i);
-    file_grep("$out_filename", qr/\<var fl="e69" loc="\d+,\d+,\d+,\d+" name="t.u.u1.u0.z0" dtype_id="3" vartype="logic" origName="z0"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="e69" loc=".*?" name="t.u.u0.u0.z1" dtype_id="3" vartype="logic" origName="z1"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="e69" loc=".*?" name="t.u.u0.u1.z1" dtype_id="3" vartype="logic" origName="z1"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="e69" loc=".*?" name="t.u.u1.u0.z0" dtype_id="3" vartype="logic" origName="z0"\/\>/i);
 }
 
 execute(

--- a/test_regress/t/t_inst_tree_inl1_pub0.pl
+++ b/test_regress/t/t_inst_tree_inl1_pub0.pl
@@ -17,9 +17,9 @@ compile(
     );
 
 if ($Self->{vlt_all}) {
-    file_grep("$out_filename", qr/\<var fl="e69" name="t.u.u0.u0.z1" dtype_id="3" vartype="logic" origName="z1"\/\>/i);
-    file_grep("$out_filename", qr/\<var fl="e69" name="t.u.u0.u1.z1" dtype_id="3" vartype="logic" origName="z1"\/\>/i);
-    file_grep("$out_filename", qr/\<var fl="e69" name="t.u.u1.u0.z0" dtype_id="3" vartype="logic" origName="z0"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="e69" loc="(\d+,){3}\d+" name="t.u.u0.u0.z1" dtype_id="3" vartype="logic" origName="z1"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="e69" loc="(\d+,){3}\d+" name="t.u.u0.u1.z1" dtype_id="3" vartype="logic" origName="z1"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="e69" loc="(\d+,){3}\d+" name="t.u.u1.u0.z0" dtype_id="3" vartype="logic" origName="z0"\/\>/i);
 }
 
 execute(

--- a/test_regress/t/t_inst_tree_inl1_pub1.pl
+++ b/test_regress/t/t_inst_tree_inl1_pub1.pl
@@ -18,9 +18,9 @@ compile(
     );
 
 if ($Self->{vlt_all}) {
-    file_grep("$out_filename", qr/\<var fl="e69" loc="(\d+,){3}\d+" name="u.u0.u0.z0" dtype_id="3" vartype="logic" origName="z0" public="true" public_flat_rd="true" public_flat_rw="true"\/\>/i);
-    file_grep("$out_filename", qr/\<var fl="e84" loc="(\d+,){3}\d+" name="u.u0.u0.u0.u0.z1" dtype_id="3" vartype="logic" origName="z1" public="true" public_flat_rd="true" public_flat_rw="true"\/\>/i);
-    file_grep("$out_filename", qr/\<var fl="e82" loc="(\d+,){3}\d+" name="u.u0.u1.u0.u0.z" dtype_id="3" vartype="logic" origName="z" public="true" public_flat_rd="true" public_flat_rw="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="e69" loc="\d+,\d+,\d+,\d+" name="u.u0.u0.z0" dtype_id="3" vartype="logic" origName="z0" public="true" public_flat_rd="true" public_flat_rw="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="e84" loc="\d+,\d+,\d+,\d+" name="u.u0.u0.u0.u0.z1" dtype_id="3" vartype="logic" origName="z1" public="true" public_flat_rd="true" public_flat_rw="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="e82" loc="\d+,\d+,\d+,\d+" name="u.u0.u1.u0.u0.z" dtype_id="3" vartype="logic" origName="z" public="true" public_flat_rd="true" public_flat_rw="true"\/\>/i);
 }
 
 execute(

--- a/test_regress/t/t_inst_tree_inl1_pub1.pl
+++ b/test_regress/t/t_inst_tree_inl1_pub1.pl
@@ -18,9 +18,9 @@ compile(
     );
 
 if ($Self->{vlt_all}) {
-    file_grep("$out_filename", qr/\<var fl="e69" name="u.u0.u0.z0" dtype_id="3" vartype="logic" origName="z0" public="true" public_flat_rd="true" public_flat_rw="true"\/\>/i);
-    file_grep("$out_filename", qr/\<var fl="e84" name="u.u0.u0.u0.u0.z1" dtype_id="3" vartype="logic" origName="z1" public="true" public_flat_rd="true" public_flat_rw="true"\/\>/i);
-    file_grep("$out_filename", qr/\<var fl="e82" name="u.u0.u1.u0.u0.z" dtype_id="3" vartype="logic" origName="z" public="true" public_flat_rd="true" public_flat_rw="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="e69" loc="(\d+,){3}\d+" name="u.u0.u0.z0" dtype_id="3" vartype="logic" origName="z0" public="true" public_flat_rd="true" public_flat_rw="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="e84" loc="(\d+,){3}\d+" name="u.u0.u0.u0.u0.z1" dtype_id="3" vartype="logic" origName="z1" public="true" public_flat_rd="true" public_flat_rw="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="e82" loc="(\d+,){3}\d+" name="u.u0.u1.u0.u0.z" dtype_id="3" vartype="logic" origName="z" public="true" public_flat_rd="true" public_flat_rw="true"\/\>/i);
 }
 
 execute(

--- a/test_regress/t/t_inst_tree_inl1_pub1.pl
+++ b/test_regress/t/t_inst_tree_inl1_pub1.pl
@@ -18,9 +18,9 @@ compile(
     );
 
 if ($Self->{vlt_all}) {
-    file_grep("$out_filename", qr/\<var fl="e69" loc="\d+,\d+,\d+,\d+" name="u.u0.u0.z0" dtype_id="3" vartype="logic" origName="z0" public="true" public_flat_rd="true" public_flat_rw="true"\/\>/i);
-    file_grep("$out_filename", qr/\<var fl="e84" loc="\d+,\d+,\d+,\d+" name="u.u0.u0.u0.u0.z1" dtype_id="3" vartype="logic" origName="z1" public="true" public_flat_rd="true" public_flat_rw="true"\/\>/i);
-    file_grep("$out_filename", qr/\<var fl="e82" loc="\d+,\d+,\d+,\d+" name="u.u0.u1.u0.u0.z" dtype_id="3" vartype="logic" origName="z" public="true" public_flat_rd="true" public_flat_rw="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="e69" loc=".*?" name="u.u0.u0.z0" dtype_id="3" vartype="logic" origName="z0" public="true" public_flat_rd="true" public_flat_rw="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="e84" loc=".*?" name="u.u0.u0.u0.u0.z1" dtype_id="3" vartype="logic" origName="z1" public="true" public_flat_rd="true" public_flat_rw="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="e82" loc=".*?" name="u.u0.u1.u0.u0.z" dtype_id="3" vartype="logic" origName="z" public="true" public_flat_rd="true" public_flat_rw="true"\/\>/i);
 }
 
 execute(

--- a/test_regress/t/t_trace_public_sig_vlt.pl
+++ b/test_regress/t/t_trace_public_sig_vlt.pl
@@ -19,7 +19,7 @@ compile(
     );
 
 if ($Self->{vlt_all}) {
-    file_grep("$out_filename", qr/\<var fl="e46" name="GSR" dtype_id="1" vartype="logic" origName="GSR" public="true" public_flat_rd="true" public_flat_rw="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="e46" loc="(\d+,){3}\d+" name="GSR" dtype_id="1" vartype="logic" origName="GSR" public="true" public_flat_rd="true" public_flat_rw="true"\/\>/i);
 }
 
 execute(

--- a/test_regress/t/t_trace_public_sig_vlt.pl
+++ b/test_regress/t/t_trace_public_sig_vlt.pl
@@ -19,7 +19,7 @@ compile(
     );
 
 if ($Self->{vlt_all}) {
-    file_grep("$out_filename", qr/\<var fl="e46" loc="\d+,\d+,\d+,\d+" name="GSR" dtype_id="1" vartype="logic" origName="GSR" public="true" public_flat_rd="true" public_flat_rw="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="e46" loc=".*?" name="GSR" dtype_id="1" vartype="logic" origName="GSR" public="true" public_flat_rd="true" public_flat_rw="true"\/\>/i);
 }
 
 execute(

--- a/test_regress/t/t_trace_public_sig_vlt.pl
+++ b/test_regress/t/t_trace_public_sig_vlt.pl
@@ -19,7 +19,7 @@ compile(
     );
 
 if ($Self->{vlt_all}) {
-    file_grep("$out_filename", qr/\<var fl="e46" loc="(\d+,){3}\d+" name="GSR" dtype_id="1" vartype="logic" origName="GSR" public="true" public_flat_rd="true" public_flat_rw="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="e46" loc="\d+,\d+,\d+,\d+" name="GSR" dtype_id="1" vartype="logic" origName="GSR" public="true" public_flat_rd="true" public_flat_rw="true"\/\>/i);
 }
 
 execute(

--- a/test_regress/t/t_unopt_combo_isolate.pl
+++ b/test_regress/t/t_unopt_combo_isolate.pl
@@ -18,11 +18,11 @@ compile(
 
 if ($Self->{vlt_all}) {
     file_grep($Self->{stats}, qr/Optimizations, isolate_assignments blocks\s+5/i);
-    file_grep("$out_filename", qr/\<var fl="d22" name="t.b" dtype_id="4" vartype="logic" origName="b" isolate_assignments="true"\/\>/i);
-    file_grep("$out_filename", qr/\<var fl="d98" name="__Vfunc_t.file.get_31_16__0__Vfuncout" dtype_id="5" vartype="logic" origName="__Vfunc_t__DOT__file__DOT__get_31_16__0__Vfuncout" isolate_assignments="true"\/\>/i);
-    file_grep("$out_filename", qr/\<var fl="d99" name="__Vfunc_t.file.get_31_16__0__t_crc" dtype_id="4" vartype="logic" origName="__Vfunc_t__DOT__file__DOT__get_31_16__0__t_crc" isolate_assignments="true"\/\>/i);
-    file_grep("$out_filename", qr/\<var fl="d111" name="__Vtask_t.file.set_b_d__1__t_crc" dtype_id="4" vartype="logic" origName="__Vtask_t__DOT__file__DOT__set_b_d__1__t_crc" isolate_assignments="true"\/\>/i);
-    file_grep("$out_filename", qr/\<var fl="d112" name="__Vtask_t.file.set_b_d__1__t_c" dtype_id="4" vartype="logic" origName="__Vtask_t__DOT__file__DOT__set_b_d__1__t_c" isolate_assignments="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="d22" loc="(\d+,){3}\d+" name="t.b" dtype_id="4" vartype="logic" origName="b" isolate_assignments="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="d98" loc="(\d+,){3}\d+" name="__Vfunc_t.file.get_31_16__0__Vfuncout" dtype_id="5" vartype="logic" origName="__Vfunc_t__DOT__file__DOT__get_31_16__0__Vfuncout" isolate_assignments="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="d99" loc="(\d+,){3}\d+" name="__Vfunc_t.file.get_31_16__0__t_crc" dtype_id="4" vartype="logic" origName="__Vfunc_t__DOT__file__DOT__get_31_16__0__t_crc" isolate_assignments="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="d111" loc="(\d+,){3}\d+" name="__Vtask_t.file.set_b_d__1__t_crc" dtype_id="4" vartype="logic" origName="__Vtask_t__DOT__file__DOT__set_b_d__1__t_crc" isolate_assignments="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="d112" loc="(\d+,){3}\d+" name="__Vtask_t.file.set_b_d__1__t_c" dtype_id="4" vartype="logic" origName="__Vtask_t__DOT__file__DOT__set_b_d__1__t_c" isolate_assignments="true"\/\>/i);
 }
 
 execute(

--- a/test_regress/t/t_unopt_combo_isolate.pl
+++ b/test_regress/t/t_unopt_combo_isolate.pl
@@ -18,11 +18,11 @@ compile(
 
 if ($Self->{vlt_all}) {
     file_grep($Self->{stats}, qr/Optimizations, isolate_assignments blocks\s+5/i);
-    file_grep("$out_filename", qr/\<var fl="d22" loc="\d+,\d+,\d+,\d+" name="t.b" dtype_id="4" vartype="logic" origName="b" isolate_assignments="true"\/\>/i);
-    file_grep("$out_filename", qr/\<var fl="d98" loc="\d+,\d+,\d+,\d+" name="__Vfunc_t.file.get_31_16__0__Vfuncout" dtype_id="5" vartype="logic" origName="__Vfunc_t__DOT__file__DOT__get_31_16__0__Vfuncout" isolate_assignments="true"\/\>/i);
-    file_grep("$out_filename", qr/\<var fl="d99" loc="\d+,\d+,\d+,\d+" name="__Vfunc_t.file.get_31_16__0__t_crc" dtype_id="4" vartype="logic" origName="__Vfunc_t__DOT__file__DOT__get_31_16__0__t_crc" isolate_assignments="true"\/\>/i);
-    file_grep("$out_filename", qr/\<var fl="d111" loc="\d+,\d+,\d+,\d+" name="__Vtask_t.file.set_b_d__1__t_crc" dtype_id="4" vartype="logic" origName="__Vtask_t__DOT__file__DOT__set_b_d__1__t_crc" isolate_assignments="true"\/\>/i);
-    file_grep("$out_filename", qr/\<var fl="d112" loc="\d+,\d+,\d+,\d+" name="__Vtask_t.file.set_b_d__1__t_c" dtype_id="4" vartype="logic" origName="__Vtask_t__DOT__file__DOT__set_b_d__1__t_c" isolate_assignments="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="d22" loc=".*?" name="t.b" dtype_id="4" vartype="logic" origName="b" isolate_assignments="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="d98" loc=".*?" name="__Vfunc_t.file.get_31_16__0__Vfuncout" dtype_id="5" vartype="logic" origName="__Vfunc_t__DOT__file__DOT__get_31_16__0__Vfuncout" isolate_assignments="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="d99" loc=".*?" name="__Vfunc_t.file.get_31_16__0__t_crc" dtype_id="4" vartype="logic" origName="__Vfunc_t__DOT__file__DOT__get_31_16__0__t_crc" isolate_assignments="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="d111" loc=".*?" name="__Vtask_t.file.set_b_d__1__t_crc" dtype_id="4" vartype="logic" origName="__Vtask_t__DOT__file__DOT__set_b_d__1__t_crc" isolate_assignments="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="d112" loc=".*?" name="__Vtask_t.file.set_b_d__1__t_c" dtype_id="4" vartype="logic" origName="__Vtask_t__DOT__file__DOT__set_b_d__1__t_c" isolate_assignments="true"\/\>/i);
 }
 
 execute(

--- a/test_regress/t/t_unopt_combo_isolate.pl
+++ b/test_regress/t/t_unopt_combo_isolate.pl
@@ -18,11 +18,11 @@ compile(
 
 if ($Self->{vlt_all}) {
     file_grep($Self->{stats}, qr/Optimizations, isolate_assignments blocks\s+5/i);
-    file_grep("$out_filename", qr/\<var fl="d22" loc="(\d+,){3}\d+" name="t.b" dtype_id="4" vartype="logic" origName="b" isolate_assignments="true"\/\>/i);
-    file_grep("$out_filename", qr/\<var fl="d98" loc="(\d+,){3}\d+" name="__Vfunc_t.file.get_31_16__0__Vfuncout" dtype_id="5" vartype="logic" origName="__Vfunc_t__DOT__file__DOT__get_31_16__0__Vfuncout" isolate_assignments="true"\/\>/i);
-    file_grep("$out_filename", qr/\<var fl="d99" loc="(\d+,){3}\d+" name="__Vfunc_t.file.get_31_16__0__t_crc" dtype_id="4" vartype="logic" origName="__Vfunc_t__DOT__file__DOT__get_31_16__0__t_crc" isolate_assignments="true"\/\>/i);
-    file_grep("$out_filename", qr/\<var fl="d111" loc="(\d+,){3}\d+" name="__Vtask_t.file.set_b_d__1__t_crc" dtype_id="4" vartype="logic" origName="__Vtask_t__DOT__file__DOT__set_b_d__1__t_crc" isolate_assignments="true"\/\>/i);
-    file_grep("$out_filename", qr/\<var fl="d112" loc="(\d+,){3}\d+" name="__Vtask_t.file.set_b_d__1__t_c" dtype_id="4" vartype="logic" origName="__Vtask_t__DOT__file__DOT__set_b_d__1__t_c" isolate_assignments="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="d22" loc="\d+,\d+,\d+,\d+" name="t.b" dtype_id="4" vartype="logic" origName="b" isolate_assignments="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="d98" loc="\d+,\d+,\d+,\d+" name="__Vfunc_t.file.get_31_16__0__Vfuncout" dtype_id="5" vartype="logic" origName="__Vfunc_t__DOT__file__DOT__get_31_16__0__Vfuncout" isolate_assignments="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="d99" loc="\d+,\d+,\d+,\d+" name="__Vfunc_t.file.get_31_16__0__t_crc" dtype_id="4" vartype="logic" origName="__Vfunc_t__DOT__file__DOT__get_31_16__0__t_crc" isolate_assignments="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="d111" loc="\d+,\d+,\d+,\d+" name="__Vtask_t.file.set_b_d__1__t_crc" dtype_id="4" vartype="logic" origName="__Vtask_t__DOT__file__DOT__set_b_d__1__t_crc" isolate_assignments="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="d112" loc="\d+,\d+,\d+,\d+" name="__Vtask_t.file.set_b_d__1__t_c" dtype_id="4" vartype="logic" origName="__Vtask_t__DOT__file__DOT__set_b_d__1__t_c" isolate_assignments="true"\/\>/i);
 }
 
 execute(

--- a/test_regress/t/t_unopt_combo_isolate_vlt.pl
+++ b/test_regress/t/t_unopt_combo_isolate_vlt.pl
@@ -18,11 +18,11 @@ compile(
 
 if ($Self->{vlt_all}) {
     file_grep($Self->{stats}, qr/Optimizations, isolate_assignments blocks\s+5/i);
-    file_grep("$out_filename", qr/\<var fl="e22" loc="\d+,\d+,\d+,\d+" name="t.b" dtype_id="4" vartype="logic" origName="b" isolate_assignments="true"\/\>/i);
-    file_grep("$out_filename", qr/\<var fl="e103" loc="\d+,\d+,\d+,\d+" name="__Vfunc_t.file.get_31_16__0__Vfuncout" dtype_id="5" vartype="logic" origName="__Vfunc_t__DOT__file__DOT__get_31_16__0__Vfuncout" isolate_assignments="true"\/\>/i);
-    file_grep("$out_filename", qr/\<var fl="e104" loc="\d+,\d+,\d+,\d+" name="__Vfunc_t.file.get_31_16__0__t_crc" dtype_id="4" vartype="logic" origName="__Vfunc_t__DOT__file__DOT__get_31_16__0__t_crc" isolate_assignments="true"\/\>/i);
-    file_grep("$out_filename", qr/\<var fl="e114" loc="\d+,\d+,\d+,\d+" name="__Vtask_t.file.set_b_d__1__t_crc" dtype_id="4" vartype="logic" origName="__Vtask_t__DOT__file__DOT__set_b_d__1__t_crc" isolate_assignments="true"\/\>/i);
-    file_grep("$out_filename", qr/\<var fl="e115" loc="\d+,\d+,\d+,\d+" name="__Vtask_t.file.set_b_d__1__t_c" dtype_id="4" vartype="logic" origName="__Vtask_t__DOT__file__DOT__set_b_d__1__t_c" isolate_assignments="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="e22" loc=".*?" name="t.b" dtype_id="4" vartype="logic" origName="b" isolate_assignments="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="e103" loc=".*?" name="__Vfunc_t.file.get_31_16__0__Vfuncout" dtype_id="5" vartype="logic" origName="__Vfunc_t__DOT__file__DOT__get_31_16__0__Vfuncout" isolate_assignments="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="e104" loc=".*?" name="__Vfunc_t.file.get_31_16__0__t_crc" dtype_id="4" vartype="logic" origName="__Vfunc_t__DOT__file__DOT__get_31_16__0__t_crc" isolate_assignments="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="e114" loc=".*?" name="__Vtask_t.file.set_b_d__1__t_crc" dtype_id="4" vartype="logic" origName="__Vtask_t__DOT__file__DOT__set_b_d__1__t_crc" isolate_assignments="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="e115" loc=".*?" name="__Vtask_t.file.set_b_d__1__t_c" dtype_id="4" vartype="logic" origName="__Vtask_t__DOT__file__DOT__set_b_d__1__t_c" isolate_assignments="true"\/\>/i);
 }
 
 execute(

--- a/test_regress/t/t_unopt_combo_isolate_vlt.pl
+++ b/test_regress/t/t_unopt_combo_isolate_vlt.pl
@@ -19,7 +19,7 @@ compile(
 if ($Self->{vlt_all}) {
     file_grep($Self->{stats}, qr/Optimizations, isolate_assignments blocks\s+5/i);
     file_grep("$out_filename", qr/\<var fl="e22" loc="\d+,\d+,\d+,\d+" name="t.b" dtype_id="4" vartype="logic" origName="b" isolate_assignments="true"\/\>/i);
-    file_grep("$out_filename", qr/\<var fl="e103" loc="\d+,\d+,\d+,\d+"__Vfunc_t.file.get_31_16__0__Vfuncout" dtype_id="5" vartype="logic" origName="__Vfunc_t__DOT__file__DOT__get_31_16__0__Vfuncout" isolate_assignments="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="e103" loc="\d+,\d+,\d+,\d+" name="__Vfunc_t.file.get_31_16__0__Vfuncout" dtype_id="5" vartype="logic" origName="__Vfunc_t__DOT__file__DOT__get_31_16__0__Vfuncout" isolate_assignments="true"\/\>/i);
     file_grep("$out_filename", qr/\<var fl="e104" loc="\d+,\d+,\d+,\d+" name="__Vfunc_t.file.get_31_16__0__t_crc" dtype_id="4" vartype="logic" origName="__Vfunc_t__DOT__file__DOT__get_31_16__0__t_crc" isolate_assignments="true"\/\>/i);
     file_grep("$out_filename", qr/\<var fl="e114" loc="\d+,\d+,\d+,\d+" name="__Vtask_t.file.set_b_d__1__t_crc" dtype_id="4" vartype="logic" origName="__Vtask_t__DOT__file__DOT__set_b_d__1__t_crc" isolate_assignments="true"\/\>/i);
     file_grep("$out_filename", qr/\<var fl="e115" loc="\d+,\d+,\d+,\d+" name="__Vtask_t.file.set_b_d__1__t_c" dtype_id="4" vartype="logic" origName="__Vtask_t__DOT__file__DOT__set_b_d__1__t_c" isolate_assignments="true"\/\>/i);

--- a/test_regress/t/t_unopt_combo_isolate_vlt.pl
+++ b/test_regress/t/t_unopt_combo_isolate_vlt.pl
@@ -18,11 +18,11 @@ compile(
 
 if ($Self->{vlt_all}) {
     file_grep($Self->{stats}, qr/Optimizations, isolate_assignments blocks\s+5/i);
-    file_grep("$out_filename", qr/\<var fl="e22" loc="(\d+,){3}\d+" name="t.b" dtype_id="4" vartype="logic" origName="b" isolate_assignments="true"\/\>/i);
-    file_grep("$out_filename", qr/\<var fl="e103" loc="(\d+,){3}\d+" name="__Vfunc_t.file.get_31_16__0__Vfuncout" dtype_id="5" vartype="logic" origName="__Vfunc_t__DOT__file__DOT__get_31_16__0__Vfuncout" isolate_assignments="true"\/\>/i);
-    file_grep("$out_filename", qr/\<var fl="e104" loc="(\d+,){3}\d+" name="__Vfunc_t.file.get_31_16__0__t_crc" dtype_id="4" vartype="logic" origName="__Vfunc_t__DOT__file__DOT__get_31_16__0__t_crc" isolate_assignments="true"\/\>/i);
-    file_grep("$out_filename", qr/\<var fl="e114" loc="(\d+,){3}\d+" name="__Vtask_t.file.set_b_d__1__t_crc" dtype_id="4" vartype="logic" origName="__Vtask_t__DOT__file__DOT__set_b_d__1__t_crc" isolate_assignments="true"\/\>/i);
-    file_grep("$out_filename", qr/\<var fl="e115" loc="(\d+,){3}\d+" name="__Vtask_t.file.set_b_d__1__t_c" dtype_id="4" vartype="logic" origName="__Vtask_t__DOT__file__DOT__set_b_d__1__t_c" isolate_assignments="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="e22" loc="\d+,\d+,\d+,\d+" name="t.b" dtype_id="4" vartype="logic" origName="b" isolate_assignments="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="e103" loc="\d+,\d+,\d+,\d+"__Vfunc_t.file.get_31_16__0__Vfuncout" dtype_id="5" vartype="logic" origName="__Vfunc_t__DOT__file__DOT__get_31_16__0__Vfuncout" isolate_assignments="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="e104" loc="\d+,\d+,\d+,\d+" name="__Vfunc_t.file.get_31_16__0__t_crc" dtype_id="4" vartype="logic" origName="__Vfunc_t__DOT__file__DOT__get_31_16__0__t_crc" isolate_assignments="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="e114" loc="\d+,\d+,\d+,\d+" name="__Vtask_t.file.set_b_d__1__t_crc" dtype_id="4" vartype="logic" origName="__Vtask_t__DOT__file__DOT__set_b_d__1__t_crc" isolate_assignments="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="e115" loc="\d+,\d+,\d+,\d+" name="__Vtask_t.file.set_b_d__1__t_c" dtype_id="4" vartype="logic" origName="__Vtask_t__DOT__file__DOT__set_b_d__1__t_c" isolate_assignments="true"\/\>/i);
 }
 
 execute(

--- a/test_regress/t/t_unopt_combo_isolate_vlt.pl
+++ b/test_regress/t/t_unopt_combo_isolate_vlt.pl
@@ -18,11 +18,11 @@ compile(
 
 if ($Self->{vlt_all}) {
     file_grep($Self->{stats}, qr/Optimizations, isolate_assignments blocks\s+5/i);
-    file_grep("$out_filename", qr/\<var fl="e22" name="t.b" dtype_id="4" vartype="logic" origName="b" isolate_assignments="true"\/\>/i);
-    file_grep("$out_filename", qr/\<var fl="e103" name="__Vfunc_t.file.get_31_16__0__Vfuncout" dtype_id="5" vartype="logic" origName="__Vfunc_t__DOT__file__DOT__get_31_16__0__Vfuncout" isolate_assignments="true"\/\>/i);
-    file_grep("$out_filename", qr/\<var fl="e104" name="__Vfunc_t.file.get_31_16__0__t_crc" dtype_id="4" vartype="logic" origName="__Vfunc_t__DOT__file__DOT__get_31_16__0__t_crc" isolate_assignments="true"\/\>/i);
-    file_grep("$out_filename", qr/\<var fl="e114" name="__Vtask_t.file.set_b_d__1__t_crc" dtype_id="4" vartype="logic" origName="__Vtask_t__DOT__file__DOT__set_b_d__1__t_crc" isolate_assignments="true"\/\>/i);
-    file_grep("$out_filename", qr/\<var fl="e115" name="__Vtask_t.file.set_b_d__1__t_c" dtype_id="4" vartype="logic" origName="__Vtask_t__DOT__file__DOT__set_b_d__1__t_c" isolate_assignments="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="e22" loc="(\d+,){3}\d+" name="t.b" dtype_id="4" vartype="logic" origName="b" isolate_assignments="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="e103" loc="(\d+,){3}\d+" name="__Vfunc_t.file.get_31_16__0__Vfuncout" dtype_id="5" vartype="logic" origName="__Vfunc_t__DOT__file__DOT__get_31_16__0__Vfuncout" isolate_assignments="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="e104" loc="(\d+,){3}\d+" name="__Vfunc_t.file.get_31_16__0__t_crc" dtype_id="4" vartype="logic" origName="__Vfunc_t__DOT__file__DOT__get_31_16__0__t_crc" isolate_assignments="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="e114" loc="(\d+,){3}\d+" name="__Vtask_t.file.set_b_d__1__t_crc" dtype_id="4" vartype="logic" origName="__Vtask_t__DOT__file__DOT__set_b_d__1__t_crc" isolate_assignments="true"\/\>/i);
+    file_grep("$out_filename", qr/\<var fl="e115" loc="(\d+,){3}\d+" name="__Vtask_t.file.set_b_d__1__t_c" dtype_id="4" vartype="logic" origName="__Vtask_t__DOT__file__DOT__set_b_d__1__t_c" isolate_assignments="true"\/\>/i);
 }
 
 execute(

--- a/test_regress/t/t_xml_first.out
+++ b/test_regress/t/t_xml_first.out
@@ -17,69 +17,69 @@
     </cell>
   </cells>
   <netlist>
-    <module fl="d6" loc="6,8,6,9" name="t" origName="t" topModule="1">
-      <var fl="d12" loc="12,10,12,13" name="clk" dtype_id="1" dir="input" vartype="logic" origName="clk"/>
-      <var fl="d13" loc="13,16,13,17" name="d" dtype_id="2" dir="input" vartype="logic" origName="d"/>
-      <var fl="d14" loc="14,22,14,23" name="q" dtype_id="2" dir="output" vartype="logic" origName="q"/>
-      <var fl="d16" loc="16,22,16,29" name="between" dtype_id="2" vartype="logic" origName="between"/>
-      <instance fl="d19" loc="19,4,19,9" name="cell1" defName="mod1__W4" origName="cell1">
-        <port fl="d19" loc="19,12,19,13" name="q" direction="out" portIndex="1">
-          <varref fl="d19" loc="19,14,19,21" name="between" dtype_id="2"/>
+    <module fl="d6" loc="d,6,8,6,9" name="t" origName="t" topModule="1">
+      <var fl="d12" loc="d,12,10,12,13" name="clk" dtype_id="1" dir="input" vartype="logic" origName="clk"/>
+      <var fl="d13" loc="d,13,16,13,17" name="d" dtype_id="2" dir="input" vartype="logic" origName="d"/>
+      <var fl="d14" loc="d,14,22,14,23" name="q" dtype_id="2" dir="output" vartype="logic" origName="q"/>
+      <var fl="d16" loc="d,16,22,16,29" name="between" dtype_id="2" vartype="logic" origName="between"/>
+      <instance fl="d19" loc="d,19,4,19,9" name="cell1" defName="mod1__W4" origName="cell1">
+        <port fl="d19" loc="d,19,12,19,13" name="q" direction="out" portIndex="1">
+          <varref fl="d19" loc="d,19,14,19,21" name="between" dtype_id="2"/>
         </port>
-        <port fl="d20" loc="20,12,20,15" name="clk" direction="in" portIndex="2">
-          <varref fl="d20" loc="20,42,20,45" name="clk" dtype_id="1"/>
+        <port fl="d20" loc="d,20,12,20,15" name="clk" direction="in" portIndex="2">
+          <varref fl="d20" loc="d,20,42,20,45" name="clk" dtype_id="1"/>
         </port>
-        <port fl="d21" loc="21,12,21,13" name="d" direction="in" portIndex="3">
-          <varref fl="d21" loc="21,42,21,43" name="d" dtype_id="2"/>
+        <port fl="d21" loc="d,21,12,21,13" name="d" direction="in" portIndex="3">
+          <varref fl="d21" loc="d,21,42,21,43" name="d" dtype_id="2"/>
         </port>
       </instance>
-      <instance fl="d24" loc="24,6,24,11" name="cell2" defName="mod2" origName="cell2">
-        <port fl="d24" loc="24,14,24,15" name="d" direction="in" portIndex="1">
-          <varref fl="d24" loc="24,16,24,23" name="between" dtype_id="2"/>
+      <instance fl="d24" loc="d,24,6,24,11" name="cell2" defName="mod2" origName="cell2">
+        <port fl="d24" loc="d,24,14,24,15" name="d" direction="in" portIndex="1">
+          <varref fl="d24" loc="d,24,16,24,23" name="between" dtype_id="2"/>
         </port>
-        <port fl="d25" loc="25,14,25,15" name="q" direction="out" portIndex="2">
-          <varref fl="d25" loc="25,42,25,43" name="q" dtype_id="2"/>
+        <port fl="d25" loc="d,25,14,25,15" name="q" direction="out" portIndex="2">
+          <varref fl="d25" loc="d,25,42,25,43" name="q" dtype_id="2"/>
         </port>
-        <port fl="d26" loc="26,14,26,17" name="clk" direction="in" portIndex="3">
-          <varref fl="d26" loc="26,42,26,45" name="clk" dtype_id="1"/>
+        <port fl="d26" loc="d,26,14,26,17" name="clk" direction="in" portIndex="3">
+          <varref fl="d26" loc="d,26,42,26,45" name="clk" dtype_id="1"/>
         </port>
       </instance>
     </module>
-    <module fl="d30" loc="30,8,30,12" name="mod1__W4" origName="mod1">
-      <var fl="d31" loc="31,15,31,20" name="WIDTH" dtype_id="3" vartype="logic" origName="WIDTH" param="true">
-        <const fl="d18" loc="18,18,18,19" name="32&apos;sh4" dtype_id="3"/>
+    <module fl="d30" loc="d,30,8,30,12" name="mod1__W4" origName="mod1">
+      <var fl="d31" loc="d,31,15,31,20" name="WIDTH" dtype_id="3" vartype="logic" origName="WIDTH" param="true">
+        <const fl="d18" loc="d,18,18,18,19" name="32&apos;sh4" dtype_id="3"/>
       </var>
-      <var fl="d33" loc="33,24,33,27" name="clk" dtype_id="1" dir="input" vartype="logic" origName="clk"/>
-      <var fl="d34" loc="34,30,34,31" name="d" dtype_id="2" dir="input" vartype="logic" origName="d"/>
-      <var fl="d35" loc="35,30,35,31" name="q" dtype_id="2" dir="output" vartype="logic" origName="q"/>
-      <var fl="d38" loc="38,15,38,22" name="IGNORED" dtype_id="3" vartype="logic" origName="IGNORED" localparam="true">
-        <const fl="d38" loc="38,25,38,26" name="32&apos;sh1" dtype_id="3"/>
+      <var fl="d33" loc="d,33,24,33,27" name="clk" dtype_id="1" dir="input" vartype="logic" origName="clk"/>
+      <var fl="d34" loc="d,34,30,34,31" name="d" dtype_id="2" dir="input" vartype="logic" origName="d"/>
+      <var fl="d35" loc="d,35,30,35,31" name="q" dtype_id="2" dir="output" vartype="logic" origName="q"/>
+      <var fl="d38" loc="d,38,15,38,22" name="IGNORED" dtype_id="3" vartype="logic" origName="IGNORED" localparam="true">
+        <const fl="d38" loc="d,38,25,38,26" name="32&apos;sh1" dtype_id="3"/>
       </var>
-      <always fl="d40" loc="40,4,40,10">
-        <sentree fl="d40" loc="40,11,40,12">
-          <senitem fl="d40" loc="40,13,40,20" edgeType="POS">
-            <varref fl="d40" loc="40,21,40,24" name="clk" dtype_id="1"/>
+      <always fl="d40" loc="d,40,4,40,10">
+        <sentree fl="d40" loc="d,40,11,40,12">
+          <senitem fl="d40" loc="d,40,13,40,20" edgeType="POS">
+            <varref fl="d40" loc="d,40,21,40,24" name="clk" dtype_id="1"/>
           </senitem>
         </sentree>
-        <assigndly fl="d41" loc="41,8,41,10" dtype_id="2">
-          <varref fl="d41" loc="41,11,41,12" name="d" dtype_id="2"/>
-          <varref fl="d41" loc="41,6,41,7" name="q" dtype_id="2"/>
+        <assigndly fl="d41" loc="d,41,8,41,10" dtype_id="2">
+          <varref fl="d41" loc="d,41,11,41,12" name="d" dtype_id="2"/>
+          <varref fl="d41" loc="d,41,6,41,7" name="q" dtype_id="2"/>
         </assigndly>
       </always>
     </module>
-    <module fl="d45" loc="45,8,45,12" name="mod2" origName="mod2">
-      <var fl="d47" loc="47,10,47,13" name="clk" dtype_id="1" dir="input" vartype="logic" origName="clk"/>
-      <var fl="d48" loc="48,16,48,17" name="d" dtype_id="2" dir="input" vartype="logic" origName="d"/>
-      <var fl="d49" loc="49,22,49,23" name="q" dtype_id="2" dir="output" vartype="logic" origName="q"/>
-      <contassign fl="d52" loc="52,13,52,14" dtype_id="2">
-        <varref fl="d52" loc="52,15,52,16" name="d" dtype_id="2"/>
-        <varref fl="d52" loc="52,11,52,12" name="q" dtype_id="2"/>
+    <module fl="d45" loc="d,45,8,45,12" name="mod2" origName="mod2">
+      <var fl="d47" loc="d,47,10,47,13" name="clk" dtype_id="1" dir="input" vartype="logic" origName="clk"/>
+      <var fl="d48" loc="d,48,16,48,17" name="d" dtype_id="2" dir="input" vartype="logic" origName="d"/>
+      <var fl="d49" loc="d,49,22,49,23" name="q" dtype_id="2" dir="output" vartype="logic" origName="q"/>
+      <contassign fl="d52" loc="d,52,13,52,14" dtype_id="2">
+        <varref fl="d52" loc="d,52,15,52,16" name="d" dtype_id="2"/>
+        <varref fl="d52" loc="d,52,11,52,12" name="q" dtype_id="2"/>
       </contassign>
     </module>
-    <typetable fl="a0" loc="0,0,0,0">
-      <basicdtype fl="d47" loc="47,10,47,13" id="1" name="logic"/>
-      <basicdtype fl="d13" loc="13,10,13,11" id="2" name="logic" left="3" right="0"/>
-      <basicdtype fl="d18" loc="18,18,18,19" id="3" name="logic" left="31" right="0"/>
+    <typetable fl="a0" loc="a,0,0,0,0">
+      <basicdtype fl="d47" loc="d,47,10,47,13" id="1" name="logic"/>
+      <basicdtype fl="d13" loc="d,13,10,13,11" id="2" name="logic" left="3" right="0"/>
+      <basicdtype fl="d18" loc="d,18,18,18,19" id="3" name="logic" left="31" right="0"/>
     </typetable>
   </netlist>
 </verilator_xml>

--- a/test_regress/t/t_xml_first.out
+++ b/test_regress/t/t_xml_first.out
@@ -17,69 +17,69 @@
     </cell>
   </cells>
   <netlist>
-    <module fl="d6" name="t" origName="t" topModule="1">
-      <var fl="d12" name="clk" dtype_id="1" dir="input" vartype="logic" origName="clk"/>
-      <var fl="d13" name="d" dtype_id="2" dir="input" vartype="logic" origName="d"/>
-      <var fl="d14" name="q" dtype_id="2" dir="output" vartype="logic" origName="q"/>
-      <var fl="d16" name="between" dtype_id="2" vartype="logic" origName="between"/>
-      <instance fl="d19" name="cell1" defName="mod1__W4" origName="cell1">
-        <port fl="d19" name="q" direction="out" portIndex="1">
-          <varref fl="d19" name="between" dtype_id="2"/>
+    <module fl="d6" loc="6,8,6,9" name="t" origName="t" topModule="1">
+      <var fl="d12" loc="12,10,12,13" name="clk" dtype_id="1" dir="input" vartype="logic" origName="clk"/>
+      <var fl="d13" loc="13,16,13,17" name="d" dtype_id="2" dir="input" vartype="logic" origName="d"/>
+      <var fl="d14" loc="14,22,14,23" name="q" dtype_id="2" dir="output" vartype="logic" origName="q"/>
+      <var fl="d16" loc="16,22,16,29" name="between" dtype_id="2" vartype="logic" origName="between"/>
+      <instance fl="d19" loc="19,4,19,9" name="cell1" defName="mod1__W4" origName="cell1">
+        <port fl="d19" loc="19,12,19,13" name="q" direction="out" portIndex="1">
+          <varref fl="d19" loc="19,14,19,21" name="between" dtype_id="2"/>
         </port>
-        <port fl="d20" name="clk" direction="in" portIndex="2">
-          <varref fl="d20" name="clk" dtype_id="1"/>
+        <port fl="d20" loc="20,12,20,15" name="clk" direction="in" portIndex="2">
+          <varref fl="d20" loc="20,42,20,45" name="clk" dtype_id="1"/>
         </port>
-        <port fl="d21" name="d" direction="in" portIndex="3">
-          <varref fl="d21" name="d" dtype_id="2"/>
+        <port fl="d21" loc="21,12,21,13" name="d" direction="in" portIndex="3">
+          <varref fl="d21" loc="21,42,21,43" name="d" dtype_id="2"/>
         </port>
       </instance>
-      <instance fl="d24" name="cell2" defName="mod2" origName="cell2">
-        <port fl="d24" name="d" direction="in" portIndex="1">
-          <varref fl="d24" name="between" dtype_id="2"/>
+      <instance fl="d24" loc="24,6,24,11" name="cell2" defName="mod2" origName="cell2">
+        <port fl="d24" loc="24,14,24,15" name="d" direction="in" portIndex="1">
+          <varref fl="d24" loc="24,16,24,23" name="between" dtype_id="2"/>
         </port>
-        <port fl="d25" name="q" direction="out" portIndex="2">
-          <varref fl="d25" name="q" dtype_id="2"/>
+        <port fl="d25" loc="25,14,25,15" name="q" direction="out" portIndex="2">
+          <varref fl="d25" loc="25,42,25,43" name="q" dtype_id="2"/>
         </port>
-        <port fl="d26" name="clk" direction="in" portIndex="3">
-          <varref fl="d26" name="clk" dtype_id="1"/>
+        <port fl="d26" loc="26,14,26,17" name="clk" direction="in" portIndex="3">
+          <varref fl="d26" loc="26,42,26,45" name="clk" dtype_id="1"/>
         </port>
       </instance>
     </module>
-    <module fl="d30" name="mod1__W4" origName="mod1">
-      <var fl="d31" name="WIDTH" dtype_id="3" vartype="logic" origName="WIDTH" param="true">
-        <const fl="d18" name="32&apos;sh4" dtype_id="3"/>
+    <module fl="d30" loc="30,8,30,12" name="mod1__W4" origName="mod1">
+      <var fl="d31" loc="31,15,31,20" name="WIDTH" dtype_id="3" vartype="logic" origName="WIDTH" param="true">
+        <const fl="d18" loc="18,18,18,19" name="32&apos;sh4" dtype_id="3"/>
       </var>
-      <var fl="d33" name="clk" dtype_id="1" dir="input" vartype="logic" origName="clk"/>
-      <var fl="d34" name="d" dtype_id="2" dir="input" vartype="logic" origName="d"/>
-      <var fl="d35" name="q" dtype_id="2" dir="output" vartype="logic" origName="q"/>
-      <var fl="d38" name="IGNORED" dtype_id="3" vartype="logic" origName="IGNORED" localparam="true">
-        <const fl="d38" name="32&apos;sh1" dtype_id="3"/>
+      <var fl="d33" loc="33,24,33,27" name="clk" dtype_id="1" dir="input" vartype="logic" origName="clk"/>
+      <var fl="d34" loc="34,30,34,31" name="d" dtype_id="2" dir="input" vartype="logic" origName="d"/>
+      <var fl="d35" loc="35,30,35,31" name="q" dtype_id="2" dir="output" vartype="logic" origName="q"/>
+      <var fl="d38" loc="38,15,38,22" name="IGNORED" dtype_id="3" vartype="logic" origName="IGNORED" localparam="true">
+        <const fl="d38" loc="38,25,38,26" name="32&apos;sh1" dtype_id="3"/>
       </var>
-      <always fl="d40">
-        <sentree fl="d40">
-          <senitem fl="d40" edgeType="POS">
-            <varref fl="d40" name="clk" dtype_id="1"/>
+      <always fl="d40" loc="40,4,40,10">
+        <sentree fl="d40" loc="40,11,40,12">
+          <senitem fl="d40" loc="40,13,40,20" edgeType="POS">
+            <varref fl="d40" loc="40,21,40,24" name="clk" dtype_id="1"/>
           </senitem>
         </sentree>
-        <assigndly fl="d41" dtype_id="2">
-          <varref fl="d41" name="d" dtype_id="2"/>
-          <varref fl="d41" name="q" dtype_id="2"/>
+        <assigndly fl="d41" loc="41,8,41,10" dtype_id="2">
+          <varref fl="d41" loc="41,11,41,12" name="d" dtype_id="2"/>
+          <varref fl="d41" loc="41,6,41,7" name="q" dtype_id="2"/>
         </assigndly>
       </always>
     </module>
-    <module fl="d45" name="mod2" origName="mod2">
-      <var fl="d47" name="clk" dtype_id="1" dir="input" vartype="logic" origName="clk"/>
-      <var fl="d48" name="d" dtype_id="2" dir="input" vartype="logic" origName="d"/>
-      <var fl="d49" name="q" dtype_id="2" dir="output" vartype="logic" origName="q"/>
-      <contassign fl="d52" dtype_id="2">
-        <varref fl="d52" name="d" dtype_id="2"/>
-        <varref fl="d52" name="q" dtype_id="2"/>
+    <module fl="d45" loc="45,8,45,12" name="mod2" origName="mod2">
+      <var fl="d47" loc="47,10,47,13" name="clk" dtype_id="1" dir="input" vartype="logic" origName="clk"/>
+      <var fl="d48" loc="48,16,48,17" name="d" dtype_id="2" dir="input" vartype="logic" origName="d"/>
+      <var fl="d49" loc="49,22,49,23" name="q" dtype_id="2" dir="output" vartype="logic" origName="q"/>
+      <contassign fl="d52" loc="52,13,52,14" dtype_id="2">
+        <varref fl="d52" loc="52,15,52,16" name="d" dtype_id="2"/>
+        <varref fl="d52" loc="52,11,52,12" name="q" dtype_id="2"/>
       </contassign>
     </module>
-    <typetable fl="a0">
-      <basicdtype fl="d47" id="1" name="logic"/>
-      <basicdtype fl="d13" id="2" name="logic" left="3" right="0"/>
-      <basicdtype fl="d18" id="3" name="logic" left="31" right="0"/>
+    <typetable fl="a0" loc="0,0,0,0">
+      <basicdtype fl="d47" loc="47,10,47,13" id="1" name="logic"/>
+      <basicdtype fl="d13" loc="13,10,13,11" id="2" name="logic" left="3" right="0"/>
+      <basicdtype fl="d18" loc="18,18,18,19" id="3" name="logic" left="31" right="0"/>
     </typetable>
   </netlist>
 </verilator_xml>

--- a/test_regress/t/t_xml_output.out
+++ b/test_regress/t/t_xml_output.out
@@ -14,11 +14,11 @@
     <cell fl="d6" name="m" submodname="m" hier="m"/>
   </cells>
   <netlist>
-    <module fl="d6" loc="6,8,6,9" name="m" origName="m">
-      <var fl="d7" loc="7,10,7,13" name="clk" tag="foo_op" dtype_id="1" dir="input" vartype="logic" origName="clk"/>
+    <module fl="d6" loc="d,6,8,6,9" name="m" origName="m">
+      <var fl="d7" loc="d,7,10,7,13" name="clk" tag="foo_op" dtype_id="1" dir="input" vartype="logic" origName="clk"/>
     </module>
-    <typetable fl="a0" loc="0,0,0,0">
-      <basicdtype fl="d7" loc="7,10,7,13" id="1" name="logic"/>
+    <typetable fl="a0" loc="a,0,0,0,0">
+      <basicdtype fl="d7" loc="d,7,10,7,13" id="1" name="logic"/>
     </typetable>
   </netlist>
 </verilator_xml>

--- a/test_regress/t/t_xml_output.out
+++ b/test_regress/t/t_xml_output.out
@@ -14,11 +14,11 @@
     <cell fl="d6" name="m" submodname="m" hier="m"/>
   </cells>
   <netlist>
-    <module fl="d6" name="m" origName="m">
-      <var fl="d7" name="clk" tag="foo_op" dtype_id="1" dir="input" vartype="logic" origName="clk"/>
+    <module fl="d6" loc="6,8,6,9" name="m" origName="m">
+      <var fl="d7" loc="7,10,7,13" name="clk" tag="foo_op" dtype_id="1" dir="input" vartype="logic" origName="clk"/>
     </module>
-    <typetable fl="a0">
-      <basicdtype fl="d7" id="1" name="logic"/>
+    <typetable fl="a0" loc="0,0,0,0">
+      <basicdtype fl="d7" loc="7,10,7,13" id="1" name="logic"/>
     </typetable>
   </netlist>
 </verilator_xml>

--- a/test_regress/t/t_xml_tag.out
+++ b/test_regress/t/t_xml_tag.out
@@ -16,67 +16,67 @@
     </cell>
   </cells>
   <netlist>
-    <module fl="d11" loc="11,8,11,9" name="m" origName="m" topModule="1">
-      <var fl="d13" loc="13,11,13,17" name="clk_ip" tag="clk_ip" dtype_id="1" dir="input" vartype="logic" origName="clk_ip"/>
-      <var fl="d14" loc="14,11,14,17" name="rst_ip" dtype_id="1" dir="input" vartype="logic" origName="rst_ip"/>
-      <var fl="d15" loc="15,11,15,17" name="foo_op" tag="foo_op" dtype_id="1" dir="output" vartype="logic" origName="foo_op"/>
-      <typedef fl="d24" loc="24,6,24,15" name="my_struct" tag="my_struct" dtype_id="2"/>
-      <instance fl="d28" loc="28,8,28,12" name="itop" defName="ifc" origName="itop"/>
-      <var fl="d28" loc="28,8,28,12" name="itop__Viftop" dtype_id="3" vartype="ifaceref" origName="itop__Viftop"/>
-      <var fl="d30" loc="30,14,30,25" name="this_struct" tag="this_struct" dtype_id="4" vartype="" origName="this_struct"/>
-      <var fl="d32" loc="32,16,32,22" name="dotted" dtype_id="5" vartype="logic" origName="dotted"/>
-      <contassign fl="d32" loc="32,23,32,24" dtype_id="5">
-        <varxref fl="d32" loc="32,30,32,35" name="value" dtype_id="6" dotted="itop"/>
-        <varref fl="d32" loc="32,16,32,22" name="dotted" dtype_id="5"/>
+    <module fl="d11" loc="d,11,8,11,9" name="m" origName="m" topModule="1">
+      <var fl="d13" loc="d,13,11,13,17" name="clk_ip" tag="clk_ip" dtype_id="1" dir="input" vartype="logic" origName="clk_ip"/>
+      <var fl="d14" loc="d,14,11,14,17" name="rst_ip" dtype_id="1" dir="input" vartype="logic" origName="rst_ip"/>
+      <var fl="d15" loc="d,15,11,15,17" name="foo_op" tag="foo_op" dtype_id="1" dir="output" vartype="logic" origName="foo_op"/>
+      <typedef fl="d24" loc="d,24,6,24,15" name="my_struct" tag="my_struct" dtype_id="2"/>
+      <instance fl="d28" loc="d,28,8,28,12" name="itop" defName="ifc" origName="itop"/>
+      <var fl="d28" loc="d,28,8,28,12" name="itop__Viftop" dtype_id="3" vartype="ifaceref" origName="itop__Viftop"/>
+      <var fl="d30" loc="d,30,14,30,25" name="this_struct" tag="this_struct" dtype_id="4" vartype="" origName="this_struct"/>
+      <var fl="d32" loc="d,32,16,32,22" name="dotted" dtype_id="5" vartype="logic" origName="dotted"/>
+      <contassign fl="d32" loc="d,32,23,32,24" dtype_id="5">
+        <varxref fl="d32" loc="d,32,30,32,35" name="value" dtype_id="6" dotted="itop"/>
+        <varref fl="d32" loc="d,32,16,32,22" name="dotted" dtype_id="5"/>
       </contassign>
-      <func fl="d34" loc="34,13,34,14" name="f" dtype_id="1">
-        <var fl="d34" loc="34,13,34,14" name="f" dtype_id="1" dir="output" vartype="logic" origName="f"/>
-        <var fl="d34" loc="34,28,34,29" name="m" dtype_id="7" dir="input" vartype="string" origName="m"/>
-        <display fl="d35" loc="35,7,35,15" displaytype="$display">
-          <sformatf fl="d35" loc="35,7,35,15" name="%@" dtype_id="7">
-            <varref fl="d35" loc="35,22,35,23" name="m" dtype_id="7"/>
+      <func fl="d34" loc="d,34,13,34,14" name="f" dtype_id="1">
+        <var fl="d34" loc="d,34,13,34,14" name="f" dtype_id="1" dir="output" vartype="logic" origName="f"/>
+        <var fl="d34" loc="d,34,28,34,29" name="m" dtype_id="7" dir="input" vartype="string" origName="m"/>
+        <display fl="d35" loc="d,35,7,35,15" displaytype="$display">
+          <sformatf fl="d35" loc="d,35,7,35,15" name="%@" dtype_id="7">
+            <varref fl="d35" loc="d,35,22,35,23" name="m" dtype_id="7"/>
           </sformatf>
         </display>
       </func>
-      <initial fl="d38" loc="38,4,38,11">
-        <begin fl="d38" loc="38,12,38,17">
-          <taskref fl="d40" loc="40,7,40,8" name="f">
-            <arg fl="d40" loc="40,9,40,736">
-              <const fl="d40" loc="40,9,40,736" name="&quot;&#1;&#2;&#3;&#4;&#5;&#6;&#7;&#8;&#9;&#10;&#11;&#12;&#13;&#14;&#15;&#16;&#17;&#18;&#19;&#20;&#21;&#22;&#23;&#24;&#25;&#26;&#27;&#28;&#29;&#30;&#31; !&quot;#$%&amp;&apos;()*+,-./0123456789:;&lt;=&gt;?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~&#127;&#128;&#129;&#130;&#131;&#132;&#133;&#134;&#135;&#136;&#137;&#138;&#139;&#140;&#141;&#142;&#143;&#144;&#145;&#146;&#147;&#148;&#149;&#150;&#151;&#152;&#153;&#154;&#155;&#156;&#157;&#158;&#159;&#160;&#161;&#162;&#163;&#164;&#165;&#166;&#167;&#168;&#169;&#170;&#171;&#172;&#173;&#174;&#175;&#176;&#177;&#178;&#179;&#180;&#181;&#182;&#183;&#184;&#185;&#186;&#187;&#188;&#189;&#190;&#191;&#192;&#193;&#194;&#195;&#196;&#197;&#198;&#199;&#200;&#201;&#202;&#203;&#204;&#205;&#206;&#207;&#208;&#209;&#210;&#211;&#212;&#213;&#214;&#215;&#216;&#217;&#218;&#219;&#220;&#221;&#222;&#223;&#224;&#225;&#226;&#227;&#228;&#229;&#230;&#231;&#232;&#233;&#234;&#235;&#236;&#237;&#238;&#239;&#240;&#241;&#242;&#243;&#244;&#245;&#246;&#247;&#248;&#249;&#250;&#251;&#252;&#253;&#254;&#255;&quot;" dtype_id="7"/>
+      <initial fl="d38" loc="d,38,4,38,11">
+        <begin fl="d38" loc="d,38,12,38,17">
+          <taskref fl="d40" loc="d,40,7,40,8" name="f">
+            <arg fl="d40" loc="d,40,9,40,736">
+              <const fl="d40" loc="d,40,9,40,736" name="&quot;&#1;&#2;&#3;&#4;&#5;&#6;&#7;&#8;&#9;&#10;&#11;&#12;&#13;&#14;&#15;&#16;&#17;&#18;&#19;&#20;&#21;&#22;&#23;&#24;&#25;&#26;&#27;&#28;&#29;&#30;&#31; !&quot;#$%&amp;&apos;()*+,-./0123456789:;&lt;=&gt;?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~&#127;&#128;&#129;&#130;&#131;&#132;&#133;&#134;&#135;&#136;&#137;&#138;&#139;&#140;&#141;&#142;&#143;&#144;&#145;&#146;&#147;&#148;&#149;&#150;&#151;&#152;&#153;&#154;&#155;&#156;&#157;&#158;&#159;&#160;&#161;&#162;&#163;&#164;&#165;&#166;&#167;&#168;&#169;&#170;&#171;&#172;&#173;&#174;&#175;&#176;&#177;&#178;&#179;&#180;&#181;&#182;&#183;&#184;&#185;&#186;&#187;&#188;&#189;&#190;&#191;&#192;&#193;&#194;&#195;&#196;&#197;&#198;&#199;&#200;&#201;&#202;&#203;&#204;&#205;&#206;&#207;&#208;&#209;&#210;&#211;&#212;&#213;&#214;&#215;&#216;&#217;&#218;&#219;&#220;&#221;&#222;&#223;&#224;&#225;&#226;&#227;&#228;&#229;&#230;&#231;&#232;&#233;&#234;&#235;&#236;&#237;&#238;&#239;&#240;&#241;&#242;&#243;&#244;&#245;&#246;&#247;&#248;&#249;&#250;&#251;&#252;&#253;&#254;&#255;&quot;" dtype_id="7"/>
             </arg>
           </taskref>
         </begin>
       </initial>
     </module>
-    <iface fl="d6" loc="6,11,6,14" name="ifc" origName="ifc">
-      <var fl="d7" loc="7,12,7,17" name="value" dtype_id="6" vartype="integer" origName="value"/>
-      <modport fl="d8" loc="8,12,8,23" name="out_modport">
-        <modportvarref fl="d8" loc="8,32,8,37" name="value" direction="out"/>
+    <iface fl="d6" loc="d,6,11,6,14" name="ifc" origName="ifc">
+      <var fl="d7" loc="d,7,12,7,17" name="value" dtype_id="6" vartype="integer" origName="value"/>
+      <modport fl="d8" loc="d,8,12,8,23" name="out_modport">
+        <modportvarref fl="d8" loc="d,8,32,8,37" name="value" direction="out"/>
       </modport>
     </iface>
-    <typetable fl="a0" loc="0,0,0,0">
-      <basicdtype fl="d30" loc="30,26,30,27" id="5" name="logic" left="31" right="0"/>
-      <basicdtype fl="d7" loc="7,4,7,11" id="6" name="integer" left="31" right="0"/>
-      <basicdtype fl="d13" loc="13,11,13,17" id="1" name="logic"/>
-      <structdtype fl="d19" loc="19,12,19,18" id="2" name="m.my_struct">
-        <memberdtype fl="d20" loc="20,16,20,19" id="8" name="clk" tag="this is clk" sub_dtype_id="9"/>
-        <memberdtype fl="d21" loc="21,16,21,17" id="10" name="k" sub_dtype_id="11"/>
-        <memberdtype fl="d22" loc="22,16,22,22" id="12" name="enable" tag="enable" sub_dtype_id="13"/>
-        <memberdtype fl="d23" loc="23,16,23,20" id="14" name="data" tag="data" sub_dtype_id="15"/>
+    <typetable fl="a0" loc="a,0,0,0,0">
+      <basicdtype fl="d30" loc="d,30,26,30,27" id="5" name="logic" left="31" right="0"/>
+      <basicdtype fl="d7" loc="d,7,4,7,11" id="6" name="integer" left="31" right="0"/>
+      <basicdtype fl="d13" loc="d,13,11,13,17" id="1" name="logic"/>
+      <structdtype fl="d19" loc="d,19,12,19,18" id="2" name="m.my_struct">
+        <memberdtype fl="d20" loc="d,20,16,20,19" id="8" name="clk" tag="this is clk" sub_dtype_id="9"/>
+        <memberdtype fl="d21" loc="d,21,16,21,17" id="10" name="k" sub_dtype_id="11"/>
+        <memberdtype fl="d22" loc="d,22,16,22,22" id="12" name="enable" tag="enable" sub_dtype_id="13"/>
+        <memberdtype fl="d23" loc="d,23,16,23,20" id="14" name="data" tag="data" sub_dtype_id="15"/>
       </structdtype>
-      <basicdtype fl="d20" loc="20,7,20,12" id="9" name="logic"/>
-      <basicdtype fl="d21" loc="21,7,21,12" id="11" name="logic"/>
-      <basicdtype fl="d22" loc="22,7,22,12" id="13" name="logic"/>
-      <basicdtype fl="d23" loc="23,7,23,12" id="15" name="logic"/>
-      <ifacerefdtype fl="d28" loc="28,8,28,12" id="3" modportname=""/>
-      <unpackarraydtype fl="d30" loc="30,26,30,27" id="4" sub_dtype_id="2">
-        <range fl="d30" loc="30,26,30,27">
-          <const fl="d30" loc="30,26,30,27" name="32&apos;h1" dtype_id="5"/>
-          <const fl="d30" loc="30,26,30,27" name="32&apos;h0" dtype_id="5"/>
+      <basicdtype fl="d20" loc="d,20,7,20,12" id="9" name="logic"/>
+      <basicdtype fl="d21" loc="d,21,7,21,12" id="11" name="logic"/>
+      <basicdtype fl="d22" loc="d,22,7,22,12" id="13" name="logic"/>
+      <basicdtype fl="d23" loc="d,23,7,23,12" id="15" name="logic"/>
+      <ifacerefdtype fl="d28" loc="d,28,8,28,12" id="3" modportname=""/>
+      <unpackarraydtype fl="d30" loc="d,30,26,30,27" id="4" sub_dtype_id="2">
+        <range fl="d30" loc="d,30,26,30,27">
+          <const fl="d30" loc="d,30,26,30,27" name="32&apos;h1" dtype_id="5"/>
+          <const fl="d30" loc="d,30,26,30,27" name="32&apos;h0" dtype_id="5"/>
         </range>
       </unpackarraydtype>
-      <refdtype fl="d30" loc="30,4,30,13" id="16" name="my_struct" sub_dtype_id="2"/>
-      <basicdtype fl="d34" loc="34,21,34,27" id="7" name="string"/>
+      <refdtype fl="d30" loc="d,30,4,30,13" id="16" name="my_struct" sub_dtype_id="2"/>
+      <basicdtype fl="d34" loc="d,34,21,34,27" id="7" name="string"/>
     </typetable>
   </netlist>
 </verilator_xml>

--- a/test_regress/t/t_xml_tag.out
+++ b/test_regress/t/t_xml_tag.out
@@ -16,67 +16,67 @@
     </cell>
   </cells>
   <netlist>
-    <module fl="d11" name="m" origName="m" topModule="1">
-      <var fl="d13" name="clk_ip" tag="clk_ip" dtype_id="1" dir="input" vartype="logic" origName="clk_ip"/>
-      <var fl="d14" name="rst_ip" dtype_id="1" dir="input" vartype="logic" origName="rst_ip"/>
-      <var fl="d15" name="foo_op" tag="foo_op" dtype_id="1" dir="output" vartype="logic" origName="foo_op"/>
-      <typedef fl="d24" name="my_struct" tag="my_struct" dtype_id="2"/>
-      <instance fl="d28" name="itop" defName="ifc" origName="itop"/>
-      <var fl="d28" name="itop__Viftop" dtype_id="3" vartype="ifaceref" origName="itop__Viftop"/>
-      <var fl="d30" name="this_struct" tag="this_struct" dtype_id="4" vartype="" origName="this_struct"/>
-      <var fl="d32" name="dotted" dtype_id="5" vartype="logic" origName="dotted"/>
-      <contassign fl="d32" dtype_id="5">
-        <varxref fl="d32" name="value" dtype_id="6" dotted="itop"/>
-        <varref fl="d32" name="dotted" dtype_id="5"/>
+    <module fl="d11" loc="11,8,11,9" name="m" origName="m" topModule="1">
+      <var fl="d13" loc="13,11,13,17" name="clk_ip" tag="clk_ip" dtype_id="1" dir="input" vartype="logic" origName="clk_ip"/>
+      <var fl="d14" loc="14,11,14,17" name="rst_ip" dtype_id="1" dir="input" vartype="logic" origName="rst_ip"/>
+      <var fl="d15" loc="15,11,15,17" name="foo_op" tag="foo_op" dtype_id="1" dir="output" vartype="logic" origName="foo_op"/>
+      <typedef fl="d24" loc="24,6,24,15" name="my_struct" tag="my_struct" dtype_id="2"/>
+      <instance fl="d28" loc="28,8,28,12" name="itop" defName="ifc" origName="itop"/>
+      <var fl="d28" loc="28,8,28,12" name="itop__Viftop" dtype_id="3" vartype="ifaceref" origName="itop__Viftop"/>
+      <var fl="d30" loc="30,14,30,25" name="this_struct" tag="this_struct" dtype_id="4" vartype="" origName="this_struct"/>
+      <var fl="d32" loc="32,16,32,22" name="dotted" dtype_id="5" vartype="logic" origName="dotted"/>
+      <contassign fl="d32" loc="32,23,32,24" dtype_id="5">
+        <varxref fl="d32" loc="32,30,32,35" name="value" dtype_id="6" dotted="itop"/>
+        <varref fl="d32" loc="32,16,32,22" name="dotted" dtype_id="5"/>
       </contassign>
-      <func fl="d34" name="f" dtype_id="1">
-        <var fl="d34" name="f" dtype_id="1" dir="output" vartype="logic" origName="f"/>
-        <var fl="d34" name="m" dtype_id="7" dir="input" vartype="string" origName="m"/>
-        <display fl="d35" displaytype="$display">
-          <sformatf fl="d35" name="%@" dtype_id="7">
-            <varref fl="d35" name="m" dtype_id="7"/>
+      <func fl="d34" loc="34,13,34,14" name="f" dtype_id="1">
+        <var fl="d34" loc="34,13,34,14" name="f" dtype_id="1" dir="output" vartype="logic" origName="f"/>
+        <var fl="d34" loc="34,28,34,29" name="m" dtype_id="7" dir="input" vartype="string" origName="m"/>
+        <display fl="d35" loc="35,7,35,15" displaytype="$display">
+          <sformatf fl="d35" loc="35,7,35,15" name="%@" dtype_id="7">
+            <varref fl="d35" loc="35,22,35,23" name="m" dtype_id="7"/>
           </sformatf>
         </display>
       </func>
-      <initial fl="d38">
-        <begin fl="d38">
-          <taskref fl="d40" name="f">
-            <arg fl="d40">
-              <const fl="d40" name="&quot;&#1;&#2;&#3;&#4;&#5;&#6;&#7;&#8;&#9;&#10;&#11;&#12;&#13;&#14;&#15;&#16;&#17;&#18;&#19;&#20;&#21;&#22;&#23;&#24;&#25;&#26;&#27;&#28;&#29;&#30;&#31; !&quot;#$%&amp;&apos;()*+,-./0123456789:;&lt;=&gt;?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~&#127;&#128;&#129;&#130;&#131;&#132;&#133;&#134;&#135;&#136;&#137;&#138;&#139;&#140;&#141;&#142;&#143;&#144;&#145;&#146;&#147;&#148;&#149;&#150;&#151;&#152;&#153;&#154;&#155;&#156;&#157;&#158;&#159;&#160;&#161;&#162;&#163;&#164;&#165;&#166;&#167;&#168;&#169;&#170;&#171;&#172;&#173;&#174;&#175;&#176;&#177;&#178;&#179;&#180;&#181;&#182;&#183;&#184;&#185;&#186;&#187;&#188;&#189;&#190;&#191;&#192;&#193;&#194;&#195;&#196;&#197;&#198;&#199;&#200;&#201;&#202;&#203;&#204;&#205;&#206;&#207;&#208;&#209;&#210;&#211;&#212;&#213;&#214;&#215;&#216;&#217;&#218;&#219;&#220;&#221;&#222;&#223;&#224;&#225;&#226;&#227;&#228;&#229;&#230;&#231;&#232;&#233;&#234;&#235;&#236;&#237;&#238;&#239;&#240;&#241;&#242;&#243;&#244;&#245;&#246;&#247;&#248;&#249;&#250;&#251;&#252;&#253;&#254;&#255;&quot;" dtype_id="7"/>
+      <initial fl="d38" loc="38,4,38,11">
+        <begin fl="d38" loc="38,12,38,17">
+          <taskref fl="d40" loc="40,7,40,8" name="f">
+            <arg fl="d40" loc="40,9,40,736">
+              <const fl="d40" loc="40,9,40,736" name="&quot;&#1;&#2;&#3;&#4;&#5;&#6;&#7;&#8;&#9;&#10;&#11;&#12;&#13;&#14;&#15;&#16;&#17;&#18;&#19;&#20;&#21;&#22;&#23;&#24;&#25;&#26;&#27;&#28;&#29;&#30;&#31; !&quot;#$%&amp;&apos;()*+,-./0123456789:;&lt;=&gt;?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~&#127;&#128;&#129;&#130;&#131;&#132;&#133;&#134;&#135;&#136;&#137;&#138;&#139;&#140;&#141;&#142;&#143;&#144;&#145;&#146;&#147;&#148;&#149;&#150;&#151;&#152;&#153;&#154;&#155;&#156;&#157;&#158;&#159;&#160;&#161;&#162;&#163;&#164;&#165;&#166;&#167;&#168;&#169;&#170;&#171;&#172;&#173;&#174;&#175;&#176;&#177;&#178;&#179;&#180;&#181;&#182;&#183;&#184;&#185;&#186;&#187;&#188;&#189;&#190;&#191;&#192;&#193;&#194;&#195;&#196;&#197;&#198;&#199;&#200;&#201;&#202;&#203;&#204;&#205;&#206;&#207;&#208;&#209;&#210;&#211;&#212;&#213;&#214;&#215;&#216;&#217;&#218;&#219;&#220;&#221;&#222;&#223;&#224;&#225;&#226;&#227;&#228;&#229;&#230;&#231;&#232;&#233;&#234;&#235;&#236;&#237;&#238;&#239;&#240;&#241;&#242;&#243;&#244;&#245;&#246;&#247;&#248;&#249;&#250;&#251;&#252;&#253;&#254;&#255;&quot;" dtype_id="7"/>
             </arg>
           </taskref>
         </begin>
       </initial>
     </module>
-    <iface fl="d6" name="ifc" origName="ifc">
-      <var fl="d7" name="value" dtype_id="6" vartype="integer" origName="value"/>
-      <modport fl="d8" name="out_modport">
-        <modportvarref fl="d8" name="value" direction="out"/>
+    <iface fl="d6" loc="6,11,6,14" name="ifc" origName="ifc">
+      <var fl="d7" loc="7,12,7,17" name="value" dtype_id="6" vartype="integer" origName="value"/>
+      <modport fl="d8" loc="8,12,8,23" name="out_modport">
+        <modportvarref fl="d8" loc="8,32,8,37" name="value" direction="out"/>
       </modport>
     </iface>
-    <typetable fl="a0">
-      <basicdtype fl="d30" id="5" name="logic" left="31" right="0"/>
-      <basicdtype fl="d7" id="6" name="integer" left="31" right="0"/>
-      <basicdtype fl="d13" id="1" name="logic"/>
-      <structdtype fl="d19" id="2" name="m.my_struct">
-        <memberdtype fl="d20" id="8" name="clk" tag="this is clk" sub_dtype_id="9"/>
-        <memberdtype fl="d21" id="10" name="k" sub_dtype_id="11"/>
-        <memberdtype fl="d22" id="12" name="enable" tag="enable" sub_dtype_id="13"/>
-        <memberdtype fl="d23" id="14" name="data" tag="data" sub_dtype_id="15"/>
+    <typetable fl="a0" loc="0,0,0,0">
+      <basicdtype fl="d30" loc="30,26,30,27" id="5" name="logic" left="31" right="0"/>
+      <basicdtype fl="d7" loc="7,4,7,11" id="6" name="integer" left="31" right="0"/>
+      <basicdtype fl="d13" loc="13,11,13,17" id="1" name="logic"/>
+      <structdtype fl="d19" loc="19,12,19,18" id="2" name="m.my_struct">
+        <memberdtype fl="d20" loc="20,16,20,19" id="8" name="clk" tag="this is clk" sub_dtype_id="9"/>
+        <memberdtype fl="d21" loc="21,16,21,17" id="10" name="k" sub_dtype_id="11"/>
+        <memberdtype fl="d22" loc="22,16,22,22" id="12" name="enable" tag="enable" sub_dtype_id="13"/>
+        <memberdtype fl="d23" loc="23,16,23,20" id="14" name="data" tag="data" sub_dtype_id="15"/>
       </structdtype>
-      <basicdtype fl="d20" id="9" name="logic"/>
-      <basicdtype fl="d21" id="11" name="logic"/>
-      <basicdtype fl="d22" id="13" name="logic"/>
-      <basicdtype fl="d23" id="15" name="logic"/>
-      <ifacerefdtype fl="d28" id="3" modportname=""/>
-      <unpackarraydtype fl="d30" id="4" sub_dtype_id="2">
-        <range fl="d30">
-          <const fl="d30" name="32&apos;h1" dtype_id="5"/>
-          <const fl="d30" name="32&apos;h0" dtype_id="5"/>
+      <basicdtype fl="d20" loc="20,7,20,12" id="9" name="logic"/>
+      <basicdtype fl="d21" loc="21,7,21,12" id="11" name="logic"/>
+      <basicdtype fl="d22" loc="22,7,22,12" id="13" name="logic"/>
+      <basicdtype fl="d23" loc="23,7,23,12" id="15" name="logic"/>
+      <ifacerefdtype fl="d28" loc="28,8,28,12" id="3" modportname=""/>
+      <unpackarraydtype fl="d30" loc="30,26,30,27" id="4" sub_dtype_id="2">
+        <range fl="d30" loc="30,26,30,27">
+          <const fl="d30" loc="30,26,30,27" name="32&apos;h1" dtype_id="5"/>
+          <const fl="d30" loc="30,26,30,27" name="32&apos;h0" dtype_id="5"/>
         </range>
       </unpackarraydtype>
-      <refdtype fl="d30" id="16" name="my_struct" sub_dtype_id="2"/>
-      <basicdtype fl="d34" id="7" name="string"/>
+      <refdtype fl="d30" loc="30,4,30,13" id="16" name="my_struct" sub_dtype_id="2"/>
+      <basicdtype fl="d34" loc="34,21,34,27" id="7" name="string"/>
     </typetable>
   </netlist>
 </verilator_xml>


### PR DESCRIPTION
This PR adds a new attribute to (most) XML elements. Today the only way to figure out where a variable, assignment, operator, etc came from is to use the "fl" attribute. This has the file and last line of the token. The new attribute "loc" adds the precise location as a comma separated string of four numbers: first line, first column, last line, last column.

This seems like a safer way to expose this information as opposed to changing the contents of the "fl" attribute, in case there are existing flows that depend on that. I considered hiding this behind a command line flag but that seems to just be clutter and this new attribute shouldn't get in the way of existing uses.