### PR TITLE
Dynamic scheduling visitor

### DIFF
--- a/nodist/parse-ast
+++ b/nodist/parse-ast
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+
+import re
+import argparse
+import termcolor
+
+parser = argparse.ArgumentParser()
+
+parser.add_argument("-i", "--input", help="Input AST dump")
+parser.add_argument("-o", "--output", help="HTML output")
+parser.add_argument("-f", "--fill", help="Propagate region data to lower nodes lacking region info", action='store_true')
+
+args = parser.parse_args()
+
+regions = {
+    'ACTIVE': ('#E74C3C', 'white'),
+    'INACTIVE': ('#8E44AD', 'red'),
+    'NBA': ('#3498DB', 'green'),
+    'OBSERVED': ('#16A085', 'yellow'),
+    'REACTIVE': ('#2ECC71', 'blue'),
+    'REINACTIVE': ('#F39C12', 'magenta'),
+    'RENBA': ('#D35400', 'cyan'),
+}
+
+sched_variants = {
+    'STATIC-SCHED': ('#1D8348', 'green'),
+    'DYNAMIC-SCHED': ('#B03A2E', 'red'),
+}
+
+def_color = ('#7F8C8D', 'grey')
+
+if args.output:
+    html = open(args.output, 'w')
+else:
+    html = None
+
+last_region = None
+last_region_depth = 0
+
+with open(args.input, 'r') as tree:
+    for line in tree:
+        line = line.rstrip()
+        region = None
+        sched = None
+
+        for key in regions:
+            if re.search(r"\[{}\]".format(key), line):
+                region = key
+
+        for key in sched_variants:
+            if re.search(r"\[{}\]".format(key), line):
+                sched = key
+
+        if args.fill:
+            depth = re.match("[:0-3]+", line.strip())
+            if depth:
+                depth = depth.group(0).count(":")
+
+                if last_region_depth < depth and region is None:
+                    region = last_region
+                else:
+                    last_region_depth = depth
+                    last_region = region
+
+        if region:
+            color = regions[region]
+        else:
+            color = def_color
+
+        if html:
+            html.write('<div style="background-color:{}">'.format(color[0]))
+            if sched is not None:
+                html.write('<div style="background-color:{}; display: inline">{} </div>'.format(sched_variants[sched][0], sched))
+            if region is not None:
+                html.write('<div style="display: inline">{}: </div>'.format(region))
+            html.write('<div style="display: inline">')
+            html.write(line)
+            html.write('</div>')
+            html.write('</div>\n')
+        else:
+            if sched is not None:
+                termcolor.cprint(sched, sched_variants[sched][1], end=' ')
+            if region is not None:
+                termcolor.cprint(region, color[1], end=': ')
+            termcolor.cprint(line, color[1])

--- a/src/Makefile_obj.in
+++ b/src/Makefile_obj.in
@@ -229,6 +229,7 @@ RAW_OBJS = \
 	V3PreShell.o \
 	V3Premit.o \
 	V3ProtectLib.o \
+	V3Region.o \
 	V3Reloop.o \
 	V3Scope.o \
 	V3Scoreboard.o \

--- a/src/Makefile_obj.in
+++ b/src/Makefile_obj.in
@@ -181,6 +181,7 @@ RAW_OBJS = \
 	V3Depth.o \
 	V3DepthBlock.o \
 	V3Descope.o \
+	V3Dynamic.o \
 	V3EmitC.o \
 	V3EmitCInlines.o \
 	V3EmitCSyms.o \

--- a/src/V3Ast.cpp
+++ b/src/V3Ast.cpp
@@ -77,6 +77,7 @@ AstNode::AstNode(AstType t, FileLine* fl)
     m_didWidth = false;
     m_doingWidth = false;
     m_protect = true;
+    m_dynamic = false;
     m_user1u = VNUser(0);
     m_user1Cnt = 0;
     m_user2u = VNUser(0);

