### PR TITLE
Internals: Mark VerilatedContextImp::timeFormatSuffix() const

### DIFF
--- a/include/verilated_imp.h
+++ b/include/verilated_imp.h
@@ -245,7 +245,7 @@ public:  // But only for verilated*.cpp
     static vluint32_t randSeedEpoch() VL_MT_SAFE { return s().s_randSeedEpoch; }
 
     // METHODS - timeformat
-    int timeFormatUnits() VL_MT_SAFE {
+    int timeFormatUnits() const VL_MT_SAFE {
         if (m_s.m_timeFormatUnits == VerilatedContext::Serialized::UNITS_NONE)
             return timeprecision();
         return m_s.m_timeFormatUnits;

--- a/include/verilated_imp.h
+++ b/include/verilated_imp.h
@@ -255,7 +255,7 @@ public:  // But only for verilated*.cpp
     void timeFormatPrecision(int value) VL_MT_SAFE { m_s.m_timeFormatPrecision = value; }
     int timeFormatWidth() const VL_MT_SAFE { return m_s.m_timeFormatWidth; }
     void timeFormatWidth(int value) VL_MT_SAFE { m_s.m_timeFormatWidth = value; }
-    std::string timeFormatSuffix() VL_MT_SAFE_EXCLUDES(m_timeDumpMutex) {
+    std::string timeFormatSuffix() const VL_MT_SAFE_EXCLUDES(m_timeDumpMutex) {
         const VerilatedLockGuard lock(m_timeDumpMutex);
         return m_timeFormatSuffix;
     }


### PR DESCRIPTION
I think the function can be marked `const`.
I guess `m_timeDumpMutex` is mutable because the mutex can be used in const functions.

BTW technically saying, other accessors such as timeFormatWidth()  should use mutex too because m_timeFormatWidth is not std::atomic. (Or they could be guarded by mutex in its caller, not sure.)