### PR TITLE
Update to clang-format-11

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -27,14 +27,14 @@ jobs:
           CI_BUILD_STAGE_NAME: build
         run: |
           bash ci/ci-install.bash &&
-          sudo apt-get install clang-10 yapf3 &&
+          sudo apt-get install clang-format-11 yapf3 &&
           git config --global user.email "action@example.com" &&
           git config --global user.name "github action"
       - name: Format code
         run: |
           autoconf &&
           ./configure &&
-          make -j 2 format CLANGFORMAT=clang-format-10 &&
+          make -j 2 format CLANGFORMAT=clang-format-11 &&
           git status
       - name: Push
         run: |

--- a/Makefile.in
+++ b/Makefile.in
@@ -470,13 +470,13 @@ analyzer-include:
 
 format: clang-format yapf format-pl-exec
 
-CLANGFORMAT = clang-format
+CLANGFORMAT = clang-format-11
 CLANGFORMAT_FLAGS = -i
 CLANGFORMAT_FILES = $(CPPCHECK_CPP) $(CPPCHECK_H) $(CPPCHECK_YL) test_regress/t/*.c* test_regress/t/*.h
 
 clang-format:
-	@$(CLANGFORMAT) --version | egrep 10.0 > /dev/null \
-		|| echo "*** You are not using clang-format 10.0, indents may differ from master's ***"
+	@$(CLANGFORMAT) --version | egrep 11.0 > /dev/null \
+		|| echo "*** You are not using clang-format 11.0, indents may differ from master's ***"
 	$(CLANGFORMAT) $(CLANGFORMAT_FLAGS) $(CLANGFORMAT_FILES)
 
 PY_PROGRAMS = \

--- a/docs/guide/install.rst
+++ b/docs/guide/install.rst
@@ -116,7 +116,7 @@ Those developing Verilator itself may also want these (see internals.rst):
 
 ::
 
-   sudo apt-get install gdb graphviz cmake clang clang-format gprof lcov
+   sudo apt-get install gdb graphviz cmake clang clang-format-11 gprof lcov
    sudo pip3 install sphinx sphinx_rtd_theme breathe
    cpan install Pod::Perldoc
    cpan install Parallel::Forker

--- a/include/verilated_sym_props.h
+++ b/include/verilated_sym_props.h
@@ -152,30 +152,34 @@ public:
     const VerilatedRange& unpacked() const { return m_unpacked[0]; }
     // DPI accessors
     int left(int dim) const {
-        return dim == 0 ? m_packed.left()
-                        : VL_LIKELY(dim >= 1 && dim <= udims()) ? m_unpacked[dim - 1].left() : 0;
+        return dim == 0                                ? m_packed.left()
+               : VL_LIKELY(dim >= 1 && dim <= udims()) ? m_unpacked[dim - 1].left()
+                                                       : 0;
     }
     int right(int dim) const {
-        return dim == 0 ? m_packed.right()
-                        : VL_LIKELY(dim >= 1 && dim <= udims()) ? m_unpacked[dim - 1].right() : 0;
+        return dim == 0                                ? m_packed.right()
+               : VL_LIKELY(dim >= 1 && dim <= udims()) ? m_unpacked[dim - 1].right()
+                                                       : 0;
     }
     int low(int dim) const {
-        return dim == 0 ? m_packed.low()
-                        : VL_LIKELY(dim >= 1 && dim <= udims()) ? m_unpacked[dim - 1].low() : 0;
+        return dim == 0                                ? m_packed.low()
+               : VL_LIKELY(dim >= 1 && dim <= udims()) ? m_unpacked[dim - 1].low()
+                                                       : 0;
     }
     int high(int dim) const {
-        return dim == 0 ? m_packed.high()
-                        : VL_LIKELY(dim >= 1 && dim <= udims()) ? m_unpacked[dim - 1].high() : 0;
+        return dim == 0                                ? m_packed.high()
+               : VL_LIKELY(dim >= 1 && dim <= udims()) ? m_unpacked[dim - 1].high()
+                                                       : 0;
     }
     int increment(int dim) const {
-        return dim == 0
-                   ? m_packed.increment()
-                   : VL_LIKELY(dim >= 1 && dim <= udims()) ? m_unpacked[dim - 1].increment() : 0;
+        return dim == 0                                ? m_packed.increment()
+               : VL_LIKELY(dim >= 1 && dim <= udims()) ? m_unpacked[dim - 1].increment()
+                                                       : 0;
     }
     int elements(int dim) const {
-        return dim == 0
-                   ? m_packed.elements()
-                   : VL_LIKELY(dim >= 1 && dim <= udims()) ? m_unpacked[dim - 1].elements() : 0;
+        return dim == 0                                ? m_packed.elements()
+               : VL_LIKELY(dim >= 1 && dim <= udims()) ? m_unpacked[dim - 1].elements()
+                                                       : 0;
     }
     // Total size in bytes (note DPI limited to 4GB)
     size_t totalSize() const;

--- a/src/V3AstNodes.h
+++ b/src/V3AstNodes.h
@@ -5428,9 +5428,9 @@ public:
                        : (m_urandom ? "%f$urandom()" : "%f$random()");
     }
     virtual string emitC() override {
-        return m_reset
-                   ? "VL_RAND_RESET_%nq(%nw, %P)"
-                   : seedp() ? "VL_RANDOM_SEEDED_%nq%lq(%nw, %P, %li)" : "VL_RANDOM_%nq(%nw, %P)";
+        return m_reset   ? "VL_RAND_RESET_%nq(%nw, %P)"
+               : seedp() ? "VL_RANDOM_SEEDED_%nq%lq(%nw, %P, %li)"
+                         : "VL_RANDOM_%nq(%nw, %P)";
     }
     virtual bool cleanOut() const override { return true; }
     virtual bool isGateOptimizable() const override { return false; }

--- a/src/V3EmitCConstPool.cpp
+++ b/src/V3EmitCConstPool.cpp
@@ -110,13 +110,11 @@ class EmitCConstPool final : EmitCBaseVisitor {
         UASSERT_OBJ(dtypep, nodep, "Array initializer has non-array dtype");
         const uint32_t size = dtypep->elementsConst();
         const uint32_t elemBytes = dtypep->subDTypep()->widthTotalBytes();
-        const uint32_t tabMod = dtypep->subDTypep()->isString()
-                                    ? 1  // String
-                                    : elemBytes <= 2
-                                          ? 8  // CData, SData
-                                          : elemBytes <= 4 ? 4  // IData
-                                                           : elemBytes <= 8 ? 2  // QData
-                                                                            : 1;
+        const uint32_t tabMod = dtypep->subDTypep()->isString() ? 1  // String
+                                : elemBytes <= 2                ? 8  // CData, SData
+                                : elemBytes <= 4                ? 4  // IData
+                                : elemBytes <= 8                ? 2  // QData
+                                                                : 1;
         VL_RESTORER(m_inUnpacked);
         VL_RESTORER(m_unpackedWord);
         m_inUnpacked = true;

--- a/src/V3GraphDfa.h
+++ b/src/V3GraphDfa.h
@@ -134,10 +134,10 @@ public:
         return (na() ? "yellow" : epsilon() ? "green" : "black");
     }
     virtual string dotLabel() const override {
-        return (na() ? ""
-                     : epsilon() ? "e"
-                                 : complement() ? ("not " + cvtToStr(input().toInt()))
-                                                : cvtToStr(input().toInt()));
+        return (na()           ? ""
+                : epsilon()    ? "e"
+                : complement() ? ("not " + cvtToStr(input().toInt()))
+                               : cvtToStr(input().toInt()));
     }
     virtual string dotStyle() const override { return (na() || cutable()) ? "dashed" : ""; }
     bool epsilon() const { return input().toInt() == EPSILON().toInt(); }

--- a/src/V3Name.cpp
+++ b/src/V3Name.cpp
@@ -118,13 +118,11 @@ private:
             if (nodep->aboveCellp()) iterate(nodep->aboveCellp());
             // Always recompute name (as many levels above scope may have changed)
             // Same formula as V3Scope
-            nodep->name(nodep->isTop()
-                            ? "TOP"
-                            : VN_IS(m_modp, Class) ? ("TOP." + m_modp->name())
-                                                   : VN_IS(m_modp, ClassPackage)
-                                                         ? ("TOP." + m_modp->name())
-                                                         : (nodep->aboveScopep()->name() + "."
-                                                            + nodep->aboveCellp()->name()));
+            nodep->name(nodep->isTop()         ? "TOP"
+                        : VN_IS(m_modp, Class) ? ("TOP." + m_modp->name())
+                        : VN_IS(m_modp, ClassPackage)
+                            ? ("TOP." + m_modp->name())
+                            : (nodep->aboveScopep()->name() + "." + nodep->aboveCellp()->name()));
             nodep->editCountInc();
             iterateChildren(nodep);
         }

--- a/src/V3Task.cpp
+++ b/src/V3Task.cpp
@@ -889,8 +889,9 @@ private:
                            << AstNode::prettyNameQ(nodep->cname()));
         }
         // Tasks (but not void functions) return a boolean 'int' indicating disabled
-        const string rtnType
-            = rtnvarp ? rtnvarp->dpiArgType(true, true) : nodep->dpiTask() ? "int" : "";
+        const string rtnType = rtnvarp            ? rtnvarp->dpiArgType(true, true)
+                               : nodep->dpiTask() ? "int"
+                                                  : "";
         AstCFunc* const funcp = new AstCFunc(nodep->fileline(), nodep->cname(), m_scopep, rtnType);
         funcp->dpiImportPrototype(true);
         funcp->dontCombine(true);

--- a/src/V3Tristate.cpp
+++ b/src/V3Tristate.cpp
@@ -92,12 +92,18 @@ public:
     AstNode* nodep() const { return m_nodep; }
     AstVar* varp() const { return VN_CAST(nodep(), Var); }
     virtual string name() const override {
-        return ((isTristate() ? "tri\\n" : feedsTri() ? "feed\\n" : "-\\n")
+        return ((isTristate() ? "tri\\n"
+                 : feedsTri() ? "feed\\n"
+                              : "-\\n")
                 + (nodep()->prettyTypeName() + " " + cvtToHex(nodep())));
     }
     virtual string dotColor() const override {
-        return (varp() ? (isTristate() ? "darkblue" : feedsTri() ? "blue" : "lightblue")
-                       : (isTristate() ? "darkgreen" : feedsTri() ? "green" : "lightgreen"));
+        return (varp() ? (isTristate() ? "darkblue"
+                          : feedsTri() ? "blue"
+                                       : "lightblue")
+                       : (isTristate() ? "darkgreen"
+                          : feedsTri() ? "green"
+                                       : "lightgreen"));
     }
     virtual FileLine* fileline() const override { return nodep()->fileline(); }
     void isTristate(bool flag) { m_isTristate = flag; }

--- a/src/V3Undriven.cpp
+++ b/src/V3Undriven.cpp
@@ -172,8 +172,9 @@ public:
                 allD = allU = true;
             if (allU) m_wholeFlags[FLAG_USED] = true;
             if (allD) m_wholeFlags[FLAG_DRIVEN] = true;
-            const char* const what
-                = nodep->isParam() ? "parameter" : nodep->isGenVar() ? "genvar" : "signal";
+            const char* const what = nodep->isParam()    ? "parameter"
+                                     : nodep->isGenVar() ? "genvar"
+                                                         : "signal";
             // Test results
             if (nodep->isIfaceRef()) {
                 // For interface top level we don't do any tracking

--- a/test_regress/t/t_tri_select.cpp
+++ b/test_regress/t/t_tri_select.cpp
@@ -17,11 +17,10 @@ bool check() {
     bool verbose = false;
 #endif
 
-    int Y = ((tb->OE1) & (!tb->OE2))
-                ? tb->A1
-                : ((!tb->OE1) & (tb->OE2))
-                      ? tb->A2
-                      : ((tb->OE1) & (tb->OE2)) ? (tb->A1 | tb->A2) : 3;  // pullup
+    int Y = ((tb->OE1) & (!tb->OE2))   ? tb->A1
+            : ((!tb->OE1) & (tb->OE2)) ? tb->A2
+            : ((tb->OE1) & (tb->OE2))  ? (tb->A1 | tb->A2)
+                                       : 3;  // pullup
 
     int W = (((tb->OE2) ? (tb->A2 & 0x1) : 0) << tb->A1)
             | (((tb->OE1) ? (tb->A2 >> 1) & 0x1 : 0) << tb->A2);


### PR DESCRIPTION
With clang-format 11, nested ternaries come out legible. It is available on 20.04 via `apt install clang-format-11`.

Any objection to updating?