### PR TITLE
Omit AstNode::m_editCount in release build

### DIFF
--- a/src/V3Ast.h
+++ b/src/V3Ast.h
@@ -1443,13 +1443,15 @@ class AstNode VL_NOT_FINAL {
     AstNodeDType* m_dtypep = nullptr;  // Data type of output or assignment (etc)
     AstNode* m_headtailp;  // When at begin/end of list, the opposite end of the list
     FileLine* m_fileline;  // Where it was declared
+#ifdef VL_DEBUG
+    // Only keep track of the edit count in the node in the debug build.
+    // In the release build we will take the space saving instead.
     uint64_t m_editCount;  // When it was last edited
+#endif
     static uint64_t s_editCntGbl;  // Global edit counter
-    // Global edit counter, last value for printing * near node #s
-    static uint64_t s_editCntLast;
+    static uint64_t s_editCntLast;  // Last committed value of global edit counter
 
-    AstNode* m_clonep
-        = nullptr;  // Pointer to clone of/ source of this module (for *LAST* cloneTree() ONLY)
+    AstNode* m_clonep = nullptr;  // Pointer to clone/source of node (only for *LAST* cloneTree())
     static int s_cloneCntGbl;  // Count of which userp is set
 
     // This member ordering both allows 64 bit alignment and puts associated data together
@@ -1720,10 +1722,14 @@ public:
     static void user5ClearTree() { VNUser5InUse::clear(); }  // Clear userp()'s across the entire tree
     // clang-format on
 
+#ifdef VL_DEBUG
     uint64_t editCount() const { return m_editCount; }
     void editCountInc() {
         m_editCount = ++s_editCntGbl;  // Preincrement, so can "watch AstNode::s_editCntGbl=##"
     }
+#else
+    void editCountInc() { ++s_editCntGbl; }
+#endif
     static uint64_t editCountLast() { return s_editCntLast; }
     static uint64_t editCountGbl() { return s_editCntGbl; }
     static void editCountSetLast() { s_editCntLast = editCountGbl(); }

--- a/src/V3AstNodes.cpp
+++ b/src/V3AstNodes.cpp
@@ -1266,10 +1266,10 @@ static std::string nodeAddr(const AstNode* nodep) {
 }
 
 void AstNode::dump(std::ostream& str) const {
-    str << typeName() << " "
-        << nodeAddr(this)
-        //<< " " << nodeAddr(m_backp)
+    str << typeName() << " " << nodeAddr(this)
+#ifdef VL_DEBUG
         << " <e" << std::dec << editCount() << ((editCount() >= editCountLast()) ? "#>" : ">")
+#endif
         << " {" << fileline()->filenameLetters() << std::dec << fileline()->lastLineno()
         << fileline()->firstColumnLetters() << "}";
     if (user1p()) str << " u1=" << nodeAddr(user1p());


### PR DESCRIPTION
I personally have never used AstNode::m_editCount or the globals, and it is 4.6% of the baseline AstNode size, so I got rid of it in the release build (kept it in debug). PRing in case you would like to comment otherwise I will merge soon.

---

This is only a debugging aid at this point, so compile out of the release build. This reduces peak memory consumption by 4-5%. We still keep a global flag to detect the tree have changed, to avoid unnecessary dumps.
