### PR TITLE
Fix cast to array types

### DIFF
--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -6307,8 +6307,8 @@ private:
                 toBaseDtp = refp->refDTypep();
             }
         }
-        const bool toNumericable = VN_IS(toBaseDtp, BasicDType)
-                                   || VN_IS(toBaseDtp, NodeUOrStructDType);
+        const bool toNumericable
+            = VN_IS(toBaseDtp, BasicDType) || VN_IS(toBaseDtp, NodeUOrStructDType);
         // UNSUP unpacked struct/unions (treated like BasicDType)
         if (toNumericable) {
             if (fromNumericable) return COMPATIBLE;

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -6299,8 +6299,19 @@ private:
         const bool fromNumericable = VN_IS(fromBaseDtp, BasicDType)
                                      || VN_IS(fromBaseDtp, EnumDType)
                                      || VN_IS(fromBaseDtp, NodeUOrStructDType);
+
+        const AstNodeDType* toBaseDtp = toDtp;
+        while (const AstPackArrayDType* const packp = VN_CAST(toBaseDtp, PackArrayDType)) {
+            toBaseDtp = packp->subDTypep();
+            while (const AstRefDType* const refp = VN_CAST(toBaseDtp, RefDType)) {
+                toBaseDtp = refp->refDTypep();
+            }
+        }
+        const bool toNumericable = VN_IS(toBaseDtp, BasicDType)
+                                     || VN_IS(toBaseDtp, EnumDType)
+                                     || VN_IS(toBaseDtp, NodeUOrStructDType);
         // UNSUP unpacked struct/unions (treated like BasicDType)
-        if (VN_IS(toDtp, BasicDType) || VN_IS(toDtp, NodeUOrStructDType)) {
+        if (toNumericable) {
             if (fromNumericable) return COMPATIBLE;
         } else if (VN_IS(toDtp, EnumDType)) {
             if (VN_IS(fromBaseDtp, EnumDType) && toDtp->sameTree(fromDtp)) return ENUM_IMPLICIT;

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -6307,7 +6307,7 @@ private:
                 toBaseDtp = refp->refDTypep();
             }
         }
-        const bool toNumericable = VN_IS(toBaseDtp, BasicDType) || VN_IS(toBaseDtp, EnumDType)
+        const bool toNumericable = VN_IS(toBaseDtp, BasicDType)
                                    || VN_IS(toBaseDtp, NodeUOrStructDType);
         // UNSUP unpacked struct/unions (treated like BasicDType)
         if (toNumericable) {

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -6307,9 +6307,8 @@ private:
                 toBaseDtp = refp->refDTypep();
             }
         }
-        const bool toNumericable = VN_IS(toBaseDtp, BasicDType)
-                                     || VN_IS(toBaseDtp, EnumDType)
-                                     || VN_IS(toBaseDtp, NodeUOrStructDType);
+        const bool toNumericable = VN_IS(toBaseDtp, BasicDType) || VN_IS(toBaseDtp, EnumDType)
+                                   || VN_IS(toBaseDtp, NodeUOrStructDType);
         // UNSUP unpacked struct/unions (treated like BasicDType)
         if (toNumericable) {
             if (fromNumericable) return COMPATIBLE;

--- a/test_regress/t/t_cast.v
+++ b/test_regress/t/t_cast.v
@@ -15,6 +15,7 @@ module t;
 
    typedef logic [3:0] mc_t;
    typedef mc_t tocast_t;
+   typedef logic [2:0] [7:0] two_dee_t;
 
    typedef struct packed {
       logic [15:0] data;
@@ -42,6 +43,8 @@ module t;
    logic [15:0] allones = 16'hffff;
    parameter FOUR = 4;
 
+   localparam two_dee_t two_dee = two_dee_t'(32'habcdef);
+
    // bug925
    localparam [6:0] RESULT = 7'((6*9+92)%96);
 
@@ -62,6 +65,9 @@ module t;
    logic one = 1'b1;
    logic [32:0] b33 = {32'(0), one};
    logic [31:0] b32 = {31'(0), one};
+
+   logic [31:0] thirty_two_bits;
+   two_dee_t two_dee_sig;
 
    initial begin
       if (logic8bit != 8'h12) $stop;
@@ -106,6 +112,17 @@ module t;
 
       if (b33 != 33'b1) $stop;
       if (b32 != 32'b1) $stop;
+
+      if (two_dee[0] != 8'hef) $stop;
+      if (two_dee[1] != 8'hcd) $stop;
+      if (two_dee[2] != 8'hab) $stop;
+
+      thirty_two_bits = 32'h123456;
+      two_dee_sig = two_dee_t'(thirty_two_bits);
+
+      if (two_dee_sig[0] != 8'h56) $stop;
+      if (two_dee_sig[1] != 8'h34) $stop;
+      if (two_dee_sig[2] != 8'h12) $stop;
 
       $write("*-* All Finished *-*\n");
       $finish;


### PR DESCRIPTION
Static casts to packed array types currently throws `UNSUPPORTED`.  This adds a test for the issue and fixes the problem in V3Width.cpp.  It does currently cause a few tests to fail:
```
        #vlt/t_castdyn_castconst_bad: %Error: Missing ok                                            
                make -j && test_regress/t/t_castdyn_castconst_bad.pl --j --vlt
        #vlt/t_castdyn_enum: %Error: Exec of perl failed: %Warning-CASTCONST: t/t_castdyn_enum.v:25:17: $cast will always return one as 'ENUMDTYPE '$unit::enum_t'' is always castable from 'logic[31:0]'
                make -j && test_regress/t/t_castdyn_enum.pl --j --vlt
        #vlt/t_enum_huge_methods: %Error: Exec of perl failed: %Warning-CASTCONST: t/t_enum_huge_methods.v:47:20: $cast will always return one as 'ENUMDTYPE 't.my_t'' is always castable from 'logic[59:0]'
                make -j && test_regress/t/t_enum_huge_methods.pl --j --vlt                        
```

But they all fail with `cast will always return` . . . `Suggest static cast`.  This appears to be a reasonable suggestion so I'd suggest converting those tests to use static casts (or deleting these elements if the test no longer makes sense).  If that plan sounds reasonable I'll add it to this PR.