### PR TITLE
Add FreeBSD to Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,9 @@
 
 version: ~> 1.0
 
-os: linux
+os:
+  - linux
+  - freebsd
 language: cpp
 cache: ccache
 
@@ -25,15 +27,25 @@ cache:
     - $VERILATOR_CACHE
 
 before_install:
-# Perl modules needed for testing
-# Not listing Bit::Vector as slow to install, and only skips one test
-  - touch temp.cpp ; g++ -E -dM -c temp.cpp | sort ; rm -rf temp.cpp
-  - yes yes | sudo cpan -fi Unix::Processors Parallel::Forker
-  - sudo apt-get install gdb gtkwave lcov
-  - sudo apt-get install libfl-dev || true
-  - sudo apt-get install libgoogle-perftools-dev
-# Only works on 20.04
-  - sudo apt-get install libsystemc-dev || true
+  - |
+    if [ "$TRAVIS_OS_NAME" = "linux" ]; then
+      touch temp.cpp ; g++ -E -dM -c temp.cpp | sort ; rm -rf temp.cpp;
+      sudo apt-get install gdb gtkwave lcov;
+      sudo apt-get install libfl-dev || true;
+      sudo apt-get install libgoogle-perftools-dev;
+      # Only works on 20.04
+      sudo apt-get install libsystemc-dev || true;
+    fi
+  - |
+    if [ "$TRAVIS_OS_NAME" = "freebsd" ]; then
+      sudo pkg install -y autoconf bison ccache gmake perl5 python3;
+      sudo pkg install -y gdb gtkwave;
+      export MAKE=gmake;
+      export VERILATOR_NUM_JOBS=$(sysctl -n hw.ncpu);
+    fi
+  # Perl modules needed for testing
+  # Not listing Bit::Vector as slow to install, and only skips one test
+  - yes yes | sudo cpan -fi Unix::Processors Parallel::Forker;
 
 before_script:
   - bash -x ci/build_vcddiff.sh
@@ -54,11 +66,13 @@ jobs:
 #     16.04 dist: xenial   cron           cron
 #     18.04 dist: bionic   cron
 #     20.04 dist: focal    !cron          cron
+#     freebsd                             cron
 #     20.04 coverage       cron
   include:
     - if: type != cron
       stage: vbuild
       name: "Build Verilator"
+      os: linux
       dist: focal
       compiler: gcc
       script: echo "Done building Verilator"
@@ -66,47 +80,55 @@ jobs:
     - if: type != cron
       stage: test
       name: "Test Dist"
+      os: linux
       dist: focal
       compiler: gcc
       script: ci/test.sh dist
     - if: type != cron
       stage: test
       name: "Test Vlt"
+      os: linux
       dist: focal
       compiler: gcc
       script: ci/test.sh vlt
     - if: type != cron
       stage: test
       name: "Test Vltmt set 0"
+      os: linux
       dist: focal
       compiler: gcc
       script: ci/test.sh vltmt0
     - if: type != cron
       stage: test
       name: "Test Vltmt set 1"
+      os: linux
       dist: focal
       compiler: gcc
       script: ci/test.sh vltmt1
 # Cron builds try different OS/compiler combinations
     - if: type = cron
+      os: linux
       dist: trusty
       compiler: gcc
       stage: vbuild
       name: "14.04 gcc build"
       script: echo
     - if: type = cron
+      os: linux
       dist: trusty
       compiler: gcc
       stage: test
       name: "14.04 gcc distvlt"
       script: ci/test.sh distvlt
     - if: type = cron
+      os: linux
       dist: trusty
       compiler: gcc
       stage: test
       name: "14.04 gcc vltmt0"
       script: ci/test.sh vltmt0
     - if: type = cron
+      os: linux
       dist: trusty
       compiler: gcc
       stage: test
@@ -114,24 +136,28 @@ jobs:
       script: ci/test.sh vltmt1
 #
     - if: type = cron
+      os: linux
       dist: xenial
       compiler: gcc
       stage: vbuild
       name: "16.04 gcc build"
       script: echo
     - if: type = cron
+      os: linux
       dist: xenial
       compiler: gcc
       stage: test
       name: "16.04 gcc distvlt"
       script: ci/test.sh distvlt
     - if: type = cron
+      os: linux
       dist: xenial
       compiler: gcc
       stage: test
       name: "16.04 gcc vltmt0"
       script: ci/test.sh vltmt0
     - if: type = cron
+      os: linux
       dist: xenial
       compiler: gcc
       stage: test
@@ -139,24 +165,28 @@ jobs:
       script: ci/test.sh vltmt1
 #
     - if: type = cron
+      os: linux
       dist: bionic
       compiler: gcc
       stage: vbuild
       name: "18.04 gcc build"
       script: echo
     - if: type = cron
+      os: linux
       dist: bionic
       compiler: gcc
       stage: test
       name: "18.04 gcc distvlt"
       script: ci/test.sh distvlt
     - if: type = cron
+      os: linux
       dist: bionic
       compiler: gcc
       stage: test
       name: "18.04 gcc vltmt0"
       script: ci/test.sh vltmt0
     - if: type = cron
+      os: linux
       dist: bionic
       compiler: gcc
       stage: test
@@ -164,24 +194,28 @@ jobs:
       script: ci/test.sh vltmt1
 #
     - if: type = cron
+      os: linux
       dist: xenial
       compiler: clang
       stage: vbuild
       name: "16.04 clang build"
       script: echo
     - if: type = cron
+      os: linux
       dist: xenial
       compiler: clang
       stage: test
       name: "16.04 clang distvlt"
       script: ci/test.sh distvlt
     - if: type = cron
