### PR TITLE
Constant enum methods

### DIFF
--- a/src/V3Simulate.h
+++ b/src/V3Simulate.h
@@ -442,7 +442,8 @@ private:
                     clearOptimizable(nodep, "Var write & read");
                 }
                 vscp->user1(vscp->user1() | VU_RV);
-                const bool isConst = nodep->varp()->isParam() && nodep->varp()->valuep();
+                const bool isConst = (nodep->varp()->isConst() || nodep->varp()->isParam())
+                                     && nodep->varp()->valuep();
                 AstNodeExpr* const valuep
                     = isConst ? fetchValueNull(nodep->varp()->valuep()) : nullptr;
                 // Propagate PARAM constants for constant function analysis

--- a/test_regress/t/t_enum_const_methods.pl
+++ b/test_regress/t/t_enum_const_methods.pl
@@ -1,0 +1,21 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2003 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_enum_const_methods.v
+++ b/test_regress/t/t_enum_const_methods.v
@@ -1,0 +1,47 @@
+// DESCRIPTION: Verilator: constant enum methods
+//
+// This file ONLY is placed into the Public Domain, for any use,
+// without warranty, 2022 by Todd Strader
+// SPDX-License-Identifier: CC0-1.0
+
+module t ();
+
+   typedef enum [1:0] {E0, E1, E2} enm_t;
+
+   function automatic enm_t get_first();
+      enm_t enm;
+      return enm.first;
+   endfunction
+
+   localparam enm_t enum_first = get_first();
+
+   function automatic enm_t get_last();
+      enm_t enm;
+      return enm.last;
+   endfunction
+
+   localparam enm_t enum_last = get_last();
+
+   function automatic enm_t get_second();
+      enm_t enm;
+      enm = enm.first;
+      return enm.next;
+   endfunction
+
+   localparam enm_t enum_second = get_second();
+
+   function automatic string get_name(enm_t enm);
+      return enm.name;
+   endfunction
+
+   localparam string e0_name = get_name(E0);
+
+   initial begin
+      if (enum_first != E0) $stop;
+      if (enum_last != E2) $stop;
+      if (enum_second != E1) $stop;
+      if (e0_name != "E0") $stop;
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end
+endmodule


### PR DESCRIPTION
Still needs C++ changes, but I was hoping to discuss implementation options here.

Basically the `next` and `name` enum methods do not work in constant functions.  This is because Verilator creates `
__Venumtab_enum*` variables in the $unit scope to facilitate these methods at runtime.  This produces the particularly confounding error message:
```
Location of non-constant VARREF '__Venumtab_enum_name0': Language violation: reference to non-function-local variable
```

I'm wondering if it would be better to produce the magic enum helper array inside the function (as opposed to in $unit) or if it would be better for constant functions to not reference the helper array and instead perform the next/name functionality in V3Simulate.
