### PR TITLE
Add regression test for accessing array-ed interfaces declared with short nomenclature

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -25,6 +25,7 @@ Jan Van Winkel
 Jeremy Bennett
 John Coiner
 John Demme
+Josh Redford
 Julien Margetts
 Kanad Kanhere
 Kevin Kiningham

--- a/test_regress/t/t_interface_arraymux.v
+++ b/test_regress/t/t_interface_arraymux.v
@@ -39,6 +39,19 @@ module ThingMuxOH
     the_intf.t things_in [NTHINGS-1:0],
     the_intf.i thing_out
     );
+    assign thing_out.valid = things_in[0].valid;
+endmodule
+
+module ThingMuxShort
+  #(
+    parameter NTHINGS = 1,
+    parameter       M = 5 )
+   (
+    input logic [NTHINGS-1:0] select_oh,
+    the_intf.t things_in [NTHINGS],
+    the_intf.i thing_out
+    );
+    assign thing_out.valid = things_in[0].valid;
 endmodule
 
 module Thinker
@@ -55,8 +68,10 @@ module Thinker
 
    the_intf #(.M(M)) curr_things [N-1:0] ();
    the_intf #(.M(M)) prev_things [N-1:0] ();
+   the_intf #(.M(M)) s_things [N] ();
    the_intf #(.M(M)) curr_thing ();
    the_intf #(.M(M)) prev_thing ();
+   the_intf #(.M(M)) s_thing ();
 
    logic [N-1:0] select_oh;
 
@@ -77,6 +92,15 @@ module Thinker
     .select_oh( select_oh   ),
     .things_in( prev_things ),
     .thing_out( prev_thing  ));
+
+   // 3rd mux, using short array nomenclature:
+   ThingMuxShort #(
+    .NTHINGS  ( N           ),
+    .M        ( M           ))
+   s_thing_mux(
+    .select_oh( select_oh   ),
+    .things_in( s_things ),
+    .thing_out( s_thing  ));
 
 endmodule
 


### PR DESCRIPTION
#2468 

Add a regression test accessing members of an interface that uses the array method `my_if [N]`

This issue is reported:
`Member selection of non-struct/union object 'ARRAYSEL' which is a 'IFACEREFDTYPE'`

Array method `my_if[0:N-1]` still works as expected.

