### PR TITLE
Optimize file writing by using memory buffer.

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -68,6 +68,7 @@ Lukasz Dalek
 Maarten De Braekeleer
 Maciej Sobkowski
 Marco Widmer
+Mariusz Glebocki
 Markus Krause
 Marlon James
 Marshal Qiao

--- a/src/V3EmitCSyms.cpp
+++ b/src/V3EmitCSyms.cpp
@@ -951,7 +951,8 @@ void EmitCSyms::emitSymImp() {
     }
 
     closeSplit();
-    VL_DO_CLEAR(delete m_ofp, m_ofp = nullptr);
+    m_ofp = nullptr;
+    VL_DO_CLEAR(delete m_ofpBase, m_ofpBase = nullptr);
 }
 
 //######################################################################

--- a/src/V3File.cpp
+++ b/src/V3File.cpp
@@ -920,13 +920,16 @@ void V3OutFormatter::printf(const char* fmt...) {
 // V3OutFormatter: A class for printing to a file, with automatic indentation of C++ code.
 
 V3OutFile::V3OutFile(const string& filename, V3OutFormatter::Language lang)
-    : V3OutFormatter{filename, lang} {
+    : V3OutFormatter{filename, lang}
+    , m_bufferp{new std::array<char, WRITE_BUFFER_SIZE_BYTES>{}} {
     if ((m_fp = V3File::new_fopen_w(filename)) == nullptr) {
         v3fatal("Cannot write " << filename);
     }
 }
 
 V3OutFile::~V3OutFile() {
+    writeBlock();
+
     if (m_fp) fclose(m_fp);
     m_fp = nullptr;
 }


### PR DESCRIPTION
`fputc` call has been replaced with assignment to consecutive bytes of allocated buffer. The buffer is saved using `fwrite` when full, and when the object is destructed.

This allowed to slightly speed up writing. In benchmarks with a larger project, the verilation time is lower by about 4 seconds (1.5%).
This difference is observable when the output is saved to a fast M2 SSD, and to a regular HDD. With and without tcmalloc.

- M2 SSD (each value is an average from 8 runs)
  - 245.13s → 241.2s with tcmalloc
  - 389.4s → 386.4s with glibc's allocator
- HDD (each value is an average from 4 runs)
  - 247.9s → 243.8s with tcmalloc
  - 397.5 → 392.7 with glibc's allocator

Verilator compiled and benchmarked on Ubuntu 20.04 using Clang 12. tcmalloc compiled from gperftools 2.9.1.

The picked buffer size (128kB) has been experimentally determined to be in the zone of buffer sizes that work best.
It is also considered to be the smallest I/O buffer size in [GNU coreutils (io_blksize)](https://github.com/coreutils/coreutils/blob/master/src/ioblksize.h) that allows to best minimize syscall overhead.
