### PR TITLE
Fix for top level parameter overwrite when a package has the same parameter name (#3241)

### DIFF
--- a/src/V3LinkDot.cpp
+++ b/src/V3LinkDot.cpp
@@ -1127,7 +1127,7 @@ class LinkDotFindVisitor final : public AstNVisitor {
             }
             if (ins) {
                 if (m_statep->forPrimary() && nodep->isGParam()
-					&& VN_IS(m_modSymp->nodep(), Module)
+                    && VN_IS(m_modSymp->nodep(), Module)
                     && (m_statep->rootEntp()->nodep() == m_modSymp->parentp()->nodep())) {
                     // This is the toplevel module. Check for command line overwrites of parameters
                     // We first search if the parameter is overwritten and then replace it with a

--- a/src/V3LinkDot.cpp
+++ b/src/V3LinkDot.cpp
@@ -1127,6 +1127,7 @@ class LinkDotFindVisitor final : public AstNVisitor {
             }
             if (ins) {
                 if (m_statep->forPrimary() && nodep->isGParam()
+					&& VN_IS(m_modSymp->nodep(), Module)
                     && (m_statep->rootEntp()->nodep() == m_modSymp->parentp()->nodep())) {
                     // This is the toplevel module. Check for command line overwrites of parameters
                     // We first search if the parameter is overwritten and then replace it with a

--- a/test_regress/t/t_flag_parameter_pkg.pl
+++ b/test_regress/t/t_flag_parameter_pkg.pl
@@ -1,0 +1,23 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2003 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    verilator_flags2 => ['-GPARAM_A=1'],
+    ms_flags2 => ['-GPARAM_A=1'],
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_flag_parameter_pkg.v
+++ b/test_regress/t/t_flag_parameter_pkg.v
@@ -1,0 +1,28 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed into the Public Domain, for any use,
+// without warranty, 2021 by Adrien Le Masle.
+// SPDX-License-Identifier: CC0-1.0
+
+package pack_a;
+   parameter PARAM_A = 0;
+endpackage : pack_a
+
+//module t;
+module t (/*AUTOARG*/
+   // Inputs
+   clk
+   );
+
+   input clk;
+
+   parameter PARAM_A = 0;
+
+   initial begin
+      $display(PARAM_A);
+      if (PARAM_A != 1) $stop;
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end
+
+endmodule


### PR DESCRIPTION
@wsnyder the issue was the check for top level module was incomplete. A package was considered a top level module and the corresponding parameter was overwritten in a package parsed before the top level module, instead of in the top level module itself.

Let me know if the fix I made looks reasonable to you. I will also try to add a test for this.
