### PR TITLE
Factor out making a make cmd string in Verilator.cpp. 

### DIFF
--- a/src/Verilator.cpp
+++ b/src/Verilator.cpp
@@ -584,20 +584,15 @@ static void verilate(const string& argString) {
     FileLine::deleteAllRemaining();
 }
 
-static void execBuildJob() {
-    UASSERT(v3Global.opt.build(), "--build is not specified.");
-    UASSERT(v3Global.opt.gmake(), "--build requires GNU Make.");
-    UASSERT(!v3Global.opt.cmake(), "--build cannot use CMake.");
-    UINFO(1, "Start Build\n");
-
+static string buildMakeCmd(const string& makefile, const string& target) {
     const V3StringList& makeFlags = v3Global.opt.makeFlags();
     const int jobs = v3Global.opt.buildJobs();
     UASSERT(jobs >= 0, "-j option parser in V3Options.cpp filters out negative value");
 
-    std::stringstream cmd;
+    std::ostringstream cmd;
     cmd << v3Global.opt.getenvMAKE();
     cmd << " -C " << v3Global.opt.makeDir();
-    cmd << " -f " << v3Global.opt.prefix() << ".mk";
+    cmd << " -f " << makefile;
     if (jobs == 0) {
         cmd << " -j";
     } else if (jobs > 1) {
@@ -606,8 +601,18 @@ static void execBuildJob() {
     for (V3StringList::const_iterator it = makeFlags.begin(); it != makeFlags.end(); ++it) {
         cmd << ' ' << *it;
     }
+    if (!target.empty()) { cmd << ' ' << target; }
 
-    const std::string cmdStr = cmd.str();
+    return cmd.str();
+}
+
+static void execBuildJob() {
+    UASSERT(v3Global.opt.build(), "--build is not specified.");
+    UASSERT(v3Global.opt.gmake(), "--build requires GNU Make.");
+    UASSERT(!v3Global.opt.cmake(), "--build cannot use CMake.");
+    UINFO(1, "Start Build\n");
+
+    const string cmdStr = buildMakeCmd(v3Global.opt.prefix() + ".mk", "");
     const int exit_code = V3Os::system(cmdStr);
     if (exit_code != 0) {
         v3error(cmdStr << " exitted with " << exit_code << std::endl);


### PR DESCRIPTION
Extracted from PR #2206
No functional change intended.

Diff is slightly confusing, but this PR just factors out buildMakeCmd() from execBuildJob().
