### PR TITLE
Speed up V3Width by pulling skip condition before node iteration.

### DIFF
--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -6125,6 +6125,7 @@ private:
     }
     void userIterateAndNext(AstNode* nodep, WidthVP* vup) {
         if (!nodep) return;
+        if (nodep->didWidth()) return;  // Avoid iterating list we have already iterated
         {
             VL_RESTORER(m_vup);
             m_vup = vup;


### PR DESCRIPTION
This speeds up verilation of a large private design by about 35%. It essentially eliminates a lot of calls to `iterateAndNext`  and `V3Width::visit(Ast...DType* nodep)`, all of which simply return anyway when `didWidth` is already set. I think this is safe based on reading what the visitors do and how they are used, but please confirm.