### PR TITLE
Fix regression due to early constant folding in +: and -:

### DIFF
--- a/src/V3WidthSel.cpp
+++ b/src/V3WidthSel.cpp
@@ -458,6 +458,7 @@ private:
         UINFO(6, "SELPLUS/MINUS " << nodep << endl);
         // Below 2 lines may change nodep->widthp()
         if (debug() >= 9) nodep->dumpTree(cout, "--SELPM0: ");
+        V3Width::widthParamsEdit(nodep->rhsp());  // constifyEdit doesn't ensure widths finished
         V3Const::constifyEdit(nodep->rhsp());  // May relink pointed to node, ok if not const
         V3Const::constifyParamsEdit(nodep->thsp());  // May relink pointed to node
         checkConstantOrReplace(nodep->thsp(), "Width of :+ or :- bit extract isn't a constant");

--- a/test_regress/t/t_select_plus.v
+++ b/test_regress/t/t_select_plus.v
@@ -74,4 +74,19 @@ module t (/*AUTOARG*/
       endcase
    end
 
+   // Additional constant folding check - this used to trigger a bug
+   reg [23:0] a;
+   reg [3:0]  b;
+
+   initial begin
+     a = 24'd0;
+     b = 4'b0111;
+     a[3*(b[2:0]+0)+:3] = 3'd7; // Check LSB expression goes to 32-bits
+     if (a != 24'b11100000_00000000_00000000) $stop;
+
+     a = 24'd0;
+     b = 4'b0110;
+     a[3*(b[2:0]+0)-:3] = 3'd7; // Check MSB expression goes to 32-bits
+     if (a != 24'b00000111_00000000_00000000) $stop;
+   end
 endmodule


### PR DESCRIPTION
This is a proposed fix to the bug I casually mentioned in #2336. It is caused by this fold introduced by a41ea180fa4dec1cc57a02a0ab2f8645164d7882:
https://github.com/verilator/verilator/blob/212aa332dd9f14d93b897d41e56e4c28389ac117/src/V3WidthSel.cpp#L461

The problem is that in the crazy LSB/MSB expresion (i.e.: op2) in the `+:`/`-:`in the test: `3*(b[2:0]+0)` that fold, removes the `+0`, but that `+0` promoted the `AstAdd` to 32-bits width, which meant, an AstExtend was later inserted for the `b[2:0]` by V3Width, but with that `+0` removed the Extend is not added and the assertion downstream in V3Extend blows up:
https://github.com/verilator/verilator/blob/212aa332dd9f14d93b897d41e56e4c28389ac117/src/V3Expand.cpp#L326

I'm not sure this is the right fix from V3Width's point of view, but according to IEEE 1800-2017 11.5.1  those expressions are self-determined, so I just set them to be checked and normalized (I asume that is what PRELIM/FINAL in WidthVP determines?) prior to calling the converter in V3WidthSel, so the necessary AstExtend is inserted up front.

If this is the right fix, then maybe we should do the same to all other self determined expressions in this area as I notice there are more constify (which I believe is the name for the constatn folder?) calls in V3WidthSel?

BTW is this the preferred way to write a test for this? I made something that executed and was self-checkin but it just added a noise to the trees making it harder to debug.