### PR TITLE
Add support for null ports

### DIFF
--- a/bin/verilator
+++ b/bin/verilator
@@ -4726,7 +4726,7 @@ correctly.
 
 =item NULLPORT
 
-Warns that a null port was detected in the module definition port list. null
+Warns that a null port was detected in the module definition port list. Null
 ports are empty placeholders, i.e. either one ore more commas at the beginning
 or the end of a module port list, or two or more consecutive commas in the
 middle of a module port list. A null port cannot be accessed within the module,

--- a/bin/verilator
+++ b/bin/verilator
@@ -4724,6 +4724,17 @@ using a regular always may be more appropriate.
 Ignoring this warning will only suppress the lint check, it will simulate
 correctly.
 
+=item NULLPORT
+
+Warns that a null port was detected in the module definition port list. null
+ports are empty placeholders, i.e. either one ore more commas at the beginning
+or the end of a module port list, or two or more consecutive commas in the
+middle of a module port list. A null port cannot be accessed within the module,
+but when instantiating the module by port order, it is treated like a regular
+port and any wire connected to it is left unconnected.
+This is considered a warning because this feature is rarely used, and is mostly
+the result of a typing error such as a dangling comma at the end of a port list.
+
 =item PINCONNECTEMPTY
 
 Warns that an instance has a pin which is connected to .pin_name(),

--- a/src/V3Error.h
+++ b/src/V3Error.h
@@ -101,6 +101,7 @@ public:
         MULTIDRIVEN,    // Driven from multiple blocks
         MULTITOP,       // Multiple top level modules
         NOLATCH,        // No latch detected in always_latch block
+        NULLPORT,       // Null port detected in module definition
         PINCONNECTEMPTY,// Cell pin connected by name with empty reference
         PINMISSING,     // Cell pin not specified
         PINNOCONNECT,   // Cell pin not connected
@@ -167,7 +168,7 @@ public:
             "IMPERFECTSCH", "IMPLICIT", "IMPORTSTAR", "IMPURE",
             "INCABSPATH", "INFINITELOOP", "INITIALDLY", "INSECURE",
             "LATCH", "LITENDIAN", "MODDUP",
-            "MULTIDRIVEN", "MULTITOP","NOLATCH", "PINCONNECTEMPTY",
+            "MULTIDRIVEN", "MULTITOP","NOLATCH", "NULLPORT", "PINCONNECTEMPTY",
             "PINMISSING", "PINNOCONNECT",  "PINNOTFOUND", "PKGNODECL", "PROCASSWIRE",
             "RANDC", "REALCVT", "REDEFMACRO",
             "SELRANGE", "SHORTREAL", "SPLITVAR", "STMTDLY", "SYMRSVDWORD", "SYNCASYNCNET",

