### PR TITLE
Support 'randc' as alias to 'rand'

### DIFF
--- a/bin/verilator
+++ b/bin/verilator
@@ -394,7 +394,6 @@ arguments.
     --public-flat-rw            Mark all variables, etc as public_flat_rw
      -pvalue+<name>=<value>     Overwrite toplevel parameter
     --quiet-exit                Don't print the command on failure
-    --randc-alias               Alias 'randc' to 'rand'
     --relative-includes         Resolve includes relative to current file
     --no-relative-cfuncs        Disallow 'this->' in generated functions
     --report-unoptflat          Extra diagnostics for UNOPTFLAT
@@ -4692,6 +4691,11 @@ declared before being used.
 
 Error that a procedural assignment is setting a wire. According to IEEE, a
 var/reg must be used as the target of procedural assignments.
+
+=item RANDC
+
+Warns that the 'randc' keyword is currently unsupported, and that it is
+being converted to 'rand'.
 
 =item REALCVT
 

--- a/bin/verilator
+++ b/bin/verilator
@@ -394,6 +394,7 @@ arguments.
     --public-flat-rw            Mark all variables, etc as public_flat_rw
      -pvalue+<name>=<value>     Overwrite toplevel parameter
     --quiet-exit                Don't print the command on failure
+    --randc-alias               Alias 'randc' to 'rand'
     --relative-includes         Resolve includes relative to current file
     --no-relative-cfuncs        Disallow 'this->' in generated functions
     --report-unoptflat          Extra diagnostics for UNOPTFLAT

--- a/src/V3Error.h
+++ b/src/V3Error.h
@@ -56,7 +56,6 @@ public:
         E_PORTSHORT,    // Error: Output port is connected to a constant, electrical short
         E_UNSUPPORTED,  // Error: Unsupported (generally)
         E_TASKNSVAR,    // Error: Task I/O not simple
-        E_RANDC,        // Error: Unsupported: 'randc'
         //
         // Warning codes:
         EC_FIRST_WARN,  // Just a code so the program knows where to start warnings
@@ -104,6 +103,7 @@ public:
         PINCONNECTEMPTY,// Cell pin connected by name with empty reference
         PKGNODECL,      // Error: Package/class needs to be predeclared
         PROCASSWIRE,    // Procedural assignment on wire
+        RANDC,          // Unsupported: 'randc' converted to 'rand'
         REALCVT,        // Real conversion
         REDEFMACRO,     // Redefining existing define macro
         SELRANGE,       // Selection index out of range
@@ -150,7 +150,7 @@ public:
             // Boolean
             " I_CELLDEFINE", " I_COVERAGE", " I_TRACING", " I_LINT", " I_DEF_NETTYPE_WIRE",
             // Errors
-            "DETECTARRAY", "ENCAPSULATED", "PORTSHORT", "UNSUPPORTED", "TASKNSVAR", "RANDC",
+            "DETECTARRAY", "ENCAPSULATED", "PORTSHORT", "UNSUPPORTED", "TASKNSVAR",
             // Warnings
             " EC_FIRST_WARN",
             "ALWCOMBORDER", "ASSIGNDLY", "ASSIGNIN",
@@ -165,7 +165,7 @@ public:
             "LITENDIAN", "MODDUP",
             "MULTIDRIVEN", "MULTITOP",
             "PINMISSING", "PINNOCONNECT", "PINCONNECTEMPTY", "PKGNODECL", "PROCASSWIRE",
-            "REALCVT", "REDEFMACRO",
+            "RANDC", "REALCVT", "REDEFMACRO",
             "SELRANGE", "SHORTREAL", "SPLITVAR", "STMTDLY", "SYMRSVDWORD", "SYNCASYNCNET",
             "TICKCOUNT", "TIMESCALEMOD",
             "UNDRIVEN", "UNOPT", "UNOPTFLAT", "UNOPTTHREADS",

--- a/src/V3Error.h
+++ b/src/V3Error.h
@@ -56,6 +56,7 @@ public:
         E_PORTSHORT,    // Error: Output port is connected to a constant, electrical short
         E_UNSUPPORTED,  // Error: Unsupported (generally)
         E_TASKNSVAR,    // Error: Task I/O not simple
+        E_RANDC,        // Error: Unsupported: 'randc'
         //
         // Warning codes:
         EC_FIRST_WARN,  // Just a code so the program knows where to start warnings
@@ -149,7 +150,7 @@ public:
             // Boolean
             " I_CELLDEFINE", " I_COVERAGE", " I_TRACING", " I_LINT", " I_DEF_NETTYPE_WIRE",
             // Errors
-            "DETECTARRAY", "ENCAPSULATED", "PORTSHORT", "UNSUPPORTED", "TASKNSVAR",
+            "DETECTARRAY", "ENCAPSULATED", "PORTSHORT", "UNSUPPORTED", "TASKNSVAR", "RANDC",
             // Warnings
             " EC_FIRST_WARN",
             "ALWCOMBORDER", "ASSIGNDLY", "ASSIGNIN",

