### PR TITLE
Remove VN_CAST_CONST and VN_AS_CONST.

### DIFF
--- a/src/V3Ast.cpp
+++ b/src/V3Ast.cpp
@@ -1164,7 +1164,7 @@ string AstNode::locationStr() const {
             return "";  // LCOV_EXCL_LINE
         }
         const AstScope* scopep;
-        if ((scopep = VN_CAST_CONST(backp, Scope))) {
+        if ((scopep = VN_CAST(backp, Scope))) {
             // The design is flattened and there are no useful scopes
             // This is probably because of inlining
             if (scopep->isTop()) break;
@@ -1178,10 +1178,10 @@ string AstNode::locationStr() const {
     while (backp) {
         const AstModule* modp;
         const AstNodeVarRef* nvrp;
-        if ((modp = VN_CAST_CONST(backp, Module)) && !modp->hierName().empty()) {
+        if ((modp = VN_CAST(backp, Module)) && !modp->hierName().empty()) {
             str += modp->hierName();
             return str;
-        } else if ((nvrp = VN_CAST_CONST(backp, NodeVarRef))) {
+        } else if ((nvrp = VN_CAST(backp, NodeVarRef))) {
             const string prettyName = nvrp->prettyName();
             // VarRefs have not been flattened yet and do not contain location information
             if (prettyName != nvrp->name()) {

--- a/src/V3AstInlines.h
+++ b/src/V3AstInlines.h
@@ -42,19 +42,19 @@ inline bool AstNode::isString() const {
 inline bool AstNode::isSigned() const { return dtypep() && dtypep()->isSigned(); }
 
 inline bool AstNode::isZero() const {
-    return (VN_IS(this, Const) && VN_AS_CONST(this, Const)->num().isEqZero());
+    return (VN_IS(this, Const) && VN_AS(this, Const)->num().isEqZero());
 }
 inline bool AstNode::isNeqZero() const {
-    return (VN_IS(this, Const) && VN_AS_CONST(this, Const)->num().isNeqZero());
+    return (VN_IS(this, Const) && VN_AS(this, Const)->num().isNeqZero());
 }
 inline bool AstNode::isOne() const {
-    return (VN_IS(this, Const) && VN_AS_CONST(this, Const)->num().isEqOne());
+    return (VN_IS(this, Const) && VN_AS(this, Const)->num().isEqOne());
 }
 inline bool AstNode::isAllOnes() const {
-    return (VN_IS(this, Const) && VN_AS_CONST(this, Const)->isEqAllOnes());
+    return (VN_IS(this, Const) && VN_AS(this, Const)->isEqAllOnes());
 }
 inline bool AstNode::isAllOnesV() const {
-    return (VN_IS(this, Const) && VN_AS_CONST(this, Const)->isEqAllOnesV());
+    return (VN_IS(this, Const) && VN_AS(this, Const)->isEqAllOnesV());
 }
 inline bool AstNode::sameTree(const AstNode* node2p) const {
     return sameTreeIter(this, node2p, true, false);

--- a/src/V3AstNodes.cpp
+++ b/src/V3AstNodes.cpp
@@ -413,7 +413,7 @@ string AstVar::vlPropDecl(const string& propName) const {
     std::vector<int> ulims;  // Unpacked dimension limits
     for (const AstNodeDType* dtp = dtypep(); dtp;) {
         dtp = dtp->skipRefp();  // Skip AstRefDType/AstTypedef, or return same node
-        if (const AstNodeArrayDType* const adtypep = VN_CAST_CONST(dtp, NodeArrayDType)) {
+        if (const AstNodeArrayDType* const adtypep = VN_CAST(dtp, NodeArrayDType)) {
             ulims.push_back(adtypep->declRange().left());
             ulims.push_back(adtypep->declRange().right());
             dtp = adtypep->subDTypep();
@@ -667,22 +667,22 @@ AstNodeDType::CTypeRecursed AstNodeDType::cTypeRecurse(bool compound) const {
     CTypeRecursed info;
 
     const AstNodeDType* dtypep = this->skipRefp();
-    if (const auto* adtypep = VN_CAST_CONST(dtypep, AssocArrayDType)) {
+    if (const auto* adtypep = VN_CAST(dtypep, AssocArrayDType)) {
         const CTypeRecursed key = adtypep->keyDTypep()->cTypeRecurse(true);
         const CTypeRecursed val = adtypep->subDTypep()->cTypeRecurse(true);
         info.m_type = "VlAssocArray<" + key.m_type + ", " + val.m_type + ">";
-    } else if (const auto* adtypep = VN_CAST_CONST(dtypep, DynArrayDType)) {
+    } else if (const auto* adtypep = VN_CAST(dtypep, DynArrayDType)) {
         const CTypeRecursed sub = adtypep->subDTypep()->cTypeRecurse(true);
         info.m_type = "VlQueue<" + sub.m_type + ">";
-    } else if (const auto* adtypep = VN_CAST_CONST(dtypep, QueueDType)) {
+    } else if (const auto* adtypep = VN_CAST(dtypep, QueueDType)) {
         const CTypeRecursed sub = adtypep->subDTypep()->cTypeRecurse(true);
         info.m_type = "VlQueue<" + sub.m_type;
         // + 1 below as VlQueue uses 0 to mean unlimited, 1 to mean size() max is 1
         if (adtypep->boundp()) info.m_type += ", " + cvtToStr(adtypep->boundConst() + 1);
         info.m_type += ">";
-    } else if (const auto* adtypep = VN_CAST_CONST(dtypep, ClassRefDType)) {
+    } else if (const auto* adtypep = VN_CAST(dtypep, ClassRefDType)) {
         info.m_type = "VlClassRef<" + EmitCBaseVisitor::prefixNameProtect(adtypep) + ">";
-    } else if (const auto* adtypep = VN_CAST_CONST(dtypep, UnpackArrayDType)) {
+    } else if (const auto* adtypep = VN_CAST(dtypep, UnpackArrayDType)) {
         if (adtypep->isCompound()) compound = true;
         const CTypeRecursed sub = adtypep->subDTypep()->cTypeRecurse(compound);
         info.m_type = "VlUnpacked<" + sub.m_type;
@@ -777,11 +777,11 @@ int AstNodeDType::widthPow2() const {
 }
 
 bool AstNodeDType::isLiteralType() const {
-    if (auto* const dtypep = VN_CAST_CONST(skipRefp(), BasicDType)) {
+    if (auto* const dtypep = VN_CAST(skipRefp(), BasicDType)) {
         return dtypep->keyword().isLiteralType();
-    } else if (auto* const dtypep = VN_CAST_CONST(skipRefp(), UnpackArrayDType)) {
+    } else if (auto* const dtypep = VN_CAST(skipRefp(), UnpackArrayDType)) {
         return dtypep->basicp()->isLiteralType();
-    } else if (auto* const dtypep = VN_CAST_CONST(skipRefp(), StructDType)) {
+    } else if (auto* const dtypep = VN_CAST(skipRefp(), StructDType)) {
         // Currently all structs are packed, later this can be expanded to
         // 'forall members _.isLiteralType()'
         return dtypep->packed();
@@ -1512,7 +1512,7 @@ void AstNodeDType::dumpSmall(std::ostream& str) const {
 }
 void AstNodeArrayDType::dumpSmall(std::ostream& str) const {
     this->AstNodeDType::dumpSmall(str);
-    if (auto* adtypep = VN_CAST_CONST(this, UnpackArrayDType)) {
+    if (auto* adtypep = VN_CAST(this, UnpackArrayDType)) {
         // uc = packed compound object, u = unpacked POD
         str << (adtypep->isCompound() ? "uc" : "u");
     } else {

--- a/src/V3Const.cpp
+++ b/src/V3Const.cpp
@@ -79,7 +79,7 @@ public:
 };
 
 static bool isConst(const AstNode* nodep, uint64_t v) {
-    const AstConst* const constp = VN_CAST_CONST(nodep, Const);
+    const AstConst* const constp = VN_CAST(nodep, Const);
     return constp && constp->toUQuad() == v;
 }
 
@@ -841,10 +841,10 @@ private:
     bool operandConst(AstNode* nodep) { return VN_IS(nodep, Const); }
     bool operandAsvConst(const AstNode* nodep) {
         // BIASV(CONST, BIASV(CONST,...)) -> BIASV( BIASV_CONSTED(a,b), ...)
-        const AstNodeBiComAsv* bnodep = VN_CAST_CONST(nodep, NodeBiComAsv);
+        const AstNodeBiComAsv* bnodep = VN_CAST(nodep, NodeBiComAsv);
         if (!bnodep) return false;
         if (!VN_IS(bnodep->lhsp(), Const)) return false;
-        const AstNodeBiComAsv* rnodep = VN_CAST_CONST(bnodep->rhsp(), NodeBiComAsv);
+        const AstNodeBiComAsv* rnodep = VN_CAST(bnodep->rhsp(), NodeBiComAsv);
         if (!rnodep) return false;
         if (rnodep->type() != bnodep->type()) return false;
         if (rnodep->width() != bnodep->width()) return false;
@@ -854,9 +854,9 @@ private:
     }
     bool operandAsvSame(const AstNode* nodep) {
         // BIASV(SAMEa, BIASV(SAMEb,...)) -> BIASV( BIASV(SAMEa,SAMEb), ...)
-        const AstNodeBiComAsv* bnodep = VN_CAST_CONST(nodep, NodeBiComAsv);
+        const AstNodeBiComAsv* bnodep = VN_CAST(nodep, NodeBiComAsv);
         if (!bnodep) return false;
-        const AstNodeBiComAsv* rnodep = VN_CAST_CONST(bnodep->rhsp(), NodeBiComAsv);
+        const AstNodeBiComAsv* rnodep = VN_CAST(bnodep->rhsp(), NodeBiComAsv);
         if (!rnodep) return false;
         if (rnodep->type() != bnodep->type()) return false;
         if (rnodep->width() != bnodep->width()) return false;
@@ -873,9 +873,9 @@ private:
         // BIASV(CONST_a_c,BIASV(c...,d...)))
         //
         // Idea for the future: All BiComAsvs could be lists, sorted by if they're constant
-        const AstNodeBiComAsv* bnodep = VN_CAST_CONST(nodep, NodeBiComAsv);
+        const AstNodeBiComAsv* bnodep = VN_CAST(nodep, NodeBiComAsv);
         if (!bnodep) return false;
-        const AstNodeBiComAsv* lnodep = VN_CAST_CONST(bnodep->lhsp(), NodeBiComAsv);
+        const AstNodeBiComAsv* lnodep = VN_CAST(bnodep->lhsp(), NodeBiComAsv);
         if (!lnodep) return false;
         if (lnodep->type() != bnodep->type()) return false;
         if (lnodep->width() != bnodep->width()) return false;
@@ -883,9 +883,9 @@ private:
     }
     bool operandAsvRUp(const AstNode* nodep) {
         // BIASV(l,BIASV(CONSTrl,rr)) -> BIASV(CONSTrl,BIASV(l,rr)) ?
-        const AstNodeBiComAsv* bnodep = VN_CAST_CONST(nodep, NodeBiComAsv);
+        const AstNodeBiComAsv* bnodep = VN_CAST(nodep, NodeBiComAsv);
         if (!bnodep) return false;
-        const AstNodeBiComAsv* rnodep = VN_CAST_CONST(bnodep->rhsp(), NodeBiComAsv);
+        const AstNodeBiComAsv* rnodep = VN_CAST(bnodep->rhsp(), NodeBiComAsv);
         if (!rnodep) return false;
         if (rnodep->type() != bnodep->type()) return false;
         if (rnodep->width() != bnodep->width()) return false;
@@ -893,8 +893,8 @@ private:
     }
     static bool operandSubAdd(const AstNode* nodep) {
         // SUB( ADD(CONSTx,y), CONSTz) -> ADD(SUB(CONSTx,CONSTz), y)
-        const AstNodeBiop* np = VN_CAST_CONST(nodep, NodeBiop);
-        const AstNodeBiop* lp = VN_CAST_CONST(np->lhsp(), NodeBiop);
+        const AstNodeBiop* np = VN_CAST(nodep, NodeBiop);
+        const AstNodeBiop* lp = VN_CAST(np->lhsp(), NodeBiop);
         return (lp && VN_IS(lp->lhsp(), Const) && VN_IS(np->rhsp(), Const)
                 && lp->width() == np->width());
     }
@@ -931,9 +931,9 @@ private:
     static bool operandAndOrSame(const AstNode* nodep) {
         // OR( AND(VAL,x), AND(VAL,y)) -> AND(VAL,OR(x,y))
         // OR( AND(x,VAL), AND(y,VAL)) -> AND(OR(x,y),VAL)
-        const AstNodeBiop* np = VN_CAST_CONST(nodep, NodeBiop);
-        const AstNodeBiop* lp = VN_CAST_CONST(np->lhsp(), NodeBiop);
-        const AstNodeBiop* rp = VN_CAST_CONST(np->rhsp(), NodeBiop);
+        const AstNodeBiop* np = VN_CAST(nodep, NodeBiop);
+        const AstNodeBiop* lp = VN_CAST(np->lhsp(), NodeBiop);
+        const AstNodeBiop* rp = VN_CAST(np->rhsp(), NodeBiop);
         return (lp && rp && lp->width() == rp->width() && lp->type() == rp->type()
                 && (operandsSame(lp->lhsp(), rp->lhsp()) || operandsSame(lp->rhsp(), rp->rhsp())));
     }
@@ -1015,8 +1015,8 @@ private:
         // Predicate for checking whether the bottom 'significantBits' bits of the given expression
         // are all zeroes.
         const auto checkBottomClear = [=](const AstNode* nodep) -> bool {
-            if (const AstShiftL* const shiftp = VN_CAST_CONST(nodep, ShiftL)) {
-                if (const AstConst* const scp = VN_CAST_CONST(shiftp->rhsp(), Const)) {
+            if (const AstShiftL* const shiftp = VN_CAST(nodep, ShiftL)) {
+                if (const AstConst* const scp = VN_CAST(shiftp->rhsp(), Const)) {
                     return scp->num().toUInt() >= significantBits;
                 }
             }
@@ -1063,14 +1063,14 @@ private:
 
         // Check if masking is redundant
         if (AstShiftR* const shiftp = VN_CAST(nodep->rhsp(), ShiftR)) {
-            if (const AstConst* scp = VN_CAST_CONST(shiftp->rhsp(), Const)) {
+            if (const AstConst* scp = VN_CAST(shiftp->rhsp(), Const)) {
                 // Check if mask is full over the non-zero bits
                 V3Number maskLo(nodep, nodep->width());
                 maskLo.setMask(nodep->width() - scp->num().toUInt());
                 return checkMask(maskLo);
             }
         } else if (AstShiftL* const shiftp = VN_CAST(nodep->rhsp(), ShiftL)) {
-            if (const AstConst* scp = VN_CAST_CONST(shiftp->rhsp(), Const)) {
+            if (const AstConst* scp = VN_CAST(shiftp->rhsp(), Const)) {
                 // Check if mask is full over the non-zero bits
                 V3Number maskLo(nodep, nodep->width());
                 V3Number maskHi(nodep, nodep->width());
@@ -1121,18 +1121,18 @@ private:
         return newp;
     }
     static bool operandShiftSame(const AstNode* nodep) {
-        const AstNodeBiop* np = VN_AS_CONST(nodep, NodeBiop);
+        const AstNodeBiop* np = VN_AS(nodep, NodeBiop);
         {
-            const AstShiftL* lp = VN_CAST_CONST(np->lhsp(), ShiftL);
-            const AstShiftL* rp = VN_CAST_CONST(np->rhsp(), ShiftL);
+            const AstShiftL* lp = VN_CAST(np->lhsp(), ShiftL);
+            const AstShiftL* rp = VN_CAST(np->rhsp(), ShiftL);
             if (lp && rp) {
                 return (lp->width() == rp->width() && lp->lhsp()->width() == rp->lhsp()->width()
                         && operandsSame(lp->rhsp(), rp->rhsp()));
             }
         }
         {
-            const AstShiftR* lp = VN_CAST_CONST(np->lhsp(), ShiftR);
-            const AstShiftR* rp = VN_CAST_CONST(np->rhsp(), ShiftR);
+            const AstShiftR* lp = VN_CAST(np->lhsp(), ShiftR);
+            const AstShiftR* rp = VN_CAST(np->rhsp(), ShiftR);
             if (lp && rp) {
                 return (lp->width() == rp->width() && lp->lhsp()->width() == rp->lhsp()->width()
                         && operandsSame(lp->rhsp(), rp->rhsp()));
@@ -1141,29 +1141,26 @@ private:
         return false;
     }
     bool operandHugeShiftL(const AstNodeBiop* nodep) {
-        return (VN_IS(nodep->rhsp(), Const)
-                && !VN_AS_CONST(nodep->rhsp(), Const)->num().isFourState()
-                && (VN_AS_CONST(nodep->rhsp(), Const)->toUInt()
-                    >= static_cast<uint32_t>(nodep->width()))
+        return (VN_IS(nodep->rhsp(), Const) && !VN_AS(nodep->rhsp(), Const)->num().isFourState()
+                && (VN_AS(nodep->rhsp(), Const)->toUInt() >= static_cast<uint32_t>(nodep->width()))
                 && isTPure(nodep->lhsp()));
     }
     bool operandHugeShiftR(const AstNodeBiop* nodep) {
-        return (VN_IS(nodep->rhsp(), Const)
-                && !VN_AS_CONST(nodep->rhsp(), Const)->num().isFourState()
-                && (VN_AS_CONST(nodep->rhsp(), Const)->toUInt()
+        return (VN_IS(nodep->rhsp(), Const) && !VN_AS(nodep->rhsp(), Const)->num().isFourState()
+                && (VN_AS(nodep->rhsp(), Const)->toUInt()
                     >= static_cast<uint32_t>(nodep->lhsp()->width()))
                 && isTPure(nodep->lhsp()));
     }
     bool operandIsTwo(const AstNode* nodep) {
-        return (VN_IS(nodep, Const) && !VN_AS_CONST(nodep, Const)->num().isFourState()
-                && nodep->width() <= VL_QUADSIZE && VN_AS_CONST(nodep, Const)->toUQuad() == 2);
+        return (VN_IS(nodep, Const) && !VN_AS(nodep, Const)->num().isFourState()
+                && nodep->width() <= VL_QUADSIZE && VN_AS(nodep, Const)->toUQuad() == 2);
     }
     bool operandIsTwostate(const AstNode* nodep) {
-        return (VN_IS(nodep, Const) && !VN_AS_CONST(nodep, Const)->num().isFourState());
+        return (VN_IS(nodep, Const) && !VN_AS(nodep, Const)->num().isFourState());
     }
     bool operandIsPowTwo(const AstNode* nodep) {
         if (!operandIsTwostate(nodep)) return false;
-        return (1 == VN_AS_CONST(nodep, Const)->num().countOnes());
+        return (1 == VN_AS(nodep, Const)->num().countOnes());
     }
     bool operandShiftOp(const AstNodeBiop* nodep) {
         if (!VN_IS(nodep->rhsp(), Const)) return false;
@@ -1181,8 +1178,8 @@ private:
         // We can only get rid of a<<b>>c or a<<b<<c, with constant b & c
         // because bits may be masked in that process, or (b+c) may exceed the word width.
         if (!(VN_IS(nodep->rhsp(), Const) && VN_IS(lhsp->rhsp(), Const))) return false;
-        if (VN_AS_CONST(nodep->rhsp(), Const)->num().isFourState()
-            || VN_AS_CONST(lhsp->rhsp(), Const)->num().isFourState())
+        if (VN_AS(nodep->rhsp(), Const)->num().isFourState()
+            || VN_AS(lhsp->rhsp(), Const)->num().isFourState())
             return false;
         if (nodep->width() != lhsp->width()) return false;
         if (nodep->width() != lhsp->lhsp()->width()) return false;
@@ -1193,8 +1190,8 @@ private:
         // It was an expression, then got constified.  In reality, the WordSel
         // must be wrapped in a Cond, that will be false.
         return (VN_IS(nodep->rhsp(), Const) && VN_IS(nodep->fromp(), NodeVarRef)
-                && VN_AS_CONST(nodep->fromp(), NodeVarRef)->access().isReadOnly()
-                && (static_cast<int>(VN_AS_CONST(nodep->rhsp(), Const)->toUInt())
+                && VN_AS(nodep->fromp(), NodeVarRef)->access().isReadOnly()
+                && (static_cast<int>(VN_AS(nodep->rhsp(), Const)->toUInt())
                     >= VN_AS(nodep->fromp(), NodeVarRef)->varp()->widthWords()));
     }
     bool operandSelFull(const AstSel* nodep) {
@@ -1289,11 +1286,11 @@ private:
         // EQ(const{width32}, EXTEND(xx{width3})) -> constant
         // When the constant has non-zero bits above the extend it's a constant.
         // Avoids compiler warning
-        const AstExtend* extendp = VN_CAST_CONST(nodep->rhsp(), Extend);
+        const AstExtend* extendp = VN_CAST(nodep->rhsp(), Extend);
         if (!extendp) return false;
         AstNode* smallerp = extendp->lhsp();
         const int subsize = smallerp->width();
-        const AstConst* constp = VN_CAST_CONST(nodep->lhsp(), Const);
+        const AstConst* constp = VN_CAST(nodep->lhsp(), Const);
         if (!constp) return false;
         if (constp->num().isBitsZero(constp->width() - 1, subsize)) return false;
         return true;
@@ -1387,8 +1384,8 @@ private:
         }
     }
     bool ifSameAssign(const AstNodeIf* nodep) {
-        const AstNodeAssign* ifp = VN_CAST_CONST(nodep->ifsp(), NodeAssign);
-        const AstNodeAssign* elsep = VN_CAST_CONST(nodep->elsesp(), NodeAssign);
+        const AstNodeAssign* ifp = VN_CAST(nodep->ifsp(), NodeAssign);
+        const AstNodeAssign* elsep = VN_CAST(nodep->elsesp(), NodeAssign);
         if (!ifp || ifp->nextp()) return false;  // Must be SINGLE statement
         if (!elsep || elsep->nextp()) return false;
         if (ifp->type() != elsep->type()) return false;  // Can't mix an assigndly and an assign
@@ -1399,7 +1396,7 @@ private:
     }
     bool operandIfIf(const AstNodeIf* nodep) {
         if (nodep->elsesp()) return false;
-        const AstNodeIf* lowerIfp = VN_CAST_CONST(nodep->ifsp(), NodeIf);
+        const AstNodeIf* lowerIfp = VN_CAST(nodep->ifsp(), NodeIf);
         if (!lowerIfp || lowerIfp->nextp()) return false;
         if (nodep->type() != lowerIfp->type()) return false;
         if (afterComment(lowerIfp->elsesp())) return false;
@@ -1414,10 +1411,10 @@ private:
         const AstNode* lfromp = lhsp->fromp();
         const AstNode* rfromp = rhsp->fromp();
         if (!lfromp || !rfromp || !lfromp->sameGateTree(rfromp)) return false;
-        const AstConst* lstart = VN_CAST_CONST(lhsp->lsbp(), Const);
-        const AstConst* rstart = VN_CAST_CONST(rhsp->lsbp(), Const);
-        const AstConst* lwidth = VN_CAST_CONST(lhsp->widthp(), Const);
-        const AstConst* rwidth = VN_CAST_CONST(rhsp->widthp(), Const);
+        const AstConst* lstart = VN_CAST(lhsp->lsbp(), Const);
+        const AstConst* rstart = VN_CAST(rhsp->lsbp(), Const);
+        const AstConst* lwidth = VN_CAST(lhsp->widthp(), Const);
+        const AstConst* rwidth = VN_CAST(rhsp->widthp(), Const);
         if (!lstart || !rstart || !lwidth || !rwidth) return false;  // too complicated
         const int rend = (rstart->toSInt() + rwidth->toSInt());
         return (rend == lstart->toSInt());
@@ -1465,8 +1462,8 @@ private:
         if (lhsp->type() != rhsp->type()) return false;
         if (!ifConcatMergeableBiop(lhsp)) return false;
 
-        const AstNodeBiop* lp = VN_CAST_CONST(lhsp, NodeBiop);
-        const AstNodeBiop* rp = VN_CAST_CONST(rhsp, NodeBiop);
+        const AstNodeBiop* lp = VN_CAST(lhsp, NodeBiop);
+        const AstNodeBiop* rp = VN_CAST(rhsp, NodeBiop);
         if (!lp || !rp) return false;
         // {a[]&b[], a[]&b[]}
         const bool lad = ifMergeAdjacent(lp->lhsp(), rp->lhsp());
@@ -2128,12 +2125,11 @@ private:
     bool operandBoolShift(const AstNode* nodep) {
         // boolean test of AND(const,SHIFTR(x,const)) -> test of AND(SHIFTL(x,const), x)
         if (!VN_IS(nodep, And)) return false;
-        if (!VN_IS(VN_AS_CONST(nodep, And)->lhsp(), Const)) return false;
-        if (!VN_IS(VN_AS_CONST(nodep, And)->rhsp(), ShiftR)) return false;
-        const AstShiftR* shiftp = VN_AS(VN_AS_CONST(nodep, And)->rhsp(), ShiftR);
+        if (!VN_IS(VN_AS(nodep, And)->lhsp(), Const)) return false;
+        if (!VN_IS(VN_AS(nodep, And)->rhsp(), ShiftR)) return false;
+        const AstShiftR* shiftp = VN_AS(VN_AS(nodep, And)->rhsp(), ShiftR);
         if (!VN_IS(shiftp->rhsp(), Const)) return false;
-        if (static_cast<uint32_t>(nodep->width())
-            <= VN_AS_CONST(shiftp->rhsp(), Const)->toUInt()) {
+        if (static_cast<uint32_t>(nodep->width()) <= VN_AS(shiftp->rhsp(), Const)->toUInt()) {
             return false;
         }
         return true;

--- a/src/V3EmitCBase.cpp
+++ b/src/V3EmitCBase.cpp
@@ -78,7 +78,7 @@ string EmitCBaseVisitor::cFuncArgs(const AstCFunc* nodep) {
     }
     // Might be a user function with argument list.
     for (const AstNode* stmtp = nodep->argsp(); stmtp; stmtp = stmtp->nextp()) {
-        if (const AstVar* portp = VN_CAST_CONST(stmtp, Var)) {
+        if (const AstVar* portp = VN_CAST(stmtp, Var)) {
             if (portp->isIO() && !portp->isFuncReturn()) {
                 if (args != "") args += ", ";
                 if (nodep->dpiImportPrototype() || nodep->dpiExportDispatcher()) {
@@ -134,9 +134,8 @@ void EmitCBaseVisitor::emitVarDecl(const AstVar* nodep, bool asRef) {
 
     const auto emitDeclArrayBrackets = [this](const AstVar* nodep) -> void {
         // This isn't very robust and may need cleanup for other data types
-        for (const AstUnpackArrayDType* arrayp
-             = VN_CAST_CONST(nodep->dtypeSkipRefp(), UnpackArrayDType);
-             arrayp; arrayp = VN_CAST_CONST(arrayp->subDTypep()->skipRefp(), UnpackArrayDType)) {
+        for (const AstUnpackArrayDType* arrayp = VN_CAST(nodep->dtypeSkipRefp(), UnpackArrayDType);
+             arrayp; arrayp = VN_CAST(arrayp->subDTypep()->skipRefp(), UnpackArrayDType)) {
             puts("[" + cvtToStr(arrayp->elementsConst()) + "]");
         }
     };

--- a/src/V3EmitCBase.h
+++ b/src/V3EmitCBase.h
@@ -41,7 +41,7 @@ public:
     VL_UNCOPYABLE(EmitCParentModule);
 
     static const AstNodeModule* get(const AstNode* nodep) {
-        return VN_AS_CONST(nodep->user4p(), NodeModule);
+        return VN_AS(nodep->user4p(), NodeModule);
     }
 };
 

--- a/src/V3EmitCConstPool.cpp
+++ b/src/V3EmitCConstPool.cpp
@@ -68,7 +68,7 @@ class EmitCConstPool final : public EmitCConstInit {
     void emitVars(const AstConstPool* poolp) {
         std::vector<const AstVar*> varps;
         for (AstNode* nodep = poolp->modp()->stmtsp(); nodep; nodep = nodep->nextp()) {
-            if (const AstVar* const varp = VN_CAST_CONST(nodep, Var)) { varps.push_back(varp); }
+            if (const AstVar* const varp = VN_CAST(nodep, Var)) { varps.push_back(varp); }
         }
 
         if (varps.empty()) return;  // Constant pool is empty, so we are done

--- a/src/V3EmitCHeaders.cpp
+++ b/src/V3EmitCHeaders.cpp
@@ -40,7 +40,7 @@ class EmitCHeader final : public EmitCConstInit {
     void emitCellDecls(const AstNodeModule* modp) {
         bool first = true;
         for (const AstNode* nodep = modp->stmtsp(); nodep; nodep = nodep->nextp()) {
-            if (const AstCell* const cellp = VN_CAST_CONST(nodep, Cell)) {
+            if (const AstCell* const cellp = VN_CAST(nodep, Cell)) {
                 decorateFirst(first, "// CELLS\n");
                 puts(prefixNameProtect(cellp->modp()) + "* " + cellp->nameProtect() + ";\n");
             }
@@ -102,7 +102,7 @@ class EmitCHeader final : public EmitCConstInit {
 
         // Emit variables in consecutive anon and non-anon batches
         for (const AstNode* nodep = modp->stmtsp(); nodep; nodep = nodep->nextp()) {
-            if (const AstVar* const varp = VN_CAST_CONST(nodep, Var)) {
+            if (const AstVar* const varp = VN_CAST(nodep, Var)) {
                 if (varp->isIO() || varp->isSignal() || varp->isClassMember() || varp->isTemp()) {
                     const bool anon = isAnonOk(varp);
                     if (anon != lastAnon) emitCurrentList();
@@ -179,7 +179,7 @@ class EmitCHeader final : public EmitCConstInit {
     void emitEnums(const AstNodeModule* modp) {
         bool first = true;
         for (const AstNode* nodep = modp->stmtsp(); nodep; nodep = nodep->nextp()) {
-            const AstTypedef* const tdefp = VN_CAST_CONST(nodep, Typedef);
+            const AstTypedef* const tdefp = VN_CAST(nodep, Typedef);
             if (!tdefp) continue;
             if (!tdefp->attrPublic()) continue;
             const AstEnumDType* const edtypep
@@ -206,7 +206,7 @@ class EmitCHeader final : public EmitCConstInit {
         std::vector<const AstCFunc*> funcsp;
 
         for (const AstNode* nodep = modp->stmtsp(); nodep; nodep = nodep->nextp()) {
-            if (const AstCFunc* const funcp = VN_CAST_CONST(nodep, CFunc)) {
+            if (const AstCFunc* const funcp = VN_CAST(nodep, CFunc)) {
                 if (funcp->dpiImportPrototype())  // Declared in __Dpi.h
                     continue;
                 if (funcp->dpiExportDispatcher())  // Declared in __Dpi.h
@@ -230,7 +230,7 @@ class EmitCHeader final : public EmitCConstInit {
     }
     void emitAll(const AstNodeModule* modp) {
         // Include files required by this AstNodeModule
-        if (const AstClass* const classp = VN_CAST_CONST(modp, Class)) {
+        if (const AstClass* const classp = VN_CAST(modp, Class)) {
             if (classp->extendsp())
                 puts("#include \""
                      + prefixNameProtect(classp->extendsp()->classp()->classOrPackagep())
@@ -246,7 +246,7 @@ class EmitCHeader final : public EmitCConstInit {
         emitTextSection(modp, AstType::atScHdr);
 
         // Open class body {{{
-        if (const AstClass* const classp = VN_CAST_CONST(modp, Class)) {
+        if (const AstClass* const classp = VN_CAST(modp, Class)) {
             puts("class ");
             puts(prefixNameProtect(modp));
             if (classp->extendsp()) {
@@ -310,7 +310,7 @@ class EmitCHeader final : public EmitCConstInit {
 
         emitAll(modp);
 
-        if (const AstClassPackage* const packagep = VN_CAST_CONST(modp, ClassPackage)) {
+        if (const AstClassPackage* const packagep = VN_CAST(modp, ClassPackage)) {
             // Put the non-static class implementation in same h file for speed
             emitAll(packagep->classp());
         }
@@ -335,6 +335,6 @@ void V3EmitC::emitcHeaders() {
     // Process each module in turn
     for (const AstNode* nodep = v3Global.rootp()->modulesp(); nodep; nodep = nodep->nextp()) {
         if (VN_IS(nodep, Class)) continue;  // Declared with the ClassPackage
-        EmitCHeader::main(VN_AS_CONST(nodep, NodeModule));
+        EmitCHeader::main(VN_AS(nodep, NodeModule));
     }
 }

--- a/src/V3EmitCImp.cpp
+++ b/src/V3EmitCImp.cpp
@@ -38,14 +38,14 @@ class EmitCGatherDependencies final : AstNVisitor {
     // METHODS
     void addSymsDependency() { m_dependencies.insert(EmitCBaseVisitor::symClassName()); }
     void addModDependency(const AstNodeModule* modp) {
-        if (const AstClass* const classp = VN_CAST_CONST(modp, Class)) {
+        if (const AstClass* const classp = VN_CAST(modp, Class)) {
             m_dependencies.insert(EmitCBaseVisitor::prefixNameProtect(classp->classOrPackagep()));
         } else {
             m_dependencies.insert(EmitCBaseVisitor::prefixNameProtect(modp));
         }
     }
     void addDTypeDependency(const AstNodeDType* nodep) {
-        if (const AstClassRefDType* const dtypep = VN_CAST_CONST(nodep, ClassRefDType)) {
+        if (const AstClassRefDType* const dtypep = VN_CAST(nodep, ClassRefDType)) {
             m_dependencies.insert(
                 EmitCBaseVisitor::prefixNameProtect(dtypep->classp()->classOrPackagep()));
         }
@@ -193,7 +193,7 @@ class EmitCImp final : EmitCFunc {
         // Emit static variable definitions
         const string modName = prefixNameProtect(modp);
         for (const AstNode* nodep = modp->stmtsp(); nodep; nodep = nodep->nextp()) {
-            if (const AstVar* const varp = VN_CAST_CONST(nodep, Var)) {
+            if (const AstVar* const varp = VN_CAST(nodep, Var)) {
                 if (varp->isStatic()) {
                     puts(varp->vlArgType(true, false, false, modName));
                     puts(";\n");
@@ -205,7 +205,7 @@ class EmitCImp final : EmitCFunc {
         const string modName = prefixNameProtect(modp);
         bool first = true;
         for (const AstNode* nodep = modp->stmtsp(); nodep; nodep = nodep->nextp()) {
-            if (const AstVar* const varp = VN_CAST_CONST(nodep, Var)) {
+            if (const AstVar* const varp = VN_CAST(nodep, Var)) {
                 if (varp->isParam()) {
                     if (first) {
                         puts("\n");
@@ -241,7 +241,7 @@ class EmitCImp final : EmitCFunc {
 
         ofp()->indentInc();
         for (const AstNode* nodep = modp->stmtsp(); nodep; nodep = nodep->nextp()) {
-            if (const AstVar* const varp = VN_CAST_CONST(nodep, Var)) {
+            if (const AstVar* const varp = VN_CAST(nodep, Var)) {
                 if (const AstBasicDType* const dtypep
                     = VN_CAST(varp->dtypeSkipRefp(), BasicDType)) {
                     if (dtypep->keyword().isMTaskState()) {
@@ -446,7 +446,7 @@ class EmitCImp final : EmitCFunc {
     }
     void emitCommonImp(const AstNodeModule* modp) {
         const AstClass* const classp
-            = VN_IS(modp, ClassPackage) ? VN_AS_CONST(modp, ClassPackage)->classp() : nullptr;
+            = VN_IS(modp, ClassPackage) ? VN_AS(modp, ClassPackage)->classp() : nullptr;
 
         if (hasCommonImp(modp) || hasCommonImp(classp)) {
             std::set<string> headers;
@@ -486,7 +486,7 @@ class EmitCImp final : EmitCFunc {
         };
 
         gather(modp);
-        if (const AstClassPackage* const packagep = VN_CAST_CONST(modp, ClassPackage)) {
+        if (const AstClassPackage* const packagep = VN_CAST(modp, ClassPackage)) {
             gather(packagep->classp());
         }
 
@@ -887,7 +887,7 @@ void V3EmitC::emitcImp() {
     // Process each module in turn
     for (const AstNode* nodep = v3Global.rootp()->modulesp(); nodep; nodep = nodep->nextp()) {
         if (VN_IS(nodep, Class)) continue;  // Imped with ClassPackage
-        const AstNodeModule* const modp = VN_AS_CONST(nodep, NodeModule);
+        const AstNodeModule* const modp = VN_AS(nodep, NodeModule);
         EmitCImp::main(modp, /* slow: */ true);
         EmitCImp::main(modp, /* slow: */ false);
     }

--- a/src/V3EmitCModel.cpp
+++ b/src/V3EmitCModel.cpp
@@ -90,7 +90,7 @@ class EmitCModel final : public EmitCFunc {
              "// The application code writes and reads these signals to\n"
              "// propagate new values into/out from the Verilated model.\n");
         for (const AstNode* nodep = modp->stmtsp(); nodep; nodep = nodep->nextp()) {
-            if (const AstVar* const varp = VN_CAST_CONST(nodep, Var)) {
+            if (const AstVar* const varp = VN_CAST(nodep, Var)) {
                 if (varp->isPrimaryIO()) {  //
                     emitVarDecl(varp, /* asRef: */ true);
                 }
@@ -102,7 +102,7 @@ class EmitCModel final : public EmitCFunc {
              "// Public to allow access to /* verilator public */ items.\n"
              "// Otherwise the application code can consider these internals.\n");
         for (AstNode* nodep = modp->stmtsp(); nodep; nodep = nodep->nextp()) {
-            if (const AstCell* const cellp = VN_CAST_CONST(nodep, Cell)) {
+            if (const AstCell* const cellp = VN_CAST(nodep, Cell)) {
                 puts(prefixNameProtect(cellp->modp()) + "* const " + cellp->nameProtect() + ";\n");
             }
         }
@@ -237,7 +237,7 @@ class EmitCModel final : public EmitCFunc {
 
         // Set up IO references
         for (const AstNode* nodep = modp->stmtsp(); nodep; nodep = nodep->nextp()) {
-            if (const AstVar* const varp = VN_CAST_CONST(nodep, Var)) {
+            if (const AstVar* const varp = VN_CAST(nodep, Var)) {
                 if (varp->isPrimaryIO()) {
                     const string protName = varp->nameProtect();
                     puts("    , " + protName + "{vlSymsp->TOP." + protName + "}\n");
@@ -247,7 +247,7 @@ class EmitCModel final : public EmitCFunc {
 
         // Setup cell pointers
         for (AstNode* nodep = modp->stmtsp(); nodep; nodep = nodep->nextp()) {
-            if (const AstCell* const cellp = VN_CAST_CONST(nodep, Cell)) {
+            if (const AstCell* const cellp = VN_CAST(nodep, Cell)) {
                 const string protName = cellp->nameProtect();
                 puts("    , " + protName + "{vlSymsp->TOP." + protName + "}\n");
             }

--- a/src/V3LinkDot.cpp
+++ b/src/V3LinkDot.cpp
@@ -99,7 +99,7 @@ public:
 class LinkNodeMatcherVarIO final : public VNodeMatcher {
 public:
     virtual bool nodeMatch(const AstNode* nodep) const override {
-        const AstVar* varp = VN_CAST_CONST(nodep, Var);
+        const AstVar* varp = VN_CAST(nodep, Var);
         if (!varp) return false;
         return varp->isIO();
     }
@@ -107,7 +107,7 @@ public:
 class LinkNodeMatcherVarParam final : public VNodeMatcher {
 public:
     virtual bool nodeMatch(const AstNode* nodep) const override {
-        const AstVar* varp = VN_CAST_CONST(nodep, Var);
+        const AstVar* varp = VN_CAST(nodep, Var);
         if (!varp) return false;
         return varp->isParam();
     }

--- a/src/V3MergeCond.cpp
+++ b/src/V3MergeCond.cpp
@@ -169,17 +169,17 @@ private:
     // Predicate to check if an expression yields only 0 or 1 (i.e.: a 1-bit value)
     static bool yieldsOneOrZero(const AstNode* nodep) {
         UASSERT_OBJ(!nodep->isWide(), nodep, "Cannot handle wide nodes");
-        if (const AstConst* const constp = VN_CAST_CONST(nodep, Const)) {
+        if (const AstConst* const constp = VN_CAST(nodep, Const)) {
             return constp->num().toUQuad() <= 1;
         }
-        if (const AstVarRef* const vrefp = VN_CAST_CONST(nodep, VarRef)) {
+        if (const AstVarRef* const vrefp = VN_CAST(nodep, VarRef)) {
             AstVar* const varp = vrefp->varp();
             return varp->widthMin() == 1 && !varp->dtypep()->isSigned();
         }
-        if (const AstShiftR* const shiftp = VN_CAST_CONST(nodep, ShiftR)) {
+        if (const AstShiftR* const shiftp = VN_CAST(nodep, ShiftR)) {
             // Shift right by width - 1 or more
-            if (const AstConst* const constp = VN_CAST_CONST(shiftp->rhsp(), Const)) {
-                const AstVarRef* const vrefp = VN_CAST_CONST(shiftp->lhsp(), VarRef);
+            if (const AstConst* const constp = VN_CAST(shiftp->rhsp(), Const)) {
+                const AstVarRef* const vrefp = VN_CAST(shiftp->lhsp(), VarRef);
                 const int width = vrefp && !vrefp->varp()->dtypep()->isSigned()
                                       ? vrefp->varp()->widthMin()
                                       : shiftp->width();
@@ -191,17 +191,17 @@ private:
             || VN_IS(nodep, Gt) || VN_IS(nodep, Gte)) {
             return true;
         }
-        if (const AstNodeBiop* const biopp = VN_CAST_CONST(nodep, NodeBiop)) {
+        if (const AstNodeBiop* const biopp = VN_CAST(nodep, NodeBiop)) {
             if (VN_IS(nodep, And))
                 return yieldsOneOrZero(biopp->lhsp()) || yieldsOneOrZero(biopp->rhsp());
             if (VN_IS(nodep, Or) || VN_IS(nodep, Xor))
                 return yieldsOneOrZero(biopp->lhsp()) && yieldsOneOrZero(biopp->rhsp());
             return false;
         }
-        if (const AstNodeCond* const condp = VN_CAST_CONST(nodep, NodeCond)) {
+        if (const AstNodeCond* const condp = VN_CAST(nodep, NodeCond)) {
             return yieldsOneOrZero(condp->expr1p()) && yieldsOneOrZero(condp->expr2p());
         }
-        if (const AstCCast* const castp = VN_CAST_CONST(nodep, CCast)) {
+        if (const AstCCast* const castp = VN_CAST(nodep, CCast)) {
             // Cast never sign extends
             return yieldsOneOrZero(castp->lhsp());
         }

--- a/src/V3Param.cpp
+++ b/src/V3Param.cpp
@@ -301,11 +301,9 @@ class ParamProcessor final {
     }
 
     static string paramValueKey(const AstNode* nodep) {
-        if (const AstRefDType* const refp = VN_CAST_CONST(nodep, RefDType)) {
-            nodep = refp->skipRefp();
-        }
+        if (const AstRefDType* const refp = VN_CAST(nodep, RefDType)) { nodep = refp->skipRefp(); }
         string key = nodep->name();
-        if (const AstIfaceRefDType* const ifrtp = VN_CAST_CONST(nodep, IfaceRefDType)) {
+        if (const AstIfaceRefDType* const ifrtp = VN_CAST(nodep, IfaceRefDType)) {
             if (ifrtp->cellp() && ifrtp->cellp()->modp()) {
                 key = ifrtp->cellp()->modp()->name();
             } else if (ifrtp->ifacep()) {
@@ -314,7 +312,7 @@ class ParamProcessor final {
                 nodep->v3fatalSrc("Can't parameterize interface without module name");
             }
         } else if (const AstNodeUOrStructDType* const dtypep
-                   = VN_CAST_CONST(nodep, NodeUOrStructDType)) {
+                   = VN_CAST(nodep, NodeUOrStructDType)) {
             key += " ";
             key += dtypep->verilogKwd();
             key += " {";
@@ -324,10 +322,10 @@ class ParamProcessor final {
                 key += ";";
             }
             key += "}";
-        } else if (const AstMemberDType* const dtypep = VN_CAST_CONST(nodep, MemberDType)) {
+        } else if (const AstMemberDType* const dtypep = VN_CAST(nodep, MemberDType)) {
             key += " ";
             key += paramValueKey(dtypep->subDTypep());
-        } else if (const AstBasicDType* const dtypep = VN_CAST_CONST(nodep, BasicDType)) {
+        } else if (const AstBasicDType* const dtypep = VN_CAST(nodep, BasicDType)) {
             if (dtypep->isRanged()) {
                 key += "[" + cvtToStr(dtypep->left()) + ":" + cvtToStr(dtypep->right()) + "]";
             }

--- a/src/V3Simulate.h
+++ b/src/V3Simulate.h
@@ -245,7 +245,7 @@ private:
 
 public:
     void newValue(AstNode* nodep, const AstNode* valuep) {
-        if (const AstConst* constp = VN_CAST_CONST(valuep, Const)) {
+        if (const AstConst* constp = VN_CAST(valuep, Const)) {
             newConst(nodep)->num().opAssign(constp->num());
         } else if (fetchValueNull(nodep) != valuep) {
             // const_cast, as clonep() is set on valuep, but nothing should care
@@ -253,7 +253,7 @@ public:
         }
     }
     void newOutValue(AstNode* nodep, const AstNode* valuep) {
-        if (const AstConst* constp = VN_CAST_CONST(valuep, Const)) {
+        if (const AstConst* constp = VN_CAST(valuep, Const)) {
             newOutConst(nodep)->num().opAssign(constp->num());
         } else if (fetchOutValueNull(nodep) != valuep) {
             // const_cast, as clonep() is set on valuep, but nothing should care

--- a/src/V3SplitVar.cpp
+++ b/src/V3SplitVar.cpp
@@ -416,7 +416,7 @@ class SplitUnpackedVarVisitor final : public AstNVisitor, public SplitVarImpl {
     }
     static int outerMostSizeOfUnpackedArray(const AstVar* nodep) {
         const AstUnpackArrayDType* const dtypep
-            = VN_AS_CONST(nodep->dtypep()->skipRefp(), UnpackArrayDType);
+            = VN_AS(nodep->dtypep()->skipRefp(), UnpackArrayDType);
         UASSERT_OBJ(dtypep, nodep, "Must be unapcked array");
         return dtypep->elementsConst();
     }

--- a/src/V3Trace.cpp
+++ b/src/V3Trace.cpp
@@ -221,7 +221,7 @@ private:
                     const auto dupit = dupFinder.findDuplicate(nodep->valuep());
                     if (dupit != dupFinder.end()) {
                         const AstTraceDecl* const dupDeclp
-                            = VN_AS_CONST(dupit->second->backp(), TraceDecl);
+                            = VN_AS(dupit->second->backp(), TraceDecl);
                         UASSERT_OBJ(dupDeclp, nodep, "Trace duplicate of wrong type");
                         TraceTraceVertex* const dupvertexp
                             = dynamic_cast<TraceTraceVertex*>(dupDeclp->user1u().toGraphVertex());

--- a/src/V3TraceDecl.cpp
+++ b/src/V3TraceDecl.cpp
@@ -301,7 +301,7 @@ private:
                 addIgnore("Unsupported: Unpacked struct/union");
             } else {
                 for (const AstMemberDType* itemp = nodep->membersp(); itemp;
-                     itemp = VN_AS_CONST(itemp->nextp(), MemberDType)) {
+                     itemp = VN_AS(itemp->nextp(), MemberDType)) {
                     AstNodeDType* const subtypep = itemp->subDTypep()->skipRefToEnump();
                     VL_RESTORER(m_traShowname);
                     VL_RESTORER(m_traValuep);


### PR DESCRIPTION
Let me know if you object to removing these. I mostly find them a nuisance when writing new code.

---

The _CONST suffix on these macros is only lexical notation, pointer
constness can be preserved by overloading the underlying
implementations appropriately. Given that the compiler will catch
invalid const usage (trying to assign a non-const pointer to a const
pointer variable, etc.), and that the declarations of symbols should
make their constness obvious, I see no reason to keep the _CONST
flavours.