### PR TITLE
Update files from GTKWave 

### DIFF
--- a/include/gtkwave/fstapi.c
+++ b/include/gtkwave/fstapi.c
@@ -1806,6 +1806,7 @@ xc->already_in_flush = 0;
 static void *fstWriterFlushContextPrivate1(void *ctx)
 {
 struct fstWriterContext *xc = (struct fstWriterContext *)ctx;
+struct fstWriterContext *xc_parent;
 
 pthread_mutex_lock(&(xc->xc_parent->mutex));
 fstWriterFlushContextPrivate2(xc);
@@ -1816,11 +1817,11 @@ free(xc->curval_mem);
 free(xc->valpos_mem);
 free(xc->vchg_mem);
 tmpfile_close(&xc->tchn_handle, &xc->tchn_handle_nam);
-fstWriterContext* const parent = xc->xc_parent;
+xc_parent = xc->xc_parent;
 free(xc);
 
-parent->in_pthread = 0;
-pthread_mutex_unlock(&(parent->mutex));
+xc_parent->in_pthread = 0;
+pthread_mutex_unlock(&(xc_parent->mutex));
 
 return(NULL);
 }

--- a/include/gtkwave/wavealloca.h
+++ b/include/gtkwave/wavealloca.h
@@ -35,6 +35,9 @@
 #else
 #include <malloc.h>
 #endif
+#elif defined(_MSC_VER)
+#include <malloc.h>
+#define alloca _alloca
 #endif
 #define wave_alloca alloca
 #endif


### PR DESCRIPTION
Fix of use-after-free is merged to gtkwave as https://github.com/gtkwave/gtkwave/pull/39

This PR syncs include/gtkwave to the latest files at gtkwave f119b35816e605e753fc1a24ae121a3787615b26 ,

No functional change is intended.