### PR TITLE
Fix suspicious dtype clone relinking.

### DIFF
--- a/src/V3Ast.cpp
+++ b/src/V3Ast.cpp
@@ -932,7 +932,9 @@ AstNode* AstNode::iterateSubtreeReturnEdits(AstNVisitor& v) {
 void AstNode::cloneRelinkTree() {
     // private: Cleanup clone() operation on whole tree. Publicly call cloneTree() instead.
     for (AstNode* nodep = this; nodep; nodep = nodep->m_nextp) {
-        if (m_dtypep && m_dtypep->clonep()) m_dtypep = m_dtypep->clonep();
+        if (nodep->m_dtypep && nodep->m_dtypep->clonep()) {
+            nodep->m_dtypep = nodep->m_dtypep->clonep();
+        }
         nodep->cloneRelink();
         if (nodep->m_op1p) nodep->m_op1p->cloneRelinkTree();
         if (nodep->m_op2p) nodep->m_op2p->cloneRelinkTree();


### PR DESCRIPTION
I found this just reading the code, does not affect the generated code
and it has been like this for 9 years, but it does seem like this is a
bug. Introduced in 87e87368236049ba2ba3b36f003c6e3e02231078.

This is quite strange and basic, so if you have comments let me know, otherwise just merge please.