### PR TITLE
VPI memory acces for packed arrays

### DIFF
--- a/test_regress/t/TestSimulator.h
+++ b/test_regress/t/TestSimulator.h
@@ -29,12 +29,14 @@ public:
         vpi_get_vlog_info(&m_info);
         if (0 == strcmp(m_info.product, "Verilator")) {
             m_simulators.verilator = true;
-        } else if (0 == strcmp(m_info.product, "Verilator")) {
+        } else if (0 == strcmp(m_info.product, "Icarus Verilog")) {
             m_simulators.icarus = true;
         } else if (0
                    == strncmp(m_info.product, "Chronologic Simulation VCS",
                               strlen("Chronologic Simulation VCS"))) {
             m_simulators.vcs = true;
+        } else if (0 == strcmp(m_info.product, "xmsim(64)")) {
+            m_simulators.ncsim = true;
         } else {
             printf("%%Warning: %s:%d: Unknown simulator in TestSimulator.h: %s\n", __FILE__,
                    __LINE__, m_info.product);
@@ -62,7 +64,7 @@ public:
     static bool has_get_scalar() { return !simulators().icarus; }
     // return test level scope
     static const char* top() {
-        if (simulators().verilator) {
+        if (simulators().verilator || simulators().ncsim) {
             return "t";
         } else {
             return "top.t";

--- a/test_regress/t/t_vpi_get.cpp
+++ b/test_regress/t/t_vpi_get.cpp
@@ -173,7 +173,7 @@ int mon_check_props() {
            {"sub.the_intf.bytesig", {8, vpiNoDirection, 0, vpiReg}, {0, 0, 0, 0}},
            {"sub.the_intf.param", {32, vpiNoDirection, 0, vpiParameter}, {0, 0, 0, 0}},
            {"sub.the_intf.lparam", {32, vpiNoDirection, 0, vpiParameter}, {0, 0, 0, 0}},
-           {"twobytwo", {2, vpiNoDirection, 0, vpiMemory}, {2, vpiNoDirection, 0, vpiMemoryWord}},
+           {"twobytwo", {4, vpiNoDirection, 0, vpiReg}, {0, 0, 0, 0}},
            {NULL, {0, 0, 0, 0}, {0, 0, 0, 0}}};
     struct params* value = values;
     while (value->signal) {

--- a/test_regress/t/t_vpi_memory.v
+++ b/test_regress/t/t_vpi_memory.v
@@ -25,31 +25,42 @@ extern "C" int mon_check();
 
    input clk;
 
+   typedef logic [31:0] word_t;
    reg [31:0] mem0 [16:1] /*verilator public_flat_rw @(posedge clk) */;
+   reg [16:1] [31:0] memp32 /*verilator public_flat_rw @(posedge clk) */;
+   reg [16:1] [30:0] memp31 /*verilator public_flat_rw @(posedge clk) */;
+   reg [15:1] [32:0] memp33 /*verilator public_flat_rw @(posedge clk) */;
+   word_t [16:1] memw /*verilator public_flat_rw @(posedge clk) */;
    integer 	  i, status;
+
+`define CHECK_MEM(mem, words) \
+      for (i = words; i > 0; i--) \
+	if (integer'(mem[i]) !== i) begin \
+          $write("%%Error: %s[%d] : GOT = %d  EXP = %d\n", `"mem`", i, mem[i], i); \
+	  status = -1; \
+        end
 
    // Test loop
    initial begin
 `ifdef VERILATOR
       status = $c32("mon_check()");
-`endif
-`ifdef IVERILOG
+`else
      status = $mon_check();
 `endif
 `ifndef USE_VPI_NOT_DPI
      status = mon_check();
 `endif
       if (status!=0) begin
-	 $write("%%Error: t_vpi_var.cpp:%0d: C Test failed\n", status);
+	 $write("%%Error: t_vpi_memory.cpp:%0d: C Test failed\n", status);
 	 $stop;
       end
-      for (i = 16; i > 0; i--)
-	if (mem0[i] !== i) begin
-          $write("%%Error: %d : GOT = %d  EXP = %d\n", i, mem0[i], i);
-	  status = 1;
-        end
+      `CHECK_MEM(mem0, 16)
+      `CHECK_MEM(memp32, 16)
+      `CHECK_MEM(memp31, 16)
+      `CHECK_MEM(memp33, 15)
+      `CHECK_MEM(memw, 16)
       if (status!=0) begin
-	 $write("%%Error: t_vpi_var.cpp:%0d: C Test failed\n", status);
+	 $write("%%Error: t_vpi_memory.cpp:%0d: C Test failed\n", status);
 	 $stop;
       end
       $write("*-* All Finished *-*\n");


### PR DESCRIPTION
I should have actually tested VPI signal access for packed vectors in #2900.  `t_vpi_memory` does this now and without the C++ change will only work for packed vectors with a width that just happens to be a multiple of 32 bits.  This is because:
```
    VerilatedVpioMemoryWord(const VerilatedVar* varp, const VerilatedScope* scopep,
                            vlsint32_t index, int offset)
        : VerilatedVpioVar{varp, scopep} {
        m_index = index;
        m_varDatap = (static_cast<vluint8_t*>(varp->datap())) + entSize() * offset;
    }
```
where `m_varDatap` assumes nicely aligned memory words.

I first went down the path of fully supporting memory words from packed vectors via the VPI.  However:
- this is clearly a pretty involved project
- many of these VPI tests need additional help to work with Icarus or other simulators
- 36.12.1 makes it sound like we shouldn't even be using `vpiMemory` anymore and instead should be using `vpiRegArray`

All of this led me to this far simpler, yet not-quite-correct implementation.  Basically, this exposes packed vectors as `vpiReg` instead of `vpiMemory` or `vpiRegArray`.  So while it isn't the correct VPI type, it does correctly expose access to the signal so long as the user is capable of handling the bit packing.  I haven't tested it, but I imagine this is basically the same boat we're in for structures which I believe should be exposed as `vpiStructure` but aren't.

So, I'd argue that this is better than pre-#2900 where we couldn't access packed vectors via the VPI at all and that it's better than the current state which is just broken.  However, if you don't buy this, I can head back to my first approach.
