### PR TITLE
Implement lint_ignore meta comment (#2755)

### DIFF
--- a/Changes
+++ b/Changes
@@ -29,6 +29,7 @@ Verilator 4.201 devel
 * Fix --public-flat-rw / DPI issue (#2858). [Todd Strader]
 * Fix interface localparam access (#2859). [Todd Strader]
 * Fix Cygwin example compile issues (#2856). [Mark Shaw]
+* Add lint_ignore meta comment (#2755). [Geza Lore]
 
 
 Verilator 4.200 2021-03-12

--- a/bin/verilator
+++ b/bin/verilator
@@ -3605,6 +3605,10 @@ Disable the specified warning message for any warnings following the comment.
 
 Re-enable the specified warning message for any warnings following the comment.
 
+=item /*verilator lint_ignore I<msg>*/
+
+Disable the specified warning message for any warnings within the same line.
+
 =item /*verilator lint_restore*/
 
 After a /*verilator lint_save*/, pop the stack containing lint message

--- a/src/V3ParseImp.h
+++ b/src/V3ParseImp.h
@@ -223,6 +223,7 @@ public:
     static void lexErrorPreprocDirective(FileLine* fl, const char* textp);
     static string lexParseTag(const char* textp);
     static double lexParseTimenum(const char* text);
+    static string lexVerilatorCmtArg(const char* textp);
     void lexPpline(const char* textp);
     void lexVerilatorCmtLint(FileLine* fl, const char* textp, bool warnOff);
     void lexVerilatorCmtLintSave(const FileLine* fl);
@@ -331,7 +332,7 @@ public:
 private:
     void lexFile(const string& modname);
     void yylexReadTok();
-    void tokenPull();
+    void linePull();
     void tokenPipeline();  // Internal; called from tokenToBison
     void tokenPipelineSym();
     size_t tokenPipeScanParam(size_t depth);

--- a/src/verilog.l
+++ b/src/verilog.l
@@ -108,7 +108,7 @@ vnum    {vnum1}|{vnum2}|{vnum3}|{vnum4}|{vnum5}
   /* Verilator control files */
 <VLT>{
   {ws}                  { FL_FWD; FL_BRK; }  /* otherwise ignore white-space */
-  {crnl}                { FL_FWD; FL_BRK; }  /* Count line numbers */
+  {crnl}                { FL; return yEOL; }  /* Count line numbers */
 
   "clock_enable"        { FL; return yVLT_CLOCK_ENABLE; }
   "clocker"             { FL; return yVLT_CLOCKER; }
@@ -157,7 +157,7 @@ vnum    {vnum1}|{vnum2}|{vnum3}|{vnum4}|{vnum5}
   /* Verilog 1995 */
 <V95,V01NC,V01C,V05,VA5,S05,S09,S12,S17,SAX>{
   {ws}                  { FL_FWD; FL_BRK; }  /* otherwise ignore white-space */
-  {crnl}                { FL_FWD; FL_BRK; }  /* Count line numbers */
+  {crnl}                { FL; return yEOL; }  /* Count line numbers */
   /*     Extensions to Verilog set, some specified by PSL */
   "$c"[0-9]*            { FL; return yD_C; }  /*Verilator only*/
   /*     System Tasks */
@@ -727,6 +727,8 @@ vnum    {vnum1}|{vnum2}|{vnum3}|{vnum4}|{vnum5}
   "/*verilator isolate_assignments*/"   { FL; return yVL_ISOLATE_ASSIGNMENTS; }
   "/*verilator lint_off"[^*]*"*/"       { FL; PARSEP->lexVerilatorCmtLint(yylval.fl, yytext, true); FL_BRK; }
   "/*verilator lint_on"[^*]*"*/"        { FL; PARSEP->lexVerilatorCmtLint(yylval.fl, yytext, false); FL_BRK; }
+  "/*verilator lint_ignore"[^*]*"*/"    { FL; yylval.strp = PARSEP->newString(V3ParseImp::lexVerilatorCmtArg(yytext));
+                                          return yVL_LINT_IGNORE; }
   "/*verilator lint_restore*/"          { FL; PARSEP->lexVerilatorCmtLintRestore(PARSEP->lexFileline()); FL_BRK; }
   "/*verilator lint_save*/"             { FL; PARSEP->lexVerilatorCmtLintSave(PARSEP->lexFileline()); FL_BRK; }
   "/*verilator no_clocker*/"            { FL; return yVL_NO_CLOCKER; }

--- a/src/verilog.y
+++ b/src/verilog.y
@@ -432,6 +432,8 @@ BISONPRE_VERSION(3.7,%define api.header.include {"V3ParseBison.h"})
 %token<fl>              '}'
 %token<fl>              '~'
 
+%token<fl>              yEOL
+
 // Specific keywords
 // yKEYWORD means match "keyword"
 // Other cases are yXX_KEYWORD where XX makes it unique,
@@ -850,6 +852,7 @@ BISONPRE_VERSION(3.7,%define api.header.include {"V3ParseBison.h"})
 %token<fl>              yVL_SFORMAT             "/*verilator sformat*/"
 %token<fl>              yVL_SPLIT_VAR           "/*verilator split_var*/"
 %token<strp>            yVL_TAG                 "/*verilator tag*/"
+%token<strp>            yVL_LINT_IGNORE         "/*verilator lint_ignore*/"
 
 %token<fl>              yP_TICK         "'"
 %token<fl>              yP_TICKBRA      "'{"

--- a/test_regress/t/t_metacmt_ignore.out
+++ b/test_regress/t/t_metacmt_ignore.out
@@ -1,0 +1,18 @@
+%Warning-LITENDIAN: t/t_metacmt_ignore.v:7:8: Little bit endian vector: left < right of bit range: [0:1]
+                                            : ... In instance t
+    7 |    reg [0:1] show1;                                      
+      |        ^
+                    ... Use "/* verilator lint_off LITENDIAN */" and lint_on around source to disable this message.
+%Warning-LITENDIAN: t/t_metacmt_ignore.v:9:8: Little bit endian vector: left < right of bit range: [0:3]
+                                            : ... In instance t
+    9 |    reg [0:3] show3;                                      
+      |        ^
+%Warning-LITENDIAN: t/t_metacmt_ignore.v:11:8: Little bit endian vector: left < right of bit range: [0:5]
+                                             : ... In instance t
+   11 |    reg [0:5] show5;                                      
+      |        ^
+%Warning-LITENDIAN: t/t_metacmt_ignore.v:14:8: Little bit endian vector: left < right of bit range: [0:9]
+                                             : ... In instance t
+   14 |    reg [0:9] show9;                                      
+      |        ^
+%Error: Exiting due to

--- a/test_regress/t/t_metacmt_ignore.pl
+++ b/test_regress/t/t_metacmt_ignore.pl
@@ -1,0 +1,19 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2008 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(vlt => 1);
+
+lint(
+    fails => $Self->{vlt_all},
+    expect_filename => $Self->{golden_filename},
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_metacmt_ignore.v
+++ b/test_regress/t/t_metacmt_ignore.v
@@ -1,0 +1,19 @@
+// DESCRIPTION: Verilator: Verilog Test module
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2020 by Wilson Snyder.
+// SPDX-License-Identifier: CC0-1.0
+
+module t;
+   reg [0:1] show1;                                     // Should warn
+   /*verilator lint_ignore LITENDIAN*/ reg [0:2] ign2;  // Should not warn
+   reg [0:3] show3;                                     // Should warn
+   reg [0:4] ign4; /*verilator lint_ignore LITENDIAN*/  // Should not warn
+   reg [0:5] show5;                                     // Should warn
+   reg [0:6] ign6; /*verilator lint_ignore LITENDIAN*/ reg [0:7] ign7; // Should not warn
+   reg [0:8] ign8; // verilator lint_ignore LITENDIAN      Should not warn
+   reg [0:9] show9;                                     // Should not warn
+   initial begin
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end
+endmodule

--- a/test_regress/t/t_metacmt_ignore_bad.out
+++ b/test_regress/t/t_metacmt_ignore_bad.out
@@ -1,0 +1,4 @@
+%Error: t/t_metacmt_ignore_bad.v:7:4: Unknown verilator lint message code: 'NONEXISTENTMESSAGE'
+    7 |    /*verilator lint_ignore NONEXISTENTMESSAGE*/ 
+      |    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+%Error: Exiting due to

--- a/test_regress/t/t_metacmt_ignore_bad.pl
+++ b/test_regress/t/t_metacmt_ignore_bad.pl
@@ -1,0 +1,19 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2008 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(vlt => 1);
+
+lint(
+    fails => $Self->{vlt_all},
+    expect_filename => $Self->{golden_filename},
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_metacmt_ignore_bad.v
+++ b/test_regress/t/t_metacmt_ignore_bad.v
@@ -1,0 +1,8 @@
+// DESCRIPTION: Verilator: Verilog Test module
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2020 by Wilson Snyder.
+// SPDX-License-Identifier: CC0-1.0
+
+module t;
+   /*verilator lint_ignore NONEXISTENTMESSAGE*/
+endmodule


### PR DESCRIPTION
Wanted to tinker with something simple so I implemented #2755 

This works by addign a buffer between the lexer an the parser. Any time new tokens are required, a whole line (or in some cases multiple lines) worth of tokens are fetched from the lexer. The meta comments applying to the whole line (currently only `lint_ignore`) are then processed and applied to all tokens in the line buffer as they are transferred to the parser/lookahead buffer. Test suite performance appears the same. Thera are a few warning generated n the lexer (verilog.l), which this obviously cannot disable, but none of them seem particularly interesting. The 3 warning classes appearing in verilog.l:
- E_UNSUPPORTED in a bunch of places, which we probably don't want to disable anyway.
- DEPRECATED in once place (verilator sc_clock being ignored).
- COLONPLUS which is trivial to fix rather than sign off.