### PR TITLE
Remove VL_THREADED define

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -322,7 +322,7 @@ CPPCHECK_INC = -I$(srcdir)/include -I$(srcdir)/src/obj_dbg -I$(srcdir)/src
 
 cppcheck: $(CPPCHECK_DEP)
 %.cppcheck: %.cpp
-	$(CPPCHECK) $(CPPCHECK_FLAGS) -DVL_DEBUG=1 -DVL_CPPCHECK=1 -DVL_THREADED=1 $(CPPCHECK_INC) $<
+	$(CPPCHECK) $(CPPCHECK_FLAGS) -DVL_DEBUG=1 -DVL_CPPCHECK=1 $(CPPCHECK_INC) $<
 
 CLANGTIDY = clang-tidy
 CLANGTIDY_FLAGS = -config='' \
@@ -330,7 +330,7 @@ CLANGTIDY_FLAGS = -config='' \
 	-checks='-fuchsia-*,-cppcoreguidelines-avoid-c-arrays,-cppcoreguidelines-init-variables,-cppcoreguidelines-avoid-goto,-modernize-avoid-c-arrays,-readability-magic-numbers,-readability-simplify-boolean-expr,-cppcoreguidelines-macro-usage' \
 
 CLANGTIDY_DEP = $(subst .cpp,.cpp.tidy,$(CPPCHECK_CPP))
-CLANGTIDY_DEFS = -DVL_DEBUG=1 -DVL_THREADED=1 -DVL_CPPCHECK=1
+CLANGTIDY_DEFS = -DVL_DEBUG=1 -DVL_CPPCHECK=1
 
 clang-tidy: $(CLANGTIDY_DEP)
 %.cpp.tidy: %.cpp

--- a/docs/guide/exe_verilator.rst
+++ b/docs/guide/exe_verilator.rst
@@ -1213,14 +1213,15 @@ Summary:
 
 .. option:: --threads <threads>
 
-.. option:: --no-threads
-
-   With "--threads 0" or "--no-threads", the default, the generated model
-   is not thread safe. With "--threads 1", the generated model is single
-   threaded but may run in a multithreaded environment. With "--threads N",
+   With "--threads 1", the default, the generated model is single threaded
+   but may run in a multithreaded environment. With "--threads N",
    where N >= 2, the model is generated to run multithreaded on up to N
    threads. See :ref:`Multithreading`. This option also applies to
    :vlopt:`--trace` (but not :vlopt:`--trace-fst`).
+
+.. option:: --no-threads
+
+   Deprecated and has no effect (ignored).
 
 .. option:: --threads-dpi all
 

--- a/docs/guide/exe_verilator.rst
+++ b/docs/guide/exe_verilator.rst
@@ -1223,6 +1223,8 @@ Summary:
 
    Deprecated and has no effect (ignored).
 
+   In versions prior to 5.004, created a model which was not thread safe.
+
 .. option:: --threads-dpi all
 
 .. option:: --threads-dpi none

--- a/docs/guide/verilating.rst
+++ b/docs/guide/verilating.rst
@@ -198,9 +198,6 @@ oversubscription, the Verilated model should not livelock nor deadlock,
 however, you can expect performance to be far worse than it would be with
 proper ratio of threads and CPU cores.
 
-:code:`VL_THREADED` is defined in the C++ code when compiling a threaded
-Verilated module, causing the Verilated support classes become threadsafe.
-
 The thread used for constructing a model must be the same thread that calls
 :code:`eval()` into the model, this is called the "eval thread". The thread
 used to perform certain global operations such as saving and tracing must

--- a/docs/guide/verilating.rst
+++ b/docs/guide/verilating.rst
@@ -183,11 +183,6 @@ Multithreading
 
 Verilator supports multithreaded simulation models.
 
-With :vlopt:`--no-threads`, the default, the model is not thread safe, and
-any use of more than one thread calling into one or even different
-Verilated models may result in unpredictable behavior. This gives the
-highest single thread performance.
-
 With :vlopt:`--threads 1 <--threads>`, the generated model is single
 threaded, however the support libraries are multithread safe. This allows
 different instantiations of model(s) to potentially each be run under a
@@ -202,10 +197,6 @@ responsibility not to oversubscribe the available CPU cores. Under CPU
 oversubscription, the Verilated model should not livelock nor deadlock,
 however, you can expect performance to be far worse than it would be with
 proper ratio of threads and CPU cores.
-
-The remainder of this section describe behavior with :vlopt:`--threads 1
-<--threads>` or :vlopt:`--threads {N} <--threads>` (not
-:vlopt:`--no-threads`).
 
 :code:`VL_THREADED` is defined in the C++ code when compiling a threaded
 Verilated module, causing the Verilated support classes become threadsafe.

--- a/docs/verilated.dox
+++ b/docs/verilated.dox
@@ -37,5 +37,4 @@ PREDEFINED             = \
                          "VL_NOT_FINAL=" \
                          "VL_PURE=" \
                          "VL_REQUIRES()=" \
-                         "VL_THREAD_LOCAL=" \
                          "__restrict=" \

