### PR TITLE
Improve V3Split capability

### DIFF
--- a/src/V3Options.cpp
+++ b/src/V3Options.cpp
@@ -1163,7 +1163,7 @@ void V3Options::parseOptsList(FileLine* fl, const string& optdir, int argc, char
             case 'e': m_oCase = flag; break;
             //    f
             case 'g': m_oGate = flag; break;
-            //    h
+            case 'h': m_oSplitAlwComb = flag; break;
             case 'i': m_oInline = flag; break;
             //    j
             case 'k': m_oSubstConst = flag; break;
@@ -1787,6 +1787,7 @@ void V3Options::optimize(int level) {
     m_oReloop = flag;
     m_oReorder = flag;
     m_oSplit = flag;
+    m_oSplitAlwComb = flag;
     m_oSubst = flag;
     m_oSubstConst = flag;
     m_oTable = flag;

--- a/src/V3Options.h
+++ b/src/V3Options.h
@@ -357,6 +357,7 @@ private:
     bool        m_oReloop;      // main switch: -Ov: reform loops
     bool        m_oReorder;     // main switch: -Or: reorder assignments in blocks
     bool        m_oSplit;       // main switch: -Os: always assignment splitting
+    bool        m_oSplitAlwComb;// main switch: -Oh: always_comb assignment splitting
     bool        m_oSubst;       // main switch: -Ou: substitute expression temp values
     bool        m_oSubstConst;  // main switch: -Ok: final constant substitution
     bool        m_oTable;       // main switch: -Oa: lookup table creation
@@ -586,6 +587,7 @@ public:
     bool oReloop() const { return m_oReloop; }
     bool oReorder() const { return m_oReorder; }
     bool oSplit() const { return m_oSplit; }
+    bool oSplitAlwComb() const { return m_oSplitAlwComb; }
     bool oSubst() const { return m_oSubst; }
     bool oSubstConst() const { return m_oSubstConst; }
     bool oTable() const { return m_oTable; }

--- a/src/V3Split.cpp
+++ b/src/V3Split.cpp
@@ -353,7 +353,7 @@ protected:
     // of what is before vs. after
 
     virtual void visit(AstActive* nodep) override {
-        VL_RESTORED(m_inCombo);
+        VL_RESTORER(m_inCombo);
         m_inCombo = true;
         for (const AstSenItem* itemp = nodep->sensesp()->sensesp(); itemp;
              itemp = VN_CAST(itemp->nextp(), SenItem)) {

--- a/src/V3Split.cpp
+++ b/src/V3Split.cpp
@@ -1027,7 +1027,7 @@ protected:
         // must be kept together.
         SplitEdge::incrementStep();
         pruneDepsOnInputs();
-        pruneDepsOnLastUpdatedSignalsInAlwaysComb();
+        if (v3Global.opt.oSplitAlwComb()) pruneDepsOnLastUpdatedSignalsInAlwaysComb();
 
         // For any 'if' node whose deps have all been pruned
         // (meaning, its conditional expression only looks at primary

--- a/test_regress/t/t_alw_nosplit.v
+++ b/test_regress/t/t_alw_nosplit.v
@@ -17,12 +17,6 @@ module t (/*AUTOARG*/
    // We expect none of these blocks to split.
    // Blocks that can split should go in t_alw_split.v instead.
 
-   reg [15:0] b_split_1, b_split_2;
-   always @ (/*AS*/m_din) begin
-      b_split_1 = m_din;
-      b_split_2 = b_split_1;
-   end
-
    reg [15:0] c_split_1, c_split_2;
    always @ (/*AS*/m_din) begin
       c_split_1 = m_din;
@@ -60,8 +54,7 @@ module t (/*AUTOARG*/
       end else begin
          m_split_2 <= m_din;
       end
-  end
-
+   end
 
    reg [15:0] z_split_1, z_split_2;
    always @ (posedge clk) begin
@@ -110,7 +103,6 @@ module t (/*AUTOARG*/
       end
       if (cyc==4) begin
          m_din <= 16'he11e;
-         if (!(b_split_1==16'hfeed && b_split_2==16'hfeed)) $stop;
          if (!(c_split_1==16'h0112 && c_split_2==16'hfeed)) $stop;
          if (!(e_split_1==16'hfeed && e_split_2==16'hfeed)) $stop;
          if (!(f_split_1==16'hfeed && f_split_2==16'hfeed)) $stop;
@@ -119,7 +111,6 @@ module t (/*AUTOARG*/
       end
       if (cyc==5) begin
          m_din <= 16'he22e;
-         if (!(b_split_1==16'he11e && b_split_2==16'he11e)) $stop;
          if (!(c_split_1==16'h1ee1 && c_split_2==16'he11e)) $stop;
          // Two valid orderings, as we don't know which posedge clk gets evaled first
          if (!(e_split_1==16'hfeed && e_split_2==16'hfeed) && !(e_split_1==16'he11e && e_split_2==16'he11e)) $stop;
@@ -129,7 +120,6 @@ module t (/*AUTOARG*/
       end
       if (cyc==6) begin
          m_din <= 16'he33e;
-         if (!(b_split_1==16'he22e && b_split_2==16'he22e)) $stop;
          if (!(c_split_1==16'h1dd1 && c_split_2==16'he22e)) $stop;
          // Two valid orderings, as we don't know which posedge clk gets evaled first
          if (!(e_split_1==16'he11e && e_split_2==16'he11e) && !(e_split_1==16'he22e && e_split_2==16'he22e)) $stop;

--- a/test_regress/t/t_alw_split.pl
+++ b/test_regress/t/t_alw_split.pl
@@ -15,7 +15,7 @@ compile(
     );
 
 if ($Self->{vlt_all}) {
-    file_grep($Self->{stats}, qr/Optimizations, Split always\s+(\d+)/i, 4);
+    file_grep($Self->{stats}, qr/Optimizations, Split always\s+(\d+)/i, 5);
 }
 
 execute(

--- a/test_regress/t/t_alw_split.v
+++ b/test_regress/t/t_alw_split.v
@@ -23,6 +23,12 @@ module t (/*AUTOARG*/
       a_split_2 = m_din;
    end
 
+   reg [15:0] b_split_1, b_split_2;
+   always @ (/*AS*/m_din) begin
+      b_split_1 = m_din;
+      b_split_2 = b_split_1;
+   end
+
    reg [15:0] d_split_1, d_split_2;
    always @ (posedge clk) begin
       d_split_1 <= m_din;
@@ -69,18 +75,21 @@ module t (/*AUTOARG*/
 	    m_din <= 16'he11e;
 	    //$write(" A %x %x\n", a_split_1, a_split_2);
 	    if (!(a_split_1==16'hfeed && a_split_2==16'hfeed)) $stop;
+         if (!(b_split_1==16'hfeed && b_split_2==16'hfeed)) $stop;
 	    if (!(d_split_1==16'h0112 && d_split_2==16'h0112)) $stop;
             if (!(h_split_1==16'hfeed && h_split_2==16'h0112)) $stop;
 	 end
 	 if (cyc==5) begin
 	    m_din <= 16'he22e;
 	    if (!(a_split_1==16'he11e && a_split_2==16'he11e)) $stop;
+        if (!(b_split_1==16'he11e && b_split_2==16'he11e)) $stop;
 	    if (!(d_split_1==16'h0112 && d_split_2==16'h0112)) $stop;
             if (!(h_split_1==16'hfeed && h_split_2==16'h0112)) $stop;
 	 end
 	 if (cyc==6) begin
 	    m_din <= 16'he33e;
 	    if (!(a_split_1==16'he22e && a_split_2==16'he22e)) $stop;
+         if (!(b_split_1==16'he22e && b_split_2==16'he22e)) $stop;
 	    if (!(d_split_1==16'h1ee1 && d_split_2==16'h0112)) $stop;
             if (!(h_split_1==16'he11e && h_split_2==16'h1ee1)) $stop;
 	 end


### PR DESCRIPTION
This PR resolves UNOPTFLAT in #2969 without any HDL change.

Current V3Split can split if all RHS of always_comb is set outside of the always block.
I think this can be relaxed to 
- All RHS must be set before it is referred

e.g.
```systemverilog
always_comb begin
  sig_a = in0 & in1;
  sig_b = ~sig_a;
end
```
can be safely split to
```systemverilog
always_comb sig_a = in0 & in1;
always_comb sig_b = ~sig_a;
```

But
```systemverilog
always_comb begin
  sig_a = in0 & in1;
  sig_b = ~sig_a;
  sig_a = in0;
end
```
cannot be split.


I thought ff3996b65459158122463ce0c6b2a6aced2ae1b4 can handle most of cases if a variable is written only in one always block, but this assumption is not necessarily satisfied as in t_order_comboclkloop test https://github.com/verilator/verilator/blob/e29132377ecf3d6fdaa093f547ea8b63ae751f94/test_regress/t/t_order_comboclkloop.v#L28-L43

e1430abbdb3b2930d7b8ecaaebb23c859d9eaefb checks if a variable is written only in the always block.
This PR passes ext tests.