### PR TITLE
Add VL_MT_SAFE attribute to several functions.

### DIFF
--- a/include/verilatedos.h
+++ b/include/verilatedos.h
@@ -160,6 +160,13 @@
 #else
 # define VL_MT_SAFE
 #endif
+// Comment tag that function is threadsafe, only if
+// other threads doesn't change tree topology
+#if defined(__clang__)
+# define VL_MT_STABLE_TREE __attribute__((annotate("MT_STABLE_TREE")))
+#else
+# define VL_MT_STABLE_TREE
+#endif
 // Comment tag that function is threadsafe, only
 // during normal operation (post-init)
 #if defined(__clang__)

--- a/include/verilatedos.h
+++ b/include/verilatedos.h
@@ -163,9 +163,9 @@
 // Comment tag that function is threadsafe, only if
 // other threads doesn't change tree topology
 #if defined(__clang__)
-# define VL_MT_STABLE_TREE __attribute__((annotate("MT_STABLE_TREE")))
+# define VL_MT_STABLE __attribute__((annotate("MT_STABLE")))
 #else
-# define VL_MT_STABLE_TREE
+# define VL_MT_STABLE
 #endif
 // Comment tag that function is threadsafe, only
 // during normal operation (post-init)

--- a/nodist/clang_check_attributes
+++ b/nodist/clang_check_attributes
@@ -37,6 +37,7 @@ def fully_qualified_name(node):
 class VlAnnotations:
     mt_start: bool = False
     mt_safe: bool = False
+    stable_tree: bool = False
     mt_safe_postinit: bool = False
     mt_unsafe: bool = False
     mt_unsafe_one: bool = False
@@ -54,6 +55,9 @@ class VlAnnotations:
     def is_pure_context(self):
         return self.pure
 
+    def is_stabe_tree_context(self):
+        return self.stable_tree
+
     def is_mt_unsafe_call(self):
         return self.mt_unsafe or self.mt_unsafe_one
 
@@ -65,6 +69,9 @@ class VlAnnotations:
 
     def is_pure_call(self):
         return self.pure
+
+    def is_stabe_tree_call(self):
+        return self.stable_tree
 
     def __or__(self, other: "VlAnnotations"):
         result = VlAnnotations()
@@ -94,6 +101,8 @@ class VlAnnotations:
                     result.mt_start = True
                 elif node.displayname == "MT_SAFE":
                     result.mt_safe = True
+                elif node.displayname == "MT_STABLE_TREE":
+                    result.stable_tree = True
                 elif node.displayname == "MT_SAFE_POSTINIT":
                     result.mt_safe_postinit = True
                 elif node.displayname == "MT_UNSAFE":
@@ -196,6 +205,7 @@ class DiagnosticKind(Enum):
     ANNOTATIONS_DEF_DECL_MISMATCH = enum.auto()
     NON_PURE_CALL_IN_PURE_CTX = enum.auto()
     NON_MT_SAFE_CALL_IN_MT_SAFE_CTX = enum.auto()
+    NON_STABLE_TREE_CALL_IN_STABLE_TREE_CTX = enum.auto()
 
     def __lt__(self, other):
         return self.value < other.value
@@ -377,6 +387,16 @@ class CallAnnotationsValidator:
                     FunctionInfo.from_node(refd, refd, annotations),
                     DiagnosticKind.NON_MT_SAFE_CALL_IN_MT_SAFE_CTX)
 
