### PR TITLE
Add stats tracking for `V3Undriven`.

### DIFF
--- a/src/V3Undriven.cpp
+++ b/src/V3Undriven.cpp
@@ -30,6 +30,7 @@
 
 #include "V3Ast.h"
 #include "V3Global.h"
+#include "V3Stats.h"
 #include "V3String.h"
 
 #include <algorithm>
@@ -475,4 +476,5 @@ public:
 void V3Undriven::undrivenAll(AstNetlist* nodep) {
     UINFO(2, __FUNCTION__ << ": " << endl);
     { UndrivenVisitor{nodep}; }
+    if (v3Global.opt.stats()) V3Stats::statsStage("undriven");
 }


### PR DESCRIPTION
There are no separate `--stats` printed for `V3Undriven`, which can be confusing. Example for a bigger design before this change:
```
  …
  Stage, Elapsed time (sec), 013_const                 0.700623
  Stage, Elapsed time (sec), 014_assertpre            35.279789
  Stage, Elapsed time (sec), 015_assert                1.206461
  …
```
Seems like `AssertPre` is taking a relatively long time, which doesn't make much sense. After this change:
```
  …
  Stage, Elapsed time (sec), 013_const                 0.698918
  Stage, Elapsed time (sec), 014_undriven             34.109472
  Stage, Elapsed time (sec), 015_assertpre             0.673485
  Stage, Elapsed time (sec), 016_assert                1.218875 
  …
```
Signed-off-by: Krzysztof Bieganski <kbieganski@antmicro.com>