### PR TITLE
Initial support for tracing strings

### DIFF
--- a/bin/verilator
+++ b/bin/verilator
@@ -409,6 +409,7 @@ detailed descriptions of these arguments.
     --trace-max-array <depth>   Maximum bit width for tracing
     --trace-max-width <width>   Maximum array depth for tracing
     --trace-params              Enable tracing of parameters
+    --trace-strings             Enable tracing strings
     --trace-structs             Enable tracing structure names
     --trace-threads <threads>   Enable FST waveform creation on separate threads
     --trace-underscore          Enable tracing of _signals

--- a/bin/verilator
+++ b/bin/verilator
@@ -407,6 +407,7 @@ detailed descriptions of these arguments.
     --trace-depth <levels>      Depth of tracing
     --trace-fst                 Enable FST waveform creation
     --trace-max-array <depth>   Maximum bit width for tracing
+    --trace-max-string <length> Maximum string length for tracing
     --trace-max-width <width>   Maximum array depth for tracing
     --trace-params              Enable tracing of parameters
     --trace-strings             Enable tracing strings

--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -44,6 +44,7 @@ HyungKi Jeong
 Iru Cai
 Ivan Vnučec
 Iztok Jeras
+Jake Merdich
 James Hanlon
 James Hutchinson
 James Pallister

--- a/docs/guide/exe_verilator.rst
+++ b/docs/guide/exe_verilator.rst
@@ -1270,6 +1270,11 @@ Summary:
 
    Disable tracing of parameters.
 
+.. option:: --trace-strings
+
+   Enable tracing to dump string variables. This may result in significantly
+   slower trace times and larger trace files.
+
 .. option:: --trace-structs
 
    Enable tracing to show the name of packed structure, union, and packed

--- a/docs/guide/exe_verilator.rst
+++ b/docs/guide/exe_verilator.rst
@@ -1265,7 +1265,7 @@ Summary:
    Rarely needed. Specify the maximum length of string to be dumped before
    truncation. Defaults to 63, as tracing large strings may bloat memory
    and file size. Larger strings aren't typically useful in wave viewers.
-   
+
    Note that VCD tracing has its own limit that may be lower than this one
    for particular strings.
 

--- a/docs/guide/exe_verilator.rst
+++ b/docs/guide/exe_verilator.rst
@@ -1265,7 +1265,7 @@ Summary:
    Rarely needed. Specify the maximum length of string to be dumped before
    truncation. Defaults to 64, as tracing large strings may bloat memory
    and file size. Larger strings aren't typically useful in wave viewers.
-   A limit of zero indicates no limit.
+   A limit of zero indicates no limit. See also :vlopt:`--trace-strings` option.
 
    Note that VCD tracing has its own limit that may be lower than this one
    for particular strings.
@@ -1283,7 +1283,7 @@ Summary:
 .. option:: --trace-strings
 
    Enable tracing to dump string variables. This may result in significantly
-   slower trace times and larger trace files.
+   slower trace times and larger trace files. See also :vlopt:`--trace-max-string` option.
 
 .. option:: --trace-structs
 

--- a/docs/guide/exe_verilator.rst
+++ b/docs/guide/exe_verilator.rst
@@ -1260,6 +1260,15 @@ Summary:
    traced.  Defaults to 32, as tracing large arrays may greatly slow traced
    simulations.
 
+.. option:: --trace-max-string *length*
+
+   Rarely needed. Specify the maximum length of string to be dumped before
+   truncation. Defaults to 63, as tracing large strings may bloat memory
+   and file size. Larger strings aren't typically useful in wave viewers.
+   
+   Note that VCD tracing has its own limit that may be lower than this one
+   for particular strings.
+
 .. option:: --trace-max-width *width*
 
    Rarely needed.  Specify the maximum bit width of a signal that may be

--- a/docs/guide/exe_verilator.rst
+++ b/docs/guide/exe_verilator.rst
@@ -1263,7 +1263,7 @@ Summary:
 .. option:: --trace-max-string *length*
 
    Rarely needed. Specify the maximum length of string to be dumped before
-   truncation. Defaults to 63, as tracing large strings may bloat memory
+   truncation. Defaults to 64, as tracing large strings may bloat memory
    and file size. Larger strings aren't typically useful in wave viewers.
 
    Note that VCD tracing has its own limit that may be lower than this one

--- a/docs/guide/exe_verilator.rst
+++ b/docs/guide/exe_verilator.rst
@@ -1265,6 +1265,7 @@ Summary:
    Rarely needed. Specify the maximum length of string to be dumped before
    truncation. Defaults to 64, as tracing large strings may bloat memory
    and file size. Larger strings aren't typically useful in wave viewers.
+   A limit of zero indicates no limit.
 
    Note that VCD tracing has its own limit that may be lower than this one
    for particular strings.

--- a/include/verilated.cpp
+++ b/include/verilated.cpp
@@ -2371,6 +2371,10 @@ void VerilatedContext::randReset(int val) VL_MT_SAFE {
     const VerilatedLockGuard lock{m_mutex};
     m_s.m_randReset = val;
 }
