### PR TITLE
subst: delay replacing node until pass end

### DIFF
--- a/src/V3Subst.cpp
+++ b/src/V3Subst.cpp
@@ -359,6 +359,13 @@ private:
     }
     virtual void visit(AstVar*) override {}
     virtual void visit(AstConst*) override {}
+    virtual void visit(AstModule* nodep) override {
+        ++m_ops;
+        if (!nodep->isSubstOptimizable()) m_ops = SUBST_MAX_OPS_NA;
+        iterateChildren(nodep);
+        // Reduce peak memory usage by reclaiming the edited AstNodes
+        doDeletes();
+    }
     virtual void visit(AstNode* nodep) override {
         m_ops++;
         if (!nodep->isSubstOptimizable()) m_ops = SUBST_MAX_OPS_NA;


### PR DESCRIPTION
This way we can delete assignment node immediately after replacing rhs values and reduce total ram usage.

This approach allows us to remove restriction on ``SUBST_MAX_OPS_SUBST`` without drastically increase ram usage, but it increases pass time, as we need to iterate more nodes.
Some statistics on our test design (from ``stats.txt`` file). Please note, that because of such high memory usage, I'm using zram swap, so time measurements can be very biased and vary from run to run.
|         | current master | current master without ``SUBST_MAX_OPS_SUBST`` | after this patch  | after this patch keeping ``SUBST_MAX_OPS_SUBST`` |
|---------|----|----|---|---|
| subst pass time |  80.15s | 91.34s | 100.31s  | 95.71s |
| RSS after subst pass |  69 987MB |  87 558MB   | 69 051MB  | 69 062MB |
| increase in RSS from previous pass | 1 060MB | 18 636MB | 126MB | 126MB |

I've also checked, that resulted cpp files are identical, when we compare output from ``after this patch`` and ``current master without SUBST_MAX_OPS_SUBST`` (comparing ``after this patch keeping SUBST_MAX_OPS_SUBST`` to ``current master `` doesn't give identical output as we differently increase ``m_ops`` value) .


Signed-off-by: Kamil Rakoczy <krakoczy@antmicro.com>