### PR TITLE
Add functions for finding vars/var scopes in a tree

### DIFF
--- a/src/V3Active.cpp
+++ b/src/V3Active.cpp
@@ -563,8 +563,8 @@ private:
         visitAlways(nodep, nodep->sensesp(), VAlwaysKwd::ALWAYS);
     }
     virtual void visit(AstSenItem* nodep) override {
-        if (nodep->varrefp()) {
-            if (const AstBasicDType* const basicp = nodep->varrefp()->dtypep()->basicp()) {
+        if (auto* const varp = AstNode::findVarp(nodep->sensp())) {
+            if (const AstBasicDType* const basicp = varp->dtypep()->basicp()) {
                 if (basicp->isEventValue()) {
                     // Events need to be treated as active high so we only activate on event being
                     // 1
@@ -578,15 +578,15 @@ private:
             // Delete the sensitivity
             // We'll add it as a generic COMBO SenItem in a moment.
             VL_DO_DANGLING(nodep->unlinkFrBack()->deleteTree(), nodep);
-        } else if (nodep->varrefp()) {
+        } else if (auto* const varp = AstNode::findVarp(nodep->sensp())) {
             // V3LinkResolve should have cleaned most of these up
-            if (!nodep->varrefp()->width1()) {
+            if (!varp->width1()) {
                 nodep->v3warn(E_UNSUPPORTED,
                               "Unsupported: Non-single bit wide signal pos/negedge sensitivity: "
-                                  << nodep->varrefp()->prettyNameQ());
+                                  << varp->prettyNameQ());
             }
             m_itemSequent = true;
-            nodep->varrefp()->varp()->usedClock(true);
+            varp->usedClock(true);
         }
     }
 

--- a/src/V3Ast.cpp
+++ b/src/V3Ast.cpp
@@ -1241,6 +1241,42 @@ AstNodeDType* AstNode::findVoidDType() const {
     return v3Global.rootp()->typeTablep()->findVoidDType(fileline());
 }
 
+//======================================================================
+// Retrieval of var/var scope from reference if possible
+AstVar* AstNode::findVarp(AstNode* nodep) {
+    while (nodep && !VN_IS(nodep, Var)) {
+        if (auto* const memberSelp = VN_CAST(nodep, MemberSel)) {
+            nodep = memberSelp->fromp();
+        } else if (auto* const selp = VN_CAST(nodep, NodeSel)) {
+            nodep = selp->fromp();
+        } else if (auto* const preSelp = VN_CAST(nodep, NodePreSel)) {
+            nodep = preSelp->fromp();
+        } else if (auto* const varrefp = VN_CAST(nodep, NodeVarRef)) {
+            return varrefp->varp();
+        } else {
+            return nullptr;
+        }
+    }
+    return VN_CAST(nodep, Var);
+}
+
+AstVarScope* AstNode::findVarScopep(AstNode* nodep) {
+    while (nodep && !VN_IS(nodep, Var)) {
+        if (auto* const memberSelp = VN_CAST(nodep, MemberSel)) {
+            nodep = memberSelp->fromp();
+        } else if (auto* const selp = VN_CAST(nodep, NodeSel)) {
+            nodep = selp->fromp();
+        } else if (auto* const preSelp = VN_CAST(nodep, NodePreSel)) {
+            nodep = preSelp->fromp();
+        } else if (auto* const varrefp = VN_CAST(nodep, NodeVarRef)) {
+            return varrefp->varScopep();
+        } else {
+            return nullptr;
+        }
+    }
+    return VN_CAST(nodep, VarScope);
+}
+
 //######################################################################
 // VNDeleter
 

--- a/src/V3Ast.h
+++ b/src/V3Ast.h
@@ -1735,6 +1735,9 @@ public:
     AstNodeDType* findBasicDType(VBasicDTypeKwd kwd) const;
     static AstBasicDType* findInsertSameDType(AstBasicDType* nodep);
 
+    static AstVar* findVarp(AstNode* nodep);
+    static AstVarScope* findVarScopep(AstNode* nodep);
+
     // METHODS - dump and error
     void v3errorEnd(std::ostringstream& str) const;
     void v3errorEndFatal(std::ostringstream& str) const VL_ATTR_NORETURN;

--- a/src/V3AstNodes.h
+++ b/src/V3AstNodes.h
@@ -3313,7 +3313,7 @@ public:
 
 class AstSenItem final : public AstNode {
     // Parents:  SENTREE
-    // Children: (optional) VARREF
+    // Children: (optional) NODE
 private:
     VEdgeType m_edgeType;  // Edge type
 public:
@@ -3322,10 +3322,10 @@ public:
     class Initial {};  // for creator type-overload selection
     class Settle {};  // for creator type-overload selection
     class Never {};  // for creator type-overload selection
-    AstSenItem(FileLine* fl, VEdgeType edgeType, AstNode* varrefp)
+    AstSenItem(FileLine* fl, VEdgeType edgeType, AstNode* nodep)
         : ASTGEN_SUPER_SenItem(fl)
         , m_edgeType{edgeType} {
-        setOp1p(varrefp);
+        setOp1p(nodep);
     }
     AstSenItem(FileLine* fl, Combo)
         : ASTGEN_SUPER_SenItem(fl)
@@ -3353,10 +3353,6 @@ public:
         editCountInc();
     }  // * = Posedge/negedge
     AstNode* sensp() const { return op1p(); }  // op1 = Signal sensitized
-    AstNodeVarRef* varrefp() const {
-        return VN_CAST(op1p(), NodeVarRef);
-    }  // op1 = Signal sensitized
-    //
     bool isClocked() const { return edgeType().clockedStmt(); }
     bool isCombo() const { return edgeType() == VEdgeType::ET_COMBO; }
     bool isInitial() const { return edgeType() == VEdgeType::ET_INITIAL; }

--- a/src/V3Clock.cpp
+++ b/src/V3Clock.cpp
@@ -135,29 +135,25 @@ private:
                           "Unsupported: Complicated event expression in sensitive activity list");
             return nullptr;
         }
-        UASSERT_OBJ(nodep->varrefp(), nodep, "No clock found on sense item");
-        AstVarScope* const clkvscp = nodep->varrefp()->varScopep();
+        AstVarScope* const clkvscp = AstNode::findVarScopep(nodep->sensp());
+        UASSERT_OBJ(clkvscp, nodep, "No clock found on sense item");
         if (nodep->edgeType() == VEdgeType::ET_POSEDGE) {
             AstVarScope* const lastVscp = getCreateLastClk(clkvscp);
             newp = new AstAnd(
-                nodep->fileline(),
-                new AstVarRef(nodep->fileline(), nodep->varrefp()->varScopep(), VAccess::READ),
+                nodep->fileline(), new AstVarRef(nodep->fileline(), clkvscp, VAccess::READ),
                 new AstNot(nodep->fileline(),
                            new AstVarRef(nodep->fileline(), lastVscp, VAccess::READ)));
         } else if (nodep->edgeType() == VEdgeType::ET_NEGEDGE) {
             AstVarScope* const lastVscp = getCreateLastClk(clkvscp);
-            newp = new AstAnd(
-                nodep->fileline(),
-                new AstNot(nodep->fileline(),
-                           new AstVarRef(nodep->fileline(), nodep->varrefp()->varScopep(),
-                                         VAccess::READ)),
-                new AstVarRef(nodep->fileline(), lastVscp, VAccess::READ));
+            newp = new AstAnd(nodep->fileline(),
+                              new AstNot(nodep->fileline(),
+                                         new AstVarRef(nodep->fileline(), clkvscp, VAccess::READ)),
+                              new AstVarRef(nodep->fileline(), lastVscp, VAccess::READ));
         } else if (nodep->edgeType() == VEdgeType::ET_BOTHEDGE) {
             AstVarScope* const lastVscp = getCreateLastClk(clkvscp);
-            newp = new AstXor(
-                nodep->fileline(),
-                new AstVarRef(nodep->fileline(), nodep->varrefp()->varScopep(), VAccess::READ),
-                new AstVarRef(nodep->fileline(), lastVscp, VAccess::READ));
+            newp = new AstXor(nodep->fileline(),
+                              new AstVarRef(nodep->fileline(), clkvscp, VAccess::READ),
+                              new AstVarRef(nodep->fileline(), lastVscp, VAccess::READ));
         } else if (nodep->edgeType() == VEdgeType::ET_HIGHEDGE) {
             newp = new AstVarRef(nodep->fileline(), clkvscp, VAccess::READ);
         } else if (nodep->edgeType() == VEdgeType::ET_LOWEDGE) {

--- a/src/V3Order.cpp
+++ b/src/V3Order.cpp
@@ -138,13 +138,13 @@ static bool domainsExclusive(const AstSenTree* fromp, const AstSenTree* top) {
     if (fromSenListp->nextp()) return false;
     if (toSenListp->nextp()) return false;
 
-    const AstNodeVarRef* const fromVarrefp = fromSenListp->varrefp();
-    const AstNodeVarRef* const toVarrefp = toSenListp->varrefp();
-    if (!fromVarrefp || !toVarrefp) return false;
+    const auto* const fromVarscopep = AstNode::findVarScopep(fromSenListp->sensp());
+    const auto* const toVarscopep = AstNode::findVarScopep(toSenListp->sensp());
+    if (!fromVarscopep || !toVarscopep) return false;
 
     // We know nothing about the relationship between different clocks here,
     // so give up on proving anything.
-    if (fromVarrefp->varScopep() != toVarrefp->varScopep()) return false;
+    if (fromVarscopep != toVarscopep) return false;
 
     return fromSenListp->edgeType().exclusiveEdge(toSenListp->edgeType());
 }


### PR DESCRIPTION
Adds two functions, `AstNode::findVarp` and `AstNode::findVarScopep`. These functions retrieve a variable/var scope from reference-ish nodes, such as `AstVarRef` and various selects. In this PR they replace `AstSenItem`'s `varrefp()` (this also allows for selects in sen items). https://github.com/verilator/verilator/pull/3363 uses these functions in different contexts as well.

This is a pre-PR to https://github.com/verilator/verilator/pull/3363.

Signed-off-by: Krzysztof Bieganski <kbieganski@antmicro.com>