### PR TITLE
Use dollar unit package as upper symbol scope for other packages

### DIFF
--- a/src/V3LinkDot.cpp
+++ b/src/V3LinkDot.cpp
@@ -868,7 +868,6 @@ class LinkDotFindVisitor final : public VNVisitor {
         } else if (doit) {
             UINFO(4, "     Link Module: " << nodep << endl);
             UASSERT_OBJ(!nodep->dead(), nodep, "Module in instance tree mislabeled as dead?");
-            VSymEnt* const upperSymp = m_curSymp ? m_curSymp : m_statep->rootEntp();
             AstPackage* const pkgp = VN_CAST(nodep, Package);
             m_classOrPackagep = pkgp;
             if (standalonePkg) {
@@ -876,6 +875,7 @@ class LinkDotFindVisitor final : public VNVisitor {
                     m_curSymp = m_modSymp = m_statep->dunitEntp();
                     nodep->user1p(m_curSymp);
                 } else {
+                    VSymEnt* const upperSymp = m_statep->dunitEntp();
                     m_scope = nodep->name();
                     m_curSymp = m_modSymp = m_statep->insertBlock(
                         upperSymp, nodep->name() + "::", nodep, m_classOrPackagep);

--- a/test_regress/t/t_pkg_using_dollar_unit_items.pl
+++ b/test_regress/t/t_pkg_using_dollar_unit_items.pl
@@ -1,0 +1,20 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2022 by Antmicro Ltd. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile();
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_pkg_using_dollar_unit_items.v
+++ b/test_regress/t/t_pkg_using_dollar_unit_items.v
@@ -1,0 +1,62 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2022 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+typedef int my_type;
+
+class my_class;
+   static int a = 1;
+endclass
+
+function int get_val;
+   return 2;
+endfunction
+
+package my_pkg;
+   int      my_type_size = $bits(my_type);
+   int      my_class_a = my_class::a;
+   int      get_val_result = get_val();
+endpackage
+
+package overwriting_pkg;
+   typedef logic [9:0] my_type;
+
+   class my_class;
+      static int a = 2;
+   endclass
+
+   function int get_val;
+      return 3;
+   endfunction
+
+   int      my_type_size = $bits(my_type);
+   int      my_class_a = my_class::a;
+   int      get_val_result = get_val();
+endpackage
+
+module t (/*AUTOARG*/
+      clk
+   );
+
+   input clk;
+
+   always @(posedge clk) begin
+      bit [5:0] results = {my_pkg::my_type_size == 32,
+                           my_pkg::my_class_a == 1,
+                           my_pkg::get_val_result == 2,
+                           overwriting_pkg::my_type_size == 10,
+                           overwriting_pkg::my_class_a == 2,
+                           overwriting_pkg::get_val_result == 3};
+
+      if (results == '1) begin
+         $write("*-* All Finished *-*\n");
+         $finish;
+      end
+      else begin
+         $write("Results: %b\n", results);
+         $stop;
+      end
+   end
+endmodule


### PR DESCRIPTION
Referencing things defined outside the current package currently doesn't work on master. The problem is only with references in packages. As I checked, it works properly in modules.
This PR fixes it. It adds `$unit` package as a scope above the current package.