### PR TITLE
Streamline dump control options

### DIFF
--- a/bin/verilator
+++ b/bin/verilator
@@ -309,10 +309,13 @@ detailed descriptions of these arguments.
      +define+<var>=<value>      Set preprocessor define
     --dpi-hdr-only              Only produce the DPI header file
     --dump-defines              Show preprocessor defines with -E
-    --dump-tree                 Enable dumping .tree files
+    --dump-graph                Enable dumping V3Graphs to .dot
+    --dump-tree                 Enable dumping Ast .tree files
     --dump-tree-addrids         Use short identifiers instead of addresses
-    --dump-treei <level>        Enable dumping .tree files at a level
-    --dump-treei-<srcfile> <level>  Enable dumping .tree file at a source file at a level
+    --dump-<srcfile>            Enable dumping everything in source file
+    --dumpi-graph <level>       Enable dumping V3Graphs to .dot files at level
+    --dumpi-tree <level>        Enable dumping Ast .tree files at level
+    --dumpi-<srcfile> <level>   Enable dumping everything in source file at level
      -E                         Preprocess, but do not compile
     --error-limit <value>       Abort after this number of errors
     --exe                       Link to create executable

--- a/docs/guide/exe_verilator.rst
+++ b/docs/guide/exe_verilator.rst
@@ -266,8 +266,8 @@ Summary:
      generally is a less-optimized binary with symbols present (so GDB can be used on it).
    * Enable debugging messages (equivalent to :vlopt:`--debugi 3 <--debugi>`).
    * Enable internal assertions (equivalent to :vlopt:`--debug-check`).
