### PR TITLE
Fix fork debug output

### DIFF
--- a/include/verilated_timing.cpp
+++ b/include/verilated_timing.cpp
@@ -148,7 +148,8 @@ void VlTriggerScheduler::dump(const char* eventDescription) {
 // VlForkSync:: Methods
 
 void VlForkSync::done(const char* filename, int linenum) {
-    VL_DEBUG_IF(VL_DBG_MSGF("             Process forked at %s:%d finished", filename, linenum););
+    VL_DEBUG_IF(
+        VL_DBG_MSGF("             Process forked at %s:%d finished\n", filename, linenum););
     if (m_join->m_counter > 0) m_join->m_counter--;
     if (m_join->m_counter == 0) m_join->m_susp.resume();
 }

--- a/include/verilated_timing.h
+++ b/include/verilated_timing.h
@@ -283,7 +283,7 @@ public:
     auto join(const char* filename, int linenum) {
         assert(m_join);
         VL_DEBUG_IF(
-            VL_DBG_MSGF("             Awaiting join of fork at: %s:%d", filename, linenum););
+            VL_DBG_MSGF("             Awaiting join of fork at: %s:%d\n", filename, linenum););
         struct Awaitable {
             const std::shared_ptr<VlJoin> join;  // Join to await on
             bool await_ready() { return join->m_counter == 0; }  // Suspend if join still exists

--- a/test_regress/t/t_timing_debug2.out
+++ b/test_regress/t/t_timing_debug2.out
@@ -11,7 +11,8 @@
 -V{t#,#}+    Vt_timing_debug2___024root____Vfork___h########__0__1
 -V{t#,#}+    Vt_timing_debug2___024root____Vfork___h########__0__2
 -V{t#,#}+    Vt_timing_debug2___024root____Vfork___h########__0__3
--V{t#,#}             Awaiting join of fork at: t/t_timing_fork_join.v:13-V{t0,14}+    Vt_timing_debug2___024root___eval_initial__TOP__1
+-V{t#,#}             Awaiting join of fork at: t/t_timing_fork_join.v:13
+-V{t#,#}+    Vt_timing_debug2___024root___eval_initial__TOP__1
 -V{t#,#}+    Vt_timing_debug2___024root___eval_settle
 -V{t#,#}+ Eval
 -V{t#,#}+    Vt_timing_debug2___024root___eval
@@ -45,7 +46,8 @@
 -V{t#,#}         Resuming delayed processes
 -V{t#,#}             Resuming: Process waiting at t/t_timing_fork_join.v:79
 [2] fork..join process 3
--V{t#,#}             Process forked at t/t_timing_fork_join.v:17 finished-V{t0,48}+    Vt_timing_debug2___024root___eval_act
+-V{t#,#}             Process forked at t/t_timing_fork_join.v:17 finished
+-V{t#,#}+    Vt_timing_debug2___024root___eval_act
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
 -V{t#,#}         No triggers active
@@ -72,7 +74,8 @@
 -V{t#,#}         Resuming delayed processes
 -V{t#,#}             Resuming: Process waiting at t/t_timing_fork_join.v:19
 [4] fork..join process 2
--V{t#,#}             Process forked at t/t_timing_fork_join.v:16 finished-V{t0,75}+    Vt_timing_debug2___024root___eval_act
+-V{t#,#}             Process forked at t/t_timing_fork_join.v:16 finished
+-V{t#,#}+    Vt_timing_debug2___024root___eval_act
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
 -V{t#,#}         No triggers active
@@ -98,7 +101,8 @@
 -V{t#,#}         Resuming delayed processes
 -V{t#,#}             Resuming: Process waiting at t/t_timing_fork_join.v:17
 [8] fork..join process 1
--V{t#,#}             Process forked at t/t_timing_fork_join.v:15 finished-V{t0,101}+    Vt_timing_debug2___024root___eval_act
+-V{t#,#}             Process forked at t/t_timing_fork_join.v:15 finished
+-V{t#,#}+    Vt_timing_debug2___024root___eval_act
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
 -V{t#,#}         No triggers active
@@ -127,7 +131,8 @@
 -V{t#,#}+    Vt_timing_debug2___024root____Vfork___h########__0__0
 -V{t#,#}+    Vt_timing_debug2___024root____Vfork___h########__0__1
 -V{t#,#}+    Vt_timing_debug2___024root____Vfork___h########__0__2
--V{t#,#}             Awaiting join of fork at: t/t_timing_fork_join.v:21-V{t0,129}+    Vt_timing_debug2___024root___eval_act
+-V{t#,#}             Awaiting join of fork at: t/t_timing_fork_join.v:21
+-V{t#,#}+    Vt_timing_debug2___024root___eval_act
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
 -V{t#,#}         No triggers active
@@ -154,7 +159,8 @@
 -V{t#,#}         Resuming delayed processes
 -V{t#,#}             Resuming: Process waiting at t/t_timing_fork_join.v:24
 [20] fork..join process 7
--V{t#,#}             Process forked at t/t_timing_fork_join.v:24 finished-V{t0,156}+    Vt_timing_debug2___024root___eval_act
+-V{t#,#}             Process forked at t/t_timing_fork_join.v:24 finished
+-V{t#,#}+    Vt_timing_debug2___024root___eval_act
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
 -V{t#,#}         No triggers active
@@ -180,7 +186,8 @@
 -V{t#,#}         Resuming delayed processes
 -V{t#,#}             Resuming: Process waiting at t/t_timing_fork_join.v:23
 [24] fork..join process 6
--V{t#,#}             Process forked at t/t_timing_fork_join.v:23 finished-V{t0,182}+    Vt_timing_debug2___024root___eval_act
+-V{t#,#}             Process forked at t/t_timing_fork_join.v:23 finished
+-V{t#,#}+    Vt_timing_debug2___024root___eval_act
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
 -V{t#,#}         No triggers active
@@ -205,9 +212,11 @@
 -V{t#,#}         Resuming delayed processes
 -V{t#,#}             Resuming: Process waiting at t/t_timing_fork_join.v:22
 [32] fork..join process 5
--V{t#,#}             Process forked at t/t_timing_fork_join.v:22 finished-V{t0,207}             Resuming: Process waiting at (null):0
+-V{t#,#}             Process forked at t/t_timing_fork_join.v:22 finished
+-V{t#,#}             Resuming: Process waiting at (null):0
 [32] fork..join in fork ends
--V{t#,#}             Process forked at t/t_timing_fork_join.v:19 finished-V{t0,209}             Resuming: Process waiting at (null):0
+-V{t#,#}             Process forked at t/t_timing_fork_join.v:19 finished
+-V{t#,#}             Resuming: Process waiting at (null):0
 -V{t#,#}+    Vt_timing_debug2___024root___eval_act
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
@@ -309,7 +318,8 @@ fork..join_any process 1
 -V{t#,#}+    Vt_timing_debug2___024root____Vfork___h########__0__0
 -V{t#,#}+    Vt_timing_debug2___024root____Vfork___h########__0__1
 -V{t#,#}         Suspending process waiting for @([event] t.e1) at t/t_timing_fork_join.v:44
--V{t#,#}             Awaiting join of fork at: t/t_timing_fork_join.v:41-V{t0,308}+    Vt_timing_debug2___024root___eval_act
+-V{t#,#}             Awaiting join of fork at: t/t_timing_fork_join.v:41
+-V{t#,#}+    Vt_timing_debug2___024root___eval_act
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
 -V{t#,#}         No triggers active
@@ -336,7 +346,8 @@ fork..join_any process 1
 -V{t#,#}         Resuming delayed processes
 -V{t#,#}             Resuming: Process waiting at t/t_timing_fork_join.v:42
 fork..join_any process 1
--V{t#,#}             Process forked at t/t_timing_fork_join.v:42 finished-V{t0,335}             Resuming: Process waiting at (null):0
+-V{t#,#}             Process forked at t/t_timing_fork_join.v:42 finished
+-V{t#,#}             Resuming: Process waiting at (null):0
 back in main process
 -V{t#,#}+    Vt_timing_debug2___024root___eval_act
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
@@ -376,7 +387,8 @@ back in main process
 -V{t#,#}         Resuming processes waiting for @([event] t.e1)
 -V{t#,#}             Resuming: Process waiting at t/t_timing_fork_join.v:44
 fork..join_any process 2
--V{t#,#}             Process forked at t/t_timing_fork_join.v:43 finished-V{t0,374}         Committing processes waiting for @([event] t.e1):
+-V{t#,#}             Process forked at t/t_timing_fork_join.v:43 finished
+-V{t#,#}         Committing processes waiting for @([event] t.e1):
 -V{t#,#}           - Process waiting at t/t_timing_fork_join.v:51
 -V{t#,#}+    Vt_timing_debug2___024root___eval_act
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act


### PR DESCRIPTION
Fixes an issue with some fork-related debug prints not putting a newline at the end. See the changed test output.

Signed-off-by: Krzysztof Bieganski <kbieganski@antmicro.com>