### PR TITLE
WIFEXITED missing from MinGW/MSYS2, added defines

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -27,6 +27,7 @@ James Hutchinson
 Jamey Hicks
 James Pallister
 Jan Van Winkel
+Jean Berniolles
 Jeremy Bennett
 John Coiner
 John Demme

--- a/src/V3Os.cpp
+++ b/src/V3Os.cpp
@@ -49,23 +49,13 @@
 # include <direct.h>  // mkdir
 # include <psapi.h>   // GetProcessMemoryInfo
 # include <thread>
+// These macros taken from gdbsupport/gdb_wait.h in binutils-gdb
 # ifndef WIFEXITED
-#    define WIFEXITED(stat)  (((*((int *) &(stat))) & 0xC0000000) == 0)
-# endif
-# ifndef WEXITSTATUS
-#    define WEXITSTATUS(stat) (*((int *) &(stat)))
-# endif
-# ifndef WIFSIGNALED
-#    define WIFSIGNALED(stat) ((*((int *) &(stat))) & 0xC0000000)
-# endif
-# ifndef WTERMSIG
-#    define WTERMSIG(stat)    ((*((int *) &(stat))) & 0x7f)
-# endif
-# ifndef WIFSTOPPED
-#    define WIFSTOPPED(stat)  0
-# endif
-# ifndef WSTOPSIG
-#    define WSTOPSIG(stat)    (((*((int *) &(stat))) >> 8) & 0xff)
+#  ifdef __MINGW32__
+#   define WIFEXITED(w)	(((w) & 0xC0000000) == 0)
+#  else
+#   define WIFEXITED(w)	(((w) & 0377) == 0)
+#  endif
 # endif
 #else
 # include <sys/time.h>

--- a/src/V3Os.cpp
+++ b/src/V3Os.cpp
@@ -49,6 +49,24 @@
 # include <direct.h>  // mkdir
 # include <psapi.h>   // GetProcessMemoryInfo
 # include <thread>
+# ifndef WIFEXITED
+#    define WIFEXITED(stat)  (((*((int *) &(stat))) & 0xC0000000) == 0)
+# endif
+# ifndef WEXITSTATUS
+#    define WEXITSTATUS(stat) (*((int *) &(stat)))
+# endif
+# ifndef WIFSIGNALED
+#    define WIFSIGNALED(stat) ((*((int *) &(stat))) & 0xC0000000)
+# endif
+# ifndef WTERMSIG
+#    define WTERMSIG(stat)    ((*((int *) &(stat))) & 0x7f)
+# endif
+# ifndef WIFSTOPPED
+#    define WIFSTOPPED(stat)  0
+# endif
+# ifndef WSTOPSIG
+#    define WSTOPSIG(stat)    (((*((int *) &(stat))) >> 8) & 0xff)
+# endif
 #else
 # include <sys/time.h>
 # include <sys/wait.h> // Needed on FreeBSD for WIFEXITED


### PR DESCRIPTION
Following on #2353, I'm creating a pull request to add W* defines that are missing on MinGW/MSYS2.
I don't think tests can be run on MSYS2/MinGW (perl runner prerequisites can't be installed), but I did a manual check by verilating a simple design.
