### PR TITLE
Implement vpi_handle type vpiLeftRange and vpiRightRange for vpiRange objects

### DIFF
--- a/include/verilated_vpi.cpp
+++ b/include/verilated_vpi.cpp
@@ -135,7 +135,7 @@ public:
     static inline VerilatedVpioConst* castp(vpiHandle h) {
         return dynamic_cast<VerilatedVpioConst*>(reinterpret_cast<VerilatedVpio*>(h));
     }
-    virtual vluint32_t type() const { return vpiUndefined; }
+    virtual vluint32_t type() const { return vpiConstant; }
     vlsint32_t num() const { return m_num; }
 };
 

--- a/include/verilated_vpi.cpp
+++ b/include/verilated_vpi.cpp
@@ -1134,16 +1134,28 @@ vpiHandle vpi_handle(PLI_INT32 type, vpiHandle object) {
     _VL_VPI_ERROR_RESET();
     switch (type) {
     case vpiLeftRange: {
-        VerilatedVpioVar* vop = VerilatedVpioVar::castp(object);
-        if (VL_UNLIKELY(!vop)) return 0;
-        if (VL_UNLIKELY(!vop->rangep())) return 0;
-        return (new VerilatedVpioConst(vop->rangep()->left()))->castVpiHandle();
+        if (VerilatedVpioVar* vop = VerilatedVpioVar::castp(object)) {
+            if (VL_UNLIKELY(!vop->rangep())) return 0;
+            return (new VerilatedVpioConst(vop->rangep()->left()))->castVpiHandle();
+        } else if (VerilatedVpioRange* vop = VerilatedVpioRange::castp(object)) {
+            if (VL_UNLIKELY(!vop->rangep())) return 0;
+            return (new VerilatedVpioConst(vop->rangep()->left()))->castVpiHandle();
+        }
+        _VL_VPI_WARNING(__FILE__, __LINE__, "%s: Unsupported vpiHandle (%p) for type %s, nothing will be returned",
+                        VL_FUNC, object, VerilatedVpiError::strFromVpiMethod(type));
+        return 0;
     }
     case vpiRightRange: {
-        VerilatedVpioVar* vop = VerilatedVpioVar::castp(object);
-        if (VL_UNLIKELY(!vop)) return 0;
-        if (VL_UNLIKELY(!vop->rangep())) return 0;
-        return (new VerilatedVpioConst(vop->rangep()->right()))->castVpiHandle();
+        if (VerilatedVpioVar* vop = VerilatedVpioVar::castp(object)) {
+            if (VL_UNLIKELY(!vop->rangep())) return 0;
+            return (new VerilatedVpioConst(vop->rangep()->right()))->castVpiHandle();
+        } else if (VerilatedVpioRange* vop = VerilatedVpioRange::castp(object)) {
+            if (VL_UNLIKELY(!vop->rangep())) return 0;
+            return (new VerilatedVpioConst(vop->rangep()->right()))->castVpiHandle();
+        }
+        _VL_VPI_WARNING(__FILE__, __LINE__, "%s: Unsupported vpiHandle (%p) for type %s, nothing will be returned",
+                        VL_FUNC, object, VerilatedVpiError::strFromVpiMethod(type));
+        return 0;
     }
     case vpiIndex: {
         VerilatedVpioVar* vop = VerilatedVpioVar::castp(object);

--- a/test_regress/t/t_vpi_memory.cpp
+++ b/test_regress/t/t_vpi_memory.cpp
@@ -87,9 +87,6 @@ int _mon_check_range(TestVpiHandle& handle, int size, int left, int right) {
     // check size of object
     int vpisize = vpi_get(vpiSize, handle);
     CHECK_RESULT(vpisize, size);
-    // check size of range
-    vpisize = vpi_get(vpiSize, handle);
-    CHECK_RESULT(vpisize, size);
     // check left hand side of range
     left_h = vpi_handle(vpiLeftRange, handle);
     CHECK_RESULT_NZ(left_h);
@@ -110,7 +107,7 @@ int _mon_check_range(TestVpiHandle& handle, int size, int left, int right) {
 
 int _mon_check_memory() {
     int cnt;
-    TestVpiHandle mem_h, lcl_h;
+    TestVpiHandle mem_h, lcl_h, side_h;
     vpiHandle iter_h;  // Icarus does not like auto free of iterator handles
     s_vpi_value value = {.format = vpiIntVal, .value = {.integer = 0}};
     vpi_printf((PLI_BYTE8*)"Check memory vpi ...\n");
@@ -158,6 +155,21 @@ int _mon_check_memory() {
     CHECK_RESULT(should_be_NULL, 0);
     should_be_NULL = vpi_handle(vpiScope, iter_h);
     CHECK_RESULT(should_be_NULL, 0);
+
+    // check vpiRange
+    iter_h = vpi_iterate(vpiRange, mem_h);
+    CHECK_RESULT_NZ(iter_h);
+    lcl_h = vpi_scan(iter_h);
+    CHECK_RESULT_NZ(lcl_h);
+    side_h = vpi_handle(vpiLeftRange, lcl_h);
+    CHECK_RESULT_NZ(side_h);
+    vpi_get_value(side_h, &value);
+    CHECK_RESULT(value.value.integer, 16);
+    side_h = vpi_handle(vpiRightRange, lcl_h);
+    CHECK_RESULT_NZ(side_h);
+    vpi_get_value(side_h, &value);
+    CHECK_RESULT(value.value.integer, 1);
+
     return 0;  // Ok
 }
 

--- a/test_regress/t/t_vpi_var.cpp
+++ b/test_regress/t/t_vpi_var.cpp
@@ -273,7 +273,7 @@ int _mon_check_var() {
         vpi_get_value(vh10, &tmpValue);
         CHECK_RESULT(tmpValue.value.integer, 4);
         p = vpi_get_str(vpiType, vh10);
-        CHECK_RESULT_CSTR(p, "*undefined*");
+        CHECK_RESULT_CSTR(p, "vpiConstant");
     }
     {
         TestVpiHandle vh10 = vpi_handle(vpiRightRange, vh4);
@@ -281,7 +281,7 @@ int _mon_check_var() {
         vpi_get_value(vh10, &tmpValue);
         CHECK_RESULT(tmpValue.value.integer, 3);
         p = vpi_get_str(vpiType, vh10);
-        CHECK_RESULT_CSTR(p, "*undefined*");
+        CHECK_RESULT_CSTR(p, "vpiConstant");
     }
     {
         TestVpiHandle vh10 = vpi_iterate(vpiMemoryWord, vh4);
@@ -297,13 +297,13 @@ int _mon_check_var() {
         vpi_get_value(vh12, &tmpValue);
         CHECK_RESULT(tmpValue.value.integer, 2);
         p = vpi_get_str(vpiType, vh12);
-        CHECK_RESULT_CSTR(p, "*undefined*");
+        CHECK_RESULT_CSTR(p, "vpiConstant");
         TestVpiHandle vh13 = vpi_handle(vpiRightRange, vh11);
         CHECK_RESULT_NZ(vh13);
         vpi_get_value(vh13, &tmpValue);
         CHECK_RESULT(tmpValue.value.integer, 1);
         p = vpi_get_str(vpiType, vh13);
-        CHECK_RESULT_CSTR(p, "*undefined*");
+        CHECK_RESULT_CSTR(p, "vpiConstant");
     }
 
     return 0;


### PR DESCRIPTION
This PR implements ```vpi_handle(vpiLeftRange, object)``` and  ```vpi_handle(vpiRightRange, object)``` for vpiRange object handles. 
Closes issues #2377  and #2105 .
Change VerilatedVpioConst type to 'vpiConstant', so that ```vpiType()``` of the resulting handle of ```vpi_handle(vpiLeftRange, object)``` will return 'vpiConstant' rather than 'undefined'.