### PR TITLE
Test to show more generate scope issues

### DIFF
--- a/test_regress/t/t_vpi_var.cpp
+++ b/test_regress/t/t_vpi_var.cpp
@@ -703,6 +703,7 @@ int main(int argc, char** argv) {
     const std::unique_ptr<VM_PREFIX> topp{new VM_PREFIX{contextp.get(),
                                                         // Note null name - we're flattening it out
                                                         ""}};
+    contextp->scopesDump();
 
 #ifdef VERILATOR
 #ifdef TEST_VERBOSE

--- a/test_regress/t/t_vpi_var.v
+++ b/test_regress/t/t_vpi_var.v
@@ -95,7 +95,21 @@ extern "C" int mon_check();
    generate
    for (i=1; i<=6; i=i+1) begin : arr
      arr #(.LENGTH(i)) arr();
-   end endgenerate
+   end 
+   endgenerate
+
+   genvar k;
+   generate
+   for (k=1; k<=6; k=k+1) begin : subs
+      sub subsub();
+   end 
+   endgenerate
+
+   generate
+   for (i=1; i<=6; i=i+1) begin : arr2
+     arr #(.LENGTH(6)) arr();
+   end 
+   endgenerate
 
 endmodule : t
 


### PR DESCRIPTION
This isn't a full test case, just modifies the design and prints out the scope.

make -j && test_regress/t/t_vpi_var.pl

produces 
```
  scopesDump:
    SCOPE 0x562c4151a640: t
       VAR 0x562c4151c128: count
       VAR 0x562c4151c1a8: fourthreetwoone
       VAR 0x562c4151c228: half_count
       VAR 0x562c4151c2a8: onebit
       VAR 0x562c4151c328: quads
       VAR 0x562c4151c3c8: text
       VAR 0x562c4151c448: text_byte
       VAR 0x562c4151c4c8: text_half
       VAR 0x562c4151c548: text_long
       VAR 0x562c4151c5c8: text_word
       VAR 0x562c4151c648: twoone
    SCOPE 0x562c4151a6b0: t.arr2[1].arr
       VAR 0x562c4151c708: check
       VAR 0x562c4151c788: rfr
       VAR 0x562c4151c808: sig
       VAR 0x562c4151c888: verbose
    SCOPE 0x562c4151a720: t.arr2[2].arr
       VAR 0x562c4151c948: check
       VAR 0x562c4151c9c8: rfr
       VAR 0x562c4151ca48: sig
       VAR 0x562c4151cac8: verbose
    SCOPE 0x562c4151a790: t.arr2[3].arr
       VAR 0x562c4151cb88: check
       VAR 0x562c4151cc08: rfr
       VAR 0x562c4151cc88: sig
       VAR 0x562c4151cd08: verbose
    SCOPE 0x562c4151a800: t.arr2[4].arr
       VAR 0x562c4151cdc8: check
       VAR 0x562c4151ce48: rfr
       VAR 0x562c4151cec8: sig
       VAR 0x562c4151cf48: verbose
    SCOPE 0x562c4151a870: t.arr2[5].arr
       VAR 0x562c4151d008: check
       VAR 0x562c4151d088: rfr
       VAR 0x562c4151d108: sig
       VAR 0x562c4151d188: verbose
    SCOPE 0x562c4151a8e0: t.arr2[6].arr
       VAR 0x562c4151d248: check
       VAR 0x562c4151d2c8: rfr
       VAR 0x562c4151d348: sig
       VAR 0x562c4151d3c8: verbose
    SCOPE 0x562c4151a678: t.arr2__BRA__1__KET__
    SCOPE 0x562c4151a6e8: t.arr2__BRA__2__KET__
    SCOPE 0x562c4151a758: t.arr2__BRA__3__KET__
    SCOPE 0x562c4151a7c8: t.arr2__BRA__4__KET__
    SCOPE 0x562c4151a838: t.arr2__BRA__5__KET__
    SCOPE 0x562c4151a8a8: t.arr2__BRA__6__KET__
    SCOPE 0x562c4151a950: t.arr[1].arr
       VAR 0x562c4151d488: check
       VAR 0x562c4151d508: rfr
       VAR 0x562c4151d588: sig
       VAR 0x562c4151d608: verbose
    SCOPE 0x562c4151a9c0: t.arr[2].arr
       VAR 0x562c4151d6c8: check
       VAR 0x562c4151d748: rfr
       VAR 0x562c4151d7c8: sig
       VAR 0x562c4151d848: verbose
    SCOPE 0x562c4151aa30: t.arr[3].arr
       VAR 0x562c4151d908: check
       VAR 0x562c4151d988: rfr
       VAR 0x562c4151da08: sig
       VAR 0x562c4151da88: verbose
    SCOPE 0x562c4151aaa0: t.arr[4].arr
       VAR 0x562c4151db48: check
       VAR 0x562c4151dbc8: rfr
       VAR 0x562c4151dc48: sig
       VAR 0x562c4151dcc8: verbose
    SCOPE 0x562c4151ab10: t.arr[5].arr
       VAR 0x562c4151dd88: check
       VAR 0x562c4151de08: rfr
       VAR 0x562c4151de88: sig
       VAR 0x562c4151df08: verbose
    SCOPE 0x562c4151ab80: t.arr[6].arr
       VAR 0x562c4151dfc8: check
       VAR 0x562c4151e048: rfr
       VAR 0x562c4151e0c8: sig
       VAR 0x562c4151e148: verbose
    SCOPE 0x562c4151a918: t.arr__BRA__1__KET__
    SCOPE 0x562c4151a988: t.arr__BRA__2__KET__
    SCOPE 0x562c4151a9f8: t.arr__BRA__3__KET__
    SCOPE 0x562c4151aa68: t.arr__BRA__4__KET__
    SCOPE 0x562c4151aad8: t.arr__BRA__5__KET__
    SCOPE 0x562c4151ab48: t.arr__BRA__6__KET__
    SCOPE 0x562c4151abb8: t.sub
       VAR 0x562c4151e208: subsig1
       VAR 0x562c4151e288: subsig2
    SCOPE 0x562c4151abf0: t.subs__BRA__1__KET__
    SCOPE 0x562c4151ac28: t.subs__BRA__1__KET__.subsub
       VAR 0x562c4151e348: subsig1
       VAR 0x562c4151e3c8: subsig2
    SCOPE 0x562c4151ac60: t.subs__BRA__2__KET__
    SCOPE 0x562c4151ac98: t.subs__BRA__2__KET__.subsub
       VAR 0x562c4151e488: subsig1
       VAR 0x562c4151e508: subsig2
    SCOPE 0x562c4151acd0: t.subs__BRA__3__KET__
    SCOPE 0x562c4151ad08: t.subs__BRA__3__KET__.subsub
       VAR 0x562c4151e5c8: subsig1
       VAR 0x562c4151e648: subsig2
    SCOPE 0x562c4151ad40: t.subs__BRA__4__KET__
    SCOPE 0x562c4151ad78: t.subs__BRA__4__KET__.subsub
       VAR 0x562c4151e708: subsig1
       VAR 0x562c4151e788: subsig2
    SCOPE 0x562c4151adb0: t.subs__BRA__5__KET__
    SCOPE 0x562c4151ade8: t.subs__BRA__5__KET__.subsub
       VAR 0x562c4151e848: subsig1
       VAR 0x562c4151e8c8: subsig2
    SCOPE 0x562c4151ae20: t.subs__BRA__6__KET__
    SCOPE 0x562c4151ae58: t.subs__BRA__6__KET__.subsub
       VAR 0x562c4151e988: subsig1
       VAR 0x562c4151ea08: subsig2
```