### PR TITLE
Fix for issue#2741

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -53,6 +53,7 @@ Nandu Raj
 Nathan Kohagen
 Nathan Myers
 Patrick Stewart
+Paul Wright
 Peter Horvath
 Peter Monsson
 Philipp Wagner

--- a/src/V3AstNodes.h
+++ b/src/V3AstNodes.h
@@ -2170,7 +2170,7 @@ public:
         return ((isIO() || isSignal())
                 && (isIO() || isBitLogic())
                 // Wrapper would otherwise duplicate wrapped module's coverage
-                && !isSc() && !isPrimaryIO() && !isConst());
+                && !isSc() && !isPrimaryIO() && !isConst() && !isDouble());
     }
     bool isClassMember() const { return varType() == AstVarType::MEMBER; }
     bool isStatementTemp() const { return (varType() == AstVarType::STMTTEMP); }

--- a/test_regress/t/t_cover_toggle.v
+++ b/test_regress/t/t_cover_toggle.v
@@ -6,10 +6,12 @@
 
 module t (/*AUTOARG*/
    // Inputs
-   clk
+   clk,
+   check_real
    );
 
    input clk;
+   input real check_real; // Check issue #2741
 
    typedef struct packed {
       union packed {


### PR DESCRIPTION
- Do not apply toggle coverage to real ports, issue#2741
- Real ports should not be included in toggle coverage collection, issue#2741
- Adding name as per contributing guidelines, issue#2741

Toggle coverage collection was applied to real inputs/outputs. These checkins should prevent this.

We appreciate your contributing to Verilator.  If this is your first commit, please add your name to docs/CONTRIBUTORS, and read our contributing guidelines in docs/CONTRIBUTING.adoc.
