### PR TITLE
pragma once for DPI headers

### DIFF
--- a/src/V3EmitCSyms.cpp
+++ b/src/V3EmitCSyms.cpp
@@ -875,6 +875,7 @@ void EmitCSyms::emitDpiHdr() {
     puts("// Manually include this file where DPI .c import functions are declared to ensure\n");
     puts("// the C functions match the expectations of the DPI imports.\n");
     puts("\n");
+    puts("#pragma once\n");
     puts("#include \"svdpi.h\"\n");
     puts("\n");
     puts("#ifdef __cplusplus\n");

--- a/test_regress/t/t_dpi_arg_inout_type__Dpi.out
+++ b/test_regress/t/t_dpi_arg_inout_type__Dpi.out
@@ -5,6 +5,7 @@
 // Manually include this file where DPI .c import functions are declared to ensure
 // the C functions match the expectations of the DPI imports.
 
+#pragma once
 #include "svdpi.h"
 
 #ifdef __cplusplus

--- a/test_regress/t/t_dpi_arg_inout_unpack__Dpi.out
+++ b/test_regress/t/t_dpi_arg_inout_unpack__Dpi.out
@@ -5,6 +5,7 @@
 // Manually include this file where DPI .c import functions are declared to ensure
 // the C functions match the expectations of the DPI imports.
 
+#pragma once
 #include "svdpi.h"
 
 #ifdef __cplusplus

--- a/test_regress/t/t_dpi_arg_input_type__Dpi.out
+++ b/test_regress/t/t_dpi_arg_input_type__Dpi.out
@@ -5,6 +5,7 @@
 // Manually include this file where DPI .c import functions are declared to ensure
 // the C functions match the expectations of the DPI imports.
 
+#pragma once
 #include "svdpi.h"
 
 #ifdef __cplusplus

--- a/test_regress/t/t_dpi_arg_input_unpack__Dpi.out
+++ b/test_regress/t/t_dpi_arg_input_unpack__Dpi.out
@@ -5,6 +5,7 @@
 // Manually include this file where DPI .c import functions are declared to ensure
 // the C functions match the expectations of the DPI imports.
 
+#pragma once
 #include "svdpi.h"
 
 #ifdef __cplusplus

--- a/test_regress/t/t_dpi_arg_output_type__Dpi.out
+++ b/test_regress/t/t_dpi_arg_output_type__Dpi.out
@@ -5,6 +5,7 @@
 // Manually include this file where DPI .c import functions are declared to ensure
 // the C functions match the expectations of the DPI imports.
 
+#pragma once
 #include "svdpi.h"
 
 #ifdef __cplusplus

--- a/test_regress/t/t_dpi_arg_output_unpack__Dpi.out
+++ b/test_regress/t/t_dpi_arg_output_unpack__Dpi.out
@@ -5,6 +5,7 @@
 // Manually include this file where DPI .c import functions are declared to ensure
 // the C functions match the expectations of the DPI imports.
 
+#pragma once
 #include "svdpi.h"
 
 #ifdef __cplusplus

--- a/test_regress/t/t_dpi_result_type__Dpi.out
+++ b/test_regress/t/t_dpi_result_type__Dpi.out
@@ -5,6 +5,7 @@
 // Manually include this file where DPI .c import functions are declared to ensure
 // the C functions match the expectations of the DPI imports.
 
+#pragma once
 #include "svdpi.h"
 
 #ifdef __cplusplus


### PR DESCRIPTION
DPI header files are sometimes included by another file multiple times.  This happened so much so that it was causing issues with some of our file servers.  `#pragma once` resolved the issue.
