### PR TITLE
Add named properties handling

### DIFF
--- a/src/V3Ast.h
+++ b/src/V3Ast.h
@@ -453,6 +453,8 @@ public:
         TIME,
         // Closer to a class type, but limited usage
         STRING,
+        // Property / Sequence argument type
+        UNTYPED,
         // Internal types for mid-steps
         SCOPEPTR,
         CHARPTR,
@@ -485,6 +487,7 @@ public:
                                             "shortint",
                                             "time",
                                             "string",
+                                            "untyped",
                                             "VerilatedScope*",
                                             "char*",
                                             "VlMTaskState",
@@ -501,11 +504,12 @@ public:
     }
     const char* dpiType() const {
         static const char* const names[]
-            = {"%E-unk",        "svBit",         "char",         "void*",           "char",
-               "int",           "%E-integer",    "svLogic",      "long long",       "double",
-               "short",         "%E-time",       "const char*",  "dpiScope",        "const char*",
-               "%E-mtaskstate", "%E-triggervec", "%E-dly-sched", "%E-trig-sched",   "%E-dyn-sched",
-               "%E-fork",       "IData",         "QData",        "%E-logic-implct", " MAX"};
+            = {"%E-unk",       "svBit",         "char",          "void*",        "char",
+               "int",          "%E-integer",    "svLogic",       "long long",    "double",
+               "short",        "%E-time",       "const char*",   "%E-untyped",   "dpiScope",
+               "const char*",  "%E-mtaskstate", "%E-triggervec", "%E-dly-sched", "%E-trig-sched",
+               "%E-dyn-sched", "%E-fork",       "IData",         "QData",        "%E-logic-implct",
+               " MAX"};
         return names[m_e];
     }
     static void selfTest() {
@@ -582,7 +586,7 @@ public:
         return (m_e == EVENT || m_e == STRING || m_e == SCOPEPTR || m_e == CHARPTR
                 || m_e == MTASKSTATE || m_e == TRIGGERVEC || m_e == DELAY_SCHEDULER
                 || m_e == TRIGGER_SCHEDULER || m_e == DYNAMIC_TRIGGER_SCHEDULER || m_e == FORK_SYNC
-                || m_e == DOUBLE);
+                || m_e == DOUBLE || m_e == UNTYPED);
     }
     bool isDouble() const VL_MT_SAFE { return m_e == DOUBLE; }
     bool isEvent() const { return m_e == EVENT; }

--- a/src/V3AstNodeDType.h
+++ b/src/V3AstNodeDType.h
@@ -465,6 +465,7 @@ public:
     int right() const { return littleEndian() ? hi() : lo(); }
     inline bool littleEndian() const;
     bool implicit() const { return keyword() == VBasicDTypeKwd::LOGIC_IMPLICIT; }
+    bool untyped() const { return keyword() == VBasicDTypeKwd::UNTYPED; }
     VNumRange declRange() const { return isRanged() ? VNumRange{left(), right()} : VNumRange{}; }
     void cvtRangeConst();  // Convert to smaller representation
     bool isCompound() const override { return isString(); }

--- a/src/V3AstNodeOther.h
+++ b/src/V3AstNodeOther.h
@@ -1593,7 +1593,7 @@ public:
         return pragType() == static_cast<const AstPragma*>(samep)->pragType();
     }
 };
