### PR TITLE
WIP: Implement type comparisions

### DIFF
--- a/src/V3Ast.h
+++ b/src/V3Ast.h
@@ -2094,7 +2094,15 @@ public:
     uint32_t arrayUnpackedElements();  // 1, or total multiplication of all dimensions
     static int uniqueNumInc() { return ++s_uniqueNum; }
     const char* charIQWN() const { return (isString() ? "N" : isWide() ? "W" : isQuad() ? "Q" : "I"); }
-    virtual bool matching(const AstNodeDType* typep) const = 0;
+    bool matching(const AstNodeDType* typep) const {
+        if (VN_IS(typep, RefDType)) {
+            // Follow RefDTypes
+            return typep->match(this);
+        } else {
+            return match(typep);
+        }
+    }
+    virtual bool match(const AstNodeDType* typep) const = 0;
 };
 
 class AstNodeUOrStructDType : public AstNodeDType {
@@ -2149,7 +2157,7 @@ public:
     int lsb() const { return 0; }
     int msb() const { return dtypep()->width()-1; }  // Packed classes look like arrays
     VNumRange declRange() const { return VNumRange(msb(), lsb(), false); }
-    virtual bool matching(const AstNodeDType* typep) const { return typep == this; }
+    virtual bool match(const AstNodeDType* typep) const { return typep == this; }
 };
 
 class AstNodeArrayDType : public AstNodeDType {
@@ -2208,7 +2216,7 @@ public:
     int elementsConst() const;
     VNumRange declRange() const;
     virtual bool matchingArrayType(const AstNodeArrayDType* matchp) const = 0;
-    virtual bool matching(const AstNodeDType* typep) const {
+    virtual bool match(const AstNodeDType* typep) const {
         const AstNodeArrayDType* arrayp = VN_CAST_CONST(typep, NodeArrayDType);
         if (!arrayp) return typep->matching(this);
         return arrayp && matchingArrayType(arrayp) && declRange() == arrayp->declRange()

--- a/src/V3Ast.h
+++ b/src/V3Ast.h
@@ -2210,6 +2210,7 @@ public:
     virtual bool matchingArrayType(const AstNodeArrayDType* matchp) const = 0;
     virtual bool matching(const AstNodeDType* typep) const {
         const AstNodeArrayDType* arrayp = VN_CAST_CONST(typep, NodeArrayDType);
+        if (!arrayp) return typep->matching(this);
         return arrayp && matchingArrayType(arrayp) && declRange() == arrayp->declRange()
                && subDTypep()->matching(arrayp->subDTypep());
     }

--- a/src/V3Ast.h
+++ b/src/V3Ast.h
@@ -2094,6 +2094,7 @@ public:
     uint32_t arrayUnpackedElements();  // 1, or total multiplication of all dimensions
     static int uniqueNumInc() { return ++s_uniqueNum; }
     const char* charIQWN() const { return (isString() ? "N" : isWide() ? "W" : isQuad() ? "Q" : "I"); }
+    virtual bool matching(const AstNodeDType* typep) const = 0;
 };
 
 class AstNodeUOrStructDType : public AstNodeDType {
@@ -2148,6 +2149,7 @@ public:
     int lsb() const { return 0; }
     int msb() const { return dtypep()->width()-1; }  // Packed classes look like arrays
     VNumRange declRange() const { return VNumRange(msb(), lsb(), false); }
+    virtual bool matching(const AstNodeDType* typep) const { return typep == this; }
 };
 
 class AstNodeArrayDType : public AstNodeDType {
@@ -2205,6 +2207,12 @@ public:
     int lsb() const;
     int elementsConst() const;
     VNumRange declRange() const;
+    virtual bool matchingArrayType(const AstNodeArrayDType* matchp) const = 0;
+    virtual bool matching(const AstNodeDType* typep) const {
+        const AstNodeArrayDType* arrayp = VN_CAST_CONST(typep, NodeArrayDType);
+        return arrayp && matchingArrayType(arrayp) && declRange() == arrayp->declRange()
+               && subDTypep()->matching(arrayp->subDTypep());
+    }
 };
 
 class AstNodeSel : public AstNodeBiop {

--- a/src/V3Ast.h
+++ b/src/V3Ast.h
@@ -2095,8 +2095,8 @@ public:
     static int uniqueNumInc() { return ++s_uniqueNum; }
     const char* charIQWN() const { return (isString() ? "N" : isWide() ? "W" : isQuad() ? "Q" : "I"); }
     bool matching(const AstNodeDType* typep) const {
-        if (VN_IS(typep, RefDType)) {
-            // Follow RefDTypes
+        if (VN_IS(typep, RefDType) || VN_IS(typep, ConstDType)) {
+            // Unwrap type wrappers
             return typep->match(this);
         } else {
             return match(typep);

--- a/src/V3AstNodes.h
+++ b/src/V3AstNodes.h
@@ -935,7 +935,7 @@ public:
     virtual int widthTotalBytes() const { return subDTypep()->widthTotalBytes(); }
     virtual bool match(const AstNodeDType* typep) const {
         const AstQueueDType* queuep = VN_CAST_CONST(typep, QueueDType);
-        return queuep && subDTypep()->matching(typep);
+        return queuep && subDTypep()->matching(queuep->subDTypep());
     }
 };
 

--- a/src/V3AstNodes.h
+++ b/src/V3AstNodes.h
@@ -673,6 +673,16 @@ public:
     virtual bool same(const AstNode* samep) const {  // width/widthMin/numeric compared elsewhere
         const AstBasicDType* sp = static_cast<const AstBasicDType*>(samep);
         return m == sp->m; }
+    bool matching(const AstBasicDType* matchp) {
+        if (isSigned() == matchp->isSigned()
+            && (same(matchp) ||
+                (isIntNumeric() && matchp->isIntNumeric()
+                 && isFourstate() == matchp->isFourstate()
+                 && nrange() == matchp->nrange()))) {
+            return true;
+        }
+        return false;
+    }
     virtual bool similarDType(AstNodeDType* samep) const {
         return type()==samep->type() && same(samep); }
     virtual string name() const { return m.m_keyword.ascii(); }
@@ -700,6 +710,7 @@ public:
     bool isString() const { return keyword().isString(); }
     bool isSloppy() const { return keyword().isSloppy(); }
     bool isZeroInit() const { return keyword().isZeroInit(); }
+    bool isIntNumeric() const { return keyword().isIntNumeric(); }
     bool isRanged() const { return rangep() || m.m_nrange.ranged(); }
     const VNumRange& nrange() const { return m.m_nrange; }  // Generally the msb/lsb/etc funcs should be used instead
     int msb() const { return (rangep() ? rangep()->msbConst() : m.m_nrange.hi()); }

--- a/src/V3AstNodes.h
+++ b/src/V3AstNodes.h
@@ -305,7 +305,7 @@ public:
     AstVarType varType() const { return m_varType; }  // * = Type of variable
     bool isParam() const { return true; }
     bool isGParam() const { return (varType()==AstVarType::GPARAM); }
-    virtual bool matching(const AstNodeDType* typep) const { return childDTypep()->matching(typep); }
+    virtual bool match(const AstNodeDType* typep) const { return childDTypep()->matching(typep); }
 };
 
 class AstTypedef : public AstNode {
@@ -390,7 +390,7 @@ public:
     virtual int widthTotalBytes() const { return dtypep()->widthTotalBytes(); }
     virtual string name() const { return m_name; }
     void name(const string& flag) { m_name = flag; }
-    virtual bool matching(const AstNodeDType* typep) const { return typep == this; }
+    virtual bool match(const AstNodeDType* typep) const { return typep == this; }
 };
 
 class AstAssocArrayDType : public AstNodeDType {
@@ -451,9 +451,8 @@ public:
     virtual AstNodeDType* skipRefToEnump() const { return (AstNodeDType*)this; }
     virtual int widthAlignBytes() const { return subDTypep()->widthAlignBytes(); }
     virtual int widthTotalBytes() const { return subDTypep()->widthTotalBytes(); }
-    virtual bool matching(const AstNodeDType* typep) const {
+    virtual bool match(const AstNodeDType* typep) const {
         const AstAssocArrayDType* arrayp = VN_CAST_CONST(typep, AssocArrayDType);
-        if (!arrayp) return typep->matching(this);
         return arrayp && subDTypep()->matching(arrayp->subDTypep())
                && keyDTypep()->matching(arrayp->keyDTypep());
     }
@@ -507,9 +506,8 @@ public:
     virtual AstNodeDType* skipRefToEnump() const { return (AstNodeDType*)this; }
     virtual int widthAlignBytes() const { return subDTypep()->widthAlignBytes(); }
     virtual int widthTotalBytes() const { return subDTypep()->widthTotalBytes(); }
-    virtual bool matching(const AstNodeDType* typep) const {
+    virtual bool match(const AstNodeDType* typep) const {
         const AstDynArrayDType* arrayp = VN_CAST_CONST(typep, DynArrayDType);
-        if (!arrayp) return typep->matching(this);
         return arrayp && subDTypep()->matching(arrayp->subDTypep());
     }
 };
@@ -615,9 +613,8 @@ public:
     virtual AstNodeDType* skipRefToEnump() const { return (AstNodeDType*)this; }
     virtual int widthAlignBytes() const { return subDTypep()->widthAlignBytes(); }
     virtual int widthTotalBytes() const { return subDTypep()->widthTotalBytes(); }
-    virtual bool matching(const AstNodeDType* typep) const {
+    virtual bool match(const AstNodeDType* typep) const {
         const AstUnsizedArrayDType* arrayp = VN_CAST_CONST(typep, UnsizedArrayDType);
-        if (!arrayp) return typep->matching(this);
         return arrayp && subDTypep()->matching(arrayp->subDTypep());
     }
 };
@@ -697,10 +694,9 @@ public:
     virtual bool same(const AstNode* samep) const {  // width/widthMin/numeric compared elsewhere
         const AstBasicDType* sp = static_cast<const AstBasicDType*>(samep);
         return m == sp->m; }
-    virtual bool matching(const AstNodeDType* typep) const {
+    virtual bool match(const AstNodeDType* typep) const {
         const AstBasicDType* matchp = VN_CAST_CONST(typep, BasicDType);
-        if (!matchp) return typep->matching(this);
-        return isSigned() == matchp->isSigned()
+        return matchp && isSigned() == matchp->isSigned()
                && (same(matchp) ||
                    (isIntNumeric() && matchp->isIntNumeric()
                     && isFourstate() == matchp->isFourstate()
@@ -793,7 +789,7 @@ public:
     virtual AstNodeDType* skipRefToEnump() const { return subDTypep()->skipRefToEnump(); }
     virtual int widthAlignBytes() const { return subDTypep()->widthAlignBytes(); }
     virtual int widthTotalBytes() const { return subDTypep()->widthTotalBytes(); }
-    virtual bool matching(const AstNodeDType* typep) const { return subDTypep()->matching(typep); }
+    virtual bool match(const AstNodeDType* typep) const { return subDTypep()->matching(typep); }
 };
 
 class AstClassRefDType : public AstNodeDType {
@@ -833,7 +829,7 @@ public:
     void packagep(AstPackage* nodep) { m_packagep = nodep; }
     AstClass* classp() const { return m_classp; }
     void classp(AstClass* nodep) { m_classp = nodep; }
-    virtual bool matching(const AstNodeDType* typep) const { return typep == this; }
+    virtual bool match(const AstNodeDType* typep) const { return typep == this; }
 };
 
 class AstIfaceRefDType : public AstNodeDType {
@@ -887,7 +883,7 @@ public:
     void modportp(AstModport* modportp) { m_modportp = modportp; }
     bool isModport() { return !m_modportName.empty(); }
     // Cannot take type() of interface
-    virtual bool matching(const AstNodeDType* typep) const { return false; }
+    virtual bool match(const AstNodeDType* typep) const { return false; }
 };
 
 class AstQueueDType : public AstNodeDType {
@@ -937,9 +933,8 @@ public:
     virtual AstNodeDType* skipRefToEnump() const { return (AstNodeDType*)this; }
     virtual int widthAlignBytes() const { return subDTypep()->widthAlignBytes(); }
     virtual int widthTotalBytes() const { return subDTypep()->widthTotalBytes(); }
-    virtual bool matching(const AstNodeDType* typep) const {
+    virtual bool match(const AstNodeDType* typep) const {
         const AstQueueDType* queuep = VN_CAST_CONST(typep, QueueDType);
-        if (!queuep) return typep->matching(this);
         return queuep && subDTypep()->matching(typep);
     }
 };
@@ -1007,7 +1002,7 @@ public:
     AstPackage* packagep() const { return m_packagep; }
     void packagep(AstPackage* nodep) { m_packagep = nodep; }
     AstNode* typeofp() const { return op2p(); }
-    virtual bool matching(const AstNodeDType* typep) const { return refDTypep()->matching(typep); }
+    virtual bool match(const AstNodeDType* typep) const { return refDTypep()->matching(typep); }
 };
 
 class AstStructDType : public AstNodeUOrStructDType {
@@ -1085,7 +1080,7 @@ public:
     virtual string tag() const { return m_tag; }
     int lsb() const { return m_lsb; }
     void lsb(int lsb) { m_lsb = lsb; }
-    virtual bool matching(const AstNodeDType* typep) const { return subDTypep()->matching(typep); }
+    virtual bool match(const AstNodeDType* typep) const { return subDTypep()->matching(typep); }
 };
 
 class AstVoidDType : public AstNodeDType {
@@ -1108,7 +1103,7 @@ public:
     virtual int widthAlignBytes() const { return 1; }
     virtual int widthTotalBytes() const { return 1; }
     virtual V3Hash sameHash() const { return V3Hash(); }
-    virtual bool matching(const AstNodeDType* typep) const { return false; }
+    virtual bool match(const AstNodeDType* typep) const { return false; }
 };
 
 class AstEnumItem : public AstNode {
@@ -1202,7 +1197,7 @@ public:
     virtual AstNodeDType* skipRefToEnump() const { return (AstNodeDType*)this; }
     virtual int widthAlignBytes() const { return subDTypep()->widthAlignBytes(); }
     virtual int widthTotalBytes() const { return subDTypep()->widthTotalBytes(); }
-    virtual bool matching(const AstNodeDType* typep) const { return typep == this; }
+    virtual bool match(const AstNodeDType* typep) const { return typep == this; }
 };
 
 class AstParseTypeDType : public AstNodeDType {
@@ -1222,7 +1217,7 @@ public:
     virtual AstNodeDType* skipRefToEnump() const { return (AstNodeDType*)this; }
     virtual int widthAlignBytes() const { return 0; }
     virtual int widthTotalBytes() const { return 0; }
-    virtual bool matching(const AstNodeDType* typep) const { return false; }
+    virtual bool match(const AstNodeDType* typep) const { return false; }
 };
 
 //######################################################################

--- a/src/V3AstNodes.h
+++ b/src/V3AstNodes.h
@@ -453,6 +453,7 @@ public:
     virtual int widthTotalBytes() const { return subDTypep()->widthTotalBytes(); }
     virtual bool matching(const AstNodeDType* typep) const {
         const AstAssocArrayDType* arrayp = VN_CAST_CONST(typep, AssocArrayDType);
+        if (!arrayp) return typep->matching(this);
         return arrayp && subDTypep()->matching(arrayp->subDTypep())
                && keyDTypep()->matching(arrayp->keyDTypep());
     }
@@ -508,6 +509,7 @@ public:
     virtual int widthTotalBytes() const { return subDTypep()->widthTotalBytes(); }
     virtual bool matching(const AstNodeDType* typep) const {
         const AstDynArrayDType* arrayp = VN_CAST_CONST(typep, DynArrayDType);
+        if (!arrayp) return typep->matching(this);
         return arrayp && subDTypep()->matching(arrayp->subDTypep());
     }
 };
@@ -615,6 +617,7 @@ public:
     virtual int widthTotalBytes() const { return subDTypep()->widthTotalBytes(); }
     virtual bool matching(const AstNodeDType* typep) const {
         const AstUnsizedArrayDType* arrayp = VN_CAST_CONST(typep, UnsizedArrayDType);
+        if (!arrayp) return typep->matching(this);
         return arrayp && subDTypep()->matching(arrayp->subDTypep());
     }
 };
@@ -696,16 +699,12 @@ public:
         return m == sp->m; }
     virtual bool matching(const AstNodeDType* typep) const {
         const AstBasicDType* matchp = VN_CAST_CONST(typep, BasicDType);
-        if (!matchp) {
-            return typep->matching(this);
-        } else if (isSigned() == matchp->isSigned()
-                   && (same(matchp) ||
-                       (isIntNumeric() && matchp->isIntNumeric()
-                        && isFourstate() == matchp->isFourstate()
-                        && nrange() == matchp->nrange()))) {
-            return true;
-        }
-        return false;
+        if (!matchp) return typep->matching(this);
+        return isSigned() == matchp->isSigned()
+               && (same(matchp) ||
+                   (isIntNumeric() && matchp->isIntNumeric()
+                    && isFourstate() == matchp->isFourstate()
+                    && nrange() == matchp->nrange()));
     }
     virtual bool similarDType(AstNodeDType* samep) const {
         return type()==samep->type() && same(samep); }
@@ -940,6 +939,7 @@ public:
     virtual int widthTotalBytes() const { return subDTypep()->widthTotalBytes(); }
     virtual bool matching(const AstNodeDType* typep) const {
         const AstQueueDType* queuep = VN_CAST_CONST(typep, QueueDType);
+        if (!queuep) return typep->matching(this);
         return queuep && subDTypep()->matching(typep);
     }
 };

--- a/src/V3AstNodes.h
+++ b/src/V3AstNodes.h
@@ -5281,6 +5281,23 @@ public:
     virtual bool sizeMattersLhs() const { return false; }
     virtual bool sizeMattersRhs() const { return false; }
 };
+class AstEqT : public AstNodeBiCom {
+public:
+    AstEqT(FileLine* fl, AstNode* lhsp, AstNode* rhsp)
+        : ASTGEN_SUPER(fl, lhsp, rhsp) { dtypeSetLogicBool(); }
+    ASTNODE_NODE_FUNCS(EqT)
+    virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstEqT(this->fileline(), lhsp, rhsp); }
+    virtual void numberOperate(V3Number& out, const V3Number& lhs, const V3Number& rhs) { out.opEq(lhs, rhs); }
+    virtual string emitVerilog() { return "%k(%l %f== %r)"; }
+    // TOOD -- if we can't even emit C, should this be a child of AstNodeMath?
+    virtual string emitC() { return ""; }
+    virtual string emitSimpleOperator() { return "=="; }
+    virtual bool cleanOut() const { return false; }
+    virtual bool cleanLhs() const { return false; }
+    virtual bool cleanRhs() const { return false; }
+    virtual bool sizeMattersLhs() const { return false; }
+    virtual bool sizeMattersRhs() const { return false; }
+};
 class AstEqD : public AstNodeBiCom {
 public:
     AstEqD(FileLine* fl, AstNode* lhsp, AstNode* rhsp)
@@ -5330,6 +5347,22 @@ public:
     virtual bool cleanOut() const { return true; }
     virtual bool cleanLhs() const { return true; }
     virtual bool cleanRhs() const { return true; }
+    virtual bool sizeMattersLhs() const { return false; }
+    virtual bool sizeMattersRhs() const { return false; }
+};
+class AstNeqT : public AstNodeBiCom {
+public:
+    AstNeqT(FileLine* fl, AstNode* lhsp, AstNode* rhsp)
+        : ASTGEN_SUPER(fl, lhsp, rhsp) { dtypeSetLogicBool(); }
+    ASTNODE_NODE_FUNCS(NeqT)
+    virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstNeqT(this->fileline(), lhsp, rhsp); }
+    virtual void numberOperate(V3Number& out, const V3Number& lhs, const V3Number& rhs) { out.opNeq(lhs, rhs); }
+    virtual string emitVerilog() { return "%k(%l %f!= %r)"; }
+    virtual string emitC() { return ""; }
+    virtual string emitSimpleOperator() { return "!="; }
+    virtual bool cleanOut() const { return false; }
+    virtual bool cleanLhs() const { return false; }
+    virtual bool cleanRhs() const { return false; }
     virtual bool sizeMattersLhs() const { return false; }
     virtual bool sizeMattersRhs() const { return false; }
 };

--- a/src/V3AstNodes.h
+++ b/src/V3AstNodes.h
@@ -5324,23 +5324,6 @@ public:
     virtual bool sizeMattersLhs() const { return false; }
     virtual bool sizeMattersRhs() const { return false; }
 };
-class AstEqT : public AstNodeBiCom {
-public:
-    AstEqT(FileLine* fl, AstNode* lhsp, AstNode* rhsp)
-        : ASTGEN_SUPER(fl, lhsp, rhsp) { dtypeSetLogicBool(); }
-    ASTNODE_NODE_FUNCS(EqT)
-    virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstEqT(this->fileline(), lhsp, rhsp); }
-    virtual void numberOperate(V3Number& out, const V3Number& lhs, const V3Number& rhs) { out.opEq(lhs, rhs); }
-    virtual string emitVerilog() { return "%k(%l %f== %r)"; }
-    // TOOD -- if we can't even emit C, should this be a child of AstNodeMath?
-    virtual string emitC() { return ""; }
-    virtual string emitSimpleOperator() { return "=="; }
-    virtual bool cleanOut() const { return false; }
-    virtual bool cleanLhs() const { return false; }
-    virtual bool cleanRhs() const { return false; }
-    virtual bool sizeMattersLhs() const { return false; }
-    virtual bool sizeMattersRhs() const { return false; }
-};
 class AstEqD : public AstNodeBiCom {
 public:
     AstEqD(FileLine* fl, AstNode* lhsp, AstNode* rhsp)
@@ -5390,22 +5373,6 @@ public:
     virtual bool cleanOut() const { return true; }
     virtual bool cleanLhs() const { return true; }
     virtual bool cleanRhs() const { return true; }
-    virtual bool sizeMattersLhs() const { return false; }
-    virtual bool sizeMattersRhs() const { return false; }
-};
-class AstNeqT : public AstNodeBiCom {
-public:
-    AstNeqT(FileLine* fl, AstNode* lhsp, AstNode* rhsp)
-        : ASTGEN_SUPER(fl, lhsp, rhsp) { dtypeSetLogicBool(); }
-    ASTNODE_NODE_FUNCS(NeqT)
-    virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstNeqT(this->fileline(), lhsp, rhsp); }
-    virtual void numberOperate(V3Number& out, const V3Number& lhs, const V3Number& rhs) { out.opNeq(lhs, rhs); }
-    virtual string emitVerilog() { return "%k(%l %f!= %r)"; }
-    virtual string emitC() { return ""; }
-    virtual string emitSimpleOperator() { return "!="; }
-    virtual bool cleanOut() const { return false; }
-    virtual bool cleanLhs() const { return false; }
-    virtual bool cleanRhs() const { return false; }
     virtual bool sizeMattersLhs() const { return false; }
     virtual bool sizeMattersRhs() const { return false; }
 };
