### PR TITLE
Check if Parallel::Forker is new enough

### DIFF
--- a/test_regress/driver.pl
+++ b/test_regress/driver.pl
@@ -30,7 +30,7 @@ eval "use Parallel::Forker; \$Fork=Parallel::Forker->new(use_sig_child=>1); \$::
 $Fork = Forker->new(use_sig_child=>1) if !$Fork;
 my $forker_Min_Version = 1.258;
 if ($::Have_Forker && $Parallel::Forker::VERSION < $forker_Min_Version) {
-    print STDERR "Parallel::Forker version is too old () requires $forker_Min_Version or newer\n";
+    print STDERR "driver.pl: Parallel::Forker is older than $forker_Min_Version, suggest 'cpan install Parallel::Forker'\n";
     $::Have_Forker = 0;
 }
 $SIG{CHLD} = sub { $Fork->sig_child() if $Fork; };

--- a/test_regress/driver.pl
+++ b/test_regress/driver.pl
@@ -28,6 +28,11 @@ $::Have_Forker = 0;
 
 eval "use Parallel::Forker; \$Fork=Parallel::Forker->new(use_sig_child=>1); \$::Have_Forker=1;";
 $Fork = Forker->new(use_sig_child=>1) if !$Fork;
+my $forker_Min_Version = 1.258;
+if ($::Have_Forker && $Parallel::Forker::VERSION < $forker_Min_Version) {
+    print STDERR "Parallel::Forker version is too old () requires $forker_Min_Version or newer\n";
+    $::Have_Forker = 0;
+}
 $SIG{CHLD} = sub { $Fork->sig_child() if $Fork; };
 $SIG{TERM} = sub { $Fork->kill_tree_all('TERM') if $Fork; die "Quitting...\n"; };
 


### PR DESCRIPTION
My Parallel::Forker was not new enough so I was getting warnings from this line in driver.pl:
```
delete $self->{running_ids}{$process->{running_id}};
```
because my version of the module wasn't calling `run_pre_start`.  I fixed this by upgrading, but am trying to add a check for this.  This properly detects if the module is too old but I'm sure I don't understand how `$Fork` and `$Have_Forker` work.  I thought the latter controlled whether we used `Parallel::Forker` or not, but even when this is set to zero, I still get the warning.

Can you explain what is going on here?
```
$Fork = Forker->new(use_sig_child=>1) if !$Fork;
```

It looks like if we didn't get a `$Fork`, we'll try to make a new `Parallel::Forker`.  But wouldn't that only be in the case where we don't have `Parallel::Forker`?

Also, looking at the version history I think we might only need 1.256, but I just picked the newest version to be safe.  Please let me know if I should bump this down:
https://metacpan.org/changes/distribution/Parallel-Forker