### PR TITLE
Fix unused variable in VL_READMEM_N

### DIFF
--- a/include/verilated.cpp
+++ b/include/verilated.cpp
@@ -1903,6 +1903,7 @@ void VL_READMEM_N(bool hex,  // Hex format, else binary
                   ) VL_MT_SAFE {
     QData addr_max = array_lsb + depth - 1;
     if (start < static_cast<QData>(array_lsb)) start = array_lsb;
+    if (end > addr_max) end = addr_max;
 
     VlReadMem rmem(hex, bits, filename, start, end);
     if (VL_UNLIKELY(!rmem.isOpen())) return;

--- a/include/verilated.cpp
+++ b/include/verilated.cpp
@@ -1901,9 +1901,7 @@ void VL_READMEM_N(bool hex,  // Hex format, else binary
                   QData start,  // First array row address to read
                   QData end  // Last row address to read
                   ) VL_MT_SAFE {
-    QData addr_max = array_lsb + depth - 1;
     if (start < static_cast<QData>(array_lsb)) start = array_lsb;
-    if (end > addr_max) end = addr_max;
 
     VlReadMem rmem(hex, bits, filename, start, end);
     if (VL_UNLIKELY(!rmem.isOpen())) return;


### PR DESCRIPTION
I'm surprised the test suite didn't catch this compiling with -Wall -Werror