### PR TITLE
Remove IMPURE warning

### DIFF
--- a/docs/guide/warnings.rst
+++ b/docs/guide/warnings.rst
@@ -741,19 +741,6 @@ List Of Warnings
    correctly.
 
 
-.. option:: IMPURE
-
-   .. TODO better example
-
-   Warns that a task or function that has been marked with a
-   :option:`/*verilator&32;no_inline_task*/` metacomment, but it references
-   variables that are not local to the task, and Verilator cannot schedule
-   these variables correctly.
-
-   Ignoring this warning may make Verilator simulations differ from other
-   simulators.
-
-
 .. option:: INCABSPATH
 
    .. TODO better example

--- a/src/V3Error.h
+++ b/src/V3Error.h
@@ -97,7 +97,6 @@ public:
         IMPERFECTSCH,   // Imperfect schedule (disabled by default). Historical, never issued.
         IMPLICIT,       // Implicit wire
         IMPORTSTAR,     // Import::* in $unit
-        IMPURE,         // Impure function not being inlined
         INCABSPATH,     // Include has absolute path
         INFINITELOOP,   // Infinite loop
         INITIALDLY,     // Initial delayed statement
@@ -180,7 +179,7 @@ public:
             "DECLFILENAME", "DEFPARAM", "DEPRECATED",
             "ENCAPSULATED", "ENDLABEL", "ENUMVALUE", "EOFNEWLINE", "GENCLK", "HIERBLOCK",
             "IFDEPTH", "IGNOREDRETURN",
-            "IMPERFECTSCH", "IMPLICIT", "IMPORTSTAR", "IMPURE",
+            "IMPERFECTSCH", "IMPLICIT", "IMPORTSTAR",
             "INCABSPATH", "INFINITELOOP", "INITIALDLY", "INSECURE",
             "LATCH", "LITENDIAN", "MINTYPMAXDLY", "MODDUP",
             "MULTIDRIVEN", "MULTITOP","NOLATCH", "NULLPORT", "PINCONNECTEMPTY",
@@ -208,8 +207,7 @@ public:
     bool pretendError() const VL_MT_SAFE {
         return (m_e == ASSIGNIN || m_e == BADSTDPRAGMA || m_e == BLKANDNBLK || m_e == BLKLOOPINIT
                 || m_e == CONTASSREG || m_e == ENCAPSULATED || m_e == ENDLABEL || m_e == ENUMVALUE
-                || m_e == IMPURE || m_e == PINNOTFOUND || m_e == PKGNODECL
-                || m_e == PROCASSWIRE  // Says IEEE
+                || m_e == PINNOTFOUND || m_e == PKGNODECL || m_e == PROCASSWIRE  // Says IEEE
                 || m_e == ZERODLY);
     }
     // Warnings to mention manual

--- a/src/V3Task.cpp
+++ b/src/V3Task.cpp
@@ -142,26 +142,8 @@ public:
     void ftaskCFuncp(AstNodeFTask* nodep, AstCFunc* cfuncp) {
         getFTaskVertex(nodep)->cFuncp(cfuncp);
     }
-    void checkPurity(AstNodeFTask* nodep) { checkPurity(nodep, getFTaskVertex(nodep)); }
 
 private:
