### PR TITLE
Fix compile error under strict C++11

### DIFF
--- a/src/V3Ast.h
+++ b/src/V3Ast.h
@@ -2021,12 +2021,12 @@ private:
         return Default;
     }
 
-    template <typename T_Node> constexpr static void checkTypeParameter() {
+    template <typename T_Node> struct CheckTypeParameter {
         static_assert(!std::is_const<T_Node>::value,
                       "Type parameter 'T_Node' should not be const qualified");
         static_assert(std::is_base_of<AstNode, T_Node>::value,
                       "Type parameter 'T_Node' must be a subtype of AstNode");
-    }
+    };
 
 public:
     // Traverse subtree and call given function 'f' in pre-order on each node that has type
@@ -2035,25 +2035,25 @@ public:
     // operation function in 'foreach' should be completely predictable by branch target caches in
     // modern CPUs, while it is basically unpredictable for VNVisitor.
     template <typename T_Node> void foreach (std::function<void(T_Node*)> f) {
-        checkTypeParameter<T_Node>();
+        (void)CheckTypeParameter<T_Node>();
         foreachImpl<T_Node, /* VisitNext: */ false>(this, f);
     }
 
     // Same as above, but for 'const' nodes
     template <typename T_Node> void foreach (std::function<void(const T_Node*)> f) const {
-        checkTypeParameter<T_Node>();
+        (void)CheckTypeParameter<T_Node>();
         foreachImpl<const T_Node, /* VisitNext: */ false>(this, f);
     }
 
     // Same as 'foreach' but also follows 'this->nextp()'
     template <typename T_Node> void foreachAndNext(std::function<void(T_Node*)> f) {
-        checkTypeParameter<T_Node>();
+        (void)CheckTypeParameter<T_Node>();
         foreachImpl<T_Node, /* VisitNext: */ true>(this, f);
     }
 
     // Same as 'foreach' but also follows 'this->nextp()'
     template <typename T_Node> void foreachAndNext(std::function<void(const T_Node*)> f) const {
-        checkTypeParameter<T_Node>();
+        (void)CheckTypeParameter<T_Node>();
         foreachImpl<const T_Node, /* VisitNext: */ true>(this, f);
     }
 
@@ -2062,13 +2062,13 @@ public:
     // present. Traversal is performed in some arbitrary order and is terminated as soon as the
     // result can be determined.
     template <typename T_Node> bool exists(std::function<bool(T_Node*)> p) {
-        checkTypeParameter<T_Node>();
+        (void)CheckTypeParameter<T_Node>();
         return predicateImpl<T_Node, /* Default: */ false, /* VisitNext: */ false>(this, p);
     }
 
     // Same as above, but for 'const' nodes
     template <typename T_Node> void exists(std::function<bool(const T_Node*)> p) const {
-        checkTypeParameter<T_Node>();
+        (void)CheckTypeParameter<T_Node>();
         return predicateImpl<const T_Node, /* Default: */ false, /* VisitNext: */ false>(this, p);
     }
 
@@ -2077,13 +2077,13 @@ public:
     // present. Traversal is performed in some arbitrary order and is terminated as soon as the
     // result can be determined.
     template <typename T_Node> bool forall(std::function<bool(T_Node*)> p) {
-        checkTypeParameter<T_Node>();
+        (void)CheckTypeParameter<T_Node>();
         return predicateImpl<T_Node, /* Default: */ true, /* VisitNext: */ false>(this, p);
     }
 
     // Same as above, but for 'const' nodes
     template <typename T_Node> void forall(std::function<bool(const T_Node*)> p) const {
-        checkTypeParameter<T_Node>();
+        (void)CheckTypeParameter<T_Node>();
         return predicateImpl<const T_Node, /* Default: */ true, /* VisitNext: */ false>(this, p);
     }
 


### PR DESCRIPTION
Building HEAD on OSX, I get the following error:

```
external/verilator_v4.222/src/V3Ast.h:2024:54: error: constexpr function's return type 'void' is not a literal type
    template <typename T_Node> constexpr static void checkTypeParameter() {
                                                     ^
external/verilator_v4.222/src/V3Ast.h:2044:9: error: no matching function for call to 'checkTypeParameter'
        checkTypeParameter<T_Node>();
        ^~~~~~~~~~~~~~~~~~~~~~~~~~
external/verilator_v4.222/src/V3Ast.h:2093:15: note: in instantiation of function template specialization 'AstNode::foreach<AstNode>' requested here
        this->foreach<AstNode>([&count](const AstNode*) { ++count; });
              ^
external/verilator_v4.222/src/V3Ast.h:2024:54: note: candidate template ignored: substitution failure [with T_Node = AstNode]
    template <typename T_Node> constexpr static void checkTypeParameter() {
```

The issue seems to be that a constexpr function cannot return void under [a strict reading of the C++11 standard](https://stackoverflow.com/questions/29261276/constexpr-void-function-rejected), although this is allowed under GCC 5+. The fix is to either add a dummy return value or convert the check to use a struct instead. I've implemented the latter here.