### PR TITLE
AstToDfg addDriver: cache rhs width to avoid use-after-free

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -55,6 +55,7 @@ Jamie Iles
 Jan Van Winkel
 Jean Berniolles
 Jeremy Bennett
+Jevin Sweval
 Jiacheng Qian
 Jiuyang Liu
 John Coiner

--- a/src/V3DfgAstToDfg.cpp
+++ b/src/V3DfgAstToDfg.cpp
@@ -277,9 +277,10 @@ class AstToDfgVisitor final : public VNVisitor {
                    std::vector<Driver>& drivers) const {
         if (DfgConcat* const concatp = vtxp->cast<DfgConcat>()) {
             DfgVertex* const rhsp = concatp->rhsp();
+            auto const rhs_width = rhsp->width();
             addDriver(rhsp->fileline(), lsb, rhsp, drivers);
             DfgVertex* const lhsp = concatp->lhsp();
-            addDriver(lhsp->fileline(), lsb + rhsp->width(), lhsp, drivers);
+            addDriver(lhsp->fileline(), lsb + rhs_width, lhsp, drivers);
             concatp->unlinkDelete(*m_dfgp);
         } else {
             drivers.emplace_back(flp, lsb, vtxp);

--- a/test_regress/t/t_dfg_3817.pl
+++ b/test_regress/t/t_dfg_3817.pl
@@ -1,0 +1,17 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2022 by Jevin Sweval. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(vlt => 1);
+
+# test case was causing use-after-free and segfaulting during verilation
+compile();
+
+ok(1);
+1;

--- a/test_regress/t/t_dfg_3817.v
+++ b/test_regress/t/t_dfg_3817.v
@@ -1,0 +1,15 @@
+// DESCRIPTION: Verilator: Verilog Test module for issue #3817
+// addDriver() was causing use-after-free and segfaulting during verilation
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2022 by Jevin Sweval.
+// SPDX-License-Identifier: CC0-1.0
+
+module t (
+  output [2:0] c_b_a,
+  input a,
+  input b,
+  input c
+);
+  assign c_b_a = {c, {b, a}};
+endmodule


### PR DESCRIPTION
This is my uneducated attempt to resolve #3817. It uses a work-list so the concat nodes aren't freed while in a nested addDriver() call.

I'll update this PR with a regression test once I learn how those are done in verilator.
