### PR TITLE
fix hanging in XMR

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -112,6 +112,7 @@ Veripool API Bot
 Victor Besyakov
 Wilson Snyder
 Xi Zhang
+Yoda Lee
 Yossi Nivin
 Yuri Victorovich
 Yutetsu TAKATSUKASA

--- a/src/V3LinkDot.cpp
+++ b/src/V3LinkDot.cpp
@@ -675,13 +675,14 @@ public:
                      << ((lookupSymp->symPrefix() == "") ? "" : " as ")
                      << ((lookupSymp->symPrefix() == "") ? "" : lookupSymp->symPrefix() + dotname)
                      << "  at se" << lookupSymp << endl);
-        const string prefix = lookupSymp->symPrefix();
+        string prefix = lookupSymp->symPrefix();
         VSymEnt* foundp = nullptr;
         while (!foundp) {
             foundp = lookupSymp->findIdFallback(prefix + dotname);  // Might be nullptr
             if (prefix.empty()) break;
             const string nextPrefix = removeLastInlineScope(prefix);
             if (prefix == nextPrefix) break;
+            prefix = nextPrefix;
         }
         if (!foundp) baddot = dotname;
         return foundp;

--- a/test_regress/t/t_func_link.pl
+++ b/test_regress/t/t_func_link.pl
@@ -1,0 +1,21 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2012 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_func_link.v
+++ b/test_regress/t/t_func_link.v
@@ -1,0 +1,54 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2012 by Wilson Snyder.
+// SPDX-License-Identifier: CC0-1.0
+
+module Test(/*AUTOARG*/
+  // Outputs
+  out,
+  // Inputs
+  clk, in
+  );
+
+  // Replace this module with the device under test.
+  //
+  // Change the code in the t module to apply values to the inputs and
+  // merge the output values into the result vector.
+
+  input clk;
+  input [31:0] in;
+  output reg [31:0] out;
+  integer cyc = 0;
+
+  SubTest subtest(.out);
+
+  always @(posedge clk) begin
+`ifdef TEST_VERBOSE
+      $write("[%0t] cyc==%0d\n", $time, cyc);
+`endif
+    cyc <= cyc + 1;
+    if (cyc < 99) begin
+      subtest.block.set(in);
+    end
+    else begin
+      $write("[%0t] cyc==%0d\n", $time, cyc);
+      $write("*-* All Finished *-*\n");
+      $finish;
+    end
+  end
+endmodule
+
+module SubTest(
+  output logic[31:0] out
+);
+
+  if (1) begin : block
+
+  function void set(logic[31:0] in);
+    out <= in;
+  endfunction
+
+  end : block
+
+endmodule


### PR DESCRIPTION
#3391 
In findSymPrefixed, it will hang if findIdFallback cannot find the VSymEnt.
Since it does not update the prefix with the next prefix generated by
removeLastInlineScope.

We appreciate your contributing to Verilator.  If this is your first commit, please add your name to docs/CONTRIBUTORS, and read our contributing guidelines in docs/CONTRIBUTING.rst.
