### PR TITLE
Fix the error "use of undeclared identifier 'WIFEXITED'" by adding #include <sys/wait.h>

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -51,5 +51,6 @@ Todd Strader
 Veripool API Bot
 Wilson Snyder
 Yossi Nivin
+Yuri Victorovich
 Yutetsu TAKATSUKASA
 Yves Mathieu

--- a/src/V3Os.cpp
+++ b/src/V3Os.cpp
@@ -54,6 +54,7 @@
 # include <thread>
 #else
 # include <sys/time.h>
+# include <sys/wait.h>
 # include <unistd.h>  // usleep
 #endif
 // clang-format on


### PR DESCRIPTION

We appreciate your contributing to Verilator.  If this is your first commit, please add your name to docs/CONTRIBUTORS, and read our contributing guidelines in docs/CONTRIBUTING.adoc.
