### PR TITLE
Always emit user-facing timing functions

### DIFF
--- a/src/V3EmitCModel.cpp
+++ b/src/V3EmitCModel.cpp
@@ -439,22 +439,20 @@ class EmitCModel final : public EmitCFunc {
             puts("}\n");
         }
 
-        if (v3Global.usesTiming()) {
-            putSectionDelimiter("Events and timing");
-            if (auto* const delaySchedp = v3Global.rootp()->delaySchedulerp()) {
-                puts("bool " + topClassName() + "::eventsPending() { return !vlSymsp->TOP.");
-                puts(delaySchedp->nameProtect());
-                puts(".empty(); }\n\n");
-                puts("uint64_t " + topClassName() + "::nextTimeSlot() { return vlSymsp->TOP.");
-                puts(delaySchedp->nameProtect());
-                puts(".nextTimeSlot(); }\n");
-            } else {
-                puts("bool " + topClassName() + "::eventsPending() { return false; }\n\n");
-                puts("uint64_t " + topClassName() + "::nextTimeSlot() {\n");
-                puts("VL_FATAL_MT(__FILE__, __LINE__, \"\", \"%Error: No delays in the "
-                     "design\");\n");
-                puts("return 0;\n}\n");
-            }
+        putSectionDelimiter("Events and timing");
+        if (auto* const delaySchedp = v3Global.rootp()->delaySchedulerp()) {
+            puts("bool " + topClassName() + "::eventsPending() { return !vlSymsp->TOP.");
+            puts(delaySchedp->nameProtect());
+            puts(".empty(); }\n\n");
+            puts("uint64_t " + topClassName() + "::nextTimeSlot() { return vlSymsp->TOP.");
+            puts(delaySchedp->nameProtect());
+            puts(".nextTimeSlot(); }\n");
+        } else {
+            puts("bool " + topClassName() + "::eventsPending() { return false; }\n\n");
+            puts("uint64_t " + topClassName() + "::nextTimeSlot() {\n");
+            puts("VL_FATAL_MT(__FILE__, __LINE__, \"\", \"%Error: No delays in the "
+                 "design\");\n");
+            puts("return 0;\n}\n");
         }
 
         putSectionDelimiter("Utilities");


### PR DESCRIPTION
Before this change, a design verilated with `--timing` that does not actually use timing features would be emitted with `eventsPending` and `nextTimeSlot` declared in the top class. However, their definitions would be missing, leading to linker errors during design compilation. This patch makes Verilator always emit the definitions, which prevents linker errors. Trying to use `nextTimeSlot` without delays in the design will result in an error at runtime.

Signed-off-by: Krzysztof Bieganski <kbieganski@antmicro.com>