### PR TITLE
Factor out trace implementation common to all formats.

### DIFF
--- a/include/verilated_fst_c.cpp
+++ b/include/verilated_fst_c.cpp
@@ -20,7 +20,6 @@
 // clang-format off
 
 #define __STDC_LIMIT_MACROS  // UINT64_MAX
-#include "verilatedos.h"
 #include "verilated.h"
 #include "verilated_fst_c.h"
 
@@ -54,65 +53,35 @@
 // clang-format on
 
 //=============================================================================
+// Specialization of the generics for this trace format
 
-class VerilatedFstCallInfo {
-protected:
-    friend class VerilatedFst;
-    VerilatedFstCallback_t m_initcb;  ///< Initialization Callback function
-    VerilatedFstCallback_t m_fullcb;  ///< Full Dumping Callback function
-    VerilatedFstCallback_t m_changecb;  ///< Incremental Dumping Callback function
-    void* m_userthis;  ///< Fake "this" for caller
-    vluint32_t m_code;  ///< Starting code number
-    // CONSTRUCTORS
-    VerilatedFstCallInfo(VerilatedFstCallback_t icb, VerilatedFstCallback_t fcb,
-                         VerilatedFstCallback_t changecb, void* ut)
-        : m_initcb(icb)
-        , m_fullcb(fcb)
-        , m_changecb(changecb)
-        , m_userthis(ut)
-        , m_code(1) {}
-    ~VerilatedFstCallInfo() {}
-};
+#define VL_DERIVED_T VerilatedFst
+#include "verilated_trace_imp.cpp"
+#undef VL_DERIVED_T
 
 //=============================================================================
 // VerilatedFst
 
 VerilatedFst::VerilatedFst(void* fst)
     : m_fst(fst)
