### PR TITLE
Override inlining of public and no_inline modules with --flatten

### DIFF
--- a/src/V3Inline.cpp
+++ b/src/V3Inline.cpp
@@ -108,7 +108,9 @@ private:
             // If inlining moves post-scope this can perhaps be relaxed.
             cantInline("modIface", true);
         }
-        if (m_modp->modPublic()) cantInline("modPublic", false);
+        if (m_modp->modPublic() && (m_modp->isTop() || !v3Global.opt.flatten())) {
+            cantInline("modPublic", false);
+        }
 
         iterateChildren(nodep);
         m_modp = nullptr;
@@ -137,7 +139,7 @@ private:
         } else if (nodep->pragType() == AstPragmaType::NO_INLINE_MODULE) {
             if (!m_modp) {
                 nodep->v3error("Inline pragma not under a module");  // LCOV_EXCL_LINE
-            } else {
+            } else if (!v3Global.opt.flatten()) {
                 cantInline("Pragma NO_INLINE_MODULE", false);
             }
             // Remove so don't propagate to upper cell...

--- a/test_regress/t/t_xml_flat_no_inline_mod.out
+++ b/test_regress/t/t_xml_flat_no_inline_mod.out
@@ -1,0 +1,41 @@
+<?xml version="1.0" ?>
+<!-- DESCRIPTION: Verilator output: XML representation of netlist -->
+<verilator_xml>
+  <files>
+    <file id="a" filename="&lt;built-in&gt;" language="1800-2017"/>
+    <file id="b" filename="&lt;command-line&gt;" language="1800-2017"/>
+    <file id="c" filename="input.vc" language="1800-2017"/>
+    <file id="d" filename="t/t_xml_flat_no_inline_mod.v" language="1800-2017"/>
+  </files>
+  <module_files>
+    <file id="d" filename="t/t_xml_flat_no_inline_mod.v" language="1800-2017"/>
+  </module_files>
+  <cells>
+    <cell fl="d11" loc="d,11,8,11,11" name="TOP" submodname="TOP" hier="TOP"/>
+  </cells>
+  <netlist>
+    <module fl="d11" loc="d,11,8,11,11" name="TOP" origName="TOP" topModule="1" public="true">
+      <var fl="d11" loc="d,11,24,11,29" name="i_clk" dtype_id="1" dir="input" vartype="logic" origName="i_clk" public="true"/>
+      <var fl="d11" loc="d,11,24,11,29" name="top.i_clk" dtype_id="1" vartype="logic" origName="i_clk"/>
+      <var fl="d7" loc="d,7,24,7,29" name="top.f.i_clk" dtype_id="1" vartype="logic" origName="i_clk"/>
+      <topscope fl="d11" loc="d,11,8,11,11">
+        <scope fl="d11" loc="d,11,8,11,11" name="TOP">
+          <varscope fl="d11" loc="d,11,24,11,29" name="i_clk" dtype_id="1"/>
+          <varscope fl="d11" loc="d,11,24,11,29" name="top.i_clk" dtype_id="1"/>
+          <varscope fl="d7" loc="d,7,24,7,29" name="top.f.i_clk" dtype_id="1"/>
+          <assignalias fl="d11" loc="d,11,24,11,29" dtype_id="1">
+            <varref fl="d11" loc="d,11,24,11,29" name="i_clk" dtype_id="1"/>
+            <varref fl="d11" loc="d,11,24,11,29" name="i_clk" dtype_id="1"/>
+          </assignalias>
+          <assignalias fl="d7" loc="d,7,24,7,29" dtype_id="1">
+            <varref fl="d7" loc="d,7,24,7,29" name="top.i_clk" dtype_id="1"/>
+            <varref fl="d7" loc="d,7,24,7,29" name="f.i_clk" dtype_id="1"/>
+          </assignalias>
+        </scope>
+      </topscope>
+    </module>
+    <typetable fl="a0" loc="a,0,0,0,0">
+      <basicdtype fl="d11" loc="d,11,18,11,23" id="1" name="logic"/>
+    </typetable>
+  </netlist>
+</verilator_xml>

--- a/test_regress/t/t_xml_flat_no_inline_mod.pl
+++ b/test_regress/t/t_xml_flat_no_inline_mod.pl
@@ -1,0 +1,25 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2012 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(vlt => 1);
+
+my $out_filename = "$Self->{obj_dir}/V$Self->{name}.xml";
+
+compile(
+    verilator_flags2 => ['--xml-only', '--flatten'],
+    verilator_make_gmake => 0,
+    make_top_shell => 0,
+    make_main => 0,
+    );
+
+files_identical("$out_filename", $Self->{golden_filename});
+
+ok(1);
+1;

--- a/test_regress/t/t_xml_flat_no_inline_mod.v
+++ b/test_regress/t/t_xml_flat_no_inline_mod.v
@@ -1,0 +1,13 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2008 by Wilson Snyder.
+// SPDX-License-Identifier: CC0-1.0
+
+module foo(input logic i_clk); /* verilator no_inline_module */
+endmodule
+
+// --flatten forces inlining of 'no_inline_module' module foo.
+module top(input logic i_clk);
+  foo f(.*);
+endmodule

--- a/test_regress/t/t_xml_flat_pub_mod.out
+++ b/test_regress/t/t_xml_flat_pub_mod.out
@@ -1,0 +1,41 @@
+<?xml version="1.0" ?>
+<!-- DESCRIPTION: Verilator output: XML representation of netlist -->
+<verilator_xml>
+  <files>
+    <file id="a" filename="&lt;built-in&gt;" language="1800-2017"/>
+    <file id="b" filename="&lt;command-line&gt;" language="1800-2017"/>
+    <file id="c" filename="input.vc" language="1800-2017"/>
+    <file id="d" filename="t/t_xml_flat_pub_mod.v" language="1800-2017"/>
+  </files>
+  <module_files>
+    <file id="d" filename="t/t_xml_flat_pub_mod.v" language="1800-2017"/>
+  </module_files>
+  <cells>
+    <cell fl="d11" loc="d,11,8,11,11" name="TOP" submodname="TOP" hier="TOP"/>
+  </cells>
+  <netlist>
+    <module fl="d11" loc="d,11,8,11,11" name="TOP" origName="TOP" topModule="1" public="true">
+      <var fl="d11" loc="d,11,24,11,29" name="i_clk" dtype_id="1" dir="input" vartype="logic" origName="i_clk" public="true"/>
+      <var fl="d11" loc="d,11,24,11,29" name="top.i_clk" dtype_id="1" vartype="logic" origName="i_clk"/>
+      <var fl="d7" loc="d,7,24,7,29" name="top.f.i_clk" dtype_id="1" vartype="logic" origName="i_clk"/>
+      <topscope fl="d11" loc="d,11,8,11,11">
+        <scope fl="d11" loc="d,11,8,11,11" name="TOP">
+          <varscope fl="d11" loc="d,11,24,11,29" name="i_clk" dtype_id="1"/>
+          <varscope fl="d11" loc="d,11,24,11,29" name="top.i_clk" dtype_id="1"/>
+          <varscope fl="d7" loc="d,7,24,7,29" name="top.f.i_clk" dtype_id="1"/>
+          <assignalias fl="d11" loc="d,11,24,11,29" dtype_id="1">
+            <varref fl="d11" loc="d,11,24,11,29" name="i_clk" dtype_id="1"/>
+            <varref fl="d11" loc="d,11,24,11,29" name="i_clk" dtype_id="1"/>
+          </assignalias>
+          <assignalias fl="d7" loc="d,7,24,7,29" dtype_id="1">
+            <varref fl="d7" loc="d,7,24,7,29" name="top.i_clk" dtype_id="1"/>
+            <varref fl="d7" loc="d,7,24,7,29" name="f.i_clk" dtype_id="1"/>
+          </assignalias>
+        </scope>
+      </topscope>
+    </module>
+    <typetable fl="a0" loc="a,0,0,0,0">
+      <basicdtype fl="d11" loc="d,11,18,11,23" id="1" name="logic"/>
+    </typetable>
+  </netlist>
+</verilator_xml>

--- a/test_regress/t/t_xml_flat_pub_mod.pl
+++ b/test_regress/t/t_xml_flat_pub_mod.pl
@@ -1,0 +1,25 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2012 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(vlt => 1);
+
+my $out_filename = "$Self->{obj_dir}/V$Self->{name}.xml";
+
+compile(
+    verilator_flags2 => ['--xml-only', '--flatten'],
+    verilator_make_gmake => 0,
+    make_top_shell => 0,
+    make_main => 0,
+    );
+
+files_identical("$out_filename", $Self->{golden_filename});
+
+ok(1);
+1;

--- a/test_regress/t/t_xml_flat_pub_mod.v
+++ b/test_regress/t/t_xml_flat_pub_mod.v
@@ -1,0 +1,13 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2008 by Wilson Snyder.
+// SPDX-License-Identifier: CC0-1.0
+
+module foo(input logic i_clk); /* verilator public_module */
+endmodule
+
+// --flatten forces inlining of public module foo.
+module top(input logic i_clk);
+  foo f(.*);
+endmodule


### PR DESCRIPTION
This patch changes V3Inline to override inlining behaviour when `--flatten` is specified for public modules and modules annotated with 'no_inline_module'.