@@ -5722,6 +5689,39 @@ public:
     virtual bool sizeMattersRhs() const { return false; }
     virtual int instrCount() const { return instrCountString(); }
     virtual bool stringFlavor() const { return true; }
+};
+class AstEqT : public AstNodeBiCom {
+public:
+    AstEqT(FileLine* fl, AstNode* lhsp, AstNode* rhsp)
+        : ASTGEN_SUPER(fl, lhsp, rhsp) { dtypeSetLogicBool(); }
+    ASTNODE_NODE_FUNCS(EqT)
+    virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstEqT(this->fileline(), lhsp, rhsp); }
+    virtual void numberOperate(V3Number& out, const V3Number& lhs, const V3Number& rhs) { out.opEq(lhs, rhs); }
+    virtual string emitVerilog() { return "%k(%l %f== %r)"; }
+    // TOOD -- if we can't even emit C, should this be a child of AstNodeMath?
+    virtual string emitC() { return ""; }
+    virtual string emitSimpleOperator() { return "=="; }
+    virtual bool cleanOut() const { return false; }
+    virtual bool cleanLhs() const { return false; }
+    virtual bool cleanRhs() const { return false; }
+    virtual bool sizeMattersLhs() const { return false; }
+    virtual bool sizeMattersRhs() const { return false; }
+};
+class AstNeqT : public AstNodeBiCom {
+public:
+    AstNeqT(FileLine* fl, AstNode* lhsp, AstNode* rhsp)
+        : ASTGEN_SUPER(fl, lhsp, rhsp) { dtypeSetLogicBool(); }
+    ASTNODE_NODE_FUNCS(NeqT)
+    virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) { return new AstNeqT(this->fileline(), lhsp, rhsp); }
+    virtual void numberOperate(V3Number& out, const V3Number& lhs, const V3Number& rhs) { out.opNeq(lhs, rhs); }
+    virtual string emitVerilog() { return "%k(%l %f!= %r)"; }
+    virtual string emitC() { return ""; }
+    virtual string emitSimpleOperator() { return "!="; }
+    virtual bool cleanOut() const { return false; }
+    virtual bool cleanLhs() const { return false; }
+    virtual bool cleanRhs() const { return false; }
+    virtual bool sizeMattersLhs() const { return false; }
+    virtual bool sizeMattersRhs() const { return false; }
 };
 class AstShiftL : public AstNodeBiop {
 public:

--- a/src/V3AstNodes.h
+++ b/src/V3AstNodes.h
@@ -3024,6 +3024,18 @@ public:
     void priorityPragma(bool flag) { m_priorityPragma = flag; }
 };
 