--- a/src/V3Options.cpp
+++ b/src/V3Options.cpp
@@ -1084,8 +1084,6 @@ void V3Options::parseOptsList(FileLine* fl, const string& optdir, int argc, char
                 addParameter(string(sw + strlen("-pvalue+")), false);
             } else if (onoff(sw, "-quiet-exit", flag /*ref*/)) {
                 m_quietExit = flag;
-            } else if (onoff(sw, "-randc-alias", flag /*ref*/)) {
-                FileLine::globalWarnOff(V3ErrorCode::E_RANDC, true);
             } else if (onoff(sw, "-relative-cfuncs", flag /*ref*/)) {
                 m_relativeCFuncs = flag;
             } else if (onoff(sw, "-relative-includes", flag /*ref*/)) {

--- a/src/V3Options.cpp
+++ b/src/V3Options.cpp
@@ -1084,6 +1084,8 @@ void V3Options::parseOptsList(FileLine* fl, const string& optdir, int argc, char
                 addParameter(string(sw + strlen("-pvalue+")), false);
             } else if (onoff(sw, "-quiet-exit", flag /*ref*/)) {
                 m_quietExit = flag;
+            } else if (onoff(sw, "-randc-alias", flag /*ref*/)) {
+                FileLine::globalWarnOff(V3ErrorCode::E_RANDC, true);
             } else if (onoff(sw, "-relative-cfuncs", flag /*ref*/)) {
                 m_relativeCFuncs = flag;
             } else if (onoff(sw, "-relative-includes", flag /*ref*/)) {

--- a/src/V3ParseImp.h
+++ b/src/V3ParseImp.h
@@ -84,8 +84,7 @@ struct VMemberQualifiers {
     void applyToNodes(AstVar* nodesp) const {
         for (AstVar* nodep = nodesp; nodep; nodep = VN_CAST(nodep->nextp(), Var)) {
             if (m_randc) {
-                nodep->v3warn(E_RANDC,
-                              "Unsupported: 'randc'. Use --randc-alias to treat as 'rand'");
+                nodep->v3warn(RANDC, "Unsupported: Converting 'randc' to 'rand'");
                 nodep->isRand(true);
             }
             if (m_rand) nodep->isRand(true);

--- a/src/V3ParseImp.h
+++ b/src/V3ParseImp.h
@@ -83,7 +83,11 @@ struct VMemberQualifiers {
     }
     void applyToNodes(AstVar* nodesp) const {
         for (AstVar* nodep = nodesp; nodep; nodep = VN_CAST(nodep->nextp(), Var)) {
-            // Ignored for now: m_randc
+            if (m_randc) {
+                nodep->v3warn(E_RANDC,
+                              "Unsupported: 'randc'. Use --randc-alias to treat as 'rand'");
+                nodep->isRand(true);
+            }
             if (m_rand) nodep->isRand(true);
             if (m_local) nodep->isHideLocal(true);
             if (m_protected) nodep->isHideProtected(true);

--- a/test_regress/t/t_randc_ignore_unsup.pl
+++ b/test_regress/t/t_randc_ignore_unsup.pl
@@ -10,10 +10,12 @@ if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); di
 
 scenarios(vlt => 1);
 
-lint(
-    fails => 1,
+compile(
     verilator_flags2 => ['-Wno-RANDC'],
-    expect_filename => $Self->{golden_filename},
+    );
+
+execute(
+    check_finished => 1,
     );
 
 ok(1);

--- a/test_regress/t/t_randc_ignore_unsup.v
+++ b/test_regress/t/t_randc_ignore_unsup.v
@@ -1,0 +1,38 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2019 by Wilson Snyder.
+// SPDX-License-Identifier: CC0-1.0
+
+class Cls;
+   randc int i;
+
+   function new;
+      i = 0;
+   endfunction
+
+endclass
+
+module t (/*AUTOARG*/);
+   bit ok = 0;
+
+   Cls obj;
+
+   initial begin
+      int rand_result;
+      int prev_i;
+      for (int i = 0; i < 10; i++) begin
+         obj = new;
+         rand_result = obj.randomize();
+         if (i > 0 && obj.i != prev_i) begin
+            ok = 1;
+         end
+         prev_i = obj.i;
+      end
+      if (ok) begin
+         $write("*-* All Finished *-*\n");
+         $finish;
+      end
+      else $stop;
+   end
+endmodule

--- a/test_regress/t/t_randc_unsup.out
+++ b/test_regress/t/t_randc_unsup.out
@@ -1,0 +1,5 @@
+%Warning-RANDC: t/t_randc_unsup.v:8:14: Unsupported: Converting 'randc' to 'rand'
+    8 |    randc int i;
+      |              ^
+                ... Use "/* verilator lint_off RANDC */" and lint_on around source to disable this message.
+%Error: Exiting due to

--- a/test_regress/t/t_randc_unsup.pl
+++ b/test_regress/t/t_randc_unsup.pl
@@ -12,7 +12,6 @@ scenarios(vlt => 1);
 
 lint(
     fails => 1,
-    verilator_flags2 => ['-Wno-RANDC'],
     expect_filename => $Self->{golden_filename},
     );
 

--- a/test_regress/t/t_randc_unsup.v
+++ b/test_regress/t/t_randc_unsup.v
@@ -1,0 +1,12 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2019 by Wilson Snyder.
+// SPDX-License-Identifier: CC0-1.0
+
+class Cls;
+   randc int i;
+endclass
+
+module t (/*AUTOARG*/);
+endmodule


### PR DESCRIPTION
Patch for #2677. Adds a command line option (`--randc-alias`) that makes Verilator treat `randc` as `rand`. Otherwise Verilator stops with an error message when encountering it.

(I decided to do it like this to avoid having the user think that `randc` is actually supported, perhaps there's a better way to do it?)