### PR TITLE
Fix sformat string incorrectly cleared

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -33,6 +33,7 @@ Gianfranco Costamagna
 Glen Gibb
 Graham Rushton
 Guokai Chen
+Gustav Svensk
 Harald Heckmann
 Howard Su
 Huang Rui

--- a/include/verilated.cpp
+++ b/include/verilated.cpp
@@ -1460,7 +1460,6 @@ void VL_SFORMAT_X(int obits, void* destp, const char* formatp, ...) VL_MT_SAFE {
 void VL_SFORMAT_X(int obits_ignored, std::string& output, const char* formatp, ...) VL_MT_SAFE {
     if (obits_ignored) {}
     std::string temp_output;
-    temp_output = "";
     va_list ap;
     va_start(ap, formatp);
     _vl_vsformat(temp_output, formatp, ap);

--- a/include/verilated.cpp
+++ b/include/verilated.cpp
@@ -1459,11 +1459,13 @@ void VL_SFORMAT_X(int obits, void* destp, const char* formatp, ...) VL_MT_SAFE {
 
 void VL_SFORMAT_X(int obits_ignored, std::string& output, const char* formatp, ...) VL_MT_SAFE {
     if (obits_ignored) {}
-    output = "";
+    std::string temp_output;
+    temp_output = "";
     va_list ap;
     va_start(ap, formatp);
-    _vl_vsformat(output, formatp, ap);
+    _vl_vsformat(temp_output, formatp, ap);
     va_end(ap);
+    output = temp_output;
 }
 
 std::string VL_SFORMATF_NX(const char* formatp, ...) VL_MT_SAFE {

--- a/test_regress/t/t_sys_sformat.v
+++ b/test_regress/t/t_sys_sformat.v
@@ -83,6 +83,12 @@ module t;
       $swriteo(str2, 4'd12);
       if (str2 != "14") $stop;
 
+      str3 = "foo";
+      $sformat(str3, "%s", str3);  // $sformat twice so verilator does not
+      $sformat(str3, "%s", str3);  // optimize the call to $sformat(str3, "%s", "foo")
+`ifdef TEST_VERBOSE  $display("str3=%0s", str3);  `endif
+      if (str3 != "foo") $stop;
+
       $write("*-* All Finished *-*\n");
       $finish;
    end


### PR DESCRIPTION
Before this commit when the same string was used as both source and
destination in `$sformat` the output was cleared. e.g. `$sformat(a_str,
"%s", a_str)` resulted in `a_str == ""` regardless of what `a_str` was
before.

See #3515 for details