### PR TITLE
Promote MODDUP to error and abort if cell linking caused one

### DIFF
--- a/src/V3Error.h
+++ b/src/V3Error.h
@@ -203,8 +203,8 @@ public:
     // Later -Werror- options may make more of these.
     bool pretendError() const {
         return (m_e == ASSIGNIN || m_e == BADSTDPRAGMA || m_e == BLKANDNBLK || m_e == BLKLOOPINIT
-                || m_e == CONTASSREG || m_e == IMPURE || m_e == PINNOTFOUND || m_e == PKGNODECL
-                || m_e == PROCASSWIRE  // Says IEEE
+                || m_e == CONTASSREG || m_e == IMPURE || m_e == MODDUP || m_e == PINNOTFOUND
+                || m_e == PKGNODECL || m_e == PROCASSWIRE  // Says IEEE
                 || m_e == ZERODLY);
     }
     // Warnings to mention manual

--- a/src/V3Global.cpp
+++ b/src/V3Global.cpp
@@ -77,6 +77,8 @@ void V3Global::readFiles() {
     if (!v3Global.opt.preprocOnly()) {
         // Resolve all modules cells refer to
         V3LinkCells::link(v3Global.rootp(), &filter, &parseSyms);
+        // Abort in case of multiple definitions
+        V3Error::abortIfErrors();
     }
 }
 


### PR DESCRIPTION
Attempt at #3231 and #3666 by dumping MODDUP to error by default and exiting after LinkCells. While this works in the basic case, there are a few problems:
- Explicitly passing `-Wno-MODDUP` turns off the error entirely and we still crash. 
- Explicitly passing `-Wwarn-MODDUP` docks it back to warning and we still crash.

What do you propose we do?

Could change the `v3warn` to `v3error`, but then we loose the MODDUPness:
https://github.com/verilator/verilator/blob/5c65e0cfa1e8e1833e9703243f870e481ab916b5/src/V3LinkCells.cpp#L495-L500

In general it's a bit unfortunate that errors can be demoted or turned off.