### PR TITLE
CI: Switch building pull requests to ubuntu 22.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,13 +35,13 @@ jobs:
           - { cc: gcc,   cxx: g++     }
         m32: [0, 1]
         exclude:
-          # Build pull requests only with ubuntu-20.04 and without m32
+          # Build pull requests only with ubuntu-22.04 and without m32
           - os:  ${{ github.event_name == 'pull_request' && 'ubuntu-18.04' || 'do-not-exclude' }}
-          - os:  ${{ github.event_name == 'pull_request' && 'ubuntu-22.04' || 'do-not-exclude' }}
+          - os:  ${{ github.event_name == 'pull_request' && 'ubuntu-20.04' || 'do-not-exclude' }}
           - m32: ${{ github.event_name == 'pull_request' && 1              || 'do-not-exclude' }}
-          # Build -m32 only on ubuntu-20.04
+          # Build -m32 only on ubuntu-22.04
           - {os: ubuntu-18.04, m32: 1}
-          - {os: ubuntu-22.04, m32: 1}
+          - {os: ubuntu-20.04, m32: 1}
         include:
           # Build GCC 10 on ubuntu-20.04
           - os: ubuntu-20.04
@@ -104,13 +104,13 @@ jobs:
         m32: [0, 1]
         suite: [dist-vlt-0, dist-vlt-1, dist-vlt-2, vltmt-0, vltmt-1]
         exclude:
-          # Build pull requests only with ubuntu-20.04 and without m32
+          # Build pull requests only with ubuntu-22.04 and without m32
           - os:  ${{ github.event_name == 'pull_request' && 'ubuntu-18.04' || 'do-not-exclude' }}
-          - os:  ${{ github.event_name == 'pull_request' && 'ubuntu-22.04' || 'do-not-exclude' }}
+          - os:  ${{ github.event_name == 'pull_request' && 'ubuntu-20.04' || 'do-not-exclude' }}
           - m32: ${{ github.event_name == 'pull_request' && 1              || 'do-not-exclude' }}
-          # Build -m32 only on ubuntu-20.04
+          # Build -m32 only on ubuntu-22.04
           - {os: ubuntu-18.04, m32: 1}
-          - {os: ubuntu-22.04, m32: 1}
+          - {os: ubuntu-20.04, m32: 1}
         include:
           # Test with GCC 10 on ubuntu-20.04 without m32
           - {os: ubuntu-20.04, compiler: { cc: gcc-10, cxx: g++-10 }, m32: 0, suite: dist-vlt-0}


### PR DESCRIPTION
This PR switches to use ``ubuntu 22.04`` instead of ``ubuntu 20.04`` in PRs. I still left building on ``ubuntu 20.04`` using ``gcc-10`` in PRs.

Signed-off-by: Kamil Rakoczy <krakoczy@antmicro.com>
