### PR TITLE
Set the global `usesTiming` flag if forks exist

### DIFF
--- a/src/V3Timing.cpp
+++ b/src/V3Timing.cpp
@@ -746,6 +746,7 @@ private:
     }
     void visit(AstFork* nodep) override {
         if (nodep->user1SetOnce()) return;
+        v3Global.setUsesTiming();
         // Create a unique name for this fork
         nodep->name(m_forkNames.get(nodep));
         unsigned idx = 0;  // Index for naming begins


### PR DESCRIPTION
If a design has forks, but no timing controls, the `usesTiming` flag wouldn't be set. This resulted in the "transform forks into separate coroutines" being skipped, and ultimately non-emitable constructs like `begin` reaching the emit stage. Fixes #3792.

Signed-off-by: Krzysztof Bieganski <kbieganski@antmicro.com>
