### PR TITLE
v3errorEnd: look for instance only when warning is not off

### DIFF
--- a/src/V3Ast.cpp
+++ b/src/V3Ast.cpp
@@ -1212,7 +1212,11 @@ void AstNode::v3errorEnd(std::ostringstream& str) const {
             const_cast<AstNode*>(this)->dump(nsstr);
             nsstr << endl;
         }
-        m_fileline->v3errorEnd(nsstr, instanceStr());
+        // Don't look for instance name when warning is disabled.
+        // In case of large number of warnings, this can
+        // take significant amount of time
+        m_fileline->v3errorEnd(nsstr,
+                               m_fileline->warnIsOff(V3Error::errorCode()) ? "" : instanceStr());
     }
 }
 


### PR DESCRIPTION
This PR changes to look for instance name for warning/error only when it is not ignored later.

This approach reduced total time of V3Undriven stage from ``34,2s`` to ``2,5s`` in our test design (containing almost 400 000 unused variables).

Signed-off-by: Kamil Rakoczy <krakoczy@antmicro.com>
