### PR TITLE
Memory clean up in tests

### DIFF
--- a/test_regress/t/t_clk_2in.cpp
+++ b/test_regress/t/t_clk_2in.cpp
@@ -50,4 +50,7 @@ int main(int argc, char* argv[]) {
     }
     topp->check = 1;
     clockit(0, 0);
+
+    topp->final();
+    VL_DO_DANGLING(delete topp, topp);
 }

--- a/test_regress/t/t_dpi_accessors.cpp
+++ b/test_regress/t/t_dpi_accessors.cpp
@@ -673,6 +673,7 @@ int main() {
 
     // Tidy up
     dut->final();
+    VL_DO_DANGLING(delete dut, dut);
     cout << "*-* All Finished *-*" << endl;
 }
 

--- a/test_regress/t/t_dpi_export_context2_bad.cpp
+++ b/test_regress/t/t_dpi_export_context2_bad.cpp
@@ -27,6 +27,7 @@ int main(int argc, char* argv[]) {
     Verilated::debug(0);
 
     topp->eval();
+    VL_DO_DANGLING(delete topp, topp);
     return 1;
 }
 int dpii_task() {

--- a/test_regress/t/t_dpi_export_context_bad.cpp
+++ b/test_regress/t/t_dpi_export_context_bad.cpp
@@ -44,5 +44,8 @@ int main(int argc, char* argv[]) {
 
     topp->eval();
     dpix_task();  // Missing svSetScope
+
+    topp->final();
+    VL_DO_DANGLING(delete topp, topp);
     return 1;
 }

--- a/test_regress/t/t_dpi_vams.cpp
+++ b/test_regress/t/t_dpi_vams.cpp
@@ -51,5 +51,8 @@ int main(int argc, char* argv[]) {
     } else {
         vl_fatal(__FILE__, __LINE__, "top", "Unexpected results\n");
     }
+
+    topp->final();
+    VL_DO_DANGLING(delete topp, topp);
     return 0;
 }

--- a/test_regress/t/t_enum_public.cpp
+++ b/test_regress/t/t_enum_public.cpp
@@ -24,4 +24,7 @@ int main(int argc, char* argv[]) {
     for (int i = 0; i < 10; i++) {  //
         topp->eval();
     }
+
+    topp->final();
+    VL_DO_DANGLING(delete topp, topp);
 }

--- a/test_regress/t/t_flag_fi.cpp
+++ b/test_regress/t/t_flag_fi.cpp
@@ -29,6 +29,7 @@ int main(int argc, char* argv[]) {
     if (!gotit) { vl_fatal(__FILE__, __LINE__, "dut", "Never got call to myfunction"); }
 
     topp->final();
+    VL_DO_DANGLING(delete topp, topp);
 
     return 0;
 }

--- a/test_regress/t/t_func_rand.cpp
+++ b/test_regress/t/t_func_rand.cpp
@@ -24,5 +24,7 @@ int main(int argc, char* argv[]) {
     if (topp->Rand != 0xfeed0fad) {
         vl_fatal(__FILE__, __LINE__, "top", "Unexpected value for Rand output\n");
     }
+    topp->final();
+    VL_DO_DANGLING(delete topp, topp);
     printf("*-* All Finished *-*\n");
 }

--- a/test_regress/t/t_math_imm2.cpp
+++ b/test_regress/t/t_math_imm2.cpp
@@ -44,6 +44,9 @@ int main(int argc, char* argv[]) {
         }
     }
 
+    sim->final();
+    VL_DO_DANGLING(delete sim, sim);
+
     if (errs) {
         vl_stop(__FILE__, __LINE__, "TOP-cpp");
         exit(10);

--- a/test_regress/t/t_mem_multi_io2.cpp
+++ b/test_regress/t/t_mem_multi_io2.cpp
@@ -78,6 +78,9 @@ int main()
         for (int j = 0; j < 5; j++) check("o345", READ(o345[i][j]), i * 8 + j);
     }
 
