### PR TITLE
Fix bit op tree optimization

### DIFF
--- a/src/V3Const.cpp
+++ b/src/V3Const.cpp
@@ -480,10 +480,9 @@ class ConstBitOpTreeVisitor final : public AstNVisitor {
             incrOps(andp, __LINE__);
 
             // Mark all bits checked in this reduction
-            const int maxBitIdx = std::min(ref.m_lsb + maskNum.width(), ref.width());
-            for (int bitIdx = ref.m_lsb; bitIdx < maxBitIdx; ++bitIdx) {
+            for (int bitIdx = ref.m_lsb; bitIdx < ref.width(); ++bitIdx) {
                 const int maskIdx = bitIdx - ref.m_lsb;
-                if (maskNum.bitIs0(maskIdx)) continue;
+                if (maskIdx >= maskNum.width() || maskNum.bitIs0(maskIdx)) continue;
                 // Set true, m_polarity takes care of the entire parity
                 m_bitPolarities.emplace_back(ref, true, bitIdx);
             }
@@ -572,10 +571,9 @@ class ConstBitOpTreeVisitor final : public AstNVisitor {
                 incrOps(andp, __LINE__);
 
                 // Mark all bits checked by this comparison
-                const int maxBitIdx = std::min(ref.m_lsb + compNum.width(), ref.width());
-                for (int bitIdx = ref.m_lsb; bitIdx < maxBitIdx; ++bitIdx) {
+                for (int bitIdx = ref.m_lsb; bitIdx < ref.width(); ++bitIdx) {
                     const int maskIdx = bitIdx - ref.m_lsb;
-                    if (maskNum.bitIs0(maskIdx)) continue;
+                    if (maskIdx >= maskNum.width() || maskNum.bitIs0(maskIdx)) continue;
                     const bool polarity = compNum.bitIs1(maskIdx) != maskFlip;
                     m_bitPolarities.emplace_back(ref, polarity, bitIdx);
                 }
@@ -588,10 +586,10 @@ class ConstBitOpTreeVisitor final : public AstNVisitor {
                 incrOps(nodep, __LINE__);
 
                 // Mark all bits checked by this comparison
-                const int maxBitIdx = std::min(ref.m_lsb + compNum.width(), ref.width());
-                for (int bitIdx = ref.m_lsb; bitIdx < maxBitIdx; ++bitIdx) {
+                for (int bitIdx = ref.m_lsb; bitIdx < ref.width(); ++bitIdx) {
                     const int maskIdx = bitIdx - ref.m_lsb;
-                    const bool polarity = compNum.bitIs1(maskIdx) != maskFlip;
+                    const bool bitIs1 = maskIdx < compNum.width() && compNum.bitIs1(maskIdx);
+                    const bool polarity = bitIs1 != maskFlip;
                     m_bitPolarities.emplace_back(ref, polarity, bitIdx);
                 }
             }

--- a/src/V3Const.cpp
+++ b/src/V3Const.cpp
@@ -480,9 +480,9 @@ class ConstBitOpTreeVisitor final : public AstNVisitor {
             incrOps(andp, __LINE__);
 
             // Mark all bits checked in this reduction
-            for (int bitIdx = ref.m_lsb; bitIdx < ref.width(); ++bitIdx) {
+            const int maxBitIdx = std::min(ref.m_lsb + maskNum.width(), ref.width());
+            for (int bitIdx = ref.m_lsb; bitIdx < maxBitIdx; ++bitIdx) {
                 const int maskIdx = bitIdx - ref.m_lsb;
-                if (maskIdx >= maskNum.width()) break;
                 if (maskNum.bitIs0(maskIdx)) continue;
                 // Set true, m_polarity takes care of the entire parity
                 m_bitPolarities.emplace_back(ref, true, bitIdx);
@@ -572,9 +572,9 @@ class ConstBitOpTreeVisitor final : public AstNVisitor {
                 incrOps(andp, __LINE__);
 
                 // Mark all bits checked by this comparison
-                for (int bitIdx = ref.m_lsb; bitIdx < ref.width(); ++bitIdx) {
+                const int maxBitIdx = std::min(ref.m_lsb + maskNum.width(), ref.width());
+                for (int bitIdx = ref.m_lsb; bitIdx < maxBitIdx; ++bitIdx) {
                     const int maskIdx = bitIdx - ref.m_lsb;
-                    if (maskIdx >= maskNum.width()) break;
                     if (maskNum.bitIs0(maskIdx)) continue;
                     const bool polarity = compNum.bitIs1(maskIdx) != maskFlip;
                     m_bitPolarities.emplace_back(ref, polarity, bitIdx);
@@ -588,10 +588,10 @@ class ConstBitOpTreeVisitor final : public AstNVisitor {
                 incrOps(nodep, __LINE__);
 
                 // Mark all bits checked by this comparison
-                for (int bitIdx = ref.m_lsb; bitIdx < ref.width(); ++bitIdx) {
+                const int maxBitIdx = std::min(ref.m_lsb + compNum.width(), ref.width());
+                for (int bitIdx = ref.m_lsb; bitIdx < maxBitIdx; ++bitIdx) {
                     const int maskIdx = bitIdx - ref.m_lsb;
-                    const bool bitIs1 = maskIdx < compNum.width() && compNum.bitIs1(maskIdx);
-                    const bool polarity = bitIs1 != maskFlip;
+                    const bool polarity = compNum.bitIs1(maskIdx) != maskFlip;
                     m_bitPolarities.emplace_back(ref, polarity, bitIdx);
                 }
             }

--- a/src/V3Const.cpp
+++ b/src/V3Const.cpp
@@ -482,7 +482,8 @@ class ConstBitOpTreeVisitor final : public AstNVisitor {
             // Mark all bits checked in this reduction
             for (int bitIdx = ref.m_lsb; bitIdx < ref.width(); ++bitIdx) {
                 const int maskIdx = bitIdx - ref.m_lsb;
-                if (maskIdx >= maskNum.width() || maskNum.bitIs0(maskIdx)) continue;
+                if (maskIdx >= maskNum.width()) break;
+                if (maskNum.bitIs0(maskIdx)) continue;
                 // Set true, m_polarity takes care of the entire parity
                 m_bitPolarities.emplace_back(ref, true, bitIdx);
             }
@@ -573,7 +574,8 @@ class ConstBitOpTreeVisitor final : public AstNVisitor {
                 // Mark all bits checked by this comparison
                 for (int bitIdx = ref.m_lsb; bitIdx < ref.width(); ++bitIdx) {
                     const int maskIdx = bitIdx - ref.m_lsb;
-                    if (maskIdx >= maskNum.width() || maskNum.bitIs0(maskIdx)) continue;
+                    if (maskIdx >= maskNum.width()) break;
+                    if (maskNum.bitIs0(maskIdx)) continue;
                     const bool polarity = compNum.bitIs1(maskIdx) != maskFlip;
                     m_bitPolarities.emplace_back(ref, polarity, bitIdx);
                 }

--- a/test_regress/t/t_const_opt.v
+++ b/test_regress/t/t_const_opt.v
@@ -135,7 +135,6 @@ endmodule
 module bug3197(input wire clk, input wire [31:0] in, output out);
    logic [63:0] d;
    always_ff @(posedge clk)
-      //d <= {d[31:0], in};
       d <= {d[31:0], in[0] ? in : 32'b0};
 
    wire tmp0 = (|d[38:0]);

--- a/test_regress/t/t_const_opt.v
+++ b/test_regress/t/t_const_opt.v
@@ -57,7 +57,7 @@ module t(/*AUTOARG*/
          $write("[%0t] cyc==%0d crc=%x sum=%x\n", $time, cyc, crc, sum);
          if (crc !== 64'hc77bb9b3784ea091) $stop;
          // What checksum will we end up with (above print should match)
-`define EXPECTED_SUM 64'ha916d9291821c6e0
+`define EXPECTED_SUM 64'hcae926ece668f35d
          if (sum !== `EXPECTED_SUM) $stop;
          $write("*-* All Finished *-*\n");
          $finish;
@@ -78,10 +78,11 @@ module Test(/*AUTOARG*/
    logic [31:0] d;
    logic d0, d1, d2, d3, d4, d5, d6, d7;
    logic bug3182_out;
+   logic bug3197_out;
 
    output logic o;
 
-   logic [5:0] tmp;
+   logic [6:0] tmp;
    assign o = ^tmp;
 
    always_ff @(posedge clk) begin
@@ -103,9 +104,11 @@ module Test(/*AUTOARG*/
       tmp[3] <= d0 <-> d1; // replaceLogEq()
       tmp[4] <= i[0] & (i[1] & (i[2] & (i[3] | d[4])));  // ConstBitOpTreeVisitor::m_frozenNodes
       tmp[5] <= bug3182_out;
+      tmp[6] <= bug3197_out;
    end
 
    bug3182 i_bug3182(.in(d[4:0]), .out(bug3182_out));
+   bug3197 i_bug3197(.clk(clk), .in(d), .out(bug3197_out));
 
 endmodule
 
@@ -127,4 +130,14 @@ module bug3182(in, out);
    wire [5:0] tmp = bit_source; // V3Gate should inline this
    wire out =  ~(tmp >> 5) & (bit_source == 5'd10);
    /* verilator lint_on WIDTH */
+endmodule
+
+module bug3197(input wire clk, input wire [31:0] in, output out);
+   logic [63:0] d;
+   always_ff @(posedge clk)
+      //d <= {d[31:0], in};
+      d <= {d[31:0], in[0] ? in : 32'b0};
+
+   wire tmp0 = (|d[38:0]);
+   assign out = (d[39] | tmp0);
 endmodule


### PR DESCRIPTION
I hope this PR fixes #3197 

When AST as below is passed to bit op tree optimizer,
```
 OR 0x55c24b849ad0 <e61271#> {d393cw} @dt=0x55c24b941b70@(G/wu32/1)
1: CCAST 0x55c24bb31470 <e95178#> {d277ca} @dt=0x55c24b941b70@(G/wu32/1) sz32
1:1: SHIFTR 0x55c24ba5f790 <e95175#> {d277ca} @dt=0x55c24b841df0@(G/w64)
1:1:1: VARREF 0x55c24b89a820 <e95166#> {d277bp} @dt=0x55c24b841df0@(G/w64)  var [RV] <- VAR 0x55c24b8dd9f0 <e56393#> {d78bc} @dt=0x55c24b841df0@(G/w64)  var [FUNC] VAR
1:1:2: CONST 0x55c24b9ca020 <e95167#> {d277cb} @dt=0x55c24b843c20@(G/swu32/6)  6'h27
2: NEQ 0x55c24b9cae90 <e95210#> {d278bp} @dt=0x55c24b840840@(G/w1)
2:1: CONST 0x55c24b9cb080 <e95206#> {d278bp} @dt=0x55c24b8a4cd0@(G/w32)  32'h0
2:2: AND 0x55c24b9ba260 <e95207#> {d278cc} @dt=0x55c24b9a3180@(G/wu64/39)
2:2:1: CONST 0x55c24b9ba140 <e61266#> {d278cc} @dt=0x55c24b841df0@(G/w64)  64'h7fffffffff
2:2:2: VARREF 0x55c24b899930 <e114836#> {d278br} @dt=0x55c24b9a3180@(G/wu64/39)  var [RV] <- VAR 0x55c24b8dd9f0 <e56393#> {d78bc} @dt=0x55c24b841df0@(G/w64)  var [FUNC] VAR
```

It optimizes as below,
```
 CCAST 0x55c24b96c640 <e114867#> {d393cw} @dt=0x55c24b941b70@(G/wu32/1) sz32
1: NEQ 0x55c24b84a160 <e114862#> {d277bp} @dt=0x55c24b840840@(G/w1)
1:1: CONST 0x55c24bb2fd40 <e114857#> {d277bp} @dt=0x55c24b841df0@(G/w64)  64'h0
1:2: AND 0x55c24b958360 <e114858#> {d277bp} @dt=0x55c24b841df0@(G/w64)
1:2:1: CONST 0x55c24bb2d840 <e114847#> {d277bp} @dt=0x55c24b841df0@(G/w64)  64'h80ffffffff  <= ????
1:2:2: VARREF 0x55c24b898330 <e114848#> {d277bp} @dt=0x55c24b841df0@(G/w64)  var [RV] <- VAR 0x55c24b8dd9f0 <e56393#> {d78bc} @dt=0x55c24b841df0@(G/w64)  var [FUNC] VAR
```
The bitmask is expected to be `64'hffffffffff`, but `64'h80ffffffff` .
This is because only lower 32 bit of `CONST 0x55c24b9ba140` is copied.
And the behavior is due to `CONST 0x55c24b9cb080` that is just 32 bit width, 

Forcing the constant to be 64bit is another way of fix, but I think this change is more robust.

I will push a commit that just adds a test, then push the fix as usual.