### PR TITLE
Add VPI error reset to vpi_get_time()

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -24,6 +24,7 @@ Julien Margetts
 Kanad Kanhere
 Kevin Kiningham
 Kuba Ober
+Ludwig Rogiers
 Lukasz Dalek
 Maarten De Braekeleer
 Maciej Sobkowski

--- a/include/verilated_vpi.cpp
+++ b/include/verilated_vpi.cpp
@@ -1907,6 +1907,7 @@ void vpi_put_value_array(vpiHandle /*object*/, p_vpi_arrayvalue /*arrayvalue_p*/
 
 void vpi_get_time(vpiHandle object, p_vpi_time time_p) {
     VerilatedVpiImp::assertOneCheck();
+    _VL_VPI_ERROR_RESET();
     // cppcheck-suppress nullPointer
     if (VL_UNLIKELY(!time_p)) {
         _VL_VPI_WARNING(__FILE__, __LINE__, "Ignoring vpi_get_time with NULL value pointer");


### PR DESCRIPTION
From the Systemverilog IEEE 1800-2017 standard:
"The vpi_chk_ error() routine shall return a nonzero value if an error occurred in the previously called VPI routine."

It looks like the VPI error is not reset at all in ```vpi_get_time()``` routine. 
This is causing a RecursionError in the logging mechanism of cocotb as reported in #2105 . 

Cocotb always calls ```vpi_chk_error()``` after any VPI function call. If any VPI error is detected, the logging mechanism in cocotb uses ```vpi_get_time()``` to retrieve the current sim time to add to the original error in the log message. Cocotb then calls ```vpi_chk_error()``` after ```vpi_get_time()``` which will then still indicate the original error and this is causing a RecursionError down the track. More details: https://github.com/cocotb/cocotb/issues/1313#issuecomment-632478985

The proposed fix in this PR will make the ```vpi_get_time()``` routine compliant with the Systemverilog IEEE 1800-2017 standard.


   

