### PR TITLE
Add --asan option that enables address sanitizer to the test driver

### DIFF
--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -29,6 +29,7 @@
 /obj_opt/
 /obj_vcs/
 /obj_vlt/
+/obj_vltasan/
 /obj_vltmt/
 INCA_libs/
 /cov_work/

--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -29,7 +29,6 @@
 /obj_opt/
 /obj_vcs/
 /obj_vlt/
-/obj_vltasan/
 /obj_vltmt/
 INCA_libs/
 /cov_work/

--- a/test_regress/driver.pl
+++ b/test_regress/driver.pl
@@ -575,7 +575,7 @@ sub new {
         sim_time => 1100,
         benchmark => $opt_benchmark,
         verbose => $opt_verbose,
-        run_env => '',
+        run_env => $self->{vlt} ? 'ASAN_OPTIONS=detect_leaks=0' : '',
         # All compilers
         v_flags => [split(/\s+/,
                           (($self->{xsim} ? " -f input.xsim.vc " :

--- a/test_regress/driver.pl
+++ b/test_regress/driver.pl
@@ -881,7 +881,7 @@ sub compile_vlt_flags {
     unshift @verilator_flags, "--trace-threads 1" if $param{vltmt} && $checkflags =~ /-trace /;
     unshift @verilator_flags, "--trace-threads 2" if $param{vltmt} && $checkflags =~ /-trace-fst /;
     unshift @verilator_flags, "--debug-partition" if $param{vltmt};
-    unshift @verilator_flags, "-CFLAGS --sanitize=address -LDFLAGS --sanitize=address" if $param{vltasan};
+    unshift @verilator_flags, "-CFLAGS -fsanitize=address -LDFLAGS -fsanitize=address" if $param{vltasan} || $param{vlt};
     unshift @verilator_flags, "--make gmake" if $param{verilator_make_gmake};
     unshift @verilator_flags, "--make cmake" if $param{verilator_make_cmake};
     unshift @verilator_flags, "--exe" if

--- a/test_regress/driver.pl
+++ b/test_regress/driver.pl
@@ -2605,8 +2605,8 @@ output.
 =item --asan
 
 Enable address sanitizer to compile Verilated C++ code.
-It detects misuse of memory such as out-of-bound access, use-after-free,
-and memory leak.
+This may detect misuses of memory, such as out-of-bound accesses, use-after-free,
+and memory leaks.
 
 =item --benchmark [<cycles>]
 


### PR DESCRIPTION
I think it is useful to compile verilated C++ with address sanitizer enabled for finding memory issues. 
I believe I was able to fix #2622 easier if I had used asan.

It would be helpful to run tests with asan. ( Perhaps CI or cron run can run with asan enabled).

It looks about 50 tests fail if asan is enabled at my first glance.
Many of failures are memory leak, but some are heap overflow such as t_dpi_open.
