### PR TITLE
Refactor trace implementation to allow experimentations

### DIFF
--- a/src/V3Ast.h
+++ b/src/V3Ast.h
@@ -193,12 +193,14 @@ class AstCFuncType {
 public:
     enum en {
         FT_NORMAL,
+        TRACE_REGISTER,
         TRACE_INIT,
         TRACE_INIT_SUB,
         TRACE_FULL,
         TRACE_FULL_SUB,
         TRACE_CHANGE,
-        TRACE_CHANGE_SUB
+        TRACE_CHANGE_SUB,
+        TRACE_CLEANUP
     };
     enum en m_e;
     inline AstCFuncType()
@@ -210,10 +212,7 @@ public:
         : m_e(static_cast<en>(_e)) {}
     operator en() const { return m_e; }
     // METHODS
-    bool isTrace() const {
-        return (m_e == TRACE_INIT || m_e == TRACE_INIT_SUB || m_e == TRACE_FULL
-                || m_e == TRACE_FULL_SUB || m_e == TRACE_CHANGE || m_e == TRACE_CHANGE_SUB);
-    }
+    bool isTrace() const { return m_e != FT_NORMAL; }
 };
 inline bool operator==(const AstCFuncType& lhs, const AstCFuncType& rhs) {
     return lhs.m_e == rhs.m_e;

--- a/src/V3AstNodes.h
+++ b/src/V3AstNodes.h
@@ -4811,33 +4811,33 @@ class AstTraceDecl : public AstNodeStmt {
     // Parents:  {statement list}
     // Children: none
 private:
-    string m_showname;  // Name of variable
     uint32_t m_code;  // Trace identifier code; converted to ASCII by trace routines
-    VNumRange m_bitRange;  // Property of var the trace details
-    VNumRange m_arrayRange;  // Property of var the trace details
-    uint32_t m_codeInc;  // Code increment
-    AstVarType m_varType;  // Type of variable (for localparam vs. param)
-    AstBasicDTypeKwd m_declKwd;  // Keyword at declaration time
-    VDirection m_declDirection;  // Declared direction input/output etc
-    bool m_isScoped;  // Uses run-time scope (for interfaces)
+    const string m_showname;  // Name of variable
+    const VNumRange m_bitRange;  // Property of var the trace details
+    const VNumRange m_arrayRange;  // Property of var the trace details
+    const uint32_t m_codeInc;  // Code increment
+    const AstVarType m_varType;  // Type of variable (for localparam vs. param)
+    const AstBasicDTypeKwd m_declKwd;  // Keyword at declaration time
+    const VDirection m_declDirection;  // Declared direction input/output etc
+    const bool m_isScoped;  // Uses run-time scope (for interfaces)
 public:
     AstTraceDecl(FileLine* fl, const string& showname,
                  AstVar* varp,  // For input/output state etc
                  AstNode* valuep, const VNumRange& bitRange, const VNumRange& arrayRange,
                  bool isScoped)
         : ASTGEN_SUPER(fl)
+        , m_code(0)
         , m_showname(showname)
         , m_bitRange(bitRange)
         , m_arrayRange(arrayRange)
+        , m_codeInc(
+              ((arrayRange.ranged() ? arrayRange.elements() : 1) * valuep->dtypep()->widthWords()
+               * (VL_EDATASIZE / 32)))  // A code is always 32-bits
+        , m_varType(varp->varType())
+        , m_declKwd(varp->declKwd())
+        , m_declDirection(varp->declDirection())
         , m_isScoped(isScoped) {
         dtypeFrom(valuep);
-        m_code = 0;
-        m_codeInc
-            = ((arrayRange.ranged() ? arrayRange.elements() : 1) * valuep->dtypep()->widthWords()
-               * (VL_EDATASIZE / (8 * sizeof(uint32_t))));  // A code is always 32-bits
-        m_varType = varp->varType();
-        m_declKwd = varp->declKwd();
-        m_declDirection = varp->declDirection();
     }
     virtual int instrCount() const { return 100; }  // Large...
     ASTNODE_NODE_FUNCS(TraceDecl)

--- a/src/V3Cdc.cpp
+++ b/src/V3Cdc.cpp
@@ -732,7 +732,7 @@ private:
 
     // Ignores
     virtual void visit(AstInitial*) VL_OVERRIDE {}
-    virtual void visit(AstTraceInc*) VL_OVERRIDE {}
+    virtual void visit(AstTraceDecl*) VL_OVERRIDE {}
     virtual void visit(AstCoverToggle*) VL_OVERRIDE {}
     virtual void visit(AstNodeDType*) VL_OVERRIDE {}
 

--- a/src/V3EmitC.cpp
+++ b/src/V3EmitC.cpp
@@ -3708,17 +3708,6 @@ class EmitCTrace : EmitCStmts {
                 puts("if (false && vcdp) {}  // Prevent unused\n");
             }
 
-            if (nodep->funcType() == AstCFuncType::TRACE_INIT) {
-                puts("vcdp->module(vlSymsp->name());  // Setup signal names\n");
-            } else if (nodep->funcType() == AstCFuncType::TRACE_INIT_SUB) {
-            } else if (nodep->funcType() == AstCFuncType::TRACE_FULL) {
-            } else if (nodep->funcType() == AstCFuncType::TRACE_FULL_SUB) {
-            } else if (nodep->funcType() == AstCFuncType::TRACE_CHANGE) {
-            } else if (nodep->funcType() == AstCFuncType::TRACE_CHANGE_SUB) {
-            } else {
-                nodep->v3fatalSrc("Bad Case");
-            }
-
             if (nodep->initsp()) {
                 string section;
                 putsDecoration("// Variables\n");

--- a/src/V3EmitCBase.h
+++ b/src/V3EmitCBase.h
@@ -55,7 +55,7 @@ public:
     static string symClassName() { return v3Global.opt.prefix() + "_" + protect("_Syms"); }
     static string symClassVar() { return symClassName() + "* __restrict vlSymsp"; }
     static string symTopAssign() {
-        return v3Global.opt.prefix() + "* __restrict vlTOPp VL_ATTR_UNUSED = vlSymsp->TOPp;";
+        return v3Global.opt.prefix() + "* const __restrict vlTOPp VL_ATTR_UNUSED = vlSymsp->TOPp;";
     }
     static string funcNameProtect(const AstCFunc* nodep, const AstNodeModule* modp) {
         if (nodep->isConstructor()) {

--- a/src/V3EmitCSyms.cpp
+++ b/src/V3EmitCSyms.cpp
@@ -442,6 +442,7 @@ void EmitCSyms::emitSymHdr() {
     }
     if (v3Global.opt.trace()) {
         puts("bool __Vm_activity;  ///< Used by trace routines to determine change occurred\n");
+        puts("uint32_t __Vm_baseCode;  ///< Used by trace routines when tracing multiple models\n");
     }
     puts("bool __Vm_didInit;\n");
 
@@ -495,10 +496,6 @@ void EmitCSyms::emitSymHdr() {
 
     puts("\n// METHODS\n");
     puts("inline const char* name() { return __Vm_namep; }\n");
-    if (v3Global.opt.trace()) {
-        puts("inline bool getClearActivity() { bool r=__Vm_activity; "
-             "__Vm_activity=false; return r; }\n");
-    }
     if (v3Global.opt.savable()) {
         puts("void " + protect("__Vserialize") + "(VerilatedSerialize& os);\n");
         puts("void " + protect("__Vdeserialize") + "(VerilatedDeserialize& os);\n");
@@ -627,7 +624,10 @@ void EmitCSyms::emitSymImp() {
         puts("    , __Vm_dumping(false)\n");
         puts("    , __Vm_dumperp(NULL)\n");
     }
-    if (v3Global.opt.trace()) puts("    , __Vm_activity(false)\n");
+    if (v3Global.opt.trace()) {
+        puts("    , __Vm_activity(false)\n");
+        puts("    , __Vm_baseCode(0)\n");
+    }
     puts("    , __Vm_didInit(false)\n");
     puts("    // Setup submodule names\n");
     char comma = ',';

--- a/src/V3Gate.cpp
+++ b/src/V3Gate.cpp
@@ -516,8 +516,8 @@ private:
     virtual void visit(AstCoverToggle* nodep) VL_OVERRIDE {
         iterateNewStmt(nodep, "CoverToggle", "CoverToggle");
     }
-    virtual void visit(AstTraceInc* nodep) VL_OVERRIDE {
-        bool lastslow = m_inSlow;
+    virtual void visit(AstTraceDecl* nodep) VL_OVERRIDE {
+        const bool lastslow = m_inSlow;
         m_inSlow = true;
         iterateNewStmt(nodep, "Tracing", "Tracing");
         m_inSlow = lastslow;


### PR DESCRIPTION
I think there is still performance on the table regarding tracing, to investiaget this I would liek to run some further experiments These patches add no real functional changes, however they do have some benefits, plus they provide a better baseline for the experiments and hence I would like to get them in even if the subsequent experiments all fail. 

With these changes there is a small performance benefit (<2.5% VCD) as we no longer emmit trace sub-functions for each activity flag combination, but only if the trace split limit is reached. This also makes profiling easier as most tracing related code is now in one function rather than being spread for example over 1400 functions in the case of SweRV EH1. Also, all TraceInc nodes are now creaed in V3Trace rather then V3TraceDecl, which makes it a bit easier to generate more arbitrary shaped trace functions.

I am fairly comfortable with the changes to V3Trace, V3TraceDecl, V3EmitC and anything in the run-time library under include/, so you don't need to spend too much time reviewing those (unles you would like to), but I think it would be useful to sanity check the other files which should have only small changes, and my changes to the AST nodes.