### PR TITLE
Tests: Public Enum Using `verilator_config

### DIFF
--- a/test_regress/t/t_enum_public_vlt.cpp
+++ b/test_regress/t/t_enum_public_vlt.cpp
@@ -1,0 +1,33 @@
+// -*- mode: C++; c-file-style: "cc-mode" -*-
+//
+// DESCRIPTION: Verilator: Verilog Test C++ main
+//
+// This file ONLY is placed into the Public Domain, for any use,
+// without warranty, 2022 by Robert Newgard
+// SPDX-License-Identifier: CC0-1.0
+
+#include <verilated.h>
+
+#include "Vt_enum_public_vlt.h"
+#include "Vt_enum_public_vlt___024root.h"
+#include "Vt_enum_public_vlt_t_pkg.h"
+
+double sc_time_stamp() { return 0; }
+
+int main(int argc, char* argv[]) {
+    Vt_enum_public_vlt* topp = new Vt_enum_public_vlt;
+
+    Verilated::debug(0);
+
+    // Check public -enum attributes in verilator_config
+    if (Vt_enum_public_vlt_t_pkg::t_enum_1::ENUM_1_0 == Vt_enum_public_vlt_t_pkg::t_enum_1::ENUM_1_1) {}
+    if (Vt_enum_public_vlt_t_pkg::t_enum_2::ENUM_2_0 == Vt_enum_public_vlt_t_pkg::t_enum_2::ENUM_2_1) {}
+    if (Vt_enum_public_vlt___024root::t__DOT__t_enum_3::ENUM_3_0 == Vt_enum_public_vlt___024root::t__DOT__t_enum_3::ENUM_3_1) {}
+
+    for (int i = 0; i < 10; i++) {  //
+        topp->eval();
+    }
+
+    topp->final();
+    VL_DO_DANGLING(delete topp, topp);
+}

--- a/test_regress/t/t_enum_public_vlt.pl
+++ b/test_regress/t/t_enum_public_vlt.pl
@@ -1,0 +1,29 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2022 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+if ($Self->{vlt_all}) {
+    compile(
+        verilator_flags2 => ["--exe $Self->{t_dir}/$Self->{name}.cpp $Self->{t_dir}/$Self->{name}.vlt"],
+        make_top_shell => 0,
+        make_main => 0,
+        );
+} else {
+    compile(
+        );
+}
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_enum_public_vlt.v
+++ b/test_regress/t/t_enum_public_vlt.v
@@ -1,0 +1,41 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2022 by Robert Newgard.
+// SPDX-License-Identifier: CC0-1.0
+
+package t_pkg;
+    typedef enum [1:0]
+    {
+        ENUM_1_0,
+        ENUM_1_1,
+        ENUM_1_2,
+        ENUM_1_3
+    }
+    t_enum_1;
+
+    typedef enum logic [1:0]
+    {
+        ENUM_2_0,
+        ENUM_2_1,
+        ENUM_2_2,
+        ENUM_2_3
+    }
+    t_enum_2;
+endpackage
+
+module t();
+    typedef enum logic [1:0]
+    {
+        ENUM_3_0,
+        ENUM_3_1,
+        ENUM_3_2,
+        ENUM_3_3
+    }
+    t_enum_3;
+
+    initial begin
+        $write("*-* All Finished *-*\n");
+        $finish();
+    end
+endmodule

--- a/test_regress/t/t_enum_public_vlt.vlt
+++ b/test_regress/t/t_enum_public_vlt.vlt
@@ -1,0 +1,11 @@
+// DESCRIPTION: Verilator: Verilog Test verilator_config file
+//
+// This file ONLY is placed into the Public Domain, for any use,
+// without warranty, 2022 by Robert Newgard
+// SPDX-License-Identifier: CC0-1.0
+
+`verilator_config
+
+public -enum  "t_enum_1"
+public -enum  "t_enum_2"
+public -enum  "t_enum_3"


### PR DESCRIPTION
    1. Feature test limited to checking
       published SV enum in C++
    2. Created tests based on t_enum_public and
       t_trace_public_func_vlt

We appreciate your contributing to Verilator.  If this is your first commit, please add your name to docs/CONTRIBUTORS, and read our contributing guidelines in docs/CONTRIBUTING.rst.
