### PR TITLE
Internals: Mark some functions of VSpellCheck 'const'

### DIFF
--- a/src/V3String.cpp
+++ b/src/V3String.cpp
@@ -460,7 +460,7 @@ VSpellCheck::EditDistance VSpellCheck::cutoffDistance(size_t goal_len, size_t ca
     return (max_length + 2) / 3;
 }
 
-string VSpellCheck::bestCandidateInfo(const string& goal, EditDistance& distancer) {
+string VSpellCheck::bestCandidateInfo(const string& goal, EditDistance& distancer) const {
     string bestCandidate;
     size_t gLen = goal.length();
     distancer = LENGTH_LIMIT * 10;

--- a/src/V3String.h
+++ b/src/V3String.h
@@ -208,12 +208,12 @@ public:
         if (m_candidates.size() < NUM_CANDIDATE_LIMIT) m_candidates.push_back(s);
     }
     // Return candidate is closest to provided string, or "" for none
-    string bestCandidate(const string& goal) {
+    string bestCandidate(const string& goal) const {
         EditDistance dist;
         return bestCandidateInfo(goal, dist /*ref*/);
     }
     // Return friendly message
-    string bestCandidateMsg(const string& goal) {
+    string bestCandidateMsg(const string& goal) const {
         string candidate = bestCandidate(goal);
         if (candidate.empty()) {
             return "";
@@ -226,7 +226,7 @@ public:
 private:
     static EditDistance editDistance(const string& s, const string& t);
     static EditDistance cutoffDistance(size_t goal_len, size_t candidate_len);
-    string bestCandidateInfo(const string& goal, EditDistance& distancer);
+    string bestCandidateInfo(const string& goal, EditDistance& distancer) const;
     static void selfTestDistanceOne(const string& a, const string& b, EditDistance expected);
     static void selfTestSuggestOne(bool matches, const string& c, const string& goal,
                                    EditDistance dist);


### PR DESCRIPTION
I will merge after CI passes as this is trivial and compiler can tell if the change is not correct.