### PR TITLE
Fix the problem that cmake-based verilated build was rerunning verilator every time

### DIFF
--- a/verilator-config.cmake.in
+++ b/verilator-config.cmake.in
@@ -221,14 +221,7 @@ function(verilate TARGET)
                           ${${VERILATE_PREFIX}_CLASSES_SLOW}
                           ${${VERILATE_PREFIX}_SUPPORT_FAST}
                           ${${VERILATE_PREFIX}_SUPPORT_SLOW})
-  foreach(GENERATED_C_SOURCE ${GENERATED_C_SOURCES})
-    get_filename_component(C_OUTPUT_NAME_WE "${GENERATED_C_SOURCE}" NAME_WE)
-    if(C_OUTPUT_NAME_WE MATCHES ".*Trace.*")
-      continue()
-    endif()
-    list(APPEND GENERATED_H_SOURCES "${VDIR}/${C_OUTPUT_NAME_WE}.h")
-  endforeach()
-  set(GENERATED_SOURCES ${GENERATED_C_SOURCES} ${GENERATED_H_SOURCES})
+  set(GENERATED_SOURCES ${GENERATED_C_SOURCES})
 
   add_custom_command(OUTPUT ${GENERATED_SOURCES} "${VCMAKE}"
                      COMMAND ${VERILATOR_COMMAND}


### PR DESCRIPTION
The root problem was that cmake's custom command was given a list of output
files with non-existent .h file names. cmake was rerunning verilator every time
expecting to build these files and they were never built.

Resolution: remove header files from the list of output files because .cpp files
and .h files are always either all outdated, or all up-to-date. Having header
files in the list of outputs doesn't have any practical benefit.

We appreciate your contributing to Verilator.  If this is your first commit, please add your name to docs/CONTRIBUTORS, and read our contributing guidelines in docs/CONTRIBUTING.adoc.
