### PR TITLE
Proper EXEEXT usage

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -44,6 +44,7 @@
 srcdir = @srcdir@
 VPATH = @srcdir@
 HOST = @HOST@
+EXEEXT = @EXEEXT@
 
 DOXYGEN = doxygen
 INSTALL = @INSTALL@
@@ -203,9 +204,9 @@ INST_PROJ_FILES = \
 	include/vltstd/*.[chv]* \
 
 INST_PROJ_BIN_FILES = \
-	bin/verilator_bin \
-	bin/verilator_bin_dbg \
-	bin/verilator_coverage_bin_dbg \
+	bin/verilator_bin$(EXEEXT) \
+	bin/verilator_bin_dbg$(EXEEXT) \
+	bin/verilator_coverage_bin_dbg$(EXEEXT) \
 
 EXAMPLES_FIRST = \
 	examples/make_hello_c \
@@ -221,10 +222,10 @@ all: all_nomsg msg_test
 all_nomsg: verilator_exe $(VL_INST_MAN_FILES)
 
 .PHONY:verilator_exe
-.PHONY:verilator_bin
-.PHONY:verilator_bin_dbg
-.PHONY:verilator_coverage_bin_dbg
-verilator_exe verilator_bin verilator_bin_dbg verilator_coverage_bin_dbg:
+.PHONY:verilator_bin$(EXEEXT)
+.PHONY:verilator_bin_dbg$(EXEEXT)
+.PHONY:verilator_coverage_bin_dbg$(EXEEXT)
+verilator_exe verilator_bin$(EXEEXT) verilator_bin_dbg$(EXEEXT) verilator_coverage_bin_dbg$(EXEEXT):
 	@echo ------------------------------------------------------------
 	@echo "making verilator in src"
 	$(MAKE) -C src $(OBJCACHE_JOBS) $(CI_MAKE_SRC_TARGET)
@@ -280,7 +281,7 @@ verilator.pdf: Makefile
 	$(MAKE) -C docs verilator.pdf
 
 # See uninstall also - don't put wildcards in this variable, it might uninstall other stuff
-VL_INST_BIN_FILES = verilator verilator_bin verilator_bin_dbg verilator_coverage_bin_dbg \
+VL_INST_BIN_FILES = verilator verilator_bin$(EXEEXT) verilator_bin_dbg$(EXEEXT) verilator_coverage_bin_dbg$(EXEEXT) \
 	verilator_coverage verilator_gantt verilator_includer verilator_profcfunc
 # Some scripts go into both the search path and pkgdatadir,
 # so they can be found by the user, and under $VERILATOR_ROOT.
@@ -305,9 +306,9 @@ installbin:
 	( cd ${srcdir}/bin ; $(INSTALL_PROGRAM) verilator_coverage $(DESTDIR)$(bindir)/verilator_coverage )
 	( cd ${srcdir}/bin ; $(INSTALL_PROGRAM) verilator_gantt $(DESTDIR)$(bindir)/verilator_gantt )
 	( cd ${srcdir}/bin ; $(INSTALL_PROGRAM) verilator_profcfunc $(DESTDIR)$(bindir)/verilator_profcfunc )
-	( cd bin ; $(INSTALL_PROGRAM) verilator_bin $(DESTDIR)$(bindir)/verilator_bin )
-	( cd bin ; $(INSTALL_PROGRAM) verilator_bin_dbg $(DESTDIR)$(bindir)/verilator_bin_dbg )
-	( cd bin ; $(INSTALL_PROGRAM) verilator_coverage_bin_dbg $(DESTDIR)$(bindir)/verilator_coverage_bin_dbg )
+	( cd bin ; $(INSTALL_PROGRAM) verilator_bin$(EXEEXT) $(DESTDIR)$(bindir)/verilator_bin$(EXEEXT) )
+	( cd bin ; $(INSTALL_PROGRAM) verilator_bin_dbg$(EXEEXT) $(DESTDIR)$(bindir)/verilator_bin_dbg$(EXEEXT) )
+	( cd bin ; $(INSTALL_PROGRAM) verilator_coverage_bin_dbg$(EXEEXT) $(DESTDIR)$(bindir)/verilator_coverage_bin_dbg$(EXEEXT) )
 	$(MKINSTALLDIRS) $(DESTDIR)$(pkgdatadir)/bin
 	( cd ${srcdir}/bin ; $(INSTALL_PROGRAM) verilator_includer $(DESTDIR)$(pkgdatadir)/bin/verilator_includer )
 
@@ -458,7 +459,7 @@ clang-tidy: $(CLANGTIDY_DEP)
 
 analyzer-src:
 	-rm -rf src/obj_dbg
-	scan-build $(MAKE) -k verilator_coverage_bin_dbg verilator_bin_dbg
+	scan-build $(MAKE) -k verilator_coverage_bin_dbg$(EXEEXT) verilator_bin_dbg$(EXEEXT)
 
 analyzer-include:
 	-rm -rf examples/*/obj*

