### PR TITLE
CI: add Windows/MSYS2 package build/test

### DIFF
--- a/.github/workflows/build-win.yml
+++ b/.github/workflows/build-win.yml
@@ -1,0 +1,80 @@
+# DESCRIPTION: Github actions config
+# This name is key to badges in README.adoc, so we use the name 'Build Windows'
+
+name: Build Windows
+
+on:
+  push:
+  pull_request:
+  schedule:
+  - cron: '0 0 * * 0' # weekly
+
+jobs:
+
+
+  win-makepkg:
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { msystem: MINGW64, arch: x86_64 }
+          - { msystem: MINGW32, arch: i686   }
+    name: ${{ matrix.msystem }} | ${{ matrix.arch }} | makepkg
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+
+    - run: git config --global core.autocrlf input
+      shell: bash
+
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - uses: msys2/setup-msys2@v2
+      with:
+        msystem: ${{ matrix.msystem }}
+        update: true
+        install: >
+          base-devel
+          mingw-w64-${{ matrix.arch }}-toolchain
+
+    - name: Build
+      run: |
+        cd ci/msys2
+        makepkg-mingw --noconfirm --noprogressbar -sCLf
+      env:
+        MINGW_INSTALLS: ${{ matrix.msystem }}
+
+    - uses: actions/upload-artifact@v2
+      with:
+        path: ci/msys2/*.zst
+
+
+  win-test:
+    needs: win-makepkg
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { msystem: MINGW64, arch: x86_64 }
+          - { msystem: MINGW32, arch: i686   }
+    name: ${{ matrix.msystem }} | ${{ matrix.arch }} | test
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+
+    - uses: msys2/setup-msys2@v2
+      with:
+        msystem: ${{ matrix.msystem }}
+        update: true
+
+    - uses: actions/download-artifact@v2
+
+    - run: pacman -U --noconfirm --noprogressbar artifact/*.zst
+
+    - run: verilator --help

--- a/.github/workflows/extended-tests.yml
+++ b/.github/workflows/extended-tests.yml
@@ -1,7 +1,7 @@
 # DESCRIPTION: Github actions config
-# This name is key to badges in README.adoc, so we use the name 'Build Windows'
+# This name is key to badges in README.adoc, so we use the name 'Extended Tests'
 
-name: Build Windows
+name: Extended Tests
 
 on:
   push:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,7 @@
 # This name is key to badges in README.rst, so we use the name build
 # SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
 
-name: build
+name: Tests
 
 on:
   push:

--- a/README.rst
+++ b/README.rst
@@ -15,6 +15,8 @@
     :target: https://github.com/verilator/verilator/actions?query=workflow%3Abuild
 .. image:: https://github.com/verilator/verilator/workflows/Build%20Windows/badge.svg
     :target: https://github.com/verilator/verilator/actions?query=workflow%3ABuild%20Windows
+.. image:: https://github.com/verilator/verilator/workflows/Extended%20Tests/badge.svg
+    :target: https://github.com/verilator/verilator/actions?query=workflow%3AExtended%20Tests
 
 
 Welcome to Verilator

--- a/README.rst
+++ b/README.rst
@@ -13,6 +13,8 @@
     :target: https://codecov.io/gh/verilator/verilator
 .. image:: https://github.com/verilator/verilator/workflows/build/badge.svg
     :target: https://github.com/verilator/verilator/actions?query=workflow%3Abuild
+.. image:: https://github.com/verilator/verilator/workflows/Build%20Windows/badge.svg
+    :target: https://github.com/verilator/verilator/actions?query=workflow%3ABuild%20Windows
 
 
 Welcome to Verilator

--- a/ci/msys2/PKGBUILD
+++ b/ci/msys2/PKGBUILD
@@ -1,0 +1,46 @@
+_realname=verilator
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=ci
+pkgrel=1
+pkgdesc="The fastest free Verilog HDL simulator (mingw-w64)"
+arch=('any')
+url="https://www.veripool.org/projects/verilator/wiki/Intro"
+license=("LGPL")
+makedepends=(
+  "${MINGW_PACKAGE_PREFIX}-autotools"
+  "${MINGW_PACKAGE_PREFIX}-cc"
+  "${MINGW_PACKAGE_PREFIX}-python"
+  "flex"
+)
+depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
+
+source=()
+sha256sums=()
+
+prepare() {
+  cp -rf "${srcdir}"/../../.. /tmp/"${_realname}-build-${MINGW_CHOST}"
+  mv /tmp/"${_realname}-build-${MINGW_CHOST}" "${srcdir}/build-${MINGW_CHOST}"
+  cd "${srcdir}/build-${MINGW_CHOST}"
+  sh autoconf
+}
+
+build() {
+  cd "${srcdir}/build-${MINGW_CHOST}"
+
+  cp /usr/include/FlexLexer.h src/
+
+  export MSYS2_ARG_CONV_EXCL="-DDEFENV"
+
+  ./configure \
+    --prefix=${MINGW_PREFIX} \
+    --build=${MINGW_CHOST} \
+    --host=${MINGW_CHOST}
+
+  make
+}
+
+package() {
+  cd "${srcdir}/build-${MINGW_CHOST}"
+  make DESTDIR="${pkgdir}" install
+}


### PR DESCRIPTION
While trying to update the Verilator package in MSYS2 (which is ~8 months behind), I found that compilation would fail.

In order to keep better track of this type of regressions, this PR adds MSYS2 testing to CI: https://github.com/verilator/verilator/actions/runs/411990309. A PKGBUILD recipe is added, which is similar to the upstream but builds the sources surrounding it, instead of downloading a tarball. Then, in one CI job a package is built and uploaded as an artifact. In a second job, the artifact is installed and tested, similarly to how any user would do in a clean environment.

GitHub Action msys2/setup-msys2 is used for setting up MSYS2 and for caching installed packages.

Currently, Linux jobs are failing because I need to add myself to the contributors list properly. However, this PR does not modify those at all.

---

The current build error on MSYS2 is the following:

```
../V3Os.cpp:353:31: error: 'WEXITSTATUS' was not declared in this scope; did you mean 'PNTSTATUS'?
  353 |         const int exit_code = WEXITSTATUS(ret);
      |                               ^~~~~~~~~~~
      |                               PNTSTATUS
make[2]: *** [../Makefile_obj:293: V3Os.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[2]: Leaving directory '/d/a/verilator/verilator/msys2/src/build-x86_64-w64-mingw32/src/obj_opt'
make[1]: *** [Makefile:60: ../bin/verilator_bin] Error 2
make[1]: Leaving directory '/d/a/verilator/verilator/msys2/src/build-x86_64-w64-mingw32/src'
make: *** [Makefile:222: verilator_exe] Error 2
```