### PR TITLE
Introduce notion of VerilatedFdList.

### DIFF
--- a/include/verilated.cpp
+++ b/include/verilated.cpp
@@ -1181,11 +1181,8 @@ done:
 // File I/O
 
 FILE* VL_CVT_I_FP(IData lhs) VL_MT_SAFE {
-    // Expected non-MCD case; returns ONLY the first file descriptor seen in lhs (which
-    // in the MCD case can result in descriptors being ignored).
-    VerilatedFdList fdlist;
-    VerilatedImp::fdToFp(lhs, fdlist);
-    return *fdlist.begin();
+    // Expected non-MCD case; returns null on MCD descriptors.
+    return VerilatedImp::fdToFp(lhs);
 }
 
 void _VL_VINT_TO_STRING(int obits, char* destoutp, WDataInP sourcep) VL_MT_SAFE {
@@ -1369,12 +1366,7 @@ void VL_FWRITEF(IData fpi, const char* formatp, ...) VL_MT_SAFE {
     _vl_vsformat(output, formatp, ap);
     va_end(ap);
 
-    VerilatedFdList fdlist;
-    VerilatedImp::fdToFp(fpi, fdlist);
-    for (VerilatedFdList::iterator it = fdlist.begin(); it != fdlist.end(); ++it) {
-        if (VL_UNLIKELY(!*it)) continue;
-        fwrite(output.c_str(), 1, output.size(), *it);
-    }
+    VerilatedImp::fdWrite(fpi, output);
 }
 
 IData VL_FSCANF_IX(IData fpi, const char* formatp, ...) VL_MT_SAFE {

--- a/include/verilated.cpp
+++ b/include/verilated.cpp
@@ -1183,9 +1183,9 @@ done:
 FILE* VL_CVT_I_FP(IData lhs) VL_MT_SAFE {
     // Expected non-MCD case; returns ONLY the first file descriptor seen in lhs (which
     // in the MCD case can result in descriptors being ignored).
-    FILE* fp[1] = {NULL};
-    VerilatedImp::fdToFp(lhs, fp, 1);
-    return fp[0];
+    VerilatedFdList fdlist;
+    VerilatedImp::fdToFp(lhs, fdlist);
+    return *fdlist.begin();
 }
 
 void _VL_VINT_TO_STRING(int obits, char* destoutp, WDataInP sourcep) VL_MT_SAFE {
@@ -1369,11 +1369,11 @@ void VL_FWRITEF(IData fpi, const char* formatp, ...) VL_MT_SAFE {
     _vl_vsformat(output, formatp, ap);
     va_end(ap);
 
-    FILE* fp[30];
-    const std::size_t n = VerilatedImp::fdToFp(fpi, fp, 30);
-    for (std::size_t i = 0; i < n; ++i) {
-        if (VL_UNLIKELY(!fp[i])) continue;
-        fwrite(output.c_str(), 1, output.size(), fp[i]);
+    VerilatedFdList fdlist;
+    VerilatedImp::fdToFp(fpi, fdlist);
+    for (VerilatedFdList::iterator it = fdlist.begin(); it != fdlist.end(); ++it) {
+        if (VL_UNLIKELY(!*it)) continue;
+        fwrite(output.c_str(), 1, output.size(), *it);
     }
 }
 

--- a/include/verilated.h
+++ b/include/verilated.h
@@ -233,7 +233,7 @@ public:
     iterator end() { return m_fp + m_sz; }
     std::size_t size() const { return m_sz; }
     std::size_t capacity() const { return 31; }
-    void append(FILE* fd) {
+    void push_back(FILE* fd) {
         if (size() < capacity()) m_fp[m_sz++] = fd;
     }
     void adopt_lock(VerilatedMutex* lock) { m_lg.adopt(lock); }

--- a/include/verilated.h
+++ b/include/verilated.h
@@ -167,17 +167,25 @@ private:
 
 public:
     explicit VerilatedLockGuard()
-        : m_mutexr(NULL) {
-    }
+        : m_mutexr(NULL) {}
     explicit VerilatedLockGuard(VerilatedMutex& mutexr) VL_ACQUIRE(mutexr)
         : m_mutexr(&mutexr) {
         m_mutexr->lock();
     }
-    ~VerilatedLockGuard() VL_RELEASE() { if (owns_lock()) m_mutexr->unlock(); }
-    void lock() VL_ACQUIRE() { if (owns_lock()) m_mutexr->lock(); }
-    void unlock() VL_RELEASE() { if (owns_lock()) m_mutexr->unlock(); }
+    ~VerilatedLockGuard() VL_RELEASE() {
+        if (owns_lock()) m_mutexr->unlock();
+    }
+    void lock() VL_ACQUIRE() {
+        if (owns_lock()) m_mutexr->lock();
+    }
+    void unlock() VL_RELEASE() {
+        if (owns_lock()) m_mutexr->unlock();
+    }
     bool owns_lock() const { return m_mutexr != NULL; }
-    void adopt(VerilatedMutex* mutexr) { unlock(); m_mutexr = mutexr; }
+    void adopt(VerilatedMutex* mutexr) {
+        unlock();
+        m_mutexr = mutexr;
+    }
     VerilatedMutex* release() {
         VerilatedMutex* ret = m_mutexr;
         m_mutexr = NULL;
@@ -206,7 +214,7 @@ public:
     void lock() {}
     void unlock() {}
     bool owns_lock() const { return false; }
-    void adopt(VerilatedMutex*) { }
+    void adopt(VerilatedMutex*) {}
     VerilatedMutex* release() { return NULL; }
 };
 
@@ -216,14 +224,18 @@ class VerilatedFdList {
     FILE* m_fp[31];
     VerilatedLockGuard m_lg;
     std::size_t m_sz;
+
 public:
     typedef FILE** iterator;
-    explicit VerilatedFdList() : m_sz(0) {}
+    explicit VerilatedFdList()
+        : m_sz(0) {}
     iterator begin() { return m_fp; }
     iterator end() { return m_fp + m_sz; }
     std::size_t size() const { return m_sz; }
     std::size_t capacity() const { return 31; }
-    void append(FILE* fd) { if (size() < capacity()) m_fp[m_sz++] = fd; }
+    void append(FILE* fd) {
+        if (size() < capacity()) m_fp[m_sz++] = fd;
+    }
     void adopt_lock(VerilatedMutex* lock) { m_lg.adopt(lock); }
 };
 

--- a/include/verilated.h
+++ b/include/verilated.h
@@ -163,34 +163,16 @@ class VL_SCOPED_CAPABILITY VerilatedLockGuard {
     VL_UNCOPYABLE(VerilatedLockGuard);
 
 private:
-    VerilatedMutex* m_mutexr;
+    VerilatedMutex& m_mutexr;
 
 public:
-    explicit VerilatedLockGuard()
-        : m_mutexr(NULL) {}
     explicit VerilatedLockGuard(VerilatedMutex& mutexr) VL_ACQUIRE(mutexr)
-        : m_mutexr(&mutexr) {
-        m_mutexr->lock();
+        : m_mutexr(mutexr) {
+        m_mutexr.lock();
     }
-    ~VerilatedLockGuard() VL_RELEASE() {
-        if (owns_lock()) m_mutexr->unlock();
-    }
-    void lock() VL_ACQUIRE() {
-        if (owns_lock()) m_mutexr->lock();
-    }
-    void unlock() VL_RELEASE() {
-        if (owns_lock()) m_mutexr->unlock();
-    }
-    bool owns_lock() const { return m_mutexr != NULL; }
-    void adopt(VerilatedMutex* mutexr) {
-        unlock();
-        m_mutexr = mutexr;
-    }
-    VerilatedMutex* release() {
-        VerilatedMutex* ret = m_mutexr;
-        m_mutexr = NULL;
-        return ret;
-    }
+    ~VerilatedLockGuard() VL_RELEASE() { m_mutexr.unlock(); }
+    void lock() VL_ACQUIRE() { m_mutexr.lock(); }
+    void unlock() VL_RELEASE() { m_mutexr.unlock(); }
 };
 
 #else  // !VL_THREADED
@@ -207,37 +189,13 @@ class VerilatedLockGuard {
     VL_UNCOPYABLE(VerilatedLockGuard);
 
 public:
-    struct adopt_lock_t {};
-    explicit VerilatedLockGuard() {}
     explicit VerilatedLockGuard(VerilatedMutex&) {}
     ~VerilatedLockGuard() {}
     void lock() {}
     void unlock() {}
-    bool owns_lock() const { return false; }
-    void adopt(VerilatedMutex*) {}
-    VerilatedMutex* release() { return NULL; }
 };
 
 #endif  // VL_THREADED
-
-class VerilatedFdList {
-    FILE* m_fp[31];
-    VerilatedLockGuard m_lg;
-    std::size_t m_sz;
-
-public:
-    typedef FILE** iterator;
-    explicit VerilatedFdList()
-        : m_sz(0) {}
-    iterator begin() { return m_fp; }
-    iterator end() { return m_fp + m_sz; }
-    std::size_t size() const { return m_sz; }
-    std::size_t capacity() const { return 31; }
-    void push_back(FILE* fd) {
-        if (size() < capacity()) m_fp[m_sz++] = fd;
-    }
-    void adopt_lock(VerilatedMutex* lock) { m_lg.adopt(lock); }
-};
 
 /// Remember the calling thread at construction time, and make sure later calls use same thread
 class VerilatedAssertOneThread {

--- a/include/verilated_imp.h
+++ b/include/verilated_imp.h
@@ -494,8 +494,8 @@ public:  // But only for verilated*.cpp
         VerilatedFdList fdlist;
         fdToFp(fdi, fdlist);
         if (VL_UNLIKELY(fdlist.size() != 1)) return 0;
-        return static_cast<IData>(fseek(*fdlist.begin(), static_cast<long>(offset),
-                                        static_cast<int>(origin)));
+        return static_cast<IData>(
+            fseek(*fdlist.begin(), static_cast<long>(offset), static_cast<int>(origin)));
     }
     static IData fdTell(IData fdi) VL_MT_SAFE {
         VerilatedFdList fdlist;

--- a/include/verilated_imp.h
+++ b/include/verilated_imp.h
@@ -558,7 +558,7 @@ public:  // But only for verilated*.cpp
     }
 
 private:
-    static inline VerilatedFpList fdToFpList(IData fdi) {
+    static inline VerilatedFpList fdToFpList(IData fdi) VL_REQUIRES(s_s.m_fdMutex) {
         VerilatedFpList fp;
         if ((fdi & (1 << 31)) != 0) {
             // Non-MCD case

--- a/include/verilated_imp.h
+++ b/include/verilated_imp.h
@@ -530,17 +530,17 @@ public:  // But only for verilated*.cpp
             // Non-MCD case
             IData idx = fdi & VL_MASK_I(31);
             switch (idx) {
-            case 0: fd.append(stdin); break;
-            case 1: fd.append(stdout); break;
-            case 2: fd.append(stderr); break;
+            case 0: fd.push_back(stdin); break;
+            case 1: fd.push_back(stdout); break;
+            case 2: fd.push_back(stderr); break;
             default:
-                if (VL_LIKELY(idx < s_s.m_fdps.size())) fd.append(s_s.m_fdps[idx]);
+                if (VL_LIKELY(idx < s_s.m_fdps.size())) fd.push_back(s_s.m_fdps[idx]);
                 break;
             }
         } else {
             // MCD Case
             for (int i = 0; (fdi != 0) && (i < fd.capacity()); ++i, fdi >>= 1) {
-                if (fdi & VL_MASK_I(1)) fd.append(s_s.m_fdps[i]);
+                if (fdi & VL_MASK_I(1)) fd.push_back(s_s.m_fdps[i]);
             }
         }
         fd.adopt_lock(lock.release());


### PR DESCRIPTION
Initial attempt at #2333.

Locks were previously used to guard updates to shared state (the table which maintains the file-descriptor to FILE* mapping, operations on FILE*, etc...). In the MCD case, this was not sufficient. For a MCD descriptor, the constituent descriptors could belong to distinct threads. In the small interval where a MCD descriptor set was computed (in verilated_imp.h:fdtofp), another thread could close one of the file descriptors contained within it, invalidating the set and causing undefined behavior when a subsequent attempt is made to access the now stale descriptor.

In general, I would expect a single distinct file-descriptor to be owned entirely by a single thread. This idiom breaks down in the MCD case, which (IMHO) is a bit dodgy when used in a multi-threaded environment. Nevertheless, the solution I came up with is to introduce the notion of a VerilatedFdList. This replaces the prior FILE* array which was previously populated by the fptofd call. The class encapsulates the notion of a file-descriptor set and, more importantly, it adopts the lock acquired by fdtofp. The lock is then subsequently released through RAII whenever the list is destructed. The only real significant change here (semantically) is that when acquiring a file-descriptor set, the global I/O mutex is not unlocked until the requested set has been destructed (and any I/O completed). The small-interval where the lock is released and then reacquired is now removed.