--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -58,7 +58,7 @@ Marshal Qiao
 Matthew Ballance
 Michael Killough
 Mike Popoloski
-Miodrag Milanovic
+Miodrag Milanović
 Morten Borup Petersen
 Nandu Raj
 Nathan Kohagen

--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -58,6 +58,7 @@ Marshal Qiao
 Matthew Ballance
 Michael Killough
 Mike Popoloski
+Miodrag Milanovic
 Morten Borup Petersen
 Nandu Raj
 Nathan Kohagen

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -47,25 +47,25 @@ obj_dbg:
 
 .SUFFIXES:
 
-.PHONY: ../bin/verilator_bin ../bin/verilator_bin_dbg ../bin/verilator_coverage_bin_dbg
+.PHONY: ../bin/verilator_bin$(EXEEXT) ../bin/verilator_bin_dbg$(EXEEXT) ../bin/verilator_coverage_bin_dbg$(EXEEXT)
 
-opt: ../bin/verilator_bin
+opt: ../bin/verilator_bin$(EXEEXT)
 ifeq ($(VERILATOR_NO_OPT_BUILD),1)	# Faster laptop development... One build
-../bin/verilator_bin: ../bin/verilator_bin_dbg
-	-cp -p $<$(EXEEXT) $@$(EXEEXT).tmp
-	-mv -f $@$(EXEEXT).tmp $@$(EXEEXT)
+../bin/verilator_bin$(EXEEXT): ../bin/verilator_bin_dbg$(EXEEXT)
+	-cp -p $< $@.tmp
+	-mv -f $@.tmp $@
 else
-../bin/verilator_bin: obj_opt ../bin prefiles
+../bin/verilator_bin$(EXEEXT): obj_opt ../bin prefiles
 	$(MAKE) -C obj_opt -j 1  TGT=../$@ -f ../Makefile_obj serial
 	$(MAKE) -C obj_opt       TGT=../$@ -f ../Makefile_obj
 endif
 
-dbg: ../bin/verilator_bin_dbg ../bin/verilator_coverage_bin_dbg
-../bin/verilator_bin_dbg: obj_dbg ../bin prefiles
+dbg: ../bin/verilator_bin_dbg$(EXEEXT) ../bin/verilator_coverage_bin_dbg$(EXEEXT)
+../bin/verilator_bin_dbg$(EXEEXT): obj_dbg ../bin prefiles
 	$(MAKE) -C obj_dbg -j 1  TGT=../$@ VL_DEBUG=1 -f ../Makefile_obj serial
 	$(MAKE) -C obj_dbg       TGT=../$@ VL_DEBUG=1 -f ../Makefile_obj
 
-../bin/verilator_coverage_bin_dbg: obj_dbg ../bin prefiles
+../bin/verilator_coverage_bin_dbg$(EXEEXT): obj_dbg ../bin prefiles
 	$(MAKE) -C obj_dbg       TGT=../$@ VL_DEBUG=1 VL_VLCOV=1 -f ../Makefile_obj serial_vlcov
 	$(MAKE) -C obj_dbg       TGT=../$@ VL_DEBUG=1 VL_VLCOV=1 -f ../Makefile_obj
 

--- a/src/Makefile_obj.in
+++ b/src/Makefile_obj.in
@@ -72,7 +72,7 @@ CFG_LIBS = @CFG_LIBS@
 #### End of system configuration section. ####
 
 VPATH += . $(bldsrc) $(srcdir)
-TGT = ../../verilator_bin
+TGT = ../../verilator_bin$(EXEEXT)
 
 #################
 ifeq ($(VL_DEBUG),)


### PR DESCRIPTION
Current behavior of build/cross-build for Windows is that after make, when we run make install it do the linking one more time for all created binaries, making build time longer (linking verilator_bin_dbg.exe takes a lot of time). 
This patch sets proper executable names (with existing EXEEXT variable coming from configure script) and prevent issue described above.
This patch is already part of our nightly builds at https://github.com/YosysHQ/oss-cad-suite-build/

