### PR TITLE
Fix test failures on Ubuntu 20.04

### DIFF
--- a/test_regress/driver.pl
+++ b/test_regress/driver.pl
@@ -2015,7 +2015,7 @@ sub files_identical {
                     && !/^- [a-z.0-9]+:\d+:[^\n]+\n/
                     && !/^-node:/
                     && !/^dot [^\n]+\n/
-                    && !/^In file: \/.*\/systemc-\d\.\d\.\d\/.*:\d+/
+                    && !/^In file: .*\/sc_.*:\d+/
             } @l1;
             @l1 = map {
                 s/(Internal Error: [^\n]+\.cpp):[0-9]+:/$1:#:/;

--- a/test_regress/t/t_vpi_get.cpp
+++ b/test_regress/t/t_vpi_get.cpp
@@ -82,7 +82,7 @@ unsigned int main_time = 0;
 #define CHECK_RESULT_CSTR_STRIP(got, exp) CHECK_RESULT_CSTR(got + strspn(got, " "), exp)
 
 static int _mon_check_props(TestVpiHandle& handle, int size, int direction, int scalar, int type) {
-    s_vpi_value value = {vpiIntVal, .value = {.integer = 0}};
+    s_vpi_value value = {.format = vpiIntVal, .value = {.integer = 0}};
     // check size of object
     int vpisize = vpi_get(vpiSize, handle);
     CHECK_RESULT(vpisize, size);

--- a/test_regress/t/t_vpi_memory.cpp
+++ b/test_regress/t/t_vpi_memory.cpp
@@ -83,7 +83,7 @@ unsigned int main_time = 0;
 
 int _mon_check_range(TestVpiHandle& handle, int size, int left, int right) {
     TestVpiHandle iter_h, left_h, right_h;
-    s_vpi_value value = {vpiIntVal, .value = {.integer = 0}};
+    s_vpi_value value = {.format = vpiIntVal, .value = {.integer = 0}};
     // check size of object
     int vpisize = vpi_get(vpiSize, handle);
     CHECK_RESULT(vpisize, size);
@@ -112,7 +112,7 @@ int _mon_check_memory() {
     int cnt;
     TestVpiHandle mem_h, lcl_h;
     vpiHandle iter_h;  // Icarus does not like auto free of iterator handles
-    s_vpi_value value = {vpiIntVal, .value = {.integer = 0}};
+    s_vpi_value value = {.format = vpiIntVal, .value = {.integer = 0}};
     vpi_printf((PLI_BYTE8*)"Check memory vpi ...\n");
     mem_h = vpi_handle_by_name((PLI_BYTE8*)TestSimulator::rooted("mem0"), NULL);
     CHECK_RESULT_NZ(mem_h);


### PR DESCRIPTION
- Packaged SystemC lives in /usr so needed to update regex in test
driver
- Clang 10 complains about mixed named and positional initializers in
struct definitions.
