### PR TITLE
Fix incorrectly specified debug level for --debug in documentation

### DIFF
--- a/bin/verilator
+++ b/bin/verilator
@@ -756,7 +756,7 @@ is fairly standard across Verilog tools while -D is similar to GCC.
 
 Select the debug executable of Verilator (if available), and enable more
 internal assertions (equivalent to C<--debug-check>), debugging messages
-(equivalent to C<--debugi 4>), and intermediate form dump files (equivalent
+(equivalent to C<--debugi 3>), and intermediate form dump files (equivalent
 to C<--dump-treei 3>).
 
 =item --debug-check

--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -49,6 +49,7 @@ Marshal Qiao
 Matthew Ballance
 Michael Killough
 Mike Popoloski
+Morten Borup Petersen
 Nandu Raj
 Nathan Kohagen
 Nathan Myers


### PR DESCRIPTION
As seen at https://github.com/verilator/verilator/blob/master/src/V3Options.cpp#L1202, setting --debug enables a debug level of 3, and not 4.