### PR TITLE
Tests:resolve self assignment in t_unoptflat_simple_2.v 

### DIFF
--- a/test_regress/t/t_unoptflat_simple_2.v
+++ b/test_regress/t/t_unoptflat_simple_2.v
@@ -14,7 +14,7 @@ module t (/*AUTOARG*/
    wire [2:0] x;
 
    assign x[1:0] = { x[0], clk };
-   assign x[2:1] = { clk, x[1] };
+   assign x[2:1] = x[1:0];
 
    always @(posedge clk or negedge clk) begin
 
@@ -22,7 +22,7 @@ module t (/*AUTOARG*/
       $write("x = %x\n", x);
 `endif
 
-      if (x[1] != 0) begin
+      if (x[2] != 0) begin
          $write("*-* All Finished *-*\n");
          $finish;
       end

--- a/test_regress/t/t_unoptflat_simple_2_bad.out
+++ b/test_regress/t/t_unoptflat_simple_2_bad.out
@@ -6,7 +6,7 @@
                     t/t_unoptflat_simple_2.v:16:      Example path: ASSIGNW
                     t/t_unoptflat_simple_2.v:14:      Example path: t.x
 %Warning-UNOPTFLAT:      Widest candidate vars to split:
-%Warning-UNOPTFLAT:           t/t_unoptflat_simple_2.v:14:  t.x, width 3, fanout 12
+%Warning-UNOPTFLAT:           t/t_unoptflat_simple_2.v:14:  t.x, width 3, fanout 10
 %Warning-UNOPTFLAT:      Most fanned out candidate vars to split:
-%Warning-UNOPTFLAT:           t/t_unoptflat_simple_2.v:14:  t.x, width 3, fanout 12
+%Warning-UNOPTFLAT:           t/t_unoptflat_simple_2.v:14:  t.x, width 3, fanout 10
 %Error: Exiting due to


### PR DESCRIPTION
The original code looks strange in x[2:1].
 x[2] = clk
 x[1] = x[1]     <= self assignment

I'm sorry if I missed the original intention of the test.