### PR TITLE
Public combo eval [WORK IN PROGRESS]

### DIFF
--- a/src/V3Inst.cpp
+++ b/src/V3Inst.cpp
@@ -555,6 +555,10 @@ public:
                    + (forTristate ? "t" : "") + "__" + cellp->name() + "__" + pinp->name());
             AstVar* newvarp
                 = new AstVar(pinVarp->fileline(), AstVarType::MODULETEMP, newvarname, pinVarp);
+            // Make the temporary variable public as well if this is public
+            if (pinVarp->isSigUserRWPublic()) {
+                newvarp->sigUserRWPublic(true);
+            }
             // Important to add statement next to cell, in case there is a
             // generate with same named cell
             cellp->addNextHere(newvarp);

--- a/src/V3Order.cpp
+++ b/src/V3Order.cpp
@@ -1470,8 +1470,6 @@ void OrderVisitor::processDomainsIterate(OrderEitherVertex* vertexp) {
     OrderVarVertex* vvertexp = dynamic_cast<OrderVarVertex*>(vertexp);
     AstSenTree* domainp = nullptr;
     UASSERT(m_comboDomainp, "not preset");
-    //TODO: This is not complete. Probably want to check that this is not being copied to the settle domain and in the combo domain
-    //TODO: We probably only want to set to m_comboDomainp if it is not already descending from some other var
     if (vvertexp && vvertexp->varScp()->varp()->isNonOutput()) domainp = m_comboDomainp;
     if (vvertexp && vvertexp->varScp()->isCircular()) domainp = m_comboDomainp;
     if (!domainp) {
@@ -1529,18 +1527,15 @@ void OrderVisitor::processDomainsIterate(OrderEitherVertex* vertexp) {
         // This is a node which has only constant inputs, or is otherwise indeterminate.
         // It should have already been copied into the settle domain.  Presumably it has
         // inputs which we never trigger, or nothing it's sensitive to, so we can rip it out.
-        if (!domainp && vertexp->scopep()) {
-            if (vvertexp->varScp()->varp()->isSigUserRWPublic())
-            {
+        if ((!domainp || (!domainp->hasCombo() && !domainp->hasClocked())) && vertexp->scopep()) {
+            bool combo = vertexp->domainMatters() && vvertexp && vvertexp->varScp()->varp()->isSigUserRWPublic();
+            if (combo) {
                 domainp = m_comboDomainp;
-            }
-            else
-            {
+            } else if (!domainp) {
                 domainp = m_deleteDomainp;
             }
         }
     }
-    //
     vertexp->domainp(domainp);
     if (vertexp->domainp()) {
         UINFO(5, "      done d=" << cvtToHex(vertexp->domainp())

--- a/src/V3Order.cpp
+++ b/src/V3Order.cpp
@@ -1470,6 +1470,8 @@ void OrderVisitor::processDomainsIterate(OrderEitherVertex* vertexp) {
     OrderVarVertex* vvertexp = dynamic_cast<OrderVarVertex*>(vertexp);
     AstSenTree* domainp = nullptr;
     UASSERT(m_comboDomainp, "not preset");
+    //TODO: This is not complete. Probably want to check that this is not being copied to the settle domain and in the combo domain
+    //TODO: We probably only want to set to m_comboDomainp if it is not already descending from some other var
     if (vvertexp && vvertexp->varScp()->varp()->isNonOutput()) domainp = m_comboDomainp;
     if (vvertexp && vvertexp->varScp()->isCircular()) domainp = m_comboDomainp;
     if (!domainp) {
@@ -1527,7 +1529,16 @@ void OrderVisitor::processDomainsIterate(OrderEitherVertex* vertexp) {
         // This is a node which has only constant inputs, or is otherwise indeterminate.
         // It should have already been copied into the settle domain.  Presumably it has
         // inputs which we never trigger, or nothing it's sensitive to, so we can rip it out.
-        if (!domainp && vertexp->scopep()) domainp = m_deleteDomainp;
+        if (!domainp && vertexp->scopep()) {
+            if (vvertexp->varScp()->varp()->isSigUserRWPublic())
+            {
+                domainp = m_comboDomainp;
+            }
+            else
+            {
+                domainp = m_deleteDomainp;
+            }
+        }
     }
     //
     vertexp->domainp(domainp);

--- a/test_regress/t/t_public_clk.cpp
+++ b/test_regress/t/t_public_clk.cpp
@@ -1,0 +1,66 @@
+// Test defines
+#define MAIN_TIME_MULTIPLIER 1
+#include <memory>
+// OS header
+#include "verilatedos.h"
+// Generated header
+#include "Vt_public_clk.h"
+// General headers
+#include "verilated.h"
+#include "verilated_vcd_c.h"
+
+#define STRINGIFY(x) STRINGIFY2(x)
+#define STRINGIFY2(x) #x
+
+std::unique_ptr<Vt_public_clk> topp;
+int main(int argc, char** argv, char** env) {
+    vluint64_t sim_time = 1100;
+    const std::unique_ptr<VerilatedContext> contextp{new VerilatedContext};
+    contextp->commandArgs(argc, argv);
+    contextp->debug(0);
+    srand48(5);
+    topp.reset(new Vt_public_clk("top"));
+
+#if VM_TRACE
+    Verilated::traceEverOn(true);
+    VL_PRINTF("Enabling waves...\n");
+    VerilatedVcdC* tfp = new VerilatedVcdC;
+    topp->trace(tfp, 99);
+    tfp->open(STRINGIFY(TEST_OBJ_DIR) "/simx.vcd");
+#endif
+
+    topp->t__DOT__clk = 0;
+    topp->eval();
+    {
+        contextp->timeInc(10 * MAIN_TIME_MULTIPLIER);
+    }
+
+#if VM_TRACE
+    if (tfp) tfp->dump(contextp->time());
+#endif
+    while ((contextp->time() < sim_time * MAIN_TIME_MULTIPLIER)
+           && !contextp->gotFinish()) {
+        topp->t__DOT__clk = !topp->t__DOT__clk;
+        topp->eval();
+        contextp->timeInc(1 * MAIN_TIME_MULTIPLIER);
+        contextp->timeInc(1 * MAIN_TIME_MULTIPLIER);
+        contextp->timeInc(1 * MAIN_TIME_MULTIPLIER);
+        contextp->timeInc(1 * MAIN_TIME_MULTIPLIER);
+        contextp->timeInc(1 * MAIN_TIME_MULTIPLIER);
+
+#if VM_TRACE
+        if (tfp) tfp->dump(contextp->time());
+#endif
+    }
+    if (!contextp->gotFinish()) {
+        vl_fatal(__FILE__, __LINE__, "main", "%Error: Timeout; never got a $finish");
+    }
+    topp->final();
+
+#if VM_TRACE
+    if (tfp) tfp->close();
+#endif
+
+    topp.reset();
+    return 0;
+}

--- a/test_regress/t/t_public_clk.pl
+++ b/test_regress/t/t_public_clk.pl
@@ -1,0 +1,27 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2003 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    make_top_shell => 0,
+    make_main => 0,
+    verilator_flags2 => [
+        "--exe",
+        "$Self->{t_dir}/$Self->{name}.cpp"
+    ],
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_public_clk.v
+++ b/test_regress/t/t_public_clk.v
@@ -1,0 +1,22 @@
+// DESCRIPTION: Verilator: public clock signal
+//
+// This file ONLY is placed into the Public Domain, for any use,
+// without warranty, 2021 by Todd Strader
+// SPDX-License-Identifier: CC0-1.0
+
+module t ();
+
+   logic clk /* verilator public_flat_rw */;
+   int count;
+   logic other_clk /* verilator public_flat_rw */;
+
+   always_comb other_clk = clk;
+
+   always_ff @(posedge other_clk) begin
+      count <= count + 1;
+      if (count == 10) begin
+         $write("*-* All Finished *-*\n");
+         $finish;
+      end
+   end
+endmodule

--- a/test_regress/t/t_public_input_dep.cpp
+++ b/test_regress/t/t_public_input_dep.cpp
@@ -1,0 +1,67 @@
+// Test defines
+#define MAIN_TIME_MULTIPLIER 1
+#include <memory>
+// OS header
+#include "verilatedos.h"
+// Generated header
+#include "Vt_public_input_dep.h"
+// General headers
+#include "verilated.h"
+#include "verilated_vcd_c.h"
+
+#define STRINGIFY(x) STRINGIFY2(x)
+#define STRINGIFY2(x) #x
+
+std::unique_ptr<Vt_public_input_dep> topp;
+int main(int argc, char** argv, char** env) {
+    vluint64_t sim_time = 1100;
+    const std::unique_ptr<VerilatedContext> contextp{new VerilatedContext};
+    contextp->commandArgs(argc, argv);
+    contextp->debug(0);
+    srand48(5);
+    topp.reset(new Vt_public_input_dep("top"));
+
+#if VM_TRACE
+    Verilated::traceEverOn(true);
+    VL_PRINTF("Enabling waves...\n");
+    VerilatedVcdC* tfp = new VerilatedVcdC;
+    topp->trace(tfp, 99);
+    tfp->open(STRINGIFY(TEST_OBJ_DIR) "/simx.vcd");
+#endif
+
+    topp->clk = 0;
+    topp->eval();
+    {
+        contextp->timeInc(10 * MAIN_TIME_MULTIPLIER);
+    }
+
+#if VM_TRACE
+    if (tfp) tfp->dump(contextp->time());
+#endif
+    while ((contextp->time() < sim_time * MAIN_TIME_MULTIPLIER)
+           && !contextp->gotFinish()) {
+        topp->clk = !topp->clk;
+        topp->t__DOT__clk_1[1] = !topp->t__DOT__clk_1[1];
+        topp->eval();
+        contextp->timeInc(1 * MAIN_TIME_MULTIPLIER);
+        contextp->timeInc(1 * MAIN_TIME_MULTIPLIER);
+        contextp->timeInc(1 * MAIN_TIME_MULTIPLIER);
+        contextp->timeInc(1 * MAIN_TIME_MULTIPLIER);
+        contextp->timeInc(1 * MAIN_TIME_MULTIPLIER);
+
+#if VM_TRACE
+        if (tfp) tfp->dump(contextp->time());
+#endif
+    }
+    if (!contextp->gotFinish()) {
+        vl_fatal(__FILE__, __LINE__, "main", "%Error: Timeout; never got a $finish");
+    }
+    topp->final();
+
+#if VM_TRACE
+    if (tfp) tfp->close();
+#endif
+
+    topp.reset();
+    return 0;
+}

--- a/test_regress/t/t_public_input_dep.cpp
+++ b/test_regress/t/t_public_input_dep.cpp
@@ -5,6 +5,7 @@
 #include "verilatedos.h"
 // Generated header
 #include "Vt_public_input_dep.h"
+#include "Vt_public_input_dep___024root.h"
 // General headers
 #include "verilated.h"
 #include "verilated_vcd_c.h"
@@ -29,7 +30,7 @@ int main(int argc, char** argv, char** env) {
     tfp->open(STRINGIFY(TEST_OBJ_DIR) "/simx.vcd");
 #endif
 
-    topp->clk = 0;
+    topp->rootp->clk = 0;
     topp->eval();
     {
         contextp->timeInc(10 * MAIN_TIME_MULTIPLIER);
@@ -40,8 +41,8 @@ int main(int argc, char** argv, char** env) {
 #endif
     while ((contextp->time() < sim_time * MAIN_TIME_MULTIPLIER)
            && !contextp->gotFinish()) {
-        topp->clk = !topp->clk;
-        topp->t__DOT__clk_1[1] = !topp->t__DOT__clk_1[1];
+        topp->rootp->clk = !topp->rootp->clk;
+        topp->rootp->t__DOT__clk_1[1] = !topp->rootp->t__DOT__clk_1[1];
         topp->eval();
         contextp->timeInc(1 * MAIN_TIME_MULTIPLIER);
         contextp->timeInc(1 * MAIN_TIME_MULTIPLIER);

--- a/test_regress/t/t_public_input_dep.pl
+++ b/test_regress/t/t_public_input_dep.pl
@@ -1,0 +1,27 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2003 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    make_top_shell => 0,
+    make_main => 0,
+    verilator_flags2 => [
+        "--exe",
+        "$Self->{t_dir}/$Self->{name}.cpp"
+    ],
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_public_input_dep.v
+++ b/test_regress/t/t_public_input_dep.v
@@ -1,0 +1,36 @@
+// DESCRIPTION: Verilator: public clock signal
+//
+// This file ONLY is placed into the Public Domain, for any use,
+// without warranty, 2021 by Anshul Shah
+// SPDX-License-Identifier: CC0-1.0
+
+module t (clk);
+   input clk;
+   int count_1;
+   int count_2;
+   logic clk_1[0:1] /* verilator public_flat_rw */;
+   logic clk_2[0:1] /* verilator public_flat_rw */;
+   logic clk_3[0:1];
+
+   always_comb clk_1[0] = ~clk;
+   always_comb clk_2[0] = ~clk_1[0];
+   always_comb clk_2[1] = ~clk_1[1];
+   always_comb clk_3[0] = ~clk_2[0];
+   always_comb clk_3[1] = ~clk_2[1];
+
+   always_ff @(posedge clk_3[0]) begin
+      count_1 <= count_1 + 1;
+      if (count_1 >= 10 && count_2 >= 10) begin
+         $write("*-* All Finished *-*\n");
+         $finish;
+      end
+   end
+
+   always_ff @(posedge clk_3[1]) begin
+      count_2 <= count_2 + 1;
+      if (count_1 >= 10 && count_2 >= 10) begin
+         $write("*-* All Finished *-*\n");
+         $finish;
+      end
+   end
+endmodule

--- a/test_regress/t/t_public_input_dep.v
+++ b/test_regress/t/t_public_input_dep.v
@@ -28,9 +28,5 @@ module t (clk);
 
    always_ff @(posedge clk_3[1]) begin
       count_2 <= count_2 + 1;
-      if (count_1 >= 10 && count_2 >= 10) begin
-         $write("*-* All Finished *-*\n");
-         $finish;
-      end
    end
 endmodule

--- a/test_regress/t/t_public_submodule.cpp
+++ b/test_regress/t/t_public_submodule.cpp
@@ -4,8 +4,8 @@
 // OS header
 #include "verilatedos.h"
 // Generated header
-#include "Vt_public_clk.h"
-#include "Vt_public_clk___024root.h"
+#include "Vt_public_submodule.h"
+#include "Vt_public_submodule___024root.h"
 // General headers
 #include "verilated.h"
 #include "verilated_vcd_c.h"
@@ -13,14 +13,14 @@
 #define STRINGIFY(x) STRINGIFY2(x)
 #define STRINGIFY2(x) #x
 
-std::unique_ptr<Vt_public_clk> topp;
+std::unique_ptr<Vt_public_submodule> topp;
 int main(int argc, char** argv, char** env) {
     vluint64_t sim_time = 1100;
     const std::unique_ptr<VerilatedContext> contextp{new VerilatedContext};
     contextp->commandArgs(argc, argv);
     contextp->debug(0);
     srand48(5);
-    topp.reset(new Vt_public_clk("top"));
+    topp.reset(new Vt_public_submodule("top"));
 
 #if VM_TRACE
     Verilated::traceEverOn(true);

--- a/test_regress/t/t_public_submodule.pl
+++ b/test_regress/t/t_public_submodule.pl
@@ -1,0 +1,27 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2003 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    make_top_shell => 0,
+    make_main => 0,
+    verilator_flags2 => [
+        "--exe",
+        "$Self->{t_dir}/$Self->{name}.cpp"
+    ],
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_public_submodule.v
+++ b/test_regress/t/t_public_submodule.v
@@ -1,0 +1,36 @@
+// DESCRIPTION: Verilator: public clock signal
+//
+// This file ONLY is placed into the Public Domain, for any use,
+// without warranty, 2021 by Todd Strader
+// SPDX-License-Identifier: CC0-1.0
+
+module t ();
+
+   logic clk /* verilator public_flat_rw */ = 0;
+   int count;
+   logic other_clk;
+
+   sub_mod sub_mod_u (
+       .sub_in(clk),
+       .sub_out(other_clk)
+    );
+
+   always_ff @(posedge other_clk) begin
+      count <= count + 1;
+      if (count == 10) begin
+         $write("*-* All Finished *-*\n");
+         $finish;
+      end
+   end
+endmodule
+
+
+module sub_mod
+  (
+   input  var logic sub_in,
+   output var logic sub_out
+   );
+
+   always_comb sub_out = ~sub_in;
+
+endmodule


### PR DESCRIPTION
Hi @wsnyder , I am working with @toddstrader to fix the public logic propagation issue by applying a change in processDomainsIterate().

Right now, if a variable does not have its domain set by its ancestors in processDomainsIterate(), it is set to the deleteDomain. The change I made moves any public variable to the combo domain if it has an initial domain, settle domain, or no domain after checking its parents. The idea with this is to move any public variable and its dependent statements to be evaluated in every loop iteration.

This still seems to be causing a few additional test failures when we run all the regression tests with --public-flat-rw. It seems that in some test cases like t_cast.v, some statements need to be in the initial and settle domain. I think that the descendant statements should be both in the initial/settle domain AND in the combo domain.

(1) I am looking for a good way to emit the code in both the eval_initial function and the main eval loop if a public variable is also a part of the initial/settle domain. Do you have any ideas?

For reference, the following tests fail when run with --public-flat-rw (in addition to the ones that normally do):
- t_cast
- t_array_interface2
- t_array_interface_nocolon
- t_math_signed_3

These all seem to be due to an initial_begin block testing a value of something that should be set in an initial function. My change moves the statements to the main eval() function which is evaluated with iteration.

(2) In general, I would also like to know if this domain shifting is a good approach, or if there is a better way to make changes to public variables be evaluated in the eval loop.

I would greatly appreciate your input on these 2 questions. Thank You!