### PR TITLE
Improve V3Localize

### DIFF
--- a/Changes
+++ b/Changes
@@ -18,6 +18,7 @@ Verilator 4.205 devel
 
 **Minor:**
 
+* Optimize a lot more model variables into function locals (#3027). [Geza Lore]
 * Remove deprecated --no-relative-cfuncs option (#3024). [Geza Lore]
 * Merge const static data globally into a new constant pool (#3013). [Geza Lore]
 * Fix error on unsupported recursive functions (#2957). [Trefor Southwell]

--- a/src/V3Ast.h
+++ b/src/V3Ast.h
@@ -156,6 +156,7 @@ public:
         return (m_e == READWRITE) ? VAccess(m_e) : (m_e == WRITE ? VAccess(READ) : VAccess(WRITE));
     }
     bool isReadOnly() const { return m_e == READ; }  // False with READWRITE
+    bool isWriteOnly() const { return m_e == WRITE; }  // False with READWRITE
     bool isReadOrRW() const { return m_e == READ || m_e == READWRITE; }
     bool isWriteOrRW() const { return m_e == WRITE || m_e == READWRITE; }
     bool isRW() const { return m_e == READWRITE; }

--- a/src/V3Ast.h
+++ b/src/V3Ast.h
@@ -26,6 +26,7 @@
 #include "V3Global.h"
 
 #include <cmath>
+#include <type_traits>
 #include <unordered_set>
 
 #include "V3Ast__gen_classes.h"  // From ./astgen
@@ -1141,10 +1142,14 @@ public:
     explicit VNUser(void* p) { m_u.up = p; }
     ~VNUser() = default;
     // Casters
-    WidthVP* c() const { return reinterpret_cast<WidthVP*>(m_u.up); }
-    VSymEnt* toSymEnt() const { return reinterpret_cast<VSymEnt*>(m_u.up); }
-    AstNode* toNodep() const { return reinterpret_cast<AstNode*>(m_u.up); }
-    V3GraphVertex* toGraphVertex() const { return reinterpret_cast<V3GraphVertex*>(m_u.up); }
+    template <class T>  //
+    typename std::enable_if<std::is_pointer<T>::value, T>::type to() const {
+        return reinterpret_cast<T>(m_u.up);
+    }
+    WidthVP* c() const { return to<WidthVP*>(); }
+    VSymEnt* toSymEnt() const { return to<VSymEnt*>(); }
+    AstNode* toNodep() const { return to<AstNode*>(); }
+    V3GraphVertex* toGraphVertex() const { return to<V3GraphVertex*>(); }
     int toInt() const { return m_u.ui; }
     static VNUser fromInt(int i) { return VNUser(i); }
 };

--- a/src/V3Ast.h
+++ b/src/V3Ast.h
@@ -2280,7 +2280,6 @@ private:
     string m_name;  // Name of variable
     string m_selfPointer;  // Output code object pointer (e.g.: 'this')
     string m_classPrefix;  // Output class prefix (i.e.: the part before ::)
-    bool m_hierThis = false;  // m_selfPointer points to "this" function
 
 protected:
     AstNodeVarRef(AstType t, FileLine* fl, const string& name, const VAccess& access)
@@ -2312,8 +2311,6 @@ public:
     void varp(AstVar* varp);
     AstVarScope* varScopep() const { return m_varScopep; }
     void varScopep(AstVarScope* varscp) { m_varScopep = varscp; }
-    bool hierThis() const { return m_hierThis; }
-    void hierThis(bool flag) { m_hierThis = flag; }
     string selfPointer() const { return m_selfPointer; }
     void selfPointer(const string& value) { m_selfPointer = value; }
     string selfPointerProtect(bool useSelfForThis) const;

--- a/src/V3AstNodes.h
+++ b/src/V3AstNodes.h
@@ -2150,7 +2150,6 @@ public:
     }
     bool isClassMember() const { return varType() == AstVarType::MEMBER; }
     bool isStatementTemp() const { return (varType() == AstVarType::STMTTEMP); }
-    bool isMovableToBlock() const { return (varType() == AstVarType::BLOCKTEMP || isFuncLocal()); }
     bool isXTemp() const { return (varType() == AstVarType::XTEMP); }
     bool isParam() const {
         return (varType() == AstVarType::LPARAM || varType() == AstVarType::GPARAM);

--- a/src/V3AstUserAllocator.h
+++ b/src/V3AstUserAllocator.h
@@ -1,0 +1,119 @@
+// -*- mode: C++; c-file-style: "cc-mode" -*-
+//*************************************************************************
+// DESCRIPTION: Verilator: Utility to hang advanced data structures of
+// AstNode::user*p() pointers with automatic memory management.
+//
+// Code available from: https://verilator.org
+//
+//*************************************************************************
+//
+// Copyright 2003-2021 by Wilson Snyder. This program is free software; you
+// can redistribute it and/or modify it under the terms of either the GNU
+// Lesser General Public License Version 3 or the Perl Artistic License
+// Version 2.0.
+// SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+//
+//*************************************************************************
+
+#ifndef VERILATOR_V3ASTUSERALLOCATOR_H_
+#define VERILATOR_V3ASTUSERALLOCATOR_H_
+
+#include "config_build.h"
+#include "verilatedos.h"
+
+#include "V3Ast.h"
+
+#include <type_traits>
+#include <vector>
+
+template <class T_Node, class T_Data, int T_UserN> class AstUserAllocatorBase VL_NOT_FINAL {
+    static_assert(1 <= T_UserN && T_UserN <= 5, "Wrong user pointer number");
+    static_assert(std::is_base_of<AstNode, T_Node>::value, "T_Node must be an AstNode type");
+
+private:
+    std::vector<T_Data*> m_allocated;
+
+    inline T_Data* getUserp(T_Node* nodep) const {
+        // This simplifies statically as T_UserN is constant. In C++17, use 'if constexpr'.
+        if (T_UserN == 1) {
+            VNUser user = nodep->user1u();
+            return user.to<T_Data*>();
+        } else if (T_UserN == 2) {
+            VNUser user = nodep->user2u();
+            return user.to<T_Data*>();
+        } else if (T_UserN == 3) {
+            VNUser user = nodep->user3u();
+            return user.to<T_Data*>();
+        } else if (T_UserN == 4) {
+            VNUser user = nodep->user4u();
+            return user.to<T_Data*>();
+        } else {
+            VNUser user = nodep->user5u();
+            return user.to<T_Data*>();
+        }
+    }
+
+    inline void setUserp(T_Node* nodep, T_Data* userp) const {
+        // This simplifies statically as T_UserN is constant. In C++17, use 'if constexpr'.
+        if (T_UserN == 1) {
+            nodep->user1u(VNUser(userp));
+        } else if (T_UserN == 2) {
+            nodep->user2u(VNUser(userp));
+        } else if (T_UserN == 3) {
+            nodep->user3u(VNUser(userp));
+        } else if (T_UserN == 4) {
+            nodep->user4u(VNUser(userp));
+        } else {
+            nodep->user5u(VNUser(userp));
+        }
+    }
+
+protected:
+    AstUserAllocatorBase() {
+        // This simplifies statically as T_UserN is constant. In C++17, use 'if constexpr'.
+        if (T_UserN == 1) {
+            AstUser1InUse::check();
+        } else if (T_UserN == 2) {
+            AstUser2InUse::check();
+        } else if (T_UserN == 3) {
+            AstUser3InUse::check();
+        } else if (T_UserN == 4) {
+            AstUser4InUse::check();
+        } else {
+            AstUser5InUse::check();
+        }
+    }
+
+    virtual ~AstUserAllocatorBase() {
+        // Delete all allocated data structures
+        for (T_Data* const p : m_allocated) { delete p; }
+    }
+
+public:
+    // Get a reference to the user data
+    T_Data& operator()(T_Node* nodep) {
+        T_Data* userp = getUserp(nodep);
+        if (!userp) {
+            userp = new T_Data;
+            m_allocated.push_back(userp);
+            setUserp(nodep, userp);
+        }
+        return *userp;
+    }
+};
+
+// User pointer allocator classes. T_Node is the type of node the allocator should be applied to
+// and is simply there for a bit of extra type safety. T_Data is the type of the data structure
+// managed by the allocator.
+template <class T_Node, class T_Data>
+class AstUser1Allocator final : public AstUserAllocatorBase<T_Node, T_Data, 1> {};
+template <class T_Node, class T_Data>
+class AstUser2Allocator final : public AstUserAllocatorBase<T_Node, T_Data, 2> {};
+template <class T_Node, class T_Data>
+class AstUser3Allocator final : public AstUserAllocatorBase<T_Node, T_Data, 3> {};
+template <class T_Node, class T_Data>
+class AstUser4Allocator final : public AstUserAllocatorBase<T_Node, T_Data, 4> {};
+template <class T_Node, class T_Data>
+class AstUser5Allocator final : public AstUserAllocatorBase<T_Node, T_Data, 5> {};
+
+#endif  // Guard

--- a/src/V3Clock.cpp
+++ b/src/V3Clock.cpp
@@ -38,6 +38,34 @@
 #include <algorithm>
 
 //######################################################################
+// Convert every WRITE AstVarRef to a READ ref
+
+class ConvertWriteRefsToRead final : public AstNVisitor {
+private:
+    // MEMBERS
+    AstNode* m_result = nullptr;
+
+    // CONSTRUCTORS
+    explicit ConvertWriteRefsToRead(AstNode* nodep) {
+        m_result = iterateSubtreeReturnEdits(nodep);
+    }
+
+    // VISITORS
+    void visit(AstVarRef* nodep) override {
+        UASSERT_OBJ(!nodep->access().isRW(), nodep, "Cannot handle a READWRITE reference");
+        if (nodep->access().isWriteOnly()) {
+            nodep->replaceWith(
+                new AstVarRef(nodep->fileline(), nodep->varScopep(), VAccess::READ));
+        }
+    }
+
+    void visit(AstNode* nodep) override { iterateChildren(nodep); }
+
+public:
+    static AstNode* main(AstNode* nodep) { return ConvertWriteRefsToRead(nodep).m_result; }
+};
+
+//######################################################################
 // Clock state, as a visitor of each AstNode
 
 class ClockVisitor final : public AstNVisitor {
@@ -272,14 +300,14 @@ private:
         //   IF(ORIG ^ CHANGE) { INC; CHANGE = ORIG; }
         AstNode* incp = nodep->incp()->unlinkFrBack();
         AstNode* origp = nodep->origp()->unlinkFrBack();
-        AstNode* changep = nodep->changep()->unlinkFrBack();
-        AstIf* newp = new AstIf(nodep->fileline(), new AstXor(nodep->fileline(), origp, changep),
+        AstNode* changeWrp = nodep->changep()->unlinkFrBack();
+        AstNode* changeRdp = ConvertWriteRefsToRead::main(changeWrp->cloneTree(false));
+        AstIf* newp = new AstIf(nodep->fileline(), new AstXor(nodep->fileline(), origp, changeRdp),
                                 incp, nullptr);
         // We could add another IF to detect posedges, and only increment if so.
         // It's another whole branch though versus a potential memory miss.
         // We'll go with the miss.
-        newp->addIfsp(
-            new AstAssign(nodep->fileline(), changep->cloneTree(false), origp->cloneTree(false)));
+        newp->addIfsp(new AstAssign(nodep->fileline(), changeWrp, origp->cloneTree(false)));
         nodep->replaceWith(newp);
         VL_DO_DANGLING(nodep->deleteTree(), nodep);
     }

--- a/src/V3DepthBlock.cpp
+++ b/src/V3DepthBlock.cpp
@@ -48,25 +48,24 @@ private:
     AstCFunc* createDeepFunc(AstNode* nodep) {
         AstNRelinker relinkHandle;
         nodep->unlinkFrBack(&relinkHandle);
-        // Create function
-        string name = m_cfuncp->name() + "__deep" + cvtToStr(++m_deepNum);
-        AstCFunc* funcp = new AstCFunc(nodep->fileline(), name, nullptr);
+        // Create sub function
+        AstScope* const scopep = m_cfuncp->scopep();
+        const string name = m_cfuncp->name() + "__deep" + cvtToStr(++m_deepNum);
+        AstCFunc* const funcp = new AstCFunc(nodep->fileline(), name, scopep);
         funcp->slow(m_cfuncp->slow());
         funcp->isStatic(m_cfuncp->isStatic());
         funcp->isLoose(m_cfuncp->isLoose());
         funcp->addStmtsp(nodep);
-        m_modp->addStmtp(funcp);
-        // Call it at the point where the body was removed from
-        AstCCall* callp = new AstCCall(nodep->fileline(), funcp);
+        scopep->addActivep(funcp);
+        // Call sub function at the point where the body was removed from
+        AstCCall* const callp = new AstCCall(nodep->fileline(), funcp);
         if (VN_IS(m_modp, Class)) {
             funcp->argTypes(EmitCBaseVisitor::symClassVar());
             callp->argTypes("vlSymsp");
-        } else if (!funcp->isStatic()) {
-            callp->selfPointer("this");
         }
         UINFO(6, "      New " << callp << endl);
-        //
         relinkHandle.relink(callp);
+        // Done
         return funcp;
     }
 

--- a/src/Verilator.cpp
+++ b/src/Verilator.cpp
@@ -403,9 +403,6 @@ static void process() {
         if (v3Global.opt.trace()) V3Trace::traceAll(v3Global.rootp());
 
         if (v3Global.opt.stats()) V3Stats::statsStageAll(v3Global.rootp(), "Scoped");
-
-        // Remove scopes; make varrefs/funccalls relative to current module
-        V3Descope::descopeAll(v3Global.rootp());
     }
 
     //--MODULE OPTIMIZATIONS--------------
@@ -416,8 +413,14 @@ static void process() {
             V3DepthBlock::depthBlockAll(v3Global.rootp());
         }
 
-        // Move BLOCKTEMPS from class to local variables
+        // Up until this point, all references must be scoped
+        v3Global.assertScoped(false);
+
+        // Move variables from modules to function local variables where possible
         if (v3Global.opt.oLocalize()) V3Localize::localizeAll(v3Global.rootp());
+
+        // Remove remaining scopes; make varrefs/funccalls relative to current module
+        V3Descope::descopeAll(v3Global.rootp());
 
         // Icache packing; combine common code in each module's functions into subroutines
         if (v3Global.opt.oCombine()) V3Combine::combineAll(v3Global.rootp());


### PR DESCRIPTION
Got a bit side tracked form the ccache efficiency work when I found this optimization opportunity. It makes the OpenTitan model 8.5% faster when compiled without --trace (measured on a single threaded model), as V3Localize now finds an additional ~21000 variables that it can convert into locals which no longer need to live in (and be stored to) the model state. ~~(Sadly when compiled with tracing these opportunities go away as variables are read in the tracing routines.)~~ 

There are 3 patches and they should be kept separate as they are largely orthogonal. The first moves V3Descpoe after V3Localize, and teaches V3Localize how to localize variables of another module. Patch 2 is just infrastructure to be used in patch 3 initially but is generic. Patch 3 teaches V3Localize how to localize any variable that is always assigned before it's read within a function (previously it only did this if the variable was used only in a single function, but a lot of stuff was duplicaed into the settle loop, so there was a lot of lost opportuity).

Some numbers for OpenTitan (single threaded, without --trace):
```
Old Localize: (0a28fc8c)

      68,728.68 msec task-clock                #    1.000 CPUs utilized            ( +-  0.05% )
             75      context-switches          #    0.001 K/sec                    ( +- 31.50% )
              0      cpu-migrations            #    0.000 K/sec
          1,549      page-faults               #    0.023 K/sec                    ( +-  0.02% )
240,412,856,507      cycles                    #    3.498 GHz                      ( +-  0.05% )
232,031,502,038      instructions              #    0.97  insn per cycle           ( +-  0.00% )
 11,966,905,530      branches                  #  174.118 M/sec                    ( +-  0.00% )
    261,356,240      branch-misses             #    2.18% of all branches          ( +-  0.47% )

        68.7321 +- 0.0323 seconds time elapsed  ( +-  0.05% )


New Localize: (21917abf)

      63,407.49 msec task-clock                #    1.000 CPUs utilized            ( +-  0.04% )
             39      context-switches          #    0.001 K/sec                    ( +- 56.85% )
              0      cpu-migrations            #    0.000 K/sec
          1,434      page-faults               #    0.023 K/sec                    ( +-  0.01% )
221,799,502,259      cycles                    #    3.498 GHz                      ( +-  0.04% )
211,109,106,971      instructions              #    0.95  insn per cycle           ( +-  0.00% )
 11,898,040,540      branches                  #  187.644 M/sec                    ( +-  0.00% )
    264,866,360      branch-misses             #    2.23% of all branches          ( +-  0.78% )

        63.4091 +- 0.0265 seconds time elapsed  ( +-  0.04% )

```
