### PR TITLE
CI: Add separate contributors action

### DIFF
--- a/.github/workflows/contributor.yml
+++ b/.github/workflows/contributor.yml
@@ -1,0 +1,17 @@
+# DESCRIPTION: Github actions config
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+name: Contributor Agreement
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  Test:
+    name: "'docs/CONTRIBUTORS' was signed"
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+    - run: test_regress/t/t_dist_contributors.pl

--- a/ci/ci-script.bash
+++ b/ci/ci-script.bash
@@ -57,9 +57,11 @@ elif [ "$CI_BUILD_STAGE_NAME" = "test" ]; then
   ##############################################################################
   # Run tests
 
+  export VERILATOR_TEST_NO_CONTRIBUTORS=1  # Separate workflow check
+
   if [ "$CI_OS_NAME" = "osx" ]; then
-    export VERILATOR_TEST_NO_GDB=1 # Pain to get GDB to work on OS X
-    export VERILATOR_TEST_NO_GPROF=1 # Apple Clang has no -pg
+    export VERILATOR_TEST_NO_GDB=1  # Pain to get GDB to work on OS X
+    export VERILATOR_TEST_NO_GPROF=1  # Apple Clang has no -pg
     # export PATH="/Applications/gtkwave.app/Contents/Resources/bin:$PATH" # fst2vcd
     file bin/verilator_bin
     file bin/verilator_bin_dbg

--- a/test_regress/t/t_dist_contributors.pl
+++ b/test_regress/t/t_dist_contributors.pl
@@ -19,7 +19,9 @@ my $Debug;
 my %Contributors;
 my %Authors;
 
-if (!-r "$root/.git") {
+if ($ENV{VERILATOR_TEST_NO_CONTRIBUTORS}) {
+    skip("Skipping due to VERILATOR_TEST_NO_CONTRIBUTORS");
+} elsif (!-r "$root/.git") {
     skip("Not in a git repository");
 } else {
     check();


### PR DESCRIPTION
This adds a workflow to check contributor agreement, as this is cleaner than failing normal tests.
