### PR TITLE
Disable stack size limit

### DIFF
--- a/bin/verilator
+++ b/bin/verilator
@@ -31,6 +31,7 @@ my $opt_gdb;
 my $opt_rr;
 my $opt_gdbbt;
 my $opt_quiet_exit;
+my $opt_unlimited_stack = 1;
 
 # No arguments can't do anything useful.  Give help
 if ($#ARGV < 0) {
@@ -49,16 +50,17 @@ foreach my $sw (@ARGV) {
 Getopt::Long::config("no_auto_abbrev", "pass_through");
 if (! GetOptions(
           # Major operating modes
-          "help"        => \&usage,
-          "debug"       => \&debug,
-          # "version!"  => \&version,   # Also passthru'ed
+          "help"             => \&usage,
+          "debug"            => \&debug,
+          # "version!"       => \&version,   # Also passthru'ed
           # Switches
-          "gdb!"        => \$opt_gdb,
-          "gdbbt!"      => \$opt_gdbbt,
-          "quiet-exit!" => \$opt_quiet_exit,
-          "rr!"         => \$opt_rr,
+          "gdb!"             => \$opt_gdb,
+          "gdbbt!"           => \$opt_gdbbt,
+          "quiet-exit!"      => \$opt_quiet_exit,
+          "rr!"              => \$opt_rr,
+          "unlimited-stack!" => \$opt_unlimited_stack,
           # Additional parameters
-          "<>"          => sub {},      # Ignored
+          "<>"               => sub {},      # Ignored
     )) {
     pod2usage(-exitstatus => 2, -verbose => 0);
 }
@@ -187,6 +189,9 @@ sub aslr_off {
 }
 
 sub ulimit_stack_unlimited {
+    if (!$opt_unlimited_stack) {
+        return "";
+    }
     system("ulimit -s unlimited 2>/dev/null");
     my $status = $?;
     if ($status == 0) {
@@ -436,6 +441,7 @@ detailed descriptions of these arguments.
     --trace-threads <threads>   Enable FST waveform creation on separate threads
     --trace-underscore          Enable tracing of _signals
      -U<var>                    Undefine preprocessor define
+    --no-unlimited-stack        Don't disable stack size limit
     --unroll-count <loops>      Tune maximum loop iterations
     --unroll-stmts <stmts>      Tune maximum loop body size
     --unused-regexp <regexp>    Tune UNUSED lint signals

--- a/bin/verilator
+++ b/bin/verilator
@@ -76,7 +76,8 @@ if ($opt_gdbbt && !gdb_works()) {
 my @quoted_sw = map { sh_escape($_) } @Opt_Verilator_Sw;
 if ($opt_gdb) {
     # Generic GDB interactive
-    run (aslr_off()
+    run (ulimit_stack_unlimited()
+         . aslr_off()
          . ($ENV{VERILATOR_GDB} || "gdb")
          . " " . verilator_bin()
          # Note, uncomment to set breakpoints before running:
@@ -92,12 +93,14 @@ if ($opt_gdb) {
          . " -ex 'bt'");
 } elsif ($opt_rr) {
     # Record with rr
-    run (aslr_off()
+    run (ulimit_stack_unlimited()
+         . aslr_off()
          . "rr record " . verilator_bin()
          . " " . join(' ', @quoted_sw));
 } elsif ($opt_gdbbt && $Debug) {
     # Run under GDB to get gdbbt
-    run (aslr_off()
+    run (ulimit_stack_unlimited()
+         . aslr_off()
          . "gdb"
          . " " . verilator_bin()
          . " --batch --quiet --return-child-result"
@@ -106,10 +109,13 @@ if ($opt_gdb) {
          . " -ex 'bt' -ex 'quit'");
 } elsif ($Debug) {
     # Debug
-    run(aslr_off() . verilator_bin() . " " . join(' ', @quoted_sw));
+    run(ulimit_stack_unlimited()
+        . aslr_off()
+        . verilator_bin()
+        . " " . join(' ', @quoted_sw));
 } else {
     # Normal, non gdb
-    run(verilator_bin() . " " . join(' ', @quoted_sw));
+    run(ulimit_stack_unlimited() . verilator_bin() . " " . join(' ', @quoted_sw));
 }
 
 #----------------------------------------------------------------------
@@ -175,6 +181,16 @@ sub aslr_off {
     my $ok = `setarch --addr-no-randomize echo ok 2>/dev/null` || "";
     if ($ok =~ /ok/) {
         return "setarch --addr-no-randomize ";
+    } else {
+        return "";
+    }
+}
+
+sub ulimit_stack_unlimited {
+    system("ulimit -s unlimited 2>/dev/null");
+    my $status = $?;
+    if ($status == 0) {
+        return "ulimit -s unlimited 2>/dev/null; exec ";
     } else {
         return "";
     }

--- a/bin/verilator
+++ b/bin/verilator
@@ -189,9 +189,7 @@ sub aslr_off {
 }
 
 sub ulimit_stack_unlimited {
-    if (!$opt_unlimited_stack) {
-        return "";
-    }
+    return "" if !$opt_unlimited_stack;
     system("ulimit -s unlimited 2>/dev/null");
     my $status = $?;
     if ($status == 0) {

--- a/docs/guide/exe_verilator.rst
+++ b/docs/guide/exe_verilator.rst
@@ -1380,6 +1380,11 @@ Summary:
 
    Undefines the given preprocessor symbol.
 
+.. option:: --no-unlimited-stack
+
+   Verilator tries to disable stack size limit using
+   :command:`ulimit -s unlimited` command. This option turns this behavior off.
+
 .. option:: --unroll-count <loops>
 
    Rarely needed.  Specifies the maximum number of loop iterations that may be

--- a/src/V3Options.cpp
+++ b/src/V3Options.cpp
@@ -1465,6 +1465,7 @@ void V3Options::parseOptsList(FileLine* fl, const string& optdir, int argc, char
 
     DECL_OPTION("-U", CbPartialMatch, &V3PreShell::undef);
     DECL_OPTION("-underline-zero", OnOff, &m_underlineZero);  // Deprecated
+    DECL_OPTION("-no-unlimited-stack", CbCall, []() {});  // Processed only in bin/verilator shell
     DECL_OPTION("-unroll-count", Set, &m_unrollCount).undocumented();  // Optimization tweak
     DECL_OPTION("-unroll-stmts", Set, &m_unrollStmts).undocumented();  // Optimization tweak
     DECL_OPTION("-unused-regexp", Set, &m_unusedRegexp);

--- a/test_regress/t/t_flag_no_unlimited_stack.pl
+++ b/test_regress/t/t_flag_no_unlimited_stack.pl
@@ -1,0 +1,19 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2022 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(vlt => 1);
+
+# Just check whether the flag is recognized.
+lint(
+    verilator_flags2 => ["--no-unlimited-stack"],
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_flag_no_unlimited_stack.v
+++ b/test_regress/t/t_flag_no_unlimited_stack.v
@@ -1,0 +1,8 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2005 by Wilson Snyder.
+// SPDX-License-Identifier: CC0-1.0
+
+module t (/*AUTOARG*/);
+endmodule


### PR DESCRIPTION
Run `ulimit -s unlimited` (if supported) before running `verilator_bin`.

Requested in https://github.com/verilator/verilator/pull/3706