### PR TITLE
Issue 2169

### DIFF
--- a/Changes
+++ b/Changes
@@ -54,6 +54,8 @@ The contributors that suggested a given feature are shown in []. Thanks!
 
 ****  Fix OpenSolaris issues, #2154. [brancoliticus]
 
+****  Fix gated clocks under --protect-lib, #2169. [Todd Strader]
+
 
 * Verilator 4.026 2020-01-11
 

--- a/src/V3ProtectLib.cpp
+++ b/src/V3ProtectLib.cpp
@@ -353,7 +353,8 @@ class ProtectVisitor : public AstNVisitor {
             nodep->v3error("Unsupported: unpacked arrays with protect-lib on "<<nodep->prettyNameQ());
         }
         if (nodep->direction() == VDirection::INPUT) {
-            if (nodep->isUsedClock()) {
+            if (nodep->isUsedClock()
+                || nodep->attrClocker() == VVarAttrClocker::CLOCKER_YES) {
                 handleClock(nodep);
             } else {
                 handleDataInput(nodep);

--- a/test_regress/t/t_prot_lib.v
+++ b/test_regress/t/t_prot_lib.v
@@ -55,6 +55,8 @@ module t (/*AUTOARG*/
          logic [3:0] [31:0] s4x32_in;
          logic [3:0] [31:0] s4x32_out;
 
+         wire clk_en = crc[0];
+
          secret
            secret (
                    .accum_in,
@@ -77,6 +79,7 @@ module t (/*AUTOARG*/
                    .s129_out,
                    .s4x32_in,
                    .s4x32_out,
+                   .clk_en,
                    .clk);
 
          always @(posedge clk) begin

--- a/test_regress/t/t_prot_lib.v
+++ b/test_regress/t/t_prot_lib.v
@@ -15,16 +15,16 @@ if (cyc > 0 && sig``_in != sig``_out) begin \
        end
 
 module t #(parameter GATED_CLK = 0) (/*AUTOARG*/
-          // Inputs
-          clk
-          );
+				     // Inputs
+				     clk
+				     );
    input clk;
 
    localparam last_cyc =
 `ifdef TEST_BENCHMARK
-        `TEST_BENCHMARK;
+			`TEST_BENCHMARK;
 `else
-        10;
+   10;
 `endif
 
    genvar x;
@@ -55,7 +55,7 @@ module t #(parameter GATED_CLK = 0) (/*AUTOARG*/
          logic [3:0] [31:0] s4x32_in;
          logic [3:0] [31:0] s4x32_out;
 
-         wire clk_en = crc[0];
+         wire 		    clk_en = crc[0];
 
          secret
            secret (
@@ -125,13 +125,13 @@ module t #(parameter GATED_CLK = 0) (/*AUTOARG*/
 
          logic possibly_gated_clk;
          if (GATED_CLK != 0) begin: yes_gated_clock
-             logic clk_en_latch /*verilator clock_enable*/;
-             /* verilator lint_off COMBDLY */
-             always_comb if (clk == '0) clk_en_latch <= clk_en;
-             /* verilator lint_on COMBDLY */
-             assign possibly_gated_clk = clk & clk_en_latch;
+            logic clk_en_latch /*verilator clock_enable*/;
+            /* verilator lint_off COMBDLY */
+            always_comb if (clk == '0) clk_en_latch <= clk_en;
+            /* verilator lint_on COMBDLY */
+            assign possibly_gated_clk = clk & clk_en_latch;
          end else begin: no_gated_clock
-             assign possibly_gated_clk = clk;
+            assign possibly_gated_clk = clk;
          end
 
          always @(posedge possibly_gated_clk) begin

--- a/test_regress/t/t_prot_lib.v
+++ b/test_regress/t/t_prot_lib.v
@@ -15,14 +15,14 @@ if (cyc > 0 && sig``_in != sig``_out) begin \
        end
 
 module t #(parameter GATED_CLK = 0) (/*AUTOARG*/
-				     // Inputs
-				     clk
-				     );
+                                    // Inputs
+                                    clk
+                                    );
    input clk;
 
    localparam last_cyc =
 `ifdef TEST_BENCHMARK
-			`TEST_BENCHMARK;
+                       `TEST_BENCHMARK;
 `else
    10;
 `endif

--- a/test_regress/t/t_prot_lib_clk_gated.pl
+++ b/test_regress/t/t_prot_lib_clk_gated.pl
@@ -1,0 +1,74 @@
+#!/usr/bin/perl
+# Makes the test run with tracing enabled by default, can be overridden
+# with --notrace
+unshift(@ARGV, "--trace");
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2019 by Todd Strader. This program is free software; you can
+# redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+
+scenarios(
+    vlt => 1,
+    xsim => 1,
+    );
+
+$Self->{sim_time} = $Self->{benchmark} * 100 if $Self->{benchmark};
+
+top_filename("t/t_prot_lib.v");
+my $secret_prefix = "secret";
+my $secret_dir = "$Self->{obj_dir}/$secret_prefix";
+mkdir $secret_dir;
+
+while (1) {
+    # Always compile the secret file with Verilator no matter what simulator
+    #   we are testing with
+    run(logfile => "$secret_dir/vlt_compile.log",
+        cmd => ["perl",
+                "$ENV{VERILATOR_ROOT}/bin/verilator",
+                "--prefix",
+                "Vt_prot_lib_secret",
+                "-cc",
+                "-Mdir",
+                $secret_dir,
+                "-GGATED_CLK=1",
+                "--protect-lib",
+                $secret_prefix,
+                "t/t_prot_lib_secret.v"]);
+    last if $Self->{errors};
+
+    run(logfile => "$secret_dir/secret_gcc.log",
+        cmd=>["make",
+              "-C",
+              $secret_dir,
+              "-f",
+              "Vt_prot_lib_secret.mk"]);
+    last if $Self->{errors};
+
+    compile(
+        verilator_flags2 => ["$secret_dir/secret.sv",
+                             "-LDFLAGS",
+                             "'-L$secret_prefix -lsecret -static'"],
+        xsim_flags2 => ["$secret_dir/secret.sv"],
+        );
+
+    execute(
+        check_finished => 1,
+        xsim_run_flags2 => ["--sv_lib",
+                            "$secret_dir/libsecret",
+                            "--dpi_absolute"],
+        );
+
+    if ($Self->{vlt} && $Self->{trace}) {
+        # We can see the ports of the secret module
+        file_grep("$Self->{obj_dir}/simx.vcd", qr/accum_in/);
+        # but we can't see what's inside
+        file_grep_not("$Self->{obj_dir}/simx.vcd", qr/secret_/);
+    }
+
+    ok(1);
+    last;
+}
+1;

--- a/test_regress/t/t_prot_lib_clk_gated.pl
+++ b/test_regress/t/t_prot_lib_clk_gated.pl
@@ -49,6 +49,7 @@ while (1) {
 
     compile(
         verilator_flags2 => ["$secret_dir/secret.sv",
+                             "-GGATED_CLK=1",
                              "-LDFLAGS",
                              "'-L$secret_prefix -lsecret -static'"],
         xsim_flags2 => ["$secret_dir/secret.sv"],

--- a/test_regress/t/t_prot_lib_secret.v
+++ b/test_regress/t/t_prot_lib_secret.v
@@ -2,7 +2,8 @@
 // This file ONLY is placed into the Public Domain, for any use,
 // without warranty, 2019 by Todd Strader.
 
-module secret (
+module secret #(parameter GATED_CLK = 0)
+              (
                input [31:0] 		 accum_in,
                output wire [31:0] 	 accum_out,
                input 			 accum_bypass,
@@ -23,6 +24,7 @@ module secret (
                output logic [128:0] 	 s129_out,
                input [3:0] [31:0] 	 s4x32_in,
                output logic [3:0] [31:0] s4x32_out,
+               input                     clk_en,
                input 			 clk);
 
    logic [31:0] 			 secret_accum_q = 0;
@@ -30,7 +32,8 @@ module secret (
 
    initial $display("created %m");
 
-   always @(posedge clk) begin
+   wire the_clk = GATED_CLK != 0 ? clk & clk_en : clk;
+   always @(posedge the_clk) begin
       secret_accum_q <= secret_accum_q + accum_in + secret_value;
    end
 

--- a/test_regress/t/t_prot_lib_secret.v
+++ b/test_regress/t/t_prot_lib_secret.v
@@ -25,7 +25,7 @@ module secret #(parameter GATED_CLK = 0)
                input [3:0] [31:0] 	 s4x32_in,
                output logic [3:0] [31:0] s4x32_out,
                input                     clk_en,
-               input 			 clk);
+               input 			 clk /*verilator clocker*/);
 
    logic [31:0] 			 secret_accum_q = 0;
    logic [31:0] 			 secret_value = 7;

--- a/test_regress/t/t_prot_lib_secret.v
+++ b/test_regress/t/t_prot_lib_secret.v
@@ -3,45 +3,45 @@
 // without warranty, 2019 by Todd Strader.
 
 module secret #(parameter GATED_CLK = 0)
-              (
-               input [31:0] 		 accum_in,
-               output wire [31:0] 	 accum_out,
-               input 			 accum_bypass,
-               output [31:0] 		 accum_bypass_out,
-               input 			 s1_in,
-               output logic 		 s1_out,
-               input [1:0] 		 s2_in,
-               output logic [1:0] 	 s2_out,
-               input [7:0] 		 s8_in,
-               output logic [7:0] 	 s8_out,
-               input [32:0] 		 s33_in,
-               output logic [32:0] 	 s33_out,
-               input [63:0] 		 s64_in,
-               output logic [63:0] 	 s64_out,
-               input [64:0] 		 s65_in,
-               output logic [64:0] 	 s65_out,
-               input [128:0] 		 s129_in,
-               output logic [128:0] 	 s129_out,
-               input [3:0] [31:0] 	 s4x32_in,
-               output logic [3:0] [31:0] s4x32_out,
-               input                     clk_en,
-               input 			 clk /*verilator clocker*/);
+   (
+    input [31:0] 	      accum_in,
+    output wire [31:0] 	      accum_out,
+    input 		      accum_bypass,
+    output [31:0] 	      accum_bypass_out,
+    input 		      s1_in,
+    output logic 	      s1_out,
+    input [1:0] 	      s2_in,
+    output logic [1:0] 	      s2_out,
+    input [7:0] 	      s8_in,
+    output logic [7:0] 	      s8_out,
+    input [32:0] 	      s33_in,
+    output logic [32:0]       s33_out,
+    input [63:0] 	      s64_in,
+    output logic [63:0]       s64_out,
+    input [64:0] 	      s65_in,
+    output logic [64:0]       s65_out,
+    input [128:0] 	      s129_in,
+    output logic [128:0]      s129_out,
+    input [3:0] [31:0] 	      s4x32_in,
+    output logic [3:0] [31:0] s4x32_out,
+    input 		      clk_en,
+    input 		      clk /*verilator clocker*/);
 
-   logic [31:0] 			 secret_accum_q = 0;
-   logic [31:0] 			 secret_value = 7;
+   logic [31:0] 	      secret_accum_q = 0;
+   logic [31:0] 	      secret_value = 7;
 
    initial $display("created %m");
 
-   logic the_clk;
+   logic 		      the_clk;
    generate
       if (GATED_CLK != 0) begin: yes_gated_clock
-          logic clk_en_latch /*verilator clock_enable*/;
-          /* verilator lint_off COMBDLY */
-          always_comb if (clk == '0) clk_en_latch <= clk_en;
-          /* verilator lint_on COMBDLY */
-          assign the_clk = clk & clk_en_latch;
+         logic clk_en_latch /*verilator clock_enable*/;
+         /* verilator lint_off COMBDLY */
+         always_comb if (clk == '0) clk_en_latch <= clk_en;
+         /* verilator lint_on COMBDLY */
+         assign the_clk = clk & clk_en_latch;
       end else begin: no_gated_clock
-          assign the_clk = clk;
+         assign the_clk = clk;
       end
    endgenerate
 

--- a/test_regress/t/t_prot_lib_secret.v
+++ b/test_regress/t/t_prot_lib_secret.v
@@ -32,7 +32,19 @@ module secret #(parameter GATED_CLK = 0)
 
    initial $display("created %m");
 
-   wire the_clk = GATED_CLK != 0 ? clk & clk_en : clk;
+   logic the_clk;
+   generate
+      if (GATED_CLK != 0) begin: yes_gated_clock
+          logic clk_en_latch /*verilator clock_enable*/;
+          /* verilator lint_off COMBDLY */
+          always_comb if (clk == '0) clk_en_latch <= clk_en;
+          /* verilator lint_on COMBDLY */
+          assign the_clk = clk & clk_en_latch;
+      end else begin: no_gated_clock
+          assign the_clk = clk;
+      end
+   endgenerate
+
    always @(posedge the_clk) begin
       secret_accum_q <= secret_accum_q + accum_in + secret_value;
    end


### PR DESCRIPTION
Fix for #2169.

--protect-lib should treat clocks a clock whether Verilator infers they are clock or the user calls them out.  Also, added a test for clock gating inside the protected module.
