### PR TITLE
Remove duplicate/wrong change-log entry

### DIFF
--- a/Changes
+++ b/Changes
@@ -21,7 +21,6 @@ Verilator 4.215 devel
 * Improve --thread verilation-time performance.
 * Fix array method names with parenthesis (#3181) (#3183). [Teng Huang]
 * Fix split_var assign merging (#3177) (#3179). [Yutetsu TAKATSUKASA]
-* Fix $display of signed/unsigned without format (#3207). [Julie Schwartz]
 * Fix nested generate if genblk naming (#3189). [yanx21]
 * Fix display of signed without format (#3204). [Julie Schwartz]
 * Fix display of empty string constant (#3207). [Julie Schwartz]

--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -45,6 +45,7 @@ John Coiner
 John Demme
 Jonathan Drolet
 Josh Redford
+Julie Schwartz
 Julien Margetts
 Kaleb Barrett
 Kanad Kanhere


### PR DESCRIPTION
I hope this isn't overkill, to point out that a change-log entry was accidentally added twice (with the wrong issue number the first time).  This PR removes the wrong entry.