### PR TITLE
On macOS, mark weak symbols with -U linker flag

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -55,6 +55,7 @@ Jamie Iles
 Jan Van Winkel
 Jean Berniolles
 Jeremy Bennett
+Jevin Sweval
 Jiacheng Qian
 Jiuyang Liu
 John Coiner

--- a/include/verilated.mk.in
+++ b/include/verilated.mk.in
@@ -47,6 +47,10 @@ ifneq ($(words $(CURDIR)),1)
 endif
 
 ######################################################################
+# OS detection
+UNAME_S := $(shell uname -s)
+
+######################################################################
 # C Preprocessor flags
 
 # Add -MMD -MP if you're using a recent version of GCC.
@@ -77,6 +81,12 @@ CPPFLAGS += $(OPT)
 
 CPPFLAGS += $(M32)
 LDFLAGS  += $(M32)
+
+# On macOS, specify all weak symbols as dynamic_lookup.
+# Otherwise, you get undefined symbol errors.
+ifeq ($(UNAME_S),Darwin)
+	LDFLAGS += -Wl,-U,__Z15vl_time_stamp64v,-U,__Z13sc_time_stampv
+endif
 
 # Allow upper level user makefiles to specify flags they want.
 # These aren't ever set by Verilator, so users are free to override them.

--- a/include/verilatedos.h
+++ b/include/verilatedos.h
@@ -54,6 +54,7 @@
 # define VL_ATTR_PURE __attribute__((pure))
 # define VL_ATTR_UNUSED __attribute__((unused))
 # if !defined(_WIN32) && !defined(__MINGW32__)
+// All VL_ATTR_WEAK symbols must be marked with the macOS -U linker flag in verilated.mk.in
 #  define VL_ATTR_WEAK __attribute__((weak))
 # endif
 # if defined(__clang__)


### PR DESCRIPTION
Otherwise, you get undefined symbol errors when a weak definition is not provided.

Currently this is only `vl_time_stamp64()` and `sc_time_stamp()`.