### PR TITLE
remove wrong comment

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -30,7 +30,7 @@ Harald Heckmann
 Howard Su
 Huang Rui
 HyungKi Jeong
-Ivan Vnucec
+Ivan Vnučec
 Iztok Jeras
 James Hanlon
 James Hutchinson

--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -30,6 +30,7 @@ Harald Heckmann
 Howard Su
 Huang Rui
 HyungKi Jeong
+Ivan Vnucec
 Iztok Jeras
 James Hanlon
 James Hutchinson

--- a/docs/guide/install.rst
+++ b/docs/guide/install.rst
@@ -46,7 +46,6 @@ In brief, to install from git:
    #sudo apt-get install zlibc zlib1g zlib1g-dev  # Ubuntu only (ignore if gives error)
 
    git clone https://github.com/verilator/verilator   # Only first time
-   ## Note the URL above is not a page you can see with a browser, it's for git only
 
    # Every time you need to build:
    unsetenv VERILATOR_ROOT  # For csh; ignore error if on bash


### PR DESCRIPTION
Actually you can see `https://github.com/verilator/verilator` URL in your browser.

We appreciate your contributing to Verilator.  If this is your first commit, please add your name to docs/CONTRIBUTORS, and read our contributing guidelines in docs/CONTRIBUTING.rst.
