### PR TITLE
Count non-empty always blocks in V3Split

### DIFF
--- a/src/V3Split.cpp
+++ b/src/V3Split.cpp
@@ -792,7 +792,7 @@ private:
 
 class RemovePlaceholdersVisitor final : public VNVisitor {
     // MEMBERS
-    int m_emptyAlways{0};
+    int m_emptyAlways = 0;
 
     // CONSTRUCTORS
     RemovePlaceholdersVisitor() = default;

--- a/src/V3Split.cpp
+++ b/src/V3Split.cpp
@@ -808,6 +808,7 @@ class RemovePlaceholdersVisitor final : public VNVisitor {
         if (!nodep->ifsp() && !nodep->elsesp() && m_isPure) pushDeletep(nodep->unlinkFrBack());
     }
     virtual void visit(AstAlways* nodep) override {
+        VL_RESTORER(m_isPure);
         m_isPure = true;
         iterateChildren(nodep);
         if (m_isPure) {

--- a/src/V3Split.cpp
+++ b/src/V3Split.cpp
@@ -791,21 +791,36 @@ private:
 };
 
 class RemovePlaceholdersVisitor final : public VNVisitor {
-    std::unordered_set<AstNode*> m_removeSet;  // placeholders to be removed
-public:
-    explicit RemovePlaceholdersVisitor(AstNode* nodep) {
-        iterate(nodep);
-        for (AstNode* np : m_removeSet) {
-            np->unlinkFrBack();  // Without next
-            VL_DO_DANGLING(np->deleteTree(), np);
+    // MEMBERS
+    int m_emptyAlways{0};
+
+    // CONSTRUCTORS
+    RemovePlaceholdersVisitor() = default;
+    virtual ~RemovePlaceholdersVisitor() override = default;
+
+    // VISITORS
+    virtual void visit(AstSplitPlaceholder* nodep) override { pushDeletep(nodep->unlinkFrBack()); }
+    virtual void visit(AstNodeIf* nodep) override {
+        iterateChildren(nodep);
+        if (!nodep->ifsp() && !nodep->elsesp()) { pushDeletep(nodep->unlinkFrBack()); }
+    }
+    virtual void visit(AstAlways* nodep) override {
+        iterateChildren(nodep);
+        if (!nodep->bodysp()) {
+            pushDeletep(nodep->unlinkFrBack());
+            ++m_emptyAlways;
         }
     }
-    virtual ~RemovePlaceholdersVisitor() override = default;
-    virtual void visit(AstSplitPlaceholder* nodep) override { m_removeSet.insert(nodep); }
     virtual void visit(AstNode* nodep) override { iterateChildren(nodep); }
 
-private:
     VL_UNCOPYABLE(RemovePlaceholdersVisitor);
+
+public:
+    static int exec(AstNode* nodep) {
+        RemovePlaceholdersVisitor visitor;
+        visitor.iterate(nodep);
+        return visitor.m_emptyAlways;
+    }
 };
 
 class SplitVisitor final : public SplitReorderBaseVisitor {
@@ -832,7 +847,8 @@ public:
             for (AlwaysVec::iterator addme = it->second.begin(); addme != it->second.end();
                  ++addme) {
                 origp->addNextHere(*addme);
-                RemovePlaceholdersVisitor{*addme};
+                const int numRemoved = RemovePlaceholdersVisitor::exec(*addme);
+                m_statSplits -= numRemoved;
             }
             origp->unlinkFrBack();  // Without next
             VL_DO_DANGLING(origp->deleteTree(), origp);
@@ -944,7 +960,7 @@ protected:
             // Counting original always blocks rather than newly-split
             // always blocks makes it a little easier to use this stat to
             // check the result of the t_alw_split test:
-            ++m_statSplits;
+            m_statSplits += ifColor.colors().size() - 1;  // -1 for the original always
 
             // Visit through the original always block one more time,
             // and emit the split always blocks into m_replaceBlocks:

--- a/test_regress/t/t_alw_nosplit.v
+++ b/test_regress/t/t_alw_nosplit.v
@@ -47,12 +47,6 @@ module t (/*AUTOARG*/
       f_split_1 = m_din;
    end
 
-   reg [15:0] l_split_1, l_split_2;
-   always @ (posedge clk) begin
-      l_split_2 <= l_split_1;
-      l_split_1 <= l_split_2 | m_din;
-   end
-
    reg [15:0] z_split_1, z_split_2;
    always @ (posedge clk) begin
       z_split_1 <= 0;

--- a/test_regress/t/t_alw_nosplit.v
+++ b/test_regress/t/t_alw_nosplit.v
@@ -47,6 +47,22 @@ module t (/*AUTOARG*/
       f_split_1 = m_din;
    end
 
+   function logic[15:0]  sideeffect_func(logic [15:0] v);
+      /*verilator no_inline_task */
+      $display(" sideeffect_func() is called %t", $time);
+      return ~v;
+   endfunction
+   reg [15:0] m_split_1 = 0;
+   reg [15:0] m_split_2 = 0;
+   always @(posedge clk) begin
+      if (sideeffect_func(m_split_1) != 16'b0) begin
+         m_split_1 <= m_din;
+      end else begin
+         m_split_2 <= m_din;
+      end
+  end
+
+
    reg [15:0] z_split_1, z_split_2;
    always @ (posedge clk) begin
       z_split_1 <= 0;
@@ -98,6 +114,7 @@ module t (/*AUTOARG*/
          if (!(c_split_1==16'h0112 && c_split_2==16'hfeed)) $stop;
          if (!(e_split_1==16'hfeed && e_split_2==16'hfeed)) $stop;
          if (!(f_split_1==16'hfeed && f_split_2==16'hfeed)) $stop;
+         if (!(m_split_1==16'hfeed && m_split_2==16'h0000)) $stop;
          if (!(z_split_1==16'h0112 && z_split_2==16'h0112)) $stop;
       end
       if (cyc==5) begin
@@ -107,6 +124,7 @@ module t (/*AUTOARG*/
          // Two valid orderings, as we don't know which posedge clk gets evaled first
          if (!(e_split_1==16'hfeed && e_split_2==16'hfeed) && !(e_split_1==16'he11e && e_split_2==16'he11e)) $stop;
          if (!(f_split_1==16'hfeed && f_split_2==16'hfeed) && !(f_split_1==16'he11e && f_split_2==16'hfeed)) $stop;
+         if (!(m_split_1==16'hfeed && m_split_2==16'h0000)) $stop;
          if (!(z_split_1==16'h0112 && z_split_2==16'h0112)) $stop;
       end
       if (cyc==6) begin
@@ -116,6 +134,7 @@ module t (/*AUTOARG*/
          // Two valid orderings, as we don't know which posedge clk gets evaled first
          if (!(e_split_1==16'he11e && e_split_2==16'he11e) && !(e_split_1==16'he22e && e_split_2==16'he22e)) $stop;
          if (!(f_split_1==16'he11e && f_split_2==16'hfeed) && !(f_split_1==16'he22e && f_split_2==16'he11e)) $stop;
+         if (!(m_split_1==16'he11e && m_split_2==16'h0000)) $stop;
          if (!(z_split_1==16'h1ee1 && z_split_2==16'h0112)) $stop;
       end
       if (cyc==7) begin

--- a/test_regress/t/t_alw_split.pl
+++ b/test_regress/t/t_alw_split.pl
@@ -15,7 +15,7 @@ compile(
     );
 
 if ($Self->{vlt_all}) {
-    file_grep($Self->{stats}, qr/Optimizations, Split always\s+(\d+)/i, 3);
+    file_grep($Self->{stats}, qr/Optimizations, Split always\s+(\d+)/i, 4);
 }
 
 execute(

--- a/test_regress/t/t_alw_split.v
+++ b/test_regress/t/t_alw_split.v
@@ -50,6 +50,12 @@ module t (/*AUTOARG*/
       end
    end
 
+   reg [15:0] l_split_1, l_split_2;
+   always @ (posedge clk) begin
+      l_split_2 <= l_split_1;
+      l_split_1 <= l_split_2 | m_din;
+   end
+
    // (The checker block is an exception, it won't split.)
    always @ (posedge clk) begin
       if (cyc!=0) begin

--- a/test_regress/t/t_alw_split_rst.pl
+++ b/test_regress/t/t_alw_split_rst.pl
@@ -16,7 +16,7 @@ compile(
     );
 
 if ($Self->{vlt_all}) {
-    file_grep($Self->{stats}, qr/Optimizations, Split always\s+(\d+)/i, 0);
+    file_grep($Self->{stats}, qr/Optimizations, Split always\s+(\d+)/i, 12);
 }
 
 execute(

--- a/test_regress/t/t_alw_splitord.pl
+++ b/test_regress/t/t_alw_splitord.pl
@@ -15,7 +15,7 @@ compile(
     );
 
 if ($Self->{vlt_all}) {
-    file_grep($Self->{stats}, qr/Optimizations, Split always\s+(\d+)/i, 0);
+    file_grep($Self->{stats}, qr/Optimizations, Split always\s+(\d+)/i, 5);
 }
 
 execute(


### PR DESCRIPTION
Factored out from #3317
The third item of https://github.com/verilator/verilator/pull/3317#issue-1148189875

Commits are cherry-picked from #3317 without any change.


Previously, Split always counted the number of always block that was going to be split.
e.g. `Split always` == 2 when V3Split split as below.
always_a -> always_b, always_c
always_d -> always_e, always_f, always_g
Note that sometimes `Split always` increments even if always_b is empty and removed later.

Now this PR counts the increased number of always.
In the example above, always block increased from 2 to 5, so `Split always` is 3.
If always block after split is empty, `Split always` does not increase by such empty block.
