### PR TITLE
Generate warning instead of errors for potentially unreachable code

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -57,6 +57,7 @@ Paul Wright
 Peter Horvath
 Peter Monsson
 Philipp Wagner
+Pierre-Henri Horrein
 Pieter Kapsenberg
 Piotr Binkowski
 Qingyao Sun

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -804,8 +804,8 @@ private:
             }
             // We're extracting, so just make sure the expression is at least wide enough.
             if (nodep->fromp()->width() < width) {
-                nodep->v3error("Extracting " << width << " bits from only "
-                                             << nodep->fromp()->width() << " bit number");
+                nodep->v3warn(SELRANGE, "Extracting " << width << " bits from only "
+                                                      << nodep->fromp()->width() << " bit number");
                 // Extend it.
                 AstNodeDType* subDTypep
                     = nodep->findLogicDType(width, width, nodep->fromp()->dtypep()->numeric());

--- a/src/V3WidthSel.cpp
+++ b/src/V3WidthSel.cpp
@@ -369,10 +369,11 @@ private:
                 lsb = x;
             }
             if (lsb > msb) {
-                nodep->v3error("["
-                               << msb << ":" << lsb
-                               << "] Range extract has backward bit ordering, perhaps you wanted ["
-                               << lsb << ":" << msb << "]");
+                nodep->v3warn(
+                    SELRANGE,
+                    "[" << msb << ":" << lsb
+                        << "] Range extract has backward bit ordering, perhaps you wanted [" << lsb
+                        << ":" << msb << "]");
                 int x = msb;
                 msb = lsb;
                 lsb = x;
@@ -398,10 +399,11 @@ private:
                 lsb = x;
             }
             if (lsb > msb) {
-                nodep->v3error("["
-                               << msb << ":" << lsb
-                               << "] Range extract has backward bit ordering, perhaps you wanted ["
-                               << lsb << ":" << msb << "]");
+                nodep->v3warn(
+                    SELRANGE,
+                    "[" << msb << ":" << lsb
+                        << "] Range extract has backward bit ordering, perhaps you wanted [" << lsb
+                        << ":" << msb << "]");
                 int x = msb;
                 msb = lsb;
                 lsb = x;
@@ -419,10 +421,11 @@ private:
         } else if (VN_IS(ddtypep, NodeUOrStructDType)) {
             // Classes aren't little endian
             if (lsb > msb) {
-                nodep->v3error("["
-                               << msb << ":" << lsb
-                               << "] Range extract has backward bit ordering, perhaps you wanted ["
-                               << lsb << ":" << msb << "]");
+                nodep->v3warn(
+                    SELRANGE,
+                    "[" << msb << ":" << lsb
+                        << "] Range extract has backward bit ordering, perhaps you wanted [" << lsb
+                        << ":" << msb << "]");
                 int x = msb;
                 msb = lsb;
                 lsb = x;

--- a/test_regress/t/t_mem_multi_ref_bad.out
+++ b/test_regress/t/t_mem_multi_ref_bad.out
@@ -2,10 +2,11 @@
                                      : ... In instance t
    15 |       dimn[1:0] = 0;             
       |           ^
-%Error: t/t_mem_multi_ref_bad.v:15:11: Extracting 2 bits from only 1 bit number
-                                     : ... In instance t
+%Warning-SELRANGE: t/t_mem_multi_ref_bad.v:15:11: Extracting 2 bits from only 1 bit number
+                                                : ... In instance t
    15 |       dimn[1:0] = 0;             
       |           ^
+                   ... Use "/* verilator lint_off SELRANGE */" and lint_on around source to disable this message.
 %Error: t/t_mem_multi_ref_bad.v:16:14: Illegal bit or array select; type does not have a bit range, or bad dimension: data type is 'logic'
                                      : ... In instance t
    16 |       dim0[1][1] = 0;            
@@ -14,7 +15,6 @@
                                                 : ... In instance t
    16 |       dim0[1][1] = 0;            
       |              ^
-                   ... Use "/* verilator lint_off SELRANGE */" and lint_on around source to disable this message.
 %Error: t/t_mem_multi_ref_bad.v:17:17: Illegal bit or array select; type does not have a bit range, or bad dimension: data type is 'logic'
                                      : ... In instance t
    17 |       dim1[1][1][1] = 0;         

--- a/test_regress/t/t_param_unreachable.pl
+++ b/test_regress/t/t_param_unreachable.pl
@@ -1,0 +1,21 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2003 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_param_unreachable.v
+++ b/test_regress/t/t_param_unreachable.v
@@ -1,0 +1,34 @@
+// DESCRIPTION: Verilator: Verilog Test module
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2020 by Pierre-Henri Horrein
+// SPDX-License-Identifier: CC0-1.0
+
+module t (input clk);
+
+   parameter DEPTH = 1;
+   reg [DEPTH-1:0] shiftreg_gen;
+   reg [DEPTH-1:0] shiftreg;
+   reg my_sr_input = '1;
+
+   // shiftreg_gen is generated: it should not raise any warning or error
+   always_ff @(posedge clk) begin
+      shiftreg_gen[0] <= my_sr_input;
+   end
+   if (DEPTH > 1) begin
+      always_ff @(posedge clk) begin
+         shiftreg_gen[DEPTH-1:1] <= shiftreg_gen[DEPTH-2:0];
+      end
+   end
+   // shiftreg is not generated: it can raise a warning
+   always_ff @(posedge clk) begin
+      shiftreg[0] <= my_sr_input;
+      /* verilator lint_off SELRANGE */
+      if (DEPTH > 1) shiftreg[DEPTH-1:1] <= shiftreg[DEPTH-2:0];
+      /* verilator lint_on SELRANGE */
+   end
+
+   initial begin
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end
+endmodule

--- a/test_regress/t/t_select_bad_msb.out
+++ b/test_regress/t/t_select_bad_msb.out
@@ -3,8 +3,8 @@
    12 |    reg [0:22] backwd;
       |        ^
                     ... Use "/* verilator lint_off LITENDIAN */" and lint_on around source to disable this message.
-%Error: t/t_select_bad_msb.v:16:16: [1:4] Range extract has backward bit ordering, perhaps you wanted [4:1]
-                                  : ... In instance t
+%Warning-SELRANGE: t/t_select_bad_msb.v:16:16: [1:4] Range extract has backward bit ordering, perhaps you wanted [4:1]
+                                             : ... In instance t
    16 |       sel2 = mi[1:4];
       |                ^
 %Error: Exiting due to


### PR DESCRIPTION
When using a "if" statement inside an always block, part of the code may
be unreachable. This can be used to avoid errors, but it generated an
error, this commit demotes this to a warning

Partly fixes #2625