-    void checkPurity(AstNodeFTask* nodep, TaskBaseVertex* vxp) {
-        if (nodep->recursive()) return;  // Impure, but no warning
-        if (!vxp->pure()) {
-            nodep->v3warn(
-                IMPURE, "Unsupported: External variable referenced by non-inlined function/task: "
-                            << nodep->prettyNameQ() << '\n'
-                            << nodep->warnContextPrimary() << '\n'
-                            << vxp->impureNode()->warnOther()
-                            << "... Location of the external reference: "
-                            << vxp->impureNode()->prettyNameQ() << '\n'
-                            << vxp->impureNode()->warnContextSecondary());
-        }
-        // And, we need to check all tasks this task calls
-        for (V3GraphEdge* edgep = vxp->outBeginp(); edgep; edgep = edgep->outNextp()) {
-            checkPurity(nodep, static_cast<TaskBaseVertex*>(edgep->top()));
-        }
-    }
     TaskFTaskVertex* getFTaskVertex(AstNodeFTask* nodep) {
         if (!nodep->user4p()) nodep->user4p(new TaskFTaskVertex{&m_callGraph, nodep});
         return static_cast<TaskFTaskVertex*>(nodep->user4u().toGraphVertex());
@@ -1457,9 +1439,6 @@ private:
                 || m_statep->ftaskNoInline(nodep)) {
                 // Clone it first, because we may have later FTaskRef's that still need
                 // the original version.
-                if (m_statep->ftaskNoInline(nodep) && !nodep->classMethod()) {
-                    m_statep->checkPurity(nodep);
-                }
                 AstNodeFTask* const clonedFuncp = nodep->cloneTree(false);
                 if (nodep->isConstructor()) m_statep->remapFuncClassp(nodep, clonedFuncp);
 

--- a/test_regress/t/t_func_impure.pl
+++ b/test_regress/t/t_func_impure.pl
@@ -8,11 +8,13 @@ if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); di
 # Version 2.0.
 # SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
 
-scenarios(vlt => 1);
+scenarios(simulator => 1);
 
-lint(
-    fails => 1,
-    expect_filename => $Self->{golden_filename},
+compile(
+    );
+
+execute(
+    check_finished => 1,
     );
 
 ok(1);

--- a/test_regress/t/t_func_impure.v
+++ b/test_regress/t/t_func_impure.v
@@ -1,4 +1,4 @@
-// DESCRIPTION: Verilator: Test of select from constant
+// DESCRIPTION: Verilator: Verilog Test module
 //
 // This file ONLY is placed under the Creative Commons Public Domain, for
 // any use, without warranty, 2020 by Wilson Snyder.
@@ -15,6 +15,10 @@ module t (/*AUTOARG*/);
 
    initial begin
       foo();
+      if (sig == '1) begin
+         $write("*-* All Finished *-*\n");
+         $finish;
+      end
    end
 
 endmodule

--- a/test_regress/t/t_func_impure_bad.out
+++ b/test_regress/t/t_func_impure_bad.out
@@ -1,8 +1,0 @@
-%Error-IMPURE: t/t_func_impure_bad.v:11:9: Unsupported: External variable referenced by non-inlined function/task: 't.foo'
-   11 |    task foo;
-      |         ^~~
-               t/t_func_impure_bad.v:13:7: ... Location of the external reference: 't.sig'
-   13 |       sig = '1;
-      |       ^~~
-               ... For error description see https://verilator.org/warn/IMPURE?v=latest
-%Error: Exiting due to

--- a/test_regress/t/t_lint_historical.v
+++ b/test_regress/t/t_lint_historical.v
@@ -39,7 +39,6 @@ module t;
    // verilator lint_off IMPERFECTSCH
    // verilator lint_off IMPLICIT
    // verilator lint_off IMPORTSTAR
-   // verilator lint_off IMPURE
    // verilator lint_off INCABSPATH
    // verilator lint_off INFINITELOOP
    // verilator lint_off INITIALDLY


### PR DESCRIPTION
This warning is thrown when non-inlined function / task references a variable declared outside the function / task. It causes problems when I try to handle `static` variables by moving them outside a function.
According to 23.9 of the Standard, it is legal within a function to reference a variable outside the function. However, in the warning description it is said that such references may cause incorrect scheduling. Is it still true? As I checked, no test failed when I removed it.

test_regress/t/t_lint_historical.v failed when I removed the warning, but according to the description, it should pass even with removed warnings. If we need to parse removed warning, I think it is not a problem to fix it. But do we need them?