### PR TITLE
Fix VPI memory word indexing

### DIFF
--- a/include/verilated_vpi.cpp
+++ b/include/verilated_vpi.cpp
@@ -1146,8 +1146,11 @@ vpiHandle vpi_handle_by_index(vpiHandle object, PLI_INT32 indx) {
     // Used to get array entries
     VL_DEBUG_IF_PLI(VL_DBG_MSGF("- vpi: vpi_handle_by_index %p %d\n", object, indx););
     VerilatedVpiImp::assertOneCheck();
-    VerilatedVpioVar* varop = VerilatedVpioVar::castp(object);
     _VL_VPI_ERROR_RESET();
+    // Memory words are not indexable
+    VerilatedVpioMemoryWord* vop = VerilatedVpioMemoryWord::castp(object);
+    if (VL_UNLIKELY(vop)) return nullptr;
+    VerilatedVpioVar* varop = VerilatedVpioVar::castp(object);
     if (VL_LIKELY(varop)) {
         if (varop->varp()->dims() < 2) return nullptr;
         if (VL_LIKELY(varop->varp()->unpacked().left() >= varop->varp()->unpacked().right())) {

--- a/test_regress/t/t_vpi_var.cpp
+++ b/test_regress/t/t_vpi_var.cpp
@@ -377,7 +377,17 @@ int _mon_check_quad() {
     TestVpiHandle vhidx2 = vpi_handle_by_index(vh2, 2);
     CHECK_RESULT_NZ(vhidx2);
     TestVpiHandle vhidx3 = vpi_handle_by_index(vh2, 3);
-    CHECK_RESULT_NZ(vhidx2);
+    CHECK_RESULT_NZ(vhidx3);
+
+    // Memory words should not be indexable
+    TestVpiHandle vhidx3idx0 = vpi_handle_by_index(vhidx3, 0);
+    CHECK_RESULT(vhidx3idx0, 0);
+    TestVpiHandle vhidx2idx2 = vpi_handle_by_index(vhidx2, 2);
+    CHECK_RESULT(vhidx2idx2, 0);
+    TestVpiHandle vhidx3idx3 = vpi_handle_by_index(vhidx3, 3);
+    CHECK_RESULT(vhidx3idx3, 0);
+    TestVpiHandle vhidx2idx61 = vpi_handle_by_index(vhidx2, 61);
+    CHECK_RESULT(vhidx2idx61, 0);
 
     v.format = vpiVectorVal;
     v.value.vector = vv;


### PR DESCRIPTION
Calling `vpi_handle_by_index()` on a memory word can inadvertently return a non-NULL handle, if the given index is within the range of the parent memory object. This happens because they share the same `VerilatedVar`, which is used to get the index.

This PR adds a check on the object handle to see if it's a memory word before attempting to get an index.