### PR TITLE
Improve AstNode function usage ergonomics

### DIFF
--- a/src/V3Active.cpp
+++ b/src/V3Active.cpp
@@ -385,7 +385,7 @@ private:
         // Blocking assignments are always OK in combinational (and initial/final) processes
         if (m_check != CT_SEQ) return;
 
-        const bool ignore = nodep->lhsp()->forall<AstVarRef>([&](const AstVarRef* refp) {
+        const bool ignore = nodep->lhsp()->forall([&](const AstVarRef* refp) {
             // Ignore reads (e.g.: index expressions)
             if (refp->access().isReadOnly()) return true;
             const AstVar* const varp = refp->varp();
@@ -500,7 +500,7 @@ private:
 
     void visitSenItems(AstNode* nodep) {
         if (v3Global.opt.timing().isSetTrue()) {
-            nodep->foreach<AstSenItem>([this](AstSenItem* senItemp) { visit(senItemp); });
+            nodep->foreach ([this](AstSenItem* senItemp) { visit(senItemp); });
         }
     }
 
@@ -561,7 +561,7 @@ private:
             }
         }
 
-        nodep->sensp()->foreach<AstVarRef>([](const AstVarRef* refp) {
+        nodep->sensp()->foreach ([](const AstVarRef* refp) {
             refp->varp()->usedClock(true);
             refp->varScopep()->user1(true);
         });

--- a/src/V3ActiveTop.cpp
+++ b/src/V3ActiveTop.cpp
@@ -47,7 +47,7 @@ class ActiveTopVisitor final : public VNVisitor {
     static bool isInitial(AstNode* nodep) {
         const VNUser1InUse user1InUse;
         // Return true if no variables that read.
-        return nodep->forall<AstVarRef>([&](const AstVarRef* refp) -> bool {
+        return nodep->forall([&](const AstVarRef* refp) -> bool {
             AstVarScope* const vscp = refp->varScopep();
             // Note: Use same heuristic as ordering does to ignore written variables
             // TODO: Use live variable analysis.

--- a/src/V3AstNodeOther.h
+++ b/src/V3AstNodeOther.h
@@ -3833,10 +3833,9 @@ public:
         return new AstAssignW{fileline(), lhsp, rhsp, controlp};
     }
     bool isTimingControl() const override {
-        return timingControlp()
-               || lhsp()->exists<AstNodeVarRef>([](const AstNodeVarRef* const refp) {
-                      return refp->access().isWriteOrRW() && refp->varp()->delayp();
-                  });
+        return timingControlp() || lhsp()->exists([](const AstNodeVarRef* const refp) {
+            return refp->access().isWriteOrRW() && refp->varp()->delayp();
+        });
     }
     bool brokeLhsMustBeLvalue() const override { return true; }
     AstAlways* convertToAlways();

--- a/src/V3Broken.cpp
+++ b/src/V3Broken.cpp
@@ -329,7 +329,7 @@ void V3Broken::brokenAll(AstNetlist* nodep) {
 
         // Mark every node in the tree
         const uint8_t brokenCntCurrent = s_brokenCntGlobal.get();
-        nodep->foreach<AstNode>([brokenCntCurrent](AstNode* nodep) {
+        nodep->foreach ([brokenCntCurrent](AstNode* nodep) {
 #ifdef VL_LEAK_CHECKS
             UASSERT_OBJ(s_allocTable.isAllocated(nodep), nodep,
                         "AstNode is in tree, but not allocated");

--- a/src/V3Const.cpp
+++ b/src/V3Const.cpp
@@ -2038,10 +2038,10 @@ private:
                 // Note only do this (need user4) when m_warn, which is
                 // done as unique visitor
                 const VNUser4InUse m_inuser4;
-                nodep->lhsp()->foreach<AstVarRef>([](const AstVarRef* nodep) {
+                nodep->lhsp()->foreach ([](const AstVarRef* nodep) {
                     if (nodep->varp()) nodep->varp()->user4(1);
                 });
-                nodep->rhsp()->foreach<AstVarRef>([&need_temp](const AstVarRef* nodep) {
+                nodep->rhsp()->foreach ([&need_temp](const AstVarRef* nodep) {
                     if (nodep->varp() && nodep->varp()->user4()) need_temp = true;
                 });
             }

--- a/src/V3Dead.cpp
+++ b/src/V3Dead.cpp
@@ -322,7 +322,7 @@ private:
                     // And its children may now be killable too; correct counts
                     // Recurse, as cells may not be directly under the module but in a generate
                     if (!modp->dead()) {  // If was dead didn't increment user1's
-                        modp->foreach<AstCell>([](const AstCell* cellp) {  //
+                        modp->foreach ([](const AstCell* cellp) {  //
                             cellp->modp()->user1Inc(-1);
                         });
                     }

--- a/src/V3DfgAstToDfg.cpp
+++ b/src/V3DfgAstToDfg.cpp
@@ -91,7 +91,7 @@ class AstToDfgVisitor final : public VNVisitor {
 
     // METHODS
     void markReferenced(AstNode* nodep) {
-        nodep->foreach<AstVarRef>([this](const AstVarRef* refp) {
+        nodep->foreach ([this](const AstVarRef* refp) {
             // No need to (and in fact cannot) mark variables with unsupported dtypes
             if (!DfgVertex::isSupportedDType(refp->varp()->dtypep())) return;
             getNet(refp->varp())->setHasModRefs();

--- a/src/V3DfgDfgToAst.cpp
+++ b/src/V3DfgDfgToAst.cpp
@@ -425,7 +425,7 @@ class DfgToAstVisitor final : DfgVisitor {
 
         // Remap all references to point to the canonical variables, if one exists
         VNDeleter deleter;
-        m_modp->foreach<AstVarRef>([&](AstVarRef* refp) {
+        m_modp->foreach ([&](AstVarRef* refp) {
             // Any variable that is written outside the DFG will have itself as the canonical
             // var, so need not be replaced, furthermore, if a variable is traced, we don't
             // want to update the write ref we just created above, so we only replace read only

--- a/src/V3DfgOptimizer.cpp
+++ b/src/V3DfgOptimizer.cpp
@@ -249,7 +249,7 @@ void V3DfgOptimizer::optimize(AstNetlist* netlistp, const string& label) {
     const VNUser2InUse user2InUse;
 
     // Mark cross-referenced variables
-    netlistp->foreach<AstVarXRef>([](const AstVarXRef* xrefp) { xrefp->varp()->user2(true); });
+    netlistp->foreach ([](const AstVarXRef* xrefp) { xrefp->varp()->user2(true); });
 
     V3DfgOptimizationContext ctx{label};
 

--- a/src/V3EmitCSyms.cpp
+++ b/src/V3EmitCSyms.cpp
@@ -786,15 +786,14 @@ void EmitCSyms::emitSymImp() {
     if (v3Global.opt.profPgo()) {
         puts("// Configure profiling for PGO\n");
         if (v3Global.opt.mtasks()) {
-            v3Global.rootp()->topModulep()->foreach<AstExecGraph>(
-                [&](const AstExecGraph* execGraphp) {
-                    for (const V3GraphVertex* vxp = execGraphp->depGraphp()->verticesBeginp(); vxp;
-                         vxp = vxp->verticesNextp()) {
-                        const ExecMTask* const mtp = static_cast<const ExecMTask*>(vxp);
-                        puts("_vm_pgoProfiler.addCounter(" + cvtToStr(mtp->profilerId()) + ", \""
-                             + mtp->hashName() + "\");\n");
-                    }
-                });
+            v3Global.rootp()->topModulep()->foreach ([&](const AstExecGraph* execGraphp) {
+                for (const V3GraphVertex* vxp = execGraphp->depGraphp()->verticesBeginp(); vxp;
+                     vxp = vxp->verticesNextp()) {
+                    const ExecMTask* const mtp = static_cast<const ExecMTask*>(vxp);
+                    puts("_vm_pgoProfiler.addCounter(" + cvtToStr(mtp->profilerId()) + ", \""
+                         + mtp->hashName() + "\");\n");
+                }
+            });
         }
     }
 

--- a/src/V3Force.cpp
+++ b/src/V3Force.cpp
@@ -153,7 +153,7 @@ class ForceConvertVisitor final : public VNVisitor {
     // referenced AstVarScope with the given function.
     void transformWritenVarScopes(AstNode* nodep, std::function<AstVarScope*(AstVarScope*)> f) {
         UASSERT_OBJ(nodep->backp(), nodep, "Must have backp, otherwise will be lost if replaced");
-        nodep->foreach<AstNodeVarRef>([&f](AstNodeVarRef* refp) {
+        nodep->foreach ([&f](AstNodeVarRef* refp) {
             if (refp->access() != VAccess::WRITE) return;
             // TODO: this is not strictly speaking safe for some complicated lvalues, eg.:
             //       'force foo[a(cnt)] = 1;', where 'cnt' is an out parameter, but it will
@@ -230,7 +230,7 @@ class ForceConvertVisitor final : public VNVisitor {
         AstAssign* const resetRdp
             = new AstAssign{fl_nowarn, lhsp->cloneTree(false), lhsp->unlinkFrBack()};
         // Replace write refs on the LHS
-        resetRdp->lhsp()->foreach<AstNodeVarRef>([this](AstNodeVarRef* refp) {
+        resetRdp->lhsp()->foreach ([this](AstNodeVarRef* refp) {
             if (refp->access() != VAccess::WRITE) return;
             AstVarScope* const vscp = refp->varScopep();
             AstVarScope* const newVscp
@@ -243,7 +243,7 @@ class ForceConvertVisitor final : public VNVisitor {
             VL_DO_DANGLING(refp->deleteTree(), refp);
         });
         // Replace write refs on RHS
-        resetRdp->rhsp()->foreach<AstNodeVarRef>([this](AstNodeVarRef* refp) {
+        resetRdp->rhsp()->foreach ([this](AstNodeVarRef* refp) {
             if (refp->access() != VAccess::WRITE) return;
             AstVarScope* const vscp = refp->varScopep();
             AstVarScope* const newVscp
@@ -273,7 +273,7 @@ class ForceConvertVisitor final : public VNVisitor {
         iterateAndNextNull(nodep->modulesp());
 
         // Replace references to forced signals
-        nodep->modulesp()->foreachAndNext<AstVarRef>([this](AstVarRef* nodep) {
+        nodep->modulesp()->foreachAndNext([this](AstVarRef* nodep) {
             if (ForceComponentsVarScope* const fcp
                 = m_forceComponentsVarScope.tryGet(nodep->varScopep())) {
                 switch (nodep->access()) {

--- a/src/V3FunctionTraits.h
+++ b/src/V3FunctionTraits.h
@@ -1,0 +1,48 @@
+// -*- mode: C++; c-file-style: "cc-mode" -*-
+//*************************************************************************
+// DESCRIPTION: Verilator: Ast node structure
+//
+// Code available from: https://verilator.org
+//
+//*************************************************************************
+//
+// Copyright 2003-2022 by Wilson Snyder. This program is free software; you
+// can redistribute it and/or modify it under the terms of either the GNU
+// Lesser General Public License Version 3 or the Perl Artistic License
+// Version 2.0.
+// SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+//
+//*************************************************************************
+
+#ifndef VERILATOR_V3FUNCTIONTRAIT_H_
+#define VERILATOR_V3FUNCTIONTRAIT_H_
+
+#include <tuple>
+#include <type_traits>
+
+namespace vltraits {
+
+template <typename T>
+struct function_traits
+    : public function_traits<decltype(&std::remove_reference_t<T>::operator())> {};
+// For generic types, directly use the result of the signature of its 'operator()'
+
+template <typename ClassType, typename ReturnType, typename... Args>
+struct function_traits<ReturnType (ClassType::*)(Args...) const>
+// we specialize for pointers to member function
+{
+    enum { arity = sizeof...(Args) };
+    // arity is the number of arguments.
+
+    typedef ReturnType result_type;
+
+    template <std::size_t i>
+    struct arg {
+        typedef typename std::tuple_element<i, std::tuple<Args...>>::type type;
+        // the i-th argument is equivalent to the i-th tuple element of a tuple
+        // composed of those arguments.
+    };
+};
+};  // namespace vltraits
+
+#endif  // Guard

--- a/src/V3Gate.cpp
+++ b/src/V3Gate.cpp
@@ -1022,13 +1022,13 @@ static void eliminate(AstNode* logicp,
         nodep->replaceWith(newp);
         VL_DO_DANGLING(nodep->deleteTree(), nodep);
         // Recursively substitute the new tree
-        newp->foreach<AstNodeVarRef>(visit);
+        newp->foreach (visit);
 
         // Remove from recursion filter
         replaced.erase(vscp);
     };
 
-    logicp->foreach<AstNodeVarRef>(visit);
+    logicp->foreach (visit);
 }
 
 // ######################################################################

--- a/src/V3Inline.cpp
+++ b/src/V3Inline.cpp
@@ -513,7 +513,7 @@ private:
             newmodp = nodep->modp();
         }
         // Find cell cross-references
-        nodep->modp()->foreach<AstCell>([](AstCell* cellp) {
+        nodep->modp()->foreach ([](AstCell* cellp) {
             // clonep is nullptr when inlining the last instance, if so the use original node
             cellp->user4p(cellp->clonep() ? cellp->clonep() : cellp);
         });

--- a/src/V3MergeCond.cpp
+++ b/src/V3MergeCond.cpp
@@ -744,7 +744,7 @@ private:
         if (!m_mgFirstp) {
             UASSERT_OBJ(condp, nodep, "Cannot start new list without condition");
             // Mark variable references in the condition
-            condp->foreach<AstVarRef>([](const AstVarRef* nodep) { nodep->varp()->user1(1); });
+            condp->foreach ([](const AstVarRef* nodep) { nodep->varp()->user1(1); });
             // Now check again if mergeable. We need this to pick up assignments to conditions,
             // e.g.: 'c = c ? a : b' at the beginning of the list, which is in fact not mergeable
             // because it updates the condition. We simply bail on these.

--- a/src/V3Order.cpp
+++ b/src/V3Order.cpp
@@ -230,7 +230,7 @@ class OrderBuildVisitor final : public VNVisitor {
             m_hybridp = nodep->sensesp();
             // Mark AstVarScopes that are explicit sensitivities
             AstNode::user3ClearTree();
-            senTreep->foreach<AstVarRef>([](const AstVarRef* refp) {  //
+            senTreep->foreach ([](const AstVarRef* refp) {  //
                 refp->varScopep()->user3(true);
             });
             m_readTriggersCombLogic = [](const AstVarScope* vscp) { return !vscp->user3(); };

--- a/src/V3Partition.cpp
+++ b/src/V3Partition.cpp
@@ -3215,7 +3215,7 @@ static void implementExecGraph(AstExecGraph* const execGraphp) {
 
 void V3Partition::finalize(AstNetlist* netlistp) {
     // Called by Verilator top stage
-    netlistp->topModulep()->foreach<AstExecGraph>([&](AstExecGraph* execGraphp) {
+    netlistp->topModulep()->foreach ([&](AstExecGraph* execGraphp) {
         // Back in V3Order, we partitioned mtasks using provisional cost
         // estimates. However, V3Order precedes some optimizations (notably
         // V3LifePost) that can change the cost of logic within each mtask.

--- a/src/V3Premit.cpp
+++ b/src/V3Premit.cpp
@@ -186,10 +186,10 @@ private:
             bool noopt = false;
             {
                 const VNUser3InUse user3InUse;
-                nodep->lhsp()->foreach<AstVarRef>([](const AstVarRef* refp) {
+                nodep->lhsp()->foreach ([](const AstVarRef* refp) {
                     if (refp->access().isWriteOrRW()) refp->varp()->user3(true);
                 });
-                nodep->rhsp()->foreach<AstVarRef>([&noopt](const AstVarRef* refp) {
+                nodep->rhsp()->foreach ([&noopt](const AstVarRef* refp) {
                     if (refp->access().isReadOnly() && refp->varp()->user3()) noopt = true;
                 });
             }

--- a/src/V3Sched.cpp
+++ b/src/V3Sched.cpp
@@ -161,10 +161,10 @@ void splitCheck(AstCFunc* ofuncp) {
 LogicClasses gatherLogicClasses(AstNetlist* netlistp) {
     LogicClasses result;
 
-    netlistp->foreach<AstScope>([&](AstScope* scopep) {
+    netlistp->foreach ([&](AstScope* scopep) {
         std::vector<AstActive*> empty;
 
-        scopep->foreach<AstActive>([&](AstActive* activep) {
+        scopep->foreach ([&](AstActive* activep) {
             AstSenTree* const senTreep = activep->sensesp();
             if (!activep->stmtsp()) {
                 // Some AstActives might be empty due to previous optimizations
@@ -671,7 +671,7 @@ AstNode* createInputCombLoop(AstNetlist* netlistp, SenExprBuilder& senExprBuilde
     // so we can make them sc_sensitive
     if (v3Global.opt.systemC()) {
         logic.foreachLogic([](AstNode* logicp) {
-            logicp->foreach<AstVarRef>([](AstVarRef* refp) {
+            logicp->foreach ([](AstVarRef* refp) {
                 if (refp->access().isWriteOnly()) return;
                 AstVarScope* const vscp = refp->varScopep();
                 if (vscp->scopep()->isTop() && vscp->varp()->isNonOutput()) {
@@ -769,13 +769,13 @@ void createEval(AstNetlist* netlistp,  //
     AstCFunc* const nbaDumpp = actTrig.m_dumpp->cloneTree(false);
     actTrig.m_dumpp->addNextHere(nbaDumpp);
     nbaDumpp->name("_dump_triggers__nba");
-    nbaDumpp->foreach<AstVarRef>([&](AstVarRef* refp) {
+    nbaDumpp->foreach ([&](AstVarRef* refp) {
         UASSERT_OBJ(refp->access().isReadOnly(), refp, "Should only read state");
         if (refp->varScopep() == actTrig.m_vscp) {
             refp->replaceWith(new AstVarRef{refp->fileline(), nbaTrigsp, VAccess::READ});
         }
     });
-    nbaDumpp->foreach<AstText>([&](AstText* textp) {  //
+    nbaDumpp->foreach ([&](AstText* textp) {  //
         textp->text(VString::replaceWord(textp->text(), "act", "nba"));
     });
 
@@ -970,7 +970,7 @@ void schedule(AstNetlist* netlistp) {
               // Replace references in each mapped value with a reference to the given vscp
               for (auto& pair : newMap) {
                   pair.second = pair.second->cloneTree(false);
-                  pair.second->foreach<AstVarRef>([&](AstVarRef* refp) {
+                  pair.second->foreach ([&](AstVarRef* refp) {
                       UASSERT_OBJ(refp->varScopep() == actTrigVscp, refp, "Unexpected reference");
                       UASSERT_OBJ(refp->access() == VAccess::READ, refp, "Should be read ref");
                       refp->replaceWith(new AstVarRef{refp->fileline(), vscp, VAccess::READ});

--- a/src/V3SchedAcyclic.cpp
+++ b/src/V3SchedAcyclic.cpp
@@ -140,7 +140,7 @@ std::unique_ptr<Graph> buildGraph(const LogicByScope& lbs) {
             const VNUser2InUse user2InUse;
             const VNUser3InUse user3InUse;
 
-            nodep->foreach<AstVarRef>([&](AstVarRef* refp) {
+            nodep->foreach ([&](AstVarRef* refp) {
                 AstVarScope* const vscp = refp->varScopep();
                 VarVertex* const vvtxp = getVarVertex(vscp);
                 // We want to cut the narrowest signals

--- a/src/V3SchedPartition.cpp
+++ b/src/V3SchedPartition.cpp
@@ -164,7 +164,7 @@ class SchedGraphBuilder final : public VNVisitor {
                 SchedSenVertex* const vtxp = new SchedSenVertex{m_graphp, senItemp};
 
                 // Connect up the variable references
-                senItemp->sensp()->foreach<AstVarRef>([&](AstVarRef* refp) {
+                senItemp->sensp()->foreach ([&](AstVarRef* refp) {
                     new V3GraphEdge{m_graphp, getVarVertex(refp->varScopep()), vtxp, 1};
                 });
 
@@ -186,7 +186,7 @@ class SchedGraphBuilder final : public VNVisitor {
 
         // Clocked or hybrid logic has explicit sensitivity, so add edge from sensitivity vertex
         if (!m_senTreep->hasCombo()) {
-            m_senTreep->foreach<AstSenItem>([=](AstSenItem* senItemp) {
+            m_senTreep->foreach ([=](AstSenItem* senItemp) {
                 if (senItemp->isIllegal()) return;
                 UASSERT_OBJ(senItemp->isClocked() || senItemp->isHybrid(), nodep,
                             "Non-clocked SenItem under clocked SenTree");
@@ -196,7 +196,7 @@ class SchedGraphBuilder final : public VNVisitor {
         }
 
         // Add edges based on references
-        nodep->foreach<AstVarRef>([=](const AstVarRef* vrefp) {
+        nodep->foreach ([=](const AstVarRef* vrefp) {
             AstVarScope* const vscp = vrefp->varScopep();
             if (vrefp->access().isReadOrRW() && m_readTriggersThisLogic(vscp)) {
                 new V3GraphEdge{m_graphp, getVarVertex(vscp), logicVtxp, 10};
@@ -208,7 +208,7 @@ class SchedGraphBuilder final : public VNVisitor {
 
         // If the logic calls a 'context' DPI import, it might fire the DPI Export trigger
         if (m_dpiExportTriggerp) {
-            nodep->foreach<AstCCall>([=](const AstCCall* callp) {
+            nodep->foreach ([=](const AstCCall* callp) {
                 if (!callp->funcp()->dpiImportWrapper()) return;
                 if (!callp->funcp()->dpiContext()) return;
                 new V3GraphEdge{m_graphp, logicVtxp, getVarVertex(m_dpiExportTriggerp), 10};
@@ -226,7 +226,7 @@ class SchedGraphBuilder final : public VNVisitor {
         // Mark explicit sensitivities as not triggering these blocks
         if (senTreep->hasHybrid()) {
             AstNode::user2ClearTree();
-            senTreep->foreach<AstVarRef>([](const AstVarRef* refp) {  //
+            senTreep->foreach ([](const AstVarRef* refp) {  //
                 refp->varScopep()->user2(true);
             });
         }
@@ -364,7 +364,7 @@ LogicRegions partition(LogicByScope& clockedLogic, LogicByScope& combinationalLo
         const VNUser2InUse user2InUse;  // AstVarScope::user2() -> bool: writen in Active region
 
         const auto markVars = [](AstNode* nodep) {
-            nodep->foreach<AstNodeVarRef>([](const AstNodeVarRef* vrefp) {
+            nodep->foreach ([](const AstNodeVarRef* vrefp) {
                 AstVarScope* const vscp = vrefp->varScopep();
                 if (vrefp->access().isReadOrRW()) vscp->user1(true);
                 if (vrefp->access().isWriteOrRW()) vscp->user2(true);
@@ -386,7 +386,7 @@ LogicRegions partition(LogicByScope& clockedLogic, LogicByScope& combinationalLo
                 nextp = nodep->nextp();
                 if (AstAssignPre* const logicp = VN_CAST(nodep, AssignPre)) {
                     bool toActiveRegion = false;
-                    logicp->foreach<AstNodeVarRef>([&](const AstNodeVarRef* vrefp) {
+                    logicp->foreach ([&](const AstNodeVarRef* vrefp) {
                         AstVarScope* const vscp = vrefp->varScopep();
                         if (vrefp->access().isReadOnly()) {
                             // Variable only read in Pre, and is written in active region

--- a/src/V3SchedReplicate.cpp
+++ b/src/V3SchedReplicate.cpp
@@ -176,7 +176,7 @@ std::unique_ptr<Graph> buildGraph(const LogicRegions& logicRegions) {
             // Hybrid logic is triggered by all reads, except for reads of the explicit
             // sensitivities
             readTriggersThisLogic = [](AstVarScope* vscp) { return !vscp->user4(); };
-            senTreep->foreach<AstVarRef>([](const AstVarRef* refp) {  //
+            senTreep->foreach ([](const AstVarRef* refp) {  //
                 refp->varScopep()->user4(true);
             });
         }
@@ -187,7 +187,7 @@ std::unique_ptr<Graph> buildGraph(const LogicRegions& logicRegions) {
             const VNUser2InUse user2InUse;
             const VNUser3InUse user3InUse;
 
-            nodep->foreach<AstVarRef>([&](AstVarRef* refp) {
+            nodep->foreach ([&](AstVarRef* refp) {
                 AstVarScope* const vscp = refp->varScopep();
                 VarVertex* const vvtxp = getVarVertex(vscp);
 

--- a/src/V3SchedTiming.cpp
+++ b/src/V3SchedTiming.cpp
@@ -256,7 +256,7 @@ void transformForks(AstNetlist* const netlistp) {
         // flow analysis framework which we don't have at the moment
         void remapLocals(AstCFunc* const funcp, AstCCall* const callp) {
             const VNUser2InUse user2InUse;  // AstVarScope -> AstVarScope: var to remap to
-            funcp->foreach<AstNodeVarRef>([&](AstNodeVarRef* refp) {
+            funcp->foreach ([&](AstNodeVarRef* refp) {
                 AstVar* const varp = refp->varp();
                 AstBasicDType* const dtypep = varp->dtypep()->basicp();
                 // If it a fork sync or an intra-assignment variable, pass it by value

--- a/src/V3SenExprBuilder.h
+++ b/src/V3SenExprBuilder.h
@@ -56,7 +56,7 @@ class SenExprBuilder final {
     }
 
     static bool isSimpleExpr(const AstNode* const exprp) {
-        return exprp->forall<AstNode>([](const AstNode* const nodep) {
+        return exprp->forall([](const AstNode* const nodep) {
             return VN_IS(nodep, Const) || VN_IS(nodep, NodeVarRef) || VN_IS(nodep, Sel)
                    || VN_IS(nodep, NodeSel) || VN_IS(nodep, MemberSel)
                    || VN_IS(nodep, CMethodHard);

--- a/src/V3StdFuture.h
+++ b/src/V3StdFuture.h
@@ -17,6 +17,8 @@
 #ifndef VERILATOR_V3STDFUTURE_H_
 #define VERILATOR_V3STDFUTURE_H_
 
+#include <functional>
+
 namespace vlstd {
 
 // constexpr std::max with arguments passed by value (required by constexpr before C++14)
@@ -25,6 +27,17 @@ constexpr T max(T a, T b) {
     return a > b ? a : b;
 }
 
+// C++17 is_invocable
+template <typename F, typename... Args>
+struct is_invocable
+    : std::is_constructible<std::function<void(Args...)>,
+                            std::reference_wrapper<typename std::remove_reference<F>::type>> {};
+
+// C++17 is_invocable_r
+template <typename R, typename F, typename... Args>
+struct is_invocable_r
+    : std::is_constructible<std::function<R(Args...)>,
+                            std::reference_wrapper<typename std::remove_reference<F>::type>> {};
 };  // namespace vlstd
 
 #endif  // Guard

--- a/src/V3Task.cpp
+++ b/src/V3Task.cpp
@@ -408,7 +408,7 @@ private:
 
     // Replace varrefs with new var pointer
     void relink(AstNode* nodep) {
-        nodep->foreachAndNext<AstVarRef>([](AstVarRef* refp) {
+        nodep->foreachAndNext([](AstVarRef* refp) {
             if (refp->varp()->user2p()) {  // It's being converted to an alias.
                 AstVarScope* const newvscp = VN_AS(refp->varp()->user2p(), VarScope);
                 refp->varScopep(newvscp);
@@ -1276,7 +1276,7 @@ private:
 
             // Mark non-local variables written by the exported function
             bool writesNonLocals = false;
-            cfuncp->foreach<AstVarRef>([&writesNonLocals](AstVarRef* refp) {
+            cfuncp->foreach ([&writesNonLocals](AstVarRef* refp) {
                 if (refp->access().isReadOnly()) return;  // Ignore read reference
                 AstVar* const varp = refp->varScopep()->varp();
                 // We are ignoring function locals as they should not be referenced anywhere

--- a/src/V3Timing.cpp
+++ b/src/V3Timing.cpp
@@ -138,7 +138,7 @@ private:
     AstDelay* getLhsNetDelay(AstNodeAssign* nodep) const {
         bool foundWrite = false;
         AstDelay* delayp = nullptr;
-        nodep->lhsp()->foreach<AstNodeVarRef>([&](const AstNodeVarRef* const refp) {
+        nodep->lhsp()->foreach ([&](const AstNodeVarRef* const refp) {
             if (!refp->access().isWriteOrRW()) return;
             UASSERT_OBJ(!foundWrite, nodep, "Should only be one variable written to on the LHS");
             foundWrite = true;
@@ -190,7 +190,7 @@ private:
     AstSenItem* varRefpsToSenItemsp(AstNode* const nodep) const {
         AstNode* senItemsp = nullptr;
         const VNUser4InUse user4InUse;
-        nodep->foreach<AstNodeVarRef>([&](AstNodeVarRef* refp) {
+        nodep->foreach ([&](AstNodeVarRef* refp) {
             if (refp->access().isWriteOnly()) return;
             AstVarScope* const vscp = refp->varScopep();
             if (vscp->user4SetOnce()) return;
@@ -530,12 +530,12 @@ private:
         // we want as only the top level selects are LValues. As an example,
         // this transforms 'x[a[i]][b[j]] = y'
         // into 't1 = a[i]; t0 = b[j]; x[t1][t0] = y'.
-        nodep->lhsp()->foreach<AstSel>([&](AstSel* selp) {
+        nodep->lhsp()->foreach ([&](AstSel* selp) {
             if (VN_IS(selp->lsbp(), Const)) return;
             replaceWithIntermediate(selp->lsbp(), m_intraLsbNames.get(nodep));
             // widthp should be const
         });
-        nodep->lhsp()->foreach<AstNodeSel>([&](AstNodeSel* selp) {
+        nodep->lhsp()->foreach ([&](AstNodeSel* selp) {
             if (VN_IS(selp->bitp(), Const)) return;
             replaceWithIntermediate(selp->bitp(), m_intraIndexNames.get(nodep));
         });

--- a/src/V3Trace.cpp
+++ b/src/V3Trace.cpp
@@ -434,7 +434,7 @@ private:
         } else if (AstCFunc* const funcp = VN_CAST(insertp, CFunc)) {
             // If there are awaits, insert the setter after each await
             if (funcp->isCoroutine() && funcp->stmtsp()) {
-                funcp->stmtsp()->foreachAndNext<AstCAwait>([&](AstCAwait* awaitp) {
+                funcp->stmtsp()->foreachAndNext([&](AstCAwait* awaitp) {
                     if (awaitp->nextp()) awaitp->addNextHere(setterp->cloneTree(false));
                 });
             }


### PR DESCRIPTION
The basic idea comes from
``` cpp
nodep->foreach<AstVarRef>([&](AstVarRef* refp) {
    // Ignore
});
```
- We must assign type on function instantiation explicitly.
- In functor, we need to write type again.
- It is verbose.
I hope compiler help to reduce the type, so we can
``` cpp
nodep->foreach([&](AstVarRef* refp) {
    // Ignore
});
```
