### PR TITLE
Fix tristate logic when reading inout port in a module #3399

### DIFF
--- a/src/V3Tristate.cpp
+++ b/src/V3Tristate.cpp
@@ -384,7 +384,15 @@ class TristateVisitor final : public TristateBaseVisitor {
         return newp;
     }
     AstNode* getEnp(AstNode* nodep) {
-        if (!nodep->user1p()) {
+        if (nodep->user1p()) {
+            if (AstVarRef* const refp = VN_CAST(nodep, VarRef)) {
+                if (refp->varp()->isIO()) {
+                    // When reading a tri-state port, we can always use the value
+                    // because such port will have resolution logic in upper module.
+                    return newAllZerosOrOnes(nodep, true);
+                }
+            }
+        } else {
             // There's no select being built yet, so add what will become a
             // constant output enable driver of all 1's
             nodep->user1p(newAllZerosOrOnes(nodep, true));

--- a/test_regress/t/t_tri_inout.cpp
+++ b/test_regress/t/t_tri_inout.cpp
@@ -47,6 +47,16 @@ int main() {
             }
         }
     }
+    tb->SEL = tb->A = tb->B = 0;
+
+    for (int i = 0; i < 256; ++i) {
+        tb->clk = 0;
+        tb->eval();
+        tb->clk = 1;
+        tb->eval();
+        if (tb->done) break;
+        if (i + 1 == 256) pass = false;
+    }
 
     if (pass) {
         VL_PRINTF("*-* All Finished *-*\n");

--- a/test_regress/t/t_tri_inout.v
+++ b/test_regress/t/t_tri_inout.v
@@ -4,10 +4,12 @@
 // without warranty, 2008 by Lane Brooks.
 // SPDX-License-Identifier: CC0-1.0
 
-module top (input A, input B, input SEL, output Y1, output Y2, output Z);
+module top (input A, input B, input SEL, input clk, output Y1, output Y2, output Z, output done);
    io   io1(.A(A), .OE( SEL), .Z(Z), .Y(Y1));
    pass io2(.A(B), .OE(!SEL), .Z(Z), .Y(Y2));
    assign Z = 1'bz;
+
+   pad_checker u_pad_checker(.clk(clk), .done(done));
 endmodule
 
 module pass (input A, input OE, inout Z, output Y);
@@ -26,4 +28,85 @@ module io_noinline (input A, input OE, inout Z, output Y);
    assign Z = (OE) ? A : 1'bz;
    assign Y = Z;
    assign Z = 1'bz;
+endmodule
+
+
+module pad_checker(input wire clk, output wire done);
+   wire tri_pad;
+   reg [1:0] ie = '0;
+   reg [1:0] oe = '0;
+   reg [1:0] in = '0;
+   wire out_0, out_1;
+
+   pad u_pad0(.pad(tri_pad), .ie(ie[0]), .oe(oe[0]), .to_pad(in[0]), .from_pad(out_0));
+   pad u_pad1(.pad(tri_pad), .ie(ie[1]), .oe(oe[1]), .to_pad(in[1]), .from_pad(out_1));
+
+   wire bin_pad_in_0, bin_pad_in_1;
+   wire bin_pad_01, bin_pad_10;
+   wire bin_pad_en_01, bin_pad_en_10;
+   wire bin_from_pad_out_0, bin_from_pad_out_1;
+   wire bin_from_pad_en_0, bin_from_pad_en_1;
+
+   // Expectation model that simulates how Verilator solves tri-state
+   pad_binary u_pad_bin_0(.pad_in(bin_pad_in_0),
+                          .pad_out(bin_pad_01),
+                          .pad_en(bin_pad_en_01),
+                          .ie(ie[0]), .oe(oe[0]),
+                          .to_pad(in[0]),
+                          .from_pad_out(bin_from_pad_out_0),
+                          .from_pad_en(bin_from_pad_en_0));
+
+   pad_binary u_pad_bin_1(.pad_in(bin_pad_in_1),
+                          .pad_out(bin_pad_10),
+                          .pad_en(bin_pad_en_10),
+                          .ie(ie[1]),
+                          .oe(oe[1]),
+                          .to_pad(in[1]),
+                          .from_pad_out(bin_from_pad_out_1),
+                          .from_pad_en(bin_from_pad_en_1));
+
+   assign bin_pad_in_0 = (bin_pad_en_10 & bin_pad_10) | (bin_pad_en_01 & bin_pad_01);
+   assign bin_pad_in_1 = (bin_pad_en_01 & bin_pad_01) | (bin_pad_en_10 & bin_pad_10);
+
+
+   logic done_reg = 0;
+   assign done = done_reg;
+   always @(posedge clk) begin
+      if ({ie, oe, in} == 6'b111111) begin
+         done_reg <= 1'b1;
+     end else begin
+         if (out_0 != bin_from_pad_out_0) begin
+            $display("ie:%b oe:%b in:%b out0 act:%b exp:%b", ie[0], oe[0], in[0], out_0, bin_from_pad_out_0);
+            $stop;
+         end
+         if (out_1 != bin_from_pad_out_1) begin
+            $display("ie:%b oe:%b in:%b out1 act:%b exp:%b", ie[1], oe[1], in[1], out_1, bin_from_pad_out_1);
+            $stop;
+         end
+         // Let's try all combination
+         {ie, oe, in} <= {ie, oe, in} + 1;
+       end
+   end
+
+endmodule
+
+module pad(inout wire pad, input wire ie, input wire oe, input wire to_pad, output wire from_pad);
+
+   assign pad = oe ? to_pad : 1'bz;
+   assign from_pad = ie ? pad : 1'bz;
+endmodule
+
+module pad_binary(input wire pad_in,
+                  output wire pad_out,
+                  output wire pad_en,
+                  input wire ie,
+                  input wire oe,
+                  input wire to_pad,
+                  output from_pad_out,
+                  output wire from_pad_en);
+
+    assign pad_out = oe & to_pad;
+    assign pad_en = oe;
+    assign from_pad_out = ie & ((oe & to_pad) | pad_in);
+    assign from_pad_en = ie;
 endmodule


### PR DESCRIPTION
As usual, I push a test, then push the fix.

Assume this kind of I/O cell model.
```systemverilog
module pad_tri (
  output logic pad_o,
  input logic pad_i,
  input logic oe,
  input logic ie,
  inout wire pad
);
  assign pad   = oe ? pad_i : 'z;
  assign pad_o = ie ? pad   : 'z;
endmodule
```
 `pad_o` is tri-state and reads `inout` port `pad`.
But verilated model does not show `pad` value to `pad_o` even when `ie == 1'b1`.

AST after V3Tristate.cpp looks like this.
```
   1:2: ASSIGNW 0x55643d41efc0 <e1753> {c36aq} @dt=0x55643d433720@(G/w1)    
    1:2:1: COND 0x55643d41ef00 <e1751> {c36av} @dt=0x55643d433720@(G/w1)    
    1:2:1:1: VARREF 0x55643d4264e0 <e1739> {c36as} @dt=0x55643d433720@(G/w1)  oe [RV] <- VAR 0x55643d4220c0 <e1736> {c31ap} @dt=0x55643d433720@(G/w1)  oe INPUT [VSTATIC]  PORT    
    1:2:1:2: VARREF 0x55643d4265f0 <e1740> {c36ax} @dt=0x55643d433720@(G/w1)  pad_i [RV] <- VAR 0x55643d421ba0 <e1735> {c30ap} @dt=0x55643d433720@(G/w1)  pad_i INPUT [VSTATIC]  PORT    
    1:2:1:3: CONST 0x55643d432700 <e2065#> {c36bf} @dt=0x55643d433720@(G/w1)  1'h0    
    1:2:2: VARREF 0x55643d426700 <e2171#> {c36ak} @dt=0x55643d43add0@(G/w1)  pad__out__out1 [LV] => VAR 0x55643d44c200 <e2170#> {c33ao} @dt=0x55643d43add0@(G/w1)  pad__out__out1 MODULETEMP    
    1:2: ASSIGNW 0x55643d41f910 <e1768> {c37aq} @dt=0x55643d433720@(G/w1)    
    1:2:1: COND 0x55643d41f850 <e1766> {c37av} @dt=0x55643d433720@(G/w1)    
    1:2:1:1: VARREF 0x55643d426810 <e1754> {c37as} @dt=0x55643d433720@(G/w1)  ie [RV] <- VAR 0x55643d41e0e0 <e1737> {c32ap} @dt=0x55643d433720@(G/w1)  ie INPUT [VSTATIC]  PORT    
    1:2:1:2: VARREF 0x55643d426920 <e1755> {c37ax} @dt=0x55643d433720@(G/w1)  pad [RV] <- VAR 0x55643d41e530 <e1738> {c33ao} @dt=0x55643d433720@(G/w1)  pad INPUT [VSTATIC]  WIRE    
    1:2:1:3: CONST 0x55643d443ae0 <e2095#> {c37bf} @dt=0x55643d433720@(G/w1)  1'h0    
    1:2:2: VARREF 0x55643d426a30 <e2114#> {c37ak} @dt=0x55643d43add0@(G/w1)  pad_o__out__out0 [LV] => VAR 0x55643d44b9a0 <e2113#> {c29aq} @dt=0x55643d43add0@(G/w1)  pad_o__out__out0 MODULETEMP    
    1:2: VAR 0x55643d432d80 <e2079#> {c33ao} @dt=0x55643d433720@(G/w1)  pad__en OUTPUT MODULETEMP    
    1:2: VAR 0x55643d44c8b0 <e2103#> {c29aq} @dt=0x55643d433720@(G/w1)  pad_o__out OUTPUT MODULETEMP    
    1:2: VAR 0x55643d44ca10 <e2106#> {c29aq} @dt=0x55643d433720@(G/w1)  pad_o__en OUTPUT MODULETEMP    
    1:2: VAR 0x55643d44b9a0 <e2113#> {c29aq} @dt=0x55643d43add0@(G/w1)  pad_o__out__out0 MODULETEMP    
    1:2: VAR 0x55643d44bb00 <e2121#> {c29aq} @dt=0x55643d43add0@(G/w1)  pad_o__out__en0 MODULETEMP    
    1:2: ASSIGNW 0x55643d42ec70 <e2128#> {c37ak} @dt=0x55643d43add0@(G/w1)    
    1:2:1: COND 0x55643d430d40 <e2125#> {c37av} @dt=0x55643d433720@(G/w1)    
    1:2:1:1: VARREF 0x55643d4301e0 <e2097#> {c37as} @dt=0x55643d433720@(G/w1)  ie [RV] <- VAR 0x55643d41e0e0 <e1737> {c32ap} @dt=0x55643d433720@(G/w1)  ie INPUT [VSTATIC]  PORT    
    1:2:1:2: VARREF 0x55643d430880 <e2098#> {c37ax} @dt=0x55643d433720@(G/w1)  pad__en [RV] <- VAR 0x55643d432d80 <e2079#> {c33ao} @dt=0x55643d433720@(G/w1)  pad__en OUTPUT MODULETEMP    
    1:2:1:3: CONST 0x55643d41f610 <e2099#> {c37bf} @dt=0x55643d433720@(G/w1)  1'h0    
    1:2:2: VARREF 0x55643d4229e0 <e2126#> {c37ak} @dt=0x55643d43add0@(G/w1)  pad_o__out__en0 [LV] => VAR 0x55643d44bb00 <e2121#> {c29aq} @dt=0x55643d43add0@(G/w1)  pad_o__out__en0 MODULETEMP    
    1:2: ASSIGNW 0x55643d42e500 <e2153#> {c37ak} @dt=0x55643d433720@(G/w1)    
    1:2:1: VARREF 0x55643d44bd70 <e2150#> {c37ak} @dt=0x55643d43add0@(G/w1)  pad_o__out__en0 [RV] <- VAR 0x55643d44bb00 <e2121#> {c29aq} @dt=0x55643d43add0@(G/w1)  pad_o__out__en0 MODULETEMP    
    1:2:2: VARREF 0x55643d44be80 <e2151#> {c29aq} @dt=0x55643d433720@(G/w1)  pad_o__en [LV] => VAR 0x55643d44ca10 <e2106#> {c29aq} @dt=0x55643d433720@(G/w1)  pad_o__en OUTPUT MODULETEMP    
    1:2: ASSIGNW 0x55643d42e5c0 <e2160#> {c29aq} @dt=0x55643d433720@(G/w1)    
    1:2:1: AND 0x55643d42ed30 <e2157#> {c37ak} @dt=0x55643d43add0@(G/w1)    
    1:2:1:1: VARREF 0x55643d439db0 <e2134#> {c37ak} @dt=0x55643d43add0@(G/w1)  pad_o__out__out0 [RV] <- VAR 0x55643d44b9a0 <e2113#> {c29aq} @dt=0x55643d43add0@(G/w1)  pad_o__out__out0 MODULETEMP    
    1:2:1:2: VARREF 0x55643d44bc60 <e2135#> {c37ak} @dt=0x55643d43add0@(G/w1)  pad_o__out__en0 [RV] <- VAR 0x55643d44bb00 <e2121#> {c29aq} @dt=0x55643d43add0@(G/w1)  pad_o__out__en0 MODULETEMP    
    1:2:2: VARREF 0x55643d44bf90 <e2158#> {c29aq} @dt=0x55643d433720@(G/w1)  pad_o__out [LV] => VAR 0x55643d44c8b0 <e2103#> {c29aq} @dt=0x55643d433720@(G/w1)  pad_o__out OUTPUT MODULETEMP
```

Problem is `pad_o__out__en0 = ie ? pad__en : 1'b0` wheere `pad_en == oe`.

When reading a tri-state port, it will be resolved in the upper module and no need to see `oe`.

After my change, AST looks as below and simulated result looks ok. But I am not sure if the change is safe.
```
    1:2: ASSIGNW 0x55df30861fc0 <e1753> {c36aq} @dt=0x55df30876720@(G/w1)                          
    1:2:1: COND 0x55df30861f00 <e1751> {c36av} @dt=0x55df30876720@(G/w1)                            
    1:2:1:1: VARREF 0x55df308694e0 <e1739> {c36as} @dt=0x55df30876720@(G/w1)  oe [RV] <- VAR 0x55df308650c0 <e1736> {c31ap} @dt=0x55df30876720@(G/w1)  oe INPUT [VSTATIC]  PORT
    1:2:1:2: VARREF 0x55df308695f0 <e1740> {c36ax} @dt=0x55df30876720@(G/w1)  pad_i [RV] <- VAR 0x55df30864ba0 <e1735> {c30ap} @dt=0x55df30876720@(G/w1)  pad_i INPUT [VSTATIC]  PORT
    1:2:1:3: CONST 0x55df30875700 <e2065#> {c36bf} @dt=0x55df30876720@(G/w1)  1'h0                                                                                                 
    1:2:2: VARREF 0x55df30869700 <e2177#> {c36ak} @dt=0x55df3087ddd0@(G/w1)  pad__out__out1 [LV] => VAR 0x55df3088f200 <e2176#> {c33ao} @dt=0x55df3087ddd0@(G/w1)  pad__out__out1 MODULETEMP
    1:2: ASSIGNW 0x55df30862910 <e1768> {c37aq} @dt=0x55df30876720@(G/w1)             
    1:2:1: COND 0x55df30862850 <e1766> {c37av} @dt=0x55df30876720@(G/w1)                                                                                                                        
    1:2:1:1: VARREF 0x55df30869810 <e1754> {c37as} @dt=0x55df30876720@(G/w1)  ie [RV] <- VAR 0x55df308610e0 <e1737> {c32ap} @dt=0x55df30876720@(G/w1)  ie INPUT [VSTATIC]  PORT
    1:2:1:2: VARREF 0x55df30869920 <e1755> {c37ax} @dt=0x55df30876720@(G/w1)  pad [RV] <- VAR 0x55df30861530 <e1738> {c33ao} @dt=0x55df30876720@(G/w1)  pad INPUT [VSTATIC]  WIRE
    1:2:1:3: CONST 0x55df30886ae0 <e2095#> {c37bf} @dt=0x55df30876720@(G/w1)  1'h0                                                                                                 
    1:2:2: VARREF 0x55df30869a30 <e2120#> {c37ak} @dt=0x55df3087ddd0@(G/w1)  pad_o__out__out0 [LV] => VAR 0x55df3088e9a0 <e2119#> {c29aq} @dt=0x55df3087ddd0@(G/w1)  pad_o__out__out0 MODULETEMP
    1:2: VAR 0x55df30875d80 <e2079#> {c33ao} @dt=0x55df30876720@(G/w1)  pad__en OUTPUT MODULETEMP
    1:2: VAR 0x55df3088f8b0 <e2109#> {c29aq} @dt=0x55df30876720@(G/w1)  pad_o__out OUTPUT MODULETEMP                                                                                                
    1:2: VAR 0x55df3088fa10 <e2112#> {c29aq} @dt=0x55df30876720@(G/w1)  pad_o__en OUTPUT MODULETEMP  
    1:2: VAR 0x55df3088e9a0 <e2119#> {c29aq} @dt=0x55df3087ddd0@(G/w1)  pad_o__out__out0 MODULETEMP
    1:2: VAR 0x55df3088eb00 <e2127#> {c29aq} @dt=0x55df3087ddd0@(G/w1)  pad_o__out__en0 MODULETEMP      
    1:2: ASSIGNW 0x55df30871c70 <e2134#> {c37ak} @dt=0x55df3087ddd0@(G/w1)                             
    1:2:1: COND 0x55df30873d40 <e2131#> {c37av} @dt=0x55df30876720@(G/w1)                              
    1:2:1:1: VARREF 0x55df308731e0 <e2103#> {c37as} @dt=0x55df30876720@(G/w1)  ie [RV] <- VAR 0x55df308610e0 <e1737> {c32ap} @dt=0x55df30876720@(G/w1)  ie INPUT [VSTATIC]  PORT
    1:2:1:2: CONST 0x55df30861c70 <e2104#> {c37ax} @dt=0x55df30876720@(G/w1)  1'h1
    1:2:1:3: CONST 0x55df30862610 <e2105#> {c37bf} @dt=0x55df30876720@(G/w1)  1'h0
    1:2:2: VARREF 0x55df308659e0 <e2132#> {c37ak} @dt=0x55df3087ddd0@(G/w1)  pad_o__out__en0 [LV] => VAR 0x55df3088eb00 <e2127#> {c29aq} @dt=0x55df3087ddd0@(G/w1)  pad_o__out__en0 MODULETEMP
    1:2: ASSIGNW 0x55df30871500 <e2159#> {c37ak} @dt=0x55df30876720@(G/w1)                                                                                                                 
    1:2:1: VARREF 0x55df3088ed70 <e2156#> {c37ak} @dt=0x55df3087ddd0@(G/w1)  pad_o__out__en0 [RV] <- VAR 0x55df3088eb00 <e2127#> {c29aq} @dt=0x55df3087ddd0@(G/w1)  pad_o__out__en0 MODULETEMP
    1:2:2: VARREF 0x55df3088ee80 <e2157#> {c29aq} @dt=0x55df30876720@(G/w1)  pad_o__en [LV] => VAR 0x55df3088fa10 <e2112#> {c29aq} @dt=0x55df30876720@(G/w1)  pad_o__en OUTPUT MODULETEMP         
    1:2: ASSIGNW 0x55df308715c0 <e2166#> {c29aq} @dt=0x55df30876720@(G/w1)    
    1:2:1: AND 0x55df30871d30 <e2163#> {c37ak} @dt=0x55df3087ddd0@(G/w1)                                                                                                                          
    1:2:1:1: VARREF 0x55df3087cdb0 <e2140#> {c37ak} @dt=0x55df3087ddd0@(G/w1)  pad_o__out__out0 [RV] <- VAR 0x55df3088e9a0 <e2119#> {c29aq} @dt=0x55df3087ddd0@(G/w1)  pad_o__out__out0 MODULETEMP
    1:2:1:2: VARREF 0x55df3088ec60 <e2141#> {c37ak} @dt=0x55df3087ddd0@(G/w1)  pad_o__out__en0 [RV] <- VAR 0x55df3088eb00 <e2127#> {c29aq} @dt=0x55df3087ddd0@(G/w1)  pad_o__out__en0 MODULETEMP
    1:2:2: VARREF 0x55df3088ef90 <e2164#> {c29aq} @dt=0x55df30876720@(G/w1)  pad_o__out [LV] => VAR 0x55df3088f8b0 <e2109#> {c29aq} @dt=0x55df30876720@(G/w1)  pad_o__out OUTPUT MODULETEMP
```