### PR TITLE
Added missing #include <memory>

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -7,6 +7,7 @@ Adrien Le Masle
 Ahmed El-Mahmoudy
 Alex Chadwick
 Àlex Torregrosa
+Aliaksei Chapyzhenka
 Ameya Vikram Singh
 Andreas Kuster
 Chris Randall

--- a/src/V3Const.cpp
+++ b/src/V3Const.cpp
@@ -34,6 +34,7 @@
 
 #include <algorithm>
 #include <type_traits>
+#include <memory>
 
 //######################################################################
 // Utilities

--- a/src/V3Const.cpp
+++ b/src/V3Const.cpp
@@ -33,8 +33,8 @@
 #include "V3UniqueNames.h"
 
 #include <algorithm>
-#include <type_traits>
 #include <memory>
+#include <type_traits>
 
 //######################################################################
 // Utilities


### PR DESCRIPTION
Added missing `#include <memory>`

Fixes: https://github.com/verilator/verilator/issues/3390