-    , m_fullDump(true)
-    , m_minNextDumpTime(0)
-    , m_nextCode(1)
-    , m_scopeEscape('.')
-    , m_symbolp(NULL)
-    , m_sigs_oldvalp(NULL) {
-    m_valueStrBuffer.reserve(64 + 1);  // Need enough room for quad
-    set_time_unit(Verilated::timeunitString());
-    set_time_resolution(Verilated::timeprecisionString());
-}
+    , m_symbolp(NULL) {}
 
 VerilatedFst::~VerilatedFst() {
     if (m_fst) fstWriterClose(m_fst);
     if (m_symbolp) VL_DO_CLEAR(delete[] m_symbolp, m_symbolp = NULL);
-    if (m_sigs_oldvalp) VL_DO_CLEAR(delete[] m_sigs_oldvalp, m_sigs_oldvalp = NULL);
 }
 
 void VerilatedFst::open(const char* filename) VL_MT_UNSAFE {
     m_assertOne.check();
     m_fst = fstWriterCreate(filename, 1);
     fstWriterSetPackType(m_fst, FST_WR_PT_LZ4);
-    fstWriterSetTimescaleFromString(m_fst, m_timeRes.c_str());
+    fstWriterSetTimescaleFromString(m_fst, timeResStr().c_str());  // lintok-begin-on-ref
 #ifdef VL_TRACE_THREADED
     fstWriterSetParallelMode(m_fst, 1);
 #endif
     m_curScope.clear();
-    m_nextCode = 1;
 
-    for (vluint32_t ent = 0; ent < m_callbacks.size(); ++ent) {
-        VerilatedFstCallInfo* cip = m_callbacks[ent];
-        cip->m_code = m_nextCode;
-        // Initialize; callbacks will call decl* which update m_nextCode
-        (cip->m_initcb)(this, cip->m_userthis, cip->m_code);
-    }
+    VerilatedTrace<VerilatedFst>::traceInit();
 
     // Clear the scope stack
     std::list<std::string>::iterator it = m_curScope.begin();
@@ -123,19 +92,16 @@ void VerilatedFst::open(const char* filename) VL_MT_UNSAFE {
 
     // convert m_code2symbol into an array for fast lookup
     if (!m_symbolp) {
-        m_symbolp = new fstHandle[m_nextCode + 10];
+        m_symbolp = new fstHandle[nextCode()];
         for (Code2SymbolType::iterator it = m_code2symbol.begin(); it != m_code2symbol.end();
              ++it) {
             m_symbolp[it->first] = it->second;
         }
     }
     m_code2symbol.clear();
-
-    // Allocate space now we know the number of codes
-    if (!m_sigs_oldvalp) m_sigs_oldvalp = new vluint32_t[m_nextCode + 10];
 }
 
-void VerilatedFst::module(const std::string& name) { m_module = name; }
+void VerilatedFst::emitTimeChange(vluint64_t timeui) { fstWriterEmitTimeChange(m_fst, timeui); }
 
 //=============================================================================
 // Decl
@@ -151,11 +117,7 @@ void VerilatedFst::declDTypeEnum(int dtypenum, const char* name, vluint32_t elem
 void VerilatedFst::declSymbol(vluint32_t code, const char* name, int dtypenum, fstVarDir vardir,
                               fstVarType vartype, bool array, int arraynum, vluint32_t len,
                               vluint32_t bits) {
-
-    // Make sure deduplicate tracking increments for future declarations
-    int codesNeeded = 1 + int(bits / 32);
-    // Not supported: if (tri) codesNeeded *= 2;  // Space in change array for __en signals
-    m_nextCode = std::max(m_nextCode, code + codesNeeded);
+    VerilatedTrace<VerilatedFst>::declCode(code, bits, false);
 
     std::pair<Code2SymbolType::iterator, bool> p
         = m_code2symbol.insert(std::make_pair(code, static_cast<fstHandle>(NULL)));
@@ -164,7 +126,7 @@ void VerilatedFst::declSymbol(vluint32_t code, const char* name, int dtypenum, f
     std::list<std::string> tokens(beg, end);  // Split name
     std::string symbol_name(tokens.back());
     tokens.pop_back();  // Remove symbol name from hierarchy
-    tokens.insert(tokens.begin(), m_module);  // Add current module to the hierarchy
+    tokens.insert(tokens.begin(), moduleName());  // Add current module to the hierarchy
 
     // Find point where current and new scope diverge
     std::list<std::string>::iterator cur_it = m_curScope.begin();
@@ -205,47 +167,49 @@ void VerilatedFst::declSymbol(vluint32_t code, const char* name, int dtypenum, f
     }
 }
 
-//=============================================================================
-// Callbacks
-
-void VerilatedFst::addCallback(VerilatedFstCallback_t initcb, VerilatedFstCallback_t fullcb,
-                               VerilatedFstCallback_t changecb, void* userthis) VL_MT_UNSAFE_ONE {
-    m_assertOne.check();
-    if (VL_UNLIKELY(isOpen())) {
-        std::string msg = (std::string("Internal: ") + __FILE__ + "::" + __FUNCTION__
-                           + " called with already open file");
-        VL_FATAL_MT(__FILE__, __LINE__, "", msg.c_str());
-    }
-    VerilatedFstCallInfo* cip = new VerilatedFstCallInfo(initcb, fullcb, changecb, userthis);
-    m_callbacks.push_back(cip);
+void VerilatedFst::declBit(vluint32_t code, const char* name, int dtypenum, fstVarDir vardir,
+                           fstVarType vartype, bool array, int arraynum) {
+    declSymbol(code, name, dtypenum, vardir, vartype, array, arraynum, 1, 1);
+}
+void VerilatedFst::declBus(vluint32_t code, const char* name, int dtypenum, fstVarDir vardir,
+                           fstVarType vartype, bool array, int arraynum, int msb, int lsb) {
+    declSymbol(code, name, dtypenum, vardir, vartype, array, arraynum, msb - lsb + 1,
+               msb - lsb + 1);
+}
+void VerilatedFst::declQuad(vluint32_t code, const char* name, int dtypenum, fstVarDir vardir,
+                            fstVarType vartype, bool array, int arraynum, int msb, int lsb) {
+    declSymbol(code, name, dtypenum, vardir, vartype, array, arraynum, msb - lsb + 1,
+               msb - lsb + 1);
+}
+void VerilatedFst::declArray(vluint32_t code, const char* name, int dtypenum, fstVarDir vardir,
+                             fstVarType vartype, bool array, int arraynum, int msb, int lsb) {
+    declSymbol(code, name, dtypenum, vardir, vartype, array, arraynum, msb - lsb + 1,
+               msb - lsb + 1);
+}
+void VerilatedFst::declFloat(vluint32_t code, const char* name, int dtypenum, fstVarDir vardir,
+                             fstVarType vartype, bool array, int arraynum) {
+    declSymbol(code, name, dtypenum, vardir, vartype, array, arraynum, 1, 32);
+}
+void VerilatedFst::declDouble(vluint32_t code, const char* name, int dtypenum, fstVarDir vardir,
+                              fstVarType vartype, bool array, int arraynum) {
+    declSymbol(code, name, dtypenum, vardir, vartype, array, arraynum, 2, 64);
 }
 
-//=============================================================================
-// Dumping
-
-void VerilatedFst::dump(vluint64_t timeui) {
-    if (!isOpen()) return;
-    if (timeui < m_minNextDumpTime) {
-        VL_PRINTF_MT("%%Warning: previous dump at t=%" VL_PRI64 "u, requesting t=%" VL_PRI64 "u\n",
-                     m_minNextDumpTime - 1, timeui);
-        return;
-    }
-    m_minNextDumpTime = timeui + 1;
-    fstWriterEmitTimeChange(m_fst, timeui);
-    if (VL_UNLIKELY(m_fullDump)) {
-        m_fullDump = false;  // No more need for next dump to be full
-        for (vluint32_t ent = 0; ent < m_callbacks.size(); ++ent) {
-            VerilatedFstCallInfo* cip = m_callbacks[ent];
-            (cip->m_fullcb)(this, cip->m_userthis, cip->m_code);
-        }
-        return;
-    }
-    for (vluint32_t ent = 0; ent < m_callbacks.size(); ++ent) {
-        VerilatedFstCallInfo* cip = m_callbacks[ent];
-        (cip->m_changecb)(this, cip->m_userthis, cip->m_code);
-    }
+void VerilatedFst::emitBit(vluint32_t code, vluint32_t newval) {
+    fstWriterEmitValueChange(m_fst, m_symbolp[code], newval ? "1" : "0");
 }
-
-//********************************************************************
-// Local Variables:
-// End:
+template <int T_Bits> void VerilatedFst::emitBus(vluint32_t code, vluint32_t newval) {
+    fstWriterEmitValueChange32(m_fst, m_symbolp[code], T_Bits, newval);
+}
+void VerilatedFst::emitQuad(vluint32_t code, vluint64_t newval, int bits) {
+    fstWriterEmitValueChange64(m_fst, m_symbolp[code], bits, newval);
+}
+void VerilatedFst::emitArray(vluint32_t code, const vluint32_t* newvalp, int bits) {
+    fstWriterEmitValueChangeVec32(m_fst, m_symbolp[code], bits, newvalp);
+}
+void VerilatedFst::emitFloat(vluint32_t code, float newval) {
+    fstWriterEmitValueChange(m_fst, m_symbolp[code], &newval);
+}
+void VerilatedFst::emitDouble(vluint32_t code, double newval) {
+    fstWriterEmitValueChange(m_fst, m_symbolp[code], &newval);
+}

--- a/include/verilated_fst_c.h
+++ b/include/verilated_fst_c.h
@@ -38,7 +38,7 @@
 class VerilatedFst : public VerilatedTrace<VerilatedFst> {
 private:
     // Give the superclass access to private bits (to avoid virtual functions)
-    friend VerilatedTrace<VerilatedFst>;
+    friend class VerilatedTrace<VerilatedFst>;
 
     //=========================================================================
     // FST specific internals

--- a/include/verilated_fst_c.h
+++ b/include/verilated_fst_c.h
@@ -20,8 +20,8 @@
 #ifndef _VERILATED_FST_C_H_
 #define _VERILATED_FST_C_H_ 1
 
-#include "verilatedos.h"
 #include "verilated.h"
+#include "verilated_trace.h"
 
 #include "gtkwave/fstapi.h"
 
@@ -30,175 +30,99 @@
 #include <string>
 #include <vector>
 
-class VerilatedFst;
-class VerilatedFstCallInfo;
-typedef void (*VerilatedFstCallback_t)(VerilatedFst* vcdp, void* userthis, vluint32_t code);
-
 //=============================================================================
 // VerilatedFst
 /// Base class to create a Verilator FST dump
 /// This is an internally used class - see VerilatedFstC for what to call from applications
 
-class VerilatedFst {
+class VerilatedFst : public VerilatedTrace<VerilatedFst> {
+private:
+    // Give the superclass access to private bits (to avoid virtual functions)
+    friend VerilatedTrace<VerilatedFst>;
+
+    //=========================================================================
+    // FST specific internals
+
     typedef std::map<vluint32_t, fstHandle> Code2SymbolType;
     typedef std::map<int, fstEnumHandle> Local2FstDtype;
-    typedef std::vector<VerilatedFstCallInfo*> CallbackVec;
 
-private:
     void* m_fst;
-    VerilatedAssertOneThread m_assertOne;  ///< Assert only called from single thread
-    bool m_fullDump;
-    vluint64_t m_minNextDumpTime;
-    vluint32_t m_nextCode;  ///< Next code number to assign
-    char m_scopeEscape;
-    std::string m_module;
-    CallbackVec m_callbacks;  ///< Routines to perform dumping
     Code2SymbolType m_code2symbol;
     Local2FstDtype m_local2fstdtype;
     std::list<std::string> m_curScope;
     fstHandle* m_symbolp;  ///< same as m_code2symbol, but as an array
-    vluint32_t* m_sigs_oldvalp;
     // CONSTRUCTORS
     VL_UNCOPYABLE(VerilatedFst);
     void declSymbol(vluint32_t code, const char* name, int dtypenum, fstVarDir vardir,
                     fstVarType vartype, bool array, int arraynum, vluint32_t len, vluint32_t bits);
-    // helpers
-    std::vector<char> m_valueStrBuffer;
 
-    std::string m_timeRes;
+protected:
+    //=========================================================================
+    // Implementation of VerilatedTrace interface
+
+    // Implementations of protected virtual methods for VerilatedTrace
+    void emitTimeChange(vluint64_t timeui) VL_OVERRIDE;
+
+    // Hooks called from VerilatedTrace
+    bool preFullDump() VL_OVERRIDE { return isOpen(); }
+    bool preChangeDump() VL_OVERRIDE { return isOpen(); }
+
+    // Implementations of duck-typed methods for VerilatedTrace
+    void emitBit(vluint32_t code, vluint32_t newval);
+    template <int T_Bits> void emitBus(vluint32_t code, vluint32_t newval);
+    void emitQuad(vluint32_t code, vluint64_t newval, int bits);
+    void emitArray(vluint32_t code, const vluint32_t* newvalp, int bits);
+    void emitFloat(vluint32_t code, float newval);
+    void emitDouble(vluint32_t code, double newval);
 
 public:
+    //=========================================================================
+    // External interface to client code
+
     explicit VerilatedFst(void* fst = NULL);
     ~VerilatedFst();
-    void changeThread() { m_assertOne.changeThread(); }
-    bool isOpen() const { return m_fst != NULL; }
+
+    /// Open the file; call isOpen() to see if errors
     void open(const char* filename) VL_MT_UNSAFE;
-    void flush() VL_MT_UNSAFE { fstWriterFlushContext(m_fst); }
+    /// Close the file
     void close() VL_MT_UNSAFE {
         m_assertOne.check();
         fstWriterClose(m_fst);
         m_fst = NULL;
     }
-    void set_time_unit(const char*) {}
-    void set_time_unit(const std::string& unit) { set_time_unit(unit.c_str()); }
+    /// Flush any remaining data to this file
+    void flush() VL_MT_UNSAFE { fstWriterFlushContext(m_fst); }
+    /// Is file open?
+    bool isOpen() const { return m_fst != NULL; }
 
-    void set_time_resolution(const char* unitp) { m_timeRes = unitp; }
-    void set_time_resolution(const std::string& unit) { m_timeRes = unit; }
+    //=========================================================================
+    // Internal interface to Verilator generated code
 
-    // double timescaleToDouble(const char* unitp);
-    // std::string doubleToTimescale(double value);
-
-    /// Change character that splits scopes.  Note whitespace are ALWAYS escapes.
-    void scopeEscape(char flag) { m_scopeEscape = flag; }
-    /// Is this an escape?
-    bool isScopeEscape(char c) { return isspace(c) || c == m_scopeEscape; }
-    /// Inside dumping routines, called each cycle to make the dump
-    void dump(vluint64_t timeui);
-    /// Inside dumping routines, declare callbacks for tracings
-    void addCallback(VerilatedFstCallback_t initcb, VerilatedFstCallback_t fullcb,
-                     VerilatedFstCallback_t changecb, void* userthis) VL_MT_UNSAFE_ONE;
-
-    /// Inside dumping routines, declare a module
-    void module(const std::string& name);
     /// Inside dumping routines, declare a data type
     void declDTypeEnum(int dtypenum, const char* name, vluint32_t elements,
                        unsigned int minValbits, const char** itemNamesp, const char** itemValuesp);
+
     /// Inside dumping routines, declare a signal
     void declBit(vluint32_t code, const char* name, int dtypenum, fstVarDir vardir,
-                 fstVarType vartype, bool array, int arraynum) {
-        declSymbol(code, name, dtypenum, vardir, vartype, array, arraynum, 1, 1);
-    }
+                 fstVarType vartype, bool array, int arraynum);
     void declBus(vluint32_t code, const char* name, int dtypenum, fstVarDir vardir,
-                 fstVarType vartype, bool array, int arraynum, int msb, int lsb) {
-        declSymbol(code, name, dtypenum, vardir, vartype, array, arraynum, msb - lsb + 1,
-                   msb - lsb + 1);
-    }
+                 fstVarType vartype, bool array, int arraynum, int msb, int lsb);
     void declQuad(vluint32_t code, const char* name, int dtypenum, fstVarDir vardir,
-                  fstVarType vartype, bool array, int arraynum, int msb, int lsb) {
-        declSymbol(code, name, dtypenum, vardir, vartype, array, arraynum, msb - lsb + 1,
-                   msb - lsb + 1);
-    }
+                  fstVarType vartype, bool array, int arraynum, int msb, int lsb);
     void declArray(vluint32_t code, const char* name, int dtypenum, fstVarDir vardir,
-                   fstVarType vartype, bool array, int arraynum, int msb, int lsb) {
-        declSymbol(code, name, dtypenum, vardir, vartype, array, arraynum, msb - lsb + 1,
-                   msb - lsb + 1);
-    }
+                   fstVarType vartype, bool array, int arraynum, int msb, int lsb);
     void declFloat(vluint32_t code, const char* name, int dtypenum, fstVarDir vardir,
-                   fstVarType vartype, bool array, int arraynum) {
-        declSymbol(code, name, dtypenum, vardir, vartype, array, arraynum, 1, 32);
-    }
+                   fstVarType vartype, bool array, int arraynum);
     void declDouble(vluint32_t code, const char* name, int dtypenum, fstVarDir vardir,
-                    fstVarType vartype, bool array, int arraynum) {
-        declSymbol(code, name, dtypenum, vardir, vartype, array, arraynum, 2, 64);
-    }
-
-    //=========================================================================
-    // Inside dumping routines used by Verilator
-
-    vluint32_t* oldp(vluint32_t code) { return m_sigs_oldvalp + code; }
-
-    //=========================================================================
-    // Write back to previous value buffer value and emit
-
-    void fullBit(vluint32_t* oldp, vluint32_t newval) {
-        *oldp = newval;
-        fstWriterEmitValueChange(m_fst, m_symbolp[oldp - m_sigs_oldvalp], newval ? "1" : "0");
-    }
-    template <int T_Bits> void fullBus(vluint32_t* oldp, vluint32_t newval) {
-        *oldp = newval;
-        fstWriterEmitValueChange32(m_fst, m_symbolp[oldp - m_sigs_oldvalp], T_Bits, newval);
-    }
-    void fullQuad(vluint32_t* oldp, vluint64_t newval, int bits) {
-        *reinterpret_cast<vluint64_t*>(oldp) = newval;
-        fstWriterEmitValueChange64(m_fst, m_symbolp[oldp - m_sigs_oldvalp], bits, newval);
-    }
-    void fullArray(vluint32_t* oldp, const vluint32_t* newvalp, int bits) {
-        for (int i = 0; i < (bits + 31) / 32; ++i) oldp[i] = newvalp[i];
-        fstWriterEmitValueChangeVec32(m_fst, m_symbolp[oldp - m_sigs_oldvalp], bits, newvalp);
-    }
-    void fullFloat(vluint32_t* oldp, float newval) {
-        // cppcheck-suppress invalidPointerCast
-        *reinterpret_cast<float*>(oldp) = newval;
-        fstWriterEmitValueChange(m_fst, m_symbolp[oldp - m_sigs_oldvalp], oldp);
-    }
-    void fullDouble(vluint32_t* oldp, double newval) {
-        // cppcheck-suppress invalidPointerCast
-        *reinterpret_cast<double*>(oldp) = newval;
-        fstWriterEmitValueChange(m_fst, m_symbolp[oldp - m_sigs_oldvalp], oldp);
-    }
-
-    //=========================================================================
-    // Check previous value and emit if changed
-
-    inline void chgBit(vluint32_t* oldp, vluint32_t newval) {
-        const vluint32_t diff = *oldp ^ newval;
-        if (VL_UNLIKELY(diff)) fullBit(oldp, newval);
-    }
-    template <int T_Bits> inline void chgBus(vluint32_t* oldp, vluint32_t newval) {
-        const vluint32_t diff = *oldp ^ newval;
-        if (VL_UNLIKELY(diff)) fullBus<T_Bits>(oldp, newval);
-    }
-    inline void chgQuad(vluint32_t* oldp, vluint64_t newval, int bits) {
-        const vluint64_t diff = *reinterpret_cast<vluint64_t*>(oldp) ^ newval;
-        if (VL_UNLIKELY(diff)) fullQuad(oldp, newval, bits);
-    }
-    inline void chgArray(vluint32_t* oldp, const vluint32_t* newvalp, int bits) {
-        for (int i = 0; i < (bits + 31) / 32; ++i) {
-            if (VL_UNLIKELY(oldp[i] ^ newvalp[i])) {
-                fullArray(oldp, newvalp, bits);
-                return;
-            }
-        }
-    }
-    inline void chgFloat(vluint32_t* oldp, float newval) {
-        // cppcheck-suppress invalidPointerCast
-        if (VL_UNLIKELY(*reinterpret_cast<float*>(oldp) != newval)) fullFloat(oldp, newval);
-    }
-    inline void chgDouble(vluint32_t* oldp, double newval) {
-        // cppcheck-suppress invalidPointerCast
-        if (VL_UNLIKELY(*reinterpret_cast<double*>(oldp) != newval)) fullDouble(oldp, newval);
-    }
+                    fstVarType vartype, bool array, int arraynum);
 };
+
+// Declare specialization here as it's used in VerilatedFstC just below
+template <> void VerilatedTrace<VerilatedFst>::dump(vluint64_t timeui);
+template <> void VerilatedTrace<VerilatedFst>::set_time_unit(const char* unitp);
+template <> void VerilatedTrace<VerilatedFst>::set_time_unit(const std::string& unit);
+template <> void VerilatedTrace<VerilatedFst>::set_time_resolution(const char* unitp);
+template <> void VerilatedTrace<VerilatedFst>::set_time_resolution(const std::string& unit);
 
 //=============================================================================
 // VerilatedFstC
@@ -239,11 +163,11 @@ public:
     /// Set time units (s/ms, defaults to ns)
     /// For Verilated models, these propage from the Verilated default --timeunit
     void set_time_unit(const char* unitp) { m_sptrace.set_time_unit(unitp); }
-    void set_time_unit(const std::string& unit) { set_time_unit(unit.c_str()); }
+    void set_time_unit(const std::string& unit) { m_sptrace.set_time_unit(unit); }
     /// Set time resolution (s/ms, defaults to ns)
     /// For Verilated models, these propage from the Verilated default --timeunit
     void set_time_resolution(const char* unitp) { m_sptrace.set_time_resolution(unitp); }
-    void set_time_resolution(const std::string& unit) { set_time_resolution(unit.c_str()); }
+    void set_time_resolution(const std::string& unit) { m_sptrace.set_time_resolution(unit); }
 
     /// Internal class access
     inline VerilatedFst* spTrace() { return &m_sptrace; };

--- a/include/verilated_trace.h
+++ b/include/verilated_trace.h
@@ -1,0 +1,184 @@
+// -*- mode: C++; c-file-style: "cc-mode" -*-
+//=============================================================================
+//
+// THIS MODULE IS PUBLICLY LICENSED
+//
+// Copyright 2001-2020 by Wilson Snyder. This program is free software; you
+// can redistribute it and/or modify it under the terms of either the GNU
+// Lesser General Public License Version 3 or the Perl Artistic License
+// Version 2.0.
+// SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+//
+//=============================================================================
+///
+/// \file
+/// \brief Tracing functionality common to all formats
+///
+//=============================================================================
+// SPDIFF_OFF
+
+#ifndef _VERILATED_TRACE_H_
+#define _VERILATED_TRACE_H_ 1
+
+#include "verilated.h"
+
+#include <string>
+#include <vector>
+
+class VerilatedTraceCallInfo;
+
+//=============================================================================
+// VerilatedTrace
+
+// VerilatedTrace uses F-bounded polymorphism to access duck-typed
+// implementations in the format specific derived class, which must be passed
+// as the type parameter T_Derived
+template <class T_Derived> class VerilatedTrace {
+private:
+    //=========================================================================
+    // Generic tracing internals
+
+    vluint32_t* m_sigs_oldvalp;  ///< Old value store
+    vluint64_t m_timeLastDump;  ///< Last time we did a dump
+    std::vector<VerilatedTraceCallInfo*> m_callbacks;  ///< Routines to perform dumping
+    bool m_fullDump;  ///< Whether a full dump is required on the next call to 'dump'
+    vluint32_t m_nextCode;  ///< Next code number to assign
+    std::string m_moduleName;  ///< Name of module being trace initialized now
+    char m_scopeEscape;
+    double m_timeRes;  ///< Time resolution (ns/ms etc)
+    double m_timeUnit;  ///< Time units (ns/ms etc)
+
+    // Equivalent to 'this' but is of the sub-type 'T_Derived*'. Use 'self()->'
+    // to access duck-typed functions to avoid a virtual function call.
+    T_Derived* self() { return static_cast<T_Derived*>(this); }
+
+    // CONSTRUCTORS
+    VL_UNCOPYABLE(VerilatedTrace);
+
+protected:
+    //=========================================================================
+    // Internals available to format specific implementations
+
+    VerilatedAssertOneThread m_assertOne;  ///< Assert only called from single thread
+
+    vluint32_t nextCode() const { return m_nextCode; }
+    const std::string& moduleName() const { return m_moduleName; }
+    void fullDump(bool value) { m_fullDump = value; }
+    vluint64_t timeLastDump() { return m_timeLastDump; }
+
+    double timeRes() const { return m_timeRes; }
+    double timeUnit() const { return m_timeUnit; }
+    std::string timeResStr() const;
+    std::string timeUnitStr() const;
+
+    void traceInit() VL_MT_UNSAFE;
+
+    void declCode(vluint32_t code, vluint32_t bits, bool tri);
+
+    /// Is this an escape?
+    bool isScopeEscape(char c) { return isspace(c) || c == m_scopeEscape; }
+    /// Character that splits scopes.  Note whitespace are ALWAYS escapes.
+    char scopeEscape() { return m_scopeEscape; }
+
+    //=========================================================================
+    // Virtual functions to be provided by the format specific implementation
+
+    // Called when the trace moves forward to a new time point
+    virtual void emitTimeChange(vluint64_t timeui) = 0;
+
+    // These hooks are called before a full or change based dump is produced.
+    // The return value indicates whether to proceed with the dump.
+    virtual bool preFullDump() { return true; }
+    virtual bool preChangeDump() { return true; }
+
+public:
+    //=========================================================================
+    // External interface to client code
+
+    explicit VerilatedTrace();
+    ~VerilatedTrace();
+
+    // Set time units (s/ms, defaults to ns)
+    void set_time_unit(const char* unitp);
+    void set_time_unit(const std::string& unit);
+    // Set time resolution (s/ms, defaults to ns)
+    void set_time_resolution(const char* unitp);
+    void set_time_resolution(const std::string& unit);
+
+    // Call
+    void dump(vluint64_t timeui);
+
+    //=========================================================================
+    // Non-hot path internal interface to Verilator generated code
+
+    typedef void (*callback_t)(T_Derived* tracep, void* userthis, vluint32_t code);
+
+    void changeThread() { m_assertOne.changeThread(); }
+
+    void addCallback(callback_t initcb, callback_t fullcb, callback_t changecb,
+                     void* userthis) VL_MT_UNSAFE_ONE;
+
+    void module(const std::string& name) VL_MT_UNSAFE_ONE {
+        m_assertOne.check();
+        m_moduleName = name;
+    }
+
+    void scopeEscape(char flag) { m_scopeEscape = flag; }
+
+    //=========================================================================
+    // Hot path internal interface to Verilator generated code
+
+    // Implementation note: We rely on the following duck-typed implementations
+    // in the derived class T_Derived. These emit* functions record a format
+    // specific trace entry. Normally one would use pure virtual functions for
+    // these here, but we cannot afford dynamic dispatch for calling these as
+    // this is very hot code during tracing.
+
+    // duck-typed void emitBit(vluint32_t code, vluint32_t newval) = 0;
+    // duck-typed template <int T_Bits> void emitBus(vluint32_t code, vluint32_t newval) = 0;
+    // duck-typed void emitQuad(vluint32_t code, vluint64_t newval, int bits) = 0;
+    // duck-typed void emitArray(vluint32_t code, const vluint32_t* newvalp, int bits) = 0;
+    // duck-typed void emitFloat(vluint32_t code, float newval) = 0;
+    // duck-typed void emitDouble(vluint32_t code, double newval) = 0;
+
+    vluint32_t* oldp(vluint32_t code) { return m_sigs_oldvalp + code; }
+
+    // Write to previous value buffer value and emit trace entry.
+    void fullBit(vluint32_t* oldp, vluint32_t newval);
+    template <int T_Bits> void fullBus(vluint32_t* oldp, vluint32_t newval);
+    void fullQuad(vluint32_t* oldp, vluint64_t newval, int bits);
+    void fullArray(vluint32_t* oldp, const vluint32_t* newvalp, int bits);
+    void fullFloat(vluint32_t* oldp, float newval);
+    void fullDouble(vluint32_t* oldp, double newval);
+
+    // Check previous dumped value of signal. If changed, then emit trace entry
+    inline void chgBit(vluint32_t* oldp, vluint32_t newval) {
+        const vluint32_t diff = *oldp ^ newval;
+        if (VL_UNLIKELY(diff)) fullBit(oldp, newval);
+    }
+    template <int T_Bits> inline void chgBus(vluint32_t* oldp, vluint32_t newval) {
+        const vluint32_t diff = *oldp ^ newval;
+        if (VL_UNLIKELY(diff)) fullBus<T_Bits>(oldp, newval);
+    }
+    inline void chgQuad(vluint32_t* oldp, vluint64_t newval, int bits) {
+        const vluint64_t diff = *reinterpret_cast<vluint64_t*>(oldp) ^ newval;
+        if (VL_UNLIKELY(diff)) fullQuad(oldp, newval, bits);
+    }
+    inline void chgArray(vluint32_t* oldp, const vluint32_t* newvalp, int bits) {
+        for (int i = 0; i < (bits + 31) / 32; ++i) {
+            if (VL_UNLIKELY(oldp[i] ^ newvalp[i])) {
+                fullArray(oldp, newvalp, bits);
+                return;
+            }
+        }
+    }
+    inline void chgFloat(vluint32_t* oldp, float newval) {
+        // cppcheck-suppress invalidPointerCast
+        if (VL_UNLIKELY(*reinterpret_cast<float*>(oldp) != newval)) fullFloat(oldp, newval);
+    }
+    inline void chgDouble(vluint32_t* oldp, double newval) {
+        // cppcheck-suppress invalidPointerCast
+        if (VL_UNLIKELY(*reinterpret_cast<double*>(oldp) != newval)) fullDouble(oldp, newval);
+    }
+};
+#endif  // guard

--- a/include/verilated_trace_imp.cpp
+++ b/include/verilated_trace_imp.cpp
@@ -1,0 +1,309 @@
+// -*- mode: C++; c-file-style: "cc-mode" -*-
+//=============================================================================
+//
+// THIS MODULE IS PUBLICLY LICENSED
+//
+// Copyright 2001-2020 by Wilson Snyder. This program is free software; you
+// can redistribute it and/or modify it under the terms of either the GNU
+// Lesser General Public License Version 3 or the Perl Artistic License
+// Version 2.0.
+// SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+//
+//=============================================================================
+///
+/// \file
+/// \brief Implementation of tracing functionality common to all trace formats
+///
+//=============================================================================
+// SPDIFF_OFF
+
+// clang-format off
+
+#ifndef VL_DERIVED_T
+# error "This file should be included in trace format implementations"
+#endif
+
+#include "verilated_trace.h"
+
+// clang-format on
+
+//=============================================================================
+// Static utility functions
+
+static double timescaleToDouble(const char* unitp) {
+    char* endp;
+    double value = strtod(unitp, &endp);
+    // On error so we allow just "ns" to return 1e-9.
+    if (value == 0.0 && endp == unitp) value = 1;
+    unitp = endp;
+    for (; *unitp && isspace(*unitp); unitp++) {}
+    switch (*unitp) {
+    case 's': value *= 1e1; break;
+    case 'm': value *= 1e-3; break;
+    case 'u': value *= 1e-6; break;
+    case 'n': value *= 1e-9; break;
+    case 'p': value *= 1e-12; break;
+    case 'f': value *= 1e-15; break;
+    case 'a': value *= 1e-18; break;
+    }
+    return value;
+}
+
+static std::string doubleToTimescale(double value) {
+    const char* suffixp = "s";
+    // clang-format off
+    if      (value >= 1e0)   { suffixp = "s"; value *= 1e0; }
+    else if (value >= 1e-3 ) { suffixp = "ms"; value *= 1e3; }
+    else if (value >= 1e-6 ) { suffixp = "us"; value *= 1e6; }
+    else if (value >= 1e-9 ) { suffixp = "ns"; value *= 1e9; }
+    else if (value >= 1e-12) { suffixp = "ps"; value *= 1e12; }
+    else if (value >= 1e-15) { suffixp = "fs"; value *= 1e15; }
+    else if (value >= 1e-18) { suffixp = "as"; value *= 1e18; }
+    // clang-format on
+    char valuestr[100];
+    sprintf(valuestr, "%3.0f%s", value, suffixp);
+    return valuestr;  // Gets converted to string, so no ref to stack
+}
+
+//=============================================================================
+// Internal callback routines for each module being traced.
+
+// Each module that wishes to be traced registers a set of callbacks stored in
+// this class.  When the trace file is being constructed, this class provides
+// the callback routines to be executed.
+class VerilatedTraceCallInfo {
+public:  // This is in .cpp file so is not widely visible
+    typedef typename VerilatedTrace<VL_DERIVED_T>::callback_t callback_t;
+
+    callback_t m_initcb;  ///< Initialization Callback function
+    callback_t m_fullcb;  ///< Full Dumping Callback function
+    callback_t m_changecb;  ///< Incremental Dumping Callback function
+    void* m_userthis;  ///< User data pointer for callback
+    vluint32_t m_code;  ///< Starting code number (set later by traceInit)
+    // CONSTRUCTORS
+    VerilatedTraceCallInfo(callback_t icb, callback_t fcb, callback_t changecb, void* ut)
+        : m_initcb(icb)
+        , m_fullcb(fcb)
+        , m_changecb(changecb)
+        , m_userthis(ut)
+        , m_code(1) {}
+    ~VerilatedTraceCallInfo() {}
+};
+
+//=============================================================================
+// VerilatedTrace
+
+template <>
+VerilatedTrace<VL_DERIVED_T>::VerilatedTrace()
+    : m_sigs_oldvalp(NULL)
+    , m_timeLastDump(0)
+    , m_fullDump(true)
+    , m_nextCode(0)
+    , m_scopeEscape('.')
+    , m_timeRes(1e-9)
+    , m_timeUnit(1e-9) {
+    set_time_unit(Verilated::timeunitString());
+    set_time_resolution(Verilated::timeprecisionString());
+}
+
+template <> VerilatedTrace<VL_DERIVED_T>::~VerilatedTrace() {
+    if (m_sigs_oldvalp) VL_DO_CLEAR(delete[] m_sigs_oldvalp, m_sigs_oldvalp = NULL);
+    while (!m_callbacks.empty()) {
+        delete m_callbacks.back();
+        m_callbacks.pop_back();
+    }
+}
+
+//=========================================================================
+// Internals available to format specific implementations
+
+template <> void VerilatedTrace<VL_DERIVED_T>::traceInit() VL_MT_UNSAFE {
+    m_assertOne.check();
+
+    // Note: It is possible to re-open a trace file (VCD in particular),
+    // so we must reset the next code here, but it must have the same number
+    // of codes on re-open
+    const vluint32_t expectedCodes = nextCode();
+    m_nextCode = 1;
+
+    // Call all initialize callbacks, which will call decl* for each signal.
+    for (vluint32_t ent = 0; ent < m_callbacks.size(); ++ent) {
+        VerilatedTraceCallInfo* cip = m_callbacks[ent];
+        cip->m_code = nextCode();
+        (cip->m_initcb)(self(), cip->m_userthis, cip->m_code);
+    }
+
+    if (expectedCodes && nextCode() != expectedCodes) {
+        VL_FATAL_MT(__FILE__, __LINE__, "",
+                    "Reopening trace file with different number of signals");
+    }
+
+    // Now that we know the number of codes, allocate space for the buffer
+    // holding previous signal values.
+    if (!m_sigs_oldvalp) m_sigs_oldvalp = new vluint32_t[nextCode()];
+}
+
+template <>
+void VerilatedTrace<VL_DERIVED_T>::declCode(vluint32_t code, vluint32_t bits, bool tri) {
+    if (!code) {
+        VL_FATAL_MT(__FILE__, __LINE__, "", "Internal: internal trace problem, code 0 is illegal");
+    }
+    // Note: The tri-state flag is not used by Verilator, but is here for
+    // compatibility with some foreign code.
+    int codesNeeded = (bits + 31) / 32;
+    if (tri) codesNeeded *= 2;
+    m_nextCode = std::max(m_nextCode, code + codesNeeded);
+}
+
+//=========================================================================
+// Internals available to format specific implementations
+
+template <> std::string VerilatedTrace<VL_DERIVED_T>::timeResStr() const {
+    return doubleToTimescale(m_timeRes);
+}
+
+template <> std::string VerilatedTrace<VL_DERIVED_T>::timeUnitStr() const {
+    return doubleToTimescale(m_timeUnit);
+}
+
+//=========================================================================
+// External interface to client code
+
+template <> void VerilatedTrace<VL_DERIVED_T>::set_time_unit(const char* unitp) {
+    m_timeUnit = timescaleToDouble(unitp);
+}
+
+template <> void VerilatedTrace<VL_DERIVED_T>::set_time_unit(const std::string& unit) {
+    set_time_unit(unit.c_str());
+}
+
+template <> void VerilatedTrace<VL_DERIVED_T>::set_time_resolution(const char* unitp) {
+    m_timeRes = timescaleToDouble(unitp);
+}
+
+template <> void VerilatedTrace<VL_DERIVED_T>::set_time_resolution(const std::string& unit) {
+    set_time_resolution(unit.c_str());
+}
+
+template <> void VerilatedTrace<VL_DERIVED_T>::dump(vluint64_t timeui) {
+    m_assertOne.check();
+    if (VL_UNLIKELY(m_timeLastDump && timeui <= m_timeLastDump)) {
+        VL_PRINTF_MT("%%Warning: previous dump at t=%" VL_PRI64 "u, requesting t=%" VL_PRI64
+                     "u, dump call ignored\n",
+                     m_timeLastDump, timeui);
+        return;
+    }
+    m_timeLastDump = timeui;
+    Verilated::quiesce();
+    if (VL_UNLIKELY(m_fullDump)) {
+        if (!preFullDump()) return;
+        emitTimeChange(timeui);
+        m_fullDump = false;  // No more need for next dump to be full
+        for (vluint32_t ent = 0; ent < m_callbacks.size(); ent++) {
+            VerilatedTraceCallInfo* cip = m_callbacks[ent];
+            (cip->m_fullcb)(self(), cip->m_userthis, cip->m_code);
+        }
+    } else {
+        if (!preChangeDump()) return;
+        emitTimeChange(timeui);
+        for (vluint32_t ent = 0; ent < m_callbacks.size(); ++ent) {
+            VerilatedTraceCallInfo* cip = m_callbacks[ent];
+            (cip->m_changecb)(self(), cip->m_userthis, cip->m_code);
+        }
+    }
+}
+
+//=============================================================================
+// Non-hot path internal interface to Verilator generated code
+
+template <>
+void VerilatedTrace<VL_DERIVED_T>::addCallback(callback_t initcb, callback_t fullcb,
+                                               callback_t changecb,
+                                               void* userthis) VL_MT_UNSAFE_ONE {
+    m_assertOne.check();
+    if (VL_UNLIKELY(timeLastDump() != 0)) {
+        std::string msg = (std::string("Internal: ") + __FILE__ + "::" + __FUNCTION__
+                           + " called with already open file");
+        VL_FATAL_MT(__FILE__, __LINE__, "", msg.c_str());
+    }
+    VerilatedTraceCallInfo* cip = new VerilatedTraceCallInfo(initcb, fullcb, changecb, userthis);
+    m_callbacks.push_back(cip);
+}
+
+//=========================================================================
+// Hot path internal interface to Verilator generated code
+
+// These functions must write the new value back into the old value store,
+// and subsequently call the format specific emit* implementations. Note
+// that this file must be included in the format specific implementation, so
+// the emit* functions can be inlined for performance.
+
+template <> void VerilatedTrace<VL_DERIVED_T>::fullBit(vluint32_t* oldp, vluint32_t newval) {
+    *oldp = newval;
+    self()->emitBit(oldp - m_sigs_oldvalp, newval);
+}
+
+// We want these functions specialized for sizes to avoid hard to predict
+// branches, but we don't want them inlined, so we explicitly instantiate the
+// template for each size used by Verilator.
+template <>
+template <int T_Bits>
+void VerilatedTrace<VL_DERIVED_T>::fullBus(vluint32_t* oldp, vluint32_t newval) {
+    *oldp = newval;
+    self()->emitBus<T_Bits>(oldp - m_sigs_oldvalp, newval);
+}
+
+// Note: No specialization for width 1, covered by 'fullBit'
+template void VerilatedTrace<VL_DERIVED_T>::fullBus<2>(vluint32_t* oldp, vluint32_t newval);
+template void VerilatedTrace<VL_DERIVED_T>::fullBus<3>(vluint32_t* oldp, vluint32_t newval);
+template void VerilatedTrace<VL_DERIVED_T>::fullBus<4>(vluint32_t* oldp, vluint32_t newval);
+template void VerilatedTrace<VL_DERIVED_T>::fullBus<5>(vluint32_t* oldp, vluint32_t newval);
+template void VerilatedTrace<VL_DERIVED_T>::fullBus<6>(vluint32_t* oldp, vluint32_t newval);
+template void VerilatedTrace<VL_DERIVED_T>::fullBus<7>(vluint32_t* oldp, vluint32_t newval);
+template void VerilatedTrace<VL_DERIVED_T>::fullBus<8>(vluint32_t* oldp, vluint32_t newval);
+template void VerilatedTrace<VL_DERIVED_T>::fullBus<9>(vluint32_t* oldp, vluint32_t newval);
+template void VerilatedTrace<VL_DERIVED_T>::fullBus<10>(vluint32_t* oldp, vluint32_t newval);
+template void VerilatedTrace<VL_DERIVED_T>::fullBus<11>(vluint32_t* oldp, vluint32_t newval);
+template void VerilatedTrace<VL_DERIVED_T>::fullBus<12>(vluint32_t* oldp, vluint32_t newval);
+template void VerilatedTrace<VL_DERIVED_T>::fullBus<13>(vluint32_t* oldp, vluint32_t newval);
+template void VerilatedTrace<VL_DERIVED_T>::fullBus<14>(vluint32_t* oldp, vluint32_t newval);
+template void VerilatedTrace<VL_DERIVED_T>::fullBus<15>(vluint32_t* oldp, vluint32_t newval);
+template void VerilatedTrace<VL_DERIVED_T>::fullBus<16>(vluint32_t* oldp, vluint32_t newval);
+template void VerilatedTrace<VL_DERIVED_T>::fullBus<17>(vluint32_t* oldp, vluint32_t newval);
+template void VerilatedTrace<VL_DERIVED_T>::fullBus<18>(vluint32_t* oldp, vluint32_t newval);
+template void VerilatedTrace<VL_DERIVED_T>::fullBus<19>(vluint32_t* oldp, vluint32_t newval);
+template void VerilatedTrace<VL_DERIVED_T>::fullBus<20>(vluint32_t* oldp, vluint32_t newval);
+template void VerilatedTrace<VL_DERIVED_T>::fullBus<21>(vluint32_t* oldp, vluint32_t newval);
+template void VerilatedTrace<VL_DERIVED_T>::fullBus<22>(vluint32_t* oldp, vluint32_t newval);
+template void VerilatedTrace<VL_DERIVED_T>::fullBus<23>(vluint32_t* oldp, vluint32_t newval);
+template void VerilatedTrace<VL_DERIVED_T>::fullBus<24>(vluint32_t* oldp, vluint32_t newval);
+template void VerilatedTrace<VL_DERIVED_T>::fullBus<25>(vluint32_t* oldp, vluint32_t newval);
+template void VerilatedTrace<VL_DERIVED_T>::fullBus<26>(vluint32_t* oldp, vluint32_t newval);
+template void VerilatedTrace<VL_DERIVED_T>::fullBus<27>(vluint32_t* oldp, vluint32_t newval);
+template void VerilatedTrace<VL_DERIVED_T>::fullBus<28>(vluint32_t* oldp, vluint32_t newval);
+template void VerilatedTrace<VL_DERIVED_T>::fullBus<29>(vluint32_t* oldp, vluint32_t newval);
+template void VerilatedTrace<VL_DERIVED_T>::fullBus<30>(vluint32_t* oldp, vluint32_t newval);
+template void VerilatedTrace<VL_DERIVED_T>::fullBus<31>(vluint32_t* oldp, vluint32_t newval);
+template void VerilatedTrace<VL_DERIVED_T>::fullBus<32>(vluint32_t* oldp, vluint32_t newval);
+
+template <>
+void VerilatedTrace<VL_DERIVED_T>::fullQuad(vluint32_t* oldp, vluint64_t newval, int bits) {
+    *reinterpret_cast<vluint64_t*>(oldp) = newval;
+    self()->emitQuad(oldp - m_sigs_oldvalp, newval, bits);
+}
+template <>
+void VerilatedTrace<VL_DERIVED_T>::fullArray(vluint32_t* oldp, const vluint32_t* newvalp,
+                                             int bits) {
+    for (int i = 0; i < (bits + 31) / 32; ++i) oldp[i] = newvalp[i];
+    self()->emitArray(oldp - m_sigs_oldvalp, newvalp, bits);
+}
+template <> void VerilatedTrace<VL_DERIVED_T>::fullFloat(vluint32_t* oldp, float newval) {
+    // cppcheck-suppress invalidPointerCast
+    *reinterpret_cast<float*>(oldp) = newval;
+    self()->emitFloat(oldp - m_sigs_oldvalp, newval);
+}
+template <> void VerilatedTrace<VL_DERIVED_T>::fullDouble(vluint32_t* oldp, double newval) {
+    // cppcheck-suppress invalidPointerCast
+    *reinterpret_cast<double*>(oldp) = newval;
+    self()->emitDouble(oldp - m_sigs_oldvalp, newval);
+}

--- a/include/verilated_trace_imp.cpp
+++ b/include/verilated_trace_imp.cpp
@@ -73,7 +73,7 @@ static std::string doubleToTimescale(double value) {
 // the callback routines to be executed.
 class VerilatedTraceCallInfo {
 public:  // This is in .cpp file so is not widely visible
-    typedef typename VerilatedTrace<VL_DERIVED_T>::callback_t callback_t;
+    typedef VerilatedTrace<VL_DERIVED_T>::callback_t callback_t;
 
     callback_t m_initcb;  ///< Initialization Callback function
     callback_t m_fullcb;  ///< Full Dumping Callback function

--- a/include/verilated_vcd_c.h
+++ b/include/verilated_vcd_c.h
@@ -55,7 +55,7 @@ public:
 class VerilatedVcd : public VerilatedTrace<VerilatedVcd> {
 private:
     // Give the superclass access to private bits (to avoid virtual functions)
-    friend VerilatedTrace<VerilatedVcd>;
+    friend class VerilatedTrace<VerilatedVcd>;
 
     //=========================================================================
     // VCD specific internals

--- a/include/verilated_vcd_c.h
+++ b/include/verilated_vcd_c.h
@@ -20,15 +20,14 @@
 #ifndef _VERILATED_VCD_C_H_
 #define _VERILATED_VCD_C_H_ 1
 
-#include "verilatedos.h"
 #include "verilated.h"
+#include "verilated_trace.h"
 
 #include <map>
 #include <string>
 #include <vector>
 
 class VerilatedVcd;
-class VerilatedVcdCallInfo;
 
 // SPDIFF_ON
 //=============================================================================
@@ -49,47 +48,25 @@ public:
 };
 
 //=============================================================================
-// VerilatedVcdSig
-/// Internal data on one signal being traced.
-
-class VerilatedVcdSig {
-protected:
-    friend class VerilatedVcd;
-    vluint32_t m_code;  ///< VCD file code number
-    int m_bits;  ///< Size of value in bits
-    VerilatedVcdSig(vluint32_t code, int bits)
-        : m_code(code)
-        , m_bits(bits) {}
-
-public:
-    ~VerilatedVcdSig() {}
-};
-
-//=============================================================================
-
-typedef void (*VerilatedVcdCallback_t)(VerilatedVcd* vcdp, void* userthis, vluint32_t code);
-
-//=============================================================================
 // VerilatedVcd
 /// Base class to create a Verilator VCD dump
 /// This is an internally used class - see VerilatedVcdC for what to call from applications
 
-class VerilatedVcd {
+class VerilatedVcd : public VerilatedTrace<VerilatedVcd> {
 private:
+    // Give the superclass access to private bits (to avoid virtual functions)
+    friend VerilatedTrace<VerilatedVcd>;
+
+    //=========================================================================
+    // VCD specific internals
+
     VerilatedVcdFile* m_filep;  ///< File we're writing to
     bool m_fileNewed;  ///< m_filep needs destruction
     bool m_isOpen;  ///< True indicates open file
     bool m_evcd;  ///< True for evcd format
     std::string m_filename;  ///< Filename we're writing to (if open)
     vluint64_t m_rolloverMB;  ///< MB of file size to rollover at
-    char m_scopeEscape;  ///< Character to separate scope components
     int m_modDepth;  ///< Depth of module hierarchy
-    bool m_fullDump;  ///< True indicates dump ignoring if changed
-    vluint32_t m_nextCode;  ///< Next code number to assign
-    std::string m_modName;  ///< Module name being traced now
-    double m_timeRes;  ///< Time resolution (ns/ms etc)
-    double m_timeUnit;  ///< Time units (ns/ms etc)
-    vluint64_t m_timeLastDump;  ///< Last time we did a dump
 
     char* m_wrBufp;  ///< Output buffer
     char* m_wrFlushp;  ///< Output buffer flush trigger location
@@ -100,15 +77,8 @@ private:
     std::vector<char> m_suffixes;  ///< VCD line end string codes + metadata
     const char* m_suffixesp;  ///< Pointer to first element of above
 
-    vluint32_t* m_sigs_oldvalp;  ///< Pointer to old signal values
-    typedef std::vector<VerilatedVcdSig> SigVec;
-    SigVec m_sigs;  ///< Pointer to signal information
-    typedef std::vector<VerilatedVcdCallInfo*> CallbackVec;
-    CallbackVec m_callbacks;  ///< Routines to perform dumping
     typedef std::map<std::string, std::string> NameMap;
     NameMap* m_namemapp;  ///< List of names for the header
-
-    VerilatedAssertOneThread m_assertOne;  ///< Assert only called from single thread
 
     void bufferResize(vluint64_t minsize);
     void bufferFlush() VL_MT_UNSAFE_ONE;
@@ -130,165 +100,112 @@ private:
                  bool tri, bool bussed, int msb, int lsb);
 
     void dumpHeader();
-    void dumpPrep(vluint64_t timeui);
-    void dumpFull(vluint64_t timeui);
-    // cppcheck-suppress functionConst
-    void dumpDone();
+
     char* writeCode(char* writep, vluint32_t code);
 
-    void finishLine(vluint32_t* oldp, char* writep);
+    void finishLine(vluint32_t code, char* writep);
+
+    /// Flush any remaining data from all files
+    static void flush_all() VL_MT_UNSAFE_ONE;
 
     // CONSTRUCTORS
     VL_UNCOPYABLE(VerilatedVcd);
 
+protected:
+    //=========================================================================
+    // Implementation of VerilatedTrace interface
+
+    // Implementations of protected virtual methods for VerilatedTrace
+    void emitTimeChange(vluint64_t timeui) VL_OVERRIDE;
+
+    // Hooks called from VerilatedTrace
+    bool preFullDump() VL_OVERRIDE { return isOpen(); }
+    bool preChangeDump() VL_OVERRIDE;
+
+    // Implementations of duck-typed methods for VerilatedTrace
+    void emitBit(vluint32_t code, vluint32_t newval);
+    template <int T_Bits> void emitBus(vluint32_t code, vluint32_t newval);
+    void emitQuad(vluint32_t code, vluint64_t newval, int bits);
+    void emitArray(vluint32_t code, const vluint32_t* newvalp, int bits);
+    void emitFloat(vluint32_t code, float newval);
+    void emitDouble(vluint32_t code, double newval);
+
 public:
+    //=========================================================================
+    // External interface to client code
+
     explicit VerilatedVcd(VerilatedVcdFile* filep = NULL);
     ~VerilatedVcd();
-    /// Routines can only be called from one thread; allow next call from different thread
-    void changeThread() { m_assertOne.changeThread(); }
 
     // ACCESSORS
     /// Set size in megabytes after which new file should be created
     void rolloverMB(vluint64_t rolloverMB) { m_rolloverMB = rolloverMB; }
-    /// Is file open?
-    bool isOpen() const { return m_isOpen; }
-    /// Change character that splits scopes.  Note whitespace are ALWAYS escapes.
-    void scopeEscape(char flag) { m_scopeEscape = flag; }
-    /// Is this an escape?
-    inline bool isScopeEscape(char c) { return isspace(c) || c == m_scopeEscape; }
 
     // METHODS
     /// Open the file; call isOpen() to see if errors
     void open(const char* filename) VL_MT_UNSAFE_ONE;
-    void openNext(bool incFilename);  ///< Open next data-only file
-    void close() VL_MT_UNSAFE_ONE;  ///< Close the file
+    /// Open next data-only file
+    void openNext(bool incFilename) VL_MT_UNSAFE_ONE;
+    /// Close the file
+    void close() VL_MT_UNSAFE_ONE;
     /// Flush any remaining data to this file
     void flush() VL_MT_UNSAFE_ONE { bufferFlush(); }
-    /// Flush any remaining data from all files
-    static void flush_all() VL_MT_UNSAFE_ONE;
+    /// Is file open?
+    bool isOpen() const { return m_isOpen; }
 
-    void set_time_unit(const char* unitp);  ///< Set time units (s/ms, defaults to ns)
-    void set_time_unit(const std::string& unit) { set_time_unit(unit.c_str()); }
+    //=========================================================================
+    // Internal interface to Verilator generated code
 
-    void set_time_resolution(const char* unitp);  ///< Set time resolution (s/ms, defaults to ns)
-    void set_time_resolution(const std::string& unit) { set_time_resolution(unit.c_str()); }
-
-    double timescaleToDouble(const char* unitp);
-    std::string doubleToTimescale(double value);
-
-    /// Inside dumping routines, called each cycle to make the dump
-    void dump(vluint64_t timeui);
-    /// Call dump with a absolute unscaled time in seconds
-    void dumpSeconds(double secs) { dump(static_cast<vluint64_t>(secs * m_timeRes)); }
-
-    /// Inside dumping routines, declare callbacks for tracings
-    void addCallback(VerilatedVcdCallback_t initcb, VerilatedVcdCallback_t fullcb,
-                     VerilatedVcdCallback_t changecb, void* userthis) VL_MT_UNSAFE_ONE;
-
-    /// Inside dumping routines, declare a module
-    void module(const std::string& name);
-    /// Inside dumping routines, declare a signal
     void declBit(vluint32_t code, const char* name, bool array, int arraynum);
     void declBus(vluint32_t code, const char* name, bool array, int arraynum, int msb, int lsb);
     void declQuad(vluint32_t code, const char* name, bool array, int arraynum, int msb, int lsb);
     void declArray(vluint32_t code, const char* name, bool array, int arraynum, int msb, int lsb);
     void declFloat(vluint32_t code, const char* name, bool array, int arraynum);
     void declDouble(vluint32_t code, const char* name, bool array, int arraynum);
-#ifndef VL_TRACE_VCD_OLD_API
+
+#ifdef VL_TRACE_VCD_OLD_API
+    //=========================================================================
+    // Note: These are only for testing for backward compatibility with foreign
+    // code and is not used by Verilator. Do not use these as there is no
+    // guarantee of functionality.
+
     void declTriBit(vluint32_t code, const char* name, bool array, int arraynum);
     void declTriBus(vluint32_t code, const char* name, bool array, int arraynum, int msb, int lsb);
     void declTriQuad(vluint32_t code, const char* name, bool array, int arraynum, int msb,
                      int lsb);
     void declTriArray(vluint32_t code, const char* name, bool array, int arraynum, int msb,
                       int lsb);
-#endif  // VL_TRACE_VCD_OLD_API
-    //  ... other module_start for submodules (based on cell name)
-
-    //=========================================================================
-    // Inside dumping routines used by Verilator
-
-    vluint32_t* oldp(vluint32_t code) { return m_sigs_oldvalp + code; }
-
-#ifndef VL_TRACE_VCD_OLD_API
-
     //=========================================================================
     // Write back to previous value buffer value and emit
 
-    void fullBit(vluint32_t* oldp, vluint32_t newval);
-    template <int T_Bits> void fullBus(vluint32_t* oldp, vluint32_t newval);
-    void fullQuad(vluint32_t* oldp, vluint64_t newval, int bits);
-    void fullArray(vluint32_t* oldp, const vluint32_t* newvalp, int bits);
-    void fullFloat(vluint32_t* oldp, float newval);
-    void fullDouble(vluint32_t* oldp, double newval);
-
-    //=========================================================================
-    // Check previous value and emit if changed
-
-    inline void chgBit(vluint32_t* oldp, vluint32_t newval) {
-        const vluint32_t diff = *oldp ^ newval;
-        if (VL_UNLIKELY(diff)) fullBit(oldp, newval);
-    }
-    template <int T_Bits> inline void chgBus(vluint32_t* oldp, vluint32_t newval) {
-        const vluint32_t diff = *oldp ^ newval;
-        if (VL_UNLIKELY(diff)) fullBus<T_Bits>(oldp, newval);
-    }
-    inline void chgQuad(vluint32_t* oldp, vluint64_t newval, int bits) {
-        const vluint64_t diff = *reinterpret_cast<vluint64_t*>(oldp) ^ newval;
-        if (VL_UNLIKELY(diff)) fullQuad(oldp, newval, bits);
-    }
-    inline void chgArray(vluint32_t* oldp, const vluint32_t* newvalp, int bits) {
-        for (int i = 0; i < (bits + 31) / 32; ++i) {
-            if (VL_UNLIKELY(oldp[i] ^ newvalp[i])) {
-                fullArray(oldp, newvalp, bits);
-                return;
-            }
-        }
-    }
-    inline void chgFloat(vluint32_t* oldp, float newval) {
-        // cppcheck-suppress invalidPointerCast
-        if (VL_UNLIKELY(*reinterpret_cast<float*>(oldp) != newval)) fullFloat(oldp, newval);
-    }
-    inline void chgDouble(vluint32_t* oldp, double newval) {
-        // cppcheck-suppress invalidPointerCast
-        if (VL_UNLIKELY(*reinterpret_cast<double*>(oldp) != newval)) fullDouble(oldp, newval);
-    }
-
-#else  // VL_TRACE_VCD_OLD_API
-
-    // Note: These are only for testing for backward compatibility. Verilator
-    // should use the more efficient versions above.
-
-    //=========================================================================
-    // Write back to previous value buffer value and emit
-
-    void fullBit(vluint32_t* oldp, vluint32_t newval) { fullBit(oldp - m_sigs_oldvalp, newval); }
+    void fullBit(vluint32_t* oldp, vluint32_t newval) { fullBit(oldp - this->oldp(0), newval); }
     template <int T_Bits> void fullBus(vluint32_t* oldp, vluint32_t newval) {
-        fullBus(oldp - m_sigs_oldvalp, newval, T_Bits);
+        fullBus(oldp - this->oldp(0), newval, T_Bits);
     }
     void fullQuad(vluint32_t* oldp, vluint64_t newval, int bits) {
-        fullQuad(oldp - m_sigs_oldvalp, newval, bits);
+        fullQuad(oldp - this->oldp(0), newval, bits);
     }
     void fullArray(vluint32_t* oldp, const vluint32_t* newvalp, int bits) {
-        fullArray(oldp - m_sigs_oldvalp, newvalp, bits);
+        fullArray(oldp - this->oldp(0), newvalp, bits);
     }
-    void fullFloat(vluint32_t* oldp, float newval) { fullFloat(oldp - m_sigs_oldvalp, newval); }
-    void fullDouble(vluint32_t* oldp, double newval) { fullDouble(oldp - m_sigs_oldvalp, newval); }
+    void fullFloat(vluint32_t* oldp, float newval) { fullFloat(oldp - this->oldp(0), newval); }
+    void fullDouble(vluint32_t* oldp, double newval) { fullDouble(oldp - this->oldp(0), newval); }
 
     //=========================================================================
     // Check previous value and emit if changed
 
-    void chgBit(vluint32_t* oldp, vluint32_t newval) { chgBit(oldp - m_sigs_oldvalp, newval); }
+    void chgBit(vluint32_t* oldp, vluint32_t newval) { chgBit(oldp - this->oldp(0), newval); }
     template <int T_Bits> void chgBus(vluint32_t* oldp, vluint32_t newval) {
-        chgBus(oldp - m_sigs_oldvalp, newval, T_Bits);
+        chgBus(oldp - this->oldp(0), newval, T_Bits);
     }
     void chgQuad(vluint32_t* oldp, vluint64_t newval, int bits) {
-        chgQuad(oldp - m_sigs_oldvalp, newval, bits);
+        chgQuad(oldp - this->oldp(0), newval, bits);
     }
     void chgArray(vluint32_t* oldp, const vluint32_t* newvalp, int bits) {
-        chgArray(oldp - m_sigs_oldvalp, newvalp, bits);
+        chgArray(oldp - this->oldp(0), newvalp, bits);
     }
-    void chgFloat(vluint32_t* oldp, float newval) { chgFloat(oldp - m_sigs_oldvalp, newval); }
-    void chgDouble(vluint32_t* oldp, double newval) { chgDouble(oldp - m_sigs_oldvalp, newval); }
+    void chgFloat(vluint32_t* oldp, float newval) { chgFloat(oldp - this->oldp(0), newval); }
+    void chgDouble(vluint32_t* oldp, double newval) { chgDouble(oldp - this->oldp(0), newval); }
 
     /// Inside dumping routines, dump one signal, faster when not inlined
     /// due to code size reduction.
@@ -317,11 +234,11 @@ public:
     /// Inside dumping routines, dump one signal if it has changed.
     /// We do want to inline these to avoid calls when the value did not change.
     inline void chgBit(vluint32_t code, const vluint32_t newval) {
-        vluint32_t diff = m_sigs_oldvalp[code] ^ newval;
+        vluint32_t diff = oldp(code)[0] ^ newval;
         if (VL_UNLIKELY(diff)) fullBit(code, newval);
     }
     inline void chgBus(vluint32_t code, const vluint32_t newval, int bits) {
-        vluint32_t diff = m_sigs_oldvalp[code] ^ newval;
+        vluint32_t diff = oldp(code)[0] ^ newval;
         if (VL_UNLIKELY(diff)) {
             if (VL_UNLIKELY(bits == 32 || (diff & ((1U << bits) - 1)))) {
                 fullBus(code, newval, bits);
@@ -329,7 +246,7 @@ public:
         }
     }
     inline void chgQuad(vluint32_t code, const vluint64_t newval, int bits) {
-        vluint64_t diff = (*(reinterpret_cast<vluint64_t*>(&m_sigs_oldvalp[code]))) ^ newval;
+        vluint64_t diff = (*(reinterpret_cast<vluint64_t*>(oldp(code)))) ^ newval;
         if (VL_UNLIKELY(diff)) {
             if (VL_UNLIKELY(bits == 64 || (diff & ((VL_ULL(1) << bits) - 1)))) {
                 fullQuad(code, newval, bits);
@@ -338,7 +255,7 @@ public:
     }
     inline void chgArray(vluint32_t code, const vluint32_t* newvalp, int bits) {
         for (int word = 0; word < (((bits - 1) / 32) + 1); ++word) {
-            if (VL_UNLIKELY(m_sigs_oldvalp[code + word] ^ newvalp[word])) {
+            if (VL_UNLIKELY(oldp(code)[word] ^ newvalp[word])) {
                 fullArray(code, newvalp, bits);
                 return;
             }
@@ -346,14 +263,15 @@ public:
     }
     inline void chgArray(vluint32_t code, const vluint64_t* newvalp, int bits) {
         for (int word = 0; word < (((bits - 1) / 64) + 1); ++word) {
-            if (VL_UNLIKELY(m_sigs_oldvalp[code + word] ^ newvalp[word])) {
+            if (VL_UNLIKELY(*(reinterpret_cast<vluint64_t*>(oldp(code + 2 * word)))
+                            ^ newvalp[word])) {
                 fullArray(code, newvalp, bits);
                 return;
             }
         }
     }
     inline void chgTriBit(vluint32_t code, const vluint32_t newval, const vluint32_t newtri) {
-        vluint32_t diff = ((m_sigs_oldvalp[code] ^ newval) | (m_sigs_oldvalp[code + 1] ^ newtri));
+        vluint32_t diff = ((oldp(code)[0] ^ newval) | (oldp(code)[1] ^ newtri));
         if (VL_UNLIKELY(diff)) {
             // Verilator 3.510 and newer provide clean input, so the below
             // is only for back compatibility
@@ -364,7 +282,7 @@ public:
     }
     inline void chgTriBus(vluint32_t code, const vluint32_t newval, const vluint32_t newtri,
                           int bits) {
-        vluint32_t diff = ((m_sigs_oldvalp[code] ^ newval) | (m_sigs_oldvalp[code + 1] ^ newtri));
+        vluint32_t diff = ((oldp(code)[0] ^ newval) | (oldp(code)[1] ^ newtri));
         if (VL_UNLIKELY(diff)) {
             if (VL_UNLIKELY(bits == 32 || (diff & ((1U << bits) - 1)))) {
                 fullTriBus(code, newval, newtri, bits);
@@ -373,9 +291,8 @@ public:
     }
     inline void chgTriQuad(vluint32_t code, const vluint64_t newval, const vluint32_t newtri,
                            int bits) {
-        vluint64_t diff
-            = (((*(reinterpret_cast<vluint64_t*>(&m_sigs_oldvalp[code]))) ^ newval)
-               | ((*(reinterpret_cast<vluint64_t*>(&m_sigs_oldvalp[code + 1]))) ^ newtri));
+        vluint64_t diff = (((*(reinterpret_cast<vluint64_t*>(oldp(code)))) ^ newval)
+                           | ((*(reinterpret_cast<vluint64_t*>(oldp(code + 1)))) ^ newtri));
         if (VL_UNLIKELY(diff)) {
             if (VL_UNLIKELY(bits == 64 || (diff & ((VL_ULL(1) << bits) - 1)))) {
                 fullTriQuad(code, newval, newtri, bits);
@@ -385,8 +302,8 @@ public:
     inline void chgTriArray(vluint32_t code, const vluint32_t* newvalp, const vluint32_t* newtrip,
                             int bits) {
         for (int word = 0; word < (((bits - 1) / 32) + 1); ++word) {
-            if (VL_UNLIKELY((m_sigs_oldvalp[code + word * 2] ^ newvalp[word])
-                            | (m_sigs_oldvalp[code + word * 2 + 1] ^ newtrip[word]))) {
+            if (VL_UNLIKELY((oldp(code)[word * 2] ^ newvalp[word])
+                            | (oldp(code)[word * 2 + 1] ^ newtrip[word]))) {
                 fullTriArray(code, newvalp, newtrip, bits);
                 return;
             }
@@ -394,23 +311,29 @@ public:
     }
     inline void chgDouble(vluint32_t code, const double newval) {
         // cppcheck-suppress invalidPointerCast
-        if (VL_UNLIKELY((*(reinterpret_cast<double*>(&m_sigs_oldvalp[code]))) != newval)) {
+        if (VL_UNLIKELY((*(reinterpret_cast<double*>(oldp(code)))) != newval)) {
             fullDouble(code, newval);
         }
     }
     inline void chgFloat(vluint32_t code, const float newval) {
         // cppcheck-suppress invalidPointerCast
-        if (VL_UNLIKELY((*(reinterpret_cast<float*>(&m_sigs_oldvalp[code]))) != newval)) {
+        if (VL_UNLIKELY((*(reinterpret_cast<float*>(oldp(code)))) != newval)) {
             fullFloat(code, newval);
         }
     }
 
-#endif  // VL_TRACE_VCD_OLD_API
-
 protected:
     // METHODS
     void evcd(bool flag) { m_evcd = flag; }
+#endif  // VL_TRACE_VCD_OLD_API
 };
+
+// Declare specializations here they are used in VerilatedVcdC just below
+template <> void VerilatedTrace<VerilatedVcd>::dump(vluint64_t timeui);
+template <> void VerilatedTrace<VerilatedVcd>::set_time_unit(const char* unitp);
+template <> void VerilatedTrace<VerilatedVcd>::set_time_unit(const std::string& unit);
+template <> void VerilatedTrace<VerilatedVcd>::set_time_resolution(const char* unitp);
+template <> void VerilatedTrace<VerilatedVcd>::set_time_resolution(const std::string& unit);
 
 //=============================================================================
 // VerilatedVcdC
@@ -460,11 +383,11 @@ public:
     /// Set time units (s/ms, defaults to ns)
     /// For Verilated models, these propage from the Verilated default --timeunit
     void set_time_unit(const char* unit) { m_sptrace.set_time_unit(unit); }
-    void set_time_unit(const std::string& unit) { set_time_unit(unit.c_str()); }
+    void set_time_unit(const std::string& unit) { m_sptrace.set_time_unit(unit); }
     /// Set time resolution (s/ms, defaults to ns)
     /// For Verilated models, these propage from the Verilated default --timeunit
     void set_time_resolution(const char* unit) { m_sptrace.set_time_resolution(unit); }
-    void set_time_resolution(const std::string& unit) { set_time_resolution(unit.c_str()); }
+    void set_time_resolution(const std::string& unit) { m_sptrace.set_time_resolution(unit); }
 
     /// Internal class access
     inline VerilatedVcd* spTrace() { return &m_sptrace; }


### PR DESCRIPTION
This is the refactor in prep for #2259 that I mentioned. I verified performance is the same (actually it's  marginally better for FST due to less inlining). I would like to keep this separate as otherwise the change would be too big and this one really is just refactor to remove duplication.

@wsnyder I don't think the templating is too controversial, but could you please check it builds with any vintage GCC we would like to support?