### PR TITLE
Include limits header for std::numeric_limits

### DIFF
--- a/include/verilated.cpp
+++ b/include/verilated.cpp
@@ -32,6 +32,7 @@
 #include <sstream>
 #include <sys/stat.h>  // mkdir
 #include <list>
+#include <limits>
 #include <utility>
 
 // clang-format off

--- a/src/V3Trace.cpp
+++ b/src/V3Trace.cpp
@@ -46,6 +46,7 @@
 #include "V3Stats.h"
 
 #include <map>
+#include <limits>
 #include <set>
 
 //######################################################################


### PR DESCRIPTION
Code using `std::numeric_limits` didn't include the limits header,
leading to a compilation error in Fedora Rawhide (GCC 11.0).

```
[  836s] g++  -I.  -MMD -I/home/abuild/rpmbuild/BUILD/verilator-4.108/test_regress/../include -I/home/abuild/rpmbuild/BUILD/verilator-4.108/test_regress/../include/vltstd -DVM_COVERAGE=0 -DVM_SC=0 -DVM_TRACE=1 -DVM_TRACE_FST=0 -faligned-new -fcf-protection=none -Wno-bool-operation -Wno-sign-compare -Wno-uninitialized -Wno-unused-but-set-variable -Wno-unused-parameter -Wno-unused-variable -Wno-shadow      -std=gnu++14 -DVERILATOR=1 -DVL_DEBUG=1 -DTEST_OBJ_DIR=obj_vlt/t_a1_first_cc -DVM_PREFIX=Vt_a1_first_cc -DVM_PREFIX_INCLUDE="<Vt_a1_first_cc.h>" -DT_A1_FIRST_CC   -O0 -c -o verilated.o /home/abuild/rpmbuild/BUILD/verilator-4.108/test_regress/../include/verilated.cpp
[  837s] /home/abuild/rpmbuild/BUILD/verilator-4.108/test_regress/../include/verilated.cpp: In function 'IData VL_FGETS_NI(std::string&, IData)':
[  837s] /home/abuild/rpmbuild/BUILD/verilator-4.108/test_regress/../include/verilated.cpp:1318:36: error: 'numeric_limits' is not a member of 'std'
[  837s]  1318 |     return getLine(dest, fpi, std::numeric_limits<size_t>::max());
[  837s]       |                                    ^~~~~~~~~~~~~~
[  837s] /home/abuild/rpmbuild/BUILD/verilator-4.108/test_regress/../include/verilated.cpp:1318:57: error: expected primary-expression before '>' token
[  837s]  1318 |     return getLine(dest, fpi, std::numeric_limits<size_t>::max());
[  837s]       |                                                         ^
[  837s] /home/abuild/rpmbuild/BUILD/verilator-4.108/test_regress/../include/verilated.cpp:1318:60: error: '::max' has not been declared; did you mean 'std::max'?
[  837s]  1318 |     return getLine(dest, fpi, std::numeric_limits<size_t>::max());
[  837s]       |                                                            ^~~
[  837s]       |                                                            std::max
[  837s] In file included from /usr/include/c++/11/algorithm:62,
[  837s]                  from /home/abuild/rpmbuild/BUILD/verilator-4.108/test_regress/../include/verilated_heavy.h:29,
[  837s]                  from /home/abuild/rpmbuild/BUILD/verilator-4.108/test_regress/../include/verilated_imp.h:29,
[  837s]                  from /home/abuild/rpmbuild/BUILD/verilator-4.108/test_regress/../include/verilated.cpp:25:
[  837s] /usr/include/c++/11/bits/stl_algo.h:3467:5: note: 'std::max' declared here
[  837s]  3467 |     max(initializer_list<_Tp> __l, _Compare __comp)
[  837s]       |     ^~~
[  837s] make[1]: *** [/home/abuild/rpmbuild/BUILD/verilator-4.108/test_regress/../include/verilated.mk:241: verilated.o] Error 1
```

We appreciate your contributing to Verilator.  If this is your first commit, please add your name to docs/CONTRIBUTORS, and read our contributing guidelines in docs/CONTRIBUTING.adoc.