-   * Enable intermediate form dump files (equivalent to :vlopt:`--dump-treei 3
-     <--dump-treei>`).
+   * Enable intermediate form dump files (equivalent to :vlopt:`--dumpi-tree 3
+     <--dumpi-tree>`).
    * Leak to make node numbers unique (equivalent to :vlopt:`--debug-leak
      <--no-debug-leak>`.
    * Call abort() instead of exit() if there are any errors (so GDB can see
@@ -358,25 +358,20 @@ Summary:
 
        touch foo.v ; verilator -E --dump-defines foo.v
 
+.. option:: --dump-graph
+
+   Rarely needed.  Enable dumping V3Graph .dot debug files with dumping
+   level 3. Before Verilator 4.228, :vlopt:`--dump-tree` used
+   to include this option.
+
 .. option:: --dump-tree
 
-   Rarely needed.  Enable writing .tree debug files with dumping level 3,
+   Rarely needed.  Enable dumping Ast .tree debug files with dumping level 3,
    which dumps the standard critical stages.  For details on the format see
    the Verilator Internals manual.  :vlopt:`--dump-tree` is enabled
    automatically with :vlopt:`--debug`, so :vlopt:`--debug --no-dump-tree
    <--dump-tree>` may be useful if the dump files are large and not
    desired.
-
-.. option:: --dump-treei <level>
-
-.. option:: --dump-treei-<srcfile> <level>
-
-   Rarely needed - for developer use.  Set internal tree dumping level
-   globally to a specific dumping level or set the specified Verilator
-   source file to the specified tree dumping level (e.g.
-   :vlopt:`--dump-treei-V3Order 9 <--dump-treei>`).  Level 0 disables dumps
-   and is equivalent to :vlopt:`--no-dump-tree <--dump-tree>`.  Level 9
-   enables dumping of every stage.
 
 .. option:: --dump-tree-addrids
 
@@ -386,6 +381,28 @@ Summary:
    not necessarily unique per node instance as an address might get reused
    by a newly allocated node after a node with the same address has been
    dumped then freed.
+
+.. option:: --dump-<srcfile>
+
+   Rarely needed - for developer use. Enable all dumping in the given
+   source file at level 3.
+
+.. option:: --dumpi-graph <level>
+
+   Rarely needed - for developer use.  Set internal V3Graph dumping level
+   globally to the specified value.
+
+.. option:: --dumpi-tree <level>
+
+   Rarely needed - for developer use.  Set internal Ast dumping level
+   globally to the specified value.
+
+.. option:: --dumpi-<srcfile> <level>
+
+   Rarely needed - for developer use. Set the dumping level in the
+   specified Verilator source file to the specified value (e.g.
+   :vlopt:`--dumpi-V3Order 9`).  Level 0 disables dumps and is equivalent
+   to :vlopt:`--no-dump-<srcfile>`.  Level 9 enables dumping of everything.
 
 .. option:: -E
 

--- a/src/V3Active.cpp
+++ b/src/V3Active.cpp
@@ -38,6 +38,8 @@
 
 #include <unordered_map>
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 //***** See below for main transformation engine
 
 //######################################################################
@@ -78,8 +80,6 @@ class LatchDetectGraph final : public V3Graph {
 protected:
     LatchDetectGraphVertex* m_curVertexp = nullptr;  // Current latch detection graph vertex
     std::vector<AstVarRef*> m_outputs;  // Vector of lvalues encountered on this pass
-
-    VL_DEBUG_FUNC;  // Declare debug()
 
     static LatchDetectGraphVertex* castVertexp(void* vertexp) {
         return reinterpret_cast<LatchDetectGraphVertex*>(vertexp);
@@ -183,7 +183,7 @@ public:
                         << " (not all control paths of combinational always assign a value)\n"
                         << nodep->warnMore()
                         << "... Suggest use of always_latch for intentional latches");
-                if (debug() >= 9) dumpDotFilePrefixed("latch_" + vrp->name());
+                if (dumpGraph() >= 9) dumpDotFilePrefixed("latch_" + vrp->name());
             }
             vertp->user(false);  // Clear again (see above)
             vrp->varp()->isLatched(latch_detected);
@@ -198,12 +198,7 @@ public:
 //######################################################################
 // Collect existing active names
 
-class ActiveBaseVisitor VL_NOT_FINAL : public VNVisitor {
-protected:
-    VL_DEBUG_FUNC;  // Declare debug()
-};
-
-class ActiveNamer final : public ActiveBaseVisitor {
+class ActiveNamer final : public VNVisitor {
 private:
     // STATE
     AstScope* m_scopep = nullptr;  // Current scope to add statement to
@@ -282,7 +277,7 @@ public:
 //######################################################################
 // Latch checking visitor
 
-class ActiveLatchCheckVisitor final : public ActiveBaseVisitor {
+class ActiveLatchCheckVisitor final : public VNVisitor {
 private:
     // NODE STATE
     // Input:
@@ -324,7 +319,7 @@ public:
 //######################################################################
 // Replace unsupported non-blocking assignments with blocking assignments
 
-class ActiveDlyVisitor final : public ActiveBaseVisitor {
+class ActiveDlyVisitor final : public VNVisitor {
 public:
     enum CheckType : uint8_t { CT_SEQ, CT_COMB, CT_INITIAL };
 
@@ -394,7 +389,7 @@ public:
 //######################################################################
 // Active class functions
 
-class ActiveVisitor final : public ActiveBaseVisitor {
+class ActiveVisitor final : public VNVisitor {
 private:
     // NODE STATE
     //  Each call to V3Const::constify
@@ -608,5 +603,5 @@ public:
 void V3Active::activeAll(AstNetlist* nodep) {
     UINFO(2, __FUNCTION__ << ": " << endl);
     { ActiveVisitor{nodep}; }  // Destruct before checking
-    V3Global::dumpCheckGlobalTree("active", 0, v3Global.opt.dumpTreeLevel(__FILE__) >= 3);
+    V3Global::dumpCheckGlobalTree("active", 0, dumpTree() >= 3);
 }

--- a/src/V3ActiveTop.cpp
+++ b/src/V3ActiveTop.cpp
@@ -33,6 +33,8 @@
 #include "V3Global.h"
 #include "V3SenTree.h"
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 //######################################################################
 // Active class functions
 
@@ -49,7 +51,6 @@ private:
     SenTreeFinder m_finder;  // Find global sentree's / add them under the AstTopScope
 
     // METHODS
-    VL_DEBUG_FUNC;  // Declare debug()
 
     // VISITORS
     void visit(AstNodeModule* nodep) override {
@@ -130,5 +131,5 @@ public:
 void V3ActiveTop::activeTopAll(AstNetlist* nodep) {
     UINFO(2, __FUNCTION__ << ": " << endl);
     { ActiveTopVisitor{nodep}; }  // Destruct before checking
-    V3Global::dumpCheckGlobalTree("activetop", 0, v3Global.opt.dumpTreeLevel(__FILE__) >= 3);
+    V3Global::dumpCheckGlobalTree("activetop", 0, dumpTree() >= 3);
 }

--- a/src/V3Assert.cpp
+++ b/src/V3Assert.cpp
@@ -23,6 +23,8 @@
 #include "V3Global.h"
 #include "V3Stats.h"
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 //######################################################################
 // Assert class functions
 
@@ -475,5 +477,5 @@ public:
 void V3Assert::assertAll(AstNetlist* nodep) {
     UINFO(2, __FUNCTION__ << ": " << endl);
     { AssertVisitor{nodep}; }  // Destruct before checking
-    V3Global::dumpCheckGlobalTree("assert", 0, v3Global.opt.dumpTreeLevel(__FILE__) >= 3);
+    V3Global::dumpCheckGlobalTree("assert", 0, dumpTree() >= 3);
 }

--- a/src/V3AssertPre.cpp
+++ b/src/V3AssertPre.cpp
@@ -25,6 +25,8 @@
 #include "V3Ast.h"
 #include "V3Global.h"
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 //######################################################################
 // Assert class functions
 
@@ -45,7 +47,6 @@ private:
     AstNode* m_disablep = nullptr;  // Last disable
 
     // METHODS
-    VL_DEBUG_FUNC;  // Declare debug()
 
     AstSenTree* newSenTree(AstNode* nodep) {
         // Create sentree based on clocked or default clock
@@ -206,5 +207,5 @@ public:
 void V3AssertPre::assertPreAll(AstNetlist* nodep) {
     UINFO(2, __FUNCTION__ << ": " << endl);
     { AssertPreVisitor{nodep}; }  // Destruct before checking
-    V3Global::dumpCheckGlobalTree("assertpre", 0, v3Global.opt.dumpTreeLevel(__FILE__) >= 3);
+    V3Global::dumpCheckGlobalTree("assertpre", 0, dumpTree() >= 3);
 }

--- a/src/V3Ast.cpp
+++ b/src/V3Ast.cpp
@@ -28,6 +28,8 @@
 #include <iomanip>
 #include <memory>
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 //======================================================================
 // Statics
 
@@ -1120,7 +1122,7 @@ void AstNode::dumpTreeFile(const string& filename, bool append, bool doDump, boo
             if (logsp->fail()) v3fatal("Can't write " << filename);
             *logsp << "Verilator Tree Dump (format 0x3900) from <e" << std::dec << editCountLast();
             *logsp << "> to <e" << std::dec << editCountGbl() << ">\n";
-            if (editCountGbl() == editCountLast() && !(v3Global.opt.dumpTree() >= 9)) {
+            if (editCountGbl() == editCountLast() && ::dumpTree() < 9) {
                 *logsp << '\n';
                 *logsp << "No changes since last dump!\n";
             } else {
@@ -1130,7 +1132,7 @@ void AstNode::dumpTreeFile(const string& filename, bool append, bool doDump, boo
         }
     }
     if (doDump && v3Global.opt.debugEmitV()) V3EmitV::debugEmitV(filename + ".v");
-    if (doCheck && (v3Global.opt.debugCheck() || v3Global.opt.dumpTree())) {
+    if (doCheck && (v3Global.opt.debugCheck() || ::dumpTree())) {
         // Error check
         checkTree();
         // Broken isn't part of check tree because it can munge iterp's

--- a/src/V3Begin.cpp
+++ b/src/V3Begin.cpp
@@ -35,6 +35,8 @@
 
 #include <algorithm>
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 //######################################################################
 
 class BeginState final {
@@ -70,7 +72,6 @@ private:
     int m_ifDepth = 0;  // Current if depth
 
     // METHODS
-    VL_DEBUG_FUNC;  // Declare debug()
 
     string dot(const string& a, const string& b) {
         if (a == "") return b;
@@ -322,5 +323,5 @@ void V3Begin::debeginAll(AstNetlist* nodep) {
         { BeginVisitor{nodep, &state}; }
         if (state.anyFuncInBegin()) { BeginRelinkVisitor{nodep, &state}; }
     }  // Destruct before checking
-    V3Global::dumpCheckGlobalTree("begin", 0, v3Global.opt.dumpTreeLevel(__FILE__) >= 3);
+    V3Global::dumpCheckGlobalTree("begin", 0, dumpTree() >= 3);
 }

--- a/src/V3Branch.cpp
+++ b/src/V3Branch.cpp
@@ -33,6 +33,8 @@
 
 #include <map>
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 //######################################################################
 // Branch state, as a visitor of each AstNode
 
@@ -49,7 +51,6 @@ private:
     std::vector<AstCFunc*> m_cfuncsp;  // List of all tasks
 
     // METHODS
-    VL_DEBUG_FUNC;  // Declare debug()
 
     void reset() {
         m_likely = false;

--- a/src/V3Broken.cpp
+++ b/src/V3Broken.cpp
@@ -36,6 +36,8 @@
 #include <unordered_map>
 #include <unordered_set>
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 //######################################################################
 // Generation counter for AstNode::m_brokenState
 

--- a/src/V3CCtors.cpp
+++ b/src/V3CCtors.cpp
@@ -35,6 +35,8 @@
 #include <algorithm>
 #include <list>
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 class VCtorType final {
 public:
     enum en : uint8_t { MODULE, CLASS, COVERAGE };

--- a/src/V3CUse.cpp
+++ b/src/V3CUse.cpp
@@ -32,6 +32,8 @@
 
 #include <set>
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 //######################################################################
 
 // Visit within a module all nodes and data types they reference, finding
@@ -106,5 +108,5 @@ void V3CUse::cUseAll() {
         // for each output file and put under that
         CUseVisitor{modp};
     }
-    V3Global::dumpCheckGlobalTree("cuse", 0, v3Global.opt.dumpTreeLevel(__FILE__) >= 3);
+    V3Global::dumpCheckGlobalTree("cuse", 0, dumpTree() >= 3);
 }

--- a/src/V3Case.cpp
+++ b/src/V3Case.cpp
@@ -45,6 +45,8 @@
 
 #include <algorithm>
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 #define CASE_OVERLAP_WIDTH 16  // Maximum width we can check for overlaps in
 #define CASE_BARF 999999  // Magic width when non-constant
 #define CASE_ENCODER_GROUP_DEPTH 8  // Levels of priority to be ORed together in top IF tree
@@ -57,7 +59,6 @@ private:
         = nullptr;  // Under a CASE value node, if so the relevant case statement
 
     // METHODS
-    VL_DEBUG_FUNC;  // Declare debug()
 
     void visit(AstNodeCase* nodep) override {
         if (VN_IS(nodep, Case) && VN_AS(nodep, Case)->casex()) {
@@ -138,7 +139,6 @@ private:
     std::array<AstNode*, 1 << CASE_OVERLAP_WIDTH> m_valueItem;
 
     // METHODS
-    VL_DEBUG_FUNC;  // Declare debug()
 
     bool isCaseTreeFast(AstCase* nodep) {
         int width = 0;
@@ -533,7 +533,7 @@ public:
 void V3Case::caseAll(AstNetlist* nodep) {
     UINFO(2, __FUNCTION__ << ": " << endl);
     { CaseVisitor{nodep}; }  // Destruct before checking
-    V3Global::dumpCheckGlobalTree("case", 0, v3Global.opt.dumpTreeLevel(__FILE__) >= 3);
+    V3Global::dumpCheckGlobalTree("case", 0, dumpTree() >= 3);
 }
 void V3Case::caseLint(AstNodeCase* nodep) {
     UINFO(4, __FUNCTION__ << ": " << endl);

--- a/src/V3Cast.cpp
+++ b/src/V3Cast.cpp
@@ -47,6 +47,8 @@
 
 #include <algorithm>
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 //######################################################################
 // Cast state, as a visitor of each AstNode
 
@@ -60,7 +62,6 @@ private:
     // STATE
 
     // METHODS
-    VL_DEBUG_FUNC;  // Declare debug()
 
     void insertCast(AstNode* nodep, int needsize) {  // We'll insert ABOVE passed node
         UINFO(4, "  NeedCast " << nodep << endl);
@@ -205,5 +206,5 @@ public:
 void V3Cast::castAll(AstNetlist* nodep) {
     UINFO(2, __FUNCTION__ << ": " << endl);
     { CastVisitor{nodep}; }  // Destruct before checking
-    V3Global::dumpCheckGlobalTree("cast", 0, v3Global.opt.dumpTreeLevel(__FILE__) >= 3);
+    V3Global::dumpCheckGlobalTree("cast", 0, dumpTree() >= 3);
 }

--- a/src/V3Cdc.cpp
+++ b/src/V3Cdc.cpp
@@ -38,13 +38,14 @@
 #include <iomanip>
 #include <memory>
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 constexpr int CDC_WEIGHT_ASYNC = 0x1000;  // Weight for edges that feed async logic
 
 //######################################################################
 
 class CdcBaseVisitor VL_NOT_FINAL : public VNVisitor {
 public:
-    VL_DEBUG_FUNC;  // Declare debug()
 };
 
 //######################################################################
@@ -323,13 +324,11 @@ private:
 
     void analyze() {
         UINFO(3, __FUNCTION__ << ": " << endl);
-        // if (debug() > 6) m_graph.dump();
-        if (debug() > 6) m_graph.dumpDotFilePrefixed("cdc_pre");
+        if (dumpGraph() > 6) m_graph.dumpDotFilePrefixed("cdc_pre");
+        // This will MAX across edge weights
+        m_graph.removeRedundantEdges(&V3GraphEdge::followAlwaysTrue);
         //
-        m_graph.removeRedundantEdges(
-            &V3GraphEdge::followAlwaysTrue);  // This will MAX across edge weights
-        //
-        m_graph.dumpDotFilePrefixed("cdc_simp");
+        if (dumpGraph() >= 3) m_graph.dumpDotFilePrefixed("cdc_simp");
         //
         analyzeReset();
     }

--- a/src/V3Changed.cpp
+++ b/src/V3Changed.cpp
@@ -36,6 +36,8 @@
 
 #include <algorithm>
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 //######################################################################
 
 class ChangedState final {
@@ -252,5 +254,5 @@ void V3Changed::changedAll(AstNetlist* nodep) {
         }
     });
 
-    V3Global::dumpCheckGlobalTree("changed", 0, v3Global.opt.dumpTreeLevel(__FILE__) >= 3);
+    V3Global::dumpCheckGlobalTree("changed", 0, dumpTree() >= 3);
 }

--- a/src/V3Class.cpp
+++ b/src/V3Class.cpp
@@ -28,6 +28,8 @@
 #include "V3Ast.h"
 #include "V3Global.h"
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 //######################################################################
 
 class ClassVisitor final : public VNVisitor {
@@ -47,7 +49,6 @@ private:
     std::vector<std::pair<AstNode*, AstNodeModule*>> m_toPackageMoves;
 
     // METHODS
-    VL_DEBUG_FUNC;  // Declare debug()
 
     void visit(AstClass* nodep) override {
         if (nodep->user1SetOnce()) return;
@@ -207,5 +208,5 @@ public:
 void V3Class::classAll(AstNetlist* nodep) {
     UINFO(2, __FUNCTION__ << ": " << endl);
     { ClassVisitor{nodep}; }  // Destruct before checking
-    V3Global::dumpCheckGlobalTree("class", 0, v3Global.opt.dumpTreeLevel(__FILE__) >= 3);
+    V3Global::dumpCheckGlobalTree("class", 0, dumpTree() >= 3);
 }

--- a/src/V3Clean.cpp
+++ b/src/V3Clean.cpp
@@ -33,6 +33,8 @@
 
 #include <algorithm>
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 //######################################################################
 // Clean state, as a visitor of each AstNode
 
@@ -54,7 +56,6 @@ private:
     const AstNodeModule* m_modp = nullptr;
 
     // METHODS
-    VL_DEBUG_FUNC;  // Declare debug()
 
     // Width resetting
     int cppWidth(AstNode* nodep) {
@@ -317,5 +318,5 @@ public:
 void V3Clean::cleanAll(AstNetlist* nodep) {
     UINFO(2, __FUNCTION__ << ": " << endl);
     { CleanVisitor{nodep}; }  // Destruct before checking
-    V3Global::dumpCheckGlobalTree("clean", 0, v3Global.opt.dumpTreeLevel(__FILE__) >= 3);
+    V3Global::dumpCheckGlobalTree("clean", 0, dumpTree() >= 3);
 }

--- a/src/V3Clock.cpp
+++ b/src/V3Clock.cpp
@@ -37,6 +37,8 @@
 
 #include <algorithm>
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 //######################################################################
 // Convert every WRITE AstVarRef to a READ ref
 
@@ -88,7 +90,6 @@ private:
     AstMTaskBody* m_mtaskBodyp = nullptr;  // Current mtask body
 
     // METHODS
-    VL_DEBUG_FUNC;  // Declare debug()
 
     AstVarScope* getCreateLastClk(AstVarScope* vscp) {
         if (vscp->user1p()) return static_cast<AstVarScope*>(vscp->user1p());
@@ -446,5 +447,5 @@ public:
 void V3Clock::clockAll(AstNetlist* nodep) {
     UINFO(2, __FUNCTION__ << ": " << endl);
     { ClockVisitor{nodep}; }  // Destruct before checking
-    V3Global::dumpCheckGlobalTree("clock", 0, v3Global.opt.dumpTreeLevel(__FILE__) >= 3);
+    V3Global::dumpCheckGlobalTree("clock", 0, dumpTree() >= 3);
 }

--- a/src/V3Combine.cpp
+++ b/src/V3Combine.cpp
@@ -33,6 +33,8 @@
 #include <list>
 #include <vector>
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 class CombineVisitor final : VNVisitor {
     // NODE STATE
     // AstNodeModule::user1()   List of AstCFuncs in this module (via m_cfuncs)
@@ -57,7 +59,6 @@ class CombineVisitor final : VNVisitor {
     VDouble0 m_cfuncsCombined;  // Statistic tracking
 
     // METHODS
-    VL_DEBUG_FUNC;  // Declare debug()
 
     void removeEmptyFunctions(std::list<AstCFunc*>& funcps) {
         for (funcit_t it = funcps.begin(), nit; it != funcps.end(); it = nit) {
@@ -235,5 +236,5 @@ public:
 void V3Combine::combineAll(AstNetlist* nodep) {
     UINFO(2, __FUNCTION__ << ": " << endl);
     CombineVisitor::apply(nodep);
-    V3Global::dumpCheckGlobalTree("combine", 0, v3Global.opt.dumpTreeLevel(__FILE__) >= 3);
+    V3Global::dumpCheckGlobalTree("combine", 0, dumpTree() >= 3);
 }

--- a/src/V3Common.cpp
+++ b/src/V3Common.cpp
@@ -29,6 +29,8 @@
 #include "V3EmitCBase.h"
 #include "V3Global.h"
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 //######################################################################
 // Common component builders
 
@@ -117,5 +119,5 @@ void V3Common::commonAll() {
             makeToStringMiddle(classp);
         }
     }
-    V3Global::dumpCheckGlobalTree("common", 0, v3Global.opt.dumpTreeLevel(__FILE__) >= 3);
+    V3Global::dumpCheckGlobalTree("common", 0, dumpTree() >= 3);
 }

--- a/src/V3Config.cpp
+++ b/src/V3Config.cpp
@@ -27,6 +27,8 @@
 #include <string>
 #include <unordered_map>
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 //######################################################################
 // Resolve wildcards in files, modules, ftasks or variables
 

--- a/src/V3Const.cpp
+++ b/src/V3Const.cpp
@@ -37,6 +37,8 @@
 #include <memory>
 #include <type_traits>
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 //######################################################################
 // Utilities
 
@@ -350,7 +352,6 @@ class ConstBitOpTreeVisitor final : public VNVisitor {
     std::vector<std::unique_ptr<VarInfo>> m_varInfos;  // VarInfo for each variable, [0] is nullptr
 
     // METHODS
-    VL_DEBUG_FUNC;  // Declare debug()
 
     bool isAndTree() const { return VN_IS(m_rootp, And); }
     bool isOrTree() const { return VN_IS(m_rootp, Or); }
@@ -893,7 +894,6 @@ private:
     V3UniqueNames m_concswapNames;  // For generating unique temporary variable names
 
     // METHODS
-    VL_DEBUG_FUNC;  // Declare debug()
 
     bool operandConst(AstNode* nodep) { return VN_IS(nodep, Const); }
     bool operandAsvConst(const AstNode* nodep) {
@@ -3664,7 +3664,7 @@ void V3Const::constifyAllLint(AstNetlist* nodep) {
         ConstVisitor visitor{ConstVisitor::PROC_V_WARN, /* globalPass: */ true};
         (void)visitor.mainAcceptEdit(nodep);
     }  // Destruct before checking
-    V3Global::dumpCheckGlobalTree("const", 0, v3Global.opt.dumpTreeLevel(__FILE__) >= 3);
+    V3Global::dumpCheckGlobalTree("const", 0, dumpTree() >= 3);
 }
 
 void V3Const::constifyCpp(AstNetlist* nodep) {
@@ -3673,7 +3673,7 @@ void V3Const::constifyCpp(AstNetlist* nodep) {
         ConstVisitor visitor{ConstVisitor::PROC_CPP, /* globalPass: */ true};
         (void)visitor.mainAcceptEdit(nodep);
     }  // Destruct before checking
-    V3Global::dumpCheckGlobalTree("const_cpp", 0, v3Global.opt.dumpTreeLevel(__FILE__) >= 3);
+    V3Global::dumpCheckGlobalTree("const_cpp", 0, dumpTree() >= 3);
 }
 
 AstNode* V3Const::constifyEdit(AstNode* nodep) {
@@ -3697,7 +3697,7 @@ void V3Const::constifyAllLive(AstNetlist* nodep) {
         ConstVisitor visitor{ConstVisitor::PROC_LIVE, /* globalPass: */ true};
         (void)visitor.mainAcceptEdit(nodep);
     }  // Destruct before checking
-    V3Global::dumpCheckGlobalTree("const", 0, v3Global.opt.dumpTreeLevel(__FILE__) >= 3);
+    V3Global::dumpCheckGlobalTree("const", 0, dumpTree() >= 3);
 }
 
 void V3Const::constifyAll(AstNetlist* nodep) {
@@ -3707,7 +3707,7 @@ void V3Const::constifyAll(AstNetlist* nodep) {
         ConstVisitor visitor{ConstVisitor::PROC_V_EXPENSIVE, /* globalPass: */ true};
         (void)visitor.mainAcceptEdit(nodep);
     }  // Destruct before checking
-    V3Global::dumpCheckGlobalTree("const", 0, v3Global.opt.dumpTreeLevel(__FILE__) >= 3);
+    V3Global::dumpCheckGlobalTree("const", 0, dumpTree() >= 3);
 }
 
 AstNode* V3Const::constifyExpensiveEdit(AstNode* nodep) {

--- a/src/V3Coverage.cpp
+++ b/src/V3Coverage.cpp
@@ -35,6 +35,8 @@
 #include <map>
 #include <unordered_map>
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 //######################################################################
 // Coverage state, as a visitor of each AstNode
 
@@ -86,7 +88,6 @@ private:
         m_handleLines;  // All line numbers for a given m_stateHandle
 
     // METHODS
-    VL_DEBUG_FUNC;  // Declare debug()
 
     const char* varIgnoreToggle(AstVar* nodep) {
         // Return true if this shouldn't be traced
@@ -546,5 +547,5 @@ public:
 void V3Coverage::coverage(AstNetlist* rootp) {
     UINFO(2, __FUNCTION__ << ": " << endl);
     { CoverageVisitor{rootp}; }  // Destruct before checking
-    V3Global::dumpCheckGlobalTree("coverage", 0, v3Global.opt.dumpTreeLevel(__FILE__) >= 3);
+    V3Global::dumpCheckGlobalTree("coverage", 0, dumpTree() >= 3);
 }

--- a/src/V3CoverageJoin.cpp
+++ b/src/V3CoverageJoin.cpp
@@ -28,6 +28,8 @@
 
 #include <vector>
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 //######################################################################
 // CoverageJoin state, as a visitor of each AstNode
 
@@ -42,7 +44,6 @@ private:
     VDouble0 m_statToggleJoins;  // Statistic tracking
 
     // METHODS
-    VL_DEBUG_FUNC;  // Declare debug()
 
     void detectDuplicates() {
         UINFO(9, "Finding duplicates\n");
@@ -116,5 +117,5 @@ public:
 void V3CoverageJoin::coverageJoin(AstNetlist* rootp) {
     UINFO(2, __FUNCTION__ << ": " << endl);
     { CoverageJoinVisitor{rootp}; }  // Destruct before checking
-    V3Global::dumpCheckGlobalTree("coveragejoin", 0, v3Global.opt.dumpTreeLevel(__FILE__) >= 3);
+    V3Global::dumpCheckGlobalTree("coveragejoin", 0, dumpTree() >= 3);
 }

--- a/src/V3Dead.cpp
+++ b/src/V3Dead.cpp
@@ -44,6 +44,8 @@
 #include <map>
 #include <vector>
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 //######################################################################
 // Dead state, as a visitor of each AstNode
 
@@ -78,7 +80,6 @@ private:
     bool m_sideEffect = false;  // Side effects discovered in assign RHS
 
     // METHODS
-    VL_DEBUG_FUNC;  // Declare debug()
 
     void checkAll(AstNode* nodep) {
         if (nodep != nodep->dtypep()) {  // NodeDTypes reference themselves
@@ -455,30 +456,29 @@ public:
 void V3Dead::deadifyModules(AstNetlist* nodep) {
     UINFO(2, __FUNCTION__ << ": " << endl);
     { DeadVisitor{nodep, false, false, false, false}; }  // Destruct before checking
-    V3Global::dumpCheckGlobalTree("deadModules", 0, v3Global.opt.dumpTreeLevel(__FILE__) >= 6);
+    V3Global::dumpCheckGlobalTree("deadModules", 0, dumpTree() >= 6);
 }
 
 void V3Dead::deadifyDTypes(AstNetlist* nodep) {
     UINFO(2, __FUNCTION__ << ": " << endl);
     { DeadVisitor{nodep, false, true, false, false}; }  // Destruct before checking
-    V3Global::dumpCheckGlobalTree("deadDtypes", 0, v3Global.opt.dumpTreeLevel(__FILE__) >= 3);
+    V3Global::dumpCheckGlobalTree("deadDtypes", 0, dumpTree() >= 3);
 }
 
 void V3Dead::deadifyDTypesScoped(AstNetlist* nodep) {
     UINFO(2, __FUNCTION__ << ": " << endl);
     { DeadVisitor{nodep, false, true, true, false}; }  // Destruct before checking
-    V3Global::dumpCheckGlobalTree("deadDtypesScoped", 0,
-                                  v3Global.opt.dumpTreeLevel(__FILE__) >= 3);
+    V3Global::dumpCheckGlobalTree("deadDtypesScoped", 0, dumpTree() >= 3);
 }
 
 void V3Dead::deadifyAll(AstNetlist* nodep) {
     UINFO(2, __FUNCTION__ << ": " << endl);
     { DeadVisitor{nodep, true, true, false, true}; }  // Destruct before checking
-    V3Global::dumpCheckGlobalTree("deadAll", 0, v3Global.opt.dumpTreeLevel(__FILE__) >= 3);
+    V3Global::dumpCheckGlobalTree("deadAll", 0, dumpTree() >= 3);
 }
 
 void V3Dead::deadifyAllScoped(AstNetlist* nodep) {
     UINFO(2, __FUNCTION__ << ": " << endl);
     { DeadVisitor{nodep, true, true, true, true}; }  // Destruct before checking
-    V3Global::dumpCheckGlobalTree("deadAllScoped", 0, v3Global.opt.dumpTreeLevel(__FILE__) >= 3);
+    V3Global::dumpCheckGlobalTree("deadAllScoped", 0, dumpTree() >= 3);
 }

--- a/src/V3Delayed.cpp
+++ b/src/V3Delayed.cpp
@@ -61,6 +61,8 @@
 #include <deque>
 #include <map>
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 //######################################################################
 // Delayed state, as a visitor of each AstNode
 
@@ -102,7 +104,6 @@ private:
     std::unordered_map<const AstVarScope*, int> m_scopeVecMap;  // Next var number for each scope
 
     // METHODS
-    VL_DEBUG_FUNC;  // Declare debug()
 
     void markVarUsage(AstNodeVarRef* nodep, bool blocking) {
         // Ignore if warning is disabled on this reference (used by V3Force).
@@ -524,5 +525,5 @@ public:
 void V3Delayed::delayedAll(AstNetlist* nodep) {
     UINFO(2, __FUNCTION__ << ": " << endl);
     { DelayedVisitor{nodep}; }  // Destruct before checking
-    V3Global::dumpCheckGlobalTree("delayed", 0, v3Global.opt.dumpTreeLevel(__FILE__) >= 3);
+    V3Global::dumpCheckGlobalTree("delayed", 0, dumpTree() >= 3);
 }

--- a/src/V3Depth.cpp
+++ b/src/V3Depth.cpp
@@ -34,6 +34,8 @@
 
 #include <algorithm>
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 //######################################################################
 
 class DepthVisitor final : public VNVisitor {
@@ -49,7 +51,6 @@ private:
     V3UniqueNames m_tempNames;  // For generating unique temporary variable names
 
     // METHODS
-    VL_DEBUG_FUNC;  // Declare debug()
 
     void createDeepTemp(AstNode* nodep) {
         UINFO(6, "  Deep  " << nodep << endl);
@@ -171,5 +172,5 @@ public:
 void V3Depth::depthAll(AstNetlist* nodep) {
     UINFO(2, __FUNCTION__ << ": " << endl);
     { DepthVisitor{nodep}; }  // Destruct before checking
-    V3Global::dumpCheckGlobalTree("depth", 0, v3Global.opt.dumpTreeLevel(__FILE__) >= 6);
+    V3Global::dumpCheckGlobalTree("depth", 0, dumpTree() >= 6);
 }

--- a/src/V3DepthBlock.cpp
+++ b/src/V3DepthBlock.cpp
@@ -31,6 +31,8 @@
 
 #include <algorithm>
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 //######################################################################
 
 class DepthBlockVisitor final : public VNVisitor {
@@ -44,7 +46,6 @@ private:
     int m_deepNum = 0;  // How many functions made
 
     // METHODS
-    VL_DEBUG_FUNC;  // Declare debug()
 
     AstCFunc* createDeepFunc(AstNode* nodep) {
         VNRelinker relinkHandle;
@@ -131,5 +132,5 @@ public:
 void V3DepthBlock::depthBlockAll(AstNetlist* nodep) {
     UINFO(2, __FUNCTION__ << ": " << endl);
     { DepthBlockVisitor{nodep}; }  // Destruct before checking
-    V3Global::dumpCheckGlobalTree("deepblock", 0, v3Global.opt.dumpTreeLevel(__FILE__) >= 3);
+    V3Global::dumpCheckGlobalTree("deepblock", 0, dumpTree() >= 3);
 }

--- a/src/V3Descope.cpp
+++ b/src/V3Descope.cpp
@@ -33,6 +33,8 @@
 
 #include <map>
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 //######################################################################
 
 class DescopeVisitor final : public VNVisitor {
@@ -53,7 +55,6 @@ private:
     FuncMmap m_modFuncs;  // Name of public functions added
 
     // METHODS
-    VL_DEBUG_FUNC;  // Declare debug()
 
     static bool modIsSingleton(AstNodeModule* modp) {
         // True iff there's exactly one instance of this module in the design (including top).
@@ -283,5 +284,5 @@ public:
 void V3Descope::descopeAll(AstNetlist* nodep) {
     UINFO(2, __FUNCTION__ << ": " << endl);
     { DescopeVisitor{nodep}; }  // Destruct before checking
-    V3Global::dumpCheckGlobalTree("descope", 0, v3Global.opt.dumpTreeLevel(__FILE__) >= 3);
+    V3Global::dumpCheckGlobalTree("descope", 0, dumpTree() >= 3);
 }

--- a/src/V3DupFinder.cpp
+++ b/src/V3DupFinder.cpp
@@ -28,6 +28,8 @@
 #include <map>
 #include <memory>
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 //######################################################################
 // V3DupFinder class functions
 
@@ -98,7 +100,5 @@ void V3DupFinder::dumpFile(const string& filename, bool tree) {
 }
 
 void V3DupFinder::dumpFilePrefixed(const string& nameComment, bool tree) {
-    if (v3Global.opt.dumpTree()) {  //
-        dumpFile(v3Global.debugFilename(nameComment) + ".hash", tree);
-    }
+    if (dump()) dumpFile(v3Global.debugFilename(nameComment) + ".hash", tree);
 }

--- a/src/V3DupFinder.h
+++ b/src/V3DupFinder.h
@@ -59,7 +59,6 @@ public:
     }
 
     // METHODS
-    VL_DEBUG_FUNC;  // Declare debug()
 
     // Expose minimal set of superclass interface
     using Super::begin;

--- a/src/V3EmitCConstInit.h
+++ b/src/V3EmitCConstInit.h
@@ -32,7 +32,6 @@ class EmitCConstInit VL_NOT_FINAL : public EmitCBaseVisitor {
     uint32_t m_unpackedWord = 0;
 
     // METHODS
-    VL_DEBUG_FUNC;  // Declare debug()
 
     uint32_t tabModulus(AstNodeDType* dtypep) {
         const uint32_t elemBytes = dtypep->widthTotalBytes();

--- a/src/V3EmitCConstPool.cpp
+++ b/src/V3EmitCConstPool.cpp
@@ -27,6 +27,8 @@
 #include <algorithm>
 #include <cinttypes>
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 //######################################################################
 // Const pool emitter
 
@@ -38,7 +40,6 @@ class EmitCConstPool final : public EmitCConstInit {
     VDouble0 m_constsEmitted;
 
     // METHODS
-    VL_DEBUG_FUNC;  // Declare debug()
 
     V3OutCFile* newOutCFile() const {
         const string fileName = v3Global.opt.makeDir() + "/" + topClassName() + "__ConstPool_"

--- a/src/V3EmitCFunc.h
+++ b/src/V3EmitCFunc.h
@@ -90,8 +90,6 @@ class EmitCLazyDecls final : public VNVisitor {
 
     void visit(AstNode* nodep) override { iterateChildrenConst(nodep); }
 
-    VL_DEBUG_FUNC;
-
 public:
     explicit EmitCLazyDecls(EmitCBaseVisitor& emitter)
         : m_emitter(emitter) {}
@@ -154,7 +152,6 @@ protected:
 
 public:
     // METHODS
-    VL_DEBUG_FUNC;  // Declare debug()
 
     // ACCESSORS
     void splitSizeInc(int count) { m_splitSize += count; }

--- a/src/V3EmitCHeaders.cpp
+++ b/src/V3EmitCHeaders.cpp
@@ -24,12 +24,13 @@
 #include <algorithm>
 #include <vector>
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 //######################################################################
 // Internal EmitC implementation
 
 class EmitCHeader final : public EmitCConstInit {
     // METHODS
-    VL_DEBUG_FUNC;  // Declare debug()
 
     void decorateFirst(bool& first, const string& str) {
         if (first) {

--- a/src/V3EmitCImp.cpp
+++ b/src/V3EmitCImp.cpp
@@ -28,6 +28,8 @@
 #include <set>
 #include <vector>
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 //######################################################################
 // Visitor that gathers the headers required by an AstCFunc
 

--- a/src/V3EmitCInlines.cpp
+++ b/src/V3EmitCInlines.cpp
@@ -24,6 +24,8 @@
 
 #include <map>
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 //######################################################################
 
 class EmitCInlines final : EmitCBaseVisitor {

--- a/src/V3EmitCMain.cpp
+++ b/src/V3EmitCMain.cpp
@@ -25,6 +25,8 @@
 
 #include <map>
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 //######################################################################
 
 class EmitCMain final : EmitCBaseVisitor {

--- a/src/V3EmitCMake.cpp
+++ b/src/V3EmitCMake.cpp
@@ -26,13 +26,14 @@
 
 #include <memory>
 
-//######################################################################
-// Emit statements
+VL_DEFINE_DEBUG_FUNCTIONS;
+
+// ######################################################################
+//  Emit statements
 
 class CMakeEmitter final {
 
     // METHODS
-    VL_DEBUG_FUNC;  // Declare debug()
 
     // STATIC FUNCTIONS
 

--- a/src/V3EmitCModel.cpp
+++ b/src/V3EmitCModel.cpp
@@ -26,6 +26,8 @@
 #include <functional>
 #include <vector>
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 class EmitCModel final : public EmitCFunc {
     // TYPES
     using CFuncVector = std::vector<const AstCFunc*>;
@@ -34,8 +36,6 @@ class EmitCModel final : public EmitCFunc {
     V3UniqueNames m_uniqueNames;  // For generating unique file names
 
     // METHODS
-    VL_DEBUG_FUNC;
-
     CFuncVector findFuncps(std::function<bool(const AstCFunc*)> cb) {
         CFuncVector funcps;
         for (AstNode* nodep = m_modp->stmtsp(); nodep; nodep = nodep->nextp()) {

--- a/src/V3EmitCSyms.cpp
+++ b/src/V3EmitCSyms.cpp
@@ -27,6 +27,8 @@
 #include <map>
 #include <vector>
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 //######################################################################
 // Symbol table emitting
 

--- a/src/V3EmitMk.cpp
+++ b/src/V3EmitMk.cpp
@@ -24,13 +24,14 @@
 #include "V3HierBlock.h"
 #include "V3Os.h"
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 //######################################################################
 // Emit statements and math operators
 
 class EmitMk final {
 public:
     // METHODS
-    VL_DEBUG_FUNC;  // Declare debug()
 
     void putMakeClassEntry(V3OutMkFile& of, const string& name) {
         of.puts("\t" + V3Os::filenameNonDirExt(name) + " \\\n");
@@ -399,7 +400,6 @@ public:
         V3OutMkFile of(m_makefile);
         emit(of);
     }
-    VL_DEBUG_FUNC;  // Declare debug()
 };
 
 //######################################################################

--- a/src/V3EmitV.cpp
+++ b/src/V3EmitV.cpp
@@ -26,6 +26,8 @@
 #include <map>
 #include <vector>
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 //######################################################################
 // Emit statements and math operators
 
@@ -36,7 +38,6 @@ class EmitVBaseVisitor VL_NOT_FINAL : public EmitCBaseVisitor {
     AstSenTree* m_sensesp;  // Domain for printing one a ALWAYS under a ACTIVE
 
     // METHODS
-    VL_DEBUG_FUNC;  // Declare debug()
 
     virtual void puts(const string& str) = 0;
     virtual void putbs(const string& str) = 0;

--- a/src/V3EmitXml.cpp
+++ b/src/V3EmitXml.cpp
@@ -26,6 +26,8 @@
 #include <map>
 #include <vector>
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 //######################################################################
 // Emit statements and math operators
 
@@ -39,7 +41,6 @@ class EmitXmlFileVisitor final : public VNVisitor {
     uint64_t m_id = 0;
 
     // METHODS
-    VL_DEBUG_FUNC;  // Declare debug()
 
     // Outfile methods
     V3OutFile* ofp() const { return m_ofp; }
@@ -330,7 +331,6 @@ private:
     std::deque<FileLine*> m_nodeModules;
 
     // METHODS
-    VL_DEBUG_FUNC;  // Declare debug()
 
     // VISITORS
     void visit(AstNetlist* nodep) override {
@@ -378,7 +378,6 @@ private:
     bool m_hasChildren = false;
 
     // METHODS
-    VL_DEBUG_FUNC;  // Declare debug()
 
     // VISITORS
     void visit(AstConstPool*) override {}

--- a/src/V3Error.cpp
+++ b/src/V3Error.cpp
@@ -20,6 +20,7 @@
 # include "V3Ast.h"
 # include "V3Global.h"
 # include "V3Stats.h"
+VL_DEFINE_DEBUG_FUNCTIONS;
 #endif
 // clang-format on
 
@@ -275,8 +276,10 @@ void V3Error::v3errorEnd(std::ostringstream& sstr, const string& extra) {
                     s_tellManual = 2;
                 }
 #ifndef V3ERROR_NO_GLOBAL_
-                if (debug()) {
+                if (dumpTree()) {
                     v3Global.rootp()->dumpTreeFile(v3Global.debugFilename("final.tree", 990));
+                }
+                if (debug()) {
                     if (s_errorExitCb) s_errorExitCb();
                     V3Stats::statsFinalAll(v3Global.rootp());
                     V3Stats::statsReport();

--- a/src/V3Expand.cpp
+++ b/src/V3Expand.cpp
@@ -37,6 +37,8 @@
 
 #include <algorithm>
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 //######################################################################
 // Expand state, as a visitor of each AstNode
 
@@ -53,7 +55,6 @@ private:
     VDouble0 m_statWideLimited;  // Statistic tracking
 
     // METHODS
-    VL_DEBUG_FUNC;  // Declare debug()
 
     bool doExpand(AstNode* nodep) {
         ++m_statWides;
@@ -898,5 +899,5 @@ public:
 void V3Expand::expandAll(AstNetlist* nodep) {
     UINFO(2, __FUNCTION__ << ": " << endl);
     { ExpandVisitor{nodep}; }  // Destruct before checking
-    V3Global::dumpCheckGlobalTree("expand", 0, v3Global.opt.dumpTreeLevel(__FILE__) >= 3);
+    V3Global::dumpCheckGlobalTree("expand", 0, dumpTree() >= 3);
 }

--- a/src/V3File.cpp
+++ b/src/V3File.cpp
@@ -56,6 +56,8 @@
 #endif
 // clang-format on
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 // If change this code, run a test with the below size set very small
 // #define INFILTER_IPC_BUFSIZ 16
 constexpr int INFILTER_IPC_BUFSIZ = (64 * 1024);  // For debug, try this as a small number
@@ -346,7 +348,6 @@ class VInFilterImp final {
 
 private:
     // METHODS
-    VL_DEBUG_FUNC;  // Declare debug()
 
     bool readContents(const string& filename, StrList& outl) {
         if (m_pid) {

--- a/src/V3FileLine.cpp
+++ b/src/V3FileLine.cpp
@@ -33,6 +33,8 @@
 #include <iomanip>
 #include <unordered_set>
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 //######################################################################
 // FileLineSingleton class functions
 
@@ -82,12 +84,6 @@ void FileLineSingleton::fileNameNumMapDumpXml(std::ostream& os) {
 
 //######################################################################
 // VFileContents class functions
-
-int VFileContent::debug() {
-    static int level = -1;
-    if (VL_UNLIKELY(level < 0)) level = v3Global.opt.debugSrcLevel(__FILE__);
-    return level;
-}
 
 void VFileContent::pushText(const string& text) {
     if (m_lines.size() == 0) {

--- a/src/V3FileLine.h
+++ b/src/V3FileLine.h
@@ -77,7 +77,6 @@ public:
     void pushText(const string& text);  // Add arbitrary text (need not be line-by-line)
     string getLine(int lineno) const;
     string ascii() const { return "ct" + cvtToStr(m_id); }
-    static int debug();
 };
 std::ostream& operator<<(std::ostream& os, VFileContent* contentp);
 

--- a/src/V3Force.cpp
+++ b/src/V3Force.cpp
@@ -46,6 +46,8 @@
 #include "V3Error.h"
 #include "V3Global.h"
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 //######################################################################
 // Convert force/release statements and signals marked 'forceable'
 
@@ -305,5 +307,5 @@ void V3Force::forceAll(AstNetlist* nodep) {
     UINFO(2, __FUNCTION__ << ": " << endl);
     if (!v3Global.hasForceableSignals()) return;
     ForceConvertVisitor::apply(nodep);
-    V3Global::dumpCheckGlobalTree("force", 0, v3Global.opt.dumpTreeLevel(__FILE__) >= 3);
+    V3Global::dumpCheckGlobalTree("force", 0, dumpTree() >= 3);
 }

--- a/src/V3GenClk.cpp
+++ b/src/V3GenClk.cpp
@@ -27,18 +27,12 @@
 #include "V3Ast.h"
 #include "V3Global.h"
 
-//######################################################################
-// GenClk state, as a visitor of each AstNode
-
-class GenClkBaseVisitor VL_NOT_FINAL : public VNVisitor {
-protected:
-    VL_DEBUG_FUNC;  // Declare debug()
-};
+VL_DEFINE_DEBUG_FUNCTIONS;
 
 //######################################################################
 // GenClk Read
 
-class GenClkRenameVisitor final : public GenClkBaseVisitor {
+class GenClkRenameVisitor final : public VNVisitor {
 private:
     // NODE STATE
     // Cleared on top scope
@@ -126,7 +120,7 @@ public:
 //######################################################################
 // GenClk Read
 
-class GenClkReadVisitor final : public GenClkBaseVisitor {
+class GenClkReadVisitor final : public VNVisitor {
 private:
     // NODE STATE
     // Cleared on top scope
@@ -221,5 +215,5 @@ public:
 void V3GenClk::genClkAll(AstNetlist* nodep) {
     UINFO(2, __FUNCTION__ << ": " << endl);
     { GenClkReadVisitor{nodep}; }  // Destruct before checking
-    V3Global::dumpCheckGlobalTree("genclk", 0, v3Global.opt.dumpTreeLevel(__FILE__) >= 3);
+    V3Global::dumpCheckGlobalTree("genclk", 0, dumpTree() >= 3);
 }

--- a/src/V3Graph.cpp
+++ b/src/V3Graph.cpp
@@ -28,8 +28,7 @@
 #include <unordered_set>
 #include <vector>
 
-int V3Graph::s_debug = 0;
-int V3Graph::debug() { return std::max(V3Error::debugDefault(), s_debug); }
+VL_DEFINE_DEBUG_FUNCTIONS;
 
 //######################################################################
 //######################################################################
@@ -312,9 +311,7 @@ void V3Graph::dumpEdge(std::ostream& os, V3GraphVertex* vertexp, V3GraphEdge* ed
 }
 
 void V3Graph::dumpDotFilePrefixed(const string& nameComment, bool colorAsSubgraph) const {
-    if (v3Global.opt.dumpTree()) {
-        dumpDotFile(v3Global.debugFilename(nameComment) + ".dot", colorAsSubgraph);
-    }
+    dumpDotFile(v3Global.debugFilename(nameComment) + ".dot", colorAsSubgraph);
 }
 
 //! Variant of dumpDotFilePrefixed without --dump option check

--- a/src/V3Graph.h
+++ b/src/V3Graph.h
@@ -81,7 +81,6 @@ class V3Graph VL_NOT_FINAL {
 private:
     // MEMBERS
     V3List<V3GraphVertex*> m_vertices;  // All vertices
-    static int s_debug;
 
 protected:
     friend class V3GraphVertex;
@@ -92,12 +91,10 @@ protected:
     void dumpEdge(std::ostream& os, V3GraphVertex* vertexp, V3GraphEdge* edgep);
     void verticesUnlink() { m_vertices.reset(); }
     // ACCESSORS
-    static int debug();
 
 public:
     V3Graph();
     virtual ~V3Graph();
-    static void debug(int level) { s_debug = level; }
     virtual string dotRankDir() const { return "TB"; }  // rankdir for dot plotting
 
     // METHODS

--- a/src/V3GraphAcyc.cpp
+++ b/src/V3GraphAcyc.cpp
@@ -24,6 +24,8 @@
 #include <list>
 #include <vector>
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 //######################################################################
 //######################################################################
 // Algorithms - acyclic
@@ -103,8 +105,6 @@ private:
     const V3EdgeFuncP
         m_origEdgeFuncp;  // Function that says we follow this edge (in original graph)
     uint32_t m_placeStep = 0;  // Number that user() must be equal to to indicate processing
-
-    static int debug() { return V3Graph::debug(); }
 
     // METHODS
     void buildGraph(V3Graph* origGraphp);
@@ -544,28 +544,28 @@ void GraphAcyc::main() {
     // edges (and thus can't represent loops - if we did the unbreakable
     // marking right, anyways)
     buildGraph(m_origGraphp);
-    if (debug() >= 6) m_breakGraph.dumpDotFilePrefixed("acyc_pre");
+    if (dumpGraph() >= 6) m_breakGraph.dumpDotFilePrefixed("acyc_pre");
 
     // Perform simple optimizations before any cuttings
     simplify(false);
-    if (debug() >= 5) m_breakGraph.dumpDotFilePrefixed("acyc_simp");
+    if (dumpGraph() >= 5) m_breakGraph.dumpDotFilePrefixed("acyc_simp");
 
     UINFO(4, " Cutting trivial loops\n");
     simplify(true);
-    if (debug() >= 6) m_breakGraph.dumpDotFilePrefixed("acyc_mid");
+    if (dumpGraph() >= 6) m_breakGraph.dumpDotFilePrefixed("acyc_mid");
 
     UINFO(4, " Ranking\n");
     m_breakGraph.rank(&V3GraphEdge::followNotCutable);
-    if (debug() >= 6) m_breakGraph.dumpDotFilePrefixed("acyc_rank");
+    if (dumpGraph() >= 6) m_breakGraph.dumpDotFilePrefixed("acyc_rank");
 
     UINFO(4, " Placement\n");
     place();
-    if (debug() >= 6) m_breakGraph.dumpDotFilePrefixed("acyc_place");
+    if (dumpGraph() >= 6) m_breakGraph.dumpDotFilePrefixed("acyc_place");
 
     UINFO(4, " Final Ranking\n");
     // Only needed to assert there are no loops in completed graph
     m_breakGraph.rank(&V3GraphEdge::followAlwaysTrue);
-    if (debug() >= 6) m_breakGraph.dumpDotFilePrefixed("acyc_done");
+    if (dumpGraph() >= 6) m_breakGraph.dumpDotFilePrefixed("acyc_done");
 }
 
 void V3Graph::acyclic(V3EdgeFuncP edgeFuncp) {

--- a/src/V3GraphAlg.cpp
+++ b/src/V3GraphAlg.cpp
@@ -27,6 +27,8 @@
 #include <map>
 #include <vector>
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 //######################################################################
 //######################################################################
 // Algorithms - weakly connected components
@@ -120,7 +122,6 @@ public:
     }
 
 private:
-    VL_DEBUG_FUNC;  // Declare debug()
     VL_UNCOPYABLE(GraphAlgRemoveTransitiveEdges);
 };
 

--- a/src/V3GraphPathChecker.h
+++ b/src/V3GraphPathChecker.h
@@ -56,7 +56,6 @@ private:
     void initHalfCriticalPaths(GraphWay way, bool checkOnly);
     void incGeneration() { ++m_generation; }
 
-    VL_DEBUG_FUNC;  // Declare debug()
     VL_UNCOPYABLE(GraphPathChecker);
 };
 

--- a/src/V3GraphTest.cpp
+++ b/src/V3GraphTest.cpp
@@ -20,6 +20,8 @@
 #include "V3Global.h"
 #include "V3Graph.h"
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 //######################################################################
 //######################################################################
 // Test class
@@ -34,14 +36,14 @@ protected:
     virtual string name() = 0;  // Name of the test
 
     // Utilities
-    void dump() {
-        if (debug() >= 9) m_graph.dumpDotFilePrefixed("v3graphtest_" + name());
+    void dumpSelf() {
+        if (dumpGraph() >= 9) m_graph.dumpDotFilePrefixed("v3graphtest_" + name());
     }
 
 public:
     V3GraphTest() = default;
     virtual ~V3GraphTest() = default;
-    VL_DEBUG_FUNC;  // Declare debug()
+
     void run() { runTest(); }
 };
 
@@ -101,7 +103,7 @@ public:
         new V3GraphEdge(gp, g3, q, 2, true);
 
         gp->stronglyConnected(&V3GraphEdge::followAlwaysTrue);
-        dump();
+        dumpSelf();
 
         UASSERT(i->color() != a->color() && a->color() != g2->color() && g2->color() != q->color(),
                 "SelfTest: Separate colors not assigned");
@@ -136,7 +138,7 @@ public:
 
         gp->acyclic(&V3GraphEdge::followAlwaysTrue);
         gp->order();
-        dump();
+        dumpSelf();
     }
 };
 
@@ -253,7 +255,7 @@ public:
         gp->acyclic(&V3GraphEdge::followAlwaysTrue);
         gp->order();
 
-        dump();
+        dumpSelf();
     }
 };
 
@@ -272,11 +274,11 @@ public:
     void runTest() override {
         V3Graph* const gp = &m_graph;
         dotImport();
-        dump();
+        dumpSelf();
         gp->acyclic(&V3GraphEdge::followAlwaysTrue);
-        dump();
+        dumpSelf();
         gp->rank(&V3GraphEdge::followAlwaysTrue);
-        dump();
+        dumpSelf();
     }
 };
 

--- a/src/V3Hasher.cpp
+++ b/src/V3Hasher.cpp
@@ -21,6 +21,8 @@
 
 #include <functional>
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 //######################################################################
 // Visitor that computes node hashes
 
@@ -35,7 +37,6 @@ private:
     const bool m_cacheInUser4;  // Use user4 to cache each V3Hash?
 
     // METHODS
-    VL_DEBUG_FUNC;  // Declare debug()
 
     V3Hash hashNodeAndIterate(AstNode* nodep, bool hashDType, bool hashChildren,
                               std::function<void()>&& f) {

--- a/src/V3Hasher.h
+++ b/src/V3Hasher.h
@@ -40,7 +40,6 @@ public:
     ~V3Hasher() = default;
 
     // METHODS
-    VL_DEBUG_FUNC;  // Declare debug()
 
     // Compute hash of node. This method caches the hash in the node's user4().
     V3Hash operator()(AstNode* nodep) const;

--- a/src/V3HierBlock.cpp
+++ b/src/V3HierBlock.cpp
@@ -86,6 +86,8 @@
 #include <utility>
 #include <vector>
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 static string V3HierCommandArgsFileName(const string& prefix, bool forCMake) {
     return v3Global.opt.makeDir() + "/" + prefix
            + (forCMake ? "_hierCMakeArgs.f" : "_hierMkArgs.f");
@@ -302,7 +304,6 @@ public:
         : m_planp{planp} {
         iterateChildren(netlist);
     }
-    VL_DEBUG_FUNC;  // Declare debug()
 };
 
 //######################################################################

--- a/src/V3HierBlock.h
+++ b/src/V3HierBlock.h
@@ -67,7 +67,6 @@ public:
         : m_modp{modp}
         , m_gparams{gparams} {}
     ~V3HierBlock();
-    VL_DEBUG_FUNC;  // Declare debug()
 
     void addParent(V3HierBlock* parentp) { m_parents.insert(parentp); }
     void addChild(V3HierBlock* childp) { m_children.insert(childp); }
@@ -107,7 +106,6 @@ public:
     using iterator = HierMap::iterator;
     using const_iterator = HierMap::const_iterator;
     using HierVector = std::vector<const V3HierBlock*>;
-    VL_DEBUG_FUNC;  // Declare debug()
 
     void add(const AstNodeModule* modp, const std::vector<AstVar*>& gparams);
     void registerUsage(const AstNodeModule* parentp, const AstNodeModule* childp);

--- a/src/V3Inline.cpp
+++ b/src/V3Inline.cpp
@@ -40,6 +40,8 @@
 #include <unordered_set>
 #include <vector>
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 // CONFIG
 static const int INLINE_MODS_SMALLER = 100;  // If a mod is < this # nodes, can always inline it
 
@@ -95,7 +97,6 @@ private:
     std::unordered_map<AstNodeModule*, LocalInstanceMap> m_instances;
 
     // METHODS
-    VL_DEBUG_FUNC;  // Declare debug()
     void cantInline(const char* reason, bool hard) {
         if (hard) {
             if (m_modp->user2() != CIL_NOTHARD) {
@@ -255,9 +256,6 @@ private:
     std::unordered_set<std::string> m_renamedInterfaces;  // Name of renamed interface variables
     AstNodeModule* const m_modp;  // Current module
     const AstCell* const m_cellp;  // Cell being cloned
-
-    // METHODS
-    VL_DEBUG_FUNC;  // Declare debug()
 
     // VISITORS
     void visit(AstCellInline* nodep) override {
@@ -478,8 +476,6 @@ private:
     VDouble0 m_statCells;  // Statistic tracking
 
     // METHODS
-    VL_DEBUG_FUNC;  // Declare debug()
-
     void inlineCell(AstCell* nodep) {
         UINFO(5, " Inline CELL   " << nodep << endl);
 
@@ -635,9 +631,6 @@ private:
 
     string m_scope;  // Scope name
 
-    // METHODS
-    VL_DEBUG_FUNC;  // Declare debug()
-
     // VISITORS
     void visit(AstNetlist* nodep) override { iterateChildren(nodep->topModulep()); }
     void visit(AstCell* nodep) override {
@@ -734,5 +727,5 @@ void V3Inline::inlineAll(AstNetlist* nodep) {
     }
 
     { InlineIntfRefVisitor{nodep}; }
-    V3Global::dumpCheckGlobalTree("inline", 0, v3Global.opt.dumpTreeLevel(__FILE__) >= 3);
+    V3Global::dumpCheckGlobalTree("inline", 0, dumpTree() >= 3);
 }

--- a/src/V3Inst.cpp
+++ b/src/V3Inst.cpp
@@ -32,6 +32,8 @@
 
 #include <algorithm>
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 //######################################################################
 // Inst state, as a visitor of each AstNode
 
@@ -44,9 +46,6 @@ private:
 
     // STATE
     AstCell* m_cellp = nullptr;  // Current cell
-
-    // METHODS
-    VL_DEBUG_FUNC;  // Declare debug()
 
     // VISITORS
     void visit(AstCell* nodep) override {
@@ -146,8 +145,6 @@ private:
     // STATE
     std::map<const std::string, AstVar*> m_modVarNameMap;  // Per module, name of cloned variables
 
-    VL_DEBUG_FUNC;  // Declare debug()
-
     // VISITORS
     void visit(AstVar* nodep) override {
         if (VN_IS(nodep->dtypep(), IfaceRefDType)) {
@@ -199,8 +196,6 @@ private:
     const AstRange* m_cellRangep = nullptr;
     int m_instSelNum = 0;  // Current instantiation count 0..N-1
     InstDeModVarVisitor m_deModVars;  // State of variables for current cell module
-
-    VL_DEBUG_FUNC;  // Declare debug()
 
     // VISITORS
     void visit(AstVar* nodep) override {
@@ -492,7 +487,6 @@ public:
 
 class InstStatic final {
 private:
-    VL_DEBUG_FUNC;  // Declare debug()
     InstStatic() = default;  // Static class
 
     static AstNode* extendOrSel(FileLine* fl, AstNode* rhsp, AstNode* cmpWidthp) {
@@ -622,11 +616,11 @@ void V3Inst::checkOutputShort(AstPin* nodep) {
 void V3Inst::instAll(AstNetlist* nodep) {
     UINFO(2, __FUNCTION__ << ": " << endl);
     { InstVisitor{nodep}; }  // Destruct before checking
-    V3Global::dumpCheckGlobalTree("inst", 0, v3Global.opt.dumpTreeLevel(__FILE__) >= 3);
+    V3Global::dumpCheckGlobalTree("inst", 0, dumpTree() >= 3);
 }
 
 void V3Inst::dearrayAll(AstNetlist* nodep) {
     UINFO(2, __FUNCTION__ << ": " << endl);
     { InstDeVisitor{nodep}; }  // Destruct before checking
-    V3Global::dumpCheckGlobalTree("dearray", 0, v3Global.opt.dumpTreeLevel(__FILE__) >= 6);
+    V3Global::dumpCheckGlobalTree("dearray", 0, dumpTree() >= 6);
 }

--- a/src/V3InstrCount.cpp
+++ b/src/V3InstrCount.cpp
@@ -24,6 +24,8 @@
 
 #include <iomanip>
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 /// Estimate the instruction cost for executing all logic within and below
 /// a given AST node. Note this estimates the number of instructions we'll
 /// execute, not the number we'll generate. That is, for conditionals,
@@ -254,7 +256,6 @@ private:
         iterateChildren(nodep);
     }
 
-    VL_DEBUG_FUNC;  // Declare debug()
     VL_UNCOPYABLE(InstrCountVisitor);
 };
 
@@ -290,7 +291,7 @@ private:
         }
         --m_depth;
     }
-    VL_DEBUG_FUNC;  // Declare debug()
+
     VL_UNCOPYABLE(InstrCountDumpVisitor);
 };
 

--- a/src/V3Life.cpp
+++ b/src/V3Life.cpp
@@ -36,6 +36,8 @@
 #include <map>
 #include <vector>
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 //######################################################################
 // Structure for global state
 
@@ -128,8 +130,6 @@ class LifeBlock final {
     LifeMap m_map;  // Current active lifetime map for current scope
     LifeBlock* const m_aboveLifep;  // Upper life, or nullptr
     LifeState* const m_statep;  // Current global state
-
-    VL_DEBUG_FUNC;  // Declare debug()
 
 public:
     LifeBlock(LifeBlock* aboveLifep, LifeState* statep)
@@ -284,7 +284,6 @@ private:
     LifeBlock* m_lifep;  // Current active lifetime map for current scope
 
     // METHODS
-    VL_DEBUG_FUNC;  // Declare debug()
     void setNoopt() {
         m_noopt = true;
         m_lifep->clear();
@@ -495,5 +494,5 @@ void V3Life::lifeAll(AstNetlist* nodep) {
         LifeState state;
         LifeTopVisitor{nodep, &state};
     }  // Destruct before checking
-    V3Global::dumpCheckGlobalTree("life", 0, v3Global.opt.dumpTreeLevel(__FILE__) >= 3);
+    V3Global::dumpCheckGlobalTree("life", 0, dumpTree() >= 3);
 }

--- a/src/V3LifePost.cpp
+++ b/src/V3LifePost.cpp
@@ -38,6 +38,8 @@
 #include <memory>  // for std::unique_ptr -> auto_ptr or unique_ptr
 #include <unordered_map>
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 //######################################################################
 // LifePost class functions
 
@@ -50,8 +52,6 @@ private:
     //  AstVarScope::user4p()   -> AstVarScope*, If set, replace this
     //                             varscope with specified new one
     // STATE
-    // METHODS
-    VL_DEBUG_FUNC;  // Declare debug()
 
     // VISITORS
     void visit(AstVarRef* nodep) override {
@@ -157,8 +157,6 @@ private:
     std::unique_ptr<GraphPathChecker> m_checker;
 
     // METHODS
-    VL_DEBUG_FUNC;  // Declare debug()
-
     bool before(const LifeLocation& a, const LifeLocation& b) {
         if (a.mtaskp == b.mtaskp) return a.sequence < b.sequence;
         return m_checker->pathExistsFrom(a.mtaskp, b.mtaskp);
@@ -351,5 +349,5 @@ void V3LifePost::lifepostAll(AstNetlist* nodep) {
     UINFO(2, __FUNCTION__ << ": " << endl);
     // Mark redundant AssignPost
     { LifePostDlyVisitor{nodep}; }  // Destruct before checking
-    V3Global::dumpCheckGlobalTree("life_post", 0, v3Global.opt.dumpTreeLevel(__FILE__) >= 3);
+    V3Global::dumpCheckGlobalTree("life_post", 0, dumpTree() >= 3);
 }

--- a/src/V3LinkCells.cpp
+++ b/src/V3LinkCells.cpp
@@ -39,6 +39,8 @@
 #include <unordered_set>
 #include <vector>
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 //######################################################################
 // Graph subclasses
 
@@ -118,8 +120,6 @@ private:
     std::unordered_set<string> m_declfnWarned;  // Files we issued DECLFILENAME on
     string m_origTopModuleName;  // original name of the top module
 
-    VL_DEBUG_FUNC;  // Declare debug()
-
     // METHODS
     V3GraphVertex* vertex(AstNodeModule* nodep) {
         // Return corresponding vertex for this module
@@ -167,7 +167,7 @@ private:
         iterateChildren(nodep);
         // Find levels in graph
         m_graph.removeRedundantEdges(&V3GraphEdge::followAlwaysTrue);
-        m_graph.dumpDotFilePrefixed("linkcells");
+        if (dumpGraph()) m_graph.dumpDotFilePrefixed("linkcells");
         m_graph.rank();
         for (V3GraphVertex* itp = m_graph.verticesBeginp(); itp; itp = itp->verticesNextp()) {
             if (const LinkCellsVertex* const vvertexp = dynamic_cast<LinkCellsVertex*>(itp)) {

--- a/src/V3LinkDot.h
+++ b/src/V3LinkDot.h
@@ -28,32 +28,13 @@
 enum VLinkDotStep : uint8_t { LDS_PRIMARY, LDS_PARAMED, LDS_ARRAYED, LDS_SCOPED };
 
 class V3LinkDot final {
-private:
-    static int debug();
     static void linkDotGuts(AstNetlist* rootp, VLinkDotStep step);
 
 public:
-    static void linkDotPrimary(AstNetlist* nodep) {
-        UINFO(2, __FUNCTION__ << ": " << endl);
-        linkDotGuts(nodep, LDS_PRIMARY);
-        V3Global::dumpCheckGlobalTree("linkdot", 0, v3Global.opt.dumpTreeLevel(__FILE__) >= 6);
-    }
-    static void linkDotParamed(AstNetlist* nodep) {
-        UINFO(2, __FUNCTION__ << ": " << endl);
-        linkDotGuts(nodep, LDS_PARAMED);
-        V3Global::dumpCheckGlobalTree("linkdotparam", 0,
-                                      v3Global.opt.dumpTreeLevel(__FILE__) >= 3);
-    }
-    static void linkDotArrayed(AstNetlist* nodep) {
-        UINFO(2, __FUNCTION__ << ": " << endl);
-        linkDotGuts(nodep, LDS_ARRAYED);
-        V3Global::dumpCheckGlobalTree("linkdot", 0, v3Global.opt.dumpTreeLevel(__FILE__) >= 6);
-    }
-    static void linkDotScope(AstNetlist* nodep) {
-        UINFO(2, __FUNCTION__ << ": " << endl);
-        linkDotGuts(nodep, LDS_SCOPED);
-        V3Global::dumpCheckGlobalTree("linkdot", 0, v3Global.opt.dumpTreeLevel(__FILE__) >= 3);
-    }
+    static void linkDotPrimary(AstNetlist* nodep);
+    static void linkDotParamed(AstNetlist* nodep);
+    static void linkDotArrayed(AstNetlist* nodep);
+    static void linkDotScope(AstNetlist* nodep);
 };
 
 #endif  // Guard

--- a/src/V3LinkInc.cpp
+++ b/src/V3LinkInc.cpp
@@ -46,6 +46,8 @@
 
 #include <algorithm>
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 //######################################################################
 
 class LinkIncVisitor final : public VNVisitor {
@@ -64,8 +66,6 @@ private:
     bool m_unsupportedHere = false;  // Used to detect where it's not supported yet
 
     // METHODS
-    VL_DEBUG_FUNC;  // Declare debug()
-
     void insertBeforeStmt(AstNode* nodep, AstNode* newp) {
         // Return node that must be visited, if any
         // See also AstNode::addBeforeStmt; this predates that function
@@ -276,5 +276,5 @@ public:
 void V3LinkInc::linkIncrements(AstNetlist* nodep) {
     UINFO(2, __FUNCTION__ << ": " << endl);
     { LinkIncVisitor{nodep}; }  // Destruct before checking
-    V3Global::dumpCheckGlobalTree("linkinc", 0, v3Global.opt.dumpTreeLevel(__FILE__) >= 3);
+    V3Global::dumpCheckGlobalTree("linkinc", 0, dumpTree() >= 3);
 }

--- a/src/V3LinkJump.cpp
+++ b/src/V3LinkJump.cpp
@@ -40,6 +40,8 @@
 #include <algorithm>
 #include <vector>
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 //######################################################################
 
 class LinkJumpVisitor final : public VNVisitor {
@@ -54,8 +56,6 @@ private:
     std::vector<AstNodeBlock*> m_blockStack;  // All begin blocks above current node
 
     // METHODS
-    VL_DEBUG_FUNC;  // Declare debug()
-
     AstJumpLabel* findAddLabel(AstNode* nodep, bool endOfIter) {
         // Put label under given node, and if WHILE optionally at end of iteration
         UINFO(4, "Create label for " << nodep << endl);
@@ -303,5 +303,5 @@ public:
 void V3LinkJump::linkJump(AstNetlist* nodep) {
     UINFO(2, __FUNCTION__ << ": " << endl);
     { LinkJumpVisitor{nodep}; }  // Destruct before checking
-    V3Global::dumpCheckGlobalTree("linkjump", 0, v3Global.opt.dumpTreeLevel(__FILE__) >= 3);
+    V3Global::dumpCheckGlobalTree("linkjump", 0, dumpTree() >= 3);
 }

--- a/src/V3LinkLValue.cpp
+++ b/src/V3LinkLValue.cpp
@@ -28,6 +28,8 @@
 
 #include <map>
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 //######################################################################
 // Link state, as a visitor of each AstNode
 
@@ -40,9 +42,6 @@ private:
     bool m_setStrengthSpecified = false;  // Set that var has assignment with strength specified.
     VAccess m_setRefLvalue;  // Set VarRefs to lvalues for pin assignments
     AstNodeFTask* m_ftaskp = nullptr;  // Function or task we're inside
-
-    // METHODS
-    VL_DEBUG_FUNC;  // Declare debug()
 
     // VISITs
     // Result handing
@@ -338,7 +337,7 @@ public:
 void V3LinkLValue::linkLValue(AstNetlist* nodep) {
     UINFO(4, __FUNCTION__ << ": " << endl);
     { LinkLValueVisitor{nodep, VAccess::NOCHANGE}; }  // Destruct before checking
-    V3Global::dumpCheckGlobalTree("linklvalue", 0, v3Global.opt.dumpTreeLevel(__FILE__) >= 6);
+    V3Global::dumpCheckGlobalTree("linklvalue", 0, dumpTree() >= 6);
 }
 void V3LinkLValue::linkLValueSet(AstNode* nodep) {
     // Called by later link functions when it is known a node needs

--- a/src/V3LinkLevel.cpp
+++ b/src/V3LinkLevel.cpp
@@ -31,6 +31,8 @@
 #include <map>
 #include <vector>
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 //######################################################################
 // Levelizing class functions
 
@@ -78,7 +80,7 @@ void V3LinkLevel::modSortByLevel() {
     UASSERT_OBJ(!v3Global.rootp()->modulesp(), v3Global.rootp(), "Unlink didn't work");
     for (AstNodeModule* nodep : mods) v3Global.rootp()->addModulesp(nodep);
     UINFO(9, "modSortByLevel() done\n");  // Comment required for gcc4.6.3 / bug666
-    V3Global::dumpCheckGlobalTree("cells", false, v3Global.opt.dumpTreeLevel(__FILE__) >= 3);
+    V3Global::dumpCheckGlobalTree("cells", false, dumpTree() >= 3);
 }
 
 void V3LinkLevel::timescaling(const ModVec& mods) {
@@ -174,7 +176,7 @@ void V3LinkLevel::wrapTop(AstNetlist* rootp) {
         }
     }
 
-    V3Global::dumpCheckGlobalTree("wraptop", 0, v3Global.opt.dumpTreeLevel(__FILE__) >= 6);
+    V3Global::dumpCheckGlobalTree("wraptop", 0, dumpTree() >= 6);
 }
 
 void V3LinkLevel::wrapTopCell(AstNetlist* rootp) {

--- a/src/V3LinkParse.cpp
+++ b/src/V3LinkParse.cpp
@@ -32,6 +32,8 @@
 #include <set>
 #include <vector>
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 //######################################################################
 // Link state, as a visitor of each AstNode
 
@@ -62,8 +64,6 @@ private:
     VLifetime m_lifetime = VLifetime::STATIC;  // Propagating lifetime
 
     // METHODS
-    VL_DEBUG_FUNC;  // Declare debug()
-
     void cleanFileline(AstNode* nodep) {
         if (!nodep->user2SetOnce()) {  // Process once
             // We make all filelines unique per AstNode.  This allows us to
@@ -619,5 +619,5 @@ public:
 void V3LinkParse::linkParse(AstNetlist* rootp) {
     UINFO(4, __FUNCTION__ << ": " << endl);
     { LinkParseVisitor{rootp}; }  // Destruct before checking
-    V3Global::dumpCheckGlobalTree("linkparse", 0, v3Global.opt.dumpTreeLevel(__FILE__) >= 6);
+    V3Global::dumpCheckGlobalTree("linkparse", 0, dumpTree() >= 6);
 }

--- a/src/V3LinkResolve.cpp
+++ b/src/V3LinkResolve.cpp
@@ -36,6 +36,8 @@
 #include <algorithm>
 #include <map>
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 //######################################################################
 // Link state, as a visitor of each AstNode
 
@@ -54,9 +56,6 @@ private:
     AstNodeCoverOrAssert* m_assertp = nullptr;  // Current assertion
     int m_senitemCvtNum = 0;  // Temporary signal counter
     bool m_underGenerate = false;  // Under GenFor/GenIf
-
-    // METHODS
-    VL_DEBUG_FUNC;  // Declare debug()
 
     // VISITs
     // TODO: Most of these visitors are here for historical reasons.
@@ -552,9 +551,6 @@ private:
     // STATE
     AstNodeModule* m_modp = nullptr;  // Current module
 
-    // METHODS
-    VL_DEBUG_FUNC;  // Declare debug()
-
     // VISITs
     void visit(AstNetlist* nodep) override {
         // Iterate modules backwards, in bottom-up order.
@@ -590,5 +586,5 @@ void V3LinkResolve::linkResolve(AstNetlist* rootp) {
         const LinkResolveVisitor visitor{rootp};
         LinkBotupVisitor{rootp};
     }  // Destruct before checking
-    V3Global::dumpCheckGlobalTree("linkresolve", 0, v3Global.opt.dumpTreeLevel(__FILE__) >= 6);
+    V3Global::dumpCheckGlobalTree("linkresolve", 0, dumpTree() >= 6);
 }

--- a/src/V3Localize.cpp
+++ b/src/V3Localize.cpp
@@ -34,6 +34,8 @@
 
 #include <vector>
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 //######################################################################
 // LocalizeVisitor
 
@@ -62,8 +64,6 @@ private:
     std::vector<AstVarScope*> m_varScopeps;  // List of variables to consider for localization
 
     // METHODS
-    VL_DEBUG_FUNC;  // Declare debug()
-
     bool isOptimizable(AstVarScope* nodep) {
         return !nodep->user1() ||  // Not marked as not optimizable, or ...
                (nodep->varp()->varType() == VVarType::BLOCKTEMP
@@ -221,5 +221,5 @@ public:
 void V3Localize::localizeAll(AstNetlist* nodep) {
     UINFO(2, __FUNCTION__ << ": " << endl);
     { LocalizeVisitor{nodep}; }  // Destruct before checking
-    V3Global::dumpCheckGlobalTree("localize", 0, v3Global.opt.dumpTreeLevel(__FILE__) >= 6);
+    V3Global::dumpCheckGlobalTree("localize", 0, dumpTree() >= 6);
 }

--- a/src/V3MergeCond.cpp
+++ b/src/V3MergeCond.cpp
@@ -87,6 +87,8 @@
 #include <queue>
 #include <set>
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 namespace {
 
 //######################################################################
@@ -455,7 +457,6 @@ private:
     StmtPropertiesAllocator* m_stmtPropertiesp = nullptr;
 
     // METHODS
-    VL_DEBUG_FUNC;  // Declare debug()
 
     // Function that processes a whole sub-tree
     void process(AstNode* nodep) {
@@ -883,5 +884,5 @@ public:
 void V3MergeCond::mergeAll(AstNetlist* nodep) {
     UINFO(2, __FUNCTION__ << ": " << endl);
     { MergeCondVisitor{nodep}; }
-    V3Global::dumpCheckGlobalTree("merge_cond", 0, v3Global.opt.dumpTreeLevel(__FILE__) >= 6);
+    V3Global::dumpCheckGlobalTree("merge_cond", 0, dumpTree() >= 6);
 }

--- a/src/V3Name.cpp
+++ b/src/V3Name.cpp
@@ -28,6 +28,8 @@
 #include "V3Global.h"
 #include "V3LanguageWords.h"
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 //######################################################################
 // Name state, as a visitor of each AstNode
 
@@ -44,8 +46,6 @@ private:
     const AstNodeModule* m_modp = nullptr;
 
     // METHODS
-    VL_DEBUG_FUNC;  // Declare debug()
-
     void rename(AstNode* nodep, bool addPvt) {
         if (!nodep->user1()) {  // Not already done
             if (addPvt) {
@@ -144,5 +144,5 @@ public:
 void V3Name::nameAll(AstNetlist* nodep) {
     UINFO(2, __FUNCTION__ << ": " << endl);
     { NameVisitor{nodep}; }  // Destruct before checking
-    V3Global::dumpCheckGlobalTree("name", 0, v3Global.opt.dumpTreeLevel(__FILE__) >= 6);
+    V3Global::dumpCheckGlobalTree("name", 0, dumpTree() >= 6);
 }

--- a/src/V3Number.cpp
+++ b/src/V3Number.cpp
@@ -27,6 +27,8 @@
 #include <cmath>
 #include <functional>
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 constexpr int MAX_SPRINTF_DOUBLE_SIZE
     = 1100;  // Maximum characters with a sprintf %e/%f/%g (really 1079)
 

--- a/src/V3Options.cpp
+++ b/src/V3Options.cpp
@@ -43,6 +43,7 @@
 #include <memory>
 #include <thread>
 #include <set>
+#include <string>
 
 #include "config_rev.h"
 
@@ -50,6 +51,8 @@
 # include <io.h>  // open, close
 #endif
 // clang-format on
+
+VL_DEFINE_DEBUG_FUNCTIONS;
 
 //######################################################################
 // V3 Internal state
@@ -1061,7 +1064,7 @@ void V3Options::parseOptsList(FileLine* fl, const string& optdir, int argc, char
     DECL_OPTION("-debug", CbCall, [this]() { setDebugMode(3); });
     DECL_OPTION("-debugi", CbVal, [this](int v) { setDebugMode(v); });
     DECL_OPTION("-debugi-", CbPartialMatchVal, [this](const char* optp, const char* valp) {
-        setDebugSrcLevel(optp, std::atoi(valp));
+        m_debugLevel[optp] = std::atoi(valp);
     });
     DECL_OPTION("-debug-abort", CbCall,
                 V3Error::vlAbort)
@@ -1082,15 +1085,11 @@ void V3Options::parseOptsList(FileLine* fl, const string& optdir, int argc, char
     DECL_OPTION("-debug-sigsegv", CbCall, throwSigsegv).undocumented();  // See also --debug-abort
     DECL_OPTION("-decoration", OnOff, &m_decoration);
     DECL_OPTION("-dpi-hdr-only", OnOff, &m_dpiHdrOnly);
-    DECL_OPTION("-dump-defines", OnOff, &m_dumpDefines);
-    DECL_OPTION("-dump-tree", CbOnOff,
-                [this](bool flag) { m_dumpTree = flag ? 3 : 0; });  // Also see --dump-treei
-    DECL_OPTION("-dump-tree-addrids", OnOff, &m_dumpTreeAddrids);
-    DECL_OPTION("-dump-treei", Set, &m_dumpTree);
-    DECL_OPTION("-dump-treei-", CbPartialMatchVal, [this](const char* optp, const char* valp) {
-        setDumpTreeLevel(optp, std::atoi(valp));
+    DECL_OPTION("-dump-", CbPartialMatch, [this](const char* optp) { m_dumpLevel[optp] = 3; });
+    DECL_OPTION("-no-dump-", CbPartialMatch, [this](const char* optp) { m_dumpLevel[optp] = 0; });
+    DECL_OPTION("-dumpi-", CbPartialMatchVal, [this](const char* optp, const char* valp) {
+        m_dumpLevel[optp] = std::atoi(valp);
     });
-
     DECL_OPTION("-E", Set, &m_preprocOnly);
     DECL_OPTION("-error-limit", CbVal, static_cast<void (*)(int)>(&V3Error::errorLimit));
     DECL_OPTION("-exe", OnOff, &m_exe);
@@ -1795,52 +1794,42 @@ V3Options::~V3Options() { VL_DO_CLEAR(delete m_impp, m_impp = nullptr); }
 
 void V3Options::setDebugMode(int level) {
     V3Error::debugDefault(level);
-    if (!m_dumpTree) m_dumpTree = 3;  // Don't override if already set.
+    if (!m_dumpLevel.count("tree")) m_dumpLevel["tree"] = 3;  // Don't override if already set.
     m_stats = true;
     m_debugCheck = true;
     cout << "Starting " << version() << endl;
 }
 
-void V3Options::setDebugSrcLevel(const string& srcfile, int level) {
-    const auto iter = m_debugSrcs.find(srcfile);
-    if (iter != m_debugSrcs.end()) {
-        iter->second = level;
-    } else {
-        m_debugSrcs.emplace(srcfile, level);
-    }
+unsigned V3Options::debugLevel(const string& tag) const {
+    const auto iter = m_debugLevel.find(tag);
+    return iter != m_debugLevel.end() ? iter->second : V3Error::debugDefault();
 }
 
-int V3Options::debugSrcLevel(const string& srcfile_path, int default_level) {
+unsigned V3Options::debugSrcLevel(const string& srcfile_path) const {
     // For simplicity, calling functions can just use __FILE__ for srcfile.
-    // That means though we need to cleanup the filename from ../Foo.cpp -> Foo
-    const string srcfile = V3Os::filenameNonDirExt(srcfile_path);
-    const auto iter = m_debugSrcs.find(srcfile);
-    if (iter != m_debugSrcs.end()) {
-        return iter->second;
-    } else {
-        return default_level;
-    }
+    // That means we need to strip the filenames: ../Foo.cpp -> Foo
+    return debugLevel(V3Os::filenameNonDirExt(srcfile_path));
 }
 
-void V3Options::setDumpTreeLevel(const string& srcfile, int level) {
-    const auto iter = m_dumpTrees.find(srcfile);
-    if (iter != m_dumpTrees.end()) {
-        iter->second = level;
-    } else {
-        m_dumpTrees.emplace(srcfile, level);
-    }
+unsigned V3Options::dumpLevel(const string& tag) const {
+    const auto iter = m_dumpLevel.find(tag);
+    return iter != m_dumpLevel.end() ? iter->second : 0;
 }
 
-int V3Options::dumpTreeLevel(const string& srcfile_path) {
+unsigned V3Options::dumpSrcLevel(const string& srcfile_path) const {
     // For simplicity, calling functions can just use __FILE__ for srcfile.
-    // That means though we need to cleanup the filename from ../Foo.cpp -> Foo
-    const string srcfile = V3Os::filenameNonDirExt(srcfile_path);
-    const auto iter = m_dumpTrees.find(srcfile);
-    if (iter != m_dumpTrees.end()) {
-        return iter->second;
-    } else {
-        return m_dumpTree;
+    // That means we need to strip the filenames: ../Foo.cpp -> Foo
+    return dumpLevel(V3Os::filenameNonDirExt(srcfile_path));
+}
+
+bool V3Options::dumpTreeAddrids() const {
+    static int level = -1;
+    if (VL_UNLIKELY(level < 0)) {
+        const unsigned value = dumpLevel("tree-addrids");
+        if (!available()) return value > 0;
+        level = static_cast<unsigned>(value);
     }
+    return level > 0;
 }
 
 void V3Options::optimize(int level) {

--- a/src/V3Options.h
+++ b/src/V3Options.h
@@ -188,7 +188,7 @@ class V3Options final {
 public:
 private:
     // TYPES
-    using DebugSrcMap = std::map<const std::string, int>;
+    using DebugLevelMap = std::map<const std::string, unsigned>;
 
     // MEMBERS (general options)
     V3OptionsImp* m_impp;  // Slow hidden options
@@ -206,8 +206,8 @@ private:
     V3StringSet m_noClockers;   // argument: Verilog -noclk signals
     V3StringList m_vFiles;      // argument: Verilog files to read
     V3StringList m_forceIncs;   // argument: -FI
-    DebugSrcMap m_debugSrcs;    // argument: --debugi-<srcfile>=<level>
-    DebugSrcMap m_dumpTrees;    // argument: --dump-treei-<srcfile>=<level>
+    DebugLevelMap m_debugLevel; // argument: --debugi-<srcfile/tag> <level>
+    DebugLevelMap m_dumpLevel;  // argument: --dumpi-<srcfile/tag> <level>
     std::map<const string, string> m_parameters;  // Parameters
     std::map<const string, V3HierarchicalBlockOption> m_hierBlocks;  // main switch: --hierarchical-block
 
@@ -238,8 +238,6 @@ private:
     bool m_debugSelfTest = false;   // main switch: --debug-self-test
     bool m_decoration = true;       // main switch: --decoration
     bool m_dpiHdrOnly = false;      // main switch: --dpi-hdr-only
-    bool m_dumpDefines = false;     // main switch: --dump-defines
-    bool m_dumpTreeAddrids = false; // main switch: --dump-tree-addrids
     bool m_exe = false;             // main switch: --exe
     bool m_flatten = false;         // main switch: --flatten
     bool m_hierarchical = false;    // main switch: --hierarchical
@@ -286,7 +284,6 @@ private:
     int         m_buildJobs = -1;    // main switch: --build-jobs, -j
     int         m_convergeLimit = 100;  // main switch: --converge-limit
     int         m_coverageMaxWidth = 256; // main switch: --coverage-max-width
-    int         m_dumpTree = 0;     // main switch: --dump-tree
     int         m_expandLimit = 64;  // main switch: --expand-limit
     int         m_gateStmts = 100;    // main switch: --gate-stmts
     int         m_hierChild = 0;      // main switch: --hierarchical-child
@@ -395,10 +392,10 @@ public:
     V3Options();
     ~V3Options();
     void setDebugMode(int level);
-    void setDebugSrcLevel(const string& srcfile, int level);
-    int debugSrcLevel(const string& srcfile_path, int default_level = V3Error::debugDefault());
-    void setDumpTreeLevel(const string& srcfile, int level);
-    int dumpTreeLevel(const string& srcfile_path);
+    unsigned debugLevel(const string& tag) const;
+    unsigned debugSrcLevel(const string& srcfile_path) const;
+    unsigned dumpLevel(const string& tag) const;
+    unsigned dumpSrcLevel(const string& srcfile_path) const;
 
     // METHODS
     void addCppFile(const string& filename);
@@ -452,7 +449,7 @@ public:
     bool debugSelfTest() const { return m_debugSelfTest; }
     bool decoration() const { return m_decoration; }
     bool dpiHdrOnly() const { return m_dpiHdrOnly; }
-    bool dumpDefines() const { return m_dumpDefines; }
+    bool dumpDefines() const { return m_dumpLevel.count("defines") && m_dumpLevel.at("defines"); }
     bool exe() const { return m_exe; }
     bool flatten() const { return m_flatten; }
     bool gmake() const { return m_gmake; }
@@ -493,8 +490,7 @@ public:
     int buildJobs() const { return m_buildJobs; }
     int convergeLimit() const { return m_convergeLimit; }
     int coverageMaxWidth() const { return m_coverageMaxWidth; }
-    int dumpTree() const { return m_dumpTree; }
-    bool dumpTreeAddrids() const { return m_dumpTreeAddrids; }
+    bool dumpTreeAddrids() const;
     int expandLimit() const { return m_expandLimit; }
     int gateStmts() const { return m_gateStmts; }
     int ifDepth() const { return m_ifDepth; }

--- a/src/V3Os.cpp
+++ b/src/V3Os.cpp
@@ -29,8 +29,13 @@
 #include "verilatedos.h"
 
 // Limited V3 headers here - this is a base class for Vlc etc
-#include "V3String.h"
 #include "V3Os.h"
+#include "V3String.h"
+
+#ifndef V3ERROR_NO_GLOBAL_
+#include "V3Global.h"
+VL_DEFINE_DEBUG_FUNCTIONS;
+#endif
 
 #include <cerrno>
 #include <climits>  // PATH_MAX (especially on FreeBSD)
@@ -38,6 +43,7 @@
 #include <dirent.h>
 #include <fstream>
 #include <memory>
+
 #include <sys/stat.h>
 #include <sys/types.h>
 

--- a/src/V3Param.cpp
+++ b/src/V3Param.cpp
@@ -65,6 +65,8 @@
 #include <memory>
 #include <vector>
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 //######################################################################
 // Hierarchical block and parameter db (modules without parameter is also handled)
 
@@ -88,7 +90,6 @@ class ParameterizedHierBlocks final {
         m_modParams;  // Parameter variables of hierarchical blocks
 
     // METHODS
-    VL_DEBUG_FUNC;  // Declare debug()
 
 public:
     ParameterizedHierBlocks(const V3HierBlockOptSet& hierOpts, AstNetlist* nodep) {
@@ -270,7 +271,6 @@ class ParamProcessor final {
     std::map<AstNodeModule*, DefaultValueMap> m_defaultParameterValues;
 
     // METHODS
-    VL_DEBUG_FUNC;  // Declare debug()
 
     static void makeSmallNames(AstNodeModule* modp) {
         std::vector<int> usedLetter;
@@ -888,7 +888,6 @@ class ParamVisitor final : public VNVisitor {
     std::unordered_map<AstNodeModule*, std::unordered_set<AstNodeModule*>> m_parentps;
 
     // METHODS
-    VL_DEBUG_FUNC;  // Declare debug()
 
     void visitCells(AstNodeModule* nodep) {
         UASSERT_OBJ(!m_iterateModule, nodep, "Should not nest");
@@ -1280,5 +1279,5 @@ public:
 void V3Param::param(AstNetlist* rootp) {
     UINFO(2, __FUNCTION__ << ": " << endl);
     { ParamVisitor{rootp}; }  // Destruct before checking
-    V3Global::dumpCheckGlobalTree("param", 0, v3Global.opt.dumpTreeLevel(__FILE__) >= 6);
+    V3Global::dumpCheckGlobalTree("param", 0, dumpTree() >= 6);
 }

--- a/src/V3ParseGrammar.cpp
+++ b/src/V3ParseGrammar.cpp
@@ -18,6 +18,8 @@
 
 #include "V3Ast.h"  // This must be before V3ParseBison.cpp, as we don't want #defines to conflict
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 //======================================================================
 // The guts come from bison output
 

--- a/src/V3ParseImp.cpp
+++ b/src/V3ParseImp.cpp
@@ -38,6 +38,8 @@
 
 #include <sstream>
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 //======================================================================
 // Globals
 
@@ -58,7 +60,7 @@ V3ParseImp::~V3ParseImp() {
 
     if (debug() >= 9) {
         UINFO(0, "~V3ParseImp\n");
-        symp()->dump(cout, "-vpi: ");
+        symp()->dumpSelf(cout, "-vpi: ");
     }
 }
 
@@ -497,7 +499,7 @@ void V3ParseImp::tokenPipelineSym() {
         const VSymEnt* foundp;
         if (const VSymEnt* const look_underp = V3ParseImp::parsep()->symp()->nextId()) {
             UINFO(7, "   tokenPipelineSym: next id lookup forced under " << look_underp << endl);
-            // if (debug() >= 7) V3ParseImp::parsep()->symp()->dump(cout, " -symtree: ");
+            // if (debug() >= 7) V3ParseImp::parsep()->symp()->dumpSelf(cout, " -symtree: ");
             foundp = look_underp->findIdFallback(*(yylval.strp));
             // "consume" it.  Must set again if want another token under temp scope
             V3ParseImp::parsep()->symp()->nextId(nullptr);
@@ -505,7 +507,7 @@ void V3ParseImp::tokenPipelineSym() {
             UINFO(7, "   tokenPipelineSym: find upward "
                          << V3ParseImp::parsep()->symp()->symCurrentp() << " for '"
                          << *(yylval.strp) << "'" << endl);
-            // if (debug()>=9) V3ParseImp::parsep()->symp()->symCurrentp()->dump(cout,
+            // if (debug()>=9) V3ParseImp::parsep()->symp()->symCurrentp()->dumpSelf(cout,
             // " -findtree: ", true);
             foundp = V3ParseImp::parsep()->symp()->symCurrentp()->findIdFallback(*(yylval.strp));
         }

--- a/src/V3ParseImp.h
+++ b/src/V3ParseImp.h
@@ -161,25 +161,10 @@ class V3ParseImp final {
     VTimescale m_timeLastUnit;  // Last `timescale's unit
 
 public:
+    VL_DEFINE_DEBUG_FUNCTIONS;
     // Note these are an exception to using the filename as the debug type
-    static int debugBison() {
-        static int level = -1;
-        if (VL_UNLIKELY(level < 0)) level = v3Global.opt.debugSrcLevel("bison");
-        return level;
-    }
-    static int debugFlex() {
-        static int level = -1;
-        if (VL_UNLIKELY(level < 0)) level = v3Global.opt.debugSrcLevel("flex");
-        return level;
-    }
-    static int debug() {
-        static int level = -1;
-        if (VL_UNLIKELY(level < 0)) {
-            level = std::max(std::max(debugBison(), debugFlex()),
-                             v3Global.opt.debugSrcLevel("V3ParseImp"));
-        }
-        return level;
-    }
+    VL_DEFINE_DEBUG(Bison);  // Define 'unsigned debugBison()'
+    VL_DEFINE_DEBUG(Flex);  // Define 'unsigned debugFlex()'
 
     // Functions called by lex rules:
     int yylexThis();

--- a/src/V3ParseSym.h
+++ b/src/V3ParseSym.h
@@ -55,6 +55,9 @@ public:
 
 private:
     // METHODS
+
+    VL_DEFINE_DEBUG_FUNCTIONS;
+
     static VSymEnt* getTable(AstNode* nodep) {
         UASSERT_OBJ(nodep->user4p(), nodep, "Current symtable not found");
         return nodep->user4u().toSymEnt();
@@ -115,7 +118,7 @@ public:
         if (VL_UNCOVERABLE(symCurrentp()->nodep() != nodep)) {  // LCOV_EXCL_START
             if (debug()) {
                 showUpward();
-                dump(cout, "-mism: ");
+                dumpSelf(cout, "-mism: ");
             }
             nodep->v3fatalSrc("Symbols suggest ending " << symCurrentp()->nodep()->prettyTypeName()
                                                         << " but parser thinks ending "
@@ -133,7 +136,7 @@ public:
         }
         UINFO(1, "ParseSym Current: " << symCurrentp()->nodep() << endl);
     }  // LCOV_EXCL_STOP
-    void dump(std::ostream& os, const string& indent = "") { m_syms.dump(os, indent); }
+    void dumpSelf(std::ostream& os, const string& indent = "") { m_syms.dumpSelf(os, indent); }
     AstNode* findEntUpward(const string& name) const {
         // Lookup the given string as an identifier, return type of the id, scanning upward
         VSymEnt* const foundp = symCurrentp()->findIdFallback(name);

--- a/src/V3Partition.cpp
+++ b/src/V3Partition.cpp
@@ -41,6 +41,8 @@
 #include <unordered_set>
 #include <vector>
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 class LogicMTask;
 class MTaskEdge;
 class MergeCandidate;
@@ -390,7 +392,6 @@ public:
     static void dumpCpFilePrefixed(const V3Graph* graphp, const string& nameComment);
 
 private:
-    VL_DEBUG_FUNC;  // Declare debug()
     VL_UNCOPYABLE(LogicMTask);
 };
 
@@ -826,7 +827,6 @@ public:
     }
 
 private:
-    VL_DEBUG_FUNC;  // Declare debug()
     VL_UNCOPYABLE(PartParallelismEst);
 };
 
@@ -1070,7 +1070,6 @@ public:
     }
 
 private:
-    VL_DEBUG_FUNC;
     VL_UNCOPYABLE(PartPropagateCp);
 };
 
@@ -1834,7 +1833,6 @@ public:
     }
 
 private:
-    VL_DEBUG_FUNC;  // Declare debug()
     VL_UNCOPYABLE(PartContraction);
 };
 
@@ -1848,8 +1846,6 @@ private:
     bool m_hasDpiHazard = false;  // Found a DPI import call.
     bool m_tracingCall = false;  // Iterating into a CCall to a CFunc
     // METHODS
-    VL_DEBUG_FUNC;
-
     void visit(AstCFunc* nodep) override {
         if (!m_tracingCall) return;
         m_tracingCall = false;
@@ -2203,7 +2199,6 @@ public:
 
 private:
     VL_UNCOPYABLE(PartFixDataHazards);
-    VL_DEBUG_FUNC;
 };
 
 //######################################################################
@@ -2525,7 +2520,7 @@ public:
             }
         }
 
-        if (debug() >= 4) schedule.dumpDotFilePrefixedAlways(mtaskGraph, "schedule");
+        if (dumpGraph() >= 4) schedule.dumpDotFilePrefixedAlways(mtaskGraph, "schedule");
 
         return schedule;
     }
@@ -2583,7 +2578,6 @@ public:
     }
 
 private:
-    VL_DEBUG_FUNC;  // Declare debug()
     VL_UNCOPYABLE(PartPackMTasks);
 };
 
@@ -2591,7 +2585,7 @@ private:
 // V3Partition implementation
 
 void V3Partition::debugMTaskGraphStats(const V3Graph* graphp, const string& stage) {
-    if (!debug()) return;
+    if (!debug() && !dump() && !dumpGraph()) return;
 
     UINFO(4, "\n");
     UINFO(4, " Stats for " << stage << endl);
@@ -2628,7 +2622,7 @@ void V3Partition::debugMTaskGraphStats(const V3Graph* graphp, const string& stag
     if (mtaskCount < 1000) {
         string filePrefix("ordermv_");
         filePrefix += stage;
-        if (debug() >= 4) graphp->dumpDotFilePrefixedAlways(filePrefix);
+        if (dumpGraph() >= 4) graphp->dumpDotFilePrefixedAlways(filePrefix);
     }
 
     // Look only at the cost of each mtask, neglect communication cost.
@@ -2729,9 +2723,7 @@ void V3Partition::go(V3Graph* mtasksp) {
     // For debug: print out the longest critical path.  This allows us to
     // verify that the costs look reasonable, that we aren't combining
     // nodes that should probably be split, etc.
-    if (v3Global.opt.dumpTreeLevel(__FILE__) >= 3) {
-        LogicMTask::dumpCpFilePrefixed(mtasksp, "cp");
-    }
+    if (dump() >= 3) LogicMTask::dumpCpFilePrefixed(mtasksp, "cp");
 
     // Merge nodes that could present data hazards; see comment within.
     {

--- a/src/V3Partition.h
+++ b/src/V3Partition.h
@@ -67,7 +67,6 @@ public:
 private:
     static void setupMTaskDeps(V3Graph* mtasksp, const Vx2MTaskMap* vx2mtaskp);
 
-    VL_DEBUG_FUNC;  // Declare debug()
     VL_UNCOPYABLE(V3Partition);
 };
 

--- a/src/V3PreLex.h
+++ b/src/V3PreLex.h
@@ -225,9 +225,8 @@ public:  // Used only by V3PreLex.cpp and V3PreProc.cpp
     // Called by VPreStream
     void streamDepthAdd(int delta) { m_streamDepth += delta; }
     int streamDepth() const { return m_streamDepth; }
-    /// Utility
-    static int debug();
-    static void debug(int level);
+    // Utility
+    static void setYYDebug(bool on);
     static string cleanDbgStrg(const string& in);
 
 private:

--- a/src/V3PreLex.l
+++ b/src/V3PreLex.l
@@ -462,11 +462,8 @@ void V3PreLex::pushStateIncFilename() {
     yymore();
 }
 
-void V3PreLex::debug(int level) {
-    yy_flex_debug = level;  // Use --debugi-V3PreShell, if level<5 this level is 0
-}
-int V3PreLex::debug() {
-    return yy_flex_debug; }
+void V3PreLex::setYYDebug(bool on) {
+    yy_flex_debug = static_cast<int>(on); }
 
 int V3PreLex::lex() {
     V3PreLex::s_currentLexp = this;  // Tell parser where to get/put data

--- a/src/V3PreProc.cpp
+++ b/src/V3PreProc.cpp
@@ -33,6 +33,8 @@
 #include <stack>
 #include <vector>
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 //======================================================================
 // Build in LEX script
 
@@ -111,8 +113,6 @@ public:
     // TYPES
     using DefinesMap = std::map<const std::string, VDefine>;
     using StrList = VInFilter::StrList;
-
-    // debug() -> see V3PreShellImp::debug; use --debugi-V3PreShell
 
     // Defines list
     DefinesMap m_defines;  ///< Map of defines
@@ -259,10 +259,7 @@ public:
     string removeDefines(const string& text) override;  // Remove defines in a text string
 
     // CONSTRUCTORS
-    V3PreProcImp() {
-        m_debug = 0;
-        m_states.push(ps_TOP);
-    }
+    V3PreProcImp() { m_states.push(ps_TOP); }
     void configure(FileLine* filelinep) {
         // configure() separate from constructor to avoid calling abstract functions
         m_preprocp = this;  // Silly, but to make code more similar to Verilog-Perl
@@ -273,7 +270,6 @@ public:
         m_lexp->m_keepComments = keepComments();
         m_lexp->m_keepWhitespace = keepWhitespace();
         m_lexp->m_pedantic = pedantic();
-        debug(debug());  // Set lexer debug via V3PreProc::debug() method
     }
     ~V3PreProcImp() override {
         if (m_lexp) VL_DO_CLEAR(delete m_lexp, m_lexp = nullptr);
@@ -489,12 +485,6 @@ void V3PreProcImp::comment(const string& text) {
 
 //*************************************************************************
 // VPreProc Methods.
-
-void V3PreProc::debug(int level) {
-    m_debug = level;
-    V3PreProcImp* idatap = static_cast<V3PreProcImp*>(this);
-    if (idatap->m_lexp) idatap->m_lexp->debug(debug() >= 5 ? debug() : 0);
-}
 
 FileLine* V3PreProc::fileline() {
     const V3PreProcImp* idatap = static_cast<V3PreProcImp*>(this);
@@ -777,6 +767,7 @@ string V3PreProcImp::defineSubst(VDefineRef* refp) {
 void V3PreProcImp::openFile(FileLine*, VInFilter* filterp, const string& filename) {
     // Open a new file, possibly overriding the current one which is active.
     if (m_incError) return;
+    m_lexp->setYYDebug(debug() >= 5);
     V3File::addSrcDepend(filename);
 
     // Read a list<string> with the whole file.

--- a/src/V3PreProc.h
+++ b/src/V3PreProc.h
@@ -39,8 +39,7 @@ class V3PreProc VL_NOT_FINAL {
     // After creating, call open(), then getline() in a loop.  The class will to the rest...
 
 protected:
-    // STATE
-    int m_debug;  // Debugging
+    VL_DEFINE_DEBUG_FUNCTIONS;
 
 public:
     // CONSTANTS
@@ -60,9 +59,6 @@ public:
     virtual string getline() = 0;  // Return next line/lines. (Null if done.)
     virtual bool isEof() const = 0;  // Return true on EOF.
     virtual void insertUnreadback(const string& text) = 0;
-
-    int debug() const { return m_debug; }
-    void debug(int level);
 
     FileLine* fileline();  ///< File/Line number for last getline call
 
@@ -99,7 +95,7 @@ public:
 
 protected:
     // CONSTRUCTORS
-    V3PreProc() { m_debug = 0; }
+    V3PreProc() {}
     void configure(FileLine* fl);
 
 public:

--- a/src/V3PreShell.cpp
+++ b/src/V3PreShell.cpp
@@ -28,6 +28,8 @@
 #include <algorithm>
 #include <iostream>
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 //######################################################################
 
 class V3PreShellImp final {
@@ -41,21 +43,11 @@ protected:
     //---------------------------------------
     // METHODS
 
-    static int debug(bool reset = false) {
-        static int level = -1;
-        if (VL_UNLIKELY(level < 0) || reset) {
-            level = v3Global.opt.debugSrcLevel(__FILE__);
-            if (s_preprocp) s_preprocp->debug(debug());
-        }
-        return level;
-    }
-
     void boot() {
         // Create the implementation pointer
         if (!s_preprocp) {
             FileLine* const cmdfl = new FileLine(FileLine::commandLineFilename());
             s_preprocp = V3PreProc::createPreProc(cmdfl);
-            s_preprocp->debug(debug());
             // Default defines
             FileLine* const prefl = new FileLine(FileLine::builtInFilename());
             s_preprocp->defineCmdLine(prefl, "VERILATOR", "1");  // LEAK_OK
@@ -88,8 +80,6 @@ protected:
 
     bool preproc(FileLine* fl, const string& modname, VInFilter* filterp, V3ParseImp* parsep,
                  const string& errmsg) {  // "" for no error
-        debug(true);  // Recheck if debug on - first check was before command line passed
-
         // Preprocess the given module, putting output in vppFilename
         UINFONL(1, "  Preprocessing " << modname << endl);
 

--- a/src/V3Premit.cpp
+++ b/src/V3Premit.cpp
@@ -36,6 +36,8 @@
 
 #include <algorithm>
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 constexpr int STATIC_CONST_MIN_WIDTH = 256;  // Minimum size to extract to static constant
 
 //######################################################################
@@ -62,8 +64,6 @@ private:
     VDouble0 m_extractedToConstPool;  // Statistic tracking
 
     // METHODS
-    VL_DEBUG_FUNC;  // Declare debug()
-
     bool assignNoTemp(AstNodeAssign* nodep) {
         return (VN_IS(nodep->lhsp(), VarRef) && !AstVar::scVarRecurse(nodep->lhsp())
                 && VN_IS(nodep->rhsp(), Const));
@@ -394,5 +394,5 @@ public:
 void V3Premit::premitAll(AstNetlist* nodep) {
     UINFO(2, __FUNCTION__ << ": " << endl);
     { PremitVisitor{nodep}; }  // Destruct before checking
-    V3Global::dumpCheckGlobalTree("premit", 0, v3Global.opt.dumpTreeLevel(__FILE__) >= 3);
+    V3Global::dumpCheckGlobalTree("premit", 0, dumpTree() >= 3);
 }

--- a/src/V3ProtectLib.cpp
+++ b/src/V3ProtectLib.cpp
@@ -26,6 +26,8 @@
 
 #include <list>
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 //######################################################################
 // ProtectLib top-level visitor
 

--- a/src/V3Randomize.cpp
+++ b/src/V3Randomize.cpp
@@ -31,6 +31,8 @@
 
 #include "V3Ast.h"
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 //######################################################################
 // Visitor that marks classes needing a randomize() method
 
@@ -47,8 +49,6 @@ private:
     BaseToDerivedMap m_baseToDerivedMap;  // Mapping from base classes to classes that extend them
 
     // METHODS
-    VL_DEBUG_FUNC;
-
     void markMembers(AstClass* nodep) {
         for (auto* classp = nodep; classp;
              classp = classp->extendsp() ? classp->extendsp()->classp() : nullptr) {
@@ -127,8 +127,6 @@ private:
     size_t m_enumValueTabCount = 0;  // Number of tables with enum values created
 
     // METHODS
-    VL_DEBUG_FUNC;
-
     AstVar* enumValueTabp(AstEnumDType* nodep) {
         if (nodep->user2p()) return VN_AS(nodep->user2p(), Var);
         UINFO(9, "Construct Venumvaltab " << nodep << endl);
@@ -258,7 +256,7 @@ void V3Randomize::randomizeNetlist(AstNetlist* nodep) {
         const RandomizeMarkVisitor markVisitor{nodep};
         RandomizeVisitor{nodep};
     }
-    V3Global::dumpCheckGlobalTree("randomize", 0, v3Global.opt.dumpTreeLevel(__FILE__) >= 3);
+    V3Global::dumpCheckGlobalTree("randomize", 0, dumpTree() >= 3);
 }
 
 AstFunc* V3Randomize::newRandomizeFunc(AstClass* nodep) {

--- a/src/V3Reloop.cpp
+++ b/src/V3Reloop.cpp
@@ -40,6 +40,8 @@
 
 #include <algorithm>
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 //######################################################################
 
 class ReloopVisitor final : public VNVisitor {
@@ -66,7 +68,6 @@ private:
     uint32_t m_mgIndexHi = 0;  // Merge range
 
     // METHODS
-    VL_DEBUG_FUNC;  // Declare debug()
 
     static AstVar* findCreateVarTemp(FileLine* fl, AstCFunc* cfuncp) {
         AstVar* varp = VN_AS(cfuncp->user1p(), Var);
@@ -269,5 +270,5 @@ public:
 void V3Reloop::reloopAll(AstNetlist* nodep) {
     UINFO(2, __FUNCTION__ << ": " << endl);
     { ReloopVisitor{nodep}; }  // Destruct before checking
-    V3Global::dumpCheckGlobalTree("reloop", 0, v3Global.opt.dumpTreeLevel(__FILE__) >= 6);
+    V3Global::dumpCheckGlobalTree("reloop", 0, dumpTree() >= 6);
 }

--- a/src/V3Scope.cpp
+++ b/src/V3Scope.cpp
@@ -34,6 +34,8 @@
 #include <unordered_map>
 #include <unordered_set>
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 //######################################################################
 // Scope class functions
 
@@ -62,7 +64,6 @@ private:
         m_varRefScopes;  // Varrefs-in-scopes needing fixup when done
 
     // METHODS
-    VL_DEBUG_FUNC;  // Declare debug()
 
     void cleanupVarRefs() {
         for (const auto& itr : m_varRefScopes) {
@@ -327,7 +328,6 @@ private:
     AstScope* m_scopep = nullptr;  // Current scope we are building
 
     // METHODS
-    VL_DEBUG_FUNC;  // Declare debug()
 
     // VISITORS
     void visit(AstScope* nodep) override {
@@ -405,5 +405,5 @@ void V3Scope::scopeAll(AstNetlist* nodep) {
         const ScopeVisitor visitor{nodep};
         ScopeCleanupVisitor{nodep};
     }  // Destruct before checking
-    V3Global::dumpCheckGlobalTree("scope", 0, v3Global.opt.dumpTreeLevel(__FILE__) >= 3);
+    V3Global::dumpCheckGlobalTree("scope", 0, dumpTree() >= 3);
 }

--- a/src/V3Simulate.h
+++ b/src/V3Simulate.h
@@ -115,7 +115,7 @@ private:
     std::vector<AstNode*> m_reclaimValuesp;  // List of allocated string numbers
 
     // Note level 8&9 include debugging each simulation value
-    VL_DEBUG_FUNC;  // Declare debug()
+    VL_DEFINE_DEBUG_FUNCTIONS;
 
     // Potentially very slow, intended for debugging
     string prettyNumber(const V3Number* nump, AstNodeDType* dtypep) {

--- a/src/V3Slice.cpp
+++ b/src/V3Slice.cpp
@@ -43,6 +43,8 @@
 #include "V3Ast.h"
 #include "V3Global.h"
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 //*************************************************************************
 
 class SliceVisitor final : public VNVisitor {
@@ -58,8 +60,6 @@ class SliceVisitor final : public VNVisitor {
     bool m_assignError = false;  // True if the current assign already has an error
 
     // METHODS
-    VL_DEBUG_FUNC;  // Declare debug()
-
     AstNode* cloneAndSel(AstNode* nodep, int elements, int offset) {
         // Insert an ArraySel, except for a few special cases
         const AstUnpackArrayDType* const arrayp
@@ -240,5 +240,5 @@ public:
 void V3Slice::sliceAll(AstNetlist* nodep) {
     UINFO(2, __FUNCTION__ << ": " << endl);
     { SliceVisitor{nodep}; }  // Destruct before checking
-    V3Global::dumpCheckGlobalTree("slice", 0, v3Global.opt.dumpTreeLevel(__FILE__) >= 3);
+    V3Global::dumpCheckGlobalTree("slice", 0, dumpTree() >= 3);
 }

--- a/src/V3Split.cpp
+++ b/src/V3Split.cpp
@@ -93,6 +93,8 @@
 #include <unordered_set>
 #include <vector>
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 //######################################################################
 // Support classes
 
@@ -261,8 +263,6 @@ public:
 
     // METHODS
 protected:
-    VL_DEBUG_FUNC;  // Declare debug()
-
     void scoreboardClear() {
         // VV*****  We reset user1p() and user2p on each block!!!
         m_inDly = false;
@@ -450,10 +450,7 @@ protected:
         UINFO(5, "ReorderBlock " << nodep << endl);
         m_graph.removeRedundantEdges(&V3GraphEdge::followAlwaysTrue);
 
-        if (debug() >= 9) {
-            m_graph.dumpDotFilePrefixed("reorderg_nodup", false);
-            // m_graph.dump(); cout<<endl;
-        }
+        if (dumpGraph() >= 9) m_graph.dumpDotFilePrefixed("reorderg_nodup", false);
 
         // Mark all the logic for this step
         // Vertex::m_user begin: true indicates logic for this step
@@ -510,10 +507,10 @@ protected:
         // And a real ordering to get the statements into something reasonable
         // We don't care if there's cutable violations here...
         // Non-cutable violations should be impossible; as those edges are program-order
-        if (debug() >= 9) m_graph.dumpDotFilePrefixed(string("splitg_preo"), false);
+        if (dumpGraph() >= 9) m_graph.dumpDotFilePrefixed(string("splitg_preo"), false);
         m_graph.acyclic(&SplitEdge::followCyclic);
         m_graph.rank(&SplitEdge::followCyclic);  // Or order(), but that's more expensive
-        if (debug() >= 9) m_graph.dumpDotFilePrefixed(string("splitg_opt"), false);
+        if (dumpGraph() >= 9) m_graph.dumpDotFilePrefixed(string("splitg_opt"), false);
     }
 
     void reorderBlock(AstNode* nodep) {
@@ -672,7 +669,6 @@ protected:
         iterateChildren(nodep);
     }
 
-    VL_DEBUG_FUNC;  // Declare debug()
 private:
     VL_UNCOPYABLE(IfColorVisitor);
 };
@@ -724,8 +720,6 @@ public:
     }
 
 protected:
-    VL_DEBUG_FUNC;  // Declare debug()
-
     AstSplitPlaceholder* makePlaceholderp() {
         return new AstSplitPlaceholder(m_origAlwaysp->fileline());
     }
@@ -942,14 +936,14 @@ protected:
             }
         }
 
-        if (debug() >= 9) m_graph.dumpDotFilePrefixed("splitg_nodup", false);
+        if (dumpGraph() >= 9) m_graph.dumpDotFilePrefixed("splitg_nodup", false);
 
         // Weak coloring to determine what needs to remain grouped
         // in a single always. This follows all edges excluding:
         //  - those we pruned above
         //  - PostEdges, which are done later
         m_graph.weaklyConnected(&SplitEdge::followScoreboard);
-        if (debug() >= 9) m_graph.dumpDotFilePrefixed("splitg_colored", false);
+        if (dumpGraph() >= 9) m_graph.dumpDotFilePrefixed("splitg_colored", false);
     }
 
     void visit(AstAlways* nodep) override {
@@ -1003,10 +997,10 @@ private:
 void V3Split::splitReorderAll(AstNetlist* nodep) {
     UINFO(2, __FUNCTION__ << ": " << endl);
     { ReorderVisitor{nodep}; }  // Destruct before checking
-    V3Global::dumpCheckGlobalTree("reorder", 0, v3Global.opt.dumpTreeLevel(__FILE__) >= 3);
+    V3Global::dumpCheckGlobalTree("reorder", 0, dumpTree() >= 3);
 }
 void V3Split::splitAlwaysAll(AstNetlist* nodep) {
     UINFO(2, __FUNCTION__ << ": " << endl);
     { SplitVisitor{nodep}; }  // Destruct before checking
-    V3Global::dumpCheckGlobalTree("split", 0, v3Global.opt.dumpTreeLevel(__FILE__) >= 3);
+    V3Global::dumpCheckGlobalTree("split", 0, dumpTree() >= 3);
 }

--- a/src/V3SplitAs.cpp
+++ b/src/V3SplitAs.cpp
@@ -32,12 +32,13 @@
 
 #include <map>
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 //######################################################################
 
 class SplitAsBaseVisitor VL_NOT_FINAL : public VNVisitor {
 public:
     // METHODS
-    VL_DEBUG_FUNC;  // Declare debug()
 };
 
 //######################################################################
@@ -196,5 +197,5 @@ public:
 void V3SplitAs::splitAsAll(AstNetlist* nodep) {
     UINFO(2, __FUNCTION__ << ": " << endl);
     { SplitAsVisitor{nodep}; }  // Destruct before checking
-    V3Global::dumpCheckGlobalTree("splitas", 0, v3Global.opt.dumpTreeLevel(__FILE__) >= 3);
+    V3Global::dumpCheckGlobalTree("splitas", 0, dumpTree() >= 3);
 }

--- a/src/V3SplitVar.cpp
+++ b/src/V3SplitVar.cpp
@@ -125,6 +125,8 @@
 #include <set>
 #include <vector>
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 struct SplitVarImpl {
     // NODE STATE
     //  AstNodeModule::user1()  -> Block number counter for generating unique names
@@ -782,7 +784,6 @@ public:
         V3Stats::addStat("SplitVar, Split unpacked arrays", m_numSplit);
     }
     const SplitVarRefsMap& getPackedVarRefs() const { return m_refsForPackedSplit; }
-    VL_DEBUG_FUNC;  // Declare debug()
 
     // Check if the passed variable can be split.
     // Even if this function returns true, the variable may not be split
@@ -1243,7 +1244,6 @@ public:
         }
         return reason;
     }
-    VL_DEBUG_FUNC;  // Declare debug()
 };
 
 const char* SplitVarImpl::cannotSplitPackedVarReason(const AstVar* varp) {
@@ -1260,9 +1260,9 @@ void V3SplitVar::splitVariable(AstNetlist* nodep) {
         const SplitUnpackedVarVisitor visitor{nodep};
         refs = visitor.getPackedVarRefs();
     }
-    V3Global::dumpCheckGlobalTree("split_var", 0, v3Global.opt.dumpTreeLevel(__FILE__) >= 9);
+    V3Global::dumpCheckGlobalTree("split_var", 0, dumpTree() >= 9);
     { SplitPackedVarVisitor{nodep, refs}; }
-    V3Global::dumpCheckGlobalTree("split_var", 0, v3Global.opt.dumpTreeLevel(__FILE__) >= 9);
+    V3Global::dumpCheckGlobalTree("split_var", 0, dumpTree() >= 9);
 }
 
 bool V3SplitVar::canSplitVar(const AstVar* varp) {

--- a/src/V3Stats.cpp
+++ b/src/V3Stats.cpp
@@ -28,6 +28,8 @@
 #include <iomanip>
 #include <map>
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 //######################################################################
 // Stats class functions
 
@@ -61,7 +63,6 @@ private:
     VDouble0 m_statVarScpBytes;  // Statistic tracking
 
     // METHODS
-    VL_DEBUG_FUNC;  // Declare debug()
 
     void allNodes(AstNode* nodep) {
         m_instrs += nodep->instrCount();

--- a/src/V3StatsReport.cpp
+++ b/src/V3StatsReport.cpp
@@ -27,6 +27,8 @@
 #include <map>
 #include <unordered_map>
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 //######################################################################
 // Stats dumping
 

--- a/src/V3String.cpp
+++ b/src/V3String.cpp
@@ -17,9 +17,14 @@
 #include "config_build.h"
 #include "verilatedos.h"
 
-// Limited V3 headers here - this is a base class for Vlc etc
-#include "V3Error.h"
 #include "V3String.h"
+
+#include "V3Error.h"
+
+#ifndef V3ERROR_NO_GLOBAL_
+#include "V3Global.h"
+VL_DEFINE_DEBUG_FUNCTIONS;
+#endif
 
 #include <algorithm>
 

--- a/src/V3Subst.cpp
+++ b/src/V3Subst.cpp
@@ -34,13 +34,7 @@
 #include <algorithm>
 #include <vector>
 
-//######################################################################
-// Common debugging baseclass
-
-class SubstBaseVisitor VL_NOT_FINAL : public VNVisitor {
-public:
-    VL_DEBUG_FUNC;  // Declare debug()
-};
+VL_DEFINE_DEBUG_FUNCTIONS;
 
 //######################################################################
 // Class for each word of a multi-word variable
@@ -72,7 +66,6 @@ class SubstVarEntry final {
     bool m_wordUse = false;  // True if any individual word usage
     SubstVarWord m_whole;  // Data for whole vector used at once
     std::vector<SubstVarWord> m_words;  // Data for every word, if multi word variable
-    static int debug() { return SubstBaseVisitor::debug(); }
 
 public:
     // CONSTRUCTORS
@@ -175,7 +168,7 @@ public:
 // See if any variables have changed value since we determined subst value,
 // as a visitor of each AstNode
 
-class SubstUseVisitor final : public SubstBaseVisitor {
+class SubstUseVisitor final : public VNVisitor {
 private:
     // NODE STATE
     // See SubstVisitor
@@ -222,7 +215,7 @@ public:
 //######################################################################
 // Subst state, as a visitor of each AstNode
 
-class SubstVisitor final : public SubstBaseVisitor {
+class SubstVisitor final : public VNVisitor {
 private:
     // NODE STATE
     // Passed to SubstUseVisitor
@@ -390,5 +383,5 @@ public:
 void V3Subst::substituteAll(AstNetlist* nodep) {
     UINFO(2, __FUNCTION__ << ": " << endl);
     { SubstVisitor{nodep}; }  // Destruct before checking
-    V3Global::dumpCheckGlobalTree("subst", 0, v3Global.opt.dumpTreeLevel(__FILE__) >= 3);
+    V3Global::dumpCheckGlobalTree("subst", 0, dumpTree() >= 3);
 }

--- a/src/V3SymTable.h
+++ b/src/V3SymTable.h
@@ -53,11 +53,7 @@ class VSymEnt final {
     bool m_exported;  // Allow importing
     bool m_imported;  // Was imported
 #ifdef VL_DEBUG
-    static int debug() {
-        static int level = -1;
-        if (VL_UNLIKELY(level < 0)) level = v3Global.opt.debugSrcLevel("V3LinkDot.cpp");
-        return level;
-    }
+    VL_DEFINE_DEBUG_FUNCTIONS;
 #else
     static constexpr int debug() { return 0; }  // NOT runtime, too hot of a function
 #endif
@@ -88,7 +84,7 @@ public:
             }
         }
     }
-    void dump(std::ostream& os, const string& indent = "", int numLevels = 1) const {
+    void dumpSelf(std::ostream& os, const string& indent = "", int numLevels = 1) const {
         VSymConstMap doneSyms;
         dumpIterate(os, doneSyms, indent, numLevels, "TOP");
     }
@@ -127,7 +123,7 @@ public:
                                      << "  " << entp->nodep() << endl);
         if (name != "" && m_idNameMap.find(name) != m_idNameMap.end()) {
             if (!V3Error::errorCount()) {  // Else may have just reported warning
-                if (debug() >= 9 || V3Error::debugDefault()) dump(cout, "- err-dump: ", 1);
+                if (debug() >= 9 || V3Error::debugDefault()) dumpSelf(cout, "- err-dump: ", 1);
                 entp->nodep()->v3fatalSrc("Inserting two symbols with same name: " << name);
             }
         } else {
@@ -272,7 +268,7 @@ public:
         if (scopes == "") scopes = "<no instances found>";
         std::cerr << V3Error::warnMore() << "... Known scopes under '" << prettyName
                   << "': " << scopes << endl;
-        if (debug()) dump(std::cerr, "       KnownScope: ", 1);
+        if (debug()) dumpSelf(std::cerr, "       KnownScope: ", 1);
     }
 };
 
@@ -291,6 +287,8 @@ class VSymGraph final {
     // CONSTRUCTORS
     VL_UNCOPYABLE(VSymGraph);
 
+    VL_DEFINE_DEBUG_FUNCTIONS;
+
 public:
     explicit VSymGraph(AstNetlist* nodep) { m_symRootp = new VSymEnt(this, nodep); }
     ~VSymGraph() {
@@ -300,7 +298,7 @@ public:
     // METHODS
     VSymEnt* rootp() const { return m_symRootp; }
     // Debug
-    void dump(std::ostream& os, const string& indent = "") {
+    void dumpSelf(std::ostream& os, const string& indent = "") {
         VSymConstMap doneSyms;
         os << "SymEnt Dump:\n";
         m_symRootp->dumpIterate(os, doneSyms, indent, 9999, "$root");
@@ -316,12 +314,12 @@ public:
         }
     }
     void dumpFilePrefixed(const string& nameComment) {
-        if (v3Global.opt.dumpTree()) {
+        if (dumpTree()) {
             const string filename = v3Global.debugFilename(nameComment) + ".txt";
             UINFO(2, "Dumping " << filename << endl);
             const std::unique_ptr<std::ofstream> logp{V3File::new_ofstream(filename)};
             if (logp->fail()) v3fatal("Can't write " << filename);
-            dump(*logp, "");
+            dumpSelf(*logp, "");
         }
     }
 

--- a/src/V3TSP.cpp
+++ b/src/V3TSP.cpp
@@ -39,6 +39,8 @@
 #include <unordered_set>
 #include <vector>
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 //######################################################################
 // Support classes
 
@@ -47,8 +49,6 @@ static uint32_t edgeIdNext = 0;
 
 static void selfTestStates();
 static void selfTestString();
-
-VL_DEBUG_FUNC;  // Declare debug()
 }  // namespace V3TSP
 
 // Vertex that tracks a per-vertex key
@@ -396,7 +396,7 @@ public:
         }
     }
     void dumpGraphFilePrefixed(const string& nameComment) const {
-        if (v3Global.opt.dumpTree()) {
+        if (::dump()) {
             const string filename = v3Global.debugFilename(nameComment) + ".txt";
             const std::unique_ptr<std::ofstream> logp{V3File::new_ofstream(filename)};
             if (logp->fail()) v3fatal("Can't write " << filename);
@@ -406,7 +406,7 @@ public:
 
     void findEulerTour(std::vector<T_Key>* sortedOutp) {
         UASSERT(sortedOutp->empty(), "Output graph must start empty");
-        if (debug() >= 6) dumpDotFilePrefixed("findEulerTour");
+        if (::dumpGraph() >= 6) dumpDotFilePrefixed("findEulerTour");
         std::unordered_set<unsigned /*edgeID*/> markedEdges;
         // Pick a start node
         Vertex* const start_vertexp = castVertexp(verticesBeginp());
@@ -464,12 +464,12 @@ void V3TSP::tspSort(const V3TSP::StateVec& states, V3TSP::StateVec* resultp) {
     // Create the minimum spanning tree
     Graph minGraph;
     graph.makeMinSpanningTree(&minGraph);
-    if (debug() >= 6) minGraph.dumpGraphFilePrefixed("minGraph");
+    if (dumpGraph() >= 6) minGraph.dumpGraphFilePrefixed("minGraph");
 
     const std::vector<const TspStateBase*> oddDegree = minGraph.getOddDegreeKeys();
     Graph matching;
     graph.perfectMatching(oddDegree, &matching);
-    if (debug() >= 6) matching.dumpGraphFilePrefixed("matching");
+    if (dumpGraph() >= 6) matching.dumpGraphFilePrefixed("matching");
 
     // Adds edges to minGraph, the resulting graph will have even number of
     // edge counts at every vertex:
@@ -672,12 +672,12 @@ void V3TSP::selfTestString() {
 
     Graph minGraph;
     graph.makeMinSpanningTree(&minGraph);
-    if (debug() >= 6) minGraph.dumpGraphFilePrefixed("minGraph");
+    if (dumpGraph() >= 6) minGraph.dumpGraphFilePrefixed("minGraph");
 
     const std::vector<string> oddDegree = minGraph.getOddDegreeKeys();
     Graph matching;
     graph.perfectMatching(oddDegree, &matching);
-    if (debug() >= 6) matching.dumpGraphFilePrefixed("matching");
+    if (dumpGraph() >= 6) matching.dumpGraphFilePrefixed("matching");
 
     minGraph.combineGraph(matching);
 

--- a/src/V3Table.cpp
+++ b/src/V3Table.cpp
@@ -34,6 +34,8 @@
 #include <cmath>
 #include <vector>
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 //######################################################################
 // Table class functions
 
@@ -169,7 +171,6 @@ private:
     std::vector<TableOutputVar> m_outVarps;  // Output variable list
 
     // METHODS
-    VL_DEBUG_FUNC;  // Declare debug()
 
 public:
     void simulateVarRefCb(AstVarRef* nodep) {
@@ -430,5 +431,5 @@ void TableSimulateVisitor::varRefCb(AstVarRef* nodep) {
 void V3Table::tableAll(AstNetlist* nodep) {
     UINFO(2, __FUNCTION__ << ": " << endl);
     { TableVisitor{nodep}; }  // Destruct before checking
-    V3Global::dumpCheckGlobalTree("table", 0, v3Global.opt.dumpTreeLevel(__FILE__) >= 3);
+    V3Global::dumpCheckGlobalTree("table", 0, dumpTree() >= 3);
 }

--- a/src/V3Task.cpp
+++ b/src/V3Task.cpp
@@ -38,6 +38,8 @@
 #include <map>
 #include <tuple>
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 //######################################################################
 // Graph subclasses
 
@@ -281,7 +283,7 @@ public:
         iterate(nodep);
         //
         m_callGraph.removeRedundantEdgesSum(&TaskEdge::followAlwaysTrue);
-        m_callGraph.dumpDotFilePrefixed("task_call");
+        if (dumpGraph()) m_callGraph.dumpDotFilePrefixed("task_call");
     }
     ~TaskStateVisitor() override = default;
     VL_UNCOPYABLE(TaskStateVisitor);
@@ -364,7 +366,6 @@ private:
     DpiCFuncs m_dpiNames;  // Map of all created DPI functions
 
     // METHODS
-    VL_DEBUG_FUNC;  // Declare debug()
 
     AstVarScope* createFuncVar(AstCFunc* funcp, const string& name, AstVar* examplep) {
         AstVar* const newvarp = new AstVar(funcp->fileline(), VVarType::BLOCKTEMP, name, examplep);
@@ -1814,5 +1815,5 @@ void V3Task::taskAll(AstNetlist* nodep) {
         TaskStateVisitor visitors{nodep};
         const TaskVisitor visitor{nodep, &visitors};
     }  // Destruct before checking
-    V3Global::dumpCheckGlobalTree("task", 0, v3Global.opt.dumpTreeLevel(__FILE__) >= 3);
+    V3Global::dumpCheckGlobalTree("task", 0, dumpTree() >= 3);
 }

--- a/src/V3Trace.cpp
+++ b/src/V3Trace.cpp
@@ -50,6 +50,8 @@
 #include <map>
 #include <set>
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 //######################################################################
 // Graph vertexes
 
@@ -194,7 +196,6 @@ private:
     using TraceVec = std::multimap<ActCodeSet, TraceTraceVertex*>;
 
     // METHODS
-    VL_DEBUG_FUNC;  // Declare debug()
 
     void detectDuplicates() {
         UINFO(9, "Finding duplicates\n");
@@ -724,11 +725,11 @@ private:
         detectDuplicates();
 
         // Simplify & optimize the graph
-        if (debug() >= 6) m_graph.dumpDotFilePrefixed("trace_pre");
+        if (dumpGraph() >= 6) m_graph.dumpDotFilePrefixed("trace_pre");
         graphSimplify(true);
-        if (debug() >= 6) m_graph.dumpDotFilePrefixed("trace_simplified");
+        if (dumpGraph() >= 6) m_graph.dumpDotFilePrefixed("trace_simplified");
         graphOptimize();
-        if (debug() >= 6) m_graph.dumpDotFilePrefixed("trace_optimized");
+        if (dumpGraph() >= 6) m_graph.dumpDotFilePrefixed("trace_optimized");
 
         // Create the fine grained activity flags
         createActivityFlags();
@@ -908,5 +909,5 @@ public:
 void V3Trace::traceAll(AstNetlist* nodep) {
     UINFO(2, __FUNCTION__ << ": " << endl);
     { TraceVisitor{nodep}; }  // Destruct before checking
-    V3Global::dumpCheckGlobalTree("trace", 0, v3Global.opt.dumpTreeLevel(__FILE__) >= 3);
+    V3Global::dumpCheckGlobalTree("trace", 0, dumpTree() >= 3);
 }

--- a/src/V3TraceDecl.cpp
+++ b/src/V3TraceDecl.cpp
@@ -37,6 +37,8 @@
 #include <limits>
 #include <vector>
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 //######################################################################
 // Utility class to emit path adjustments
 
@@ -133,7 +135,6 @@ private:
     VDouble0 m_statIgnSigs;  // Statistic tracking
 
     // METHODS
-    VL_DEBUG_FUNC;  // Declare debug()
 
     const char* vscIgnoreTrace(const AstVarScope* nodep) {
         // Return true if this shouldn't be traced
@@ -525,5 +526,5 @@ public:
 void V3TraceDecl::traceDeclAll(AstNetlist* nodep) {
     UINFO(2, __FUNCTION__ << ": " << endl);
     { TraceDeclVisitor{nodep}; }  // Destruct before checking
-    V3Global::dumpCheckGlobalTree("tracedecl", 0, v3Global.opt.dumpTreeLevel(__FILE__) >= 3);
+    V3Global::dumpCheckGlobalTree("tracedecl", 0, dumpTree() >= 3);
 }

--- a/src/V3Tristate.cpp
+++ b/src/V3Tristate.cpp
@@ -106,12 +106,13 @@
 #include <algorithm>
 #include <map>
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 //######################################################################
 
 class TristateBaseVisitor VL_NOT_FINAL : public VNVisitor {
 public:
     // METHODS
-    VL_DEBUG_FUNC;  // Declare debug()
 };
 
 //######################################################################
@@ -176,7 +177,6 @@ public:
 
 private:
     // METHODS
-    VL_DEBUG_FUNC;  // Declare debug()
 
     TristateVertex* makeVertex(AstNode* nodep) {
         TristateVertex* vertexp = reinterpret_cast<TristateVertex*>(nodep->user5p());
@@ -264,7 +264,6 @@ public:
         AstNode::user5ClearTree();  // Wipe all node user5p's that point to vertexes
     }
     void graphWalk(AstNodeModule* nodep) {
-        // if (debug() >= 9) m_graph.dumpDotFilePrefixed("tri_pre__" + nodep->name());
         UINFO(9, " Walking " << nodep << endl);
         for (V3GraphVertex* itp = m_graph.verticesBeginp(); itp; itp = itp->verticesNextp()) {
             graphWalkRecurseFwd(static_cast<TristateVertex*>(itp), 0);
@@ -272,7 +271,7 @@ public:
         for (V3GraphVertex* itp = m_graph.verticesBeginp(); itp; itp = itp->verticesNextp()) {
             graphWalkRecurseBack(static_cast<TristateVertex*>(itp), 0);
         }
-        if (debug() >= 9) m_graph.dumpDotFilePrefixed("tri_pos__" + nodep->name());
+        if (dumpGraph() >= 9) m_graph.dumpDotFilePrefixed("tri_pos__" + nodep->name());
     }
     void associate(AstNode* fromp, AstNode* top) {
         new V3GraphEdge(&m_graph, makeVertex(fromp), makeVertex(top), 1);
@@ -1643,5 +1642,5 @@ public:
 void V3Tristate::tristateAll(AstNetlist* nodep) {
     UINFO(2, __FUNCTION__ << ": " << endl);
     { TristateVisitor{nodep}; }  // Destruct before checking
-    V3Global::dumpCheckGlobalTree("tristate", 0, v3Global.opt.dumpTreeLevel(__FILE__) >= 3);
+    V3Global::dumpCheckGlobalTree("tristate", 0, dumpTree() >= 3);
 }

--- a/src/V3Undriven.cpp
+++ b/src/V3Undriven.cpp
@@ -36,6 +36,8 @@
 #include <algorithm>
 #include <vector>
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 //######################################################################
 // Class for every variable we may process
 
@@ -46,8 +48,6 @@ class UndrivenVarEntry final {
     std::vector<bool> m_bitFlags;  // Used/Driven on each subbit
 
     enum : uint8_t { FLAG_USED = 0, FLAG_DRIVEN = 1, FLAGS_PER_BIT = 2 };
-
-    VL_DEBUG_FUNC;  // Declare debug()
 
 public:
     // CONSTRUCTORS
@@ -257,7 +257,6 @@ private:
     const AstAlways* m_alwaysCombp = nullptr;  // Current always if combo, otherwise nullptr
 
     // METHODS
-    VL_DEBUG_FUNC;  // Declare debug()
 
     UndrivenVarEntry* getEntryp(AstVar* nodep, int which_user) {
         if (!(which_user == 1 ? nodep->user1p() : nodep->user2p())) {

--- a/src/V3Unknown.cpp
+++ b/src/V3Unknown.cpp
@@ -41,6 +41,8 @@
 
 #include <algorithm>
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 //######################################################################
 
 class UnknownVisitor final : public VNVisitor {
@@ -64,7 +66,6 @@ private:
     V3UniqueNames m_xrandNames;  // For generating unique temporary variable names
 
     // METHODS
-    VL_DEBUG_FUNC;  // Declare debug()
 
     void replaceBoundLvalue(AstNode* nodep, AstNode* condp) {
         // Spec says a out-of-range LHS SEL results in a NOP.
@@ -502,5 +503,5 @@ public:
 void V3Unknown::unknownAll(AstNetlist* nodep) {
     UINFO(2, __FUNCTION__ << ": " << endl);
     { UnknownVisitor{nodep}; }  // Destruct before checking
-    V3Global::dumpCheckGlobalTree("unknown", 0, v3Global.opt.dumpTreeLevel(__FILE__) >= 3);
+    V3Global::dumpCheckGlobalTree("unknown", 0, dumpTree() >= 3);
 }

--- a/src/V3Unroll.cpp
+++ b/src/V3Unroll.cpp
@@ -37,6 +37,8 @@
 
 #include <algorithm>
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 //######################################################################
 // Unroll state, as a visitor of each AstNode
 
@@ -57,7 +59,6 @@ private:
     VDouble0 m_statIters;  // Statistic tracking
 
     // METHODS
-    VL_DEBUG_FUNC;  // Declare debug()
 
     // VISITORS
     bool cantUnroll(AstNode* nodep, const char* reason) const {
@@ -517,5 +518,5 @@ void V3Unroll::unrollAll(AstNetlist* nodep) {
         UnrollStateful unroller;
         unroller.unrollAll(nodep);
     }  // Destruct before checking
-    V3Global::dumpCheckGlobalTree("unroll", 0, v3Global.opt.dumpTreeLevel(__FILE__) >= 3);
+    V3Global::dumpCheckGlobalTree("unroll", 0, dumpTree() >= 3);
 }

--- a/src/V3VariableOrder.cpp
+++ b/src/V3VariableOrder.cpp
@@ -34,6 +34,8 @@
 #include <algorithm>
 #include <vector>
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 //######################################################################
 // Establish mtask variable sort order in mtasks mode
 
@@ -205,5 +207,5 @@ void V3VariableOrder::orderAll() {
          modp = VN_AS(modp->nextp(), NodeModule)) {
         VariableOrder::processModule(modp);
     }
-    V3Global::dumpCheckGlobalTree("variableorder", 0, v3Global.opt.dumpTreeLevel(__FILE__) >= 3);
+    V3Global::dumpCheckGlobalTree("variableorder", 0, dumpTree() >= 3);
 }

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -81,6 +81,8 @@
 #define VERILATOR_V3WIDTH_CPP_
 #include "V3WidthCommit.h"
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 //######################################################################
 
 enum Stage : uint8_t {
@@ -235,9 +237,6 @@ private:
         EXTEND_LHS,  // Extend with sign if node signed. e.g. node=y in ASSIGN(y,x), "x = y"
         EXTEND_OFF  // No extension
     };
-
-    // METHODS
-    static int debug() { return V3Width::debug(); }
 
     // VISITORS
     //   Naming:  width_O{outputtype}_L{lhstype}_R{rhstype}_W{widthing}_S{signing}
@@ -6728,12 +6727,6 @@ public:
 //######################################################################
 // Width class functions
 
-int V3Width::debug() {
-    static int level = -1;
-    if (VL_UNLIKELY(level < 0)) level = v3Global.opt.debugSrcLevel(__FILE__);
-    return level;
-}
-
 void V3Width::width(AstNetlist* nodep) {
     UINFO(2, __FUNCTION__ << ": " << endl);
     {
@@ -6744,7 +6737,7 @@ void V3Width::width(AstNetlist* nodep) {
         WidthRemoveVisitor rvisitor;
         (void)rvisitor.mainAcceptEdit(nodep);
     }  // Destruct before checking
-    V3Global::dumpCheckGlobalTree("width", 0, v3Global.opt.dumpTreeLevel(__FILE__) >= 3);
+    V3Global::dumpCheckGlobalTree("width", 0, dumpTree() >= 3);
 }
 
 //! Single node parameter propagation
@@ -6780,5 +6773,5 @@ AstNode* V3Width::widthGenerateParamsEdit(
 void V3Width::widthCommit(AstNetlist* nodep) {
     UINFO(2, __FUNCTION__ << ": " << endl);
     { WidthCommitVisitor{nodep}; }  // Destruct before checking
-    V3Global::dumpCheckGlobalTree("widthcommit", 0, v3Global.opt.dumpTreeLevel(__FILE__) >= 6);
+    V3Global::dumpCheckGlobalTree("widthcommit", 0, dumpTree() >= 6);
 }

--- a/src/V3Width.h
+++ b/src/V3Width.h
@@ -27,7 +27,6 @@ class AstNode;
 
 class V3Width final {
 public:
-    static int debug();
     static void width(AstNetlist* nodep);
     static AstNode* widthParamsEdit(AstNode* nodep);
     static AstNode* widthGenerateParamsEdit(AstNode* nodep);

--- a/src/V3WidthCommit.h
+++ b/src/V3WidthCommit.h
@@ -35,8 +35,9 @@
 /// This step is only called on real V3Width, not intermediate e.g. widthParams
 
 class WidthRemoveVisitor final : public VNVisitor {
-private:
     // METHODS
+    VL_DEFINE_DEBUG_FUNCTIONS;
+
     void replaceWithSignedVersion(AstNode* nodep, AstNode* newp) {
         UINFO(6, " Replace " << nodep << " w/ " << newp << endl);
         nodep->replaceWith(newp);
@@ -74,6 +75,8 @@ class WidthCommitVisitor final : public VNVisitor {
 
 public:
     // METHODS
+    VL_DEFINE_DEBUG_FUNCTIONS;
+
     static AstConst* newIfConstCommitSize(AstConst* nodep) {
         if (((nodep->dtypep()->width() != nodep->num().width()) || !nodep->num().sized())
             && !nodep->num().isString()) {  // Need to force the number from unsized to sized

--- a/src/V3WidthSel.cpp
+++ b/src/V3WidthSel.cpp
@@ -34,6 +34,8 @@
 #include "V3Global.h"
 #include "V3Width.h"
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 //######################################################################
 // Width state, as a visitor of each AstNode
 
@@ -47,7 +49,6 @@ private:
 #define iterateChildren DO_NOT_iterateChildern_IN_V3WidthSel
 
     // METHODS
-    VL_DEBUG_FUNC;  // Declare debug()
 
     void checkConstantOrReplace(AstNode* nodep, const string& message) {
         // See also V3Width::checkConstantOrReplace

--- a/src/Verilator.cpp
+++ b/src/Verilator.cpp
@@ -103,6 +103,8 @@
 
 #include <ctime>
 
+VL_DEFINE_DEBUG_FUNCTIONS;
+
 V3Global v3Global;
 
 static void reportStatsIfEnabled() {
@@ -607,7 +609,7 @@ static void verilate(const string& argString) {
     }
 
     // Final steps
-    V3Global::dumpCheckGlobalTree("final", 990, v3Global.opt.dumpTreeLevel(__FILE__) >= 3);
+    V3Global::dumpCheckGlobalTree("final", 990, dumpTree() >= 3);
 
     V3Error::abortIfErrors();
 

--- a/src/VlcMain.cpp
+++ b/src/VlcMain.cpp
@@ -23,14 +23,18 @@
 
 #include "verilatedos.h"
 
-// Cheat for speed and compile .cpp files into one object
+// Cheat for speed and compile .cpp files into one object TODO: Reconsider
 #define V3ERROR_NO_GLOBAL_
+#include "V3Error.h"
+static int debug() { return V3Error::debugDefault(); }
 #include "V3Error.cpp"
 #include "V3String.cpp"
 #define V3OPTION_PARSER_NO_VOPTION_BOOL
+// clang-format off
 #include "V3OptionParser.cpp"
 #include "V3Os.cpp"
 #include "VlcTop.cpp"
+// clanf-format on
 
 #include "VlcOptions.h"
 #include "VlcTop.h"

--- a/src/VlcPoint.h
+++ b/src/VlcPoint.h
@@ -102,6 +102,8 @@ private:
     std::vector<VlcPoint> m_points;  //< List of all points
     uint64_t m_numPoints = 0;  //< Total unique points
 
+    static int debug() { return V3Error::debugDefault(); }
+
 public:
     // ITERATORS
     using ByName = NameMap;

--- a/src/VlcTest.h
+++ b/src/VlcTest.h
@@ -93,6 +93,8 @@ private:
     // MEMBERS
     ByName m_tests;  //< List of all tests
 
+    static int debug() { return V3Error::debugDefault(); }
+
 public:
     // ITERATORS
     using iterator = ByName::iterator;

--- a/test_regress/driver.pl
+++ b/test_regress/driver.pl
@@ -235,7 +235,7 @@ sub parameter {
     elsif ($param =~ /\.pl/) {
         push @opt_tests, $param;
     }
-    elsif ($param =~ /^-?(-debugi|-dump-treei)/) {
+    elsif ($param =~ /^-?(-debugi|-dumpi)/) {
         push @Opt_Driver_Verilator_Flags, $param;
         $_Parameter_Next_Level = $param;
     }

--- a/test_regress/t/t_debug_emitv.pl
+++ b/test_regress/t/t_debug_emitv.pl
@@ -13,7 +13,7 @@ scenarios(vlt => 1);
 lint(
     # We also have dump-tree turned on, so hit a lot of AstNode*::dump() functions
     # Likewise XML
-    v_flags => ["--lint-only --dump-treei 9 --dump-treei-V3EmitV 9 --debug-emitv"],
+    v_flags => ["--lint-only --dumpi-tree 9 --dumpi-V3EmitV 9 --debug-emitv"],
     );
 
 files_identical(glob_one("$Self->{obj_dir}/$Self->{VM_PREFIX}_*_width.tree.v"), $Self->{golden_filename});

--- a/test_regress/t/t_debug_emitv_addrids.pl
+++ b/test_regress/t/t_debug_emitv_addrids.pl
@@ -15,7 +15,7 @@ top_filename("t/t_debug_emitv.v");
 lint(
     # We also have dump-tree turned on, so hit a lot of AstNode*::dump() functions
     # Likewise XML
-    v_flags => ["--lint-only --dump-treei 9 --dump-tree-addrids"],
+    v_flags => ["--lint-only --dumpi-tree 9 --dump-tree-addrids"],
     );
 
 ok(1);

--- a/test_regress/t/t_dotfiles.pl
+++ b/test_regress/t/t_dotfiles.pl
@@ -14,7 +14,7 @@ scenarios(vltmt => 1);
 top_filename("t/t_gen_alw.v");
 
 compile(
-    v_flags2 => ["--debug --debugi 5"],
+    v_flags2 => ["--dumpi-graph 6"],
     threads => 2
     );
 


### PR DESCRIPTION
This patch reworks dumping control in line whit what we discussed in #3527. I have moved VL_DEBUG_FUNC (with a modified name and extended functionality) to the top of .cpp files (there is no need for one in each class), and added it to visitors as needed in .h files (as .h files might be included in .cpp files which themselves define these), and we now have `dump*()` functions generated by this macro.

- `dumpTree()` is the maximum of `--dumpi-tree` or `--dumpi-<srcfile>` 
- `dumpGraph()` is the maximum of `--dumpi-graph` or `--dumpi-<srcfile>` (used to be part of `--dump-treei` before)
- `dump()` is only affected by `--dumpi-<srcfile>`, so is appropriate for pass specific text files and similar

`dump` and `dumpTree` clash with a few existing names which fixed on a case by case basis. Could consider renaming this to something more specific (`doDump()` ?). There is also `AstNode::dumpTree`, but that is not ambiguous outside of an AstNode class, so is not a big issue.

I'm also contemplating tweaking these so instead of `if (dump() >= 2)` one would write `if (dump(2))` to avoid messes caused by liberal use of `>=` vs `>`.

As this is a developer option, I have not kept `--dump-treei` (which is now `--dumpi-tree --dumpi-graph`)

TODO:
- [x] Audit and fix other places that should use `if (dump())` instead of `if (debug())`
- [ ] Consider renaming `dump()` to `doDump()` (also `debug()` to `doDebug()` ?)
- [ ] Consider changing `if (dump() >= 2)` to `if (dump(2))`

@wsnyder if you are happy with this I will finish off and merge. The interesting files are `V3Option*`, `V3Error*`. `docs/*`, `bin/*`

It is now easy to add further `--dumpi-foo` options for new things.

---

- Rename `--dump-treei` option to `--dumpi-tree`, which itself is now a special case of `--dumpi-<tag>` where tag can be a magic word, or a filename
- Control dumping via static `dump*()` functions, analogous to `debug()`
- Make dumping independent of the value of `debug()` (so dumping always works even without the debug flag)
- Add separate `--dumpi-graph` for dumping V3Graphs, which is again a special case of `--dumpi-<tag>`
- Alias `--dump-<tag>` to `--dumpi-<tag> 3` as before