### PR TITLE
One Verilog IO dir :Set a directory (other than CWD) to use for all verilog file IO

### DIFF
--- a/include/verilated.cpp
+++ b/include/verilated.cpp
@@ -1310,11 +1310,17 @@ IData VL_FERROR_IN(IData, std::string& outputr) VL_MT_SAFE {
     return ret;
 }
 
+void Verilated::setVerilogIODir(const char* dir) {
+    VerilatedImp::setVerilogIODir(dir);
+}
+
 IData VL_FOPEN_NN(const std::string& filename, const std::string& mode) {
-    return VerilatedImp::fdNew(filename.c_str(), mode.c_str());
+    std::string fileAndPath = VerilatedImp::getVerilogIODir() + filename;
+    return VerilatedImp::fdNew(fileAndPath.c_str(), mode.c_str());
 }
 IData VL_FOPEN_MCD_N(const std::string& filename) VL_MT_SAFE {
-    return VerilatedImp::fdNewMcd(filename.c_str());
+    std::string fileAndPath = VerilatedImp::getVerilogIODir() + filename;
+    return VerilatedImp::fdNewMcd(fileAndPath.c_str());
 }
 
 void VL_FFLUSH_I(IData fdi) VL_MT_SAFE { VerilatedImp::fdFlush(fdi); }
@@ -1791,10 +1797,11 @@ VlReadMem::VlReadMem(bool hex, int bits, const std::string& filename, QData star
     , m_end{end}
     , m_addr{start}
     , m_linenum{0} {
-    m_fp = fopen(filename.c_str(), "r");
+    std::string fileAndPath = VerilatedImp::getVerilogIODir() + filename;
+    m_fp = fopen(fileAndPath.c_str(), "r");
     if (VL_UNLIKELY(!m_fp)) {
         // We don't report the Verilog source filename as it slow to have to pass it down
-        VL_FATAL_MT(filename.c_str(), 0, "", "$readmem file not found");
+        VL_FATAL_MT(fileAndPath.c_str(), 0, "", "$readmem file not found");
         // cppcheck-suppress resourceLeak  // m_fp is nullptr - bug in cppcheck
         return;
     }
@@ -1928,10 +1935,10 @@ VlWriteMem::VlWriteMem(bool hex, int bits, const std::string& filename, QData st
         VL_FATAL_MT(filename.c_str(), 0, "", "$writemem invalid address range");
         return;
     }
-
-    m_fp = fopen(filename.c_str(), "w");
+    std::string fileAndPath = VerilatedImp::getVerilogIODir() + filename;
+    m_fp = fopen(fileAndPath.c_str(), "w");
     if (VL_UNLIKELY(!m_fp)) {
-        VL_FATAL_MT(filename.c_str(), 0, "", "$writemem file not found");
+        VL_FATAL_MT(fileAndPath.c_str(), 0, "", "$writemem file not found");
         // cppcheck-suppress resourceLeak  // m_fp is nullptr - bug in cppcheck
         return;
     }

--- a/include/verilated.h
+++ b/include/verilated.h
@@ -545,6 +545,9 @@ public:
 
 public:
     // METHODS - INTERNAL USE ONLY (but public due to what uses it)
+    // Sets a directory (other than CWD) to use for all Verilog file IO
+    static void setVerilogIODir(const char* dir);
+
     // Internal: Create a new module name by concatenating two strings
     static const char* catName(const char* n1, const char* n2,
                                const char* delimiter = ".");  // Returns static data

--- a/include/verilated_imp.h
+++ b/include/verilated_imp.h
@@ -245,6 +245,7 @@ protected:
     int m_exportNext VL_GUARDED_BY(m_exportMutex);  ///< Next export funcnum
 
     // File I/O
+    std::string m_verilogIODir; ///< Directory for Verilog file IO
     VerilatedMutex m_fdMutex;  ///< Protect m_fdps, m_fdFree
     std::vector<FILE*> m_fdps VL_GUARDED_BY(m_fdMutex);  ///< File descriptors
     /// List of free descriptors (SLOW - FOPEN/CLOSE only)
@@ -569,6 +570,13 @@ public:  // But only for verilated*.cpp
         const VerilatedFpList fdlist = fdToFpList(fdi);
         if (VL_UNLIKELY(fdlist.size() != 1)) return nullptr;
         return *fdlist.begin();
+    }
+
+    static void setVerilogIODir(const char* dir) {
+        s_s.v.m_verilogIODir = std::string(dir) + "/";
+    }
+    static std::string getVerilogIODir() {
+        return s_s.v.m_verilogIODir;
     }
 
 private:

--- a/test_regress/.gitignore
+++ b/test_regress/.gitignore
@@ -16,3 +16,4 @@ vc_hdrs.h
 xsim.*/
 *.jou
 *.pb
+t/a_file.mem

--- a/test_regress/t/t_readmem_path.cpp
+++ b/test_regress/t/t_readmem_path.cpp
@@ -1,0 +1,26 @@
+// -*- mode: C++; c-file-style: "cc-mode" -*-
+//
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed into the Public Domain, for any use,
+// without warranty, 2008 by Wilson Snyder.
+
+#include <verilated.h>
+#include <verilated_syms.h>
+#include <verilated_vcd_c.h>
+#include <map>
+#include <string>
+
+#include "Vt_readmem_path.h"
+
+using namespace std;
+
+int main(int argc, char **argv, char **env) {
+    Vt_readmem_path *top = new Vt_readmem_path("top");
+    Verilated::setVerilogIODir("t");
+
+    top->eval();
+    top->final();
+    VL_PRINTF ("*-* All Finished *-*\n");
+    return 0;
+}

--- a/test_regress/t/t_readmem_path.pl
+++ b/test_regress/t/t_readmem_path.pl
@@ -1,0 +1,23 @@
+#!/usr/bin/perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2003 by Wilson Snyder. This program is free software; you can
+# redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+#
+$Self->{vlt} or $Self->skip("Verilator only test");
+
+compile (
+    make_top_shell => 0,
+    make_main => 0,
+    v_flags2 => ["--trace --exe $Self->{t_dir}/$Self->{name}.cpp"],
+         );
+
+execute (
+         check_finished=>1,
+     );
+
+ok(1);
+1;

--- a/test_regress/t/t_readmem_path.v
+++ b/test_regress/t/t_readmem_path.v
@@ -1,0 +1,25 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed into the Public Domain, for any use,
+// without warranty, 2003 by Wilson Snyder.
+
+module t;
+
+   // verilator lint_off LITENDIAN
+   reg [5:0] binary_nostart [2:15];
+   // verilator lint_on LITENDIAN
+
+   integer fd;
+
+   initial begin
+
+      $readmemb("t_sys_readmem_b.mem", binary_nostart);
+      fd = $fopen("a_file.mem", "w");
+      $fdisplay(fd, "This is a file");
+      $fclose(fd);
+      fd = $fopen("a_file.mem", "r");
+
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end
+endmodule


### PR DESCRIPTION
Pretty simple addition, enabling setting the path for file IO. 
