### PR TITLE
Add attribute when using clang to VL_MT_SAFE and VL_MT_UNSAFE

### DIFF
--- a/include/verilatedos.h
+++ b/include/verilatedos.h
@@ -163,14 +163,22 @@
 // Comment tag that Function is pure (and thus also VL_MT_SAFE)
 #define VL_PURE
 // Comment tag that function is threadsafe when VL_THREADED
-#define VL_MT_SAFE
+#if defined(__clang__)
+# define VL_MT_SAFE __attribute__((annotate("MT_SAFE")))
+#else
+# define VL_MT_SAFE
+#endif
 // Comment tag that function is threadsafe when VL_THREADED, only
 // during normal operation (post-init)
 #define VL_MT_SAFE_POSTINIT
 // Attribute that function is clang threadsafe and uses given mutex
 #define VL_MT_SAFE_EXCLUDES(mutex) VL_EXCLUDES(mutex)
 // Comment tag that function is not threadsafe when VL_THREADED
-#define VL_MT_UNSAFE
+#if defined(__clang__)
+# define VL_MT_UNSAFE __attribute__((annotate("MT_UNSAFE")))
+#else
+# define VL_MT_UNSAFE
+#endif
 // Comment tag that function is not threadsafe when VL_THREADED,
 // protected to make sure single-caller
 #define VL_MT_UNSAFE_ONE


### PR DESCRIPTION
Related to: https://github.com/verilator/verilator/pull/3681

This PR adds attribute that annotates ``VL_MT_SAFE`` and ``VL_MT_UNSAFE`` functions that later can be read using clang bindings. ``gcc`` produces ``attribute directive ignored`` warning, so I'm only setting it for ``clang``.

Signed-off-by: Kamil Rakoczy <krakoczy@antmicro.com>