### PR TITLE
Add template version of `AstNode::addNext`

### DIFF
--- a/src/V3Ast.h
+++ b/src/V3Ast.h
@@ -1760,8 +1760,26 @@ public:
     // METHODS - Tree modifications
     // Returns nodep, adds newp to end of nodep's list
     static AstNode* addNext(AstNode* nodep, AstNode* newp);
+    template <typename T_NodeResult, typename T_NodeNext>
+    static typename std::enable_if<std::is_base_of<T_NodeResult, T_NodeNext>::value,
+                                   T_NodeResult*>::type
+    addNext(T_NodeResult* nodep, T_NodeNext* newp) {
+        static_assert(std::is_base_of<AstNode, T_NodeResult>::value,
+                      "T_NodeResult must derive from AstNode.");
+        return reinterpret_cast<T_NodeResult*>(
+            addNext(static_cast<AstNode*>(nodep), static_cast<AstNode*>(newp)));
+    }
     // Returns nodep, adds newp (maybe nullptr) to end of nodep's list
     static AstNode* addNextNull(AstNode* nodep, AstNode* newp);
+    template <typename T_NodeResult, typename T_NodeNext>
+    static typename std::enable_if<std::is_base_of<T_NodeResult, T_NodeNext>::value,
+                                   T_NodeResult*>::type
+    addNextNull(T_NodeResult* nodep, T_NodeNext* newp) {
+        static_assert(std::is_base_of<AstNode, T_NodeResult>::value,
+                      "T_NodeResult must derive from AstNode.");
+        return reinterpret_cast<T_NodeResult*>(
+            addNextNull(static_cast<AstNode*>(nodep), static_cast<AstNode*>(newp)));
+    }
     inline AstNode* addNext(AstNode* newp) { return addNext(this, newp); }
     inline AstNode* addNextNull(AstNode* newp) { return addNextNull(this, newp); }
     void addNextHere(AstNode* newp);  // Insert newp at this->nextp

--- a/src/V3Const.cpp
+++ b/src/V3Const.cpp
@@ -2079,7 +2079,7 @@ private:
             AstSel* const sel2p = new AstSel(conp->fileline(), rhs2p, lsb2, msb2 - lsb2 + 1);
             // Make new assigns of same flavor as old one
             //*** Not cloneTree; just one node.
-            AstNode* newp = nullptr;
+            AstNodeAssign* newp = nullptr;
             if (!need_temp) {
                 AstNodeAssign* const asn1ap = VN_AS(nodep->cloneType(lc1p, sel1p), NodeAssign);
                 AstNodeAssign* const asn2ap = VN_AS(nodep->cloneType(lc2p, sel2p), NodeAssign);

--- a/src/V3ParseGrammar.cpp
+++ b/src/V3ParseGrammar.cpp
@@ -67,10 +67,10 @@ void V3ParseImp::parserClear() {
 //======================================================================
 // V3ParseGrammar functions requiring bison state
 
-AstNode* V3ParseGrammar::argWrapList(AstNode* nodep) {
+AstArg* V3ParseGrammar::argWrapList(AstNode* nodep) {
     // Convert list of expressions to list of arguments
     if (!nodep) return nullptr;
-    AstNode* outp = nullptr;
+    AstArg* outp = nullptr;
     AstBegin* const tempp = new AstBegin(nodep->fileline(), "[EditWrapper]", nodep);
     while (nodep) {
         AstNode* const nextp = nodep->nextp();

--- a/src/V3Slice.cpp
+++ b/src/V3Slice.cpp
@@ -139,12 +139,13 @@ class SliceVisitor final : public VNVisitor {
                 // Left and right could have different msb/lsbs/endianness, but #elements is common
                 // and all variables are realigned to start at zero
                 // Assign of a little endian'ed slice to a big endian one must reverse the elements
-                AstNode* newlistp = nullptr;
+                AstNodeAssign* newlistp = nullptr;
                 const int elements = arrayp->rangep()->elementsConst();
                 for (int offset = 0; offset < elements; ++offset) {
-                    AstNode* const newp = nodep->cloneType  // AstNodeAssign
-                                          (cloneAndSel(nodep->lhsp(), elements, offset),
-                                           cloneAndSel(nodep->rhsp(), elements, offset));
+                    AstNodeAssign* const newp
+                        = VN_AS(nodep->cloneType(cloneAndSel(nodep->lhsp(), elements, offset),
+                                                 cloneAndSel(nodep->rhsp(), elements, offset)),
+                                NodeAssign);
                     if (debug() >= 9) newp->dumpTree(cout, "-new ");
                     newlistp = AstNode::addNextNull(newlistp, newp);
                 }

--- a/src/verilog.y
+++ b/src/verilog.y
@@ -91,7 +91,7 @@ public:
     }
 
     // METHODS
-    AstNode* argWrapList(AstNode* nodep);
+    AstArg* argWrapList(AstNode* nodep);
     bool allTracingOn(FileLine* fl) {
         return v3Global.opt.trace() && m_tracingParse && fl->tracingOn();
     }


### PR DESCRIPTION
Adds a template version of `AstNode::addNext` for better code ergonomics. No functional change intended.

Pre-PR to #3599.

Signed-off-by: Krzysztof Bieganski <kbieganski@antmicro.com>