### PR TITLE
V3Width: Process aruments in non-static method call

### DIFF
--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -3218,6 +3218,7 @@ private:
                     nodep->dtypeFrom(ftaskp);
                     nodep->classOrPackagep(classp);
                     if (VN_IS(ftaskp, Task)) nodep->makeStatement();
+                    processFTaskRefArgs(nodep);
                 }
                 return;
             }

--- a/test_regress/t/t_class_method_str_literal.pl
+++ b/test_regress/t/t_class_method_str_literal.pl
@@ -1,0 +1,21 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2003 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_class_method_str_literal.v
+++ b/test_regress/t/t_class_method_str_literal.v
@@ -1,0 +1,16 @@
+module t;
+
+class T;
+    function automatic void print_str(input string a_string);
+        $display(a_string);
+    endfunction
+endclass
+
+
+initial begin
+    T t_c = new;
+    t_c.print_str("print me");
+    $write("*-* All Finished *-*\n");
+    $finish;
+end
+endmodule

--- a/test_regress/t/t_class_method_str_literal.v
+++ b/test_regress/t/t_class_method_str_literal.v
@@ -1,3 +1,9 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2022 by Wilson Snyder.
+// SPDX-License-Identifier: CC0-1.0
+
 module t;
 
 class T;

--- a/test_regress/t/t_class_method_str_literal.v
+++ b/test_regress/t/t_class_method_str_literal.v
@@ -4,12 +4,18 @@ class T;
     function automatic void print_str(input string a_string);
         $display(a_string);
     endfunction
+
+    static function automatic void static_print_str(input string a_string);
+        $display(a_string);
+    endfunction
 endclass
 
 
 initial begin
     T t_c = new;
-    t_c.print_str("print me");
+    t_c.print_str("function though member");
+    t_c.static_print_str("static function through member");
+    T::static_print_str("static function through class");
     $write("*-* All Finished *-*\n");
     $finish;
 end


### PR DESCRIPTION
Fix for #3547 

I'm not very confident in this solution.
I tried adding a call to `processFTaskRefArgs` in the end of `visit(AstMethodCall* nodep)` in V3Width.cpp and that solved the issue in #3547, but other tests broke. I also tried adding the call for both static and not static class methods, and that also broke a few tests.

My gut feeling is that the argument should always be processed when processing a method call, but that broke several tests. 
My solution feels a bit strange, because the arguments are only processed for non-static class method calls.