### PR TITLE
Add memory header to V3File.h (for unique_ptr).

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -116,6 +116,7 @@ Unai Martinez-Corral
 Vassilis Papaefstathiou
 Veripool API Bot
 Victor Besyakov
+William D. Jones
 Wilson Snyder
 Xi Zhang
 Yoda Lee

--- a/src/V3File.h
+++ b/src/V3File.h
@@ -28,6 +28,7 @@
 #include <list>
 #include <vector>
 #include <fstream>
+#include <memory>
 
 //============================================================================
 // V3File: Create streams, recording dependency information


### PR DESCRIPTION
Similar to #3392. `<memory>` is required for `unique_ptr`, but in practice some C++ impls may transitively make `unique_ptr` available without including `<memory>`.

My compiler/OS (MinGW64 Windows) is not one of them :).