### PR TITLE
Rename AstTimingControl to AstEventControl

### DIFF
--- a/src/V3AstNodes.h
+++ b/src/V3AstNodes.h
@@ -5243,15 +5243,15 @@ public:
     }
 };
 
-class AstTimingControl final : public AstNodeStmt {
+class AstEventControl final : public AstNodeStmt {
     // Parents: stmtlist
 public:
-    AstTimingControl(FileLine* fl, AstSenTree* sensesp, AstNode* stmtsp)
-        : ASTGEN_SUPER_TimingControl(fl) {
+    AstEventControl(FileLine* fl, AstSenTree* sensesp, AstNode* stmtsp)
+        : ASTGEN_SUPER_EventControl(fl) {
         setNOp1p(sensesp);
         setNOp2p(stmtsp);
     }
-    ASTNODE_NODE_FUNCS(TimingControl)
+    ASTNODE_NODE_FUNCS(EventControl)
     virtual string verilogKwd() const override { return "@(%l) %r"; }
     virtual bool isGateOptimizable() const override { return false; }
     virtual bool isPredictOptimizable() const override { return false; }

--- a/src/V3LinkParse.cpp
+++ b/src/V3LinkParse.cpp
@@ -582,12 +582,12 @@ private:
         iterateChildren(nodep);
         nodep->timeunit(m_modp->timeunit());
     }
-    virtual void visit(AstTimingControl* nodep) override {
+    virtual void visit(AstEventControl* nodep) override {
         cleanFileline(nodep);
         iterateChildren(nodep);
         AstAlways* const alwaysp = VN_CAST(nodep->backp(), Always);
         if (alwaysp && alwaysp->keyword() == VAlwaysKwd::ALWAYS_COMB) {
-            alwaysp->v3error("Timing control statements not legal under always_comb "
+            alwaysp->v3error("Event control statements not legal under always_comb "
                              "(IEEE 1800-2017 9.2.2.2.2)\n"
                              << nodep->warnMore() << "... Suggest use a normal 'always'");
             VL_DO_DANGLING(nodep->unlinkFrBack()->deleteTree(), nodep);

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -1323,10 +1323,10 @@ private:
         nodep->replaceWith(newp);
         VL_DO_DANGLING(nodep->deleteTree(), nodep);
     }
-    virtual void visit(AstTimingControl* nodep) override {
-        nodep->v3warn(E_UNSUPPORTED, "Unsupported: timing control statement in this location\n"
+    virtual void visit(AstEventControl* nodep) override {
+        nodep->v3warn(E_UNSUPPORTED, "Unsupported: event control statement in this location\n"
                                          << nodep->warnMore()
-                                         << "... Suggest have one timing control statement "
+                                         << "... Suggest have one event control statement "
                                          << "per procedure, at the top of the procedure");
         VL_DO_DANGLING(nodep->unlinkFrBack()->deleteTree(), nodep);
     }

--- a/src/verilog.y
+++ b/src/verilog.y
@@ -3252,7 +3252,7 @@ statement_item<nodep>:          // IEEE: statement_item
         |       par_block                               { $$ = $1; }
         //                      // IEEE: procedural_timing_control_statement + procedural_timing_control
         |       delay_control stmtBlock                 { $$ = new AstDelay($1->fileline(), $1); $$->addNextNull($2); }
-        |       event_control stmtBlock                 { $$ = new AstTimingControl(FILELINE_OR_CRE($1), $1, $2); }
+        |       event_control stmtBlock                 { $$ = new AstEventControl(FILELINE_OR_CRE($1), $1, $2); }
         //UNSUP cycle_delay stmtBlock                   { UNSUP }
         //
         |       seq_block                               { $$ = $1; }

--- a/test_regress/t/t_event_control_unsup.out
+++ b/test_regress/t/t_event_control_unsup.out
@@ -1,12 +1,12 @@
-%Error-UNSUPPORTED: t/t_event_control_unsup.v:14:7: Unsupported: timing control statement in this location
+%Error-UNSUPPORTED: t/t_event_control_unsup.v:14:7: Unsupported: event control statement in this location
                                                   : ... In instance t
-                                                  : ... Suggest have one timing control statement per procedure, at the top of the procedure
+                                                  : ... Suggest have one event control statement per procedure, at the top of the procedure
    14 |       @(clk);
       |       ^
                     ... For error description see https://verilator.org/warn/UNSUPPORTED?v=latest
-%Error-UNSUPPORTED: t/t_event_control_unsup.v:16:7: Unsupported: timing control statement in this location
+%Error-UNSUPPORTED: t/t_event_control_unsup.v:16:7: Unsupported: event control statement in this location
                                                   : ... In instance t
-                                                  : ... Suggest have one timing control statement per procedure, at the top of the procedure
+                                                  : ... Suggest have one event control statement per procedure, at the top of the procedure
    16 |       @(clk);
       |       ^
 %Error: Exiting due to

--- a/test_regress/t/t_lint_comb_bad.out
+++ b/test_regress/t/t_lint_comb_bad.out
@@ -1,4 +1,4 @@
-%Error: t/t_lint_comb_bad.v:14:4: Timing control statements not legal under always_comb (IEEE 1800-2017 9.2.2.2.2)
+%Error: t/t_lint_comb_bad.v:14:4: Event control statements not legal under always_comb (IEEE 1800-2017 9.2.2.2.2)
                                 : ... Suggest use a normal 'always'
    14 |    always_comb @(*) begin
       |    ^~~~~~~~~~~


### PR DESCRIPTION
Renames `AstTimingControl` to `AstEventControl`, which is in line with IEEE 1800-2017 9.4.2.

This is a pre-PR to https://github.com/verilator/verilator/pull/3363.

Signed-off-by: Krzysztof Bieganski <kbieganski@antmicro.com>