### PR TITLE
Add proper delegation to dump methods

### DIFF
--- a/src/V3Ast.h
+++ b/src/V3Ast.h
@@ -1945,6 +1945,7 @@ public:
     AstNode* lhsp() const { return op1p(); }
     void lhsp(AstNode* nodep) { return setOp1p(nodep); }
     // METHODS
+    virtual void dump(std::ostream& str) const override;
     // Set out to evaluation of a AstConst'ed lhs
     virtual void numberOperate(V3Number& out, const V3Number& lhs) = 0;
     virtual bool cleanLhs() const = 0;

--- a/src/V3Ast.h
+++ b/src/V3Ast.h
@@ -2008,6 +2008,7 @@ public:
     void rhsp(AstNode* nodep) { return setOp2p(nodep); }
     void thsp(AstNode* nodep) { return setOp3p(nodep); }
     // METHODS
+    virtual void dump(std::ostream& str) const override;
     // Set out to evaluation of a AstConst'ed
     virtual void numberOperate(V3Number& out, const V3Number& lhs, const V3Number& rhs,
                                const V3Number& ths)

--- a/src/V3Ast.h
+++ b/src/V3Ast.h
@@ -2160,6 +2160,7 @@ public:
     }
     ASTNODE_BASE_FUNCS(NodeProcedure)
     // METHODS
+    virtual void dump(std::ostream& str) const override;
     AstNode* bodysp() const { return op2p(); }  // op2 = Statements to evaluate
     void addStmtp(AstNode* nodep) { addOp2p(nodep); }
     bool isJustOneBodyStmt() const { return bodysp() && !bodysp()->nextp(); }

--- a/src/V3Ast.h
+++ b/src/V3Ast.h
@@ -2889,6 +2889,7 @@ public:
     AstNodeRange(AstType t, FileLine* fl)
         : AstNode{t, fl} {}
     ASTNODE_BASE_FUNCS(NodeRange)
+    virtual void dump(std::ostream& str) const override;
 };
 
 //######################################################################

--- a/src/V3Ast.h
+++ b/src/V3Ast.h
@@ -1907,6 +1907,7 @@ public:
         : AstNode{t, fl} {}
     ASTNODE_BASE_FUNCS(NodeMath)
     // METHODS
+    virtual void dump(std::ostream& str) const override;
     virtual bool hasDType() const override { return true; }
     virtual string emitVerilog() = 0;  /// Format string for verilog writing; see V3EmitV
     // For documentation on emitC format see EmitCStmts::emitOpName

--- a/src/V3Ast.h
+++ b/src/V3Ast.h
@@ -2176,8 +2176,11 @@ public:
     // METHODS
     bool isStatement() const { return m_statement; }  // Really a statement
     void statement(bool flag) { m_statement = flag; }
-    virtual void addNextStmt(AstNode* newp, AstNode* belowp);  // Stop statement searchback here
-    virtual void addBeforeStmt(AstNode* newp, AstNode* belowp);  // Stop statement searchback here
+    virtual void addNextStmt(AstNode* newp,
+                             AstNode* belowp) override;  // Stop statement searchback here
+    virtual void addBeforeStmt(AstNode* newp,
+                               AstNode* belowp) override;  // Stop statement searchback here
+    virtual void dump(std::ostream& str = std::cout) const override;
 };
 
 class AstNodeAssign : public AstNodeStmt {

--- a/src/V3Ast.h
+++ b/src/V3Ast.h
@@ -2304,6 +2304,7 @@ public:
         this->varp(varp);
     }
     ASTNODE_BASE_FUNCS(NodeVarRef)
+    virtual void dump(std::ostream& str) const override;
     virtual bool hasDType() const override { return true; }
     virtual const char* broken() const override;
     virtual int instrCount() const override { return widthInstrs(); }

--- a/src/V3Ast.h
+++ b/src/V3Ast.h
@@ -1930,6 +1930,7 @@ public:
     // See checkTreeIter also that asserts no children
     // cppcheck-suppress functionConst
     void iterateChildren(AstNVisitor& v) {}
