### PR TITLE
Test: Use non-blocking assignment as DRIVE macro does in t_prot_lib

### DIFF
--- a/test_regress/t/t_prot_lib.v
+++ b/test_regress/t/t_prot_lib.v
@@ -113,14 +113,14 @@ module t #(parameter GATED_CLK = 0) (/*AUTOARG*/
             `DRIVE(s65)
             `DRIVE(s129)
             `DRIVE(s4x32)
-            {s6x16up_in[0][0], s6x16up_in[0][1], s6x16up_in[0][2]} = crc[47:0];
-            {s6x16up_in[1][0], s6x16up_in[1][1], s6x16up_in[1][2]} = ~crc[63:16];
-            {s8x16up_in[0][0], s8x16up_in[0][1], s8x16up_in[0][2], s8x16up_in[0][3]} = crc;
-            {s8x16up_in[1][0], s8x16up_in[1][1], s8x16up_in[1][2], s8x16up_in[1][3]} = ~crc;
-            {s8x16up_3d_in[0][0][0], s8x16up_3d_in[0][0][1]} = ~crc[31:0];
-            {s8x16up_3d_in[0][1][0], s8x16up_3d_in[0][1][1]} = ~crc[63:32];
-            {s8x16up_3d_in[1][0][0], s8x16up_3d_in[1][0][1]} = crc[31:0];
-            {s8x16up_3d_in[1][1][0], s8x16up_3d_in[1][1][1]} = crc[63:32];
+            {s6x16up_in[0][0], s6x16up_in[0][1], s6x16up_in[0][2]} <= crc[47:0];
+            {s6x16up_in[1][0], s6x16up_in[1][1], s6x16up_in[1][2]} <= ~crc[63:16];
+            {s8x16up_in[0][0], s8x16up_in[0][1], s8x16up_in[0][2], s8x16up_in[0][3]} <= crc;
+            {s8x16up_in[1][0], s8x16up_in[1][1], s8x16up_in[1][2], s8x16up_in[1][3]} <= ~crc;
+            {s8x16up_3d_in[0][0][0], s8x16up_3d_in[0][0][1]} <= ~crc[31:0];
+            {s8x16up_3d_in[0][1][0], s8x16up_3d_in[0][1][1]} <= ~crc[63:32];
+            {s8x16up_3d_in[1][0][0], s8x16up_3d_in[1][0][1]} <= crc[31:0];
+            {s8x16up_3d_in[1][1][0], s8x16up_3d_in[1][1][1]} <= crc[63:32];
             if (cyc == 0) begin
                accum_in <= x*100;
                accum_bypass <= '0;


### PR DESCRIPTION
I found that I should have used non-blocking assignment.

I will merge after CI passes because no C++ code is changed.
