### PR TITLE
Fix shadowing of vlSymsp

### DIFF
--- a/src/V3EmitC.cpp
+++ b/src/V3EmitC.cpp
@@ -285,7 +285,7 @@ void EmitCImp::emitCtorImp(AstNodeModule* modp) {
         putsDecoration("// Create Sym instance\n");
         // Must be before other constructors, as __vlCoverInsert calls it.
         // Note _vcontextp__ may be nullptr, VerilatedSyms::VerilatedSyms cleans it up
-        puts(EmitCBaseVisitor::symClassVar() + " = new " + symClassName() + "("
+        puts("new " + symClassName() + "("
              + (optSystemC() ? "nullptr" : "_vcontextp__") + ", this, name());\n");
     }
 
@@ -339,9 +339,9 @@ void EmitCImp::emitConfigureImp(AstNodeModule* modp) {
     }
 
     puts("\nvoid " + modName + "::" + protect("__Vconfigure") + "(" + symClassName()
-         + "* vlSymsp, bool first) {\n");
+         + "* _vlSymsp, bool first) {\n");
     puts("if (false && first) {}  // Prevent unused\n");
-    puts("this->vlSymsp = vlSymsp;\n");  // First, as later stuff needs it.
+    puts("this->vlSymsp = _vlSymsp;\n");  // First, as later stuff needs it.
     if (v3Global.opt.coverage()) {
         puts(modName + "__" + protect("_configure_coverage") + "(this, first);\n");
     }

--- a/src/V3EmitC.cpp
+++ b/src/V3EmitC.cpp
@@ -285,8 +285,8 @@ void EmitCImp::emitCtorImp(AstNodeModule* modp) {
         putsDecoration("// Create Sym instance\n");
         // Must be before other constructors, as __vlCoverInsert calls it.
         // Note _vcontextp__ may be nullptr, VerilatedSyms::VerilatedSyms cleans it up
-        puts("new " + symClassName() + "("
-             + (optSystemC() ? "nullptr" : "_vcontextp__") + ", this, name());\n");
+        puts("new " + symClassName() + "(" + (optSystemC() ? "nullptr" : "_vcontextp__")
+             + ", this, name());\n");
     }
 
     emitSensitives();


### PR DESCRIPTION
This commit removes shadowing of the vlSymsp member of the top-level module, allowing models to compile when `-Werror=shadow` is set.
This may be useful when i.e., an external project which defines its own error flags depends on the processor model.
