### PR TITLE
Update verilator-config.cmake.in

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -69,6 +69,7 @@ Markus Krause
 Marlon James
 Marshal Qiao
 Martin Schmidt
+Martin Stadler
 Matthew Ballance
 Michael Killough
 Michaël Lefebvre

--- a/verilator-config.cmake.in
+++ b/verilator-config.cmake.in
@@ -334,8 +334,13 @@ function(verilate TARGET)
 
   target_link_libraries(${TARGET} PUBLIC
     ${${VERILATE_PREFIX}_USER_LDLIBS}
-    "$<$<BOOL:$<TARGET_PROPERTY:VERILATOR_THREADED>>:${VERILATOR_MT_CFLAGS}>"
   )
+
+  if (${VERILATE_PREFIX}_THREADS OR ${VERILATE_PREFIX}_TRACE_THREADS)
+    target_link_libraries(${TARGET} PUBLIC
+      ${VERILATOR_MT_CFLAGS}
+    )
+  endif()
 
   target_compile_features(${TARGET} PRIVATE cxx_std_11)
 endfunction()


### PR DESCRIPTION
Add linker flags to `TARGET` instead of using generator expression to support linking `TARGET` to higher-level targets in a top-level CMakeLists.txt file.

Fixes #3377
