### PR TITLE
Move thread pool and execution profiler into the context

### DIFF
--- a/include/verilated.cpp
+++ b/include/verilated.cpp
@@ -66,6 +66,10 @@
 #if defined(_WIN32) || defined(__MINGW32__)
 # include <direct.h>  // mkdir
 #endif
+
+#ifdef VL_THREADED
+# include "verilated_threads.h"
+#endif
 // clang-format on
 
 // Max characters in static char string for VL_VALUE_STRING
@@ -2428,6 +2432,33 @@ const char* VerilatedContext::timeprecisionString() const VL_MT_SAFE {
     return vl_time_str(timeprecision());
 }
 
+void VerilatedContext::threads(unsigned n) {
+    if (n == 0) VL_FATAL_MT(__FILE__, __LINE__, "", "%Error: Simulation threads must be >= 1");
+
+    if (m_threadPool) {
+        VL_FATAL_MT(
+            __FILE__, __LINE__, "",
+            "%Error: Cannot set simulation threads after the thread pool has been created.");
+    }
+
+#if VL_THREADED
+    if (m_threads == n) return;  // To avoid unnecessary warnings
+    m_threads = n;
+    const unsigned hardwareThreadsAvailable = std::thread::hardware_concurrency();
+    if (m_threads > hardwareThreadsAvailable) {
+        VL_PRINTF_MT("%%Warning: System has %u hardware threads but simulation thread count set "
+                     "to %u. This will likely cause significant slowdown.\n",
+                     hardwareThreadsAvailable, m_threads);
+    }
+#else
+    if (n > 1) {
+        VL_PRINTF_MT("%%Warning: Verilator run-time library built without VL_THREADS. Ignoring "
+                     "call to 'VerilatedContext::threads' with argument %u.\n",
+                     n);
+    }
+#endif
+}
+
 void VerilatedContext::commandArgs(int argc, const char** argv) VL_MT_SAFE_EXCLUDES(m_argMutex) {
     const VerilatedLockGuard lock{m_argMutex};
     m_args.m_argVec.clear();  // Empty first, then add
@@ -2456,6 +2487,33 @@ void VerilatedContext::internalsDump() const VL_MT_SAFE {
     impp()->scopesDump();
     VerilatedImp::exportsDump();
     VerilatedImp::userDump();
+}
+
+void VerilatedContext::addModel(VerilatedModel* modelp) {
+    threadPoolp();  // Ensure thread pool is created, so m_threads cannot change any more
+
+    if (modelp->threads() > m_threads) {
+        std::ostringstream msg;
+        msg << "VerilatedContext has " << m_threads << " threads but model '"
+            << modelp->modelName() << "' (instantiated as '" << modelp->hierName()
+            << "') was Verilated with --threads " << modelp->threads() << ".\n";
+        const std::string str = msg.str();
+        VL_FATAL_MT(__FILE__, __LINE__, modelp->hierName(), str.c_str());
+    }
+}
+
+VerilatedVirtualBase* VerilatedContext::threadPoolp() {
+    if (m_threads == 1) return nullptr;
+#if VL_THREADED
+    if (!m_threadPool) m_threadPool.reset(new VlThreadPool{this, m_threads - 1});
+#endif
+    return m_threadPool.get();
+}
+
+VerilatedVirtualBase*
+VerilatedContext::enableExecutionProfiler(VerilatedVirtualBase* (*construct)(VerilatedContext&)) {
+    if (!m_executionProfiler) m_executionProfiler.reset(construct(*this));
+    return m_executionProfiler.get();
 }
 
 //======================================================================

--- a/include/verilated_profiler.cpp
+++ b/include/verilated_profiler.cpp
@@ -66,41 +66,66 @@ template <size_t N> static size_t roundUptoMultipleOf(size_t value) {
     return (value + mask) & ~mask;
 }
 
-VlExecutionProfiler::VlExecutionProfiler() {
+VlExecutionProfiler::VlExecutionProfiler(VerilatedContext& context)
+    : m_context{context} {
     // Setup profiling on main thread
     setupThread(0);
 }
 
-void VlExecutionProfiler::configure(const VerilatedContext& context) {
+void VlExecutionProfiler::configure() {
+
     if (VL_UNLIKELY(m_enabled)) {
         --m_windowCount;
-        if (VL_UNLIKELY(m_windowCount == context.profExecWindow())) {
+        if (VL_UNLIKELY(m_windowCount == m_context.profExecWindow())) {
             VL_DEBUG_IF(VL_DBG_MSGF("+ profile start collection\n"););
             clear();  // Clear the profile after the cache warm-up cycles.
             m_tickBegin = VL_CPU_TICK();
         } else if (VL_UNLIKELY(m_windowCount == 0)) {
             const uint64_t tickEnd = VL_CPU_TICK();
             VL_DEBUG_IF(VL_DBG_MSGF("+ profile end\n"););
-            const std::string& fileName = context.profExecFilename();
+            const std::string& fileName = m_context.profExecFilename();
             dump(fileName.c_str(), tickEnd);
             m_enabled = false;
         }
         return;
     }
 
-    const uint64_t startReq = context.profExecStart() + 1;  // + 1, so we can start at time 0
+    const uint64_t startReq = m_context.profExecStart() + 1;  // + 1, so we can start at time 0
 
-    if (VL_UNLIKELY(m_lastStartReq < startReq && VL_TIME_Q() >= context.profExecStart())) {
+    if (VL_UNLIKELY(m_lastStartReq < startReq && VL_TIME_Q() >= m_context.profExecStart())) {
         VL_DEBUG_IF(VL_DBG_MSGF("+ profile start warmup\n"););
         VL_DEBUG_IF(assert(m_windowCount == 0););
         m_enabled = true;
-        m_windowCount = context.profExecWindow() * 2;
+        m_windowCount = m_context.profExecWindow() * 2;
         m_lastStartReq = startReq;
     }
 }
 
-void VlExecutionProfiler::startWorkerSetup(VlExecutionProfiler* profilep, uint32_t threadId) {
-    profilep->setupThread(threadId);
+VerilatedVirtualBase* VlExecutionProfiler::construct(VerilatedContext& context) {
+    VlExecutionProfiler* const selfp = new VlExecutionProfiler{context};
+#if VL_THREADED
+    if (VlThreadPool* const threadPoolp = static_cast<VlThreadPool*>(context.threadPoolp())) {
+        for (int i = 0; i < threadPoolp->numThreads(); ++i) {
+            // Data to pass to worker thread initialization
+            struct Data {
+                VlExecutionProfiler* const selfp;
+                const uint32_t threadId;
+            } data{selfp, static_cast<uint32_t>(i + 1)};
+
+            // Initialize worker thread
+            threadPoolp->workerp(i)->addTask(
+                [](void* userp, bool) {
+                    Data* const datap = static_cast<Data*>(userp);
+                    datap->selfp->setupThread(datap->threadId);
+                },
+                &data);
+
+            // Wait until initializationis complete
+            threadPoolp->workerp(i)->wait();
+        }
+    }
+#endif
+    return selfp;
 }
 
 void VlExecutionProfiler::setupThread(uint32_t threadId) {

--- a/src/V3EmitCHeaders.cpp
+++ b/src/V3EmitCHeaders.cpp
@@ -251,15 +251,15 @@ class EmitCHeader final : public EmitCConstInit {
         emitTextSection(modp, VNType::atScHdr);
 
         // Open class body {{{
+        puts("\nclass ");
+        puts(prefixNameProtect(modp));
         if (const AstClass* const classp = VN_CAST(modp, Class)) {
-            puts("class ");
-            puts(prefixNameProtect(modp));
             if (classp->extendsp()) {
                 puts(" : public ");
                 puts(prefixNameProtect(classp->extendsp()->classp()));
             }
         } else {
-            puts("VL_MODULE(" + prefixNameProtect(modp) + ")");
+            puts(" final : public VerilatedModule");
         }
         puts(" {\n");
         ofp()->resetPrivate();

--- a/src/V3EmitCMake.cpp
+++ b/src/V3EmitCMake.cpp
@@ -173,7 +173,7 @@ class CMakeEmitter final {
                                     + ".cpp");
             }
         }
-        if (v3Global.opt.mtasks()) {
+        if (v3Global.opt.threads()) {
             global.emplace_back("${VERILATOR_ROOT}/include/verilated_threads.cpp");
         }
         if (v3Global.opt.usesProfiler()) {

--- a/src/V3EmitCSyms.cpp
+++ b/src/V3EmitCSyms.cpp
@@ -445,15 +445,15 @@ void EmitCSyms::emitSymHdr() {
     }
     puts("bool __Vm_didInit = false;\n");
 
-    if (v3Global.opt.profExec()) {
-        puts("\n// EXECUTION PROFILING\n");
-        puts("VlExecutionProfiler __Vm_executionProfiler;\n");
-    }
-
     if (v3Global.opt.mtasks()) {
         puts("\n// MULTI-THREADING\n");
         puts("VlThreadPool* const __Vm_threadPoolp;\n");
         puts("bool __Vm_even_cycle = false;\n");
+    }
+
+    if (v3Global.opt.profExec()) {
+        puts("\n// EXECUTION PROFILING\n");
+        puts("VlExecutionProfiler* const __Vm_executionProfilerp;\n");
     }
 
     puts("\n// MODULE INSTANCE STATE\n");
@@ -673,7 +673,6 @@ void EmitCSyms::emitSymImp() {
         puts("_vm_pgoProfiler.write(\"" + topClassName()
              + "\", _vm_contextp__->profVltFilename());\n");
     }
-    if (v3Global.opt.mtasks()) puts("delete __Vm_threadPoolp;\n");
     puts("}\n\n");
 
     // Constructor
@@ -705,12 +704,13 @@ void EmitCSyms::emitSymImp() {
         // Note we create N-1 threads in the thread pool. The thread
         // that calls eval() becomes the final Nth thread for the
         // duration of the eval call.
-        puts("    , __Vm_threadPoolp{new VlThreadPool{_vm_contextp__, "
-             + cvtToStr(v3Global.opt.threads() - 1) + ", "
-             + (v3Global.opt.profExec()
-                    ? "&__Vm_executionProfiler, &VlExecutionProfiler::startWorkerSetup"
-                    : "nullptr, nullptr")
-             + "}}\n");
+        puts("    , __Vm_threadPoolp{static_cast<VlThreadPool*>(contextp->threadPoolp())}\n");
+    }
+
+    if (v3Global.opt.profExec()) {
+        puts("    , "
+             "__Vm_executionProfilerp{static_cast<VlExecutionProfiler*>(contextp->"
+             "enableExecutionProfiler(&VlExecutionProfiler::construct))}\n");
     }
 
     puts("    // Setup module instances\n");

--- a/src/V3EmitMk.cpp
+++ b/src/V3EmitMk.cpp
@@ -116,7 +116,7 @@ public:
                             putMakeClassEntry(of, v3Global.opt.traceSourceLang() + ".cpp");
                         }
                     }
-                    if (v3Global.opt.mtasks()) putMakeClassEntry(of, "verilated_threads.cpp");
+                    if (v3Global.opt.threads()) putMakeClassEntry(of, "verilated_threads.cpp");
                     if (v3Global.opt.usesProfiler()) {
                         putMakeClassEntry(of, "verilated_profiler.cpp");
                     }

--- a/src/V3Trace.cpp
+++ b/src/V3Trace.cpp
@@ -512,8 +512,10 @@ private:
                 m_regFuncp->addStmtsp(new AstText(flp, "tracep->addChgCb(", true));
             }
             m_regFuncp->addStmtsp(new AstAddrOfCFunc(flp, funcp));
-            const string threadPool{m_parallelism > 1 ? "vlSymsp->__Vm_threadPoolp" : "nullptr"};
-            m_regFuncp->addStmtsp(new AstText(flp, ", vlSelf, " + threadPool + ");\n", true));
+            m_regFuncp->addStmtsp(new AstText(flp, ", vlSelf", true));
+            m_regFuncp->addStmtsp(
+                new AstText(flp, ", vlSelf->vlSymsp->__Vm_modelp->contextp()", true));
+            m_regFuncp->addStmtsp(new AstText(flp, ");\n", true));
         } else {
             // Sub functions
             funcp->argTypes(v3Global.opt.traceClassBase() + "::Buffer* bufp");
@@ -700,7 +702,8 @@ private:
         // Register it
         m_regFuncp->addStmtsp(new AstText(fl, "tracep->addCleanupCb(", true));
         m_regFuncp->addStmtsp(new AstAddrOfCFunc(fl, cleanupFuncp));
-        m_regFuncp->addStmtsp(new AstText(fl, ", vlSelf);\n", true));
+        m_regFuncp->addStmtsp(
+            new AstText(fl, ", vlSelf, vlSelf->vlSymsp->__Vm_modelp->contextp());\n", true));
 
         // Clear global activity flag
         cleanupFuncp->addStmtsp(

--- a/test_regress/driver.pl
+++ b/test_regress/driver.pl
@@ -579,6 +579,7 @@ sub new {
         sc_time_resolution => "SC_PS",  # Keep - PS is SystemC default
         sim_time => 1100,
         threads => -1,          # --threads (negative means auto based on scenario)
+        context_threads => 0,   # Number of threads to allocate in the context
         benchmark => $opt_benchmark,
         verbose => $opt_verbose,
         run_env => '',
@@ -974,7 +975,11 @@ sub compile {
     $self->oprint("Compile\n") if $self->{verbose};
 
     die "%Error: 'threads =>' argument must be <= 1 for vlt scenario" if $param{vlt} && $param{threads} > 1;
-    $param{threads} = ::calc_threads($Vltmt_threads) if ($param{threads} < 0 && $param{vltmt});
+    # Compute automatic parameter values
+    $param{threads} = ::calc_threads($Vltmt_threads) if $param{threads} < 0 && $param{vltmt};
+    $param{context_threads} = $param{threads} >= 1 ? $param{threads} : 1 if !$param{context_threads};
+    $self->{threads} = $param{threads};
+    $self->{context_threads} = $param{context_threads};
 
     compile_vlt_cmd(%param);
 
@@ -1795,6 +1800,7 @@ sub _make_main {
     }
 
     print $fh "    const std::unique_ptr<VerilatedContext> contextp{new VerilatedContext};\n";
+    print $fh "    contextp->threads($self->{context_threads});\n";
     print $fh "    contextp->commandArgs(argc, argv);\n";
     print $fh "    contextp->debug(" . ($self->{verilated_debug} ? 1 : 0) . ");\n";
     print $fh "    srand48(5);\n";  # Ensure determinism

--- a/test_regress/t/t_embed1.pl
+++ b/test_regress/t/t_embed1.pl
@@ -22,7 +22,8 @@ mkdir $child_dir;
         (VM_PREFIX => "$Self->{VM_PREFIX}_child",
          top_filename => "$Self->{name}_child.v",
          verilator_flags => ["-cc", "-Mdir", "${child_dir}", "--debug-check"],
-         threads => $Self->{vltmt} ? $Self->get_default_vltmt_threads() : 0
+         # Can't use multi threading (like hier blocks), but needs to be thread safe
+         threads => $Self->{vltmt} ? 1 : 0,
         );
 
     run(logfile => "${child_dir}/vlt_compile.log",

--- a/test_regress/t/t_gantt_two.cpp
+++ b/test_regress/t/t_gantt_two.cpp
@@ -1,0 +1,43 @@
+//
+// DESCRIPTION: Verilator: Verilog Multiple Model Test Module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2022 by Geza Lore.
+// SPDX-License-Identifier: CC0-1.0
+//
+
+#include <memory>
+#include "verilated.h"
+#include "Vt_gantt_two.h"
+
+int main(int argc, char** argv, char** env) {
+    srand48(5);
+
+    const std::unique_ptr<VerilatedContext> contextp{new VerilatedContext};
+#ifdef VL_THREADED
+    contextp->threads(2);
+#endif
+    contextp->commandArgs(argc, argv);
+    contextp->debug(0);
+
+    std::unique_ptr<Vt_gantt_two> topap{new Vt_gantt_two{contextp.get(), "topa"}};
+    std::unique_ptr<Vt_gantt_two> topbp{new Vt_gantt_two{contextp.get(), "topb"}};
+
+    topap->clk = false;
+    topap->eval();
+    topbp->clk = false;
+    topbp->eval();
+
+    contextp->timeInc(10);
+    while ((contextp->time() < 1100) && !contextp->gotFinish()) {
+        topap->clk = !topap->clk;
+        topap->eval();
+        topbp->clk = !topbp->clk;
+        topbp->eval();
+        contextp->timeInc(5);
+    }
+    if (!contextp->gotFinish()) {
+        vl_fatal(__FILE__, __LINE__, "main", "%Error: Timeout; never got a $finish");
+    }
+    return 0;
+}

--- a/test_regress/t/t_gantt_two.pl
+++ b/test_regress/t/t_gantt_two.pl
@@ -1,0 +1,61 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2003 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+# Test for bin/verilator_gantt,
+
+scenarios(vlt_all => 1);
+
+# It doesn't really matter what test
+# we use, so long as it runs several cycles,
+# enough for the profiling to happen:
+top_filename("t/t_gen_alw.v");
+
+compile(
+    make_top_shell => 0,
+    make_main => 0,
+    v_flags2 => ["--prof-exec --exe $Self->{t_dir}/$Self->{name}.cpp"],
+    # Checks below care about thread count, so use 2 (minimum reasonable)
+    threads => $Self->{vltmt} ? 2 : 0,
+    make_flags => 'CPPFLAGS_ADD=-DVL_NO_LEGACY',
+    );
+
+execute(
+    all_run_flags => ["+verilator+prof+exec+start+4",
+                      " +verilator+prof+exec+window+4",
+                      " +verilator+prof+exec+file+$Self->{obj_dir}/profile_exec.dat",
+                      " +verilator+prof+vlt+file+$Self->{obj_dir}/profile.vlt",
+                      ],
+    check_finished => 1,
+    );
+
+# For now, verilator_gantt still reads from STDIN
+#  (probably it should take a file, gantt.dat like verilator_profcfunc)
+# The profiling data still goes direct to the runtime's STDOUT
+#  (maybe that should go to a separate file - gantt.dat?)
+run(cmd => ["$ENV{VERILATOR_ROOT}/bin/verilator_gantt",
+            "$Self->{obj_dir}/profile_exec.dat",
+            "--vcd $Self->{obj_dir}/profile_exec.vcd",
+            "| tee $Self->{obj_dir}/gantt.log"],
+    );
+
+if ($Self->{vltmt}) {
+    file_grep("$Self->{obj_dir}/gantt.log", qr/Total threads += 2/i);
+    file_grep("$Self->{obj_dir}/gantt.log", qr/Total mtasks += 7/i);
+} else {
+    file_grep("$Self->{obj_dir}/gantt.log", qr/Total threads += 1/i);
+    file_grep("$Self->{obj_dir}/gantt.log", qr/Total mtasks += 0/i);
+}
+file_grep("$Self->{obj_dir}/gantt.log", qr/Total evals += 4/i);
+
+# Diff to itself, just to check parsing
+vcd_identical("$Self->{obj_dir}/profile_exec.vcd", "$Self->{obj_dir}/profile_exec.vcd");
+
+ok(1);
+1;

--- a/test_regress/t/t_hier_block_cmake/main.cpp
+++ b/test_regress/t/t_hier_block_cmake/main.cpp
@@ -14,8 +14,11 @@
 
 int main(int argc, char *argv[]) {
     const std::unique_ptr<VerilatedContext> contextp{new VerilatedContext};
-    std::unique_ptr<Vt_hier_block> top{new Vt_hier_block{contextp.get(), "top"}};
+#if VL_THREADED
+    contextp->threads(6);
+#endif
     contextp->commandArgs(argc, argv);
+    std::unique_ptr<Vt_hier_block> top{new Vt_hier_block{contextp.get(), "top"}};
     for (int i = 0; i < 100 && !contextp->gotFinish(); ++i) {
         top->eval();
         top->clk ^= 1;

--- a/test_regress/t/t_lib_prot_shared.pl
+++ b/test_regress/t/t_lib_prot_shared.pl
@@ -59,7 +59,8 @@ while (1) {
                              "-LDFLAGS",
                              "'-Wl,-rpath,$abs_secret_dir -L$abs_secret_dir -l$secret_prefix'"],
         xsim_flags2 => ["$secret_dir/secret.sv"],
-        threads => $Self->{vltmt} ? 1 : 0
+        threads => $Self->{vltmt} ? 1 : 0,
+        context_threads => $Self->{vltmt} ? 6 : 1
         );
 
     execute(

--- a/test_regress/t/t_threads_crazy.pl
+++ b/test_regress/t/t_threads_crazy.pl
@@ -10,20 +10,16 @@ if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); di
 
 scenarios(vltmt => 1);
 
-if ($Self->cfg_with_m32) {
-    skip("Does not work with -m32 (resource unavailable)");
-}
-
 compile(
     verilator_flags2 => ['--cc'],
-    threads => 1024
+    threads => 4,
+    context_threads => 2
     );
 
 execute(
-    check_finished => 1,
+    fails => 1
     );
 
-file_grep($Self->{run_log_filename}, qr/System has .* CPUs but.*--threads 1024/);
-
+file_grep($Self->{run_log_filename}, qr/%Error: .*\/verilated\.cpp:\d+: VerilatedContext has 2 threads but model 'Vt_threads_crazy' \(instantiated as 'top'\) was Verilated with --threads 4\./);
 ok(1);
 1;

--- a/test_regress/t/t_threads_crazy_context.pl
+++ b/test_regress/t/t_threads_crazy_context.pl
@@ -1,0 +1,36 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2003-2009 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(vlt_all => 1);
+
+if ($Self->cfg_with_m32) {
+    skip("Does not work with -m32 (resource unavailable)");
+}
+
+top_filename("t/t_threads_crazy.v");
+
+compile(
+    verilator_flags2 => ['--cc'],
+    threads => $Self->{vltmt} ? 2 : 0,
+    context_threads => 1024
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+if ($Self->{vltmt}) {
+    file_grep($Self->{run_log_filename}, qr/System has \d+ hardware threads but simulation thread count set to 1024\. This will likely cause significant slowdown\./);
+} else {
+    file_grep($Self->{run_log_filename}, qr/Verilator run-time library built without VL_THREADS\. Ignoring call to 'VerilatedContext::threads' with argument 1024\./);
+}
+
+ok(1);
+1;

--- a/test_regress/t/t_wrapper_context.cpp
+++ b/test_regress/t/t_wrapper_context.cpp
@@ -92,6 +92,8 @@ int main(int argc, char** argv, char** env) {
     std::unique_ptr<VerilatedContext> context1p{new VerilatedContext};
 
     // configuration
+    context0p->threads(1);
+    context1p->threads(1);
     context0p->fatalOnError(false);
     context1p->fatalOnError(false);
     context0p->traceEverOn(true);


### PR DESCRIPTION
WIP fix for #3454, I will need to park this for a week, sharing in case anybody would like to know the status of the issue.

TODO:
- [x] Fix occasional deadlock on shutdown of thread pool
- [x] Fix prof+exec+start and other parameters to work properly, per model, in a sound way. 