### PR TITLE
Fix print format warning on some platforms

### DIFF
--- a/include/verilated_timing.cpp
+++ b/include/verilated_timing.cpp
@@ -46,7 +46,7 @@ void VlCoroutineHandle::dump() const {
 
 #ifdef VL_DEBUG
 void VlDelayScheduler::VlDelayedCoroutine::dump() const {
-    VL_DBG_MSGF("             Awaiting time %lu: ", m_timestep);
+    VL_DBG_MSGF("             Awaiting time %" PRIu64 ": ", m_timestep);
     m_handle.dump();
 }
 #endif


### PR DESCRIPTION
`%lu` generates a warning on some platforms (like MacOS), as it's defined as 32 bits.

Signed-off-by: Krzysztof Bieganski <kbieganski@antmicro.com>