### PR TITLE
Fix null pointer access on debugi larger than 8

### DIFF
--- a/src/V3Param.cpp
+++ b/src/V3Param.cpp
@@ -781,7 +781,7 @@ public:
         bool any_overrides = false;
         // Must always clone __Vrcm (recursive modules)
         if (nodep->recursive()) any_overrides = true;
-        if (debug() > 8) nodep->paramsp()->dumpTreeAndNext(cout, "-cellparams: ");
+        if (debug() > 8 && nodep->paramsp()) nodep->paramsp()->dumpTreeAndNext(cout, "-cellparams: ");
 
         if (srcModp->hierBlock()) {
             longname = parameterizedHierBlockName(srcModp, nodep->paramsp());


### PR DESCRIPTION
Fix null pointer access on debugi larger than 8 at V3Param.cpp
Contributed by [Shunyao CAD]

#3380 
Signed-off-by: HungMingWu <u9089000@gmail.com>