### PR TITLE
Fix UNOPTFLAT warning from initial static var

### DIFF
--- a/src/V3Order.cpp
+++ b/src/V3Order.cpp
@@ -1133,6 +1133,10 @@ class OrderProcess final : VNDeleter {
         return name;
     }
 
+    bool nodeIsInitial(const OrderLogicVertex* LVtxp) {
+        return LVtxp && (VN_IS(LVtxp->nodep(), Initial) || VN_IS(LVtxp->nodep(), InitialStatic));
+    }
+
     void nodeMarkCircular(OrderVarVertex* vertexp, OrderEdge* edgep) {
         // To be marked circular requires being a clock assigned in a delayed assignment, or
         // having a cutable in or out edge, none of which is true for the DPI export trigger.
@@ -1146,8 +1150,7 @@ class OrderProcess final : VNDeleter {
             toLVtxp = dynamic_cast<OrderLogicVertex*>(edgep->top());
         }
         //
-        if ((fromLVtxp && VN_IS(fromLVtxp->nodep(), Initial))
-            || (toLVtxp && VN_IS(toLVtxp->nodep(), Initial))) {
+        if (nodeIsInitial(fromLVtxp) || nodeIsInitial(toLVtxp)) {
             // IEEE does not specify ordering between initial blocks, so we
             // can do whatever we want. We especially do not want to
             // evaluate multiple times, so do not mark the edge circular

--- a/test_regress/t/t_initialstatic_circ.pl
+++ b/test_regress/t/t_initialstatic_circ.pl
@@ -1,0 +1,21 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2022 by Antmicro Ltd. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_initialstatic_circ.v
+++ b/test_regress/t/t_initialstatic_circ.v
@@ -1,0 +1,31 @@
+// DESCRIPTION::Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2022 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+package pkg;
+  int unsigned id = 0;
+
+  function int unsigned func();
+    int unsigned local_id;
+    local_id  = id + 1;
+    id = local_id;
+    return local_id;
+  endfunction : func
+endpackage
+
+module t(/*AUTOARG*/
+  // Inputs
+  clk
+  );
+  input clk;
+  import pkg::*;
+  int unsigned func_id = func();
+
+  always @ (posedge clk) begin
+    $display(id);
+    $write("*-* All Finished *-*\n");
+    $finish;
+  end
+endmodule


### PR DESCRIPTION
This PR fixes UNOPTFLAT warning when variable is initialized on declaration instead of in initial block.

Signed-off-by: Kamil Rakoczy <krakoczy@antmicro.com>

