### PR TITLE
Perform VCD tracing in parallel when using --threads

### DIFF
--- a/Changes
+++ b/Changes
@@ -11,6 +11,10 @@ contributors that suggested a given feature are shown in []. Thanks!
 Verilator 4.223 devel
 ==========================
 
+**Major:**
+
+* VCD tracing is now parallelized with --threads (#3449). [Geza Lore, Shunyao CAD]
+
 **Minor:**
 
 * Support compile time trace signal selection with tracing_on/off (#3323). [Shunyao CAD]

--- a/bin/verilator
+++ b/bin/verilator
@@ -405,7 +405,7 @@ detailed descriptions of these arguments.
     --trace-max-width <width>   Maximum array depth for tracing
     --trace-params              Enable tracing of parameters
     --trace-structs             Enable tracing structure names
-    --trace-threads <threads>   Enable waveform creation on separate threads
+    --trace-threads <threads>   Enable FST waveform creation on separate threads
     --trace-underscore          Enable tracing of _signals
      -U<var>                    Undefine preprocessor define
     --unroll-count <loops>      Tune maximum loop iterations

--- a/docs/guide/exe_verilator.rst
+++ b/docs/guide/exe_verilator.rst
@@ -1041,7 +1041,8 @@ Summary:
    is not thread safe. With "--threads 1", the generated model is single
    threaded but may run in a multithreaded environment. With "--threads N",
    where N >= 2, the model is generated to run multithreaded on up to N
-   threads. See :ref:`Multithreading`.
+   threads. See :ref:`Multithreading`. This option also applies to
+   :vlopt:`--trace` (but not :vlopt:`--trace-fst`).
 
 .. option:: --threads-dpi all
 
@@ -1119,7 +1120,8 @@ Summary:
    Having tracing compiled in may result in some small performance losses,
    even when tracing is not turned on during model execution.
 
-   See also :vlopt:`--trace-threads` option.
+   When using :vlopt:`--threads`, VCD tracing is parallelized, using the
+   same number of threads as passed to :vlopt:`--threads`.
 
 .. option:: --trace-coverage
 
@@ -1173,12 +1175,12 @@ Summary:
 .. option:: --trace-threads *threads*
 
    Enable waveform tracing using separate threads. This is typically faster
-   in simulation runtime but uses more total compute. This option is
-   independent of, and works with, both :vlopt:`--trace` and
-   :vlopt:`--trace-fst`.  Different trace formats can take advantage of
-   more trace threads to varying degrees. Currently VCD tracing can utilize
-   at most "--trace-threads 1", and FST tracing can utilize at most
-   "--trace-threads 2". This overrides :vlopt:`--no-threads` .
+   in simulation runtime but uses more total compute. This option only
+   applies to :vlopt:`--trace-fst`. FST tracing can utilize at most
+   "--trace-threads 2". This overrides :vlopt:`--no-threads`.
+
+   This option is accepted, but has absolutely no effect with
+   :vlopt:`--trace`, which respects :vlopt:`--threads` instead.
 
 .. option:: --trace-underscore
 

--- a/docs/guide/verilating.rst
+++ b/docs/guide/verilating.rst
@@ -221,9 +221,13 @@ model, it may be beneficial to performance to adjust the
 influences the partitioning of the model by adjusting the assumed execution
 time of DPI imports.
 
-The :vlopt:`--trace-threads` options can be used to produce trace dumps
-using multiple threads. If :vlopt:`--trace-threads` is set without
-:vlopt:`--threads`, then :vlopt:`--trace-threads` will imply
+When using :vlopt:`--trace` to perform VCD tracing, the VCD trace
+construction is parallelized using the same number of threads as specified
+with :vlopt:`--threads`, and is executed on the same thread pool as the model.
+
+The :vlopt:`--trace-threads` options can be used with :vlopt:`--trace-fst`
+to offload FST tracing using multiple threads. If :vlopt:`--trace-threads` is
+given without :vlopt:`--threads`, then :vlopt:`--trace-threads` will imply
 :vlopt:`--threads 1 <--threads>`, i.e.: the support libraries will be
 thread safe.
 
@@ -231,12 +235,12 @@ With :vlopt:`--trace-threads 0 <--trace-threads>`, trace dumps are produced
 on the main thread. This again gives the highest single thread performance.
 
 With :vlopt:`--trace-threads {N} <--trace-threads>`, where N is at least 1,
-N additional threads will be created and managed by the trace files (e.g.:
-VerilatedVcdC or VerilatedFstC), to generate the trace dump. The main
-thread will be released to proceed with execution as soon as possible,
-though some blocking of the main thread is still necessary while capturing
-the trace. Different trace formats can utilize a various number of
-threads. See the :vlopt:`--trace-threads` option.
+up to N additional threads will be created and managed by the trace files
+(e.g.: VerilatedFstC), to offload construction of the trace dump. The main
+thread will be released to proceed with execution as soon as possible, though
+some blocking of the main thread is still necessary while capturing the
+trace. FST tracing can utilize up to 2 offload threads, so there is no use
+of setting :vlopt:`--trace-threads` higher than 2 at the moment.
 
 When running a multithreaded model, the default Linux task scheduler often
 works against the model, by assuming threads are short lived, and thus
@@ -441,7 +445,7 @@ SystemC include directories and link to the SystemC libraries.
 
 .. describe:: TRACE_THREADS
 
-   Optional. Generated multi-threaded trace dumping, same as
+   Optional. Generated multi-threaded FST trace dumping, same as
    "--trace-threads".
 
 .. describe:: TOP_MODULE

--- a/include/verilated.h
+++ b/include/verilated.h
@@ -147,7 +147,7 @@ extern uint32_t VL_THREAD_ID() VL_MT_SAFE;
 
 #if VL_THREADED
 
-#define VL_LOCK_SPINS 50000  /// Number of times to spin for a mutex before relaxing
+#define VL_LOCK_SPINS 50000  /// Number of times to spin for a mutex before yielding
 
 /// Mutex, wrapped to allow -fthread_safety checks
 class VL_CAPABILITY("mutex") VerilatedMutex final {

--- a/include/verilated_fst_c.cpp
+++ b/include/verilated_fst_c.cpp
@@ -254,10 +254,12 @@ VerilatedFstBuffer* VerilatedFst::getTraceBuffer() { return new VerilatedFstBuff
 
 void VerilatedFst::commitTraceBuffer(VerilatedFstBuffer* bufp) {
 #ifdef VL_TRACE_OFFLOAD
-    m_offloadBufferWritep = bufp->m_offloadBufferWritep;
-#else
-    delete bufp;
+    if (bufp->m_offloadBufferWritep) {
+        m_offloadBufferWritep = bufp->m_offloadBufferWritep;
+        return;  // Buffer will be deleted by the offload thread
+    }
 #endif
+    delete bufp;
 }
 
 //=============================================================================

--- a/include/verilated_fst_c.h
+++ b/include/verilated_fst_c.h
@@ -113,12 +113,12 @@ public:
 
 #ifndef DOXYGEN
 // Declare specialization here as it's used in VerilatedFstC just below
-template <> void VerilatedFst::Super::dump(uint64_t);
-template <> void VerilatedFst::Super::set_time_unit(const char*);
-template <> void VerilatedFst::Super::set_time_unit(const std::string&);
-template <> void VerilatedFst::Super::set_time_resolution(const char*);
-template <> void VerilatedFst::Super::set_time_resolution(const std::string&);
-template <> void VerilatedFst::Super::dumpvars(int, const std::string&);
+template <> void VerilatedFst::Super::dump(uint64_t time);
+template <> void VerilatedFst::Super::set_time_unit(const char* unitp);
+template <> void VerilatedFst::Super::set_time_unit(const std::string& unit);
+template <> void VerilatedFst::Super::set_time_resolution(const char* unitp);
+template <> void VerilatedFst::Super::set_time_resolution(const std::string& unit);
+template <> void VerilatedFst::Super::dumpvars(int level, const std::string& hier);
 #endif
 
 //=============================================================================
@@ -136,23 +136,23 @@ class VerilatedFstBuffer final : public VerilatedTraceBuffer<VerilatedFst, Veril
     // String buffer long enough to hold maxBits() chars
     char* const m_strbuf = m_owner.m_strbuf;
 
+public:
     // CONSTRUCTOR
     explicit VerilatedFstBuffer(VerilatedFst& owner);
     ~VerilatedFstBuffer() = default;
 
-public:
     //=========================================================================
     // Implementation of VerilatedTraceBuffer interface
 
     // Implementations of duck-typed methods for VerilatedTraceBuffer. These are
     // called from only one place (the full* methods), so always inline them.
-    inline void emitBit(uint32_t code, CData newval);
-    inline void emitCData(uint32_t code, CData newval, int bits);
-    inline void emitSData(uint32_t code, SData newval, int bits);
-    inline void emitIData(uint32_t code, IData newval, int bits);
-    inline void emitQData(uint32_t code, QData newval, int bits);
-    inline void emitWData(uint32_t code, const WData* newvalp, int bits);
-    inline void emitDouble(uint32_t code, double newval);
+    VL_ATTR_ALWINLINE inline void emitBit(uint32_t code, CData newval);
+    VL_ATTR_ALWINLINE inline void emitCData(uint32_t code, CData newval, int bits);
+    VL_ATTR_ALWINLINE inline void emitSData(uint32_t code, SData newval, int bits);
+    VL_ATTR_ALWINLINE inline void emitIData(uint32_t code, IData newval, int bits);
+    VL_ATTR_ALWINLINE inline void emitQData(uint32_t code, QData newval, int bits);
+    VL_ATTR_ALWINLINE inline void emitWData(uint32_t code, const WData* newvalp, int bits);
+    VL_ATTR_ALWINLINE inline void emitDouble(uint32_t code, double newval);
 };
 
 //=============================================================================

--- a/include/verilated_fst_c.h
+++ b/include/verilated_fst_c.h
@@ -31,15 +31,19 @@
 #include <string>
 #include <vector>
 
+class VerilatedFstBuffer;
+
 //=============================================================================
 // VerilatedFst
 // Base class to create a Verilator FST dump
 // This is an internally used class - see VerilatedFstC for what to call from applications
 
-class VerilatedFst final : public VerilatedTrace<VerilatedFst> {
+class VerilatedFst final : public VerilatedTrace<VerilatedFst, VerilatedFstBuffer> {
+public:
+    using Super = VerilatedTrace<VerilatedFst, VerilatedFstBuffer>;
+
 private:
-    // Give the superclass access to private bits (to avoid virtual functions)
-    friend class VerilatedTrace<VerilatedFst>;
+    friend Buffer;  // Give the buffer access to the private bits
 
     //=========================================================================
     // FST specific internals
@@ -60,31 +64,26 @@ protected:
     //=========================================================================
     // Implementation of VerilatedTrace interface
 
-    // Implementations of protected virtual methods for VerilatedTrace
+    // Called when the trace moves forward to a new time point
     virtual void emitTimeChange(uint64_t timeui) override;
 
     // Hooks called from VerilatedTrace
     virtual bool preFullDump() override { return isOpen(); }
     virtual bool preChangeDump() override { return isOpen(); }
 
-    // Implementations of duck-typed methods for VerilatedTrace. These are
-    // called from only one place (namely full*) so always inline them.
-    inline void emitBit(uint32_t code, CData newval);
-    inline void emitCData(uint32_t code, CData newval, int bits);
-    inline void emitSData(uint32_t code, SData newval, int bits);
-    inline void emitIData(uint32_t code, IData newval, int bits);
-    inline void emitQData(uint32_t code, QData newval, int bits);
-    inline void emitWData(uint32_t code, const WData* newvalp, int bits);
-    inline void emitDouble(uint32_t code, double newval);
+    // Trace buffer management
+    virtual VerilatedFstBuffer* getTraceBuffer() override;
+    virtual void commitTraceBuffer(VerilatedFstBuffer*) override;
 
 public:
     //=========================================================================
     // External interface to client code
-    // (All must be threadsafe)
 
+    // CONSTRUCTOR
     explicit VerilatedFst(void* fst = nullptr);
     ~VerilatedFst();
 
+    // METHODS - All must be thread safe
     // Open the file; call isOpen() to see if errors
     void open(const char* filename) VL_MT_SAFE_EXCLUDES(m_mutex);
     // Close the file
@@ -97,11 +96,6 @@ public:
     //=========================================================================
     // Internal interface to Verilator generated code
 
-    // Inside dumping routines, declare a data type
-    void declDTypeEnum(int dtypenum, const char* name, uint32_t elements, unsigned int minValbits,
-                       const char** itemNamesp, const char** itemValuesp);
-
-    // Inside dumping routines, declare a signal
     void declBit(uint32_t code, const char* name, int dtypenum, fstVarDir vardir,
                  fstVarType vartype, bool array, int arraynum);
     void declBus(uint32_t code, const char* name, int dtypenum, fstVarDir vardir,
@@ -112,17 +106,54 @@ public:
                    fstVarType vartype, bool array, int arraynum, int msb, int lsb);
     void declDouble(uint32_t code, const char* name, int dtypenum, fstVarDir vardir,
                     fstVarType vartype, bool array, int arraynum);
+
+    void declDTypeEnum(int dtypenum, const char* name, uint32_t elements, unsigned int minValbits,
+                       const char** itemNamesp, const char** itemValuesp);
 };
 
 #ifndef DOXYGEN
 // Declare specialization here as it's used in VerilatedFstC just below
-template <> void VerilatedTrace<VerilatedFst>::dump(uint64_t timeui);
-template <> void VerilatedTrace<VerilatedFst>::set_time_unit(const char* unitp);
-template <> void VerilatedTrace<VerilatedFst>::set_time_unit(const std::string& unit);
-template <> void VerilatedTrace<VerilatedFst>::set_time_resolution(const char* unitp);
-template <> void VerilatedTrace<VerilatedFst>::set_time_resolution(const std::string& unit);
-template <> void VerilatedTrace<VerilatedFst>::dumpvars(int level, const std::string& hier);
+template <> void VerilatedFst::Super::dump(uint64_t);
+template <> void VerilatedFst::Super::set_time_unit(const char*);
+template <> void VerilatedFst::Super::set_time_unit(const std::string&);
+template <> void VerilatedFst::Super::set_time_resolution(const char*);
+template <> void VerilatedFst::Super::set_time_resolution(const std::string&);
+template <> void VerilatedFst::Super::dumpvars(int, const std::string&);
 #endif
+
+//=============================================================================
+// VerilatedFstBuffer
+
+class VerilatedFstBuffer final : public VerilatedTraceBuffer<VerilatedFst, VerilatedFstBuffer> {
+    // Give the trace file access to the private bits
+    friend VerilatedFst;
+    friend VerilatedFst::Super;
+
+    // The FST file handle
+    void* const m_fst = m_owner.m_fst;
+    // code to fstHande map, as an array
+    const fstHandle* const m_symbolp = m_owner.m_symbolp;
+    // String buffer long enough to hold maxBits() chars
+    char* const m_strbuf = m_owner.m_strbuf;
+
+    // CONSTRUCTOR
+    explicit VerilatedFstBuffer(VerilatedFst& owner);
+    ~VerilatedFstBuffer() = default;
+
+public:
+    //=========================================================================
+    // Implementation of VerilatedTraceBuffer interface
+
+    // Implementations of duck-typed methods for VerilatedTraceBuffer. These are
+    // called from only one place (the full* methods), so always inline them.
+    inline void emitBit(uint32_t code, CData newval);
+    inline void emitCData(uint32_t code, CData newval, int bits);
+    inline void emitSData(uint32_t code, SData newval, int bits);
+    inline void emitIData(uint32_t code, IData newval, int bits);
+    inline void emitQData(uint32_t code, QData newval, int bits);
+    inline void emitWData(uint32_t code, const WData* newvalp, int bits);
+    inline void emitDouble(uint32_t code, double newval);
+};
 
 //=============================================================================
 // VerilatedFstC

--- a/include/verilated_trace.h
+++ b/include/verilated_trace.h
@@ -35,6 +35,7 @@
 #include <bitset>
 #include <memory>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #ifdef VL_TRACE_OFFLOAD
@@ -44,6 +45,9 @@
 #endif
 
 // clang-format on
+
+class VlThreadPool;
+template <class T_Trace, class T_Buffer> class VerilatedTraceBuffer;
 
 #ifdef VL_TRACE_OFFLOAD
 //=============================================================================
@@ -107,7 +111,8 @@ public:
         CHG_WDATA = 0x6,
         CHG_DOUBLE = 0x8,
         // TODO: full..
-        TIME_CHANGE = 0xd,
+        TIME_CHANGE = 0xc,
+        TRACE_BUFFER = 0xd,
         END = 0xe,  // End of buffer
         SHUTDOWN = 0xf  // Shutdown worker thread, also marks end of buffer
     };
@@ -117,16 +122,22 @@ public:
 //=============================================================================
 // VerilatedTrace
 
-// VerilatedTrace uses F-bounded polymorphism to access duck-typed
-// implementations in the format specific derived class, which must be passed
-// as the type parameter T_Derived
-template <class T_Derived> class VerilatedTrace VL_NOT_FINAL {
+// T_Trace is the format specific subclass of VerilatedTrace.
+// T_Buffer is the format specific subclass of VerilatedTraceBuffer.
+template <class T_Trace, class T_Buffer> class VerilatedTrace VL_NOT_FINAL {
+    // Give the buffer (both base and derived) access to the private bits
+    friend VerilatedTraceBuffer<T_Trace, T_Buffer>;
+    friend T_Buffer;
+
 public:
+    using Buffer = T_Buffer;
+
     //=========================================================================
     // Generic tracing internals
 
-    using initCb_t = void (*)(void*, T_Derived*, uint32_t);  // Type of init callbacks
-    using dumpCb_t = void (*)(void*, T_Derived*);  // Type of all but init callbacks
+    using initCb_t = void (*)(void*, T_Trace*, uint32_t);  // Type of init callbacks
+    using dumpCb_t = void (*)(void*, Buffer*);  // Type of dump callbacks
+    using cleanupCb_t = void (*)(void*, T_Trace*);  // Type of cleanup callbacks
 
 private:
     struct CallbackRecord {
@@ -134,9 +145,10 @@ private:
         // (the one in Ubuntu 14.04 with GCC 4.8.4 in particular) use the
         // assignment operator on inserting into collections, so they don't work
         // with const fields...
-        union {
-            initCb_t m_initCb;  // The callback function
-            dumpCb_t m_dumpCb;  // The callback function
+        union {  // The callback
+            initCb_t m_initCb;
+            dumpCb_t m_dumpCb;
+            cleanupCb_t m_cleanupCb;
         };
         void* m_userp;  // The user pointer to pass to the callback (the symbol table)
         CallbackRecord(initCb_t cb, void* userp)
@@ -145,15 +157,22 @@ private:
         CallbackRecord(dumpCb_t cb, void* userp)
             : m_dumpCb{cb}
             , m_userp{userp} {}
+        CallbackRecord(cleanupCb_t cb, void* userp)
+            : m_cleanupCb{cb}
+            , m_userp{userp} {}
     };
 
-    uint32_t* m_sigs_oldvalp = nullptr;  // Old value store
+protected:
+    uint32_t* m_sigs_oldvalp = nullptr;  // Previous value store
     EData* m_sigs_enabledp = nullptr;  // Bit vector of enabled codes (nullptr = all on)
+private:
     uint64_t m_timeLastDump = 0;  // Last time we did a dump
     std::vector<bool> m_sigs_enabledVec;  // Staging for m_sigs_enabledp
-    std::vector<CallbackRecord> m_initCbs;  // Routines to initialize traciong
-    std::vector<CallbackRecord> m_fullCbs;  // Routines to perform full dump
-    std::vector<CallbackRecord> m_chgCbs;  // Routines to perform incremental dump
+    std::vector<CallbackRecord> m_initCbs;  // Routines to initialize tracing
+    // Routines to perform full dump
+    std::unordered_map<VlThreadPool*, std::vector<CallbackRecord>> m_fullCbs;
+    // Routines to perform incremental dump
+    std::unordered_map<VlThreadPool*, std::vector<CallbackRecord>> m_chgCbs;
     std::vector<CallbackRecord> m_cleanupCbs;  // Routines to call at the end of dump
     bool m_fullDump = true;  // Whether a full dump is required on the next call to 'dump'
     uint32_t m_nextCode = 0;  // Next code number to assign
@@ -168,9 +187,12 @@ private:
     void addCallbackRecord(std::vector<CallbackRecord>& cbVec, CallbackRecord& cbRec)
         VL_MT_SAFE_EXCLUDES(m_mutex);
 
-    // Equivalent to 'this' but is of the sub-type 'T_Derived*'. Use 'self()->'
+    // Equivalent to 'this' but is of the sub-type 'T_Trace*'. Use 'self()->'
     // to access duck-typed functions to avoid a virtual function call.
-    T_Derived* self() { return static_cast<T_Derived*>(this); }
+    T_Trace* self() { return static_cast<T_Trace*>(this); }
+
+    void
+    runParallelCallbacks(std::unordered_map<VlThreadPool*, std::vector<CallbackRecord>> cbMap);
 
     // Flush any remaining data for this file
     static void onFlush(void* selfp) VL_MT_UNSAFE_ONE;
@@ -186,10 +208,14 @@ private:
     VerilatedThreadQueue<uint32_t*> m_offloadBuffersToWorker;
     // Buffers returned from worker after processing
     VerilatedThreadQueue<uint32_t*> m_offloadBuffersFromWorker;
+
+protected:
     // Write pointer into current buffer
     uint32_t* m_offloadBufferWritep = nullptr;
     // End of offload buffer
     uint32_t* m_offloadBufferEndp = nullptr;
+
+private:
     // The offload worker thread itself
     std::unique_ptr<std::thread> m_workerThread;
 
@@ -251,6 +277,10 @@ protected:
     virtual bool preFullDump() = 0;
     virtual bool preChangeDump() = 0;
 
+    // Trace buffer management
+    virtual Buffer* getTraceBuffer() = 0;
+    virtual void commitTraceBuffer(Buffer*) = 0;
+
 public:
     //=========================================================================
     // External interface to client code
@@ -272,18 +302,54 @@ public:
     void dump(uint64_t timeui) VL_MT_SAFE_EXCLUDES(m_mutex);
 
     //=========================================================================
+    // Internal interface to Verilator generated code
+
+    //=========================================================================
     // Non-hot path internal interface to Verilator generated code
 
     void addInitCb(initCb_t cb, void* userp) VL_MT_SAFE;
-    void addFullCb(dumpCb_t cb, void* userp) VL_MT_SAFE;
-    void addChgCb(dumpCb_t cb, void* userp) VL_MT_SAFE;
-    void addCleanupCb(dumpCb_t cb, void* userp) VL_MT_SAFE;
+    void addFullCb(dumpCb_t cb, void* userp, VlThreadPool* = nullptr) VL_MT_SAFE;
+    void addChgCb(dumpCb_t cb, void* userp, VlThreadPool* = nullptr) VL_MT_SAFE;
+    void addCleanupCb(cleanupCb_t cb, void* userp) VL_MT_SAFE;
 
     void scopeEscape(char flag) { m_scopeEscape = flag; }
 
     void pushNamePrefix(const std::string&);
     void popNamePrefix(unsigned count = 1);
+};
 
+//=============================================================================
+// VerilatedTraceBuffer
+
+// T_Trace is the format specific subclass of VerilatedTrace.
+// T_Buffer is the format specific subclass of VerilatedTraceBuffer.
+// The format-specific hot-path methods use duck-typing via T_Buffer for performance.
+template <class T_Trace, class T_Buffer> class VerilatedTraceBuffer VL_NOT_FINAL {
+    friend T_Trace;  // Give the trace file access to the private bits
+
+protected:
+    T_Trace& m_owner;  // The VerilatedTrace subclass that owns this buffer
+
+    // Previous value store
+    uint32_t* const m_sigs_oldvalp = m_owner.m_sigs_oldvalp;
+    // Bit vector of enabled codes (nullptr = all on)
+    EData* const m_sigs_enabledp = m_owner.m_sigs_enabledp;
+
+#ifdef VL_TRACE_OFFLOAD
+    // Write pointer into current buffer
+    uint32_t* m_offloadBufferWritep = m_owner.m_offloadBufferWritep;
+    // End of offload buffer
+    uint32_t* const m_offloadBufferEndp = m_owner.m_offloadBufferEndp;
+#endif
+
+    // Equivalent to 'this' but is of the sub-type 'T_Derived*'. Use 'self()->'
+    // to access duck-typed functions to avoid a virtual function call.
+    inline T_Buffer* self() { return static_cast<T_Buffer*>(this); }
+
+    explicit VerilatedTraceBuffer(T_Trace& owner);
+    virtual ~VerilatedTraceBuffer() = default;
+
+public:
     //=========================================================================
     // Hot path internal interface to Verilator generated code
 
@@ -364,9 +430,13 @@ public:
         VL_DEBUG_IF(assert(m_offloadBufferWritep <= m_offloadBufferEndp););
     }
 
-#define CHG(name) chg##name##Impl
-#else
-#define CHG(name) chg##name
+#define chgBit chgBitImpl
+#define chgCData chgCDataImpl
+#define chgSData chgSDataImpl
+#define chgIData chgIDataImpl
+#define chgQData chgQDataImpl
+#define chgWData chgWDataImpl
+#define chgDouble chgDoubleImpl
 #endif
 
     // In non-offload mode, these are called directly by the trace callbacks,
@@ -374,27 +444,27 @@ public:
     // thread and are called chg*Impl
 
     // Check previous dumped value of signal. If changed, then emit trace entry
-    VL_ATTR_ALWINLINE inline void CHG(Bit)(uint32_t* oldp, CData newval) {
+    VL_ATTR_ALWINLINE inline void chgBit(uint32_t* oldp, CData newval) {
         const uint32_t diff = *oldp ^ newval;
         if (VL_UNLIKELY(diff)) fullBit(oldp, newval);
     }
-    VL_ATTR_ALWINLINE inline void CHG(CData)(uint32_t* oldp, CData newval, int bits) {
+    VL_ATTR_ALWINLINE inline void chgCData(uint32_t* oldp, CData newval, int bits) {
         const uint32_t diff = *oldp ^ newval;
         if (VL_UNLIKELY(diff)) fullCData(oldp, newval, bits);
     }
-    VL_ATTR_ALWINLINE inline void CHG(SData)(uint32_t* oldp, SData newval, int bits) {
+    VL_ATTR_ALWINLINE inline void chgSData(uint32_t* oldp, SData newval, int bits) {
         const uint32_t diff = *oldp ^ newval;
         if (VL_UNLIKELY(diff)) fullSData(oldp, newval, bits);
     }
-    VL_ATTR_ALWINLINE inline void CHG(IData)(uint32_t* oldp, IData newval, int bits) {
+    VL_ATTR_ALWINLINE inline void chgIData(uint32_t* oldp, IData newval, int bits) {
         const uint32_t diff = *oldp ^ newval;
         if (VL_UNLIKELY(diff)) fullIData(oldp, newval, bits);
     }
-    VL_ATTR_ALWINLINE inline void CHG(QData)(uint32_t* oldp, QData newval, int bits) {
+    VL_ATTR_ALWINLINE inline void chgQData(uint32_t* oldp, QData newval, int bits) {
         const uint64_t diff = *reinterpret_cast<QData*>(oldp) ^ newval;
         if (VL_UNLIKELY(diff)) fullQData(oldp, newval, bits);
     }
-    inline void CHG(WData)(uint32_t* oldp, const WData* newvalp, int bits) {
+    inline void chgWData(uint32_t* oldp, const WData* newvalp, int bits) {
         for (int i = 0; i < (bits + 31) / 32; ++i) {
             if (VL_UNLIKELY(oldp[i] ^ newvalp[i])) {
                 fullWData(oldp, newvalp, bits);
@@ -402,11 +472,20 @@ public:
             }
         }
     }
-    VL_ATTR_ALWINLINE inline void CHG(Double)(uint32_t* oldp, double newval) {
+    VL_ATTR_ALWINLINE inline void chgDouble(uint32_t* oldp, double newval) {
         // cppcheck-suppress invalidPointerCast
         if (VL_UNLIKELY(*reinterpret_cast<double*>(oldp) != newval)) fullDouble(oldp, newval);
     }
 
-#undef CHG
+#ifdef VL_TRACE_OFFLOAD
+#undef chgBit
+#undef chgCData
+#undef chgSData
+#undef chgIData
+#undef chgQData
+#undef chgWData
+#undef chgDouble
+#endif
 };
+
 #endif  // guard

--- a/include/verilated_trace.h
+++ b/include/verilated_trace.h
@@ -22,7 +22,8 @@
 #ifndef VERILATOR_VERILATED_TRACE_H_
 #define VERILATOR_VERILATED_TRACE_H_
 
-#ifdef VL_TRACE_THREADED
+// In FST mode, VL_TRACE_THREADED enables offloading
+#if defined(VL_TRACE_FST_WRITER_THREAD) && defined(VL_TRACE_THREADED)
 #define VL_TRACE_OFFLOAD
 #endif
 

--- a/include/verilated_vcd_c.cpp
+++ b/include/verilated_vcd_c.cpp
@@ -65,9 +65,11 @@ constexpr unsigned VL_TRACE_SUFFIX_ENTRY_SIZE = 8;  // Size of a suffix entry
 //=============================================================================
 // Specialization of the generics for this trace format
 
-#define VL_DERIVED_T VerilatedVcd
+#define VL_SUB_T VerilatedVcd
+#define VL_BUF_T VerilatedVcdBuffer
 #include "verilated_trace_imp.h"
-#undef VL_DERIVED_T
+#undef VL_SUB_T
+#undef VL_BUF_T
 
 //=============================================================================
 //=============================================================================
@@ -183,7 +185,7 @@ void VerilatedVcd::makeNameMap() {
     deleteNameMap();
     m_namemapp = new NameMap;
 
-    VerilatedTrace<VerilatedVcd>::traceInit();
+    Super::traceInit();
 
     // Though not speced, it's illegal to generate a vcd with signals
     // not under any module - it crashes at least two viewers.
@@ -224,7 +226,7 @@ void VerilatedVcd::closePrev() {
     // This function is on the flush() call path
     if (!isOpen()) return;
 
-    VerilatedTrace<VerilatedVcd>::flushBase();
+    Super::flushBase();
     bufferFlush();
     m_isOpen = false;
     m_filep->close();
@@ -251,14 +253,14 @@ void VerilatedVcd::close() VL_MT_SAFE_EXCLUDES(m_mutex) {
         printStr(" $end\n");
     }
     closePrev();
-    // closePrev() called VerilatedTrace<VerilatedVcd>::flush(), so we just
+    // closePrev() called Super::flush(), so we just
     // need to shut down the tracing thread here.
-    VerilatedTrace<VerilatedVcd>::closeBase();
+    Super::closeBase();
 }
 
 void VerilatedVcd::flush() VL_MT_SAFE_EXCLUDES(m_mutex) {
     const VerilatedLockGuard lock{m_mutex};
-    VerilatedTrace<VerilatedVcd>::flushBase();
+    Super::flushBase();
     bufferFlush();
 }
 
@@ -277,7 +279,7 @@ void VerilatedVcd::printQuad(uint64_t n) {
     printStr(buf);
 }
 
-void VerilatedVcd::bufferResize(uint64_t minsize) {
+void VerilatedVcd::bufferResize(size_t minsize) {
     // minsize is size of largest write.  We buffer at least 8 times as much data,
     // writing when we are 3/4 full (with thus 2*minsize remaining free)
     if (VL_UNLIKELY(minsize > m_wrChunkSize)) {
@@ -463,7 +465,7 @@ void VerilatedVcd::declare(uint32_t code, const char* name, const char* wirep, b
                            int arraynum, bool tri, bool bussed, int msb, int lsb) {
     const int bits = ((msb > lsb) ? (msb - lsb) : (lsb - msb)) + 1;
 
-    const bool enabled = VerilatedTrace<VerilatedVcd>::declCode(code, name, bits, tri);
+    const bool enabled = Super::declCode(code, name, bits, tri);
 
     if (m_suffixes.size() <= nextCode() * VL_TRACE_SUFFIX_ENTRY_SIZE) {
         m_suffixes.resize(nextCode() * VL_TRACE_SUFFIX_ENTRY_SIZE * 2, 0);
@@ -564,7 +566,24 @@ void VerilatedVcd::declDouble(uint32_t code, const char* name, bool array, int a
 }
 
 //=============================================================================
-// Trace rendering prinitives
+// Get/commit trace buffer
+
+VerilatedVcdBuffer* VerilatedVcd::getTraceBuffer() { return new VerilatedVcdBuffer{*this}; }
+
+void VerilatedVcd::commitTraceBuffer(VerilatedVcdBuffer* bufp) {
+    // Needs adjusting for emitTimeChange
+    m_writep = bufp->m_writep;
+    delete bufp;
+}
+
+//=============================================================================
+// VerilatedVcdBuffer implementation
+
+VerilatedVcdBuffer::VerilatedVcdBuffer(VerilatedVcd& owner)
+    : VerilatedTraceBuffer<VerilatedVcd, VerilatedVcdBuffer>{owner} {}
+
+//=============================================================================
+// Trace rendering primitives
 
 static inline void
 VerilatedVcdCCopyAndAppendNewLine(char* writep, const char* suffixp) VL_ATTR_NO_SANITIZE_ALIGN;
@@ -589,15 +608,22 @@ static inline void VerilatedVcdCCopyAndAppendNewLine(char* writep, const char* s
 #endif
 }
 
-void VerilatedVcd::finishLine(uint32_t code, char* writep) {
-    const char* const suffixp = m_suffixes.data() + code * VL_TRACE_SUFFIX_ENTRY_SIZE;
+void VerilatedVcdBuffer::finishLine(uint32_t code, char* writep) {
+    const char* const suffixp = m_suffixes + code * VL_TRACE_SUFFIX_ENTRY_SIZE;
     VL_DEBUG_IFDEF(assert(suffixp[0]););
     VerilatedVcdCCopyAndAppendNewLine(writep, suffixp);
 
     // Now write back the write pointer incremented by the actual size of the
     // suffix, which was stored in the last byte of the suffix buffer entry.
     m_writep = writep + suffixp[VL_TRACE_SUFFIX_ENTRY_SIZE - 1];
-    bufferCheck();
+
+    // Flush the write buffer if there's not enough space left for new information
+    // We only call this once per vector, so we need enough slop for a very wide "b###" line
+    if (VL_UNLIKELY(m_writep > m_wrFlushp)) {
+        m_owner.m_writep = m_writep;
+        m_owner.bufferFlush();
+        m_writep = m_owner.m_writep;
+    }
 }
 
 //=============================================================================
@@ -608,7 +634,7 @@ void VerilatedVcd::finishLine(uint32_t code, char* writep) {
 // so always inline them.
 
 VL_ATTR_ALWINLINE
-void VerilatedVcd::emitBit(uint32_t code, CData newval) {
+void VerilatedVcdBuffer::emitBit(uint32_t code, CData newval) {
     // Don't prefetch suffix as it's a bit too late;
     char* wp = m_writep;
     *wp++ = '0' | static_cast<char>(newval);
@@ -616,7 +642,7 @@ void VerilatedVcd::emitBit(uint32_t code, CData newval) {
 }
 
 VL_ATTR_ALWINLINE
-void VerilatedVcd::emitCData(uint32_t code, CData newval, int bits) {
+void VerilatedVcdBuffer::emitCData(uint32_t code, CData newval, int bits) {
     char* wp = m_writep;
     *wp++ = 'b';
     cvtCDataToStr(wp, newval << (VL_BYTESIZE - bits));
@@ -624,7 +650,7 @@ void VerilatedVcd::emitCData(uint32_t code, CData newval, int bits) {
 }
 
 VL_ATTR_ALWINLINE
-void VerilatedVcd::emitSData(uint32_t code, SData newval, int bits) {
+void VerilatedVcdBuffer::emitSData(uint32_t code, SData newval, int bits) {
     char* wp = m_writep;
     *wp++ = 'b';
     cvtSDataToStr(wp, newval << (VL_SHORTSIZE - bits));
@@ -632,7 +658,7 @@ void VerilatedVcd::emitSData(uint32_t code, SData newval, int bits) {
 }
 
 VL_ATTR_ALWINLINE
-void VerilatedVcd::emitIData(uint32_t code, IData newval, int bits) {
+void VerilatedVcdBuffer::emitIData(uint32_t code, IData newval, int bits) {
     char* wp = m_writep;
     *wp++ = 'b';
     cvtIDataToStr(wp, newval << (VL_IDATASIZE - bits));
@@ -640,7 +666,7 @@ void VerilatedVcd::emitIData(uint32_t code, IData newval, int bits) {
 }
 
 VL_ATTR_ALWINLINE
-void VerilatedVcd::emitQData(uint32_t code, QData newval, int bits) {
+void VerilatedVcdBuffer::emitQData(uint32_t code, QData newval, int bits) {
     char* wp = m_writep;
     *wp++ = 'b';
     cvtQDataToStr(wp, newval << (VL_QUADSIZE - bits));
@@ -648,7 +674,7 @@ void VerilatedVcd::emitQData(uint32_t code, QData newval, int bits) {
 }
 
 VL_ATTR_ALWINLINE
-void VerilatedVcd::emitWData(uint32_t code, const WData* newvalp, int bits) {
+void VerilatedVcdBuffer::emitWData(uint32_t code, const WData* newvalp, int bits) {
     int words = VL_WORDS_I(bits);
     char* wp = m_writep;
     *wp++ = 'b';
@@ -665,10 +691,10 @@ void VerilatedVcd::emitWData(uint32_t code, const WData* newvalp, int bits) {
 }
 
 VL_ATTR_ALWINLINE
-void VerilatedVcd::emitDouble(uint32_t code, double newval) {
+void VerilatedVcdBuffer::emitDouble(uint32_t code, double newval) {
     char* wp = m_writep;
     // Buffer can't overflow before VL_SNPRINTF; we sized during declaration
-    VL_SNPRINTF(wp, m_wrChunkSize, "r%.16g", newval);
+    VL_SNPRINTF(wp, m_maxSignalBytes, "r%.16g", newval);
     wp += std::strlen(wp);
     finishLine(code, wp);
 }

--- a/include/verilatedos.h
+++ b/include/verilatedos.h
@@ -40,6 +40,7 @@
 #ifdef __GNUC__
 # define VL_ATTR_ALIGNED(alignment) __attribute__((aligned(alignment)))
 # define VL_ATTR_ALWINLINE __attribute__((always_inline))
+# define VL_ATTR_NOINLINE __attribute__((noinline))
 # define VL_ATTR_COLD __attribute__((cold))
 # define VL_ATTR_HOT __attribute__((hot))
 # define VL_ATTR_NORETURN __attribute__((noreturn))
@@ -81,6 +82,9 @@
 #endif
 #ifndef VL_ATTR_ALWINLINE
 # define VL_ATTR_ALWINLINE  ///< Attribute to inline, even when not optimizing
+#endif
+#ifndef VL_ATTR_NOINLINE
+# define VL_ATTR_NOINLINE  ///< Attribute to never inline, even when optimizing
 #endif
 #ifndef VL_ATTR_COLD
 # define VL_ATTR_COLD  ///< Attribute that function is rarely executed

--- a/src/V3EmitCImp.cpp
+++ b/src/V3EmitCImp.cpp
@@ -751,20 +751,20 @@ class EmitCTrace final : EmitCFunc {
         const string func = nodep->full() ? "full" : "chg";
         bool emitWidth = true;
         if (nodep->dtypep()->basicp()->isDouble()) {
-            puts("tracep->" + func + "Double");
+            puts("bufp->" + func + "Double");
             emitWidth = false;
         } else if (nodep->isWide() || emitTraceIsScBv(nodep) || emitTraceIsScBigUint(nodep)) {
-            puts("tracep->" + func + "WData");
+            puts("bufp->" + func + "WData");
         } else if (nodep->isQuad()) {
-            puts("tracep->" + func + "QData");
+            puts("bufp->" + func + "QData");
         } else if (nodep->declp()->widthMin() > 16) {
-            puts("tracep->" + func + "IData");
+            puts("bufp->" + func + "IData");
         } else if (nodep->declp()->widthMin() > 8) {
-            puts("tracep->" + func + "SData");
+            puts("bufp->" + func + "SData");
         } else if (nodep->declp()->widthMin() > 1) {
-            puts("tracep->" + func + "CData");
+            puts("bufp->" + func + "CData");
         } else {
-            puts("tracep->" + func + "Bit");
+            puts("bufp->" + func + "Bit");
             emitWidth = false;
         }
 

--- a/src/V3EmitCImp.cpp
+++ b/src/V3EmitCImp.cpp
@@ -770,7 +770,7 @@ class EmitCTrace final : EmitCFunc {
 
         const uint32_t offset = (arrayindex < 0) ? 0 : (arrayindex * nodep->declp()->widthWords());
         const uint32_t code = nodep->declp()->code() + offset;
-        puts(v3Global.opt.useTraceOffloadThread() && !nodep->full() ? "(base+" : "(oldp+");
+        puts(v3Global.opt.useTraceOffload() && !nodep->full() ? "(base+" : "(oldp+");
         puts(cvtToStr(code - nodep->baseCode()));
         puts(",");
         emitTraceValue(nodep, arrayindex);

--- a/src/V3EmitCMake.cpp
+++ b/src/V3EmitCMake.cpp
@@ -115,7 +115,9 @@ class CMakeEmitter final {
         cmake_set_raw(*of, name + "_THREADS", cvtToStr(v3Global.opt.threads()));
         *of << "# Threaded tracing output mode?  0/1/N threads (from --trace-threads)\n";
         cmake_set_raw(*of, name + "_TRACE_THREADS",
-                      cvtToStr(v3Global.opt.useTraceOffloadThread()));
+                      cvtToStr(v3Global.opt.traceFormat().vcd()  ? v3Global.opt.traceThreads()
+                               : v3Global.opt.traceThreads() > 1 ? v3Global.opt.traceThreads() - 1
+                                                                 : 0));
         cmake_set_raw(*of, name + "_TRACE_FST_WRITER_THREAD",
                       v3Global.opt.traceThreads() && v3Global.opt.traceFormat().fst() ? "1" : "0");
         *of << "# Struct output mode?  0/1 (from --trace-structs)\n";

--- a/src/V3EmitCMake.cpp
+++ b/src/V3EmitCMake.cpp
@@ -113,11 +113,8 @@ class CMakeEmitter final {
         cmake_set_raw(*of, name + "_COVERAGE", v3Global.opt.coverage() ? "1" : "0");
         *of << "# Threaded output mode?  0/1/N threads (from --threads)\n";
         cmake_set_raw(*of, name + "_THREADS", cvtToStr(v3Global.opt.threads()));
-        *of << "# Threaded tracing output mode?  0/1/N threads (from --trace-threads)\n";
-        cmake_set_raw(*of, name + "_TRACE_THREADS",
-                      cvtToStr(v3Global.opt.traceFormat().vcd()  ? v3Global.opt.traceThreads()
-                               : v3Global.opt.traceThreads() > 1 ? v3Global.opt.traceThreads() - 1
-                                                                 : 0));
+        *of << "# Threaded tracing output mode?  0/1/N threads (from --threads/--trace-threads)\n";
+        cmake_set_raw(*of, name + "_TRACE_THREADS", cvtToStr(v3Global.opt.vmTraceThreads()));
         cmake_set_raw(*of, name + "_TRACE_FST_WRITER_THREAD",
                       v3Global.opt.traceThreads() && v3Global.opt.traceFormat().fst() ? "1" : "0");
         *of << "# Struct output mode?  0/1 (from --trace-structs)\n";

--- a/src/V3EmitMk.cpp
+++ b/src/V3EmitMk.cpp
@@ -75,7 +75,9 @@ public:
         of.puts("\n");
         of.puts("# Tracing threaded output mode?  0/1/N threads (from --trace-thread)\n");
         of.puts("VM_TRACE_THREADS = ");
-        of.puts(cvtToStr(v3Global.opt.useTraceOffloadThread()));
+        of.puts(cvtToStr(v3Global.opt.traceFormat().vcd()  ? v3Global.opt.traceThreads()
+                         : v3Global.opt.traceThreads() > 1 ? v3Global.opt.traceThreads() - 1
+                                                           : 0));
         of.puts("\n");
         of.puts("# Separate FST writer thread? 0/1 (from --trace-fst with --trace-thread > 0)\n");
         of.puts("VM_TRACE_FST_WRITER_THREAD = ");

--- a/src/V3EmitMk.cpp
+++ b/src/V3EmitMk.cpp
@@ -73,11 +73,10 @@ public:
         of.puts("VM_TRACE_FST = ");
         of.puts(v3Global.opt.trace() && v3Global.opt.traceFormat().fst() ? "1" : "0");
         of.puts("\n");
-        of.puts("# Tracing threaded output mode?  0/1/N threads (from --trace-thread)\n");
+        of.puts(
+            "# Tracing threaded output mode?  0/1/N threads (from --threads/--trace-thread)\n");
         of.puts("VM_TRACE_THREADS = ");
-        of.puts(cvtToStr(v3Global.opt.traceFormat().vcd()  ? v3Global.opt.traceThreads()
-                         : v3Global.opt.traceThreads() > 1 ? v3Global.opt.traceThreads() - 1
-                                                           : 0));
+        of.puts(cvtToStr(v3Global.opt.vmTraceThreads()));
         of.puts("\n");
         of.puts("# Separate FST writer thread? 0/1 (from --trace-fst with --trace-thread > 0)\n");
         of.puts("VM_TRACE_FST_WRITER_THREAD = ");

--- a/src/V3Options.h
+++ b/src/V3Options.h
@@ -518,9 +518,7 @@ public:
     int traceMaxArray() const { return m_traceMaxArray; }
     int traceMaxWidth() const { return m_traceMaxWidth; }
     int traceThreads() const { return m_traceThreads; }
-    bool useTraceOffloadThread() const {
-        return traceThreads() == 0 ? 0 : traceThreads() - traceFormat().fst();
-    }
+    bool useTraceOffloadThread() const { return traceFormat().fst() && traceThreads() > 1; }
     int unrollCount() const { return m_unrollCount; }
     int unrollStmts() const { return m_unrollStmts; }
 

--- a/src/V3Options.h
+++ b/src/V3Options.h
@@ -518,7 +518,11 @@ public:
     int traceMaxArray() const { return m_traceMaxArray; }
     int traceMaxWidth() const { return m_traceMaxWidth; }
     int traceThreads() const { return m_traceThreads; }
-    bool useTraceOffloadThread() const { return traceFormat().fst() && traceThreads() > 1; }
+    bool useTraceOffload() const { return trace() && traceFormat().fst() && traceThreads() > 1; }
+    bool useTraceParallel() const { return trace() && traceFormat().vcd() && threads() > 1; }
+    unsigned vmTraceThreads() const {
+        return useTraceParallel() ? threads() : useTraceOffload() ? 1 : 0;
+    }
     int unrollCount() const { return m_unrollCount; }
     int unrollStmts() const { return m_unrollStmts; }
 

--- a/src/V3Trace.cpp
+++ b/src/V3Trace.cpp
@@ -180,6 +180,9 @@ private:
     TraceActivityVertex* const m_alwaysVtxp;  // "Always trace" vertex
     bool m_finding = false;  // Pass one of algorithm?
 
+    // Trace parallelism. Only VCD tracing can be parallelized at this time.
+    const uint32_t m_parallelism = 1;
+
     VDouble0 m_statUniqSigs;  // Statistic tracking
     VDouble0 m_statUniqCodes;  // Statistic tracking
 
@@ -388,7 +391,7 @@ private:
                 if (!it->second->duplicatep()) {
                     uint32_t cost = 0;
                     const AstTraceDecl* const declp = it->second->nodep();
-                    // The number of comparisons required by tracep->chg*
+                    // The number of comparisons required by bufp->chg*
                     cost += declp->isWide() ? declp->codeInc() : 1;
                     // Arrays are traced by element
                     cost *= declp->arrayRange().ranged() ? declp->arrayRange().elements() : 1;
@@ -494,7 +497,7 @@ private:
         };
         if (isTopFunc) {
             // Top functions
-            funcp->argTypes("void* voidSelf, " + v3Global.opt.traceClassBase() + "* tracep");
+            funcp->argTypes("void* voidSelf, " + v3Global.opt.traceClassBase() + "::Buffer* bufp");
             addInitStr(voidSelfAssign(m_topModp));
             addInitStr(symClassAssign());
             // Add global activity check to change dump functions
@@ -508,32 +511,33 @@ private:
                 m_regFuncp->addStmtsp(new AstText(flp, "tracep->addChgCb(", true));
             }
             m_regFuncp->addStmtsp(new AstAddrOfCFunc(flp, funcp));
-            m_regFuncp->addStmtsp(new AstText(flp, ", vlSelf);\n", true));
+            const string threadPool{m_parallelism > 1 ? "vlSymsp->__Vm_threadPoolp" : "nullptr"};
+            m_regFuncp->addStmtsp(new AstText(flp, ", vlSelf, " + threadPool + ");\n", true));
         } else {
             // Sub functions
-            funcp->argTypes(v3Global.opt.traceClassBase() + "* tracep");
+            funcp->argTypes(v3Global.opt.traceClassBase() + "::Buffer* bufp");
             // Setup base references. Note in rare occasions we can end up with an empty trace
             // sub function, hence the VL_ATTR_UNUSED attributes.
             if (full) {
                 // Full dump sub function
                 addInitStr("uint32_t* const oldp VL_ATTR_UNUSED = "
-                           "tracep->oldp(vlSymsp->__Vm_baseCode);\n");
+                           "bufp->oldp(vlSymsp->__Vm_baseCode);\n");
             } else {
                 // Change dump sub function
                 if (v3Global.opt.useTraceOffloadThread()) {
                     addInitStr("const uint32_t base VL_ATTR_UNUSED = "
                                "vlSymsp->__Vm_baseCode + "
                                + cvtToStr(baseCode) + ";\n");
-                    addInitStr("if (false && tracep) {}  // Prevent unused\n");
+                    addInitStr("if (false && bufp) {}  // Prevent unused\n");
                 } else {
                     addInitStr("uint32_t* const oldp VL_ATTR_UNUSED = "
-                               "tracep->oldp(vlSymsp->__Vm_baseCode + "
+                               "bufp->oldp(vlSymsp->__Vm_baseCode + "
                                + cvtToStr(baseCode) + ");\n");
                 }
             }
             // Add call to top function
             AstCCall* const callp = new AstCCall(funcp->fileline(), funcp);
-            callp->argTypes("tracep");
+            callp->argTypes("bufp");
             topFuncp->addStmtsp(callp);
         }
         // Done
@@ -747,13 +751,11 @@ private:
         m_regFuncp->isLoose(true);
         m_topScopep->addActivep(m_regFuncp);
 
-        const int parallelism = 1;  // Note: will bump this later, code below works for any value
-
         // Create the full dump functions, also allocates signal numbers
-        createFullTraceFunction(traces, nFullCodes, parallelism);
+        createFullTraceFunction(traces, nFullCodes, m_parallelism);
 
         // Create the incremental dump functions
-        createChgTraceFunctions(traces, nChgCodes, parallelism);
+        createChgTraceFunctions(traces, nChgCodes, m_parallelism);
 
         // Remove refs to traced values from TraceDecl nodes, these have now moved under
         // TraceInc

--- a/src/V3Trace.cpp
+++ b/src/V3Trace.cpp
@@ -181,7 +181,8 @@ private:
     bool m_finding = false;  // Pass one of algorithm?
 
     // Trace parallelism. Only VCD tracing can be parallelized at this time.
-    const uint32_t m_parallelism = 1;
+    const uint32_t m_parallelism
+        = v3Global.opt.useTraceParallel() ? static_cast<uint32_t>(v3Global.opt.threads()) : 1;
 
     VDouble0 m_statUniqSigs;  // Statistic tracking
     VDouble0 m_statUniqCodes;  // Statistic tracking
@@ -524,7 +525,7 @@ private:
                            "bufp->oldp(vlSymsp->__Vm_baseCode);\n");
             } else {
                 // Change dump sub function
-                if (v3Global.opt.useTraceOffloadThread()) {
+                if (v3Global.opt.useTraceOffload()) {
                     addInitStr("const uint32_t base VL_ATTR_UNUSED = "
                                "vlSymsp->__Vm_baseCode + "
                                + cvtToStr(baseCode) + ";\n");
@@ -732,7 +733,7 @@ private:
         // We will split functions such that each have to dump roughly the same amount of data
         // for this we need to keep tack of the number of codes used by the trace functions.
         uint32_t nFullCodes = 0;  // Number of non-duplicate codes (need to go into full* dump)
-        uint32_t nChgCodes = 0;  // Number of non-consant codes (need to go in to chg* dump)
+        uint32_t nChgCodes = 0;  // Number of non-constant codes (need to go in to chg* dump)
         sortTraces(traces, nFullCodes, nChgCodes);
 
         UINFO(5, "nFullCodes: " << nFullCodes << " nChgCodes: " << nChgCodes << endl);

--- a/test_regress/driver.pl
+++ b/test_regress/driver.pl
@@ -924,7 +924,6 @@ sub compile_vlt_flags {
     unshift @verilator_flags, "--trace" if $opt_trace;
     my $threads = ::calc_threads($Vltmt_threads);
     unshift @verilator_flags, "--threads $threads" if $param{vltmt} && $checkflags !~ /-threads /;
-    unshift @verilator_flags, "--trace-threads 1" if $param{vltmt} && $checkflags =~ /-trace /;
     unshift @verilator_flags, "--trace-threads 2" if $param{vltmt} && $checkflags =~ /-trace-fst /;
     unshift @verilator_flags, "--debug-partition" if $param{vltmt};
     unshift @verilator_flags, "-CFLAGS -ggdb -LDFLAGS -ggdb" if $opt_gdbsim;


### PR DESCRIPTION
VCD tracing is now parallelized using the same thread pool as the model.
We achieve this by breaking the top level trace functions into multiple
top level functions (as many as --threads), and after emitting the time
stamp to the VCD file on the main thread, we execute the tracing
functions in parallel on the same thread pool as the model (which we
pass to the trace file during registration), tracing into a secondary
per thread buffer. The main thread will then stitch (memcpy) the buffers
together into the output file.

This makes the `--trace-threads` option redundant with `--trace`, which
now only affects `--trace-fst`. FST tracing uses the previous offloading
scheme.

This obviously helps a lot in VCD tracing performance, and I have seen
better than Amdahl speedup, namely I get 3.9x on XiangShan 4T (2.7x on
OpenTitan 4T).