### PR TITLE
Fix build with Bison 3.7 and newer

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -53,6 +53,7 @@ Pieter Kapsenberg
 Piotr Binkowski
 Qingyao Sun
 Richard Myers
+Rupert Swarbrick
 Sean Cross
 Sebastien Van Cauwenberghe
 Sergi Granell

--- a/src/verilog.y
+++ b/src/verilog.y
@@ -301,6 +301,15 @@ class AstSenTree;
 // Bison 3.0 and newer
 BISONPRE_VERSION(3.0,%define parse.error verbose)
 
+// We run bison with the -d argument. This tells it to generate a
+// header file with token names. Old versions of bison pasted the
+// contents of that file into the generated source as well; newer
+// versions just include it.
+//
+// Since we run bison through ../bisonpre, it doesn't know the correct
+// header file name, so we need to tell it.
+BISONPRE_VERSION(3.7,%define api.header.include {"V3ParseBison.h"})
+
 // When writing Bison patterns we use yTOKEN instead of "token",
 // so Bison will error out on unknown "token"s.
 


### PR DESCRIPTION
It seems that, rather than pasting the contents of the generated
header, bison 3.7 now #include's it.

Unfortunately, our "bisonpre" wrapper script defeats bison's logic for
guessing the header name. This patch tells it the right name
explicitly.
