### PR TITLE
Fix scope map for multiple construction

### DIFF
--- a/include/verilated.cpp
+++ b/include/verilated.cpp
@@ -278,9 +278,7 @@ Verilated::Serialized::Serialized() {
     s_timeprecision = VL_TIME_PRECISION;  // Initial value until overriden by _Vconfigure
 }
 
-void Verilated::NonSerialized::setup() {
-    s_profThreadsFilenamep = strdup("profile_threads.dat");
-}
+void Verilated::NonSerialized::setup() { s_profThreadsFilenamep = strdup("profile_threads.dat"); }
 void Verilated::NonSerialized::teardown() {
     if (s_profThreadsFilenamep) {
         VL_DO_CLEAR(free(const_cast<char*>(s_profThreadsFilenamep)),
@@ -2497,12 +2495,8 @@ void Verilated::endOfEvalGuts(VerilatedEvalMsgQueue* evalMsgQp) VL_MT_SAFE {
 // ctor nor dtor of members are not called automatically.
 // VerilatedInitializer::setup() and teardown() guarantees to initialize/destruct just once.
 
-void VerilatedImp::setup() {
-    new (&VerilatedImp::s_s) VerilatedImpData();
-}
-void VerilatedImp::teardown() {
-    VerilatedImp::s_s.~VerilatedImpU();
-}
+void VerilatedImp::setup() { new (&VerilatedImp::s_s) VerilatedImpData(); }
+void VerilatedImp::teardown() { VerilatedImp::s_s.~VerilatedImpU(); }
 
 //===========================================================================
 // VerilatedImp:: Methods
@@ -2793,9 +2787,7 @@ void VerilatedHierarchy::add(VerilatedScope* fromp, VerilatedScope* top) {
     VerilatedImp::hierarchyAdd(fromp, top);
 }
 
-void VerilatedHierarchy::clear() {
-    VerilatedImp::hierarchyClear();
-}
+void VerilatedHierarchy::clear() { VerilatedImp::hierarchyClear(); }
 
 //===========================================================================
 // VerilatedOneThreaded:: Methods

--- a/include/verilated.cpp
+++ b/include/verilated.cpp
@@ -2793,6 +2793,10 @@ void VerilatedHierarchy::add(VerilatedScope* fromp, VerilatedScope* top) {
     VerilatedImp::hierarchyAdd(fromp, top);
 }
 
+void VerilatedHierarchy::remove(VerilatedScope* fromp, VerilatedScope* top) {
+    VerilatedImp::hierarchyRemove(fromp, top);
+}
+
 //===========================================================================
 // VerilatedOneThreaded:: Methods
 

--- a/include/verilated.cpp
+++ b/include/verilated.cpp
@@ -2793,6 +2793,10 @@ void VerilatedHierarchy::add(VerilatedScope* fromp, VerilatedScope* top) {
     VerilatedImp::hierarchyAdd(fromp, top);
 }
 
+void VerilatedHierarchy::clear() {
+    VerilatedImp::hierarchyClear();
+}
+
 //===========================================================================
 // VerilatedOneThreaded:: Methods
 

--- a/include/verilated.cpp
+++ b/include/verilated.cpp
@@ -278,7 +278,9 @@ Verilated::Serialized::Serialized() {
     s_timeprecision = VL_TIME_PRECISION;  // Initial value until overriden by _Vconfigure
 }
 
-void Verilated::NonSerialized::setup() { s_profThreadsFilenamep = strdup("profile_threads.dat"); }
+void Verilated::NonSerialized::setup() {
+    s_profThreadsFilenamep = strdup("profile_threads.dat");
+}
 void Verilated::NonSerialized::teardown() {
     if (s_profThreadsFilenamep) {
         VL_DO_CLEAR(free(const_cast<char*>(s_profThreadsFilenamep)),
@@ -2495,8 +2497,12 @@ void Verilated::endOfEvalGuts(VerilatedEvalMsgQueue* evalMsgQp) VL_MT_SAFE {
 // ctor nor dtor of members are not called automatically.
 // VerilatedInitializer::setup() and teardown() guarantees to initialize/destruct just once.
 
-void VerilatedImp::setup() { new (&VerilatedImp::s_s) VerilatedImpData(); }
-void VerilatedImp::teardown() { VerilatedImp::s_s.~VerilatedImpU(); }
+void VerilatedImp::setup() {
+    new (&VerilatedImp::s_s) VerilatedImpData();
+}
+void VerilatedImp::teardown() {
+    VerilatedImp::s_s.~VerilatedImpU();
+}
 
 //===========================================================================
 // VerilatedImp:: Methods
@@ -2787,7 +2793,9 @@ void VerilatedHierarchy::add(VerilatedScope* fromp, VerilatedScope* top) {
     VerilatedImp::hierarchyAdd(fromp, top);
 }
 
-void VerilatedHierarchy::clear() { VerilatedImp::hierarchyClear(); }
+void VerilatedHierarchy::clear() {
+    VerilatedImp::hierarchyClear();
+}
 
 //===========================================================================
 // VerilatedOneThreaded:: Methods

--- a/include/verilated.cpp
+++ b/include/verilated.cpp
@@ -2793,10 +2793,6 @@ void VerilatedHierarchy::add(VerilatedScope* fromp, VerilatedScope* top) {
     VerilatedImp::hierarchyAdd(fromp, top);
 }
 
-void VerilatedHierarchy::clear() {
-    VerilatedImp::hierarchyClear();
-}
-
 //===========================================================================
 // VerilatedOneThreaded:: Methods
 

--- a/include/verilated.h
+++ b/include/verilated.h
@@ -363,6 +363,7 @@ public:  // But internals only - called from VerilatedModule's
 class VerilatedHierarchy final {
 public:
     static void add(VerilatedScope* fromp, VerilatedScope* top);
+    static void clear();
 };
 
 //===========================================================================

--- a/include/verilated.h
+++ b/include/verilated.h
@@ -363,7 +363,6 @@ public:  // But internals only - called from VerilatedModule's
 class VerilatedHierarchy final {
 public:
     static void add(VerilatedScope* fromp, VerilatedScope* top);
-    static void clear();
 };
 
 //===========================================================================

--- a/include/verilated.h
+++ b/include/verilated.h
@@ -363,6 +363,7 @@ public:  // But internals only - called from VerilatedModule's
 class VerilatedHierarchy final {
 public:
     static void add(VerilatedScope* fromp, VerilatedScope* top);
+    static void remove(VerilatedScope* fromp, VerilatedScope* top);
 };
 
 //===========================================================================

--- a/include/verilated_imp.h
+++ b/include/verilated_imp.h
@@ -413,6 +413,11 @@ public:  // But only for verilated*.cpp
         const VerilatedLockGuard lock(s_s.v.m_hierMapMutex);
         s_s.v.m_hierMap[fromp].push_back(top);
     }
+    static void hierarchyClear() VL_MT_SAFE {
+        // Slow ok - called at construction for VPI accessible elements
+        const VerilatedLockGuard lock(s_s.v.m_hierMapMutex);
+        s_s.v.m_hierMap.clear();
+    }
     static const VerilatedHierarchyMap* hierarchyMap() VL_MT_SAFE_POSTINIT {
         // Thread save only assuming this is called only after model construction completed
         return &s_s.v.m_hierMap;

--- a/include/verilated_imp.h
+++ b/include/verilated_imp.h
@@ -413,7 +413,8 @@ public:  // But only for verilated*.cpp
         const VerilatedLockGuard lock(s_s.v.m_hierMapMutex);
         s_s.v.m_hierMap[fromp].push_back(top);
     }
-    static void hierarchyRemove(const VerilatedScope* fromp, const VerilatedScope* top) VL_MT_SAFE {
+    static void hierarchyRemove(const VerilatedScope* fromp,
+                                const VerilatedScope* top) VL_MT_SAFE {
         // Slow ok - called at destruction for VPI accessible elements
         const VerilatedLockGuard lock(s_s.v.m_hierMapMutex);
         VerilatedHierarchyMap& map = s_s.v.m_hierMap;

--- a/include/verilated_imp.h
+++ b/include/verilated_imp.h
@@ -413,11 +413,6 @@ public:  // But only for verilated*.cpp
         const VerilatedLockGuard lock(s_s.v.m_hierMapMutex);
         s_s.v.m_hierMap[fromp].push_back(top);
     }
-    static void hierarchyClear() VL_MT_SAFE {
-        // Slow ok - called at construction for VPI accessible elements
-        const VerilatedLockGuard lock(s_s.v.m_hierMapMutex);
-        s_s.v.m_hierMap.clear();
-    }
     static const VerilatedHierarchyMap* hierarchyMap() VL_MT_SAFE_POSTINIT {
         // Thread save only assuming this is called only after model construction completed
         return &s_s.v.m_hierMap;

--- a/include/verilated_imp.h
+++ b/include/verilated_imp.h
@@ -413,6 +413,15 @@ public:  // But only for verilated*.cpp
         const VerilatedLockGuard lock(s_s.v.m_hierMapMutex);
         s_s.v.m_hierMap[fromp].push_back(top);
     }
+    static void hierarchyRemove(const VerilatedScope* fromp, const VerilatedScope* top) VL_MT_SAFE {
+        // Slow ok - called at destruction for VPI accessible elements
+        const VerilatedLockGuard lock(s_s.v.m_hierMapMutex);
+        VerilatedHierarchyMap& map = s_s.v.m_hierMap;
+        if (map.find(fromp) == map.end()) return;
+        VerilatedScopeVector& scopes = map[fromp];
+        const auto it = find(scopes.begin(), scopes.end(), top);
+        if (it != scopes.end()) scopes.erase(it);
+    }
     static const VerilatedHierarchyMap* hierarchyMap() VL_MT_SAFE_POSTINIT {
         // Thread save only assuming this is called only after model construction completed
         return &s_s.v.m_hierMap;

--- a/src/V3EmitCSyms.cpp
+++ b/src/V3EmitCSyms.cpp
@@ -687,7 +687,6 @@ void EmitCSyms::emitSymImp() {
 
     if (v3Global.opt.vpi()) {
         puts("\n// Setup scope hierarchy\n");
-        puts("__Vhier.clear();\n");
         for (ScopeNames::const_iterator it = m_scopeNames.begin(); it != m_scopeNames.end();
              ++it) {
             string name = it->second.m_prettyName;

--- a/src/V3EmitCSyms.cpp
+++ b/src/V3EmitCSyms.cpp
@@ -687,6 +687,7 @@ void EmitCSyms::emitSymImp() {
 
     if (v3Global.opt.vpi()) {
         puts("\n// Setup scope hierarchy\n");
+        puts("__Vhier.clear();\n");
         for (ScopeNames::const_iterator it = m_scopeNames.begin(); it != m_scopeNames.end();
              ++it) {
             string name = it->second.m_prettyName;

--- a/src/V3EmitCSyms.cpp
+++ b/src/V3EmitCSyms.cpp
@@ -566,7 +566,8 @@ void EmitCSyms::emitScopeHier(bool destroy) {
             string name = it->second.m_prettyName;
             if (it->first == "TOP") continue;
             if ((name.find('.') == string::npos) && (it->second.m_type == "SCOPE_MODULE")) {
-                puts("__Vhier." + method + "(0, &" + protect("__Vscope_" + it->second.m_symName) + ");\n");
+                puts("__Vhier." + method + "(0, &" + protect("__Vscope_" + it->second.m_symName)
+                     + ");\n");
             }
         }
 

--- a/src/V3EmitCSyms.cpp
+++ b/src/V3EmitCSyms.cpp
@@ -116,6 +116,7 @@ class EmitCSyms final : EmitCBaseVisitor {
     void checkSplit(bool usesVfinal);
     void closeSplit();
     void emitSymImpPreamble();
+    void emitScopeHier(bool destroy);
     void emitSymImp();
     void emitDpiHdr();
     void emitDpiImp();
@@ -467,7 +468,7 @@ void EmitCSyms::emitSymHdr() {
 
     puts("\n// CREATORS\n");
     puts(symClassName() + "(" + topClassName() + "* topp, const char* namep);\n");
-    puts(string("~") + symClassName() + "() = default;\n");
+    puts(string("~") + symClassName() + "();\n");
 
     for (const auto& i : m_usesVfinal) {
         puts("void " + symClassName() + "_" + cvtToStr(i.first) + "(");
@@ -552,6 +553,39 @@ void EmitCSyms::emitSymImpPreamble() {
          nodep = VN_CAST(nodep->nextp(), NodeModule)) {
         if (VN_IS(nodep, Class)) continue;  // Class included earlier
         puts("#include \"" + prefixNameProtect(nodep) + ".h\"\n");
+    }
+}
+
+void EmitCSyms::emitScopeHier(bool destroy) {
+    if (v3Global.opt.vpi()) {
+        string verb = destroy ? "Tear down" : "Set up";
+        string method = destroy ? "remove" : "add";
+        puts("\n// " + verb + " scope hierarchy\n");
+        for (ScopeNames::const_iterator it = m_scopeNames.begin(); it != m_scopeNames.end();
+             ++it) {
+            string name = it->second.m_prettyName;
+            if (it->first == "TOP") continue;
+            if ((name.find('.') == string::npos) && (it->second.m_type == "SCOPE_MODULE")) {
+                puts("__Vhier." + method + "(0, &" + protect("__Vscope_" + it->second.m_symName) + ");\n");
+            }
+        }
+
+        for (ScopeNameHierarchy::const_iterator it = m_vpiScopeHierarchy.begin();
+             it != m_vpiScopeHierarchy.end(); ++it) {
+            for (ScopeNameList::const_iterator lit = it->second.begin(); lit != it->second.end();
+                 ++lit) {
+                string fromname = scopeSymString(it->first);
+                string toname = scopeSymString(*lit);
+                const auto from = vlstd::as_const(m_scopeNames).find(fromname);
+                const auto to = vlstd::as_const(m_scopeNames).find(toname);
+                UASSERT(from != m_scopeNames.end(), fromname + " not in m_scopeNames");
+                UASSERT(to != m_scopeNames.end(), toname + " not in m_scopeNames");
+                puts("__Vhier." + method + "(");
+                puts("&" + protect("__Vscope_" + from->second.m_symName) + ", ");
+                puts("&" + protect("__Vscope_" + to->second.m_symName) + ");\n");
+            }
+        }
+        puts("\n");
     }
 }
 
@@ -685,34 +719,7 @@ void EmitCSyms::emitSymImp() {
         }
     }
 
-    if (v3Global.opt.vpi()) {
-        puts("\n// Setup scope hierarchy\n");
-        for (ScopeNames::const_iterator it = m_scopeNames.begin(); it != m_scopeNames.end();
-             ++it) {
-            string name = it->second.m_prettyName;
-            if (it->first == "TOP") continue;
-            if ((name.find('.') == string::npos) && (it->second.m_type == "SCOPE_MODULE")) {
-                puts("__Vhier.add(0, &" + protect("__Vscope_" + it->second.m_symName) + ");\n");
-            }
-        }
-
-        for (ScopeNameHierarchy::const_iterator it = m_vpiScopeHierarchy.begin();
-             it != m_vpiScopeHierarchy.end(); ++it) {
-            for (ScopeNameList::const_iterator lit = it->second.begin(); lit != it->second.end();
-                 ++lit) {
-                string fromname = scopeSymString(it->first);
-                string toname = scopeSymString(*lit);
-                const auto from = vlstd::as_const(m_scopeNames).find(fromname);
-                const auto to = vlstd::as_const(m_scopeNames).find(toname);
-                UASSERT(from != m_scopeNames.end(), fromname + " not in m_scopeNames");
-                UASSERT(to != m_scopeNames.end(), toname + " not in m_scopeNames");
-                puts("__Vhier.add(");
-                puts("&" + protect("__Vscope_" + from->second.m_symName) + ", ");
-                puts("&" + protect("__Vscope_" + to->second.m_symName) + ");\n");
-            }
-        }
-        puts("\n");
-    }
+    emitScopeHier(false);
 
     // Everything past here is in the __Vfinal loop, so start a new split file if needed
     closeSplit();
@@ -826,6 +833,10 @@ void EmitCSyms::emitSymImp() {
     }
 
     m_ofpBase->puts("}\n");
+    puts(symClassName() + "::~" + symClassName() + "()\n");
+    puts("{\n");
+    emitScopeHier(true);
+    puts("}\n");
     closeSplit();
     VL_DO_CLEAR(delete m_ofp, m_ofp = nullptr);
 }

--- a/src/V3EmitCSyms.cpp
+++ b/src/V3EmitCSyms.cpp
@@ -639,6 +639,10 @@ void EmitCSyms::emitSymImp() {
     puts("\n");
 
     puts("\n// FUNCTIONS\n");
+    puts(symClassName() + "::~" + symClassName() + "()\n");
+    puts("{\n");
+    emitScopeHier(true);
+    puts("}\n\n");
     puts(symClassName() + "::" + symClassName() + "(" + topClassName()
          + "* topp, const char* namep)\n");
     puts("    // Setup locals\n");
@@ -834,10 +838,6 @@ void EmitCSyms::emitSymImp() {
     }
 
     m_ofpBase->puts("}\n");
-    puts(symClassName() + "::~" + symClassName() + "()\n");
-    puts("{\n");
-    emitScopeHier(true);
-    puts("}\n");
     closeSplit();
     VL_DO_CLEAR(delete m_ofp, m_ofp = nullptr);
 }

--- a/test_regress/t/t_vpi_module.cpp
+++ b/test_regress/t/t_vpi_module.cpp
@@ -168,6 +168,9 @@ int main(int argc, char** argv, char** env) {
     Verilated::fatalOnVpiError(0);
 
     VM_PREFIX* topp = new VM_PREFIX("");  // Note null name - we're flattening it out
+    // Test second construction
+    delete topp;
+    topp = new VM_PREFIX("");
 
 #ifdef VERILATOR
 #ifdef TEST_VERBOSE


### PR DESCRIPTION
The scope map retains state in the singleton across instances of the verilated DUT.  This clears it out at construction time.