### PR TITLE
Fix to make trace code allocation dense.

### DIFF
--- a/Changes
+++ b/Changes
@@ -15,11 +15,11 @@ The contributors that suggested a given feature are shown in []. Thanks!
 
 ****  Add error if use SystemC 2.2 and earlier (pre-2011) as is deprecated.
 
-****  Improve FST dump performance, #2244. [Geza Lore]
+****  Improve FST dump performance, #2244, #2250. [Geza Lore]
 
 ****  Fix build of fast path tracing code to use OPT_FAST, #2245. [Geza Lore]
 
-****  Improve VCD dump performance, ##2246. [Geza Lore]
+****  Improve VCD dump performance, #2246, #2250. [Geza Lore]
 
 
 * Verilator 4.032 2020-04-04

--- a/src/V3AstNodes.h
+++ b/src/V3AstNodes.h
@@ -4226,7 +4226,7 @@ public:
         m_code = 0;
         m_codeInc = ((arrayRange.ranged() ? arrayRange.elements() : 1)
                      * valuep->dtypep()->widthWords()
-                     * (VL_EDATASIZE / sizeof(uint32_t)));  // A code is always 32-bits
+                     * (VL_EDATASIZE / (8*sizeof(uint32_t))));  // A code is always 32-bits
         m_varType = varp->varType();
         m_declKwd = varp->declKwd();
         m_declDirection = varp->declDirection();


### PR DESCRIPTION
I found this while hacking on the tracing implementation. It removes 70% of D-cache misses with SweRV VCD tracing as we no longer store 2 bits per cache line in the worst case :) should help FST as well but there the FST API still dominates.