### PR TITLE
Prevent V3Unknown from running with flat XML output

### DIFF
--- a/src/Verilator.cpp
+++ b/src/Verilator.cpp
@@ -193,12 +193,16 @@ static void process() {
         // Expand inouts, stage 2
         // Also simplify pin connections to always be AssignWs in prep for V3Unknown
         V3Tristate::tristateAll(v3Global.rootp());
+    }
 
+    if (!v3Global.opt.xmlOnly()) {
         // Move assignments from X into MODULE temps.
         // (Before flattening, so each new X variable is shared between all scopes of that module.)
         V3Unknown::unknownAll(v3Global.rootp());
         v3Global.constRemoveXs(true);
+    }
 
+    if (!(v3Global.opt.xmlOnly() && !v3Global.opt.flatten())) {
         // Module inlining
         // Cannot remove dead variables after this, as alias information for final
         // V3Scope's V3LinkDot is in the AstVar.

--- a/test_regress/t/t_xml_flat_vlvbound.out
+++ b/test_regress/t/t_xml_flat_vlvbound.out
@@ -11,221 +11,190 @@
     <file id="d" filename="t/t_xml_flat_vlvbound.v" language="1800-2017"/>
   </module_files>
   <cells>
-    <cell fl="d1" loc="d,1,8,1,21" name="TOP" submodname="TOP" hier="TOP"/>
+    <cell fl="d7" loc="d,7,8,7,21" name="TOP" submodname="TOP" hier="TOP"/>
   </cells>
   <netlist>
-    <module fl="d1" loc="d,1,8,1,21" name="TOP" origName="TOP" topModule="1" public="true">
-      <var fl="d3" loc="d,3,25,3,28" name="i_a" dtype_id="1" dir="input" vartype="logic" origName="i_a" public="true"/>
-      <var fl="d4" loc="d,4,25,4,28" name="i_b" dtype_id="1" dir="input" vartype="logic" origName="i_b" public="true"/>
-      <var fl="d5" loc="d,5,25,5,28" name="o_a" dtype_id="2" dir="output" vartype="logic" origName="o_a" public="true"/>
-      <var fl="d6" loc="d,6,25,6,28" name="o_b" dtype_id="2" dir="output" vartype="logic" origName="o_b" public="true"/>
-      <var fl="d3" loc="d,3,25,3,28" name="vlvbound_test.i_a" dtype_id="1" vartype="logic" origName="i_a"/>
-      <var fl="d4" loc="d,4,25,4,28" name="vlvbound_test.i_b" dtype_id="1" vartype="logic" origName="i_b"/>
-      <var fl="d5" loc="d,5,25,5,28" name="vlvbound_test.o_a" dtype_id="2" vartype="logic" origName="o_a"/>
-      <var fl="d6" loc="d,6,25,6,28" name="vlvbound_test.o_b" dtype_id="2" vartype="logic" origName="o_b"/>
-      <var fl="d13" loc="d,13,10,13,11" name="vlvbound_test.__Vlvbound1" dtype_id="3" vartype="logic" origName="__Vlvbound1"/>
-      <topscope fl="d1" loc="d,1,8,1,21">
-        <scope fl="d1" loc="d,1,8,1,21" name="TOP">
-          <varscope fl="d3" loc="d,3,25,3,28" name="i_a" dtype_id="1"/>
-          <varscope fl="d4" loc="d,4,25,4,28" name="i_b" dtype_id="1"/>
-          <varscope fl="d5" loc="d,5,25,5,28" name="o_a" dtype_id="2"/>
-          <varscope fl="d6" loc="d,6,25,6,28" name="o_b" dtype_id="2"/>
-          <varscope fl="d3" loc="d,3,25,3,28" name="vlvbound_test.i_a" dtype_id="1"/>
-          <varscope fl="d4" loc="d,4,25,4,28" name="vlvbound_test.i_b" dtype_id="1"/>
-          <varscope fl="d5" loc="d,5,25,5,28" name="vlvbound_test.o_a" dtype_id="2"/>
-          <varscope fl="d6" loc="d,6,25,6,28" name="vlvbound_test.o_b" dtype_id="2"/>
-          <varscope fl="d13" loc="d,13,10,13,11" name="vlvbound_test.__Vlvbound1" dtype_id="3"/>
-          <varscope fl="d9" loc="d,9,34,9,37" name="__Vfunc_vlvbound_test.foo__0__Vfuncout" dtype_id="2"/>
-          <varscope fl="d9" loc="d,9,57,9,60" name="__Vfunc_vlvbound_test.foo__0__val" dtype_id="1"/>
-          <varscope fl="d10" loc="d,10,17,10,20" name="__Vfunc_vlvbound_test.foo__0__ret" dtype_id="2"/>
-          <varscope fl="d11" loc="d,11,13,11,14" name="__Vfunc_vlvbound_test.foo__0__i" dtype_id="4"/>
-          <varscope fl="d9" loc="d,9,34,9,37" name="__Vfunc_vlvbound_test.foo__1__Vfuncout" dtype_id="2"/>
-          <varscope fl="d9" loc="d,9,57,9,60" name="__Vfunc_vlvbound_test.foo__1__val" dtype_id="1"/>
-          <varscope fl="d10" loc="d,10,17,10,20" name="__Vfunc_vlvbound_test.foo__1__ret" dtype_id="2"/>
-          <varscope fl="d11" loc="d,11,13,11,14" name="__Vfunc_vlvbound_test.foo__1__i" dtype_id="4"/>
-          <assignalias fl="d3" loc="d,3,25,3,28" dtype_id="1">
-            <varref fl="d3" loc="d,3,25,3,28" name="i_a" dtype_id="1"/>
-            <varref fl="d3" loc="d,3,25,3,28" name="i_a" dtype_id="1"/>
+    <module fl="d7" loc="d,7,8,7,21" name="TOP" origName="TOP" topModule="1" public="true">
+      <var fl="d9" loc="d,9,25,9,28" name="i_a" dtype_id="1" dir="input" vartype="logic" origName="i_a" public="true"/>
+      <var fl="d10" loc="d,10,25,10,28" name="i_b" dtype_id="1" dir="input" vartype="logic" origName="i_b" public="true"/>
+      <var fl="d11" loc="d,11,25,11,28" name="o_a" dtype_id="2" dir="output" vartype="logic" origName="o_a" public="true"/>
+      <var fl="d12" loc="d,12,25,12,28" name="o_b" dtype_id="2" dir="output" vartype="logic" origName="o_b" public="true"/>
+      <var fl="d9" loc="d,9,25,9,28" name="vlvbound_test.i_a" dtype_id="1" vartype="logic" origName="i_a"/>
+      <var fl="d10" loc="d,10,25,10,28" name="vlvbound_test.i_b" dtype_id="1" vartype="logic" origName="i_b"/>
+      <var fl="d11" loc="d,11,25,11,28" name="vlvbound_test.o_a" dtype_id="2" vartype="logic" origName="o_a"/>
+      <var fl="d12" loc="d,12,25,12,28" name="vlvbound_test.o_b" dtype_id="2" vartype="logic" origName="o_b"/>
+      <topscope fl="d7" loc="d,7,8,7,21">
+        <scope fl="d7" loc="d,7,8,7,21" name="TOP">
+          <varscope fl="d9" loc="d,9,25,9,28" name="i_a" dtype_id="1"/>
+          <varscope fl="d10" loc="d,10,25,10,28" name="i_b" dtype_id="1"/>
+          <varscope fl="d11" loc="d,11,25,11,28" name="o_a" dtype_id="2"/>
+          <varscope fl="d12" loc="d,12,25,12,28" name="o_b" dtype_id="2"/>
+          <varscope fl="d9" loc="d,9,25,9,28" name="vlvbound_test.i_a" dtype_id="1"/>
+          <varscope fl="d10" loc="d,10,25,10,28" name="vlvbound_test.i_b" dtype_id="1"/>
+          <varscope fl="d11" loc="d,11,25,11,28" name="vlvbound_test.o_a" dtype_id="2"/>
+          <varscope fl="d12" loc="d,12,25,12,28" name="vlvbound_test.o_b" dtype_id="2"/>
+          <varscope fl="d15" loc="d,15,34,15,37" name="__Vfunc_vlvbound_test.foo__0__Vfuncout" dtype_id="2"/>
+          <varscope fl="d15" loc="d,15,57,15,60" name="__Vfunc_vlvbound_test.foo__0__val" dtype_id="1"/>
+          <varscope fl="d16" loc="d,16,17,16,20" name="__Vfunc_vlvbound_test.foo__0__ret" dtype_id="2"/>
+          <varscope fl="d17" loc="d,17,13,17,14" name="__Vfunc_vlvbound_test.foo__0__i" dtype_id="3"/>
+          <varscope fl="d15" loc="d,15,34,15,37" name="__Vfunc_vlvbound_test.foo__1__Vfuncout" dtype_id="2"/>
+          <varscope fl="d15" loc="d,15,57,15,60" name="__Vfunc_vlvbound_test.foo__1__val" dtype_id="1"/>
+          <varscope fl="d16" loc="d,16,17,16,20" name="__Vfunc_vlvbound_test.foo__1__ret" dtype_id="2"/>
+          <varscope fl="d17" loc="d,17,13,17,14" name="__Vfunc_vlvbound_test.foo__1__i" dtype_id="3"/>
+          <assignalias fl="d9" loc="d,9,25,9,28" dtype_id="1">
+            <varref fl="d9" loc="d,9,25,9,28" name="i_a" dtype_id="1"/>
+            <varref fl="d9" loc="d,9,25,9,28" name="i_a" dtype_id="1"/>
           </assignalias>
-          <assignalias fl="d4" loc="d,4,25,4,28" dtype_id="1">
-            <varref fl="d4" loc="d,4,25,4,28" name="i_b" dtype_id="1"/>
-            <varref fl="d4" loc="d,4,25,4,28" name="i_b" dtype_id="1"/>
+          <assignalias fl="d10" loc="d,10,25,10,28" dtype_id="1">
+            <varref fl="d10" loc="d,10,25,10,28" name="i_b" dtype_id="1"/>
+            <varref fl="d10" loc="d,10,25,10,28" name="i_b" dtype_id="1"/>
           </assignalias>
-          <assignalias fl="d5" loc="d,5,25,5,28" dtype_id="2">
-            <varref fl="d5" loc="d,5,25,5,28" name="o_a" dtype_id="2"/>
-            <varref fl="d5" loc="d,5,25,5,28" name="o_a" dtype_id="2"/>
+          <assignalias fl="d11" loc="d,11,25,11,28" dtype_id="2">
+            <varref fl="d11" loc="d,11,25,11,28" name="o_a" dtype_id="2"/>
+            <varref fl="d11" loc="d,11,25,11,28" name="o_a" dtype_id="2"/>
           </assignalias>
-          <assignalias fl="d6" loc="d,6,25,6,28" dtype_id="2">
-            <varref fl="d6" loc="d,6,25,6,28" name="o_b" dtype_id="2"/>
-            <varref fl="d6" loc="d,6,25,6,28" name="o_b" dtype_id="2"/>
+          <assignalias fl="d12" loc="d,12,25,12,28" dtype_id="2">
+            <varref fl="d12" loc="d,12,25,12,28" name="o_b" dtype_id="2"/>
+            <varref fl="d12" loc="d,12,25,12,28" name="o_b" dtype_id="2"/>
           </assignalias>
-          <always fl="d18" loc="d,18,14,18,15">
-            <comment fl="d18" loc="d,18,16,18,19" name="Function: foo"/>
-            <assign fl="d18" loc="d,18,20,18,23" dtype_id="1">
-              <varref fl="d18" loc="d,18,20,18,23" name="i_a" dtype_id="1"/>
-              <varref fl="d9" loc="d,9,57,9,60" name="__Vfunc_vlvbound_test.foo__0__val" dtype_id="1"/>
+          <always fl="d24" loc="d,24,14,24,15">
+            <comment fl="d24" loc="d,24,16,24,19" name="Function: foo"/>
+            <assign fl="d24" loc="d,24,20,24,23" dtype_id="1">
+              <varref fl="d24" loc="d,24,20,24,23" name="i_a" dtype_id="1"/>
+              <varref fl="d15" loc="d,15,57,15,60" name="__Vfunc_vlvbound_test.foo__0__val" dtype_id="1"/>
             </assign>
-            <assign fl="d12" loc="d,12,11,12,12" dtype_id="4">
-              <const fl="d12" loc="d,12,12,12,13" name="32&apos;sh0" dtype_id="5"/>
-              <varref fl="d12" loc="d,12,10,12,11" name="__Vfunc_vlvbound_test.foo__0__i" dtype_id="4"/>
+            <assign fl="d18" loc="d,18,11,18,12" dtype_id="3">
+              <const fl="d18" loc="d,18,12,18,13" name="32&apos;sh0" dtype_id="4"/>
+              <varref fl="d18" loc="d,18,10,18,11" name="__Vfunc_vlvbound_test.foo__0__i" dtype_id="3"/>
             </assign>
-            <while fl="d12" loc="d,12,5,12,8">
-              <gts fl="d12" loc="d,12,18,12,19" dtype_id="6">
-                <const fl="d12" loc="d,12,20,12,21" name="32&apos;sh7" dtype_id="5"/>
-                <varref fl="d12" loc="d,12,16,12,17" name="__Vfunc_vlvbound_test.foo__0__i" dtype_id="4"/>
+            <while fl="d18" loc="d,18,5,18,8">
+              <gts fl="d18" loc="d,18,18,18,19" dtype_id="5">
+                <const fl="d18" loc="d,18,20,18,21" name="32&apos;sh7" dtype_id="4"/>
+                <varref fl="d18" loc="d,18,16,18,17" name="__Vfunc_vlvbound_test.foo__0__i" dtype_id="3"/>
               </gts>
-              <assign fl="d13" loc="d,13,14,13,15" dtype_id="3">
-                <eq fl="d13" loc="d,13,31,13,33" dtype_id="3">
-                  <const fl="d13" loc="d,13,34,13,39" name="2&apos;h0" dtype_id="7"/>
-                  <sel fl="d13" loc="d,13,20,13,21" dtype_id="7">
-                    <varref fl="d13" loc="d,13,17,13,20" name="__Vfunc_vlvbound_test.foo__0__val" dtype_id="1"/>
-                    <sel fl="d13" loc="d,13,22,13,23" dtype_id="8">
-                      <muls fl="d13" loc="d,13,22,13,23" dtype_id="5">
-                        <const fl="d13" loc="d,13,23,13,24" name="32&apos;sh2" dtype_id="5"/>
-                        <varref fl="d13" loc="d,13,21,13,22" name="__Vfunc_vlvbound_test.foo__0__i" dtype_id="4"/>
+              <assign fl="d19" loc="d,19,14,19,15" dtype_id="6">
+                <eq fl="d19" loc="d,19,31,19,33" dtype_id="6">
+                  <const fl="d19" loc="d,19,34,19,39" name="2&apos;h0" dtype_id="7"/>
+                  <sel fl="d19" loc="d,19,20,19,21" dtype_id="7">
+                    <varref fl="d19" loc="d,19,17,19,20" name="__Vfunc_vlvbound_test.foo__0__val" dtype_id="1"/>
+                    <sel fl="d19" loc="d,19,22,19,23" dtype_id="8">
+                      <muls fl="d19" loc="d,19,22,19,23" dtype_id="4">
+                        <const fl="d19" loc="d,19,23,19,24" name="32&apos;sh2" dtype_id="4"/>
+                        <varref fl="d19" loc="d,19,21,19,22" name="__Vfunc_vlvbound_test.foo__0__i" dtype_id="3"/>
                       </muls>
-                      <const fl="d13" loc="d,13,22,13,23" name="32&apos;h0" dtype_id="9"/>
-                      <const fl="d13" loc="d,13,22,13,23" name="32&apos;h4" dtype_id="9"/>
+                      <const fl="d19" loc="d,19,22,19,23" name="32&apos;h0" dtype_id="9"/>
+                      <const fl="d19" loc="d,19,22,19,23" name="32&apos;h4" dtype_id="9"/>
                     </sel>
-                    <const fl="d13" loc="d,13,28,13,29" name="32&apos;sh2" dtype_id="5"/>
+                    <const fl="d19" loc="d,19,28,19,29" name="32&apos;sh2" dtype_id="4"/>
                   </sel>
                 </eq>
-                <varref fl="d13" loc="d,13,10,13,11" name="__Vlvbound1" dtype_id="3"/>
+                <sel fl="d19" loc="d,19,10,19,11" dtype_id="6">
+                  <varref fl="d19" loc="d,19,7,19,10" name="__Vfunc_vlvbound_test.foo__0__ret" dtype_id="2"/>
+                  <sel fl="d19" loc="d,19,11,19,12" dtype_id="10">
+                    <varref fl="d19" loc="d,19,11,19,12" name="__Vfunc_vlvbound_test.foo__0__i" dtype_id="3"/>
+                    <const fl="d19" loc="d,19,11,19,12" name="32&apos;h0" dtype_id="9"/>
+                    <const fl="d19" loc="d,19,11,19,12" name="32&apos;h3" dtype_id="9"/>
+                  </sel>
+                  <const fl="d19" loc="d,19,10,19,11" name="32&apos;h1" dtype_id="9"/>
+                </sel>
               </assign>
-              <if fl="d13" loc="d,13,10,13,11">
-                <gte fl="d13" loc="d,13,10,13,11" dtype_id="6">
-                  <const fl="d13" loc="d,13,10,13,11" name="3&apos;h6" dtype_id="10"/>
-                  <sel fl="d13" loc="d,13,11,13,12" dtype_id="11">
-                    <varref fl="d13" loc="d,13,11,13,12" name="__Vfunc_vlvbound_test.foo__0__i" dtype_id="4"/>
-                    <const fl="d13" loc="d,13,11,13,12" name="32&apos;h0" dtype_id="9"/>
-                    <const fl="d13" loc="d,13,11,13,12" name="32&apos;h3" dtype_id="9"/>
-                  </sel>
-                </gte>
-                <assign fl="d13" loc="d,13,10,13,11" dtype_id="3">
-                  <varref fl="d13" loc="d,13,10,13,11" name="__Vlvbound1" dtype_id="3"/>
-                  <sel fl="d13" loc="d,13,10,13,11" dtype_id="3">
-                    <varref fl="d13" loc="d,13,7,13,10" name="__Vfunc_vlvbound_test.foo__0__ret" dtype_id="2"/>
-                    <sel fl="d13" loc="d,13,11,13,12" dtype_id="11">
-                      <varref fl="d13" loc="d,13,11,13,12" name="__Vfunc_vlvbound_test.foo__0__i" dtype_id="4"/>
-                      <const fl="d13" loc="d,13,11,13,12" name="32&apos;h0" dtype_id="9"/>
-                      <const fl="d13" loc="d,13,11,13,12" name="32&apos;h3" dtype_id="9"/>
-                    </sel>
-                    <const fl="d13" loc="d,13,10,13,11" name="32&apos;h1" dtype_id="9"/>
-                  </sel>
-                </assign>
-              </if>
-              <assign fl="d12" loc="d,12,24,12,26" dtype_id="4">
-                <add fl="d12" loc="d,12,24,12,26" dtype_id="9">
-                  <const fl="d12" loc="d,12,24,12,26" name="32&apos;h1" dtype_id="9"/>
-                  <varref fl="d12" loc="d,12,23,12,24" name="__Vfunc_vlvbound_test.foo__0__i" dtype_id="4"/>
+              <assign fl="d18" loc="d,18,24,18,26" dtype_id="3">
+                <add fl="d18" loc="d,18,24,18,26" dtype_id="9">
+                  <const fl="d18" loc="d,18,24,18,26" name="32&apos;h1" dtype_id="9"/>
+                  <varref fl="d18" loc="d,18,23,18,24" name="__Vfunc_vlvbound_test.foo__0__i" dtype_id="3"/>
                 </add>
-                <varref fl="d12" loc="d,12,23,12,24" name="__Vfunc_vlvbound_test.foo__0__i" dtype_id="4"/>
+                <varref fl="d18" loc="d,18,23,18,24" name="__Vfunc_vlvbound_test.foo__0__i" dtype_id="3"/>
               </assign>
             </while>
-            <assign fl="d15" loc="d,15,5,15,11" dtype_id="2">
-              <varref fl="d15" loc="d,15,12,15,15" name="__Vfunc_vlvbound_test.foo__0__ret" dtype_id="2"/>
-              <varref fl="d15" loc="d,15,5,15,11" name="__Vfunc_vlvbound_test.foo__0__Vfuncout" dtype_id="2"/>
+            <assign fl="d21" loc="d,21,5,21,11" dtype_id="2">
+              <varref fl="d21" loc="d,21,12,21,15" name="__Vfunc_vlvbound_test.foo__0__ret" dtype_id="2"/>
+              <varref fl="d21" loc="d,21,5,21,11" name="__Vfunc_vlvbound_test.foo__0__Vfuncout" dtype_id="2"/>
             </assign>
-            <assign fl="d18" loc="d,18,14,18,15" dtype_id="2">
-              <varref fl="d18" loc="d,18,16,18,19" name="__Vfunc_vlvbound_test.foo__0__Vfuncout" dtype_id="2"/>
-              <varref fl="d18" loc="d,18,10,18,13" name="o_a" dtype_id="2"/>
+            <assign fl="d24" loc="d,24,14,24,15" dtype_id="2">
+              <varref fl="d24" loc="d,24,16,24,19" name="__Vfunc_vlvbound_test.foo__0__Vfuncout" dtype_id="2"/>
+              <varref fl="d24" loc="d,24,10,24,13" name="o_a" dtype_id="2"/>
             </assign>
           </always>
-          <always fl="d19" loc="d,19,14,19,15">
-            <comment fl="d19" loc="d,19,16,19,19" name="Function: foo"/>
-            <assign fl="d19" loc="d,19,20,19,23" dtype_id="1">
-              <varref fl="d19" loc="d,19,20,19,23" name="i_b" dtype_id="1"/>
-              <varref fl="d9" loc="d,9,57,9,60" name="__Vfunc_vlvbound_test.foo__1__val" dtype_id="1"/>
+          <always fl="d25" loc="d,25,14,25,15">
+            <comment fl="d25" loc="d,25,16,25,19" name="Function: foo"/>
+            <assign fl="d25" loc="d,25,20,25,23" dtype_id="1">
+              <varref fl="d25" loc="d,25,20,25,23" name="i_b" dtype_id="1"/>
+              <varref fl="d15" loc="d,15,57,15,60" name="__Vfunc_vlvbound_test.foo__1__val" dtype_id="1"/>
             </assign>
-            <assign fl="d12" loc="d,12,11,12,12" dtype_id="4">
-              <const fl="d12" loc="d,12,12,12,13" name="32&apos;sh0" dtype_id="5"/>
-              <varref fl="d12" loc="d,12,10,12,11" name="__Vfunc_vlvbound_test.foo__1__i" dtype_id="4"/>
+            <assign fl="d18" loc="d,18,11,18,12" dtype_id="3">
+              <const fl="d18" loc="d,18,12,18,13" name="32&apos;sh0" dtype_id="4"/>
+              <varref fl="d18" loc="d,18,10,18,11" name="__Vfunc_vlvbound_test.foo__1__i" dtype_id="3"/>
             </assign>
-            <while fl="d12" loc="d,12,5,12,8">
-              <gts fl="d12" loc="d,12,18,12,19" dtype_id="6">
-                <const fl="d12" loc="d,12,20,12,21" name="32&apos;sh7" dtype_id="5"/>
-                <varref fl="d12" loc="d,12,16,12,17" name="__Vfunc_vlvbound_test.foo__1__i" dtype_id="4"/>
+            <while fl="d18" loc="d,18,5,18,8">
+              <gts fl="d18" loc="d,18,18,18,19" dtype_id="5">
+                <const fl="d18" loc="d,18,20,18,21" name="32&apos;sh7" dtype_id="4"/>
+                <varref fl="d18" loc="d,18,16,18,17" name="__Vfunc_vlvbound_test.foo__1__i" dtype_id="3"/>
               </gts>
-              <assign fl="d13" loc="d,13,14,13,15" dtype_id="3">
-                <eq fl="d13" loc="d,13,31,13,33" dtype_id="3">
-                  <const fl="d13" loc="d,13,34,13,39" name="2&apos;h0" dtype_id="7"/>
-                  <sel fl="d13" loc="d,13,20,13,21" dtype_id="7">
-                    <varref fl="d13" loc="d,13,17,13,20" name="__Vfunc_vlvbound_test.foo__1__val" dtype_id="1"/>
-                    <sel fl="d13" loc="d,13,22,13,23" dtype_id="8">
-                      <muls fl="d13" loc="d,13,22,13,23" dtype_id="5">
-                        <const fl="d13" loc="d,13,23,13,24" name="32&apos;sh2" dtype_id="5"/>
-                        <varref fl="d13" loc="d,13,21,13,22" name="__Vfunc_vlvbound_test.foo__1__i" dtype_id="4"/>
+              <assign fl="d19" loc="d,19,14,19,15" dtype_id="6">
+                <eq fl="d19" loc="d,19,31,19,33" dtype_id="6">
+                  <const fl="d19" loc="d,19,34,19,39" name="2&apos;h0" dtype_id="7"/>
+                  <sel fl="d19" loc="d,19,20,19,21" dtype_id="7">
+                    <varref fl="d19" loc="d,19,17,19,20" name="__Vfunc_vlvbound_test.foo__1__val" dtype_id="1"/>
+                    <sel fl="d19" loc="d,19,22,19,23" dtype_id="8">
+                      <muls fl="d19" loc="d,19,22,19,23" dtype_id="4">
+                        <const fl="d19" loc="d,19,23,19,24" name="32&apos;sh2" dtype_id="4"/>
+                        <varref fl="d19" loc="d,19,21,19,22" name="__Vfunc_vlvbound_test.foo__1__i" dtype_id="3"/>
                       </muls>
-                      <const fl="d13" loc="d,13,22,13,23" name="32&apos;h0" dtype_id="9"/>
-                      <const fl="d13" loc="d,13,22,13,23" name="32&apos;h4" dtype_id="9"/>
+                      <const fl="d19" loc="d,19,22,19,23" name="32&apos;h0" dtype_id="9"/>
+                      <const fl="d19" loc="d,19,22,19,23" name="32&apos;h4" dtype_id="9"/>
                     </sel>
-                    <const fl="d13" loc="d,13,28,13,29" name="32&apos;sh2" dtype_id="5"/>
+                    <const fl="d19" loc="d,19,28,19,29" name="32&apos;sh2" dtype_id="4"/>
                   </sel>
                 </eq>
-                <varref fl="d13" loc="d,13,10,13,11" name="__Vlvbound1" dtype_id="3"/>
+                <sel fl="d19" loc="d,19,10,19,11" dtype_id="6">
+                  <varref fl="d19" loc="d,19,7,19,10" name="__Vfunc_vlvbound_test.foo__1__ret" dtype_id="2"/>
+                  <sel fl="d19" loc="d,19,11,19,12" dtype_id="10">
+                    <varref fl="d19" loc="d,19,11,19,12" name="__Vfunc_vlvbound_test.foo__1__i" dtype_id="3"/>
+                    <const fl="d19" loc="d,19,11,19,12" name="32&apos;h0" dtype_id="9"/>
+                    <const fl="d19" loc="d,19,11,19,12" name="32&apos;h3" dtype_id="9"/>
+                  </sel>
+                  <const fl="d19" loc="d,19,10,19,11" name="32&apos;h1" dtype_id="9"/>
+                </sel>
               </assign>
-              <if fl="d13" loc="d,13,10,13,11">
-                <gte fl="d13" loc="d,13,10,13,11" dtype_id="6">
-                  <const fl="d13" loc="d,13,10,13,11" name="3&apos;h6" dtype_id="10"/>
-                  <sel fl="d13" loc="d,13,11,13,12" dtype_id="11">
-                    <varref fl="d13" loc="d,13,11,13,12" name="__Vfunc_vlvbound_test.foo__1__i" dtype_id="4"/>
-                    <const fl="d13" loc="d,13,11,13,12" name="32&apos;h0" dtype_id="9"/>
-                    <const fl="d13" loc="d,13,11,13,12" name="32&apos;h3" dtype_id="9"/>
-                  </sel>
-                </gte>
-                <assign fl="d13" loc="d,13,10,13,11" dtype_id="3">
-                  <varref fl="d13" loc="d,13,10,13,11" name="__Vlvbound1" dtype_id="3"/>
-                  <sel fl="d13" loc="d,13,10,13,11" dtype_id="3">
-                    <varref fl="d13" loc="d,13,7,13,10" name="__Vfunc_vlvbound_test.foo__1__ret" dtype_id="2"/>
-                    <sel fl="d13" loc="d,13,11,13,12" dtype_id="11">
-                      <varref fl="d13" loc="d,13,11,13,12" name="__Vfunc_vlvbound_test.foo__1__i" dtype_id="4"/>
-                      <const fl="d13" loc="d,13,11,13,12" name="32&apos;h0" dtype_id="9"/>
-                      <const fl="d13" loc="d,13,11,13,12" name="32&apos;h3" dtype_id="9"/>
-                    </sel>
-                    <const fl="d13" loc="d,13,10,13,11" name="32&apos;h1" dtype_id="9"/>
-                  </sel>
-                </assign>
-              </if>
-              <assign fl="d12" loc="d,12,24,12,26" dtype_id="4">
-                <add fl="d12" loc="d,12,24,12,26" dtype_id="9">
-                  <const fl="d12" loc="d,12,24,12,26" name="32&apos;h1" dtype_id="9"/>
-                  <varref fl="d12" loc="d,12,23,12,24" name="__Vfunc_vlvbound_test.foo__1__i" dtype_id="4"/>
+              <assign fl="d18" loc="d,18,24,18,26" dtype_id="3">
+                <add fl="d18" loc="d,18,24,18,26" dtype_id="9">
+                  <const fl="d18" loc="d,18,24,18,26" name="32&apos;h1" dtype_id="9"/>
+                  <varref fl="d18" loc="d,18,23,18,24" name="__Vfunc_vlvbound_test.foo__1__i" dtype_id="3"/>
                 </add>
-                <varref fl="d12" loc="d,12,23,12,24" name="__Vfunc_vlvbound_test.foo__1__i" dtype_id="4"/>
+                <varref fl="d18" loc="d,18,23,18,24" name="__Vfunc_vlvbound_test.foo__1__i" dtype_id="3"/>
               </assign>
             </while>
-            <assign fl="d15" loc="d,15,5,15,11" dtype_id="2">
-              <varref fl="d15" loc="d,15,12,15,15" name="__Vfunc_vlvbound_test.foo__1__ret" dtype_id="2"/>
-              <varref fl="d15" loc="d,15,5,15,11" name="__Vfunc_vlvbound_test.foo__1__Vfuncout" dtype_id="2"/>
+            <assign fl="d21" loc="d,21,5,21,11" dtype_id="2">
+              <varref fl="d21" loc="d,21,12,21,15" name="__Vfunc_vlvbound_test.foo__1__ret" dtype_id="2"/>
+              <varref fl="d21" loc="d,21,5,21,11" name="__Vfunc_vlvbound_test.foo__1__Vfuncout" dtype_id="2"/>
             </assign>
-            <assign fl="d19" loc="d,19,14,19,15" dtype_id="2">
-              <varref fl="d19" loc="d,19,16,19,19" name="__Vfunc_vlvbound_test.foo__1__Vfuncout" dtype_id="2"/>
-              <varref fl="d19" loc="d,19,10,19,13" name="o_b" dtype_id="2"/>
+            <assign fl="d25" loc="d,25,14,25,15" dtype_id="2">
+              <varref fl="d25" loc="d,25,16,25,19" name="__Vfunc_vlvbound_test.foo__1__Vfuncout" dtype_id="2"/>
+              <varref fl="d25" loc="d,25,10,25,13" name="o_b" dtype_id="2"/>
             </assign>
           </always>
         </scope>
       </topscope>
-      <var fl="d9" loc="d,9,34,9,37" name="__Vfunc_vlvbound_test.foo__0__Vfuncout" dtype_id="2" vartype="logic" origName="__Vfunc_vlvbound_test__DOT__foo__0__Vfuncout"/>
-      <var fl="d9" loc="d,9,57,9,60" name="__Vfunc_vlvbound_test.foo__0__val" dtype_id="1" vartype="logic" origName="__Vfunc_vlvbound_test__DOT__foo__0__val"/>
-      <var fl="d10" loc="d,10,17,10,20" name="__Vfunc_vlvbound_test.foo__0__ret" dtype_id="2" vartype="logic" origName="__Vfunc_vlvbound_test__DOT__foo__0__ret"/>
-      <var fl="d11" loc="d,11,13,11,14" name="__Vfunc_vlvbound_test.foo__0__i" dtype_id="4" vartype="integer" origName="__Vfunc_vlvbound_test__DOT__foo__0__i"/>
-      <var fl="d9" loc="d,9,34,9,37" name="__Vfunc_vlvbound_test.foo__1__Vfuncout" dtype_id="2" vartype="logic" origName="__Vfunc_vlvbound_test__DOT__foo__1__Vfuncout"/>
-      <var fl="d9" loc="d,9,57,9,60" name="__Vfunc_vlvbound_test.foo__1__val" dtype_id="1" vartype="logic" origName="__Vfunc_vlvbound_test__DOT__foo__1__val"/>
-      <var fl="d10" loc="d,10,17,10,20" name="__Vfunc_vlvbound_test.foo__1__ret" dtype_id="2" vartype="logic" origName="__Vfunc_vlvbound_test__DOT__foo__1__ret"/>
-      <var fl="d11" loc="d,11,13,11,14" name="__Vfunc_vlvbound_test.foo__1__i" dtype_id="4" vartype="integer" origName="__Vfunc_vlvbound_test__DOT__foo__1__i"/>
+      <var fl="d15" loc="d,15,34,15,37" name="__Vfunc_vlvbound_test.foo__0__Vfuncout" dtype_id="2" vartype="logic" origName="__Vfunc_vlvbound_test__DOT__foo__0__Vfuncout"/>
+      <var fl="d15" loc="d,15,57,15,60" name="__Vfunc_vlvbound_test.foo__0__val" dtype_id="1" vartype="logic" origName="__Vfunc_vlvbound_test__DOT__foo__0__val"/>
+      <var fl="d16" loc="d,16,17,16,20" name="__Vfunc_vlvbound_test.foo__0__ret" dtype_id="2" vartype="logic" origName="__Vfunc_vlvbound_test__DOT__foo__0__ret"/>
+      <var fl="d17" loc="d,17,13,17,14" name="__Vfunc_vlvbound_test.foo__0__i" dtype_id="3" vartype="integer" origName="__Vfunc_vlvbound_test__DOT__foo__0__i"/>
+      <var fl="d15" loc="d,15,34,15,37" name="__Vfunc_vlvbound_test.foo__1__Vfuncout" dtype_id="2" vartype="logic" origName="__Vfunc_vlvbound_test__DOT__foo__1__Vfuncout"/>
+      <var fl="d15" loc="d,15,57,15,60" name="__Vfunc_vlvbound_test.foo__1__val" dtype_id="1" vartype="logic" origName="__Vfunc_vlvbound_test__DOT__foo__1__val"/>
+      <var fl="d16" loc="d,16,17,16,20" name="__Vfunc_vlvbound_test.foo__1__ret" dtype_id="2" vartype="logic" origName="__Vfunc_vlvbound_test__DOT__foo__1__ret"/>
+      <var fl="d17" loc="d,17,13,17,14" name="__Vfunc_vlvbound_test.foo__1__i" dtype_id="3" vartype="integer" origName="__Vfunc_vlvbound_test__DOT__foo__1__i"/>
     </module>
     <typetable fl="a0" loc="a,0,0,0,0">
-      <basicdtype fl="d12" loc="d,12,18,12,19" id="3" name="logic"/>
-      <basicdtype fl="d13" loc="d,13,34,13,39" id="7" name="logic" left="1" right="0"/>
-      <basicdtype fl="d3" loc="d,3,11,3,16" id="1" name="logic" left="15" right="0"/>
-      <basicdtype fl="d5" loc="d,5,12,5,17" id="2" name="logic" left="6" right="0"/>
-      <basicdtype fl="d11" loc="d,11,5,11,12" id="4" name="integer" left="31" right="0"/>
-      <basicdtype fl="d13" loc="d,13,10,13,11" id="11" name="logic" left="2" right="0"/>
-      <basicdtype fl="d13" loc="d,13,11,13,12" id="9" name="logic" left="31" right="0"/>
-      <basicdtype fl="d13" loc="d,13,20,13,21" id="8" name="logic" left="3" right="0"/>
-      <basicdtype fl="d12" loc="d,12,12,12,13" id="5" name="logic" left="31" right="0"/>
-      <basicdtype fl="d12" loc="d,12,18,12,19" id="6" name="logic"/>
-      <basicdtype fl="d13" loc="d,13,10,13,11" id="10" name="logic" left="2" right="0"/>
+      <basicdtype fl="d18" loc="d,18,18,18,19" id="6" name="logic"/>
+      <basicdtype fl="d19" loc="d,19,34,19,39" id="7" name="logic" left="1" right="0"/>
+      <basicdtype fl="d9" loc="d,9,11,9,16" id="1" name="logic" left="15" right="0"/>
+      <basicdtype fl="d11" loc="d,11,12,11,17" id="2" name="logic" left="6" right="0"/>
+      <basicdtype fl="d17" loc="d,17,5,17,12" id="3" name="integer" left="31" right="0"/>
+      <basicdtype fl="d19" loc="d,19,10,19,11" id="10" name="logic" left="2" right="0"/>
+      <basicdtype fl="d19" loc="d,19,11,19,12" id="9" name="logic" left="31" right="0"/>
+      <basicdtype fl="d19" loc="d,19,20,19,21" id="8" name="logic" left="3" right="0"/>
+      <basicdtype fl="d18" loc="d,18,12,18,13" id="4" name="logic" left="31" right="0"/>
+      <basicdtype fl="d18" loc="d,18,18,18,19" id="5" name="logic"/>
     </typetable>
   </netlist>
 </verilator_xml>

--- a/test_regress/t/t_xml_flat_vlvbound.out
+++ b/test_regress/t/t_xml_flat_vlvbound.out
@@ -1,0 +1,231 @@
+<?xml version="1.0" ?>
+<!-- DESCRIPTION: Verilator output: XML representation of netlist -->
+<verilator_xml>
+  <files>
+    <file id="a" filename="&lt;built-in&gt;" language="1800-2017"/>
+    <file id="b" filename="&lt;command-line&gt;" language="1800-2017"/>
+    <file id="c" filename="input.vc" language="1800-2017"/>
+    <file id="d" filename="t/t_xml_flat_vlvbound.v" language="1800-2017"/>
+  </files>
+  <module_files>
+    <file id="d" filename="t/t_xml_flat_vlvbound.v" language="1800-2017"/>
+  </module_files>
+  <cells>
+    <cell fl="d1" loc="d,1,8,1,21" name="TOP" submodname="TOP" hier="TOP"/>
+  </cells>
+  <netlist>
+    <module fl="d1" loc="d,1,8,1,21" name="TOP" origName="TOP" topModule="1" public="true">
+      <var fl="d3" loc="d,3,25,3,28" name="i_a" dtype_id="1" dir="input" vartype="logic" origName="i_a" public="true"/>
+      <var fl="d4" loc="d,4,25,4,28" name="i_b" dtype_id="1" dir="input" vartype="logic" origName="i_b" public="true"/>
+      <var fl="d5" loc="d,5,25,5,28" name="o_a" dtype_id="2" dir="output" vartype="logic" origName="o_a" public="true"/>
+      <var fl="d6" loc="d,6,25,6,28" name="o_b" dtype_id="2" dir="output" vartype="logic" origName="o_b" public="true"/>
+      <var fl="d3" loc="d,3,25,3,28" name="vlvbound_test.i_a" dtype_id="1" vartype="logic" origName="i_a"/>
+      <var fl="d4" loc="d,4,25,4,28" name="vlvbound_test.i_b" dtype_id="1" vartype="logic" origName="i_b"/>
+      <var fl="d5" loc="d,5,25,5,28" name="vlvbound_test.o_a" dtype_id="2" vartype="logic" origName="o_a"/>
+      <var fl="d6" loc="d,6,25,6,28" name="vlvbound_test.o_b" dtype_id="2" vartype="logic" origName="o_b"/>
+      <var fl="d13" loc="d,13,10,13,11" name="vlvbound_test.__Vlvbound1" dtype_id="3" vartype="logic" origName="__Vlvbound1"/>
+      <topscope fl="d1" loc="d,1,8,1,21">
+        <scope fl="d1" loc="d,1,8,1,21" name="TOP">
+          <varscope fl="d3" loc="d,3,25,3,28" name="i_a" dtype_id="1"/>
+          <varscope fl="d4" loc="d,4,25,4,28" name="i_b" dtype_id="1"/>
+          <varscope fl="d5" loc="d,5,25,5,28" name="o_a" dtype_id="2"/>
+          <varscope fl="d6" loc="d,6,25,6,28" name="o_b" dtype_id="2"/>
+          <varscope fl="d3" loc="d,3,25,3,28" name="vlvbound_test.i_a" dtype_id="1"/>
+          <varscope fl="d4" loc="d,4,25,4,28" name="vlvbound_test.i_b" dtype_id="1"/>
+          <varscope fl="d5" loc="d,5,25,5,28" name="vlvbound_test.o_a" dtype_id="2"/>
+          <varscope fl="d6" loc="d,6,25,6,28" name="vlvbound_test.o_b" dtype_id="2"/>
+          <varscope fl="d13" loc="d,13,10,13,11" name="vlvbound_test.__Vlvbound1" dtype_id="3"/>
+          <varscope fl="d9" loc="d,9,34,9,37" name="__Vfunc_vlvbound_test.foo__0__Vfuncout" dtype_id="2"/>
+          <varscope fl="d9" loc="d,9,57,9,60" name="__Vfunc_vlvbound_test.foo__0__val" dtype_id="1"/>
+          <varscope fl="d10" loc="d,10,17,10,20" name="__Vfunc_vlvbound_test.foo__0__ret" dtype_id="2"/>
+          <varscope fl="d11" loc="d,11,13,11,14" name="__Vfunc_vlvbound_test.foo__0__i" dtype_id="4"/>
+          <varscope fl="d9" loc="d,9,34,9,37" name="__Vfunc_vlvbound_test.foo__1__Vfuncout" dtype_id="2"/>
+          <varscope fl="d9" loc="d,9,57,9,60" name="__Vfunc_vlvbound_test.foo__1__val" dtype_id="1"/>
+          <varscope fl="d10" loc="d,10,17,10,20" name="__Vfunc_vlvbound_test.foo__1__ret" dtype_id="2"/>
+          <varscope fl="d11" loc="d,11,13,11,14" name="__Vfunc_vlvbound_test.foo__1__i" dtype_id="4"/>
+          <assignalias fl="d3" loc="d,3,25,3,28" dtype_id="1">
+            <varref fl="d3" loc="d,3,25,3,28" name="i_a" dtype_id="1"/>
+            <varref fl="d3" loc="d,3,25,3,28" name="i_a" dtype_id="1"/>
+          </assignalias>
+          <assignalias fl="d4" loc="d,4,25,4,28" dtype_id="1">
+            <varref fl="d4" loc="d,4,25,4,28" name="i_b" dtype_id="1"/>
+            <varref fl="d4" loc="d,4,25,4,28" name="i_b" dtype_id="1"/>
+          </assignalias>
+          <assignalias fl="d5" loc="d,5,25,5,28" dtype_id="2">
+            <varref fl="d5" loc="d,5,25,5,28" name="o_a" dtype_id="2"/>
+            <varref fl="d5" loc="d,5,25,5,28" name="o_a" dtype_id="2"/>
+          </assignalias>
+          <assignalias fl="d6" loc="d,6,25,6,28" dtype_id="2">
+            <varref fl="d6" loc="d,6,25,6,28" name="o_b" dtype_id="2"/>
+            <varref fl="d6" loc="d,6,25,6,28" name="o_b" dtype_id="2"/>
+          </assignalias>
+          <always fl="d18" loc="d,18,14,18,15">
+            <comment fl="d18" loc="d,18,16,18,19" name="Function: foo"/>
+            <assign fl="d18" loc="d,18,20,18,23" dtype_id="1">
+              <varref fl="d18" loc="d,18,20,18,23" name="i_a" dtype_id="1"/>
+              <varref fl="d9" loc="d,9,57,9,60" name="__Vfunc_vlvbound_test.foo__0__val" dtype_id="1"/>
+            </assign>
+            <assign fl="d12" loc="d,12,11,12,12" dtype_id="4">
+              <const fl="d12" loc="d,12,12,12,13" name="32&apos;sh0" dtype_id="5"/>
+              <varref fl="d12" loc="d,12,10,12,11" name="__Vfunc_vlvbound_test.foo__0__i" dtype_id="4"/>
+            </assign>
+            <while fl="d12" loc="d,12,5,12,8">
+              <gts fl="d12" loc="d,12,18,12,19" dtype_id="6">
+                <const fl="d12" loc="d,12,20,12,21" name="32&apos;sh7" dtype_id="5"/>
+                <varref fl="d12" loc="d,12,16,12,17" name="__Vfunc_vlvbound_test.foo__0__i" dtype_id="4"/>
+              </gts>
+              <assign fl="d13" loc="d,13,14,13,15" dtype_id="3">
+                <eq fl="d13" loc="d,13,31,13,33" dtype_id="3">
+                  <const fl="d13" loc="d,13,34,13,39" name="2&apos;h0" dtype_id="7"/>
+                  <sel fl="d13" loc="d,13,20,13,21" dtype_id="7">
+                    <varref fl="d13" loc="d,13,17,13,20" name="__Vfunc_vlvbound_test.foo__0__val" dtype_id="1"/>
+                    <sel fl="d13" loc="d,13,22,13,23" dtype_id="8">
+                      <muls fl="d13" loc="d,13,22,13,23" dtype_id="5">
+                        <const fl="d13" loc="d,13,23,13,24" name="32&apos;sh2" dtype_id="5"/>
+                        <varref fl="d13" loc="d,13,21,13,22" name="__Vfunc_vlvbound_test.foo__0__i" dtype_id="4"/>
+                      </muls>
+                      <const fl="d13" loc="d,13,22,13,23" name="32&apos;h0" dtype_id="9"/>
+                      <const fl="d13" loc="d,13,22,13,23" name="32&apos;h4" dtype_id="9"/>
+                    </sel>
+                    <const fl="d13" loc="d,13,28,13,29" name="32&apos;sh2" dtype_id="5"/>
+                  </sel>
+                </eq>
+                <varref fl="d13" loc="d,13,10,13,11" name="__Vlvbound1" dtype_id="3"/>
+              </assign>
+              <if fl="d13" loc="d,13,10,13,11">
+                <gte fl="d13" loc="d,13,10,13,11" dtype_id="6">
+                  <const fl="d13" loc="d,13,10,13,11" name="3&apos;h6" dtype_id="10"/>
+                  <sel fl="d13" loc="d,13,11,13,12" dtype_id="11">
+                    <varref fl="d13" loc="d,13,11,13,12" name="__Vfunc_vlvbound_test.foo__0__i" dtype_id="4"/>
+                    <const fl="d13" loc="d,13,11,13,12" name="32&apos;h0" dtype_id="9"/>
+                    <const fl="d13" loc="d,13,11,13,12" name="32&apos;h3" dtype_id="9"/>
+                  </sel>
+                </gte>
+                <assign fl="d13" loc="d,13,10,13,11" dtype_id="3">
+                  <varref fl="d13" loc="d,13,10,13,11" name="__Vlvbound1" dtype_id="3"/>
+                  <sel fl="d13" loc="d,13,10,13,11" dtype_id="3">
+                    <varref fl="d13" loc="d,13,7,13,10" name="__Vfunc_vlvbound_test.foo__0__ret" dtype_id="2"/>
+                    <sel fl="d13" loc="d,13,11,13,12" dtype_id="11">
+                      <varref fl="d13" loc="d,13,11,13,12" name="__Vfunc_vlvbound_test.foo__0__i" dtype_id="4"/>
+                      <const fl="d13" loc="d,13,11,13,12" name="32&apos;h0" dtype_id="9"/>
+                      <const fl="d13" loc="d,13,11,13,12" name="32&apos;h3" dtype_id="9"/>
+                    </sel>
+                    <const fl="d13" loc="d,13,10,13,11" name="32&apos;h1" dtype_id="9"/>
+                  </sel>
+                </assign>
+              </if>
+              <assign fl="d12" loc="d,12,24,12,26" dtype_id="4">
+                <add fl="d12" loc="d,12,24,12,26" dtype_id="9">
+                  <const fl="d12" loc="d,12,24,12,26" name="32&apos;h1" dtype_id="9"/>
+                  <varref fl="d12" loc="d,12,23,12,24" name="__Vfunc_vlvbound_test.foo__0__i" dtype_id="4"/>
+                </add>
+                <varref fl="d12" loc="d,12,23,12,24" name="__Vfunc_vlvbound_test.foo__0__i" dtype_id="4"/>
+              </assign>
+            </while>
+            <assign fl="d15" loc="d,15,5,15,11" dtype_id="2">
+              <varref fl="d15" loc="d,15,12,15,15" name="__Vfunc_vlvbound_test.foo__0__ret" dtype_id="2"/>
+              <varref fl="d15" loc="d,15,5,15,11" name="__Vfunc_vlvbound_test.foo__0__Vfuncout" dtype_id="2"/>
+            </assign>
+            <assign fl="d18" loc="d,18,14,18,15" dtype_id="2">
+              <varref fl="d18" loc="d,18,16,18,19" name="__Vfunc_vlvbound_test.foo__0__Vfuncout" dtype_id="2"/>
+              <varref fl="d18" loc="d,18,10,18,13" name="o_a" dtype_id="2"/>
+            </assign>
+          </always>
+          <always fl="d19" loc="d,19,14,19,15">
+            <comment fl="d19" loc="d,19,16,19,19" name="Function: foo"/>
+            <assign fl="d19" loc="d,19,20,19,23" dtype_id="1">
+              <varref fl="d19" loc="d,19,20,19,23" name="i_b" dtype_id="1"/>
+              <varref fl="d9" loc="d,9,57,9,60" name="__Vfunc_vlvbound_test.foo__1__val" dtype_id="1"/>
+            </assign>
+            <assign fl="d12" loc="d,12,11,12,12" dtype_id="4">
+              <const fl="d12" loc="d,12,12,12,13" name="32&apos;sh0" dtype_id="5"/>
+              <varref fl="d12" loc="d,12,10,12,11" name="__Vfunc_vlvbound_test.foo__1__i" dtype_id="4"/>
+            </assign>
+            <while fl="d12" loc="d,12,5,12,8">
+              <gts fl="d12" loc="d,12,18,12,19" dtype_id="6">
+                <const fl="d12" loc="d,12,20,12,21" name="32&apos;sh7" dtype_id="5"/>
+                <varref fl="d12" loc="d,12,16,12,17" name="__Vfunc_vlvbound_test.foo__1__i" dtype_id="4"/>
+              </gts>
+              <assign fl="d13" loc="d,13,14,13,15" dtype_id="3">
+                <eq fl="d13" loc="d,13,31,13,33" dtype_id="3">
+                  <const fl="d13" loc="d,13,34,13,39" name="2&apos;h0" dtype_id="7"/>
+                  <sel fl="d13" loc="d,13,20,13,21" dtype_id="7">
+                    <varref fl="d13" loc="d,13,17,13,20" name="__Vfunc_vlvbound_test.foo__1__val" dtype_id="1"/>
+                    <sel fl="d13" loc="d,13,22,13,23" dtype_id="8">
+                      <muls fl="d13" loc="d,13,22,13,23" dtype_id="5">
+                        <const fl="d13" loc="d,13,23,13,24" name="32&apos;sh2" dtype_id="5"/>
+                        <varref fl="d13" loc="d,13,21,13,22" name="__Vfunc_vlvbound_test.foo__1__i" dtype_id="4"/>
+                      </muls>
+                      <const fl="d13" loc="d,13,22,13,23" name="32&apos;h0" dtype_id="9"/>
+                      <const fl="d13" loc="d,13,22,13,23" name="32&apos;h4" dtype_id="9"/>
+                    </sel>
+                    <const fl="d13" loc="d,13,28,13,29" name="32&apos;sh2" dtype_id="5"/>
+                  </sel>
+                </eq>
+                <varref fl="d13" loc="d,13,10,13,11" name="__Vlvbound1" dtype_id="3"/>
+              </assign>
+              <if fl="d13" loc="d,13,10,13,11">
+                <gte fl="d13" loc="d,13,10,13,11" dtype_id="6">
+                  <const fl="d13" loc="d,13,10,13,11" name="3&apos;h6" dtype_id="10"/>
+                  <sel fl="d13" loc="d,13,11,13,12" dtype_id="11">
+                    <varref fl="d13" loc="d,13,11,13,12" name="__Vfunc_vlvbound_test.foo__1__i" dtype_id="4"/>
+                    <const fl="d13" loc="d,13,11,13,12" name="32&apos;h0" dtype_id="9"/>
+                    <const fl="d13" loc="d,13,11,13,12" name="32&apos;h3" dtype_id="9"/>
+                  </sel>
+                </gte>
+                <assign fl="d13" loc="d,13,10,13,11" dtype_id="3">
+                  <varref fl="d13" loc="d,13,10,13,11" name="__Vlvbound1" dtype_id="3"/>
+                  <sel fl="d13" loc="d,13,10,13,11" dtype_id="3">
+                    <varref fl="d13" loc="d,13,7,13,10" name="__Vfunc_vlvbound_test.foo__1__ret" dtype_id="2"/>
+                    <sel fl="d13" loc="d,13,11,13,12" dtype_id="11">
+                      <varref fl="d13" loc="d,13,11,13,12" name="__Vfunc_vlvbound_test.foo__1__i" dtype_id="4"/>
+                      <const fl="d13" loc="d,13,11,13,12" name="32&apos;h0" dtype_id="9"/>
+                      <const fl="d13" loc="d,13,11,13,12" name="32&apos;h3" dtype_id="9"/>
+                    </sel>
+                    <const fl="d13" loc="d,13,10,13,11" name="32&apos;h1" dtype_id="9"/>
+                  </sel>
+                </assign>
+              </if>
+              <assign fl="d12" loc="d,12,24,12,26" dtype_id="4">
+                <add fl="d12" loc="d,12,24,12,26" dtype_id="9">
+                  <const fl="d12" loc="d,12,24,12,26" name="32&apos;h1" dtype_id="9"/>
+                  <varref fl="d12" loc="d,12,23,12,24" name="__Vfunc_vlvbound_test.foo__1__i" dtype_id="4"/>
+                </add>
+                <varref fl="d12" loc="d,12,23,12,24" name="__Vfunc_vlvbound_test.foo__1__i" dtype_id="4"/>
+              </assign>
+            </while>
+            <assign fl="d15" loc="d,15,5,15,11" dtype_id="2">
+              <varref fl="d15" loc="d,15,12,15,15" name="__Vfunc_vlvbound_test.foo__1__ret" dtype_id="2"/>
+              <varref fl="d15" loc="d,15,5,15,11" name="__Vfunc_vlvbound_test.foo__1__Vfuncout" dtype_id="2"/>
+            </assign>
+            <assign fl="d19" loc="d,19,14,19,15" dtype_id="2">
+              <varref fl="d19" loc="d,19,16,19,19" name="__Vfunc_vlvbound_test.foo__1__Vfuncout" dtype_id="2"/>
+              <varref fl="d19" loc="d,19,10,19,13" name="o_b" dtype_id="2"/>
+            </assign>
+          </always>
+        </scope>
+      </topscope>
+      <var fl="d9" loc="d,9,34,9,37" name="__Vfunc_vlvbound_test.foo__0__Vfuncout" dtype_id="2" vartype="logic" origName="__Vfunc_vlvbound_test__DOT__foo__0__Vfuncout"/>
+      <var fl="d9" loc="d,9,57,9,60" name="__Vfunc_vlvbound_test.foo__0__val" dtype_id="1" vartype="logic" origName="__Vfunc_vlvbound_test__DOT__foo__0__val"/>
+      <var fl="d10" loc="d,10,17,10,20" name="__Vfunc_vlvbound_test.foo__0__ret" dtype_id="2" vartype="logic" origName="__Vfunc_vlvbound_test__DOT__foo__0__ret"/>
+      <var fl="d11" loc="d,11,13,11,14" name="__Vfunc_vlvbound_test.foo__0__i" dtype_id="4" vartype="integer" origName="__Vfunc_vlvbound_test__DOT__foo__0__i"/>
+      <var fl="d9" loc="d,9,34,9,37" name="__Vfunc_vlvbound_test.foo__1__Vfuncout" dtype_id="2" vartype="logic" origName="__Vfunc_vlvbound_test__DOT__foo__1__Vfuncout"/>
+      <var fl="d9" loc="d,9,57,9,60" name="__Vfunc_vlvbound_test.foo__1__val" dtype_id="1" vartype="logic" origName="__Vfunc_vlvbound_test__DOT__foo__1__val"/>
+      <var fl="d10" loc="d,10,17,10,20" name="__Vfunc_vlvbound_test.foo__1__ret" dtype_id="2" vartype="logic" origName="__Vfunc_vlvbound_test__DOT__foo__1__ret"/>
+      <var fl="d11" loc="d,11,13,11,14" name="__Vfunc_vlvbound_test.foo__1__i" dtype_id="4" vartype="integer" origName="__Vfunc_vlvbound_test__DOT__foo__1__i"/>
+    </module>
+    <typetable fl="a0" loc="a,0,0,0,0">
+      <basicdtype fl="d12" loc="d,12,18,12,19" id="3" name="logic"/>
+      <basicdtype fl="d13" loc="d,13,34,13,39" id="7" name="logic" left="1" right="0"/>
+      <basicdtype fl="d3" loc="d,3,11,3,16" id="1" name="logic" left="15" right="0"/>
+      <basicdtype fl="d5" loc="d,5,12,5,17" id="2" name="logic" left="6" right="0"/>
+      <basicdtype fl="d11" loc="d,11,5,11,12" id="4" name="integer" left="31" right="0"/>
+      <basicdtype fl="d13" loc="d,13,10,13,11" id="11" name="logic" left="2" right="0"/>
+      <basicdtype fl="d13" loc="d,13,11,13,12" id="9" name="logic" left="31" right="0"/>
+      <basicdtype fl="d13" loc="d,13,20,13,21" id="8" name="logic" left="3" right="0"/>
+      <basicdtype fl="d12" loc="d,12,12,12,13" id="5" name="logic" left="31" right="0"/>
+      <basicdtype fl="d12" loc="d,12,18,12,19" id="6" name="logic"/>
+      <basicdtype fl="d13" loc="d,13,10,13,11" id="10" name="logic" left="2" right="0"/>
+    </typetable>
+  </netlist>
+</verilator_xml>

--- a/test_regress/t/t_xml_flat_vlvbound.pl
+++ b/test_regress/t/t_xml_flat_vlvbound.pl
@@ -1,0 +1,25 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2012 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(vlt => 1);
+
+my $out_filename = "$Self->{obj_dir}/V$Self->{name}.xml";
+
+compile(
+    verilator_flags2 => ['--xml-only', '--flatten'],
+    verilator_make_gmake => 0,
+    make_top_shell => 0,
+    make_main => 0,
+    );
+
+files_identical("$out_filename", $Self->{golden_filename});
+
+ok(1);
+1;

--- a/test_regress/t/t_xml_flat_vlvbound.v
+++ b/test_regress/t/t_xml_flat_vlvbound.v
@@ -1,3 +1,9 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2012 by Wilson Snyder.
+// SPDX-License-Identifier: CC0-1.0
+
 module vlvbound_test
   (
     input logic [15:0]  i_a,

--- a/test_regress/t/t_xml_flat_vlvbound.v
+++ b/test_regress/t/t_xml_flat_vlvbound.v
@@ -1,0 +1,21 @@
+module vlvbound_test
+  (
+    input logic [15:0]  i_a,
+    input logic [15:0]  i_b,
+    output logic [6:0]  o_a,
+    output logic [6:0]  o_b
+  );
+
+  function automatic logic [6:0] foo(input logic [15:0] val);
+    logic [6:0] ret;
+    integer i;
+    for (i=0 ; i < 7; i++) begin
+      ret[i] = (val[i*2 +: 2] == 2'b00);
+    end
+    return ret;
+  endfunction
+
+  assign o_a = foo(i_a);
+  assign o_b = foo(i_b);
+
+endmodule


### PR DESCRIPTION
This patch updates the main `process` function to prevent the V3Unknown pass from being run when generating flat XML output. The problem with this pass and flat XML is that it adds shared `__Vlvbound` nodes for temporary variables, and introduces false dependencies in the connectivity of the netlist. This pass should have been omitted with the original patch to add flattening, but I overlooked it. See this original issue https://www.veripool.org/boards/3/topics/2619 for more details.