+    tb->final();
+    VL_DO_DANGLING(delete tb, tb);
+
     if (pass) {
         VL_PRINTF("*-* All Finished *-*\n");
     } else {

--- a/test_regress/t/t_mem_multi_io3.cpp
+++ b/test_regress/t/t_mem_multi_io3.cpp
@@ -20,6 +20,9 @@ int main()
     Verilated::debug(0);
     tb = new VM_PREFIX("tb");
 
+    tb->final();
+    VL_DO_DANGLING(delete tb, tb);
+
     // Just a constructor test
     VL_PRINTF("*-* All Finished *-*\n");
     return 0;

--- a/test_regress/t/t_mem_slot.cpp
+++ b/test_regress/t/t_mem_slot.cpp
@@ -55,5 +55,8 @@ int main(int argc, char* argv[]) {
     for (i = 0; i < 100; i++)  //
         StepSim(sim, random() % 3, random() % 2, random() % 2, random() % 3);
 
+    sim->final();
+    VL_DO_DANGLING(delete sim, sim);
+
     printf("*-* All Finished *-*\n");
 }

--- a/test_regress/t/t_multitop_sig.cpp
+++ b/test_regress/t/t_multitop_sig.cpp
@@ -39,5 +39,9 @@ int main(int argc, char* argv[]) {
         CHECK_RESULT(topp->b__02Eout, 1);
         CHECK_RESULT(topp->uniq_out, 0);
     }
+
+    topp->final();
+    VL_DO_DANGLING(delete topp, topp);
+
     printf("*-* All Finished *-*\n");
 }

--- a/test_regress/t/t_order_multidriven.cpp
+++ b/test_regress/t/t_order_multidriven.cpp
@@ -56,5 +56,9 @@ int main() {
     }
 
     vcd->close();
+
+    vcore->final();
+    VL_DO_DANGLING(delete vcore, vcore);
+
     printf("*-* All Finished *-*\n");
 }

--- a/test_regress/t/t_order_quad.cpp
+++ b/test_regress/t/t_order_quad.cpp
@@ -38,12 +38,13 @@ int main(int argc, char* argv[]) {
     topp->eval();
     check(topp->y, 0x3c00000000ULL);
 
-    topp->final();
     if (!fail) {
         VL_PRINTF("*-* All Finished *-*\n");
         topp->final();
     } else {
         vl_fatal(__FILE__, __LINE__, "top", "Unexpected results\n");
     }
+
+    VL_DO_DANGLING(delete topp, topp);
     return 0;
 }

--- a/test_regress/t/t_param_public.cpp
+++ b/test_regress/t/t_param_public.cpp
@@ -26,4 +26,7 @@ int main(int argc, char* argv[]) {
     for (int i = 0; i < 10; i++) {  //
         topp->eval();
     }
+
+    topp->final();
+    VL_DO_DANGLING(delete topp, topp);
 }

--- a/test_regress/t/t_sc_names.cpp
+++ b/test_regress/t/t_sc_names.cpp
@@ -24,5 +24,6 @@ int sc_main(int argc, char* argv[]) {
     } else {
         vl_fatal(__FILE__, __LINE__, "tb", "Unexpected results\n");
     }
+    VL_DO_DANGLING(delete tb, tb);
     return 0;
 }

--- a/test_regress/t/t_scope_map.cpp
+++ b/test_regress/t/t_scope_map.cpp
@@ -161,6 +161,8 @@ int main(int argc, char** argv, char** env) {
 
     tfp->close();
     top->final();
+    VL_DO_DANGLING(delete top, top);
+
     VL_PRINTF("*-* All Finished *-*\n");
 
     return 0;

--- a/test_regress/t/t_timescale.cpp
+++ b/test_regress/t/t_timescale.cpp
@@ -50,6 +50,7 @@ int main(int argc, char** argv, char** env) {
     CHECK_RESULT(VL_TIME_STR_CONVERT(0), 0);
 
     top->final();
+    VL_DO_DANGLING(delete top, top);
     printf("*-* All Finished *-*\n");
     return 0;
 }

--- a/test_regress/t/t_timescale_parse.cpp
+++ b/test_regress/t/t_timescale_parse.cpp
@@ -19,4 +19,5 @@ int main() {
     tb->eval();
 
     tb->final();
+    VL_DO_DANGLING(delete tb, tb);
 }

--- a/test_regress/t/t_trace_cat.cpp
+++ b/test_regress/t/t_trace_cat.cpp
@@ -58,6 +58,7 @@ int main(int argc, char** argv, char** env) {
     }
     tfp->close();
     top->final();
+    VL_DO_DANGLING(delete top, top);
     printf("*-* All Finished *-*\n");
     return 0;
 }

