### PR TITLE
Adding missing sstream include

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -6,6 +6,7 @@ Please see the Verilator manual for 200+ additional contributors. Thanks to all.
 Ahmed El-Mahmoudy
 Alex Chadwick
 Chris Randall
+Dan Petrisko
 David Stanford
 Driss Hafdi
 Eric Rippey

--- a/include/verilated.cpp
+++ b/include/verilated.cpp
@@ -29,6 +29,7 @@
 #include <algorithm>
 #include <cctype>
 #include <cerrno>
+#include <sstream>
 #include <tgmath.h>
 #include <sys/stat.h>  // mkdir
 


### PR DESCRIPTION
Hi, I noticed a regression in Verilator 4.031 when building with systemc.

```
xxx/share/verilator/include/verilated.cpp: In static member function ‘static void Verilated::timeprecision(int)’:
xxx/share/verilator/include/verilated.cpp:2163:28: error: aggregate ‘std::ostringstream msg’ has incomplete type and cannot be defined
         std::ostringstream msg;
```

This patch fixes the error.
