### PR TITLE
Set return type of countbit functions to int

### DIFF
--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -1337,19 +1337,17 @@ private:
             iterateCheckSizedSelf(nodep, "RHS", nodep->rhsp(), SELF, BOTH);
             iterateCheckSizedSelf(nodep, "THS", nodep->thsp(), SELF, BOTH);
             iterateCheckSizedSelf(nodep, "FHS", nodep->fhsp(), SELF, BOTH);
-            // If it's a 32 bit number, we need a 6 bit number as we need to return '32'.
-            const int selwidth = V3Number::log2b(nodep->lhsp()->width()) + 1;
-            nodep->dtypeSetLogicSized(selwidth,
-                                      VSigning::UNSIGNED);  // Spec doesn't indicate if an integer
+            // For widthMin, if a 32 bit number, we need a 6 bit number as we need to return '32'.
+            const int widthMin = V3Number::log2b(nodep->lhsp()->width()) + 1;
+            nodep->dtypeSetLogicUnsized(32, widthMin, VSigning::SIGNED);
         }
     }
     void visit(AstCountOnes* nodep) override {
         if (m_vup->prelim()) {
             iterateCheckSizedSelf(nodep, "LHS", nodep->lhsp(), SELF, BOTH);
-            // If it's a 32 bit number, we need a 6 bit number as we need to return '32'.
-            const int selwidth = V3Number::log2b(nodep->lhsp()->width()) + 1;
-            nodep->dtypeSetLogicSized(selwidth,
-                                      VSigning::UNSIGNED);  // Spec doesn't indicate if an integer
+            // For widthMin, if a 32 bit number, we need a 6 bit number as we need to return '32'.
+            const int widthMin = V3Number::log2b(nodep->lhsp()->width()) + 1;
+            nodep->dtypeSetLogicUnsized(32, widthMin, VSigning::SIGNED);
         }
     }
     void visit(AstCvtPackString* nodep) override {

--- a/test_regress/t/t_math_countbits.v
+++ b/test_regress/t/t_math_countbits.v
@@ -23,19 +23,19 @@ module t(/*AUTOARG*/
    reg [31:0] ctrl1;
    reg [31:0] ctrl2;
 
-   reg [4:0] result_16_1;
-   reg [4:0] result_16_2;
-   reg [4:0] result_16_3;
-   reg [5:0] result_32_1;
-   reg [5:0] result_32_2;
-   reg [5:0] result_32_3;
-   reg [6:0] result_64_1;
-   reg [6:0] result_64_2;
-   reg [6:0] result_64_3;
-   reg [3:0] result_10_3;
-   reg [4:0] result_21_3;
-   reg [5:0] result_59_3;
-   reg [6:0] result_70_3;
+   int result_16_1;
+   int result_16_2;
+   int result_16_3;
+   int result_32_1;
+   int result_32_2;
+   int result_32_3;
+   int result_64_1;
+   int result_64_2;
+   int result_64_3;
+   int result_10_3;
+   int result_21_3;
+   int result_59_3;
+   int result_70_3;
 
    initial begin
       if ($countbits(32'b111100000000, '1) != 4) $stop;

--- a/test_regress/t/t_math_svl.v
+++ b/test_regress/t/t_math_svl.v
@@ -14,13 +14,13 @@ module t (/*AUTOARG*/
    reg [15:0] l;
    reg [49:0] q;
    reg [79:0] w;
-   reg [4:0]  lc;
+   int        lc;
    reg        lo;
    reg        l0;
-   reg [5:0]  qc;
+   int        qc;
    reg        qo;
    reg        q0;
-   reg [6:0]  wc;
+   int        wc;
    reg        wo;
    reg        w0;
 
@@ -55,7 +55,7 @@ module t (/*AUTOARG*/
       if ($isunknown(32'b11101011111) != 0) $stop;
       if ($isunknown(32'b10zzzzzzzzz) != 1) $stop;
       if ($bits(0) != 32'd32) $stop;
-      if ($bits(lc) != 5) $stop;
+      if ($bits(lc) != 32) $stop;
       if ($onehot(32'b00000001000000) != 1'b1) $stop;
       if ($onehot(32'b00001001000000) != 1'b0) $stop;
       if ($onehot(32'b0) != 1'b0) $stop;
@@ -81,51 +81,51 @@ module t (/*AUTOARG*/
             q <= ~50'h0;
             w <= ~80'h0;
             //
-            if ({lc,lo,l0} != {5'd0,1'b0,1'b1}) $stop;
-            if ({qc,qo,q0} != {6'd0,1'b0,1'b1}) $stop;
-            if ({wc,wo,w0} != {7'd0,1'b0,1'b1}) $stop;
+            if ({lc,lo,l0} != {32'd0,1'b0,1'b1}) $stop;
+            if ({qc,qo,q0} != {32'd0,1'b0,1'b1}) $stop;
+            if ({wc,wo,w0} != {32'd0,1'b0,1'b1}) $stop;
          end
          if (cyc==3) begin
             l <= 16'b0010110010110111;
             q <= 50'h01_1111_0001;
             w <= 80'h0100_0000_0f00_00f0_0000;
             //
-            if ({lc,lo,l0} != {5'd16,1'b0,1'b0}) $stop;
-            if ({qc,qo,q0} != {6'd50,1'b0,1'b0}) $stop;
-            if ({wc,wo,w0} != {7'd80,1'b0,1'b0}) $stop;
+            if ({lc,lo,l0} != {32'd16,1'b0,1'b0}) $stop;
+            if ({qc,qo,q0} != {32'd50,1'b0,1'b0}) $stop;
+            if ({wc,wo,w0} != {32'd80,1'b0,1'b0}) $stop;
          end
          if (cyc==4) begin
             l <= 16'b0000010000000000;
             q <= 50'h1_0000_0000;
             w <= 80'h010_00000000_00000000;
             //
-            if ({lc,lo,l0} != {5'd9,1'b0,1'b0}) $stop;
-            if ({qc,qo,q0} != {6'd6,1'b0,1'b0}) $stop;
-            if ({wc,wo,w0} != {7'd9,1'b0,1'b0}) $stop;
+            if ({lc,lo,l0} != {32'd9,1'b0,1'b0}) $stop;
+            if ({qc,qo,q0} != {32'd6,1'b0,1'b0}) $stop;
+            if ({wc,wo,w0} != {32'd9,1'b0,1'b0}) $stop;
          end
          if (cyc==5) begin
             l <= 16'b0000000100000000;
             q <= 50'h8000_0000_0000;
             w <= 80'h10_00000000_00000000;
             //
-            if ({lc,lo,l0} != {5'd1,1'b1,1'b1}) $stop;
-            if ({qc,qo,q0} != {6'd1,1'b1,1'b1}) $stop;
-            if ({wc,wo,w0} != {7'd1,1'b1,1'b1}) $stop;
+            if ({lc,lo,l0} != {32'd1,1'b1,1'b1}) $stop;
+            if ({qc,qo,q0} != {32'd1,1'b1,1'b1}) $stop;
+            if ({wc,wo,w0} != {32'd1,1'b1,1'b1}) $stop;
          end
          if (cyc==6) begin
             l <= 16'b0000100100000000;
             q <= 50'h01_00000100;
             w <= 80'h01_00000100_00000000;
             //
-            if ({lc,lo,l0} != {5'd1,1'b1,1'b1}) $stop;
-            if ({qc,qo,q0} != {6'd1,1'b1,1'b1}) $stop;
-            if ({wc,wo,w0} != {7'd1,1'b1,1'b1}) $stop;
+            if ({lc,lo,l0} != {32'd1,1'b1,1'b1}) $stop;
+            if ({qc,qo,q0} != {32'd1,1'b1,1'b1}) $stop;
+            if ({wc,wo,w0} != {32'd1,1'b1,1'b1}) $stop;
          end
          if (cyc==7) begin
             //
-            if ({lc,lo,l0} != {5'd2,1'b0,1'b0}) $stop;
-            if ({qc,qo,q0} != {6'd2,1'b0,1'b0}) $stop;
-            if ({wc,wo,w0} != {7'd2,1'b0,1'b0}) $stop;
+            if ({lc,lo,l0} != {32'd2,1'b0,1'b0}) $stop;
+            if ({qc,qo,q0} != {32'd2,1'b0,1'b0}) $stop;
+            if ({wc,wo,w0} != {32'd2,1'b0,1'b0}) $stop;
          end
          if (cyc==8) begin
          end


### PR DESCRIPTION
According to section 20.9 of IEEE Std 1800-2017, `countbits` and `countones` functions should have return type `int`.