### PR TITLE
Support wide operations in queues

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -48,6 +48,7 @@ Tim Snyder
 Tobias Rosenkranz
 Tobias Wölfel
 Todd Strader
+Vassilis Papaefstathiou
 Veripool API Bot
 Wilson Snyder
 Yossi Nivin

--- a/test_regress/t/t_dynarray.v
+++ b/test_regress/t/t_dynarray.v
@@ -27,6 +27,15 @@ module t (/*AUTOARG*/
    byte_t a[];
    byte_t b[];
 
+  // wide data array
+   typedef struct packed {
+     logic [15:0]  header;
+     logic [223:0] payload;
+     logic [15:0]  checksum;
+   } pck256_t;
+
+   pck256_t p256[];
+
    always @ (posedge clk) begin
       cyc <= cyc + 1;
       begin
@@ -100,6 +109,33 @@ module t (/*AUTOARG*/
          `checkh(b[1], 0);
          `checkh(b[2], 0);
          `checkh(b[4], 0);
+
+         // test wide dynamic array
+         p256 = new [11];
+         `checkh(p256.size, 11);
+         `checkh(p256.size(), 11);
+
+         p256[1].header   = 16'hcafe;
+         p256[1].payload  = {14{16'hbabe}};
+         p256[1].checksum = 16'hdead;
+         `checkh(p256[1].header, 16'hcafe);
+         `checkh(p256[1], {16'hcafe,{14{16'hbabe}},16'hdead});
+
+         `checkh(p256[0], '0);
+
+         p256[5] = '1;
+         `checkh(p256[5], {32{8'hff}});
+
+         p256[5].header = 16'h2;
+         `checkh(p256[5], {16'h2,{30{8'hff}}});
+
+         p256[2] = ( p256[5].header == 2 ) ? p256[1] : p256[5];
+         `checkh(p256[2], {16'hcafe,{14{16'hbabe}},16'hdead});
+
+
+         p256.delete();
+         `checkh(p256.size, 0);
+
       end
 
       $write("*-* All Finished *-*\n");

--- a/test_regress/t/t_queue.v
+++ b/test_regress/t/t_queue.v
@@ -195,6 +195,45 @@ module t (/*AUTOARG*/
 
       end
 
+      // testing a wide queue
+      begin
+         typedef struct packed {
+            bit [7:0] opcode;
+            bit [23:0] addr;
+            bit [127:0] data;
+         } instructionW; // named structure type
+
+         instructionW inst_push;
+         instructionW inst_pop;
+
+         instructionW q[$];
+         `checkh($dimensions(q), 2);
+
+         `checkh(q[0].opcode, 0);
+         `checkh(q[0].addr, 0);
+         `checkh(q[0].data, 0);
+
+         inst_push.opcode = 1;
+         inst_push.addr = 42;
+         inst_push.data = {4{32'hdeadbeef}};
+         q.push_back(inst_push);
+         `checkh(q[0].opcode, 1);
+         `checkh(q[0].addr, 42);
+         `checkh(q[0].data, {4{32'hdeadbeef}});
+
+
+         inst_pop = q.pop_front();
+         `checkh(inst_pop.opcode, 1);
+         `checkh(inst_pop.addr, 42);
+         `checkh(inst_pop.data, {4{32'hdeadbeef}});
+
+         `checkh(q.size(), 0);
+
+         `checkh(q[0].opcode, 0);
+         `checkh(q[0].addr, 0);
+         `checkh(q[0].data, 0);
+      end
+
       /* Unsup:
       begin
          int q[4][$];


### PR DESCRIPTION
Dear Wilson & Contributors to Verilator,

Since this is the first time I communicate with you I would like to thank you for this amazing effort all these years. Verilator has become my beloved simulator :)

I came across an issue while testing the Systemverilog queues and found that wide arguments (>64 bits) where not supported in the current implementation and the code could not compile.
I fixed the issue and also provide a test-case in this pull request.

Let me know if the fix looks OK to you.

Thanks a lot and best regards,
Vassilis Papaefstathiou
 