### PR TITLE
Fix replaceMulShift optimization (#2413)

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -6,6 +6,7 @@ Please see the Verilator manual for 200+ additional contributors. Thanks to all.
 Ahmed El-Mahmoudy
 Alex Chadwick
 Chris Randall
+Conor McCullough
 Dan Petrisko
 David Horton
 David Stanford

--- a/src/V3Const.cpp
+++ b/src/V3Const.cpp
@@ -588,6 +588,9 @@ private:
         }
         return false;
     }
+    bool operandsSameSize(AstNode* lhsp, AstNode* rhsp) {
+        return lhsp->width() == rhsp->width();
+    }
 
     //----------------------------------------
     // Constant Replacement functions.
@@ -2322,7 +2325,7 @@ private:
     TREEOP ("AstMulS  {$lhsp.isOne, $rhsp}",    "replaceWRhs(nodep)");
     TREEOP ("AstDiv   {$lhsp, $rhsp.isOne}",    "replaceWLhs(nodep)");
     TREEOP ("AstDivS  {$lhsp, $rhsp.isOne}",    "replaceWLhs(nodep)");
-    TREEOP ("AstMul   {operandIsPowTwo($lhsp), $rhsp}", "replaceMulShift(nodep)");  // a*2^n -> a<<n
+    TREEOP ("AstMul   {operandIsPowTwo($lhsp), operandsSameSize($lhsp,,$rhsp)}", "replaceMulShift(nodep)");  // a*2^n -> a<<n
     TREEOP ("AstDiv   {$lhsp, operandIsPowTwo($rhsp)}", "replaceDivShift(nodep)");  // a/2^n -> a>>n
     TREEOP ("AstModDiv{$lhsp, operandIsPowTwo($rhsp)}", "replaceModAnd(nodep)");  // a % 2^n -> a&(2^n-1)
     TREEOP ("AstPow   {operandIsTwo($lhsp), $rhsp}",    "replacePowShift(nodep)");  // 2**a == 1<<a

--- a/test_regress/t/t_select_plus_mul_pow2.pl
+++ b/test_regress/t/t_select_plus_mul_pow2.pl
@@ -1,0 +1,21 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2019 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_select_plus_mul_pow2.v
+++ b/test_regress/t/t_select_plus_mul_pow2.v
@@ -1,0 +1,54 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2020 by Conor McCullough.
+// SPDX-License-Identifier: CC0-1.0
+
+module t (/*AUTOARG*/
+   // Inputs
+   clk
+   );
+
+   input clk;
+
+   reg [63:0] 		from = 64'h0706050403020100;
+   reg [7:0] 		to;
+   reg [2:0] 		bitn;
+   reg [7:0] cyc; initial cyc=0;
+
+   always @* begin
+      to = from[bitn * 8 +: 8];
+   end
+
+   always @ (posedge clk) begin
+      cyc <= cyc + 8'd1;
+      case (cyc)
+	8'd00: begin bitn<=3'd0; end
+	8'd01: begin bitn<=3'd1; end
+	8'd02: begin bitn<=3'd2; end
+	8'd03: begin bitn<=3'd3; end
+	8'd04: begin bitn<=3'd4; end
+	8'd05: begin bitn<=3'd5; end
+	8'd06: begin bitn<=3'd6; end
+	8'd07: begin bitn<=3'd7; end
+	8'd08: begin
+	   $write("*-* All Finished *-*\n");
+	   $finish;
+	end
+	default: ;
+      endcase
+      case (cyc)
+	8'd00: ;
+	8'd01: begin if (to !== 8'h00) $stop; end
+	8'd02: begin if (to !== 8'h01) $stop; end
+	8'd03: begin if (to !== 8'h02) $stop; end
+	8'd04: begin if (to !== 8'h03) $stop; end
+	8'd05: begin if (to !== 8'h04) $stop; end
+	8'd06: begin if (to !== 8'h05) $stop; end
+	8'd07: begin if (to !== 8'h06) $stop; end
+	8'd08: begin if (to !== 8'h07) $stop; end
+	default: $stop;
+      endcase
+   end
+
+endmodule


### PR DESCRIPTION
Added check that LHS and RHS have the same width before applying
replacement.