### PR TITLE
Fix  performance degradation when --threads is used with --hierarchical (Issue 2562)

### DIFF
--- a/src/V3HierBlock.cpp
+++ b/src/V3HierBlock.cpp
@@ -228,6 +228,9 @@ void V3HierBlock::writeCommandArgsFile(bool forCMake) const {
          ++child) {
         *of << (*child)->hierBlockArgs().front() << "\n";
     }
+    // Hierarchical blocks should not use multi-threading,
+    // but needs to be thread safe when top is multi-threaded.
+    if (v3Global.opt.threads() > 0) { *of << "--threads 1\n"; }
     *of << v3Global.opt.allArgsStringForHierBlock(false) << "\n";
 }
 
@@ -425,6 +428,9 @@ void V3HierBlockPlan::writeCommandArgsFiles(bool forCMake) const {
     if (!v3Global.opt.protectLib().empty()) {
         *of << "--protect-lib " << v3Global.opt.protectLib() << "\n";
         *of << "--protect-key " << v3Global.opt.protectKeyDefaulted() << "\n";
+    }
+    if (v3Global.opt.threads() > 0) {
+        *of << "--threads " << cvtToStr(v3Global.opt.threads()) << "\n";
     }
     *of << (v3Global.opt.systemC() ? "--sc" : "--cc") << "\n";
     *of << v3Global.opt.allArgsStringForHierBlock(true) << "\n";

--- a/src/V3Options.cpp
+++ b/src/V3Options.cpp
@@ -504,7 +504,7 @@ string V3Options::filePathCheckOneDir(const string& modname, const string& dirna
 int V3Options::stripOptionsForChildRun(const string& opt, bool forTop) const {
     if (opt == "Mdir" || opt == "clk" || opt == "f" || opt == "j" || opt == "l2-name"
         || opt == "mod-prefix" || opt == "prefix" || opt == "protect-lib" || opt == "protect-key"
-        || opt == "top-module" || opt == "v") {
+        || opt == "threads" || opt == "top-module" || opt == "v") {
         return 2;
     }
     if (opt == "build" || (!forTop && (opt == "cc" || opt == "exe" || opt == "sc"))


### PR DESCRIPTION
Fixes #2562

hier_blocks should be just single threaded otherwise too many threads will be created and the performance may be too bad.

I will merge tomorrow if CI is happy.