### PR TITLE
Compile the debug build with -Og -ggdb -gz if supported.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -322,6 +322,16 @@ _MY_CXX_CHECK_OPT(CFG_CXXFLAGS_PARSER,-Wno-parentheses-equality)
 _MY_CXX_CHECK_OPT(CFG_CXXFLAGS_PARSER,-Wno-unused)
 AC_SUBST(CFG_CXXFLAGS_PARSER)
 
+# Flags for compiling the debug version of Verilator (in addition to above CFG_CXXFLAGS_SRC)
+_MY_CXX_CHECK_OPT(CFG_CXXFLAGS_DEBUG,-Og)
+_MY_CXX_CHECK_OPT(CFG_CXXFLAGS_DEBUG,-ggdb)
+_MY_CXX_CHECK_OPT(CFG_CXXFLAGS_DEBUG,-gz)
+AC_SUBST(CFG_CXXFLAGS_DEBUG)
+
+# Flags for linking the debug version of Verilator (in addition to above CFG_LDFLAGS_SRC)
+_MY_LDLIBS_CHECK_OPT(CFG_LDFLAGS_DEBUG,-gz)
+AC_SUBST(CFG_LDFLAGS_DEBUG)
+
 # Flags for Verilated makefile
 # For example, -Wno-div-by-zero isn't in 4.1.2
 # Random code often does / 0.  Unfortunately VL_DIV_I(0,0) will warn

--- a/src/Makefile_obj.in
+++ b/src/Makefile_obj.in
@@ -77,13 +77,11 @@ TGT = ../../verilator_bin$(EXEEXT)
 #################
 ifeq ($(VL_DEBUG),)
 # Optimize
-COPT = -O2
+CPPFLAGS += -O2
 else
 # Debug
-COPT = -ggdb -DVL_DEBUG -D_GLIBCXX_DEBUG
-# Debug & Profile:
-#LDFLAGS += -pg -g
-#COPT = -ggdb -pg -g
+CPPFLAGS += @CFG_CXXFLAGS_DEBUG@ -DVL_DEBUG -D_GLIBCXX_DEBUG
+LDFLAGS += @CFG_LDFLAGS_DEBUG@
 endif
 #################
 
@@ -96,7 +94,6 @@ LIBS = $(CFG_LIBS) -lm
 CPPFLAGS += -MMD
 CPPFLAGS += -I. -I$(bldsrc) -I$(srcdir) -I$(incdir) -I../../include
 #CPPFLAGS += -DVL_LEAK_CHECKS 	# If running valgrind or other hunting tool
-CPPFLAGS += $(COPT)
 CPPFLAGS += -MP # Only works on recent GCC versions
 ifeq ($(CFG_WITH_CCWARN),yes)	# Local... Else don't burden users
 CPPFLAGS += -W -Wall $(CFG_CXXFLAGS_WEXTRA) $(CFG_CXXFLAGS_SRC) -Werror

--- a/src/V3LinkInc.cpp
+++ b/src/V3LinkInc.cpp
@@ -176,7 +176,7 @@ private:
     void prepost_stmt_visit(AstNodeTriop* nodep) {
         iterateChildren(nodep);
 
-        AstNodeVarRef* varrefp;
+        AstNodeVarRef* varrefp = nullptr;
         if (m_unsupportedHere || !(varrefp = VN_CAST(nodep->rhsp(), VarRef))) {
             nodep->v3warn(E_UNSUPPORTED, "Unsupported: Incrementation in this context.");
             return;

--- a/src/V3Options.cpp
+++ b/src/V3Options.cpp
@@ -815,7 +815,7 @@ string V3Options::protectKeyDefaulted() {
 void V3Options::throwSigsegv() {  // LCOV_EXCL_START
 #if !(defined(VL_CPPCHECK) || defined(__clang_analyzer__))
     // clang-format off
-    { char* zp = nullptr; *zp = 0; }  // Intentional core dump, ignore warnings here
+    *static_cast<volatile char*>(nullptr) = 0;  // Intentional core dump, ignore warnings here
     // clang-format on
 #endif
 }  // LCOV_EXCL_STOP


### PR DESCRIPTION
@wsnyder let me know if you see this causing problems, otherwise I will merge it when passing (old compilers are happy on my fork, the code change is required to squash a gcc warning on 16.04)

---

Check the C++ compiler for -Og via configure and use it if available.

Per the GCC manual:
-Og should be the optimization level of choice for the standard
edit-compile-debug cycle, offering a reasonable level of optimization
while maintaining fast compilation and a good debugging experience. It
is a better choice than -O0 for producing debuggable code because some
compiler passes that collect debug information are disabled at -O0.

The debug exe is painfully slow on large designs, hopefully this is an
improvement.

Similarly, check for and use -gz to compress the debug info as it is
huge otherwise. This should help with distribution and caching on CI.

Also checks for -ggdb via configure for compatibility.