### PR TITLE
Reduce max RSS usage

### DIFF
--- a/src/V3Const.cpp
+++ b/src/V3Const.cpp
@@ -3680,7 +3680,7 @@ AstNode* V3Const::constifyEdit(AstNode* nodep) {
     return nodep;
 }
 
-AstNode* V3Const::constifyCppNode(AstNode* nodep) {
+AstNode* V3Const::constifyEditCpp(AstNode* nodep) {
     ConstVisitor visitor{ConstVisitor::PROC_CPP, /* globalPass: */ false};
     nodep = visitor.mainAcceptEdit(nodep);
     return nodep;

--- a/src/V3Const.cpp
+++ b/src/V3Const.cpp
@@ -3583,7 +3583,11 @@ public:
     }
     virtual ~ConstVisitor() override {
         if (m_doCpp) {
-            V3Stats::addStat("Optimizations, Const bit op reduction", m_statBitOpReduction);
+            if (m_globalPass) {
+                V3Stats::addStat("Optimizations, Const bit op reduction", m_statBitOpReduction);
+            } else {
+                V3Stats::addStatSum("Optimizations, Const bit op reduction", m_statBitOpReduction);
+            }
         }
     }
 
@@ -3672,6 +3676,12 @@ void V3Const::constifyCpp(AstNetlist* nodep) {
 
 AstNode* V3Const::constifyEdit(AstNode* nodep) {
     ConstVisitor visitor{ConstVisitor::PROC_V_NOWARN, /* globalPass: */ false};
+    nodep = visitor.mainAcceptEdit(nodep);
+    return nodep;
+}
+
+AstNode* V3Const::constifyCppNode(AstNode* nodep) {
+    ConstVisitor visitor{ConstVisitor::PROC_CPP, /* globalPass: */ false};
     nodep = visitor.mainAcceptEdit(nodep);
     return nodep;
 }

--- a/src/V3Const.h
+++ b/src/V3Const.h
@@ -39,7 +39,7 @@ public:
     static void constifyCpp(AstNetlist* nodep);
     // Only the current node and lower
     // Return new node that may have replaced nodep
-    static AstNode* constifyCppNode(AstNode* nodep);
+    static AstNode* constifyEditCpp(AstNode* nodep);
     // Only the current node and lower
     // Return new node that may have replaced nodep
     static AstNode* constifyEdit(AstNode* nodep);

--- a/src/V3Const.h
+++ b/src/V3Const.h
@@ -39,6 +39,9 @@ public:
     static void constifyCpp(AstNetlist* nodep);
     // Only the current node and lower
     // Return new node that may have replaced nodep
+    static AstNode* constifyCppNode(AstNode* nodep);
+    // Only the current node and lower
+    // Return new node that may have replaced nodep
     static AstNode* constifyEdit(AstNode* nodep);
     // Only the current node and lower, with special SenTree optimization
     // Return new node that may have replaced nodep

--- a/src/V3Expand.cpp
+++ b/src/V3Expand.cpp
@@ -32,6 +32,7 @@
 #include "V3Expand.h"
 #include "V3Stats.h"
 #include "V3Ast.h"
+#include "V3Const.h"
 
 #include <algorithm>
 
@@ -160,6 +161,7 @@ private:
                            new AstShiftL{fl, llowp,
                                          new AstConst{fl, static_cast<uint32_t>(loffset)},
                                          VL_EDATASIZE}}};
+            newp = V3Const::constifyCppNode(newp);
         } else {
             newp = llowp;
         }
@@ -520,8 +522,9 @@ private:
                             cleanmask.setMask(VL_BITBIT_E(destp->widthMin()));
                             newp = new AstAnd{lfl, newp, new AstConst{lfl, cleanmask}};
                         }
-
-                        addWordAssign(nodep, w, destp, new AstOr{lfl, oldvalp, newp});
+                        AstNode* const orp
+                            = V3Const::constifyCppNode(new AstOr{lfl, oldvalp, newp});
+                        addWordAssign(nodep, w, destp, orp);
                     }
                 }
                 VL_DO_DANGLING(rhsp->deleteTree(), rhsp);
@@ -541,7 +544,8 @@ private:
                 AstNode* const shifted = new AstShiftL{
                     lfl, rhsp, new AstConst{lfl, static_cast<uint32_t>(lsb)}, destp->width()};
                 AstNode* const cleaned = new AstAnd{lfl, shifted, new AstConst{lfl, cleanmask}};
-                AstNode* const newp = new AstAssign{nfl, destp, new AstOr{lfl, oldvalp, cleaned}};
+                AstNode* const orp = V3Const::constifyCppNode(new AstOr{lfl, oldvalp, cleaned});
+                AstNode* newp = new AstAssign{nfl, destp, orp};
                 insertBefore(nodep, newp);
             }
             return true;

--- a/src/V3Expand.cpp
+++ b/src/V3Expand.cpp
@@ -161,7 +161,7 @@ private:
                            new AstShiftL{fl, llowp,
                                          new AstConst{fl, static_cast<uint32_t>(loffset)},
                                          VL_EDATASIZE}}};
-            newp = V3Const::constifyCppNode(newp);
+            newp = V3Const::constifyEditCpp(newp);
         } else {
             newp = llowp;
         }
@@ -523,7 +523,7 @@ private:
                             newp = new AstAnd{lfl, newp, new AstConst{lfl, cleanmask}};
                         }
                         AstNode* const orp
-                            = V3Const::constifyCppNode(new AstOr{lfl, oldvalp, newp});
+                            = V3Const::constifyEditCpp(new AstOr{lfl, oldvalp, newp});
                         addWordAssign(nodep, w, destp, orp);
                     }
                 }
@@ -544,7 +544,7 @@ private:
                 AstNode* const shifted = new AstShiftL{
                     lfl, rhsp, new AstConst{lfl, static_cast<uint32_t>(lsb)}, destp->width()};
                 AstNode* const cleaned = new AstAnd{lfl, shifted, new AstConst{lfl, cleanmask}};
-                AstNode* const orp = V3Const::constifyCppNode(new AstOr{lfl, oldvalp, cleaned});
+                AstNode* const orp = V3Const::constifyEditCpp(new AstOr{lfl, oldvalp, cleaned});
                 AstNode* newp = new AstAssign{nfl, destp, orp};
                 insertBefore(nodep, newp);
             }


### PR DESCRIPTION
This PR reduces max RSS usage (mostly applies only to large designs) by directly constify nodes inside Expand pass.
This approach allowed us to reduce max RSS in our test design from 71.69GB to 69.39GB.

I've also checked, that this change doesn't change the resulted cpp code (in our test design).

Signed-off-by: Kamil Rakoczy <krakoczy@antmicro.com>