### PR TITLE
Correct FST-support issue with some GCC versions

### DIFF
--- a/include/verilated_fst_c.cpp
+++ b/include/verilated_fst_c.cpp
@@ -19,6 +19,10 @@
 ///
 //=============================================================================
 // SPDIFF_OFF
+//
+// The inttypes supplied with some GCC versions requires STDC_FORMAT_MACROS
+// to be declared in order to get the PRIxx macros used by fstapi.c
+#define __STDC_FORMAT_MACROS
 
 #include "verilatedos.h"
 #include "verilated.h"

--- a/include/verilated_fst_c.cpp
+++ b/include/verilated_fst_c.cpp
@@ -20,9 +20,6 @@
 //=============================================================================
 // SPDIFF_OFF
 //
-// The inttypes supplied with some GCC versions requires STDC_FORMAT_MACROS
-// to be declared in order to get the PRIxx macros used by fstapi.c
-#define __STDC_FORMAT_MACROS
 
 #include "verilatedos.h"
 #include "verilated.h"

--- a/include/verilatedos.h
+++ b/include/verilatedos.h
@@ -269,6 +269,10 @@ typedef signed   __int32        ssize_t;        ///< signed size_t; returned fro
 
 #else  // Linux or compliant Unix flavors, -m64
 
+// The inttypes supplied with some GCC versions requires STDC_FORMAT_MACROS
+// to be declared in order to get the PRIxx macros used by fstapi.c
+#define __STDC_FORMAT_MACROS
+
 # include <inttypes.h>  // Solaris
 # include <stdint.h>  // Linux and most flavors
 # include <sys/types.h>  // __WORDSIZE


### PR DESCRIPTION
The inttypes.h supplied with some GCC versions (eg GCC 4.8.5 used by Conda) requires defining the __STDC_FORMAT_MACROS macro in order to provide the PRIxx macros. This PR adds the define in the verilated_fst_c.cpp file.

Signed-off-by: Matthew Ballance <matt.ballance@gmail.com>

We appreciate your contributing to Verilator.  If this is your first commit, please add your name to docs/CONTRIBUTORS, and read our contributing guidelines in docs/CONTRIBUTING.adoc.
