### PR TITLE
Escape invalid characters in VCD signal names

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -76,6 +76,7 @@ Martin Schmidt
 Martin Stadler
 Matthew Ballance
 Michael Killough
+Michael Nolan
 Michaël Lefebvre
 Mike Popoloski
 Miodrag Milanović

--- a/include/verilated_vcd_c.cpp
+++ b/include/verilated_vcd_c.cpp
@@ -507,7 +507,19 @@ void VerilatedVcd::declare(uint32_t code, const char* name, const char* wirep, b
             hiername += basename;
             basename = "";
         } else {
-            basename += *cp;
+            if('0' <= *cp && *cp <= '9')
+                basename += *cp;
+            else if('a' <= *cp && *cp <= 'z')
+                basename += *cp;
+            else if('A' <= *cp && *cp <= 'Z')
+                basename += *cp;
+            else if(*cp == '.' || *cp == '_')
+                basename += *cp;
+            else if(*cp == ':')
+                basename += "__COLON__";
+            else {
+                basename += "x" + std::to_string((int)*cp);
+            }
         }
     }
     hiername += "\t" + basename;


### PR DESCRIPTION
Fix for issue #3485, escapes colons and other unknown characters in identifiers in VCDs. I'm not sure if this is the right way to do this or if this is the place to do it. 
