### PR TITLE
Fix performance issues

### DIFF
--- a/src/V3Active.cpp
+++ b/src/V3Active.cpp
@@ -571,10 +571,11 @@ private:
         if (nodep->access().isWriteOnly()) {
             vscp->user2(true);
         } else {
-            // If the variable is read before it is written, and is not in the sensitivity list,
-            // then this cannot be optimized into a combinational process
+            // If the variable is read before it is written (and is not a never-changing value),
+            // and is not in the sensitivity list, then this cannot be optimized into a
+            // combinational process
             // TODO: live variable analysis would be more precise
-            if (!vscp->user2() && !vscp->user1()) m_canBeComb = false;
+            if (!vscp->user2() && !vscp->varp()->valuep() && !vscp->user1()) m_canBeComb = false;
         }
     }
     void visit(AstAssignDly* nodep) override {

--- a/src/V3AstNodeMath.h
+++ b/src/V3AstNodeMath.h
@@ -4265,9 +4265,7 @@ public:
     bool same(const AstNode* samep) const override;
     inline bool same(const AstVarRef* samep) const;
     inline bool sameNoLvalue(AstVarRef* samep) const;
-    int instrCount() const override {
-        return widthInstrs() * (access().isReadOrRW() ? INSTR_COUNT_LD : 1);
-    }
+    int instrCount() const override;
     string emitVerilog() override { V3ERROR_NA_RETURN(""); }
     string emitC() override { V3ERROR_NA_RETURN(""); }
     bool cleanOut() const override { return true; }

--- a/src/V3AstNodeOther.h
+++ b/src/V3AstNodeOther.h
@@ -2851,6 +2851,7 @@ public:
         statement(true);
         dtypeSetVoid();
     }
+    int instrCount() const override;
 };
 class AstCReset final : public AstNodeStmt {
     // Reset variable at startup

--- a/test_regress/t/t_case_huge.pl
+++ b/test_regress/t/t_case_huge.pl
@@ -14,9 +14,12 @@ compile(
     verilator_flags2 => ["--stats"],
     );
 
-if ($Self->{vlt_all}) {
+if ($Self->{vlt}) {
     file_grep($Self->{stats}, qr/Optimizations, Tables created\s+(\d+)/i, 10);
-    file_grep($Self->{stats}, qr/Optimizations, Combined CFuncs\s+(\d+)/i, 0);
+    file_grep($Self->{stats}, qr/Optimizations, Combined CFuncs\s+(\d+)/i, 8);
+} elsif ($Self->{vltmt}) {
+    file_grep($Self->{stats}, qr/Optimizations, Tables created\s+(\d+)/i, 10);
+    file_grep($Self->{stats}, qr/Optimizations, Combined CFuncs\s+(\d+)/i, 9);
 }
 
 execute(


### PR DESCRIPTION
Two fixes to issues that caused a severe performance regression in one design (I mentioned this privately).

Commit 1: Cost VlTriggerVec::at accurately in partitioning. (this caused inaccurate MTask to Thread packing)

Commit 2: Fix V3Table preventing optimization of clocked blocks into comb blocks. (this introduced zillions of extra triggers we don't really need)

Given an important release is due, please do a quick check. If all is ok, then will non-squash merge these imminently.