### PR TITLE
Replace `InstrCountCostVisitor` with `InstrCountVisitor` 

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -35,6 +35,7 @@ Guokai Chen
 Harald Heckmann
 Howard Su
 Huang Rui
+HuangHuang Zhou
 HungMingWu
 HyungKi Jeong
 Iru Cai

--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -35,7 +35,7 @@ Guokai Chen
 Harald Heckmann
 Howard Su
 Huang Rui
-HuangHuang Zhou
+Huanghuang Zhou
 HungMingWu
 HyungKi Jeong
 Iru Cai

--- a/docs/internals.rst
+++ b/docs/internals.rst
@@ -274,7 +274,7 @@ path through the graph is the sum of macro-task execution costs. Sarkar
 does almost the same thing, except that he has nonzero estimates for
 synchronization costs.
 
-Verilator's cost estimates are assigned by ``InstrCountCostVisitor``.  This
+Verilator's cost estimates are assigned by ``InstrCountVisitor``.  This
 class is perhaps the most fragile piece of the multithread
 implementation. It's easy to have a bug where you count something cheap
 (eg. accessing one element of a huge array) as if it were expensive (eg.


### PR DESCRIPTION
Small fix.
Replace `InstrCountCostVisitor` with `InstrCountVisitor`  in internals.rst 

Signed-off-by: huanghuang.zhou <huanghuang.zhou@terapines.com>

We appreciate your contributing to Verilator.  If this is your first commit, please add your name to docs/CONTRIBUTORS, and read our contributing guidelines in docs/CONTRIBUTING.rst.
