### PR TITLE
Add support for with in unique, unique_index, min, max in queues

### DIFF
--- a/include/verilated_types.h
+++ b/include/verilated_types.h
@@ -439,6 +439,20 @@ public:
         }
         return out;
     }
+    template <typename Func>
+    VlQueue unique(Func with_func) const {
+        VlQueue out;
+        std::unordered_set<T_Value> saw;
+        for (const auto& i : m_deque) {
+            const auto i_mapped = with_func(0, i);
+            auto it = saw.find(i_mapped);
+            if (it == saw.end()) {
+                saw.insert(it, i_mapped);
+                out.push_back(i);
+            }
+        }
+        return out;
+    }
     VlQueue<IData> unique_index() const {
         VlQueue<IData> out;
         IData index = 0;
@@ -447,6 +461,22 @@ public:
             auto it = saw.find(i);
             if (it == saw.end()) {
                 saw.insert(it, i);
+                out.push_back(index);
+            }
+            ++index;
+        }
+        return out;
+    }
+    template <typename Func>
+    VlQueue<IData> unique_index(Func with_func) const {
+        VlQueue<IData> out;
+        IData index = 0;
+        std::unordered_set<T_Value> saw;
+        for (const auto& i : m_deque) {
+            const auto i_mapped = with_func(index, i);
+            auto it = saw.find(i_mapped);
+            if (it == saw.end()) {
+                saw.insert(it, i_mapped);
                 out.push_back(index);
             }
             ++index;
@@ -517,9 +547,27 @@ public:
         const auto it = std::min_element(m_deque.begin(), m_deque.end());
         return VlQueue::cons(*it);
     }
+    template <typename Func>
+    VlQueue min(Func with_func) const {
+        if (m_deque.empty()) return VlQueue{};
+        const auto it = std::min_element(m_deque.begin(), m_deque.end(),
+                                         [&with_func](const IData& a, const IData& b) {
+                                             return with_func(0, a) < with_func(0, b);
+                                         });
+        return VlQueue::cons(*it);
+    }
     VlQueue max() const {
         if (m_deque.empty()) return VlQueue{};
         const auto it = std::max_element(m_deque.begin(), m_deque.end());
+        return VlQueue::cons(*it);
+    }
+    template <typename Func>
+    VlQueue max(Func with_func) const {
+        if (m_deque.empty()) return VlQueue{};
+        const auto it = std::max_element(m_deque.begin(), m_deque.end(),
+                                         [&with_func](const IData& a, const IData& b) {
+                                             return with_func(0, a) < with_func(0, b);
+                                         });
         return VlQueue::cons(*it);
     }
 

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -3231,10 +3231,12 @@ private:
             newp->dtypeSetVoid();
         } else if (nodep->name() == "min" || nodep->name() == "max" || nodep->name() == "unique"
                    || nodep->name() == "unique_index") {
+            AstWith* const withp = methodWithArgument(
+                nodep, false, true, nullptr, nodep->findUInt32DType(), adtypep->subDTypep());
             methodOkArguments(nodep, 0, 0);
             methodCallLValueRecurse(nodep, nodep->fromp(), VAccess::READ);
             newp = new AstCMethodHard{nodep->fileline(), nodep->fromp()->unlinkFrBack(),
-                                      nodep->name()};
+                                      nodep->name(), withp};
             if (nodep->name() == "unique_index") {
                 newp->dtypep(newp->findQueueIndexDType());
             } else {

--- a/test_regress/t/t_queue_method.v
+++ b/test_regress/t/t_queue_method.v
@@ -44,10 +44,17 @@ module t (/*AUTOARG*/);
       v = $sformatf("%p", qv); `checks(v, "'{'h2, 'h4, 'h1, 'h3} ");
       qv = qe.unique;
       `checkh(qv.size(), 0);
+      qv = q.unique(x) with (x % 2);
+      `checkh(qv.size(), 2);
       qi = q.unique_index; qv.sort;
-      v = $sformatf("%p", qi); `checks(v, "'{'h0, 'h2, 'h3, 'h4} ");
+      // According to 7.12.1 of IEEE Std 1800-2017, it is not specified which index of duplicated value should be returned
+      `checkh(qi.size(), 4);
+      qi.delete(1);
+      v = $sformatf("%p", qi); `checks(v, "'{'h0, 'h3, 'h4} ");
       qi = qe.unique_index;
       `checkh(qi.size(), 0);
+      qi = q.unique_index(x) with (x % 3); qv.sort;
+      `checkh(qi.size(), 3);
 
       q.reverse;
       v = $sformatf("%p", q); `checks(v, "'{'h3, 'h1, 'h4, 'h2, 'h2} ");
@@ -104,8 +111,12 @@ module t (/*AUTOARG*/);
 
       qv = q.min;
       v = $sformatf("%p", qv); `checks(v, "'{'h1} ");
+      qv = q.min(x) with (x + 1);
+      v = $sformatf("%p", qv); `checks(v, "'{'h1} ");
       qv = q.max;
       v = $sformatf("%p", qv); `checks(v, "'{'h4} ");
+      qv = q.max(x) with ((x % 4) + 100);
+      v = $sformatf("%p", qv); `checks(v, "'{'h3} ");
       qv = qe.min;
       v = $sformatf("%p", qv); `checks(v, "'{}");
       qv = qe.max;

--- a/test_regress/t/t_queue_method_bad.out
+++ b/test_regress/t/t_queue_method_bad.out
@@ -1,41 +1,37 @@
-%Error: t/t_queue_method_bad.v:15:21: 'with' not legal on this method
-                                    : ... In instance t
-   15 |       qv = q.unique with (1);   
-      |                     ^~~~
-%Error: t/t_queue_method_bad.v:16:9: The 1 arguments passed to .reverse method does not match its requiring 0 arguments
+%Error: t/t_queue_method_bad.v:15:9: The 1 arguments passed to .reverse method does not match its requiring 0 arguments
                                    : ... In instance t
-   16 |       q.reverse(1);   
+   15 |       q.reverse(1);   
       |         ^~~~~~~
-%Error: t/t_queue_method_bad.v:17:9: The 1 arguments passed to .shuffle method does not match its requiring 0 arguments
+%Error: t/t_queue_method_bad.v:16:9: The 1 arguments passed to .shuffle method does not match its requiring 0 arguments
                                    : ... In instance t
-   17 |       q.shuffle(1);   
+   16 |       q.shuffle(1);   
       |         ^~~~~~~
-%Error: t/t_queue_method_bad.v:18:14: 'with' statement is required for .find method
+%Error: t/t_queue_method_bad.v:17:14: 'with' statement is required for .find method
                                     : ... In instance t
-   18 |       qv = q.find;   
+   17 |       qv = q.find;   
       |              ^~~~
-%Error: t/t_queue_method_bad.v:19:14: 'with' statement is required for .find_first method
+%Error: t/t_queue_method_bad.v:18:14: 'with' statement is required for .find_first method
                                     : ... In instance t
-   19 |       qv = q.find_first;   
+   18 |       qv = q.find_first;   
       |              ^~~~~~~~~~
-%Error: t/t_queue_method_bad.v:20:14: 'with' statement is required for .find_last method
+%Error: t/t_queue_method_bad.v:19:14: 'with' statement is required for .find_last method
                                     : ... In instance t
-   20 |       qv = q.find_last;   
+   19 |       qv = q.find_last;   
       |              ^~~~~~~~~
-%Error: t/t_queue_method_bad.v:21:14: 'with' statement is required for .find_index method
+%Error: t/t_queue_method_bad.v:20:14: 'with' statement is required for .find_index method
                                     : ... In instance t
-   21 |       qi = q.find_index;   
+   20 |       qi = q.find_index;   
       |              ^~~~~~~~~~
-%Error: t/t_queue_method_bad.v:22:14: 'with' statement is required for .find_first_index method
+%Error: t/t_queue_method_bad.v:21:14: 'with' statement is required for .find_first_index method
                                     : ... In instance t
-   22 |       qi = q.find_first_index;   
+   21 |       qi = q.find_first_index;   
       |              ^~~~~~~~~~~~~~~~
-%Error: t/t_queue_method_bad.v:23:14: 'with' statement is required for .find_last_index method
+%Error: t/t_queue_method_bad.v:22:14: 'with' statement is required for .find_last_index method
                                     : ... In instance t
-   23 |       qi = q.find_last_index;   
+   22 |       qi = q.find_last_index;   
       |              ^~~~~~~~~~~~~~~
-%Error: t/t_queue_method_bad.v:25:19: 'with' not legal on this method
+%Error: t/t_queue_method_bad.v:24:19: 'with' not legal on this method
                                     : ... In instance t
-   25 |       qi = q.size with (1);   
+   24 |       qi = q.size with (1);   
       |                   ^~~~
 %Error: Exiting due to

--- a/test_regress/t/t_queue_method_bad.v
+++ b/test_regress/t/t_queue_method_bad.v
@@ -12,7 +12,6 @@ module t (/*AUTOARG*/);
       int qi[$];  // Index returns
 
       q = '{2, 2, 4, 1, 3};
-      qv = q.unique with (1);  // Bad no with allowed
       q.reverse(1);  // Bad no args allowed
       q.shuffle(1);  // Bad no args allowed
       qv = q.find;  // Bad missing with


### PR DESCRIPTION
It adds support for unique, unique_index, min, max in queues.
I had to change one test in which the error was expected. `with` clause is actually allowed in that method.
I also changed the checking of result of `unique_index` in another test to make it to not rely on order of indices of duplicated values.
Section 7.12.1 of IEEE Std 1800-2017 says:
> The ordering of the returned elements is unrelated to the ordering of the
original array. The index returned for duplicate valued entries may be the index for one of the
duplicates.
