### PR TITLE
Doc: Remove extra I

### DIFF
--- a/bin/verilator
+++ b/bin/verilator
@@ -455,11 +455,11 @@ ARGUMENTS"> for the detailed description of these arguments.
      +verilator+debug                  Enable debugging
      +verilator+debugi+<value>         Enable debugging at a level
      +verilator+help                   Display help
-     +verilator+prof+threads+file+I<filename>  Set profile filename
-     +verilator+prof+threads+start+I<value>    Set profile starting point
-     +verilator+prof+threads+window+I<value>   Set profile duration
-     +verilator+rand+reset+I<value>    Set random reset technique
-     +verilator+seed+I<value>          Set random seed
+     +verilator+prof+threads+file+<filename>  Set profile filename
+     +verilator+prof+threads+start+<value>    Set profile starting point
+     +verilator+prof+threads+window+<value>   Set profile duration
+     +verilator+rand+reset+<value>     Set random reset technique
+     +verilator+seed+<value>           Set random seed
      +verilator+noassert               Disable assert checking
      +verilator+V                      Verbose version and config
      +verilator+version                Show version and exit


### PR DESCRIPTION
Both PDF and [HTML](https://www.veripool.org/projects/verilator/wiki/Manual-verilator#ARGUMENT-SUMMARY) manual look to have extra `I` that is inteded for italic.

Here is screen capture of PDF.
![image](https://user-images.githubusercontent.com/1785692/107949495-b0841f80-6fd8-11eb-947d-5394ab61cafe.png)
