### PR TITLE
Handle `AstMemberSel` in `V3EmitV.cpp`

### DIFF
--- a/src/V3EmitV.cpp
+++ b/src/V3EmitV.cpp
@@ -494,6 +494,11 @@ class EmitVBaseVisitor VL_NOT_FINAL : public EmitCBaseVisitor {
         emitVerilogFormat(nodep, nodep->emitVerilog(), nodep->lhsp(), nodep->rhsp(),
                           nodep->thsp());
     }
+    virtual void visit(AstMemberSel* nodep) override {
+        iterate(nodep->fromp());
+        puts(".");
+        puts(nodep->prettyName());
+    }
     virtual void visit(AstAttrOf* nodep) override {
         putfs(nodep, "$_ATTROF(");
         iterateAndNextConstNull(nodep->fromp());


### PR DESCRIPTION
Pre-PR to https://github.com/verilator/verilator/pull/3363 and https://github.com/verilator/verilator/pull/3550. Adds `AstMemberSel` handling to `V3EmitV` so it's properly printed in trigger debug info.

Signed-off-by: Krzysztof Bieganski <kbieganski@antmicro.com>