+        # stable tree context
+        if ctx.is_stabe_tree_context():
+            if not (annotations.is_stabe_tree_call()
+                    or annotations.is_pure_call()
+                    or self.check_mt_safe_call(node, refd, annotations)):
+                self.emit_diagnostic(
+                    FunctionInfo.from_node(refd, refd, annotations),
+                    DiagnosticKind.NON_STABLE_TREE_CALL_IN_STABLE_TREE_CTX)
+
+        # pure context
         if ctx.is_pure_context():
             if not annotations.is_pure_call():
                 self.emit_diagnostic(
@@ -394,6 +414,16 @@ class CallAnnotationsValidator:
                 self.emit_diagnostic(
                     FunctionInfo.from_node(refd, refd, annotations),
                     DiagnosticKind.NON_MT_SAFE_CALL_IN_MT_SAFE_CTX)
+
+        # stable tree context
+        if ctx.is_stabe_tree_context():
+            if not (annotations.is_pure_call()
+                    or annotations.is_mt_safe_call()
+                    or annotations.is_stabe_tree_call()):
+                self.emit_diagnostic(
+                    FunctionInfo.from_node(refd, refd, annotations),
+                    DiagnosticKind.NON_STABLE_TREE_CALL_IN_STABLE_TREE_CTX)
+
         # pure context
         if ctx.is_pure_context():
             if not annotations.is_pure_call():
@@ -409,6 +439,13 @@ class CallAnnotationsValidator:
         # Constructors are OK in MT-safe context
         # only if they call local methods or MT-safe functions.
         if ctx.is_mt_safe_context() or self._constructor_context:
+            self._constructor_context += 1
+            self.iterate_children(refd.get_children(),
+                                  self.dispatch_node_inside_definition)
+            self._constructor_context -= 1
+
+        # stable tree context
+        if ctx.is_stabe_tree_context():
             self._constructor_context += 1
             self.iterate_children(refd.get_children(),
                                   self.dispatch_node_inside_definition)
@@ -788,6 +825,8 @@ class TopDownSummaryPrinter():
                 name += "is mtsafe but calls non-mtsafe function(s)"
             elif func.reason == DiagnosticKind.NON_PURE_CALL_IN_PURE_CTX:
                 name += "is pure but calls non-pure function(s)"
+            elif func.reason == DiagnosticKind.NON_STABLE_TREE_CALL_IN_STABLE_TREE_CTX:
+                name += "calls stable_tree function(s) but isn't annotated as stable_tree"
             else:
                 name += "for unknown reason (please add description)"
 

--- a/nodist/clang_check_attributes
+++ b/nodist/clang_check_attributes
@@ -101,7 +101,7 @@ class VlAnnotations:
                     result.mt_start = True
                 elif node.displayname == "MT_SAFE":
                     result.mt_safe = True
-                elif node.displayname == "MT_STABLE_TREE":
+                elif node.displayname == "MT_STABLE":
                     result.stable_tree = True
                 elif node.displayname == "MT_SAFE_POSTINIT":
                     result.mt_safe_postinit = True

--- a/src/V3Ast.cpp
+++ b/src/V3Ast.cpp
@@ -1079,7 +1079,7 @@ bool AstNode::sameTreeIter(const AstNode* node1p, const AstNode* node2p, bool ig
 //======================================================================
 // Debugging
 
-void AstNode::checkTreeIter(const AstNode* prevBackp) const {
+void AstNode::checkTreeIter(const AstNode* prevBackp) const VL_MT_STABLE_TREE {
     // private: Check a tree and children
     UASSERT_OBJ(prevBackp == this->backp(), this, "Back node inconsistent");
     switch (this->type()) {

--- a/src/V3Ast.cpp
+++ b/src/V3Ast.cpp
@@ -1079,7 +1079,7 @@ bool AstNode::sameTreeIter(const AstNode* node1p, const AstNode* node2p, bool ig
 //======================================================================
 // Debugging
 
-void AstNode::checkTreeIter(const AstNode* prevBackp) const VL_MT_STABLE_TREE {
+void AstNode::checkTreeIter(const AstNode* prevBackp) const VL_MT_STABLE {
     // private: Check a tree and children
     UASSERT_OBJ(prevBackp == this->backp(), this, "Back node inconsistent");
     switch (this->type()) {

--- a/src/V3Ast.cpp
+++ b/src/V3Ast.cpp
@@ -155,7 +155,7 @@ string AstNode::vcdName(const string& namein) {
     return prettyName(pretty);
 }
 
-string AstNode::prettyName(const string& namein) {
+string AstNode::prettyName(const string& namein) VL_PURE {
     // This function is somewhat hot, so we short-circuit some compares
     string pretty;
     pretty.reserve(namein.length());

--- a/src/V3Ast.h
+++ b/src/V3Ast.h
@@ -102,11 +102,11 @@ public:
         : m_e(static_cast<en>(_e)) {}  // Need () or GCC 4.8 false warning
     constexpr operator en() const VL_MT_SAFE { return m_e; }
 };
-constexpr bool operator==(const VNType& lhs, const VNType& rhs) VL_MT_SAFE {
+constexpr bool operator==(const VNType& lhs, const VNType& rhs) VL_PURE {
     return lhs.m_e == rhs.m_e;
 }
-constexpr bool operator==(const VNType& lhs, VNType::en rhs) { return lhs.m_e == rhs; }
-constexpr bool operator==(VNType::en lhs, const VNType& rhs) { return lhs == rhs.m_e; }
+constexpr bool operator==(const VNType& lhs, VNType::en rhs) VL_PURE { return lhs.m_e == rhs; }
+constexpr bool operator==(VNType::en lhs, const VNType& rhs) VL_PURE { return lhs == rhs.m_e; }
 inline std::ostream& operator<<(std::ostream& os, const VNType& rhs) { return os << rhs.ascii(); }
 
 // ######################################################################
@@ -1600,7 +1600,7 @@ protected:
 public:
     // ACCESSORS
     VNType type() const VL_MT_SAFE { return m_type; }
-    const char* typeName() const { return type().ascii(); }  // See also prettyTypeName
+    const char* typeName() const VL_MT_SAFE { return type().ascii(); }  // See also prettyTypeName
     AstNode* nextp() const VL_MT_SAFE { return m_nextp; }
     AstNode* backp() const VL_MT_SAFE { return m_backp; }
     AstNode* abovep() const;  // Parent node above, only when no nextp() as otherwise slow
@@ -1667,7 +1667,7 @@ public:
     string origNameProtect() const;  // origName with --protect-id applied
     string shortName() const;  // Name with __PVT__ removed for concatenating scopes
     static string dedotName(const string& namein);  // Name with dots removed
-    static string prettyName(const string& namein);  // Name for printing out to the user
+    static string prettyName(const string& namein) VL_PURE;  // Name for printing out to the user
     static string vpiName(const string& namein);  // Name for vpi access
     static string prettyNameQ(const string& namein) {  // Quoted pretty name (for errors)
         return std::string{"'"} + prettyName(namein) + "'";
@@ -1676,7 +1676,7 @@ public:
     encodeName(const string& namein);  // Encode user name into internal C representation
     static string encodeNumber(int64_t num);  // Encode number into internal C representation
     static string vcdName(const string& namein);  // Name for printing out to vcd files
-    string prettyName() const { return prettyName(name()); }
+    string prettyName() const VL_MT_SAFE { return prettyName(name()); }
     string prettyNameQ() const { return prettyNameQ(name()); }
     string prettyTypeName() const;  // "VARREF" for error messages (NOT dtype's pretty name)
     virtual string prettyOperatorName() const { return "operator " + prettyTypeName(); }
@@ -1705,9 +1705,9 @@ public:
     int widthWords() const { return VL_WORDS_I(width()); }
     bool isQuad() const VL_MT_SAFE { return (width() > VL_IDATASIZE && width() <= VL_QUADSIZE); }
     bool isWide() const VL_MT_SAFE { return (width() > VL_QUADSIZE); }
-    inline bool isDouble() const;
-    inline bool isSigned() const;
-    inline bool isString() const;
+    inline bool isDouble() const VL_MT_SAFE;
+    inline bool isSigned() const VL_MT_SAFE;
+    inline bool isString() const VL_MT_SAFE;
 
     // clang-format off
     VNUser      user1u() const VL_MT_SAFE {
@@ -1992,7 +1992,7 @@ private:
 
     // For internal use only.
     template <typename TargetType, typename DeclType>
-    constexpr static bool uselessCast() {
+    constexpr static bool uselessCast() VL_PURE {
         using NonRef = typename std::remove_reference<DeclType>::type;
         using NonPtr = typename std::remove_pointer<NonRef>::type;
         using NonCV = typename std::remove_cv<NonPtr>::type;
@@ -2001,7 +2001,7 @@ private:
 
     // For internal use only.
     template <typename TargetType, typename DeclType>
-    constexpr static bool impossibleCast() {
+    constexpr static bool impossibleCast() VL_PURE {
         using NonRef = typename std::remove_reference<DeclType>::type;
         using NonPtr = typename std::remove_pointer<NonRef>::type;
         using NonCV = typename std::remove_cv<NonPtr>::type;

--- a/src/V3Ast.h
+++ b/src/V3Ast.h
@@ -1600,7 +1600,7 @@ protected:
 public:
     // ACCESSORS
     VNType type() const VL_MT_SAFE { return m_type; }
-    const char* typeName() const VL_MT_SAFE { return type().ascii(); }  // See also prettyTypeName
+    const char* typeName() const { return type().ascii(); }  // See also prettyTypeName
     AstNode* nextp() const VL_MT_SAFE { return m_nextp; }
     AstNode* backp() const VL_MT_SAFE { return m_backp; }
     AstNode* abovep() const;  // Parent node above, only when no nextp() as otherwise slow
@@ -1663,7 +1663,7 @@ public:
     virtual void tag(const string& text) {}
     virtual string tag() const { return ""; }
     virtual string verilogKwd() const { return ""; }
-    string nameProtect() const VL_MT_SAFE;  // Name with --protect-id applied
+    string nameProtect() const;  // Name with --protect-id applied
     string origNameProtect() const;  // origName with --protect-id applied
     string shortName() const;  // Name with __PVT__ removed for concatenating scopes
     static string dedotName(const string& namein);  // Name with dots removed
@@ -1676,7 +1676,7 @@ public:
     encodeName(const string& namein);  // Encode user name into internal C representation
     static string encodeNumber(int64_t num);  // Encode number into internal C representation
     static string vcdName(const string& namein);  // Name for printing out to vcd files
-    string prettyName() const VL_MT_SAFE { return prettyName(name()); }
+    string prettyName() const { return prettyName(name()); }
     string prettyNameQ() const { return prettyNameQ(name()); }
     string prettyTypeName() const;  // "VARREF" for error messages (NOT dtype's pretty name)
     virtual string prettyOperatorName() const { return "operator " + prettyTypeName(); }

--- a/src/V3Ast.h
+++ b/src/V3Ast.h
@@ -1545,7 +1545,7 @@ class AstNode VL_NOT_FINAL {
 private:
     AstNode* cloneTreeIter();
     AstNode* cloneTreeIterList();
-    void checkTreeIter(const AstNode* prevBackp) const VL_MT_SAFE;
+    void checkTreeIter(const AstNode* prevBackp) const VL_MT_STABLE_TREE;
     bool gateTreeIter() const;
     static bool sameTreeIter(const AstNode* node1p, const AstNode* node2p, bool ignNext,
                              bool gateOnly);
@@ -1601,14 +1601,14 @@ public:
     // ACCESSORS
     VNType type() const VL_MT_SAFE { return m_type; }
     const char* typeName() const VL_MT_SAFE { return type().ascii(); }  // See also prettyTypeName
-    AstNode* nextp() const VL_MT_SAFE { return m_nextp; }
-    AstNode* backp() const VL_MT_SAFE { return m_backp; }
+    AstNode* nextp() const VL_MT_STABLE_TREE { return m_nextp; }
+    AstNode* backp() const VL_MT_STABLE_TREE { return m_backp; }
     AstNode* abovep() const;  // Parent node above, only when no nextp() as otherwise slow
-    AstNode* op1p() const VL_MT_SAFE { return m_op1p; }
-    AstNode* op2p() const VL_MT_SAFE { return m_op2p; }
-    AstNode* op3p() const VL_MT_SAFE { return m_op3p; }
-    AstNode* op4p() const VL_MT_SAFE { return m_op4p; }
-    AstNodeDType* dtypep() const VL_MT_SAFE { return m_dtypep; }
+    AstNode* op1p() const VL_MT_STABLE_TREE { return m_op1p; }
+    AstNode* op2p() const VL_MT_STABLE_TREE { return m_op2p; }
+    AstNode* op3p() const VL_MT_STABLE_TREE { return m_op3p; }
+    AstNode* op4p() const VL_MT_STABLE_TREE { return m_op4p; }
+    AstNodeDType* dtypep() const VL_MT_STABLE_TREE { return m_dtypep; }
     AstNode* clonep() const { return ((m_cloneCnt == s_cloneCntGbl) ? m_clonep : nullptr); }
     AstNode* firstAbovep() const {  // Returns nullptr when second or later in list
         return ((backp() && backp()->nextp() != this) ? backp() : nullptr);
@@ -1697,25 +1697,27 @@ public:
     void protect(bool flag) { m_flags.protect = flag; }
 
     // TODO stomp these width functions out, and call via dtypep() instead
-    inline int width() const VL_MT_SAFE;
+    inline int width() const VL_MT_STABLE_TREE;
     inline int widthMin() const;
     int widthMinV() const {
         return v3Global.widthMinUsage() == VWidthMinUsage::VERILOG_WIDTH ? widthMin() : width();
     }
     int widthWords() const { return VL_WORDS_I(width()); }
-    bool isQuad() const VL_MT_SAFE { return (width() > VL_IDATASIZE && width() <= VL_QUADSIZE); }
-    bool isWide() const VL_MT_SAFE { return (width() > VL_QUADSIZE); }
-    inline bool isDouble() const VL_MT_SAFE;
-    inline bool isSigned() const VL_MT_SAFE;
-    inline bool isString() const VL_MT_SAFE;
+    bool isQuad() const VL_MT_STABLE_TREE {
+        return (width() > VL_IDATASIZE && width() <= VL_QUADSIZE);
+    }
+    bool isWide() const VL_MT_STABLE_TREE { return (width() > VL_QUADSIZE); }
+    inline bool isDouble() const VL_MT_STABLE_TREE;
+    inline bool isSigned() const VL_MT_STABLE_TREE;
+    inline bool isString() const VL_MT_STABLE_TREE;
 
     // clang-format off
-    VNUser      user1u() const VL_MT_SAFE {
+    VNUser      user1u() const VL_MT_STABLE_TREE {
         // Slows things down measurably, so disabled by default
         //UASSERT_STATIC(VNUser1InUse::s_userBusy, "userp set w/o busy");
         return ((m_user1Cnt==VNUser1InUse::s_userCntGbl) ? m_user1u : VNUser{0});
     }
-    AstNode*    user1p() const VL_MT_SAFE { return user1u().toNodep(); }
+    AstNode*    user1p() const VL_MT_STABLE_TREE { return user1u().toNodep(); }
     void        user1u(const VNUser& user) { m_user1u=user; m_user1Cnt=VNUser1InUse::s_userCntGbl; }
     void        user1p(void* userp) { user1u(VNUser{userp}); }
     int         user1() const { return user1u().toInt(); }
@@ -1724,12 +1726,12 @@ public:
     int         user1SetOnce() { int v=user1(); if (!v) user1(1); return v; }  // Better for cache than user1Inc()
     static void user1ClearTree() { VNUser1InUse::clear(); }  // Clear userp()'s across the entire tree
 
-    VNUser      user2u() const VL_MT_SAFE {
+    VNUser      user2u() const VL_MT_STABLE_TREE {
         // Slows things down measurably, so disabled by default
         //UASSERT_STATIC(VNUser2InUse::s_userBusy, "userp set w/o busy");
         return ((m_user2Cnt==VNUser2InUse::s_userCntGbl) ? m_user2u : VNUser{0});
     }
-    AstNode*    user2p() const VL_MT_SAFE { return user2u().toNodep(); }
+    AstNode*    user2p() const VL_MT_STABLE_TREE { return user2u().toNodep(); }
     void        user2u(const VNUser& user) { m_user2u=user; m_user2Cnt=VNUser2InUse::s_userCntGbl; }
     void        user2p(void* userp) { user2u(VNUser{userp}); }
     int         user2() const { return user2u().toInt(); }
@@ -1738,12 +1740,12 @@ public:
     int         user2SetOnce() { int v=user2(); if (!v) user2(1); return v; }  // Better for cache than user2Inc()
     static void user2ClearTree() { VNUser2InUse::clear(); }  // Clear userp()'s across the entire tree
 
-    VNUser      user3u() const VL_MT_SAFE {
+    VNUser      user3u() const VL_MT_STABLE_TREE {
         // Slows things down measurably, so disabled by default
         //UASSERT_STATIC(VNUser3InUse::s_userBusy, "userp set w/o busy");
         return ((m_user3Cnt==VNUser3InUse::s_userCntGbl) ? m_user3u : VNUser{0});
     }
-    AstNode*    user3p() const VL_MT_SAFE { return user3u().toNodep(); }
+    AstNode*    user3p() const VL_MT_STABLE_TREE { return user3u().toNodep(); }
     void        user3u(const VNUser& user) { m_user3u=user; m_user3Cnt=VNUser3InUse::s_userCntGbl; }
     void        user3p(void* userp) { user3u(VNUser{userp}); }
     int         user3() const { return user3u().toInt(); }
@@ -1752,12 +1754,12 @@ public:
     int         user3SetOnce() { int v=user3(); if (!v) user3(1); return v; }  // Better for cache than user3Inc()
     static void user3ClearTree() { VNUser3InUse::clear(); }  // Clear userp()'s across the entire tree
 
-    VNUser      user4u() const VL_MT_SAFE {
+    VNUser      user4u() const VL_MT_STABLE_TREE {
         // Slows things down measurably, so disabled by default
         //UASSERT_STATIC(VNUser4InUse::s_userBusy, "userp set w/o busy");
         return ((m_user4Cnt==VNUser4InUse::s_userCntGbl) ? m_user4u : VNUser{0});
     }
-    AstNode*    user4p() const VL_MT_SAFE { return user4u().toNodep(); }
+    AstNode*    user4p() const VL_MT_STABLE_TREE { return user4u().toNodep(); }
     void        user4u(const VNUser& user) { m_user4u=user; m_user4Cnt=VNUser4InUse::s_userCntGbl; }
     void        user4p(void* userp) { user4u(VNUser{userp}); }
     int         user4() const { return user4u().toInt(); }
@@ -1766,12 +1768,12 @@ public:
     int         user4SetOnce() { int v=user4(); if (!v) user4(1); return v; }  // Better for cache than user4Inc()
     static void user4ClearTree() { VNUser4InUse::clear(); }  // Clear userp()'s across the entire tree
 
-    VNUser      user5u() const VL_MT_SAFE {
+    VNUser      user5u() const VL_MT_STABLE_TREE {
         // Slows things down measurably, so disabled by default
         //UASSERT_STATIC(VNUser5InUse::s_userBusy, "userp set w/o busy");
         return ((m_user5Cnt==VNUser5InUse::s_userCntGbl) ? m_user5u : VNUser{0});
     }
-    AstNode*    user5p() const VL_MT_SAFE { return user5u().toNodep(); }
+    AstNode*    user5p() const VL_MT_STABLE_TREE { return user5u().toNodep(); }
     void        user5u(const VNUser& user) { m_user5u=user; m_user5Cnt=VNUser5InUse::s_userCntGbl; }
     void        user5p(void* userp) { user5u(VNUser{userp}); }
     int         user5() const { return user5u().toInt(); }
@@ -1907,7 +1909,7 @@ public:
     // Does tree of this == node2p?, not allowing non-isGateOptimizable
     inline bool sameGateTree(const AstNode* node2p) const;
     void deleteTree();  // Always deletes the next link
-    void checkTree() const VL_MT_SAFE {
+    void checkTree() const VL_MT_STABLE_TREE {
         if (v3Global.opt.debugCheck()) checkTreeIter(backp());
     }
     void checkIter() const;
@@ -2035,7 +2037,7 @@ public:
 
     // For use via the VN_AS macro only
     template <typename T, typename E>
-    static T* privateAs(AstNode* nodep) VL_MT_SAFE {
+    static T* privateAs(AstNode* nodep) VL_PURE {
         static_assert(!uselessCast<T, E>(), "Unnecessary VN_AS, node known to have target type.");
         static_assert(!impossibleCast<T, E>(), "Unnecessary VN_AS, node cannot be this type.");
         UASSERT_OBJ(!nodep || privateTypeTest<T>(nodep), nodep,
@@ -2044,7 +2046,7 @@ public:
         return reinterpret_cast<T*>(nodep);
     }
     template <typename T, typename E>
-    static const T* privateAs(const AstNode* nodep) VL_MT_SAFE {
+    static const T* privateAs(const AstNode* nodep) VL_PURE {
         static_assert(!uselessCast<T, E>(), "Unnecessary VN_AS, node known to have target type.");
         static_assert(!impossibleCast<T, E>(), "Unnecessary VN_AS, node cannot be this type.");
         UASSERT_OBJ(!nodep || privateTypeTest<T>(nodep), nodep,

--- a/src/V3Ast.h
+++ b/src/V3Ast.h
@@ -1545,7 +1545,7 @@ class AstNode VL_NOT_FINAL {
 private:
     AstNode* cloneTreeIter();
     AstNode* cloneTreeIterList();
-    void checkTreeIter(const AstNode* prevBackp) const VL_MT_STABLE_TREE;
+    void checkTreeIter(const AstNode* prevBackp) const VL_MT_STABLE;
     bool gateTreeIter() const;
     static bool sameTreeIter(const AstNode* node1p, const AstNode* node2p, bool ignNext,
                              bool gateOnly);
@@ -1601,14 +1601,14 @@ public:
     // ACCESSORS
     VNType type() const VL_MT_SAFE { return m_type; }
     const char* typeName() const VL_MT_SAFE { return type().ascii(); }  // See also prettyTypeName
-    AstNode* nextp() const VL_MT_STABLE_TREE { return m_nextp; }
-    AstNode* backp() const VL_MT_STABLE_TREE { return m_backp; }
+    AstNode* nextp() const VL_MT_STABLE { return m_nextp; }
+    AstNode* backp() const VL_MT_STABLE { return m_backp; }
     AstNode* abovep() const;  // Parent node above, only when no nextp() as otherwise slow
-    AstNode* op1p() const VL_MT_STABLE_TREE { return m_op1p; }
-    AstNode* op2p() const VL_MT_STABLE_TREE { return m_op2p; }
-    AstNode* op3p() const VL_MT_STABLE_TREE { return m_op3p; }
-    AstNode* op4p() const VL_MT_STABLE_TREE { return m_op4p; }
-    AstNodeDType* dtypep() const VL_MT_STABLE_TREE { return m_dtypep; }
+    AstNode* op1p() const VL_MT_STABLE { return m_op1p; }
+    AstNode* op2p() const VL_MT_STABLE { return m_op2p; }
+    AstNode* op3p() const VL_MT_STABLE { return m_op3p; }
+    AstNode* op4p() const VL_MT_STABLE { return m_op4p; }
+    AstNodeDType* dtypep() const VL_MT_STABLE { return m_dtypep; }
     AstNode* clonep() const { return ((m_cloneCnt == s_cloneCntGbl) ? m_clonep : nullptr); }
     AstNode* firstAbovep() const {  // Returns nullptr when second or later in list
         return ((backp() && backp()->nextp() != this) ? backp() : nullptr);
@@ -1697,27 +1697,25 @@ public:
     void protect(bool flag) { m_flags.protect = flag; }
 
     // TODO stomp these width functions out, and call via dtypep() instead
-    inline int width() const VL_MT_STABLE_TREE;
+    inline int width() const VL_MT_STABLE;
     inline int widthMin() const;
     int widthMinV() const {
         return v3Global.widthMinUsage() == VWidthMinUsage::VERILOG_WIDTH ? widthMin() : width();
     }
     int widthWords() const { return VL_WORDS_I(width()); }
-    bool isQuad() const VL_MT_STABLE_TREE {
-        return (width() > VL_IDATASIZE && width() <= VL_QUADSIZE);
-    }
-    bool isWide() const VL_MT_STABLE_TREE { return (width() > VL_QUADSIZE); }
-    inline bool isDouble() const VL_MT_STABLE_TREE;
-    inline bool isSigned() const VL_MT_STABLE_TREE;
-    inline bool isString() const VL_MT_STABLE_TREE;
+    bool isQuad() const VL_MT_STABLE { return (width() > VL_IDATASIZE && width() <= VL_QUADSIZE); }
+    bool isWide() const VL_MT_STABLE { return (width() > VL_QUADSIZE); }
+    inline bool isDouble() const VL_MT_STABLE;
+    inline bool isSigned() const VL_MT_STABLE;
+    inline bool isString() const VL_MT_STABLE;
 
     // clang-format off
-    VNUser      user1u() const VL_MT_STABLE_TREE {
+    VNUser      user1u() const VL_MT_STABLE {
         // Slows things down measurably, so disabled by default
         //UASSERT_STATIC(VNUser1InUse::s_userBusy, "userp set w/o busy");
         return ((m_user1Cnt==VNUser1InUse::s_userCntGbl) ? m_user1u : VNUser{0});
     }
-    AstNode*    user1p() const VL_MT_STABLE_TREE { return user1u().toNodep(); }
+    AstNode*    user1p() const VL_MT_STABLE { return user1u().toNodep(); }
     void        user1u(const VNUser& user) { m_user1u=user; m_user1Cnt=VNUser1InUse::s_userCntGbl; }
     void        user1p(void* userp) { user1u(VNUser{userp}); }
     int         user1() const { return user1u().toInt(); }
@@ -1726,12 +1724,12 @@ public:
     int         user1SetOnce() { int v=user1(); if (!v) user1(1); return v; }  // Better for cache than user1Inc()
     static void user1ClearTree() { VNUser1InUse::clear(); }  // Clear userp()'s across the entire tree
 
-    VNUser      user2u() const VL_MT_STABLE_TREE {
+    VNUser      user2u() const VL_MT_STABLE {
         // Slows things down measurably, so disabled by default
         //UASSERT_STATIC(VNUser2InUse::s_userBusy, "userp set w/o busy");
         return ((m_user2Cnt==VNUser2InUse::s_userCntGbl) ? m_user2u : VNUser{0});
     }
-    AstNode*    user2p() const VL_MT_STABLE_TREE { return user2u().toNodep(); }
+    AstNode*    user2p() const VL_MT_STABLE { return user2u().toNodep(); }
     void        user2u(const VNUser& user) { m_user2u=user; m_user2Cnt=VNUser2InUse::s_userCntGbl; }
     void        user2p(void* userp) { user2u(VNUser{userp}); }
     int         user2() const { return user2u().toInt(); }
@@ -1740,12 +1738,12 @@ public:
     int         user2SetOnce() { int v=user2(); if (!v) user2(1); return v; }  // Better for cache than user2Inc()
     static void user2ClearTree() { VNUser2InUse::clear(); }  // Clear userp()'s across the entire tree
 
-    VNUser      user3u() const VL_MT_STABLE_TREE {
+    VNUser      user3u() const VL_MT_STABLE {
         // Slows things down measurably, so disabled by default
         //UASSERT_STATIC(VNUser3InUse::s_userBusy, "userp set w/o busy");
         return ((m_user3Cnt==VNUser3InUse::s_userCntGbl) ? m_user3u : VNUser{0});
     }
-    AstNode*    user3p() const VL_MT_STABLE_TREE { return user3u().toNodep(); }
+    AstNode*    user3p() const VL_MT_STABLE { return user3u().toNodep(); }
     void        user3u(const VNUser& user) { m_user3u=user; m_user3Cnt=VNUser3InUse::s_userCntGbl; }
     void        user3p(void* userp) { user3u(VNUser{userp}); }
     int         user3() const { return user3u().toInt(); }
@@ -1754,12 +1752,12 @@ public:
     int         user3SetOnce() { int v=user3(); if (!v) user3(1); return v; }  // Better for cache than user3Inc()
     static void user3ClearTree() { VNUser3InUse::clear(); }  // Clear userp()'s across the entire tree
 
-    VNUser      user4u() const VL_MT_STABLE_TREE {
+    VNUser      user4u() const VL_MT_STABLE {
         // Slows things down measurably, so disabled by default
         //UASSERT_STATIC(VNUser4InUse::s_userBusy, "userp set w/o busy");
         return ((m_user4Cnt==VNUser4InUse::s_userCntGbl) ? m_user4u : VNUser{0});
     }
-    AstNode*    user4p() const VL_MT_STABLE_TREE { return user4u().toNodep(); }
+    AstNode*    user4p() const VL_MT_STABLE { return user4u().toNodep(); }
     void        user4u(const VNUser& user) { m_user4u=user; m_user4Cnt=VNUser4InUse::s_userCntGbl; }
     void        user4p(void* userp) { user4u(VNUser{userp}); }
     int         user4() const { return user4u().toInt(); }
@@ -1768,12 +1766,12 @@ public:
     int         user4SetOnce() { int v=user4(); if (!v) user4(1); return v; }  // Better for cache than user4Inc()
     static void user4ClearTree() { VNUser4InUse::clear(); }  // Clear userp()'s across the entire tree
 
-    VNUser      user5u() const VL_MT_STABLE_TREE {
+    VNUser      user5u() const VL_MT_STABLE {
         // Slows things down measurably, so disabled by default
         //UASSERT_STATIC(VNUser5InUse::s_userBusy, "userp set w/o busy");
         return ((m_user5Cnt==VNUser5InUse::s_userCntGbl) ? m_user5u : VNUser{0});
     }
-    AstNode*    user5p() const VL_MT_STABLE_TREE { return user5u().toNodep(); }
+    AstNode*    user5p() const VL_MT_STABLE { return user5u().toNodep(); }
     void        user5u(const VNUser& user) { m_user5u=user; m_user5Cnt=VNUser5InUse::s_userCntGbl; }
     void        user5p(void* userp) { user5u(VNUser{userp}); }
     int         user5() const { return user5u().toInt(); }
@@ -1909,7 +1907,7 @@ public:
     // Does tree of this == node2p?, not allowing non-isGateOptimizable
     inline bool sameGateTree(const AstNode* node2p) const;
     void deleteTree();  // Always deletes the next link
-    void checkTree() const VL_MT_STABLE_TREE {
+    void checkTree() const VL_MT_STABLE {
         if (v3Global.opt.debugCheck()) checkTreeIter(backp());
     }
     void checkIter() const;

--- a/src/V3AstInlines.h
+++ b/src/V3AstInlines.h
@@ -25,7 +25,7 @@
 //######################################################################
 // Inline METHODS
 
-int AstNode::width() const { return dtypep() ? dtypep()->width() : 0; }
+int AstNode::width() const VL_MT_STABLE_TREE { return dtypep() ? dtypep()->width() : 0; }
 int AstNode::widthMin() const { return dtypep() ? dtypep()->widthMin() : 0; }
 bool AstNode::width1() const {  // V3Const uses to know it can optimize
     return dtypep() && dtypep()->width() == 1;
@@ -33,13 +33,13 @@ bool AstNode::width1() const {  // V3Const uses to know it can optimize
 int AstNode::widthInstrs() const {
     return (!dtypep() ? 1 : (dtypep()->isWide() ? dtypep()->widthWords() : 1));
 }
-bool AstNode::isDouble() const VL_MT_SAFE {
+bool AstNode::isDouble() const VL_MT_STABLE_TREE {
     return dtypep() && VN_IS(dtypep(), BasicDType) && VN_AS(dtypep(), BasicDType)->isDouble();
 }
-bool AstNode::isString() const VL_MT_SAFE {
+bool AstNode::isString() const VL_MT_STABLE_TREE {
     return dtypep() && dtypep()->basicp() && dtypep()->basicp()->isString();
 }
-bool AstNode::isSigned() const { return dtypep() && dtypep()->isSigned(); }
+bool AstNode::isSigned() const VL_MT_STABLE_TREE { return dtypep() && dtypep()->isSigned(); }
 
 bool AstNode::isZero() const {
     return (VN_IS(this, Const) && VN_AS(this, Const)->num().isEqZero());
@@ -61,12 +61,16 @@ bool AstNode::sameGateTree(const AstNode* node2p) const {
     return sameTreeIter(this, node2p, true, true);
 }
 
-int AstNodeArrayDType::left() const VL_MT_SAFE { return rangep()->leftConst(); }
-int AstNodeArrayDType::right() const VL_MT_SAFE { return rangep()->rightConst(); }
-int AstNodeArrayDType::hi() const VL_MT_SAFE { return rangep()->hiConst(); }
-int AstNodeArrayDType::lo() const VL_MT_SAFE { return rangep()->loConst(); }
-int AstNodeArrayDType::elementsConst() const VL_MT_SAFE { return rangep()->elementsConst(); }
-VNumRange AstNodeArrayDType::declRange() const VL_MT_SAFE { return VNumRange{left(), right()}; }
+int AstNodeArrayDType::left() const VL_MT_STABLE_TREE { return rangep()->leftConst(); }
+int AstNodeArrayDType::right() const VL_MT_STABLE_TREE { return rangep()->rightConst(); }
+int AstNodeArrayDType::hi() const VL_MT_STABLE_TREE { return rangep()->hiConst(); }
+int AstNodeArrayDType::lo() const VL_MT_STABLE_TREE { return rangep()->loConst(); }
+int AstNodeArrayDType::elementsConst() const VL_MT_STABLE_TREE {
+    return rangep()->elementsConst();
+}
+VNumRange AstNodeArrayDType::declRange() const VL_MT_STABLE_TREE {
+    return VNumRange{left(), right()};
+}
 
 AstRange::AstRange(FileLine* fl, int left, int right)
     : ASTGEN_SUPER_Range(fl) {
@@ -78,16 +82,16 @@ AstRange::AstRange(FileLine* fl, const VNumRange& range)
     leftp(new AstConst{fl, static_cast<uint32_t>(range.left())});
     rightp(new AstConst{fl, static_cast<uint32_t>(range.right())});
 }
-int AstRange::leftConst() const VL_MT_SAFE {
+int AstRange::leftConst() const VL_MT_STABLE_TREE {
     AstConst* const constp = VN_CAST(leftp(), Const);
     return (constp ? constp->toSInt() : 0);
 }
-int AstRange::rightConst() const VL_MT_SAFE {
+int AstRange::rightConst() const VL_MT_STABLE_TREE {
     AstConst* const constp = VN_CAST(rightp(), Const);
     return (constp ? constp->toSInt() : 0);
 }
 
-int AstQueueDType::boundConst() const VL_MT_SAFE {
+int AstQueueDType::boundConst() const VL_MT_STABLE_TREE {
     AstConst* const constp = VN_CAST(boundp(), Const);
     return (constp ? constp->toSInt() : 0);
 }

--- a/src/V3AstInlines.h
+++ b/src/V3AstInlines.h
@@ -33,10 +33,10 @@ bool AstNode::width1() const {  // V3Const uses to know it can optimize
 int AstNode::widthInstrs() const {
     return (!dtypep() ? 1 : (dtypep()->isWide() ? dtypep()->widthWords() : 1));
 }
-bool AstNode::isDouble() const {
+bool AstNode::isDouble() const VL_MT_SAFE {
     return dtypep() && VN_IS(dtypep(), BasicDType) && VN_AS(dtypep(), BasicDType)->isDouble();
 }
-bool AstNode::isString() const {
+bool AstNode::isString() const VL_MT_SAFE {
     return dtypep() && dtypep()->basicp() && dtypep()->basicp()->isString();
 }
 bool AstNode::isSigned() const { return dtypep() && dtypep()->isSigned(); }
@@ -61,12 +61,12 @@ bool AstNode::sameGateTree(const AstNode* node2p) const {
     return sameTreeIter(this, node2p, true, true);
 }
 
-int AstNodeArrayDType::left() const { return rangep()->leftConst(); }
-int AstNodeArrayDType::right() const { return rangep()->rightConst(); }
-int AstNodeArrayDType::hi() const { return rangep()->hiConst(); }
-int AstNodeArrayDType::lo() const { return rangep()->loConst(); }
-int AstNodeArrayDType::elementsConst() const { return rangep()->elementsConst(); }
-VNumRange AstNodeArrayDType::declRange() const { return VNumRange{left(), right()}; }
+int AstNodeArrayDType::left() const VL_MT_SAFE { return rangep()->leftConst(); }
+int AstNodeArrayDType::right() const VL_MT_SAFE { return rangep()->rightConst(); }
+int AstNodeArrayDType::hi() const VL_MT_SAFE { return rangep()->hiConst(); }
+int AstNodeArrayDType::lo() const VL_MT_SAFE { return rangep()->loConst(); }
+int AstNodeArrayDType::elementsConst() const VL_MT_SAFE { return rangep()->elementsConst(); }
+VNumRange AstNodeArrayDType::declRange() const VL_MT_SAFE { return VNumRange{left(), right()}; }
 
 AstRange::AstRange(FileLine* fl, int left, int right)
     : ASTGEN_SUPER_Range(fl) {
@@ -78,16 +78,16 @@ AstRange::AstRange(FileLine* fl, const VNumRange& range)
     leftp(new AstConst{fl, static_cast<uint32_t>(range.left())});
     rightp(new AstConst{fl, static_cast<uint32_t>(range.right())});
 }
-int AstRange::leftConst() const {
+int AstRange::leftConst() const VL_MT_SAFE {
     AstConst* const constp = VN_CAST(leftp(), Const);
     return (constp ? constp->toSInt() : 0);
 }
-int AstRange::rightConst() const {
+int AstRange::rightConst() const VL_MT_SAFE {
     AstConst* const constp = VN_CAST(rightp(), Const);
     return (constp ? constp->toSInt() : 0);
 }
 
-int AstQueueDType::boundConst() const {
+int AstQueueDType::boundConst() const VL_MT_SAFE {
     AstConst* const constp = VN_CAST(boundp(), Const);
     return (constp ? constp->toSInt() : 0);
 }

--- a/src/V3AstInlines.h
+++ b/src/V3AstInlines.h
@@ -25,7 +25,7 @@
 //######################################################################
 // Inline METHODS
 
-int AstNode::width() const VL_MT_STABLE_TREE { return dtypep() ? dtypep()->width() : 0; }
+int AstNode::width() const VL_MT_STABLE { return dtypep() ? dtypep()->width() : 0; }
 int AstNode::widthMin() const { return dtypep() ? dtypep()->widthMin() : 0; }
 bool AstNode::width1() const {  // V3Const uses to know it can optimize
     return dtypep() && dtypep()->width() == 1;
@@ -33,13 +33,13 @@ bool AstNode::width1() const {  // V3Const uses to know it can optimize
 int AstNode::widthInstrs() const {
     return (!dtypep() ? 1 : (dtypep()->isWide() ? dtypep()->widthWords() : 1));
 }
-bool AstNode::isDouble() const VL_MT_STABLE_TREE {
+bool AstNode::isDouble() const VL_MT_STABLE {
     return dtypep() && VN_IS(dtypep(), BasicDType) && VN_AS(dtypep(), BasicDType)->isDouble();
 }
-bool AstNode::isString() const VL_MT_STABLE_TREE {
+bool AstNode::isString() const VL_MT_STABLE {
     return dtypep() && dtypep()->basicp() && dtypep()->basicp()->isString();
 }
-bool AstNode::isSigned() const VL_MT_STABLE_TREE { return dtypep() && dtypep()->isSigned(); }
+bool AstNode::isSigned() const VL_MT_STABLE { return dtypep() && dtypep()->isSigned(); }
 
 bool AstNode::isZero() const {
     return (VN_IS(this, Const) && VN_AS(this, Const)->num().isEqZero());
@@ -61,16 +61,12 @@ bool AstNode::sameGateTree(const AstNode* node2p) const {
     return sameTreeIter(this, node2p, true, true);
 }
 
-int AstNodeArrayDType::left() const VL_MT_STABLE_TREE { return rangep()->leftConst(); }
-int AstNodeArrayDType::right() const VL_MT_STABLE_TREE { return rangep()->rightConst(); }
-int AstNodeArrayDType::hi() const VL_MT_STABLE_TREE { return rangep()->hiConst(); }
-int AstNodeArrayDType::lo() const VL_MT_STABLE_TREE { return rangep()->loConst(); }
-int AstNodeArrayDType::elementsConst() const VL_MT_STABLE_TREE {
-    return rangep()->elementsConst();
-}
-VNumRange AstNodeArrayDType::declRange() const VL_MT_STABLE_TREE {
-    return VNumRange{left(), right()};
-}
+int AstNodeArrayDType::left() const VL_MT_STABLE { return rangep()->leftConst(); }
+int AstNodeArrayDType::right() const VL_MT_STABLE { return rangep()->rightConst(); }
+int AstNodeArrayDType::hi() const VL_MT_STABLE { return rangep()->hiConst(); }
+int AstNodeArrayDType::lo() const VL_MT_STABLE { return rangep()->loConst(); }
+int AstNodeArrayDType::elementsConst() const VL_MT_STABLE { return rangep()->elementsConst(); }
+VNumRange AstNodeArrayDType::declRange() const VL_MT_STABLE { return VNumRange{left(), right()}; }
 
 AstRange::AstRange(FileLine* fl, int left, int right)
     : ASTGEN_SUPER_Range(fl) {
@@ -82,16 +78,16 @@ AstRange::AstRange(FileLine* fl, const VNumRange& range)
     leftp(new AstConst{fl, static_cast<uint32_t>(range.left())});
     rightp(new AstConst{fl, static_cast<uint32_t>(range.right())});
 }
-int AstRange::leftConst() const VL_MT_STABLE_TREE {
+int AstRange::leftConst() const VL_MT_STABLE {
     AstConst* const constp = VN_CAST(leftp(), Const);
     return (constp ? constp->toSInt() : 0);
 }
-int AstRange::rightConst() const VL_MT_STABLE_TREE {
+int AstRange::rightConst() const VL_MT_STABLE {
     AstConst* const constp = VN_CAST(rightp(), Const);
     return (constp ? constp->toSInt() : 0);
 }
 
-int AstQueueDType::boundConst() const VL_MT_STABLE_TREE {
+int AstQueueDType::boundConst() const VL_MT_STABLE {
     AstConst* const constp = VN_CAST(boundp(), Const);
     return (constp ? constp->toSInt() : 0);
 }

--- a/src/V3AstInlines.h
+++ b/src/V3AstInlines.h
@@ -33,10 +33,10 @@ bool AstNode::width1() const {  // V3Const uses to know it can optimize
 int AstNode::widthInstrs() const {
     return (!dtypep() ? 1 : (dtypep()->isWide() ? dtypep()->widthWords() : 1));
 }
-bool AstNode::isDouble() const VL_MT_SAFE {
+bool AstNode::isDouble() const {
     return dtypep() && VN_IS(dtypep(), BasicDType) && VN_AS(dtypep(), BasicDType)->isDouble();
 }
-bool AstNode::isString() const VL_MT_SAFE {
+bool AstNode::isString() const {
     return dtypep() && dtypep()->basicp() && dtypep()->basicp()->isString();
 }
 bool AstNode::isSigned() const { return dtypep() && dtypep()->isSigned(); }
@@ -61,12 +61,12 @@ bool AstNode::sameGateTree(const AstNode* node2p) const {
     return sameTreeIter(this, node2p, true, true);
 }
 
-int AstNodeArrayDType::left() const VL_MT_SAFE { return rangep()->leftConst(); }
-int AstNodeArrayDType::right() const VL_MT_SAFE { return rangep()->rightConst(); }
-int AstNodeArrayDType::hi() const VL_MT_SAFE { return rangep()->hiConst(); }
-int AstNodeArrayDType::lo() const VL_MT_SAFE { return rangep()->loConst(); }
-int AstNodeArrayDType::elementsConst() const VL_MT_SAFE { return rangep()->elementsConst(); }
-VNumRange AstNodeArrayDType::declRange() const VL_MT_SAFE { return VNumRange{left(), right()}; }
+int AstNodeArrayDType::left() const { return rangep()->leftConst(); }
+int AstNodeArrayDType::right() const { return rangep()->rightConst(); }
+int AstNodeArrayDType::hi() const { return rangep()->hiConst(); }
+int AstNodeArrayDType::lo() const { return rangep()->loConst(); }
+int AstNodeArrayDType::elementsConst() const { return rangep()->elementsConst(); }
+VNumRange AstNodeArrayDType::declRange() const { return VNumRange{left(), right()}; }
 
 AstRange::AstRange(FileLine* fl, int left, int right)
     : ASTGEN_SUPER_Range(fl) {
@@ -87,7 +87,7 @@ int AstRange::rightConst() const {
     return (constp ? constp->toSInt() : 0);
 }
 
-int AstQueueDType::boundConst() const VL_MT_SAFE {
+int AstQueueDType::boundConst() const {
     AstConst* const constp = VN_CAST(boundp(), Const);
     return (constp ? constp->toSInt() : 0);
 }

--- a/src/V3AstNodeDType.h
+++ b/src/V3AstNodeDType.h
@@ -126,12 +126,12 @@ public:
     const char* charIQWN() const {
         return (isString() ? "N" : isWide() ? "W" : isQuad() ? "Q" : "I");
     }
-    string cType(const string& name, bool forFunc, bool isRef) const VL_MT_SAFE;
-    bool isLiteralType() const VL_MT_SAFE;  // Represents a C++ LiteralType? (can be constexpr)
+    string cType(const string& name, bool forFunc, bool isRef) const;
+    bool isLiteralType() const;  // Represents a C++ LiteralType? (can be constexpr)
 
 private:
     class CTypeRecursed;
-    CTypeRecursed cTypeRecurse(bool compound) const VL_MT_SAFE;
+    CTypeRecursed cTypeRecurse(bool compound) const;
 };
 class AstNodeArrayDType VL_NOT_FINAL : public AstNodeDType {
     // Array data type, ie "some_dtype var_name [2:0]"
@@ -177,7 +177,7 @@ public:
     AstNodeDType* virtRefDTypep() const override { return m_refDTypep; }
     void virtRefDTypep(AstNodeDType* nodep) override { refDTypep(nodep); }
     // METHODS
-    AstBasicDType* basicp() const override VL_MT_SAFE {
+    AstBasicDType* basicp() const override {
         return subDTypep()->basicp();
     }  // (Slow) recurse down to find basic data type
     AstNodeDType* skipRefp() const override VL_MT_SAFE { return (AstNodeDType*)this; }
@@ -583,8 +583,8 @@ public:
     AstNodeDType* virtRefDTypep() const override { return m_refDTypep; }
     void virtRefDTypep(AstNodeDType* nodep) override { refDTypep(nodep); }
     // METHODS
-    AstBasicDType* basicp() const override VL_MT_SAFE { return subDTypep()->basicp(); }
-    AstNodeDType* skipRefp() const override VL_MT_SAFE { return subDTypep()->skipRefp(); }
+    AstBasicDType* basicp() const override { return subDTypep()->basicp(); }
+    AstNodeDType* skipRefp() const override { return subDTypep()->skipRefp(); }
     AstNodeDType* skipRefToConstp() const override { return (AstNodeDType*)this; }
     AstNodeDType* skipRefToEnump() const override { return subDTypep()->skipRefToEnump(); }
     int widthAlignBytes() const override { return subDTypep()->widthAlignBytes(); }
@@ -630,7 +630,7 @@ public:
     // METHODS
     // op1 = Range of variable
     AstNodeDType* dtypeSkipRefp() const { return dtypep()->skipRefp(); }
-    AstBasicDType* basicp() const override VL_MT_SAFE { return subDTypep()->basicp(); }
+    AstBasicDType* basicp() const override { return subDTypep()->basicp(); }
     AstNodeDType* skipRefp() const override VL_MT_SAFE { return (AstNodeDType*)this; }
     AstNodeDType* skipRefToConstp() const override { return (AstNodeDType*)this; }
     AstNodeDType* skipRefToEnump() const override { return (AstNodeDType*)this; }
@@ -765,8 +765,8 @@ public:
     void dump(std::ostream& str = std::cout) const override;
     void dumpSmall(std::ostream& str) const override;
     // METHODS
-    AstBasicDType* basicp() const override VL_MT_SAFE { return subDTypep()->basicp(); }
-    AstNodeDType* skipRefp() const override VL_MT_SAFE { return subDTypep()->skipRefp(); }
+    AstBasicDType* basicp() const override { return subDTypep()->basicp(); }
+    AstNodeDType* skipRefp() const override { return subDTypep()->skipRefp(); }
     AstNodeDType* skipRefToConstp() const override { return subDTypep()->skipRefToConstp(); }
     // cppcheck-suppress csyleCast
     AstNodeDType* skipRefToEnump() const override { return (AstNodeDType*)this; }
@@ -891,10 +891,10 @@ public:
     //
     // (Slow) recurse down to find basic data type (Note don't need virtual -
     // AstVar isn't a NodeDType)
-    AstBasicDType* basicp() const override VL_MT_SAFE { return subDTypep()->basicp(); }
+    AstBasicDType* basicp() const override { return subDTypep()->basicp(); }
     // op1 = Range of variable (Note don't need virtual - AstVar isn't a NodeDType)
     AstNodeDType* dtypeSkipRefp() const { return subDTypep()->skipRefp(); }
-    AstNodeDType* skipRefp() const override VL_MT_SAFE { return subDTypep()->skipRefp(); }
+    AstNodeDType* skipRefp() const override { return subDTypep()->skipRefp(); }
     AstNodeDType* skipRefToConstp() const override { return subDTypep()->skipRefToConstp(); }
     AstNodeDType* skipRefToEnump() const override { return subDTypep()->skipRefToEnump(); }
     // (Slow) recurses - Structure alignment 1,2,4 or 8 bytes (arrays affect this)
@@ -932,8 +932,8 @@ public:
     void dump(std::ostream& str = std::cout) const override;
     AstNodeDType* getChildDTypep() const override { return childDTypep(); }
     AstNodeDType* subDTypep() const override { return dtypep() ? dtypep() : childDTypep(); }
-    AstBasicDType* basicp() const override VL_MT_SAFE { return subDTypep()->basicp(); }
-    AstNodeDType* skipRefp() const override VL_MT_SAFE { return subDTypep()->skipRefp(); }
+    AstBasicDType* basicp() const override { return subDTypep()->basicp(); }
+    AstNodeDType* skipRefp() const override { return subDTypep()->skipRefp(); }
     AstNodeDType* skipRefToConstp() const override { return subDTypep()->skipRefToConstp(); }
     AstNodeDType* skipRefToEnump() const override { return subDTypep()->skipRefToEnump(); }
     bool similarDType(const AstNodeDType* samep) const override {
@@ -1086,11 +1086,11 @@ public:
     string prettyDTypeName() const override {
         return subDTypep() ? prettyName(subDTypep()->name()) : prettyName();
     }
-    AstBasicDType* basicp() const override VL_MT_SAFE {
+    AstBasicDType* basicp() const override {
         return subDTypep() ? subDTypep()->basicp() : nullptr;
     }
     AstNodeDType* subDTypep() const override;
-    AstNodeDType* skipRefp() const override VL_MT_SAFE {
+    AstNodeDType* skipRefp() const override {
         // Skip past both the Ref and the Typedef
         if (subDTypep()) {
             return subDTypep()->skipRefp();
@@ -1206,8 +1206,8 @@ public:
     AstNodeDType* virtRefDTypep() const override { return m_refDTypep; }
     void virtRefDTypep(AstNodeDType* nodep) override { refDTypep(nodep); }
     // METHODS
-    AstBasicDType* basicp() const override VL_MT_SAFE { return subDTypep()->basicp(); }
-    AstNodeDType* skipRefp() const override VL_MT_SAFE { return (AstNodeDType*)this; }
+    AstBasicDType* basicp() const override { return subDTypep()->basicp(); }
+    AstNodeDType* skipRefp() const override { return (AstNodeDType*)this; }
     AstNodeDType* skipRefToConstp() const override { return (AstNodeDType*)this; }
     AstNodeDType* skipRefToEnump() const override { return (AstNodeDType*)this; }
     int widthAlignBytes() const override { return subDTypep()->widthAlignBytes(); }
@@ -1273,8 +1273,8 @@ public:
     AstNodeDType* virtRefDTypep() const override { return m_refDTypep; }
     void virtRefDTypep(AstNodeDType* nodep) override { refDTypep(nodep); }
     // METHODS
-    AstBasicDType* basicp() const override VL_MT_SAFE { return subDTypep()->basicp(); }
-    AstNodeDType* skipRefp() const override VL_MT_SAFE { return (AstNodeDType*)this; }
+    AstBasicDType* basicp() const override { return subDTypep()->basicp(); }
+    AstNodeDType* skipRefp() const override { return (AstNodeDType*)this; }
     AstNodeDType* skipRefToConstp() const override { return (AstNodeDType*)this; }
     AstNodeDType* skipRefToEnump() const override { return (AstNodeDType*)this; }
     int widthAlignBytes() const override { return sizeof(std::map<std::string, std::string>); }

--- a/src/V3AstNodeDType.h
+++ b/src/V3AstNodeDType.h
@@ -63,9 +63,9 @@ public:
     // Integral or packed, allowed inside an unpacked union/struct
     virtual bool isIntegralOrPacked() const { return !isCompound(); }
     // (Slow) recurse down to find basic data type
-    virtual AstBasicDType* basicp() const VL_MT_STABLE_TREE = 0;
+    virtual AstBasicDType* basicp() const VL_MT_STABLE = 0;
     // recurses over typedefs/const/enum to next non-typeref type
-    virtual AstNodeDType* skipRefp() const VL_MT_STABLE_TREE = 0;
+    virtual AstNodeDType* skipRefp() const VL_MT_STABLE = 0;
     // recurses over typedefs to next non-typeref-or-const type
     virtual AstNodeDType* skipRefToConstp() const = 0;
     // recurses over typedefs/const to next non-typeref-or-enum/struct type
@@ -126,13 +126,13 @@ public:
     const char* charIQWN() const {
         return (isString() ? "N" : isWide() ? "W" : isQuad() ? "Q" : "I");
     }
-    string cType(const string& name, bool forFunc, bool isRef) const VL_MT_STABLE_TREE;
+    string cType(const string& name, bool forFunc, bool isRef) const VL_MT_STABLE;
     // Represents a C++ LiteralType? (can be constexpr)
-    bool isLiteralType() const VL_MT_STABLE_TREE;
+    bool isLiteralType() const VL_MT_STABLE;
 
 private:
     class CTypeRecursed;
-    CTypeRecursed cTypeRecurse(bool compound) const VL_MT_STABLE_TREE;
+    CTypeRecursed cTypeRecurse(bool compound) const VL_MT_STABLE;
 };
 class AstNodeArrayDType VL_NOT_FINAL : public AstNodeDType {
     // Array data type, ie "some_dtype var_name [2:0]"
@@ -171,29 +171,29 @@ public:
                 && subDTypep()->skipRefp()->similarDType(asamep->subDTypep()->skipRefp()));
     }
     AstNodeDType* getChildDTypep() const override { return childDTypep(); }
-    AstNodeDType* subDTypep() const override VL_MT_STABLE_TREE {
+    AstNodeDType* subDTypep() const override VL_MT_STABLE {
         return m_refDTypep ? m_refDTypep : childDTypep();
     }
     void refDTypep(AstNodeDType* nodep) { m_refDTypep = nodep; }
     AstNodeDType* virtRefDTypep() const override { return m_refDTypep; }
     void virtRefDTypep(AstNodeDType* nodep) override { refDTypep(nodep); }
     // METHODS
-    AstBasicDType* basicp() const override VL_MT_STABLE_TREE {
+    AstBasicDType* basicp() const override VL_MT_STABLE {
         return subDTypep()->basicp();
     }  // (Slow) recurse down to find basic data type
-    AstNodeDType* skipRefp() const override VL_MT_STABLE_TREE { return (AstNodeDType*)this; }
+    AstNodeDType* skipRefp() const override VL_MT_STABLE { return (AstNodeDType*)this; }
     AstNodeDType* skipRefToConstp() const override { return (AstNodeDType*)this; }
     AstNodeDType* skipRefToEnump() const override { return (AstNodeDType*)this; }
     int widthAlignBytes() const override { return subDTypep()->widthAlignBytes(); }
     int widthTotalBytes() const override {
         return elementsConst() * subDTypep()->widthTotalBytes();
     }
-    inline int left() const VL_MT_STABLE_TREE;
-    inline int right() const VL_MT_STABLE_TREE;
-    inline int hi() const VL_MT_STABLE_TREE;
-    inline int lo() const VL_MT_STABLE_TREE;
-    inline int elementsConst() const VL_MT_STABLE_TREE;
-    inline VNumRange declRange() const VL_MT_STABLE_TREE;
+    inline int left() const VL_MT_STABLE;
+    inline int right() const VL_MT_STABLE;
+    inline int hi() const VL_MT_STABLE;
+    inline int lo() const VL_MT_STABLE;
+    inline int elementsConst() const VL_MT_STABLE;
+    inline VNumRange declRange() const VL_MT_STABLE;
 };
 class AstNodeUOrStructDType VL_NOT_FINAL : public AstNodeDType {
     // A struct or union; common handling
@@ -232,7 +232,7 @@ public:
                     : VN_AS(findBitRangeDType(VNumRange{width() - 1, 0}, width(), numeric()),
                             BasicDType));
     }
-    AstNodeDType* skipRefp() const override VL_MT_STABLE_TREE { return (AstNodeDType*)this; }
+    AstNodeDType* skipRefp() const override VL_MT_STABLE { return (AstNodeDType*)this; }
     AstNodeDType* skipRefToConstp() const override { return (AstNodeDType*)this; }
     AstNodeDType* skipRefToEnump() const override { return (AstNodeDType*)this; }
     // (Slow) recurses - Structure alignment 1,2,4 or 8 bytes (arrays affect this)
@@ -337,7 +337,7 @@ public:
     void dumpSmall(std::ostream& str) const override;
     AstNodeDType* getChildDTypep() const override { return childDTypep(); }
     AstNodeDType* getChild2DTypep() const override { return keyChildDTypep(); }
-    AstNodeDType* subDTypep() const override VL_MT_STABLE_TREE {
+    AstNodeDType* subDTypep() const override VL_MT_STABLE {
         return m_refDTypep ? m_refDTypep : childDTypep();
     }
     void refDTypep(AstNodeDType* nodep) { m_refDTypep = nodep; }
@@ -346,13 +346,13 @@ public:
     AstNodeDType* virtRefDType2p() const override { return m_keyDTypep; }
     void virtRefDType2p(AstNodeDType* nodep) override { keyDTypep(nodep); }
     //
-    AstNodeDType* keyDTypep() const VL_MT_STABLE_TREE {
+    AstNodeDType* keyDTypep() const VL_MT_STABLE {
         return m_keyDTypep ? m_keyDTypep : keyChildDTypep();
     }
     void keyDTypep(AstNodeDType* nodep) { m_keyDTypep = nodep; }
     // METHODS
-    AstBasicDType* basicp() const override VL_MT_STABLE_TREE { return nullptr; }
-    AstNodeDType* skipRefp() const override VL_MT_STABLE_TREE { return (AstNodeDType*)this; }
+    AstBasicDType* basicp() const override VL_MT_STABLE { return nullptr; }
+    AstNodeDType* skipRefp() const override VL_MT_STABLE { return (AstNodeDType*)this; }
     AstNodeDType* skipRefToConstp() const override { return (AstNodeDType*)this; }
     AstNodeDType* skipRefToEnump() const override { return (AstNodeDType*)this; }
     int widthAlignBytes() const override { return subDTypep()->widthAlignBytes(); }
@@ -424,8 +424,8 @@ public:
         }
     }
     // METHODS
-    AstBasicDType* basicp() const override VL_MT_STABLE_TREE { return (AstBasicDType*)this; }
-    AstNodeDType* skipRefp() const override VL_MT_STABLE_TREE { return (AstNodeDType*)this; }
+    AstBasicDType* basicp() const override VL_MT_STABLE { return (AstBasicDType*)this; }
+    AstNodeDType* skipRefp() const override VL_MT_STABLE { return (AstNodeDType*)this; }
     AstNodeDType* skipRefToConstp() const override { return (AstNodeDType*)this; }
     AstNodeDType* skipRefToEnump() const override { return (AstNodeDType*)this; }
     // (Slow) recurses - Structure alignment 1,2,4 or 8 bytes (arrays affect this)
@@ -492,13 +492,13 @@ public:
     }
     ASTGEN_MEMBERS_AstBracketArrayDType;
     bool similarDType(const AstNodeDType* samep) const override { V3ERROR_NA_RETURN(false); }
-    AstNodeDType* subDTypep() const override VL_MT_STABLE_TREE { return childDTypep(); }
+    AstNodeDType* subDTypep() const override VL_MT_STABLE { return childDTypep(); }
     // METHODS
     // Will be removed in V3Width, which relies on this
     // being a child not a dtype pointed node
     bool maybePointedTo() const override { return false; }
-    AstBasicDType* basicp() const override VL_MT_STABLE_TREE { return nullptr; }
-    AstNodeDType* skipRefp() const override VL_MT_STABLE_TREE { return (AstNodeDType*)this; }
+    AstBasicDType* basicp() const override VL_MT_STABLE { return nullptr; }
+    AstNodeDType* skipRefp() const override VL_MT_STABLE { return (AstNodeDType*)this; }
     AstNodeDType* skipRefToConstp() const override { return (AstNodeDType*)this; }
     AstNodeDType* skipRefToEnump() const override { return (AstNodeDType*)this; }
     int widthAlignBytes() const override { V3ERROR_NA_RETURN(0); }
@@ -532,8 +532,8 @@ public:
     void dump(std::ostream& str = std::cout) const override;
     void dumpSmall(std::ostream& str) const override;
     string name() const override;
-    AstBasicDType* basicp() const override VL_MT_STABLE_TREE { return nullptr; }
-    AstNodeDType* skipRefp() const override VL_MT_STABLE_TREE { return (AstNodeDType*)this; }
+    AstBasicDType* basicp() const override VL_MT_STABLE { return nullptr; }
+    AstNodeDType* skipRefp() const override VL_MT_STABLE { return (AstNodeDType*)this; }
     AstNodeDType* skipRefToConstp() const override { return (AstNodeDType*)this; }
     AstNodeDType* skipRefToEnump() const override { return (AstNodeDType*)this; }
     int widthAlignBytes() const override { return 0; }
@@ -579,15 +579,15 @@ public:
         return skipRefp()->similarDType(samep->skipRefp());
     }
     AstNodeDType* getChildDTypep() const override { return childDTypep(); }
-    AstNodeDType* subDTypep() const override VL_MT_STABLE_TREE {
+    AstNodeDType* subDTypep() const override VL_MT_STABLE {
         return m_refDTypep ? m_refDTypep : childDTypep();
     }
     void refDTypep(AstNodeDType* nodep) { m_refDTypep = nodep; }
     AstNodeDType* virtRefDTypep() const override { return m_refDTypep; }
     void virtRefDTypep(AstNodeDType* nodep) override { refDTypep(nodep); }
     // METHODS
-    AstBasicDType* basicp() const override VL_MT_STABLE_TREE { return subDTypep()->basicp(); }
-    AstNodeDType* skipRefp() const override VL_MT_STABLE_TREE { return subDTypep()->skipRefp(); }
+    AstBasicDType* basicp() const override VL_MT_STABLE { return subDTypep()->basicp(); }
+    AstNodeDType* skipRefp() const override VL_MT_STABLE { return subDTypep()->skipRefp(); }
     AstNodeDType* skipRefToConstp() const override { return (AstNodeDType*)this; }
     AstNodeDType* skipRefToEnump() const override { return subDTypep()->skipRefToEnump(); }
     int widthAlignBytes() const override { return subDTypep()->widthAlignBytes(); }
@@ -628,15 +628,15 @@ public:
         return type() == samep->type() && same(samep);
     }
     AstNodeDType* getChildDTypep() const override { return childDTypep(); }
-    AstNodeDType* subDTypep() const override VL_MT_STABLE_TREE {
+    AstNodeDType* subDTypep() const override VL_MT_STABLE {
         return dtypep() ? dtypep() : childDTypep();
     }
     void* containerp() const { return m_containerp; }
     // METHODS
     // op1 = Range of variable
     AstNodeDType* dtypeSkipRefp() const { return dtypep()->skipRefp(); }
-    AstBasicDType* basicp() const override VL_MT_STABLE_TREE { return subDTypep()->basicp(); }
-    AstNodeDType* skipRefp() const override VL_MT_STABLE_TREE { return (AstNodeDType*)this; }
+    AstBasicDType* basicp() const override VL_MT_STABLE { return subDTypep()->basicp(); }
+    AstNodeDType* skipRefp() const override VL_MT_STABLE { return (AstNodeDType*)this; }
     AstNodeDType* skipRefToConstp() const override { return (AstNodeDType*)this; }
     AstNodeDType* skipRefToEnump() const override { return (AstNodeDType*)this; }
     int widthAlignBytes() const override { return dtypep()->widthAlignBytes(); }
@@ -684,15 +684,15 @@ public:
     string prettyDTypeName() const override;
     void dumpSmall(std::ostream& str) const override;
     AstNodeDType* getChildDTypep() const override { return childDTypep(); }
-    AstNodeDType* subDTypep() const override VL_MT_STABLE_TREE {
+    AstNodeDType* subDTypep() const override VL_MT_STABLE {
         return m_refDTypep ? m_refDTypep : childDTypep();
     }
     void refDTypep(AstNodeDType* nodep) { m_refDTypep = nodep; }
     AstNodeDType* virtRefDTypep() const override { return m_refDTypep; }
     void virtRefDTypep(AstNodeDType* nodep) override { refDTypep(nodep); }
     // METHODS
-    AstBasicDType* basicp() const override VL_MT_STABLE_TREE { return nullptr; }
-    AstNodeDType* skipRefp() const override VL_MT_STABLE_TREE { return (AstNodeDType*)this; }
+    AstBasicDType* basicp() const override VL_MT_STABLE { return nullptr; }
+    AstNodeDType* skipRefp() const override VL_MT_STABLE { return (AstNodeDType*)this; }
     AstNodeDType* skipRefToConstp() const override { return (AstNodeDType*)this; }
     AstNodeDType* skipRefToEnump() const override { return (AstNodeDType*)this; }
     int widthAlignBytes() const override { return subDTypep()->widthAlignBytes(); }
@@ -715,9 +715,9 @@ public:
     AstNodeDType* virtRefDTypep() const override { return nullptr; }
     void virtRefDTypep(AstNodeDType* nodep) override {}
     bool similarDType(const AstNodeDType* samep) const override { return this == samep; }
-    AstBasicDType* basicp() const override VL_MT_STABLE_TREE { return nullptr; }
+    AstBasicDType* basicp() const override VL_MT_STABLE { return nullptr; }
     // cppcheck-suppress csyleCast
-    AstNodeDType* skipRefp() const override VL_MT_STABLE_TREE { return (AstNodeDType*)this; }
+    AstNodeDType* skipRefp() const override VL_MT_STABLE { return (AstNodeDType*)this; }
     // cppcheck-suppress csyleCast
     AstNodeDType* skipRefToConstp() const override { return (AstNodeDType*)this; }
     // cppcheck-suppress csyleCast
@@ -761,7 +761,7 @@ public:
     }
     bool similarDType(const AstNodeDType* samep) const override { return this == samep; }
     AstNodeDType* getChildDTypep() const override { return childDTypep(); }
-    AstNodeDType* subDTypep() const override VL_MT_STABLE_TREE {
+    AstNodeDType* subDTypep() const override VL_MT_STABLE {
         return m_refDTypep ? m_refDTypep : childDTypep();
     }
     void refDTypep(AstNodeDType* nodep) { m_refDTypep = nodep; }
@@ -772,8 +772,8 @@ public:
     void dump(std::ostream& str = std::cout) const override;
     void dumpSmall(std::ostream& str) const override;
     // METHODS
-    AstBasicDType* basicp() const override VL_MT_STABLE_TREE { return subDTypep()->basicp(); }
-    AstNodeDType* skipRefp() const override VL_MT_STABLE_TREE { return subDTypep()->skipRefp(); }
+    AstBasicDType* basicp() const override VL_MT_STABLE { return subDTypep()->basicp(); }
+    AstNodeDType* skipRefp() const override VL_MT_STABLE { return subDTypep()->skipRefp(); }
     AstNodeDType* skipRefToConstp() const override { return subDTypep()->skipRefToConstp(); }
     // cppcheck-suppress csyleCast
     AstNodeDType* skipRefToEnump() const override { return (AstNodeDType*)this; }
@@ -825,8 +825,8 @@ public:
     void dump(std::ostream& str = std::cout) const override;
     void dumpSmall(std::ostream& str) const override;
     void cloneRelink() override;
-    AstBasicDType* basicp() const override VL_MT_STABLE_TREE { return nullptr; }
-    AstNodeDType* skipRefp() const override VL_MT_STABLE_TREE { return (AstNodeDType*)this; }
+    AstBasicDType* basicp() const override VL_MT_STABLE { return nullptr; }
+    AstNodeDType* skipRefp() const override VL_MT_STABLE { return (AstNodeDType*)this; }
     AstNodeDType* skipRefToConstp() const override { return (AstNodeDType*)this; }
     AstNodeDType* skipRefToEnump() const override { return (AstNodeDType*)this; }
     bool similarDType(const AstNodeDType* samep) const override { return this == samep; }
@@ -890,7 +890,7 @@ public:
         if (m_refDTypep && m_refDTypep->clonep()) m_refDTypep = m_refDTypep->clonep();
     }
     AstNodeDType* getChildDTypep() const override { return childDTypep(); }
-    AstNodeDType* subDTypep() const override VL_MT_STABLE_TREE {
+    AstNodeDType* subDTypep() const override VL_MT_STABLE {
         return m_refDTypep ? m_refDTypep : childDTypep();
     }
     void refDTypep(AstNodeDType* nodep) { m_refDTypep = nodep; }
@@ -900,10 +900,10 @@ public:
     //
     // (Slow) recurse down to find basic data type (Note don't need virtual -
     // AstVar isn't a NodeDType)
-    AstBasicDType* basicp() const override VL_MT_STABLE_TREE { return subDTypep()->basicp(); }
+    AstBasicDType* basicp() const override VL_MT_STABLE { return subDTypep()->basicp(); }
     // op1 = Range of variable (Note don't need virtual - AstVar isn't a NodeDType)
     AstNodeDType* dtypeSkipRefp() const { return subDTypep()->skipRefp(); }
-    AstNodeDType* skipRefp() const override VL_MT_STABLE_TREE { return subDTypep()->skipRefp(); }
+    AstNodeDType* skipRefp() const override VL_MT_STABLE { return subDTypep()->skipRefp(); }
     AstNodeDType* skipRefToConstp() const override { return subDTypep()->skipRefToConstp(); }
     AstNodeDType* skipRefToEnump() const override { return subDTypep()->skipRefToEnump(); }
     // (Slow) recurses - Structure alignment 1,2,4 or 8 bytes (arrays affect this)
@@ -940,11 +940,11 @@ public:
     ASTGEN_MEMBERS_AstParamTypeDType;
     void dump(std::ostream& str = std::cout) const override;
     AstNodeDType* getChildDTypep() const override { return childDTypep(); }
-    AstNodeDType* subDTypep() const override VL_MT_STABLE_TREE {
+    AstNodeDType* subDTypep() const override VL_MT_STABLE {
         return dtypep() ? dtypep() : childDTypep();
     }
-    AstBasicDType* basicp() const override VL_MT_STABLE_TREE { return subDTypep()->basicp(); }
-    AstNodeDType* skipRefp() const override VL_MT_STABLE_TREE { return subDTypep()->skipRefp(); }
+    AstBasicDType* basicp() const override VL_MT_STABLE { return subDTypep()->basicp(); }
+    AstNodeDType* skipRefp() const override VL_MT_STABLE { return subDTypep()->skipRefp(); }
     AstNodeDType* skipRefToConstp() const override { return subDTypep()->skipRefToConstp(); }
     AstNodeDType* skipRefToEnump() const override { return subDTypep()->skipRefToEnump(); }
     bool similarDType(const AstNodeDType* samep) const override {
@@ -978,8 +978,8 @@ public:
     AstNodeDType* dtypep() const { return nullptr; }
     // METHODS
     bool similarDType(const AstNodeDType* samep) const override { return this == samep; }
-    AstBasicDType* basicp() const override VL_MT_STABLE_TREE { return nullptr; }
-    AstNodeDType* skipRefp() const override VL_MT_STABLE_TREE { return nullptr; }
+    AstBasicDType* basicp() const override VL_MT_STABLE { return nullptr; }
+    AstNodeDType* skipRefp() const override VL_MT_STABLE { return nullptr; }
     // cppcheck-suppress csyleCast
     AstNodeDType* skipRefToConstp() const override { return (AstNodeDType*)this; }
     // cppcheck-suppress csyleCast
@@ -1033,17 +1033,17 @@ public:
     void dumpSmall(std::ostream& str) const override;
     string prettyDTypeName() const override;
     AstNodeDType* getChildDTypep() const override { return childDTypep(); }
-    AstNodeDType* subDTypep() const override VL_MT_STABLE_TREE {
+    AstNodeDType* subDTypep() const override VL_MT_STABLE {
         return m_refDTypep ? m_refDTypep : childDTypep();
     }
     void refDTypep(AstNodeDType* nodep) { m_refDTypep = nodep; }
-    inline int boundConst() const VL_MT_STABLE_TREE;
+    inline int boundConst() const VL_MT_STABLE;
     AstNodeDType* virtRefDTypep() const override { return m_refDTypep; }
     void virtRefDTypep(AstNodeDType* nodep) override { refDTypep(nodep); }
     // METHODS
-    AstBasicDType* basicp() const override VL_MT_STABLE_TREE { return nullptr; }
+    AstBasicDType* basicp() const override VL_MT_STABLE { return nullptr; }
     // cppcheck-suppress csyleCast
-    AstNodeDType* skipRefp() const override VL_MT_STABLE_TREE { return (AstNodeDType*)this; }
+    AstNodeDType* skipRefp() const override VL_MT_STABLE { return (AstNodeDType*)this; }
     // cppcheck-suppress csyleCast
     AstNodeDType* skipRefToConstp() const override { return (AstNodeDType*)this; }
     // cppcheck-suppress csyleCast
@@ -1097,11 +1097,11 @@ public:
     string prettyDTypeName() const override {
         return subDTypep() ? prettyName(subDTypep()->name()) : prettyName();
     }
-    AstBasicDType* basicp() const override VL_MT_STABLE_TREE {
+    AstBasicDType* basicp() const override VL_MT_STABLE {
         return subDTypep() ? subDTypep()->basicp() : nullptr;
     }
-    AstNodeDType* subDTypep() const override VL_MT_STABLE_TREE;
-    AstNodeDType* skipRefp() const override VL_MT_STABLE_TREE {
+    AstNodeDType* subDTypep() const override VL_MT_STABLE;
+    AstNodeDType* skipRefp() const override VL_MT_STABLE {
         // Skip past both the Ref and the Typedef
         if (subDTypep()) {
             return subDTypep()->skipRefp();
@@ -1174,15 +1174,15 @@ public:
     void dumpSmall(std::ostream& str) const override;
     AstNodeDType* getChildDTypep() const override { return childDTypep(); }
     // op1 = Range of variable
-    AstNodeDType* subDTypep() const override VL_MT_STABLE_TREE {
+    AstNodeDType* subDTypep() const override VL_MT_STABLE {
         return m_refDTypep ? m_refDTypep : childDTypep();
     }
     void refDTypep(AstNodeDType* nodep) { m_refDTypep = nodep; }
     AstNodeDType* virtRefDTypep() const override { return m_refDTypep; }
     void virtRefDTypep(AstNodeDType* nodep) override { refDTypep(nodep); }
     // METHODS
-    AstBasicDType* basicp() const override VL_MT_STABLE_TREE { return subDTypep()->basicp(); }
-    AstNodeDType* skipRefp() const override VL_MT_STABLE_TREE { return (AstNodeDType*)this; }
+    AstBasicDType* basicp() const override VL_MT_STABLE { return subDTypep()->basicp(); }
+    AstNodeDType* skipRefp() const override VL_MT_STABLE { return (AstNodeDType*)this; }
     AstNodeDType* skipRefToConstp() const override { return (AstNodeDType*)this; }
     AstNodeDType* skipRefToEnump() const override { return (AstNodeDType*)this; }
     int widthAlignBytes() const override { return sizeof(std::map<std::string, std::string>); }
@@ -1214,15 +1214,15 @@ public:
     bool similarDType(const AstNodeDType* samep) const override;
     void dumpSmall(std::ostream& str) const override;
     AstNodeDType* getChildDTypep() const override { return childDTypep(); }
-    AstNodeDType* subDTypep() const override VL_MT_STABLE_TREE {
+    AstNodeDType* subDTypep() const override VL_MT_STABLE {
         return m_refDTypep ? m_refDTypep : childDTypep();
     }
     void refDTypep(AstNodeDType* nodep) { m_refDTypep = nodep; }
     AstNodeDType* virtRefDTypep() const override { return m_refDTypep; }
     void virtRefDTypep(AstNodeDType* nodep) override { refDTypep(nodep); }
     // METHODS
-    AstBasicDType* basicp() const override VL_MT_STABLE_TREE { return subDTypep()->basicp(); }
-    AstNodeDType* skipRefp() const override VL_MT_STABLE_TREE { return (AstNodeDType*)this; }
+    AstBasicDType* basicp() const override VL_MT_STABLE { return subDTypep()->basicp(); }
+    AstNodeDType* skipRefp() const override VL_MT_STABLE { return (AstNodeDType*)this; }
     AstNodeDType* skipRefToConstp() const override { return (AstNodeDType*)this; }
     AstNodeDType* skipRefToEnump() const override { return (AstNodeDType*)this; }
     int widthAlignBytes() const override { return subDTypep()->widthAlignBytes(); }
@@ -1245,9 +1245,9 @@ public:
     AstNodeDType* virtRefDTypep() const override { return nullptr; }
     void virtRefDTypep(AstNodeDType* nodep) override {}
     bool similarDType(const AstNodeDType* samep) const override { return this == samep; }
-    AstBasicDType* basicp() const override VL_MT_STABLE_TREE { return nullptr; }
+    AstBasicDType* basicp() const override VL_MT_STABLE { return nullptr; }
     // cppcheck-suppress csyleCast
-    AstNodeDType* skipRefp() const override VL_MT_STABLE_TREE { return (AstNodeDType*)this; }
+    AstNodeDType* skipRefp() const override VL_MT_STABLE { return (AstNodeDType*)this; }
     // cppcheck-suppress csyleCast
     AstNodeDType* skipRefToConstp() const override { return (AstNodeDType*)this; }
     // cppcheck-suppress csyleCast
@@ -1281,15 +1281,15 @@ public:
     bool similarDType(const AstNodeDType* samep) const override;
     void dumpSmall(std::ostream& str) const override;
     AstNodeDType* getChildDTypep() const override { return childDTypep(); }
-    AstNodeDType* subDTypep() const override VL_MT_STABLE_TREE {
+    AstNodeDType* subDTypep() const override VL_MT_STABLE {
         return m_refDTypep ? m_refDTypep : childDTypep();
     }
     void refDTypep(AstNodeDType* nodep) { m_refDTypep = nodep; }
     AstNodeDType* virtRefDTypep() const override { return m_refDTypep; }
     void virtRefDTypep(AstNodeDType* nodep) override { refDTypep(nodep); }
     // METHODS
-    AstBasicDType* basicp() const override VL_MT_STABLE_TREE { return subDTypep()->basicp(); }
-    AstNodeDType* skipRefp() const override VL_MT_STABLE_TREE { return (AstNodeDType*)this; }
+    AstBasicDType* basicp() const override VL_MT_STABLE { return subDTypep()->basicp(); }
+    AstNodeDType* skipRefp() const override VL_MT_STABLE { return (AstNodeDType*)this; }
     AstNodeDType* skipRefToConstp() const override { return (AstNodeDType*)this; }
     AstNodeDType* skipRefToEnump() const override { return (AstNodeDType*)this; }
     int widthAlignBytes() const override { return sizeof(std::map<std::string, std::string>); }

--- a/src/V3AstNodeExpr.h
+++ b/src/V3AstNodeExpr.h
@@ -994,7 +994,7 @@ public:
     const V3Number& num() const VL_MT_SAFE { return m_num; }  // * = Value
     V3Number& num() { return m_num; }  // * = Value
     uint32_t toUInt() const { return num().toUInt(); }
-    int32_t toSInt() const { return num().toSInt(); }
+    int32_t toSInt() const VL_MT_SAFE { return num().toSInt(); }
     uint64_t toUQuad() const { return num().toUQuad(); }
     string emitVerilog() override { V3ERROR_NA_RETURN(""); }
     string emitC() override { V3ERROR_NA_RETURN(""); }

--- a/src/V3AstNodeExpr.h
+++ b/src/V3AstNodeExpr.h
@@ -644,9 +644,7 @@ public:
     string emitC() override { V3ERROR_NA_RETURN(""); }
     bool cleanOut() const override { V3ERROR_NA_RETURN(true); }
     AstNodeDType* getChildDTypep() const override { return childDTypep(); }
-    AstNodeDType* subDTypep() const VL_MT_STABLE_TREE {
-        return dtypep() ? dtypep() : childDTypep();
-    }
+    AstNodeDType* subDTypep() const VL_MT_STABLE { return dtypep() ? dtypep() : childDTypep(); }
 };
 class AstCastParse final : public AstNodeExpr {
     // Cast to appropriate type, where we haven't determined yet what the data type is
@@ -1576,9 +1574,7 @@ public:
     bool cleanOut() const override { V3ERROR_NA_RETURN(""); }
     int instrCount() const override { return widthInstrs(); }
     AstNodeDType* getChildDTypep() const override { return childDTypep(); }
-    AstNodeDType* subDTypep() const VL_MT_STABLE_TREE {
-        return dtypep() ? dtypep() : childDTypep();
-    }
+    AstNodeDType* subDTypep() const VL_MT_STABLE { return dtypep() ? dtypep() : childDTypep(); }
 };
 class AstRand final : public AstNodeExpr {
     // $random/$random(seed) or $urandom/$urandom(seed)
@@ -1976,9 +1972,7 @@ public:
     bool same(const AstNode* /*samep*/) const override { return true; }
     bool cleanOut() const override { return true; }
     AstNodeDType* getChildDTypep() const override { return childDTypep(); }
-    AstNodeDType* subDTypep() const VL_MT_STABLE_TREE {
-        return dtypep() ? dtypep() : childDTypep();
-    }
+    AstNodeDType* subDTypep() const VL_MT_STABLE { return dtypep() ? dtypep() : childDTypep(); }
 };
 class AstTimePrecision final : public AstNodeExpr {
     // Verilog $timeprecision

--- a/src/V3AstNodeExpr.h
+++ b/src/V3AstNodeExpr.h
@@ -994,7 +994,7 @@ public:
     const V3Number& num() const VL_MT_SAFE { return m_num; }  // * = Value
     V3Number& num() { return m_num; }  // * = Value
     uint32_t toUInt() const { return num().toUInt(); }
-    int32_t toSInt() const VL_MT_SAFE { return num().toSInt(); }
+    int32_t toSInt() const { return num().toSInt(); }
     uint64_t toUQuad() const { return num().toUQuad(); }
     string emitVerilog() override { V3ERROR_NA_RETURN(""); }
     string emitC() override { V3ERROR_NA_RETURN(""); }

--- a/src/V3AstNodeExpr.h
+++ b/src/V3AstNodeExpr.h
@@ -644,7 +644,9 @@ public:
     string emitC() override { V3ERROR_NA_RETURN(""); }
     bool cleanOut() const override { V3ERROR_NA_RETURN(true); }
     AstNodeDType* getChildDTypep() const override { return childDTypep(); }
-    AstNodeDType* subDTypep() const { return dtypep() ? dtypep() : childDTypep(); }
+    AstNodeDType* subDTypep() const VL_MT_STABLE_TREE {
+        return dtypep() ? dtypep() : childDTypep();
+    }
 };
 class AstCastParse final : public AstNodeExpr {
     // Cast to appropriate type, where we haven't determined yet what the data type is
@@ -1574,7 +1576,9 @@ public:
     bool cleanOut() const override { V3ERROR_NA_RETURN(""); }
     int instrCount() const override { return widthInstrs(); }
     AstNodeDType* getChildDTypep() const override { return childDTypep(); }
-    AstNodeDType* subDTypep() const { return dtypep() ? dtypep() : childDTypep(); }
+    AstNodeDType* subDTypep() const VL_MT_STABLE_TREE {
+        return dtypep() ? dtypep() : childDTypep();
+    }
 };
 class AstRand final : public AstNodeExpr {
     // $random/$random(seed) or $urandom/$urandom(seed)
@@ -1972,7 +1976,9 @@ public:
     bool same(const AstNode* /*samep*/) const override { return true; }
     bool cleanOut() const override { return true; }
     AstNodeDType* getChildDTypep() const override { return childDTypep(); }
-    AstNodeDType* subDTypep() const { return dtypep() ? dtypep() : childDTypep(); }
+    AstNodeDType* subDTypep() const VL_MT_STABLE_TREE {
+        return dtypep() ? dtypep() : childDTypep();
+    }
 };
 class AstTimePrecision final : public AstNodeExpr {
     // Verilog $timeprecision

--- a/src/V3AstNodeOther.h
+++ b/src/V3AstNodeOther.h
@@ -1544,7 +1544,9 @@ public:
     ASTGEN_MEMBERS_AstTypedef;
     void dump(std::ostream& str) const override;
     AstNodeDType* getChildDTypep() const override { return childDTypep(); }
-    virtual AstNodeDType* subDTypep() const { return dtypep() ? dtypep() : childDTypep(); }
+    virtual AstNodeDType* subDTypep() const VL_MT_SAFE {
+        return dtypep() ? dtypep() : childDTypep();
+    }
     // METHODS
     string name() const override { return m_name; }
     bool maybePointedTo() const override { return true; }
@@ -1793,10 +1795,10 @@ public:
     string vlPropDecl(const string& propName) const;  // Return VerilatorVarProps declaration
     void combineType(VVarType type);
     AstNodeDType* getChildDTypep() const override { return childDTypep(); }
-    AstNodeDType* dtypeSkipRefp() const { return subDTypep()->skipRefp(); }
+    AstNodeDType* dtypeSkipRefp() const VL_MT_SAFE { return subDTypep()->skipRefp(); }
     // (Slow) recurse down to find basic data type (Note don't need virtual -
     // AstVar isn't a NodeDType)
-    AstBasicDType* basicp() const { return subDTypep()->basicp(); }
+    AstBasicDType* basicp() const VL_MT_SAFE { return subDTypep()->basicp(); }
     virtual AstNodeDType* subDTypep() const VL_MT_SAFE {
         return dtypep() ? dtypep() : childDTypep();
     }
@@ -2334,19 +2336,19 @@ public:
     inline AstRange(FileLine* fl, int left, int right);
     inline AstRange(FileLine* fl, const VNumRange& range);
     ASTGEN_MEMBERS_AstRange;
-    inline int leftConst() const;
-    inline int rightConst() const;
-    int hiConst() const {
+    inline int leftConst() const VL_MT_SAFE;
+    inline int rightConst() const VL_MT_SAFE;
+    int hiConst() const VL_MT_SAFE {
         const int l = leftConst();
         const int r = rightConst();
         return l > r ? l : r;
     }
-    int loConst() const {
+    int loConst() const VL_MT_SAFE {
         const int l = leftConst();
         const int r = rightConst();
         return l > r ? r : l;
     }
-    int elementsConst() const { return hiConst() - loConst() + 1; }
+    int elementsConst() const VL_MT_SAFE { return hiConst() - loConst() + 1; }
     bool littleEndian() const { return leftConst() < rightConst(); }
     void dump(std::ostream& str) const override;
     virtual string emitC() { V3ERROR_NA_RETURN(""); }

--- a/src/V3AstNodeOther.h
+++ b/src/V3AstNodeOther.h
@@ -1793,10 +1793,10 @@ public:
     string vlPropDecl(const string& propName) const;  // Return VerilatorVarProps declaration
     void combineType(VVarType type);
     AstNodeDType* getChildDTypep() const override { return childDTypep(); }
-    AstNodeDType* dtypeSkipRefp() const VL_MT_SAFE { return subDTypep()->skipRefp(); }
+    AstNodeDType* dtypeSkipRefp() const { return subDTypep()->skipRefp(); }
     // (Slow) recurse down to find basic data type (Note don't need virtual -
     // AstVar isn't a NodeDType)
-    AstBasicDType* basicp() const VL_MT_SAFE { return subDTypep()->basicp(); }
+    AstBasicDType* basicp() const { return subDTypep()->basicp(); }
     virtual AstNodeDType* subDTypep() const VL_MT_SAFE {
         return dtypep() ? dtypep() : childDTypep();
     }
@@ -2334,19 +2334,19 @@ public:
     inline AstRange(FileLine* fl, int left, int right);
     inline AstRange(FileLine* fl, const VNumRange& range);
     ASTGEN_MEMBERS_AstRange;
-    inline int leftConst() const VL_MT_SAFE;
-    inline int rightConst() const VL_MT_SAFE;
-    int hiConst() const VL_MT_SAFE {
+    inline int leftConst() const;
+    inline int rightConst() const;
+    int hiConst() const {
         const int l = leftConst();
         const int r = rightConst();
         return l > r ? l : r;
     }
-    int loConst() const VL_MT_SAFE {
+    int loConst() const {
         const int l = leftConst();
         const int r = rightConst();
         return l > r ? r : l;
     }
-    int elementsConst() const VL_MT_SAFE { return hiConst() - loConst() + 1; }
+    int elementsConst() const { return hiConst() - loConst() + 1; }
     bool littleEndian() const { return leftConst() < rightConst(); }
     void dump(std::ostream& str) const override;
     virtual string emitC() { V3ERROR_NA_RETURN(""); }

--- a/src/V3AstNodeOther.h
+++ b/src/V3AstNodeOther.h
@@ -1544,7 +1544,7 @@ public:
     ASTGEN_MEMBERS_AstTypedef;
     void dump(std::ostream& str) const override;
     AstNodeDType* getChildDTypep() const override { return childDTypep(); }
-    virtual AstNodeDType* subDTypep() const VL_MT_STABLE_TREE {
+    virtual AstNodeDType* subDTypep() const VL_MT_STABLE {
         return dtypep() ? dtypep() : childDTypep();
     }
     // METHODS
@@ -1795,11 +1795,11 @@ public:
     string vlPropDecl(const string& propName) const;  // Return VerilatorVarProps declaration
     void combineType(VVarType type);
     AstNodeDType* getChildDTypep() const override { return childDTypep(); }
-    AstNodeDType* dtypeSkipRefp() const VL_MT_STABLE_TREE { return subDTypep()->skipRefp(); }
+    AstNodeDType* dtypeSkipRefp() const VL_MT_STABLE { return subDTypep()->skipRefp(); }
     // (Slow) recurse down to find basic data type (Note don't need virtual -
     // AstVar isn't a NodeDType)
-    AstBasicDType* basicp() const VL_MT_STABLE_TREE { return subDTypep()->basicp(); }
-    virtual AstNodeDType* subDTypep() const VL_MT_STABLE_TREE {
+    AstBasicDType* basicp() const VL_MT_STABLE { return subDTypep()->basicp(); }
+    virtual AstNodeDType* subDTypep() const VL_MT_STABLE {
         return dtypep() ? dtypep() : childDTypep();
     }
     void ansi(bool flag) { m_ansi = flag; }
@@ -2336,19 +2336,19 @@ public:
     inline AstRange(FileLine* fl, int left, int right);
     inline AstRange(FileLine* fl, const VNumRange& range);
     ASTGEN_MEMBERS_AstRange;
-    inline int leftConst() const VL_MT_STABLE_TREE;
-    inline int rightConst() const VL_MT_STABLE_TREE;
-    int hiConst() const VL_MT_STABLE_TREE {
+    inline int leftConst() const VL_MT_STABLE;
+    inline int rightConst() const VL_MT_STABLE;
+    int hiConst() const VL_MT_STABLE {
         const int l = leftConst();
         const int r = rightConst();
         return l > r ? l : r;
     }
-    int loConst() const VL_MT_STABLE_TREE {
+    int loConst() const VL_MT_STABLE {
         const int l = leftConst();
         const int r = rightConst();
         return l > r ? r : l;
     }
-    int elementsConst() const VL_MT_STABLE_TREE { return hiConst() - loConst() + 1; }
+    int elementsConst() const VL_MT_STABLE { return hiConst() - loConst() + 1; }
     bool littleEndian() const { return leftConst() < rightConst(); }
     void dump(std::ostream& str) const override;
     virtual string emitC() { V3ERROR_NA_RETURN(""); }

--- a/src/V3AstNodeOther.h
+++ b/src/V3AstNodeOther.h
@@ -1544,7 +1544,7 @@ public:
     ASTGEN_MEMBERS_AstTypedef;
     void dump(std::ostream& str) const override;
     AstNodeDType* getChildDTypep() const override { return childDTypep(); }
-    virtual AstNodeDType* subDTypep() const VL_MT_SAFE {
+    virtual AstNodeDType* subDTypep() const VL_MT_STABLE_TREE {
         return dtypep() ? dtypep() : childDTypep();
     }
     // METHODS
@@ -1795,11 +1795,11 @@ public:
     string vlPropDecl(const string& propName) const;  // Return VerilatorVarProps declaration
     void combineType(VVarType type);
     AstNodeDType* getChildDTypep() const override { return childDTypep(); }
-    AstNodeDType* dtypeSkipRefp() const VL_MT_SAFE { return subDTypep()->skipRefp(); }
+    AstNodeDType* dtypeSkipRefp() const VL_MT_STABLE_TREE { return subDTypep()->skipRefp(); }
     // (Slow) recurse down to find basic data type (Note don't need virtual -
     // AstVar isn't a NodeDType)
-    AstBasicDType* basicp() const VL_MT_SAFE { return subDTypep()->basicp(); }
-    virtual AstNodeDType* subDTypep() const VL_MT_SAFE {
+    AstBasicDType* basicp() const VL_MT_STABLE_TREE { return subDTypep()->basicp(); }
+    virtual AstNodeDType* subDTypep() const VL_MT_STABLE_TREE {
         return dtypep() ? dtypep() : childDTypep();
     }
     void ansi(bool flag) { m_ansi = flag; }
@@ -2336,19 +2336,19 @@ public:
     inline AstRange(FileLine* fl, int left, int right);
     inline AstRange(FileLine* fl, const VNumRange& range);
     ASTGEN_MEMBERS_AstRange;
-    inline int leftConst() const VL_MT_SAFE;
-    inline int rightConst() const VL_MT_SAFE;
-    int hiConst() const VL_MT_SAFE {
+    inline int leftConst() const VL_MT_STABLE_TREE;
+    inline int rightConst() const VL_MT_STABLE_TREE;
+    int hiConst() const VL_MT_STABLE_TREE {
         const int l = leftConst();
         const int r = rightConst();
         return l > r ? l : r;
     }
-    int loConst() const VL_MT_SAFE {
+    int loConst() const VL_MT_STABLE_TREE {
         const int l = leftConst();
         const int r = rightConst();
         return l > r ? r : l;
     }
-    int elementsConst() const VL_MT_SAFE { return hiConst() - loConst() + 1; }
+    int elementsConst() const VL_MT_STABLE_TREE { return hiConst() - loConst() + 1; }
     bool littleEndian() const { return leftConst() < rightConst(); }
     void dump(std::ostream& str) const override;
     virtual string emitC() { V3ERROR_NA_RETURN(""); }

--- a/src/V3AstNodes.cpp
+++ b/src/V3AstNodes.cpp
@@ -704,13 +704,12 @@ public:
     }
 };
 
-string AstNodeDType::cType(const string& name, bool /*forFunc*/,
-                           bool isRef) const VL_MT_STABLE_TREE {
+string AstNodeDType::cType(const string& name, bool /*forFunc*/, bool isRef) const VL_MT_STABLE {
     const CTypeRecursed info = cTypeRecurse(false);
     return info.render(name, isRef);
 }
 
-AstNodeDType::CTypeRecursed AstNodeDType::cTypeRecurse(bool compound) const VL_MT_STABLE_TREE {
+AstNodeDType::CTypeRecursed AstNodeDType::cTypeRecurse(bool compound) const VL_MT_STABLE {
     // Legacy compound argument currently just passed through and unused
     CTypeRecursed info;
 
@@ -847,7 +846,7 @@ int AstNodeDType::widthPow2() const {
     return 1;
 }
 
-bool AstNodeDType::isLiteralType() const VL_MT_STABLE_TREE {
+bool AstNodeDType::isLiteralType() const VL_MT_STABLE {
     if (const auto* const dtypep = VN_CAST(skipRefp(), BasicDType)) {
         return dtypep->keyword().isLiteralType();
     } else if (const auto* const dtypep = VN_CAST(skipRefp(), UnpackArrayDType)) {
@@ -1805,7 +1804,7 @@ void AstRefDType::cloneRelink() {
         m_classOrPackagep = m_classOrPackagep->clonep();
     }
 }
-AstNodeDType* AstRefDType::subDTypep() const VL_MT_STABLE_TREE {
+AstNodeDType* AstRefDType::subDTypep() const VL_MT_STABLE {
     if (typedefp()) return typedefp()->subDTypep();
     return refDTypep();  // Maybe nullptr
 }

--- a/src/V3AstNodes.cpp
+++ b/src/V3AstNodes.cpp
@@ -704,12 +704,12 @@ public:
     }
 };
 
-string AstNodeDType::cType(const string& name, bool /*forFunc*/, bool isRef) const {
+string AstNodeDType::cType(const string& name, bool /*forFunc*/, bool isRef) const VL_MT_SAFE {
     const CTypeRecursed info = cTypeRecurse(false);
     return info.render(name, isRef);
 }
 
-AstNodeDType::CTypeRecursed AstNodeDType::cTypeRecurse(bool compound) const {
+AstNodeDType::CTypeRecursed AstNodeDType::cTypeRecurse(bool compound) const VL_MT_SAFE {
     // Legacy compound argument currently just passed through and unused
     CTypeRecursed info;
 
@@ -1804,7 +1804,7 @@ void AstRefDType::cloneRelink() {
         m_classOrPackagep = m_classOrPackagep->clonep();
     }
 }
-AstNodeDType* AstRefDType::subDTypep() const {
+AstNodeDType* AstRefDType::subDTypep() const VL_MT_SAFE {
     if (typedefp()) return typedefp()->subDTypep();
     return refDTypep();  // Maybe nullptr
 }

--- a/src/V3AstNodes.cpp
+++ b/src/V3AstNodes.cpp
@@ -704,7 +704,7 @@ public:
     }
 };
 
-string AstNodeDType::cType(const string& name, bool /*forFunc*/, bool isRef) const VL_MT_SAFE {
+string AstNodeDType::cType(const string& name, bool /*forFunc*/, bool isRef) const {
     const CTypeRecursed info = cTypeRecurse(false);
     return info.render(name, isRef);
 }
@@ -846,7 +846,7 @@ int AstNodeDType::widthPow2() const {
     return 1;
 }
 
-bool AstNodeDType::isLiteralType() const VL_MT_SAFE {
+bool AstNodeDType::isLiteralType() const {
     if (const auto* const dtypep = VN_CAST(skipRefp(), BasicDType)) {
         return dtypep->keyword().isLiteralType();
     } else if (const auto* const dtypep = VN_CAST(skipRefp(), UnpackArrayDType)) {

--- a/src/V3AstNodes.cpp
+++ b/src/V3AstNodes.cpp
@@ -704,12 +704,13 @@ public:
     }
 };
 
-string AstNodeDType::cType(const string& name, bool /*forFunc*/, bool isRef) const VL_MT_SAFE {
+string AstNodeDType::cType(const string& name, bool /*forFunc*/,
+                           bool isRef) const VL_MT_STABLE_TREE {
     const CTypeRecursed info = cTypeRecurse(false);
     return info.render(name, isRef);
 }
 
-AstNodeDType::CTypeRecursed AstNodeDType::cTypeRecurse(bool compound) const VL_MT_SAFE {
+AstNodeDType::CTypeRecursed AstNodeDType::cTypeRecurse(bool compound) const VL_MT_STABLE_TREE {
     // Legacy compound argument currently just passed through and unused
     CTypeRecursed info;
 
@@ -846,7 +847,7 @@ int AstNodeDType::widthPow2() const {
     return 1;
 }
 
-bool AstNodeDType::isLiteralType() const {
+bool AstNodeDType::isLiteralType() const VL_MT_STABLE_TREE {
     if (const auto* const dtypep = VN_CAST(skipRefp(), BasicDType)) {
         return dtypep->keyword().isLiteralType();
     } else if (const auto* const dtypep = VN_CAST(skipRefp(), UnpackArrayDType)) {
@@ -1804,7 +1805,7 @@ void AstRefDType::cloneRelink() {
         m_classOrPackagep = m_classOrPackagep->clonep();
     }
 }
-AstNodeDType* AstRefDType::subDTypep() const VL_MT_SAFE {
+AstNodeDType* AstRefDType::subDTypep() const VL_MT_STABLE_TREE {
     if (typedefp()) return typedefp()->subDTypep();
     return refDTypep();  // Maybe nullptr
 }

--- a/src/V3EmitCBase.h
+++ b/src/V3EmitCBase.h
@@ -40,7 +40,7 @@ public:
     EmitCParentModule();
     VL_UNCOPYABLE(EmitCParentModule);
 
-    static const AstNodeModule* get(const AstNode* nodep) VL_MT_SAFE {
+    static const AstNodeModule* get(const AstNode* nodep) VL_MT_STABLE_TREE {
         return VN_AS(nodep->user4p(), NodeModule);
     }
 };
@@ -78,15 +78,13 @@ public:
         return className + "* const __restrict vlSelf VL_ATTR_UNUSED = static_cast<" + className
                + "*>(voidSelf);\n";
     }
-    static string symClassName() VL_MT_SAFE {
-        return v3Global.opt.prefix() + "_" + protect("_Syms");
-    }
+    static string symClassName() { return v3Global.opt.prefix() + "_" + protect("_Syms"); }
     static string symClassVar() { return symClassName() + "* __restrict vlSymsp"; }
     static string symClassAssign() {
         return symClassName() + "* const __restrict vlSymsp VL_ATTR_UNUSED = vlSelf->vlSymsp;\n";
     }
     static string funcNameProtect(const AstCFunc* nodep, const AstNodeModule* modp = nullptr);
-    static string prefixNameProtect(const AstNode* nodep) VL_MT_SAFE {  // C++ name with prefix
+    static string prefixNameProtect(const AstNode* nodep) {  // C++ name with prefix
         return v3Global.opt.modPrefix() + "_" + protect(nodep->name());
     }
     static string topClassName() VL_MT_SAFE {  // Return name of top wrapper module

--- a/src/V3EmitCBase.h
+++ b/src/V3EmitCBase.h
@@ -40,7 +40,7 @@ public:
     EmitCParentModule();
     VL_UNCOPYABLE(EmitCParentModule);
 
-    static const AstNodeModule* get(const AstNode* nodep) {
+    static const AstNodeModule* get(const AstNode* nodep) VL_MT_SAFE {
         return VN_AS(nodep->user4p(), NodeModule);
     }
 };
@@ -70,22 +70,26 @@ public:
     static string protectWordsIf(const string& name, bool doIt) {
         return VIdProtect::protectWordsIf(name, doIt);
     }
-    static string ifNoProtect(const string& in) { return v3Global.opt.protectIds() ? "" : in; }
+    static string ifNoProtect(const string& in) VL_MT_SAFE {
+        return v3Global.opt.protectIds() ? "" : in;
+    }
     static string voidSelfAssign(const AstNodeModule* modp) {
         const string className = prefixNameProtect(modp);
         return className + "* const __restrict vlSelf VL_ATTR_UNUSED = static_cast<" + className
                + "*>(voidSelf);\n";
     }
-    static string symClassName() { return v3Global.opt.prefix() + "_" + protect("_Syms"); }
+    static string symClassName() VL_MT_SAFE {
+        return v3Global.opt.prefix() + "_" + protect("_Syms");
+    }
     static string symClassVar() { return symClassName() + "* __restrict vlSymsp"; }
     static string symClassAssign() {
         return symClassName() + "* const __restrict vlSymsp VL_ATTR_UNUSED = vlSelf->vlSymsp;\n";
     }
     static string funcNameProtect(const AstCFunc* nodep, const AstNodeModule* modp = nullptr);
-    static string prefixNameProtect(const AstNode* nodep) {  // C++ name with prefix
+    static string prefixNameProtect(const AstNode* nodep) VL_MT_SAFE {  // C++ name with prefix
         return v3Global.opt.modPrefix() + "_" + protect(nodep->name());
     }
-    static string topClassName() {  // Return name of top wrapper module
+    static string topClassName() VL_MT_SAFE {  // Return name of top wrapper module
         return v3Global.opt.prefix();
     }
 

--- a/src/V3EmitCBase.h
+++ b/src/V3EmitCBase.h
@@ -40,7 +40,7 @@ public:
     EmitCParentModule();
     VL_UNCOPYABLE(EmitCParentModule);
 
-    static const AstNodeModule* get(const AstNode* nodep) VL_MT_STABLE_TREE {
+    static const AstNodeModule* get(const AstNode* nodep) VL_MT_STABLE {
         return VN_AS(nodep->user4p(), NodeModule);
     }
 };

--- a/src/V3Error.h
+++ b/src/V3Error.h
@@ -648,7 +648,7 @@ inline void v3errorEndFatal(std::ostringstream& sstr)
 // Helper macros for VL_DEFINE_DEBUG_FUNCTIONS
 // Takes an optional "name" (as __VA_ARGS__)
 #define VL_DEFINE_DEBUG(...) \
-    VL_ATTR_UNUSED static int debug##__VA_ARGS__() { \
+    VL_ATTR_UNUSED static int debug##__VA_ARGS__() VL_MT_SAFE { \
         static int level = -1; \
         if (VL_UNLIKELY(level < 0)) { \
             std::string tag{VL_STRINGIFY(__VA_ARGS__)}; \

--- a/src/V3File.cpp
+++ b/src/V3File.cpp
@@ -853,7 +853,8 @@ void V3OutFormatter::putcNoTracking(char chr) {
     putcOutput(chr);
 }
 
-string V3OutFormatter::quoteNameControls(const string& namein, V3OutFormatter::Language lang) {
+string V3OutFormatter::quoteNameControls(const string& namein,
+                                         V3OutFormatter::Language lang) VL_PURE {
     // Encode control chars into output-appropriate escapes
     // Reverse is V3Parse::deQuote
     string out;

--- a/src/V3File.h
+++ b/src/V3File.h
@@ -35,11 +35,11 @@
 
 class V3File final {
 public:
-    static std::ifstream* new_ifstream(const string& filename) {
+    static std::ifstream* new_ifstream(const string& filename) VL_MT_SAFE {
         addSrcDepend(filename);
         return new_ifstream_nodepend(filename);
     }
-    static std::ifstream* new_ifstream_nodepend(const string& filename) {
+    static std::ifstream* new_ifstream_nodepend(const string& filename) VL_MT_SAFE {
         return new std::ifstream{filename.c_str()};
     }
     static std::ofstream* new_ofstream(const string& filename, bool append = false) {
@@ -61,8 +61,8 @@ public:
     }
 
     // Dependencies
-    static void addSrcDepend(const string& filename);
-    static void addTgtDepend(const string& filename);
+    static void addSrcDepend(const string& filename) VL_MT_SAFE;
+    static void addTgtDepend(const string& filename) VL_MT_SAFE;
     static void writeDepend(const string& filename);
     static std::vector<string> getAllDeps();
     static void writeTimes(const string& filename, const string& cmdlineIn);
@@ -171,7 +171,7 @@ public:
     // STATIC METHODS
     static string indentSpaces(int num);
     // Add escaped characters to strings
-    static string quoteNameControls(const string& namein, Language lang = LA_C);
+    static string quoteNameControls(const string& namein, Language lang = LA_C) VL_PURE;
     static bool tokenMatch(const char* cp, const char* cmp);
     static bool tokenNotStart(const char* cp);  // Import/export meaning no endfunction
     static bool tokenStart(const char* cp);

--- a/src/V3File.h
+++ b/src/V3File.h
@@ -35,7 +35,7 @@
 
 class V3File final {
 public:
-    static std::ifstream* new_ifstream(const string& filename) VL_MT_SAFE {
+    static std::ifstream* new_ifstream(const string& filename) {
         addSrcDepend(filename);
         return new_ifstream_nodepend(filename);
     }
@@ -61,8 +61,8 @@ public:
     }
 
     // Dependencies
-    static void addSrcDepend(const string& filename) VL_MT_SAFE;
-    static void addTgtDepend(const string& filename) VL_MT_SAFE;
+    static void addSrcDepend(const string& filename);
+    static void addTgtDepend(const string& filename);
     static void writeDepend(const string& filename);
     static std::vector<string> getAllDeps();
     static void writeTimes(const string& filename, const string& cmdlineIn);

--- a/src/V3FileLine.cpp
+++ b/src/V3FileLine.cpp
@@ -39,7 +39,7 @@ VL_DEFINE_DEBUG_FUNCTIONS;
 //######################################################################
 // FileLineSingleton class functions
 
-string FileLineSingleton::filenameLetters(fileNameIdx_t fileno) {
+string FileLineSingleton::filenameLetters(fileNameIdx_t fileno) VL_PURE {
     constexpr int size
         = 1 + (64 / 4);  // Each letter retires more than 4 bits of a > 64 bit number
     char out[size];
@@ -155,7 +155,7 @@ void VFileContent::pushText(const string& text) {
     m_lines.emplace_back(string(leftover, line_start));  // Might be ""
 }
 
-string VFileContent::getLine(int lineno) const {
+string VFileContent::getLine(int lineno) const VL_MT_SAFE {
     // Return error text rather than asserting so the user isn't left without a message
     // cppcheck-suppress negativeContainerIndex
     if (VL_UNCOVERABLE(lineno < 0 || lineno >= (int)m_lines.size())) {
@@ -284,7 +284,7 @@ FileLine* FileLine::copyOrSameFileLine() {
     return newp;
 }
 
-string FileLine::filebasename() const {
+string FileLine::filebasename() const VL_MT_SAFE {
     string name = filename();
     string::size_type pos;
     if ((pos = name.rfind('/')) != string::npos) name.erase(0, pos + 1);
@@ -420,7 +420,7 @@ string FileLine::warnOtherStandalone() const VL_EXCLUDES(V3Error::s().m_mutex) V
     return warnOther();
 }
 
-string FileLine::source() const {
+string FileLine::source() const VL_MT_SAFE {
     if (VL_UNCOVERABLE(!m_contentp)) {  // LCOV_EXCL_START
         if (debug() || v3Global.opt.debugCheck()) {
             // The newline here is to work around the " <line#> | "
@@ -431,7 +431,7 @@ string FileLine::source() const {
     }  // LCOV_EXCL_STOP
     return m_contentp->getLine(m_contentLineno);
 }
-string FileLine::prettySource() const {
+string FileLine::prettySource() const VL_MT_SAFE {
     string out = source();
     // Drop ignore trailing newline
     const string::size_type pos = out.find('\n');

--- a/src/V3FileLine.cpp
+++ b/src/V3FileLine.cpp
@@ -155,7 +155,7 @@ void VFileContent::pushText(const string& text) {
     m_lines.emplace_back(string(leftover, line_start));  // Might be ""
 }
 
-string VFileContent::getLine(int lineno) const VL_MT_SAFE {
+string VFileContent::getLine(int lineno) const {
     // Return error text rather than asserting so the user isn't left without a message
     // cppcheck-suppress negativeContainerIndex
     if (VL_UNCOVERABLE(lineno < 0 || lineno >= (int)m_lines.size())) {
@@ -284,7 +284,7 @@ FileLine* FileLine::copyOrSameFileLine() {
     return newp;
 }
 
-string FileLine::filebasename() const VL_MT_SAFE {
+string FileLine::filebasename() const {
     string name = filename();
     string::size_type pos;
     if ((pos = name.rfind('/')) != string::npos) name.erase(0, pos + 1);
@@ -420,7 +420,7 @@ string FileLine::warnOtherStandalone() const VL_EXCLUDES(V3Error::s().m_mutex) V
     return warnOther();
 }
 
-string FileLine::source() const VL_MT_SAFE {
+string FileLine::source() const {
     if (VL_UNCOVERABLE(!m_contentp)) {  // LCOV_EXCL_START
         if (debug() || v3Global.opt.debugCheck()) {
             // The newline here is to work around the " <line#> | "
@@ -431,7 +431,7 @@ string FileLine::source() const VL_MT_SAFE {
     }  // LCOV_EXCL_STOP
     return m_contentp->getLine(m_contentLineno);
 }
-string FileLine::prettySource() const VL_MT_SAFE {
+string FileLine::prettySource() const {
     string out = source();
     // Drop ignore trailing newline
     const string::size_type pos = out.find('\n');

--- a/src/V3FileLine.h
+++ b/src/V3FileLine.h
@@ -112,7 +112,7 @@ class VFileContent final {
 
 public:
     void pushText(const string& text);  // Add arbitrary text (need not be line-by-line)
-    string getLine(int lineno) const VL_MT_SAFE;
+    string getLine(int lineno) const;
     string ascii() const { return "ct" + cvtToStr(m_id); }
 };
 std::ostream& operator<<(std::ostream& os, VFileContent* contentp);
@@ -238,21 +238,21 @@ public:
     // If not otherwise more specific, use last lineno for errors etc,
     // as the parser errors etc generally make more sense pointing at the last parse point
     int lineno() const VL_MT_SAFE { return m_lastLineno; }
-    string source() const VL_MT_SAFE;
-    string prettySource() const VL_MT_SAFE;  // Source, w/stripped unprintables and newlines
+    string source() const;
+    string prettySource() const;  // Source, w/stripped unprintables and newlines
     FileLine* parent() const VL_MT_SAFE { return m_parent; }
     V3LangCode language() const { return singleton().numberToLang(filenameno()); }
     string ascii() const;
     string asciiLineCol() const;
     int filenameno() const VL_MT_SAFE { return m_filenameno; }
-    string filename() const VL_MT_SAFE { return singleton().numberToName(filenameno()); }
+    string filename() const { return singleton().numberToName(filenameno()); }
     bool filenameIsGlobal() const VL_MT_SAFE {
         return (filename() == commandLineFilename() || filename() == builtInFilename());
     }
-    string filenameLetters() const VL_MT_SAFE {
+    string filenameLetters() const {
         return FileLineSingleton::filenameLetters(filenameno());
     }
-    string filebasename() const VL_MT_SAFE;
+    string filebasename() const;
     string filebasenameNoExt() const;
     string firstColumnLetters() const VL_MT_SAFE;
     string profileFuncname() const;
@@ -362,7 +362,7 @@ public:
 private:
     string warnContext() const;
     string warnContextParent() const VL_REQUIRES(V3Error::s().m_mutex);
-    const MsgEnBitSet& msgEn() const VL_MT_SAFE { return singleton().msgEn(m_msgEnIdx); }
+    const MsgEnBitSet& msgEn() const { return singleton().msgEn(m_msgEnIdx); }
 };
 std::ostream& operator<<(std::ostream& os, FileLine* fileline);
 

--- a/src/V3FileLine.h
+++ b/src/V3FileLine.h
@@ -64,7 +64,7 @@ class FileLineSingleton final {
     ~FileLineSingleton() = default;
 
     fileNameIdx_t nameToNumber(const string& filename);
-    string numberToName(fileNameIdx_t filenameno) const { return m_names[filenameno]; }
+    string numberToName(fileNameIdx_t filenameno) const VL_MT_SAFE { return m_names[filenameno]; }
     V3LangCode numberToLang(fileNameIdx_t filenameno) const { return m_languages[filenameno]; }
     void numberToLang(fileNameIdx_t filenameno, const V3LangCode& l) {
         m_languages[filenameno] = l;
@@ -75,7 +75,7 @@ class FileLineSingleton final {
         m_languages.clear();
     }
     void fileNameNumMapDumpXml(std::ostream& os);
-    static string filenameLetters(fileNameIdx_t fileno);
+    static string filenameLetters(fileNameIdx_t fileno) VL_PURE;
 
     // Add given bitset to the interned bitsets, return interned index
     msgEnSetIdx_t addMsgEnBitSet(const MsgEnBitSet& bitSet);
@@ -112,7 +112,7 @@ class VFileContent final {
 
 public:
     void pushText(const string& text);  // Add arbitrary text (need not be line-by-line)
-    string getLine(int lineno) const;
+    string getLine(int lineno) const VL_MT_SAFE;
     string ascii() const { return "ct" + cvtToStr(m_id); }
 };
 std::ostream& operator<<(std::ostream& os, VFileContent* contentp);
@@ -159,7 +159,7 @@ protected:
 
 private:
     // CONSTRUCTORS
-    static FileLineSingleton& singleton() {
+    static FileLineSingleton& singleton() VL_MT_SAFE {
         static FileLineSingleton s;
         return s;
     }
@@ -238,21 +238,21 @@ public:
     // If not otherwise more specific, use last lineno for errors etc,
     // as the parser errors etc generally make more sense pointing at the last parse point
     int lineno() const VL_MT_SAFE { return m_lastLineno; }
-    string source() const;
-    string prettySource() const;  // Source, w/stripped unprintables and newlines
+    string source() const VL_MT_SAFE;
+    string prettySource() const VL_MT_SAFE;  // Source, w/stripped unprintables and newlines
     FileLine* parent() const VL_MT_SAFE { return m_parent; }
     V3LangCode language() const { return singleton().numberToLang(filenameno()); }
-    string ascii() const;
+    string ascii() const VL_MT_SAFE;
     string asciiLineCol() const;
     int filenameno() const VL_MT_SAFE { return m_filenameno; }
-    string filename() const { return singleton().numberToName(filenameno()); }
+    string filename() const VL_MT_SAFE { return singleton().numberToName(filenameno()); }
     bool filenameIsGlobal() const VL_MT_SAFE {
         return (filename() == commandLineFilename() || filename() == builtInFilename());
     }
-    string filenameLetters() const {
+    string filenameLetters() const VL_MT_SAFE {
         return FileLineSingleton::filenameLetters(filenameno());
     }
-    string filebasename() const;
+    string filebasename() const VL_MT_SAFE;
     string filebasenameNoExt() const;
     string firstColumnLetters() const VL_MT_SAFE;
     string profileFuncname() const;
@@ -270,7 +270,7 @@ public:
     }
     void warnOff(V3ErrorCode code, bool flag) { warnOn(code, !flag); }
     bool warnOff(const string& msg, bool flag);  // Returns 1 if ok
-    bool warnIsOff(V3ErrorCode code) const;
+    bool warnIsOff(V3ErrorCode code) const VL_MT_SAFE;
     void warnLintOff(bool flag);
     void warnStyleOff(bool flag);
     void warnUnusedOff(bool flag);

--- a/src/V3Global.h
+++ b/src/V3Global.h
@@ -143,7 +143,7 @@ public:
     void widthMinUsage(const VWidthMinUsage& flag) { m_widthMinUsage = flag; }
     bool constRemoveXs() const { return m_constRemoveXs; }
     void constRemoveXs(bool flag) { m_constRemoveXs = flag; }
-    string debugFilename(const string& nameComment, int newNumber = 0);
+    string debugFilename(const string& nameComment, int newNumber = 0) VL_MT_SAFE;
     static string digitsFilename(int number);
     bool needTraceDumper() const { return m_needTraceDumper; }
     void needTraceDumper(bool flag) { m_needTraceDumper = flag; }

--- a/src/V3Hash.cpp
+++ b/src/V3Hash.cpp
@@ -24,11 +24,11 @@
 V3Hash::V3Hash(const std::string& val)
     : m_value{static_cast<uint32_t>(std::hash<std::string>{}(val))} {}
 
-std::ostream& operator<<(std::ostream& os, const V3Hash& rhs) {
+std::ostream& operator<<(std::ostream& os, const V3Hash& rhs) VL_MT_SAFE {
     return os << 'h' << std::hex << std::setw(8) << std::setfill('0') << rhs.value();
 }
 
-std::string V3Hash::toString() const {
+std::string V3Hash::toString() const VL_MT_SAFE {
     std::ostringstream os;
     os << *this;
     return os.str();

--- a/src/V3Hash.cpp
+++ b/src/V3Hash.cpp
@@ -28,7 +28,7 @@ std::ostream& operator<<(std::ostream& os, const V3Hash& rhs) {
     return os << 'h' << std::hex << std::setw(8) << std::setfill('0') << rhs.value();
 }
 
-std::string V3Hash::toString() const VL_MT_SAFE {
+std::string V3Hash::toString() const {
     std::ostringstream os;
     os << *this;
     return os.str();

--- a/src/V3Hash.h
+++ b/src/V3Hash.h
@@ -48,7 +48,7 @@ public:
 
     // METHODS
     uint32_t value() const VL_MT_SAFE { return m_value; }
-    std::string toString() const VL_MT_SAFE;
+    std::string toString() const;
 
     // OPERATORS
     // Comparisons

--- a/src/V3Hash.h
+++ b/src/V3Hash.h
@@ -48,7 +48,7 @@ public:
 
     // METHODS
     uint32_t value() const VL_MT_SAFE { return m_value; }
-    std::string toString() const;
+    std::string toString() const VL_MT_SAFE;
 
     // OPERATORS
     // Comparisons
@@ -69,7 +69,7 @@ public:
     }
 };
 
-std::ostream& operator<<(std::ostream& os, const V3Hash& rhs);
+std::ostream& operator<<(std::ostream& os, const V3Hash& rhs) VL_MT_SAFE;
 
 template <>
 struct std::hash<V3Hash> {

--- a/src/V3Number.cpp
+++ b/src/V3Number.cpp
@@ -604,11 +604,11 @@ string V3Number::displayPad(size_t fmtsize, char pad, bool left, const string& i
     return left ? (in + padding) : (padding + in);
 }
 
-string V3Number::displayed(AstNode* nodep, const string& vformat) const {
+string V3Number::displayed(AstNode* nodep, const string& vformat) const VL_MT_SAFE {
     return displayed(nodep->fileline(), vformat);
 }
 
-string V3Number::displayed(FileLine* fl, const string& vformat) const {
+string V3Number::displayed(FileLine* fl, const string& vformat) const VL_MT_SAFE {
     auto pos = vformat.cbegin();
     UASSERT(pos != vformat.cend() && pos[0] == '%',
             "$display-like function with non format argument " << *this);
@@ -913,7 +913,7 @@ uint32_t V3Number::toUInt() const VL_MT_SAFE {
     return m_data.num()[0].m_value;
 }
 
-double V3Number::toDouble() const {
+double V3Number::toDouble() const VL_MT_SAFE {
     if (VL_UNCOVERABLE(!isDouble() || width() != 64)) {
         v3fatalSrc("Real operation on wrong sized/non-real number");
     }
@@ -996,14 +996,14 @@ uint8_t V3Number::dataByte(int byte) const {
     return (edataWord(byte / (VL_EDATASIZE / 8)) >> ((byte * 8) % VL_EDATASIZE)) & 0xff;
 }
 
-bool V3Number::isAllZ() const {
+bool V3Number::isAllZ() const VL_MT_SAFE {
     if (isDouble() || isString()) return false;
     for (int i = 0; i < width(); i++) {
         if (!bitIsZ(i)) return false;
     }
     return true;
 }
-bool V3Number::isAllX() const {
+bool V3Number::isAllX() const VL_MT_SAFE {
     if (isDouble() || isString()) return false;
     uint32_t mask = hiWordMask();
     for (int i = words() - 1; i >= 0; --i) {
@@ -1057,7 +1057,7 @@ bool V3Number::isFourState() const {
     }
     return false;
 }
-bool V3Number::isAnyX() const {
+bool V3Number::isAnyX() const VL_MT_SAFE {
     if (isDouble() || isString()) return false;
     for (int bit = 0; bit < width(); bit++) {
         if (bitIsX(bit)) return true;
@@ -1065,7 +1065,7 @@ bool V3Number::isAnyX() const {
     return false;
 }
 bool V3Number::isAnyXZ() const { return isAnyX() || isAnyZ(); }
-bool V3Number::isAnyZ() const {
+bool V3Number::isAnyZ() const VL_MT_SAFE {
     if (isDouble() || isString()) return false;
     for (int bit = 0; bit < width(); bit++) {
         if (bitIsZ(bit)) return true;
@@ -1082,7 +1082,7 @@ bool V3Number::isLtXZ(const V3Number& rhs) const {
     }
     return false;
 }
-int V3Number::countX(int lsb, int nbits) const {
+int V3Number::countX(int lsb, int nbits) const VL_MT_SAFE {
     int count = 0;
     for (int bitn = 0; bitn < nbits; ++bitn) {
         if (lsb + bitn >= width()) return count;
@@ -1090,7 +1090,7 @@ int V3Number::countX(int lsb, int nbits) const {
     }
     return count;
 }
-int V3Number::countZ(int lsb, int nbits) const {
+int V3Number::countZ(int lsb, int nbits) const VL_MT_SAFE {
     int count = 0;
     for (int bitn = 0; bitn < nbits; ++bitn) {
         if (lsb + bitn >= width()) return count;

--- a/src/V3Number.cpp
+++ b/src/V3Number.cpp
@@ -598,7 +598,7 @@ bool V3Number::displayedFmtLegal(char format, bool isScan) {
     }
 }
 
-string V3Number::displayPad(size_t fmtsize, char pad, bool left, const string& in) {
+string V3Number::displayPad(size_t fmtsize, char pad, bool left, const string& in) VL_PURE {
     string padding;
     if (in.length() < fmtsize) padding = string(fmtsize - in.length(), pad);
     return left ? (in + padding) : (padding + in);
@@ -901,7 +901,7 @@ string V3Number::toDecimalU() const {
 //======================================================================
 // ACCESSORS - as numbers
 
-uint32_t V3Number::toUInt() const {
+uint32_t V3Number::toUInt() const VL_MT_SAFE {
     UASSERT(!isFourState(), "toUInt with 4-state " << *this);
     // We allow wide numbers that represent values <= 32 bits
     for (int i = 1; i < words(); ++i) {
@@ -926,7 +926,7 @@ double V3Number::toDouble() const {
     return u.d;
 }
 
-int32_t V3Number::toSInt() const {
+int32_t V3Number::toSInt() const VL_MT_SAFE {
     if (isSigned()) {
         const uint32_t v = toUInt();
         const uint32_t signExtend = (-(v & (1UL << (width() - 1))));
@@ -939,7 +939,7 @@ int32_t V3Number::toSInt() const {
     }
 }
 
-uint64_t V3Number::toUQuad() const {
+uint64_t V3Number::toUQuad() const VL_MT_SAFE {
     UASSERT(!isFourState(), "toUQuad with 4-state " << *this);
     // We allow wide numbers that represent values <= 64 bits
     if (isDouble()) return static_cast<uint64_t>(toDouble());

--- a/src/V3Number.cpp
+++ b/src/V3Number.cpp
@@ -901,7 +901,7 @@ string V3Number::toDecimalU() const {
 //======================================================================
 // ACCESSORS - as numbers
 
-uint32_t V3Number::toUInt() const VL_MT_SAFE {
+uint32_t V3Number::toUInt() const {
     UASSERT(!isFourState(), "toUInt with 4-state " << *this);
     // We allow wide numbers that represent values <= 32 bits
     for (int i = 1; i < words(); ++i) {
@@ -939,7 +939,7 @@ int32_t V3Number::toSInt() const {
     }
 }
 
-uint64_t V3Number::toUQuad() const VL_MT_SAFE {
+uint64_t V3Number::toUQuad() const {
     UASSERT(!isFourState(), "toUQuad with 4-state " << *this);
     // We allow wide numbers that represent values <= 64 bits
     if (isDouble()) return static_cast<uint64_t>(toDouble());

--- a/src/V3Number.h
+++ b/src/V3Number.h
@@ -63,7 +63,7 @@ public:
         DOUBLE = 2,
         STRING = 3,
     };
-    friend std::ostream& operator<<(std::ostream& os, const V3NumberDataType& rhs) {
+    friend std::ostream& operator<<(std::ostream& os, const V3NumberDataType& rhs) VL_MT_SAFE {
         switch (rhs) {
         case V3NumberDataType::UNINITIALIZED: return os << "UNINITIALIZED";
         case V3NumberDataType::LOGIC: return os << "LOGIC";
@@ -559,9 +559,9 @@ private:
             m_data.m_sized = false;
         }
     }
-    static string displayPad(size_t fmtsize, char pad, bool left, const string& in);
-    string displayed(FileLine* fl, const string& vformat) const;
-    string displayed(const string& vformat) const {
+    static string displayPad(size_t fmtsize, char pad, bool left, const string& in) VL_PURE;
+    string displayed(FileLine* fl, const string& vformat) const VL_MT_SAFE;
+    string displayed(const string& vformat) const VL_MT_SAFE {
         return displayed(m_fileline, vformat);
     }
 
@@ -637,11 +637,11 @@ public:
     bool isAnyXZ() const;
     bool isAnyZ() const;
     bool isMsbXZ() const { return bitIsXZ(m_data.width() - 1); }
-    uint32_t toUInt() const;
-    int32_t toSInt() const;
-    uint64_t toUQuad() const;
-    int64_t toSQuad() const;
-    string toString() const;
+    uint32_t toUInt() const VL_MT_SAFE;
+    int32_t toSInt() const VL_MT_SAFE;
+    uint64_t toUQuad() const VL_MT_SAFE;
+    int64_t toSQuad() const VL_MT_SAFE;
+    string toString() const VL_MT_SAFE;
     string toDecimalS() const;  // return ASCII signed decimal number
     string toDecimalU() const;  // return ASCII unsigned decimal number
     double toDouble() const;

--- a/src/V3Number.h
+++ b/src/V3Number.h
@@ -202,7 +202,7 @@ public:
         UASSERT(isNumber(), "`num` member accessed when data type is " << m_type);
         return isInlineNumber() ? m_inlineNumber.data() : m_dynamicNumber.data();
     }
-    const ValueAndX* num() const VL_MT_SAFE {
+    const ValueAndX* num() const {
         UASSERT(isNumber(), "`num` member accessed when data type is " << m_type);
         return isInlineNumber() ? m_inlineNumber.data() : m_dynamicNumber.data();
     }
@@ -210,7 +210,7 @@ public:
         UASSERT(isString(), "`str` member accessed when data type is " << m_type);
         return m_string;
     }
-    const std::string& str() const VL_MT_SAFE {
+    const std::string& str() const {
         UASSERT(isString(), "`str` member accessed when data type is " << m_type);
         return m_string;
     }
@@ -383,7 +383,7 @@ public:
     }
 
 private:
-    char bitIs(int bit) const VL_MT_SAFE {
+    char bitIs(int bit) const {
         if (bit >= m_data.width() || bit < 0) {
             // We never sign extend
             return '0';
@@ -409,14 +409,14 @@ private:
     }
 
 public:
-    bool bitIs0(int bit) const VL_MT_SAFE {
+    bool bitIs0(int bit) const {
         if (!isNumber()) return false;
         if (bit < 0) return false;
         if (bit >= m_data.width()) return !bitIsXZ(m_data.width() - 1);
         const ValueAndX v = m_data.num()[bit / 32];
         return ((v.m_value & (1UL << (bit & 31))) == 0 && !(v.m_valueX & (1UL << (bit & 31))));
     }
-    bool bitIs1(int bit) const VL_MT_SAFE {
+    bool bitIs1(int bit) const {
         if (!isNumber()) return false;
         if (bit < 0) return false;
         if (bit >= m_data.width()) return false;
@@ -430,21 +430,21 @@ public:
         const ValueAndX v = m_data.num()[bit / 32];
         return ((v.m_value & (1UL << (bit & 31))) && !(v.m_valueX & (1UL << (bit & 31))));
     }
-    bool bitIsX(int bit) const VL_MT_SAFE {
+    bool bitIsX(int bit) const {
         if (!isNumber()) return false;
         if (bit < 0) return false;
         if (bit >= m_data.width()) return bitIsZ(m_data.width() - 1);
         const ValueAndX v = m_data.num()[bit / 32];
         return ((v.m_value & (1UL << (bit & 31))) && (v.m_valueX & (1UL << (bit & 31))));
     }
-    bool bitIsXZ(int bit) const VL_MT_SAFE {
+    bool bitIsXZ(int bit) const {
         if (!isNumber()) return false;
         if (bit < 0) return false;
         if (bit >= m_data.width()) return bitIsXZ(m_data.width() - 1);
         const ValueAndX v = m_data.num()[bit / 32];
         return ((v.m_valueX & (1UL << (bit & 31))));
     }
-    bool bitIsZ(int bit) const VL_MT_SAFE {
+    bool bitIsZ(int bit) const {
         if (!isNumber()) return false;
         if (bit < 0) return false;
         if (bit >= m_data.width()) return bitIsZ(m_data.width() - 1);
@@ -453,14 +453,14 @@ public:
     }
 
 private:
-    uint32_t bitsValue(int lsb, int nbits) const VL_MT_SAFE {
+    uint32_t bitsValue(int lsb, int nbits) const {
         uint32_t v = 0;
         for (int bitn = 0; bitn < nbits; bitn++) { v |= (bitIs1(lsb + bitn) << bitn); }
         return v;
     }
 
-    int countX(int lsb, int nbits) const VL_MT_SAFE;
-    int countZ(int lsb, int nbits) const VL_MT_SAFE;
+    int countX(int lsb, int nbits) const;
+    int countZ(int lsb, int nbits) const;
 
     int words() const VL_MT_SAFE { return ((width() + 31) / 32); }
     uint32_t hiWordMask() const VL_MT_SAFE { return VL_MASK_I(width()); }
@@ -560,8 +560,8 @@ private:
         }
     }
     static string displayPad(size_t fmtsize, char pad, bool left, const string& in);
-    string displayed(FileLine* fl, const string& vformat) const VL_MT_SAFE;
-    string displayed(const string& vformat) const VL_MT_SAFE {
+    string displayed(FileLine* fl, const string& vformat) const;
+    string displayed(const string& vformat) const {
         return displayed(m_fileline, vformat);
     }
 
@@ -583,7 +583,7 @@ public:
     V3Number& setMask(int nbits);  // IE if nbits=1, then 0b1, if 2->0b11, if 3->0b111 etc
 
     // ACCESSORS
-    string ascii(bool prefixed = true, bool cleanVerilog = false) const VL_MT_SAFE;
+    string ascii(bool prefixed = true, bool cleanVerilog = false) const;
     string displayed(AstNode* nodep, const string& vformat) const;
     static bool displayedFmtLegal(char format, bool isScan);  // Is this a valid format letter?
     int width() const VL_MT_SAFE { return m_data.width(); }
@@ -612,10 +612,10 @@ public:
         return m_data.type() == V3NumberDataType::LOGIC
                || m_data.type() == V3NumberDataType::DOUBLE;
     }
-    bool isNegative() const VL_MT_SAFE { return !isString() && bitIs1(width() - 1); }
+    bool isNegative() const { return !isString() && bitIs1(width() - 1); }
     bool is1Step() const VL_MT_SAFE { return m_data.m_is1Step; }
     bool isNull() const VL_MT_SAFE { return m_data.m_isNull; }
-    bool isFourState() const VL_MT_SAFE;
+    bool isFourState() const;
     bool hasZ() const {
         if (isString()) return false;
         for (int i = 0; i < words(); i++) {
@@ -624,27 +624,27 @@ public:
         }
         return false;
     }
-    bool isAllZ() const VL_MT_SAFE;
-    bool isAllX() const VL_MT_SAFE;
-    bool isEqZero() const VL_MT_SAFE;
+    bool isAllZ() const;
+    bool isAllX() const;
+    bool isEqZero() const;
     bool isNeqZero() const;
     bool isBitsZero(int msb, int lsb) const;
     bool isEqOne() const;
     bool isEqAllOnes(int optwidth = 0) const;
     bool isCaseEq(const V3Number& rhs) const;  // operator==
     bool isLtXZ(const V3Number& rhs) const;  // operator< with XZ compared
-    bool isAnyX() const VL_MT_SAFE;
+    bool isAnyX() const;
     bool isAnyXZ() const;
-    bool isAnyZ() const VL_MT_SAFE;
+    bool isAnyZ() const;
     bool isMsbXZ() const { return bitIsXZ(m_data.width() - 1); }
     uint32_t toUInt() const;
-    int32_t toSInt() const VL_MT_SAFE;
+    int32_t toSInt() const;
     uint64_t toUQuad() const;
-    int64_t toSQuad() const VL_MT_SAFE;
-    string toString() const VL_MT_SAFE;
-    string toDecimalS() const VL_MT_SAFE;  // return ASCII signed decimal number
-    string toDecimalU() const VL_MT_SAFE;  // return ASCII unsigned decimal number
-    double toDouble() const VL_MT_SAFE;
+    int64_t toSQuad() const;
+    string toString() const;
+    string toDecimalS() const;  // return ASCII signed decimal number
+    string toDecimalU() const;  // return ASCII unsigned decimal number
+    double toDouble() const;
     V3Hash toHash() const;
     uint32_t edataWord(int eword) const;
     uint8_t dataByte(int byte) const;

--- a/src/V3Number.h
+++ b/src/V3Number.h
@@ -202,7 +202,7 @@ public:
         UASSERT(isNumber(), "`num` member accessed when data type is " << m_type);
         return isInlineNumber() ? m_inlineNumber.data() : m_dynamicNumber.data();
     }
-    const ValueAndX* num() const {
+    const ValueAndX* num() const VL_MT_SAFE {
         UASSERT(isNumber(), "`num` member accessed when data type is " << m_type);
         return isInlineNumber() ? m_inlineNumber.data() : m_dynamicNumber.data();
     }
@@ -409,14 +409,14 @@ private:
     }
 
 public:
-    bool bitIs0(int bit) const {
+    bool bitIs0(int bit) const VL_MT_SAFE {
         if (!isNumber()) return false;
         if (bit < 0) return false;
         if (bit >= m_data.width()) return !bitIsXZ(m_data.width() - 1);
         const ValueAndX v = m_data.num()[bit / 32];
         return ((v.m_value & (1UL << (bit & 31))) == 0 && !(v.m_valueX & (1UL << (bit & 31))));
     }
-    bool bitIs1(int bit) const {
+    bool bitIs1(int bit) const VL_MT_SAFE {
         if (!isNumber()) return false;
         if (bit < 0) return false;
         if (bit >= m_data.width()) return false;
@@ -430,21 +430,21 @@ public:
         const ValueAndX v = m_data.num()[bit / 32];
         return ((v.m_value & (1UL << (bit & 31))) && !(v.m_valueX & (1UL << (bit & 31))));
     }
-    bool bitIsX(int bit) const {
+    bool bitIsX(int bit) const VL_MT_SAFE {
         if (!isNumber()) return false;
         if (bit < 0) return false;
         if (bit >= m_data.width()) return bitIsZ(m_data.width() - 1);
         const ValueAndX v = m_data.num()[bit / 32];
         return ((v.m_value & (1UL << (bit & 31))) && (v.m_valueX & (1UL << (bit & 31))));
     }
-    bool bitIsXZ(int bit) const {
+    bool bitIsXZ(int bit) const VL_MT_SAFE {
         if (!isNumber()) return false;
         if (bit < 0) return false;
         if (bit >= m_data.width()) return bitIsXZ(m_data.width() - 1);
         const ValueAndX v = m_data.num()[bit / 32];
         return ((v.m_valueX & (1UL << (bit & 31))));
     }
-    bool bitIsZ(int bit) const {
+    bool bitIsZ(int bit) const VL_MT_SAFE {
         if (!isNumber()) return false;
         if (bit < 0) return false;
         if (bit >= m_data.width()) return bitIsZ(m_data.width() - 1);
@@ -453,14 +453,14 @@ public:
     }
 
 private:
-    uint32_t bitsValue(int lsb, int nbits) const {
+    uint32_t bitsValue(int lsb, int nbits) const VL_MT_SAFE {
         uint32_t v = 0;
         for (int bitn = 0; bitn < nbits; bitn++) { v |= (bitIs1(lsb + bitn) << bitn); }
         return v;
     }
 
-    int countX(int lsb, int nbits) const;
-    int countZ(int lsb, int nbits) const;
+    int countX(int lsb, int nbits) const VL_MT_SAFE;
+    int countZ(int lsb, int nbits) const VL_MT_SAFE;
 
     int words() const VL_MT_SAFE { return ((width() + 31) / 32); }
     uint32_t hiWordMask() const VL_MT_SAFE { return VL_MASK_I(width()); }
@@ -584,7 +584,7 @@ public:
 
     // ACCESSORS
     string ascii(bool prefixed = true, bool cleanVerilog = false) const;
-    string displayed(AstNode* nodep, const string& vformat) const;
+    string displayed(AstNode* nodep, const string& vformat) const VL_MT_SAFE;
     static bool displayedFmtLegal(char format, bool isScan);  // Is this a valid format letter?
     int width() const VL_MT_SAFE { return m_data.width(); }
     int widthMin() const;  // Minimum width that can represent this number (~== log2(num)+1)
@@ -624,8 +624,8 @@ public:
         }
         return false;
     }
-    bool isAllZ() const;
-    bool isAllX() const;
+    bool isAllZ() const VL_MT_SAFE;
+    bool isAllX() const VL_MT_SAFE;
     bool isEqZero() const;
     bool isNeqZero() const;
     bool isBitsZero(int msb, int lsb) const;
@@ -633,9 +633,9 @@ public:
     bool isEqAllOnes(int optwidth = 0) const;
     bool isCaseEq(const V3Number& rhs) const;  // operator==
     bool isLtXZ(const V3Number& rhs) const;  // operator< with XZ compared
-    bool isAnyX() const;
+    bool isAnyX() const VL_MT_SAFE;
     bool isAnyXZ() const;
-    bool isAnyZ() const;
+    bool isAnyZ() const VL_MT_SAFE;
     bool isMsbXZ() const { return bitIsXZ(m_data.width() - 1); }
     uint32_t toUInt() const VL_MT_SAFE;
     int32_t toSInt() const VL_MT_SAFE;
@@ -644,7 +644,7 @@ public:
     string toString() const VL_MT_SAFE;
     string toDecimalS() const;  // return ASCII signed decimal number
     string toDecimalU() const;  // return ASCII unsigned decimal number
-    double toDouble() const;
+    double toDouble() const VL_MT_SAFE;
     V3Hash toHash() const;
     uint32_t edataWord(int eword) const;
     uint8_t dataByte(int byte) const;
@@ -777,7 +777,7 @@ public:
     V3Number& opLtN(const V3Number& lhs, const V3Number& rhs);
     V3Number& opLteN(const V3Number& lhs, const V3Number& rhs);
 };
-inline std::ostream& operator<<(std::ostream& os, const V3Number& rhs) {
+inline std::ostream& operator<<(std::ostream& os, const V3Number& rhs) VL_MT_SAFE {
     return os << rhs.ascii();
 }
 

--- a/src/V3Options.cpp
+++ b/src/V3Options.cpp
@@ -1927,7 +1927,7 @@ unsigned V3Options::debugLevel(const string& tag) const VL_MT_SAFE {
     return iter != m_debugLevel.end() ? iter->second : V3Error::debugDefault();
 }
 
-unsigned V3Options::debugSrcLevel(const string& srcfile_path) const VL_MT_SAFE {
+unsigned V3Options::debugSrcLevel(const string& srcfile_path) const {
     // For simplicity, calling functions can just use __FILE__ for srcfile.
     // That means we need to strip the filenames: ../Foo.cpp -> Foo
     return debugLevel(V3Os::filenameNonDirExt(srcfile_path));
@@ -1938,7 +1938,7 @@ unsigned V3Options::dumpLevel(const string& tag) const VL_MT_SAFE {
     return iter != m_dumpLevel.end() ? iter->second : 0;
 }
 
-unsigned V3Options::dumpSrcLevel(const string& srcfile_path) const VL_MT_SAFE {
+unsigned V3Options::dumpSrcLevel(const string& srcfile_path) const {
     // For simplicity, calling functions can just use __FILE__ for srcfile.
     // That means we need to strip the filenames: ../Foo.cpp -> Foo
     return dumpLevel(V3Os::filenameNonDirExt(srcfile_path));

--- a/src/V3Options.cpp
+++ b/src/V3Options.cpp
@@ -874,7 +874,7 @@ void V3Options::notify() {
 //######################################################################
 // V3 Options accessors
 
-string V3Options::version() {
+string V3Options::version() VL_PURE {
     string ver = DTVERSION;
     ver += " rev " + cvtToStr(DTVERSION_rev);
     return ver;

--- a/src/V3Options.cpp
+++ b/src/V3Options.cpp
@@ -1927,7 +1927,7 @@ unsigned V3Options::debugLevel(const string& tag) const VL_MT_SAFE {
     return iter != m_debugLevel.end() ? iter->second : V3Error::debugDefault();
 }
 
-unsigned V3Options::debugSrcLevel(const string& srcfile_path) const {
+unsigned V3Options::debugSrcLevel(const string& srcfile_path) const VL_MT_SAFE {
     // For simplicity, calling functions can just use __FILE__ for srcfile.
     // That means we need to strip the filenames: ../Foo.cpp -> Foo
     return debugLevel(V3Os::filenameNonDirExt(srcfile_path));

--- a/src/V3Options.h
+++ b/src/V3Options.h
@@ -650,7 +650,7 @@ public:
     }
 
     // METHODS (from main)
-    static string version();
+    static string version() VL_PURE;
     static string argString(int argc, char** argv);  ///< Return list of arguments as simple string
     string allArgsString() const VL_MT_SAFE;  ///< Return all passed arguments as simple string
     // Return options for child hierarchical blocks when forTop==false, otherwise returns args for

--- a/src/V3Options.h
+++ b/src/V3Options.h
@@ -405,7 +405,7 @@ public:
     ~V3Options();
     void setDebugMode(int level);
     unsigned debugLevel(const string& tag) const VL_MT_SAFE;
-    unsigned debugSrcLevel(const string& srcfile_path) const;
+    unsigned debugSrcLevel(const string& srcfile_path) const VL_MT_SAFE;
     unsigned dumpLevel(const string& tag) const VL_MT_SAFE;
     unsigned dumpSrcLevel(const string& srcfile_path) const;
 

--- a/src/V3Options.h
+++ b/src/V3Options.h
@@ -405,9 +405,9 @@ public:
     ~V3Options();
     void setDebugMode(int level);
     unsigned debugLevel(const string& tag) const VL_MT_SAFE;
-    unsigned debugSrcLevel(const string& srcfile_path) const VL_MT_SAFE;
+    unsigned debugSrcLevel(const string& srcfile_path) const;
     unsigned dumpLevel(const string& tag) const VL_MT_SAFE;
-    unsigned dumpSrcLevel(const string& srcfile_path) const VL_MT_SAFE;
+    unsigned dumpSrcLevel(const string& srcfile_path) const;
 
     // METHODS
     void addCppFile(const string& filename);

--- a/src/V3Os.cpp
+++ b/src/V3Os.cpp
@@ -142,7 +142,7 @@ string V3Os::filenameDir(const string& filename) {
     }
 }
 
-string V3Os::filenameNonDir(const string& filename) {
+string V3Os::filenameNonDir(const string& filename) VL_PURE {
     string::size_type pos;
     if ((pos = filename.rfind('/')) != string::npos) {
         return filename.substr(pos + 1);
@@ -151,7 +151,7 @@ string V3Os::filenameNonDir(const string& filename) {
     }
 }
 
-string V3Os::filenameNonExt(const string& filename) {
+string V3Os::filenameNonExt(const string& filename) VL_PURE {
     string base = filenameNonDir(filename);
     string::size_type pos;
     if ((pos = base.find('.')) != string::npos) base.erase(pos);

--- a/src/V3Os.h
+++ b/src/V3Os.h
@@ -37,10 +37,11 @@ public:
     // METHODS (generic filename utilities)
     static string filenameFromDirBase(const string& dir, const string& basename);
     /// Return non-directory part of filename
-    static string filenameNonDir(const string& filename);
+    static string filenameNonDir(const string& filename) VL_PURE;
     /// Return non-extensioned (no .) part of filename
-    static string filenameNonExt(const string& filename);
-    static string filenameNonDirExt(const string& filename) {  ///< Return basename of filename
+    static string filenameNonExt(const string& filename) VL_PURE;
+    ///< Return basename of filename
+    static string filenameNonDirExt(const string& filename) VL_PURE {
         return filenameNonExt(filenameNonDir(filename));
     }
     static string filenameDir(const string& filename);  ///< Return directory part of filename

--- a/src/V3String.cpp
+++ b/src/V3String.cpp
@@ -36,7 +36,7 @@ std::map<string, string> VName::s_dehashMap;
 // Wildcard
 
 // Double procedures, inlined, unrolls loop much better
-bool VString::wildmatchi(const char* s, const char* p) {
+bool VString::wildmatchi(const char* s, const char* p) VL_PURE {
     for (; *p; s++, p++) {
         if (*p != '*') {
             if (((*s) != (*p)) && *p != '?') return false;
@@ -52,7 +52,7 @@ bool VString::wildmatchi(const char* s, const char* p) {
     return (*s == '\0');
 }
 
-bool VString::wildmatch(const char* s, const char* p) {
+bool VString::wildmatch(const char* s, const char* p) VL_PURE {
     for (; *p; s++, p++) {
         if (*p != '*') {
             if (((*s) != (*p)) && *p != '?') return false;
@@ -68,7 +68,7 @@ bool VString::wildmatch(const char* s, const char* p) {
     return (*s == '\0');
 }
 
-bool VString::wildmatch(const string& s, const string& p) {
+bool VString::wildmatch(const string& s, const string& p) VL_PURE {
     return wildmatch(s.c_str(), p.c_str());
 }
 
@@ -130,7 +130,7 @@ string VString::escapeStringForPath(const string& str) {
     return result;
 }
 
-string VString::spaceUnprintable(const string& str) {
+string VString::spaceUnprintable(const string& str) VL_PURE {
     string out;
     for (const char c : str) {
         if (std::isprint(c)) {
@@ -216,10 +216,12 @@ static const uint32_t sha256K[]
        0xc67178f2};
 
 VL_ATTR_ALWINLINE
-static uint32_t shaRotr32(uint32_t lhs, uint32_t rhs) { return lhs >> rhs | lhs << (32 - rhs); }
+static uint32_t shaRotr32(uint32_t lhs, uint32_t rhs) VL_PURE {
+    return lhs >> rhs | lhs << (32 - rhs);
+}
 
 VL_ATTR_ALWINLINE
-static void sha256Block(uint32_t* h, const uint32_t* chunk) {
+static void sha256Block(uint32_t* h, const uint32_t* chunk) VL_PURE {
     uint32_t ah[8];
     const uint32_t* p = chunk;
 

--- a/src/V3String.h
+++ b/src/V3String.h
@@ -34,13 +34,14 @@
 // Global string-related functions
 
 template <class T>
-std::string cvtToStr(const T& t) {
+std::string cvtToStr(const T& t) VL_PURE {
     std::ostringstream os;
     os << t;
     return os.str();
 }
 template <class T>
-typename std::enable_if<std::is_pointer<T>::value, std::string>::type cvtToHex(const T tp) {
+typename std::enable_if<std::is_pointer<T>::value, std::string>::type
+cvtToHex(const T tp) VL_MT_SAFE {
     std::ostringstream os;
     os << static_cast<const void*>(tp);
     return os.str();
@@ -78,14 +79,14 @@ inline string ucfirst(const string& text) {
 // VString - String manipulation
 
 class VString final {
-    static bool wildmatchi(const char* s, const char* p);
+    static bool wildmatchi(const char* s, const char* p) VL_PURE;
 
 public:
     // METHODS (generic string utilities)
     // Return true if p with ? or *'s matches s
-    static bool wildmatch(const char* s, const char* p);
+    static bool wildmatch(const char* s, const char* p) VL_PURE;
     // Return true if p with ? or *'s matches s
-    static bool wildmatch(const string& s, const string& p);
+    static bool wildmatch(const string& s, const string& p) VL_PURE;
     // Return {a}{dot}{b}, omitting dot if a or b are empty
     static string dot(const string& a, const string& dot, const string& b);
     // Convert string to lowercase (tolower)
@@ -107,7 +108,7 @@ public:
     static string quoteStringLiteralForShell(const string& str);
     // Replace any unprintable with space
     // This includes removing tabs, so column tracking is correct
-    static string spaceUnprintable(const string& str);
+    static string spaceUnprintable(const string& str) VL_PURE;
     // Remove any whitespace
     static string removeWhitespace(const string& str);
     // Return true if only whitespace or ""

--- a/src/V3String.h
+++ b/src/V3String.h
@@ -41,7 +41,7 @@ std::string cvtToStr(const T& t) VL_PURE {
 }
 template <class T>
 typename std::enable_if<std::is_pointer<T>::value, std::string>::type
-cvtToHex(const T tp) VL_MT_SAFE {
+cvtToHex(const T tp) VL_PURE {
     std::ostringstream os;
     os << static_cast<const void*>(tp);
     return os.str();

--- a/src/astgen
+++ b/src/astgen
@@ -865,7 +865,7 @@ def write_type_enum(prefix, nodeList):
         fh.write("        _BOUNDS_END\n")
         fh.write("    };\n")
 
-        fh.write("    const char* ascii() const {\n")
+        fh.write("    const char* ascii() const VL_MT_SAFE {\n")
         fh.write("        static const char* const names[_ENUM_END + 1] = {\n")
         for node in sorted(filter(lambda _: _.isLeaf, nodeList),
                            key=lambda _: _.typeId):

--- a/src/astgen
+++ b/src/astgen
@@ -931,7 +931,7 @@ def write_ast_macros(filename):
             static Ast{t}* cloneTreeNull(Ast{t}* nodep, bool cloneNextLink) {{
                 return nodep ? nodep->cloneTree(cloneNextLink) : nullptr;
             }}
-            Ast{t}* clonep() const VL_MT_SAFE {{ return static_cast<Ast{t}*>(AstNode::clonep()); }}
+            Ast{t}* clonep() const {{ return static_cast<Ast{t}*>(AstNode::clonep()); }}
             Ast{t}* addNext(Ast{t}* nodep) {{ return static_cast<Ast{t}*>(AstNode::addNext(this, nodep)); }}
             ''',
                       t=node.name)

--- a/src/astgen
+++ b/src/astgen
@@ -952,7 +952,7 @@ def write_ast_macros(filename):
                             "op{n}p()").format(n=n, kind=kind)
                 if monad == "List":
                     emitBlock('''\
-                    Ast{kind}* {name}() const VL_MT_STABLE_TREE {{ return {retrieve}; }}
+                    Ast{kind}* {name}() const VL_MT_STABLE {{ return {retrieve}; }}
                     void add{Name}(Ast{kind}* nodep) {{ addNOp{n}p(reinterpret_cast<AstNode*>(nodep)); }}
                     ''',
                               kind=kind,
@@ -962,7 +962,7 @@ def write_ast_macros(filename):
                               retrieve=retrieve)
                 elif monad == "Optional":
                     emitBlock('''\
-                    Ast{kind}* {name}() const VL_MT_STABLE_TREE {{ return {retrieve}; }}
+                    Ast{kind}* {name}() const VL_MT_STABLE {{ return {retrieve}; }}
                     void {name}(Ast{kind}* nodep) {{ setNOp{n}p(reinterpret_cast<AstNode*>(nodep)); }}
                     ''',
                               kind=kind,
@@ -971,7 +971,7 @@ def write_ast_macros(filename):
                               retrieve=retrieve)
                 else:
                     emitBlock('''\
-                    Ast{kind}* {name}() const VL_MT_STABLE_TREE {{ return {retrieve}; }}
+                    Ast{kind}* {name}() const VL_MT_STABLE {{ return {retrieve}; }}
                     void {name}(Ast{kind}* nodep) {{ setOp{n}p(reinterpret_cast<AstNode*>(nodep)); }}
                     ''',
                               kind=kind,

--- a/src/astgen
+++ b/src/astgen
@@ -952,7 +952,7 @@ def write_ast_macros(filename):
                             "op{n}p()").format(n=n, kind=kind)
                 if monad == "List":
                     emitBlock('''\
-                    Ast{kind}* {name}() const VL_MT_SAFE {{ return {retrieve}; }}
+                    Ast{kind}* {name}() const VL_MT_STABLE_TREE {{ return {retrieve}; }}
                     void add{Name}(Ast{kind}* nodep) {{ addNOp{n}p(reinterpret_cast<AstNode*>(nodep)); }}
                     ''',
                               kind=kind,
@@ -962,7 +962,7 @@ def write_ast_macros(filename):
                               retrieve=retrieve)
                 elif monad == "Optional":
                     emitBlock('''\
-                    Ast{kind}* {name}() const VL_MT_SAFE {{ return {retrieve}; }}
+                    Ast{kind}* {name}() const VL_MT_STABLE_TREE {{ return {retrieve}; }}
                     void {name}(Ast{kind}* nodep) {{ setNOp{n}p(reinterpret_cast<AstNode*>(nodep)); }}
                     ''',
                               kind=kind,
@@ -971,7 +971,7 @@ def write_ast_macros(filename):
                               retrieve=retrieve)
                 else:
                     emitBlock('''\
-                    Ast{kind}* {name}() const VL_MT_SAFE {{ return {retrieve}; }}
+                    Ast{kind}* {name}() const VL_MT_STABLE_TREE {{ return {retrieve}; }}
                     void {name}(Ast{kind}* nodep) {{ setOp{n}p(reinterpret_cast<AstNode*>(nodep)); }}
                     ''',
                               kind=kind,

--- a/test_regress/t/t_a5_attributes_src.pl
+++ b/test_regress/t/t_a5_attributes_src.pl
@@ -36,7 +36,7 @@ sub check {
             tee => 1,
             cmd => ["python3", "$root/nodist/clang_check_attributes --verilator-root=$root --cxxflags='$clang_args' $precompile_args $srcfiles_str"]);
 
-        file_grep($Self->{run_log_filename}, "Number of functions reported unsafe: 27");
+        file_grep($Self->{run_log_filename}, "Number of functions reported unsafe: 0");
     }
 
     run_clang_check();


### PR DESCRIPTION
Related to: https://github.com/verilator/verilator/pull/3608

This PR marks some of the functions used in parallel context in #3608  as VL_MT_SAFE.

Signed-off-by: Kamil Rakoczy <krakoczy@antmicro.com>

