### PR TITLE
Further performance improvement of AstNode type tests

### DIFF
--- a/src/V3Ast.h
+++ b/src/V3Ast.h
@@ -79,8 +79,10 @@ public:
     // cppcheck-suppress uninitVar  // responsibility of each subclass
     inline AstType() {}
     // cppcheck-suppress noExplicitConstructor
-    inline AstType(en _e) : m_e(_e) {}
-    explicit inline AstType(int _e) : m_e(static_cast<en>(_e)) {}
+    inline AstType(en _e)
+        : m_e(_e) {}
+    explicit inline AstType(int _e)
+        : m_e(static_cast<en>(_e)) {}
     operator en() const { return m_e; }
   };
   inline bool operator==(AstType lhs, AstType rhs) { return (lhs.m_e == rhs.m_e); }
@@ -112,9 +114,11 @@ public:
         };
         return names[m_e];
     };
-    inline AstNumeric() : m_e(UNSIGNED) {}
+    inline AstNumeric()
+        : m_e(UNSIGNED) {}
     // cppcheck-suppress noExplicitConstructor
-    inline AstNumeric(en _e) : m_e(_e) {}
+    inline AstNumeric(en _e)
+        : m_e(_e) {}
     // cppcheck-suppress noExplicitConstructor
     inline AstNumeric(VSignedState signst) {
         if (signst==signedst_UNSIGNED) m_e = UNSIGNED;
@@ -123,7 +127,8 @@ public:
     }
     static inline AstNumeric fromBool(bool isSigned) {  // Factory method
         return isSigned ? AstNumeric(SIGNED) : AstNumeric(UNSIGNED); }
-    explicit inline AstNumeric(int _e) : m_e(static_cast<en>(_e)) {}
+    explicit inline AstNumeric(int _e)
+        : m_e(static_cast<en>(_e)) {}
     operator en() const { return m_e; }
     inline bool isSigned() const { return m_e==SIGNED; }
     inline bool isNosign() const { return m_e==NOSIGN; }
@@ -151,10 +156,13 @@ public:
         ENUM_SIZE
     };
     enum en m_e;
-    inline AstPragmaType() : m_e(ILLEGAL) {}
+    inline AstPragmaType()
+        : m_e(ILLEGAL) {}
     // cppcheck-suppress noExplicitConstructor
-    inline AstPragmaType(en _e) : m_e(_e) {}
-    explicit inline AstPragmaType(int _e) : m_e(static_cast<en>(_e)) {}
+    inline AstPragmaType(en _e)
+        : m_e(_e) {}
+    explicit inline AstPragmaType(int _e)
+        : m_e(static_cast<en>(_e)) {}
     operator en() const { return m_e; }
   };
   inline bool operator==(AstPragmaType lhs, AstPragmaType rhs) { return (lhs.m_e == rhs.m_e); }
@@ -175,10 +183,13 @@ public:
         TRACE_CHANGE_SUB
     };
     enum en m_e;
-    inline AstCFuncType() : m_e(FT_NORMAL) {}
+    inline AstCFuncType()
+        : m_e(FT_NORMAL) {}
     // cppcheck-suppress noExplicitConstructor
-    inline AstCFuncType(en _e) : m_e(_e) {}
-    explicit inline AstCFuncType(int _e) : m_e(static_cast<en>(_e)) {}
+    inline AstCFuncType(en _e)
+        : m_e(_e) {}
+    explicit inline AstCFuncType(int _e)
+        : m_e(static_cast<en>(_e)) {}
     operator en() const { return m_e; }
     // METHODS
     bool isTrace() const { return (m_e==TRACE_INIT || m_e==TRACE_INIT_SUB
@@ -268,10 +279,13 @@ public:
         }
         return false;
     }
-    inline VEdgeType() : m_e(ET_ILLEGAL) {}
+    inline VEdgeType()
+        : m_e(ET_ILLEGAL) {}
     // cppcheck-suppress noExplicitConstructor
-    inline VEdgeType(en _e) : m_e(_e) {}
-    explicit inline VEdgeType(int _e) : m_e(static_cast<en>(_e)) {}
+    inline VEdgeType(en _e)
+        : m_e(_e) {}
+    explicit inline VEdgeType(int _e)
+        : m_e(static_cast<en>(_e)) {}
     operator en() const { return m_e; }
   };
   inline bool operator==(VEdgeType lhs, VEdgeType rhs) { return (lhs.m_e == rhs.m_e); }
@@ -337,10 +351,13 @@ public:
         };
         return names[m_e];
     };
-    inline AstAttrType() : m_e(ILLEGAL) {}
+    inline AstAttrType()
+        : m_e(ILLEGAL) {}
     // cppcheck-suppress noExplicitConstructor
-    inline AstAttrType(en _e) : m_e(_e) {}
-    explicit inline AstAttrType(int _e) : m_e(static_cast<en>(_e)) {}
+    inline AstAttrType(en _e)
+        : m_e(_e) {}
+    explicit inline AstAttrType(int _e)
+        : m_e(static_cast<en>(_e)) {}
     operator en() const { return m_e; }
   };
   inline bool operator==(AstAttrType lhs, AstAttrType rhs) { return (lhs.m_e == rhs.m_e); }
@@ -397,10 +414,13 @@ public:
         UASSERT(0==strcmp(AstBasicDTypeKwd(_ENUM_MAX).ascii(), " MAX"), "SelfTest: Enum mismatch");
         UASSERT(0==strcmp(AstBasicDTypeKwd(_ENUM_MAX).dpiType(), " MAX"), "SelfTest: Enum mismatch");
     }
-    inline AstBasicDTypeKwd() : m_e(UNKNOWN) {}
+    inline AstBasicDTypeKwd()
+        : m_e(UNKNOWN) {}
     // cppcheck-suppress noExplicitConstructor
-    inline AstBasicDTypeKwd(en _e) : m_e(_e) {}
-    explicit inline AstBasicDTypeKwd(int _e) : m_e(static_cast<en>(_e)) {}
+    inline AstBasicDTypeKwd(en _e)
+        : m_e(_e) {}
+    explicit inline AstBasicDTypeKwd(int _e)
+        : m_e(static_cast<en>(_e)) {}
     operator en() const { return m_e; }
     int width() const {
         switch (m_e) {
@@ -487,10 +507,13 @@ public:
         CONSTREF
     };
     enum en m_e;
-    inline VDirection() : m_e(NONE) {}
+    inline VDirection()
+        : m_e(NONE) {}
     // cppcheck-suppress noExplicitConstructor
-    inline VDirection(en _e) : m_e(_e) {}
-    explicit inline VDirection(int _e) : m_e(static_cast<en>(_e)) {}
+    inline VDirection(en _e)
+        : m_e(_e) {}
+    explicit inline VDirection(int _e)
+        : m_e(static_cast<en>(_e)) {}
     operator en() const { return m_e; }
     const char* ascii() const {
         static const char* const names[] = {
@@ -533,10 +556,13 @@ public:
     };
     enum en m_e;
     // CONSTRUCTOR - note defaults to *UNKNOWN*
-    inline VBoolOrUnknown() : m_e(BU_UNKNOWN) {}
+    inline VBoolOrUnknown()
+        : m_e(BU_UNKNOWN) {}
     // cppcheck-suppress noExplicitConstructor
-    inline VBoolOrUnknown(en _e) : m_e(_e) {}
-    explicit inline VBoolOrUnknown(int _e) : m_e(static_cast<en>(_e)) {}
+    inline VBoolOrUnknown(en _e)
+        : m_e(_e) {}
+    explicit inline VBoolOrUnknown(int _e)
+        : m_e(static_cast<en>(_e)) {}
     const char* ascii() const {
         static const char* const names[] = {
             "FALSE", "TRUE", "UNK"};
@@ -576,10 +602,13 @@ public:
         IFACEREF        // Used to link Interfaces between modules
     };
     enum en m_e;
-    inline AstVarType() : m_e(UNKNOWN) {}
+    inline AstVarType()
+        : m_e(UNKNOWN) {}
     // cppcheck-suppress noExplicitConstructor
-    inline AstVarType(en _e) : m_e(_e) {}
-    explicit inline AstVarType(int _e) : m_e(static_cast<en>(_e)) {}
+    inline AstVarType(en _e)
+        : m_e(_e) {}
+    explicit inline AstVarType(int _e)
+        : m_e(static_cast<en>(_e)) {}
     operator en() const { return m_e; }
     const char* ascii() const {
         static const char* const names[] = {
@@ -631,10 +660,13 @@ public:
     };
     enum en m_e;
     // CONSTRUCTOR - note defaults to *UNKNOWN*
-    inline VBranchPred() : m_e(BP_UNKNOWN) {}
+    inline VBranchPred()
+        : m_e(BP_UNKNOWN) {}
     // cppcheck-suppress noExplicitConstructor
-    inline VBranchPred(en _e) : m_e(_e) {}
-    explicit inline VBranchPred(int _e) : m_e(static_cast<en>(_e)) {}
+    inline VBranchPred(en _e)
+        : m_e(_e) {}
+    explicit inline VBranchPred(int _e)
+        : m_e(static_cast<en>(_e)) {}
     operator en() const { return m_e; }
     bool unknown() const { return m_e == BP_UNKNOWN; }
     bool likely() const { return m_e == BP_LIKELY; }
@@ -666,10 +698,13 @@ public:
     };
     enum en m_e;
     // CONSTRUCTOR - note defaults to *UNKNOWN*
-    inline VVarAttrClocker() : m_e(CLOCKER_UNKNOWN) {}
+    inline VVarAttrClocker()
+        : m_e(CLOCKER_UNKNOWN) {}
     // cppcheck-suppress noExplicitConstructor
-    inline VVarAttrClocker(en _e) : m_e(_e) {}
-    explicit inline VVarAttrClocker(int _e) : m_e(static_cast<en>(_e)) {}
+    inline VVarAttrClocker(en _e)
+        : m_e(_e) {}
+    explicit inline VVarAttrClocker(int _e)
+        : m_e(static_cast<en>(_e)) {}
     operator en() const { return m_e; }
     bool unknown() const { return m_e==CLOCKER_UNKNOWN; }
     VVarAttrClocker invert() const {
@@ -698,10 +733,13 @@ public:
         ALWAYS_COMB
     };
     enum en m_e;
-    inline VAlwaysKwd() : m_e(ALWAYS) {}
+    inline VAlwaysKwd()
+        : m_e(ALWAYS) {}
     // cppcheck-suppress noExplicitConstructor
-    inline VAlwaysKwd(en _e) : m_e(_e) {}
-    explicit inline VAlwaysKwd(int _e) : m_e(static_cast<en>(_e)) {}
+    inline VAlwaysKwd(en _e)
+        : m_e(_e) {}
+    explicit inline VAlwaysKwd(int _e)
+        : m_e(static_cast<en>(_e)) {}
     operator en() const { return m_e; }
     const char* ascii() const {
         static const char* const names[] = {
@@ -723,10 +761,13 @@ public:
         CT_CASEINSIDE
     };
     enum en m_e;
-    inline VCaseType() : m_e(CT_CASE) {}
+    inline VCaseType()
+        : m_e(CT_CASE) {}
     // cppcheck-suppress noExplicitConstructor
-    inline VCaseType(en _e) : m_e(_e) {}
-    explicit inline VCaseType(int _e) : m_e(static_cast<en>(_e)) {}
+    inline VCaseType(en _e)
+        : m_e(_e) {}
+    explicit inline VCaseType(int _e)
+        : m_e(static_cast<en>(_e)) {}
     operator en() const { return m_e; }
   };
   inline bool operator==(VCaseType lhs, VCaseType rhs) { return (lhs.m_e == rhs.m_e); }
@@ -746,10 +787,13 @@ public:
         DT_FATAL
     };
     enum en m_e;
-    inline AstDisplayType() : m_e(DT_DISPLAY) {}
+    inline AstDisplayType()
+        : m_e(DT_DISPLAY) {}
     // cppcheck-suppress noExplicitConstructor
-    inline AstDisplayType(en _e) : m_e(_e) {}
-    explicit inline AstDisplayType(int _e) : m_e(static_cast<en>(_e)) {}
+    inline AstDisplayType(en _e)
+        : m_e(_e) {}
+    explicit inline AstDisplayType(int _e)
+        : m_e(static_cast<en>(_e)) {}
     operator en() const { return m_e; }
     bool addNewline() const { return m_e!=DT_WRITE; }
     bool needScopeTracking() const { return m_e!=DT_DISPLAY && m_e!=DT_WRITE; }
@@ -771,10 +815,13 @@ public:
         PX_TEXT         // Unknown ID component
     };
     enum en m_e;
-    inline VParseRefExp() : m_e(PX_NONE) {}
+    inline VParseRefExp()
+        : m_e(PX_NONE) {}
     // cppcheck-suppress noExplicitConstructor
