### PR TITLE
Public unpacked input port

### DIFF
--- a/src/V3Inline.cpp
+++ b/src/V3Inline.cpp
@@ -311,8 +311,8 @@ private:
                 // code will be emitted.
                 UINFO(9, "assign to public and unpacked: " << nodep << endl);
                 m_modp->addStmtp(
-                    new AstAssignW(flp, new AstVarRef(flp, nodep, VAccess::WRITE),
-                                   new AstVarRef(flp, exprvarrefp->varp(), VAccess::READ)));
+                    new AstAssignW{flp, new AstVarRef{flp, nodep, VAccess::WRITE},
+                                   new AstVarRef{flp, exprvarrefp->varp(), VAccess::READ}});
             } else if (nodep->isIfaceRef()) {
                 m_modp->addStmtp(
                     new AstAssignVarScope(flp, new AstVarRef(flp, nodep, VAccess::WRITE),

--- a/src/V3Inline.cpp
+++ b/src/V3Inline.cpp
@@ -311,8 +311,8 @@ private:
                 // code will be emitted.
                 UINFO(9, "assign to public and unpacked: " << nodep << endl);
                 m_modp->addStmtp(
-                    new AstAssignW(flp, new AstVarRef(flp, exprvarrefp->varp(), VAccess::WRITE),
-                                   new AstVarRef(flp, nodep, VAccess::READ)));
+                    new AstAssignW(flp, new AstVarRef(flp, nodep, VAccess::WRITE),
+                                   new AstVarRef(flp, exprvarrefp->varp(), VAccess::READ)));
             } else if (nodep->isIfaceRef()) {
                 m_modp->addStmtp(
                     new AstAssignVarScope(flp, new AstVarRef(flp, nodep, VAccess::WRITE),

--- a/test_regress/t/t_pub_unpacked_port.pl
+++ b/test_regress/t/t_pub_unpacked_port.pl
@@ -1,0 +1,24 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2022 by Todd Strader. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(
+    vlt => 1,
+    );
+
+while (1) {
+
+    compile();
+
+    execute();
+
+    ok(1);
+    last;
+}
+1;

--- a/test_regress/t/t_pub_unpacked_port.pl
+++ b/test_regress/t/t_pub_unpacked_port.pl
@@ -12,13 +12,7 @@ scenarios(
     vlt => 1,
     );
 
-while (1) {
-
-    compile();
-
-    execute();
-
-    ok(1);
-    last;
-}
+compile();
+execute();
+ok(1);
 1;

--- a/test_regress/t/t_pub_unpacked_port.v
+++ b/test_regress/t/t_pub_unpacked_port.v
@@ -1,0 +1,55 @@
+// DESCRIPTION: Verilator: Verilog Test module
+// This file ONLY is placed into the Public Domain, for any use,
+// without warranty, 2022 by Todd Strader.
+// SPDX-License-Identifier: CC0-1.0
+
+module sub (
+   output logic [31:0] sub_s1up_out,
+   input logic sub_clk,
+   input logic [31:0] sub_s1up_in[0:0] /* verilator public_flat_rw */
+   );
+
+   // Evaluate clock edges
+   always @(posedge sub_clk) begin
+      sub_s1up_out <= sub_s1up_in[0];
+   end
+
+endmodule
+
+
+module t (/*AUTOARG*/
+   // Inputs
+   clk
+   );
+   input clk;
+
+   integer cyc = 0;
+   logic   [31:0]     s1up_in[1];
+   logic   [31:0]     s1up_out;
+
+   sub the_sub (
+      .sub_s1up_in (s1up_in),
+      .sub_s1up_out (s1up_out),
+      .sub_clk (clk));
+
+   always_comb   s1up_in[0] = cyc;
+
+   always @(posedge clk) begin
+      cyc <= cyc + 1;
+
+      if (cyc == 10) begin
+         if (s1up_out != 9) begin
+             $display("%%Error: got %0d instead of 9", s1up_out);
+             $stop;
+         end
+         if (the_sub.sub_s1up_in[0] != 10) begin
+             $display("%%Error: the_sub.sub_s1up_in was %0d instead of 10", the_sub.sub_s1up_in[0]);
+             $stop;
+         end
+         $display("final cycle = %0d", cyc);
+         $write("*-* All Finished *-*\n");
+         $finish;
+      end
+   end
+
+endmodule

--- a/test_regress/t/t_pub_unpacked_port.v
+++ b/test_regress/t/t_pub_unpacked_port.v
@@ -4,14 +4,14 @@
 // SPDX-License-Identifier: CC0-1.0
 
 module sub (
-   output logic [31:0] sub_s1up_out,
+   output logic [31:0] sub_s1up_out[0:0] /* verilator public_flat_rw */,
    input logic sub_clk,
    input logic [31:0] sub_s1up_in[0:0] /* verilator public_flat_rw */
    );
 
    // Evaluate clock edges
    always @(posedge sub_clk) begin
-      sub_s1up_out <= sub_s1up_in[0];
+      sub_s1up_out <= sub_s1up_in;
    end
 
 endmodule
@@ -25,7 +25,7 @@ module t (/*AUTOARG*/
 
    integer cyc = 0;
    logic   [31:0]     s1up_in[1];
-   logic   [31:0]     s1up_out;
+   logic   [31:0]     s1up_out[1];
 
    sub the_sub (
       .sub_s1up_in (s1up_in),
@@ -38,7 +38,7 @@ module t (/*AUTOARG*/
       cyc <= cyc + 1;
 
       if (cyc == 10) begin
-         if (s1up_out != 9) begin
+         if (s1up_out[0] != 9) begin
              $display("%%Error: got %0d instead of 9", s1up_out);
              $stop;
          end


### PR DESCRIPTION
Public, unpacked ports are not correctly assigned in the C++.  Without the V3Inline change, this test will fail, not because `the_sub` provides the wrong output on `sub_s1up_out`, but because `sub_s1up_in` is wrong.  The problem does not manifest if the port is not marked public or if the port is a packed array.

While sifting through the debug, I found that the inline trees were different between the public ('<') and not public ('>') versions:
```
<     1:2: ASSIGNW   {d9be} @dt=@(w32)u[0:0]                                                                                                                                                                                                                                                                                                                                                                                             
<     1:2:1: VARREF   {d9be} @dt=@(w32)u[0:0]  t__DOT__the_sub__DOT__sub_s1up_in [VSTATIC]  PORT                                                                                                                                                                                          
<     1:2:2: VARREF   {d9be} @dt=@(w32)u[0:0]  t__DOT____Vcellinp__the_sub__sub_s1up_in MODULETEMP                                                                                                                                                                                                                                                                                                                                       
---                                                                                                                                                                                                                                                                                               
>     1:2: ASSIGNALIAS   {d9be} @dt=@(w32)u[0:0]                                                                                                                                                                                                                                                                                                                                                                                         
>     1:2:1: VARREF   {d9be} @dt=@(w32)u[0:0]  t__DOT____Vcellinp__the_sub__sub_s1up_in MODULETEMP
>     1:2:2: VARREF   {d9be} @dt=@(w32)u[0:0]  t__DOT__the_sub__DOT__sub_s1up_in [VSTATIC]  PORT
```

I'm not sure what the difference between PORT and MODULETEMP is here, but from digging into the C++ I can see why the former would be a problem.  We're changing the MODULETEMP but it keeps getting overwritten by the PORT.

I traced this back to the section of V3Inline I've modified.  This comes from: https://github.com/verilator/verilator/issues/2073 (cc @wallento)

I can't say that I understand that change yet, but I figured I'd try to flip the assignment since I'm pretty sure that's what my test wants.  It passes now and surprisingly so does everything else.  Is there something else I should try here?  Or is this actually the way that the assignment should be done?