### PR TITLE
Handle signal strengths when the strongest signal is constant

### DIFF
--- a/src/V3Ast.h
+++ b/src/V3Ast.h
@@ -732,6 +732,10 @@ public:
         return (m_e == WIRE || m_e == WREAL || m_e == IMPLICITWIRE || m_e == TRIWIRE || m_e == TRI0
                 || m_e == TRI1 || m_e == PORT || m_e == SUPPLY0 || m_e == SUPPLY1 || m_e == VAR);
     }
+    bool isNet() const {
+        return (m_e == WIRE || m_e == IMPLICITWIRE || m_e == TRIWIRE || m_e == TRI0 || m_e == TRI1
+                || m_e == SUPPLY0 || m_e == SUPPLY1);
+    }
     bool isContAssignable() const {  // In Verilog, always ok in SystemVerilog
         return (m_e == SUPPLY0 || m_e == SUPPLY1 || m_e == WIRE || m_e == WREAL
                 || m_e == IMPLICITWIRE || m_e == TRIWIRE || m_e == TRI0 || m_e == TRI1
@@ -972,6 +976,32 @@ inline bool operator==(const VParseRefExp& lhs, const VParseRefExp& rhs) {
 inline bool operator==(const VParseRefExp& lhs, VParseRefExp::en rhs) { return lhs.m_e == rhs; }
 inline bool operator==(VParseRefExp::en lhs, const VParseRefExp& rhs) { return lhs == rhs.m_e; }
 inline std::ostream& operator<<(std::ostream& os, const VParseRefExp& rhs) {
+    return os << rhs.ascii();
+}
+
+//######################################################################
+
+class VStrength final {
+public:
+    enum en : uint8_t { HIGHZ, SMALL, MEDIUM, WEAK, LARGE, PULL, STRONG, SUPPLY };
+    enum en m_e;
+
+    inline VStrength(en strengthLevel)
+        : m_e(strengthLevel) {}
+    explicit inline VStrength(int _e)
+        : m_e(static_cast<en>(_e)) {}  // Need () or GCC 4.8 false warning
+
+    operator en() const { return m_e; }
+    const char* ascii() const {
+        static const char* const names[]
+            = {"highz", "small", "medium", "weak", "large", "pull", "strong", "supply"};
+        return names[m_e];
+    }
+};
+inline bool operator==(const VStrength& lhs, const VStrength& rhs) { return lhs.m_e == rhs.m_e; }
+inline bool operator==(const VStrength& lhs, VStrength::en rhs) { return lhs.m_e == rhs; }
+inline bool operator==(VStrength::en lhs, const VStrength& rhs) { return lhs == rhs.m_e; }
+inline std::ostream& operator<<(std::ostream& os, const VStrength& rhs) {
     return os << rhs.ascii();
 }
 

--- a/src/V3AstNodes.cpp
+++ b/src/V3AstNodes.cpp
@@ -1786,6 +1786,10 @@ void AstSenItem::dump(std::ostream& str) const {
     this->AstNode::dump(str);
     str << " [" << edgeType().ascii() << "]";
 }
+void AstStrengthSpec::dump(std::ostream& str) const {
+    this->AstNode::dump(str);
+    str << " (" << m_s0.ascii() << ", " << m_s1.ascii() << ")";
+}
 void AstParseRef::dump(std::ostream& str) const {
     this->AstNode::dump(str);
     str << " [" << expect().ascii() << "]";

--- a/src/V3Const.cpp
+++ b/src/V3Const.cpp
@@ -2853,6 +2853,7 @@ private:
         if (m_wremove && !m_params && m_doNConst && m_modp && operandConst(nodep->rhsp())
             && !VN_AS(nodep->rhsp(), Const)->num().isFourState()
             && varrefp  // Don't do messes with BITREFs/ARRAYREFs
+            && !varrefp->varp()->hasStrengthAssignment()  // Strengths are resolved in V3Tristate
             && !varrefp->varp()->valuep()  // Not already constified
             && !varrefp->varScopep()) {  // Not scoped (or each scope may have different initial
                                          // value)

--- a/src/V3ParseGrammar.cpp
+++ b/src/V3ParseGrammar.cpp
@@ -84,9 +84,13 @@ AstArg* V3ParseGrammar::argWrapList(AstNode* nodep) {
 }
 
 AstNode* V3ParseGrammar::createSupplyExpr(FileLine* fileline, const string& name, int value) {
-    return new AstAssignW(
-        fileline, new AstVarRef(fileline, name, VAccess::WRITE),
-        new AstConst(fileline, AstConst::StringToParse(), (value ? "'1" : "'0")));
+    AstAssignW* assignp
+        = new AstAssignW{fileline, new AstVarRef{fileline, name, VAccess::WRITE},
+                         new AstConst{fileline, AstConst::StringToParse{}, (value ? "'1" : "'0")}};
+    AstStrengthSpec* strengthSpecp
+        = new AstStrengthSpec{fileline, VStrength::SUPPLY, VStrength::SUPPLY};
+    assignp->strengthSpecp(strengthSpecp);
+    return assignp;
 }
 
 AstRange* V3ParseGrammar::scrubRange(AstNodeRange* nrangep) {

--- a/src/V3ParseImp.cpp
+++ b/src/V3ParseImp.cpp
@@ -398,8 +398,7 @@ void V3ParseImp::tokenPipeline() {
         const int nexttok = nexttokp->token;
         yylval = curValue;
         // Now potentially munge the current token
-        if (token == '('
-            && (nexttok == ygenSTRENGTH || nexttok == ySUPPLY0 || nexttok == ySUPPLY1)) {
+        if (token == '(' && isStrengthToken(nexttok)) {
             token = yP_PAR__STRENGTH;
         } else if (token == ':') {
             if (nexttok == yBEGIN) {
@@ -481,6 +480,12 @@ void V3ParseImp::tokenPipeline() {
     }
     yylval.token = token;
     // effectively returns yylval
+}
+
+bool V3ParseImp::isStrengthToken(int tok) {
+    return tok == ygenSTRENGTH || tok == ySUPPLY0 || tok == ySUPPLY1 || tok == ySTRONG0
+           || tok == ySTRONG1 || tok == yPULL0 || tok == yPULL1 || tok == yWEAK0 || tok == yWEAK1
+           || tok == yHIGHZ0 || tok == yHIGHZ1;
 }
 
 void V3ParseImp::tokenPipelineSym() {

--- a/src/V3ParseImp.h
+++ b/src/V3ParseImp.h
@@ -121,6 +121,7 @@ struct V3ParseBisonYYSType {
         V3ErrorCode::en errcodeen;
         VAttrType::en attrtypeen;
         VLifetime::en lifetime;
+        VStrength::en strength;
 
 #include "V3Ast__gen_yystype.h"
     };
@@ -216,6 +217,7 @@ public:
     }
     int lexKwdLastState() const { return m_lexKwdLast; }
     static const char* tokenName(int tok);
+    static bool isStrengthToken(int tok);
 
     void ppPushText(const string& text) {
         m_ppBuffers.push_back(text);

--- a/src/V3Tristate.cpp
+++ b/src/V3Tristate.cpp
@@ -55,6 +55,33 @@
 // duplicating vars and logic that is common between each instance of a
 // module.
 //
+//
+// Another thing done in this phase is signal strength handling.
+// Currently they are only supported in assignments and only in case when the strongest assignment
+// has constant with all bits equal on the RHS. It is the case when they can be statically
+// resolved.
+//
+// Static resolution is done in the following way:
+// - The assignment of value 0 (size may be greater than 1), that has greatest strength (the
+// one corresponding to 0) of all other assignments of 0, has to be found.
+// - The same is done for value '1 and strength corresponding to value 1.
+// - The greater of these two strengths is chosen. If they are equal the one that corresponds
+// to 1 is taken as the greatest.
+// - All assignments, that have strengths weaker or equal to the one that was found before, are
+// removed. They are the assignments with constants on the RHS and also all assignments that have
+// both strengths non-greater that the one was found, because they are weaker no matter what is on
+// RHS.
+//
+// All assignments that are stronger than the one with strongest constant are left as they are.
+//
+// There is a possible problem with equally strong assignments, because multiple assignments with
+// the same strength, but different values should result in x value, but these values are
+// unsupported.
+//
+// Singal strength can also be used in simple logic gates parsed as assignments (see verilog.y),
+// but these gates are then either removed (if they are weaker than the strongest constant) or
+// handled as the gates witout signal strengths are handled now. In other words, gate with greater
+// strength won't properly overwrite weaker driver.
 //*************************************************************************
 
 #include "config_build.h"
@@ -340,6 +367,8 @@ class TristateVisitor final : public TristateBaseVisitor {
     // TYPES
     using RefVec = std::vector<AstVarRef*>;
     using VarMap = std::unordered_map<AstVar*, RefVec*>;
+    using Assigns = std::vector<AstAssignW*>;
+    using VarToAssignsMap = std::map<AstVar*, Assigns>;
     enum : uint8_t {
         U2_GRAPHING = 1,  // bit[0] if did m_graphing visit
         U2_NONGRAPH = 2,  // bit[1] if did !m_graphing visit
@@ -352,6 +381,7 @@ class TristateVisitor final : public TristateBaseVisitor {
     AstNodeModule* m_modp = nullptr;  // Current module
     AstCell* m_cellp = nullptr;  // current cell
     VarMap m_lhsmap;  // Tristate left-hand-side driver map
+    VarToAssignsMap m_assigns;  // Assigns in current module
     int m_unique = 0;
     bool m_alhs = false;  // On LHS of assignment
     const AstNode* m_logicp = nullptr;  // Current logic being built
@@ -636,6 +666,117 @@ class TristateVisitor final : public TristateBaseVisitor {
         nodep->addStmtp(assp);
     }
 
+    void addToAssignmentList(AstAssignW* nodep) {
+        if (AstVarRef* const varRefp = VN_CAST(nodep->lhsp(), VarRef)) {
+            if (varRefp->varp()->isNet()) {
+                m_assigns[varRefp->varp()].push_back(nodep);
+            } else if (nodep->strengthSpecp()) {
+                if (!varRefp->varp()->isNet())
+                    nodep->v3warn(E_UNSUPPORTED, "Unsupported: Signal strengths are unsupported "
+                                                 "on the following variable type: "
+                                                     << varRefp->varp()->varType());
+
+                nodep->strengthSpecp()->unlinkFrBack()->deleteTree();
+            }
+        } else if (nodep->strengthSpecp()) {
+            nodep->v3warn(E_UNSUPPORTED,
+                          "Unsupported: Assignments with signal strength with LHS of type: "
+                              << nodep->lhsp()->prettyTypeName());
+        }
+    }
+
+    uint8_t getStrength(AstAssignW* const nodep, bool value) {
+        if (AstStrengthSpec* const strengthSpec = nodep->strengthSpecp()) {
+            return value ? strengthSpec->strength1() : strengthSpec->strength0();
+        }
+        return VStrength::STRONG;  // default strength is strong
+    }
+
+    bool assignmentOfValueOnAllBits(AstAssignW* const nodep, bool value) {
+        if (AstConst* const constp = VN_CAST(nodep->rhsp(), Const)) {
+            const V3Number num = constp->num();
+            return value ? num.isEqAllOnes() : num.isEqZero();
+        }
+        return false;
+    }
+
+    AstAssignW* getStrongestAssignmentOfValue(const Assigns& assigns, bool value) {
+        auto maxIt = std::max_element(
+            assigns.begin(), assigns.end(), [&](AstAssignW* ap, AstAssignW* bp) {
+                bool valuesOnRhsA = assignmentOfValueOnAllBits(ap, value);
+                bool valuesOnRhsB = assignmentOfValueOnAllBits(bp, value);
+                if (!valuesOnRhsA) return valuesOnRhsB;
+                if (!valuesOnRhsB) return false;
+                return getStrength(ap, value) < getStrength(bp, value);
+            });
+        // If not all assignments have const with all bits equal to value on the RHS,
+        // std::max_element will return one of them anyway, so it has to be checked before
+        // returning
+        return assignmentOfValueOnAllBits(*maxIt, value) ? *maxIt : nullptr;
+    }
+
+    void removeWeakerAssignments(Assigns& assigns) {
+        // Weaker assignments are these assignments that can't change the final value of the net.
+        // If the value of the RHS is known, only strength corresponding to its value is taken into
+        // account. Assignments of constants that have bits both 0 and 1 are skipped here, because
+        // it would involve handling parts of bits separately.
+
+        // First, the strongest assignment, that has value on the RHS consisting of only 1 or only
+        // 0, has to be found.
+        AstAssignW* const strongest0p = getStrongestAssignmentOfValue(assigns, 0);
+        AstAssignW* const strongest1p = getStrongestAssignmentOfValue(assigns, 1);
+        AstAssignW* strongestp = nullptr;
+        uint8_t greatestKnownStrength = 0;
+        const auto getIfStrongest = [&](AstAssignW* const strongestCandidatep, bool value) {
+            if (!strongestCandidatep) return;
+            uint8_t strength = getStrength(strongestCandidatep, value);
+            if (strength >= greatestKnownStrength) {
+                greatestKnownStrength = strength;
+                strongestp = strongestCandidatep;
+            }
+        };
+        getIfStrongest(strongest0p, 0);
+        getIfStrongest(strongest1p, 1);
+
+        if (strongestp) {
+            // Then all weaker assignments can be safely removed.
+            // Assignments of the same strength are also removed, because duplicates aren't needed.
+            // One problem is with 2 assignments of different values and equal strengths. It should
+            // result in assignment of x value, but these values aren't supported now.
+            auto removedIt
+                = std::remove_if(assigns.begin(), assigns.end(), [&](AstAssignW* assignp) {
+                      if (assignp == strongestp) return false;
+                      const uint8_t strength0 = getStrength(assignp, 0);
+                      const uint8_t strength1 = getStrength(assignp, 1);
+                      const bool toRemove = (strength0 <= greatestKnownStrength
+                                             && strength1 <= greatestKnownStrength)
+                                            || (strength0 <= greatestKnownStrength
+                                                && assignmentOfValueOnAllBits(assignp, 0))
+                                            || (strength1 <= greatestKnownStrength
+                                                && assignmentOfValueOnAllBits(assignp, 1));
+                      if (toRemove) {
+                          // Don't propagate tristate if its assignment is removed.
+                          TristateVertex* const vertexp
+                              = reinterpret_cast<TristateVertex*>(assignp->rhsp()->user5p());
+                          if (vertexp) vertexp->isTristate(false);
+                          VL_DO_DANGLING(pushDeletep(assignp->unlinkFrBack()), assignp);
+                          return true;
+                      }
+                      return false;
+                  });
+            assigns.erase(removedIt, assigns.end());
+        }
+    }
+
+    void resolveMultipleNetAssignments() {
+        for (auto& varpAssigns : m_assigns) {
+            if (varpAssigns.second.size() > 1) {
+                // first the static resolution is tried
+                removeWeakerAssignments(varpAssigns.second);
+            }
+        }
+    }
+
     // VISITORS
     virtual void visit(AstConst* nodep) override {
         UINFO(9, dbgState() << nodep << endl);
@@ -889,6 +1030,8 @@ class TristateVisitor final : public TristateBaseVisitor {
 
     void visitAssign(AstNodeAssign* nodep) {
         if (m_graphing) {
+            if (AstAssignW* assignWp = VN_CAST(nodep, AssignW)) addToAssignmentList(assignWp);
+
             if (nodep->user2() & U2_GRAPHING) return;
             VL_RESTORER(m_logicp);
             m_logicp = nodep;
@@ -1373,6 +1516,7 @@ class TristateVisitor final : public TristateBaseVisitor {
         VL_RESTORER(m_graphing);
         VL_RESTORER(m_unique);
         VL_RESTORER(m_lhsmap);
+        VL_RESTORER(m_assigns);
         // Not preserved, needs pointer instead: TristateGraph origTgraph = m_tgraph;
         UASSERT_OBJ(m_tgraph.empty(), nodep, "Unsupported: NodeModule under NodeModule");
         {
@@ -1382,6 +1526,7 @@ class TristateVisitor final : public TristateBaseVisitor {
             m_unique = 0;
             m_logicp = nullptr;
             m_lhsmap.clear();
+            m_assigns.clear();
             m_modp = nodep;
             // Walk the graph, finding all variables and tristate constructs
             {
@@ -1389,6 +1534,8 @@ class TristateVisitor final : public TristateBaseVisitor {
                 iterateChildren(nodep);
                 m_graphing = false;
             }
+            // resolve multiple net assignments and signal strengths
+            resolveMultipleNetAssignments();
             // Use graph to find tristate signals
             m_tgraph.graphWalk(nodep);
             // Build the LHS drivers map for this module

--- a/src/verilog.l
+++ b/src/verilog.l
@@ -325,8 +325,8 @@ vnum    {vnum1}|{vnum2}|{vnum3}|{vnum4}|{vnum5}
   "forever"             { FL; return yFOREVER; }
   "fork"                { FL; return yFORK; }
   "function"            { FL; return yFUNCTION; }
-  "highz0"              { FL; return ygenSTRENGTH; }
-  "highz1"              { FL; return ygenSTRENGTH; }
+  "highz0"              { FL; return yHIGHZ0; }
+  "highz1"              { FL; return yHIGHZ1; }
   "if"                  { FL; return yIF; }
   "initial"             { FL; return yINITIAL; }
   "inout"               { FL; return yINOUT; }
@@ -350,8 +350,8 @@ vnum    {vnum1}|{vnum2}|{vnum3}|{vnum4}|{vnum5}
   "pmos"                { FL; return yPMOS; }
   "posedge"             { FL; return yPOSEDGE; }
   "primitive"           { FL; return yPRIMITIVE; }
-  "pull0"               { FL; return ygenSTRENGTH; }
-  "pull1"               { FL; return ygenSTRENGTH; }
+  "pull0"               { FL; return yPULL0; }
+  "pull1"               { FL; return yPULL1; }
   "pulldown"            { FL; return yPULLDOWN; }
   "pullup"              { FL; return yPULLUP; }
   "rcmos"               { FL; return yRCMOS; }
@@ -369,8 +369,8 @@ vnum    {vnum1}|{vnum2}|{vnum3}|{vnum4}|{vnum5}
   "small"               { FL; return ygenSTRENGTH; }
   "specify"             { FL; return ySPECIFY; }
   "specparam"           { FL; return ySPECPARAM; }
-  "strong0"             { FL; return ygenSTRENGTH; }
-  "strong1"             { FL; return ygenSTRENGTH; }
+  "strong0"             { FL; return ySTRONG0; }
+  "strong1"             { FL; return ySTRONG1; }
   "supply0"             { FL; return ySUPPLY0; }
   "supply1"             { FL; return ySUPPLY1; }
   "table"               { FL; yy_push_state(TABLE); return yTABLE; }
@@ -388,8 +388,8 @@ vnum    {vnum1}|{vnum2}|{vnum3}|{vnum4}|{vnum5}
   "vectored"            { FL; return yVECTORED; }
   "wait"                { FL; return yWAIT; }
   "wand"                { FL; return yWAND; }
-  "weak0"               { FL; return ygenSTRENGTH; }
-  "weak1"               { FL; return ygenSTRENGTH; }
+  "weak0"               { FL; return yWEAK0; }
+  "weak1"               { FL; return yWEAK1; }
   "while"               { FL; return yWHILE; }
   "wire"                { FL; return yWIRE; }
   "wor"                 { FL; return yWOR; }

--- a/test_regress/t/t_strength_assignments.pl
+++ b/test_regress/t/t_strength_assignments.pl
@@ -1,0 +1,21 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2022 by Antmicro Ltd. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_strength_assignments.v
+++ b/test_regress/t/t_strength_assignments.v
@@ -1,0 +1,38 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2022 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+module t (/*AUTOARG*/);
+   wire a;
+   assign (weak0, weak1) a = 1;
+   assign (weak0, supply1) a = 1;
+   assign (strong0, strong1) a = 0;
+
+   wire (weak0, weak1) b = 1;
+   assign (strong0, strong1) b = 0;
+
+   wire [1:0] c;
+   assign (weak0, supply1) c = '1;
+   assign (supply0, pull1) c = '1;
+   assign (strong0, strong1) c = '0;
+
+   supply0 d;
+   assign (strong0, strong1) d = 1;
+
+   wire (supply0, supply1) e = 'z;
+   assign (weak0, weak1) e = 1;
+
+   always begin
+      if (a && !b && c === '1 && !d && e) begin
+         $write("*-* All Finished *-*\n");
+         $finish;
+      end
+      else begin
+         $write("Error: a = %b, b = %b, c = %b, d = %b, e = %b ", a, b, c, d, e);
+         $write("expected: a = 1, b = 0, c = 11, d = 0, e = 1\n");
+         $stop;
+      end
+   end
+endmodule

--- a/test_regress/t/t_strength_bufif1.out
+++ b/test_regress/t/t_strength_bufif1.out
@@ -1,0 +1,5 @@
+%Error-UNSUPPORTED: t/t_strength_bufif1.v:9:11: Unsupported: Strength specifier on this gate type
+    9 |    bufif1 (strong0, strong1) (a, 1'b1, 1'b1);
+      |           ^
+                    ... For error description see https://verilator.org/warn/UNSUPPORTED?v=latest
+%Error: Exiting due to

--- a/test_regress/t/t_strength_bufif1.pl
+++ b/test_regress/t/t_strength_bufif1.pl
@@ -1,0 +1,19 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2022 by Antmicro Ltd. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(vlt => 1);
+
+lint(
+    fails => $Self->{vlt_all},
+    expect_filename => $Self->{golden_filename},
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_strength_bufif1.v
+++ b/test_regress/t/t_strength_bufif1.v
@@ -1,0 +1,17 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2022 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+module t (/*AUTOARG*/);
+   wire a;
+   bufif1 (strong0, strong1) (a, 1'b1, 1'b1);
+
+   always begin
+      if (a) begin
+         $write("*-* All Finished *-*\n");
+         $finish;
+      end
+   end
+endmodule

--- a/test_regress/t/t_strength_highz.out
+++ b/test_regress/t/t_strength_highz.out
@@ -1,0 +1,14 @@
+%Error-UNSUPPORTED: t/t_strength_highz.v:8:17: Unsupported: highz strength
+    8 |    wire (weak0, highz1) a = 1;
+      |                 ^~~~~~
+                    ... For error description see https://verilator.org/warn/UNSUPPORTED?v=latest
+%Error-UNSUPPORTED: t/t_strength_highz.v:9:19: Unsupported: highz strength
+    9 |    wire (strong1, highz0) b = 0;
+      |                   ^~~~~~
+%Error-UNSUPPORTED: t/t_strength_highz.v:10:10: Unsupported: highz strength
+   10 |    wire (highz0, pull1) c = 0;
+      |          ^~~~~~
+%Error-UNSUPPORTED: t/t_strength_highz.v:11:10: Unsupported: highz strength
+   11 |    wire (highz1, supply0) d = 1;
+      |          ^~~~~~
+%Error: Exiting due to

--- a/test_regress/t/t_strength_highz.pl
+++ b/test_regress/t/t_strength_highz.pl
@@ -1,0 +1,19 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2003 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(vlt => 1);
+
+lint(
+    fails => $Self->{vlt_all},
+    expect_filename => $Self->{golden_filename},
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_strength_highz.v
+++ b/test_regress/t/t_strength_highz.v
@@ -1,0 +1,19 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2022 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+module t (/*AUTOARG*/);
+   wire (weak0, highz1) a = 1;
+   wire (strong1, highz0) b = 0;
+   wire (highz0, pull1) c = 0;
+   wire (highz1, supply0) d = 1;
+
+   always begin
+      if (a === 1'bz && b === 1'bz && c === 1'bz && d === 1'bz) begin
+         $write("*-* All Finished *-*\n");
+         $finish;
+      end
+   end
+endmodule

--- a/test_regress/t/t_strength_strong1_strong1_bad.out
+++ b/test_regress/t/t_strength_strong1_strong1_bad.out
@@ -1,0 +1,4 @@
+%Error: t/t_strength_strong1_strong1_bad.v:8:19: syntax error, unexpected strong1
+    8 |    wire (strong1, strong1) a = 1;
+      |                   ^~~~~~~
+%Error: Exiting due to

--- a/test_regress/t/t_strength_strong1_strong1_bad.pl
+++ b/test_regress/t/t_strength_strong1_strong1_bad.pl
@@ -1,0 +1,19 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2022 by Antmicro Ltd. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(linter => 1);
+
+lint(
+    fails => 1,
+    expect_filename => $Self->{golden_filename},
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_strength_strong1_strong1_bad.v
+++ b/test_regress/t/t_strength_strong1_strong1_bad.v
@@ -1,0 +1,13 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2022 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+module t (/*AUTOARG*/);
+   wire (strong1, strong1) a = 1;
+   initial begin
+      $stop;
+   end
+
+endmodule

--- a/test_regress/t/t_weak_nor_strong_assign.pl
+++ b/test_regress/t/t_weak_nor_strong_assign.pl
@@ -1,0 +1,21 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2022 by Antmicro Ltd. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_weak_nor_strong_assign.v
+++ b/test_regress/t/t_weak_nor_strong_assign.v
@@ -1,0 +1,18 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2022 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+module t (/*AUTOARG*/);
+   wire a;
+   nor (pull0, weak1) n1(a, 0, 0);
+   assign (strong0, weak1) a = 0;
+
+   always begin
+      if (!a) begin
+         $write("*-* All Finished *-*\n");
+         $finish;
+      end
+   end
+endmodule


### PR DESCRIPTION
It is another approach to handle signal strength. Previous was there: https://github.com/verilator/verilator/pull/3580 and parsing phase is just copied.
Here I add the handling of case when the strongest driver is a constant. I just find the strongest assignment with constant on RHS and then just remove all weaker or equally strong assignments.

To be more formal:
I find the assignment of value 0 (size may be greater than 1) that has greatest strength (the one corresponding to 0) of all other assignments of 0.
Then I do the same for value '1 and strength corresponding to value 1.
Then I find greater of these two strengths. If they are equal I take the one that corresponds to 1.
Then I remove all assignments that have strengths weaker or equal to the one I found.
So I remove all other assignments of constants on RHS and also all assignment that have both strengths non-greater that the one I found, because they are weaker not matter what is on RHS.

All assignments that are stronger than the one with strongest constant I leave as they are.

There is a possible problem with equally strong assignments, because multiple assignments with the same strength, but different values should result in `x` value, but these values are unsupported.

In some cases the first AstAssignW of some net was changed to AstAssign and put into `initial` block and the value of RHS is put into `valuep()`.
I delayed this step to be happening after V3Tristate phase. I did this, because the value of the first assignment may be overwritten by some stronger assignment and also change of assignment type made the handling more complicated, because strengths can only be specified for continuous assignments.
It causes that two tests changed their error messages. In `t_bitsel_wire_array_bad` there is no instance information. I think that field was just removed in some earlier phase, because this change may delay the moment of printing such error. In `t_split_var_1_bad` one of error messages was replaced by 3 messages. I think that first of them is more accurate than the previous, but I wonder if I should try to remove two additional messages.