### PR TITLE
Add handling of new tristate node types in visitCaseEq

### DIFF
--- a/test_regress/t/t_tri_and_eqcase.out
+++ b/test_regress/t/t_tri_and_eqcase.out
@@ -1,0 +1,5 @@
+%Error-UNSUPPORTED: t/t_tri_and_eqcase.v:9:28: Unsupported tristate construct: AND
+    9 |    logic b = 1'z === (clk1 & clk2);
+      |                            ^
+                    ... For error description see https://verilator.org/warn/UNSUPPORTED?v=latest
+%Error: Exiting due to

--- a/test_regress/t/t_tri_and_eqcase.pl
+++ b/test_regress/t/t_tri_and_eqcase.pl
@@ -1,0 +1,19 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2003 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(vlt => 1);
+
+lint(
+    fails => $Self->{vlt_all},
+    expect_filename => $Self->{golden_filename},
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_tri_and_eqcase.v
+++ b/test_regress/t/t_tri_and_eqcase.v
@@ -1,0 +1,17 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2022 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+module t (clk1, clk2);
+   input wire clk1, clk2;
+   logic b = 1'z === (clk1 & clk2);
+
+   always begin
+      if (!b) begin
+         $write("*-* All Finished *-*\n");
+         $finish;
+      end
+   end
+endmodule

--- a/test_regress/t/t_tri_cast_select_eqcase.pl
+++ b/test_regress/t/t_tri_cast_select_eqcase.pl
@@ -1,0 +1,21 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2022 by Antmicro Ltd. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_tri_cast_select_eqcase.v
+++ b/test_regress/t/t_tri_cast_select_eqcase.v
@@ -1,0 +1,23 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2022 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+module t (/*AUTOARG*/);
+   wire [3:0] a = 4'b10z0;
+   logic     b = 2'bzz === 2'(a[1]);
+   logic     c = 2'b0z === 2'(a[1]);
+
+   always begin
+      if (!b && c) begin
+         $write("*-* All Finished *-*\n");
+         $finish;
+      end
+      else begin
+         $write("Error: b = %b, c = %b, ", b, c);
+         $write("expected: b = 0, c = 1\n");
+         $stop;
+      end
+   end
+endmodule

--- a/test_regress/t/t_tri_cond_eqcase.pl
+++ b/test_regress/t/t_tri_cond_eqcase.pl
@@ -1,0 +1,21 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2022 by Antmicro Ltd. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_tri_cond_eqcase.v
+++ b/test_regress/t/t_tri_cond_eqcase.v
@@ -1,0 +1,26 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2022 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+module t (input clk);
+   wire a, b;
+   // Input port is needed to omit optimizations
+   // based on its value. To keep test simple,
+   // let's imitate change of value by just swapping the values of COND
+   assign a = 'z === (clk ? 1'b1 : 1'bz);
+   assign b = 'z === (clk ? 1'bz : 1'b1);
+
+   always begin
+      if (a && !b) begin
+         $write("*-* All Finished *-*\n");
+         $finish;
+      end
+      else begin
+         $write("Error: a = %b, b = %b, ", a, b);
+         $write("expected: a = 1, b = 0\n");
+         $stop;
+      end
+   end
+endmodule

--- a/test_regress/t/t_tri_select_eqcase.pl
+++ b/test_regress/t/t_tri_select_eqcase.pl
@@ -1,0 +1,21 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2022 by Antmicro Ltd. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_tri_select_eqcase.v
+++ b/test_regress/t/t_tri_select_eqcase.v
@@ -1,0 +1,23 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2022 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+module t (/*AUTOARG*/);
+   wire [3:0] a = 4'b11z1;
+   logic     b = 1'bz === a[1];
+   logic     c = 1'bz === a[2];
+
+   always begin
+      if (b && !c) begin
+         $write("*-* All Finished *-*\n");
+         $finish;
+      end
+      else begin
+         $write("Error: b = %b, c = %b, ", b, c);
+         $write("expected: b = 1, c = 0\n");
+         $stop;
+      end
+   end
+endmodule


### PR DESCRIPTION
These node types are:
* AstSel
* AstExtend
* AstCond
and I also made use of user1p if it exists.

Signed-off-by: Ryszard Rozak <rrozak@antmicro.com>