### PR TITLE
 Fix #3445 of BitOpTreeOpt

### DIFF
--- a/src/V3Const.cpp
+++ b/src/V3Const.cpp
@@ -678,7 +678,7 @@ public:
 
         // Add size of reduction tree to op count
         resultOps += termps.size() - 1;
-        for (auto&& lsbAndNodes : frozenNodes) {
+        for (const auto& lsbAndNodes : frozenNodes) {
             if (lsbAndNodes.first > 0) ++resultOps;  // Needs AstShiftR
             resultOps += lsbAndNodes.second.size();
         }
@@ -691,7 +691,7 @@ public:
             cout << "Bitop tree considered: " << endl;
             for (AstNode* const termp : termps) termp->dumpTree("Reduced term: ");
             for (const std::pair<AstNode*, int>& termp : visitor.m_frozenNodes)
-                termp.first->dumpTree("Frozen term lsb:" + std::to_string(termp.second) + " :");
+                termp.first->dumpTree("Frozen term with lsb " + std::to_string(termp.second) + ": ");
             cout << "Needs flipping: " << needsFlip << endl;
             cout << "Needs cleaning: " << needsCleaning << endl;
             cout << "Size: " << resultOps << " input size: " << visitor.m_ops << endl;
@@ -735,9 +735,9 @@ public:
         }
         // Add any frozen terms to the reduction
         for (auto&& lsbAndNodes : frozenNodes) {
-            AstNode* termp = lsbAndNodes.second.front()->unlinkFrBack();
-            for (size_t i = 1; i < lsbAndNodes.second.size(); ++i) {
-                termp = reduce(termp, lsbAndNodes.second[i]->unlinkFrBack());
+            AstNode* termp = nullptr;
+            for (AstNode* const itemp : lsbAndNodes.second) {
+                termp = reduce(termp, itemp->unlinkFrBack());
             }
             if (lsbAndNodes.first > 0) {  // LSB is not 0, so shiftR
                 AstNodeDType* const dtypep = termp->dtypep();

--- a/src/V3Const.cpp
+++ b/src/V3Const.cpp
@@ -691,7 +691,8 @@ public:
             cout << "Bitop tree considered: " << endl;
             for (AstNode* const termp : termps) termp->dumpTree("Reduced term: ");
             for (const std::pair<AstNode*, int>& termp : visitor.m_frozenNodes)
-                termp.first->dumpTree("Frozen term with lsb " + std::to_string(termp.second) + ": ");
+                termp.first->dumpTree("Frozen term with lsb " + std::to_string(termp.second)
+                                      + ": ");
             cout << "Needs flipping: " << needsFlip << endl;
             cout << "Needs cleaning: " << needsCleaning << endl;
             cout << "Size: " << resultOps << " input size: " << visitor.m_ops << endl;

--- a/test_regress/t/t_const_opt.pl
+++ b/test_regress/t/t_const_opt.pl
@@ -18,5 +18,8 @@ execute(
     check_finished => 1,
     );
 
+if ($Self->{vlt}) {
+    file_grep($Self->{stats}, qr/Optimizations, Const bit op reduction\s+(\d+)/i, 9);
+}
 ok(1);
 1;

--- a/test_regress/t/t_const_opt.pl
+++ b/test_regress/t/t_const_opt.pl
@@ -19,7 +19,7 @@ execute(
     );
 
 if ($Self->{vlt}) {
-    file_grep($Self->{stats}, qr/Optimizations, Const bit op reduction\s+(\d+)/i, 9);
+    file_grep($Self->{stats}, qr/Optimizations, Const bit op reduction\s+(\d+)/i, 10);
 }
 ok(1);
 1;

--- a/test_regress/t/t_const_opt.v
+++ b/test_regress/t/t_const_opt.v
@@ -145,6 +145,18 @@ module bug3197(input wire clk, input wire [31:0] in, output out);
    assign out = (d[39] | tmp0);
 endmodule
 
+
+// Bug #3445
+// An unoptimized node is kept as frozen node, but its LSB were not saved.
+// AST of RHS of result0 looks as below:
+//   AND(SHIFTR(AND(WORDSEL(ARRAYSEL(VARREF)), WORDSEL(ARRAYSEL(VARREF)))), 32'd11)
+//                  ~~~~~~~~~~~~~~~~~~~~~~~~~  ~~~~~~~~~~~~~~~~~~~~~~~~~
+// Two of WORDSELs are frozen nodes. They are under SHIFTR of 11 bits.
+//
+// Fixing #3445 needs to
+//  1. Take AstShiftR into op count when diciding optimizable or not
+//     (result0 in the test)
+//  2. Insert AstShiftR if LSB of the frozen node is not 0 (result1 in the test)
 module bug3445(input wire clk, input wire [31:0] in, output wire out);
    logic [127:0] d;
    always_ff @(posedge clk)


### PR DESCRIPTION
second shot of #3452 

As written in https://github.com/verilator/verilator/issues/3445#issue-1248381686, LSB of frozen node has been ignored. This PR keeps the information and insert AstShiftR if LSB > 0.

As usual, I will push test first to see the CI failure, then push the fix.