### PR TITLE
Add `V3UniqueNames` consistency assertion

### DIFF
--- a/src/V3DfgDfgToAst.cpp
+++ b/src/V3DfgDfgToAst.cpp
@@ -135,7 +135,7 @@ class DfgToAstVisitor final : DfgVisitor {
     std::unordered_map<const DfgVertex*, AstVar*> m_resultVars;
     // Map from an AstVar, to the canonical AstVar that can be substituted for that AstVar
     std::unordered_map<AstVar*, AstVar*> m_canonVars;
-    V3UniqueNames m_tmpNames{"_VdfgTmp"};  // For generating temporary names
+    V3UniqueNames m_tmpNames{"__VdfgTmp"};  // For generating temporary names
 
     // METHODS
 

--- a/src/V3DfgOptimizer.cpp
+++ b/src/V3DfgOptimizer.cpp
@@ -103,7 +103,7 @@ class DataflowExtractVisitor final : public VNVisitor {
         iterateChildrenConst(nodep);
 
         // Replace candidate expressions only reading combinationally driven signals with variables
-        V3UniqueNames names{"_VdfgExtracted__"};
+        V3UniqueNames names{"__VdfgExtracted"};
         for (AstNodeModule* modp = nodep->modulesp(); modp;
              modp = VN_AS(modp->nextp(), NodeModule)) {
             // Only extract from proper modules

--- a/src/V3SenExprBuilder.h
+++ b/src/V3SenExprBuilder.h
@@ -42,9 +42,9 @@ class SenExprBuilder final {
                                                         // has an update statement in m_preUpdates
     std::unordered_set<VNRef<AstNode>> m_hasPostUpdate;  // Likewis for m_postUpdates
 
-    V3UniqueNames m_currNames{"__Vtrigcurr__expression"};  // For generating unique current value
-                                                           // signal names
-    V3UniqueNames m_prevNames{"__Vtrigprev__expression"};  // Likewise for previous values
+    V3UniqueNames m_currNames{"__Vtrigcurrexpr"};  // For generating unique current value
+                                                   // signal names
+    V3UniqueNames m_prevNames{"__Vtrigprevexpr"};  // Likewise for previous values
 
     static bool isSupportedDType(AstNodeDType* dtypep) {
         dtypep = dtypep->skipRefp();

--- a/src/V3String.cpp
+++ b/src/V3String.cpp
@@ -183,6 +183,10 @@ bool VString::startsWith(const string& str, const string& prefix) {
     return str.rfind(prefix, 0) == 0;  // Faster than .find(_) == 0
 }
 
+bool VString::endsWith(const string& str, const string& suffix) {
+    return str.compare(str.length() - suffix.length(), suffix.length(), suffix) == 0;
+}
+
 //######################################################################
 // VHashSha256
 

--- a/src/V3String.h
+++ b/src/V3String.h
@@ -116,6 +116,8 @@ public:
     static string replaceWord(const string& str, const string& from, const string& to);
     // Predicate to check if 'str' starts with 'prefix'
     static bool startsWith(const string& str, const string& prefix);
+    // Predicate to check if 'str' ends with 'suffix'
+    static bool endsWith(const string& str, const string& suffix);
 };
 
 //######################################################################

--- a/src/V3Timing.cpp
+++ b/src/V3Timing.cpp
@@ -108,11 +108,11 @@ private:
     double m_timescaleFactor = 1.0;  // Factor to scale delays by
 
     // Unique names
-    V3UniqueNames m_contAssignVarNames{"__VassignWtmp__"};  // Names for temp AssignW vars
-    V3UniqueNames m_intraValueNames{"__Vintraval__"};  // Intra assign delay value var names
-    V3UniqueNames m_intraIndexNames{"__Vintraidx__"};  // Intra assign delay index var names
-    V3UniqueNames m_intraLsbNames{"__Vintralsb__"};  // Intra assign delay LSB var names
-    V3UniqueNames m_forkNames{"__Vfork__"};  // Fork name generator
+    V3UniqueNames m_contAssignVarNames{"__VassignWtmp"};  // Names for temp AssignW vars
+    V3UniqueNames m_intraValueNames{"__Vintraval"};  // Intra assign delay value var names
+    V3UniqueNames m_intraIndexNames{"__Vintraidx"};  // Intra assign delay index var names
+    V3UniqueNames m_intraLsbNames{"__Vintralsb"};  // Intra assign delay LSB var names
+    V3UniqueNames m_forkNames{"__Vfork"};  // Fork name generator
     V3UniqueNames m_trigSchedNames{"__VtrigSched"};  // Trigger scheduler name generator
 
     // DTypes

--- a/src/V3UniqueNames.h
+++ b/src/V3UniqueNames.h
@@ -33,10 +33,14 @@ class V3UniqueNames final {
     std::unordered_map<std::string, unsigned> m_multiplicity;  // Suffix number for given key
 
 public:
-    V3UniqueNames()
-        : m_prefix{""} {}
+    V3UniqueNames() = default;
     explicit V3UniqueNames(const std::string& prefix)
-        : m_prefix{prefix} {}
+        : m_prefix{prefix} {
+        if (!m_prefix.empty()) {
+            UASSERT(VString::startsWith(m_prefix, "__V"), "Prefix must start with '__V'");
+            UASSERT(!VString::endsWith(m_prefix, "_"), "Prefix must not end with '_'");
+        }
+    }
 
     // Return argument, prepended with the prefix if any, then appended with a unique suffix each
     // time we are called with the same argument.

--- a/test_regress/t/t_timing_debug1.out
+++ b/test_regress/t/t_timing_debug1.out
@@ -17,8 +17,8 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__stl
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__stl
 -V{t#,#}         'stl' region trigger index 0 is active: Internal 'stl' trigger - first iteration
--V{t#,#}         'stl' region trigger index 1 is active: @([hybrid] __VassignWtmp___t.clk1__0)
--V{t#,#}         'stl' region trigger index 2 is active: @([hybrid] __VassignWtmp___t.clk2__0)
+-V{t#,#}         'stl' region trigger index 1 is active: @([hybrid] __VassignWtmp_t.clk1__0)
+-V{t#,#}         'stl' region trigger index 2 is active: @([hybrid] __VassignWtmp_t.clk2__0)
 -V{t#,#}         'stl' region trigger index 3 is active: @([hybrid] t.c1)
 -V{t#,#}+    Vt_timing_debug1___024root___eval_stl
 -V{t#,#}+    Vt_timing_debug1___024root___stl_sequent__TOP__0
@@ -26,9 +26,9 @@
 -V{t#,#}+    Vt_timing_debug1___024root___stl_sequent__TOP__2
 -V{t#,#}+    Vt_timing_debug1___024root___act_comb__TOP__2
 -V{t#,#}+    Vt_timing_debug1___024root___stl_comb__TOP__1
--V{t#,#}+    Vt_timing_debug1___024root____Vfork___h########__0__0
+-V{t#,#}+    Vt_timing_debug1___024root____Vfork_h########__0__0
 -V{t#,#}+    Vt_timing_debug1___024root___stl_comb__TOP__2
--V{t#,#}+    Vt_timing_debug1___024root____Vfork___h########__0__0
+-V{t#,#}+    Vt_timing_debug1___024root____Vfork_h########__0__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__stl
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__stl
 -V{t#,#}         No triggers active
@@ -36,8 +36,8 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 0 is active: @([hybrid] __VassignWtmp___t.clk1__0)
--V{t#,#}         'act' region trigger index 1 is active: @([hybrid] __VassignWtmp___t.clk2__0)
+-V{t#,#}         'act' region trigger index 0 is active: @([hybrid] __VassignWtmp_t.clk1__0)
+-V{t#,#}         'act' region trigger index 1 is active: @([hybrid] __VassignWtmp_t.clk2__0)
 -V{t#,#}         'act' region trigger index 2 is active: @([hybrid] t.c1)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}         Committing processes waiting for @(posedge t.clk1):
@@ -48,9 +48,9 @@
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_sequent__TOP__0
--V{t#,#}+    Vt_timing_debug1___024root____Vfork___h########__0__0
+-V{t#,#}+    Vt_timing_debug1___024root____Vfork_h########__0__0
 -V{t#,#}+    Vt_timing_debug1___024root___act_sequent__TOP__1
--V{t#,#}+    Vt_timing_debug1___024root____Vfork___h########__0__0
+-V{t#,#}+    Vt_timing_debug1___024root____Vfork_h########__0__0
 -V{t#,#}+    Vt_timing_debug1___024root___act_comb__TOP__2
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
@@ -83,12 +83,12 @@
 -V{t#,#}+    Vt_timing_debug1___024root___act_comb__TOP__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 0 is active: @([hybrid] __VassignWtmp___t.clk1__0)
+-V{t#,#}         'act' region trigger index 0 is active: @([hybrid] __VassignWtmp_t.clk1__0)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_sequent__TOP__0
--V{t#,#}+    Vt_timing_debug1___024root____Vfork___h########__0__0
+-V{t#,#}+    Vt_timing_debug1___024root____Vfork_h########__0__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         'act' region trigger index 3 is active: @(posedge t.clk1)
@@ -140,12 +140,12 @@
 -V{t#,#}+    Vt_timing_debug1___024root___act_comb__TOP__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 0 is active: @([hybrid] __VassignWtmp___t.clk1__0)
+-V{t#,#}         'act' region trigger index 0 is active: @([hybrid] __VassignWtmp_t.clk1__0)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_sequent__TOP__0
--V{t#,#}+    Vt_timing_debug1___024root____Vfork___h########__0__0
+-V{t#,#}+    Vt_timing_debug1___024root____Vfork_h########__0__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         No triggers active
@@ -208,12 +208,12 @@
 -V{t#,#}+    Vt_timing_debug1___024root___act_comb__TOP__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 0 is active: @([hybrid] __VassignWtmp___t.clk1__0)
+-V{t#,#}         'act' region trigger index 0 is active: @([hybrid] __VassignWtmp_t.clk1__0)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_sequent__TOP__0
--V{t#,#}+    Vt_timing_debug1___024root____Vfork___h########__0__0
+-V{t#,#}+    Vt_timing_debug1___024root____Vfork_h########__0__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         'act' region trigger index 3 is active: @(posedge t.clk1)
@@ -260,12 +260,12 @@
 -V{t#,#}+    Vt_timing_debug1___024root___act_comb__TOP__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 1 is active: @([hybrid] __VassignWtmp___t.clk2__0)
+-V{t#,#}         'act' region trigger index 1 is active: @([hybrid] __VassignWtmp_t.clk2__0)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_sequent__TOP__1
--V{t#,#}+    Vt_timing_debug1___024root____Vfork___h########__0__0
+-V{t#,#}+    Vt_timing_debug1___024root____Vfork_h########__0__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         'act' region trigger index 5 is active: @(posedge t.clk2)
@@ -324,14 +324,14 @@
 -V{t#,#}+    Vt_timing_debug1___024root___act_comb__TOP__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 0 is active: @([hybrid] __VassignWtmp___t.clk1__0)
+-V{t#,#}         'act' region trigger index 0 is active: @([hybrid] __VassignWtmp_t.clk1__0)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}         Committing processes waiting for @(posedge t.clk2):
 -V{t#,#}           - Process waiting at t/t_timing_sched.v:46
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_sequent__TOP__0
--V{t#,#}+    Vt_timing_debug1___024root____Vfork___h########__0__0
+-V{t#,#}+    Vt_timing_debug1___024root____Vfork_h########__0__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         No triggers active
@@ -392,12 +392,12 @@
 -V{t#,#}+    Vt_timing_debug1___024root___act_comb__TOP__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 0 is active: @([hybrid] __VassignWtmp___t.clk1__0)
+-V{t#,#}         'act' region trigger index 0 is active: @([hybrid] __VassignWtmp_t.clk1__0)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_sequent__TOP__0
--V{t#,#}+    Vt_timing_debug1___024root____Vfork___h########__0__0
+-V{t#,#}+    Vt_timing_debug1___024root____Vfork_h########__0__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         'act' region trigger index 3 is active: @(posedge t.clk1)
@@ -448,12 +448,12 @@
 -V{t#,#}+    Vt_timing_debug1___024root___act_comb__TOP__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 0 is active: @([hybrid] __VassignWtmp___t.clk1__0)
+-V{t#,#}         'act' region trigger index 0 is active: @([hybrid] __VassignWtmp_t.clk1__0)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_sequent__TOP__0
--V{t#,#}+    Vt_timing_debug1___024root____Vfork___h########__0__0
+-V{t#,#}+    Vt_timing_debug1___024root____Vfork_h########__0__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         No triggers active
@@ -514,12 +514,12 @@
 -V{t#,#}+    Vt_timing_debug1___024root___act_comb__TOP__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 0 is active: @([hybrid] __VassignWtmp___t.clk1__0)
+-V{t#,#}         'act' region trigger index 0 is active: @([hybrid] __VassignWtmp_t.clk1__0)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_sequent__TOP__0
--V{t#,#}+    Vt_timing_debug1___024root____Vfork___h########__0__0
+-V{t#,#}+    Vt_timing_debug1___024root____Vfork_h########__0__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         'act' region trigger index 3 is active: @(posedge t.clk1)
@@ -564,12 +564,12 @@
 -V{t#,#}+    Vt_timing_debug1___024root___act_comb__TOP__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 1 is active: @([hybrid] __VassignWtmp___t.clk2__0)
+-V{t#,#}         'act' region trigger index 1 is active: @([hybrid] __VassignWtmp_t.clk2__0)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_sequent__TOP__1
--V{t#,#}+    Vt_timing_debug1___024root____Vfork___h########__0__0
+-V{t#,#}+    Vt_timing_debug1___024root____Vfork_h########__0__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         No triggers active
@@ -600,12 +600,12 @@
 -V{t#,#}+    Vt_timing_debug1___024root___act_comb__TOP__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 0 is active: @([hybrid] __VassignWtmp___t.clk1__0)
+-V{t#,#}         'act' region trigger index 0 is active: @([hybrid] __VassignWtmp_t.clk1__0)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_sequent__TOP__0
--V{t#,#}+    Vt_timing_debug1___024root____Vfork___h########__0__0
+-V{t#,#}+    Vt_timing_debug1___024root____Vfork_h########__0__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         No triggers active
@@ -666,12 +666,12 @@
 -V{t#,#}+    Vt_timing_debug1___024root___act_comb__TOP__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 0 is active: @([hybrid] __VassignWtmp___t.clk1__0)
+-V{t#,#}         'act' region trigger index 0 is active: @([hybrid] __VassignWtmp_t.clk1__0)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_sequent__TOP__0
--V{t#,#}+    Vt_timing_debug1___024root____Vfork___h########__0__0
+-V{t#,#}+    Vt_timing_debug1___024root____Vfork_h########__0__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         'act' region trigger index 3 is active: @(posedge t.clk1)
@@ -716,12 +716,12 @@
 -V{t#,#}+    Vt_timing_debug1___024root___act_comb__TOP__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 0 is active: @([hybrid] __VassignWtmp___t.clk1__0)
+-V{t#,#}         'act' region trigger index 0 is active: @([hybrid] __VassignWtmp_t.clk1__0)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_sequent__TOP__0
--V{t#,#}+    Vt_timing_debug1___024root____Vfork___h########__0__0
+-V{t#,#}+    Vt_timing_debug1___024root____Vfork_h########__0__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         No triggers active
@@ -783,15 +783,15 @@
 -V{t#,#}+    Vt_timing_debug1___024root___act_comb__TOP__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 0 is active: @([hybrid] __VassignWtmp___t.clk1__0)
--V{t#,#}         'act' region trigger index 1 is active: @([hybrid] __VassignWtmp___t.clk2__0)
+-V{t#,#}         'act' region trigger index 0 is active: @([hybrid] __VassignWtmp_t.clk1__0)
+-V{t#,#}         'act' region trigger index 1 is active: @([hybrid] __VassignWtmp_t.clk2__0)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_sequent__TOP__0
--V{t#,#}+    Vt_timing_debug1___024root____Vfork___h########__0__0
+-V{t#,#}+    Vt_timing_debug1___024root____Vfork_h########__0__0
 -V{t#,#}+    Vt_timing_debug1___024root___act_sequent__TOP__1
--V{t#,#}+    Vt_timing_debug1___024root____Vfork___h########__0__0
+-V{t#,#}+    Vt_timing_debug1___024root____Vfork_h########__0__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         'act' region trigger index 3 is active: @(posedge t.clk1)
@@ -886,12 +886,12 @@
 -V{t#,#}+    Vt_timing_debug1___024root___act_comb__TOP__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 0 is active: @([hybrid] __VassignWtmp___t.clk1__0)
+-V{t#,#}         'act' region trigger index 0 is active: @([hybrid] __VassignWtmp_t.clk1__0)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_sequent__TOP__0
--V{t#,#}+    Vt_timing_debug1___024root____Vfork___h########__0__0
+-V{t#,#}+    Vt_timing_debug1___024root____Vfork_h########__0__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         No triggers active
@@ -952,12 +952,12 @@
 -V{t#,#}+    Vt_timing_debug1___024root___act_comb__TOP__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 0 is active: @([hybrid] __VassignWtmp___t.clk1__0)
+-V{t#,#}         'act' region trigger index 0 is active: @([hybrid] __VassignWtmp_t.clk1__0)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_sequent__TOP__0
--V{t#,#}+    Vt_timing_debug1___024root____Vfork___h########__0__0
+-V{t#,#}+    Vt_timing_debug1___024root____Vfork_h########__0__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         'act' region trigger index 3 is active: @(posedge t.clk1)
@@ -1008,12 +1008,12 @@
 -V{t#,#}+    Vt_timing_debug1___024root___act_comb__TOP__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 0 is active: @([hybrid] __VassignWtmp___t.clk1__0)
+-V{t#,#}         'act' region trigger index 0 is active: @([hybrid] __VassignWtmp_t.clk1__0)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_sequent__TOP__0
--V{t#,#}+    Vt_timing_debug1___024root____Vfork___h########__0__0
+-V{t#,#}+    Vt_timing_debug1___024root____Vfork_h########__0__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         No triggers active
@@ -1074,12 +1074,12 @@
 -V{t#,#}+    Vt_timing_debug1___024root___act_comb__TOP__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 1 is active: @([hybrid] __VassignWtmp___t.clk2__0)
+-V{t#,#}         'act' region trigger index 1 is active: @([hybrid] __VassignWtmp_t.clk2__0)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_sequent__TOP__1
--V{t#,#}+    Vt_timing_debug1___024root____Vfork___h########__0__0
+-V{t#,#}+    Vt_timing_debug1___024root____Vfork_h########__0__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         No triggers active
@@ -1109,12 +1109,12 @@
 -V{t#,#}+    Vt_timing_debug1___024root___act_comb__TOP__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 0 is active: @([hybrid] __VassignWtmp___t.clk1__0)
+-V{t#,#}         'act' region trigger index 0 is active: @([hybrid] __VassignWtmp_t.clk1__0)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_sequent__TOP__0
--V{t#,#}+    Vt_timing_debug1___024root____Vfork___h########__0__0
+-V{t#,#}+    Vt_timing_debug1___024root____Vfork_h########__0__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         'act' region trigger index 3 is active: @(posedge t.clk1)
@@ -1159,12 +1159,12 @@
 -V{t#,#}+    Vt_timing_debug1___024root___act_comb__TOP__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 0 is active: @([hybrid] __VassignWtmp___t.clk1__0)
+-V{t#,#}         'act' region trigger index 0 is active: @([hybrid] __VassignWtmp_t.clk1__0)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_sequent__TOP__0
--V{t#,#}+    Vt_timing_debug1___024root____Vfork___h########__0__0
+-V{t#,#}+    Vt_timing_debug1___024root____Vfork_h########__0__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         No triggers active
@@ -1225,12 +1225,12 @@
 -V{t#,#}+    Vt_timing_debug1___024root___act_comb__TOP__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 0 is active: @([hybrid] __VassignWtmp___t.clk1__0)
+-V{t#,#}         'act' region trigger index 0 is active: @([hybrid] __VassignWtmp_t.clk1__0)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_sequent__TOP__0
--V{t#,#}+    Vt_timing_debug1___024root____Vfork___h########__0__0
+-V{t#,#}+    Vt_timing_debug1___024root____Vfork_h########__0__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         'act' region trigger index 3 is active: @(posedge t.clk1)
@@ -1275,12 +1275,12 @@
 -V{t#,#}+    Vt_timing_debug1___024root___act_comb__TOP__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 0 is active: @([hybrid] __VassignWtmp___t.clk1__0)
+-V{t#,#}         'act' region trigger index 0 is active: @([hybrid] __VassignWtmp_t.clk1__0)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_sequent__TOP__0
--V{t#,#}+    Vt_timing_debug1___024root____Vfork___h########__0__0
+-V{t#,#}+    Vt_timing_debug1___024root____Vfork_h########__0__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         No triggers active
@@ -1313,14 +1313,14 @@
 -V{t#,#}+    Vt_timing_debug1___024root___act_comb__TOP__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 1 is active: @([hybrid] __VassignWtmp___t.clk2__0)
+-V{t#,#}         'act' region trigger index 1 is active: @([hybrid] __VassignWtmp_t.clk2__0)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}         Committing processes waiting for @(posedge t.clk1):
 -V{t#,#}           - Process waiting at t/t_timing_sched.v:17
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_sequent__TOP__1
--V{t#,#}+    Vt_timing_debug1___024root____Vfork___h########__0__0
+-V{t#,#}+    Vt_timing_debug1___024root____Vfork_h########__0__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         'act' region trigger index 5 is active: @(posedge t.clk2)
@@ -1406,12 +1406,12 @@
 -V{t#,#}+    Vt_timing_debug1___024root___act_comb__TOP__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 0 is active: @([hybrid] __VassignWtmp___t.clk1__0)
+-V{t#,#}         'act' region trigger index 0 is active: @([hybrid] __VassignWtmp_t.clk1__0)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_sequent__TOP__0
--V{t#,#}+    Vt_timing_debug1___024root____Vfork___h########__0__0
+-V{t#,#}+    Vt_timing_debug1___024root____Vfork_h########__0__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         'act' region trigger index 3 is active: @(posedge t.clk1)
@@ -1462,12 +1462,12 @@
 -V{t#,#}+    Vt_timing_debug1___024root___act_comb__TOP__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 0 is active: @([hybrid] __VassignWtmp___t.clk1__0)
+-V{t#,#}         'act' region trigger index 0 is active: @([hybrid] __VassignWtmp_t.clk1__0)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_sequent__TOP__0
--V{t#,#}+    Vt_timing_debug1___024root____Vfork___h########__0__0
+-V{t#,#}+    Vt_timing_debug1___024root____Vfork_h########__0__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         No triggers active
@@ -1528,12 +1528,12 @@
 -V{t#,#}+    Vt_timing_debug1___024root___act_comb__TOP__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 0 is active: @([hybrid] __VassignWtmp___t.clk1__0)
+-V{t#,#}         'act' region trigger index 0 is active: @([hybrid] __VassignWtmp_t.clk1__0)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_sequent__TOP__0
--V{t#,#}+    Vt_timing_debug1___024root____Vfork___h########__0__0
+-V{t#,#}+    Vt_timing_debug1___024root____Vfork_h########__0__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         'act' region trigger index 3 is active: @(posedge t.clk1)
@@ -1579,15 +1579,15 @@
 -V{t#,#}+    Vt_timing_debug1___024root___act_comb__TOP__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 0 is active: @([hybrid] __VassignWtmp___t.clk1__0)
--V{t#,#}         'act' region trigger index 1 is active: @([hybrid] __VassignWtmp___t.clk2__0)
+-V{t#,#}         'act' region trigger index 0 is active: @([hybrid] __VassignWtmp_t.clk1__0)
+-V{t#,#}         'act' region trigger index 1 is active: @([hybrid] __VassignWtmp_t.clk2__0)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_sequent__TOP__0
--V{t#,#}+    Vt_timing_debug1___024root____Vfork___h########__0__0
+-V{t#,#}+    Vt_timing_debug1___024root____Vfork_h########__0__0
 -V{t#,#}+    Vt_timing_debug1___024root___act_sequent__TOP__1
--V{t#,#}+    Vt_timing_debug1___024root____Vfork___h########__0__0
+-V{t#,#}+    Vt_timing_debug1___024root____Vfork_h########__0__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         No triggers active
@@ -1648,12 +1648,12 @@
 -V{t#,#}+    Vt_timing_debug1___024root___act_comb__TOP__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 0 is active: @([hybrid] __VassignWtmp___t.clk1__0)
+-V{t#,#}         'act' region trigger index 0 is active: @([hybrid] __VassignWtmp_t.clk1__0)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_sequent__TOP__0
--V{t#,#}+    Vt_timing_debug1___024root____Vfork___h########__0__0
+-V{t#,#}+    Vt_timing_debug1___024root____Vfork_h########__0__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         'act' region trigger index 3 is active: @(posedge t.clk1)
@@ -1698,12 +1698,12 @@
 -V{t#,#}+    Vt_timing_debug1___024root___act_comb__TOP__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 0 is active: @([hybrid] __VassignWtmp___t.clk1__0)
+-V{t#,#}         'act' region trigger index 0 is active: @([hybrid] __VassignWtmp_t.clk1__0)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_sequent__TOP__0
--V{t#,#}+    Vt_timing_debug1___024root____Vfork___h########__0__0
+-V{t#,#}+    Vt_timing_debug1___024root____Vfork_h########__0__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         No triggers active
@@ -1764,12 +1764,12 @@
 -V{t#,#}+    Vt_timing_debug1___024root___act_comb__TOP__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 0 is active: @([hybrid] __VassignWtmp___t.clk1__0)
+-V{t#,#}         'act' region trigger index 0 is active: @([hybrid] __VassignWtmp_t.clk1__0)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_sequent__TOP__0
--V{t#,#}+    Vt_timing_debug1___024root____Vfork___h########__0__0
+-V{t#,#}+    Vt_timing_debug1___024root____Vfork_h########__0__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         'act' region trigger index 3 is active: @(posedge t.clk1)
@@ -1814,12 +1814,12 @@
 -V{t#,#}+    Vt_timing_debug1___024root___act_comb__TOP__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 1 is active: @([hybrid] __VassignWtmp___t.clk2__0)
+-V{t#,#}         'act' region trigger index 1 is active: @([hybrid] __VassignWtmp_t.clk2__0)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_sequent__TOP__1
--V{t#,#}+    Vt_timing_debug1___024root____Vfork___h########__0__0
+-V{t#,#}+    Vt_timing_debug1___024root____Vfork_h########__0__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         'act' region trigger index 5 is active: @(posedge t.clk2)
@@ -1880,14 +1880,14 @@
 -V{t#,#}+    Vt_timing_debug1___024root___act_comb__TOP__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 0 is active: @([hybrid] __VassignWtmp___t.clk1__0)
+-V{t#,#}         'act' region trigger index 0 is active: @([hybrid] __VassignWtmp_t.clk1__0)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}         Committing processes waiting for @(posedge t.clk2):
 -V{t#,#}           - Process waiting at t/t_timing_sched.v:46
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_sequent__TOP__0
--V{t#,#}+    Vt_timing_debug1___024root____Vfork___h########__0__0
+-V{t#,#}+    Vt_timing_debug1___024root____Vfork_h########__0__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         No triggers active

--- a/test_regress/t/t_timing_debug2.out
+++ b/test_regress/t/t_timing_debug2.out
@@ -7,12 +7,12 @@
 -V{t#,#}+    Vt_timing_debug2___024root___eval_initial
 -V{t#,#}+    Vt_timing_debug2___024root___eval_initial__TOP__0
 -V{t#,#}             Process forked at t/t_timing_fork_join.v:14 finished
--V{t#,#}+    Vt_timing_debug2___024root____Vfork___h########__0__1
--V{t#,#}+    Vt_timing_debug2___024root____Vfork___h########__0__2
--V{t#,#}+    Vt_timing_debug2___024root____Vfork___h########__0__3
+-V{t#,#}+    Vt_timing_debug2___024root____Vfork_h########__0__1
+-V{t#,#}+    Vt_timing_debug2___024root____Vfork_h########__0__2
+-V{t#,#}+    Vt_timing_debug2___024root____Vfork_h########__0__3
 [0] fork..join process 4
 -V{t#,#}             Process forked at t/t_timing_fork_join.v:18 finished
--V{t#,#}+    Vt_timing_debug2___024root____Vfork___h########__0__5
+-V{t#,#}+    Vt_timing_debug2___024root____Vfork_h########__0__5
 -V{t#,#}             Awaiting join of fork at: t/t_timing_fork_join.v:13
 -V{t#,#}+    Vt_timing_debug2___024root___eval_initial__TOP__1
 -V{t#,#}+    Vt_timing_debug2___024root___eval_initial__TOP__2
@@ -123,9 +123,9 @@
 -V{t#,#}         Resuming delayed processes
 -V{t#,#}             Resuming: Process waiting at t/t_timing_fork_join.v:16
 [16] fork in fork starts
--V{t#,#}+    Vt_timing_debug2___024root____Vfork___h########__0__0
--V{t#,#}+    Vt_timing_debug2___024root____Vfork___h########__0__1
--V{t#,#}+    Vt_timing_debug2___024root____Vfork___h########__0__2
+-V{t#,#}+    Vt_timing_debug2___024root____Vfork_h########__0__0
+-V{t#,#}+    Vt_timing_debug2___024root____Vfork_h########__0__1
+-V{t#,#}+    Vt_timing_debug2___024root____Vfork_h########__0__2
 [16] fork..join process 8
 -V{t#,#}             Process forked at t/t_timing_fork_join.v:25 finished
 -V{t#,#}             Awaiting join of fork at: t/t_timing_fork_join.v:21
@@ -239,7 +239,7 @@
 -V{t#,#}         Resuming delayed processes
 -V{t#,#}             Resuming: Process waiting at t/t_timing_fork_join.v:30
 [64] main process
--V{t#,#}+    Vt_timing_debug2___024root____Vfork___h########__0__0
+-V{t#,#}+    Vt_timing_debug2___024root____Vfork_h########__0__0
 -V{t#,#}         Suspending process waiting for @([event] t.e1) at t/t_timing_fork_join.v:33
 fork..join_any process 2
 -V{t#,#}             Process forked at t/t_timing_fork_join.v:37 finished
@@ -315,8 +315,8 @@ fork..join_any process 1
 -V{t#,#}             Awaiting time 100: Process waiting at t/t_timing_fork_join.v:41
 -V{t#,#}         Resuming delayed processes
 -V{t#,#}             Resuming: Process waiting at t/t_timing_fork_join.v:41
--V{t#,#}+    Vt_timing_debug2___024root____Vfork___h########__0__0
--V{t#,#}+    Vt_timing_debug2___024root____Vfork___h########__0__1
+-V{t#,#}+    Vt_timing_debug2___024root____Vfork_h########__0__0
+-V{t#,#}+    Vt_timing_debug2___024root____Vfork_h########__0__1
 -V{t#,#}         Suspending process waiting for @([event] t.e1) at t/t_timing_fork_join.v:44
 -V{t#,#}             Awaiting join of fork at: t/t_timing_fork_join.v:41
 -V{t#,#}+    Vt_timing_debug2___024root___eval_act
@@ -400,10 +400,10 @@ fork..join_any process 2
 -V{t#,#}           - Process waiting at t/t_timing_fork_join.v:51
 -V{t#,#}         Resuming processes waiting for @([event] t.e1)
 -V{t#,#}             Resuming: Process waiting at t/t_timing_fork_join.v:51
--V{t#,#}+    Vt_timing_debug2___024root____Vfork___h########__0__0
--V{t#,#}+    Vt_timing_debug2___024root____Vfork___h########__0__1
+-V{t#,#}+    Vt_timing_debug2___024root____Vfork_h########__0__0
+-V{t#,#}+    Vt_timing_debug2___024root____Vfork_h########__0__1
 -V{t#,#}         Suspending process waiting for @([event] t.e2) at t/t_timing_fork_join.v:62
--V{t#,#}+    Vt_timing_debug2___024root____Vfork___h########__0__2
+-V{t#,#}+    Vt_timing_debug2___024root____Vfork_h########__0__2
 -V{t#,#}         Suspending process waiting for @([event] t.e3) at t/t_timing_fork_join.v:68
 in main process
 -V{t#,#}         Suspending process waiting for @([event] t.e1) at t/t_timing_fork_join.v:75


### PR DESCRIPTION
This PR simplifies the usage of `V3UniqueNames` and makes it more consistent.

Currently, all instances of `V3UniqueNames` are being initialized with a string like `_V*` or `__V*`. I think it makes sense to integrate it into the class itself.

Signed-off-by: Krzysztof Bieganski <kbieganski@antmicro.com>
