### PR TITLE
Internals: Use size_t to compare with vector::capacity()

### DIFF
--- a/include/verilated_imp.h
+++ b/include/verilated_imp.h
@@ -595,7 +595,7 @@ private:
             }
         } else {
             // MCD Case
-            for (int i = 0; (fdi != 0) && (i < fp.capacity()); ++i, fdi >>= 1) {
+            for (size_t i = 0; (fdi != 0) && (i < fp.capacity()); ++i, fdi >>= 1) {
                 if (fdi & VL_MASK_I(1)) fp.push_back(s_s.v.m_fdps[i]);
             }
         }


### PR DESCRIPTION
When I set CXXFLAGS=-Werror=sign-compare and run tests, I found the sign<=>unsigned comparison.

```
In file included from /mnt/prj/verilator/include/verilated.cpp:25:
/mnt/prj/verilator/include/verilated_imp.h: In static member function 'static VerilatedFpList VerilatedImp::fdToFpList(IData)':
/mnt/prj/verilator/include/verilated_imp.h:598:46: error: comparison of integer expressions of different signedness: 'int' and 'std::size_t' {aka 'long unsigned int'} [-Werror=sign-compare]
  598 |             for (int i = 0; (fdi != 0) && (i < fp.capacity()); ++i, fdi >>= 1) {
      |                                            ~~^~~~~~~~~~~~~~~
cc1plus: some warnings being treated as errors
```