### PR TITLE
Adding failing test case for source synchronous signals

### DIFF
--- a/test_regress/t/t_source_sync.out
+++ b/test_regress/t/t_source_sync.out
@@ -1,7 +1,7 @@
-%Error: t/t_source_sync.v:20:14: syntax error, unexpected /*verilator clocker*/, expecting ',' or ';'
-   20 |    logic clk /*verilator clocker*/ ;
+%Error: t/t_source_sync.v:8:14: syntax error, unexpected /*verilator clocker*/, expecting ',' or ';'
+    8 |    logic clk /*verilator clocker*/ ;
       |              ^~~~~~~~~~~~~~~~~~~~~
-%Error: t/t_source_sync.v:22:1: syntax error, unexpected '}'
-   22 | } ss_s;
+%Error: t/t_source_sync.v:10:1: syntax error, unexpected '}'
+   10 | } ss_s;
       | ^
 %Error: Exiting due to

--- a/test_regress/t/t_source_sync.out
+++ b/test_regress/t/t_source_sync.out
@@ -1,0 +1,7 @@
+%Error: t/t_source_sync.v:20:14: syntax error, unexpected /*verilator clocker*/, expecting ',' or ';'
+   20 |    logic clk /*verilator clocker*/ ;
+      |              ^~~~~~~~~~~~~~~~~~~~~
+%Error: t/t_source_sync.v:22:1: syntax error, unexpected '}'
+   22 | } ss_s;
+      | ^
+%Error: Exiting due to

--- a/test_regress/t/t_source_sync.pl
+++ b/test_regress/t/t_source_sync.pl
@@ -1,0 +1,20 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2019 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(linter => 1);
+
+compile(
+    );
+
+execute(
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_source_sync.pl
+++ b/test_regress/t/t_source_sync.pl
@@ -8,12 +8,11 @@ if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); di
 # Version 2.0.
 # SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
 
-scenarios(linter => 1);
+scenarios(vlt => 1);
 
 compile(
-    );
-
-execute(
+    fails => 1,
+    expect_filename => $Self->{golden_filename},
     );
 
 ok(1);

--- a/test_regress/t/t_source_sync.v
+++ b/test_regress/t/t_source_sync.v
@@ -1,17 +1,5 @@
 // DESCRIPTION: Verilator: Verilog Test module
 //
-// Use this file as a template for submitting bugs, etc.
-// This module takes a single clock input, and should either
-//      $write("*-* All Finished *-*\n");
-//      $finish;
-// on success, or $stop.
-//
-// The code as shown applies a random vector to the Test
-// module, then calculates a CRC on the Test module's outputs.
-//
-// **If you do not wish for your code to be released to the public
-// please note it here, otherwise:**
-//
 // This file ONLY is placed under the Creative Commons Public Domain, for
 // any use, without warranty, 2020 by Dan Petrisko.
 // SPDX-License-Identifier: CC0-1.0

--- a/test_regress/t/t_source_sync.v
+++ b/test_regress/t/t_source_sync.v
@@ -1,0 +1,24 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// Use this file as a template for submitting bugs, etc.
+// This module takes a single clock input, and should either
+//      $write("*-* All Finished *-*\n");
+//      $finish;
+// on success, or $stop.
+//
+// The code as shown applies a random vector to the Test
+// module, then calculates a CRC on the Test module's outputs.
+//
+// **If you do not wish for your code to be released to the public
+// please note it here, otherwise:**
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2020 by Dan Petrisko.
+// SPDX-License-Identifier: CC0-1.0
+
+typedef struct packed {
+   logic clk /*verilator clocker*/;
+   logic data;
+} ss_s;
+
+endmodule


### PR DESCRIPTION
Source-synchronous structs are a common construct. With complex code, Verilator does not detect the clock signal in the struct as a clock. Trying to fix this with a clocker pragma results in the following error, exposed by this test case:

```
======================================================================
vlt/t_source_sync: ==================================================
        perl /home/dpetrisko/scratch/verilator/test_regress/../bin/verilator --prefix Vt_source_sync ../obj_vlt/t_source_sync/Vt_source_sync__main.cpp --exe --make gmake --x-assign unique -cc -Mdir obj_vlt/t_source_sync -OD --debug-check --comp-limit-members 10 --clk clk  -f input.vc +define+TEST_OBJ_DIR=obj_vlt/t_source_sync t/t_source_sync.v    > obj_vlt/t_source_sync/vlt_compile.log
%Error: t/t_source_sync.v:20:14: syntax error, unexpected /*verilator clocker*/, expecting ',' or ';'
   20 |    logic clk /*verilator clocker*/ ;
      |              ^~~~~~~~~~~~~~~~~~~~~
%Error: t/t_source_sync.v:22:1: syntax error, unexpected '}'
   22 | } ss_s;
      | ^
%Error: Exiting due to 2 error(s)
%Warning: vlt/t_source_sync: Exec of perl failed: %Error: t/t_source_sync.v:20:14: syntax error, unexpected /*verilator clocker*/, expecting ',' or ';'

vlt/t_source_sync: %Error: Exec of perl failed: %Error: t/t_source_sync.v:20:14: syntax error, unexpected /*verilator clocker*/, expecting ',' or ';'
vlt/t_source_sync: FAILED: Exec of perl failed: %Error: t/t_source_sync.v:20:14: syntax error, unexpected /*verilator clocker*/, expecting ',' or ';'
==SUMMARY: Passed 0  Failed 1  Unsup 0  Time 0:01
==SUMMARY: Passed 0  Failed 1  Unsup 0  Time 0:01

======================================================================
        #vlt/t_source_sync: %Error: Exec of perl failed: %Error: t/t_source_sync.v:20:14: syntax error, unexpected /*verilator clocker*/, expecting ',' or ';'
                make && test_regress/t/t_source_sync.pl  --vlt
TESTS DONE, FAILED: Passed 0  Failed 1  Unsup 0  Time 0:01
```