### PR TITLE
Visual Studio has localtime_s

### DIFF
--- a/include/verilatedos.h
+++ b/include/verilatedos.h
@@ -511,10 +511,8 @@ typedef unsigned long long vluint64_t;  ///< 64-bit unsigned type
 # define VL_STRCASECMP strcasecmp
 #endif
 
-#ifdef __MINGW32__
+#if defined(__MINGW32__) || defined(_MSC_VER)
 # define VL_LOCALTIME_R(timep, tmp) localtime_s((tmp), (timep))
-#elif defined(_MSC_VER)
-# define VL_LOCALTIME_R(timep, tmp) localtime_c((tmp), (timep))
 #else
 # define VL_LOCALTIME_R(timep, tmp) localtime_r((timep), (tmp))
 #endif

--- a/src/V3Param.cpp
+++ b/src/V3Param.cpp
@@ -58,6 +58,7 @@
 #include "V3Unroll.h"
 #include "V3Hasher.h"
 
+#include <cctype>
 #include <deque>
 #include <map>
 #include <memory>


### PR DESCRIPTION
Hello!

While building a verilator project using Visual Studio 16 2019, compilation failed due to not having `localtime_c`.
It looks like Visual Studio has `localtime_s`, which makes it have the same behavior as mingw.

See https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/localtime-s-localtime32-s-localtime64-s

