### PR TITLE
More minor spelling fixes in docs/guide/*.rst

### DIFF
--- a/docs/guide/exe_verilator_gantt.rst
+++ b/docs/guide/exe_verilator_gantt.rst
@@ -13,7 +13,7 @@ For an overview of use of verilator_gantt, see :ref:`Profiling`.
 Gantt Chart VCD
 ---------------
 
-Verilated_gnatt creates a value change dump (VCD) format dump file which
+Verilated_gantt creates a value change dump (VCD) format dump file which
 may be viewed in a waveform viewer (e.g. C<GTKWave>):
 
 .. figure:: figures/fig_gantt_min.png

--- a/docs/guide/faq.rst
+++ b/docs/guide/faq.rst
@@ -45,7 +45,7 @@ Can you provide binaries?
 """""""""""""""""""""""""
 
 You can install Verilator via the system package manager (apt, yum, etc.)
-on many Linux distributions, including Debian, Ubuntu, SuSE, RedHat, and
+on many Linux distributions, including Debian, Ubuntu, SuSE, Red Hat, and
 others.  These packages are provided by the Linux distributions and
 generally will lag the version of the mainline Verilator repository.  If no
 binary package is available for your distribution, how about you set one

--- a/docs/guide/files.rst
+++ b/docs/guide/files.rst
@@ -157,7 +157,7 @@ The Verilated executable may produce the following:
    * - profile.vlt
      - -profile data file for :ref:`Thread PGO`
    * - profile_threads.dat
-     - -profile-threads data file for :command:`verilator_gnatt`
+     - -profile-threads data file for :command:`verilator_gantt`
 
 Verilator_gantt may produce the following:
 

--- a/docs/guide/install.rst
+++ b/docs/guide/install.rst
@@ -77,7 +77,7 @@ OS Requirements
 ---------------
 
 Verilator is developed and has primary testing on Ubuntu, with additional
-testing on FreeBSD and Apple OS-X. Versions have also built on Redhat
+testing on FreeBSD and Apple OS-X. Versions have also built on Red Hat
 Linux, and other flavors of GNU/Linux-ish platforms. Verilator also works
 on Windows Subsystem for Linux (WSL2), Windows under Cygwin, and Windows
 under MinGW (gcc -mno-cygwin). Verilated output (not Verilator itself)

--- a/docs/guide/languages.rst
+++ b/docs/guide/languages.rst
@@ -340,7 +340,7 @@ Force statement
 ---------------
 
 Verilator supports the procedural `force` (and corresponding `release`)
-statement. The behaviour of the `force` statement however does not entirely
+statement. The behavior of the `force` statement however does not entirely
 comply with the IEEE 1800 SystemVerilog standard. According to the standard,
 when a procedural statement of the form `force a = b;` is executed, the
 simulation should behave as if from that point onwards, a continuous
@@ -350,7 +350,7 @@ More specifically: the value of `a` should be updated, whenever the value of
 Verilator instead evaluates the current value of `b` at the time the `force`
 statement is executed, and forces `a` to that value, without updating it
 until a new `force` or `release` statement is encountered that applies to
-`a`. This non-standard behaviour is nevertheless consistent with some other
+`a`. This non-standard behavior is nevertheless consistent with some other
 simulators.
 
 

--- a/docs/guide/verilating.rst
+++ b/docs/guide/verilating.rst
@@ -68,7 +68,7 @@ multi-core SoC.
 
 Verilator is run in hierarchical mode on the whole SoC.  Verilator will
 make two models, one for the CPU hierarchy block, and one for the SoC.  The
-Verialted code for the SoC will automatically call the CPU Verilated model.
+Verilated code for the SoC will automatically call the CPU Verilated model.
 
 The current hierarchical Verilation is based on :vlopt:`--lib-create`. Each
 hierarchy block is Verilated into a library. User modules of the hierarchy

--- a/docs/guide/warnings.rst
+++ b/docs/guide/warnings.rst
@@ -447,7 +447,7 @@ List Of Warnings
               p0();
          endmodule
 
-   Other tools with similar warnings: Veriable's forbid_defparam_rule.
+   Other tools with similar warnings: Verible's forbid_defparam_rule.
 
 
 .. option:: DEPRECATED
@@ -1217,7 +1217,7 @@ List Of Warnings
    used to cause some important action at a later time, it might be an
    important difference.
 
-   Some possible work arounds:
+   Some possible workarounds:
 
    * Move the delayed statement into the C++ wrapper file, where the
      stimulus and clock generation can be done in C++.


### PR DESCRIPTION
Focus on subtle errors in specialized vocabulary, like gantt and Verilated.

