### PR TITLE
Disallow delays with `--lib-create`

### DIFF
--- a/docs/guide/exe_verilator.rst
+++ b/docs/guide/exe_verilator.rst
@@ -741,6 +741,8 @@ Summary:
    model has a time resolution that is always compatible with the time
    precision of the upper instantiating module.
 
+   Designs compiled using this option cannot use :vlopt:`--timing` with delays.
+
    See also :vlopt:`--protect-lib`.
 
 .. option:: +libext+<ext>[+<ext>][...]
@@ -1067,6 +1069,8 @@ Summary:
    encrypted RTL (i.e. IEEE P1735).  See :file:`examples/make_protect_lib`
    in the distribution for a demonstration of how to build and use the DPI
    library.
+
+   Designs compiled using this option cannot use :vlopt:`--timing` with delays.
 
 .. option:: --public
 

--- a/docs/guide/verilating.rst
+++ b/docs/guide/verilating.rst
@@ -113,6 +113,8 @@ Hierarchy blocks have some limitations including:
   hierarchical model and pass up into another hierarchical model or the top
   module.
 
+* Delays are not allowed in hierarchy blocks.
+
 But, the following usage is supported:
 
 * Nested hierarchy blocks. A hierarchy block may instantiate other

--- a/src/Verilator.cpp
+++ b/src/Verilator.cpp
@@ -559,6 +559,9 @@ static void process() {
 
     // Output DPI protected library files
     if (!v3Global.opt.libCreate().empty()) {
+        if (v3Global.rootp()->delaySchedulerp()) {
+            v3warn(E_UNSUPPORTED, "Unsupported: --lib-create with --timing and delays");
+        }
         V3ProtectLib::protect();
         V3EmitV::emitvFiles();
         V3EmitC::emitcFiles();


### PR DESCRIPTION
The DPI interface generated using `--lib-create` does not take delays into account. This means the user is unable to handle processes active in between cycles, leading to the error:
```
%Error: Encountered process that should've been resumed at an earlier simulation time. Missed a time slot?
```

This PR prevents the use of `--lib-create` when there are delays in the design.

Signed-off-by: Krzysztof Bieganski <kbieganski@antmicro.com>