### PR TITLE
Fix compatibility problem with CMake policy CMP0025

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -33,6 +33,7 @@ Patrick Stewart
 Peter Monsson
 Philipp Wagner
 Pieter Kapsenberg
+Qingyao Sun
 Richard Myers
 Sean Cross
 Sebastien Van Cauwenberghe

--- a/verilator-config.cmake.in
+++ b/verilator-config.cmake.in
@@ -163,7 +163,9 @@ function(verilate TARGET)
   endforeach()
 
   string(TOLOWER ${CMAKE_CXX_COMPILER_ID} COMPILER)
-  if (NOT COMPILER MATCHES "msvc|clang")
+  if (COMPILER STREQUAL "appleclang")
+    set(COMPILER clang)
+  elseif (NOT COMPILER MATCHES "^msvc$|^clang$")
     set(COMPILER gcc)
   endif()
 


### PR DESCRIPTION
Fixes #2276 

I additionally made the regex a "full match", so `COMPILER` settings like `fooclang` or `msvcccc` will now be replaced with `gcc`. Previously, only a partial match is required to trigger `MATCHES`, and this is exactly why `appleclang` sneaked under this if-statement.