### PR TITLE
expose packed vectors via the VPI

### DIFF
--- a/src/V3EmitCSyms.cpp
+++ b/src/V3EmitCSyms.cpp
@@ -789,7 +789,7 @@ void EmitCSyms::emitSymImp() {
                 }
             }
             //
-            if (pdim > 1 || udim > 1) {
+            if (udim > 1 && (pdim && udim)) {
                 puts("//UNSUP ");  // VerilatedImp can't deal with >2d or packed arrays
             }
             puts(protect("__Vscope_" + it->second.m_scopeName) + ".varInsert(__Vfinal,");

--- a/test_regress/t/t_vpi_get.cpp
+++ b/test_regress/t/t_vpi_get.cpp
@@ -168,6 +168,9 @@ int mon_check_props() {
            {"testout", {24, vpiOutput, 0, vpiPort}, {0, 0, 0, 0}},
            {"sub.subin", {1, vpiInput, 1, vpiPort}, {0, 0, 0, 0}},
            {"sub.subout", {1, vpiOutput, 1, vpiPort}, {0, 0, 0, 0}},
+           {"twobytwo",
+            {2, vpiNoDirection, 0, vpiMemory},
+            {2, vpiNoDirection, 0, vpiMemoryWord}},
            {NULL, {0, 0, 0, 0}, {0, 0, 0, 0}}};
     struct params* value = values;
     while (value->signal) {

--- a/test_regress/t/t_vpi_get.cpp
+++ b/test_regress/t/t_vpi_get.cpp
@@ -168,9 +168,7 @@ int mon_check_props() {
            {"testout", {24, vpiOutput, 0, vpiPort}, {0, 0, 0, 0}},
            {"sub.subin", {1, vpiInput, 1, vpiPort}, {0, 0, 0, 0}},
            {"sub.subout", {1, vpiOutput, 1, vpiPort}, {0, 0, 0, 0}},
-           {"twobytwo",
-            {2, vpiNoDirection, 0, vpiMemory},
-            {2, vpiNoDirection, 0, vpiMemoryWord}},
+           {"twobytwo", {2, vpiNoDirection, 0, vpiMemory}, {2, vpiNoDirection, 0, vpiMemoryWord}},
            {NULL, {0, 0, 0, 0}, {0, 0, 0, 0}}};
     struct params* value = values;
     while (value->signal) {

--- a/test_regress/t/t_vpi_get.v
+++ b/test_regress/t/t_vpi_get.v
@@ -42,12 +42,13 @@ extern "C" int mon_check();
    reg [2:1]    twoone          `PUBLIC_FLAT_RW;
    reg          onetwo [1:2]    `PUBLIC_FLAT_RW;
    reg [2:1]    fourthreetwoone[4:3] `PUBLIC_FLAT_RW;
+   reg [1:0] [1:0] twobytwo     `PUBLIC_FLAT_RW;
 
    integer      status;
 
 `ifdef IVERILOG
    // stop icarus optimizing signals away
-   wire 	redundant = onebit | onetwo[1] | twoone | fourthreetwoone[3];
+   wire 	redundant = onebit | onetwo[1] | twoone | fourthreetwoone[3] | twobytwo;
 `endif
 
    wire         subin  `PUBLIC_FLAT_RD;


### PR DESCRIPTION
I'm not sure what the limitation is in VerilatedImp mentioned in the comment in V3EmitCSyms.cpp.  However, this appears to work.
