### PR TITLE
Make reference to increment temporary an rvalue

### DIFF
--- a/src/V3LinkInc.cpp
+++ b/src/V3LinkInc.cpp
@@ -189,6 +189,7 @@ private:
     void visit(AstLogEq* nodep) override { unsupported_visit(nodep); }
     void visit(AstLogIf* nodep) override { unsupported_visit(nodep); }
     void visit(AstNodeCond* nodep) override { unsupported_visit(nodep); }
+    void visit(AstPropClocked* nodep) override { unsupported_visit(nodep); }
     void prepost_visit(AstNodeTriop* nodep) {
         // Check if we are underneath a statement
         if (!m_insStmtp) {
@@ -273,7 +274,7 @@ private:
         }
 
         // Replace the node with the temporary
-        nodep->replaceWith(new AstVarRef(varrefp->fileline(), varp, VAccess::WRITE));
+        nodep->replaceWith(new AstVarRef{varrefp->fileline(), varp, VAccess::READ});
         VL_DO_DANGLING(nodep->deleteTree(), nodep);
     }
     void visit(AstPreAdd* nodep) override { prepost_visit(nodep); }

--- a/test_regress/t/t_increment_bad.out
+++ b/test_regress/t/t_increment_bad.out
@@ -20,4 +20,7 @@
 %Error-UNSUPPORTED: t/t_increment_bad.v:23:24: Unsupported: Incrementation in this context.
    23 |       pos = array[0][0]++;
       |                        ^~
+%Error-UNSUPPORTED: t/t_increment_bad.v:26:37: Unsupported: Incrementation in this context.
+   26 |    assert property (@(posedge clk) a++ >= 0);
+      |                                     ^~
 %Error: Exiting due to

--- a/test_regress/t/t_increment_bad.v
+++ b/test_regress/t/t_increment_bad.v
@@ -22,4 +22,6 @@ module t (/*AUTOARG*/
 
       pos = array[0][0]++;
    end
+
+   assert property (@(posedge clk) a++ >= 0);
 endmodule

--- a/test_regress/t/t_sampled_expr_unsup.out
+++ b/test_regress/t/t_sampled_expr_unsup.out
@@ -1,6 +1,6 @@
-%Error-UNSUPPORTED: t/t_sampled_expr_unsup.v:34:36: Unsupported: Write to variable in sampled expression
-                                                  : ... In instance t.t1
-   34 |    assert property (@(posedge clk) a++ >= 0);
-      |                                    ^
+%Error-UNSUPPORTED: t/t_sampled_expr_unsup.v:20:38: Unsupported: Write to variable in sampled expression
+                                                  : ... In instance t
+   20 |    assert property (@(posedge clk) f(a) >= 0);
+      |                                      ^
                     ... For error description see https://verilator.org/warn/UNSUPPORTED?v=latest
 %Error: Exiting due to

--- a/test_regress/t/t_sampled_expr_unsup.v
+++ b/test_regress/t/t_sampled_expr_unsup.v
@@ -10,26 +10,12 @@ module t (/*AUTOARG*/
    );
    input clk;
 
-   integer cyc;
+   int a = 0;
 
-   Test1 t1(clk);
+   function int f(output int a);
+       a = 1;
+       return a;
+   endfunction
 
-   always @(posedge clk) begin
-      cyc <= cyc + 1;
-
-      if (cyc >= 10) begin
-         $write("*-* All Finished *-*\n");
-         $finish;
-      end
-   end
-endmodule
-
-module Test1(
-   clk
-   );
-
-   input clk;
-   reg [3:0] a = 0;
-
-   assert property (@(posedge clk) a++ >= 0);
+   assert property (@(posedge clk) f(a) >= 0);
 endmodule


### PR DESCRIPTION
Incrementation operations are being replaced with write references to a temporary var, but these should be read references.

Signed-off-by: Krzysztof Bieganski <kbieganski@antmicro.com>