--- a/test_regress/t/t_trace_public_func.cpp
+++ b/test_regress/t/t_trace_public_func.cpp
@@ -46,6 +46,7 @@ int main(int argc, char** argv, char** env) {
     }
     tfp->close();
     top->final();
+    VL_DO_DANGLING(delete top, top);
     printf("*-* All Finished *-*\n");
     return 0;
 }

--- a/test_regress/t/t_trace_public_sig.cpp
+++ b/test_regress/t/t_trace_public_sig.cpp
@@ -46,6 +46,7 @@ int main(int argc, char** argv, char** env) {
     }
     tfp->close();
     top->final();
+    VL_DO_DANGLING(delete top, top);
     printf("*-* All Finished *-*\n");
     return 0;
 }

--- a/test_regress/t/t_tri_gate.cpp
+++ b/test_regress/t/t_tri_gate.cpp
@@ -54,5 +54,6 @@ int main() {
     } else {
         vl_fatal(__FILE__, __LINE__, "top", "Unexpected results from tristate test\n");
     }
+    VL_DO_DANGLING(delete tb, tb);
     return 0;
 }

--- a/test_regress/t/t_tri_inout.cpp
+++ b/test_regress/t/t_tri_inout.cpp
@@ -54,5 +54,6 @@ int main() {
     } else {
         vl_fatal(__FILE__, __LINE__, "top", "Unexpected results from inout test\n");
     }
+    VL_DO_DANGLING(delete tb, tb);
     return 0;
 }

--- a/test_regress/t/t_tri_inz.cpp
+++ b/test_regress/t/t_tri_inz.cpp
@@ -44,5 +44,6 @@ int main() {
     } else {
         vl_fatal(__FILE__, __LINE__, "top", "Unexpected results from t_tri_inz\n");
     }
+    VL_DO_DANGLING(delete tb, tb);
     return 0;
 }

--- a/test_regress/t/t_tri_pullup.cpp
+++ b/test_regress/t/t_tri_pullup.cpp
@@ -63,5 +63,6 @@ int main() {
     } else {
         vl_fatal(__FILE__, __LINE__, "top", "Unexpected results from pullup test\n");
     }
+    VL_DO_DANGLING(delete tb, tb);
     return 0;
 }

--- a/test_regress/t/t_tri_select.cpp
+++ b/test_regress/t/t_tri_select.cpp
@@ -66,5 +66,6 @@ int main() {
     } else {
         vl_fatal(__FILE__, __LINE__, "top", "Unexpected results from t_tri_select\n");
     }
+    VL_DO_DANGLING(delete tb, tb);
     return 0;
 }

--- a/test_regress/t/t_var_pinsizes.cpp
+++ b/test_regress/t/t_var_pinsizes.cpp
@@ -15,6 +15,7 @@ int main() {
 
     VL_PRINTF("*-* All Finished *-*\n");
     tb->final();
+    VL_DO_DANGLING(delete tb, tb);
     return 0;
 }
 
@@ -23,5 +24,6 @@ int sc_main(int argc, char* argv[]) {
 
     VL_PRINTF("*-* All Finished *-*\n");
     tb->final();
+    VL_DO_DANGLING(delete tb, tb);
     return 0;
 }

--- a/test_regress/t/t_vpi_sc.cpp
+++ b/test_regress/t/t_vpi_sc.cpp
@@ -12,5 +12,6 @@ int sc_main(int argc, char* argv[]) {
 
     VL_PRINTF("*-* All Finished *-*\n");
     tb->final();
+    VL_DO_DANGLING(delete tb, tb);
     return 0;
 }

--- a/test_regress/t/t_x_assign.cpp
+++ b/test_regress/t/t_x_assign.cpp
@@ -48,6 +48,7 @@ int main(int argc, const char** argv) {
         exit(1);
     }
 
+    VL_DO_DANGLING(delete top, top);
     std::cout << "*-* All Finished *-*" << std::endl;
     return 0;
 }


### PR DESCRIPTION
This patch normalizes what the tests do before exiting. After this
change each test should call final on the top module and explicitly
free the top module object before exiting.
