### PR TITLE
Support for ENUM.next(c) with constant c > 1

### DIFF
--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -1897,6 +1897,9 @@ private:
             if (nodep->name() == "name") {
                 methodOkArguments(nodep, 0, 0);
             } else if (nodep->pinsp()
+                       && !(VN_IS(VN_CAST(nodep->pinsp(), Arg)->exprp(), Const))) {
+                nodep->v3fatalSrc("Unsupported: enum next/prev with non-const argument");
+            } else if (nodep->pinsp()
                        && !(VN_IS(VN_CAST(nodep->pinsp(), Arg)->exprp(), Const)
                             && VN_CAST(VN_CAST(nodep->pinsp(), Arg)->exprp(), Const)->toUInt() == 1
                             && !nodep->pinsp()->nextp())) {
@@ -1910,7 +1913,6 @@ private:
                 AstMethodCall* newp = new AstMethodCall(
                         nodep->fileline(), clonep,
                         nodep->name(), argp);
-
                 nodep->replaceWith(newp); nodep->deleteTree(); VL_DANGLING(nodep);
                 return;
             }
@@ -1929,7 +1931,7 @@ private:
                     if (vconstp->toUQuad() >= msbdim) msbdim = vconstp->toUQuad();
                 }
                 if (adtypep->itemsp()->width() > 64 || msbdim >= (1 << 16)) {
-                    nodep->v3error("Unsupported; enum next/prev method on enum with > 10 bits");
+                    nodep->v3error("Unsupported: enum next/prev method on enum with > 10 bits");
                     return;
                 }
             }

--- a/test_regress/t/t_enum_type_methods.v
+++ b/test_regress/t/t_enum_type_methods.v
@@ -34,10 +34,15 @@ module t (/*AUTOARG*/
       `checkh(e.next, E04);
       `checkh(e.next(), E04);
       `checkh(e.next(1), E04);
-      //Unsup: `checkh(e.next(2), E01);
+      `checkh(e.next(1).next(1), E01);
+      `checkh(e.next(2), E01);
+      `checkh(e.next(1).next(1).next(1), E03);
+      `checkh(e.next(1).next(2), E03);
+      `checkh(e.next(3), E03);
       `checkh(e.prev, E01);
       `checkh(e.prev(1), E01);
-      //Unsup: `checkh(e.prev(2), E04);
+      `checkh(e.prev(1).prev(1), E04);
+      `checkh(e.prev(2), E04);
       `checkh(e.num, 3);
       `checks(e.name, "E03");
       //
@@ -61,30 +66,30 @@ module t (/*AUTOARG*/
 	 `checks(e.name, "E01");
 	 `checkh(e.next, E03);
 	 `checkh(e.next(1), E03);
-	 //Unsup: `checkh(e.next(2), E04);
+	 `checkh(e.next(2), E04);
 	 `checkh(e.prev, E04);
 	 `checkh(e.prev(1), E04);
-	 //Unsup: `checkh(e.prev(2), E03);
+	 `checkh(e.prev(2), E03);
 	 e <= E03;
       end
       else if (cyc==2) begin
 	 `checks(e.name, "E03");
 	 `checkh(e.next, E04);
 	 `checkh(e.next(1), E04);
-	 //Unsup: `checkh(e.next(2), E01);
+	 `checkh(e.next(2), E01);
 	 `checkh(e.prev, E01);
 	 `checkh(e.prev(1), E01);
-	 //Unsup: `checkh(e.prev(2), E04);
+	 `checkh(e.prev(2), E04);
 	 e <= E04;
       end
       else if (cyc==3) begin
 	 `checks(e.name, "E04");
 	 `checkh(e.next, E01);
 	 `checkh(e.next(1), E01);
-	 //Unsup: `checkh(e.next(2), E03);
+	 `checkh(e.next(2), E03);
 	 `checkh(e.prev, E03);
 	 `checkh(e.prev(1), E03);
-	 //Unsup: `checkh(e.prev(2), E01);
+	 `checkh(e.prev(2), E01);
 	 e <= E01;
       end
       else if (cyc==99) begin

--- a/test_regress/t/t_enum_type_methods_bad.out
+++ b/test_regress/t/t_enum_type_methods_bad.out
@@ -1,0 +1,5 @@
+%Error: Internal Error: t/t_enum_type_methods_bad.v:24: ../V3Width.cpp:#: Unsupported: enum next/prev with non-const argument
+                                                      : ... In instance t
+      e.next(increment);
+        ^~~~
+                        ... See the manual and https://verilator.org for more assistance.

--- a/test_regress/t/t_enum_type_methods_bad.pl
+++ b/test_regress/t/t_enum_type_methods_bad.pl
@@ -1,0 +1,18 @@
+#!/usr/bin/perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2003 by Wilson Snyder. This program is free software; you can
+# redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+
+scenarios(simulator => 1);
+
+compile(
+    fails => 1,
+    expect_filename => $Self->{golden_filename}
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_enum_type_methods_bad.v
+++ b/test_regress/t/t_enum_type_methods_bad.v
@@ -1,0 +1,28 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed into the Public Domain, for any use,
+// without warranty, 2014 by Wilson Snyder.
+
+module t (/*AUTOARG*/
+   // Inputs
+   clk,
+   increment
+   );
+   input clk;
+   input [1:0] increment;
+
+   typedef enum [3:0] {
+		       E01 = 1,
+		       E03 = 3,
+		       E04 = 4,
+		       E05 = 5
+		       } my_t;
+
+   my_t e;
+
+   always @ (posedge clk) begin
+      e.next(increment);
+	  $finish;
+   end
+
+endmodule


### PR DESCRIPTION
First working implementation.
It works by unrolling ENUM.next(k) to ENUM.next(1).next(k - 1);

Is this the right location for the functionality? One can argue, that it is some kind of unroll operation.