### PR TITLE
VPI: Range iterator fix

### DIFF
--- a/test_regress/t/t_vpi_memory.cpp
+++ b/test_regress/t/t_vpi_memory.cpp
@@ -174,6 +174,9 @@ int _mon_check_memory() {
     CHECK_RESULT_NZ(side_h);
     vpi_get_value(side_h, &value);
     CHECK_RESULT(value.value.integer, 1);
+    // iterator should exhaust after 1 dimension
+    lcl_h = vpi_scan(iter_h);
+    CHECK_RESULT(lcl_h, 0);
 
     // check writing to vpiConstant
     vpi_put_value(side_h, &value, NULL, vpiNoDelay);


### PR DESCRIPTION
Range iterators should return NULL after returning all ranges for the associated object. Otherwise the common way handling of iterators causes an infinite loop:

```cpp
while (hdl = vpi_scan(itr_hdl)) {
  ...
}
```

This PR separates the iterator object from the range object, and ensures that `vpi_scan()` on the iterator returns NULL after the range is returned. Only supports 1 dimension to match `VerilatedVpioVar::rangep()`.

Updated test to verify iterator exhaustion.