### PR TITLE
Support sequential anyedge processes on 1 bit signals

### DIFF
--- a/src/V3Active.cpp
+++ b/src/V3Active.cpp
@@ -586,6 +586,12 @@ private:
                     nodep->edgeType(VEdgeType::ET_HIGHEDGE);
                 }
             }
+            // If it's width 1 and anyedge, it can remain sequential
+            bool onlyItemInTree
+                = !m_itemCombo && VN_IS(nodep->backp(), SenTree) && !nodep->nextp();
+            if (nodep->edgeType() == VEdgeType::ET_ANYEDGE && nodep->varrefp()->width1()
+                && onlyItemInTree)
+                nodep->edgeType(VEdgeType::ET_BOTHEDGE);
         }
         if (nodep->edgeType() == VEdgeType::ET_ANYEDGE) {
             m_itemCombo = true;

--- a/test_regress/t/t_alw_clkdly.out
+++ b/test_regress/t/t_alw_clkdly.out
@@ -1,0 +1,9 @@
+@ posedge clk
+@ anyedge other
+@ posedge clk
+@ anyedge other
+@ posedge clk
+@ anyedge other
+@ posedge clk
+*-* All Finished *-*
+@ anyedge other

--- a/test_regress/t/t_alw_clkdly.pl
+++ b/test_regress/t/t_alw_clkdly.pl
@@ -1,0 +1,23 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2022 by Krzysztof Bieganski. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+files_identical("$Self->{obj_dir}/vlt_sim.log", $Self->{golden_filename}, "logfile");
+
+ok(1);
+1;

--- a/test_regress/t/t_alw_clkdly.v
+++ b/test_regress/t/t_alw_clkdly.v
@@ -1,0 +1,31 @@
+// DESCRIPTION::Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2022 by Krzysztof Bieganski.
+// SPDX-License-Identifier: CC0-1.0
+
+module t (/*AUTOARG*/
+   // Inputs
+   clk
+   );
+   input clk;
+
+   logic other;
+
+   integer cyc = 1;
+
+   always @(posedge clk) begin
+      $write("@ posedge clk\n");
+      other <= ~other;
+      cyc++;
+      if (cyc == 5) begin
+         $write("*-* All Finished *-*\n");
+         $finish;
+      end
+   end
+
+   always @(other) begin
+       $write("@ anyedge other\n");
+   end
+
+endmodule


### PR DESCRIPTION
Currently, any processes sensitive to `ANYEDGE` get converted to combo logic. This results in incorrect behavior in some cases (see provided test case). This PR relaxes this for 1-bit signals by changing the senitem to `BOTHEDGE`.

Signed-off-by: Krzysztof Bieganski <kbieganski@antmicro.com>