### PR TITLE
Disable argument template type deduction.

### DIFF
--- a/include/verilated_imp.h
+++ b/include/verilated_imp.h
@@ -487,8 +487,8 @@ public:  // But only for verilated*.cpp
         const VerilatedLockGuard lock(s_s.m_fdMutex);
         if (s_s.m_fdFree.empty()) {
             // Need to create more space in m_fdps and m_fdFree
-            const size_t start = std::max(31ul + 1ul + 3ul, s_s.m_fdps.size());
-            const size_t excess = 10;
+            const std::size_t start = std::max<std::size_t>(31 + 1 + 3, s_s.m_fdps.size());
+            const std::size_t excess = 10;
             s_s.m_fdps.resize(start + excess);
             std::fill(s_s.m_fdps.begin() + start, s_s.m_fdps.end(), (FILE*)0);
             s_s.m_fdFree.resize(excess);

--- a/include/verilated_imp.h
+++ b/include/verilated_imp.h
@@ -487,7 +487,7 @@ public:  // But only for verilated*.cpp
         const VerilatedLockGuard lock(s_s.m_fdMutex);
         if (s_s.m_fdFree.empty()) {
             // Need to create more space in m_fdps and m_fdFree
-            const std::size_t start = std::max<std::size_t>(31 + 1 + 3, s_s.m_fdps.size());
+            const std::size_t start = std::max<std::size_t>(31ul + 1ul + 3ul, s_s.m_fdps.size());
             const std::size_t excess = 10;
             s_s.m_fdps.resize(start + excess);
             std::fill(s_s.m_fdps.begin() + start, s_s.m_fdps.end(), (FILE*)0);


### PR DESCRIPTION
From issue #2421; test regression fails for architectures where std::vector<>::size_type is not 64b which was implicit in the code. Circumvent this problem by disabling template type deduction and instead forcing the type to be std::size_t. On the failing architectures, this would cause the return value from .size() to be promoted from an unsigned int (32b) to an unsigned long int (64b). I don't have the ability to reproduce the failure, but would hope this fix would be sufficient to correct the failing cases.