### PR TITLE
First attempt at |=> support

### DIFF
--- a/Changes
+++ b/Changes
@@ -27,6 +27,8 @@ The contributors that suggested a given feature are shown in []. Thanks!
 
 ****  Add support for assume property. [Peter Monsson]
 
+****  Add support for |=> inside properties (#1292). [Peter Monsson]
+
 
 * Verilator 4.040 2020-08-15
 

--- a/src/V3AssertPre.cpp
+++ b/src/V3AssertPre.cpp
@@ -137,6 +137,29 @@ private:
         VL_DO_DANGLING(pushDeletep(nodep), nodep);
     }
 
+    virtual void visit(AstImplication* nodep) override {
+        if (nodep->sentreep()) return;  // Already processed
+        iterateChildren(nodep);
+
+	FileLine* fl = nodep->fileline();
+        AstNode* rhsp = nodep->rhsp()->unlinkFrBack();
+        AstNode* lhsp = nodep->lhsp()->unlinkFrBack();
+
+	if (VN_IS(nodep->abovep(), PropClocked)) {
+	    printf("This never happens?");
+	}
+	
+	AstNode* past = new AstPast(fl, lhsp, nullptr);
+        past->dtypeFrom(lhsp);
+        AstNode* exprp = new AstOr(fl,
+				   new AstNot(fl, past),
+				   rhsp);
+        exprp->dtypeSetLogicBool();
+        nodep->replaceWith(exprp);
+        nodep->sentreep(newSenTree(nodep));
+        VL_DO_DANGLING(pushDeletep(nodep), nodep);
+    }
+    
     virtual void visit(AstPropClocked* nodep) override {
         // No need to iterate the body, once replace will get iterated
         iterateAndNextNull(nodep->sensesp());

--- a/src/V3AssertPre.cpp
+++ b/src/V3AssertPre.cpp
@@ -39,6 +39,8 @@ private:
     AstSenItem* m_senip = nullptr;  // Last sensitivity
     // Reset each always:
     AstSenItem* m_seniAlwaysp = nullptr;  // Last sensitivity in always
+    // Reset each assertion:
+    AstNode* m_disablep = nullptr;  // Last disable
 
     // METHODS
     VL_DEBUG_FUNC;  // Declare debug()
@@ -58,7 +60,10 @@ private:
         }
         return newp;
     }
-    void clearAssertInfo() { m_senip = nullptr; }
+    void clearAssertInfo() {
+        m_senip = nullptr;
+        m_disablep = nullptr;
+    }
 
     // VISITORS
     //========== Statements
@@ -130,7 +135,7 @@ private:
         AstNode* past = new AstPast(fl, exprp, nullptr);
         past->dtypeFrom(exprp);
         exprp = new AstEq(fl, past,
-                          exprp->cloneTree(false));  // new AstVarRef(fl, exprp, true)
+                          exprp->cloneTree(false));
         exprp->dtypeSetLogicBool();
         nodep->replaceWith(exprp);
         nodep->sentreep(newSenTree(nodep));
@@ -139,27 +144,22 @@ private:
 
     virtual void visit(AstImplication* nodep) override {
         if (nodep->sentreep()) return;  // Already processed
-        iterateChildren(nodep);
 
-	FileLine* fl = nodep->fileline();
+        FileLine* fl = nodep->fileline();
         AstNode* rhsp = nodep->rhsp()->unlinkFrBack();
         AstNode* lhsp = nodep->lhsp()->unlinkFrBack();
 
-	if (VN_IS(nodep->abovep(), PropClocked)) {
-	    printf("This never happens?");
-	}
-	
-	AstNode* past = new AstPast(fl, lhsp, nullptr);
+        if (m_disablep) { lhsp = new AstAnd(fl, new AstNot(fl, m_disablep), lhsp); }
+
+        AstNode* past = new AstPast(fl, lhsp, nullptr);
         past->dtypeFrom(lhsp);
-        AstNode* exprp = new AstOr(fl,
-				   new AstNot(fl, past),
-				   rhsp);
+        AstNode* exprp = new AstOr(fl, new AstNot(fl, past), rhsp);
         exprp->dtypeSetLogicBool();
         nodep->replaceWith(exprp);
         nodep->sentreep(newSenTree(nodep));
         VL_DO_DANGLING(pushDeletep(nodep), nodep);
     }
