### PR TITLE
Fix output of loops on waiving

### DIFF
--- a/src/V3FileLine.cpp
+++ b/src/V3FileLine.cpp
@@ -360,8 +360,8 @@ void FileLine::v3errorEnd(std::ostringstream& sstr, const string& locationStr) {
         lstr << std::setw(ascii().length()) << " "
              << ": " << locationStr;
     }
-    if (warnIsOff(V3Error::errorCode())
-        || V3Config::waive(this, V3Error::errorCode(), sstr.str())) {
+    m_waive = V3Config::waive(this, V3Error::errorCode(), sstr.str());
+    if (warnIsOff(V3Error::errorCode()) || m_waive) {
         V3Error::suppressThisWarning();
     } else if (!V3Error::errorContexted()) {
         nsstr << warnContextPrimary();

--- a/src/V3FileLine.h
+++ b/src/V3FileLine.h
@@ -103,6 +103,7 @@ class FileLine {
     VFileContent* m_contentp;  // Source text contents line is within
     FileLine* m_parent;  // Parent line that included this line
     std::bitset<V3ErrorCode::_ENUM_MAX> m_warnOn;
+    bool m_waive;  // Waive warning
 
 protected:
     // User routines should never need to change line numbers
@@ -134,7 +135,8 @@ public:
         , m_contentLineno(0)
         , m_contentp(NULL)
         , m_parent(NULL)
-        , m_warnOn(defaultFileLine().m_warnOn) {}
+        , m_warnOn(defaultFileLine().m_warnOn)
+        , m_waive(false) {}
     explicit FileLine(FileLine* fromp)
         : m_firstLineno(fromp->m_firstLineno)
         , m_firstColumn(fromp->m_firstColumn)
@@ -144,7 +146,8 @@ public:
         , m_contentLineno(fromp->m_contentLineno)
         , m_contentp(fromp->m_contentp)
         , m_parent(fromp->m_parent)
-        , m_warnOn(fromp->m_warnOn) {}
+        , m_warnOn(fromp->m_warnOn)
+        , m_waive(fromp->m_waive) {}
     struct EmptySecret {};  // Constructor selection
     explicit FileLine(EmptySecret);
     FileLine* copyOrSameFileLine();
@@ -213,6 +216,7 @@ public:
     void warnStyleOff(bool flag);
     void warnStateFrom(const FileLine& from) { m_warnOn = from.m_warnOn; }
     void warnResetDefault() { warnStateFrom(defaultFileLine()); }
+    bool lastWarnWaived() { return m_waive; }
 
     // Specific flag ACCESSORS/METHODS
     bool coverageOn() const { return m_warnOn.test(V3ErrorCode::I_COVERAGE); }

--- a/src/V3Order.cpp
+++ b/src/V3Order.cpp
@@ -816,7 +816,8 @@ private:
                 nodep->v3warn(UNOPT,
                               "Signal unoptimizable: Feedback to public clock or circular logic: "
                                   << nodep->prettyNameQ());
-                if (!nodep->fileline()->warnIsOff(V3ErrorCode::UNOPT)) {
+                if (!nodep->fileline()->warnIsOff(V3ErrorCode::UNOPT)
+                    && !nodep->fileline()->lastWarnWaived()) {
                     nodep->fileline()->modifyWarnOff(V3ErrorCode::UNOPT,
                                                      true);  // Complain just once
                     // Give the user an example.
@@ -834,7 +835,8 @@ private:
                 nodep->v3warn(UNOPTFLAT,
                               "Signal unoptimizable: Feedback to clock or circular logic: "
                                   << nodep->prettyNameQ());
-                if (!nodep->fileline()->warnIsOff(V3ErrorCode::UNOPTFLAT)) {
+                if (!nodep->fileline()->warnIsOff(V3ErrorCode::UNOPTFLAT)
+                    && !nodep->fileline()->lastWarnWaived()) {
                     nodep->fileline()->modifyWarnOff(V3ErrorCode::UNOPTFLAT,
                                                      true);  // Complain just once
                     // Give the user an example.

--- a/test_regress/t/t_unopt_combo.vlt
+++ b/test_regress/t/t_unopt_combo.vlt
@@ -1,0 +1,3 @@
+`verilator_config
+
+lint_off -rule UNOPTFLAT -file "*t_unopt_combo.v" -match "Signal unoptimizable: Feedback to clock or circular logic: 't.c'"

--- a/test_regress/t/t_unopt_combo_waive.pl
+++ b/test_regress/t/t_unopt_combo_waive.pl
@@ -1,0 +1,21 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2003 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(vlt_all => 1);
+
+top_filename("t/t_unopt_combo.v");
+
+compile(
+    v_flags2 => ['+define+ATTRIBUTES', "t/t_unopt_combo.vlt"],
+    expect_filename => $Self->{golden_filename},  # Expect no output, as we waived
+    );
+
+ok(1);
+1;


### PR DESCRIPTION
When an unopt loop is waived, we also don't want the loop's example
path being plot.