### PR TITLE
Rename --asan to --sanitize

### DIFF
--- a/test_regress/t/t_debug_sigsegv_bad.pl
+++ b/test_regress/t/t_debug_sigsegv_bad.pl
@@ -14,6 +14,7 @@ $ENV{VERILATOR_TEST_NO_GDB} and skip("Skipping due to VERILATOR_TEST_NO_GDB");
 lint(
     v_flags => ["--debug-sigsegv"],
     fails => 1,
+    sanitize => 0,
     expect =>
 '%Error: Verilator internal fault, sorry. Suggest trying --debug --gdbbt
 %Error: Command Failed.*',

--- a/test_regress/t/t_debug_sigsegv_bt_bad.pl
+++ b/test_regress/t/t_debug_sigsegv_bt_bad.pl
@@ -13,6 +13,7 @@ $ENV{VERILATOR_TEST_NO_GDB} and skip("Skipping due to VERILATOR_TEST_NO_GDB");
 
 lint(
     verilator_flags2 => ["--lint-only --debug --gdbbt --debug-sigsegv"],
+    sanitize => 0,
     fails => $Self->{vlt_all},
     expect =>
 '.*


### PR DESCRIPTION
Rename the option as suggested in https://github.com/verilator/verilator/pull/2700#issuecomment-745631280 .

I am editing perl after blank of 10+ years. Please feel free to edit.