### PR TITLE
[bug #3140] fix internal error caused by nodep->declElWidth() == 0

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -103,3 +103,4 @@ Yossi Nivin
 Yuri Victorovich
 Yutetsu TAKATSUKASA
 Yves Mathieu
+Zhenglei Wang

--- a/src/V3Const.cpp
+++ b/src/V3Const.cpp
@@ -1346,10 +1346,15 @@ private:
                        && (nodep->msbConst() > maxDeclBit || nodep->lsbConst() > maxDeclBit)) {
                 // See also warning in V3Width
                 // Must adjust by element width as declRange() is in number of elements
+                string msbLsbProtected;
+                if (nodep->declElWidth() == 0) {
+                    msbLsbProtected = "(nodep->declElWidth() == 0) " + std::to_string(nodep->msbConst()) + ":" + std::to_string(nodep->lsbConst());
+                } else {
+                    msbLsbProtected = std::to_string(nodep->msbConst() / nodep->declElWidth()) + ":" + std::to_string(nodep->lsbConst() / nodep->declElWidth());
+                }
                 nodep->v3warn(SELRANGE,
                               "Selection index out of range: "
-                                  << (nodep->msbConst() / nodep->declElWidth()) << ":"
-                                  << (nodep->lsbConst() / nodep->declElWidth()) << " outside "
+                                  << msbLsbProtected << " outside "
                                   << nodep->declRange().hiMaxSelect() << ":0"
                                   << (nodep->declRange().lo() >= 0
                                           ? ""

--- a/test_regress/t/t_bigmem.pl
+++ b/test_regress/t/t_bigmem.pl
@@ -1,0 +1,21 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2021 by filamoon. This program is free software; you can
+# redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_bigmem.v
+++ b/test_regress/t/t_bigmem.v
@@ -1,0 +1,16 @@
+// This test shall generate a warning, but not an internal error.
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2021 by filamoon.
+// SPDX-License-Identifier: CC0-1.0
+module t_bigmem(
+   input wire clk,
+   input wire [27:0] addr,
+   input wire [255:0] data,
+   input wire wen
+);
+   reg [(1<<28)-1:0][255:0] mem;
+   always @(posedge clk) begin
+      if (wen) mem[addr] <= data;
+   end
+endmodule


### PR DESCRIPTION
We appreciate your contributing to Verilator.  If this is your first commit, please add your name to docs/CONTRIBUTORS, and read our contributing guidelines in docs/CONTRIBUTING.rst.