--- a/src/V3ParseGrammar.cpp
+++ b/src/V3ParseGrammar.cpp
@@ -154,7 +154,7 @@ AstVar* V3ParseGrammar::createVariable(FileLine* fileline, const string& name,
                          << GRAMMARP->m_varIO << "  dt=" << (dtypep ? "set" : "") << endl);
     if (GRAMMARP->m_varIO == VDirection::NONE && GRAMMARP->m_varDecl == AstVarType::PORT) {
         // Just a port list with variable name (not v2k format); AstPort already created
-        if (dtypep) fileline->v3warn(E_UNSUPPORTED, "Unsupported: Ranges ignored in port-lists");
+        if (dtypep && !(VN_IS(dtypep, BasicDType) && VN_CAST(dtypep, BasicDType)->implicit())) fileline->v3warn(E_UNSUPPORTED, "Unsupported: Ranges ignored in port-lists");
         return nullptr;
     }
     if (GRAMMARP->m_varDecl == AstVarType::WREAL) {

--- a/src/V3ParseGrammar.cpp
+++ b/src/V3ParseGrammar.cpp
@@ -154,7 +154,8 @@ AstVar* V3ParseGrammar::createVariable(FileLine* fileline, const string& name,
                          << GRAMMARP->m_varIO << "  dt=" << (dtypep ? "set" : "") << endl);
     if (GRAMMARP->m_varIO == VDirection::NONE && GRAMMARP->m_varDecl == AstVarType::PORT) {
         // Just a port list with variable name (not v2k format); AstPort already created
-        if (dtypep && !(VN_IS(dtypep, BasicDType) && VN_CAST(dtypep, BasicDType)->implicit())) fileline->v3warn(E_UNSUPPORTED, "Unsupported: Ranges ignored in port-lists");
+        if (dtypep && !(VN_IS(dtypep, BasicDType) && VN_CAST(dtypep, BasicDType)->implicit()))
+            fileline->v3warn(E_UNSUPPORTED, "Unsupported: Ranges ignored in port-lists");
         return nullptr;
     }
     if (GRAMMARP->m_varDecl == AstVarType::WREAL) {

--- a/src/V3ParseGrammar.cpp
+++ b/src/V3ParseGrammar.cpp
@@ -154,8 +154,7 @@ AstVar* V3ParseGrammar::createVariable(FileLine* fileline, const string& name,
                          << GRAMMARP->m_varIO << "  dt=" << (dtypep ? "set" : "") << endl);
     if (GRAMMARP->m_varIO == VDirection::NONE && GRAMMARP->m_varDecl == AstVarType::PORT) {
         // Just a port list with variable name (not v2k format); AstPort already created
-        if (dtypep && !(VN_IS(dtypep, BasicDType) && VN_CAST(dtypep, BasicDType)->implicit()))
-            fileline->v3warn(E_UNSUPPORTED, "Unsupported: Ranges ignored in port-lists");
+        if (dtypep) fileline->v3warn(E_UNSUPPORTED, "Unsupported: Ranges ignored in port-lists");
         return nullptr;
     }
     if (GRAMMARP->m_varDecl == AstVarType::WREAL) {

--- a/src/verilog.y
+++ b/src/verilog.y
@@ -1279,14 +1279,19 @@ paramPortDeclOrArg<nodep>:	// IEEE: param_assignment + parameter_port_declaratio
 portsStarE<nodep>:		// IEEE: .* + list_of_ports + list_of_port_declarations + empty
 		/* empty */				{ $$ = nullptr; }
 	|	'(' ')'					{ $$ = nullptr; }
+	|	'(' list_of_commas ')'	{ $$ = nullptr; } // Insert null port handling here
 	//			// .* expanded from module_declaration
 	//UNSUP	'(' yP_DOTSTAR ')'				{ UNSUP }
-	|	'(' {VARRESET_LIST(PORT);} list_of_ports	{ $$ = $3; VARRESET_NONLIST(UNKNOWN); }
+	|	start_with_commas_or_none {VARRESET_LIST(PORT);} list_of_ports	{ $$ = $3; VARRESET_NONLIST(UNKNOWN); }
+	;
+start_with_commas_or_none:
+		'('
+	|	'(' list_of_commas
 	;
 
 list_of_commas:	// one or more commas for null port handling
 		','
-	|	list_of_commas ','
+	|	list_of_commas ',' // Insert null port handling here
 	;
 list_of_ports_comma<nodep>:		// IEEE: list_of_ports + list_of_port_declarations
 		portAndTag	list_of_commas			{ $$ = $1; }

--- a/src/verilog.y
+++ b/src/verilog.y
@@ -1278,17 +1278,23 @@ paramPortDeclOrArg<nodep>:	// IEEE: param_assignment + parameter_port_declaratio
 
 portsStarE<nodep>:		// IEEE: .* + list_of_ports + list_of_port_declarations + empty
 		/* empty */				{ $$ = nullptr; }
+	|	'(' ')'					{ $$ = nullptr; }
 	//			// .* expanded from module_declaration
 	//UNSUP	'(' yP_DOTSTAR ')'				{ UNSUP }
 	|	'(' {VARRESET_LIST(PORT);} list_of_ports ')'	{ $$ = $3; VARRESET_NONLIST(UNKNOWN); }
 	;
 
-list_of_ports<nodep>:		// IEEE: list_of_ports + list_of_port_declarations
-		portAndTag				{ $$ = $1; }
-	|	list_of_ports ',' portAndTag		{ $$ = $1->addNextNull($3); }
+list_of_portsEmpty<nodep>:		// IEEE: list_of_ports + list_of_port_declarations
+		portAndTagEmpty			{ $$ = $1; }
+	|	list_of_portsEmpty ',' portAndTagEmpty		{ $$ = $1->addNextNull($3); }
 	;
 
-portAndTag<nodep>:
+list_of_ports<nodep>:		// IEEE: list_of_ports + list_of_port_declarations
+		portAndTag			{ $$ = $1; }
+	|	list_of_portsEmpty ',' portAndTagEmpty		{ $$ = $1->addNextNull($3); }
+	;
+
+portAndTagEmpty<nodep>:
 		/* empty */
 			{ int p = PINNUMINC();
 			  string pn = "__pinNumber"+cvtToStr(p);
@@ -1302,7 +1308,11 @@ portAndTag<nodep>:
 			  varp->trace(false);
 			  $$ = $$->addNext(varp);
 			  $$->v3warn(NULLPORT, "Null port on module (perhaps extraneous comma)"); }
-	|	port					{ $$ = $1; }
+	|	portAndTag				{ $$ = $1; }
+	;
+
+portAndTag<nodep>:
+		port					{ $$ = $1; }
 	|	vlTag port				{ $$ = $2; }  // Tag will associate with previous port
 	;
 

--- a/src/verilog.y
+++ b/src/verilog.y
@@ -1330,9 +1330,7 @@ list_of_ports<nodep>:		// IEEE: list_of_ports + list_of_port_declarations
 			  //VARDTYPE_NDECL(new AstBasicDType($<fl>1, LOGIC_IMPLICIT));
 			  VARDTYPE_NDECL(nullptr);
 			  // if we got here we have one more trailing comma
-			  std::cerr << "udif!" << std::endl;
-			  $$ = $1->addNextNull(VARDONEP($1, nullptr, nullptr));
-			  std::cerr << std::dec << 1328 << " " << std::hex << $$ << std::endl;
+			  $$ = $1->addNextNull(VARDONEP($1, nullptr, nullptr)); DBG($$);
 			  $$->v3warn(NULLPORT, "Null port on module (perhaps extraneous comma)"); }
 	;
 

--- a/src/verilog.y
+++ b/src/verilog.y
@@ -1280,7 +1280,7 @@ paramPortDeclOrArg<nodep>:	// IEEE: param_assignment + parameter_port_declaratio
 portsStarE<nodep>:		// IEEE: .* + list_of_ports + list_of_port_declarations + empty
 		/* empty */				{ $$ = nullptr; }
 	|	'(' ')'					{ $$ = nullptr; }
-	|	'(' list_of_commas ')'	{ $$ = nullptr; $2->v3warn(NULLPORT, "null port detected"); } // Insert proper null port handling here
+	|	'(' list_of_commas ')'	{ $$ = nullptr; $2->v3warn(NULLPORT, "Null port on module (perhaps extraneous comma)"); } // Insert proper null port handling here
 	//			// .* expanded from module_declaration
 	//UNSUP	'(' yP_DOTSTAR ')'				{ UNSUP }
 	|	start_with_commas_or_none {VARRESET_LIST(PORT);} list_of_ports	{ $$ = $3; VARRESET_NONLIST(UNKNOWN); }

--- a/src/verilog.y
+++ b/src/verilog.y
@@ -1292,7 +1292,18 @@ list_of_ports<nodep>:		// IEEE: list_of_ports + list_of_port_declarations
 	;
 
 portAndTag<nodep>:
-		/* empty */				{ $$ = nullptr; } // null port
+		/* empty */
+			{ $$ = new AstPort(CRELINE(), PINNUMINC(), "");
+			  AstVar* varp = new AstVar(CRELINE(), AstVarType::PORT, "", VFlagChildDType(), 
+			                            new AstBasicDType(CRELINE(), LOGIC_IMPLICIT));
+			  varp->declDirection(VDirection::INPUT);
+			  varp->direction(VDirection::INPUT);
+			  varp->ansi(false);
+			  varp->declTyped(true);
+			  varp->trace(false);
+			  $$ = $$->addNext(varp);
+			  $$->v3warn(NULLPORT, "Null port on module (perhaps extraneous comma)");
+			  DBG($$); } // 1st ',' is nullptr in case it's just a regular separator comma}
 	|	port					{ $$ = $1; }
 	|	vlTag port				{ $$ = $2; }  // Tag will associate with previous port
 	;

--- a/src/verilog.y
+++ b/src/verilog.y
@@ -270,9 +270,6 @@ int V3ParseGrammar::s_modTypeImpNum = 0;
         if (nodep) nodep->deleteTree(); \
     }
 
-//#define DBG(x)
-#define DBG(x) UINFO(0, " " << #x << "=" << std::hex << (x) << std::endl);
-
 static void ERRSVKWD(FileLine* fileline, const string& tokname) {
     static int toldonce = 0;
     fileline->v3error(
@@ -1293,8 +1290,10 @@ list_of_ports<nodep>:		// IEEE: list_of_ports + list_of_port_declarations
 
 portAndTag<nodep>:
 		/* empty */
-			{ $$ = new AstPort(CRELINE(), PINNUMINC(), "");
-			  AstVar* varp = new AstVar(CRELINE(), AstVarType::PORT, "", VFlagChildDType(), 
+			{ int p = PINNUMINC();
+			  string pn = "__pinNumber"+cvtToStr(p);
+			  $$ = new AstPort(CRELINE(), p, pn);
+			  AstVar* varp = new AstVar(CRELINE(), AstVarType::PORT, pn, VFlagChildDType(), 
 			                            new AstBasicDType(CRELINE(), LOGIC_IMPLICIT));
 			  varp->declDirection(VDirection::INPUT);
 			  varp->direction(VDirection::INPUT);
@@ -1302,8 +1301,7 @@ portAndTag<nodep>:
 			  varp->declTyped(true);
 			  varp->trace(false);
 			  $$ = $$->addNext(varp);
-			  $$->v3warn(NULLPORT, "Null port on module (perhaps extraneous comma)");
-			  DBG($$); } // 1st ',' is nullptr in case it's just a regular separator comma}
+			  $$->v3warn(NULLPORT, "Null port on module (perhaps extraneous comma)"); }
 	|	port					{ $$ = $1; }
 	|	vlTag port				{ $$ = $2; }  // Tag will associate with previous port
 	;

--- a/src/verilog.y
+++ b/src/verilog.y
@@ -1299,7 +1299,7 @@ portAndTagEmpty<nodep>:
 			{ int p = PINNUMINC();
 			  string pn = "__pinNumber"+cvtToStr(p);
 			  $$ = new AstPort(CRELINE(), p, pn);
-			  AstVar* varp = new AstVar(CRELINE(), AstVarType::PORT, pn, VFlagChildDType(), 
+			  AstVar* varp = new AstVar(CRELINE(), AstVarType::PORT, pn, VFlagChildDType(),
 			                            new AstBasicDType(CRELINE(), LOGIC_IMPLICIT));
 			  varp->declDirection(VDirection::INPUT);
 			  varp->direction(VDirection::INPUT);

--- a/src/verilog.y
+++ b/src/verilog.y
@@ -1297,10 +1297,10 @@ list_of_ports<nodep>:		// IEEE: list_of_ports + list_of_port_declarations
 portAndTagE<nodep>:
 		/* empty */
 			{ int p = PINNUMINC();
-			  string pn = "__pinNumber"+cvtToStr(p);
-			  $$ = new AstPort(CRELINE(), p, pn);
-			  AstVar* varp = new AstVar(CRELINE(), AstVarType::PORT, pn, VFlagChildDType(),
-			                            new AstBasicDType(CRELINE(), LOGIC_IMPLICIT));
+			   const string name = "__pinNumber" + cvtToStr(p);
+			  $$ = new AstPort{CRELINE(), p, name};
+			  AstVar* varp = new AstVar{CRELINE(), AstVarType::PORT, name, VFlagChildDType{},
+			                            new AstBasicDType{CRELINE(), LOGIC_IMPLICIT}};
 			  varp->declDirection(VDirection::INPUT);
 			  varp->direction(VDirection::INPUT);
 			  varp->ansi(false);

--- a/src/verilog.y
+++ b/src/verilog.y
@@ -272,7 +272,8 @@ int V3ParseGrammar::s_modTypeImpNum = 0;
     }
 
 //#define DBG(x)
-#define DBG(x)  std::cerr << std::dec << __LINE__ << " " << #x << "=" << std::hex << (x) << std::endl;
+#define DBG(x) \
+    std::cerr << std::dec << __LINE__ << " " << #x << "=" << std::hex << (x) << std::endl;
 
 static void ERRSVKWD(FileLine* fileline, const string& tokname) {
     static int toldonce = 0;

--- a/src/verilog.y
+++ b/src/verilog.y
@@ -1284,9 +1284,13 @@ portsStarE<nodep>:		// IEEE: .* + list_of_ports + list_of_port_declarations + em
 	|	'(' {VARRESET_LIST(PORT);} list_of_ports	{ $$ = $3; VARRESET_NONLIST(UNKNOWN); }
 	;
 
+list_of_commas:	// one or more commas for null port handling
+		','
+	|	list_of_commas ','
+	;
 list_of_ports_comma<nodep>:		// IEEE: list_of_ports + list_of_port_declarations
-		portAndTag	','			{ $$ = $1; }
-	|	list_of_ports_comma portAndTag	','		{ $$ = $1->addNextNull($2); }
+		portAndTag	list_of_commas			{ $$ = $1; }
+	|	list_of_ports_comma portAndTag	list_of_commas		{ $$ = $1->addNextNull($2); }
 	;
 
 list_of_ports<nodep>:		// IEEE: list_of_ports + list_of_port_declarations

--- a/src/verilog.y
+++ b/src/verilog.y
@@ -1284,17 +1284,17 @@ portsStarE<nodep>:		// IEEE: .* + list_of_ports + list_of_port_declarations + em
 	|	'(' {VARRESET_LIST(PORT);} list_of_ports ')'	{ $$ = $3; VARRESET_NONLIST(UNKNOWN); }
 	;
 
-list_of_portsEmpty<nodep>:		// IEEE: list_of_ports + list_of_port_declarations
-		portAndTagEmpty			{ $$ = $1; }
-	|	list_of_portsEmpty ',' portAndTagEmpty		{ $$ = $1->addNextNull($3); }
+list_of_portsE<nodep>:		// IEEE: list_of_ports + list_of_port_declarations
+		portAndTagE			{ $$ = $1; }
+	|	list_of_portsE ',' portAndTagE		{ $$ = $1->addNextNull($3); }
 	;
 
 list_of_ports<nodep>:		// IEEE: list_of_ports + list_of_port_declarations
 		portAndTag			{ $$ = $1; }
-	|	list_of_portsEmpty ',' portAndTagEmpty		{ $$ = $1->addNextNull($3); }
+	|	list_of_portsE ',' portAndTagE		{ $$ = $1->addNextNull($3); }
 	;
 
-portAndTagEmpty<nodep>:
+portAndTagE<nodep>:
 		/* empty */
 			{ int p = PINNUMINC();
 			  string pn = "__pinNumber"+cvtToStr(p);

--- a/src/verilog.y
+++ b/src/verilog.y
@@ -1281,12 +1281,18 @@ portsStarE<nodep>:		// IEEE: .* + list_of_ports + list_of_port_declarations + em
 	|	'(' ')'					{ $$ = nullptr; }
 	//			// .* expanded from module_declaration
 	//UNSUP	'(' yP_DOTSTAR ')'				{ UNSUP }
-	|	'(' {VARRESET_LIST(PORT);} list_of_ports ')'	{ $$ = $3; VARRESET_NONLIST(UNKNOWN); }
+	|	'(' {VARRESET_LIST(PORT);} list_of_ports	{ $$ = $3; VARRESET_NONLIST(UNKNOWN); }
+	;
+
+list_of_ports_comma<nodep>:		// IEEE: list_of_ports + list_of_port_declarations
+		portAndTag	','			{ $$ = $1; }
+	|	list_of_ports_comma portAndTag	','		{ $$ = $1->addNextNull($2); }
 	;
 
 list_of_ports<nodep>:		// IEEE: list_of_ports + list_of_port_declarations
-		portAndTag				{ $$ = $1; }
-	|	list_of_ports ',' portAndTag		{ $$ = $1->addNextNull($3); }
+		portAndTag	')'			{ $$ = $1; }
+	|	list_of_ports_comma portAndTag	')'		{ $$ = $1->addNextNull($2); }
+	|	list_of_ports_comma ')'		{ $$ = $1; }
 	;
 
 portAndTag<nodep>:

--- a/test_regress/t/t_lint_nullport.out
+++ b/test_regress/t/t_lint_nullport.out
@@ -1,10 +1,7 @@
-%Warning-NULLPORT: t/t_lint_nullport.v:3:11: Null port on module (perhaps extraneous comma)
-    3 | module t1();
-      |           ^
-                   ... Use "/* verilator lint_off NULLPORT */" and lint_on around source to disable this message.
 %Warning-NULLPORT: t/t_lint_nullport.v:17:13: Null port on module (perhaps extraneous comma)
    17 | module t5(a,);
       |             ^
+                   ... Use "/* verilator lint_off NULLPORT */" and lint_on around source to disable this message.
 %Warning-NULLPORT: t/t_lint_nullport.v:21:13: Null port on module (perhaps extraneous comma)
    21 | module t6(a,,);
       |             ^

--- a/test_regress/t/t_lint_nullport.out
+++ b/test_regress/t/t_lint_nullport.out
@@ -1,0 +1,110 @@
+%Warning-NULLPORT: t/t_lint_nullport.v:3:11: Null port on module (perhaps extraneous comma)
+    3 | module t1();
+      |           ^
+                   ... Use "/* verilator lint_off NULLPORT */" and lint_on around source to disable this message.
+%Warning-NULLPORT: t/t_lint_nullport.v:17:13: Null port on module (perhaps extraneous comma)
+   17 | module t5(a,);
+      |             ^
+%Warning-NULLPORT: t/t_lint_nullport.v:21:13: Null port on module (perhaps extraneous comma)
+   21 | module t6(a,,);
+      |             ^
+%Warning-NULLPORT: t/t_lint_nullport.v:21:14: Null port on module (perhaps extraneous comma)
+   21 | module t6(a,,);
+      |              ^
+%Warning-NULLPORT: t/t_lint_nullport.v:25:15: Null port on module (perhaps extraneous comma)
+   25 | module t7(a,b,);
+      |               ^
+%Warning-NULLPORT: t/t_lint_nullport.v:29:15: Null port on module (perhaps extraneous comma)
+   29 | module t8(a,b,,);
+      |               ^
+%Warning-NULLPORT: t/t_lint_nullport.v:29:16: Null port on module (perhaps extraneous comma)
+   29 | module t8(a,b,,);
+      |                ^
+%Warning-NULLPORT: t/t_lint_nullport.v:33:13: Null port on module (perhaps extraneous comma)
+   33 | module t9(a,,b);
+      |             ^
+%Warning-NULLPORT: t/t_lint_nullport.v:37:14: Null port on module (perhaps extraneous comma)
+   37 | module t10(a,,b,);
+      |              ^
+%Warning-NULLPORT: t/t_lint_nullport.v:37:17: Null port on module (perhaps extraneous comma)
+   37 | module t10(a,,b,);
+      |                 ^
+%Warning-NULLPORT: t/t_lint_nullport.v:41:14: Null port on module (perhaps extraneous comma)
+   41 | module t11(a,,b,,);
+      |              ^
+%Warning-NULLPORT: t/t_lint_nullport.v:41:17: Null port on module (perhaps extraneous comma)
+   41 | module t11(a,,b,,);
+      |                 ^
+%Warning-NULLPORT: t/t_lint_nullport.v:41:18: Null port on module (perhaps extraneous comma)
+   41 | module t11(a,,b,,);
+      |                  ^
+%Warning-NULLPORT: t/t_lint_nullport.v:45:12: Null port on module (perhaps extraneous comma)
+   45 | module t12(,a,,b);
+      |            ^
+%Warning-NULLPORT: t/t_lint_nullport.v:45:15: Null port on module (perhaps extraneous comma)
+   45 | module t12(,a,,b);
+      |               ^
+%Warning-NULLPORT: t/t_lint_nullport.v:49:12: Null port on module (perhaps extraneous comma)
+   49 | module t13(,a,,b,);
+      |            ^
+%Warning-NULLPORT: t/t_lint_nullport.v:49:15: Null port on module (perhaps extraneous comma)
+   49 | module t13(,a,,b,);
+      |               ^
+%Warning-NULLPORT: t/t_lint_nullport.v:49:18: Null port on module (perhaps extraneous comma)
+   49 | module t13(,a,,b,);
+      |                  ^
+%Warning-NULLPORT: t/t_lint_nullport.v:53:12: Null port on module (perhaps extraneous comma)
+   53 | module t14(,a,,b,,);
+      |            ^
+%Warning-NULLPORT: t/t_lint_nullport.v:53:15: Null port on module (perhaps extraneous comma)
+   53 | module t14(,a,,b,,);
+      |               ^
+%Warning-NULLPORT: t/t_lint_nullport.v:53:18: Null port on module (perhaps extraneous comma)
+   53 | module t14(,a,,b,,);
+      |                  ^
+%Warning-NULLPORT: t/t_lint_nullport.v:53:19: Null port on module (perhaps extraneous comma)
+   53 | module t14(,a,,b,,);
+      |                   ^
+%Warning-NULLPORT: t/t_lint_nullport.v:57:12: Null port on module (perhaps extraneous comma)
+   57 | module t15(,,a,,b);
+      |            ^
+%Warning-NULLPORT: t/t_lint_nullport.v:57:13: Null port on module (perhaps extraneous comma)
+   57 | module t15(,,a,,b);
+      |             ^
+%Warning-NULLPORT: t/t_lint_nullport.v:57:16: Null port on module (perhaps extraneous comma)
+   57 | module t15(,,a,,b);
+      |                ^
+%Warning-NULLPORT: t/t_lint_nullport.v:61:12: Null port on module (perhaps extraneous comma)
+   61 | module t16(,,a,,b,);
+      |            ^
+%Warning-NULLPORT: t/t_lint_nullport.v:61:13: Null port on module (perhaps extraneous comma)
+   61 | module t16(,,a,,b,);
+      |             ^
+%Warning-NULLPORT: t/t_lint_nullport.v:61:16: Null port on module (perhaps extraneous comma)
+   61 | module t16(,,a,,b,);
+      |                ^
+%Warning-NULLPORT: t/t_lint_nullport.v:61:19: Null port on module (perhaps extraneous comma)
+   61 | module t16(,,a,,b,);
+      |                   ^
+%Warning-NULLPORT: t/t_lint_nullport.v:65:12: Null port on module (perhaps extraneous comma)
+   65 | module t17(,,a,,b,,);
+      |            ^
+%Warning-NULLPORT: t/t_lint_nullport.v:65:13: Null port on module (perhaps extraneous comma)
+   65 | module t17(,,a,,b,,);
+      |             ^
+%Warning-NULLPORT: t/t_lint_nullport.v:65:16: Null port on module (perhaps extraneous comma)
+   65 | module t17(,,a,,b,,);
+      |                ^
+%Warning-NULLPORT: t/t_lint_nullport.v:65:19: Null port on module (perhaps extraneous comma)
+   65 | module t17(,,a,,b,,);
+      |                   ^
+%Warning-NULLPORT: t/t_lint_nullport.v:65:20: Null port on module (perhaps extraneous comma)
+   65 | module t17(,,a,,b,,);
+      |                    ^
+%Warning-NULLPORT: t/t_lint_nullport.v:69:12: Null port on module (perhaps extraneous comma)
+   69 | module t18(,);
+      |            ^
+%Warning-NULLPORT: t/t_lint_nullport.v:69:13: Null port on module (perhaps extraneous comma)
+   69 | module t18(,);
+      |             ^
+%Error: Exiting due to

--- a/test_regress/t/t_lint_nullport.out
+++ b/test_regress/t/t_lint_nullport.out
@@ -1,107 +1,107 @@
-%Warning-NULLPORT: t/t_lint_nullport.v:17:13: Null port on module (perhaps extraneous comma)
-   17 | module t5(a,);
+%Warning-NULLPORT: t/t_lint_nullport.v:23:13: Null port on module (perhaps extraneous comma)
+   23 | module t5(a,);
       |             ^
                    ... Use "/* verilator lint_off NULLPORT */" and lint_on around source to disable this message.
-%Warning-NULLPORT: t/t_lint_nullport.v:21:13: Null port on module (perhaps extraneous comma)
-   21 | module t6(a,,);
+%Warning-NULLPORT: t/t_lint_nullport.v:27:13: Null port on module (perhaps extraneous comma)
+   27 | module t6(a,,);
       |             ^
-%Warning-NULLPORT: t/t_lint_nullport.v:21:14: Null port on module (perhaps extraneous comma)
-   21 | module t6(a,,);
+%Warning-NULLPORT: t/t_lint_nullport.v:27:14: Null port on module (perhaps extraneous comma)
+   27 | module t6(a,,);
       |              ^
-%Warning-NULLPORT: t/t_lint_nullport.v:25:15: Null port on module (perhaps extraneous comma)
-   25 | module t7(a,b,);
+%Warning-NULLPORT: t/t_lint_nullport.v:31:15: Null port on module (perhaps extraneous comma)
+   31 | module t7(a,b,);
       |               ^
-%Warning-NULLPORT: t/t_lint_nullport.v:29:15: Null port on module (perhaps extraneous comma)
-   29 | module t8(a,b,,);
+%Warning-NULLPORT: t/t_lint_nullport.v:35:15: Null port on module (perhaps extraneous comma)
+   35 | module t8(a,b,,);
       |               ^
-%Warning-NULLPORT: t/t_lint_nullport.v:29:16: Null port on module (perhaps extraneous comma)
-   29 | module t8(a,b,,);
+%Warning-NULLPORT: t/t_lint_nullport.v:35:16: Null port on module (perhaps extraneous comma)
+   35 | module t8(a,b,,);
       |                ^
-%Warning-NULLPORT: t/t_lint_nullport.v:33:13: Null port on module (perhaps extraneous comma)
-   33 | module t9(a,,b);
+%Warning-NULLPORT: t/t_lint_nullport.v:39:13: Null port on module (perhaps extraneous comma)
+   39 | module t9(a,,b);
       |             ^
-%Warning-NULLPORT: t/t_lint_nullport.v:37:14: Null port on module (perhaps extraneous comma)
-   37 | module t10(a,,b,);
+%Warning-NULLPORT: t/t_lint_nullport.v:43:14: Null port on module (perhaps extraneous comma)
+   43 | module t10(a,,b,);
       |              ^
-%Warning-NULLPORT: t/t_lint_nullport.v:37:17: Null port on module (perhaps extraneous comma)
-   37 | module t10(a,,b,);
+%Warning-NULLPORT: t/t_lint_nullport.v:43:17: Null port on module (perhaps extraneous comma)
+   43 | module t10(a,,b,);
       |                 ^
-%Warning-NULLPORT: t/t_lint_nullport.v:41:14: Null port on module (perhaps extraneous comma)
-   41 | module t11(a,,b,,);
+%Warning-NULLPORT: t/t_lint_nullport.v:47:14: Null port on module (perhaps extraneous comma)
+   47 | module t11(a,,b,,);
       |              ^
-%Warning-NULLPORT: t/t_lint_nullport.v:41:17: Null port on module (perhaps extraneous comma)
-   41 | module t11(a,,b,,);
+%Warning-NULLPORT: t/t_lint_nullport.v:47:17: Null port on module (perhaps extraneous comma)
+   47 | module t11(a,,b,,);
       |                 ^
-%Warning-NULLPORT: t/t_lint_nullport.v:41:18: Null port on module (perhaps extraneous comma)
-   41 | module t11(a,,b,,);
+%Warning-NULLPORT: t/t_lint_nullport.v:47:18: Null port on module (perhaps extraneous comma)
+   47 | module t11(a,,b,,);
       |                  ^
-%Warning-NULLPORT: t/t_lint_nullport.v:45:12: Null port on module (perhaps extraneous comma)
-   45 | module t12(,a,,b);
+%Warning-NULLPORT: t/t_lint_nullport.v:51:12: Null port on module (perhaps extraneous comma)
+   51 | module t12(,a,,b);
       |            ^
-%Warning-NULLPORT: t/t_lint_nullport.v:45:15: Null port on module (perhaps extraneous comma)
-   45 | module t12(,a,,b);
+%Warning-NULLPORT: t/t_lint_nullport.v:51:15: Null port on module (perhaps extraneous comma)
+   51 | module t12(,a,,b);
       |               ^
-%Warning-NULLPORT: t/t_lint_nullport.v:49:12: Null port on module (perhaps extraneous comma)
-   49 | module t13(,a,,b,);
+%Warning-NULLPORT: t/t_lint_nullport.v:55:12: Null port on module (perhaps extraneous comma)
+   55 | module t13(,a,,b,);
       |            ^
-%Warning-NULLPORT: t/t_lint_nullport.v:49:15: Null port on module (perhaps extraneous comma)
-   49 | module t13(,a,,b,);
+%Warning-NULLPORT: t/t_lint_nullport.v:55:15: Null port on module (perhaps extraneous comma)
+   55 | module t13(,a,,b,);
       |               ^
-%Warning-NULLPORT: t/t_lint_nullport.v:49:18: Null port on module (perhaps extraneous comma)
-   49 | module t13(,a,,b,);
+%Warning-NULLPORT: t/t_lint_nullport.v:55:18: Null port on module (perhaps extraneous comma)
+   55 | module t13(,a,,b,);
       |                  ^
-%Warning-NULLPORT: t/t_lint_nullport.v:53:12: Null port on module (perhaps extraneous comma)
-   53 | module t14(,a,,b,,);
+%Warning-NULLPORT: t/t_lint_nullport.v:59:12: Null port on module (perhaps extraneous comma)
+   59 | module t14(,a,,b,,);
       |            ^
-%Warning-NULLPORT: t/t_lint_nullport.v:53:15: Null port on module (perhaps extraneous comma)
-   53 | module t14(,a,,b,,);
+%Warning-NULLPORT: t/t_lint_nullport.v:59:15: Null port on module (perhaps extraneous comma)
+   59 | module t14(,a,,b,,);
       |               ^
-%Warning-NULLPORT: t/t_lint_nullport.v:53:18: Null port on module (perhaps extraneous comma)
-   53 | module t14(,a,,b,,);
+%Warning-NULLPORT: t/t_lint_nullport.v:59:18: Null port on module (perhaps extraneous comma)
+   59 | module t14(,a,,b,,);
       |                  ^
-%Warning-NULLPORT: t/t_lint_nullport.v:53:19: Null port on module (perhaps extraneous comma)
-   53 | module t14(,a,,b,,);
+%Warning-NULLPORT: t/t_lint_nullport.v:59:19: Null port on module (perhaps extraneous comma)
+   59 | module t14(,a,,b,,);
       |                   ^
-%Warning-NULLPORT: t/t_lint_nullport.v:57:12: Null port on module (perhaps extraneous comma)
-   57 | module t15(,,a,,b);
+%Warning-NULLPORT: t/t_lint_nullport.v:63:12: Null port on module (perhaps extraneous comma)
+   63 | module t15(,,a,,b);
       |            ^
-%Warning-NULLPORT: t/t_lint_nullport.v:57:13: Null port on module (perhaps extraneous comma)
-   57 | module t15(,,a,,b);
+%Warning-NULLPORT: t/t_lint_nullport.v:63:13: Null port on module (perhaps extraneous comma)
+   63 | module t15(,,a,,b);
       |             ^
-%Warning-NULLPORT: t/t_lint_nullport.v:57:16: Null port on module (perhaps extraneous comma)
-   57 | module t15(,,a,,b);
+%Warning-NULLPORT: t/t_lint_nullport.v:63:16: Null port on module (perhaps extraneous comma)
+   63 | module t15(,,a,,b);
       |                ^
-%Warning-NULLPORT: t/t_lint_nullport.v:61:12: Null port on module (perhaps extraneous comma)
-   61 | module t16(,,a,,b,);
+%Warning-NULLPORT: t/t_lint_nullport.v:67:12: Null port on module (perhaps extraneous comma)
+   67 | module t16(,,a,,b,);
       |            ^
-%Warning-NULLPORT: t/t_lint_nullport.v:61:13: Null port on module (perhaps extraneous comma)
-   61 | module t16(,,a,,b,);
+%Warning-NULLPORT: t/t_lint_nullport.v:67:13: Null port on module (perhaps extraneous comma)
+   67 | module t16(,,a,,b,);
       |             ^
-%Warning-NULLPORT: t/t_lint_nullport.v:61:16: Null port on module (perhaps extraneous comma)
-   61 | module t16(,,a,,b,);
+%Warning-NULLPORT: t/t_lint_nullport.v:67:16: Null port on module (perhaps extraneous comma)
+   67 | module t16(,,a,,b,);
       |                ^
-%Warning-NULLPORT: t/t_lint_nullport.v:61:19: Null port on module (perhaps extraneous comma)
-   61 | module t16(,,a,,b,);
+%Warning-NULLPORT: t/t_lint_nullport.v:67:19: Null port on module (perhaps extraneous comma)
+   67 | module t16(,,a,,b,);
       |                   ^
-%Warning-NULLPORT: t/t_lint_nullport.v:65:12: Null port on module (perhaps extraneous comma)
-   65 | module t17(,,a,,b,,);
+%Warning-NULLPORT: t/t_lint_nullport.v:71:12: Null port on module (perhaps extraneous comma)
+   71 | module t17(,,a,,b,,);
       |            ^
-%Warning-NULLPORT: t/t_lint_nullport.v:65:13: Null port on module (perhaps extraneous comma)
-   65 | module t17(,,a,,b,,);
+%Warning-NULLPORT: t/t_lint_nullport.v:71:13: Null port on module (perhaps extraneous comma)
+   71 | module t17(,,a,,b,,);
       |             ^
-%Warning-NULLPORT: t/t_lint_nullport.v:65:16: Null port on module (perhaps extraneous comma)
-   65 | module t17(,,a,,b,,);
+%Warning-NULLPORT: t/t_lint_nullport.v:71:16: Null port on module (perhaps extraneous comma)
+   71 | module t17(,,a,,b,,);
       |                ^
-%Warning-NULLPORT: t/t_lint_nullport.v:65:19: Null port on module (perhaps extraneous comma)
-   65 | module t17(,,a,,b,,);
+%Warning-NULLPORT: t/t_lint_nullport.v:71:19: Null port on module (perhaps extraneous comma)
+   71 | module t17(,,a,,b,,);
       |                   ^
-%Warning-NULLPORT: t/t_lint_nullport.v:65:20: Null port on module (perhaps extraneous comma)
-   65 | module t17(,,a,,b,,);
+%Warning-NULLPORT: t/t_lint_nullport.v:71:20: Null port on module (perhaps extraneous comma)
+   71 | module t17(,,a,,b,,);
       |                    ^
-%Warning-NULLPORT: t/t_lint_nullport.v:69:12: Null port on module (perhaps extraneous comma)
-   69 | module t18(,);
+%Warning-NULLPORT: t/t_lint_nullport.v:75:12: Null port on module (perhaps extraneous comma)
+   75 | module t18(,);
       |            ^
-%Warning-NULLPORT: t/t_lint_nullport.v:69:13: Null port on module (perhaps extraneous comma)
-   69 | module t18(,);
+%Warning-NULLPORT: t/t_lint_nullport.v:75:13: Null port on module (perhaps extraneous comma)
+   75 | module t18(,);
       |             ^
 %Error: Exiting due to

--- a/test_regress/t/t_lint_nullport.pl
+++ b/test_regress/t/t_lint_nullport.pl
@@ -11,7 +11,8 @@ if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); di
 scenarios(linter => 1);
 
 lint(
-	#    expect_filename => $Self->{golden_filename},
+    fails => 1,
+    expect_filename => $Self->{golden_filename},
     );
 
 ok(1);

--- a/test_regress/t/t_lint_nullport.pl
+++ b/test_regress/t/t_lint_nullport.pl
@@ -1,0 +1,18 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2021 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(linter => 1);
+
+lint(
+	#    expect_filename => $Self->{golden_filename},
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_lint_nullport.v
+++ b/test_regress/t/t_lint_nullport.v
@@ -1,4 +1,10 @@
-/* verilator lint_off MULTITOP */
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2021 by Udi Finkelstein.
+// SPDX-License-Identifier: CC0-1.0
+
+`/* verilator lint_off MULTITOP */
 // First, test we haven't broken normal ports
 module t1();
 endmodule

--- a/test_regress/t/t_lint_nullport.v
+++ b/test_regress/t/t_lint_nullport.v
@@ -4,7 +4,7 @@
 // any use, without warranty, 2021 by Udi Finkelstein.
 // SPDX-License-Identifier: CC0-1.0
 
-`/* verilator lint_off MULTITOP */
+/* verilator lint_off MULTITOP */
 // First, test we haven't broken normal ports
 module t1();
 endmodule

--- a/test_regress/t/t_lint_nullport.v
+++ b/test_regress/t/t_lint_nullport.v
@@ -1,0 +1,74 @@
+/* verilator lint_off MULTITOP */
+// First, test we haven't broken normal ports
+module t1();
+endmodule
+
+module t2;
+endmodule
+
+module t3(a);
+input a;
+endmodule
+
+module t4(a, b);
+input a, b;
+endmodule
+
+module t5(a,);
+input a;
+endmodule
+
+module t6(a,,);
+input a;
+endmodule
+
+module t7(a,b,);
+input a, b;
+endmodule
+
+module t8(a,b,,);
+input a, b;
+endmodule
+
+module t9(a,,b);
+input a, b;
+endmodule
+
+module t10(a,,b,);
+input a, b;
+endmodule
+
+module t11(a,,b,,);
+input a, b;
+endmodule
+
+module t12(,a,,b);
+input a, b;
+endmodule
+
+module t13(,a,,b,);
+input a, b;
+endmodule
+
+module t14(,a,,b,,);
+input a, b;
+endmodule
+
+module t15(,,a,,b);
+input a, b;
+endmodule
+
+module t16(,,a,,b,);
+input a, b;
+endmodule
+
+module t17(,,a,,b,,);
+input a, b;
+endmodule
+
+module t18(,);
+endmodule
+
+/* verilator lint_off NULLPORT */
+module t19(,,);
+endmodule


### PR DESCRIPTION
Here is a very preliminary support for null ports. **It is probably too immature to be merged**, but I would like this to be reviewed.

The intention here is to provide a **full** implementation, by flagging all null port uses with warnings, but actually implement it by setting a regular port whose name is a pure number. Hopefully by doing this it will never get referenced. I really hope that the Verilator code downstream knows how to optimize this out with no runtime impact.

The good parts:
* All possible null port combinations supported (one or more null ports before, between and after normal ports, or any combination of).
* NULLPORT warnings are reported for each null port

The bad parts:
* null port positioning on the warning is inaccurate. Probably an easy fix, but not high priority right now.
* allocation of null port AST elements  is a good guess at best, let alone any thinking about deallocation.

