### PR TITLE
DOC: example_binary does not uses SystemC code

### DIFF
--- a/docs/guide/example_binary.rst
+++ b/docs/guide/example_binary.rst
@@ -6,7 +6,7 @@
 Example Create-Binary Execution
 ===============================
 
-We'll compile this SystemC example into a Verilated simulation binary.  For
+We'll compile this SystemVerilog example into a Verilated simulation binary.  For
 an example that discusses the next level of detail see :ref:`Example C++
 Execution`.
 


### PR DESCRIPTION
I also tried to fix the `-j 0` explanation where the zero is not fixed width, but was unsure how.

The point is, I tested the timing support in Verilator 5 and I am happy.