### PR TITLE
Resolve Verilator crash on self-referential enumerated type.

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -41,6 +41,7 @@ Richard Myers
 Sean Cross
 Sebastien Van Cauwenberghe
 Stefan Wallentowitz
+Stephen Henry
 Tim Snyder
 Tobias Rosenkranz
 Tobias Wölfel

--- a/src/V3LinkDot.cpp
+++ b/src/V3LinkDot.cpp
@@ -2369,6 +2369,12 @@ private:
             }
         }
     }
+    virtual void visit(AstEnumDType* nodep) VL_OVERRIDE {
+        iterateChildren(nodep);
+        AstRefDType* refdtype = VN_CAST(nodep->childDTypep(), RefDType);
+        if (refdtype && (nodep == refdtype->refDTypep()))
+            refdtype->v3error("Self-referential enumerated type definition");
+    }
     virtual void visit(AstEnumItemRef* nodep) VL_OVERRIDE {
         // EnumItemRef may be under a dot.  Should already be resolved.
         iterateChildren(nodep);

--- a/test_regress/t/t_enum_recurse_bad2.out
+++ b/test_regress/t/t_enum_recurse_bad2.out
@@ -1,0 +1,4 @@
+%Error: t/t_enum_recurse_bad2.v:7:14: Self-referential enumerated type definition
+    7 | typedef enum foo_t { A  = 'b0, B = 'b1 } foo_t;
+      |              ^~~~~
+%Error: Exiting due to

--- a/test_regress/t/t_enum_recurse_bad2.pl
+++ b/test_regress/t/t_enum_recurse_bad2.pl
@@ -1,0 +1,19 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2004 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    fails => 1,
+    expect_filename => $Self->{golden_filename},
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_enum_recurse_bad2.v
+++ b/test_regress/t/t_enum_recurse_bad2.v
@@ -1,0 +1,7 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2019 by Wilson Snyder.
+// SPDX-License-Identifier: CC0-1.0
+
+typedef enum foo_t { A  = 'b0, B = 'b1 } foo_t;


### PR DESCRIPTION
A malformed, self-referential enum type: `typedef enum foo { ... } foo;` causes Verilator to crash (V3Width enters an infinite recursion when attempting to resolve the basic type for the enum). The following patch flags the self-referential case after linking so that Verilator errors out before reaching the V3Width step.


