### PR TITLE
Added fault simulation capability

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -5,6 +5,7 @@ Please see the Verilator manual for 200+ additional contributors. Thanks to all.
 
 Ahmed El-Mahmoudy
 Alex Chadwick
+Bogdan-Andrei Tabacaru
 Chris Randall
 Conor McCullough
 Dan Petrisko
@@ -12,6 +13,7 @@ David Horton
 David Stanford
 Driss Hafdi
 Edgar E. Iglesias
+Endri Kaja
 Eric Rippey
 Fan Shupei
 Garrett Smith

--- a/src/V3AstNodes.h
+++ b/src/V3AstNodes.h
@@ -1949,6 +1949,7 @@ private:
     bool m_noSubst : 1;  // Do not substitute out references
     bool m_overridenParam : 1;  // Overridden parameter by #(...) or defparam
     bool m_trace : 1;  // Trace this variable
+    bool m_fi:1; //fi
     VLifetime m_lifetime;  // Lifetime
     VVarAttrClocker m_attrClocker;
     MTaskIdSet m_mtaskIds;  // MTaskID's that read or write this var
@@ -1988,6 +1989,7 @@ private:
         m_noSubst = false;
         m_overridenParam = false;
         m_trace = false;
+        m_fi = false; //fi
         m_attrClocker = VVarAttrClocker::CLOCKER_UNKNOWN;
     }
 
@@ -2113,6 +2115,7 @@ public:
     void usedClock(bool flag) { m_usedClock = flag; }
     void usedParam(bool flag) { m_usedParam = flag; }
     void usedLoopIdx(bool flag) { m_usedLoopIdx = flag; }
+    void fi(bool flag) { m_fi = flag; } //fi
     void sigPublic(bool flag) { m_sigPublic = flag; }
     void sigModPublic(bool flag) { m_sigModPublic = flag; }
     void sigUserRdPublic(bool flag) {
@@ -2184,6 +2187,7 @@ public:
     bool isUsedClock() const { return m_usedClock; }
     bool isUsedParam() const { return m_usedParam; }
     bool isUsedLoopIdx() const { return m_usedLoopIdx; }
+    bool isFi() const { return m_fi; }//fi
     bool isSc() const { return m_sc; }
     bool isScQuad() const;
     bool isScBv() const;

--- a/src/V3LinkLevel.cpp
+++ b/src/V3LinkLevel.cpp
@@ -226,6 +226,9 @@ void V3LinkLevel::wrapTopCell(AstNetlist* rootp) {
                                      "Unsupported: ref/const ref as primary input/output: "
                                          << varp->prettyNameQ());
                     }
+                    if (v3Global.opt.fault_injection()) { //fi
+		    varp->fi(true);
+		    }
                     if (varp->isIO() && v3Global.opt.systemC()) {
                         varp->sc(true);
                         // User can see trace one level down from the wrapper

--- a/src/V3Options.cpp
+++ b/src/V3Options.cpp
@@ -985,6 +985,8 @@ void V3Options::parseOptsList(FileLine* fl, const string& optdir, int argc, char
             } else if (!strcmp(sw, "-cc")) {
                 m_outFormatOk = true;
                 m_systemC = false;
+            } else if ( !strcmp (sw, "-fi") ) { //fi
+		m_fault_injection = true;
             } else if (onoff(sw, "-cdc", flag /*ref*/)) {
                 m_cdc = flag;
             } else if (onoff(sw, "-coverage", flag /*ref*/)) {

--- a/src/V3Options.h
+++ b/src/V3Options.h
@@ -320,6 +320,7 @@ private:
     bool m_vpi = false;             // main switch: --vpi
     bool m_xInitialEdge = false;    // main switch: --x-initial-edge
     bool m_xmlOnly = false;         // main switch: --xml-only
+    bool m_fault_injection = false; //fi
 
     int         m_buildJobs = 1;    // main switch: -j
     int         m_convergeLimit = 100;  // main switch: --converge-limit
@@ -441,6 +442,7 @@ public:
     void addVFile(const string& filename);
     void addForceInc(const string& filename);
     void notify();
+    bool fault_injection() const { return m_fault_injection; }//fi
 
     // ACCESSORS (options)
     bool preprocOnly() const { return m_preprocOnly; }


### PR DESCRIPTION
With the new changes, Verilator is able to simulate different fault models:
Limitation: Do not add _verilator public_ to any signal.
Limitation: Can not inject fault at WData
Limitation: Can not inject faults at 2D arrays
[fi_documentation.pdf](https://github.com/verilator/verilator/files/5730987/fi_documentation.pdf)
