### PR TITLE
msys2: define WEXITSTATUS

### DIFF
--- a/src/V3Os.cpp
+++ b/src/V3Os.cpp
@@ -53,8 +53,10 @@
 # ifndef WIFEXITED
 #  ifdef __MINGW32__
 #   define WIFEXITED(w)	(((w) & 0xC0000000) == 0)
+#   define WEXITSTATUS(w)	((w) & ~0xC0000000)
 #  else
 #   define WIFEXITED(w)	(((w) & 0377) == 0)
+#   define WEXITSTATUS(w)	(((w) >> 8) & 0377)
 #  endif
 # endif
 #else


### PR DESCRIPTION
Coming from #2681, this is a fix for building on MSYS2, which complains due to `WEXITSTATUS` being undefined.

> I picked the define from https://github.com/bminor/binutils-gdb/blob/master/gdbsupport/gdb_wait.h#L79-L85 (see [December 10, 2020 8:38 AM](https://gitter.im/msys2/msys2?at=5fd1d066b6b8f41abb81ddc4)).

NOTE: This fix was already upstreamed to MSYS2 repos as a patch for v4.106 half an hour ago: https://github.com/msys2/MINGW-packages/pull/7424.