### PR TITLE
Convert three files from Unicode to ASCII

### DIFF
--- a/docs/CONTRIBUTING.rst
+++ b/docs/CONTRIBUTING.rst
@@ -59,7 +59,7 @@ Did you write a patch that fixes a bug?
   Creative Commons Public Domain (CC0), unless you request otherwise or
   put a GNU/Artistic license on your file.
 
-- Most important is we get your patch. If you’d like to clean up
+- Most important is we get your patch. If you'd like to clean up
   indentation and related issues ahead of our feedback, that is
   appreciated; please see the coding conventions in `docs/internals
   <internals.rst>`__.

--- a/docs/guide/languages.rst
+++ b/docs/guide/languages.rst
@@ -130,11 +130,11 @@ simulation (perhaps using :vlopt:`--build`) and run it.
 With :vlopt:`--no-timing`, all timing controls cause the :option:`NOTIMING`
 error, except:
 
-* delay statements – they are ignored (as they are in synthesis), though they
+* delay statements - they are ignored (as they are in synthesis), though they
   do issue a :option:`STMTDLY` warning,
-* intra-assignment timing controls – they are ignored, though they do issue an
+* intra-assignment timing controls - they are ignored, though they do issue an
   :option:`ASSIGNDLY` warning,
-* net delays – they are ignored,
+* net delays - they are ignored,
 * event controls at the top of the procedure,
 
 Forks cause this error as well, except:

--- a/docs/internals.rst
+++ b/docs/internals.rst
@@ -564,7 +564,7 @@ lifetime, and prevents multiple ``resume`` calls in the case of
 ^^^^^^^^^^^^^^^
 
 Return value of all coroutines. Together with the promise type contained
-within, it allows for chaining coroutines – resuming coroutines from up the
+within, it allows for chaining coroutines - resuming coroutines from up the
 call stack. The calling coroutine's handle is saved in the promise object as a
 continuation, that is, the coroutine that must be resumed after the promise's
 coroutine finishes. This is necessary as C++ coroutines are stackless, meaning
@@ -585,7 +585,7 @@ simulation time is retrieved from a ``VerilatedContext`` object.
 
 This class manages processes that await events (triggers). There is one such
 object per each trigger awaited by coroutines. Coroutines ``co_await`` this
-object's ``trigger`` function. They are stored in two stages – `uncommitted`
+object's ``trigger`` function. They are stored in two stages - `uncommitted`
 and `ready`. First, they land in the `uncommitted` stage, and cannot be
 resumed. The ``resume`` function resumes all coroutines from the `ready` stage
 and moves `uncommitted` coroutines into `ready`. The ``commit`` function only


### PR DESCRIPTION
While Unicode has its place, CVE-2021-42694 and CVE-2021-42574 make it clear it also has disadvantages.
In a code base like Verilator, I figure the fewer Unicode files the better. This patch reduces the count from seven to four, with no penalty that I can see.
