### PR TITLE
get-wrote-bytes added a simple getter to access the the number of byte…

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -32,6 +32,7 @@ Geza Lore
 Gianfranco Costamagna
 Glen Gibb
 Graham Rushton
+Gregory Carver
 Guokai Chen
 Gustav Svensk
 Harald Heckmann

--- a/include/verilated_vcd_c.h
+++ b/include/verilated_vcd_c.h
@@ -126,6 +126,7 @@ public:
     // ACCESSORS
     // Set size in megabytes after which new file should be created
     void rolloverMB(uint64_t rolloverMB) { m_rolloverMB = rolloverMB; }
+    uint64_t getWroteBytes() { return m_wroteBytes; }
 
     // METHODS - All must be thread safe
     // Open the file; call isOpen() to see if errors
@@ -302,6 +303,8 @@ public:
     void set_time_resolution(const std::string& unit) VL_MT_SAFE {
         m_sptrace.set_time_resolution(unit);
     }
+    uint64_t get_wrote_bytes() { return m_sptrace.getWroteBytes(); }
+
     // Set variables to dump, using $dumpvars format
     // If level = 0, dump everything and hier is then ignored
     void dumpvars(int level, const std::string& hier) VL_MT_SAFE {

--- a/include/verilated_vcd_c.h
+++ b/include/verilated_vcd_c.h
@@ -126,7 +126,7 @@ public:
     // ACCESSORS
     // Set size in megabytes after which new file should be created
     void rolloverMB(uint64_t rolloverMB) { m_rolloverMB = rolloverMB; }
-    uint64_t getWroteBytes() { return m_wroteBytes; }
+    uint64_t wroteBytes() const { return m_wroteBytes; }
 
     // METHODS - All must be thread safe
     // Open the file; call isOpen() to see if errors


### PR DESCRIPTION
…s that's been written to file so far.

We appreciate your contributing to Verilator.  If this is your first commit, please add your name to docs/CONTRIBUTORS, and read our contributing guidelines in docs/CONTRIBUTING.rst.
