### PR TITLE
src/bisonpre: specify utf-8 encoding

### DIFF
--- a/src/bisonpre
+++ b/src/bisonpre
@@ -150,7 +150,7 @@ def clean_output(filename, outname, is_output, is_c):
         lines = out
         out = []
 
-    with open(outname, "w") as fh:
+    with open(outname, "w", encoding="utf-8") as fh:
         for line in lines:
             # Fix filename refs
             line = re.sub(basename, newbase, line)


### PR DESCRIPTION
This is a fix for the failing builds on MSYS2 (Windows). See https://github.com/umarcor/MINGW-packages/runs/6968828371?check_suite_focus=true#step:9:453.
