### PR TITLE
Add VL_MT_SAFE annotation to const functions

### DIFF
--- a/src/V3Ast.cpp
+++ b/src/V3Ast.cpp
@@ -1184,7 +1184,7 @@ void AstNode::dumpTreeDotFile(const string& filename, bool append, bool doDump) 
     }
 }
 
-void AstNode::v3errorEndFatal(std::ostringstream& str) const {
+void AstNode::v3errorEndFatal(std::ostringstream& str) const VL_MT_SAFE {
     v3errorEnd(str);
     assert(0);  // LCOV_EXCL_LINE
     VL_UNREACHABLE;

--- a/src/V3Ast.h
+++ b/src/V3Ast.h
@@ -95,13 +95,14 @@ public:
     // cppcheck-suppress uninitVar  // responsibility of each subclass
     VNType() = default;
     // cppcheck-suppress noExplicitConstructor
-    constexpr VNType(en _e)
-        : m_e{_e} {}
+    constexpr VNType(en _e) VL_MT_SAFE : m_e{_e} {}
     explicit VNType(int _e)
         : m_e(static_cast<en>(_e)) {}  // Need () or GCC 4.8 false warning
-    constexpr operator en() const { return m_e; }
+    constexpr operator en() const VL_MT_SAFE { return m_e; }
 };
-constexpr bool operator==(const VNType& lhs, const VNType& rhs) { return lhs.m_e == rhs.m_e; }
+constexpr bool operator==(const VNType& lhs, const VNType& rhs) VL_MT_SAFE {
+    return lhs.m_e == rhs.m_e;
+}
 constexpr bool operator==(const VNType& lhs, VNType::en rhs) { return lhs.m_e == rhs; }
 constexpr bool operator==(VNType::en lhs, const VNType& rhs) { return lhs == rhs.m_e; }
 inline std::ostream& operator<<(std::ostream& os, const VNType& rhs) { return os << rhs.ascii(); }
@@ -207,8 +208,8 @@ public:
     explicit VSigning(int _e)
         : m_e(static_cast<en>(_e)) {}  // Need () or GCC 4.8 false warning
     constexpr operator en() const { return m_e; }
-    bool isSigned() const { return m_e == SIGNED; }
-    bool isNosign() const { return m_e == NOSIGN; }
+    bool isSigned() const VL_MT_SAFE { return m_e == SIGNED; }
+    bool isNosign() const VL_MT_SAFE { return m_e == NOSIGN; }
     // No isUnsigned() as it's ambiguous if NOSIGN should be included or not.
 };
 constexpr bool operator==(const VSigning& lhs, const VSigning& rhs) { return lhs.m_e == rhs.m_e; }
@@ -590,17 +591,17 @@ public:
         return (m_e == BIT || m_e == BYTE || m_e == CHANDLE || m_e == INT || m_e == LONGINT
                 || m_e == DOUBLE || m_e == SHORTINT || m_e == UINT32 || m_e == UINT64);
     }
