### PR TITLE
Ignore some files generated by modelsim

### DIFF
--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -24,6 +24,7 @@
 /obj_dir/
 /obj_dist/
 /obj_iv/
+/obj_ms/
 /obj_nc/
 /obj_opt/
 /obj_vcs/
@@ -46,6 +47,7 @@ src/Makefile$
 src/Makefile_obj$
 include/verilated.mk$
 test_regress/.gdbinit$
+test_regress/transcript
 codecov.yml
 config.cache$
 config.status$

--- a/test_regress/.gitignore
+++ b/test_regress/.gitignore
@@ -11,6 +11,7 @@ simx*
 ncverilog.*
 INCA_libs
 logs
+transcript
 .vcsmx_rebuild
 vc_hdrs.h
 xsim.*/


### PR DESCRIPTION
I think they are safe to be ignored just like other simulators.
