### PR TITLE
src/Makefile_obj.in: fix compile error when using bison 3.6.1

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -14,6 +14,7 @@ Garrett Smith
 Geza Lore
 Gianfranco Costamagna
 Howard Su
+Huang Rui
 Iztok Jeras
 James Hanlon
 Jeremy Bennett

--- a/src/bisonpre
+++ b/src/bisonpre
@@ -212,6 +212,8 @@ sub clean_output {
         $line =~ s!\(YY_\("!(YY_((char*)"!g;
         # Fix bison 2.3 glr-parser warning about yyerrorloc.YYTYPE::yydummy uninit
         $line =~ s!(YYLTYPE yyerrloc;)!$1 yyerrloc.yydummy=0;/*bisonpre*/!g;
+        # Fix bison 3.6.1 unexpected nested-comment
+        $line =~ s!/\* "/\*.*\*/"  \*/!!g;
         $fh->write($line);
     }
     $fh->close;


### PR DESCRIPTION
Workaround issue: bison 3.6.1 generated unexpected nested-comment

This commit will remove unexpected nested-comment and safe for old version of bison.

I agreed with docs/CONTRIBUTING.adoc
Closes: https://github.com/verilator/verilator/issues/2320
