### PR TITLE
Always define VL_THREADED

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -549,6 +549,7 @@ if test "$_my_result" = "no" ; then
 Verilator requires a C++11 or newer compiler.]])
 
 fi
+AC_DEFINE([VL_THREADED], [1], [Defined if compiler supports C++11])
 
 # Checks for library functions.
 AC_CHECK_MEMBER([struct stat.st_mtim.tv_nsec],

--- a/src/V3HierBlock.h
+++ b/src/V3HierBlock.h
@@ -21,8 +21,6 @@
 #ifndef VERILATOR_V3HIERBLOCK_H_
 #define VERILATOR_V3HIERBLOCK_H_
 
-#include "verilatedos.h"
-
 #include "V3Global.h"
 
 #include <map>

--- a/src/V3Waiver.cpp
+++ b/src/V3Waiver.cpp
@@ -14,8 +14,6 @@
 //
 //*************************************************************************
 
-#include "verilatedos.h"
-
 #include "V3Waiver.h"
 
 #include "V3File.h"

--- a/src/config_build.h.in
+++ b/src/config_build.h.in
@@ -83,6 +83,7 @@ using std::endl;
 // - If undef, not system-wide, user can set SYSTEMC_INCLUDE.
 #undef HAVE_SYSTEMC
 #undef HAVE_COROUTINES
+#undef VL_THREADED
 
 //**********************************************************************
 //**** OS and compiler specifics


### PR DESCRIPTION
Related to: https://github.com/verilator/verilator/pull/3680

Now configure script requires that compiler have C++11 support.

Signed-off-by: Kamil Rakoczy <krakoczy@antmicro.com>
