### PR TITLE
Internals: Move --coverage and --savable check out of V3EmitC

### DIFF
--- a/src/V3EmitC.cpp
+++ b/src/V3EmitC.cpp
@@ -3120,10 +3120,7 @@ void EmitCImp::emitIntTop(AstNodeModule*) {
     }
     if (v3Global.opt.mtasks()) puts("#include \"verilated_threads.h\"\n");
     if (v3Global.opt.savable()) puts("#include \"verilated_save.h\"\n");
-    if (v3Global.opt.coverage()) {
-        puts("#include \"verilated_cov.h\"\n");
-        if (v3Global.opt.savable()) v3error("--coverage and --savable not supported together");
-    }
+    if (v3Global.opt.coverage()) puts("#include \"verilated_cov.h\"\n");
     if (v3Global.dpi()) {
         // do this before including our main .h file so that any references to
         // types defined in svdpi.h are available

--- a/src/V3Options.cpp
+++ b/src/V3Options.cpp
@@ -787,6 +787,10 @@ void V3Options::notify() {
         cmdfl->v3warn(E_UNSUPPORTED,
                       "--main not usable with SystemC. Suggest see examples for sc_main().");
     }
+
+    if (coverage() && savable()) {
+        cmdfl->v3error("--coverage and --savable not supported together");
+    }
 }
 
 //######################################################################


### PR DESCRIPTION
Boring nit, will merge when CI is passing.