### PR TITLE
Fix driver.pl when expected value is 0

### DIFF
--- a/test_regress/driver.pl
+++ b/test_regress/driver.pl
@@ -2434,7 +2434,7 @@ sub file_grep {
     return if ($contents eq "_Already_Errored_");
     if ($contents !~ /$regexp/) {
         $self->error("File_grep: $filename: Regexp not found: $regexp\n");
-    } elsif ($expvalue && $expvalue ne $1) {
+    } elsif (defined($expvalue) && $expvalue ne $1) {
         $self->error("File_grep: $filename: Got='$1' Expected='$expvalue' in regexp: $regexp\n");
     }
 }

--- a/test_regress/t/t_case_huge.pl
+++ b/test_regress/t/t_case_huge.pl
@@ -16,8 +16,7 @@ compile(
 
 if ($Self->{vlt_all}) {
     file_grep($Self->{stats}, qr/Optimizations, Tables created\s+(\d+)/i, 10);
-    file_grep($Self->{stats}, qr/Optimizations, Combined CFuncs\s+(\d+)/i,
-              ($Self->{vltmt} ? 0 : 8));
+    file_grep($Self->{stats}, qr/Optimizations, Combined CFuncs\s+(\d+)/i, 8);
 }
 
 execute(


### PR DESCRIPTION
Factored out from #3317 item 1
> file_grep() in driver.pl skipped checking if the expected value is 0. ( or anything evaluated false in perl such as "0" )

I will merge after CI passes.