### PR TITLE
Fix assertion failure in bitOpTree opt

### DIFF
--- a/src/V3Const.cpp
+++ b/src/V3Const.cpp
@@ -106,10 +106,14 @@ class ConstBitOpTreeVisitor final : public AstNVisitor {
             UASSERT_OBJ(bit < VL_QUADSIZE, m_refp,
                         "bit:" << bit << " is too big after V3Expand"
                                << " back:" << m_refp->backp());
-            if (bit >= m_bitPolarity.width()) {
+            if (bit >= m_bitPolarity.width()) {  // Need to expand m_bitPolarity
                 const V3Number oldPol = std::move(m_bitPolarity);
                 // oldPol.width() is 8, 16, or 32 because this visitor is called after V3Expand
-                const int newWidth = oldPol.width() * 2;
+                // newWidth is increased by 2x because
+                //  - CCast will cast to such bitwidth anyway
+                //  - can avoid frequent expansion
+                int newWidth = oldPol.width();
+                while (bit >= newWidth) newWidth *= 2;
                 m_bitPolarity = V3Number{m_refp, newWidth};
                 UASSERT_OBJ(newWidth == 16 || newWidth == 32 || newWidth == 64, m_refp,
                             "bit:" << bit << " newWidth:" << newWidth);

--- a/src/V3Const.cpp
+++ b/src/V3Const.cpp
@@ -96,11 +96,6 @@ class ConstBitOpTreeVisitor final : public AstNVisitor {
         ConstBitOpTreeVisitor* m_parentp;  // ConstBitOpTreeVisitor that holds this VarInfo
         AstVarRef* m_refp;  // Points the variable that this VarInfo covers
         V3Number m_bitPolarity;  // Coefficient of each bit
-        static int widthOfRef(AstVarRef* refp) {
-            if (AstWordSel* selp = VN_CAST(refp->backp(), WordSel)) return selp->width();
-            if (AstCCast* castp = VN_CAST(refp->backp(), CCast)) return castp->width();
-            return refp->width();
-        }
 
     public:
         // METHODS
@@ -108,6 +103,26 @@ class ConstBitOpTreeVisitor final : public AstNVisitor {
         bool sameVarAs(const AstNodeVarRef* otherp) const { return m_refp->sameGateTree(otherp); }
         void setPolarity(bool compBit, int bit) {
             UASSERT_OBJ(!hasConstantResult(), m_refp, "Already has result of " << m_constResult);
+            UASSERT_OBJ(bit < VL_QUADSIZE, m_refp,
+                        "bit:" << bit << " is too big after V3Expand"
+                               << " back:" << m_refp->backp());
+            if (bit >= m_bitPolarity.width()) {
+                const V3Number oldPol = std::move(m_bitPolarity);
+                // oldPol.width() is 8, 16, or 32 because this visitor is called after V3Expand
+                const int newWidth = oldPol.width() * 2;
+                m_bitPolarity = V3Number{m_refp, newWidth};
+                UASSERT_OBJ(newWidth == 16 || newWidth == 32 || newWidth == 64, m_refp,
+                            "bit:" << bit << " newWidth:" << newWidth);
+                m_bitPolarity.setAllBitsX();
+                for (int i = 0; i < oldPol.width(); ++i) {
+                    if (oldPol.bitIs0(i))
+                        m_bitPolarity.setBit(i, '0');
+                    else if (oldPol.bitIs1(i))
+                        m_bitPolarity.setBit(i, '1');
+                }
+            }
+            UASSERT_OBJ(bit < m_bitPolarity.width(), m_refp,
+                        "bit:" << bit << " width:" << m_bitPolarity.width() << m_refp);
             if (m_bitPolarity.bitIsX(bit)) {  // The bit is not yet set
                 m_bitPolarity.setBit(bit, compBit);
             } else {  // Priviously set the bit
@@ -129,7 +144,7 @@ class ConstBitOpTreeVisitor final : public AstNVisitor {
             FileLine* fl = m_refp->fileline();
             AstNode* srcp = VN_CAST(m_refp->backp(), WordSel);
             if (!srcp) srcp = m_refp;
-            const int width = widthOfRef(m_refp);
+            const int width = m_bitPolarity.width();
 
             if (hasConstantResult())
                 return new AstConst{fl,
@@ -160,7 +175,7 @@ class ConstBitOpTreeVisitor final : public AstNVisitor {
         VarInfo(ConstBitOpTreeVisitor* parent, AstVarRef* refp)
             : m_parentp(parent)
             , m_refp(refp)
-            , m_bitPolarity(refp, widthOfRef(refp)) {
+            , m_bitPolarity(refp, refp->isWide() ? VL_EDATASIZE : refp->width()) {
             m_bitPolarity.setAllBitsX();
         }
     };

--- a/test_regress/t/t_const_opt_cov.pl
+++ b/test_regress/t/t_const_opt_cov.pl
@@ -11,7 +11,7 @@ if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); di
 scenarios(simulator => 1);
 
 compile(
-    verilator_flags2=>["-Wno-UNOPTTHREADS", "--stats", "--coverage"],
+    verilator_flags2=>["-Wno-UNOPTTHREADS", "--stats", "--coverage", "--trace"],
     );
 
 execute(


### PR DESCRIPTION
Second try to repair #2891

Ast such as below caused the issue:
```
     XOR 0x55aed9e5b430 <e104786#> {d70bs} @dt=0x55aed9c4e050@(G/wu32/1)
    1: CCAST 0x55aeda436a10 <e147374#> {d70bs} @dt=0x55aed9c4e050@(G/wu32/1) sz32
    1:1: SHIFTR 0x55aed9e5aec0 <e147371#> {d70bs} @dt=0x55aed9d80f80@(G/wu64/33)
    1:1:1: CCAST 0x55aed9e5af80 <e147361#> {d30cl} @dt=0x55aed9d80f80@(G/wu64/33) sz64
    1:1:1:1: WORDSEL 0x55aeda07ea30 <e336940#> {d30cn} @dt=0x55aed9c4d170@(G/w32)
    1:1:1:1:1: VARREF 0x55aeda435af0 <e147260#> {d30cn} @dt=0x55aed9c3ff20@(w128)p[3:0]  t__DOT__data_i [RV] <- VAR 0x55aed9e48c70 <e2223#> {d23aw} u4=0x1 @dt=0x55aed9c3ff20@(w128)p[3:0]  t__DOT__data_i [VSTATIC]  VAR
    1:1:1:1:2: CONST 0x55aeda07e0a0 <e147261#> {d30ct} @dt=0x55aed9c4d170@(G/w32)  32'h0
    1:1:2: CONST 0x55aed9e59d60 <e147362#> {d70bs} @dt=0x55aed9c4d170@(G/w32)  32'h20
    2: CCAST 0x55aeda436ad0 <e147394#> {d70bs} @dt=0x55aed9c4e050@(G/wu32/1) sz32
    2:1: SHIFTR 0x55aed9e5adf0 <e147391#> {d70bs} @dt=0x55aed9d80f80@(G/wu64/33)
    2:1:1: VARREF 0x55aed9e5a110 <e147381#> {d70bs} @dt=0x55aed9d80f80@(G/wu64/33)  t__DOT__genblk1__BRA__0__KET____DOT__u_bank_data_ecc_check__DOT____Vtogcov__data_i [LV] => VAR 0x55aed9f7dec0 <e27062#> {d70bs} @dt=0x55aed9c3d320@(G/w33)  t__DOT__genblk1__BRA__0__KET____DOT__u_bank_data_ecc_check__DOT____Vtogcov__data_i MODULETEMP
```

The bitwidth of a variable considering casts in tree requires traversing backp().
Instead of doing so, the width of m_bitPolarity is dynamically expanded if necessary.

I ran ext_tests with `--trace` and `--coverage` enabled.