+class AstTypeCase : public AstNodeCase {
+    // Case statement for type references
+    // Parents:  {statement list}
+    // exprp Children:  MATHs
+    // casesp Children: CASEITEMs
+public:
+    AstTypeCase(FileLine* fl, AstNodeDType* typep, AstNode* casesp)
+        : ASTGEN_SUPER(fl, typep, casesp) { }
+    ASTNODE_NODE_FUNCS(TypeCase)
+    virtual string verilogKwd() const { return "case"; }
+};
+
 class AstCaseItem : public AstNode {
     // Single item of a case statement
     // Parents:  CASE

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -3585,6 +3585,8 @@ private:
             userIterateAndNext(nodep->rhsp(), WidthVP(CONTEXT, PRELIM).p());
             m_leaveTypeof = false;
             bool equal = false;
+            // TODO -- remove
+            nodep->dumpTree(cout, "typeCompare: ");
             AstRefDType* refLhsp = VN_CAST(nodep->lhsp(), RefDType);
             AstRefDType* refRhsp = VN_CAST(nodep->rhsp(), RefDType);
             if (refLhsp && refRhsp) {
@@ -3592,9 +3594,16 @@ private:
                 AstNodeDType* typeRhsp = refRhsp->refDTypep();
                 if (AstBasicDType* basicLhsp = VN_CAST(typeLhsp, BasicDType)) {
                     AstBasicDType* basicRhsp = VN_CAST(typeRhsp, BasicDType);
-                    if (basicRhsp && basicLhsp->same(typeRhsp)
-                        && basicLhsp->isSigned() == basicRhsp->isSigned()) {
-                        equal = true;
+                    // QUESTION -- AstBasicDType::same() doesn't check signedness . . . should it?
+                    if (basicRhsp && basicLhsp->isSigned() == basicRhsp->isSigned()) {
+                        AstBasicDTypeKwd kwdLhs = basicLhsp->keyword();
+                        AstBasicDTypeKwd kwdRhs = basicRhsp->keyword();
+                        if (basicLhsp->same(typeRhsp) ||
+                            (kwdLhs.isIntNumeric() && kwdRhs.isIntNumeric()
+                             && kwdLhs.isFourstate() == kwdRhs.isFourstate()
+                             && basicLhsp->nrange() == basicRhsp->nrange())) {
+                            equal = true;
+                        }
                     }
                 } else if (refLhsp->dtypep() == refRhsp->dtypep()) {
                     equal = true;

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -3594,8 +3594,8 @@ private:
                     if (VN_IS(typeRhsp, BasicDType) && basicLhsp->same(typeRhsp)) {
                         equal = true;
                     }
-                } else {
-                    nodep->v3fatalSrc("TODO -- handle this");
+                } else if (refLhsp->dtypep() == refRhsp->dtypep()) {
+                    equal = true;
                 }
             } else {
                 nodep->v3fatalSrc("TODO -- also handle this");

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -3581,8 +3581,7 @@ private:
             // don't clean up types which may not be in the type table
             // we're going to remove this whole sub-tree anyway
             m_leaveTypeof = true;
-            userIterateAndNext(nodep->lhsp(), WidthVP(CONTEXT, PRELIM).p());
-            userIterateAndNext(nodep->rhsp(), WidthVP(CONTEXT, PRELIM).p());
+            userIterateChildren(nodep, WidthVP(CONTEXT, PRELIM).p());
             m_leaveTypeof = false;
             bool equal = false;
             // TODO -- remove

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -3592,19 +3592,10 @@ private:
             if (refLhsp && refRhsp) {
                 AstNodeDType* typeLhsp = refLhsp->refDTypep();
                 AstNodeDType* typeRhsp = refRhsp->refDTypep();
-                if (AstBasicDType* basicLhsp = VN_CAST(typeLhsp, BasicDType)) {
-                    AstBasicDType* basicRhsp = VN_CAST(typeRhsp, BasicDType);
-                    // QUESTION -- AstBasicDType::same() doesn't check signedness . . . should it?
-                    if (basicRhsp && basicLhsp->isSigned() == basicRhsp->isSigned()) {
-                        AstBasicDTypeKwd kwdLhs = basicLhsp->keyword();
-                        AstBasicDTypeKwd kwdRhs = basicRhsp->keyword();
-                        if (basicLhsp->same(typeRhsp) ||
-                            (kwdLhs.isIntNumeric() && kwdRhs.isIntNumeric()
-                             && kwdLhs.isFourstate() == kwdRhs.isFourstate()
-                             && basicLhsp->nrange() == basicRhsp->nrange())) {
-                            equal = true;
-                        }
-                    }
+                AstBasicDType* basicLhsp = VN_CAST(typeLhsp, BasicDType);
+                AstBasicDType* basicRhsp = VN_CAST(typeRhsp, BasicDType);
+                if (basicLhsp && basicRhsp && basicLhsp->matching(basicRhsp)) {
+                    equal = true;
                 } else if (refLhsp->dtypep() == refRhsp->dtypep()) {
                     equal = true;
                 }

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -3590,17 +3590,13 @@ private:
             AstRefDType* refLhsp = VN_CAST(nodep->lhsp(), RefDType);
             AstRefDType* refRhsp = VN_CAST(nodep->rhsp(), RefDType);
             if (refLhsp && refRhsp) {
-                AstNodeDType* typeLhsp = refLhsp->refDTypep();
-                AstNodeDType* typeRhsp = refRhsp->refDTypep();
-                AstBasicDType* basicLhsp = VN_CAST(typeLhsp, BasicDType);
-                AstBasicDType* basicRhsp = VN_CAST(typeRhsp, BasicDType);
-                if (basicLhsp && basicRhsp && basicLhsp->matching(basicRhsp)) {
-                    equal = true;
-                } else if (refLhsp->dtypep() == refRhsp->dtypep()) {
+                if (refLhsp->matching(refRhsp)
+                    // TODO -- is this even necessary in the end?
+                    || refLhsp->dtypep() == refRhsp->dtypep()) {
                     equal = true;
                 }
             } else {
-                nodep->v3fatalSrc("TODO -- also handle this");
+                nodep->v3fatalSrc("Expected two types for type comparison");
             }
             bool isNot = VN_IS(nodep, NeqT);
             uint32_t value = equal ^ isNot ? 1 : 0;

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -3591,7 +3591,9 @@ private:
                 AstNodeDType* typeLhsp = refLhsp->refDTypep();
                 AstNodeDType* typeRhsp = refRhsp->refDTypep();
                 if (AstBasicDType* basicLhsp = VN_CAST(typeLhsp, BasicDType)) {
-                    if (VN_IS(typeRhsp, BasicDType) && basicLhsp->same(typeRhsp)) {
+                    AstBasicDType* basicRhsp = VN_CAST(typeRhsp, BasicDType);
+                    if (basicRhsp && basicLhsp->same(typeRhsp)
+                        && basicLhsp->isSigned() == basicRhsp->isSigned()) {
                         equal = true;
                     }
                 } else if (refLhsp->dtypep() == refRhsp->dtypep()) {

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -254,6 +254,9 @@ private:
     // ...    These comparisons don't allow reals
     virtual void visit(AstEqWild* nodep) VL_OVERRIDE {      visit_cmp_eq_gt(nodep, false); }
     virtual void visit(AstNeqWild* nodep) VL_OVERRIDE {     visit_cmp_eq_gt(nodep, false); }
+    // ...    Type compares
+    virtual void visit(AstEqT* nodep) VL_OVERRIDE {         visit_cmp_eq_type(nodep); }
+    virtual void visit(AstNeqT* nodep) VL_OVERRIDE {        visit_cmp_eq_type(nodep); }
     // ...    Real compares
     virtual void visit(AstEqD* nodep) VL_OVERRIDE {         visit_cmp_real(nodep); }
     virtual void visit(AstNeqD* nodep) VL_OVERRIDE {        visit_cmp_real(nodep); }
@@ -3568,6 +3571,16 @@ private:
         if (m_vup->prelim()) {
             userIterateAndNext(nodep->lhsp(), WidthVP(SELF, BOTH).p());
             nodep->dtypeSetLogicBool();
+        }
+    }
+
+    void visit_cmp_eq_type(AstNodeBiop* nodep) {
+        if (m_vup->prelim()) {
+            userIterateAndNext(nodep->lhsp(), WidthVP(CONTEXT, PRELIM).p());
+            userIterateAndNext(nodep->rhsp(), WidthVP(CONTEXT, PRELIM).p());
+            // TODO -- remove
+            UINFO(1,"Type comparision LHS : "<<nodep->lhsp()<<endl);
+            UINFO(1,"Type comparision RHS : "<<nodep->rhsp()<<endl);
         }
     }
 

--- a/src/verilog.y
+++ b/src/verilog.y
@@ -3695,9 +3695,11 @@ expr<nodep>:			// IEEE: part of expression/constant_expression/primary
 	|	~l~expr '*' ~r~expr			{ $$ = new AstMul	($2,$1,$3); }
 	|	~l~expr '/' ~r~expr			{ $$ = new AstDiv	($2,$1,$3); }
 	|	~l~expr '%' ~r~expr			{ $$ = new AstModDiv	($2,$1,$3); }
-	|	type_reference yP_EQUAL type_reference	{ $$ = new AstEqT	($2,$1,$3); }
+	|	type_reference yP_EQUAL type_reference        { $$ = new AstEqT	        ($2,$1,$3); }
+	|	type_reference yP_NOTEQUAL type_reference     { $$ = new AstNeqT	($2,$1,$3); }
+	|	type_reference yP_CASEEQUAL type_reference    { $$ = new AstEqT	        ($2,$1,$3); }
+	|	type_reference yP_CASENOTEQUAL type_reference { $$ = new AstNeqT	($2,$1,$3); }
 	|	~l~expr yP_EQUAL ~r~expr		{ $$ = new AstEq	($2,$1,$3); }
-	|	type_reference yP_NOTEQUAL type_reference { $$ = new AstNeqT	($2,$1,$3); }
 	|	~l~expr yP_NOTEQUAL ~r~expr		{ $$ = new AstNeq	($2,$1,$3); }
 	|	~l~expr yP_CASEEQUAL ~r~expr		{ $$ = new AstEqCase	($2,$1,$3); }
 	|	~l~expr yP_CASENOTEQUAL ~r~expr		{ $$ = new AstNeqCase	($2,$1,$3); }

--- a/src/verilog.y
+++ b/src/verilog.y
@@ -3695,7 +3695,9 @@ expr<nodep>:			// IEEE: part of expression/constant_expression/primary
 	|	~l~expr '*' ~r~expr			{ $$ = new AstMul	($2,$1,$3); }
 	|	~l~expr '/' ~r~expr			{ $$ = new AstDiv	($2,$1,$3); }
 	|	~l~expr '%' ~r~expr			{ $$ = new AstModDiv	($2,$1,$3); }
+	|	type_reference yP_EQUAL type_reference	{ $$ = new AstEq	($2,$1,$3); }
 	|	~l~expr yP_EQUAL ~r~expr		{ $$ = new AstEq	($2,$1,$3); }
+	|	type_reference yP_NOTEQUAL type_reference { $$ = new AstNeq	($2,$1,$3); }
 	|	~l~expr yP_NOTEQUAL ~r~expr		{ $$ = new AstNeq	($2,$1,$3); }
 	|	~l~expr yP_CASEEQUAL ~r~expr		{ $$ = new AstEqCase	($2,$1,$3); }
 	|	~l~expr yP_CASENOTEQUAL ~r~expr		{ $$ = new AstNeqCase	($2,$1,$3); }

--- a/src/verilog.y
+++ b/src/verilog.y
@@ -3695,9 +3695,9 @@ expr<nodep>:			// IEEE: part of expression/constant_expression/primary
 	|	~l~expr '*' ~r~expr			{ $$ = new AstMul	($2,$1,$3); }
 	|	~l~expr '/' ~r~expr			{ $$ = new AstDiv	($2,$1,$3); }
 	|	~l~expr '%' ~r~expr			{ $$ = new AstModDiv	($2,$1,$3); }
-	|	type_reference yP_EQUAL type_reference	{ $$ = new AstEq	($2,$1,$3); }
+	|	type_reference yP_EQUAL type_reference	{ $$ = new AstEqT	($2,$1,$3); }
 	|	~l~expr yP_EQUAL ~r~expr		{ $$ = new AstEq	($2,$1,$3); }
-	|	type_reference yP_NOTEQUAL type_reference { $$ = new AstNeq	($2,$1,$3); }
+	|	type_reference yP_NOTEQUAL type_reference { $$ = new AstNeqT	($2,$1,$3); }
 	|	~l~expr yP_NOTEQUAL ~r~expr		{ $$ = new AstNeq	($2,$1,$3); }
 	|	~l~expr yP_CASEEQUAL ~r~expr		{ $$ = new AstEqCase	($2,$1,$3); }
 	|	~l~expr yP_CASENOTEQUAL ~r~expr		{ $$ = new AstNeqCase	($2,$1,$3); }

--- a/test_regress/t/t_type_comparison.pl
+++ b/test_regress/t/t_type_comparison.pl
@@ -1,0 +1,20 @@
+#!/usr/bin/perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2020 by Todd Strader. This program is free software; you can
+# redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+
+scenarios(simulator => 1);
+
+compile(
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_type_comparison.v
+++ b/test_regress/t/t_type_comparison.v
@@ -1,0 +1,49 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed into the Public Domain, for any use,
+// without warranty, 2020 by Todd Strader.
+
+module foo
+   #(parameter type a_type = logic,
+     parameter type b_type = int)
+   ();
+
+   initial begin
+      if (type(a_type) != type(logic[7:0])) begin
+         $display("%%Error: a_type is wrong");
+         $stop();
+      end
+
+      if (type(b_type) != type(real)) begin
+         $display("%%Error: b_type is wrong");
+         $stop();
+      end
+
+      if (type(a_type) == type(logic)) begin
+         $display("%%Error: a_type is the default value");
+         $stop();
+      end
+
+      if (type(b_type) == type(int)) begin
+         $display("%%Error: b_type is the default value");
+         $stop();
+      end
+
+      if (type(a_type) == type(b_type)) begin
+         $display("%%Error: a_type equals b_type");
+         $stop();
+      end
+
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end
+
+endmodule
+
+module t();
+
+   foo #(
+      .a_type (logic[7:0]),
+      .b_type (real)) the_foo ();
+
+endmodule

--- a/test_regress/t/t_type_comparison.v
+++ b/test_regress/t/t_type_comparison.v
@@ -57,6 +57,8 @@ module t();
    integer integer_v;
    time time_v;
 
+   const int int_c;
+
    typedef bit node;        // 'bit' and 'node' are matching types
    typedef node type1;
    typedef type1 type2;     // 'type1' and 'type2' are matching types
@@ -119,7 +121,7 @@ module t();
       if (type(MD_ARY) == type(MD_ARY_TOO)) $stop();
       if (type(MY_CHAR) != type(byte)) $stop();
       // TODO -- the rest
-      // TODO -- case equal/not equal, ===, !===
+      // TODO -- case statement
       // TODO -- generate case
       // TODO -- test associative arrays
       // TODO -- test dynamic arrays
@@ -132,14 +134,17 @@ module t();
       if (type(shortint) !== type(shortint_v)) $stop();
       if (type(int) === type(shortint_v)) $stop();
 
-      should_be_true = '0;
-      case (type(shortint_v))
-         type(shortint): should_be_true = '1;
-         type(int): $stop();
-         default: $stop();
-      endcase
+      if (type(int_c) != type(int_v)) $stop();
+      if (type(int_v) != type(int_c)) $stop();
 
-      if (!should_be_true) $stop();
+      should_be_true = '0;
+//      case (type(shortint_v))
+//         type(shortint): should_be_true = '1;
+//         type(int): $stop();
+//         default: $stop();
+//      endcase
+//
+//      if (!should_be_true) $stop();
    end
 
 

--- a/test_regress/t/t_type_comparison.v
+++ b/test_regress/t/t_type_comparison.v
@@ -46,4 +46,46 @@ module t();
       .a_type (logic[7:0]),
       .b_type (real)) the_foo ();
 
+   // From 6.22.1 (mostly)
+   typedef bit node;        // 'bit' and 'node' are matching types
+   typedef node type1;
+   typedef type1 type2;     // 'type1' and 'type2' are matching types
+
+   struct packed {int A; int B;} AB1, AB2;  // AB1, AB2 have matching types
+   struct packed {int A; int B;} AB3;       // the type of AB3 does not match
+                                            // the type of AB1
+
+   typedef struct packed {int A; int B;} AB_t;
+   AB_t AB4; AB_t AB5;  // AB4 and AB5 have matching types
+   typedef struct packed {int A; int B;} otherAB_t;
+   otherAB_t AB6;       // the type of AB6 does not match the type of AB4 or AB5
+
+   typedef bit signed [7:0] BYTE;   // matches the byte type
+   /* verilator lint_off LITENDIAN */
+   typedef bit signed [0:7] ETYB;   // does not match the byte type
+   /* verilator lint_on LITENDIAN */
+
+   typedef byte MEM_BYTES [256];
+   typedef bit signed [7:0] MY_MEM_BYTES [256];     // MY_MEM_BYTES matches
+                                                    // MEM_BYTES
+   typedef logic [1:0] [3:0] NIBBLES;
+   typedef logic [7:0] MY_BYTE; // MY_BYTE and NIBBLES are not matching types
+   typedef logic MD_ARY [][2:0];
+   typedef logic MD_ARY_TOO [][0:2]; // Does not match MD_ARY
+
+   typedef byte signed MY_CHAR; // MY_CHAR matches the byte type
+
+   // TODO -- this (6.22.1 h)
+   //import the_pkg::*;
+
+   initial begin
+      if (type(bit) != type(node)) $stop();
+      if (type(type1) != type(type2)) $stop();
+      if (type(AB1) != type(AB2)) $stop();
+      if (type(AB3) == type(AB1)) $stop();
+      // TODO -- the rest
+      // TODO -- case equal/not equal, ===, !===
+   end
+
+
 endmodule

--- a/test_regress/t/t_type_comparison.v
+++ b/test_regress/t/t_type_comparison.v
@@ -91,10 +91,10 @@ module t();
    // TODO -- this (6.22.1 h)
    //import the_pkg::*;
 
+   bit should_be_true;
+
    initial begin
       if (type(shortint) != type(shortint_v)) $stop();
-      if (type(shortint) !== type(shortint_v)) $stop();
-      if (type(int) === type(shortint_v)) $stop();
       if (type(int) != type(int_v)) $stop();
       if (type(longint) != type(longint_v)) $stop();
       if (type(byte) != type(byte_v)) $stop();
@@ -120,6 +120,7 @@ module t();
       if (type(MY_CHAR) != type(byte)) $stop();
       // TODO -- the rest
       // TODO -- case equal/not equal, ===, !===
+      // TODO -- generate case
       // TODO -- test associative arrays
       // TODO -- test dynamic arrays
       // TODO -- test unsized arrays
@@ -127,6 +128,18 @@ module t();
       // TODO -- test queues
       // TODO -- test structs, enums and unions
       // TODO -- test struct member vs type
+
+      if (type(shortint) !== type(shortint_v)) $stop();
+      if (type(int) === type(shortint_v)) $stop();
+
+      should_be_true = '0;
+      case (type(shortint_v))
+         type(shortint): should_be_true = '1;
+         type(int): $stop();
+         default: $stop();
+      endcase
+
+      if (!should_be_true) $stop();
    end
 
 

--- a/test_regress/t/t_type_comparison.v
+++ b/test_regress/t/t_type_comparison.v
@@ -40,13 +40,21 @@ module foo
 
 endmodule
 
+package pkg;
+   typedef struct packed {logic foo;} struct_t;
+   typedef enum {A_VAL, B_VAL, C_VAL} enum_t;
+   typedef union packed {
+      logic [7:0] foo;
+      logic [3:0] bar;
+   } union_t;
+endpackage
+
 module t();
 
    foo #(
       .a_type (logic[7:0]),
       .b_type (real)) the_foo ();
 
-   // From 6.22.1 (mostly)
    shortint shortint_v;
    int int_v;
    longint longint_v;
@@ -59,6 +67,7 @@ module t();
 
    const int int_c;
 
+   // From 6.22.1 (mostly)
    typedef bit node;        // 'bit' and 'node' are matching types
    typedef node type1;
    typedef type1 type2;     // 'type1' and 'type2' are matching types
@@ -90,8 +99,11 @@ module t();
 
    typedef byte signed MY_CHAR; // MY_CHAR matches the byte type
 
-   // TODO -- this (6.22.1 h)
-   //import the_pkg::*;
+   // 6.22.1 h
+   import pkg::*;
+   struct_t struct_v;
+   enum_t enum_v;
+   union_t union_v;
 
    bit should_be_true;
 
@@ -120,16 +132,20 @@ module t();
       if (type(NIBBLES) == type(MY_BYTE)) $stop();
       if (type(MD_ARY) == type(MD_ARY_TOO)) $stop();
       if (type(MY_CHAR) != type(byte)) $stop();
+      if (type(struct_v) != type(struct_t)) $stop();
+      if (type(struct_v) != type(pkg::struct_t)) $stop();
+      if (type(struct_t) != type(pkg::struct_t)) $stop();
+      if (type(struct_v.foo) != type(logic)) $stop();
+      if (type(logic) != type(struct_v.foo)) $stop();
+      if (type(enum_v) != type(enum_t)) $stop();
+      if (type(union_v) != type(union_t)) $stop();
       // TODO -- the rest
       // TODO -- case statement
       // TODO -- generate case
       // TODO -- test associative arrays
       // TODO -- test dynamic arrays
       // TODO -- test unsized arrays
-      // TODO -- test const vars (both LHS and RHS) against const and non-const
       // TODO -- test queues
-      // TODO -- test structs, enums and unions
-      // TODO -- test struct member vs type
 
       if (type(shortint) !== type(shortint_v)) $stop();
       if (type(int) === type(shortint_v)) $stop();

--- a/test_regress/t/t_type_comparison.v
+++ b/test_regress/t/t_type_comparison.v
@@ -47,6 +47,16 @@ module t();
       .b_type (real)) the_foo ();
 
    // From 6.22.1 (mostly)
+   shortint shortint_v;
+   int int_v;
+   longint longint_v;
+   byte byte_v;
+   bit bit_v;
+   logic logic_v;
+   reg reg_v;
+   integer integer_v;
+   time time_v;
+
    typedef bit node;        // 'bit' and 'node' are matching types
    typedef node type1;
    typedef type1 type2;     // 'type1' and 'type2' are matching types
@@ -64,6 +74,7 @@ module t();
    /* verilator lint_off LITENDIAN */
    typedef bit signed [0:7] ETYB;   // does not match the byte type
    /* verilator lint_on LITENDIAN */
+   typedef bit [7:0] UNSIGNED_BYTE;   // also does not match the byte type
 
    typedef byte MEM_BYTES [256];
    typedef bit signed [7:0] MY_MEM_BYTES [256];     // MY_MEM_BYTES matches
@@ -79,6 +90,15 @@ module t();
    //import the_pkg::*;
 
    initial begin
+      if (type(shortint) != type(shortint_v)) $stop();
+      if (type(int) != type(int_v)) $stop();
+      if (type(longint) != type(longint_v)) $stop();
+      if (type(byte) != type(byte_v)) $stop();
+      if (type(bit) != type(bit_v)) $stop();
+      if (type(logic) != type(logic_v)) $stop();
+      if (type(reg) != type(reg_v)) $stop();
+      if (type(integer) != type(integer_v)) $stop();
+      if (type(time) != type(time_v)) $stop();
       if (type(bit) != type(node)) $stop();
       if (type(type1) != type(type2)) $stop();
       if (type(AB1) != type(AB2)) $stop();
@@ -87,6 +107,8 @@ module t();
       if (type(AB6) == type(AB4)) $stop();
       if (type(AB6) == type(AB5)) $stop();
       if (type(BYTE) != type(byte)) $stop();
+      if (type(ETYB) == type(byte)) $stop();
+      if (type(BYTE) == type(UNSIGNED_BYTE)) $stop();
       // TODO -- the rest
       // TODO -- case equal/not equal, ===, !===
    end

--- a/test_regress/t/t_type_comparison.v
+++ b/test_regress/t/t_type_comparison.v
@@ -79,7 +79,7 @@ module t();
    typedef byte MEM_BYTES [256];
    typedef bit signed [7:0] MY_MEM_BYTES [256];     // MY_MEM_BYTES matches
                                                     // MEM_BYTES
-   typedef byte [255:0] MEM_BYTES_PACKED;
+   typedef bit signed [7:0] [255:0] MEM_BYTES_PACKED;
    typedef bit signed [7:0] [255:0] MY_MEM_BYTES_PACKED;
    typedef logic [1:0] [3:0] NIBBLES;
    typedef logic [7:0] MY_BYTE; // MY_BYTE and NIBBLES are not matching types

--- a/test_regress/t/t_type_comparison.v
+++ b/test_regress/t/t_type_comparison.v
@@ -67,6 +67,20 @@ module t();
 
    const int int_c;
 
+   integer string_to_integer_1[string];
+   integer string_to_integer_2[string];
+   integer int_to_integer[int];
+
+   int dyn_1 [];
+   int dyn_2 [];
+   real dyn_3 [];
+   int dyn_4 [] [];
+   int dyn_5 [] [];
+
+   int queue_1 [$];
+   int queue_2 [$];
+   real queue_3 [$];
+
    // From 6.22.1 (mostly)
    typedef bit node;        // 'bit' and 'node' are matching types
    typedef node type1;
@@ -108,6 +122,12 @@ module t();
    bit should_be_true;
 
    initial begin
+      // size of non-fixed-length arrays does not matter for type matching
+      string_to_integer_2["foo"] = 5;
+      dyn_1 = new[100];
+      dyn_2[3] = 7;
+      queue_1.push_front(8);
+
       if (type(shortint) != type(shortint_v)) $stop();
       if (type(int) != type(int_v)) $stop();
       if (type(longint) != type(longint_v)) $stop();
@@ -117,6 +137,14 @@ module t();
       if (type(reg) != type(reg_v)) $stop();
       if (type(integer) != type(integer_v)) $stop();
       if (type(time) != type(time_v)) $stop();
+      if (type(string_to_integer_1) != type(string_to_integer_2)) $stop();
+      if (type(string_to_integer_1) == type(int_to_integer)) $stop();
+      if (type(dyn_1) != type(dyn_2)) $stop();
+      if (type(dyn_1) == type(dyn_3)) $stop();
+      if (type(dyn_1) == type(dyn_4)) $stop();
+      if (type(dyn_4) != type(dyn_5)) $stop();
+      if (type(queue_1) != type(queue_2)) $stop();
+      if (type(queue_1) == type(queue_3)) $stop();
       if (type(bit) != type(node)) $stop();
       if (type(type1) != type(type2)) $stop();
       if (type(AB1) != type(AB2)) $stop();
@@ -142,10 +170,6 @@ module t();
       // TODO -- the rest
       // TODO -- case statement
       // TODO -- generate case
-      // TODO -- test associative arrays
-      // TODO -- test dynamic arrays
-      // TODO -- test unsized arrays
-      // TODO -- test queues
 
       if (type(shortint) !== type(shortint_v)) $stop();
       if (type(int) === type(shortint_v)) $stop();

--- a/test_regress/t/t_type_comparison.v
+++ b/test_regress/t/t_type_comparison.v
@@ -93,6 +93,8 @@ module t();
 
    initial begin
       if (type(shortint) != type(shortint_v)) $stop();
+      if (type(shortint) !== type(shortint_v)) $stop();
+      if (type(int) === type(shortint_v)) $stop();
       if (type(int) != type(int_v)) $stop();
       if (type(longint) != type(longint_v)) $stop();
       if (type(byte) != type(byte_v)) $stop();

--- a/test_regress/t/t_type_comparison.v
+++ b/test_regress/t/t_type_comparison.v
@@ -112,10 +112,10 @@ module t();
       if (type(ETYB) == type(byte)) $stop();
       if (type(BYTE) == type(UNSIGNED_BYTE)) $stop();
       if (type(MEM_BYTES) != type(MY_MEM_BYTES)) $stop();
-//      if (type(MEM_BYTES_PACKED) != type(MY_MEM_BYTES_PACKED)) $stop();
-//      if (type(NIBBLES) == type(MY_BYTE)) $stop();
-//      if (type(MD_ARY) == type(MD_ARY_TOO)) $stop();
-//      if (type(MY_CHAR) != type(byte)) $stop();
+      if (type(MEM_BYTES_PACKED) != type(MY_MEM_BYTES_PACKED)) $stop();
+      if (type(NIBBLES) == type(MY_BYTE)) $stop();
+      if (type(MD_ARY) == type(MD_ARY_TOO)) $stop();
+      if (type(MY_CHAR) != type(byte)) $stop();
       // TODO -- the rest
       // TODO -- case equal/not equal, ===, !===
       // TODO -- test associative arrays

--- a/test_regress/t/t_type_comparison.v
+++ b/test_regress/t/t_type_comparison.v
@@ -79,6 +79,8 @@ module t();
    typedef byte MEM_BYTES [256];
    typedef bit signed [7:0] MY_MEM_BYTES [256];     // MY_MEM_BYTES matches
                                                     // MEM_BYTES
+   typedef byte [255:0] MEM_BYTES_PACKED;
+   typedef bit signed [7:0] [255:0] MY_MEM_BYTES_PACKED;
    typedef logic [1:0] [3:0] NIBBLES;
    typedef logic [7:0] MY_BYTE; // MY_BYTE and NIBBLES are not matching types
    typedef logic MD_ARY [][2:0];
@@ -109,6 +111,11 @@ module t();
       if (type(BYTE) != type(byte)) $stop();
       if (type(ETYB) == type(byte)) $stop();
       if (type(BYTE) == type(UNSIGNED_BYTE)) $stop();
+      if (type(MEM_BYTES) != type(MY_MEM_BYTES)) $stop();
+//      if (type(MEM_BYTES_PACKED) != type(MY_MEM_BYTES_PACKED)) $stop();
+//      if (type(NIBBLES) == type(MY_BYTE)) $stop();
+//      if (type(MD_ARY) == type(MD_ARY_TOO)) $stop();
+//      if (type(MY_CHAR) != type(byte)) $stop();
       // TODO -- the rest
       // TODO -- case equal/not equal, ===, !===
    end

--- a/test_regress/t/t_type_comparison.v
+++ b/test_regress/t/t_type_comparison.v
@@ -118,6 +118,13 @@ module t();
 //      if (type(MY_CHAR) != type(byte)) $stop();
       // TODO -- the rest
       // TODO -- case equal/not equal, ===, !===
+      // TODO -- test associative arrays
+      // TODO -- test dynamic arrays
+      // TODO -- test unsized arrays
+      // TODO -- test const vars (both LHS and RHS) against const and non-const
+      // TODO -- test queues
+      // TODO -- test structs, enums and unions
+      // TODO -- test struct member vs type
    end
 
 

--- a/test_regress/t/t_type_comparison.v
+++ b/test_regress/t/t_type_comparison.v
@@ -83,6 +83,10 @@ module t();
       if (type(type1) != type(type2)) $stop();
       if (type(AB1) != type(AB2)) $stop();
       if (type(AB3) == type(AB1)) $stop();
+      if (type(AB4) != type(AB5)) $stop();
+      if (type(AB6) == type(AB4)) $stop();
+      if (type(AB6) == type(AB5)) $stop();
+      if (type(BYTE) != type(byte)) $stop();
       // TODO -- the rest
       // TODO -- case equal/not equal, ===, !===
    end


### PR DESCRIPTION
6.23 says that types can be compared as constant expressions.  VCS also supports this:
https://www.edaplayground.com/x/p4P

I have a test and started attacking the parser since I was just getting syntax errors.  I thought I could just make `type_reference` a child of `expr`, but that makes a loop since `type_reference` uses `expr`.  I ended up defining `type_reference` yP_EQUAL and yP_NOTEQUAL expressions, but I'm guessing this is a bit ham handed (I'll probably also need yP_CASEEQUAL and yPCASENOTEQUAL).  Is there a cleaner way to do this that I'm not yet seeing?

As it is now, I get:
```
%Error: t/t_type_comparison.v:13: Operator NEQ expected non-datatype LHS but '' is a datatype.
```
which sounds exactly right for the state I'm in.  I'll attack V3Width next.