### PR TITLE
Support timing with more Clang and libc++ versions

### DIFF
--- a/include/verilated_timing.h
+++ b/include/verilated_timing.h
@@ -29,30 +29,27 @@
 
 // clang-format off
 // Some preprocessor magic to support both Clang and GCC coroutines with both libc++ and libstdc++
-#ifdef __clang__
-# if __clang_major__ < 14
-#  ifdef __GLIBCXX__ // Using stdlibc++
-#   define __cpp_impl_coroutine 1  // Clang doesn't define this, but it's needed for libstdc++
-#   include <coroutine>
-    namespace std { // Bring coroutine library into std::experimental, as Clang < 14 expects it to be there
-        namespace experimental {
-            using namespace std;
-        }
-    }
-#  else // Using libc++
-#   include <experimental/coroutine> // Clang older than 14, coroutines are under experimental
-    namespace std {
-        using namespace experimental; // Bring std::experimental into the std namespace
-    }
-#  endif
-# else // Clang >= 14
-#  if __GLIBCXX__ // Using stdlibc++
-#   define __cpp_impl_coroutine 1  // Clang doesn't define this, but it's needed for libstdc++
-#  endif
-#  include <coroutine>
+#if defined _LIBCPP_VERSION  // libc++
+# if __clang_major__ > 13  // Clang > 13 warns that coroutine types in std::experimental are deprecated
+#  pragma clang diagnostic push
+#  pragma clang diagnostic ignored "-Wdeprecated-experimental-coroutine"
 # endif
-#else  // Not Clang
+# include <experimental/coroutine>
+  namespace std {
+      using namespace experimental; // Bring std::experimental into the std namespace
+  }
+#else
+# if defined __clang__ && defined __GLIBCXX__
+#  define __cpp_impl_coroutine 1  // Clang doesn't define this, but it's needed for libstdc++
+# endif
 # include <coroutine>
+# if __clang_major__ < 14
+   namespace std { // Bring coroutine library into std::experimental, as Clang < 14 expects it to be there
+       namespace experimental {
+           using namespace std;
+       }
+   }
+# endif
 #endif
 // clang-format on
 


### PR DESCRIPTION
The previous version of this version check depended on libc++ version being synced with Clang's version. However, that is not always the case, e.g. the default Clang in MacOS Monterey introduces itself as Clang 14, but the `_LIBCPP_VERSION` define is set to 13000.

Another issue is that, on Clang >= 14, if you use coroutines via the `-fcoroutines-ts` flag, you have to include `<experimental/coroutine>`. Including `<coroutine>` results in compilation errors, because its contents are actually hidden behind an `ifdef` that [checks if we're using C++20](https://github.com/llvm/llvm-project/blob/329fda39c507e8740978d10458451dcdb21563be/libcxx/include/__coroutine/coroutine_handle.h#L23). And we're not, by default.

So it's better to just use `<experimental/coroutine>` (and `std::experimental::*`) for Clang with libc++, no matter what Clang's version is.

Note that Clang >= 14 produces a warning that they'll remove `<experimental/coroutine>` in LLVM 15 (hence the disabled warning here), though that hasn't actually happened. I expect that it will happen eventually, so that will be something we'll have to deal with.

Tested on Ubuntu 20.04 with Clang 13, 14, and 15, and on MacOS Monterey with whatever the default version of Clang is (Clang 14 with an asterisk).

Fixes https://github.com/verilator/verilator/issues/3669

Signed-off-by: Krzysztof Bieganski <kbieganski@antmicro.com>
