### PR TITLE
Fix bounds check in VL_SEL_IWII

### DIFF
--- a/include/verilated.h
+++ b/include/verilated.h
@@ -2705,7 +2705,7 @@ static inline IData VL_BITSEL_IWII(int, int lbits, int, int, WDataInP lwp, IData
 static inline IData VL_SEL_IWII(int, int lbits, int, int, WDataInP lwp, IData lsb,
                                 IData width) VL_MT_SAFE {
     int msb = lsb + width - 1;
-    if (VL_UNLIKELY(msb > lbits)) {
+    if (VL_UNLIKELY(msb >= lbits)) {
         return ~0;  // Spec says you can go outside the range of a array.  Don't coredump if so.
     } else if (VL_BITWORD_E(msb) == VL_BITWORD_E(static_cast<int>(lsb))) {
         return VL_BITRSHIFT_W(lwp, lsb);

--- a/test_regress/t/t_emit_constw.v
+++ b/test_regress/t/t_emit_constw.v
@@ -62,7 +62,7 @@ module t (/*AUTOARG*/
 			 ^ bytehash(w17));
    // verilator lint_on WIDTH
 
-`define EXPECTED_SUM 64'hb6fdb64085fc17f5
+`define EXPECTED_SUM 64'h2bc7c2a98a302891
 
    // Test loop
    always @ (posedge clk) begin


### PR DESCRIPTION
This is a fix for a bug in the function `VL_SEL_IWII` in `verilated.h`, specifically in this line: https://github.com/verilator/verilator/blob/422c076fec475a0cdfee613c6d664e97fe565cd5/include/verilated.h#L2708. There's a greater-than comparison instead of greater or equal, which causes this function to go out of bounds of the array, thus accessing whatever is in memory after it.

I attached a small test case that demonstrates the issue. Keep in mind that the `--Ox` flag is necessary for the bug to occur.
If you look at its output, at the end the values of `w4[121 :+ 8]` and `w4_2[121 :+ 8]` differ in the most significant bit, and that's only because the least significant bit of their respective following arrays is different.

[t_sel_bad.zip](https://github.com/verilator/verilator/files/6400830/t_sel_bad.zip)