### PR TITLE
Improve performance of AstNode casting and type checks

### DIFF
--- a/src/V3Ast.h
+++ b/src/V3Ast.h
@@ -57,12 +57,12 @@ typedef std::set<int> MTaskIdSet;  // Set of mtaskIds for Var sorting
     } while (0)
 
 // (V)erilator (N)ode is: True if AstNode is of a a given AstType
-#define VN_IS(nodep,nodetypename) (AstNode::privateIs ## nodetypename(nodep))
+#define VN_IS(nodep,nodetypename) (AstNode::privateIs<Ast ## nodetypename>(nodep))
 
 // (V)erilator (N)ode cast: Cast to given type if can; effectively
 // dynamic_cast<nodetypename>(nodep)
-#define VN_CAST(nodep,nodetypename) (AstNode::privateCast ## nodetypename(nodep))
-#define VN_CAST_CONST(nodep,nodetypename) (AstNode::privateConstCast ## nodetypename(nodep) )
+#define VN_CAST(nodep,nodetypename) (AstNode::privateCast<Ast ## nodetypename>(nodep))
+#define VN_CAST_CONST(nodep,nodetypename) (AstNode::privateConstCast<Ast ## nodetypename>(nodep))
 
 // (V)erilator (N)ode deleted: Reference to deleted child (for assertions only)
 #define VN_DELETED(nodep) VL_UNLIKELY((vluint64_t)(nodep) == 0x1)
@@ -1535,10 +1535,21 @@ private:
 
     // CONVERSION
 public:
-#include "V3Ast__gen_interface.h"  // From ./astgen
-    // Things like:
-    //  AstAlways*      castAlways();
+    // These for use by VN_IS macro only
+    template<class T>
+    static bool privateIs(const AstNode* nodep);
+
+    // These for use by VN_CAST macro only
+    template<class T>
+    static T* privateCast(AstNode* nodep);
+
+    // These for use by VN_CAST_CONST macro only
+    template<class T>
+    static const T* privateConstCast(const AstNode* nodep);
 };
