### PR TITLE
Fix detecting number of build jobs in ubuntu 18.04

### DIFF
--- a/src/V3StatsReport.cpp
+++ b/src/V3StatsReport.cpp
@@ -44,6 +44,7 @@ class StatsReport final {
         os << "Information:\n";
         os << "  " << V3Options::version() << '\n';
         os << "  Arguments: " << v3Global.opt.allArgsString() << '\n';
+        os << "  Build jobs: " << v3Global.opt.buildJobs() << '\n';
         os << '\n';
     }
 

--- a/test_regress/t/t_flag_build_jobs_and_j.pl
+++ b/test_regress/t/t_flag_build_jobs_and_j.pl
@@ -14,16 +14,15 @@ top_filename("t/t_flag_make_cmake.v");
 compile(
     verilator_make_cmake => 0,
     verilator_make_gmake => 0,
-    verilator_flags2 => ['--exe --cc --build -j 10 --build-jobs 2',
-                         '../' . $Self->{main_filename},
-                         '-MAKEFLAGS -p --trace'],
+    verilator_flags2 => ['--exe --cc --build -j 10 --build-jobs 2 --stats',
+                         '../' . $Self->{main_filename}],
     );
 
 execute(
     check_finished => 1,
     );
 
-file_grep($Self->{obj_dir} . '/vlt_compile.log', qr/MAKEFLAGS = pw -j2/);
+file_grep($Self->{stats}, qr/Build jobs: 2/);
 
 ok(1);
 1;


### PR DESCRIPTION
``make`` added information about number of jobs to ``MAKEFLAGS`` in 4.2 (https://lists.gnu.org/archive/html/info-gnu/2016-05/msg00013.html), but ``ubuntu 18.04`` still uses ``4.1``. I couldn't find easy way to get jobs information from ``make 4.1``.

This PR adds build jobs to stats file and adapts failing test to grep for correct value.


Signed-off-by: Kamil Rakoczy <krakoczy@antmicro.com>

