### PR TITLE
Set correct dtype in replaceShiftSame()

### DIFF
--- a/Changes
+++ b/Changes
@@ -17,6 +17,7 @@ Verilator 4.225 devel
 * Fix empty string arguments to display (#3484). [Grulfen]
 * Fix table misoptimizing away display (#3488). [Stefan Post]
 * Fix wrong bit op tree optimization (#3509). [Nathan Graybeal]
+* Fix incorrect tristate logic (#3399) [shareefj, Vighnesh Iyer]
 
 
 Verilator 4.224 2022-06-19

--- a/src/V3Const.cpp
+++ b/src/V3Const.cpp
@@ -1764,6 +1764,7 @@ private:
         lp->rhsp(lrp);
         nodep->lhsp(llp);
         nodep->rhsp(rlp);
+        nodep->dtypep(llp->dtypep());  // dtype of Biop is before shift.
         VL_DO_DANGLING(rp->deleteTree(), rp);
         VL_DO_DANGLING(rrp->deleteTree(), rrp);
         // nodep->dumpTree(cout, "  repShiftSame_new: ");

--- a/test_regress/t/t_const_opt.pl
+++ b/test_regress/t/t_const_opt.pl
@@ -19,7 +19,7 @@ execute(
     );
 
 if ($Self->{vlt}) {
-    file_grep($Self->{stats}, qr/Optimizations, Const bit op reduction\s+(\d+)/i, 14);
+    file_grep($Self->{stats}, qr/Optimizations, Const bit op reduction\s+(\d+)/i, 15);
 }
 ok(1);
 1;


### PR DESCRIPTION
See #3399 

As usual,  I push a test first, then push fix.

ext tests pass.

I noticed an optimization chance in  bit op tree, but of course it should not be included here.