### PR TITLE
Fix iteration over mutating list bug in VPI impl

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -32,6 +32,7 @@ John Coiner
 John Demme
 Josh Redford
 Julien Margetts
+Kaleb Barrett
 Kanad Kanhere
 Kevin Kiningham
 Kuba Ober

--- a/include/verilated_vpi.cpp
+++ b/include/verilated_vpi.cpp
@@ -477,7 +477,8 @@ public:
     static bool callCbs(vluint32_t reason) VL_MT_UNSAFE_ONE {
         VpioCbList& cbObjList = s_s.m_cbObjLists[reason];
         bool called = false;
-        for (auto it = cbObjList.begin(); it != cbObjList.end();) {
+        const auto end = cbObjList.end();  // prevent looping over newly added elements
+        for (auto it = cbObjList.begin(); it != end;) {
             if (VL_UNLIKELY(!*it)) {  // Deleted earlier, cleanup
                 it = cbObjList.erase(it);
                 continue;
@@ -494,7 +495,8 @@ public:
         VpioCbList& cbObjList = s_s.m_cbObjLists[cbValueChange];
         typedef std::set<VerilatedVpioVar*> VpioVarSet;
         VpioVarSet update;  // set of objects to update after callbacks
-        for (auto it = cbObjList.begin(); it != cbObjList.end();) {
+        const auto end = cbObjList.end();  // prevent looping over newly added elements
+        for (auto it = cbObjList.begin(); it != end;) {
             if (VL_UNLIKELY(!*it)) {  // Deleted earlier, cleanup
                 it = cbObjList.erase(it);
                 continue;


### PR DESCRIPTION
Previously, in any given VPI callback, if the callback body registered the same callback, that callback would be processed in the currently executing call to the call*Cbs function. In the worse case, this could lead to an infinite loop. It is a bug in the class of "modifying the loop you are iterating over".

Closes #2536. Well, at least the verilator aspect of that issue; it is duplicated in the cocotb repo (cocotb/cocotb#2051).