### PR TITLE
Fix make support for BSD ar

### DIFF
--- a/include/verilated.mk.in
+++ b/include/verilated.mk.in
@@ -223,7 +223,8 @@ endif
 	$(info Archive $(AR) -rcs $@ $^)
 	$(foreach L, $(filter-out %.a,$^), $(shell echo $L >>$@.verilator_deplist.tmp))
 	@if test $(words $(filter %.a,$^)) -eq 0; then \
-		$(AR) -rcs $@ @$@.verilator_deplist.tmp; \
+		cat $@.verilator_deplist.tmp | xargs $(AR) -rc $@; \
+		$(AR) -s $@; \
 	else \
 		$(RM) -rf $@.tmpdir; \
 		for archive in $(filter %.a,$^); do \
@@ -232,7 +233,8 @@ endif
 			$(AR) -x ../../$${archive}; \
 			cd ../..; \
 		done; \
-		$(AR) -rcs $@ @$@.verilator_deplist.tmp $@.tmpdir/*/*.o; \
+		cat $@.verilator_deplist.tmp | xargs $(AR) -rc $@; \
+		$(AR) -rcs $@ $@.tmpdir/*/*.o; \
 	fi \
 	; $(RM) -rf $@.verilator_deplist.tmp $@.tmpdir
 


### PR DESCRIPTION
This is a fix for #2999.  Requiring GNU `ar` on macOS would seem, to me, to require scrapping macOS's native binutils etc and switching fully to GNU.  I would prefer not to.

It looks like we can easily replace the use of `@` with `xargs`, which I believe knows the max line length and will break up the command as necessary.  (If not, you can add flags like `-L 1` to specify a maximum number of files per command line.)  I didn't know if we should be concerned about building the index on multiple invocations, so (out of paranoia), I've just given `-s` at the end.  I use `ar -s` rather than adding RANLIB to the configure script.  Also, I assume that it's OK to expect `xargs` to be available (without adding it to the configure check etc), since we expect `echo` and `sed` (in the configure script itself)?

Also, I note that the existing commands were still using a wildcard on the `ar` command line (`$@.tmpdir/*/*.o`).  Do we know that this will never exceed the maximum line length? or was this an oversight (which should also be handled with `@` or `xargs`)?