-class AstPropClocked final : public AstNode {
+class AstPropSpec final : public AstNode {
     // A clocked property
     // Parents:  ASSERT|COVER (property)
     // Children: SENITEM, Properties
@@ -1601,13 +1601,13 @@ class AstPropClocked final : public AstNode {
     // @astgen op2 := disablep : Optional[AstNode]
     // @astgen op3 := propp : AstNode
 public:
-    AstPropClocked(FileLine* fl, AstSenItem* sensesp, AstNode* disablep, AstNode* propp)
-        : ASTGEN_SUPER_PropClocked(fl) {
+    AstPropSpec(FileLine* fl, AstSenItem* sensesp, AstNode* disablep, AstNode* propp)
+        : ASTGEN_SUPER_PropSpec(fl) {
         this->sensesp(sensesp);
         this->disablep(disablep);
         this->propp(propp);
     }
-    ASTGEN_MEMBERS_AstPropClocked;
+    ASTGEN_MEMBERS_AstPropSpec;
     bool hasDType() const override {
         return true;
     }  // Used under Cover, which expects a bool child
@@ -2431,6 +2431,14 @@ public:
         this->fvarp(fvarp);
     }
     ASTGEN_MEMBERS_AstFunc;
+    bool hasDType() const override { return true; }
+};
+class AstProperty final : public AstNodeFTask {
+    // A property inside a module
+public:
+    AstProperty(FileLine* fl, const string& name, AstNode* stmtp)
+        : ASTGEN_SUPER_Property(fl, name, stmtp) {}
+    ASTGEN_MEMBERS_AstProperty;
     bool hasDType() const override { return true; }
 };
 class AstTask final : public AstNodeFTask {

--- a/src/V3LinkInc.cpp
+++ b/src/V3LinkInc.cpp
@@ -195,7 +195,7 @@ private:
     void visit(AstLogEq* nodep) override { unsupported_visit(nodep); }
     void visit(AstLogIf* nodep) override { unsupported_visit(nodep); }
     void visit(AstNodeCond* nodep) override { unsupported_visit(nodep); }
-    void visit(AstPropClocked* nodep) override { unsupported_visit(nodep); }
+    void visit(AstPropSpec* nodep) override { unsupported_visit(nodep); }
     void prepost_visit(AstNodeTriop* nodep) {
         // Check if we are underneath a statement
         if (!m_insStmtp) {

--- a/src/V3ParseGrammar.cpp
+++ b/src/V3ParseGrammar.cpp
@@ -169,7 +169,14 @@ AstVar* V3ParseGrammar::createVariable(FileLine* fileline, const string& name,
         dtypep = new AstBasicDType(fileline, VBasicDTypeKwd::DOUBLE);
     }
     if (!dtypep) {  // Created implicitly
-        dtypep = new AstBasicDType(fileline, LOGIC_IMPLICIT);
+        if (m_insideProperty) {
+            if (m_typedPropertyPort) {
+                fileline->v3warn(E_UNSUPPORTED, "Untyped property port following a typed port");
+            }
+            dtypep = new AstBasicDType{fileline, VBasicDTypeKwd::UNTYPED};
+        } else {
+            dtypep = new AstBasicDType{fileline, LOGIC_IMPLICIT};
+        }
     } else {  // May make new variables with same type, so clone
         dtypep = dtypep->cloneTree(false);
     }

--- a/src/verilog.l
+++ b/src/verilog.l
@@ -598,7 +598,7 @@ vnum    {vnum1}|{vnum2}|{vnum3}|{vnum4}|{vnum5}
   "unique0"             { FL; return yUNIQUE0; }
   "until"               { ERROR_RSVD_WORD("SystemVerilog 2009"); }
   "until_with"          { ERROR_RSVD_WORD("SystemVerilog 2009"); }
-  "untyped"             { ERROR_RSVD_WORD("SystemVerilog 2009"); }
+  "untyped"             { FL; return yUNTYPED; }
   "weak"                { ERROR_RSVD_WORD("SystemVerilog 2009"); }
 }
 

--- a/test_regress/t/t_assert_clock_event_unsup.out
+++ b/test_regress/t/t_assert_clock_event_unsup.out
@@ -1,0 +1,5 @@
+%Error-UNSUPPORTED: t/t_assert_clock_event_unsup.v:26:7: Unsupported: Clock event before property call and in its body
+   26 |       @(negedge clk)
+      |       ^
+                    ... For error description see https://verilator.org/warn/UNSUPPORTED?v=latest
+%Error: Exiting due to

--- a/test_regress/t/t_assert_clock_event_unsup.pl
+++ b/test_regress/t/t_assert_clock_event_unsup.pl
@@ -1,0 +1,20 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2022 by Antmicro Ltd. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(vlt => 1);
+
+compile(
+    expect_filename=>$Self->{golden_filename},
+    verilator_flags2=> ['--assert'],
+    fails => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_assert_clock_event_unsup.v
+++ b/test_regress/t/t_assert_clock_event_unsup.v
@@ -1,0 +1,37 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2022 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+module t (/*AUTOARG*/
+      clk
+   );
+
+   input clk;
+   int cyc = 0;
+   logic val = 0;
+
+   always @(posedge clk) begin
+      cyc <= cyc + 1;
+      val = ~val;
+   end
+
+   property check(int cyc_mod_2, logic expected);
+      @(posedge clk)
+        cyc % 2 == cyc_mod_2 |=> val == expected;
+   endproperty
+
+   property check_if_1(int cyc_mod_2);
+      @(negedge clk)
+        check(cyc_mod_2, 1);
+   endproperty
+
+   assert property(check_if_1(1))
+     else begin
+        // Assertion should fail
+        $write("*-* All Finished *-*\n");
+        $finish;
+     end
+
+endmodule

--- a/test_regress/t/t_assert_disable_bad.out
+++ b/test_regress/t/t_assert_disable_bad.out
@@ -1,0 +1,5 @@
+%Error: t/t_assert_disable_bad.v:27:38: disable iff expression before property call and in its body is not legal
+                                      : ... In instance t
+   27 |    assert property (disable iff (val == 0) check(1, 1));
+      |                                      ^~
+%Error: Exiting due to

--- a/test_regress/t/t_assert_disable_bad.pl
+++ b/test_regress/t/t_assert_disable_bad.pl
@@ -1,0 +1,20 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2022 by Antmicro Ltd. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(vlt => 1);
+
+compile(
+    expect_filename=>$Self->{golden_filename},
+    verilator_flags2=> ['--assert'],
+    fails => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_assert_disable_bad.v
+++ b/test_regress/t/t_assert_disable_bad.v
@@ -1,0 +1,28 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2022 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+module t (/*AUTOARG*/
+      clk
+   );
+
+   input clk;
+   int cyc = 0;
+   logic val = 0;
+
+   always @(posedge clk) begin
+      cyc <= cyc + 1;
+      val = ~val;
+   end
+
+   property check(int cyc_mod_2, logic expected);
+      @(posedge clk)
+        disable iff (cyc == 0) cyc % 2 == cyc_mod_2 |=> val == expected;
+   endproperty
+
+   // Test should fail due to duplicated disable iff statements
+   // (IEEE Std 1800-2012, section 16.12.1).
+   assert property (disable iff (val == 0) check(1, 1));
+endmodule

--- a/test_regress/t/t_assert_named_property.pl
+++ b/test_regress/t/t_assert_named_property.pl
@@ -1,0 +1,22 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2022 by Antmicro Ltd. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    verilator_flags2 => ['--assert'],
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_assert_named_property.v
+++ b/test_regress/t/t_assert_named_property.v
@@ -1,0 +1,66 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2022 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+module t (/*AUTOARG*/
+      clk
+   );
+
+   input clk;
+   int cyc = 0;
+   logic val = 0;
+
+   always @(posedge clk) begin
+      cyc <= cyc + 1;
+      val = ~val;
+   end
+
+   property check(int cyc_mod_2, logic expected);
+      @(posedge clk)
+        cyc % 2 == cyc_mod_2 |=> val == expected;
+   endproperty
+
+   property check_if_1(int cyc_mod_2);
+      check(cyc_mod_2, 1);
+   endproperty
+
+   property check_if_gt_5(int cyc);
+      @(posedge clk)
+        cyc > 5;
+   endproperty
+
+   property pass_assertion(int cyc);
+      disable iff (cyc <= 10)
+      cyc > 10;
+   endproperty
+
+   int expected_fails = 0;
+
+   assert property(check(0, 1))
+     else begin
+        // Assertion should pass
+        $display("Assert failed, but shouldn't");
+        $stop;
+     end
+   assert property(check(1, 1))
+     else begin
+        // Assertion should fail
+        expected_fails += 1;
+     end
+   assert property(check_if_1(1))
+     else begin
+        // Assertion should fail
+        expected_fails += 1;
+     end
+   assert property(disable iff (cyc < 5) check_if_gt_5(cyc + 1));
+   assert property(@(posedge clk) pass_assertion(cyc));
+
+   always @(posedge clk) begin
+      if (expected_fails == 2) begin
+         $write("*-* All Finished *-*\n");
+         $finish;
+      end
+   end
+endmodule

--- a/test_regress/t/t_assert_property_untyped.pl
+++ b/test_regress/t/t_assert_property_untyped.pl
@@ -1,0 +1,22 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2022 by Antmicro Ltd. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    verilator_flags2 => ['--assert'],
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_assert_property_untyped.v
+++ b/test_regress/t/t_assert_property_untyped.v
@@ -1,0 +1,38 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2022 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+module t (/*AUTOARG*/
+      clk
+   );
+
+   input clk;
+   int cyc = 0;
+   logic [4:0] val = 0;
+
+   always @(posedge clk) begin
+      cyc <= cyc + 1;
+      val = ~val;
+   end
+
+   property check(cyc_mod_2, untyped expected);
+      @(posedge clk)
+        cyc % 2 == cyc_mod_2 |=> val == expected;
+   endproperty
+
+   assert property(check(0, 5'b11111))
+     else begin
+        // Assertion should pass
+        $display("Assert failed, but shouldn't");
+        $stop;
+     end
+
+   always @(posedge clk) begin
+      if (cyc == 10) begin
+         $write("*-* All Finished *-*\n");
+         $finish;
+      end
+   end
+endmodule

--- a/test_regress/t/t_assert_property_untyped_unsup.out
+++ b/test_regress/t/t_assert_property_untyped_unsup.out
@@ -1,0 +1,5 @@
+%Error-UNSUPPORTED: t/t_assert_property_untyped_unsup.v:20:52: Untyped property port following a typed port
+   20 |    property check(cyc_mod_2, logic [4:0] expected, arg3, untyped arg4, arg5);
+      |                                                    ^~~~
+                    ... For error description see https://verilator.org/warn/UNSUPPORTED?v=latest
+%Error: Exiting due to

--- a/test_regress/t/t_assert_property_untyped_unsup.pl
+++ b/test_regress/t/t_assert_property_untyped_unsup.pl
@@ -1,0 +1,20 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2022 by Antmicro Ltd. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(vlt => 1);
+
+compile(
+    expect_filename=>$Self->{golden_filename},
+    verilator_flags2=> ['--assert'],
+    fails => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_assert_property_untyped_unsup.v
+++ b/test_regress/t/t_assert_property_untyped_unsup.v
@@ -1,0 +1,33 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2022 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+module t (/*AUTOARG*/
+      clk
+   );
+
+   input clk;
+   int cyc = 0;
+   logic [4:0] val = 0;
+
+   always @(posedge clk) begin
+      cyc <= cyc + 1;
+      val = ~val;
+   end
+
+   property check(cyc_mod_2, logic [4:0] expected, arg3, untyped arg4, arg5);
+      @(posedge clk)
+        cyc % 2 == cyc_mod_2 |=> val == expected;
+   endproperty
+
+   assert property(check(0, 5'b11111, 100, 25, 17));
+
+   always @(posedge clk) begin
+      if (cyc == 10) begin
+         $write("*-* All Finished *-*\n");
+         $finish;
+      end
+   end
+endmodule

--- a/test_regress/t/t_assert_recursive_property_unsup.out
+++ b/test_regress/t/t_assert_recursive_property_unsup.out
@@ -1,0 +1,6 @@
+%Error-UNSUPPORTED: t/t_assert_recursive_property_unsup.v:20:4: Unsupported: Recursive property call: 'check'
+                                                              : ... In instance t
+   20 |    property check(int n);
+      |    ^~~~~~~~
+                    ... For error description see https://verilator.org/warn/UNSUPPORTED?v=latest
+%Error: Exiting due to

--- a/test_regress/t/t_assert_recursive_property_unsup.pl
+++ b/test_regress/t/t_assert_recursive_property_unsup.pl
@@ -1,0 +1,20 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2022 by Antmicro Ltd. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(vlt => 1);
+
+compile(
+    expect_filename=>$Self->{golden_filename},
+    verilator_flags2=> ['--assert'],
+    fails => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_assert_recursive_property_unsup.v
+++ b/test_regress/t/t_assert_recursive_property_unsup.v
@@ -1,0 +1,36 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2022 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+module t (/*AUTOARG*/
+      clk
+   );
+
+   input clk;
+   int cyc = 0;
+   logic val = 0;
+
+   always @(posedge clk) begin
+      cyc <= cyc + 1;
+      val = ~val;
+   end
+
+   property check(int n);
+      disable iff (n == 0)
+        check(n - 1);
+   endproperty
+
+   assert property(@(posedge clk) check(1))
+     else begin
+        // Assertion should pass
+        $write("*-* Assertion failed *-*\n");
+        $stop;
+     end
+
+   always @(posedge clk) begin
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end
+endmodule


### PR DESCRIPTION
It adds handling of named properties by replacing property references with its expressions. This approach was mentioned in IEEE Std 1800-2012, section 16.12.1.
Nested properties are supported, but not recursive.