### PR TITLE
Fix non-blocking assignments in forks

### DIFF
--- a/test_regress/t/t_timing_bug3781.pl
+++ b/test_regress/t/t_timing_bug3781.pl
@@ -1,0 +1,28 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2022 by Antmicro Ltd. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+if (!$Self->have_coroutines) {
+    skip("No coroutine support");
+}
+else {
+    compile(
+        verilator_flags2 => ["--exe --main --timing"],
+        make_main => 0,
+        );
+
+    execute(
+        check_finished => 1,
+        );
+}
+
+ok(1);
+1;

--- a/test_regress/t/t_timing_bug3781.v
+++ b/test_regress/t/t_timing_bug3781.v
@@ -1,0 +1,30 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2022 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+module t;
+    logic clk;
+    logic [7:0] data;
+    logic [3:0] ptr;
+    logic [7:0] mem[16];
+
+    initial begin
+        clk = 1'b0;
+        fork forever #5 clk = ~clk; join_none
+        ptr = '0;
+        #10 data = 1;
+        #10 if (mem[ptr] != data) $stop;
+        #10 data = 2;
+        #10 if (mem[ptr] != data) $stop;
+        #10 data = 3;
+        #10 if (mem[ptr] != data) $stop;
+        #10 $write("*-* All Finished *-*\n");
+        $finish;
+    end
+
+    always @(posedge clk) begin
+        mem[ptr] <= #1 data;
+    end
+endmodule


### PR DESCRIPTION
NBAs in forks are currently being treated like normal NBAs, but they should be treated like NBAs in suspendable processes. Also affects NBAs with intra-assignment delays (as they are being transformed to assignments in forks).

Fixes #3781.

Signed-off-by: Krzysztof Bieganski <kbieganski@antmicro.com>