### PR TITLE
Split unused genvar, param, and signal warnings

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -118,6 +118,7 @@ Tobias Rosenkranz
 Tobias Wölfel
 Todd Strader
 Tomasz Gorochowik
+Topa Topino
 Tymoteusz Blazejczyk
 Udi Finkelstein
 Unai Martinez-Corral

--- a/docs/guide/exe_verilator.rst
+++ b/docs/guide/exe_verilator.rst
@@ -1475,7 +1475,8 @@ Summary:
    equivalent to ``-Wno-ALWCOMBORDER -Wno-BSSPACE -Wno-CASEINCOMPLETE
    -Wno-CASEOVERLAP -Wno-CASEX -Wno-CASTCONST -Wno-CASEWITHX -Wno-CMPCONST -Wno-COLONPLUS
    -Wno-ENDLABEL -Wno-IMPLICIT -Wno-LITENDIAN -Wno-PINCONNECTEMPTY
-   -Wno-PINMISSING -Wno-SYNCASYNCNET -Wno-UNDRIVEN -Wno-UNSIGNED -Wno-UNUSED
+   -Wno-PINMISSING -Wno-SYNCASYNCNET -Wno-UNDRIVEN -Wno-UNSIGNED
+   -Wno-UNUSEDGENVAR -Wno-UNUSEDPARAM -Wno-UNUSEDSIGNAL
    -Wno-WIDTH`` plus the list shown for Wno-style.
 
    It is strongly recommended you cleanup your code rather than using this
@@ -1487,7 +1488,8 @@ Summary:
    Disable all code style related warning messages (note by default they are
    already disabled).  This is equivalent to ``-Wno-DECLFILENAME -Wno-DEFPARAM
    -Wno-EOFNEWLINE -Wno-IMPORTSTAR -Wno-INCABSPATH -Wno-PINCONNECTEMPTY
-   -Wno-PINNOCONNECT -Wno-SYNCASYNCNET -Wno-UNDRIVEN -Wno-UNUSED
+   -Wno-PINNOCONNECT -Wno-SYNCASYNCNET -Wno-UNDRIVEN
+   -Wno-UNUSEDGENVAR -Wno-UNUSEDPARAM -Wno-UNUSEDSIGNAL
    -Wno-VARHIDDEN``.
 
 .. option:: -Wpedantic
@@ -1516,7 +1518,7 @@ Summary:
    Enable all code style related warning messages.  This is equivalent to
    ``-Wwarn ASSIGNDLY -Wwarn-DECLFILENAME -Wwarn-DEFPARAM -Wwarn-EOFNEWLINE
    -Wwarn-INCABSPATH -Wwarn-PINNOCONNECT -Wwarn-SYNCASYNCNET -Wwarn-UNDRIVEN
-   -Wwarn-UNUSED -Wwarn-VARHIDDEN``.
+   -Wwarn-UNUSEDGENVAR -Wwarn-UNUSEDPARAM -Wwarn-UNUSEDSIGNAL -Wwarn-VARHIDDEN``.
 
 .. option:: --x-assign 0
 

--- a/docs/guide/warnings.rst
+++ b/docs/guide/warnings.rst
@@ -1542,9 +1542,31 @@ List Of Warnings
 
 .. option:: UNUSED
 
+   Disabling/enabling UNUSED is equivalent to disabling/enabling the
+   `UNUSEDGENVAR`, `UNUSEDPARAM` and `UNUSEDSIGNAL` warnings.
+
+   Never issued since version 5.000.  Historically warned that a variable,
+   parameter, or signal was unused.
+
+.. option:: UNUSEDGENVAR
+
    .. TODO better example
 
