### PR TITLE
Fix missing VL_REQUIRES in commandArgsAddGuts definition

### DIFF
--- a/include/verilated.cpp
+++ b/include/verilated.cpp
@@ -2454,14 +2454,17 @@ void VerilatedContext::threads(unsigned n) {
 }
 
 void VerilatedContext::commandArgs(int argc, const char** argv) VL_MT_SAFE_EXCLUDES(m_argMutex) {
-    const VerilatedLockGuard lock{m_argMutex};
-    m_args.m_argVec.clear();  // Empty first, then add
-    impp()->commandArgsAddGuts(argc, argv);
+    // don't lock `m_argMutex` here, it is done in `impp()->commandArgsAddGuts`
+    // `m_argMutex` here is the same as in `impp()->commandArgsAddGuts`
+    // due to clang limitations, it doesn't properly checks it
+    impp()->commandArgsGuts(argc, argv);
 }
 void VerilatedContext::commandArgsAdd(int argc, const char** argv)
     VL_MT_SAFE_EXCLUDES(m_argMutex) {
-    const VerilatedLockGuard lock{m_argMutex};
-    impp()->commandArgsAddGuts(argc, argv);
+    // don't lock `m_argMutex` here, it is done in `impp()->commandArgsAddGutsLock`
+    // `m_argMutex` here is the same as in `impp()->commandArgsAddGutsLock`
+    // due to clang limitations, it doesn't properly checks it
+    impp()->commandArgsAddGutsLock(argc, argv);
 }
 const char* VerilatedContext::commandArgsPlusMatch(const char* prefixp)
     VL_MT_SAFE_EXCLUDES(m_argMutex) {
@@ -2510,6 +2513,18 @@ VerilatedContext::enableExecutionProfiler(VerilatedVirtualBase* (*construct)(Ver
 
 //======================================================================
 // VerilatedContextImp:: Methods - command line
+void VerilatedContextImp::commandArgsGuts(int argc, const char** argv)
+    VL_MT_SAFE_EXCLUDES(m_argMutex) {
+    const VerilatedLockGuard lock{m_argMutex};
+    m_args.m_argVec.clear();  // Empty first, then add
+    commandArgsAddGuts(argc, argv);
+}
+
+void VerilatedContextImp::commandArgsAddGutsLock(int argc, const char** argv)
+    VL_MT_SAFE_EXCLUDES(m_argMutex) {
+    const VerilatedLockGuard lock{m_argMutex};
+    commandArgsAddGuts(argc, argv);
+}
 
 void VerilatedContextImp::commandArgsAddGuts(int argc, const char** argv) VL_REQUIRES(m_argMutex) {
     if (!m_args.m_argVecLoaded) m_args.m_argVec.clear();

--- a/include/verilated_imp.h
+++ b/include/verilated_imp.h
@@ -387,7 +387,9 @@ private:
 
 protected:
     // METHODS - protected
-    void commandArgsAddGuts(int argc, const char** argv);
+    void commandArgsGuts(int argc, const char** argv) VL_MT_SAFE_EXCLUDES(m_argMutex);
+    void commandArgsAddGutsLock(int argc, const char** argv) VL_MT_SAFE_EXCLUDES(m_argMutex);
+    void commandArgsAddGuts(int argc, const char** argv) VL_REQUIRES(m_argMutex);
     void commandArgVl(const std::string& arg);
     bool commandArgVlString(const std::string& arg, const std::string& prefix,
                             std::string& valuer);


### PR DESCRIPTION
Discovered while working on: https://github.com/verilator/verilator/pull/3748

Currently only declaration of ``commandArgsAddGuts`` have ``VL_REQUIRES`` (https://github.com/verilator/verilator/blob/master/include/verilated.cpp#L2514). Clang thread-safety analysis requires definition to have this annotation.

This PR adds this annotation to definition and fixes problems found by clang thread-safety analysis.

Signed-off-by: Kamil Rakoczy <krakoczy@antmicro.com>
