### PR TITLE
Use both gcc and clang in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,15 +11,28 @@ on:
 
 jobs:
   vlt:
-    runs-on: ubuntu-20.04
-    name: build and test
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-20.04]
+        compiler: [clang, gcc]
+        include:
+          - compiler: clang
+            cc: clang
+            cxx: clang++
+          - compiler: gcc
+            cc: gcc
+            cxx: g++
+    runs-on: ${{ matrix.os }}
+    name: ${{ matrix.os }}-${{ matrix.compiler }}-build-test
     env:
       CI_OS_NAME: linux
+      CI_COMMIT: ${{ github.sha }}
       CCACHE_COMPRESS: 1
       CCACHE_DIR: ${{ github.workspace }}/.ccache
-      CCACHE_MAXSIZE: 4Gi
-      CC: ccache gcc
-      CXX: ccache g++
+      CCACHE_MAXSIZE: 2Gi  # 2GiB for clang and gcc, 4GiB in total
+      CC: ${{ matrix.cc }}
+      CXX: ${{ matrix.cxx }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -29,12 +42,9 @@ jobs:
           cache-name: ccache
         with:
           path: ${{ github.workspace }}/.ccache
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ github.ref }}-${{ github.sha }}
+          key: ${{ matrix.os }}-${{ matrix.compiler }}-${{ env.cache-name }}-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
-
+            ${{ matrix.os }}-${{ matrix.compiler }}-${{ env.cache-name }}
       - name: Install packages for build
         env:
           CI_BUILD_STAGE_NAME: build

--- a/ci/ci-ccache-maint.bash
+++ b/ci/ci-ccache-maint.bash
@@ -19,7 +19,7 @@ set -x
 ccache --version
 
 # Flush ccache if requested in commit message
-COMMIT="${TRAVIS_PULL_REQUEST_SHA:-$TRAVIS_COMMIT}"
+COMMIT="${CI_PULL_REQUEST_SHA:-$CI_COMMIT}"
 if git log --format=%B -n 1 "$COMMIT" | grep -q -i '\[CI\s\+ccache\s\+clear\]'; then
   echo "Flushing ccache due to commit message"
   ccache -C


### PR DESCRIPTION
This PR enables checking using clang in addition to gcc.

The remaining TRAVIS_ variable is renamed to CI_.

If a commit message contains `[CI ccache clear]`, ccache will be flushed.

[Here](https://github.com/yTakatsukasa/verilator/actions/runs/401910635) is how it looks.