--- a/src/V3Ast.h
+++ b/src/V3Ast.h
@@ -1456,6 +1456,7 @@ class AstNode {
     bool m_didWidth : 1;  // Did V3Width computation
     bool m_doingWidth : 1;  // Inside V3Width
     bool m_protect : 1;  // Protect name if protection is on
+    bool m_dynamic : 1;  // Needs dynamic scheduling
     //          // Space for more bools here
 
     // This member ordering both allows 64 bit alignment and puts associated data together
@@ -1563,6 +1564,9 @@ public:
     bool brokeExists() const;
     bool brokeExistsAbove() const;
     bool brokeExistsBelow() const;
+
+    bool dynamic() const { return m_dynamic; }
+    void dynamic(const bool flag) { m_dynamic = flag; }
 
     // CONSTRUCTORS
     virtual ~AstNode() {}

--- a/src/V3Ast.h
+++ b/src/V3Ast.h
@@ -2711,6 +2711,8 @@ private:
     bool m_pure : 1;  // DPI import pure (vs. virtual pure)
     bool m_pureVirtual : 1;  // Pure virtual
     bool m_virtual : 1;  // Virtual method in class
+    bool m_dynamicValid : 1;  // Already visited in V3Dynamic visitor
+    bool m_dynamicWeak : 1;  // Weak dynamic flag, discarded after inlining
     VLifetime m_lifetime;  // Lifetime
 public:
     AstNodeFTask(AstType t, FileLine* fl, const string& name, AstNode* stmtsp)
@@ -2730,7 +2732,9 @@ public:
         , m_isConstructor{false}
         , m_pure{false}
         , m_pureVirtual{false}
-        , m_virtual{false} {
+        , m_virtual{false}
+        , m_dynamicValid{false}
+        , m_dynamicWeak{false} {
         addNOp3p(stmtsp);
         cname(name);  // Might be overridden by dpi import/export
     }
@@ -2792,6 +2796,10 @@ public:
     bool pureVirtual() const { return m_pureVirtual; }
     void isVirtual(bool flag) { m_virtual = flag; }
     bool isVirtual() const { return m_virtual; }
+    void isDynamicValid(bool flag) { m_dynamicValid = flag; }
+    bool isDynamicValid() const { return m_dynamicValid; }
+    void isDynamicWeak(bool flag) { m_dynamicWeak = flag; }
+    bool isDynamicWeak() const { return m_dynamicWeak; }
     void lifetime(const VLifetime& flag) { m_lifetime = flag; }
     VLifetime lifetime() const { return m_lifetime; }
 };

--- a/src/V3AstNodes.cpp
+++ b/src/V3AstNodes.cpp
@@ -87,7 +87,10 @@ const char* AstNodeUOrStructDType::broken() const {
     return nullptr;
 }
 
-void AstNodeStmt::dump(std::ostream& str) const { this->AstNode::dump(str); }
+void AstNodeStmt::dump(std::ostream& str) const {
+    this->AstNode::dump(str);
+    if (!region().isNone()) str << " [" << region() << "]";
+}
 
 void AstNodeCCall::dump(std::ostream& str) const {
     this->AstNodeStmt::dump(str);
@@ -1627,6 +1630,7 @@ void AstCFunc::dump(std::ostream& str) const {
     } else if (isStatic().trueUnknown()) {
         str << " [STATIC]";
     }
+    if (!region().isNone()) str << " [" << region() << "]";
     if (dpiImport()) str << " [DPII]";
     if (dpiExport()) str << " [DPIX]";
     if (dpiExportWrapper()) str << " [DPIXWR]";

--- a/src/V3AstNodes.cpp
+++ b/src/V3AstNodes.cpp
@@ -1114,6 +1114,7 @@ void AstClass::dump(std::ostream& str) const {
     this->AstNode::dump(str);
     if (isExtended()) str << " [EXT]";
     if (isVirtual()) str << " [VIRT]";
+    if (isPredefined()) str << " [PRE]";
 }
 AstClass* AstClassExtends::classp() const {
     AstClassRefDType* refp = VN_CAST(dtypep(), ClassRefDType);

--- a/src/V3AstNodes.cpp
+++ b/src/V3AstNodes.cpp
@@ -1038,6 +1038,10 @@ void AstNode::dump(std::ostream& str) const {
             str << "  " << V3OutFormatter::quoteNameControls(name());
         }
     }
+    if (dynamic())
+        str << " [DYNAMIC-SCHED]";
+    else
+        str << " [STATIC-SCHED]";
 }
 
 void AstNodeProcedure::dump(std::ostream& str) const { this->AstNode::dump(str); }

--- a/src/V3AstNodes.h
+++ b/src/V3AstNodes.h
@@ -306,6 +306,7 @@ class AstClass : public AstNodeModule {
     AstClassPackage* m_packagep = nullptr;  // Class package this is under
     bool m_virtual = false;  // Virtual class
     bool m_extended = false;  // Is extension or extended by other classes
+    bool m_predefined = false;  // Is a predefined class
     void insertCache(AstNode* nodep);
 
 public:
@@ -341,6 +342,8 @@ public:
     void isExtended(bool flag) { m_extended = flag; }
     bool isVirtual() const { return m_virtual; }
     void isVirtual(bool flag) { m_virtual = flag; }
+    bool isPredefined() const { return m_predefined; }
+    void isPredefined(bool flag) { m_predefined = flag; }
 };
 
 class AstClassExtends : public AstNode {

--- a/src/V3AstNodes.h
+++ b/src/V3AstNodes.h
@@ -2488,6 +2488,7 @@ public:
         , m_isProgram{program} {}
     ASTNODE_NODE_FUNCS(Module)
     virtual string verilogKwd() const override { return m_isProgram ? "program" : "module"; }
+    bool isProgram() const { return m_isProgram; }
 };
 
 class AstNotFoundModule : public AstNodeModule {

--- a/src/V3AstNodes.h
+++ b/src/V3AstNodes.h
@@ -8557,6 +8557,7 @@ private:
     string m_argTypes;  // Argument types
     string m_ctorInits;  // Constructor sub-class inits
     string m_ifdef;  // #ifdef symbol around this function
+    VRegion m_region;  // Region
     VBoolOrUnknown m_isConst;  // Function is declared const (*this not changed)
     VBoolOrUnknown m_isStatic;  // Function is declared static (no this)
     bool m_dontCombine : 1;  // V3Combine shouldn't compare this func tree, it's special
@@ -8679,6 +8680,8 @@ public:
     void dpiImport(bool flag) { m_dpiImport = flag; }
     bool dpiImportWrapper() const { return m_dpiImportWrapper; }
     void dpiImportWrapper(bool flag) { m_dpiImportWrapper = flag; }
+    void region(const VRegion& flag) { m_region = flag; }
+    VRegion region() const { return m_region; }
     //
     // If adding node accessors, see below emptyBody
     AstNode* argsp() const { return op1p(); }

--- a/src/V3Dynamic.cpp
+++ b/src/V3Dynamic.cpp
@@ -1,0 +1,167 @@
+// -*- mode: C++; c-file-style: "cc-mode" -*-
+//*************************************************************************
+// DESCRIPTION: Verilator: Mark nodes that need dynamic scheduling
+//
+//*************************************************************************
+// V3Dynamic's Transformations:
+//
+//  Set m_dynamic in AstNodeFTask and AstNodeProcedure nodes that
+//  need dynamic scheduling
+//
+//  To qualify for dynamic scheduling at least one of the following must
+//  be true for the node or its subnodes:
+//   - code uses mailbox, semaphore or process variables
+//     (only if the class was not overridden by user defined class)
+//   - task is declared as virtual method
+//   - task is DPI imported
+//   - task contains delays but was not inlined
+//   - task/function contains statements belonging to different regions
+//     (applies to stratified scheduler only)
+//
+//*************************************************************************
+
+#include "config_build.h"
+#include "verilatedos.h"
+
+#include "V3Global.h"
+#include "V3Dynamic.h"
+#include "V3Ast.h"
+
+#include <map>
+
+class DynamicRegionCheckerVisitor : public AstNVisitor {
+private:
+    VRegion m_region = VRegion::NONE;
+    bool m_mixed = false;
+    // VISITORS
+    virtual void visit(AstNodeStmt* nodep) override {
+        if (m_region == VRegion::NONE)
+            m_region = nodep->region();
+        else if (m_region != nodep->region())
+            m_mixed = true;
+    }
+    virtual void visit(AstNode* nodep) override { iterateChildren(nodep); }
+
+public:
+    explicit DynamicRegionCheckerVisitor(AstNodeFTask* nodep) { iterateChildren(nodep); }
+    bool isMixed() const { return m_mixed; }
+};
+
+class DynamicSubtreeVisitor : public AstNVisitor {
+private:
+    bool m_dynamic = false;
+    bool m_dynamicWeak = false;
+    bool m_inTask = false;
+    // VISITORS
+    virtual void
+    visit(AstVarRef* nodep) override {  // Predefined classes (process/mailbox/semaphore)
+        UINFO(4, " Visiting VarRef: " << nodep << endl);
+        if (nodep->varScopep()) {
+            AstClassRefDType* dtypep = VN_CAST(nodep->varScopep()->dtypep(), ClassRefDType);
+            if (dtypep) {
+                UINFO(4, "  ClassRefDType: " << dtypep << endl);
+                AstClass* classp = dtypep->classp();
+                if (classp && classp->isPredefined()) {
+                    const string cname = classp->origName();
+                    if (cname == "mailbox")
+                        m_dynamic = true;
+                    else if (cname == "semaphore")
+                        m_dynamic = true;
+                    else if (cname == "process")
+                        m_dynamic = true;
+                }
+            }
+        }
+        iterateChildren(nodep);
+    }
+
+    virtual void visit(AstNodeFTaskRef* nodep) override {  // Function/Task calls
+        UINFO(4, " Visiting NodeFTaskRef: " << nodep << endl);
+
+        DynamicSubtreeVisitor visitor(nodep->taskp());
+
+        iterateChildren(nodep);
+
+        if (nodep->taskp()->dynamic()) m_dynamic = true;
+    }
+
+    virtual void visit(AstNodeFTask* nodep) override { // We visit this in a separate DynamicSubtreeVisitor
+
+    }
+
+    virtual void visit(AstDelay* nodep) override {  // Tasks that contain delays
+        UINFO(4, " Visiting Delay: " << nodep << endl);
+        if (m_inTask) m_dynamicWeak = true;
+        iterateChildren(nodep);
+    }
+
+    virtual void visit(AstNode* nodep) override { iterateChildren(nodep); }
+
+public:
+    explicit DynamicSubtreeVisitor(AstNodeProcedure* nodep) {
+        iterateChildren(nodep);
+        nodep->dynamic(m_dynamic);
+    }
+
+    explicit DynamicSubtreeVisitor(AstNodeFTask* nodep) {
+        UINFO(4, "  Visiting NodeFTask: " << nodep << endl);
+
+        if (nodep->isDynamicValid()) return; // Don't visit function/task twice
+
+        m_inTask = VN_IS(nodep, Task);
+
+        iterateChildren(nodep);
+
+        if (v3Global.opt.stratifiedScheduler()) {
+            DynamicRegionCheckerVisitor visitor(nodep);
+            if (visitor.isMixed()) {
+                UINFO(4, "Found NodeFTask with mixed regions: " << nodep << endl);
+                m_dynamic = true;
+            }
+        }
+
+        if (nodep->isVirtual()) m_dynamic = true;
+        if (nodep->dpiImport()) m_dynamic = true;
+
+        if (m_dynamic) {
+            nodep->dynamic(true);
+        } else {
+            nodep->isDynamicWeak(m_dynamicWeak);
+        }
+
+        nodep->isDynamicValid(true);
+    }
+
+    virtual ~DynamicSubtreeVisitor() {}
+};
+
+class DynamicVisitor : public AstNVisitor {
+private:
+    // VISITORS
+    virtual void visit(AstNodeProcedure* nodep) override {  // Initial/Always/Final
+        UINFO(4, "Visiting NodeProcedure: " << nodep << endl);
+        // DynamicSubtreeVisitor continues visiting deeper down
+        DynamicSubtreeVisitor visitor(nodep);
+    }
+
+    virtual void visit(AstNodeFTask* nodep) override {  // Function/Task
+        // we visit AstNodeFTasks in DynamicSubtreeVisitor, no need to visit them here
+    }
+
+    virtual void visit(AstNode* nodep) override { iterateChildren(nodep); }
+public:
+    // CONSTRUCTORS
+    explicit DynamicVisitor(AstNetlist* nodep) {
+        iterateChildren(nodep);
+        V3Global::dumpCheckGlobalTree("dynamic", 0, v3Global.opt.dumpTreeLevel(__FILE__) >= 3);
+    }
+    virtual ~DynamicVisitor() {}
+};
+
+//######################################################################
+// Dynamic class functions
+
+void V3Dynamic::markDynamic(AstNetlist* nodep) {
+    UINFO(2, __FUNCTION__ << ": " << endl);
+    DynamicVisitor visitor(nodep);
+}

--- a/src/V3Dynamic.h
+++ b/src/V3Dynamic.h
@@ -1,0 +1,20 @@
+// -*- mode: C++; c-file-style: "cc-mode" -*-
+
+#ifndef _V3DYNAMIC_H_
+#define _V3DYNAMIC_H_ 1
+
+#include "config_build.h"
+#include "verilatedos.h"
+
+#include "V3Error.h"
+#include "V3Ast.h"
+
+//============================================================================
+
+class V3Dynamic {
+public:
+    // CONSTRUCTORS
+    static void markDynamic(AstNetlist* nodep);
+};
+
+#endif  // Guard

--- a/src/V3EmitC.cpp
+++ b/src/V3EmitC.cpp
@@ -1218,6 +1218,7 @@ public:
     virtual void visit(AstCFile*) override {}  // Handled outside the Visit class
     virtual void visit(AstCellInline*) override {}  // Handled outside visit (in EmitCSyms)
     virtual void visit(AstCUse*) override {}  // Handled outside the Visit class
+    virtual void visit(AstDelay*) override {}
     // Default
     virtual void visit(AstNode* nodep) override {
         puts(string("\n???? // ") + nodep->prettyTypeName() + "\n");

--- a/src/V3Options.cpp
+++ b/src/V3Options.cpp
@@ -1103,6 +1103,9 @@ void V3Options::parseOptsList(FileLine* fl, const string& optdir, int argc, char
             } else if (onoff(sw, "-stats-vars", flag /*ref*/)) {
                 m_statsVars = flag;
                 m_stats |= flag;
+            } else if (onoff(sw, "-stratified-scheduler",
+                             flag /*ref*/)) {  // Undocumented, experimental
+                m_stratifiedScheduler = flag;
             } else if (onoff(sw, "-structs-unpacked", flag /*ref*/)) {
                 m_structsPacked = flag;
             } else if (!strcmp(sw, "-sv")) {

--- a/src/V3Options.h
+++ b/src/V3Options.h
@@ -303,6 +303,7 @@ private:
     bool m_relativeIncludes = false; // main switch: --relative-includes
     bool m_reportUnoptflat = false; // main switch: --report-unoptflat
     bool m_savable = false;         // main switch: --savable
+    bool m_stratifiedScheduler = false; // main switch: --stratified-scheduler
     bool m_structsPacked = true;    // main switch: --structs-packed
     bool m_systemC = false;         // main switch: --sc: System C instead of simple C++
     bool m_stats = false;           // main switch: --stats
@@ -454,6 +455,7 @@ public:
     bool savable() const { return m_savable; }
     bool stats() const { return m_stats; }
     bool statsVars() const { return m_statsVars; }
+    bool stratifiedScheduler() const { return m_stratifiedScheduler; }
     bool structsPacked() const { return m_structsPacked; }
     bool assertOn() const { return m_assert; }  // assertOn as __FILE__ may be defined
     bool autoflush() const { return m_autoflush; }

--- a/src/V3Region.cpp
+++ b/src/V3Region.cpp
@@ -1,0 +1,95 @@
+// -*- mode: C++; c-file-style: "cc-mode" -*-
+//*************************************************************************
+// DESCRIPTION: Verilator: Assigning statements to regions
+//
+//*************************************************************************
+// V3Region's Transformations:
+//
+//  Adds region information to nodes
+//
+//*************************************************************************
+
+#include "config_build.h"
+#include "verilatedos.h"
+
+#include "V3Global.h"
+#include "V3Region.h"
+#include "V3Ast.h"
+
+#include <map>
+
+class RegionVisitor : public AstNVisitor {
+    bool m_inReactive = false;
+
+private:
+    void markStmt(AstNodeStmt* nodep, bool inactive = false) {
+        if (inactive)
+            nodep->region(m_inReactive ? VRegion::REINACTIVE : VRegion::INACTIVE);
+        else
+            nodep->region(m_inReactive ? VRegion::REACTIVE : VRegion::ACTIVE);
+    }
+
+    // VISITORS
+    virtual void visit(AstModule* nodep) override {
+        m_inReactive = nodep->isProgram();
+        iterateChildren(nodep);
+        m_inReactive = false;
+    }
+
+    virtual void visit(AstNodeProcedure* nodep) override {
+        iterateChildren(nodep);
+    }
+
+    virtual void visit(AstNodeFTask* nodep) override {
+        iterateChildren(nodep);
+    }
+
+    virtual void visit(AstAssignDly* nodep) override {
+        nodep->region(m_inReactive ? VRegion::RENBA : VRegion::NBA);
+        iterateChildren(nodep);
+    }
+
+    virtual void visit(AstNodeCoverOrAssert* nodep) override {
+        if (nodep->immediate()) {
+            markStmt(nodep);
+            iterateChildren(nodep);
+            return;
+        }
+        nodep->region(VRegion::OBSERVED);
+        const AstAssert* assertp = VN_CAST(nodep, Assert);
+        VL_RESTORER(m_inReactive);
+        if (assertp) m_inReactive = true;
+        iterateChildren(nodep);
+    }
+
+    virtual void visit(AstNodeStmt* nodep) override {
+        markStmt(nodep);
+        iterateChildren(nodep);
+    }
+
+    virtual void visit(AstDelay* nodep) override {
+        const AstConst* constp = VN_CAST(nodep->lhsp(), Const);
+        UASSERT_OBJ(constp, nodep, "Delay value isn't a constant!");
+
+        bool inactive = (constp->toUInt() == 0);
+        markStmt(nodep, inactive);
+    }
+
+    virtual void visit(AstNode* nodep) override { iterateChildren(nodep); }
+
+public:
+    // CONSTRUCTORS
+    explicit RegionVisitor(AstNetlist* nodep) {
+        iterateChildren(nodep);
+        V3Global::dumpCheckGlobalTree("region", 0, v3Global.opt.dumpTreeLevel(__FILE__) >= 3);
+    }
+    virtual ~RegionVisitor() {}
+};
+
+//######################################################################
+// Region class functions
+
+void V3Region::assignRegions(AstNetlist* nodep) {
+    UINFO(2, __FUNCTION__ << ": " << endl);
+    RegionVisitor visitor(nodep);
+}

--- a/src/V3Region.h
+++ b/src/V3Region.h
@@ -1,0 +1,20 @@
+// -*- mode: C++; c-file-style: "cc-mode" -*-
+
+#ifndef _V3REGION_H_
+#define _V3REGION_H_ 1
+
+#include "config_build.h"
+#include "verilatedos.h"
+
+#include "V3Error.h"
+#include "V3Ast.h"
+
+//============================================================================
+
+class V3Region {
+public:
+    // CONSTRUCTORS
+    static void assignRegions(AstNetlist* nodep);
+};
+
+#endif  // Guard

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -557,8 +557,10 @@ private:
             VL_DO_DANGLING(pushDeletep(nodep->unlinkFrBack()), nodep);
             return;
         }
-        nodep->v3warn(STMTDLY, "Unsupported: Ignoring delay on this delayed statement.");
-        VL_DO_DANGLING(pushDeletep(nodep->unlinkFrBack()), nodep);
+        if (!v3Global.opt.stratifiedScheduler()) {
+            nodep->v3warn(STMTDLY, "Unsupported: Ignoring delay on this delayed statement.");
+            VL_DO_DANGLING(pushDeletep(nodep->unlinkFrBack()), nodep);
+        }
     }
     virtual void visit(AstFork* nodep) override {
         if (VN_IS(m_ftaskp, Func) && !nodep->joinType().joinNone()) {

--- a/src/Verilator.cpp
+++ b/src/Verilator.cpp
@@ -41,6 +41,7 @@
 #include "V3Depth.h"
 #include "V3DepthBlock.h"
 #include "V3Descope.h"
+#include "V3Dynamic.h"
 #include "V3EmitC.h"
 #include "V3EmitCMain.h"
 #include "V3EmitCMake.h"
@@ -272,6 +273,11 @@ static void process() {
         // Relocate classes (after linkDot)
         V3Class::classAll(v3Global.rootp());
     }
+
+    //--DYNAMIC SCHEDULING METADATA--------------
+
+    // Determine which parts of the code need dynamic scheduling
+    V3Dynamic::markDynamic(v3Global.rootp());
 
     //--SCOPE BASED OPTIMIZATIONS--------------
 

--- a/src/Verilator.cpp
+++ b/src/Verilator.cpp
@@ -75,6 +75,7 @@
 #include "V3PreShell.h"
 #include "V3Premit.h"
 #include "V3ProtectLib.h"
+#include "V3Region.h"
 #include "V3Reloop.h"
 #include "V3Scope.h"
 #include "V3Scoreboard.h"
@@ -186,6 +187,9 @@ static void process() {
     // Signal based lint checks, no change to structures
     // Must be before first constification pass drops dead code
     V3Undriven::undrivenAll(v3Global.rootp());
+
+    // Add region information to nodes
+    if (v3Global.opt.stratifiedScheduler()) V3Region::assignRegions(v3Global.rootp());
 
     // Assertion insertion
     //    After we've added block coverage, but before other nasty transforms


### PR DESCRIPTION
This visitor expands upon the region visitor (#2532)
It is an initial version of a visitor that will detect blocks of code which need threads based scheduling (as mentioned in the call notes in #2446)

For the moment it detects:
- blocks of code using `mailbox` `semaphore` `process` builtin classes
- tasks declared as `virtual` methods
- DPI imported tasks
- tasks that contain delays but were not inlined
- tasks/functions that contain statements belonging to different regions (this only applies to the stratified scheduler)

After the visitor detects anything from the list above it sets `m_dynamic` of the surrounding `AstNodeProcedure` or `AstNodeFTask` (at this point `AstNode` class contains the `m_dynamic` field but that will be changed once we know which nodes need this information)

Please share any suggestions on what should or what shouldn't be detected as requiring thread based scheduling.

CC: @wsnyder @martin-lueker @tgorochowik 