### PR TITLE
Fix sc names

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -11,6 +11,7 @@ Dan Petrisko
 David Horton
 David Stanford
 Driss Hafdi
+Edgar E. Iglesias
 Eric Rippey
 Fan Shupei
 Garrett Smith

--- a/src/V3EmitC.cpp
+++ b/src/V3EmitC.cpp
@@ -3791,8 +3791,8 @@ void V3EmitC::emitc() {
          nodep = VN_CAST(nodep->nextp(), NodeModule)) {
         if (VN_IS(nodep, Class)) continue;  // Imped with ClassPackage
         // clang-format off
-        { EmitCImp cint; cint.mainInt(nodep); }
-        { EmitCImp slow; slow.mainImp(nodep, true); }
+        EmitCImp cint; cint.mainInt(nodep);
+        cint.mainImp(nodep, true);
         { EmitCImp fast; fast.mainImp(nodep, false); }
         // clang-format on
     }

--- a/test_regress/t/t_sc_names.cpp
+++ b/test_regress/t/t_sc_names.cpp
@@ -1,0 +1,30 @@
+// -*- mode: C++; c-file-style: "cc-mode" -*-
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2020 by Edgar E. Iglesias.
+// SPDX-License-Identifier: CC0-1.0
+
+#include VM_PREFIX_INCLUDE
+#include "Vt_sc_names.h"
+
+VM_PREFIX* tb = NULL;
+
+int sc_main(int argc, char* argv[]) {
+    tb = new VM_PREFIX("tb");
+    std::vector < sc_object* > ch = tb->get_child_objects();
+    bool found = false;
+
+    /* We expect to find clk in here. */
+    for (int i = 0; i < ch.size(); ++i) {
+        if (!strcmp(ch[i]->basename(), "clk")) {
+            found = true;
+        }
+    }
+
+    if (found) {
+        VL_PRINTF("*-* All Finished *-*\n");
+        tb->final();
+    } else {
+        vl_fatal(__FILE__, __LINE__, "tb", "Unexpected results\n");
+    }
+    return 0;
+}

--- a/test_regress/t/t_sc_names.pl
+++ b/test_regress/t/t_sc_names.pl
@@ -1,0 +1,30 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2020 by Edgar E. Iglesias. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+if (!$Self->have_sc) {
+    skip("No SystemC installed");
+}
+else {
+    top_filename("t/t_sc_names.v");
+
+    compile(
+        make_main => 0,
+        verilator_flags2 => ["-sc --exe $Self->{t_dir}/t_sc_names.cpp"],
+        );
+
+    execute(
+        check_finished => 1,
+        );
+}
+
+ok(1);
+1;

--- a/test_regress/t/t_sc_names.v
+++ b/test_regress/t/t_sc_names.v
@@ -1,0 +1,11 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2020 by Edgar E. Iglesias.
+// SPDX-License-Identifier: CC0-1.0
+
+module t (
+   clk
+   );
+   input clk;
+endmodule


### PR DESCRIPTION
Hi,

I was trying out a recent Verilator version and ran into some issues with some of our SystemC code that auto-connects AXI ports based on signal names. It turns out that somewhere around 4.028, the generation of calls to Systemc port constructors broke. This results in all generated ports having machine generated names (port_XXX).

The code that walks the tree finding objects that need to have their constructor called does not get called because we use different objectsfor mainInt() and mainImp(). I'm not sure this fix is the correct one but it fixes the problem on my side and passes the testsuite.

This pull requests contains the fix and a new test-case.

Best regards,
Edgar