### PR TITLE
Fix vpi scope naming

### DIFF
--- a/Changes
+++ b/Changes
@@ -21,6 +21,8 @@ The contributors that suggested a given feature are shown in []. Thanks!
 
 ****  Add parameter to set maximum signal width. #2082. [Øyvind Harboe]
 
+****  Fix VPI scope naming for public modules. [Nandu Raj]
+
 
 * Verilator 4.026 2020-01-11
 

--- a/src/V3EmitCSyms.cpp
+++ b/src/V3EmitCSyms.cpp
@@ -293,9 +293,10 @@ class EmitCSyms : EmitCBaseVisitor {
         m_scopes.push_back(make_pair(nodep, m_modp));
 
         if (v3Global.opt.vpi() && !nodep->isTop()) {
+            string name_dedot = AstNode::dedotName(nodep->shortName());
             m_vpiScopeCandidates.insert(make_pair(nodep->name(),
                                                   ScopeData(scopeSymString(nodep->name()),
-                                                            nodep->name(), "SCOPE_MODULE")));
+                                                            name_dedot, "SCOPE_MODULE")));
         }
     }
     virtual void visit(AstScopeName* nodep) {


### PR DESCRIPTION
Dedot and shorten the name so that public modules and interface cells
are accessible too via VPI.

Fixes #2109