### PR TITLE
Fix SEGV when $fgets, $sscanf, or $fscanf is used with string

### DIFF
--- a/include/verilated.cpp
+++ b/include/verilated.cpp
@@ -1082,9 +1082,13 @@ IData _vl_vsscanf(FILE* fp,  // If a fscanf
                 if (obits == -1) {  // string
                     owp = nullptr;
                     if (VL_UNCOVERABLE(fmt != 's')) {
-                        VL_FATAL_MT(__FILE__, __LINE__, "", "Internal: format other than %s is passed to string");  // LCOV_EXCL_LINE
+                        VL_FATAL_MT(
+                            __FILE__, __LINE__, "",
+                            "Internal: format other than %s is passed to string");  // LCOV_EXCL_LINE
                     }
-                } else if (obits > VL_QUADSIZE) {owp = va_arg(ap, WDataOutP);}
+                } else if (obits > VL_QUADSIZE) {
+                    owp = va_arg(ap, WDataOutP);
+                }
 
                 for (int i = 0; i < VL_WORDS_I(obits); ++i) owp[i] = 0;
                 switch (fmt) {
@@ -1202,7 +1206,7 @@ IData _vl_vsscanf(FILE* fp,  // If a fscanf
                 if (!inIgnore) ++got;
                 // Reload data if non-wide (if wide, we put it in the right place directly)
                 if (obits == 0) {  // Due to inIgnore
-                } else if (obits == -1) { //string
+                } else if (obits == -1) {  // string
                     std::string* p = va_arg(ap, std::string*);
                     *p = tmp;
                 } else if (obits <= VL_BYTESIZE) {

--- a/include/verilated.cpp
+++ b/include/verilated.cpp
@@ -1282,6 +1282,23 @@ IData VL_FGETS_IXI(int obits, void* destp, IData fpi) VL_MT_SAFE {
     return got;
 }
 
+// declared in verilated_heavy.h
+IData VL_FGETS_NI(std::string& str, IData fpi) VL_MT_SAFE {
+    str.clear();
+
+    // While threadsafe, each thread can only access different file handles
+    FILE* fp = VL_CVT_I_FP(fpi);
+    if (VL_UNLIKELY(!fp)) return 0;
+
+    while (true) {
+        const int c = getc(fp);
+        if (c == EOF) break;
+        str.push_back(c);
+        if (c == '\n') break;
+    }
+    return str.size();
+}
+
 IData VL_FERROR_IN(IData, std::string& outputr) VL_MT_SAFE {
     // We ignore lhs/fpi - IEEE says "most recent error" so probably good enough
     IData ret = errno;

--- a/include/verilated_heavy.h
+++ b/include/verilated_heavy.h
@@ -523,6 +523,8 @@ inline IData VL_CMP_NN(const std::string& lhs, const std::string& rhs, bool igno
 
 extern IData VL_ATOI_N(const std::string& str, int base) VL_PURE;
 
+extern IData VL_FGETS_NI(std::string& destp, IData fpi);
+
 //======================================================================
 // Dumping
 

--- a/src/V3AstNodes.h
+++ b/src/V3AstNodes.h
@@ -7912,7 +7912,10 @@ public:
         V3ERROR_NA;
     }
     virtual string emitVerilog() override { return "%f$fgets(%l,%r)"; }
-    virtual string emitC() override { return "VL_FGETS_%nqX%rq(%lw, %P, &(%li), %ri)"; }
+    virtual string emitC() override {
+        return strgp()->dtypep()->basicp()->isString() ? "VL_FGETS_NI(%li, %ri)"
+                                                       : "VL_FGETS_%nqX%rq(%lw, %P, &(%li), %ri)";
+    }
     virtual bool cleanOut() const override { return false; }
     virtual bool cleanLhs() const override { return true; }
     virtual bool cleanRhs() const override { return true; }

--- a/src/V3EmitC.cpp
+++ b/src/V3EmitC.cpp
@@ -2181,7 +2181,12 @@ void EmitCStmts::displayArg(AstNode* dispp, AstNode** elistp, bool isScan, const
     }
     emitDispState.pushFormat(pfmt);
     if (!ignore) {
-        emitDispState.pushArg(' ', nullptr, cvtToStr(argp->widthMin()));
+        if (argp->dtypep()->basicp()->keyword() == AstBasicDTypeKwd::STRING) {
+            // string in SystemVerilog is std::string in C++ which is not POD
+            emitDispState.pushArg(' ', nullptr, "-1");
+        } else {
+            emitDispState.pushArg(' ', nullptr, cvtToStr(argp->widthMin()));
+        }
         emitDispState.pushArg(fmtLetter, argp, "");
     } else {
         emitDispState.pushArg(fmtLetter, nullptr, "");

--- a/test_regress/t/t_sys_file_basic.v
+++ b/test_regress/t/t_sys_file_basic.v
@@ -134,6 +134,12 @@ module t;
 	 if (chars != 10) $stop;
 	 if (letterw != "\0\0\0\0\0\0widestuff\n") $stop;
 
+	 s = "";
+	 chars = $fgets(s, file);
+	 if (`verbose) $write("c=%0d w=%s", chars, s); // Output includes newline
+	 if (chars != 7) $stop;
+	 if (s != "string\n") $stop;
+
 	 // $sscanf
 	 if ($sscanf("x","")!=0) $stop;
 	 if ($sscanf("z","z")!=0) $stop;

--- a/test_regress/t/t_sys_file_basic.v
+++ b/test_regress/t/t_sys_file_basic.v
@@ -179,6 +179,12 @@ module t;
 	 `checkr(r, 0.1);
 	 if (letterq != 64'hfffffffffffc65a5) $stop;
 
+	 chars = $sscanf("scan from string",
+			 "scan %s string", s);
+	 if (`verbose) $write("c=%0d s=%s\n", chars, s);
+	 if (chars != 1) $stop;
+	 if (s != "from") $stop;
+
 	 // Cover quad and %e/%f
 	 chars = $sscanf("r=0.2",
 			 "r=%e", r);
@@ -250,6 +256,11 @@ module t;
 	 if (`verbose) $write("c=%0d l=%x\n", chars, letterl);
 	 if (chars != 1) $stop;
 	 if (letterl != "\n") $stop;
+
+	 chars = $fscanf(file, "%c%s not_included\n", letterl, s);
+	 if (`verbose) $write("c=%0d l=%s\n", chars, s);
+	 if (chars != 2) $stop;
+	 if (s != "BCD") $stop;
 
 	 // msg1229
 	 v_a = $fgetc(file);

--- a/test_regress/t/t_sys_file_basic_input.dat
+++ b/test_regress/t/t_sys_file_basic_input.dat
@@ -1,6 +1,7 @@
 hi
 lquad
 widestuff
+string
 *xa=1f xb=237904689_02348923
 *ba=10 bb=11010010101001010101 note_the_two
 *oa=23 ob=12563

--- a/test_regress/t/t_sys_file_basic_input.dat
+++ b/test_regress/t/t_sys_file_basic_input.dat
@@ -8,4 +8,5 @@ string
 *d=-236123
 *u=-236124
 *fredfishblah
+aBCD not_included
 12346789


### PR DESCRIPTION
I encountered SEGV of verilated code.
The root cause is something like below where `s` is std::string.
```c++
VL_FGETS_IXI(64, &(vlTOPp->t__DOT__s), vlTOPp->t__DOT__file)
```

`VL_FGETS_IXI()` looks designed for POD types such as IData and accesses via void pointer.
https://github.com/verilator/verilator/blob/4cec3ff2a05ea407b56644d092ad57d56ca81096/include/verilated.cpp#L1255

std::string can not be accessed in that way.

Maybe there are some more similar functions that accesses via void pointer.
I will append them later.