### PR TITLE
Don't merge bit select assignments in C code

### DIFF
--- a/Changes
+++ b/Changes
@@ -14,6 +14,7 @@ Verilator 4.203 devel
 **Minor:**
 
 * Fix initialization of assoc in assoc array (#2914). [myftptoyman]
+* Fix merging of assignments in C++ code (#2970). [Ruper Swarbrick]
 
 
 Verilator 4.202 2021-04-24

--- a/src/V3Const.cpp
+++ b/src/V3Const.cpp
@@ -1719,7 +1719,7 @@ private:
             VL_DO_DANGLING(streamp->deleteTree(), streamp);
             // Further reduce, any of the nodes may have more reductions.
             return true;
-        } else if (replaceAssignMultiSel(nodep)) {
+        } else if (m_doV && replaceAssignMultiSel(nodep)) {
             return true;
         }
         return false;

--- a/test_regress/t/t_no_sel_assign_merge_in_cpp.pl
+++ b/test_regress/t/t_no_sel_assign_merge_in_cpp.pl
@@ -1,0 +1,16 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2021 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(vlt => 1);
+
+lint();
+
+ok(1);
+1;

--- a/test_regress/t/t_no_sel_assign_merge_in_cpp.v
+++ b/test_regress/t/t_no_sel_assign_merge_in_cpp.v
@@ -1,0 +1,14 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2021 by Wilson Snyder.
+// SPDX-License-Identifier: CC0-1.0
+
+module t_no_sel_assign_merge_in_cpp (
+  input  wire [(8*39)-1:0] d_i,
+  output wire [(8*32)-1:0] d_o
+);
+  for (genvar i = 0; i < 8; i = i + 1) begin
+    assign d_o[i*32 +: 32] = d_i[i*39 +: 32];
+  end
+endmodule


### PR DESCRIPTION
Fixes #2970. The bug is caused by the optimzation enabled by 4f36e3e, merging the temporary added in V3Premit for wide ops into a concatenation when running `V3Const::constifyCpp` after V3Premit. This fix simply disables this optimisation when running the constant folder on lowered C++ code.

@wsnyder Intuitively I am under the impression that AstSel should not be present on the left hand side of an assignment by this stage (as in C++ you can only assign to whole words), should not these have been converted to AstWordSel?