### PR TITLE
Strengthen AstNode types to AstNodeExpr

### DIFF
--- a/src/V3Assert.cpp
+++ b/src/V3Assert.cpp
@@ -59,8 +59,8 @@ private:
         nodep->displayType(VDisplayType::DT_WRITE);
         nodep->fmtp()->text(assertDisplayMessage(nodep, prefix, nodep->fmtp()->text()));
         // cppcheck-suppress nullPointer
-        AstNode* const timenewp = new AstTime{nodep->fileline(), m_modp->timeunit()};
-        if (AstNode* const timesp = nodep->fmtp()->exprsp()) {
+        AstNodeExpr* const timenewp = new AstTime{nodep->fileline(), m_modp->timeunit()};
+        if (AstNodeExpr* const timesp = nodep->fmtp()->exprsp()) {
             timesp->unlinkFrBackWithNext();
             timenewp->addNext(timesp);
         }
@@ -69,7 +69,7 @@ private:
             nodep->fmtp()->scopeNamep(new AstScopeName{nodep->fileline(), true});
         }
     }
-    AstSampled* newSampledExpr(AstNode* nodep) {
+    AstSampled* newSampledExpr(AstNodeExpr* nodep) {
         const auto sampledp = new AstSampled{nodep->fileline(), nodep};
         sampledp->dtypeFrom(nodep);
         return sampledp;
@@ -98,16 +98,16 @@ private:
         // Add a internal if to check assertions are on.
         // Don't make this a AND term, as it's unlikely to need to test this.
         FileLine* const fl = nodep->fileline();
-        AstNodeIf* const newp = new AstIf{
-            fl,
-            (force ? new AstConst{fl, AstConst::BitTrue{}}
-                   :  // If assertions are off, have constant propagation rip them out later
-                 // This allows syntax errors and such to be detected normally.
-                 (v3Global.opt.assertOn()
-                      ? static_cast<AstNode*>(
-                          new AstCExpr{fl, "vlSymsp->_vm_contextp__->assertOn()", 1})
-                      : static_cast<AstNode*>(new AstConst{fl, AstConst::BitFalse{}}))),
-            nodep};
+
+        // If assertions are off, have constant propagation rip them out later
+        // This allows syntax errors and such to be detected normally.
+        AstNodeExpr* const condp
+            = force ? static_cast<AstNodeExpr*>(new AstConst{fl, AstConst::BitTrue{}})
+              : v3Global.opt.assertOn()
+                  ? static_cast<AstNodeExpr*>(
+                      new AstCExpr{fl, "vlSymsp->_vm_contextp__->assertOn()", 1})
+                  : static_cast<AstNodeExpr*>(new AstConst{fl, AstConst::BitFalse{}});
+        AstNodeIf* const newp = new AstIf{fl, condp, nodep};
         newp->isBoundsCheck(true);  // To avoid LATCH warning
         newp->user1(true);  // Don't assert/cover this if
         return newp;
@@ -133,7 +133,7 @@ private:
     void newPslAssertion(AstNodeCoverOrAssert* nodep, AstNode* failsp) {
         if (m_beginp && nodep->name() == "") nodep->name(m_beginp->name());
 
-        AstNode* const propp = nodep->propp()->unlinkFrBackWithNext();
+        AstNodeExpr* const propp = VN_AS(nodep->propp()->unlinkFrBackWithNext(), NodeExpr);
         AstSenTree* const sentreep = nodep->sentreep();
         const string& message = nodep->name();
         AstNode* passsp = nodep->passsp();
@@ -211,7 +211,7 @@ private:
         if (nodep->user1SetOnce()) return;
         if (nodep->uniquePragma() || nodep->unique0Pragma()) {
             const AstNodeIf* ifp = nodep;
-            AstNode* propp = nullptr;
+            AstNodeExpr* propp = nullptr;
             bool hasDefaultElse = false;
             do {
                 // If this statement ends with 'else if', then nextIf will point to the
@@ -228,7 +228,7 @@ private:
                 }
 
                 // Build a bitmask of the true predicates
-                AstNode* const predp = ifp->condp()->cloneTree(false);
+                AstNodeExpr* const predp = ifp->condp()->cloneTree(false);
                 if (propp) {
                     propp = new AstConcat{nodep->fileline(), predp, propp};
                 } else {
@@ -249,10 +249,10 @@ private:
 
             // Note: if this ends with an 'else', then we don't need to validate that one of the
             // predicates evaluates to true.
-            AstNode* const ohot
+            AstNodeExpr* const ohot
                 = ((allow_none || hasDefaultElse)
-                       ? static_cast<AstNode*>(new AstOneHot0{nodep->fileline(), propp})
-                       : static_cast<AstNode*>(new AstOneHot{nodep->fileline(), propp}));
+                       ? static_cast<AstNodeExpr*>(new AstOneHot0{nodep->fileline(), propp})
+                       : static_cast<AstNodeExpr*>(new AstOneHot{nodep->fileline(), propp}));
             AstIf* const checkifp
                 = new AstIf{nodep->fileline(), new AstLogNot{nodep->fileline(), ohot},
                             newFireAssert(nodep, "'unique if' statement violated"), newifp};
@@ -290,11 +290,12 @@ private:
                 if (!has_default && !nodep->itemsp()) {
                     // Not parallel, but harmlessly so.
                 } else {
-                    AstNode* propp = nullptr;
+                    AstNodeExpr* propp = nullptr;
                     for (AstCaseItem* itemp = nodep->itemsp(); itemp;
                          itemp = VN_AS(itemp->nextp(), CaseItem)) {
-                        for (AstNode* icondp = itemp->condsp(); icondp; icondp = icondp->nextp()) {
-                            AstNode* onep;
+                        for (AstNodeExpr* icondp = itemp->condsp(); icondp;
+                             icondp = VN_AS(icondp->nextp(), NodeExpr)) {
+                            AstNodeExpr* onep;
                             if (AstInsideRange* const rcondp = VN_CAST(icondp, InsideRange)) {
                                 onep = rcondp->newAndFromInside(nodep->exprp(),
                                                                 rcondp->lhsp()->cloneTree(true),
@@ -319,10 +320,11 @@ private:
                     if (!propp) propp = new AstConst{nodep->fileline(), AstConst::BitFalse{}};
 
                     const bool allow_none = has_default || nodep->unique0Pragma();
-                    AstNode* const ohot
-                        = (allow_none
-                               ? static_cast<AstNode*>(new AstOneHot0{nodep->fileline(), propp})
-                               : static_cast<AstNode*>(new AstOneHot{nodep->fileline(), propp}));
+                    AstNodeExpr* const ohot
+                        = (allow_none ? static_cast<AstNodeExpr*>(
+                               new AstOneHot0{nodep->fileline(), propp})
+                                      : static_cast<AstNodeExpr*>(
+                                          new AstOneHot{nodep->fileline(), propp}));
                     AstIf* const ifp = new AstIf{
                         nodep->fileline(), new AstLogNot{nodep->fileline(), ohot},
                         newFireAssert(nodep,
@@ -345,8 +347,8 @@ private:
             ticks = VN_AS(nodep->ticksp(), Const)->toUInt();
         }
         UASSERT_OBJ(ticks >= 1, nodep, "0 tick should have been checked in V3Width");
-        AstNode* const exprp = nodep->exprp()->unlinkFrBack();
-        AstNode* inp = newSampledExpr(exprp);
+        AstNodeExpr* const exprp = nodep->exprp()->unlinkFrBack();
+        AstNodeExpr* inp = newSampledExpr(exprp);
         AstVar* invarp = nullptr;
         AstSenTree* const sentreep = nodep->sentreep();
         sentreep->unlinkFrBack();

--- a/src/V3AssertPre.cpp
+++ b/src/V3AssertPre.cpp
@@ -46,7 +46,7 @@ private:
     // Reset each always:
     AstSenItem* m_seniAlwaysp = nullptr;  // Last sensitivity in always
     // Reset each assertion:
-    AstNode* m_disablep = nullptr;  // Last disable
+    AstNodeExpr* m_disablep = nullptr;  // Last disable
 
     // METHODS
 
@@ -113,7 +113,7 @@ private:
                 }
                 // If disable iff is in outer property, move it to inner
                 if (nodep->disablep()) {
-                    AstNode* const disablep = nodep->disablep()->unlinkFrBack();
+                    AstNodeExpr* const disablep = nodep->disablep()->unlinkFrBack();
                     propExprp->disablep(disablep);
                 }
 
@@ -170,9 +170,9 @@ private:
         if (nodep->sentreep()) return;  // Already processed
         iterateChildren(nodep);
         FileLine* const fl = nodep->fileline();
-        AstNode* exprp = nodep->exprp()->unlinkFrBack();
+        AstNodeExpr* exprp = nodep->exprp()->unlinkFrBack();
         if (exprp->width() > 1) exprp = new AstSel(fl, exprp, 0, 1);
-        AstNode* const past = new AstPast(fl, exprp, nullptr);
+        AstNodeExpr* const past = new AstPast(fl, exprp, nullptr);
         past->dtypeFrom(exprp);
         exprp = new AstAnd(fl, past, new AstNot(fl, exprp->cloneTree(false)));
         exprp->dtypeSetBit();
@@ -189,9 +189,9 @@ private:
         if (nodep->sentreep()) return;  // Already processed
         iterateChildren(nodep);
         FileLine* const fl = nodep->fileline();
-        AstNode* exprp = nodep->exprp()->unlinkFrBack();
+        AstNodeExpr* exprp = nodep->exprp()->unlinkFrBack();
         if (exprp->width() > 1) exprp = new AstSel(fl, exprp, 0, 1);
-        AstNode* const past = new AstPast(fl, exprp, nullptr);
+        AstNodeExpr* const past = new AstPast(fl, exprp, nullptr);
         past->dtypeFrom(exprp);
         exprp = new AstAnd(fl, new AstNot(fl, past), exprp->cloneTree(false));
         exprp->dtypeSetBit();
@@ -203,8 +203,8 @@ private:
         if (nodep->sentreep()) return;  // Already processed
         iterateChildren(nodep);
         FileLine* const fl = nodep->fileline();
-        AstNode* exprp = nodep->exprp()->unlinkFrBack();
-        AstNode* const past = new AstPast(fl, exprp, nullptr);
+        AstNodeExpr* exprp = nodep->exprp()->unlinkFrBack();
+        AstNodeExpr* const past = new AstPast(fl, exprp, nullptr);
         past->dtypeFrom(exprp);
         exprp = new AstEq(fl, past, exprp->cloneTree(false));
         exprp->dtypeSetBit();
@@ -217,14 +217,14 @@ private:
         if (nodep->sentreep()) return;  // Already processed
 
         FileLine* const fl = nodep->fileline();
-        AstNode* const rhsp = nodep->rhsp()->unlinkFrBack();
-        AstNode* lhsp = nodep->lhsp()->unlinkFrBack();
+        AstNodeExpr* const rhsp = nodep->rhsp()->unlinkFrBack();
+        AstNodeExpr* lhsp = nodep->lhsp()->unlinkFrBack();
 
         if (m_disablep) lhsp = new AstAnd(fl, new AstNot(fl, m_disablep), lhsp);
 
-        AstNode* const past = new AstPast(fl, lhsp, nullptr);
+        AstNodeExpr* const past = new AstPast(fl, lhsp, nullptr);
         past->dtypeFrom(lhsp);
-        AstNode* const exprp = new AstOr(fl, new AstNot(fl, past), rhsp);
+        AstNodeExpr* const exprp = new AstOr(fl, new AstNot(fl, past), rhsp);
         exprp->dtypeSetBit();
         nodep->replaceWith(exprp);
         nodep->sentreep(newSenTree(nodep));
@@ -238,8 +238,8 @@ private:
         if (m_senip)
             nodep->v3warn(E_UNSUPPORTED, "Unsupported: Only one PSL clock allowed per assertion");
         // Block is the new expression to evaluate
-        AstNode* blockp = nodep->propp()->unlinkFrBack();
-        if (AstNode* const disablep = nodep->disablep()) {
+        AstNodeExpr* blockp = VN_AS(nodep->propp()->unlinkFrBack(), NodeExpr);
+        if (AstNodeExpr* const disablep = nodep->disablep()) {
             m_disablep = disablep->cloneTree(false);
             if (VN_IS(nodep->backp(), Cover)) {
                 blockp = new AstAnd(disablep->fileline(),

--- a/src/V3Ast.h
+++ b/src/V3Ast.h
@@ -1877,8 +1877,8 @@ public:
     void addNextHere(AstNode* newp);  // Insert newp at this->nextp
     void addHereThisAsNext(AstNode* newp);  // Adds at old place of this, this becomes next
     void replaceWith(AstNode* newp);  // Replace current node in tree with new node
-    AstNode* unlinkFrBack(VNRelinker* linkerp
-                          = nullptr);  // Unlink this from whoever points to it.
+    // Unlink this from whoever points to it.
+    AstNode* unlinkFrBack(VNRelinker* linkerp = nullptr);
     // Unlink this from whoever points to it, keep entire next list with unlinked node
     AstNode* unlinkFrBackWithNext(VNRelinker* linkerp = nullptr);
     void swapWith(AstNode* bp);

--- a/src/V3AstInlines.h
+++ b/src/V3AstInlines.h
@@ -130,7 +130,7 @@ bool AstBasicDType::littleEndian() const {
 bool AstActive::hasClocked() const { return m_sensesp->hasClocked(); }
 bool AstActive::hasCombo() const { return m_sensesp->hasCombo(); }
 
-AstElabDisplay::AstElabDisplay(FileLine* fl, VDisplayType dispType, AstNode* exprsp)
+AstElabDisplay::AstElabDisplay(FileLine* fl, VDisplayType dispType, AstNodeExpr* exprsp)
     : ASTGEN_SUPER_ElabDisplay(fl) {
     addFmtp(new AstSFormatF{fl, AstSFormatF::NoFormat(), exprsp});
     m_displayType = dispType;

--- a/src/V3AstNodeDType.h
+++ b/src/V3AstNodeDType.h
@@ -261,13 +261,13 @@ public:
 // === AstNode ===
 class AstEnumItem final : public AstNode {
     // @astgen op1 := rangep : Optional[AstRange] // Range for name appending
-    // @astgen op2 := valuep : Optional[AstNode]
+    // @astgen op2 := valuep : Optional[AstNodeExpr]
 private:
     string m_name;
 
 public:
     // Parents: ENUM
-    AstEnumItem(FileLine* fl, const string& name, AstRange* rangep, AstNode* valuep)
+    AstEnumItem(FileLine* fl, const string& name, AstRange* rangep, AstNodeExpr* valuep)
         : ASTGEN_SUPER_EnumItem(fl)
         , m_name{name} {
         this->rangep(rangep);
@@ -972,18 +972,18 @@ public:
 class AstQueueDType final : public AstNodeDType {
     // Queue array data type, ie "[ $ ]"
     // @astgen op1 := childDTypep : Optional[AstNodeDType] // moved to refDTypep() in V3Width
-    // @astgen op2 := boundp : Optional[AstNode]
+    // @astgen op2 := boundp : Optional[AstNodeExpr]
 private:
     AstNodeDType* m_refDTypep = nullptr;  // Elements of this type (after widthing)
 public:
-    AstQueueDType(FileLine* fl, VFlagChildDType, AstNodeDType* dtp, AstNode* boundp)
+    AstQueueDType(FileLine* fl, VFlagChildDType, AstNodeDType* dtp, AstNodeExpr* boundp)
         : ASTGEN_SUPER_QueueDType(fl) {
         this->childDTypep(dtp);
         this->boundp(boundp);
         refDTypep(nullptr);
         dtypep(nullptr);  // V3Width will resolve
     }
-    AstQueueDType(FileLine* fl, AstNodeDType* dtp, AstNode* boundp)
+    AstQueueDType(FileLine* fl, AstNodeDType* dtp, AstNodeExpr* boundp)
         : ASTGEN_SUPER_QueueDType(fl) {
         this->boundp(boundp);
         refDTypep(dtp);
@@ -1032,7 +1032,7 @@ public:
 };
 class AstRefDType final : public AstNodeDType {
     // @astgen op1 := typeofp : Optional[AstNode]
-    // @astgen op2 := classOrPackageOpp : Optional[AstNode]
+    // @astgen op2 := classOrPackageOpp : Optional[AstNodeExpr]
     // @astgen op3 := paramsp : List[AstPin]
 private:
     // Pre-Width must reference the Typeref, not what it points to, as some child
@@ -1046,7 +1046,7 @@ public:
     AstRefDType(FileLine* fl, const string& name)
         : ASTGEN_SUPER_RefDType(fl)
         , m_name{name} {}
-    AstRefDType(FileLine* fl, const string& name, AstNode* classOrPackagep, AstPin* paramsp)
+    AstRefDType(FileLine* fl, const string& name, AstNodeExpr* classOrPackagep, AstPin* paramsp)
         : ASTGEN_SUPER_RefDType(fl)
         , m_name{name} {
         this->classOrPackageOpp(classOrPackagep);

--- a/src/V3AstNodes.cpp
+++ b/src/V3AstNodes.cpp
@@ -252,7 +252,7 @@ int AstNodeUOrStructDType::widthAlignBytes() const {
     }
 }
 
-AstNodeBiop* AstEq::newTyped(FileLine* fl, AstNode* lhsp, AstNode* rhsp) {
+AstNodeBiop* AstEq::newTyped(FileLine* fl, AstNodeExpr* lhsp, AstNodeExpr* rhsp) {
     if (lhsp->isString() && rhsp->isString()) {
         return new AstEqN(fl, lhsp, rhsp);
     } else if (lhsp->isDouble() && rhsp->isDouble()) {
@@ -262,7 +262,7 @@ AstNodeBiop* AstEq::newTyped(FileLine* fl, AstNode* lhsp, AstNode* rhsp) {
     }
 }
 
-AstNodeBiop* AstEqWild::newTyped(FileLine* fl, AstNode* lhsp, AstNode* rhsp) {
+AstNodeBiop* AstEqWild::newTyped(FileLine* fl, AstNodeExpr* lhsp, AstNodeExpr* rhsp) {
     if (lhsp->isString() && rhsp->isString()) {
         return new AstEqN(fl, lhsp, rhsp);
     } else if (lhsp->isDouble() && rhsp->isDouble()) {
@@ -279,13 +279,13 @@ AstExecGraph::AstExecGraph(FileLine* fileline, const string& name)
 
 AstExecGraph::~AstExecGraph() { VL_DO_DANGLING(delete m_depGraphp, m_depGraphp); }
 
-AstNode* AstInsideRange::newAndFromInside(AstNode* exprp, AstNode* lhsp, AstNode* rhsp) {
-    AstNode* const ap = new AstGte(fileline(), exprp->cloneTree(true), lhsp);
-    AstNode* const bp = new AstLte(fileline(), exprp->cloneTree(true), rhsp);
+AstNodeExpr* AstInsideRange::newAndFromInside(AstNodeExpr* exprp, AstNodeExpr* lhsp,
+                                              AstNodeExpr* rhsp) {
+    AstNodeExpr* const ap = new AstGte{fileline(), exprp->cloneTree(true), lhsp};
+    AstNodeExpr* const bp = new AstLte{fileline(), exprp->cloneTree(true), rhsp};
     ap->fileline()->modifyWarnOff(V3ErrorCode::UNSIGNED, true);
     bp->fileline()->modifyWarnOff(V3ErrorCode::CMPCONST, true);
-    AstNode* const newp = new AstAnd(fileline(), ap, bp);
-    return newp;
+    return new AstAnd(fileline(), ap, bp);
 }
 
 AstConst* AstConst::parseParamLiteral(FileLine* fl, const string& literal) {
@@ -1122,7 +1122,7 @@ const char* AstConstPool::broken() const {
     return nullptr;
 }
 
-AstVarScope* AstConstPool::createNewEntry(const string& name, AstNode* initp) {
+AstVarScope* AstConstPool::createNewEntry(const string& name, AstNodeExpr* initp) {
     FileLine* const fl = initp->fileline();
     AstVar* const varp = new AstVar(fl, VVarType::MODULETEMP, name, initp->dtypep());
     varp->isConst(true);
@@ -1575,7 +1575,7 @@ void AstInitArray::cloneRelink() {
         if (it->second->clonep()) it->second = it->second->clonep();
     }
 }
-void AstInitArray::addIndexValuep(uint64_t index, AstNode* newp) {
+void AstInitArray::addIndexValuep(uint64_t index, AstNodeExpr* newp) {
     const auto it = m_map.find(index);
     if (it != m_map.end()) {
         it->second->valuep(newp);
@@ -1585,7 +1585,7 @@ void AstInitArray::addIndexValuep(uint64_t index, AstNode* newp) {
         addInitsp(itemp);
     }
 }
-AstNode* AstInitArray::getIndexValuep(uint64_t index) const {
+AstNodeExpr* AstInitArray::getIndexValuep(uint64_t index) const {
     const auto it = m_map.find(index);
     if (it == m_map.end()) {
         return nullptr;
@@ -1593,8 +1593,8 @@ AstNode* AstInitArray::getIndexValuep(uint64_t index) const {
         return it->second->valuep();
     }
 }
-AstNode* AstInitArray::getIndexDefaultedValuep(uint64_t index) const {
-    AstNode* valuep = getIndexValuep(index);
+AstNodeExpr* AstInitArray::getIndexDefaultedValuep(uint64_t index) const {
+    AstNodeExpr* valuep = getIndexValuep(index);
     if (!valuep) valuep = defaultp();
     return valuep;
 }
@@ -2302,8 +2302,8 @@ void AstCUse::dump(std::ostream& str) const {
 
 AstAlways* AstAssignW::convertToAlways() {
     const bool hasTimingControl = isTimingControl();
-    AstNode* const lhs1p = lhsp()->unlinkFrBack();
-    AstNode* const rhs1p = rhsp()->unlinkFrBack();
+    AstNodeExpr* const lhs1p = lhsp()->unlinkFrBack();
+    AstNodeExpr* const rhs1p = rhsp()->unlinkFrBack();
     AstNode* const controlp = timingControlp() ? timingControlp()->unlinkFrBack() : nullptr;
     FileLine* const flp = fileline();
     AstNode* bodysp = new AstAssign{flp, lhs1p, rhs1p, controlp};

--- a/src/V3CCtors.cpp
+++ b/src/V3CCtors.cpp
@@ -152,7 +152,7 @@ void V3CCtors::evalAsserts() {
                         AstVarRef* const vrefp
                             = new AstVarRef{varp->fileline(), varp, VAccess::READ};
                         vrefp->selfPointer("this");
-                        AstNode* newp = vrefp;
+                        AstNodeExpr* newp = vrefp;
                         if (varp->isWide()) {
                             newp = new AstWordSel{
                                 varp->fileline(), newp,
@@ -167,8 +167,7 @@ void V3CCtors::evalAsserts() {
                             new AstCStmt{varp->fileline(), "Verilated::overWidthError(\""
                                                                + varp->prettyName() + "\");"}};
                         ifp->branchPred(VBranchPred::BP_UNLIKELY);
-                        newp = ifp;
-                        funcp->addStmtsp(newp);
+                        funcp->addStmtsp(ifp);
                     }
                 }
             }

--- a/src/V3Cast.cpp
+++ b/src/V3Cast.cpp
@@ -63,7 +63,7 @@ private:
 
     // METHODS
 
-    void insertCast(AstNode* nodep, int needsize) {  // We'll insert ABOVE passed node
+    void insertCast(AstNodeExpr* nodep, int needsize) {  // We'll insert ABOVE passed node
         UINFO(4, "  NeedCast " << nodep << endl);
         VNRelinker relinkHandle;
         nodep->unlinkFrBack(&relinkHandle);
@@ -87,7 +87,7 @@ private:
             return VL_IDATASIZE;
         }
     }
-    void ensureCast(AstNode* nodep) {
+    void ensureCast(AstNodeExpr* nodep) {
         if (castSize(nodep->backp()) != castSize(nodep) || !nodep->user1()) {
             insertCast(nodep, castSize(nodep->backp()));
         }
@@ -101,13 +101,12 @@ private:
             insertCast(nodep->lhsp(), VL_IDATASIZE);
         }
     }
-    void ensureNullChecked(AstNode* nodep) {
+    void ensureNullChecked(AstNodeExpr* nodep) {
         // TODO optimize to track null checked values and avoid where possible
         if (!VN_IS(nodep->backp(), NullCheck)) {
             VNRelinker relinkHandle;
             nodep->unlinkFrBack(&relinkHandle);
-            AstNode* const newp = new AstNullCheck{nodep->fileline(), nodep};
-            relinkHandle.relink(newp);
+            relinkHandle.relink(new AstNullCheck{nodep->fileline(), nodep});
         }
     }
 

--- a/src/V3Common.cpp
+++ b/src/V3Common.cpp
@@ -42,7 +42,8 @@ static void makeVlToString(AstClass* nodep) {
     funcp->isConst(false);
     funcp->isStatic(false);
     funcp->protect(false);
-    AstNode* const exprp = new AstCExpr{nodep->fileline(), "obj ? obj->to_string() : \"null\"", 0};
+    AstNodeExpr* const exprp
+        = new AstCExpr{nodep->fileline(), "obj ? obj->to_string() : \"null\"", 0};
     exprp->dtypeSetString();
     funcp->addStmtsp(new AstCReturn{nodep->fileline(), exprp});
     nodep->addStmtsp(funcp);
@@ -55,7 +56,7 @@ static void makeVlToString(AstIface* nodep) {
     funcp->isConst(false);
     funcp->isStatic(false);
     funcp->protect(false);
-    AstNode* const exprp = new AstCExpr{nodep->fileline(), "obj ? obj->name() : \"null\"", 0};
+    AstNodeExpr* const exprp = new AstCExpr{nodep->fileline(), "obj ? obj->name() : \"null\"", 0};
     exprp->dtypeSetString();
     funcp->addStmtsp(new AstCReturn{nodep->fileline(), exprp});
     nodep->addStmtsp(funcp);
@@ -65,7 +66,7 @@ static void makeToString(AstClass* nodep) {
     funcp->isConst(true);
     funcp->isStatic(false);
     funcp->protect(false);
-    AstNode* const exprp
+    AstCExpr* const exprp
         = new AstCExpr{nodep->fileline(), R"(std::string{"'{"} + to_string_middle() + "}")", 0};
     exprp->dtypeSetString();
     funcp->addStmtsp(new AstCReturn{nodep->fileline(), exprp});

--- a/src/V3Const.h
+++ b/src/V3Const.h
@@ -20,14 +20,16 @@
 #include "config_build.h"
 #include "verilatedos.h"
 
-class AstNetlist;
-class AstNode;
+#include "V3Ast.h"
 
 //============================================================================
 
 class V3Const final {
 public:
     static AstNode* constifyParamsEdit(AstNode* nodep);
+    static AstNodeExpr* constifyParamsEdit(AstNodeExpr* exprp) {
+        return VN_AS(constifyParamsEdit(static_cast<AstNode*>(exprp)), NodeExpr);
+    }
     static AstNode* constifyGenerateParamsEdit(AstNode* nodep);
     // Only do constant pushing, without removing dead logic
     static void constifyAllLive(AstNetlist* nodep);
@@ -40,9 +42,15 @@ public:
     // Only the current node and lower
     // Return new node that may have replaced nodep
     static AstNode* constifyEditCpp(AstNode* nodep);
+    static AstNodeExpr* constifyEditCpp(AstNodeExpr* exprp) {
+        return VN_AS(constifyEditCpp(static_cast<AstNode*>(exprp)), NodeExpr);
+    }
     // Only the current node and lower
     // Return new node that may have replaced nodep
     static AstNode* constifyEdit(AstNode* nodep);
+    static AstNodeExpr* constifyEdit(AstNodeExpr* exprp) {
+        return VN_AS(constifyEdit(static_cast<AstNode*>(exprp)), NodeExpr);
+    }
     // Only the current node and lower, with special SenTree optimization
     // Return new node that may have replaced nodep
     static AstNode* constifyExpensiveEdit(AstNode* nodep);

--- a/src/V3Coverage.cpp
+++ b/src/V3Coverage.cpp
@@ -47,9 +47,9 @@ private:
 
     struct ToggleEnt {
         const string m_comment;  // Comment for coverage dump
-        AstNode* m_varRefp;  // How to get to this element
-        AstNode* m_chgRefp;  // How to get to this element
-        ToggleEnt(const string& comment, AstNode* vp, AstNode* cp)
+        AstNodeExpr* m_varRefp;  // How to get to this element
+        AstNodeExpr* m_chgRefp;  // How to get to this element
+        ToggleEnt(const string& comment, AstNodeExpr* vp, AstNodeExpr* cp)
             : m_comment{comment}
             , m_varRefp{vp}
             , m_chgRefp{cp} {}

--- a/src/V3Depth.cpp
+++ b/src/V3Depth.cpp
@@ -52,7 +52,7 @@ private:
 
     // METHODS
 
-    void createDeepTemp(AstNode* nodep) {
+    void createDeepTemp(AstNodeExpr* nodep) {
         UINFO(6, "  Deep  " << nodep << endl);
         // if (debug() >= 9) nodep->dumpTree(cout, "deep:");
         AstVar* const varp = new AstVar{nodep->fileline(), VVarType::STMTTEMP,

--- a/src/V3DfgDfgToAst.cpp
+++ b/src/V3DfgDfgToAst.cpp
@@ -299,7 +299,7 @@ class DfgToAstVisitor final : DfgVisitor {
         });
     }
 
-    void addResultEquation(FileLine* flp, AstNode* lhsp, AstNode* rhsp) {
+    void addResultEquation(FileLine* flp, AstNodeExpr* lhsp, AstNodeExpr* rhsp) {
         m_modp->addStmtsp(new AstAssignW{flp, lhsp, rhsp});
         ++m_ctx.m_resultEquations;
     }

--- a/src/V3Force.cpp
+++ b/src/V3Force.cpp
@@ -174,8 +174,8 @@ class ForceConvertVisitor final : public VNVisitor {
         pushDeletep(nodep);
 
         FileLine* const flp = nodep->fileline();
-        AstNode* const lhsp = nodep->lhsp();  // The LValue we are forcing
-        AstNode* const rhsp = nodep->rhsp();  // The value we are forcing it to
+        AstNodeExpr* const lhsp = nodep->lhsp();  // The LValue we are forcing
+        AstNodeExpr* const rhsp = nodep->rhsp();  // The value we are forcing it to
 
         // Set corresponding enable signals to ones
         V3Number ones{lhsp, lhsp->width()};
@@ -210,7 +210,7 @@ class ForceConvertVisitor final : public VNVisitor {
         pushDeletep(nodep);
 
         FileLine* const flp = nodep->fileline();
-        AstNode* const lhsp = nodep->lhsp();  // The LValue we are releasing
+        AstNodeExpr* const lhsp = nodep->lhsp();  // The LValue we are releasing
 
         // Set corresponding enable signals to zero
         V3Number zero{lhsp, lhsp->width()};

--- a/src/V3LinkDot.cpp
+++ b/src/V3LinkDot.cpp
@@ -1223,7 +1223,7 @@ class LinkDotFindVisitor final : public VNVisitor {
                     // new value.
                     if (v3Global.opt.hasParameter(nodep->name())) {
                         const string svalue = v3Global.opt.parameter(nodep->name());
-                        if (AstNode* const valuep
+                        if (AstConst* const valuep
                             = AstConst::parseParamLiteral(nodep->fileline(), svalue)) {
                             UINFO(9, "       replace parameter " << nodep << endl);
                             UINFO(9, "       with " << valuep << endl);
@@ -1366,7 +1366,7 @@ class LinkDotFindVisitor final : public VNVisitor {
             // DOT(x, SELLOOPVARS(var, loops)) -> SELLOOPVARS(DOT(x, var), loops)
             if (AstDot* const dotp = VN_CAST(nodep->arrayp(), Dot)) {
                 if (AstSelLoopVars* const loopvarsp = VN_CAST(dotp->rhsp(), SelLoopVars)) {
-                    AstNode* const fromp = loopvarsp->fromp()->unlinkFrBack();
+                    AstNodeExpr* const fromp = loopvarsp->fromp()->unlinkFrBack();
                     loopvarsp->unlinkFrBack();
                     dotp->replaceWith(loopvarsp);
                     dotp->rhsp(fromp);
@@ -1540,7 +1540,7 @@ private:
         if (!cellp) {
             nodep->v3error("In defparam, instance " << nodep->path() << " never declared");
         } else {
-            AstNode* const exprp = nodep->rhsp()->unlinkFrBack();
+            AstNodeExpr* const exprp = nodep->rhsp()->unlinkFrBack();
             UINFO(9, "Defparam cell " << nodep->path() << "." << nodep->name() << " attach-to "
                                       << cellp << "  <= " << exprp << endl);
             // Don't need to check the name of the defparam exists.  V3Param does.
@@ -2295,7 +2295,7 @@ private:
                 nodep->replaceWith(newp);
                 VL_DO_DANGLING(pushDeletep(nodep), nodep);
             } else {  // Dot midpoint
-                AstNode* newp = nodep->rhsp()->unlinkFrBack();
+                AstNodeExpr* newp = nodep->rhsp()->unlinkFrBack();
                 if (m_ds.m_unresolved) {
                     AstCellRef* const crp = new AstCellRef(nodep->fileline(), nodep->name(),
                                                            nodep->lhsp()->unlinkFrBack(), newp);
@@ -2358,8 +2358,8 @@ private:
             return;
         } else if (m_ds.m_dotPos == DP_MEMBER) {
             // Found a Var, everything following is membership.  {scope}.{var}.HERE {member}
-            AstNode* const varEtcp = m_ds.m_dotp->lhsp()->unlinkFrBack();
-            AstNode* const newp
+            AstNodeExpr* const varEtcp = m_ds.m_dotp->lhsp()->unlinkFrBack();
+            AstNodeExpr* const newp
                 = new AstMemberSel(nodep->fileline(), varEtcp, VFlagChildDType(), nodep->name());
             if (m_ds.m_dotErr) {
                 nodep->unlinkFrBack();  // Avoid circular node loop on errors
@@ -2545,7 +2545,8 @@ private:
                     m_ds.m_dotPos = DP_SCOPE;
                     UINFO(9, " modport -> iface varref " << foundp->nodep() << endl);
                     // We lose the modport name here, so we cannot detect mismatched modports.
-                    AstNode* newp = new AstVarRef{nodep->fileline(), ifaceRefVarp, VAccess::READ};
+                    AstNodeExpr* newp
+                        = new AstVarRef{nodep->fileline(), ifaceRefVarp, VAccess::READ};
                     auto* const cellarrayrefp = VN_CAST(m_ds.m_unlinkedScopep, CellArrayRef);
                     if (cellarrayrefp) {
                         // iface[vec].modport became CellArrayRef(iface, lsb)
@@ -2811,8 +2812,8 @@ private:
         } else if (m_ds.m_dotp && m_ds.m_dotPos == DP_MEMBER) {
             // Found a Var, everything following is method call.
             // {scope}.{var}.HERE {method} ( ARGS )
-            AstNode* const varEtcp = m_ds.m_dotp->lhsp()->unlinkFrBack();
-            AstNode* argsp = nullptr;
+            AstNodeExpr* const varEtcp = m_ds.m_dotp->lhsp()->unlinkFrBack();
+            AstNodeExpr* argsp = nullptr;
             if (nodep->pinsp()) argsp = nodep->pinsp()->unlinkFrBackWithNext();
             AstNode* const newp = new AstMethodCall(nodep->fileline(), varEtcp, VFlagChildDType(),
                                                     nodep->name(), argsp);
@@ -2965,7 +2966,7 @@ private:
             }
         }
         if (m_ds.m_unresolved && m_ds.m_dotPos == DP_SCOPE) {
-            AstNode* const exprp = nodep->bitp()->unlinkFrBack();
+            AstNodeExpr* const exprp = nodep->bitp()->unlinkFrBack();
             AstCellArrayRef* const newp
                 = new AstCellArrayRef(nodep->fileline(), nodep->fromp()->name(), exprp);
             nodep->replaceWith(newp);

--- a/src/V3LinkInc.cpp
+++ b/src/V3LinkInc.cpp
@@ -205,8 +205,8 @@ private:
         UASSERT_OBJ(nodep, constp, "Expecting CONST");
         AstConst* const newconstp = constp->cloneTree(true);
 
-        AstNode* const storetop = nodep->thsp();
-        AstNode* const valuep = nodep->rhsp();
+        AstNodeExpr* const storetop = nodep->thsp();
+        AstNodeExpr* const valuep = nodep->rhsp();
 
         storetop->unlinkFrBack();
         valuep->unlinkFrBack();
@@ -247,7 +247,7 @@ private:
         insertBeforeStmt(nodep, varp);
 
         // Define what operation will we be doing
-        AstNode* operp;
+        AstNodeExpr* operp;
         if (VN_IS(nodep, PostSub) || VN_IS(nodep, PreSub)) {
             operp = new AstSub(fl, new AstVarRef(fl, varrefp->varp(), VAccess::READ), newconstp);
         } else {

--- a/src/V3LinkJump.cpp
+++ b/src/V3LinkJump.cpp
@@ -159,7 +159,7 @@ private:
         // So later optimizations don't need to deal with them,
         //    REPEAT(count,body) -> loop=count,WHILE(loop>0) { body, loop-- }
         // Note var can be signed or unsigned based on original number.
-        AstNode* const countp = nodep->countp()->unlinkFrBackWithNext();
+        AstNodeExpr* const countp = nodep->countp()->unlinkFrBackWithNext();
         const string name = string("__Vrepeat") + cvtToStr(m_modRepeatNum++);
         // Spec says value is integral, if negative is ignored
         AstVar* const varp
@@ -172,8 +172,8 @@ private:
             nodep->fileline(), new AstVarRef(nodep->fileline(), varp, VAccess::WRITE),
             new AstSub(nodep->fileline(), new AstVarRef(nodep->fileline(), varp, VAccess::READ),
                        new AstConst(nodep->fileline(), 1)));
-        AstNode* const zerosp = new AstConst(nodep->fileline(), AstConst::Signed32(), 0);
-        AstNode* const condp = new AstGtS(
+        AstNodeExpr* const zerosp = new AstConst(nodep->fileline(), AstConst::Signed32(), 0);
+        AstNodeExpr* const condp = new AstGtS(
             nodep->fileline(), new AstVarRef(nodep->fileline(), varp, VAccess::READ), zerosp);
         AstNode* const bodysp = nodep->stmtsp();
         if (bodysp) bodysp->unlinkFrBackWithNext();
@@ -210,7 +210,7 @@ private:
             m_loopInc = true;
             iterateAndNextNull(nodep->incsp());
         }
-        AstNode* const condp = nodep->condp() ? nodep->condp()->unlinkFrBack() : nullptr;
+        AstNodeExpr* const condp = nodep->condp() ? nodep->condp()->unlinkFrBack() : nullptr;
         AstNode* const bodyp = nodep->stmtsp() ? nodep->stmtsp()->unlinkFrBack() : nullptr;
         AstNode* const incsp = nodep->incsp() ? nodep->incsp()->unlinkFrBack() : nullptr;
         AstWhile* const whilep = new AstWhile{nodep->fileline(), condp, bodyp, incsp};

--- a/src/V3LinkParse.cpp
+++ b/src/V3LinkParse.cpp
@@ -181,7 +181,7 @@ private:
             FileLine* const flp = nodep->fileline();
             for (int i = left; i != (right + increment); i += increment, offset_from_init++) {
                 const string name = nodep->name() + cvtToStr(i);
-                AstNode* valuep = nullptr;
+                AstNodeExpr* valuep = nullptr;
                 if (nodep->valuep()) {
                     valuep
                         = new AstAdd(flp, nodep->valuep()->cloneTree(true),
@@ -266,7 +266,7 @@ private:
                 newfl->warnOff(V3ErrorCode::PROCASSWIRE, true);
                 auto* const assp
                     = new AstAssign(newfl, new AstVarRef(newfl, nodep->name(), VAccess::WRITE),
-                                    nodep->valuep()->unlinkFrBack());
+                                    VN_AS(nodep->valuep()->unlinkFrBack(), NodeExpr));
                 if (nodep->lifetime().isAutomatic()) {
                     nodep->addNextHere(new AstInitialAutomatic{newfl, assp});
                 } else {
@@ -274,9 +274,9 @@ private:
                 }
             }  // 4. Under blocks, it's an initial value to be under an assign
             else {
-                nodep->addNextHere(new AstAssign(fl,
-                                                 new AstVarRef(fl, nodep->name(), VAccess::WRITE),
-                                                 nodep->valuep()->unlinkFrBack()));
+                nodep->addNextHere(
+                    new AstAssign(fl, new AstVarRef(fl, nodep->name(), VAccess::WRITE),
+                                  VN_AS(nodep->valuep()->unlinkFrBack(), NodeExpr)));
             }
         }
         if (nodep->isIfaceRef() && !nodep->isIfaceParent() && !v3Global.opt.topIfacesSupported()) {

--- a/src/V3ParseGrammar.cpp
+++ b/src/V3ParseGrammar.cpp
@@ -69,14 +69,14 @@ void V3ParseImp::parserClear() {
 //======================================================================
 // V3ParseGrammar functions requiring bison state
 
-AstArg* V3ParseGrammar::argWrapList(AstNode* nodep) {
+AstArg* V3ParseGrammar::argWrapList(AstNodeExpr* nodep) {
     // Convert list of expressions to list of arguments
     if (!nodep) return nullptr;
     AstArg* outp = nullptr;
     AstBegin* const tempp = new AstBegin{nodep->fileline(), "[EditWrapper]", nodep};
     while (nodep) {
-        AstNode* const nextp = nodep->nextp();
-        AstNode* const exprp = nodep->unlinkFrBack();
+        AstNodeExpr* const nextp = VN_AS(nodep->nextp(), NodeExpr);
+        AstNodeExpr* const exprp = nodep->unlinkFrBack();
         nodep = nextp;
         outp = AstNode::addNext(outp, new AstArg{exprp->fileline(), "", exprp});
     }

--- a/src/V3Randomize.cpp
+++ b/src/V3Randomize.cpp
@@ -184,7 +184,7 @@ private:
                     = new AstVarRef{fl, enumValueTabp(enumDtp), VAccess::READ};
                 tabRefp->classOrPackagep(v3Global.rootp()->dollarUnitPkgAddp());
                 AstRand* const randp = new AstRand{fl, nullptr, false};
-                AstNode* const moddivp = new AstModDiv{
+                AstNodeExpr* const moddivp = new AstModDiv{
                     fl, randp, new AstConst{fl, static_cast<uint32_t>(enumDtp->itemCount())}};
                 randp->dtypep(varrefp->findBasicDType(VBasicDTypeKwd::UINT32));
                 moddivp->dtypep(enumDtp);
@@ -296,7 +296,7 @@ private:
 
         for (AstCaseItem* itemp = nodep->itemsp(); itemp;
              itemp = VN_AS(itemp->nextp(), CaseItem)) {
-            AstNode* const condp = itemp->condsp()->unlinkFrBack();
+            AstNodeExpr* const condp = itemp->condsp()->unlinkFrBack();
             sump
                 = new AstAdd{condp->fileline(), sump, new AstExtend{itemp->fileline(), condp, 64}};
             AstNode* const stmtsp
@@ -318,7 +318,7 @@ private:
         ifsp->addElsesp(dispp);
 
         AstNode* newp = randVarp;
-        AstNode* randp = new AstRand{fl, nullptr, false};
+        AstNodeExpr* randp = new AstRand{fl, nullptr, false};
         randp->dtypeSetUInt64();
         newp->addNext(new AstAssign{fl, new AstVarRef{fl, randVarp, VAccess::WRITE},
                                     new AstAdd{fl, new AstConst{fl, AstConst::Unsized64{}, 1},

--- a/src/V3Reloop.cpp
+++ b/src/V3Reloop.cpp
@@ -107,8 +107,8 @@ private:
 
                 AstNode* const initp = new AstAssign(fl, new AstVarRef(fl, itp, VAccess::WRITE),
                                                      new AstConst(fl, m_mgIndexLo));
-                AstNode* const condp = new AstLte(fl, new AstVarRef(fl, itp, VAccess::READ),
-                                                  new AstConst(fl, m_mgIndexHi));
+                AstNodeExpr* const condp = new AstLte(fl, new AstVarRef(fl, itp, VAccess::READ),
+                                                      new AstConst(fl, m_mgIndexHi));
                 AstNode* const incp = new AstAssign(
                     fl, new AstVarRef(fl, itp, VAccess::WRITE),
                     new AstAdd(fl, new AstConst(fl, 1), new AstVarRef(fl, itp, VAccess::READ)));
@@ -118,15 +118,15 @@ private:
                 whilep->addStmtsp(bodyp);
 
                 // Replace constant index with new loop index
-                AstNode* const offsetp
+                AstNodeExpr* const offsetp
                     = m_mgOffset == 0 ? nullptr : new AstConst(fl, std::abs(m_mgOffset));
-                AstNode* const lbitp = m_mgSelLp->bitp();
-                AstNode* const lvrefp = new AstVarRef(fl, itp, VAccess::READ);
+                AstNodeExpr* const lbitp = m_mgSelLp->bitp();
+                AstNodeExpr* const lvrefp = new AstVarRef(fl, itp, VAccess::READ);
                 lbitp->replaceWith(m_mgOffset > 0 ? new AstAdd(fl, lvrefp, offsetp) : lvrefp);
                 VL_DO_DANGLING(lbitp->deleteTree(), lbitp);
                 if (m_mgSelRp) {  // else constant and no replace
-                    AstNode* const rbitp = m_mgSelRp->bitp();
-                    AstNode* const rvrefp = new AstVarRef(fl, itp, VAccess::READ);
+                    AstNodeExpr* const rbitp = m_mgSelRp->bitp();
+                    AstNodeExpr* const rvrefp = new AstVarRef(fl, itp, VAccess::READ);
                     rbitp->replaceWith(m_mgOffset < 0 ? new AstAdd(fl, rvrefp, offsetp) : rvrefp);
                     VL_DO_DANGLING(rbitp->deleteTree(), lbitp);
                 }

--- a/src/V3SenExprBuilder.h
+++ b/src/V3SenExprBuilder.h
@@ -64,7 +64,7 @@ class SenExprBuilder final {
     }
 
     // METHODS
-    AstNode* getCurr(AstNode* exprp) {
+    AstNodeExpr* getCurr(AstNodeExpr* exprp) {
         // For simple expressions like varrefs or selects, just use them directly
         if (isSimpleExpr(exprp)) return exprp->cloneTree(false);
 
@@ -89,7 +89,7 @@ class SenExprBuilder final {
         }
         return new AstVarRef{flp, currp, VAccess::READ};
     }
-    AstVarScope* getPrev(AstNode* exprp) {
+    AstVarScope* getPrev(AstNodeExpr* exprp) {
         FileLine* const flp = exprp->fileline();
         const auto rdCurr = [=]() { return getCurr(exprp); };
 
@@ -150,9 +150,9 @@ class SenExprBuilder final {
         return prevp;
     }
 
-    std::pair<AstNode*, bool> createTerm(AstSenItem* senItemp) {
+    std::pair<AstNodeExpr*, bool> createTerm(AstSenItem* senItemp) {
         FileLine* const flp = senItemp->fileline();
-        AstNode* const senp = senItemp->sensp();
+        AstNodeExpr* const senp = senItemp->sensp();
 
         const auto currp = [=]() { return getCurr(senp); };
         const auto prevp = [=]() { return new AstVarRef{flp, getPrev(senp), VAccess::READ}; };
@@ -215,14 +215,14 @@ class SenExprBuilder final {
 public:
     // Returns the expression computing the trigger, and a bool indicating that
     // this trigger should be fired on the first evaluation (at initialization)
-    std::pair<AstNode*, bool> build(const AstSenTree* senTreep) {
+    std::pair<AstNodeExpr*, bool> build(const AstSenTree* senTreep) {
         FileLine* const flp = senTreep->fileline();
-        AstNode* resultp = nullptr;
+        AstNodeExpr* resultp = nullptr;
         bool firedAtInitialization = false;
         for (AstSenItem* senItemp = senTreep->sensesp(); senItemp;
              senItemp = VN_AS(senItemp->nextp(), SenItem)) {
             const auto& pair = createTerm(senItemp);
-            if (AstNode* const termp = pair.first) {
+            if (AstNodeExpr* const termp = pair.first) {
                 resultp = resultp ? new AstOr{flp, resultp, termp} : termp;
                 firedAtInitialization |= pair.second;
             }

--- a/src/V3Simulate.h
+++ b/src/V3Simulate.h
@@ -191,7 +191,7 @@ public:
                 for (V3TaskConnects::iterator conIt = tconnects->begin();
                      conIt != tconnects->end(); ++conIt) {
                     AstVar* const portp = conIt->first;
-                    AstNode* const pinp = conIt->second->exprp();
+                    AstNodeExpr* const pinp = conIt->second->exprp();
                     AstNodeDType* const dtypep = pinp->dtypep();
                     if (AstConst* const valp = fetchConstNull(pinp)) {
                         stack << "\n           " << portp->prettyName() << " = "
@@ -248,26 +248,26 @@ private:
     }
 
 public:
-    void newValue(AstNode* nodep, const AstNode* valuep) {
+    void newValue(AstNode* nodep, const AstNodeExpr* valuep) {
         if (const AstConst* const constp = VN_CAST(valuep, Const)) {
             newConst(nodep)->num().opAssign(constp->num());
         } else if (fetchValueNull(nodep) != valuep) {
             // const_cast, as clonep() is set on valuep, but nothing should care
-            setValue(nodep, newTrackedClone(const_cast<AstNode*>(valuep)));
+            setValue(nodep, newTrackedClone(const_cast<AstNodeExpr*>(valuep)));
         }
     }
-    void newOutValue(AstNode* nodep, const AstNode* valuep) {
+    void newOutValue(AstNode* nodep, const AstNodeExpr* valuep) {
         if (const AstConst* const constp = VN_CAST(valuep, Const)) {
             newOutConst(nodep)->num().opAssign(constp->num());
         } else if (fetchOutValueNull(nodep) != valuep) {
             // const_cast, as clonep() is set on valuep, but nothing should care
-            setOutValue(nodep, newTrackedClone(const_cast<AstNode*>(valuep)));
+            setOutValue(nodep, newTrackedClone(const_cast<AstNodeExpr*>(valuep)));
         }
     }
 
 private:
-    AstNode* newTrackedClone(AstNode* nodep) {
-        AstNode* const newp = nodep->cloneTree(false);
+    AstNodeExpr* newTrackedClone(AstNodeExpr* nodep) {
+        AstNodeExpr* const newp = nodep->cloneTree(false);
         m_reclaimValuesp.push_back(newp);
         return newp;
     }
@@ -293,16 +293,16 @@ private:
     }
 
 public:
-    AstNode* fetchValueNull(AstNode* nodep) { return nodep->user3p(); }
+    AstNodeExpr* fetchValueNull(AstNode* nodep) { return VN_AS(nodep->user3p(), NodeExpr); }
 
 private:
-    AstNode* fetchOutValueNull(AstNode* nodep) { return nodep->user2p(); }
+    AstNodeExpr* fetchOutValueNull(AstNode* nodep) { return VN_AS(nodep->user2p(), NodeExpr); }
     AstConst* fetchConstNull(AstNode* nodep) { return VN_CAST(fetchValueNull(nodep), Const); }
     AstConst* fetchOutConstNull(AstNode* nodep) {
         return VN_CAST(fetchOutValueNull(nodep), Const);
     }
-    AstNode* fetchValue(AstNode* nodep) {
-        AstNode* const valuep = fetchValueNull(nodep);
+    AstNodeExpr* fetchValue(AstNode* nodep) {
+        AstNodeExpr* const valuep = fetchValueNull(nodep);
         UASSERT_OBJ(valuep, nodep, "No value found for node.");
         // UINFO(9, "     fetch val " << *valuep << " on " << nodep << endl);
         return valuep;
@@ -332,12 +332,12 @@ public:
     }
 
 private:
-    void setValue(AstNode* nodep, const AstNode* valuep) {
+    void setValue(AstNode* nodep, const AstNodeExpr* valuep) {
         UASSERT_OBJ(valuep, nodep, "Simulate setting null value");
         UINFO(9, "     set val " << valuep->name() << " on " << nodep << endl);
         nodep->user3p((void*)valuep);
     }
-    void setOutValue(AstNode* nodep, const AstNode* valuep) {
+    void setOutValue(AstNode* nodep, const AstNodeExpr* valuep) {
         UASSERT_OBJ(valuep, nodep, "Simulate setting null value");
         UINFO(9, "     set oval " << valuep->name() << " on " << nodep << endl);
         nodep->user2p((void*)valuep);
@@ -386,7 +386,7 @@ private:
         // True to jump over this node - all visitors must call this up front
         return (m_jumpp && m_jumpp->labelp() != nodep);
     }
-    void assignOutValue(AstNodeAssign* nodep, AstNode* vscp, const AstNode* valuep) {
+    void assignOutValue(AstNodeAssign* nodep, AstNode* vscp, const AstNodeExpr* valuep) {
         if (VN_IS(nodep, AssignDly)) {
             // Don't do setValue, as value isn't yet visible to following statements
             newOutValue(vscp, valuep);
@@ -443,10 +443,10 @@ private:
                 }
                 vscp->user1(vscp->user1() | VU_RV);
                 const bool isConst = nodep->varp()->isParam() && nodep->varp()->valuep();
-                AstNode* const valuep
+                AstNodeExpr* const valuep
                     = isConst ? fetchValueNull(nodep->varp()->valuep()) : nullptr;
-                if (isConst
-                    && valuep) {  // Propagate PARAM constants for constant function analysis
+                // Propagate PARAM constants for constant function analysis
+                if (isConst && valuep) {
                     if (!m_checkOnly && optimizable()) newValue(vscp, valuep);
                 } else {
                     if (m_checkOnly) varRefCb(nodep);
@@ -458,7 +458,7 @@ private:
                         "LHS varref should be handled in AstAssign visitor.");
             {
                 // Return simulation value - copy by reference instead of value for speed
-                AstNode* valuep = fetchValueNull(vscp);
+                AstNodeExpr* valuep = fetchValueNull(vscp);
                 if (!valuep) {
                     if (m_params) {
                         clearOptimizable(
@@ -697,7 +697,7 @@ private:
                 m_reclaimValuesp.push_back(initp);
             }
             const uint32_t index = fetchConst(selp->bitp())->toUInt();
-            AstNode* const valuep = newTrackedClone(fetchValue(nodep->rhsp()));
+            AstNodeExpr* const valuep = newTrackedClone(fetchValue(nodep->rhsp()));
             UINFO(9, "     set val[" << index << "] = " << valuep << endl);
             // Values are in the "real" tree under the InitArray so can eventually extract it,
             // Not in the usual setValue (pointed to by user2/3p)
@@ -803,7 +803,7 @@ private:
         if (AstInitArray* const initp = VN_CAST(fetchValueNull(nodep->fromp()), InitArray)) {
             AstConst* const indexp = fetchConst(nodep->bitp());
             const uint32_t offset = indexp->num().toUInt();
-            AstNode* const itemp = initp->getIndexDefaultedValuep(offset);
+            AstNodeExpr* const itemp = initp->getIndexDefaultedValuep(offset);
             if (!itemp) {
                 clearOptimizable(nodep, "Array initialization has too few elements, need element "
                                             + cvtToStr(offset));

--- a/src/V3Subst.cpp
+++ b/src/V3Subst.cpp
@@ -119,7 +119,7 @@ public:
         m_wordUse = true;
     }
     // ACCESSORS
-    AstNode* substWhole(AstNode* errp) {
+    AstNodeExpr* substWhole(AstNode* errp) {
         if (!m_varp->isWide() && !m_whole.m_complex && m_whole.m_assignp && !m_wordAssign) {
             const AstNodeAssign* const assp = m_whole.m_assignp;
             UASSERT_OBJ(assp, errp, "Reading whole that was never assigned");
@@ -129,7 +129,7 @@ public:
         }
     }
     // Return what to substitute given word number for
-    AstNode* substWord(AstNode* errp, int word) {
+    AstNodeExpr* substWord(AstNode* errp, int word) {
         if (!m_whole.m_complex && !m_whole.m_assignp && !m_words[word].m_complex) {
             const AstNodeAssign* const assp = getWordAssignp(word);
             UASSERT_OBJ(assp, errp, "Reading a word that was never assigned, or bad word #");
@@ -287,9 +287,9 @@ private:
         }
         if (!hit) iterate(nodep->lhsp());
     }
-    void replaceSubstEtc(AstNode* nodep, AstNode* substp) {
+    void replaceSubstEtc(AstNode* nodep, AstNodeExpr* substp) {
         if (debug() > 5) nodep->dumpTree(cout, "  substw_old: ");
-        AstNode* newp = substp->cloneTree(true);
+        AstNodeExpr* newp = substp->cloneTree(true);
         if (!nodep->isQuad() && newp->isQuad()) {
             newp = new AstCCast{newp->fileline(), newp, nodep};
         }
@@ -308,7 +308,7 @@ private:
             const int word = constp->toUInt();
             UINFO(8, " USEword" << word << " " << varrefp << endl);
             SubstVarEntry* const entryp = getEntryp(varrefp);
-            if (AstNode* const substp = entryp->substWord(nodep, word)) {
+            if (AstNodeExpr* const substp = entryp->substWord(nodep, word)) {
                 // Check that the RHS hasn't changed value since we recorded it.
                 const SubstUseVisitor visitor{substp, entryp->getWordStep(word)};
                 if (visitor.ok()) {
@@ -335,7 +335,7 @@ private:
             if (nodep->access().isWriteOrRW()) {
                 UINFO(8, " ASSIGNcpx " << nodep << endl);
                 entryp->assignComplex();
-            } else if (AstNode* const substp = entryp->substWhole(nodep)) {
+            } else if (AstNodeExpr* const substp = entryp->substWhole(nodep)) {
                 // Check that the RHS hasn't changed value since we recorded it.
                 const SubstUseVisitor visitor{substp, entryp->getWholeStep()};
                 if (visitor.ok()) {

--- a/src/V3Table.cpp
+++ b/src/V3Table.cpp
@@ -336,7 +336,7 @@ private:
     AstNode* createLookupInput(FileLine* fl, AstVarScope* indexVscp) {
         // Concat inputs into a single temp variable (inside always)
         // First var in inVars becomes the LSB of the concat
-        AstNode* concatp = nullptr;
+        AstNodeExpr* concatp = nullptr;
         for (AstVarScope* invscp : m_inVarps) {
             AstVarRef* const refp = new AstVarRef{fl, invscp, VAccess::READ};
             if (concatp) {
@@ -359,8 +359,8 @@ private:
                              AstVarScope* outputAssignedTableVscp) {
         FileLine* const fl = nodep->fileline();
         for (TableOutputVar& tov : m_outVarps) {
-            AstNode* const alhsp = new AstVarRef{fl, tov.varScopep(), VAccess::WRITE};
-            AstNode* const arhsp = select(fl, tov.tabeVarScopep(), indexVscp);
+            AstNodeExpr* const alhsp = new AstVarRef{fl, tov.varScopep(), VAccess::WRITE};
+            AstNodeExpr* const arhsp = select(fl, tov.tabeVarScopep(), indexVscp);
             AstNode* outsetp = m_assignDly
                                    ? static_cast<AstNode*>(new AstAssignDly{fl, alhsp, arhsp})
                                    : static_cast<AstNode*>(new AstAssign{fl, alhsp, arhsp});
@@ -369,7 +369,7 @@ private:
             if (tov.mayBeUnassigned()) {
                 V3Number outputChgMask{nodep, static_cast<int>(m_outVarps.size()), 0};
                 outputChgMask.setBit(tov.ord(), 1);
-                AstNode* const condp
+                AstNodeExpr* const condp
                     = new AstAnd{fl, select(fl, outputAssignedTableVscp, indexVscp),
                                  new AstConst{fl, outputChgMask}};
                 outsetp = new AstIf{fl, condp, outsetp};

--- a/src/V3Trace.cpp
+++ b/src/V3Trace.cpp
@@ -421,7 +421,7 @@ private:
         graphSimplify(false);
     }
 
-    AstNode* selectActivity(FileLine* flp, uint32_t acode, const VAccess& access) {
+    AstNodeExpr* selectActivity(FileLine* flp, uint32_t acode, const VAccess& access) {
         return new AstArraySel(flp, new AstVarRef(flp, m_activityVscp, access), acode);
     }
 
@@ -667,12 +667,12 @@ private:
                 if (!prevActSet || actSet != *prevActSet) {
                     FileLine* const flp = m_topScopep->fileline();
                     const bool always = actSet.count(TraceActivityVertex::ACTIVITY_ALWAYS) != 0;
-                    AstNode* condp = nullptr;
+                    AstNodeExpr* condp = nullptr;
                     if (always) {
                         condp = new AstConst(flp, 1);  // Always true, will be folded later
                     } else {
                         for (const uint32_t actCode : actSet) {
-                            AstNode* const selp = selectActivity(flp, actCode, VAccess::READ);
+                            AstNodeExpr* const selp = selectActivity(flp, actCode, VAccess::READ);
                             condp = condp ? new AstOr(flp, condp, selp) : selp;
                         }
                     }

--- a/src/V3TraceDecl.cpp
+++ b/src/V3TraceDecl.cpp
@@ -128,7 +128,7 @@ private:
     };
     std::vector<Signal> m_signals;  // Signals under current scope
     AstVarScope* m_traVscp = nullptr;  // Current AstVarScope we are constructing AstTraceDecls for
-    AstNode* m_traValuep = nullptr;  // Value expression for current signal
+    AstNodeExpr* m_traValuep = nullptr;  // Value expression for current signal
     string m_traName;  // Name component for current signal
 
     VDouble0 m_statSigs;  // Statistic tracking

--- a/src/astgen
+++ b/src/astgen
@@ -425,9 +425,10 @@ class Cpt:
                               key=lambda val: self._exec_syms[val]):
                 argnp = self._exec_syms[sym]
                 arg = self.add_nodep(sym)
-                out += "AstNode* " + argnp + " = " + arg + "->unlinkFrBack();\n"
+                out += "AstNodeExpr* " + argnp + " = " + arg + "->unlinkFrBack();\n"
 
-            out += "AstNode* newp = " + self._exec_new_recurse(aref) + ";\n"
+            out += "AstNodeExpr* newp = " + self._exec_new_recurse(
+                aref) + ";\n"
             out += "nodep->replaceWith(newp);"
             out += "VL_DO_DANGLING(nodep->deleteTree(), nodep);"
         elif func == "NEVER":
@@ -918,11 +919,17 @@ def write_ast_macros(filename):
         for node in AstNodeList:
             fh.write("#define ASTGEN_MEMBERS_Ast{t} \\\n".format(t=node.name))
             emitBlock('''\
-            static Ast{t}* cloneTreeNull(Ast{t}* nodep, bool cloneNextLink) {{
-                return nodep ? nodep->cloneTree(cloneNextLink) : nullptr;
+            Ast{t}* unlinkFrBack(VNRelinker* linkerp = nullptr) {{
+                return static_cast<Ast{t}*>(AstNode::unlinkFrBack(linkerp));
+            }}
+            Ast{t}* unlinkFrBackWithNext(VNRelinker* linkerp = nullptr) {{
+                return static_cast<Ast{t}*>(AstNode::unlinkFrBackWithNext(linkerp));
             }}
             Ast{t}* cloneTree(bool cloneNext) {{
                 return static_cast<Ast{t}*>(AstNode::cloneTree(cloneNext));
+            }}
+            static Ast{t}* cloneTreeNull(Ast{t}* nodep, bool cloneNextLink) {{
+                return nodep ? nodep->cloneTree(cloneNextLink) : nullptr;
             }}
             Ast{t}* clonep() const VL_MT_SAFE {{ return static_cast<Ast{t}*>(AstNode::clonep()); }}
             Ast{t}* addNext(Ast{t}* nodep) {{ return static_cast<Ast{t}*>(AstNode::addNext(this, nodep)); }}

--- a/test_regress/t/t_stream_bad.out
+++ b/test_regress/t/t_stream_bad.out
@@ -1,0 +1,15 @@
+%Error: t/t_stream_bad.v:12:32: Expecting expression to be constant, but can't convert a RAND to constant.
+                              : ... In instance t
+   12 |    initial packed_data_32 = {<<$random{byte_in}};
+      |                                ^~~~~~~
+%Error: t/t_stream_bad.v:12:30: Slice size isn't a constant or basic data type.
+                              : ... In instance t
+   12 |    initial packed_data_32 = {<<$random{byte_in}};
+      |                              ^~
+%Warning-WIDTH: t/t_stream_bad.v:12:27: Operator ASSIGN expects 32 bits on the Assign RHS, but Assign RHS's STREAML generates 8 bits.
+                                      : ... In instance t
+   12 |    initial packed_data_32 = {<<$random{byte_in}};
+      |                           ^
+                ... For warning description see https://verilator.org/warn/WIDTH?v=latest
+                ... Use "/* verilator lint_off WIDTH */" and lint_on around source to disable this message.
+%Error: Exiting due to

--- a/test_regress/t/t_stream_bad.pl
+++ b/test_regress/t/t_stream_bad.pl
@@ -1,0 +1,19 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2003 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+lint(
+    fails => 1,
+    expect_filename => $Self->{golden_filename},
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_stream_bad.v
+++ b/test_regress/t/t_stream_bad.v
@@ -1,0 +1,14 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2022 by Geza Lore.
+// SPDX-License-Identifier: CC0-1.0
+
+module t;
+
+   logic [31:0] packed_data_32;
+   byte          byte_in[4];
+
+   initial packed_data_32 = {<<$random{byte_in}};
+
+endmodule

--- a/test_regress/t/t_stream_integer_type.out
+++ b/test_regress/t/t_stream_integer_type.out
@@ -72,63 +72,115 @@
                                                 : ... In instance t
   136 |          {<<32{reg_out}}      = v_packed_data_128;
       |                               ^
-%Error: t/t_stream_integer_type.v:150:33: Operator STREAML expected non-datatype RHS but 'byte' is a datatype.
-                                        : ... In instance t
-  150 |          packed_data_32    = {<<byte{byte_in}};
-      |                                 ^~~~
 %Warning-WIDTH: t/t_stream_integer_type.v:150:28: Operator ASSIGN expects 32 bits on the Assign RHS, but Assign RHS's STREAML generates 8 bits.
                                                 : ... In instance t
   150 |          packed_data_32    = {<<byte{byte_in}};
       |                            ^
-%Error: t/t_stream_integer_type.v:151:33: Operator STREAML expected non-datatype RHS but 'shortint' is a datatype.
-                                        : ... In instance t
-  151 |          packed_data_64    = {<<shortint{shortint_in}};
-      |                                 ^~~~~~~~
 %Warning-WIDTH: t/t_stream_integer_type.v:151:28: Operator ASSIGN expects 64 bits on the Assign RHS, but Assign RHS's STREAML generates 16 bits.
                                                 : ... In instance t
   151 |          packed_data_64    = {<<shortint{shortint_in}};
       |                            ^
-%Error: t/t_stream_integer_type.v:152:33: Operator STREAML expected non-datatype RHS but 'int' is a datatype.
-                                        : ... In instance t
-  152 |          packed_data_128   = {<<int{int_in}};
-      |                                 ^~~
 %Warning-WIDTH: t/t_stream_integer_type.v:152:28: Operator ASSIGN expects 128 bits on the Assign RHS, but Assign RHS's STREAML generates 32 bits.
                                                 : ... In instance t
   152 |          packed_data_128   = {<<int{int_in}};
       |                            ^
-%Error: t/t_stream_integer_type.v:153:33: Operator STREAML expected non-datatype RHS but 'integer' is a datatype.
-                                        : ... In instance t
-  153 |          packed_data_128_i = {<<integer{integer_in}};
-      |                                 ^~~~~~~
 %Warning-WIDTH: t/t_stream_integer_type.v:153:28: Operator ASSIGN expects 128 bits on the Assign RHS, but Assign RHS's STREAML generates 32 bits.
                                                 : ... In instance t
   153 |          packed_data_128_i = {<<integer{integer_in}};
       |                            ^
-%Error: t/t_stream_integer_type.v:154:33: Operator STREAML expected non-datatype RHS but 'longint' is a datatype.
-                                        : ... In instance t
-  154 |          packed_data_256   = {<<longint{longint_in}};
-      |                                 ^~~~~~~
 %Warning-WIDTH: t/t_stream_integer_type.v:154:28: Operator ASSIGN expects 256 bits on the Assign RHS, but Assign RHS's STREAML generates 64 bits.
                                                 : ... In instance t
   154 |          packed_data_256   = {<<longint{longint_in}};
       |                            ^
-%Error: t/t_stream_integer_type.v:155:33: Operator STREAML expected non-datatype RHS but 'time' is a datatype.
-                                        : ... In instance t
-  155 |          packed_time_256   = {<<time{time_in}};
-      |                                 ^~~~
 %Warning-WIDTH: t/t_stream_integer_type.v:155:28: Operator ASSIGN expects 256 bits on the Assign RHS, but Assign RHS's STREAML generates 64 bits.
                                                 : ... In instance t
   155 |          packed_time_256   = {<<time{time_in}};
       |                            ^
-%Error: t/t_stream_integer_type.v:156:33: Operator STREAML expected non-datatype RHS but 'test_byte' is a datatype.
-                                        : ... In instance t
-  156 |          v_packed_data_32  = {<<test_byte{bit_in}};
-      |                                 ^~~~~~~~~
-%Error: t/t_stream_integer_type.v:156:31: Slice size isn't a constant or basic data type.
-                                        : ... In instance t
-  156 |          v_packed_data_32  = {<<test_byte{bit_in}};
-      |                               ^~
-%Error: Internal Error: t/t_stream_integer_type.v:156:28: ../V3Width.cpp:#: Node has no type
-                                                        : ... In instance t
+%Warning-WIDTH: t/t_stream_integer_type.v:156:28: Operator ASSIGN expects 32 bits on the Assign RHS, but Assign RHS's STREAML generates 8 bits.
+                                                : ... In instance t
   156 |          v_packed_data_32  = {<<test_byte{bit_in}};
       |                            ^
+%Warning-WIDTH: t/t_stream_integer_type.v:157:28: Operator ASSIGN expects 64 bits on the Assign RHS, but Assign RHS's STREAML generates 16 bits.
+                                                : ... In instance t
+  157 |          v_packed_data_64  = {<<test_short{logic_in}};
+      |                            ^
+%Warning-WIDTH: t/t_stream_integer_type.v:158:28: Operator ASSIGN expects 128 bits on the Assign RHS, but Assign RHS's STREAML generates 32 bits.
+                                                : ... In instance t
+  158 |          v_packed_data_128 = {<<test_word{reg_in}};
+      |                            ^
+%Warning-WIDTH: t/t_stream_integer_type.v:160:37: Operator ASSIGN expects 8 bits on the Assign RHS, but Assign RHS's VARREF 'packed_data_32' generates 32 bits.
+                                                : ... In instance t
+  160 |          {<<byte{byte_out}}         = packed_data_32;
+      |                                     ^
+%Warning-WIDTH: t/t_stream_integer_type.v:161:37: Operator ASSIGN expects 16 bits on the Assign RHS, but Assign RHS's VARREF 'packed_data_64' generates 64 bits.
+                                                : ... In instance t
+  161 |          {<<shortint{shortint_out}} = packed_data_64;
+      |                                     ^
+%Warning-WIDTH: t/t_stream_integer_type.v:162:37: Operator ASSIGN expects 32 bits on the Assign RHS, but Assign RHS's VARREF 'packed_data_128' generates 128 bits.
+                                                : ... In instance t
+  162 |          {<<int{int_out}}           = packed_data_128;
+      |                                     ^
+%Warning-WIDTH: t/t_stream_integer_type.v:163:37: Operator ASSIGN expects 32 bits on the Assign RHS, but Assign RHS's VARREF 'packed_data_128_i' generates 128 bits.
+                                                : ... In instance t
+  163 |          {<<integer{integer_out}}   = packed_data_128_i;
+      |                                     ^
+%Warning-WIDTH: t/t_stream_integer_type.v:164:37: Operator ASSIGN expects 64 bits on the Assign RHS, but Assign RHS's VARREF 'packed_data_256' generates 256 bits.
+                                                : ... In instance t
+  164 |          {<<longint{longint_out}}   = packed_data_256;
+      |                                     ^
+%Warning-WIDTH: t/t_stream_integer_type.v:165:37: Operator ASSIGN expects 64 bits on the Assign RHS, but Assign RHS's VARREF 'packed_time_256' generates 256 bits.
+                                                : ... In instance t
+  165 |          {<<time{time_out}}         = packed_time_256;
+      |                                     ^
+%Warning-WIDTH: t/t_stream_integer_type.v:166:37: Operator ASSIGN expects 8 bits on the Assign RHS, but Assign RHS's VARREF 'v_packed_data_32' generates 32 bits.
+                                                : ... In instance t
+  166 |          {<<test_byte{bit_out}}     = v_packed_data_32;
+      |                                     ^
+%Warning-WIDTH: t/t_stream_integer_type.v:167:37: Operator ASSIGN expects 16 bits on the Assign RHS, but Assign RHS's VARREF 'v_packed_data_64' generates 64 bits.
+                                                : ... In instance t
+  167 |          {<<test_short{logic_out}}  = v_packed_data_64;
+      |                                     ^
+%Warning-WIDTH: t/t_stream_integer_type.v:168:37: Operator ASSIGN expects 32 bits on the Assign RHS, but Assign RHS's VARREF 'v_packed_data_128' generates 128 bits.
+                                                : ... In instance t
+  168 |          {<<test_word{reg_out}}     = v_packed_data_128;
+      |                                     ^
+%Error: t/t_stream_integer_type.v:128:11: SEL is not an unpacked array, but is in an unpacked array context
+  128 |          {<<8{byte_out}}      = packed_data_32;
+      |           ^~
+%Error: t/t_stream_integer_type.v:129:11: SEL is not an unpacked array, but is in an unpacked array context
+  129 |          {<<16{shortint_out}} = packed_data_64;
+      |           ^~
+%Error: t/t_stream_integer_type.v:130:11: SEL is not an unpacked array, but is in an unpacked array context
+  130 |          {<<32{int_out}}      = packed_data_128;
+      |           ^~
+%Error: t/t_stream_integer_type.v:131:11: SEL is not an unpacked array, but is in an unpacked array context
+  131 |          {<<32{integer_out}}  = packed_data_128_i;
+      |           ^~
+%Error: t/t_stream_integer_type.v:132:11: SEL is not an unpacked array, but is in an unpacked array context
+  132 |          {<<64{longint_out}}  = packed_data_256;
+      |           ^~
+%Error: t/t_stream_integer_type.v:133:11: SEL is not an unpacked array, but is in an unpacked array context
+  133 |          {<<64{time_out}}     = packed_time_256;
+      |           ^~
+%Error: t/t_stream_integer_type.v:134:11: SEL is not an unpacked array, but is in an unpacked array context
+  134 |          {<<8{bit_out}}       = v_packed_data_32;
+      |           ^~
+%Error: t/t_stream_integer_type.v:135:11: SEL is not an unpacked array, but is in an unpacked array context
+  135 |          {<<16{logic_out}}    = v_packed_data_64;
+      |           ^~
+%Error: t/t_stream_integer_type.v:136:11: SEL is not an unpacked array, but is in an unpacked array context
+  136 |          {<<32{reg_out}}      = v_packed_data_128;
+      |           ^~
+%Error: t/t_stream_integer_type.v:160:11: SEL is not an unpacked array, but is in an unpacked array context
+  160 |          {<<byte{byte_out}}         = packed_data_32;
+      |           ^~
+%Error: t/t_stream_integer_type.v:161:11: SEL is not an unpacked array, but is in an unpacked array context
+  161 |          {<<shortint{shortint_out}} = packed_data_64;
+      |           ^~
+%Error: t/t_stream_integer_type.v:162:11: SEL is not an unpacked array, but is in an unpacked array context
+  162 |          {<<int{int_out}}           = packed_data_128;
+      |           ^~
+%Error: t/t_stream_integer_type.v:163:11: SEL is not an unpacked array, but is in an unpacked array context
+  163 |          {<<integer{integer_out}}   = packed_data_128_i;
+      |           ^~
+%Error: Exiting due to


### PR DESCRIPTION
This is the follow up I promised from #3721 and another (not final) step towards #3420.

I strengthened the types of all nodes to AstNodeExpr where I could.

Two nodes became AstNodeExpr that really should not be: AstArg and AstSelLoopVars. These should be modelled better, but I don't want to include more changes in this patch. I think we are still better of with those warts where they are now. I added TODOs to fix them.

I changed 2 bits in the grammar:
- task_subroutine_callNoMethod no longer includes calls to system tasks, due to type constraints (task_subroutine_callNoMethod needs to yield an Expr). 
- Stream operators with a primitive data type as the first argument are now parsed as if $bits was applied to the type. This allows keeping AstNodeStream as an AstNodeBiop. This has the additional effect of t_stream_integer_type getting further internally but still failing at a later pass.

Found a bug in processing %p in SFormat, which is now fixed as well.
