### PR TITLE
Fix unused variable warnings

### DIFF
--- a/include/verilated.h
+++ b/include/verilated.h
@@ -2491,6 +2491,8 @@ static inline IData VL_SHIFTL_IIW(int obits, int, int rbits, IData lhs, WDataInP
 }
 static inline IData VL_SHIFTL_IIQ(int obits, int lbits, int rbits, IData lhs,
                                   QData rhs) VL_MT_SAFE {
+    (void)lbits;
+    (void)rbits;
     if (VL_UNLIKELY(rhs >= VL_IDATASIZE)) return 0;
     return VL_CLEAN_II(obits, obits, lhs << rhs);
 }
@@ -2505,6 +2507,8 @@ static inline QData VL_SHIFTL_QQW(int obits, int, int rbits, QData lhs, WDataInP
 }
 static inline QData VL_SHIFTL_QQQ(int obits, int lbits, int rbits, QData lhs,
                                   QData rhs) VL_MT_SAFE {
+    (void)lbits;
+    (void)rbits;
     if (VL_UNLIKELY(rhs >= VL_QUADSIZE)) return 0;
     return VL_CLEAN_QQ(obits, obits, lhs << rhs);
 }
@@ -2570,10 +2574,12 @@ static inline QData VL_SHIFTR_QQW(int obits, int, int rbits, QData lhs, WDataInP
     return VL_CLEAN_QQ(obits, obits, lhs >> (static_cast<QData>(rwp[0])));
 }
 static inline IData VL_SHIFTR_IIQ(int obits, int, int rbits, IData lhs, QData rhs) VL_MT_SAFE {
+    (void)rbits;
     if (VL_UNLIKELY(rhs >= VL_IDATASIZE)) return 0;
     return VL_CLEAN_QQ(obits, obits, lhs >> rhs);
 }
 static inline QData VL_SHIFTR_QQQ(int obits, int, int rbits, QData lhs, QData rhs) VL_MT_SAFE {
+    (void)rbits;
     if (VL_UNLIKELY(rhs >= VL_QUADSIZE)) return 0;
     return VL_CLEAN_QQ(obits, obits, lhs >> rhs);
 }

--- a/include/verilated.h
+++ b/include/verilated.h
@@ -2567,13 +2567,11 @@ static inline QData VL_SHIFTR_QQW(int obits, int, int rbits, QData lhs, WDataInP
     // Above checks rwp[1]==0 so not needed in below shift
     return VL_CLEAN_QQ(obits, obits, lhs >> (static_cast<QData>(rwp[0])));
 }
-static inline IData VL_SHIFTR_IIQ(int obits, int, int rbits, IData lhs, QData rhs) VL_MT_SAFE {
-    (void)rbits;
+static inline IData VL_SHIFTR_IIQ(int obits, int, int, IData lhs, QData rhs) VL_MT_SAFE {
     if (VL_UNLIKELY(rhs >= VL_IDATASIZE)) return 0;
     return VL_CLEAN_QQ(obits, obits, lhs >> rhs);
 }
-static inline QData VL_SHIFTR_QQQ(int obits, int, int rbits, QData lhs, QData rhs) VL_MT_SAFE {
-    (void)rbits;
+static inline QData VL_SHIFTR_QQQ(int obits, int, int, QData lhs, QData rhs) VL_MT_SAFE {
     if (VL_UNLIKELY(rhs >= VL_QUADSIZE)) return 0;
     return VL_CLEAN_QQ(obits, obits, lhs >> rhs);
 }

--- a/include/verilated.h
+++ b/include/verilated.h
@@ -2489,8 +2489,7 @@ static inline IData VL_SHIFTL_IIW(int obits, int, int rbits, IData lhs, WDataInP
     }
     return VL_CLEAN_II(obits, obits, lhs << rwp[0]);
 }
-static inline IData VL_SHIFTL_IIQ(int obits, int, int, IData lhs,
-                                  QData rhs) VL_MT_SAFE {
+static inline IData VL_SHIFTL_IIQ(int obits, int, int, IData lhs, QData rhs) VL_MT_SAFE {
     if (VL_UNLIKELY(rhs >= VL_IDATASIZE)) return 0;
     return VL_CLEAN_II(obits, obits, lhs << rhs);
 }
@@ -2503,8 +2502,7 @@ static inline QData VL_SHIFTL_QQW(int obits, int, int rbits, QData lhs, WDataInP
     // Above checks rwp[1]==0 so not needed in below shift
     return VL_CLEAN_QQ(obits, obits, lhs << (static_cast<QData>(rwp[0])));
 }
-static inline QData VL_SHIFTL_QQQ(int obits, int, int, QData lhs,
-                                  QData rhs) VL_MT_SAFE {
+static inline QData VL_SHIFTL_QQQ(int obits, int, int, QData lhs, QData rhs) VL_MT_SAFE {
     if (VL_UNLIKELY(rhs >= VL_QUADSIZE)) return 0;
     return VL_CLEAN_QQ(obits, obits, lhs << rhs);
 }

--- a/include/verilated.h
+++ b/include/verilated.h
@@ -2503,10 +2503,8 @@ static inline QData VL_SHIFTL_QQW(int obits, int, int rbits, QData lhs, WDataInP
     // Above checks rwp[1]==0 so not needed in below shift
     return VL_CLEAN_QQ(obits, obits, lhs << (static_cast<QData>(rwp[0])));
 }
-static inline QData VL_SHIFTL_QQQ(int obits, int lbits, int rbits, QData lhs,
+static inline QData VL_SHIFTL_QQQ(int obits, int, int, QData lhs,
                                   QData rhs) VL_MT_SAFE {
-    (void)lbits;
-    (void)rbits;
     if (VL_UNLIKELY(rhs >= VL_QUADSIZE)) return 0;
     return VL_CLEAN_QQ(obits, obits, lhs << rhs);
 }

--- a/include/verilated.h
+++ b/include/verilated.h
@@ -2489,10 +2489,8 @@ static inline IData VL_SHIFTL_IIW(int obits, int, int rbits, IData lhs, WDataInP
     }
     return VL_CLEAN_II(obits, obits, lhs << rwp[0]);
 }
-static inline IData VL_SHIFTL_IIQ(int obits, int lbits, int rbits, IData lhs,
+static inline IData VL_SHIFTL_IIQ(int obits, int, int, IData lhs,
                                   QData rhs) VL_MT_SAFE {
-    (void)lbits;
-    (void)rbits;
     if (VL_UNLIKELY(rhs >= VL_IDATASIZE)) return 0;
     return VL_CLEAN_II(obits, obits, lhs << rhs);
 }


### PR DESCRIPTION
When compiling with `-Werror=unused-parameter`, this patch is needed to avoid unused parameter errors.