### PR TITLE
Build verilator_bin with -O3

### DIFF
--- a/src/Makefile_obj.in
+++ b/src/Makefile_obj.in
@@ -79,7 +79,7 @@ ifeq ($(VL_NOOPT),1)
 CPPFLAGS += -O0
 else ifeq ($(VL_DEBUG),)
 # Optimize
-CPPFLAGS += -O2
+CPPFLAGS += -O3
 else
 # Debug
 CPPFLAGS += @CFG_CXXFLAGS_DEBUG@ -DVL_DEBUG -D_GLIBCXX_DEBUG


### PR DESCRIPTION
Do you have any objection against this? Does not make a lot of difference, but is a consistent few percent throughout. Building Verilator itself I have not noticed a significant difference so I can't see any harm.