### PR TITLE
Use C++ user defined literals for typed constants

### DIFF
--- a/include/verilated.h
+++ b/include/verilated.h
@@ -116,6 +116,10 @@ using WData = EData;        ///< Data representing >64 packed bits (used as poin
 //    N     = std::string;  // No typedef needed; Verilator uses string
 // clang-format on
 
+// Literal operators for creating constants of specific types
+VL_ATTR_ALWINLINE IData operator"" _I(unsigned long long value) { return value; }
+VL_ATTR_ALWINLINE QData operator"" _Q(unsigned long long value) { return value; }
+
 using WDataInP = const WData*;  ///< 'bit' of >64 packed bits as array input to a function
 using WDataOutP = WData*;  ///< 'bit' of >64 packed bits as array output from a function
 

--- a/include/verilated_types.h
+++ b/include/verilated_types.h
@@ -1145,6 +1145,12 @@ public:
         m_objp = vlstd::exchange(moved.m_objp, nullptr);
         return *this;
     }
+    // Assign with nullptr
+    VlClassRef& operator=(std::nullptr_t) {
+        refCountDec();
+        m_objp = nullptr;
+        return *this;
+    }
     // Dynamic caster
     template <typename T_OtherClass>
     VlClassRef<T_OtherClass> dynamicCast() const {

--- a/src/V3Cast.cpp
+++ b/src/V3Cast.cpp
@@ -169,12 +169,7 @@ private:
         }
         nodep->user1(1);
     }
-    void visit(AstConst* nodep) override {
-        // Constants are of unknown size if smaller than 33 bits, because
-        // we're too lazy to wrap every constant in the universe in
-        // ((IData)#).
-        nodep->user1(nodep->isQuad() || nodep->isWide());
-    }
+    void visit(AstConst* nodep) override { nodep->user1(1); }
 
     // Null dereference protection
     void visit(AstNullCheck* nodep) override {

--- a/src/V3EmitCFunc.cpp
+++ b/src/V3EmitCFunc.cpp
@@ -559,24 +559,28 @@ void EmitCFunc::emitConstant(AstConst* nodep, AstVarRef* assigntop, const string
             // is a real number
             ofp()->printf("%.17e", nodep->num().toDouble());
         }
+    } else if (nodep->toUQuad() == 0ULL) {
+        if (AstNodeAssign* const assignp = VN_CAST(nodep->backp(), NodeAssign)) {
+            if (VN_IS(assignp->lhsp()->dtypep(), ClassRefDType)) {
+                puts("nullptr");
+                return;
+            }
+        }
+        puts(nodep->isQuad() ? "0_Q" : "0_I");
     } else if (nodep->isQuad()) {
         const uint64_t num = nodep->toUQuad();
         if (num < 10) {
-            ofp()->printf("%" PRIu64 "ULL", num);
+            ofp()->printf("%" PRIu64 "_Q", num);
         } else {
-            ofp()->printf("0x%" PRIx64 "ULL", num);
+            ofp()->printf("0x%" PRIx64 "_Q", num);
         }
     } else {
         const uint32_t num = nodep->toUInt();
-        // Only 32 bits - llx + long long here just to appease CPP format warning
         if (num < 10) {
-            puts(cvtToStr(num));
+            ofp()->printf("%" PRIu32 "_I", num);
         } else {
-            ofp()->printf("0x%" PRIx64, static_cast<uint64_t>(num));
+            ofp()->printf("0x%" PRIx32 "_I", num);
         }
-        // If signed, we'll do our own functions
-        // But must be here, or <= comparisons etc may end up signed
-        puts("U");
     }
 }
 

--- a/test_regress/t/t_xml_debugcheck.out
+++ b/test_regress/t/t_xml_debugcheck.out
@@ -687,9 +687,7 @@
         </assignpre>
         <assigndly loc="d,61,11,61,13" dtype_id="4">
           <add loc="d,61,18,61,19" dtype_id="4">
-            <ccast loc="d,61,20,61,21" dtype_id="13">
-              <const loc="d,61,20,61,21" name="32&apos;sh1" dtype_id="7"/>
-            </ccast>
+            <const loc="d,61,20,61,21" name="32&apos;sh1" dtype_id="7"/>
             <varref loc="d,61,14,61,17" name="t.cyc" dtype_id="4"/>
           </add>
           <varref loc="d,61,7,61,10" name="__Vdly__t.cyc" dtype_id="4"/>
@@ -1568,9 +1566,7 @@
                     </if>
                     <assign loc="d,10,8,10,9" dtype_id="5">
                       <add loc="d,10,8,10,9" dtype_id="5">
-                        <ccast loc="d,10,8,10,9" dtype_id="13">
-                          <const loc="d,10,8,10,9" name="32&apos;h1" dtype_id="13"/>
-                        </ccast>
+                        <const loc="d,10,8,10,9" name="32&apos;h1" dtype_id="13"/>
                         <varref loc="d,10,8,10,9" name="__VactIterCount" dtype_id="5"/>
                       </add>
                       <varref loc="d,10,8,10,9" name="__VactIterCount" dtype_id="5"/>
@@ -1615,9 +1611,7 @@
                 </if>
                 <assign loc="d,10,8,10,9" dtype_id="5">
                   <add loc="d,10,8,10,9" dtype_id="5">
-                    <ccast loc="d,10,8,10,9" dtype_id="13">
-                      <const loc="d,10,8,10,9" name="32&apos;h1" dtype_id="13"/>
-                    </ccast>
+                    <const loc="d,10,8,10,9" name="32&apos;h1" dtype_id="13"/>
                     <varref loc="d,10,8,10,9" name="__VnbaIterCount" dtype_id="5"/>
                   </add>
                   <varref loc="d,10,8,10,9" name="__VnbaIterCount" dtype_id="5"/>


### PR DESCRIPTION
I am trying to make the generated code a bit more readable (and well defined maybe).

One thing that we have tones of is casts around integer literals:
`__Vdly__t__DOT__cyc = ((IData)(1U) + vlSelf->t__DOT__cyc);`

Assuming that `IData` is 32-bit unsigned, `(IData)(1U)` is almost always pointless, as the type of an integer literal with suffix `U` is at least `unsigned int` (or a longer unsigned type if necessary to fit the value). I think this means that the cast is only really necessary on platforms where `unsigned int` is less than 32-bits wide, which is esoteric in itself, but more interestingly, we can use the C++ 11 user defined literal syntax to emit this instead:

`__Vdly__t__DOT__cyc = (1_I + vlSelf->t__DOT__cyc);`

Similarly we can emit `1_Q` instead of `(QData)(1ULL)`, which I would argue is easier on the reader, especially if highly nested expressions where casting can add a lot of noise.

This is also somewhat safer I think, as constants now have a clear C++ type, this uncovered for example an issue of using `x = 0U` to set a `VlClassRef` to nullptr, which I had to fix up in emit at the moment (I don't think we know if an AstConst is supposed to represent a nullptr rather than an integer 0).

This also has the benefit of having to add fewer AstCCast nodes in V3Cast, and I have not noticed any detrimental effect on compilation speed of the output.

Do you think this is a good thing and we should do it?

---

Instead of casting constants, emit them with _I or _Q suffixes, and use the user defined literal operators to create constants of type IData and QData respectively. The aim of this is to improve readability of the generated code.