-   Warns that the specified signal or parameter is never used/consumed.
+   Warns that the specified genvar is never used/consumed.
+
+
+.. option:: UNUSEDPARAM
+
+   .. TODO better example
+
+   Warns that the specified parameter is never used/consumed.
+
+
+.. option:: UNUSEDSIGNAL
+
+   .. TODO better example
+
+   Warns that the specified signal is never used/consumed.
    Verilator is fairly liberal in the usage calculations; making a signal
    public, a signal matching the :vlopt:`--unused-regexp` option (default
    "\*unused\*" or accessing only a single array element marks the entire

--- a/src/V3Config.cpp
+++ b/src/V3Config.cpp
@@ -332,8 +332,11 @@ public:
     }
     bool waive(V3ErrorCode code, const string& match) {
         for (const auto& itr : m_waivers) {
-            if (((itr.first == code) || (itr.first == V3ErrorCode::I_LINT))
-                && VString::wildmatch(match, itr.second)) {
+            if ( ( (itr.first == code)
+                   || (itr.first == V3ErrorCode::I_LINT)
+                   || (code.unusedError() && itr.first == V3ErrorCode::I_UNUSED)
+                 )
+                 && VString::wildmatch(match, itr.second)) {
                 return true;
             }
         }

--- a/src/V3Coverage.cpp
+++ b/src/V3Coverage.cpp
@@ -128,7 +128,7 @@ private:
             AstVar* const varp = new AstVar(incp->fileline(), VVarType::MODULETEMP, trace_var_name,
                                             incp->findUInt32DType());
             varp->trace(true);
-            varp->fileline()->modifyWarnOff(V3ErrorCode::UNUSED, true);
+            varp->fileline()->modifyWarnOff(V3ErrorCode::UNUSEDSIGNAL, true);
             m_modp->addStmtsp(varp);
             UINFO(5, "New coverage trace: " << varp << endl);
             AstAssign* const assp = new AstAssign(
@@ -283,7 +283,7 @@ private:
                 const string newvarname = std::string{"__Vtogcov__"} + nodep->shortName();
                 AstVar* const chgVarp
                     = new AstVar(nodep->fileline(), VVarType::MODULETEMP, newvarname, nodep);
-                chgVarp->fileline()->modifyWarnOff(V3ErrorCode::UNUSED, true);
+                chgVarp->fileline()->modifyWarnOff(V3ErrorCode::UNUSEDSIGNAL, true);
                 m_modp->addStmtsp(chgVarp);
 
                 // Create bucket for each dimension * bit.

--- a/src/V3Error.h
+++ b/src/V3Error.h
@@ -51,6 +51,7 @@ public:
         I_COVERAGE,     // Coverage is on/off from /*verilator coverage_on/off*/
         I_TRACING,      // Tracing is on/off from /*verilator tracing_on/off*/
         I_LINT,         // All lint messages
+        I_UNUSED,       // Unused genvar, parameter or signal message (Backward Compatibility)
         I_DEF_NETTYPE_WIRE,  // `default_nettype is WIRE (false=NONE)
         I_TIMING,       // Enable timing from /*verilator timing_on/off*/
         // Error codes:
@@ -134,7 +135,9 @@ public:
         UNOPTTHREADS,   // Thread partitioner unable to fill all requested threads
         UNPACKED,       // Unsupported unpacked
         UNSIGNED,       // Comparison is constant due to unsigned arithmetic
-        UNUSED,         // No receivers
+        UNUSEDGENVAR,   // No receivers for genvar
+        UNUSEDPARAM,    // No receivers for parameters
+        UNUSEDSIGNAL,   // No receivers for signals
         USERERROR,      // Elaboration time $error
         USERFATAL,      // Elaboration time $fatal
         USERINFO,       // Elaboration time $info
@@ -164,7 +167,7 @@ public:
             // Leading spaces indicate it can't be disabled.
             " MIN", " INFO", " FATAL", " FATALEXIT", " FATALSRC", " ERROR", " FIRST_NAMED",
             // Boolean
-            " I_CELLDEFINE", " I_COVERAGE", " I_TRACING", " I_LINT", " I_DEF_NETTYPE_WIRE", " I_TIMING",
+            " I_CELLDEFINE", " I_COVERAGE", " I_TRACING", " I_LINT", " I_UNUSED", " I_DEF_NETTYPE_WIRE", " I_TIMING",
             // Errors
             "ENCAPSULATED", "PORTSHORT", "UNSUPPORTED", "TASKNSVAR", "NEEDTIMINGOPT", "NOTIMING",
             // Warnings
@@ -185,7 +188,7 @@ public:
             "SELRANGE", "SHORTREAL", "SPLITVAR", "STMTDLY", "SYMRSVDWORD", "SYNCASYNCNET",
             "TICKCOUNT", "TIMESCALEMOD",
             "UNDRIVEN", "UNOPT", "UNOPTFLAT", "UNOPTTHREADS",
-            "UNPACKED", "UNSIGNED", "UNUSED",
+            "UNPACKED", "UNSIGNED", "UNUSEDGENVAR", "UNUSEDPARAM", "UNUSEDSIGNAL",
             "USERERROR", "USERFATAL", "USERINFO", "USERWARN",
             "VARHIDDEN", "WAITCONST", "WIDTH", "WIDTHCONCAT", "ZERODLY",
             " MAX"
@@ -224,8 +227,16 @@ public:
         return (m_e == ASSIGNDLY  // More than style, but for backward compatibility
                 || m_e == BLKSEQ || m_e == DEFPARAM || m_e == DECLFILENAME || m_e == EOFNEWLINE
                 || m_e == IMPORTSTAR || m_e == INCABSPATH || m_e == PINCONNECTEMPTY
-                || m_e == PINNOCONNECT || m_e == SYNCASYNCNET || m_e == UNDRIVEN || m_e == UNUSED
+                || m_e == PINNOCONNECT || m_e == SYNCASYNCNET || m_e == UNDRIVEN
+                || m_e == UNUSEDGENVAR || m_e == UNUSEDPARAM || m_e == UNUSEDSIGNAL
                 || m_e == VARHIDDEN);
+    }
+    // Warnings that are unused only
+    bool unusedError() const {
+        return (m_e == UNUSEDGENVAR || m_e == UNUSEDPARAM || m_e == UNUSEDSIGNAL);
+    }
+    static bool unusedMsg(const char* msgp) {
+        return 0 == VL_STRCASECMP(msgp, "UNUSED");
     }
 };
 constexpr bool operator==(const V3ErrorCode& lhs, const V3ErrorCode& rhs) {

--- a/src/V3FileLine.h
+++ b/src/V3FileLine.h
@@ -264,6 +264,7 @@ public:
     bool warnIsOff(V3ErrorCode code) const;
     void warnLintOff(bool flag);
     void warnStyleOff(bool flag);
+    void warnUnusedOff(bool flag);
     void warnStateFrom(const FileLine& from) { m_msgEnIdx = from.m_msgEnIdx; }
     void warnResetDefault() { warnStateFrom(defaultFileLine()); }
     bool lastWarnWaived() const { return m_waive; }
@@ -284,6 +285,7 @@ public:
     static string builtInFilename() { return "<built-in>"; }
     static void globalWarnLintOff(bool flag) { defaultFileLine().warnLintOff(flag); }
     static void globalWarnStyleOff(bool flag) { defaultFileLine().warnStyleOff(flag); }
+    static void globalWarnUnusedOff(bool flag) { defaultFileLine().warnUnusedOff(flag); }
     static void globalWarnOff(V3ErrorCode code, bool flag) {
         defaultFileLine().warnOff(code, flag);
     }

--- a/src/V3Options.cpp
+++ b/src/V3Options.cpp
@@ -1469,6 +1469,11 @@ void V3Options::parseOptsList(FileLine* fl, const string& optdir, int argc, char
         FileLine::globalWarnLintOff(false);
         FileLine::globalWarnStyleOff(false);
     });
+    DECL_OPTION("-Werror-UNUSED", CbCall, []() {
+        V3Error::pretendError(V3ErrorCode::UNUSEDGENVAR, true);
+        V3Error::pretendError(V3ErrorCode::UNUSEDPARAM, true);
+        V3Error::pretendError(V3ErrorCode::UNUSEDSIGNAL, true);
+    });
     DECL_OPTION("-Werror-", CbPartialMatch, [this, fl](const char* optp) {
         const V3ErrorCode code(optp);
         if (code == V3ErrorCode::EC_ERROR) {
@@ -1499,6 +1504,7 @@ void V3Options::parseOptsList(FileLine* fl, const string& optdir, int argc, char
         FileLine::globalWarnStyleOff(true);
     });
     DECL_OPTION("-Wno-style", CbCall, []() { FileLine::globalWarnStyleOff(true); });
+    DECL_OPTION("-Wno-UNUSED", CbCall, []() { FileLine::globalWarnUnusedOff(true); });
     DECL_OPTION("-Wwarn-", CbPartialMatch, [this, fl, &parser](const char* optp) {
         const V3ErrorCode code{optp};
         if (code == V3ErrorCode::EC_ERROR) {
@@ -1514,6 +1520,12 @@ void V3Options::parseOptsList(FileLine* fl, const string& optdir, int argc, char
     });
     DECL_OPTION("-Wwarn-lint", CbCall, []() { FileLine::globalWarnLintOff(false); });
     DECL_OPTION("-Wwarn-style", CbCall, []() { FileLine::globalWarnStyleOff(false); });
+    DECL_OPTION("-Wwarn-UNUSED", CbCall, []() {
+        FileLine::globalWarnUnusedOff(false);
+        V3Error::pretendError(V3ErrorCode::UNUSEDGENVAR, false);
+        V3Error::pretendError(V3ErrorCode::UNUSEDSIGNAL, false);
+        V3Error::pretendError(V3ErrorCode::UNUSEDPARAM, false);
+    });
     DECL_OPTION("-waiver-output", Set, &m_waiverOutput);
 
     DECL_OPTION("-x-assign", CbVal, [this, fl](const char* valp) {

--- a/src/verilog.y
+++ b/src/verilog.y
@@ -6637,7 +6637,9 @@ vltOffFront<errcodeen>:
         |       yVLT_TRACING_OFF                        { $$ = V3ErrorCode::I_TRACING; }
         |       yVLT_LINT_OFF                           { $$ = V3ErrorCode::I_LINT; }
         |       yVLT_LINT_OFF yVLT_D_RULE idAny
-                        { $$ = V3ErrorCode{(*$3).c_str()};
+                        { const char *codemsg = (*$3).c_str();
+                          if (V3ErrorCode::unusedMsg(codemsg)) {$$ = V3ErrorCode::I_UNUSED; }
+                          else {$$ = V3ErrorCode{codemsg}; }
                           if ($$ == V3ErrorCode::EC_ERROR) { $1->v3error("Unknown Error Code: " << *$3);  } }
         ;
 
@@ -6647,7 +6649,9 @@ vltOnFront<errcodeen>:
         |       yVLT_TRACING_ON                         { $$ = V3ErrorCode::I_TRACING; }
         |       yVLT_LINT_ON                            { $$ = V3ErrorCode::I_LINT; }
         |       yVLT_LINT_ON yVLT_D_RULE idAny
-                        { $$ = V3ErrorCode{(*$3).c_str()};
+                        { const char *codemsg = (*$3).c_str();
+                          if (V3ErrorCode::unusedMsg(codemsg)) {$$ = V3ErrorCode::I_UNUSED; }
+                          else {$$ = V3ErrorCode{codemsg}; }
                           if ($$ == V3ErrorCode::EC_ERROR) { $1->v3error("Unknown Error Code: " << *$3);  } }
         ;
 

--- a/test_regress/t/t_delay_stmtdly_bad.out
+++ b/test_regress/t/t_delay_stmtdly_bad.out
@@ -24,12 +24,12 @@
                                    : ... In instance t
    50 |          #100 $finish;
       |          ^
-%Warning-UNUSED: t/t_delay.v:23:12: Signal is not used: 'dly_s'
-                                  : ... In instance t
+%Warning-UNUSEDSIGNAL: t/t_delay.v:23:12: Signal is not used: 'dly_s'
+                                        : ... In instance t
    23 |    dly_s_t dly_s;
       |            ^~~~~
-%Warning-UNUSED: t/t_delay.v:57:13: Signal is not used: 'delay'
-                                  : ... In instance t.sub
+%Warning-UNUSEDSIGNAL: t/t_delay.v:57:13: Signal is not used: 'delay'
+                                        : ... In instance t.sub
    57 |    realtime delay = 2.3;
       |             ^~~~~
 %Warning-BLKSEQ: t/t_delay.v:43:20: Blocking assignment '=' in sequential logic process

--- a/test_regress/t/t_flag_context_bad.out
+++ b/test_regress/t/t_flag_context_bad.out
@@ -2,6 +2,6 @@
                                            : ... In instance t
                 ... For warning description see https://verilator.org/warn/WIDTH?v=latest
                 ... Use "/* verilator lint_off WIDTH */" and lint_on around source to disable this message.
-%Warning-UNUSED: t/t_flag_context_bad.v:9:15: Signal is not used: 'foo'
-                                            : ... In instance t
+%Warning-UNUSEDSIGNAL: t/t_flag_context_bad.v:9:15: Signal is not used: 'foo'
+                                                  : ... In instance t
 %Error: Exiting due to

--- a/test_regress/t/t_lint_once_bad.out
+++ b/test_regress/t/t_lint_once_bad.out
@@ -1,11 +1,11 @@
-%Warning-UNUSED: t/t_lint_once_bad.v:19:14: Signal is not driven, nor used: 'unus1'
-                                          : ... In instance t.sub1
+%Warning-UNUSEDSIGNAL: t/t_lint_once_bad.v:19:14: Signal is not driven, nor used: 'unus1'
+                                                : ... In instance t.sub1
    19 |    reg [A:0] unus1;    reg [A:0] unus2;
       |              ^~~~~
-                 ... For warning description see https://verilator.org/warn/UNUSED?v=latest
-                 ... Use "/* verilator lint_off UNUSED */" and lint_on around source to disable this message.
-%Warning-UNUSED: t/t_lint_once_bad.v:19:34: Signal is not driven, nor used: 'unus2'
-                                          : ... In instance t.sub1
+                       ... For warning description see https://verilator.org/warn/UNUSEDSIGNAL?v=latest
+                       ... Use "/* verilator lint_off UNUSEDSIGNAL */" and lint_on around source to disable this message.
+%Warning-UNUSEDSIGNAL: t/t_lint_once_bad.v:19:34: Signal is not driven, nor used: 'unus2'
+                                                : ... In instance t.sub1
    19 |    reg [A:0] unus1;    reg [A:0] unus2;
       |                                  ^~~~~
 %Error: Exiting due to

--- a/test_regress/t/t_lint_unused_bad.out
+++ b/test_regress/t/t_lint_unused_bad.out
@@ -1,39 +1,63 @@
-%Warning-UNUSED: t/t_lint_unused_bad.v:17:15: Bits of signal are not used: 'assunu1'[5:1]
-                                            : ... In instance t.sub
+%Warning-UNUSEDSIGNAL: t/t_lint_unused_bad.v:17:15: Bits of signal are not used: 'assunu1'[5:1]
+                                                  : ... In instance t.sub
    17 |    wire [5:0] assunu1 = 0;   
       |               ^~~~~~~
-                 ... For warning description see https://verilator.org/warn/UNUSED?v=latest
-                 ... Use "/* verilator lint_off UNUSED */" and lint_on around source to disable this message.
+                       ... For warning description see https://verilator.org/warn/UNUSEDSIGNAL?v=latest
+                       ... Use "/* verilator lint_off UNUSEDSIGNAL */" and lint_on around source to disable this message.
 %Warning-UNDRIVEN: t/t_lint_unused_bad.v:21:17: Bits of signal are not driven: 'udrb2'[14:13,11]
                                               : ... In instance t.sub
    21 |    wire [15:10] udrb2;   
       |                 ^~~~~
-%Warning-UNUSED: t/t_lint_unused_bad.v:26:15: Signal is not driven, nor used: 'unu3'
-                                            : ... In instance t.sub
+%Warning-UNUSEDSIGNAL: t/t_lint_unused_bad.v:26:15: Signal is not driven, nor used: 'unu3'
+                                                  : ... In instance t.sub
    26 |    wire       unu3;   
       |               ^~~~
-%Warning-UNUSED: t/t_lint_unused_bad.v:28:15: Bits of signal are not driven, nor used: 'mixed'[3]
-                                            : ... In instance t.sub
+%Warning-UNUSEDSIGNAL: t/t_lint_unused_bad.v:28:15: Bits of signal are not driven, nor used: 'mixed'[3]
+                                                  : ... In instance t.sub
    28 |    wire [3:0] mixed;   
       |               ^~~~~
-%Warning-UNUSED: t/t_lint_unused_bad.v:28:15: Bits of signal are not used: 'mixed'[2]
-                                            : ... In instance t.sub
+%Warning-UNUSEDSIGNAL: t/t_lint_unused_bad.v:28:15: Bits of signal are not used: 'mixed'[2]
+                                                  : ... In instance t.sub
    28 |    wire [3:0] mixed;   
       |               ^~~~~
 %Warning-UNDRIVEN: t/t_lint_unused_bad.v:28:15: Bits of signal are not driven: 'mixed'[1]
                                               : ... In instance t.sub
    28 |    wire [3:0] mixed;   
       |               ^~~~~
-%Warning-UNUSED: t/t_lint_unused_bad.v:37:14: Parameter is not used: 'UNUSED_P'
-                                            : ... In instance t.sub
+%Warning-UNUSEDPARAM: t/t_lint_unused_bad.v:37:14: Parameter is not used: 'UNUSED_P'
+                                                 : ... In instance t.sub
    37 |    parameter UNUSED_P = 1;
       |              ^~~~~~~~
-%Warning-UNUSED: t/t_lint_unused_bad.v:38:15: Parameter is not used: 'UNUSED_LP'
-                                            : ... In instance t.sub
+%Warning-UNUSEDPARAM: t/t_lint_unused_bad.v:38:15: Parameter is not used: 'UNUSED_LP'
+                                                 : ... In instance t.sub
    38 |    localparam UNUSED_LP = 2;
       |               ^~~~~~~~~
-%Warning-UNUSED: t/t_lint_unused_bad.v:40:15: Genvar is not driven, nor used: 'unused_gv'
-                                            : ... In instance t.sub
+%Warning-UNUSEDGENVAR: t/t_lint_unused_bad.v:40:15: Genvar is not used: 'unused_gv'
+                                                  : ... In instance t.sub
    40 |    genvar     unused_gv;
       |               ^~~~~~~~~
+%Warning-UNUSEDPARAM: t/t_lint_unused_bad.v:45:15: Parameter is not used: 'linter_param1'
+                                                 : ... In instance t.sub
+   45 |    localparam linter_param1 = 1;
+      |               ^~~~~~~~~~~~~
+%Warning-UNUSEDGENVAR: t/t_lint_unused_bad.v:46:11: Genvar is not used: 'linter_genvar1'
+                                                  : ... In instance t.sub
+   46 |    genvar linter_genvar1;
+      |           ^~~~~~~~~~~~~~
+%Warning-UNUSEDSIGNAL: t/t_lint_unused_bad.v:50:9: Signal is not driven, nor used: 'linter_sig2'
+                                                 : ... In instance t.sub
+   50 |    wire linter_sig2;
+      |         ^~~~~~~~~~~
+%Warning-UNUSEDGENVAR: t/t_lint_unused_bad.v:52:11: Genvar is not used: 'linter_genvar2'
+                                                  : ... In instance t.sub
+   52 |    genvar linter_genvar2;
+      |           ^~~~~~~~~~~~~~
+%Warning-UNUSEDSIGNAL: t/t_lint_unused_bad.v:56:9: Signal is not driven, nor used: 'linter_sig3'
+                                                 : ... In instance t.sub
+   56 |    wire linter_sig3;
+      |         ^~~~~~~~~~~
+%Warning-UNUSEDPARAM: t/t_lint_unused_bad.v:57:15: Parameter is not used: 'linter_param3'
+                                                 : ... In instance t.sub
+   57 |    localparam linter_param3 = 3;
+      |               ^~~~~~~~~~~~~
 %Error: Exiting due to

--- a/test_regress/t/t_lint_unused_bad.v
+++ b/test_regress/t/t_lint_unused_bad.v
@@ -40,6 +40,30 @@ module sub;
    genvar     unused_gv;
    genvar     ok_gv;
 
+   // verilator lint_off UNUSEDSIGNAL
+   wire linter_sig1;
+   localparam linter_param1 = 1;
+   genvar linter_genvar1;
+   // verilator lint_on UNUSEDSIGNAL
+
+   // verilator lint_off UNUSEDPARAM
+   wire linter_sig2;
+   localparam linter_param2 = 2;
+   genvar linter_genvar2;
+   // verilator lint_on UNUSEDPARAM
+
+   // verilator lint_off UNUSEDGENVAR
+   wire linter_sig3;
+   localparam linter_param3 = 3;
+   genvar linter_genvar3;
+   // verilator lint_on UNUSEDGENVAR
+
+   // verilator lint_off UNUSED
+   wire linter_sig4;
+   localparam linter_param4 = 4;
+   genvar linter_genvar4;
+   // verilator lint_on UNUSED
+
    initial begin
       if (0 && assunu1[0] != 0 && udrb2 != 0) begin end
       if (0 && assunub2[THREE] && assunub2[1:0]!=0) begin end

--- a/test_regress/t/t_lint_unused_iface_bad.out
+++ b/test_regress/t/t_lint_unused_iface_bad.out
@@ -4,8 +4,8 @@
       |          ^~~~~~~~
                    ... For warning description see https://verilator.org/warn/UNDRIVEN?v=latest
                    ... Use "/* verilator lint_off UNDRIVEN */" and lint_on around source to disable this message.
-%Warning-UNUSED: t/t_lint_unused_iface_bad.v:9:10: Signal is not used: 'sig_uusd'
-                                                 : ... In instance t.sub
+%Warning-UNUSEDSIGNAL: t/t_lint_unused_iface_bad.v:9:10: Signal is not used: 'sig_uusd'
+                                                       : ... In instance t.sub
     9 |    logic sig_uusd;
       |          ^~~~~~~~
 %Error: Exiting due to

--- a/test_regress/t/t_waiveroutput.out
+++ b/test_regress/t/t_waiveroutput.out
@@ -9,5 +9,5 @@
 
 // lint_off -rule WIDTH -file "*t/t_waiveroutput.v" -match "Operator ASSIGN expects 1 bits on the Assign RHS, but Assign RHS's CONST '2'h3' generates 2 bits."
 
-// lint_off -rule UNUSED -file "*t/t_waiveroutput.v" -match "Signal is not used: 'width_warn'"
+// lint_off -rule UNUSEDSIGNAL -file "*t/t_waiveroutput.v" -match "Signal is not used: 'width_warn'"
 


### PR DESCRIPTION
This is related to #3571. I added three new warnings:

* UNUSEDGENVAR: This one detects unused genvars.
* UNUSEDPARAM: This one detects unused parameters, localparam,... 
* UNUSEDSIGNAL: This one detects unused signals. Basically, it behaves like UNUSED from before https://github.com/verilator/verilator/commit/47eeef485d1781f104211d96ffb7498f55ae1b2b

I also kept UNUSED warning. It is not a basic warning anymore, but behaves more like lint or style warning, aka it calls the above three warnings.

I updated some of the tests to reflect the changes. I ran the longtests and they all pass. This is my first contribution. Let me know if I need to do any additional thing.