### PR TITLE
VerilatedVarProps::totalSize was missing the first unpacked dim

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -17,6 +17,7 @@ Iztok Jeras
 James Hanlon
 Jeremy Bennett
 John Coiner
+John Demme
 Julien Margetts
 Kanad Kanhere
 Kevin Kiningham

--- a/include/verilated.cpp
+++ b/include/verilated.cpp
@@ -2444,7 +2444,7 @@ vluint32_t VerilatedVarProps::entSize() const {
 
 size_t VerilatedVarProps::totalSize() const {
     size_t size = entSize();
-    for (int dim = 1; dim <= dims(); ++dim) size *= m_unpacked[dim].elements();
+    for (int dim = 0; dim <= dims(); ++dim) size *= m_unpacked[dim].elements();
     return size;
 }
 

--- a/test_regress/t/t_dpi_open_c.cpp
+++ b/test_regress/t/t_dpi_open_c.cpp
@@ -117,7 +117,7 @@ void _dpii_all(int c, int p, int u, const svOpenArrayHandle i, const svOpenArray
     // NC always returns zero and warns
     (void)svSizeOfArray(i);
 #endif
-#if !defined(VCS) && !defined(MS)  // VCS does not support dimension 0 query
+#if !defined(VCS)
     if (p) {
         int d = 0;
         if (c == 0 || c == 1) {

--- a/test_regress/t/t_dpi_open_c.cpp
+++ b/test_regress/t/t_dpi_open_c.cpp
@@ -22,6 +22,8 @@
 # include "../vc_hdrs.h"
 #elif defined(NC)
 # define NEED_EXTERNS
+#elif defined(MS)
+# define NEED_EXTERNS
 #else
 # error "Unknown simulator for DPI test"
 #endif
@@ -94,6 +96,15 @@ int dpii_failure() { return failure; }
         } \
     } while (0)
 
+#define CHECK_RESULT_HEX_NE(got, exp) \
+    do { \
+        if ((got) == (exp)) { \
+            std::cout << std::dec << "%Error: " << __FILE__ << ":" << __LINE__ << std::hex \
+                      << ": GOT=" << (got) << "   EXP!=" << (exp) << std::endl; \
+            failure = __LINE__; \
+        } \
+    } while (0)
+
 void dpii_unused(const svOpenArrayHandle u) {}
 
 void _dpii_all(int c, int p, int u, const svOpenArrayHandle i, const svOpenArrayHandle o) {
@@ -106,7 +117,7 @@ void _dpii_all(int c, int p, int u, const svOpenArrayHandle i, const svOpenArray
     // NC always returns zero and warns
     (void)svSizeOfArray(i);
 #endif
-#ifndef VCS  // VCS does not support dimension 0 query
+#if !defined(VCS) && !defined(MS)  // VCS does not support dimension 0 query
     if (p) {
         int d = 0;
         if (c == 0 || c == 1) {
@@ -224,8 +235,29 @@ void dpii_open_pw_u3(int c, int p, int u, const svOpenArrayHandle i, const svOpe
 }
 
 void dpii_open_bit(const svOpenArrayHandle i, const svOpenArrayHandle o) {}
-void dpii_open_byte(const svOpenArrayHandle i, const svOpenArrayHandle o) {}
-void dpii_open_int(const svOpenArrayHandle i, const svOpenArrayHandle o) {}
+
+void dpii_open_byte(const svOpenArrayHandle i, const svOpenArrayHandle o) {
+    intptr_t arrPtr = (intptr_t)svGetArrayPtr(i);
+    CHECK_RESULT_HEX_NE(arrPtr, 0); // All the arrays should actually exist
+#ifndef NC
+    // NC always returns zero and warns
+    int sizeInputOfArray = svSizeOfArray(i);
+    CHECK_RESULT_HEX_NE(sizeInputOfArray, 0); // None of the test cases have zero size
+    CHECK_RESULT_HEX_NE(svDimensions(i), 0); // All the test cases are unpacked arrays
+#endif
+}
+
+void dpii_open_int(const svOpenArrayHandle i, const svOpenArrayHandle o) {
+    intptr_t arrPtr = (intptr_t)svGetArrayPtr(i);
+    CHECK_RESULT_HEX_NE(arrPtr, 0); // All the arrays should actually exist
+#ifndef NC
+    // NC always returns zero and warns
+    int sizeInputOfArray = svSizeOfArray(i);
+    CHECK_RESULT_HEX_NE(sizeInputOfArray, 0); // None of the test cases have zero size
+    CHECK_RESULT_HEX_NE(svDimensions(i), 0); // All the test cases are unpacked arrays
+#endif
+}
+
 void dpii_open_integer(const svOpenArrayHandle i, const svOpenArrayHandle o) {}
 void dpii_open_logic(const svOpenArrayHandle i, const svOpenArrayHandle o) {}
 

--- a/test_regress/t/t_dpi_open_c.cpp
+++ b/test_regress/t/t_dpi_open_c.cpp
@@ -117,7 +117,7 @@ void _dpii_all(int c, int p, int u, const svOpenArrayHandle i, const svOpenArray
     // NC always returns zero and warns
     (void)svSizeOfArray(i);
 #endif
-#if !defined(VCS)
+#ifndef VCS  // VCS does not support dimension 0 query
     if (p) {
         int d = 0;
         if (c == 0 || c == 1) {

--- a/test_regress/t/t_dpi_open_c.cpp
+++ b/test_regress/t/t_dpi_open_c.cpp
@@ -22,8 +22,8 @@
 # include "../vc_hdrs.h"
 #elif defined(NC)
 # define NEED_EXTERNS
-#elif defined(MS)
-# define NEED_EXTERNS
+// #elif defined(MS)
+// # define NEED_EXTERNS
 #else
 # error "Unknown simulator for DPI test"
 #endif

--- a/test_regress/t/t_dpi_open_c.cpp
+++ b/test_regress/t/t_dpi_open_c.cpp
@@ -102,8 +102,10 @@ void _dpii_all(int c, int p, int u, const svOpenArrayHandle i, const svOpenArray
            __FILE__, __LINE__, c, p, u, svGetArrayPtr(i));
 #endif
     (void)svGetArrayPtr(i);
+#ifndef NC
     // NC always returns zero and warns
-    //(void)svSizeOfArray(i);
+    (void)svSizeOfArray(i);
+#endif
 #ifndef VCS  // VCS does not support dimension 0 query
     if (p) {
         int d = 0;


### PR DESCRIPTION
Throwing off the calculation. This looks like a simple off-by-one error.

The net effect is when running 'svSizeOfArray' from a DPI function, said calculation does not include the first unpacked dimension of the array. For instance, if I have a 'byte Data [3:0]', it returns 1 when it should return 4.


We appreciate your contributing to Verilator.  If this is your first commit, please add your name to docs/CONTRIBUTORS, and read our contributing guidelines in docs/CONTRIBUTING.adoc.


This is a one-character change... Is including my name in the contributors list appropriate?

Closes #2297 