### PR TITLE
Issue 3610

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -129,5 +129,6 @@ Yoda Lee
 Yossi Nivin
 Yuri Victorovich
 Yutetsu TAKATSUKASA
+Yu-Sheng Lin
 Yves Mathieu
 Zhanglei Wang

--- a/src/V3EmitCModel.cpp
+++ b/src/V3EmitCModel.cpp
@@ -552,6 +552,11 @@ class EmitCModel final : public EmitCFunc {
                     "elaboration.\");\n");
             puts(/**/ "}");
         }
+        puts(/**/ "if (tfp->isOpen()) {\n");
+        puts(/****/ "vl_fatal(__FILE__, __LINE__, __FILE__,\"'" + topClassName()
+             + +"::trace()' shall not be called after '" + v3Global.opt.traceClassBase()
+             + "C::open()'.\");\n");
+        puts(/**/ "}\n");
         puts(/**/ "if (false && levels && options) {}  // Prevent unused\n");
         puts(/**/ "tfp->spTrace()->addModel(this);\n");
         puts(/**/ "tfp->spTrace()->addInitCb(&" + protect("trace_init") + ", &(vlSymsp->TOP));\n");

--- a/test_regress/t/t_trace_open_wrong_order.cpp
+++ b/test_regress/t/t_trace_open_wrong_order.cpp
@@ -1,0 +1,25 @@
+// -*- mode: C++; c-file-style: "cc-mode" -*-
+//
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2010 by Yu-Sheng Lin.
+// SPDX-License-Identifier: CC0-1.0
+
+#include <verilated.h>
+#include <verilated_vcd_c.h>
+
+#include "Vt_trace_open_wrong_order.h"
+using namespace std;
+
+int main(int argc, char** argv) {
+    VerilatedContext ctx;
+    VerilatedVcdC tfp;
+    Vt_trace_open_wrong_order dut;
+    ctx.traceEverOn(true);
+    tfp.open("dump.vcd");  // Error! shall put to the next line!
+    dut.trace(&tfp, 99);  // Error!
+    tfp.dump(0);
+    tfp.close();
+    return 0;
+}

--- a/test_regress/t/t_trace_open_wrong_order.pl
+++ b/test_regress/t/t_trace_open_wrong_order.pl
@@ -1,0 +1,30 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2022 by Yu-Sheng Lin. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+if ($Self->{vlt_all}) {
+    compile(
+        verilator_flags2 => ["--cc --trace --exe $Self->{t_dir}/$Self->{name}.cpp"],
+        make_top_shell => 0,
+        make_main => 0,
+        );
+} else {
+    compile(
+        );
+}
+
+execute(
+    fails => 1
+    );
+file_grep($Self->{run_log_filename}, qr/::trace\(\)' shall not be called after 'VerilatedVcdC::open\(\)'/i);
+
+ok(1);
+1;

--- a/test_regress/t/t_trace_open_wrong_order.v
+++ b/test_regress/t/t_trace_open_wrong_order.v
@@ -1,0 +1,8 @@
+// DESCRIPTION: Verilator: Verilog dummy test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2022 by Yu-Sheng Lin.
+// SPDX-License-Identifier: CC0-1.0
+
+module t(input clk);
+endmodule


### PR DESCRIPTION
This PR aims to add error messages for `trace()` in verilator as discussed https://github.com/verilator/verilator/issues/3610 .
However, part of the the tests fail since the expected error messages appear at C++ executing stage, and there will be minor difference. Any idea to solve the discrepancy?

```
%Warning: vlt/t_trace_open_wrong_order: Line 1 miscompares; obj_vlt/t_trace_open_wrong_order/vlt_sim.log != t/t_trace_open_wrong_order.out
F1: %Error: ./Vt_trace_open_wrong_order.cpp:0: Vt_trace_open_wrong_order::trace() shall not be called after VerilatedVcdC::open().
F2: %Error: Vt_trace_open_wrong_order.cpp:0: Vt_trace_open_wrong_order::trace() shall not be called after VerilatedVcdC::open().
```