### PR TITLE
Internals: Add TREEOPC() that executes only when m_doCpp==true

### DIFF
--- a/src/V3Const.cpp
+++ b/src/V3Const.cpp
@@ -2223,6 +2223,7 @@ private:
 
     //    v--- * * This op done on Verilog or C+++ mode, in all non-m_doConst stages
     //    v--- *1* These ops are always first, as we warn before replacing
+    //    v--- *C* This op is a (C)++ op, only in m_doCpp mode
     //    v--- *V* This op is a (V)erilog op, only in m_doV mode
     //    v--- *A* This op works on (A)ll constant children, allowed in m_doConst mode
     //    v--- *S* This op specifies a type should use (S)hort-circuiting of its lhs op

--- a/src/astgen
+++ b/src/astgen
@@ -88,7 +88,7 @@ class Cpt:
         # doflag "S" indicates an op specifying short-circuiting for a type.
         match = re.search(
             #       1   2                 3                  4
-            r'TREEOP(1?)([ASV]?)\s*\(\s*\"([^\"]*)\"\s*,\s*\"([^\"]*)\"\s*\)',
+            r'TREEOP(1?)([ACSV]?)\s*\(\s*\"([^\"]*)\"\s*,\s*\"([^\"]*)\"\s*\)',
             func)
         match_skip = re.search(r'TREE_SKIP_VISIT\s*\(\s*\"([^\"]*)\"\s*\)',
                                func)
@@ -115,6 +115,8 @@ class Cpt:
                 mif = "m_doNConst"
             elif doflag == 'A':
                 mif = ""
+            elif doflag == 'C':
+                mif = "m_doCpp"
             elif doflag == 'S':
                 mif = "m_doNConst"  # Not just for m_doGenerate
             elif doflag == 'V':


### PR DESCRIPTION
Will be used in #2751. cf. https://github.com/verilator/verilator/pull/2751#discussion_r558912504

Will merge when I find CI passes.