### PR TITLE
Corrected golden reference for t_process_std-test

### DIFF
--- a/test_regress/t/t_process_std.out
+++ b/test_regress/t/t_process_std.out
@@ -1,11 +1,10 @@
-%Error: t/t_process.pl:1:1: syntax error, unexpected '#'
-    1 | #!/usr/bin/env perl
-      | ^
-%Error-UNSUPPORTED: t/t_process.pl:2:19: Unsupported: Verilog 2001-config reserved word not implemented: 'use'
-    2 | if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
-      |                   ^~~
+%Error: t/t_process.v:22:4: Can't find typedef: 'process'
+   22 |    process p;
+      |    ^~~~~~~
+%Error-UNSUPPORTED: t/t_process.v:26:20: Unsupported: 'process'
+   26 |       p = process::self();
+      |                    ^~~~
                     ... For error description see https://verilator.org/warn/UNSUPPORTED?v=latest
-%Error-UNSUPPORTED: t/t_process.pl:3:47: Unsupported: SystemVerilog 2005 reserved word not implemented: 'expect'
-    3 | # DESCRIPTION: Verilator: Verilog Test driver/expect definition
-      |                                               ^~~~~~
-%Error: Exiting due to
+%Error: Internal Error: t/t_process.v:26:11: ../V3LinkDot.cpp:#: Bad package link
+   26 |       p = process::self();
+      |           ^~~~~~~

--- a/test_regress/t/t_process_std.pl
+++ b/test_regress/t/t_process_std.pl
@@ -10,7 +10,7 @@ if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); di
 
 scenarios(simulator => 1);
 
-top_filename("t/t_process.pl");
+top_filename("t/t_process.v");
 
 compile(
     v_flags2 => ["+define+T_PROCESS+std::process"],


### PR DESCRIPTION
t_process_std.pl wrongly verilated the perl-file itself instead of the verilog file.

