### PR TITLE
Fix test failure on FreeBSD

### DIFF
--- a/include/verilated.mk.in
+++ b/include/verilated.mk.in
@@ -201,20 +201,23 @@ else
 endif
 
 # When archiving just objects (.o), single $(AR) run is enough.
-# When merging objects (.o) and archives (.a), the following step is taken.
-#   1. create a temporary archive ($*__tmp.a) which contains only .o
-#   2. create a thin archive that refers all archives including $*__tmp.a
-#   3. convert the thin archive to the ordinal archive
+# When merging objects (.o) and archives (.a), the following steps are taken.
+#   1. Extract object files from .a
+#   2. Create a new archive from extracted .o and given .o
 %.a:
 	if test $(words $(filter %.a,$^)) -eq 0; then \
 		$(AR) -cr $@ $^; \
 		$(RANLIB) $@; \
 	else \
-		$(RM) -f $*__tmp.a; \
-		$(AR) -cr $*__tmp.a  $(filter-out %.a,$^); \
-		$(AR) -cqT $@  $*__tmp.a $(filter %.a,$^); \
-		printf "create $@\n addlib $@\n save\\n end" | $(AR) -M; \
-		$(RM) -f $*__tmp.a; \
+		$(RM) -rf $*__tmpdir; \
+		for archive in $(filter %.a,$^); do \
+			mkdir -p $*__tmpdir/$$(basename $${archive}); \
+			cd $*__tmpdir/$$(basename $${archive}); \
+			$(AR) -x ../../$${archive}; \
+			cd ../..; \
+		done; \
+		$(AR) -cr $@ $(filter %.o,$^) $*__tmpdir/*/*.o; \
+		$(RM) -rf $*__tmpdir; \
 	fi
 
 $(VM_PREFIX)__ALL.a: $(VK_OBJS) $(VM_HIER_LIBS)

--- a/test_regress/t/t_hier_block.pl
+++ b/test_regress/t/t_hier_block.pl
@@ -20,7 +20,7 @@ compile(
     v_flags2 => ['t/t_hier_block.cpp'],
     verilator_flags2 => ['--stats', ($Self->{vltmt} ? ' --threads 6' : ''),
                          '--hierarchical',
-                         '--CFLAGS', '"-pipe -DCPP_MACRO=cplusplus -time"'
+                         '--CFLAGS', '"-pipe -DCPP_MACRO=cplusplus"'
     ],
     );
 

--- a/test_regress/t/t_hier_block_cmake.pl
+++ b/test_regress/t/t_hier_block_cmake.pl
@@ -22,7 +22,7 @@ compile(
     v_flags2 => ['t/t_hier_block.cpp'],
     verilator_flags2 => ['--stats',
                          '--hierarchical',
-                         '--CFLAGS', "'-pipe -DCPP_MACRO=cplusplus -time'",
+                         '--CFLAGS', "'-pipe -DCPP_MACRO=cplusplus '",
                          '--make cmake',
                          ($Self->{vltmt} ? ' --threads 6' : '')],
     );

--- a/test_regress/t/t_hier_block_nohier.pl
+++ b/test_regress/t/t_hier_block_nohier.pl
@@ -23,7 +23,7 @@ compile(
     v_flags2 => ['t/t_hier_block.cpp'],
     verilator_flags2 => ['--stats',
                          '+define+USE_VLT', 't/t_hier_block_vlt.vlt',
-                         '--CFLAGS', '"-pipe -DCPP_MACRO=cplusplus -time"',
+                         '--CFLAGS', '"-pipe -DCPP_MACRO=cplusplus"',
                          ($Self->{vltmt} ? ' --threads 6' : '')],
     );
 

--- a/test_regress/t/t_hier_block_prot_lib.pl
+++ b/test_regress/t/t_hier_block_prot_lib.pl
@@ -31,7 +31,7 @@ while (1) {
                 "PROTECT_KEY",
                 "t/t_hier_block.v",
                 "-DAS_PROT_LIB",
-                '--CFLAGS', '"-pipe -DCPP_MACRO=cplusplus -time"',
+                '--CFLAGS', '"-pipe -DCPP_MACRO=cplusplus"',
                 $Self->{vltmt} ? ' --threads 1' : '',
                 "--build"],
         verilator_run => 1,

--- a/test_regress/t/t_hier_block_sc.pl
+++ b/test_regress/t/t_hier_block_sc.pl
@@ -23,7 +23,7 @@ compile(
                          '--stats',
                          '--hierarchical',
                          ($Self->{vltmt} ? ' --threads 6' : ''),
-                         '--CFLAGS', '"-pipe -DCPP_MACRO=cplusplus -time"'
+                         '--CFLAGS', '"-pipe -DCPP_MACRO=cplusplus"'
     ],
     );
 

--- a/test_regress/t/t_hier_block_vlt.pl
+++ b/test_regress/t/t_hier_block_vlt.pl
@@ -21,7 +21,7 @@ compile(
     verilator_flags2 => ['--stats',
                          '--hierarchical',
                          '+define+USE_VLT', 't/t_hier_block_vlt.vlt',
-                         '--CFLAGS', '"-pipe -DCPP_MACRO=cplusplus -time"',
+                         '--CFLAGS', '"-pipe -DCPP_MACRO=cplusplus"',
                          ($Self->{vltmt} ? ' --threads 6' : '')],
     );
 


### PR DESCRIPTION
Fixes #2517
I installed FreeBSD-12.1 to VM and confirmed the symptom.
The test failed because the archiver used on FreeBSD is not gnu one, so thin-archive is not supported on the platform.
Thin-archive was used to merge multiple .a files, but turns out to be binutils specific.

This PR uses extract and archive options of ar command that are common operation among platforms.

I confirmed t_hier_block_*.pl passed on FreeBSD 12.1 on VM.

-time option is removed not to see warnings from C++ compiler during test.