### PR TITLE
Emit function locals in the place they appear in the tree

### DIFF
--- a/src/V3EmitCFunc.cpp
+++ b/src/V3EmitCFunc.cpp
@@ -544,7 +544,6 @@ void EmitCFunc::emitVarList(AstNode* firstp, EisWhich which, const string& prefi
                     doit = (varp->isParam() && !VN_IS(varp->valuep(), Const));
                     break;
                 case EVL_CLASS_ALL: doit = true; break;
-                case EVL_FUNC_ALL: doit = true; break;
                 default: v3fatalSrc("Bad Case");
                 }
                 if (varp->isStatic() ? !isstatic : isstatic) doit = false;
@@ -574,8 +573,8 @@ void EmitCFunc::emitVarList(AstNode* firstp, EisWhich which, const string& prefi
                            && !varp->isSc()  // Aggregates can't be anon
                            && (varp->basicp()
                                && !varp->basicp()->isOpaque())  // Aggregates can't be anon
-                           && which != EVL_FUNC_ALL);  // Anon not legal in funcs, and gcc
-                                                       // bug free there anyhow
+                        );
+
                     if (anonOk) {
                         varAnonMap[sortbytes].push_back(varp);
                     } else {


### PR DESCRIPTION
Quick check to see if you think we should not do this for some reason. It all works on tests/ext-tests/titan and performance is same. In the future we should emit known sub-expression as variables so the C compiler need not spend time discovering they are indeed common sub-expressions (e.g.: in V3Expand we clone index expressions all over the place, so we know they are the same), so it would be good to transition to this scheme where function local variables are declared where they are in the AST, so the output code is more readable. Can just merge if happy.

---

Commit message:

Do not sort and hoist function local variables to the top of the
function definition. The stack layout of automatic variables is not
defined by C so the compilers can lay these out optimally. Simplifies
internals for follow on work. Effect on model performance is neutral to
very slight improvement, so we do not seem to be loosing anything.

