### PR TITLE
Add #include <cerrno> in verilated.h

### DIFF
--- a/include/verilated.h
+++ b/include/verilated.h
@@ -45,6 +45,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <cerrno>
 // <iostream> avoided to reduce compile time
 // <map> avoided and instead in verilated_heavy.h to reduce compile time
 // <string> avoided and instead in verilated_heavy.h to reduce compile time


### PR DESCRIPTION
Related to the error of #2255 (wherein it looks like none of the proposed fixed got merged):
> /usr/bin/ld: _ZN9Verilated3t_sE: TLS reference in ... mismatches non-TLS definition in verilated.o section .bss

Adding `#include <errno.h>` does not seem to provide a consistent fix - I think that the `#include <cerrno>` of verilated.cpp provides a conflicting definition of `errno` in some edge-cases. Adding the `#include <cerrno>` in verilated.h (seems to) solve the issue.
