### PR TITLE
CMake: Unconditionally require C++11 or greater

### DIFF
--- a/verilator-config.cmake.in
+++ b/verilator-config.cmake.in
@@ -312,12 +312,7 @@ function(verilate TARGET)
     "$<$<BOOL:$<TARGET_PROPERTY:VERILATOR_THREADED>>:${VERILATOR_MT_CFLAGS}>"
   )
 
-  # SystemC requires the C++ version to match the library version, avoid setting anything here
-  set(GEN_THREADED $<BOOL:$<TARGET_PROPERTY:VERILATOR_THREADED>>)
-  set(GEN_SYSTEMC $<BOOL:$<TARGET_PROPERTY:VERILATOR_SYSTEMC>>)
-  target_compile_features(${TARGET} PRIVATE
-    $<$<AND:${GEN_THREADED},$<NOT:${GEN_SYSTEMC}>>:cxx_std_11>
-  )
+  target_compile_features(${TARGET} PRIVATE cxx_std_11)
 endfunction()
 
 function(_verilator_find_systemc)


### PR DESCRIPTION
#2514

Previously the CMake stuff only set C++11 mode if threading was set. Now we require it always.
I don't think the SystemC check is needed any more if we're not supporting C++ < 11. CMake will choose the newest C++ version requested if you do e.g. `target_compile_features(my_target PRIVATE cxx_std_17)` elsewhere.