-    inline VParseRefExp(en _e) : m_e(_e) {}
-    explicit inline VParseRefExp(int _e) : m_e(static_cast<en>(_e)) {}
+    inline VParseRefExp(en _e)
+        : m_e(_e) {}
+    explicit inline VParseRefExp(int _e)
+        : m_e(static_cast<en>(_e)) {}
     operator en() const { return m_e; }
     const char* ascii() const {
         static const char* const names[] = {
@@ -816,7 +863,8 @@ public:
     }
     //
     class LeftRight {};
-    VNumRange() : m_hi(0), m_lo(0), mu_flags(0) {}
+    VNumRange()
+        : m_hi(0), m_lo(0), mu_flags(0) {}
     VNumRange(int hi, int lo, bool littleEndian)
         : m_hi(0), m_lo(0), mu_flags(0)
         { init(hi, lo, littleEndian); }
@@ -1215,9 +1263,10 @@ public:
 
 protected:
     // CONSTRUCTORS
-    AstNode(AstType t) : m_type(t) { init(); }
-    explicit AstNode(AstType t, FileLine* fileline)
-        : m_type(t) {init(); m_fileline = fileline; }
+    AstNode(AstType t)
+        : m_type(t) { init(); }
+    AstNode(AstType t, FileLine* fl)
+        : m_type(t) { init(); m_fileline = fl; }
     virtual AstNode* clone() = 0;  // Generally, cloneTree is what you want instead
     virtual void cloneRelink() {}
     void cloneRelinkTree();
@@ -1573,7 +1622,7 @@ inline void AstNRelinker::relink(AstNode* newp) { newp->AstNode::relink(this); }
 class AstNodeMath : public AstNode {
     // Math -- anything that's part of an expression tree
 public:
-    explicit AstNodeMath(AstType t, FileLine* fl)
+    AstNodeMath(AstType t, FileLine* fl)
         : AstNode(t, fl) {}
     ASTNODE_BASE_FUNCS(NodeMath)
     // METHODS
@@ -1590,7 +1639,7 @@ public:
 class AstNodeTermop : public AstNodeMath {
     // Terminal operator -- a operator with no "inputs"
 public:
-    explicit AstNodeTermop(AstType t, FileLine* fl)
+    AstNodeTermop(AstType t, FileLine* fl)
         : AstNodeMath(t, fl) {}
     ASTNODE_BASE_FUNCS(NodeTermop)
     // Know no children, and hot function, so skip iterator for speed
@@ -1742,7 +1791,7 @@ class AstNodeStmt : public AstNode {
     // Statement -- anything that's directly under a function
     bool m_statement;  // Really a statement (e.g. not a function with return)
 public:
-    explicit AstNodeStmt(AstType t, FileLine* fl, bool statement = true)
+    AstNodeStmt(AstType t, FileLine* fl, bool statement = true)
         : AstNode(t, fl)
         , m_statement(statement) {}
     ASTNODE_BASE_FUNCS(NodeStmt)
@@ -1836,7 +1885,8 @@ public:
 class AstNodeSenItem : public AstNode {
     // An AstSenItem or AstSenGate
 public:
-    explicit AstNodeSenItem(AstType t, FileLine* fl) : AstNode(t, fl) {}
+    AstNodeSenItem(AstType t, FileLine* fl)
+        : AstNode(t, fl) {}
     ASTNODE_BASE_FUNCS(NodeSenItem)
     virtual bool isClocked() const = 0;
     virtual bool isCombo() const = 0;
@@ -1925,7 +1975,8 @@ private:
     static int  s_uniqueNum;    // Unique number assigned to each dtype during creation for IEEE matching
 public:
     // CONSTRUCTORS
-    explicit AstNodeDType(AstType t, FileLine* fl) : AstNode(t, fl) {
+    AstNodeDType(AstType t, FileLine* fl)
+        : AstNode(t, fl) {
         m_width = 0; m_widthMin = 0; m_generic = false;
     }
     ASTNODE_BASE_FUNCS(NodeDType)
@@ -2036,7 +2087,8 @@ private:
     AstNodeDType* m_refDTypep;  // Elements of this type (after widthing)
     AstNode* rangenp() const { return op2p(); }  // op2 = Array(s) of variable
 public:
-    explicit AstNodeArrayDType(AstType t, FileLine* fl) : AstNodeDType(t, fl) {
+    AstNodeArrayDType(AstType t, FileLine* fl)
+        : AstNodeDType(t, fl) {
         m_refDTypep = NULL;
     }
     ASTNODE_BASE_FUNCS(NodeArrayDType)
@@ -2101,7 +2153,8 @@ public:
 class AstNodeStream : public AstNodeBiop {
     // Verilog {rhs{lhs}} - Note rhsp() is the slice size, not the lhsp()
 public:
-    AstNodeStream(AstType t, FileLine* fl, AstNode* lhsp, AstNode* rhsp) : AstNodeBiop(t, fl, lhsp, rhsp) {
+    AstNodeStream(AstType t, FileLine* fl, AstNode* lhsp, AstNode* rhsp)
+        : AstNodeBiop(t, fl, lhsp, rhsp) {
         if (lhsp->dtypep()) {
             dtypeSetLogicSized(lhsp->dtypep()->width(), AstNumeric::UNSIGNED);
         }
@@ -2292,7 +2345,8 @@ public:
 class AstNodeRange : public AstNode {
     // A range, sized or unsized
 public:
-    explicit AstNodeRange(AstType t, FileLine* fl) : AstNode(t, fl) { }
+    AstNodeRange(AstType t, FileLine* fl)
+        : AstNode(t, fl) { }
     ASTNODE_BASE_FUNCS(NodeRange)
 };
 

--- a/src/V3Ast.h
+++ b/src/V3Ast.h
@@ -1159,6 +1159,8 @@ class AstNode {
 
     AstNode*    m_headtailp;    // When at begin/end of list, the opposite end of the list
 
+    const AstType m_type;       // Node sub-type identifier
+
     FileLine*   m_fileline;     // Where it was declared
     vluint64_t  m_editCount;    // When it was last edited
     static vluint64_t s_editCntGbl;  // Global edit counter
@@ -1213,8 +1215,9 @@ public:
 
 protected:
     // CONSTRUCTORS
-    AstNode() { init(); }
-    explicit AstNode(FileLine* fileline) {init(); m_fileline = fileline; }
+    AstNode(AstType t) : m_type(t) { init(); }
+    explicit AstNode(AstType t, FileLine* fileline)
+        : m_type(t) {init(); m_fileline = fileline; }
     virtual AstNode* clone() = 0;  // Generally, cloneTree is what you want instead
     virtual void cloneRelink() {}
     void cloneRelinkTree();
@@ -1245,7 +1248,7 @@ protected:
 
 public:
     // ACCESSORS
-    virtual AstType type() const = 0;
+    inline AstType type() const { return m_type; }
     const char* typeName() const { return type().ascii(); }  // See also prettyTypeName
     AstNode* nextp() const { return m_nextp; }
     AstNode* backp() const { return m_backp; }
@@ -1570,8 +1573,8 @@ inline void AstNRelinker::relink(AstNode* newp) { newp->AstNode::relink(this); }
 class AstNodeMath : public AstNode {
     // Math -- anything that's part of an expression tree
 public:
-    explicit AstNodeMath(FileLine* fl)
-        : AstNode(fl) {}
+    explicit AstNodeMath(AstType t, FileLine* fl)
+        : AstNode(t, fl) {}
     ASTNODE_BASE_FUNCS(NodeMath)
     // METHODS
     virtual bool hasDType() const { return true; }
@@ -1587,8 +1590,8 @@ public:
 class AstNodeTermop : public AstNodeMath {
     // Terminal operator -- a operator with no "inputs"
 public:
-    explicit AstNodeTermop(FileLine* fl)
-        : AstNodeMath(fl) {}
+    explicit AstNodeTermop(AstType t, FileLine* fl)
+        : AstNodeMath(t, fl) {}
     ASTNODE_BASE_FUNCS(NodeTermop)
     // Know no children, and hot function, so skip iterator for speed
     // See checkTreeIter also that asserts no children
@@ -1599,8 +1602,8 @@ public:
 class AstNodeUniop : public AstNodeMath {
     // Unary math
 public:
-    AstNodeUniop(FileLine* fl, AstNode* lhsp)
-        : AstNodeMath(fl) {
+    AstNodeUniop(AstType t, FileLine* fl, AstNode* lhsp)
+        : AstNodeMath(t, fl) {
         dtypeFrom(lhsp);
         setOp1p(lhsp); }
     ASTNODE_BASE_FUNCS(NodeUniop)
@@ -1621,8 +1624,8 @@ public:
 class AstNodeBiop : public AstNodeMath {
     // Binary math
 public:
-    AstNodeBiop(FileLine* fl, AstNode* lhs, AstNode* rhs)
-        : AstNodeMath(fl) {
+    AstNodeBiop(AstType t, FileLine* fl, AstNode* lhs, AstNode* rhs)
+        : AstNodeMath(t, fl) {
         setOp1p(lhs); setOp2p(rhs); }
     ASTNODE_BASE_FUNCS(NodeBiop)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) = 0;  // Clone single node, just get same type back.
@@ -1648,8 +1651,8 @@ public:
 class AstNodeTriop : public AstNodeMath {
     // Trinary math
 public:
-    AstNodeTriop(FileLine* fl, AstNode* lhs, AstNode* rhs, AstNode* ths)
-        : AstNodeMath(fl) {
+    AstNodeTriop(AstType t, FileLine* fl, AstNode* lhs, AstNode* rhs, AstNode* ths)
+        : AstNodeMath(t, fl) {
         setOp1p(lhs); setOp2p(rhs); setOp3p(ths); }
     ASTNODE_BASE_FUNCS(NodeTriop)
     AstNode* lhsp() const { return op1p(); }
@@ -1676,22 +1679,22 @@ public:
 class AstNodeBiCom : public AstNodeBiop {
     // Binary math with commutative properties
 public:
-    AstNodeBiCom(FileLine* fl, AstNode* lhs, AstNode* rhs)
-        : AstNodeBiop(fl, lhs, rhs) {}
+    AstNodeBiCom(AstType t, FileLine* fl, AstNode* lhs, AstNode* rhs)
+        : AstNodeBiop(t, fl, lhs, rhs) {}
     ASTNODE_BASE_FUNCS(NodeBiCom)
 };
 
 class AstNodeBiComAsv : public AstNodeBiCom {
     // Binary math with commutative & associative properties
 public:
-    AstNodeBiComAsv(FileLine* fl, AstNode* lhs, AstNode* rhs)
-        : AstNodeBiCom(fl, lhs, rhs) {}
+    AstNodeBiComAsv(AstType t, FileLine* fl, AstNode* lhs, AstNode* rhs)
+        : AstNodeBiCom(t, fl, lhs, rhs) {}
     ASTNODE_BASE_FUNCS(NodeBiComAsv)
 };
 class AstNodeCond : public AstNodeTriop {
 public:
-    AstNodeCond(FileLine* fl, AstNode* condp, AstNode* expr1p, AstNode* expr2p)
-        : AstNodeTriop(fl, condp, expr1p, expr2p) {
+    AstNodeCond(AstType t, FileLine* fl, AstNode* condp, AstNode* expr1p, AstNode* expr2p)
+        : AstNodeTriop(t, fl, condp, expr1p, expr2p) {
         if (expr1p) dtypeFrom(expr1p);
         else if (expr2p) dtypeFrom(expr2p);
     }
@@ -1717,8 +1720,8 @@ public:
 class AstNodePreSel : public AstNode {
     // Something that becomes an AstSel
 public:
-    AstNodePreSel(FileLine* fl, AstNode* lhs, AstNode* rhs, AstNode* ths)
-        : AstNode(fl) {
+    AstNodePreSel(AstType t, FileLine* fl, AstNode* lhs, AstNode* rhs, AstNode* ths)
+        : AstNode(t, fl) {
         setOp1p(lhs); setOp2p(rhs); setNOp3p(ths); }
     ASTNODE_BASE_FUNCS(NodePreSel)
     AstNode* lhsp() const { return op1p(); }
@@ -1739,8 +1742,8 @@ class AstNodeStmt : public AstNode {
     // Statement -- anything that's directly under a function
     bool m_statement;  // Really a statement (e.g. not a function with return)
 public:
-    explicit AstNodeStmt(FileLine* fl, bool statement = true)
-        : AstNode(fl)
+    explicit AstNodeStmt(AstType t, FileLine* fl, bool statement = true)
+        : AstNode(t, fl)
         , m_statement(statement) {}
     ASTNODE_BASE_FUNCS(NodeStmt)
     // METHODS
@@ -1752,8 +1755,8 @@ public:
 
 class AstNodeAssign : public AstNodeStmt {
 public:
-    AstNodeAssign(FileLine* fl, AstNode* lhsp, AstNode* rhsp)
-        : AstNodeStmt(fl) {
+    AstNodeAssign(AstType t, FileLine* fl, AstNode* lhsp, AstNode* rhsp)
+        : AstNodeStmt(t, fl) {
         setOp1p(rhsp); setOp2p(lhsp);
         dtypeFrom(lhsp);
     }
@@ -1775,9 +1778,9 @@ public:
 
 class AstNodeFor : public AstNodeStmt {
 public:
-    AstNodeFor(FileLine* fileline, AstNode* initsp, AstNode* condp,
+    AstNodeFor(AstType t, FileLine* fl, AstNode* initsp, AstNode* condp,
                AstNode* incsp, AstNode* bodysp)
-        : AstNodeStmt(fileline) {
+        : AstNodeStmt(t, fl) {
         addNOp1p(initsp); setOp2p(condp); addNOp3p(incsp); addNOp4p(bodysp);
     }
     ASTNODE_BASE_FUNCS(NodeFor)
@@ -1795,8 +1798,8 @@ class AstNodeIf : public AstNodeStmt {
 private:
     VBranchPred m_branchPred;  // Branch prediction as taken/untaken?
 public:
-    AstNodeIf(FileLine* fl, AstNode* condp, AstNode* ifsp, AstNode* elsesp)
-        : AstNodeStmt(fl) {
+    AstNodeIf(AstType t, FileLine* fl, AstNode* condp, AstNode* ifsp, AstNode* elsesp)
+        : AstNodeStmt(t, fl) {
         setOp1p(condp); addNOp2p(ifsp); addNOp3p(elsesp);
     }
     ASTNODE_BASE_FUNCS(NodeIf)
@@ -1817,8 +1820,8 @@ public:
 
 class AstNodeCase : public AstNodeStmt {
 public:
-    AstNodeCase(FileLine* fl, AstNode* exprp, AstNode* casesp)
-        : AstNodeStmt(fl) {
+    AstNodeCase(AstType t, FileLine* fl, AstNode* exprp, AstNode* casesp)
+        : AstNodeStmt(t, fl) {
         setOp1p(exprp); addNOp2p(casesp);
     }
     ASTNODE_BASE_FUNCS(NodeCase)
@@ -1833,7 +1836,7 @@ public:
 class AstNodeSenItem : public AstNode {
     // An AstSenItem or AstSenGate
 public:
-    explicit AstNodeSenItem(FileLine* fl) : AstNode(fl) {}
+    explicit AstNodeSenItem(AstType t, FileLine* fl) : AstNode(t, fl) {}
     ASTNODE_BASE_FUNCS(NodeSenItem)
     virtual bool isClocked() const = 0;
     virtual bool isCombo() const = 0;
@@ -1854,13 +1857,13 @@ private:
     bool        m_hierThis;     // Hiername points to "this" function
     void init();
 public:
-    AstNodeVarRef(FileLine* fl, const string& name, bool lvalue)
-        : AstNodeMath(fl), m_lvalue(lvalue), m_varp(NULL), m_varScopep(NULL),
+    AstNodeVarRef(AstType t, FileLine* fl, const string& name, bool lvalue)
+        : AstNodeMath(t, fl), m_lvalue(lvalue), m_varp(NULL), m_varScopep(NULL),
           m_packagep(NULL), m_name(name), m_hierThis(false) {
         init();
     }
-    AstNodeVarRef(FileLine* fl, const string& name, AstVar* varp, bool lvalue)
-        : AstNodeMath(fl), m_lvalue(lvalue), m_varp(varp), m_varScopep(NULL),
+    AstNodeVarRef(AstType t, FileLine* fl, const string& name, AstVar* varp, bool lvalue)
+        : AstNodeMath(t, fl), m_lvalue(lvalue), m_varp(varp), m_varScopep(NULL),
           m_packagep(NULL), m_name(name), m_hierThis(false) {
         // May have varp==NULL
         init();
@@ -1896,8 +1899,8 @@ private:
     string      m_text;
 public:
     // Node that simply puts text into the output stream
-    AstNodeText(FileLine* fileline, const string& textp)
-        : AstNode(fileline) {
+    AstNodeText(AstType t, FileLine* fl, const string& textp)
+        : AstNode(t, fl) {
         m_text = textp;  // Copy it
     }
     ASTNODE_BASE_FUNCS(NodeText)
@@ -1922,7 +1925,7 @@ private:
     static int  s_uniqueNum;    // Unique number assigned to each dtype during creation for IEEE matching
 public:
     // CONSTRUCTORS
-    explicit AstNodeDType(FileLine* fl) : AstNode(fl) {
+    explicit AstNodeDType(AstType t, FileLine* fl) : AstNode(t, fl) {
         m_width = 0; m_widthMin = 0; m_generic = false;
     }
     ASTNODE_BASE_FUNCS(NodeDType)
@@ -1982,8 +1985,8 @@ private:
     bool                m_isFourstate;
     MemberNameMap       m_members;
 public:
-    AstNodeUOrStructDType(FileLine* fl, AstNumeric numericUnpack)
-        : AstNodeDType(fl) {
+    AstNodeUOrStructDType(AstType t, FileLine* fl, AstNumeric numericUnpack)
+        : AstNodeDType(t, fl) {
         // AstNumeric::NOSIGN overloaded to indicate not packed
         m_packed = (numericUnpack != AstNumeric::NOSIGN);
         m_isFourstate = false;  // V3Width computes
@@ -2033,7 +2036,7 @@ private:
     AstNodeDType* m_refDTypep;  // Elements of this type (after widthing)
     AstNode* rangenp() const { return op2p(); }  // op2 = Array(s) of variable
 public:
-    explicit AstNodeArrayDType(FileLine* fl) : AstNodeDType(fl) {
+    explicit AstNodeArrayDType(AstType t, FileLine* fl) : AstNodeDType(t, fl) {
         m_refDTypep = NULL;
     }
     ASTNODE_BASE_FUNCS(NodeArrayDType)
@@ -2084,8 +2087,8 @@ public:
 class AstNodeSel : public AstNodeBiop {
     // Single bit range extraction, perhaps with non-constant selection or array selection
 public:
-    AstNodeSel(FileLine* fl, AstNode* fromp, AstNode* bitp)
-        : AstNodeBiop(fl, fromp, bitp) {}
+    AstNodeSel(AstType t, FileLine* fl, AstNode* fromp, AstNode* bitp)
+        : AstNodeBiop(t, fl, fromp, bitp) {}
     ASTNODE_BASE_FUNCS(NodeSel)
     AstNode* fromp() const { return op1p(); }  // op1 = Extracting what (NULL=TBD during parsing)
     void fromp(AstNode* nodep) { setOp1p(nodep); }
@@ -2098,7 +2101,7 @@ public:
 class AstNodeStream : public AstNodeBiop {
     // Verilog {rhs{lhs}} - Note rhsp() is the slice size, not the lhsp()
 public:
-    AstNodeStream(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : AstNodeBiop(fl, lhsp, rhsp) {
+    AstNodeStream(AstType t, FileLine* fl, AstNode* lhsp, AstNode* rhsp) : AstNodeBiop(t, fl, lhsp, rhsp) {
         if (lhsp->dtypep()) {
             dtypeSetLogicSized(lhsp->dtypep()->width(), AstNumeric::UNSIGNED);
         }
@@ -2124,8 +2127,8 @@ private:
     bool        m_dpiTask:1;    // DPI import task (vs. void function)
     bool        m_pure:1;       // DPI import pure
 public:
-    AstNodeFTask(FileLine* fileline, const string& name, AstNode* stmtsp)
-        : AstNode(fileline)
+    AstNodeFTask(AstType t, FileLine* fl, const string& name, AstNode* stmtsp)
+        : AstNode(t, fl)
         , m_name(name)
         , m_dpiOpenParent(0), m_taskPublic(false)
         , m_attrIsolateAssign(false), m_prototype(false)
@@ -2187,13 +2190,13 @@ private:
     string              m_inlinedDots;  // Dotted hierarchy flattened out
     AstPackage*         m_packagep;     // Package hierarchy
 public:
-    AstNodeFTaskRef(FileLine* fl, bool statement, AstNode* namep, AstNode* pinsp)
-        : AstNodeStmt(fl, statement)
+    AstNodeFTaskRef(AstType t, FileLine* fl, bool statement, AstNode* namep, AstNode* pinsp)
+        : AstNodeStmt(t, fl, statement)
         , m_taskp(NULL), m_packagep(NULL) {
         setOp1p(namep); addNOp2p(pinsp);
     }
-    AstNodeFTaskRef(FileLine* fl, bool statement, const string& name, AstNode* pinsp)
-        : AstNodeStmt(fl, statement)
+    AstNodeFTaskRef(AstType t, FileLine* fl, bool statement, const string& name, AstNode* pinsp)
+        : AstNodeStmt(t, fl, statement)
         , m_taskp(NULL), m_name(name), m_packagep(NULL) {
         addNOp2p(pinsp);
     }
@@ -2244,8 +2247,8 @@ private:
     int         m_varNum;       // Incrementing variable number
     int         m_typeNum;      // Incrementing implicit type number
 public:
-    AstNodeModule(FileLine* fl, const string& name)
-        : AstNode(fl)
+    AstNodeModule(AstType t, FileLine* fl, const string& name)
+        : AstNode(t, fl)
         , m_name(name), m_origName(name)
         , m_modPublic(false), m_modTrace(false), m_inLibrary(false), m_dead(false)
         , m_internal(false), m_recursive(false), m_recursiveClone(false)
@@ -2289,13 +2292,13 @@ public:
 class AstNodeRange : public AstNode {
     // A range, sized or unsized
 public:
-    explicit AstNodeRange(FileLine* fl) : AstNode(fl) { }
+    explicit AstNodeRange(AstType t, FileLine* fl) : AstNode(t, fl) { }
     ASTNODE_BASE_FUNCS(NodeRange)
 };
 
 //######################################################################
 
-#include "V3AstNodes.h"
+#include "V3AstNodes__gen.h"
 
 //######################################################################
 // Inline AstNVisitor METHODS

--- a/src/V3AstNodes.cpp
+++ b/src/V3AstNodes.cpp
@@ -168,7 +168,7 @@ AstNodeBiop* AstEqWild::newTyped(FileLine* fl, AstNode* lhsp, AstNode* rhsp) {
 }
 
 AstExecGraph::AstExecGraph(FileLine* fileline)
-    : AstNode(fileline) {
+    : AstNode(AstType::atExecGraph, fileline) {
     m_depGraphp = new V3Graph;
 }
 AstExecGraph::~AstExecGraph() {

--- a/src/V3AstNodes.h
+++ b/src/V3AstNodes.h
@@ -199,7 +199,7 @@ class AstAssocRange : public AstNodeRange {
     // Associative array range specification
     // Only for early parsing - becomes AstAssocDType
 public:
-    explicit AstAssocRange(FileLine* fl, AstNodeDType* dtp)
+    AstAssocRange(FileLine* fl, AstNodeDType* dtp)
         : ASTGEN_SUPER(fl) {
         setOp1p(dtp);
     }
@@ -227,7 +227,8 @@ public:
 class AstUnsizedRange : public AstNodeRange {
     // Unsized range specification, for open arrays
 public:
-    explicit AstUnsizedRange(FileLine* fl) : ASTGEN_SUPER(fl) { }
+    explicit AstUnsizedRange(FileLine* fl)
+        : ASTGEN_SUPER(fl) {}
     ASTNODE_NODE_FUNCS(UnsizedRange)
     virtual string emitC() { V3ERROR_NA; return ""; }
     virtual string emitVerilog() { return "[]"; }
@@ -238,7 +239,8 @@ public:
 class AstGatePin : public AstNodeMath {
     // Possibly expand a gate primitive input pin value to match the range of the gate primitive
 public:
-    AstGatePin(FileLine* fl, AstNode* lhsp, AstRange* rangep) : ASTGEN_SUPER(fl) {
+    AstGatePin(FileLine* fl, AstNode* lhsp, AstRange* rangep)
+        : ASTGEN_SUPER(fl) {
         setOp1p(lhsp); setOp2p(rangep);
     }
     ASTNODE_NODE_FUNCS(GatePin)
@@ -2321,8 +2323,8 @@ class AstGenerate : public AstNode {
     // Parents: MODULE
     // Children: modItems
 public:
-    AstGenerate(FileLine* fileline, AstNode* stmtsp)
-        : ASTGEN_SUPER(fileline) {
+    AstGenerate(FileLine* fl, AstNode* stmtsp)
+        : ASTGEN_SUPER(fl) {
         addNOp1p(stmtsp);
     }
     ASTNODE_NODE_FUNCS(Generate)
@@ -2534,7 +2536,8 @@ class AstSenGate : public AstNodeSenItem {
     // AND as applied to a sensitivity list and a gating expression
     // Performing this gating is optional; it may be removed by later optimizations
 public:
-    AstSenGate(FileLine* fl, AstSenItem* sensesp, AstNode* rhsp) : ASTGEN_SUPER(fl) {
+    AstSenGate(FileLine* fl, AstSenItem* sensesp, AstNode* rhsp)
+        : ASTGEN_SUPER(fl) {
         dtypeSetLogicBool(); addOp1p(sensesp); setOp2p(rhsp);
     }
     ASTNODE_NODE_FUNCS(SenGate)
@@ -2629,8 +2632,8 @@ public:
 
 class AstAssign : public AstNodeAssign {
 public:
-    AstAssign(FileLine* fileline, AstNode* lhsp, AstNode* rhsp)
-        : ASTGEN_SUPER(fileline, lhsp, rhsp) {
+    AstAssign(FileLine* fl, AstNode* lhsp, AstNode* rhsp)
+        : ASTGEN_SUPER(fl, lhsp, rhsp) {
         dtypeFrom(lhsp);
     }
     ASTNODE_NODE_FUNCS(Assign)
@@ -2642,8 +2645,8 @@ class AstAssignAlias : public AstNodeAssign {
     // Like AstAssignW, but a true bidirect interconnection alias
     // If both sides are wires, there's no LHS vs RHS,
 public:
-    AstAssignAlias(FileLine* fileline, AstVarRef* lhsp, AstVarRef* rhsp)
-        : ASTGEN_SUPER(fileline, lhsp, rhsp) {}
+    AstAssignAlias(FileLine* fl, AstVarRef* lhsp, AstVarRef* rhsp)
+        : ASTGEN_SUPER(fl, lhsp, rhsp) {}
     ASTNODE_NODE_FUNCS(AssignAlias)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { V3ERROR_NA; return NULL; }
     virtual bool brokeLhsMustBeLvalue() const { return false; }
@@ -2651,8 +2654,8 @@ public:
 
 class AstAssignDly : public AstNodeAssign {
 public:
-    AstAssignDly(FileLine* fileline, AstNode* lhsp, AstNode* rhsp)
-        : ASTGEN_SUPER(fileline, lhsp, rhsp) {}
+    AstAssignDly(FileLine* fl, AstNode* lhsp, AstNode* rhsp)
+        : ASTGEN_SUPER(fl, lhsp, rhsp) {}
     ASTNODE_NODE_FUNCS(AssignDly)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstAssignDly(this->fileline(), lhsp, rhsp); }
     virtual bool isGateOptimizable() const { return false; }
@@ -2663,8 +2666,8 @@ public:
 class AstAssignW : public AstNodeAssign {
     // Like assign, but wire/assign's in verilog, the only setting of the specified variable
 public:
-    AstAssignW(FileLine* fileline, AstNode* lhsp, AstNode* rhsp)
-        : ASTGEN_SUPER(fileline, lhsp, rhsp) { }
+    AstAssignW(FileLine* fl, AstNode* lhsp, AstNode* rhsp)
+        : ASTGEN_SUPER(fl, lhsp, rhsp) { }
     ASTNODE_NODE_FUNCS(AssignW)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstAssignW(this->fileline(), lhsp, rhsp); }
     virtual bool brokeLhsMustBeLvalue() const { return true; }
@@ -2681,8 +2684,8 @@ public:
 class AstAssignVarScope : public AstNodeAssign {
     // Assign two VarScopes to each other
 public:
-    AstAssignVarScope(FileLine* fileline, AstNode* lhsp, AstNode* rhsp)
-        : ASTGEN_SUPER(fileline, lhsp, rhsp) {
+    AstAssignVarScope(FileLine* fl, AstNode* lhsp, AstNode* rhsp)
+        : ASTGEN_SUPER(fl, lhsp, rhsp) {
         dtypeFrom(rhsp);
     }
     ASTNODE_NODE_FUNCS(AssignVarScope)
@@ -2694,8 +2697,8 @@ class AstPull : public AstNode {
 private:
     bool m_direction;
 public:
-    AstPull(FileLine* fileline, AstNode* lhsp, bool direction)
-        : ASTGEN_SUPER(fileline) {
+    AstPull(FileLine* fl, AstNode* lhsp, bool direction)
+        : ASTGEN_SUPER(fl) {
         setOp1p(lhsp);
         m_direction = direction;
     }
@@ -2710,8 +2713,8 @@ public:
 class AstAssignPre : public AstNodeAssign {
     // Like Assign, but predelayed assignment requiring special order handling
 public:
-    AstAssignPre(FileLine* fileline, AstNode* lhsp, AstNode* rhsp)
-        : ASTGEN_SUPER(fileline, lhsp, rhsp) {}
+    AstAssignPre(FileLine* fl, AstNode* lhsp, AstNode* rhsp)
+        : ASTGEN_SUPER(fl, lhsp, rhsp) {}
     ASTNODE_NODE_FUNCS(AssignPre)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstAssignPre(this->fileline(), lhsp, rhsp); }
     virtual bool brokeLhsMustBeLvalue() const { return true; }
@@ -2720,8 +2723,8 @@ public:
 class AstAssignPost : public AstNodeAssign {
     // Like Assign, but predelayed assignment requiring special order handling
 public:
-    AstAssignPost(FileLine* fileline, AstNode* lhsp, AstNode* rhsp)
-        : ASTGEN_SUPER(fileline, lhsp, rhsp) {}
+    AstAssignPost(FileLine* fl, AstNode* lhsp, AstNode* rhsp)
+        : ASTGEN_SUPER(fl, lhsp, rhsp) {}
     ASTNODE_NODE_FUNCS(AssignPost)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstAssignPost(this->fileline(), lhsp, rhsp); }
     virtual bool brokeLhsMustBeLvalue() const { return true; }
@@ -2878,8 +2881,8 @@ class AstGenCase : public AstNodeCase {
     // exprp Children:  MATHs
     // casesp Children: CASEITEMs
 public:
-    AstGenCase(FileLine* fileline, AstNode* exprp, AstNode* casesp)
-        : ASTGEN_SUPER(fileline, exprp, casesp) {
+    AstGenCase(FileLine* fl, AstNode* exprp, AstNode* casesp)
+        : ASTGEN_SUPER(fl, exprp, casesp) {
     }
     ASTNODE_NODE_FUNCS(GenCase)
 };
@@ -2897,8 +2900,8 @@ private:
     bool        m_unique0Pragma;        // unique0 case
     bool        m_priorityPragma;       // priority case
 public:
-    AstCase(FileLine* fileline, VCaseType casex, AstNode* exprp, AstNode* casesp)
-        : ASTGEN_SUPER(fileline, exprp, casesp) {
+    AstCase(FileLine* fl, VCaseType casex, AstNode* exprp, AstNode* casesp)
+        : ASTGEN_SUPER(fl, exprp, casesp) {
         m_casex = casex;
         m_fullPragma = false; m_parallelPragma = false;
         m_uniquePragma = false; m_unique0Pragma = false; m_priorityPragma = false;
@@ -2932,8 +2935,8 @@ class AstCaseItem : public AstNode {
 private:
     bool m_ignoreOverlap;  // Default created by assertions; ignore overlaps
 public:
-    AstCaseItem(FileLine* fileline, AstNode* condsp, AstNode* bodysp)
-        : ASTGEN_SUPER(fileline) {
+    AstCaseItem(FileLine* fl, AstNode* condsp, AstNode* bodysp)
+        : ASTGEN_SUPER(fl) {
         addNOp1p(condsp); addNOp2p(bodysp);
         m_ignoreOverlap = false;
     }
@@ -2992,15 +2995,15 @@ class AstDisplay : public AstNodeStmt {
 private:
     AstDisplayType      m_displayType;
 public:
-    AstDisplay(FileLine* fileline, AstDisplayType dispType, const string& text, AstNode* filep, AstNode* exprsp)
-        : ASTGEN_SUPER(fileline) {
-        setOp1p(new AstSFormatF(fileline, text, true, exprsp));
+    AstDisplay(FileLine* fl, AstDisplayType dispType, const string& text, AstNode* filep, AstNode* exprsp)
+        : ASTGEN_SUPER(fl) {
+        setOp1p(new AstSFormatF(fl, text, true, exprsp));
         setNOp3p(filep);
         m_displayType = dispType;
     }
-    AstDisplay(FileLine* fileline, AstDisplayType dispType, AstNode* filep, AstNode* exprsp)
-        : ASTGEN_SUPER(fileline) {
-        setOp1p(new AstSFormatF(fileline, AstSFormatF::NoFormat(), exprsp));
+    AstDisplay(FileLine* fl, AstDisplayType dispType, AstNode* filep, AstNode* exprsp)
+        : ASTGEN_SUPER(fl) {
+        setOp1p(new AstSFormatF(fl, AstSFormatF::NoFormat(), exprsp));
         setNOp3p(filep);
         m_displayType = dispType;
     }
@@ -3033,9 +3036,9 @@ class AstElabDisplay : public AstNode {
 private:
     AstDisplayType m_displayType;
 public:
-    AstElabDisplay(FileLine* fileline, AstDisplayType dispType, AstNode* exprsp)
-        : ASTGEN_SUPER(fileline) {
-        setOp1p(new AstSFormatF(fileline, AstSFormatF::NoFormat(), exprsp));
+    AstElabDisplay(FileLine* fl, AstDisplayType dispType, AstNode* exprsp)
+        : ASTGEN_SUPER(fl) {
+        setOp1p(new AstSFormatF(fl, AstSFormatF::NoFormat(), exprsp));
         m_displayType = dispType;
     }
     ASTNODE_NODE_FUNCS(ElabDisplay)
@@ -3061,9 +3064,9 @@ class AstSFormat : public AstNodeStmt {
     // Children: string to load
     // Children: SFORMATF to generate print string
 public:
-    AstSFormat(FileLine* fileline, AstNode* lhsp, const string& text, AstNode* exprsp)
-        : ASTGEN_SUPER(fileline) {
-        setOp1p(new AstSFormatF(fileline, text, true, exprsp));
+    AstSFormat(FileLine* fl, AstNode* lhsp, const string& text, AstNode* exprsp)
+        : ASTGEN_SUPER(fl) {
+        setOp1p(new AstSFormatF(fl, text, true, exprsp));
         setOp3p(lhsp);
     }
     ASTNODE_NODE_FUNCS(SFormat)
@@ -3090,8 +3093,8 @@ class AstSysFuncAsTask : public AstNodeStmt {
     // Parents: stmtlist
     // Children: a system function
 public:
-    AstSysFuncAsTask(FileLine* fileline, AstNode* exprsp)
-        : ASTGEN_SUPER(fileline) { addNOp1p(exprsp); }
+    AstSysFuncAsTask(FileLine* fl, AstNode* exprsp)
+        : ASTGEN_SUPER(fl) { addNOp1p(exprsp); }
     ASTNODE_NODE_FUNCS(SysFuncAsTask)
     virtual string verilogKwd() const { return ""; }
     virtual bool isGateOptimizable() const { return true; }
@@ -3109,8 +3112,8 @@ class AstSysIgnore : public AstNodeStmt {
     // Parents: stmtlist
     // Children: varrefs or exprs
 public:
-    AstSysIgnore(FileLine* fileline, AstNode* exprsp)
-        : ASTGEN_SUPER(fileline) { addNOp1p(exprsp); }
+    AstSysIgnore(FileLine* fl, AstNode* exprsp)
+        : ASTGEN_SUPER(fl) { addNOp1p(exprsp); }
     ASTNODE_NODE_FUNCS(SysIgnore)
     virtual string verilogKwd() const { return "$ignored"; }
     virtual bool isGateOptimizable() const { return false; }  // Though deleted before opt
@@ -3126,8 +3129,8 @@ class AstFClose : public AstNodeStmt {
     // Parents: stmtlist
     // Children: file which must be a varref
 public:
-    AstFClose(FileLine* fileline, AstNode* filep)
-        : ASTGEN_SUPER(fileline) {
+    AstFClose(FileLine* fl, AstNode* filep)
+        : ASTGEN_SUPER(fl) {
         setNOp2p(filep);
     }
     ASTNODE_NODE_FUNCS(FClose)
@@ -3146,8 +3149,8 @@ public:
 class AstFOpen : public AstNodeStmt {
     // Although a system function in IEEE, here a statement which sets the file pointer (MCD)
 public:
-    AstFOpen(FileLine* fileline, AstNode* filep, AstNode* filenamep, AstNode* modep)
-        : ASTGEN_SUPER(fileline) {
+    AstFOpen(FileLine* fl, AstNode* filep, AstNode* filenamep, AstNode* modep)
+        : ASTGEN_SUPER(fl) {
         setOp1p(filep);
         setOp2p(filenamep);
         setOp3p(modep);
@@ -3170,8 +3173,8 @@ class AstFFlush : public AstNodeStmt {
     // Parents: stmtlist
     // Children: file which must be a varref
 public:
-    AstFFlush(FileLine* fileline, AstNode* filep)
-        : ASTGEN_SUPER(fileline) {
+    AstFFlush(FileLine* fl, AstNode* filep)
+        : ASTGEN_SUPER(fl) {
         setNOp2p(filep);
     }
     ASTNODE_NODE_FUNCS(FFlush)
@@ -3194,9 +3197,9 @@ class AstFRead : public AstNodeMath {
     // Children: low index
     // Children: count
 public:
-    AstFRead(FileLine* fileline, AstNode* memp, AstNode* filep,
+    AstFRead(FileLine* fl, AstNode* memp, AstNode* filep,
              AstNode* startp, AstNode* countp)
-        : ASTGEN_SUPER(fileline) {
+        : ASTGEN_SUPER(fl) {
         setOp1p(memp);
         setOp2p(filep);
         setNOp3p(startp);
@@ -3227,8 +3230,8 @@ class AstFRewind : public AstNodeMath {
     // Parents: stmtlist
     // Children: file which must be a varref
 public:
-    AstFRewind(FileLine* fileline, AstNode* filep)
-        : ASTGEN_SUPER(fileline) {
+    AstFRewind(FileLine* fl, AstNode* filep)
+        : ASTGEN_SUPER(fl) {
         setNOp2p(filep);
     }
     ASTNODE_NODE_FUNCS(FRewind)
@@ -3251,8 +3254,8 @@ class AstFTell : public AstNodeMath {
     // Parents: stmtlist
     // Children: file which must be a varref
 public:
-    AstFTell(FileLine* fileline, AstNode* filep)
-        : ASTGEN_SUPER(fileline) {
+    AstFTell(FileLine* fl, AstNode* filep)
+        : ASTGEN_SUPER(fl) {
         setNOp2p(filep);
     }
     ASTNODE_NODE_FUNCS(FTell)
@@ -3277,9 +3280,9 @@ class AstFSeek : public AstNodeMath {
     // Children: offset
     // Children: operation
 public:
-    AstFSeek(FileLine* fileline, AstNode* filep,
+    AstFSeek(FileLine* fl, AstNode* filep,
              AstNode* offset, AstNode* operation)
-        : ASTGEN_SUPER(fileline) {
+        : ASTGEN_SUPER(fl) {
         setOp2p(filep);
         setNOp3p(offset);
         setNOp4p(operation);
@@ -3310,8 +3313,8 @@ class AstFScanF : public AstNodeMath {
 private:
     string      m_text;
 public:
-    AstFScanF(FileLine* fileline, const string& text, AstNode* filep, AstNode* exprsp)
-        : ASTGEN_SUPER(fileline), m_text(text) {
+    AstFScanF(FileLine* fl, const string& text, AstNode* filep, AstNode* exprsp)
+        : ASTGEN_SUPER(fl), m_text(text) {
         addNOp1p(exprsp);
         setNOp2p(filep);
     }
@@ -3343,8 +3346,8 @@ class AstSScanF : public AstNodeMath {
 private:
     string      m_text;
 public:
-    AstSScanF(FileLine* fileline, const string& text, AstNode* fromp, AstNode* exprsp)
-        : ASTGEN_SUPER(fileline), m_text(text) {
+    AstSScanF(FileLine* fl, const string& text, AstNode* fromp, AstNode* exprsp)
+        : ASTGEN_SUPER(fl), m_text(text) {
         addNOp1p(exprsp);
         setOp2p(fromp);
     }
@@ -3373,10 +3376,10 @@ class AstNodeReadWriteMem : public AstNodeStmt {
 private:
     bool m_isHex;  // readmemh, not readmemb
 public:
-    AstNodeReadWriteMem(AstType t, FileLine* fileline, bool hex,
+    AstNodeReadWriteMem(AstType t, FileLine* fl, bool hex,
                         AstNode* filenamep, AstNode* memp,
                         AstNode* lsbp, AstNode* msbp)
-        : AstNodeStmt(t, fileline), m_isHex(hex) {
+        : AstNodeStmt(t, fl), m_isHex(hex) {
         setOp1p(filenamep); setOp2p(memp); setNOp3p(lsbp); setNOp4p(msbp);
     }
     virtual bool isGateOptimizable() const { return false; }
@@ -3398,9 +3401,9 @@ public:
 
 class AstReadMem : public AstNodeReadWriteMem {
 public:
-    AstReadMem(FileLine* fileline, bool hex,
+    AstReadMem(FileLine* fl, bool hex,
                AstNode* filenamep, AstNode* memp, AstNode* lsbp, AstNode* msbp)
-        : ASTGEN_SUPER(fileline, hex, filenamep, memp, lsbp, msbp)
+        : ASTGEN_SUPER(fl, hex, filenamep, memp, lsbp, msbp)
         { }
     ASTNODE_NODE_FUNCS(ReadMem);
     virtual string verilogKwd() const { return (isHex()?"$readmemh":"$readmemb"); }
@@ -3409,9 +3412,9 @@ public:
 
 class AstWriteMem : public AstNodeReadWriteMem {
 public:
-    AstWriteMem(FileLine* fileline,
+    AstWriteMem(FileLine* fl,
                 AstNode* filenamep, AstNode* memp, AstNode* lsbp, AstNode* msbp)
-        : ASTGEN_SUPER(fileline, true, filenamep, memp, lsbp, msbp) { }
+        : ASTGEN_SUPER(fl, true, filenamep, memp, lsbp, msbp) { }
     ASTNODE_NODE_FUNCS(WriteMem)
     virtual string verilogKwd() const { return (isHex()?"$writememh":"$writememb"); }
     virtual const char* cFuncPrefixp() const { return "VL_WRITEMEM_"; }
@@ -3420,8 +3423,8 @@ public:
 class AstSystemT : public AstNodeStmt {
     // $system used as task
 public:
-    AstSystemT(FileLine* fileline, AstNode* lhsp)
-        : ASTGEN_SUPER(fileline) {
+    AstSystemT(FileLine* fl, AstNode* lhsp)
+        : ASTGEN_SUPER(fl) {
         setOp1p(lhsp);
     }
     ASTNODE_NODE_FUNCS(SystemT)
@@ -3439,8 +3442,8 @@ public:
 class AstSystemF : public AstNodeMath {
     // $system used as function
 public:
-    AstSystemF(FileLine* fileline, AstNode* lhsp)
-        : ASTGEN_SUPER(fileline) {
+    AstSystemF(FileLine* fl, AstNode* lhsp)
+        : ASTGEN_SUPER(fl) {
         setOp1p(lhsp);
     }
     ASTNODE_NODE_FUNCS(SystemF)
@@ -3462,8 +3465,8 @@ class AstValuePlusArgs : public AstNodeMath {
     // Parents: expr
     // Child: variable to set.  If NULL then this is a $test$plusargs instead of $value$plusargs
 public:
-    AstValuePlusArgs(FileLine* fileline, AstNode* searchp, AstNode* outp)
-        : ASTGEN_SUPER(fileline) {
+    AstValuePlusArgs(FileLine* fl, AstNode* searchp, AstNode* outp)
+        : ASTGEN_SUPER(fl) {
         setOp1p(searchp); setOp2p(outp);
     }
     ASTNODE_NODE_FUNCS(ValuePlusArgs)
@@ -3487,8 +3490,8 @@ class AstTestPlusArgs : public AstNodeMath {
 private:
     string      m_text;
 public:
-    AstTestPlusArgs(FileLine* fileline, const string& text)
-        : ASTGEN_SUPER(fileline), m_text(text) { }
+    AstTestPlusArgs(FileLine* fl, const string& text)
+        : ASTGEN_SUPER(fl), m_text(text) { }
     ASTNODE_NODE_FUNCS(TestPlusArgs)
     virtual string name() const { return m_text; }
     virtual string verilogKwd() const { return "$test$plusargs"; }
@@ -3506,18 +3509,18 @@ public:
 
 class AstGenFor : public AstNodeFor {
 public:
-    AstGenFor(FileLine* fileline, AstNode* initsp, AstNode* condp,
+    AstGenFor(FileLine* fl, AstNode* initsp, AstNode* condp,
            AstNode* incsp, AstNode* bodysp)
-        : ASTGEN_SUPER(fileline, initsp, condp, incsp, bodysp) {
+        : ASTGEN_SUPER(fl, initsp, condp, incsp, bodysp) {
     }
     ASTNODE_NODE_FUNCS(GenFor)
 };
 
 class AstForeach : public AstNodeStmt {
 public:
-    AstForeach(FileLine* fileline, AstNode* arrayp, AstNode* varsp,
+    AstForeach(FileLine* fl, AstNode* arrayp, AstNode* varsp,
                AstNode* bodysp)
-        : ASTGEN_SUPER(fileline) {
+        : ASTGEN_SUPER(fl) {
         setOp1p(arrayp); addNOp2p(varsp); addNOp4p(bodysp);
     }
     ASTNODE_NODE_FUNCS(Foreach)
@@ -3532,8 +3535,8 @@ public:
 
 class AstRepeat : public AstNodeStmt {
 public:
-    AstRepeat(FileLine* fileline, AstNode* countp, AstNode* bodysp)
-        : ASTGEN_SUPER(fileline) {
+    AstRepeat(FileLine* fl, AstNode* countp, AstNode* bodysp)
+        : ASTGEN_SUPER(fl) {
         setOp2p(countp); addNOp3p(bodysp);
     }
     ASTNODE_NODE_FUNCS(Repeat)
@@ -3547,8 +3550,8 @@ public:
 
 class AstWhile : public AstNodeStmt {
 public:
-    AstWhile(FileLine* fileline, AstNode* condp, AstNode* bodysp, AstNode* incsp=NULL)
-        : ASTGEN_SUPER(fileline) {
+    AstWhile(FileLine* fl, AstNode* condp, AstNode* bodysp, AstNode* incsp=NULL)
+        : ASTGEN_SUPER(fl) {
         setOp2p(condp); addNOp3p(bodysp); addNOp4p(incsp);
     }
     ASTNODE_NODE_FUNCS(While)
@@ -3569,8 +3572,8 @@ public:
 
 class AstBreak : public AstNodeStmt {
 public:
-    explicit AstBreak(FileLine* fileline)
-        : ASTGEN_SUPER(fileline) {}
+    explicit AstBreak(FileLine* fl)
+        : ASTGEN_SUPER(fl) {}
     ASTNODE_NODE_FUNCS(Break)
     virtual string verilogKwd() const { return "break"; }
     virtual V3Hash sameHash() const { return V3Hash(); }
@@ -3579,8 +3582,8 @@ public:
 
 class AstContinue : public AstNodeStmt {
 public:
-    explicit AstContinue(FileLine* fileline)
-        : ASTGEN_SUPER(fileline) {}
+    explicit AstContinue(FileLine* fl)
+        : ASTGEN_SUPER(fl) {}
     ASTNODE_NODE_FUNCS(Continue)
     virtual string verilogKwd() const { return "continue"; }
     virtual V3Hash sameHash() const { return V3Hash(); }
@@ -3591,8 +3594,8 @@ class AstDisable : public AstNodeStmt {
 private:
     string m_name;  // Name of block
 public:
-    AstDisable(FileLine* fileline, const string& name)
-        : ASTGEN_SUPER(fileline), m_name(name) {}
+    AstDisable(FileLine* fl, const string& name)
+        : ASTGEN_SUPER(fl), m_name(name) {}
     ASTNODE_NODE_FUNCS(Disable)
     virtual string name() const { return m_name; }  // * = Block name
     void name(const string& flag) { m_name = flag; }
@@ -3601,8 +3604,8 @@ public:
 
 class AstReturn : public AstNodeStmt {
 public:
-    AstReturn(FileLine* fileline, AstNode* lhsp=NULL)
-        : ASTGEN_SUPER(fileline) {
+    AstReturn(FileLine* fl, AstNode* lhsp=NULL)
+        : ASTGEN_SUPER(fl) {
         setNOp1p(lhsp);
     }
     ASTNODE_NODE_FUNCS(Return)
@@ -3614,8 +3617,8 @@ public:
 
 class AstGenIf : public AstNodeIf {
 public:
-    AstGenIf(FileLine* fileline, AstNode* condp, AstNode* ifsp, AstNode* elsesp)
-        : ASTGEN_SUPER(fileline, condp, ifsp, elsesp) {
+    AstGenIf(FileLine* fl, AstNode* condp, AstNode* ifsp, AstNode* elsesp)
+        : ASTGEN_SUPER(fl, condp, ifsp, elsesp) {
     }
     ASTNODE_NODE_FUNCS(GenIf)
 };
@@ -3626,8 +3629,8 @@ private:
     bool        m_unique0Pragma;        // unique0 case
     bool        m_priorityPragma;       // priority case
 public:
-    AstIf(FileLine* fileline, AstNode* condp, AstNode* ifsp, AstNode* elsesp=NULL)
-        : ASTGEN_SUPER(fileline, condp, ifsp, elsesp) {
+    AstIf(FileLine* fl, AstNode* condp, AstNode* ifsp, AstNode* elsesp=NULL)
+        : ASTGEN_SUPER(fl, condp, ifsp, elsesp) {
         m_uniquePragma = false; m_unique0Pragma = false; m_priorityPragma = false;
     }
     ASTNODE_NODE_FUNCS(If)
@@ -3741,8 +3744,8 @@ private:
     bool        m_generate;     // Underneath a generate
 public:
     // Node that simply puts name into the output stream
-    AstBegin(FileLine* fileline, const string& name, AstNode* stmtsp, bool generate=false)
-        : ASTGEN_SUPER(fileline)
+    AstBegin(FileLine* fl, const string& name, AstNode* stmtsp, bool generate=false)
+        : ASTGEN_SUPER(fl)
         , m_name(name) {
         addNOp1p(stmtsp);
         m_unnamed = (name=="");
@@ -3938,7 +3941,7 @@ public:
 
 class AstStop : public AstNodeStmt {
 public:
-    explicit AstStop(FileLine* fl, bool maybe)
+    AstStop(FileLine* fl, bool maybe)
         : ASTGEN_SUPER(fl) {}
     ASTNODE_NODE_FUNCS(Stop)
     virtual bool isGateOptimizable() const { return false; }
@@ -4062,8 +4065,8 @@ private:
     string      m_name;
     AstSenTree* m_sensesp;
 public:
-    AstActive(FileLine* fileline, const string& name, AstSenTree* sensesp)
-        : ASTGEN_SUPER(fileline) {
+    AstActive(FileLine* fl, const string& name, AstSenTree* sensesp)
+        : ASTGEN_SUPER(fl) {
         m_name = name;  // Copy it
         UASSERT(sensesp, "Sensesp required arg");
         m_sensesp = sensesp;
@@ -4120,8 +4123,8 @@ private:
     string scopeNameFormatter(AstText* scopeTextp) const;
     string scopePrettyNameFormatter(AstText* scopeTextp) const;
 public:
-    explicit AstScopeName(FileLine* fl) : ASTGEN_SUPER(fl), m_dpiExport(false) {
-        dtypeSetUInt64(); }
+    explicit AstScopeName(FileLine* fl)
+        : ASTGEN_SUPER(fl), m_dpiExport(false) { dtypeSetUInt64(); }
     ASTNODE_NODE_FUNCS(ScopeName)
     virtual V3Hash sameHash() const { return V3Hash(); }
     virtual bool same(const AstNode* samep) const {
@@ -4173,9 +4176,10 @@ class AstRand : public AstNodeTermop {
 private:
     bool m_reset;  // Random reset, versus always random
 public:
-    AstRand(FileLine* fl, AstNodeDType* dtp, bool reset) : ASTGEN_SUPER(fl) {
-        dtypep(dtp); m_reset = reset; }
-    explicit AstRand(FileLine* fl) : ASTGEN_SUPER(fl), m_reset(false) { }
+    AstRand(FileLine* fl, AstNodeDType* dtp, bool reset)
+        : ASTGEN_SUPER(fl) { dtypep(dtp); m_reset = reset; }
+    explicit AstRand(FileLine* fl)
+        : ASTGEN_SUPER(fl), m_reset(false) {}
     ASTNODE_NODE_FUNCS(Rand)
     virtual string emitVerilog() { return "%f$random"; }
     virtual string emitC() {
@@ -4192,8 +4196,8 @@ public:
 
 class AstTime : public AstNodeTermop {
 public:
-    explicit AstTime(FileLine* fl) : ASTGEN_SUPER(fl) {
-        dtypeSetUInt64(); }
+    explicit AstTime(FileLine* fl)
+        : ASTGEN_SUPER(fl) { dtypeSetUInt64(); }
     ASTNODE_NODE_FUNCS(Time)
     virtual string emitVerilog() { return "%f$time"; }
     virtual string emitC() { return "VL_TIME_%nq()"; }
@@ -4207,8 +4211,8 @@ public:
 
 class AstTimeD : public AstNodeTermop {
 public:
-    explicit AstTimeD(FileLine* fl) : ASTGEN_SUPER(fl) {
-        dtypeSetDouble(); }
+    explicit AstTimeD(FileLine* fl)
+        : ASTGEN_SUPER(fl) { dtypeSetDouble(); }
     ASTNODE_NODE_FUNCS(TimeD)
     virtual string emitVerilog() { return "%f$realtime"; }
     virtual string emitC() { return "VL_TIME_D()"; }
@@ -4248,8 +4252,8 @@ public:
 
 class AstNegate : public AstNodeUniop {
 public:
-    AstNegate(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {
-        dtypeFrom(lhsp); }
+    AstNegate(FileLine* fl, AstNode* lhsp)
+        : ASTGEN_SUPER(fl, lhsp) { dtypeFrom(lhsp); }
     ASTNODE_NODE_FUNCS(Negate)
     virtual void numberOperate(V3Number& out, const V3Number& lhs) { out.opNegate(lhs); }
     virtual string emitVerilog() { return "%f(- %l)"; }
@@ -4260,8 +4264,8 @@ public:
 };
 class AstNegateD : public AstNodeUniop {
 public:
-    AstNegateD(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {
-        dtypeSetDouble(); }
+    AstNegateD(FileLine* fl, AstNode* lhsp)
+        : ASTGEN_SUPER(fl, lhsp) { dtypeSetDouble(); }
     ASTNODE_NODE_FUNCS(NegateD)
     virtual void numberOperate(V3Number& out, const V3Number& lhs) { out.opNegateD(lhs); }
     virtual string emitVerilog() { return "%f(- %l)"; }
@@ -4275,8 +4279,8 @@ public:
 };
 class AstRedAnd : public AstNodeUniop {
 public:
-    AstRedAnd(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {
-        dtypeSetLogicBool(); }
+    AstRedAnd(FileLine* fl, AstNode* lhsp)
+        : ASTGEN_SUPER(fl, lhsp) { dtypeSetLogicBool(); }
     ASTNODE_NODE_FUNCS(RedAnd)
     virtual void numberOperate(V3Number& out, const V3Number& lhs) { out.opRedAnd(lhs); }
     virtual string emitVerilog() { return "%f(& %l)"; }
@@ -4287,8 +4291,8 @@ public:
 };
 class AstRedOr : public AstNodeUniop {
 public:
-    AstRedOr(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {
-        dtypeSetLogicBool(); }
+    AstRedOr(FileLine* fl, AstNode* lhsp)
+        : ASTGEN_SUPER(fl, lhsp) { dtypeSetLogicBool(); }
     ASTNODE_NODE_FUNCS(RedOr)
     virtual void numberOperate(V3Number& out, const V3Number& lhs) { out.opRedOr(lhs); }
     virtual string emitVerilog() { return "%f(| %l)"; }
@@ -4299,8 +4303,8 @@ public:
 };
 class AstRedXor : public AstNodeUniop {
 public:
-    AstRedXor(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {
-        dtypeSetLogicBool(); }
+    AstRedXor(FileLine* fl, AstNode* lhsp)
+        : ASTGEN_SUPER(fl, lhsp) { dtypeSetLogicBool(); }
     ASTNODE_NODE_FUNCS(RedXor)
     virtual void numberOperate(V3Number& out, const V3Number& lhs) { out.opRedXor(lhs); }
     virtual string emitVerilog() { return "%f(^ %l)"; }
@@ -4314,8 +4318,8 @@ public:
 class AstRedXnor : public AstNodeUniop {
     // AstRedXnors are replaced with AstRedXors in V3Const.
 public:
-    AstRedXnor(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {
-        dtypeSetLogicBool(); }
+    AstRedXnor(FileLine* fl, AstNode* lhsp)
+        : ASTGEN_SUPER(fl, lhsp) { dtypeSetLogicBool(); }
     ASTNODE_NODE_FUNCS(RedXnor)
     virtual void numberOperate(V3Number& out, const V3Number& lhs) { out.opRedXnor(lhs); }
     virtual string emitVerilog() { return "%f(~^ %l)"; }
@@ -4329,8 +4333,8 @@ public:
 class AstLenN : public AstNodeUniop {
     // Length of a string
 public:
-    AstLenN(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {
-        dtypeSetSigned32(); }
+    AstLenN(FileLine* fl, AstNode* lhsp)
+        : ASTGEN_SUPER(fl, lhsp) { dtypeSetSigned32(); }
     ASTNODE_NODE_FUNCS(LenN)
     virtual void numberOperate(V3Number& out, const V3Number& lhs) { out.opLenN(lhs); }
     virtual string emitVerilog() { return "%f(%l)"; }
@@ -4341,8 +4345,8 @@ public:
 };
 class AstLogNot : public AstNodeUniop {
 public:
-    AstLogNot(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {
-        dtypeSetLogicBool(); }
+    AstLogNot(FileLine* fl, AstNode* lhsp)
+        : ASTGEN_SUPER(fl, lhsp) { dtypeSetLogicBool(); }
     ASTNODE_NODE_FUNCS(LogNot)
     virtual void numberOperate(V3Number& out, const V3Number& lhs) { out.opLogNot(lhs); }
     virtual string emitVerilog() { return "%f(! %l)"; }
@@ -4354,8 +4358,8 @@ public:
 };
 class AstNot : public AstNodeUniop {
 public:
-    AstNot(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {
-        dtypeFrom(lhsp); }
+    AstNot(FileLine* fl, AstNode* lhsp)
+        : ASTGEN_SUPER(fl, lhsp) { dtypeFrom(lhsp); }
     ASTNODE_NODE_FUNCS(Not)
     virtual void numberOperate(V3Number& out, const V3Number& lhs) { out.opNot(lhs); }
     virtual string emitVerilog() { return "%f(~ %l)"; }
@@ -4368,9 +4372,10 @@ public:
 class AstExtend : public AstNodeUniop {
     // Expand a value into a wider entity by 0 extension.  Width is implied from nodep->width()
 public:
-    AstExtend(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {}
-    AstExtend(FileLine* fl, AstNode* lhsp, int width) : ASTGEN_SUPER(fl, lhsp) {
-        dtypeSetLogicSized(width, AstNumeric::UNSIGNED); }
+    AstExtend(FileLine* fl, AstNode* lhsp)
+        : ASTGEN_SUPER(fl, lhsp) {}
+    AstExtend(FileLine* fl, AstNode* lhsp, int width)
+        : ASTGEN_SUPER(fl, lhsp) { dtypeSetLogicSized(width, AstNumeric::UNSIGNED); }
     ASTNODE_NODE_FUNCS(Extend)
     virtual void numberOperate(V3Number& out, const V3Number& lhs) { out.opAssign(lhs); }
     virtual string emitVerilog() { return "%l"; }
@@ -4383,10 +4388,11 @@ public:
 class AstExtendS : public AstNodeUniop {
     // Expand a value into a wider entity by sign extension.  Width is implied from nodep->width()
 public:
-    AstExtendS(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {}
-    AstExtendS(FileLine* fl, AstNode* lhsp, int width) : ASTGEN_SUPER(fl, lhsp) {
+    AstExtendS(FileLine* fl, AstNode* lhsp)
+        : ASTGEN_SUPER(fl, lhsp) {}
+    AstExtendS(FileLine* fl, AstNode* lhsp, int width)
         // Important that widthMin be correct, as opExtend requires it after V3Expand
-        dtypeSetLogicSized(width, AstNumeric::UNSIGNED); }
+        : ASTGEN_SUPER(fl, lhsp) { dtypeSetLogicSized(width, AstNumeric::UNSIGNED); }
     ASTNODE_NODE_FUNCS(ExtendS)
     virtual void numberOperate(V3Number& out, const V3Number& lhs) {
         out.opExtendS(lhs, lhsp()->widthMinV());
@@ -4402,7 +4408,8 @@ public:
 class AstSigned : public AstNodeUniop {
     // $signed(lhs)
 public:
-    AstSigned(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {
+    AstSigned(FileLine* fl, AstNode* lhsp)
+        : ASTGEN_SUPER(fl, lhsp) {
         UASSERT_OBJ(!v3Global.assertDTypesResolved(), this,
                     "not coded to create after dtypes resolved"); }
     ASTNODE_NODE_FUNCS(Signed)
@@ -4417,7 +4424,8 @@ public:
 class AstUnsigned : public AstNodeUniop {
     // $unsigned(lhs)
 public:
-    AstUnsigned(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {
+    AstUnsigned(FileLine* fl, AstNode* lhsp)
+        : ASTGEN_SUPER(fl, lhsp) {
         UASSERT_OBJ(!v3Global.assertDTypesResolved(), this,
                     "not coded to create after dtypes resolved"); }
     ASTNODE_NODE_FUNCS(Unsigned)
@@ -4432,8 +4440,8 @@ public:
 class AstRToIS : public AstNodeUniop {
     // $rtoi(lhs)
 public:
-    AstRToIS(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {
-        dtypeSetSigned32(); }
+    AstRToIS(FileLine* fl, AstNode* lhsp)
+        : ASTGEN_SUPER(fl, lhsp) { dtypeSetSigned32(); }
     ASTNODE_NODE_FUNCS(RToIS)
     virtual void numberOperate(V3Number& out, const V3Number& lhs) { out.opRToIS(lhs); }
     virtual string emitVerilog() { return "%f$rtoi(%l)"; }
@@ -4445,8 +4453,8 @@ public:
 };
 class AstRToIRoundS : public AstNodeUniop {
 public:
-    AstRToIRoundS(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {
-        dtypeSetSigned32(); }
+    AstRToIRoundS(FileLine* fl, AstNode* lhsp)
+        : ASTGEN_SUPER(fl, lhsp) { dtypeSetSigned32(); }
     ASTNODE_NODE_FUNCS(RToIRoundS)
     virtual void numberOperate(V3Number& out, const V3Number& lhs) { out.opRToIRoundS(lhs); }
     virtual string emitVerilog() { return "%f$rtoi_rounded(%l)"; }
@@ -4458,8 +4466,8 @@ public:
 };
 class AstIToRD : public AstNodeUniop {
 public:
-    AstIToRD(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {
-        dtypeSetDouble(); }
+    AstIToRD(FileLine* fl, AstNode* lhsp)
+        : ASTGEN_SUPER(fl, lhsp) { dtypeSetDouble(); }
     ASTNODE_NODE_FUNCS(IToRD)
     virtual void numberOperate(V3Number& out, const V3Number& lhs) { out.opIToRD(lhs); }
     virtual string emitVerilog() { return "%f$itor(%l)"; }
@@ -4471,8 +4479,8 @@ public:
 };
 class AstRealToBits : public AstNodeUniop {
 public:
-    AstRealToBits(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {
-        dtypeSetUInt64(); }
+    AstRealToBits(FileLine* fl, AstNode* lhsp)
+        : ASTGEN_SUPER(fl, lhsp) { dtypeSetUInt64(); }
     ASTNODE_NODE_FUNCS(RealToBits)
     virtual void numberOperate(V3Number& out, const V3Number& lhs) { out.opRealToBits(lhs); }
     virtual string emitVerilog() { return "%f$realtobits(%l)"; }
@@ -4484,8 +4492,8 @@ public:
 };
 class AstBitsToRealD : public AstNodeUniop {
 public:
-    AstBitsToRealD(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {
-        dtypeSetDouble(); }
+    AstBitsToRealD(FileLine* fl, AstNode* lhsp)
+        : ASTGEN_SUPER(fl, lhsp) { dtypeSetDouble(); }
     ASTNODE_NODE_FUNCS(BitsToRealD)
     virtual void numberOperate(V3Number& out, const V3Number& lhs) { out.opBitsToRealD(lhs); }
     virtual string emitVerilog() { return "%f$bitstoreal(%l)"; }
@@ -4498,7 +4506,8 @@ public:
 
 class AstCLog2 : public AstNodeUniop {
 public:
-    AstCLog2(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {}
+    AstCLog2(FileLine* fl, AstNode* lhsp)
+        : ASTGEN_SUPER(fl, lhsp) {}
     ASTNODE_NODE_FUNCS(CLog2)
     virtual void numberOperate(V3Number& out, const V3Number& lhs) { out.opCLog2(lhs); }
     virtual string emitVerilog() { return "%f$clog2(%l)"; }
@@ -4511,7 +4520,8 @@ public:
 class AstCountOnes : public AstNodeUniop {
     // Number of bits set in vector
 public:
-    AstCountOnes(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {}
+    AstCountOnes(FileLine* fl, AstNode* lhsp)
+        : ASTGEN_SUPER(fl, lhsp) {}
     ASTNODE_NODE_FUNCS(CountOnes)
     virtual void numberOperate(V3Number& out, const V3Number& lhs) { out.opCountOnes(lhs); }
     virtual string emitVerilog() { return "%f$countones(%l)"; }
@@ -4524,8 +4534,8 @@ public:
 class AstIsUnknown : public AstNodeUniop {
     // True if any unknown bits
 public:
-    AstIsUnknown(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {
-        dtypeSetLogicBool(); }
+    AstIsUnknown(FileLine* fl, AstNode* lhsp)
+        : ASTGEN_SUPER(fl, lhsp) { dtypeSetLogicBool(); }
     ASTNODE_NODE_FUNCS(IsUnknown)
     virtual void numberOperate(V3Number& out, const V3Number& lhs) { out.opIsUnknown(lhs); }
     virtual string emitVerilog() { return "%f$isunknown(%l)"; }
@@ -4537,8 +4547,8 @@ public:
 class AstOneHot : public AstNodeUniop {
     // True if only single bit set in vector
 public:
-    AstOneHot(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {
-        dtypeSetLogicBool(); }
+    AstOneHot(FileLine* fl, AstNode* lhsp)
+        : ASTGEN_SUPER(fl, lhsp) { dtypeSetLogicBool(); }
     ASTNODE_NODE_FUNCS(OneHot)
     virtual void numberOperate(V3Number& out, const V3Number& lhs) { out.opOneHot(lhs); }
     virtual string emitVerilog() { return "%f$onehot(%l)"; }
@@ -4551,8 +4561,8 @@ public:
 class AstOneHot0 : public AstNodeUniop {
     // True if only single bit, or no bits set in vector
 public:
-    AstOneHot0(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {
-        dtypeSetLogicBool(); }
+    AstOneHot0(FileLine* fl, AstNode* lhsp)
+        : ASTGEN_SUPER(fl, lhsp) { dtypeSetLogicBool(); }
     ASTNODE_NODE_FUNCS(OneHot0)
     virtual void numberOperate(V3Number& out, const V3Number& lhs) { out.opOneHot0(lhs); }
     virtual string emitVerilog() { return "%f$onehot0(%l)"; }
@@ -4566,7 +4576,8 @@ public:
 class AstCast : public AstNode {
     // Cast to appropriate data type - note lhsp is value, to match AstTypedef, AstCCast, etc
 public:
-    AstCast(FileLine* fl, AstNode* lhsp, AstNodeDType* dtp) : ASTGEN_SUPER(fl) {
+    AstCast(FileLine* fl, AstNode* lhsp, AstNodeDType* dtp)
+        : ASTGEN_SUPER(fl) {
         setOp1p(lhsp); setOp2p(dtp);
         dtypeFrom(dtp);
     }
@@ -4585,7 +4596,8 @@ public:
 class AstCastParse : public AstNode {
     // Cast to appropriate type, where we haven't determined yet what the data type is
 public:
-    AstCastParse(FileLine* fl, AstNode* lhsp, AstNode* dtp) : ASTGEN_SUPER(fl) {
+    AstCastParse(FileLine* fl, AstNode* lhsp, AstNode* dtp)
+        : ASTGEN_SUPER(fl) {
         setOp1p(lhsp); setOp2p(dtp);
     }
     ASTNODE_NODE_FUNCS(CastParse)
@@ -4601,7 +4613,8 @@ public:
 class AstCastSize : public AstNode {
     // Cast to specific size; signed/twostate inherited from lower element per IEEE
 public:
-    AstCastSize(FileLine* fl, AstNode* lhsp, AstConst* rhsp) : ASTGEN_SUPER(fl) {
+    AstCastSize(FileLine* fl, AstNode* lhsp, AstConst* rhsp)
+        : ASTGEN_SUPER(fl) {
         setOp1p(lhsp); setOp2p(rhsp);
     }
     ASTNODE_NODE_FUNCS(CastSize)
@@ -4620,14 +4633,16 @@ class AstCCast : public AstNodeUniop {
 private:
     int         m_size;
 public:
-    AstCCast(FileLine* fl, AstNode* lhsp, int setwidth, int minwidth=-1) : ASTGEN_SUPER(fl, lhsp) {
+    AstCCast(FileLine* fl, AstNode* lhsp, int setwidth, int minwidth=-1)
+        : ASTGEN_SUPER(fl, lhsp) {
         m_size = setwidth;
         if (setwidth) {
             if (minwidth==-1) minwidth = setwidth;
             dtypeSetLogicUnsized(setwidth, minwidth, AstNumeric::UNSIGNED);
         }
     }
-    AstCCast(FileLine* fl, AstNode* lhsp, AstNode* typeFromp) : ASTGEN_SUPER(fl, lhsp) {
+    AstCCast(FileLine* fl, AstNode* lhsp, AstNode* typeFromp)
+        : ASTGEN_SUPER(fl, lhsp) {
         dtypeFrom(typeFromp);
         m_size = width();
     }
@@ -4649,8 +4664,8 @@ public:
 class AstCvtPackString : public AstNodeUniop {
     // Convert to Verilator Packed String (aka verilog "string")
 public:
-    AstCvtPackString(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {
-        dtypeSetString(); }  // Really, width should be dtypep -> STRING
+    AstCvtPackString(FileLine* fl, AstNode* lhsp)
+        : ASTGEN_SUPER(fl, lhsp) { dtypeSetString(); }  // Really, width should be dtypep -> STRING
     ASTNODE_NODE_FUNCS(CvtPackString)
     virtual void numberOperate(V3Number& out, const V3Number& lhs) { V3ERROR_NA; }
     virtual string emitVerilog() { return "%f$_CAST(%l)"; }
@@ -4664,7 +4679,8 @@ public:
 
 class AstFEof : public AstNodeUniop {
 public:
-    AstFEof(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {}
+    AstFEof(FileLine* fl, AstNode* lhsp)
+        : ASTGEN_SUPER(fl, lhsp) {}
     ASTNODE_NODE_FUNCS(FEof)
     virtual void numberOperate(V3Number& out, const V3Number& lhs) { V3ERROR_NA; }
     virtual string emitVerilog() { return "%f$feof(%l)"; }
@@ -4679,7 +4695,8 @@ public:
 
 class AstFGetC : public AstNodeUniop {
 public:
-    AstFGetC(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {}
+    AstFGetC(FileLine* fl, AstNode* lhsp)
+        : ASTGEN_SUPER(fl, lhsp) {}
     ASTNODE_NODE_FUNCS(FGetC)
     virtual void numberOperate(V3Number& out, const V3Number& lhs) { V3ERROR_NA; }
     virtual string emitVerilog() { return "%f$fgetc(%l)"; }
@@ -4729,7 +4746,8 @@ public:
 
 class AstLogD : public AstNodeSystemUniop {
 public:
-    AstLogD(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {}
+    AstLogD(FileLine* fl, AstNode* lhsp)
+        : ASTGEN_SUPER(fl, lhsp) {}
     ASTNODE_NODE_FUNCS(LogD)
     virtual void numberOperate(V3Number& out, const V3Number& lhs) { out.setDouble(log(lhs.toDouble())); }
     virtual string emitVerilog() { return "%f$ln(%l)"; }
@@ -4737,7 +4755,8 @@ public:
 };
 class AstLog10D : public AstNodeSystemUniop {
 public:
-    AstLog10D(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {}
+    AstLog10D(FileLine* fl, AstNode* lhsp)
+        : ASTGEN_SUPER(fl, lhsp) {}
     ASTNODE_NODE_FUNCS(Log10D)
     virtual void numberOperate(V3Number& out, const V3Number& lhs) { out.setDouble(log10(lhs.toDouble())); }
     virtual string emitVerilog() { return "%f$log10(%l)"; }
@@ -4746,7 +4765,8 @@ public:
 
 class AstExpD : public AstNodeSystemUniop {
 public:
-    AstExpD(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {}
+    AstExpD(FileLine* fl, AstNode* lhsp)
+        : ASTGEN_SUPER(fl, lhsp) {}
     ASTNODE_NODE_FUNCS(ExpD)
     virtual void numberOperate(V3Number& out, const V3Number& lhs) { out.setDouble(exp(lhs.toDouble())); }
     virtual string emitVerilog() { return "%f$exp(%l)"; }
@@ -4755,7 +4775,8 @@ public:
 
 class AstSqrtD : public AstNodeSystemUniop {
 public:
-    AstSqrtD(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {}
+    AstSqrtD(FileLine* fl, AstNode* lhsp)
+        : ASTGEN_SUPER(fl, lhsp) {}
     ASTNODE_NODE_FUNCS(SqrtD)
     virtual void numberOperate(V3Number& out, const V3Number& lhs) { out.setDouble(sqrt(lhs.toDouble())); }
     virtual string emitVerilog() { return "%f$sqrt(%l)"; }
@@ -4764,7 +4785,8 @@ public:
 
 class AstFloorD : public AstNodeSystemUniop {
 public:
-    AstFloorD(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {}
+    AstFloorD(FileLine* fl, AstNode* lhsp)
+        : ASTGEN_SUPER(fl, lhsp) {}
     ASTNODE_NODE_FUNCS(FloorD)
     virtual void numberOperate(V3Number& out, const V3Number& lhs) { out.setDouble(floor(lhs.toDouble())); }
     virtual string emitVerilog() { return "%f$floor(%l)"; }
@@ -4773,7 +4795,8 @@ public:
 
 class AstCeilD : public AstNodeSystemUniop {
 public:
-    AstCeilD(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {}
+    AstCeilD(FileLine* fl, AstNode* lhsp)
+        : ASTGEN_SUPER(fl, lhsp) {}
     ASTNODE_NODE_FUNCS(CeilD)
     virtual void numberOperate(V3Number& out, const V3Number& lhs) { out.setDouble(ceil(lhs.toDouble())); }
     virtual string emitVerilog() { return "%f$ceil(%l)"; }
@@ -4782,7 +4805,8 @@ public:
 
 class AstSinD : public AstNodeSystemUniop {
 public:
-    AstSinD(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {}
+    AstSinD(FileLine* fl, AstNode* lhsp)
+        : ASTGEN_SUPER(fl, lhsp) {}
     ASTNODE_NODE_FUNCS(SinD)
     virtual void numberOperate(V3Number& out, const V3Number& lhs) { out.setDouble(sin(lhs.toDouble())); }
     virtual string emitVerilog() { return "%f$sin(%l)"; }
@@ -4791,7 +4815,8 @@ public:
 
 class AstCosD : public AstNodeSystemUniop {
 public:
-    AstCosD(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {}
+    AstCosD(FileLine* fl, AstNode* lhsp)
+        : ASTGEN_SUPER(fl, lhsp) {}
     ASTNODE_NODE_FUNCS(CosD)
     virtual void numberOperate(V3Number& out, const V3Number& lhs) { out.setDouble(cos(lhs.toDouble())); }
     virtual string emitVerilog() { return "%f$cos(%l)"; }
@@ -4800,7 +4825,8 @@ public:
 
 class AstTanD : public AstNodeSystemUniop {
 public:
-    AstTanD(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {}
+    AstTanD(FileLine* fl, AstNode* lhsp)
+        : ASTGEN_SUPER(fl, lhsp) {}
     ASTNODE_NODE_FUNCS(TanD)
     virtual void numberOperate(V3Number& out, const V3Number& lhs) { out.setDouble(tan(lhs.toDouble())); }
     virtual string emitVerilog() { return "%f$tan(%l)"; }
@@ -4809,7 +4835,8 @@ public:
 
 class AstAsinD : public AstNodeSystemUniop {
 public:
-    AstAsinD(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {}
+    AstAsinD(FileLine* fl, AstNode* lhsp)
+        : ASTGEN_SUPER(fl, lhsp) {}
     ASTNODE_NODE_FUNCS(AsinD)
     virtual void numberOperate(V3Number& out, const V3Number& lhs) { out.setDouble(asin(lhs.toDouble())); }
     virtual string emitVerilog() { return "%f$asin(%l)"; }
@@ -4818,7 +4845,8 @@ public:
 
 class AstAcosD : public AstNodeSystemUniop {
 public:
-    AstAcosD(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {}
+    AstAcosD(FileLine* fl, AstNode* lhsp)
+        : ASTGEN_SUPER(fl, lhsp) {}
     ASTNODE_NODE_FUNCS(AcosD)
     virtual void numberOperate(V3Number& out, const V3Number& lhs) { out.setDouble(acos(lhs.toDouble())); }
     virtual string emitVerilog() { return "%f$acos(%l)"; }
@@ -4827,7 +4855,8 @@ public:
 
 class AstAtanD : public AstNodeSystemUniop {
 public:
-    AstAtanD(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {}
+    AstAtanD(FileLine* fl, AstNode* lhsp)
+        : ASTGEN_SUPER(fl, lhsp) {}
     ASTNODE_NODE_FUNCS(AtanD)
     virtual void numberOperate(V3Number& out, const V3Number& lhs) { out.setDouble(atan(lhs.toDouble())); }
     virtual string emitVerilog() { return "%f$atan(%l)"; }
@@ -4836,7 +4865,8 @@ public:
 
 class AstSinhD : public AstNodeSystemUniop {
 public:
-    AstSinhD(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {}
+    AstSinhD(FileLine* fl, AstNode* lhsp)
+        : ASTGEN_SUPER(fl, lhsp) {}
     ASTNODE_NODE_FUNCS(SinhD)
     virtual void numberOperate(V3Number& out, const V3Number& lhs) { out.setDouble(sinh(lhs.toDouble())); }
     virtual string emitVerilog() { return "%f$sinh(%l)"; }
@@ -4845,7 +4875,8 @@ public:
 
 class AstCoshD : public AstNodeSystemUniop {
 public:
-    AstCoshD(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {}
+    AstCoshD(FileLine* fl, AstNode* lhsp)
+        : ASTGEN_SUPER(fl, lhsp) {}
     ASTNODE_NODE_FUNCS(CoshD)
     virtual void numberOperate(V3Number& out, const V3Number& lhs) { out.setDouble(cosh(lhs.toDouble())); }
     virtual string emitVerilog() { return "%f$cosh(%l)"; }
@@ -4854,7 +4885,8 @@ public:
 
 class AstTanhD : public AstNodeSystemUniop {
 public:
-    AstTanhD(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {}
+    AstTanhD(FileLine* fl, AstNode* lhsp)
+        : ASTGEN_SUPER(fl, lhsp) {}
     ASTNODE_NODE_FUNCS(TanhD)
     virtual void numberOperate(V3Number& out, const V3Number& lhs) { out.setDouble(tanh(lhs.toDouble())); }
     virtual string emitVerilog() { return "%f$tanh(%l)"; }
@@ -4863,7 +4895,8 @@ public:
 
 class AstAsinhD : public AstNodeSystemUniop {
 public:
-    AstAsinhD(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {}
+    AstAsinhD(FileLine* fl, AstNode* lhsp)
+        : ASTGEN_SUPER(fl, lhsp) {}
     ASTNODE_NODE_FUNCS(AsinhD)
     virtual void numberOperate(V3Number& out, const V3Number& lhs) { out.setDouble(asinh(lhs.toDouble())); }
     virtual string emitVerilog() { return "%f$asinh(%l)"; }
@@ -4872,7 +4905,8 @@ public:
 
 class AstAcoshD : public AstNodeSystemUniop {
 public:
-    AstAcoshD(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {}
+    AstAcoshD(FileLine* fl, AstNode* lhsp)
+        : ASTGEN_SUPER(fl, lhsp) {}
     ASTNODE_NODE_FUNCS(AcoshD)
     virtual void numberOperate(V3Number& out, const V3Number& lhs) { out.setDouble(acosh(lhs.toDouble())); }
     virtual string emitVerilog() { return "%f$acosh(%l)"; }
@@ -4881,7 +4915,8 @@ public:
 
 class AstAtanhD : public AstNodeSystemUniop {
 public:
-    AstAtanhD(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {}
+    AstAtanhD(FileLine* fl, AstNode* lhsp)
+        : ASTGEN_SUPER(fl, lhsp) {}
     ASTNODE_NODE_FUNCS(AtanhD)
     virtual void numberOperate(V3Number& out, const V3Number& lhs) { out.setDouble(atanh(lhs.toDouble())); }
     virtual string emitVerilog() { return "%f$atanh(%l)"; }
@@ -4890,8 +4925,8 @@ public:
 class AstToLowerN : public AstNodeUniop {
     // string.tolower()
 public:
-    AstToLowerN(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {
-        dtypeSetString(); }
+    AstToLowerN(FileLine* fl, AstNode* lhsp)
+        : ASTGEN_SUPER(fl, lhsp) { dtypeSetString(); }
     ASTNODE_NODE_FUNCS(ToLowerN)
     virtual void numberOperate(V3Number& out, const V3Number& lhs) { out.opToLowerN(lhs); }
     virtual string emitVerilog() { return "%l.tolower()"; }
@@ -4903,8 +4938,8 @@ public:
 class AstToUpperN : public AstNodeUniop {
     // string.toupper()
 public:
-    AstToUpperN(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {
-        dtypeSetString(); }
+    AstToUpperN(FileLine* fl, AstNode* lhsp)
+        : ASTGEN_SUPER(fl, lhsp) { dtypeSetString(); }
     ASTNODE_NODE_FUNCS(ToUpperN)
     virtual void numberOperate(V3Number& out, const V3Number& lhs) { out.opToUpperN(lhs); }
     virtual string emitVerilog() { return "%l.toupper()"; }
@@ -4960,8 +4995,8 @@ public:
 
 class AstLogOr : public AstNodeBiop {
 public:
-    AstLogOr(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
-        dtypeSetLogicBool(); }
+    AstLogOr(FileLine* fl, AstNode* lhsp, AstNode* rhsp)
+        : ASTGEN_SUPER(fl, lhsp, rhsp) { dtypeSetLogicBool(); }
     ASTNODE_NODE_FUNCS(LogOr)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstLogOr(this->fileline(), lhsp, rhsp); }
     virtual void numberOperate(V3Number& out, const V3Number& lhs, const V3Number& rhs) { out.opLogOr(lhs, rhs); }
@@ -4977,8 +5012,8 @@ public:
 };
 class AstLogAnd : public AstNodeBiop {
 public:
-    AstLogAnd(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
-        dtypeSetLogicBool(); }
+    AstLogAnd(FileLine* fl, AstNode* lhsp, AstNode* rhsp)
+        : ASTGEN_SUPER(fl, lhsp, rhsp) { dtypeSetLogicBool(); }
     ASTNODE_NODE_FUNCS(LogAnd)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstLogAnd(this->fileline(), lhsp, rhsp); }
     virtual void numberOperate(V3Number& out, const V3Number& lhs, const V3Number& rhs) { out.opLogAnd(lhs, rhs); }
@@ -4994,8 +5029,8 @@ public:
 };
 class AstLogEq : public AstNodeBiCom {
 public:
-    AstLogEq(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
-        dtypeSetLogicBool(); }
+    AstLogEq(FileLine* fl, AstNode* lhsp, AstNode* rhsp)
+        : ASTGEN_SUPER(fl, lhsp, rhsp) { dtypeSetLogicBool(); }
     ASTNODE_NODE_FUNCS(LogEq)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) {
         return new AstLogEq(this->fileline(), lhsp, rhsp); }
@@ -5013,8 +5048,8 @@ public:
 };
 class AstLogIf : public AstNodeBiop {
 public:
-    AstLogIf(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
-        dtypeSetLogicBool(); }
+    AstLogIf(FileLine* fl, AstNode* lhsp, AstNode* rhsp)
+        : ASTGEN_SUPER(fl, lhsp, rhsp) { dtypeSetLogicBool(); }
     ASTNODE_NODE_FUNCS(LogIf)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) {
         return new AstLogIf(this->fileline(), lhsp, rhsp); }
@@ -5032,8 +5067,8 @@ public:
 };
 class AstOr : public AstNodeBiComAsv {
 public:
-    AstOr(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
-        dtypeFrom(lhsp); }
+    AstOr(FileLine* fl, AstNode* lhsp, AstNode* rhsp)
+        : ASTGEN_SUPER(fl, lhsp, rhsp) { dtypeFrom(lhsp); }
     ASTNODE_NODE_FUNCS(Or)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstOr(this->fileline(), lhsp, rhsp); }
     virtual void numberOperate(V3Number& out, const V3Number& lhs, const V3Number& rhs) { out.opOr(lhs, rhs); }
@@ -5048,8 +5083,8 @@ public:
 };
 class AstAnd : public AstNodeBiComAsv {
 public:
-    AstAnd(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
-        dtypeFrom(lhsp); }
+    AstAnd(FileLine* fl, AstNode* lhsp, AstNode* rhsp)
+        : ASTGEN_SUPER(fl, lhsp, rhsp) { dtypeFrom(lhsp); }
     ASTNODE_NODE_FUNCS(And)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstAnd(this->fileline(), lhsp, rhsp); }
     virtual void numberOperate(V3Number& out, const V3Number& lhs, const V3Number& rhs) { out.opAnd(lhs, rhs); }
@@ -5064,8 +5099,8 @@ public:
 };
 class AstXor : public AstNodeBiComAsv {
 public:
-    AstXor(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
-        dtypeFrom(lhsp); }
+    AstXor(FileLine* fl, AstNode* lhsp, AstNode* rhsp)
+        : ASTGEN_SUPER(fl, lhsp, rhsp) { dtypeFrom(lhsp); }
     ASTNODE_NODE_FUNCS(Xor)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstXor(this->fileline(), lhsp, rhsp); }
     virtual void numberOperate(V3Number& out, const V3Number& lhs, const V3Number& rhs) { out.opXor(lhs, rhs); }
@@ -5080,8 +5115,8 @@ public:
 };
 class AstXnor : public AstNodeBiComAsv {
 public:
-    AstXnor(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
-        dtypeFrom(lhsp); }
+    AstXnor(FileLine* fl, AstNode* lhsp, AstNode* rhsp)
+        : ASTGEN_SUPER(fl, lhsp, rhsp) { dtypeFrom(lhsp); }
     ASTNODE_NODE_FUNCS(Xnor)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstXnor(this->fileline(), lhsp, rhsp); }
     virtual void numberOperate(V3Number& out, const V3Number& lhs, const V3Number& rhs) { out.opXnor(lhs, rhs); }
@@ -5096,8 +5131,8 @@ public:
 };
 class AstEq : public AstNodeBiCom {
 public:
-    AstEq(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
-        dtypeSetLogicBool(); }
+    AstEq(FileLine* fl, AstNode* lhsp, AstNode* rhsp)
+        : ASTGEN_SUPER(fl, lhsp, rhsp) { dtypeSetLogicBool(); }
     ASTNODE_NODE_FUNCS(Eq)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstEq(this->fileline(), lhsp, rhsp); }
     static AstNodeBiop* newTyped(FileLine* fl, AstNode* lhsp, AstNode* rhsp);  // Return AstEq/AstEqD
@@ -5113,8 +5148,8 @@ public:
 };
 class AstEqD : public AstNodeBiCom {
 public:
-    AstEqD(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
-        dtypeSetLogicBool(); }
+    AstEqD(FileLine* fl, AstNode* lhsp, AstNode* rhsp)
+        : ASTGEN_SUPER(fl, lhsp, rhsp) { dtypeSetLogicBool(); }
     ASTNODE_NODE_FUNCS(EqD)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstEqD(this->fileline(), lhsp, rhsp); }
     virtual void numberOperate(V3Number& out, const V3Number& lhs, const V3Number& rhs) { out.opEqD(lhs, rhs); }
@@ -5131,8 +5166,8 @@ public:
 };
 class AstEqN : public AstNodeBiCom {
 public:
-    AstEqN(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
-        dtypeSetLogicBool(); }
+    AstEqN(FileLine* fl, AstNode* lhsp, AstNode* rhsp)
+        : ASTGEN_SUPER(fl, lhsp, rhsp) { dtypeSetLogicBool(); }
     ASTNODE_NODE_FUNCS(EqN)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstEqN(this->fileline(), lhsp, rhsp); }
     virtual void numberOperate(V3Number& out, const V3Number& lhs, const V3Number& rhs) { out.opEqN(lhs, rhs); }
@@ -5149,8 +5184,8 @@ public:
 };
 class AstNeq : public AstNodeBiCom {
 public:
-    AstNeq(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
-        dtypeSetLogicBool(); }
+    AstNeq(FileLine* fl, AstNode* lhsp, AstNode* rhsp)
+        : ASTGEN_SUPER(fl, lhsp, rhsp) { dtypeSetLogicBool(); }
     ASTNODE_NODE_FUNCS(Neq)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstNeq(this->fileline(), lhsp, rhsp); }
     virtual void numberOperate(V3Number& out, const V3Number& lhs, const V3Number& rhs) { out.opNeq(lhs, rhs); }
@@ -5165,8 +5200,8 @@ public:
 };
 class AstNeqD : public AstNodeBiCom {
 public:
-    AstNeqD(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
-        dtypeSetLogicBool(); }
+    AstNeqD(FileLine* fl, AstNode* lhsp, AstNode* rhsp)
+        : ASTGEN_SUPER(fl, lhsp, rhsp) { dtypeSetLogicBool(); }
     ASTNODE_NODE_FUNCS(NeqD)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstNeqD(this->fileline(), lhsp, rhsp); }
     virtual void numberOperate(V3Number& out, const V3Number& lhs, const V3Number& rhs) { out.opNeqD(lhs, rhs); }
@@ -5183,8 +5218,8 @@ public:
 };
 class AstNeqN : public AstNodeBiCom {
 public:
-    AstNeqN(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
-        dtypeSetLogicBool(); }
+    AstNeqN(FileLine* fl, AstNode* lhsp, AstNode* rhsp)
+        : ASTGEN_SUPER(fl, lhsp, rhsp) { dtypeSetLogicBool(); }
     ASTNODE_NODE_FUNCS(NeqN)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstNeqN(this->fileline(), lhsp, rhsp); }
     virtual void numberOperate(V3Number& out, const V3Number& lhs, const V3Number& rhs) { out.opNeqN(lhs, rhs); }
@@ -5201,8 +5236,8 @@ public:
 };
 class AstLt : public AstNodeBiop {
 public:
-    AstLt(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
-        dtypeSetLogicBool(); }
+    AstLt(FileLine* fl, AstNode* lhsp, AstNode* rhsp)
+        : ASTGEN_SUPER(fl, lhsp, rhsp) { dtypeSetLogicBool(); }
     ASTNODE_NODE_FUNCS(Lt)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstLt(this->fileline(), lhsp, rhsp); }
     virtual void numberOperate(V3Number& out, const V3Number& lhs, const V3Number& rhs) { out.opLt(lhs, rhs); }
@@ -5217,8 +5252,8 @@ public:
 };
 class AstLtD : public AstNodeBiop {
 public:
-    AstLtD(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
-        dtypeSetLogicBool(); }
+    AstLtD(FileLine* fl, AstNode* lhsp, AstNode* rhsp)
+        : ASTGEN_SUPER(fl, lhsp, rhsp) { dtypeSetLogicBool(); }
     ASTNODE_NODE_FUNCS(LtD)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstLtD(this->fileline(), lhsp, rhsp); }
     virtual void numberOperate(V3Number& out, const V3Number& lhs, const V3Number& rhs) { out.opLtD(lhs, rhs); }
@@ -5235,8 +5270,8 @@ public:
 };
 class AstLtS : public AstNodeBiop {
 public:
-    AstLtS(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
-        dtypeSetLogicBool(); }
+    AstLtS(FileLine* fl, AstNode* lhsp, AstNode* rhsp)
+        : ASTGEN_SUPER(fl, lhsp, rhsp) { dtypeSetLogicBool(); }
     ASTNODE_NODE_FUNCS(LtS)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstLtS(this->fileline(), lhsp, rhsp); }
     virtual void numberOperate(V3Number& out, const V3Number& lhs, const V3Number& rhs) { out.opLtS(lhs, rhs); }
@@ -5252,8 +5287,8 @@ public:
 };
 class AstLtN : public AstNodeBiop {
 public:
-    AstLtN(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
-        dtypeSetLogicBool(); }
+    AstLtN(FileLine* fl, AstNode* lhsp, AstNode* rhsp)
+        : ASTGEN_SUPER(fl, lhsp, rhsp) { dtypeSetLogicBool(); }
     ASTNODE_NODE_FUNCS(LtN)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstLtN(this->fileline(), lhsp, rhsp); }
     virtual void numberOperate(V3Number& out, const V3Number& lhs, const V3Number& rhs) { out.opLtN(lhs, rhs); }
@@ -5270,8 +5305,8 @@ public:
 };
 class AstGt : public AstNodeBiop {
 public:
-    AstGt(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
-        dtypeSetLogicBool(); }
+    AstGt(FileLine* fl, AstNode* lhsp, AstNode* rhsp)
+        : ASTGEN_SUPER(fl, lhsp, rhsp) { dtypeSetLogicBool(); }
     ASTNODE_NODE_FUNCS(Gt)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstGt(this->fileline(), lhsp, rhsp); }
     virtual void numberOperate(V3Number& out, const V3Number& lhs, const V3Number& rhs) { out.opGt(lhs, rhs); }
@@ -5286,8 +5321,8 @@ public:
 };
 class AstGtD : public AstNodeBiop {
 public:
-    AstGtD(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
-        dtypeSetLogicBool(); }
+    AstGtD(FileLine* fl, AstNode* lhsp, AstNode* rhsp)
+        : ASTGEN_SUPER(fl, lhsp, rhsp) { dtypeSetLogicBool(); }
     ASTNODE_NODE_FUNCS(GtD)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstGtD(this->fileline(), lhsp, rhsp); }
     virtual void numberOperate(V3Number& out, const V3Number& lhs, const V3Number& rhs) { out.opGtD(lhs, rhs); }
@@ -5304,8 +5339,8 @@ public:
 };
 class AstGtS : public AstNodeBiop {
 public:
-    AstGtS(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
-        dtypeSetLogicBool(); }
+    AstGtS(FileLine* fl, AstNode* lhsp, AstNode* rhsp)
+        : ASTGEN_SUPER(fl, lhsp, rhsp) { dtypeSetLogicBool(); }
     ASTNODE_NODE_FUNCS(GtS)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstGtS(this->fileline(), lhsp, rhsp); }
     virtual void numberOperate(V3Number& out, const V3Number& lhs, const V3Number& rhs) { out.opGtS(lhs, rhs); }
@@ -5321,8 +5356,8 @@ public:
 };
 class AstGtN : public AstNodeBiop {
 public:
-    AstGtN(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
-        dtypeSetLogicBool(); }
+    AstGtN(FileLine* fl, AstNode* lhsp, AstNode* rhsp)
+        : ASTGEN_SUPER(fl, lhsp, rhsp) { dtypeSetLogicBool(); }
     ASTNODE_NODE_FUNCS(GtN)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstGtN(this->fileline(), lhsp, rhsp); }
     virtual void numberOperate(V3Number& out, const V3Number& lhs, const V3Number& rhs) { out.opGtN(lhs, rhs); }
@@ -5339,8 +5374,8 @@ public:
 };
 class AstGte : public AstNodeBiop {
 public:
-    AstGte(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
-        dtypeSetLogicBool(); }
+    AstGte(FileLine* fl, AstNode* lhsp, AstNode* rhsp)
+        : ASTGEN_SUPER(fl, lhsp, rhsp) { dtypeSetLogicBool(); }
     ASTNODE_NODE_FUNCS(Gte)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstGte(this->fileline(), lhsp, rhsp); }
     static AstNodeBiop* newTyped(FileLine* fl, AstNode* lhsp, AstNode* rhsp);  // Return AstGte/AstGteS/AstGteD
@@ -5356,8 +5391,8 @@ public:
 };
 class AstGteD : public AstNodeBiop {
 public:
-    AstGteD(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
-        dtypeSetLogicBool(); }
+    AstGteD(FileLine* fl, AstNode* lhsp, AstNode* rhsp)
+        : ASTGEN_SUPER(fl, lhsp, rhsp) { dtypeSetLogicBool(); }
     ASTNODE_NODE_FUNCS(GteD)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstGteD(this->fileline(), lhsp, rhsp); }
     virtual void numberOperate(V3Number& out, const V3Number& lhs, const V3Number& rhs) { out.opGteD(lhs, rhs); }
@@ -5374,8 +5409,8 @@ public:
 };
 class AstGteS : public AstNodeBiop {
 public:
-    AstGteS(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
-        dtypeSetLogicBool(); }
+    AstGteS(FileLine* fl, AstNode* lhsp, AstNode* rhsp)
+        : ASTGEN_SUPER(fl, lhsp, rhsp) { dtypeSetLogicBool(); }
     ASTNODE_NODE_FUNCS(GteS)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstGteS(this->fileline(), lhsp, rhsp); }
     virtual void numberOperate(V3Number& out, const V3Number& lhs, const V3Number& rhs) { out.opGteS(lhs, rhs); }
@@ -5391,8 +5426,8 @@ public:
 };
 class AstGteN : public AstNodeBiop {
 public:
-    AstGteN(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
-        dtypeSetLogicBool(); }
+    AstGteN(FileLine* fl, AstNode* lhsp, AstNode* rhsp)
+        : ASTGEN_SUPER(fl, lhsp, rhsp) { dtypeSetLogicBool(); }
     ASTNODE_NODE_FUNCS(GteN)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstGteN(this->fileline(), lhsp, rhsp); }
     virtual void numberOperate(V3Number& out, const V3Number& lhs, const V3Number& rhs) { out.opGteN(lhs, rhs); }
@@ -5409,8 +5444,8 @@ public:
 };
 class AstLte : public AstNodeBiop {
 public:
-    AstLte(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
-        dtypeSetLogicBool(); }
+    AstLte(FileLine* fl, AstNode* lhsp, AstNode* rhsp)
+        : ASTGEN_SUPER(fl, lhsp, rhsp) { dtypeSetLogicBool(); }
     ASTNODE_NODE_FUNCS(Lte)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstLte(this->fileline(), lhsp, rhsp); }
     static AstNodeBiop* newTyped(FileLine* fl, AstNode* lhsp, AstNode* rhsp);  // Return AstLte/AstLteS/AstLteD
@@ -5426,8 +5461,8 @@ public:
 };
 class AstLteD : public AstNodeBiop {
 public:
-    AstLteD(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
-        dtypeSetLogicBool(); }
+    AstLteD(FileLine* fl, AstNode* lhsp, AstNode* rhsp)
+        : ASTGEN_SUPER(fl, lhsp, rhsp) { dtypeSetLogicBool(); }
     ASTNODE_NODE_FUNCS(LteD)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstLteD(this->fileline(), lhsp, rhsp); }
     virtual void numberOperate(V3Number& out, const V3Number& lhs, const V3Number& rhs) { out.opLteD(lhs, rhs); }
@@ -5444,8 +5479,8 @@ public:
 };
 class AstLteS : public AstNodeBiop {
 public:
-    AstLteS(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
-        dtypeSetLogicBool(); }
+    AstLteS(FileLine* fl, AstNode* lhsp, AstNode* rhsp)
+        : ASTGEN_SUPER(fl, lhsp, rhsp) { dtypeSetLogicBool(); }
     ASTNODE_NODE_FUNCS(LteS)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstLteS(this->fileline(), lhsp, rhsp); }
     virtual void numberOperate(V3Number& out, const V3Number& lhs, const V3Number& rhs) { out.opLteS(lhs, rhs); }
@@ -5461,8 +5496,8 @@ public:
 };
 class AstLteN : public AstNodeBiop {
 public:
-    AstLteN(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
-        dtypeSetLogicBool(); }
+    AstLteN(FileLine* fl, AstNode* lhsp, AstNode* rhsp)
+        : ASTGEN_SUPER(fl, lhsp, rhsp) { dtypeSetLogicBool(); }
     ASTNODE_NODE_FUNCS(LteN)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstLteN(this->fileline(), lhsp, rhsp); }
     virtual void numberOperate(V3Number& out, const V3Number& lhs, const V3Number& rhs) { out.opLteN(lhs, rhs); }
@@ -5539,8 +5574,8 @@ public:
 };
 class AstAdd : public AstNodeBiComAsv {
 public:
-    AstAdd(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
-        dtypeFrom(lhsp); }
+    AstAdd(FileLine* fl, AstNode* lhsp, AstNode* rhsp)
+        : ASTGEN_SUPER(fl, lhsp, rhsp) { dtypeFrom(lhsp); }
     ASTNODE_NODE_FUNCS(Add)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstAdd(this->fileline(), lhsp, rhsp); }
     virtual void numberOperate(V3Number& out, const V3Number& lhs, const V3Number& rhs) { out.opAdd(lhs, rhs); }
@@ -5555,8 +5590,8 @@ public:
 };
 class AstAddD : public AstNodeBiComAsv {
 public:
-    AstAddD(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
-        dtypeSetDouble(); }
+    AstAddD(FileLine* fl, AstNode* lhsp, AstNode* rhsp)
+        : ASTGEN_SUPER(fl, lhsp, rhsp) { dtypeSetDouble(); }
     ASTNODE_NODE_FUNCS(AddD)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstAddD(this->fileline(), lhsp, rhsp); }
     virtual void numberOperate(V3Number& out, const V3Number& lhs, const V3Number& rhs) { out.opAddD(lhs, rhs); }
@@ -5573,8 +5608,8 @@ public:
 };
 class AstSub : public AstNodeBiop {
 public:
-    AstSub(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
-        dtypeFrom(lhsp); }
+    AstSub(FileLine* fl, AstNode* lhsp, AstNode* rhsp)
+        : ASTGEN_SUPER(fl, lhsp, rhsp) { dtypeFrom(lhsp); }
     ASTNODE_NODE_FUNCS(Sub)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstSub(this->fileline(), lhsp, rhsp); }
     virtual void numberOperate(V3Number& out, const V3Number& lhs, const V3Number& rhs) { out.opSub(lhs, rhs); }
@@ -5589,8 +5624,8 @@ public:
 };
 class AstSubD : public AstNodeBiop {
 public:
-    AstSubD(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
-        dtypeSetDouble(); }
+    AstSubD(FileLine* fl, AstNode* lhsp, AstNode* rhsp)
+        : ASTGEN_SUPER(fl, lhsp, rhsp) { dtypeSetDouble(); }
     ASTNODE_NODE_FUNCS(SubD)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstSubD(this->fileline(), lhsp, rhsp); }
     virtual void numberOperate(V3Number& out, const V3Number& lhs, const V3Number& rhs) { out.opSubD(lhs, rhs); }
@@ -5607,8 +5642,8 @@ public:
 };
 class AstMul : public AstNodeBiComAsv {
 public:
-    AstMul(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
-        dtypeFrom(lhsp); }
+    AstMul(FileLine* fl, AstNode* lhsp, AstNode* rhsp)
+        : ASTGEN_SUPER(fl, lhsp, rhsp) { dtypeFrom(lhsp); }
     ASTNODE_NODE_FUNCS(Mul)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstMul(this->fileline(), lhsp, rhsp); }
     virtual void numberOperate(V3Number& out, const V3Number& lhs, const V3Number& rhs) { out.opMul(lhs, rhs); }
@@ -5624,8 +5659,8 @@ public:
 };
 class AstMulD : public AstNodeBiComAsv {
 public:
-    AstMulD(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
-        dtypeSetDouble(); }
+    AstMulD(FileLine* fl, AstNode* lhsp, AstNode* rhsp)
+        : ASTGEN_SUPER(fl, lhsp, rhsp) { dtypeSetDouble(); }
     ASTNODE_NODE_FUNCS(MulD)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstMulD(this->fileline(), lhsp, rhsp); }
     virtual void numberOperate(V3Number& out, const V3Number& lhs, const V3Number& rhs) { out.opMulD(lhs, rhs); }
@@ -5642,8 +5677,8 @@ public:
 };
 class AstMulS : public AstNodeBiComAsv {
 public:
-    AstMulS(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
-        dtypeFrom(lhsp); }
+    AstMulS(FileLine* fl, AstNode* lhsp, AstNode* rhsp)
+        : ASTGEN_SUPER(fl, lhsp, rhsp) { dtypeFrom(lhsp); }
     ASTNODE_NODE_FUNCS(MulS)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstMulS(this->fileline(), lhsp, rhsp); }
     virtual void numberOperate(V3Number& out, const V3Number& lhs, const V3Number& rhs) { out.opMulS(lhs, rhs); }
@@ -5660,8 +5695,8 @@ public:
 };
 class AstDiv : public AstNodeBiop {
 public:
-    AstDiv(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
-        dtypeFrom(lhsp); }
+    AstDiv(FileLine* fl, AstNode* lhsp, AstNode* rhsp)
+        : ASTGEN_SUPER(fl, lhsp, rhsp) { dtypeFrom(lhsp); }
     ASTNODE_NODE_FUNCS(Div)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstDiv(this->fileline(), lhsp, rhsp); }
     virtual void numberOperate(V3Number& out, const V3Number& lhs, const V3Number& rhs) { out.opDiv(lhs, rhs); }
@@ -5676,8 +5711,8 @@ public:
 };
 class AstDivD : public AstNodeBiop {
 public:
-    AstDivD(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
-        dtypeSetDouble(); }
+    AstDivD(FileLine* fl, AstNode* lhsp, AstNode* rhsp)
+        : ASTGEN_SUPER(fl, lhsp, rhsp) { dtypeSetDouble(); }
     ASTNODE_NODE_FUNCS(DivD)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstDivD(this->fileline(), lhsp, rhsp); }
     virtual void numberOperate(V3Number& out, const V3Number& lhs, const V3Number& rhs) { out.opDivD(lhs, rhs); }
@@ -5694,8 +5729,8 @@ public:
 };
 class AstDivS : public AstNodeBiop {
 public:
-    AstDivS(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
-        dtypeFrom(lhsp); }
+    AstDivS(FileLine* fl, AstNode* lhsp, AstNode* rhsp)
+        : ASTGEN_SUPER(fl, lhsp, rhsp) { dtypeFrom(lhsp); }
     ASTNODE_NODE_FUNCS(DivS)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstDivS(this->fileline(), lhsp, rhsp); }
     virtual void numberOperate(V3Number& out, const V3Number& lhs, const V3Number& rhs) { out.opDivS(lhs, rhs); }
@@ -5711,8 +5746,8 @@ public:
 };
 class AstModDiv : public AstNodeBiop {
 public:
-    AstModDiv(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
-        dtypeFrom(lhsp); }
+    AstModDiv(FileLine* fl, AstNode* lhsp, AstNode* rhsp)
+        : ASTGEN_SUPER(fl, lhsp, rhsp) { dtypeFrom(lhsp); }
     ASTNODE_NODE_FUNCS(ModDiv)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstModDiv(this->fileline(), lhsp, rhsp); }
     virtual void numberOperate(V3Number& out, const V3Number& lhs, const V3Number& rhs) { out.opModDiv(lhs, rhs); }
@@ -5727,8 +5762,8 @@ public:
 };
 class AstModDivS : public AstNodeBiop {
 public:
-    AstModDivS(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
-        dtypeFrom(lhsp); }
+    AstModDivS(FileLine* fl, AstNode* lhsp, AstNode* rhsp)
+        : ASTGEN_SUPER(fl, lhsp, rhsp) { dtypeFrom(lhsp); }
     ASTNODE_NODE_FUNCS(ModDivS)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstModDivS(this->fileline(), lhsp, rhsp); }
     virtual void numberOperate(V3Number& out, const V3Number& lhs, const V3Number& rhs) { out.opModDivS(lhs, rhs); }
@@ -5744,8 +5779,8 @@ public:
 };
 class AstPow : public AstNodeBiop {
 public:
-    AstPow(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
-        dtypeFrom(lhsp); }
+    AstPow(FileLine* fl, AstNode* lhsp, AstNode* rhsp)
+        : ASTGEN_SUPER(fl, lhsp, rhsp) { dtypeFrom(lhsp); }
     ASTNODE_NODE_FUNCS(Pow)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstPow(this->fileline(), lhsp, rhsp); }
     virtual void numberOperate(V3Number& out, const V3Number& lhs, const V3Number& rhs) { out.opPow(lhs, rhs); }
@@ -5760,8 +5795,8 @@ public:
 };
 class AstPowD : public AstNodeBiop {
 public:
-    AstPowD(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
-        dtypeSetDouble(); }
+    AstPowD(FileLine* fl, AstNode* lhsp, AstNode* rhsp)
+        : ASTGEN_SUPER(fl, lhsp, rhsp) { dtypeSetDouble(); }
     ASTNODE_NODE_FUNCS(PowD)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstPowD(this->fileline(), lhsp, rhsp); }
     virtual void numberOperate(V3Number& out, const V3Number& lhs, const V3Number& rhs) { out.opPowD(lhs, rhs); }
@@ -5777,8 +5812,8 @@ public:
 };
 class AstPowSU : public AstNodeBiop {
 public:
-    AstPowSU(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
-        dtypeFrom(lhsp); }
+    AstPowSU(FileLine* fl, AstNode* lhsp, AstNode* rhsp)
+        : ASTGEN_SUPER(fl, lhsp, rhsp) { dtypeFrom(lhsp); }
     ASTNODE_NODE_FUNCS(PowSU)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstPowSU(this->fileline(), lhsp, rhsp); }
     virtual void numberOperate(V3Number& out, const V3Number& lhs, const V3Number& rhs) { out.opPowSU(lhs, rhs); }
@@ -5794,8 +5829,8 @@ public:
 };
 class AstPowSS : public AstNodeBiop {
 public:
-    AstPowSS(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
-        dtypeFrom(lhsp); }
+    AstPowSS(FileLine* fl, AstNode* lhsp, AstNode* rhsp)
+        : ASTGEN_SUPER(fl, lhsp, rhsp) { dtypeFrom(lhsp); }
     ASTNODE_NODE_FUNCS(PowSS)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstPowSS(this->fileline(), lhsp, rhsp); }
     virtual void numberOperate(V3Number& out, const V3Number& lhs, const V3Number& rhs) { out.opPowSS(lhs, rhs); }
@@ -5811,8 +5846,8 @@ public:
 };
 class AstPowUS : public AstNodeBiop {
 public:
-    AstPowUS(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
-        dtypeFrom(lhsp); }
+    AstPowUS(FileLine* fl, AstNode* lhsp, AstNode* rhsp)
+        : ASTGEN_SUPER(fl, lhsp, rhsp) { dtypeFrom(lhsp); }
     ASTNODE_NODE_FUNCS(PowUS)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstPowUS(this->fileline(), lhsp, rhsp); }
     virtual void numberOperate(V3Number& out, const V3Number& lhs, const V3Number& rhs) { out.opPowUS(lhs, rhs); }
@@ -5828,8 +5863,8 @@ public:
 };
 class AstEqCase : public AstNodeBiCom {
 public:
-    AstEqCase(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
-        dtypeSetLogicBool(); }
+    AstEqCase(FileLine* fl, AstNode* lhsp, AstNode* rhsp)
+        : ASTGEN_SUPER(fl, lhsp, rhsp) { dtypeSetLogicBool(); }
     ASTNODE_NODE_FUNCS(EqCase)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstEqCase(this->fileline(), lhsp, rhsp); }
     virtual void numberOperate(V3Number& out, const V3Number& lhs, const V3Number& rhs) { out.opCaseEq(lhs, rhs); }
@@ -5844,8 +5879,8 @@ public:
 };
 class AstNeqCase : public AstNodeBiCom {
 public:
-    AstNeqCase(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
-        dtypeSetLogicBool(); }
+    AstNeqCase(FileLine* fl, AstNode* lhsp, AstNode* rhsp)
+        : ASTGEN_SUPER(fl, lhsp, rhsp) { dtypeSetLogicBool(); }
     ASTNODE_NODE_FUNCS(NeqCase)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstNeqCase(this->fileline(), lhsp, rhsp); }
     virtual void numberOperate(V3Number& out, const V3Number& lhs, const V3Number& rhs) { out.opCaseNeq(lhs, rhs); }
@@ -5861,8 +5896,8 @@ public:
 class AstEqWild : public AstNodeBiop {
     // Note wildcard operator rhs differs from lhs
 public:
-    AstEqWild(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
-        dtypeSetLogicBool(); }
+    AstEqWild(FileLine* fl, AstNode* lhsp, AstNode* rhsp)
+        : ASTGEN_SUPER(fl, lhsp, rhsp) { dtypeSetLogicBool(); }
     ASTNODE_NODE_FUNCS(EqWild)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstEqWild(this->fileline(), lhsp, rhsp); }
     static AstNodeBiop* newTyped(FileLine* fl, AstNode* lhsp, AstNode* rhsp);  // Return AstEqWild/AstEqD
@@ -5878,8 +5913,8 @@ public:
 };
 class AstNeqWild : public AstNodeBiop {
 public:
-    AstNeqWild(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
-        dtypeSetLogicBool(); }
+    AstNeqWild(FileLine* fl, AstNode* lhsp, AstNode* rhsp)
+        : ASTGEN_SUPER(fl, lhsp, rhsp) { dtypeSetLogicBool(); }
     ASTNODE_NODE_FUNCS(NeqWild)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstNeqWild(this->fileline(), lhsp, rhsp); }
     virtual void numberOperate(V3Number& out, const V3Number& lhs, const V3Number& rhs) { out.opWildNeq(lhs, rhs); }
@@ -5895,7 +5930,8 @@ public:
 class AstConcat : public AstNodeBiop {
     // If you're looking for {#{}}, see AstReplicate
 public:
-    AstConcat(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
+    AstConcat(FileLine* fl, AstNode* lhsp, AstNode* rhsp)
+        : ASTGEN_SUPER(fl, lhsp, rhsp) {
         if (lhsp->dtypep() && rhsp->dtypep()) {
             dtypeSetLogicSized(lhsp->dtypep()->width()+rhsp->dtypep()->width(),
                                AstNumeric::UNSIGNED);
@@ -5916,9 +5952,8 @@ public:
 class AstConcatN : public AstNodeBiop {
     // String concatenate
 public:
-    AstConcatN(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
-        dtypeSetString();
-    }
+    AstConcatN(FileLine* fl, AstNode* lhsp, AstNode* rhsp)
+        : ASTGEN_SUPER(fl, lhsp, rhsp) { dtypeSetString(); }
     ASTNODE_NODE_FUNCS(ConcatN)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstConcatN(this->fileline(), lhsp, rhsp); }
     virtual string emitVerilog() { return "%f{%l, %k%r}"; }
@@ -5986,7 +6021,8 @@ public:
 class AstStreamL : public AstNodeStream {
     // Verilog {rhs{lhs}} - Note rhsp() is the slice size, not the lhsp()
 public:
-    AstStreamL(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {}
+    AstStreamL(FileLine* fl, AstNode* lhsp, AstNode* rhsp)
+        : ASTGEN_SUPER(fl, lhsp, rhsp) {}
     ASTNODE_NODE_FUNCS(StreamL)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstStreamL(this->fileline(), lhsp, rhsp); }
     virtual string emitVerilog() { return "%f{ << %r %k{%l} }"; }
@@ -6002,7 +6038,8 @@ public:
 class AstStreamR : public AstNodeStream {
     // Verilog {rhs{lhs}} - Note rhsp() is the slice size, not the lhsp()
 public:
-    AstStreamR(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {}
+    AstStreamR(FileLine* fl, AstNode* lhsp, AstNode* rhsp)
+        : ASTGEN_SUPER(fl, lhsp, rhsp) {}
     ASTNODE_NODE_FUNCS(StreamR)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstStreamR(this->fileline(), lhsp, rhsp); }
     virtual string emitVerilog() { return "%f{ >> %r %k{%l} }"; }
@@ -6020,8 +6057,8 @@ class AstBufIf1 : public AstNodeBiop {
     // Note unlike the Verilog bufif1() UDP, this allows any width; each lhsp
     // bit enables respective rhsp bit
 public:
-    AstBufIf1(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
-        dtypeFrom(lhsp); }
+    AstBufIf1(FileLine* fl, AstNode* lhsp, AstNode* rhsp)
+        : ASTGEN_SUPER(fl, lhsp, rhsp) { dtypeFrom(lhsp); }
     ASTNODE_NODE_FUNCS(BufIf1)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstBufIf1(this->fileline(), lhsp, rhsp); }
     virtual void numberOperate(V3Number& out, const V3Number& lhs, const V3Number& rhs) { out.opBufIf1(lhs, rhs); }
@@ -6036,7 +6073,8 @@ public:
 };
 class AstFGetS : public AstNodeBiop {
 public:
-    AstFGetS(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {}
+    AstFGetS(FileLine* fl, AstNode* lhsp, AstNode* rhsp)
+        : ASTGEN_SUPER(fl, lhsp, rhsp) {}
     ASTNODE_NODE_FUNCS(FGetS)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstFGetS(this->fileline(), lhsp, rhsp); }
     virtual void numberOperate(V3Number& out, const V3Number& lhs, const V3Number& rhs) { V3ERROR_NA; }
@@ -6067,7 +6105,8 @@ public:
 
 class AstAtan2D : public AstNodeSystemBiop {
 public:
-    AstAtan2D(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {}
+    AstAtan2D(FileLine* fl, AstNode* lhsp, AstNode* rhsp)
+        : ASTGEN_SUPER(fl, lhsp, rhsp) {}
     ASTNODE_NODE_FUNCS(Atan2D)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstAtan2D(this->fileline(), lhsp, rhsp); }
     virtual void numberOperate(V3Number& out, const V3Number& lhs, const V3Number& rhs) {
@@ -6078,7 +6117,8 @@ public:
 
 class AstHypotD : public AstNodeSystemBiop {
 public:
-    AstHypotD(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {}
+    AstHypotD(FileLine* fl, AstNode* lhsp, AstNode* rhsp)
+        : ASTGEN_SUPER(fl, lhsp, rhsp) {}
     ASTNODE_NODE_FUNCS(HypotD)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstHypotD(this->fileline(), lhsp, rhsp); }
     virtual void numberOperate(V3Number& out, const V3Number& lhs, const V3Number& rhs) {
@@ -6090,9 +6130,8 @@ public:
 class AstPutcN : public AstNodeTriop {
     // Verilog string.putc()
 public:
-    AstPutcN(FileLine* fl, AstNode* lhsp, AstNode* rhsp, AstNode* ths) : ASTGEN_SUPER(fl, lhsp, rhsp, ths) {
-        dtypeSetString();
-    }
+    AstPutcN(FileLine* fl, AstNode* lhsp, AstNode* rhsp, AstNode* ths)
+        : ASTGEN_SUPER(fl, lhsp, rhsp, ths) { dtypeSetString(); }
     ASTNODE_NODE_FUNCS(PutcN)
     virtual void numberOperate(V3Number& out, const V3Number& lhs,
                                const V3Number& rhs, const V3Number& ths) {
@@ -6114,9 +6153,8 @@ public:
 class AstGetcN : public AstNodeBiop {
     // Verilog string.getc()
 public:
-    AstGetcN(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
-        dtypeSetBitSized(8, AstNumeric::UNSIGNED);
-    }
+    AstGetcN(FileLine* fl, AstNode* lhsp, AstNode* rhsp)
+        : ASTGEN_SUPER(fl, lhsp, rhsp) { dtypeSetBitSized(8, AstNumeric::UNSIGNED); }
     ASTNODE_NODE_FUNCS(GetcN)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) {
         return new AstGetcN(this->fileline(), lhsp, rhsp);
@@ -6138,9 +6176,8 @@ public:
 class AstSubstrN : public AstNodeTriop {
     // Verilog string.substr()
 public:
-    AstSubstrN(FileLine* fl, AstNode* lhsp, AstNode* rhsp, AstNode* ths) : ASTGEN_SUPER(fl, lhsp, rhsp, ths) {
-        dtypeSetString();
-    }
+    AstSubstrN(FileLine* fl, AstNode* lhsp, AstNode* rhsp, AstNode* ths)
+        : ASTGEN_SUPER(fl, lhsp, rhsp, ths) { dtypeSetString(); }
     ASTNODE_NODE_FUNCS(SubstrN)
     virtual void numberOperate(V3Number& out, const V3Number& lhs,
                                const V3Number& rhs, const V3Number& ths) {
@@ -6196,10 +6233,8 @@ class AstPast : public AstNodeMath {
     // Parents: math
     // Children: expression
 public:
-    AstPast(FileLine* fl, AstNode* exprp, AstNode* ticksp) : ASTGEN_SUPER(fl) {
-        addOp1p(exprp);
-        addNOp2p(ticksp);
-    }
+    AstPast(FileLine* fl, AstNode* exprp, AstNode* ticksp)
+        : ASTGEN_SUPER(fl) { addOp1p(exprp); addNOp2p(ticksp); }
     ASTNODE_NODE_FUNCS(Past)
     virtual string emitVerilog() { V3ERROR_NA; return ""; }
     virtual void numberOperate(V3Number& out, const V3Number& lhs, const V3Number& rhs) { V3ERROR_NA; }
@@ -6220,9 +6255,8 @@ class AstPattern : public AstNodeMath {
     // Parents: AstNodeAssign, AstPattern, ...
     // Children: expression, AstPattern, AstPatReplicate
 public:
-    AstPattern(FileLine* fl, AstNode* itemsp) : ASTGEN_SUPER(fl) {
-        addNOp2p(itemsp);
-    }
+    AstPattern(FileLine* fl, AstNode* itemsp)
+        : ASTGEN_SUPER(fl) { addNOp2p(itemsp); }
     ASTNODE_NODE_FUNCS(Pattern)
     virtual string emitVerilog() { V3ERROR_NA; return ""; }  // Implemented specially
     virtual void numberOperate(V3Number& out, const V3Number& lhs, const V3Number& rhs) { V3ERROR_NA; }
@@ -6243,8 +6277,8 @@ class AstPatMember : public AstNodeMath {
 private:
     bool        m_default;
 public:
-    AstPatMember(FileLine* fl, AstNode* lhsp, AstNode* keyp, AstNode* repp) : ASTGEN_SUPER(fl) {
-        addOp1p(lhsp), setNOp2p(keyp), setNOp3p(repp); m_default = false; }
+    AstPatMember(FileLine* fl, AstNode* lhsp, AstNode* keyp, AstNode* repp)
+        : ASTGEN_SUPER(fl) { addOp1p(lhsp), setNOp2p(keyp), setNOp3p(repp); m_default = false; }
     ASTNODE_NODE_FUNCS(PatMember)
     virtual void numberOperate(V3Number& out, const V3Number& lhs, const V3Number& rhs) { V3ERROR_NA; }
     virtual string emitVerilog() { return lhssp()?"%f{%r{%k%l}}":"%l"; }
@@ -6787,8 +6821,8 @@ class AstMTaskBody : public AstNode {
 private:
     ExecMTask* m_execMTaskp;
 public:
-    explicit AstMTaskBody(FileLine* flp)
-        : ASTGEN_SUPER(flp)
+    explicit AstMTaskBody(FileLine* fl)
+        : ASTGEN_SUPER(fl)
         , m_execMTaskp(NULL) {}
     ASTNODE_NODE_FUNCS(MTaskBody);
     virtual const char* broken() const { BROKEN_RTN(!m_execMTaskp); return NULL; }
@@ -6811,7 +6845,7 @@ class AstExecGraph : public AstNode {
 private:
     V3Graph *m_depGraphp;  // contains ExecMTask's
 public:
-    explicit AstExecGraph(FileLine* fileline);
+    explicit AstExecGraph(FileLine* fl);
     ASTNODE_NODE_FUNCS_NO_DTOR(ExecGraph)
     virtual ~AstExecGraph();
     virtual const char* broken() const { BROKEN_RTN(!m_depGraphp); return NULL; }
@@ -6823,8 +6857,8 @@ public:
 class AstSplitPlaceholder : public AstNode {
 public:
     // Dummy node used within V3Split; never exists outside of V3Split.
-    explicit AstSplitPlaceholder(FileLine* filelinep)
-        : ASTGEN_SUPER(filelinep) {}
+    explicit AstSplitPlaceholder(FileLine* fl)
+        : ASTGEN_SUPER(fl) {}
     ASTNODE_NODE_FUNCS(SplitPlaceholder)
 };
 
@@ -6840,7 +6874,8 @@ class AstTypeTable : public AstNode {
     typedef std::map<VBasicTypeKey,AstBasicDType*> DetailedMap;
     DetailedMap m_detailedMap;
 public:
-    explicit AstTypeTable(FileLine* fl) : ASTGEN_SUPER(fl), m_voidp(NULL) {
+    explicit AstTypeTable(FileLine* fl)
+        : ASTGEN_SUPER(fl), m_voidp(NULL) {
         for (int i=0; i<AstBasicDTypeKwd::_ENUM_MAX; ++i) m_basicps[i] = NULL;
     }
     ASTNODE_NODE_FUNCS(TypeTable)

--- a/src/V3AstNodes.h
+++ b/src/V3AstNodes.h
@@ -30,7 +30,6 @@
 
 #define ASTNODE_NODE_FUNCS_NO_DTOR(name) \
     virtual void accept(AstNVisitor& v) { v.visit(this); } \
-    virtual AstType type() const { return AstType::at ## name; } \
     virtual AstNode* clone() { return new Ast ##name (*this); } \
     static Ast ##name * cloneTreeNull(Ast ##name * nodep, bool cloneNextLink) { \
         return nodep ? nodep->cloneTree(cloneNextLink) : NULL; } \
@@ -40,6 +39,11 @@
 #define ASTNODE_NODE_FUNCS(name) \
     virtual ~Ast ##name() {} \
     ASTNODE_NODE_FUNCS_NO_DTOR(name)
+
+//######################################################################
+// Macros replaced by 'astgen'
+
+#define ASTGEN_SUPER(...) // Roughly: <SuperClass>(AstType::at<ThisClass>, ...)
 
 //######################################################################
 //=== Ast* : Specific types
@@ -62,75 +66,75 @@ private:
     }
 public:
     AstConst(FileLine* fl, const V3Number& num)
-        : AstNodeMath(fl)
+        : ASTGEN_SUPER(fl)
         , m_num(num) {
         initWithNumber();
     }
     class WidthedValue {};  // for creator type-overload selection
     AstConst(FileLine* fl, WidthedValue, int width, uint32_t value)
-        : AstNodeMath(fl)
+        : ASTGEN_SUPER(fl)
         , m_num(this, width, value) {
         initWithNumber();
     }
     class DtypedValue{};  // for creator type-overload selection
     AstConst(FileLine* fl, DtypedValue, AstNodeDType* nodedtypep, uint32_t value)
-        : AstNodeMath(fl)
+        : ASTGEN_SUPER(fl)
         , m_num(this, nodedtypep->width(), value, nodedtypep->widthSized()) {
         initWithNumber();
     }
     class StringToParse {};  // for creator type-overload selection
     AstConst(FileLine* fl, StringToParse, const char* sourcep)
-        : AstNodeMath(fl)
+        : ASTGEN_SUPER(fl)
         , m_num(this, sourcep) {
         initWithNumber();
     }
     class VerilogStringLiteral {};  // for creator type-overload selection
     AstConst(FileLine* fl, VerilogStringLiteral, const string& str)
-        : AstNodeMath(fl)
+        : ASTGEN_SUPER(fl)
         , m_num(V3Number::VerilogStringLiteral(), this, str) {
         initWithNumber();
     }
     AstConst(FileLine* fl, uint32_t num)
-        : AstNodeMath(fl)
+        : ASTGEN_SUPER(fl)
         , m_num(this, 32, num) {
         dtypeSetLogicUnsized(m_num.width(), 0, AstNumeric::UNSIGNED);
     }
     class Unsized32 {};  // for creator type-overload selection
     AstConst(FileLine* fl, Unsized32, uint32_t num)  // Unsized 32-bit integer of specified value
-        : AstNodeMath(fl)
+        : ASTGEN_SUPER(fl)
         , m_num(this, 32, num) {
         m_num.width(32, false);
         dtypeSetLogicUnsized(32, m_num.widthMin(), AstNumeric::UNSIGNED);
     }
     class Signed32 {};  // for creator type-overload selection
     AstConst(FileLine* fl, Signed32, int32_t num)  // Signed 32-bit integer of specified value
-        : AstNodeMath(fl)
+        : ASTGEN_SUPER(fl)
         , m_num(this, 32, num) {
         m_num.width(32, true);
         dtypeSetLogicUnsized(32, m_num.widthMin(), AstNumeric::SIGNED);
     }
     class SizedEData {};  // for creator type-overload selection
     AstConst(FileLine* fl, SizedEData, vluint64_t num)
-        : AstNodeMath(fl)
+        : ASTGEN_SUPER(fl)
         , m_num(this, VL_EDATASIZE, 0) {
         m_num.setQuad(num);
         dtypeSetLogicSized(VL_EDATASIZE, AstNumeric::UNSIGNED);
     }
     class RealDouble {};  // for creator type-overload selection
     AstConst(FileLine* fl, RealDouble, double num)
-        : AstNodeMath(fl)
+        : ASTGEN_SUPER(fl)
         , m_num(this, 64) { m_num.setDouble(num); dtypeSetDouble(); }
     class String {};  // for creator type-overload selection
     AstConst(FileLine* fl, String, const string& num)
-        : AstNodeMath(fl)
+        : ASTGEN_SUPER(fl)
         , m_num(V3Number::String(), this, num) { dtypeSetString(); }
     class LogicFalse {};
     AstConst(FileLine* fl, LogicFalse)  // Shorthand const 0, dtype should be a logic of size 1
-        : AstNodeMath(fl)
+        : ASTGEN_SUPER(fl)
         , m_num(this, 1, 0) { dtypeSetLogicBool(); }
     class LogicTrue {};
     AstConst(FileLine* fl, LogicTrue)  // Shorthand const 1, dtype should be a logic of size 1
-        : AstNodeMath(fl)
+        : ASTGEN_SUPER(fl)
         , m_num(this, 1, 1) { dtypeSetLogicBool(); }
     ASTNODE_NODE_FUNCS(Const)
     virtual string name() const { return num().ascii(); }  // * = Value
@@ -157,17 +161,17 @@ private:
     bool        m_littleEndian:1;       // Bit vector is little endian
 public:
     AstRange(FileLine* fl, AstNode* msbp, AstNode* lsbp)
-        : AstNodeRange(fl) {
+        : ASTGEN_SUPER(fl) {
         m_littleEndian = false;
         setOp2p(msbp); setOp3p(lsbp); }
     AstRange(FileLine* fl, int msb, int lsb)
-        : AstNodeRange(fl) {
+        : ASTGEN_SUPER(fl) {
         m_littleEndian = false;
         setOp2p(new AstConst(fl, msb));
         setOp3p(new AstConst(fl, lsb));
     }
     AstRange(FileLine* fl, const VNumRange& range)
-        : AstNodeRange(fl) {
+        : ASTGEN_SUPER(fl) {
         m_littleEndian = range.littleEndian();
         setOp2p(new AstConst(fl, range.hi()));
         setOp3p(new AstConst(fl, range.lo()));
@@ -196,7 +200,7 @@ class AstAssocRange : public AstNodeRange {
     // Only for early parsing - becomes AstAssocDType
 public:
     explicit AstAssocRange(FileLine* fl, AstNodeDType* dtp)
-        : AstNodeRange(fl) {
+        : ASTGEN_SUPER(fl) {
         setOp1p(dtp);
     }
     ASTNODE_NODE_FUNCS(AssocRange)
@@ -212,7 +216,7 @@ class AstQueueRange : public AstNodeRange {
     // Only for early parsing - becomes AstQueueDType
 public:
     explicit AstQueueRange(FileLine* fl)
-        : AstNodeRange(fl) {}
+        : ASTGEN_SUPER(fl) {}
     ASTNODE_NODE_FUNCS(QueueRange)
     virtual string emitC() { V3ERROR_NA; return ""; }
     virtual string emitVerilog() { V3ERROR_NA; return ""; }
@@ -223,7 +227,7 @@ public:
 class AstUnsizedRange : public AstNodeRange {
     // Unsized range specification, for open arrays
 public:
-    explicit AstUnsizedRange(FileLine* fl) : AstNodeRange(fl) { }
+    explicit AstUnsizedRange(FileLine* fl) : ASTGEN_SUPER(fl) { }
     ASTNODE_NODE_FUNCS(UnsizedRange)
     virtual string emitC() { V3ERROR_NA; return ""; }
     virtual string emitVerilog() { return "[]"; }
@@ -234,7 +238,7 @@ public:
 class AstGatePin : public AstNodeMath {
     // Possibly expand a gate primitive input pin value to match the range of the gate primitive
 public:
-    AstGatePin(FileLine* fl, AstNode* lhsp, AstRange* rangep) : AstNodeMath(fl) {
+    AstGatePin(FileLine* fl, AstNode* lhsp, AstRange* rangep) : ASTGEN_SUPER(fl) {
         setOp1p(lhsp); setOp2p(rangep);
     }
     ASTNODE_NODE_FUNCS(GatePin)
@@ -250,7 +254,7 @@ class AstClass : public AstNode {
     string m_name;  // Name
 public:
     AstClass(FileLine* fl, const string& name)
-        : AstNode(fl)
+        : ASTGEN_SUPER(fl)
         , m_name(name) {}
     ASTNODE_NODE_FUNCS(Class)
     virtual string name() const { return m_name; }  // * = Var name
@@ -272,7 +276,7 @@ private:
     string      m_name;         // Name of variable
 public:
     AstParamTypeDType(FileLine* fl, AstVarType type, const string& name, VFlagChildDType, AstNodeDType* dtp)
-        : AstNodeDType(fl), m_varType(type), m_name(name) {
+        : ASTGEN_SUPER(fl), m_varType(type), m_name(name) {
         childDTypep(dtp);  // Only for parser
         dtypep(NULL);  // V3Width will resolve
     }
@@ -308,7 +312,7 @@ private:
     string      m_tag;  // Holds the string of the verilator tag -- used in XML output.
 public:
     AstTypedef(FileLine* fl, const string& name, AstNode* attrsp, VFlagChildDType, AstNodeDType* dtp)
-        : AstNode(fl), m_name(name) {
+        : ASTGEN_SUPER(fl), m_name(name) {
         childDTypep(dtp);  // Only for parser
         addAttrsp(attrsp);
         dtypep(NULL);  // V3Width will resolve
@@ -339,7 +343,7 @@ private:
     string      m_name;
 public:
     AstTypedefFwd(FileLine* fl, const string& name)
-        : AstNode(fl), m_name(name) {}
+        : ASTGEN_SUPER(fl), m_name(name) {}
     ASTNODE_NODE_FUNCS(TypedefFwd)
     // METHODS
     virtual string name() const { return m_name; }
@@ -356,7 +360,7 @@ private:
 public:
     AstDefImplicitDType(FileLine* fl, const string& name, void* containerp,
                         VFlagChildDType, AstNodeDType* dtp)
-        : AstNodeDType(fl), m_name(name), m_containerp(containerp) {
+        : ASTGEN_SUPER(fl), m_name(name), m_containerp(containerp) {
         childDTypep(dtp);  // Only for parser
         dtypep(NULL);  // V3Width will resolve
         m_uniqueNum = uniqueNumInc();
@@ -394,7 +398,7 @@ private:
     AstNodeDType* m_keyDTypep;  // Keys of this type (after widthing)
 public:
     AstAssocArrayDType(FileLine* fl, VFlagChildDType, AstNodeDType* dtp, AstNodeDType* keyDtp)
-        : AstNodeDType(fl) {
+        : ASTGEN_SUPER(fl) {
         childDTypep(dtp);  // Only for parser
         keyChildDTypep(keyDtp);  // Only for parser
         refDTypep(NULL);
@@ -450,7 +454,7 @@ class AstPackArrayDType : public AstNodeArrayDType {
     // Children: RANGE (array bounds)
 public:
     AstPackArrayDType(FileLine* fl, VFlagChildDType, AstNodeDType* dtp, AstRange* rangep)
-        : AstNodeArrayDType(fl) {
+        : ASTGEN_SUPER(fl) {
         childDTypep(dtp);  // Only for parser
         refDTypep(NULL);
         setOp2p(rangep);
@@ -459,7 +463,7 @@ public:
         widthForce(width, width);
     }
     AstPackArrayDType(FileLine* fl, AstNodeDType* dtp, AstRange* rangep)
-        : AstNodeArrayDType(fl) {
+        : ASTGEN_SUPER(fl) {
         refDTypep(dtp);
         setOp2p(rangep);
         dtypep(this);
@@ -475,7 +479,7 @@ class AstUnpackArrayDType : public AstNodeArrayDType {
     // Children: RANGE (array bounds)
 public:
     AstUnpackArrayDType(FileLine* fl, VFlagChildDType, AstNodeDType* dtp, AstRange* rangep)
-        : AstNodeArrayDType(fl) {
+        : ASTGEN_SUPER(fl) {
         childDTypep(dtp);  // Only for parser
         refDTypep(NULL);
         setOp2p(rangep);
@@ -485,7 +489,7 @@ public:
         widthFromSub(subDTypep());
     }
     AstUnpackArrayDType(FileLine* fl, AstNodeDType* dtp, AstRange* rangep)
-        : AstNodeArrayDType(fl) {
+        : ASTGEN_SUPER(fl) {
         refDTypep(dtp);
         setOp2p(rangep);
         dtypep(this);
@@ -503,7 +507,7 @@ private:
     AstNodeDType* m_refDTypep;  // Elements of this type (after widthing)
 public:
     AstUnsizedArrayDType(FileLine* fl, VFlagChildDType, AstNodeDType* dtp)
-        : AstNodeDType(fl) {
+        : ASTGEN_SUPER(fl) {
         childDTypep(dtp);  // Only for parser
         refDTypep(NULL);
         dtypep(NULL);  // V3Width will resolve
@@ -553,23 +557,23 @@ private:
     // See also in AstNodeDType: m_width, m_widthMin, m_numeric(issigned)
 public:
     AstBasicDType(FileLine* fl, AstBasicDTypeKwd kwd, VSignedState signst=signedst_NOSIGN)
-        : AstNodeDType(fl) {
+        : ASTGEN_SUPER(fl) {
         init(kwd, AstNumeric(signst), 0, -1, NULL);
     }
     AstBasicDType(FileLine* fl, VFlagLogicPacked, int wantwidth)
-        : AstNodeDType(fl) {
+        : ASTGEN_SUPER(fl) {
         init(AstBasicDTypeKwd::LOGIC, AstNumeric::NOSIGN, wantwidth, -1, NULL);
     }
     AstBasicDType(FileLine* fl, VFlagBitPacked, int wantwidth)
-        : AstNodeDType(fl) {
+        : ASTGEN_SUPER(fl) {
         init(AstBasicDTypeKwd::BIT, AstNumeric::NOSIGN, wantwidth, -1, NULL);
     }
     AstBasicDType(FileLine* fl, AstBasicDTypeKwd kwd, AstNumeric numer, int wantwidth, int widthmin)
-        : AstNodeDType(fl) {
+        : ASTGEN_SUPER(fl) {
         init(kwd, numer, wantwidth, widthmin, NULL);
     }
     AstBasicDType(FileLine* fl, AstBasicDTypeKwd kwd, AstNumeric numer, VNumRange range, int widthmin)
-        : AstNodeDType(fl) {
+        : ASTGEN_SUPER(fl) {
         init(kwd, numer, range.elements(), widthmin, NULL);
         m.m_nrange = range;  // as init() presumes lsb==0, but range.lsb() might not be
     }
@@ -667,7 +671,7 @@ private:
     AstNodeDType*       m_refDTypep;    // Inherit from this base data type
 public:
     AstConstDType(FileLine* fl, VFlagChildDType, AstNodeDType* dtp)
-        : AstNodeDType(fl) {
+        : ASTGEN_SUPER(fl) {
         childDTypep(dtp);  // Only for parser
         refDTypep(NULL);  // V3Width will resolve
         dtypep(NULL);  // V3Width will resolve
@@ -708,7 +712,7 @@ private:
     AstPackage* m_packagep;  // Package hierarchy
 public:
     AstClassRefDType(FileLine* fl, AstClass* classp)
-        : AstNodeDType(fl), m_classp(classp), m_packagep(NULL) {
+        : ASTGEN_SUPER(fl), m_classp(classp), m_packagep(NULL) {
         dtypep(this);
     }
     ASTNODE_NODE_FUNCS(ClassRefDType)
@@ -753,12 +757,12 @@ private:
 public:
     AstIfaceRefDType(FileLine* fl,
                      const string& cellName, const string& ifaceName)
-        : AstNodeDType(fl), m_modportFileline(NULL),
+        : ASTGEN_SUPER(fl), m_modportFileline(NULL),
           m_cellName(cellName), m_ifaceName(ifaceName), m_modportName(""),
           m_ifacep(NULL), m_cellp(NULL), m_modportp(NULL) { }
     AstIfaceRefDType(FileLine* fl, FileLine* modportFl,
                      const string& cellName, const string& ifaceName, const string& modport)
-        : AstNodeDType(fl), m_modportFileline(modportFl),
+        : ASTGEN_SUPER(fl), m_modportFileline(modportFl),
           m_cellName(cellName), m_ifaceName(ifaceName), m_modportName(modport),
           m_ifacep(NULL), m_cellp(NULL), m_modportp(NULL) { }
     ASTNODE_NODE_FUNCS(IfaceRefDType)
@@ -799,7 +803,7 @@ private:
     AstNodeDType* m_refDTypep;  // Elements of this type (after widthing)
 public:
     AstQueueDType(FileLine* fl, VFlagChildDType, AstNodeDType* dtp, AstNode* boundp)
-        : AstNodeDType(fl) {
+        : ASTGEN_SUPER(fl) {
         setNOp2p(boundp);
         childDTypep(dtp);  // Only for parser
         refDTypep(NULL);
@@ -847,9 +851,9 @@ private:
     AstPackage* m_packagep;     // Package hierarchy
 public:
     AstRefDType(FileLine* fl, const string& name)
-        : AstNodeDType(fl), m_refDTypep(NULL), m_name(name), m_packagep(NULL) {}
+        : ASTGEN_SUPER(fl), m_refDTypep(NULL), m_name(name), m_packagep(NULL) {}
     AstRefDType(FileLine* fl, AstNodeDType* defp)
-        : AstNodeDType(fl), m_refDTypep(defp), m_packagep(NULL) {
+        : ASTGEN_SUPER(fl), m_refDTypep(defp), m_packagep(NULL) {
         dtypeFrom(defp->dtypep());
         widthFromSub(subDTypep());
     }
@@ -901,7 +905,7 @@ class AstStructDType : public AstNodeUOrStructDType {
 public:
     // AstNumeric below is mispurposed to indicate if packed or not
     AstStructDType(FileLine* fl, AstNumeric numericUnpack)
-        : AstNodeUOrStructDType(fl, numericUnpack) {}
+        : ASTGEN_SUPER(fl, numericUnpack) {}
     ASTNODE_NODE_FUNCS(StructDType)
     virtual string verilogKwd() const { return "struct"; }
 };
@@ -911,7 +915,7 @@ public:
     //UNSUP: bool isTagged;
     // AstNumeric below is mispurposed to indicate if packed or not
     AstUnionDType(FileLine* fl, AstNumeric numericUnpack)
-        : AstNodeUOrStructDType(fl, numericUnpack) {}
+        : ASTGEN_SUPER(fl, numericUnpack) {}
     ASTNODE_NODE_FUNCS(UnionDType)
     virtual string verilogKwd() const { return "union"; }
 };
@@ -927,14 +931,14 @@ private:
     //UNSUP: int m_randType;    // Randomization type (IEEE)
 public:
     AstMemberDType(FileLine* fl, const string& name, VFlagChildDType, AstNodeDType* dtp)
-        : AstNodeDType(fl)
+        : ASTGEN_SUPER(fl)
         , m_name(name), m_lsb(-1) {
         childDTypep(dtp);  // Only for parser
         dtypep(NULL);  // V3Width will resolve
         refDTypep(NULL);
     }
     AstMemberDType(FileLine* fl, const string& name, AstNodeDType* dtp)
-        : AstNodeDType(fl)
+        : ASTGEN_SUPER(fl)
         , m_name(name), m_lsb(-1) {
         UASSERT(dtp, "AstMember created with no dtype");
         refDTypep(dtp);
@@ -978,7 +982,7 @@ class AstVoidDType : public AstNodeDType {
     // For e.g. a function returning void
 public:
     AstVoidDType(FileLine* fl)
-        : AstNodeDType(fl) { dtypep(this); }
+        : ASTGEN_SUPER(fl) { dtypep(this); }
     ASTNODE_NODE_FUNCS(VoidDType)
     virtual void dumpSmall(std::ostream& str) const;
     virtual bool hasDType() const { return true; }
@@ -1002,7 +1006,7 @@ private:
 public:
     // Parents: ENUM
     AstEnumItem(FileLine* fl, const string& name, AstNode* rangep, AstNode* initp)
-        : AstNode(fl), m_name(name)
+        : ASTGEN_SUPER(fl), m_name(name)
         { addNOp1p(rangep); addNOp2p(initp); }
     ASTNODE_NODE_FUNCS(EnumItem)
     virtual string name() const { return m_name; }
@@ -1021,7 +1025,7 @@ private:
     AstPackage* m_packagep;     // Package hierarchy
 public:
     AstEnumItemRef(FileLine* fl, AstEnumItem* itemp, AstPackage* packagep)
-        : AstNodeMath(fl), m_itemp(itemp), m_packagep(packagep) {
+        : ASTGEN_SUPER(fl), m_itemp(itemp), m_packagep(packagep) {
         dtypeFrom(m_itemp);
     }
     ASTNODE_NODE_FUNCS(EnumItemRef)
@@ -1050,7 +1054,7 @@ private:
     int m_uniqueNum;
 public:
     AstEnumDType(FileLine* fl, VFlagChildDType, AstNodeDType* dtp, AstNode* itemsp)
-        : AstNodeDType(fl) {
+        : ASTGEN_SUPER(fl) {
         childDTypep(dtp);  // Only for parser
         refDTypep(NULL);
         addNOp2p(itemsp);
@@ -1095,7 +1099,7 @@ class AstParseTypeDType : public AstNodeDType {
     // e.g. the data type is a container of any data type
 public:
     explicit AstParseTypeDType(FileLine* fl)
-        : AstNodeDType(fl) {}
+        : ASTGEN_SUPER(fl) {}
     ASTNODE_NODE_FUNCS(ParseTypeDType)
     AstNodeDType* dtypep() const { return NULL; }
     // METHODS
@@ -1122,11 +1126,11 @@ private:
     }
 public:
     AstArraySel(FileLine* fl, AstNode* fromp, AstNode* bitp)
-        :AstNodeSel(fl, fromp, bitp) {
+        : ASTGEN_SUPER(fl, fromp, bitp) {
         init(fromp);
     }
     AstArraySel(FileLine* fl, AstNode* fromp, int bit)
-        :AstNodeSel(fl, fromp, new AstConst(fl, bit)) {
+        : ASTGEN_SUPER(fl, fromp, new AstConst(fl, bit)) {
         init(fromp);
     }
     ASTNODE_NODE_FUNCS(ArraySel)
@@ -1161,7 +1165,7 @@ private:
     }
 public:
     AstAssocSel(FileLine* fl, AstNode* fromp, AstNode* bitp)
-        : AstNodeSel(fl, fromp, bitp) {
+        : ASTGEN_SUPER(fl, fromp, bitp) {
         init(fromp);
     }
     ASTNODE_NODE_FUNCS(AssocSel)
@@ -1187,7 +1191,7 @@ class AstWordSel : public AstNodeSel {
     // Select a single word from a multi-word wide value
 public:
     AstWordSel(FileLine* fl, AstNode* fromp, AstNode* bitp)
-        : AstNodeSel(fl, fromp, bitp) {
+        : ASTGEN_SUPER(fl, fromp, bitp) {
         dtypeSetUInt32();  // Always used on WData arrays so returns edata size
     }
     ASTNODE_NODE_FUNCS(WordSel)
@@ -1208,7 +1212,7 @@ class AstSelExtract : public AstNodePreSel {
     // Range extraction, gets replaced with AstSel
 public:
     AstSelExtract(FileLine* fl, AstNode* fromp, AstNode* msbp, AstNode* lsbp)
-        : AstNodePreSel(fl, fromp, msbp, lsbp) {}
+        : ASTGEN_SUPER(fl, fromp, msbp, lsbp) {}
     ASTNODE_NODE_FUNCS(SelExtract)
     AstNode* msbp() const { return rhsp(); }
     AstNode* lsbp() const { return thsp(); }
@@ -1219,7 +1223,7 @@ class AstSelBit : public AstNodePreSel {
     // Gets replaced during link with AstArraySel or AstSel
 public:
     AstSelBit(FileLine* fl, AstNode* fromp, AstNode* bitp)
-        :AstNodePreSel(fl, fromp, bitp, NULL) {
+        : ASTGEN_SUPER(fl, fromp, bitp, NULL) {
         UASSERT_OBJ(!v3Global.assertDTypesResolved(), this,
                     "not coded to create after dtypes resolved"); }
     ASTNODE_NODE_FUNCS(SelBit)
@@ -1231,7 +1235,7 @@ class AstSelPlus : public AstNodePreSel {
     // Gets replaced during link with AstSel
 public:
     AstSelPlus(FileLine* fl, AstNode* fromp, AstNode* bitp, AstNode* widthp)
-        : AstNodePreSel(fl, fromp, bitp, widthp) {}
+        : ASTGEN_SUPER(fl, fromp, bitp, widthp) {}
     ASTNODE_NODE_FUNCS(SelPlus)
     AstNode* bitp() const { return rhsp(); }
     AstNode* widthp() const { return thsp(); }
@@ -1242,7 +1246,7 @@ class AstSelMinus : public AstNodePreSel {
     // Gets replaced during link with AstSel
 public:
     AstSelMinus(FileLine* fl, AstNode* fromp, AstNode* bitp, AstNode* widthp)
-        : AstNodePreSel(fl, fromp, bitp, widthp) {}
+        : ASTGEN_SUPER(fl, fromp, bitp, widthp) {}
     ASTNODE_NODE_FUNCS(SelMinus)
     AstNode* bitp() const { return rhsp(); }
     AstNode* widthp() const { return thsp(); }
@@ -1259,7 +1263,7 @@ private:
     int         m_declElWidth;  // If a packed array, the number of bits per element
 public:
     AstSel(FileLine* fl, AstNode* fromp, AstNode* lsbp, AstNode* widthp)
-        : AstNodeTriop(fl, fromp, lsbp, widthp) {
+        : ASTGEN_SUPER(fl, fromp, lsbp, widthp) {
         m_declElWidth = 1;
         if (VN_IS(widthp, Const)) {
             dtypeSetLogicSized(VN_CAST(widthp, Const)->toUInt(),
@@ -1267,7 +1271,7 @@ public:
         }
     }
     AstSel(FileLine* fl, AstNode* fromp, int lsb, int bitwidth)
-        : AstNodeTriop(fl, fromp,
+        : ASTGEN_SUPER(fl, fromp,
                       new AstConst(fl, lsb), new AstConst(fl, bitwidth)) {
         m_declElWidth = 1;
         dtypeSetLogicSized(bitwidth, AstNumeric::UNSIGNED);
@@ -1312,7 +1316,7 @@ private:
     VNumRange m_declRange;  // Range of the 'from' array if isRanged() is set, else invalid
 public:
     AstSliceSel(FileLine* fl, AstNode* fromp, const VNumRange& declRange)
-        : AstNodeTriop(fl, fromp,
+        : ASTGEN_SUPER(fl, fromp,
                        new AstConst(fl, declRange.lo()),
                        new AstConst(fl, declRange.elements()))
         , m_declRange(declRange) { }
@@ -1347,13 +1351,13 @@ private:
     string m_name;  // Name of method
 public:
     AstMethodCall(FileLine* fl, AstNode* fromp, VFlagChildDType, const string& name, AstNode* pinsp)
-        : AstNode(fl), m_name(name) {
+        : ASTGEN_SUPER(fl), m_name(name) {
         setOp1p(fromp);
         dtypep(NULL);  // V3Width will resolve
         addNOp2p(pinsp);
     }
     AstMethodCall(FileLine* fl, AstNode* fromp, const string& name, AstNode* pinsp)
-        : AstNode(fl), m_name(name) {
+        : ASTGEN_SUPER(fl), m_name(name) {
         setOp1p(fromp);
         addNOp2p(pinsp);
     }
@@ -1376,7 +1380,7 @@ private:
 public:
     AstCMethodHard(FileLine* fl, AstNode* fromp, VFlagChildDType, const string& name,
                    AstNode* pinsp)
-        : AstNodeStmt(fl, false)
+        : ASTGEN_SUPER(fl, false)
         , m_name(name)
         , m_pure(false) {
         setOp1p(fromp);
@@ -1384,7 +1388,7 @@ public:
         addNOp2p(pinsp);
     }
     AstCMethodHard(FileLine* fl, AstNode* fromp, const string& name, AstNode* pinsp)
-        : AstNodeStmt(fl, false)
+        : ASTGEN_SUPER(fl, false)
         , m_name(name) {
         setOp1p(fromp);
         addNOp2p(pinsp);
@@ -1467,7 +1471,7 @@ private:
     }
 public:
     AstVar(FileLine* fl, AstVarType type, const string& name, VFlagChildDType, AstNodeDType* dtp)
-        : AstNode(fl)
+        : ASTGEN_SUPER(fl)
         , m_name(name), m_origName(name) {
         init();
         combineType(type);
@@ -1477,7 +1481,7 @@ public:
         else m_declKwd = AstBasicDTypeKwd::LOGIC;
     }
     AstVar(FileLine* fl, AstVarType type, const string& name, AstNodeDType* dtp)
-        : AstNode(fl)
+        : ASTGEN_SUPER(fl)
         , m_name(name), m_origName(name) {
         init();
         combineType(type);
@@ -1487,7 +1491,7 @@ public:
         else m_declKwd = AstBasicDTypeKwd::LOGIC;
     }
     AstVar(FileLine* fl, AstVarType type, const string& name, VFlagLogicPacked, int wantwidth)
-        : AstNode(fl)
+        : ASTGEN_SUPER(fl)
         , m_name(name), m_origName(name) {
         init();
         combineType(type);
@@ -1495,7 +1499,7 @@ public:
         m_declKwd = AstBasicDTypeKwd::LOGIC;
     }
     AstVar(FileLine* fl, AstVarType type, const string& name, VFlagBitPacked, int wantwidth)
-        : AstNode(fl)
+        : ASTGEN_SUPER(fl)
         , m_name(name), m_origName(name) {
         init();
         combineType(type);
@@ -1503,7 +1507,7 @@ public:
         m_declKwd = AstBasicDTypeKwd::BIT;
     }
     AstVar(FileLine* fl, AstVarType type, const string& name, AstVar* examplep)
-        : AstNode(fl)
+        : ASTGEN_SUPER(fl)
         , m_name(name), m_origName(name) {
         init();
         combineType(type);
@@ -1690,7 +1694,7 @@ private:
     string      m_path;         // Dotted cellname to set parameter of
 public:
     AstDefParam(FileLine* fl, const string& path, const string& name, AstNode* rhsp)
-        : AstNode(fl) {
+        : ASTGEN_SUPER(fl) {
         setOp1p(rhsp);
         m_name = name;
         m_path = path;
@@ -1709,7 +1713,7 @@ class AstImplicit : public AstNode {
     // Parents: MODULE
 public:
     AstImplicit(FileLine* fl, AstNode* exprsp)
-        : AstNode(fl) {
+        : ASTGEN_SUPER(fl) {
         addNOp1p(exprsp);
     }
     ASTNODE_NODE_FUNCS(Implicit)
@@ -1729,7 +1733,7 @@ private:
 public:
     AstScope(FileLine* fl, AstNodeModule* modp, const string& name,
              AstScope* aboveScopep, AstCell* aboveCellp)
-        : AstNode(fl)
+        : ASTGEN_SUPER(fl)
         , m_name(name), m_aboveScopep(aboveScopep), m_aboveCellp(aboveCellp), m_modp(modp) {}
     ASTNODE_NODE_FUNCS(Scope)
     virtual void cloneRelink();
@@ -1758,7 +1762,7 @@ class AstTopScope : public AstNode {
     // Children: SCOPEs
 public:
     AstTopScope(FileLine* fl, AstScope* ascopep)
-        : AstNode(fl)
+        : ASTGEN_SUPER(fl)
         {addNOp2p(ascopep);}
     ASTNODE_NODE_FUNCS(TopScope)
     AstNode* stmtsp() const { return op1p(); }
@@ -1779,7 +1783,7 @@ private:
     bool        m_trace:1;      // Tracing is turned on for this scope
 public:
     AstVarScope(FileLine* fl, AstScope* scopep, AstVar* varp)
-        : AstNode(fl)
+        : ASTGEN_SUPER(fl)
         , m_scopep(scopep), m_varp(varp) {
         m_circular = false;
         m_trace = true;
@@ -1811,14 +1815,14 @@ class AstVarRef : public AstNodeVarRef {
     // A reference to a variable (lvalue or rvalue)
 public:
     AstVarRef(FileLine* fl, const string& name, bool lvalue)
-        : AstNodeVarRef(fl, name, NULL, lvalue) {}
+        : ASTGEN_SUPER(fl, name, NULL, lvalue) {}
     // This form only allowed post-link because output/wire compression may
     // lead to deletion of AstVar's
     AstVarRef(FileLine* fl, AstVar* varp, bool lvalue)
-        : AstNodeVarRef(fl, varp->name(), varp, lvalue) {}
+        : ASTGEN_SUPER(fl, varp->name(), varp, lvalue) {}
     // This form only allowed post-link (see above)
     AstVarRef(FileLine* fl, AstVarScope* varscp, bool lvalue)
-        : AstNodeVarRef(fl, varscp->varp()->name(), varscp->varp(), lvalue) {
+        : ASTGEN_SUPER(fl, varscp->varp()->name(), varscp->varp(), lvalue) {
         varScopep(varscp);
     }
     ASTNODE_NODE_FUNCS(VarRef)
@@ -1850,10 +1854,10 @@ private:
     string      m_inlinedDots;  // Dotted hierarchy flattened out
 public:
     AstVarXRef(FileLine* fl, const string& name, const string& dotted, bool lvalue)
-        : AstNodeVarRef(fl, name, NULL, lvalue)
+        : ASTGEN_SUPER(fl, name, NULL, lvalue)
         , m_dotted(dotted) { }
     AstVarXRef(FileLine* fl, AstVar* varp, const string& dotted, bool lvalue)
-        : AstNodeVarRef(fl, varp->name(), varp, lvalue)
+        : ASTGEN_SUPER(fl, varp->name(), varp, lvalue)
         , m_dotted(dotted) {
         dtypeFrom(varp);
     }
@@ -1888,7 +1892,7 @@ private:
     bool        m_svImplicit;   // Pin is SystemVerilog .name'ed
 public:
     AstPin(FileLine* fl, int pinNum, const string& name, AstNode* exprp)
-        : AstNode(fl)
+        : ASTGEN_SUPER(fl)
         , m_name(name), m_param(false), m_svImplicit(false) {
         m_pinNum = pinNum;
         m_modVarp = NULL;
@@ -1896,7 +1900,7 @@ public:
         setNOp1p(exprp);
     }
     AstPin(FileLine* fl, int pinNum, AstVarRef* varname, AstNode* exprp)
-        : AstNode(fl), m_param(false), m_svImplicit(false) {
+        : ASTGEN_SUPER(fl), m_param(false), m_svImplicit(false) {
         m_name = varname->name();
         m_pinNum = pinNum;
         m_modVarp = NULL;
@@ -1937,7 +1941,7 @@ private:
     string      m_name;         // Pin name, or "" for number based interconnect
 public:
     AstArg(FileLine* fl, const string& name, AstNode* exprp)
-        : AstNode(fl)
+        : ASTGEN_SUPER(fl)
         , m_name(name) {
         setNOp1p(exprp);
     }
@@ -1954,7 +1958,7 @@ class AstModule : public AstNodeModule {
     // A module declaration
 public:
     AstModule(FileLine* fl, const string& name)
-        : AstNodeModule(fl, name) {}
+        : ASTGEN_SUPER(fl, name) {}
     ASTNODE_NODE_FUNCS(Module)
     virtual string verilogKwd() const { return "module"; }
 };
@@ -1963,7 +1967,7 @@ class AstNotFoundModule : public AstNodeModule {
     // A missing module declaration
 public:
     AstNotFoundModule(FileLine* fl, const string& name)
-        : AstNodeModule(fl, name) {}
+        : ASTGEN_SUPER(fl, name) {}
     ASTNODE_NODE_FUNCS(NotFoundModule)
     virtual string verilogKwd() const { return "/*not-found-*/ module"; }
 };
@@ -1972,7 +1976,7 @@ class AstPackage : public AstNodeModule {
     // A package declaration
 public:
     AstPackage(FileLine* fl, const string& name)
-        : AstNodeModule(fl, name) {}
+        : ASTGEN_SUPER(fl, name) {}
     ASTNODE_NODE_FUNCS(Package)
     virtual string verilogKwd() const { return "package"; }
     static string dollarUnitName() { return AstNode::encodeName("$unit"); }
@@ -1983,7 +1987,7 @@ class AstPrimitive : public AstNodeModule {
     // A primitive declaration
 public:
     AstPrimitive(FileLine* fl, const string& name)
-        : AstNodeModule(fl, name) {}
+        : ASTGEN_SUPER(fl, name) {}
     ASTNODE_NODE_FUNCS(Primitive)
     virtual string verilogKwd() const { return "primitive"; }
 };
@@ -1993,7 +1997,7 @@ class AstPackageExportStarStar : public AstNode {
 public:
     // cppcheck-suppress noExplicitConstructor
     AstPackageExportStarStar(FileLine* fl)
-        : AstNode(fl) {}
+        : ASTGEN_SUPER(fl) {}
     ASTNODE_NODE_FUNCS(PackageExportStarStar)
 };
 
@@ -2004,7 +2008,7 @@ private:
     AstPackage* m_packagep;     // Package hierarchy
 public:
     AstPackageExport(FileLine* fl, AstPackage* packagep, const string& name)
-        : AstNode(fl), m_name(name), m_packagep(packagep) {}
+        : ASTGEN_SUPER(fl), m_name(name), m_packagep(packagep) {}
     ASTNODE_NODE_FUNCS(PackageExport)
     virtual const char* broken() const { BROKEN_RTN(!m_packagep || !m_packagep->brokeExists()); return NULL; }
     virtual void cloneRelink() { if (m_packagep && m_packagep->clonep()) m_packagep = m_packagep->clonep(); }
@@ -2021,7 +2025,7 @@ private:
     AstPackage* m_packagep;     // Package hierarchy
 public:
     AstPackageImport(FileLine* fl, AstPackage* packagep, const string& name)
-        : AstNode(fl), m_name(name), m_packagep(packagep) {}
+        : ASTGEN_SUPER(fl), m_name(name), m_packagep(packagep) {}
     ASTNODE_NODE_FUNCS(PackageImport)
     virtual const char* broken() const { BROKEN_RTN(!m_packagep || !m_packagep->brokeExists()); return NULL; }
     virtual void cloneRelink() { if (m_packagep && m_packagep->clonep()) m_packagep = m_packagep->clonep(); }
@@ -2035,7 +2039,7 @@ class AstIface : public AstNodeModule {
     // A module declaration
 public:
     AstIface(FileLine* fl, const string& name)
-        : AstNodeModule(fl, name) { }
+        : ASTGEN_SUPER(fl, name) { }
     ASTNODE_NODE_FUNCS(Iface)
 };
 
@@ -2048,14 +2052,14 @@ private:
     AstVar* m_varp;  // Post link, variable within class that is target of selection
 public:
     AstMemberSel(FileLine* fl, AstNode* fromp, VFlagChildDType, const string& name)
-        : AstNodeMath(fl)
+        : ASTGEN_SUPER(fl)
         , m_name(name)
         , m_varp(NULL) {
         setOp1p(fromp);
         dtypep(NULL);  // V3Width will resolve
     }
     AstMemberSel(FileLine* fl, AstNode* fromp, AstNodeDType* dtp)
-        : AstNodeMath(fl)
+        : ASTGEN_SUPER(fl)
         , m_name(dtp->name())
         , m_varp(NULL) {
         setOp1p(fromp);
@@ -2092,7 +2096,7 @@ private:
     AstNodeFTask* m_ftaskp;     // Link to the function
 public:
     AstModportFTaskRef(FileLine* fl, const string& name, bool isExport)
-        : AstNode(fl), m_name(name), m_export(isExport), m_ftaskp(NULL) { }
+        : ASTGEN_SUPER(fl), m_name(name), m_export(isExport), m_ftaskp(NULL) { }
     ASTNODE_NODE_FUNCS(ModportFTaskRef)
     virtual const char* broken() const { BROKEN_RTN(m_ftaskp && !m_ftaskp->brokeExists()); return NULL; }
     virtual void dump(std::ostream& str) const;
@@ -2114,7 +2118,7 @@ private:
     AstVar*     m_varp;         // Link to the actual Var
 public:
     AstModportVarRef(FileLine* fl, const string& name, VDirection::en direction)
-        : AstNode(fl), m_name(name), m_direction(direction), m_varp(NULL) { }
+        : ASTGEN_SUPER(fl), m_name(name), m_direction(direction), m_varp(NULL) { }
     ASTNODE_NODE_FUNCS(ModportVarRef)
     virtual const char* broken() const { BROKEN_RTN(m_varp && !m_varp->brokeExists()); return NULL; }
     virtual void dump(std::ostream& str) const;
@@ -2132,7 +2136,7 @@ private:
     string      m_name;         // Name of the modport
 public:
     AstModport(FileLine* fl, const string& name, AstNode* varsp)
-        : AstNode(fl), m_name(name) {
+        : ASTGEN_SUPER(fl), m_name(name) {
         addNOp1p(varsp); }
     virtual string name() const { return m_name; }
     virtual bool maybePointedTo() const { return true; }
@@ -2146,7 +2150,7 @@ private:
     string m_name;  // Name of the reference
 public:
     AstIntfRef(FileLine* fl, const string& name)
-        : AstNode(fl), m_name(name) { }
+        : ASTGEN_SUPER(fl), m_name(name) { }
     virtual string name() const { return m_name; }
     ASTNODE_NODE_FUNCS(IntfRef)
 };
@@ -2166,7 +2170,7 @@ public:
     AstCell(FileLine* fl, FileLine* mfl,
             const string& instName, const string& modName,
             AstPin* pinsp, AstPin* paramsp, AstRange* rangep)
-        : AstNode(fl)
+        : ASTGEN_SUPER(fl)
         , m_modNameFileline(mfl)
         , m_name(instName), m_origName(instName), m_modName(modName)
         , m_modp(NULL), m_hasIfaceVar(false), m_recursive(false), m_trace(true) {
@@ -2213,7 +2217,7 @@ private:
     AstScope*   m_scopep;       // The scope that the cell is inlined into
 public:
     AstCellInline(FileLine* fl, const string& name, const string& origModName)
-        : AstNode(fl)
+        : ASTGEN_SUPER(fl)
         , m_name(name), m_origModName(origModName), m_scopep(NULL) {}
     ASTNODE_NODE_FUNCS(CellInline)
     virtual void dump(std::ostream& str) const;
@@ -2233,7 +2237,7 @@ private:
 public:
     AstCellRef(FileLine* fl,
                const string& name, AstNode* cellp, AstNode* exprp)
-        : AstNode(fl)
+        : ASTGEN_SUPER(fl)
         , m_name(name) {
         addNOp1p(cellp); addNOp2p(exprp); }
     ASTNODE_NODE_FUNCS(CellRef)
@@ -2250,7 +2254,7 @@ private:
 public:
     AstCellArrayRef(FileLine* fl,
                     const string& name, AstNode* selectExprp)
-        : AstNode(fl)
+        : ASTGEN_SUPER(fl)
         , m_name(name) {
         addNOp1p(selectExprp); }
     ASTNODE_NODE_FUNCS(CellArrayRef)
@@ -2266,7 +2270,7 @@ private:
 public:
     AstUnlinkedRef(FileLine* fl,
                    AstNode* refp, const string& name, AstNode* crp)
-        : AstNode(fl)
+        : ASTGEN_SUPER(fl)
         , m_name(name) {
         addNOp1p(refp); addNOp2p(crp); }
     ASTNODE_NODE_FUNCS(UnlinkedRef)
@@ -2283,7 +2287,7 @@ private:
     string      m_name;         // Binding to name
 public:
     AstBind(FileLine* fl, const string& name, AstNode* cellsp)
-        : AstNode(fl)
+        : ASTGEN_SUPER(fl)
         , m_name(name) {
         UASSERT_OBJ(VN_IS(cellsp, Cell), cellsp, "Only cells allowed to be bound");
         addNOp1p(cellsp);
@@ -2302,7 +2306,7 @@ private:
     string      m_name;         // Name of pin
 public:
     AstPort(FileLine* fl, int pinnum, const string& name)
-        : AstNode(fl)
+        : ASTGEN_SUPER(fl)
         , m_pinNum(pinnum), m_name(name) {}
     ASTNODE_NODE_FUNCS(Port)
     virtual string name() const { return m_name; }  // * = Port name
@@ -2318,7 +2322,7 @@ class AstGenerate : public AstNode {
     // Children: modItems
 public:
     AstGenerate(FileLine* fileline, AstNode* stmtsp)
-        : AstNode(fileline) {
+        : ASTGEN_SUPER(fileline) {
         addNOp1p(stmtsp);
     }
     ASTNODE_NODE_FUNCS(Generate)
@@ -2339,7 +2343,7 @@ private:
 public:
     AstParseRef(FileLine* fl, VParseRefExp expect, const string& name,
                 AstNode* lhsp, AstNodeFTaskRef* ftaskrefp)
-        : AstNode(fl), m_expect(expect), m_name(name) { setNOp1p(lhsp); setNOp2p(ftaskrefp); }
+        : ASTGEN_SUPER(fl), m_expect(expect), m_name(name) { setNOp1p(lhsp); setNOp2p(ftaskrefp); }
     ASTNODE_NODE_FUNCS(ParseRef)
     virtual void dump(std::ostream& str) const;
     virtual string name() const { return m_name; }  // * = Var name
@@ -2364,7 +2368,7 @@ private:
     AstPackage* m_packagep;     // Package hierarchy
 public:
     AstPackageRef(FileLine* fl, AstPackage* packagep)
-        : AstNode(fl), m_packagep(packagep) {}
+        : ASTGEN_SUPER(fl), m_packagep(packagep) {}
     ASTNODE_NODE_FUNCS(PackageRef)
     // METHODS
     virtual const char* broken() const { BROKEN_RTN(!m_packagep || !m_packagep->brokeExists()); return NULL; }
@@ -2384,7 +2388,7 @@ class AstDot : public AstNode {
     // These are eliminated in the link stage
 public:
     AstDot(FileLine* fl, AstNode* lhsp, AstNode* rhsp)
-        : AstNode(fl) { setOp1p(lhsp); setOp2p(rhsp); }
+        : ASTGEN_SUPER(fl) { setOp1p(lhsp); setOp2p(rhsp); }
     ASTNODE_NODE_FUNCS(Dot)
     static AstNode* newIfPkg(FileLine*fl, AstPackage* packagep, AstNode* rhsp) {  // For parser, make only if non-null package
         if (!packagep) return rhsp;
@@ -2401,7 +2405,7 @@ class AstUnbounded : public AstNode {
     // A $ in the parser, used for unbounded and queues
 public:
     AstUnbounded(FileLine* fl)
-        : AstNode(fl) {}
+        : ASTGEN_SUPER(fl) {}
     ASTNODE_NODE_FUNCS(Unbounded)
     virtual string emitVerilog() { return "$"; }
     virtual string emitC() { V3ERROR_NA; return ""; }
@@ -2413,7 +2417,7 @@ class AstTask : public AstNodeFTask {
     // A task inside a module
 public:
     AstTask(FileLine* fl, const string& name, AstNode* stmtp)
-        : AstNodeFTask(fl, name, stmtp) {}
+        : ASTGEN_SUPER(fl, name, stmtp) {}
     ASTNODE_NODE_FUNCS(Task)
 };
 
@@ -2421,7 +2425,7 @@ class AstFunc : public AstNodeFTask {
     // A function inside a module
 public:
     AstFunc(FileLine* fl, const string& name, AstNode* stmtp, AstNode* fvarsp)
-        : AstNodeFTask(fl, name, stmtp) {
+        : ASTGEN_SUPER(fl, name, stmtp) {
         addNOp1p(fvarsp);
     }
     ASTNODE_NODE_FUNCS(Func)
@@ -2432,11 +2436,11 @@ class AstTaskRef : public AstNodeFTaskRef {
     // A reference to a task
 public:
     AstTaskRef(FileLine* fl, AstParseRef* namep, AstNode* pinsp)
-        : AstNodeFTaskRef(fl, true, namep, pinsp) {
+        : ASTGEN_SUPER(fl, true, namep, pinsp) {
         statement(true);
     }
     AstTaskRef(FileLine* fl, const string& name, AstNode* pinsp)
-        : AstNodeFTaskRef(fl, true, name, pinsp) {}
+        : ASTGEN_SUPER(fl, true, name, pinsp) {}
     ASTNODE_NODE_FUNCS(TaskRef)
 };
 
@@ -2444,9 +2448,9 @@ class AstFuncRef : public AstNodeFTaskRef {
     // A reference to a function
 public:
     AstFuncRef(FileLine* fl, AstParseRef* namep, AstNode* pinsp)
-        : AstNodeFTaskRef(fl, false, namep, pinsp) {}
+        : ASTGEN_SUPER(fl, false, namep, pinsp) {}
     AstFuncRef(FileLine* fl, const string& name, AstNode* pinsp)
-        : AstNodeFTaskRef(fl, false, name, pinsp) {}
+        : ASTGEN_SUPER(fl, false, name, pinsp) {}
     ASTNODE_NODE_FUNCS(FuncRef)
     virtual bool hasDType() const { return true; }
 };
@@ -2460,7 +2464,7 @@ private:
     string      m_cname;        // Name of function on c side
 public:
     AstDpiExport(FileLine* fl, const string& vname, const string& cname)
-        : AstNode(fl), m_name(vname), m_cname(cname) { }
+        : ASTGEN_SUPER(fl), m_name(vname), m_cname(cname) { }
     ASTNODE_NODE_FUNCS(DpiExport)
     virtual string name() const { return m_name; }
     virtual void name(const string& name) { m_name = name; }
@@ -2482,27 +2486,27 @@ public:
     class Settle {};   // for creator type-overload selection
     class Never {};    // for creator type-overload selection
     AstSenItem(FileLine* fl, VEdgeType edgeType, AstNode* varrefp)
-        : AstNodeSenItem(fl), m_edgeType(edgeType) {
+        : ASTGEN_SUPER(fl), m_edgeType(edgeType) {
         setOp1p(varrefp);
     }
     AstSenItem(FileLine* fl, Combo)
-        : AstNodeSenItem(fl) {
+        : ASTGEN_SUPER(fl) {
         m_edgeType = VEdgeType::ET_COMBO;
     }
     AstSenItem(FileLine* fl, Illegal)
-        : AstNodeSenItem(fl) {
+        : ASTGEN_SUPER(fl) {
         m_edgeType = VEdgeType::ET_ILLEGAL;
     }
     AstSenItem(FileLine* fl, Initial)
-        : AstNodeSenItem(fl) {
+        : ASTGEN_SUPER(fl) {
         m_edgeType = VEdgeType::ET_INITIAL;
     }
     AstSenItem(FileLine* fl, Settle)
-        : AstNodeSenItem(fl) {
+        : ASTGEN_SUPER(fl) {
         m_edgeType = VEdgeType::ET_SETTLE;
     }
     AstSenItem(FileLine* fl, Never)
-        : AstNodeSenItem(fl) {
+        : ASTGEN_SUPER(fl) {
         m_edgeType = VEdgeType::ET_NEVER;
     }
     ASTNODE_NODE_FUNCS(SenItem)
@@ -2530,7 +2534,7 @@ class AstSenGate : public AstNodeSenItem {
     // AND as applied to a sensitivity list and a gating expression
     // Performing this gating is optional; it may be removed by later optimizations
 public:
-    AstSenGate(FileLine* fl, AstSenItem* sensesp, AstNode* rhsp) : AstNodeSenItem(fl) {
+    AstSenGate(FileLine* fl, AstSenItem* sensesp, AstNode* rhsp) : ASTGEN_SUPER(fl) {
         dtypeSetLogicBool(); addOp1p(sensesp); setOp2p(rhsp);
     }
     ASTNODE_NODE_FUNCS(SenGate)
@@ -2555,7 +2559,7 @@ private:
     bool m_multi;  // Created from combo logic by ORing multiple clock domains
 public:
     AstSenTree(FileLine* fl, AstNodeSenItem* sensesp)
-        : AstNode(fl), m_multi(false) {
+        : ASTGEN_SUPER(fl), m_multi(false) {
         addNOp1p(sensesp);
     }
     ASTNODE_NODE_FUNCS(SenTree)
@@ -2577,7 +2581,7 @@ class AstAlways : public AstNode {
     VAlwaysKwd m_keyword;
 public:
     AstAlways(FileLine* fl, VAlwaysKwd keyword, AstSenTree* sensesp, AstNode* bodysp)
-        : AstNode(fl), m_keyword(keyword) {
+        : ASTGEN_SUPER(fl), m_keyword(keyword) {
         addNOp1p(sensesp); addNOp2p(bodysp);
     }
     ASTNODE_NODE_FUNCS(Always)
@@ -2596,7 +2600,7 @@ class AstAlwaysPublic : public AstNodeStmt {
     // Body statements are just AstVarRefs to the public signals
 public:
     AstAlwaysPublic(FileLine* fl, AstSenTree* sensesp, AstNode* bodysp)
-        : AstNodeStmt(fl) {
+        : ASTGEN_SUPER(fl) {
         addNOp1p(sensesp); addNOp2p(bodysp);
     }
     ASTNODE_NODE_FUNCS(AlwaysPublic)
@@ -2614,7 +2618,7 @@ class AstAlwaysPost : public AstNode {
     // Like always but post assignments for memory assignment IFs
 public:
     AstAlwaysPost(FileLine* fl, AstSenTree* sensesp, AstNode* bodysp)
-        : AstNode(fl) {
+        : ASTGEN_SUPER(fl) {
         addNOp1p(sensesp); addNOp2p(bodysp);
     }
     ASTNODE_NODE_FUNCS(AlwaysPost)
@@ -2626,7 +2630,7 @@ public:
 class AstAssign : public AstNodeAssign {
 public:
     AstAssign(FileLine* fileline, AstNode* lhsp, AstNode* rhsp)
-        : AstNodeAssign(fileline, lhsp, rhsp) {
+        : ASTGEN_SUPER(fileline, lhsp, rhsp) {
         dtypeFrom(lhsp);
     }
     ASTNODE_NODE_FUNCS(Assign)
@@ -2639,7 +2643,7 @@ class AstAssignAlias : public AstNodeAssign {
     // If both sides are wires, there's no LHS vs RHS,
 public:
     AstAssignAlias(FileLine* fileline, AstVarRef* lhsp, AstVarRef* rhsp)
-        : AstNodeAssign(fileline, lhsp, rhsp) {}
+        : ASTGEN_SUPER(fileline, lhsp, rhsp) {}
     ASTNODE_NODE_FUNCS(AssignAlias)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { V3ERROR_NA; return NULL; }
     virtual bool brokeLhsMustBeLvalue() const { return false; }
@@ -2648,7 +2652,7 @@ public:
 class AstAssignDly : public AstNodeAssign {
 public:
     AstAssignDly(FileLine* fileline, AstNode* lhsp, AstNode* rhsp)
-        : AstNodeAssign(fileline, lhsp, rhsp) {}
+        : ASTGEN_SUPER(fileline, lhsp, rhsp) {}
     ASTNODE_NODE_FUNCS(AssignDly)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstAssignDly(this->fileline(), lhsp, rhsp); }
     virtual bool isGateOptimizable() const { return false; }
@@ -2660,7 +2664,7 @@ class AstAssignW : public AstNodeAssign {
     // Like assign, but wire/assign's in verilog, the only setting of the specified variable
 public:
     AstAssignW(FileLine* fileline, AstNode* lhsp, AstNode* rhsp)
-        : AstNodeAssign(fileline, lhsp, rhsp) { }
+        : ASTGEN_SUPER(fileline, lhsp, rhsp) { }
     ASTNODE_NODE_FUNCS(AssignW)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstAssignW(this->fileline(), lhsp, rhsp); }
     virtual bool brokeLhsMustBeLvalue() const { return true; }
@@ -2678,7 +2682,7 @@ class AstAssignVarScope : public AstNodeAssign {
     // Assign two VarScopes to each other
 public:
     AstAssignVarScope(FileLine* fileline, AstNode* lhsp, AstNode* rhsp)
-        : AstNodeAssign(fileline, lhsp, rhsp) {
+        : ASTGEN_SUPER(fileline, lhsp, rhsp) {
         dtypeFrom(rhsp);
     }
     ASTNODE_NODE_FUNCS(AssignVarScope)
@@ -2691,7 +2695,7 @@ private:
     bool m_direction;
 public:
     AstPull(FileLine* fileline, AstNode* lhsp, bool direction)
-        : AstNode(fileline) {
+        : ASTGEN_SUPER(fileline) {
         setOp1p(lhsp);
         m_direction = direction;
     }
@@ -2707,7 +2711,7 @@ class AstAssignPre : public AstNodeAssign {
     // Like Assign, but predelayed assignment requiring special order handling
 public:
     AstAssignPre(FileLine* fileline, AstNode* lhsp, AstNode* rhsp)
-        : AstNodeAssign(fileline, lhsp, rhsp) {}
+        : ASTGEN_SUPER(fileline, lhsp, rhsp) {}
     ASTNODE_NODE_FUNCS(AssignPre)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstAssignPre(this->fileline(), lhsp, rhsp); }
     virtual bool brokeLhsMustBeLvalue() const { return true; }
@@ -2717,7 +2721,7 @@ class AstAssignPost : public AstNodeAssign {
     // Like Assign, but predelayed assignment requiring special order handling
 public:
     AstAssignPost(FileLine* fileline, AstNode* lhsp, AstNode* rhsp)
-        : AstNodeAssign(fileline, lhsp, rhsp) {}
+        : ASTGEN_SUPER(fileline, lhsp, rhsp) {}
     ASTNODE_NODE_FUNCS(AssignPost)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstAssignPost(this->fileline(), lhsp, rhsp); }
     virtual bool brokeLhsMustBeLvalue() const { return true; }
@@ -2732,7 +2736,7 @@ private:
     string m_name;  // Text of comment
 public:
     AstComment(FileLine* fl, const string& name, bool showAt=false)
-        : AstNodeStmt(fl)
+        : ASTGEN_SUPER(fl)
         , m_showAt(showAt), m_name(name) {}
     ASTNODE_NODE_FUNCS(Comment)
     virtual string name() const { return m_name; }  // * = Text
@@ -2747,7 +2751,7 @@ class AstCond : public AstNodeCond {
     // Children: MATH
 public:
     AstCond(FileLine* fl, AstNode* condp, AstNode* expr1p, AstNode* expr2p)
-        : AstNodeCond(fl, condp, expr1p, expr2p) {}
+        : ASTGEN_SUPER(fl, condp, expr1p, expr2p) {}
     ASTNODE_NODE_FUNCS(Cond)
     virtual AstNode* cloneType(AstNode* condp, AstNode* expr1p, AstNode* expr2p) {
         return new AstCond(this->fileline(), condp, expr1p, expr2p); }
@@ -2759,7 +2763,7 @@ class AstCondBound : public AstNodeCond {
     // Children: MATH
 public:
     AstCondBound(FileLine* fl, AstNode* condp, AstNode* expr1p, AstNode* expr2p)
-        : AstNodeCond(fl, condp, expr1p, expr2p) {}
+        : ASTGEN_SUPER(fl, condp, expr1p, expr2p) {}
     ASTNODE_NODE_FUNCS(CondBound)
     virtual AstNode* cloneType(AstNode* condp, AstNode* expr1p, AstNode* expr2p) {
         return new AstCondBound(this->fileline(), condp, expr1p, expr2p); }
@@ -2778,7 +2782,7 @@ private:
     int         m_binNum;       // Set by V3EmitCSyms to tell final V3Emit what to increment
 public:
     AstCoverDecl(FileLine* fl, int column, const string& page, const string& comment)
-        : AstNodeStmt(fl) {
+        : ASTGEN_SUPER(fl) {
         m_text = comment; m_page = page; m_column = column;
         m_binNum = 0;
         m_dataDeclp = NULL;
@@ -2825,7 +2829,7 @@ private:
     AstCoverDecl* m_declp;  // [After V3Coverage] Pointer to declaration
 public:
     AstCoverInc(FileLine* fl, AstCoverDecl* declp)
-        : AstNodeStmt(fl) {
+        : ASTGEN_SUPER(fl) {
         m_declp = declp;
     }
     ASTNODE_NODE_FUNCS(CoverInc)
@@ -2849,7 +2853,7 @@ class AstCoverToggle : public AstNodeStmt {
     // Children: AstCoverInc, orig var, change det var
 public:
     AstCoverToggle(FileLine* fl, AstCoverInc* incp, AstNode* origp, AstNode* changep)
-        : AstNodeStmt(fl) {
+        : ASTGEN_SUPER(fl) {
         setOp1p(incp);
         setOp2p(origp);
         setOp3p(changep);
@@ -2875,7 +2879,7 @@ class AstGenCase : public AstNodeCase {
     // casesp Children: CASEITEMs
 public:
     AstGenCase(FileLine* fileline, AstNode* exprp, AstNode* casesp)
-        : AstNodeCase(fileline, exprp, casesp) {
+        : ASTGEN_SUPER(fileline, exprp, casesp) {
     }
     ASTNODE_NODE_FUNCS(GenCase)
 };
@@ -2894,7 +2898,7 @@ private:
     bool        m_priorityPragma;       // priority case
 public:
     AstCase(FileLine* fileline, VCaseType casex, AstNode* exprp, AstNode* casesp)
-        : AstNodeCase(fileline, exprp, casesp) {
+        : ASTGEN_SUPER(fileline, exprp, casesp) {
         m_casex = casex;
         m_fullPragma = false; m_parallelPragma = false;
         m_uniquePragma = false; m_unique0Pragma = false; m_priorityPragma = false;
@@ -2929,7 +2933,7 @@ private:
     bool m_ignoreOverlap;  // Default created by assertions; ignore overlaps
 public:
     AstCaseItem(FileLine* fileline, AstNode* condsp, AstNode* bodysp)
-        : AstNode(fileline) {
+        : ASTGEN_SUPER(fileline) {
         addNOp1p(condsp); addNOp2p(bodysp);
         m_ignoreOverlap = false;
     }
@@ -2953,11 +2957,11 @@ class AstSFormatF : public AstNode {
 public:
     class NoFormat {};
     AstSFormatF(FileLine* fl, const string& text, bool hidden, AstNode* exprsp)
-        : AstNode(fl), m_text(text), m_hidden(hidden), m_hasFormat(true) {
+        : ASTGEN_SUPER(fl), m_text(text), m_hidden(hidden), m_hasFormat(true) {
         dtypeSetString();
         addNOp1p(exprsp); addNOp2p(NULL); }
     AstSFormatF(FileLine* fl, NoFormat, AstNode* exprsp)
-        : AstNode(fl), m_text(""), m_hidden(true), m_hasFormat(false) {
+        : ASTGEN_SUPER(fl), m_text(""), m_hidden(true), m_hasFormat(false) {
         dtypeSetString();
         addNOp1p(exprsp); addNOp2p(NULL); }
     ASTNODE_NODE_FUNCS(SFormatF)
@@ -2989,13 +2993,13 @@ private:
     AstDisplayType      m_displayType;
 public:
     AstDisplay(FileLine* fileline, AstDisplayType dispType, const string& text, AstNode* filep, AstNode* exprsp)
-        : AstNodeStmt(fileline) {
+        : ASTGEN_SUPER(fileline) {
         setOp1p(new AstSFormatF(fileline, text, true, exprsp));
         setNOp3p(filep);
         m_displayType = dispType;
     }
     AstDisplay(FileLine* fileline, AstDisplayType dispType, AstNode* filep, AstNode* exprsp)
-        : AstNodeStmt(fileline) {
+        : ASTGEN_SUPER(fileline) {
         setOp1p(new AstSFormatF(fileline, AstSFormatF::NoFormat(), exprsp));
         setNOp3p(filep);
         m_displayType = dispType;
@@ -3030,7 +3034,7 @@ private:
     AstDisplayType m_displayType;
 public:
     AstElabDisplay(FileLine* fileline, AstDisplayType dispType, AstNode* exprsp)
-        : AstNode(fileline) {
+        : ASTGEN_SUPER(fileline) {
         setOp1p(new AstSFormatF(fileline, AstSFormatF::NoFormat(), exprsp));
         m_displayType = dispType;
     }
@@ -3058,7 +3062,7 @@ class AstSFormat : public AstNodeStmt {
     // Children: SFORMATF to generate print string
 public:
     AstSFormat(FileLine* fileline, AstNode* lhsp, const string& text, AstNode* exprsp)
-        : AstNodeStmt(fileline) {
+        : ASTGEN_SUPER(fileline) {
         setOp1p(new AstSFormatF(fileline, text, true, exprsp));
         setOp3p(lhsp);
     }
@@ -3087,7 +3091,7 @@ class AstSysFuncAsTask : public AstNodeStmt {
     // Children: a system function
 public:
     AstSysFuncAsTask(FileLine* fileline, AstNode* exprsp)
-        : AstNodeStmt(fileline) { addNOp1p(exprsp); }
+        : ASTGEN_SUPER(fileline) { addNOp1p(exprsp); }
     ASTNODE_NODE_FUNCS(SysFuncAsTask)
     virtual string verilogKwd() const { return ""; }
     virtual bool isGateOptimizable() const { return true; }
@@ -3106,7 +3110,7 @@ class AstSysIgnore : public AstNodeStmt {
     // Children: varrefs or exprs
 public:
     AstSysIgnore(FileLine* fileline, AstNode* exprsp)
-        : AstNodeStmt(fileline) { addNOp1p(exprsp); }
+        : ASTGEN_SUPER(fileline) { addNOp1p(exprsp); }
     ASTNODE_NODE_FUNCS(SysIgnore)
     virtual string verilogKwd() const { return "$ignored"; }
     virtual bool isGateOptimizable() const { return false; }  // Though deleted before opt
@@ -3123,7 +3127,7 @@ class AstFClose : public AstNodeStmt {
     // Children: file which must be a varref
 public:
     AstFClose(FileLine* fileline, AstNode* filep)
-        : AstNodeStmt(fileline) {
+        : ASTGEN_SUPER(fileline) {
         setNOp2p(filep);
     }
     ASTNODE_NODE_FUNCS(FClose)
@@ -3143,7 +3147,7 @@ class AstFOpen : public AstNodeStmt {
     // Although a system function in IEEE, here a statement which sets the file pointer (MCD)
 public:
     AstFOpen(FileLine* fileline, AstNode* filep, AstNode* filenamep, AstNode* modep)
-        : AstNodeStmt(fileline) {
+        : ASTGEN_SUPER(fileline) {
         setOp1p(filep);
         setOp2p(filenamep);
         setOp3p(modep);
@@ -3167,7 +3171,7 @@ class AstFFlush : public AstNodeStmt {
     // Children: file which must be a varref
 public:
     AstFFlush(FileLine* fileline, AstNode* filep)
-        : AstNodeStmt(fileline) {
+        : ASTGEN_SUPER(fileline) {
         setNOp2p(filep);
     }
     ASTNODE_NODE_FUNCS(FFlush)
@@ -3192,7 +3196,7 @@ class AstFRead : public AstNodeMath {
 public:
     AstFRead(FileLine* fileline, AstNode* memp, AstNode* filep,
              AstNode* startp, AstNode* countp)
-        : AstNodeMath(fileline) {
+        : ASTGEN_SUPER(fileline) {
         setOp1p(memp);
         setOp2p(filep);
         setNOp3p(startp);
@@ -3224,7 +3228,7 @@ class AstFRewind : public AstNodeMath {
     // Children: file which must be a varref
 public:
     AstFRewind(FileLine* fileline, AstNode* filep)
-        : AstNodeMath(fileline) {
+        : ASTGEN_SUPER(fileline) {
         setNOp2p(filep);
     }
     ASTNODE_NODE_FUNCS(FRewind)
@@ -3248,7 +3252,7 @@ class AstFTell : public AstNodeMath {
     // Children: file which must be a varref
 public:
     AstFTell(FileLine* fileline, AstNode* filep)
-        : AstNodeMath(fileline) {
+        : ASTGEN_SUPER(fileline) {
         setNOp2p(filep);
     }
     ASTNODE_NODE_FUNCS(FTell)
@@ -3275,7 +3279,7 @@ class AstFSeek : public AstNodeMath {
 public:
     AstFSeek(FileLine* fileline, AstNode* filep,
              AstNode* offset, AstNode* operation)
-        : AstNodeMath(fileline) {
+        : ASTGEN_SUPER(fileline) {
         setOp2p(filep);
         setNOp3p(offset);
         setNOp4p(operation);
@@ -3307,7 +3311,7 @@ private:
     string      m_text;
 public:
     AstFScanF(FileLine* fileline, const string& text, AstNode* filep, AstNode* exprsp)
-        : AstNodeMath(fileline), m_text(text) {
+        : ASTGEN_SUPER(fileline), m_text(text) {
         addNOp1p(exprsp);
         setNOp2p(filep);
     }
@@ -3340,7 +3344,7 @@ private:
     string      m_text;
 public:
     AstSScanF(FileLine* fileline, const string& text, AstNode* fromp, AstNode* exprsp)
-        : AstNodeMath(fileline), m_text(text) {
+        : ASTGEN_SUPER(fileline), m_text(text) {
         addNOp1p(exprsp);
         setOp2p(fromp);
     }
@@ -3369,10 +3373,10 @@ class AstNodeReadWriteMem : public AstNodeStmt {
 private:
     bool m_isHex;  // readmemh, not readmemb
 public:
-    AstNodeReadWriteMem(FileLine* fileline, bool hex,
+    AstNodeReadWriteMem(AstType t, FileLine* fileline, bool hex,
                         AstNode* filenamep, AstNode* memp,
                         AstNode* lsbp, AstNode* msbp)
-        : AstNodeStmt(fileline), m_isHex(hex) {
+        : AstNodeStmt(t, fileline), m_isHex(hex) {
         setOp1p(filenamep); setOp2p(memp); setNOp3p(lsbp); setNOp4p(msbp);
     }
     virtual bool isGateOptimizable() const { return false; }
@@ -3396,7 +3400,7 @@ class AstReadMem : public AstNodeReadWriteMem {
 public:
     AstReadMem(FileLine* fileline, bool hex,
                AstNode* filenamep, AstNode* memp, AstNode* lsbp, AstNode* msbp)
-        : AstNodeReadWriteMem(fileline, hex, filenamep, memp, lsbp, msbp)
+        : ASTGEN_SUPER(fileline, hex, filenamep, memp, lsbp, msbp)
         { }
     ASTNODE_NODE_FUNCS(ReadMem);
     virtual string verilogKwd() const { return (isHex()?"$readmemh":"$readmemb"); }
@@ -3407,7 +3411,7 @@ class AstWriteMem : public AstNodeReadWriteMem {
 public:
     AstWriteMem(FileLine* fileline,
                 AstNode* filenamep, AstNode* memp, AstNode* lsbp, AstNode* msbp)
-        : AstNodeReadWriteMem(fileline, true, filenamep, memp, lsbp, msbp) { }
+        : ASTGEN_SUPER(fileline, true, filenamep, memp, lsbp, msbp) { }
     ASTNODE_NODE_FUNCS(WriteMem)
     virtual string verilogKwd() const { return (isHex()?"$writememh":"$writememb"); }
     virtual const char* cFuncPrefixp() const { return "VL_WRITEMEM_"; }
@@ -3417,7 +3421,7 @@ class AstSystemT : public AstNodeStmt {
     // $system used as task
 public:
     AstSystemT(FileLine* fileline, AstNode* lhsp)
-        : AstNodeStmt(fileline) {
+        : ASTGEN_SUPER(fileline) {
         setOp1p(lhsp);
     }
     ASTNODE_NODE_FUNCS(SystemT)
@@ -3436,7 +3440,7 @@ class AstSystemF : public AstNodeMath {
     // $system used as function
 public:
     AstSystemF(FileLine* fileline, AstNode* lhsp)
-        : AstNodeMath(fileline) {
+        : ASTGEN_SUPER(fileline) {
         setOp1p(lhsp);
     }
     ASTNODE_NODE_FUNCS(SystemF)
@@ -3459,7 +3463,7 @@ class AstValuePlusArgs : public AstNodeMath {
     // Child: variable to set.  If NULL then this is a $test$plusargs instead of $value$plusargs
 public:
     AstValuePlusArgs(FileLine* fileline, AstNode* searchp, AstNode* outp)
-        : AstNodeMath(fileline) {
+        : ASTGEN_SUPER(fileline) {
         setOp1p(searchp); setOp2p(outp);
     }
     ASTNODE_NODE_FUNCS(ValuePlusArgs)
@@ -3484,7 +3488,7 @@ private:
     string      m_text;
 public:
     AstTestPlusArgs(FileLine* fileline, const string& text)
-        : AstNodeMath(fileline), m_text(text) { }
+        : ASTGEN_SUPER(fileline), m_text(text) { }
     ASTNODE_NODE_FUNCS(TestPlusArgs)
     virtual string name() const { return m_text; }
     virtual string verilogKwd() const { return "$test$plusargs"; }
@@ -3504,7 +3508,7 @@ class AstGenFor : public AstNodeFor {
 public:
     AstGenFor(FileLine* fileline, AstNode* initsp, AstNode* condp,
            AstNode* incsp, AstNode* bodysp)
-        : AstNodeFor(fileline, initsp, condp, incsp, bodysp) {
+        : ASTGEN_SUPER(fileline, initsp, condp, incsp, bodysp) {
     }
     ASTNODE_NODE_FUNCS(GenFor)
 };
@@ -3513,7 +3517,7 @@ class AstForeach : public AstNodeStmt {
 public:
     AstForeach(FileLine* fileline, AstNode* arrayp, AstNode* varsp,
                AstNode* bodysp)
-        : AstNodeStmt(fileline) {
+        : ASTGEN_SUPER(fileline) {
         setOp1p(arrayp); addNOp2p(varsp); addNOp4p(bodysp);
     }
     ASTNODE_NODE_FUNCS(Foreach)
@@ -3529,7 +3533,7 @@ public:
 class AstRepeat : public AstNodeStmt {
 public:
     AstRepeat(FileLine* fileline, AstNode* countp, AstNode* bodysp)
-        : AstNodeStmt(fileline) {
+        : ASTGEN_SUPER(fileline) {
         setOp2p(countp); addNOp3p(bodysp);
     }
     ASTNODE_NODE_FUNCS(Repeat)
@@ -3544,7 +3548,7 @@ public:
 class AstWhile : public AstNodeStmt {
 public:
     AstWhile(FileLine* fileline, AstNode* condp, AstNode* bodysp, AstNode* incsp=NULL)
-        : AstNodeStmt(fileline) {
+        : ASTGEN_SUPER(fileline) {
         setOp2p(condp); addNOp3p(bodysp); addNOp4p(incsp);
     }
     ASTNODE_NODE_FUNCS(While)
@@ -3566,7 +3570,7 @@ public:
 class AstBreak : public AstNodeStmt {
 public:
     explicit AstBreak(FileLine* fileline)
-        : AstNodeStmt(fileline) {}
+        : ASTGEN_SUPER(fileline) {}
     ASTNODE_NODE_FUNCS(Break)
     virtual string verilogKwd() const { return "break"; }
     virtual V3Hash sameHash() const { return V3Hash(); }
@@ -3576,7 +3580,7 @@ public:
 class AstContinue : public AstNodeStmt {
 public:
     explicit AstContinue(FileLine* fileline)
-        : AstNodeStmt(fileline) {}
+        : ASTGEN_SUPER(fileline) {}
     ASTNODE_NODE_FUNCS(Continue)
     virtual string verilogKwd() const { return "continue"; }
     virtual V3Hash sameHash() const { return V3Hash(); }
@@ -3588,7 +3592,7 @@ private:
     string m_name;  // Name of block
 public:
     AstDisable(FileLine* fileline, const string& name)
-        : AstNodeStmt(fileline), m_name(name) {}
+        : ASTGEN_SUPER(fileline), m_name(name) {}
     ASTNODE_NODE_FUNCS(Disable)
     virtual string name() const { return m_name; }  // * = Block name
     void name(const string& flag) { m_name = flag; }
@@ -3598,7 +3602,7 @@ public:
 class AstReturn : public AstNodeStmt {
 public:
     AstReturn(FileLine* fileline, AstNode* lhsp=NULL)
-        : AstNodeStmt(fileline) {
+        : ASTGEN_SUPER(fileline) {
         setNOp1p(lhsp);
     }
     ASTNODE_NODE_FUNCS(Return)
@@ -3611,7 +3615,7 @@ public:
 class AstGenIf : public AstNodeIf {
 public:
     AstGenIf(FileLine* fileline, AstNode* condp, AstNode* ifsp, AstNode* elsesp)
-        : AstNodeIf(fileline, condp, ifsp, elsesp) {
+        : ASTGEN_SUPER(fileline, condp, ifsp, elsesp) {
     }
     ASTNODE_NODE_FUNCS(GenIf)
 };
@@ -3623,7 +3627,7 @@ private:
     bool        m_priorityPragma;       // priority case
 public:
     AstIf(FileLine* fileline, AstNode* condp, AstNode* ifsp, AstNode* elsesp=NULL)
-        : AstNodeIf(fileline, condp, ifsp, elsesp) {
+        : ASTGEN_SUPER(fileline, condp, ifsp, elsesp) {
         m_uniquePragma = false; m_unique0Pragma = false; m_priorityPragma = false;
     }
     ASTNODE_NODE_FUNCS(If)
@@ -3644,7 +3648,7 @@ private:
     int m_labelNum;  // Set by V3EmitCSyms to tell final V3Emit what to increment
 public:
     AstJumpLabel(FileLine* fl, AstNode* stmtsp)
-        : AstNodeStmt(fl), m_labelNum(0) {
+        : ASTGEN_SUPER(fl), m_labelNum(0) {
         addNOp1p(stmtsp);
     }
     virtual int instrCount() const { return 0; }
@@ -3666,7 +3670,7 @@ private:
     AstJumpLabel* m_labelp;  // [After V3Jump] Pointer to declaration
 public:
     AstJumpGo(FileLine* fl, AstJumpLabel* labelp)
-        : AstNodeStmt(fl) {
+        : ASTGEN_SUPER(fl) {
         m_labelp = labelp;
     }
     ASTNODE_NODE_FUNCS(JumpGo)
@@ -3689,7 +3693,7 @@ class AstChangeXor : public AstNodeBiComAsv {
     // Children: VARREF
 public:
     AstChangeXor(FileLine* fl, AstNode* lhsp, AstNode* rhsp)
-        : AstNodeBiComAsv(fl, lhsp, rhsp) {
+        : ASTGEN_SUPER(fl, lhsp, rhsp) {
         dtypeSetUInt32();  // Always used on, and returns word entities
     }
     ASTNODE_NODE_FUNCS(ChangeXor)
@@ -3713,7 +3717,7 @@ private:
 public:
     // Null lhs+rhs used to indicate change needed with no spec vars
     AstChangeDet(FileLine* fl, AstNode* lhsp, AstNode* rhsp, bool clockReq)
-        : AstNodeStmt(fl) {
+        : ASTGEN_SUPER(fl) {
         setNOp1p(lhsp); setNOp2p(rhsp); m_clockReq = clockReq;
     }
     ASTNODE_NODE_FUNCS(ChangeDet)
@@ -3738,7 +3742,7 @@ private:
 public:
     // Node that simply puts name into the output stream
     AstBegin(FileLine* fileline, const string& name, AstNode* stmtsp, bool generate=false)
-        : AstNode(fileline)
+        : ASTGEN_SUPER(fileline)
         , m_name(name) {
         addNOp1p(stmtsp);
         m_unnamed = (name=="");
@@ -3762,7 +3766,7 @@ public:
 class AstInitial : public AstNode {
 public:
     AstInitial(FileLine* fl, AstNode* bodysp)
-        : AstNode(fl) {
+        : ASTGEN_SUPER(fl) {
         addNOp1p(bodysp);
     }
     ASTNODE_NODE_FUNCS(Initial)
@@ -3774,7 +3778,7 @@ public:
 class AstFinal : public AstNode {
 public:
     AstFinal(FileLine* fl, AstNode* bodysp)
-        : AstNode(fl) {
+        : ASTGEN_SUPER(fl) {
         addNOp1p(bodysp);
     }
     ASTNODE_NODE_FUNCS(Final)
@@ -3784,7 +3788,7 @@ public:
 class AstInside : public AstNodeMath {
 public:
     AstInside(FileLine* fl, AstNode* exprp, AstNode* itemsp)
-        : AstNodeMath(fl) {
+        : ASTGEN_SUPER(fl) {
         addOp1p(exprp); addOp2p(itemsp);
         dtypeSetLogicBool();
     }
@@ -3799,7 +3803,7 @@ public:
 class AstInsideRange : public AstNodeMath {
 public:
     AstInsideRange(FileLine* fl, AstNode* lhsp, AstNode* rhsp)
-        : AstNodeMath(fl) {
+        : ASTGEN_SUPER(fl) {
         addOp1p(lhsp); addOp2p(rhsp);
     }
     ASTNODE_NODE_FUNCS(InsideRange)
@@ -3817,7 +3821,7 @@ class AstInitItem : public AstNode {
 public:
     // Parents: INITARRAY
     AstInitItem(FileLine* fl, AstNode* valuep)
-        : AstNode(fl) { addOp1p(valuep); }
+        : ASTGEN_SUPER(fl) { addOp1p(valuep); }
     ASTNODE_NODE_FUNCS(InitItem)
     virtual bool maybePointedTo() const { return true; }
     virtual bool hasDType() const { return false; }  // See valuep()'s dtype instead
@@ -3839,7 +3843,7 @@ private:
     KeyItemMap m_map;  // Node value for each array index
 public:
     AstInitArray(FileLine* fl, AstNodeArrayDType* newDTypep, AstNode* defaultp)
-        : AstNode(fl) {
+        : ASTGEN_SUPER(fl) {
         dtypep(newDTypep);
         addNOp1p(defaultp);
     }
@@ -3900,7 +3904,7 @@ class AstNew : public AstNodeMath {
     // Children: varref|arraysel, math
 public:
     AstNew(FileLine* fl)
-        : AstNodeMath(fl) {
+        : ASTGEN_SUPER(fl) {
         dtypep(NULL);  // V3Width will resolve
     }
     ASTNODE_NODE_FUNCS(New)
@@ -3921,7 +3925,7 @@ public:
     // Pragmas don't result in any output code, they're just flags that affect
     // other processing in verilator.
     AstPragma(FileLine* fl, AstPragmaType pragType)
-        : AstNode(fl) {
+        : ASTGEN_SUPER(fl) {
         m_pragType = pragType;
     }
     ASTNODE_NODE_FUNCS(Pragma)
@@ -3935,7 +3939,7 @@ public:
 class AstStop : public AstNodeStmt {
 public:
     explicit AstStop(FileLine* fl, bool maybe)
-        : AstNodeStmt(fl) {}
+        : ASTGEN_SUPER(fl) {}
     ASTNODE_NODE_FUNCS(Stop)
     virtual bool isGateOptimizable() const { return false; }
     virtual bool isPredictOptimizable() const { return false; }
@@ -3951,7 +3955,7 @@ public:
 class AstFinish : public AstNodeStmt {
 public:
     explicit AstFinish(FileLine* fl)
-        : AstNodeStmt(fl) {}
+        : ASTGEN_SUPER(fl) {}
     ASTNODE_NODE_FUNCS(Finish)
     virtual bool isGateOptimizable() const { return false; }
     virtual bool isPredictOptimizable() const { return false; }
@@ -3985,7 +3989,7 @@ public:
                  AstNode* valuep,
                  const VNumRange& bitRange, const VNumRange& arrayRange,
                  bool isScoped)
-        : AstNodeStmt(fl)
+        : ASTGEN_SUPER(fl)
         , m_showname(showname), m_bitRange(bitRange), m_arrayRange(arrayRange)
         , m_isScoped(isScoped) {
         dtypeFrom(valuep);
@@ -4024,7 +4028,7 @@ private:
     AstTraceDecl* m_declp;        // [After V3Trace] Pointer to declaration
 public:
     AstTraceInc(FileLine* fl, AstTraceDecl* declp, AstNode* valuep)
-        : AstNodeStmt(fl) {
+        : ASTGEN_SUPER(fl) {
         dtypeFrom(declp);
         m_declp = declp;
         addNOp2p(valuep);
@@ -4059,7 +4063,7 @@ private:
     AstSenTree* m_sensesp;
 public:
     AstActive(FileLine* fileline, const string& name, AstSenTree* sensesp)
-        : AstNode(fileline) {
+        : ASTGEN_SUPER(fileline) {
         m_name = name;  // Copy it
         UASSERT(sensesp, "Sensesp required arg");
         m_sensesp = sensesp;
@@ -4095,7 +4099,7 @@ private:
     AstAttrType m_attrType;  // What sort of extraction
 public:
     AstAttrOf(FileLine* fl, AstAttrType attrtype, AstNode* fromp=NULL, AstNode* dimp=NULL)
-        : AstNode(fl) {
+        : ASTGEN_SUPER(fl) {
         setNOp1p(fromp);
         setNOp2p(dimp);
         m_attrType = attrtype; }
@@ -4116,7 +4120,7 @@ private:
     string scopeNameFormatter(AstText* scopeTextp) const;
     string scopePrettyNameFormatter(AstText* scopeTextp) const;
 public:
-    explicit AstScopeName(FileLine* fl) : AstNodeMath(fl), m_dpiExport(false) {
+    explicit AstScopeName(FileLine* fl) : ASTGEN_SUPER(fl), m_dpiExport(false) {
         dtypeSetUInt64(); }
     ASTNODE_NODE_FUNCS(ScopeName)
     virtual V3Hash sameHash() const { return V3Hash(); }
@@ -4144,7 +4148,7 @@ public:
 class AstUdpTable : public AstNode {
 public:
     AstUdpTable(FileLine* fl, AstNode* bodysp)
-        : AstNode(fl) {
+        : ASTGEN_SUPER(fl) {
         addNOp1p(bodysp);
     }
     ASTNODE_NODE_FUNCS(UdpTable)
@@ -4155,7 +4159,7 @@ class AstUdpTableLine : public AstNode {
     string      m_text;
 public:
     AstUdpTableLine(FileLine* fl, const string& text)
-        : AstNode(fl), m_text(text) {}
+        : ASTGEN_SUPER(fl), m_text(text) {}
     ASTNODE_NODE_FUNCS(UdpTableLine)
     virtual string name() const { return m_text; }
     string text() const { return m_text; }
@@ -4169,9 +4173,9 @@ class AstRand : public AstNodeTermop {
 private:
     bool m_reset;  // Random reset, versus always random
 public:
-    AstRand(FileLine* fl, AstNodeDType* dtp, bool reset) : AstNodeTermop(fl) {
+    AstRand(FileLine* fl, AstNodeDType* dtp, bool reset) : ASTGEN_SUPER(fl) {
         dtypep(dtp); m_reset = reset; }
-    explicit AstRand(FileLine* fl) : AstNodeTermop(fl), m_reset(false) { }
+    explicit AstRand(FileLine* fl) : ASTGEN_SUPER(fl), m_reset(false) { }
     ASTNODE_NODE_FUNCS(Rand)
     virtual string emitVerilog() { return "%f$random"; }
     virtual string emitC() {
@@ -4188,7 +4192,7 @@ public:
 
 class AstTime : public AstNodeTermop {
 public:
-    explicit AstTime(FileLine* fl) : AstNodeTermop(fl) {
+    explicit AstTime(FileLine* fl) : ASTGEN_SUPER(fl) {
         dtypeSetUInt64(); }
     ASTNODE_NODE_FUNCS(Time)
     virtual string emitVerilog() { return "%f$time"; }
@@ -4203,7 +4207,7 @@ public:
 
 class AstTimeD : public AstNodeTermop {
 public:
-    explicit AstTimeD(FileLine* fl) : AstNodeTermop(fl) {
+    explicit AstTimeD(FileLine* fl) : ASTGEN_SUPER(fl) {
         dtypeSetDouble(); }
     ASTNODE_NODE_FUNCS(TimeD)
     virtual string emitVerilog() { return "%f$realtime"; }
@@ -4221,7 +4225,7 @@ class AstUCFunc : public AstNodeMath {
     // Perhaps this should be an AstNodeListop; but there's only one list math right now
 public:
     AstUCFunc(FileLine* fl, AstNode* exprsp)
-        : AstNodeMath(fl) {
+        : ASTGEN_SUPER(fl) {
         addNOp1p(exprsp);
     }
     ASTNODE_NODE_FUNCS(UCFunc)
@@ -4244,7 +4248,7 @@ public:
 
 class AstNegate : public AstNodeUniop {
 public:
-    AstNegate(FileLine* fl, AstNode* lhsp) : AstNodeUniop(fl, lhsp) {
+    AstNegate(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {
         dtypeFrom(lhsp); }
     ASTNODE_NODE_FUNCS(Negate)
     virtual void numberOperate(V3Number& out, const V3Number& lhs) { out.opNegate(lhs); }
@@ -4256,7 +4260,7 @@ public:
 };
 class AstNegateD : public AstNodeUniop {
 public:
-    AstNegateD(FileLine* fl, AstNode* lhsp) : AstNodeUniop(fl, lhsp) {
+    AstNegateD(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {
         dtypeSetDouble(); }
     ASTNODE_NODE_FUNCS(NegateD)
     virtual void numberOperate(V3Number& out, const V3Number& lhs) { out.opNegateD(lhs); }
@@ -4271,7 +4275,7 @@ public:
 };
 class AstRedAnd : public AstNodeUniop {
 public:
-    AstRedAnd(FileLine* fl, AstNode* lhsp) : AstNodeUniop(fl, lhsp) {
+    AstRedAnd(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {
         dtypeSetLogicBool(); }
     ASTNODE_NODE_FUNCS(RedAnd)
     virtual void numberOperate(V3Number& out, const V3Number& lhs) { out.opRedAnd(lhs); }
@@ -4283,7 +4287,7 @@ public:
 };
 class AstRedOr : public AstNodeUniop {
 public:
-    AstRedOr(FileLine* fl, AstNode* lhsp) : AstNodeUniop(fl, lhsp) {
+    AstRedOr(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {
         dtypeSetLogicBool(); }
     ASTNODE_NODE_FUNCS(RedOr)
     virtual void numberOperate(V3Number& out, const V3Number& lhs) { out.opRedOr(lhs); }
@@ -4295,7 +4299,7 @@ public:
 };
 class AstRedXor : public AstNodeUniop {
 public:
-    AstRedXor(FileLine* fl, AstNode* lhsp) : AstNodeUniop(fl, lhsp) {
+    AstRedXor(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {
         dtypeSetLogicBool(); }
     ASTNODE_NODE_FUNCS(RedXor)
     virtual void numberOperate(V3Number& out, const V3Number& lhs) { out.opRedXor(lhs); }
@@ -4310,7 +4314,7 @@ public:
 class AstRedXnor : public AstNodeUniop {
     // AstRedXnors are replaced with AstRedXors in V3Const.
 public:
-    AstRedXnor(FileLine* fl, AstNode* lhsp) : AstNodeUniop(fl, lhsp) {
+    AstRedXnor(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {
         dtypeSetLogicBool(); }
     ASTNODE_NODE_FUNCS(RedXnor)
     virtual void numberOperate(V3Number& out, const V3Number& lhs) { out.opRedXnor(lhs); }
@@ -4325,7 +4329,7 @@ public:
 class AstLenN : public AstNodeUniop {
     // Length of a string
 public:
-    AstLenN(FileLine* fl, AstNode* lhsp) : AstNodeUniop(fl, lhsp) {
+    AstLenN(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {
         dtypeSetSigned32(); }
     ASTNODE_NODE_FUNCS(LenN)
     virtual void numberOperate(V3Number& out, const V3Number& lhs) { out.opLenN(lhs); }
@@ -4337,7 +4341,7 @@ public:
 };
 class AstLogNot : public AstNodeUniop {
 public:
-    AstLogNot(FileLine* fl, AstNode* lhsp) : AstNodeUniop(fl, lhsp) {
+    AstLogNot(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {
         dtypeSetLogicBool(); }
     ASTNODE_NODE_FUNCS(LogNot)
     virtual void numberOperate(V3Number& out, const V3Number& lhs) { out.opLogNot(lhs); }
@@ -4350,7 +4354,7 @@ public:
 };
 class AstNot : public AstNodeUniop {
 public:
-    AstNot(FileLine* fl, AstNode* lhsp) : AstNodeUniop(fl, lhsp) {
+    AstNot(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {
         dtypeFrom(lhsp); }
     ASTNODE_NODE_FUNCS(Not)
     virtual void numberOperate(V3Number& out, const V3Number& lhs) { out.opNot(lhs); }
@@ -4364,8 +4368,8 @@ public:
 class AstExtend : public AstNodeUniop {
     // Expand a value into a wider entity by 0 extension.  Width is implied from nodep->width()
 public:
-    AstExtend(FileLine* fl, AstNode* lhsp) : AstNodeUniop(fl, lhsp) {}
-    AstExtend(FileLine* fl, AstNode* lhsp, int width) : AstNodeUniop(fl, lhsp) {
+    AstExtend(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {}
+    AstExtend(FileLine* fl, AstNode* lhsp, int width) : ASTGEN_SUPER(fl, lhsp) {
         dtypeSetLogicSized(width, AstNumeric::UNSIGNED); }
     ASTNODE_NODE_FUNCS(Extend)
     virtual void numberOperate(V3Number& out, const V3Number& lhs) { out.opAssign(lhs); }
@@ -4379,8 +4383,8 @@ public:
 class AstExtendS : public AstNodeUniop {
     // Expand a value into a wider entity by sign extension.  Width is implied from nodep->width()
 public:
-    AstExtendS(FileLine* fl, AstNode* lhsp) : AstNodeUniop(fl, lhsp) {}
-    AstExtendS(FileLine* fl, AstNode* lhsp, int width) : AstNodeUniop(fl, lhsp) {
+    AstExtendS(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {}
+    AstExtendS(FileLine* fl, AstNode* lhsp, int width) : ASTGEN_SUPER(fl, lhsp) {
         // Important that widthMin be correct, as opExtend requires it after V3Expand
         dtypeSetLogicSized(width, AstNumeric::UNSIGNED); }
     ASTNODE_NODE_FUNCS(ExtendS)
@@ -4398,7 +4402,7 @@ public:
 class AstSigned : public AstNodeUniop {
     // $signed(lhs)
 public:
-    AstSigned(FileLine* fl, AstNode* lhsp) : AstNodeUniop(fl, lhsp) {
+    AstSigned(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {
         UASSERT_OBJ(!v3Global.assertDTypesResolved(), this,
                     "not coded to create after dtypes resolved"); }
     ASTNODE_NODE_FUNCS(Signed)
@@ -4413,7 +4417,7 @@ public:
 class AstUnsigned : public AstNodeUniop {
     // $unsigned(lhs)
 public:
-    AstUnsigned(FileLine* fl, AstNode* lhsp) : AstNodeUniop(fl, lhsp) {
+    AstUnsigned(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {
         UASSERT_OBJ(!v3Global.assertDTypesResolved(), this,
                     "not coded to create after dtypes resolved"); }
     ASTNODE_NODE_FUNCS(Unsigned)
@@ -4428,7 +4432,7 @@ public:
 class AstRToIS : public AstNodeUniop {
     // $rtoi(lhs)
 public:
-    AstRToIS(FileLine* fl, AstNode* lhsp) : AstNodeUniop(fl, lhsp) {
+    AstRToIS(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {
         dtypeSetSigned32(); }
     ASTNODE_NODE_FUNCS(RToIS)
     virtual void numberOperate(V3Number& out, const V3Number& lhs) { out.opRToIS(lhs); }
@@ -4441,7 +4445,7 @@ public:
 };
 class AstRToIRoundS : public AstNodeUniop {
 public:
-    AstRToIRoundS(FileLine* fl, AstNode* lhsp) : AstNodeUniop(fl, lhsp) {
+    AstRToIRoundS(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {
         dtypeSetSigned32(); }
     ASTNODE_NODE_FUNCS(RToIRoundS)
     virtual void numberOperate(V3Number& out, const V3Number& lhs) { out.opRToIRoundS(lhs); }
@@ -4454,7 +4458,7 @@ public:
 };
 class AstIToRD : public AstNodeUniop {
 public:
-    AstIToRD(FileLine* fl, AstNode* lhsp) : AstNodeUniop(fl, lhsp) {
+    AstIToRD(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {
         dtypeSetDouble(); }
     ASTNODE_NODE_FUNCS(IToRD)
     virtual void numberOperate(V3Number& out, const V3Number& lhs) { out.opIToRD(lhs); }
@@ -4467,7 +4471,7 @@ public:
 };
 class AstRealToBits : public AstNodeUniop {
 public:
-    AstRealToBits(FileLine* fl, AstNode* lhsp) : AstNodeUniop(fl, lhsp) {
+    AstRealToBits(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {
         dtypeSetUInt64(); }
     ASTNODE_NODE_FUNCS(RealToBits)
     virtual void numberOperate(V3Number& out, const V3Number& lhs) { out.opRealToBits(lhs); }
@@ -4480,7 +4484,7 @@ public:
 };
 class AstBitsToRealD : public AstNodeUniop {
 public:
-    AstBitsToRealD(FileLine* fl, AstNode* lhsp) : AstNodeUniop(fl, lhsp) {
+    AstBitsToRealD(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {
         dtypeSetDouble(); }
     ASTNODE_NODE_FUNCS(BitsToRealD)
     virtual void numberOperate(V3Number& out, const V3Number& lhs) { out.opBitsToRealD(lhs); }
@@ -4494,7 +4498,7 @@ public:
 
 class AstCLog2 : public AstNodeUniop {
 public:
-    AstCLog2(FileLine* fl, AstNode* lhsp) : AstNodeUniop(fl, lhsp) {}
+    AstCLog2(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {}
     ASTNODE_NODE_FUNCS(CLog2)
     virtual void numberOperate(V3Number& out, const V3Number& lhs) { out.opCLog2(lhs); }
     virtual string emitVerilog() { return "%f$clog2(%l)"; }
@@ -4507,7 +4511,7 @@ public:
 class AstCountOnes : public AstNodeUniop {
     // Number of bits set in vector
 public:
-    AstCountOnes(FileLine* fl, AstNode* lhsp) : AstNodeUniop(fl, lhsp) {}
+    AstCountOnes(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {}
     ASTNODE_NODE_FUNCS(CountOnes)
     virtual void numberOperate(V3Number& out, const V3Number& lhs) { out.opCountOnes(lhs); }
     virtual string emitVerilog() { return "%f$countones(%l)"; }
@@ -4520,7 +4524,7 @@ public:
 class AstIsUnknown : public AstNodeUniop {
     // True if any unknown bits
 public:
-    AstIsUnknown(FileLine* fl, AstNode* lhsp) : AstNodeUniop(fl, lhsp) {
+    AstIsUnknown(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {
         dtypeSetLogicBool(); }
     ASTNODE_NODE_FUNCS(IsUnknown)
     virtual void numberOperate(V3Number& out, const V3Number& lhs) { out.opIsUnknown(lhs); }
@@ -4533,7 +4537,7 @@ public:
 class AstOneHot : public AstNodeUniop {
     // True if only single bit set in vector
 public:
-    AstOneHot(FileLine* fl, AstNode* lhsp) : AstNodeUniop(fl, lhsp) {
+    AstOneHot(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {
         dtypeSetLogicBool(); }
     ASTNODE_NODE_FUNCS(OneHot)
     virtual void numberOperate(V3Number& out, const V3Number& lhs) { out.opOneHot(lhs); }
@@ -4547,7 +4551,7 @@ public:
 class AstOneHot0 : public AstNodeUniop {
     // True if only single bit, or no bits set in vector
 public:
-    AstOneHot0(FileLine* fl, AstNode* lhsp) : AstNodeUniop(fl, lhsp) {
+    AstOneHot0(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {
         dtypeSetLogicBool(); }
     ASTNODE_NODE_FUNCS(OneHot0)
     virtual void numberOperate(V3Number& out, const V3Number& lhs) { out.opOneHot0(lhs); }
@@ -4562,7 +4566,7 @@ public:
 class AstCast : public AstNode {
     // Cast to appropriate data type - note lhsp is value, to match AstTypedef, AstCCast, etc
 public:
-    AstCast(FileLine* fl, AstNode* lhsp, AstNodeDType* dtp) : AstNode(fl) {
+    AstCast(FileLine* fl, AstNode* lhsp, AstNodeDType* dtp) : ASTGEN_SUPER(fl) {
         setOp1p(lhsp); setOp2p(dtp);
         dtypeFrom(dtp);
     }
@@ -4581,7 +4585,7 @@ public:
 class AstCastParse : public AstNode {
     // Cast to appropriate type, where we haven't determined yet what the data type is
 public:
-    AstCastParse(FileLine* fl, AstNode* lhsp, AstNode* dtp) : AstNode(fl) {
+    AstCastParse(FileLine* fl, AstNode* lhsp, AstNode* dtp) : ASTGEN_SUPER(fl) {
         setOp1p(lhsp); setOp2p(dtp);
     }
     ASTNODE_NODE_FUNCS(CastParse)
@@ -4597,7 +4601,7 @@ public:
 class AstCastSize : public AstNode {
     // Cast to specific size; signed/twostate inherited from lower element per IEEE
 public:
-    AstCastSize(FileLine* fl, AstNode* lhsp, AstConst* rhsp) : AstNode(fl) {
+    AstCastSize(FileLine* fl, AstNode* lhsp, AstConst* rhsp) : ASTGEN_SUPER(fl) {
         setOp1p(lhsp); setOp2p(rhsp);
     }
     ASTNODE_NODE_FUNCS(CastSize)
@@ -4616,14 +4620,14 @@ class AstCCast : public AstNodeUniop {
 private:
     int         m_size;
 public:
-    AstCCast(FileLine* fl, AstNode* lhsp, int setwidth, int minwidth=-1) : AstNodeUniop(fl, lhsp) {
+    AstCCast(FileLine* fl, AstNode* lhsp, int setwidth, int minwidth=-1) : ASTGEN_SUPER(fl, lhsp) {
         m_size = setwidth;
         if (setwidth) {
             if (minwidth==-1) minwidth = setwidth;
             dtypeSetLogicUnsized(setwidth, minwidth, AstNumeric::UNSIGNED);
         }
     }
-    AstCCast(FileLine* fl, AstNode* lhsp, AstNode* typeFromp) : AstNodeUniop(fl, lhsp) {
+    AstCCast(FileLine* fl, AstNode* lhsp, AstNode* typeFromp) : ASTGEN_SUPER(fl, lhsp) {
         dtypeFrom(typeFromp);
         m_size = width();
     }
@@ -4645,7 +4649,7 @@ public:
 class AstCvtPackString : public AstNodeUniop {
     // Convert to Verilator Packed String (aka verilog "string")
 public:
-    AstCvtPackString(FileLine* fl, AstNode* lhsp) : AstNodeUniop(fl, lhsp) {
+    AstCvtPackString(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {
         dtypeSetString(); }  // Really, width should be dtypep -> STRING
     ASTNODE_NODE_FUNCS(CvtPackString)
     virtual void numberOperate(V3Number& out, const V3Number& lhs) { V3ERROR_NA; }
@@ -4660,7 +4664,7 @@ public:
 
 class AstFEof : public AstNodeUniop {
 public:
-    AstFEof(FileLine* fl, AstNode* lhsp) : AstNodeUniop(fl, lhsp) {}
+    AstFEof(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {}
     ASTNODE_NODE_FUNCS(FEof)
     virtual void numberOperate(V3Number& out, const V3Number& lhs) { V3ERROR_NA; }
     virtual string emitVerilog() { return "%f$feof(%l)"; }
@@ -4675,7 +4679,7 @@ public:
 
 class AstFGetC : public AstNodeUniop {
 public:
-    AstFGetC(FileLine* fl, AstNode* lhsp) : AstNodeUniop(fl, lhsp) {}
+    AstFGetC(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {}
     ASTNODE_NODE_FUNCS(FGetC)
     virtual void numberOperate(V3Number& out, const V3Number& lhs) { V3ERROR_NA; }
     virtual string emitVerilog() { return "%f$fgetc(%l)"; }
@@ -4692,7 +4696,7 @@ public:
 class AstFUngetC : public AstNodeBiop {
 public:
     AstFUngetC(FileLine* fl, AstNode* lhsp, AstNode* rhsp)
-        : AstNodeBiop(fl, lhsp, rhsp) {}
+        : ASTGEN_SUPER(fl, lhsp, rhsp) {}
     ASTNODE_NODE_FUNCS(FUngetC)
     virtual void numberOperate(V3Number& out, const V3Number& lhs, const V3Number& rhs) { V3ERROR_NA; }
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) {
@@ -4713,8 +4717,8 @@ public:
 
 class AstNodeSystemUniop : public AstNodeUniop {
 public:
-    AstNodeSystemUniop(FileLine* fl, AstNode* lhsp) : AstNodeUniop(fl, lhsp) {
-        dtypeSetDouble(); }
+    AstNodeSystemUniop(AstType t, FileLine* fl, AstNode* lhsp)
+        : AstNodeUniop(t, fl, lhsp) { dtypeSetDouble(); }
     ASTNODE_BASE_FUNCS(NodeSystemUniop)
     virtual bool cleanOut() const { return true; }
     virtual bool cleanLhs() const { return false; }
@@ -4725,7 +4729,7 @@ public:
 
 class AstLogD : public AstNodeSystemUniop {
 public:
-    AstLogD(FileLine* fl, AstNode* lhsp) : AstNodeSystemUniop(fl, lhsp) {}
+    AstLogD(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {}
     ASTNODE_NODE_FUNCS(LogD)
     virtual void numberOperate(V3Number& out, const V3Number& lhs) { out.setDouble(log(lhs.toDouble())); }
     virtual string emitVerilog() { return "%f$ln(%l)"; }
@@ -4733,7 +4737,7 @@ public:
 };
 class AstLog10D : public AstNodeSystemUniop {
 public:
-    AstLog10D(FileLine* fl, AstNode* lhsp) : AstNodeSystemUniop(fl, lhsp) {}
+    AstLog10D(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {}
     ASTNODE_NODE_FUNCS(Log10D)
     virtual void numberOperate(V3Number& out, const V3Number& lhs) { out.setDouble(log10(lhs.toDouble())); }
     virtual string emitVerilog() { return "%f$log10(%l)"; }
@@ -4742,7 +4746,7 @@ public:
 
 class AstExpD : public AstNodeSystemUniop {
 public:
-    AstExpD(FileLine* fl, AstNode* lhsp) : AstNodeSystemUniop(fl, lhsp) {}
+    AstExpD(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {}
     ASTNODE_NODE_FUNCS(ExpD)
     virtual void numberOperate(V3Number& out, const V3Number& lhs) { out.setDouble(exp(lhs.toDouble())); }
     virtual string emitVerilog() { return "%f$exp(%l)"; }
@@ -4751,7 +4755,7 @@ public:
 
 class AstSqrtD : public AstNodeSystemUniop {
 public:
-    AstSqrtD(FileLine* fl, AstNode* lhsp) : AstNodeSystemUniop(fl, lhsp) {}
+    AstSqrtD(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {}
     ASTNODE_NODE_FUNCS(SqrtD)
     virtual void numberOperate(V3Number& out, const V3Number& lhs) { out.setDouble(sqrt(lhs.toDouble())); }
     virtual string emitVerilog() { return "%f$sqrt(%l)"; }
@@ -4760,7 +4764,7 @@ public:
 
 class AstFloorD : public AstNodeSystemUniop {
 public:
-    AstFloorD(FileLine* fl, AstNode* lhsp) : AstNodeSystemUniop(fl, lhsp) {}
+    AstFloorD(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {}
     ASTNODE_NODE_FUNCS(FloorD)
     virtual void numberOperate(V3Number& out, const V3Number& lhs) { out.setDouble(floor(lhs.toDouble())); }
     virtual string emitVerilog() { return "%f$floor(%l)"; }
@@ -4769,7 +4773,7 @@ public:
 
 class AstCeilD : public AstNodeSystemUniop {
 public:
-    AstCeilD(FileLine* fl, AstNode* lhsp) : AstNodeSystemUniop(fl, lhsp) {}
+    AstCeilD(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {}
     ASTNODE_NODE_FUNCS(CeilD)
     virtual void numberOperate(V3Number& out, const V3Number& lhs) { out.setDouble(ceil(lhs.toDouble())); }
     virtual string emitVerilog() { return "%f$ceil(%l)"; }
@@ -4778,7 +4782,7 @@ public:
 
 class AstSinD : public AstNodeSystemUniop {
 public:
-    AstSinD(FileLine* fl, AstNode* lhsp) : AstNodeSystemUniop(fl, lhsp) {}
+    AstSinD(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {}
     ASTNODE_NODE_FUNCS(SinD)
     virtual void numberOperate(V3Number& out, const V3Number& lhs) { out.setDouble(sin(lhs.toDouble())); }
     virtual string emitVerilog() { return "%f$sin(%l)"; }
@@ -4787,7 +4791,7 @@ public:
 
 class AstCosD : public AstNodeSystemUniop {
 public:
-    AstCosD(FileLine* fl, AstNode* lhsp) : AstNodeSystemUniop(fl, lhsp) {}
+    AstCosD(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {}
     ASTNODE_NODE_FUNCS(CosD)
     virtual void numberOperate(V3Number& out, const V3Number& lhs) { out.setDouble(cos(lhs.toDouble())); }
     virtual string emitVerilog() { return "%f$cos(%l)"; }
@@ -4796,7 +4800,7 @@ public:
 
 class AstTanD : public AstNodeSystemUniop {
 public:
-    AstTanD(FileLine* fl, AstNode* lhsp) : AstNodeSystemUniop(fl, lhsp) {}
+    AstTanD(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {}
     ASTNODE_NODE_FUNCS(TanD)
     virtual void numberOperate(V3Number& out, const V3Number& lhs) { out.setDouble(tan(lhs.toDouble())); }
     virtual string emitVerilog() { return "%f$tan(%l)"; }
@@ -4805,7 +4809,7 @@ public:
 
 class AstAsinD : public AstNodeSystemUniop {
 public:
-    AstAsinD(FileLine* fl, AstNode* lhsp) : AstNodeSystemUniop(fl, lhsp) {}
+    AstAsinD(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {}
     ASTNODE_NODE_FUNCS(AsinD)
     virtual void numberOperate(V3Number& out, const V3Number& lhs) { out.setDouble(asin(lhs.toDouble())); }
     virtual string emitVerilog() { return "%f$asin(%l)"; }
@@ -4814,7 +4818,7 @@ public:
 
 class AstAcosD : public AstNodeSystemUniop {
 public:
-    AstAcosD(FileLine* fl, AstNode* lhsp) : AstNodeSystemUniop(fl, lhsp) {}
+    AstAcosD(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {}
     ASTNODE_NODE_FUNCS(AcosD)
     virtual void numberOperate(V3Number& out, const V3Number& lhs) { out.setDouble(acos(lhs.toDouble())); }
     virtual string emitVerilog() { return "%f$acos(%l)"; }
@@ -4823,7 +4827,7 @@ public:
 
 class AstAtanD : public AstNodeSystemUniop {
 public:
-    AstAtanD(FileLine* fl, AstNode* lhsp) : AstNodeSystemUniop(fl, lhsp) {}
+    AstAtanD(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {}
     ASTNODE_NODE_FUNCS(AtanD)
     virtual void numberOperate(V3Number& out, const V3Number& lhs) { out.setDouble(atan(lhs.toDouble())); }
     virtual string emitVerilog() { return "%f$atan(%l)"; }
@@ -4832,7 +4836,7 @@ public:
 
 class AstSinhD : public AstNodeSystemUniop {
 public:
-    AstSinhD(FileLine* fl, AstNode* lhsp) : AstNodeSystemUniop(fl, lhsp) {}
+    AstSinhD(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {}
     ASTNODE_NODE_FUNCS(SinhD)
     virtual void numberOperate(V3Number& out, const V3Number& lhs) { out.setDouble(sinh(lhs.toDouble())); }
     virtual string emitVerilog() { return "%f$sinh(%l)"; }
@@ -4841,7 +4845,7 @@ public:
 
 class AstCoshD : public AstNodeSystemUniop {
 public:
-    AstCoshD(FileLine* fl, AstNode* lhsp) : AstNodeSystemUniop(fl, lhsp) {}
+    AstCoshD(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {}
     ASTNODE_NODE_FUNCS(CoshD)
     virtual void numberOperate(V3Number& out, const V3Number& lhs) { out.setDouble(cosh(lhs.toDouble())); }
     virtual string emitVerilog() { return "%f$cosh(%l)"; }
@@ -4850,7 +4854,7 @@ public:
 
 class AstTanhD : public AstNodeSystemUniop {
 public:
-    AstTanhD(FileLine* fl, AstNode* lhsp) : AstNodeSystemUniop(fl, lhsp) {}
+    AstTanhD(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {}
     ASTNODE_NODE_FUNCS(TanhD)
     virtual void numberOperate(V3Number& out, const V3Number& lhs) { out.setDouble(tanh(lhs.toDouble())); }
     virtual string emitVerilog() { return "%f$tanh(%l)"; }
@@ -4859,7 +4863,7 @@ public:
 
 class AstAsinhD : public AstNodeSystemUniop {
 public:
-    AstAsinhD(FileLine* fl, AstNode* lhsp) : AstNodeSystemUniop(fl, lhsp) {}
+    AstAsinhD(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {}
     ASTNODE_NODE_FUNCS(AsinhD)
     virtual void numberOperate(V3Number& out, const V3Number& lhs) { out.setDouble(asinh(lhs.toDouble())); }
     virtual string emitVerilog() { return "%f$asinh(%l)"; }
@@ -4868,7 +4872,7 @@ public:
 
 class AstAcoshD : public AstNodeSystemUniop {
 public:
-    AstAcoshD(FileLine* fl, AstNode* lhsp) : AstNodeSystemUniop(fl, lhsp) {}
+    AstAcoshD(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {}
     ASTNODE_NODE_FUNCS(AcoshD)
     virtual void numberOperate(V3Number& out, const V3Number& lhs) { out.setDouble(acosh(lhs.toDouble())); }
     virtual string emitVerilog() { return "%f$acosh(%l)"; }
@@ -4877,7 +4881,7 @@ public:
 
 class AstAtanhD : public AstNodeSystemUniop {
 public:
-    AstAtanhD(FileLine* fl, AstNode* lhsp) : AstNodeSystemUniop(fl, lhsp) {}
+    AstAtanhD(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {}
     ASTNODE_NODE_FUNCS(AtanhD)
     virtual void numberOperate(V3Number& out, const V3Number& lhs) { out.setDouble(atanh(lhs.toDouble())); }
     virtual string emitVerilog() { return "%f$atanh(%l)"; }
@@ -4886,7 +4890,7 @@ public:
 class AstToLowerN : public AstNodeUniop {
     // string.tolower()
 public:
-    AstToLowerN(FileLine* fl, AstNode* lhsp) : AstNodeUniop(fl, lhsp) {
+    AstToLowerN(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {
         dtypeSetString(); }
     ASTNODE_NODE_FUNCS(ToLowerN)
     virtual void numberOperate(V3Number& out, const V3Number& lhs) { out.opToLowerN(lhs); }
@@ -4899,7 +4903,7 @@ public:
 class AstToUpperN : public AstNodeUniop {
     // string.toupper()
 public:
-    AstToUpperN(FileLine* fl, AstNode* lhsp) : AstNodeUniop(fl, lhsp) {
+    AstToUpperN(FileLine* fl, AstNode* lhsp) : ASTGEN_SUPER(fl, lhsp) {
         dtypeSetString(); }
     ASTNODE_NODE_FUNCS(ToUpperN)
     virtual void numberOperate(V3Number& out, const V3Number& lhs) { out.opToUpperN(lhs); }
@@ -4918,7 +4922,7 @@ private:
     FmtType m_fmt;  // Operation type
 public:
     AstAtoN(FileLine* fl, AstNode* lhsp, FmtType fmt)
-        : AstNodeUniop(fl, lhsp)
+        : ASTGEN_SUPER(fl, lhsp)
         , m_fmt(fmt) {
         fmt == ATOREAL ? dtypeSetDouble() : dtypeSetSigned32();
     }
@@ -4956,7 +4960,7 @@ public:
 
 class AstLogOr : public AstNodeBiop {
 public:
-    AstLogOr(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : AstNodeBiop(fl, lhsp, rhsp) {
+    AstLogOr(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
         dtypeSetLogicBool(); }
     ASTNODE_NODE_FUNCS(LogOr)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstLogOr(this->fileline(), lhsp, rhsp); }
@@ -4973,7 +4977,7 @@ public:
 };
 class AstLogAnd : public AstNodeBiop {
 public:
-    AstLogAnd(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : AstNodeBiop(fl, lhsp, rhsp) {
+    AstLogAnd(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
         dtypeSetLogicBool(); }
     ASTNODE_NODE_FUNCS(LogAnd)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstLogAnd(this->fileline(), lhsp, rhsp); }
@@ -4990,7 +4994,7 @@ public:
 };
 class AstLogEq : public AstNodeBiCom {
 public:
-    AstLogEq(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : AstNodeBiCom(fl, lhsp, rhsp) {
+    AstLogEq(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
         dtypeSetLogicBool(); }
     ASTNODE_NODE_FUNCS(LogEq)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) {
@@ -5009,7 +5013,7 @@ public:
 };
 class AstLogIf : public AstNodeBiop {
 public:
-    AstLogIf(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : AstNodeBiop(fl, lhsp, rhsp) {
+    AstLogIf(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
         dtypeSetLogicBool(); }
     ASTNODE_NODE_FUNCS(LogIf)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) {
@@ -5028,7 +5032,7 @@ public:
 };
 class AstOr : public AstNodeBiComAsv {
 public:
-    AstOr(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : AstNodeBiComAsv(fl, lhsp, rhsp) {
+    AstOr(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
         dtypeFrom(lhsp); }
     ASTNODE_NODE_FUNCS(Or)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstOr(this->fileline(), lhsp, rhsp); }
@@ -5044,7 +5048,7 @@ public:
 };
 class AstAnd : public AstNodeBiComAsv {
 public:
-    AstAnd(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : AstNodeBiComAsv(fl, lhsp, rhsp) {
+    AstAnd(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
         dtypeFrom(lhsp); }
     ASTNODE_NODE_FUNCS(And)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstAnd(this->fileline(), lhsp, rhsp); }
@@ -5060,7 +5064,7 @@ public:
 };
 class AstXor : public AstNodeBiComAsv {
 public:
-    AstXor(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : AstNodeBiComAsv(fl, lhsp, rhsp) {
+    AstXor(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
         dtypeFrom(lhsp); }
     ASTNODE_NODE_FUNCS(Xor)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstXor(this->fileline(), lhsp, rhsp); }
@@ -5076,7 +5080,7 @@ public:
 };
 class AstXnor : public AstNodeBiComAsv {
 public:
-    AstXnor(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : AstNodeBiComAsv(fl, lhsp, rhsp) {
+    AstXnor(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
         dtypeFrom(lhsp); }
     ASTNODE_NODE_FUNCS(Xnor)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstXnor(this->fileline(), lhsp, rhsp); }
@@ -5092,7 +5096,7 @@ public:
 };
 class AstEq : public AstNodeBiCom {
 public:
-    AstEq(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : AstNodeBiCom(fl, lhsp, rhsp) {
+    AstEq(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
         dtypeSetLogicBool(); }
     ASTNODE_NODE_FUNCS(Eq)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstEq(this->fileline(), lhsp, rhsp); }
@@ -5109,7 +5113,7 @@ public:
 };
 class AstEqD : public AstNodeBiCom {
 public:
-    AstEqD(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : AstNodeBiCom(fl, lhsp, rhsp) {
+    AstEqD(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
         dtypeSetLogicBool(); }
     ASTNODE_NODE_FUNCS(EqD)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstEqD(this->fileline(), lhsp, rhsp); }
@@ -5127,7 +5131,7 @@ public:
 };
 class AstEqN : public AstNodeBiCom {
 public:
-    AstEqN(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : AstNodeBiCom(fl, lhsp, rhsp) {
+    AstEqN(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
         dtypeSetLogicBool(); }
     ASTNODE_NODE_FUNCS(EqN)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstEqN(this->fileline(), lhsp, rhsp); }
@@ -5145,7 +5149,7 @@ public:
 };
 class AstNeq : public AstNodeBiCom {
 public:
-    AstNeq(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : AstNodeBiCom(fl, lhsp, rhsp) {
+    AstNeq(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
         dtypeSetLogicBool(); }
     ASTNODE_NODE_FUNCS(Neq)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstNeq(this->fileline(), lhsp, rhsp); }
@@ -5161,7 +5165,7 @@ public:
 };
 class AstNeqD : public AstNodeBiCom {
 public:
-    AstNeqD(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : AstNodeBiCom(fl, lhsp, rhsp) {
+    AstNeqD(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
         dtypeSetLogicBool(); }
     ASTNODE_NODE_FUNCS(NeqD)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstNeqD(this->fileline(), lhsp, rhsp); }
@@ -5179,7 +5183,7 @@ public:
 };
 class AstNeqN : public AstNodeBiCom {
 public:
-    AstNeqN(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : AstNodeBiCom(fl, lhsp, rhsp) {
+    AstNeqN(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
         dtypeSetLogicBool(); }
     ASTNODE_NODE_FUNCS(NeqN)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstNeqN(this->fileline(), lhsp, rhsp); }
@@ -5197,7 +5201,7 @@ public:
 };
 class AstLt : public AstNodeBiop {
 public:
-    AstLt(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : AstNodeBiop(fl, lhsp, rhsp) {
+    AstLt(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
         dtypeSetLogicBool(); }
     ASTNODE_NODE_FUNCS(Lt)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstLt(this->fileline(), lhsp, rhsp); }
@@ -5213,7 +5217,7 @@ public:
 };
 class AstLtD : public AstNodeBiop {
 public:
-    AstLtD(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : AstNodeBiop(fl, lhsp, rhsp) {
+    AstLtD(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
         dtypeSetLogicBool(); }
     ASTNODE_NODE_FUNCS(LtD)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstLtD(this->fileline(), lhsp, rhsp); }
@@ -5231,7 +5235,7 @@ public:
 };
 class AstLtS : public AstNodeBiop {
 public:
-    AstLtS(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : AstNodeBiop(fl, lhsp, rhsp) {
+    AstLtS(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
         dtypeSetLogicBool(); }
     ASTNODE_NODE_FUNCS(LtS)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstLtS(this->fileline(), lhsp, rhsp); }
@@ -5248,7 +5252,7 @@ public:
 };
 class AstLtN : public AstNodeBiop {
 public:
-    AstLtN(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : AstNodeBiop(fl, lhsp, rhsp) {
+    AstLtN(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
         dtypeSetLogicBool(); }
     ASTNODE_NODE_FUNCS(LtN)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstLtN(this->fileline(), lhsp, rhsp); }
@@ -5266,7 +5270,7 @@ public:
 };
 class AstGt : public AstNodeBiop {
 public:
-    AstGt(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : AstNodeBiop(fl, lhsp, rhsp) {
+    AstGt(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
         dtypeSetLogicBool(); }
     ASTNODE_NODE_FUNCS(Gt)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstGt(this->fileline(), lhsp, rhsp); }
@@ -5282,7 +5286,7 @@ public:
 };
 class AstGtD : public AstNodeBiop {
 public:
-    AstGtD(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : AstNodeBiop(fl, lhsp, rhsp) {
+    AstGtD(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
         dtypeSetLogicBool(); }
     ASTNODE_NODE_FUNCS(GtD)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstGtD(this->fileline(), lhsp, rhsp); }
@@ -5300,7 +5304,7 @@ public:
 };
 class AstGtS : public AstNodeBiop {
 public:
-    AstGtS(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : AstNodeBiop(fl, lhsp, rhsp) {
+    AstGtS(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
         dtypeSetLogicBool(); }
     ASTNODE_NODE_FUNCS(GtS)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstGtS(this->fileline(), lhsp, rhsp); }
@@ -5317,7 +5321,7 @@ public:
 };
 class AstGtN : public AstNodeBiop {
 public:
-    AstGtN(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : AstNodeBiop(fl, lhsp, rhsp) {
+    AstGtN(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
         dtypeSetLogicBool(); }
     ASTNODE_NODE_FUNCS(GtN)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstGtN(this->fileline(), lhsp, rhsp); }
@@ -5335,7 +5339,7 @@ public:
 };
 class AstGte : public AstNodeBiop {
 public:
-    AstGte(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : AstNodeBiop(fl, lhsp, rhsp) {
+    AstGte(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
         dtypeSetLogicBool(); }
     ASTNODE_NODE_FUNCS(Gte)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstGte(this->fileline(), lhsp, rhsp); }
@@ -5352,7 +5356,7 @@ public:
 };
 class AstGteD : public AstNodeBiop {
 public:
-    AstGteD(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : AstNodeBiop(fl, lhsp, rhsp) {
+    AstGteD(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
         dtypeSetLogicBool(); }
     ASTNODE_NODE_FUNCS(GteD)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstGteD(this->fileline(), lhsp, rhsp); }
@@ -5370,7 +5374,7 @@ public:
 };
 class AstGteS : public AstNodeBiop {
 public:
-    AstGteS(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : AstNodeBiop(fl, lhsp, rhsp) {
+    AstGteS(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
         dtypeSetLogicBool(); }
     ASTNODE_NODE_FUNCS(GteS)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstGteS(this->fileline(), lhsp, rhsp); }
@@ -5387,7 +5391,7 @@ public:
 };
 class AstGteN : public AstNodeBiop {
 public:
-    AstGteN(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : AstNodeBiop(fl, lhsp, rhsp) {
+    AstGteN(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
         dtypeSetLogicBool(); }
     ASTNODE_NODE_FUNCS(GteN)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstGteN(this->fileline(), lhsp, rhsp); }
@@ -5405,7 +5409,7 @@ public:
 };
 class AstLte : public AstNodeBiop {
 public:
-    AstLte(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : AstNodeBiop(fl, lhsp, rhsp) {
+    AstLte(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
         dtypeSetLogicBool(); }
     ASTNODE_NODE_FUNCS(Lte)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstLte(this->fileline(), lhsp, rhsp); }
@@ -5422,7 +5426,7 @@ public:
 };
 class AstLteD : public AstNodeBiop {
 public:
-    AstLteD(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : AstNodeBiop(fl, lhsp, rhsp) {
+    AstLteD(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
         dtypeSetLogicBool(); }
     ASTNODE_NODE_FUNCS(LteD)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstLteD(this->fileline(), lhsp, rhsp); }
@@ -5440,7 +5444,7 @@ public:
 };
 class AstLteS : public AstNodeBiop {
 public:
-    AstLteS(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : AstNodeBiop(fl, lhsp, rhsp) {
+    AstLteS(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
         dtypeSetLogicBool(); }
     ASTNODE_NODE_FUNCS(LteS)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstLteS(this->fileline(), lhsp, rhsp); }
@@ -5457,7 +5461,7 @@ public:
 };
 class AstLteN : public AstNodeBiop {
 public:
-    AstLteN(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : AstNodeBiop(fl, lhsp, rhsp) {
+    AstLteN(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
         dtypeSetLogicBool(); }
     ASTNODE_NODE_FUNCS(LteN)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstLteN(this->fileline(), lhsp, rhsp); }
@@ -5476,7 +5480,7 @@ public:
 class AstShiftL : public AstNodeBiop {
 public:
     AstShiftL(FileLine* fl, AstNode* lhsp, AstNode* rhsp, int setwidth=0)
-        : AstNodeBiop(fl, lhsp, rhsp) {
+        : ASTGEN_SUPER(fl, lhsp, rhsp) {
         if (setwidth) { dtypeSetLogicSized(setwidth, AstNumeric::UNSIGNED); }
     }
     ASTNODE_NODE_FUNCS(ShiftL)
@@ -5494,7 +5498,7 @@ public:
 class AstShiftR : public AstNodeBiop {
 public:
     AstShiftR(FileLine* fl, AstNode* lhsp, AstNode* rhsp, int setwidth=0)
-        : AstNodeBiop(fl, lhsp, rhsp) {
+        : ASTGEN_SUPER(fl, lhsp, rhsp) {
         if (setwidth) { dtypeSetLogicSized(setwidth, AstNumeric::UNSIGNED); }
     }
     ASTNODE_NODE_FUNCS(ShiftR)
@@ -5515,7 +5519,7 @@ class AstShiftRS : public AstNodeBiop {
     // Output data type's width determines which bit is used for sign extension
 public:
     AstShiftRS(FileLine* fl, AstNode* lhsp, AstNode* rhsp, int setwidth=0)
-        : AstNodeBiop(fl, lhsp, rhsp) {
+        : ASTGEN_SUPER(fl, lhsp, rhsp) {
         // Important that widthMin be correct, as opExtend requires it after V3Expand
         if (setwidth) { dtypeSetLogicSized(setwidth, AstNumeric::SIGNED); }
     }
@@ -5535,7 +5539,7 @@ public:
 };
 class AstAdd : public AstNodeBiComAsv {
 public:
-    AstAdd(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : AstNodeBiComAsv(fl, lhsp, rhsp) {
+    AstAdd(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
         dtypeFrom(lhsp); }
     ASTNODE_NODE_FUNCS(Add)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstAdd(this->fileline(), lhsp, rhsp); }
@@ -5551,7 +5555,7 @@ public:
 };
 class AstAddD : public AstNodeBiComAsv {
 public:
-    AstAddD(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : AstNodeBiComAsv(fl, lhsp, rhsp) {
+    AstAddD(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
         dtypeSetDouble(); }
     ASTNODE_NODE_FUNCS(AddD)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstAddD(this->fileline(), lhsp, rhsp); }
@@ -5569,7 +5573,7 @@ public:
 };
 class AstSub : public AstNodeBiop {
 public:
-    AstSub(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : AstNodeBiop(fl, lhsp, rhsp) {
+    AstSub(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
         dtypeFrom(lhsp); }
     ASTNODE_NODE_FUNCS(Sub)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstSub(this->fileline(), lhsp, rhsp); }
@@ -5585,7 +5589,7 @@ public:
 };
 class AstSubD : public AstNodeBiop {
 public:
-    AstSubD(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : AstNodeBiop(fl, lhsp, rhsp) {
+    AstSubD(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
         dtypeSetDouble(); }
     ASTNODE_NODE_FUNCS(SubD)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstSubD(this->fileline(), lhsp, rhsp); }
@@ -5603,7 +5607,7 @@ public:
 };
 class AstMul : public AstNodeBiComAsv {
 public:
-    AstMul(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : AstNodeBiComAsv(fl, lhsp, rhsp) {
+    AstMul(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
         dtypeFrom(lhsp); }
     ASTNODE_NODE_FUNCS(Mul)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstMul(this->fileline(), lhsp, rhsp); }
@@ -5620,7 +5624,7 @@ public:
 };
 class AstMulD : public AstNodeBiComAsv {
 public:
-    AstMulD(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : AstNodeBiComAsv(fl, lhsp, rhsp) {
+    AstMulD(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
         dtypeSetDouble(); }
     ASTNODE_NODE_FUNCS(MulD)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstMulD(this->fileline(), lhsp, rhsp); }
@@ -5638,7 +5642,7 @@ public:
 };
 class AstMulS : public AstNodeBiComAsv {
 public:
-    AstMulS(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : AstNodeBiComAsv(fl, lhsp, rhsp) {
+    AstMulS(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
         dtypeFrom(lhsp); }
     ASTNODE_NODE_FUNCS(MulS)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstMulS(this->fileline(), lhsp, rhsp); }
@@ -5656,7 +5660,7 @@ public:
 };
 class AstDiv : public AstNodeBiop {
 public:
-    AstDiv(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : AstNodeBiop(fl, lhsp, rhsp) {
+    AstDiv(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
         dtypeFrom(lhsp); }
     ASTNODE_NODE_FUNCS(Div)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstDiv(this->fileline(), lhsp, rhsp); }
@@ -5672,7 +5676,7 @@ public:
 };
 class AstDivD : public AstNodeBiop {
 public:
-    AstDivD(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : AstNodeBiop(fl, lhsp, rhsp) {
+    AstDivD(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
         dtypeSetDouble(); }
     ASTNODE_NODE_FUNCS(DivD)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstDivD(this->fileline(), lhsp, rhsp); }
@@ -5690,7 +5694,7 @@ public:
 };
 class AstDivS : public AstNodeBiop {
 public:
-    AstDivS(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : AstNodeBiop(fl, lhsp, rhsp) {
+    AstDivS(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
         dtypeFrom(lhsp); }
     ASTNODE_NODE_FUNCS(DivS)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstDivS(this->fileline(), lhsp, rhsp); }
@@ -5707,7 +5711,7 @@ public:
 };
 class AstModDiv : public AstNodeBiop {
 public:
-    AstModDiv(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : AstNodeBiop(fl, lhsp, rhsp) {
+    AstModDiv(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
         dtypeFrom(lhsp); }
     ASTNODE_NODE_FUNCS(ModDiv)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstModDiv(this->fileline(), lhsp, rhsp); }
@@ -5723,7 +5727,7 @@ public:
 };
 class AstModDivS : public AstNodeBiop {
 public:
-    AstModDivS(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : AstNodeBiop(fl, lhsp, rhsp) {
+    AstModDivS(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
         dtypeFrom(lhsp); }
     ASTNODE_NODE_FUNCS(ModDivS)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstModDivS(this->fileline(), lhsp, rhsp); }
@@ -5740,7 +5744,7 @@ public:
 };
 class AstPow : public AstNodeBiop {
 public:
-    AstPow(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : AstNodeBiop(fl, lhsp, rhsp) {
+    AstPow(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
         dtypeFrom(lhsp); }
     ASTNODE_NODE_FUNCS(Pow)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstPow(this->fileline(), lhsp, rhsp); }
@@ -5756,7 +5760,7 @@ public:
 };
 class AstPowD : public AstNodeBiop {
 public:
-    AstPowD(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : AstNodeBiop(fl, lhsp, rhsp) {
+    AstPowD(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
         dtypeSetDouble(); }
     ASTNODE_NODE_FUNCS(PowD)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstPowD(this->fileline(), lhsp, rhsp); }
@@ -5773,7 +5777,7 @@ public:
 };
 class AstPowSU : public AstNodeBiop {
 public:
-    AstPowSU(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : AstNodeBiop(fl, lhsp, rhsp) {
+    AstPowSU(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
         dtypeFrom(lhsp); }
     ASTNODE_NODE_FUNCS(PowSU)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstPowSU(this->fileline(), lhsp, rhsp); }
@@ -5790,7 +5794,7 @@ public:
 };
 class AstPowSS : public AstNodeBiop {
 public:
-    AstPowSS(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : AstNodeBiop(fl, lhsp, rhsp) {
+    AstPowSS(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
         dtypeFrom(lhsp); }
     ASTNODE_NODE_FUNCS(PowSS)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstPowSS(this->fileline(), lhsp, rhsp); }
@@ -5807,7 +5811,7 @@ public:
 };
 class AstPowUS : public AstNodeBiop {
 public:
-    AstPowUS(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : AstNodeBiop(fl, lhsp, rhsp) {
+    AstPowUS(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
         dtypeFrom(lhsp); }
     ASTNODE_NODE_FUNCS(PowUS)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstPowUS(this->fileline(), lhsp, rhsp); }
@@ -5824,7 +5828,7 @@ public:
 };
 class AstEqCase : public AstNodeBiCom {
 public:
-    AstEqCase(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : AstNodeBiCom(fl, lhsp, rhsp) {
+    AstEqCase(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
         dtypeSetLogicBool(); }
     ASTNODE_NODE_FUNCS(EqCase)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstEqCase(this->fileline(), lhsp, rhsp); }
@@ -5840,7 +5844,7 @@ public:
 };
 class AstNeqCase : public AstNodeBiCom {
 public:
-    AstNeqCase(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : AstNodeBiCom(fl, lhsp, rhsp) {
+    AstNeqCase(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
         dtypeSetLogicBool(); }
     ASTNODE_NODE_FUNCS(NeqCase)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstNeqCase(this->fileline(), lhsp, rhsp); }
@@ -5857,7 +5861,7 @@ public:
 class AstEqWild : public AstNodeBiop {
     // Note wildcard operator rhs differs from lhs
 public:
-    AstEqWild(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : AstNodeBiop(fl, lhsp, rhsp) {
+    AstEqWild(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
         dtypeSetLogicBool(); }
     ASTNODE_NODE_FUNCS(EqWild)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstEqWild(this->fileline(), lhsp, rhsp); }
@@ -5874,7 +5878,7 @@ public:
 };
 class AstNeqWild : public AstNodeBiop {
 public:
-    AstNeqWild(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : AstNodeBiop(fl, lhsp, rhsp) {
+    AstNeqWild(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
         dtypeSetLogicBool(); }
     ASTNODE_NODE_FUNCS(NeqWild)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstNeqWild(this->fileline(), lhsp, rhsp); }
@@ -5891,7 +5895,7 @@ public:
 class AstConcat : public AstNodeBiop {
     // If you're looking for {#{}}, see AstReplicate
 public:
-    AstConcat(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : AstNodeBiop(fl, lhsp, rhsp) {
+    AstConcat(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
         if (lhsp->dtypep() && rhsp->dtypep()) {
             dtypeSetLogicSized(lhsp->dtypep()->width()+rhsp->dtypep()->width(),
                                AstNumeric::UNSIGNED);
@@ -5912,7 +5916,7 @@ public:
 class AstConcatN : public AstNodeBiop {
     // String concatenate
 public:
-    AstConcatN(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : AstNodeBiop(fl, lhsp, rhsp) {
+    AstConcatN(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
         dtypeSetString();
     }
     ASTNODE_NODE_FUNCS(ConcatN)
@@ -5942,9 +5946,9 @@ private:
     }
 public:
     AstReplicate(FileLine* fl, AstNode* lhsp, AstNode* rhsp)
-        : AstNodeBiop(fl, lhsp, rhsp) { init(); }
+        : ASTGEN_SUPER(fl, lhsp, rhsp) { init(); }
     AstReplicate(FileLine* fl, AstNode* lhsp, uint32_t repCount)
-        : AstNodeBiop(fl, lhsp, new AstConst(fl, repCount)) { init(); }
+        : ASTGEN_SUPER(fl, lhsp, new AstConst(fl, repCount)) { init(); }
     ASTNODE_NODE_FUNCS(Replicate)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstReplicate(this->fileline(), lhsp, rhsp); }
     virtual void numberOperate(V3Number& out, const V3Number& lhs, const V3Number& rhs) { out.opRepl(lhs, rhs); }
@@ -5963,9 +5967,9 @@ private:
     void init() { dtypeSetString(); }
 public:
     AstReplicateN(FileLine* fl, AstNode* lhsp, AstNode* rhsp)
-        : AstNodeBiop(fl, lhsp, rhsp) { init(); }
+        : ASTGEN_SUPER(fl, lhsp, rhsp) { init(); }
     AstReplicateN(FileLine* fl, AstNode* lhsp, uint32_t repCount)
-        : AstNodeBiop(fl, lhsp, new AstConst(fl, repCount)) { init(); }
+        : ASTGEN_SUPER(fl, lhsp, new AstConst(fl, repCount)) { init(); }
     ASTNODE_NODE_FUNCS(ReplicateN)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstReplicateN(this->fileline(), lhsp, rhsp); }
     virtual void numberOperate(V3Number& out, const V3Number& lhs, const V3Number& rhs) { out.opReplN(lhs, rhs); }
@@ -5982,7 +5986,7 @@ public:
 class AstStreamL : public AstNodeStream {
     // Verilog {rhs{lhs}} - Note rhsp() is the slice size, not the lhsp()
 public:
-    AstStreamL(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : AstNodeStream(fl, lhsp, rhsp) {}
+    AstStreamL(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {}
     ASTNODE_NODE_FUNCS(StreamL)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstStreamL(this->fileline(), lhsp, rhsp); }
     virtual string emitVerilog() { return "%f{ << %r %k{%l} }"; }
@@ -5998,7 +6002,7 @@ public:
 class AstStreamR : public AstNodeStream {
     // Verilog {rhs{lhs}} - Note rhsp() is the slice size, not the lhsp()
 public:
-    AstStreamR(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : AstNodeStream(fl, lhsp, rhsp) {}
+    AstStreamR(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {}
     ASTNODE_NODE_FUNCS(StreamR)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstStreamR(this->fileline(), lhsp, rhsp); }
     virtual string emitVerilog() { return "%f{ >> %r %k{%l} }"; }
@@ -6016,7 +6020,7 @@ class AstBufIf1 : public AstNodeBiop {
     // Note unlike the Verilog bufif1() UDP, this allows any width; each lhsp
     // bit enables respective rhsp bit
 public:
-    AstBufIf1(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : AstNodeBiop(fl, lhsp, rhsp) {
+    AstBufIf1(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
         dtypeFrom(lhsp); }
     ASTNODE_NODE_FUNCS(BufIf1)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstBufIf1(this->fileline(), lhsp, rhsp); }
@@ -6032,7 +6036,7 @@ public:
 };
 class AstFGetS : public AstNodeBiop {
 public:
-    AstFGetS(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : AstNodeBiop(fl, lhsp, rhsp) {}
+    AstFGetS(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {}
     ASTNODE_NODE_FUNCS(FGetS)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstFGetS(this->fileline(), lhsp, rhsp); }
     virtual void numberOperate(V3Number& out, const V3Number& lhs, const V3Number& rhs) { V3ERROR_NA; }
@@ -6050,8 +6054,8 @@ public:
 
 class AstNodeSystemBiop : public AstNodeBiop {
 public:
-    AstNodeSystemBiop(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : AstNodeBiop(fl, lhsp, rhsp) {
-        dtypeSetDouble(); }
+    AstNodeSystemBiop(AstType t, FileLine* fl, AstNode* lhsp, AstNode* rhsp)
+        : AstNodeBiop(t, fl, lhsp, rhsp) { dtypeSetDouble(); }
     virtual bool cleanOut() const { return false; }
     virtual bool cleanLhs() const { return false; }
     virtual bool cleanRhs() const { return false; }
@@ -6063,7 +6067,7 @@ public:
 
 class AstAtan2D : public AstNodeSystemBiop {
 public:
-    AstAtan2D(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : AstNodeSystemBiop(fl, lhsp, rhsp) {}
+    AstAtan2D(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {}
     ASTNODE_NODE_FUNCS(Atan2D)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstAtan2D(this->fileline(), lhsp, rhsp); }
     virtual void numberOperate(V3Number& out, const V3Number& lhs, const V3Number& rhs) {
@@ -6074,7 +6078,7 @@ public:
 
 class AstHypotD : public AstNodeSystemBiop {
 public:
-    AstHypotD(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : AstNodeSystemBiop(fl, lhsp, rhsp) {}
+    AstHypotD(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {}
     ASTNODE_NODE_FUNCS(HypotD)
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstHypotD(this->fileline(), lhsp, rhsp); }
     virtual void numberOperate(V3Number& out, const V3Number& lhs, const V3Number& rhs) {
@@ -6086,7 +6090,7 @@ public:
 class AstPutcN : public AstNodeTriop {
     // Verilog string.putc()
 public:
-    AstPutcN(FileLine* fl, AstNode* lhsp, AstNode* rhsp, AstNode* ths) : AstNodeTriop(fl, lhsp, rhsp, ths) {
+    AstPutcN(FileLine* fl, AstNode* lhsp, AstNode* rhsp, AstNode* ths) : ASTGEN_SUPER(fl, lhsp, rhsp, ths) {
         dtypeSetString();
     }
     ASTNODE_NODE_FUNCS(PutcN)
@@ -6110,7 +6114,7 @@ public:
 class AstGetcN : public AstNodeBiop {
     // Verilog string.getc()
 public:
-    AstGetcN(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : AstNodeBiop(fl, lhsp, rhsp) {
+    AstGetcN(FileLine* fl, AstNode* lhsp, AstNode* rhsp) : ASTGEN_SUPER(fl, lhsp, rhsp) {
         dtypeSetBitSized(8, AstNumeric::UNSIGNED);
     }
     ASTNODE_NODE_FUNCS(GetcN)
@@ -6134,7 +6138,7 @@ public:
 class AstSubstrN : public AstNodeTriop {
     // Verilog string.substr()
 public:
-    AstSubstrN(FileLine* fl, AstNode* lhsp, AstNode* rhsp, AstNode* ths) : AstNodeTriop(fl, lhsp, rhsp, ths) {
+    AstSubstrN(FileLine* fl, AstNode* lhsp, AstNode* rhsp, AstNode* ths) : ASTGEN_SUPER(fl, lhsp, rhsp, ths) {
         dtypeSetString();
     }
     ASTNODE_NODE_FUNCS(SubstrN)
@@ -6161,7 +6165,7 @@ private:
     bool m_ignoreCase;  // True for str.icompare()
 public:
     AstCompareNN(FileLine* fl, AstNode* lhsp, AstNode* rhsp, bool ignoreCase)
-        : AstNodeBiop(fl, lhsp, rhsp)
+        : ASTGEN_SUPER(fl, lhsp, rhsp)
         , m_ignoreCase(ignoreCase) {
         dtypeSetUInt32();
     }
@@ -6192,7 +6196,7 @@ class AstPast : public AstNodeMath {
     // Parents: math
     // Children: expression
 public:
-    AstPast(FileLine* fl, AstNode* exprp, AstNode* ticksp) : AstNodeMath(fl) {
+    AstPast(FileLine* fl, AstNode* exprp, AstNode* ticksp) : ASTGEN_SUPER(fl) {
         addOp1p(exprp);
         addNOp2p(ticksp);
     }
@@ -6216,7 +6220,7 @@ class AstPattern : public AstNodeMath {
     // Parents: AstNodeAssign, AstPattern, ...
     // Children: expression, AstPattern, AstPatReplicate
 public:
-    AstPattern(FileLine* fl, AstNode* itemsp) : AstNodeMath(fl) {
+    AstPattern(FileLine* fl, AstNode* itemsp) : ASTGEN_SUPER(fl) {
         addNOp2p(itemsp);
     }
     ASTNODE_NODE_FUNCS(Pattern)
@@ -6239,7 +6243,7 @@ class AstPatMember : public AstNodeMath {
 private:
     bool        m_default;
 public:
-    AstPatMember(FileLine* fl, AstNode* lhsp, AstNode* keyp, AstNode* repp) : AstNodeMath(fl) {
+    AstPatMember(FileLine* fl, AstNode* lhsp, AstNode* keyp, AstNode* repp) : ASTGEN_SUPER(fl) {
         addOp1p(lhsp), setNOp2p(keyp), setNOp3p(repp); m_default = false; }
     ASTNODE_NODE_FUNCS(PatMember)
     virtual void numberOperate(V3Number& out, const V3Number& lhs, const V3Number& rhs) { V3ERROR_NA; }
@@ -6264,7 +6268,7 @@ class AstClocking : public AstNode {
     // Children: Assertions
 public:
     AstClocking(FileLine* fl, AstNodeSenItem* sensesp, AstNode* bodysp)
-        : AstNode(fl) {
+        : ASTGEN_SUPER(fl) {
         addOp1p(sensesp);
         addNOp2p(bodysp);
     }
@@ -6282,7 +6286,7 @@ class AstPropClocked : public AstNode {
     // Children: SENITEM, Properties
 public:
     AstPropClocked(FileLine* fl, AstNodeSenItem* sensesp, AstNode* disablep, AstNode* propp)
-        : AstNode(fl) {
+        : ASTGEN_SUPER(fl) {
         addNOp1p(sensesp);
         addNOp2p(disablep);
         addOp3p(propp);
@@ -6302,9 +6306,9 @@ private:
     bool m_immediate;  // Immediate assertion/cover
     string m_name;  // Name to report
 public:
-    AstNodeCoverOrAssert(FileLine* fl, AstNode* propp, AstNode* passsp,
+    AstNodeCoverOrAssert(AstType t, FileLine* fl, AstNode* propp, AstNode* passsp,
                          bool immediate, const string& name="")
-        : AstNodeStmt(fl)
+        : AstNodeStmt(t, fl)
         , m_immediate(immediate)
         , m_name(name) {
         addOp1p(propp);
@@ -6328,7 +6332,7 @@ public:
     ASTNODE_NODE_FUNCS(Assert)
     AstAssert(FileLine* fl, AstNode* propp, AstNode* passsp, AstNode* failsp,
               bool immediate, const string& name = "")
-        : AstNodeCoverOrAssert(fl, propp, passsp, immediate, name) {
+        : ASTGEN_SUPER(fl, propp, passsp, immediate, name) {
         addNOp3p(failsp);
     }
     AstNode* failsp() const { return op3p(); }  // op3 = if assertion fails
@@ -6339,7 +6343,7 @@ public:
     ASTNODE_NODE_FUNCS(Cover)
     AstCover(FileLine* fl, AstNode* propp, AstNode* stmtsp,
              bool immediate, const string& name = "")
-        : AstNodeCoverOrAssert(fl, propp, stmtsp, immediate, name) {}
+        : ASTGEN_SUPER(fl, propp, stmtsp, immediate, name) {}
     AstNode* coverincp() const { return op3p(); }  // op3 = coverage node
     void coverincp(AstCoverInc* nodep) { addOp3p(nodep); }  // op3 = coverage node
     virtual bool immediate() const { return false; }
@@ -6349,7 +6353,7 @@ class AstRestrict : public AstNodeCoverOrAssert {
 public:
     ASTNODE_NODE_FUNCS(Restrict)
     AstRestrict(FileLine* fl, AstNode* propp)
-        : AstNodeCoverOrAssert(fl, propp, NULL, false, "") {}
+        : ASTGEN_SUPER(fl, propp, NULL, false, "") {}
 };
 
 //======================================================================
@@ -6359,8 +6363,8 @@ class AstNodeSimpleText : public AstNodeText {
 private:
     bool m_tracking;  // When emit, it's ok to parse the string to do indentation
 public:
-    AstNodeSimpleText(FileLine* fl, const string& textp, bool tracking=false)
-        : AstNodeText(fl, textp), m_tracking(tracking) {}
+    AstNodeSimpleText(AstType t, FileLine* fl, const string& textp, bool tracking=false)
+        : AstNodeText(t, fl, textp), m_tracking(tracking) {}
     ASTNODE_BASE_FUNCS(NodeSimpleText)
     void tracking(bool flag) { m_tracking = flag; }
     bool tracking() const { return m_tracking; }
@@ -6369,7 +6373,7 @@ public:
 class AstText : public AstNodeSimpleText {
 public:
     AstText(FileLine* fl, const string& textp, bool tracking=false)
-        : AstNodeSimpleText(fl, textp, tracking) {}
+        : ASTGEN_SUPER(fl, textp, tracking) {}
     ASTNODE_NODE_FUNCS(Text)
 };
 
@@ -6379,7 +6383,7 @@ private:
 public:
     AstTextBlock(FileLine* fl, const string& textp="", bool tracking=false,
                  bool commas=false)
-        : AstNodeSimpleText(fl, textp, tracking), m_commas(commas) {}
+        : ASTGEN_SUPER(fl, textp, tracking), m_commas(commas) {}
     ASTNODE_NODE_FUNCS(TextBlock)
     void commas(bool flag) { m_commas = flag; }
     bool commas() const { return m_commas; }
@@ -6393,7 +6397,7 @@ public:
 class AstScCtor : public AstNodeText {
 public:
     AstScCtor(FileLine* fl, const string& textp)
-        : AstNodeText(fl, textp) {}
+        : ASTGEN_SUPER(fl, textp) {}
     ASTNODE_NODE_FUNCS(ScCtor)
     virtual bool isPure() const { return false; }  // SPECIAL: User may order w/other sigs
     virtual bool isOutputter() const { return true; }
@@ -6402,7 +6406,7 @@ public:
 class AstScDtor : public AstNodeText {
 public:
     AstScDtor(FileLine* fl, const string& textp)
-        : AstNodeText(fl, textp) {}
+        : ASTGEN_SUPER(fl, textp) {}
     ASTNODE_NODE_FUNCS(ScDtor)
     virtual bool isPure() const { return false; }  // SPECIAL: User may order w/other sigs
     virtual bool isOutputter() const { return true; }
@@ -6411,7 +6415,7 @@ public:
 class AstScHdr : public AstNodeText {
 public:
     AstScHdr(FileLine* fl, const string& textp)
-        : AstNodeText(fl, textp) {}
+        : ASTGEN_SUPER(fl, textp) {}
     ASTNODE_NODE_FUNCS(ScHdr)
     virtual bool isPure() const { return false; }  // SPECIAL: User may order w/other sigs
     virtual bool isOutputter() const { return true; }
@@ -6420,7 +6424,7 @@ public:
 class AstScImp : public AstNodeText {
 public:
     AstScImp(FileLine* fl, const string& textp)
-        : AstNodeText(fl, textp) {}
+        : ASTGEN_SUPER(fl, textp) {}
     ASTNODE_NODE_FUNCS(ScImp)
     virtual bool isPure() const { return false; }  // SPECIAL: User may order w/other sigs
     virtual bool isOutputter() const { return true; }
@@ -6429,7 +6433,7 @@ public:
 class AstScImpHdr : public AstNodeText {
 public:
     AstScImpHdr(FileLine* fl, const string& textp)
-        : AstNodeText(fl, textp) {}
+        : ASTGEN_SUPER(fl, textp) {}
     ASTNODE_NODE_FUNCS(ScImpHdr)
     virtual bool isPure() const { return false; }  // SPECIAL: User may order w/other sigs
     virtual bool isOutputter() const { return true; }
@@ -6438,7 +6442,7 @@ public:
 class AstScInt : public AstNodeText {
 public:
     AstScInt(FileLine* fl, const string& textp)
-        : AstNodeText(fl, textp) {}
+        : ASTGEN_SUPER(fl, textp) {}
     ASTNODE_NODE_FUNCS(ScInt)
     virtual bool isPure() const { return false; }  // SPECIAL: User may order w/other sigs
     virtual bool isOutputter() const { return true; }
@@ -6448,7 +6452,7 @@ class AstUCStmt : public AstNodeStmt {
     // User $c statement
 public:
     AstUCStmt(FileLine* fl, AstNode* exprsp)
-        : AstNodeStmt(fl) {
+        : ASTGEN_SUPER(fl) {
         addNOp1p(exprsp);
     }
     ASTNODE_NODE_FUNCS(UCStmt)
@@ -6471,8 +6475,8 @@ class AstNodeFile : public AstNode {
 private:
     string      m_name;         ///< Filename
 public:
-    AstNodeFile(FileLine* fl, const string& name)
-        : AstNode(fl) {
+    AstNodeFile(AstType t, FileLine* fl, const string& name)
+        : AstNode(t, fl) {
         m_name = name;
     }
     ASTNODE_BASE_FUNCS(NodeFile)
@@ -6491,7 +6495,7 @@ class AstVFile : public AstNodeFile {
     // Parents:  NETLIST
 public:
     AstVFile(FileLine* fl, const string& name)
-        : AstNodeFile(fl, name) { }
+        : ASTGEN_SUPER(fl, name) { }
     ASTNODE_NODE_FUNCS(VFile)
     virtual void dump(std::ostream& str=std::cout) const;
 };
@@ -6508,7 +6512,7 @@ private:
     bool        m_support:1;    ///< Support file (non systemc)
 public:
     AstCFile(FileLine* fl, const string& name)
-        : AstNodeFile(fl, name) {
+        : ASTGEN_SUPER(fl, name) {
         m_slow = false;
         m_source = false;
         m_support = false;
@@ -6552,7 +6556,7 @@ private:
     bool        m_dpiImportWrapper:1;   // Wrapper from dpi import
 public:
     AstCFunc(FileLine* fl, const string& name, AstScope* scopep, const string& rtnType="")
-        : AstNode(fl) {
+        : ASTGEN_SUPER(fl) {
         m_funcType = AstCFuncType::FT_NORMAL;
         m_isStatic = VBoolOrUnknown::BU_UNKNOWN;  // Unknown until see where thisp needed
         m_scopep = scopep;
@@ -6656,13 +6660,13 @@ private:
     string      m_argTypes;
 public:
     AstCCall(FileLine* fl, AstCFunc* funcp, AstNode* argsp=NULL)
-        : AstNodeStmt(fl) {
+        : ASTGEN_SUPER(fl) {
         m_funcp = funcp;
         addNOp1p(argsp);
     }
     AstCCall(AstCCall* oldp, AstCFunc* funcp)  // Replacement form for V3Combine
         // Note this removes old attachments from the oldp
-        : AstNodeStmt(oldp->fileline()) {
+        : ASTGEN_SUPER(oldp->fileline()) {
         m_funcp = funcp;
         m_hiername = oldp->hiername();
         m_argTypes = oldp->argTypes();
@@ -6702,7 +6706,7 @@ class AstCReturn : public AstNodeStmt {
     // Children: Math
 public:
     AstCReturn(FileLine* fl, AstNode* lhsp)
-        : AstNodeStmt(fl) {
+        : ASTGEN_SUPER(fl) {
         setOp1p(lhsp);
     }
     ASTNODE_NODE_FUNCS(CReturn)
@@ -6720,12 +6724,12 @@ private:
 public:
     // Emit C textual math function (like AstUCFunc)
     AstCMath(FileLine* fl, AstNode* exprsp)
-        : AstNodeMath(fl), m_cleanOut(true), m_pure(false) {
+        : ASTGEN_SUPER(fl), m_cleanOut(true), m_pure(false) {
         addOp1p(exprsp);
         dtypeFrom(exprsp);
     }
     AstCMath(FileLine* fl, const string& textStmt, int setwidth, bool cleanOut=true)
-        : AstNodeMath(fl), m_cleanOut(cleanOut) {
+        : ASTGEN_SUPER(fl), m_cleanOut(cleanOut) {
         addNOp1p(new AstText(fl, textStmt, true));
         if (setwidth) { dtypeSetLogicSized(setwidth, AstNumeric::UNSIGNED); }
     }
@@ -6747,7 +6751,7 @@ class AstCReset : public AstNodeStmt {
     // Reset variable at startup
 public:
     AstCReset(FileLine* fl, AstNode* exprsp)
-        : AstNodeStmt(fl) {
+        : ASTGEN_SUPER(fl) {
         addNOp1p(exprsp);
     }
     ASTNODE_NODE_FUNCS(CReset)
@@ -6762,11 +6766,11 @@ class AstCStmt : public AstNodeStmt {
     // Emit C statement
 public:
     AstCStmt(FileLine* fl, AstNode* exprsp)
-        : AstNodeStmt(fl) {
+        : ASTGEN_SUPER(fl) {
         addNOp1p(exprsp);
     }
     AstCStmt(FileLine* fl, const string& textStmt)
-        : AstNodeStmt(fl) {
+        : ASTGEN_SUPER(fl) {
         addNOp1p(new AstText(fl, textStmt, true));
     }
     ASTNODE_NODE_FUNCS(CStmt)
@@ -6784,7 +6788,7 @@ private:
     ExecMTask* m_execMTaskp;
 public:
     explicit AstMTaskBody(FileLine* flp)
-        : AstNode(flp)
+        : ASTGEN_SUPER(flp)
         , m_execMTaskp(NULL) {}
     ASTNODE_NODE_FUNCS(MTaskBody);
     virtual const char* broken() const { BROKEN_RTN(!m_execMTaskp); return NULL; }
@@ -6820,7 +6824,7 @@ class AstSplitPlaceholder : public AstNode {
 public:
     // Dummy node used within V3Split; never exists outside of V3Split.
     explicit AstSplitPlaceholder(FileLine* filelinep)
-        : AstNode(filelinep) {}
+        : ASTGEN_SUPER(filelinep) {}
     ASTNODE_NODE_FUNCS(SplitPlaceholder)
 };
 
@@ -6836,7 +6840,7 @@ class AstTypeTable : public AstNode {
     typedef std::map<VBasicTypeKey,AstBasicDType*> DetailedMap;
     DetailedMap m_detailedMap;
 public:
-    explicit AstTypeTable(FileLine* fl) : AstNode(fl), m_voidp(NULL) {
+    explicit AstTypeTable(FileLine* fl) : ASTGEN_SUPER(fl), m_voidp(NULL) {
         for (int i=0; i<AstBasicDTypeKwd::_ENUM_MAX; ++i) m_basicps[i] = NULL;
     }
     ASTNODE_NODE_FUNCS(TypeTable)
@@ -6868,7 +6872,7 @@ private:
     AstExecGraph* m_execGraphp;  // Execution MTask graph for threads>1 mode
 public:
     AstNetlist()
-        : AstNode(new FileLine(FileLine::builtInFilename()))
+        : ASTGEN_SUPER(new FileLine(FileLine::builtInFilename()))
         , m_typeTablep(NULL)
         , m_dollarUnitPkgp(NULL)
         , m_evalp(NULL)
@@ -6907,5 +6911,7 @@ public:
 };
 
 //######################################################################
+
+#undef ASTGEN_SUPER
 
 #endif  // Guard

--- a/src/astgen
+++ b/src/astgen
@@ -31,7 +31,7 @@ if (! GetOptions(
 read_types("$Opt_I[0]/V3Ast.h");
 read_types("$Opt_I[0]/V3AstNodes.h");
 foreach my $type (sort (keys %Classes)) {
-    # Chekc all leafs are not AstNode* and non-leave are AstNode*
+    # Check all leaves are not AstNode* and non-leaves are AstNode*
     my @children = children_of($type);
     if ($type =~ /^Node/) {
         @children  || die "Error: Final AstNode subclasses must not be named AstNode*: Ast$type"
@@ -50,6 +50,7 @@ if ($opt_classes) {
     write_visitor("V3Ast__gen_visitor.h");
     write_impl("V3Ast__gen_impl.h");
     write_types("V3Ast__gen_types.h");
+    write_header("V3AstNodes__gen.h");
 }
 foreach my $cpt (@Opt_Cpt) {
     Cpt::process(in_filename=>"$Opt_I[0]/${cpt}.cpp", out_filename=>"${cpt}__gen.cpp");
@@ -346,12 +347,43 @@ sub write_types {
     printf $fh "    };\n";
 
     printf $fh "    const char* ascii() const {\n";
-    printf $fh "        const char* const names[_ENUM_END + 1] = {\n";
+    printf $fh "        static const char* const names[_ENUM_END + 1] = {\n";
     write_type_enum($fh, "Node", 0, {}, "concrete-ascii", 3);
     printf $fh "            \"_ENUM_END\"\n";
     printf $fh "        };\n";
     printf $fh "        return names[m_e];\n";
     printf $fh "    };\n";
+    $fh->close();
+}
+
+sub write_header {
+    my $fh = open_file(@_);
+
+    my $type = "None";
+    my $base = "None";
+
+    my $ifile = "$Opt_I[0]/V3AstNodes.h";
+    my $ifh = IO::File->new($ifile) or die "%Error: $! $ifile,";
+
+    while (defined (my $line = $ifh->getline())) {
+        # Drop expanded macro definitions - but keep empty line so compiler
+        # message locations are accurate
+        $line =~ s/^\s*#(define|undef)\s+ASTGEN_.*$//;
+
+        # Track current node type and base class
+        if ($line =~ /^\s*class\s*Ast(\S+)\s*:\s*(public)?\s*(AstNode\S*)/) {
+          $type = $1;
+          $base = $3;
+        }
+
+        # Substitute macros
+        $line =~ s/\bASTGEN_SUPER\s*\(/$base(AstType::at$type, /;
+
+        # Emit the line
+        print $fh $line;
+    }
+
+    $ifh->close();
     $fh->close();
 }
 


### PR DESCRIPTION
Another optimisation for node type testing. This is a little bit more extensive in terms of changes, though they are all very mechanical and are all to V3Ast* files. To avoid having to hand-write boilerplate which uses auto-generated values (AstType::at*), I instead fed V3AstNodes.h through astgen and included the result (V3AstNodes__gen.h) in V3Ast.h. Note that V3AstNodes.h already had a #error at the top when included directly, so no client code should have to care.