### PR TITLE
Fix `forall` return type

### DIFF
--- a/src/V3Ast.h
+++ b/src/V3Ast.h
@@ -2043,7 +2043,7 @@ public:
 
     // Same as above, but for 'const' nodes
     template <typename T_Node>
-    void forall(std::function<bool(const T_Node*)> p) const {
+    bool forall(std::function<bool(const T_Node*)> p) const {
         static_assert(checkTypeParameter<T_Node>(), "Invalid type parameter 'T_Node'");
         return predicateImpl<const T_Node, /* Default: */ true>(this, p);
     }


### PR DESCRIPTION
Fixes the return type of one of the `AstNode::forall` functions.

Signed-off-by: Krzysztof Bieganski <kbieganski@antmicro.com>