### PR TITLE
use separate AST class for program

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -47,6 +47,7 @@ Peter Horvath
 Peter Monsson
 Philipp Wagner
 Pieter Kapsenberg
+Piotr Binkowski
 Qingyao Sun
 Richard Myers
 Sean Cross

--- a/src/V3AstNodes.h
+++ b/src/V3AstNodes.h
@@ -2436,6 +2436,15 @@ public:
     virtual string verilogKwd() const { return "module"; }
 };
 
+class AstProgram : public AstNodeModule {
+    // A program declaration
+public:
+    AstProgram(FileLine* fl, const string& name)
+        : ASTGEN_SUPER(fl, name) {}
+    ASTNODE_NODE_FUNCS(Program)
+    virtual string verilogKwd() const { return "program"; }
+};
+
 class AstNotFoundModule : public AstNodeModule {
     // A missing module declaration
 public:

--- a/src/verilog.y
+++ b/src/verilog.y
@@ -1473,7 +1473,7 @@ program_declaration:		// IEEE: program_declaration + program_nonansi_header + pr
 
 pgmFront<modulep>:
 		yPROGRAM lifetimeE idAny/*new_program*/
-			{ $$ = new AstModule($<fl>3,*$3);
+			{ $$ = new AstProgram($<fl>3,*$3);
 			  $$->lifetime($2);
 			  $$->inLibrary(PARSEP->inLibrary() || $$->fileline()->celldefineOn());
 			  $$->modTrace(GRAMMARP->allTracingOn($$->fileline()));


### PR DESCRIPTION
This PR aims to add a separate Ast class for the `program` construct, currently `program` blocks use `AstModule` which makes it impossible to distinguish them from `module` blocks and distinguishing between them is needed for #2464 