### PR TITLE
Fix converting subclasses to string

### DIFF
--- a/src/V3Common.cpp
+++ b/src/V3Common.cpp
@@ -87,10 +87,10 @@ static void makeToStringMiddle(AstClass* nodep) {
         }
     }
     if (nodep->extendsp() && nodep->extendsp()->classp()->user1()) {
-        string stmt = "out += \"";
+        string stmt = "out += ";
         if (!comma.empty()) stmt += "\", \"+ ";
         // comma = ", ";  // Nothing further so not needed
-        stmt += nodep->extendsp()->dtypep()->nameProtect();
+        stmt += EmitCBaseVisitor::prefixNameProtect(nodep->extendsp()->dtypep());
         stmt += "::to_string_middle();\n";
         nodep->user1(true);  // So what we extend dumps this
         funcp->addStmtsp(new AstCStmt{nodep->fileline(), stmt});
@@ -104,13 +104,13 @@ static void makeToStringMiddle(AstClass* nodep) {
 
 void V3Common::commonAll() {
     UINFO(2, __FUNCTION__ << ": " << endl);
+    // NODE STATE
+    // Entire netlist:
+    //  AstClass::user1()     -> bool.  True if class needs to_string dumper
+    const VNUser1InUse m_inuser1;
     // Create common contents for each module
     for (AstNode* nodep = v3Global.rootp()->modulesp(); nodep; nodep = nodep->nextp()) {
         if (AstClass* const classp = VN_CAST(nodep, Class)) {
-            // NODE STATE
-            // Entire netlist:
-            //  AstClass::user1()     -> bool.  True if class needs to_string dumper
-            const VNUser1InUse m_inuser1;
             // Create ToString methods
             makeVlToString(classp);
             makeToString(classp);


### PR DESCRIPTION
The code was unreachable and produced invalid C++.
Submitting just this single patch, as discussed in https://github.com/verilator/verilator/pull/3541#issuecomment-1218126808