### PR TITLE
Internals: Remove duplicated entry of -quiet-exit

### DIFF
--- a/src/V3Options.cpp
+++ b/src/V3Options.cpp
@@ -1445,8 +1445,6 @@ void V3Options::parseOptsList(FileLine* fl, const string& optdir, int argc, char
                 // Processed only in bin/verilator shell
             } else if (!strcmp(sw, "-gdbbt")) {
                 // Processed only in bin/verilator shell
-            } else if (!strcmp(sw, "-quiet-exit")) {
-                // Processed only in bin/verilator shell
             } else if (!strcmp(sw, "-mod-prefix") && (i + 1) < argc) {
                 shift;
                 m_modPrefix = argv[i];


### PR DESCRIPTION
During testing #2809, I found `-quiet-exit` appears twice. (Dup check in the code told me.)

https://github.com/verilator/verilator/blob/018d994781fe41187306a04968214350e565ef11/src/V3Options.cpp#L1087-L1088

This branch below is a dead code as the check above is executed.
https://github.com/verilator/verilator/blob/018d994781fe41187306a04968214350e565ef11/src/V3Options.cpp#L1448-L1449