+    virtual void dump(std::ostream& str) const override;
 };
 
 class AstNodeUniop : public AstNodeMath {

--- a/src/V3AstNodes.cpp
+++ b/src/V3AstNodes.cpp
@@ -1063,9 +1063,10 @@ string AstBasicDType::prettyDTypeName() const {
 }
 
 void AstNodeMath::dump(std::ostream& str) const { this->AstNode::dump(str); }
+void AstNodeUniop::dump(std::ostream& str) const { this->AstNodeMath::dump(str); }
 
 void AstCCast::dump(std::ostream& str) const {
-    this->AstNode::dump(str);
+    this->AstNodeUniop::dump(str);
     str << " sz" << size();
 }
 void AstCell::dump(std::ostream& str) const {
@@ -1256,7 +1257,7 @@ void AstTimeD::dump(std::ostream& str) const {
     str << " " << timeunit();
 }
 void AstTimeImport::dump(std::ostream& str) const {
-    this->AstNode::dump(str);
+    this->AstNodeUniop::dump(str);
     str << " " << timeunit();
 }
 void AstTypedef::dump(std::ostream& str) const {

--- a/src/V3AstNodes.cpp
+++ b/src/V3AstNodes.cpp
@@ -1245,12 +1245,14 @@ void AstPrintTimeScale::dump(std::ostream& str) const {
     this->AstNodeStmt::dump(str);
     str << " " << timeunit();
 }
+
+void AstNodeTermop::dump(std::ostream& str) const { this->AstNodeMath::dump(str); }
 void AstTime::dump(std::ostream& str) const {
-    this->AstNode::dump(str);
+    this->AstNodeTermop::dump(str);
     str << " " << timeunit();
 }
 void AstTimeD::dump(std::ostream& str) const {
-    this->AstNode::dump(str);
+    this->AstNodeTermop::dump(str);
     str << " " << timeunit();
 }
 void AstTimeImport::dump(std::ostream& str) const {

--- a/src/V3AstNodes.cpp
+++ b/src/V3AstNodes.cpp
@@ -1037,8 +1037,10 @@ void AstNode::dump(std::ostream& str) const {
     }
 }
 
+void AstNodeProcedure::dump(std::ostream& str) const { this->AstNode::dump(str); }
+
 void AstAlways::dump(std::ostream& str) const {
-    this->AstNode::dump(str);
+    this->AstNodeProcedure::dump(str);
     if (keyword() != VAlwaysKwd::ALWAYS) str << " [" << keyword().ascii() << "]";
 }
 

--- a/src/V3AstNodes.cpp
+++ b/src/V3AstNodes.cpp
@@ -1439,8 +1439,9 @@ void AstVarScope::dump(std::ostream& str) const {
         str << " ->UNLINKED";
     }
 }
+void AstNodeVarRef::dump(std::ostream& str) const { this->AstNodeMath::dump(str); }
 void AstVarXRef::dump(std::ostream& str) const {
-    this->AstNode::dump(str);
+    this->AstNodeVarRef::dump(str);
     if (packagep()) { str << " pkg=" << nodeAddr(packagep()); }
     if (access().isWrite()) {
         str << " [LV] => ";
@@ -1458,7 +1459,7 @@ void AstVarXRef::dump(std::ostream& str) const {
     }
 }
 void AstVarRef::dump(std::ostream& str) const {
-    this->AstNode::dump(str);
+    this->AstNodeVarRef::dump(str);
     if (packagep()) { str << " pkg=" << nodeAddr(packagep()); }
     if (access().isWrite()) {
         str << " [LV] => ";

--- a/src/V3AstNodes.cpp
+++ b/src/V3AstNodes.cpp
@@ -1610,10 +1610,11 @@ void AstNodeText::dump(std::ostream& str) const {
     str << " \"" << out << "\"";
 }
 
-void AstVFile::dump(std::ostream& str) const { this->AstNode::dump(str); }
+void AstNodeFile::dump(std::ostream& str) const { this->AstNode::dump(str); }
+void AstVFile::dump(std::ostream& str) const { this->AstNodeFile::dump(str); }
 
 void AstCFile::dump(std::ostream& str) const {
-    this->AstNode::dump(str);
+    this->AstNodeFile::dump(str);
     if (source()) str << " [SRC]";
     if (slow()) str << " [SLOW]";
 }

--- a/src/V3AstNodes.cpp
+++ b/src/V3AstNodes.cpp
@@ -1061,6 +1061,9 @@ string AstBasicDType::prettyDTypeName() const {
     }
     return os.str();
 }
+
+void AstNodeMath::dump(std::ostream& str) const { this->AstNode::dump(str); }
+
 void AstCCast::dump(std::ostream& str) const {
     this->AstNode::dump(str);
     str << " sz" << size();
@@ -1131,7 +1134,7 @@ void AstDisplay::dump(std::ostream& str) const {
     // str<<" "<<displayType().ascii();
 }
 void AstEnumItemRef::dump(std::ostream& str) const {
-    this->AstNode::dump(str);
+    this->AstNodeMath::dump(str);
     str << " -> ";
     if (itemp()) {
         itemp()->dump(str);
@@ -1189,7 +1192,7 @@ void AstJumpLabel::dump(std::ostream& str) const {
     }
 }
 void AstMemberSel::dump(std::ostream& str) const {
-    this->AstNode::dump(str);
+    this->AstNodeMath::dump(str);
     str << " -> ";
     if (varp()) {
         varp()->dump(str);

--- a/src/V3AstNodes.cpp
+++ b/src/V3AstNodes.cpp
@@ -1264,8 +1264,9 @@ void AstTypedef::dump(std::ostream& str) const {
     this->AstNode::dump(str);
     if (attrPublic()) str << " [PUBLIC]";
 }
+void AstNodeRange::dump(std::ostream& str) const { this->AstNode::dump(str); }
 void AstRange::dump(std::ostream& str) const {
-    this->AstNode::dump(str);
+    this->AstNodeRange::dump(str);
     if (littleEndian()) str << " [LITTLE]";
 }
 void AstRefDType::dump(std::ostream& str) const {

--- a/src/V3AstNodes.cpp
+++ b/src/V3AstNodes.cpp
@@ -87,8 +87,10 @@ const char* AstNodeUOrStructDType::broken() const {
     return nullptr;
 }
 
+void AstNodeStmt::dump(std::ostream& str) const { this->AstNode::dump(str); }
+
 void AstNodeCCall::dump(std::ostream& str) const {
-    this->AstNode::dump(str);
+    this->AstNodeStmt::dump(str);
     if (funcp()) {
         str << " " << funcp()->name() << " => ";
         funcp()->dump(str);
@@ -1119,11 +1121,11 @@ void AstClassRefDType::dumpSmall(std::ostream& str) const {
     str << "class:" << name();
 }
 void AstNodeCoverOrAssert::dump(std::ostream& str) const {
-    this->AstNode::dump(str);
+    this->AstNodeStmt::dump(str);
     if (immediate()) str << " [IMMEDIATE]";
 }
 void AstDisplay::dump(std::ostream& str) const {
-    this->AstNode::dump(str);
+    this->AstNodeStmt::dump(str);
     // str<<" "<<displayType().ascii();
 }
 void AstEnumItemRef::dump(std::ostream& str) const {
@@ -1167,7 +1169,7 @@ void AstInitArray::dump(std::ostream& str) const {
     }
 }
 void AstJumpGo::dump(std::ostream& str) const {
-    this->AstNode::dump(str);
+    this->AstNodeStmt::dump(str);
     str << " -> ";
     if (labelp()) {
         labelp()->dump(str);
@@ -1176,7 +1178,7 @@ void AstJumpGo::dump(std::ostream& str) const {
     }
 }
 void AstJumpLabel::dump(std::ostream& str) const {
-    this->AstNode::dump(str);
+    this->AstNodeStmt::dump(str);
     str << " -> ";
     if (blockp()) {
         blockp()->dump(str);
@@ -1194,7 +1196,7 @@ void AstMemberSel::dump(std::ostream& str) const {
     }
 }
 void AstMethodCall::dump(std::ostream& str) const {
-    this->AstNode::dump(str);
+    this->AstNodeStmt::dump(str);
     if (isStatement()) str << " [STMT]";
     str << " -> ";
     if (taskp()) {
@@ -1235,7 +1237,7 @@ void AstPin::dump(std::ostream& str) const {
     if (svImplicit()) str << " [.SV]";
 }
 void AstPrintTimeScale::dump(std::ostream& str) const {
-    this->AstNode::dump(str);
+    this->AstNodeStmt::dump(str);
     str << " " << timeunit();
 }
 void AstTime::dump(std::ostream& str) const {
@@ -1522,7 +1524,7 @@ void AstActive::dump(std::ostream& str) const {
     }
 }
 void AstNodeFTaskRef::dump(std::ostream& str) const {
-    this->AstNode::dump(str);
+    this->AstNodeStmt::dump(str);
     if (packagep()) { str << " pkg=" << nodeAddr(packagep()); }
     str << " -> ";
     if (dotted() != "") { str << ".=" << dotted() << " "; }
@@ -1554,7 +1556,7 @@ void AstBegin::dump(std::ostream& str) const {
     if (implied()) str << " [IMPLIED]";
 }
 void AstCoverDecl::dump(std::ostream& str) const {
-    this->AstNode::dump(str);
+    this->AstNodeStmt::dump(str);
     if (!page().empty()) str << " page=" << page();
     if (!linescov().empty()) str << " lc=" << linescov();
     if (this->dataDeclNullp()) {
@@ -1565,7 +1567,7 @@ void AstCoverDecl::dump(std::ostream& str) const {
     }
 }
 void AstCoverInc::dump(std::ostream& str) const {
-    this->AstNode::dump(str);
+    this->AstNodeStmt::dump(str);
     str << " -> ";
     if (declp()) {
         declp()->dump(str);
@@ -1578,7 +1580,7 @@ void AstFork::dump(std::ostream& str) const {
     if (!joinType().join()) str << " [" << joinType() << "]";
 }
 void AstTraceInc::dump(std::ostream& str) const {
-    this->AstNode::dump(str);
+    this->AstNodeStmt::dump(str);
     str << " -> ";
     if (declp()) {
         declp()->dump(str);

--- a/src/V3AstNodes.cpp
+++ b/src/V3AstNodes.cpp
@@ -1362,15 +1362,16 @@ void AstPackageImport::dump(std::ostream& str) const {
     this->AstNode::dump(str);
     str << " -> " << packagep();
 }
+void AstNodeTriop::dump(std::ostream& str) const { this->AstNodeMath::dump(str); }
 void AstSel::dump(std::ostream& str) const {
-    this->AstNode::dump(str);
+    this->AstNodeTriop::dump(str);
     if (declRange().ranged()) {
         str << " decl" << declRange() << "]";
         if (declElWidth() != 1) str << "/" << declElWidth();
     }
 }
 void AstSliceSel::dump(std::ostream& str) const {
-    this->AstNode::dump(str);
+    this->AstNodeTriop::dump(str);
     if (declRange().ranged()) str << " decl" << declRange();
 }
 void AstMTaskBody::dump(std::ostream& str) const {

--- a/src/V3AstNodes.h
+++ b/src/V3AstNodes.h
@@ -8496,6 +8496,7 @@ public:
         m_name = name;
     }
     ASTNODE_BASE_FUNCS(NodeFile)
+    virtual void dump(std::ostream& str) const override;
     virtual string name() const override { return m_name; }
     virtual V3Hash sameHash() const override { return V3Hash(); }
     virtual bool same(const AstNode* samep) const override { return true; }


### PR DESCRIPTION
This PR aims to add proper delegation to `dump` methods (expanded version of what was present in #2549). Currently some of them call `AstNode::dump(str)` directly and this PR adds calls to `dump` methods of intermediate classes which should make it easier to add debug information where needed.

While working on this I also found a few nodes that used `AstNode::dump` when intermediate `dump` was available (`AstClass`, `AstClassRefDType`, `AstIfaceRefDType`, `AstMethodCall` and `AstFork`) but I left them as is for the moment.