### PR TITLE
Fix use-after-free in fst testcases.

### DIFF
--- a/include/gtkwave/fstapi.c
+++ b/include/gtkwave/fstapi.c
@@ -1816,10 +1816,11 @@ free(xc->curval_mem);
 free(xc->valpos_mem);
 free(xc->vchg_mem);
 tmpfile_close(&xc->tchn_handle, &xc->tchn_handle_nam);
+fstWriterContext* const parent = xc->xc_parent;
 free(xc);
 
-xc->xc_parent->in_pthread = 0;
-pthread_mutex_unlock(&(xc->xc_parent->mutex));
+parent->in_pthread = 0;
+pthread_mutex_unlock(&(parent->mutex));
 
 return(NULL);
 }


### PR DESCRIPTION
Part of #2703

This PR fixes use-after-free found by address sanitizer.
FST related tests looks all green with this change.