### PR TITLE
Fixed warning for unused param in VL_RTOIROUND_Q_D

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -17,6 +17,7 @@ Howard Su
 Huang Rui
 Iztok Jeras
 James Hanlon
+Jan Van Winkel
 Jeremy Bennett
 John Coiner
 John Demme

--- a/include/verilated.h
+++ b/include/verilated.h
@@ -2384,7 +2384,7 @@ static inline WDataOutP VL_SEL_WWII(int obits, int lbits, int, int, WDataOutP ow
 
 /// Return QData from double (numeric)
 // EMIT_RULE: VL_RTOIROUND_Q_D:  oclean=dirty; lclean==clean/real
-static inline QData VL_RTOIROUND_Q_D(int bits, double lhs) VL_PURE {
+static inline QData VL_RTOIROUND_Q_D(int, double lhs) VL_PURE {
     // IEEE format: [63]=sign [62:52]=exp+1023 [51:0]=mantissa
     // This does not need to support subnormals as they are sub-integral
     lhs = VL_ROUND(lhs);


### PR DESCRIPTION
Fixed warning for unused param for `bits` in `VL_RTOIROUND_Q_D` located in `include/verilated.h` by casting it to void in case external program is build with `-Wall -Wextra`