### PR TITLE
Ensure that constructor-parameter arguments are comma-separated in generated C++

### DIFF
--- a/src/V3EmitCFunc.h
+++ b/src/V3EmitCFunc.h
@@ -392,10 +392,15 @@ public:
         emitCCallArgs(nodep, "");
     }
     virtual void visit(AstCNew* nodep) override {
+        bool comma = false;
         puts("std::make_shared<" + prefixNameProtect(nodep->dtypep()) + ">(");
         puts("vlSymsp");  // TODO make this part of argsp, and eliminate when unnecessary
-        if (nodep->argsp()) puts(", ");
-        iterateAndNextNull(nodep->argsp());
+        if (nodep->argsp()) comma = true;
+        for (AstNode* subnodep = nodep->argsp(); subnodep; subnodep = subnodep->nextp()) {
+            if (comma) puts(", ");
+            iterate(subnodep);
+            comma = true;
+        }
         puts(")");
     }
     virtual void visit(AstCMethodHard* nodep) override {

--- a/test_regress/t/t_class_new.v
+++ b/test_regress/t/t_class_new.v
@@ -26,10 +26,20 @@ class ClsArg;
    endfunction
 endclass
 
+class Cls2Arg;
+   int imembera;
+   int imemberb;
+   function new(int i, int j);
+      imembera = i + 1;
+      imemberb = j + 2;
+   endfunction
+endclass
+
 module t (/*AUTOARG*/);
    initial begin
       ClsNoArg c1;
-      ClsArg c2;
+      ClsArg   c2;
+      Cls2Arg  c3;
 
       c1 = new;
       if (c1.imembera != 5) $stop;
@@ -41,6 +51,10 @@ module t (/*AUTOARG*/);
       c2 = ClsArg::create6();
       if (c2.imembera != 6) $stop;
       if (c2.geta() != 6) $stop;
+
+      c3 = new(4, 5);
+      if (c3.imembera != 5) $stop;
+      if (c3.imemberb != 7) $stop;
 
       $write("*-* All Finished *-*\n");
       $finish;


### PR DESCRIPTION
The code generated to pass more than one parameter to a class constructor omits commas between parameters. The attached PR generates code for parameters passed to constructor calls in a similar way to the way that general function calls are generated. The PR also includes an enhanced testcase that fails without the changes to V3EmitCFunc.h and passes with the changes.

Signed-off-by: Matthew Ballance <matt.ballance@gmail.com>

We appreciate your contributing to Verilator.  If this is your first commit, please add your name to docs/CONTRIBUTORS, and read our contributing guidelines in docs/CONTRIBUTING.rst.