+
+// Specialisations of privateIs/privateCast
+#include "V3Ast__gen_impl.h"  // From ./astgen
 
 inline std::ostream& operator<<(std::ostream& os, const AstNode* rhs) {
     if (!rhs) os<<"NULL"; else rhs->dump(os); return os;
@@ -2285,11 +2296,6 @@ public:
 //######################################################################
 
 #include "V3AstNodes.h"
-
-#include "V3Ast__gen_impl.h"  // From ./astgen
-// Things like:
-//  inline AstAlways* AstNode::castAlways() { return dynamic_cast<AstAlways*>(this); }
-//  inline bool AstNode::privateIsaAlways(const AstNode* nodep) { return nodep && nodep->type() == AstType::atAlways; }
 
 //######################################################################
 // Inline AstNVisitor METHODS

--- a/src/astgen
+++ b/src/astgen
@@ -48,7 +48,6 @@ if ($opt_classes) {
     write_report("V3Ast__gen_report.txt");
     write_classes("V3Ast__gen_classes.h");
     write_visitor("V3Ast__gen_visitor.h");
-    write_intf("V3Ast__gen_interface.h");
     write_impl("V3Ast__gen_impl.h");
     write_types("V3Ast__gen_types.h");
 }
@@ -244,68 +243,112 @@ sub write_visitor {
     $fh->close();
 }
 
-sub write_intf {
+sub write_impl {
     my $fh = open_file(@_);
 
     print $fh "\n";
-    print $fh "    // These for use by VN_IS macro only\n";
+
+    print $fh "    // These for use by VN_IS only\n";
     foreach my $type (sort (keys %Classes)) {
-        print $fh "    static bool privateIs",$type,"(const AstNode* nodep);\n";
+        print $fh "template<> inline bool AstNode::privateIs<Ast",$type,">(const AstNode* nodep) { ";
+        if ($type eq "Node") {
+            print $fh "return nodep != NULL; ";
+        } else {
+            print $fh "return nodep && ";
+            if ($type =~ /^Node/) {
+                print $fh "(static_cast<int>(nodep->type()) >= static_cast<int>(AstType::first",$type,")) && ";
+                print $fh "(static_cast<int>(nodep->type()) <= static_cast<int>(AstType::last",$type,")); ";
+            } else {
+                print $fh "(static_cast<int>(nodep->type()) == static_cast<int>(AstType::at",$type,")); ";
+            }
+        }
+        print $fh "}\n"
     }
 
-    print $fh "\n";
     print $fh "    // These for use by VN_CAST macro only\n";
     foreach my $type (sort (keys %Classes)) {
-        print $fh "    static Ast",$type,"* privateCast",$type,"(AstNode* nodep);\n";
+        print $fh "template<> inline Ast",$type,"* AstNode::privateCast<Ast",$type,">(AstNode* nodep) { ";
+        if ($type eq "Node") {
+            print $fh "return nodep; ";
+        } else {
+            print $fh "return AstNode::privateIs<Ast",$type,">(nodep) ? ";
+            print $fh "reinterpret_cast<Ast",$type,"*>(nodep) : NULL; ";
+        }
+        print $fh "}\n";
     }
+
+    print $fh "    // These for use by VN_CAST_CONST macro only\n";
     foreach my $type (sort (keys %Classes)) {
-        print $fh "    static const Ast",$type,"* privateConstCast",$type,"(const AstNode* nodep);\n";
+        print $fh "template<> inline const Ast",$type,"* AstNode::privateConstCast<Ast",$type,">(const AstNode* nodep) { ";
+        if ($type eq "Node") {
+            print $fh "return nodep; ";
+        } else {
+            print $fh "return AstNode::privateIs<Ast",$type,">(nodep) ? ";
+            print $fh "reinterpret_cast<const Ast",$type,"*>(nodep) : NULL; ";
+        }
+        print $fh "}\n";
     }
 
     $fh->close();
 }
 
-sub write_impl {
-    my $fh = open_file(@_);
+sub write_type_enum {
+    my $fh = shift;
+    my $type = shift;
+    my $idx = shift;
+    my $processed = shift;
+    my $kind = shift;
+    my $indent = shift;
 
-    print $fh "\n";
-    print $fh "    // These for use by VN_IS macro only\n";
-    foreach my $type (sort (keys %Classes)) {
-        if (children_of($type)) {
-            print $fh "inline bool AstNode::privateIs",$type,"(const AstNode* nodep) { return (bool)(dynamic_cast<const Ast",$type,"*>(nodep)); }\n";
-        } else {
-            print $fh "inline bool AstNode::privateIs",$type,"(const AstNode* nodep) { return nodep && nodep->type() == AstType::at",$type,"; }\n";
+    # Skip this if it has already been processed
+    return $idx if (exists $processed->{$type});
+
+    # Mark processed
+    $processed->{$type} = 1;
+
+    # The last used index
+    my $last;
+
+    if ($type !~ /^Node/) {
+        $last = $idx;
+        if ($kind eq "concrete-enum") {
+            print $fh " "x($indent*4), "at",$type," = ",$idx,",\n";
+        } elsif ($kind eq "concrete-ascii") {
+            print $fh " "x($indent*4), "\"", uc $type, "\",\n";
         }
+        $idx += 1;
+    } elsif ($kind eq "abstract-enum") {
+        print $fh " "x($indent*4), "first",$type," = ",$idx,",\n";
     }
 
-    foreach my $type (sort (keys %Classes)) {
-        print $fh "inline Ast",$type,"* AstNode::privateCast",$type,"(AstNode* nodep) { return dynamic_cast<Ast",$type,"*>(nodep); }\n";
-    }
-    foreach my $type (sort (keys %Classes)) {
-        print $fh "inline const Ast",$type,"* AstNode::privateConstCast",$type,"(const AstNode* nodep) { return dynamic_cast<const Ast",$type,"*>(nodep); }\n";
+    foreach my $child (sort keys %{$::Children{$type}}) {
+        ($idx, $last) = write_type_enum($fh, $child, $idx, $processed, $kind, $indent);
     }
 
-    $fh->close();
+    if ($type =~ /^Node/ && ($kind eq "abstract-enum")) {
+        print $fh " "x($indent*4), "last",$type," = ",$last,",\n";
+    }
+
+    return $idx, $last;
 }
 
 sub write_types {
     my $fh = open_file(@_);
 
     printf $fh "    enum en {\n";
-    # Add "at" prefix to avoid conflicting with FOPEN and other macros in include files
-    foreach my $type (sort (keys %Classes)) {
-        next if $type =~ /^Node/;
-        print $fh "\tat",$type,",\n";
-    }
-    printf $fh "\t_ENUM_END\n";
+    (my $final, undef) = write_type_enum($fh, "Node", 0, {}, "concrete-enum", 2);
+    printf $fh "        _ENUM_END = $final\n";
     printf $fh "    };\n";
+
+    printf $fh "    enum bounds {\n";
+    write_type_enum($fh, "Node", 0, {}, "abstract-enum", 2);
+    printf $fh "        _BOUNDS_END\n";
+    printf $fh "    };\n";
+
     printf $fh "    const char* ascii() const {\n";
-    printf $fh "        const char* const names[] = {\n";
-    foreach my $type (sort (keys %Classes)) {
-        next if $type =~ /^Node/;
-        print $fh "\t\"", uc $type, "\",\n";
-    }
-    printf $fh "\t\"_ENUM_END\"\n";
+    printf $fh "        const char* const names[_ENUM_END + 1] = {\n";
+    write_type_enum($fh, "Node", 0, {}, "concrete-ascii", 3);
+    printf $fh "            \"_ENUM_END\"\n";
     printf $fh "        };\n";
     printf $fh "        return names[m_e];\n";
     printf $fh "    };\n";


### PR DESCRIPTION
Hello,

I spent some time optimising Verilator itself. This is should be the first result of that effort. Purposes of patches are in the commit messages. In short they eliminate all instances of dynamic_cast applied to AstNode via the VN_IS and VN_CAST/VN_CAST_CONST macros.

Git archaeology tells me that the implementation of AstNode casting was similar until 597d28b505ec16f571685347a0050b279ad5781f which suggests it was changed due to some lint checks complaining (cppcheck maybe?), but I feel the 6-13% compilation speed difference I measured is significant enough to warrant the effort/signoff if necessary.

Local testing with --enable-longtests are OK, and Travis non-cron build seem happy.

For completeness, measurements were on an Intel 6440HQ, with fixed CPU frequency so the variance of execution times among 3 runs is under 0.1% as reported by perf stat, so the speed gain is very clear. Host was Ubuntu 17.10 with GCC 7.2.0.

This is my first Verilator contribution so I apologise if I missed something. Please let me know if you would be happy to take similar patches.

Geza