### PR TITLE
Assert monotonic dump times #2103

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -28,6 +28,7 @@ Maciej Sobkowski
 Marco Widmer
 Matthew Ballance
 Mike Popoloski
+Nathan Myers
 Patrick Stewart
 Peter Monsson
 Philipp Wagner

--- a/include/verilated_fst_c.cpp
+++ b/include/verilated_fst_c.cpp
@@ -77,7 +77,7 @@ protected:
 VerilatedFst::VerilatedFst(void* fst)
     : m_fst(fst)
     , m_fullDump(true)
-    , m_lastDumpTime(0)
+    , m_minNextDumpTime(0)
     , m_nextCode(1)
     , m_scopeEscape('.') {
     m_valueStrBuffer.reserve(64 + 1);  // Need enough room for quad
@@ -198,8 +198,8 @@ void VerilatedFst::addCallback(VerilatedFstCallback_t initcb, VerilatedFstCallba
 
 void VerilatedFst::dump(vluint64_t timeui) {
     if (!isOpen()) return;
-    assert(m_lastDumpTime < timeui || timeui == 0);
-    m_lastDumpTime = timeui;
+    assert(m_minNextDumpTime <= timeui);
+    m_minNextDumpTime = timeui + 1;
     if (VL_UNLIKELY(m_fullDump)) {
         m_fullDump = false;  // No more need for next dump to be full
         for (vluint32_t ent = 0; ent < m_callbacks.size(); ++ent) {

--- a/include/verilated_fst_c.cpp
+++ b/include/verilated_fst_c.cpp
@@ -198,8 +198,11 @@ void VerilatedFst::addCallback(VerilatedFstCallback_t initcb, VerilatedFstCallba
 
 void VerilatedFst::dump(vluint64_t timeui) {
     if (!isOpen()) return;
-    assert(m_minNextDumpTime <= timeui);
-    if (   m_minNextDumpTime >  timeui) return;
+    if (timeui < m_minNextDumpTime) {
+      VL_PRINTF_MT("%%Warning: previous dump at t=%" VL_PRI64 ", requesting t=%" VL_PRI64 "\n",
+        vlsint64_t(m_minNextDumpTime - 1), vlsint64_t(timeui));
+      return;
+    }
     m_minNextDumpTime = timeui + 1;
     if (VL_UNLIKELY(m_fullDump)) {
         m_fullDump = false;  // No more need for next dump to be full

--- a/include/verilated_fst_c.cpp
+++ b/include/verilated_fst_c.cpp
@@ -35,7 +35,6 @@
 #include "gtkwave/lz4.c"
 
 #include <algorithm>
-#include <cassert>
 #include <cerrno>
 #include <ctime>
 #include <fcntl.h>

--- a/include/verilated_fst_c.cpp
+++ b/include/verilated_fst_c.cpp
@@ -198,8 +198,8 @@ void VerilatedFst::addCallback(VerilatedFstCallback_t initcb, VerilatedFstCallba
 void VerilatedFst::dump(vluint64_t timeui) {
     if (!isOpen()) return;
     if (timeui < m_minNextDumpTime) {
-      VL_PRINTF_MT("%%Warning: previous dump at t=%" VL_PRI64 ", requesting t=%" VL_PRI64 "\n",
-        vlsint64_t(m_minNextDumpTime - 1), vlsint64_t(timeui));
+      VL_PRINTF_MT("%%Warning: previous dump at t=%" VL_PRI64 "u, requesting t=%" VL_PRI64 "u\n",
+        m_minNextDumpTime - 1, timeui);
       return;
     }
     m_minNextDumpTime = timeui + 1;

--- a/include/verilated_fst_c.cpp
+++ b/include/verilated_fst_c.cpp
@@ -198,7 +198,7 @@ void VerilatedFst::addCallback(VerilatedFstCallback_t initcb, VerilatedFstCallba
 
 void VerilatedFst::dump(vluint64_t timeui) {
     if (!isOpen()) return;
-    assert(m_lastDumpTime < timeui);
+    assert(m_lastDumpTime < timeui || timeui == 0);
     m_lastDumpTime = timeui;
     if (VL_UNLIKELY(m_fullDump)) {
         m_fullDump = false;  // No more need for next dump to be full

--- a/include/verilated_fst_c.cpp
+++ b/include/verilated_fst_c.cpp
@@ -35,6 +35,7 @@
 #include "gtkwave/lz4.c"
 
 #include <algorithm>
+#include <cassert>
 #include <cerrno>
 #include <ctime>
 #include <fcntl.h>
@@ -76,6 +77,7 @@ protected:
 VerilatedFst::VerilatedFst(void* fst)
     : m_fst(fst)
     , m_fullDump(true)
+    , m_lastDumpTime(0)
     , m_nextCode(1)
     , m_scopeEscape('.') {
     m_valueStrBuffer.reserve(64 + 1);  // Need enough room for quad
@@ -196,6 +198,7 @@ void VerilatedFst::addCallback(VerilatedFstCallback_t initcb, VerilatedFstCallba
 
 void VerilatedFst::dump(vluint64_t timeui) {
     if (!isOpen()) return;
+    assert(m_lastDumpTime < timeui);
     if (VL_UNLIKELY(m_fullDump)) {
         m_fullDump = false;  // No more need for next dump to be full
         for (vluint32_t ent = 0; ent < m_callbacks.size(); ++ent) {

--- a/include/verilated_fst_c.cpp
+++ b/include/verilated_fst_c.cpp
@@ -199,6 +199,7 @@ void VerilatedFst::addCallback(VerilatedFstCallback_t initcb, VerilatedFstCallba
 void VerilatedFst::dump(vluint64_t timeui) {
     if (!isOpen()) return;
     assert(m_minNextDumpTime <= timeui);
+    if (   m_minNextDumpTime >  timeui) return;
     m_minNextDumpTime = timeui + 1;
     if (VL_UNLIKELY(m_fullDump)) {
         m_fullDump = false;  // No more need for next dump to be full

--- a/include/verilated_fst_c.cpp
+++ b/include/verilated_fst_c.cpp
@@ -199,6 +199,7 @@ void VerilatedFst::addCallback(VerilatedFstCallback_t initcb, VerilatedFstCallba
 void VerilatedFst::dump(vluint64_t timeui) {
     if (!isOpen()) return;
     assert(m_lastDumpTime < timeui);
+    m_lastDumpTime = timeui;
     if (VL_UNLIKELY(m_fullDump)) {
         m_fullDump = false;  // No more need for next dump to be full
         for (vluint32_t ent = 0; ent < m_callbacks.size(); ++ent) {

--- a/include/verilated_fst_c.h
+++ b/include/verilated_fst_c.h
@@ -48,6 +48,7 @@ private:
     void* m_fst;
     VerilatedAssertOneThread m_assertOne;  ///< Assert only called from single thread
     bool m_fullDump;
+    vluint64_t m_lastDumpTime;
     vluint32_t m_nextCode;  ///< Next code number to assign
     char m_scopeEscape;
     std::string m_module;

--- a/include/verilated_fst_c.h
+++ b/include/verilated_fst_c.h
@@ -48,7 +48,7 @@ private:
     void* m_fst;
     VerilatedAssertOneThread m_assertOne;  ///< Assert only called from single thread
     bool m_fullDump;
-    vluint64_t m_lastDumpTime;
+    vluint64_t m_minNextDumpTime;
     vluint32_t m_nextCode;  ///< Next code number to assign
     char m_scopeEscape;
     std::string m_module;


### PR DESCRIPTION
This is a pull request on behalf of Richard Myers, to ensure 
that dump is called with monotonically increasing timestamps.
It builds, but I have not run tests.

(BTW, in C++11 and later, line 51 in the header file could be

  vluint64_t m_lastDumpTime = 0;

and then not need to be initialized in the constructor.
Used faithfully, this can eliminate a lot of risk of 
uninitialized members.)
