### PR TITLE
Remove spurious spaces-in-filenames check

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -24,6 +24,7 @@ Eric Rippey
 Fan Shupei
 Felix Yan
 Garrett Smith
+George Lyon
 Geza Lore
 Gianfranco Costamagna
 Glen Gibb

--- a/include/verilated.mk.in
+++ b/include/verilated.mk.in
@@ -38,13 +38,6 @@ VERILATOR_INCLUDER = $(PERL) $(VERILATOR_ROOT)/bin/verilator_includer
 VERILATOR_CCACHE_REPORT = $(PYTHON3) $(VERILATOR_ROOT)/bin/verilator_ccache_report
 
 ######################################################################
-# Make checks
-
-ifneq ($(words $(CURDIR)),1)
- $(error Unsupported: GNU Make cannot build in directories containing spaces, build elsewhere: '$(CURDIR)')
-endif
-
-######################################################################
 # C Preprocessor flags
 
 # Add -MMD -MP if you're using a recent version of GCC.


### PR DESCRIPTION
I can successfully compile a verilated executable using GNU Make 3.81 (on macOS) with spaces in the path if I comment out this line. Maybe this is an obsolete constraint?