### PR TITLE
Public interface params

### DIFF
--- a/src/V3LinkParse.cpp
+++ b/src/V3LinkParse.cpp
@@ -218,6 +218,8 @@ private:
         if (v3Global.opt.publicFlatRW()) {
             switch (nodep->varType()) {
             case AstVarType::VAR:  // FALLTHRU
+            case AstVarType::GPARAM:  // FALLTHRU
+            case AstVarType::LPARAM:  // FALLTHRU
             case AstVarType::PORT:  // FALLTHRU
             case AstVarType::WIRE: nodep->sigUserRWPublic(true); break;
             default: break;

--- a/test_regress/t/t_vpi_get.cpp
+++ b/test_regress/t/t_vpi_get.cpp
@@ -171,6 +171,8 @@ int mon_check_props() {
            {"sub.subout", {1, vpiOutput, 1, vpiPort}, {0, 0, 0, 0}},
            {"sub.subparam", {32, vpiNoDirection, 0, vpiParameter}, {0, 0, 0, 0}},
            {"sub.the_intf.bytesig", {8, vpiNoDirection, 0, vpiReg}, {0, 0, 0, 0}},
+           {"sub.the_intf.param", {32, vpiNoDirection, 0, vpiParameter}, {0, 0, 0, 0}},
+           {"sub.the_intf.lparam", {32, vpiNoDirection, 0, vpiParameter}, {0, 0, 0, 0}},
            {NULL, {0, 0, 0, 0}, {0, 0, 0, 0}}};
     struct params* value = values;
     while (value->signal) {

--- a/test_regress/t/t_vpi_get.cpp
+++ b/test_regress/t/t_vpi_get.cpp
@@ -163,17 +163,20 @@ int mon_check_props() {
            {"fourthreetwoone",
             {2, vpiNoDirection, 0, vpiMemory},
             {2, vpiNoDirection, 0, vpiMemoryWord}},
+           {"theint", {32, vpiNoDirection, 0, vpiReg}, {0, 0, 0, 0}},
            {"clk", {1, vpiInput, 1, vpiPort}, {0, 0, 0, 0}},
            {"testin", {16, vpiInput, 0, vpiPort}, {0, 0, 0, 0}},
            {"testout", {24, vpiOutput, 0, vpiPort}, {0, 0, 0, 0}},
            {"sub.subin", {1, vpiInput, 1, vpiPort}, {0, 0, 0, 0}},
            {"sub.subout", {1, vpiOutput, 1, vpiPort}, {0, 0, 0, 0}},
+           {"sub.subparam", {32, vpiNoDirection, 0, vpiParameter}, {0, 0, 0, 0}},
+           {"sub.the_intf.bytesig", {8, vpiNoDirection, 0, vpiReg}, {0, 0, 0, 0}},
            {NULL, {0, 0, 0, 0}, {0, 0, 0, 0}}};
     struct params* value = values;
     while (value->signal) {
         TestVpiHandle h = VPI_HANDLE(value->signal);
-        CHECK_RESULT_NZ(h);
         TEST_MSG("%s\n", value->signal);
+        CHECK_RESULT_NZ(h);
         if (int status = _mon_check_props(h, value->attributes.size, value->attributes.direction,
                                           value->attributes.scalar, value->attributes.type))
             return status;

--- a/test_regress/t/t_vpi_get.v
+++ b/test_regress/t/t_vpi_get.v
@@ -23,6 +23,7 @@ import "DPI-C" function void dpi_print(input string somestring);
 `endif
 
 interface intf #(parameter int param `PUBLIC_FLAT_RD = 7);
+   localparam int lparam `PUBLIC_FLAT_RD = param + 1;
    logic [7:0] bytesig `PUBLIC_FLAT_RD;
 endinterface
 

--- a/test_regress/t/t_vpi_get.v
+++ b/test_regress/t/t_vpi_get.v
@@ -22,6 +22,10 @@ import "DPI-C" function void dpi_print(input string somestring);
  `define PUBLIC_FLAT_RW
 `endif
 
+interface intf #(parameter int param `PUBLIC_FLAT_RD = 7);
+   logic [7:0] bytesig `PUBLIC_FLAT_RD;
+endinterface
+
 module t (/*AUTOARG*/
    // Inputs
    input clk                            `PUBLIC_FLAT_RD,
@@ -42,6 +46,8 @@ extern "C" int mon_check();
    reg [2:1]    twoone          `PUBLIC_FLAT_RW;
    reg          onetwo [1:2]    `PUBLIC_FLAT_RW;
    reg [2:1]    fourthreetwoone[4:3] `PUBLIC_FLAT_RW;
+   reg [1:0] [1:0] twobytwo     `PUBLIC_FLAT_RW;
+   int          theint          `PUBLIC_FLAT_RW;
 
    integer      status;
 
@@ -67,7 +73,7 @@ extern "C" int mon_check();
      status = mon_check();
 `endif
       if (status!=0) begin
-	 $write("%%Error: t_vpi_var.cpp:%0d: C Test failed\n", status);
+	 $write("%%Error: t_vpi_get.cpp:%0d: C Test failed\n", status);
 	 $stop;
       end
       $write("*-* All Finished *-*\n");
@@ -76,8 +82,11 @@ extern "C" int mon_check();
 
 endmodule : t
 
-module sub (
+module sub #(
+   parameter int subparam `PUBLIC_FLAT_RD = 2
+) (
    input  subin  `PUBLIC_FLAT_RD,
    output subout `PUBLIC_FLAT_RD
 );
+   intf the_intf();
 endmodule : sub


### PR DESCRIPTION
--public-flat-rw didn't auto-mark interface parameters and localparams as public.  In the process of testing this I discovered that a number of vpi_get() calls weren't working for parameters because we were casting to `VerilatedVpioVar`.  I created a base class (`VerilatedVpioVarBase`) for the overlap between vars and params to handle this.

If desired I can break this out into two commits.