### PR TITLE
Support parameter access from arrays of interfaces, #2155.

### DIFF
--- a/Changes
+++ b/Changes
@@ -41,6 +41,8 @@ The contributors that suggested a given feature are shown in []. Thanks!
 
 ****  Fix WIDTH warning on </<= of narrower value, #2141. [agrobman]
 
+****  Support parameter access from arrays of interfaces, #2155. [Todd Strader]
+
 
 * Verilator 4.026 2020-01-11
 

--- a/src/V3LinkDot.cpp
+++ b/src/V3LinkDot.cpp
@@ -2070,11 +2070,21 @@ private:
                         refp->varp(varp);
                         m_ds.m_dotText = "";
                         if (m_ds.m_unresolved && m_ds.m_unlinkedScope) {
-                            newp = new AstUnlinkedRef(nodep->fileline(), VN_CAST(refp, VarXRef),
-                                                      refp->name(),
-                                                      m_ds.m_unlinkedScope->unlinkFrBack());
-                            m_ds.m_unlinkedScope = NULL;
-                            m_ds.m_unresolved = false;
+                            string dotted = refp->dotted();
+                            size_t pos = dotted.find("__BRA__??__KET__");
+                            // Arrays of interfaces all have the same parameters
+                            if (pos != string::npos && varp->isParam()
+                                && VN_IS(m_ds.m_unlinkedScope, CellArrayRef)) {
+                                refp->dotted(dotted.substr(0, pos));
+                                newp = refp;
+                            } else {
+                                newp = new AstUnlinkedRef(nodep->fileline(),
+                                                          VN_CAST(refp, VarXRef),
+                                                          refp->name(),
+                                                          m_ds.m_unlinkedScope->unlinkFrBack());
+                                m_ds.m_unlinkedScope = NULL;
+                                m_ds.m_unresolved = false;
+                           }
                         } else {
                             newp = refp;
                         }

--- a/src/V3Param.cpp
+++ b/src/V3Param.cpp
@@ -355,9 +355,16 @@ private:
                 if (VN_IS(backp, Var)
                     && VN_CAST(backp, Var)->isIfaceRef()
                     && VN_CAST(backp, Var)->childDTypep()
-                    && VN_CAST(VN_CAST(backp, Var)->childDTypep(), IfaceRefDType)) {
+                    && (VN_CAST(VN_CAST(backp, Var)->childDTypep(), IfaceRefDType)
+                        || (VN_CAST(VN_CAST(backp, Var)->childDTypep(), UnpackArrayDType)
+                            && VN_CAST(VN_CAST(backp, Var)->childDTypep()->getChildDTypep(),
+                                       IfaceRefDType)))) {
                     AstIfaceRefDType* ifacerefp
                         = VN_CAST(VN_CAST(backp, Var)->childDTypep(), IfaceRefDType);
+                    if (!ifacerefp) {
+                        ifacerefp = VN_CAST(VN_CAST(backp, Var)->childDTypep()->getChildDTypep(),
+                                            IfaceRefDType);
+                    }
                     // Interfaces passed in on the port map have ifaces
                     if (AstIface* ifacep = ifacerefp->ifacep()) {
                         if (dotted == backp->name()) {

--- a/test_regress/t/t_interface_parameter_access.v
+++ b/test_regress/t/t_interface_parameter_access.v
@@ -34,14 +34,17 @@ module t (/*AUTOARG*/
    input clk;
 
    test_if #( .FOO (identity(5)) ) the_interface ();
+   test_if #( .FOO (identity(7)) ) array_interface [1:0] ();
 
    testmod testmod_i (.clk (clk),
 		      .intf (the_interface),
-                      .intf_no_mp (the_interface)
+                      .intf_no_mp (the_interface),
+                      .intf_array (array_interface)
                       );
 
    localparam THE_TOP_FOO = the_interface.FOO;
    localparam THE_TOP_FOO_BITS = $bits({the_interface.FOO, the_interface.FOO});
+   localparam THE_ARRAY_FOO = array_interface[0].FOO;
 
    initial begin
       if (THE_TOP_FOO != 5) begin
@@ -50,6 +53,10 @@ module t (/*AUTOARG*/
       end
       if (THE_TOP_FOO_BITS != 64) begin
          $display("%%Error: THE_TOP_FOO_BITS = %0d", THE_TOP_FOO_BITS);
+	 $stop;
+      end
+      if (THE_ARRAY_FOO != 7) begin
+         $display("%%Error: THE_ARRAY_FOO = %0d", THE_ARRAY_FOO);
 	 $stop;
       end
    end
@@ -61,11 +68,13 @@ module testmod
   (
    input clk,
    test_if.mp intf,
-   test_if intf_no_mp
+   test_if intf_no_mp,
+   test_if.mp intf_array [1:0]
    );
 
    localparam THE_FOO = intf.FOO;
    localparam THE_OTHER_FOO = intf_no_mp.FOO;
+   localparam THE_ARRAY_FOO = intf_array[0].FOO;
 
    always @(posedge clk) begin
       if (THE_FOO != 5) begin
@@ -76,12 +85,20 @@ module testmod
          $display("%%Error: THE_OTHER_FOO = %0d", THE_OTHER_FOO);
          $stop;
       end
+      if (THE_ARRAY_FOO != 7) begin
+         $display("%%Error: THE_ARRAY_FOO = %0d", THE_ARRAY_FOO);
+         $stop;
+      end
       if (intf.FOO != 5) begin
          $display("%%Error: intf.FOO = %0d", intf.FOO);
 	 $stop;
       end
       if (intf_no_mp.FOO != 5) begin
          $display("%%Error: intf_no_mp.FOO = %0d", intf_no_mp.FOO);
+         $stop;
+      end
+      if (intf_array[0].FOO != 7) begin
+         $display("%%Error: intf_array[0].FOO = %0d", intf_array[0].FOO);
          $stop;
       end
       //      if (i.getFoo() != 5) begin


### PR DESCRIPTION
Fix for #2155.  Also, this works in VCS for reference:
https://www.edaplayground.com/x/4vpu