### PR TITLE
Add computation of critical path to AstExecGraph

### DIFF
--- a/src/V3AstNodes.h
+++ b/src/V3AstNodes.h
@@ -9143,8 +9143,13 @@ class AstExecGraph final : public AstNode {
     // The mtask bodies are also children of this node, so we can visit
     // them without traversing the graph (it's not always needed to
     // traverse the graph.)
+
+    typedef std::vector<const ExecMTask*> ExecGraphCritPath;
+
 private:
     V3Graph* m_depGraphp;  // contains ExecMTask's
+    ExecGraphCritPath m_critPath;
+
 public:
     explicit AstExecGraph(FileLine* fl);
     ASTNODE_NODE_FUNCS_NO_DTOR(ExecGraph)
@@ -9156,6 +9161,9 @@ public:
     const V3Graph* depGraphp() const { return m_depGraphp; }
     V3Graph* mutableDepGraphp() { return m_depGraphp; }
     void addMTaskBody(AstMTaskBody* bodyp) { addOp1p(bodyp); }
+
+    const ExecGraphCritPath& critPath() const { return m_critPath; }
+    void updateCritPath();
 };
 
 class AstSplitPlaceholder final : public AstNode {

--- a/src/V3Partition.cpp
+++ b/src/V3Partition.cpp
@@ -2021,6 +2021,7 @@ private:
     // TYPES
     struct MTaskState {
         uint32_t completionTime;  // Estimated time this mtask will complete
+        uint32_t startTime;  // Estimated time this mtask will start
     };
     struct MTaskCmp {
         bool operator()(const ExecMTask* ap, ExecMTask* bp) const { return ap->id() < bp->id(); }
@@ -2088,6 +2089,7 @@ public:
     void setCompletionTime(ExecMTask* mtaskp, uint32_t time) {
         MTaskState& state = m_mtaskState[mtaskp];
         state.completionTime = time;
+        state.startTime = state.completionTime - mtaskp->cost();
     }
 
     void go() {
@@ -2181,6 +2183,8 @@ public:
                 bestMtaskp->threadRoot(true);
             }
             bestMtaskp->thread(bestTh);
+            bestMtaskp->startTime(bestTime);
+            bestMtaskp->endTime(bestEndTime);
 
             // Update the thread state
             m_prevMTask[bestTh] = bestMtaskp;

--- a/src/V3Partition.cpp
+++ b/src/V3Partition.cpp
@@ -2565,6 +2565,10 @@ void V3Partition::finalize() {
     // "Pack" the mtasks: statically associate each mtask with a thread,
     // and determine the order in which each thread will runs its mtasks.
     PartPackMTasks(execGraphp->mutableDepGraphp()).go();
+
+    // With all mtasks scheduled, we now update the critical path
+    // estimate of the AstExecGraph.
+    execGraphp->updateCritPath();
 }
 
 void V3Partition::selfTest() {

--- a/src/V3PartitionGraph.h
+++ b/src/V3PartitionGraph.h
@@ -61,6 +61,10 @@ private:
     // mtask. In abstract time units.
     uint32_t m_cost = 0;  // Predicted runtime of this mtask, in the same
     // abstract time units as priority().
+    uint32_t m_startTime = 0;  // predicted start time of this mtask, in the same
+    // abstract time units as priority()
+    uint32_t m_endTime = 0;  // predicted end time of this mtask, in the same
+    // abstract time units as priority()
     uint32_t m_thread = 0xffffffff;  // Thread for static (pack_mtasks) scheduling,
     // or 0xffffffff if not yet assigned.
     const ExecMTask* m_packNextp = nullptr;  // Next for static (pack_mtasks) scheduling
@@ -79,6 +83,10 @@ public:
     virtual uint32_t cost() const override { return m_cost; }
     void cost(uint32_t cost) { m_cost = cost; }
     void thread(uint32_t thread) { m_thread = thread; }
+    void startTime(uint32_t startTime) { m_startTime = startTime; }
+    uint32_t startTime() const { return m_startTime; }
+    uint32_t endTime() const { return m_endTime; }
+    void endTime(uint32_t endTime) { m_endTime = endTime; }
     uint32_t thread() const { return m_thread; }
     void packNextp(const ExecMTask* nextp) { m_packNextp = nextp; }
     const ExecMTask* packNextp() const { return m_packNextp; }


### PR DESCRIPTION
530642f makes start and end time estimates for a given mtask available through the mtask after it has been scheduled. This is not only useful for estimating the critical path (by the AstExecGraph itself) but also for further algorithms and analysis.

a093dd0 computes a critical path estimate.
To compute a critical path estimate, we first locate the mtask which is expected to finish the latest. From here, we backtrack through its dependencies, selecting the mtask which finish the _latest_ in time.
This is done instead of checking which dependencies finish exactly when a critical task starts, due to the fact that scheduling may choose to schedule a task some time after a dependency finished executing on another thread (see PartPackMTasks).

A critical path estimate + start/end times is required for #2779.