### PR TITLE
Add simulator benchmarking data option for regression tests

### DIFF
--- a/test_regress/driver.pl
+++ b/test_regress/driver.pl
@@ -1755,6 +1755,10 @@ sub _make_main {
     print $fh "#define MAIN_TIME_MULTIPLIER ".($self->{main_time_multiplier} || 1)."\n";
 
     print $fh "#include <memory>\n";
+    print $fh "#include <fstream>\n" if $self->{benchmarksim};
+    print $fh "#include <chrono>\n" if $self->{benchmarksim};
+    print $fh "#include <iomanip>\n" if $self->{benchmarksim};
+
     print $fh "// OS header\n";
     print $fh "#include \"verilatedos.h\"\n";
 
@@ -1770,9 +1774,6 @@ sub _make_main {
     print $fh "#include \"verilated_vcd_c.h\"\n" if $self->{trace} && $self->{trace_format} eq 'vcd-c';
     print $fh "#include \"verilated_vcd_sc.h\"\n" if $self->{trace} && $self->{trace_format} eq 'vcd-sc';
     print $fh "#include \"verilated_save.h\"\n" if $self->{savable};
-    print $fh "#include <fstream>\n" if $self->{benchmarksim};
-    print $fh "#include <chrono>\n" if $self->{benchmarksim};
-    print $fh "#include <iomanip>\n" if $self->{benchmarksim};
 
     print $fh "std::unique_ptr<$VM_PREFIX> topp;\n";
 

--- a/test_regress/driver.pl
+++ b/test_regress/driver.pl
@@ -706,7 +706,8 @@ sub init_benchmarksim {
     my $self = (ref $_[0] ? shift : $Self);
     # Simulations with benchmarksim enabled append to the same file between runs.
     # Test files must ensure a clean benchmark data file before executing tests.
-    my $fh = IO::File->new(">".benchmarksim_filename) or die "%Error: $! ".benchmarksim_filename;
+    my $filename = $self->benchmarksim_filename();
+    my $fh = IO::File->new(">".$filename) or die "%Error: $! ".$filename;
     print $fh "# Verilator simulation benchmark data\n";
     print $fh "# Test name: ".$self->{name}."\n";
     print $fh "# Top file: ".$self->{top_filename}."\n";
@@ -1897,7 +1898,7 @@ sub _make_main {
         $fh->print("            starttime = std::chrono::steady_clock::now();\n");
         $fh->print("            warm = true;\n");
         $fh->print("        } else {\n");
-        $fh->print("            n_evals++;\n");
+        $fh->print("            ++n_evals;\n");
         $fh->print("        }\n");
     }
     print $fh "    }\n";
@@ -1905,7 +1906,7 @@ sub _make_main {
     if ($self->{benchmarksim}) {
         $fh->print("    {\n");
         $fh->print("        const std::chrono::duration<double> exec_s =  std::chrono::steady_clock::now() - starttime;\n");
-        $fh->print("        std::ofstream benchfile(\"".$self->benchmarksim_filename."\", std::ofstream::out | std::ofstream::app);\n");
+        $fh->print("        std::ofstream benchfile(\"".$self->benchmarksim_filename()."\", std::ofstream::out | std::ofstream::app);\n");
         $fh->print("        benchfile << std::fixed << std::setprecision(9) << n_evals << \",\" << exec_s.count() << std::endl;\n");
         $fh->print("        benchfile.close();\n");
         $fh->print("    }\n");

--- a/test_regress/driver.pl
+++ b/test_regress/driver.pl
@@ -2707,7 +2707,7 @@ should be used instead.
 =item benchmarksim
 
 Output the number of model evaluations and execution time of a test to
-I<test_output_dir>/I<test_name>_benchmarksim.csv. Multiple invocations 
+I<test_output_dir>/I<test_name>_benchmarksim.csv. Multiple invocations
 of the same test file will append to to the same .csv file.
 
 =item xsim_flags

--- a/test_regress/driver.pl
+++ b/test_regress/driver.pl
@@ -1828,7 +1828,8 @@ sub _make_main {
 
     if ($self->{benchmarksim}) {
         $fh->print("    std::chrono::time_point<std::chrono::steady_clock> starttime;\n");
-        $fh->print("    bool warm = false;\n")
+        $fh->print("    bool warm = false;\n");
+        $fh->print("    uint64_t n_evals = 0;\n");
     }
 
     if ($self->{trace}) {
@@ -1894,8 +1895,9 @@ sub _make_main {
         $fh->print("        if (VL_UNLIKELY(!warm)) {\n");
         $fh->print("            starttime = std::chrono::steady_clock::now();\n");
         $fh->print("            warm = true;\n");
+        $fh->print("        } else {\n");
+        $fh->print("            n_evals++;\n");
         $fh->print("        }\n");
-
     }
     print $fh "    }\n";
 
@@ -1903,7 +1905,7 @@ sub _make_main {
         $fh->print("    {\n");
         $fh->print("        const std::chrono::duration<double> exec_s =  std::chrono::steady_clock::now() - starttime;\n");
         $fh->print("        std::ofstream benchfile(\"".$self->benchmarksim_filename."\", std::ofstream::out | std::ofstream::app);\n");
-        $fh->print("        benchfile << std::fixed << std::setprecision(9) << sim_time << \",\" << exec_s.count() << std::endl;\n");
+        $fh->print("        benchfile << std::fixed << std::setprecision(9) << n_evals << \",\" << exec_s.count() << std::endl;\n");
         $fh->print("        benchfile.close();\n");
         $fh->print("    }\n");
     }
@@ -2703,7 +2705,7 @@ should be used instead.
 
 =item benchmarksim
 
-Output the number of cycles executed and execution time of a test to
+Output the number of model evaluations and execution time of a test to
 I<test_output_dir>/I<test_name>_benchmarksim.csv. Multiple invocations 
 of the same test file will append to to the same .csv file.
 

--- a/test_regress/t/t_benchmarksim.pl
+++ b/test_regress/t/t_benchmarksim.pl
@@ -13,14 +13,14 @@ scenarios(vlt => 1);
 # Use any top file
 top_filename("t/t_a1_first_cc.v");
 
-init_simbenchmark();
+init_benchmarksim();
 
 # As an example, compile and simulate the top file with varying optimization level
 my @l_opt = (1,2,3);
 
 foreach my $l_opt (@l_opt) {
     compile(
-        simbenchmark => 1,
+        benchmarksim => 1,
         v_flags2 => ["-O$l_opt"]
         );
 
@@ -29,7 +29,7 @@ foreach my $l_opt (@l_opt) {
         );
 }
 
-my $fh = IO::File->new("<".simbenchmark_filename) or error("Benchmark data file not found");
+my $fh = IO::File->new("<".benchmarksim_filename) or error("Benchmark data file not found");
 my $lines = 0;
 while (defined(my $line = $fh->getline)) {
     if ($line =~ /^#/) { next; }

--- a/test_regress/t/t_benchmarksim.pl
+++ b/test_regress/t/t_benchmarksim.pl
@@ -11,7 +11,7 @@ if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); di
 scenarios(vlt => 1);
 
 # Use any top file
-top_filename("t/t_a1_first_cc.v");
+top_filename("t/t_gen_alw.v");
 
 init_benchmarksim();
 

--- a/test_regress/t/t_benchmarksim.pl
+++ b/test_regress/t/t_benchmarksim.pl
@@ -29,7 +29,7 @@ foreach my $l_opt (@l_opt) {
         );
 }
 
-my $fh = IO::File->new("<".benchmarksim_filename) or error("Benchmark data file not found");
+my $fh = IO::File->new("<".benchmarksim_filename()) or error("Benchmark data file not found");
 my $lines = 0;
 while (defined(my $line = $fh->getline)) {
     if ($line =~ /^#/) { next; }

--- a/test_regress/t/t_simbenchmark.pl
+++ b/test_regress/t/t_simbenchmark.pl
@@ -1,0 +1,48 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2003 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(vlt => 1);
+
+# Use any top file
+top_filename("t/t_a1_first_cc.v");
+
+init_simbenchmark();
+
+# As an example, compile and simulate the top file with varying optimization level
+my @l_opt = (1,2,3);
+my $n_opt = scalar(@l_opt);
+
+foreach my $l_opt (@l_opt) {
+    compile(
+        simbenchmark => 1,
+        v_flags2 => ["-O$l_opt"]
+        );
+
+    execute(
+        check_finished => 1,
+        );
+}
+
+my $fh = IO::File->new("<".simbenchmark_filename) or error("Benchmark data file not found");
+my $lines = 0;
+while (defined(my $line = $fh->getline)) {
+    if ($line =~ /^#/) { next; }
+    my @data = grep {$_ != ""} ($line =~ /(\d*\.?\d*)/g);
+    error("Expected 2 tokens on line ".$lines." but got ".scalar(@data)) if scalar(@data) != 2;
+    my $cycles = $data[0];
+    my $time = $data[1];
+    error("Invalid data on line ".$lines) if $cycles <= 0.0 || $time <= 0.0;
+    $lines += 1;
+}
+
+error("Expected ".$n_opt." lines but found ".$lines) if int($lines) != int($n_opt);
+
+1;
+ok(1);

--- a/test_regress/t/t_simbenchmark.pl
+++ b/test_regress/t/t_simbenchmark.pl
@@ -17,7 +17,6 @@ init_simbenchmark();
 
 # As an example, compile and simulate the top file with varying optimization level
 my @l_opt = (1,2,3);
-my $n_opt = scalar(@l_opt);
 
 foreach my $l_opt (@l_opt) {
     compile(
@@ -34,15 +33,20 @@ my $fh = IO::File->new("<".simbenchmark_filename) or error("Benchmark data file 
 my $lines = 0;
 while (defined(my $line = $fh->getline)) {
     if ($line =~ /^#/) { next; }
-    my @data = grep {$_ != ""} ($line =~ /(\d*\.?\d*)/g);
-    error("Expected 2 tokens on line ".$lines." but got ".scalar(@data)) if scalar(@data) != 2;
-    my $cycles = $data[0];
-    my $time = $data[1];
-    error("Invalid data on line ".$lines) if $cycles <= 0.0 || $time <= 0.0;
+    if ($lines == 0) {
+        error("Expected header but found $line") if $line ne "evals, time[s]\n";
+    } else {
+        my @data = grep {$_ != ""} ($line =~ /(\d*\.?\d*)/g);
+        error("Expected 2 tokens on line ".$lines." but got ".scalar(@data)) if scalar(@data) != 2;
+        my $cycles = $data[0];
+        my $time = $data[1];
+        error("Invalid data on line ".$lines) if $cycles <= 0.0 || $time <= 0.0;
+    }
     $lines += 1;
 }
+my $n_lines_expected = scalar(@l_opt) + 1;
 
-error("Expected ".$n_opt." lines but found ".$lines) if int($lines) != int($n_opt);
+error("Expected ".$n_lines_expected." lines but found ".$lines) if int($lines) != int($n_lines_expected);
 
 1;
 ok(1);


### PR DESCRIPTION
This commit adds a `simbenchmark` option to the regression test `compile` command, for precisely logging test cycles and execution time.
The option is not intended as a fully-fledged benchmarking infrastructure, but rather a utility for generating cycle- and execution time information when executing a verilated test.
This is a step away from being associated with actual regression testing. However, the regression test infrastructure already allows for scripting different invocations of verilator and the executable, useful for benchmarking.

As an example use case, the included test file shows how optimization level is varied across three different builds+simulations. The output file from this test is:
```
# Verilator simulation benchmark data
# Test name: t_simbenchmark
# Top file: t/t_a1_first_cc.v
# cycles	time[s]
1100	0.000039
1100	0.000027
1100	0.000028
```
The output is easy to parse for further processing/plotting. Whether there, in the future, should be an option to plot the output data could be discussed.

Future work:
- `sim_time` in the generated top-level main file should be a parameter.
- Given the above, the test execution script from verilog-sim-benchmark can be integrated to generate better estimates of cycles/second through varying 'sim_time' over multiple executions.

This is the first time I am touching perl (I'll leave my thoughts on the language to myself ... :wink:), so I apologize in advance if there is anything horrible in there!