### PR TITLE
interface localparam access

### DIFF
--- a/src/V3SymTable.h
+++ b/src/V3SymTable.h
@@ -249,7 +249,7 @@ public:
             const string& name = it->first;
             VSymEnt* subSrcp = it->second;
             const AstVar* varp = VN_CAST(subSrcp->nodep(), Var);
-            if (!onlyUnmodportable || (varp && varp->varType() == AstVarType::GPARAM)) {
+            if (!onlyUnmodportable || (varp && (varp->varType() == AstVarType::GPARAM || varp->varType() == AstVarType::LPARAM))) {
                 VSymEnt* subSymp = new VSymEnt(graphp, subSrcp);
                 reinsert(name, subSymp);
                 // And recurse to create children

--- a/src/V3SymTable.h
+++ b/src/V3SymTable.h
@@ -249,7 +249,10 @@ public:
             const string& name = it->first;
             VSymEnt* subSrcp = it->second;
             const AstVar* varp = VN_CAST(subSrcp->nodep(), Var);
-            if (!onlyUnmodportable || (varp && (varp->varType() == AstVarType::GPARAM || varp->varType() == AstVarType::LPARAM))) {
+            if (!onlyUnmodportable
+                || (varp
+                    && (varp->varType() == AstVarType::GPARAM
+                        || varp->varType() == AstVarType::LPARAM))) {
                 VSymEnt* subSymp = new VSymEnt(graphp, subSrcp);
                 reinsert(name, subSymp);
                 // And recurse to create children

--- a/src/V3SymTable.h
+++ b/src/V3SymTable.h
@@ -251,8 +251,7 @@ public:
             const AstVar* varp = VN_CAST(subSrcp->nodep(), Var);
             if (!onlyUnmodportable
                 || (varp
-                    && (varp->varType() == AstVarType::GPARAM
-                        || varp->varType() == AstVarType::LPARAM))) {
+                    && varp->isParam())) {
                 VSymEnt* subSymp = new VSymEnt(graphp, subSrcp);
                 reinsert(name, subSymp);
                 // And recurse to create children

--- a/src/V3SymTable.h
+++ b/src/V3SymTable.h
@@ -249,9 +249,7 @@ public:
             const string& name = it->first;
             VSymEnt* subSrcp = it->second;
             const AstVar* varp = VN_CAST(subSrcp->nodep(), Var);
-            if (!onlyUnmodportable
-                || (varp
-                    && varp->isParam())) {
+            if (!onlyUnmodportable || (varp && varp->isParam())) {
                 VSymEnt* subSymp = new VSymEnt(graphp, subSrcp);
                 reinsert(name, subSymp);
                 // And recurse to create children

--- a/test_regress/t/t_interface_parameter_access.v
+++ b/test_regress/t/t_interface_parameter_access.v
@@ -11,6 +11,8 @@ interface test_if #(parameter integer FOO = 1);
    // Interface variable
    logic 	data;
 
+   localparam integer BAR = FOO + 1;
+
    // Modport
    modport mp(
               import  getFoo,
@@ -76,6 +78,9 @@ module testmod
    localparam THE_FOO = intf.FOO;
    localparam THE_OTHER_FOO = intf_no_mp.FOO;
    localparam THE_ARRAY_FOO = intf_array[0].FOO;
+   localparam THE_BAR = intf.BAR;
+   localparam THE_OTHER_BAR = intf_no_mp.BAR;
+   localparam THE_ARRAY_BAR = intf_array[0].BAR;
 
    always @(posedge clk) begin
       if (THE_FOO != 5) begin
@@ -106,6 +111,30 @@ module testmod
       //         $display("%%Error: i.getFoo() = %0d", i.getFoo());
       //	 $stop;
       //      end
+      if (THE_BAR != 6) begin
+         $display("%%Error: THE_BAR = %0d", THE_BAR);
+	 $stop;
+      end
+      if (THE_OTHER_BAR != 6) begin
+         $display("%%Error: THE_OTHER_BAR = %0d", THE_OTHER_BAR);
+         $stop;
+      end
+      if (THE_ARRAY_BAR != 8) begin
+         $display("%%Error: THE_ARRAY_BAR = %0d", THE_ARRAY_BAR);
+         $stop;
+      end
+      if (intf.BAR != 6) begin
+         $display("%%Error: intf.BAR = %0d", intf.BAR);
+	 $stop;
+      end
+      if (intf_no_mp.BAR != 6) begin
+         $display("%%Error: intf_no_mp.BAR = %0d", intf_no_mp.BAR);
+         $stop;
+      end
+      if (intf_array[0].BAR != 8) begin
+         $display("%%Error: intf_array[0].BAR = %0d", intf_array[0].BAR);
+         $stop;
+      end
       $write("*-* All Finished *-*\n");
       $finish;
    end

--- a/test_regress/t/t_interface_parameter_access.v
+++ b/test_regress/t/t_interface_parameter_access.v
@@ -113,7 +113,7 @@ module testmod
       //      end
       if (THE_BAR != 6) begin
          $display("%%Error: THE_BAR = %0d", THE_BAR);
-	 $stop;
+         $stop;
       end
       if (THE_OTHER_BAR != 6) begin
          $display("%%Error: THE_OTHER_BAR = %0d", THE_OTHER_BAR);


### PR DESCRIPTION
Dotted access to interface localparams does not work in the same way that it does for parameters.  Without the change to V3SymTable.h I get errors like:
```
%Error: t/t_interface_parameter_access.v:81:30: Can't find definition of 'BAR' in dotted signal: 'intf.BAR'
   81 |    localparam THE_BAR = intf.BAR;
      |                              ^~~
        ... Known scopes under 'BAR': <no instances found>
```