### PR TITLE
Emit implementations into separate files based on required headers.

### DIFF
--- a/Changes
+++ b/Changes
@@ -14,6 +14,8 @@ Verilator 4.211 devel
 **Minor:**
 
 * Fix -G to treat simple integer literals as signed (#3060). [Anikin1610]
+* Output files are split based on the set of headers required
+  in order to aid incremental compilation via ccache (#3071). [Geza Lore]
 
 
 Verilator 4.210 2021-07-07

--- a/src/V3CUse.cpp
+++ b/src/V3CUse.cpp
@@ -59,8 +59,6 @@ class CUseVisitor final : public AstNVisitor {
     virtual void visit(AstClassRefDType* nodep) override {
         if (nodep->user1SetOnce()) return;  // Process once
         if (!m_impOnly) addNewUse(nodep, VUseType::INT_FWD_CLASS, nodep->classp()->name());
-        // No class.h, it's inside the class package's h file
-        addNewUse(nodep, VUseType::IMP_INCLUDE, nodep->classp()->classOrPackagep()->name());
         // Need to include extends() when we implement, but no need for pointers to know
         VL_RESTORER(m_impOnly);
         {

--- a/src/V3EmitCFunc.h
+++ b/src/V3EmitCFunc.h
@@ -118,7 +118,6 @@ private:
     AstVarRef* m_wideTempRefp;  // Variable that _WW macros should be setting
     int m_labelNum;  // Next label number
     int m_splitSize;  // # of cfunc nodes placed into output file
-    int m_splitFilenum;  // File number being created, 0 = primary
     bool m_inUC = false;  // Inside an AstUCStmt or AstUCMath
     std::vector<AstChangeDet*> m_blkChangeDetVec;  // All encountered changes in block
 
@@ -133,15 +132,11 @@ public:
     VL_DEBUG_FUNC;  // Declare debug()
 
     // ACCESSORS
-    int splitFilenumInc() {
-        m_splitSize = 0;
-        return m_splitFilenum++;
-    }
-    int splitSize() const { return m_splitSize; }
     void splitSizeInc(int count) { m_splitSize += count; }
     void splitSizeInc(AstNode* nodep) { splitSizeInc(EmitCBaseCounterVisitor(nodep).count()); }
+    void splitSizeReset() { m_splitSize = 0; }
     bool splitNeeded() const {
-        return v3Global.opt.outputSplit() && splitSize() >= v3Global.opt.outputSplit();
+        return v3Global.opt.outputSplit() && m_splitSize >= v3Global.opt.outputSplit();
     }
 
     // METHODS
@@ -1220,7 +1215,6 @@ public:
         m_wideTempRefp = nullptr;
         m_labelNum = 0;
         m_splitSize = 0;
-        m_splitFilenum = 0;
     }
     EmitCFunc(AstNode* nodep, V3OutCFile* ofp, bool trackText = false)
         : EmitCFunc{} {

--- a/src/V3EmitCModel.cpp
+++ b/src/V3EmitCModel.cpp
@@ -20,11 +20,13 @@
 #include "V3Global.h"
 #include "V3EmitC.h"
 #include "V3EmitCFunc.h"
+#include "V3UniqueNames.h"
 
 #include <algorithm>
 #include <vector>
 
 class EmitCModel final : public EmitCFunc {
+    V3UniqueNames m_uniqueNames;  // For generating unique file names
 
     // METHODS
     VL_DEBUG_FUNC;
@@ -584,11 +586,13 @@ class EmitCModel final : public EmitCFunc {
             }
 
             if (!m_ofp) {
-                const string filename = v3Global.opt.makeDir() + "/" + topClassName()
-                                        + "__Dpi_Export_" + cvtToStr(splitFilenumInc()) + ".cpp";
+                string filename = v3Global.opt.makeDir() + "/" + topClassName() + "__Dpi_Export";
+                filename = m_uniqueNames.get(filename);
+                filename += ".cpp";
                 newCFile(filename, /* slow: */ false, /* source: */ true);
                 m_ofp = v3Global.opt.systemC() ? new V3OutScFile{filename}
                                                : new V3OutCFile{filename};
+                splitSizeReset();  // Reset file size tracking
                 m_lazyDecls.reset();
                 m_ofp->putsHeader();
                 puts(

--- a/src/V3UniqueNames.h
+++ b/src/V3UniqueNames.h
@@ -1,0 +1,39 @@
+// -*- mode: C++; c-file-style: "cc-mode" -*-
+//*************************************************************************
+// DESCRIPTION: Verilator: Basic data structure to keep names unique
+//
+// Code available from: https://verilator.org
+//
+//*************************************************************************
+//
+// Copyright 2005-2021 by Wilson Snyder. This program is free software; you
+// can redistribute it and/or modify it under the terms of either the GNU
+// Lesser General Public License Version 3 or the Perl Artistic License
+// Version 2.0.
+// SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+//
+//*************************************************************************
+//
+//*************************************************************************
+
+#ifndef VERILATOR_V3UNIQUENAMES_H_
+#define VERILATOR_V3UNIQUENAMES_H_
+#include "config_build.h"
+#include "verilatedos.h"
+
+#include <string>
+#include <unordered_map>
+
+class V3UniqueNames final {
+    std::unordered_map<std::string, unsigned> m_multiplicity;  // Suffix number for given key
+
+public:
+    // Return argument, appended with a unique suffix each time we are called with the same
+    // argument.
+    std::string get(const std::string& name) {
+        const unsigned num = m_multiplicity.emplace(name, 0).first->second++;
+        return name + "__" + cvtToStr(num);
+    }
+};
+
+#endif  // Guard

--- a/test_regress/t/t_alw_noreorder.pl
+++ b/test_regress/t/t_alw_noreorder.pl
@@ -19,8 +19,9 @@ file_grep($Self->{stats}, qr/Optimizations, Split always\s+(\d+)/i, 0);
 # Here we should see some dly vars since reorder is disabled.
 # (Whereas our twin test, t_alw_reorder, should see no dly vars
 #  since it enables the reorder step.)
-file_grep("$Self->{obj_dir}/$Self->{VM_PREFIX}___024root.cpp", qr/dly__t__DOT__v1/i);
-file_grep("$Self->{obj_dir}/$Self->{VM_PREFIX}___024root.cpp", qr/dly__t__DOT__v2/i);
+my @files = glob_all("$Self->{obj_dir}/$Self->{VM_PREFIX}___024root*.cpp");
+file_grep_any(\@files, qr/dly__t__DOT__v1/i);
+file_grep_any(\@files, qr/dly__t__DOT__v2/i);
 
 execute(
     check_finished=>1,

--- a/test_regress/t/t_alw_reorder.pl
+++ b/test_regress/t/t_alw_reorder.pl
@@ -18,8 +18,10 @@ file_grep($Self->{stats}, qr/Optimizations, Split always\s+(\d+)/i, 0);
 # Important: if reorder succeeded, we should see no dly vars.
 # Equally important: twin test t_alw_noreorder should see dly vars,
 #  is identical to this test except for disabling the reorder step.
-foreach my $file ("$Self->{obj_dir}/$Self->{VM_PREFIX}.cpp",
-                  "$Self->{obj_dir}/$Self->{VM_PREFIX}.h") {
+foreach my $file (
+      glob_all("$Self->{obj_dir}/$Self->{VM_PREFIX}*.h"),
+      glob_all("$Self->{obj_dir}/$Self->{VM_PREFIX}*.cpp")
+    ) {
     file_grep_not($file, qr/dly__t__DOT__v1/i);
     file_grep_not($file, qr/dly__t__DOT__v2/i);
     file_grep_not($file, qr/dly__t__DOT__v3/i);

--- a/test_regress/t/t_c_this.pl
+++ b/test_regress/t/t_c_this.pl
@@ -15,7 +15,7 @@ compile();
 if ($Self->{vlt_all}) {
     # The word 'this' (but only the whole word 'this' should have been replaced
     # in the contents.
-    my $file = "$Self->{obj_dir}/$Self->{VM_PREFIX}___024root.cpp";
+    my $file = glob_one("$Self->{obj_dir}/$Self->{VM_PREFIX}___024root__DepSet_*__0.cpp");
     my $text = file_contents($file);
     error("$file has 'this->clk'") if ($text =~ m/\bthis->clk\b/);
     error("$file does not have 'xthis'") if ($text !~ m/\bxthis\b/);

--- a/test_regress/t/t_flag_comp_limit_parens.pl
+++ b/test_regress/t/t_flag_comp_limit_parens.pl
@@ -18,7 +18,7 @@ execute(
     check_finished => 1,
     );
 
-file_grep("$Self->{obj_dir}/Vt_flag_comp_limit_parens___024root__Slow.cpp", qr/Vdeeptemp/x);
+file_grep(glob_one("$Self->{obj_dir}/Vt_flag_comp_limit_parens___024root__DepSet_*__0__Slow.cpp"), qr/Vdeeptemp/x);
 
 ok(1);
 1;

--- a/test_regress/t/t_flag_csplit_off.pl
+++ b/test_regress/t/t_flag_csplit_off.pl
@@ -61,7 +61,7 @@ while (1) {
 sub check_no_splits {
     foreach my $file (glob("$Self->{obj_dir}/*.cpp")) {
         $file =~ s/__024root//;
-        if ($file =~ qr/__\d/) {
+        if ($file =~ qr/__[1-9]/) {
             error("Split file found: $file");
         }
     }

--- a/test_regress/t/t_flag_xinitial_unique.pl
+++ b/test_regress/t/t_flag_xinitial_unique.pl
@@ -18,7 +18,7 @@ execute(
     check_finished => 1,
     );
 
-file_grep("$Self->{obj_dir}/$Self->{VM_PREFIX}___024root__Slow.cpp", qr/VL_RAND_RESET/);
+file_grep(glob_one("$Self->{obj_dir}/$Self->{VM_PREFIX}___024root__DepSet_*__0__Slow.cpp"), qr/VL_RAND_RESET/);
 
 ok(1);
 1;

--- a/test_regress/t/t_foreach.pl
+++ b/test_regress/t/t_foreach.pl
@@ -20,14 +20,16 @@ execute(
 
 # We expect all loops should be unrolled by verilator,
 # none of the loop variables should exist in the output:
-file_grep_not("$Self->{obj_dir}/$Self->{VM_PREFIX}___024root.cpp", qr/index_/);
-file_grep_not("$Self->{obj_dir}/$Self->{VM_PREFIX}___024root__Slow.cpp", qr/index_/);
+for my $file (glob_all("$Self->{obj_dir}/$Self->{VM_PREFIX}*.cpp")) {
+  file_grep_not($file, qr/index_/);
+}
 
 # Further, we expect that all logic within the loop should
 # have been evaluated inside the compiler. So there should be
 # no references to 'sum' in the .cpp.
-file_grep_not("$Self->{obj_dir}/$Self->{VM_PREFIX}___024root.cpp", qr/sum/);
-file_grep_not("$Self->{obj_dir}/$Self->{VM_PREFIX}___024root__Slow.cpp", qr/sum/);
+for my $file (glob_all("$Self->{obj_dir}/$Self->{VM_PREFIX}*.cpp")) {
+  file_grep_not($file, qr/sum/);
+}
 
 ok(1);
 1;

--- a/test_regress/t/t_inst_tree_inl0_pub1.pl
+++ b/test_regress/t/t_inst_tree_inl0_pub1.pl
@@ -23,17 +23,18 @@ sub checkRelativeRefs {
     my ($mod, $expect_relative) = @_;
     my $found_relative = 0;
 
-    my $file = "$Self->{obj_dir}/V$Self->{name}_${mod}.cpp";
-    my $text = file_contents($file);
+    foreach my $file (glob_all("$Self->{obj_dir}/V$Self->{name}_${mod}*.cpp")) {
+        my $text = file_contents($file);
 
-    if ($text =~ m/this->/ || $text =~ m/vlSelf->/) {
-        $found_relative = 1;
-    }
+        if ($text =~ m/this->/ || $text =~ m/vlSelf->/) {
+            $found_relative = 1;
+        }
 
-    if ($found_relative != $expect_relative) {
-        error("$file " .
-              ($found_relative ? "has" : "does not have") .
-              " relative variable references.");
+        if ($found_relative != $expect_relative) {
+            error("$file " .
+                  ($found_relative ? "has" : "does not have") .
+                  " relative variable references.");
+        }
     }
 }
 

--- a/test_regress/t/t_optm_if_array.pl
+++ b/test_regress/t/t_optm_if_array.pl
@@ -17,8 +17,9 @@ execute(
     check_finished => 1,
     );
 
-file_grep_not("$Self->{obj_dir}/$Self->{VM_PREFIX}___024root.cpp", qr/rstn_r/);
-file_grep_not("$Self->{obj_dir}/$Self->{VM_PREFIX}___024root__Slow.cpp", qr/rstn_r/);
+for my $file (glob_all("$Self->{obj_dir}/$Self->{VM_PREFIX}___024root*.cpp")) {
+  file_grep_not($file, qr/rstn_r/);
+}
 
 ok(1);
 1;

--- a/test_regress/t/t_optm_redor.pl
+++ b/test_regress/t/t_optm_redor.pl
@@ -17,8 +17,9 @@ execute(
     check_finished => 1,
     );
 
-file_grep_not("$Self->{obj_dir}/$Self->{VM_PREFIX}___024root.cpp", qr/rstn_r/);
-file_grep_not("$Self->{obj_dir}/$Self->{VM_PREFIX}___024root__Slow.cpp", qr/rstn_r/);
+for my $file (glob_all("$Self->{obj_dir}/$Self->{VM_PREFIX}___024root*.cpp")) {
+  file_grep_not($file, qr/rstn_r/);
+}
 
 ok(1);
 1;

--- a/test_regress/t/t_trace_ena_cc.pl
+++ b/test_regress/t/t_trace_ena_cc.pl
@@ -21,8 +21,8 @@ execute(
     );
 
 if ($Self->{vlt_all}) {
-    file_grep     ("$Self->{obj_dir}/V$Self->{name}__Trace__Slow.cpp", qr/c_trace_on\"/x);
-    file_grep_not ("$Self->{obj_dir}/V$Self->{name}__Trace__Slow.cpp", qr/_trace_off\"/x);
+    file_grep     ("$Self->{obj_dir}/V$Self->{name}__Trace__0__Slow.cpp", qr/c_trace_on\"/x);
+    file_grep_not ("$Self->{obj_dir}/V$Self->{name}__Trace__0__Slow.cpp", qr/_trace_off\"/x);
     file_grep     ("$Self->{obj_dir}/simx.vcd", qr/\$enddefinitions/x);
     file_grep_not ("$Self->{obj_dir}/simx.vcd", qr/inside_sub/x);
 


### PR DESCRIPTION
This patch partitions AstCFuncs under an AstNodeModule based on which
header files they require for their implementation, and emits them
into separate files based on the distinct dependency sets. This helps
with incremental recompilation of the output C++.

With this, the single threaded model (without tracing) on OpenTitan gets about 95% ccache hit rate when changing small amounts of logic, or about 35% hit rate when renaming/adding/removing a small number of signals. 

Note we now do emit more files as functions under different AstNodeModules will go into different files, but they will also be split up based on dependencies. An alternative could be to take all functions in the whole model, and just emit them based on dependency sets, so we can end up with functions from different modules in the same file. The only thing this should change is the output filenames.

This patch makes most uses of AstCUse redundant (as we need that info on a per function basis), so I might get rid of the remaining at a later stage.