### PR TITLE
Better grep check in t_foreach

### DIFF
--- a/test_regress/t/t_foreach.pl
+++ b/test_regress/t/t_foreach.pl
@@ -28,7 +28,7 @@ for my $file (glob_all("$Self->{obj_dir}/$Self->{VM_PREFIX}*.cpp")) {
 # have been evaluated inside the compiler. So there should be
 # no references to 'sum' in the .cpp.
 for my $file (glob_all("$Self->{obj_dir}/$Self->{VM_PREFIX}*.cpp")) {
-    file_grep_not($file, qr/sum/);
+    file_grep_not($file, qr/[^a-zA-Z]sum[^a-zA-Z]/);
 }
 
 ok(1);


### PR DESCRIPTION
Prevents false positives in `t_foreach` if there's a variable/function that has `sum` as part of its name.

This is a pre-PR to #3363.

Signed-off-by: Krzysztof Bieganski <kbieganski@antmicro.com>