### PR TITLE
Fix #3824 of wrong bit op tree optimization

### DIFF
--- a/src/V3Const.cpp
+++ b/src/V3Const.cpp
@@ -560,9 +560,11 @@ class ConstBitOpTreeVisitor final : public VNVisitor {
                     if (leafInfo.lsb() <= leafInfo.msb()) {
                         m_bitPolarities.emplace_back(leafInfo, isXorTree() || leafInfo.polarity(),
                                                      leafInfo.lsb());
-                    } else if (isAndTree() && leafInfo.polarity()) {
-                        // If there is a constant 0 term in an And tree, we must include it. Fudge
-                        // this by adding a bit with both polarities, which will simplify to zero
+                    } else if ((isAndTree() && leafInfo.polarity())
+                               || (isOrTree() && !leafInfo.polarity())) {
+                        // If there is a constant 0 term in an And tree or 1 term in an Or tree, we
+                        // must include it. Fudge this by adding a bit with both polarities, which
+                        // will simplify to zero or one respectively.
                         m_bitPolarities.emplace_back(leafInfo, true, 0);
                         m_bitPolarities.emplace_back(leafInfo, false, 0);
                     }

--- a/src/V3Const.cpp
+++ b/src/V3Const.cpp
@@ -565,6 +565,8 @@ class ConstBitOpTreeVisitor final : public VNVisitor {
                         // If there is a constant 0 term in an And tree or 1 term in an Or tree, we
                         // must include it. Fudge this by adding a bit with both polarities, which
                         // will simplify to zero or one respectively.
+                        // Note that Xor tree does not need this kind of care, polarity of Xor tree
+                        // is already cared when visitin AstNot. Taking xor with 1'b0 is nop.
                         m_bitPolarities.emplace_back(leafInfo, true, 0);
                         m_bitPolarities.emplace_back(leafInfo, false, 0);
                     }

--- a/test_regress/t/t_const_opt.pl
+++ b/test_regress/t/t_const_opt.pl
@@ -20,7 +20,7 @@ execute(
     );
 
 if ($Self->{vlt}) {
-    file_grep($Self->{stats}, qr/Optimizations, Const bit op reduction\s+(\d+)/i, 15);
+    file_grep($Self->{stats}, qr/Optimizations, Const bit op reduction\s+(\d+)/i, 16);
 }
 ok(1);
 1;


### PR DESCRIPTION
As usual, push a test to reproduce #3824, then push its fix later.

When a variable is shift-out, then the term becomes constant.
I cannot remember why only And has been considered.

I checked ext tests pass.