### PR TITLE
foreach: fix segmentation fault when dtypep is nullptr

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -55,6 +55,7 @@ Josh Redford
 Julie Schwartz
 Julien Margetts
 Kaleb Barrett
+Kamil Rakoczy
 Kanad Kanhere
 Keith Colbert
 Kevin Kiningham

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -3794,8 +3794,9 @@ private:
         const AstSelLoopVars* const loopsp = VN_CAST(nodep->arrayp(), SelLoopVars);
         UASSERT_OBJ(loopsp, nodep, "No loop variables under foreach");
         // if (debug()) nodep->dumpTree(cout, "-foreach-old: ");
+        userIterateAndNext(loopsp->fromp(), WidthVP(SELF, BOTH).p());
         AstNode* const fromp = loopsp->fromp();
-        userIterateAndNext(fromp, WidthVP(SELF, BOTH).p());
+        UASSERT_OBJ(fromp->dtypep(), fromp, "Missing data type");
         AstNodeDType* fromDtp = fromp->dtypep()->skipRefp();
         // Split into for loop
         AstNode* bodyp = nodep->bodysp();  // Might be null

--- a/test_regress/t/t_foreach.v
+++ b/test_regress/t/t_foreach.v
@@ -112,12 +112,10 @@ module t (/*AUTOARG*/);
       strarray[1].mid.subarray[1] = 5;
       strarray[2].mid.subarray[0] = 6;
       strarray[2].mid.subarray[1] = 7;
-`ifndef VERILATOR  // Unsupported
       foreach (strarray[s])
         foreach (strarray[s].mid.subarray[ss])
           add += strarray[s].mid.subarray[ss];
       `checkh(add, 'h19);
-`endif
 
       add = 0;
       foreach (oned[i]) begin


### PR DESCRIPTION
This PR fixes segmentation fault when dtypep is nullptr.

Up to now, we were saving ``fromp`` pointer before calling ``userIterateAndNext`` that could change this pointer.
Later we would use old ``fromp`` value resulting in segmentation fault.

This fixes foreach with hierarchical access, e.g.: ``strarray[s].mid.subarray[ss]``.