### PR TITLE
Fix comment annotation after #3703

### DIFF
--- a/include/verilatedos.h
+++ b/include/verilatedos.h
@@ -485,7 +485,7 @@ using ssize_t = uint32_t;  ///< signed size_t; returned from read()
 #elif defined(__powerpc64__)
 # define VL_CPU_RELAX() asm volatile("or 1, 1, 1; or 2, 2, 2;" ::: "memory")
 #elif defined(__loongarch__)
-/ LoongArch does not currently have a yield/pause instruction
+// LoongArch does not currently have a yield/pause instruction
 # define VL_CPU_RELAX() asm volatile("nop" ::: "memory")
 #else
 # error "Missing VL_CPU_RELAX() definition."


### PR DESCRIPTION
This PR fixes missing `/` in the comment after #3703. Thanks @cheungxi for spotting this.

Signed-off-by: Kamil Rakoczy <krakoczy@antmicro.com>
