### PR TITLE
V3Number width checking with increased limits

### DIFF
--- a/Changes
+++ b/Changes
@@ -17,6 +17,8 @@ The contributors that suggested a given feature are shown in []. Thanks!
 
 ****  Add error on misused define. [Topa Tota]
 
+****  Add parameter to set maximum signal width. #2082. [Øyvind Harboe]
+
 
 * Verilator 4.026 2020-01-11
 

--- a/bin/verilator
+++ b/bin/verilator
@@ -323,6 +323,7 @@ detailed descriptions in L</"VERILATION ARGUMENTS"> for more information.
     --language <lang>           Default language standard to parse
      +libext+<ext>+[ext]...     Extensions for finding modules
     --lint-only                 Lint, but do not make output
+    --max-num-width <value>     Maximum number width (default: 64K)
     --MMD                       Create .d dependency files
     --MP                        Create phony dependency targets
     --Mdir <directory>          Name of output object directory
@@ -967,6 +968,11 @@ stylistic and not enabled by default.
 
 If the design is not to be completely Verilated see also the --bbox-sys and
 --bbox-unsup options.
+
+=item --max-num-width I<value>
+
+Set the maximum number literal width (e.g. in 1024'd22 this it the 1024).
+Defaults to 64K.
 
 =item --MMD
 =item --no-MMD

--- a/src/V3Number.cpp
+++ b/src/V3Number.cpp
@@ -32,7 +32,6 @@
 #include <iomanip>
 
 #define MAX_SPRINTF_DOUBLE_SIZE 100  // Maximum characters with a sprintf %e/%f/%g (probably < 30)
-#define MAX_WIDTH 5*1024  // Maximum width before error
 
 // Number operations build output in-place so can't call e.g. foo.opX(foo)
 #define NUM_ASSERT_OP_ARGS1(arg1)  \
@@ -125,10 +124,11 @@ void V3Number::V3NumberCreate(AstNode* nodep, const char* sourcep, FileLine* fl)
         value_startp = cp;
 
         if (atoi(widthn.c_str())) {
-            if (atoi(widthn.c_str()) < 0 || atoi(widthn.c_str()) > MAX_WIDTH) {
+            if (atoi(widthn.c_str()) < 0 || atoi(widthn.c_str()) > v3Global.opt.maxNumWidth()) {
                 // atoi might convert large number to negative, so can't tell which
-                v3error("Unsupported: Width of number exceeds implementation limit: "<<sourcep);
-                width(MAX_WIDTH, true);
+                v3error("Unsupported: Width of number exceeds implementation limit: "
+                        << sourcep << "  (IEEE 2017 6.9.1)");
+                width(v3Global.opt.maxNumWidth(), true);
             } else {
                 width(atoi(widthn.c_str()), true);
             }

--- a/src/V3Options.cpp
+++ b/src/V3Options.cpp
@@ -948,6 +948,10 @@ void V3Options::parseOptsList(FileLine* fl, const string& optdir, int argc, char
                     fl->v3fatal("Unknown --make system specified: '"<<argv[i]<<"'");
                 }
             }
+            else if (!strcmp(sw, "-max-num-width")) {
+                shift;
+                m_maxNumWidth = atoi(argv[i]);
+            }
             else if (!strcmp(sw, "-no-l2name")) {  // Historical and undocumented
                 m_l2Name = "";
             }
@@ -1518,6 +1522,7 @@ V3Options::V3Options() {
     m_gateStmts = 100;
     m_ifDepth = 0;
     m_inlineMult = 2000;
+    m_maxNumWidth = 65536;
     m_moduleRecursion = 100;
     m_outputSplit = 0;
     m_outputSplitCFuncs = 0;

--- a/src/V3Options.h
+++ b/src/V3Options.h
@@ -201,6 +201,7 @@ class V3Options {
     int         m_ifDepth;      // main switch: --if-depth
     int         m_inlineMult;   // main switch: --inline-mult
     VOptionBool m_makeDepend;  // main switch: -MMD
+    int         m_maxNumWidth;  // main switch: --max-num-width
     int         m_moduleRecursion;// main switch: --module-recursion-depth
     int         m_outputSplit;  // main switch: --output-split
     int         m_outputSplitCFuncs;// main switch: --output-split-cfuncs
@@ -376,6 +377,7 @@ class V3Options {
     int ifDepth() const { return m_ifDepth; }
     int inlineMult() const { return m_inlineMult; }
     VOptionBool makeDepend() const { return m_makeDepend; }
+    int maxNumWidth() const { return m_maxNumWidth; }
     int moduleRecursionDepth() const { return m_moduleRecursion; }
     int outputSplit() const { return m_outputSplit; }
     int outputSplitCFuncs() const { return m_outputSplitCFuncs; }

--- a/test_regress/t/t_fuzz_negwidth_bad.out
+++ b/test_regress/t/t_fuzz_negwidth_bad.out
@@ -1,0 +1,4 @@
+%Error: t/t_fuzz_negwidth_bad.v:8: Unsupported: Width of number exceeds implementation limit: 1231232312312312'd1  (IEEE 2017 6.9.1)
+int c = 1231232312312312'd1;
+        ^~~~~~~~~~~~~~~~~~~
+%Error: Exiting due to

--- a/test_regress/t/t_fuzz_negwidth_bad.v
+++ b/test_regress/t/t_fuzz_negwidth_bad.v
@@ -4,4 +4,5 @@
 // without warranty, 2019 by Wilson Snyder.
 
 int a = -12'd1;
-int b = 1231232312312312'd1;
+int b = 65536'd1;
+int c = 1231232312312312'd1;

--- a/test_regress/t/t_lint_numwidth.pl
+++ b/test_regress/t/t_lint_numwidth.pl
@@ -2,7 +2,7 @@
 if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
 # DESCRIPTION: Verilator: Verilog Test driver/expect definition
 #
-# Copyright 2003 by Wilson Snyder. This program is free software; you can
+# Copyright 2008 by Wilson Snyder. This program is free software; you can
 # redistribute it and/or modify it under the terms of either the GNU
 # Lesser General Public License Version 3 or the Perl Artistic License
 # Version 2.0.
@@ -10,8 +10,7 @@ if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); di
 scenarios(linter => 1);
 
 lint(
-    fails => 1,
-    expect_filename => $Self->{golden_filename},
+    verilator_flags2 => ["--max-num-width 131072"],
     );
 
 ok(1);

--- a/test_regress/t/t_lint_numwidth.v
+++ b/test_regress/t/t_lint_numwidth.v
@@ -1,0 +1,8 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed into the Public Domain, for any use,
+// without warranty, 2010 by Wilson Snyder.
+
+logic [65535:0] a = 65536'd1;
+logic [65536:0] b = 65537'd1;
+logic [131071:0] c = 131072'd1;


### PR DESCRIPTION
To better support generated code and to remove artificial limits of
the width checking, adopt it to check the limits of the underlying
machine and libraries: int size and maximum vector allocator size are
the limit.