+void VerilatedContext::maxStringTrace(int val) VL_MT_SAFE {
+    const VerilatedLockGuard lock{m_mutex};
+    m_s.m_maxStringTrace = val;
+}
 void VerilatedContext::timeunit(int value) VL_MT_SAFE {
     if (value < 0) value = -value;  // Stored as 0..15
     const VerilatedLockGuard lock{m_mutex};

--- a/include/verilated.cpp
+++ b/include/verilated.cpp
@@ -2373,7 +2373,11 @@ void VerilatedContext::randReset(int val) VL_MT_SAFE {
 }
 void VerilatedContext::maxStringTrace(int val) VL_MT_SAFE {
     const VerilatedLockGuard lock{m_mutex};
-    m_s.m_maxStringTrace = val;
+    if (val == 0) {
+        m_s.m_maxStringTrace = INT_MAX;
+    } else {
+        m_s.m_maxStringTrace = val;
+    }
 }
 void VerilatedContext::timeunit(int value) VL_MT_SAFE {
     if (value < 0) value = -value;  // Stored as 0..15

--- a/include/verilated.cpp
+++ b/include/verilated.cpp
@@ -2373,11 +2373,7 @@ void VerilatedContext::randReset(int val) VL_MT_SAFE {
 }
 void VerilatedContext::maxStringTrace(int val) VL_MT_SAFE {
     const VerilatedLockGuard lock{m_mutex};
-    if (val == 0) {
-        m_s.m_maxStringTrace = INT_MAX;
-    } else {
-        m_s.m_maxStringTrace = val;
-    }
+    m_s.m_maxStringTrace = val ? val : INT_MAX;
 }
 void VerilatedContext::timeunit(int value) VL_MT_SAFE {
     if (value < 0) value = -value;  // Stored as 0..15

--- a/include/verilated.h
+++ b/include/verilated.h
@@ -366,6 +366,7 @@ protected:
         int m_timeFormatUnits = UNITS_NONE;  // $timeformat units
         int m_timeFormatPrecision = 0;  // $timeformat number of decimal places
         int m_timeFormatWidth = 20;  // $timeformat character width
+        int m_maxStringTrace = 127; // Max string size to have in dumps
         // CONSTRUCTORS
         Serialized();
         ~Serialized() = default;
@@ -497,6 +498,10 @@ public:
     void randSeed(int val) VL_MT_SAFE;
     /// Set default random seed, 0 = seed it automatically
     int randSeed() const VL_MT_SAFE { return m_s.m_randSeed; }
+    /// Return max traced string length
+    void maxStringTrace(int val) VL_MT_SAFE;
+    /// Set max traced string length
+    int maxStringTrace() const VL_MT_SAFE { return m_s.m_maxStringTrace; }
 
     // Time handling
     /// Returns current simulation time.

--- a/include/verilated.h
+++ b/include/verilated.h
@@ -41,6 +41,7 @@
 #include <algorithm>
 #include <array>
 #include <cassert>
+#include <climits>
 #include <cmath>
 #include <cstdarg>
 #include <cstdio>
@@ -366,7 +367,7 @@ protected:
         int m_timeFormatUnits = UNITS_NONE;  // $timeformat units
         int m_timeFormatPrecision = 0;  // $timeformat number of decimal places
         int m_timeFormatWidth = 20;  // $timeformat character width
-        int m_maxStringTrace = 127; // Max string size to have in dumps
+        int m_maxStringTrace = INT_MAX; // Max string size to have in dumps
         // CONSTRUCTORS
         Serialized();
         ~Serialized() = default;

--- a/include/verilated_fst_c.cpp
+++ b/include/verilated_fst_c.cpp
@@ -161,7 +161,7 @@ void VerilatedFst::declare(uint32_t code, const char* name, int dtypenum, fstVar
                            int lsb) {
     const int bits = ((msb > lsb) ? (msb - lsb) : (lsb - msb)) + 1;
 
-    const bool enabled = Super::declCode(code, name, bits, false);
+    const bool enabled = Super::declCode(code, name, bits, false, (vartype == FST_VT_GEN_STRING));
     if (!enabled) return;
 
     std::string nameasstr = namePrefix() + name;
@@ -246,7 +246,7 @@ void VerilatedFst::declDouble(uint32_t code, const char* name, int dtypenum, fst
 void VerilatedFst::declString(uint32_t code, const char* name, int dtypenum, fstVarDir vardir,
                               fstVarType vartype, bool array, int arraynum) {
     declare(code, name, dtypenum, vardir, vartype, array, arraynum, false,
-            (VL_LEN_FAST_TRACED_STRING + 1) * 8, 0);
+            sizeof(std::string) * 8, 0);
 }
 
 //=============================================================================

--- a/include/verilated_fst_c.cpp
+++ b/include/verilated_fst_c.cpp
@@ -243,6 +243,11 @@ void VerilatedFst::declDouble(uint32_t code, const char* name, int dtypenum, fst
                               fstVarType vartype, bool array, int arraynum) {
     declare(code, name, dtypenum, vardir, vartype, array, arraynum, false, 63, 0);
 }
+void VerilatedFst::declString(uint32_t code, const char* name, int dtypenum, fstVarDir vardir,
+                              fstVarType vartype, bool array, int arraynum) {
+    declare(code, name, dtypenum, vardir, vartype, array, arraynum, false,
+            (LEN_FAST_TRACED_STRING + 1) * 8, 0);
+}
 
 //=============================================================================
 // Get/commit trace buffer
@@ -342,4 +347,9 @@ void VerilatedFstBuffer::emitWData(uint32_t code, const WData* newvalp, int bits
 VL_ATTR_ALWINLINE
 void VerilatedFstBuffer::emitDouble(uint32_t code, double newval) {
     fstWriterEmitValueChange(m_fst, m_symbolp[code], &newval);
+}
+
+VL_ATTR_ALWINLINE
+void VerilatedFstBuffer::emitStringRaw(uint32_t code, const char* newval, int bytes) {
+    fstWriterEmitVariableLengthValueChange(m_fst, m_symbolp[code], newval, bytes);
 }

--- a/include/verilated_fst_c.cpp
+++ b/include/verilated_fst_c.cpp
@@ -246,7 +246,7 @@ void VerilatedFst::declDouble(uint32_t code, const char* name, int dtypenum, fst
 void VerilatedFst::declString(uint32_t code, const char* name, int dtypenum, fstVarDir vardir,
                               fstVarType vartype, bool array, int arraynum) {
     declare(code, name, dtypenum, vardir, vartype, array, arraynum, false,
-            (LEN_FAST_TRACED_STRING + 1) * 8, 0);
+            (VL_LEN_FAST_TRACED_STRING + 1) * 8, 0);
 }
 
 //=============================================================================

--- a/include/verilated_fst_c.h
+++ b/include/verilated_fst_c.h
@@ -111,6 +111,8 @@ public:
                    fstVarType vartype, bool array, int arraynum, int msb, int lsb);
     void declDouble(uint32_t code, const char* name, int dtypenum, fstVarDir vardir,
                     fstVarType vartype, bool array, int arraynum);
+    void declString(uint32_t code, const char* name, int dtypenum, fstVarDir vardir,
+                    fstVarType vartype, bool array, int arraynum);
 
     void declDTypeEnum(int dtypenum, const char* name, uint32_t elements, unsigned int minValbits,
                        const char** itemNamesp, const char** itemValuesp);
@@ -168,6 +170,7 @@ class VerilatedFstBuffer VL_NOT_FINAL {
     VL_ATTR_ALWINLINE void emitQData(uint32_t code, QData newval, int bits);
     VL_ATTR_ALWINLINE void emitWData(uint32_t code, const WData* newvalp, int bits);
     VL_ATTR_ALWINLINE void emitDouble(uint32_t code, double newval);
+    VL_ATTR_ALWINLINE void emitStringRaw(uint32_t code, const char* newvalp, int bytes);
 };
 
 //=============================================================================

--- a/include/verilated_trace.h
+++ b/include/verilated_trace.h
@@ -48,11 +48,6 @@ class VerilatedTraceBuffer;
 template <class T_Buffer>
 class VerilatedTraceOffloadBuffer;
 
-// Traced strings above this size may be inefficient as they cannot be deduped.
-// Must be <=254, but larger sizes bloat memory proportional to the number of
-// traceable strings.
-constexpr size_t LEN_FAST_TRACED_STRING = 63;
-
 #ifdef VL_THREADED
 //=============================================================================
 // Offloaded tracing
@@ -489,7 +484,7 @@ public:
         // cppcheck-suppress invalidPointerCast
         int oldsize = *reinterpret_cast<char*>(oldp);
         const char* oldstr = reinterpret_cast<char*>(oldp) + 1;
-        if (VL_UNLIKELY((oldsize > LEN_FAST_TRACED_STRING) || (oldsize != bytes)
+        if (VL_UNLIKELY((oldsize > VL_LEN_FAST_TRACED_STRING) || (oldsize != bytes)
                         || (memcmp(newval, oldstr, bytes)))) {
             fullStringRaw(oldp, newval, bytes);
         }
@@ -572,7 +567,7 @@ public:
         VL_DEBUG_IF(assert(m_offloadBufferWritep <= m_offloadBufferEndp););
     }
     void chgStringRaw(uint32_t code, char* newval, int bytes) {
-        if (bytes > LEN_FAST_TRACED_STRING) {
+        if (bytes > VL_LEN_FAST_TRACED_STRING) {
             // For big strings, make a temporary allocation
             VL_DEBUG_IF(assert(bytes >= 0x1000000););  // 16MB is enough for anybody
             m_offloadBufferWritep[0] = (bytes << 4) | VerilatedTraceOffloadCommand::CHG_BIG_STRING;

--- a/include/verilated_trace.h
+++ b/include/verilated_trace.h
@@ -485,7 +485,7 @@ public:
         int oldsize = *reinterpret_cast<char*>(oldp);
         const char* oldstr = reinterpret_cast<char*>(oldp) + 1;
         if (VL_UNLIKELY((oldsize > VL_LEN_FAST_TRACED_STRING) || (oldsize != bytes)
-                        || (memcmp(newval, oldstr, bytes)))) {
+                        || (std::memcmp(newval, oldstr, bytes)))) {
             fullStringRaw(oldp, newval, bytes);
         }
     }
@@ -575,14 +575,14 @@ public:
             char* indirectstringbufp = new char[bytes];
             // cppcheck-suppress invalidPointerCast
             *reinterpret_cast<const char**>(m_offloadBufferWritep + 2) = indirectstringbufp;
-            memcpy(indirectstringbufp, newval, bytes);
+            std::memcpy(indirectstringbufp, newval, bytes);
             m_offloadBufferWritep += 4;
         } else {
             // For smallish strings, write inline
             int stringSizeDw = (bytes + 3) >> 2;  // Bytes to DW, rounded up.
             m_offloadBufferWritep[0] = (bytes << 4) | VerilatedTraceOffloadCommand::CHG_STRING;
             m_offloadBufferWritep[1] = code;
-            memcpy(m_offloadBufferWritep + 2, newval, bytes);
+            std::memcpy(m_offloadBufferWritep + 2, newval, bytes);
             m_offloadBufferWritep += stringSizeDw + 2;
         }
         VL_DEBUG_IF(assert(m_offloadBufferWritep <= m_offloadBufferEndp););

--- a/include/verilated_trace.h
+++ b/include/verilated_trace.h
@@ -572,11 +572,8 @@ public:
         VL_DEBUG_IF(assert(bytes >= 0x1000000););  // 16MB is enough for anybody
         m_offloadBufferWritep[0] = (bytes << 4) | VerilatedTraceOffloadCommand::CHG_STRING;
         m_offloadBufferWritep[1] = code;
-        char* indirectstringbufp = new char[bytes];
-        // cppcheck-suppress invalidPointerCast
-        *reinterpret_cast<const char**>(m_offloadBufferWritep + 2) = indirectstringbufp;
-        std::memcpy(indirectstringbufp, newval, bytes);
-        m_offloadBufferWritep += 4;
+        std::string* sdata = new(m_offloadBufferWritep + 2) std::string(newval, bytes);
+        m_offloadBufferWritep += 2 + sizeof(std::string);
         VL_DEBUG_IF(assert(m_offloadBufferWritep <= m_offloadBufferEndp););
     }
 };

--- a/include/verilated_trace.h
+++ b/include/verilated_trace.h
@@ -485,7 +485,7 @@ public:
     }
     VL_ATTR_ALWINLINE void chgStringRaw(uint32_t* oldp, const char* newval, int bytes) {
         // cppcheck-suppress invalidPointerCast
-        std::string* oldvalp = *reinterpret_cast<std::string*>(oldp);
+        std::string* oldvalp = reinterpret_cast<std::string*>(oldp);
         if (VL_UNLIKELY(oldvalp->compare(0, oldvalp->size(), newval, bytes) == 0)) {
             fullStringRaw(oldp, newval, bytes);
         }

--- a/include/verilated_trace_imp.h
+++ b/include/verilated_trace_imp.h
@@ -358,7 +358,7 @@ void VerilatedTrace<VL_SUB_T, VL_BUF_T>::traceInit() VL_MT_UNSAFE {
     }
     if (!oldStringCodes.empty() && m_sigs_stringCodes != oldStringCodes) {
         VL_FATAL_MT(__FILE__, __LINE__, "",
-                    "Reopening trace file with different signals!");
+                    "Reopening trace file with different signals");
     }
 
     // Now that we know the number of codes, allocate space for the buffer

--- a/include/verilated_trace_imp.h
+++ b/include/verilated_trace_imp.h
@@ -193,9 +193,9 @@ void VerilatedTrace<VL_SUB_T, VL_BUF_T>::offloadWorkerThreadMain() {
                 continue;
             case VerilatedTraceOffloadCommand::CHG_BIG_STRING:
                 VL_TRACE_OFFLOAD_DEBUG("Command CHG_BIG_STRING" << top);
-                traceBufp->chgStringRaw(oldp, *reinterpret_cast<const char*const*>(readp), top);
+                traceBufp->chgStringRaw(oldp, *reinterpret_cast<const char* const*>(readp), top);
                 readp += 2;
-                delete[] * reinterpret_cast<const char*const*>(readp);
+                delete[] * reinterpret_cast<const char* const*>(readp);
                 continue;
 
                 //===

--- a/include/verilated_trace_imp.h
+++ b/include/verilated_trace_imp.h
@@ -923,7 +923,7 @@ void VerilatedTraceBuffer<VL_BUF_T>::fullDouble(uint32_t* oldp, double newval) {
 template <>
 void VerilatedTraceBuffer<VL_BUF_T>::fullStringRaw(uint32_t* oldp, const char* newval, int bytes) {
     const uint32_t code = oldp - m_sigs_oldvalp;
-    if (bytes > LEN_FAST_TRACED_STRING) {
+    if (bytes > VL_LEN_FAST_TRACED_STRING) {
         *reinterpret_cast<char*>(oldp) = 0xFF;
     } else {
         *reinterpret_cast<char*>(oldp) = bytes;

--- a/include/verilated_trace_imp.h
+++ b/include/verilated_trace_imp.h
@@ -187,11 +187,14 @@ void VerilatedTrace<VL_SUB_T, VL_BUF_T>::offloadWorkerThreadMain() {
                 readp += 2;
                 continue;
             case VerilatedTraceOffloadCommand::CHG_STRING:
-                VL_TRACE_OFFLOAD_DEBUG("Command CHG_STRING" << top);
-                traceBufp->chgStringRaw(oldp, *reinterpret_cast<const char* const*>(readp), top);
-                delete[] * reinterpret_cast<const char* const*>(readp);
-                readp += 2;
-                continue;
+                {
+                    VL_TRACE_OFFLOAD_DEBUG("Command CHG_STRING" << top);
+                    const std::string* stringp = reinterpret_cast<const std::string*>(readp);
+                    traceBufp->chgStringRaw(oldp, stringp->data(), top);
+                    stringp->~basic_string();
+                    readp += sizeof(std::string);
+                    continue;
+                }
 
                 //===
                 // Rare commands

--- a/include/verilated_trace_imp.h
+++ b/include/verilated_trace_imp.h
@@ -927,7 +927,7 @@ void VerilatedTraceBuffer<VL_BUF_T>::fullStringRaw(uint32_t* oldp, const char* n
         *reinterpret_cast<char*>(oldp) = 0xFF;
     } else {
         *reinterpret_cast<char*>(oldp) = bytes;
-        memcpy(reinterpret_cast<char*>(oldp) + 1, newval, bytes);
+        std::memcpy(reinterpret_cast<char*>(oldp) + 1, newval, bytes);
     }
     if (VL_UNLIKELY(m_sigs_enabledp && !(VL_BITISSET_W(m_sigs_enabledp, code)))) return;
     // cppcheck-suppress invalidPointerCast

--- a/include/verilated_trace_imp.h
+++ b/include/verilated_trace_imp.h
@@ -189,8 +189,8 @@ void VerilatedTrace<VL_SUB_T, VL_BUF_T>::offloadWorkerThreadMain() {
             case VerilatedTraceOffloadCommand::CHG_STRING:
                 VL_TRACE_OFFLOAD_DEBUG("Command CHG_STRING" << top);
                 traceBufp->chgStringRaw(oldp, *reinterpret_cast<const char* const*>(readp), top);
-                readp += 2;
                 delete[] * reinterpret_cast<const char* const*>(readp);
+                readp += 2;
                 continue;
 
                 //===
@@ -353,7 +353,7 @@ void VerilatedTrace<VL_SUB_T, VL_BUF_T>::traceInit() VL_MT_UNSAFE {
         VL_FATAL_MT(__FILE__, __LINE__, "",
                     "Reopening trace file with different number of signals");
     }
-    if (m_sigs_stringCodes != oldStringCodes) {
+    if (!oldStringCodes.empty() && m_sigs_stringCodes != oldStringCodes) {
         VL_FATAL_MT(__FILE__, __LINE__, "",
                     "Reopening trace file with different signals!");
     }
@@ -445,6 +445,7 @@ bool VerilatedTrace<VL_SUB_T, VL_BUF_T>::declCode(uint32_t code, const char* nam
     int codesNeeded = VL_WORDS_I(bits);
     if (tri) codesNeeded *= 2;
     m_nextCode = std::max(m_nextCode, code + codesNeeded);
+    ++m_numSignals;
     if (str) m_sigs_stringCodes.push_back(code);
     m_maxBits = std::max(m_maxBits, bits);
     return enabled;

--- a/include/verilated_vcd_c.cpp
+++ b/include/verilated_vcd_c.cpp
@@ -569,8 +569,8 @@ void VerilatedVcd::declDouble(uint32_t code, const char* name, bool array, int a
     declare(code, name, "real", array, arraynum, false, false, 63, 0);
 }
 void VerilatedVcd::declString(uint32_t code, const char* name, bool array, int arraynum) {
-    declare(code, name, "string", array, arraynum, false, false, (VL_LEN_FAST_TRACED_STRING + 1) * 8,
-            0);
+    declare(code, name, "string", array, arraynum, false, false,
+            (VL_LEN_FAST_TRACED_STRING + 1) * 8, 0);
 }
 
 //=============================================================================

--- a/include/verilated_vcd_c.cpp
+++ b/include/verilated_vcd_c.cpp
@@ -569,7 +569,7 @@ void VerilatedVcd::declDouble(uint32_t code, const char* name, bool array, int a
     declare(code, name, "real", array, arraynum, false, false, 63, 0);
 }
 void VerilatedVcd::declString(uint32_t code, const char* name, bool array, int arraynum) {
-    declare(code, name, "string", array, arraynum, false, false, (LEN_FAST_TRACED_STRING + 1) * 8,
+    declare(code, name, "string", array, arraynum, false, false, (VL_LEN_FAST_TRACED_STRING + 1) * 8,
             0);
 }
 

--- a/include/verilated_vcd_c.cpp
+++ b/include/verilated_vcd_c.cpp
@@ -473,10 +473,10 @@ void VerilatedVcd::dumpHeader() {
 }
 
 void VerilatedVcd::declare(uint32_t code, const char* name, const char* wirep, bool array,
-                           int arraynum, bool tri, bool bussed, int msb, int lsb) {
+                           int arraynum, bool tri, bool bussed, int msb, int lsb, bool str) {
     const int bits = ((msb > lsb) ? (msb - lsb) : (lsb - msb)) + 1;
 
-    const bool enabled = Super::declCode(code, name, bits, tri);
+    const bool enabled = Super::declCode(code, name, bits, tri, str);
 
     if (m_suffixes.size() <= nextCode() * VL_TRACE_SUFFIX_ENTRY_SIZE) {
         m_suffixes.resize(nextCode() * VL_TRACE_SUFFIX_ENTRY_SIZE * 2, 0);
@@ -551,26 +551,26 @@ void VerilatedVcd::declare(uint32_t code, const char* name, const char* wirep, b
 }
 
 void VerilatedVcd::declBit(uint32_t code, const char* name, bool array, int arraynum) {
-    declare(code, name, "wire", array, arraynum, false, false, 0, 0);
+    declare(code, name, "wire", array, arraynum, false, false, 0, 0, false);
 }
 void VerilatedVcd::declBus(uint32_t code, const char* name, bool array, int arraynum, int msb,
                            int lsb) {
-    declare(code, name, "wire", array, arraynum, false, true, msb, lsb);
+    declare(code, name, "wire", array, arraynum, false, true, msb, lsb, false);
 }
 void VerilatedVcd::declQuad(uint32_t code, const char* name, bool array, int arraynum, int msb,
                             int lsb) {
-    declare(code, name, "wire", array, arraynum, false, true, msb, lsb);
+    declare(code, name, "wire", array, arraynum, false, true, msb, lsb, false);
 }
 void VerilatedVcd::declArray(uint32_t code, const char* name, bool array, int arraynum, int msb,
                              int lsb) {
-    declare(code, name, "wire", array, arraynum, false, true, msb, lsb);
+    declare(code, name, "wire", array, arraynum, false, true, msb, lsb, false);
 }
 void VerilatedVcd::declDouble(uint32_t code, const char* name, bool array, int arraynum) {
-    declare(code, name, "real", array, arraynum, false, false, 63, 0);
+    declare(code, name, "real", array, arraynum, false, false, 63, 0, false);
 }
 void VerilatedVcd::declString(uint32_t code, const char* name, bool array, int arraynum) {
     declare(code, name, "string", array, arraynum, false, false,
-            (VL_LEN_FAST_TRACED_STRING + 1) * 8, 0);
+            sizeof(std::string) * 8, 0, true);
 }
 
 //=============================================================================

--- a/include/verilated_vcd_c.cpp
+++ b/include/verilated_vcd_c.cpp
@@ -776,7 +776,6 @@ void VerilatedVcdBuffer::emitDouble(uint32_t code, double newval) {
     finishLine(code, wp);
 }
 
-VL_ATTR_ALWINLINE
 void VerilatedVcdBuffer::emitStringRaw(uint32_t code, const char* newval, int size) {
     char* wp = m_writep;
 

--- a/include/verilated_vcd_c.h
+++ b/include/verilated_vcd_c.h
@@ -147,6 +147,7 @@ public:
     void declQuad(uint32_t code, const char* name, bool array, int arraynum, int msb, int lsb);
     void declArray(uint32_t code, const char* name, bool array, int arraynum, int msb, int lsb);
     void declDouble(uint32_t code, const char* name, bool array, int arraynum);
+    void declString(uint32_t code, const char* name, bool array, int arraynum);
 };
 
 #ifndef DOXYGEN
@@ -217,6 +218,7 @@ class VerilatedVcdBuffer VL_NOT_FINAL {
     VL_ATTR_ALWINLINE void emitQData(uint32_t code, QData newval, int bits);
     VL_ATTR_ALWINLINE void emitWData(uint32_t code, const WData* newvalp, int bits);
     VL_ATTR_ALWINLINE void emitDouble(uint32_t code, double newval);
+    VL_ATTR_ALWINLINE void emitStringRaw(uint32_t code, const char* newval, int bytes);
 };
 
 //=============================================================================

--- a/include/verilated_vcd_c.h
+++ b/include/verilated_vcd_c.h
@@ -218,7 +218,7 @@ class VerilatedVcdBuffer VL_NOT_FINAL {
     VL_ATTR_ALWINLINE void emitQData(uint32_t code, QData newval, int bits);
     VL_ATTR_ALWINLINE void emitWData(uint32_t code, const WData* newvalp, int bits);
     VL_ATTR_ALWINLINE void emitDouble(uint32_t code, double newval);
-    VL_ATTR_ALWINLINE void emitStringRaw(uint32_t code, const char* newval, int bytes);
+    void emitStringRaw(uint32_t code, const char* newval, int bytes);
 };
 
 //=============================================================================

--- a/include/verilated_vcd_c.h
+++ b/include/verilated_vcd_c.h
@@ -88,7 +88,7 @@ private:
     void printQuad(uint64_t n);
     void printTime(uint64_t timeui);
     void declare(uint32_t code, const char* name, const char* wirep, bool array, int arraynum,
-                 bool tri, bool bussed, int msb, int lsb);
+                 bool tri, bool bussed, int msb, int lsb, bool str);
 
     void dumpHeader();
 

--- a/include/verilatedos.h
+++ b/include/verilatedos.h
@@ -405,11 +405,6 @@ using ssize_t = uint32_t;  ///< signed size_t; returned from read()
 #define VL_VALUE_STRING_MAX_WORDS 64  ///< Max size in words of String conversion operation
 #define VL_VALUE_STRING_MAX_CHARS (VL_VALUE_STRING_MAX_WORDS * VL_EDATASIZE / VL_BYTESIZE)
 
-// Traced strings above this size may be inefficient as they cannot be deduped.
-// Must be <=254, but larger sizes bloat memory proportional to the number of
-// traceable strings.
-#define VL_LEN_FAST_TRACED_STRING 63
-
 //=========================================================================
 // Base macros
 

--- a/include/verilatedos.h
+++ b/include/verilatedos.h
@@ -405,6 +405,11 @@ using ssize_t = uint32_t;  ///< signed size_t; returned from read()
 #define VL_VALUE_STRING_MAX_WORDS 64  ///< Max size in words of String conversion operation
 #define VL_VALUE_STRING_MAX_CHARS (VL_VALUE_STRING_MAX_WORDS * VL_EDATASIZE / VL_BYTESIZE)
 
+// Traced strings above this size may be inefficient as they cannot be deduped.
+// Must be <=254, but larger sizes bloat memory proportional to the number of
+// traceable strings.
+#define VL_LEN_FAST_TRACED_STRING 63
+
 //=========================================================================
 // Base macros
 

--- a/src/V3Ast.h
+++ b/src/V3Ast.h
@@ -1642,6 +1642,7 @@ public:
         return v3Global.widthMinUsage() == VWidthMinUsage::VERILOG_WIDTH ? widthMin() : width();
     }
     int widthWords() const { return VL_WORDS_I(width()); }
+    int traceWidthWords() const { return isString() ? (sizeof(std::string) / 4) : VL_WORDS_I(width()); }
     bool isQuad() const { return (width() > VL_IDATASIZE && width() <= VL_QUADSIZE); }
     bool isWide() const { return (width() > VL_QUADSIZE); }
     inline bool isDouble() const;

--- a/src/V3AstNodeOther.h
+++ b/src/V3AstNodeOther.h
@@ -3516,9 +3516,12 @@ public:
         , m_showname{showname}
         , m_bitRange{bitRange}
         , m_arrayRange{arrayRange}
-        , m_codeInc(
-              ((arrayRange.ranged() ? arrayRange.elements() : 1) * valuep->dtypep()->widthWords()
-               * (VL_EDATASIZE / 32)))  // A code is always 32-bits
+        , m_codeInc(((arrayRange.ranged() ? arrayRange.elements() : 1)
+                     * (valuep->isString() ? ((LEN_FAST_TRACED_STRING + 1)
+                                              / 4)  // strings get a small buffer to dedup
+                                                    // (different from actual storage size)
+                                           : valuep->dtypep()->widthWords())
+                     * (VL_EDATASIZE / 32)))  // A code is always 32-bits
         , m_varType{varp->varType()}
         , m_declKwd{varp->declKwd()}
         , m_declDirection{varp->declDirection()} {

--- a/src/V3AstNodeOther.h
+++ b/src/V3AstNodeOther.h
@@ -3517,7 +3517,7 @@ public:
         , m_bitRange{bitRange}
         , m_arrayRange{arrayRange}
         , m_codeInc(((arrayRange.ranged() ? arrayRange.elements() : 1)
-                     * (valuep->isString() ? ((LEN_FAST_TRACED_STRING + 1)
+                     * (valuep->isString() ? ((VL_LEN_FAST_TRACED_STRING + 1)
                                               / 4)  // strings get a small buffer to dedup
                                                     // (different from actual storage size)
                                            : valuep->dtypep()->widthWords())

--- a/src/V3AstNodeOther.h
+++ b/src/V3AstNodeOther.h
@@ -3517,9 +3517,7 @@ public:
         , m_bitRange{bitRange}
         , m_arrayRange{arrayRange}
         , m_codeInc(((arrayRange.ranged() ? arrayRange.elements() : 1)
-                     * (valuep->isString() ? ((VL_LEN_FAST_TRACED_STRING + 1)
-                                              / 4)  // strings get a small buffer to dedup
-                                                    // (different from actual storage size)
+                     * (valuep->isString() ? (sizeof(std::string) / 4)
                                            : valuep->dtypep()->widthWords())
                      * (VL_EDATASIZE / 32)))  // A code is always 32-bits
         , m_varType{varp->varType()}

--- a/src/V3AstNodeOther.h
+++ b/src/V3AstNodeOther.h
@@ -3517,8 +3517,7 @@ public:
         , m_bitRange{bitRange}
         , m_arrayRange{arrayRange}
         , m_codeInc(((arrayRange.ranged() ? arrayRange.elements() : 1)
-                     * (valuep->isString() ? (sizeof(std::string) / 4)
-                                           : valuep->dtypep()->widthWords())
+                     * valuep->dtypep()->traceWidthWords()
                      * (VL_EDATASIZE / 32)))  // A code is always 32-bits
         , m_varType{varp->varType()}
         , m_declKwd{varp->declKwd()}

--- a/src/V3EmitCImp.cpp
+++ b/src/V3EmitCImp.cpp
@@ -637,7 +637,7 @@ class EmitCTrace final : EmitCFunc {
         }
 
         puts("(c+" + cvtToStr(nodep->code()));
-        if (nodep->arrayRange().ranged()) puts("+i*" + cvtToStr(nodep->widthWords()));
+        if (nodep->arrayRange().ranged()) puts("+i*" + cvtToStr(nodep->traceWidthWords()));
         puts(",");
         putsQuoted(VIdProtect::protectWordsIf(nodep->showname(), nodep->protect()));
         // Direction
@@ -783,7 +783,7 @@ class EmitCTrace final : EmitCFunc {
             emitWidth = false;
         }
 
-        const uint32_t offset = (arrayindex < 0) ? 0 : (arrayindex * nodep->declp()->widthWords());
+        const uint32_t offset = (arrayindex < 0) ? 0 : (arrayindex * nodep->declp()->traceWidthWords());
         const uint32_t code = nodep->declp()->code() + offset;
         puts(v3Global.opt.useTraceOffload() && !nodep->full() ? "(base+" : "(oldp+");
         puts(cvtToStr(code - nodep->baseCode()));

--- a/src/V3EmitCImp.cpp
+++ b/src/V3EmitCImp.cpp
@@ -665,6 +665,8 @@ class EmitCTrace final : EmitCFunc {
                 } else {
                     fstvt = "FST_VT_VCD_REAL";
                 }
+            } else if (nodep->isString()){
+                fstvt = "FST_VT_GEN_STRING";
             }
             // clang-format off
             else if (vartype == VVarType::GPARAM) {  fstvt = "FST_VT_VCD_PARAMETER"; }
@@ -684,7 +686,6 @@ class EmitCTrace final : EmitCFunc {
             else if (kwd == VBasicDTypeKwd::SHORTINT) { fstvt = "FST_VT_SV_SHORTINT"; }
             else if (kwd == VBasicDTypeKwd::LONGINT) {  fstvt = "FST_VT_SV_LONGINT"; }
             else if (kwd == VBasicDTypeKwd::BYTE) {     fstvt = "FST_VT_SV_BYTE"; }
-            else if (kwd == VBasicDTypeKwd::STRING) {   fstvt = "FST_VT_GEN_STRING"; }
             else { fstvt = "FST_VT_SV_BIT"; }
             // clang-format on
             //

--- a/src/V3EmitCImp.cpp
+++ b/src/V3EmitCImp.cpp
@@ -624,6 +624,8 @@ class EmitCTrace final : EmitCFunc {
     void emitTraceInitOne(AstTraceDecl* nodep, int enumNum) {
         if (nodep->dtypep()->basicp()->isDouble()) {
             puts("tracep->declDouble");
+        } else if (nodep->isString()) {
+            puts("tracep->declString");
         } else if (nodep->isWide()) {
             puts("tracep->declArray");
         } else if (nodep->isQuad()) {
@@ -682,6 +684,7 @@ class EmitCTrace final : EmitCFunc {
             else if (kwd == VBasicDTypeKwd::SHORTINT) { fstvt = "FST_VT_SV_SHORTINT"; }
             else if (kwd == VBasicDTypeKwd::LONGINT) {  fstvt = "FST_VT_SV_LONGINT"; }
             else if (kwd == VBasicDTypeKwd::BYTE) {     fstvt = "FST_VT_SV_BYTE"; }
+            else if (kwd == VBasicDTypeKwd::STRING) {   fstvt = "FST_VT_GEN_STRING"; }
             else { fstvt = "FST_VT_SV_BIT"; }
             // clang-format on
             //
@@ -697,7 +700,6 @@ class EmitCTrace final : EmitCFunc {
             // FST_VT_VCD_WAND
             // FST_VT_VCD_WOR
             // FST_VT_SV_ENUM
-            // FST_VT_GEN_STRING
             puts("," + fstvt);
         }
         // Range
@@ -706,7 +708,8 @@ class EmitCTrace final : EmitCFunc {
         } else {
             puts(", false,-1");
         }
-        if (!nodep->dtypep()->basicp()->isDouble() && nodep->bitRange().ranged()) {
+        if (!nodep->dtypep()->basicp()->isDouble() && !nodep->isString()
+            && nodep->bitRange().ranged()) {
             puts(", " + cvtToStr(nodep->bitRange().left()) + ","
                  + cvtToStr(nodep->bitRange().right()));
         }
@@ -761,6 +764,9 @@ class EmitCTrace final : EmitCFunc {
         bool emitWidth = true;
         if (nodep->dtypep()->basicp()->isDouble()) {
             puts("bufp->" + func + "Double");
+            emitWidth = false;
+        } else if (nodep->isString()) {
+            puts("bufp->" + func + "String");
             emitWidth = false;
         } else if (nodep->isWide() || emitTraceIsScBv(nodep) || emitTraceIsScBigUint(nodep)) {
             puts("bufp->" + func + "WData");

--- a/src/V3EmitCSyms.cpp
+++ b/src/V3EmitCSyms.cpp
@@ -778,6 +778,13 @@ void EmitCSyms::emitSymImp() {
         }
     }
 
+    puts("// Configure max string length\n");
+    if (!v3Global.rootp()->timeunit().isNone()) {
+        puts("_vm_contextp__->maxStringTrace(");
+        puts(cvtToStr(v3Global.opt.traceMaxString()));
+        puts(");\n");
+    }
+
     puts("// Configure time unit / time precision\n");
     if (!v3Global.rootp()->timeunit().isNone()) {
         puts("_vm_contextp__->timeunit(");

--- a/src/V3Global.h
+++ b/src/V3Global.h
@@ -25,7 +25,6 @@
 // clang-format on
 
 #include "verilatedos.h"
-#include "verilated_trace.h"
 
 #include "V3Error.h"
 #include "V3FileLine.h"

--- a/src/V3Global.h
+++ b/src/V3Global.h
@@ -25,6 +25,7 @@
 // clang-format on
 
 #include "verilatedos.h"
+#include "verilated_trace.h"
 
 #include "V3Error.h"
 #include "V3FileLine.h"

--- a/src/V3Options.cpp
+++ b/src/V3Options.cpp
@@ -1401,6 +1401,7 @@ void V3Options::parseOptsList(FileLine* fl, const string& optdir, int argc, char
     DECL_OPTION("-trace-max-width", Set, &m_traceMaxWidth);
     DECL_OPTION("-trace-params", OnOff, &m_traceParams);
     DECL_OPTION("-trace-structs", OnOff, &m_traceStructs);
+    DECL_OPTION("-trace-strings", OnOff, &m_traceStrings);
     DECL_OPTION("-trace-threads", CbVal, [this, fl](const char* valp) {
         m_trace = true;
         m_traceThreads = std::atoi(valp);

--- a/src/V3Options.cpp
+++ b/src/V3Options.cpp
@@ -1398,6 +1398,7 @@ void V3Options::parseOptsList(FileLine* fl, const string& optdir, int argc, char
         if (m_traceThreads == 0) m_traceThreads = 1;
     });
     DECL_OPTION("-trace-max-array", Set, &m_traceMaxArray);
+    DECL_OPTION("-trace-max-string", Set, &m_traceMaxString);
     DECL_OPTION("-trace-max-width", Set, &m_traceMaxWidth);
     DECL_OPTION("-trace-params", OnOff, &m_traceParams);
     DECL_OPTION("-trace-structs", OnOff, &m_traceStructs);

--- a/src/V3Options.h
+++ b/src/V3Options.h
@@ -277,6 +277,7 @@ private:
     bool m_trace = false;           // main switch: --trace
     bool m_traceCoverage = false;   // main switch: --trace-coverage
     bool m_traceParams = true;      // main switch: --trace-params
+    bool m_traceStrings = false;    // main switch: --trace-strings
     bool m_traceStructs = false;    // main switch: --trace-structs
     bool m_traceUnderscore = false; // main switch: --trace-underscore
     bool m_underlineZero = false;   // main switch: --underline-zero; undocumented old Verilator 2
@@ -463,6 +464,7 @@ public:
     bool trace() const { return m_trace; }
     bool traceCoverage() const { return m_traceCoverage; }
     bool traceParams() const { return m_traceParams; }
+    bool traceStrings() const { return m_traceStrings; }
     bool traceStructs() const { return m_traceStructs; }
     bool traceUnderscore() const { return m_traceUnderscore; }
     bool main() const { return m_main; }

--- a/src/V3Options.h
+++ b/src/V3Options.h
@@ -313,6 +313,7 @@ private:
     int         m_traceDepth = 0;   // main switch: --trace-depth
     TraceFormat m_traceFormat;  // main switch: --trace or --trace-fst
     int         m_traceMaxArray = 32;  // main switch: --trace-max-array
+    int         m_traceMaxString = 64; // main switch: --trace-max-string
     int         m_traceMaxWidth = 256; // main switch: --trace-max-width
     int         m_traceThreads = 0; // main switch: --trace-threads
     int         m_unrollCount = 64;  // main switch: --unroll-count
@@ -523,6 +524,7 @@ public:
     int traceDepth() const { return m_traceDepth; }
     TraceFormat traceFormat() const { return m_traceFormat; }
     int traceMaxArray() const { return m_traceMaxArray; }
+    int traceMaxString() const { return m_traceMaxString; }
     int traceMaxWidth() const { return m_traceMaxWidth; }
     int traceThreads() const { return m_traceThreads; }
     bool useTraceOffload() const { return trace() && traceFormat().fst() && traceThreads() > 1; }

--- a/src/V3TraceDecl.cpp
+++ b/src/V3TraceDecl.cpp
@@ -453,7 +453,11 @@ private:
     void visit(AstBasicDType* nodep) override {
         if (m_traVscp) {
             if (nodep->isString()) {
-                addIgnore("Unsupported: strings");
+                if (v3Global.opt.traceStrings()) {
+                    addTraceDecl(VNumRange{}, 0);
+                } else {
+                    addIgnore("Unsupported: strings");
+                }
             } else {
                 addTraceDecl(VNumRange{}, 0);
             }

--- a/src/V3TraceDecl.cpp
+++ b/src/V3TraceDecl.cpp
@@ -363,12 +363,9 @@ private:
                               == nodep) {  // Nothing above this array
                 // Simple 1-D array, use existing V3EmitC runtime loop rather than unrolling
                 // This will put "(index)" at end of signal name for us
-                if (m_traVscp->dtypep()->skipRefToEnump()->isString()) {
-                    if (v3Global.opt.traceStrings()) {
-                        addTraceDecl(VNumRange{}, 0);
-                    } else {
-                        addIgnore("Disabled: strings");
-                    }
+                if (m_traVscp->dtypep()->skipRefToEnump()->isString()
+                    && !v3Global.opt.traceStrings()) {
+                    addIgnore("Disabled: strings");
                 } else {
                     addTraceDecl(nodep->declRange(), 0);
                 }

--- a/src/V3TraceDecl.cpp
+++ b/src/V3TraceDecl.cpp
@@ -364,7 +364,11 @@ private:
                 // Simple 1-D array, use existing V3EmitC runtime loop rather than unrolling
                 // This will put "(index)" at end of signal name for us
                 if (m_traVscp->dtypep()->skipRefToEnump()->isString()) {
-                    addIgnore("Unsupported: strings");
+                    if (v3Global.opt.traceStrings()) {
+                        addTraceDecl(VNumRange{}, 0);
+                    } else {
+                        addIgnore("Disabled: strings");
+                    }
                 } else {
                     addTraceDecl(nodep->declRange(), 0);
                 }
@@ -456,7 +460,7 @@ private:
                 if (v3Global.opt.traceStrings()) {
                     addTraceDecl(VNumRange{}, 0);
                 } else {
-                    addIgnore("Unsupported: strings");
+                    addIgnore("Disabled: strings");
                 }
             } else {
                 addTraceDecl(VNumRange{}, 0);

--- a/test_regress/t/t_trace_string.pl
+++ b/test_regress/t/t_trace_string.pl
@@ -11,7 +11,7 @@ if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); di
 scenarios(simulator => 1);
 
 compile(
-    verilator_flags2 => ['--cc --trace'],
+    verilator_flags2 => ['--cc --trace --trace-strings'],
     );
 
 execute(

--- a/test_regress/t/t_trace_string.v
+++ b/test_regress/t/t_trace_string.v
@@ -19,6 +19,8 @@ module t (/*AUTOARG*/
       $finish;
    end
 
+   string SOMESTRING = "foo";
+
    localparam string REGX [0:31] = '{"zero", "ra", "sp", "gp", "tp", "t0", "t1", "t2", "s0/fp", "s1", "a0", "a1", "a2", "a3", "a4", "a5",
                                       "a6", "a7", "s2", "s3", "s4", "s5", "s6", "s7", "s8", "s9", "s10", "s11", "t3", "t4", "t5", "t6"};
 

--- a/test_regress/t/t_trace_string_fst.pl
+++ b/test_regress/t/t_trace_string_fst.pl
@@ -13,7 +13,7 @@ scenarios(simulator => 1);
 top_filename("t/t_trace_string.v");
 
 compile(
-    verilator_flags2 => ['--cc --trace'],
+    verilator_flags2 => ['--cc --trace-fst --trace-strings'],
     );
 
 execute(

--- a/test_regress/t/t_trace_string_skip.pl
+++ b/test_regress/t/t_trace_string_skip.pl
@@ -10,20 +10,15 @@ if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); di
 
 scenarios(simulator => 1);
 
-if (!$Self->have_sc) {
-    skip("No SystemC installed");
-}
-else {
-    top_filename("t/t_trace_string.v");
+top_filename("t/t_trace_string.v");
 
-    compile(
-        verilator_flags2 => ['--sc --trace-fst --trace-strings'],
-        );
+compile(
+    verilator_flags2 => ['--cc --trace'],
+    );
 
-    execute(
-        check_finished => 1,
-        );
-}
+execute(
+    check_finished => 1,
+    );
 
 ok(1);
 1;

--- a/verilator-config.cmake.in
+++ b/verilator-config.cmake.in
@@ -175,6 +175,10 @@ function(verilate TARGET)
     list(APPEND VERILATOR_ARGS --cc)
   endif()
 
+  if (VERILATE_TRACE_STRINGS)
+      list(APPEND VERILATOR_ARGS --trace-strings)
+  endif()
+
   if (VERILATE_TRACE_STRUCTS)
       list(APPEND VERILATOR_ARGS --trace-structs)
   endif()


### PR DESCRIPTION
Adds optional support for embedding verilog strings into traces. My personal use case for this is embedding assembly into a trace alongside the instructions themselves.

Note this needs a nightly GtkWave due to a fixed GtkWave bug.

Implementation notes:
 - This introduces --trace-strings and --trace-max-string args since strings are big and most users don't need them in traces by default.
 - Users can trace big strings if needed, but viewers can't really view big strings anyhow. 64 bytes was chosen as a good balance for usability.
 - If something changes beyond the max size of the traced string, it will still appear as a change in the wave viewers (even if you can't tell what changed in them).
 - Arrays of strings can be traced, but they don't currently appear in GTKWave.

Max sizes:
   - When async tracing, there's a max of 16MB (could be increased).
   - When using FST, there's a max of 4GB (implementation limit).
   - The limitation of the VCD encoder is complicated but shorter than either of the previous ones. It's proportional to the max signal size, plus many characters use more space due to string escaping.
   - 1 additional copy of the string (not clamped to max size) will be present in memory while tracing. If using async tracing, 2 copies.

Major changes from V1:
 - Now allows setting an arbitrary string max size.
 - Since the user can provide a large max string value, it's not good to always preallocate the max length. Lean on std::string for this. This is about a 5% overhead vs doing it manually, but it simplifies things in most places over an indirect buffer. We also now need to keep track of which values are strings in the tracer so we can clean up memory when it's destroyed.
 - Now traces string arrays too. It was a 2-line change.

Signed-off-by: Jake Merdich <jake@merdich.com>
