### PR TITLE
cmake: fix upper-case and missing include directory

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -483,6 +483,7 @@ target_include_directories(${verilator}
     ../include
     ${WIN_FLEX_BISON}
     ${CMAKE_CURRENT_BINARY_DIR}
+    ${CMAKE_CURRENT_BINARY_DIR}/../include
     ${CMAKE_CURRENT_SOURCE_DIR}
 )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -183,7 +183,7 @@ set(COMMON_SOURCES
     V3Branch.cpp                  
     V3Broken.cpp                  
     V3CCtors.cpp
-    V3Cuse.cpp
+    V3CUse.cpp
     V3Case.cpp                    
     V3Cast.cpp                    
     V3Cdc.cpp                     
@@ -375,7 +375,7 @@ add_custom_command(
     MAIN_DEPENDENCY ./V3PreLex.l
     DEPENDS ${HEADERS}
     COMMAND ${FLEX_EXECUTABLE} ARGS
-        ${LFLAGS} -o "${FLEX_V3PreLex_pregen_OUTPUTS}" "${srcdir}/V3Prelex.l"
+        ${LFLAGS} -o "${FLEX_V3PreLex_pregen_OUTPUTS}" "${srcdir}/V3PreLex.l"
 )
 # Output used by another command
 


### PR DESCRIPTION
This PR fixes missing upper-case and adds generated include directory (this is place where configured ``verilated_config.h.in`` is generated) to ``target_include_directories``.
