### PR TITLE
Fix for V3Const bitoptree optimisation removing necessary cleaning AND

### DIFF
--- a/Changes
+++ b/Changes
@@ -25,6 +25,7 @@ Verilator 4.211 devel
 * Refactored Verilated include files; include verilated.h not verilated_heavy.h.
 * Fix -G to treat simple integer literals as signed (#3060). [Anikin1610]
 * Fix emitted string array initializers (#2895). [Iztok Jeras]
+* Fix bitop tree optimization dropping necessary & operator (#3096). [Flavien Solt]
 
 
 Verilator 4.210 2021-07-07

--- a/test_regress/t/t_const_bitoptree_bug3096.cpp
+++ b/test_regress/t/t_const_bitoptree_bug3096.cpp
@@ -1,0 +1,29 @@
+// -*- mode: C++; c-file-style: "cc-mode" -*-
+//*************************************************************************
+//
+// Copyright 2021 by Geza Lore. This program is free software; you can
+// redistribute it and/or modify it under the terms of either the GNU
+// Lesser General Public License Version 3 or the Perl Artistic License
+// Version 2.0.
+// SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+//
+//*************************************************************************
+
+#include <cassert>
+#include <iostream>
+
+#include <Vt_const_bitoptree_bug3096.h>
+
+int main(int argc, char* argv[]) {
+    Vt_const_bitoptree_bug3096* const tb = new Vt_const_bitoptree_bug3096;
+
+    tb->instr_i = 0x08c0006f;
+    tb->eval();
+
+    std::cout << "tb->illegal_instr_o: " << static_cast<int>(tb->illegal_instr_o) << std::endl
+              << std::flush;
+    assert(tb->illegal_instr_o == 0);
+
+    delete tb;
+    return 0;
+}

--- a/test_regress/t/t_const_bitoptree_bug3096.pl
+++ b/test_regress/t/t_const_bitoptree_bug3096.pl
@@ -1,0 +1,22 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2015 by Todd Strader. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(vlt_all => 1);
+
+compile(
+    make_top_shell => 0,
+    make_main => 0,
+    v_flags2 => ["--exe $Self->{t_dir}/$Self->{name}.cpp"],
+    );
+
+execute();
+
+ok(1);
+1;

--- a/test_regress/t/t_const_bitoptree_bug3096.v
+++ b/test_regress/t/t_const_bitoptree_bug3096.v
@@ -1,0 +1,24 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// Copyright 2021 by Geza Lore. This program is free software; you can
+// redistribute it and/or modify it under the terms of either the GNU
+// Lesser General Public License Version 3 or the Perl Artistic License
+// Version 2.0.
+// SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+// From issue #3096
+
+module decoder(
+               input wire [31:0] instr_i,
+               // Making 'a' an output preserves it as a sub-expression and causes a missing clean
+               output wire       a,
+               output wire       illegal_instr_o
+               );
+   /* verilator lint_off WIDTH */
+   wire                          b = ! instr_i[12:5];
+   wire                          c = ! instr_i[1:0];
+   wire                          d = ! instr_i[15:13];
+   /* verilator lint_on WIDTH */
+   assign a = d ? b : 1'h1;
+   assign illegal_instr_o = c ? a : 1'h0;
+endmodule


### PR DESCRIPTION
This is a very rudimentary fix for #3096. The bug is reproduced by the added test and is caused by the bit-op-tree optimisation dropping a cleaning AND here:
https://github.com/verilator/verilator/blob/bc3e24c8cd145116b6b3b543838dc2fb565f2195/src/V3Const.cpp#L856-L862

that AND is necessary because the RHS is an OR(_, NOT(_)), and the NOT translates into a C++ `~` which sets the top bits, so the result is 254 (0xfe)/255  (0xff) without the AND, while it should be 0/1.

@yTakatsukasa I feel there should be a better fix, would you mind looking into this?