### PR TITLE
Mark all visit() with VL_OVERRIDE

### DIFF
--- a/include/verilatedos.h
+++ b/include/verilatedos.h
@@ -184,11 +184,13 @@
 #  define VL_INCLUDE_UNORDERED_MAP <unordered_map>
 #  define VL_INCLUDE_UNORDERED_SET <unordered_set>
 # endif
+# define VL_OVERRIDE override
 #else
 # define VL_EQ_DELETE
 # define vl_unique_ptr std::auto_ptr
 # define VL_INCLUDE_UNORDERED_MAP "verilated_unordered_set_map.h"
 # define VL_INCLUDE_UNORDERED_SET "verilated_unordered_set_map.h"
+# define VL_OVERRIDE
 #endif
 
 //=========================================================================

--- a/src/V3Active.cpp
+++ b/src/V3Active.cpp
@@ -70,7 +70,7 @@ private:
         m_scopep->addActivep(nodep);
     }
     // VISITORS
-    virtual void visit(AstScope* nodep) {
+    virtual void visit(AstScope* nodep) VL_OVERRIDE {
         m_scopep = nodep;
         m_iActivep = NULL;
         m_cActivep = NULL;
@@ -79,15 +79,15 @@ private:
         iterateChildren(nodep);
         // Don't clear scopep, the namer persists beyond this visit
     }
-    virtual void visit(AstSenTree* nodep) {
+    virtual void visit(AstSenTree* nodep) VL_OVERRIDE {
         // Simplify sensitivity list
         VL_DO_DANGLING(V3Const::constifyExpensiveEdit(nodep), nodep);
     }
     // Empty visitors, speed things up
-    virtual void visit(AstNodeStmt* nodep) { }
+    virtual void visit(AstNodeStmt* nodep) VL_OVERRIDE { }
     //--------------------
     // Default
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         // Default: Just iterate
         iterateChildren(nodep);
     }
@@ -163,7 +163,7 @@ private:
     AstNode*    m_alwaysp;      // Always we're under
     AstNode*    m_assignp;      // In assign
     // VISITORS
-    virtual void visit(AstAssignDly* nodep) {
+    virtual void visit(AstAssignDly* nodep) VL_OVERRIDE {
         if (m_check != CT_SEQ) {
             // Convert to a non-delayed assignment
             UINFO(5,"    ASSIGNDLY "<<nodep<<endl);
@@ -184,7 +184,7 @@ private:
             VL_DO_DANGLING(nodep->deleteTree(), nodep);
         }
     }
-    virtual void visit(AstAssign* nodep) {
+    virtual void visit(AstAssign* nodep) VL_OVERRIDE {
         if (m_check == CT_SEQ) {
             AstNode* las = m_assignp;
             m_assignp = nodep;
@@ -192,7 +192,7 @@ private:
             m_assignp = las;
         }
     }
-    virtual void visit(AstVarRef* nodep) {
+    virtual void visit(AstVarRef* nodep) VL_OVERRIDE {
         AstVar* varp = nodep->varp();
         if (m_check == CT_SEQ
             && m_assignp
@@ -210,7 +210,7 @@ private:
         }
     }
     //--------------------
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
     }
 public:
@@ -240,7 +240,7 @@ private:
     bool        m_itemSequent;  // Found a SenItem sequential
 
     // VISITORS
-    virtual void visit(AstScope* nodep) {
+    virtual void visit(AstScope* nodep) VL_OVERRIDE {
         // Create required actives and add to scope
         UINFO(4," SCOPE   "<<nodep<<endl);
         // Clear last scope's names, and collect this scope's existing names
@@ -248,10 +248,10 @@ private:
         m_scopeFinalp = NULL;
         iterateChildren(nodep);
     }
-    virtual void visit(AstActive* nodep) {
+    virtual void visit(AstActive* nodep) VL_OVERRIDE {
         // Actives are being formed, so we can ignore any already made
     }
-    virtual void visit(AstInitial* nodep) {
+    virtual void visit(AstInitial* nodep) VL_OVERRIDE {
         // Relink to IACTIVE, unless already under it
         UINFO(4,"    INITIAL "<<nodep<<endl);
         ActiveDlyVisitor dlyvisitor (nodep, ActiveDlyVisitor::CT_INITIAL);
@@ -259,28 +259,28 @@ private:
         nodep->unlinkFrBack();
         wantactivep->addStmtsp(nodep);
     }
-    virtual void visit(AstAssignAlias* nodep) {
+    virtual void visit(AstAssignAlias* nodep) VL_OVERRIDE {
         // Relink to CACTIVE, unless already under it
         UINFO(4,"    ASSIGNW "<<nodep<<endl);
         AstActive* wantactivep = m_namer.getCActive(nodep->fileline());
         nodep->unlinkFrBack();
         wantactivep->addStmtsp(nodep);
     }
-    virtual void visit(AstAssignW* nodep) {
+    virtual void visit(AstAssignW* nodep) VL_OVERRIDE {
         // Relink to CACTIVE, unless already under it
         UINFO(4,"    ASSIGNW "<<nodep<<endl);
         AstActive* wantactivep = m_namer.getCActive(nodep->fileline());
         nodep->unlinkFrBack();
         wantactivep->addStmtsp(nodep);
     }
-    virtual void visit(AstCoverToggle* nodep) {
+    virtual void visit(AstCoverToggle* nodep) VL_OVERRIDE {
         // Relink to CACTIVE, unless already under it
         UINFO(4,"    COVERTOGGLE "<<nodep<<endl);
         AstActive* wantactivep = m_namer.getCActive(nodep->fileline());
         nodep->unlinkFrBack();
         wantactivep->addStmtsp(nodep);
     }
-    virtual void visit(AstFinal* nodep) {
+    virtual void visit(AstFinal* nodep) VL_OVERRIDE {
         // Relink to CFUNC for the final
         UINFO(4,"    FINAL "<<nodep<<endl);
         if (!nodep->bodysp()) {  // Empty, Kill it.
@@ -372,7 +372,7 @@ private:
             ActiveDlyVisitor dlyvisitor (nodep, ActiveDlyVisitor::CT_SEQ);
         }
     }
-    virtual void visit(AstAlways* nodep) {
+    virtual void visit(AstAlways* nodep) VL_OVERRIDE {
         // Move always to appropriate ACTIVE based on its sense list
         UINFO(4,"    ALW   "<<nodep<<endl);
         //if (debug()>=9) nodep->dumpTree(cout, "  Alw: ");
@@ -384,13 +384,13 @@ private:
         }
         visitAlways(nodep, nodep->sensesp(), nodep->keyword());
     }
-    virtual void visit(AstAlwaysPublic* nodep) {
+    virtual void visit(AstAlwaysPublic* nodep) VL_OVERRIDE {
         // Move always to appropriate ACTIVE based on its sense list
         UINFO(4,"    ALWPub   "<<nodep<<endl);
         //if (debug()>=9) nodep->dumpTree(cout, "  Alw: ");
         visitAlways(nodep, nodep->sensesp(), VAlwaysKwd::ALWAYS);
     }
-    virtual void visit(AstSenGate* nodep) {
+    virtual void visit(AstSenGate* nodep) VL_OVERRIDE {
         AstSenItem* subitemp = nodep->sensesp();
         UASSERT_OBJ(subitemp->edgeType() == VEdgeType::ET_ANYEDGE
                     || subitemp->edgeType() == VEdgeType::ET_POSEDGE
@@ -398,7 +398,7 @@ private:
                     nodep, "Strange activity type under SenGate");
         iterateChildren(nodep);
     }
-    virtual void visit(AstSenItem* nodep) {
+    virtual void visit(AstSenItem* nodep) VL_OVERRIDE {
         if (nodep->edgeType() == VEdgeType::ET_ANYEDGE) {
             m_itemCombo = true;
             // Delete the sensitivity
@@ -416,10 +416,10 @@ private:
     }
 
     // Empty visitors, speed things up
-    virtual void visit(AstNodeMath* nodep) {}
-    virtual void visit(AstVarScope* nodep) {}
+    virtual void visit(AstNodeMath* nodep) VL_OVERRIDE {}
+    virtual void visit(AstVarScope* nodep) VL_OVERRIDE {}
     //--------------------
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
     }
 public:

--- a/src/V3ActiveTop.cpp
+++ b/src/V3ActiveTop.cpp
@@ -56,19 +56,19 @@ private:
     VL_DEBUG_FUNC;  // Declare debug()
 
     // VISITORS
-    virtual void visit(AstTopScope* nodep) {
+    virtual void visit(AstTopScope* nodep) VL_OVERRIDE {
         m_topscopep = nodep;
         m_finder.main(m_topscopep);
         iterateChildren(nodep);
         m_topscopep = NULL;
     }
-    virtual void visit(AstNodeModule* nodep) {
+    virtual void visit(AstNodeModule* nodep) VL_OVERRIDE {
         // Create required actives and add to module
         // We can start ordering at a module, or a scope
         UINFO(4," MOD   "<<nodep<<endl);
         iterateChildren(nodep);
     }
-    virtual void visit(AstActive* nodep) {
+    virtual void visit(AstActive* nodep) VL_OVERRIDE {
         UINFO(4,"   ACTIVE "<<nodep<<endl);
         V3Const::constifyExpensiveEdit(nodep);  // Remove duplicate clocks and such; sensesp() may change!
         AstSenTree* sensesp = nodep->sensesp();
@@ -113,29 +113,29 @@ private:
         // No need to do statements under it, they're already moved.
         //iterateChildren(nodep);
     }
-    virtual void visit(AstInitial* nodep) {  // LCOV_EXCL_LINE
+    virtual void visit(AstInitial* nodep) VL_OVERRIDE {  // LCOV_EXCL_LINE
         nodep->v3fatalSrc("Node should have been under ACTIVE");
     }
-    virtual void visit(AstAssignAlias* nodep) {  // LCOV_EXCL_LINE
+    virtual void visit(AstAssignAlias* nodep) VL_OVERRIDE {  // LCOV_EXCL_LINE
         nodep->v3fatalSrc("Node should have been under ACTIVE");
     }
-    virtual void visit(AstAssignW* nodep) {  // LCOV_EXCL_LINE
+    virtual void visit(AstAssignW* nodep) VL_OVERRIDE {  // LCOV_EXCL_LINE
         nodep->v3fatalSrc("Node should have been under ACTIVE");
     }
-    virtual void visit(AstAlways* nodep) {  // LCOV_EXCL_LINE
+    virtual void visit(AstAlways* nodep) VL_OVERRIDE {  // LCOV_EXCL_LINE
         nodep->v3fatalSrc("Node should have been under ACTIVE");
     }
-    virtual void visit(AstAlwaysPublic* nodep) {  // LCOV_EXCL_LINE
+    virtual void visit(AstAlwaysPublic* nodep) VL_OVERRIDE {  // LCOV_EXCL_LINE
         nodep->v3fatalSrc("Node should have been under ACTIVE");
     }
-    virtual void visit(AstFinal* nodep) {  // LCOV_EXCL_LINE
+    virtual void visit(AstFinal* nodep) VL_OVERRIDE {  // LCOV_EXCL_LINE
         nodep->v3fatalSrc("Node should have been deleted");
     }
     // Empty visitors, speed things up
-    virtual void visit(AstNodeMath* nodep) {}
-    virtual void visit(AstVarScope* nodep) {}
+    virtual void visit(AstNodeMath* nodep) VL_OVERRIDE {}
+    virtual void visit(AstVarScope* nodep) VL_OVERRIDE {}
     //--------------------
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
     }
 public:

--- a/src/V3Assert.cpp
+++ b/src/V3Assert.cpp
@@ -174,7 +174,7 @@ private:
     }
 
     // VISITORS
-    virtual void visit(AstIf* nodep) {
+    virtual void visit(AstIf* nodep) VL_OVERRIDE {
         if (nodep->user1SetOnce()) return;
         if (nodep->uniquePragma() || nodep->unique0Pragma()) {
             AstNodeIf* ifp = nodep;
@@ -234,7 +234,7 @@ private:
     }
 
     //========== Case assertions
-    virtual void visit(AstCase* nodep) {
+    virtual void visit(AstCase* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         if (!nodep->user1SetOnce()) {
             bool has_default = false;
@@ -296,7 +296,7 @@ private:
     }
 
     //========== Past
-    virtual void visit(AstPast* nodep) {
+    virtual void visit(AstPast* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         uint32_t ticks = 1;
         if (nodep->ticksp()) {
@@ -328,7 +328,7 @@ private:
     }
 
     //========== Statements
-    virtual void visit(AstDisplay* nodep) {
+    virtual void visit(AstDisplay* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         // Replace the special types with standard text
         if (nodep->displayType()==AstDisplayType::DT_INFO) {
@@ -341,21 +341,21 @@ private:
         }
     }
 
-    virtual void visit(AstAssert* nodep) {
+    virtual void visit(AstAssert* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         newPslAssertion(nodep, nodep->failsp());
     }
-    virtual void visit(AstCover* nodep) {
+    virtual void visit(AstCover* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         newPslAssertion(nodep, NULL);
     }
-    virtual void visit(AstRestrict* nodep) {
+    virtual void visit(AstRestrict* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         // IEEE says simulator ignores these
         VL_DO_DANGLING(pushDeletep(nodep->unlinkFrBack()), nodep);
     }
 
-    virtual void visit(AstNodeModule* nodep) {
+    virtual void visit(AstNodeModule* nodep) VL_OVERRIDE {
         AstNodeModule* origModp = m_modp;
         unsigned origPastNum = m_modPastNum;
         {
@@ -366,7 +366,7 @@ private:
         m_modp = origModp;
         m_modPastNum = origPastNum;
     }
-    virtual void visit(AstBegin* nodep) {
+    virtual void visit(AstBegin* nodep) VL_OVERRIDE {
         // This code is needed rather than a visitor in V3Begin,
         // because V3Assert is called before V3Begin
         AstBegin* lastp = m_beginp;
@@ -377,7 +377,7 @@ private:
         m_beginp = lastp;
     }
 
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
     }
 public:

--- a/src/V3AssertPre.cpp
+++ b/src/V3AssertPre.cpp
@@ -71,7 +71,7 @@ private:
 
     // VISITORS
     //========== Statements
-    virtual void visit(AstClocking* nodep) {
+    virtual void visit(AstClocking* nodep) VL_OVERRIDE {
         UINFO(8,"   CLOCKING"<<nodep<<endl);
         // Store the new default clock, reset on new module
         m_seniDefaultp = nodep->sensesp();
@@ -83,7 +83,7 @@ private:
         }
         VL_DO_DANGLING(pushDeletep(nodep), nodep);
     }
-    virtual void visit(AstAlways* nodep) {
+    virtual void visit(AstAlways* nodep) VL_OVERRIDE {
         iterateAndNextNull(nodep->sensesp());
         if (nodep->sensesp()) {
             m_seniAlwaysp = nodep->sensesp()->sensesp();
@@ -92,7 +92,7 @@ private:
         m_seniAlwaysp = NULL;
     }
 
-    virtual void visit(AstNodeCoverOrAssert* nodep) {
+    virtual void visit(AstNodeCoverOrAssert* nodep) VL_OVERRIDE {
         if (nodep->sentreep()) return;  // Already processed
         clearAssertInfo();
         // Find Clocking's buried under nodep->exprsp
@@ -102,12 +102,12 @@ private:
         }
         clearAssertInfo();
     }
-    virtual void visit(AstPast* nodep) {
+    virtual void visit(AstPast* nodep) VL_OVERRIDE {
         if (nodep->sentreep()) return;  // Already processed
         iterateChildren(nodep);
         nodep->sentreep(newSenTree(nodep));
     }
-    virtual void visit(AstPropClocked* nodep) {
+    virtual void visit(AstPropClocked* nodep) VL_OVERRIDE {
         // No need to iterate the body, once replace will get iterated
         iterateAndNextNull(nodep->sensesp());
         if (m_senip) {
@@ -132,12 +132,12 @@ private:
         nodep->replaceWith(blockp);
         VL_DO_DANGLING(pushDeletep(nodep), nodep);
     }
-    virtual void visit(AstNodeModule* nodep) {
+    virtual void visit(AstNodeModule* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         // Reset defaults
         m_seniDefaultp = NULL;
     }
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
     }
 

--- a/src/V3Begin.cpp
+++ b/src/V3Begin.cpp
@@ -78,7 +78,7 @@ private:
     VL_DEBUG_FUNC;  // Declare debug()
 
     // VISITORS
-    virtual void visit(AstNodeModule* nodep) {
+    virtual void visit(AstNodeModule* nodep) VL_OVERRIDE {
         AstNodeModule* origModp = m_modp;
         {
             m_modp = nodep;
@@ -86,7 +86,7 @@ private:
         }
         m_modp = origModp;
     }
-    virtual void visit(AstNodeFTask* nodep) {
+    virtual void visit(AstNodeFTask* nodep) VL_OVERRIDE {
         UINFO(8,"  "<<nodep<<endl);
         // Rename it
         if (m_unnamedScope != "") {
@@ -111,7 +111,7 @@ private:
         m_namedScope = oldScope;
         m_unnamedScope = oldUnnamed;
     }
-    virtual void visit(AstBegin* nodep) {
+    virtual void visit(AstBegin* nodep) VL_OVERRIDE {
         // Begin blocks were only useful in variable creation, change names and delete
         UINFO(8,"  "<<nodep<<endl);
         string oldScope = m_namedScope;
@@ -160,7 +160,7 @@ private:
         }
         VL_DO_DANGLING(pushDeletep(nodep), nodep);
     }
-    virtual void visit(AstVar* nodep) {
+    virtual void visit(AstVar* nodep) VL_OVERRIDE {
         if (m_unnamedScope != "") {
             // Rename it
             nodep->name(m_unnamedScope+"__DOT__"+nodep->name());
@@ -171,7 +171,7 @@ private:
             else m_modp->addStmtp(nodep);
         }
     }
-    virtual void visit(AstCell* nodep) {
+    virtual void visit(AstCell* nodep) VL_OVERRIDE {
         UINFO(8,"   CELL "<<nodep<<endl);
         if (m_namedScope != "") {
             m_statep->userMarkChanged(nodep);
@@ -184,14 +184,14 @@ private:
         }
         iterateChildren(nodep);
     }
-    virtual void visit(AstVarXRef* nodep) {
+    virtual void visit(AstVarXRef* nodep) VL_OVERRIDE {
         UINFO(9, "   VARXREF "<<nodep<<endl);
         if (m_namedScope != "" && nodep->inlinedDots() == "") {
             nodep->inlinedDots(m_namedScope);
             UINFO(9, "    rescope to "<<nodep<<endl);
         }
     }
-    virtual void visit(AstScopeName* nodep) {
+    virtual void visit(AstScopeName* nodep) VL_OVERRIDE {
         // If there's a %m in the display text, we add a special node that will contain the name()
         // Similar code in V3Inline
         if (nodep->user1SetOnce()) return;  // Don't double-add text's
@@ -204,13 +204,13 @@ private:
         }
         iterateChildren(nodep);
     }
-    virtual void visit(AstCoverDecl* nodep) {
+    virtual void visit(AstCoverDecl* nodep) VL_OVERRIDE {
         // Don't need to fix path in coverage statements, they're not under
         // any BEGINs, but V3Coverage adds them all under the module itself.
         iterateChildren(nodep);
     }
     // VISITORS - LINT CHECK
-    virtual void visit(AstIf* nodep) {  // Note not AstNodeIf; other types don't get covered
+    virtual void visit(AstIf* nodep) VL_OVERRIDE {  // Note not AstNodeIf; other types don't get covered
         // Check IFDEPTH warning - could be in other transform files if desire
         int prevIfDepth = m_ifDepth;
         if (m_ifDepth == -1 || v3Global.opt.ifDepth()<1) {  // Turned off
@@ -224,7 +224,7 @@ private:
         iterateChildren(nodep);
         m_ifDepth = prevIfDepth;
     }
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
     }
 public:
@@ -249,21 +249,21 @@ private:
     //   AstNodeFTask::user1p           // Node replaced, rename it
 
     // VISITORS
-    virtual void visit(AstNodeFTaskRef* nodep) {
+    virtual void visit(AstNodeFTaskRef* nodep) VL_OVERRIDE {
         if (nodep->taskp()->user1()) {  // It was converted
             UINFO(9, "    relinkFTask "<<nodep<<endl);
             nodep->name(nodep->taskp()->name());
         }
         iterateChildren(nodep);
     }
-    virtual void visit(AstVarRef* nodep) {
+    virtual void visit(AstVarRef* nodep) VL_OVERRIDE {
         if (nodep->varp()->user1()) {  // It was converted
             UINFO(9, "    relinVarRef "<<nodep<<endl);
             nodep->name(nodep->varp()->name());
         }
         iterateChildren(nodep);
     }
-    virtual void visit(AstIfaceRefDType* nodep) {
+    virtual void visit(AstIfaceRefDType* nodep) VL_OVERRIDE {
         // May have changed cell names
         // TypeTable is always after all modules, so names are stable
         UINFO(8,"   IFACEREFDTYPE "<<nodep<<endl);
@@ -272,7 +272,7 @@ private:
         iterateChildren(nodep);
     }
     //--------------------
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
     }
 public:

--- a/src/V3Branch.cpp
+++ b/src/V3Branch.cpp
@@ -70,7 +70,7 @@ private:
     }
 
     // VISITORS
-    virtual void visit(AstNodeIf* nodep) {
+    virtual void visit(AstNodeIf* nodep) VL_OVERRIDE {
         UINFO(4," IF: "<<nodep<<endl);
         int lastLikely = m_likely;
         int lastUnlikely = m_unlikely;
@@ -96,17 +96,17 @@ private:
         m_likely = lastLikely;
         m_unlikely = lastUnlikely;
     }
-    virtual void visit(AstCCall* nodep) {
+    virtual void visit(AstCCall* nodep) VL_OVERRIDE {
         checkUnlikely(nodep);
         nodep->funcp()->user1Inc();
         iterateChildren(nodep);
     }
-    virtual void visit(AstCFunc* nodep) {
+    virtual void visit(AstCFunc* nodep) VL_OVERRIDE {
         checkUnlikely(nodep);
         m_cfuncsp.push_back(nodep);
         iterateChildren(nodep);
     }
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         checkUnlikely(nodep);
         iterateChildren(nodep);
     }

--- a/src/V3Broken.cpp
+++ b/src/V3Broken.cpp
@@ -209,7 +209,7 @@ private:
         iterateChildrenConst(nodep);
     }
     // VISITORS
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         processAndIterate(nodep);
     }
 public:
@@ -257,7 +257,7 @@ private:
         iterateChildrenConst(nodep);
         BrokenTable::setUnder(nodep, false);
     }
-    virtual void visit(AstNodeAssign* nodep) {
+    virtual void visit(AstNodeAssign* nodep) VL_OVERRIDE {
         processAndIterate(nodep);
         UASSERT_OBJ(!(v3Global.assertDTypesResolved()
                       && nodep->brokeLhsMustBeLvalue()
@@ -265,7 +265,7 @@ private:
                       && !VN_CAST(nodep->lhsp(), NodeVarRef)->lvalue()),
                     nodep, "Assignment LHS is not an lvalue");
     }
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         processAndIterate(nodep);
     }
 public:

--- a/src/V3Case.cpp
+++ b/src/V3Case.cpp
@@ -62,7 +62,7 @@ private:
     // METHODS
     VL_DEBUG_FUNC;  // Declare debug()
 
-    virtual void visit(AstNodeCase* nodep) {
+    virtual void visit(AstNodeCase* nodep) VL_OVERRIDE {
         if (VN_IS(nodep, Case) && VN_CAST(nodep, Case)->casex()) {
             nodep->v3warn(CASEX, "Suggest casez (with ?'s) in place of casex (with X's)");
         }
@@ -89,7 +89,7 @@ private:
             m_caseExprp = NULL;
         }
     }
-    virtual void visit(AstConst* nodep) {
+    virtual void visit(AstConst* nodep) VL_OVERRIDE {
         // See also neverItem
         if (m_caseExprp && nodep->num().isFourState()) {
             if (VN_IS(m_caseExprp, GenCase)) {
@@ -106,7 +106,7 @@ private:
             }
         }
     }
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
     }
 public:
@@ -460,7 +460,7 @@ private:
     }
 
     // VISITORS
-    virtual void visit(AstCase* nodep) {
+    virtual void visit(AstCase* nodep) VL_OVERRIDE {
         V3Case::caseLint(nodep);
         iterateChildren(nodep);
         if (debug()>=9) nodep->dumpTree(cout, " case_old: ");
@@ -476,7 +476,7 @@ private:
     }
     //--------------------
     // Default: Just iterate
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
     }
 

--- a/src/V3Cast.cpp
+++ b/src/V3Cast.cpp
@@ -102,19 +102,19 @@ private:
     }
 
     // VISITORS
-    virtual void visit(AstNodeUniop* nodep) {
+    virtual void visit(AstNodeUniop* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         nodep->user1(nodep->lhsp()->user1());
         if (nodep->sizeMattersLhs()) insureCast(nodep->lhsp());
     }
-    virtual void visit(AstNodeBiop* nodep) {
+    virtual void visit(AstNodeBiop* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         nodep->user1(nodep->lhsp()->user1()
                     | nodep->rhsp()->user1());
         if (nodep->sizeMattersLhs()) insureCast(nodep->lhsp());
         if (nodep->sizeMattersRhs()) insureCast(nodep->rhsp());
     }
-    virtual void visit(AstNodeTriop* nodep) {
+    virtual void visit(AstNodeTriop* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         nodep->user1(nodep->lhsp()->user1()
                     | nodep->rhsp()->user1()
@@ -123,12 +123,12 @@ private:
         if (nodep->sizeMattersRhs()) insureCast(nodep->rhsp());
         if (nodep->sizeMattersThs()) insureCast(nodep->thsp());
     }
-    virtual void visit(AstCCast* nodep) {
+    virtual void visit(AstCCast* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         insureLower32Cast(nodep);
         nodep->user1(1);
     }
-    virtual void visit(AstNegate* nodep) {
+    virtual void visit(AstNegate* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         nodep->user1(nodep->lhsp()->user1());
         if (nodep->lhsp()->widthMin()==1) {
@@ -140,7 +140,7 @@ private:
             insureCast(nodep->lhsp());
         }
     }
-    virtual void visit(AstVarRef* nodep) {
+    virtual void visit(AstVarRef* nodep) VL_OVERRIDE {
         if (!nodep->lvalue()
             && !VN_IS(nodep->backp(), CCast)
             && VN_IS(nodep->backp(), NodeMath)
@@ -153,7 +153,7 @@ private:
         }
         nodep->user1(1);
     }
-    virtual void visit(AstConst* nodep) {
+    virtual void visit(AstConst* nodep) VL_OVERRIDE {
         // Constants are of unknown size if smaller than 33 bits, because
         // we're too lazy to wrap every constant in the universe in
         // ((IData)#).
@@ -161,11 +161,11 @@ private:
     }
 
     // NOPs
-    virtual void visit(AstVar* nodep) {}
+    virtual void visit(AstVar* nodep) VL_OVERRIDE {}
 
     //--------------------
     // Default: Just iterate
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
     }
 

--- a/src/V3Cdc.cpp
+++ b/src/V3Cdc.cpp
@@ -136,7 +136,7 @@ private:
     std::ofstream* m_ofp;  // Output file
     string              m_prefix;
 
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         *m_ofp<<m_prefix;
         if (nodep->user3()) *m_ofp<<" %%";
         else *m_ofp<<"  ";
@@ -170,7 +170,7 @@ private:
     int         m_maxLineno;
     size_t      m_maxFilenameLen;
 
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         // Keeping line+filename lengths separate is much faster than calling ascii().length()
         if (nodep->fileline()->lineno() >= m_maxLineno) {
@@ -608,7 +608,7 @@ private:
     }
 
     // VISITORS
-    virtual void visit(AstNodeModule* nodep) {
+    virtual void visit(AstNodeModule* nodep) VL_OVERRIDE {
         AstNodeModule* origModp = m_modp;
         {
             m_modp = nodep;
@@ -616,14 +616,14 @@ private:
         }
         m_modp = origModp;
     }
-    virtual void visit(AstScope* nodep) {
+    virtual void visit(AstScope* nodep) VL_OVERRIDE {
         UINFO(4," SCOPE "<<nodep<<endl);
         m_scopep = nodep;
         m_logicVertexp = NULL;
         iterateChildren(nodep);
         m_scopep = NULL;
     }
-    virtual void visit(AstActive* nodep) {
+    virtual void visit(AstActive* nodep) VL_OVERRIDE {
         // Create required blocks and add to module
         UINFO(4,"  BLOCK  "<<nodep<<endl);
         AstNode::user2ClearTree();
@@ -634,7 +634,7 @@ private:
         m_domainp = NULL;
         AstNode::user2ClearTree();
     }
-    virtual void visit(AstNodeVarRef* nodep) {
+    virtual void visit(AstNodeVarRef* nodep) VL_OVERRIDE {
         if (m_scopep) {
             UASSERT_OBJ(m_logicVertexp, nodep, "Var ref not under a logic block");
             AstVarScope* varscp = nodep->varScopep();
@@ -662,72 +662,72 @@ private:
             }
         }
     }
-    virtual void visit(AstAssignDly* nodep) {
+    virtual void visit(AstAssignDly* nodep) VL_OVERRIDE {
         m_inDly = true;
         iterateChildren(nodep);
         m_inDly = false;
     }
-    virtual void visit(AstSenItem* nodep) {
+    virtual void visit(AstSenItem* nodep) VL_OVERRIDE {
         // Note we look at only AstSenItems, not AstSenGate's
         // The gating term of a AstSenGate is normal logic
         m_inSenItem = true;
         iterateChildren(nodep);
         m_inSenItem = false;
     }
-    virtual void visit(AstAlways* nodep) {
+    virtual void visit(AstAlways* nodep) VL_OVERRIDE {
         iterateNewStmt(nodep);
     }
-    virtual void visit(AstAlwaysPublic* nodep) {
+    virtual void visit(AstAlwaysPublic* nodep) VL_OVERRIDE {
         // CDC doesn't care about public variables
     }
-    virtual void visit(AstCFunc* nodep) {
+    virtual void visit(AstCFunc* nodep) VL_OVERRIDE {
         iterateNewStmt(nodep);
     }
-    virtual void visit(AstSenGate* nodep) {
+    virtual void visit(AstSenGate* nodep) VL_OVERRIDE {
         // First handle the clock part will be handled in a minute by visit AstSenItem
         // The logic gating term is dealt with as logic
         iterateNewStmt(nodep);
     }
-    virtual void visit(AstAssignAlias* nodep) {
+    virtual void visit(AstAssignAlias* nodep) VL_OVERRIDE {
         iterateNewStmt(nodep);
     }
-    virtual void visit(AstAssignW* nodep) {
+    virtual void visit(AstAssignW* nodep) VL_OVERRIDE {
         iterateNewStmt(nodep);
     }
 
     // Math that shouldn't cause us to clear hazard
-    virtual void visit(AstConst* nodep) { }
-    virtual void visit(AstReplicate* nodep) {
+    virtual void visit(AstConst* nodep) VL_OVERRIDE { }
+    virtual void visit(AstReplicate* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
     }
-    virtual void visit(AstConcat* nodep) {
+    virtual void visit(AstConcat* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
     }
-    virtual void visit(AstNot* nodep) {
+    virtual void visit(AstNot* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
     }
-    virtual void visit(AstSel* nodep) {
+    virtual void visit(AstSel* nodep) VL_OVERRIDE {
         if (!VN_IS(nodep->lsbp(), Const)) setNodeHazard(nodep);
         iterateChildren(nodep);
     }
-    virtual void visit(AstNodeSel* nodep) {
+    virtual void visit(AstNodeSel* nodep) VL_OVERRIDE {
         if (!VN_IS(nodep->bitp(), Const)) setNodeHazard(nodep);
         iterateChildren(nodep);
     }
 
     // Ignores
-    virtual void visit(AstInitial* nodep) { }
-    virtual void visit(AstTraceInc* nodep) { }
-    virtual void visit(AstCoverToggle* nodep) { }
-    virtual void visit(AstNodeDType* nodep) { }
+    virtual void visit(AstInitial* nodep) VL_OVERRIDE { }
+    virtual void visit(AstTraceInc* nodep) VL_OVERRIDE { }
+    virtual void visit(AstCoverToggle* nodep) VL_OVERRIDE { }
+    virtual void visit(AstNodeDType* nodep) VL_OVERRIDE { }
 
     //--------------------
     // Default
-    virtual void visit(AstNodeMath* nodep) {
+    virtual void visit(AstNodeMath* nodep) VL_OVERRIDE {
         setNodeHazard(nodep);
         iterateChildren(nodep);
     }
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
     }
 

--- a/src/V3Changed.cpp
+++ b/src/V3Changed.cpp
@@ -148,13 +148,13 @@ private:
         m_statep->m_numStmts += visitor.count();
     }
 
-    virtual void visit(AstBasicDType* nodep) {
+    virtual void visit(AstBasicDType* nodep) VL_OVERRIDE {
         newChangeDet();
     }
-    virtual void visit(AstPackArrayDType* nodep) {
+    virtual void visit(AstPackArrayDType* nodep) VL_OVERRIDE {
         newChangeDet();
     }
-    virtual void visit(AstUnpackArrayDType* nodep) {
+    virtual void visit(AstUnpackArrayDType* nodep) VL_OVERRIDE {
         for (int index=0; index < nodep->elementsConst(); ++index) {
             AstNode* origVEp = m_varEqnp;
             AstNode* origNLEp = m_newLvEqnp;
@@ -175,7 +175,7 @@ private:
             m_newRvEqnp = origNREp;
         }
     }
-    virtual void visit(AstNodeUOrStructDType* nodep) {
+    virtual void visit(AstNodeUOrStructDType* nodep) VL_OVERRIDE {
         if (nodep->packedUnsup()) {
             newChangeDet();
         } else {
@@ -185,7 +185,7 @@ private:
                            <<m_vscp->varp()->prettyNameQ());
         }
     }
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         if (debug()) nodep->dumpTree(cout, "-DETECTARRAY-general-");
         m_vscp->v3warn(E_DETECTARRAY, "Unsupported: Can't detect changes on complex variable"
@@ -247,7 +247,7 @@ private:
     }
 
     // VISITORS
-    virtual void visit(AstNodeModule* nodep) {
+    virtual void visit(AstNodeModule* nodep) VL_OVERRIDE {
         UINFO(4," MOD   "<<nodep<<endl);
         if (nodep->isTop()) {
             m_statep->m_topModp = nodep;
@@ -255,7 +255,7 @@ private:
         iterateChildren(nodep);
     }
 
-    virtual void visit(AstTopScope* nodep) {
+    virtual void visit(AstTopScope* nodep) VL_OVERRIDE {
         UINFO(4," TS "<<nodep<<endl);
         // Clearing
         AstNode::user1ClearTree();
@@ -279,7 +279,7 @@ private:
 
         iterateChildren(nodep);
     }
-    virtual void visit(AstVarScope* nodep) {
+    virtual void visit(AstVarScope* nodep) VL_OVERRIDE {
         if (nodep->isCircular()) {
             UINFO(8,"  CIRC "<<nodep<<endl);
             if (!nodep->user1SetOnce()) {
@@ -287,12 +287,12 @@ private:
             }
         }
     }
-    virtual void visit(AstNodeMath* nodep) {
+    virtual void visit(AstNodeMath* nodep) VL_OVERRIDE {
         // Short-circuit
     }
     //--------------------
     // Default: Just iterate
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
     }
 

--- a/src/V3Clean.cpp
+++ b/src/V3Clean.cpp
@@ -176,7 +176,7 @@ private:
     }
 
     // VISITORS
-    virtual void visit(AstNodeModule* nodep) {
+    virtual void visit(AstNodeModule* nodep) VL_OVERRIDE {
         AstNodeModule* origModp = m_modp;
         {
             m_modp = nodep;
@@ -184,7 +184,7 @@ private:
         }
         m_modp = origModp;
     }
-    virtual void visit(AstNodeUniop* nodep) {
+    virtual void visit(AstNodeUniop* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         computeCppWidth(nodep);
         if (nodep->cleanLhs()) {
@@ -192,45 +192,45 @@ private:
         }
         setClean(nodep, nodep->cleanOut());
     }
-    virtual void visit(AstNodeBiop* nodep) {
+    virtual void visit(AstNodeBiop* nodep) VL_OVERRIDE {
         operandBiop(nodep);
         setClean(nodep, nodep->cleanOut());
     }
-    virtual void visit(AstAnd* nodep) {
+    virtual void visit(AstAnd* nodep) VL_OVERRIDE {
         operandBiop(nodep);
         setClean(nodep, isClean(nodep->lhsp()) || isClean(nodep->rhsp()));
     }
-    virtual void visit(AstXor* nodep) {
+    virtual void visit(AstXor* nodep) VL_OVERRIDE {
         operandBiop(nodep);
         setClean(nodep, isClean(nodep->lhsp()) && isClean(nodep->rhsp()));
     }
-    virtual void visit(AstOr* nodep) {
+    virtual void visit(AstOr* nodep) VL_OVERRIDE {
         operandBiop(nodep);
         setClean(nodep, isClean(nodep->lhsp()) && isClean(nodep->rhsp()));
     }
-    virtual void visit(AstNodeMath* nodep) {
+    virtual void visit(AstNodeMath* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         computeCppWidth(nodep);
         setClean(nodep, nodep->cleanOut());
     }
-    virtual void visit(AstNodeAssign* nodep) {
+    virtual void visit(AstNodeAssign* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         computeCppWidth(nodep);
         if (nodep->cleanRhs()) {
             insureClean(nodep->rhsp());
         }
     }
-    virtual void visit(AstText* nodep) {
+    virtual void visit(AstText* nodep) VL_OVERRIDE {
         setClean(nodep, true);
     }
-    virtual void visit(AstScopeName* nodep) {
+    virtual void visit(AstScopeName* nodep) VL_OVERRIDE {
         setClean(nodep, true);
     }
-    virtual void visit(AstSel* nodep) {
+    virtual void visit(AstSel* nodep) VL_OVERRIDE {
         operandTriop(nodep);
         setClean(nodep, nodep->cleanOut());
     }
-    virtual void visit(AstUCFunc* nodep) {
+    virtual void visit(AstUCFunc* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         computeCppWidth(nodep);
         setClean(nodep, false);
@@ -240,64 +240,64 @@ private:
         }
         insureCleanAndNext(nodep->bodysp());
     }
-    virtual void visit(AstTraceDecl* nodep) {
+    virtual void visit(AstTraceDecl* nodep) VL_OVERRIDE {
         // No cleaning, or would loose pointer to enum
         iterateChildren(nodep);
     }
-    virtual void visit(AstTraceInc* nodep) {
+    virtual void visit(AstTraceInc* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         insureCleanAndNext(nodep->valuep());
     }
-    virtual void visit(AstTypedef* nodep) {
+    virtual void visit(AstTypedef* nodep) VL_OVERRIDE {
         // No cleaning, or would loose pointer to enum
         iterateChildren(nodep);
     }
-    virtual void visit(AstParamTypeDType* nodep) {
+    virtual void visit(AstParamTypeDType* nodep) VL_OVERRIDE {
         // No cleaning, or would loose pointer to enum
         iterateChildren(nodep);
     }
 
     // Control flow operators
-    virtual void visit(AstNodeCond* nodep) {
+    virtual void visit(AstNodeCond* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         insureClean(nodep->condp());
         setClean(nodep, isClean(nodep->expr1p()) && isClean(nodep->expr2p()));
     }
-    virtual void visit(AstWhile* nodep) {
+    virtual void visit(AstWhile* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         insureClean(nodep->condp());
     }
-    virtual void visit(AstNodeIf* nodep) {
+    virtual void visit(AstNodeIf* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         insureClean(nodep->condp());
     }
-    virtual void visit(AstSFormatF* nodep) {
+    virtual void visit(AstSFormatF* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         insureCleanAndNext(nodep->exprsp());
         setClean(nodep, true);  // generates a string, so not relevant
     }
-    virtual void visit(AstUCStmt* nodep) {
+    virtual void visit(AstUCStmt* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         insureCleanAndNext(nodep->bodysp());
     }
-    virtual void visit(AstCCall* nodep) {
+    virtual void visit(AstCCall* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         insureCleanAndNext(nodep->argsp());
         setClean(nodep, true);
     }
-    virtual void visit(AstCMethodHard* nodep) {
+    virtual void visit(AstCMethodHard* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         insureCleanAndNext(nodep->pinsp());
         setClean(nodep, true);
     }
-    virtual void visit(AstIntfRef* nodep) {
+    virtual void visit(AstIntfRef* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         setClean(nodep, true);  // generates a string, so not relevant
     }
 
     //--------------------
     // Default: Just iterate
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         computeCppWidth(nodep);
     }

--- a/src/V3Clock.cpp
+++ b/src/V3Clock.cpp
@@ -189,7 +189,7 @@ private:
     }
 
     // VISITORS
-    virtual void visit(AstTopScope* nodep) {
+    virtual void visit(AstTopScope* nodep) VL_OVERRIDE {
         UINFO(4," TOPSCOPE   "<<nodep<<endl);
         m_topScopep = nodep;
         m_scopep = nodep->scopep();
@@ -254,7 +254,7 @@ private:
         m_topScopep = NULL;
         m_scopep = NULL;
     }
-    virtual void visit(AstNodeModule* nodep) {
+    virtual void visit(AstNodeModule* nodep) VL_OVERRIDE {
         //UINFO(4," MOD   "<<nodep<<endl);
         AstNodeModule* origModp = m_modp;
         {
@@ -263,7 +263,7 @@ private:
         }
         m_modp = origModp;
     }
-    virtual void visit(AstScope* nodep) {
+    virtual void visit(AstScope* nodep) VL_OVERRIDE {
         //UINFO(4," SCOPE   "<<nodep<<endl);
         m_scopep = nodep;
         iterateChildren(nodep);
@@ -274,7 +274,7 @@ private:
         }
         m_scopep = NULL;
     }
-    virtual void visit(AstAlways* nodep) {
+    virtual void visit(AstAlways* nodep) VL_OVERRIDE {
         AstNode* cmtp = new AstComment(nodep->fileline(), nodep->typeName(), true);
         nodep->replaceWith(cmtp);
         if (AstNode* stmtsp = nodep->bodysp()) {
@@ -283,7 +283,7 @@ private:
         }
         VL_DO_DANGLING(nodep->deleteTree(), nodep);
     }
-    virtual void visit(AstAlwaysPost* nodep) {
+    virtual void visit(AstAlwaysPost* nodep) VL_OVERRIDE {
         AstNode* cmtp = new AstComment(nodep->fileline(), nodep->typeName(), true);
         nodep->replaceWith(cmtp);
         if (AstNode* stmtsp = nodep->bodysp()) {
@@ -292,7 +292,7 @@ private:
         }
         VL_DO_DANGLING(nodep->deleteTree(), nodep);
     }
-    virtual void visit(AstCoverToggle* nodep) {
+    virtual void visit(AstCoverToggle* nodep) VL_OVERRIDE {
         //nodep->dumpTree(cout, "ct:");
         //COVERTOGGLE(INC, ORIG, CHANGE) ->
         //   IF(ORIG ^ CHANGE) { INC; CHANGE = ORIG; }
@@ -312,7 +312,7 @@ private:
                                     origp->cloneTree(false)));
         nodep->replaceWith(newp); VL_DO_DANGLING(nodep->deleteTree(), nodep);
     }
-    virtual void visit(AstInitial* nodep) {
+    virtual void visit(AstInitial* nodep) VL_OVERRIDE {
         AstNode* cmtp = new AstComment(nodep->fileline(), nodep->typeName(), true);
         nodep->replaceWith(cmtp);
         if (AstNode* stmtsp = nodep->bodysp()) {
@@ -321,7 +321,7 @@ private:
         }
         VL_DO_DANGLING(nodep->deleteTree(), nodep);
     }
-    virtual void visit(AstCFunc* nodep) {
+    virtual void visit(AstCFunc* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         // Link to global function
         if (nodep->formCallTree()) {
@@ -331,7 +331,7 @@ private:
             m_finalFuncp->addStmtsp(callp);
         }
     }
-    virtual void visit(AstSenTree* nodep) {
+    virtual void visit(AstSenTree* nodep) VL_OVERRIDE {
         // Delete it later; Actives still pointing to it
         nodep->unlinkFrBack();
         pushDeletep(nodep);
@@ -345,7 +345,7 @@ private:
     void addToInitial(AstNode* stmtsp) {
        m_initFuncp->addStmtsp(stmtsp);  // add to top level function
     }
-    virtual void visit(AstActive* nodep) {
+    virtual void visit(AstActive* nodep) VL_OVERRIDE {
         // Careful if adding variables here, ACTIVES can be under other ACTIVES
         // Need to save and restore any member state in AstUntilStable block
         if (!m_topScopep || !nodep->stmtsp()) {
@@ -413,7 +413,7 @@ private:
             VL_DO_DANGLING(nodep->unlinkFrBack()->deleteTree(), nodep);
         }
     }
-    virtual void visit(AstExecGraph* nodep) {
+    virtual void visit(AstExecGraph* nodep) VL_OVERRIDE {
         for (m_mtaskBodyp = VN_CAST(nodep->op1p(), MTaskBody);
              m_mtaskBodyp;
              m_mtaskBodyp = VN_CAST(m_mtaskBodyp->nextp(), MTaskBody)) {
@@ -430,7 +430,7 @@ private:
 
     //--------------------
     // Default: Just iterate
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
     }
 

--- a/src/V3Combine.cpp
+++ b/src/V3Combine.cpp
@@ -131,13 +131,13 @@ public:
     }
 private:
     // VISITORS
-    virtual void visit(AstCCall* nodep) {
+    virtual void visit(AstCCall* nodep) VL_OVERRIDE {
         addCall(nodep);
     }
     // Speed things up
-    virtual void visit(AstNodeAssign* nodep) {}
-    virtual void visit(AstNodeMath* nodep) {}
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNodeAssign* nodep) VL_OVERRIDE {}
+    virtual void visit(AstNodeMath* nodep) VL_OVERRIDE {}
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
     }
 public:
@@ -160,7 +160,7 @@ private:
     // OUTPUT:
     //  AstNode::user3()        -> bool. True to indicate duplicated
     // VISITORS
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         nodep->user3(true);
         iterateChildren(nodep);
     }
@@ -389,7 +389,7 @@ private:
     }
 
     // VISITORS
-    virtual void visit(AstNetlist* nodep) {
+    virtual void visit(AstNetlist* nodep) VL_OVERRIDE {
         // Track all callers of each function
         m_call.main(nodep);
         //
@@ -398,7 +398,7 @@ private:
         // Required so that a module instantiating another can benefit from collapsing.
         iterateChildrenBackwards(nodep);
     }
-    virtual void visit(AstNodeModule* nodep) {
+    virtual void visit(AstNodeModule* nodep) VL_OVERRIDE {
         UINFO(4," MOD   "<<nodep<<endl);
         m_modp = nodep;
         m_modNFuncs = 0;
@@ -427,7 +427,7 @@ private:
         }
         m_modp = NULL;
     }
-    virtual void visit(AstCFunc* nodep) {
+    virtual void visit(AstCFunc* nodep) VL_OVERRIDE {
         m_funcp = nodep;
         if (!nodep->dontCombine()) {
             if (m_state == STATE_HASH) {
@@ -438,7 +438,7 @@ private:
         }
         m_funcp = NULL;
     }
-    virtual void visit(AstNodeStmt* nodep) {
+    virtual void visit(AstNodeStmt* nodep) VL_OVERRIDE {
         if (!nodep->isStatement()) {
             iterateChildren(nodep);
             return;
@@ -453,10 +453,10 @@ private:
 
     //--------------------
     // Default: Just iterate
-    virtual void visit(AstVar*) {}
-    virtual void visit(AstTraceDecl*) {}
-    virtual void visit(AstTraceInc*) {}
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstVar*) VL_OVERRIDE {}
+    virtual void visit(AstTraceDecl*) VL_OVERRIDE {}
+    virtual void visit(AstTraceInc*) VL_OVERRIDE {}
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
     }
 

--- a/src/V3Const.cpp
+++ b/src/V3Const.cpp
@@ -46,10 +46,10 @@ class ConstVarMarkVisitor : public AstNVisitor {
     // AstVar::user4p           -> bool, Var marked, 0=not set yet
 private:
     // VISITORS
-    virtual void visit(AstVarRef* nodep) {
+    virtual void visit(AstVarRef* nodep) VL_OVERRIDE {
         if (nodep->varp()) nodep->varp()->user4(1);
     }
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
     }
 public:
@@ -68,10 +68,10 @@ class ConstVarFindVisitor : public AstNVisitor {
     bool m_found;
 private:
     // VISITORS
-    virtual void visit(AstVarRef* nodep) {
+    virtual void visit(AstVarRef* nodep) VL_OVERRIDE {
         if (nodep->varp() && nodep->varp()->user4()) m_found = true;
     }
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
     }
 public:
@@ -1282,11 +1282,11 @@ private:
     //----------------------------------------
 
     // VISITORS
-    virtual void visit(AstNetlist* nodep) {
+    virtual void visit(AstNetlist* nodep) VL_OVERRIDE {
         // Iterate modules backwards, in bottom-up order.  That's faster
         iterateChildrenBackwards(nodep);
     }
-    virtual void visit(AstNodeModule* nodep) {
+    virtual void visit(AstNodeModule* nodep) VL_OVERRIDE {
         AstNodeModule* origModp = m_modp;
         {
             m_modp = nodep;
@@ -1294,14 +1294,14 @@ private:
         }
         m_modp = origModp;
     }
-    virtual void visit(AstCFunc* nodep) {
+    virtual void visit(AstCFunc* nodep) VL_OVERRIDE {
         // No ASSIGNW removals under funcs, we've long eliminated INITIALs
         // (We should perhaps rename the assignw's to just assigns)
         m_wremove = false;
         iterateChildren(nodep);
         m_wremove = true;
     }
-    virtual void visit(AstScope* nodep) {
+    virtual void visit(AstScope* nodep) VL_OVERRIDE {
         // No ASSIGNW removals under scope, we've long eliminated INITIALs
         m_scopep = nodep;
         m_wremove = false;
@@ -1374,16 +1374,16 @@ private:
     }
 
     // Special cases
-    virtual void visit(AstConst* nodep) {}  // Already constant
+    virtual void visit(AstConst* nodep) VL_OVERRIDE {}  // Already constant
 
-    virtual void visit(AstCell* nodep) {
+    virtual void visit(AstCell* nodep) VL_OVERRIDE {
         if (m_params) {
             iterateAndNextNull(nodep->paramsp());
         } else {
             iterateChildren(nodep);
         }
     }
-    virtual void visit(AstPin* nodep) {
+    virtual void visit(AstPin* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
     }
 
@@ -1571,14 +1571,14 @@ private:
         nodep->replaceWith(fromp); VL_DO_DANGLING(nodep->deleteTree(), nodep);
     }
 
-    virtual void visit(AstAttrOf* nodep) {
+    virtual void visit(AstAttrOf* nodep) VL_OVERRIDE {
         AstAttrOf* oldAttr = m_attrp;
         m_attrp = nodep;
         iterateChildren(nodep);
         m_attrp = oldAttr;
     }
 
-    virtual void visit(AstArraySel* nodep) {
+    virtual void visit(AstArraySel* nodep) VL_OVERRIDE {
         iterateAndNextNull(nodep->bitp());
         if (VN_IS(nodep->bitp(), Const)
             && VN_IS(nodep->fromp(), VarRef)
@@ -1604,7 +1604,7 @@ private:
         }
         m_selp = NULL;
     }
-    virtual void visit(AstNodeVarRef* nodep) {
+    virtual void visit(AstNodeVarRef* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         UASSERT_OBJ(nodep->varp(), nodep, "Not linked");
         bool did = false;
@@ -1655,7 +1655,7 @@ private:
                            <<nodep->varp()->prettyNameQ());
         }
     }
-    virtual void visit(AstEnumItemRef* nodep) {
+    virtual void visit(AstEnumItemRef* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         UASSERT_OBJ(nodep->itemp(), nodep, "Not linked");
         bool did = false;
@@ -1680,7 +1680,7 @@ private:
         }
     }
 
-    // virtual void visit(AstCvtPackString* nodep) {
+    // virtual void visit(AstCvtPackString* nodep) VL_OVERRIDE {
     // Not constant propagated (for today) because AstNodeMath::isOpaque is set
     // Someday if lower is constant, convert to quoted "string".
 
@@ -1688,7 +1688,7 @@ private:
         // Only one if it's not in a list
         return (!nodep->nextp() && nodep->backp()->nextp() != nodep);
     }
-    virtual void visit(AstSenItem* nodep) {
+    virtual void visit(AstSenItem* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         if (m_doNConst
             && (VN_IS(nodep->sensp(), Const)
@@ -1730,7 +1730,7 @@ private:
                         "Null sensitivity variable");
         }
     }
-    virtual void visit(AstSenGate* nodep) {
+    virtual void visit(AstSenGate* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         if (AstConst* constp = VN_CAST(nodep->rhsp(), Const)) {
             if (constp->isZero()) {
@@ -1782,7 +1782,7 @@ private:
         }
     };
 
-    virtual void visit(AstSenTree* nodep) {
+    virtual void visit(AstSenTree* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         if (m_doExpensive) {
             //cout<<endl; nodep->dumpTree(cout, "ssin: ");
@@ -1893,17 +1893,17 @@ private:
 
     //-----
     // Zero elimination
-    virtual void visit(AstNodeAssign* nodep) {
+    virtual void visit(AstNodeAssign* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         if (m_doNConst && replaceNodeAssign(nodep)) return;
     }
-    virtual void visit(AstAssignAlias* nodep) {
+    virtual void visit(AstAssignAlias* nodep) VL_OVERRIDE {
         // Don't perform any optimizations, keep the alias around
     }
-    virtual void visit(AstAssignVarScope* nodep) {
+    virtual void visit(AstAssignVarScope* nodep) VL_OVERRIDE {
         // Don't perform any optimizations, the node won't be linked yet
     }
-    virtual void visit(AstAssignW* nodep) {
+    virtual void visit(AstAssignW* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         if (m_doNConst && replaceNodeAssign(nodep)) return;
         AstNodeVarRef* varrefp = VN_CAST(nodep->lhsp(), VarRef);  // Not VarXRef, as different refs may set different values to each hierarchy
@@ -1930,7 +1930,7 @@ private:
         }
     }
 
-    virtual void visit(AstNodeIf* nodep) {
+    virtual void visit(AstNodeIf* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         if (m_doNConst) {
             if (const AstConst* constp = VN_CAST(nodep->condp(), Const)) {
@@ -2009,7 +2009,7 @@ private:
         }
     }
 
-    virtual void visit(AstDisplay* nodep) {
+    virtual void visit(AstDisplay* nodep) VL_OVERRIDE {
         // DISPLAY(SFORMAT(text1)),DISPLAY(SFORMAT(text2)) -> DISPLAY(SFORMAT(text1+text2))
         iterateChildren(nodep);
         if (stmtDisplayDisplay(nodep)) return;
@@ -2054,7 +2054,7 @@ private:
         VL_DO_DANGLING(nodep->unlinkFrBack()->deleteTree(), nodep);
         return true;
     }
-    virtual void visit(AstSFormatF* nodep) {
+    virtual void visit(AstSFormatF* nodep) VL_OVERRIDE {
         // Substitute constants into displays.  The main point of this is to
         // simplify assertion methodologies which call functions with display's.
         // This eliminates a pile of wide temps, and makes the C a whole lot more readable.
@@ -2117,17 +2117,17 @@ private:
         }
     }
 
-    virtual void visit(AstFuncRef* nodep) {
+    virtual void visit(AstFuncRef* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         if (m_params) {  // Only parameters force us to do constant function call propagation
             replaceWithSimulation(nodep);
         }
     }
-    virtual void visit(AstArg* nodep) {
+    virtual void visit(AstArg* nodep) VL_OVERRIDE {
         // replaceWithSimulation on the Arg's parent FuncRef replaces these
         iterateChildren(nodep);
     }
-    virtual void visit(AstWhile* nodep) {
+    virtual void visit(AstWhile* nodep) VL_OVERRIDE {
         bool oldHasJumpGo = m_hasJumpGo;
         m_hasJumpGo = false;
         {
@@ -2153,19 +2153,19 @@ private:
             }
         }
     }
-    virtual void visit(AstInitArray* nodep) {
+    virtual void visit(AstInitArray* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
     }
-    virtual void visit(AstInitItem* nodep) {
+    virtual void visit(AstInitItem* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
     }
     // These are converted by V3Param.  Don't constify as we don't want the
     // from() VARREF to disappear, if any.
     // If output of a presel didn't get consted, chances are V3Param didn't visit properly
-    virtual void visit(AstNodePreSel* nodep) {}
+    virtual void visit(AstNodePreSel* nodep) VL_OVERRIDE {}
 
     // Ignored, can eliminate early
-    virtual void visit(AstSysIgnore* nodep) {
+    virtual void visit(AstSysIgnore* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         if (m_doNConst) {
             VL_DO_DANGLING(nodep->unlinkFrBack()->deleteTree(), nodep);
@@ -2173,7 +2173,7 @@ private:
     }
 
     // Simplify
-    virtual void visit(AstBasicDType* nodep) {
+    virtual void visit(AstBasicDType* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         nodep->cvtRangeConst();
     }
@@ -2181,7 +2181,7 @@ private:
     //-----
     // Jump elimination
 
-    virtual void visit(AstJumpGo* nodep) {
+    virtual void visit(AstJumpGo* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         m_hasJumpGo = true;
         if (m_doExpensive) {
@@ -2200,7 +2200,7 @@ private:
         }
     }
 
-    virtual void visit(AstJumpLabel* nodep) {
+    virtual void visit(AstJumpLabel* nodep) VL_OVERRIDE {
         // Because JumpLabels disable many optimizations,
         // remove JumpLabels that are not pointed to by any AstJumpGos
         // Note this assumes all AstJumpGos are underneath the given label; V3Broken asserts this
@@ -2546,7 +2546,7 @@ private:
     // Note we can't convert EqCase/NeqCase to Eq/Neq here because that would break 3'b1x1==3'b101
 
     //-----
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         // Default: Just iterate
         if (m_required) {
             if (VN_IS(nodep, NodeDType) || VN_IS(nodep, Range)) {

--- a/src/V3Coverage.cpp
+++ b/src/V3Coverage.cpp
@@ -149,7 +149,7 @@ private:
             +"_"+type;
     }
     // VISITORS - BOTH
-    virtual void visit(AstNodeModule* nodep) {
+    virtual void visit(AstNodeModule* nodep) VL_OVERRIDE {
         AstNodeModule* origModp = m_modp;
         bool origInModOff = m_inModOff;
         {
@@ -163,7 +163,7 @@ private:
     }
 
     // VISITORS - TOGGLE COVERAGE
-    virtual void visit(AstNodeFTask* nodep) {
+    virtual void visit(AstNodeFTask* nodep) VL_OVERRIDE {
         bool oldtog = m_inToggleOff;
         {
             m_inToggleOff = true;
@@ -171,7 +171,7 @@ private:
         }
         m_inToggleOff = oldtog;
     }
-    virtual void visit(AstVar* nodep) {
+    virtual void visit(AstVar* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         if (m_modp && !m_inModOff && !m_inToggleOff
             && nodep->fileline()->coverageOn() && v3Global.opt.coverageToggle()) {
@@ -307,7 +307,7 @@ private:
     }
 
     // VISITORS - LINE COVERAGE
-    virtual void visit(AstIf* nodep) {  // Note not AstNodeIf; other types don't get covered
+    virtual void visit(AstIf* nodep) VL_OVERRIDE {  // Note not AstNodeIf; other types don't get covered
         UINFO(4," IF: "<<nodep<<endl);
         if (m_checkBlock) {
             // An else-if.  When we iterate the if, use "elsif" marking
@@ -344,7 +344,7 @@ private:
             m_checkBlock = true;  // Reset as a child may have cleared it
         }
     }
-    virtual void visit(AstCaseItem* nodep) {
+    virtual void visit(AstCaseItem* nodep) VL_OVERRIDE {
         UINFO(4," CASEI: "<<nodep<<endl);
         if (m_checkBlock && !m_inModOff
             && nodep->fileline()->coverageOn() && v3Global.opt.coverageLine()) {
@@ -357,7 +357,7 @@ private:
             m_checkBlock = true;  // Reset as a child may have cleared it
         }
     }
-    virtual void visit(AstCover* nodep) {
+    virtual void visit(AstCover* nodep) VL_OVERRIDE {
         UINFO(4," COVER: "<<nodep<<endl);
         m_checkBlock = true;  // Always do cover blocks, even if there's a $stop
         iterateChildren(nodep);
@@ -368,11 +368,11 @@ private:
         }
         m_checkBlock = true;  // Reset as a child may have cleared it
     }
-    virtual void visit(AstStop* nodep) {
+    virtual void visit(AstStop* nodep) VL_OVERRIDE {
         UINFO(4,"  STOP: "<<nodep<<endl);
         m_checkBlock = false;
     }
-    virtual void visit(AstPragma* nodep) {
+    virtual void visit(AstPragma* nodep) VL_OVERRIDE {
         if (nodep->pragType() == AstPragmaType::COVERAGE_BLOCK_OFF) {
             // Skip all NEXT nodes under this block, and skip this if/case branch
             UINFO(4,"  OFF: "<<nodep<<endl);
@@ -382,7 +382,7 @@ private:
             if (m_checkBlock) iterateChildren(nodep);
         }
     }
-    virtual void visit(AstBegin* nodep) {
+    virtual void visit(AstBegin* nodep) VL_OVERRIDE {
         // Record the hierarchy of any named begins, so we can apply to user
         // coverage points.  This is because there may be cov points inside
         // generate blocks; each point should get separate consideration.
@@ -402,7 +402,7 @@ private:
     }
 
     // VISITORS - BOTH
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         // Default: Just iterate
         if (m_checkBlock) {
             iterateChildren(nodep);

--- a/src/V3CoverageJoin.cpp
+++ b/src/V3CoverageJoin.cpp
@@ -102,19 +102,19 @@ private:
     }
 
     // VISITORS
-    virtual void visit(AstNetlist* nodep) {
+    virtual void visit(AstNetlist* nodep) VL_OVERRIDE {
         // Find all Coverage's
         iterateChildren(nodep);
         // Simplify
         detectDuplicates();
     }
-    virtual void visit(AstCoverToggle* nodep) {
+    virtual void visit(AstCoverToggle* nodep) VL_OVERRIDE {
         m_toggleps.push_back(nodep);
         iterateChildren(nodep);
     }
     //--------------------
-    virtual void visit(AstNodeMath* nodep) {}  // Accelerate
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNodeMath* nodep) VL_OVERRIDE {}  // Accelerate
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
     }
 

--- a/src/V3Dead.cpp
+++ b/src/V3Dead.cpp
@@ -57,13 +57,13 @@ private:
     // NODE STATE
     // ** Shared with DeadVisitor **
     // VISITORS
-    virtual void visit(AstCell* nodep) {
+    virtual void visit(AstCell* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         nodep->modp()->user1Inc(-1);
     }
     //-----
-    virtual void visit(AstNodeMath* nodep) {}  // Accelerate
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNodeMath* nodep) VL_OVERRIDE {}  // Accelerate
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
     }
 public:
@@ -133,7 +133,7 @@ private:
     }
 
     // VISITORS
-    virtual void visit(AstNodeModule* nodep) {
+    virtual void visit(AstNodeModule* nodep) VL_OVERRIDE {
         AstNodeModule* origModp = m_modp;
         {
             m_modp = nodep;
@@ -144,12 +144,12 @@ private:
         }
         m_modp = origModp;
     }
-    virtual void visit(AstCFunc* nodep) {
+    virtual void visit(AstCFunc* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         checkAll(nodep);
         if (nodep->scopep()) nodep->scopep()->user1Inc();
     }
-    virtual void visit(AstScope* nodep) {
+    virtual void visit(AstScope* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         checkAll(nodep);
         if (nodep->aboveScopep()) nodep->aboveScopep()->user1Inc();
@@ -158,14 +158,14 @@ private:
             m_scopesp.push_back(nodep);
         }
     }
-    virtual void visit(AstCell* nodep) {
+    virtual void visit(AstCell* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         checkAll(nodep);
         m_cellsp.push_back(nodep);
         nodep->modp()->user1Inc();
     }
 
-    virtual void visit(AstNodeVarRef* nodep) {
+    virtual void visit(AstNodeVarRef* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         checkAll(nodep);
         if (nodep->varScopep()) {
@@ -180,7 +180,7 @@ private:
             else nodep->packagep()->user1Inc();
         }
     }
-    virtual void visit(AstNodeFTaskRef* nodep) {
+    virtual void visit(AstNodeFTaskRef* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         checkAll(nodep);
         if (nodep->packagep()) {
@@ -188,7 +188,7 @@ private:
             else nodep->packagep()->user1Inc();
         }
     }
-    virtual void visit(AstRefDType* nodep) {
+    virtual void visit(AstRefDType* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         checkDType(nodep);
         checkAll(nodep);
@@ -197,12 +197,12 @@ private:
             else nodep->packagep()->user1Inc();
         }
     }
-    virtual void visit(AstNodeDType* nodep) {
+    virtual void visit(AstNodeDType* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         checkDType(nodep);
         checkAll(nodep);
     }
-    virtual void visit(AstEnumItemRef* nodep) {
+    virtual void visit(AstEnumItemRef* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         checkAll(nodep);
         if (nodep->packagep()) {
@@ -211,7 +211,7 @@ private:
         }
         checkAll(nodep);
     }
-    virtual void visit(AstModport* nodep) {
+    virtual void visit(AstModport* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         if (m_elimCells) {
             if (!nodep->varsp()) {
@@ -221,7 +221,7 @@ private:
         }
         checkAll(nodep);
     }
-    virtual void visit(AstTypedef* nodep) {
+    virtual void visit(AstTypedef* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         if (m_elimCells && !nodep->attrPublic()) {
             VL_DO_DANGLING(pushDeletep(nodep->unlinkFrBack()), nodep);
@@ -232,7 +232,7 @@ private:
         // Normal modules may disappear, e.g. if they are parameterized then removed
         if (nodep->attrPublic() && m_modp && VN_IS(m_modp, Package)) m_modp->user1Inc();
     }
-    virtual void visit(AstVarScope* nodep) {
+    virtual void visit(AstVarScope* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         checkAll(nodep);
         if (nodep->scopep()) nodep->scopep()->user1Inc();
@@ -240,7 +240,7 @@ private:
             m_vscsp.push_back(nodep);
         }
     }
-    virtual void visit(AstVar* nodep) {
+    virtual void visit(AstVar* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         checkAll(nodep);
         if (nodep->isSigPublic() && m_modp && VN_IS(m_modp, Package)) m_modp->user1Inc();
@@ -248,7 +248,7 @@ private:
             m_varsp.push_back(nodep);
         }
     }
-    virtual void visit(AstNodeAssign* nodep) {
+    virtual void visit(AstNodeAssign* nodep) VL_OVERRIDE {
         // See if simple assignments to variables may be eliminated because
         // that variable is never used.
         // Similar code in V3Life
@@ -268,7 +268,7 @@ private:
     }
 
     //-----
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         if (nodep->isOutputter()) m_sideEffect = true;
         iterateChildren(nodep);
         checkAll(nodep);

--- a/src/V3Delayed.cpp
+++ b/src/V3Delayed.cpp
@@ -348,22 +348,22 @@ private:
     }
 
     // VISITORS
-    virtual void visit(AstNetlist* nodep) {
+    virtual void visit(AstNetlist* nodep) VL_OVERRIDE {
         //VV*****  We reset all userp() on the netlist
         m_modVarMap.clear();
         iterateChildren(nodep);
     }
-    virtual void visit(AstScope* nodep) {
+    virtual void visit(AstScope* nodep) VL_OVERRIDE {
         UINFO(4," MOD   "<<nodep<<endl);
         AstNode::user3ClearTree();
         iterateChildren(nodep);
     }
-    virtual void visit(AstCFunc* nodep) {
+    virtual void visit(AstCFunc* nodep) VL_OVERRIDE {
         m_cfuncp = nodep;
         iterateChildren(nodep);
         m_cfuncp = NULL;
     }
-    virtual void visit(AstActive* nodep) {
+    virtual void visit(AstActive* nodep) VL_OVERRIDE {
         m_activep = nodep;
         bool oldinit = m_inInitial;
         m_inInitial = nodep->hasInitial();
@@ -371,7 +371,7 @@ private:
         iterateChildren(nodep);
         m_inInitial = oldinit;
     }
-    virtual void visit(AstAssignDly* nodep) {
+    virtual void visit(AstAssignDly* nodep) VL_OVERRIDE {
         m_inDly = true;
         m_nextDlyp = VN_CAST(nodep->nextp(), AssignDly);  // Next assignment in same block, maybe NULL.
         if (m_cfuncp) nodep->v3error("Unsupported: Delayed assignment inside public function/task");
@@ -395,7 +395,7 @@ private:
         m_nextDlyp = NULL;
     }
 
-    virtual void visit(AstVarRef* nodep) {
+    virtual void visit(AstVarRef* nodep) VL_OVERRIDE {
         if (!nodep->user2Inc()) {  // Not done yet
             if (m_inDly && nodep->lvalue()) {
                 UINFO(4,"AssignDlyVar: "<<nodep<<endl);
@@ -444,10 +444,10 @@ private:
         }
     }
 
-    virtual void visit(AstNodeFor* nodep) {
+    virtual void visit(AstNodeFor* nodep) VL_OVERRIDE {
         nodep->v3fatalSrc("For statements should have been converted to while statements in V3Begin");
     }
-    virtual void visit(AstWhile* nodep) {
+    virtual void visit(AstWhile* nodep) VL_OVERRIDE {
         bool oldloop = m_inLoop;
         m_inLoop = true;
         iterateChildren(nodep);
@@ -456,7 +456,7 @@ private:
 
     //--------------------
     // Default: Just iterate
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
     }
 

--- a/src/V3Depth.cpp
+++ b/src/V3Depth.cpp
@@ -82,7 +82,7 @@ private:
     }
 
     // VISITORS
-    virtual void visit(AstNodeModule* nodep) {
+    virtual void visit(AstNodeModule* nodep) VL_OVERRIDE {
         UINFO(4," MOD   "<<nodep<<endl);
         AstNodeModule* origModp = m_modp;
         {
@@ -92,7 +92,7 @@ private:
         }
         m_modp = origModp;
     }
-    virtual void visit(AstCFunc* nodep) {
+    virtual void visit(AstCFunc* nodep) VL_OVERRIDE {
         m_funcp = nodep;
         m_depth = 0;
         m_maxdepth = 0;
@@ -106,7 +106,7 @@ private:
         iterateChildren(nodep);
         m_stmtp = NULL;
     }
-    virtual void visit(AstNodeStmt* nodep) {
+    virtual void visit(AstNodeStmt* nodep) VL_OVERRIDE {
         if (!nodep->isStatement()) {
             iterateChildren(nodep);
         } else {
@@ -114,9 +114,9 @@ private:
         }
     }
     // Operators
-    virtual void visit(AstNodeTermop* nodep) {
+    virtual void visit(AstNodeTermop* nodep) VL_OVERRIDE {
     }
-    virtual void visit(AstNodeMath* nodep) {
+    virtual void visit(AstNodeMath* nodep) VL_OVERRIDE {
         // We have some operator defines that use 2 parens, so += 2.
         m_depth += 2;
         if (m_depth>m_maxdepth) m_maxdepth = m_depth;
@@ -143,19 +143,19 @@ private:
             m_funcp->isStatic(false);
         }
     }
-    virtual void visit(AstUCFunc* nodep) {
+    virtual void visit(AstUCFunc* nodep) VL_OVERRIDE {
         needNonStaticFunc(nodep);
         iterateChildren(nodep);
     }
-    virtual void visit(AstUCStmt* nodep) {
+    virtual void visit(AstUCStmt* nodep) VL_OVERRIDE {
         needNonStaticFunc(nodep);
         visitStmt(nodep);
     }
 
     //--------------------
     // Default: Just iterate
-    virtual void visit(AstVar* nodep) {}  // Don't hit varrefs under vars
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstVar* nodep) VL_OVERRIDE {}  // Don't hit varrefs under vars
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
     }
 

--- a/src/V3DepthBlock.cpp
+++ b/src/V3DepthBlock.cpp
@@ -71,7 +71,7 @@ private:
     }
 
     // VISITORS
-    virtual void visit(AstNodeModule* nodep) {
+    virtual void visit(AstNodeModule* nodep) VL_OVERRIDE {
         UINFO(4," MOD   "<<nodep<<endl);
         AstNodeModule* origModp = m_modp;
         {
@@ -81,7 +81,7 @@ private:
         }
         m_modp = origModp;
     }
-    virtual void visit(AstCFunc* nodep) {
+    virtual void visit(AstCFunc* nodep) VL_OVERRIDE {
         // We recurse into this.
         int lastDepth = m_depth;
         AstCFunc* lastFuncp = m_funcp;
@@ -109,7 +109,7 @@ private:
         }
         m_depth--;
     }
-    virtual void visit(AstNodeStmt* nodep) {
+    virtual void visit(AstNodeStmt* nodep) VL_OVERRIDE {
         if (!nodep->isStatement()) {
             iterateChildren(nodep);
         } else {
@@ -117,11 +117,11 @@ private:
         }
     }
 
-    virtual void visit(AstNodeMath* nodep) {}  // Accelerate
+    virtual void visit(AstNodeMath* nodep) VL_OVERRIDE {}  // Accelerate
     //--------------------
     // Default: Just iterate
-    virtual void visit(AstVar* nodep) {}  // Don't hit varrefs under vars
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstVar* nodep) VL_OVERRIDE {}  // Don't hit varrefs under vars
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
     }
 

--- a/src/V3Descope.cpp
+++ b/src/V3Descope.cpp
@@ -227,7 +227,7 @@ private:
     }
 
     // VISITORS
-    virtual void visit(AstNodeModule* nodep) {
+    virtual void visit(AstNodeModule* nodep) VL_OVERRIDE {
         AstNodeModule* origModp = m_modp;
         {
             m_modp = nodep;
@@ -238,17 +238,17 @@ private:
         }
         m_modp = origModp;
     }
-    virtual void visit(AstScope* nodep) {
+    virtual void visit(AstScope* nodep) VL_OVERRIDE {
         m_scopep = nodep;
         iterateChildren(nodep);
         m_scopep = NULL;
     }
-    virtual void visit(AstVarScope* nodep) {
+    virtual void visit(AstVarScope* nodep) VL_OVERRIDE {
         // Delete the varscope when we're finished
         nodep->unlinkFrBack();
         pushDeletep(nodep);
     }
-    virtual void visit(AstNodeVarRef* nodep) {
+    virtual void visit(AstNodeVarRef* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         // Convert the hierch name
         UASSERT_OBJ(m_scopep, nodep, "Node not under scope");
@@ -258,7 +258,7 @@ private:
         nodep->hierThis(hierThis);
         nodep->varScopep(NULL);
     }
-    virtual void visit(AstCCall* nodep) {
+    virtual void visit(AstCCall* nodep) VL_OVERRIDE {
         // UINFO(9,"       "<<nodep<<endl);
         iterateChildren(nodep);
         // Convert the hierch name
@@ -269,7 +269,7 @@ private:
         // Can't do this, as we may have more calls later
         // nodep->funcp()->scopep(NULL);
     }
-    virtual void visit(AstCFunc* nodep) {
+    virtual void visit(AstCFunc* nodep) VL_OVERRIDE {
         if (!nodep->user1()) {
             m_needThis = false;
             m_allowThis = nodep->isStatic().falseU();  // Non-static or unknown if static
@@ -290,8 +290,8 @@ private:
             }
         }
     }
-    virtual void visit(AstVar*) {}
-    virtual void visit(AstNode* nodep) { iterateChildren(nodep); }
+    virtual void visit(AstVar*) VL_OVERRIDE {}
+    virtual void visit(AstNode* nodep) VL_OVERRIDE { iterateChildren(nodep); }
 
 public:
     // CONSTRUCTORS

--- a/src/V3EmitC.cpp
+++ b/src/V3EmitC.cpp
@@ -205,7 +205,7 @@ public:
     }
 
     // VISITORS
-    virtual void visit(AstNodeAssign* nodep) {
+    virtual void visit(AstNodeAssign* nodep) VL_OVERRIDE {
         bool paren = true;  bool decind = false;
         if (AstSel* selp = VN_CAST(nodep->lhsp(), Sel)) {
             if (selp->widthMin()==1) {
@@ -270,9 +270,9 @@ public:
         if (decind) ofp()->blockDec();
         if (!m_suppressSemi) puts(";\n");
     }
-    virtual void visit(AstAlwaysPublic*) {
+    virtual void visit(AstAlwaysPublic*) VL_OVERRIDE {
     }
-    virtual void visit(AstAssocSel* nodep) {
+    virtual void visit(AstAssocSel* nodep) VL_OVERRIDE {
         iterateAndNextNull(nodep->fromp());
         putbs(".at(");
         AstAssocArrayDType* adtypep = VN_CAST(nodep->fromp()->dtypep(), AssocArrayDType);
@@ -293,7 +293,7 @@ public:
             puts(".data()");  // Access returned std::array as C array
         }
     }
-    virtual void visit(AstCCall* nodep) {
+    virtual void visit(AstCCall* nodep) VL_OVERRIDE {
         puts(nodep->hiernameProtect());
         puts(nodep->funcp()->nameProtect());
         puts("(");
@@ -311,7 +311,7 @@ public:
             puts(");\n");
         }
     }
-    virtual void visit(AstCMethodHard* nodep) {
+    virtual void visit(AstCMethodHard* nodep) VL_OVERRIDE {
         iterate(nodep->fromp());
         puts(".");
         puts(nodep->nameProtect());
@@ -328,15 +328,15 @@ public:
         UASSERT_OBJ(!nodep->isStatement() || VN_IS(nodep->dtypep(), VoidDType),
                     nodep, "Statement of non-void data type");
     }
-    virtual void visit(AstIntfRef* nodep) {
+    virtual void visit(AstIntfRef* nodep) VL_OVERRIDE {
         putsQuoted(VIdProtect::protectWordsIf(AstNode::vcdName(nodep->name()),
                                               nodep->protect()));
     }
-    virtual void visit(AstNodeCase* nodep) {
+    virtual void visit(AstNodeCase* nodep) VL_OVERRIDE {
         // In V3Case...
         nodep->v3fatalSrc("Case statements should have been reduced out");
     }
-    virtual void visit(AstComment* nodep) {
+    virtual void visit(AstComment* nodep) VL_OVERRIDE {
         string at;
         if (nodep->showAt()) {
             at = " at "+nodep->fileline()->ascii();
@@ -348,7 +348,7 @@ public:
         }
         iterateChildren(nodep);
     }
-    virtual void visit(AstCoverDecl* nodep) {
+    virtual void visit(AstCoverDecl* nodep) VL_OVERRIDE {
         puts("__vlCoverInsert(");  // As Declared in emitCoverageDecl
         puts("&(vlSymsp->__Vcoverage[");
         puts(cvtToStr(nodep->dataDeclThisp()->binNum())); puts("])");
@@ -367,22 +367,22 @@ public:
         puts(", ");     putsQuoted(protectWordsIf(nodep->comment(), nodep->protect()));
         puts(");\n");
     }
-    virtual void visit(AstCoverInc* nodep) {
+    virtual void visit(AstCoverInc* nodep) VL_OVERRIDE {
         puts("++(vlSymsp->__Vcoverage[");
         puts(cvtToStr(nodep->declp()->dataDeclThisp()->binNum()));
         puts("]);\n");
     }
-    virtual void visit(AstCReturn* nodep) {
+    virtual void visit(AstCReturn* nodep) VL_OVERRIDE {
         puts("return (");
         iterateAndNextNull(nodep->lhsp());
         puts(");\n");
     }
-    virtual void visit(AstDisplay* nodep) {
+    virtual void visit(AstDisplay* nodep) VL_OVERRIDE {
         string text = nodep->fmtp()->text();
         if (nodep->addNewline()) text += "\n";
         displayNode(nodep, nodep->fmtp()->scopeNamep(), text, nodep->fmtp()->exprsp(), false);
     }
-    virtual void visit(AstScopeName* nodep) {
+    virtual void visit(AstScopeName* nodep) VL_OVERRIDE {
         // For use under AstCCalls for dpiImports.  ScopeNames under
         // displays are handled in AstDisplay
         if (!nodep->dpiExport()) {
@@ -391,20 +391,20 @@ public:
             putbs("(&(vlSymsp->"+protect("__Vscope_"+scope)+"))");
         }
     }
-    virtual void visit(AstSFormat* nodep) {
+    virtual void visit(AstSFormat* nodep) VL_OVERRIDE {
         displayNode(nodep, nodep->fmtp()->scopeNamep(), nodep->fmtp()->text(),
                     nodep->fmtp()->exprsp(), false);
     }
-    virtual void visit(AstSFormatF* nodep) {
+    virtual void visit(AstSFormatF* nodep) VL_OVERRIDE {
         displayNode(nodep, nodep->scopeNamep(), nodep->text(), nodep->exprsp(), false);
     }
-    virtual void visit(AstFScanF* nodep) {
+    virtual void visit(AstFScanF* nodep) VL_OVERRIDE {
         displayNode(nodep, NULL, nodep->text(), nodep->exprsp(), true);
     }
-    virtual void visit(AstSScanF* nodep) {
+    virtual void visit(AstSScanF* nodep) VL_OVERRIDE {
         displayNode(nodep, NULL, nodep->text(), nodep->exprsp(), true);
     }
-    virtual void visit(AstValuePlusArgs* nodep) {
+    virtual void visit(AstValuePlusArgs* nodep) VL_OVERRIDE {
         puts("VL_VALUEPLUSARGS_IN");
         emitIQW(nodep->outp());
         puts("(");
@@ -416,12 +416,12 @@ public:
         iterateAndNextNull(nodep->outp());
         puts(")");
     }
-    virtual void visit(AstTestPlusArgs* nodep) {
+    virtual void visit(AstTestPlusArgs* nodep) VL_OVERRIDE {
         puts("VL_TESTPLUSARGS_I(");
         putsQuoted(nodep->text());
         puts(")");
     }
-    virtual void visit(AstFGetS* nodep) {
+    virtual void visit(AstFGetS* nodep) VL_OVERRIDE {
         checkMaxWords(nodep);
         emitOpName(nodep, nodep->emitC(), nodep->lhsp(), nodep->rhsp(), NULL);
     }
@@ -432,7 +432,7 @@ public:
                            <<" bits exceeds hardcoded limit VL_TO_STRING_MAX_WORDS in verilatedos.h");
         }
     }
-    virtual void visit(AstFOpen* nodep) {
+    virtual void visit(AstFOpen* nodep) VL_OVERRIDE {
         iterateAndNextNull(nodep->filep());
         puts(" = VL_FOPEN_");
         emitIQW(nodep->filenamep());
@@ -449,7 +449,7 @@ public:
         iterateAndNextNull(nodep->modep());
         puts(");\n");
     }
-    virtual void visit(AstNodeReadWriteMem* nodep) {
+    virtual void visit(AstNodeReadWriteMem* nodep) VL_OVERRIDE {
         puts(nodep->cFuncPrefixp());
         puts("N(");
         puts(nodep->isHex() ? "true" : "false");
@@ -487,14 +487,14 @@ public:
         if (nodep->msbp()) { iterateAndNextNull(nodep->msbp()); } else puts("~VL_ULL(0)");
         puts(");\n");
     }
-    virtual void visit(AstFClose* nodep) {
+    virtual void visit(AstFClose* nodep) VL_OVERRIDE {
         puts("VL_FCLOSE_I(");
         iterateAndNextNull(nodep->filep());
         puts("); ");
         iterateAndNextNull(nodep->filep());  // For safety, so user doesn't later WRITE with it.
         puts(" = 0;\n");
     }
-    virtual void visit(AstFFlush* nodep) {
+    virtual void visit(AstFFlush* nodep) VL_OVERRIDE {
         if (!nodep->filep()) {
             puts("fflush(stdout);\n");
         } else {
@@ -505,7 +505,7 @@ public:
             puts(")); }\n");
         }
     }
-    virtual void visit(AstFSeek* nodep) {
+    virtual void visit(AstFSeek* nodep) VL_OVERRIDE {
         puts("(fseek(VL_CVT_I_FP(");
         iterateAndNextNull(nodep->filep());
         puts("),");
@@ -514,17 +514,17 @@ public:
         iterateAndNextNull(nodep->operation());
         puts(")==-1?-1:0)");
     }
-    virtual void visit(AstFTell* nodep) {
+    virtual void visit(AstFTell* nodep) VL_OVERRIDE {
         puts("ftell(VL_CVT_I_FP(");
         iterateAndNextNull(nodep->filep());
         puts("))");
     }
-    virtual void visit(AstFRewind* nodep) {
+    virtual void visit(AstFRewind* nodep) VL_OVERRIDE {
         puts("(fseek(VL_CVT_I_FP(");
         iterateAndNextNull(nodep->filep());
         puts("), 0, 0)==-1?-1:0)");
     }
-    virtual void visit(AstFRead* nodep) {
+    virtual void visit(AstFRead* nodep) VL_OVERRIDE {
         puts("VL_FREAD_I(");
         puts(cvtToStr(nodep->memp()->widthMin()));  // Need real storage width
         putbs(",");
@@ -563,12 +563,12 @@ public:
         else puts(cvtToStr(array_size));
         puts(");\n");
     }
-    virtual void visit(AstSysFuncAsTask* nodep) {
+    virtual void visit(AstSysFuncAsTask* nodep) VL_OVERRIDE {
         if (!nodep->lhsp()->isWide()) puts("(void)");
         iterateAndNextNull(nodep->lhsp());
         if (!nodep->lhsp()->isWide()) puts(";");
     }
-    virtual void visit(AstSystemT* nodep) {
+    virtual void visit(AstSystemT* nodep) VL_OVERRIDE {
         puts("(void)VL_SYSTEM_I");
         emitIQW(nodep->lhsp());
         puts("(");
@@ -580,7 +580,7 @@ public:
         iterateAndNextNull(nodep->lhsp());
         puts(");\n");
     }
-    virtual void visit(AstSystemF* nodep) {
+    virtual void visit(AstSystemF* nodep) VL_OVERRIDE {
         puts("VL_SYSTEM_I");
         emitIQW(nodep->lhsp());
         puts("(");
@@ -592,17 +592,17 @@ public:
         iterateAndNextNull(nodep->lhsp());
         puts(")");
     }
-    virtual void visit(AstJumpGo* nodep) {
+    virtual void visit(AstJumpGo* nodep) VL_OVERRIDE {
         puts("goto __Vlabel"+cvtToStr(nodep->labelp()->labelNum())+";\n");
     }
-    virtual void visit(AstJumpLabel* nodep) {
+    virtual void visit(AstJumpLabel* nodep) VL_OVERRIDE {
         nodep->labelNum(++m_labelNum);
         puts("{\n");  // Make it visually obvious label jumps outside these
         iterateAndNextNull(nodep->stmtsp());
         puts("}\n");
         puts("__Vlabel"+cvtToStr(nodep->labelNum())+": ;\n");
     }
-    virtual void visit(AstWhile* nodep) {
+    virtual void visit(AstWhile* nodep) VL_OVERRIDE {
         iterateAndNextNull(nodep->precondsp());
         puts("while (");
         iterateAndNextNull(nodep->condp());
@@ -612,7 +612,7 @@ public:
         iterateAndNextNull(nodep->precondsp());  // Need to recompute before next loop
         puts("}\n");
     }
-    virtual void visit(AstNodeIf* nodep) {
+    virtual void visit(AstNodeIf* nodep) VL_OVERRIDE {
         puts("if (");
         if (!nodep->branchPred().unknown()) {
             puts(nodep->branchPred().ascii()); puts("(");
@@ -627,7 +627,7 @@ public:
         }
         puts("}\n");
     }
-    virtual void visit(AstStop* nodep) {
+    virtual void visit(AstStop* nodep) VL_OVERRIDE {
         puts("VL_STOP_MT(");
         putsQuoted(protect(nodep->fileline()->filename()));
         puts(", ");
@@ -635,41 +635,41 @@ public:
         puts(", \"\"");
         puts(");\n");
     }
-    virtual void visit(AstFinish* nodep) {
+    virtual void visit(AstFinish* nodep) VL_OVERRIDE {
         puts("VL_FINISH_MT(");
         putsQuoted(protect(nodep->fileline()->filename()));
         puts(", ");
         puts(cvtToStr(nodep->fileline()->lineno()));
         puts(", \"\");\n");
     }
-    virtual void visit(AstText* nodep) {
+    virtual void visit(AstText* nodep) VL_OVERRIDE {
         if (nodep->tracking() || m_trackText) {
             puts(nodep->text());
         } else {
             ofp()->putsNoTracking(nodep->text());
         }
     }
-    virtual void visit(AstTextBlock* nodep) {
+    virtual void visit(AstTextBlock* nodep) VL_OVERRIDE {
         visit(VN_CAST(nodep, Text));
         for (AstNode* childp = nodep->nodesp(); childp; childp = childp->nextp()) {
             iterate(childp);
             if (nodep->commas() && childp->nextp()) puts(", ");
         }
     }
-    virtual void visit(AstCStmt* nodep) {
+    virtual void visit(AstCStmt* nodep) VL_OVERRIDE {
         putbs("");
         iterateAndNextNull(nodep->bodysp());
     }
-    virtual void visit(AstCMath* nodep) {
+    virtual void visit(AstCMath* nodep) VL_OVERRIDE {
         putbs("");
         iterateAndNextNull(nodep->bodysp());
     }
-    virtual void visit(AstUCStmt* nodep) {
+    virtual void visit(AstUCStmt* nodep) VL_OVERRIDE {
         putsDecoration(ifNoProtect("// $c statement at "+nodep->fileline()->ascii()+"\n"));
         iterateAndNextNull(nodep->bodysp());
         puts("\n");
     }
-    virtual void visit(AstUCFunc* nodep) {
+    virtual void visit(AstUCFunc* nodep) VL_OVERRIDE {
         puts("\n");
         putsDecoration(ifNoProtect("// $c function at "+nodep->fileline()->ascii()+"\n"));
         iterateAndNextNull(nodep->bodysp());
@@ -677,10 +677,10 @@ public:
     }
 
     // Operators
-    virtual void visit(AstNodeTermop* nodep) {
+    virtual void visit(AstNodeTermop* nodep) VL_OVERRIDE {
         emitOpName(nodep, nodep->emitC(), NULL, NULL, NULL);
     }
-    virtual void visit(AstNodeUniop* nodep) {
+    virtual void visit(AstNodeUniop* nodep) VL_OVERRIDE {
         if (emitSimpleOk(nodep)) {
             putbs("("); puts(nodep->emitSimpleOperator()); puts(" ");
             iterateAndNextNull(nodep->lhsp()); puts(")");
@@ -688,7 +688,7 @@ public:
             emitOpName(nodep, nodep->emitC(), nodep->lhsp(), NULL, NULL);
         }
     }
-    virtual void visit(AstNodeBiop* nodep) {
+    virtual void visit(AstNodeBiop* nodep) VL_OVERRIDE {
         if (emitSimpleOk(nodep)) {
             putbs("("); iterateAndNextNull(nodep->lhsp());
             puts(" "); putbs(nodep->emitSimpleOperator()); puts(" ");
@@ -697,11 +697,11 @@ public:
             emitOpName(nodep, nodep->emitC(), nodep->lhsp(), nodep->rhsp(), NULL);
         }
     }
-    virtual void visit(AstNodeTriop* nodep) {
+    virtual void visit(AstNodeTriop* nodep) VL_OVERRIDE {
         UASSERT_OBJ(!emitSimpleOk(nodep), nodep, "Triop cannot be described in a simple way");
         emitOpName(nodep, nodep->emitC(), nodep->lhsp(), nodep->rhsp(), nodep->thsp());
     }
-    virtual void visit(AstRedXor* nodep) {
+    virtual void visit(AstRedXor* nodep) VL_OVERRIDE {
         if (nodep->lhsp()->isWide()) {
             visit(VN_CAST(nodep, NodeUniop));
         } else {
@@ -712,42 +712,42 @@ public:
             puts(")");
         }
     }
-    virtual void visit(AstMulS* nodep) {
+    virtual void visit(AstMulS* nodep) VL_OVERRIDE {
         if (nodep->widthWords() > VL_MULS_MAX_WORDS) {
             nodep->v3error("Unsupported: Signed multiply of "<<nodep->width()
                            <<" bits exceeds hardcoded limit VL_MULS_MAX_WORDS in verilatedos.h");
         }
         visit(VN_CAST(nodep, NodeBiop));
     }
-    virtual void visit(AstPow* nodep) {
+    virtual void visit(AstPow* nodep) VL_OVERRIDE {
         if (nodep->widthWords() > VL_MULS_MAX_WORDS) {
             nodep->v3error("Unsupported: Power of "<<nodep->width()
                            <<" bits exceeds hardcoded limit VL_MULS_MAX_WORDS in verilatedos.h");
         }
         visit(VN_CAST(nodep, NodeBiop));
     }
-    virtual void visit(AstPowSS* nodep) {
+    virtual void visit(AstPowSS* nodep) VL_OVERRIDE {
         if (nodep->widthWords() > VL_MULS_MAX_WORDS) {
             nodep->v3error("Unsupported: Power of "<<nodep->width()
                            <<" bits exceeds hardcoded limit VL_MULS_MAX_WORDS in verilatedos.h");
         }
         visit(VN_CAST(nodep, NodeBiop));
     }
-    virtual void visit(AstPowSU* nodep) {
+    virtual void visit(AstPowSU* nodep) VL_OVERRIDE {
         if (nodep->widthWords() > VL_MULS_MAX_WORDS) {
             nodep->v3error("Unsupported: Power of "<<nodep->width()
                            <<" bits exceeds hardcoded limit VL_MULS_MAX_WORDS in verilatedos.h");
         }
         visit(VN_CAST(nodep, NodeBiop));
     }
-    virtual void visit(AstPowUS* nodep) {
+    virtual void visit(AstPowUS* nodep) VL_OVERRIDE {
         if (nodep->widthWords() > VL_MULS_MAX_WORDS) {
             nodep->v3error("Unsupported: Power of "<<nodep->width()
                            <<" bits exceeds hardcoded limit VL_MULS_MAX_WORDS in verilatedos.h");
         }
         visit(VN_CAST(nodep, NodeBiop));
     }
-    virtual void visit(AstCCast* nodep) {
+    virtual void visit(AstCCast* nodep) VL_OVERRIDE {
         // Extending a value of the same word width is just a NOP.
         if (nodep->size() <= VL_IDATASIZE) {
             puts("(IData)(");
@@ -757,7 +757,7 @@ public:
         iterateAndNextNull(nodep->lhsp());
         puts(")");
     }
-    virtual void visit(AstNodeCond* nodep) {
+    virtual void visit(AstNodeCond* nodep) VL_OVERRIDE {
         // Widths match up already, so we'll just use C++'s operator w/o any temps.
         if (nodep->expr1p()->isWide()) {
             emitOpName(nodep, nodep->emitC(), nodep->condp(), nodep->expr1p(), nodep->expr2p());
@@ -768,16 +768,16 @@ public:
             iterateAndNextNull(nodep->expr2p()); puts(")");
         }
     }
-    virtual void visit(AstNew* nodep) {
+    virtual void visit(AstNew* nodep) VL_OVERRIDE {
         puts("std::make_shared<" + nodep->dtypep()->nameProtect() + ">(");
         iterateChildren(nodep);
         puts(")");
     }
-    virtual void visit(AstSel* nodep) {
+    virtual void visit(AstSel* nodep) VL_OVERRIDE {
         // Note ASSIGN checks for this on a LHS
         emitOpName(nodep, nodep->emitC(), nodep->fromp(), nodep->lsbp(), nodep->thsp());
     }
-    virtual void visit(AstReplicate* nodep) {
+    virtual void visit(AstReplicate* nodep) VL_OVERRIDE {
         if (nodep->lhsp()->widthMin() == 1 && !nodep->isWide()) {
             UASSERT_OBJ((static_cast<int>(VN_CAST(nodep->rhsp(), Const)->toUInt())
                          * nodep->lhsp()->widthMin()) == nodep->widthMin(),
@@ -795,7 +795,7 @@ public:
             emitOpName(nodep, nodep->emitC(), nodep->lhsp(), nodep->rhsp(), NULL);
         }
     }
-    virtual void visit(AstStreamL* nodep) {
+    virtual void visit(AstStreamL* nodep) VL_OVERRIDE {
         // Attempt to use a "fast" stream function for slice size = power of 2
         if (!nodep->isWide()) {
             uint32_t isPow2 = VN_CAST(nodep->rhsp(), Const)->num().countOnes() == 1;
@@ -819,7 +819,7 @@ public:
                    nodep->lhsp(), nodep->rhsp(), NULL);
     }
     // Terminals
-    virtual void visit(AstVarRef* nodep) {
+    virtual void visit(AstVarRef* nodep) VL_OVERRIDE {
         puts(nodep->hiernameProtect());
         puts(nodep->varp()->nameProtect());
     }
@@ -943,7 +943,7 @@ public:
         emitConstant(constp, NULL, assignString);
         puts(";\n");
     }
-    virtual void visit(AstConst* nodep) {
+    virtual void visit(AstConst* nodep) VL_OVERRIDE {
         if (nodep->isWide()) {
             UASSERT_OBJ(m_wideTempRefp, nodep, "Wide Constant w/ no temp");
             emitConstant(nodep, m_wideTempRefp, "");
@@ -954,27 +954,27 @@ public:
     }
 
     // Just iterate
-    virtual void visit(AstNetlist* nodep) {
+    virtual void visit(AstNetlist* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
     }
-    virtual void visit(AstTopScope* nodep) {
+    virtual void visit(AstTopScope* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
     }
-    virtual void visit(AstScope* nodep) {
+    virtual void visit(AstScope* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
     }
     // NOPs
-    virtual void visit(AstTypedef*) {}
-    virtual void visit(AstPragma*) {}
-    virtual void visit(AstCell*) {}  // Handled outside the Visit class
-    virtual void visit(AstVar*) {}  // Handled outside the Visit class
-    virtual void visit(AstNodeText*) {}  // Handled outside the Visit class
-    virtual void visit(AstTraceDecl*) {}  // Handled outside the Visit class
-    virtual void visit(AstTraceInc*) {}  // Handled outside the Visit class
-    virtual void visit(AstCFile*) {}  // Handled outside the Visit class
-    virtual void visit(AstCellInline*) {}  // Handled outside the Visit class (EmitCSyms)
+    virtual void visit(AstTypedef*) VL_OVERRIDE {}
+    virtual void visit(AstPragma*) VL_OVERRIDE {}
+    virtual void visit(AstCell*) VL_OVERRIDE {}  // Handled outside the Visit class
+    virtual void visit(AstVar*) VL_OVERRIDE {}  // Handled outside the Visit class
+    virtual void visit(AstNodeText*) VL_OVERRIDE {}  // Handled outside the Visit class
+    virtual void visit(AstTraceDecl*) VL_OVERRIDE {}  // Handled outside the Visit class
+    virtual void visit(AstTraceInc*) VL_OVERRIDE {}  // Handled outside the Visit class
+    virtual void visit(AstCFile*) VL_OVERRIDE {}  // Handled outside the Visit class
+    virtual void visit(AstCellInline*) VL_OVERRIDE {}  // Handled outside the Visit class (EmitCSyms)
     // Default
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         puts(string("\n???? // ")+nodep->prettyTypeName()+"\n");
         iterateChildren(nodep);
         nodep->v3fatalSrc("Unknown node type reached emitter: "<<nodep->prettyTypeName());
@@ -1204,7 +1204,7 @@ class EmitCImp : EmitCStmts {
         }
     }
 
-    virtual void visit(AstMTaskBody* nodep) {
+    virtual void visit(AstMTaskBody* nodep) VL_OVERRIDE {
         ExecMTask* mtp = nodep->execMTaskp();
         puts("\n");
         puts("void ");
@@ -1223,7 +1223,7 @@ class EmitCImp : EmitCStmts {
     //---------------------------------------
     // VISITORS
     using EmitCStmts::visit;  // Suppress hidden overloaded virtual function warning
-    virtual void visit(AstCFunc* nodep) {
+    virtual void visit(AstCFunc* nodep) VL_OVERRIDE {
         // TRACE_* and DPI handled elsewhere
         if (nodep->funcType().isTrace()) return;
         if (nodep->dpiImport()) return;
@@ -1313,16 +1313,16 @@ class EmitCImp : EmitCStmts {
         }
     }
 
-    virtual void visit(AstChangeDet* nodep) {
+    virtual void visit(AstChangeDet* nodep) VL_OVERRIDE {
         m_blkChangeDetVec.push_back(nodep);
     }
 
-    virtual void visit(AstCReset* nodep) {
+    virtual void visit(AstCReset* nodep) VL_OVERRIDE {
         AstVar* varp = nodep->varrefp()->varp();
         emitVarReset(varp);
     }
 
-    virtual void visit(AstExecGraph* nodep) {
+    virtual void visit(AstExecGraph* nodep) VL_OVERRIDE {
         UASSERT_OBJ(nodep == v3Global.rootp()->execGraphp(), nodep,
                     "ExecGraph should be a singleton!");
         // The location of the AstExecGraph within the containing _eval()
@@ -3175,14 +3175,14 @@ class EmitCTrace : EmitCStmts {
 
     // VISITORS
     using EmitCStmts::visit;  // Suppress hidden overloaded virtual function warning
-    virtual void visit(AstNetlist* nodep) {
+    virtual void visit(AstNetlist* nodep) VL_OVERRIDE {
         // Top module only
         iterate(nodep->topModulep());
     }
-    virtual void visit(AstNodeModule* nodep) {
+    virtual void visit(AstNodeModule* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
     }
-    virtual void visit(AstCFunc* nodep) {
+    virtual void visit(AstCFunc* nodep) VL_OVERRIDE {
         if (nodep->slow() != m_slow) return;
         if (nodep->funcType().isTrace()) {  // TRACE_*
             m_funcp = nodep;
@@ -3228,7 +3228,7 @@ class EmitCTrace : EmitCStmts {
         }
         m_funcp = NULL;
     }
-    virtual void visit(AstTraceDecl* nodep) {
+    virtual void visit(AstTraceDecl* nodep) VL_OVERRIDE {
         int enumNum = emitTraceDeclDType(nodep->dtypep());
         if (nodep->arrayRange().ranged()) {
             puts("{int i; for (i=0; i<"+cvtToStr(nodep->arrayRange().elements())+"; i++) {\n");
@@ -3239,7 +3239,7 @@ class EmitCTrace : EmitCStmts {
             puts("\n");
         }
     }
-    virtual void visit(AstTraceInc* nodep) {
+    virtual void visit(AstTraceInc* nodep) VL_OVERRIDE {
         if (nodep->declp()->arrayRange().ranged()) {
             // It traces faster if we unroll the loop
             for (int i=0; i<nodep->declp()->arrayRange().elements(); i++) {
@@ -3249,9 +3249,9 @@ class EmitCTrace : EmitCStmts {
             emitTraceChangeOne(nodep, -1);
         }
     }
-    virtual void visit(AstCoverDecl* nodep) {
+    virtual void visit(AstCoverDecl* nodep) VL_OVERRIDE {
     }
-    virtual void visit(AstCoverInc* nodep) {
+    virtual void visit(AstCoverInc* nodep) VL_OVERRIDE {
     }
 
 public:

--- a/src/V3EmitCBase.h
+++ b/src/V3EmitCBase.h
@@ -108,7 +108,7 @@ private:
     // MEMBERS
     int m_count;  // Number of statements
     // VISITORS
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         m_count++;
         iterateChildren(nodep);
     }

--- a/src/V3EmitCInlines.cpp
+++ b/src/V3EmitCInlines.cpp
@@ -40,51 +40,51 @@ class EmitCInlines : EmitCBaseVisitor {
     void emitInt();
 
     // VISITORS
-    virtual void visit(AstBasicDType* nodep) {
+    virtual void visit(AstBasicDType* nodep) VL_OVERRIDE {
         if (nodep->keyword() == AstBasicDTypeKwd::STRING) {
             // Request #include <string> via verilated_heavy.h when we create symbol file
             v3Global.needHeavy(true);
         }
     }
-    virtual void visit(AstAssocArrayDType* nodep) {
+    virtual void visit(AstAssocArrayDType* nodep) VL_OVERRIDE {
         v3Global.needHeavy(true);
         iterateChildren(nodep);
     }
-    virtual void visit(AstQueueDType* nodep) {
+    virtual void visit(AstQueueDType* nodep) VL_OVERRIDE {
         v3Global.needHeavy(true);
         iterateChildren(nodep);
     }
-    virtual void visit(AstNodeReadWriteMem* nodep) {
+    virtual void visit(AstNodeReadWriteMem* nodep) VL_OVERRIDE {
         v3Global.needHeavy(true);
         iterateChildren(nodep);
     }
-    virtual void visit(AstValuePlusArgs* nodep) {
+    virtual void visit(AstValuePlusArgs* nodep) VL_OVERRIDE {
         v3Global.needHeavy(true);
         iterateChildren(nodep);
     }
-    virtual void visit(AstAtoN* nodep) {
+    virtual void visit(AstAtoN* nodep) VL_OVERRIDE {
         v3Global.needHeavy(true);
         iterateChildren(nodep);
     }
-    virtual void visit(AstPutcN* nodep) {
+    virtual void visit(AstPutcN* nodep) VL_OVERRIDE {
         v3Global.needHeavy(true);
         iterateChildren(nodep);
     }
-    virtual void visit(AstGetcN* nodep) {
+    virtual void visit(AstGetcN* nodep) VL_OVERRIDE {
         v3Global.needHeavy(true);
         iterateChildren(nodep);
     }
-    virtual void visit(AstSubstrN* nodep) {
+    virtual void visit(AstSubstrN* nodep) VL_OVERRIDE {
         v3Global.needHeavy(true);
         iterateChildren(nodep);
     }
-    virtual void visit(AstCompareNN* nodep) {
+    virtual void visit(AstCompareNN* nodep) VL_OVERRIDE {
         v3Global.needHeavy(true);
         iterateChildren(nodep);
     }
 
     // Default
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
     }
     //---------------------------------------

--- a/src/V3EmitCSyms.cpp
+++ b/src/V3EmitCSyms.cpp
@@ -244,7 +244,7 @@ class EmitCSyms : EmitCBaseVisitor {
     }
 
     // VISITORS
-    virtual void visit(AstNetlist* nodep) {
+    virtual void visit(AstNetlist* nodep) VL_OVERRIDE {
         // Collect list of scopes
         iterateChildren(nodep);
         varsExpand();
@@ -268,7 +268,7 @@ class EmitCSyms : EmitCBaseVisitor {
             if (!m_dpiHdrOnly) emitDpiImp();
         }
     }
-    virtual void visit(AstNodeModule* nodep) {
+    virtual void visit(AstNodeModule* nodep) VL_OVERRIDE {
         nameCheck(nodep);
         AstNodeModule* origModp = m_modp;
         {
@@ -277,7 +277,7 @@ class EmitCSyms : EmitCBaseVisitor {
         }
         m_modp = origModp;
     }
-    virtual void visit(AstCellInline* nodep) {
+    virtual void visit(AstCellInline* nodep) VL_OVERRIDE {
         if (v3Global.opt.vpi()) {
             string type = (nodep->origModName() == "__BEGIN__") ? "SCOPE_OTHER"
                                                                 : "SCOPE_MODULE";
@@ -287,7 +287,7 @@ class EmitCSyms : EmitCBaseVisitor {
                                                                   name_dedot, type)));
         }
     }
-    virtual void visit(AstScope* nodep) {
+    virtual void visit(AstScope* nodep) VL_OVERRIDE {
         nameCheck(nodep);
 
         m_scopes.push_back(make_pair(nodep, m_modp));
@@ -298,7 +298,7 @@ class EmitCSyms : EmitCBaseVisitor {
                                                             nodep->name(), "SCOPE_MODULE")));
         }
     }
-    virtual void visit(AstScopeName* nodep) {
+    virtual void visit(AstScopeName* nodep) VL_OVERRIDE {
         string name = nodep->scopeSymName();
         //UINFO(9,"scnameins sp "<<nodep->name()<<" sp "<<nodep->scopePrettySymName()<<" ss "<<name<<endl);
         if (m_scopeNames.find(name) == m_scopeNames.end()) {
@@ -318,7 +318,7 @@ class EmitCSyms : EmitCBaseVisitor {
             }
         }
     }
-    virtual void visit(AstVar* nodep) {
+    virtual void visit(AstVar* nodep) VL_OVERRIDE {
         nameCheck(nodep);
         iterateChildren(nodep);
         if (nodep->isSigUserRdPublic()
@@ -326,13 +326,13 @@ class EmitCSyms : EmitCBaseVisitor {
             m_modVars.push_back(make_pair(m_modp, nodep));
         }
     }
-    virtual void visit(AstCoverDecl* nodep) {
+    virtual void visit(AstCoverDecl* nodep) VL_OVERRIDE {
         // Assign numbers to all bins, so we know how big of an array to use
         if (!nodep->dataDeclNullp()) {  // else duplicate we don't need code for
             nodep->binNum(m_coverBins++);
         }
     }
-    virtual void visit(AstCFunc* nodep) {
+    virtual void visit(AstCFunc* nodep) VL_OVERRIDE {
         nameCheck(nodep);
         if (nodep->dpiImport() || nodep->dpiExportWrapper()) {
             m_dpis.push_back(nodep);
@@ -342,9 +342,9 @@ class EmitCSyms : EmitCBaseVisitor {
         m_funcp = NULL;
     }
     // NOPs
-    virtual void visit(AstConst*) {}
+    virtual void visit(AstConst*) VL_OVERRIDE {}
     // Default
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
     }
     //---------------------------------------

--- a/src/V3EmitV.cpp
+++ b/src/V3EmitV.cpp
@@ -57,15 +57,15 @@ class EmitVBaseVisitor : public EmitCBaseVisitor {
     }
 
     // VISITORS
-    virtual void visit(AstNetlist* nodep) {
+    virtual void visit(AstNetlist* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
     }
-    virtual void visit(AstNodeModule* nodep) {
+    virtual void visit(AstNodeModule* nodep) VL_OVERRIDE {
         putfs(nodep, nodep->verilogKwd()+" "+modClassName(nodep)+";\n");
         iterateChildren(nodep);
         putqs(nodep, "end"+nodep->verilogKwd()+"\n");
     }
-    virtual void visit(AstNodeFTask* nodep) {
+    virtual void visit(AstNodeFTask* nodep) VL_OVERRIDE {
         putfs(nodep, nodep->isFunction() ? "function":"task");
         puts(" ");
         puts(nodep->prettyName());
@@ -75,7 +75,7 @@ class EmitVBaseVisitor : public EmitCBaseVisitor {
         putqs(nodep, "end\n");
     }
 
-    virtual void visit(AstBegin* nodep) {
+    virtual void visit(AstBegin* nodep) VL_OVERRIDE {
         if (nodep->unnamed()) {
             putbs("begin\n");
         } else {
@@ -84,22 +84,22 @@ class EmitVBaseVisitor : public EmitCBaseVisitor {
         iterateChildren(nodep);
         puts("end\n");
     }
-    virtual void visit(AstGenerate* nodep) {
+    virtual void visit(AstGenerate* nodep) VL_OVERRIDE {
         putfs(nodep, "generate\n");
         iterateChildren(nodep);
         putqs(nodep, "end\n");
     }
-    virtual void visit(AstFinal* nodep) {
+    virtual void visit(AstFinal* nodep) VL_OVERRIDE {
         putfs(nodep, "final begin\n");
         iterateChildren(nodep);
         putqs(nodep, "end\n");
     }
-    virtual void visit(AstInitial* nodep) {
+    virtual void visit(AstInitial* nodep) VL_OVERRIDE {
         putfs(nodep, "initial begin\n");
         iterateChildren(nodep);
         putqs(nodep, "end\n");
     }
-    virtual void visit(AstAlways* nodep) {
+    virtual void visit(AstAlways* nodep) VL_OVERRIDE {
         putfs(nodep, "always ");
         if (m_sensesp) iterateAndNextNull(m_sensesp);  // In active
         else iterateAndNextNull(nodep->sensesp());
@@ -107,7 +107,7 @@ class EmitVBaseVisitor : public EmitCBaseVisitor {
         iterateAndNextNull(nodep->bodysp());
         putqs(nodep, "end\n");
     }
-    virtual void visit(AstAlwaysPublic* nodep) {
+    virtual void visit(AstAlwaysPublic* nodep) VL_OVERRIDE {
         putfs(nodep, "/*verilator public_flat_rw ");
         if (m_sensesp) iterateAndNextNull(m_sensesp);  // In active
         else iterateAndNextNull(nodep->sensesp());
@@ -115,37 +115,37 @@ class EmitVBaseVisitor : public EmitCBaseVisitor {
         iterateAndNextNull(nodep->bodysp());
         putqs(nodep, "*/\n");
     }
-    virtual void visit(AstNodeAssign* nodep) {
+    virtual void visit(AstNodeAssign* nodep) VL_OVERRIDE {
         iterateAndNextNull(nodep->lhsp());
         putfs(nodep, " "+nodep->verilogKwd()+" ");
         iterateAndNextNull(nodep->rhsp());
         if (!m_suppressSemi) puts(";\n");
     }
-    virtual void visit(AstAssignDly* nodep) {
+    virtual void visit(AstAssignDly* nodep) VL_OVERRIDE {
         iterateAndNextNull(nodep->lhsp());
         putfs(nodep, " <= ");
         iterateAndNextNull(nodep->rhsp());
         puts(";\n");
     }
-    virtual void visit(AstAssignAlias* nodep) {
+    virtual void visit(AstAssignAlias* nodep) VL_OVERRIDE {
         putbs("alias ");
         iterateAndNextNull(nodep->lhsp());
         putfs(nodep, " = ");
         iterateAndNextNull(nodep->rhsp());
         if (!m_suppressSemi) puts(";\n");
     }
-    virtual void visit(AstAssignW* nodep) {
+    virtual void visit(AstAssignW* nodep) VL_OVERRIDE {
         putfs(nodep, "assign ");
         iterateAndNextNull(nodep->lhsp());
         putbs(" = ");
         iterateAndNextNull(nodep->rhsp());
         if (!m_suppressSemi) puts(";\n");
     }
-    virtual void visit(AstBreak* nodep) {
+    virtual void visit(AstBreak* nodep) VL_OVERRIDE {
         putbs("break");
         if (!m_suppressSemi) puts(";\n");
     }
-    virtual void visit(AstSenTree* nodep) {
+    virtual void visit(AstSenTree* nodep) VL_OVERRIDE {
         // AstSenItem is called for dumping in isolation by V3Order
         putfs(nodep, "@(");
         for (AstNode* expp=nodep->sensesp(); expp; expp = expp->nextp()) {
@@ -154,16 +154,16 @@ class EmitVBaseVisitor : public EmitCBaseVisitor {
         }
         puts(")");
     }
-    virtual void visit(AstSenGate* nodep) {
+    virtual void visit(AstSenGate* nodep) VL_OVERRIDE {
         emitVerilogFormat(nodep, nodep->emitVerilog(), nodep->sensesp(), nodep->rhsp());
     }
-    virtual void visit(AstSenItem* nodep) {
+    virtual void visit(AstSenItem* nodep) VL_OVERRIDE {
         putfs(nodep, "");
         puts(nodep->edgeType().verilogKwd());
         if (nodep->sensp()) puts(" ");
         iterateChildren(nodep);
     }
-    virtual void visit(AstNodeCase* nodep) {
+    virtual void visit(AstNodeCase* nodep) VL_OVERRIDE {
         putfs(nodep, "");
         if (const AstCase* casep = VN_CAST(nodep, Case)) {
             if (casep->priorityPragma()) puts("priority ");
@@ -184,7 +184,7 @@ class EmitVBaseVisitor : public EmitCBaseVisitor {
         iterateAndNextNull(nodep->itemsp());
         putqs(nodep, "endcase\n");
     }
-    virtual void visit(AstCaseItem* nodep) {
+    virtual void visit(AstCaseItem* nodep) VL_OVERRIDE {
         if (nodep->condsp()) {
             iterateAndNextNull(nodep->condsp());
         } else putbs("default");
@@ -192,17 +192,17 @@ class EmitVBaseVisitor : public EmitCBaseVisitor {
         iterateAndNextNull(nodep->bodysp());
         putqs(nodep, "end\n");
     }
-    virtual void visit(AstComment* nodep) {
+    virtual void visit(AstComment* nodep) VL_OVERRIDE {
         puts(string("// ")+nodep->name()+"\n");
         iterateChildren(nodep);
     }
-    virtual void visit(AstContinue* nodep) {
+    virtual void visit(AstContinue* nodep) VL_OVERRIDE {
         putbs("continue");
         if (!m_suppressSemi) puts(";\n");
     }
-    virtual void visit(AstCoverDecl*) {}  // N/A
-    virtual void visit(AstCoverInc*) {}  // N/A
-    virtual void visit(AstCoverToggle*) {}  // N/A
+    virtual void visit(AstCoverDecl*) VL_OVERRIDE {}  // N/A
+    virtual void visit(AstCoverInc*) VL_OVERRIDE {}  // N/A
+    virtual void visit(AstCoverToggle*) VL_OVERRIDE {}  // N/A
 
     void visitNodeDisplay(AstNode* nodep, AstNode* fileOrStrgp,
                           const string& text, AstNode* exprsp) {
@@ -216,28 +216,28 @@ class EmitVBaseVisitor : public EmitCBaseVisitor {
         }
         puts(");\n");
     }
-    virtual void visit(AstDisable* nodep) {
+    virtual void visit(AstDisable* nodep) VL_OVERRIDE {
         putbs("disable "+nodep->name()+";\n");
     }
-    virtual void visit(AstDisplay* nodep) {
+    virtual void visit(AstDisplay* nodep) VL_OVERRIDE {
         visitNodeDisplay(nodep, nodep->filep(), nodep->fmtp()->text(), nodep->fmtp()->exprsp());
     }
-    virtual void visit(AstElabDisplay* nodep) {
+    virtual void visit(AstElabDisplay* nodep) VL_OVERRIDE {
         visitNodeDisplay(nodep, NULL, nodep->fmtp()->text(), nodep->fmtp()->exprsp());
     }
-    virtual void visit(AstFScanF* nodep) {
+    virtual void visit(AstFScanF* nodep) VL_OVERRIDE {
         visitNodeDisplay(nodep, nodep->filep(), nodep->text(), nodep->exprsp());
     }
-    virtual void visit(AstSScanF* nodep) {
+    virtual void visit(AstSScanF* nodep) VL_OVERRIDE {
         visitNodeDisplay(nodep, nodep->fromp(), nodep->text(), nodep->exprsp());
     }
-    virtual void visit(AstSFormat* nodep) {
+    virtual void visit(AstSFormat* nodep) VL_OVERRIDE {
         visitNodeDisplay(nodep, nodep->lhsp(), nodep->fmtp()->text(), nodep->fmtp()->exprsp());
     }
-    virtual void visit(AstSFormatF* nodep) {
+    virtual void visit(AstSFormatF* nodep) VL_OVERRIDE {
         visitNodeDisplay(nodep, NULL, nodep->text(), nodep->exprsp());
     }
-    virtual void visit(AstFOpen* nodep) {
+    virtual void visit(AstFOpen* nodep) VL_OVERRIDE {
         putfs(nodep, nodep->verilogKwd());
         putbs(" (");
         if (nodep->filep()) iterateAndNextNull(nodep->filep());
@@ -247,27 +247,27 @@ class EmitVBaseVisitor : public EmitCBaseVisitor {
         if (nodep->modep()) iterateAndNextNull(nodep->modep());
         puts(");\n");
     }
-    virtual void visit(AstFClose* nodep) {
+    virtual void visit(AstFClose* nodep) VL_OVERRIDE {
         putfs(nodep, nodep->verilogKwd());
         putbs(" (");
         if (nodep->filep()) iterateAndNextNull(nodep->filep());
         puts(");\n");
     }
-    virtual void visit(AstFFlush* nodep) {
+    virtual void visit(AstFFlush* nodep) VL_OVERRIDE {
         putfs(nodep, nodep->verilogKwd());
         putbs(" (");
         if (nodep->filep()) iterateAndNextNull(nodep->filep());
         puts(");\n");
     }
-    virtual void visit(AstJumpGo* nodep) {
+    virtual void visit(AstJumpGo* nodep) VL_OVERRIDE {
         putbs("disable "+cvtToHex(nodep->labelp())+";\n");
     }
-    virtual void visit(AstJumpLabel* nodep) {
+    virtual void visit(AstJumpLabel* nodep) VL_OVERRIDE {
         putbs("begin : "+cvtToHex(nodep)+"\n");
         if (nodep->stmtsp()) iterateAndNextNull(nodep->stmtsp());
         puts("end\n");
     }
-    virtual void visit(AstNodeReadWriteMem* nodep) {
+    virtual void visit(AstNodeReadWriteMem* nodep) VL_OVERRIDE {
         putfs(nodep, nodep->verilogKwd());
         putbs(" (");
         if (nodep->filenamep()) iterateAndNextNull(nodep->filenamep());
@@ -277,17 +277,17 @@ class EmitVBaseVisitor : public EmitCBaseVisitor {
         if (nodep->msbp()) { putbs(","); iterateAndNextNull(nodep->msbp()); }
         puts(");\n");
     }
-    virtual void visit(AstSysFuncAsTask* nodep) {
+    virtual void visit(AstSysFuncAsTask* nodep) VL_OVERRIDE {
         iterateAndNextNull(nodep->lhsp());
         puts(";\n");
     }
-    virtual void visit(AstSysIgnore* nodep) {
+    virtual void visit(AstSysIgnore* nodep) VL_OVERRIDE {
         putfs(nodep, nodep->verilogKwd());
         putbs(" (");
         iterateAndNextNull(nodep->exprsp());
         puts(");\n");
     }
-    virtual void visit(AstNodeFor* nodep) {
+    virtual void visit(AstNodeFor* nodep) VL_OVERRIDE {
         putfs(nodep, "for (");
         m_suppressSemi = true;
         iterateAndNextNull(nodep->initsp());
@@ -300,14 +300,14 @@ class EmitVBaseVisitor : public EmitCBaseVisitor {
         iterateAndNextNull(nodep->bodysp());
         putqs(nodep, "end\n");
     }
-    virtual void visit(AstRepeat* nodep) {
+    virtual void visit(AstRepeat* nodep) VL_OVERRIDE {
         putfs(nodep, "repeat (");
         iterateAndNextNull(nodep->countp());
         puts(") begin\n");
         iterateAndNextNull(nodep->bodysp());
         putfs(nodep, "end\n");
     }
-    virtual void visit(AstWhile* nodep) {
+    virtual void visit(AstWhile* nodep) VL_OVERRIDE {
         iterateAndNextNull(nodep->precondsp());
         putfs(nodep, "while (");
         iterateAndNextNull(nodep->condp());
@@ -317,7 +317,7 @@ class EmitVBaseVisitor : public EmitCBaseVisitor {
         iterateAndNextNull(nodep->precondsp());  // Need to recompute before next loop
         putfs(nodep, "end\n");
     }
-    virtual void visit(AstNodeIf* nodep) {
+    virtual void visit(AstNodeIf* nodep) VL_OVERRIDE {
         putfs(nodep, "");
         if (const AstIf* ifp = VN_CAST(nodep, If)) {
             if (ifp->priorityPragma()) puts("priority ");
@@ -335,7 +335,7 @@ class EmitVBaseVisitor : public EmitCBaseVisitor {
         }
         putqs(nodep, "end\n");
     }
-    virtual void visit(AstPast* nodep) {
+    virtual void visit(AstPast* nodep) VL_OVERRIDE {
         putfs(nodep, "$past(");
         iterateAndNextNull(nodep->exprp());
         if (nodep->ticksp()) {
@@ -344,49 +344,49 @@ class EmitVBaseVisitor : public EmitCBaseVisitor {
         }
         puts(")");
     }
-    virtual void visit(AstReturn* nodep) {
+    virtual void visit(AstReturn* nodep) VL_OVERRIDE {
         putfs(nodep, "return ");
         iterateAndNextNull(nodep->lhsp());
         puts(";\n");
     }
-    virtual void visit(AstStop* nodep) {
+    virtual void visit(AstStop* nodep) VL_OVERRIDE {
         putfs(nodep, "$stop;\n");
     }
-    virtual void visit(AstFinish* nodep) {
+    virtual void visit(AstFinish* nodep) VL_OVERRIDE {
         putfs(nodep, "$finish;\n");
     }
-    virtual void visit(AstText* nodep) {
+    virtual void visit(AstText* nodep) VL_OVERRIDE {
         if (nodep->tracking() || m_trackText) {
             puts(nodep->text());
         } else {
             putsNoTracking(nodep->text());
         }
     }
-    virtual void visit(AstTextBlock* nodep) {
+    virtual void visit(AstTextBlock* nodep) VL_OVERRIDE {
         visit(VN_CAST(nodep, Text));
         for (AstNode* childp = nodep->nodesp(); childp; childp = childp->nextp()) {
             iterate(childp);
             if (nodep->commas() && childp->nextp()) puts(", ");
         }
     }
-    virtual void visit(AstScopeName* nodep) {
+    virtual void visit(AstScopeName* nodep) VL_OVERRIDE {
     }
-    virtual void visit(AstCStmt* nodep) {
+    virtual void visit(AstCStmt* nodep) VL_OVERRIDE {
         putfs(nodep, "$_CSTMT(");
         iterateAndNextNull(nodep->bodysp());
         puts(");\n");
     }
-    virtual void visit(AstCMath* nodep) {
+    virtual void visit(AstCMath* nodep) VL_OVERRIDE {
         putfs(nodep, "$_CMATH(");
         iterateAndNextNull(nodep->bodysp());
         puts(");\n");
     }
-    virtual void visit(AstUCStmt* nodep) {
+    virtual void visit(AstUCStmt* nodep) VL_OVERRIDE {
         putfs(nodep, "$c(");
         iterateAndNextNull(nodep->bodysp());
         puts(");\n");
     }
-    virtual void visit(AstUCFunc* nodep) {
+    virtual void visit(AstUCFunc* nodep) VL_OVERRIDE {
         putfs(nodep, "$c(");
         iterateAndNextNull(nodep->bodysp());
         puts(")");
@@ -444,19 +444,19 @@ class EmitVBaseVisitor : public EmitCBaseVisitor {
         }
     }
 
-    virtual void visit(AstNodeTermop* nodep) {
+    virtual void visit(AstNodeTermop* nodep) VL_OVERRIDE {
         emitVerilogFormat(nodep, nodep->emitVerilog());
     }
-    virtual void visit(AstNodeUniop* nodep) {
+    virtual void visit(AstNodeUniop* nodep) VL_OVERRIDE {
         emitVerilogFormat(nodep, nodep->emitVerilog(), nodep->lhsp());
     }
-    virtual void visit(AstNodeBiop* nodep) {
+    virtual void visit(AstNodeBiop* nodep) VL_OVERRIDE {
         emitVerilogFormat(nodep, nodep->emitVerilog(), nodep->lhsp(), nodep->rhsp());
     }
-    virtual void visit(AstNodeTriop* nodep) {
+    virtual void visit(AstNodeTriop* nodep) VL_OVERRIDE {
         emitVerilogFormat(nodep, nodep->emitVerilog(), nodep->lhsp(), nodep->rhsp(), nodep->thsp());
     }
-    virtual void visit(AstAttrOf* nodep) {
+    virtual void visit(AstAttrOf* nodep) VL_OVERRIDE {
         putfs(nodep, "$_ATTROF(");
         iterateAndNextNull(nodep->fromp());
         if (nodep->dimp()) {
@@ -465,7 +465,7 @@ class EmitVBaseVisitor : public EmitCBaseVisitor {
         }
         puts(")");
     }
-    virtual void visit(AstInitArray* nodep) {
+    virtual void visit(AstInitArray* nodep) VL_OVERRIDE {
         putfs(nodep, "`{");
         int comma = 0;
         const AstInitArray::KeyItemMap& mapr = nodep->map();
@@ -479,13 +479,13 @@ class EmitVBaseVisitor : public EmitCBaseVisitor {
         }
         puts("}");
     }
-    virtual void visit(AstNodeCond* nodep) {
+    virtual void visit(AstNodeCond* nodep) VL_OVERRIDE {
         putbs("(");
         iterateAndNextNull(nodep->condp()); putfs(nodep, " ? ");
         iterateAndNextNull(nodep->expr1p()); putbs(" : ");
         iterateAndNextNull(nodep->expr2p()); puts(")");
     }
-    virtual void visit(AstRange* nodep) {
+    virtual void visit(AstRange* nodep) VL_OVERRIDE {
         puts("[");
         if (VN_IS(nodep->msbp(), Const) && VN_IS(nodep->lsbp(), Const)) {
             // Looks nicer if we print [1:0] rather than [32'sh1:32sh0]
@@ -496,7 +496,7 @@ class EmitVBaseVisitor : public EmitCBaseVisitor {
             iterateAndNextNull(nodep->rightp()); puts("]");
         }
     }
-    virtual void visit(AstSel* nodep) {
+    virtual void visit(AstSel* nodep) VL_OVERRIDE {
         iterateAndNextNull(nodep->fromp()); puts("[");
         if (VN_IS(nodep->lsbp(), Const)) {
             if (nodep->widthp()->isOne()) {
@@ -518,44 +518,44 @@ class EmitVBaseVisitor : public EmitCBaseVisitor {
         }
         puts("]");
     }
-    virtual void visit(AstSliceSel* nodep) {
+    virtual void visit(AstSliceSel* nodep) VL_OVERRIDE {
         iterateAndNextNull(nodep->fromp());
         puts(cvtToStr(nodep->declRange()));
     }
-    virtual void visit(AstTypedef* nodep) {
+    virtual void visit(AstTypedef* nodep) VL_OVERRIDE {
         putfs(nodep, "typedef ");
         iterateAndNextNull(nodep->dtypep()); puts(" ");
         puts(nodep->prettyName());
         puts(";\n");
     }
-    virtual void visit(AstBasicDType* nodep) {
+    virtual void visit(AstBasicDType* nodep) VL_OVERRIDE {
         if (nodep->isSigned()) putfs(nodep, "signed ");
         putfs(nodep, nodep->prettyName());
         if (nodep->rangep()) { puts(" "); iterateAndNextNull(nodep->rangep()); puts(" "); }
         else if (nodep->isRanged()) { puts(" ["); puts(cvtToStr(nodep->msb())); puts(":0] "); }
     }
-    virtual void visit(AstConstDType* nodep) {
+    virtual void visit(AstConstDType* nodep) VL_OVERRIDE {
         putfs(nodep, "const ");
         iterate(nodep->subDTypep());
     }
-    virtual void visit(AstNodeArrayDType* nodep) {
+    virtual void visit(AstNodeArrayDType* nodep) VL_OVERRIDE {
         iterate(nodep->subDTypep());
         iterateAndNextNull(nodep->rangep());
     }
-    virtual void visit(AstNodeUOrStructDType* nodep) {
+    virtual void visit(AstNodeUOrStructDType* nodep) VL_OVERRIDE {
         puts(nodep->verilogKwd()+" ");
         if (nodep->packed()) puts("packed ");
         puts("\n");
         iterateAndNextNull(nodep->membersp());
         puts("}");
     }
-    virtual void visit(AstMemberDType* nodep) {
+    virtual void visit(AstMemberDType* nodep) VL_OVERRIDE {
         iterate(nodep->subDTypep());
         puts(" ");
         puts(nodep->name());
         puts("}");
     }
-    virtual void visit(AstNodeFTaskRef* nodep) {
+    virtual void visit(AstNodeFTaskRef* nodep) VL_OVERRIDE {
         if (nodep->dotted()!="") {
             putfs(nodep, nodep->dotted()); puts("."); puts(nodep->prettyName());
         } else { putfs(nodep, nodep->prettyName()); }
@@ -563,11 +563,11 @@ class EmitVBaseVisitor : public EmitCBaseVisitor {
         iterateAndNextNull(nodep->pinsp());
         puts(")");
     }
-    virtual void visit(AstArg* nodep) {
+    virtual void visit(AstArg* nodep) VL_OVERRIDE {
         iterateAndNextNull(nodep->exprp());
     }
     // Terminals
-    virtual void visit(AstVarRef* nodep) {
+    virtual void visit(AstVarRef* nodep) VL_OVERRIDE {
         if (nodep->varScopep()) {
             putfs(nodep, nodep->varScopep()->prettyName());
         } else {
@@ -575,43 +575,43 @@ class EmitVBaseVisitor : public EmitCBaseVisitor {
             puts(nodep->varp()->prettyName());
         }
     }
-    virtual void visit(AstVarXRef* nodep) {
+    virtual void visit(AstVarXRef* nodep) VL_OVERRIDE {
         putfs(nodep, nodep->dotted());
         puts(".");
         puts(nodep->varp()->prettyName());
     }
-    virtual void visit(AstConst* nodep) {
+    virtual void visit(AstConst* nodep) VL_OVERRIDE {
         putfs(nodep, nodep->num().ascii(true, true));
     }
 
     // Just iterate
-    virtual void visit(AstTopScope* nodep) {
+    virtual void visit(AstTopScope* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
     }
-    virtual void visit(AstScope* nodep) {
+    virtual void visit(AstScope* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
     }
-    virtual void visit(AstVar* nodep) {
+    virtual void visit(AstVar* nodep) VL_OVERRIDE {
         putfs(nodep, nodep->verilogKwd());
         puts(" ");
         iterate(nodep->dtypep()); puts(" ");
         puts(nodep->prettyName());
         if (!m_suppressVarSemi) puts(";\n"); else puts("\n");
     }
-    virtual void visit(AstActive* nodep) {
+    virtual void visit(AstActive* nodep) VL_OVERRIDE {
         m_sensesp = nodep->sensesp();
         iterateAndNextNull(nodep->stmtsp());
         m_sensesp = NULL;
     }
-    virtual void visit(AstVarScope*) {}
-    virtual void visit(AstNodeText*) {}
-    virtual void visit(AstTraceDecl*) {}
-    virtual void visit(AstTraceInc*) {}
+    virtual void visit(AstVarScope*) VL_OVERRIDE {}
+    virtual void visit(AstNodeText*) VL_OVERRIDE {}
+    virtual void visit(AstTraceDecl*) VL_OVERRIDE {}
+    virtual void visit(AstTraceInc*) VL_OVERRIDE {}
     // NOPs
-    virtual void visit(AstPragma*) {}
-    virtual void visit(AstCell*) {}  // Handled outside the Visit class
+    virtual void visit(AstPragma*) VL_OVERRIDE {}
+    virtual void visit(AstCell*) VL_OVERRIDE {}  // Handled outside the Visit class
     // Default
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         puts(string("\n???? // ")+nodep->prettyTypeName()+"\n");
         iterateChildren(nodep);
         // Not v3fatalSrc so we keep processing

--- a/src/V3EmitXml.cpp
+++ b/src/V3EmitXml.cpp
@@ -95,22 +95,22 @@ class EmitXmlFileVisitor : public AstNVisitor {
     }
 
     // VISITORS
-    virtual void visit(AstAssignW* nodep) {
+    virtual void visit(AstAssignW* nodep) VL_OVERRIDE {
         outputTag(nodep, "contassign");  // IEEE: vpiContAssign
         outputChildrenEnd(nodep, "contassign");
     }
-    virtual void visit(AstCell* nodep) {
+    virtual void visit(AstCell* nodep) VL_OVERRIDE {
         outputTag(nodep, "instance");  // IEEE: vpiInstance
         puts(" defName="); putsQuoted(nodep->modName());  // IEEE vpiDefName
         puts(" origName="); putsQuoted(nodep->origName());
         outputChildrenEnd(nodep, "instance");
     }
-    virtual void visit(AstNetlist* nodep) {
+    virtual void visit(AstNetlist* nodep) VL_OVERRIDE {
         puts("<netlist>\n");
         iterateChildren(nodep);
         puts("</netlist>\n");
     }
-    virtual void visit(AstNodeModule* nodep) {
+    virtual void visit(AstNodeModule* nodep) VL_OVERRIDE {
         outputTag(nodep, "");
         puts(" origName="); putsQuoted(nodep->origName());
         if (nodep->level()==1 || nodep->level()==2)  // ==2 because we don't add wrapper when in XML mode
@@ -118,7 +118,7 @@ class EmitXmlFileVisitor : public AstNVisitor {
         if (nodep->modPublic()) puts(" public=\"true\"");
         outputChildrenEnd(nodep, "");
     }
-    virtual void visit(AstVar* nodep) {
+    virtual void visit(AstVar* nodep) VL_OVERRIDE {
         AstVarType typ = nodep->varType();
         string kw = nodep->verilogKwd();
         string vt = nodep->dtypep()->name();
@@ -148,7 +148,7 @@ class EmitXmlFileVisitor : public AstNVisitor {
         if (nodep->attrSFormat()) puts(" sformat=\"true\"");
         outputChildrenEnd(nodep, "");
     }
-    virtual void visit(AstPin* nodep) {
+    virtual void visit(AstPin* nodep) VL_OVERRIDE {
         // What we call a pin in verilator is a port in the IEEE spec.
         outputTag(nodep, "port");  // IEEE: vpiPort
         if (nodep->modVarp()->isIO()) {
@@ -158,26 +158,26 @@ class EmitXmlFileVisitor : public AstNVisitor {
         // Children includes vpiHighConn and vpiLowConn; we don't support port bits (yet?)
         outputChildrenEnd(nodep, "port");
     }
-    virtual void visit(AstSenItem* nodep) {
+    virtual void visit(AstSenItem* nodep) VL_OVERRIDE {
         outputTag(nodep, "");
         puts(" edgeType=\""+cvtToStr(nodep->edgeType().ascii())+"\"");  // IEEE vpiTopModule
         outputChildrenEnd(nodep, "");
     }
-    virtual void visit(AstModportVarRef* nodep) {
+    virtual void visit(AstModportVarRef* nodep) VL_OVERRIDE {
         // Dump direction for Modport references
         string kw = nodep->direction().xmlKwd();
         outputTag(nodep, "");
         puts(" direction="); putsQuoted(kw);
         outputChildrenEnd(nodep, "");
     }
-    virtual void visit(AstVarXRef* nodep) {
+    virtual void visit(AstVarXRef* nodep) VL_OVERRIDE {
         outputTag(nodep, "");
         puts(" dotted="); putsQuoted(nodep->dotted());
         outputChildrenEnd(nodep, "");
     }
 
     // Data types
-    virtual void visit(AstBasicDType* nodep) {
+    virtual void visit(AstBasicDType* nodep) VL_OVERRIDE {
         outputTag(nodep, "basicdtype");
         if (nodep->isRanged()) {
             puts(" left=\""+cvtToStr(nodep->left())+"\"");
@@ -185,30 +185,30 @@ class EmitXmlFileVisitor : public AstNVisitor {
         }
         puts("/>\n");
     }
-    virtual void visit(AstIfaceRefDType* nodep) {
+    virtual void visit(AstIfaceRefDType* nodep) VL_OVERRIDE {
         string mpn;
         outputTag(nodep, "");
         if (nodep->isModport()) mpn = nodep->modportName();
         puts(" modportname="); putsQuoted(mpn);
         outputChildrenEnd(nodep, "");
     }
-    virtual void visit(AstDisplay* nodep) {
+    virtual void visit(AstDisplay* nodep) VL_OVERRIDE {
         outputTag(nodep, "");
         puts(" displaytype="); putsQuoted(nodep->verilogKwd());
         outputChildrenEnd(nodep, "");
     }
-    virtual void visit(AstElabDisplay* nodep) {
+    virtual void visit(AstElabDisplay* nodep) VL_OVERRIDE {
         outputTag(nodep, "");
         puts(" displaytype="); putsQuoted(nodep->verilogKwd());
         outputChildrenEnd(nodep, "");
     }
-    virtual void visit(AstExtend* nodep) {
+    virtual void visit(AstExtend* nodep) VL_OVERRIDE {
         outputTag(nodep, "");
         puts(" width="); putsQuoted(cvtToStr(nodep->width()));
         puts(" widthminv="); putsQuoted(cvtToStr(nodep->lhsp()->widthMinV()));
         outputChildrenEnd(nodep, "");
     }
-    virtual void visit(AstExtendS* nodep) {
+    virtual void visit(AstExtendS* nodep) VL_OVERRIDE {
         outputTag(nodep, "");
         puts(" width="); putsQuoted(cvtToStr(nodep->width()));
         puts(" widthminv="); putsQuoted(cvtToStr(nodep->lhsp()->widthMinV()));
@@ -216,7 +216,7 @@ class EmitXmlFileVisitor : public AstNVisitor {
     }
 
     // Default
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         outputTag(nodep, "");
         outputChildrenEnd(nodep, "");
     }
@@ -243,11 +243,11 @@ private:
     VL_DEBUG_FUNC;  // Declare debug()
 
     // VISITORS
-    virtual void visit(AstNetlist* nodep) {
+    virtual void visit(AstNetlist* nodep) VL_OVERRIDE {
         // Children are iterated backwards to ensure correct compilation order
         iterateChildrenBackwards(nodep);
     }
-    virtual void visit(AstNodeModule* nodep) {
+    virtual void visit(AstNodeModule* nodep) VL_OVERRIDE {
         // Only list modules and interfaces
         // Assumes modules and interfaces list is already sorted level wise
         if (!nodep->dead()
@@ -257,7 +257,7 @@ private:
         }
     }
     //-----
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         // All modules are present at root so no need to iterate on children
     }
 
@@ -294,7 +294,7 @@ private:
     VL_DEBUG_FUNC;  // Declare debug()
 
     // VISITORS
-    virtual void visit(AstNodeModule* nodep) {
+    virtual void visit(AstNodeModule* nodep) VL_OVERRIDE {
         if (nodep->level() >= 0
             && nodep->level() <=2 ) {  // ==2 because we don't add wrapper when in XML mode
             m_os<<"<cells>\n";
@@ -313,7 +313,7 @@ private:
             m_os<<"</cells>\n";
         }
     }
-    virtual void visit(AstCell* nodep) {
+    virtual void visit(AstCell* nodep) VL_OVERRIDE {
         if (nodep->modp()->dead()) {
             return;
         }
@@ -335,7 +335,7 @@ private:
         m_hasChildren = true;
     }
     //-----
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
     }
 

--- a/src/V3Expand.cpp
+++ b/src/V3Expand.cpp
@@ -306,7 +306,7 @@ private:
     }
 
     // VISITORS
-    virtual void visit(AstExtend* nodep) {
+    virtual void visit(AstExtend* nodep) VL_OVERRIDE {
         if (nodep->user1SetOnce()) return;  // Process once
         iterateChildren(nodep);
         if (nodep->isWide()) {
@@ -343,7 +343,7 @@ private:
         return true;
     }
 
-    virtual void visit(AstSel* nodep) {
+    virtual void visit(AstSel* nodep) VL_OVERRIDE {
         if (nodep->user1SetOnce()) return;  // Process once
         iterateChildren(nodep);
         // Remember, Sel's may have non-integer rhs, so need to optimize for that!
@@ -670,7 +670,7 @@ private:
         }
     }
 
-    virtual void visit(AstConcat* nodep) {
+    virtual void visit(AstConcat* nodep) VL_OVERRIDE {
         if (nodep->user1SetOnce()) return;  // Process once
         iterateChildren(nodep);
         if (nodep->isWide()) {
@@ -714,7 +714,7 @@ private:
         return true;
     }
 
-    virtual void visit(AstReplicate* nodep) {
+    virtual void visit(AstReplicate* nodep) VL_OVERRIDE {
         if (nodep->user1SetOnce()) return;  // Process once
         iterateChildren(nodep);
         if (nodep->isWide()) {
@@ -779,7 +779,7 @@ private:
         return true;
     }
 
-    virtual void visit(AstChangeXor* nodep) {
+    virtual void visit(AstChangeXor* nodep) VL_OVERRIDE {
         if (nodep->user1SetOnce()) return;  // Process once
         iterateChildren(nodep);
         UINFO(8,"    Wordize ChangeXor "<<nodep<<endl);
@@ -819,10 +819,10 @@ private:
             VL_DO_DANGLING(replaceWithDelete(nodep, newp), nodep);
         }
     }
-    virtual void visit(AstEq* nodep) { visitEqNeq(nodep); }
-    virtual void visit(AstNeq* nodep) { visitEqNeq(nodep); }
+    virtual void visit(AstEq* nodep) VL_OVERRIDE { visitEqNeq(nodep); }
+    virtual void visit(AstNeq* nodep) VL_OVERRIDE { visitEqNeq(nodep); }
 
-    virtual void visit(AstRedOr* nodep) {
+    virtual void visit(AstRedOr* nodep) VL_OVERRIDE {
         if (nodep->user1SetOnce()) return;  // Process once
         iterateChildren(nodep);
         if (nodep->lhsp()->isWide()) {
@@ -847,7 +847,7 @@ private:
             VL_DO_DANGLING(replaceWithDelete(nodep, newp), nodep);
         }
     }
-    virtual void visit(AstRedAnd* nodep) {
+    virtual void visit(AstRedAnd* nodep) VL_OVERRIDE {
         if (nodep->user1SetOnce()) return;  // Process once
         iterateChildren(nodep);
         if (nodep->lhsp()->isWide()) {
@@ -880,7 +880,7 @@ private:
             VL_DO_DANGLING(replaceWithDelete(nodep, newp), nodep);
         }
     }
-    virtual void visit(AstRedXor* nodep) {
+    virtual void visit(AstRedXor* nodep) VL_OVERRIDE {
         if (nodep->user1SetOnce()) return;  // Process once
         iterateChildren(nodep);
         if (nodep->lhsp()->isWide()) {
@@ -899,7 +899,7 @@ private:
         // which the inlined function does nicely.
     }
 
-    virtual void visit(AstNodeStmt* nodep) {
+    virtual void visit(AstNodeStmt* nodep) VL_OVERRIDE {
         if (nodep->user1SetOnce()) return;  // Process once
         if (!nodep->isStatement()) {
             iterateChildren(nodep);
@@ -909,7 +909,7 @@ private:
         iterateChildren(nodep);
         m_stmtp = NULL;
     }
-    virtual void visit(AstNodeAssign* nodep) {
+    virtual void visit(AstNodeAssign* nodep) VL_OVERRIDE {
         if (nodep->user1SetOnce()) return;  // Process once
         m_stmtp = nodep;
         iterateChildren(nodep);
@@ -955,8 +955,8 @@ private:
 
     //--------------------
     // Default: Just iterate
-    virtual void visit(AstVar*) {}  // Don't hit varrefs under vars
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstVar*) VL_OVERRIDE {}  // Don't hit varrefs under vars
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
     }
 

--- a/src/V3Gate.cpp
+++ b/src/V3Gate.cpp
@@ -207,7 +207,7 @@ private:
         }
     }
     // VISITORS
-    virtual void visit(AstNodeVarRef* nodep) {
+    virtual void visit(AstNodeVarRef* nodep) VL_OVERRIDE {
         ++m_ops;
         iterateChildren(nodep);
         // We only allow a LHS ref for the var being set, and a RHS ref for
@@ -235,7 +235,7 @@ private:
             m_rhsVarRefs.push_back(nodep);
         }
     }
-    virtual void visit(AstNodeAssign* nodep) {
+    virtual void visit(AstNodeAssign* nodep) VL_OVERRIDE {
         m_substTreep = nodep->rhsp();
         if (!VN_IS(nodep->lhsp(), NodeVarRef)) {
             clearSimple("ASSIGN(non-VARREF)");
@@ -258,7 +258,7 @@ private:
     }
     //--------------------
     // Default
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         // *** Special iterator
         if (!m_isSimple) return;  // Fastpath
         if (++m_ops > v3Global.opt.gateStmts()) {
@@ -388,7 +388,7 @@ private:
     void decomposeClkVectors();
 
     // VISITORS
-    virtual void visit(AstNetlist* nodep) {
+    virtual void visit(AstNetlist* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         //if (debug()>6) m_graph.dump();
         if (debug()>6) m_graph.dumpDotFilePrefixed("gate_pre");
@@ -419,7 +419,7 @@ private:
         consumedMove();
         replaceAssigns();
     }
-    virtual void visit(AstNodeModule* nodep) {
+    virtual void visit(AstNodeModule* nodep) VL_OVERRIDE {
         AstNodeModule* origModp = m_modp;
         {
             m_modp = nodep;
@@ -428,14 +428,14 @@ private:
         }
         m_modp = origModp;
     }
-    virtual void visit(AstScope* nodep) {
+    virtual void visit(AstScope* nodep) VL_OVERRIDE {
         UINFO(4," SCOPE "<<nodep<<endl);
         m_scopep = nodep;
         m_logicVertexp = NULL;
         iterateChildren(nodep);
         m_scopep = NULL;
     }
-    virtual void visit(AstActive* nodep) {
+    virtual void visit(AstActive* nodep) VL_OVERRIDE {
         // Create required blocks and add to module
         UINFO(4,"  BLOCK  "<<nodep<<endl);
         m_activeReducible = !(nodep->hasClocked());  // Seq logic outputs aren't reducible
@@ -446,7 +446,7 @@ private:
         m_activep = NULL;
         m_activeReducible = true;
     }
-    virtual void visit(AstNodeVarRef* nodep) {
+    virtual void visit(AstNodeVarRef* nodep) VL_OVERRIDE {
         if (m_scopep) {
             UASSERT_OBJ(m_logicVertexp, nodep, "Var ref not under a logic block");
             AstVarScope* varscp = nodep->varScopep();
@@ -472,19 +472,19 @@ private:
             }
         }
     }
-    virtual void visit(AstAlways* nodep) {
+    virtual void visit(AstAlways* nodep) VL_OVERRIDE {
         iterateNewStmt(nodep, (nodep->isJustOneBodyStmt()?NULL:"Multiple Stmts"), NULL);
     }
-    virtual void visit(AstAlwaysPublic* nodep) {
+    virtual void visit(AstAlwaysPublic* nodep) VL_OVERRIDE {
         bool lastslow = m_inSlow;
         m_inSlow = true;
         iterateNewStmt(nodep, "AlwaysPublic", NULL);
         m_inSlow = lastslow;
     }
-    virtual void visit(AstCFunc* nodep) {
+    virtual void visit(AstCFunc* nodep) VL_OVERRIDE {
         iterateNewStmt(nodep, "User C Function", "User C Function");
     }
-    virtual void visit(AstSenItem* nodep) {
+    virtual void visit(AstSenItem* nodep) VL_OVERRIDE {
         // Note we look at only AstSenItems, not AstSenGate's
         // The gating term of a AstSenGate is normal logic
         m_inSenItem = true;
@@ -495,33 +495,33 @@ private:
         }
         m_inSenItem = false;
     }
-    virtual void visit(AstSenGate* nodep) {
+    virtual void visit(AstSenGate* nodep) VL_OVERRIDE {
         // First handle the clock part will be handled in a minute by visit AstSenItem
         // The logic gating term is dealt with as logic
         iterateNewStmt(nodep, "Clock gater", "Clock gater");
     }
-    virtual void visit(AstInitial* nodep) {
+    virtual void visit(AstInitial* nodep) VL_OVERRIDE {
         bool lastslow = m_inSlow;
         m_inSlow = true;
         iterateNewStmt(nodep, (nodep->isJustOneBodyStmt()?NULL:"Multiple Stmts"), NULL);
         m_inSlow = lastslow;
     }
-    virtual void visit(AstAssignAlias* nodep) {
+    virtual void visit(AstAssignAlias* nodep) VL_OVERRIDE {
         iterateNewStmt(nodep, NULL, NULL);
     }
-    virtual void visit(AstAssignW* nodep) {
+    virtual void visit(AstAssignW* nodep) VL_OVERRIDE {
         iterateNewStmt(nodep, NULL, NULL);
     }
-    virtual void visit(AstCoverToggle* nodep) {
+    virtual void visit(AstCoverToggle* nodep) VL_OVERRIDE {
         iterateNewStmt(nodep, "CoverToggle", "CoverToggle");
     }
-    virtual void visit(AstTraceInc* nodep) {
+    virtual void visit(AstTraceInc* nodep) VL_OVERRIDE {
         bool lastslow = m_inSlow;
         m_inSlow = true;
         iterateNewStmt(nodep, "Tracing", "Tracing");
         m_inSlow = lastslow;
     }
-    virtual void visit(AstConcat* nodep) {
+    virtual void visit(AstConcat* nodep) VL_OVERRIDE {
         UASSERT_OBJ(!(VN_IS(nodep->backp(), NodeAssign)
                       && VN_CAST(nodep->backp(), NodeAssign)->lhsp()==nodep),
                     nodep, "Concat on LHS of assignment; V3Const should have deleted it");
@@ -530,7 +530,7 @@ private:
 
     //--------------------
     // Default
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         if (nodep->isOutputter() && m_logicVertexp) m_logicVertexp->setConsumed("outputter");
     }
@@ -863,7 +863,7 @@ private:
     void hashReplace(AstNode* oldp, AstNode* newp);
 
     // VISITORS
-    virtual void visit(AstNodeVarRef* nodep) {
+    virtual void visit(AstNodeVarRef* nodep) VL_OVERRIDE {
         if (nodep->varScopep() == m_elimVarScp) {
             // Substitute in the new tree
             // It's possible we substitute into something that will be reduced more later,
@@ -890,7 +890,7 @@ private:
             VL_DO_DANGLING(nodep->deleteTree(), nodep);
         }
     }
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
     }
 public:
@@ -1069,7 +1069,7 @@ private:
     bool                m_dedupable;            // Determined the assign to be dedupable
 
     // VISITORS
-    virtual void visit(AstNodeAssign* assignp) {
+    virtual void visit(AstNodeAssign* assignp) VL_OVERRIDE {
         if (m_dedupable) {
             // I think we could safely dedupe an always block with multiple
             // non-blocking statements, but erring on side of caution here
@@ -1080,7 +1080,7 @@ private:
             }
         }
     }
-    virtual void visit(AstAlways* alwaysp) {
+    virtual void visit(AstAlways* alwaysp) VL_OVERRIDE {
         if (m_dedupable) {
             if (!m_always) {
                 m_always = true;
@@ -1094,7 +1094,7 @@ private:
     //  always @(...)
     //    if (...)
     //       foo = ...; // or foo <= ...;
-    virtual void visit(AstNodeIf* ifp) {
+    virtual void visit(AstNodeIf* ifp) VL_OVERRIDE {
         if (m_dedupable) {
             if (m_always && !m_ifCondp && !ifp->elsesp()) {  //we're under an always, this is the first IF,  and there's no else
                 m_ifCondp = ifp->condp();
@@ -1105,10 +1105,10 @@ private:
         }
     }
 
-    virtual void visit(AstComment*) {}  // NOP
+    virtual void visit(AstComment*) VL_OVERRIDE {}  // NOP
     //--------------------
     // Default
-    virtual void visit(AstNode*) {
+    virtual void visit(AstNode*) VL_OVERRIDE {
         m_dedupable = false;
     }
 
@@ -1428,7 +1428,7 @@ private:
     bool                m_found;        // Offset found
 
     // VISITORS
-    virtual void visit(AstNodeVarRef* nodep) {
+    virtual void visit(AstNodeVarRef* nodep) VL_OVERRIDE {
         UINFO(9,"CLK DECOMP Concat search var (off = "<<m_offset<<") - "<<nodep<<endl);
         if (nodep->varScopep() == m_vscp && !nodep->user2() && !m_found) {
             // A concatenation may use the same var multiple times
@@ -1440,14 +1440,14 @@ private:
         }
         m_offset += nodep->dtypep()->width();
     }
-    virtual void visit(AstConcat* nodep) {
+    virtual void visit(AstConcat* nodep) VL_OVERRIDE {
         UINFO(9,"CLK DECOMP Concat search (off = "<<m_offset<<") - "<<nodep<<endl);
         iterate(nodep->rhsp());
         iterate(nodep->lhsp());
     }
     //--------------------
     // Default
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
     }
 public:
@@ -1620,7 +1620,7 @@ void GateVisitor::decomposeClkVectors() {
 class GateDeassignVisitor : public GateBaseVisitor {
 private:
     // VISITORS
-    virtual void visit(AstVarScope* nodep) {
+    virtual void visit(AstVarScope* nodep) VL_OVERRIDE {
         if (AstNodeAssign* assp = VN_CAST(nodep->valuep(), NodeAssign)) {
             UINFO(5," Removeassign "<<assp<<endl);
             AstNode* valuep = assp->rhsp();
@@ -1630,9 +1630,9 @@ private:
         }
     }
     // Speedups
-    virtual void visit(AstVar* nodep) {}
-    virtual void visit(AstActive* nodep) {}
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstVar* nodep) VL_OVERRIDE {}
+    virtual void visit(AstActive* nodep) VL_OVERRIDE {}
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
     }
 

--- a/src/V3GenClk.cpp
+++ b/src/V3GenClk.cpp
@@ -83,7 +83,7 @@ private:
     }
 
     // VISITORS
-    virtual void visit(AstTopScope* nodep) {
+    virtual void visit(AstTopScope* nodep) VL_OVERRIDE {
         AstNode::user2ClearTree();  // user2p() used on entire tree
 
         AstScope* scopep = nodep->scopep();
@@ -93,7 +93,7 @@ private:
         iterateChildren(nodep);
     }
     //----
-    virtual void visit(AstVarRef* nodep) {
+    virtual void visit(AstVarRef* nodep) VL_OVERRIDE {
         // Consumption/generation of a variable,
         AstVarScope* vscp = nodep->varScopep();
         UASSERT_OBJ(vscp, nodep, "Scope not assigned");
@@ -109,19 +109,19 @@ private:
             }
         }
     }
-    virtual void visit(AstActive* nodep) {
+    virtual void visit(AstActive* nodep) VL_OVERRIDE {
         m_activep = nodep;
         UASSERT_OBJ(nodep->sensesp(), nodep, "Unlinked");
         iterateChildren(nodep->sensesp());  // iterateAndNext?
         m_activep = NULL;
         iterateChildren(nodep);
     }
-    virtual void visit(AstCFunc* nodep) {
+    virtual void visit(AstCFunc* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
     }
 
     //-----
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
     }
 public:
@@ -152,7 +152,7 @@ private:
     AstNodeModule* m_topModp;   // Top module
 
     // VISITORS
-    virtual void visit(AstTopScope* nodep) {
+    virtual void visit(AstTopScope* nodep) VL_OVERRIDE {
         AstNode::user1ClearTree();  // user1p() used on entire tree
         iterateChildren(nodep);
         {
@@ -161,14 +161,14 @@ private:
             GenClkRenameVisitor visitor (nodep, m_topModp);
         }
     }
-    virtual void visit(AstNodeModule* nodep) {
+    virtual void visit(AstNodeModule* nodep) VL_OVERRIDE {
         // Only track the top scopes, not lower level functions
         if (nodep->isTop()) {
             m_topModp = nodep;
             iterateChildren(nodep);
         }
     }
-    virtual void visit(AstCCall* nodep) {
+    virtual void visit(AstCCall* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         if (!nodep->funcp()->entryPoint()) {
             // Enter the function and trace it
@@ -176,7 +176,7 @@ private:
             iterate(nodep->funcp());
         }
     }
-    virtual void visit(AstCFunc* nodep) {
+    virtual void visit(AstCFunc* nodep) VL_OVERRIDE {
         if (!m_tracingCall && !nodep->entryPoint()) {
             // Only consider logic within a CFunc when looking
             // at the call to it, and not when scanning whatever
@@ -188,7 +188,7 @@ private:
     }
     //----
 
-    virtual void visit(AstVarRef* nodep) {
+    virtual void visit(AstVarRef* nodep) VL_OVERRIDE {
         // Consumption/generation of a variable,
         AstVarScope* vscp = nodep->varScopep();
         UASSERT_OBJ(vscp, nodep, "Scope not assigned");
@@ -203,13 +203,13 @@ private:
             vscp->circular(true);
         }
     }
-    virtual void visit(AstNodeAssign* nodep) {
+    virtual void visit(AstNodeAssign* nodep) VL_OVERRIDE {
         //UINFO(8,"ASS "<<nodep<<endl);
         m_assignp = nodep;
         iterateChildren(nodep);
         m_assignp = NULL;
     }
-    virtual void visit(AstActive* nodep) {
+    virtual void visit(AstActive* nodep) VL_OVERRIDE {
         UINFO(8,"ACTIVE "<<nodep<<endl);
         m_activep = nodep;
         UASSERT_OBJ(nodep->sensesp(), nodep, "Unlinked");
@@ -219,8 +219,8 @@ private:
     }
 
     //-----
-    virtual void visit(AstVar*) {}  // Don't want varrefs under it
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstVar*) VL_OVERRIDE {}  // Don't want varrefs under it
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
     }
 public:

--- a/src/V3Hashed.cpp
+++ b/src/V3Hashed.cpp
@@ -88,10 +88,10 @@ private:
 
     //--------------------
     // Default: Just iterate
-    virtual void visit(AstVar*) {}
-    virtual void visit(AstTypedef*) {}
-    virtual void visit(AstParamTypeDType*) {}
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstVar*) VL_OVERRIDE {}
+    virtual void visit(AstTypedef*) VL_OVERRIDE {}
+    virtual void visit(AstParamTypeDType*) VL_OVERRIDE {}
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         nodeHashIterate(nodep);
     }
 

--- a/src/V3Inline.cpp
+++ b/src/V3Inline.cpp
@@ -100,7 +100,7 @@ private:
     }
 
     // VISITORS
-    virtual void visit(AstNodeModule* nodep) {
+    virtual void visit(AstNodeModule* nodep) VL_OVERRIDE {
         UASSERT_OBJ(!m_modp, nodep, "Unsupported: Recursive modules");
         m_modp = nodep;
         m_allMods.push_back(nodep);
@@ -116,12 +116,12 @@ private:
         iterateChildren(nodep);
         m_modp = NULL;
     }
-    virtual void visit(AstCell* nodep) {
+    virtual void visit(AstCell* nodep) VL_OVERRIDE {
         nodep->modp()->user3Inc();  // Inc refs
         m_instances[m_modp][nodep->modp()]++;
         iterateChildren(nodep);
     }
-    virtual void visit(AstPragma* nodep) {
+    virtual void visit(AstPragma* nodep) VL_OVERRIDE {
         if (nodep->pragType() == AstPragmaType::INLINE_MODULE) {
             //UINFO(0,"PRAG MARK "<<m_modp<<endl);
             if (!m_modp) {
@@ -144,27 +144,27 @@ private:
             iterateChildren(nodep);
         }
     }
-    virtual void visit(AstVarXRef* nodep) {
+    virtual void visit(AstVarXRef* nodep) VL_OVERRIDE {
         // Cleanup link until V3LinkDot can correct it
         nodep->varp(NULL);
     }
-    virtual void visit(AstNodeFTaskRef* nodep) {
+    virtual void visit(AstNodeFTaskRef* nodep) VL_OVERRIDE {
         // Cleanup link until V3LinkDot can correct it
         if (!nodep->packagep()) nodep->taskp(NULL);
         iterateChildren(nodep);
     }
-    virtual void visit(AstAlways* nodep) {
+    virtual void visit(AstAlways* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         m_modp->user4Inc();  // statement count
     }
-    virtual void visit(AstNodeAssign* nodep) {
+    virtual void visit(AstNodeAssign* nodep) VL_OVERRIDE {
         // Don't count assignments, as they'll likely flatten out
         // Still need to iterate though to nullify VarXRefs
         int oldcnt = m_modp->user4();
         iterateChildren(nodep);
         m_modp->user4(oldcnt);
     }
-    virtual void visit(AstNetlist* nodep) {
+    virtual void visit(AstNetlist* nodep) VL_OVERRIDE {
         // Build user2, user3, and user4 for all modules.
         // Also build m_allMods and m_instances.
         iterateChildren(nodep);
@@ -207,7 +207,7 @@ private:
     }
     //--------------------
     // Default: Just iterate
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         if (m_modp) {
             m_modp->user4Inc();  // Inc statement count
@@ -243,13 +243,13 @@ private:
     VL_DEBUG_FUNC;  // Declare debug()
 
     // VISITORS
-    virtual void visit(AstCell* nodep) {
+    virtual void visit(AstCell* nodep) VL_OVERRIDE {
         nodep->user4p(nodep->clonep());
     }
     // Accelerate
-    virtual void visit(AstNodeStmt* nodep) {}
-    virtual void visit(AstNodeMath* nodep) {}
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNodeStmt* nodep) VL_OVERRIDE {}
+    virtual void visit(AstNodeMath* nodep) VL_OVERRIDE {}
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
     }
 
@@ -281,7 +281,7 @@ private:
     VL_DEBUG_FUNC;  // Declare debug()
 
     // VISITORS
-    virtual void visit(AstCellInline* nodep) {
+    virtual void visit(AstCellInline* nodep) VL_OVERRIDE {
         // Inlined cell under the inline cell, need to move to avoid conflicts
         nodep->unlinkFrBack();
         m_modp->addInlinesp(nodep);
@@ -292,17 +292,17 @@ private:
         // Do CellInlines under this, but don't move them
         iterateChildren(nodep);
     }
-    virtual void visit(AstCell* nodep) {
+    virtual void visit(AstCell* nodep) VL_OVERRIDE {
         // Cell under the inline cell, need to rename to avoid conflicts
         string name = m_cellp->name() + "__DOT__" + nodep->name();
         nodep->name(name);
         iterateChildren(nodep);
     }
-    virtual void visit(AstModule* nodep) {
+    virtual void visit(AstModule* nodep) VL_OVERRIDE {
         m_renamedInterfaces.clear();
         iterateChildren(nodep);
     }
-    virtual void visit(AstVar* nodep) {
+    virtual void visit(AstVar* nodep) VL_OVERRIDE {
         if (nodep->user2p()) {
             // Make an assignment, so we'll trace it properly
             // user2p is either a const or a var.
@@ -386,17 +386,17 @@ private:
         if (debug()>=9 && nodep->valuep()) { nodep->valuep()->dumpTree(cout, "varchangei:"); }
         iterateChildren(nodep);
     }
-    virtual void visit(AstNodeFTask* nodep) {
+    virtual void visit(AstNodeFTask* nodep) VL_OVERRIDE {
         // Function under the inline cell, need to rename to avoid conflicts
         nodep->name(m_cellp->name() + "__DOT__" + nodep->name());
         iterateChildren(nodep);
     }
-    virtual void visit(AstTypedef* nodep) {
+    virtual void visit(AstTypedef* nodep) VL_OVERRIDE {
         // Typedef under the inline cell, need to rename to avoid conflicts
         nodep->name(m_cellp->name() + "__DOT__" + nodep->name());
         iterateChildren(nodep);
     }
-    virtual void visit(AstVarRef* nodep) {
+    virtual void visit(AstVarRef* nodep) VL_OVERRIDE {
         if (nodep->varp()->user2p()  // It's being converted to an alias.
             && !nodep->varp()->user3()
             && !VN_IS(nodep->backp(), AssignAlias)) {  // Don't constant propagate aliases (we just made)
@@ -417,7 +417,7 @@ private:
         nodep->name(nodep->varp()->name());
         iterateChildren(nodep);
     }
-    virtual void visit(AstVarXRef* nodep) {
+    virtual void visit(AstVarXRef* nodep) VL_OVERRIDE {
         // Track what scope it was originally under so V3LinkDot can resolve it
         string newdots = VString::dot(m_cellp->name(), ".", nodep->inlinedDots());
         nodep->inlinedDots(newdots);
@@ -436,7 +436,7 @@ private:
         }
         iterateChildren(nodep);
     }
-    virtual void visit(AstNodeFTaskRef* nodep) {
+    virtual void visit(AstNodeFTaskRef* nodep) VL_OVERRIDE {
         // Track what scope it was originally under so V3LinkDot can resolve it
         string newdots = VString::dot(m_cellp->name(), ".", nodep->inlinedDots());
         nodep->inlinedDots(newdots);
@@ -448,9 +448,9 @@ private:
     }
 
     // Not needed, as V3LinkDot doesn't care about typedefs
-    //virtual void visit(AstRefDType* nodep) {}
+    //virtual void visit(AstRefDType* nodep) VL_OVERRIDE {}
 
-    virtual void visit(AstScopeName* nodep) {
+    virtual void visit(AstScopeName* nodep) VL_OVERRIDE {
         // If there's a %m in the display text, we add a special node that will contain the name()
         // Similar code in V3Begin
         // To keep correct visual order, must add before other Text's
@@ -464,12 +464,12 @@ private:
         if (afterp) nodep->scopeEntrp(afterp);
         iterateChildren(nodep);
     }
-    virtual void visit(AstCoverDecl* nodep) {
+    virtual void visit(AstCoverDecl* nodep) VL_OVERRIDE {
         // Fix path in coverage statements
         nodep->hier(VString::dot(m_cellp->prettyName(), ".", nodep->hier()));
         iterateChildren(nodep);
     }
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
     }
 
@@ -513,11 +513,11 @@ private:
     VL_DEBUG_FUNC;  // Declare debug()
 
     // VISITORS
-    virtual void visit(AstNetlist* nodep) {
+    virtual void visit(AstNetlist* nodep) VL_OVERRIDE {
         // Iterate modules backwards, in bottom-up order.  Required!
         iterateChildrenBackwards(nodep);
     }
-    virtual void visit(AstIfaceRefDType* nodep) {
+    virtual void visit(AstIfaceRefDType* nodep) VL_OVERRIDE {
         if (nodep->user5()) {
             // The cell has been removed so let's make sure we don't leave a reference to it
             // This dtype may still be in use by the AstAssignVarScope created earlier
@@ -525,7 +525,7 @@ private:
             nodep->cellp(NULL);
         }
     }
-    virtual void visit(AstNodeModule* nodep) {
+    virtual void visit(AstNodeModule* nodep) VL_OVERRIDE {
         AstNodeModule* origModp = m_modp;
         {
             m_modp = nodep;
@@ -533,7 +533,7 @@ private:
         }
         m_modp = origModp;
     }
-    virtual void visit(AstCell* nodep) {
+    virtual void visit(AstCell* nodep) VL_OVERRIDE {
         if (nodep->modp()->user1()) {  // Marked with inline request
             UINFO(5," Inline CELL   "<<nodep<<endl);
             UINFO(5,"   To MOD      "<<m_modp<<endl);
@@ -612,9 +612,9 @@ private:
     }
 
     //--------------------
-    virtual void visit(AstNodeMath* nodep) {}  // Accelerate
-    virtual void visit(AstNodeStmt* nodep) {}  // Accelerate
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNodeMath* nodep) VL_OVERRIDE {}  // Accelerate
+    virtual void visit(AstNodeStmt* nodep) VL_OVERRIDE {}  // Accelerate
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
     }
 
@@ -645,17 +645,17 @@ private:
     VL_DEBUG_FUNC;  // Declare debug()
 
     // VISITORS
-    virtual void visit(AstNetlist* nodep) {
+    virtual void visit(AstNetlist* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
     }
 
-    virtual void visit(AstModule* nodep) {
+    virtual void visit(AstModule* nodep) VL_OVERRIDE {
         if (nodep->isTop()) {
             iterateChildren(nodep);
         }
     }
 
-    virtual void visit(AstCell* nodep) {
+    virtual void visit(AstCell* nodep) VL_OVERRIDE {
         string oldScope = m_scope;
         if (m_scope.empty()) {
             m_scope = nodep->name();
@@ -691,7 +691,7 @@ private:
         m_scope = oldScope;
     }
 
-    virtual void visit(AstAssignVarScope* nodep) {
+    virtual void visit(AstAssignVarScope* nodep) VL_OVERRIDE {
         // Reference
         AstVarRef* reflp = VN_CAST(nodep->lhsp(), VarRef);
         // What the reference refers to
@@ -717,9 +717,9 @@ private:
     }
 
     //--------------------
-    virtual void visit(AstNodeMath*) {}  // Accelerate
-    virtual void visit(AstNodeStmt*) {}  // Accelerate
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNodeMath*) VL_OVERRIDE {}  // Accelerate
+    virtual void visit(AstNodeStmt*) VL_OVERRIDE {}  // Accelerate
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
     }
 

--- a/src/V3Inst.cpp
+++ b/src/V3Inst.cpp
@@ -54,7 +54,7 @@ private:
     VL_DEBUG_FUNC;  // Declare debug()
 
     // VISITORS
-    virtual void visit(AstCell* nodep) {
+    virtual void visit(AstCell* nodep) VL_OVERRIDE {
         UINFO(4,"  CELL   "<<nodep<<endl);
         m_cellp = nodep;
         //VV*****  We reset user1p() on each cell!!!
@@ -62,7 +62,7 @@ private:
         iterateChildren(nodep);
         m_cellp = NULL;
     }
-    virtual void visit(AstPin* nodep) {
+    virtual void visit(AstPin* nodep) VL_OVERRIDE {
         // PIN(p,expr) -> ASSIGNW(VARXREF(p),expr)    (if sub's input)
         //            or  ASSIGNW(expr,VARXREF(p))    (if sub's output)
         UINFO(4,"   PIN  "<<nodep<<endl);
@@ -116,7 +116,7 @@ private:
         VL_DO_DANGLING(nodep->unlinkFrBack()->deleteTree(), nodep);
     }
 
-    virtual void visit(AstUdpTable* nodep) {
+    virtual void visit(AstUdpTable* nodep) VL_OVERRIDE {
         if (!v3Global.opt.bboxUnsup()) {
             // If we support primitives, update V3Undriven to remove special case
             nodep->v3error("Unsupported: Verilog 1995 UDP Tables.  Use --bbox-unsup to ignore tables.");
@@ -124,13 +124,13 @@ private:
     }
 
     // Save some time
-    virtual void visit(AstNodeMath*) {}
-    virtual void visit(AstNodeAssign*) {}
-    virtual void visit(AstAlways*) {}
+    virtual void visit(AstNodeMath*) VL_OVERRIDE {}
+    virtual void visit(AstNodeAssign*) VL_OVERRIDE {}
+    virtual void visit(AstAlways*) VL_OVERRIDE {}
 
     //--------------------
     // Default: Just iterate
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
     }
 public:
@@ -155,7 +155,7 @@ private:
     VL_DEBUG_FUNC;  // Declare debug()
 
     // VISITORS
-    virtual void visit(AstVar* nodep) {
+    virtual void visit(AstVar* nodep) VL_OVERRIDE {
         if (VN_IS(nodep->dtypep(), IfaceRefDType)) {
             UINFO(8,"   dm-1-VAR    "<<nodep<<endl);
             insert(nodep);
@@ -163,9 +163,9 @@ private:
         iterateChildren(nodep);
     }
     // Save some time
-    virtual void visit(AstNodeMath*) {}
+    virtual void visit(AstNodeMath*) VL_OVERRIDE {}
     // Default: Just iterate
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
     }
 public:
@@ -213,7 +213,7 @@ private:
     VL_DEBUG_FUNC;  // Declare debug()
 
     // VISITORS
-    virtual void visit(AstVar* nodep) {
+    virtual void visit(AstVar* nodep) VL_OVERRIDE {
         if (VN_IS(nodep->dtypep(), UnpackArrayDType)
             && VN_IS(VN_CAST(nodep->dtypep(), UnpackArrayDType)->subDTypep(), IfaceRefDType)) {
             UINFO(8,"   dv-vec-VAR    "<<nodep<<endl);
@@ -246,7 +246,7 @@ private:
         iterateChildren(nodep);
     }
 
-    virtual void visit(AstCell* nodep) {
+    virtual void visit(AstCell* nodep) VL_OVERRIDE {
         UINFO(4,"  CELL   "<<nodep<<endl);
         // Find submodule vars
         UASSERT_OBJ(nodep->modp(), nodep, "Unlinked");
@@ -313,7 +313,7 @@ private:
         }
     }
 
-    virtual void visit(AstPin* nodep) {
+    virtual void visit(AstPin* nodep) VL_OVERRIDE {
         // Any non-direct pins need reconnection with a part-select
         if (!nodep->exprp()) return;  // No-connect
         if (m_cellRangep) {
@@ -447,10 +447,10 @@ private:
     }
 
     // Save some time
-    virtual void visit(AstNodeMath*) {}
+    virtual void visit(AstNodeMath*) VL_OVERRIDE {}
     //--------------------
     // Default: Just iterate
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
     }
 public:

--- a/src/V3InstrCount.cpp
+++ b/src/V3InstrCount.cpp
@@ -124,7 +124,7 @@ private:
     }
 
     // VISITORS
-    virtual void visit(AstNodeSel* nodep) {
+    virtual void visit(AstNodeSel* nodep) VL_OVERRIDE {
         // This covers both AstArraySel and AstWordSel
         //
         // If some vector is a bazillion dwords long, and we're selecting 1
@@ -135,7 +135,7 @@ private:
         VisitBase vb(this, nodep);
         iterateAndNextNull(nodep->bitp());
     }
-    virtual void visit(AstSel* nodep) {
+    virtual void visit(AstSel* nodep) VL_OVERRIDE {
         // Similar to AstNodeSel above, a small select into a large vector
         // is not expensive. Count the cost of the AstSel itself (scales with
         // its width) and the cost of the lsbp() and widthp() nodes, but not
@@ -144,13 +144,13 @@ private:
         iterateAndNextNull(nodep->lsbp());
         iterateAndNextNull(nodep->widthp());
     }
-    virtual void visit(AstSliceSel* nodep) {
+    virtual void visit(AstSliceSel* nodep) VL_OVERRIDE {
         nodep->v3fatalSrc("AstSliceSel unhandled");
     }
-    virtual void visit(AstMemberSel* nodep) {
+    virtual void visit(AstMemberSel* nodep) VL_OVERRIDE {
         nodep->v3fatalSrc("AstMemberSel unhandled");
     }
-    virtual void visit(AstConcat* nodep) {
+    virtual void visit(AstConcat* nodep) VL_OVERRIDE {
         // Nop.
         //
         // Ignore concat. The problem with counting concat is that when we
@@ -170,7 +170,7 @@ private:
         // the widths of the operands (ignored here).
         markCost(nodep);
     }
-    virtual void visit(AstNodeIf* nodep) {
+    virtual void visit(AstNodeIf* nodep) VL_OVERRIDE {
         VisitBase vb(this, nodep);
         iterateAndNextNull(nodep->condp());
         uint32_t savedCount = m_instrCount;
@@ -195,7 +195,7 @@ private:
             if (nodep->ifsp()) nodep->ifsp()->user4(0);  // Don't dump it
         }
     }
-    virtual void visit(AstNodeCond* nodep) {
+    virtual void visit(AstNodeCond* nodep) VL_OVERRIDE {
         // Just like if/else above, the ternary operator only evaluates
         // one of the two expressions, so only count the max.
         VisitBase vb(this, nodep);
@@ -220,7 +220,7 @@ private:
             if (nodep->expr2p()) nodep->expr2p()->user4(0);  // Don't dump it
         }
     }
-    virtual void visit(AstActive* nodep) {
+    virtual void visit(AstActive* nodep) VL_OVERRIDE {
         // You'd think that the OrderLogicVertex's would be disjoint trees
         // of stuff in the AST, but it isn't so: V3Order makes an
         // OrderLogicVertex for each ACTIVE, and then also makes an
@@ -236,14 +236,14 @@ private:
         markCost(nodep);
         UASSERT_OBJ(nodep == m_startNodep, nodep, "Multiple actives, or not start node");
     }
-    virtual void visit(AstCCall* nodep) {
+    virtual void visit(AstCCall* nodep) VL_OVERRIDE {
         VisitBase vb(this, nodep);
         iterateChildren(nodep);
         m_tracingCall = true;
         iterate(nodep->funcp());
         UASSERT_OBJ(!m_tracingCall, nodep, "visit(AstCFunc) should have cleared m_tracingCall.");
     }
-    virtual void visit(AstCFunc* nodep) {
+    virtual void visit(AstCFunc* nodep) VL_OVERRIDE {
         // Don't count a CFunc other than by tracing a call or counting it
         // from the root
         UASSERT_OBJ(m_tracingCall || nodep == m_startNodep, nodep,
@@ -257,7 +257,7 @@ private:
         }
         m_inCFunc = saved_inCFunc;
     }
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         VisitBase vb(this, nodep);
         iterateChildren(nodep);
     }
@@ -289,7 +289,7 @@ public:
 private:
     // METHODS
     string indent() { return string(m_depth, ':')+" "; }
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         ++m_depth;
         if (unsigned costPlus1 = nodep->user4()) {
             *m_osp <<"  "<<indent()

--- a/src/V3Life.cpp
+++ b/src/V3Life.cpp
@@ -296,7 +296,7 @@ private:
     VL_DEBUG_FUNC;  // Declare debug()
 
     // VISITORS
-    virtual void visit(AstVarRef* nodep) {
+    virtual void visit(AstVarRef* nodep) VL_OVERRIDE {
         // Consumption/generation of a variable,
         // it's used so can't elim assignment before this use.
         UASSERT_OBJ(nodep->varScopep(), nodep, "NULL");
@@ -310,7 +310,7 @@ private:
             VL_DO_DANGLING(m_lifep->varUsageReplace(vscp, nodep), nodep);
         }
     }
-    virtual void visit(AstNodeAssign* nodep) {
+    virtual void visit(AstNodeAssign* nodep) VL_OVERRIDE {
         // Collect any used variables first, as lhs may also be on rhs
         // Similar code in V3Dead
         vluint64_t lastEdit = AstNode::editCountGbl();  // When it was last edited
@@ -330,13 +330,13 @@ private:
             iterateAndNextNull(nodep->lhsp());
         }
     }
-    virtual void visit(AstAssignDly* nodep) {
+    virtual void visit(AstAssignDly* nodep) VL_OVERRIDE {
         // Don't treat as normal assign; V3Life doesn't understand time sense
         iterateChildren(nodep);
     }
 
     //---- Track control flow changes
-    virtual void visit(AstNodeIf* nodep) {
+    virtual void visit(AstNodeIf* nodep) VL_OVERRIDE {
         UINFO(4,"   IF "<<nodep<<endl);
         // Condition is part of PREVIOUS block
         iterateAndNextNull(nodep->condp());
@@ -362,7 +362,7 @@ private:
         VL_DO_DANGLING(delete elseLifep, elseLifep);
     }
 
-    virtual void visit(AstWhile* nodep) {
+    virtual void visit(AstWhile* nodep) VL_OVERRIDE {
         // While's are a problem, as we don't allow loops in the graph.  We
         // may go around the cond/body multiple times.  Thus a
         // lifelication just in the body is ok, but we can't delete an
@@ -391,7 +391,7 @@ private:
         VL_DO_DANGLING(delete condLifep, condLifep);
         VL_DO_DANGLING(delete bodyLifep, bodyLifep);
     }
-    virtual void visit(AstJumpLabel* nodep) {
+    virtual void visit(AstJumpLabel* nodep) VL_OVERRIDE {
         // As with While's we can't predict if a JumpGo will kill us or not
         // It's worse though as an IF(..., JUMPGO) may change the control flow.
         // Just don't optimize blocks with labels; they're rare - so far.
@@ -410,7 +410,7 @@ private:
         bodyLifep->lifeToAbove();
         VL_DO_DANGLING(delete bodyLifep, bodyLifep);
     }
-    virtual void visit(AstCCall* nodep) {
+    virtual void visit(AstCCall* nodep) VL_OVERRIDE {
         //UINFO(4,"  CCALL "<<nodep<<endl);
         iterateChildren(nodep);
         // Enter the function and trace it
@@ -419,7 +419,7 @@ private:
             iterate(nodep->funcp());
         }
     }
-    virtual void visit(AstCFunc* nodep) {
+    virtual void visit(AstCFunc* nodep) VL_OVERRIDE {
         //UINFO(4,"  CCALL "<<nodep<<endl);
         if (!m_tracingCall && !nodep->entryPoint()) return;
         m_tracingCall = false;
@@ -428,17 +428,17 @@ private:
         }
         iterateChildren(nodep);
     }
-    virtual void visit(AstUCFunc* nodep) {
+    virtual void visit(AstUCFunc* nodep) VL_OVERRIDE {
         m_sideEffect = true;  // If appears on assign RHS, don't ever delete the assignment
         iterateChildren(nodep);
     }
-    virtual void visit(AstCMath* nodep) {
+    virtual void visit(AstCMath* nodep) VL_OVERRIDE {
         m_sideEffect = true;  // If appears on assign RHS, don't ever delete the assignment
         iterateChildren(nodep);
     }
 
-    virtual void visit(AstVar*) {}  // Don't want varrefs under it
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstVar*) VL_OVERRIDE {}  // Don't want varrefs under it
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
     }
 
@@ -472,28 +472,28 @@ private:
     LifeState* m_statep;        // Current state
 
     // VISITORS
-    virtual void visit(AstCFunc* nodep) {
+    virtual void visit(AstCFunc* nodep) VL_OVERRIDE {
         if (nodep->entryPoint()) {
             // Usage model 1: Simulate all C code, doing lifetime analysis
             LifeVisitor visitor (nodep, m_statep);
         }
     }
-    virtual void visit(AstAlways* nodep) {
+    virtual void visit(AstAlways* nodep) VL_OVERRIDE {
         // Usage model 2: Cleanup basic blocks
         LifeVisitor visitor (nodep, m_statep);
     }
-    virtual void visit(AstInitial* nodep) {
+    virtual void visit(AstInitial* nodep) VL_OVERRIDE {
         // Usage model 2: Cleanup basic blocks
         LifeVisitor visitor (nodep, m_statep);
     }
-    virtual void visit(AstFinal* nodep) {
+    virtual void visit(AstFinal* nodep) VL_OVERRIDE {
         // Usage model 2: Cleanup basic blocks
         LifeVisitor visitor (nodep, m_statep);
     }
-    virtual void visit(AstVar*) {}  // Accelerate
-    virtual void visit(AstNodeStmt*) {}  // Accelerate
-    virtual void visit(AstNodeMath*) {}  // Accelerate
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstVar*) VL_OVERRIDE {}  // Accelerate
+    virtual void visit(AstNodeStmt*) VL_OVERRIDE {}  // Accelerate
+    virtual void visit(AstNodeMath*) VL_OVERRIDE {}  // Accelerate
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
     }
 public:

--- a/src/V3LifePost.cpp
+++ b/src/V3LifePost.cpp
@@ -58,7 +58,7 @@ private:
     VL_DEBUG_FUNC;  // Declare debug()
 
     // VISITORS
-    virtual void visit(AstVarRef* nodep) {
+    virtual void visit(AstVarRef* nodep) VL_OVERRIDE {
         AstVarScope* vscp = nodep->varScopep();
         UASSERT_OBJ(vscp, nodep, "Scope not assigned");
         if (AstVarScope* newvscp = reinterpret_cast<AstVarScope*>(vscp->user4p())) {
@@ -68,11 +68,11 @@ private:
             VL_DO_DANGLING(nodep->deleteTree(), nodep);
         }
     }
-    virtual void visit(AstNodeModule* nodep) {
+    virtual void visit(AstNodeModule* nodep) VL_OVERRIDE {
         // Only track the top scopes, not lower level functions
         if (nodep->isTop()) iterateChildren(nodep);
     }
-    virtual void visit(AstCCall* nodep) {
+    virtual void visit(AstCCall* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         if (!nodep->funcp()->entryPoint()) {
             // Enter the function and trace it
@@ -80,18 +80,18 @@ private:
             iterate(nodep->funcp());
         }
     }
-    virtual void visit(AstExecGraph* nodep) {
+    virtual void visit(AstExecGraph* nodep) VL_OVERRIDE {
         // Can just iterate across the MTask bodies in any order.  Order
         // isn't important for LifePostElimVisitor's simple substitution.
         iterateChildren(nodep);
     }
-    virtual void visit(AstCFunc* nodep) {
+    virtual void visit(AstCFunc* nodep) VL_OVERRIDE {
         if (!m_tracingCall && !nodep->entryPoint()) return;
         m_tracingCall = false;
         iterateChildren(nodep);
     }
-    virtual void visit(AstVar*) {}  // Don't want varrefs under it
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstVar*) VL_OVERRIDE {}  // Don't want varrefs under it
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
     }
 public:
@@ -259,7 +259,7 @@ private:
     }
 
     // VISITORS
-    virtual void visit(AstTopScope* nodep) {
+    virtual void visit(AstTopScope* nodep) VL_OVERRIDE {
         AstNode::user4ClearTree();  // user4p() used on entire tree
 
         // First, build maps of every location (mtask and sequence
@@ -284,7 +284,7 @@ private:
         // Replace any node4p varscopes with the new scope
         LifePostElimVisitor visitor (nodep);
     }
-    virtual void visit(AstVarRef* nodep) {
+    virtual void visit(AstVarRef* nodep) VL_OVERRIDE {
         // Consumption/generation of a variable,
         AstVarScope* vscp = nodep->varScopep();
         UASSERT_OBJ(vscp, nodep, "Scope not assigned");
@@ -296,14 +296,14 @@ private:
             m_reads[vscp].insert(loc);
         }
     }
-    virtual void visit(AstAssignPre* nodep) {
+    virtual void visit(AstAssignPre* nodep) VL_OVERRIDE {
         // Do not record varrefs within assign pre.
         //
         // The pre-assignment into the dly var should not count as its
         // first write; we only want to consider reads and writes that
         // would still happen if the dly var were eliminated.
     }
-    virtual void visit(AstAssignPost* nodep) {
+    virtual void visit(AstAssignPost* nodep) VL_OVERRIDE {
         // Don't record ASSIGNPOST in the read/write maps, record them in a
         // separate map
         if (AstVarRef* rhsp = VN_CAST(nodep->rhsp(), VarRef)) {
@@ -315,11 +315,11 @@ private:
             m_assignposts[dlyVarp] = LifePostLocation(loc, nodep);
         }
     }
-    virtual void visit(AstNodeModule* nodep) {
+    virtual void visit(AstNodeModule* nodep) VL_OVERRIDE {
         // Only track the top scopes, not lower level functions
         if (nodep->isTop()) iterateChildren(nodep);
     }
-    virtual void visit(AstCCall* nodep) {
+    virtual void visit(AstCCall* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         if (!nodep->funcp()->entryPoint()) {
             // Enter the function and trace it
@@ -327,7 +327,7 @@ private:
             iterate(nodep->funcp());
         }
     }
-    virtual void visit(AstExecGraph* nodep) {
+    virtual void visit(AstExecGraph* nodep) VL_OVERRIDE {
         // Treat the ExecGraph like a call to each mtask body
         m_mtasksGraphp = nodep->depGraphp();
         for (V3GraphVertex* mtaskVxp = m_mtasksGraphp->verticesBeginp();
@@ -339,14 +339,14 @@ private:
         }
         m_execMTaskp = NULL;
     }
-    virtual void visit(AstCFunc* nodep) {
+    virtual void visit(AstCFunc* nodep) VL_OVERRIDE {
         if (!m_tracingCall && !nodep->entryPoint()) return;
         m_tracingCall = false;
         iterateChildren(nodep);
     }
     //-----
-    virtual void visit(AstVar*) {}  // Don't want varrefs under it
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstVar*) VL_OVERRIDE {}  // Don't want varrefs under it
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
     }
 public:

--- a/src/V3LinkCells.cpp
+++ b/src/V3LinkCells.cpp
@@ -158,7 +158,7 @@ private:
     }
 
     // VISITs
-    virtual void visit(AstNetlist* nodep) {
+    virtual void visit(AstNetlist* nodep) VL_OVERRIDE {
         AstNode::user1ClearTree();
         readModNames();
         iterateChildren(nodep);
@@ -190,7 +190,7 @@ private:
             v3error("Specified --top-module '"<<v3Global.opt.topModule()<<"' was not found in design.");
         }
     }
-    virtual void visit(AstNodeModule* nodep) {
+    virtual void visit(AstNodeModule* nodep) VL_OVERRIDE {
         // Module: Pick up modnames, so we can resolve cells later
         m_modp = nodep;
         UINFO(2,"Link Module: "<<nodep<<endl);
@@ -228,7 +228,7 @@ private:
         m_modp = NULL;
     }
 
-    virtual void visit(AstIfaceRefDType* nodep) {
+    virtual void visit(AstIfaceRefDType* nodep) VL_OVERRIDE {
         // Cell: Resolve its filename.  If necessary, parse it.
         UINFO(4,"Link IfaceRef: "<<nodep<<endl);
         // Use findIdUpward instead of findIdFlat; it doesn't matter for now
@@ -247,14 +247,14 @@ private:
         // Note cannot do modport resolution here; modports are allowed underneath generates
     }
 
-    virtual void visit(AstPackageImport* nodep) {
+    virtual void visit(AstPackageImport* nodep) VL_OVERRIDE {
         // Package Import: We need to do the package before the use of a package
         iterateChildren(nodep);
         UASSERT_OBJ(nodep->packagep(), nodep, "Unlinked package");  // Parser should set packagep
         new V3GraphEdge(&m_graph, vertex(m_modp), vertex(nodep->packagep()), 1, false);
     }
 
-    virtual void visit(AstBind* nodep) {
+    virtual void visit(AstBind* nodep) VL_OVERRIDE {
         // Bind: Has cells underneath that need to be put into the new
         // module, and cells which need resolution
         // TODO this doesn't allow bind to dotted hier names, that would require
@@ -276,7 +276,7 @@ private:
         pushDeletep(nodep->unlinkFrBack());
     }
 
-    virtual void visit(AstCell* nodep) {
+    virtual void visit(AstCell* nodep) VL_OVERRIDE {
         // Cell: Resolve its filename.  If necessary, parse it.
         // Execute only once.  Complication is that cloning may result in
         // user1 being set (for pre-clone) so check if user1() matches the
@@ -448,8 +448,8 @@ private:
 
     // Accelerate the recursion
     // Must do statements to support Generates, math though...
-    virtual void visit(AstNodeMath* nodep) {}
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNodeMath* nodep) VL_OVERRIDE {}
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         // Default: Just iterate
         iterateChildren(nodep);
     }

--- a/src/V3LinkDot.cpp
+++ b/src/V3LinkDot.cpp
@@ -726,7 +726,7 @@ class LinkDotFindVisitor : public AstNVisitor {
     }
 
     // VISITs
-    virtual void visit(AstNetlist* nodep) {
+    virtual void visit(AstNetlist* nodep) VL_OVERRIDE {
         // Process $unit or other packages
         // Not needed - dotted references not allowed from inside packages
         //for (AstNodeModule* nodep = v3Global.rootp()->modulesp();
@@ -758,8 +758,8 @@ class LinkDotFindVisitor : public AstNVisitor {
             m_curSymp = m_modSymp = NULL;
         }
     }
-    virtual void visit(AstTypeTable* nodep) {}
-    virtual void visit(AstNodeModule* nodep) {
+    virtual void visit(AstTypeTable* nodep) VL_OVERRIDE {}
+    virtual void visit(AstNodeModule* nodep) VL_OVERRIDE {
         // Called on top module from Netlist, other modules from the cell creating them,
         // and packages
         UINFO(8,"   "<<nodep<<endl);
@@ -821,12 +821,12 @@ class LinkDotFindVisitor : public AstNVisitor {
         // Prep for next
         m_packagep = NULL;
     }
-    virtual void visit(AstScope* nodep) {
+    virtual void visit(AstScope* nodep) VL_OVERRIDE {
         UASSERT_OBJ(m_statep->forScopeCreation(), nodep,
                     "Scopes should only exist right after V3Scope");
         // Ignored.  Processed in next step
     }
-    virtual void visit(AstCell* nodep) {
+    virtual void visit(AstCell* nodep) VL_OVERRIDE {
         UINFO(5,"   CELL under "<<m_scope<<" is "<<nodep<<endl);
         // Process XREFs/etc inside pins
         if (nodep->recursive() && m_inRecursion) return;
@@ -867,7 +867,7 @@ class LinkDotFindVisitor : public AstNVisitor {
         m_paramNum = oldParamNum;
         m_inRecursion = oldRecursion;
     }
-    virtual void visit(AstCellInline* nodep) {
+    virtual void visit(AstCellInline* nodep) VL_OVERRIDE {
         UINFO(5,"   CELLINLINE under "<<m_scope<<" is "<<nodep<<endl);
         VSymEnt* aboveSymp = m_curSymp;
         // If baz__DOT__foo__DOT__bar, we need to find baz__DOT__foo and add bar to it.
@@ -887,11 +887,11 @@ class LinkDotFindVisitor : public AstNVisitor {
             m_statep->insertInline(aboveSymp, m_modSymp, nodep, nodep->name());
         }
     }
-    virtual void visit(AstDefParam* nodep) {
+    virtual void visit(AstDefParam* nodep) VL_OVERRIDE {
         nodep->user1p(m_curSymp);
         iterateChildren(nodep);
     }
-    virtual void visit(AstGenerate* nodep) {
+    virtual void visit(AstGenerate* nodep) VL_OVERRIDE {
         // Begin: ... blocks often replicate under genif/genfor, so simply
         // suppress duplicate checks.  See t_gen_forif.v for an example.
         bool lastInGen = m_inGenerate;
@@ -901,7 +901,7 @@ class LinkDotFindVisitor : public AstNVisitor {
         }
         m_inGenerate = lastInGen;
     }
-    virtual void visit(AstBegin* nodep) {
+    virtual void visit(AstBegin* nodep) VL_OVERRIDE {
         UINFO(5,"   "<<nodep<<endl);
         // Rename "genblk"s to include a number
         if (m_statep->forPrimary() && !nodep->user4SetOnce()) {
@@ -943,7 +943,7 @@ class LinkDotFindVisitor : public AstNVisitor {
         m_beginp = oldbegin;
         m_beginNum = oldNum;
     }
-    virtual void visit(AstNodeFTask* nodep) {
+    virtual void visit(AstNodeFTask* nodep) VL_OVERRIDE {
         // NodeTask: Remember its name for later resolution
         UINFO(5,"   "<<nodep<<endl);
         UASSERT_OBJ(m_curSymp && m_modSymp, nodep, "Function/Task not under module?");
@@ -979,7 +979,7 @@ class LinkDotFindVisitor : public AstNVisitor {
         }
         m_curSymp = oldCurSymp;
     }
-    virtual void visit(AstVar* nodep) {
+    virtual void visit(AstVar* nodep) VL_OVERRIDE {
         // Var: Remember its name for later resolution
         UASSERT_OBJ(m_curSymp && m_modSymp, nodep, "Var not under module?");
         iterateChildren(nodep);
@@ -1097,21 +1097,21 @@ class LinkDotFindVisitor : public AstNVisitor {
             }
         }
     }
-    virtual void visit(AstTypedef* nodep) {
+    virtual void visit(AstTypedef* nodep) VL_OVERRIDE {
         UASSERT_OBJ(m_curSymp, nodep, "Typedef not under module/package/$unit");
         iterateChildren(nodep);
         m_statep->insertSym(m_curSymp, nodep->name(), nodep, m_packagep);
     }
-    virtual void visit(AstParamTypeDType* nodep) {
+    virtual void visit(AstParamTypeDType* nodep) VL_OVERRIDE {
         UASSERT_OBJ(m_curSymp, nodep, "Parameter type not under module/package/$unit");
         iterateChildren(nodep);
         m_statep->insertSym(m_curSymp, nodep->name(), nodep, m_packagep);
     }
-    virtual void visit(AstCFunc* nodep) {
+    virtual void visit(AstCFunc* nodep) VL_OVERRIDE {
         // For dotted resolution, ignore all AstVars under functions, otherwise shouldn't exist
         UASSERT_OBJ(!m_statep->forScopeCreation(), nodep, "No CFuncs expected in tree yet");
     }
-    virtual void visit(AstEnumItem* nodep) {
+    virtual void visit(AstEnumItem* nodep) VL_OVERRIDE {
         // EnumItem: Remember its name for later resolution
         iterateChildren(nodep);
         // Find under either a task or the module's vars
@@ -1149,7 +1149,7 @@ class LinkDotFindVisitor : public AstNVisitor {
             m_statep->insertSym(m_curSymp, nodep->name(), nodep, m_packagep);
         }
     }
-    virtual void visit(AstPackageImport* nodep) {
+    virtual void visit(AstPackageImport* nodep) VL_OVERRIDE {
         UINFO(4,"  Link: "<<nodep<<endl);
         VSymEnt* srcp = m_statep->getNodeSym(nodep->packagep());
         if (nodep->name()=="*") {
@@ -1167,7 +1167,7 @@ class LinkDotFindVisitor : public AstNVisitor {
         UINFO(9,"    Link Done: "<<nodep<<endl);
         // No longer needed, but can't delete until any multi-instantiated modules are expanded
     }
-    virtual void visit(AstPackageExport* nodep) {
+    virtual void visit(AstPackageExport* nodep) VL_OVERRIDE {
         UINFO(9,"  Link: "<<nodep<<endl);
         VSymEnt* srcp = m_statep->getNodeSym(nodep->packagep());
         if (nodep->name()!="*") {
@@ -1181,13 +1181,13 @@ class LinkDotFindVisitor : public AstNVisitor {
         UINFO(9,"    Link Done: "<<nodep<<endl);
         // No longer needed, but can't delete until any multi-instantiated modules are expanded
     }
-    virtual void visit(AstPackageExportStarStar* nodep) {
+    virtual void visit(AstPackageExportStarStar* nodep) VL_OVERRIDE {
         UINFO(4,"  Link: "<<nodep<<endl);
         m_curSymp->exportStarStar(m_statep->symsp());
         // No longer needed, but can't delete until any multi-instantiated modules are expanded
     }
 
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         // Default: Just iterate
         iterateChildren(nodep);
     }
@@ -1252,8 +1252,8 @@ private:
     }
 
     // VISITs
-    virtual void visit(AstTypeTable* nodep) {}
-    virtual void visit(AstNodeModule* nodep) {
+    virtual void visit(AstTypeTable* nodep) VL_OVERRIDE {}
+    virtual void visit(AstNodeModule* nodep) VL_OVERRIDE {
         UINFO(5,"   "<<nodep<<endl);
         if (nodep->dead() || !nodep->user4()) {
             UINFO(4,"Mark dead module "<<nodep<<endl);
@@ -1270,7 +1270,7 @@ private:
             m_modp = NULL;
         }
     }
-    virtual void visit(AstPin* nodep) {
+    virtual void visit(AstPin* nodep) VL_OVERRIDE {
         // Pin: Link to submodule's port
         // Deal with implicit definitions - do before Resolve visitor as may
         // be referenced above declaration
@@ -1279,7 +1279,7 @@ private:
             pinImplicitExprRecurse(nodep->exprp());
         }
     }
-    virtual void visit(AstDefParam* nodep) {
+    virtual void visit(AstDefParam* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         nodep->v3warn(DEFPARAM, "Suggest replace defparam assignment with Verilog 2001 #(."
                       <<nodep->prettyName()<<"(...etc...))");
@@ -1301,7 +1301,7 @@ private:
             VL_DO_DANGLING(nodep->unlinkFrBack()->deleteTree(), nodep);
         }
     }
-    virtual void visit(AstPort* nodep) {
+    virtual void visit(AstPort* nodep) VL_OVERRIDE {
         // Port: Stash the pin number
         // Need to set pin numbers after varnames are created
         // But before we do the final resolution based on names
@@ -1328,14 +1328,14 @@ private:
         // Ports not needed any more
         VL_DO_DANGLING(nodep->unlinkFrBack()->deleteTree(), nodep);
     }
-    virtual void visit(AstAssignW* nodep) {
+    virtual void visit(AstAssignW* nodep) VL_OVERRIDE {
         // Deal with implicit definitions
         // We used to nodep->allowImplicit() here, but it turns out
         // normal "assigns" can also make implicit wires.  Yuk.
         pinImplicitExprRecurse(nodep->lhsp());
         iterateChildren(nodep);
     }
-    virtual void visit(AstAssignAlias* nodep) {
+    virtual void visit(AstAssignAlias* nodep) VL_OVERRIDE {
         // tran gates need implicit creation
         // As VarRefs don't exist in forPrimary, sanity check
         UASSERT_OBJ(!m_statep->forPrimary(), nodep, "Assign aliases unexpected pre-dot");
@@ -1347,13 +1347,13 @@ private:
         }
         iterateChildren(nodep);
     }
-    virtual void visit(AstImplicit* nodep) {
+    virtual void visit(AstImplicit* nodep) VL_OVERRIDE {
         // Unsupported gates need implicit creation
         pinImplicitExprRecurse(nodep);
         // We're done with implicit gates
         VL_DO_DANGLING(nodep->unlinkFrBack()->deleteTree(), nodep);
     }
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         // Default: Just iterate
         iterateChildren(nodep);
     }
@@ -1383,11 +1383,11 @@ class LinkDotScopeVisitor : public AstNVisitor {
     int debug() { return LinkDotState::debug(); }
 
     // VISITs
-    virtual void visit(AstNetlist* nodep) {
+    virtual void visit(AstNetlist* nodep) VL_OVERRIDE {
         // Recurse..., backward as must do packages before using packages
         iterateChildrenBackwards(nodep);
     }
-    virtual void visit(AstScope* nodep) {
+    virtual void visit(AstScope* nodep) VL_OVERRIDE {
         UINFO(8,"  SCOPE "<<nodep<<endl);
         UASSERT_OBJ(m_statep->forScopeCreation(), nodep,
                     "Scopes should only exist right after V3Scope");
@@ -1399,7 +1399,7 @@ class LinkDotScopeVisitor : public AstNVisitor {
         m_modSymp = NULL;
         m_scopep = NULL;
     }
-    virtual void visit(AstVarScope* nodep) {
+    virtual void visit(AstVarScope* nodep) VL_OVERRIDE {
         if (!nodep->varp()->isFuncLocal()) {
             VSymEnt* varSymp = m_statep->insertSym(m_modSymp, nodep->varp()->name(), nodep, NULL);
             if (nodep->varp()->isIfaceRef()
@@ -1433,12 +1433,12 @@ class LinkDotScopeVisitor : public AstNVisitor {
             }
         }
     }
-    virtual void visit(AstNodeFTask* nodep) {
+    virtual void visit(AstNodeFTask* nodep) VL_OVERRIDE {
         VSymEnt* symp = m_statep->insertBlock(m_modSymp, nodep->name(), nodep, NULL);
         symp->fallbackp(m_modSymp);
         // No recursion, we don't want to pick up variables
     }
-    virtual void visit(AstAssignAlias* nodep) {
+    virtual void visit(AstAssignAlias* nodep) VL_OVERRIDE {
         // Track aliases created by V3Inline; if we get a VARXREF(aliased_from)
         // we'll need to replace it with a VARXREF(aliased_to)
         if (debug()>=9) nodep->dumpTree(cout, "-    alias: ");
@@ -1448,7 +1448,7 @@ class LinkDotScopeVisitor : public AstNVisitor {
         fromVscp->user2p(toVscp);
         iterateChildren(nodep);
     }
-    virtual void visit(AstAssignVarScope* nodep) {
+    virtual void visit(AstAssignVarScope* nodep) VL_OVERRIDE {
         UINFO(5,"ASSIGNVARSCOPE  "<<nodep<<endl);
         if (debug()>=9) nodep->dumpTree(cout, "-    avs: ");
         VSymEnt* rhsSymp;
@@ -1500,10 +1500,10 @@ class LinkDotScopeVisitor : public AstNVisitor {
     }
     // For speed, don't recurse things that can't have scope
     // Note we allow AstNodeStmt's as generates may be under them
-    virtual void visit(AstCell*) {}
-    virtual void visit(AstVar*) {}
-    virtual void visit(AstNodeMath*) {}
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstCell*) VL_OVERRIDE {}
+    virtual void visit(AstVar*) VL_OVERRIDE {}
+    virtual void visit(AstNodeMath*) VL_OVERRIDE {}
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         // Default: Just iterate
         iterateChildren(nodep);
     }
@@ -1533,7 +1533,7 @@ class LinkDotIfaceVisitor : public AstNVisitor {
     int debug() { return LinkDotState::debug(); }
 
     // VISITs
-    virtual void visit(AstModport* nodep) {
+    virtual void visit(AstModport* nodep) VL_OVERRIDE {
         // Modport: Remember its name for later resolution
         UINFO(5,"   fiv: "<<nodep<<endl);
         VSymEnt* oldCurSymp = m_curSymp;
@@ -1545,7 +1545,7 @@ class LinkDotIfaceVisitor : public AstNVisitor {
         }
         m_curSymp = oldCurSymp;
     }
-    virtual void visit(AstModportFTaskRef* nodep) {
+    virtual void visit(AstModportFTaskRef* nodep) VL_OVERRIDE {
         UINFO(5,"   fif: "<<nodep<<endl);
         iterateChildren(nodep);
         if (nodep->isExport()) nodep->v3error("Unsupported: modport export");
@@ -1567,7 +1567,7 @@ class LinkDotIfaceVisitor : public AstNVisitor {
             nodep->unlinkFrBack(); VL_DO_DANGLING(pushDeletep(nodep), nodep);
         }
     }
-    virtual void visit(AstModportVarRef* nodep) {
+    virtual void visit(AstModportVarRef* nodep) VL_OVERRIDE {
         UINFO(5,"   fiv: "<<nodep<<endl);
         iterateChildren(nodep);
         VSymEnt* symp = m_curSymp->findIdFallback(nodep->name());
@@ -1591,7 +1591,7 @@ class LinkDotIfaceVisitor : public AstNVisitor {
             nodep->unlinkFrBack(); VL_DO_DANGLING(pushDeletep(nodep), nodep);
         }
     }
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         // Default: Just iterate
         iterateChildren(nodep);
     }
@@ -1768,12 +1768,12 @@ private:
     }
 
     // VISITs
-    virtual void visit(AstNetlist* nodep) {
+    virtual void visit(AstNetlist* nodep) VL_OVERRIDE {
         // Recurse..., backward as must do packages before using packages
         iterateChildrenBackwards(nodep);
     }
-    virtual void visit(AstTypeTable* nodep) {}
-    virtual void visit(AstNodeModule* nodep) {
+    virtual void visit(AstTypeTable* nodep) VL_OVERRIDE {}
+    virtual void visit(AstNodeModule* nodep) VL_OVERRIDE {
         if (nodep->dead()) return;
         checkNoDot(nodep);
         UINFO(8,"  "<<nodep<<endl);
@@ -1786,7 +1786,7 @@ private:
         m_modp = NULL;
         m_ds.m_dotSymp = m_curSymp = m_modSymp = NULL;
     }
-    virtual void visit(AstScope* nodep) {
+    virtual void visit(AstScope* nodep) VL_OVERRIDE {
         UINFO(8,"   "<<nodep<<endl);
         VSymEnt* oldModSymp = m_modSymp;
         VSymEnt* oldCurSymp = m_curSymp;
@@ -1797,13 +1797,13 @@ private:
         m_modSymp = oldModSymp;
         m_curSymp = oldCurSymp;
     }
-    virtual void visit(AstCellInline* nodep) {
+    virtual void visit(AstCellInline* nodep) VL_OVERRIDE {
         checkNoDot(nodep);
         if (m_statep->forScopeCreation() && !v3Global.opt.vpi()) {
             nodep->unlinkFrBack(); VL_DO_DANGLING(pushDeletep(nodep), nodep);
         }
     }
-    virtual void visit(AstCell* nodep) {
+    virtual void visit(AstCell* nodep) VL_OVERRIDE {
         // Cell: Recurse inside or cleanup not founds
         checkNoDot(nodep);
         m_cellp = nodep;
@@ -1832,7 +1832,7 @@ private:
         // Parent module inherits child's publicity
         // This is done bottom up in the LinkBotupVisitor stage
     }
-    virtual void visit(AstPin* nodep) {
+    virtual void visit(AstPin* nodep) VL_OVERRIDE {
         // Pin: Link to submodule's port
         checkNoDot(nodep);
         iterateChildren(nodep);
@@ -1874,7 +1874,7 @@ private:
         }
         // Early return() above when deleted
     }
-    virtual void visit(AstDot* nodep) {
+    virtual void visit(AstDot* nodep) VL_OVERRIDE {
         // Legal under a DOT: AstDot, AstParseRef, AstPackageRef, AstNodeSel
         //    also a DOT can be part of an expression, but only above plus
         //    AstFTaskRef are legal children
@@ -1940,7 +1940,7 @@ private:
             m_ds.m_dotp = lastStates.m_dotp;
         }
     }
-    virtual void visit(AstParseRef* nodep) {
+    virtual void visit(AstParseRef* nodep) VL_OVERRIDE {
         if (nodep->user3SetOnce()) return;
         UINFO(9,"   linkPARSEREF "<<m_ds.ascii()<<"  n="<<nodep<<endl);
         // m_curSymp is symbol table of outer expression
@@ -2174,7 +2174,7 @@ private:
             m_ds = lastStates;
         }
     }
-    virtual void visit(AstVarRef* nodep) {
+    virtual void visit(AstVarRef* nodep) VL_OVERRIDE {
         // VarRef: Resolve its reference
         // ParseRefs are used the first pass (forPrimary) so we shouldn't get can't find
         // errors here now that we have a VarRef.
@@ -2193,7 +2193,7 @@ private:
             }
         }
     }
-    virtual void visit(AstVarXRef* nodep) {
+    virtual void visit(AstVarXRef* nodep) VL_OVERRIDE {
         // VarRef: Resolve its reference
         // We always link even if varp() is set, because the module we choose may change
         // due to creating new modules, flattening, etc.
@@ -2267,11 +2267,11 @@ private:
             }
         }
     }
-    virtual void visit(AstEnumItemRef* nodep) {
+    virtual void visit(AstEnumItemRef* nodep) VL_OVERRIDE {
         // EnumItemRef may be under a dot.  Should already be resolved.
         iterateChildren(nodep);
     }
-    virtual void visit(AstMethodCall* nodep) {
+    virtual void visit(AstMethodCall* nodep) VL_OVERRIDE {
         // Created here so should already be resolved.
         DotStates lastStates = m_ds;
         {
@@ -2280,7 +2280,7 @@ private:
         }
         m_ds = lastStates;
     }
-    virtual void visit(AstVar* nodep) {
+    virtual void visit(AstVar* nodep) VL_OVERRIDE {
         checkNoDot(nodep);
         iterateChildren(nodep);
         if (m_statep->forPrimary() && nodep->isIO() && !m_ftaskp && !nodep->user4()) {
@@ -2288,7 +2288,7 @@ private:
                            <<nodep->prettyNameQ());
         }
     }
-    virtual void visit(AstNodeFTaskRef* nodep) {
+    virtual void visit(AstNodeFTaskRef* nodep) VL_OVERRIDE {
         if (nodep->user3SetOnce()) return;
         UINFO(8,"     "<<nodep<<endl);
         if (m_ds.m_dotp && m_ds.m_dotPos == DP_PACKAGE) {
@@ -2402,7 +2402,7 @@ private:
         }
         m_ds = lastStates;
     }
-    virtual void visit(AstSelBit* nodep) {
+    virtual void visit(AstSelBit* nodep) VL_OVERRIDE {
         if (nodep->user3SetOnce()) return;
         iterateAndNextNull(nodep->lhsp());
         if (m_ds.m_dotPos == DP_SCOPE) {  // Already under dot, so this is {modulepart} DOT {modulepart}
@@ -2427,7 +2427,7 @@ private:
             nodep->replaceWith(newp); VL_DO_DANGLING(pushDeletep(nodep), nodep);
         }
     }
-    virtual void visit(AstNodePreSel* nodep) {
+    virtual void visit(AstNodePreSel* nodep) VL_OVERRIDE {
         // Excludes simple AstSelBit, see above
         if (nodep->user3SetOnce()) return;
         if (m_ds.m_dotPos == DP_SCOPE) {  // Already under dot, so this is {modulepart} DOT {modulepart}
@@ -2445,11 +2445,11 @@ private:
         }
         m_ds = lastStates;
     }
-    virtual void visit(AstMemberSel* nodep) {
+    virtual void visit(AstMemberSel* nodep) VL_OVERRIDE {
         // checkNoDot not appropriate, can be under a dot
         iterateChildren(nodep);
     }
-    virtual void visit(AstBegin* nodep) {
+    virtual void visit(AstBegin* nodep) VL_OVERRIDE {
         UINFO(5,"   "<<nodep<<endl);
         checkNoDot(nodep);
         VSymEnt* oldCurSymp = m_curSymp;
@@ -2461,7 +2461,7 @@ private:
         m_ds.m_dotSymp = m_curSymp = oldCurSymp;
         UINFO(5,"   cur=se"<<cvtToHex(m_curSymp)<<endl);
     }
-    virtual void visit(AstNodeFTask* nodep) {
+    virtual void visit(AstNodeFTask* nodep) VL_OVERRIDE {
         UINFO(5,"   "<<nodep<<endl);
         checkNoDot(nodep);
         VSymEnt* oldCurSymp = m_curSymp;
@@ -2473,7 +2473,7 @@ private:
         m_ds.m_dotSymp = m_curSymp = oldCurSymp;
         m_ftaskp = NULL;
     }
-    virtual void visit(AstRefDType* nodep) {
+    virtual void visit(AstRefDType* nodep) VL_OVERRIDE {
         // Resolve its reference
         if (nodep->user3SetOnce()) return;
         if (m_ds.m_dotp && m_ds.m_dotPos == DP_PACKAGE) {
@@ -2509,7 +2509,7 @@ private:
         }
         iterateChildren(nodep);
     }
-    virtual void visit(AstDpiExport* nodep) {
+    virtual void visit(AstDpiExport* nodep) VL_OVERRIDE {
         // AstDpiExport: Make sure the function referenced exists, then dump it
         iterateChildren(nodep);
         checkNoDot(nodep);
@@ -2526,35 +2526,35 @@ private:
         }
         VL_DO_DANGLING(nodep->unlinkFrBack()->deleteTree(), nodep);
     }
-    virtual void visit(AstPackageImport* nodep) {
+    virtual void visit(AstPackageImport* nodep) VL_OVERRIDE {
         // No longer needed
         checkNoDot(nodep);
         VL_DO_DANGLING(nodep->unlinkFrBack()->deleteTree(), nodep);
     }
-    virtual void visit(AstPackageExport* nodep) {
+    virtual void visit(AstPackageExport* nodep) VL_OVERRIDE {
         // No longer needed
         checkNoDot(nodep);
         VL_DO_DANGLING(nodep->unlinkFrBack()->deleteTree(), nodep);
     }
-    virtual void visit(AstPackageExportStarStar* nodep) {
+    virtual void visit(AstPackageExportStarStar* nodep) VL_OVERRIDE {
         // No longer needed
         checkNoDot(nodep);
         VL_DO_DANGLING(nodep->unlinkFrBack()->deleteTree(), nodep);
     }
-    virtual void visit(AstCellRef* nodep) {
+    virtual void visit(AstCellRef* nodep) VL_OVERRIDE {
         UINFO(5,"  AstCellRef: "<<nodep<<" "<<m_ds.ascii()<<endl);
         iterateChildren(nodep);
     }
-    virtual void visit(AstCellArrayRef* nodep) {
+    virtual void visit(AstCellArrayRef* nodep) VL_OVERRIDE {
         UINFO(5,"  AstCellArrayRef: "<<nodep<<" "<<m_ds.ascii()<<endl);
         // Expression already iterated
     }
-    virtual void visit(AstUnlinkedRef* nodep) {
+    virtual void visit(AstUnlinkedRef* nodep) VL_OVERRIDE {
         UINFO(5,"  AstCellArrayRef: "<<nodep<<" "<<m_ds.ascii()<<endl);
         // No need to iterate, if we have a UnlinkedVarXRef, we're already done
     }
 
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         // Default: Just iterate
         checkNoDot(nodep);
         iterateChildren(nodep);

--- a/src/V3LinkJump.cpp
+++ b/src/V3LinkJump.cpp
@@ -107,7 +107,7 @@ private:
     }
 
     // VISITORS
-    virtual void visit(AstNodeModule* nodep) {
+    virtual void visit(AstNodeModule* nodep) VL_OVERRIDE {
         if (nodep->dead()) return;
         AstNodeModule* origModp = m_modp;
         int origRepeatNum = m_modRepeatNum;
@@ -119,18 +119,18 @@ private:
         m_modp = origModp;
         m_modRepeatNum = origRepeatNum;
     }
-    virtual void visit(AstNodeFTask* nodep) {
+    virtual void visit(AstNodeFTask* nodep) VL_OVERRIDE {
         m_ftaskp = nodep;
         iterateChildren(nodep);
         m_ftaskp = NULL;
     }
-    virtual void visit(AstBegin* nodep) {
+    virtual void visit(AstBegin* nodep) VL_OVERRIDE {
         UINFO(8,"  "<<nodep<<endl);
         m_beginStack.push_back(nodep);
         iterateChildren(nodep);
         m_beginStack.pop_back();
     }
-    virtual void visit(AstRepeat* nodep) {
+    virtual void visit(AstRepeat* nodep) VL_OVERRIDE {
         // So later optimizations don't need to deal with them,
         //    REPEAT(count,body) -> loop=count,WHILE(loop>0) { body, loop-- }
         // Note var can be signed or unsigned based on original number.
@@ -163,7 +163,7 @@ private:
         nodep->replaceWith(newp);
         VL_DO_DANGLING(nodep->deleteTree(), nodep);
     }
-    virtual void visit(AstWhile* nodep) {
+    virtual void visit(AstWhile* nodep) VL_OVERRIDE {
         // Don't need to track AstRepeat/AstFor as they have already been converted
         AstWhile* lastLoopp = m_loopp;
         bool lastInc = m_loopInc;
@@ -177,7 +177,7 @@ private:
         m_loopInc = lastInc;
         m_loopp = lastLoopp;
     }
-    virtual void visit(AstReturn* nodep) {
+    virtual void visit(AstReturn* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         AstFunc* funcp = VN_CAST(m_ftaskp, Func);
         if (!m_ftaskp) {
@@ -200,7 +200,7 @@ private:
         }
         nodep->unlinkFrBack(); VL_DO_DANGLING(pushDeletep(nodep), nodep);
     }
-    virtual void visit(AstBreak* nodep) {
+    virtual void visit(AstBreak* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         if (!m_loopp) { nodep->v3error("break isn't underneath a loop"); }
         else {
@@ -210,7 +210,7 @@ private:
         }
         nodep->unlinkFrBack(); VL_DO_DANGLING(pushDeletep(nodep), nodep);
     }
-    virtual void visit(AstContinue* nodep) {
+    virtual void visit(AstContinue* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         if (!m_loopp) { nodep->v3error("continue isn't underneath a loop"); }
         else {
@@ -221,7 +221,7 @@ private:
         }
         nodep->unlinkFrBack(); VL_DO_DANGLING(pushDeletep(nodep), nodep);
     }
-    virtual void visit(AstDisable* nodep) {
+    virtual void visit(AstDisable* nodep) VL_OVERRIDE {
         UINFO(8,"   DISABLE "<<nodep<<endl);
         iterateChildren(nodep);
         AstBegin* beginp = NULL;
@@ -244,12 +244,12 @@ private:
         nodep->unlinkFrBack(); VL_DO_DANGLING(pushDeletep(nodep), nodep);
         //if (debug()>=9) { UINFO(0,"\n"); beginp->dumpTree(cout, "  labelo: "); }
     }
-    virtual void visit(AstVarRef* nodep) {
+    virtual void visit(AstVarRef* nodep) VL_OVERRIDE {
         if (m_loopInc && nodep->varp()) nodep->varp()->usedLoopIdx(true);
     }
 
-    virtual void visit(AstConst* nodep) {}
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstConst* nodep) VL_OVERRIDE {}
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
     }
 public:

--- a/src/V3LinkLValue.cpp
+++ b/src/V3LinkLValue.cpp
@@ -50,7 +50,7 @@ private:
 
     // VISITs
     // Result handing
-    virtual void visit(AstNodeVarRef* nodep) {
+    virtual void visit(AstNodeVarRef* nodep) VL_OVERRIDE {
         // VarRef: LValue its reference
         if (m_setRefLvalue) {
             nodep->lvalue(true);
@@ -66,7 +66,7 @@ private:
     }
 
     // Nodes that start propagating down lvalues
-    virtual void visit(AstPin* nodep) {
+    virtual void visit(AstPin* nodep) VL_OVERRIDE {
         if (nodep->modVarp() && nodep->modVarp()->isWritable()) {
             // When the varref's were created, we didn't know the I/O state
             // Now that we do, and it's from a output, we know it's a lvalue
@@ -77,7 +77,7 @@ private:
             iterateChildren(nodep);
         }
     }
-    virtual void visit(AstNodeAssign* nodep) {
+    virtual void visit(AstNodeAssign* nodep) VL_OVERRIDE {
         bool last_setRefLvalue = m_setRefLvalue;
         {
             m_setRefLvalue = true;
@@ -87,7 +87,7 @@ private:
         }
         m_setRefLvalue = last_setRefLvalue;
     }
-    virtual void visit(AstFOpen* nodep) {
+    virtual void visit(AstFOpen* nodep) VL_OVERRIDE {
         bool last_setRefLvalue = m_setRefLvalue;
         {
             m_setRefLvalue = true;
@@ -98,7 +98,7 @@ private:
         }
         m_setRefLvalue = last_setRefLvalue;
     }
-    virtual void visit(AstFClose* nodep) {
+    virtual void visit(AstFClose* nodep) VL_OVERRIDE {
         bool last_setRefLvalue = m_setRefLvalue;
         {
             m_setRefLvalue = true;
@@ -106,7 +106,7 @@ private:
         }
         m_setRefLvalue = last_setRefLvalue;
     }
-    virtual void visit(AstFFlush* nodep) {
+    virtual void visit(AstFFlush* nodep) VL_OVERRIDE {
         bool last_setRefLvalue = m_setRefLvalue;
         {
             m_setRefLvalue = true;
@@ -114,7 +114,7 @@ private:
         }
         m_setRefLvalue = last_setRefLvalue;
     }
-    virtual void visit(AstFGetC* nodep) {
+    virtual void visit(AstFGetC* nodep) VL_OVERRIDE {
         bool last_setRefLvalue = m_setRefLvalue;
         {
             m_setRefLvalue = true;
@@ -122,7 +122,7 @@ private:
         }
         m_setRefLvalue = last_setRefLvalue;
     }
-    virtual void visit(AstFGetS* nodep) {
+    virtual void visit(AstFGetS* nodep) VL_OVERRIDE {
         bool last_setRefLvalue = m_setRefLvalue;
         {
             m_setRefLvalue = true;
@@ -131,7 +131,7 @@ private:
         }
         m_setRefLvalue = last_setRefLvalue;
     }
-    virtual void visit(AstFRead* nodep) {
+    virtual void visit(AstFRead* nodep) VL_OVERRIDE {
         bool last_setRefLvalue = m_setRefLvalue;
         {
             m_setRefLvalue = true;
@@ -140,7 +140,7 @@ private:
         }
         m_setRefLvalue = last_setRefLvalue;
     }
-    virtual void visit(AstFScanF* nodep) {
+    virtual void visit(AstFScanF* nodep) VL_OVERRIDE {
         bool last_setRefLvalue = m_setRefLvalue;
         {
             m_setRefLvalue = true;
@@ -149,7 +149,7 @@ private:
         }
         m_setRefLvalue = last_setRefLvalue;
     }
-    virtual void visit(AstFUngetC* nodep) {
+    virtual void visit(AstFUngetC* nodep) VL_OVERRIDE {
         bool last_setRefLvalue = m_setRefLvalue;
         {
             m_setRefLvalue = true;
@@ -157,7 +157,7 @@ private:
         }
         m_setRefLvalue = last_setRefLvalue;
     }
-    virtual void visit(AstSScanF* nodep) {
+    virtual void visit(AstSScanF* nodep) VL_OVERRIDE {
         bool last_setRefLvalue = m_setRefLvalue;
         {
             m_setRefLvalue = true;
@@ -165,13 +165,13 @@ private:
         }
         m_setRefLvalue = last_setRefLvalue;
     }
-    virtual void visit(AstSysIgnore* nodep) {
+    virtual void visit(AstSysIgnore* nodep) VL_OVERRIDE {
         // Can't know if lvalue or not; presume so as stricter
         bool last_setRefLvalue = m_setRefLvalue;
         iterateChildren(nodep);
         m_setRefLvalue = last_setRefLvalue;
     }
-    virtual void visit(AstReadMem* nodep) {
+    virtual void visit(AstReadMem* nodep) VL_OVERRIDE {
         bool last_setRefLvalue = m_setRefLvalue;
         {
             m_setRefLvalue = true;
@@ -183,7 +183,7 @@ private:
         }
         m_setRefLvalue = last_setRefLvalue;
     }
-    virtual void visit(AstValuePlusArgs* nodep) {
+    virtual void visit(AstValuePlusArgs* nodep) VL_OVERRIDE {
         bool last_setRefLvalue = m_setRefLvalue;
         {
             m_setRefLvalue = false;
@@ -193,7 +193,7 @@ private:
         }
         m_setRefLvalue = last_setRefLvalue;
     }
-    virtual void visit(AstSFormat* nodep) {
+    virtual void visit(AstSFormat* nodep) VL_OVERRIDE {
         bool last_setRefLvalue = m_setRefLvalue;
         {
             m_setRefLvalue = true;
@@ -205,7 +205,7 @@ private:
     }
 
     // Nodes that change LValue state
-    virtual void visit(AstSel* nodep) {
+    virtual void visit(AstSel* nodep) VL_OVERRIDE {
         bool last_setRefLvalue = m_setRefLvalue;
         {
             iterateAndNextNull(nodep->lhsp());
@@ -216,7 +216,7 @@ private:
         }
         m_setRefLvalue = last_setRefLvalue;
     }
-    virtual void visit(AstNodeSel* nodep) {
+    virtual void visit(AstNodeSel* nodep) VL_OVERRIDE {
         bool last_setRefLvalue = m_setRefLvalue;
         {   // Only set lvalues on the from
             iterateAndNextNull(nodep->lhsp());
@@ -225,7 +225,7 @@ private:
         }
         m_setRefLvalue = last_setRefLvalue;
     }
-    virtual void visit(AstCellArrayRef* nodep) {
+    virtual void visit(AstCellArrayRef* nodep) VL_OVERRIDE {
         bool last_setRefLvalue = m_setRefLvalue;
         {   // selp is not an lvalue
             m_setRefLvalue = false;
@@ -233,7 +233,7 @@ private:
         }
         m_setRefLvalue = last_setRefLvalue;
     }
-    virtual void visit(AstNodePreSel* nodep) {
+    virtual void visit(AstNodePreSel* nodep) VL_OVERRIDE {
         bool last_setRefLvalue = m_setRefLvalue;
         {   // Only set lvalues on the from
             iterateAndNextNull(nodep->lhsp());
@@ -243,12 +243,12 @@ private:
         }
         m_setRefLvalue = last_setRefLvalue;
     }
-    virtual void visit(AstNodeFTask* nodep) {
+    virtual void visit(AstNodeFTask* nodep) VL_OVERRIDE {
         m_ftaskp = nodep;
         iterateChildren(nodep);
         m_ftaskp = NULL;
     }
-    virtual void visit(AstNodeFTaskRef* nodep) {
+    virtual void visit(AstNodeFTaskRef* nodep) VL_OVERRIDE {
         AstNode* pinp = nodep->pinsp();
         AstNodeFTask* taskp = nodep->taskp();
         // We'll deal with mismatching pins later
@@ -270,7 +270,7 @@ private:
         }
     }
 
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         // Default: Just iterate
         iterateChildren(nodep);
     }

--- a/src/V3LinkParse.cpp
+++ b/src/V3LinkParse.cpp
@@ -106,7 +106,7 @@ private:
     }
 
     // VISITs
-    virtual void visit(AstNodeFTask* nodep) {
+    virtual void visit(AstNodeFTask* nodep) VL_OVERRIDE {
         V3Config::applyFTask(m_modp, nodep);
 
         if (!nodep->user1SetOnce()) {  // Process only once.
@@ -116,7 +116,7 @@ private:
             m_ftaskp = NULL;
         }
     }
-    virtual void visit(AstNodeFTaskRef* nodep) {
+    virtual void visit(AstNodeFTaskRef* nodep) VL_OVERRIDE {
         if (!nodep->user1SetOnce()) {  // Process only once.
             cleanFileline(nodep);
             UINFO(5,"   "<<nodep<<endl);
@@ -126,22 +126,22 @@ private:
             m_valueModp = upperValueModp;
         }
     }
-    virtual void visit(AstNodeDType* nodep) {
+    virtual void visit(AstNodeDType* nodep) VL_OVERRIDE {
         visitIterateNodeDType(nodep);
     }
-    virtual void visit(AstEnumDType* nodep) {
+    virtual void visit(AstEnumDType* nodep) VL_OVERRIDE {
         if (nodep->name() == "") {
             nodep->name(nameFromTypedef(nodep));  // Might still remain ""
         }
         visitIterateNodeDType(nodep);
     }
-    virtual void visit(AstNodeUOrStructDType* nodep) {
+    virtual void visit(AstNodeUOrStructDType* nodep) VL_OVERRIDE {
         if (nodep->name() == "") {
             nodep->name(nameFromTypedef(nodep));  // Might still remain ""
         }
         visitIterateNodeDType(nodep);
     }
-    virtual void visit(AstEnumItem* nodep) {
+    virtual void visit(AstEnumItem* nodep) VL_OVERRIDE {
         // Expand ranges
         cleanFileline(nodep);
         iterateChildren(nodep);
@@ -173,7 +173,7 @@ private:
         }
     }
 
-    virtual void visit(AstVar* nodep) {
+    virtual void visit(AstVar* nodep) VL_OVERRIDE {
         cleanFileline(nodep);
         if (VN_IS(nodep->subDTypep(), ParseTypeDType)) {
             // It's a parameter type. Use a different node type for this.
@@ -255,7 +255,7 @@ private:
         }
     }
 
-    virtual void visit(AstAttrOf* nodep) {
+    virtual void visit(AstAttrOf* nodep) VL_OVERRIDE {
         cleanFileline(nodep);
         iterateChildren(nodep);
         if (nodep->attrType() == AstAttrType::DT_PUBLIC) {
@@ -322,7 +322,7 @@ private:
         }
     }
 
-    virtual void visit(AstAlwaysPublic* nodep) {
+    virtual void visit(AstAlwaysPublic* nodep) VL_OVERRIDE {
         // AlwaysPublic was attached under a var, but it's a statement that should be
         // at the same level as the var
         cleanFileline(nodep);
@@ -337,7 +337,7 @@ private:
         }
     }
 
-    virtual void visit(AstDefImplicitDType* nodep) {
+    virtual void visit(AstDefImplicitDType* nodep) VL_OVERRIDE {
         cleanFileline(nodep);
         UINFO(8,"   DEFIMPLICIT "<<nodep<<endl);
         // Must remember what names we've already created, and combine duplicates
@@ -376,14 +376,14 @@ private:
         VL_DO_DANGLING(nodep->deleteTree(), nodep);
     }
 
-    virtual void visit(AstTypedefFwd* nodep) {
+    virtual void visit(AstTypedefFwd* nodep) VL_OVERRIDE {
         // We only needed the forward declaration in order to parse correctly.
         // We won't even check it was ever really defined, as it might have been in a header
         // file referring to a module we never needed
         VL_DO_DANGLING(nodep->unlinkFrBack()->deleteTree(), nodep);
     }
 
-    virtual void visit(AstForeach* nodep) {
+    virtual void visit(AstForeach* nodep) VL_OVERRIDE {
         // FOREACH(array,loopvars,body)
         // -> BEGIN(declare vars, loopa=lowest; WHILE(loopa<=highest, ... body))
         //nodep->dumpTree(cout, "-foreach-old:");
@@ -443,7 +443,7 @@ private:
         nodep->replaceWith(newp); VL_DO_DANGLING(nodep->deleteTree(), nodep);
     }
 
-    virtual void visit(AstNodeModule* nodep) {
+    virtual void visit(AstNodeModule* nodep) VL_OVERRIDE {
         V3Config::applyModule(nodep);
 
         AstNodeModule* origModp = m_modp;
@@ -467,36 +467,36 @@ private:
         iterateChildren(nodep);
         m_valueModp = upperValueModp;
     }
-    virtual void visit(AstInitial* nodep) {
+    virtual void visit(AstInitial* nodep) VL_OVERRIDE {
         visitIterateNoValueMod(nodep);
     }
-    virtual void visit(AstFinal* nodep) {
+    virtual void visit(AstFinal* nodep) VL_OVERRIDE {
         visitIterateNoValueMod(nodep);
     }
-    virtual void visit(AstAlways* nodep) {
+    virtual void visit(AstAlways* nodep) VL_OVERRIDE {
         m_inAlways = true;
         visitIterateNoValueMod(nodep);
         m_inAlways = false;
     }
-    virtual void visit(AstCover* nodep) {
+    virtual void visit(AstCover* nodep) VL_OVERRIDE {
         visitIterateNoValueMod(nodep);
     }
-    virtual void visit(AstRestrict* nodep) {
+    virtual void visit(AstRestrict* nodep) VL_OVERRIDE {
         visitIterateNoValueMod(nodep);
     }
 
-    virtual void visit(AstBegin* nodep) {
+    virtual void visit(AstBegin* nodep) VL_OVERRIDE {
         V3Config::applyCoverageBlock(m_modp, nodep);
         cleanFileline(nodep);
         iterateChildren(nodep);
     }
-    virtual void visit(AstCase* nodep) {
+    virtual void visit(AstCase* nodep) VL_OVERRIDE {
         V3Config::applyCase(nodep);
         cleanFileline(nodep);
         iterateChildren(nodep);
     }
 
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         // Default: Just iterate
         cleanFileline(nodep);
         iterateChildren(nodep);

--- a/src/V3LinkResolve.cpp
+++ b/src/V3LinkResolve.cpp
@@ -65,7 +65,7 @@ private:
     // TODO: Most of these visitors are here for historical reasons.
     // TODO: ExpectDecriptor can move to data type resolution, and the rest
     // TODO: could move to V3LinkParse to get them out of the way of elaboration
-    virtual void visit(AstNodeModule* nodep) {
+    virtual void visit(AstNodeModule* nodep) VL_OVERRIDE {
         // Module: Create sim table for entire module and iterate
         UINFO(8,"MODULE "<<nodep<<endl);
         if (nodep->dead()) return;
@@ -79,7 +79,7 @@ private:
         m_modp = origModp;
         m_senitemCvtNum = origSenitemCvtNum;
     }
-    virtual void visit(AstInitial* nodep) {
+    virtual void visit(AstInitial* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         // Initial assignments under function/tasks can just be simple
         // assignments without the initial
@@ -87,14 +87,14 @@ private:
             VL_DO_DANGLING(nodep->replaceWith(nodep->bodysp()->unlinkFrBackWithNext()), nodep);
         }
     }
-    virtual void visit(AstNodeCoverOrAssert* nodep) {
+    virtual void visit(AstNodeCoverOrAssert* nodep) VL_OVERRIDE {
         if (m_assertp) nodep->v3error("Assert not allowed under another assert");
         m_assertp = nodep;
         iterateChildren(nodep);
         m_assertp = NULL;
     }
 
-    virtual void visit(AstVar* nodep) {
+    virtual void visit(AstVar* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         if (m_ftaskp) nodep->funcLocal(true);
         if (nodep->isSigModPublic()) {
@@ -103,7 +103,7 @@ private:
         }
     }
 
-    virtual void visit(AstNodeVarRef* nodep) {
+    virtual void visit(AstNodeVarRef* nodep) VL_OVERRIDE {
         // VarRef: Resolve its reference
         if (nodep->varp()) {
             nodep->varp()->usedParam(true);
@@ -111,7 +111,7 @@ private:
         iterateChildren(nodep);
     }
 
-    virtual void visit(AstNodeFTask* nodep) {
+    virtual void visit(AstNodeFTask* nodep) VL_OVERRIDE {
         // NodeTask: Remember its name for later resolution
         // Remember the existing symbol table scope
         m_ftaskp = nodep;
@@ -121,14 +121,14 @@ private:
             nodep->scopeNamep(new AstScopeName(nodep->fileline()));
         }
     }
-    virtual void visit(AstNodeFTaskRef* nodep) {
+    virtual void visit(AstNodeFTaskRef* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         if (nodep->taskp() && (nodep->taskp()->dpiContext() || nodep->taskp()->dpiExport())) {
             nodep->scopeNamep(new AstScopeName(nodep->fileline()));
         }
     }
 
-    virtual void visit(AstSenItem* nodep) {
+    virtual void visit(AstSenItem* nodep) VL_OVERRIDE {
         // Remove bit selects, and bark if it's not a simple variable
         iterateChildren(nodep);
         if (nodep->isClocked()) {
@@ -195,11 +195,11 @@ private:
             nodep->v3error("Unsupported: Complex statement in sensitivity list");
         }
     }
-    virtual void visit(AstSenGate* nodep) {
+    virtual void visit(AstSenGate* nodep) VL_OVERRIDE {
         nodep->v3fatalSrc("SenGates shouldn't be in tree yet");
     }
 
-    virtual void visit(AstNodePreSel* nodep) {
+    virtual void visit(AstNodePreSel* nodep) VL_OVERRIDE {
         if (!nodep->attrp()) {
             iterateChildren(nodep);
             // Constification may change the fromp() to a constant, which will lose the
@@ -231,7 +231,7 @@ private:
         }
     }
 
-    virtual void visit(AstCaseItem* nodep) {
+    virtual void visit(AstCaseItem* nodep) VL_OVERRIDE {
         // Move default caseItems to the bottom of the list
         // That saves us from having to search each case list twice, for non-defaults and defaults
         iterateChildren(nodep);
@@ -243,7 +243,7 @@ private:
         }
     }
 
-    virtual void visit(AstPragma* nodep) {
+    virtual void visit(AstPragma* nodep) VL_OVERRIDE {
         if (nodep->pragType() == AstPragmaType::PUBLIC_MODULE) {
             UASSERT_OBJ(m_modp, nodep, "PUBLIC_MODULE not under a module");
             m_modp->modPublic(true);
@@ -364,31 +364,31 @@ private:
         if (filep && filep->varp()) filep->varp()->attrFileDescr(true);
     }
 
-    virtual void visit(AstFOpen* nodep) {
+    virtual void visit(AstFOpen* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         expectDescriptor(nodep, VN_CAST(nodep->filep(), NodeVarRef));
     }
-    virtual void visit(AstFClose* nodep) {
+    virtual void visit(AstFClose* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         expectDescriptor(nodep, VN_CAST(nodep->filep(), NodeVarRef));
     }
-    virtual void visit(AstFEof* nodep) {
+    virtual void visit(AstFEof* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         expectDescriptor(nodep, VN_CAST(nodep->filep(), NodeVarRef));
     }
-    virtual void visit(AstFRead* nodep) {
+    virtual void visit(AstFRead* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         expectDescriptor(nodep, VN_CAST(nodep->filep(), NodeVarRef));
     }
-    virtual void visit(AstFScanF* nodep) {
+    virtual void visit(AstFScanF* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         expectFormat(nodep, nodep->text(), nodep->exprsp(), true);
     }
-    virtual void visit(AstSScanF* nodep) {
+    virtual void visit(AstSScanF* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         expectFormat(nodep, nodep->text(), nodep->exprsp(), true);
     }
-    virtual void visit(AstSFormatF* nodep) {
+    virtual void visit(AstSFormatF* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         // Cleanup old-school displays without format arguments
         if (!nodep->hasFormat()) {
@@ -410,7 +410,7 @@ private:
         }
     }
 
-    virtual void visit(AstUdpTable* nodep) {
+    virtual void visit(AstUdpTable* nodep) VL_OVERRIDE {
         UINFO(5,"UDPTABLE  "<<nodep<<endl);
         if (!v3Global.opt.bboxUnsup()) {
             // We don't warn until V3Inst, so that UDPs that are in libraries and
@@ -441,23 +441,23 @@ private:
         }
     }
 
-    virtual void visit(AstScCtor* nodep) {
+    virtual void visit(AstScCtor* nodep) VL_OVERRIDE {
         // Constructor info means the module must remain public
         m_modp->modPublic(true);
         iterateChildren(nodep);
     }
-    virtual void visit(AstScDtor* nodep) {
+    virtual void visit(AstScDtor* nodep) VL_OVERRIDE {
         // Destructor info means the module must remain public
         m_modp->modPublic(true);
         iterateChildren(nodep);
     }
-    virtual void visit(AstScInt* nodep) {
+    virtual void visit(AstScInt* nodep) VL_OVERRIDE {
         // Special class info means the module must remain public
         m_modp->modPublic(true);
         iterateChildren(nodep);
     }
 
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         // Default: Just iterate
         iterateChildren(nodep);
     }
@@ -489,11 +489,11 @@ private:
     VL_DEBUG_FUNC;  // Declare debug()
 
     // VISITs
-    virtual void visit(AstNetlist* nodep) {
+    virtual void visit(AstNetlist* nodep) VL_OVERRIDE {
         // Iterate modules backwards, in bottom-up order.
         iterateChildrenBackwards(nodep);
     }
-    virtual void visit(AstNodeModule* nodep) {
+    virtual void visit(AstNodeModule* nodep) VL_OVERRIDE {
         AstNodeModule* origModp = m_modp;
         {
             m_modp = nodep;
@@ -501,15 +501,15 @@ private:
         }
         m_modp = origModp;
     }
-    virtual void visit(AstCell* nodep) {
+    virtual void visit(AstCell* nodep) VL_OVERRIDE {
         // Parent module inherits child's publicity
         if (nodep->modp()->modPublic()) m_modp->modPublic(true);
         //** No iteration for speed
     }
-    virtual void visit(AstNodeMath* nodep) {
+    virtual void visit(AstNodeMath* nodep) VL_OVERRIDE {
         // Speedup
     }
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         // Default: Just iterate
         iterateChildren(nodep);
     }

--- a/src/V3Localize.cpp
+++ b/src/V3Localize.cpp
@@ -77,14 +77,14 @@ private:
     // See above
 
     // METHODS
-    virtual void visit(AstVarRef* nodep) {
+    virtual void visit(AstVarRef* nodep) VL_OVERRIDE {
         VarFlags flags (nodep->varp());
         if (flags.m_done) {
             nodep->hiername("");  // Remove this->
             nodep->hierThis(true);
         }
     }
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
     }
 public:
@@ -151,11 +151,11 @@ private:
     }
 
     // VISITORS
-    virtual void visit(AstNetlist* nodep) {
+    virtual void visit(AstNetlist* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         moveVars();
     }
-    virtual void visit(AstCFunc* nodep) {
+    virtual void visit(AstCFunc* nodep) VL_OVERRIDE {
         UINFO(4,"  CFUNC "<<nodep<<endl);
         m_cfuncp = nodep;
         searchFuncStmts(nodep->argsp());
@@ -186,7 +186,7 @@ private:
         }
     }
 
-    virtual void visit(AstVar* nodep) {
+    virtual void visit(AstVar* nodep) VL_OVERRIDE {
         if (!nodep->isSigPublic()
             && !nodep->isPrimaryIO()
             && !m_cfuncp) {  // Not already inside a function
@@ -195,7 +195,7 @@ private:
         }
         // No iterate; Don't want varrefs under it
     }
-    virtual void visit(AstVarRef* nodep) {
+    virtual void visit(AstVarRef* nodep) VL_OVERRIDE {
         if (!VarFlags(nodep->varp()).m_notOpt) {
             if (!m_cfuncp) {  // Not in function, can't optimize
                 clearOptimizable(nodep->varp(), "BVnofunc");
@@ -224,7 +224,7 @@ private:
         }
         // No iterate; Don't want varrefs under it
     }
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
     }
 public:

--- a/src/V3Name.cpp
+++ b/src/V3Name.cpp
@@ -75,7 +75,7 @@ private:
     }
 
     // VISITORS
-    virtual void visit(AstNodeModule* nodep) {
+    virtual void visit(AstNodeModule* nodep) VL_OVERRIDE {
         AstNodeModule* origModp = m_modp;
         {
             m_modp = nodep;
@@ -84,44 +84,44 @@ private:
         m_modp = origModp;
     }
     // Add __PVT__ to names of local signals
-    virtual void visit(AstVar* nodep) {
+    virtual void visit(AstVar* nodep) VL_OVERRIDE {
         // Don't iterate... Don't need temps for RANGES under the Var.
         rename(nodep, (!m_modp->isTop()
                        && !nodep->isSigPublic()
                        && !nodep->isFuncLocal()  // Isn't exposed, and would mess up dpi import wrappers
                        && !nodep->isTemp()));  // Don't bother to rename internal signals
     }
-    virtual void visit(AstCFunc* nodep) {
+    virtual void visit(AstCFunc* nodep) VL_OVERRIDE {
         if (!nodep->user1()) {
             iterateChildren(nodep);
             rename(nodep, false);
         }
     }
-    virtual void visit(AstVarRef* nodep) {
+    virtual void visit(AstVarRef* nodep) VL_OVERRIDE {
         if (nodep->varp()) {
             iterate(nodep->varp());
             nodep->name(nodep->varp()->name());
         }
     }
-    virtual void visit(AstCell* nodep) {
+    virtual void visit(AstCell* nodep) VL_OVERRIDE {
         if (!nodep->user1()) {
             rename(nodep, !nodep->modp()->modPublic());
             iterateChildren(nodep);
         }
     }
-    virtual void visit(AstMemberDType* nodep) {
+    virtual void visit(AstMemberDType* nodep) VL_OVERRIDE {
         if (!nodep->user1()) {
             rename(nodep, false);
             iterateChildren(nodep);
         }
     }
-    virtual void visit(AstMemberSel* nodep) {
+    virtual void visit(AstMemberSel* nodep) VL_OVERRIDE {
         if (!nodep->user1()) {
             rename(nodep, false);
             iterateChildren(nodep);
         }
     }
-    virtual void visit(AstScope* nodep) {
+    virtual void visit(AstScope* nodep) VL_OVERRIDE {
         if (!nodep->user1SetOnce()) {
             if (nodep->aboveScopep()) iterate(nodep->aboveScopep());
             if (nodep->aboveCellp()) iterate(nodep->aboveCellp());
@@ -134,7 +134,7 @@ private:
     }
 
     //--------------------
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
     }
 public:

--- a/src/V3Order.cpp
+++ b/src/V3Order.cpp
@@ -274,7 +274,7 @@ private:
     // METHODS
     VL_DEBUG_FUNC;  // Declare debug()
 
-    virtual void visit(AstNodeAssign* nodep) {
+    virtual void visit(AstNodeAssign* nodep) VL_OVERRIDE {
         m_hasClk = false;
         if (AstVarRef* varrefp = VN_CAST(nodep->rhsp(), VarRef)) {
             this->visit(varrefp);
@@ -315,7 +315,7 @@ private:
         }
     }
 
-    virtual void visit(AstVarRef* nodep) {
+    virtual void visit(AstVarRef* nodep) VL_OVERRIDE {
         if (m_inAss && nodep->varp()->attrClocker() == VVarAttrClocker::CLOCKER_YES) {
             if (m_inClocked) {
                 nodep->v3warn(CLKDATA,
@@ -328,7 +328,7 @@ private:
             }
         }
     }
-    virtual void visit(AstConcat* nodep) {
+    virtual void visit(AstConcat* nodep) VL_OVERRIDE {
         if (m_inAss) {
             iterateAndNextNull(nodep->lhsp());
             int lw = m_childClkWidth;
@@ -337,20 +337,20 @@ private:
             m_childClkWidth = lw + rw;  // Pass up
         }
     }
-    virtual void visit(AstNodeSel* nodep) {
+    virtual void visit(AstNodeSel* nodep) VL_OVERRIDE {
         if (m_inAss) {
             iterateChildren(nodep);
             // Pass up result width
             if (m_childClkWidth > nodep->width()) m_childClkWidth = nodep->width();
         }
     }
-    virtual void visit(AstSel* nodep) {
+    virtual void visit(AstSel* nodep) VL_OVERRIDE {
         if (m_inAss) {
             iterateChildren(nodep);
             if (m_childClkWidth > nodep->width()) m_childClkWidth = nodep->width();
         }
     }
-    virtual void visit(AstReplicate* nodep) {
+    virtual void visit(AstReplicate* nodep) VL_OVERRIDE {
         if (m_inAss) {
             iterateChildren(nodep);
             if (VN_IS(nodep->rhsp(), Const)) {
@@ -360,12 +360,12 @@ private:
             }
         }
     }
-    virtual void visit(AstActive* nodep) {
+    virtual void visit(AstActive* nodep) VL_OVERRIDE {
         m_inClocked = nodep->hasClocked();
         iterateChildren(nodep);
         m_inClocked = false;
     }
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
     }
 
@@ -393,7 +393,7 @@ private:
     bool m_clkAss;  // There is signals marked as clocker in the assignment
     // METHODS
     VL_DEBUG_FUNC;  // Declare debug()
-    virtual void visit(AstNodeAssign* nodep) {
+    virtual void visit(AstNodeAssign* nodep) VL_OVERRIDE {
         if (const AstVarRef* varrefp = VN_CAST(nodep->lhsp(), VarRef)) {
             if (varrefp->varp()->attrClocker() == VVarAttrClocker::CLOCKER_YES) {
                 m_clkAss = true;
@@ -402,13 +402,13 @@ private:
         }
         iterateChildren(nodep->rhsp());
     }
-    virtual void visit(AstVarRef* nodep) {
+    virtual void visit(AstVarRef* nodep) VL_OVERRIDE {
         // Previous versions checked attrClocker() here, but this breaks
         // the updated t_clocker VCD test.
         // If reenable this visitor note AstNodeMath short circuit below
     }
-    virtual void visit(AstNodeMath* nodep) {}  // Accelerate
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNodeMath* nodep) VL_OVERRIDE {}  // Accelerate
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
     }
 public:
@@ -953,7 +953,7 @@ private:
         }
     }
     // VISITORS
-    virtual void visit(AstNetlist* nodep) {
+    virtual void visit(AstNetlist* nodep) VL_OVERRIDE {
         {
             AstUser4InUse       m_inuser4;      // Used only when building tree, so below
             iterateChildren(nodep);
@@ -961,7 +961,7 @@ private:
         // We're finished, complete the topscopes
         if (m_topScopep) { process(); m_topScopep=NULL; }
     }
-    virtual void visit(AstTopScope* nodep) {
+    virtual void visit(AstTopScope* nodep) VL_OVERRIDE {
         // Process the last thing we're finishing
         UASSERT_OBJ(!m_topScopep, nodep, "Only one topscope should ever be created");
         UINFO(2,"  Loading tree...\n");
@@ -1000,7 +1000,7 @@ private:
         AstNode::user3ClearTree();
         AstNode::user4ClearTree();
     }
-    virtual void visit(AstNodeModule* nodep) {
+    virtual void visit(AstNodeModule* nodep) VL_OVERRIDE {
         AstNodeModule* origModp = m_modp;
         {
             m_modp = nodep;
@@ -1008,7 +1008,7 @@ private:
         }
         m_modp = origModp;
     }
-    virtual void visit(AstScope* nodep) {
+    virtual void visit(AstScope* nodep) VL_OVERRIDE {
         UINFO(4," SCOPE "<<nodep<<endl);
         m_scopep = nodep;
         m_logicVxp = NULL;
@@ -1018,7 +1018,7 @@ private:
         iterateChildren(nodep);
         m_scopep = NULL;
     }
-    virtual void visit(AstActive* nodep) {
+    virtual void visit(AstActive* nodep) VL_OVERRIDE {
         // Create required activation blocks and add to module
         UINFO(4,"  ACTIVE  "<<nodep<<endl);
         m_activep = nodep;
@@ -1034,14 +1034,14 @@ private:
         m_activeSenVxp = NULL;
         m_inClocked = false;
     }
-    virtual void visit(AstVarScope* nodep) {
+    virtual void visit(AstVarScope* nodep) VL_OVERRIDE {
         // Create links to all input signals
         if (m_modp->isTop() && nodep->varp()->isNonOutput()) {
             OrderVarVertex* varVxp = newVarUserVertex(nodep, WV_STD);
             new OrderEdge(&m_graph, m_inputsVxp, varVxp, WEIGHT_INPUT);
         }
     }
-    virtual void visit(AstNodeVarRef* nodep) {
+    virtual void visit(AstNodeVarRef* nodep) VL_OVERRIDE {
         if (m_scopep) {
             AstVarScope* varscp = nodep->varScopep();
             UASSERT_OBJ(varscp, nodep, "Var didn't get varscoped in V3Scope.cpp");
@@ -1170,7 +1170,7 @@ private:
             }
         }
     }
-    virtual void visit(AstSenTree* nodep) {
+    virtual void visit(AstSenTree* nodep) VL_OVERRIDE {
         // Having a node derived from the sentree isn't required for
         // correctness, it merely makes the graph better connected
         // and improves graph algorithmic performance
@@ -1185,27 +1185,27 @@ private:
             m_inSenTree = false;
         }
     }
-    virtual void visit(AstAlways* nodep) {
+    virtual void visit(AstAlways* nodep) VL_OVERRIDE {
         iterateNewStmt(nodep);
     }
-    virtual void visit(AstAlwaysPost* nodep) {
+    virtual void visit(AstAlwaysPost* nodep) VL_OVERRIDE {
         m_inPost = true;
         iterateNewStmt(nodep);
         m_inPost = false;
     }
-    virtual void visit(AstAlwaysPublic* nodep) {
+    virtual void visit(AstAlwaysPublic* nodep) VL_OVERRIDE {
         iterateNewStmt(nodep);
     }
-    virtual void visit(AstAssignAlias* nodep) {
+    virtual void visit(AstAssignAlias* nodep) VL_OVERRIDE {
         iterateNewStmt(nodep);
     }
-    virtual void visit(AstAssignW* nodep) {
+    virtual void visit(AstAssignW* nodep) VL_OVERRIDE {
         OrderClkAssVisitor visitor(nodep);
         m_inClkAss = visitor.isClkAss();
         iterateNewStmt(nodep);
         m_inClkAss = false;
     }
-    virtual void visit(AstAssignPre* nodep) {
+    virtual void visit(AstAssignPre* nodep) VL_OVERRIDE {
         OrderClkAssVisitor visitor(nodep);
         m_inClkAss = visitor.isClkAss();
         m_inPre = true;
@@ -1213,7 +1213,7 @@ private:
         m_inPre = false;
         m_inClkAss = false;
     }
-    virtual void visit(AstAssignPost* nodep) {
+    virtual void visit(AstAssignPost* nodep) VL_OVERRIDE {
         OrderClkAssVisitor visitor(nodep);
         m_inClkAss = visitor.isClkAss();
         m_inPost = true;
@@ -1221,15 +1221,15 @@ private:
         m_inPost = false;
         m_inClkAss = false;
     }
-    virtual void visit(AstCoverToggle* nodep) {
+    virtual void visit(AstCoverToggle* nodep) VL_OVERRIDE {
         iterateNewStmt(nodep);
     }
-    virtual void visit(AstInitial* nodep) {
+    virtual void visit(AstInitial* nodep) VL_OVERRIDE {
         // We use initials to setup parameters and static consts's which may be referenced
         // in user initial blocks.  So use ordering to sort them all out.
         iterateNewStmt(nodep);
     }
-    virtual void visit(AstCFunc*) {
+    virtual void visit(AstCFunc*) VL_OVERRIDE {
         // Ignore for now
         // We should detect what variables are set in the function, and make
         // settlement code for them, then set a global flag, so we call "settle"
@@ -1237,7 +1237,7 @@ private:
     }
     //--------------------
     // Default
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
     }
 public:

--- a/src/V3Param.cpp
+++ b/src/V3Param.cpp
@@ -266,11 +266,11 @@ private:
     }
 
     // VISITORS
-    virtual void visit(AstNetlist* nodep) {
+    virtual void visit(AstNetlist* nodep) VL_OVERRIDE {
         // Modules must be done in top-down-order
         iterateChildren(nodep);
     }
-    virtual void visit(AstNodeModule* nodep) {
+    virtual void visit(AstNodeModule* nodep) VL_OVERRIDE {
         if (nodep->dead()) {
             UINFO(4," MOD-dead.  "<<nodep<<endl);  // Marked by LinkDot
         } else if (nodep->recursiveClone()) {
@@ -288,7 +288,7 @@ private:
             UINFO(4," MOD-dead?  "<<nodep<<endl);  // Should have been done by now, if not dead
         }
     }
-    virtual void visit(AstCell* nodep) {
+    virtual void visit(AstCell* nodep) VL_OVERRIDE {
         // Must do ifaces first, so push to list and do in proper order
         string* genHierNamep = new string(m_generateHierName);
         nodep->user5p(genHierNamep);
@@ -296,7 +296,7 @@ private:
     }
 
     // Make sure all parameters are constantified
-    virtual void visit(AstVar* nodep) {
+    virtual void visit(AstVar* nodep) VL_OVERRIDE {
         if (!nodep->user5SetOnce()) {  // Process once
             iterateChildren(nodep);
             if (nodep->isParam()) {
@@ -322,7 +322,7 @@ private:
         }
     }
     // Make sure varrefs cause vars to constify before things above
-    virtual void visit(AstVarRef* nodep) {
+    virtual void visit(AstVarRef* nodep) VL_OVERRIDE {
         if (nodep->varp()) iterate(nodep->varp());
     }
     bool ifaceParamReplace(AstVarXRef* nodep, AstNode* candp) {
@@ -342,7 +342,7 @@ private:
         }
         return false;
     }
-    virtual void visit(AstVarXRef* nodep) {
+    virtual void visit(AstVarXRef* nodep) VL_OVERRIDE {
         // Check to see if the scope is just an interface because interfaces are special
         string dotted = nodep->dotted();
         if (!dotted.empty() && nodep->varp() && nodep->varp()->isParam()) {
@@ -382,7 +382,7 @@ private:
         nodep->varp(NULL);  // Needs relink, as may remove pointed-to var
     }
 
-    virtual void visit(AstUnlinkedRef* nodep) {
+    virtual void visit(AstUnlinkedRef* nodep) VL_OVERRIDE {
         AstVarXRef* varxrefp = VN_CAST(nodep->op1p(), VarXRef);
         AstNodeFTaskRef* taskrefp = VN_CAST(nodep->op1p(), NodeFTaskRef);
         if (varxrefp) {
@@ -403,7 +403,7 @@ private:
         nodep->replaceWith(nodep->op1p()->unlinkFrBack());
         VL_DO_DANGLING(pushDeletep(nodep), nodep);
     }
-    virtual void visit(AstCellArrayRef* nodep) {
+    virtual void visit(AstCellArrayRef* nodep) VL_OVERRIDE {
         V3Const::constifyParamsEdit(nodep->selp());
         if (const AstConst* constp = VN_CAST(nodep->selp(), Const)) {
             string index = AstNode::encodeNumber(constp->toSInt());
@@ -424,7 +424,7 @@ private:
     }
 
     // Generate Statements
-    virtual void visit(AstGenerate* nodep) {
+    virtual void visit(AstGenerate* nodep) VL_OVERRIDE {
         if (debug()>=9) nodep->dumpTree(cout, "-genin: ");
         iterateChildren(nodep);
         // After expanding the generate, all statements under it can be moved
@@ -438,7 +438,7 @@ private:
         }
         VL_DO_DANGLING(nodep->deleteTree(), nodep);
     }
-    virtual void visit(AstGenIf* nodep) {
+    virtual void visit(AstGenIf* nodep) VL_OVERRIDE {
         UINFO(9,"  GENIF "<<nodep<<endl);
         iterateAndNextNull(nodep->condp());
         // We suppress errors when widthing params since short-circuiting in
@@ -468,7 +468,7 @@ private:
     //! @todo Unlike generated IF, we don't have to worry about short-circuiting the conditional
     //!       expression, since this is currently restricted to simple comparisons. If we ever do
     //!       move to more generic constant expressions, such code will be needed here.
-    virtual void visit(AstBegin* nodep) {
+    virtual void visit(AstBegin* nodep) VL_OVERRIDE {
         if (nodep->genforp()) {
             AstGenFor* forp = VN_CAST(nodep->genforp(), GenFor);
             UASSERT_OBJ(forp, nodep, "Non-GENFOR under generate-for BEGIN");
@@ -501,10 +501,10 @@ private:
             m_generateHierName = rootHierName;
         }
     }
-    virtual void visit(AstGenFor* nodep) {
+    virtual void visit(AstGenFor* nodep) VL_OVERRIDE {
         nodep->v3fatalSrc("GENFOR should have been wrapped in BEGIN");
     }
-    virtual void visit(AstGenCase* nodep) {
+    virtual void visit(AstGenCase* nodep) VL_OVERRIDE {
         UINFO(9,"  GENCASE "<<nodep<<endl);
         AstNode* keepp = NULL;
         iterateAndNextNull(nodep->exprp());
@@ -557,7 +557,7 @@ private:
     }
 
     // Default: Just iterate
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
     }
 

--- a/src/V3Partition.cpp
+++ b/src/V3Partition.cpp
@@ -1766,7 +1766,7 @@ private:
     // METHODS
     VL_DEBUG_FUNC;
 
-    virtual void visit(AstCFunc* nodep) {
+    virtual void visit(AstCFunc* nodep) VL_OVERRIDE {
         if (!m_tracingCall) return;
         m_tracingCall = false;
         if (nodep->dpiImportWrapper()) {
@@ -1777,13 +1777,13 @@ private:
         }
         iterateChildren(nodep);
     }
-    virtual void visit(AstCCall* nodep) {
+    virtual void visit(AstCCall* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         // Enter the function and trace it
         m_tracingCall = true;
         iterate(nodep->funcp());
     }
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
     }
 

--- a/src/V3Premit.cpp
+++ b/src/V3Premit.cpp
@@ -55,14 +55,14 @@ private:
     VL_DEBUG_FUNC;  // Declare debug()
 
     // VISITORS
-    virtual void visit(AstNodeAssign* nodep) {
+    virtual void visit(AstNodeAssign* nodep) VL_OVERRIDE {
         //AstNode::user4ClearTree();  // Implied by AstUser4InUse
         // LHS first as fewer varrefs
         iterateAndNextNull(nodep->lhsp());
         // Now find vars marked as lhs
         iterateAndNextNull(nodep->rhsp());
     }
-    virtual void visit(AstVarRef* nodep) {
+    virtual void visit(AstVarRef* nodep) VL_OVERRIDE {
         // it's LHS var is used so need a deep temporary
         if (nodep->lvalue()) {
             nodep->varp()->user4(true);
@@ -73,7 +73,7 @@ private:
             }
         }
     }
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
     }
 
@@ -197,7 +197,7 @@ private:
     }
 
     // VISITORS
-    virtual void visit(AstNodeModule* nodep) {
+    virtual void visit(AstNodeModule* nodep) VL_OVERRIDE {
         UINFO(4," MOD   "<<nodep<<endl);
         AstNodeModule* origModp = m_modp;
         {
@@ -207,7 +207,7 @@ private:
         }
         m_modp = origModp;
     }
-    virtual void visit(AstCFunc* nodep) {
+    virtual void visit(AstCFunc* nodep) VL_OVERRIDE {
         m_funcp = nodep;
         iterateChildren(nodep);
         m_funcp = NULL;
@@ -216,7 +216,7 @@ private:
         m_assignLhs = false;
         if (m_funcp) m_stmtp = nodep;
     }
-    virtual void visit(AstWhile* nodep) {
+    virtual void visit(AstWhile* nodep) VL_OVERRIDE {
         UINFO(4,"  WHILE  "<<nodep<<endl);
         startStatement(nodep);
         iterateAndNextNull(nodep->precondsp());
@@ -229,7 +229,7 @@ private:
         iterateAndNextNull(nodep->incsp());
         m_stmtp = NULL;
     }
-    virtual void visit(AstNodeAssign* nodep) {
+    virtual void visit(AstNodeAssign* nodep) VL_OVERRIDE {
         startStatement(nodep);
         {
             bool noopt = PremitAssignVisitor(nodep).noOpt();
@@ -245,7 +245,7 @@ private:
         m_assignLhs = false;
         m_stmtp = NULL;
     }
-    virtual void visit(AstNodeStmt* nodep) {
+    virtual void visit(AstNodeStmt* nodep) VL_OVERRIDE {
         if (!nodep->isStatement()) {
             iterateChildren(nodep);
             return;
@@ -255,7 +255,7 @@ private:
         iterateChildren(nodep);
         m_stmtp = NULL;
     }
-    virtual void visit(AstTraceInc* nodep) {
+    virtual void visit(AstTraceInc* nodep) VL_OVERRIDE {
         startStatement(nodep);
         m_inTracep = nodep;
         iterateChildren(nodep);
@@ -309,29 +309,29 @@ private:
         }
         iterateChildren(nodep); checkNode(nodep);
     }
-    virtual void visit(AstShiftL* nodep) {
+    virtual void visit(AstShiftL* nodep) VL_OVERRIDE {
         visitShift(nodep);
     }
-    virtual void visit(AstShiftR* nodep) {
+    virtual void visit(AstShiftR* nodep) VL_OVERRIDE {
         visitShift(nodep);
     }
-    virtual void visit(AstShiftRS* nodep) {
+    virtual void visit(AstShiftRS* nodep) VL_OVERRIDE {
         visitShift(nodep);
     }
     // Operators
-    virtual void visit(AstNodeTermop* nodep) {
+    virtual void visit(AstNodeTermop* nodep) VL_OVERRIDE {
         iterateChildren(nodep); checkNode(nodep);
     }
-    virtual void visit(AstNodeUniop* nodep) {
+    virtual void visit(AstNodeUniop* nodep) VL_OVERRIDE {
         iterateChildren(nodep); checkNode(nodep);
     }
-    virtual void visit(AstNodeBiop* nodep) {
+    virtual void visit(AstNodeBiop* nodep) VL_OVERRIDE {
         iterateChildren(nodep); checkNode(nodep);
     }
-    virtual void visit(AstUCFunc* nodep) {
+    virtual void visit(AstUCFunc* nodep) VL_OVERRIDE {
         iterateChildren(nodep); checkNode(nodep);
     }
-    virtual void visit(AstSel* nodep) {
+    virtual void visit(AstSel* nodep) VL_OVERRIDE {
         iterateAndNextNull(nodep->fromp());
         {   // Only the 'from' is part of the assignment LHS
             bool prevAssign = m_assignLhs;
@@ -342,7 +342,7 @@ private:
         }
         checkNode(nodep);
     }
-    virtual void visit(AstArraySel* nodep) {
+    virtual void visit(AstArraySel* nodep) VL_OVERRIDE {
         iterateAndNextNull(nodep->fromp());
         {   // Only the 'from' is part of the assignment LHS
             bool prevAssign = m_assignLhs;
@@ -352,7 +352,7 @@ private:
         }
         checkNode(nodep);
     }
-    virtual void visit(AstAssocSel* nodep) {
+    virtual void visit(AstAssocSel* nodep) VL_OVERRIDE {
         iterateAndNextNull(nodep->fromp());
         {   // Only the 'from' is part of the assignment LHS
             bool prevAssign = m_assignLhs;
@@ -362,10 +362,10 @@ private:
         }
         checkNode(nodep);
     }
-    virtual void visit(AstConst* nodep) {
+    virtual void visit(AstConst* nodep) VL_OVERRIDE {
         iterateChildren(nodep); checkNode(nodep);
     }
-    virtual void visit(AstNodeCond* nodep) {
+    virtual void visit(AstNodeCond* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         if (nodep->expr1p()->isWide()
             && !VN_IS(nodep->condp(), Const)
@@ -378,7 +378,7 @@ private:
     }
 
     // Autoflush
-    virtual void visit(AstDisplay* nodep) {
+    virtual void visit(AstDisplay* nodep) VL_OVERRIDE {
         startStatement(nodep);
         iterateChildren(nodep);
         m_stmtp = NULL;
@@ -396,7 +396,7 @@ private:
             }
         }
     }
-    virtual void visit(AstSFormatF* nodep) {
+    virtual void visit(AstSFormatF* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         // Any strings sent to a display must be var of string data type,
         // to avoid passing a pointer to a temporary.
@@ -411,8 +411,8 @@ private:
 
     //--------------------
     // Default: Just iterate
-    virtual void visit(AstVar* nodep) {}  // Don't hit varrefs under vars
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstVar* nodep) VL_OVERRIDE {}  // Don't hit varrefs under vars
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
     }
 

--- a/src/V3ProtectLib.cpp
+++ b/src/V3ProtectLib.cpp
@@ -68,7 +68,7 @@ class ProtectVisitor : public AstNVisitor {
     bool m_foundTop;                    // Have seen the top module
 
     // VISITORS
-    virtual void visit(AstNetlist* nodep) {
+    virtual void visit(AstNetlist* nodep) VL_OVERRIDE {
         m_vfilep = new AstVFile(nodep->fileline(),
                                 v3Global.opt.makeDir()+"/"+m_libName+".sv");
         nodep->addFilesp(m_vfilep);
@@ -78,7 +78,7 @@ class ProtectVisitor : public AstNVisitor {
         iterateChildren(nodep);
     }
 
-    virtual void visit(AstNodeModule* nodep) {
+    virtual void visit(AstNodeModule* nodep) VL_OVERRIDE {
         if (!nodep->isTop()) {
             return;
         } else {
@@ -347,7 +347,7 @@ class ProtectVisitor : public AstNVisitor {
         m_cfilep->tblockp(txtp);
     }
 
-    virtual void visit(AstVar* nodep) {
+    virtual void visit(AstVar* nodep) VL_OVERRIDE {
         if (!nodep->isIO()) return;
         if (VN_IS(nodep->dtypep(), UnpackArrayDType)) {
             nodep->v3error("Unsupported: unpacked arrays with protect-lib on "<<nodep->prettyNameQ());
@@ -366,7 +366,7 @@ class ProtectVisitor : public AstNVisitor {
         }
     }
 
-    virtual void visit(AstNode* nodep) { }
+    virtual void visit(AstNode* nodep) VL_OVERRIDE { }
 
     string cInputConnection(AstVar* varp) {
         string frstmt;

--- a/src/V3Reloop.cpp
+++ b/src/V3Reloop.cpp
@@ -148,12 +148,12 @@ private:
     }
 
     // VISITORS
-    virtual void visit(AstCFunc* nodep) {
+    virtual void visit(AstCFunc* nodep) VL_OVERRIDE {
         m_cfuncp = nodep;
         iterateChildren(nodep);
         m_cfuncp = NULL;
     }
-    virtual void visit(AstNodeAssign* nodep) {
+    virtual void visit(AstNodeAssign* nodep) VL_OVERRIDE {
         if (!m_cfuncp) return;
 
         // Left select WordSel or ArraySel
@@ -227,9 +227,9 @@ private:
     }
     //--------------------
     // Default: Just iterate
-    virtual void visit(AstVar* nodep) {}  // Speedup
-    virtual void visit(AstNodeMath* nodep) {}  // Speedup
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstVar* nodep) VL_OVERRIDE {}  // Speedup
+    virtual void visit(AstNodeMath* nodep) VL_OVERRIDE {}  // Speedup
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
     }
 

--- a/src/V3Scope.cpp
+++ b/src/V3Scope.cpp
@@ -88,7 +88,7 @@ private:
     }
 
     // VISITORS
-    virtual void visit(AstNetlist* nodep) {
+    virtual void visit(AstNetlist* nodep) VL_OVERRIDE {
         AstNodeModule* modp = nodep->topModulep();
         if (!modp) { nodep->v3error("No top level module found"); return; }
         // Operate starting at the top of the hierarchy
@@ -97,7 +97,7 @@ private:
         iterate(modp);
         cleanupVarRefs();
     }
-    virtual void visit(AstNodeModule* nodep) {
+    virtual void visit(AstNodeModule* nodep) VL_OVERRIDE {
         // Create required blocks and add to module
         string scopename;
         if (!m_aboveScopep) scopename = "TOP";
@@ -151,13 +151,13 @@ private:
 
         // ***Note m_scopep is passed back to the caller of the routine (above)
     }
-    virtual void visit(AstCellInline* nodep) {
+    virtual void visit(AstCellInline* nodep) VL_OVERRIDE {
         nodep->scopep(m_scopep);
     }
-    virtual void visit(AstActive* nodep) {
+    virtual void visit(AstActive* nodep) VL_OVERRIDE {
         nodep->v3fatalSrc("Actives now made after scoping");
     }
-    virtual void visit(AstInitial* nodep) {
+    virtual void visit(AstInitial* nodep) VL_OVERRIDE {
         // Add to list of blocks under this scope
         UINFO(4,"    Move "<<nodep<<endl);
         AstInitial* clonep = nodep->cloneTree(false);
@@ -165,7 +165,7 @@ private:
         m_scopep->addActivep(clonep);
         iterateChildren(clonep);  // We iterate under the *clone*
     }
-    virtual void visit(AstFinal* nodep) {
+    virtual void visit(AstFinal* nodep) VL_OVERRIDE {
         // Add to list of blocks under this scope
         UINFO(4,"    Move "<<nodep<<endl);
         AstFinal* clonep = nodep->cloneTree(false);
@@ -173,7 +173,7 @@ private:
         m_scopep->addActivep(clonep);
         iterateChildren(clonep);  // We iterate under the *clone*
     }
-    virtual void visit(AstAssignAlias* nodep) {
+    virtual void visit(AstAssignAlias* nodep) VL_OVERRIDE {
         // Add to list of blocks under this scope
         UINFO(4,"    Move "<<nodep<<endl);
         AstNode* clonep = nodep->cloneTree(false);
@@ -181,7 +181,7 @@ private:
         m_scopep->addActivep(clonep);
         iterateChildren(clonep);  // We iterate under the *clone*
     }
-    virtual void visit(AstAssignVarScope* nodep) {
+    virtual void visit(AstAssignVarScope* nodep) VL_OVERRIDE {
         // Copy under the scope but don't recurse
         UINFO(4,"    Move "<<nodep<<endl);
         AstNode* clonep = nodep->cloneTree(false);
@@ -189,7 +189,7 @@ private:
         m_scopep->addActivep(clonep);
         iterateChildren(clonep);  // We iterate under the *clone*
     }
-    virtual void visit(AstAssignW* nodep) {
+    virtual void visit(AstAssignW* nodep) VL_OVERRIDE {
         // Add to list of blocks under this scope
         UINFO(4,"    Move "<<nodep<<endl);
         AstNode* clonep = nodep->cloneTree(false);
@@ -197,7 +197,7 @@ private:
         m_scopep->addActivep(clonep);
         iterateChildren(clonep);  // We iterate under the *clone*
     }
-    virtual void visit(AstAlways* nodep) {
+    virtual void visit(AstAlways* nodep) VL_OVERRIDE {
         // Add to list of blocks under this scope
         UINFO(4,"    Move "<<nodep<<endl);
         AstNode* clonep = nodep->cloneTree(false);
@@ -205,7 +205,7 @@ private:
         m_scopep->addActivep(clonep);
         iterateChildren(clonep);  // We iterate under the *clone*
     }
-    virtual void visit(AstAlwaysPublic* nodep) {
+    virtual void visit(AstAlwaysPublic* nodep) VL_OVERRIDE {
         // Add to list of blocks under this scope
         UINFO(4,"    Move "<<nodep<<endl);
         AstNode* clonep = nodep->cloneTree(false);
@@ -213,7 +213,7 @@ private:
         m_scopep->addActivep(clonep);
         iterateChildren(clonep);  // We iterate under the *clone*
     }
-    virtual void visit(AstCoverToggle* nodep) {
+    virtual void visit(AstCoverToggle* nodep) VL_OVERRIDE {
         // Add to list of blocks under this scope
         UINFO(4,"    Move "<<nodep<<endl);
         AstNode* clonep = nodep->cloneTree(false);
@@ -221,7 +221,7 @@ private:
         m_scopep->addActivep(clonep);
         iterateChildren(clonep);  // We iterate under the *clone*
     }
-    virtual void visit(AstCFunc* nodep) {
+    virtual void visit(AstCFunc* nodep) VL_OVERRIDE {
         // Add to list of blocks under this scope
         UINFO(4,"    CFUNC "<<nodep<<endl);
         AstCFunc* clonep = nodep->cloneTree(false);
@@ -231,7 +231,7 @@ private:
         // We iterate under the *clone*
         iterateChildren(clonep);
     }
-    virtual void visit(AstNodeFTask* nodep) {
+    virtual void visit(AstNodeFTask* nodep) VL_OVERRIDE {
         // Add to list of blocks under this scope
         UINFO(4,"    FTASK "<<nodep<<endl);
         AstNodeFTask* clonep = nodep->cloneTree(false);
@@ -240,7 +240,7 @@ private:
         // We iterate under the *clone*
         iterateChildren(clonep);
     }
-    virtual void visit(AstVar* nodep) {
+    virtual void visit(AstVar* nodep) VL_OVERRIDE {
         // Make new scope variable
         // This is called cross-module by AstVar, so we cannot trust any m_ variables
         if (!nodep->user1p()) {
@@ -259,7 +259,7 @@ private:
             m_scopep->addVarp(varscp);
         }
     }
-    virtual void visit(AstVarRef* nodep) {
+    virtual void visit(AstVarRef* nodep) VL_OVERRIDE {
         // VarRef needs to point to VarScope
         // Make sure variable has made user1p.
         UASSERT_OBJ(nodep->varp(), nodep, "Unlinked");
@@ -272,7 +272,7 @@ private:
             m_varRefScopes.insert(make_pair(nodep, m_scopep));
         }
    }
-    virtual void visit(AstScopeName* nodep) {
+    virtual void visit(AstScopeName* nodep) VL_OVERRIDE {
         // If there's a %m in the display text, we add a special node that will contain the name()
         string prefix = string("__DOT__")+m_scopep->name();
         // TOP and above will be the user's name().
@@ -288,13 +288,13 @@ private:
         if (afterp) nodep->scopeEntrp(afterp);
         iterateChildren(nodep);
     }
-    virtual void visit(AstScope* nodep) {
+    virtual void visit(AstScope* nodep) VL_OVERRIDE {
         // Scope that was made by this module for different cell;
         // Want to ignore blocks under it, so just do nothing
     }
     //--------------------
     // Default
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
     }
 public:
@@ -322,7 +322,7 @@ private:
     VL_DEBUG_FUNC;  // Declare debug()
 
     // VISITORS
-    virtual void visit(AstScope* nodep) {
+    virtual void visit(AstScope* nodep) VL_OVERRIDE {
         // Want to ignore blocks under it
         m_scopep = nodep;
         iterateChildren(nodep);
@@ -341,42 +341,42 @@ private:
         }
     }
 
-    virtual void visit(AstInitial* nodep) {
+    virtual void visit(AstInitial* nodep) VL_OVERRIDE {
         movedDeleteOrIterate(nodep);
     }
-    virtual void visit(AstFinal* nodep) {
+    virtual void visit(AstFinal* nodep) VL_OVERRIDE {
         movedDeleteOrIterate(nodep);
     }
-    virtual void visit(AstAssignAlias* nodep) {
+    virtual void visit(AstAssignAlias* nodep) VL_OVERRIDE {
         movedDeleteOrIterate(nodep);
     }
-    virtual void visit(AstAssignVarScope* nodep) {
+    virtual void visit(AstAssignVarScope* nodep) VL_OVERRIDE {
         movedDeleteOrIterate(nodep);
     }
-    virtual void visit(AstAssignW* nodep) {
+    virtual void visit(AstAssignW* nodep) VL_OVERRIDE {
         movedDeleteOrIterate(nodep);
     }
-    virtual void visit(AstAlways* nodep) {
+    virtual void visit(AstAlways* nodep) VL_OVERRIDE {
         movedDeleteOrIterate(nodep);
     }
-    virtual void visit(AstAlwaysPublic* nodep) {
+    virtual void visit(AstAlwaysPublic* nodep) VL_OVERRIDE {
         movedDeleteOrIterate(nodep);
     }
-    virtual void visit(AstCoverToggle* nodep) {
+    virtual void visit(AstCoverToggle* nodep) VL_OVERRIDE {
         movedDeleteOrIterate(nodep);
     }
-    virtual void visit(AstNodeFTask* nodep) {
+    virtual void visit(AstNodeFTask* nodep) VL_OVERRIDE {
         movedDeleteOrIterate(nodep);
     }
-    virtual void visit(AstCFunc* nodep) {
+    virtual void visit(AstCFunc* nodep) VL_OVERRIDE {
         movedDeleteOrIterate(nodep);
     }
 
-    virtual void visit(AstVarXRef* nodep) {
+    virtual void visit(AstVarXRef* nodep) VL_OVERRIDE {
         // The crossrefs are dealt with in V3LinkDot
         nodep->varp(NULL);
     }
-    virtual void visit(AstNodeFTaskRef* nodep) {
+    virtual void visit(AstNodeFTaskRef* nodep) VL_OVERRIDE {
         // The crossrefs are dealt with in V3LinkDot
         UINFO(9,"   Old pkg-taskref "<<nodep<<endl);
         if (nodep->packagep()) {
@@ -392,7 +392,7 @@ private:
         }
         iterateChildren(nodep);
     }
-    virtual void visit(AstModportFTaskRef* nodep) {
+    virtual void visit(AstModportFTaskRef* nodep) VL_OVERRIDE {
         // The crossrefs are dealt with in V3LinkDot
         nodep->ftaskp(NULL);
         iterateChildren(nodep);
@@ -400,7 +400,7 @@ private:
 
     //--------------------
     // Default
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
     }
 public:

--- a/src/V3SenTree.h
+++ b/src/V3SenTree.h
@@ -105,29 +105,29 @@ private:
     // VISITORS
     VL_DEBUG_FUNC;  // Declare debug()
 
-    virtual void visit(AstNodeModule* nodep) {
+    virtual void visit(AstNodeModule* nodep) VL_OVERRIDE {
         // Only do the top
         if (nodep->isTop()) {
             iterateChildren(nodep);
         }
     }
-    virtual void visit(AstTopScope* nodep) {
+    virtual void visit(AstTopScope* nodep) VL_OVERRIDE {
         m_topscopep = nodep;
         iterateChildren(nodep);
         // Don't clear topscopep, the namer persists beyond this visit
     }
-    virtual void visit(AstScope* nodep) {
+    virtual void visit(AstScope* nodep) VL_OVERRIDE {
         // But no SenTrees under TopScope's scope
     }
     // Memorize existing block names
-    virtual void visit(AstActive* nodep) {
+    virtual void visit(AstActive* nodep) VL_OVERRIDE {
         // Don't grab SenTrees under Actives, only those that are global (under Scope directly)
         iterateChildren(nodep);
     }
-    virtual void visit(AstSenTree* nodep) { m_trees.add(nodep); }
+    virtual void visit(AstSenTree* nodep) VL_OVERRIDE { m_trees.add(nodep); }
     // Empty visitors, speed things up
-    virtual void visit(AstNodeStmt* nodep) { }
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNodeStmt* nodep) VL_OVERRIDE { }
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
     }
     // METHODS

--- a/src/V3Simulate.h
+++ b/src/V3Simulate.h
@@ -378,15 +378,15 @@ private:
     }
 
     // VISITORS
-    virtual void visit(AstAlways* nodep) {
+    virtual void visit(AstAlways* nodep) VL_OVERRIDE {
         if (jumpingOver(nodep)) return;
         checkNodeInfo(nodep);
         iterateChildren(nodep);
     }
-    virtual void visit(AstSenTree* nodep) {
+    virtual void visit(AstSenTree* nodep) VL_OVERRIDE {
         // Sensitivities aren't inputs per se; we'll keep our tree under the same sens.
     }
-    virtual void visit(AstVarRef* nodep) {
+    virtual void visit(AstVarRef* nodep) VL_OVERRIDE {
         if (jumpingOver(nodep)) return;
         if (!optimizable()) return;  // Accelerate
         UASSERT_OBJ(nodep->varp(), nodep, "Unlinked");
@@ -451,12 +451,12 @@ private:
             }
         }
     }
-    virtual void visit(AstVarXRef* nodep) {
+    virtual void visit(AstVarXRef* nodep) VL_OVERRIDE {
         if (jumpingOver(nodep)) return;
         if (m_scoped) { badNodeType(nodep); return; }
         else { clearOptimizable(nodep, "Language violation: Dotted hierarchical references not allowed in constant functions"); }
     }
-    virtual void visit(AstNodeFTask* nodep) {
+    virtual void visit(AstNodeFTask* nodep) VL_OVERRIDE {
         if (jumpingOver(nodep)) return;
         if (!m_params) { badNodeType(nodep); return; }
         if (nodep->dpiImport()) {
@@ -465,7 +465,7 @@ private:
         checkNodeInfo(nodep);
         iterateChildren(nodep);
     }
-    virtual void visit(AstNodeIf* nodep) {
+    virtual void visit(AstNodeIf* nodep) VL_OVERRIDE {
         if (jumpingOver(nodep)) return;
         UINFO(5, "   IF "<<nodep<<endl);
         checkNodeInfo(nodep);
@@ -482,19 +482,19 @@ private:
             }
         }
     }
-    virtual void visit(AstConst* nodep) {
+    virtual void visit(AstConst* nodep) VL_OVERRIDE {
         checkNodeInfo(nodep);
         if (!m_checkOnly && optimizable()) {
             newValue(nodep, nodep);
         }
     }
-    virtual void visit(AstInitArray* nodep) {
+    virtual void visit(AstInitArray* nodep) VL_OVERRIDE {
         checkNodeInfo(nodep);
         if (!m_checkOnly && optimizable()) {
             newValue(nodep, nodep);
         }
     }
-    virtual void visit(AstEnumItemRef* nodep) {
+    virtual void visit(AstEnumItemRef* nodep) VL_OVERRIDE {
         checkNodeInfo(nodep);
         UASSERT_OBJ(nodep->itemp(), nodep, "Not linked");
         if (!m_checkOnly && optimizable()) {
@@ -509,7 +509,7 @@ private:
             }
         }
     }
-    virtual void visit(AstNodeUniop* nodep) {
+    virtual void visit(AstNodeUniop* nodep) VL_OVERRIDE {
         if (!optimizable()) return;  // Accelerate
         checkNodeInfo(nodep);
         iterateChildren(nodep);
@@ -518,7 +518,7 @@ private:
                                  fetchConst(nodep->lhsp())->num());
         }
     }
-    virtual void visit(AstNodeBiop* nodep) {
+    virtual void visit(AstNodeBiop* nodep) VL_OVERRIDE {
         if (!optimizable()) return;  // Accelerate
         checkNodeInfo(nodep);
         iterateChildren(nodep);
@@ -528,7 +528,7 @@ private:
                                  fetchConst(nodep->rhsp())->num());
         }
     }
-    virtual void visit(AstNodeTriop* nodep) {
+    virtual void visit(AstNodeTriop* nodep) VL_OVERRIDE {
         if (!optimizable()) return;  // Accelerate
         checkNodeInfo(nodep);
         iterateChildren(nodep);
@@ -539,7 +539,7 @@ private:
                                  fetchConst(nodep->thsp())->num());
         }
     }
-    virtual void visit(AstLogAnd* nodep) {
+    virtual void visit(AstLogAnd* nodep) VL_OVERRIDE {
         // Need to short circuit
         if (!optimizable()) return;  // Accelerate
         checkNodeInfo(nodep);
@@ -557,7 +557,7 @@ private:
             }
         }
     }
-    virtual void visit(AstLogOr* nodep) {
+    virtual void visit(AstLogOr* nodep) VL_OVERRIDE {
         // Need to short circuit
         if (!optimizable()) return;  // Accelerate
         checkNodeInfo(nodep);
@@ -575,7 +575,7 @@ private:
             }
         }
     }
-    virtual void visit(AstLogIf* nodep) {
+    virtual void visit(AstLogIf* nodep) VL_OVERRIDE {
         // Need to short circuit, same as (!A || B)
         if (!optimizable()) return;  // Accelerate
         checkNodeInfo(nodep);
@@ -594,7 +594,7 @@ private:
             }
         }
     }
-    virtual void visit(AstNodeCond* nodep) {
+    virtual void visit(AstNodeCond* nodep) VL_OVERRIDE {
         // We could use above visit(AstNodeTriop), but need to do short circuiting.
         // It's also slower even O(n^2) to evaluate both sides when we
         // really only need to evaluate one side.
@@ -716,7 +716,7 @@ private:
         }
     }
 
-    virtual void visit(AstNodeAssign* nodep) {
+    virtual void visit(AstNodeAssign* nodep) VL_OVERRIDE {
         if (jumpingOver(nodep)) return;
         if (!optimizable()) return;  // Accelerate
         if (VN_IS(nodep, AssignDly)) {
@@ -751,7 +751,7 @@ private:
         }
         m_inDlyAssign = false;
     }
-    virtual void visit(AstArraySel* nodep) {
+    virtual void visit(AstArraySel* nodep) VL_OVERRIDE {
         checkNodeInfo(nodep);
         iterateChildren(nodep);
         if (AstInitArray* initp = VN_CAST(fetchValueNull(nodep->fromp()), InitArray)) {
@@ -768,11 +768,11 @@ private:
             clearOptimizable(nodep, "Array select of non-array");
         }
     }
-    virtual void visit(AstBegin* nodep) {
+    virtual void visit(AstBegin* nodep) VL_OVERRIDE {
         checkNodeInfo(nodep);
         iterateChildren(nodep);
     }
-    virtual void visit(AstNodeCase* nodep) {
+    virtual void visit(AstNodeCase* nodep) VL_OVERRIDE {
         if (jumpingOver(nodep)) return;
         UINFO(5, "   CASE "<<nodep<<endl);
         checkNodeInfo(nodep);
@@ -810,16 +810,16 @@ private:
         }
     }
 
-    virtual void visit(AstCaseItem* nodep) {
+    virtual void visit(AstCaseItem* nodep) VL_OVERRIDE {
         // Real handling is in AstNodeCase
         if (jumpingOver(nodep)) return;
         checkNodeInfo(nodep);
         iterateChildren(nodep);
     }
 
-    virtual void visit(AstComment*) {}
+    virtual void visit(AstComment*) VL_OVERRIDE {}
 
-    virtual void visit(AstJumpGo* nodep) {
+    virtual void visit(AstJumpGo* nodep) VL_OVERRIDE {
         if (jumpingOver(nodep)) return;
         checkNodeInfo(nodep);
         if (!m_checkOnly) {
@@ -827,7 +827,7 @@ private:
             m_jumpp = nodep;
         }
     }
-    virtual void visit(AstJumpLabel* nodep) {
+    virtual void visit(AstJumpLabel* nodep) VL_OVERRIDE {
         if (jumpingOver(nodep)) return;
         checkNodeInfo(nodep);
         iterateChildren(nodep);
@@ -836,7 +836,7 @@ private:
             m_jumpp = NULL;
         }
     }
-    virtual void visit(AstStop* nodep) {
+    virtual void visit(AstStop* nodep) VL_OVERRIDE {
         if (jumpingOver(nodep)) return;
         if (m_params) {  // This message seems better than an obscure $stop
             // The spec says $stop is just ignored, it seems evil to ignore assertions
@@ -845,7 +845,7 @@ private:
         checkNodeInfo(nodep);
     }
 
-    virtual void visit(AstNodeFor* nodep) {
+    virtual void visit(AstNodeFor* nodep) VL_OVERRIDE {
         // Doing lots of Whiles is slow, so only for parameters
         UINFO(5, "   FOR "<<nodep<<endl);
         if (!m_params) { badNodeType(nodep); return; }
@@ -874,7 +874,7 @@ private:
         }
     }
 
-    virtual void visit(AstWhile* nodep) {
+    virtual void visit(AstWhile* nodep) VL_OVERRIDE {
         // Doing lots of Whiles is slow, so only for parameters
         if (jumpingOver(nodep)) return;
         UINFO(5, "   WHILE "<<nodep<<endl);
@@ -909,7 +909,7 @@ private:
         }
     }
 
-    virtual void visit(AstFuncRef* nodep) {
+    virtual void visit(AstFuncRef* nodep) VL_OVERRIDE {
         if (jumpingOver(nodep)) return;
         if (!optimizable()) return;  // Accelerate
         UINFO(5, "   FUNCREF "<<nodep<<endl);
@@ -956,17 +956,17 @@ private:
         }
     }
 
-    virtual void visit(AstVar* nodep) {
+    virtual void visit(AstVar* nodep) VL_OVERRIDE {
         if (jumpingOver(nodep)) return;
         if (!m_params) { badNodeType(nodep); return; }
     }
 
-    virtual void visit(AstScopeName* nodep) {
+    virtual void visit(AstScopeName* nodep) VL_OVERRIDE {
         if (jumpingOver(nodep)) return;
         // Ignore
     }
 
-    virtual void visit(AstSFormatF* nodep) {
+    virtual void visit(AstSFormatF* nodep) VL_OVERRIDE {
         if (jumpingOver(nodep)) return;
         if (!optimizable()) return;  // Accelerate
         iterateChildren(nodep);
@@ -1017,7 +1017,7 @@ private:
         }
     }
 
-    virtual void visit(AstDisplay* nodep) {
+    virtual void visit(AstDisplay* nodep) VL_OVERRIDE {
         if (jumpingOver(nodep)) return;
         if (!optimizable()) return;  // Accelerate
         iterateChildren(nodep);
@@ -1039,7 +1039,7 @@ private:
     // These types are definitely not reducible
     //   AstCoverInc, AstFinish,
     //   AstRand, AstTime, AstUCFunc, AstCCall, AstCStmt, AstUCStmt
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         if (jumpingOver(nodep)) return;
         badNodeType(nodep);
     }

--- a/src/V3Slice.cpp
+++ b/src/V3Slice.cpp
@@ -124,7 +124,7 @@ class SliceVisitor : public AstNVisitor {
         return newp;
     }
 
-    virtual void visit(AstNodeAssign* nodep) {
+    virtual void visit(AstNodeAssign* nodep) VL_OVERRIDE {
         // Called recursively on newly created assignments
         if (!nodep->user1()
             && !VN_IS(nodep, AssignAlias)) {
@@ -157,7 +157,7 @@ class SliceVisitor : public AstNVisitor {
         }
     }
 
-    virtual void visit(AstInitArray* nodep) {
+    virtual void visit(AstInitArray* nodep) VL_OVERRIDE {
         UASSERT_OBJ(!m_assignp, nodep,
                     "Array initialization should have been removed earlier");
     }
@@ -216,20 +216,20 @@ class SliceVisitor : public AstNVisitor {
             iterateChildren(nodep);
         }
     }
-    virtual void visit(AstEq* nodep) {
+    virtual void visit(AstEq* nodep) VL_OVERRIDE {
         expandBiOp(nodep);
     }
-    virtual void visit(AstNeq* nodep) {
+    virtual void visit(AstNeq* nodep) VL_OVERRIDE {
         expandBiOp(nodep);
     }
-    virtual void visit(AstEqCase* nodep) {
+    virtual void visit(AstEqCase* nodep) VL_OVERRIDE {
         expandBiOp(nodep);
     }
-    virtual void visit(AstNeqCase* nodep) {
+    virtual void visit(AstNeqCase* nodep) VL_OVERRIDE {
         expandBiOp(nodep);
     }
 
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         // Default: Just iterate
         iterateChildren(nodep);
     }

--- a/src/V3Split.cpp
+++ b/src/V3Split.cpp
@@ -346,19 +346,19 @@ protected:
     virtual void makeRvalueEdges(SplitVarStdVertex* vstdp) = 0;
 
     // VISITORS
-    virtual void visit(AstAlways* nodep) = 0;
-    virtual void visit(AstNodeIf* nodep) = 0;
+    virtual void visit(AstAlways* nodep) VL_OVERRIDE = 0;
+    virtual void visit(AstNodeIf* nodep) VL_OVERRIDE = 0;
 
     // We don't do AstNodeFor/AstWhile loops, due to the standard question
     // of what is before vs. after
 
-    virtual void visit(AstAssignDly* nodep) {
+    virtual void visit(AstAssignDly* nodep) VL_OVERRIDE {
         m_inDly = true;
         UINFO(4,"    ASSIGNDLY "<<nodep<<endl);
         iterateChildren(nodep);
         m_inDly = false;
     }
-    virtual void visit(AstVarRef* nodep) {
+    virtual void visit(AstVarRef* nodep) VL_OVERRIDE {
         if (!m_stmtStackps.empty()) {
             AstVarScope* vscp = nodep->varScopep();
             UASSERT_OBJ(vscp, nodep, "Not linked");
@@ -422,7 +422,7 @@ protected:
         }
     }
 
-    virtual void visit(AstJumpGo* nodep) {
+    virtual void visit(AstJumpGo* nodep) VL_OVERRIDE {
         // Jumps will disable reordering at all levels
         // This is overly pessimistic; we could treat jumps as barriers, and
         // reorder everything between jumps/labels, however jumps are rare
@@ -434,7 +434,7 @@ protected:
 
     //--------------------
     // Default
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         // **** SPECIAL default type that sets PLI_ORDERING
         if (!m_stmtStackps.empty() && !nodep->isPure()) {
             UINFO(9,"         NotSplittable "<<nodep<<endl);
@@ -606,7 +606,7 @@ protected:
         firstp->user3p(oldBlockUser3);
     }
 
-    virtual void visit(AstAlways* nodep) {
+    virtual void visit(AstAlways* nodep) VL_OVERRIDE {
         UINFO(4,"   ALW   "<<nodep<<endl);
         if (debug()>=9) nodep->dumpTree(cout, "   alwIn:: ");
         scoreboardClear();
@@ -614,7 +614,7 @@ protected:
         if (debug()>=9) nodep->dumpTree(cout, "   alwOut: ");
     }
 
-    virtual void visit(AstNodeIf* nodep) {
+    virtual void visit(AstNodeIf* nodep) VL_OVERRIDE {
         UINFO(4,"     IF "<<nodep<<endl);
         iterateAndNextNull(nodep->condp());
         processBlock(nodep->ifsp());
@@ -672,13 +672,13 @@ private:
     }
 
 protected:
-    virtual void visit(AstNodeIf* nodep) {
+    virtual void visit(AstNodeIf* nodep) VL_OVERRIDE {
         m_ifStack.push_back(nodep);
         trackNode(nodep);
         iterateChildren(nodep);
         m_ifStack.pop_back();
     }
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         trackNode(nodep);
         iterateChildren(nodep);
     }
@@ -746,7 +746,7 @@ protected:
         return new AstSplitPlaceholder(m_origAlwaysp->fileline());
     }
 
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         // Anything that's not an if/else we assume is a leaf
         // (that is, something we won't split.) Don't visit further
         // into the leaf.
@@ -768,7 +768,7 @@ protected:
         m_addAfter[color] = clonedp;
     }
 
-    virtual void visit(AstNodeIf* nodep) {
+    virtual void visit(AstNodeIf* nodep) VL_OVERRIDE {
         const ColorSet& colors = m_ifColorp->colors(nodep);
         typedef vl_unordered_map<uint32_t, AstNodeIf*> CloneMap;
         CloneMap clones;
@@ -829,10 +829,10 @@ public:
         }
     }
     virtual ~RemovePlaceholdersVisitor() {}
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
     }
-    virtual void visit(AstSplitPlaceholder* nodep) {
+    virtual void visit(AstSplitPlaceholder* nodep) VL_OVERRIDE {
         m_removeSet.insert(nodep);
     }
 private:
@@ -955,7 +955,7 @@ protected:
         if (debug()>=9) m_graph.dumpDotFilePrefixed("splitg_colored", false);
     }
 
-    virtual void visit(AstAlways* nodep) {
+    virtual void visit(AstAlways* nodep) VL_OVERRIDE {
         // build the scoreboard
         scoreboardClear();
         scanBlock(nodep->bodysp());
@@ -988,7 +988,7 @@ protected:
             emitSplit.go();
         }
     }
-    virtual void visit(AstNodeIf* nodep) {
+    virtual void visit(AstNodeIf* nodep) VL_OVERRIDE {
         UINFO(4,"     IF "<<nodep<<endl);
         m_curIfConditional = nodep;
         iterateAndNextNull(nodep->condp());

--- a/src/V3SplitAs.cpp
+++ b/src/V3SplitAs.cpp
@@ -55,13 +55,13 @@ private:
     AstVarScope* m_splitVscp;  // Variable we want to split
 
     // METHODS
-    virtual void visit(AstVarRef* nodep) {
+    virtual void visit(AstVarRef* nodep) VL_OVERRIDE {
         if (nodep->lvalue() && !m_splitVscp
             && nodep->varp()->attrIsolateAssign()) {
             m_splitVscp = nodep->varScopep();
         }
     }
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
     }
 public:
@@ -87,7 +87,7 @@ private:
     bool         m_matches;     // Statement below has matching lvalue reference
 
     // METHODS
-    virtual void visit(AstVarRef* nodep) {
+    virtual void visit(AstVarRef* nodep) VL_OVERRIDE {
         if (nodep->lvalue()) {
             if (nodep->varScopep()==m_splitVscp) {
                 UINFO(6,"       CL VAR "<<nodep<<endl);
@@ -95,7 +95,7 @@ private:
             }
         }
     }
-    virtual void visit(AstNodeStmt* nodep) {
+    virtual void visit(AstNodeStmt* nodep) VL_OVERRIDE {
         if (!nodep->isStatement()) {
             iterateChildren(nodep);
             return;
@@ -121,7 +121,7 @@ private:
         m_keepStmt = oldKeep || m_keepStmt;
         UINFO(9,"     upKeep="<<m_keepStmt<<" STMT "<<nodep<<endl);
     }
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
     }
 public:
@@ -168,7 +168,7 @@ private:
         }
     }
 
-    virtual void visit(AstAlways* nodep) {
+    virtual void visit(AstAlways* nodep) VL_OVERRIDE {
         // Are there any lvalue references below this?
         // There could be more than one.  So, we process the first one found first.
         AstVarScope* lastSplitVscp = NULL;
@@ -194,9 +194,9 @@ private:
     }
 
     // Speedup; no always under math
-    virtual void visit(AstNodeMath* nodep) {}
+    virtual void visit(AstNodeMath* nodep) VL_OVERRIDE {}
 
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
     }
 

--- a/src/V3Stats.cpp
+++ b/src/V3Stats.cpp
@@ -82,7 +82,7 @@ private:
     }
 
     // VISITORS
-    virtual void visit(AstNodeModule* nodep) {
+    virtual void visit(AstNodeModule* nodep) VL_OVERRIDE {
         allNodes(nodep);
         if (!m_fast) {
             // Count all CFuncs below this module
@@ -91,7 +91,7 @@ private:
         // Else we recursively trace fast CFuncs from the top _eval
         // func, see visit(AstNetlist*)
     }
-    virtual void visit(AstVar* nodep) {
+    virtual void visit(AstVar* nodep) VL_OVERRIDE {
         allNodes(nodep);
         iterateChildrenConst(nodep);
         if (m_counting && nodep->dtypep()) {
@@ -114,7 +114,7 @@ private:
             }
         }
     }
-    virtual void visit(AstVarScope* nodep) {
+    virtual void visit(AstVarScope* nodep) VL_OVERRIDE {
         allNodes(nodep);
         iterateChildrenConst(nodep);
         if (m_counting) {
@@ -123,7 +123,7 @@ private:
             }
         }
     }
-    virtual void visit(AstNodeIf* nodep) {
+    virtual void visit(AstNodeIf* nodep) VL_OVERRIDE {
         UINFO(4,"   IF i="<<m_instrs<<" "<<nodep<<endl);
         allNodes(nodep);
         // Condition is part of cost allocated to PREVIOUS block
@@ -175,9 +175,9 @@ private:
         }
     }
     // While's we assume evaluate once.
-    //virtual void visit(AstWhile* nodep) {
+    //virtual void visit(AstWhile* nodep) VL_OVERRIDE {
 
-    virtual void visit(AstCCall* nodep) {
+    virtual void visit(AstCCall* nodep) VL_OVERRIDE {
         allNodes(nodep);
         iterateChildrenConst(nodep);
         if (m_fast && !nodep->funcp()->entryPoint()) {
@@ -186,7 +186,7 @@ private:
             iterate(nodep->funcp());
         }
     }
-    virtual void visit(AstCFunc* nodep) {
+    virtual void visit(AstCFunc* nodep) VL_OVERRIDE {
         if (m_fast) {
             if (!m_tracingCall && !nodep->entryPoint()) return;
             m_tracingCall = false;
@@ -196,11 +196,11 @@ private:
         iterateChildrenConst(nodep);
         m_cfuncp = NULL;
     }
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         allNodes(nodep);
         iterateChildrenConst(nodep);
     }
-    virtual void visit(AstNetlist* nodep) {
+    virtual void visit(AstNetlist* nodep) VL_OVERRIDE {
         if (m_fast && nodep->evalp()) {
             m_instrs = 0;
             m_counting = true;

--- a/src/V3Subst.cpp
+++ b/src/V3Subst.cpp
@@ -193,7 +193,7 @@ private:
         return reinterpret_cast<SubstVarEntry*>(nodep->varp()->user1p());  // Might be NULL
     }
     // VISITORS
-    virtual void visit(AstVarRef* nodep) {
+    virtual void visit(AstVarRef* nodep) VL_OVERRIDE {
         SubstVarEntry* entryp = findEntryp(nodep);
         if (entryp) {
             // Don't sweat it.  We assign a new temp variable for every new assignment,
@@ -206,8 +206,8 @@ private:
             }
         }
     }
-    virtual void visit(AstConst* nodep) {}  // Accelerate
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstConst* nodep) VL_OVERRIDE {}  // Accelerate
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
     }
 public:
@@ -261,7 +261,7 @@ private:
     }
 
     // VISITORS
-    virtual void visit(AstNodeAssign* nodep) {
+    virtual void visit(AstNodeAssign* nodep) VL_OVERRIDE {
         m_ops = 0;
         m_assignStep++;
         iterateAndNextNull(nodep->rhsp());
@@ -311,7 +311,7 @@ private:
         VL_DO_DANGLING(pushDeletep(nodep), nodep);
         ++m_statSubsts;
     }
-    virtual void visit(AstWordSel* nodep) {
+    virtual void visit(AstWordSel* nodep) VL_OVERRIDE {
         iterate(nodep->rhsp());
         AstVarRef* varrefp = VN_CAST(nodep->lhsp(), VarRef);
         AstConst* constp = VN_CAST(nodep->rhsp(), Const);
@@ -338,7 +338,7 @@ private:
             iterate(nodep->lhsp());
         }
     }
-    virtual void visit(AstVarRef* nodep) {
+    virtual void visit(AstVarRef* nodep) VL_OVERRIDE {
         // Any variable
         if (nodep->lvalue()) {
             m_assignStep++;
@@ -366,9 +366,9 @@ private:
             }
         }
     }
-    virtual void visit(AstVar* nodep) {}
-    virtual void visit(AstConst* nodep) {}
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstVar* nodep) VL_OVERRIDE {}
+    virtual void visit(AstConst* nodep) VL_OVERRIDE {}
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         m_ops++;
         if (!nodep->isSubstOptimizable()) {
             m_ops = SUBST_MAX_OPS_NA;

--- a/src/V3Table.cpp
+++ b/src/V3Table.cpp
@@ -424,10 +424,10 @@ private:
 
 
     // VISITORS
-    virtual void visit(AstNetlist* nodep) {
+    virtual void visit(AstNetlist* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
     }
-    virtual void visit(AstNodeModule* nodep) {
+    virtual void visit(AstNodeModule* nodep) VL_OVERRIDE {
         AstNodeModule* origModp = m_modp;
         int origModTables = m_modTables;
         ModTableVector origModTableVscs = m_modTableVscs;
@@ -441,27 +441,27 @@ private:
         m_modTables = origModTables;
         m_modTableVscs = origModTableVscs;
     }
-    virtual void visit(AstScope* nodep) {
+    virtual void visit(AstScope* nodep) VL_OVERRIDE {
         UINFO(4," SCOPE "<<nodep<<endl);
         m_scopep = nodep;
         iterateChildren(nodep);
         m_scopep = NULL;
     }
-    virtual void visit(AstAlways* nodep) {
+    virtual void visit(AstAlways* nodep) VL_OVERRIDE {
         UINFO(4,"  ALWAYS  "<<nodep<<endl);
         if (treeTest(nodep)) {
             // Well, then, I'll be a memory hog.
             VL_DO_DANGLING(createTable(nodep), nodep);
         }
     }
-    virtual void visit(AstAssignAlias* nodep) {}
-    virtual void visit(AstAssignW* nodep) {
+    virtual void visit(AstAssignAlias* nodep) VL_OVERRIDE {}
+    virtual void visit(AstAssignW* nodep) VL_OVERRIDE {
         // It's nearly impossible to have a large enough assign to make this worthwhile
         // For now we won't bother.
         // Accelerated: no iterate
     }
     // default
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
     }
 public:

--- a/src/V3Task.cpp
+++ b/src/V3Task.cpp
@@ -163,7 +163,7 @@ private:
     }
 
     // VISITORS
-    virtual void visit(AstScope* nodep) {
+    virtual void visit(AstScope* nodep) VL_OVERRIDE {
         // Each FTask is unique per-scope, so AstNodeFTaskRefs do not need
         // pointers to what scope the FTask is to be invoked under.
         // However, to create variables, we need to track the scopes involved.
@@ -184,12 +184,12 @@ private:
         }
         iterateChildren(nodep);
     }
-    virtual void visit(AstAssignW* nodep) {
+    virtual void visit(AstAssignW* nodep) VL_OVERRIDE {
         m_assignwp = nodep;
         VL_DO_DANGLING(iterateChildren(nodep), nodep);  // May delete nodep.
         m_assignwp = NULL;
     }
-    virtual void visit(AstNodeFTaskRef* nodep) {
+    virtual void visit(AstNodeFTaskRef* nodep) VL_OVERRIDE {
         if (m_assignwp) {
             // Wire assigns must become always statements to deal with insertion
             // of multiple statements.  Perhaps someday make all wassigns into always's?
@@ -201,7 +201,7 @@ private:
         UASSERT_OBJ(nodep->taskp(), nodep, "Unlinked task");
         new TaskEdge(&m_callGraph, m_curVxp, getFTaskVertex(nodep->taskp()));
     }
-    virtual void visit(AstNodeFTask* nodep) {
+    virtual void visit(AstNodeFTask* nodep) VL_OVERRIDE {
         UINFO(9,"  TASK "<<nodep<<endl);
         TaskBaseVertex* lastVxp = m_curVxp;
         m_curVxp = getFTaskVertex(nodep);
@@ -209,7 +209,7 @@ private:
         iterateChildren(nodep);
         m_curVxp = lastVxp;
     }
-    virtual void visit(AstPragma* nodep) {
+    virtual void visit(AstPragma* nodep) VL_OVERRIDE {
         if (nodep->pragType() == AstPragmaType::NO_INLINE_TASK) {
             // Just mark for the next steps, and we're done with it.
             m_curVxp->noInline(true);
@@ -219,11 +219,11 @@ private:
             iterateChildren(nodep);
         }
     }
-    virtual void visit(AstVar* nodep) {
+    virtual void visit(AstVar* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         nodep->user4p(m_curVxp);  // Remember what task it's under
     }
-    virtual void visit(AstVarRef* nodep) {
+    virtual void visit(AstVarRef* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         if (nodep->varp()->user4u().toGraphVertex() != m_curVxp) {
             if (m_curVxp->pure()
@@ -234,7 +234,7 @@ private:
     }
     //--------------------
     // Default: Just iterate
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
     }
 public:
@@ -264,7 +264,7 @@ private:
     //   AstVar::user2p         // AstVarScope* to replace varref with
 
     // VISITORS
-    virtual void visit(AstVarRef* nodep) {
+    virtual void visit(AstVarRef* nodep) VL_OVERRIDE {
         // Similar code in V3Inline
         if (nodep->varp()->user2p()) {  // It's being converted to an alias.
             UINFO(9, "    relinkVar "<<cvtToHex(nodep->varp()->user2p())<<" "<<nodep<<endl);
@@ -278,7 +278,7 @@ private:
     }
 
     //--------------------
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
     }
 public:
@@ -1127,7 +1127,7 @@ private:
     }
 
     // VISITORS
-    virtual void visit(AstNodeModule* nodep) {
+    virtual void visit(AstNodeModule* nodep) VL_OVERRIDE {
         AstNodeModule* origModp = m_modp;
         int origNCalls = m_modNCalls;
         {
@@ -1139,17 +1139,17 @@ private:
         m_modp = origModp;
         m_modNCalls = origNCalls;
     }
-    virtual void visit(AstTopScope* nodep) {
+    virtual void visit(AstTopScope* nodep) VL_OVERRIDE {
         m_topScopep = nodep;
         iterateChildren(nodep);
     }
-    virtual void visit(AstScope* nodep) {
+    virtual void visit(AstScope* nodep) VL_OVERRIDE {
         m_scopep = nodep;
         m_insStmtp = NULL;
         iterateChildren(nodep);
         m_scopep = NULL;
     }
-    virtual void visit(AstNodeFTaskRef* nodep) {
+    virtual void visit(AstNodeFTaskRef* nodep) VL_OVERRIDE {
         UASSERT_OBJ(nodep->taskp(), nodep, "Unlinked?");
         iterateIntoFTask(nodep->taskp());  // First, do hierarchical funcs
         UINFO(4," FTask REF   "<<nodep<<endl);
@@ -1195,7 +1195,7 @@ private:
         // Visit nodes that normal iteration won't find
         if (visitp) iterateAndNextNull(visitp);
     }
-    virtual void visit(AstNodeFTask* nodep) {
+    virtual void visit(AstNodeFTask* nodep) VL_OVERRIDE {
         UINFO(4," Inline   "<<nodep<<endl);
         InsertMode prevInsMode = m_insMode;
         AstNode* prevInsStmtp = m_insStmtp;
@@ -1256,7 +1256,7 @@ private:
         m_insMode = prevInsMode;
         m_insStmtp = prevInsStmtp;
     }
-    virtual void visit(AstWhile* nodep) {
+    virtual void visit(AstWhile* nodep) VL_OVERRIDE {
         // Special, as statements need to be put in different places
         // Preconditions insert first just before themselves (the normal
         // rule for other statement types)
@@ -1273,10 +1273,10 @@ private:
         // Done the loop
         m_insStmtp = NULL;  // Next thing should be new statement
     }
-    virtual void visit(AstNodeFor* nodep) {
+    virtual void visit(AstNodeFor* nodep) VL_OVERRIDE {
         nodep->v3fatalSrc("For statements should have been converted to while statements in V3Begin.cpp");
     }
-    virtual void visit(AstNodeStmt* nodep) {
+    virtual void visit(AstNodeStmt* nodep) VL_OVERRIDE {
         if (!nodep->isStatement()) {
             iterateChildren(nodep);
             return;
@@ -1288,7 +1288,7 @@ private:
     }
     //--------------------
     // Default: Just iterate
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
     }
 

--- a/src/V3Trace.cpp
+++ b/src/V3Trace.cpp
@@ -613,7 +613,7 @@ private:
     }
 
     // VISITORS
-    virtual void visit(AstNetlist* nodep) {
+    virtual void visit(AstNetlist* nodep) VL_OVERRIDE {
         m_code = 1;  // Multiple TopScopes will require fixing how code#s
         // are assigned as duplicate varscopes must result in the same tracing code#.
 
@@ -641,17 +641,17 @@ private:
         assignActivity();
         putTracesIntoTree();
     }
-    virtual void visit(AstNodeModule* nodep) {
+    virtual void visit(AstNodeModule* nodep) VL_OVERRIDE {
         if (nodep->isTop()) m_topModp = nodep;
         iterateChildren(nodep);
     }
-    virtual void visit(AstTopScope* nodep) {
+    virtual void visit(AstTopScope* nodep) VL_OVERRIDE {
         AstScope* scopep = nodep->scopep();
         UASSERT_OBJ(scopep, nodep, "No scope found on top level");
         m_highScopep = scopep;
         iterateChildren(nodep);
     }
-    virtual void visit(AstCCall* nodep) {
+    virtual void visit(AstCCall* nodep) VL_OVERRIDE {
         UINFO(8,"   CCALL "<<nodep<<endl);
         if (!m_finding && !nodep->user2()) {
             // See if there are other calls in same statement list;
@@ -669,7 +669,7 @@ private:
         }
         iterateChildren(nodep);
     }
-    virtual void visit(AstCFunc* nodep) {
+    virtual void visit(AstCFunc* nodep) VL_OVERRIDE {
         UINFO(8,"   CFUNC "<<nodep<<endl);
         if (nodep->funcType() == AstCFuncType::TRACE_INIT) {
             m_initFuncp = nodep;
@@ -693,7 +693,7 @@ private:
         iterateChildren(nodep);
         m_funcp = NULL;
     }
-    virtual void visit(AstTraceInc* nodep) {
+    virtual void visit(AstTraceInc* nodep) VL_OVERRIDE {
         UINFO(8,"   TRACE "<<nodep<<endl);
         UASSERT_OBJ(!m_finding, nodep, "Traces should have been removed in prev step.");
         nodep->unlinkFrBack();
@@ -706,7 +706,7 @@ private:
         iterateChildren(nodep);
         m_tracep = NULL;
     }
-    virtual void visit(AstVarRef* nodep) {
+    virtual void visit(AstVarRef* nodep) VL_OVERRIDE {
         if (m_tracep) {
             UASSERT_OBJ(nodep->varScopep(), nodep, "No var scope?");
             UASSERT_OBJ(!nodep->lvalue(), nodep, "Lvalue in trace?  Should be const.");
@@ -732,7 +732,7 @@ private:
         }
     }
     //--------------------
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
     }
 

--- a/src/V3TraceDecl.cpp
+++ b/src/V3TraceDecl.cpp
@@ -143,7 +143,7 @@ private:
     }
 
     // VISITORS
-    virtual void visit(AstTopScope* nodep) {
+    virtual void visit(AstTopScope* nodep) VL_OVERRIDE {
         m_scopetopp = nodep->scopep();
         // Make containers for TRACEDECLs first
         m_initFuncp = newCFunc(AstCFuncType::TRACE_INIT, "traceInitThis", true);
@@ -154,7 +154,7 @@ private:
         // And find variables
         iterateChildren(nodep);
     }
-    virtual void visit(AstScope* nodep) {
+    virtual void visit(AstScope* nodep) VL_OVERRIDE {
         AstCell* cellp = VN_CAST(nodep->aboveCellp(), Cell);
         if (cellp && VN_IS(cellp->modp(), Iface)) {
             AstCFunc* origSubFunc = m_initSubFuncp;
@@ -192,7 +192,7 @@ private:
             iterateChildren(nodep);
         }
     }
-    virtual void visit(AstVarScope* nodep) {
+    virtual void visit(AstVarScope* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         // Prefilter - things that get through this if will either get
         // traced or get a comment as to why not traced.
@@ -235,17 +235,17 @@ private:
         }
     }
     // VISITORS - Data types when tracing
-    virtual void visit(AstConstDType* nodep) {
+    virtual void visit(AstConstDType* nodep) VL_OVERRIDE {
         if (m_traVscp) {
             iterate(nodep->subDTypep()->skipRefp());
         }
     }
-    virtual void visit(AstRefDType* nodep) {
+    virtual void visit(AstRefDType* nodep) VL_OVERRIDE {
         if (m_traVscp) {
             iterate(nodep->subDTypep()->skipRefp());
         }
     }
-    virtual void visit(AstUnpackArrayDType* nodep) {
+    virtual void visit(AstUnpackArrayDType* nodep) VL_OVERRIDE {
         // Note more specific dtypes above
         if (m_traVscp) {
             if (static_cast<int>(nodep->arrayUnpackedElements()) > v3Global.opt.traceMaxArray()) {
@@ -280,7 +280,7 @@ private:
             }
         }
     }
-    virtual void visit(AstPackArrayDType* nodep) {
+    virtual void visit(AstPackArrayDType* nodep) VL_OVERRIDE {
         if (m_traVscp) {
             if (!v3Global.opt.traceStructs()) {
                 // Everything downstream is packed, so deal with as one trace unit.
@@ -306,7 +306,7 @@ private:
             }
         }
     }
-    virtual void visit(AstNodeUOrStructDType* nodep) {
+    virtual void visit(AstNodeUOrStructDType* nodep) VL_OVERRIDE {
         if (m_traVscp) {
             if (nodep->packed() && !v3Global.opt.traceStructs()) {
                 // Everything downstream is packed, so deal with as one trace unit
@@ -341,7 +341,7 @@ private:
             }
         }
     }
-    virtual void visit(AstBasicDType* nodep) {
+    virtual void visit(AstBasicDType* nodep) VL_OVERRIDE {
         if (m_traVscp) {
             if (nodep->isString()) {
                 addIgnore("Unsupported: strings");
@@ -350,14 +350,14 @@ private:
             }
         }
     }
-    virtual void visit(AstNodeDType* nodep) {
+    virtual void visit(AstNodeDType* nodep) VL_OVERRIDE {
         // Note more specific dtypes above
         if (!m_traVscp) return;
         addIgnore("Unsupported: data type");
     }
 
     //--------------------
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
     }
 

--- a/src/V3Tristate.cpp
+++ b/src/V3Tristate.cpp
@@ -286,7 +286,7 @@ class TristatePinVisitor : public TristateBaseVisitor {
     TristateGraph& m_tgraph;
     bool m_lvalue;  // Flip to be an LVALUE
     // VISITORS
-    virtual void visit(AstVarRef* nodep) {
+    virtual void visit(AstVarRef* nodep) VL_OVERRIDE {
         if (m_lvalue && !nodep->lvalue()) {
             UINFO(9,"  Flip-to-LValue "<<nodep<<endl);
             nodep->lvalue(true);
@@ -298,17 +298,17 @@ class TristatePinVisitor : public TristateBaseVisitor {
             m_tgraph.setTristate(nodep->varp());
         }
     }
-    virtual void visit(AstArraySel* nodep) {
+    virtual void visit(AstArraySel* nodep) VL_OVERRIDE {
         // Doesn't work because we'd set lvalue on the array index's var
         UASSERT_OBJ(!m_lvalue, nodep, "ArraySel conversion to output, under tristate node");
         iterateChildren(nodep);
     }
-    virtual void visit(AstSliceSel* nodep) {
+    virtual void visit(AstSliceSel* nodep) VL_OVERRIDE {
         // Doesn't work because we'd set lvalue on the array index's var
         UASSERT_OBJ(!m_lvalue, nodep, "SliceSel conversion to output, under tristate node");
         iterateChildren(nodep);
     }
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
     }
 public:
@@ -646,7 +646,7 @@ class TristateVisitor : public TristateBaseVisitor {
     }
 
     // VISITORS
-    virtual void visit(AstConst* nodep) {
+    virtual void visit(AstConst* nodep) VL_OVERRIDE {
         UINFO(9,dbgState()<<nodep<<endl);
         if (m_graphing) {
             if (!m_alhs && nodep->num().hasZ()) {
@@ -682,7 +682,7 @@ class TristateVisitor : public TristateBaseVisitor {
         }
     }
 
-    virtual void visit(AstCond* nodep) {
+    virtual void visit(AstCond* nodep) VL_OVERRIDE {
         if (m_graphing) {
             iterateChildren(nodep);
             if (m_alhs) {
@@ -725,7 +725,7 @@ class TristateVisitor : public TristateBaseVisitor {
         }
     }
 
-    virtual void visit(AstSel* nodep) {
+    virtual void visit(AstSel* nodep) VL_OVERRIDE {
         if (m_graphing) {
             iterateChildren(nodep);
             if (m_alhs) {
@@ -763,7 +763,7 @@ class TristateVisitor : public TristateBaseVisitor {
         }
     }
 
-    virtual void visit(AstConcat* nodep) {
+    virtual void visit(AstConcat* nodep) VL_OVERRIDE {
         if (m_graphing) {
             iterateChildren(nodep);
             if (m_alhs) {
@@ -813,7 +813,7 @@ class TristateVisitor : public TristateBaseVisitor {
         }
     }
 
-    virtual void visit(AstBufIf1* nodep) {
+    virtual void visit(AstBufIf1* nodep) VL_OVERRIDE {
         // For BufIf1, the enable is the LHS expression
         iterateChildren(nodep);
         UINFO(9,dbgState()<<nodep<<endl);
@@ -899,10 +899,10 @@ class TristateVisitor : public TristateBaseVisitor {
             expr2p->user1p(NULL);
         }
     }
-    virtual void visit(AstAnd* nodep) {
+    virtual void visit(AstAnd* nodep) VL_OVERRIDE {
         visitAndOr(nodep, true);
     }
-    virtual void visit(AstOr* nodep) {
+    virtual void visit(AstOr* nodep) VL_OVERRIDE {
         visitAndOr(nodep, false);
     }
 
@@ -939,10 +939,10 @@ class TristateVisitor : public TristateBaseVisitor {
             m_alhs = false;
         }
     }
-    virtual void visit(AstAssignW* nodep) {
+    virtual void visit(AstAssignW* nodep) VL_OVERRIDE {
         visitAssign(nodep);
     }
-    virtual void visit(AstAssign* nodep) {
+    virtual void visit(AstAssign* nodep) VL_OVERRIDE {
         visitAssign(nodep);
     }
 
@@ -993,20 +993,20 @@ class TristateVisitor : public TristateBaseVisitor {
             return;
         }
     }
-    virtual void visit(AstEqCase* nodep) {
+    virtual void visit(AstEqCase* nodep) VL_OVERRIDE {
         visitCaseEq(nodep, false);
     }
-    virtual void visit(AstNeqCase* nodep) {
+    virtual void visit(AstNeqCase* nodep) VL_OVERRIDE {
         visitCaseEq(nodep, true);
     }
-    virtual void visit(AstEqWild* nodep) {
+    virtual void visit(AstEqWild* nodep) VL_OVERRIDE {
         visitEqNeqWild(nodep);
     }
-    virtual void visit(AstNeqWild* nodep) {
+    virtual void visit(AstNeqWild* nodep) VL_OVERRIDE {
         visitEqNeqWild(nodep);
     }
 
-    virtual void visit(AstPull* nodep) {
+    virtual void visit(AstPull* nodep) VL_OVERRIDE {
         UINFO(9,dbgState()<<nodep<<endl);
         AstVarRef* varrefp = NULL;
         if (VN_IS(nodep->lhsp(), VarRef)) {
@@ -1083,7 +1083,7 @@ class TristateVisitor : public TristateBaseVisitor {
     //                     __out(to-resolver-only)
     //     const inout  Spec says illegal
     //     const output Unsupported; Illegal?
-    virtual void visit(AstPin* nodep) {
+    virtual void visit(AstPin* nodep) VL_OVERRIDE {
         if (m_graphing) {
             if (nodep->user2() & U2_GRAPHING) return;  // This pin is already expanded
             nodep->user2(U2_GRAPHING);
@@ -1238,7 +1238,7 @@ class TristateVisitor : public TristateBaseVisitor {
         }
     }
 
-    virtual void visit(AstVarRef* nodep) {
+    virtual void visit(AstVarRef* nodep) VL_OVERRIDE {
         UINFO(9,dbgState()<<nodep<<endl);
         if (m_graphing) {
             if (nodep->lvalue()) {
@@ -1272,7 +1272,7 @@ class TristateVisitor : public TristateBaseVisitor {
         }
     }
 
-    virtual void visit(AstVar* nodep) {
+    virtual void visit(AstVar* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         UINFO(9,dbgState()<<nodep<<endl);
         if (m_graphing) {
@@ -1305,7 +1305,7 @@ class TristateVisitor : public TristateBaseVisitor {
         }
     }
 
-    virtual void visit(AstNodeModule* nodep) {
+    virtual void visit(AstNodeModule* nodep) VL_OVERRIDE {
         UINFO(8, nodep << endl);
         AstNodeModule* origModp = m_modp;
         bool origGraphing = m_graphing;
@@ -1340,28 +1340,28 @@ class TristateVisitor : public TristateBaseVisitor {
         m_tgraph = origTgraph;
     }
 
-    virtual void visit(AstNodeFTask* nodep) {
+    virtual void visit(AstNodeFTask* nodep) VL_OVERRIDE {
         // don't deal with functions
     }
 
-    virtual void visit(AstCaseItem* nodep) {
+    virtual void visit(AstCaseItem* nodep) VL_OVERRIDE {
         // don't deal with casez compare '???? values
         iterateAndNextNull(nodep->bodysp());
     }
 
-    virtual void visit(AstCell* nodep) {
+    virtual void visit(AstCell* nodep) VL_OVERRIDE {
         m_cellp = nodep;
         m_alhs = false;
         iterateChildren(nodep);
         m_cellp = NULL;
     }
 
-    virtual void visit(AstNetlist* nodep) {
+    virtual void visit(AstNetlist* nodep) VL_OVERRIDE {
         iterateChildrenBackwards(nodep);
     }
 
     // Default: Just iterate
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         checkUnhandled(nodep);
     }

--- a/src/V3Undriven.cpp
+++ b/src/V3Undriven.cpp
@@ -274,7 +274,7 @@ private:
     }
 
     // VISITORS
-    virtual void visit(AstVar* nodep) {
+    virtual void visit(AstVar* nodep) VL_OVERRIDE {
         for (int usr=1; usr<(m_alwaysCombp?3:2); ++usr) {
             // For assigns and non-combo always, do just usr==1, to look
             // for module-wide undriven etc.
@@ -299,15 +299,15 @@ private:
         // Discover variables used in bit definitions, etc
         iterateChildren(nodep);
     }
-    virtual void visit(AstArraySel* nodep) {
+    virtual void visit(AstArraySel* nodep) VL_OVERRIDE {
         // Arrays are rarely constant assigned, so for now we punt and do all entries
         iterateChildren(nodep);
     }
-    virtual void visit(AstSliceSel* nodep) {
+    virtual void visit(AstSliceSel* nodep) VL_OVERRIDE {
         // Arrays are rarely constant assigned, so for now we punt and do all entries
         iterateChildren(nodep);
     }
-    virtual void visit(AstSel* nodep) {
+    virtual void visit(AstSel* nodep) VL_OVERRIDE {
         AstNodeVarRef* varrefp = VN_CAST(nodep->fromp(), NodeVarRef);
         AstConst* constp = VN_CAST(nodep->lsbp(), Const);
         if (varrefp && constp && !constp->num().isFourState()) {
@@ -330,7 +330,7 @@ private:
             iterateChildren(nodep);
         }
     }
-    virtual void visit(AstNodeVarRef* nodep) {
+    virtual void visit(AstNodeVarRef* nodep) VL_OVERRIDE {
         // Any variable
         if (nodep->lvalue()
             && !VN_IS(nodep, VarXRef)) {  // Ignore interface variables and similar ugly items
@@ -363,14 +363,14 @@ private:
     }
 
     // Don't know what black boxed calls do, assume in+out
-    virtual void visit(AstSysIgnore* nodep) {
+    virtual void visit(AstSysIgnore* nodep) VL_OVERRIDE {
         bool prevMark = m_inBBox;
         m_inBBox = true;
         iterateChildren(nodep);
         m_inBBox = prevMark;
     }
 
-    virtual void visit(AstAssign* nodep) {
+    virtual void visit(AstAssign* nodep) VL_OVERRIDE {
         bool prevProc = m_inProcAssign;
         {
             m_inProcAssign = true;
@@ -378,7 +378,7 @@ private:
         }
         m_inProcAssign = prevProc;
     }
-    virtual void visit(AstAssignDly* nodep) {
+    virtual void visit(AstAssignDly* nodep) VL_OVERRIDE {
         bool prevProc = m_inProcAssign;
         {
             m_inProcAssign = true;
@@ -386,7 +386,7 @@ private:
         }
         m_inProcAssign = prevProc;
     }
-    virtual void visit(AstAssignW* nodep) {
+    virtual void visit(AstAssignW* nodep) VL_OVERRIDE {
         bool prevCont = m_inContAssign;
         {
             m_inContAssign = true;
@@ -394,7 +394,7 @@ private:
         }
         m_inContAssign = prevCont;
     }
-    virtual void visit(AstAlways* nodep) {
+    virtual void visit(AstAlways* nodep) VL_OVERRIDE {
         AstAlways* prevAlwp = m_alwaysCombp;
         {
             AstNode::user2ClearTree();
@@ -407,7 +407,7 @@ private:
         m_alwaysCombp = prevAlwp;
     }
 
-    virtual void visit(AstNodeFTask* nodep) {
+    virtual void visit(AstNodeFTask* nodep) VL_OVERRIDE {
         AstNodeFTask* prevTaskp = m_taskp;
         m_taskp = nodep;
         iterateChildren(nodep);
@@ -415,18 +415,18 @@ private:
     }
 
     // Until we support tables, primitives will have undriven and unused I/Os
-    virtual void visit(AstPrimitive* nodep) {}
+    virtual void visit(AstPrimitive* nodep) VL_OVERRIDE {}
 
     // Coverage artifacts etc shouldn't count as a sink
-    virtual void visit(AstCoverDecl* nodep) {}
-    virtual void visit(AstCoverInc* nodep) {}
-    virtual void visit(AstCoverToggle* nodep) {}
-    virtual void visit(AstTraceDecl* nodep) {}
-    virtual void visit(AstTraceInc* nodep) {}
+    virtual void visit(AstCoverDecl* nodep) VL_OVERRIDE {}
+    virtual void visit(AstCoverInc* nodep) VL_OVERRIDE {}
+    virtual void visit(AstCoverToggle* nodep) VL_OVERRIDE {}
+    virtual void visit(AstTraceDecl* nodep) VL_OVERRIDE {}
+    virtual void visit(AstTraceInc* nodep) VL_OVERRIDE {}
 
     // iterate
-    virtual void visit(AstConst* nodep) {}
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstConst* nodep) VL_OVERRIDE {}
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
     }
 public:

--- a/src/V3Unknown.cpp
+++ b/src/V3Unknown.cpp
@@ -145,7 +145,7 @@ private:
     }
 
     // VISITORS
-    virtual void visit(AstNodeModule* nodep) {
+    virtual void visit(AstNodeModule* nodep) VL_OVERRIDE {
         UINFO(4," MOD   "<<nodep<<endl);
         AstNodeModule* origModp = m_modp;
         {
@@ -155,23 +155,23 @@ private:
         }
         m_modp = origModp;
     }
-    virtual void visit(AstAssignDly* nodep) {
+    virtual void visit(AstAssignDly* nodep) VL_OVERRIDE {
         m_assigndlyp = nodep;
         VL_DO_DANGLING(iterateChildren(nodep), nodep);  // May delete nodep.
         m_assigndlyp = NULL;
     }
-    virtual void visit(AstAssignW* nodep) {
+    virtual void visit(AstAssignW* nodep) VL_OVERRIDE {
         m_assignwp = nodep;
         VL_DO_DANGLING(iterateChildren(nodep), nodep);  // May delete nodep.
         m_assignwp = NULL;
     }
-    virtual void visit(AstCaseItem* nodep) {
+    virtual void visit(AstCaseItem* nodep) VL_OVERRIDE {
         m_constXCvt = false;  // Avoid losing the X's in casex
         iterateAndNextNull(nodep->condsp());
         m_constXCvt = true;
         iterateAndNextNull(nodep->bodysp());
     }
-    virtual void visit(AstNodeDType* nodep) {
+    virtual void visit(AstNodeDType* nodep) VL_OVERRIDE {
         m_constXCvt = false;  // Avoid losing the X's in casex
         iterateChildren(nodep);
         m_constXCvt = true;
@@ -243,19 +243,19 @@ private:
         }
     }
 
-    virtual void visit(AstEqCase* nodep) {
+    virtual void visit(AstEqCase* nodep) VL_OVERRIDE {
         visitEqNeqCase(nodep);
     }
-    virtual void visit(AstNeqCase* nodep) {
+    virtual void visit(AstNeqCase* nodep) VL_OVERRIDE {
         visitEqNeqCase(nodep);
     }
-    virtual void visit(AstEqWild* nodep) {
+    virtual void visit(AstEqWild* nodep) VL_OVERRIDE {
         visitEqNeqWild(nodep);
     }
-    virtual void visit(AstNeqWild* nodep) {
+    virtual void visit(AstNeqWild* nodep) VL_OVERRIDE {
         visitEqNeqWild(nodep);
     }
-    virtual void visit(AstIsUnknown* nodep) {
+    virtual void visit(AstIsUnknown* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         // Ahh, we're two state, so this is easy
         UINFO(4," ISUNKNOWN->0 "<<nodep<<endl);
@@ -263,7 +263,7 @@ private:
         nodep->replaceWith(newp);
         VL_DO_DANGLING(nodep->deleteTree(), nodep);
     }
-    virtual void visit(AstConst* nodep) {
+    virtual void visit(AstConst* nodep) VL_OVERRIDE {
         if (m_constXCvt
             && nodep->num().isFourState()) {
             UINFO(4," CONST4 "<<nodep<<endl);
@@ -327,7 +327,7 @@ private:
         }
     }
 
-    virtual void visit(AstSel* nodep) {
+    virtual void visit(AstSel* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         if (!nodep->user1SetOnce()) {
             // Guard against reading/writing past end of bit vector array
@@ -379,7 +379,7 @@ private:
     // visit(AstSliceSel) not needed as its bounds are constant and checked
     // in V3Width.
 
-    virtual void visit(AstArraySel* nodep) {
+    virtual void visit(AstArraySel* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         if (!nodep->user1SetOnce()) {
             if (debug()==9) nodep->dumpTree(cout, "-in: ");
@@ -457,7 +457,7 @@ private:
     }
     //--------------------
     // Default: Just iterate
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
     }
 

--- a/src/V3Unroll.cpp
+++ b/src/V3Unroll.cpp
@@ -367,7 +367,7 @@ private:
         return true;
     }
 
-    virtual void visit(AstWhile* nodep) {
+    virtual void visit(AstWhile* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         if (m_varModeCheck || m_varModeReplace) {
         } else {
@@ -396,7 +396,7 @@ private:
             }
         }
     }
-    virtual void visit(AstGenFor* nodep) {
+    virtual void visit(AstGenFor* nodep) VL_OVERRIDE {
         if (!m_generate || m_varModeReplace) {
             iterateChildren(nodep);
         }  // else V3Param will recursively call each for loop to be unrolled for us
@@ -424,7 +424,7 @@ private:
             }
         }
     }
-    virtual void visit(AstNodeFor* nodep) {
+    virtual void visit(AstNodeFor* nodep) VL_OVERRIDE {
         if (m_generate) {  // Ignore for's when expanding genfor's
             iterateChildren(nodep);
         } else {
@@ -432,7 +432,7 @@ private:
         }
     }
 
-    virtual void visit(AstVarRef* nodep) {
+    virtual void visit(AstVarRef* nodep) VL_OVERRIDE {
         if (m_varModeCheck
             && nodep->varp() == m_forVarp
             && nodep->varScopep() == m_forVscp
@@ -453,7 +453,7 @@ private:
 
     //--------------------
     // Default: Just iterate
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         if (m_varModeCheck && nodep == m_ignoreIncp) {
             // Ignore subtree that is the increment
         } else {

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -220,121 +220,121 @@ private:
     //                  _Ox=anything
 
     // Widths: 1 bit out, lhs 1 bit; Real: converts via compare with 0
-    virtual void visit(AstLogNot* nodep) {      visit_log_not(nodep); }
+    virtual void visit(AstLogNot* nodep) VL_OVERRIDE {      visit_log_not(nodep); }
     // Widths: 1 bit out, lhs 1 bit, rhs 1 bit; Real: converts via compare with 0
-    virtual void visit(AstLogAnd* nodep) {      visit_log_and_or(nodep); }
-    virtual void visit(AstLogOr* nodep) {       visit_log_and_or(nodep); }
-    virtual void visit(AstLogEq* nodep) {       visit_log_and_or(nodep); }  // Conversion from real not in IEEE, but a fallout
-    virtual void visit(AstLogIf* nodep) {       visit_log_and_or(nodep); }  // Conversion from real not in IEEE, but a fallout
+    virtual void visit(AstLogAnd* nodep) VL_OVERRIDE {      visit_log_and_or(nodep); }
+    virtual void visit(AstLogOr* nodep) VL_OVERRIDE {       visit_log_and_or(nodep); }
+    virtual void visit(AstLogEq* nodep) VL_OVERRIDE {       visit_log_and_or(nodep); }  // Conversion from real not in IEEE, but a fallout
+    virtual void visit(AstLogIf* nodep) VL_OVERRIDE {       visit_log_and_or(nodep); }  // Conversion from real not in IEEE, but a fallout
 
     // Widths: 1 bit out, Any width lhs
-    virtual void visit(AstRedAnd* nodep) {      visit_red_and_or(nodep); }
-    virtual void visit(AstRedOr* nodep) {       visit_red_and_or(nodep); }
-    virtual void visit(AstRedXnor* nodep){      visit_red_and_or(nodep); }
-    virtual void visit(AstRedXor* nodep) {      visit_red_and_or(nodep); }
-    virtual void visit(AstOneHot* nodep) {      visit_red_and_or(nodep); }
-    virtual void visit(AstOneHot0* nodep) {     visit_red_and_or(nodep); }
-    virtual void visit(AstIsUnknown* nodep) {   visit_red_unknown(nodep); }  // Allow real
+    virtual void visit(AstRedAnd* nodep) VL_OVERRIDE {      visit_red_and_or(nodep); }
+    virtual void visit(AstRedOr* nodep) VL_OVERRIDE {       visit_red_and_or(nodep); }
+    virtual void visit(AstRedXnor* nodep) VL_OVERRIDE {      visit_red_and_or(nodep); }
+    virtual void visit(AstRedXor* nodep) VL_OVERRIDE {      visit_red_and_or(nodep); }
+    virtual void visit(AstOneHot* nodep) VL_OVERRIDE {      visit_red_and_or(nodep); }
+    virtual void visit(AstOneHot0* nodep) VL_OVERRIDE {     visit_red_and_or(nodep); }
+    virtual void visit(AstIsUnknown* nodep) VL_OVERRIDE {   visit_red_unknown(nodep); }  // Allow real
 
     // These have different node types, as they operate differently
     // Must add to case statement below,
     // Widths: 1 bit out, lhs width == rhs width.  real if lhs|rhs real
-    virtual void visit(AstEq* nodep) {          visit_cmp_eq_gt(nodep, true); }
-    virtual void visit(AstNeq* nodep) {         visit_cmp_eq_gt(nodep, true); }
-    virtual void visit(AstGt* nodep) {          visit_cmp_eq_gt(nodep, true); }
-    virtual void visit(AstGte* nodep) {         visit_cmp_eq_gt(nodep, true); }
-    virtual void visit(AstLt* nodep) {          visit_cmp_eq_gt(nodep, true); }
-    virtual void visit(AstLte* nodep) {         visit_cmp_eq_gt(nodep, true); }
-    virtual void visit(AstGtS* nodep) {         visit_cmp_eq_gt(nodep, true); }
-    virtual void visit(AstGteS* nodep) {        visit_cmp_eq_gt(nodep, true); }
-    virtual void visit(AstLtS* nodep) {         visit_cmp_eq_gt(nodep, true); }
-    virtual void visit(AstLteS* nodep) {        visit_cmp_eq_gt(nodep, true); }
-    virtual void visit(AstEqCase* nodep) {      visit_cmp_eq_gt(nodep, true); }
-    virtual void visit(AstNeqCase* nodep) {     visit_cmp_eq_gt(nodep, true); }
+    virtual void visit(AstEq* nodep) VL_OVERRIDE {          visit_cmp_eq_gt(nodep, true); }
+    virtual void visit(AstNeq* nodep) VL_OVERRIDE {         visit_cmp_eq_gt(nodep, true); }
+    virtual void visit(AstGt* nodep) VL_OVERRIDE {          visit_cmp_eq_gt(nodep, true); }
+    virtual void visit(AstGte* nodep) VL_OVERRIDE {         visit_cmp_eq_gt(nodep, true); }
+    virtual void visit(AstLt* nodep) VL_OVERRIDE {          visit_cmp_eq_gt(nodep, true); }
+    virtual void visit(AstLte* nodep) VL_OVERRIDE {         visit_cmp_eq_gt(nodep, true); }
+    virtual void visit(AstGtS* nodep) VL_OVERRIDE {         visit_cmp_eq_gt(nodep, true); }
+    virtual void visit(AstGteS* nodep) VL_OVERRIDE {        visit_cmp_eq_gt(nodep, true); }
+    virtual void visit(AstLtS* nodep) VL_OVERRIDE {         visit_cmp_eq_gt(nodep, true); }
+    virtual void visit(AstLteS* nodep) VL_OVERRIDE {        visit_cmp_eq_gt(nodep, true); }
+    virtual void visit(AstEqCase* nodep) VL_OVERRIDE {      visit_cmp_eq_gt(nodep, true); }
+    virtual void visit(AstNeqCase* nodep) VL_OVERRIDE {     visit_cmp_eq_gt(nodep, true); }
     // ...    These comparisons don't allow reals
-    virtual void visit(AstEqWild* nodep) {      visit_cmp_eq_gt(nodep, false); }
-    virtual void visit(AstNeqWild* nodep) {     visit_cmp_eq_gt(nodep, false); }
+    virtual void visit(AstEqWild* nodep) VL_OVERRIDE {      visit_cmp_eq_gt(nodep, false); }
+    virtual void visit(AstNeqWild* nodep) VL_OVERRIDE {     visit_cmp_eq_gt(nodep, false); }
     // ...    Real compares
-    virtual void visit(AstEqD* nodep) {         visit_cmp_real(nodep); }
-    virtual void visit(AstNeqD* nodep) {        visit_cmp_real(nodep); }
-    virtual void visit(AstLtD* nodep) {         visit_cmp_real(nodep); }
-    virtual void visit(AstLteD* nodep) {        visit_cmp_real(nodep); }
-    virtual void visit(AstGtD* nodep) {         visit_cmp_real(nodep); }
-    virtual void visit(AstGteD* nodep) {        visit_cmp_real(nodep); }
+    virtual void visit(AstEqD* nodep) VL_OVERRIDE {         visit_cmp_real(nodep); }
+    virtual void visit(AstNeqD* nodep) VL_OVERRIDE {        visit_cmp_real(nodep); }
+    virtual void visit(AstLtD* nodep) VL_OVERRIDE {         visit_cmp_real(nodep); }
+    virtual void visit(AstLteD* nodep) VL_OVERRIDE {        visit_cmp_real(nodep); }
+    virtual void visit(AstGtD* nodep) VL_OVERRIDE {         visit_cmp_real(nodep); }
+    virtual void visit(AstGteD* nodep) VL_OVERRIDE {        visit_cmp_real(nodep); }
     // ...    String compares
-    virtual void visit(AstEqN* nodep) {         visit_cmp_string(nodep); }
-    virtual void visit(AstNeqN* nodep) {        visit_cmp_string(nodep); }
-    virtual void visit(AstLtN* nodep) {         visit_cmp_string(nodep); }
-    virtual void visit(AstLteN* nodep) {        visit_cmp_string(nodep); }
-    virtual void visit(AstGtN* nodep) {         visit_cmp_string(nodep); }
-    virtual void visit(AstGteN* nodep) {        visit_cmp_string(nodep); }
+    virtual void visit(AstEqN* nodep) VL_OVERRIDE {         visit_cmp_string(nodep); }
+    virtual void visit(AstNeqN* nodep) VL_OVERRIDE {        visit_cmp_string(nodep); }
+    virtual void visit(AstLtN* nodep) VL_OVERRIDE {         visit_cmp_string(nodep); }
+    virtual void visit(AstLteN* nodep) VL_OVERRIDE {        visit_cmp_string(nodep); }
+    virtual void visit(AstGtN* nodep) VL_OVERRIDE {         visit_cmp_string(nodep); }
+    virtual void visit(AstGteN* nodep) VL_OVERRIDE {        visit_cmp_string(nodep); }
 
     // Widths: out width = lhs width = rhs width
     // Signed: Output signed iff LHS & RHS signed.
     // Real: Not allowed
-    virtual void visit(AstAnd* nodep) {         visit_boolmath_and_or(nodep); }
-    virtual void visit(AstOr* nodep) {          visit_boolmath_and_or(nodep); }
-    virtual void visit(AstXnor* nodep) {        visit_boolmath_and_or(nodep); }
-    virtual void visit(AstXor* nodep) {         visit_boolmath_and_or(nodep); }
-    virtual void visit(AstBufIf1* nodep) {      visit_boolmath_and_or(nodep); }  // Signed behavior changing in 3.814
+    virtual void visit(AstAnd* nodep) VL_OVERRIDE {         visit_boolmath_and_or(nodep); }
+    virtual void visit(AstOr* nodep) VL_OVERRIDE {          visit_boolmath_and_or(nodep); }
+    virtual void visit(AstXnor* nodep) VL_OVERRIDE {        visit_boolmath_and_or(nodep); }
+    virtual void visit(AstXor* nodep) VL_OVERRIDE {         visit_boolmath_and_or(nodep); }
+    virtual void visit(AstBufIf1* nodep) VL_OVERRIDE {      visit_boolmath_and_or(nodep); }  // Signed behavior changing in 3.814
     // Width: Max(Lhs,Rhs) sort of.
     // Real: If either side real
     // Signed: If both sides real
-    virtual void visit(AstAdd* nodep) {         visit_add_sub_replace(nodep, true); }
-    virtual void visit(AstSub* nodep) {         visit_add_sub_replace(nodep, true); }
-    virtual void visit(AstDiv* nodep) {         visit_add_sub_replace(nodep, true); }
-    virtual void visit(AstMul* nodep) {         visit_add_sub_replace(nodep, true); }
+    virtual void visit(AstAdd* nodep) VL_OVERRIDE {         visit_add_sub_replace(nodep, true); }
+    virtual void visit(AstSub* nodep) VL_OVERRIDE {         visit_add_sub_replace(nodep, true); }
+    virtual void visit(AstDiv* nodep) VL_OVERRIDE {         visit_add_sub_replace(nodep, true); }
+    virtual void visit(AstMul* nodep) VL_OVERRIDE {         visit_add_sub_replace(nodep, true); }
     // These can't promote to real
-    virtual void visit(AstModDiv* nodep) {      visit_add_sub_replace(nodep, false); }
-    virtual void visit(AstModDivS* nodep) {     visit_add_sub_replace(nodep, false); }
-    virtual void visit(AstMulS* nodep) {        visit_add_sub_replace(nodep, false); }
-    virtual void visit(AstDivS* nodep) {        visit_add_sub_replace(nodep, false); }
+    virtual void visit(AstModDiv* nodep) VL_OVERRIDE {      visit_add_sub_replace(nodep, false); }
+    virtual void visit(AstModDivS* nodep) VL_OVERRIDE {     visit_add_sub_replace(nodep, false); }
+    virtual void visit(AstMulS* nodep) VL_OVERRIDE {        visit_add_sub_replace(nodep, false); }
+    virtual void visit(AstDivS* nodep) VL_OVERRIDE {        visit_add_sub_replace(nodep, false); }
     // Widths: out width = lhs width, but upper matters
     // Signed: Output signed iff LHS signed; unary operator
     // Unary promote to real
-    virtual void visit(AstNegate* nodep) {      visit_negate_not(nodep, true); }
+    virtual void visit(AstNegate* nodep) VL_OVERRIDE {      visit_negate_not(nodep, true); }
     // Unary never real
-    virtual void visit(AstNot* nodep) {         visit_negate_not(nodep, false); }
+    virtual void visit(AstNot* nodep) VL_OVERRIDE {         visit_negate_not(nodep, false); }
 
     // Real: inputs and output real
-    virtual void visit(AstAddD* nodep) {        visit_real_add_sub(nodep); }
-    virtual void visit(AstSubD* nodep) {        visit_real_add_sub(nodep); }
-    virtual void visit(AstDivD* nodep) {        visit_real_add_sub(nodep); }
-    virtual void visit(AstMulD* nodep) {        visit_real_add_sub(nodep); }
-    virtual void visit(AstPowD* nodep) {        visit_real_add_sub(nodep); }
-    virtual void visit(AstNodeSystemBiop* nodep) { visit_real_add_sub(nodep); }
+    virtual void visit(AstAddD* nodep) VL_OVERRIDE {        visit_real_add_sub(nodep); }
+    virtual void visit(AstSubD* nodep) VL_OVERRIDE {        visit_real_add_sub(nodep); }
+    virtual void visit(AstDivD* nodep) VL_OVERRIDE {        visit_real_add_sub(nodep); }
+    virtual void visit(AstMulD* nodep) VL_OVERRIDE {        visit_real_add_sub(nodep); }
+    virtual void visit(AstPowD* nodep) VL_OVERRIDE {        visit_real_add_sub(nodep); }
+    virtual void visit(AstNodeSystemBiop* nodep) VL_OVERRIDE { visit_real_add_sub(nodep); }
     // Real: Output real
-    virtual void visit(AstNegateD* nodep) {     visit_real_neg_ceil(nodep); }
-    virtual void visit(AstNodeSystemUniop* nodep) { visit_real_neg_ceil(nodep); }
+    virtual void visit(AstNegateD* nodep) VL_OVERRIDE {     visit_real_neg_ceil(nodep); }
+    virtual void visit(AstNodeSystemUniop* nodep) VL_OVERRIDE { visit_real_neg_ceil(nodep); }
 
     // Widths: out signed/unsigned width = lhs width, input un|signed
-    virtual void visit(AstSigned* nodep) {
+    virtual void visit(AstSigned* nodep) VL_OVERRIDE {
         visit_signed_unsigned(nodep, AstNumeric::SIGNED); }
-    virtual void visit(AstUnsigned* nodep) {
+    virtual void visit(AstUnsigned* nodep) VL_OVERRIDE {
         visit_signed_unsigned(nodep, AstNumeric::UNSIGNED); }
 
     // Widths: Output width from lhs, rhs<33 bits
     // Signed: If lhs signed
-    virtual void visit(AstShiftL* nodep) {      visit_shift(nodep); }
-    virtual void visit(AstShiftR* nodep) {      visit_shift(nodep); }
+    virtual void visit(AstShiftL* nodep) VL_OVERRIDE {      visit_shift(nodep); }
+    virtual void visit(AstShiftR* nodep) VL_OVERRIDE {      visit_shift(nodep); }
     // ShiftRS converts to ShiftR, but not vice-versa
-    virtual void visit(AstShiftRS* nodep) {     visit_shift(nodep); }
+    virtual void visit(AstShiftRS* nodep) VL_OVERRIDE {     visit_shift(nodep); }
 
     //========
     // Widths: Output real, input integer signed
-    virtual void visit(AstBitsToRealD* nodep) { visit_Or_Lu64(nodep); }
-    virtual void visit(AstIToRD* nodep) {       visit_Or_Ls32(nodep); }
+    virtual void visit(AstBitsToRealD* nodep) VL_OVERRIDE { visit_Or_Lu64(nodep); }
+    virtual void visit(AstIToRD* nodep) VL_OVERRIDE {       visit_Or_Ls32(nodep); }
 
     // Widths: Output integer signed, input real
-    virtual void visit(AstRToIS* nodep) {       visit_Os32_Lr(nodep); }
-    virtual void visit(AstRToIRoundS* nodep) {  visit_Os32_Lr(nodep); }
+    virtual void visit(AstRToIS* nodep) VL_OVERRIDE {       visit_Os32_Lr(nodep); }
+    virtual void visit(AstRToIRoundS* nodep) VL_OVERRIDE {  visit_Os32_Lr(nodep); }
 
     // Widths: Output integer unsigned, input real
-    virtual void visit(AstRealToBits* nodep) {  visit_Ou64_Lr(nodep); }
+    virtual void visit(AstRealToBits* nodep) VL_OVERRIDE {  visit_Ou64_Lr(nodep); }
 
     // Output integer, input string
-    virtual void visit(AstLenN* nodep) { visit_Os32_string(nodep); }
-    virtual void visit(AstPutcN* nodep) {
+    virtual void visit(AstLenN* nodep) VL_OVERRIDE { visit_Os32_string(nodep); }
+    virtual void visit(AstPutcN* nodep) VL_OVERRIDE {
         // CALLER: str.putc()
         UASSERT_OBJ(nodep->rhsp() && nodep->thsp(), nodep, "For ternary ops only!");
         if (m_vup && m_vup->prelim()) {
@@ -345,7 +345,7 @@ private:
             nodep->dtypeSetString(); //AstPutcN returns the new string to be assigned by AstAssign
         }
     }
-    virtual void visit(AstGetcN* nodep) {
+    virtual void visit(AstGetcN* nodep) VL_OVERRIDE {
         // CALLER: str.getc()
         UASSERT_OBJ(nodep->rhsp(), nodep, "For binary ops only!");
         if (m_vup && m_vup->prelim()) {
@@ -355,7 +355,7 @@ private:
             nodep->dtypeSetBitSized(8, AstNumeric::UNSIGNED);
         }
     }
-    virtual void visit(AstSubstrN* nodep) {
+    virtual void visit(AstSubstrN* nodep) VL_OVERRIDE {
         // CALLER: str.substr()
         UASSERT_OBJ(nodep->rhsp() && nodep->thsp(), nodep, "For ternary ops only!");
         if (m_vup && m_vup->prelim()) {
@@ -366,7 +366,7 @@ private:
             nodep->dtypeSetString();
         }
     }
-    virtual void visit(AstCompareNN* nodep) {
+    virtual void visit(AstCompareNN* nodep) VL_OVERRIDE {
         // CALLER: str.compare(), str.icompare()
         // Widths: 32 bit out
         UASSERT_OBJ(nodep->rhsp(), nodep, "For binary ops only!");
@@ -377,7 +377,7 @@ private:
             nodep->dtypeSetSigned32();
         }
     }
-    virtual void visit(AstAtoN* nodep) {
+    virtual void visit(AstAtoN* nodep) VL_OVERRIDE {
         // CALLER: str.atobin(), atoi(), atohex(), atooct(), atoreal()
         // Width: 64bit floating point for atoreal(), 32bit out for the others
         if (m_vup->prelim()) {
@@ -392,13 +392,13 @@ private:
     }
 
     // Widths: Constant, terminal
-    virtual void visit(AstTime* nodep) { nodep->dtypeSetUInt64(); }
-    virtual void visit(AstTimeD* nodep) { nodep->dtypeSetDouble(); }
-    virtual void visit(AstTestPlusArgs* nodep) { nodep->dtypeSetSigned32(); }
-    virtual void visit(AstScopeName* nodep) { nodep->dtypeSetUInt64(); }  // A pointer, but not that it matters
+    virtual void visit(AstTime* nodep) VL_OVERRIDE { nodep->dtypeSetUInt64(); }
+    virtual void visit(AstTimeD* nodep) VL_OVERRIDE { nodep->dtypeSetDouble(); }
+    virtual void visit(AstTestPlusArgs* nodep) VL_OVERRIDE { nodep->dtypeSetSigned32(); }
+    virtual void visit(AstScopeName* nodep) VL_OVERRIDE { nodep->dtypeSetUInt64(); }  // A pointer, but not that it matters
 
     // Special cases.  So many....
-    virtual void visit(AstNodeCond* nodep) {
+    virtual void visit(AstNodeCond* nodep) VL_OVERRIDE {
         // op=cond?expr1:expr2
         // Signed: Output signed iff RHS & THS signed  (presumed, not in IEEE)
         // See IEEE-2012 11.4.11 and Table 11-21.
@@ -437,7 +437,7 @@ private:
             iterateCheck(nodep, "Conditional False", nodep->expr2p(), CONTEXT, FINAL, subDTypep, EXTEND_EXP);
         }
     }
-    virtual void visit(AstConcat* nodep) {
+    virtual void visit(AstConcat* nodep) VL_OVERRIDE {
         // Real: Not allowed (assumed)
         // Signed: unsigned output, input either (assumed)
         // IEEE-2012 Table 11-21, and 11.8.1:
@@ -490,7 +490,7 @@ private:
             }
         }
     }
-    virtual void visit(AstConcatN* nodep) {
+    virtual void visit(AstConcatN* nodep) VL_OVERRIDE {
         // String concatenate.
         // Already did AstConcat simplifications
         if (m_vup->prelim()) {
@@ -506,19 +506,19 @@ private:
             }
         }
     }
-    virtual void visit(AstToLowerN* nodep) {
+    virtual void visit(AstToLowerN* nodep) VL_OVERRIDE {
         if (m_vup->prelim()) {
             iterateCheckString(nodep, "LHS", nodep->lhsp(), BOTH);
             nodep->dtypeSetString();
         }
     }
-    virtual void visit(AstToUpperN* nodep) {
+    virtual void visit(AstToUpperN* nodep) VL_OVERRIDE {
         if (m_vup->prelim()) {
             iterateCheckString(nodep, "LHS", nodep->lhsp(), BOTH);
             nodep->dtypeSetString();
         }
     }
-    virtual void visit(AstReplicate* nodep) {
+    virtual void visit(AstReplicate* nodep) VL_OVERRIDE {
         // IEEE-2012 Table 11-21:
         //   LHS, RHS is self-determined
         //   width: value(LHS) * width(RHS)
@@ -559,7 +559,7 @@ private:
             }
         }
     }
-    virtual void visit(AstReplicateN* nodep) {
+    virtual void visit(AstReplicateN* nodep) VL_OVERRIDE {
         // Replicate with string
         if (m_vup->prelim()) {
             iterateCheckString(nodep, "LHS", nodep->lhsp(), BOTH);
@@ -581,7 +581,7 @@ private:
             }
         }
     }
-    virtual void visit(AstNodeStream* nodep) {
+    virtual void visit(AstNodeStream* nodep) VL_OVERRIDE {
         if (m_vup->prelim()) {
             iterateCheckSizedSelf(nodep, "LHS", nodep->lhsp(), SELF, BOTH);
             iterateCheckSizedSelf(nodep, "RHS", nodep->rhsp(), SELF, BOTH);
@@ -609,7 +609,7 @@ private:
             }
         }
     }
-    virtual void visit(AstRange* nodep) {
+    virtual void visit(AstRange* nodep) VL_OVERRIDE {
         // Real: Not allowed
         // Signed: unsigned output, input either
         // Convert all range values to constants
@@ -643,7 +643,7 @@ private:
         }
     }
 
-    virtual void visit(AstSel* nodep) {
+    virtual void visit(AstSel* nodep) VL_OVERRIDE {
         // Signed: always unsigned; Real: Not allowed
         // LSB is self-determined (IEEE 2012 11.5.1)
         // We also use SELs to shorten a signed constant etc, in this case they are signed.
@@ -748,7 +748,7 @@ private:
         }
     }
 
-    virtual void visit(AstArraySel* nodep) {
+    virtual void visit(AstArraySel* nodep) VL_OVERRIDE {
         // Signed/Real: Output signed iff LHS signed/real; binary operator
         // Note by contrast, bit extract selects are unsigned
         // LSB is self-determined (IEEE 2012 11.5.1)
@@ -807,7 +807,7 @@ private:
         }
     }
 
-    virtual void visit(AstAssocSel* nodep) {
+    virtual void visit(AstAssocSel* nodep) VL_OVERRIDE {
         // Signed/Real: Output type based on array-declared type; binary operator
         if (m_vup->prelim()) {
             AstNodeDType* fromDtp = nodep->fromp()->dtypep()->skipRefp();
@@ -821,7 +821,7 @@ private:
         }
     }
 
-    virtual void visit(AstSliceSel* nodep) {
+    virtual void visit(AstSliceSel* nodep) VL_OVERRIDE {
         // Always creates as output an unpacked array
         if (m_vup->prelim()) {
             userIterateAndNext(nodep->fromp(), WidthVP(SELF, BOTH).p());
@@ -861,7 +861,7 @@ private:
         }
     }
 
-    virtual void visit(AstSelBit* nodep) {
+    virtual void visit(AstSelBit* nodep) VL_OVERRIDE {
         // Just a quick check as after V3Param these nodes instead are AstSel's
         userIterateAndNext(nodep->fromp(), WidthVP(CONTEXT, PRELIM).p());  // FINAL in AstSel
         userIterateAndNext(nodep->rhsp(), WidthVP(CONTEXT, PRELIM).p());  // FINAL in AstSel
@@ -871,7 +871,7 @@ private:
         if (selp!=nodep) { nodep = NULL; userIterate(selp, m_vup); return; }
         nodep->v3fatalSrc("AstSelBit should disappear after widthSel");
     }
-    virtual void visit(AstSelExtract* nodep) {
+    virtual void visit(AstSelExtract* nodep) VL_OVERRIDE {
         // Just a quick check as after V3Param these nodes instead are AstSel's
         userIterateAndNext(nodep->fromp(), WidthVP(CONTEXT, PRELIM).p());  // FINAL in AstSel
         userIterateAndNext(nodep->rhsp(), WidthVP(CONTEXT, PRELIM).p());  // FINAL in AstSel
@@ -881,7 +881,7 @@ private:
         if (selp!=nodep) { nodep = NULL; userIterate(selp, m_vup); return; }
         nodep->v3fatalSrc("AstSelExtract should disappear after widthSel");
     }
-    virtual void visit(AstSelPlus* nodep) {
+    virtual void visit(AstSelPlus* nodep) VL_OVERRIDE {
         userIterateAndNext(nodep->fromp(), WidthVP(CONTEXT, PRELIM).p());  // FINAL in AstSel
         userIterateAndNext(nodep->rhsp(), WidthVP(CONTEXT, PRELIM).p());  // FINAL in AstSel
         userIterateAndNext(nodep->thsp(), WidthVP(CONTEXT, PRELIM).p());  // FINAL in AstSel
@@ -890,7 +890,7 @@ private:
         if (selp!=nodep) { nodep = NULL; userIterate(selp, m_vup); return; }
         nodep->v3fatalSrc("AstSelPlus should disappear after widthSel");
     }
-    virtual void visit(AstSelMinus* nodep) {
+    virtual void visit(AstSelMinus* nodep) VL_OVERRIDE {
         userIterateAndNext(nodep->fromp(), WidthVP(CONTEXT, PRELIM).p());  // FINAL in AstSel
         userIterateAndNext(nodep->rhsp(), WidthVP(CONTEXT, PRELIM).p());  // FINAL in AstSel
         userIterateAndNext(nodep->thsp(), WidthVP(CONTEXT, PRELIM).p());  // FINAL in AstSel
@@ -900,13 +900,13 @@ private:
         nodep->v3fatalSrc("AstSelMinus should disappear after widthSel");
     }
 
-    virtual void visit(AstExtend* nodep) {
+    virtual void visit(AstExtend* nodep) VL_OVERRIDE {
         // Only created by this process, so we know width from here down is correct.
     }
-    virtual void visit(AstExtendS* nodep) {
+    virtual void visit(AstExtendS* nodep) VL_OVERRIDE {
         // Only created by this process, so we know width from here down is correct.
     }
-    virtual void visit(AstConst* nodep) {
+    virtual void visit(AstConst* nodep) VL_OVERRIDE {
         // The node got setup with the signed/real state of the node.
         // However a later operation may have changed the node->signed w/o changing
         // the number's sign.  So we don't: nodep->dtypeChgSigned(nodep->num().isSigned());
@@ -922,7 +922,7 @@ private:
         // We don't size the constant until we commit the widths, as need parameters
         // to remain unsized, and numbers to remain unsized to avoid backp() warnings
     }
-    virtual void visit(AstPast* nodep) {
+    virtual void visit(AstPast* nodep) VL_OVERRIDE {
         if (m_vup->prelim()) {
             iterateCheckSizedSelf(nodep, "LHS", nodep->exprp(), SELF, BOTH);
             nodep->dtypeFrom(nodep->exprp());
@@ -945,15 +945,15 @@ private:
             }
         }
     }
-    virtual void visit(AstRand* nodep) {
+    virtual void visit(AstRand* nodep) VL_OVERRIDE {
         if (m_vup->prelim()) {
             nodep->dtypeSetSigned32();  // Says the spec
         }
     }
-    virtual void visit(AstUnbounded* nodep) {
+    virtual void visit(AstUnbounded* nodep) VL_OVERRIDE {
         nodep->v3error("Unsupported/illegal unbounded ('$') in this context.");
     }
-    virtual void visit(AstUCFunc* nodep) {
+    virtual void visit(AstUCFunc* nodep) VL_OVERRIDE {
         // Give it the size the user wants.
         if (m_vup && m_vup->prelim()) {
             nodep->dtypeSetLogicUnsized(32, 1, AstNumeric::UNSIGNED);  // We don't care
@@ -966,13 +966,13 @@ private:
             if (nodep->width()>64) nodep->v3error("Unsupported: $c can't generate wider than 64 bits");
         }
     }
-    virtual void visit(AstCLog2* nodep) {
+    virtual void visit(AstCLog2* nodep) VL_OVERRIDE {
         if (m_vup->prelim()) {
             iterateCheckSizedSelf(nodep, "LHS", nodep->lhsp(), SELF, BOTH);
             nodep->dtypeSetSigned32();
         }
     }
-    virtual void visit(AstPow* nodep) {
+    virtual void visit(AstPow* nodep) VL_OVERRIDE {
         // Pow is special, output sign only depends on LHS sign, but
         // function result depends on both signs
         // RHS is self-determined (IEEE)
@@ -1016,25 +1016,25 @@ private:
             }
         }
     }
-    virtual void visit(AstPowSU* nodep) {
+    virtual void visit(AstPowSU* nodep) VL_OVERRIDE {
         // POWSU/SS/US only created here, dtype already determined, so
         // nothing to do in this function
         userIterateAndNext(nodep->lhsp(), WidthVP(SELF, BOTH).p());
         userIterateAndNext(nodep->rhsp(), WidthVP(SELF, BOTH).p());
     }
-    virtual void visit(AstPowSS* nodep) {
+    virtual void visit(AstPowSS* nodep) VL_OVERRIDE {
         // POWSU/SS/US only created here, dtype already determined, so
         // nothing to do in this function
         userIterateAndNext(nodep->lhsp(), WidthVP(SELF, BOTH).p());
         userIterateAndNext(nodep->rhsp(), WidthVP(SELF, BOTH).p());
     }
-    virtual void visit(AstPowUS* nodep) {
+    virtual void visit(AstPowUS* nodep) VL_OVERRIDE {
         // POWSU/SS/US only created here, dtype already determined, so
         // nothing to do in this function
         userIterateAndNext(nodep->lhsp(), WidthVP(SELF, BOTH).p());
         userIterateAndNext(nodep->rhsp(), WidthVP(SELF, BOTH).p());
     }
-    virtual void visit(AstCountOnes* nodep) {
+    virtual void visit(AstCountOnes* nodep) VL_OVERRIDE {
         if (m_vup->prelim()) {
             iterateCheckSizedSelf(nodep, "LHS", nodep->lhsp(), SELF, BOTH);
             // If it's a 32 bit number, we need a 6 bit number as we need to return '32'.
@@ -1042,12 +1042,12 @@ private:
             nodep->dtypeSetLogicSized(selwidth, AstNumeric::UNSIGNED);  // Spec doesn't indicate if an integer
         }
     }
-    virtual void visit(AstCvtPackString* nodep) {
+    virtual void visit(AstCvtPackString* nodep) VL_OVERRIDE {
         // Opaque returns, so arbitrary
         userIterateAndNext(nodep->lhsp(), WidthVP(SELF, BOTH).p());
         // Type set in constructor
     }
-    virtual void visit(AstAttrOf* nodep) {
+    virtual void visit(AstAttrOf* nodep) VL_OVERRIDE {
         AstAttrOf* oldAttr = m_attrp;
         m_attrp = nodep;
         userIterateAndNext(nodep->fromp(), WidthVP(SELF, BOTH).p());
@@ -1158,16 +1158,16 @@ private:
         }
         m_attrp = oldAttr;
     }
-    virtual void visit(AstPull* nodep) {
+    virtual void visit(AstPull* nodep) VL_OVERRIDE {
         // May have select underneath, let seek natural size
         userIterateChildren(nodep, WidthVP(SELF, BOTH).p());
     }
-    virtual void visit(AstText* nodep) {
+    virtual void visit(AstText* nodep) VL_OVERRIDE {
         // Only used in CStmts which don't care....
     }
 
     // DTYPES
-    virtual void visit(AstNodeArrayDType* nodep) {
+    virtual void visit(AstNodeArrayDType* nodep) VL_OVERRIDE {
         if (nodep->didWidthAndSet()) return;  // This node is a dtype & not both PRELIMed+FINALed
         if (nodep->childDTypep()) nodep->refDTypep(moveChildDTypeEdit(nodep));
         // Iterate into subDTypep() to resolve that type and update pointer.
@@ -1184,7 +1184,7 @@ private:
         }
         UINFO(4,"dtWidthed "<<nodep<<endl);
     }
-    virtual void visit(AstAssocArrayDType* nodep) {
+    virtual void visit(AstAssocArrayDType* nodep) VL_OVERRIDE {
         if (nodep->didWidthAndSet()) return;  // This node is a dtype & not both PRELIMed+FINALed
         if (nodep->childDTypep()) nodep->refDTypep(moveChildDTypeEdit(nodep));
         if (nodep->keyChildDTypep()) nodep->keyDTypep(moveDTypeEdit(nodep, nodep->keyChildDTypep()));
@@ -1194,7 +1194,7 @@ private:
         nodep->dtypep(nodep);  // The array itself, not subDtype
         UINFO(4,"dtWidthed "<<nodep<<endl);
     }
-    virtual void visit(AstQueueDType* nodep) {
+    virtual void visit(AstQueueDType* nodep) VL_OVERRIDE {
         if (nodep->didWidthAndSet()) return;  // This node is a dtype & not both PRELIMed+FINALed
         if (nodep->childDTypep()) nodep->refDTypep(moveChildDTypeEdit(nodep));
         // Iterate into subDTypep() to resolve that type and update pointer.
@@ -1205,7 +1205,7 @@ private:
         }
         UINFO(4,"dtWidthed "<<nodep<<endl);
     }
-    virtual void visit(AstUnsizedArrayDType* nodep) {
+    virtual void visit(AstUnsizedArrayDType* nodep) VL_OVERRIDE {
         if (nodep->didWidthAndSet()) return;  // This node is a dtype & not both PRELIMed+FINALed
         if (nodep->childDTypep()) nodep->refDTypep(moveChildDTypeEdit(nodep));
         // Iterate into subDTypep() to resolve that type and update pointer.
@@ -1214,7 +1214,7 @@ private:
         nodep->dtypep(nodep);  // The array itself, not subDtype
         UINFO(4,"dtWidthed "<<nodep<<endl);
     }
-    virtual void visit(AstBasicDType* nodep) {
+    virtual void visit(AstBasicDType* nodep) VL_OVERRIDE {
         if (nodep->didWidthAndSet()) return;  // This node is a dtype & not both PRELIMed+FINALed
         if (nodep->generic()) return;  // Already perfect
         if (nodep->rangep()) {
@@ -1239,7 +1239,7 @@ private:
         // Instead for now doing this in V3WidthCommit
         UINFO(4,"dtWidthed "<<nodep<<endl);
     }
-    virtual void visit(AstConstDType* nodep) {
+    virtual void visit(AstConstDType* nodep) VL_OVERRIDE {
         if (nodep->didWidthAndSet()) return;  // This node is a dtype & not both PRELIMed+FINALed
         // Move any childDTypep to instead be in global AstTypeTable.
         // This way if this node gets deleted and some other dtype points to it
@@ -1252,7 +1252,7 @@ private:
         nodep->widthFromSub(nodep->subDTypep());
         UINFO(4,"dtWidthed "<<nodep<<endl);
     }
-    virtual void visit(AstRefDType* nodep) {
+    virtual void visit(AstRefDType* nodep) VL_OVERRIDE {
         if (nodep->doingWidth()) {  // Early exit if have circular parameter definition
             nodep->v3error("Typedef's type is circular: "<<nodep->prettyName());
             nodep->dtypeSetLogicBool();
@@ -1272,20 +1272,20 @@ private:
         UINFO(4,"dtWidthed "<<nodep<<endl);
         nodep->doingWidth(false);
     }
-    virtual void visit(AstTypedef* nodep) {
+    virtual void visit(AstTypedef* nodep) VL_OVERRIDE {
         if (nodep->didWidthAndSet()) return;  // This node is a dtype & not both PRELIMed+FINALed
         if (nodep->childDTypep()) nodep->dtypep(moveChildDTypeEdit(nodep));
         userIterateChildren(nodep, NULL);
         nodep->dtypep(iterateEditDTypep(nodep, nodep->subDTypep()));
     }
-    virtual void visit(AstParamTypeDType* nodep) {
+    virtual void visit(AstParamTypeDType* nodep) VL_OVERRIDE {
         if (nodep->didWidthAndSet()) return;  // This node is a dtype & not both PRELIMed+FINALed
         if (nodep->childDTypep()) nodep->dtypep(moveChildDTypeEdit(nodep));
         userIterateChildren(nodep, NULL);
         nodep->dtypep(iterateEditDTypep(nodep, nodep->subDTypep()));
         nodep->widthFromSub(nodep->subDTypep());
     }
-    virtual void visit(AstCastParse* nodep) {
+    virtual void visit(AstCastParse* nodep) VL_OVERRIDE {
         // nodep->dtp could be data type, or a primary_constant
         // Don't iterate lhsp, will deal with that once convert the type
         V3Const::constifyParamsEdit(nodep->dtp());  // itemp may change
@@ -1301,7 +1301,7 @@ private:
             nodep->replaceWith(nodep->lhsp()->unlinkFrBack());
         }
     }
-    virtual void visit(AstCast* nodep) {
+    virtual void visit(AstCast* nodep) VL_OVERRIDE {
         if (nodep->childDTypep()) nodep->dtypep(moveChildDTypeEdit(nodep));
         nodep->dtypep(iterateEditDTypep(nodep, nodep->dtypep()));
         //if (debug()) nodep->dumpTree(cout, "  CastPre: ");
@@ -1341,7 +1341,7 @@ private:
         VL_DO_DANGLING(pushDeletep(nodep), nodep);
         //if (debug()) newp->dumpTree(cout, "  CastOut: ");
     }
-    virtual void visit(AstCastSize* nodep) {
+    virtual void visit(AstCastSize* nodep) VL_OVERRIDE {
         // IEEE: Signedness of result is same as self-determined signedness
         // However, the result is same as BITSEL, so we do not sign extend the LHS
         UASSERT_OBJ(VN_IS(nodep->rhsp(), Const), nodep,
@@ -1391,7 +1391,7 @@ private:
         }
         //if (debug()) nodep->dumpTree(cout, "  CastSizeOut: ");
     }
-    virtual void visit(AstVar* nodep) {
+    virtual void visit(AstVar* nodep) VL_OVERRIDE {
         //if (debug()) nodep->dumpTree(cout, "  InitPre: ");
         // Must have deterministic constant width
         // We can't skip this step when width()!=0, as creating a AstVar
@@ -1492,7 +1492,7 @@ private:
         nodep->didWidth(true);
         nodep->doingWidth(false);
     }
-    virtual void visit(AstNodeVarRef* nodep) {
+    virtual void visit(AstNodeVarRef* nodep) VL_OVERRIDE {
         if (nodep->didWidth()) return;
         if (!nodep->varp()) {
             if (m_paramsOnly && VN_IS(nodep, VarXRef)) {
@@ -1526,7 +1526,7 @@ private:
         nodep->didWidth(true);
     }
 
-    virtual void visit(AstEnumDType* nodep) {
+    virtual void visit(AstEnumDType* nodep) VL_OVERRIDE {
         if (nodep->didWidthAndSet()) return;  // This node is a dtype & not both PRELIMed+FINALed
         UINFO(5,"  ENUMDTYPE "<<nodep<<endl);
         if (nodep->childDTypep()) nodep->refDTypep(moveChildDTypeEdit(nodep));
@@ -1584,7 +1584,7 @@ private:
             num.opAdd(one, constp->num());
         }
     }
-    virtual void visit(AstEnumItem* nodep) {
+    virtual void visit(AstEnumItem* nodep) VL_OVERRIDE {
         UINFO(5,"   ENUMITEM "<<nodep<<endl);
         AstNodeDType* vdtypep = m_vup->dtypep();
         UASSERT_OBJ(vdtypep, nodep, "ENUMITEM not under ENUM");
@@ -1597,7 +1597,7 @@ private:
             iterateCheck(nodep, "Enum value", nodep->valuep(), CONTEXT, FINAL, nodep->dtypep(), EXTEND_EXP);
         }
     }
-    virtual void visit(AstEnumItemRef* nodep) {
+    virtual void visit(AstEnumItemRef* nodep) VL_OVERRIDE {
         if (!nodep->itemp()->didWidth()) {
             // We need to do the whole enum en-mass
             AstNode* enump = nodep->itemp();
@@ -1610,10 +1610,10 @@ private:
         }
         nodep->dtypeFrom(nodep->itemp());
     }
-    virtual void visit(AstInitItem* nodep) {
+    virtual void visit(AstInitItem* nodep) VL_OVERRIDE {
         userIterateChildren(nodep, m_vup);
     }
-    virtual void visit(AstInitArray* nodep) {
+    virtual void visit(AstInitArray* nodep) VL_OVERRIDE {
         // InitArray has type of the array; children are array values
         if (m_vup->prelim()) {  // First stage evaluation
             AstNodeDType* vdtypep = m_vup->dtypep();
@@ -1626,7 +1626,7 @@ private:
             }
         }
     }
-    virtual void visit(AstInside* nodep) {
+    virtual void visit(AstInside* nodep) VL_OVERRIDE {
         userIterateAndNext(nodep->exprp(), WidthVP(CONTEXT, PRELIM).p());
         for (AstNode* nextip, *itemp = nodep->itemsp(); itemp; itemp=nextip) {
             nextip = itemp->nextp();  // Prelim may cause the node to get replaced
@@ -1676,14 +1676,14 @@ private:
         if (debug()>=9) newp->dumpTree(cout, "-inside-out: ");
         nodep->replaceWith(newp); VL_DO_DANGLING(pushDeletep(nodep), nodep);
     }
-    virtual void visit(AstInsideRange* nodep) {
+    virtual void visit(AstInsideRange* nodep) VL_OVERRIDE {
         // Just do each side; AstInside will rip these nodes out later
         userIterateAndNext(nodep->lhsp(), m_vup);
         userIterateAndNext(nodep->rhsp(), m_vup);
         nodep->dtypeFrom(nodep->lhsp());
     }
 
-    virtual void visit(AstIfaceRefDType* nodep) {
+    virtual void visit(AstIfaceRefDType* nodep) VL_OVERRIDE {
         if (nodep->didWidthAndSet()) return;  // This node is a dtype & not both PRELIMed+FINALed
         UINFO(5,"   IFACEREF "<<nodep<<endl);
         userIterateChildren(nodep, m_vup);
@@ -1691,7 +1691,7 @@ private:
         nodep->widthForce(1, 1);  // Not really relevant
         UINFO(4,"dtWidthed "<<nodep<<endl);
     }
-    virtual void visit(AstNodeUOrStructDType* nodep) {
+    virtual void visit(AstNodeUOrStructDType* nodep) VL_OVERRIDE {
         if (nodep->didWidthAndSet()) return;  // This node is a dtype & not both PRELIMed+FINALed
         UINFO(5,"   NODECLASS "<<nodep<<endl);
         //if (debug()>=9) nodep->dumpTree("-class-in--");
@@ -1723,7 +1723,7 @@ private:
         nodep->widthForce(width, width);  // Signing stays as-is, as parsed from declaration
         //if (debug()>=9) nodep->dumpTree("-class-out-");
     }
-    virtual void visit(AstMemberDType* nodep) {
+    virtual void visit(AstMemberDType* nodep) VL_OVERRIDE {
         if (nodep->didWidthAndSet()) return;  // This node is a dtype & not both PRELIMed+FINALed
         if (nodep->childDTypep()) nodep->refDTypep(moveChildDTypeEdit(nodep));
         // Iterate into subDTypep() to resolve that type and update pointer.
@@ -1731,7 +1731,7 @@ private:
         nodep->dtypep(nodep);  // The member itself, not subDtype
         nodep->widthFromSub(nodep->subDTypep());
     }
-    virtual void visit(AstMemberSel* nodep) {
+    virtual void visit(AstMemberSel* nodep) VL_OVERRIDE {
         UINFO(5,"   MEMBERSEL "<<nodep<<endl);
         if (debug()>=9) nodep->dumpTree("-mbs-in: ");
         userIterateChildren(nodep, WidthVP(SELF, BOTH).p());
@@ -1788,12 +1788,12 @@ private:
         return false;
     }
 
-    virtual void visit(AstCMethodHard* nodep) {
+    virtual void visit(AstCMethodHard* nodep) VL_OVERRIDE {
         // Never created before V3Width, so no need to redo it
         UASSERT_OBJ(nodep->dtypep(), nodep, "CMETHODCALLs should have already been sized");
     }
 
-    virtual void visit(AstMethodCall* nodep) {
+    virtual void visit(AstMethodCall* nodep) VL_OVERRIDE {
         UINFO(5,"   METHODSEL "<<nodep<<endl);
         if (nodep->didWidth()) return;
         if (debug()>=9) nodep->dumpTree("-mts-in: ");
@@ -2239,7 +2239,7 @@ private:
         }
     }
 
-    virtual void visit(AstNew* nodep) {
+    virtual void visit(AstNew* nodep) VL_OVERRIDE {
         if (nodep->didWidthAndSet()) return;
         userIterateChildren(nodep, WidthVP(SELF, BOTH).p());
         AstClassRefDType* refp = VN_CAST(m_vup->dtypeNullp(), ClassRefDType);
@@ -2251,7 +2251,7 @@ private:
         nodep->dtypep(refp);
     }
 
-    virtual void visit(AstPattern* nodep) {
+    virtual void visit(AstPattern* nodep) VL_OVERRIDE {
         if (nodep->didWidthAndSet()) return;
         UINFO(9,"PATTERN "<<nodep<<endl);
         if (nodep->childDTypep()) nodep->dtypep(moveChildDTypeEdit(nodep));  // data_type '{ pattern }
@@ -2550,7 +2550,7 @@ private:
         //if (debug()>=9) newp->dumpTree("-apat-out: ");
         VL_DO_DANGLING(pushDeletep(nodep), nodep);  // Deletes defaultp also, if present
     }
-    virtual void visit(AstPatMember* nodep) {
+    virtual void visit(AstPatMember* nodep) VL_OVERRIDE {
         AstNodeDType* vdtypep = m_vup->dtypeNullp();
         UASSERT_OBJ(vdtypep, nodep, "Pattern member type not assigned by AstPattern visitor");
         nodep->dtypep(vdtypep);
@@ -2575,7 +2575,7 @@ private:
         return times;
     }
 
-    virtual void visit(AstPropClocked* nodep) {
+    virtual void visit(AstPropClocked* nodep) VL_OVERRIDE {
         if (m_vup->prelim()) {  // First stage evaluation
             iterateCheckBool(nodep, "Property", nodep->propp(), BOTH);
             userIterateAndNext(nodep->sensesp(), NULL);
@@ -2589,7 +2589,7 @@ private:
     //--------------------
     // Top levels
 
-    virtual void visit(AstNodeCase* nodep) {
+    virtual void visit(AstNodeCase* nodep) VL_OVERRIDE {
         // IEEE-2012 12.5:
         //    Width: MAX(expr, all items)
         //    Signed: Only if expr, and all items signed
@@ -2630,7 +2630,7 @@ private:
             }
         }
     }
-    virtual void visit(AstNodeFor* nodep) {
+    virtual void visit(AstNodeFor* nodep) VL_OVERRIDE {
         assertAtStatement(nodep);
         userIterateAndNext(nodep->initsp(), NULL);
         iterateCheckBool(nodep, "For Test Condition", nodep->condp(), BOTH);  // it's like an if() condition.
@@ -2638,19 +2638,19 @@ private:
         userIterateAndNext(nodep->incsp(), NULL);
 
     }
-    virtual void visit(AstRepeat* nodep) {
+    virtual void visit(AstRepeat* nodep) VL_OVERRIDE {
         assertAtStatement(nodep);
         userIterateAndNext(nodep->countp(), WidthVP(SELF, BOTH).p());
         userIterateAndNext(nodep->bodysp(), NULL);
     }
-    virtual void visit(AstWhile* nodep) {
+    virtual void visit(AstWhile* nodep) VL_OVERRIDE {
         assertAtStatement(nodep);
         userIterateAndNext(nodep->precondsp(), NULL);
         iterateCheckBool(nodep, "For Test Condition", nodep->condp(), BOTH);  // it's like an if() condition.
         userIterateAndNext(nodep->bodysp(), NULL);
         userIterateAndNext(nodep->incsp(), NULL);
     }
-    virtual void visit(AstNodeIf* nodep) {
+    virtual void visit(AstNodeIf* nodep) VL_OVERRIDE {
         assertAtStatement(nodep);
         //if (debug()) nodep->dumpTree(cout, "  IfPre: ");
         if (!VN_IS(nodep, GenIf)) {  // for m_paramsOnly
@@ -2661,7 +2661,7 @@ private:
         //if (debug()) nodep->dumpTree(cout, "  IfOut: ");
     }
 
-    virtual void visit(AstNodeAssign* nodep) {
+    virtual void visit(AstNodeAssign* nodep) VL_OVERRIDE {
         // IEEE-2012 10.7, 11.8.2, 11.8.3, 11.5:  (Careful of 11.8.1 which is
         //                  only one step; final dtype depends on assign LHS.)
         //    Determine RHS type width and signing
@@ -2689,7 +2689,7 @@ private:
         }
     }
 
-    virtual void visit(AstSFormatF* nodep) {
+    virtual void visit(AstSFormatF* nodep) VL_OVERRIDE {
         // Excludes NodeDisplay, see below
         if (m_vup && !m_vup->prelim()) return;  // Can be called as statement or function
         // Just let all arguments seek their natural sizes
@@ -2792,7 +2792,7 @@ private:
         nodep->text(newFormat);
         UINFO(9,"  Display out "<<nodep->text()<<endl);
     }
-    virtual void visit(AstDisplay* nodep) {
+    virtual void visit(AstDisplay* nodep) VL_OVERRIDE {
         assertAtStatement(nodep);
         if (nodep->filep()) {
             iterateCheckFileDesc(nodep, nodep->filep(), BOTH);
@@ -2800,7 +2800,7 @@ private:
         // Just let all arguments seek their natural sizes
         userIterateChildren(nodep, WidthVP(SELF, BOTH).p());
     }
-    virtual void visit(AstElabDisplay* nodep) {
+    virtual void visit(AstElabDisplay* nodep) VL_OVERRIDE {
         assertAtStatement(nodep);
         // Just let all arguments seek their natural sizes
         userIterateChildren(nodep, WidthVP(SELF, BOTH).p());
@@ -2824,64 +2824,64 @@ private:
             VL_DO_DANGLING(nodep->unlinkFrBack()->deleteTree(), nodep);
         }
     }
-    virtual void visit(AstFOpen* nodep) {
+    virtual void visit(AstFOpen* nodep) VL_OVERRIDE {
         // Although a system function in IEEE, here a statement which sets the file pointer (MCD)
         assertAtStatement(nodep);
         iterateCheckFileDesc(nodep, nodep->filep(), BOTH);
         userIterateAndNext(nodep->filenamep(), WidthVP(SELF, BOTH).p());
         userIterateAndNext(nodep->modep(), WidthVP(SELF, BOTH).p());
     }
-    virtual void visit(AstFClose* nodep) {
+    virtual void visit(AstFClose* nodep) VL_OVERRIDE {
         assertAtStatement(nodep);
         iterateCheckFileDesc(nodep, nodep->filep(), BOTH);
     }
-    virtual void visit(AstFEof* nodep) {
+    virtual void visit(AstFEof* nodep) VL_OVERRIDE {
         if (m_vup->prelim()) {
             iterateCheckFileDesc(nodep, nodep->filep(), BOTH);
             nodep->dtypeSetLogicUnsized(32, 1, AstNumeric::SIGNED);  // Spec says integer return
         }
     }
-    virtual void visit(AstFFlush* nodep) {
+    virtual void visit(AstFFlush* nodep) VL_OVERRIDE {
         assertAtStatement(nodep);
         if (nodep->filep()) {
             iterateCheckFileDesc(nodep, nodep->filep(), BOTH);
         }
     }
-    virtual void visit(AstFRewind* nodep) {
+    virtual void visit(AstFRewind* nodep) VL_OVERRIDE {
         iterateCheckFileDesc(nodep, nodep->filep(), BOTH);
         nodep->dtypeSetLogicUnsized(32, 1, AstNumeric::SIGNED);  // Spec says integer return
     }
-    virtual void visit(AstFTell* nodep) {
+    virtual void visit(AstFTell* nodep) VL_OVERRIDE {
         iterateCheckFileDesc(nodep, nodep->filep(), BOTH);
         nodep->dtypeSetLogicUnsized(32, 1, AstNumeric::SIGNED);  // Spec says integer return
     }
-    virtual void visit(AstFSeek* nodep) {
+    virtual void visit(AstFSeek* nodep) VL_OVERRIDE {
         iterateCheckFileDesc(nodep, nodep->filep(), BOTH);
         iterateCheckSigned32(nodep, "$fseek offset", nodep->offset(), BOTH);
         iterateCheckSigned32(nodep, "$fseek operation", nodep->operation(), BOTH);
         nodep->dtypeSetLogicUnsized(32, 1, AstNumeric::SIGNED);  // Spec says integer return
     }
-    virtual void visit(AstFGetC* nodep) {
+    virtual void visit(AstFGetC* nodep) VL_OVERRIDE {
         if (m_vup->prelim()) {
             iterateCheckFileDesc(nodep, nodep->filep(), BOTH);
             nodep->dtypeSetLogicUnsized(32, 8, AstNumeric::SIGNED);  // Spec says integer return
         }
     }
-    virtual void visit(AstFGetS* nodep) {
+    virtual void visit(AstFGetS* nodep) VL_OVERRIDE {
         if (m_vup->prelim()) {
             nodep->dtypeSetSigned32();  // Spec says integer return
             iterateCheckFileDesc(nodep, nodep->filep(), BOTH);
             userIterateAndNext(nodep->strgp(), WidthVP(SELF, BOTH).p());
         }
     }
-    virtual void visit(AstFUngetC* nodep) {
+    virtual void visit(AstFUngetC* nodep) VL_OVERRIDE {
         if (m_vup->prelim()) {
             iterateCheckFileDesc(nodep, nodep->filep(), BOTH);
             iterateCheckSigned32(nodep, "$fungetc character", nodep->charp(), BOTH);
             nodep->dtypeSetLogicUnsized(32, 8, AstNumeric::SIGNED);  // Spec says integer return
         }
     }
-    virtual void visit(AstFRead* nodep) {
+    virtual void visit(AstFRead* nodep) VL_OVERRIDE {
         if (m_vup->prelim()) {
             nodep->dtypeSetSigned32();  // Spec says integer return
             userIterateAndNext(nodep->memp(), WidthVP(SELF, BOTH).p());
@@ -2894,38 +2894,38 @@ private:
             }
         }
     }
-    virtual void visit(AstFScanF* nodep) {
+    virtual void visit(AstFScanF* nodep) VL_OVERRIDE {
         if (m_vup->prelim()) {
             nodep->dtypeSetSigned32();  // Spec says integer return
             iterateCheckFileDesc(nodep, nodep->filep(), BOTH);
             userIterateAndNext(nodep->exprsp(), WidthVP(SELF, BOTH).p());
         }
     }
-    virtual void visit(AstSScanF* nodep) {
+    virtual void visit(AstSScanF* nodep) VL_OVERRIDE {
         if (m_vup->prelim()) {
             nodep->dtypeSetSigned32();  // Spec says integer return
             userIterateAndNext(nodep->fromp(), WidthVP(SELF, BOTH).p());
             userIterateAndNext(nodep->exprsp(), WidthVP(SELF, BOTH).p());
         }
     }
-    virtual void visit(AstSysIgnore* nodep) {
+    virtual void visit(AstSysIgnore* nodep) VL_OVERRIDE {
         userIterateAndNext(nodep->exprsp(), WidthVP(SELF, BOTH).p());
     }
-    virtual void visit(AstSystemF* nodep) {
+    virtual void visit(AstSystemF* nodep) VL_OVERRIDE {
         if (m_vup->prelim()) {
             userIterateAndNext(nodep->lhsp(), WidthVP(SELF, BOTH).p());
             nodep->dtypeSetSigned32();  // Spec says integer return
         }
     }
-    virtual void visit(AstSysFuncAsTask* nodep) {
+    virtual void visit(AstSysFuncAsTask* nodep) VL_OVERRIDE {
         assertAtStatement(nodep);
         userIterateAndNext(nodep->lhsp(), WidthVP(SELF, BOTH).p());
     }
-    virtual void visit(AstSystemT* nodep) {
+    virtual void visit(AstSystemT* nodep) VL_OVERRIDE {
         assertAtStatement(nodep);
         userIterateAndNext(nodep->lhsp(), WidthVP(SELF, BOTH).p());
     }
-    virtual void visit(AstNodeReadWriteMem* nodep) {
+    virtual void visit(AstNodeReadWriteMem* nodep) VL_OVERRIDE {
         assertAtStatement(nodep);
         userIterateAndNext(nodep->filenamep(), WidthVP(SELF, BOTH).p());
         userIterateAndNext(nodep->memp(), WidthVP(SELF, BOTH).p());
@@ -2954,34 +2954,34 @@ private:
         userIterateAndNext(nodep->lsbp(), WidthVP(SELF, BOTH).p());
         userIterateAndNext(nodep->msbp(), WidthVP(SELF, BOTH).p());
     }
-    virtual void visit(AstValuePlusArgs* nodep) {
+    virtual void visit(AstValuePlusArgs* nodep) VL_OVERRIDE {
         if (m_vup->prelim()) {
             userIterateAndNext(nodep->searchp(), WidthVP(SELF, BOTH).p());
             userIterateAndNext(nodep->outp(), WidthVP(SELF, BOTH).p());
             nodep->dtypeChgWidthSigned(32, 1, AstNumeric::SIGNED);  // Spec says integer return
         }
     }
-    virtual void visit(AstUCStmt* nodep) {
+    virtual void visit(AstUCStmt* nodep) VL_OVERRIDE {
         // Just let all arguments seek their natural sizes
         assertAtStatement(nodep);
         userIterateChildren(nodep, WidthVP(SELF, BOTH).p());
     }
-    virtual void visit(AstAssert* nodep) {
+    virtual void visit(AstAssert* nodep) VL_OVERRIDE {
         assertAtStatement(nodep);
         iterateCheckBool(nodep, "Property", nodep->propp(), BOTH);  // it's like an if() condition.
         userIterateAndNext(nodep->passsp(), NULL);
         userIterateAndNext(nodep->failsp(), NULL);
     }
-    virtual void visit(AstCover* nodep) {
+    virtual void visit(AstCover* nodep) VL_OVERRIDE {
         assertAtStatement(nodep);
         iterateCheckBool(nodep, "Property", nodep->propp(), BOTH);  // it's like an if() condition.
         userIterateAndNext(nodep->passsp(), NULL);
     }
-    virtual void visit(AstRestrict* nodep) {
+    virtual void visit(AstRestrict* nodep) VL_OVERRIDE {
         assertAtStatement(nodep);
         iterateCheckBool(nodep, "Property", nodep->propp(), BOTH);  // it's like an if() condition.
     }
-    virtual void visit(AstPin* nodep) {
+    virtual void visit(AstPin* nodep) VL_OVERRIDE {
         //if (debug()) nodep->dumpTree(cout, "-  PinPre: ");
         // TOP LEVEL NODE
         if (nodep->modVarp() && nodep->modVarp()->isGParam()) {
@@ -3086,7 +3086,7 @@ private:
         }
         //if (debug()) nodep->dumpTree(cout, "-  PinOut: ");
     }
-    virtual void visit(AstCell* nodep) {
+    virtual void visit(AstCell* nodep) VL_OVERRIDE {
         if (!m_paramsOnly) {
             if (VN_IS(nodep->modp(), NotFoundModule)) {
                 // We've resolved parameters and hit a module that we couldn't resolve.  It's
@@ -3105,7 +3105,7 @@ private:
         userIterateAndNext(nodep->paramsp(), NULL);
         m_cellRangep = NULL;
     }
-    virtual void visit(AstGatePin* nodep) {
+    virtual void visit(AstGatePin* nodep) VL_OVERRIDE {
         if (m_vup->prelim()) {
             userIterateAndNext(nodep->rangep(), WidthVP(SELF, BOTH).p());
             userIterateAndNext(nodep->exprp(), WidthVP(CONTEXT, PRELIM).p());
@@ -3131,7 +3131,7 @@ private:
             VL_DO_DANGLING(pushDeletep(nodep), nodep);
         }
     }
-    virtual void visit(AstNodeFTask* nodep) {
+    virtual void visit(AstNodeFTask* nodep) VL_OVERRIDE {
         // Grab width from the output variable (if it's a function)
         if (nodep->didWidth()) return;
         if (nodep->doingWidth()) {
@@ -3159,7 +3159,7 @@ private:
             nodep->dpiOpenParentInc();  // Mark so V3Task will wait for a child to build calling func
         }
     }
-    virtual void visit(AstReturn* nodep) {
+    virtual void visit(AstReturn* nodep) VL_OVERRIDE {
         // IEEE: Assignment-like context
         assertAtStatement(nodep);
         if (!m_funcp) {
@@ -3177,12 +3177,12 @@ private:
         }
     }
 
-    virtual void visit(AstFuncRef* nodep) {
+    virtual void visit(AstFuncRef* nodep) VL_OVERRIDE {
         visit(VN_CAST(nodep, NodeFTaskRef));
         nodep->dtypeFrom(nodep->taskp());
         //if (debug()) nodep->dumpTree(cout, "  FuncOut: ");
     }
-    virtual void visit(AstNodeFTaskRef* nodep) {
+    virtual void visit(AstNodeFTaskRef* nodep) VL_OVERRIDE {
         // For arguments, is assignment-like context; see IEEE rules in AstNodeAssign
         // Function hasn't been widthed, so make it so.
         UINFO(5, "  FTASKREF "<<nodep<<endl);
@@ -3304,27 +3304,27 @@ private:
         }
         nodep->didWidth(true);
     }
-    virtual void visit(AstInitial* nodep) {
+    virtual void visit(AstInitial* nodep) VL_OVERRIDE {
         assertAtStatement(nodep);
         m_initialp = nodep;
         userIterateChildren(nodep, NULL);
         m_initialp = NULL;
     }
-    virtual void visit(AstNetlist* nodep) {
+    virtual void visit(AstNetlist* nodep) VL_OVERRIDE {
         // Iterate modules backwards, in bottom-up order.  That's faster
         userIterateChildrenBackwards(nodep, NULL);
     }
 
     //--------------------
     // Default
-    virtual void visit(AstNodeMath* nodep) {
+    virtual void visit(AstNodeMath* nodep) VL_OVERRIDE {
         if (!nodep->didWidth()) {
             nodep->v3fatalSrc("Visit function missing? Widthed function missing for math node: "
                               <<nodep);
         }
         userIterateChildren(nodep, NULL);
     }
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         // Default: Just iterate
         UASSERT_OBJ(!m_vup, nodep,
                     "Visit function missing? Widthed expectation for this node: "<<nodep);

--- a/src/V3WidthCommit.h
+++ b/src/V3WidthCommit.h
@@ -39,13 +39,13 @@
 class WidthRemoveVisitor : public AstNVisitor {
 private:
     // VISITORS
-    virtual void visit(AstSigned* nodep) {
+    virtual void visit(AstSigned* nodep) VL_OVERRIDE {
         VL_DO_DANGLING(replaceWithSignedVersion(nodep, nodep->lhsp()->unlinkFrBack()), nodep);
     }
-    virtual void visit(AstUnsigned* nodep) {
+    virtual void visit(AstUnsigned* nodep) VL_OVERRIDE {
         VL_DO_DANGLING(replaceWithSignedVersion(nodep, nodep->lhsp()->unlinkFrBack()), nodep);
     }
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
     }
     void replaceWithSignedVersion(AstNode* nodep, AstNode* newp) {
@@ -114,7 +114,7 @@ private:
         return nodep;
     }
     // VISITORS
-    virtual void visit(AstConst* nodep) {
+    virtual void visit(AstConst* nodep) VL_OVERRIDE {
         UASSERT_OBJ(nodep->dtypep(), nodep, "No dtype");
         iterate(nodep->dtypep());  // Do datatype first
         if (AstConst* newp = newIfConstCommitSize(nodep)) {
@@ -126,15 +126,15 @@ private:
         }
         editDType(nodep);
     }
-    virtual void visit(AstNodeDType* nodep) {
+    virtual void visit(AstNodeDType* nodep) VL_OVERRIDE {
         visitIterateNodeDType(nodep);
     }
-    virtual void visit(AstNodeUOrStructDType* nodep) {
+    virtual void visit(AstNodeUOrStructDType* nodep) VL_OVERRIDE {
         if (nodep->user1SetOnce()) return;  // Process once
         visitIterateNodeDType(nodep);
         nodep->clearCache();
     }
-    virtual void visit(AstParamTypeDType* nodep) {
+    virtual void visit(AstParamTypeDType* nodep) VL_OVERRIDE {
         if (nodep->user1SetOnce()) return;  // Process once
         visitIterateNodeDType(nodep);
         // Move to type table as all dtype pointers must resolve there
@@ -153,11 +153,11 @@ private:
         nodep->virtRefDTypep(editOneDType(nodep->virtRefDTypep()));
         nodep->virtRefDType2p(editOneDType(nodep->virtRefDType2p()));
     }
-    virtual void visit(AstNodePreSel* nodep) {  // LCOV_EXCL_LINE
+    virtual void visit(AstNodePreSel* nodep) VL_OVERRIDE {  // LCOV_EXCL_LINE
         // This check could go anywhere after V3Param
         nodep->v3fatalSrc("Presels should have been removed before this point");
     }
-    virtual void visit(AstNode* nodep) {
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {
         iterateChildren(nodep);
         editDType(nodep);
     }

--- a/src/V3WidthSel.cpp
+++ b/src/V3WidthSel.cpp
@@ -196,7 +196,7 @@ private:
     // VISITORS
     // If adding new visitors, insure V3Width's visit(TYPE) calls into here
 
-    virtual void visit(AstSelBit* nodep) {
+    virtual void visit(AstSelBit* nodep) VL_OVERRIDE {
         // Select of a non-width specified part of an array, i.e. "array[2]"
         // This select style has a lsb and msb (no user specified width)
         UINFO(6,"SELBIT "<<nodep<<endl);
@@ -300,7 +300,7 @@ private:
         }
         if (!rhsp->backp()) { VL_DO_DANGLING(pushDeletep(rhsp), rhsp); }
     }
-    virtual void visit(AstSelExtract* nodep) {
+    virtual void visit(AstSelExtract* nodep) VL_OVERRIDE {
         // Select of a range specified part of an array, i.e. "array[2:3]"
         // SELEXTRACT(from,msb,lsb) -> SEL(from, lsb, 1+msb-lsb)
         // This select style has a (msb or lsb) and width
@@ -492,17 +492,17 @@ private:
         if (!rhsp->backp()) { VL_DO_DANGLING(pushDeletep(rhsp), rhsp); }
         if (!widthp->backp()) { VL_DO_DANGLING(pushDeletep(widthp), widthp); }
     }
-    virtual void visit(AstSelPlus* nodep) {
+    virtual void visit(AstSelPlus* nodep) VL_OVERRIDE {
         replaceSelPlusMinus(nodep);
     }
-    virtual void visit(AstSelMinus* nodep) {
+    virtual void visit(AstSelMinus* nodep) VL_OVERRIDE {
         replaceSelPlusMinus(nodep);
     }
     // If adding new visitors, insure V3Width's visit(TYPE) calls into here
 
     //--------------------
     // Default
-    virtual void visit(AstNode* nodep) {  // LCOV_EXCL_LINE
+    virtual void visit(AstNode* nodep) VL_OVERRIDE {  // LCOV_EXCL_LINE
         // See notes above; we never iterate
         nodep->v3fatalSrc("Shouldn't iterate in V3WidthSel");
     }


### PR DESCRIPTION
derives from https://github.com/verilator/verilator/pull/2066#discussion_r368572790

Quite a lot of changed lines, but all changes are just adding VL_OVERRIDE.