### PR TITLE
Add basic handling of this keyword

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -53,6 +53,7 @@ Philipp Wagner
 Pieter Kapsenberg
 Piotr Binkowski
 Qingyao Sun
+Rafal Kapuscik
 Richard Myers
 Rupert Swarbrick
 Sean Cross

--- a/src/V3AstNodes.h
+++ b/src/V3AstNodes.h
@@ -2360,8 +2360,8 @@ public:
             return (varScopep() == samep->varScopep());
         } else {
             return (hiername() == samep->hiername()
-                   && (hiername() != "" || samep->hiername() != "")
-                   && varp()->name() == samep->varp()->name());
+                    && (hiername() != "" || samep->hiername() != "")
+                    && varp()->name() == samep->varp()->name());
         }
     }
     virtual int instrCount() const override {

--- a/src/V3AstNodes.h
+++ b/src/V3AstNodes.h
@@ -2359,7 +2359,9 @@ public:
         if (varScopep()) {
             return (varScopep() == samep->varScopep());
         } else {
-            return (hiername() == samep->hiername() && varp()->name() == samep->varp()->name());
+            return (hiername() == samep->hiername()
+                   && (hiername() != "" || samep->hiername() != "")
+                   && varp()->name() == samep->varp()->name());
         }
     }
     virtual int instrCount() const override {

--- a/src/V3LinkDot.cpp
+++ b/src/V3LinkDot.cpp
@@ -1962,12 +1962,12 @@ private:
             m_ds.m_dotPos = DP_SCOPE;
 
             if (VN_IS(nodep->lhsp(), ParseRef) && nodep->lhsp()->name() == "this") {
-                VSymEnt* classSymbolTable = m_ds.m_dotSymp;
+                VSymEnt* classSymp = m_ds.m_dotSymp;
                 do {
-                    classSymbolTable = classSymbolTable->fallbackp();
-                } while (classSymbolTable && !VN_IS(classSymbolTable->nodep(), Class));
-                m_ds.m_dotSymp = classSymbolTable;
-                if(!classSymbolTable) {
+                    classSymp = classSymp->fallbackp();
+                } while (classSymp && !VN_IS(classSymp->nodep(), Class));
+                m_ds.m_dotSymp = classSymp;
+                if (!classSymp) {
                     nodep->v3error("'this' used outside class");
                     m_ds.m_dotErr = true;
                 }

--- a/src/V3LinkDot.cpp
+++ b/src/V3LinkDot.cpp
@@ -1962,7 +1962,15 @@ private:
             m_ds.m_dotPos = DP_SCOPE;
 
             if (VN_IS(nodep->lhsp(), ParseRef) && nodep->lhsp()->name() == "this") {
-                m_ds.m_dotSymp = m_ds.m_dotSymp->fallbackp();
+                VSymEnt* classSymbolTable = m_ds.m_dotSymp;
+                do {
+                    classSymbolTable = classSymbolTable->fallbackp();
+                } while (classSymbolTable && !VN_IS(classSymbolTable->nodep(), Class));
+                m_ds.m_dotSymp = classSymbolTable;
+                if(!classSymbolTable) {
+                    nodep->v3error("'this' used outside class");
+                    m_ds.m_dotErr = true;
+                }
             } else if (VN_IS(nodep->lhsp(), ClassOrPackageRef)) {
                 // m_ds.m_dotText communicates the cell prefix between stages
                 // if (!start) { nodep->lhsp()->v3error("Package reference may not be embedded in

--- a/src/V3LinkDot.cpp
+++ b/src/V3LinkDot.cpp
@@ -2021,9 +2021,7 @@ private:
         // Generally resolved during Primay, but might be at param time under AstUnlinkedRef
         UASSERT_OBJ(m_statep->forPrimary() || m_statep->forPrearray(), nodep,
                     "ParseRefs should no longer exist");
-        if (nodep->name() == "super") {
-            nodep->v3warn(E_UNSUPPORTED, "Unsupported: super");
-        }
+        if (nodep->name() == "super") { nodep->v3warn(E_UNSUPPORTED, "Unsupported: super"); }
         DotStates lastStates = m_ds;
         bool start = (m_ds.m_dotPos == DP_NONE);  // Save, as m_dotp will be changed
         if (start) {

--- a/src/V3LinkDot.cpp
+++ b/src/V3LinkDot.cpp
@@ -1961,8 +1961,10 @@ private:
             m_ds.m_dotp = nodep;  // Always, not just at start
             m_ds.m_dotPos = DP_SCOPE;
 
-            // m_ds.m_dotText communicates the cell prefix between stages
-            if (VN_IS(nodep->lhsp(), ClassOrPackageRef)) {
+            if (VN_IS(nodep->lhsp(), ParseRef) && nodep->lhsp()->name() == "this") {
+                m_ds.m_dotSymp = m_ds.m_dotSymp->fallbackp();
+            } else if (VN_IS(nodep->lhsp(), ClassOrPackageRef)) {
+                // m_ds.m_dotText communicates the cell prefix between stages
                 // if (!start) { nodep->lhsp()->v3error("Package reference may not be embedded in
                 // dotted reference"); m_ds.m_dotErr=true; }
                 m_ds.m_dotPos = DP_PACKAGE;
@@ -2019,9 +2021,7 @@ private:
         // Generally resolved during Primay, but might be at param time under AstUnlinkedRef
         UASSERT_OBJ(m_statep->forPrimary() || m_statep->forPrearray(), nodep,
                     "ParseRefs should no longer exist");
-        if (nodep->name() == "this") {
-            nodep->v3warn(E_UNSUPPORTED, "Unsupported: this");
-        } else if (nodep->name() == "super") {
+        if (nodep->name() == "super") {
             nodep->v3warn(E_UNSUPPORTED, "Unsupported: super");
         }
         DotStates lastStates = m_ds;
@@ -2030,10 +2030,7 @@ private:
             m_ds.init(m_curSymp);
             // Note m_ds.m_dot remains nullptr; this is a reference not under a dot
         }
-        if (nodep->name() == "this") {
-            nodep->v3warn(E_UNSUPPORTED, "Unsupported: this");
-            m_ds.m_dotErr = true;
-        } else if (nodep->name() == "super") {
+        if (nodep->name() == "super") {
             nodep->v3warn(E_UNSUPPORTED, "Unsupported: super");
             m_ds.m_dotErr = true;
         }

--- a/src/V3SymTable.h
+++ b/src/V3SymTable.h
@@ -108,6 +108,7 @@ public:
     void operator delete(void* objp, size_t size) {}
 #endif
     void fallbackp(VSymEnt* entp) { m_fallbackp = entp; }
+    VSymEnt* fallbackp() const { return m_fallbackp; }
     void parentp(VSymEnt* entp) { m_parentp = entp; }
     VSymEnt* parentp() const { return m_parentp; }
     void packagep(AstNodeModule* entp) { m_packagep = entp; }

--- a/test_regress/t/t_class_extends_this.out
+++ b/test_regress/t/t_class_extends_this.out
@@ -1,15 +1,3 @@
-%Error-UNSUPPORTED: t/t_class_extends_this.v:13:11: Unsupported: this
-   13 |       if (this.value != 1) $stop;
-      |           ^~~~
-%Error: t/t_class_extends_this.v:13:11: Can't find definition of scope/variable: 'this'
-   13 |       if (this.value != 1) $stop;
-      |           ^~~~
-%Error-UNSUPPORTED: t/t_class_extends_this.v:21:11: Unsupported: this
-   21 |       if (this.value != 2) $stop;
-      |           ^~~~
-%Error: t/t_class_extends_this.v:21:11: Can't find definition of scope/variable: 'this'
-   21 |       if (this.value != 2) $stop;
-      |           ^~~~
 %Error-UNSUPPORTED: t/t_class_extends_this.v:22:11: Unsupported: super
    22 |       if (super.value != 1) $stop;
       |           ^~~~~
@@ -28,12 +16,6 @@
 %Error: t/t_class_extends_this.v:24:7: Can't find definition of scope/variable: 'super'
    24 |       super.value = 10;
       |       ^~~~~
-%Error-UNSUPPORTED: t/t_class_extends_this.v:25:7: Unsupported: this
-   25 |       this.value = 20;
-      |       ^~~~
-%Error: t/t_class_extends_this.v:25:7: Can't find definition of scope/variable: 'this'
-   25 |       this.value = 20;
-      |       ^~~~
 %Error-UNSUPPORTED: t/t_class_extends_this.v:26:11: Unsupported: super
    26 |       if (super.value != 10) $stop;
       |           ^~~~~

--- a/test_regress/t/t_class_uses_this.pl
+++ b/test_regress/t/t_class_uses_this.pl
@@ -1,0 +1,21 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2020 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_class_uses_this.v
+++ b/test_regress/t/t_class_uses_this.v
@@ -1,0 +1,34 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2020 Rafal Kapuscik
+// SPDX-License-Identifier: CC0-1.0
+//
+class foo;
+   bit [3:0] addr;
+   function void set (bit [3:0] addr);
+   begin : body
+     this.addr = addr;
+   end : body
+   endfunction
+endclass
+
+module t(/*AUTOARG*/
+   // Inputs
+   clk
+   );
+   input clk;
+   foo bar;
+   foo baz;
+   initial begin
+       bar = new();
+       baz = new();
+       bar.set(4);
+`ifdef TEST_VERBOSE
+       $display(bar.addr);
+       $display(baz.addr);
+`endif
+       $write("*-* All Finished *-*\n");
+       $finish;
+   end
+endmodule

--- a/test_regress/t/t_class_uses_this_bad.out
+++ b/test_regress/t/t_class_uses_this_bad.out
@@ -1,4 +1,4 @@
-%Error: t/t_class_uses_this_bad.v:28:12: 'this' used outside class
-   28 |        this.addr = 2;
+%Error: t/t_class_uses_this_bad.v:15:12: 'this' used outside class
+   15 |        this.addr = 2;
       |            ^
 %Error: Exiting due to

--- a/test_regress/t/t_class_uses_this_bad.out
+++ b/test_regress/t/t_class_uses_this_bad.out
@@ -1,0 +1,4 @@
+%Error: t/t_class_uses_this_bad.v:28:12: 'this' used outside class
+   28 |        this.addr = 2;
+      |            ^
+%Error: Exiting due to

--- a/test_regress/t/t_class_uses_this_bad.pl
+++ b/test_regress/t/t_class_uses_this_bad.pl
@@ -1,0 +1,23 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2020 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    fails => 1,
+    expect_filename => $Self->{golden_filename},
+    );
+
+#execute(
+#    check_finished => 1,
+#    );
+
+ok(1);
+1;

--- a/test_regress/t/t_class_uses_this_bad.v
+++ b/test_regress/t/t_class_uses_this_bad.v
@@ -1,0 +1,19 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2020 Rafal Kapuscik
+// SPDX-License-Identifier: CC0-1.0
+//
+
+module t(/*AUTOARG*/
+   // Inputs
+   clk
+   );
+   input clk;
+   bit [3:0] addr;
+   initial begin
+       this.addr = 2;
+       $write("*-* All Finished *-*\n");
+       $finish;
+   end
+endmodule


### PR DESCRIPTION
This PR adds support for the `this` keyword by pointing to the right symbol table.

When encountering AstDot node with `this` reference on the left, current symbol table is ignored (as the names are probably aliased) and fallback table is used. Then Verilator is able to find the correct variable with the usual flow.