### PR TITLE
Fix `co_await VlNow{}` being added too many times

### DIFF
--- a/src/V3SchedTiming.cpp
+++ b/src/V3SchedTiming.cpp
@@ -264,7 +264,7 @@ void transformForks(AstNetlist* const netlistp) {
                     // We can just pass it to the new function
                 } else if (m_forkp->joinType().join()) {
                     // If it's fork..join, we can refer to variables from the parent process
-                    if (m_funcp->user1SetOnce()) {  // Only do this once per function
+                    if (!m_funcp->user1SetOnce()) {  // Only do this once per function
                         // Move all locals to the heap before the fork
                         auto* const awaitp = new AstCAwait{
                             m_forkp->fileline(), new AstCStmt{m_forkp->fileline(), "VlNow{}"}};


### PR DESCRIPTION
Fixes `co_await VlNow{}` being added too many times in `transformForks` (or not at all).

Pre-PR to #3599.

Signed-off-by: Krzysztof Bieganski <kbieganski@antmicro.com>