### PR TITLE
delete file object to flush its contents.

### DIFF
--- a/src/V3EmitCSyms.cpp
+++ b/src/V3EmitCSyms.cpp
@@ -354,6 +354,7 @@ public:
         m_ofpBase = NULL;
         iterate(nodep);
     }
+    virtual ~EmitCSyms() VL_OVERRIDE { VL_DO_DANGLING(delete m_ofpBase, m_ofpBase); }
 };
 
 void EmitCSyms::emitSymHdr() {


### PR DESCRIPTION
Cherry-picked from #2249