### PR TITLE
Fix #3470 of incorrect bit op tree optimization

### DIFF
--- a/Changes
+++ b/Changes
@@ -13,7 +13,7 @@ Verilator 4.225 devel
 
 **Minor:**
 
-
+* Fix incorrect bit op tree optimization (#3470). [algrobman]
 
 Verilator 4.224 2022-06-19
 ==========================

--- a/src/V3Const.cpp
+++ b/src/V3Const.cpp
@@ -80,6 +80,7 @@ class ConstBitOpTreeVisitor final : public VNVisitor {
     using ResultTerm = std::tuple<AstNode*, unsigned, bool>;
 
     class LeafInfo final {  // Leaf node (either AstConst or AstVarRef)
+        // MEMBERS
         bool m_polarity = true;
         int m_lsb = 0;  // LSB of actually used bit of m_refp->varp()
         int m_msb = 0;  // MSB of actually used bit of m_refp->varp()
@@ -88,10 +89,13 @@ class ConstBitOpTreeVisitor final : public VNVisitor {
         const AstConst* m_constp = nullptr;
 
     public:
+        // CONSTRUCTORS
         LeafInfo() = default;
         explicit LeafInfo(int lsb)
             : m_lsb{lsb} {}
         explicit LeafInfo(const LeafInfo& other) = default;
+
+        // METHODS
         void setLeaf(AstVarRef* refp) {
             UASSERT(!m_refp && !m_constp, "Must be called just once");
             m_refp = refp;
@@ -106,14 +110,15 @@ class ConstBitOpTreeVisitor final : public VNVisitor {
             m_msb = std::min(m_msb, m_lsb + castp->width() - 1);
         }
         void updateBitRange(AstShiftR*, AstConst* constp) { m_lsb += constp->toUInt(); }
+        void wordIdx(int i) { m_wordIdx = i; }
+        void polarity(bool p) { m_polarity = p; }
+
         AstVarRef* refp() const { return m_refp; }
         const AstConst* constp() const { return m_constp; }
         int wordIdx() const { return m_wordIdx; }
         bool polarity() const { return m_polarity; }
         int lsb() const { return m_lsb; }
 
-        void wordIdx(int i) { m_wordIdx = i; }
-        void polarity(bool p) { m_polarity = p; }
         int msb() const { return std::min(m_msb, varWidth() - 1); }
         int varWidth() const {
             UASSERT(m_refp, "m_refp should be set");

--- a/src/V3Const.cpp
+++ b/src/V3Const.cpp
@@ -91,9 +91,9 @@ class ConstBitOpTreeVisitor final : public VNVisitor {
     public:
         // CONSTRUCTORS
         LeafInfo() = default;
+        LeafInfo(const LeafInfo& other) = default;
         explicit LeafInfo(int lsb)
             : m_lsb{lsb} {}
-        explicit LeafInfo(const LeafInfo& other) = default;
 
         // METHODS
         void setLeaf(AstVarRef* refp) {

--- a/src/V3Const.cpp
+++ b/src/V3Const.cpp
@@ -109,7 +109,9 @@ class ConstBitOpTreeVisitor final : public VNVisitor {
         void updateBitRange(const AstCCast* castp) {
             m_msb = std::min(m_msb, m_lsb + castp->width() - 1);
         }
-        void updateBitRange(AstShiftR*, AstConst* constp) { m_lsb += constp->toUInt(); }
+        void updateBitRange(const AstShiftR* shiftp) {
+            m_lsb += VN_AS(shiftp->rhsp(), Const)->toUInt();
+        }
         void wordIdx(int i) { m_wordIdx = i; }
         void polarity(bool p) { m_polarity = p; }
 
@@ -429,7 +431,7 @@ class ConstBitOpTreeVisitor final : public VNVisitor {
         m_lsb += constp->toUInt();
         incrOps(nodep, __LINE__);
         iterate(nodep->lhsp());
-        m_leafp->updateBitRange(nodep, constp);
+        m_leafp->updateBitRange(nodep);
         m_lsb -= constp->toUInt();
     }
     virtual void visit(AstNot* nodep) override {

--- a/test_regress/t/t_const_opt.pl
+++ b/test_regress/t/t_const_opt.pl
@@ -19,7 +19,7 @@ execute(
     );
 
 if ($Self->{vlt}) {
-    file_grep($Self->{stats}, qr/Optimizations, Const bit op reduction\s+(\d+)/i, 11);
+    file_grep($Self->{stats}, qr/Optimizations, Const bit op reduction\s+(\d+)/i, 14);
 }
 ok(1);
 1;

--- a/test_regress/t/t_const_opt.v
+++ b/test_regress/t/t_const_opt.v
@@ -62,7 +62,7 @@ module t(/*AUTOARG*/
          $write("[%0t] cyc==%0d crc=%x sum=%x\n", $time, cyc, crc, sum);
          if (crc !== 64'hc77bb9b3784ea091) $stop;
          // What checksum will we end up with (above print should match)
-`define EXPECTED_SUM 64'hdccb9e7b8b638233
+`define EXPECTED_SUM 64'hde21e019a3e12039
 
          if (sum !== `EXPECTED_SUM) $stop;
          $write("*-* All Finished *-*\n");
@@ -86,10 +86,11 @@ module Test(/*AUTOARG*/
    logic bug3182_out;
    logic bug3197_out;
    logic bug3445_out;
+   logic bug3470_out;
 
    output logic o;
 
-   logic [7:0] tmp;
+   logic [8:0] tmp;
    assign o = ^tmp;
 
    always_ff @(posedge clk) begin
@@ -113,11 +114,13 @@ module Test(/*AUTOARG*/
       tmp[5] <= bug3182_out;
       tmp[6] <= bug3197_out;
       tmp[7] <= bug3445_out;
+      tmp[8] <= bug3470_out;
    end
 
    bug3182 i_bug3182(.in(d[4:0]), .out(bug3182_out));
    bug3197 i_bug3197(.clk(clk), .in(d), .out(bug3197_out));
    bug3445 i_bug3445(.clk(clk), .in(d), .out(bug3445_out));
+   bug3470 i_bug3470(.clk(clk), .in(d), .out(bug3470_out));
 
 endmodule
 
@@ -202,4 +205,15 @@ module bug3445(input wire clk, input wire [31:0] in, output wire out);
    end
 
    assign out = result0 ^ result1 ^ (result2 | result3);
+endmodule
+
+module bug3470(input wire clk, input wire [31:0] in, output wire out);
+   logic [38:0] d;
+   always_ff @(posedge clk)
+      d <= {d[6:0], in};
+
+   logic tmp;
+   always_ff @(posedge clk)
+     tmp <= ^(d >> 32) ^ (^d[31:0]);
+   assign out = tmp;
 endmodule


### PR DESCRIPTION
As usual, I push a test to reproduce #3470, then push the fix.

Here is the AST of the trouble.
Bit mask in the result is `39'hFFFFFFFF` even though `39'h7FFFFFFFFF` is expected.
```
matchBitOpTree[6] INPUT:  XOR 0x564620099ba0 <e10920701#> {by683bn} @dt=0x564612cd3ad0@(G/wu32/1)
matchBitOpTree[6] INPUT: 1: REDXOR 0x564620099c60 <e10920669#> {by683bc} @dt=0x564612cd3ad0@(G/wu32/1)
matchBitOpTree[6] INPUT: 1:1: CCAST 0x564620099440 <e12421355#> {bo370cs} @dt=0x564612ca9230@(w32) sz32
matchBitOpTree[6] INPUT: 1:1:1: VARREF 0x564620099090 <e14760825#> {bo370cd} @dt=0x56461b5a2940@(G/wu64/39)  tb_top__DOT__rvtop__DOT__dccm_rd_data_lo [RV] <- VAR 0x56460d4956a0 <e4302463#> {g349bl} @dt=0x564612d9fa70@(G/w39)  tb_top__DOT__rvtop__DOT__dccm_rd_data_lo [VSTATIC]  VAR
matchBitOpTree[6] INPUT: 2: REDXOR 0x564620099e90 <e10920673#> {by683bp} @dt=0x564612cd3ad0@(G/wu32/1)
matchBitOpTree[6] INPUT: 2:1: AND 0x56461aef6490 <e10920686#> {bo373cs} @dt=0x56461de60460@(G/wu32/7)
matchBitOpTree[6] INPUT: 2:1:1: CONST 0x56461aef6370 <e10920682#> {bo373cs} @dt=0x56460d2ea030@(G/w32)  32'h7f
matchBitOpTree[6] INPUT: 2:1:2: CCAST 0x56461e25a820 <e12421375#> {bo373cs} @dt=0x56461de60460@(G/wu32/7) sz32
matchBitOpTree[6] INPUT: 2:1:2:1: SHIFTR 0x56462008e9e0 <e12421372#> {bo373cs} @dt=0x56461b5a2940@(G/wu64/39)
matchBitOpTree[6] INPUT: 2:1:2:1:1: VARREF 0x564620097590 <e12421362#> {bo373cd} @dt=0x56461b5a2940@(G/wu64/39)  tb_top__DOT__rvtop__DOT__dccm_rd_data_lo [RV] <- VAR 0x56460d4956a0 <e4302463#> {g349bl} @dt=0x564612d9fa70@(G/w39)  tb_top__DOT__rvtop__DOT__dccm_rd_data_lo [VSTATIC]  VAR
matchBitOpTree[6] INPUT: 2:1:2:1:2: CONST 0x5646200b5d60 <e12421363#> {bo373ds} @dt=0x56461e0d44a0@(G/wu32/6)  6'h20
- V3Const.cpp:1121:   Transformed leaf of bit tree to AND 0x5646200912a0 <e14760867#> {by683bn} @dt=0x564612cd3ad0@(G/wu32/1)
matchBitOpTree[6] RESULT:  AND 0x5646200912a0 <e14760869#> {by683bn} @dt=0x564612cd3ad0@(G/wu32/1)
matchBitOpTree[6] RESULT: 1: CONST 0x5646200432c0 <e14760860#> {by683bn} @dt=0x56460d2ea030@(G/w32)  32'h1
matchBitOpTree[6] RESULT: 2: REDXOR 0x56461dbb6300 <e14760861#> {bo370cd} @dt=0x564612cd3ad0@(G/wu32/1)
matchBitOpTree[6] RESULT: 2:1: AND 0x56461dbb63c0 <e14760846#> {bo370cd} @dt=0x56460d2ea030@(G/w32)
matchBitOpTree[6] RESULT: 2:1:1: CONST 0x56461aef6190 <e14760836#> {bo370cd} @dt=0x564612d9fa70@(G/w39)  *39'hffffffff*
matchBitOpTree[6] RESULT: 2:1:2: VARREF 0x564620091f70 <e14760837#> {bo370cd} @dt=0x56461b5a2940@(G/wu64/39)  tb_top__DOT__rvtop__DOT__dccm_rd_data_lo [RV] <- VAR 0x56460d4956a0 <e4302463#> {g349bl} @dt=0x564612d9fa70@(G/w39)  tb_top__DOT__rvtop__DOT__dccm_rd_data_lo [VSTATIC]  VAR
```

I found that CCast in `REDXOR((int32_t)dccm_rd_data_lo)` was ignored and the term was interpreted as `REDXOR(dccm_rd_data_lo)`.
The other term was `REDXOR(dccm_rd_data_lo >> 32)`. So `dccm_rd_data_lo[38:32]` appeared in both term, hence the optimize result was `REDXOR(dccm_rd_data_lo[31:0])`.

To fix the bug, truncation by CCast is considered by adding `LeafInfo::m_msb`.

I think it is easier to review commit by commit.