### PR TITLE
Compile fast tracing code with OPT_FAST in single compile mode.

### DIFF
--- a/Changes
+++ b/Changes
@@ -17,6 +17,8 @@ The contributors that suggested a given feature are shown in []. Thanks!
 
 ****  Improve FST dump performance, #2244. [Geza Lore]
 
+****  Fix build of fast path tracing code to use OPT_FAST, #2245. [Geza Lore]
+
 
 * Verilator 4.032 2020-04-04
 

--- a/bin/verilator
+++ b/bin/verilator
@@ -2110,9 +2110,8 @@ After running Make, the C++ compiler may produce the following:
     {mod_prefix}{misc}.o                // Intermediate objects
     {prefix}                            // Final executable (w/--exe argument)
     {prefix}__ALL.a                     // Library of all Verilated objects
-    {prefix}__ALLboth.cpp               // Include of classes for single compile
-    {prefix}__ALLcls.cpp                // Include of user classes for single compile
-    {prefix}__ALLsup.cpp                // Include of support files for single compile
+    {prefix}__ALLfast.cpp               // Include of hot code for single compile
+    {prefix}__ALLslow.cpp               // Include of slow code for single compile
     {prefix}{misc}.d                    // Intermediate dependencies
     {prefix}{misc}.o                    // Intermediate objects
 
@@ -2689,8 +2688,8 @@ underneath NC:
    cd obj_dir
    ncsc_run \
         sc_main.cpp \
-        Vour__ALLcls.cpp \
-        Vour__ALLsup.cpp \
+        Vour__ALLfast.cpp \
+        Vour__ALLslow.cpp \
         verilated.cpp
 
 For larger designs you'll want to automate this using makefiles, which pull

--- a/include/verilated.mk.in
+++ b/include/verilated.mk.in
@@ -163,10 +163,11 @@ LIBS   += -lm -lstdc++
 #######################################################################
 # Overall Objects Linking
 
-VK_CLASSES_H   = $(addsuffix .h, $(VM_CLASSES))
-VK_CLASSES_CPP = $(addsuffix .cpp, $(VM_CLASSES))
+VK_CLASSES_FAST_CPP = $(addsuffix .cpp, $(VM_CLASSES_FAST))
+VK_CLASSES_SLOW_CPP = $(addsuffix .cpp, $(VM_CLASSES_SLOW))
 
-VK_SUPPORT_CPP = $(addsuffix .cpp, $(VM_SUPPORT))
+VK_SUPPORT_FAST_CPP = $(addsuffix .cpp, $(VM_SUPPORT_FAST))
+VK_SUPPORT_SLOW_CPP = $(addsuffix .cpp, $(VM_SUPPORT_SLOW))
 
 VK_USER_OBJS   = $(addsuffix .o, $(VM_USER_CLASSES))
 
@@ -175,11 +176,11 @@ VK_GLOBAL_OBJS = $(addsuffix .o, $(VM_GLOBAL_FAST) $(VM_GLOBAL_SLOW))
 ifneq ($(VM_PARALLEL_BUILDS),1)
   # Fast building, all .cpp's in one fell swoop
   # This saves about 5 sec per module, but can be slower if only a little changes
-  VK_OBJS += $(VM_PREFIX)__ALLcls.o   $(VM_PREFIX)__ALLsup.o
-  all_cpp:   $(VM_PREFIX)__ALLcls.cpp $(VM_PREFIX)__ALLsup.cpp
-  $(VM_PREFIX)__ALLcls.cpp: $(VK_CLASSES_CPP)
+  VK_OBJS += $(VM_PREFIX)__ALLfast.o   $(VM_PREFIX)__ALLslow.o
+  all_cpp:   $(VM_PREFIX)__ALLfast.cpp $(VM_PREFIX)__ALLslow.cpp
+  $(VM_PREFIX)__ALLfast.cpp: $(VK_CLASSES_FAST_CPP) $(VK_SUPPORT_FAST_CPP)
 	$(VERILATOR_INCLUDER) -DVL_INCLUDE_OPT=include $^ > $@
-  $(VM_PREFIX)__ALLsup.cpp: $(VK_SUPPORT_CPP)
+  $(VM_PREFIX)__ALLslow.cpp: $(VK_CLASSES_SLOW_CPP) $(VK_SUPPORT_SLOW_CPP)
 	$(VERILATOR_INCLUDER) -DVL_INCLUDE_OPT=include $^ > $@
 else
   #Slow way of building... Each .cpp file by itself
@@ -194,10 +195,10 @@ $(VM_PREFIX)__ALL.a: $(VK_OBJS)
 ### Compile rules
 
 ifneq ($(VM_DEFAULT_RULES),0)
-$(VM_PREFIX)__ALLcls.o: $(VM_PREFIX)__ALLcls.cpp
+$(VM_PREFIX)__ALLfast.o: $(VM_PREFIX)__ALLfast.cpp
 	$(OBJCACHE) $(CXX) $(CXXFLAGS) $(CPPFLAGS) $(OPT_FAST) -c -o $@ $<
 
-$(VM_PREFIX)__ALLsup.o: $(VM_PREFIX)__ALLsup.cpp
+$(VM_PREFIX)__ALLslow.o: $(VM_PREFIX)__ALLslow.cpp
 	$(OBJCACHE) $(CXX) $(CXXFLAGS) $(CPPFLAGS) $(OPT_SLOW) -c -o $@ $<
 
 # VM_GLOBAL_FAST files including verilated.o use this rule


### PR DESCRIPTION
Please see commit message. This has impacted the SweRV default build, where simulation with VCD tracing is [unsurpsisingly] 35% faster with this change.