### PR TITLE
OpenBSD: Use $MAKE in tests.

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -35,6 +35,7 @@ Maarten De Braekeleer
 Maciej Sobkowski
 Marco Widmer
 Matthew Ballance
+Michael Killough
 Mike Popoloski
 Nathan Kohagen
 Nathan Myers

--- a/test_regress/driver.pl
+++ b/test_regress/driver.pl
@@ -9,6 +9,7 @@ BEGIN {
     if (!$ENV{VERILATOR_ROOT} && -x "../bin/verilator") {
         $ENV{VERILATOR_ROOT} = Cwd::getcwd()."/..";
     }
+    $ENV{MAKE} ||= "make"
 }
 
 use Getopt::Long;
@@ -373,7 +374,7 @@ sub one_test {
              } else {
                  $test->oprint("FAILED: $test->{errors}\n");
                  my $j = ($opt_jobs>1?" -j":"");
-                 my $makecmd = $ENV{VERILATOR_MAKE} || "make$j &&";
+                 my $makecmd = $ENV{VERILATOR_MAKE} || "$ENV{MAKE}$j &&";
                  my $upperdir = (Cwd::getcwd() =~ /test_regress/
                                  ? 'test_regress/' : '');
                  push @{$self->{fail_msgs}},
@@ -1127,7 +1128,7 @@ sub compile {
             $self->oprint("Running make (gmake)\n") if $self->{verbose};
             $self->_run(logfile => "$self->{obj_dir}/vlt_gcc.log",
                         entering => "$self->{obj_dir}",
-                        cmd => ["make",
+                        cmd => [$ENV{MAKE},
                                 "-C ".$self->{obj_dir},
                                 "-f ".$::RealBin."/Makefile_obj",
                                 ($self->{verbose} ? "" : "--no-print-directory"),
@@ -1425,7 +1426,7 @@ sub have_sc {
 }
 
 sub make_version {
-    my $ver = `make --version`;
+    my $ver = `$ENV{MAKE} --version`;
     if ($ver =~ /make ([0-9]+\.[0-9]+)/i) {
         return $1;
     } else {
@@ -2231,13 +2232,13 @@ sub _vcd_read {
 
 our $_Cxx_Version;
 sub cxx_version {
-    $_Cxx_Version ||= `make -C $ENV{VERILATOR_ROOT}/test_regress -f Makefile print-cxx-version`;
+    $_Cxx_Version ||= `$ENV{MAKE} -C $ENV{VERILATOR_ROOT}/test_regress -f Makefile print-cxx-version`;
     return $_Cxx_Version;
 }
 
 our $_Cfg_With_Threaded;
 sub cfg_with_threaded {
-    $_Cfg_With_Threaded ||= `make -C $ENV{VERILATOR_ROOT} -f Makefile print-cfg-with-threaded`;
+    $_Cfg_With_Threaded ||= `$ENV{MAKE} -C $ENV{VERILATOR_ROOT} -f Makefile print-cfg-with-threaded`;
     return ($_Cfg_With_Threaded =~ /yes/i) ? 1:0;
 }
 

--- a/test_regress/t/t_a4_examples.pl
+++ b/test_regress/t/t_a4_examples.pl
@@ -14,7 +14,7 @@ $Self->{clean_command} = 'rm -rf ../examples/*/build ../examples/*/obj*';
 
 my @examples = sort(glob("../examples/*"));
 for my $example (@examples) {
-    run(cmd=>["make -C $example"]);
+    run(cmd=>["$ENV{MAKE} -C $example"]);
 }
 
 ok(1);

--- a/test_regress/t/t_dist_install.pl
+++ b/test_regress/t/t_dist_install.pl
@@ -25,7 +25,7 @@ if (!-r "$root/.git") {
         check_finished => 0);
     # Install into temp area
     print "Install...\n";
-    run(cmd => ["cd $root && make DESTDIR=$destdir install-all"],
+    run(cmd => ["cd $root && $ENV{MAKE} DESTDIR=$destdir install-all"],
         check_finished => 0);
 
     # Check we can run a test
@@ -35,7 +35,7 @@ if (!-r "$root/.git") {
 
     # Uninstall
     print "Uninstall...\n";
-    run(cmd => ["cd $root && make DESTDIR=$destdir uninstall"],
+    run(cmd => ["cd $root && $ENV{MAKE} DESTDIR=$destdir uninstall"],
         check_finished => 0);
 
     # Check empty

--- a/test_regress/t/t_dist_manifest.pl
+++ b/test_regress/t/t_dist_manifest.pl
@@ -83,8 +83,8 @@ ok(1);
 
 sub get_manifest_files {
     my $root = shift;
-    `cd $root && make dist-file-list`;
-    my $manifest_files = `cd $root && make dist-file-list`;
+    `cd $root && $ENV{MAKE} dist-file-list`;
+    my $manifest_files = `cd $root && $ENV{MAKE} dist-file-list`;
     $manifest_files =~ s!.*begin-dist-file-list:!!sg;
     $manifest_files =~ s!end-dist-file-list:.*$!!sg;
     print "MF $manifest_files\n" if $Self->{verbose};

--- a/test_regress/t/t_dist_whitespace.pl
+++ b/test_regress/t/t_dist_whitespace.pl
@@ -80,8 +80,8 @@ ok(1);
 
 sub get_manifest_files {
     my $root = shift;
-    `cd $root && make dist-file-list`;
-    my $manifest_files = `cd $root && make dist-file-list`;
+    `cd $root && $ENV{MAKE} dist-file-list`;
+    my $manifest_files = `cd $root && $ENV{MAKE} dist-file-list`;
     $manifest_files =~ s!.*begin-dist-file-list:!!sg;
     $manifest_files =~ s!end-dist-file-list:.*$!!sg;
     print "MF $manifest_files\n" if $Self->{verbose};

--- a/test_regress/t/t_embed1.pl
+++ b/test_regress/t/t_embed1.pl
@@ -29,7 +29,7 @@ mkdir $child_dir;
 
     run(logfile => "${child_dir}/vlt_gcc.log",
         cmd => ["cd ${child_dir} && ",
-                "make", "-f".getcwd()."/Makefile_obj",
+                $ENV{MAKE}, "-f".getcwd()."/Makefile_obj",
                 "CPPFLAGS_DRIVER=-D".uc($self->{name}),
                 ($opt_verbose ? "CPPFLAGS_DRIVER2=-DTEST_VERBOSE=1":""),
                 "VM_PREFIX=$self->{VM_PREFIX}_child",

--- a/test_regress/t/t_flag_csplit.pl
+++ b/test_regress/t/t_flag_csplit.pl
@@ -28,7 +28,7 @@ while (1) {
     # properly build
     run(logfile => "$Self->{obj_dir}/vlt_gcc.log",
         tee => $self->{verbose},
-        cmd=>["make",
+        cmd=>[$ENV{MAKE},
               "-C ".$Self->{obj_dir},
               "-f $Self->{VM_PREFIX}.mk",
               "-j 4",

--- a/test_regress/t/t_flag_csplit_off.pl
+++ b/test_regress/t/t_flag_csplit_off.pl
@@ -30,7 +30,7 @@ while (1) {
     # properly build
     run(logfile => "$Self->{obj_dir}/vlt_gcc.log",
         tee => $self->{verbose},
-        cmd=>["make",
+        cmd=>[$ENV{MAKE},
               "-C ".$Self->{obj_dir},
               "-f $Self->{VM_PREFIX}.mk",
               "-j 4",

--- a/test_regress/t/t_prot_lib.pl
+++ b/test_regress/t/t_prot_lib.pl
@@ -41,7 +41,7 @@ while (1) {
     last if $Self->{errors};
 
     run(logfile => "$secret_dir/secret_gcc.log",
-        cmd=>["make",
+        cmd=>[$ENV{MAKE},
               "-C",
               $secret_dir,
               "-f",

--- a/test_regress/t/t_prot_lib_clk_gated.pl
+++ b/test_regress/t/t_prot_lib_clk_gated.pl
@@ -43,7 +43,7 @@ while (1) {
     last if $Self->{errors};
 
     run(logfile => "$secret_dir/secret_gcc.log",
-        cmd=>["make",
+        cmd=>[$ENV{MAKE},
               "-C",
               $secret_dir,
               "-f",

--- a/test_regress/t/t_prot_lib_secret.pl
+++ b/test_regress/t/t_prot_lib_secret.pl
@@ -21,7 +21,7 @@ compile (
     make_top_shell => 0,
     );
 
-run(cmd=>["make",
+run(cmd=>[$ENV{MAKE},
           "-C",
           "$Self->{obj_dir}",
           "-f",


### PR DESCRIPTION
These are two small changes to allow building on OpenBSD:

 - `#include <sys/wait.h>` in order to use `WEXITSTATUS`. This include is necessary on OpenBSD and is unlikely to hurt on other platforms, although I have not tested.
 - Use `$MAKE` in the regression tests driver rather than hard-coding to `make`. This allows it to be overridden with `MAKE=gmake` on BSD. I wasn't sure whether this was correct, or whether I should be using `$VERILATOR_MAKE`, which is also referenenced in `driver.pl`. As far as I could tell, `$VERILATOR_MAKE` serves a different purpose.

These are in separate commits, in case you'd like them to be separated out into separate PRs. Please let me know.

I've added myself to `CONTRIBUTORS` as specified in the contribution guide, to certify my contribution is my own. 
