### PR TITLE
introduce define for FST tracing

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -40,6 +40,7 @@ Lukasz Dalek
 Maarten De Braekeleer
 Maciej Sobkowski
 Marco Widmer
+Markus Krause
 Marshal Qiao
 Matthew Ballance
 Michael Killough

--- a/include/verilated.mk.in
+++ b/include/verilated.mk.in
@@ -54,6 +54,7 @@ VK_CPPFLAGS_ALWAYS += \
 		-DVM_COVERAGE=$(VM_COVERAGE) \
 		-DVM_SC=$(VM_SC) \
 		-DVM_TRACE=$(VM_TRACE) \
+		-DVM_TRACE_FST=$(VM_TRACE_FST) \
 		$(CFG_CXXFLAGS_NO_UNUSED) \
 
 ifeq ($(CFG_WITH_CCWARN),yes)	# Local... Else don't burden users

--- a/src/V3EmitMk.cpp
+++ b/src/V3EmitMk.cpp
@@ -65,6 +65,10 @@ public:
         of.puts("VM_TRACE = ");
         of.puts(v3Global.opt.trace() ? "1" : "0");
         of.puts("\n");
+        of.puts("# Tracing output mode in FST format?  0/1 (from --trace-fst)\n");
+        of.puts("VM_TRACE_FST = ");
+        of.puts(v3Global.opt.traceFormat().fst() ? "1" : "0");
+        of.puts("\n");
         of.puts("# Tracing threaded output mode?  0/1/N threads (from --trace-thread)\n");
         of.puts("VM_TRACE_THREADS = ");
         of.puts(cvtToStr(v3Global.opt.trueTraceThreads()));

--- a/src/V3EmitMk.cpp
+++ b/src/V3EmitMk.cpp
@@ -67,7 +67,7 @@ public:
         of.puts("\n");
         of.puts("# Tracing output mode in FST format?  0/1 (from --trace-fst)\n");
         of.puts("VM_TRACE_FST = ");
-        of.puts(v3Global.opt.traceFormat().fst() ? "1" : "0");
+        of.puts(v3Global.opt.trace() && v3Global.opt.traceFormat().fst() ? "1" : "0");
         of.puts("\n");
         of.puts("# Tracing threaded output mode?  0/1/N threads (from --trace-thread)\n");
         of.puts("VM_TRACE_THREADS = ");


### PR DESCRIPTION
this is to allow C++ verilator toplevel to support
multiple modes of waveform tracing
VM_TRACE_FST can be used inside a #if VM_TRACE
section to switch between classic .vcd tracing and the
more compact .fst format supported by GTKWAVE

We appreciate your contributing to Verilator.  If this is your first commit, please add your name to docs/CONTRIBUTORS, and read our contributing guidelines in docs/CONTRIBUTING.adoc.
