### PR TITLE
Add .dot graph visualization of AstExecGraph

### DIFF
--- a/src/V3AstNodes.h
+++ b/src/V3AstNodes.h
@@ -9156,6 +9156,11 @@ public:
     const V3Graph* depGraphp() const { return m_depGraphp; }
     V3Graph* mutableDepGraphp() { return m_depGraphp; }
     void addMTaskBody(AstMTaskBody* bodyp) { addOp1p(bodyp); }
+
+    // Debugging
+    void dumpDotFile(const string& filename) const;
+    void dumpDotFilePrefixed(const string& nameComment) const;
+    void dumpDotFilePrefixedAlways(const string& nameComment) const;
 };
 
 class AstSplitPlaceholder final : public AstNode {

--- a/src/V3Partition.cpp
+++ b/src/V3Partition.cpp
@@ -2561,6 +2561,8 @@ void V3Partition::finalize() {
     // "Pack" the mtasks: statically associate each mtask with a thread,
     // and determine the order in which each thread will runs its mtasks.
     PartPackMTasks(execGraphp->mutableDepGraphp()).go();
+
+    execGraphp->dumpDotFilePrefixed("exec_final");
 }
 
 void V3Partition::selfTest() {


### PR DESCRIPTION
This commit adds the creation of .dot files - used by GraphViz - to visualize how mtasks are statically scheduled across the set of specified threads.
We visualize each thread as a row, with nodes of a row being the mtasks scheduled for the given thread. The width of the mtask nodes are proportional to their cost. mtask dependencies are shown using an edge between the source and sink mtasks.

It could be argued that this information would be more easily displayed in a .vcd file. However, i find this rather restrictive in terms of not being able to annotate ie. mtask dependencies. Furthermore, keeping this to .dot files allows for embedding more details in the future, if the multithread scheduling implementation is elaborated.