### PR TITLE
Test: Add unpacked array of 1 bit wire to DPI tests

### DIFF
--- a/test_regress/t/t_dpi_arg_inout_unpack.cpp
+++ b/test_regress/t/t_dpi_arg_inout_unpack.cpp
@@ -99,6 +99,17 @@ template <typename T> bool compare(const T& act, const T& exp) {
     }
 }
 
+bool compare_scalar(const svScalar v0, sv_longint_unsigned_t val) {
+    const bool act_bit = v0 == sv_1;
+    const bool exp_bit = val & 1;
+    if (act_bit != exp_bit) {
+        std::cout << "Mismatch at bit:" << 0 << " exp:" << exp_bit << " act:" << act_bit;
+        return false;
+    }
+    if (VERBOSE_MESSAGE) { std::cout << "OK " << val << " as expected " << std::endl; }
+    return true;
+}
+
 bool compare(const svLogicVecVal* v0, sv_longint_unsigned_t val, int bitwidth) {
     for (int i = 0; i < bitwidth; ++i) {
         const bool act_bit = svGetBitselLogic(v0, i);
@@ -162,6 +173,39 @@ template <typename T> bool update_3d(T* v) {
     ++v[(1 * 3 + 0) * 2 + 0];
     ++v[(2 * 3 + 0) * 2 + 0];
     ++v[(3 * 3 + 0) * 2 + 0];
+    return true;
+}
+
+bool update_0d_scalar(svScalar* v) {
+    if (!compare_scalar(v[0], sv_0)) return false;
+    v[0] = sv_1;
+    return true;
+}
+bool update_1d_scalar(svScalar* v) {
+    if (!compare_scalar(v[0], sv_1)) return false;
+    v[0] = sv_0;
+    if (!compare_scalar(v[1], sv_0)) return false;
+    v[1] = sv_1;
+    return true;
+}
+bool update_2d_scalar(svScalar* v) {
+    if (!compare_scalar(v[(0 * 2) + 1], sv_1)) return false;
+    v[(0 * 2) + 1] = sv_0;
+    if (!compare_scalar(v[(1 * 2) + 1], sv_0)) return false;
+    v[(1 * 2) + 1] = sv_1;
+    if (!compare_scalar(v[(2 * 2) + 1], sv_1)) return false;
+    v[(2 * 2) + 1] = sv_0;
+    return true;
+}
+bool update_3d_scalar(svScalar* v) {
+    if (!compare_scalar(v[((0 * 3) + 0) * 2 + 0], sv_0)) return false;
+    v[(0 * 3 + 0) * 2 + 0] = sv_1;
+    if (!compare_scalar(v[((1 * 3) + 0) * 2 + 0], sv_1)) return false;
+    v[(1 * 3 + 0) * 2 + 0] = sv_0;
+    if (!compare_scalar(v[((2 * 3) + 0) * 2 + 0], sv_0)) return false;
+    v[(2 * 3 + 0) * 2 + 0] = sv_1;
+    if (!compare_scalar(v[((3 * 3) + 0) * 2 + 0], sv_1)) return false;
+    v[(3 * 3 + 0) * 2 + 0] = sv_0;
     return true;
 }
 
@@ -481,6 +525,11 @@ void i_string_3d(const char** v) {
     v[(3 * 3 + 0) * 2 + 0] = s3;
 }
 
+void i_bit1_0d(svBit* v) { update_0d_scalar(v); }
+void i_bit1_1d(svBit* v) { update_1d_scalar(v); }
+void i_bit1_2d(svBit* v) { update_2d_scalar(v); }
+void i_bit1_3d(svBit* v) { update_3d_scalar(v); }
+
 void i_bit7_0d(svBitVecVal* v) { update_0d(v, 7); }
 void i_bit7_1d(svBitVecVal* v) { update_1d(v, 7); }
 void i_bit7_2d(svBitVecVal* v) { update_2d(v, 7); }
@@ -490,6 +539,11 @@ void i_bit121_0d(svBitVecVal* v) { update_0d(v, 121); }
 void i_bit121_1d(svBitVecVal* v) { update_1d(v, 121); }
 void i_bit121_2d(svBitVecVal* v) { update_2d(v, 121); }
 void i_bit121_3d(svBitVecVal* v) { update_3d(v, 121); }
+
+void i_logic1_0d(svLogic* v) { update_0d_scalar(v); }
+void i_logic1_1d(svLogic* v) { update_1d_scalar(v); }
+void i_logic1_2d(svLogic* v) { update_2d_scalar(v); }
+void i_logic1_3d(svLogic* v) { update_3d_scalar(v); }
 
 void i_logic7_0d(svLogicVecVal* v) { update_0d(v, 7); }
 void i_logic7_1d(svLogicVecVal* v) { update_1d(v, 7); }

--- a/test_regress/t/t_dpi_arg_inout_unpack__Dpi.out
+++ b/test_regress/t/t_dpi_arg_inout_unpack__Dpi.out
@@ -13,299 +13,331 @@ extern "C" {
     
     
     // DPI EXPORTS
-    // DPI export at t/t_dpi_arg_inout_unpack.v:529:18
+    // DPI export at t/t_dpi_arg_inout_unpack.v:575:18
     extern void e_bit121_0d(svBitVecVal* val);
-    // DPI export at t/t_dpi_arg_inout_unpack.v:530:18
+    // DPI export at t/t_dpi_arg_inout_unpack.v:576:18
     extern void e_bit121_1d(svBitVecVal* val);
-    // DPI export at t/t_dpi_arg_inout_unpack.v:531:18
+    // DPI export at t/t_dpi_arg_inout_unpack.v:577:18
     extern void e_bit121_2d(svBitVecVal* val);
-    // DPI export at t/t_dpi_arg_inout_unpack.v:532:18
+    // DPI export at t/t_dpi_arg_inout_unpack.v:578:18
     extern void e_bit121_3d(svBitVecVal* val);
-    // DPI export at t/t_dpi_arg_inout_unpack.v:524:18
+    // DPI export at t/t_dpi_arg_inout_unpack.v:565:18
+    extern void e_bit1_0d(svBit* val);
+    // DPI export at t/t_dpi_arg_inout_unpack.v:566:18
+    extern void e_bit1_1d(svBit* val);
+    // DPI export at t/t_dpi_arg_inout_unpack.v:567:18
+    extern void e_bit1_2d(svBit* val);
+    // DPI export at t/t_dpi_arg_inout_unpack.v:568:18
+    extern void e_bit1_3d(svBit* val);
+    // DPI export at t/t_dpi_arg_inout_unpack.v:570:18
     extern void e_bit7_0d(svBitVecVal* val);
-    // DPI export at t/t_dpi_arg_inout_unpack.v:525:18
+    // DPI export at t/t_dpi_arg_inout_unpack.v:571:18
     extern void e_bit7_1d(svBitVecVal* val);
-    // DPI export at t/t_dpi_arg_inout_unpack.v:526:18
+    // DPI export at t/t_dpi_arg_inout_unpack.v:572:18
     extern void e_bit7_2d(svBitVecVal* val);
-    // DPI export at t/t_dpi_arg_inout_unpack.v:527:18
+    // DPI export at t/t_dpi_arg_inout_unpack.v:573:18
     extern void e_bit7_3d(svBitVecVal* val);
-    // DPI export at t/t_dpi_arg_inout_unpack.v:395:18
-    extern void e_byte_0d(char* val);
-    // DPI export at t/t_dpi_arg_inout_unpack.v:396:18
-    extern void e_byte_1d(char* val);
-    // DPI export at t/t_dpi_arg_inout_unpack.v:397:18
-    extern void e_byte_2d(char* val);
-    // DPI export at t/t_dpi_arg_inout_unpack.v:398:18
-    extern void e_byte_3d(char* val);
-    // DPI export at t/t_dpi_arg_inout_unpack.v:400:18
-    extern void e_byte_unsigned_0d(unsigned char* val);
-    // DPI export at t/t_dpi_arg_inout_unpack.v:401:18
-    extern void e_byte_unsigned_1d(unsigned char* val);
-    // DPI export at t/t_dpi_arg_inout_unpack.v:402:18
-    extern void e_byte_unsigned_2d(unsigned char* val);
-    // DPI export at t/t_dpi_arg_inout_unpack.v:403:18
-    extern void e_byte_unsigned_3d(unsigned char* val);
-    // DPI export at t/t_dpi_arg_inout_unpack.v:465:18
-    extern void e_chandle_0d(void** val);
-    // DPI export at t/t_dpi_arg_inout_unpack.v:469:18
-    extern void e_chandle_1d(void** val);
-    // DPI export at t/t_dpi_arg_inout_unpack.v:475:18
-    extern void e_chandle_2d(void** val);
-    // DPI export at t/t_dpi_arg_inout_unpack.v:483:18
-    extern void e_chandle_3d(void** val);
-    // DPI export at t/t_dpi_arg_inout_unpack.v:416:18
-    extern void e_int_0d(int* val);
-    // DPI export at t/t_dpi_arg_inout_unpack.v:417:18
-    extern void e_int_1d(int* val);
-    // DPI export at t/t_dpi_arg_inout_unpack.v:418:18
-    extern void e_int_2d(int* val);
-    // DPI export at t/t_dpi_arg_inout_unpack.v:419:18
-    extern void e_int_3d(int* val);
-    // DPI export at t/t_dpi_arg_inout_unpack.v:421:18
-    extern void e_int_unsigned_0d(unsigned int* val);
-    // DPI export at t/t_dpi_arg_inout_unpack.v:422:18
-    extern void e_int_unsigned_1d(unsigned int* val);
-    // DPI export at t/t_dpi_arg_inout_unpack.v:423:18
-    extern void e_int_unsigned_2d(unsigned int* val);
-    // DPI export at t/t_dpi_arg_inout_unpack.v:424:18
-    extern void e_int_unsigned_3d(unsigned int* val);
-    // DPI export at t/t_dpi_arg_inout_unpack.v:446:18
-    extern void e_integer_0d(svLogicVecVal* val);
-    // DPI export at t/t_dpi_arg_inout_unpack.v:447:18
-    extern void e_integer_1d(svLogicVecVal* val);
-    // DPI export at t/t_dpi_arg_inout_unpack.v:448:18
-    extern void e_integer_2d(svLogicVecVal* val);
-    // DPI export at t/t_dpi_arg_inout_unpack.v:449:18
-    extern void e_integer_3d(svLogicVecVal* val);
-    // DPI export at t/t_dpi_arg_inout_unpack.v:539:18
-    extern void e_logic121_0d(svLogicVecVal* val);
-    // DPI export at t/t_dpi_arg_inout_unpack.v:540:18
-    extern void e_logic121_1d(svLogicVecVal* val);
-    // DPI export at t/t_dpi_arg_inout_unpack.v:541:18
-    extern void e_logic121_2d(svLogicVecVal* val);
-    // DPI export at t/t_dpi_arg_inout_unpack.v:542:18
-    extern void e_logic121_3d(svLogicVecVal* val);
-    // DPI export at t/t_dpi_arg_inout_unpack.v:534:18
-    extern void e_logic7_0d(svLogicVecVal* val);
-    // DPI export at t/t_dpi_arg_inout_unpack.v:535:18
-    extern void e_logic7_1d(svLogicVecVal* val);
-    // DPI export at t/t_dpi_arg_inout_unpack.v:536:18
-    extern void e_logic7_2d(svLogicVecVal* val);
-    // DPI export at t/t_dpi_arg_inout_unpack.v:537:18
-    extern void e_logic7_3d(svLogicVecVal* val);
-    // DPI export at t/t_dpi_arg_inout_unpack.v:428:18
-    extern void e_longint_0d(long long* val);
-    // DPI export at t/t_dpi_arg_inout_unpack.v:429:18
-    extern void e_longint_1d(long long* val);
-    // DPI export at t/t_dpi_arg_inout_unpack.v:430:18
-    extern void e_longint_2d(long long* val);
-    // DPI export at t/t_dpi_arg_inout_unpack.v:431:18
-    extern void e_longint_3d(long long* val);
-    // DPI export at t/t_dpi_arg_inout_unpack.v:433:18
-    extern void e_longint_unsigned_0d(unsigned long long* val);
-    // DPI export at t/t_dpi_arg_inout_unpack.v:434:18
-    extern void e_longint_unsigned_1d(unsigned long long* val);
-    // DPI export at t/t_dpi_arg_inout_unpack.v:435:18
-    extern void e_longint_unsigned_2d(unsigned long long* val);
     // DPI export at t/t_dpi_arg_inout_unpack.v:436:18
-    extern void e_longint_unsigned_3d(unsigned long long* val);
-    // DPI export at t/t_dpi_arg_inout_unpack.v:544:18
-    extern void e_pack_struct_0d(svLogicVecVal* val);
-    // DPI export at t/t_dpi_arg_inout_unpack.v:545:18
-    extern void e_pack_struct_1d(svLogicVecVal* val);
-    // DPI export at t/t_dpi_arg_inout_unpack.v:546:18
-    extern void e_pack_struct_2d(svLogicVecVal* val);
-    // DPI export at t/t_dpi_arg_inout_unpack.v:547:18
-    extern void e_pack_struct_3d(svLogicVecVal* val);
-    // DPI export at t/t_dpi_arg_inout_unpack.v:452:18
-    extern void e_real_0d(double* val);
-    // DPI export at t/t_dpi_arg_inout_unpack.v:453:18
-    extern void e_real_1d(double* val);
-    // DPI export at t/t_dpi_arg_inout_unpack.v:454:18
-    extern void e_real_2d(double* val);
-    // DPI export at t/t_dpi_arg_inout_unpack.v:455:18
-    extern void e_real_3d(double* val);
-    // DPI export at t/t_dpi_arg_inout_unpack.v:405:18
-    extern void e_shortint_0d(short* val);
-    // DPI export at t/t_dpi_arg_inout_unpack.v:406:18
-    extern void e_shortint_1d(short* val);
-    // DPI export at t/t_dpi_arg_inout_unpack.v:407:18
-    extern void e_shortint_2d(short* val);
-    // DPI export at t/t_dpi_arg_inout_unpack.v:408:18
-    extern void e_shortint_3d(short* val);
-    // DPI export at t/t_dpi_arg_inout_unpack.v:410:18
-    extern void e_shortint_unsigned_0d(unsigned short* val);
-    // DPI export at t/t_dpi_arg_inout_unpack.v:411:18
-    extern void e_shortint_unsigned_1d(unsigned short* val);
-    // DPI export at t/t_dpi_arg_inout_unpack.v:412:18
-    extern void e_shortint_unsigned_2d(unsigned short* val);
-    // DPI export at t/t_dpi_arg_inout_unpack.v:413:18
-    extern void e_shortint_unsigned_3d(unsigned short* val);
-    // DPI export at t/t_dpi_arg_inout_unpack.v:495:18
-    extern void e_string_0d(const char** val);
-    // DPI export at t/t_dpi_arg_inout_unpack.v:499:18
-    extern void e_string_1d(const char** val);
-    // DPI export at t/t_dpi_arg_inout_unpack.v:505:18
-    extern void e_string_2d(const char** val);
-    // DPI export at t/t_dpi_arg_inout_unpack.v:513:18
-    extern void e_string_3d(const char** val);
+    extern void e_byte_0d(char* val);
+    // DPI export at t/t_dpi_arg_inout_unpack.v:437:18
+    extern void e_byte_1d(char* val);
+    // DPI export at t/t_dpi_arg_inout_unpack.v:438:18
+    extern void e_byte_2d(char* val);
     // DPI export at t/t_dpi_arg_inout_unpack.v:439:18
-    extern void e_time_0d(svLogicVecVal* val);
-    // DPI export at t/t_dpi_arg_inout_unpack.v:440:18
-    extern void e_time_1d(svLogicVecVal* val);
+    extern void e_byte_3d(char* val);
     // DPI export at t/t_dpi_arg_inout_unpack.v:441:18
-    extern void e_time_2d(svLogicVecVal* val);
+    extern void e_byte_unsigned_0d(unsigned char* val);
     // DPI export at t/t_dpi_arg_inout_unpack.v:442:18
+    extern void e_byte_unsigned_1d(unsigned char* val);
+    // DPI export at t/t_dpi_arg_inout_unpack.v:443:18
+    extern void e_byte_unsigned_2d(unsigned char* val);
+    // DPI export at t/t_dpi_arg_inout_unpack.v:444:18
+    extern void e_byte_unsigned_3d(unsigned char* val);
+    // DPI export at t/t_dpi_arg_inout_unpack.v:506:18
+    extern void e_chandle_0d(void** val);
+    // DPI export at t/t_dpi_arg_inout_unpack.v:510:18
+    extern void e_chandle_1d(void** val);
+    // DPI export at t/t_dpi_arg_inout_unpack.v:516:18
+    extern void e_chandle_2d(void** val);
+    // DPI export at t/t_dpi_arg_inout_unpack.v:524:18
+    extern void e_chandle_3d(void** val);
+    // DPI export at t/t_dpi_arg_inout_unpack.v:457:18
+    extern void e_int_0d(int* val);
+    // DPI export at t/t_dpi_arg_inout_unpack.v:458:18
+    extern void e_int_1d(int* val);
+    // DPI export at t/t_dpi_arg_inout_unpack.v:459:18
+    extern void e_int_2d(int* val);
+    // DPI export at t/t_dpi_arg_inout_unpack.v:460:18
+    extern void e_int_3d(int* val);
+    // DPI export at t/t_dpi_arg_inout_unpack.v:462:18
+    extern void e_int_unsigned_0d(unsigned int* val);
+    // DPI export at t/t_dpi_arg_inout_unpack.v:463:18
+    extern void e_int_unsigned_1d(unsigned int* val);
+    // DPI export at t/t_dpi_arg_inout_unpack.v:464:18
+    extern void e_int_unsigned_2d(unsigned int* val);
+    // DPI export at t/t_dpi_arg_inout_unpack.v:465:18
+    extern void e_int_unsigned_3d(unsigned int* val);
+    // DPI export at t/t_dpi_arg_inout_unpack.v:487:18
+    extern void e_integer_0d(svLogicVecVal* val);
+    // DPI export at t/t_dpi_arg_inout_unpack.v:488:18
+    extern void e_integer_1d(svLogicVecVal* val);
+    // DPI export at t/t_dpi_arg_inout_unpack.v:489:18
+    extern void e_integer_2d(svLogicVecVal* val);
+    // DPI export at t/t_dpi_arg_inout_unpack.v:490:18
+    extern void e_integer_3d(svLogicVecVal* val);
+    // DPI export at t/t_dpi_arg_inout_unpack.v:590:18
+    extern void e_logic121_0d(svLogicVecVal* val);
+    // DPI export at t/t_dpi_arg_inout_unpack.v:591:18
+    extern void e_logic121_1d(svLogicVecVal* val);
+    // DPI export at t/t_dpi_arg_inout_unpack.v:592:18
+    extern void e_logic121_2d(svLogicVecVal* val);
+    // DPI export at t/t_dpi_arg_inout_unpack.v:593:18
+    extern void e_logic121_3d(svLogicVecVal* val);
+    // DPI export at t/t_dpi_arg_inout_unpack.v:580:18
+    extern void e_logic1_0d(svLogic* val);
+    // DPI export at t/t_dpi_arg_inout_unpack.v:581:18
+    extern void e_logic1_1d(svLogic* val);
+    // DPI export at t/t_dpi_arg_inout_unpack.v:582:18
+    extern void e_logic1_2d(svLogic* val);
+    // DPI export at t/t_dpi_arg_inout_unpack.v:583:18
+    extern void e_logic1_3d(svLogic* val);
+    // DPI export at t/t_dpi_arg_inout_unpack.v:585:18
+    extern void e_logic7_0d(svLogicVecVal* val);
+    // DPI export at t/t_dpi_arg_inout_unpack.v:586:18
+    extern void e_logic7_1d(svLogicVecVal* val);
+    // DPI export at t/t_dpi_arg_inout_unpack.v:587:18
+    extern void e_logic7_2d(svLogicVecVal* val);
+    // DPI export at t/t_dpi_arg_inout_unpack.v:588:18
+    extern void e_logic7_3d(svLogicVecVal* val);
+    // DPI export at t/t_dpi_arg_inout_unpack.v:469:18
+    extern void e_longint_0d(long long* val);
+    // DPI export at t/t_dpi_arg_inout_unpack.v:470:18
+    extern void e_longint_1d(long long* val);
+    // DPI export at t/t_dpi_arg_inout_unpack.v:471:18
+    extern void e_longint_2d(long long* val);
+    // DPI export at t/t_dpi_arg_inout_unpack.v:472:18
+    extern void e_longint_3d(long long* val);
+    // DPI export at t/t_dpi_arg_inout_unpack.v:474:18
+    extern void e_longint_unsigned_0d(unsigned long long* val);
+    // DPI export at t/t_dpi_arg_inout_unpack.v:475:18
+    extern void e_longint_unsigned_1d(unsigned long long* val);
+    // DPI export at t/t_dpi_arg_inout_unpack.v:476:18
+    extern void e_longint_unsigned_2d(unsigned long long* val);
+    // DPI export at t/t_dpi_arg_inout_unpack.v:477:18
+    extern void e_longint_unsigned_3d(unsigned long long* val);
+    // DPI export at t/t_dpi_arg_inout_unpack.v:595:18
+    extern void e_pack_struct_0d(svLogicVecVal* val);
+    // DPI export at t/t_dpi_arg_inout_unpack.v:596:18
+    extern void e_pack_struct_1d(svLogicVecVal* val);
+    // DPI export at t/t_dpi_arg_inout_unpack.v:597:18
+    extern void e_pack_struct_2d(svLogicVecVal* val);
+    // DPI export at t/t_dpi_arg_inout_unpack.v:598:18
+    extern void e_pack_struct_3d(svLogicVecVal* val);
+    // DPI export at t/t_dpi_arg_inout_unpack.v:493:18
+    extern void e_real_0d(double* val);
+    // DPI export at t/t_dpi_arg_inout_unpack.v:494:18
+    extern void e_real_1d(double* val);
+    // DPI export at t/t_dpi_arg_inout_unpack.v:495:18
+    extern void e_real_2d(double* val);
+    // DPI export at t/t_dpi_arg_inout_unpack.v:496:18
+    extern void e_real_3d(double* val);
+    // DPI export at t/t_dpi_arg_inout_unpack.v:446:18
+    extern void e_shortint_0d(short* val);
+    // DPI export at t/t_dpi_arg_inout_unpack.v:447:18
+    extern void e_shortint_1d(short* val);
+    // DPI export at t/t_dpi_arg_inout_unpack.v:448:18
+    extern void e_shortint_2d(short* val);
+    // DPI export at t/t_dpi_arg_inout_unpack.v:449:18
+    extern void e_shortint_3d(short* val);
+    // DPI export at t/t_dpi_arg_inout_unpack.v:451:18
+    extern void e_shortint_unsigned_0d(unsigned short* val);
+    // DPI export at t/t_dpi_arg_inout_unpack.v:452:18
+    extern void e_shortint_unsigned_1d(unsigned short* val);
+    // DPI export at t/t_dpi_arg_inout_unpack.v:453:18
+    extern void e_shortint_unsigned_2d(unsigned short* val);
+    // DPI export at t/t_dpi_arg_inout_unpack.v:454:18
+    extern void e_shortint_unsigned_3d(unsigned short* val);
+    // DPI export at t/t_dpi_arg_inout_unpack.v:536:18
+    extern void e_string_0d(const char** val);
+    // DPI export at t/t_dpi_arg_inout_unpack.v:540:18
+    extern void e_string_1d(const char** val);
+    // DPI export at t/t_dpi_arg_inout_unpack.v:546:18
+    extern void e_string_2d(const char** val);
+    // DPI export at t/t_dpi_arg_inout_unpack.v:554:18
+    extern void e_string_3d(const char** val);
+    // DPI export at t/t_dpi_arg_inout_unpack.v:480:18
+    extern void e_time_0d(svLogicVecVal* val);
+    // DPI export at t/t_dpi_arg_inout_unpack.v:481:18
+    extern void e_time_1d(svLogicVecVal* val);
+    // DPI export at t/t_dpi_arg_inout_unpack.v:482:18
+    extern void e_time_2d(svLogicVecVal* val);
+    // DPI export at t/t_dpi_arg_inout_unpack.v:483:18
     extern void e_time_3d(svLogicVecVal* val);
     
     // DPI IMPORTS
-    // DPI import at t/t_dpi_arg_inout_unpack.v:584:41
+    // DPI import at t/t_dpi_arg_inout_unpack.v:635:41
     extern void check_exports();
-    // DPI import at t/t_dpi_arg_inout_unpack.v:171:36
+    // DPI import at t/t_dpi_arg_inout_unpack.v:192:36
     extern void* get_non_null();
-    // DPI import at t/t_dpi_arg_inout_unpack.v:254:33
+    // DPI import at t/t_dpi_arg_inout_unpack.v:280:33
     extern void i_bit121_0d(svBitVecVal* val);
-    // DPI import at t/t_dpi_arg_inout_unpack.v:255:33
+    // DPI import at t/t_dpi_arg_inout_unpack.v:281:33
     extern void i_bit121_1d(svBitVecVal* val);
-    // DPI import at t/t_dpi_arg_inout_unpack.v:256:33
+    // DPI import at t/t_dpi_arg_inout_unpack.v:282:33
     extern void i_bit121_2d(svBitVecVal* val);
-    // DPI import at t/t_dpi_arg_inout_unpack.v:257:33
+    // DPI import at t/t_dpi_arg_inout_unpack.v:283:33
     extern void i_bit121_3d(svBitVecVal* val);
-    // DPI import at t/t_dpi_arg_inout_unpack.v:249:33
-    extern void i_bit7_0d(svBitVecVal* val);
-    // DPI import at t/t_dpi_arg_inout_unpack.v:250:33
-    extern void i_bit7_1d(svBitVecVal* val);
-    // DPI import at t/t_dpi_arg_inout_unpack.v:251:33
-    extern void i_bit7_2d(svBitVecVal* val);
-    // DPI import at t/t_dpi_arg_inout_unpack.v:252:33
-    extern void i_bit7_3d(svBitVecVal* val);
-    // DPI import at t/t_dpi_arg_inout_unpack.v:173:33
-    extern void i_byte_0d(char* val);
-    // DPI import at t/t_dpi_arg_inout_unpack.v:174:33
-    extern void i_byte_1d(char* val);
-    // DPI import at t/t_dpi_arg_inout_unpack.v:175:33
-    extern void i_byte_2d(char* val);
-    // DPI import at t/t_dpi_arg_inout_unpack.v:176:33
-    extern void i_byte_3d(char* val);
-    // DPI import at t/t_dpi_arg_inout_unpack.v:178:33
-    extern void i_byte_unsigned_0d(unsigned char* val);
-    // DPI import at t/t_dpi_arg_inout_unpack.v:179:33
-    extern void i_byte_unsigned_1d(unsigned char* val);
-    // DPI import at t/t_dpi_arg_inout_unpack.v:180:33
-    extern void i_byte_unsigned_2d(unsigned char* val);
-    // DPI import at t/t_dpi_arg_inout_unpack.v:181:33
-    extern void i_byte_unsigned_3d(unsigned char* val);
-    // DPI import at t/t_dpi_arg_inout_unpack.v:239:33
-    extern void i_chandle_0d(void** val);
-    // DPI import at t/t_dpi_arg_inout_unpack.v:240:33
-    extern void i_chandle_1d(void** val);
-    // DPI import at t/t_dpi_arg_inout_unpack.v:241:33
-    extern void i_chandle_2d(void** val);
-    // DPI import at t/t_dpi_arg_inout_unpack.v:242:33
-    extern void i_chandle_3d(void** val);
-    // DPI import at t/t_dpi_arg_inout_unpack.v:193:33
-    extern void i_int_0d(int* val);
-    // DPI import at t/t_dpi_arg_inout_unpack.v:194:33
-    extern void i_int_1d(int* val);
-    // DPI import at t/t_dpi_arg_inout_unpack.v:195:33
-    extern void i_int_2d(int* val);
-    // DPI import at t/t_dpi_arg_inout_unpack.v:196:33
-    extern void i_int_3d(int* val);
-    // DPI import at t/t_dpi_arg_inout_unpack.v:198:33
-    extern void i_int_unsigned_0d(unsigned int* val);
-    // DPI import at t/t_dpi_arg_inout_unpack.v:199:33
-    extern void i_int_unsigned_1d(unsigned int* val);
-    // DPI import at t/t_dpi_arg_inout_unpack.v:200:33
-    extern void i_int_unsigned_2d(unsigned int* val);
-    // DPI import at t/t_dpi_arg_inout_unpack.v:201:33
-    extern void i_int_unsigned_3d(unsigned int* val);
-    // DPI import at t/t_dpi_arg_inout_unpack.v:221:33
-    extern void i_integer_0d(svLogicVecVal* val);
-    // DPI import at t/t_dpi_arg_inout_unpack.v:222:33
-    extern void i_integer_1d(svLogicVecVal* val);
-    // DPI import at t/t_dpi_arg_inout_unpack.v:223:33
-    extern void i_integer_2d(svLogicVecVal* val);
-    // DPI import at t/t_dpi_arg_inout_unpack.v:224:33
-    extern void i_integer_3d(svLogicVecVal* val);
-    // DPI import at t/t_dpi_arg_inout_unpack.v:264:33
-    extern void i_logic121_0d(svLogicVecVal* val);
-    // DPI import at t/t_dpi_arg_inout_unpack.v:265:33
-    extern void i_logic121_1d(svLogicVecVal* val);
-    // DPI import at t/t_dpi_arg_inout_unpack.v:266:33
-    extern void i_logic121_2d(svLogicVecVal* val);
-    // DPI import at t/t_dpi_arg_inout_unpack.v:267:33
-    extern void i_logic121_3d(svLogicVecVal* val);
-    // DPI import at t/t_dpi_arg_inout_unpack.v:259:33
-    extern void i_logic7_0d(svLogicVecVal* val);
-    // DPI import at t/t_dpi_arg_inout_unpack.v:260:33
-    extern void i_logic7_1d(svLogicVecVal* val);
-    // DPI import at t/t_dpi_arg_inout_unpack.v:261:33
-    extern void i_logic7_2d(svLogicVecVal* val);
-    // DPI import at t/t_dpi_arg_inout_unpack.v:262:33
-    extern void i_logic7_3d(svLogicVecVal* val);
-    // DPI import at t/t_dpi_arg_inout_unpack.v:203:33
-    extern void i_longint_0d(long long* val);
-    // DPI import at t/t_dpi_arg_inout_unpack.v:204:33
-    extern void i_longint_1d(long long* val);
-    // DPI import at t/t_dpi_arg_inout_unpack.v:205:33
-    extern void i_longint_2d(long long* val);
-    // DPI import at t/t_dpi_arg_inout_unpack.v:206:33
-    extern void i_longint_3d(long long* val);
-    // DPI import at t/t_dpi_arg_inout_unpack.v:208:33
-    extern void i_longint_unsigned_0d(unsigned long long* val);
-    // DPI import at t/t_dpi_arg_inout_unpack.v:209:33
-    extern void i_longint_unsigned_1d(unsigned long long* val);
-    // DPI import at t/t_dpi_arg_inout_unpack.v:210:33
-    extern void i_longint_unsigned_2d(unsigned long long* val);
-    // DPI import at t/t_dpi_arg_inout_unpack.v:211:33
-    extern void i_longint_unsigned_3d(unsigned long long* val);
-    // DPI import at t/t_dpi_arg_inout_unpack.v:269:33
-    extern void i_pack_struct_0d(svLogicVecVal* val);
     // DPI import at t/t_dpi_arg_inout_unpack.v:270:33
-    extern void i_pack_struct_1d(svLogicVecVal* val);
+    extern void i_bit1_0d(svBit* val);
     // DPI import at t/t_dpi_arg_inout_unpack.v:271:33
-    extern void i_pack_struct_2d(svLogicVecVal* val);
+    extern void i_bit1_1d(svBit* val);
     // DPI import at t/t_dpi_arg_inout_unpack.v:272:33
-    extern void i_pack_struct_3d(svLogicVecVal* val);
-    // DPI import at t/t_dpi_arg_inout_unpack.v:227:33
-    extern void i_real_0d(double* val);
-    // DPI import at t/t_dpi_arg_inout_unpack.v:228:33
-    extern void i_real_1d(double* val);
-    // DPI import at t/t_dpi_arg_inout_unpack.v:229:33
-    extern void i_real_2d(double* val);
-    // DPI import at t/t_dpi_arg_inout_unpack.v:230:33
-    extern void i_real_3d(double* val);
-    // DPI import at t/t_dpi_arg_inout_unpack.v:183:33
-    extern void i_shortint_0d(short* val);
-    // DPI import at t/t_dpi_arg_inout_unpack.v:184:33
-    extern void i_shortint_1d(short* val);
-    // DPI import at t/t_dpi_arg_inout_unpack.v:185:33
-    extern void i_shortint_2d(short* val);
-    // DPI import at t/t_dpi_arg_inout_unpack.v:186:33
-    extern void i_shortint_3d(short* val);
-    // DPI import at t/t_dpi_arg_inout_unpack.v:188:33
-    extern void i_shortint_unsigned_0d(unsigned short* val);
-    // DPI import at t/t_dpi_arg_inout_unpack.v:189:33
-    extern void i_shortint_unsigned_1d(unsigned short* val);
-    // DPI import at t/t_dpi_arg_inout_unpack.v:190:33
-    extern void i_shortint_unsigned_2d(unsigned short* val);
-    // DPI import at t/t_dpi_arg_inout_unpack.v:191:33
-    extern void i_shortint_unsigned_3d(unsigned short* val);
-    // DPI import at t/t_dpi_arg_inout_unpack.v:244:33
-    extern void i_string_0d(const char** val);
-    // DPI import at t/t_dpi_arg_inout_unpack.v:245:33
-    extern void i_string_1d(const char** val);
-    // DPI import at t/t_dpi_arg_inout_unpack.v:246:33
-    extern void i_string_2d(const char** val);
-    // DPI import at t/t_dpi_arg_inout_unpack.v:247:33
-    extern void i_string_3d(const char** val);
+    extern void i_bit1_2d(svBit* val);
+    // DPI import at t/t_dpi_arg_inout_unpack.v:273:33
+    extern void i_bit1_3d(svBit* val);
+    // DPI import at t/t_dpi_arg_inout_unpack.v:275:33
+    extern void i_bit7_0d(svBitVecVal* val);
+    // DPI import at t/t_dpi_arg_inout_unpack.v:276:33
+    extern void i_bit7_1d(svBitVecVal* val);
+    // DPI import at t/t_dpi_arg_inout_unpack.v:277:33
+    extern void i_bit7_2d(svBitVecVal* val);
+    // DPI import at t/t_dpi_arg_inout_unpack.v:278:33
+    extern void i_bit7_3d(svBitVecVal* val);
+    // DPI import at t/t_dpi_arg_inout_unpack.v:194:33
+    extern void i_byte_0d(char* val);
+    // DPI import at t/t_dpi_arg_inout_unpack.v:195:33
+    extern void i_byte_1d(char* val);
+    // DPI import at t/t_dpi_arg_inout_unpack.v:196:33
+    extern void i_byte_2d(char* val);
+    // DPI import at t/t_dpi_arg_inout_unpack.v:197:33
+    extern void i_byte_3d(char* val);
+    // DPI import at t/t_dpi_arg_inout_unpack.v:199:33
+    extern void i_byte_unsigned_0d(unsigned char* val);
+    // DPI import at t/t_dpi_arg_inout_unpack.v:200:33
+    extern void i_byte_unsigned_1d(unsigned char* val);
+    // DPI import at t/t_dpi_arg_inout_unpack.v:201:33
+    extern void i_byte_unsigned_2d(unsigned char* val);
+    // DPI import at t/t_dpi_arg_inout_unpack.v:202:33
+    extern void i_byte_unsigned_3d(unsigned char* val);
+    // DPI import at t/t_dpi_arg_inout_unpack.v:260:33
+    extern void i_chandle_0d(void** val);
+    // DPI import at t/t_dpi_arg_inout_unpack.v:261:33
+    extern void i_chandle_1d(void** val);
+    // DPI import at t/t_dpi_arg_inout_unpack.v:262:33
+    extern void i_chandle_2d(void** val);
+    // DPI import at t/t_dpi_arg_inout_unpack.v:263:33
+    extern void i_chandle_3d(void** val);
     // DPI import at t/t_dpi_arg_inout_unpack.v:214:33
-    extern void i_time_0d(svLogicVecVal* val);
+    extern void i_int_0d(int* val);
     // DPI import at t/t_dpi_arg_inout_unpack.v:215:33
-    extern void i_time_1d(svLogicVecVal* val);
+    extern void i_int_1d(int* val);
     // DPI import at t/t_dpi_arg_inout_unpack.v:216:33
-    extern void i_time_2d(svLogicVecVal* val);
+    extern void i_int_2d(int* val);
     // DPI import at t/t_dpi_arg_inout_unpack.v:217:33
+    extern void i_int_3d(int* val);
+    // DPI import at t/t_dpi_arg_inout_unpack.v:219:33
+    extern void i_int_unsigned_0d(unsigned int* val);
+    // DPI import at t/t_dpi_arg_inout_unpack.v:220:33
+    extern void i_int_unsigned_1d(unsigned int* val);
+    // DPI import at t/t_dpi_arg_inout_unpack.v:221:33
+    extern void i_int_unsigned_2d(unsigned int* val);
+    // DPI import at t/t_dpi_arg_inout_unpack.v:222:33
+    extern void i_int_unsigned_3d(unsigned int* val);
+    // DPI import at t/t_dpi_arg_inout_unpack.v:242:33
+    extern void i_integer_0d(svLogicVecVal* val);
+    // DPI import at t/t_dpi_arg_inout_unpack.v:243:33
+    extern void i_integer_1d(svLogicVecVal* val);
+    // DPI import at t/t_dpi_arg_inout_unpack.v:244:33
+    extern void i_integer_2d(svLogicVecVal* val);
+    // DPI import at t/t_dpi_arg_inout_unpack.v:245:33
+    extern void i_integer_3d(svLogicVecVal* val);
+    // DPI import at t/t_dpi_arg_inout_unpack.v:295:33
+    extern void i_logic121_0d(svLogicVecVal* val);
+    // DPI import at t/t_dpi_arg_inout_unpack.v:296:33
+    extern void i_logic121_1d(svLogicVecVal* val);
+    // DPI import at t/t_dpi_arg_inout_unpack.v:297:33
+    extern void i_logic121_2d(svLogicVecVal* val);
+    // DPI import at t/t_dpi_arg_inout_unpack.v:298:33
+    extern void i_logic121_3d(svLogicVecVal* val);
+    // DPI import at t/t_dpi_arg_inout_unpack.v:285:33
+    extern void i_logic1_0d(svLogic* val);
+    // DPI import at t/t_dpi_arg_inout_unpack.v:286:33
+    extern void i_logic1_1d(svLogic* val);
+    // DPI import at t/t_dpi_arg_inout_unpack.v:287:33
+    extern void i_logic1_2d(svLogic* val);
+    // DPI import at t/t_dpi_arg_inout_unpack.v:288:33
+    extern void i_logic1_3d(svLogic* val);
+    // DPI import at t/t_dpi_arg_inout_unpack.v:290:33
+    extern void i_logic7_0d(svLogicVecVal* val);
+    // DPI import at t/t_dpi_arg_inout_unpack.v:291:33
+    extern void i_logic7_1d(svLogicVecVal* val);
+    // DPI import at t/t_dpi_arg_inout_unpack.v:292:33
+    extern void i_logic7_2d(svLogicVecVal* val);
+    // DPI import at t/t_dpi_arg_inout_unpack.v:293:33
+    extern void i_logic7_3d(svLogicVecVal* val);
+    // DPI import at t/t_dpi_arg_inout_unpack.v:224:33
+    extern void i_longint_0d(long long* val);
+    // DPI import at t/t_dpi_arg_inout_unpack.v:225:33
+    extern void i_longint_1d(long long* val);
+    // DPI import at t/t_dpi_arg_inout_unpack.v:226:33
+    extern void i_longint_2d(long long* val);
+    // DPI import at t/t_dpi_arg_inout_unpack.v:227:33
+    extern void i_longint_3d(long long* val);
+    // DPI import at t/t_dpi_arg_inout_unpack.v:229:33
+    extern void i_longint_unsigned_0d(unsigned long long* val);
+    // DPI import at t/t_dpi_arg_inout_unpack.v:230:33
+    extern void i_longint_unsigned_1d(unsigned long long* val);
+    // DPI import at t/t_dpi_arg_inout_unpack.v:231:33
+    extern void i_longint_unsigned_2d(unsigned long long* val);
+    // DPI import at t/t_dpi_arg_inout_unpack.v:232:33
+    extern void i_longint_unsigned_3d(unsigned long long* val);
+    // DPI import at t/t_dpi_arg_inout_unpack.v:300:33
+    extern void i_pack_struct_0d(svLogicVecVal* val);
+    // DPI import at t/t_dpi_arg_inout_unpack.v:301:33
+    extern void i_pack_struct_1d(svLogicVecVal* val);
+    // DPI import at t/t_dpi_arg_inout_unpack.v:302:33
+    extern void i_pack_struct_2d(svLogicVecVal* val);
+    // DPI import at t/t_dpi_arg_inout_unpack.v:303:33
+    extern void i_pack_struct_3d(svLogicVecVal* val);
+    // DPI import at t/t_dpi_arg_inout_unpack.v:248:33
+    extern void i_real_0d(double* val);
+    // DPI import at t/t_dpi_arg_inout_unpack.v:249:33
+    extern void i_real_1d(double* val);
+    // DPI import at t/t_dpi_arg_inout_unpack.v:250:33
+    extern void i_real_2d(double* val);
+    // DPI import at t/t_dpi_arg_inout_unpack.v:251:33
+    extern void i_real_3d(double* val);
+    // DPI import at t/t_dpi_arg_inout_unpack.v:204:33
+    extern void i_shortint_0d(short* val);
+    // DPI import at t/t_dpi_arg_inout_unpack.v:205:33
+    extern void i_shortint_1d(short* val);
+    // DPI import at t/t_dpi_arg_inout_unpack.v:206:33
+    extern void i_shortint_2d(short* val);
+    // DPI import at t/t_dpi_arg_inout_unpack.v:207:33
+    extern void i_shortint_3d(short* val);
+    // DPI import at t/t_dpi_arg_inout_unpack.v:209:33
+    extern void i_shortint_unsigned_0d(unsigned short* val);
+    // DPI import at t/t_dpi_arg_inout_unpack.v:210:33
+    extern void i_shortint_unsigned_1d(unsigned short* val);
+    // DPI import at t/t_dpi_arg_inout_unpack.v:211:33
+    extern void i_shortint_unsigned_2d(unsigned short* val);
+    // DPI import at t/t_dpi_arg_inout_unpack.v:212:33
+    extern void i_shortint_unsigned_3d(unsigned short* val);
+    // DPI import at t/t_dpi_arg_inout_unpack.v:265:33
+    extern void i_string_0d(const char** val);
+    // DPI import at t/t_dpi_arg_inout_unpack.v:266:33
+    extern void i_string_1d(const char** val);
+    // DPI import at t/t_dpi_arg_inout_unpack.v:267:33
+    extern void i_string_2d(const char** val);
+    // DPI import at t/t_dpi_arg_inout_unpack.v:268:33
+    extern void i_string_3d(const char** val);
+    // DPI import at t/t_dpi_arg_inout_unpack.v:235:33
+    extern void i_time_0d(svLogicVecVal* val);
+    // DPI import at t/t_dpi_arg_inout_unpack.v:236:33
+    extern void i_time_1d(svLogicVecVal* val);
+    // DPI import at t/t_dpi_arg_inout_unpack.v:237:33
+    extern void i_time_2d(svLogicVecVal* val);
+    // DPI import at t/t_dpi_arg_inout_unpack.v:238:33
     extern void i_time_3d(svLogicVecVal* val);
     
 #ifdef __cplusplus

--- a/test_regress/t/t_dpi_arg_input_unpack.cpp
+++ b/test_regress/t/t_dpi_arg_input_unpack.cpp
@@ -458,6 +458,25 @@ void i_string_3d(CONSTARG char** v) {
     if (!check_3d(v)) stop();
 }
 
+void i_bit1_0d(CONSTARG svBit v) {
+    if (!compare<svScalar>(v, sv_0)) stop();
+}
+void i_bit1_1d(CONSTARG svBit* v) {
+    if (!compare<svScalar>(v[0], sv_1)) stop();
+    if (!compare<svScalar>(v[1], sv_0)) stop();
+}
+void i_bit1_2d(CONSTARG svBit* v) {
+    if (!compare<svScalar>(v[0 * 2 + 1], sv_1)) stop();
+    if (!compare<svScalar>(v[1 * 2 + 1], sv_0)) stop();
+    if (!compare<svScalar>(v[2 * 2 + 1], sv_1)) stop();
+}
+void i_bit1_3d(CONSTARG svBit* v) {
+    if (!compare<svScalar>(v[(0 * 3 + 0) * 2 + 0], sv_0)) stop();
+    if (!compare<svScalar>(v[(1 * 3 + 0) * 2 + 0], sv_1)) stop();
+    if (!compare<svScalar>(v[(2 * 3 + 0) * 2 + 0], sv_0)) stop();
+    if (!compare<svScalar>(v[(3 * 3 + 0) * 2 + 0], sv_1)) stop();
+}
+
 void i_bit7_0d(CONSTARG svBitVecVal* v) {
     if (!check_0d(v, 7)) stop();
 }
@@ -482,6 +501,25 @@ void i_bit121_2d(CONSTARG svBitVecVal* v) {
 }
 void i_bit121_3d(CONSTARG svBitVecVal* v) {
     if (!check_3d(v, 121)) stop();
+}
+
+void i_logic1_0d(CONSTARG svLogic v) {
+    if (!compare<svScalar>(v, sv_0)) stop();
+}
+void i_logic1_1d(CONSTARG svLogic* v) {
+    if (!compare<svScalar>(v[0], sv_1)) stop();
+    if (!compare<svScalar>(v[1], sv_0)) stop();
+}
+void i_logic1_2d(CONSTARG svLogic* v) {
+    if (!compare<svScalar>(v[0 * 2 + 1], sv_1)) stop();
+    if (!compare<svScalar>(v[1 * 2 + 1], sv_0)) stop();
+    if (!compare<svScalar>(v[2 * 2 + 1], sv_1)) stop();
+}
+void i_logic1_3d(CONSTARG svLogic* v) {
+    if (!compare<svScalar>(v[(0 * 3 + 0) * 2 + 0], sv_0)) stop();
+    if (!compare<svScalar>(v[(1 * 3 + 0) * 2 + 0], sv_1)) stop();
+    if (!compare<svScalar>(v[(2 * 3 + 0) * 2 + 0], sv_0)) stop();
+    if (!compare<svScalar>(v[(3 * 3 + 0) * 2 + 0], sv_1)) stop();
 }
 
 void i_logic7_0d(CONSTARG svLogicVecVal* v) {

--- a/test_regress/t/t_dpi_arg_input_unpack__Dpi.out
+++ b/test_regress/t/t_dpi_arg_input_unpack__Dpi.out
@@ -13,299 +13,331 @@ extern "C" {
     
     
     // DPI EXPORTS
-    // DPI export at t/t_dpi_arg_input_unpack.v:501:18
+    // DPI export at t/t_dpi_arg_input_unpack.v:535:18
     extern void e_bit121_0d(const svBitVecVal* val);
-    // DPI export at t/t_dpi_arg_input_unpack.v:502:18
+    // DPI export at t/t_dpi_arg_input_unpack.v:536:18
     extern void e_bit121_1d(const svBitVecVal* val);
-    // DPI export at t/t_dpi_arg_input_unpack.v:503:18
+    // DPI export at t/t_dpi_arg_input_unpack.v:537:18
     extern void e_bit121_2d(const svBitVecVal* val);
-    // DPI export at t/t_dpi_arg_input_unpack.v:504:18
+    // DPI export at t/t_dpi_arg_input_unpack.v:538:18
     extern void e_bit121_3d(const svBitVecVal* val);
-    // DPI export at t/t_dpi_arg_input_unpack.v:496:18
+    // DPI export at t/t_dpi_arg_input_unpack.v:525:18
+    extern void e_bit1_0d(svBit val);
+    // DPI export at t/t_dpi_arg_input_unpack.v:526:18
+    extern void e_bit1_1d(const svBit* val);
+    // DPI export at t/t_dpi_arg_input_unpack.v:527:18
+    extern void e_bit1_2d(const svBit* val);
+    // DPI export at t/t_dpi_arg_input_unpack.v:528:18
+    extern void e_bit1_3d(const svBit* val);
+    // DPI export at t/t_dpi_arg_input_unpack.v:530:18
     extern void e_bit7_0d(const svBitVecVal* val);
-    // DPI export at t/t_dpi_arg_input_unpack.v:497:18
+    // DPI export at t/t_dpi_arg_input_unpack.v:531:18
     extern void e_bit7_1d(const svBitVecVal* val);
-    // DPI export at t/t_dpi_arg_input_unpack.v:498:18
+    // DPI export at t/t_dpi_arg_input_unpack.v:532:18
     extern void e_bit7_2d(const svBitVecVal* val);
-    // DPI export at t/t_dpi_arg_input_unpack.v:499:18
+    // DPI export at t/t_dpi_arg_input_unpack.v:533:18
     extern void e_bit7_3d(const svBitVecVal* val);
-    // DPI export at t/t_dpi_arg_input_unpack.v:332:18
+    // DPI export at t/t_dpi_arg_input_unpack.v:361:18
     extern void e_byte_0d(char val);
-    // DPI export at t/t_dpi_arg_input_unpack.v:333:18
-    extern void e_byte_1d(const char* val);
-    // DPI export at t/t_dpi_arg_input_unpack.v:334:18
-    extern void e_byte_2d(const char* val);
-    // DPI export at t/t_dpi_arg_input_unpack.v:335:18
-    extern void e_byte_3d(const char* val);
-    // DPI export at t/t_dpi_arg_input_unpack.v:337:18
-    extern void e_byte_unsigned_0d(unsigned char val);
-    // DPI export at t/t_dpi_arg_input_unpack.v:338:18
-    extern void e_byte_unsigned_1d(const unsigned char* val);
-    // DPI export at t/t_dpi_arg_input_unpack.v:339:18
-    extern void e_byte_unsigned_2d(const unsigned char* val);
-    // DPI export at t/t_dpi_arg_input_unpack.v:340:18
-    extern void e_byte_unsigned_3d(const unsigned char* val);
-    // DPI export at t/t_dpi_arg_input_unpack.v:398:18
-    extern void e_chandle_0d(void* val);
-    // DPI export at t/t_dpi_arg_input_unpack.v:404:18
-    extern void e_chandle_1d(const void** val);
-    // DPI export at t/t_dpi_arg_input_unpack.v:414:18
-    extern void e_chandle_2d(const void** val);
-    // DPI export at t/t_dpi_arg_input_unpack.v:428:18
-    extern void e_chandle_3d(const void** val);
-    // DPI export at t/t_dpi_arg_input_unpack.v:352:18
-    extern void e_int_0d(int val);
-    // DPI export at t/t_dpi_arg_input_unpack.v:353:18
-    extern void e_int_1d(const int* val);
-    // DPI export at t/t_dpi_arg_input_unpack.v:354:18
-    extern void e_int_2d(const int* val);
-    // DPI export at t/t_dpi_arg_input_unpack.v:355:18
-    extern void e_int_3d(const int* val);
-    // DPI export at t/t_dpi_arg_input_unpack.v:357:18
-    extern void e_int_unsigned_0d(unsigned int val);
-    // DPI export at t/t_dpi_arg_input_unpack.v:358:18
-    extern void e_int_unsigned_1d(const unsigned int* val);
-    // DPI export at t/t_dpi_arg_input_unpack.v:359:18
-    extern void e_int_unsigned_2d(const unsigned int* val);
-    // DPI export at t/t_dpi_arg_input_unpack.v:360:18
-    extern void e_int_unsigned_3d(const unsigned int* val);
-    // DPI export at t/t_dpi_arg_input_unpack.v:380:18
-    extern void e_integer_0d(const svLogicVecVal* val);
-    // DPI export at t/t_dpi_arg_input_unpack.v:381:18
-    extern void e_integer_1d(const svLogicVecVal* val);
-    // DPI export at t/t_dpi_arg_input_unpack.v:382:18
-    extern void e_integer_2d(const svLogicVecVal* val);
-    // DPI export at t/t_dpi_arg_input_unpack.v:383:18
-    extern void e_integer_3d(const svLogicVecVal* val);
-    // DPI export at t/t_dpi_arg_input_unpack.v:511:18
-    extern void e_logic121_0d(const svLogicVecVal* val);
-    // DPI export at t/t_dpi_arg_input_unpack.v:512:18
-    extern void e_logic121_1d(const svLogicVecVal* val);
-    // DPI export at t/t_dpi_arg_input_unpack.v:513:18
-    extern void e_logic121_2d(const svLogicVecVal* val);
-    // DPI export at t/t_dpi_arg_input_unpack.v:514:18
-    extern void e_logic121_3d(const svLogicVecVal* val);
-    // DPI export at t/t_dpi_arg_input_unpack.v:506:18
-    extern void e_logic7_0d(const svLogicVecVal* val);
-    // DPI export at t/t_dpi_arg_input_unpack.v:507:18
-    extern void e_logic7_1d(const svLogicVecVal* val);
-    // DPI export at t/t_dpi_arg_input_unpack.v:508:18
-    extern void e_logic7_2d(const svLogicVecVal* val);
-    // DPI export at t/t_dpi_arg_input_unpack.v:509:18
-    extern void e_logic7_3d(const svLogicVecVal* val);
     // DPI export at t/t_dpi_arg_input_unpack.v:362:18
-    extern void e_longint_0d(long long val);
+    extern void e_byte_1d(const char* val);
     // DPI export at t/t_dpi_arg_input_unpack.v:363:18
-    extern void e_longint_1d(const long long* val);
+    extern void e_byte_2d(const char* val);
     // DPI export at t/t_dpi_arg_input_unpack.v:364:18
-    extern void e_longint_2d(const long long* val);
-    // DPI export at t/t_dpi_arg_input_unpack.v:365:18
-    extern void e_longint_3d(const long long* val);
+    extern void e_byte_3d(const char* val);
+    // DPI export at t/t_dpi_arg_input_unpack.v:366:18
+    extern void e_byte_unsigned_0d(unsigned char val);
     // DPI export at t/t_dpi_arg_input_unpack.v:367:18
-    extern void e_longint_unsigned_0d(unsigned long long val);
+    extern void e_byte_unsigned_1d(const unsigned char* val);
     // DPI export at t/t_dpi_arg_input_unpack.v:368:18
-    extern void e_longint_unsigned_1d(const unsigned long long* val);
+    extern void e_byte_unsigned_2d(const unsigned char* val);
     // DPI export at t/t_dpi_arg_input_unpack.v:369:18
-    extern void e_longint_unsigned_2d(const unsigned long long* val);
-    // DPI export at t/t_dpi_arg_input_unpack.v:370:18
-    extern void e_longint_unsigned_3d(const unsigned long long* val);
-    // DPI export at t/t_dpi_arg_input_unpack.v:516:18
-    extern void e_pack_struct_0d(const svLogicVecVal* val);
-    // DPI export at t/t_dpi_arg_input_unpack.v:517:18
-    extern void e_pack_struct_1d(const svLogicVecVal* val);
-    // DPI export at t/t_dpi_arg_input_unpack.v:518:18
-    extern void e_pack_struct_2d(const svLogicVecVal* val);
-    // DPI export at t/t_dpi_arg_input_unpack.v:519:18
-    extern void e_pack_struct_3d(const svLogicVecVal* val);
+    extern void e_byte_unsigned_3d(const unsigned char* val);
+    // DPI export at t/t_dpi_arg_input_unpack.v:427:18
+    extern void e_chandle_0d(void* val);
+    // DPI export at t/t_dpi_arg_input_unpack.v:433:18
+    extern void e_chandle_1d(const void** val);
+    // DPI export at t/t_dpi_arg_input_unpack.v:443:18
+    extern void e_chandle_2d(const void** val);
+    // DPI export at t/t_dpi_arg_input_unpack.v:457:18
+    extern void e_chandle_3d(const void** val);
+    // DPI export at t/t_dpi_arg_input_unpack.v:381:18
+    extern void e_int_0d(int val);
+    // DPI export at t/t_dpi_arg_input_unpack.v:382:18
+    extern void e_int_1d(const int* val);
+    // DPI export at t/t_dpi_arg_input_unpack.v:383:18
+    extern void e_int_2d(const int* val);
+    // DPI export at t/t_dpi_arg_input_unpack.v:384:18
+    extern void e_int_3d(const int* val);
     // DPI export at t/t_dpi_arg_input_unpack.v:386:18
-    extern void e_real_0d(double val);
+    extern void e_int_unsigned_0d(unsigned int val);
     // DPI export at t/t_dpi_arg_input_unpack.v:387:18
-    extern void e_real_1d(const double* val);
+    extern void e_int_unsigned_1d(const unsigned int* val);
     // DPI export at t/t_dpi_arg_input_unpack.v:388:18
-    extern void e_real_2d(const double* val);
+    extern void e_int_unsigned_2d(const unsigned int* val);
     // DPI export at t/t_dpi_arg_input_unpack.v:389:18
+    extern void e_int_unsigned_3d(const unsigned int* val);
+    // DPI export at t/t_dpi_arg_input_unpack.v:409:18
+    extern void e_integer_0d(const svLogicVecVal* val);
+    // DPI export at t/t_dpi_arg_input_unpack.v:410:18
+    extern void e_integer_1d(const svLogicVecVal* val);
+    // DPI export at t/t_dpi_arg_input_unpack.v:411:18
+    extern void e_integer_2d(const svLogicVecVal* val);
+    // DPI export at t/t_dpi_arg_input_unpack.v:412:18
+    extern void e_integer_3d(const svLogicVecVal* val);
+    // DPI export at t/t_dpi_arg_input_unpack.v:550:18
+    extern void e_logic121_0d(const svLogicVecVal* val);
+    // DPI export at t/t_dpi_arg_input_unpack.v:551:18
+    extern void e_logic121_1d(const svLogicVecVal* val);
+    // DPI export at t/t_dpi_arg_input_unpack.v:552:18
+    extern void e_logic121_2d(const svLogicVecVal* val);
+    // DPI export at t/t_dpi_arg_input_unpack.v:553:18
+    extern void e_logic121_3d(const svLogicVecVal* val);
+    // DPI export at t/t_dpi_arg_input_unpack.v:540:18
+    extern void e_logic1_0d(svLogic val);
+    // DPI export at t/t_dpi_arg_input_unpack.v:541:18
+    extern void e_logic1_1d(const svLogic* val);
+    // DPI export at t/t_dpi_arg_input_unpack.v:542:18
+    extern void e_logic1_2d(const svLogic* val);
+    // DPI export at t/t_dpi_arg_input_unpack.v:543:18
+    extern void e_logic1_3d(const svLogic* val);
+    // DPI export at t/t_dpi_arg_input_unpack.v:545:18
+    extern void e_logic7_0d(const svLogicVecVal* val);
+    // DPI export at t/t_dpi_arg_input_unpack.v:546:18
+    extern void e_logic7_1d(const svLogicVecVal* val);
+    // DPI export at t/t_dpi_arg_input_unpack.v:547:18
+    extern void e_logic7_2d(const svLogicVecVal* val);
+    // DPI export at t/t_dpi_arg_input_unpack.v:548:18
+    extern void e_logic7_3d(const svLogicVecVal* val);
+    // DPI export at t/t_dpi_arg_input_unpack.v:391:18
+    extern void e_longint_0d(long long val);
+    // DPI export at t/t_dpi_arg_input_unpack.v:392:18
+    extern void e_longint_1d(const long long* val);
+    // DPI export at t/t_dpi_arg_input_unpack.v:393:18
+    extern void e_longint_2d(const long long* val);
+    // DPI export at t/t_dpi_arg_input_unpack.v:394:18
+    extern void e_longint_3d(const long long* val);
+    // DPI export at t/t_dpi_arg_input_unpack.v:396:18
+    extern void e_longint_unsigned_0d(unsigned long long val);
+    // DPI export at t/t_dpi_arg_input_unpack.v:397:18
+    extern void e_longint_unsigned_1d(const unsigned long long* val);
+    // DPI export at t/t_dpi_arg_input_unpack.v:398:18
+    extern void e_longint_unsigned_2d(const unsigned long long* val);
+    // DPI export at t/t_dpi_arg_input_unpack.v:399:18
+    extern void e_longint_unsigned_3d(const unsigned long long* val);
+    // DPI export at t/t_dpi_arg_input_unpack.v:555:18
+    extern void e_pack_struct_0d(const svLogicVecVal* val);
+    // DPI export at t/t_dpi_arg_input_unpack.v:556:18
+    extern void e_pack_struct_1d(const svLogicVecVal* val);
+    // DPI export at t/t_dpi_arg_input_unpack.v:557:18
+    extern void e_pack_struct_2d(const svLogicVecVal* val);
+    // DPI export at t/t_dpi_arg_input_unpack.v:558:18
+    extern void e_pack_struct_3d(const svLogicVecVal* val);
+    // DPI export at t/t_dpi_arg_input_unpack.v:415:18
+    extern void e_real_0d(double val);
+    // DPI export at t/t_dpi_arg_input_unpack.v:416:18
+    extern void e_real_1d(const double* val);
+    // DPI export at t/t_dpi_arg_input_unpack.v:417:18
+    extern void e_real_2d(const double* val);
+    // DPI export at t/t_dpi_arg_input_unpack.v:418:18
     extern void e_real_3d(const double* val);
-    // DPI export at t/t_dpi_arg_input_unpack.v:342:18
+    // DPI export at t/t_dpi_arg_input_unpack.v:371:18
     extern void e_shortint_0d(short val);
-    // DPI export at t/t_dpi_arg_input_unpack.v:343:18
+    // DPI export at t/t_dpi_arg_input_unpack.v:372:18
     extern void e_shortint_1d(const short* val);
-    // DPI export at t/t_dpi_arg_input_unpack.v:344:18
-    extern void e_shortint_2d(const short* val);
-    // DPI export at t/t_dpi_arg_input_unpack.v:345:18
-    extern void e_shortint_3d(const short* val);
-    // DPI export at t/t_dpi_arg_input_unpack.v:347:18
-    extern void e_shortint_unsigned_0d(unsigned short val);
-    // DPI export at t/t_dpi_arg_input_unpack.v:348:18
-    extern void e_shortint_unsigned_1d(const unsigned short* val);
-    // DPI export at t/t_dpi_arg_input_unpack.v:349:18
-    extern void e_shortint_unsigned_2d(const unsigned short* val);
-    // DPI export at t/t_dpi_arg_input_unpack.v:350:18
-    extern void e_shortint_unsigned_3d(const unsigned short* val);
-    // DPI export at t/t_dpi_arg_input_unpack.v:447:18
-    extern void e_string_0d(const char* val);
-    // DPI export at t/t_dpi_arg_input_unpack.v:453:18
-    extern void e_string_1d(const char** val);
-    // DPI export at t/t_dpi_arg_input_unpack.v:463:18
-    extern void e_string_2d(const char** val);
-    // DPI export at t/t_dpi_arg_input_unpack.v:477:18
-    extern void e_string_3d(const char** val);
     // DPI export at t/t_dpi_arg_input_unpack.v:373:18
-    extern void e_time_0d(const svLogicVecVal* val);
+    extern void e_shortint_2d(const short* val);
     // DPI export at t/t_dpi_arg_input_unpack.v:374:18
-    extern void e_time_1d(const svLogicVecVal* val);
-    // DPI export at t/t_dpi_arg_input_unpack.v:375:18
-    extern void e_time_2d(const svLogicVecVal* val);
+    extern void e_shortint_3d(const short* val);
     // DPI export at t/t_dpi_arg_input_unpack.v:376:18
+    extern void e_shortint_unsigned_0d(unsigned short val);
+    // DPI export at t/t_dpi_arg_input_unpack.v:377:18
+    extern void e_shortint_unsigned_1d(const unsigned short* val);
+    // DPI export at t/t_dpi_arg_input_unpack.v:378:18
+    extern void e_shortint_unsigned_2d(const unsigned short* val);
+    // DPI export at t/t_dpi_arg_input_unpack.v:379:18
+    extern void e_shortint_unsigned_3d(const unsigned short* val);
+    // DPI export at t/t_dpi_arg_input_unpack.v:476:18
+    extern void e_string_0d(const char* val);
+    // DPI export at t/t_dpi_arg_input_unpack.v:482:18
+    extern void e_string_1d(const char** val);
+    // DPI export at t/t_dpi_arg_input_unpack.v:492:18
+    extern void e_string_2d(const char** val);
+    // DPI export at t/t_dpi_arg_input_unpack.v:506:18
+    extern void e_string_3d(const char** val);
+    // DPI export at t/t_dpi_arg_input_unpack.v:402:18
+    extern void e_time_0d(const svLogicVecVal* val);
+    // DPI export at t/t_dpi_arg_input_unpack.v:403:18
+    extern void e_time_1d(const svLogicVecVal* val);
+    // DPI export at t/t_dpi_arg_input_unpack.v:404:18
+    extern void e_time_2d(const svLogicVecVal* val);
+    // DPI export at t/t_dpi_arg_input_unpack.v:405:18
     extern void e_time_3d(const svLogicVecVal* val);
     
     // DPI IMPORTS
-    // DPI import at t/t_dpi_arg_input_unpack.v:576:41
+    // DPI import at t/t_dpi_arg_input_unpack.v:615:41
     extern void check_exports();
-    // DPI import at t/t_dpi_arg_input_unpack.v:106:36
+    // DPI import at t/t_dpi_arg_input_unpack.v:115:36
     extern void* get_non_null();
-    // DPI import at t/t_dpi_arg_input_unpack.v:189:33
+    // DPI import at t/t_dpi_arg_input_unpack.v:203:33
     extern void i_bit121_0d(const svBitVecVal* val);
-    // DPI import at t/t_dpi_arg_input_unpack.v:190:33
-    extern void i_bit121_1d(const svBitVecVal* val);
-    // DPI import at t/t_dpi_arg_input_unpack.v:191:33
-    extern void i_bit121_2d(const svBitVecVal* val);
-    // DPI import at t/t_dpi_arg_input_unpack.v:192:33
-    extern void i_bit121_3d(const svBitVecVal* val);
-    // DPI import at t/t_dpi_arg_input_unpack.v:184:33
-    extern void i_bit7_0d(const svBitVecVal* val);
-    // DPI import at t/t_dpi_arg_input_unpack.v:185:33
-    extern void i_bit7_1d(const svBitVecVal* val);
-    // DPI import at t/t_dpi_arg_input_unpack.v:186:33
-    extern void i_bit7_2d(const svBitVecVal* val);
-    // DPI import at t/t_dpi_arg_input_unpack.v:187:33
-    extern void i_bit7_3d(const svBitVecVal* val);
-    // DPI import at t/t_dpi_arg_input_unpack.v:108:33
-    extern void i_byte_0d(char val);
-    // DPI import at t/t_dpi_arg_input_unpack.v:109:33
-    extern void i_byte_1d(const char* val);
-    // DPI import at t/t_dpi_arg_input_unpack.v:110:33
-    extern void i_byte_2d(const char* val);
-    // DPI import at t/t_dpi_arg_input_unpack.v:111:33
-    extern void i_byte_3d(const char* val);
-    // DPI import at t/t_dpi_arg_input_unpack.v:113:33
-    extern void i_byte_unsigned_0d(unsigned char val);
-    // DPI import at t/t_dpi_arg_input_unpack.v:114:33
-    extern void i_byte_unsigned_1d(const unsigned char* val);
-    // DPI import at t/t_dpi_arg_input_unpack.v:115:33
-    extern void i_byte_unsigned_2d(const unsigned char* val);
-    // DPI import at t/t_dpi_arg_input_unpack.v:116:33
-    extern void i_byte_unsigned_3d(const unsigned char* val);
-    // DPI import at t/t_dpi_arg_input_unpack.v:174:33
-    extern void i_chandle_0d(void* val);
-    // DPI import at t/t_dpi_arg_input_unpack.v:175:33
-    extern void i_chandle_1d(const void** val);
-    // DPI import at t/t_dpi_arg_input_unpack.v:176:33
-    extern void i_chandle_2d(const void** val);
-    // DPI import at t/t_dpi_arg_input_unpack.v:177:33
-    extern void i_chandle_3d(const void** val);
-    // DPI import at t/t_dpi_arg_input_unpack.v:128:33
-    extern void i_int_0d(int val);
-    // DPI import at t/t_dpi_arg_input_unpack.v:129:33
-    extern void i_int_1d(const int* val);
-    // DPI import at t/t_dpi_arg_input_unpack.v:130:33
-    extern void i_int_2d(const int* val);
-    // DPI import at t/t_dpi_arg_input_unpack.v:131:33
-    extern void i_int_3d(const int* val);
-    // DPI import at t/t_dpi_arg_input_unpack.v:133:33
-    extern void i_int_unsigned_0d(unsigned int val);
-    // DPI import at t/t_dpi_arg_input_unpack.v:134:33
-    extern void i_int_unsigned_1d(const unsigned int* val);
-    // DPI import at t/t_dpi_arg_input_unpack.v:135:33
-    extern void i_int_unsigned_2d(const unsigned int* val);
-    // DPI import at t/t_dpi_arg_input_unpack.v:136:33
-    extern void i_int_unsigned_3d(const unsigned int* val);
-    // DPI import at t/t_dpi_arg_input_unpack.v:156:33
-    extern void i_integer_0d(const svLogicVecVal* val);
-    // DPI import at t/t_dpi_arg_input_unpack.v:157:33
-    extern void i_integer_1d(const svLogicVecVal* val);
-    // DPI import at t/t_dpi_arg_input_unpack.v:158:33
-    extern void i_integer_2d(const svLogicVecVal* val);
-    // DPI import at t/t_dpi_arg_input_unpack.v:159:33
-    extern void i_integer_3d(const svLogicVecVal* val);
-    // DPI import at t/t_dpi_arg_input_unpack.v:199:33
-    extern void i_logic121_0d(const svLogicVecVal* val);
-    // DPI import at t/t_dpi_arg_input_unpack.v:200:33
-    extern void i_logic121_1d(const svLogicVecVal* val);
-    // DPI import at t/t_dpi_arg_input_unpack.v:201:33
-    extern void i_logic121_2d(const svLogicVecVal* val);
-    // DPI import at t/t_dpi_arg_input_unpack.v:202:33
-    extern void i_logic121_3d(const svLogicVecVal* val);
-    // DPI import at t/t_dpi_arg_input_unpack.v:194:33
-    extern void i_logic7_0d(const svLogicVecVal* val);
-    // DPI import at t/t_dpi_arg_input_unpack.v:195:33
-    extern void i_logic7_1d(const svLogicVecVal* val);
-    // DPI import at t/t_dpi_arg_input_unpack.v:196:33
-    extern void i_logic7_2d(const svLogicVecVal* val);
-    // DPI import at t/t_dpi_arg_input_unpack.v:197:33
-    extern void i_logic7_3d(const svLogicVecVal* val);
-    // DPI import at t/t_dpi_arg_input_unpack.v:138:33
-    extern void i_longint_0d(long long val);
-    // DPI import at t/t_dpi_arg_input_unpack.v:139:33
-    extern void i_longint_1d(const long long* val);
-    // DPI import at t/t_dpi_arg_input_unpack.v:140:33
-    extern void i_longint_2d(const long long* val);
-    // DPI import at t/t_dpi_arg_input_unpack.v:141:33
-    extern void i_longint_3d(const long long* val);
-    // DPI import at t/t_dpi_arg_input_unpack.v:143:33
-    extern void i_longint_unsigned_0d(unsigned long long val);
-    // DPI import at t/t_dpi_arg_input_unpack.v:144:33
-    extern void i_longint_unsigned_1d(const unsigned long long* val);
-    // DPI import at t/t_dpi_arg_input_unpack.v:145:33
-    extern void i_longint_unsigned_2d(const unsigned long long* val);
-    // DPI import at t/t_dpi_arg_input_unpack.v:146:33
-    extern void i_longint_unsigned_3d(const unsigned long long* val);
     // DPI import at t/t_dpi_arg_input_unpack.v:204:33
-    extern void i_pack_struct_0d(const svLogicVecVal* val);
+    extern void i_bit121_1d(const svBitVecVal* val);
     // DPI import at t/t_dpi_arg_input_unpack.v:205:33
-    extern void i_pack_struct_1d(const svLogicVecVal* val);
+    extern void i_bit121_2d(const svBitVecVal* val);
     // DPI import at t/t_dpi_arg_input_unpack.v:206:33
-    extern void i_pack_struct_2d(const svLogicVecVal* val);
-    // DPI import at t/t_dpi_arg_input_unpack.v:207:33
-    extern void i_pack_struct_3d(const svLogicVecVal* val);
-    // DPI import at t/t_dpi_arg_input_unpack.v:162:33
-    extern void i_real_0d(double val);
-    // DPI import at t/t_dpi_arg_input_unpack.v:163:33
-    extern void i_real_1d(const double* val);
-    // DPI import at t/t_dpi_arg_input_unpack.v:164:33
-    extern void i_real_2d(const double* val);
-    // DPI import at t/t_dpi_arg_input_unpack.v:165:33
-    extern void i_real_3d(const double* val);
+    extern void i_bit121_3d(const svBitVecVal* val);
+    // DPI import at t/t_dpi_arg_input_unpack.v:193:33
+    extern void i_bit1_0d(svBit val);
+    // DPI import at t/t_dpi_arg_input_unpack.v:194:33
+    extern void i_bit1_1d(const svBit* val);
+    // DPI import at t/t_dpi_arg_input_unpack.v:195:33
+    extern void i_bit1_2d(const svBit* val);
+    // DPI import at t/t_dpi_arg_input_unpack.v:196:33
+    extern void i_bit1_3d(const svBit* val);
+    // DPI import at t/t_dpi_arg_input_unpack.v:198:33
+    extern void i_bit7_0d(const svBitVecVal* val);
+    // DPI import at t/t_dpi_arg_input_unpack.v:199:33
+    extern void i_bit7_1d(const svBitVecVal* val);
+    // DPI import at t/t_dpi_arg_input_unpack.v:200:33
+    extern void i_bit7_2d(const svBitVecVal* val);
+    // DPI import at t/t_dpi_arg_input_unpack.v:201:33
+    extern void i_bit7_3d(const svBitVecVal* val);
+    // DPI import at t/t_dpi_arg_input_unpack.v:117:33
+    extern void i_byte_0d(char val);
     // DPI import at t/t_dpi_arg_input_unpack.v:118:33
-    extern void i_shortint_0d(short val);
+    extern void i_byte_1d(const char* val);
     // DPI import at t/t_dpi_arg_input_unpack.v:119:33
-    extern void i_shortint_1d(const short* val);
+    extern void i_byte_2d(const char* val);
     // DPI import at t/t_dpi_arg_input_unpack.v:120:33
-    extern void i_shortint_2d(const short* val);
-    // DPI import at t/t_dpi_arg_input_unpack.v:121:33
-    extern void i_shortint_3d(const short* val);
+    extern void i_byte_3d(const char* val);
+    // DPI import at t/t_dpi_arg_input_unpack.v:122:33
+    extern void i_byte_unsigned_0d(unsigned char val);
     // DPI import at t/t_dpi_arg_input_unpack.v:123:33
-    extern void i_shortint_unsigned_0d(unsigned short val);
+    extern void i_byte_unsigned_1d(const unsigned char* val);
     // DPI import at t/t_dpi_arg_input_unpack.v:124:33
-    extern void i_shortint_unsigned_1d(const unsigned short* val);
+    extern void i_byte_unsigned_2d(const unsigned char* val);
     // DPI import at t/t_dpi_arg_input_unpack.v:125:33
-    extern void i_shortint_unsigned_2d(const unsigned short* val);
-    // DPI import at t/t_dpi_arg_input_unpack.v:126:33
-    extern void i_shortint_unsigned_3d(const unsigned short* val);
-    // DPI import at t/t_dpi_arg_input_unpack.v:179:33
-    extern void i_string_0d(const char* val);
-    // DPI import at t/t_dpi_arg_input_unpack.v:180:33
-    extern void i_string_1d(const char** val);
-    // DPI import at t/t_dpi_arg_input_unpack.v:181:33
-    extern void i_string_2d(const char** val);
-    // DPI import at t/t_dpi_arg_input_unpack.v:182:33
-    extern void i_string_3d(const char** val);
+    extern void i_byte_unsigned_3d(const unsigned char* val);
+    // DPI import at t/t_dpi_arg_input_unpack.v:183:33
+    extern void i_chandle_0d(void* val);
+    // DPI import at t/t_dpi_arg_input_unpack.v:184:33
+    extern void i_chandle_1d(const void** val);
+    // DPI import at t/t_dpi_arg_input_unpack.v:185:33
+    extern void i_chandle_2d(const void** val);
+    // DPI import at t/t_dpi_arg_input_unpack.v:186:33
+    extern void i_chandle_3d(const void** val);
+    // DPI import at t/t_dpi_arg_input_unpack.v:137:33
+    extern void i_int_0d(int val);
+    // DPI import at t/t_dpi_arg_input_unpack.v:138:33
+    extern void i_int_1d(const int* val);
+    // DPI import at t/t_dpi_arg_input_unpack.v:139:33
+    extern void i_int_2d(const int* val);
+    // DPI import at t/t_dpi_arg_input_unpack.v:140:33
+    extern void i_int_3d(const int* val);
+    // DPI import at t/t_dpi_arg_input_unpack.v:142:33
+    extern void i_int_unsigned_0d(unsigned int val);
+    // DPI import at t/t_dpi_arg_input_unpack.v:143:33
+    extern void i_int_unsigned_1d(const unsigned int* val);
+    // DPI import at t/t_dpi_arg_input_unpack.v:144:33
+    extern void i_int_unsigned_2d(const unsigned int* val);
+    // DPI import at t/t_dpi_arg_input_unpack.v:145:33
+    extern void i_int_unsigned_3d(const unsigned int* val);
+    // DPI import at t/t_dpi_arg_input_unpack.v:165:33
+    extern void i_integer_0d(const svLogicVecVal* val);
+    // DPI import at t/t_dpi_arg_input_unpack.v:166:33
+    extern void i_integer_1d(const svLogicVecVal* val);
+    // DPI import at t/t_dpi_arg_input_unpack.v:167:33
+    extern void i_integer_2d(const svLogicVecVal* val);
+    // DPI import at t/t_dpi_arg_input_unpack.v:168:33
+    extern void i_integer_3d(const svLogicVecVal* val);
+    // DPI import at t/t_dpi_arg_input_unpack.v:218:33
+    extern void i_logic121_0d(const svLogicVecVal* val);
+    // DPI import at t/t_dpi_arg_input_unpack.v:219:33
+    extern void i_logic121_1d(const svLogicVecVal* val);
+    // DPI import at t/t_dpi_arg_input_unpack.v:220:33
+    extern void i_logic121_2d(const svLogicVecVal* val);
+    // DPI import at t/t_dpi_arg_input_unpack.v:221:33
+    extern void i_logic121_3d(const svLogicVecVal* val);
+    // DPI import at t/t_dpi_arg_input_unpack.v:208:33
+    extern void i_logic1_0d(svLogic val);
+    // DPI import at t/t_dpi_arg_input_unpack.v:209:33
+    extern void i_logic1_1d(const svLogic* val);
+    // DPI import at t/t_dpi_arg_input_unpack.v:210:33
+    extern void i_logic1_2d(const svLogic* val);
+    // DPI import at t/t_dpi_arg_input_unpack.v:211:33
+    extern void i_logic1_3d(const svLogic* val);
+    // DPI import at t/t_dpi_arg_input_unpack.v:213:33
+    extern void i_logic7_0d(const svLogicVecVal* val);
+    // DPI import at t/t_dpi_arg_input_unpack.v:214:33
+    extern void i_logic7_1d(const svLogicVecVal* val);
+    // DPI import at t/t_dpi_arg_input_unpack.v:215:33
+    extern void i_logic7_2d(const svLogicVecVal* val);
+    // DPI import at t/t_dpi_arg_input_unpack.v:216:33
+    extern void i_logic7_3d(const svLogicVecVal* val);
+    // DPI import at t/t_dpi_arg_input_unpack.v:147:33
+    extern void i_longint_0d(long long val);
+    // DPI import at t/t_dpi_arg_input_unpack.v:148:33
+    extern void i_longint_1d(const long long* val);
     // DPI import at t/t_dpi_arg_input_unpack.v:149:33
-    extern void i_time_0d(const svLogicVecVal* val);
+    extern void i_longint_2d(const long long* val);
     // DPI import at t/t_dpi_arg_input_unpack.v:150:33
-    extern void i_time_1d(const svLogicVecVal* val);
-    // DPI import at t/t_dpi_arg_input_unpack.v:151:33
-    extern void i_time_2d(const svLogicVecVal* val);
+    extern void i_longint_3d(const long long* val);
     // DPI import at t/t_dpi_arg_input_unpack.v:152:33
+    extern void i_longint_unsigned_0d(unsigned long long val);
+    // DPI import at t/t_dpi_arg_input_unpack.v:153:33
+    extern void i_longint_unsigned_1d(const unsigned long long* val);
+    // DPI import at t/t_dpi_arg_input_unpack.v:154:33
+    extern void i_longint_unsigned_2d(const unsigned long long* val);
+    // DPI import at t/t_dpi_arg_input_unpack.v:155:33
+    extern void i_longint_unsigned_3d(const unsigned long long* val);
+    // DPI import at t/t_dpi_arg_input_unpack.v:223:33
+    extern void i_pack_struct_0d(const svLogicVecVal* val);
+    // DPI import at t/t_dpi_arg_input_unpack.v:224:33
+    extern void i_pack_struct_1d(const svLogicVecVal* val);
+    // DPI import at t/t_dpi_arg_input_unpack.v:225:33
+    extern void i_pack_struct_2d(const svLogicVecVal* val);
+    // DPI import at t/t_dpi_arg_input_unpack.v:226:33
+    extern void i_pack_struct_3d(const svLogicVecVal* val);
+    // DPI import at t/t_dpi_arg_input_unpack.v:171:33
+    extern void i_real_0d(double val);
+    // DPI import at t/t_dpi_arg_input_unpack.v:172:33
+    extern void i_real_1d(const double* val);
+    // DPI import at t/t_dpi_arg_input_unpack.v:173:33
+    extern void i_real_2d(const double* val);
+    // DPI import at t/t_dpi_arg_input_unpack.v:174:33
+    extern void i_real_3d(const double* val);
+    // DPI import at t/t_dpi_arg_input_unpack.v:127:33
+    extern void i_shortint_0d(short val);
+    // DPI import at t/t_dpi_arg_input_unpack.v:128:33
+    extern void i_shortint_1d(const short* val);
+    // DPI import at t/t_dpi_arg_input_unpack.v:129:33
+    extern void i_shortint_2d(const short* val);
+    // DPI import at t/t_dpi_arg_input_unpack.v:130:33
+    extern void i_shortint_3d(const short* val);
+    // DPI import at t/t_dpi_arg_input_unpack.v:132:33
+    extern void i_shortint_unsigned_0d(unsigned short val);
+    // DPI import at t/t_dpi_arg_input_unpack.v:133:33
+    extern void i_shortint_unsigned_1d(const unsigned short* val);
+    // DPI import at t/t_dpi_arg_input_unpack.v:134:33
+    extern void i_shortint_unsigned_2d(const unsigned short* val);
+    // DPI import at t/t_dpi_arg_input_unpack.v:135:33
+    extern void i_shortint_unsigned_3d(const unsigned short* val);
+    // DPI import at t/t_dpi_arg_input_unpack.v:188:33
+    extern void i_string_0d(const char* val);
+    // DPI import at t/t_dpi_arg_input_unpack.v:189:33
+    extern void i_string_1d(const char** val);
+    // DPI import at t/t_dpi_arg_input_unpack.v:190:33
+    extern void i_string_2d(const char** val);
+    // DPI import at t/t_dpi_arg_input_unpack.v:191:33
+    extern void i_string_3d(const char** val);
+    // DPI import at t/t_dpi_arg_input_unpack.v:158:33
+    extern void i_time_0d(const svLogicVecVal* val);
+    // DPI import at t/t_dpi_arg_input_unpack.v:159:33
+    extern void i_time_1d(const svLogicVecVal* val);
+    // DPI import at t/t_dpi_arg_input_unpack.v:160:33
+    extern void i_time_2d(const svLogicVecVal* val);
+    // DPI import at t/t_dpi_arg_input_unpack.v:161:33
     extern void i_time_3d(const svLogicVecVal* val);
     
 #ifdef __cplusplus

--- a/test_regress/t/t_dpi_arg_output_unpack.cpp
+++ b/test_regress/t/t_dpi_arg_output_unpack.cpp
@@ -130,6 +130,26 @@ void set_3d(svLogicVecVal* v, int bitwidth) {
     set_uint(v + ((3 * 3 + 0) * 2 + 0) * unit, 51, bitwidth);
 }
 
+void set_0d_scalar(svScalar* v) { *v = sv_0; }
+
+void set_1d_scalar(svScalar* v) {
+    v[0] = sv_1;
+    v[1] = sv_0;
+}
+
+void set_2d_scalar(svScalar* v) {
+    v[0 * 2 + 1] = sv_1;
+    v[1 * 2 + 1] = sv_0;
+    v[2 * 2 + 1] = sv_1;
+}
+
+void set_3d_scalar(svScalar* v) {
+    v[(0 * 3 + 0) * 2 + 0] = sv_0;
+    v[(1 * 3 + 0) * 2 + 0] = sv_1;
+    v[(2 * 3 + 0) * 2 + 0] = sv_0;
+    v[(3 * 3 + 0) * 2 + 0] = sv_1;
+}
+
 void set_0d(svBitVecVal* v, int bitwidth) { set_uint(v, 42, bitwidth); }
 
 void set_1d(svBitVecVal* v, int bitwidth) {
@@ -343,6 +363,11 @@ void i_string_3d(const char** v) {
     v[(3 * 3 + 0) * 2 + 0] = s3;
 }
 
+void i_bit1_0d(svBit* v) { set_0d_scalar(v); }
+void i_bit1_1d(svBit* v) { set_1d_scalar(v); }
+void i_bit1_2d(svBit* v) { set_2d_scalar(v); }
+void i_bit1_3d(svBit* v) { set_3d_scalar(v); }
+
 void i_bit7_0d(svBitVecVal* v) { set_0d(v, 7); }
 void i_bit7_1d(svBitVecVal* v) { set_1d(v, 7); }
 void i_bit7_2d(svBitVecVal* v) { set_2d(v, 7); }
@@ -352,6 +377,11 @@ void i_bit121_0d(svBitVecVal* v) { set_0d(v, 121); }
 void i_bit121_1d(svBitVecVal* v) { set_1d(v, 121); }
 void i_bit121_2d(svBitVecVal* v) { set_2d(v, 121); }
 void i_bit121_3d(svBitVecVal* v) { set_3d(v, 121); }
+
+void i_logic1_0d(svLogic* v) { set_0d_scalar(v); }
+void i_logic1_1d(svLogic* v) { set_1d_scalar(v); }
+void i_logic1_2d(svLogic* v) { set_2d_scalar(v); }
+void i_logic1_3d(svLogic* v) { set_3d_scalar(v); }
 
 void i_logic7_0d(svLogicVecVal* v) { set_0d(v, 7); }
 void i_logic7_1d(svLogicVecVal* v) { set_1d(v, 7); }

--- a/test_regress/t/t_dpi_arg_output_unpack__Dpi.out
+++ b/test_regress/t/t_dpi_arg_output_unpack__Dpi.out
@@ -13,299 +13,331 @@ extern "C" {
     
     
     // DPI EXPORTS
-    // DPI export at t/t_dpi_arg_output_unpack.v:460:18
+    // DPI export at t/t_dpi_arg_output_unpack.v:503:18
     extern void e_bit121_0d(svBitVecVal* val);
-    // DPI export at t/t_dpi_arg_output_unpack.v:461:18
+    // DPI export at t/t_dpi_arg_output_unpack.v:504:18
     extern void e_bit121_1d(svBitVecVal* val);
-    // DPI export at t/t_dpi_arg_output_unpack.v:462:18
+    // DPI export at t/t_dpi_arg_output_unpack.v:505:18
     extern void e_bit121_2d(svBitVecVal* val);
-    // DPI export at t/t_dpi_arg_output_unpack.v:463:18
+    // DPI export at t/t_dpi_arg_output_unpack.v:506:18
     extern void e_bit121_3d(svBitVecVal* val);
-    // DPI export at t/t_dpi_arg_output_unpack.v:455:18
+    // DPI export at t/t_dpi_arg_output_unpack.v:493:18
+    extern void e_bit1_0d(svBit* val);
+    // DPI export at t/t_dpi_arg_output_unpack.v:494:18
+    extern void e_bit1_1d(svBit* val);
+    // DPI export at t/t_dpi_arg_output_unpack.v:495:18
+    extern void e_bit1_2d(svBit* val);
+    // DPI export at t/t_dpi_arg_output_unpack.v:496:18
+    extern void e_bit1_3d(svBitVecVal* val);
+    // DPI export at t/t_dpi_arg_output_unpack.v:498:18
     extern void e_bit7_0d(svBitVecVal* val);
-    // DPI export at t/t_dpi_arg_output_unpack.v:456:18
+    // DPI export at t/t_dpi_arg_output_unpack.v:499:18
     extern void e_bit7_1d(svBitVecVal* val);
-    // DPI export at t/t_dpi_arg_output_unpack.v:457:18
+    // DPI export at t/t_dpi_arg_output_unpack.v:500:18
     extern void e_bit7_2d(svBitVecVal* val);
-    // DPI export at t/t_dpi_arg_output_unpack.v:458:18
+    // DPI export at t/t_dpi_arg_output_unpack.v:501:18
     extern void e_bit7_3d(svBitVecVal* val);
-    // DPI export at t/t_dpi_arg_output_unpack.v:351:18
-    extern void e_byte_0d(char* val);
-    // DPI export at t/t_dpi_arg_output_unpack.v:352:18
-    extern void e_byte_1d(char* val);
-    // DPI export at t/t_dpi_arg_output_unpack.v:353:18
-    extern void e_byte_2d(char* val);
-    // DPI export at t/t_dpi_arg_output_unpack.v:354:18
-    extern void e_byte_3d(char* val);
-    // DPI export at t/t_dpi_arg_output_unpack.v:356:18
-    extern void e_byte_unsigned_0d(unsigned char* val);
-    // DPI export at t/t_dpi_arg_output_unpack.v:357:18
-    extern void e_byte_unsigned_1d(unsigned char* val);
-    // DPI export at t/t_dpi_arg_output_unpack.v:358:18
-    extern void e_byte_unsigned_2d(unsigned char* val);
-    // DPI export at t/t_dpi_arg_output_unpack.v:359:18
-    extern void e_byte_unsigned_3d(unsigned char* val);
-    // DPI export at t/t_dpi_arg_output_unpack.v:417:18
-    extern void e_chandle_0d(void** val);
-    // DPI export at t/t_dpi_arg_output_unpack.v:420:18
-    extern void e_chandle_1d(void** val);
-    // DPI export at t/t_dpi_arg_output_unpack.v:424:18
-    extern void e_chandle_2d(void** val);
-    // DPI export at t/t_dpi_arg_output_unpack.v:429:18
-    extern void e_chandle_3d(void** val);
-    // DPI export at t/t_dpi_arg_output_unpack.v:371:18
-    extern void e_int_0d(int* val);
-    // DPI export at t/t_dpi_arg_output_unpack.v:372:18
-    extern void e_int_1d(int* val);
-    // DPI export at t/t_dpi_arg_output_unpack.v:373:18
-    extern void e_int_2d(int* val);
-    // DPI export at t/t_dpi_arg_output_unpack.v:374:18
-    extern void e_int_3d(int* val);
-    // DPI export at t/t_dpi_arg_output_unpack.v:376:18
-    extern void e_int_unsigned_0d(unsigned int* val);
-    // DPI export at t/t_dpi_arg_output_unpack.v:377:18
-    extern void e_int_unsigned_1d(unsigned int* val);
-    // DPI export at t/t_dpi_arg_output_unpack.v:378:18
-    extern void e_int_unsigned_2d(unsigned int* val);
-    // DPI export at t/t_dpi_arg_output_unpack.v:379:18
-    extern void e_int_unsigned_3d(unsigned int* val);
-    // DPI export at t/t_dpi_arg_output_unpack.v:399:18
-    extern void e_integer_0d(svLogicVecVal* val);
-    // DPI export at t/t_dpi_arg_output_unpack.v:400:18
-    extern void e_integer_1d(svLogicVecVal* val);
-    // DPI export at t/t_dpi_arg_output_unpack.v:401:18
-    extern void e_integer_2d(svLogicVecVal* val);
-    // DPI export at t/t_dpi_arg_output_unpack.v:402:18
-    extern void e_integer_3d(svLogicVecVal* val);
-    // DPI export at t/t_dpi_arg_output_unpack.v:470:18
-    extern void e_logic121_0d(svLogicVecVal* val);
-    // DPI export at t/t_dpi_arg_output_unpack.v:471:18
-    extern void e_logic121_1d(svLogicVecVal* val);
-    // DPI export at t/t_dpi_arg_output_unpack.v:472:18
-    extern void e_logic121_2d(svLogicVecVal* val);
-    // DPI export at t/t_dpi_arg_output_unpack.v:473:18
-    extern void e_logic121_3d(svLogicVecVal* val);
-    // DPI export at t/t_dpi_arg_output_unpack.v:465:18
-    extern void e_logic7_0d(svLogicVecVal* val);
-    // DPI export at t/t_dpi_arg_output_unpack.v:466:18
-    extern void e_logic7_1d(svLogicVecVal* val);
-    // DPI export at t/t_dpi_arg_output_unpack.v:467:18
-    extern void e_logic7_2d(svLogicVecVal* val);
-    // DPI export at t/t_dpi_arg_output_unpack.v:468:18
-    extern void e_logic7_3d(svLogicVecVal* val);
-    // DPI export at t/t_dpi_arg_output_unpack.v:381:18
-    extern void e_longint_0d(long long* val);
-    // DPI export at t/t_dpi_arg_output_unpack.v:382:18
-    extern void e_longint_1d(long long* val);
-    // DPI export at t/t_dpi_arg_output_unpack.v:383:18
-    extern void e_longint_2d(long long* val);
-    // DPI export at t/t_dpi_arg_output_unpack.v:384:18
-    extern void e_longint_3d(long long* val);
-    // DPI export at t/t_dpi_arg_output_unpack.v:386:18
-    extern void e_longint_unsigned_0d(unsigned long long* val);
-    // DPI export at t/t_dpi_arg_output_unpack.v:387:18
-    extern void e_longint_unsigned_1d(unsigned long long* val);
-    // DPI export at t/t_dpi_arg_output_unpack.v:388:18
-    extern void e_longint_unsigned_2d(unsigned long long* val);
     // DPI export at t/t_dpi_arg_output_unpack.v:389:18
-    extern void e_longint_unsigned_3d(unsigned long long* val);
-    // DPI export at t/t_dpi_arg_output_unpack.v:475:18
-    extern void e_pack_struct_0d(svLogicVecVal* val);
-    // DPI export at t/t_dpi_arg_output_unpack.v:476:18
-    extern void e_pack_struct_1d(svLogicVecVal* val);
-    // DPI export at t/t_dpi_arg_output_unpack.v:477:18
-    extern void e_pack_struct_2d(svLogicVecVal* val);
-    // DPI export at t/t_dpi_arg_output_unpack.v:478:18
-    extern void e_pack_struct_3d(svLogicVecVal* val);
-    // DPI export at t/t_dpi_arg_output_unpack.v:405:18
-    extern void e_real_0d(double* val);
-    // DPI export at t/t_dpi_arg_output_unpack.v:406:18
-    extern void e_real_1d(double* val);
-    // DPI export at t/t_dpi_arg_output_unpack.v:407:18
-    extern void e_real_2d(double* val);
-    // DPI export at t/t_dpi_arg_output_unpack.v:408:18
-    extern void e_real_3d(double* val);
-    // DPI export at t/t_dpi_arg_output_unpack.v:361:18
-    extern void e_shortint_0d(short* val);
-    // DPI export at t/t_dpi_arg_output_unpack.v:362:18
-    extern void e_shortint_1d(short* val);
-    // DPI export at t/t_dpi_arg_output_unpack.v:363:18
-    extern void e_shortint_2d(short* val);
-    // DPI export at t/t_dpi_arg_output_unpack.v:364:18
-    extern void e_shortint_3d(short* val);
-    // DPI export at t/t_dpi_arg_output_unpack.v:366:18
-    extern void e_shortint_unsigned_0d(unsigned short* val);
-    // DPI export at t/t_dpi_arg_output_unpack.v:367:18
-    extern void e_shortint_unsigned_1d(unsigned short* val);
-    // DPI export at t/t_dpi_arg_output_unpack.v:368:18
-    extern void e_shortint_unsigned_2d(unsigned short* val);
-    // DPI export at t/t_dpi_arg_output_unpack.v:369:18
-    extern void e_shortint_unsigned_3d(unsigned short* val);
-    // DPI export at t/t_dpi_arg_output_unpack.v:436:18
-    extern void e_string_0d(const char** val);
-    // DPI export at t/t_dpi_arg_output_unpack.v:439:18
-    extern void e_string_1d(const char** val);
-    // DPI export at t/t_dpi_arg_output_unpack.v:443:18
-    extern void e_string_2d(const char** val);
-    // DPI export at t/t_dpi_arg_output_unpack.v:448:18
-    extern void e_string_3d(const char** val);
+    extern void e_byte_0d(char* val);
+    // DPI export at t/t_dpi_arg_output_unpack.v:390:18
+    extern void e_byte_1d(char* val);
+    // DPI export at t/t_dpi_arg_output_unpack.v:391:18
+    extern void e_byte_2d(char* val);
     // DPI export at t/t_dpi_arg_output_unpack.v:392:18
-    extern void e_time_0d(svLogicVecVal* val);
-    // DPI export at t/t_dpi_arg_output_unpack.v:393:18
-    extern void e_time_1d(svLogicVecVal* val);
+    extern void e_byte_3d(char* val);
     // DPI export at t/t_dpi_arg_output_unpack.v:394:18
-    extern void e_time_2d(svLogicVecVal* val);
+    extern void e_byte_unsigned_0d(unsigned char* val);
     // DPI export at t/t_dpi_arg_output_unpack.v:395:18
+    extern void e_byte_unsigned_1d(unsigned char* val);
+    // DPI export at t/t_dpi_arg_output_unpack.v:396:18
+    extern void e_byte_unsigned_2d(unsigned char* val);
+    // DPI export at t/t_dpi_arg_output_unpack.v:397:18
+    extern void e_byte_unsigned_3d(unsigned char* val);
+    // DPI export at t/t_dpi_arg_output_unpack.v:455:18
+    extern void e_chandle_0d(void** val);
+    // DPI export at t/t_dpi_arg_output_unpack.v:458:18
+    extern void e_chandle_1d(void** val);
+    // DPI export at t/t_dpi_arg_output_unpack.v:462:18
+    extern void e_chandle_2d(void** val);
+    // DPI export at t/t_dpi_arg_output_unpack.v:467:18
+    extern void e_chandle_3d(void** val);
+    // DPI export at t/t_dpi_arg_output_unpack.v:409:18
+    extern void e_int_0d(int* val);
+    // DPI export at t/t_dpi_arg_output_unpack.v:410:18
+    extern void e_int_1d(int* val);
+    // DPI export at t/t_dpi_arg_output_unpack.v:411:18
+    extern void e_int_2d(int* val);
+    // DPI export at t/t_dpi_arg_output_unpack.v:412:18
+    extern void e_int_3d(int* val);
+    // DPI export at t/t_dpi_arg_output_unpack.v:414:18
+    extern void e_int_unsigned_0d(unsigned int* val);
+    // DPI export at t/t_dpi_arg_output_unpack.v:415:18
+    extern void e_int_unsigned_1d(unsigned int* val);
+    // DPI export at t/t_dpi_arg_output_unpack.v:416:18
+    extern void e_int_unsigned_2d(unsigned int* val);
+    // DPI export at t/t_dpi_arg_output_unpack.v:417:18
+    extern void e_int_unsigned_3d(unsigned int* val);
+    // DPI export at t/t_dpi_arg_output_unpack.v:437:18
+    extern void e_integer_0d(svLogicVecVal* val);
+    // DPI export at t/t_dpi_arg_output_unpack.v:438:18
+    extern void e_integer_1d(svLogicVecVal* val);
+    // DPI export at t/t_dpi_arg_output_unpack.v:439:18
+    extern void e_integer_2d(svLogicVecVal* val);
+    // DPI export at t/t_dpi_arg_output_unpack.v:440:18
+    extern void e_integer_3d(svLogicVecVal* val);
+    // DPI export at t/t_dpi_arg_output_unpack.v:518:18
+    extern void e_logic121_0d(svLogicVecVal* val);
+    // DPI export at t/t_dpi_arg_output_unpack.v:519:18
+    extern void e_logic121_1d(svLogicVecVal* val);
+    // DPI export at t/t_dpi_arg_output_unpack.v:520:18
+    extern void e_logic121_2d(svLogicVecVal* val);
+    // DPI export at t/t_dpi_arg_output_unpack.v:521:18
+    extern void e_logic121_3d(svLogicVecVal* val);
+    // DPI export at t/t_dpi_arg_output_unpack.v:508:18
+    extern void e_logic1_0d(svLogic* val);
+    // DPI export at t/t_dpi_arg_output_unpack.v:509:18
+    extern void e_logic1_1d(svLogic* val);
+    // DPI export at t/t_dpi_arg_output_unpack.v:510:18
+    extern void e_logic1_2d(svLogic* val);
+    // DPI export at t/t_dpi_arg_output_unpack.v:511:18
+    extern void e_logic1_3d(svLogicVecVal* val);
+    // DPI export at t/t_dpi_arg_output_unpack.v:513:18
+    extern void e_logic7_0d(svLogicVecVal* val);
+    // DPI export at t/t_dpi_arg_output_unpack.v:514:18
+    extern void e_logic7_1d(svLogicVecVal* val);
+    // DPI export at t/t_dpi_arg_output_unpack.v:515:18
+    extern void e_logic7_2d(svLogicVecVal* val);
+    // DPI export at t/t_dpi_arg_output_unpack.v:516:18
+    extern void e_logic7_3d(svLogicVecVal* val);
+    // DPI export at t/t_dpi_arg_output_unpack.v:419:18
+    extern void e_longint_0d(long long* val);
+    // DPI export at t/t_dpi_arg_output_unpack.v:420:18
+    extern void e_longint_1d(long long* val);
+    // DPI export at t/t_dpi_arg_output_unpack.v:421:18
+    extern void e_longint_2d(long long* val);
+    // DPI export at t/t_dpi_arg_output_unpack.v:422:18
+    extern void e_longint_3d(long long* val);
+    // DPI export at t/t_dpi_arg_output_unpack.v:424:18
+    extern void e_longint_unsigned_0d(unsigned long long* val);
+    // DPI export at t/t_dpi_arg_output_unpack.v:425:18
+    extern void e_longint_unsigned_1d(unsigned long long* val);
+    // DPI export at t/t_dpi_arg_output_unpack.v:426:18
+    extern void e_longint_unsigned_2d(unsigned long long* val);
+    // DPI export at t/t_dpi_arg_output_unpack.v:427:18
+    extern void e_longint_unsigned_3d(unsigned long long* val);
+    // DPI export at t/t_dpi_arg_output_unpack.v:523:18
+    extern void e_pack_struct_0d(svLogicVecVal* val);
+    // DPI export at t/t_dpi_arg_output_unpack.v:524:18
+    extern void e_pack_struct_1d(svLogicVecVal* val);
+    // DPI export at t/t_dpi_arg_output_unpack.v:525:18
+    extern void e_pack_struct_2d(svLogicVecVal* val);
+    // DPI export at t/t_dpi_arg_output_unpack.v:526:18
+    extern void e_pack_struct_3d(svLogicVecVal* val);
+    // DPI export at t/t_dpi_arg_output_unpack.v:443:18
+    extern void e_real_0d(double* val);
+    // DPI export at t/t_dpi_arg_output_unpack.v:444:18
+    extern void e_real_1d(double* val);
+    // DPI export at t/t_dpi_arg_output_unpack.v:445:18
+    extern void e_real_2d(double* val);
+    // DPI export at t/t_dpi_arg_output_unpack.v:446:18
+    extern void e_real_3d(double* val);
+    // DPI export at t/t_dpi_arg_output_unpack.v:399:18
+    extern void e_shortint_0d(short* val);
+    // DPI export at t/t_dpi_arg_output_unpack.v:400:18
+    extern void e_shortint_1d(short* val);
+    // DPI export at t/t_dpi_arg_output_unpack.v:401:18
+    extern void e_shortint_2d(short* val);
+    // DPI export at t/t_dpi_arg_output_unpack.v:402:18
+    extern void e_shortint_3d(short* val);
+    // DPI export at t/t_dpi_arg_output_unpack.v:404:18
+    extern void e_shortint_unsigned_0d(unsigned short* val);
+    // DPI export at t/t_dpi_arg_output_unpack.v:405:18
+    extern void e_shortint_unsigned_1d(unsigned short* val);
+    // DPI export at t/t_dpi_arg_output_unpack.v:406:18
+    extern void e_shortint_unsigned_2d(unsigned short* val);
+    // DPI export at t/t_dpi_arg_output_unpack.v:407:18
+    extern void e_shortint_unsigned_3d(unsigned short* val);
+    // DPI export at t/t_dpi_arg_output_unpack.v:474:18
+    extern void e_string_0d(const char** val);
+    // DPI export at t/t_dpi_arg_output_unpack.v:477:18
+    extern void e_string_1d(const char** val);
+    // DPI export at t/t_dpi_arg_output_unpack.v:481:18
+    extern void e_string_2d(const char** val);
+    // DPI export at t/t_dpi_arg_output_unpack.v:486:18
+    extern void e_string_3d(const char** val);
+    // DPI export at t/t_dpi_arg_output_unpack.v:430:18
+    extern void e_time_0d(svLogicVecVal* val);
+    // DPI export at t/t_dpi_arg_output_unpack.v:431:18
+    extern void e_time_1d(svLogicVecVal* val);
+    // DPI export at t/t_dpi_arg_output_unpack.v:432:18
+    extern void e_time_2d(svLogicVecVal* val);
+    // DPI export at t/t_dpi_arg_output_unpack.v:433:18
     extern void e_time_3d(svLogicVecVal* val);
     
     // DPI IMPORTS
-    // DPI import at t/t_dpi_arg_output_unpack.v:505:41
+    // DPI import at t/t_dpi_arg_output_unpack.v:553:41
     extern void check_exports();
-    // DPI import at t/t_dpi_arg_output_unpack.v:123:36
+    // DPI import at t/t_dpi_arg_output_unpack.v:129:36
     extern void* get_non_null();
-    // DPI import at t/t_dpi_arg_output_unpack.v:206:33
-    extern void i_bit121_0d(svBitVecVal* val);
-    // DPI import at t/t_dpi_arg_output_unpack.v:207:33
-    extern void i_bit121_1d(svBitVecVal* val);
-    // DPI import at t/t_dpi_arg_output_unpack.v:208:33
-    extern void i_bit121_2d(svBitVecVal* val);
-    // DPI import at t/t_dpi_arg_output_unpack.v:209:33
-    extern void i_bit121_3d(svBitVecVal* val);
-    // DPI import at t/t_dpi_arg_output_unpack.v:201:33
-    extern void i_bit7_0d(svBitVecVal* val);
-    // DPI import at t/t_dpi_arg_output_unpack.v:202:33
-    extern void i_bit7_1d(svBitVecVal* val);
-    // DPI import at t/t_dpi_arg_output_unpack.v:203:33
-    extern void i_bit7_2d(svBitVecVal* val);
-    // DPI import at t/t_dpi_arg_output_unpack.v:204:33
-    extern void i_bit7_3d(svBitVecVal* val);
-    // DPI import at t/t_dpi_arg_output_unpack.v:125:33
-    extern void i_byte_0d(char* val);
-    // DPI import at t/t_dpi_arg_output_unpack.v:126:33
-    extern void i_byte_1d(char* val);
-    // DPI import at t/t_dpi_arg_output_unpack.v:127:33
-    extern void i_byte_2d(char* val);
-    // DPI import at t/t_dpi_arg_output_unpack.v:128:33
-    extern void i_byte_3d(char* val);
-    // DPI import at t/t_dpi_arg_output_unpack.v:130:33
-    extern void i_byte_unsigned_0d(unsigned char* val);
-    // DPI import at t/t_dpi_arg_output_unpack.v:131:33
-    extern void i_byte_unsigned_1d(unsigned char* val);
-    // DPI import at t/t_dpi_arg_output_unpack.v:132:33
-    extern void i_byte_unsigned_2d(unsigned char* val);
-    // DPI import at t/t_dpi_arg_output_unpack.v:133:33
-    extern void i_byte_unsigned_3d(unsigned char* val);
-    // DPI import at t/t_dpi_arg_output_unpack.v:191:33
-    extern void i_chandle_0d(void** val);
-    // DPI import at t/t_dpi_arg_output_unpack.v:192:33
-    extern void i_chandle_1d(void** val);
-    // DPI import at t/t_dpi_arg_output_unpack.v:193:33
-    extern void i_chandle_2d(void** val);
-    // DPI import at t/t_dpi_arg_output_unpack.v:194:33
-    extern void i_chandle_3d(void** val);
-    // DPI import at t/t_dpi_arg_output_unpack.v:145:33
-    extern void i_int_0d(int* val);
-    // DPI import at t/t_dpi_arg_output_unpack.v:146:33
-    extern void i_int_1d(int* val);
-    // DPI import at t/t_dpi_arg_output_unpack.v:147:33
-    extern void i_int_2d(int* val);
-    // DPI import at t/t_dpi_arg_output_unpack.v:148:33
-    extern void i_int_3d(int* val);
-    // DPI import at t/t_dpi_arg_output_unpack.v:150:33
-    extern void i_int_unsigned_0d(unsigned int* val);
-    // DPI import at t/t_dpi_arg_output_unpack.v:151:33
-    extern void i_int_unsigned_1d(unsigned int* val);
-    // DPI import at t/t_dpi_arg_output_unpack.v:152:33
-    extern void i_int_unsigned_2d(unsigned int* val);
-    // DPI import at t/t_dpi_arg_output_unpack.v:153:33
-    extern void i_int_unsigned_3d(unsigned int* val);
-    // DPI import at t/t_dpi_arg_output_unpack.v:173:33
-    extern void i_integer_0d(svLogicVecVal* val);
-    // DPI import at t/t_dpi_arg_output_unpack.v:174:33
-    extern void i_integer_1d(svLogicVecVal* val);
-    // DPI import at t/t_dpi_arg_output_unpack.v:175:33
-    extern void i_integer_2d(svLogicVecVal* val);
-    // DPI import at t/t_dpi_arg_output_unpack.v:176:33
-    extern void i_integer_3d(svLogicVecVal* val);
-    // DPI import at t/t_dpi_arg_output_unpack.v:216:33
-    extern void i_logic121_0d(svLogicVecVal* val);
     // DPI import at t/t_dpi_arg_output_unpack.v:217:33
-    extern void i_logic121_1d(svLogicVecVal* val);
+    extern void i_bit121_0d(svBitVecVal* val);
     // DPI import at t/t_dpi_arg_output_unpack.v:218:33
-    extern void i_logic121_2d(svLogicVecVal* val);
+    extern void i_bit121_1d(svBitVecVal* val);
     // DPI import at t/t_dpi_arg_output_unpack.v:219:33
-    extern void i_logic121_3d(svLogicVecVal* val);
-    // DPI import at t/t_dpi_arg_output_unpack.v:211:33
-    extern void i_logic7_0d(svLogicVecVal* val);
+    extern void i_bit121_2d(svBitVecVal* val);
+    // DPI import at t/t_dpi_arg_output_unpack.v:220:33
+    extern void i_bit121_3d(svBitVecVal* val);
+    // DPI import at t/t_dpi_arg_output_unpack.v:207:33
+    extern void i_bit1_0d(svBit* val);
+    // DPI import at t/t_dpi_arg_output_unpack.v:208:33
+    extern void i_bit1_1d(svBit* val);
+    // DPI import at t/t_dpi_arg_output_unpack.v:209:33
+    extern void i_bit1_2d(svBit* val);
+    // DPI import at t/t_dpi_arg_output_unpack.v:210:33
+    extern void i_bit1_3d(svBit* val);
     // DPI import at t/t_dpi_arg_output_unpack.v:212:33
-    extern void i_logic7_1d(svLogicVecVal* val);
+    extern void i_bit7_0d(svBitVecVal* val);
     // DPI import at t/t_dpi_arg_output_unpack.v:213:33
-    extern void i_logic7_2d(svLogicVecVal* val);
+    extern void i_bit7_1d(svBitVecVal* val);
     // DPI import at t/t_dpi_arg_output_unpack.v:214:33
-    extern void i_logic7_3d(svLogicVecVal* val);
-    // DPI import at t/t_dpi_arg_output_unpack.v:155:33
-    extern void i_longint_0d(long long* val);
-    // DPI import at t/t_dpi_arg_output_unpack.v:156:33
-    extern void i_longint_1d(long long* val);
-    // DPI import at t/t_dpi_arg_output_unpack.v:157:33
-    extern void i_longint_2d(long long* val);
-    // DPI import at t/t_dpi_arg_output_unpack.v:158:33
-    extern void i_longint_3d(long long* val);
-    // DPI import at t/t_dpi_arg_output_unpack.v:160:33
-    extern void i_longint_unsigned_0d(unsigned long long* val);
-    // DPI import at t/t_dpi_arg_output_unpack.v:161:33
-    extern void i_longint_unsigned_1d(unsigned long long* val);
-    // DPI import at t/t_dpi_arg_output_unpack.v:162:33
-    extern void i_longint_unsigned_2d(unsigned long long* val);
-    // DPI import at t/t_dpi_arg_output_unpack.v:163:33
-    extern void i_longint_unsigned_3d(unsigned long long* val);
-    // DPI import at t/t_dpi_arg_output_unpack.v:221:33
-    extern void i_pack_struct_0d(svLogicVecVal* val);
-    // DPI import at t/t_dpi_arg_output_unpack.v:222:33
-    extern void i_pack_struct_1d(svLogicVecVal* val);
-    // DPI import at t/t_dpi_arg_output_unpack.v:223:33
-    extern void i_pack_struct_2d(svLogicVecVal* val);
-    // DPI import at t/t_dpi_arg_output_unpack.v:224:33
-    extern void i_pack_struct_3d(svLogicVecVal* val);
-    // DPI import at t/t_dpi_arg_output_unpack.v:179:33
-    extern void i_real_0d(double* val);
-    // DPI import at t/t_dpi_arg_output_unpack.v:180:33
-    extern void i_real_1d(double* val);
-    // DPI import at t/t_dpi_arg_output_unpack.v:181:33
-    extern void i_real_2d(double* val);
-    // DPI import at t/t_dpi_arg_output_unpack.v:182:33
-    extern void i_real_3d(double* val);
-    // DPI import at t/t_dpi_arg_output_unpack.v:135:33
-    extern void i_shortint_0d(short* val);
+    extern void i_bit7_2d(svBitVecVal* val);
+    // DPI import at t/t_dpi_arg_output_unpack.v:215:33
+    extern void i_bit7_3d(svBitVecVal* val);
+    // DPI import at t/t_dpi_arg_output_unpack.v:131:33
+    extern void i_byte_0d(char* val);
+    // DPI import at t/t_dpi_arg_output_unpack.v:132:33
+    extern void i_byte_1d(char* val);
+    // DPI import at t/t_dpi_arg_output_unpack.v:133:33
+    extern void i_byte_2d(char* val);
+    // DPI import at t/t_dpi_arg_output_unpack.v:134:33
+    extern void i_byte_3d(char* val);
     // DPI import at t/t_dpi_arg_output_unpack.v:136:33
-    extern void i_shortint_1d(short* val);
+    extern void i_byte_unsigned_0d(unsigned char* val);
     // DPI import at t/t_dpi_arg_output_unpack.v:137:33
-    extern void i_shortint_2d(short* val);
+    extern void i_byte_unsigned_1d(unsigned char* val);
     // DPI import at t/t_dpi_arg_output_unpack.v:138:33
-    extern void i_shortint_3d(short* val);
-    // DPI import at t/t_dpi_arg_output_unpack.v:140:33
-    extern void i_shortint_unsigned_0d(unsigned short* val);
-    // DPI import at t/t_dpi_arg_output_unpack.v:141:33
-    extern void i_shortint_unsigned_1d(unsigned short* val);
-    // DPI import at t/t_dpi_arg_output_unpack.v:142:33
-    extern void i_shortint_unsigned_2d(unsigned short* val);
-    // DPI import at t/t_dpi_arg_output_unpack.v:143:33
-    extern void i_shortint_unsigned_3d(unsigned short* val);
-    // DPI import at t/t_dpi_arg_output_unpack.v:196:33
-    extern void i_string_0d(const char** val);
+    extern void i_byte_unsigned_2d(unsigned char* val);
+    // DPI import at t/t_dpi_arg_output_unpack.v:139:33
+    extern void i_byte_unsigned_3d(unsigned char* val);
     // DPI import at t/t_dpi_arg_output_unpack.v:197:33
-    extern void i_string_1d(const char** val);
+    extern void i_chandle_0d(void** val);
     // DPI import at t/t_dpi_arg_output_unpack.v:198:33
-    extern void i_string_2d(const char** val);
+    extern void i_chandle_1d(void** val);
     // DPI import at t/t_dpi_arg_output_unpack.v:199:33
-    extern void i_string_3d(const char** val);
+    extern void i_chandle_2d(void** val);
+    // DPI import at t/t_dpi_arg_output_unpack.v:200:33
+    extern void i_chandle_3d(void** val);
+    // DPI import at t/t_dpi_arg_output_unpack.v:151:33
+    extern void i_int_0d(int* val);
+    // DPI import at t/t_dpi_arg_output_unpack.v:152:33
+    extern void i_int_1d(int* val);
+    // DPI import at t/t_dpi_arg_output_unpack.v:153:33
+    extern void i_int_2d(int* val);
+    // DPI import at t/t_dpi_arg_output_unpack.v:154:33
+    extern void i_int_3d(int* val);
+    // DPI import at t/t_dpi_arg_output_unpack.v:156:33
+    extern void i_int_unsigned_0d(unsigned int* val);
+    // DPI import at t/t_dpi_arg_output_unpack.v:157:33
+    extern void i_int_unsigned_1d(unsigned int* val);
+    // DPI import at t/t_dpi_arg_output_unpack.v:158:33
+    extern void i_int_unsigned_2d(unsigned int* val);
+    // DPI import at t/t_dpi_arg_output_unpack.v:159:33
+    extern void i_int_unsigned_3d(unsigned int* val);
+    // DPI import at t/t_dpi_arg_output_unpack.v:179:33
+    extern void i_integer_0d(svLogicVecVal* val);
+    // DPI import at t/t_dpi_arg_output_unpack.v:180:33
+    extern void i_integer_1d(svLogicVecVal* val);
+    // DPI import at t/t_dpi_arg_output_unpack.v:181:33
+    extern void i_integer_2d(svLogicVecVal* val);
+    // DPI import at t/t_dpi_arg_output_unpack.v:182:33
+    extern void i_integer_3d(svLogicVecVal* val);
+    // DPI import at t/t_dpi_arg_output_unpack.v:232:33
+    extern void i_logic121_0d(svLogicVecVal* val);
+    // DPI import at t/t_dpi_arg_output_unpack.v:233:33
+    extern void i_logic121_1d(svLogicVecVal* val);
+    // DPI import at t/t_dpi_arg_output_unpack.v:234:33
+    extern void i_logic121_2d(svLogicVecVal* val);
+    // DPI import at t/t_dpi_arg_output_unpack.v:235:33
+    extern void i_logic121_3d(svLogicVecVal* val);
+    // DPI import at t/t_dpi_arg_output_unpack.v:222:33
+    extern void i_logic1_0d(svLogic* val);
+    // DPI import at t/t_dpi_arg_output_unpack.v:223:33
+    extern void i_logic1_1d(svLogic* val);
+    // DPI import at t/t_dpi_arg_output_unpack.v:224:33
+    extern void i_logic1_2d(svLogic* val);
+    // DPI import at t/t_dpi_arg_output_unpack.v:225:33
+    extern void i_logic1_3d(svLogic* val);
+    // DPI import at t/t_dpi_arg_output_unpack.v:227:33
+    extern void i_logic7_0d(svLogicVecVal* val);
+    // DPI import at t/t_dpi_arg_output_unpack.v:228:33
+    extern void i_logic7_1d(svLogicVecVal* val);
+    // DPI import at t/t_dpi_arg_output_unpack.v:229:33
+    extern void i_logic7_2d(svLogicVecVal* val);
+    // DPI import at t/t_dpi_arg_output_unpack.v:230:33
+    extern void i_logic7_3d(svLogicVecVal* val);
+    // DPI import at t/t_dpi_arg_output_unpack.v:161:33
+    extern void i_longint_0d(long long* val);
+    // DPI import at t/t_dpi_arg_output_unpack.v:162:33
+    extern void i_longint_1d(long long* val);
+    // DPI import at t/t_dpi_arg_output_unpack.v:163:33
+    extern void i_longint_2d(long long* val);
+    // DPI import at t/t_dpi_arg_output_unpack.v:164:33
+    extern void i_longint_3d(long long* val);
     // DPI import at t/t_dpi_arg_output_unpack.v:166:33
-    extern void i_time_0d(svLogicVecVal* val);
+    extern void i_longint_unsigned_0d(unsigned long long* val);
     // DPI import at t/t_dpi_arg_output_unpack.v:167:33
-    extern void i_time_1d(svLogicVecVal* val);
+    extern void i_longint_unsigned_1d(unsigned long long* val);
     // DPI import at t/t_dpi_arg_output_unpack.v:168:33
-    extern void i_time_2d(svLogicVecVal* val);
+    extern void i_longint_unsigned_2d(unsigned long long* val);
     // DPI import at t/t_dpi_arg_output_unpack.v:169:33
+    extern void i_longint_unsigned_3d(unsigned long long* val);
+    // DPI import at t/t_dpi_arg_output_unpack.v:237:33
+    extern void i_pack_struct_0d(svLogicVecVal* val);
+    // DPI import at t/t_dpi_arg_output_unpack.v:238:33
+    extern void i_pack_struct_1d(svLogicVecVal* val);
+    // DPI import at t/t_dpi_arg_output_unpack.v:239:33
+    extern void i_pack_struct_2d(svLogicVecVal* val);
+    // DPI import at t/t_dpi_arg_output_unpack.v:240:33
+    extern void i_pack_struct_3d(svLogicVecVal* val);
+    // DPI import at t/t_dpi_arg_output_unpack.v:185:33
+    extern void i_real_0d(double* val);
+    // DPI import at t/t_dpi_arg_output_unpack.v:186:33
+    extern void i_real_1d(double* val);
+    // DPI import at t/t_dpi_arg_output_unpack.v:187:33
+    extern void i_real_2d(double* val);
+    // DPI import at t/t_dpi_arg_output_unpack.v:188:33
+    extern void i_real_3d(double* val);
+    // DPI import at t/t_dpi_arg_output_unpack.v:141:33
+    extern void i_shortint_0d(short* val);
+    // DPI import at t/t_dpi_arg_output_unpack.v:142:33
+    extern void i_shortint_1d(short* val);
+    // DPI import at t/t_dpi_arg_output_unpack.v:143:33
+    extern void i_shortint_2d(short* val);
+    // DPI import at t/t_dpi_arg_output_unpack.v:144:33
+    extern void i_shortint_3d(short* val);
+    // DPI import at t/t_dpi_arg_output_unpack.v:146:33
+    extern void i_shortint_unsigned_0d(unsigned short* val);
+    // DPI import at t/t_dpi_arg_output_unpack.v:147:33
+    extern void i_shortint_unsigned_1d(unsigned short* val);
+    // DPI import at t/t_dpi_arg_output_unpack.v:148:33
+    extern void i_shortint_unsigned_2d(unsigned short* val);
+    // DPI import at t/t_dpi_arg_output_unpack.v:149:33
+    extern void i_shortint_unsigned_3d(unsigned short* val);
+    // DPI import at t/t_dpi_arg_output_unpack.v:202:33
+    extern void i_string_0d(const char** val);
+    // DPI import at t/t_dpi_arg_output_unpack.v:203:33
+    extern void i_string_1d(const char** val);
+    // DPI import at t/t_dpi_arg_output_unpack.v:204:33
+    extern void i_string_2d(const char** val);
+    // DPI import at t/t_dpi_arg_output_unpack.v:205:33
+    extern void i_string_3d(const char** val);
+    // DPI import at t/t_dpi_arg_output_unpack.v:172:33
+    extern void i_time_0d(svLogicVecVal* val);
+    // DPI import at t/t_dpi_arg_output_unpack.v:173:33
+    extern void i_time_1d(svLogicVecVal* val);
+    // DPI import at t/t_dpi_arg_output_unpack.v:174:33
+    extern void i_time_2d(svLogicVecVal* val);
+    // DPI import at t/t_dpi_arg_output_unpack.v:175:33
     extern void i_time_3d(svLogicVecVal* val);
     
 #ifdef __cplusplus


### PR DESCRIPTION
This PR adds more cases that use unpacked array of 1 bit wire.

I will merge after CI passes because this is just adding test without changing Verilator itself.