### PR TITLE
Fix mingw build

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -370,7 +370,12 @@ AC_SUBST(CFG_LDFLAGS_SRC)
 # The pthread library is required by tcmalloc, so add it if it exists. If it
 # does not, the tcmalloc check below will fail anyway, and linking against
 # pthreads is harmless otherwise.
+CFG_LIBS="$LIBS $CFG_LIBS"
 _MY_LDLIBS_CHECK_OPT(CFG_LIBS, -lpthread)
+
+# Check libraries for MingW
+_MY_LDLIBS_CHECK_OPT(CFG_LIBS, -lbcrypt)
+_MY_LDLIBS_CHECK_OPT(CFG_LIBS, -lpsapi)
 
 # Check if tcmalloc is available based on --enable-tcmalloc
 _MY_LDLIBS_CHECK_IFELSE(

--- a/src/V3Os.cpp
+++ b/src/V3Os.cpp
@@ -43,7 +43,7 @@
 #include <sys/types.h>
 
 #if defined(_WIN32) || defined(__MINGW32__)
-# include <winnt.h>   // LONG for bcrypt.h on MINGW
+# include <windows.h>   // LONG for bcrypt.h on MINGW
 # include <bcrypt.h>  // BCryptGenRandom
 # include <chrono>
 # include <direct.h>  // mkdir


### PR DESCRIPTION
Fix the build under mingw64 by including windows.h, and by specifying the required libraries to link against.