### PR TITLE
GCC4 compile fix

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -59,6 +59,7 @@ Marshal Qiao
 Martin Schmidt
 Matthew Ballance
 Michael Killough
+Michael Schaffner
 Mike Popoloski
 Miodrag Milanović
 Morten Borup Petersen

--- a/src/V3Const.cpp
+++ b/src/V3Const.cpp
@@ -32,6 +32,7 @@
 #include "V3Stats.h"
 
 #include <algorithm>
+#include <memory>
 
 //######################################################################
 // Utilities


### PR DESCRIPTION
This fixes compilation errors on GCC 4.8.5 (CentOS 7 environment).

```
$ gcc --version
gcc (GCC) 4.8.5 20150623 (Red Hat 4.8.5-44)
Copyright (C) 2015 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
```

errors without the fix:
```
../V3Const.cpp:244:17: error: ‘unique_ptr’ is not a member of ‘std’
     std::vector<std::unique_ptr<VarInfo>> m_varInfos;  // VarInfo for each variable, [0] is nullptr
                 ^
../V3Const.cpp:244:17: error: ‘unique_ptr’ is not a member of ‘std’
../V3Const.cpp:244:33: error: template argument 1 is invalid
     std::vector<std::unique_ptr<VarInfo>> m_varInfos;  // VarInfo for each variable, [0] is nullptr
                                 ^
../V3Const.cpp:244:33: error: template argument 2 is invalid
../V3Const.cpp:244:40: error: expected unqualified-id before ‘>’ token
     std::vector<std::unique_ptr<VarInfo>> m_varInfos;  // VarInfo for each variable, [0] is nullptr
                                        ^
../V3Const.cpp: In member function ‘ConstBitOpTreeVisitor::VarInfo& ConstBitOpTreeVisitor::getVarInfo(const ConstBitOpTreeVisitor::LeafInfo&)’:
../V3Const.cpp:281:23: error: ‘m_varInfos’ was not declared in this scope
             baseIdx = m_varInfos.size();
                       ^
../V3Const.cpp:288:29: error: ‘m_varInfos’ was not declared in this scope
         VarInfo* varInfop = m_varInfos[idx].get();
                             ^
../V3Const.cpp: In constructor ‘ConstBitOpTreeVisitor::ConstBitOpTreeVisitor(AstNode*, int)’:
../V3Const.cpp:488:9: error: ‘m_varInfos’ was not declared in this scope
         m_varInfos.push_back(nullptr);
         ^
../V3Const.cpp: In static member function ‘static AstNode* ConstBitOpTreeVisitor::simplify(AstNode*, int, VDouble0&)’:
../V3Const.cpp:519:41: error: ‘class ConstBitOpTreeVisitor’ has no member named ‘m_varInfos’
         if (visitor.m_failed || visitor.m_varInfos.size() == 1) return nullptr;
                                         ^
../V3Const.cpp:522:34: error: ‘class ConstBitOpTreeVisitor’ has no member named ‘m_varInfos’
         const int vars = visitor.m_varInfos.size() - 1;
                                  ^
../V3Const.cpp:524:33: error: ‘class ConstBitOpTreeVisitor’ has no member named ‘m_varInfos’
         for (auto&& v : visitor.m_varInfos) {
                                 ^
../V3Const.cpp:544:40: error: ‘class ConstBitOpTreeVisitor’ has no member named ‘m_varInfos’
         for (auto&& varinfop : visitor.m_varInfos) {
                                        ^
```

Signed-off-by: Michael Schaffner <msf@google.com>
