### PR TITLE
Fix BitOpTree optimization to consider polarity of frozen node (#3445)

### DIFF
--- a/test_regress/t/t_const_opt.pl
+++ b/test_regress/t/t_const_opt.pl
@@ -19,7 +19,7 @@ execute(
     );
 
 if ($Self->{vlt}) {
-    file_grep($Self->{stats}, qr/Optimizations, Const bit op reduction\s+(\d+)/i, 10);
+    file_grep($Self->{stats}, qr/Optimizations, Const bit op reduction\s+(\d+)/i, 11);
 }
 ok(1);
 1;


### PR DESCRIPTION
This is the other failure reported in #3445.

#3453 preserves lsb information of frozen nodes.
This PR keeps polarity.
I believe there is no more context for frozen nodes to remember.

As usual, I will push a test to reproduce the issue, then push the fix.

ext tests pass.