### PR TITLE
Fix memory leaks when using shared protect-lib

### DIFF
--- a/include/verilated.cpp
+++ b/include/verilated.cpp
@@ -80,6 +80,7 @@ struct VerilatedInitializer {
         static bool done = false;
         if (!done) {
             VerilatedImp::setup();
+            Verilated::s_ns.setup();
             done = true;
         }
     }
@@ -87,6 +88,7 @@ struct VerilatedInitializer {
         static bool done = false;
         if (!done) {
             VerilatedImp::teardown();
+            Verilated::s_ns.teardown();
             done = true;
         }
     }

--- a/include/verilated.cpp
+++ b/include/verilated.cpp
@@ -276,10 +276,10 @@ Verilated::Serialized::Serialized() {
     s_timeprecision = VL_TIME_PRECISION;  // Initial value until overriden by _Vconfigure
 }
 
-Verilated::NonSerialized::NonSerialized() {
+void Verilated::NonSerialized::setup() {
     s_profThreadsFilenamep = strdup("profile_threads.dat");
 }
-Verilated::NonSerialized::~NonSerialized() {
+void Verilated::NonSerialized::teardown() {
     if (s_profThreadsFilenamep) {
         VL_DO_CLEAR(free(const_cast<char*>(s_profThreadsFilenamep)),
                     s_profThreadsFilenamep = nullptr);

--- a/include/verilated.h
+++ b/include/verilated.h
@@ -399,8 +399,8 @@ class Verilated final {
         vluint32_t s_profThreadsWindow = 2;  ///< +prof+threads window size
         // Slow path
         const char* s_profThreadsFilenamep;  ///< +prof+threads filename
-        NonSerialized();
-        ~NonSerialized();
+        void setup();
+        void teardown();
     } s_ns;
 
     // no need to be save-restored (serialized) the
@@ -429,6 +429,8 @@ class Verilated final {
     } t_s;
 
 private:
+    friend struct VerilatedInitializer;
+
     // CONSTRUCTORS
     VL_UNCOPYABLE(Verilated);
 


### PR DESCRIPTION
This PR fixes leaks in shared protect-lib. (part of #2703)
t_hier_block_prot_lib_shared and t_prot_lib_shared finish cleanly with --sanitize.

This is similar to #2526, but has been stealth because dtor of the class does not cause double-free.
https://github.com/verilator/verilator/blob/30397356485a5214edb9130605ebcf57f5394284/include/verilated.cpp#L268-L270
