### PR TITLE
Execute vlcovgen with python3.

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -64,6 +64,7 @@ Qingyao Sun
 Rafal Kapuscik
 Richard Myers
 Rupert Swarbrick
+Samuel Riedel
 Sean Cross
 Sebastien Van Cauwenberghe
 Sergi Granell

--- a/src/Makefile_obj.in
+++ b/src/Makefile_obj.in
@@ -315,7 +315,7 @@ serial:: V3Ast__gen_classes.h V3ParseBison.c
 serial_vlcov:: vlcovgen.d
 
 vlcovgen.d: $(VLCOVGEN) $(srcdir)/../include/verilated_cov_key.h
-	$(PERL) $(VLCOVGEN) --srcdir $(srcdir)
+	$(PYTHON3) $(VLCOVGEN) --srcdir $(srcdir)
 	touch $@
 
 V3Ast__gen_classes.h : $(ASTGEN) V3Ast.h V3AstNodes.h


### PR DESCRIPTION
This fixes #2772.

The `src/vlcovgen` script was converted from Perl to Python, but the build system still executes the script with Perl. This PR fixes this.

This is my first contribution to Verilator. I certify that I comply with the developer's certificate. I also added my name to the contributor's list. Please let me know if you need anything else.
