### PR TITLE
Internals:Make some accessors in V3Number public

### DIFF
--- a/src/V3Number.h
+++ b/src/V3Number.h
@@ -109,6 +109,8 @@ private:
         return ("01zx"[(((m_value[bit / 32] & (1UL << (bit & 31))) ? 1 : 0)
                         | ((m_valueX[bit / 32] & (1UL << (bit & 31))) ? 2 : 0))]);
     }
+
+public:
     bool bitIs0(int bit) const {
         if (bit < 0) return false;
         if (bit >= m_width) return !bitIsXZ(m_width - 1);
@@ -144,6 +146,8 @@ private:
         return ((~m_value[bit / 32] & (1UL << (bit & 31)))
                 && (m_valueX[bit / 32] & (1UL << (bit & 31))));
     }
+
+private:
     uint32_t bitsValue(int lsb, int nbits) const {
         uint32_t v = 0;
         for (int bitn = 0; bitn < nbits; bitn++) { v |= (bitIs1(lsb + bitn) << bitn); }


### PR DESCRIPTION
From https://github.com/verilator/verilator/pull/2751#discussion_r556660655

V3Number::bitIs??() are basic accessors and they don't reveal the internal structure of V3Number. I think they are safe to be public.