### PR TITLE
Fix incorrect condition in varNotReferenced

### DIFF
--- a/src/V3Const.cpp
+++ b/src/V3Const.cpp
@@ -1531,7 +1531,7 @@ private:
         // Return false if referenced, or tree too deep to be worth it, or side effects
         if (!nodep) return true;
         if (level > 2) return false;
-        if (nodep->isPure()) return false;  // For example a $fgetc can't be reordered
+        if (!nodep->isPure()) return false;  // For example a $fgetc can't be reordered
         if (VN_IS(nodep, NodeVarRef) && VN_CAST(nodep, NodeVarRef)->varp() == varp) return false;
         return (varNotReferenced(nodep->nextp(), varp, level + 1)
                 && varNotReferenced(nodep->op1p(), varp, level + 1)

--- a/test_regress/t/t_split_var_0.pl
+++ b/test_regress/t/t_split_var_0.pl
@@ -22,7 +22,7 @@ execute(
     check_finished => 1,
     );
 
-file_grep($Self->{stats}, qr/SplitVar,\s+Split packed variables\s+(\d+)/i, 13);
+file_grep($Self->{stats}, qr/SplitVar,\s+Split packed variables\s+(\d+)/i, 11);
 file_grep($Self->{stats}, qr/SplitVar,\s+Split unpacked arrays\s+(\d+)/i, 27);
 ok(1);
 1;

--- a/test_regress/t/t_split_var_2_trace.pl
+++ b/test_regress/t/t_split_var_2_trace.pl
@@ -24,7 +24,7 @@ execute(
     );
 
 vcd_identical("$Self->{obj_dir}/simx.vcd", $Self->{golden_filename});
-file_grep($Self->{stats}, qr/SplitVar,\s+Split packed variables\s+(\d+)/i, 12);
+file_grep($Self->{stats}, qr/SplitVar,\s+Split packed variables\s+(\d+)/i, 10);
 file_grep($Self->{stats}, qr/SplitVar,\s+Split unpacked arrays\s+(\d+)/i, 27);
 
 ok(1);


### PR DESCRIPTION
The intention was to not merge impure assignments, but the actual
predicate failed if the assignment was indeed pure.

This fix gains 1.5% speed on SweRV EH1.

Not sure if this reduces the coverage of the tests for SplitVar due to eliminating some splitting necessity, or the eliminated splits are simply redundant...