### PR TITLE
Handle case in EqCase when constp doesn't have user1p()

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -99,6 +99,7 @@ Rafal Kapuscik
 Raynard Qiao
 Richard Myers
 Rupert Swarbrick
+Ryszard Rozak
 Samuel Riedel
 Sean Cross
 Sebastien Van Cauwenberghe

--- a/test_regress/t/t_tri_cond_eqcase_with_1.pl
+++ b/test_regress/t/t_tri_cond_eqcase_with_1.pl
@@ -1,0 +1,21 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2022 by Antmicro Ltd. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_tri_cond_eqcase_with_1.v
+++ b/test_regress/t/t_tri_cond_eqcase_with_1.v
@@ -1,0 +1,21 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2022 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+module t (/*AUTOARG*/
+   // Inputs
+   clk
+   );
+   input clk;
+   wire  a;
+   assign a = 1 === (clk ? 1 : 1'bz);
+
+   always begin
+      if (!a) begin
+         $write("*-* All Finished *-*\n");
+         $finish;
+      end
+   end
+endmodule

--- a/test_regress/t/t_tri_eqcase_input.pl
+++ b/test_regress/t/t_tri_eqcase_input.pl
@@ -1,0 +1,21 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2022 by Antmicro Ltd. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_tri_eqcase_input.v
+++ b/test_regress/t/t_tri_eqcase_input.v
@@ -1,0 +1,20 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2022 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+module t (/*AUTOARG*/
+   // Inputs
+   clk
+   );
+   input clk;
+   wire a = 1'bz === clk;
+
+   always begin
+      if (a) begin
+         $write("*-* All Finished *-*\n");
+         $finish;
+      end
+   end
+endmodule


### PR DESCRIPTION
In this PR I added support of case when LHS of AstCaseEq is constant and not marked as tristate, but RHS is a tristate.
I also included test that contains statement that is supported by this commit.
This PR can be merged independently from https://github.com/verilator/verilator/pull/3545.