### PR TITLE
Fix VL_RESTORER behavior on passing a lvalue reference

### DIFF
--- a/src/V3Global.h
+++ b/src/V3Global.h
@@ -43,7 +43,7 @@ class V3HierBlockPlan;
 /// end-of-stope.
 // Object must be named, or it will not persist until end-of-scope.
 // Constructor needs () or GCC 4.8 false warning.
-#define VL_RESTORER(var) const VRestorer<decltype(var)> restorer_##var(var);
+#define VL_RESTORER(var) const VRestorer<typename std::decay<decltype(var)>::type> restorer_##var(var);
 
 // Object used by VL_RESTORER.  This object must be an auto variable, not
 // allocated on the heap or otherwise.


### PR DESCRIPTION
Fixing Wrong VL_RESTORER behavior on passing a lvalue reference 
#3325 
Signed-off-by: HungMingWu <u9089000@gmail.com>

