### PR TITLE
Fix --protect-ids when using SV classes

### DIFF
--- a/Changes
+++ b/Changes
@@ -18,7 +18,7 @@ Verilator 4.203 devel
 * Split always blocks to better respect --output-split-cfuncs. [Geza Lore]
 * Fix initialization of assoc in assoc array (#2914). [myftptoyman]
 * Fix merging of assignments in C++ code (#2970). [Ruper Swarbrick]
-* Fix --protect-ids when using SV classes. [Geza Lore]
+* Fix --protect-ids when using SV classes (#2994). [Geza Lore]
 
 
 Verilator 4.202 2021-04-24

--- a/Changes
+++ b/Changes
@@ -18,6 +18,7 @@ Verilator 4.203 devel
 * Split always blocks to better respect --output-split-cfuncs. [Geza Lore]
 * Fix initialization of assoc in assoc array (#2914). [myftptoyman]
 * Fix merging of assignments in C++ code (#2970). [Ruper Swarbrick]
+* Fix --protect-ids when using SV classes. [Geza Lore]
 
 
 Verilator 4.202 2021-04-24

--- a/src/V3File.cpp
+++ b/src/V3File.cpp
@@ -1016,7 +1016,8 @@ public:
         }
     }
     string protectWordsIf(const string& old, bool doIt) {
-        // Split at " " (for traces), "." (for scopes), or "->" (for scopes)
+        // Split at " " (for traces), "." (for scopes), "->" (for scopes), "::" (for superclass
+        // reference)
         if (!(doIt && v3Global.opt.protectIds())) return old;
         string out;
         string::size_type start = 0;
@@ -1028,6 +1029,7 @@ public:
             trySep(old, start, " ", pos /*ref*/, separator /*ref*/);
             trySep(old, start, ".", pos /*ref*/, separator /*ref*/);
             trySep(old, start, "->", pos /*ref*/, separator /*ref*/);
+            trySep(old, start, "::", pos /*ref*/, separator /*ref*/);
             if (pos == string::npos) break;
             out += protectIf(old.substr(start, pos - start), true) + separator;
             start = pos + separator.length();

--- a/src/V3Task.cpp
+++ b/src/V3Task.cpp
@@ -1157,7 +1157,8 @@ private:
                 cfuncp->argTypes(EmitCBaseVisitor::symClassVar());
                 if (cfuncp->name() == "new") {
                     cfuncp->addInitsp(
-                        new AstCStmt(nodep->fileline(), "_ctor_var_reset(vlSymsp);\n"));
+                        new AstCStmt(nodep->fileline(),
+                                     VIdProtect::protect("_ctor_var_reset") + "(vlSymsp);\n"));
                 }
             }
         }

--- a/test_regress/t/t_class_extends_protect_ids.pl
+++ b/test_regress/t/t_class_extends_protect_ids.pl
@@ -1,0 +1,34 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2021 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(vlt_all => 1);
+
+# This test makes randomly named .cpp/.h files, which tend to collect, so remove them first
+foreach my $filename (glob ("$Self->{obj_dir}/*_PS*.cpp"
+                            ." $Self->{obj_dir}/*_PS*.h"
+                            ." $Self->{obj_dir}/*.d" )) {
+    print "rm $filename\n" if $Self->{verbose};
+    unlink $filename;
+}
+
+top_filename("t/t_class_extends.v");
+
+compile(
+    make_flags => 'VM_PARALLEL_BUILDS=1',  # bug2775
+    verilator_flags2 => ["--protect-ids",
+                         "--protect-key SECRET_KEY"]
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_class_local_protect_ids.pl
+++ b/test_regress/t/t_class_local_protect_ids.pl
@@ -1,0 +1,33 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2021 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(vlt_all => 1);
+
+# This test makes randomly named .cpp/.h files, which tend to collect, so remove them first
+foreach my $filename (glob ("$Self->{obj_dir}/*_PS*.cpp"
+                            ." $Self->{obj_dir}/*_PS*.h"
+                            ." $Self->{obj_dir}/*.d" )) {
+    print "rm $filename\n" if $Self->{verbose};
+    unlink $filename;
+}
+
+top_filename("t/t_class_local.v");
+
+compile(
+    verilator_flags2 => ["--protect-ids",
+                         "--protect-key SECRET_KEY"]
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_class_static_method_protect_ids.pl
+++ b/test_regress/t/t_class_static_method_protect_ids.pl
@@ -1,0 +1,33 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2021 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(vlt_all => 1);
+
+# This test makes randomly named .cpp/.h files, which tend to collect, so remove them first
+foreach my $filename (glob ("$Self->{obj_dir}/*_PS*.cpp"
+                            ." $Self->{obj_dir}/*_PS*.h"
+                            ." $Self->{obj_dir}/*.d" )) {
+    print "rm $filename\n" if $Self->{verbose};
+    unlink $filename;
+}
+
+top_filename("t/t_class_static_method.v");
+
+compile(
+    verilator_flags2 => ["--protect-ids",
+                         "--protect-key SECRET_KEY"]
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_class_virtual_protect_ids.pl
+++ b/test_regress/t/t_class_virtual_protect_ids.pl
@@ -1,0 +1,33 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2021 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(vlt_all => 1);
+
+# This test makes randomly named .cpp/.h files, which tend to collect, so remove them first
+foreach my $filename (glob ("$Self->{obj_dir}/*_PS*.cpp"
+                            ." $Self->{obj_dir}/*_PS*.h"
+                            ." $Self->{obj_dir}/*.d" )) {
+    print "rm $filename\n" if $Self->{verbose};
+    unlink $filename;
+}
+
+top_filename("t/t_class_virtual.v");
+
+compile(
+    verilator_flags2 => ["--protect-ids",
+                         "--protect-key SECRET_KEY"]
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;


### PR DESCRIPTION
A few names were incorrectly mangled, which made --protect-ids produce
invalid output when certain SV class constructs were uses. Now fixed and
added a few extra tests to catch this.

Happy to merge this when CI passes.