### PR TITLE
Fix __DOT__ concat of hashed names

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -23,6 +23,7 @@ Garrett Smith
 Geza Lore
 Gianfranco Costamagna
 Glen Gibb
+Graham Rushton
 Harald Heckmann
 Howard Su
 Huang Rui

--- a/src/V3String.cpp
+++ b/src/V3String.cpp
@@ -388,7 +388,6 @@ string VName::dehash(const string& in) {
     // keeps track of the position after the most recently found instance of __DOT__
     for (string::size_type last_dot_pos = 0; last_dot_pos < in.size(); ) {
         const string::size_type next_dot_pos = in.find("__DOT__", last_dot_pos);
-
         // Two iterators defining the range between the last and next dots.
         auto search_begin = std::begin(in) + last_dot_pos;
         auto search_end = next_dot_pos == string::npos ? std::end(in)

--- a/src/V3String.cpp
+++ b/src/V3String.cpp
@@ -427,7 +427,6 @@ string VName::dehash(const string& in) {
             last_dot_pos = string::npos;
         }
     }
-
     return dehashed.empty() ? in : dehashed;
 }
 

--- a/src/V3String.cpp
+++ b/src/V3String.cpp
@@ -382,7 +382,6 @@ void VHashSha256::selfTest() {
 string VName::dehash(const string& in) {
     static const char VHSH[] = "__Vhsh";
     static const size_t DOT_LEN = strlen("__DOT__");
-
     std::string dehashed;
 
     // Need to split 'in' into components separated by __DOT__, 'last_dot_pos'

--- a/test_regress/t/t_trace_complex.out
+++ b/test_regress/t/t_trace_complex.out
@@ -39,6 +39,9 @@ $timescale   1ps $end
    $var wire  2 % v_strp [1:0] $end
    $var wire  4 & v_strp_strp [3:0] $end
    $var wire  2 ' v_unip_strp [1:0] $end
+   $scope module a_module_instantiation_with_a_very_long_name_that_once_its_signals_get_concatenated_and_inlined_will_almost_certainly_result_in_them_getting_hashed $end
+    $var wire 32 J PARAM [31:0] $end
+   $upscope $end
    $scope module p2 $end
     $var wire 32 H PARAM [31:0] $end
    $upscope $end
@@ -92,6 +95,7 @@ b00000000 F
 0G
 b00000000000000000000000000000010 H
 b00000000000000000000000000000011 I
+b00000000000000000000000000000100 J
 #10
 b00000000000000000000000000000001 $
 b11 %

--- a/test_regress/t/t_trace_complex.v
+++ b/test_regress/t/t_trace_complex.v
@@ -78,6 +78,8 @@ module t (clk);
    p #(.PARAM(2)) p2 ();
    p #(.PARAM(3)) p3 ();
 
+   p #(.PARAM(4)) a_module_instantiation_with_a_very_long_name_that_once_its_signals_get_concatenated_and_inlined_will_almost_certainly_result_in_them_getting_hashed ();
+
    always @ (posedge clk) begin
       cyc <= cyc + 1;
       v_strp <= ~v_strp;

--- a/test_regress/t/t_trace_complex_fst.out
+++ b/test_regress/t/t_trace_complex_fst.out
@@ -58,15 +58,19 @@ $upscope $end
 $scope module p3 $end
 $var parameter 32 B PARAM $end
 $upscope $end
+$scope module a_module_instantiation_with_a_very_long_name_that_once_its_signals_get_concatenated_and_inlined_will_almost_certainly_result_in_them_getting_hashed $end
+$var parameter 32 C PARAM $end
+$upscope $end
 $upscope $end
 $scope module $unit $end
-$var bit 1 C global_bit $end
+$var bit 1 D global_bit $end
 $upscope $end
 $upscope $end
 $enddefinitions $end
-#0
 $dumpvars
-1C
+#0
+1D
+b00000000000000000000000000000100 C
 b00000000000000000000000000000011 B
 b00000000000000000000000000000010 A
 b00000000000000000000000000000000 @
@@ -101,7 +105,6 @@ b0000 $
 b00 #
 b00000000000000000000000000000000 "
 0!
-$end
 #10
 1!
 b00000000000000000000000000000001 "

--- a/test_regress/t/t_trace_complex_fst_sc.out
+++ b/test_regress/t/t_trace_complex_fst_sc.out
@@ -1,5 +1,5 @@
 $date
-	Thu Apr  1 15:12:03 2021
+	Mon Apr 19 17:05:53 2021
 
 $end
 $version
@@ -57,15 +57,19 @@ $upscope $end
 $scope module p3 $end
 $var parameter 32 B PARAM $end
 $upscope $end
+$scope module a_module_instantiation_with_a_very_long_name_that_once_its_signals_get_concatenated_and_inlined_will_almost_certainly_result_in_them_getting_hashed $end
+$var parameter 32 C PARAM $end
+$upscope $end
 $upscope $end
 $scope module $unit $end
-$var bit 1 C global_bit $end
+$var bit 1 D global_bit $end
 $upscope $end
 $upscope $end
 $enddefinitions $end
-#0
 $dumpvars
-1C
+#0
+1D
+b00000000000000000000000000000100 C
 b00000000000000000000000000000011 B
 b00000000000000000000000000000010 A
 b00000000000000000000000000000000 @
@@ -100,7 +104,6 @@ b0000 $
 b00 #
 b00000000000000000000000000000000 "
 0!
-$end
 #10
 1!
 b00000000000000000000000000000001 "

--- a/test_regress/t/t_trace_complex_params.out
+++ b/test_regress/t/t_trace_complex_params.out
@@ -39,6 +39,9 @@ $timescale   1ps $end
    $var wire  2 % v_strp [1:0] $end
    $var wire  4 & v_strp_strp [3:0] $end
    $var wire  2 ' v_unip_strp [1:0] $end
+   $scope module a_module_instantiation_with_a_very_long_name_that_once_its_signals_get_concatenated_and_inlined_will_almost_certainly_result_in_them_getting_hashed $end
+    $var wire 32 J PARAM [31:0] $end
+   $upscope $end
    $scope module p2 $end
     $var wire 32 H PARAM [31:0] $end
    $upscope $end
@@ -92,6 +95,7 @@ b00000000 F
 0G
 b00000000000000000000000000000010 H
 b00000000000000000000000000000011 I
+b00000000000000000000000000000100 J
 #10
 b00000000000000000000000000000001 $
 b11 %

--- a/test_regress/t/t_trace_complex_params_fst.out
+++ b/test_regress/t/t_trace_complex_params_fst.out
@@ -58,15 +58,19 @@ $upscope $end
 $scope module p3 $end
 $var parameter 32 B PARAM $end
 $upscope $end
+$scope module a_module_instantiation_with_a_very_long_name_that_once_its_signals_get_concatenated_and_inlined_will_almost_certainly_result_in_them_getting_hashed $end
+$var parameter 32 C PARAM $end
+$upscope $end
 $upscope $end
 $scope module $unit $end
-$var bit 1 C global_bit $end
+$var bit 1 D global_bit $end
 $upscope $end
 $upscope $end
 $enddefinitions $end
-#0
 $dumpvars
-1C
+#0
+1D
+b00000000000000000000000000000100 C
 b00000000000000000000000000000011 B
 b00000000000000000000000000000010 A
 b00000000000000000000000000000000 @
@@ -101,7 +105,6 @@ b0000 $
 b00 #
 b00000000000000000000000000000000 "
 0!
-$end
 #10
 1!
 b00000000000000000000000000000001 "

--- a/test_regress/t/t_trace_complex_params_fst_sc.out
+++ b/test_regress/t/t_trace_complex_params_fst_sc.out
@@ -1,5 +1,5 @@
 $date
-	Thu Apr  1 15:17:39 2021
+	Mon Apr 19 17:07:10 2021
 
 $end
 $version
@@ -57,15 +57,19 @@ $upscope $end
 $scope module p3 $end
 $var parameter 32 B PARAM $end
 $upscope $end
+$scope module a_module_instantiation_with_a_very_long_name_that_once_its_signals_get_concatenated_and_inlined_will_almost_certainly_result_in_them_getting_hashed $end
+$var parameter 32 C PARAM $end
+$upscope $end
 $upscope $end
 $scope module $unit $end
-$var bit 1 C global_bit $end
+$var bit 1 D global_bit $end
 $upscope $end
 $upscope $end
 $enddefinitions $end
-#0
 $dumpvars
-1C
+#0
+1D
+b00000000000000000000000000000100 C
 b00000000000000000000000000000011 B
 b00000000000000000000000000000010 A
 b00000000000000000000000000000000 @
@@ -100,7 +104,6 @@ b0000 $
 b00 #
 b00000000000000000000000000000000 "
 0!
-$end
 #10
 1!
 b00000000000000000000000000000001 "


### PR DESCRIPTION
In VName::hashedName() the names of some AST nodes are hashed if they
are too long, this takes the form of truncating them then appending a
suffix of the form __Vhsh<hash>.

Later, for the purposes of tracing they are dehashed. Dehashing involves
looking up the suffix in a map which was populated when the original
name was hashed. An assert occurs if the suffix is not found in the map.
The indication of whether this dehashing is necessary is whether the
string contains __Vhsh.

Several places in the code name new nodes by concatenating the literal
__DOT__ to an existing node name plus a new identifier. However, if the
existing node name has been hashed this results in a new node name of
the form long_string__Vhsh<hash>__DOT__ident. When generating code to
support tracing these new names appear as though they require dehashing
as they contain __Vhsh, but they do not appear in the map as they
weren't generated by the hashedName function, triggering the assert.

The attempted fix is to dehash the existing node's name before perfoming
the concatenation.