-    
+
     virtual void visit(AstPropClocked* nodep) override {
         // No need to iterate the body, once replace will get iterated
         iterateAndNextNull(nodep->sensesp());
@@ -168,6 +168,7 @@ private:
         // Block is the new expression to evaluate
         AstNode* blockp = nodep->propp()->unlinkFrBack();
         if (nodep->disablep()) {
+            m_disablep = nodep->disablep()->cloneTree(false);
             if (VN_IS(nodep->backp(), Cover)) {
                 blockp = new AstAnd(
                     nodep->disablep()->fileline(),

--- a/src/V3AstNodes.h
+++ b/src/V3AstNodes.h
@@ -8235,6 +8235,32 @@ public:
     void isDefault(bool flag) { m_default = flag; }
 };
 
+class AstImplication : public AstNodeMath {
+    // Verilog |-> |=>
+    // Parents: math
+    // Children: expression
+public:
+    AstImplication(FileLine* fl, AstNode* lhs, AstNode* rhs)
+        : ASTGEN_SUPER(fl) {
+        setOp1p(lhs);
+        setOp2p(rhs);
+    }
+    ASTNODE_NODE_FUNCS(Implication)
+    virtual string emitVerilog() override { V3ERROR_NA_RETURN(""); }
+    virtual string emitC() override { V3ERROR_NA_RETURN(""); }
+    virtual string emitSimpleOperator() override { V3ERROR_NA_RETURN(""); }
+    virtual bool cleanOut() const override { V3ERROR_NA_RETURN(""); }
+    virtual int instrCount() const override { return widthInstrs(); }
+    AstNode* lhsp() const { return op1p(); }
+    AstNode* rhsp() const { return op2p(); }
+    void lhsp(AstNode* nodep) { return setOp1p(nodep); }
+    void rhsp(AstNode* nodep) { return setOp2p(nodep); }
+    AstSenTree* sentreep() const { return VN_CAST(op4p(), SenTree); }  // op4 = clock domain
+    void sentreep(AstSenTree* sentreep) { addOp4p(sentreep); }  // op4 = clock domain
+    virtual V3Hash sameHash() const override { return V3Hash(); }
+    virtual bool same(const AstNode* samep) const override { return true; }
+};
+
 //======================================================================
 // Assertions
 

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -1103,7 +1103,7 @@ private:
             nodep->dtypeSetLogicBool();
         }
     }
-    
+
     virtual void visit(AstRand* nodep) override {
         if (m_vup->prelim()) {
             nodep->dtypeSetSigned32();  // Says the spec

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -1096,6 +1096,14 @@ private:
         }
     }
 
+    virtual void visit(AstImplication* nodep) override {
+        if (m_vup->prelim()) {
+            iterateCheckBool(nodep, "LHS", nodep->lhsp(), BOTH);
+            iterateCheckBool(nodep, "RHS", nodep->rhsp(), BOTH);
+            nodep->dtypeSetLogicBool();
+        }
+    }
+    
     virtual void visit(AstRand* nodep) override {
         if (m_vup->prelim()) {
             nodep->dtypeSetSigned32();  // Says the spec

--- a/src/verilog.y
+++ b/src/verilog.y
@@ -5267,8 +5267,7 @@ pexpr<nodep>:  // IEEE: property_expr  (The name pexpr is important as regexps j
 	//UNSUP: This rule has been super-specialized to what is supported now
 	//UNSUP remove below
 		expr yP_ORMINUSGT pexpr			{ $$ = new AstLogOr($2, new AstLogNot($2, $1), $3); }
-	|	expr yP_OREQGT pexpr			{ $$ = new AstImplication($2, $1, $3); } // This handles disable iff in the past time step incorrectly
-//	|	expr yP_OREQGT pexpr			{ $$ = new AstLogOr($2, new AstLogNot($2, new AstPast($2, $1, nullptr)), $3); } // This handles disable iff in the past time step incorrectly
+	|	expr yP_OREQGT pexpr			{ $$ = new AstImplication($2, $1, $3); }
 	|	expr					{ $$ = $1; }
 	//UNSUP remove above, use below:
 	//

--- a/src/verilog.y
+++ b/src/verilog.y
@@ -5267,7 +5267,8 @@ pexpr<nodep>:  // IEEE: property_expr  (The name pexpr is important as regexps j
 	//UNSUP: This rule has been super-specialized to what is supported now
 	//UNSUP remove below
 		expr yP_ORMINUSGT pexpr			{ $$ = new AstLogOr($2, new AstLogNot($2, $1), $3); }
-	//UNSUP	expr yP_OREQGT pexpr			{ $$ = new AstLogOr($2, new AstLogNot($2, new AstPast($2, $1, nullptr)), $3); } // This handles disable iff in the past time step incorrectly
+	|	expr yP_OREQGT pexpr			{ $$ = new AstImplication($2, $1, $3); } // This handles disable iff in the past time step incorrectly
+//	|	expr yP_OREQGT pexpr			{ $$ = new AstLogOr($2, new AstLogNot($2, new AstPast($2, $1, nullptr)), $3); } // This handles disable iff in the past time step incorrectly
 	|	expr					{ $$ = $1; }
 	//UNSUP remove above, use below:
 	//

--- a/test_regress/t/t_assert_implication.v
+++ b/test_regress/t/t_assert_implication.v
@@ -55,4 +55,9 @@ module Test
      0 |-> 1
    );
 
+   assert property (
+     @(posedge clk)
+     0 |=> 1
+   );
+
 endmodule

--- a/test_regress/t/t_assert_implication.v
+++ b/test_regress/t/t_assert_implication.v
@@ -14,11 +14,13 @@ module t (/*AUTOARG*/
 
    Test test (/*AUTOINST*/
               // Inputs
-              .clk                      (clk));
+              .clk(clk),
+              .cyc(cyc));
 
    always @ (posedge clk) begin
       if (cyc!=0) begin
          cyc <= cyc + 1;
+	 $display("cyc=%0d", cyc);
          if (cyc==10) begin
             $write("*-* All Finished *-*\n");
             $finish;
@@ -30,7 +32,8 @@ endmodule
 
 module Test
   (
-   input clk
+   input clk,
+   input integer cyc
    );
 
 `ifdef FAIL_ASSERT_1
@@ -55,9 +58,17 @@ module Test
      0 |-> 1
    );
 
+   // Test correct handling of time step in |=>
    assert property (
      @(posedge clk)
-     0 |=> 1
+     cyc > 2 |=> cyc > 3
    );
+
+   // Test correct handling of disable iff in |=>
+   assert property (
+     @(posedge clk) disable iff (cyc < 3)
+     1 |=> cyc > 3
+   );
+
 
 endmodule

--- a/test_regress/t/t_assert_implication.v
+++ b/test_regress/t/t_assert_implication.v
@@ -20,7 +20,7 @@ module t (/*AUTOARG*/
    always @ (posedge clk) begin
       if (cyc!=0) begin
          cyc <= cyc + 1;
-	 $display("cyc=%0d", cyc);
+         $display("cyc=%0d", cyc);
          if (cyc==10) begin
             $write("*-* All Finished *-*\n");
             $finish;

--- a/test_regress/t/t_assert_implication.v
+++ b/test_regress/t/t_assert_implication.v
@@ -20,7 +20,9 @@ module t (/*AUTOARG*/
    always @ (posedge clk) begin
       if (cyc!=0) begin
          cyc <= cyc + 1;
+`ifdef TEST_VERBOSE
          $display("cyc=%0d", cyc);
+`endif
          if (cyc==10) begin
             $write("*-* All Finished *-*\n");
             $finish;
@@ -41,8 +43,35 @@ module Test
      @(posedge clk)
      1 |-> 0
    ) else $display("[%0t] wrong implication", $time);
+
+   assert property (
+     @(posedge clk)
+     1 |=> 0
+   ) else $display("[%0t] wrong implication", $time);
+
+   assert property (
+     @(posedge clk)
+     cyc%3==1 |=> cyc%3==1
+   ) else $display("[%0t] wrong implication (step)", $time);
+
+   assert property (
+     @(posedge clk)
+     cyc%3==1 |=> cyc%3==0
+   ) else $display("[%0t] wrong implication (step)", $time);
+
+   assert property (
+     @(posedge clk) disable iff (cyc == 3)
+     (cyc == 4) |=> 0
+   ) else $display("[%0t] wrong implication (disable)", $time);
+
+   assert property (
+     @(posedge clk) disable iff (cyc == 6)
+     (cyc == 4) |=> 0
+   ) else $display("[%0t] wrong implication (disable)", $time);
+
 `endif
 
+   // Test |->
    assert property (
      @(posedge clk)
      1 |-> 1
@@ -58,17 +87,44 @@ module Test
      0 |-> 1
    );
 
+   // Test |=>
+   assert property (
+     @(posedge clk)
+     1 |=> 1
+   );
+
+   assert property (
+     @(posedge clk)
+     0 |=> 0
+   );
+
+   assert property (
+     @(posedge clk)
+     0 |=> 1
+   );
+
    // Test correct handling of time step in |=>
    assert property (
      @(posedge clk)
-     cyc > 2 |=> cyc > 3
+     cyc%3==1 |=> cyc%3==2
    );
 
-   // Test correct handling of disable iff in |=>
+   // Test correct handling of disable iff
    assert property (
      @(posedge clk) disable iff (cyc < 3)
      1 |=> cyc > 3
    );
 
+   // Test correct handling of disable iff in current cycle
+   assert property (
+     @(posedge clk) disable iff (cyc == 4)
+     (cyc == 4) |=> 0
+   );
+
+   // Test correct handling of disable iff in previous cycle
+   assert property (
+     @(posedge clk) disable iff (cyc == 5)
+     (cyc == 4) |=> 0
+   );
 
 endmodule


### PR DESCRIPTION
I am trying to close #1292, but I am a bit stuck in the V3AssertPre stage. I want to be able to access the parent AstPropClocked and in particular the disablep() member, but it doesn't appear to be present. Maybe it is already lowered into an expression? 

I don't have an intuitive feel for how the visitor moves through the AST. Can you suggest an approach to access the disablep() method?

Thanks in advance.

(This is not meant to be merged, only meant to show my current work)

Snippets from the debug tree:

Const:
    1:2: ASSERT 0x7fffefc69660 <e206> {d58ae}
    1:2:1: PROPCLOCKED 0x7fffefc69550 <e302> {d59ag} @dt=0x7fffefc10940@(G/w1)
    1:2:1:1: SENITEM 0x7fffefc68b90 <e187> {d59ai} [POS]
    1:2:1:1:1: VARREF 0x7fffefc6abc0 <e301> {d59aq} @dt=0x7fffefc10940@(G/w1)  clk [RV] <- VAR 0x7fffefc65710 <e289> {d33ak} @dt=0x7fffefc10940@(G/w1)  clk INPUT [VSTATIC]  PORT
    1:2:1:3: IMPLICATION 0x7fffefc69490 <e300> {d60ai} @dt=0x7fffefc10940@(G/w1)
    1:2:1:3:1: CONST 0x7fffefc61020 <e455#> {d60ag} @dt=0x7fffefc62de0@(G/sw32)  32'sh0
    1:2:1:3:2: CONST 0x7fffefc612b0 <e465#> {d60am} @dt=0x7fffefc62de0@(G/sw32)  32'sh1


AssertPre:
    1:2: ASSERT 0x7fffefc69660 <e206> {d58ae}
    1:2:1: OR 0x7fffefc6f140 <e590#> {d60ai} @dt=0x7fffefc6f200@(G/nw1)
    1:2:1:1: NOT 0x7fffefc6f080 <e582#> {d60ai} @dt=0x7fffefc62de0@(G/sw32)
    1:2:1:1:1: PAST 0x7fffefc6efc0 <e580#> {d60ai} @dt=0x7fffefc62de0@(G/sw32)
    1:2:1:1:1:1: CONST 0x7fffefc61020 <e575#> {d60ag} @dt=0x7fffefc62de0@(G/sw32)  32'sh0
    1:2:1:1:1:4: SENTREE 0x7fffefc6f7b0 <e592#> {d60ai}
    1:2:1:1:1:4:1: SENITEM 0x7fffefc6f5d0 <e187> {d59ai} [POS]
    1:2:1:1:1:4:1:1: VARREF 0x7fffefc6f690 <e301> {d59aq} @dt=0x7fffefc10940@(G/w1)  clk [RV] <- VAR 0x7fffefc65710 <e289> {d33ak} @dt=0x7fffefc10940@(G/w1)  clk INPUT [VSTATIC]  PORT
    1:2:1:2: CONST 0x7fffefc612b0 <e583#> {d60am} @dt=0x7fffefc62de0@(G/sw32)  32'sh1
    1:2:2: SENTREE 0x7fffefc6fa50 <e593#> {d58ae}
    1:2:2:1: SENITEM 0x7fffefc6f870 <e187> {d59ai} [POS]
    1:2:2:1:1: VARREF 0x7fffefc6f930 <e301> {d59aq} @dt=0x7fffefc10940@(G/w1)  clk [RV] <- VAR 0x7fffefc65710 <e289> {d33ak} @dt=0x7fffefc10940@(G/w1)  clk INPUT [VSTATIC]  PORT

 