### PR TITLE
Use correct scope when dumping structs to VCD

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -5,6 +5,7 @@ Please see the Verilator manual for 200+ additional contributors. Thanks to all.
 
 Ahmed El-Mahmoudy
 Alex Chadwick
+Àlex Torregrosa
 Chris Randall
 Conor McCullough
 Dan Petrisko

--- a/include/verilated_trace.h
+++ b/include/verilated_trace.h
@@ -222,7 +222,7 @@ protected:
     void declCode(vluint32_t code, vluint32_t bits, bool tri);
 
     /// Is this an escape?
-    bool isScopeEscape(char c) { return isspace(c) || c == m_scopeEscape; }
+    bool isScopeEscape(char c) { return c != '\f' && (isspace(c) || c == m_scopeEscape); }
     /// Character that splits scopes.  Note whitespace are ALWAYS escapes.
     char scopeEscape() { return m_scopeEscape; }
 

--- a/include/verilated_vcd_c.cpp
+++ b/include/verilated_vcd_c.cpp
@@ -403,9 +403,9 @@ void VerilatedVcd::dumpHeader() {
             printIndent(1);
             // Find character after name end
             const char* sp = np;
-            while(*sp && *sp != ' ' && *sp != '\t' && *sp != '@') sp++;
+            while(*sp && *sp != ' ' && *sp != '\t' && *sp != '\f') sp++;
 
-            if (*sp == '@') {
+            if (*sp == '\f') {
                 printStr("$scope struct ");
             } else {
                printStr("$scope module "); 
@@ -416,7 +416,7 @@ void VerilatedVcd::dumpHeader() {
                     printStr("(");
                 } else if (*np == ']') {
                     printStr(")");
-                } else if (*np != '@'){
+                } else if (*np != '\f'){
                     *m_writep++ = *np;
                 }
             }

--- a/include/verilated_vcd_c.cpp
+++ b/include/verilated_vcd_c.cpp
@@ -408,7 +408,7 @@ void VerilatedVcd::dumpHeader() {
             if (*sp == '\f') {
                 printStr("$scope struct ");
             } else {
-               printStr("$scope module "); 
+               printStr("$scope module ");
             }
 
             for (; *np && *np != ' ' && *np != '\t'; np++) {

--- a/include/verilated_vcd_c.cpp
+++ b/include/verilated_vcd_c.cpp
@@ -376,7 +376,6 @@ void VerilatedVcd::dumpHeader() {
         const char* hiername = hiernamestr.c_str();
         const char* lp = lastName;
         const char* np = hiername;
-        const char* sp;
         lastName = hiername;
 
         // Skip common prefix, it must break at a space or tab
@@ -403,7 +402,7 @@ void VerilatedVcd::dumpHeader() {
             if (*np == '\t') break;  // tab means signal name starts
             printIndent(1);
             // Find character after name end
-            sp = np;
+            const char* sp = np;
             while(*sp && *sp != ' ' && *sp != '\t' && *sp != '@') sp++;
 
             if (*sp == '@') {

--- a/include/verilated_vcd_c.cpp
+++ b/include/verilated_vcd_c.cpp
@@ -376,6 +376,7 @@ void VerilatedVcd::dumpHeader() {
         const char* hiername = hiernamestr.c_str();
         const char* lp = lastName;
         const char* np = hiername;
+        const char* sp;
         lastName = hiername;
 
         // Skip common prefix, it must break at a space or tab
@@ -401,13 +402,22 @@ void VerilatedVcd::dumpHeader() {
             if (*np == ' ') np++;
             if (*np == '\t') break;  // tab means signal name starts
             printIndent(1);
-            printStr("$scope module ");
+            // Find character after name end
+            sp = np;
+            while(*sp && *sp != ' ' && *sp != '\t' && *sp != '@') sp++;
+
+            if (*sp == '@') {
+                printStr("$scope struct ");
+            } else {
+               printStr("$scope module "); 
+            }
+
             for (; *np && *np != ' ' && *np != '\t'; np++) {
                 if (*np == '[') {
                     printStr("(");
                 } else if (*np == ']') {
                     printStr(")");
-                } else {
+                } else if (*np != '@'){
                     *m_writep++ = *np;
                 }
             }

--- a/src/V3TraceDecl.cpp
+++ b/src/V3TraceDecl.cpp
@@ -295,7 +295,10 @@ private:
                     VL_RESTORER(m_traShowname);
                     VL_RESTORER(m_traValuep);
                     {
-                        m_traShowname += string(" ") + itemp->prettyName();
+                        // Add @ to mark as struct
+                        // Since it is not a valid symbol for verilog variable names, no
+                        // collision should happen
+                        m_traShowname += string("@ ") + itemp->prettyName();
                         if (VN_IS(nodep, StructDType)) {
                             m_traValuep
                                 = new AstSel(nodep->fileline(), m_traValuep->cloneTree(true),

--- a/src/V3TraceDecl.cpp
+++ b/src/V3TraceDecl.cpp
@@ -298,7 +298,12 @@ private:
                         // Add @ to mark as struct
                         // Since it is not a valid symbol for verilog variable names, no
                         // collision should happen
-                        m_traShowname += string("@ ") + itemp->prettyName();
+                        if (v3Global.opt.traceFormat().fst()) {
+                            m_traShowname += string(" ") + itemp->prettyName();
+                        } else {
+                            m_traShowname += string("\f ") + itemp->prettyName();
+                        }
+
                         if (VN_IS(nodep, StructDType)) {
                             m_traValuep
                                 = new AstSel(nodep->fileline(), m_traValuep->cloneTree(true),

--- a/test_regress/driver.pl
+++ b/test_regress/driver.pl
@@ -2238,7 +2238,7 @@ sub _vcd_read {
     my @hier = ($data);
     my $lasthier;
     while (defined(my $line = $fh->getline)) {
-        if ($line =~ /\$scope module\s+(\S+)/) {
+        if ($line =~ /\$scope (module|struct)\s+(\S+)/) {
             $hier[$#hier]->{$1} ||= {};
             push @hier, $hier[$#hier]->{$1};
             $lasthier = $hier[$#hier];

--- a/test_regress/t/t_interface_ref_trace.out
+++ b/test_regress/t/t_interface_ref_trace.out
@@ -14,7 +14,7 @@ $timescale   1ps $end
       $var wire  1 0 clk $end
       $var wire 32 # cyc [31:0] $end
       $var wire 32 $ value [31:0] $end
-      $scope module the_struct $end
+      $scope struct the_struct $end
        $var wire 32 % val100 [31:0] $end
        $var wire 32 & val200 [31:0] $end
       $upscope $end
@@ -25,7 +25,7 @@ $timescale   1ps $end
       $var wire  1 0 clk $end
       $var wire 32 # cyc [31:0] $end
       $var wire 32 ' value [31:0] $end
-      $scope module the_struct $end
+      $scope struct the_struct $end
        $var wire 32 ( val100 [31:0] $end
        $var wire 32 ) val200 [31:0] $end
       $upscope $end
@@ -36,7 +36,7 @@ $timescale   1ps $end
       $var wire  1 0 clk $end
       $var wire 32 # cyc [31:0] $end
       $var wire 32 * value [31:0] $end
-      $scope module the_struct $end
+      $scope struct the_struct $end
        $var wire 32 + val100 [31:0] $end
        $var wire 32 , val200 [31:0] $end
       $upscope $end
@@ -47,7 +47,7 @@ $timescale   1ps $end
       $var wire  1 0 clk $end
       $var wire 32 # cyc [31:0] $end
       $var wire 32 * value [31:0] $end
-      $scope module the_struct $end
+      $scope struct the_struct $end
        $var wire 32 + val100 [31:0] $end
        $var wire 32 , val200 [31:0] $end
       $upscope $end
@@ -57,7 +57,7 @@ $timescale   1ps $end
      $var wire  1 0 clk $end
      $var wire 32 # cyc [31:0] $end
      $var wire 32 * value [31:0] $end
-     $scope module the_struct $end
+     $scope struct the_struct $end
       $var wire 32 + val100 [31:0] $end
       $var wire 32 , val200 [31:0] $end
      $upscope $end
@@ -66,7 +66,7 @@ $timescale   1ps $end
      $var wire  1 0 clk $end
      $var wire 32 # cyc [31:0] $end
      $var wire 32 $ value [31:0] $end
-     $scope module the_struct $end
+     $scope struct the_struct $end
       $var wire 32 % val100 [31:0] $end
       $var wire 32 & val200 [31:0] $end
      $upscope $end
@@ -75,7 +75,7 @@ $timescale   1ps $end
      $var wire  1 0 clk $end
      $var wire 32 # cyc [31:0] $end
      $var wire 32 ' value [31:0] $end
-     $scope module the_struct $end
+     $scope struct the_struct $end
       $var wire 32 ( val100 [31:0] $end
       $var wire 32 ) val200 [31:0] $end
      $upscope $end
@@ -87,7 +87,7 @@ $timescale   1ps $end
       $var wire  1 0 clk $end
       $var wire 32 # cyc [31:0] $end
       $var wire 32 ' value [31:0] $end
-      $scope module the_struct $end
+      $scope struct the_struct $end
        $var wire 32 ( val100 [31:0] $end
        $var wire 32 ) val200 [31:0] $end
       $upscope $end
@@ -98,7 +98,7 @@ $timescale   1ps $end
       $var wire  1 0 clk $end
       $var wire 32 # cyc [31:0] $end
       $var wire 32 $ value [31:0] $end
-      $scope module the_struct $end
+      $scope struct the_struct $end
        $var wire 32 % val100 [31:0] $end
        $var wire 32 & val200 [31:0] $end
       $upscope $end
@@ -109,7 +109,7 @@ $timescale   1ps $end
       $var wire  1 0 clk $end
       $var wire 32 # cyc [31:0] $end
       $var wire 32 - value [31:0] $end
-      $scope module the_struct $end
+      $scope struct the_struct $end
        $var wire 32 . val100 [31:0] $end
        $var wire 32 / val200 [31:0] $end
       $upscope $end
@@ -120,7 +120,7 @@ $timescale   1ps $end
       $var wire  1 0 clk $end
       $var wire 32 # cyc [31:0] $end
       $var wire 32 - value [31:0] $end
-      $scope module the_struct $end
+      $scope struct the_struct $end
        $var wire 32 . val100 [31:0] $end
        $var wire 32 / val200 [31:0] $end
       $upscope $end
@@ -130,7 +130,7 @@ $timescale   1ps $end
      $var wire  1 0 clk $end
      $var wire 32 # cyc [31:0] $end
      $var wire 32 - value [31:0] $end
-     $scope module the_struct $end
+     $scope struct the_struct $end
       $var wire 32 . val100 [31:0] $end
       $var wire 32 / val200 [31:0] $end
      $upscope $end
@@ -139,7 +139,7 @@ $timescale   1ps $end
      $var wire  1 0 clk $end
      $var wire 32 # cyc [31:0] $end
      $var wire 32 ' value [31:0] $end
-     $scope module the_struct $end
+     $scope struct the_struct $end
       $var wire 32 ( val100 [31:0] $end
       $var wire 32 ) val200 [31:0] $end
      $upscope $end
@@ -148,7 +148,7 @@ $timescale   1ps $end
      $var wire  1 0 clk $end
      $var wire 32 # cyc [31:0] $end
      $var wire 32 $ value [31:0] $end
-     $scope module the_struct $end
+     $scope struct the_struct $end
       $var wire 32 % val100 [31:0] $end
       $var wire 32 & val200 [31:0] $end
      $upscope $end
@@ -159,7 +159,7 @@ $timescale   1ps $end
      $var wire  1 0 clk $end
      $var wire 32 # cyc [31:0] $end
      $var wire 32 $ value [31:0] $end
-     $scope module the_struct $end
+     $scope struct the_struct $end
       $var wire 32 % val100 [31:0] $end
       $var wire 32 & val200 [31:0] $end
      $upscope $end
@@ -170,7 +170,7 @@ $timescale   1ps $end
      $var wire  1 0 clk $end
      $var wire 32 # cyc [31:0] $end
      $var wire 32 ' value [31:0] $end
-     $scope module the_struct $end
+     $scope struct the_struct $end
       $var wire 32 ( val100 [31:0] $end
       $var wire 32 ) val200 [31:0] $end
      $upscope $end
@@ -180,7 +180,7 @@ $timescale   1ps $end
     $var wire  1 0 clk $end
     $var wire 32 # cyc [31:0] $end
     $var wire 32 $ value [31:0] $end
-    $scope module the_struct $end
+    $scope struct the_struct $end
      $var wire 32 % val100 [31:0] $end
      $var wire 32 & val200 [31:0] $end
     $upscope $end
@@ -189,7 +189,7 @@ $timescale   1ps $end
     $var wire  1 0 clk $end
     $var wire 32 # cyc [31:0] $end
     $var wire 32 ' value [31:0] $end
-    $scope module the_struct $end
+    $scope struct the_struct $end
      $var wire 32 ( val100 [31:0] $end
      $var wire 32 ) val200 [31:0] $end
     $upscope $end
@@ -199,7 +199,7 @@ $timescale   1ps $end
      $var wire  1 0 clk $end
      $var wire 32 # cyc [31:0] $end
      $var wire 32 $ value [31:0] $end
-     $scope module the_struct $end
+     $scope struct the_struct $end
       $var wire 32 % val100 [31:0] $end
       $var wire 32 & val200 [31:0] $end
      $upscope $end
@@ -210,7 +210,7 @@ $timescale   1ps $end
      $var wire  1 0 clk $end
      $var wire 32 # cyc [31:0] $end
      $var wire 32 ' value [31:0] $end
-     $scope module the_struct $end
+     $scope struct the_struct $end
       $var wire 32 ( val100 [31:0] $end
       $var wire 32 ) val200 [31:0] $end
      $upscope $end

--- a/test_regress/t/t_trace_complex_structs.out
+++ b/test_regress/t/t_trace_complex_structs.out
@@ -38,52 +38,52 @@ $timescale   1ps $end
      $var wire 32 H a [31:0] $end
     $upscope $end
    $upscope $end
-   $scope module v_arrp_strp(3) $end
+   $scope struct v_arrp_strp(3) $end
     $var wire  1 1 b0 $end
     $var wire  1 0 b1 $end
    $upscope $end
-   $scope module v_arrp_strp(4) $end
+   $scope struct v_arrp_strp(4) $end
     $var wire  1 3 b0 $end
     $var wire  1 2 b1 $end
    $upscope $end
-   $scope module v_arru_strp(3) $end
+   $scope struct v_arru_strp(3) $end
     $var wire  1 7 b0 $end
     $var wire  1 6 b1 $end
    $upscope $end
-   $scope module v_arru_strp(4) $end
+   $scope struct v_arru_strp(4) $end
     $var wire  1 9 b0 $end
     $var wire  1 8 b1 $end
    $upscope $end
-   $scope module v_enumb2_str $end
+   $scope struct v_enumb2_str $end
     $var wire  3 E a [2:0] $end
     $var wire  3 F b [2:0] $end
    $upscope $end
-   $scope module v_str32x2(0) $end
+   $scope struct v_str32x2(0) $end
     $var wire 32 @ data [31:0] $end
    $upscope $end
-   $scope module v_str32x2(1) $end
+   $scope struct v_str32x2(1) $end
     $var wire 32 A data [31:0] $end
    $upscope $end
-   $scope module v_strp $end
+   $scope struct v_strp $end
     $var wire  1 & b0 $end
     $var wire  1 % b1 $end
    $upscope $end
-   $scope module v_strp_strp $end
-    $scope module x0 $end
+   $scope struct v_strp_strp $end
+    $scope struct x0 $end
      $var wire  1 * b0 $end
      $var wire  1 ) b1 $end
     $upscope $end
-    $scope module x1 $end
+    $scope struct x1 $end
      $var wire  1 ( b0 $end
      $var wire  1 ' b1 $end
     $upscope $end
    $upscope $end
-   $scope module v_unip_strp $end
-    $scope module x0 $end
+   $scope struct v_unip_strp $end
+    $scope struct x0 $end
      $var wire  1 , b0 $end
      $var wire  1 + b1 $end
     $upscope $end
-    $scope module x1 $end
+    $scope struct x1 $end
      $var wire  1 , b0 $end
      $var wire  1 + b1 $end
     $upscope $end


### PR DESCRIPTION
The scope for structs was being set to `$scope module` instead of `$scope struct` when dumping a struct declaration to a vcd file.

Setting the correct value allows gtkwave to show a different icon for structs, making them easier to differentiate.