### PR TITLE
Region visitor

### DIFF
--- a/src/Makefile_obj.in
+++ b/src/Makefile_obj.in
@@ -229,6 +229,7 @@ RAW_OBJS = \
 	V3PreShell.o \
 	V3Premit.o \
 	V3ProtectLib.o \
+	V3Region.o \
 	V3Reloop.o \
 	V3Scope.o \
 	V3Scoreboard.o \

--- a/src/V3AstNodes.cpp
+++ b/src/V3AstNodes.cpp
@@ -87,7 +87,10 @@ const char* AstNodeUOrStructDType::broken() const {
     return nullptr;
 }
 
-void AstNodeStmt::dump(std::ostream& str) const { this->AstNode::dump(str); }
+void AstNodeStmt::dump(std::ostream& str) const {
+    this->AstNode::dump(str);
+    if (!region().isNone()) str << " [" << region() << "]";
+}
 
 void AstNodeCCall::dump(std::ostream& str) const {
     this->AstNodeStmt::dump(str);
@@ -1627,6 +1630,7 @@ void AstCFunc::dump(std::ostream& str) const {
     } else if (isStatic().trueUnknown()) {
         str << " [STATIC]";
     }
+    if (!region().isNone()) str << " [" << region() << "]";
     if (dpiImport()) str << " [DPII]";
     if (dpiExport()) str << " [DPIX]";
     if (dpiExportWrapper()) str << " [DPIXWR]";

--- a/src/V3AstNodes.h
+++ b/src/V3AstNodes.h
@@ -2488,6 +2488,7 @@ public:
         , m_isProgram{program} {}
     ASTNODE_NODE_FUNCS(Module)
     virtual string verilogKwd() const override { return m_isProgram ? "program" : "module"; }
+    bool isProgram() const { return m_isProgram; }
 };
 
 class AstNotFoundModule : public AstNodeModule {

--- a/src/V3AstNodes.h
+++ b/src/V3AstNodes.h
@@ -8557,6 +8557,7 @@ private:
     string m_argTypes;  // Argument types
     string m_ctorInits;  // Constructor sub-class inits
     string m_ifdef;  // #ifdef symbol around this function
+    VRegion m_region;  // Region
     VBoolOrUnknown m_isConst;  // Function is declared const (*this not changed)
     VBoolOrUnknown m_isStatic;  // Function is declared static (no this)
     bool m_dontCombine : 1;  // V3Combine shouldn't compare this func tree, it's special
@@ -8679,6 +8680,8 @@ public:
     void dpiImport(bool flag) { m_dpiImport = flag; }
     bool dpiImportWrapper() const { return m_dpiImportWrapper; }
     void dpiImportWrapper(bool flag) { m_dpiImportWrapper = flag; }
+    void region(const VRegion& flag) { m_region = flag; }
+    VRegion region() const { return m_region; }
     //
     // If adding node accessors, see below emptyBody
     AstNode* argsp() const { return op1p(); }

--- a/src/V3EmitC.cpp
+++ b/src/V3EmitC.cpp
@@ -1218,6 +1218,7 @@ public:
     virtual void visit(AstCFile*) override {}  // Handled outside the Visit class
     virtual void visit(AstCellInline*) override {}  // Handled outside visit (in EmitCSyms)
     virtual void visit(AstCUse*) override {}  // Handled outside the Visit class
+    virtual void visit(AstDelay*) override {}
     // Default
     virtual void visit(AstNode* nodep) override {
         puts(string("\n???? // ") + nodep->prettyTypeName() + "\n");

--- a/src/V3Options.cpp
+++ b/src/V3Options.cpp
@@ -1103,6 +1103,9 @@ void V3Options::parseOptsList(FileLine* fl, const string& optdir, int argc, char
             } else if (onoff(sw, "-stats-vars", flag /*ref*/)) {
                 m_statsVars = flag;
                 m_stats |= flag;
+            } else if (onoff(sw, "-stratified-scheduler",
+                             flag /*ref*/)) {  // Undocumented, experimental
+                m_stratifiedScheduler = flag;
             } else if (onoff(sw, "-structs-unpacked", flag /*ref*/)) {
                 m_structsPacked = flag;
             } else if (!strcmp(sw, "-sv")) {

--- a/src/V3Options.h
+++ b/src/V3Options.h
@@ -303,6 +303,7 @@ private:
     bool m_relativeIncludes = false; // main switch: --relative-includes
     bool m_reportUnoptflat = false; // main switch: --report-unoptflat
     bool m_savable = false;         // main switch: --savable
+    bool m_stratifiedScheduler = false; // main switch: --stratified-scheduler
     bool m_structsPacked = true;    // main switch: --structs-packed
     bool m_systemC = false;         // main switch: --sc: System C instead of simple C++
     bool m_stats = false;           // main switch: --stats
@@ -454,6 +455,7 @@ public:
     bool savable() const { return m_savable; }
     bool stats() const { return m_stats; }
     bool statsVars() const { return m_statsVars; }
+    bool stratifiedScheduler() const { return m_stratifiedScheduler; }
     bool structsPacked() const { return m_structsPacked; }
     bool assertOn() const { return m_assert; }  // assertOn as __FILE__ may be defined
     bool autoflush() const { return m_autoflush; }

--- a/src/V3Region.cpp
+++ b/src/V3Region.cpp
@@ -1,0 +1,95 @@
+// -*- mode: C++; c-file-style: "cc-mode" -*-
+//*************************************************************************
+// DESCRIPTION: Verilator: Assigning statements to regions
+//
+//*************************************************************************
+// V3Region's Transformations:
+//
+//  Adds region information to nodes
+//
+//*************************************************************************
+
+#include "config_build.h"
+#include "verilatedos.h"
+
+#include "V3Global.h"
+#include "V3Region.h"
+#include "V3Ast.h"
+
+#include <map>
+
+class RegionVisitor : public AstNVisitor {
+    bool m_inReactive = false;
+
+private:
+    void markStmt(AstNodeStmt* nodep, bool inactive = false) {
+        if (inactive)
+            nodep->region(m_inReactive ? VRegion::REINACTIVE : VRegion::INACTIVE);
+        else
+            nodep->region(m_inReactive ? VRegion::REACTIVE : VRegion::ACTIVE);
+    }
+
+    // VISITORS
+    virtual void visit(AstModule* nodep) override {
+        m_inReactive = nodep->isProgram();
+        iterateChildren(nodep);
+        m_inReactive = false;
+    }
+
+    virtual void visit(AstNodeProcedure* nodep) override {
+        iterateChildren(nodep);
+    }
+
+    virtual void visit(AstNodeFTask* nodep) override {
+        iterateChildren(nodep);
+    }
+
+    virtual void visit(AstAssignDly* nodep) override {
+        nodep->region(m_inReactive ? VRegion::RENBA : VRegion::NBA);
+        iterateChildren(nodep);
+    }
+
+    virtual void visit(AstNodeCoverOrAssert* nodep) override {
+        if (nodep->immediate()) {
+            markStmt(nodep);
+            iterateChildren(nodep);
+            return;
+        }
+        nodep->region(VRegion::OBSERVED);
+        const AstAssert* assertp = VN_CAST(nodep, Assert);
+        VL_RESTORER(m_inReactive);
+        if (assertp) m_inReactive = true;
+        iterateChildren(nodep);
+    }
+
+    virtual void visit(AstNodeStmt* nodep) override {
+        markStmt(nodep);
+        iterateChildren(nodep);
+    }
+
+    virtual void visit(AstDelay* nodep) override {
+        const AstConst* constp = VN_CAST(nodep->lhsp(), Const);
+        UASSERT_OBJ(constp, nodep, "Delay value isn't a constant!");
+
+        bool inactive = (constp->toUInt() == 0);
+        markStmt(nodep, inactive);
+    }
+
+    virtual void visit(AstNode* nodep) override { iterateChildren(nodep); }
+
+public:
+    // CONSTRUCTORS
+    explicit RegionVisitor(AstNetlist* nodep) {
+        iterateChildren(nodep);
+        V3Global::dumpCheckGlobalTree("region", 0, v3Global.opt.dumpTreeLevel(__FILE__) >= 3);
+    }
+    virtual ~RegionVisitor() {}
+};
+
+//######################################################################
+// Region class functions
+
+void V3Region::assignRegions(AstNetlist* nodep) {
+    UINFO(2, __FUNCTION__ << ": " << endl);
+    RegionVisitor visitor(nodep);
+}

--- a/src/V3Region.h
+++ b/src/V3Region.h
@@ -1,0 +1,20 @@
+// -*- mode: C++; c-file-style: "cc-mode" -*-
+
+#ifndef _V3REGION_H_
+#define _V3REGION_H_ 1
+
+#include "config_build.h"
+#include "verilatedos.h"
+
+#include "V3Error.h"
+#include "V3Ast.h"
+
+//============================================================================
+
+class V3Region {
+public:
+    // CONSTRUCTORS
+    static void assignRegions(AstNetlist* nodep);
+};
+
+#endif  // Guard

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -557,8 +557,10 @@ private:
             VL_DO_DANGLING(pushDeletep(nodep->unlinkFrBack()), nodep);
             return;
         }
-        nodep->v3warn(STMTDLY, "Unsupported: Ignoring delay on this delayed statement.");
-        VL_DO_DANGLING(pushDeletep(nodep->unlinkFrBack()), nodep);
+        if (!v3Global.opt.stratifiedScheduler()) {
+            nodep->v3warn(STMTDLY, "Unsupported: Ignoring delay on this delayed statement.");
+            VL_DO_DANGLING(pushDeletep(nodep->unlinkFrBack()), nodep);
+        }
     }
     virtual void visit(AstFork* nodep) override {
         if (VN_IS(m_ftaskp, Func) && !nodep->joinType().joinNone()) {

--- a/src/Verilator.cpp
+++ b/src/Verilator.cpp
@@ -75,6 +75,7 @@
 #include "V3PreShell.h"
 #include "V3Premit.h"
 #include "V3ProtectLib.h"
+#include "V3Region.h"
 #include "V3Reloop.h"
 #include "V3Scope.h"
 #include "V3Scoreboard.h"
@@ -186,6 +187,9 @@ static void process() {
     // Signal based lint checks, no change to structures
     // Must be before first constification pass drops dead code
     V3Undriven::undrivenAll(v3Global.rootp());
+
+    // Add region information to nodes
+    if (v3Global.opt.stratifiedScheduler()) V3Region::assignRegions(v3Global.rootp());
 
     // Assertion insertion
     //    After we've added block coverage, but before other nasty transforms


### PR DESCRIPTION
This PR contains expanded region visitor from #2464

This visitor should now support:
- ordinary statements (Active/Reactive)
- zero delays `#0` (Inactive/ReInactive)
- nonblocking assignments (NBA/ReNBA)
- `assert property` (Observed+Reactive region group)

Region information should be also correctly assigned to inlined functions (thanks to modifications in V3Task) and to function calls when code was not inlined.

I think this should cover statements currenlty represented in the Ast but feel free to point out anything that I might have overlooked.