+      os: linux
       dist: xenial
       compiler: clang
       stage: test
       name: "16.04 clang vltmt0"
       script: ci/test.sh vltmt0
     - if: type = cron
+      os: linux
       dist: xenial
       compiler: clang
       stage: test
@@ -189,29 +223,40 @@ jobs:
       script: ci/test.sh vltmt1
 #
     - if: type = cron
+      os: linux
       dist: focal
       compiler: clang
       stage: vbuild
       name: "20.04 clang build"
       script: echo
     - if: type = cron
+      os: linux
       dist: focal
       compiler: clang
       stage: test
       name: "20.04 clang distvlt"
       script: ci/test.sh distvlt
     - if: type = cron
+      os: linux
       dist: focal
       compiler: clang
       stage: test
       name: "20.04 clang vltmt0"
       script: ci/test.sh vltmt0
     - if: type = cron
+      os: linux
       dist: focal
       compiler: clang
       stage: test
       name: "20.04 clang vltmt1"
       script: ci/test.sh vltmt1
+#
+    - if: type != cron
+      os: freebsd
+      compiler: clang
+      stage: vbuild
+      name: "freebsd clang build and examples"
+      script: gmake examples
 #
 # Cron coverage runs (two parts to avoid 50min timeout)
     - if: type = cron

--- a/ci/build_vcddiff.sh
+++ b/ci/build_vcddiff.sh
@@ -8,6 +8,10 @@
 # SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
 set -e
 
+if [ -z "${MAKE}" ]; then
+    MAKE=make
+fi
+
 # NB: it would be better to add this via a PPA
 
 TMP_DIR=$(mktemp -d)
@@ -15,5 +19,5 @@ TMP_DIR=$(mktemp -d)
 git -C "${TMP_DIR}" clone https://github.com/veripool/vcddiff
 VCDDIFF_DIR=${TMP_DIR}/vcddiff
 git -C "${VCDDIFF_DIR}" checkout 5112f88b7ba8818dce9dfb72619e64a1fc19542c
-make -C "${VCDDIFF_DIR}"
+${MAKE} -C "${VCDDIFF_DIR}"
 sudo cp "${VCDDIFF_DIR}/vcddiff" /usr/local/bin

--- a/ci/build_verilator.sh
+++ b/ci/build_verilator.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # DESCRIPTION: Verilator: Travis CI build script
 #
 # Copyright 2019 by Todd Strader. This program is free software; you
@@ -19,6 +19,10 @@ set -e
 
 if [ -z "${VERILATOR_NUM_JOBS}" ]; then
     VERILATOR_NUM_JOBS=$(nproc)
+fi
+
+if [ -z "${MAKE}" ]; then
+    MAKE=make
 fi
 
 # Caching would be simpler if we installed without VERILATOR_ROOT, but
@@ -49,7 +53,7 @@ if [[ ! -f "${CACHED_REV_FILE}" || \
     fi
 
     cd "${VERILATOR_ROOT}"
-    autoconf && ./configure ${VERILATOR_CONFIG_FLAGS} && make -j ${VERILATOR_NUM_JOBS}
+    autoconf && ./configure ${VERILATOR_CONFIG_FLAGS} && ${MAKE} -j ${VERILATOR_NUM_JOBS}
     # Copy the Verilator build artifacts
     mkdir -p "${VERILATOR_CACHE}"
     rm -rf ${VERILATOR_CACHE}/*

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # DESCRIPTION: Verilator: Travis CI test script
 #
 # Copyright 2019 by Todd Strader. This program is free software; you
@@ -9,26 +9,30 @@
 
 set -e
 
+if [ -z "${MAKE}" ]; then
+    MAKE=make
+fi
+
 export DRIVER_FLAGS='-j 0 --quiet --rerun'
 
 case $1 in
     dist)
-        make -C test_regress SCENARIOS=--dist
+        ${MAKE} -C test_regress SCENARIOS=--dist
         ;;
     vlt)
-        make -C test_regress SCENARIOS=--vlt
+        ${MAKE} -C test_regress SCENARIOS=--vlt
         ;;
     distvlt)
-        make -C test_regress SCENARIOS="--dist --vlt"
+        ${MAKE} -C test_regress SCENARIOS="--dist --vlt"
         ;;
     vltmt)
-        make -C test_regress SCENARIOS=--vltmt
+        ${MAKE} -C test_regress SCENARIOS=--vltmt
         ;;
     vltmt0)
-        make -C test_regress SCENARIOS=--vltmt DRIVER_HASHSET=--hashset=0/2
+        ${MAKE} -C test_regress SCENARIOS=--vltmt DRIVER_HASHSET=--hashset=0/2
         ;;
     vltmt1)
-        make -C test_regress SCENARIOS=--vltmt DRIVER_HASHSET=--hashset=1/2
+        ${MAKE} -C test_regress SCENARIOS=--vltmt DRIVER_HASHSET=--hashset=1/2
         ;;
     coverage-build)
         nodist/code_coverage --stages 1-2


### PR DESCRIPTION
This adds FreeBSD to the Travis CI config. As `ccache` doesn't work for
FreeBSD on Travis at the moment, this just builds and runs `make
examples`, rather than running the full tests. (Hopefully fixing
travis-ci/casher#54 will enable `ccache` to work).

The CI shell scripts are updated with a portable shebang and to use the
`$MAKE` environment variable. The `ci/test.sh` script is updated for
consistency, even though it is not run on FreeBSD as part of this PR.

The FreeBSD job is added as `!= cron` in this commit, so we can see it
run as part of the PR's CI. Once it passes and we're happy, I can add a
subsequent commit to make it `= cron`.

Fixes #2390.