### PR TITLE
use shortName to fix VPI inline module naming mismatch

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -53,6 +53,7 @@ Jamie Iles
 Jan Van Winkel
 Jean Berniolles
 Jeremy Bennett
+Jiuyang Liu
 John Coiner
 John Demme
 Jonathan Drolet

--- a/src/V3EmitCSyms.cpp
+++ b/src/V3EmitCSyms.cpp
@@ -295,7 +295,7 @@ class EmitCSyms final : EmitCBaseVisitor {
         if (v3Global.opt.vpi()) {
             const string type
                 = (nodep->origModName() == "__BEGIN__") ? "SCOPE_OTHER" : "SCOPE_MODULE";
-            const string name = nodep->scopep()->name() + "__DOT__" + nodep->name();
+            const string name = nodep->scopep()->shortName() + "__DOT__" + nodep->name();
             const string name_dedot = AstNode::dedotName(name);
             const int timeunit = m_modp->timeunit().powerOfTen();
             m_vpiScopeCandidates.insert(


### PR DESCRIPTION
This patch fixes #3690, tested on my giant design, kudo @CircuitCoder for helping me figure this out, the f6f13c7fda71cacf1ae61c8901bcd1a395b58a38 failed to get vpi handler with `vpi_handle_by_name`, with this patch, it works fine, wait for CI to get this in.