### PR TITLE
Rework parallel build and split

### DIFF
--- a/Changes
+++ b/Changes
@@ -23,6 +23,13 @@ The contributors that suggested a given feature are shown in []. Thanks!
 
 ****  Fix queues and dynamic array wide ops. (#2352) [Vassilis Papaefstathiou]
 
+****  --output-split is now on by default. VM_PARALLEL_BUILDS is set by
+      default iff the --output-split caused an actual file split to occur.
+      --output-split-cfuncs and --output-split-ctrace now default to the
+      value of --output-split. These changes should improve build times of
+      medium and large designs with default options. User makefiles may
+      require changes.
+
 
 * Verilator 4.034 2020-05-03
 

--- a/bin/verilator
+++ b/bin/verilator
@@ -2004,7 +2004,7 @@ depending on the operating system.
     # Might be needed if SystemC 2.3.0
     export SYSTEMC_CXX_FLAGS=-pthread
 
-    g++ -L$SYSTEMC_LIBDIR ../sc_main.o Vour__ALL*.o verilated.o \
+    g++ -L$SYSTEMC_LIBDIR ../sc_main.o Vour__ALL.a verilated.o \
               -o Vour -lsystemc
 
 And now we run it
@@ -2187,8 +2187,7 @@ After running Make, the C++ compiler may produce the following:
     {mod_prefix}{misc}.o                // Intermediate objects
     {prefix}                            // Final executable (w/--exe argument)
     {prefix}__ALL.a                     // Library of all Verilated objects
-    {prefix}__ALLfast.cpp               // Include of hot code for single compile
-    {prefix}__ALLslow.cpp               // Include of slow code for single compile
+    {prefix}__ALL.cpp                   // Include of all code for single compile
     {prefix}{misc}.d                    // Intermediate dependencies
     {prefix}{misc}.o                    // Intermediate objects
 
@@ -2772,8 +2771,7 @@ underneath NC:
    cd obj_dir
    ncsc_run \
         sc_main.cpp \
-        Vour__ALLfast.cpp \
-        Vour__ALLslow.cpp \
+        Vour__ALL.cpp \
         verilated.cpp
 
 For larger designs you'll want to automate this using makefiles, which pull

--- a/bin/verilator
+++ b/bin/verilator
@@ -1122,17 +1122,15 @@ developers.
 
 Enables splitting the output .cpp files into multiple outputs.  When a C++
 file exceeds the specified number of operations, a new file will be created
-at the next function boundary.  In addition, any infrequently executed
-"cold" routines will be placed into __Slow files.  This accelerates
-compilation by as optimization can be disabled on the routines in __Slow,
-and the remaining files can be compiled on parallel machines.  Using
---output-split should have only a trivial impact on performance.  On one
-design --output-split 20000 resulted in splitting into approximately
-one-minute-compile chunks.
+at the next function boundary.  In addition, if the total output code size
+exceeds the specified value, VM_PARALLEL_BUILDS will be set to 1 by default
+in the generated make files, making parallel compilation possible. Using
+--output-split should have only a trivial impact on model performance. But
+can greatly improve C++ compilation speed. The use of I<ccache> (set for you
+if present at configure time) is also more effective with this option.
 
-Typically when using this, make with VM_PARALLEL_BUILDS=1 (set for you if
-using the default makefiles), and use I<ccache> (set for you if present at
-configure time).
+This option is on by default with a value of 20000. To disable, pass with a
+value of 0.
 
 =item --output-split-cfuncs I<statements>
 
@@ -1144,10 +1142,14 @@ worse with decreasing split values.  Note that this option is stronger than
 --output-split in the sense that --output-split will not split inside a
 function.
 
+Defaults to the value of --output-split, unless explicitly specified.
+
 =item --output-split-ctrace I<statements>
 
-Enables splitting trace functions in the output .cpp files into
-multiple functions.  Defaults to same setting as --output-split-cfuncs.
+Similar to --output-split-cfuncs, enables splitting trace functions in the
+output .cpp files into multiple functions.
+
+Defaults to the value of --output-split, unless explicitly specified.
 
 =item -P
 
@@ -2085,16 +2087,17 @@ line to make:
 
     make OPT_FAST="-Os -march=native -fno-stack-protector" -f Vour.mk Vour__ALL.a
 
-OPT_FAST specifies optimizations for those programs that are part of the
-fast path, mostly code that is executed every cycle.  OPT_SLOW specifies
-optimizations for slow-path files (plus tracing), which execute only
-rarely, yet take a long time to compile with optimization on.  OPT
-specifies overall optimization and affects all compiles, including those
-OPT_FAST and OPT_SLOW control.  For best results, use OPT="-Os
--march=native", and link with "-static".  Nearly the same results can be
-had with much better compile times with OPT_FAST="-O1 -fstrict-aliasing".
-Higher optimization such as "-O2" or "-O3" may help, but gcc compile times
-may be excessive under O3 on even medium sized designs.
+OPT_FAST specifies optimizations for those parts of the program that are on the
+fast path. This is mostly code that is executed every cycle.  OPT_SLOW
+specifies optimizations for slow-path files, which execute only rarely, yet
+take a long time to compile with optimization on.  OPT_SLOW is ignored if
+VM_PARALLEL_BUILDS is not 1, in which case all code is compliled with OPT_FAST.
+See also the C<--output-split> option.  OPT specifies overall optimization and
+affects all compiles, including those OPT_FAST and OPT_SLOW control.  For best
+results, use OPT="-Os -march=native", and link with "-static".  Nearly the same
+results can be had with much better compile times with OPT_FAST="-O1
+-fstrict-aliasing".  Higher optimization such as "-O2" or "-O3" may help, but
+gcc compile times may be excessive under O3 on even medium sized designs.
 
 Unfortunately, using the optimizer with SystemC files can result in
 compiles taking several minutes.  (The SystemC libraries have many little
@@ -5215,7 +5218,12 @@ test_regress/t/t_extend_class files show an example of how to do this.
 =item How do I get faster build times?
 
 When running make pass the make variable VM_PARALLEL_BUILDS=1 so that
-builds occur in parallel.
+builds occur in parallel. Note this is now set by default if the output
+code size exceeds the value of --output-split.
+
+Verilator emits any infrequently executed "cold" routines into separate
+__Slow.cpp files. This can accelerate compilation as optimization can be
+disabled on these routines. See the OPT_FAST and OPT_SLOW make variables.
 
 Use a recent compiler.  Newer compilers tend do be faster, with the
 now relatively old GCC 3.0 to 3.3 being horrible.

--- a/include/verilated.mk.in
+++ b/include/verilated.mk.in
@@ -94,12 +94,6 @@ LDLIBS   += $(VM_USER_LDLIBS)
 #OPT_FAST =
 
 #######################################################################
-##### Aggregates
-
-VM_CLASSES += $(VM_CLASSES_FAST) $(VM_CLASSES_SLOW)
-VM_SUPPORT += $(VM_SUPPORT_FAST) $(VM_SUPPORT_SLOW)
-
-#######################################################################
 ##### SystemC builds
 
 ifeq ($(VM_SC),1)
@@ -163,35 +157,36 @@ ifneq ($(VK_LIBS_THREADED),0)
 endif
 
 #######################################################################
-##### Stub
+### Aggregates
 
-preproc:
+VM_FAST += $(VM_CLASSES_FAST) $(VM_SUPPORT_FAST)
+VM_SLOW += $(VM_CLASSES_SLOW) $(VM_SUPPORT_SLOW)
 
 #######################################################################
-# Overall Objects Linking
+### Overall Objects Linking
 
-VK_CLASSES_FAST_CPP = $(addsuffix .cpp, $(VM_CLASSES_FAST))
-VK_CLASSES_SLOW_CPP = $(addsuffix .cpp, $(VM_CLASSES_SLOW))
-
-VK_SUPPORT_FAST_CPP = $(addsuffix .cpp, $(VM_SUPPORT_FAST))
-VK_SUPPORT_SLOW_CPP = $(addsuffix .cpp, $(VM_SUPPORT_SLOW))
+VK_FAST_OBJS = $(addsuffix .o, $(VM_FAST))
+VK_SLOW_OBJS = $(addsuffix .o, $(VM_SLOW))
 
 VK_USER_OBJS   = $(addsuffix .o, $(VM_USER_CLASSES))
 
 VK_GLOBAL_OBJS = $(addsuffix .o, $(VM_GLOBAL_FAST) $(VM_GLOBAL_SLOW))
 
 ifneq ($(VM_PARALLEL_BUILDS),1)
-  # Fast building, all .cpp's in one fell swoop
-  # This saves about 5 sec per module, but can be slower if only a little changes
-  VK_OBJS += $(VM_PREFIX)__ALLfast.o   $(VM_PREFIX)__ALLslow.o
-  all_cpp:   $(VM_PREFIX)__ALLfast.cpp $(VM_PREFIX)__ALLslow.cpp
-  $(VM_PREFIX)__ALLfast.cpp: $(VK_CLASSES_FAST_CPP) $(VK_SUPPORT_FAST_CPP)
+  # Fast build for small designs: All .cpp files in one fell swoop. This
+  # saves total compute, but can be slower if only a little changes. It is
+  # also a lot slower for medium to large designs when the speed of the C
+  # compiler dominates, which in this mode is not parallelizable.
+
+  VK_OBJS += $(VM_PREFIX)__ALL.o
+  $(VM_PREFIX)__ALL.cpp: $(addsuffix .cpp, $(VM_FAST) $(VM_SLOW))
 	$(VERILATOR_INCLUDER) -DVL_INCLUDE_OPT=include $^ > $@
-  $(VM_PREFIX)__ALLslow.cpp: $(VK_CLASSES_SLOW_CPP) $(VK_SUPPORT_SLOW_CPP)
-	$(VERILATOR_INCLUDER) -DVL_INCLUDE_OPT=include $^ > $@
+  all_cpp: $(VM_PREFIX)__ALL.cpp
 else
-  #Slow way of building... Each .cpp file by itself
-  VK_OBJS += $(addsuffix .o, $(VM_CLASSES) $(VM_SUPPORT))
+  # Parallel build: Each .cpp file by itself. This can be somewhat slower for
+  # very small designs and examples, but is a lot faster for large designs.
+
+  VK_OBJS += $(VK_FAST_OBJS) $(VK_SLOW_OBJS)
 endif
 
 $(VM_PREFIX)__ALL.a: $(VK_OBJS)
@@ -202,19 +197,15 @@ $(VM_PREFIX)__ALL.a: $(VK_OBJS)
 ### Compile rules
 
 ifneq ($(VM_DEFAULT_RULES),0)
-$(VM_PREFIX)__ALLfast.o: $(VM_PREFIX)__ALLfast.cpp
+$(VM_PREFIX)__ALL.o: $(VM_PREFIX)__ALL.cpp
 	$(OBJCACHE) $(CXX) $(CXXFLAGS) $(CPPFLAGS) $(OPT_FAST) -c -o $@ $<
 
-$(VM_PREFIX)__ALLslow.o: $(VM_PREFIX)__ALLslow.cpp
-	$(OBJCACHE) $(CXX) $(CXXFLAGS) $(CPPFLAGS) $(OPT_SLOW) -c -o $@ $<
-
-# VM_GLOBAL_FAST files including verilated.o use this rule
+# Anything not in $(VK_SLOW_OBJS), including verilated.o use this rule
 %.o: %.cpp
 	$(OBJCACHE) $(CXX) $(CXXFLAGS) $(CPPFLAGS) $(OPT_FAST) -c -o $@ $<
 
-%__Slow.o: %__Slow.cpp
+$(VK_SLOW_OBJS): %.o: %.cpp
 	$(OBJCACHE) $(CXX) $(CXXFLAGS) $(CPPFLAGS) $(OPT_SLOW) -c -o $@ $<
-
 endif
 
 #Default rule embedded in make:

--- a/src/V3EmitC.cpp
+++ b/src/V3EmitC.cpp
@@ -3234,6 +3234,8 @@ void EmitCImp::emitImp(AstNodeModule* modp) {
 
 void EmitCImp::maybeSplit(AstNodeModule* fileModp) {
     if (splitNeeded()) {
+        // Splitting file, so using parallel build.
+        v3Global.useParallelBuild(true);
         // Close old file
         VL_DO_CLEAR(delete m_ofp, m_ofp = NULL);
         // Open a new file
@@ -3652,6 +3654,8 @@ class EmitCTrace : EmitCStmts {
             m_funcp = nodep;
 
             if (splitNeeded()) {
+                // Splitting file, so using parallel build.
+                v3Global.useParallelBuild(true);
                 // Close old file
                 VL_DO_CLEAR(delete m_ofp, m_ofp = NULL);
                 // Open a new file

--- a/src/V3EmitCSyms.cpp
+++ b/src/V3EmitCSyms.cpp
@@ -521,6 +521,9 @@ void EmitCSyms::checkSplit(bool usesVfinal) {
         return;
     }
 
+    // Splitting file, so using parallel build.
+    v3Global.useParallelBuild(true);
+
     m_numStmts = 0;
     string filename
         = v3Global.opt.makeDir() + "/" + symClassName() + "__" + cvtToStr(++m_funcNum) + ".cpp";

--- a/src/V3EmitMk.cpp
+++ b/src/V3EmitMk.cpp
@@ -57,7 +57,7 @@ public:
         of.puts("\n");
         of.puts("# Parallel builds?  0/1 (from --output-split)\n");
         of.puts("VM_PARALLEL_BUILDS = ");
-        of.puts(v3Global.opt.outputSplit() ? "1" : "0");
+        of.puts(v3Global.useParallelBuild() ? "1" : "0");
         of.puts("\n");
         of.puts("# Threaded output mode?  0/1/N threads (from --threads)\n");
         of.puts("VM_THREADS = ");

--- a/src/V3Global.h
+++ b/src/V3Global.h
@@ -77,6 +77,7 @@ class V3Global {
     bool m_needHeavy;  // Need verilated_heavy.h include
     bool m_needTraceDumper;  // Need __Vm_dumperp in symbols
     bool m_dpi;  // Need __Dpi include files
+    bool m_useParallelBuild;  // Use parallel build for model
 
 public:
     // Options
@@ -93,7 +94,8 @@ public:
         , m_needC11(false)
         , m_needHeavy(false)
         , m_needTraceDumper(false)
-        , m_dpi(false) {}
+        , m_dpi(false)
+        , m_useParallelBuild(false) {}
     AstNetlist* makeNetlist();
     void boot() {
         UASSERT(!m_rootp, "call once");
@@ -129,6 +131,8 @@ public:
     void needTraceDumper(bool flag) { m_needTraceDumper = flag; }
     bool dpi() const { return m_dpi; }
     void dpi(bool flag) { m_dpi = flag; }
+    void useParallelBuild(bool flag) { m_useParallelBuild = flag; }
+    bool useParallelBuild() const { return m_useParallelBuild; }
 };
 
 extern V3Global v3Global;

--- a/src/V3Options.cpp
+++ b/src/V3Options.cpp
@@ -640,6 +640,10 @@ void V3Options::notify() {
     // --trace-threads implies --threads 1 unless explicitly specified
     if (traceThreads() && !threads()) m_threads = 1;
 
+    // Default split limits if not specified
+    if (m_outputSplitCFuncs < 0) m_outputSplitCFuncs = m_outputSplit;
+    if (m_outputSplitCTrace < 0) m_outputSplitCTrace = m_outputSplit;
+
     if (v3Global.opt.main() && v3Global.opt.systemC()) {
         cmdfl->v3error("--main not usable with SystemC. Suggest see examples for sc_main().");
     }
@@ -1058,13 +1062,15 @@ void V3Options::parseOptsList(FileLine* fl, const string& optdir, int argc, char
             } else if (!strcmp(sw, "-output-split-cfuncs") && (i + 1) < argc) {
                 shift;
                 m_outputSplitCFuncs = atoi(argv[i]);
-                if (m_outputSplitCFuncs
-                    && (!m_outputSplitCTrace || m_outputSplitCTrace > m_outputSplitCFuncs)) {
-                    m_outputSplitCTrace = m_outputSplitCFuncs;
+                if (m_outputSplitCFuncs < 0) {
+                    fl->v3error("--output-split-cfuncs must be >= 0: " << argv[i]);
                 }
-            } else if (!strcmp(sw, "-output-split-ctrace")) {  // Undocumented optimization tweak
+            } else if (!strcmp(sw, "-output-split-ctrace")) {
                 shift;
                 m_outputSplitCTrace = atoi(argv[i]);
+                if (m_outputSplitCTrace < 0) {
+                    fl->v3error("--output-split-ctrace must be >= 0: " << argv[i]);
+                }
             } else if (!strcmp(sw, "-protect-lib") && (i + 1) < argc) {
                 shift;
                 m_protectLib = argv[i];
@@ -1605,9 +1611,9 @@ V3Options::V3Options() {
     m_inlineMult = 2000;
     m_maxNumWidth = 65536;
     m_moduleRecursion = 100;
-    m_outputSplit = 0;
-    m_outputSplitCFuncs = 0;
-    m_outputSplitCTrace = 0;
+    m_outputSplit = 20000;
+    m_outputSplitCFuncs = -1;
+    m_outputSplitCTrace = -1;
     m_traceDepth = 0;
     m_traceMaxArray = 32;
     m_traceMaxWidth = 256;

--- a/test_regress/driver.pl
+++ b/test_regress/driver.pl
@@ -1416,6 +1416,15 @@ sub have_sc {
     return 0;
 }
 
+sub make_version {
+    my $ver = `make --version`;
+    if ($ver =~ /make ([0-9]+\.[0-9]+)/i) {
+        return $1;
+    } else {
+        return -1;
+    }
+}
+
 sub have_cmake {
     return cmake_version() >= version->declare("3.8");
 }

--- a/test_regress/t/t_flag_csplit.pl
+++ b/test_regress/t/t_flag_csplit.pl
@@ -111,7 +111,7 @@ sub check_gcc_flags {
         chomp $line;
         print ":log: $line\n" if $Self->{verbose};
         if ($line =~ /\.cpp/) {
-            my $filetype = ($line =~ /Slow/) ? "slow":"fast";
+            my $filetype = ($line =~ /Slow|Syms/) ? "slow":"fast";
             my $opt = ($line !~ /-O2/) ? "slow":"fast";
             print "$filetype, $opt, $line\n" if $Self->{verbose};
             if ($filetype ne $opt) {

--- a/test_regress/t/t_flag_xinitial_0.pl
+++ b/test_regress/t/t_flag_xinitial_0.pl
@@ -18,7 +18,7 @@ execute(
     check_finished => 1,
     );
 
-file_grep_not("$Self->{obj_dir}/$Self->{VM_PREFIX}.cpp", qr/VL_RAND_RESET/);
+file_grep_not("$Self->{obj_dir}/$Self->{VM_PREFIX}__Slow.cpp", qr/VL_RAND_RESET/);
 
 ok(1);
 1;

--- a/test_regress/t/t_flag_xinitial_unique.pl
+++ b/test_regress/t/t_flag_xinitial_unique.pl
@@ -18,7 +18,7 @@ execute(
     check_finished => 1,
     );
 
-file_grep("$Self->{obj_dir}/$Self->{VM_PREFIX}.cpp", qr/VL_RAND_RESET/);
+file_grep("$Self->{obj_dir}/$Self->{VM_PREFIX}__Slow.cpp", qr/VL_RAND_RESET/);
 
 ok(1);
 1;

--- a/test_regress/t/t_foreach.pl
+++ b/test_regress/t/t_foreach.pl
@@ -21,11 +21,13 @@ execute(
 # We expect all loops should be unrolled by verilator,
 # none of the loop variables should exist in the output:
 file_grep_not("$Self->{obj_dir}/$Self->{VM_PREFIX}.cpp", qr/index_/);
+file_grep_not("$Self->{obj_dir}/$Self->{VM_PREFIX}__Slow.cpp", qr/index_/);
 
 # Further, we expect that all logic within the loop should
 # have been evaluated inside the compiler. So there should be
 # no references to 'sum' in the .cpp.
 file_grep_not("$Self->{obj_dir}/$Self->{VM_PREFIX}.cpp", qr/sum/);
+file_grep_not("$Self->{obj_dir}/$Self->{VM_PREFIX}__Slow.cpp", qr/sum/);
 
 ok(1);
 1;

--- a/test_regress/t/t_optm_if_array.pl
+++ b/test_regress/t/t_optm_if_array.pl
@@ -18,6 +18,7 @@ execute(
     );
 
 file_grep_not("$Self->{obj_dir}/$Self->{VM_PREFIX}.cpp", qr/rstn_r/);
+file_grep_not("$Self->{obj_dir}/$Self->{VM_PREFIX}__Slow.cpp", qr/rstn_r/);
 
 ok(1);
 1;

--- a/test_regress/t/t_optm_redor.pl
+++ b/test_regress/t/t_optm_redor.pl
@@ -18,6 +18,7 @@ execute(
     );
 
 file_grep_not("$Self->{obj_dir}/$Self->{VM_PREFIX}.cpp", qr/rstn_r/);
+file_grep_not("$Self->{obj_dir}/$Self->{VM_PREFIX}__Slow.cpp", qr/rstn_r/);
 
 ok(1);
 1;

--- a/test_regress/t/t_protect_ids_key.out
+++ b/test_regress/t/t_protect_ids_key.out
@@ -22,6 +22,7 @@
   <map from="PSEGxK" to="__Vscope_t__secret_inst"/>
   <map from="PS25fg" to="__Vtask_dpix_a_task__1__i"/>
   <map from="PSHuZZ" to="_change_request"/>
+  <map from="PS75kd" to="_change_request_1"/>
   <map from="PSyTg5" to="_ctor_var_reset"/>
   <map from="PS8lsQ" to="_eval"/>
   <map from="PSKZ7c" to="_eval_debug_assertions"/>

--- a/test_regress/t/t_trace_two_cc.cpp
+++ b/test_regress/t/t_trace_two_cc.cpp
@@ -20,6 +20,7 @@
 
 // Compile in place
 #include "Vt_trace_two_b.cpp"
+#include "Vt_trace_two_b__Slow.cpp"
 #include "Vt_trace_two_b__Syms.cpp"
 #include "Vt_trace_two_b__Trace.cpp"
 #include "Vt_trace_two_b__Trace__Slow.cpp"

--- a/test_regress/t/t_trace_two_sc.cpp
+++ b/test_regress/t/t_trace_two_sc.cpp
@@ -16,6 +16,7 @@
 
 // Compile in place
 #include "Vt_trace_two_b.cpp"
+#include "Vt_trace_two_b__Slow.cpp"
 #include "Vt_trace_two_b__Syms.cpp"
 #include "Vt_trace_two_b__Trace.cpp"
 #include "Vt_trace_two_b__Trace__Slow.cpp"

--- a/test_regress/t/t_unopt_converge_initial_run_bad.pl
+++ b/test_regress/t/t_unopt_converge_initial_run_bad.pl
@@ -13,7 +13,7 @@ scenarios(simulator => 1);
 top_filename("t/t_unopt_converge_initial.v");
 
 compile(
-    v_flags2 => ['+define+ALLOW_UNOPT'],
+    v_flags2 => ['+define+ALLOW_UNOPT --output-split 0'],
     );
 
 execute(

--- a/test_regress/t/t_unopt_converge_print_bad.pl
+++ b/test_regress/t/t_unopt_converge_print_bad.pl
@@ -14,7 +14,7 @@ top_filename("t/t_unopt_converge.v");
 #$Self->{verilated_debug} = 1;
 
 compile(
-    v_flags2 => ['+define+ALLOW_UNOPT'],
+    v_flags2 => ['+define+ALLOW_UNOPT --output-split 0'],
     make_flags => 'CPPFLAGS_ADD=-DVL_DEBUG',
     );
 

--- a/test_regress/t/t_unopt_converge_run_bad.pl
+++ b/test_regress/t/t_unopt_converge_run_bad.pl
@@ -13,7 +13,7 @@ scenarios(simulator => 1);
 top_filename("t/t_unopt_converge.v");
 
 compile(
-    v_flags2 => ['+define+ALLOW_UNOPT'],
+    v_flags2 => ['+define+ALLOW_UNOPT --output-split 0'],
     );
 
 execute(

--- a/test_regress/t/t_verilated_debug.out
+++ b/test_regress/t/t_verilated_debug.out
@@ -11,9 +11,11 @@ internalsDump:
 -V{t#,#}+    Vt_verilated_debug::_eval_settle
 -V{t#,#}+    Vt_verilated_debug::_eval
 -V{t#,#}+    Vt_verilated_debug::_change_request
+-V{t#,#}+    Vt_verilated_debug::_change_request_1
 -V{t#,#}+ Clock loop
 -V{t#,#}+    Vt_verilated_debug::_eval
 -V{t#,#}+    Vt_verilated_debug::_change_request
+-V{t#,#}+    Vt_verilated_debug::_change_request_1
 -V{t#,#}+++++TOP Evaluate Vt_verilated_debug::eval
 -V{t#,#}+    Vt_verilated_debug::_eval_debug_assertions
 -V{t#,#}+ Clock loop
@@ -21,4 +23,5 @@ internalsDump:
 -V{t#,#}+    Vt_verilated_debug::_sequent__TOP__1
 *-* All Finished *-*
 -V{t#,#}+    Vt_verilated_debug::_change_request
+-V{t#,#}+    Vt_verilated_debug::_change_request_1
 -V{t#,#}+    Vt_verilated_debug::final


### PR DESCRIPTION
Still WIP due to the issues below, but this is the baseline for #2360 and also implements some of #2247. It works fine for the test suite  but a couple of issues remain for EH1/EH2:

- My recent changes to how trace routines are built means that without  `--output-split-ctrace` there is one huge trace function which remains the long pole in the build time. A similar issue remains for EH2, where there is a single sequent block that is 77k lines long and remains the long pole (and it is a very long pole). 

Question: How would you feel about defaulting `--output-split-cfuncs` and `--output-split-ctrace` to the value of `--output-split`, or some multiple thereof? Without something like that,  this PR has less then hoped for benefit for big builds.

- I think default 10000 is probably too small. It yields about 3000-4000 line files. I will investigate a bit later, but SweRV EH2 will have 40+ files (assuming we do the split-cfuncs above) which I feel might be too much, though on a modern servwer you can easily get 40+ cores to compiles it alli one go. Let me know if you have an oppinion on this.

- EH1 baseline speed is 9% slower with this patch (clang 10). This is completely unexpected, but I have seen similar amount of slowdown from trivial code changes I made perviously, so I think this is hitting some behaviour threshold possibly around inlining in clang. I know for a fact tha `_eval` in EH1 has a lot more branches with smaller sub-functions than EH2, and EH2 speed is the same.

Question: Would you be happy to commit this with the performance regression, while raising a new issue to investigate why output split slows down EH1? Otherwise will have to dig into that right now which might take a while to resolve.
