### PR TITLE
Internals: Remove VerilatedVcd::m_suffixesp

### DIFF
--- a/include/verilated_vcd_c.cpp
+++ b/include/verilated_vcd_c.cpp
@@ -99,7 +99,6 @@ VerilatedVcd::VerilatedVcd(VerilatedVcdFile* filep) {
     m_wrBufp = new char[m_wrChunkSize * 8];
     m_wrFlushp = m_wrBufp + m_wrChunkSize * 6;
     m_writep = m_wrBufp;
-    m_suffixesp = nullptr;
 }
 
 void VerilatedVcd::open(const char* filename) VL_MT_SAFE_EXCLUDES(m_mutex) {
@@ -113,9 +112,6 @@ void VerilatedVcd::open(const char* filename) VL_MT_SAFE_EXCLUDES(m_mutex) {
     if (!isOpen()) return;
 
     dumpHeader();
-
-    // Get the direct access pointer to the code strings
-    m_suffixesp = &m_suffixes[0];  // Note: C++11 m_suffixes.data();
 
     // When using rollover, the first chunk contains the header only.
     if (m_rolloverMB) openNextImp(true);
@@ -610,7 +606,7 @@ static inline void VerilatedVcdCCopyAndAppendNewLine(char* writep, const char* s
 }
 
 void VerilatedVcd::finishLine(vluint32_t code, char* writep) {
-    const char* const suffixp = m_suffixesp + code * VL_TRACE_SUFFIX_ENTRY_SIZE;
+    const char* const suffixp = m_suffixes.data() + code * VL_TRACE_SUFFIX_ENTRY_SIZE;
     VerilatedVcdCCopyAndAppendNewLine(writep, suffixp);
 
     // Now write back the write pointer incremented by the actual size of the

--- a/include/verilated_vcd_c.h
+++ b/include/verilated_vcd_c.h
@@ -80,7 +80,6 @@ private:
     vluint64_t m_wroteBytes = 0;  // Number of bytes written to this file
 
     std::vector<char> m_suffixes;  // VCD line end string codes + metadata
-    const char* m_suffixesp;  // Pointer to first element of above
 
     using NameMap = std::map<const std::string, const std::string>;
     NameMap* m_namemapp = nullptr;  // List of names for the header


### PR DESCRIPTION
This is the last piece factored out from #2923 .

Reasons are:
- it's error prone to keep updating whennever m_suffixes is resized
- invalid pointer may be set when there is not signal to trace as in t_trace_dumporder_bad

Using `data()` instead of `&[0]` resolves the latter, but I think removing it is more simple.