### PR TITLE
Fix --public-flat-rw / DPI issue

### DIFF
--- a/src/V3EmitCSyms.cpp
+++ b/src/V3EmitCSyms.cpp
@@ -330,7 +330,8 @@ class EmitCSyms final : EmitCBaseVisitor {
     virtual void visit(AstVar* nodep) override {
         nameCheck(nodep);
         iterateChildren(nodep);
-        if (nodep->isSigUserRdPublic()) m_modVars.emplace_back(std::make_pair(m_modp, nodep));
+        if (nodep->isSigUserRdPublic() && !m_cfuncp)
+            m_modVars.emplace_back(std::make_pair(m_modp, nodep));
     }
     virtual void visit(AstCoverDecl* nodep) override {
         // Assign numbers to all bins, so we know how big of an array to use

--- a/test_regress/t/t_vpi_get.cpp
+++ b/test_regress/t/t_vpi_get.cpp
@@ -202,6 +202,8 @@ int mon_check() {
     return 0;  // Ok
 }
 
+void dpi_print(const char* somestring) { printf("SOMESTRING = %s\n", somestring); }
+
 //======================================================================
 
 #ifdef IS_VPI

--- a/test_regress/t/t_vpi_get.v
+++ b/test_regress/t/t_vpi_get.v
@@ -12,6 +12,8 @@
 import "DPI-C" context function int mon_check();
 `endif
 
+import "DPI-C" function void dpi_print(input string somestring);
+
 `ifdef VERILATOR_COMMENTS
  `define PUBLIC_FLAT_RD /*verilator public_flat_rd*/
  `define PUBLIC_FLAT_RW /*verilator public_flat_rw @(posedge clk)*/
@@ -54,6 +56,7 @@ extern "C" int mon_check();
 
    // Test loop
    initial begin
+      dpi_print("foo");
 `ifdef VERILATOR
       status = $c32("mon_check()");
 `endif


### PR DESCRIPTION
Using --public-flat-rw and DPI functions together produces C++ with errors.  This is what I get without the update to V3EmitCSyms.cpp:
```
ccache g++  -I.  -MMD -I/usr/scratch/local/devs/verilator-hrt/include -I/usr/scratch/local/devs/verilator-hrt/include/vltstd -DVM_COVERAGE=0 -DVM_SC=0 -DVM_TRACE=0 -DVM_TRACE_FST=0 -Wno-sign-compare -Wno-uninitialized -Wno-unused-but-set-variable -Wno-unused-parameter -Wno-unused-variable -Wno-shadow     -DVL_DEBUG -ggdb  -std=gnu++14 -DVERILATOR=1 -DVL_DEBUG=1 -DTEST_OBJ_DIR=obj_vlt/t_vpi_get_public_rw_switch -DVM_PREFIX=Vt_vpi_get -DVM_PREFIX_INCLUDE="<Vt_vpi_get.h>" -DT_VPI_GET_PUBLIC_RW_SWITCH   -O0 -c -o Vt_vpi_get__ALL.o Vt_vpi_get__ALL.cpp
In file included from Vt_vpi_get__ALL.cpp:8:0:
Vt_vpi_get__Syms.cpp: In constructor ‘Vt_vpi_get__Syms::Vt_vpi_get__Syms(VerilatedContext*, Vt_vpi_get*, const char*)’:
Vt_vpi_get__Syms.cpp:50:63: error: ‘class Vt_vpi_get’ has no member named ‘somestring’; did you mean ‘testin’?
         __Vscope_TOP.varInsert(__Vfinal,"somestring", &(TOPp->somestring), false, VLVT_STRING,VLVD_IN|VLVF_PUB_RW,0);
                                                               ^~~~~~~~~~
Vt_vpi_get__Syms.cpp:53:78: error: ‘class Vt_vpi_get___024unit’ has no member named ‘somestring’
         __Vscope___024unit.varInsert(__Vfinal,"somestring", &(TOP____024unit.somestring), false, VLVT_STRING,VLVD_IN|VLVF_PUB_RW,0);
                                                                              ^~~~~~~~~~
```