### PR TITLE
Fix to enable verilated model in MSVC

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -90,3 +90,4 @@ Yuri Victorovich
 Yutetsu TAKATSUKASA
 Yves Mathieu
 HyungKi Jeong
+Drew Taussig

--- a/include/verilated_sym_props.h
+++ b/include/verilated_sym_props.h
@@ -70,7 +70,7 @@ public:
 
 class VerilatedVarProps VL_NOT_FINAL {
     // TYPES
-    enum { MAGIC = 0xddc4f829 };
+    static constexpr vluint32_t MAGIC = 0xddc4f829UL;
     // MEMBERS
     const vluint32_t m_magic;  // Magic number
     const VerilatedVarType m_vltype;  // Data type


### PR DESCRIPTION
This fixes a error when using the verilated model in Windows (MSVC)
