### PR TITLE
Fix package reported as vpiModule

### DIFF
--- a/src/V3EmitCSyms.cpp
+++ b/src/V3EmitCSyms.cpp
@@ -298,11 +298,12 @@ class EmitCSyms final : EmitCBaseVisitor {
         m_scopes.emplace_back(std::make_pair(nodep, m_modp));
 
         if (v3Global.opt.vpi() && !nodep->isTop()) {
+            string type = VN_IS(nodep->modp(), Package) ? "SCOPE_OTHER" : "SCOPE_MODULE";
             string name_dedot = AstNode::dedotName(nodep->shortName());
             int timeunit = m_modp->timeunit().powerOfTen();
             m_vpiScopeCandidates.insert(
                 std::make_pair(nodep->name(), ScopeData(scopeSymString(nodep->name()), name_dedot,
-                                                        timeunit, "SCOPE_MODULE")));
+                                                        timeunit, type)));
         }
     }
     virtual void visit(AstScopeName* nodep) override {

--- a/test_regress/t/t_vpi_module.pl
+++ b/test_regress/t/t_vpi_module.pl
@@ -19,7 +19,7 @@ compile(
     make_pli => 1,
     iv_flags2 => ["-g2005-sv -D USE_VPI_NOT_DPI"],
     v_flags2 => ["+define+USE_VPI_NOT_DPI"],
-    verilator_flags2 => ["-CFLAGS '-DVL_DEBUG -ggdb' --exe --vpi --no-l2name $Self->{t_dir}/t_vpi_module.cpp"],
+    verilator_flags2 => ["-CFLAGS '-DVL_DEBUG -ggdb' --exe --vpi --public-flat-rw --no-l2name $Self->{t_dir}/t_vpi_module.cpp"],
     );
 
 execute(

--- a/test_regress/t/t_vpi_module.pl
+++ b/test_regress/t/t_vpi_module.pl
@@ -19,7 +19,7 @@ compile(
     make_pli => 1,
     iv_flags2 => ["-g2005-sv -D USE_VPI_NOT_DPI"],
     v_flags2 => ["+define+USE_VPI_NOT_DPI"],
-    verilator_flags2 => ["-CFLAGS '-DVL_DEBUG -ggdb' --exe --vpi --public-flat-rw --no-l2name $Self->{t_dir}/t_vpi_module.cpp"],
+    verilator_flags2 => ["-CFLAGS '-DVL_DEBUG -ggdb' --exe --vpi --no-l2name $Self->{t_dir}/t_vpi_module.cpp"],
     );
 
 execute(

--- a/test_regress/t/t_vpi_module.v
+++ b/test_regress/t/t_vpi_module.v
@@ -12,6 +12,10 @@
 import "DPI-C" context function int mon_check();
 `endif
 
+package somepackage;
+   int someint;
+endpackage
+
 module t (/*AUTOARG*/
    // Inputs
    clk

--- a/test_regress/t/t_vpi_module.v
+++ b/test_regress/t/t_vpi_module.v
@@ -13,7 +13,7 @@ import "DPI-C" context function int mon_check();
 `endif
 
 package somepackage;
-   int someint;
+   int someint /*verilator public_flat_rw*/;
 endpackage
 
 module t (/*AUTOARG*/


### PR DESCRIPTION
Without the C++ change I get:
```
%Error: t_vpi_module.cpp:109: GOT = 'somepackage'   EXP = 't'
%Error: t_vpi_module.cpp:109: C Test failed
%Error: t/t_vpi_module.v:57: Verilog $stop
```
because the package scope is marked as a `vpiModule`.

I couldn't reproduce this until I added `-public-flat-rw`.  I imagine that if I make the package's variable public that would work too.  Please let me know which way is preferable.