### PR TITLE
Convert to emit 'loose methods' with explicit 'self' pointers

### DIFF
--- a/Changes
+++ b/Changes
@@ -11,6 +11,11 @@ contributors that suggested a given feature are shown in []. Thanks!
 Verilator 4.205 devel
 ==========================
 
+**Major:**
+
+* Generated code is now emitted as global functions rather than methods. '$c'
+  contents might need to be updated, see the docs (#3006). [Geza Lore]
+
 **Minor:**
 
 

--- a/docs/guide/extensions.rst
+++ b/docs/guide/extensions.rst
@@ -33,7 +33,12 @@ or "`ifdef`"'s may break other tools.
    that returns up to a 32-bit number (without a trailing ;). This can be
    used to call C++ functions from your Verilog code.
 
-   String arguments will be put directly into the output C++ code.
+   String arguments will be put directly into the output C++ code, except
+   the word 'this' (i.e.: the object pointer) might be replaced with a
+   different pointer as Verilator might implement logic with non-member
+   functions. For this reason, any references to class members must be made
+   via an explicit 'this->' pointer dereference.
+
    Expression arguments will have the code to evaluate the expression
    inserted.  Thus to call a C++ function, :code:`$c("func(",a,")")` will
    result in :code:`func(a)` in the output C++ code.  For input arguments,

--- a/include/verilated_threads.cpp
+++ b/include/verilated_threads.cpp
@@ -74,7 +74,7 @@ void VlWorkerThread::workerLoop() {
         if (VL_UNLIKELY(m_exiting.load(std::memory_order_acquire))) break;
 
         if (VL_LIKELY(work.m_fnp)) {
-            work.m_fnp(work.m_evenCycle, work.m_sym);
+            work.m_fnp(work.m_selfp, work.m_evenCycle);
             work.m_fnp = nullptr;
         }
     }

--- a/include/verilated_threads.h
+++ b/include/verilated_threads.h
@@ -48,12 +48,12 @@
 #endif
 // clang-format on
 
-// VlMTaskVertex and VlThreadpool will work with multiple symbol table types.
+// VlMTaskVertex and VlThreadpool will work with multiple model class types.
 // Since the type is opaque to VlMTaskVertex and VlThreadPool, represent it
 // as a void* here.
-using VlThrSymTab = void*;
+using VlSelfP = void*;
 
-using VlExecFnp = void (*)(bool, VlThrSymTab);
+using VlExecFnp = void (*)(VlSelfP, bool);
 
 // Track dependencies for a single MTask.
 class VlMTaskVertex final {
@@ -177,15 +177,15 @@ private:
     // TYPES
     struct ExecRec {
         VlExecFnp m_fnp;  // Function to execute
-        VlThrSymTab m_sym;  // Symbol table to execute
+        VlSelfP m_selfp;  // Symbol table to execute
         bool m_evenCycle;  // Even/odd for flag alternation
         ExecRec()
             : m_fnp{nullptr}
-            , m_sym{nullptr}
+            , m_selfp{nullptr}
             , m_evenCycle{false} {}
-        ExecRec(VlExecFnp fnp, bool evenCycle, VlThrSymTab sym)
+        ExecRec(VlExecFnp fnp, VlSelfP selfp, bool evenCycle)
             : m_fnp{fnp}
-            , m_sym{sym}
+            , m_selfp{selfp}
             , m_evenCycle{evenCycle} {}
     };
 
@@ -237,13 +237,13 @@ public:
         m_ready.erase(m_ready.begin());
         m_ready_size.fetch_sub(1, std::memory_order_relaxed);
     }
-    inline void wakeUp() { addTask(nullptr, false, nullptr); }
-    inline void addTask(VlExecFnp fnp, bool evenCycle, VlThrSymTab sym)
+    inline void wakeUp() { addTask(nullptr, nullptr, false); }
+    inline void addTask(VlExecFnp fnp, VlSelfP selfp, bool evenCycle)
         VL_MT_SAFE_EXCLUDES(m_mutex) {
         bool notify;
         {
             const VerilatedLockGuard lk(m_mutex);
-            m_ready.emplace_back(fnp, evenCycle, sym);
+            m_ready.emplace_back(fnp, selfp, evenCycle);
             m_ready_size.fetch_add(1, std::memory_order_relaxed);
             notify = m_waiting;
         }

--- a/src/V3Active.cpp
+++ b/src/V3Active.cpp
@@ -474,11 +474,10 @@ private:
         if (!m_scopeFinalp) {
             m_scopeFinalp = new AstCFunc(
                 nodep->fileline(), "_final_" + m_namer.scopep()->nameDotless(), m_namer.scopep());
-            m_scopeFinalp->argTypes(EmitCBaseVisitor::symClassVar());
-            m_scopeFinalp->addInitsp(
-                new AstCStmt(nodep->fileline(), EmitCBaseVisitor::symTopAssign() + "\n"));
             m_scopeFinalp->dontCombine(true);
             m_scopeFinalp->formCallTree(true);
+            m_scopeFinalp->isStatic(false);
+            m_scopeFinalp->isLoose(true);
             m_scopeFinalp->slow(true);
             m_namer.scopep()->addActivep(m_scopeFinalp);
         }

--- a/src/V3Ast.h
+++ b/src/V3Ast.h
@@ -1687,6 +1687,7 @@ public:
     AstNodeDType* findSigned32DType() { return findBasicDType(AstBasicDTypeKwd::INTEGER); }
     AstNodeDType* findUInt32DType() { return findBasicDType(AstBasicDTypeKwd::UINT32); }
     AstNodeDType* findUInt64DType() { return findBasicDType(AstBasicDTypeKwd::UINT64); }
+    AstNodeDType* findCHandleDType() { return findBasicDType(AstBasicDTypeKwd::CHANDLE); }
     AstNodeDType* findVoidDType() const;
     AstNodeDType* findQueueIndexDType() const;
     AstNodeDType* findBitDType(int width, int widthMin, VSigning numeric) const;
@@ -2272,9 +2273,9 @@ private:
     AstVarScope* m_varScopep = nullptr;  // Varscope for hierarchy
     AstNodeModule* m_classOrPackagep = nullptr;  // Package hierarchy
     string m_name;  // Name of variable
-    string m_hiernameToProt;  // Scope converted into name-> for emitting
-    string m_hiernameToUnprot;  // Scope converted into name-> for emitting
-    bool m_hierThis = false;  // Hiername points to "this" function
+    string m_selfPointer;  // Output code object pointer (e.g.: 'this')
+    string m_classPrefix;  // Output class prefix (i.e.: the part before ::)
+    bool m_hierThis = false;  // m_selfPointer points to "this" function
 
 protected:
     AstNodeVarRef(AstType t, FileLine* fl, const string& name, const VAccess& access)
@@ -2306,13 +2307,14 @@ public:
     void varp(AstVar* varp);
     AstVarScope* varScopep() const { return m_varScopep; }
     void varScopep(AstVarScope* varscp) { m_varScopep = varscp; }
-    string hiernameToProt() const { return m_hiernameToProt; }
-    void hiernameToProt(const string& hn) { m_hiernameToProt = hn; }
-    string hiernameToUnprot() const { return m_hiernameToUnprot; }
-    void hiernameToUnprot(const string& hn) { m_hiernameToUnprot = hn; }
-    string hiernameProtect() const;
     bool hierThis() const { return m_hierThis; }
     void hierThis(bool flag) { m_hierThis = flag; }
+    string selfPointer() const { return m_selfPointer; }
+    void selfPointer(const string& value) { m_selfPointer = value; }
+    string selfPointerProtect(bool useSelfForThis) const;
+    string classPrefix() const { return m_classPrefix; }
+    void classPrefix(const string& value) { m_classPrefix = value; }
+    string classPrefixProtect() const;
     AstNodeModule* classOrPackagep() const { return m_classOrPackagep; }
     void classOrPackagep(AstNodeModule* nodep) { m_classOrPackagep = nodep; }
     // Know no children, and hot function, so skip iterator for speed
@@ -2615,8 +2617,8 @@ class AstNodeCCall VL_NOT_FINAL : public AstNodeStmt {
     // A call of a C++ function, perhaps a AstCFunc or perhaps globally named
     // Functions are not statements, while tasks are. AstNodeStmt needs isStatement() to deal.
     AstCFunc* m_funcp;
-    string m_hiernameToProt;
-    string m_hiernameToUnprot;
+    string m_selfPointer;  // Output code object pointer (e.g.: 'this')
+    string m_classPrefix;  // Output class prefix (i.e.: the part before ::)
     string m_argTypes;
 
 protected:
@@ -2642,11 +2644,12 @@ public:
     virtual bool isPure() const override;
     virtual bool isOutputter() const override { return !isPure(); }
     AstCFunc* funcp() const { return m_funcp; }
-    string hiernameToProt() const { return m_hiernameToProt; }
-    void hiernameToProt(const string& hn) { m_hiernameToProt = hn; }
-    string hiernameToUnprot() const { return m_hiernameToUnprot; }
-    void hiernameToUnprot(const string& hn) { m_hiernameToUnprot = hn; }
-    string hiernameProtect() const;
+    string selfPointer() const { return m_selfPointer; }
+    void selfPointer(const string& value) { m_selfPointer = value; }
+    string selfPointerProtect(bool useSelfForThis) const;
+    string classPrefix() const { return m_classPrefix; }
+    void classPrefix(const string& value) { m_classPrefix = value; }
+    string classPrefixProtect() const;
     void argTypes(const string& str) { m_argTypes = str; }
     string argTypes() const { return m_argTypes; }
     // op1p reserved for AstCMethodCall

--- a/src/V3CCtors.cpp
+++ b/src/V3CCtors.cpp
@@ -61,23 +61,21 @@ private:
         const int funcNum = m_newFunctions.size();
         const string funcName = m_basename + "_" + cvtToStr(funcNum);
         AstCFunc* const funcp = new AstCFunc(m_modp->fileline(), funcName, nullptr, "void");
-        funcp->isStatic(!m_type.isClass());  // Class constructors are non static
+        funcp->isStatic(false);
+        funcp->isLoose(!m_type.isClass());
         funcp->declPrivate(true);
         funcp->slow(!m_type.isClass());  // Only classes construct on fast path
         string preventUnusedStmt;
         if (m_type.isClass()) {
             funcp->argTypes(EmitCBaseVisitor::symClassVar());
-            preventUnusedStmt = "if (false && vlSymsp) {}";
+            preventUnusedStmt = "if (false && vlSymsp) {}  // Prevent unused\n";
         } else if (m_type.isCoverage()) {
-            funcp->argTypes(EmitCBaseVisitor::prefixNameProtect(m_modp) + "* self, "
-                            + EmitCBaseVisitor::symClassVar() + ", bool first");
-            preventUnusedStmt = "if (false && self && vlSymsp && first) {}";
-        } else {  // Module
-            funcp->argTypes(EmitCBaseVisitor::prefixNameProtect(m_modp) + "* self");
-            preventUnusedStmt = "if (false && self) {}";
+            funcp->argTypes("bool first");
+            preventUnusedStmt = "if (false && first) {}  // Prevent unused\n";
         }
-        preventUnusedStmt += "  // Prevent unused\n";
-        funcp->addStmtsp(new AstCStmt(m_modp->fileline(), preventUnusedStmt));
+        if (!preventUnusedStmt.empty()) {
+            funcp->addStmtsp(new AstCStmt(m_modp->fileline(), preventUnusedStmt));
+        }
         m_modp->addStmtp(funcp);
         m_numStmts = 0;
         return funcp;
@@ -113,10 +111,9 @@ public:
                 AstCCall* const callp = new AstCCall(m_modp->fileline(), funcp);
                 if (m_type.isClass()) {
                     callp->argTypes("vlSymsp");
-                } else if (m_type.isCoverage()) {
-                    callp->argTypes("self, vlSymsp, first");
-                } else {  // Module
-                    callp->argTypes("self");
+                } else {
+                    if (m_type.isCoverage()) callp->argTypes("first");
+                    callp->selfPointer("this");
                 }
                 rootFuncp->addStmtsp(callp);
             }
@@ -134,6 +131,7 @@ void V3CCtors::evalAsserts() {
     AstCFunc* funcp = new AstCFunc(modp->fileline(), "_eval_debug_assertions", nullptr, "void");
     funcp->declPrivate(true);
     funcp->isStatic(false);
+    funcp->isLoose(true);
     funcp->slow(false);
     funcp->ifdef("VL_DEBUG");
     modp->addStmtp(funcp);
@@ -145,7 +143,11 @@ void V3CCtors::evalAsserts() {
                     int lastWordWidth = varp->width() % storedWidth;
                     if (lastWordWidth != 0) {
                         // if (signal & CONST(upper_non_clean_mask)) { fail; }
-                        AstNode* newp = new AstVarRef(varp->fileline(), varp, VAccess::READ);
+                        AstVarRef* const vrefp
+                            = new AstVarRef(varp->fileline(), varp, VAccess::READ);
+                        vrefp->selfPointer(v3Global.opt.relativeCFuncs() ? "this"
+                                                                         : "vlSymsp->TOPp");
+                        AstNode* newp = vrefp;
                         if (varp->isWide()) {
                             newp = new AstWordSel(
                                 varp->fileline(), newp,

--- a/src/V3Changed.cpp
+++ b/src/V3Changed.cpp
@@ -61,14 +61,13 @@ public:
             m_chgFuncp
                 = new AstCFunc(m_scopetopp->fileline(), "_change_request_" + cvtToStr(++m_funcNum),
                                m_scopetopp, "QData");
-            m_chgFuncp->argTypes(EmitCBaseVisitor::symClassVar());
-            m_chgFuncp->symProlog(true);
+            m_chgFuncp->isStatic(false);
+            m_chgFuncp->isLoose(true);
             m_chgFuncp->declPrivate(true);
             m_scopetopp->addActivep(m_chgFuncp);
 
             // Add a top call to it
             AstCCall* callp = new AstCCall(m_scopetopp->fileline(), m_chgFuncp);
-            callp->argTypes("vlSymsp");
 
             if (!m_tlChgFuncp->stmtsp()) {
                 m_tlChgFuncp->addStmtsp(new AstCReturn(m_scopetopp->fileline(), callp));
@@ -251,8 +250,8 @@ private:
         // Create a wrapper change detection function that calls each change detection function
         m_statep->m_tlChgFuncp
             = new AstCFunc(nodep->fileline(), "_change_request", scopep, "QData");
-        m_statep->m_tlChgFuncp->argTypes(EmitCBaseVisitor::symClassVar());
-        m_statep->m_tlChgFuncp->symProlog(true);
+        m_statep->m_tlChgFuncp->isStatic(false);
+        m_statep->m_tlChgFuncp->isLoose(true);
         m_statep->m_tlChgFuncp->declPrivate(true);
         m_statep->m_scopetopp->addActivep(m_statep->m_tlChgFuncp);
         // Each change detection function needs at least one AstChangeDet

--- a/src/V3Clock.cpp
+++ b/src/V3Clock.cpp
@@ -164,6 +164,18 @@ private:
         m_lastSenp = nullptr;
         m_lastIfp = nullptr;
     }
+    AstCFunc* makeTopFunction(const string& name, bool slow = false) {
+        AstCFunc* const funcp = new AstCFunc{m_topScopep->fileline(), name, m_topScopep->scopep()};
+        funcp->dontCombine(true);
+        funcp->isStatic(false);
+        funcp->isLoose(true);
+        funcp->entryPoint(true);
+        funcp->slow(slow);
+        funcp->isConst(false);
+        funcp->declPrivate(true);
+        m_topScopep->scopep()->addActivep(funcp);
+        return funcp;
+    }
     void splitCheck(AstCFunc* ofuncp) {
         if (!v3Global.opt.outputSplitCFuncs() || !ofuncp->stmtsp()) return;
         if (EmitCBaseCounterVisitor(ofuncp->stmtsp()).count() < v3Global.opt.outputSplitCFuncs())
@@ -184,15 +196,13 @@ private:
                 // Make a new function
                 funcp = new AstCFunc{ofuncp->fileline(), ofuncp->name() + cvtToStr(++funcnum),
                                      m_topScopep->scopep()};
-                funcp->argTypes(EmitCBaseVisitor::symClassVar());
                 funcp->dontCombine(true);
-                funcp->symProlog(true);
-                funcp->isStatic(true);
+                funcp->isStatic(false);
+                funcp->isLoose(true);
                 funcp->slow(ofuncp->slow());
                 m_topScopep->scopep()->addActivep(funcp);
                 //
                 AstCCall* callp = new AstCCall{funcp->fileline(), funcp};
-                callp->argTypes("vlSymsp");
                 ofuncp->addStmtsp(callp);
                 func_stmts = 0;
             }
@@ -212,55 +222,10 @@ private:
         // VV*****  We reset all user1p()
         AstNode::user1ClearTree();
         // Make top functions
-        {
-            AstCFunc* funcp = new AstCFunc{nodep->fileline(), "_eval", m_topScopep->scopep()};
-            funcp->argTypes(EmitCBaseVisitor::symClassVar());
-            funcp->dontCombine(true);
-            funcp->symProlog(true);
-            funcp->isStatic(true);
-            funcp->entryPoint(true);
-            m_topScopep->scopep()->addActivep(funcp);
-            m_evalFuncp = funcp;
-        }
-        {
-            AstCFunc* funcp
-                = new AstCFunc{nodep->fileline(), "_eval_initial", m_topScopep->scopep()};
-            funcp->argTypes(EmitCBaseVisitor::symClassVar());
-            funcp->dontCombine(true);
-            funcp->slow(true);
-            funcp->symProlog(true);
-            funcp->isStatic(true);
-            funcp->entryPoint(true);
-            m_topScopep->scopep()->addActivep(funcp);
-            m_initFuncp = funcp;
-        }
-        {
-            AstCFunc* funcp = new AstCFunc{nodep->fileline(), "final", m_topScopep->scopep()};
-            funcp->skipDecl(true);
-            funcp->dontCombine(true);
-            funcp->slow(true);
-            funcp->isStatic(false);
-            funcp->entryPoint(true);
-            funcp->protect(false);
-            funcp->addInitsp(new AstCStmt(nodep->fileline(), EmitCBaseVisitor::symClassVar()
-                                                                 + " = this->__VlSymsp;\n"));
-            funcp->addInitsp(
-                new AstCStmt(nodep->fileline(), EmitCBaseVisitor::symTopAssign() + "\n"));
-            m_topScopep->scopep()->addActivep(funcp);
-            m_finalFuncp = funcp;
-        }
-        {
-            AstCFunc* funcp
-                = new AstCFunc{nodep->fileline(), "_eval_settle", m_topScopep->scopep()};
-            funcp->argTypes(EmitCBaseVisitor::symClassVar());
-            funcp->dontCombine(true);
-            funcp->slow(true);
-            funcp->isStatic(true);
-            funcp->symProlog(true);
-            funcp->entryPoint(true);
-            m_topScopep->scopep()->addActivep(funcp);
-            m_settleFuncp = funcp;
-        }
+        m_evalFuncp = makeTopFunction("_eval");
+        m_initFuncp = makeTopFunction("_eval_initial", /* slow: */ true);
+        m_settleFuncp = makeTopFunction("_eval_settle", /* slow: */ true);
+        m_finalFuncp = makeTopFunction("_final", /* slow: */ true);
         // Process the activates
         iterateChildren(nodep);
         UINFO(4, " TOPSCOPE iter done " << nodep << endl);
@@ -324,7 +289,6 @@ private:
         if (nodep->formCallTree()) {
             UINFO(4, "    formCallTree " << nodep << endl);
             AstCCall* callp = new AstCCall(nodep->fileline(), nodep);
-            callp->argTypes("vlSymsp");
             m_finalFuncp->addStmtsp(callp);
         }
     }

--- a/src/V3Combine.cpp
+++ b/src/V3Combine.cpp
@@ -72,8 +72,8 @@ public:
                 AstNode* const argsp
                     = oldp->argsp() ? oldp->argsp()->unlinkFrBackWithNext() : nullptr;
                 AstCCall* const newp = new AstCCall(oldp->fileline(), newfuncp, argsp);
-                newp->hiernameToProt(oldp->hiernameToProt());
-                newp->hiernameToUnprot(oldp->hiernameToUnprot());
+                newp->selfPointer(oldp->selfPointer());
+                newp->classPrefix(oldp->classPrefix());
                 newp->argTypes(oldp->argTypes());
                 addCall(newp);  // Fix the table, in case the newfuncp itself gets replaced
                 oldp->replaceWith(newp);
@@ -86,14 +86,23 @@ public:
         }
     }
     // METHODS
-    void addCall(AstCCall* nodep) {
-        if (nodep->funcp()->dontCombine()) return;
-        m_callMmap.emplace(nodep->funcp(), nodep);
-    }
+    void addCall(AstCCall* nodep) { m_callMmap.emplace(nodep->funcp(), nodep); }
 
 private:
     // VISITORS
-    virtual void visit(AstCCall* nodep) override { addCall(nodep); }
+    virtual void visit(AstCCall* nodep) override {
+        if (nodep->funcp()->dontCombine()) return;
+        addCall(nodep);
+    }
+    // LCOV_EXCL_START
+    virtual void visit(AstAddrOfCFunc* nodep) override {
+        // We cannot yet handle references via AstAddrOfCFunc, but currently those are
+        // only used in tracing functions, which are not combined. Blow up in case this changes.
+        if (nodep->funcp()->dontCombine()) return;
+        nodep->v3fatalSrc(
+            "Don't know how to combine functions that are referenced via AstAddrOfCFunc");
+    }
+    // LCOV_EXCL_END
     // Speed things up
     virtual void visit(AstNodeAssign*) override {}
     virtual void visit(AstNodeMath*) override {}

--- a/src/V3DepthBlock.cpp
+++ b/src/V3DepthBlock.cpp
@@ -51,14 +51,19 @@ private:
         // Create function
         string name = m_cfuncp->name() + "__deep" + cvtToStr(++m_deepNum);
         AstCFunc* funcp = new AstCFunc(nodep->fileline(), name, nullptr);
-        funcp->argTypes(EmitCBaseVisitor::symClassVar());
-        funcp->symProlog(true);
         funcp->slow(m_cfuncp->slow());
+        funcp->isStatic(m_cfuncp->isStatic());
+        funcp->isLoose(m_cfuncp->isLoose());
         funcp->addStmtsp(nodep);
         m_modp->addStmtp(funcp);
         // Call it at the point where the body was removed from
         AstCCall* callp = new AstCCall(nodep->fileline(), funcp);
-        callp->argTypes("vlSymsp");
+        if (VN_IS(m_modp, Class)) {
+            funcp->argTypes(EmitCBaseVisitor::symClassVar());
+            callp->argTypes("vlSymsp");
+        } else if (funcp->isStatic().falseUnknown()) {
+            callp->selfPointer("this");
+        }
         UINFO(6, "      New " << callp << endl);
         //
         relinkHandle.relink(callp);

--- a/src/V3Descope.cpp
+++ b/src/V3Descope.cpp
@@ -56,7 +56,8 @@ private:
     VL_DEBUG_FUNC;  // Declare debug()
 
     static bool modIsSingleton(AstNodeModule* modp) {
-        // True iff there's exactly one instance of this module in the design.
+        // True iff there's exactly one instance of this module in the design (including top).
+        if (modp->isTop()) return true;
         int instances = 0;
         for (AstNode* stmtp = modp->stmtsp(); stmtp; stmtp = stmtp->nextp()) {
             if (VN_IS(stmtp, Scope)) {
@@ -66,82 +67,65 @@ private:
         return (instances == 1);
     }
 
-    // Construct the best prefix to reference an object in 'scopep'
-    // from a CFunc in 'm_scopep'. Result may be relative
-    // ("this->[...]") or absolute ("vlTOPp->[...]").
+    // Construct the best self pointer to reference an object in 'scopep'  from a CFunc in
+    // 'm_scopep'. Result may be relative ("this->[...]") or absolute ("vlSyms->[...]").
     //
-    // Using relative references allows V3Combine'ing
-    // code across multiple instances of the same module.
-    //
-    // Sets 'hierThisr' true if the object is local to this scope
-    // (and could be made into a function-local later in V3Localize),
-    // false if the object is in another scope.
-    string descopedName(bool& hierThisr, string& hierUnprot, const AstScope* scopep,
-                        const AstVar* varp) {
+    // Using relative references allows V3Combine'ing code across multiple instances of the same
+    // module.
+    string descopedSelfPointer(const AstScope* scopep) {
         UASSERT(scopep, "Var/Func not scoped");
-        hierThisr = (scopep == m_scopep);
 
         // It's possible to disable relative references. This is a concession
         // to older compilers (gcc < 4.5.x) that don't understand __restrict__
         // well and emit extra ld/st to guard against pointer aliasing
-        // when this-> and vlTOPp-> are mixed in the same function.
-        //
-        // "vlTOPp" is declared "restrict" so better compilers understand
-        // that it won't alias with "this".
+        // when this-> and vlSyms-> are mixed in the same function.
         bool relativeRefOk = v3Global.opt.relativeCFuncs();
         //
         // Static functions can't use this
         if (!m_allowThis) relativeRefOk = false;
         //
-        // Use absolute refs in top-scoped routines, keep them static.
-        // The DPI callback registration depends on representing top-level
-        // static routines as plain function pointers. That breaks if those
-        // become true OO routines.
-        //
-        // V3Combine wouldn't likely be able to combine top-level
-        // routines anyway, so there's no harm in keeping these static.
-        UASSERT_OBJ(m_modp, scopep, "Scope not under module");
-        if (m_modp->isTop()) relativeRefOk = false;
-        //
-        // Use absolute refs if this scope is the only instance of the module.
-        // Saves a bit of overhead on passing the 'this' pointer, and there's no
-        // need to be nice to V3Combine when we have only a single instance.
-        // The risk that this prevents combining identical logic from differently-
-        // named but identical modules seems low.
-        if (m_modSingleton) relativeRefOk = false;
-        //
         // Class methods need relative
         if (m_modp && VN_IS(m_modp, Class)) relativeRefOk = true;
 
-        if (varp && varp->isFuncLocal()) {
-            hierThisr = true;
-            return "";  // Relative to function, not in this
-        } else if (relativeRefOk && scopep == m_scopep) {
+        UINFO(8, "      Descope ref under " << m_scopep << endl);
+        UINFO(8, "              ref to    " << scopep << endl);
+        UINFO(8, "             aboveScope " << scopep->aboveScopep() << endl);
+
+        if (relativeRefOk && scopep == m_scopep) {
             m_needThis = true;
-            return "this->";
+            return "this";
         } else if (VN_IS(scopep->modp(), Class)) {
-            hierUnprot = v3Global.opt.modPrefix() + "_";  // Prefix before protected part
-            return scopep->modp()->name() + "::";
-        } else if (relativeRefOk && scopep->aboveScopep() && scopep->aboveScopep() == m_scopep) {
-            // Reference to scope of instance directly under this module, can just "cell->"
+            return "";
+        } else if (!m_modSingleton && relativeRefOk && scopep->aboveScopep() == m_scopep
+                   && VN_IS(scopep->modp(), Module)) {
+            // Reference to scope of instance directly under this module, can just "this->cell",
+            // which can potentially be V3Combined, but note this requires one extra pointer
+            // dereference which is slower, so we only use it if the source scope is not a
+            // singleton.
             string name = scopep->name();
             string::size_type pos;
             if ((pos = name.rfind('.')) != string::npos) name.erase(0, pos + 1);
             m_needThis = true;
-            return name + "->";
+            return "this->" + name;
         } else {
-            // Reference to something elsewhere, or relative references
-            // are disabled. Use global variable
-            UINFO(8, "      Descope " << scopep << endl);
-            UINFO(8, "           to " << scopep->name() << endl);
-            UINFO(8, "        under " << m_scopep->name() << endl);
-            if (!scopep->aboveScopep()) {  // Top
-                // We could also return "vlSymsp->TOPp->" here, but GCC would
-                // suspect aliases.
-                return "vlTOPp->";
+            // Reference to something elsewhere, or relative references are disabled. Use global
+            // variable
+            if (scopep->isTop()) {  // Top
+                return "vlSymsp->TOPp";
             } else {
-                return scopep->nameVlSym() + ".";
+                return "(&" + scopep->nameVlSym() + ")";
             }
+        }
+    }
+
+    // Construct the class prefix (as in, the part before the :: scope resolution operator) when
+    // referencing an object in 'scopep' from a CFunc in 'm_scopep'.
+    string descopedClassPrefix(const AstScope* scopep) {
+        UASSERT(scopep, "Var/Func not scoped");
+        if (VN_IS(scopep->modp(), Class) && scopep != m_scopep) {
+            return scopep->modp()->name();
+        } else {
+            return "";
         }
     }
 
@@ -164,11 +148,6 @@ private:
                 if (newfuncp->finalsp()) newfuncp->finalsp()->unlinkFrBackWithNext()->deleteTree();
                 newfuncp->name(name);
                 newfuncp->isStatic(false);
-                newfuncp->addInitsp(
-                    new AstCStmt(newfuncp->fileline(),
-                                 EmitCBaseVisitor::symClassVar() + " = this->__VlSymsp;\n"));
-                newfuncp->addInitsp(
-                    new AstCStmt(newfuncp->fileline(), EmitCBaseVisitor::symTopAssign() + "\n"));
                 topFuncp->addNextHere(newfuncp);
                 // In the body, call each function if it matches the given scope
                 for (FuncMmap::iterator eachIt = it;
@@ -255,13 +234,15 @@ private:
         // Convert the hierch name
         UINFO(9, "  ref-in " << nodep << endl);
         UASSERT_OBJ(m_scopep, nodep, "Node not under scope");
-        bool hierThis;
-        string hierUnprot;
-        nodep->hiernameToProt(descopedName(hierThis /*ref*/, hierUnprot /*ref*/,
-                                           nodep->varScopep()->scopep(),
-                                           nodep->varScopep()->varp()));
-        nodep->hiernameToUnprot(hierUnprot);
-        nodep->hierThis(hierThis);
+        const AstVar* const varp = nodep->varScopep()->varp();
+        const AstScope* const scopep = nodep->varScopep()->scopep();
+        if (varp->isFuncLocal()) {
+            nodep->hierThis(true);
+        } else {
+            nodep->hierThis(scopep == m_scopep);
+            nodep->selfPointer(descopedSelfPointer(scopep));
+            nodep->classPrefix(descopedClassPrefix(scopep));
+        }
         nodep->varScopep(nullptr);
         UINFO(9, "  refout " << nodep << endl);
     }
@@ -270,12 +251,9 @@ private:
         iterateChildren(nodep);
         // Convert the hierch name
         UASSERT_OBJ(m_scopep, nodep, "Node not under scope");
-        UASSERT_OBJ(nodep->funcp()->scopep(), nodep, "CFunc not under scope");
-        bool hierThis;
-        string hierUnprot;
-        nodep->hiernameToProt(
-            descopedName(hierThis /*ref*/, hierUnprot /*ref*/, nodep->funcp()->scopep(), nullptr));
-        nodep->hiernameToUnprot(hierUnprot);
+        const AstScope* const scopep = nodep->funcp()->scopep();
+        nodep->selfPointer(descopedSelfPointer(scopep));
+        nodep->classPrefix(descopedClassPrefix(scopep));
         // Can't do this, as we may have more calls later
         // nodep->funcp()->scopep(nullptr);
     }

--- a/src/V3EmitV.cpp
+++ b/src/V3EmitV.cpp
@@ -624,9 +624,12 @@ class EmitVBaseVisitor VL_NOT_FINAL : public EmitCBaseVisitor {
         if (nodep->varScopep()) {
             putfs(nodep, nodep->varScopep()->prettyName());
         } else {
-            putfs(nodep, nodep->hiernameToUnprot());
-            puts(nodep->hiernameToProt());
-            puts(nodep->varp()->prettyName());
+            if (nodep->selfPointer().empty()) {
+                putfs(nodep, nodep->varp()->prettyName());
+            } else {
+                putfs(nodep, nodep->selfPointer() + "->");
+                puts(nodep->varp()->prettyName());
+            }
         }
     }
     virtual void visit(AstVarXRef* nodep) override {

--- a/src/V3File.cpp
+++ b/src/V3File.cpp
@@ -966,7 +966,7 @@ public:
     VIdProtectImp() {
         passthru("this");
         passthru("TOPp");
-        passthru("vlTOPp");
+        passthru("vlSelf");
         passthru("vlSymsp");
     }
     ~VIdProtectImp() = default;
@@ -1016,8 +1016,7 @@ public:
         }
     }
     string protectWordsIf(const string& old, bool doIt) {
-        // Split at " " (for traces), "." (for scopes), "->" (for scopes), "::" (for superclass
-        // reference)
+        // Split at " " (for traces), "." (for scopes), "->", "(", "&", ")" (for self pointers)
         if (!(doIt && v3Global.opt.protectIds())) return old;
         string out;
         string::size_type start = 0;
@@ -1029,7 +1028,9 @@ public:
             trySep(old, start, " ", pos /*ref*/, separator /*ref*/);
             trySep(old, start, ".", pos /*ref*/, separator /*ref*/);
             trySep(old, start, "->", pos /*ref*/, separator /*ref*/);
-            trySep(old, start, "::", pos /*ref*/, separator /*ref*/);
+            trySep(old, start, "(", pos /*ref*/, separator /*ref*/);
+            trySep(old, start, "&", pos /*ref*/, separator /*ref*/);
+            trySep(old, start, ")", pos /*ref*/, separator /*ref*/);
             if (pos == string::npos) break;
             out += protectIf(old.substr(start, pos - start), true) + separator;
             start = pos + separator.length();

--- a/src/V3File.h
+++ b/src/V3File.h
@@ -165,6 +165,9 @@ public:
     void blockDec() {
         if (!m_parenVec.empty()) m_parenVec.pop();
     }
+    void ensureNewLine() {
+        if (!m_nobreak) puts("\n");
+    }
     // STATIC METHODS
     static string indentSpaces(int num);
     // Add escaped characters to strings

--- a/src/V3Hasher.cpp
+++ b/src/V3Hasher.cpp
@@ -199,7 +199,7 @@ private:
                 iterateNull(nodep->varScopep());
             } else {
                 iterateNull(nodep->varp());
-                m_hash += nodep->hiernameToProt();
+                m_hash += nodep->selfPointer();
             }
         });
     }
@@ -227,6 +227,11 @@ private:
     virtual void visit(AstTestPlusArgs* nodep) override {
         m_hash += hashNodeAndIterate(nodep, HASH_DTYPE, HASH_CHILDREN, [=]() {  //
             m_hash += nodep->text();
+        });
+    }
+    virtual void visit(AstAddrOfCFunc* nodep) override {
+        m_hash += hashNodeAndIterate(nodep, HASH_DTYPE, HASH_CHILDREN, [=]() {  //
+            iterateNull(nodep->funcp());
         });
     }
 
@@ -364,7 +369,9 @@ private:
         });
     }
     virtual void visit(AstCFunc* nodep) override {
-        m_hash += hashNodeAndIterate(nodep, HASH_DTYPE, HASH_CHILDREN, [=]() {});
+        m_hash += hashNodeAndIterate(nodep, HASH_DTYPE, HASH_CHILDREN, [=]() {  //
+            m_hash += nodep->isLoose();
+        });
     }
     virtual void visit(AstVar* nodep) override {
         m_hash += hashNodeAndIterate(nodep, HASH_DTYPE, HASH_CHILDREN, [=]() {

--- a/src/V3Localize.cpp
+++ b/src/V3Localize.cpp
@@ -76,8 +76,7 @@ private:
         // cppcheck-suppress unreadVariable  // cppcheck 1.90 bug
         VarFlags flags(nodep->varp());
         if (flags.m_done) {
-            nodep->hiernameToProt("");  // Remove this->
-            nodep->hiernameToUnprot("");  // Remove this->
+            nodep->selfPointer("");  // Remove 'this'
             nodep->hierThis(true);
         }
     }

--- a/src/V3Order.cpp
+++ b/src/V3Order.cpp
@@ -1754,14 +1754,13 @@ AstActive* OrderVisitor::processMoveOneLogic(const OrderLogicVertex* lvertexp,
             if (!newFuncpr && domainp != m_deleteDomainp) {
                 const string name = cfuncName(modp, domainp, scopep, nodep);
                 newFuncpr = new AstCFunc(nodep->fileline(), name, scopep);
-                newFuncpr->argTypes(EmitCBaseVisitor::symClassVar());
-                newFuncpr->symProlog(true);
+                newFuncpr->isStatic(false);
+                newFuncpr->isLoose(true);
                 newStmtsr = 0;
                 if (domainp->hasInitial() || domainp->hasSettle()) newFuncpr->slow(true);
                 scopep->addActivep(newFuncpr);
                 // Create top call to it
                 AstCCall* const callp = new AstCCall(nodep->fileline(), newFuncpr);
-                callp->argTypes("vlSymsp");
                 // Where will we be adding the call?
                 AstActive* const newActivep = new AstActive(nodep->fileline(), name, domainp);
                 newActivep->addStmtsp(callp);

--- a/src/V3String.cpp
+++ b/src/V3String.cpp
@@ -157,6 +157,23 @@ double VString::parseDouble(const string& str, bool* successp) {
     return d;
 }
 
+static bool isWordChar(char c) { return isalnum(c) || c == '_'; }
+
+string VString::replaceWord(const string& str, const string& from, const string& to) {
+    string result = str;
+    const size_t len = from.size();
+    UASSERT_STATIC(len > 0, "Cannot replace empty string");
+    for (size_t pos = 0; (pos = result.find(from, pos)) != string::npos; pos += len) {
+        // Only replace whole words
+        if (((pos > 0) && isWordChar(result[pos - 1])) ||  //
+            ((pos + len < result.size()) && isWordChar(result[pos + len]))) {
+            continue;
+        }
+        result.replace(pos, len, to);
+    }
+    return result;
+}
+
 //######################################################################
 // VHashSha256
 

--- a/src/V3String.h
+++ b/src/V3String.h
@@ -100,6 +100,10 @@ public:
     static bool isWhitespace(const string& str);
     // Return double by parsing string
     static double parseDouble(const string& str, bool* successp);
+    // Replace all occurrences of the word 'from' in 'str' with 'to'. A word is considered
+    // to be a consecutive sequence of the characters [a-zA-Z0-9_]. Sub-words are not replaced.
+    // e.g.: replaceWords("one apple bad_apple", "apple", "banana") -> "one banana bad_apple"
+    static string replaceWord(const string& str, const string& from, const string& to);
 };
 
 //######################################################################

--- a/src/V3Trace.cpp
+++ b/src/V3Trace.cpp
@@ -485,33 +485,43 @@ private:
         name += cvtToStr(funcNump++);
         FileLine* const flp = m_topScopep->fileline();
         AstCFunc* const funcp = new AstCFunc(flp, name, m_topScopep);
-        const string argTypes("void* userp, " + v3Global.opt.traceClassBase() + "* tracep");
-        funcp->argTypes(argTypes);
         funcp->funcType(type);
+        funcp->dontCombine(true);
+        const bool isTopFunc
+            = type == AstCFuncType::TRACE_FULL || type == AstCFuncType::TRACE_CHANGE;
+        if (isTopFunc) {
+            funcp->argTypes("void* voidSelf, " + v3Global.opt.traceClassBase() + "* tracep");
+            funcp->isStatic(true);
+            funcp->addInitsp(new AstCStmt(
+                flp, prefixNameProtect(m_topModp) + "* const __restrict vlSelf = static_cast<"
+                         + prefixNameProtect(m_topModp) + "*>(voidSelf);\n"));
+            funcp->addInitsp(new AstCStmt(flp, symClassAssign()));
+
+        } else {
+            funcp->argTypes(v3Global.opt.traceClassBase() + "* tracep");
+            funcp->isStatic(false);
+        }
+        funcp->isLoose(true);
         funcp->slow(type == AstCFuncType::TRACE_FULL || type == AstCFuncType::TRACE_FULL_SUB);
-        funcp->symProlog(true);
-        funcp->declPrivate(true);
         // Add it to top scope
         m_topScopep->addActivep(funcp);
         // Add call to new function
         if (callfromp) {
             AstCCall* callp = new AstCCall(funcp->fileline(), funcp);
-            callp->argTypes("userp, tracep");
+            callp->argTypes("tracep");
             callfromp->addStmtsp(callp);
         }
         // Register function
         if (regp) {
-            string registration = "tracep->add";
             if (type == AstCFuncType::TRACE_FULL) {
-                registration += "Full";
+                regp->addStmtsp(new AstText(flp, "tracep->addFullCb(", true));
             } else if (type == AstCFuncType::TRACE_CHANGE) {
-                registration += "Chg";
+                regp->addStmtsp(new AstText(flp, "tracep->addChgCb(", true));
             } else {
                 funcp->v3fatalSrc("Don't know how to register this type of function");
             }
-            registration += "Cb(&" + protect(name) + ", __VlSymsp);\n";
-            AstCStmt* const stmtp = new AstCStmt(flp, registration);
-            regp->addStmtsp(stmtp);
+            regp->addStmtsp(new AstAddrOfCFunc(flp, funcp));
+            regp->addStmtsp(new AstText(flp, ", vlSelf);\n", true));
         }
         // Add global activity check to TRACE_CHANGE functions
         if (type == AstCFuncType::TRACE_CHANGE) {
@@ -666,17 +676,22 @@ private:
     void createCleanupFunction(AstCFunc* regFuncp) {
         FileLine* const fl = m_topScopep->fileline();
         AstCFunc* const cleanupFuncp = new AstCFunc(fl, "traceCleanup", m_topScopep);
-        const string argTypes("void* userp, " + v3Global.opt.traceClassBase() + "* /*unused*/");
-        cleanupFuncp->argTypes(argTypes);
+        cleanupFuncp->argTypes("void* voidSelf, " + v3Global.opt.traceClassBase()
+                               + "* /*unused*/");
         cleanupFuncp->funcType(AstCFuncType::TRACE_CLEANUP);
         cleanupFuncp->slow(false);
-        cleanupFuncp->symProlog(true);
-        cleanupFuncp->declPrivate(true);
+        cleanupFuncp->isStatic(true);
+        cleanupFuncp->isLoose(true);
         m_topScopep->addActivep(cleanupFuncp);
+        cleanupFuncp->addInitsp(new AstCStmt(
+            fl, prefixNameProtect(m_topModp) + "* const __restrict vlSelf = static_cast<"
+                    + prefixNameProtect(m_topModp) + "*>(voidSelf);\n"));
+        cleanupFuncp->addInitsp(new AstCStmt(fl, symClassAssign()));
 
         // Register it
-        regFuncp->addStmtsp(new AstCStmt(
-            fl, string("tracep->addCleanupCb(&" + protect("traceCleanup") + ", __VlSymsp);\n")));
+        regFuncp->addStmtsp(new AstText(fl, "tracep->addCleanupCb(", true));
+        regFuncp->addStmtsp(new AstAddrOfCFunc(fl, cleanupFuncp));
+        regFuncp->addStmtsp(new AstText(fl, ", vlSelf);\n", true));
 
         // Clear global activity flag
         cleanupFuncp->addStmtsp(
@@ -726,7 +741,7 @@ private:
         regFuncp->funcType(AstCFuncType::TRACE_REGISTER);
         regFuncp->slow(true);
         regFuncp->isStatic(false);
-        regFuncp->declPrivate(true);
+        regFuncp->isLoose(true);
         m_topScopep->addActivep(regFuncp);
 
         const int parallelism = 1;  // Note: will bump this later, code below works for any value

--- a/src/V3TraceDecl.cpp
+++ b/src/V3TraceDecl.cpp
@@ -72,13 +72,13 @@ private:
     AstCFunc* newCFunc(AstCFuncType type, const string& name) {
         FileLine* const flp = m_topScopep->fileline();
         AstCFunc* const funcp = new AstCFunc(flp, name, m_topScopep);
-        string argTypes("void* userp, " + v3Global.opt.traceClassBase() + "* tracep");
+        string argTypes = v3Global.opt.traceClassBase() + "* tracep";
         if (m_interface) argTypes += ", int scopet, const char* scopep";
         funcp->argTypes(argTypes);
         funcp->funcType(type);
-        funcp->symProlog(true);
+        funcp->isStatic(false);
+        funcp->isLoose(true);
         funcp->slow(true);
-        funcp->declPrivate(true);
         m_topScopep->addActivep(funcp);
         UINFO(5, "  Newfunc " << funcp << endl);
         return funcp;
@@ -86,10 +86,10 @@ private:
     void callCFuncSub(AstCFunc* basep, AstCFunc* funcp, AstIntfRef* irp) {
         AstCCall* callp = new AstCCall(funcp->fileline(), funcp);
         if (irp) {
-            callp->argTypes("userp, tracep, VLT_TRACE_SCOPE_INTERFACE");
+            callp->argTypes("tracep, VLT_TRACE_SCOPE_INTERFACE");
             callp->addArgsp(irp->unlinkFrBack());
         } else {
-            callp->argTypes("userp, tracep");
+            callp->argTypes("tracep");
         }
         basep->addStmtsp(callp);
     }

--- a/test_regress/t/t_c_this.pl
+++ b/test_regress/t/t_c_this.pl
@@ -1,0 +1,27 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2021 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(vlt => 1);
+
+compile();
+
+if ($Self->{vlt_all}) {
+    # The word 'this' (but only the whole word 'this' should have been replaced
+    # in the contents.
+    my $file = "$Self->{obj_dir}/$Self->{VM_PREFIX}.cpp";
+    my $text = file_contents($file);
+    error("$file has 'this->clk'") if ($text =~ m/\bthis->clk\b/);
+    error("$file does not have 'xthis'") if ($text !~ m/\bxthis\b/);
+    error("$file does not have 'thisx'") if ($text !~ m/\bthisx\b/);
+    error("$file does not have 'xthisx'") if ($text !~ m/\bxthisx\b/);
+}
+
+ok(1);
+1;

--- a/test_regress/t/t_c_this.v
+++ b/test_regress/t/t_c_this.v
@@ -1,0 +1,15 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2021 by Wilson Snyder.
+// SPDX-License-Identifier: CC0-1.0
+
+module t (clk);
+   input clk;
+   always @(posedge clk) begin
+     $c("const CData xthis = this->clk;");
+     $c("const CData thisx = xthis;");
+     $c("const CData xthisx = thisx;");
+     $c("this->clk = xthisx;");
+   end
+endmodule

--- a/test_regress/t/t_class_extends_this_protect_ids.pl
+++ b/test_regress/t/t_class_extends_this_protect_ids.pl
@@ -1,0 +1,33 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2020 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(vlt_all => 1);
+
+# This test makes randomly named .cpp/.h files, which tend to collect, so remove them first
+foreach my $filename (glob ("$Self->{obj_dir}/*_PS*.cpp"
+                            ." $Self->{obj_dir}/*_PS*.h"
+                            ." $Self->{obj_dir}/*.d" )) {
+    print "rm $filename\n" if $Self->{verbose};
+    unlink $filename;
+}
+
+top_filename("t/t_class_extends_this.v");
+
+compile(
+    verilator_flags2 => ["--protect-ids",
+                         "--protect-key SECRET_KEY"]
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_cover_line.out
+++ b/test_regress/t/t_cover_line.out
@@ -125,7 +125,7 @@
 	         end
 %000002	         else if (cyc==5) begin
 	`ifdef VERILATOR
-%000001	            $c("call_task();");
+%000001	            $c("this->call_task();");
 	`else
 	            call_task();
 	`endif

--- a/test_regress/t/t_cover_line.v
+++ b/test_regress/t/t_cover_line.v
@@ -104,7 +104,7 @@ module t (/*AUTOARG*/
          end
          else if (cyc==5) begin
 `ifdef VERILATOR
-            $c("call_task();");
+            $c("this->call_task();");
 `else
             call_task();
 `endif

--- a/test_regress/t/t_debug_emitv.out
+++ b/test_regress/t/t_debug_emitv.out
@@ -47,8 +47,6 @@ module Vt_debug_emitv;
     end
 
     ???? // CFUNC '_final_TOP'
-    $_CSTMT(Vt_debug_emitv* const __restrict vlTOPp VL_ATTR_UNUSED = vlSymsp->TOPp;
-    );
     $display("stmt");
     always @(posedge clk)@(negedge clk) begin
         $display("posedge clk");
@@ -238,13 +236,9 @@ class Vt_debug_emitv___024unit__03a__03aCls;
 signed int [31:0]  member;
 
 ???? // CFUNC '__VnoInFunc_method'
-$_CSTMT(Vt_debug_emitv* const __restrict vlTOPp VL_ATTR_UNUSED = vlSymsp->TOPp;
-);
 
 ???? // CFUNC 'new'
 $_CSTMT(_ctor_var_reset(vlSymsp);
-);
-$_CSTMT(Vt_debug_emitv* const __restrict vlTOPp VL_ATTR_UNUSED = vlSymsp->TOPp;
 );
 $unit::Cls.member = 32'sh1;
 endclass

--- a/test_regress/t/t_dpi_var.v
+++ b/test_regress/t/t_dpi_var.v
@@ -88,7 +88,7 @@ module sub (/*AUTOARG*/
 
    initial begin
       // Test the naming
-      $c("mon_class_name(name());");
+      $c("mon_class_name(this->name());");
       mon_scope_name("%m");
       // Scheme A - pass pointer directly
       $c("mon_register_a(\"in\",&",in,",false);");

--- a/test_regress/t/t_extend.v
+++ b/test_regress/t/t_extend.v
@@ -34,7 +34,7 @@ module t (/*AUTOARG*/
 `ifdef VERILATOR
 	 $c("VL_PRINTF(\"Calling $c, calling $c...\\n\");");
 	 $c("VL_PRINTF(\"Cyc=%d\\n\",",cyc,");");
-	 c_worked <= $c("my_function()");
+	 c_worked <= $c("this->my_function()");
 	 c_wider <= $c9("0x10");
 `else
 	 c_worked <= 1'b1;

--- a/test_regress/t/t_extend_class.v
+++ b/test_regress/t/t_extend_class.v
@@ -43,7 +43,7 @@ module t_extend_class_v (/*AUTOARG*/
 
    always @* begin
       // When "in" changes, call my method
-      out = $c("m_myobjp->my_math(",in,")");
+      out = $c("this->m_myobjp->my_math(",in,")");
    end
 
  `systemc_header

--- a/test_regress/t/t_flag_csplit.pl
+++ b/test_regress/t/t_flag_csplit.pl
@@ -96,6 +96,7 @@ sub check_cpp {
                 && $func !~ /::trace$/
                 && $func !~ /::traceInit$/
                 && $func !~ /::traceFull$/
+                && $func !~ /::final$/
                 ) {
                 push @funcs, $func;
             }

--- a/test_regress/t/t_flag_csplit_eval.pl
+++ b/test_regress/t/t_flag_csplit_eval.pl
@@ -15,7 +15,7 @@ sub check_evals {
         local $/; undef $/;
         my $wholefile = <$fh>;
 
-        if ($wholefile =~ /::_eval[0-9]+/) {
+        if ($wholefile =~ /___eval[0-9]+/) {
             ++$got;
         }
     }

--- a/test_regress/t/t_func_public.v
+++ b/test_regress/t/t_func_public.v
@@ -16,7 +16,7 @@ module t (clk);
 	 cyc <= cyc + 1;
 	 if (cyc==1) begin
 `ifdef verilator
-	    $c("publicTop();");
+	    $c("this->publicTop();");
 `endif
 	 end
 	 if (cyc==20) begin
@@ -84,32 +84,32 @@ module tpub (
 	 //
 `ifdef VERILATOR_PUBLIC_TASKS
 	 if (cyc==11) begin
-	    $c("publicNoArgs();");
-	    $c("publicSetBool(true);");
-	    $c("publicSetLong(0x11bca);");
-	    $c("publicSetQuad(0x66655554444ULL);");
-	    $c("publicSetFlop(0x321);");
+	    $c("this->publicNoArgs();");
+	    $c("this->publicSetBool(true);");
+	    $c("this->publicSetLong(0x11bca);");
+	    $c("this->publicSetQuad(0x66655554444ULL);");
+	    $c("this->publicSetFlop(0x321);");
 	    //Unsupported: $c("WData w[3] = {0x12, 0x5678_9123, 0x1245_2352}; publicSetWide(w);");
 	 end
 	 if (cyc==12) begin
-	    $c("got_bool = publicGetSetBool(true);");
-	    $c("got_long = publicGetSetLong(0x11bca);");
-	    $c("got_quad = publicGetSetQuad(0xaaaabbbbccccULL);");
+	    $c("this->got_bool = this->publicGetSetBool(true);");
+	    $c("this->got_long = this->publicGetSetLong(0x11bca);");
+	    $c("this->got_quad = this->publicGetSetQuad(0xaaaabbbbccccULL);");
 	 end
 	 if (cyc==13) begin
-	    $c("{ bool gb; publicGetBool(gb); got_bool=gb; }");
+	    $c("{ bool gb; this->publicGetBool(gb); this->got_bool=gb; }");
 	    if (1'b1 != got_bool) $stop;
-	    $c("publicGetLong(got_long);");
+	    $c("this->publicGetLong(this->got_long);");
 	    if (24'h11bca != got_long) $stop;
-	    $c("{ vluint64_t qq; publicGetQuad(qq); got_quad=qq; }");
+	    $c("{ vluint64_t qq; this->publicGetQuad(qq); this->got_quad=qq; }");
 	    if (60'haaaa_bbbb_cccc != got_quad) $stop;
-	    $c("{ WData gw[3]; publicGetWide(gw); VL_ASSIGN_W(72,got_wide,gw); }");
+	    $c("{ WData gw[3]; this->publicGetWide(gw); VL_ASSIGN_W(72,this->got_wide,gw); }");
 	    if (72'hac_abca_aaaa_bbbb_1234 != got_wide) $stop;
 	    //Below doesn't work, because we're calling it inside the loop that sets var_flop
 	    // if (12'h321 != var_flop) $stop;
 	 end
 	 if (cyc==14) begin
-	    if ($c32("publicInstNum()") != i) $stop;
+	    if ($c32("this->publicInstNum()") != i) $stop;
 	 end
 `endif
       end

--- a/test_regress/t/t_func_rand.v
+++ b/test_regress/t/t_func_rand.v
@@ -20,7 +20,7 @@ module t (clk, Rand);
       input [7:0]    idx;
       begin
 `ifdef verilator
-	 QxRand32 = $c ("QxRandTbl(",tbl,",",idx,")");
+	 QxRand32 = $c("this->QxRandTbl(",tbl,",",idx,")");
 `else
 	 QxRand32 = 32'hfeed0fad;
 `endif

--- a/test_regress/t/t_inst_tree_inl0_pub1.pl
+++ b/test_regress/t/t_inst_tree_inl0_pub1.pl
@@ -26,9 +26,7 @@ sub checkRelativeRefs {
     my $file = "$Self->{obj_dir}/V$Self->{name}_${mod}.cpp";
     my $text = file_contents($file);
 
-    # Remove "this->__VlSymsp" which is noise
-    $text =~ s/this->__VlSymsp//g;
-    if ($text =~ m/this->/) {
+    if ($text =~ m/this->/ || $text =~ m/vlSelf->/) {
         $found_relative = 1;
     }
 
@@ -45,12 +43,9 @@ if ($Self->{vlt_all}) {
     file_grep($Self->{stats}, qr/Optimizations, Combined CFuncs\s+(\d+)/i,
               ($Self->{vltmt} ? 84 : 52));
 
-    # Expect absolute refs in CFuncs for t (top module) and l1 (because it
-    # has only one instance)
-    checkRelativeRefs("t", 0);
-    checkRelativeRefs("l1", 0);
-
-    # Others should get relative references
+    # Everything should use relative references
+    checkRelativeRefs("t", 1);
+    checkRelativeRefs("l1", 1);
     checkRelativeRefs("l2", 1);
     checkRelativeRefs("l3", 1);
     checkRelativeRefs("l4", 1);

--- a/test_regress/t/t_inst_tree_inl0_pub1_norelcfuncs.pl
+++ b/test_regress/t/t_inst_tree_inl0_pub1_norelcfuncs.pl
@@ -24,13 +24,18 @@ if ($Self->{vlt_all}) {
     file_grep($Self->{stats}, qr/Optimizations, Combined CFuncs\s+(\d+)/i,
               ($Self->{vltmt} ? 0 : 31));
 
-    # Should not find any 'this->' except some 'this->__VlSymsp'
+    # Should not find any 'this->' or 'vlSelf->' except some specific cases
     my @files = `ls $Self->{obj_dir}/*.cpp`;
     foreach my $file (@files) {
         chomp $file;
         my $text = file_contents($file);
-        $text =~ s/this->__VlSymsp//g;
-        if ($text =~ m/this->/) {
+        $text =~ s/(vlSelf|this)->vlSymsp//g;
+        $text =~ s/vlSelf->.* = VL_RAND_RESET.*;//g;
+        $text =~ s/vlSelf->__Vm_even_cycle//g;
+        $text =~ s/vlSelf->__Vm_even_cycle//g;
+        $text =~ s/vlSelf->__Vm_mt_(final|\d+)//g;
+        $text =~ s/vlSelf->__Vm_threadPoolp//g;
+        if ($text =~ m/this->/ || $text =~ m/vlSelf->/) {
             error("$file has unexpected this-> refs when --norelative-cfuncs");
         }
     }

--- a/test_regress/t/t_param_public.v
+++ b/test_regress/t/t_param_public.v
@@ -27,7 +27,7 @@ module a;
    parameter ONE /*verilator public*/ = 22;
    initial if (ONE != 1) $stop;
 `ifdef VERILATOR
-   initial if ($c32("ONE") != 1) $stop;
+   initial if ($c32("this->ONE") != 1) $stop;
 `endif
 endmodule
 
@@ -36,7 +36,7 @@ module b #(
 	   );
    initial if (TWO != 2) $stop;
 `ifdef VERILATOR
-   initial if ($c32("TWO") != 2) $stop;
+   initial if ($c32("this->TWO") != 2) $stop;
 `endif
 endmodule
 

--- a/test_regress/t/t_protect_ids_key.out
+++ b/test_regress/t/t_protect_ids_key.out
@@ -29,6 +29,7 @@
   <map from="PSABAY" to="_eval_initial"/>
   <map from="PSOLeN" to="_eval_initial_loop"/>
   <map from="PSBUJ6" to="_eval_settle"/>
+  <map from="PSAsei" to="_final"/>
   <map from="PSV5uq" to="_sequent__TOP__1"/>
   <map from="PS8sdG" to="_sequent__TOP__t__DOT__secret_inst__1"/>
   <map from="PScyq8" to="clk"/>
@@ -38,6 +39,6 @@
   <map from="PSBSVV" to="t/t_protect_ids.v"/>
   <map from="PSB07q" to="t__DOT__secret_inst2__DOT__secret_cyc"/>
   <map from="this" to="this"/>
+  <map from="vlSelf" to="vlSelf"/>
   <map from="vlSymsp" to="vlSymsp"/>
-  <map from="vlTOPp" to="vlTOPp"/>
 </verilator_id_map>

--- a/test_regress/t/t_unopt_converge_initial_run_bad.out
+++ b/test_regress/t/t_unopt_converge_initial_run_bad.out
@@ -1,5 +1,5 @@
 -V{t#,#}- Verilated::debug is on. Message prefix indicates {<thread>,<sequence_number>}.
--V{t#,#}+    Vt_unopt_converge_initial_run_bad::_change_request
+-V{t#,#}+    Vt_unopt_converge_initial_run_bad___change_request
 -V{t#,#}        CHANGE: t/t_unopt_converge_initial.v:19: x
 %Error: t/t_unopt_converge_initial.v:7: Verilated model didn't DC converge
 Aborting...

--- a/test_regress/t/t_unopt_converge_print_bad.out
+++ b/test_regress/t/t_unopt_converge_print_bad.out
@@ -1,5 +1,5 @@
 -V{t#,#}- Verilated::debug is on. Message prefix indicates {<thread>,<sequence_number>}.
--V{t#,#}+    Vt_unopt_converge_print_bad::_change_request
+-V{t#,#}+    Vt_unopt_converge_print_bad___change_request
 -V{t#,#}        CHANGE: t/t_unopt_converge.v:19: x
 %Error: t/t_unopt_converge.v:7: Verilated model didn't converge
 Aborting...

--- a/test_regress/t/t_unopt_converge_run_bad.out
+++ b/test_regress/t/t_unopt_converge_run_bad.out
@@ -1,5 +1,5 @@
 -V{t#,#}- Verilated::debug is on. Message prefix indicates {<thread>,<sequence_number>}.
--V{t#,#}+    Vt_unopt_converge_run_bad::_change_request
+-V{t#,#}+    Vt_unopt_converge_run_bad___change_request
 -V{t#,#}        CHANGE: t/t_unopt_converge.v:19: x
 %Error: t/t_unopt_converge.v:7: Verilated model didn't converge
 Aborting...

--- a/test_regress/t/t_verilated_debug.out
+++ b/test_regress/t/t_verilated_debug.out
@@ -1,29 +1,30 @@
 -V{t#,#}- Verilated::debug is on. Message prefix indicates {<thread>,<sequence_number>}.
--V{t#,#}+    Vt_verilated_debug::_ctor_var_reset
+-V{t#,#}+    Vt_verilated_debug___ctor_var_reset
 internalsDump:
   Version: Verilator ###
   Argv: obj_vlt/t_verilated_debug/Vt_verilated_debug
   scopesDump:
 
--V{t#,#}+++++TOP Evaluate Vt_verilated_debug::eval
--V{t#,#}+    Vt_verilated_debug::_eval_debug_assertions
--V{t#,#}+    Vt_verilated_debug::_eval_initial
--V{t#,#}+    Vt_verilated_debug::_initial__TOP__1
+-V{t#,#}+++++TOP Evaluate Vt_verilated_debug::eval_step
+-V{t#,#}+    Vt_verilated_debug___eval_debug_assertions
+-V{t#,#}+    Vt_verilated_debug___eval_initial
+-V{t#,#}+    Vt_verilated_debug___initial__TOP__1
   Data: w96: 000000aa 000000bb 000000cc 
--V{t#,#}+    Vt_verilated_debug::_eval_settle
--V{t#,#}+    Vt_verilated_debug::_eval
--V{t#,#}+    Vt_verilated_debug::_change_request
--V{t#,#}+    Vt_verilated_debug::_change_request_1
+-V{t#,#}+ Initial loop
+-V{t#,#}+    Vt_verilated_debug___eval_settle
+-V{t#,#}+    Vt_verilated_debug___eval
+-V{t#,#}+    Vt_verilated_debug___change_request
+-V{t#,#}+    Vt_verilated_debug___change_request_1
 -V{t#,#}+ Clock loop
--V{t#,#}+    Vt_verilated_debug::_eval
--V{t#,#}+    Vt_verilated_debug::_change_request
--V{t#,#}+    Vt_verilated_debug::_change_request_1
--V{t#,#}+++++TOP Evaluate Vt_verilated_debug::eval
--V{t#,#}+    Vt_verilated_debug::_eval_debug_assertions
+-V{t#,#}+    Vt_verilated_debug___eval
+-V{t#,#}+    Vt_verilated_debug___change_request
+-V{t#,#}+    Vt_verilated_debug___change_request_1
+-V{t#,#}+++++TOP Evaluate Vt_verilated_debug::eval_step
+-V{t#,#}+    Vt_verilated_debug___eval_debug_assertions
 -V{t#,#}+ Clock loop
--V{t#,#}+    Vt_verilated_debug::_eval
--V{t#,#}+    Vt_verilated_debug::_sequent__TOP__2
+-V{t#,#}+    Vt_verilated_debug___eval
+-V{t#,#}+    Vt_verilated_debug___sequent__TOP__2
 *-* All Finished *-*
--V{t#,#}+    Vt_verilated_debug::_change_request
--V{t#,#}+    Vt_verilated_debug::_change_request_1
--V{t#,#}+    Vt_verilated_debug::final
+-V{t#,#}+    Vt_verilated_debug___change_request
+-V{t#,#}+    Vt_verilated_debug___change_request_1
+-V{t#,#}+    Vt_verilated_debug___final


### PR DESCRIPTION
This is a bigish change. It implements #2988  (which itself is on the way to #2958 and #2140). There are some minor differences from what was discussed in #2988 but the result is hopefully more practicable.

It is still WIP for the reasons raised below, on which I would like some advice, but it is mostly there. Regressions, ext tests pass and https://github.com/lowRISC/opentitan builds.

I tried to keep the commits self consistent and tests shold pass at all of them, in case this helps review.

I will try to summarize the effective change in the output code at the end of this patch queue.

Internally, there are 2 ways to reference variables/cells (as in V3Descope). Relative addressing via `this`, or absolute addressing via `vlSyms`. This means any internal function may require access to these 2 values.

In this PR, all internal functions that are under an `AstNodeModule` (except under `AstClass`) have been changed to receive an explicit `self` pointer as a single argument, and then converted to what I call 'loose methods'. Loose methods are semantically methods in the sense that they associate with a particular class, but they are declared as global functions, so they don't need to be declared in the header (which removes the dependency causing recompilatoin). This means the standard signature changed from:
```
<ModuleClass>::<funcname>(Syms* vlSyms);
```
to:
```
<ModuleClass>__<funcname>(<ModuleClass>* self);
```

In all modules bar AstClass, `vlSyms` is available via `self->vlSyms`. There are hints towards aliasing issues in V3Descope, but these seem to relate to vintage compliers, the workaround for which (--no-relative-cfuncs) is already deprecated. At a later date we should change things to use relative addressing wherever possible for simplicity. The issue seems to be the potential aliasing between `self` and `vlSyms->SOMETHING_WIHT_TYPE_OF_SELF`. I think if this ever comes out again, we should just teach Verilator to emmit better code that work with mixed references by the judiscious use or `restrict`, unless you think we need to worry about vintage compilers. Comments or concerns on this are welcome.

There is no change to methdos under an `AstClass`, they are emitted as methods before, and `vlSyms` is passed as a parameter as before.

To keep Verilator internals simple, relative references are always emitted as an acces via explicit poitner access by emitting `this->...`, and aboslute references are emitted as `vlSyms->...`. For normal methods, this just works because `this` is available, and `vlSyms` either comes from a function argument (for `AstClass` members) or a class member (other `AstNodeModule` members). For loose methods, we emit a standard prologue and epliloge of the form:
```
#define this self
#define vlSyms self->vlSyms
  <body>
#undef this
#undef vlSyms
```

Once we introduced loose methods, we now no longer need to declare them in the module header, so we just declare them lazily as needed.

This all seems to work. I run some basic benchmarking on EH1, and it looks ok:
```
Platform:
- Intel(R) Core(TM) i7-5930K
- Turbo boost disabled
- CPU frequency pinned to 3.50GHz
- Everything run single threaded on core 0
- Tracing to ramdisk
- System otherwise idle
- Ubuntu 20.04.2 LTS
- Compilers installed via apt

################################################################################
# EH1 - no tracing

make -f $RV_ROOT/tools/Makefile \
  VERILATOR=$VERILATOR \
  CONF_PARAMS="-iccm_enable=1 -fpga_optimize" \
  target=high_perf \
  TEST=cmark_iccm \
  verilator-build program.hex

numactl -C 0 perf stat -r 10 ./obj_dir/Vtb_top

+--------------+----------------+----------------+
| compiler     | loose methods  | 1f331bd9       |
+==============+================+================+
| gcc    9.3.0 | 18.30 +- 0.004 | 18.33 +- 0.004 |
| clang 10.0.0 | 19.44 +- 0.006 | 19.49 +- 0.005 |

####################
# EH1 - tracing

NOTE: testbench/test_tb_top.cpp modified to write sim.vcd to ramdisk

make -f $RV_ROOT/tools/Makefile \
  VERILATOR=$VERILATOR \
  CONF_PARAMS="-iccm_enable=1 -fpga_optimize" \
  target=high_perf \
  TEST=cmark_iccm \
  debug=1 \
  verilator-build program.hex

numactl -C 0 perf stat --pre "rm -f /ramdisk/sim.vcd" -r 10 ./obj_dir/Vtb_top +dumpon

+--------------+----------------+----------------+
| compiler     | loose methods  | 1f331bd9       |
+==============+================+================+
| gcc    9.3.0 | 55.81 +- 0.004 | 55.75 +- 0.008 |
| clang 10.0.0 | 42.62 +- 0.005 | 42.69 +- 0.014 |
```

The reason the PR is still WIP:
- I actually need to test with the hashing base code splitting I have been working on that this actually works, but it addresses the issues I saw previously. I will do this next.
- You might want to run some more performance benchmarks. Sadly I don't have access to large designs to do much more testing. I requested some suggestions from the opentitan team for using that project as a benchmark (looking at you @rswarbrick) as it seems to be of sufficient size.
- In all of this, there is a need to figure out which `AstNodeModule` a particular `AstCFunc` is under (for cross module references), I have been using the following gross hack to do this, which is not ideal:
https://github.com/gezalore/verilator/blob/a31b3fbed6ae904e3b2b57ebbc5899a0bb39af75/src/V3EmitC.cpp#L391-L393
Note in later patches there will be a need finding the module of any `AstVar` as well (again for cross module references to static constants for example), in which case this hack is not only gross but is a performance problem due to `backp` going backwards on a long list before moving up the tree at the head of the list. Having this mechanism also allows us to get rid of the `classPrefix` member from `AstVarRef`/`AstNodeCCall` (currently used to access superclass methods/static variable, which would be nice. Do you have a suggestion on what would be the best way of doing this? I worry having  a `m_modp` inside an `AstCFunc`/`AstVar` that points to the module up the tree would complicate internals having to keep it in sync when movingthings around. Also `m_scopep` seems not available all the way to Emit.

EDIT: fixed typos