### PR TITLE
Add timescale directive for hier_block if the original design has it

### DIFF
--- a/test_regress/t/t_hier_block.v
+++ b/test_regress/t/t_hier_block.v
@@ -9,6 +9,10 @@
 `define HIER_BLOCK /*verilator hier_block*/
 `endif
 
+`ifndef PROTLIB_TOP
+`timescale 1ns/1ps
+`endif
+
 interface byte_ifs(input clk);
    logic [7:0] data;
    modport sender(input clk, output data);


### PR DESCRIPTION
Reported in https://github.com/verilator/verilator/issues/2544#issuecomment-693126788

When a module has timescale information, the generated hier_block should also have the same timescale setting otherwise the upper modules that loads a protect-lib of the hier_block would show `%Error-TIMESCALEMOD`.

Test is modified to reproduce the issue in c7fa50eb2fda6c4aec41517fa57d20ee44f13119.
SV wrapper of the protect-lib emits timescale directive only when the wrapper will be used for hierarchical Verilation.
Adding timescale directive here is safe because the wrapper will be loaded only with the original design.

This PR does not change the behavior for protect-lib in general.

 I will send a few more PRs to resolve the issue #2544 (multiple independent issues are found in the report).