### PR TITLE
Constant fold some == and != based on partial bit patterns.

### DIFF
--- a/test_regress/t/t_tautological_bitwise_compare.pl
+++ b/test_regress/t/t_tautological_bitwise_compare.pl
@@ -1,0 +1,21 @@
+#!/usr/bin/perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2003 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_tautological_bitwise_compare.v
+++ b/test_regress/t/t_tautological_bitwise_compare.v
@@ -1,0 +1,46 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// Copyright 2020 by Geza Lore. This program is free software; you can
+// redistribute it and/or modify it under the terms of either the GNU
+// Lesser General Public License Version 3 or the Perl Artistic License
+// Version 2.0.
+// SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+module t_tautological_bitwise_compare(clk);
+   input clk;
+
+   reg   x = 0;
+
+   always @(posedge clk) begin
+      if (!x) begin
+         // These used to trigger a warning with clang 10.0.0:
+         // error: bitwise comparison always evaluates to false
+         // [-Werror,-Wtautological-bitwise-compare]. The body of the 'if' is
+         // not important, just not empty so the 'if' remains. Also it cannot
+         // be something that causes the condition to get a branch hint like
+         // $stop as that seems to suppress the clang warning.
+
+         // Always false bit 1 set on lhs, clear on rhs
+         if ({1'h1, x} == 2'h0) x <= '0;
+         if ({1'h1, x} == 2'h1) x <= '0;
+         if ({1'h1, x} == {1'b0, x}) x <= '0;
+         if ({1'h0, x} == {1'b1, x}) x <= '0;
+         // Always true for the same reason
+         if ({1'h1, x} != 2'h0) x <= '0;
+         if ({1'h1, x} != 2'h1) x <= '0;
+         if ({1'h1, x} != {1'b0, x}) x <= '0;
+         if ({1'h0, x} != {1'b1, x}) x <= '0;
+
+         // Not known up front, but won't get here if x is set
+         if ({1'h1, x} == 2'h3) $stop;
+         if ({1'h1, x} != 2'h2) $stop;
+      end
+
+      // This make sure 'x' is used but not constant so it doesn't get removed
+      x <= '1;
+
+      // Done
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end
+endmodule


### PR DESCRIPTION
@wsnyder could you please have a quick review of this? I left in some questions. Also please let me know if there are better APIs for doing things as I haven't been around this bit before.

Given that It does not handle all cases where this optimizaton could theoretically be used I decided not to add more virtual functions to the AstNodes. I have mostly done this to keep clang 10 on Ubuntu 20.04 happy.