### PR TITLE
Internals: Fix macOS arm64 build by excluding x86 only cpuid header

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -28,6 +28,7 @@ Geza Lore
 Gianfranco Costamagna
 Glen Gibb
 Graham Rushton
+Guokai Chen
 Harald Heckmann
 Howard Su
 Huang Rui

--- a/include/verilated_threads.h
+++ b/include/verilated_threads.h
@@ -43,7 +43,7 @@
 #if defined(__linux)
 # include <sched.h>  // For sched_getcpu()
 #endif
-#if defined(__APPLE__)
+#if defined(__APPLE__) && !defined(__arm64__)
 # include <cpuid.h>  // For __cpuid_count()
 #endif
 // clang-format on
@@ -168,7 +168,7 @@ public:
     static int getcpu() {  // Return current executing CPU
 #if defined(__linux)
         return sched_getcpu();
-#elif defined(__APPLE__)
+#elif defined(__APPLE__) && !defined(__arm64__)
         vluint32_t info[4];
         __cpuid_count(1, 0, info[0], info[1], info[2], info[3]);
         // info[1] is EBX, bits 24-31 are APIC ID


### PR DESCRIPTION
This fixes https://github.com/verilator/verilator/issues/3285
