### PR TITLE
Add support of --trace-structs parameter for CMake (#2985)

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -55,6 +55,7 @@ Marco Widmer
 Markus Krause
 Marlon James
 Marshal Qiao
+Martin Schmidt
 Matthew Ballance
 Michael Killough
 Mike Popoloski

--- a/src/V3EmitCMake.cpp
+++ b/src/V3EmitCMake.cpp
@@ -115,6 +115,8 @@ class CMakeEmitter final {
         cmake_set_raw(*of, name + "_THREADS", cvtToStr(v3Global.opt.threads()));
         *of << "# Threaded tracing output mode?  0/1/N threads (from --trace-threads)\n";
         cmake_set_raw(*of, name + "_TRACE_THREADS", cvtToStr(v3Global.opt.traceThreads()));
+        *of << "# Struct output mode?  0/1 (from --trace-structs)\n";
+        cmake_set_raw(*of, name + "_TRACE_STRUCTS", cvtToStr(v3Global.opt.traceStructs()));
         *of << "# VCD Tracing output mode?  0/1 (from --trace)\n";
         cmake_set_raw(*of, name + "_TRACE_VCD",
                       (v3Global.opt.trace() && (v3Global.opt.traceFormat() == TraceFormat::VCD))

--- a/verilator-config.cmake.in
+++ b/verilator-config.cmake.in
@@ -119,8 +119,15 @@ define_property(TARGET
   FULL_DOCS "Verilator SystemC enabled"
 )
 
+define_property(TARGET
+    PROPERTY VERILATOR_TRACE_STRUCTS
+    BRIEF_DOCS "Verilator trace structs enabled"
+    FULL_DOCS "Verilator trace structs enabled"
+)
+
+
 function(verilate TARGET)
-  cmake_parse_arguments(VERILATE "COVERAGE;TRACE;TRACE_FST;SYSTEMC"
+  cmake_parse_arguments(VERILATE "COVERAGE;TRACE;TRACE_FST;SYSTEMC;TRACE_STRUCTS"
                                  "PREFIX;TOP_MODULE;THREADS;TRACE_THREADS;DIRECTORY"
                                  "SOURCES;VERILATOR_ARGS;INCLUDE_DIRS;OPT_SLOW;OPT_FAST;OPT_GLOBAL"
                                  ${ARGN})
@@ -166,6 +173,10 @@ function(verilate TARGET)
     list(APPEND VERILATOR_ARGS --sc)
   else()
     list(APPEND VERILATOR_ARGS --cc)
+  endif()
+
+  if (VERILATE_TRACE_STRUCTS)
+      list(APPEND VERILATOR_ARGS --trace-structs)
   endif()
 
   foreach(INC ${VERILATE_INCLUDE_DIRS})
@@ -275,6 +286,10 @@ function(verilate TARGET)
   if (${VERILATE_PREFIX}_SC)
     # If any verilate() call specifies SYSTEMC, define VM_SC in the final build
     set_property(TARGET ${TARGET} PROPERTY VERILATOR_SYSTEMC ON)
+  endif()
+
+  if (${VERILATE_PREFIX}_TRACE_STRUCTS)
+    set_property(TARGET ${TARGET} PROPERTY VERILATOR_TRACE_STRUCTS ON)
   endif()
 
     # Add the compile flags only on Verilated sources


### PR DESCRIPTION
Add support for `TRACE_STRUCTS` to the CMake's `verilate` function.
Also enable the `--build` option to properly generate a CMakeLists.txt with the `TRACE_STRUCTS` set.

Fixes #2985 
