### PR TITLE
Support assignment patterns as children of pins

### DIFF
--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -4127,6 +4127,9 @@ private:
         // TOP LEVEL NODE
         if (nodep->modVarp() && nodep->modVarp()->isGParam()) {
             // Widthing handled as special init() case
+            if (auto* patternp = VN_CAST(nodep->exprp(), Pattern))
+                if (auto* modVarp = nodep->modVarp())
+                    patternp->childDTypep(modVarp->childDTypep()->cloneTree(false));
             userIterateChildren(nodep, WidthVP(SELF, BOTH).p());
         } else if (!m_paramsOnly) {
             if (!nodep->modVarp()->didWidth()) {

--- a/test_regress/t/t_param_pattern.pl
+++ b/test_regress/t/t_param_pattern.pl
@@ -1,0 +1,22 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2003 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    verilator_flags2 => ['--dump-tree']
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_param_pattern.v
+++ b/test_regress/t/t_param_pattern.v
@@ -1,0 +1,45 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed into the Public Domain, for any use,
+// without warranty, 2021 by Krzysztof Bieganski.
+// SPDX-License-Identifier: CC0-1.0
+
+`define checkd(gotv,expv) do if ((gotv) !== (expv)) begin $write("%%Error: %s:%0d:  got=%0d exp=%0d\n", `__FILE__,`__LINE__, (gotv), (expv)); $stop; end while(0);
+
+package config_pkg;
+   typedef struct packed {
+      int UPPER0;
+      int UPPER2;
+      int USE_QUAD0;
+      int USE_QUAD1;
+      int USE_QUAD2;
+   } config_struct;
+
+endpackage : config_pkg
+
+module t;
+    import config_pkg::*;
+
+    struct_submodule #(.MY_CONFIG('{
+                                       UPPER0: 10,
+                                       UPPER2: 20,
+                                       USE_QUAD0: 4,
+                                       USE_QUAD1: 5,
+                                       USE_QUAD2: 6
+                                    })) a_submodule_I ();
+endmodule : t
+
+module struct_submodule
+  import config_pkg::*;
+   #(parameter config_struct MY_CONFIG = '0);
+
+   initial begin
+      `checkd(MY_CONFIG.UPPER0, 10);
+      `checkd(MY_CONFIG.USE_QUAD0, 4);
+      `checkd(MY_CONFIG.USE_QUAD1, 5);
+      `checkd(MY_CONFIG.USE_QUAD2, 6);
+      `checkd(MY_CONFIG.UPPER2, 20);
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end
+endmodule : struct_submodule


### PR DESCRIPTION
Currently, initializing a parameter with an assignment pattern causes the following error:

```
Unsupported/Illegal: Assignment pattern member not underneath a supported construct: PIN 
```

This PR is an attempt to fix that. It's a bit hacky, but the problem is that when Verilator tries to convert the parameter value's AST to a constant, it's unable to do so because the pin doesn't have a dtype (the corresponding module var also doesn't have it, but it does have a `childDTypep`, which is what I'm using here).

Of course, I'm open to suggestions on how to do it in a more proper way.