### PR TITLE
Fix wrong bit op tree optimization

### DIFF
--- a/src/V3Const.cpp
+++ b/src/V3Const.cpp
@@ -537,7 +537,7 @@ class ConstBitOpTreeVisitor final : public AstNVisitor {
                     if (leafInfo.m_lsb < leafInfo.width()) {
                         m_bitPolarities.emplace_back(leafInfo, isXorTree() || leafInfo.m_polarity,
                                                      leafInfo.m_lsb);
-                    } else if (isAndTree()) {
+                    } else if (isAndTree() && leafInfo.m_polarity) {
                         // If there is a constant 0 term in an And tree, we must include it. Fudge
                         // this by adding a bit with both polarities, which will simplify to zero
                         m_bitPolarities.emplace_back(leafInfo, true, 0);

--- a/test_regress/t/t_const_no_opt.pl
+++ b/test_regress/t/t_const_no_opt.pl
@@ -9,9 +9,11 @@ if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); di
 # SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
 
 scenarios(simulator => 1);
+top_filename("t/t_const_opt.v");
 
+# Run the same design as t_const_opt.pl without bitopt tree optimization to make sure that the result is same.
 compile(
-    verilator_flags2 => ["-Wno-UNOPTTHREADS", "--stats", "$Self->{t_dir}/$Self->{name}.cpp"],
+    verilator_flags2 => ["-Wno-UNOPTTHREADS", "--stats", "-Oo", "$Self->{t_dir}/t_const_opt.cpp"],
     );
 
 execute(

--- a/test_regress/t/t_const_opt.cpp
+++ b/test_regress/t/t_const_opt.cpp
@@ -1,0 +1,13 @@
+// -*- mode: C++; c-file-style: "cc-mode" -*-
+//*************************************************************************
+//
+// Copyright 2021 by Yutetsu TAKATSUKASA. This program is free software; you can
+// redistribute it and/or modify it under the terms of either the GNU
+// Lesser General Public License Version 3 or the Perl Artistic License
+// Version 2.0.
+// SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+//
+//*************************************************************************
+
+// This function is used to introduce dependency and disturb optimization
+extern "C" int fake_dependency() { return 0; }

--- a/test_regress/t/t_const_opt.v
+++ b/test_regress/t/t_const_opt.v
@@ -57,7 +57,7 @@ module t(/*AUTOARG*/
          $write("[%0t] cyc==%0d crc=%x sum=%x\n",$time, cyc, crc, sum);
          if (crc !== 64'hc77bb9b3784ea091) $stop;
          // What checksum will we end up with (above print should match)
-`define EXPECTED_SUM 64'he78be35df15ae0ab
+`define EXPECTED_SUM 64'ha916d9291821c6e0
          if (sum !== `EXPECTED_SUM) $stop;
          $write("*-* All Finished *-*\n");
          $finish;
@@ -77,10 +77,11 @@ module Test(/*AUTOARG*/
    input [31:0] i;
    logic [31:0] d;
    logic d0, d1, d2, d3, d4, d5, d6, d7;
+   logic bug3182_out;
 
    output logic o;
 
-   logic [4:0] tmp;
+   logic [5:0] tmp;
    assign o = ^tmp;
 
    always_ff @(posedge clk) begin
@@ -101,6 +102,29 @@ module Test(/*AUTOARG*/
       tmp[2] <= ((d0 & d1) | (d0 & d2))^ ((d3 & d4) | (d5 & d4));  // replaceAndOr()
       tmp[3] <= d0 <-> d1; // replaceLogEq()
       tmp[4] <= i[0] & (i[1] & (i[2] & (i[3] | d[4])));  // ConstBitOpTreeVisitor::m_frozenNodes
+      tmp[5] <= bug3182_out;
    end
 
+   bug3182 i_bug3182(.in(d[4:0]), .out(bug3182_out));
+
+endmodule
+
+module bug3182(in, out);
+   input wire [4:0] in;
+   output wire out;
+
+   // This function always returns 0, so safe to take bitwise OR with any value.
+   // Calling this function stops constant folding as Verialtor does not know
+   // what this function returns.
+   import "DPI-C" context function int fake_dependency();
+
+   logic [4:0] bit_source;
+
+   /* verilator lint_off WIDTH */
+   always @(in)
+      bit_source = fake_dependency() | in;
+
+   wire [5:0] tmp = bit_source; // V3Gate should inline this
+   wire out =  ~(tmp >> 5) & (bit_source == 5'd10);
+   /* verilator lint_on WIDTH */
 endmodule


### PR DESCRIPTION
Fixes #3182 

Here is the input of the problematic bit op tree path. (Note that `bits_source` is originally `SimTop__DOT__l_soc__DOT__core_with_l2__DOT__core__DOT__memBlock__DOT__dcache__DOT__dcache__DOT__wb_io_mem_release_bits_source`, but I shortened in the following snippet).

```
    AND 0x556f7b9f39f0 <e171813016#> {c1049971bf} @dt=0x556fb8a4dfb0@(G/wu32/1)
    1: NOT 0x556f7b9f3ab0 <e171813012#> {c1049969as} @dt=0x556fb8a4dfb0@(G/wu32/1)
    1:1: SHIFTR 0x556f7b9f3c40 <e196387914#> {c1049969bu} @dt=0x556fb8a4dfb0@(G/wu32/1)
    1:1:1: VARREF 0x556f79de76e0 <e196387904#> {c1032795bs} @dt=0x556fb8a4b210@(G/wu32/6)  bits_source [RV] <- VAR 0x556f5f5ee850 <e51888605#> {c453059ao} @dt=0x556c34314260@(G/w5)  bits_source [VSTATIC]  WIRE
    1:1:2: CONST 0x556f79de77f0 <e196387905#> {c1049969bv} @dt=0x556bafb09cf0@(G/swu32/3)  3'h5
    2: GTE 0x556f798209e0 <e171813015#> {c1049970bz} @dt=0x556f46c20010@(G/nwu32/1)
    2:1: CONST 0x556f79820aa0 <e171813013#> {c1049970cc} @dt=0x556c21cbee00@(G/wu32/5)  5'h10
    2:2: VARREF 0x556f79820bc0 <e171813014#> {c1032795bs} @dt=0x556c21cbee00@(G/wu32/5)  bits_source [RV] <- VAR 0x556f5f5ee850 <e51888605#> {c453059ao} @dt=0x556c34314260@(G/w5)  bits_source [VSTATIC]  WIRE
```
Variable `bits_source` has just 5 bit width as `(G/w5)` tells.
The result of SHIFTR (Logical shift right) of 5 is 0.
NOT flips the result to 1, but the NOT is ignored in the master.

I have been trying to make a small test case, but unfortunately not yet.
I think It's better to merge this fix rather than taking time to adding a test as this bug causes wrong simulation result.
When I can make a small test case, I will send another PR.