-    bool isOpaque() const {  // IE not a simple number we can bit optimize
+    bool isOpaque() const VL_MT_SAFE {  // IE not a simple number we can bit optimize
         return (m_e == EVENT || m_e == STRING || m_e == SCOPEPTR || m_e == CHARPTR
                 || m_e == MTASKSTATE || m_e == TRIGGERVEC || m_e == DELAY_SCHEDULER
                 || m_e == TRIGGER_SCHEDULER || m_e == FORK_SYNC || m_e == DOUBLE);
     }
-    bool isDouble() const { return m_e == DOUBLE; }
+    bool isDouble() const VL_MT_SAFE { return m_e == DOUBLE; }
     bool isEvent() const { return m_e == EVENT; }
-    bool isString() const { return m_e == STRING; }
-    bool isMTaskState() const { return m_e == MTASKSTATE; }
+    bool isString() const VL_MT_SAFE { return m_e == STRING; }
+    bool isMTaskState() const VL_MT_SAFE { return m_e == MTASKSTATE; }
     // Does this represent a C++ LiteralType? (can be constexpr)
-    bool isLiteralType() const {
+    bool isLiteralType() const VL_MT_SAFE {
         switch (m_e) {
         case BIT:
         case BYTE:
@@ -619,13 +620,13 @@ public:
         }
     }
 };
-constexpr bool operator==(const VBasicDTypeKwd& lhs, const VBasicDTypeKwd& rhs) {
+constexpr bool operator==(const VBasicDTypeKwd& lhs, const VBasicDTypeKwd& rhs) VL_MT_SAFE {
     return lhs.m_e == rhs.m_e;
 }
-constexpr bool operator==(const VBasicDTypeKwd& lhs, VBasicDTypeKwd::en rhs) {
+constexpr bool operator==(const VBasicDTypeKwd& lhs, VBasicDTypeKwd::en rhs) VL_MT_SAFE {
     return lhs.m_e == rhs;
 }
-constexpr bool operator==(VBasicDTypeKwd::en lhs, const VBasicDTypeKwd& rhs) {
+constexpr bool operator==(VBasicDTypeKwd::en lhs, const VBasicDTypeKwd& rhs) VL_MT_SAFE {
     return lhs == rhs.m_e;
 }
 
@@ -642,7 +643,7 @@ public:
         : m_e{_e} {}
     explicit VDirection(int _e)
         : m_e(static_cast<en>(_e)) {}  // Need () or GCC 4.8 false warning
-    constexpr operator en() const { return m_e; }
+    constexpr operator en() const VL_MT_SAFE { return m_e; }
     const char* ascii() const {
         static const char* const names[] = {"NONE", "INPUT", "OUTPUT", "INOUT", "REF", "CONSTREF"};
         return names[m_e];
@@ -662,9 +663,9 @@ public:
     bool isNonOutput() const {
         return m_e == INPUT || m_e == INOUT || m_e == REF || m_e == CONSTREF;
     }
-    bool isReadOnly() const { return m_e == INPUT || m_e == CONSTREF; }
-    bool isWritable() const { return m_e == OUTPUT || m_e == INOUT || m_e == REF; }
-    bool isRefOrConstRef() const { return m_e == REF || m_e == CONSTREF; }
+    bool isReadOnly() const VL_MT_SAFE { return m_e == INPUT || m_e == CONSTREF; }
+    bool isWritable() const VL_MT_SAFE { return m_e == OUTPUT || m_e == INOUT || m_e == REF; }
+    bool isRefOrConstRef() const VL_MT_SAFE { return m_e == REF || m_e == CONSTREF; }
 };
 constexpr bool operator==(const VDirection& lhs, const VDirection& rhs) {
     return lhs.m_e == rhs.m_e;
@@ -777,11 +778,9 @@ public:
         MEMBER
     };
     enum en m_e;
-    VVarType()
-        : m_e{UNKNOWN} {}
+    VVarType() VL_MT_SAFE : m_e{UNKNOWN} {}
     // cppcheck-suppress noExplicitConstructor
-    constexpr VVarType(en _e)
-        : m_e{_e} {}
+    constexpr VVarType(en _e) VL_MT_SAFE : m_e{_e} {}
     explicit VVarType(int _e)
         : m_e(static_cast<en>(_e)) {}  // Need () or GCC 4.8 false warning
     constexpr operator en() const { return m_e; }
@@ -815,10 +814,16 @@ public:
         return (m_e == BLOCKTEMP || m_e == MODULETEMP || m_e == STMTTEMP || m_e == XTEMP);
     }
 };
-constexpr bool operator==(const VVarType& lhs, const VVarType& rhs) { return lhs.m_e == rhs.m_e; }
-constexpr bool operator==(const VVarType& lhs, VVarType::en rhs) { return lhs.m_e == rhs; }
-constexpr bool operator==(VVarType::en lhs, const VVarType& rhs) { return lhs == rhs.m_e; }
-inline std::ostream& operator<<(std::ostream& os, const VVarType& rhs) {
+constexpr bool operator==(const VVarType& lhs, const VVarType& rhs) VL_MT_SAFE {
+    return lhs.m_e == rhs.m_e;
+}
+constexpr bool operator==(const VVarType& lhs, VVarType::en rhs) VL_MT_SAFE {
+    return lhs.m_e == rhs;
+}
+constexpr bool operator==(VVarType::en lhs, const VVarType& rhs) VL_MT_SAFE {
+    return lhs == rhs.m_e;
+}
+inline std::ostream& operator<<(std::ostream& os, const VVarType& rhs) VL_MT_SAFE {
     return os << rhs.ascii();
 }
 
@@ -1117,10 +1122,14 @@ public:
     }
     int left() const { return m_left; }
     int right() const { return m_right; }
-    int hi() const { return m_left > m_right ? m_left : m_right; }  // How to show a declaration
-    int lo() const { return m_left > m_right ? m_right : m_left; }  // How to show a declaration
+    int hi() const VL_MT_SAFE {
+        return m_left > m_right ? m_left : m_right;
+    }  // How to show a declaration
+    int lo() const VL_MT_SAFE {
+        return m_left > m_right ? m_right : m_left;
+    }  // How to show a declaration
     int leftToRightInc() const { return littleEndian() ? 1 : -1; }
-    int elements() const { return hi() - lo() + 1; }
+    int elements() const VL_MT_SAFE { return hi() - lo() + 1; }
     bool ranged() const { return m_ranged; }
     bool littleEndian() const { return m_left < m_right; }
     int hiMaxSelect() const {
@@ -1234,12 +1243,12 @@ public:
     ~VNUser() = default;
     // Casters
     template <class T>
-    typename std::enable_if<std::is_pointer<T>::value, T>::type to() const {
+    typename std::enable_if<std::is_pointer<T>::value, T>::type to() const VL_MT_SAFE {
         return reinterpret_cast<T>(m_u.up);
     }
     WidthVP* c() const { return to<WidthVP*>(); }
     VSymEnt* toSymEnt() const { return to<VSymEnt*>(); }
-    AstNode* toNodep() const { return to<AstNode*>(); }
+    AstNode* toNodep() const VL_MT_SAFE { return to<AstNode*>(); }
     V3GraphVertex* toGraphVertex() const { return to<V3GraphVertex*>(); }
     int toInt() const { return m_u.ui; }
     static VNUser fromInt(int i) { return VNUser{i}; }
@@ -1542,7 +1551,7 @@ class AstNode VL_NOT_FINAL {
 private:
     AstNode* cloneTreeIter();
     AstNode* cloneTreeIterList();
-    void checkTreeIter(const AstNode* backp) const;
+    void checkTreeIter(const AstNode* backp) const VL_MT_SAFE;
     bool gateTreeIter() const;
     static bool sameTreeIter(const AstNode* node1p, const AstNode* node2p, bool ignNext,
                              bool gateOnly);
@@ -1596,16 +1605,16 @@ protected:
 
 public:
     // ACCESSORS
-    VNType type() const { return m_type; }
-    const char* typeName() const { return type().ascii(); }  // See also prettyTypeName
-    AstNode* nextp() const { return m_nextp; }
-    AstNode* backp() const { return m_backp; }
+    VNType type() const VL_MT_SAFE { return m_type; }
+    const char* typeName() const VL_MT_SAFE { return type().ascii(); }  // See also prettyTypeName
+    AstNode* nextp() const VL_MT_SAFE { return m_nextp; }
+    AstNode* backp() const VL_MT_SAFE { return m_backp; }
     AstNode* abovep() const;  // Parent node above, only when no nextp() as otherwise slow
-    AstNode* op1p() const { return m_op1p; }
-    AstNode* op2p() const { return m_op2p; }
-    AstNode* op3p() const { return m_op3p; }
-    AstNode* op4p() const { return m_op4p; }
-    AstNodeDType* dtypep() const { return m_dtypep; }
+    AstNode* op1p() const VL_MT_SAFE { return m_op1p; }
+    AstNode* op2p() const VL_MT_SAFE { return m_op2p; }
+    AstNode* op3p() const VL_MT_SAFE { return m_op3p; }
+    AstNode* op4p() const VL_MT_SAFE { return m_op4p; }
+    AstNodeDType* dtypep() const VL_MT_SAFE { return m_dtypep; }
     AstNode* clonep() const { return ((m_cloneCnt == s_cloneCntGbl) ? m_clonep : nullptr); }
     AstNode* firstAbovep() const {  // Returns nullptr when second or later in list
         return ((backp() && backp()->nextp() != this) ? backp() : nullptr);
@@ -1620,7 +1629,7 @@ public:
                 // If we're first in the list, check what backp() thinks of us:
                 || (backp() && backp()->isFirstInMyListOfStatements(this)));
     }
-    uint8_t brokenState() const { return m_brokenState; }
+    uint8_t brokenState() const VL_MT_SAFE { return m_brokenState; }
     void brokenState(uint8_t value) { m_brokenState = value; }
 
     // Used by AstNode::broken()
@@ -1652,7 +1661,7 @@ public:
     static constexpr int INSTR_COUNT_PLI = 20;  // PLI routines
 
     // ACCESSORS
-    virtual string name() const { return ""; }
+    virtual string name() const VL_MT_SAFE { return ""; }
     virtual string origName() const { return ""; }
     virtual void name(const string& name) {
         this->v3fatalSrc("name() called on object without name() method");
@@ -1660,7 +1669,7 @@ public:
     virtual void tag(const string& text) {}
     virtual string tag() const { return ""; }
     virtual string verilogKwd() const { return ""; }
-    string nameProtect() const;  // Name with --protect-id applied
+    string nameProtect() const VL_MT_SAFE;  // Name with --protect-id applied
     string origNameProtect() const;  // origName with --protect-id applied
     string shortName() const;  // Name with __PVT__ removed for concatenating scopes
     static string dedotName(const string& namein);  // Name with dots removed
@@ -1672,11 +1681,11 @@ public:
     encodeName(const string& namein);  // Encode user name into internal C representation
     static string encodeNumber(int64_t num);  // Encode number into internal C representation
     static string vcdName(const string& namein);  // Name for printing out to vcd files
-    string prettyName() const { return prettyName(name()); }
+    string prettyName() const VL_MT_SAFE { return prettyName(name()); }
     string prettyNameQ() const { return prettyNameQ(name()); }
     string prettyTypeName() const;  // "VARREF" for error messages (NOT dtype's pretty name)
     virtual string prettyOperatorName() const { return "operator " + prettyTypeName(); }
-    FileLine* fileline() const { return m_fileline; }
+    FileLine* fileline() const VL_MT_SAFE { return m_fileline; }
     void fileline(FileLine* fl) { m_fileline = fl; }
     inline bool width1() const;
     inline int widthInstrs() const;
@@ -1689,29 +1698,29 @@ public:
     }
     bool doingWidth() const { return m_flags.doingWidth; }
     void doingWidth(bool flag) { m_flags.doingWidth = flag; }
-    bool protect() const { return m_flags.protect; }
+    bool protect() const VL_MT_SAFE { return m_flags.protect; }
     void protect(bool flag) { m_flags.protect = flag; }
 
     // TODO stomp these width functions out, and call via dtypep() instead
-    inline int width() const;
+    inline int width() const VL_MT_SAFE;
     inline int widthMin() const;
     int widthMinV() const {
         return v3Global.widthMinUsage() == VWidthMinUsage::VERILOG_WIDTH ? widthMin() : width();
     }
     int widthWords() const { return VL_WORDS_I(width()); }
-    bool isQuad() const { return (width() > VL_IDATASIZE && width() <= VL_QUADSIZE); }
-    bool isWide() const { return (width() > VL_QUADSIZE); }
+    bool isQuad() const VL_MT_SAFE { return (width() > VL_IDATASIZE && width() <= VL_QUADSIZE); }
+    bool isWide() const VL_MT_SAFE { return (width() > VL_QUADSIZE); }
     inline bool isDouble() const;
     inline bool isSigned() const;
     inline bool isString() const;
 
     // clang-format off
-    VNUser      user1u() const {
+    VNUser      user1u() const VL_MT_SAFE {
         // Slows things down measurably, so disabled by default
         //UASSERT_STATIC(VNUser1InUse::s_userBusy, "userp set w/o busy");
         return ((m_user1Cnt==VNUser1InUse::s_userCntGbl) ? m_user1u : VNUser{0});
     }
-    AstNode*    user1p() const { return user1u().toNodep(); }
+    AstNode*    user1p() const VL_MT_SAFE { return user1u().toNodep(); }
     void        user1u(const VNUser& user) { m_user1u=user; m_user1Cnt=VNUser1InUse::s_userCntGbl; }
     void        user1p(void* userp) { user1u(VNUser{userp}); }
     int         user1() const { return user1u().toInt(); }
@@ -1720,12 +1729,12 @@ public:
     int         user1SetOnce() { int v=user1(); if (!v) user1(1); return v; }  // Better for cache than user1Inc()
     static void user1ClearTree() { VNUser1InUse::clear(); }  // Clear userp()'s across the entire tree
 
-    VNUser      user2u() const {
+    VNUser      user2u() const VL_MT_SAFE {
         // Slows things down measurably, so disabled by default
         //UASSERT_STATIC(VNUser2InUse::s_userBusy, "userp set w/o busy");
         return ((m_user2Cnt==VNUser2InUse::s_userCntGbl) ? m_user2u : VNUser{0});
     }
-    AstNode*    user2p() const { return user2u().toNodep(); }
+    AstNode*    user2p() const VL_MT_SAFE { return user2u().toNodep(); }
     void        user2u(const VNUser& user) { m_user2u=user; m_user2Cnt=VNUser2InUse::s_userCntGbl; }
     void        user2p(void* userp) { user2u(VNUser{userp}); }
     int         user2() const { return user2u().toInt(); }
@@ -1734,12 +1743,12 @@ public:
     int         user2SetOnce() { int v=user2(); if (!v) user2(1); return v; }  // Better for cache than user2Inc()
     static void user2ClearTree() { VNUser2InUse::clear(); }  // Clear userp()'s across the entire tree
 
-    VNUser      user3u() const {
+    VNUser      user3u() const VL_MT_SAFE {
         // Slows things down measurably, so disabled by default
         //UASSERT_STATIC(VNUser3InUse::s_userBusy, "userp set w/o busy");
         return ((m_user3Cnt==VNUser3InUse::s_userCntGbl) ? m_user3u : VNUser{0});
     }
-    AstNode*    user3p() const { return user3u().toNodep(); }
+    AstNode*    user3p() const VL_MT_SAFE { return user3u().toNodep(); }
     void        user3u(const VNUser& user) { m_user3u=user; m_user3Cnt=VNUser3InUse::s_userCntGbl; }
     void        user3p(void* userp) { user3u(VNUser{userp}); }
     int         user3() const { return user3u().toInt(); }
@@ -1748,12 +1757,12 @@ public:
     int         user3SetOnce() { int v=user3(); if (!v) user3(1); return v; }  // Better for cache than user3Inc()
     static void user3ClearTree() { VNUser3InUse::clear(); }  // Clear userp()'s across the entire tree
 
-    VNUser      user4u() const {
+    VNUser      user4u() const VL_MT_SAFE {
         // Slows things down measurably, so disabled by default
         //UASSERT_STATIC(VNUser4InUse::s_userBusy, "userp set w/o busy");
         return ((m_user4Cnt==VNUser4InUse::s_userCntGbl) ? m_user4u : VNUser{0});
     }
-    AstNode*    user4p() const { return user4u().toNodep(); }
+    AstNode*    user4p() const VL_MT_SAFE { return user4u().toNodep(); }
     void        user4u(const VNUser& user) { m_user4u=user; m_user4Cnt=VNUser4InUse::s_userCntGbl; }
     void        user4p(void* userp) { user4u(VNUser{userp}); }
     int         user4() const { return user4u().toInt(); }
@@ -1762,12 +1771,12 @@ public:
     int         user4SetOnce() { int v=user4(); if (!v) user4(1); return v; }  // Better for cache than user4Inc()
     static void user4ClearTree() { VNUser4InUse::clear(); }  // Clear userp()'s across the entire tree
 
-    VNUser      user5u() const {
+    VNUser      user5u() const VL_MT_SAFE {
         // Slows things down measurably, so disabled by default
         //UASSERT_STATIC(VNUser5InUse::s_userBusy, "userp set w/o busy");
         return ((m_user5Cnt==VNUser5InUse::s_userCntGbl) ? m_user5u : VNUser{0});
     }
-    AstNode*    user5p() const { return user5u().toNodep(); }
+    AstNode*    user5p() const VL_MT_SAFE { return user5u().toNodep(); }
     void        user5u(const VNUser& user) { m_user5u=user; m_user5Cnt=VNUser5InUse::s_userCntGbl; }
     void        user5p(void* userp) { user5u(VNUser{userp}); }
     int         user5() const { return user5u().toInt(); }
@@ -1785,8 +1794,8 @@ public:
 #else
     void editCountInc() { ++s_editCntGbl; }
 #endif
-    static uint64_t editCountLast() { return s_editCntLast; }
-    static uint64_t editCountGbl() { return s_editCntGbl; }
+    static uint64_t editCountLast() VL_MT_SAFE { return s_editCntLast; }
+    static uint64_t editCountGbl() VL_MT_SAFE { return s_editCntGbl; }
     static void editCountSetLast() { s_editCntLast = editCountGbl(); }
 
     // ACCESSORS for specific types
@@ -1851,8 +1860,8 @@ public:
     static AstBasicDType* findInsertSameDType(AstBasicDType* nodep);
 
     // METHODS - dump and error
-    void v3errorEnd(std::ostringstream& str) const;
-    void v3errorEndFatal(std::ostringstream& str) const VL_ATTR_NORETURN;
+    void v3errorEnd(std::ostringstream& str) const VL_MT_SAFE;
+    void v3errorEndFatal(std::ostringstream& str) const VL_ATTR_NORETURN VL_MT_SAFE;
     string warnContextPrimary() const { return fileline()->warnContextPrimary(); }
     string warnContextSecondary() const { return fileline()->warnContextSecondary(); }
     string warnMore() const { return fileline()->warnMore(); }
@@ -1901,7 +1910,7 @@ public:
     // Does tree of this == node2p?, not allowing non-isGateOptimizable
     inline bool sameGateTree(const AstNode* node2p) const;
     void deleteTree();  // Always deletes the next link
-    void checkTree() const {
+    void checkTree() const VL_MT_SAFE {
         if (v3Global.opt.debugCheck()) checkTreeIter(backp());
     }
     void checkIter() const;
@@ -1943,13 +1952,13 @@ public:
     virtual int instrCount() const { return 0; }
     virtual bool same(const AstNode*) const { return true; }
     // Iff has a data type; dtype() must be non null
-    virtual bool hasDType() const { return false; }
+    virtual bool hasDType() const VL_MT_SAFE { return false; }
     // Iff has a non-null childDTypep(), as generic node function
     virtual AstNodeDType* getChildDTypep() const { return nullptr; }
     // Iff has a non-null child2DTypep(), as generic node function
     virtual AstNodeDType* getChild2DTypep() const { return nullptr; }
     // Another AstNode* may have a pointer into this node, other then normal front/back/etc.
-    virtual bool maybePointedTo() const { return false; }
+    virtual bool maybePointedTo() const VL_MT_SAFE { return false; }
     // Don't reclaim this node in V3Dead
     virtual bool undead() const { return false; }
     // Check if node is consistent, return nullptr if ok, else reason string
@@ -2003,7 +2012,7 @@ private:
 public:
     // For use via the VN_IS macro only
     template <typename T, typename E>
-    static bool privateIs(const AstNode* nodep) {
+    static bool privateIs(const AstNode* nodep) VL_MT_SAFE {
         static_assert(!uselessCast<T, E>(), "Unnecessary VN_IS, node known to have target type.");
         static_assert(!impossibleCast<T, E>(), "Unnecessary VN_IS, node cannot be this type.");
         return nodep && privateTypeTest<T>(nodep);
@@ -2011,14 +2020,14 @@ public:
 
     // For use via the VN_CAST macro only
     template <typename T, typename E>
-    static T* privateCast(AstNode* nodep) {
+    static T* privateCast(AstNode* nodep) VL_MT_SAFE {
         static_assert(!uselessCast<T, E>(),
                       "Unnecessary VN_CAST, node known to have target type.");
         static_assert(!impossibleCast<T, E>(), "Unnecessary VN_CAST, node cannot be this type.");
         return nodep && privateTypeTest<T>(nodep) ? reinterpret_cast<T*>(nodep) : nullptr;
     }
     template <typename T, typename E>
-    static const T* privateCast(const AstNode* nodep) {
+    static const T* privateCast(const AstNode* nodep) VL_MT_SAFE {
         static_assert(!uselessCast<T, E>(),
                       "Unnecessary VN_CAST, node known to have target type.");
         static_assert(!impossibleCast<T, E>(), "Unnecessary VN_CAST, node cannot be this type.");
@@ -2027,7 +2036,7 @@ public:
 
     // For use via the VN_AS macro only
     template <typename T, typename E>
-    static T* privateAs(AstNode* nodep) {
+    static T* privateAs(AstNode* nodep) VL_MT_SAFE {
         static_assert(!uselessCast<T, E>(), "Unnecessary VN_AS, node known to have target type.");
         static_assert(!impossibleCast<T, E>(), "Unnecessary VN_AS, node cannot be this type.");
         UASSERT_OBJ(!nodep || privateTypeTest<T>(nodep), nodep,
@@ -2036,7 +2045,7 @@ public:
         return reinterpret_cast<T*>(nodep);
     }
     template <typename T, typename E>
-    static const T* privateAs(const AstNode* nodep) {
+    static const T* privateAs(const AstNode* nodep) VL_MT_SAFE {
         static_assert(!uselessCast<T, E>(), "Unnecessary VN_AS, node known to have target type.");
         static_assert(!impossibleCast<T, E>(), "Unnecessary VN_AS, node cannot be this type.");
         UASSERT_OBJ(!nodep || privateTypeTest<T>(nodep), nodep,

--- a/src/V3AstInlines.h
+++ b/src/V3AstInlines.h
@@ -33,10 +33,10 @@ bool AstNode::width1() const {  // V3Const uses to know it can optimize
 int AstNode::widthInstrs() const {
     return (!dtypep() ? 1 : (dtypep()->isWide() ? dtypep()->widthWords() : 1));
 }
-bool AstNode::isDouble() const {
+bool AstNode::isDouble() const VL_MT_SAFE {
     return dtypep() && VN_IS(dtypep(), BasicDType) && VN_AS(dtypep(), BasicDType)->isDouble();
 }
-bool AstNode::isString() const {
+bool AstNode::isString() const VL_MT_SAFE {
     return dtypep() && dtypep()->basicp() && dtypep()->basicp()->isString();
 }
 bool AstNode::isSigned() const { return dtypep() && dtypep()->isSigned(); }
@@ -61,12 +61,12 @@ bool AstNode::sameGateTree(const AstNode* node2p) const {
     return sameTreeIter(this, node2p, true, true);
 }
 
-int AstNodeArrayDType::left() const { return rangep()->leftConst(); }
-int AstNodeArrayDType::right() const { return rangep()->rightConst(); }
-int AstNodeArrayDType::hi() const { return rangep()->hiConst(); }
-int AstNodeArrayDType::lo() const { return rangep()->loConst(); }
-int AstNodeArrayDType::elementsConst() const { return rangep()->elementsConst(); }
-VNumRange AstNodeArrayDType::declRange() const { return VNumRange{left(), right()}; }
+int AstNodeArrayDType::left() const VL_MT_SAFE { return rangep()->leftConst(); }
+int AstNodeArrayDType::right() const VL_MT_SAFE { return rangep()->rightConst(); }
+int AstNodeArrayDType::hi() const VL_MT_SAFE { return rangep()->hiConst(); }
+int AstNodeArrayDType::lo() const VL_MT_SAFE { return rangep()->loConst(); }
+int AstNodeArrayDType::elementsConst() const VL_MT_SAFE { return rangep()->elementsConst(); }
+VNumRange AstNodeArrayDType::declRange() const VL_MT_SAFE { return VNumRange{left(), right()}; }
 
 AstRange::AstRange(FileLine* fl, int left, int right)
     : ASTGEN_SUPER_Range(fl) {
@@ -87,7 +87,7 @@ int AstRange::rightConst() const {
     return (constp ? constp->toSInt() : 0);
 }
 
-int AstQueueDType::boundConst() const {
+int AstQueueDType::boundConst() const VL_MT_SAFE {
     AstConst* const constp = VN_CAST(boundp(), Const);
     return (constp ? constp->toSInt() : 0);
 }

--- a/src/V3AstNodeDType.h
+++ b/src/V3AstNodeDType.h
@@ -103,19 +103,20 @@ public:
         m_numeric = nodep->m_numeric;
     }
     //
-    int width() const { return m_width; }
+    int width() const VL_MT_SAFE { return m_width; }
     void numeric(VSigning flag) { m_numeric = flag; }
-    bool isSigned() const { return m_numeric.isSigned(); }
-    bool isNosign() const { return m_numeric.isNosign(); }
+    bool isSigned() const VL_MT_SAFE { return m_numeric.isSigned(); }
+    bool isNosign() const VL_MT_SAFE { return m_numeric.isNosign(); }
     VSigning numeric() const { return m_numeric; }
-    int widthWords() const { return VL_WORDS_I(width()); }
-    int widthMin() const {  // If sized, the size, if unsized the min digits to represent it
+    int widthWords() const VL_MT_SAFE { return VL_WORDS_I(width()); }
+    int widthMin() const VL_MT_SAFE {  // If sized, the size,
+                                       // if unsized the min digits to represent it
         return m_widthMin ? m_widthMin : m_width;
     }
     int widthPow2() const;
     void widthMinFromWidth() { m_widthMin = m_width; }
-    bool widthSized() const { return !m_widthMin || m_widthMin == m_width; }
-    bool generic() const { return m_generic; }
+    bool widthSized() const VL_MT_SAFE { return !m_widthMin || m_widthMin == m_width; }
+    bool generic() const VL_MT_SAFE { return m_generic; }
     void generic(bool flag) { m_generic = flag; }
     std::pair<uint32_t, uint32_t> dimensions(bool includeBasic);
     uint32_t arrayUnpackedElements();  // 1, or total multiplication of all dimensions
@@ -123,12 +124,12 @@ public:
     const char* charIQWN() const {
         return (isString() ? "N" : isWide() ? "W" : isQuad() ? "Q" : "I");
     }
-    string cType(const string& name, bool forFunc, bool isRef) const;
-    bool isLiteralType() const;  // Does this represent a C++ LiteralType? (can be constexpr)
+    string cType(const string& name, bool forFunc, bool isRef) const VL_MT_SAFE;
+    bool isLiteralType() const VL_MT_SAFE;  // Represents a C++ LiteralType? (can be constexpr)
 
 private:
     class CTypeRecursed;
-    CTypeRecursed cTypeRecurse(bool compound) const;
+    CTypeRecursed cTypeRecurse(bool compound) const VL_MT_SAFE;
 };
 class AstNodeArrayDType VL_NOT_FINAL : public AstNodeDType {
     // Array data type, ie "some_dtype var_name [2:0]"
@@ -167,15 +168,17 @@ public:
                 && subDTypep()->skipRefp()->similarDType(asamep->subDTypep()->skipRefp()));
     }
     AstNodeDType* getChildDTypep() const override { return childDTypep(); }
-    AstNodeDType* subDTypep() const override { return m_refDTypep ? m_refDTypep : childDTypep(); }
+    AstNodeDType* subDTypep() const override VL_MT_SAFE {
+        return m_refDTypep ? m_refDTypep : childDTypep();
+    }
     void refDTypep(AstNodeDType* nodep) { m_refDTypep = nodep; }
     AstNodeDType* virtRefDTypep() const override { return m_refDTypep; }
     void virtRefDTypep(AstNodeDType* nodep) override { refDTypep(nodep); }
     // METHODS
-    AstBasicDType* basicp() const override {
+    AstBasicDType* basicp() const override VL_MT_SAFE {
         return subDTypep()->basicp();
     }  // (Slow) recurse down to find basic data type
-    AstNodeDType* skipRefp() const override { return (AstNodeDType*)this; }
+    AstNodeDType* skipRefp() const override VL_MT_SAFE { return (AstNodeDType*)this; }
     AstNodeDType* skipRefToConstp() const override { return (AstNodeDType*)this; }
     AstNodeDType* skipRefToEnump() const override { return (AstNodeDType*)this; }
     int widthAlignBytes() const override { return subDTypep()->widthAlignBytes(); }
@@ -225,7 +228,7 @@ public:
                     : VN_AS(findBitRangeDType(VNumRange{width() - 1, 0}, width(), numeric()),
                             BasicDType));
     }
-    AstNodeDType* skipRefp() const override { return (AstNodeDType*)this; }
+    AstNodeDType* skipRefp() const override VL_MT_SAFE { return (AstNodeDType*)this; }
     AstNodeDType* skipRefToConstp() const override { return (AstNodeDType*)this; }
     AstNodeDType* skipRefToEnump() const override { return (AstNodeDType*)this; }
     // (Slow) recurses - Structure alignment 1,2,4 or 8 bytes (arrays affect this)
@@ -237,7 +240,7 @@ public:
     }
     string name() const override { return m_name; }
     void name(const string& flag) override { m_name = flag; }
-    bool packed() const { return m_packed; }
+    bool packed() const VL_MT_SAFE { return m_packed; }
     // packed() but as don't support unpacked, presently all structs
     static bool packedUnsup() { return true; }
     void isFourstate(bool flag) { m_isFourstate = flag; }
@@ -327,18 +330,22 @@ public:
     void dumpSmall(std::ostream& str) const override;
     AstNodeDType* getChildDTypep() const override { return childDTypep(); }
     AstNodeDType* getChild2DTypep() const override { return keyChildDTypep(); }
-    AstNodeDType* subDTypep() const override { return m_refDTypep ? m_refDTypep : childDTypep(); }
+    AstNodeDType* subDTypep() const override VL_MT_SAFE {
+        return m_refDTypep ? m_refDTypep : childDTypep();
+    }
     void refDTypep(AstNodeDType* nodep) { m_refDTypep = nodep; }
     AstNodeDType* virtRefDTypep() const override { return m_refDTypep; }
     void virtRefDTypep(AstNodeDType* nodep) override { refDTypep(nodep); }
     AstNodeDType* virtRefDType2p() const override { return m_keyDTypep; }
     void virtRefDType2p(AstNodeDType* nodep) override { keyDTypep(nodep); }
     //
-    AstNodeDType* keyDTypep() const { return m_keyDTypep ? m_keyDTypep : keyChildDTypep(); }
+    AstNodeDType* keyDTypep() const VL_MT_SAFE {
+        return m_keyDTypep ? m_keyDTypep : keyChildDTypep();
+    }
     void keyDTypep(AstNodeDType* nodep) { m_keyDTypep = nodep; }
     // METHODS
-    AstBasicDType* basicp() const override { return nullptr; }
-    AstNodeDType* skipRefp() const override { return (AstNodeDType*)this; }
+    AstBasicDType* basicp() const override VL_MT_SAFE { return nullptr; }
+    AstNodeDType* skipRefp() const override VL_MT_SAFE { return (AstNodeDType*)this; }
     AstNodeDType* skipRefToConstp() const override { return (AstNodeDType*)this; }
     AstNodeDType* skipRefToEnump() const override { return (AstNodeDType*)this; }
     int widthAlignBytes() const override { return subDTypep()->widthAlignBytes(); }
@@ -410,8 +417,8 @@ public:
         }
     }
     // METHODS
-    AstBasicDType* basicp() const override { return (AstBasicDType*)this; }
-    AstNodeDType* skipRefp() const override { return (AstNodeDType*)this; }
+    AstBasicDType* basicp() const override VL_MT_SAFE { return (AstBasicDType*)this; }
+    AstNodeDType* skipRefp() const override VL_MT_SAFE { return (AstNodeDType*)this; }
     AstNodeDType* skipRefToConstp() const override { return (AstNodeDType*)this; }
     AstNodeDType* skipRefToEnump() const override { return (AstNodeDType*)this; }
     // (Slow) recurses - Structure alignment 1,2,4 or 8 bytes (arrays affect this)
@@ -419,18 +426,22 @@ public:
     // (Slow) recurses - Width in bytes rounding up 1,2,4,8,12,...
     int widthTotalBytes() const override;
     bool isFourstate() const override { return keyword().isFourstate(); }
-    VBasicDTypeKwd keyword() const {  // Avoid using - use isSomething accessors instead
+    VBasicDTypeKwd keyword() const VL_MT_SAFE {  // Avoid using - use isSomething accessors instead
         return m.m_keyword;
     }
     bool isBitLogic() const { return keyword().isBitLogic(); }
-    bool isDouble() const { return keyword().isDouble(); }
-    bool isEvent() const { return keyword() == VBasicDTypeKwd::EVENT; }
-    bool isTriggerVec() const { return keyword() == VBasicDTypeKwd::TRIGGERVEC; }
-    bool isForkSync() const { return keyword() == VBasicDTypeKwd::FORK_SYNC; }
-    bool isDelayScheduler() const { return keyword() == VBasicDTypeKwd::DELAY_SCHEDULER; }
-    bool isTriggerScheduler() const { return keyword() == VBasicDTypeKwd::TRIGGER_SCHEDULER; }
-    bool isOpaque() const { return keyword().isOpaque(); }
-    bool isString() const { return keyword().isString(); }
+    bool isDouble() const VL_MT_SAFE { return keyword().isDouble(); }
+    bool isEvent() const VL_MT_SAFE { return keyword() == VBasicDTypeKwd::EVENT; }
+    bool isTriggerVec() const VL_MT_SAFE { return keyword() == VBasicDTypeKwd::TRIGGERVEC; }
+    bool isForkSync() const VL_MT_SAFE { return keyword() == VBasicDTypeKwd::FORK_SYNC; }
+    bool isDelayScheduler() const VL_MT_SAFE {
+        return keyword() == VBasicDTypeKwd::DELAY_SCHEDULER;
+    }
+    bool isTriggerScheduler() const VL_MT_SAFE {
+        return keyword() == VBasicDTypeKwd::TRIGGER_SCHEDULER;
+    }
+    bool isOpaque() const VL_MT_SAFE { return keyword().isOpaque(); }
+    bool isString() const VL_MT_SAFE { return keyword().isString(); }
     bool isZeroInit() const { return keyword().isZeroInit(); }
     bool isRanged() const { return rangep() || m.m_nrange.ranged(); }
     bool isDpiBitVec() const {  // DPI uses svBitVecVal
@@ -474,8 +485,8 @@ public:
     // Will be removed in V3Width, which relies on this
     // being a child not a dtype pointed node
     bool maybePointedTo() const override { return false; }
-    AstBasicDType* basicp() const override { return nullptr; }
-    AstNodeDType* skipRefp() const override { return (AstNodeDType*)this; }
+    AstBasicDType* basicp() const override VL_MT_SAFE { return nullptr; }
+    AstNodeDType* skipRefp() const override VL_MT_SAFE { return (AstNodeDType*)this; }
     AstNodeDType* skipRefToConstp() const override { return (AstNodeDType*)this; }
     AstNodeDType* skipRefToEnump() const override { return (AstNodeDType*)this; }
     int widthAlignBytes() const override { V3ERROR_NA_RETURN(0); }
@@ -509,8 +520,8 @@ public:
     void dump(std::ostream& str = std::cout) const override;
     void dumpSmall(std::ostream& str) const override;
     string name() const override;
-    AstBasicDType* basicp() const override { return nullptr; }
-    AstNodeDType* skipRefp() const override { return (AstNodeDType*)this; }
+    AstBasicDType* basicp() const override VL_MT_SAFE { return nullptr; }
+    AstNodeDType* skipRefp() const override VL_MT_SAFE { return (AstNodeDType*)this; }
     AstNodeDType* skipRefToConstp() const override { return (AstNodeDType*)this; }
     AstNodeDType* skipRefToEnump() const override { return (AstNodeDType*)this; }
     int widthAlignBytes() const override { return 0; }
@@ -561,8 +572,8 @@ public:
     AstNodeDType* virtRefDTypep() const override { return m_refDTypep; }
     void virtRefDTypep(AstNodeDType* nodep) override { refDTypep(nodep); }
     // METHODS
-    AstBasicDType* basicp() const override { return subDTypep()->basicp(); }
-    AstNodeDType* skipRefp() const override { return subDTypep()->skipRefp(); }
+    AstBasicDType* basicp() const override VL_MT_SAFE { return subDTypep()->basicp(); }
+    AstNodeDType* skipRefp() const override VL_MT_SAFE { return subDTypep()->skipRefp(); }
     AstNodeDType* skipRefToConstp() const override { return (AstNodeDType*)this; }
     AstNodeDType* skipRefToEnump() const override { return subDTypep()->skipRefToEnump(); }
     int widthAlignBytes() const override { return subDTypep()->widthAlignBytes(); }
@@ -608,8 +619,8 @@ public:
     // METHODS
     // op1 = Range of variable
     AstNodeDType* dtypeSkipRefp() const { return dtypep()->skipRefp(); }
-    AstBasicDType* basicp() const override { return subDTypep()->basicp(); }
-    AstNodeDType* skipRefp() const override { return (AstNodeDType*)this; }
+    AstBasicDType* basicp() const override VL_MT_SAFE { return subDTypep()->basicp(); }
+    AstNodeDType* skipRefp() const override VL_MT_SAFE { return (AstNodeDType*)this; }
     AstNodeDType* skipRefToConstp() const override { return (AstNodeDType*)this; }
     AstNodeDType* skipRefToEnump() const override { return (AstNodeDType*)this; }
     int widthAlignBytes() const override { return dtypep()->widthAlignBytes(); }
@@ -657,13 +668,15 @@ public:
     string prettyDTypeName() const override;
     void dumpSmall(std::ostream& str) const override;
     AstNodeDType* getChildDTypep() const override { return childDTypep(); }
-    AstNodeDType* subDTypep() const override { return m_refDTypep ? m_refDTypep : childDTypep(); }
+    AstNodeDType* subDTypep() const override VL_MT_SAFE {
+        return m_refDTypep ? m_refDTypep : childDTypep();
+    }
     void refDTypep(AstNodeDType* nodep) { m_refDTypep = nodep; }
     AstNodeDType* virtRefDTypep() const override { return m_refDTypep; }
     void virtRefDTypep(AstNodeDType* nodep) override { refDTypep(nodep); }
     // METHODS
-    AstBasicDType* basicp() const override { return nullptr; }
-    AstNodeDType* skipRefp() const override { return (AstNodeDType*)this; }
+    AstBasicDType* basicp() const override VL_MT_SAFE { return nullptr; }
+    AstNodeDType* skipRefp() const override VL_MT_SAFE { return (AstNodeDType*)this; }
     AstNodeDType* skipRefToConstp() const override { return (AstNodeDType*)this; }
     AstNodeDType* skipRefToEnump() const override { return (AstNodeDType*)this; }
     int widthAlignBytes() const override { return subDTypep()->widthAlignBytes(); }
@@ -686,9 +699,9 @@ public:
     AstNodeDType* virtRefDTypep() const override { return nullptr; }
     void virtRefDTypep(AstNodeDType* nodep) override {}
     bool similarDType(AstNodeDType* samep) const override { return this == samep; }
-    AstBasicDType* basicp() const override { return nullptr; }
+    AstBasicDType* basicp() const override VL_MT_SAFE { return nullptr; }
     // cppcheck-suppress csyleCast
-    AstNodeDType* skipRefp() const override { return (AstNodeDType*)this; }
+    AstNodeDType* skipRefp() const override VL_MT_SAFE { return (AstNodeDType*)this; }
     // cppcheck-suppress csyleCast
     AstNodeDType* skipRefToConstp() const override { return (AstNodeDType*)this; }
     // cppcheck-suppress csyleCast
@@ -739,8 +752,8 @@ public:
     string name() const override { return m_name; }
     void name(const string& flag) override { m_name = flag; }
     // METHODS
-    AstBasicDType* basicp() const override { return subDTypep()->basicp(); }
-    AstNodeDType* skipRefp() const override { return subDTypep()->skipRefp(); }
+    AstBasicDType* basicp() const override VL_MT_SAFE { return subDTypep()->basicp(); }
+    AstNodeDType* skipRefp() const override VL_MT_SAFE { return subDTypep()->skipRefp(); }
     AstNodeDType* skipRefToConstp() const override { return subDTypep()->skipRefToConstp(); }
     // cppcheck-suppress csyleCast
     AstNodeDType* skipRefToEnump() const override { return (AstNodeDType*)this; }
@@ -783,8 +796,8 @@ public:
     void dump(std::ostream& str = std::cout) const override;
     void dumpSmall(std::ostream& str) const override;
     void cloneRelink() override;
-    AstBasicDType* basicp() const override { return nullptr; }
-    AstNodeDType* skipRefp() const override { return (AstNodeDType*)this; }
+    AstBasicDType* basicp() const override VL_MT_SAFE { return nullptr; }
+    AstNodeDType* skipRefp() const override VL_MT_SAFE { return (AstNodeDType*)this; }
     AstNodeDType* skipRefToConstp() const override { return (AstNodeDType*)this; }
     AstNodeDType* skipRefToEnump() const override { return (AstNodeDType*)this; }
     bool similarDType(AstNodeDType* samep) const override { return this == samep; }
@@ -852,10 +865,10 @@ public:
     //
     // (Slow) recurse down to find basic data type (Note don't need virtual -
     // AstVar isn't a NodeDType)
-    AstBasicDType* basicp() const override { return subDTypep()->basicp(); }
+    AstBasicDType* basicp() const override VL_MT_SAFE { return subDTypep()->basicp(); }
     // op1 = Range of variable (Note don't need virtual - AstVar isn't a NodeDType)
     AstNodeDType* dtypeSkipRefp() const { return subDTypep()->skipRefp(); }
-    AstNodeDType* skipRefp() const override { return subDTypep()->skipRefp(); }
+    AstNodeDType* skipRefp() const override VL_MT_SAFE { return subDTypep()->skipRefp(); }
     AstNodeDType* skipRefToConstp() const override { return subDTypep()->skipRefToConstp(); }
     AstNodeDType* skipRefToEnump() const override { return subDTypep()->skipRefToEnump(); }
     // (Slow) recurses - Structure alignment 1,2,4 or 8 bytes (arrays affect this)
@@ -892,8 +905,8 @@ public:
     ASTGEN_MEMBERS_AstParamTypeDType;
     AstNodeDType* getChildDTypep() const override { return childDTypep(); }
     AstNodeDType* subDTypep() const override { return dtypep() ? dtypep() : childDTypep(); }
-    AstBasicDType* basicp() const override { return subDTypep()->basicp(); }
-    AstNodeDType* skipRefp() const override { return subDTypep()->skipRefp(); }
+    AstBasicDType* basicp() const override VL_MT_SAFE { return subDTypep()->basicp(); }
+    AstNodeDType* skipRefp() const override VL_MT_SAFE { return subDTypep()->skipRefp(); }
     AstNodeDType* skipRefToConstp() const override { return subDTypep()->skipRefToConstp(); }
     AstNodeDType* skipRefToEnump() const override { return subDTypep()->skipRefToEnump(); }
     bool similarDType(AstNodeDType* samep) const override {
@@ -927,8 +940,8 @@ public:
     AstNodeDType* dtypep() const { return nullptr; }
     // METHODS
     bool similarDType(AstNodeDType* samep) const override { return this == samep; }
-    AstBasicDType* basicp() const override { return nullptr; }
-    AstNodeDType* skipRefp() const override { return nullptr; }
+    AstBasicDType* basicp() const override VL_MT_SAFE { return nullptr; }
+    AstNodeDType* skipRefp() const override VL_MT_SAFE { return nullptr; }
     // cppcheck-suppress csyleCast
     AstNodeDType* skipRefToConstp() const override { return (AstNodeDType*)this; }
     // cppcheck-suppress csyleCast
@@ -982,15 +995,17 @@ public:
     void dumpSmall(std::ostream& str) const override;
     string prettyDTypeName() const override;
     AstNodeDType* getChildDTypep() const override { return childDTypep(); }
-    AstNodeDType* subDTypep() const override { return m_refDTypep ? m_refDTypep : childDTypep(); }
+    AstNodeDType* subDTypep() const override VL_MT_SAFE {
+        return m_refDTypep ? m_refDTypep : childDTypep();
+    }
     void refDTypep(AstNodeDType* nodep) { m_refDTypep = nodep; }
     inline int boundConst() const;
     AstNodeDType* virtRefDTypep() const override { return m_refDTypep; }
     void virtRefDTypep(AstNodeDType* nodep) override { refDTypep(nodep); }
     // METHODS
-    AstBasicDType* basicp() const override { return nullptr; }
+    AstBasicDType* basicp() const override VL_MT_SAFE { return nullptr; }
     // cppcheck-suppress csyleCast
-    AstNodeDType* skipRefp() const override { return (AstNodeDType*)this; }
+    AstNodeDType* skipRefp() const override VL_MT_SAFE { return (AstNodeDType*)this; }
     // cppcheck-suppress csyleCast
     AstNodeDType* skipRefToConstp() const override { return (AstNodeDType*)this; }
     // cppcheck-suppress csyleCast
@@ -1043,11 +1058,11 @@ public:
     string prettyDTypeName() const override {
         return subDTypep() ? subDTypep()->name() : prettyName();
     }
-    AstBasicDType* basicp() const override {
+    AstBasicDType* basicp() const override VL_MT_SAFE {
         return subDTypep() ? subDTypep()->basicp() : nullptr;
     }
     AstNodeDType* subDTypep() const override;
-    AstNodeDType* skipRefp() const override {
+    AstNodeDType* skipRefp() const override VL_MT_SAFE {
         // Skip past both the Ref and the Typedef
         if (subDTypep()) {
             return subDTypep()->skipRefp();
@@ -1119,8 +1134,8 @@ public:
     AstNodeDType* virtRefDTypep() const override { return m_refDTypep; }
     void virtRefDTypep(AstNodeDType* nodep) override { refDTypep(nodep); }
     // METHODS
-    AstBasicDType* basicp() const override { return subDTypep()->basicp(); }
-    AstNodeDType* skipRefp() const override { return (AstNodeDType*)this; }
+    AstBasicDType* basicp() const override VL_MT_SAFE { return subDTypep()->basicp(); }
+    AstNodeDType* skipRefp() const override VL_MT_SAFE { return (AstNodeDType*)this; }
     AstNodeDType* skipRefToConstp() const override { return (AstNodeDType*)this; }
     AstNodeDType* skipRefToEnump() const override { return (AstNodeDType*)this; }
     int widthAlignBytes() const override { return subDTypep()->widthAlignBytes(); }
@@ -1143,9 +1158,9 @@ public:
     AstNodeDType* virtRefDTypep() const override { return nullptr; }
     void virtRefDTypep(AstNodeDType* nodep) override {}
     bool similarDType(AstNodeDType* samep) const override { return this == samep; }
-    AstBasicDType* basicp() const override { return nullptr; }
+    AstBasicDType* basicp() const override VL_MT_SAFE { return nullptr; }
     // cppcheck-suppress csyleCast
-    AstNodeDType* skipRefp() const override { return (AstNodeDType*)this; }
+    AstNodeDType* skipRefp() const override VL_MT_SAFE { return (AstNodeDType*)this; }
     // cppcheck-suppress csyleCast
     AstNodeDType* skipRefToConstp() const override { return (AstNodeDType*)this; }
     // cppcheck-suppress csyleCast
@@ -1179,13 +1194,15 @@ public:
     bool similarDType(AstNodeDType* samep) const override;
     void dumpSmall(std::ostream& str) const override;
     AstNodeDType* getChildDTypep() const override { return childDTypep(); }
-    AstNodeDType* subDTypep() const override { return m_refDTypep ? m_refDTypep : childDTypep(); }
+    AstNodeDType* subDTypep() const override VL_MT_SAFE {
+        return m_refDTypep ? m_refDTypep : childDTypep();
+    }
     void refDTypep(AstNodeDType* nodep) { m_refDTypep = nodep; }
     AstNodeDType* virtRefDTypep() const override { return m_refDTypep; }
     void virtRefDTypep(AstNodeDType* nodep) override { refDTypep(nodep); }
     // METHODS
-    AstBasicDType* basicp() const override { return subDTypep()->basicp(); }
-    AstNodeDType* skipRefp() const override { return (AstNodeDType*)this; }
+    AstBasicDType* basicp() const override VL_MT_SAFE { return subDTypep()->basicp(); }
+    AstNodeDType* skipRefp() const override VL_MT_SAFE { return (AstNodeDType*)this; }
     AstNodeDType* skipRefToConstp() const override { return (AstNodeDType*)this; }
     AstNodeDType* skipRefToEnump() const override { return (AstNodeDType*)this; }
     int widthAlignBytes() const override { return sizeof(std::map<std::string, std::string>); }
@@ -1235,7 +1252,7 @@ public:
     // Outer dimension comes first. The first element is this node.
     std::vector<AstUnpackArrayDType*> unpackDimensions();
     void isCompound(bool flag) { m_isCompound = flag; }
-    bool isCompound() const override { return m_isCompound; }
+    bool isCompound() const override VL_MT_SAFE { return m_isCompound; }
 };
 
 // === AstNodeUOrStructDType ===

--- a/src/V3AstNodeMath.h
+++ b/src/V3AstNodeMath.h
@@ -574,10 +574,10 @@ public:
     }
     ASTGEN_MEMBERS_AstConst;
     string name() const override { return num().ascii(); }  // * = Value
-    const V3Number& num() const { return m_num; }  // * = Value
+    const V3Number& num() const VL_MT_SAFE { return m_num; }  // * = Value
     V3Number& num() { return m_num; }  // * = Value
     uint32_t toUInt() const { return num().toUInt(); }
-    int32_t toSInt() const { return num().toSInt(); }
+    int32_t toSInt() const VL_MT_SAFE { return num().toSInt(); }
     uint64_t toUQuad() const { return num().toUQuad(); }
     string emitVerilog() override { V3ERROR_NA_RETURN(""); }
     string emitC() override { V3ERROR_NA_RETURN(""); }

--- a/src/V3AstNodeOther.h
+++ b/src/V3AstNodeOther.h
@@ -236,13 +236,13 @@ public:
     // ACCESSORS
     void name(const string& name) override { m_name = name; }
     string origName() const override { return m_origName; }
-    string someInstanceName() const { return m_someInstanceName; }
+    string someInstanceName() const VL_MT_SAFE { return m_someInstanceName; }
     void someInstanceName(const string& name) { m_someInstanceName = name; }
     bool inLibrary() const { return m_inLibrary; }
     void inLibrary(bool flag) { m_inLibrary = flag; }
     void level(int level) { m_level = level; }
-    int level() const { return m_level; }
-    bool isTop() const { return level() == 1; }
+    int level() const VL_MT_SAFE { return m_level; }
+    bool isTop() const VL_MT_SAFE { return level() == 1; }
     void modPublic(bool flag) { m_modPublic = flag; }
     bool modPublic() const { return m_modPublic; }
     void modTrace(bool flag) { m_modTrace = flag; }
@@ -574,7 +574,7 @@ public:
         const AstNodeText* asamep = static_cast<const AstNodeText*>(samep);
         return text() == asamep->text();
     }
-    const string& text() const { return m_text; }
+    const string& text() const VL_MT_SAFE { return m_text; }
     void text(const string& value) { m_text = value; }
 };
 class AstNodeSimpleText VL_NOT_FINAL : public AstNodeText {
@@ -758,7 +758,7 @@ public:
     void isConst(VBoolOrUnknown flag) { m_isConst = flag; }
     bool isStatic() const { return m_isStatic; }
     void isStatic(bool flag) { m_isStatic = flag; }
-    bool isTrace() const { return m_isTrace; }
+    bool isTrace() const VL_MT_SAFE { return m_isTrace; }
     void isTrace(bool flag) { m_isTrace = flag; }
     void cname(const string& name) { m_cname = name; }
     string cname() const { return m_cname; }
@@ -771,7 +771,7 @@ public:
     bool dontInline() const { return dontCombine() || slow() || funcPublic(); }
     bool declPrivate() const { return m_declPrivate; }
     void declPrivate(bool flag) { m_declPrivate = flag; }
-    bool slow() const { return m_slow; }
+    bool slow() const VL_MT_SAFE { return m_slow; }
     void slow(bool flag) { m_slow = flag; }
     bool funcPublic() const { return m_funcPublic; }
     void funcPublic(bool flag) { m_funcPublic = flag; }
@@ -800,11 +800,11 @@ public:
     void pure(bool flag) { m_pure = flag; }
     bool dpiContext() const { return m_dpiContext; }
     void dpiContext(bool flag) { m_dpiContext = flag; }
-    bool dpiExportDispatcher() const { return m_dpiExportDispatcher; }
+    bool dpiExportDispatcher() const VL_MT_SAFE { return m_dpiExportDispatcher; }
     void dpiExportDispatcher(bool flag) { m_dpiExportDispatcher = flag; }
     bool dpiExportImpl() const { return m_dpiExportImpl; }
     void dpiExportImpl(bool flag) { m_dpiExportImpl = flag; }
-    bool dpiImportPrototype() const { return m_dpiImportPrototype; }
+    bool dpiImportPrototype() const VL_MT_SAFE { return m_dpiImportPrototype; }
     void dpiImportPrototype(bool flag) { m_dpiImportPrototype = flag; }
     bool dpiImportWrapper() const { return m_dpiImportWrapper; }
     void dpiImportWrapper(bool flag) { m_dpiImportWrapper = flag; }
@@ -1712,9 +1712,9 @@ public:
     string nameVlSym() const { return ((string("vlSymsp->")) + nameDotless()); }
     AstNodeModule* modp() const { return m_modp; }
     //
-    AstScope* aboveScopep() const { return m_aboveScopep; }
+    AstScope* aboveScopep() const VL_MT_SAFE { return m_aboveScopep; }
     AstCell* aboveCellp() const { return m_aboveCellp; }
-    bool isTop() const { return aboveScopep() == nullptr; }  // At top of hierarchy
+    bool isTop() const VL_MT_SAFE { return aboveScopep() == nullptr; }  // At top of hierarchy
     // Create new MODULETEMP variable under this scope
     AstVarScope* createTemp(const string& name, unsigned width);
     AstVarScope* createTemp(const string& name, AstNodeDType* dtypep);
@@ -2132,18 +2132,18 @@ public:
     }
     ASTGEN_MEMBERS_AstVar;
     void dump(std::ostream& str) const override;
-    string name() const override { return m_name; }  // * = Var name
+    string name() const override VL_MT_SAFE { return m_name; }  // * = Var name
     bool hasDType() const override { return true; }
     bool maybePointedTo() const override { return true; }
     string origName() const override { return m_origName; }  // * = Original name
     void origName(const string& name) { m_origName = name; }
-    VVarType varType() const { return m_varType; }  // * = Type of variable
+    VVarType varType() const VL_MT_SAFE { return m_varType; }  // * = Type of variable
     void direction(const VDirection& flag) {
         m_direction = flag;
         if (m_direction == VDirection::INOUT) m_tristate = true;
     }
-    VDirection direction() const { return m_direction; }
-    bool isIO() const { return m_direction != VDirection::NONE; }
+    VDirection direction() const VL_MT_SAFE { return m_direction; }
+    bool isIO() const VL_MT_SAFE { return m_direction != VDirection::NONE; }
     void declDirection(const VDirection& flag) { m_declDirection = flag; }
     VDirection declDirection() const { return m_declDirection; }
     void varType(VVarType type) { m_varType = type; }
@@ -2163,17 +2163,19 @@ public:
     string dpiTmpVarType(const string& varName) const;
     // Return Verilator internal type for argument: CData, SData, IData, WData
     string vlArgType(bool named, bool forReturn, bool forFunc, const string& namespc = "",
-                     bool asRef = false) const;
+                     bool asRef = false) const VL_MT_SAFE;
     string vlEnumType() const;  // Return VerilatorVarType: VLVT_UINT32, etc
     string vlEnumDir() const;  // Return VerilatorVarDir: VLVD_INOUT, etc
     string vlPropDecl(const string& propName) const;  // Return VerilatorVarProps declaration
     void combineType(VVarType type);
     AstNodeDType* getChildDTypep() const override { return childDTypep(); }
-    AstNodeDType* dtypeSkipRefp() const { return subDTypep()->skipRefp(); }
+    AstNodeDType* dtypeSkipRefp() const VL_MT_SAFE { return subDTypep()->skipRefp(); }
     // (Slow) recurse down to find basic data type (Note don't need virtual -
     // AstVar isn't a NodeDType)
-    AstBasicDType* basicp() const { return subDTypep()->basicp(); }
-    virtual AstNodeDType* subDTypep() const { return dtypep() ? dtypep() : childDTypep(); }
+    AstBasicDType* basicp() const VL_MT_SAFE { return subDTypep()->basicp(); }
+    virtual AstNodeDType* subDTypep() const VL_MT_SAFE {
+        return dtypep() ? dtypep() : childDTypep();
+    }
     void ansi(bool flag) { m_ansi = flag; }
     void declTyped(bool flag) { m_declTyped = flag; }
     void attrClocker(VVarAttrClocker flag) { m_attrClocker = flag; }
@@ -2209,7 +2211,7 @@ public:
     void hasStrengthAssignment(bool flag) { m_hasStrengthAssignment = flag; }
     bool hasStrengthAssignment() { return m_hasStrengthAssignment; }
     void isDpiOpenArray(bool flag) { m_isDpiOpenArray = flag; }
-    bool isDpiOpenArray() const { return m_isDpiOpenArray; }
+    bool isDpiOpenArray() const VL_MT_SAFE { return m_isDpiOpenArray; }
     bool isHideLocal() const { return m_isHideLocal; }
     void isHideLocal(bool flag) { m_isHideLocal = flag; }
     bool isHideProtected() const { return m_isHideProtected; }
@@ -2238,8 +2240,8 @@ public:
     bool isDeclTyped() const { return m_declTyped; }
     bool isInoutish() const { return m_direction.isInoutish(); }
     bool isNonOutput() const { return m_direction.isNonOutput(); }
-    bool isReadOnly() const { return m_direction.isReadOnly(); }
-    bool isWritable() const { return m_direction.isWritable(); }
+    bool isReadOnly() const VL_MT_SAFE { return m_direction.isReadOnly(); }
+    bool isWritable() const VL_MT_SAFE { return m_direction.isWritable(); }
     bool isTristate() const { return m_tristate; }
     bool isPrimaryIO() const { return m_primaryIO; }
     bool isPrimaryInish() const { return isPrimaryIO() && isNonOutput(); }
@@ -2257,7 +2259,7 @@ public:
     bool isClassMember() const { return varType() == VVarType::MEMBER; }
     bool isStatementTemp() const { return (varType() == VVarType::STMTTEMP); }
     bool isXTemp() const { return (varType() == VVarType::XTEMP); }
-    bool isParam() const {
+    bool isParam() const VL_MT_SAFE {
         return (varType() == VVarType::LPARAM || varType() == VVarType::GPARAM);
     }
     bool isGParam() const { return (varType() == VVarType::GPARAM); }
@@ -2269,7 +2271,7 @@ public:
     bool isUsedClock() const { return m_usedClock; }
     bool isUsedParam() const { return m_usedParam; }
     bool isUsedLoopIdx() const { return m_usedLoopIdx; }
-    bool isSc() const { return m_sc; }
+    bool isSc() const VL_MT_SAFE { return m_sc; }
     bool isScQuad() const;
     bool isScBv() const;
     bool isScUint() const;
@@ -2281,8 +2283,8 @@ public:
     bool isSigUserRWPublic() const { return m_sigUserRWPublic; }
     bool isTrace() const { return m_trace; }
     bool isRand() const { return m_isRand; }
-    bool isConst() const { return m_isConst; }
-    bool isStatic() const { return m_isStatic; }
+    bool isConst() const VL_MT_SAFE { return m_isConst; }
+    bool isStatic() const VL_MT_SAFE { return m_isStatic; }
     bool isLatched() const { return m_isLatched; }
     bool isFuncLocal() const { return m_funcLocal; }
     bool isFuncReturn() const { return m_funcReturn; }
@@ -2456,7 +2458,7 @@ public:
     bool source() const { return m_source; }
     void source(bool flag) { m_source = flag; }
     bool support() const { return m_support; }
-    void support(bool flag) { m_support = flag; }
+    void support(bool flag) VL_MT_SAFE { m_support = flag; }
 };
 class AstVFile final : public AstNodeFile {
     // Verilog output file
@@ -2490,7 +2492,7 @@ public:
     const char* broken() const override;
     void cloneRelink() override;
     bool timescaleMatters() const override { return false; }
-    AstClassPackage* classOrPackagep() const { return m_classOrPackagep; }
+    AstClassPackage* classOrPackagep() const VL_MT_SAFE { return m_classOrPackagep; }
     void classOrPackagep(AstClassPackage* classpackagep) { m_classOrPackagep = classpackagep; }
     AstNode* membersp() const { return stmtsp(); }
     void addMembersp(AstNode* nodep) {
@@ -2523,7 +2525,7 @@ public:
     const char* broken() const override;
     void cloneRelink() override;
     bool timescaleMatters() const override { return false; }
-    AstClass* classp() const { return m_classp; }
+    AstClass* classp() const VL_MT_SAFE { return m_classp; }
     void classp(AstClass* classp) { m_classp = classp; }
 };
 class AstIface final : public AstNodeModule {
@@ -2716,19 +2718,19 @@ public:
     inline AstRange(FileLine* fl, int left, int right);
     inline AstRange(FileLine* fl, const VNumRange& range);
     ASTGEN_MEMBERS_AstRange;
-    inline int leftConst() const;
-    inline int rightConst() const;
-    int hiConst() const {
+    inline int leftConst() const VL_MT_SAFE;
+    inline int rightConst() const VL_MT_SAFE;
+    int hiConst() const VL_MT_SAFE {
         const int l = leftConst();
         const int r = rightConst();
         return l > r ? l : r;
     }
-    int loConst() const {
+    int loConst() const VL_MT_SAFE {
         const int l = leftConst();
         const int r = rightConst();
         return l > r ? r : l;
     }
-    int elementsConst() const { return hiConst() - loConst() + 1; }
+    int elementsConst() const VL_MT_SAFE { return hiConst() - loConst() + 1; }
     bool littleEndian() const { return leftConst() < rightConst(); }
     void dump(std::ostream& str) const override;
     virtual string emitC() { V3ERROR_NA_RETURN(""); }

--- a/src/V3AstNodes.cpp
+++ b/src/V3AstNodes.cpp
@@ -379,7 +379,7 @@ string AstVar::verilogKwd() const {
 }
 
 string AstVar::vlArgType(bool named, bool forReturn, bool forFunc, const string& namespc,
-                         bool asRef) const {
+                         bool asRef) const VL_MT_SAFE {
     UASSERT_OBJ(!forReturn, this,
                 "Internal data is never passed as return, but as first argument");
     string ostatic;
@@ -679,7 +679,7 @@ class AstNodeDType::CTypeRecursed final {
 public:
     string m_type;  // The base type, e.g.: "Foo_t"s
     string m_dims;  // Array dimensions, e.g.: "[3][2][1]"
-    string render(const string& name, bool isRef) const {
+    string render(const string& name, bool isRef) const VL_MT_SAFE {
         string out;
         out += m_type;
         if (!name.empty()) out += " ";
@@ -696,7 +696,7 @@ public:
     }
 };
 
-string AstNodeDType::cType(const string& name, bool /*forFunc*/, bool isRef) const {
+string AstNodeDType::cType(const string& name, bool /*forFunc*/, bool isRef) const VL_MT_SAFE {
     const CTypeRecursed info = cTypeRecurse(false);
     return info.render(name, isRef);
 }
@@ -828,7 +828,7 @@ int AstNodeDType::widthPow2() const {
     return 1;
 }
 
-bool AstNodeDType::isLiteralType() const {
+bool AstNodeDType::isLiteralType() const VL_MT_SAFE {
     if (const auto* const dtypep = VN_CAST(skipRefp(), BasicDType)) {
         return dtypep->keyword().isLiteralType();
     } else if (const auto* const dtypep = VN_CAST(skipRefp(), UnpackArrayDType)) {

--- a/src/V3Broken.cpp
+++ b/src/V3Broken.cpp
@@ -51,7 +51,7 @@ static class BrokenCntGlobal {
     uint8_t m_count = MIN_VALUE;
 
 public:
-    uint8_t get() const {
+    uint8_t get() const VL_MT_SAFE {
         UASSERT(MIN_VALUE <= m_count && m_count <= MAX_VALUE, "Invalid generation number");
         return m_count;
     }

--- a/src/V3EmitCBase.h
+++ b/src/V3EmitCBase.h
@@ -54,7 +54,7 @@ public:
     V3OutCFile* m_ofp = nullptr;
     bool m_trackText = false;  // Always track AstText nodes
     // METHODS
-    V3OutCFile* ofp() const { return m_ofp; }
+    V3OutCFile* ofp() const VL_MT_SAFE { return m_ofp; }
     void puts(const string& str) { ofp()->puts(str); }
     void putbs(const string& str) { ofp()->putbs(str); }
     void putsDecoration(const string& str) {

--- a/src/V3Error.h
+++ b/src/V3Error.h
@@ -160,8 +160,8 @@ public:
     explicit V3ErrorCode(const char* msgp);  // Matching code or ERROR
     explicit V3ErrorCode(int _e)
         : m_e(static_cast<en>(_e)) {}  // Need () or GCC 4.8 false warning
-    constexpr operator en() const { return m_e; }
-    const char* ascii() const {
+    constexpr operator en() const VL_MT_SAFE { return m_e; }
+    const char* ascii() const VL_MT_SAFE {
         // clang-format off
         static const char* const names[] = {
             // Leading spaces indicate it can't be disabled.
@@ -197,25 +197,25 @@ public:
         return names[m_e];
     }
     // Warnings that default to off
-    bool defaultsOff() const {
+    bool defaultsOff() const VL_MT_SAFE {
         return (m_e == IMPERFECTSCH || m_e == I_CELLDEFINE || styleError());
     }
     // Warnings that warn about nasty side effects
-    bool dangerous() const { return (m_e == COMBDLY); }
+    bool dangerous() const VL_MT_SAFE { return (m_e == COMBDLY); }
     // Warnings we'll present to the user as errors
     // Later -Werror- options may make more of these.
-    bool pretendError() const {
+    bool pretendError() const VL_MT_SAFE {
         return (m_e == ASSIGNIN || m_e == BADSTDPRAGMA || m_e == BLKANDNBLK || m_e == BLKLOOPINIT
                 || m_e == CONTASSREG || m_e == IMPURE || m_e == PINNOTFOUND || m_e == PKGNODECL
                 || m_e == PROCASSWIRE  // Says IEEE
                 || m_e == ZERODLY);
     }
     // Warnings to mention manual
-    bool mentionManual() const {
+    bool mentionManual() const VL_MT_SAFE {
         return (m_e == EC_FATALSRC || m_e == SYMRSVDWORD || pretendError());
     }
     // Warnings that are lint only
-    bool lintError() const {
+    bool lintError() const VL_MT_SAFE {
         return (m_e == ALWCOMBORDER || m_e == BSSPACE || m_e == CASEINCOMPLETE
                 || m_e == CASEOVERLAP || m_e == CASEWITHX || m_e == CASEX || m_e == CASTCONST
                 || m_e == CMPCONST || m_e == COLONPLUS || m_e == ENDLABEL || m_e == IMPLICIT
@@ -223,7 +223,7 @@ public:
                 || m_e == UNSIGNED || m_e == WIDTH);
     }
     // Warnings that are style only
-    bool styleError() const {
+    bool styleError() const VL_MT_SAFE {
         return (m_e == ASSIGNDLY  // More than style, but for backward compatibility
                 || m_e == BLKSEQ || m_e == DEFPARAM || m_e == DECLFILENAME || m_e == EOFNEWLINE
                 || m_e == IMPORTSTAR || m_e == INCABSPATH || m_e == PINCONNECTEMPTY
@@ -232,7 +232,7 @@ public:
                 || m_e == VARHIDDEN);
     }
     // Warnings that are unused only
-    bool unusedError() const {
+    bool unusedError() const VL_MT_SAFE {
         return (m_e == UNUSEDGENVAR || m_e == UNUSEDPARAM || m_e == UNUSEDSIGNAL);
     }
     static bool unusedMsg(const char* msgp) { return 0 == VL_STRCASECMP(msgp, "UNUSED"); }
@@ -285,15 +285,15 @@ public:
     // CONSTRUCTORS
     // ACCESSORS
     static void debugDefault(int level) { s_debugDefault = level; }
-    static int debugDefault() { return s_debugDefault; }
+    static int debugDefault() VL_MT_SAFE { return s_debugDefault; }
     static void errorLimit(int level) { s_errorLimit = level; }
-    static int errorLimit() { return s_errorLimit; }
+    static int errorLimit() VL_MT_SAFE { return s_errorLimit; }
     static void warnFatal(bool flag) { s_warnFatal = flag; }
     static bool warnFatal() { return s_warnFatal; }
     static string msgPrefix();  // returns %Error/%Warn
-    static int errorCount() { return s_errCount; }
+    static int errorCount() VL_MT_SAFE { return s_errCount; }
     static int warnCount() { return s_warnCount; }
-    static bool errorContexted() { return s_errorContexted; }
+    static bool errorContexted() VL_MT_SAFE { return s_errorContexted; }
     static void errorContexted(bool flag) { s_errorContexted = flag; }
     // METHODS
     static void incErrors();
@@ -307,7 +307,7 @@ public:
     static void pretendError(V3ErrorCode code, bool flag) { s_pretendError[code] = flag; }
     static bool isError(V3ErrorCode code, bool supp);
     static string lineStr(const char* filename, int lineno);
-    static V3ErrorCode errorCode() { return s_errorCode; }
+    static V3ErrorCode errorCode() VL_MT_SAFE { return s_errorCode; }
     static void errorExitCb(ErrorExitCb cb) { s_errorExitCb = cb; }
 
     // When printing an error/warning, print prefix for multiline message

--- a/src/V3FileLine.cpp
+++ b/src/V3FileLine.cpp
@@ -155,7 +155,7 @@ void VFileContent::pushText(const string& text) {
     m_lines.emplace_back(string(leftover, line_start));  // Might be ""
 }
 
-string VFileContent::getLine(int lineno) const {
+string VFileContent::getLine(int lineno) const VL_MT_SAFE {
     // Return error text rather than asserting so the user isn't left without a message
     // cppcheck-suppress negativeContainerIndex
     if (VL_UNCOVERABLE(lineno < 0 || lineno >= (int)m_lines.size())) {
@@ -284,7 +284,7 @@ FileLine* FileLine::copyOrSameFileLine() {
     return newp;
 }
 
-string FileLine::filebasename() const {
+string FileLine::filebasename() const VL_MT_SAFE {
     string name = filename();
     string::size_type pos;
     if ((pos = name.rfind('/')) != string::npos) name.erase(0, pos + 1);
@@ -298,7 +298,7 @@ string FileLine::filebasenameNoExt() const {
     return name;
 }
 
-string FileLine::firstColumnLetters() const {
+string FileLine::firstColumnLetters() const VL_MT_SAFE {
     const char a = ((firstColumn() / 26) % 26) + 'a';
     const char b = (firstColumn() % 26) + 'a';
     return string(1, a) + string(1, b);
@@ -322,7 +322,7 @@ string FileLine::asciiLineCol() const {
             + "-" + cvtToStr(lastColumn()) + "[" + (m_contentp ? m_contentp->ascii() : "ct0") + "+"
             + cvtToStr(m_contentLineno) + "]");
 }
-string FileLine::ascii() const {
+string FileLine::ascii() const VL_MT_SAFE {
     // For most errors especially in the parser the lastLineno is more accurate than firstLineno
     return filename() + ":" + cvtToStr(lastLineno()) + ":" + cvtToStr(firstColumn());
 }
@@ -369,7 +369,7 @@ void FileLine::warnUnusedOff(bool flag) {
     warnOff(V3ErrorCode::UNUSEDSIGNAL, flag);
 }
 
-bool FileLine::warnIsOff(V3ErrorCode code) const {
+bool FileLine::warnIsOff(V3ErrorCode code) const VL_MT_SAFE {
     if (!msgEn().test(code)) return true;
     if (!defaultFileLine().msgEn().test(code)) return true;  // Global overrides local
     if ((code.lintError() || code.styleError()) && !msgEn().test(V3ErrorCode::I_LINT)) {
@@ -406,7 +406,7 @@ string FileLine::warnMore() const {
         return V3Error::warnMore();
     }
 }
-string FileLine::warnOther() const {
+string FileLine::warnOther() const VL_MT_SAFE {
     if (lastLineno()) {
         return V3Error::warnMore() + ascii() + ": ";
     } else {
@@ -414,7 +414,7 @@ string FileLine::warnOther() const {
     }
 }
 
-string FileLine::source() const {
+string FileLine::source() const VL_MT_SAFE {
     if (VL_UNCOVERABLE(!m_contentp)) {  // LCOV_EXCL_START
         if (debug() || v3Global.opt.debugCheck()) {
             // The newline here is to work around the " <line#> | "
@@ -425,7 +425,7 @@ string FileLine::source() const {
     }  // LCOV_EXCL_STOP
     return m_contentp->getLine(m_contentLineno);
 }
-string FileLine::prettySource() const {
+string FileLine::prettySource() const VL_MT_SAFE {
     string out = source();
     // Drop ignore trailing newline
     const string::size_type pos = out.find('\n');
@@ -434,7 +434,7 @@ string FileLine::prettySource() const {
     return VString::spaceUnprintable(out);
 }
 
-string FileLine::warnContext(bool secondary) const {
+string FileLine::warnContext(bool secondary) const VL_MT_SAFE {
     V3Error::errorContexted(true);
     if (!v3Global.opt.context()) return "";
     string out;

--- a/src/V3FileLine.h
+++ b/src/V3FileLine.h
@@ -86,7 +86,9 @@ class FileLineSingleton final {
     // Return index to intersection set
     msgEnSetIdx_t msgEnAnd(msgEnSetIdx_t lhsIdx, msgEnSetIdx_t rhsIdx);
     // Retrieve interned bitset at given interned index. The returned reference is not persistent.
-    const MsgEnBitSet& msgEn(msgEnSetIdx_t idx) const { return m_internedMsgEns.at(idx); }
+    const MsgEnBitSet& msgEn(msgEnSetIdx_t idx) const VL_MT_SAFE {
+        return m_internedMsgEns.at(idx);
+    }
 };
 
 // All source lines from a file/stream, to enable errors to show sources
@@ -110,7 +112,7 @@ class VFileContent final {
 
 public:
     void pushText(const string& text);  // Add arbitrary text (need not be line-by-line)
-    string getLine(int lineno) const;
+    string getLine(int lineno) const VL_MT_SAFE;
     string ascii() const { return "ct" + cvtToStr(m_id); }
 };
 std::ostream& operator<<(std::ostream& os, VFileContent* contentp);
@@ -228,29 +230,31 @@ public:
     }
     // Advance last line/column based on given text
     void forwardToken(const char* textp, size_t size, bool trackLines = true);
-    int firstLineno() const { return m_firstLineno; }
-    int firstColumn() const { return m_firstColumn; }
-    int lastLineno() const { return m_lastLineno; }
-    int lastColumn() const { return m_lastColumn; }
+    int firstLineno() const VL_MT_SAFE { return m_firstLineno; }
+    int firstColumn() const VL_MT_SAFE { return m_firstColumn; }
+    int lastLineno() const VL_MT_SAFE { return m_lastLineno; }
+    int lastColumn() const VL_MT_SAFE { return m_lastColumn; }
     VFileContent* contentp() const { return m_contentp; }
     // If not otherwise more specific, use last lineno for errors etc,
     // as the parser errors etc generally make more sense pointing at the last parse point
-    int lineno() const { return m_lastLineno; }
-    string source() const;
-    string prettySource() const;  // Source, w/stripped unprintables and newlines
-    FileLine* parent() const { return m_parent; }
+    int lineno() const VL_MT_SAFE { return m_lastLineno; }
+    string source() const VL_MT_SAFE;
+    string prettySource() const VL_MT_SAFE;  // Source, w/stripped unprintables and newlines
+    FileLine* parent() const VL_MT_SAFE { return m_parent; }
     V3LangCode language() const { return singleton().numberToLang(filenameno()); }
     string ascii() const;
     string asciiLineCol() const;
-    int filenameno() const { return m_filenameno; }
-    string filename() const { return singleton().numberToName(filenameno()); }
-    bool filenameIsGlobal() const {
+    int filenameno() const VL_MT_SAFE { return m_filenameno; }
+    string filename() const VL_MT_SAFE { return singleton().numberToName(filenameno()); }
+    bool filenameIsGlobal() const VL_MT_SAFE {
         return (filename() == commandLineFilename() || filename() == builtInFilename());
     }
-    string filenameLetters() const { return FileLineSingleton::filenameLetters(filenameno()); }
-    string filebasename() const;
+    string filenameLetters() const VL_MT_SAFE {
+        return FileLineSingleton::filenameLetters(filenameno());
+    }
+    string filebasename() const VL_MT_SAFE;
     string filebasenameNoExt() const;
-    string firstColumnLetters() const;
+    string firstColumnLetters() const VL_MT_SAFE;
     string profileFuncname() const;
     string xmlDetailedLocation() const;
     string lineDirectiveStrg(int enterExit) const;
@@ -281,8 +285,8 @@ public:
 
     // METHODS - Global
     // <command-line> and <built-in> match what GCC outputs
-    static string commandLineFilename() { return "<command-line>"; }
-    static string builtInFilename() { return "<built-in>"; }
+    static string commandLineFilename() VL_MT_SAFE { return "<command-line>"; }
+    static string builtInFilename() VL_MT_SAFE { return "<built-in>"; }
     static void globalWarnLintOff(bool flag) { defaultFileLine().warnLintOff(flag); }
     static void globalWarnStyleOff(bool flag) { defaultFileLine().warnStyleOff(flag); }
     static void globalWarnUnusedOff(bool flag) { defaultFileLine().warnUnusedOff(flag); }
@@ -316,13 +320,13 @@ public:
     string warnMore() const;
     /// When building an error, prefix for printing secondary information
     /// from a different FileLine than the original error
-    string warnOther() const;
+    string warnOther() const VL_MT_SAFE;
     /// When building an error, current location in include etc
     /// If not used in a given error, automatically pasted at end of error
-    string warnContextPrimary() const { return warnContext(false); }
+    string warnContextPrimary() const VL_MT_SAFE { return warnContext(false); }
     /// When building an error, additional location for additional references
     /// Simplified information vs warnContextPrimary() to make dump clearer
-    string warnContextSecondary() const { return warnContext(true); }
+    string warnContextSecondary() const VL_MT_SAFE { return warnContext(true); }
     bool operator==(const FileLine& rhs) const {
         return (m_firstLineno == rhs.m_firstLineno && m_firstColumn == rhs.m_firstColumn
                 && m_lastLineno == rhs.m_lastLineno && m_lastColumn == rhs.m_lastColumn
@@ -345,8 +349,8 @@ public:
     }
 
 private:
-    string warnContext(bool secondary) const;
-    const MsgEnBitSet& msgEn() const { return singleton().msgEn(m_msgEnIdx); }
+    string warnContext(bool secondary) const VL_MT_SAFE;
+    const MsgEnBitSet& msgEn() const VL_MT_SAFE { return singleton().msgEn(m_msgEnIdx); }
 };
 std::ostream& operator<<(std::ostream& os, FileLine* fileline);
 

--- a/src/V3Global.h
+++ b/src/V3Global.h
@@ -127,7 +127,7 @@ public:
     void clear();
     void shutdown();  // Release allocated resorces
     // ACCESSORS (general)
-    AstNetlist* rootp() const { return m_rootp; }
+    AstNetlist* rootp() const VL_MT_SAFE { return m_rootp; }
     VWidthMinUsage widthMinUsage() const { return m_widthMinUsage; }
     bool assertDTypesResolved() const { return m_assertDTypesResolved; }
     bool assertScoped() const { return m_assertScoped; }
@@ -146,7 +146,7 @@ public:
     static string digitsFilename(int number);
     bool needTraceDumper() const { return m_needTraceDumper; }
     void needTraceDumper(bool flag) { m_needTraceDumper = flag; }
-    bool dpi() const { return m_dpi; }
+    bool dpi() const VL_MT_SAFE { return m_dpi; }
     void dpi(bool flag) { m_dpi = flag; }
     bool hasEvents() const { return m_hasEvents; }
     void setHasEvents() { m_hasEvents = true; }
@@ -156,7 +156,7 @@ public:
     void setUsesTiming() { m_usesTiming = true; }
     bool hasForceableSignals() const { return m_hasForceableSignals; }
     void setHasForceableSignals() { m_hasForceableSignals = true; }
-    bool hasSCTextSections() const { return m_hasSCTextSections; }
+    bool hasSCTextSections() const VL_MT_SAFE { return m_hasSCTextSections; }
     void setHasSCTextSections() { m_hasSCTextSections = true; }
     V3HierBlockPlan* hierPlanp() const { return m_hierPlanp; }
     void hierPlanp(V3HierBlockPlan* plan) {

--- a/src/V3Hash.cpp
+++ b/src/V3Hash.cpp
@@ -28,7 +28,7 @@ std::ostream& operator<<(std::ostream& os, const V3Hash& rhs) {
     return os << 'h' << std::hex << std::setw(8) << std::setfill('0') << rhs.value();
 }
 
-std::string V3Hash::toString() const {
+std::string V3Hash::toString() const VL_MT_SAFE {
     std::ostringstream os;
     os << *this;
     return os.str();

--- a/src/V3Hash.h
+++ b/src/V3Hash.h
@@ -17,6 +17,8 @@
 #ifndef VERILATOR_V3HASH_H_
 #define VERILATOR_V3HASH_H_
 
+#include "verilatedos.h"
+
 #include <cstdint>
 #include <string>
 
@@ -45,8 +47,8 @@ public:
     explicit V3Hash(const std::string& val);
 
     // METHODS
-    uint32_t value() const { return m_value; }
-    std::string toString() const;
+    uint32_t value() const VL_MT_SAFE { return m_value; }
+    std::string toString() const VL_MT_SAFE;
 
     // OPERATORS
     // Comparisons

--- a/src/V3LangCode.h
+++ b/src/V3LangCode.h
@@ -48,7 +48,7 @@ public:
                                      "1800-2005", "1800-2009", "1800-2012", "1800-2017"};
         return names[m_e];
     }
-    static V3LangCode mostRecent() { return V3LangCode{L1800_2017}; }
+    static V3LangCode mostRecent() VL_MT_SAFE { return V3LangCode{L1800_2017}; }
     bool systemVerilog() const {
         return m_e == L1800_2005 || m_e == L1800_2009 || m_e == L1800_2012 || m_e == L1800_2017;
     }

--- a/src/V3Number.cpp
+++ b/src/V3Number.cpp
@@ -76,7 +76,7 @@ constexpr int MAX_SPRINTF_DOUBLE_SIZE
 //======================================================================
 // Errors
 
-void V3Number::v3errorEnd(const std::ostringstream& str) const {
+void V3Number::v3errorEnd(const std::ostringstream& str) const VL_MT_SAFE {
     std::ostringstream nsstr;
     nsstr << str.str();
     if (m_nodep) {
@@ -88,7 +88,7 @@ void V3Number::v3errorEnd(const std::ostringstream& str) const {
     }
 }
 
-void V3Number::v3errorEndFatal(const std::ostringstream& str) const {
+void V3Number::v3errorEndFatal(const std::ostringstream& str) const VL_MT_SAFE {
     v3errorEnd(str);
     assert(0);  // LCOV_EXCL_LINE
     VL_UNREACHABLE;
@@ -874,7 +874,7 @@ string V3Number::toDecimalU() const {
 //======================================================================
 // ACCESSORS - as numbers
 
-uint32_t V3Number::toUInt() const {
+uint32_t V3Number::toUInt() const VL_MT_SAFE {
     UASSERT(!isFourState(), "toUInt with 4-state " << *this);
     // We allow wide numbers that represent values <= 32 bits
     for (int i = 1; i < words(); ++i) {
@@ -912,7 +912,7 @@ int32_t V3Number::toSInt() const {
     }
 }
 
-uint64_t V3Number::toUQuad() const {
+uint64_t V3Number::toUQuad() const VL_MT_SAFE {
     UASSERT(!isFourState(), "toUQuad with 4-state " << *this);
     // We allow wide numbers that represent values <= 64 bits
     if (isDouble()) return static_cast<uint64_t>(toDouble());

--- a/src/V3Options.cpp
+++ b/src/V3Options.cpp
@@ -395,7 +395,7 @@ void V3Options::addForceInc(const string& filename) { m_forceIncs.push_back(file
 
 void V3Options::addArg(const string& arg) { m_impp->m_allArgs.push_back(arg); }
 
-string V3Options::allArgsString() const {
+string V3Options::allArgsString() const VL_MT_SAFE {
     string out;
     for (const string& i : m_impp->m_allArgs) {
         if (out != "") out += " ";
@@ -1852,29 +1852,29 @@ void V3Options::setDebugMode(int level) {
     cout << "Starting " << version() << endl;
 }
 
-unsigned V3Options::debugLevel(const string& tag) const {
+unsigned V3Options::debugLevel(const string& tag) const VL_MT_SAFE {
     const auto iter = m_debugLevel.find(tag);
     return iter != m_debugLevel.end() ? iter->second : V3Error::debugDefault();
 }
 
-unsigned V3Options::debugSrcLevel(const string& srcfile_path) const {
+unsigned V3Options::debugSrcLevel(const string& srcfile_path) const VL_MT_SAFE {
     // For simplicity, calling functions can just use __FILE__ for srcfile.
     // That means we need to strip the filenames: ../Foo.cpp -> Foo
     return debugLevel(V3Os::filenameNonDirExt(srcfile_path));
 }
 
-unsigned V3Options::dumpLevel(const string& tag) const {
+unsigned V3Options::dumpLevel(const string& tag) const VL_MT_SAFE {
     const auto iter = m_dumpLevel.find(tag);
     return iter != m_dumpLevel.end() ? iter->second : 0;
 }
 
-unsigned V3Options::dumpSrcLevel(const string& srcfile_path) const {
+unsigned V3Options::dumpSrcLevel(const string& srcfile_path) const VL_MT_SAFE {
     // For simplicity, calling functions can just use __FILE__ for srcfile.
     // That means we need to strip the filenames: ../Foo.cpp -> Foo
     return dumpLevel(V3Os::filenameNonDirExt(srcfile_path));
 }
 
-bool V3Options::dumpTreeAddrids() const {
+bool V3Options::dumpTreeAddrids() const VL_MT_SAFE {
     static int level = -1;
     if (VL_UNLIKELY(level < 0)) {
         const unsigned value = dumpLevel("tree-addrids");

--- a/src/V3Options.h
+++ b/src/V3Options.h
@@ -146,7 +146,7 @@ public:
         static const char* const names[] = {"VerilatedVcd", "VerilatedFst"};
         return names[m_e];
     }
-    string sourceName() const {
+    string sourceName() const VL_MT_SAFE {
         static const char* const names[] = {"verilated_vcd", "verilated_fst"};
         return names[m_e];
     }
@@ -401,10 +401,10 @@ public:
     V3Options();
     ~V3Options();
     void setDebugMode(int level);
-    unsigned debugLevel(const string& tag) const;
-    unsigned debugSrcLevel(const string& srcfile_path) const;
-    unsigned dumpLevel(const string& tag) const;
-    unsigned dumpSrcLevel(const string& srcfile_path) const;
+    unsigned debugLevel(const string& tag) const VL_MT_SAFE;
+    unsigned debugSrcLevel(const string& srcfile_path) const VL_MT_SAFE;
+    unsigned dumpLevel(const string& tag) const VL_MT_SAFE;
+    unsigned dumpSrcLevel(const string& srcfile_path) const VL_MT_SAFE;
 
     // METHODS
     void addCppFile(const string& filename);
@@ -416,7 +416,7 @@ public:
     void addNoClocker(const string& signame);
     void addVFile(const string& filename);
     void addForceInc(const string& filename);
-    bool available() const { return m_available; }
+    bool available() const VL_MT_SAFE { return m_available; }
     void ccSet();
     void notify();
 
@@ -426,8 +426,8 @@ public:
     bool preprocNoLine() const { return m_preprocNoLine; }
     bool underlineZero() const { return m_underlineZero; }
     string flags() const { return m_flags; }
-    bool systemC() const { return m_systemC; }
-    bool savable() const { return m_savable; }
+    bool systemC() const VL_MT_SAFE { return m_systemC; }
+    bool savable() const VL_MT_SAFE { return m_savable; }
     bool stats() const { return m_stats; }
     bool statsVars() const { return m_statsVars; }
     bool structsPacked() const { return m_structsPacked; }
@@ -440,23 +440,25 @@ public:
     void buildDepBin(const string& flag) { m_buildDepBin = flag; }
     bool cdc() const { return m_cdc; }
     bool cmake() const { return m_cmake; }
-    bool context() const { return m_context; }
-    bool coverage() const { return m_coverageLine || m_coverageToggle || m_coverageUser; }
+    bool context() const VL_MT_SAFE { return m_context; }
+    bool coverage() const VL_MT_SAFE {
+        return m_coverageLine || m_coverageToggle || m_coverageUser;
+    }
     bool coverageLine() const { return m_coverageLine; }
     bool coverageToggle() const { return m_coverageToggle; }
     bool coverageUnderscore() const { return m_coverageUnderscore; }
     bool coverageUser() const { return m_coverageUser; }
-    bool debugCheck() const { return m_debugCheck; }
+    bool debugCheck() const VL_MT_SAFE { return m_debugCheck; }
     bool debugCollision() const { return m_debugCollision; }
-    bool debugEmitV() const { return m_debugEmitV; }
+    bool debugEmitV() const VL_MT_SAFE { return m_debugEmitV; }
     bool debugExitParse() const { return m_debugExitParse; }
     bool debugExitUvm() const { return m_debugExitUvm; }
     bool debugLeak() const { return m_debugLeak; }
     bool debugNondeterminism() const { return m_debugNondeterminism; }
     bool debugPartition() const { return m_debugPartition; }
-    bool debugProtect() const { return m_debugProtect; }
+    bool debugProtect() const VL_MT_SAFE { return m_debugProtect; }
     bool debugSelfTest() const { return m_debugSelfTest; }
-    bool decoration() const { return m_decoration; }
+    bool decoration() const VL_MT_SAFE { return m_decoration; }
     bool dpiHdrOnly() const { return m_dpiHdrOnly; }
     bool dumpDefines() const { return m_dumpLevel.count("defines") && m_dumpLevel.at("defines"); }
     bool dumpTreeDot() const {
@@ -487,12 +489,12 @@ public:
     bool profExec() const { return m_profExec; }
     bool profPgo() const { return m_profPgo; }
     bool usesProfiler() const { return profExec() || profPgo(); }
-    bool protectIds() const { return m_protectIds; }
+    bool protectIds() const VL_MT_SAFE { return m_protectIds; }
     bool allPublic() const { return m_public; }
     bool publicFlatRW() const { return m_publicFlatRW; }
-    bool lintOnly() const { return m_lintOnly; }
+    bool lintOnly() const VL_MT_SAFE { return m_lintOnly; }
     bool ignc() const { return m_ignc; }
-    bool quietExit() const { return m_quietExit; }
+    bool quietExit() const VL_MT_SAFE { return m_quietExit; }
     bool reportUnoptflat() const { return m_reportUnoptflat; }
     bool verilate() const { return m_verilate; }
     bool vpi() const { return m_vpi; }
@@ -500,10 +502,10 @@ public:
     bool xmlOnly() const { return m_xmlOnly; }
     bool topIfacesSupported() const { return lintOnly() && !hierarchical(); }
 
-    int buildJobs() const { return m_buildJobs; }
+    int buildJobs() const VL_MT_SAFE { return m_buildJobs; }
     int convergeLimit() const { return m_convergeLimit; }
     int coverageMaxWidth() const { return m_coverageMaxWidth; }
-    bool dumpTreeAddrids() const;
+    bool dumpTreeAddrids() const VL_MT_SAFE;
     int expandLimit() const { return m_expandLimit; }
     int gateStmts() const { return m_gateStmts; }
     int ifDepth() const { return m_ifDepth; }
@@ -518,7 +520,7 @@ public:
     int pinsBv() const { return m_pinsBv; }
     int reloopLimit() const { return m_reloopLimit; }
     VOptionBool skipIdentical() const { return m_skipIdentical; }
-    int threads() const { return m_threads; }
+    int threads() const VL_MT_SAFE { return m_threads; }
     int threadsMaxMTasks() const { return m_threadsMaxMTasks; }
     bool mtasks() const { return (m_threads > 1); }
     VTimescale timeDefaultPrec() const { return m_timeDefaultPrec; }
@@ -559,10 +561,10 @@ public:
         }
         return libName;
     }
-    string makeDir() const { return m_makeDir; }
-    string modPrefix() const { return m_modPrefix; }
+    string makeDir() const VL_MT_SAFE { return m_makeDir; }
+    string modPrefix() const VL_MT_SAFE { return m_modPrefix; }
     string pipeFilter() const { return m_pipeFilter; }
-    string prefix() const { return m_prefix; }
+    string prefix() const VL_MT_SAFE { return m_prefix; }
     // Not just called protectKey() to avoid bugs of not using protectKeyDefaulted()
     bool protectKeyProvided() const { return !m_protectKey.empty(); }
     string protectKeyDefaulted();  // Set default key if not set by user
@@ -627,24 +629,24 @@ public:
     string traceClassBase() const { return m_traceFormat.classBase(); }
     string traceClassLang() const { return m_traceFormat.classBase() + (systemC() ? "Sc" : "C"); }
     string traceSourceBase() const { return m_traceFormat.sourceName(); }
-    string traceSourceLang() const {
+    string traceSourceLang() const VL_MT_SAFE {
         return m_traceFormat.sourceName() + (systemC() ? "_sc" : "_c");
     }
 
     bool hierarchical() const { return m_hierarchical; }
     int hierChild() const { return m_hierChild; }
-    bool hierTop() const { return !m_hierChild && !m_hierBlocks.empty(); }
+    bool hierTop() const VL_MT_SAFE { return !m_hierChild && !m_hierBlocks.empty(); }
     const V3HierBlockOptSet& hierBlocks() const { return m_hierBlocks; }
     // Directory to save .tree, .dot, .dat, .vpp for hierarchical block top
     // Returns makeDir() unless top module of hierarchical verilation.
-    string hierTopDataDir() const {
+    string hierTopDataDir() const VL_MT_SAFE {
         return hierTop() ? (makeDir() + '/' + prefix() + "__hier.dir") : makeDir();
     }
 
     // METHODS (from main)
     static string version();
     static string argString(int argc, char** argv);  ///< Return list of arguments as simple string
-    string allArgsString() const;  ///< Return all passed arguments as simple string
+    string allArgsString() const VL_MT_SAFE;  ///< Return all passed arguments as simple string
     // Return options for child hierarchical blocks when forTop==false, otherwise returns args for
     // the top module.
     string allArgsStringForHierBlock(bool forTop) const;

--- a/src/V3Stats.h
+++ b/src/V3Stats.h
@@ -75,13 +75,13 @@ class V3Statistic final {
     bool m_printit = true;  ///< Print the results
 public:
     // METHODS
-    string stage() const { return m_stage; }
-    string name() const { return m_name; }
-    double count() const { return m_count; }
-    bool sumit() const { return m_sumit; }
-    bool perf() const { return m_perf; }
-    bool printit() const { return m_printit; }
-    virtual void dump(std::ofstream& os) const;
+    string stage() const VL_MT_SAFE { return m_stage; }
+    string name() const VL_MT_SAFE { return m_name; }
+    double count() const VL_MT_SAFE { return m_count; }
+    bool sumit() const VL_MT_SAFE { return m_sumit; }
+    bool perf() const VL_MT_SAFE { return m_perf; }
+    bool printit() const VL_MT_SAFE { return m_printit; }
+    virtual void dump(std::ofstream& os) const VL_MT_SAFE;
     void combineWith(V3Statistic* otherp) {
         m_count += otherp->count();
         otherp->m_printit = false;

--- a/src/astgen
+++ b/src/astgen
@@ -924,7 +924,7 @@ def write_ast_macros(filename):
             Ast{t}* cloneTree(bool cloneNext) {{
                 return static_cast<Ast{t}*>(AstNode::cloneTree(cloneNext));
             }}
-            Ast{t}* clonep() const {{ return static_cast<Ast{t}*>(AstNode::clonep()); }}
+            Ast{t}* clonep() const VL_MT_SAFE {{ return static_cast<Ast{t}*>(AstNode::clonep()); }}
             Ast{t}* addNext(Ast{t}* nodep) {{ return static_cast<Ast{t}*>(AstNode::addNext(this, nodep)); }}
             ''',
                       t=node.name)
@@ -945,7 +945,7 @@ def write_ast_macros(filename):
                             "op{n}p()").format(n=n, kind=kind)
                 if monad == "List":
                     emitBlock('''\
-                    Ast{kind}* {name}() const {{ return {retrieve}; }}
+                    Ast{kind}* {name}() const VL_MT_SAFE {{ return {retrieve}; }}
                     void add{Name}(Ast{kind}* nodep) {{ addNOp{n}p(reinterpret_cast<AstNode*>(nodep)); }}
                     ''',
                               kind=kind,
@@ -955,7 +955,7 @@ def write_ast_macros(filename):
                               retrieve=retrieve)
                 elif monad == "Optional":
                     emitBlock('''\
-                    Ast{kind}* {name}() const {{ return {retrieve}; }}
+                    Ast{kind}* {name}() const VL_MT_SAFE {{ return {retrieve}; }}
                     void {name}(Ast{kind}* nodep) {{ setNOp{n}p(reinterpret_cast<AstNode*>(nodep)); }}
                     ''',
                               kind=kind,
@@ -964,7 +964,7 @@ def write_ast_macros(filename):
                               retrieve=retrieve)
                 else:
                     emitBlock('''\
-                    Ast{kind}* {name}() const {{ return {retrieve}; }}
+                    Ast{kind}* {name}() const VL_MT_SAFE {{ return {retrieve}; }}
                     void {name}(Ast{kind}* nodep) {{ setOp{n}p(reinterpret_cast<AstNode*>(nodep)); }}
                     ''',
                               kind=kind,


### PR DESCRIPTION
Related to: https://github.com/verilator/verilator/pull/3608

This PR adds ``VL_MT_SAFE`` annotation to ``const`` functions that are called from ``EmitCImp::main`` and ``EmitCTrace::main``.
