### PR TITLE
Stack overflow detection on Linux.

### DIFF
--- a/bin/verilator
+++ b/bin/verilator
@@ -31,6 +31,7 @@ my $opt_gdb;
 my $opt_rr;
 my $opt_gdbbt;
 my $opt_quiet_exit;
+my $opt_unlimited_stack = 1;
 
 # No arguments can't do anything useful.  Give help
 if ($#ARGV < 0) {
@@ -49,16 +50,17 @@ foreach my $sw (@ARGV) {
 Getopt::Long::config("no_auto_abbrev", "pass_through");
 if (! GetOptions(
           # Major operating modes
-          "help"        => \&usage,
-          "debug"       => \&debug,
-          # "version!"  => \&version,   # Also passthru'ed
+          "help"             => \&usage,
+          "debug"            => \&debug,
+          # "version!"       => \&version,   # Also passthru'ed
           # Switches
-          "gdb!"        => \$opt_gdb,
-          "gdbbt!"      => \$opt_gdbbt,
-          "quiet-exit!" => \$opt_quiet_exit,
-          "rr!"         => \$opt_rr,
+          "gdb!"             => \$opt_gdb,
+          "gdbbt!"           => \$opt_gdbbt,
+          "quiet-exit!"      => \$opt_quiet_exit,
+          "rr!"              => \$opt_rr,
+          "unlimited-stack!" => \$opt_unlimited_stack,
           # Additional parameters
-          "<>"          => sub {},      # Ignored
+          "<>"               => sub {},      # Ignored
     )) {
     pod2usage(-exitstatus => 2, -verbose => 0);
 }
@@ -187,6 +189,9 @@ sub aslr_off {
 }
 
 sub ulimit_stack_unlimited {
+    if (!$opt_unlimited_stack) {
+        return "";
+    }
     system("ulimit -s unlimited 2>/dev/null");
     my $status = $?;
     if ($status == 0) {
@@ -436,6 +441,7 @@ detailed descriptions of these arguments.
     --trace-threads <threads>   Enable FST waveform creation on separate threads
     --trace-underscore          Enable tracing of _signals
      -U<var>                    Undefine preprocessor define
+    --no-unlimited-stack        Don't disable stack size limit
     --unroll-count <loops>      Tune maximum loop iterations
     --unroll-stmts <stmts>      Tune maximum loop body size
     --unused-regexp <regexp>    Tune UNUSED lint signals

--- a/bin/verilator
+++ b/bin/verilator
@@ -76,7 +76,8 @@ if ($opt_gdbbt && !gdb_works()) {
 my @quoted_sw = map { sh_escape($_) } @Opt_Verilator_Sw;
 if ($opt_gdb) {
     # Generic GDB interactive
-    run (aslr_off()
+    run (ulimit_stack_unlimited()
+         . aslr_off()
          . ($ENV{VERILATOR_GDB} || "gdb")
          . " " . verilator_bin()
          # Note, uncomment to set breakpoints before running:
@@ -92,12 +93,14 @@ if ($opt_gdb) {
          . " -ex 'bt'");
 } elsif ($opt_rr) {
     # Record with rr
-    run (aslr_off()
+    run (ulimit_stack_unlimited()
+         . aslr_off()
          . "rr record " . verilator_bin()
          . " " . join(' ', @quoted_sw));
 } elsif ($opt_gdbbt && $Debug) {
     # Run under GDB to get gdbbt
-    run (aslr_off()
+    run (ulimit_stack_unlimited()
+         . aslr_off()
          . "gdb"
          . " " . verilator_bin()
          . " --batch --quiet --return-child-result"
@@ -106,10 +109,13 @@ if ($opt_gdb) {
          . " -ex 'bt' -ex 'quit'");
 } elsif ($Debug) {
     # Debug
-    run(aslr_off() . verilator_bin() . " " . join(' ', @quoted_sw));
+    run(ulimit_stack_unlimited()
+        . aslr_off()
+        . verilator_bin()
+        . " " . join(' ', @quoted_sw));
 } else {
     # Normal, non gdb
-    run(verilator_bin() . " " . join(' ', @quoted_sw));
+    run(ulimit_stack_unlimited() . verilator_bin() . " " . join(' ', @quoted_sw));
 }
 
 #----------------------------------------------------------------------
@@ -175,6 +181,16 @@ sub aslr_off {
     my $ok = `setarch --addr-no-randomize echo ok 2>/dev/null` || "";
     if ($ok =~ /ok/) {
         return "setarch --addr-no-randomize ";
+    } else {
+        return "";
+    }
+}
+
+sub ulimit_stack_unlimited {
+    system("ulimit -s unlimited 2>/dev/null");
+    my $status = $?;
+    if ($status == 0) {
+        return "ulimit -s unlimited 2>/dev/null; exec ";
     } else {
         return "";
     }

--- a/src/V3Options.cpp
+++ b/src/V3Options.cpp
@@ -1465,6 +1465,7 @@ void V3Options::parseOptsList(FileLine* fl, const string& optdir, int argc, char
 
     DECL_OPTION("-U", CbPartialMatch, &V3PreShell::undef);
     DECL_OPTION("-underline-zero", OnOff, &m_underlineZero);  // Deprecated
+    DECL_OPTION("-no-unlimited-stack", CbCall, []() {});  // Processed only in bin/verilator shell
     DECL_OPTION("-unroll-count", Set, &m_unrollCount).undocumented();  // Optimization tweak
     DECL_OPTION("-unroll-stmts", Set, &m_unrollStmts).undocumented();  // Optimization tweak
     DECL_OPTION("-unused-regexp", Set, &m_unusedRegexp);

--- a/src/V3Options.h
+++ b/src/V3Options.h
@@ -682,6 +682,7 @@ public:
 
     // METHODS (other OS)
     static void throwSigsegv();
+    static void overflowStack();
 };
 
 //######################################################################

--- a/src/V3Os.cpp
+++ b/src/V3Os.cpp
@@ -566,10 +566,9 @@ extern "C" void v3SegfaultSignalHandler(int /*signo*/, siginfo_t* info, void* /*
 void V3Os::setupThreadSegfaultSignalHandler() {
 // Relies on /proc/self/maps; tested only on Linux.
 #if defined(__linux__)
-    // Segfault signal handler uses something between 300 and 400 bytes of the stack.
     // MINSIGSTKSZ may not be constant (it is a function call on some systems).
     // As a result we have to use dynamic memory below.
-    static const std::size_t signalStackSize = (MINSIGSTKSZ < 1024) ? 1024 : MINSIGSTKSZ;
+    static const std::size_t signalStackSize = (MINSIGSTKSZ < 4096) ? 4096 : MINSIGSTKSZ;
     // Stack used by all signal handlers in the current thread.
     static const thread_local std::unique_ptr<char[]> signalStackp{new char[signalStackSize]};
 

--- a/src/V3Os.h
+++ b/src/V3Os.h
@@ -69,6 +69,11 @@ public:
     // METHODS (sub command)
     /// Run system command, returns the exit code of the child process.
     static int system(const string& command);
+
+    // METHODS (segfault handler)
+    // Configure segfault signal handler for a calling thread.
+    // First call installs process-wide handler for the signal.
+    static void setupThreadSegfaultSignalHandler();
 };
 
 #endif  // Guard

--- a/src/Verilator.cpp
+++ b/src/Verilator.cpp
@@ -725,6 +725,8 @@ int main(int argc, char** argv, char** /*env*/) {
     // General initialization
     std::ios::sync_with_stdio();
 
+    V3Os::setupThreadSegfaultSignalHandler();
+
     time_t randseed;
     time(&randseed);
     srand(static_cast<int>(randseed));

--- a/test_regress/t/t_flag_no_unlimited_stack.pl
+++ b/test_regress/t/t_flag_no_unlimited_stack.pl
@@ -1,0 +1,19 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2022 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(vlt => 1);
+
+# Just check whether the flag is recognized.
+lint(
+    verilator_flags2 => ["--no-unlimited-stack"],
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_flag_no_unlimited_stack.v
+++ b/test_regress/t/t_flag_no_unlimited_stack.v
@@ -1,0 +1,8 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2005 by Wilson Snyder.
+// SPDX-License-Identifier: CC0-1.0
+
+module t (/*AUTOARG*/);
+endmodule

--- a/test_regress/t/t_sigsegv_not_stack_overflow_bad.pl
+++ b/test_regress/t/t_sigsegv_not_stack_overflow_bad.pl
@@ -1,0 +1,27 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2022 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(vlt => 1);
+
+if ($^O eq "linux") {
+    lint(
+        v_flags => ["--debug-sigsegv"],
+        fails => 1,
+        sanitize => 0,
+        expect => '\A(?!.*?Segmentation fault due to stack overflow.*?)' .
+                  '.*' .
+                  '%Error: Verilator internal fault, sorry. Suggest trying --debug --gdbbt\n' .
+                  '%Error: Command Failed.*'
+        );
+
+    ok(1);
+} else {
+    skip("Linux only test");
+}

--- a/test_regress/t/t_sigsegv_stack_overflow_bad.pl
+++ b/test_regress/t/t_sigsegv_stack_overflow_bad.pl
@@ -11,10 +11,18 @@ if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); di
 scenarios(vlt => 1);
 
 if ($^O eq "linux") {
-    lint(
-        v_flags => ["--debug-sigsegv-stackoverflow"],
+    run(cmd => ["bash -c 'ulimit -s 8192;",  # 8MB stack limit.
+                "exec ../bin/verilator",
+                "--no-unlimited-stack",
+                "--debug-sigsegv-stackoverflow",
+                "--cc",
+                "--sv",
+                $Self->{top_filename},
+                "'",
+        ],
+        tee => $Self->{verbose},
+        logfile => $Self->{run_log_filename},
         fails => 1,
-        sanitize => 0,
         expect => '.*' .
                   'Segmentation fault due to stack overflow.\n' .
                   'Try increasing stack size limit.*\n' .

--- a/test_regress/t/t_sigsegv_stack_overflow_bad.pl
+++ b/test_regress/t/t_sigsegv_stack_overflow_bad.pl
@@ -1,0 +1,28 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2022 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(vlt => 1);
+
+if ($^O eq "linux") {
+    lint(
+        v_flags => ["--debug-sigsegv-stackoverflow"],
+        fails => 1,
+        sanitize => 0,
+        expect => '.*' .
+                  'Segmentation fault due to stack overflow.\n' .
+                  'Try increasing stack size limit.*\n' .
+                  '%Error: Verilator internal fault, sorry. Suggest trying --debug --gdbbt\n' .
+                  '%Error: Command Failed.*',
+        );
+
+    ok(1);
+} else {
+    skip("Linux only test");
+}


### PR DESCRIPTION
The PR adds a code that detects segmentation faults caused by stack overflow. If one is detected, it prints the following message and calls default segfault handler which terminates the process with appropriate exit code.
```
Segmentation fault due to stack overflow.
Try increasing stack size limit using `ulimit -s` command.
```
Other segmentation faults are handled as before, i.e. by calling default segfault handler.

The handler works in every thread which called `V3Os::setupThreadSegfaultSignalHandler();` function. For now this is just the main thread, but the code should work without changes with incoming support for worker threads.

## Why?

Verilator uses a lot of recursion (visitors). We have one design which causes so much nested function calls that the default system stack (8MB) is not enough.
I think that segmentation faults are usually seen as a result of a bug, so the short explanation when this is not really the case might be useful for users.

## Testing

Generate a sample SV file which causes a lot of recursion to happen in Verilator:
```bash
gen_sv_array() {
    local -ri w=$1
    local -ri h=$2
    local i j
    printf 'module foo;\n  wire[%d:0][2:0] a = {' $(($w * $h))
    for ((i=0;i<$h;i++)); do
        printf '\n    ';
        for ((j=0;j<$w;j++)); do
            printf "{3'h0},"
        done
    done
    printf "\n  {3'h0}};\nendmodule\n"
}

gen_sv_array 256 256 > test.sv
```

### Stack overflow test

Set stack size to 8MB and run verilator in a subshell.
Subshell (i.e. separate process) is used for convenience - `ulimit` sets hard limit in the calling process (and its subprocesses), which can't be inceased later.
```bash
( ulimit -s $((1024 * 8)); verilator --cc --sv ./test.sv; )
```
output:
> ```
>
> Segmentation fault due to stack overflow.
> Try increasing stack size limit using `ulimit -s` command.
>
> %Error: Verilator internal fault, sorry. Suggest trying --debug --gdbbt
> %Error: Command Failed /home/mglb/projects/Verilator/repos/verilator/bin/verilator_bin --cc --sv ./test.sv
> ```

### Null pointer dereference test

`verilator_bin` is used below to see the real exit code.

```bash
( ulimit -s $((1024 * 8)); verilator_bin -debug-sigsegv --cc --sv ./test.sv; echo $? )
```
output (139 means segmentation fault):
> ```
> 139
> ```

### Successful execution test

Set large stack size (32MB) and run verilator in a subshell.
```bash
( ulimit -s $((1024 * 32)); verilator --cc --sv ./test.sv; )
```