### PR TITLE
Fix cmake build with --hierarchical option

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -170,6 +170,8 @@ DISTFILES_INC = $(INFOS) .gitignore \
 	test_regress/t/t*/*.v* \
 	test_regress/t/t*/*/*.sv* \
 	test_regress/t/t*/*/*.v* \
+	test_regress/t/t*/*.cpp \
+	test_regress/t/t*/CMakeLists.txt \
 	test_regress/t/*.cpp \
 	test_regress/t/*.h \
 	test_regress/t/*.dat \

--- a/src/V3EmitCMake.cpp
+++ b/src/V3EmitCMake.cpp
@@ -232,7 +232,7 @@ class CMakeEmitter {
                 const string vFile = hblockp->vFileIfNecessary();
                 if (!vFile.empty()) *of << vFile << " ";
                 const V3StringList& vFiles = v3Global.opt.vFiles();
-                for (const string& i : vFiles) *of << V3Os::filenameRealPath(i);
+                for (const string& i : vFiles) *of << V3Os::filenameRealPath(i) << " ";
                 *of << " VERILATOR_ARGS ";
                 *of << "-f " << deslash(hblockp->commandArgsFileName(true))
                     << " -CFLAGS -fPIC"  // hierarchical block will be static, but may be linked

--- a/src/V3EmitCMake.cpp
+++ b/src/V3EmitCMake.cpp
@@ -204,15 +204,14 @@ class CMakeEmitter {
             *of << "# Verilate hierarchical blocks\n";
             // Sorted hierarchical blocks in order of leaf-first.
             const V3HierBlockPlan::HierVector& hierBlocks = planp->hierBlocksSorted();
-            const string topTarget = v3Global.opt.protectLib().empty() ? v3Global.opt.prefix()
-                                                                       : v3Global.opt.protectLib();
+            *of << "get_target_property(TOP_TARGET_NAME \"${TARGET}\" NAME)\n";
             for (V3HierBlockPlan::HierVector::const_iterator it = hierBlocks.begin();
                  it != hierBlocks.end(); ++it) {
                 const V3HierBlock* hblockp = *it;
                 const V3HierBlock::HierBlockSet& children = hblockp->children();
                 const string prefix = hblockp->hierPrefix();
                 *of << "add_library(" << prefix << " STATIC)\n";
-                *of << "target_link_libraries(" << topTarget << " PRIVATE " << prefix << ")\n";
+                *of << "target_link_libraries(${TOP_TARGET_NAME}  PRIVATE " << prefix << ")\n";
                 if (!children.empty()) {
                     *of << "target_link_libraries(" << prefix << " INTERFACE";
                     for (V3HierBlock::HierBlockSet::const_iterator child = children.begin();
@@ -223,10 +222,11 @@ class CMakeEmitter {
                 }
                 *of << "verilate(" << prefix << " PREFIX " << prefix << " TOP_MODULE "
                     << hblockp->modp()->name() << " DIRECTORY "
-                    << deslash("${CMAKE_CURRENT_BINARY_DIR}/" + prefix) << " SOURCES ";
+                    << deslash(v3Global.opt.makeDir() + "/" + prefix) << " SOURCES ";
                 for (V3HierBlock::HierBlockSet::const_iterator child = children.begin();
                      child != children.end(); ++child) {
-                    *of << deslash(" ${CMAKE_CURRENT_BINARY_DIR}/" + (*child)->hierWrapper(true));
+                    *of << " "
+                        << deslash(v3Global.opt.makeDir() + "/" + (*child)->hierWrapper(true));
                 }
                 *of << " ";
                 const string vFile = hblockp->vFileIfNecessary();
@@ -240,11 +240,12 @@ class CMakeEmitter {
                     << ")\n";
             }
             *of << "\n# Verilate the top module that refers protect-lib wrappers of above\n";
-            *of << "verilate(" << topTarget << " PREFIX " << v3Global.opt.prefix()
-                << " TOP_MODULE " << v3Global.rootp()->topModulep()->name() << " DIRECTORY "
-                << deslash("${CMAKE_CURRENT_BINARY_DIR}/" + topTarget + ".dir") << " SOURCES ";
+            *of << "verilate(${TOP_TARGET_NAME} PREFIX " << v3Global.opt.prefix() << " TOP_MODULE "
+                << v3Global.rootp()->topModulep()->name() << " DIRECTORY "
+                << deslash(v3Global.opt.makeDir()) << " SOURCES ";
             for (V3HierBlockPlan::const_iterator it = planp->begin(); it != planp->end(); ++it) {
-                *of << deslash(" ${CMAKE_CURRENT_BINARY_DIR}/" + it->second->hierWrapper(true));
+                *of << " "
+                    << deslash(v3Global.opt.makeDir() + "/" + it->second->hierWrapper(true));
             }
             *of << " " << deslash(cmake_list(v3Global.opt.vFiles()));
             *of << " VERILATOR_ARGS ";

--- a/src/V3HierBlock.cpp
+++ b/src/V3HierBlock.cpp
@@ -218,8 +218,8 @@ void V3HierBlock::writeCommandArgsFile(bool forCMake) const {
              child != m_children.end(); ++child) {
             *of << v3Global.opt.makeDir() << "/" << (*child)->hierWrapper(true) << "\n";
         }
+        *of << "-Mdir " << v3Global.opt.makeDir() << "/" << hierPrefix() << " \n";
     }
-    *of << "-Mdir " << v3Global.opt.makeDir() << "/" << hierPrefix() << " \n";
     V3HierWriteCommonInputs(this, of.get(), forCMake);
     const V3StringList& commandOpts = commandArgs(false);
     for (const string& opt : commandOpts) *of << opt << "\n";

--- a/test_regress/t/t_hier_block_cmake/CMakeLists.txt
+++ b/test_regress/t/t_hier_block_cmake/CMakeLists.txt
@@ -1,0 +1,27 @@
+######################################################################
+#
+# DESCRIPTION: CMake script for t_hier_block_cmake
+#
+# Copyright 2003-2020 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+#
+######################################################################
+
+cmake_minimum_required (VERSION 3.8)
+project (t_hier_block_cmake)
+
+find_package(verilator REQUIRED)
+
+add_executable(t_hier_block_cmake  main.cpp ../t_hier_block.cpp)
+
+if(TEST_THREADS)
+    set(VERILATOR_OPTIONS "${VERILATOR_OPTIONS}" --threads ${TEST_THREADS})
+endif()
+set(VERILATOR_OPTIONS "${VERILATOR_OPTIONS}" --hierarchical --stats --CFLAGS "-pipe -DCPP_MACRO=cplusplus")
+
+verilate(t_hier_block_cmake VERILATOR_ARGS ${VERILATOR_OPTIONS} SOURCES
+    ../t_hier_block.v )
+

--- a/test_regress/t/t_hier_block_cmake/main.cpp
+++ b/test_regress/t/t_hier_block_cmake/main.cpp
@@ -1,0 +1,27 @@
+// -*- mode: C++; c-file-style: "cc-mode" -*-
+//*************************************************************************
+//
+// Copyright 2020 by Yutetsu TAKATSUKASA. This program is free software; you can
+// redistribute it and/or modify it under the terms of either the GNU
+// Lesser General Public License Version 3 or the Perl Artistic License
+// Version 2.0.
+// SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+//
+//*************************************************************************
+
+#include <memory>
+#include "Vt_hier_block.h"
+
+int main(int argc, char *argv[]) {
+    std::unique_ptr<Vt_hier_block> top{new Vt_hier_block("top")};
+    Verilated::commandArgs(argc, argv);
+    for (int i = 0; i < 100 && !Verilated::gotFinish(); ++i) {
+        top->eval();
+        top->clk ^= 1;
+    }
+    if (!Verilated::gotFinish()) {
+        vl_fatal(__FILE__, __LINE__, "main", "%Error: Timeout; never got a $finish");
+    }
+    top->final();
+    return 0;
+}


### PR DESCRIPTION
Fixes #2544 

There were some problems.
1. .cmake generated by `hier_block` assumed the target name is `--prefix`.
2. `DIRECTORY` option was not properly passed via `-Mdir` option

To test the item 1. above,  simple dedicated CMakeLists.txt is used in 5d99340cf022a1225ae14c093f044b9924821b4f .