### PR TITLE
Fix Logic error on V3Partition

### DIFF
--- a/src/V3Partition.cpp
+++ b/src/V3Partition.cpp
@@ -1847,7 +1847,7 @@ private:
         }
         // Find all reader tasks for this variable, group by rank.
         for (V3GraphEdge* edgep = (*ovvIt)->outBeginp(); edgep; edgep = edgep->outNextp()) {
-            const OrderLogicVertex* const logicp = dynamic_cast<OrderLogicVertex*>(edgep->fromp());
+            const OrderLogicVertex* const logicp = dynamic_cast<OrderLogicVertex*>(edgep->top());
             if (!logicp) continue;
             if (logicp->domainp()->hasInitial() || logicp->domainp()->hasSettle()) continue;
             LogicMTask* const readerMtaskp = m_olv2mtask.at(logicp);


### PR DESCRIPTION
Fix logic error on V3Partition
enumerate out edges should use `top`, not `fromp`.
Contribute by [Shunyao CAD]

#3359 

Signed-off-by: HungMingWu <u9089000@gmail.com>


