### PR TITLE
MinGW does not support 'localtime_r'.

### DIFF
--- a/include/verilatedos.h
+++ b/include/verilatedos.h
@@ -500,7 +500,9 @@ typedef unsigned long long vluint64_t;  ///< 64-bit unsigned type
 # define VL_STRCASECMP strcasecmp
 #endif
 
-#ifdef _MSC_VER
+#ifdef __MINGW32__
+# define VL_LOCALTIME_R(timep, tmp) localtime_s((tmp), (timep))
+#elif defined(_MSC_VER)
 # define VL_LOCALTIME_R(timep, tmp) localtime_c((tmp), (timep))
 #else
 # define VL_LOCALTIME_R(timep, tmp) localtime_r((timep), (tmp))


### PR DESCRIPTION
Compilation is failed on MinGW+Msys2 environment(windows).
add 'localtime_s' function macro instead of 'localtime_r'.