--- a/include/verilated.cpp
+++ b/include/verilated.cpp
@@ -3082,7 +3082,7 @@ void VerilatedHierarchy::remove(VerilatedScope* fromp, VerilatedScope* top) {
 //===========================================================================
 // VerilatedOneThreaded:: Methods
 
-#if defined(VL_DEBUG)
+#ifdef VL_DEBUG
 void VerilatedAssertOneThread::fatal_different() VL_MT_SAFE {
     VL_FATAL_MT(__FILE__, __LINE__, "",
                 "Routine called that is single threaded, but called from"

--- a/include/verilated.cpp
+++ b/include/verilated.cpp
@@ -27,7 +27,7 @@
 //
 // verilated.o may exist both in --lib-create (incrementally linked .a/.so)
 // and the main module.  Both refer the same instance of static
-// variables/VL_THREAD_LOCAL in verilated.o such as Verilated, or
+// variables/thread_local in verilated.o such as Verilated, or
 // VerilatedImpData.  This is important to share that state, but the
 // sharing may cause a double-free error when shutting down because the
 // loader will insert a constructor/destructor at each reference to
@@ -94,7 +94,7 @@ VerilatedContext* Verilated::s_lastContextp = nullptr;
 
 // Keep below together in one cache line
 // Internal note: Globals may multi-construct, see verilated.cpp top.
-VL_THREAD_LOCAL Verilated::ThreadLocal Verilated::t_s;
+thread_local Verilated::ThreadLocal Verilated::t_s;
 
 //===========================================================================
 // User definable functions
@@ -242,7 +242,7 @@ uint32_t VL_THREAD_ID() VL_MT_SAFE {
     // Alternative is to use std::this_thread::get_id, but that returns a
     // hard-to-read number and is very slow
     static std::atomic<uint32_t> s_nextId(0);
-    static VL_THREAD_LOCAL uint32_t t_myId = ++s_nextId;
+    static thread_local uint32_t t_myId = ++s_nextId;
     return t_myId;
 }
 
@@ -289,8 +289,8 @@ static uint32_t vl_sys_rand32() VL_MT_UNSAFE {
 }
 
 uint64_t vl_rand64() VL_MT_SAFE {
-    static VL_THREAD_LOCAL uint64_t t_state[2];
-    static VL_THREAD_LOCAL uint32_t t_seedEpoch = 0;
+    static thread_local uint64_t t_state[2];
+    static thread_local uint32_t t_seedEpoch = 0;
     // For speed, we use a thread-local epoch number to know when to reseed
     // A thread always belongs to a single context, so this works out ok
     if (VL_UNLIKELY(t_seedEpoch != VerilatedContextImp::randSeedEpoch())) {
@@ -734,7 +734,7 @@ void _vl_vsformat(std::string& output, const char* formatp, va_list ap) VL_MT_SA
     // Note uses a single buffer internally; presumes only one usage per printf
     // Note also assumes variables < 64 are not wide, this assumption is
     // sometimes not true in low-level routines written here in verilated.cpp
-    static VL_THREAD_LOCAL char t_tmp[VL_VALUE_STRING_MAX_WIDTH];
+    static thread_local char t_tmp[VL_VALUE_STRING_MAX_WIDTH];
     const char* pctp = nullptr;  // Most recent %##.##g format
     bool inPct = false;
     bool widthSet = false;
@@ -1132,7 +1132,7 @@ IData _vl_vsscanf(FILE* fp,  // If a fscanf
     // Read a Verilog $sscanf/$fscanf style format into the output list
     // The format must be pre-processed (and lower cased) by Verilator
     // Arguments are in "width, arg-value (or WDataIn* if wide)" form
-    static VL_THREAD_LOCAL char t_tmp[VL_VALUE_STRING_MAX_WIDTH];
+    static thread_local char t_tmp[VL_VALUE_STRING_MAX_WIDTH];
     int floc = fbits - 1;
     IData got = 0;
     bool inPct = false;
@@ -1425,7 +1425,7 @@ void VL_FCLOSE_I(IData fdi) VL_MT_SAFE {
 }
 
 void VL_SFORMAT_X(int obits, CData& destr, const char* formatp, ...) VL_MT_SAFE {
-    static VL_THREAD_LOCAL std::string t_output;  // static only for speed
+    static thread_local std::string t_output;  // static only for speed
     t_output = "";
     va_list ap;
     va_start(ap, formatp);
@@ -1436,7 +1436,7 @@ void VL_SFORMAT_X(int obits, CData& destr, const char* formatp, ...) VL_MT_SAFE 
 }
 
 void VL_SFORMAT_X(int obits, SData& destr, const char* formatp, ...) VL_MT_SAFE {
-    static VL_THREAD_LOCAL std::string t_output;  // static only for speed
+    static thread_local std::string t_output;  // static only for speed
     t_output = "";
     va_list ap;
     va_start(ap, formatp);
@@ -1447,7 +1447,7 @@ void VL_SFORMAT_X(int obits, SData& destr, const char* formatp, ...) VL_MT_SAFE 
 }
 
 void VL_SFORMAT_X(int obits, IData& destr, const char* formatp, ...) VL_MT_SAFE {
-    static VL_THREAD_LOCAL std::string t_output;  // static only for speed
+    static thread_local std::string t_output;  // static only for speed
     t_output = "";
     va_list ap;
     va_start(ap, formatp);
@@ -1458,7 +1458,7 @@ void VL_SFORMAT_X(int obits, IData& destr, const char* formatp, ...) VL_MT_SAFE 
 }
 
 void VL_SFORMAT_X(int obits, QData& destr, const char* formatp, ...) VL_MT_SAFE {
-    static VL_THREAD_LOCAL std::string t_output;  // static only for speed
+    static thread_local std::string t_output;  // static only for speed
     t_output = "";
     va_list ap;
     va_start(ap, formatp);
@@ -1469,7 +1469,7 @@ void VL_SFORMAT_X(int obits, QData& destr, const char* formatp, ...) VL_MT_SAFE 
 }
 
 void VL_SFORMAT_X(int obits, void* destp, const char* formatp, ...) VL_MT_SAFE {
-    static VL_THREAD_LOCAL std::string t_output;  // static only for speed
+    static thread_local std::string t_output;  // static only for speed
     t_output = "";
     va_list ap;
     va_start(ap, formatp);
@@ -1490,7 +1490,7 @@ void VL_SFORMAT_X(int obits_ignored, std::string& output, const char* formatp, .
 }
 
 std::string VL_SFORMATF_NX(const char* formatp, ...) VL_MT_SAFE {
-    static VL_THREAD_LOCAL std::string t_output;  // static only for speed
+    static thread_local std::string t_output;  // static only for speed
     t_output = "";
     va_list ap;
     va_start(ap, formatp);
@@ -1501,7 +1501,7 @@ std::string VL_SFORMATF_NX(const char* formatp, ...) VL_MT_SAFE {
 }
 
 void VL_WRITEF(const char* formatp, ...) VL_MT_SAFE {
-    static VL_THREAD_LOCAL std::string t_output;  // static only for speed
+    static thread_local std::string t_output;  // static only for speed
     t_output = "";
     va_list ap;
     va_start(ap, formatp);
@@ -1513,7 +1513,7 @@ void VL_WRITEF(const char* formatp, ...) VL_MT_SAFE {
 
 void VL_FWRITEF(IData fpi, const char* formatp, ...) VL_MT_SAFE {
     // While threadsafe, each thread can only access different file handles
-    static VL_THREAD_LOCAL std::string t_output;  // static only for speed
+    static thread_local std::string t_output;  // static only for speed
     t_output = "";
 
     va_list ap;
@@ -1743,7 +1743,7 @@ IData VL_VALUEPLUSARGS_INN(int, const std::string& ld, std::string& rdr) VL_MT_S
 
 const char* vl_mc_scan_plusargs(const char* prefixp) VL_MT_SAFE {
     const std::string& match = Verilated::threadContextp()->impp()->argPlusMatch(prefixp);
-    static VL_THREAD_LOCAL char t_outstr[VL_VALUE_STRING_MAX_WIDTH];
+    static thread_local char t_outstr[VL_VALUE_STRING_MAX_WIDTH];
     if (match.empty()) return nullptr;
     char* dp = t_outstr;
     for (const char* sp = match.c_str() + std::strlen(prefixp) + 1;  // +1 to skip the "+"
@@ -1837,7 +1837,7 @@ IData VL_ATOI_N(const std::string& str, int base) VL_PURE {
 static const char* memhFormat(int nBits) {
     assert((nBits >= 1) && (nBits <= 32));
 
-    static VL_THREAD_LOCAL char t_buf[32];
+    static thread_local char t_buf[32];
     switch ((nBits - 1) / 4) {
     case 0: VL_SNPRINTF(t_buf, 32, "%%01x"); break;
     case 1: VL_SNPRINTF(t_buf, 32, "%%02x"); break;
@@ -1855,7 +1855,7 @@ static const char* memhFormat(int nBits) {
 static const char* formatBinary(int nBits, uint32_t bits) {
     assert((nBits >= 1) && (nBits <= 32));
 
-    static VL_THREAD_LOCAL char t_buf[64];
+    static thread_local char t_buf[64];
     for (int i = 0; i < nBits; i++) {
         const bool isOne = bits & (1 << (nBits - 1 - i));
         t_buf[i] = (isOne ? '1' : '0');
@@ -2469,7 +2469,7 @@ void VerilatedContext::commandArgsAdd(int argc, const char** argv)
 const char* VerilatedContext::commandArgsPlusMatch(const char* prefixp)
     VL_MT_SAFE_EXCLUDES(m_argMutex) {
     const std::string& match = impp()->argPlusMatch(prefixp);
-    static VL_THREAD_LOCAL char t_outstr[VL_VALUE_STRING_MAX_WIDTH];
+    static thread_local char t_outstr[VL_VALUE_STRING_MAX_WIDTH];
     if (match.empty()) return "";
     char* dp = t_outstr;
     for (const char* sp = match.c_str(); *sp && (dp - t_outstr) < (VL_VALUE_STRING_MAX_WIDTH - 2);)
@@ -2747,8 +2747,8 @@ void Verilated::debug(int level) VL_MT_SAFE {
 
 const char* Verilated::catName(const char* n1, const char* n2, const char* delimiter) VL_MT_SAFE {
     // Used by symbol table creation to make module names
-    static VL_THREAD_LOCAL char* t_strp = nullptr;
-    static VL_THREAD_LOCAL size_t t_len = 0;
+    static thread_local char* t_strp = nullptr;
+    static thread_local size_t t_len = 0;
     const size_t newlen = std::strlen(n1) + std::strlen(n2) + std::strlen(delimiter) + 1;
     if (VL_UNLIKELY(!t_strp || newlen > t_len)) {
         if (t_strp) delete[] t_strp;

--- a/include/verilated.h
+++ b/include/verilated.h
@@ -662,7 +662,7 @@ class Verilated final {
     static VerilatedContext* s_lastContextp;  // Last context constructed/attached
 
     // Not covered by mutex, as per-thread
-    static VL_THREAD_LOCAL struct ThreadLocal {
+    static thread_local struct ThreadLocal {
         // No non-POD objects here due to this:
         // Internal note: Globals may multi-construct, see verilated.cpp top.
 

--- a/include/verilated.h
+++ b/include/verilated.h
@@ -203,7 +203,7 @@ public:
 
 class VerilatedAssertOneThread final {
     // MEMBERS
-#if defined(VL_DEBUG)
+#ifdef VL_DEBUG
     uint32_t m_threadid;  // Thread that is legal
 public:
     // CONSTRUCTORS

--- a/include/verilated.mk.in
+++ b/include/verilated.mk.in
@@ -130,18 +130,8 @@ endif
 #######################################################################
 ##### Threaded builds
 
-ifneq ($(VM_C11),0)
- ifneq ($(VM_C11),)
-  VK_C11=1
- endif
-endif
-
-ifneq ($(VM_THREADS),0)
- ifneq ($(VM_THREADS),)
-  VK_C11=1
-  VK_LIBS_THREADED=1
- endif
-endif
+VK_C11=1
+VK_LIBS_THREADED=1
 
 ifneq ($(VM_TIMING),0)
  ifneq ($(VM_TIMING),)

--- a/include/verilated.mk.in
+++ b/include/verilated.mk.in
@@ -130,9 +130,8 @@ endif
 #######################################################################
 ##### Threaded builds
 
-# Deprecated, as always threaded
-VK_C11=1
-VK_LIBS_THREADED=1
+LDLIBS += $(CFG_LDLIBS_THREADS)
+CPPFLAGS += $(CFG_CXXFLAGS_STD_NEWEST)
 
 ifneq ($(VM_TIMING),0)
  ifneq ($(VM_TIMING),)
@@ -140,18 +139,6 @@ ifneq ($(VM_TIMING),0)
  endif
 endif
 
-ifneq ($(VK_C11),0)
- ifneq ($(VK_C11),)
-  # Need C++11 at least, so always default to newest
-  CPPFLAGS += $(CFG_CXXFLAGS_STD_NEWEST)
- endif
-endif
-
-ifneq ($(VK_LIBS_THREADED),0)
- ifneq ($(VK_LIBS_THREADED),)
-  LDLIBS += $(CFG_LDLIBS_THREADS)
- endif
-endif
 
 #######################################################################
 ### Aggregates

--- a/include/verilated.mk.in
+++ b/include/verilated.mk.in
@@ -130,8 +130,8 @@ endif
 #######################################################################
 ##### Threaded builds
 
-LDLIBS += $(CFG_LDLIBS_THREADS)
 CPPFLAGS += $(CFG_CXXFLAGS_STD_NEWEST)
+LDLIBS += $(CFG_LDLIBS_THREADS)
 
 ifneq ($(VM_TIMING),0)
  ifneq ($(VM_TIMING),)

--- a/include/verilated.mk.in
+++ b/include/verilated.mk.in
@@ -136,13 +136,12 @@ ifneq ($(VM_C11),0)
  endif
 endif
 
-ifneq ($(VM_THREADS),0)
- ifneq ($(VM_THREADS),)
-  CPPFLAGS += -DVL_THREADED
+#ifneq ($(VM_THREADS),0)
+# ifneq ($(VM_THREADS),)
   VK_C11=1
   VK_LIBS_THREADED=1
- endif
-endif
+# endif
+#endif
 
 ifneq ($(VM_TIMING),0)
  ifneq ($(VM_TIMING),)

--- a/include/verilated.mk.in
+++ b/include/verilated.mk.in
@@ -136,12 +136,12 @@ ifneq ($(VM_C11),0)
  endif
 endif
 
-#ifneq ($(VM_THREADS),0)
-# ifneq ($(VM_THREADS),)
+ifneq ($(VM_THREADS),0)
+ ifneq ($(VM_THREADS),)
   VK_C11=1
   VK_LIBS_THREADED=1
-# endif
-#endif
+ endif
+endif
 
 ifneq ($(VM_TIMING),0)
  ifneq ($(VM_TIMING),)

--- a/include/verilated.mk.in
+++ b/include/verilated.mk.in
@@ -130,6 +130,7 @@ endif
 #######################################################################
 ##### Threaded builds
 
+# Deprecated, as always threaded
 VK_C11=1
 VK_LIBS_THREADED=1
 

--- a/include/verilated_fst_c.cpp
+++ b/include/verilated_fst_c.cpp
@@ -28,10 +28,8 @@
 #include "verilated_fst_c.h"
 
 // GTKWave configuration
-#ifdef VL_THREADED
-# define HAVE_LIBPTHREAD
-# define FST_WRITER_PARALLEL
-#endif
+#define HAVE_LIBPTHREAD
+#define FST_WRITER_PARALLEL
 
 // Include the GTKWave implementation directly
 #define FST_CONFIG_INCLUDE "fst_config.h"
@@ -248,14 +246,11 @@ void VerilatedFst::declDouble(uint32_t code, const char* name, int dtypenum, fst
 // Get/commit trace buffer
 
 VerilatedFst::Buffer* VerilatedFst::getTraceBuffer() {
-#ifdef VL_THREADED
     if (offload()) return new OffloadBuffer{*this};
-#endif
     return new Buffer{*this};
 }
 
 void VerilatedFst::commitTraceBuffer(VerilatedFst::Buffer* bufp) {
-#ifdef VL_THREADED
     if (offload()) {
         OffloadBuffer* const offloadBufferp = static_cast<OffloadBuffer*>(bufp);
         if (offloadBufferp->m_offloadBufferWritep) {
@@ -263,7 +258,6 @@ void VerilatedFst::commitTraceBuffer(VerilatedFst::Buffer* bufp) {
             return;  // Buffer will be deleted by the offload thread
         }
     }
-#endif
     delete bufp;
 }
 

--- a/include/verilated_funcs.h
+++ b/include/verilated_funcs.h
@@ -73,11 +73,7 @@ extern void VL_WARN_MT(const char* filename, int linenum, const char* hier,
 
 // clang-format off
 /// Print a string, multithread safe. Eventually VL_PRINTF will get called.
-#ifdef VL_THREADED
 extern void VL_PRINTF_MT(const char* formatp, ...) VL_ATTR_PRINTF(1) VL_MT_SAFE;
-#else
-# define VL_PRINTF_MT VL_PRINTF  // The following parens will take care of themselves
-#endif
 // clang-format on
 
 /// Print a debug message from internals with standard prefix, with printf style format

--- a/include/verilated_imp.h
+++ b/include/verilated_imp.h
@@ -149,7 +149,7 @@ private:
     VL_UNCOPYABLE(VerilatedThreadMsgQueue);
     // METHODS
     static VerilatedThreadMsgQueue& threadton() {
-        static VL_THREAD_LOCAL VerilatedThreadMsgQueue t_s;
+        static thread_local VerilatedThreadMsgQueue t_s;
         return t_s;
     }
 

--- a/include/verilated_imp.h
+++ b/include/verilated_imp.h
@@ -41,10 +41,8 @@
 #include <string>
 #include <utility>
 #include <vector>
-#ifdef VL_THREADED
-# include <functional>
-# include <queue>
-#endif
+#include <functional>
+#include <queue>
 // clang-format on
 
 class VerilatedScope;
@@ -52,7 +50,6 @@ class VerilatedScope;
 //======================================================================
 // Threaded message passing
 
-#ifdef VL_THREADED
 // Message, enqueued on an mtask, and consumed on the main eval thread
 class VerilatedMsg final {
 public:
@@ -178,7 +175,6 @@ public:
         }
     }
 };
-#endif  // VL_THREADED
 
 // FILE* list constructed from a file-descriptor
 class VerilatedFpList final {

--- a/include/verilated_profiler.cpp
+++ b/include/verilated_profiler.cpp
@@ -20,9 +20,7 @@
 
 #include "verilated_profiler.h"
 
-#if VL_THREADED
 #include "verilated_threads.h"
-#endif
 
 #include <fstream>
 #include <string>
@@ -105,7 +103,6 @@ void VlExecutionProfiler::configure() {
 
 VerilatedVirtualBase* VlExecutionProfiler::construct(VerilatedContext& context) {
     VlExecutionProfiler* const selfp = new VlExecutionProfiler{context};
-#if VL_THREADED
     if (VlThreadPool* const threadPoolp = static_cast<VlThreadPool*>(context.threadPoolp())) {
         for (int i = 0; i < threadPoolp->numThreads(); ++i) {
             // Data to pass to worker thread initialization
@@ -126,7 +123,6 @@ VerilatedVirtualBase* VlExecutionProfiler::construct(VerilatedContext& context) 
             threadPoolp->workerp(i)->wait();
         }
     }
-#endif
     return selfp;
 }
 
@@ -172,9 +168,7 @@ void VlExecutionProfiler::dump(const char* filenamep, uint64_t tickEnd)
             Verilated::threadContextp()->profExecWindow());
     const unsigned threads = static_cast<unsigned>(m_traceps.size());
     fprintf(fp, "VLPROF stat threads %u\n", threads);
-#ifdef VL_THREADED
     fprintf(fp, "VLPROF stat yields %" PRIu64 "\n", VlMTaskVertex::yields());
-#endif
 
     // Copy /proc/cpuinfo into this output so verilator_gantt can be run on
     // a different machine

--- a/include/verilated_profiler.cpp
+++ b/include/verilated_profiler.cpp
@@ -30,7 +30,7 @@
 
 // Internal note: Globals may multi-construct, see verilated.cpp top.
 
-VL_THREAD_LOCAL VlExecutionProfiler::ExecutionTrace VlExecutionProfiler::t_trace;
+thread_local VlExecutionProfiler::ExecutionTrace VlExecutionProfiler::t_trace;
 
 constexpr const char* const VlExecutionRecord::s_ascii[];
 

--- a/include/verilated_profiler.h
+++ b/include/verilated_profiler.h
@@ -151,7 +151,7 @@ class VlExecutionProfiler final : public VerilatedVirtualBase {
 
     // STATE
     VerilatedContext& m_context;  // The context this profiler is under
-    static VL_THREAD_LOCAL ExecutionTrace t_trace;  // thread-local trace buffers
+    static thread_local ExecutionTrace t_trace;  // thread-local trace buffers
     mutable VerilatedMutex m_mutex;
     // Map from thread id to &t_trace of given thread
     std::map<uint32_t, ExecutionTrace*> m_traceps VL_GUARDED_BY(m_mutex);

--- a/include/verilated_threads.h
+++ b/include/verilated_threads.h
@@ -27,15 +27,6 @@
 
 #include "verilated.h"  // for VerilatedMutex and clang annotations
 
-#ifndef VL_THREADED
-// Hitting this likely means verilated_threads.cpp is being compiled when
-// 'verilator --threads' was not used.  'verilator --threads' sets
-// VL_THREADED.
-// Alternatively it is always safe but may harm performance to always
-// define VL_THREADED for all compiles.
-#error "verilated_threads.h/cpp expected VL_THREADED (from verilator --threads)"
-#endif
-
 #include <atomic>
 #include <condition_variable>
 #include <set>

--- a/include/verilated_trace.h
+++ b/include/verilated_trace.h
@@ -35,10 +35,8 @@
 #include <unordered_set>
 #include <vector>
 
-#ifdef VL_THREADED
-# include <deque>
-# include <thread>
-#endif
+#include <deque>
+#include <thread>
 
 // clang-format on
 
@@ -48,7 +46,6 @@ class VerilatedTraceBuffer;
 template <class T_Buffer>
 class VerilatedTraceOffloadBuffer;
 
-#ifdef VL_THREADED
 //=============================================================================
 // Offloaded tracing
 
@@ -117,7 +114,6 @@ public:
         SHUTDOWN = 0xf  // Shutdown worker thread, also marks end of buffer
     };
 };
-#endif
 
 //=============================================================================
 // VerilatedTraceConfig
@@ -186,10 +182,9 @@ private:
             , m_userp{userp} {}
     };
 
-    bool m_offload = false;  // Use the offload thread (ignored if !VL_THREADED)
-    bool m_parallel = false;  // Use parallel tracing (ignored if !VL_THREADED)
+    bool m_offload = false;  // Use the offload thread
+    bool m_parallel = false;  // Use parallel tracing
 
-#ifdef VL_THREADED
     struct ParallelWorkerData {
         const dumpCb_t m_cb;  // The callback
         void* const m_userp;  // The use pointer to pass to the callback
@@ -209,7 +204,6 @@ private:
 
     // Passed a ParallelWorkerData*, second argument is ignored
     static void parallelWorkerTask(void*, bool);
-#endif
 
 protected:
     uint32_t* m_sigs_oldvalp = nullptr;  // Previous value store
@@ -251,7 +245,6 @@ private:
     // Close the file on termination
     static void onExit(void* selfp) VL_MT_UNSAFE_ONE;
 
-#ifdef VL_THREADED
     // Number of total offload buffers that have been allocated
     uint32_t m_numOffloadBuffers = 0;
     // Size of offload buffers
@@ -282,7 +275,6 @@ private:
 
     // Shut down and join worker, if it's running, otherwise do nothing
     void shutdownOffloadWorker();
-#endif
 
     // CONSTRUCTORS
     VL_UNCOPYABLE(VerilatedTrace);
@@ -317,13 +309,8 @@ protected:
     void closeBase();
     void flushBase();
 
-#ifdef VL_THREADED
     bool offload() const { return m_offload; }
     bool parallel() const { return m_parallel; }
-#else
-    static constexpr bool offload() { return false; }
-    static constexpr bool parallel() { return false; }
-#endif
 
     //=========================================================================
     // Virtual functions to be provided by the format specific implementation
@@ -475,7 +462,6 @@ public:
     }
 };
 
-#ifdef VL_THREADED
 //=============================================================================
 // VerilatedTraceOffloadBuffer
 
@@ -548,6 +534,5 @@ public:
         VL_DEBUG_IF(assert(m_offloadBufferWritep <= m_offloadBufferEndp););
     }
 };
-#endif
 
 #endif  // guard

--- a/include/verilated_types.h
+++ b/include/verilated_types.h
@@ -367,7 +367,7 @@ public:
     // Can't just overload operator[] or provide a "at" reference to set,
     // because we need to be able to insert only when the value is set
     T_Value& at(int32_t index) {
-        static VL_THREAD_LOCAL T_Value s_throwAway;
+        static thread_local T_Value s_throwAway;
         // Needs to work for dynamic arrays, so does not use T_MaxSize
         if (VL_UNLIKELY(index < 0 || index >= m_deque.size())) {
             s_throwAway = atDefault();
@@ -378,7 +378,7 @@ public:
     }
     // Accessing. Verilog: v = assoc[index]
     const T_Value& at(int32_t index) const {
-        static VL_THREAD_LOCAL T_Value s_throwAway;
+        static thread_local T_Value s_throwAway;
         // Needs to work for dynamic arrays, so does not use T_MaxSize
         if (VL_UNLIKELY(index < 0 || index >= m_deque.size())) {
             return atDefault();

--- a/include/verilated_vcd_c.h
+++ b/include/verilated_vcd_c.h
@@ -65,11 +65,9 @@ private:
     using NameMap = std::map<const std::string, const std::string>;
     NameMap* m_namemapp = nullptr;  // List of names for the header
 
-#ifdef VL_THREADED
     // Vector of free trace buffers as (pointer, size) pairs.
     std::vector<std::pair<char*, size_t>> m_freeBuffers;
     size_t m_numBuffers = 0;  // Number of trace buffers allocated
-#endif
 
     void bufferResize(size_t minsize);
     void bufferFlush() VL_MT_UNSAFE_ONE;
@@ -187,7 +185,6 @@ class VerilatedVcdBuffer VL_NOT_FINAL {
     // The maximum number of bytes a single signal can emit
     const size_t m_maxSignalBytes = m_owner.m_maxSignalBytes;
 
-#ifdef VL_THREADED
     // Additional data for parallel tracing only
     char* m_bufp = nullptr;  // The beginning of the trace buffer
     size_t m_size = 0;  // The size of the buffer at m_bufp
@@ -197,7 +194,6 @@ class VerilatedVcdBuffer VL_NOT_FINAL {
         m_growp = (m_bufp + m_size) - (2 * m_maxSignalBytes);
         assert(m_growp >= m_bufp + m_maxSignalBytes);
     }
-#endif
 
     void finishLine(uint32_t code, char* writep);
 

--- a/include/verilated_vpi.cpp
+++ b/include/verilated_vpi.cpp
@@ -71,7 +71,7 @@ class VerilatedVpio VL_NOT_FINAL {
 
     // MEM MANGLEMENT
     // Internal note: Globals may multi-construct, see verilated.cpp top.
-    static VL_THREAD_LOCAL uint8_t* t_freeHead;
+    static thread_local uint8_t* t_freeHead;
 
 public:
     // CONSTRUCTORS
@@ -205,7 +205,7 @@ public:
     const VerilatedRange* rangep() const override { return &get_range(); }
     const char* name() const override { return m_varp->name(); }
     const char* fullname() const override {
-        static VL_THREAD_LOCAL std::string t_out;
+        static thread_local std::string t_out;
         t_out = std::string{m_scopep->name()} + "." + name();
         return t_out.c_str();
     }
@@ -348,7 +348,7 @@ public:
     uint32_t size() const override { return varp()->packed().elements(); }
     const VerilatedRange* rangep() const override { return &(varp()->packed()); }
     const char* fullname() const override {
-        static VL_THREAD_LOCAL std::string t_out;
+        static thread_local std::string t_out;
         constexpr size_t LEN_MAX_INDEX = 25;
         char num[LEN_MAX_INDEX];
         VL_SNPRINTF(num, LEN_MAX_INDEX, "%d", m_index);
@@ -666,7 +666,7 @@ public:
 // Statics
 // Internal note: Globals may multi-construct, see verilated.cpp top.
 
-VL_THREAD_LOCAL uint8_t* VerilatedVpio::t_freeHead = nullptr;
+thread_local uint8_t* VerilatedVpio::t_freeHead = nullptr;
 
 //======================================================================
 // VerilatedVpiError
@@ -708,7 +708,7 @@ public:
     }
     void setMessage(const std::string& file, PLI_INT32 line, const char* message, ...) {
         // message cannot be a const string& as va_start cannot use a reference
-        static VL_THREAD_LOCAL std::string t_filehold;
+        static thread_local std::string t_filehold;
         va_list args;
         va_start(args, message);
         VL_VSNPRINTF(m_buff, sizeof(m_buff), message, args);
@@ -1701,15 +1701,15 @@ void vl_get_value(const VerilatedVar* varp, void* varDatap, p_vpi_value valuep,
                   const char* fullname) {
     if (!vl_check_format(varp, valuep, fullname, true)) return;
     // Maximum required size is for binary string, one byte per bit plus null termination
-    static VL_THREAD_LOCAL char t_outStr[VL_VALUE_STRING_MAX_WORDS * VL_EDATASIZE + 1];
+    static thread_local char t_outStr[VL_VALUE_STRING_MAX_WORDS * VL_EDATASIZE + 1];
     // cppcheck-suppress variableScope
-    static const VL_THREAD_LOCAL int t_outStrSz = sizeof(t_outStr) - 1;
+    static const thread_local int t_outStrSz = sizeof(t_outStr) - 1;
     // We used to presume vpiValue.format = vpiIntVal or if single bit vpiScalarVal
     // This may cause backward compatibility issues with older code.
     if (valuep->format == vpiVectorVal) {
         // Vector pointer must come from our memory pool
         // It only needs to persist until the next vpi_get_value
-        static VL_THREAD_LOCAL t_vpi_vecval t_out[VL_VALUE_STRING_MAX_WORDS * 2];
+        static thread_local t_vpi_vecval t_out[VL_VALUE_STRING_MAX_WORDS * 2];
         valuep->value.vector = t_out;
         if (varp->vltype() == VLVT_UINT8) {
             t_out[0].aval = *(reinterpret_cast<CData*>(varDatap));

--- a/include/verilatedos.h
+++ b/include/verilatedos.h
@@ -56,7 +56,7 @@
 # if !defined(_WIN32) && !defined(__MINGW32__)
 #  define VL_ATTR_WEAK __attribute__((weak))
 # endif
-# if defined(__clang__) && defined(VL_THREADED)
+# if defined(__clang__)
 #  define VL_ACQUIRE(...) __attribute__((acquire_capability(__VA_ARGS__)))
 #  define VL_ACQUIRE_SHARED(...) __attribute__((acquire_shared_capability(__VA_ARGS__)))
 #  define VL_RELEASE(...) __attribute__((release_capability(__VA_ARGS__)))
@@ -139,20 +139,7 @@
 # define VL_PREFETCH_RW(p)  ///< Prefetch pointer argument with read/write intent
 #endif
 
-#if defined(VL_THREADED) && !defined(VL_CPPCHECK)
-# if defined(_MSC_VER) && _MSC_VER >= 1900
-#  define VL_THREAD_LOCAL thread_local
-# elif defined(__GNUC__)
-#  if (__cplusplus < 201103L)
-#   error "VL_THREADED/--threads support requires C++-11 or newer only; use newer compiler"
-#  endif
-# else
-#  error "Unsupported compiler for VL_THREADED: No thread-local declarator"
-# endif
-# define VL_THREAD_LOCAL thread_local  // "thread_local" when supported
-#else
-# define VL_THREAD_LOCAL  // "thread_local" when supported
-#endif
+#define VL_THREAD_LOCAL thread_local
 
 #ifndef VL_NO_LEGACY
 # define VL_FUNC __func__  // Deprecated
@@ -162,24 +149,24 @@
 
 // Comment tag that Function is pure (and thus also VL_MT_SAFE)
 #define VL_PURE
-// Comment tag that function is threadsafe when VL_THREADED
+// Comment tag that function is threadsafe
 #if defined(__clang__)
 # define VL_MT_SAFE __attribute__((annotate("MT_SAFE")))
 #else
 # define VL_MT_SAFE
 #endif
-// Comment tag that function is threadsafe when VL_THREADED, only
+// Comment tag that function is threadsafe, only
 // during normal operation (post-init)
 #define VL_MT_SAFE_POSTINIT
 // Attribute that function is clang threadsafe and uses given mutex
 #define VL_MT_SAFE_EXCLUDES(mutex) VL_EXCLUDES(mutex)
-// Comment tag that function is not threadsafe when VL_THREADED
+// Comment tag that function is not threadsafe
 #if defined(__clang__)
 # define VL_MT_UNSAFE __attribute__((annotate("MT_UNSAFE")))
 #else
 # define VL_MT_UNSAFE
 #endif
-// Comment tag that function is not threadsafe when VL_THREADED,
+// Comment tag that function is not threadsafe
 // protected to make sure single-caller
 #define VL_MT_UNSAFE_ONE
 
@@ -482,28 +469,26 @@ using ssize_t = uint32_t;  ///< signed size_t; returned from read()
 //=========================================================================
 // Threading related OS-specific functions
 
-#if VL_THREADED
-# ifdef _WIN32
-#  define WIN32_LEAN_AND_MEAN
-#  define NOMINMAX
-#  include "Windows.h"
-#  define VL_CPU_RELAX() YieldProcessor()
-# elif defined(__i386__) || defined(__x86_64__) || defined(VL_CPPCHECK)
+#ifdef _WIN32
+# define WIN32_LEAN_AND_MEAN
+# define NOMINMAX
+# include "Windows.h"
+# define VL_CPU_RELAX() YieldProcessor()
+#elif defined(__i386__) || defined(__x86_64__) || defined(VL_CPPCHECK)
 // For more efficient busy waiting on SMT CPUs, let the processor know
 // we're just waiting so it can let another thread run
-#  define VL_CPU_RELAX() asm volatile("rep; nop" ::: "memory")
-# elif defined(__ia64__)
-#  define VL_CPU_RELAX() asm volatile("hint @pause" ::: "memory")
-# elif defined(__aarch64__)
-#  define VL_CPU_RELAX() asm volatile("yield" ::: "memory")
-# elif defined(__powerpc64__)
-#  define VL_CPU_RELAX() asm volatile("or 1, 1, 1; or 2, 2, 2;" ::: "memory")
-# elif defined(__loongarch__)
-// LoongArch does not currently have a yield/pause instruction
-#  define VL_CPU_RELAX() asm volatile("nop" ::: "memory")
-# else
-#  error "Missing VL_CPU_RELAX() definition. Or, don't use VL_THREADED"
-# endif
+# define VL_CPU_RELAX() asm volatile("rep; nop" ::: "memory")
+#elif defined(__ia64__)
+# define VL_CPU_RELAX() asm volatile("hint @pause" ::: "memory")
+#elif defined(__aarch64__)
+# define VL_CPU_RELAX() asm volatile("yield" ::: "memory")
+#elif defined(__powerpc64__)
+# define VL_CPU_RELAX() asm volatile("or 1, 1, 1; or 2, 2, 2;" ::: "memory")
+#elif defined(__loongarch__)
+/ LoongArch does not currently have a yield/pause instruction
+# define VL_CPU_RELAX() asm volatile("nop" ::: "memory")
+#else
+# error "Missing VL_CPU_RELAX() definition."
 #endif
 
 //=========================================================================

--- a/include/verilatedos.h
+++ b/include/verilatedos.h
@@ -139,9 +139,9 @@
 # define VL_PREFETCH_RW(p)  ///< Prefetch pointer argument with read/write intent
 #endif
 
-#define VL_THREAD_LOCAL thread_local
 
 #ifndef VL_NO_LEGACY
+# define VL_THREAD_LOCAL thread_local  // Deprecated
 # define VL_FUNC __func__  // Deprecated
 # define VL_THREAD  // Deprecated
 # define VL_STATIC_OR_THREAD static  // Deprecated

--- a/include/verilatedos.h
+++ b/include/verilatedos.h
@@ -141,9 +141,9 @@
 
 
 #ifndef VL_NO_LEGACY
-# define VL_THREAD_LOCAL thread_local  // Deprecated
 # define VL_FUNC __func__  // Deprecated
 # define VL_THREAD  // Deprecated
+# define VL_THREAD_LOCAL thread_local  // Deprecated
 # define VL_STATIC_OR_THREAD static  // Deprecated
 #endif
 

--- a/src/V3EmitCBase.cpp
+++ b/src/V3EmitCBase.cpp
@@ -210,7 +210,7 @@ void EmitCBaseVisitor::emitVarDecl(const AstVar* nodep, bool asRef) {
             // Issue 2622.
             const bool beStatic = name.size() >= suffix.size()
                                   && name.substr(name.size() - suffix.size()) == suffix;
-            if (beStatic) puts("static VL_THREAD_LOCAL ");
+            if (beStatic) puts("static thread_local ");
         }
         puts(nodep->vlArgType(true, false, false, "", asRef));
         puts(";\n");

--- a/src/V3EmitCMake.cpp
+++ b/src/V3EmitCMake.cpp
@@ -116,6 +116,8 @@ class CMakeEmitter final {
         cmake_set_raw(*of, name + "_COVERAGE", v3Global.opt.coverage() ? "1" : "0");
         *of << "# Timing mode?  0/1\n";
         cmake_set_raw(*of, name + "_TIMING", v3Global.usesTiming() ? "1" : "0");
+        *of << "# Threaded output mode?  1/N threads (from --threads)\n";
+        cmake_set_raw(*of, name + "_THREADS", cvtToStr(v3Global.opt.threads()));
         *of << "# VCD Tracing output mode?  0/1 (from --trace)\n";
         cmake_set_raw(*of, name + "_TRACE_VCD",
                       (v3Global.opt.trace() && v3Global.opt.traceFormat().vcd()) ? "1" : "0");

--- a/src/V3EmitCMake.cpp
+++ b/src/V3EmitCMake.cpp
@@ -116,8 +116,6 @@ class CMakeEmitter final {
         cmake_set_raw(*of, name + "_COVERAGE", v3Global.opt.coverage() ? "1" : "0");
         *of << "# Timing mode?  0/1\n";
         cmake_set_raw(*of, name + "_TIMING", v3Global.usesTiming() ? "1" : "0");
-        *of << "# Threaded output mode?  0/1/N threads (from --threads)\n";
-        cmake_set_raw(*of, name + "_THREADS", cvtToStr(v3Global.opt.threads()));
         *of << "# VCD Tracing output mode?  0/1 (from --trace)\n";
         cmake_set_raw(*of, name + "_TRACE_VCD",
                       (v3Global.opt.trace() && v3Global.opt.traceFormat().vcd()) ? "1" : "0");

--- a/src/V3EmitMk.cpp
+++ b/src/V3EmitMk.cpp
@@ -63,10 +63,6 @@ public:
         of.puts("VM_PARALLEL_BUILDS = ");
         of.puts(v3Global.useParallelBuild() ? "1" : "0");
         of.puts("\n");
-        of.puts("# Threaded output mode?  0/1/N threads (from --threads)\n");
-        of.puts("VM_THREADS = ");
-        of.puts(cvtToStr(v3Global.opt.threads()));
-        of.puts("\n");
         of.puts("# Tracing output mode?  0/1 (from --trace/--trace-fst)\n");
         of.puts("VM_TRACE = ");
         of.puts(v3Global.opt.trace() ? "1" : "0");

--- a/src/V3Options.cpp
+++ b/src/V3Options.cpp
@@ -1389,7 +1389,7 @@ void V3Options::parseOptsList(FileLine* fl, const string& optdir, int argc, char
 
     DECL_OPTION("-threads-coarsen", OnOff, &m_threadsCoarsen).undocumented();  // Debug
     DECL_OPTION("-no-threads", CbCall, [this, fl]() {
-        fl->v3warn(DEPRECATED, "Option --no-threads is deprecated.");
+        fl->v3warn(DEPRECATED, "Option --no-threads is deprecated, use '--threads 1' instead");
         m_threads = 1;
     });
     DECL_OPTION("-threads", CbVal, [this, fl](const char* valp) {
@@ -1397,7 +1397,7 @@ void V3Options::parseOptsList(FileLine* fl, const string& optdir, int argc, char
         if (m_threads < 0) fl->v3fatal("--threads must be >= 0: " << valp);
         if (m_threads == 0) {
             fl->v3warn(DEPRECATED,
-                       "Option --threads 0 is deprecated and it defaults to --threads 1. ");
+                       "Option --threads 0 is deprecated, use '--threads 1' instead");
             m_threads = 1;
         }
     });

--- a/src/V3Options.cpp
+++ b/src/V3Options.cpp
@@ -1388,10 +1388,18 @@ void V3Options::parseOptsList(FileLine* fl, const string& optdir, int argc, char
     DECL_OPTION("-sv", CbCall, [this]() { m_defaultLanguage = V3LangCode::L1800_2017; });
 
     DECL_OPTION("-threads-coarsen", OnOff, &m_threadsCoarsen).undocumented();  // Debug
-    DECL_OPTION("-no-threads", CbCall, [this]() { m_threads = 0; });
+    DECL_OPTION("-no-threads", CbCall, [this, fl]() {
+        fl->v3warn(DEPRECATED, "Option --no-threads is deprecated.");
+        m_threads = 1;
+    });
     DECL_OPTION("-threads", CbVal, [this, fl](const char* valp) {
         m_threads = std::atoi(valp);
         if (m_threads < 0) fl->v3fatal("--threads must be >= 0: " << valp);
+        if (m_threads == 0) {
+            fl->v3warn(DEPRECATED,
+                       "Option --threads 0 is deprecated and it defaults to --threads 1. ");
+            m_threads = 1;
+        }
     });
     DECL_OPTION("-threads-dpi", CbVal, [this, fl](const char* valp) {
         if (!std::strcmp(valp, "all")) {

--- a/src/V3Options.cpp
+++ b/src/V3Options.cpp
@@ -1396,8 +1396,7 @@ void V3Options::parseOptsList(FileLine* fl, const string& optdir, int argc, char
         m_threads = std::atoi(valp);
         if (m_threads < 0) fl->v3fatal("--threads must be >= 0: " << valp);
         if (m_threads == 0) {
-            fl->v3warn(DEPRECATED,
-                       "Option --threads 0 is deprecated, use '--threads 1' instead");
+            fl->v3warn(DEPRECATED, "Option --threads 0 is deprecated, use '--threads 1' instead");
             m_threads = 1;
         }
     });

--- a/src/V3Options.h
+++ b/src/V3Options.h
@@ -304,7 +304,7 @@ private:
     int         m_pinsBv = 65;       // main switch: --pins-bv
     int         m_reloopLimit = 40; // main switch: --reloop-limit
     VOptionBool m_skipIdentical;  // main switch: --skip-identical
-    int         m_threads = 0;      // main switch: --threads (0 == --no-threads)
+    int         m_threads = 1;      // main switch: --threads
     int         m_threadsMaxMTasks = 0;  // main switch: --threads-max-mtasks
     VTimescale  m_timeDefaultPrec;  // main switch: --timescale
     VTimescale  m_timeDefaultUnit;  // main switch: --timescale

--- a/test_regress/driver.pl
+++ b/test_regress/driver.pl
@@ -904,7 +904,7 @@ sub compile_vlt_flags {
                           @{$param{verilator_flags}},
                           @{$param{verilator_flags2}},
                           @{$param{verilator_flags3}});
-    die "%Error: specify threads via 'threads =>' argument, not as a command line option" unless ($checkflags !~ /(^|\s)-?-threads\s/ && $checkflags !~ /(^|\s)-?-no-threads($|\s)/);
+    die "%Error: specify threads via 'threads =>' argument, not as a command line option" unless ($checkflags !~ /(^|\s)-?-threads\s/);
     $self->{sc} = 1 if ($checkflags =~ /-sc\b/);
     $self->{trace} = ($opt_trace || $checkflags =~ /-trace\b/
                       || $checkflags =~ /-trace-fst\b/);

--- a/test_regress/t/t_embed1.pl
+++ b/test_regress/t/t_embed1.pl
@@ -23,7 +23,7 @@ mkdir $child_dir;
          top_filename => "$Self->{name}_child.v",
          verilator_flags => ["-cc", "-Mdir", "${child_dir}", "--debug-check"],
          # Can't use multi threading (like hier blocks), but needs to be thread safe
-         threads => $Self->{vltmt} ? 1 : 0,
+         threads => 1,
         );
 
     run(logfile => "${child_dir}/vlt_compile.log",

--- a/test_regress/t/t_flag_values_deprecated.out
+++ b/test_regress/t/t_flag_values_deprecated.out
@@ -1,3 +1,3 @@
-%Error-DEPRECATED: Option --no-threads is deprecated.
+%Error-DEPRECATED: Option --no-threads is deprecated, use '--threads 1' instead
                    ... For error description see https://verilator.org/warn/DEPRECATED?v=latest
 %Error: Exiting due to

--- a/test_regress/t/t_flag_values_deprecated.out
+++ b/test_regress/t/t_flag_values_deprecated.out
@@ -1,3 +1,5 @@
+%Warning-DEPRECATED: Option --threads 0 is deprecated, use '--threads 1' instead
+                     ... For warning description see https://verilator.org/warn/DEPRECATED?v=latest
+                     ... Use "/* verilator lint_off DEPRECATED */" and lint_on around source to disable this message.
 %Error-DEPRECATED: Option --no-threads is deprecated, use '--threads 1' instead
-                   ... For error description see https://verilator.org/warn/DEPRECATED?v=latest
 %Error: Exiting due to

--- a/test_regress/t/t_flag_values_deprecated.out
+++ b/test_regress/t/t_flag_values_deprecated.out
@@ -1,0 +1,3 @@
+%Error-DEPRECATED: Option --no-threads is deprecated.
+                   ... For error description see https://verilator.org/warn/DEPRECATED?v=latest
+%Error: Exiting due to

--- a/test_regress/t/t_flag_values_deprecated.pl
+++ b/test_regress/t/t_flag_values_deprecated.pl
@@ -11,8 +11,9 @@ if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); di
 scenarios(vlt => 1);
 
 lint(
-    verilator_flags2 => ["-Werror-DEPRECATED", "--no-threads", ],
+    verilator_flags2 => ["-Werror-DEPRECATED", "--no-threads"],
     fails => 1,
+    threads => 0,
     expect_filename => $Self->{golden_filename},
     );
 

--- a/test_regress/t/t_flag_values_deprecated.pl
+++ b/test_regress/t/t_flag_values_deprecated.pl
@@ -2,23 +2,18 @@
 if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
 # DESCRIPTION: Verilator: Verilog Test driver/expect definition
 #
-# Copyright 2003-2009 by Wilson Snyder. This program is free software; you
+# Copyright 2022 by Antmicro. This program is free software; you
 # can redistribute it and/or modify it under the terms of either the GNU
 # Lesser General Public License Version 3 or the Perl Artistic License
 # Version 2.0.
 # SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
 
-scenarios(simulator => 1);
+scenarios(vlt => 1);
 
-top_filename("t/t_threads_counter.v");
-
-compile(
-    verilator_flags2 => ['--cc'],
-    threads => 1,
-    );
-
-execute(
-    check_finished => 1,
+lint(
+    verilator_flags2 => ["-Werror-DEPRECATED", "--no-threads", ],
+    fails => 1,
+    expect_filename => $Self->{golden_filename},
     );
 
 ok(1);

--- a/test_regress/t/t_gantt.pl
+++ b/test_regress/t/t_gantt.pl
@@ -20,7 +20,7 @@ top_filename("t/t_gen_alw.v");
 compile(
     v_flags2 => ["--prof-exec"],
     # Checks below care about thread count, so use 2 (minimum reasonable)
-    threads => $Self->{vltmt} ? 2 : 0
+    threads => $Self->{vltmt} ? 2 : 1
     );
 
 execute(

--- a/test_regress/t/t_gantt_two.cpp
+++ b/test_regress/t/t_gantt_two.cpp
@@ -16,9 +16,8 @@ int main(int argc, char** argv, char** env) {
     srand48(5);
 
     const std::unique_ptr<VerilatedContext> contextp{new VerilatedContext};
-#ifdef VL_THREADED
-    contextp->threads(2);
-#endif
+    // VL_USE_THREADS define is set in t_gantt_two.pl
+    contextp->threads(VL_USE_THREADS);
     contextp->commandArgs(argc, argv);
     contextp->debug(0);
 

--- a/test_regress/t/t_gantt_two.cpp
+++ b/test_regress/t/t_gantt_two.cpp
@@ -17,7 +17,7 @@ int main(int argc, char** argv, char** env) {
 
     const std::unique_ptr<VerilatedContext> contextp{new VerilatedContext};
     // VL_USE_THREADS define is set in t_gantt_two.pl
-    contextp->threads(VL_USE_THREADS);
+    contextp->threads(TEST_USE_THREADS);
     contextp->commandArgs(argc, argv);
     contextp->debug(0);
 

--- a/test_regress/t/t_gantt_two.pl
+++ b/test_regress/t/t_gantt_two.pl
@@ -22,7 +22,7 @@ compile(
     make_main => 0,
     v_flags2 => ["--prof-exec --exe $Self->{t_dir}/$Self->{name}.cpp"],
     # Checks below care about thread count, so use 2 (minimum reasonable)
-    threads => $Self->{vltmt} ? 2 : 0,
+    threads => $Self->{vltmt} ? 2 : 1,
     make_flags => 'CPPFLAGS_ADD=-DVL_NO_LEGACY',
     );
 

--- a/test_regress/t/t_gantt_two.pl
+++ b/test_regress/t/t_gantt_two.pl
@@ -25,7 +25,7 @@ compile(
     v_flags2 => ["--prof-exec --exe $Self->{t_dir}/$Self->{name}.cpp"],
     # Checks below care about thread count, so use 2 (minimum reasonable)
     threads => $threads_num,
-    make_flags => "CPPFLAGS_ADD=\"-DVL_NO_LEGACY -DVL_USE_THREADS=$threads_num\"",
+    make_flags => "CPPFLAGS_ADD=\"-DVL_NO_LEGACY -DTEST_USE_THREADS=$threads_num\"",
     );
 
 execute(

--- a/test_regress/t/t_gantt_two.pl
+++ b/test_regress/t/t_gantt_two.pl
@@ -17,13 +17,15 @@ scenarios(vlt_all => 1);
 # enough for the profiling to happen:
 top_filename("t/t_gen_alw.v");
 
+my $threads_num = $Self->{vltmt} ? 2 : 1;
+
 compile(
     make_top_shell => 0,
     make_main => 0,
     v_flags2 => ["--prof-exec --exe $Self->{t_dir}/$Self->{name}.cpp"],
     # Checks below care about thread count, so use 2 (minimum reasonable)
-    threads => $Self->{vltmt} ? 2 : 1,
-    make_flags => 'CPPFLAGS_ADD=-DVL_NO_LEGACY',
+    threads => $threads_num,
+    make_flags => "CPPFLAGS_ADD=\"-DVL_NO_LEGACY -DVL_USE_THREADS=$threads_num\"",
     );
 
 execute(

--- a/test_regress/t/t_hier_block.pl
+++ b/test_regress/t/t_hier_block.pl
@@ -23,7 +23,7 @@ compile(
                          '--Wno-TIMESCALEMOD',
                          '--CFLAGS', '"-pipe -DCPP_MACRO=cplusplus"'
     ],
-    threads => $Self->{vltmt} ? 6 : 0
+    threads => $Self->{vltmt} ? 6 : 1
     );
 
 execute(

--- a/test_regress/t/t_hier_block_cmake.pl
+++ b/test_regress/t/t_hier_block_cmake.pl
@@ -13,17 +13,19 @@ clean_objs();
 scenarios(simulator => 1);
 top_filename("t/t_hier_block.v");
 
+my $threads = ($Self->{vltmt} ? '-DTEST_THREADS=6' : '-DTEST_THREADS=1');
+
 if (!$Self->have_cmake) {
     $Self->skip("Test requires CMake; ignore error since not available or version too old\n");
 } else {
     run(logfile => "$Self->{obj_dir}/cmake.log",
         cmd => ['cd "' . $Self->{obj_dir} . '" && cmake ' . $Self->{t_dir} . '/t_hier_block_cmake',
             "-DCMAKE_PREFIX_PATH=$ENV{VERILATOR_ROOT}",
-            ($Self->{vltmt} ? '-DTEST_THREADS=6' : '')
+            $threads
         ]);
 
     run(logfile => "$Self->{obj_dir}/build.log",
-        cmd => ['cd "' . $Self->{obj_dir} . '" && cmake --build', '.']
+        cmd => ['cd "' . $Self->{obj_dir} . '" && cmake --build', '.', '--', "CXX_FLAGS=$threads"]
     );
 
     run(logfile => "$Self->{obj_dir}/run.log",

--- a/test_regress/t/t_hier_block_cmake/main.cpp
+++ b/test_regress/t/t_hier_block_cmake/main.cpp
@@ -14,9 +14,8 @@
 
 int main(int argc, char *argv[]) {
     const std::unique_ptr<VerilatedContext> contextp{new VerilatedContext};
-#if VL_THREADED
-    contextp->threads(6);
-#endif
+    // TEST_THREADS is set in t_hier_block_cmake.pl
+    contextp->threads(TEST_THREADS);
     contextp->commandArgs(argc, argv);
     std::unique_ptr<Vt_hier_block> top{new Vt_hier_block{contextp.get(), "top"}};
     for (int i = 0; i < 100 && !contextp->gotFinish(); ++i) {

--- a/test_regress/t/t_hier_block_nohier.pl
+++ b/test_regress/t/t_hier_block_nohier.pl
@@ -24,7 +24,7 @@ compile(
     verilator_flags2 => ['--stats',
                          '+define+USE_VLT', 't/t_hier_block_vlt.vlt',
                          '--CFLAGS', '"-pipe -DCPP_MACRO=cplusplus"'],
-    threads => $Self->{vltmt} ? 6 : 0
+    threads => $Self->{vltmt} ? 6 : 1
     );
 
 execute(

--- a/test_regress/t/t_hier_block_sc.pl
+++ b/test_regress/t/t_hier_block_sc.pl
@@ -24,7 +24,7 @@ compile(
                          '--hierarchical',
                          '--CFLAGS', '"-pipe -DCPP_MACRO=cplusplus"'
     ],
-    threads => $Self->{vltmt} ? 6 : 0
+    threads => $Self->{vltmt} ? 6 : 1
     );
 
 execute(

--- a/test_regress/t/t_hier_block_sc_trace_fst.pl
+++ b/test_regress/t/t_hier_block_sc_trace_fst.pl
@@ -26,7 +26,7 @@ compile(
                          "--CFLAGS", '"-O0 -ggdb"',
                          "--trace-fst"
     ],
-    threads => $Self->{vltmt} ? 6 : 0
+    threads => $Self->{vltmt} ? 6 : 1
     );
 
 execute(

--- a/test_regress/t/t_hier_block_sc_trace_vcd.pl
+++ b/test_regress/t/t_hier_block_sc_trace_vcd.pl
@@ -26,7 +26,7 @@ compile(
                          "--CFLAGS", '"-O0 -ggdb"',
                          "--trace"
     ],
-    threads => $Self->{vltmt} ? 6 : 0
+    threads => $Self->{vltmt} ? 6 : 1
     );
 
 execute(

--- a/test_regress/t/t_hier_block_trace_fst.pl
+++ b/test_regress/t/t_hier_block_trace_fst.pl
@@ -22,7 +22,7 @@ compile(
                          '--trace-fst',
                          '--no-trace-underscore',  # To avoid handle mismatches
     ],
-    threads => $Self->{vltmt} ? 6 : 0
+    threads => $Self->{vltmt} ? 6 : 1
     );
 
 execute(

--- a/test_regress/t/t_hier_block_trace_vcd.pl
+++ b/test_regress/t/t_hier_block_trace_vcd.pl
@@ -22,7 +22,7 @@ compile(
                          '--trace',
                          '--no-trace-underscore',  # To avoid handle mismatches
     ],
-    threads => $Self->{vltmt} ? 6 : 0
+    threads => $Self->{vltmt} ? 6 : 1
     );
 
 execute(

--- a/test_regress/t/t_hier_block_vlt.pl
+++ b/test_regress/t/t_hier_block_vlt.pl
@@ -23,7 +23,7 @@ compile(
                          '+define+SHOW_TIMESCALE',
                          '+define+USE_VLT', 't/t_hier_block_vlt.vlt',
                          '--CFLAGS', '"-pipe -DCPP_MACRO=cplusplus"'],
-    threads => $Self->{vltmt} ? 6 : 0
+    threads => $Self->{vltmt} ? 6 : 1
     );
 
 execute(

--- a/test_regress/t/t_inst_tree_inl0_pub1.pl
+++ b/test_regress/t/t_inst_tree_inl0_pub1.pl
@@ -16,7 +16,7 @@ my $default_vltmt_threads = $Self->get_default_vltmt_threads();
 compile(
     verilator_flags2 => ['--stats', "$Self->{t_dir}/$Self->{name}.vlt"],
     # Force 3 threads even if we have fewer cores
-    threads => $Self->{vltmt} ? $default_vltmt_threads : 0
+    threads => $Self->{vltmt} ? $default_vltmt_threads : 1
     );
 
 sub checkRelativeRefs {

--- a/test_regress/t/t_lib_prot_shared.pl
+++ b/test_regress/t/t_lib_prot_shared.pl
@@ -61,7 +61,7 @@ while (1) {
                              "-LDFLAGS",
                              "'-Wl,-rpath,$abs_secret_dir -L$abs_secret_dir -l$secret_prefix'"],
         xsim_flags2 => ["$secret_dir/secret.sv"],
-        threads => $Self->{vltmt} ? 1 : 0,
+        threads => 1,
         context_threads => $Self->{vltmt} ? 6 : 1
         );
 

--- a/test_regress/t/t_split_var_0.pl
+++ b/test_regress/t/t_split_var_0.pl
@@ -15,7 +15,7 @@ scenarios(simulator => 1);
 # So use 6 threads here though it's not optimal in performace wise, but ok.
 compile(
     verilator_flags2 => ['--stats', "$Self->{t_dir}/t_split_var_0.vlt"],
-    threads => $Self->{vltmt} ? 6 : 0
+    threads => $Self->{vltmt} ? 6 : 1
     );
 
 execute(

--- a/test_regress/t/t_split_var_2_trace.pl
+++ b/test_regress/t/t_split_var_2_trace.pl
@@ -16,7 +16,7 @@ top_filename("t/t_split_var_0.v");
 # So use 6 threads here though it's not optimal in performace wise, but ok.
 compile(
     verilator_flags2 => ['--cc --trace --stats +define+TEST_ATTRIBUTES'],
-    threads => $Self->{vltmt} ? 6 : 0
+    threads => $Self->{vltmt} ? 6 : 1
     );
 
 execute(

--- a/test_regress/t/t_threads_crazy_context.pl
+++ b/test_regress/t/t_threads_crazy_context.pl
@@ -18,7 +18,7 @@ top_filename("t/t_threads_crazy.v");
 
 compile(
     verilator_flags2 => ['--cc'],
-    threads => $Self->{vltmt} ? 2 : 0,
+    threads => $Self->{vltmt} ? 2 : 1,
     context_threads => 1024
     );
 
@@ -28,8 +28,6 @@ execute(
 
 if ($Self->{vltmt}) {
     file_grep($Self->{run_log_filename}, qr/System has \d+ hardware threads but simulation thread count set to 1024\. This will likely cause significant slowdown\./);
-} else {
-    file_grep($Self->{run_log_filename}, qr/Verilator run-time library built without VL_THREADS\. Ignoring call to 'VerilatedContext::threads' with argument 1024\./);
 }
 
 ok(1);

--- a/test_regress/t/t_timing_debug1.out
+++ b/test_regress/t/t_timing_debug1.out
@@ -32,6 +32,7 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__stl
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__stl
 -V{t#,#}         No triggers active
+-V{t#,#}MTask0 starting
 -V{t#,#}+ Eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
@@ -61,8 +62,10 @@
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         No triggers active
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
+-V{t#,#}End-of-eval cleanup
 -V{t#,#}+++++TOP Evaluate Vt_timing_debug1::eval_step
 -V{t#,#}+    Vt_timing_debug1___024root___eval_debug_assertions
+-V{t#,#}MTask0 starting
 -V{t#,#}+ Eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
@@ -119,8 +122,10 @@
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         No triggers active
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
+-V{t#,#}End-of-eval cleanup
 -V{t#,#}+++++TOP Evaluate Vt_timing_debug1::eval_step
 -V{t#,#}+    Vt_timing_debug1___024root___eval_debug_assertions
+-V{t#,#}MTask0 starting
 -V{t#,#}+ Eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
@@ -156,8 +161,10 @@
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         No triggers active
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
+-V{t#,#}End-of-eval cleanup
 -V{t#,#}+++++TOP Evaluate Vt_timing_debug1::eval_step
 -V{t#,#}+    Vt_timing_debug1___024root___eval_debug_assertions
+-V{t#,#}MTask0 starting
 -V{t#,#}+ Eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
@@ -188,8 +195,10 @@
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         No triggers active
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
+-V{t#,#}End-of-eval cleanup
 -V{t#,#}+++++TOP Evaluate Vt_timing_debug1::eval_step
 -V{t#,#}+    Vt_timing_debug1___024root___eval_debug_assertions
+-V{t#,#}MTask0 starting
 -V{t#,#}+ Eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
@@ -238,8 +247,10 @@
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         No triggers active
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
+-V{t#,#}End-of-eval cleanup
 -V{t#,#}+++++TOP Evaluate Vt_timing_debug1::eval_step
 -V{t#,#}+    Vt_timing_debug1___024root___eval_debug_assertions
+-V{t#,#}MTask0 starting
 -V{t#,#}+ Eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
@@ -301,8 +312,10 @@
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         No triggers active
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
+-V{t#,#}End-of-eval cleanup
 -V{t#,#}+++++TOP Evaluate Vt_timing_debug1::eval_step
 -V{t#,#}+    Vt_timing_debug1___024root___eval_debug_assertions
+-V{t#,#}MTask0 starting
 -V{t#,#}+ Eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
@@ -342,8 +355,10 @@
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         No triggers active
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
+-V{t#,#}End-of-eval cleanup
 -V{t#,#}+++++TOP Evaluate Vt_timing_debug1::eval_step
 -V{t#,#}+    Vt_timing_debug1___024root___eval_debug_assertions
+-V{t#,#}MTask0 starting
 -V{t#,#}+ Eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
@@ -373,8 +388,10 @@
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         No triggers active
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
+-V{t#,#}End-of-eval cleanup
 -V{t#,#}+++++TOP Evaluate Vt_timing_debug1::eval_step
 -V{t#,#}+    Vt_timing_debug1___024root___eval_debug_assertions
+-V{t#,#}MTask0 starting
 -V{t#,#}+ Eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
@@ -428,8 +445,10 @@
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         No triggers active
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
+-V{t#,#}End-of-eval cleanup
 -V{t#,#}+++++TOP Evaluate Vt_timing_debug1::eval_step
 -V{t#,#}+    Vt_timing_debug1___024root___eval_debug_assertions
+-V{t#,#}MTask0 starting
 -V{t#,#}+ Eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
@@ -464,8 +483,10 @@
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         No triggers active
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
+-V{t#,#}End-of-eval cleanup
 -V{t#,#}+++++TOP Evaluate Vt_timing_debug1::eval_step
 -V{t#,#}+    Vt_timing_debug1___024root___eval_debug_assertions
+-V{t#,#}MTask0 starting
 -V{t#,#}+ Eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
@@ -495,8 +516,10 @@
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         No triggers active
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
+-V{t#,#}End-of-eval cleanup
 -V{t#,#}+++++TOP Evaluate Vt_timing_debug1::eval_step
 -V{t#,#}+    Vt_timing_debug1___024root___eval_debug_assertions
+-V{t#,#}MTask0 starting
 -V{t#,#}+ Eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
@@ -544,8 +567,10 @@
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         No triggers active
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
+-V{t#,#}End-of-eval cleanup
 -V{t#,#}+++++TOP Evaluate Vt_timing_debug1::eval_step
 -V{t#,#}+    Vt_timing_debug1___024root___eval_debug_assertions
+-V{t#,#}MTask0 starting
 -V{t#,#}+ Eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
@@ -580,8 +605,10 @@
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         No triggers active
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
+-V{t#,#}End-of-eval cleanup
 -V{t#,#}+++++TOP Evaluate Vt_timing_debug1::eval_step
 -V{t#,#}+    Vt_timing_debug1___024root___eval_debug_assertions
+-V{t#,#}MTask0 starting
 -V{t#,#}+ Eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
@@ -616,8 +643,10 @@
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         No triggers active
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
+-V{t#,#}End-of-eval cleanup
 -V{t#,#}+++++TOP Evaluate Vt_timing_debug1::eval_step
 -V{t#,#}+    Vt_timing_debug1___024root___eval_debug_assertions
+-V{t#,#}MTask0 starting
 -V{t#,#}+ Eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
@@ -647,8 +676,10 @@
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         No triggers active
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
+-V{t#,#}End-of-eval cleanup
 -V{t#,#}+++++TOP Evaluate Vt_timing_debug1::eval_step
 -V{t#,#}+    Vt_timing_debug1___024root___eval_debug_assertions
+-V{t#,#}MTask0 starting
 -V{t#,#}+ Eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
@@ -696,8 +727,10 @@
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         No triggers active
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
+-V{t#,#}End-of-eval cleanup
 -V{t#,#}+++++TOP Evaluate Vt_timing_debug1::eval_step
 -V{t#,#}+    Vt_timing_debug1___024root___eval_debug_assertions
+-V{t#,#}MTask0 starting
 -V{t#,#}+ Eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
@@ -732,8 +765,10 @@
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         No triggers active
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
+-V{t#,#}End-of-eval cleanup
 -V{t#,#}+++++TOP Evaluate Vt_timing_debug1::eval_step
 -V{t#,#}+    Vt_timing_debug1___024root___eval_debug_assertions
+-V{t#,#}MTask0 starting
 -V{t#,#}+ Eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
@@ -763,8 +798,10 @@
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         No triggers active
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
+-V{t#,#}End-of-eval cleanup
 -V{t#,#}+++++TOP Evaluate Vt_timing_debug1::eval_step
 -V{t#,#}+    Vt_timing_debug1___024root___eval_debug_assertions
+-V{t#,#}MTask0 starting
 -V{t#,#}+ Eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
@@ -834,8 +871,10 @@
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         No triggers active
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
+-V{t#,#}End-of-eval cleanup
 -V{t#,#}+++++TOP Evaluate Vt_timing_debug1::eval_step
 -V{t#,#}+    Vt_timing_debug1___024root___eval_debug_assertions
+-V{t#,#}MTask0 starting
 -V{t#,#}+ Eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
@@ -866,8 +905,10 @@
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         No triggers active
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
+-V{t#,#}End-of-eval cleanup
 -V{t#,#}+++++TOP Evaluate Vt_timing_debug1::eval_step
 -V{t#,#}+    Vt_timing_debug1___024root___eval_debug_assertions
+-V{t#,#}MTask0 starting
 -V{t#,#}+ Eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
@@ -902,8 +943,10 @@
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         No triggers active
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
+-V{t#,#}End-of-eval cleanup
 -V{t#,#}+++++TOP Evaluate Vt_timing_debug1::eval_step
 -V{t#,#}+    Vt_timing_debug1___024root___eval_debug_assertions
+-V{t#,#}MTask0 starting
 -V{t#,#}+ Eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
@@ -933,8 +976,10 @@
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         No triggers active
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
+-V{t#,#}End-of-eval cleanup
 -V{t#,#}+++++TOP Evaluate Vt_timing_debug1::eval_step
 -V{t#,#}+    Vt_timing_debug1___024root___eval_debug_assertions
+-V{t#,#}MTask0 starting
 -V{t#,#}+ Eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
@@ -988,8 +1033,10 @@
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         No triggers active
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
+-V{t#,#}End-of-eval cleanup
 -V{t#,#}+++++TOP Evaluate Vt_timing_debug1::eval_step
 -V{t#,#}+    Vt_timing_debug1___024root___eval_debug_assertions
+-V{t#,#}MTask0 starting
 -V{t#,#}+ Eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
@@ -1024,8 +1071,10 @@
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         No triggers active
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
+-V{t#,#}End-of-eval cleanup
 -V{t#,#}+++++TOP Evaluate Vt_timing_debug1::eval_step
 -V{t#,#}+    Vt_timing_debug1___024root___eval_debug_assertions
+-V{t#,#}MTask0 starting
 -V{t#,#}+ Eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
@@ -1055,8 +1104,10 @@
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         No triggers active
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
+-V{t#,#}End-of-eval cleanup
 -V{t#,#}+++++TOP Evaluate Vt_timing_debug1::eval_step
 -V{t#,#}+    Vt_timing_debug1___024root___eval_debug_assertions
+-V{t#,#}MTask0 starting
 -V{t#,#}+ Eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
@@ -1090,8 +1141,10 @@
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         No triggers active
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
+-V{t#,#}End-of-eval cleanup
 -V{t#,#}+++++TOP Evaluate Vt_timing_debug1::eval_step
 -V{t#,#}+    Vt_timing_debug1___024root___eval_debug_assertions
+-V{t#,#}MTask0 starting
 -V{t#,#}+ Eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
@@ -1139,8 +1192,10 @@
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         No triggers active
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
+-V{t#,#}End-of-eval cleanup
 -V{t#,#}+++++TOP Evaluate Vt_timing_debug1::eval_step
 -V{t#,#}+    Vt_timing_debug1___024root___eval_debug_assertions
+-V{t#,#}MTask0 starting
 -V{t#,#}+ Eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
@@ -1175,8 +1230,10 @@
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         No triggers active
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
+-V{t#,#}End-of-eval cleanup
 -V{t#,#}+++++TOP Evaluate Vt_timing_debug1::eval_step
 -V{t#,#}+    Vt_timing_debug1___024root___eval_debug_assertions
+-V{t#,#}MTask0 starting
 -V{t#,#}+ Eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
@@ -1206,8 +1263,10 @@
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         No triggers active
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
+-V{t#,#}End-of-eval cleanup
 -V{t#,#}+++++TOP Evaluate Vt_timing_debug1::eval_step
 -V{t#,#}+    Vt_timing_debug1___024root___eval_debug_assertions
+-V{t#,#}MTask0 starting
 -V{t#,#}+ Eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
@@ -1255,8 +1314,10 @@
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         No triggers active
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
+-V{t#,#}End-of-eval cleanup
 -V{t#,#}+++++TOP Evaluate Vt_timing_debug1::eval_step
 -V{t#,#}+    Vt_timing_debug1___024root___eval_debug_assertions
+-V{t#,#}MTask0 starting
 -V{t#,#}+ Eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
@@ -1291,8 +1352,10 @@
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         No triggers active
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
+-V{t#,#}End-of-eval cleanup
 -V{t#,#}+++++TOP Evaluate Vt_timing_debug1::eval_step
 -V{t#,#}+    Vt_timing_debug1___024root___eval_debug_assertions
+-V{t#,#}MTask0 starting
 -V{t#,#}+ Eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
@@ -1356,8 +1419,10 @@
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         No triggers active
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
+-V{t#,#}End-of-eval cleanup
 -V{t#,#}+++++TOP Evaluate Vt_timing_debug1::eval_step
 -V{t#,#}+    Vt_timing_debug1___024root___eval_debug_assertions
+-V{t#,#}MTask0 starting
 -V{t#,#}+ Eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
@@ -1387,8 +1452,10 @@
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         No triggers active
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
+-V{t#,#}End-of-eval cleanup
 -V{t#,#}+++++TOP Evaluate Vt_timing_debug1::eval_step
 -V{t#,#}+    Vt_timing_debug1___024root___eval_debug_assertions
+-V{t#,#}MTask0 starting
 -V{t#,#}+ Eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
@@ -1442,8 +1509,10 @@
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         No triggers active
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
+-V{t#,#}End-of-eval cleanup
 -V{t#,#}+++++TOP Evaluate Vt_timing_debug1::eval_step
 -V{t#,#}+    Vt_timing_debug1___024root___eval_debug_assertions
+-V{t#,#}MTask0 starting
 -V{t#,#}+ Eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
@@ -1478,8 +1547,10 @@
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         No triggers active
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
+-V{t#,#}End-of-eval cleanup
 -V{t#,#}+++++TOP Evaluate Vt_timing_debug1::eval_step
 -V{t#,#}+    Vt_timing_debug1___024root___eval_debug_assertions
+-V{t#,#}MTask0 starting
 -V{t#,#}+ Eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
@@ -1509,8 +1580,10 @@
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         No triggers active
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
+-V{t#,#}End-of-eval cleanup
 -V{t#,#}+++++TOP Evaluate Vt_timing_debug1::eval_step
 -V{t#,#}+    Vt_timing_debug1___024root___eval_debug_assertions
+-V{t#,#}MTask0 starting
 -V{t#,#}+ Eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
@@ -1558,8 +1631,10 @@
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         No triggers active
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
+-V{t#,#}End-of-eval cleanup
 -V{t#,#}+++++TOP Evaluate Vt_timing_debug1::eval_step
 -V{t#,#}+    Vt_timing_debug1___024root___eval_debug_assertions
+-V{t#,#}MTask0 starting
 -V{t#,#}+ Eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
@@ -1598,8 +1673,10 @@
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         No triggers active
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
+-V{t#,#}End-of-eval cleanup
 -V{t#,#}+++++TOP Evaluate Vt_timing_debug1::eval_step
 -V{t#,#}+    Vt_timing_debug1___024root___eval_debug_assertions
+-V{t#,#}MTask0 starting
 -V{t#,#}+ Eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
@@ -1629,8 +1706,10 @@
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         No triggers active
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
+-V{t#,#}End-of-eval cleanup
 -V{t#,#}+++++TOP Evaluate Vt_timing_debug1::eval_step
 -V{t#,#}+    Vt_timing_debug1___024root___eval_debug_assertions
+-V{t#,#}MTask0 starting
 -V{t#,#}+ Eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
@@ -1678,8 +1757,10 @@
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         No triggers active
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
+-V{t#,#}End-of-eval cleanup
 -V{t#,#}+++++TOP Evaluate Vt_timing_debug1::eval_step
 -V{t#,#}+    Vt_timing_debug1___024root___eval_debug_assertions
+-V{t#,#}MTask0 starting
 -V{t#,#}+ Eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
@@ -1714,8 +1795,10 @@
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         No triggers active
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
+-V{t#,#}End-of-eval cleanup
 -V{t#,#}+++++TOP Evaluate Vt_timing_debug1::eval_step
 -V{t#,#}+    Vt_timing_debug1___024root___eval_debug_assertions
+-V{t#,#}MTask0 starting
 -V{t#,#}+ Eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
@@ -1745,8 +1828,10 @@
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         No triggers active
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
+-V{t#,#}End-of-eval cleanup
 -V{t#,#}+++++TOP Evaluate Vt_timing_debug1::eval_step
 -V{t#,#}+    Vt_timing_debug1___024root___eval_debug_assertions
+-V{t#,#}MTask0 starting
 -V{t#,#}+ Eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
@@ -1794,8 +1879,10 @@
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         No triggers active
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
+-V{t#,#}End-of-eval cleanup
 -V{t#,#}+++++TOP Evaluate Vt_timing_debug1::eval_step
 -V{t#,#}+    Vt_timing_debug1___024root___eval_debug_assertions
+-V{t#,#}MTask0 starting
 -V{t#,#}+ Eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
@@ -1855,8 +1942,10 @@
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         No triggers active
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
+-V{t#,#}End-of-eval cleanup
 -V{t#,#}+++++TOP Evaluate Vt_timing_debug1::eval_step
 -V{t#,#}+    Vt_timing_debug1___024root___eval_debug_assertions
+-V{t#,#}MTask0 starting
 -V{t#,#}+ Eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
@@ -1898,4 +1987,5 @@
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         No triggers active
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
+-V{t#,#}End-of-eval cleanup
 -V{t#,#}+    Vt_timing_debug1___024root___eval_final

--- a/test_regress/t/t_timing_debug2.out
+++ b/test_regress/t/t_timing_debug2.out
@@ -60,6 +60,7 @@
 -V{t#,#}             Awaiting join of fork at: t/t_timing_class.v:209
 -V{t#,#}+      Vt_timing_debug2_t___eval_initial__TOP__t__7
 -V{t#,#}+    Vt_timing_debug2___024root___eval_settle
+-V{t#,#}MTask0 starting
 -V{t#,#}+ Eval
 -V{t#,#}+    Vt_timing_debug2___024root___eval
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
@@ -69,8 +70,10 @@
 -V{t#,#}+    Vt_timing_debug2___024root___timing_commit
 -V{t#,#}         Committing processes waiting for @([event] t.ec.e):
 -V{t#,#}           - Process waiting at t/t_timing_class.v:80
+-V{t#,#}End-of-eval cleanup
 -V{t#,#}+++++TOP Evaluate Vt_timing_debug2::eval_step
 -V{t#,#}+    Vt_timing_debug2___024root___eval_debug_assertions
+-V{t#,#}MTask0 starting
 -V{t#,#}+ Eval
 -V{t#,#}+    Vt_timing_debug2___024root___eval
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
@@ -107,8 +110,10 @@
 -V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
 -V{t#,#}         No triggers active
 -V{t#,#}+    Vt_timing_debug2___024root___timing_commit
+-V{t#,#}End-of-eval cleanup
 -V{t#,#}+++++TOP Evaluate Vt_timing_debug2::eval_step
 -V{t#,#}+    Vt_timing_debug2___024root___eval_debug_assertions
+-V{t#,#}MTask0 starting
 -V{t#,#}+ Eval
 -V{t#,#}+    Vt_timing_debug2___024root___eval
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
@@ -174,8 +179,10 @@
 -V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:29
 -V{t#,#}         Suspending process waiting for @([event] t::EventClass.e) at t/t_timing_class.v:29
 -V{t#,#}+    Vt_timing_debug2___024root___timing_commit
+-V{t#,#}End-of-eval cleanup
 -V{t#,#}+++++TOP Evaluate Vt_timing_debug2::eval_step
 -V{t#,#}+    Vt_timing_debug2___024root___eval_debug_assertions
+-V{t#,#}MTask0 starting
 -V{t#,#}+ Eval
 -V{t#,#}+    Vt_timing_debug2___024root___eval
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
@@ -230,8 +237,10 @@
 -V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:29
 -V{t#,#}         Suspending process waiting for @([event] t::EventClass.e) at t/t_timing_class.v:29
 -V{t#,#}+    Vt_timing_debug2___024root___timing_commit
+-V{t#,#}End-of-eval cleanup
 -V{t#,#}+++++TOP Evaluate Vt_timing_debug2::eval_step
 -V{t#,#}+    Vt_timing_debug2___024root___eval_debug_assertions
+-V{t#,#}MTask0 starting
 -V{t#,#}+ Eval
 -V{t#,#}+    Vt_timing_debug2___024root___eval
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
@@ -305,8 +314,10 @@
 -V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
 -V{t#,#}         No triggers active
 -V{t#,#}+    Vt_timing_debug2___024root___timing_commit
+-V{t#,#}End-of-eval cleanup
 -V{t#,#}+++++TOP Evaluate Vt_timing_debug2::eval_step
 -V{t#,#}+    Vt_timing_debug2___024root___eval_debug_assertions
+-V{t#,#}MTask0 starting
 -V{t#,#}+ Eval
 -V{t#,#}+    Vt_timing_debug2___024root___eval
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
@@ -344,8 +355,10 @@
 -V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
 -V{t#,#}         No triggers active
 -V{t#,#}+    Vt_timing_debug2___024root___timing_commit
+-V{t#,#}End-of-eval cleanup
 -V{t#,#}+++++TOP Evaluate Vt_timing_debug2::eval_step
 -V{t#,#}+    Vt_timing_debug2___024root___eval_debug_assertions
+-V{t#,#}MTask0 starting
 -V{t#,#}+ Eval
 -V{t#,#}+    Vt_timing_debug2___024root___eval
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
@@ -401,8 +414,10 @@
 -V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
 -V{t#,#}         No triggers active
 -V{t#,#}+    Vt_timing_debug2___024root___timing_commit
+-V{t#,#}End-of-eval cleanup
 -V{t#,#}+++++TOP Evaluate Vt_timing_debug2::eval_step
 -V{t#,#}+    Vt_timing_debug2___024root___eval_debug_assertions
+-V{t#,#}MTask0 starting
 -V{t#,#}+ Eval
 -V{t#,#}+    Vt_timing_debug2___024root___eval
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
@@ -459,10 +474,12 @@
 -V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
 -V{t#,#}         No triggers active
 -V{t#,#}+    Vt_timing_debug2___024root___timing_commit
+-V{t#,#}End-of-eval cleanup
 -V{t#,#}+++++TOP Evaluate Vt_timing_debug2::eval_step
 -V{t#,#}+    Vt_timing_debug2___024root___eval_debug_assertions
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aForkDelayClass::~
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aForkClass::~
+-V{t#,#}MTask0 starting
 -V{t#,#}+ Eval
 -V{t#,#}+    Vt_timing_debug2___024root___eval
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
@@ -490,8 +507,10 @@
 -V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
 -V{t#,#}         No triggers active
 -V{t#,#}+    Vt_timing_debug2___024root___timing_commit
+-V{t#,#}End-of-eval cleanup
 -V{t#,#}+++++TOP Evaluate Vt_timing_debug2::eval_step
 -V{t#,#}+    Vt_timing_debug2___024root___eval_debug_assertions
+-V{t#,#}MTask0 starting
 -V{t#,#}+ Eval
 -V{t#,#}+    Vt_timing_debug2___024root___eval
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
@@ -521,8 +540,10 @@
 -V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
 -V{t#,#}         No triggers active
 -V{t#,#}+    Vt_timing_debug2___024root___timing_commit
+-V{t#,#}End-of-eval cleanup
 -V{t#,#}+++++TOP Evaluate Vt_timing_debug2::eval_step
 -V{t#,#}+    Vt_timing_debug2___024root___eval_debug_assertions
+-V{t#,#}MTask0 starting
 -V{t#,#}+ Eval
 -V{t#,#}+    Vt_timing_debug2___024root___eval
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
@@ -549,8 +570,10 @@
 -V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
 -V{t#,#}         No triggers active
 -V{t#,#}+    Vt_timing_debug2___024root___timing_commit
+-V{t#,#}End-of-eval cleanup
 -V{t#,#}+++++TOP Evaluate Vt_timing_debug2::eval_step
 -V{t#,#}+    Vt_timing_debug2___024root___eval_debug_assertions
+-V{t#,#}MTask0 starting
 -V{t#,#}+ Eval
 -V{t#,#}+    Vt_timing_debug2___024root___eval
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
@@ -577,9 +600,11 @@
 -V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
 -V{t#,#}         No triggers active
 -V{t#,#}+    Vt_timing_debug2___024root___timing_commit
+-V{t#,#}End-of-eval cleanup
 -V{t#,#}+++++TOP Evaluate Vt_timing_debug2::eval_step
 -V{t#,#}+    Vt_timing_debug2___024root___eval_debug_assertions
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aAssignDelayClass::~
+-V{t#,#}MTask0 starting
 -V{t#,#}+ Eval
 -V{t#,#}+    Vt_timing_debug2___024root___eval
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
@@ -606,6 +631,7 @@
 -V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
 -V{t#,#}         No triggers active
 -V{t#,#}+    Vt_timing_debug2___024root___timing_commit
+-V{t#,#}End-of-eval cleanup
 -V{t#,#}+    Vt_timing_debug2___024root___eval_final
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aDelay40::~
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aDelayClass::~

--- a/test_regress/t/t_trace_litendian.pl
+++ b/test_regress/t/t_trace_litendian.pl
@@ -15,7 +15,7 @@ scenarios(simulator => 1);
 # Strangely, asking for more threads makes it go away.
 compile(
     verilator_flags2 => ['--cc --trace --trace-params -Wno-LITENDIAN'],
-    threads => $Self->{vltmt} ? 6 : 0
+    threads => $Self->{vltmt} ? 6 : 1
     );
 
 execute(

--- a/test_regress/t/t_trace_litendian_fst.pl
+++ b/test_regress/t/t_trace_litendian_fst.pl
@@ -17,7 +17,7 @@ top_filename("t/t_trace_litendian.v");
 # Strangely, asking for more threads makes it go away.
 compile(
     verilator_flags2 => ['--cc --trace-fst --trace-params -Wno-LITENDIAN'],
-    threads => $Self->{vltmt} ? 6 : 0
+    threads => $Self->{vltmt} ? 6 : 1
     );
 
 execute(

--- a/test_regress/t/t_trace_litendian_fst_sc.pl
+++ b/test_regress/t/t_trace_litendian_fst_sc.pl
@@ -21,7 +21,7 @@ else {
     # Strangely, asking for more threads makes it go away.
     compile(
         verilator_flags2 => ['--sc --trace-fst --trace-params -Wno-LITENDIAN'],
-        threads => $Self->{vltmt} ? 6 : 0
+        threads => $Self->{vltmt} ? 6 : 1
         );
 
     execute(

--- a/test_regress/t/t_verilated_debug.out
+++ b/test_regress/t/t_verilated_debug.out
@@ -13,13 +13,16 @@ internalsDump:
 -V{t#,#}+    Vt_verilated_debug___024root___eval_initial__TOP
   Data: w96: 000000aa 000000bb 000000cc 
 -V{t#,#}+    Vt_verilated_debug___024root___eval_settle
+-V{t#,#}MTask0 starting
 -V{t#,#}+ Eval
 -V{t#,#}+    Vt_verilated_debug___024root___eval
 -V{t#,#}+    Vt_verilated_debug___024root___eval_triggers__act
 -V{t#,#}+    Vt_verilated_debug___024root___dump_triggers__act
 -V{t#,#}         No triggers active
+-V{t#,#}End-of-eval cleanup
 -V{t#,#}+++++TOP Evaluate Vt_verilated_debug::eval_step
 -V{t#,#}+    Vt_verilated_debug___024root___eval_debug_assertions
+-V{t#,#}MTask0 starting
 -V{t#,#}+ Eval
 -V{t#,#}+    Vt_verilated_debug___024root___eval
 -V{t#,#}+    Vt_verilated_debug___024root___eval_triggers__act
@@ -35,4 +38,5 @@ internalsDump:
 -V{t#,#}+    Vt_verilated_debug___024root___eval_triggers__act
 -V{t#,#}+    Vt_verilated_debug___024root___dump_triggers__act
 -V{t#,#}         No triggers active
+-V{t#,#}End-of-eval cleanup
 -V{t#,#}+    Vt_verilated_debug___024root___eval_final

--- a/verilator-config.cmake.in
+++ b/verilator-config.cmake.in
@@ -78,6 +78,12 @@ if (NOT CMAKE_CXX_COMPILER_ID MATCHES MSVC)
 endif()
 
 define_property(TARGET
+  PROPERTY VERILATOR_THREADED
+  BRIEF_DOCS "Deprecated and has no effect (ignored)"
+  FULL_DOCS "Deprecated and has no effect (ignored)"
+)
+
+define_property(TARGET
   PROPERTY VERILATOR_TRACE_THREADED
   BRIEF_DOCS "Verilator multithread tracing enabled"
   FULL_DOCS "Verilator multithread tracing enabled"

--- a/verilator-config.cmake.in
+++ b/verilator-config.cmake.in
@@ -262,11 +262,6 @@ function(verilate TARGET)
                      "${VCMAKE}" "${VCMAKE_COPY}"
                      DEPENDS "${VCMAKE}" VERBATIM)
 
-  if (${VERILATE_PREFIX}_THREADS)
-    # If any verilate() call specifies THREADS, define VL_THREADED in the final build
-    set_property(TARGET ${TARGET} PROPERTY VERILATOR_THREADED ON)
-  endif()
-
   if (${VERILATE_PREFIX}_COVERAGE)
     # If any verilate() call specifies COVERAGE, define VM_COVERAGE in the final build
     set_property(TARGET ${TARGET} PROPERTY VERILATOR_COVERAGE ON)
@@ -326,7 +321,6 @@ function(verilate TARGET)
   target_compile_definitions(${TARGET} PRIVATE
     VM_COVERAGE=$<BOOL:$<TARGET_PROPERTY:VERILATOR_COVERAGE>>
     VM_SC=$<BOOL:$<TARGET_PROPERTY:VERILATOR_SYSTEMC>>
-    $<$<BOOL:$<TARGET_PROPERTY:VERILATOR_THREADED>>:VL_THREADED>
     VM_TRACE=$<BOOL:$<TARGET_PROPERTY:VERILATOR_TRACE>>
     VM_TRACE_VCD=$<BOOL:$<TARGET_PROPERTY:VERILATOR_TRACE_VCD>>
     VM_TRACE_FST=$<BOOL:$<TARGET_PROPERTY:VERILATOR_TRACE_FST>>

--- a/verilator-config.cmake.in
+++ b/verilator-config.cmake.in
@@ -324,11 +324,9 @@ function(verilate TARGET)
     ${${VERILATE_PREFIX}_USER_LDLIBS}
   )
 
-  if (${VERILATE_PREFIX}_THREADS OR ${VERILATE_PREFIX}_TRACE_THREADS)
-    target_link_libraries(${TARGET} PUBLIC
-      ${VERILATOR_MT_CFLAGS}
-    )
-  endif()
+  target_link_libraries(${TARGET} PUBLIC
+    ${VERILATOR_MT_CFLAGS}
+  )
 
   target_compile_features(${TARGET} PRIVATE cxx_std_11)
 

--- a/verilator-config.cmake.in
+++ b/verilator-config.cmake.in
@@ -78,12 +78,6 @@ if (NOT CMAKE_CXX_COMPILER_ID MATCHES MSVC)
 endif()
 
 define_property(TARGET
-  PROPERTY VERILATOR_THREADED
-  BRIEF_DOCS "Verilator multithreading enabled"
-  FULL_DOCS "Verilator multithreading enabled"
-)
-
-define_property(TARGET
   PROPERTY VERILATOR_TRACE_THREADED
   BRIEF_DOCS "Verilator multithread tracing enabled"
   FULL_DOCS "Verilator multithread tracing enabled"


### PR DESCRIPTION
Related to: https://github.com/verilator/verilator/pull/3686

This PR removes ``VL_THREADED`` define from verilator, adapts ``--threads`` and deprecates ``--no-threads`` option.
