### PR TITLE
Scope module fix

### DIFF
--- a/src/V3EmitCSyms.cpp
+++ b/src/V3EmitCSyms.cpp
@@ -168,8 +168,6 @@ class EmitCSyms final : EmitCBaseVisitor {
     void varHierarchyScopes(string scp) {
         while (!scp.empty()) {
             const auto scpit = m_vpiScopeCandidates.find(scp);
-            // QUESTION -- why do we search for scp but insert scpit->second.m_symName?
-            // in the case of t_vpi_module those are "TOP.t" and "t" respectively
             if ((scpit != m_vpiScopeCandidates.end())
                 && (m_scopeNames.find(scp) == m_scopeNames.end())) {
                 auto scopeNameit = m_scopeNames.find(scpit->second.m_symName);

--- a/src/V3EmitCSyms.cpp
+++ b/src/V3EmitCSyms.cpp
@@ -168,9 +168,16 @@ class EmitCSyms final : EmitCBaseVisitor {
     void varHierarchyScopes(string scp) {
         while (!scp.empty()) {
             const auto scpit = m_vpiScopeCandidates.find(scp);
+            // QUESTION -- why do we search for scp but insert scpit->second.m_symName?
+            // in the case of t_vpi_module those are "TOP.t" and "t" respectively
             if ((scpit != m_vpiScopeCandidates.end())
                 && (m_scopeNames.find(scp) == m_scopeNames.end())) {
-                m_scopeNames.emplace(scpit->second.m_symName, scpit->second);
+                auto scopeNameit = m_scopeNames.find(scpit->second.m_symName);
+                if (scopeNameit == m_scopeNames.end()) {
+                    m_scopeNames.emplace(scpit->second.m_symName, scpit->second);
+                } else {
+                    scopeNameit->second.m_type = scpit->second.m_type;
+                }
             }
             string::size_type pos = scp.rfind("__DOT__");
             if (pos == string::npos) {
@@ -233,20 +240,20 @@ class EmitCSyms final : EmitCBaseVisitor {
              ++it) {
             if (it->second.m_type != "SCOPE_MODULE") continue;
 
-            string name = it->second.m_prettyName;
-            if (name.substr(0, 4) == "TOP.") name.replace(0, 4, "");
+            string symName = it->second.m_symName;
+            string above = symName;
+            if (above.substr(0, 4) == "TOP.") above.replace(0, 4, "");
 
-            string above = name;
             while (!above.empty()) {
-                string::size_type pos = above.rfind('.');
+                string::size_type pos = above.rfind("__");
                 if (pos == string::npos) break;
                 above.resize(pos);
                 if (m_vpiScopeHierarchy.find(above) != m_vpiScopeHierarchy.end()) {
-                    m_vpiScopeHierarchy[above].push_back(name);
+                    m_vpiScopeHierarchy[above].push_back(symName);
                     break;
                 }
             }
-            m_vpiScopeHierarchy[name] = std::vector<string>();
+            m_vpiScopeHierarchy[symName] = std::vector<string>();
         }
     }
 

--- a/test_regress/t/t_vpi_module.cpp
+++ b/test_regress/t/t_vpi_module.cpp
@@ -92,7 +92,7 @@ int mon_check() {
 
     TestVpiHandle topmod;
     // both somepackage and t exist at the top level
-    while (topmod = vpi_scan(it)) {
+    while ((topmod = vpi_scan(it))) {
         if (vpi_get(vpiType, topmod) == vpiModule) break;
     }
     CHECK_RESULT_NZ(topmod);

--- a/test_regress/t/t_vpi_module.cpp
+++ b/test_regress/t/t_vpi_module.cpp
@@ -90,9 +90,12 @@ int mon_check() {
     // modDump(it, 0);
     // return 1;
 
-    TestVpiHandle topmod = vpi_scan(it);
+    TestVpiHandle topmod;
+    // both somepackage and t exist at the top level
+    while (topmod = vpi_scan(it)) {
+        if (vpi_get(vpiType, topmod) == vpiModule) break;
+    }
     CHECK_RESULT_NZ(topmod);
-    CHECK_RESULT(vpi_get(vpiType, topmod), vpiModule);
 
     const char* t_name = vpi_get_str(vpiName, topmod);
     CHECK_RESULT_NZ(t_name);

--- a/test_regress/t/t_vpi_module.pl
+++ b/test_regress/t/t_vpi_module.pl
@@ -18,7 +18,6 @@ compile(
     make_main => 0,
     make_pli => 1,
     iv_flags2 => ["-g2005-sv -D USE_VPI_NOT_DPI"],
-    v_flags2 => ["+define+USE_VPI_NOT_DPI"],
     verilator_flags2 => ["-CFLAGS '-DVL_DEBUG -ggdb' --exe --vpi --no-l2name $Self->{t_dir}/t_vpi_module.cpp"],
     );
 

--- a/test_regress/t/t_vpi_module.v
+++ b/test_regress/t/t_vpi_module.v
@@ -6,9 +6,7 @@
 // Version 2.0.
 // SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
 
-`ifdef USE_VPI_NOT_DPI
-//We call it via $c so we can verify DPI isn't required - see bug572
-`else
+`ifndef USE_VPI_NOT_DPI
 import "DPI-C" context function int mon_check();
 `endif
 
@@ -43,9 +41,6 @@ extern "C" int mon_check();
 
    // Test loop
    initial begin
-`ifdef VERILATOR
-      status = $c32("mon_check()");
-`endif
 `ifdef IVERILOG
       status = $mon_check();
 `endif

--- a/test_regress/t/t_vpi_module.v
+++ b/test_regress/t/t_vpi_module.v
@@ -6,7 +6,7 @@
 // Version 2.0.
 // SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
 
-`ifndef USE_VPI_NOT_DPI
+`ifndef IVERILOG
 import "DPI-C" context function int mon_check();
 `endif
 
@@ -19,7 +19,7 @@ module t (/*AUTOARG*/
    clk
    );
 
-`ifdef VERILATOR
+`ifdef USE_DOLLAR_C32
 `systemc_header
 extern "C" int mon_check();
 `verilog
@@ -43,8 +43,9 @@ extern "C" int mon_check();
    initial begin
 `ifdef IVERILOG
       status = $mon_check();
-`endif
-`ifndef USE_VPI_NOT_DPI
+`elsif USE_DOLLAR_C32
+      status = $c32("mon_check()");
+`else
       status = mon_check();
 `endif
       if (status!=0) begin

--- a/test_regress/t/t_vpi_module_dpi.pl
+++ b/test_regress/t/t_vpi_module_dpi.pl
@@ -13,12 +13,16 @@ scenarios(simulator => 1);
 skip("Known compiler limitation")
     if $Self->cxx_version =~ /\(GCC\) 4.4/;
 
+VM_PREFIX("Vt_vpi_module");
+top_filename("t/t_vpi_module.v");
+pli_filename("t_vpi_module.cpp");
+
 compile(
     make_top_shell => 0,
     make_main => 0,
     make_pli => 1,
     iv_flags2 => ["-g2005-sv"],
-    verilator_flags2 => ["-CFLAGS '-DVL_DEBUG -ggdb' +define+USE_DOLLAR_C32 --exe --vpi --no-l2name $Self->{t_dir}/t_vpi_module.cpp"],
+    verilator_flags2 => ["-CFLAGS '-DVL_DEBUG -ggdb' --exe --vpi --no-l2name $Self->{t_dir}/t_vpi_module.cpp"],
     );
 
 execute(


### PR DESCRIPTION
Modules with DPI functions are marked as `SCOPE_OTHER` instead of `SCOPE_MODULE`.  This prevents them from being seen when iterating over vpiModule.  I modified `t_vpi_module` to demonstrate this.