### PR TITLE
Fix with clause handling in functions

### DIFF
--- a/src/V3LinkDot.cpp
+++ b/src/V3LinkDot.cpp
@@ -1731,7 +1731,7 @@ class LinkDotScopeVisitor final : public VNVisitor {
     void visit(AstNodeFTask* nodep) override {
         VSymEnt* const symp = m_statep->insertBlock(m_modSymp, nodep->name(), nodep, nullptr);
         symp->fallbackp(m_modSymp);
-        // No recursion, we don't want to pick up variables
+        iterateChildren(nodep);
     }
     void visit(AstForeach* nodep) override {
         VSymEnt* const symp = m_statep->insertBlock(m_modSymp, nodep->name(), nodep, nullptr);

--- a/test_regress/t/t_array_query_with.pl
+++ b/test_regress/t/t_array_query_with.pl
@@ -1,0 +1,22 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2022 by Antmicro Ltd. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    verilator_flags2 => ['--assert'],
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_array_query_with.v
+++ b/test_regress/t/t_array_query_with.v
@@ -1,0 +1,52 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2022 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+module t (/*AUTOARG*/
+      clk
+   );
+
+   input clk;
+
+   function bit test_find;
+      string bar[$];
+      string found[$];
+      bar.push_back("baz");
+      bar.push_back("qux");
+      found = bar.find(x) with (x == "baz");
+      return found.size() == 1;
+   endfunction
+
+   function bit test_find_index;
+      int    q[$] = {1, 2, 3, 4};
+      int    found[$] = q.find_index(x) with (x <= 2);
+      return found.size() == 2;
+   endfunction
+
+   function bit test_find_first_index;
+      int    q[] = {1, 2, 3, 4, 5, 6};
+      int    first_even_idx[$] = q.find_first_index(x) with (x % 2 == 0);
+      return first_even_idx[0] == 1;
+   endfunction
+
+   function bit test_sort;
+      int    q[] = {-5, 2, -3, 0, 4};
+      q.sort(x) with (x >= 0 ? x : -x);
+      return q[1] == 2;
+   endfunction
+
+   always @(posedge clk) begin
+      bit [3:0] results = {test_find(), test_find_index(),
+                           test_find_first_index(), test_sort()};
+      if (results == '1) begin
+         $write("*-* All Finished *-*\n");
+         $finish;
+      end
+      else begin
+         $write("Results: %b\n", results);
+         $stop;
+      end
+   end
+endmodule


### PR DESCRIPTION
Array query methods with `with` clause don't work when they are used in functions. It is because `AstWith` node isn't added to the symbol table when it is under a function (because children of functions aren't visited). Then `LinkDotResolveVisitor` expects that `AstWith` node is present in the symbol table.
I fixed it by adding the children iteration to functions. I think that the problem would occur also in other nodes that are added to the symbol table and may be both under a function and a module.