### PR TITLE
Emit: Fix indent tracking when // inside string literal

### DIFF
--- a/src/V3File.cpp
+++ b/src/V3File.cpp
@@ -715,9 +715,13 @@ void V3OutFormatter::puts(const char* strg) {
             break;
         case ' ': wordstart = true; break;
         case '\t': wordstart = true; break;
+        case '"':
+            wordstart = false;
+            m_inStringLiteral = !m_inStringLiteral;
+            break;
         case '/':
             if (m_lang == LA_C || m_lang == LA_VERILOG) {
-                if (cp > strg && cp[-1] == '/') {
+                if (cp > strg && cp[-1] == '/' && !m_inStringLiteral) {
                     // Output ignoring contents to EOL
                     cp++;
                     while (*cp && cp[1] && cp[1] != '\n') putcNoTracking(*cp++);

--- a/src/V3File.h
+++ b/src/V3File.h
@@ -121,6 +121,7 @@ private:
     int m_column = 0;
     int m_nobreak = false;  // Basic operator or begin paren, don't break next
     bool m_prependIndent = true;
+    bool m_inStringLiteral = false;
     int m_indentLevel = 0;  // Current {} indentation
     std::stack<int> m_parenVec;  // Stack of columns where last ( was
     int m_bracketLevel = 0;  // Intenting = { block, indicates number of {'s seen.


### PR DESCRIPTION
Trivial cosmetics. Will merge when CI passing.

// was so far unconditionally treated as comment.
c443e229eea8473d755e43c9f0c914a796898948 introduced a string literal in
the output that contained a http:// url, which broke the indent
tracking. No functional change intended.
