### PR TITLE
Fix module parameter 'name' collision

### DIFF
--- a/src/V3EmitCHeaders.cpp
+++ b/src/V3EmitCHeaders.cpp
@@ -147,7 +147,7 @@ class EmitCHeader final : public EmitCConstInit {
         if (!VN_IS(modp, Class)) {  // Classes use CFuncs with isConstructor/isDestructor
             const string& name = prefixNameProtect(modp);
             putsDecoration("\n// CONSTRUCTORS\n");
-            puts(name + "(" + symClassName() + "* symsp, const char* V__name);\n");
+            puts(name + "(" + symClassName() + "* symsp, const char* v__name);\n");
             puts("~" + name + "();\n");
             puts("VL_UNCOPYABLE(" + name + ");\n");
         }

--- a/src/V3EmitCHeaders.cpp
+++ b/src/V3EmitCHeaders.cpp
@@ -147,7 +147,7 @@ class EmitCHeader final : public EmitCConstInit {
         if (!VN_IS(modp, Class)) {  // Classes use CFuncs with isConstructor/isDestructor
             const string& name = prefixNameProtect(modp);
             putsDecoration("\n// CONSTRUCTORS\n");
-            puts(name + "(" + symClassName() + "* symsp, const char* name);\n");
+            puts(name + "(" + symClassName() + "* symsp, const char* V__name);\n");
             puts("~" + name + "();\n");
             puts("VL_UNCOPYABLE(" + name + ");\n");
         }

--- a/src/V3EmitCImp.cpp
+++ b/src/V3EmitCImp.cpp
@@ -250,8 +250,8 @@ class EmitCImp final : EmitCFunc {
                          "(" + modName + "* vlSelf);");
         puts("\n");
 
-        puts(modName + "::" + modName + "(" + symClassName() + "* symsp, const char* name)\n");
-        puts("    : VerilatedModule{name}\n");
+        puts(modName + "::" + modName + "(" + symClassName() + "* symsp, const char* V__name)\n");
+        puts("    : VerilatedModule{V__name}\n");
 
         ofp()->indentInc();
         for (const AstNode* nodep = modp->stmtsp(); nodep; nodep = nodep->nextp()) {

--- a/src/V3EmitCImp.cpp
+++ b/src/V3EmitCImp.cpp
@@ -250,8 +250,8 @@ class EmitCImp final : EmitCFunc {
                          "(" + modName + "* vlSelf);");
         puts("\n");
 
-        puts(modName + "::" + modName + "(" + symClassName() + "* symsp, const char* V__name)\n");
-        puts("    : VerilatedModule{V__name}\n");
+        puts(modName + "::" + modName + "(" + symClassName() + "* symsp, const char* v__name)\n");
+        puts("    : VerilatedModule{v__name}\n");
 
         ofp()->indentInc();
         for (const AstNode* nodep = modp->stmtsp(); nodep; nodep = nodep->nextp()) {

--- a/test_regress/t/t_name_collision.pl
+++ b/test_regress/t/t_name_collision.pl
@@ -1,0 +1,21 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2003 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_name_collision.v
+++ b/test_regress/t/t_name_collision.v
@@ -1,0 +1,18 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2022 by Wilson Snyder.
+// SPDX-License-Identifier: CC0-1.0
+
+module HasNameParam
+  #(parameter name /*verilator public*/ = 0)
+   ();
+endmodule
+
+module t ();
+   HasNameParam a();
+   initial begin
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end
+endmodule


### PR DESCRIPTION
Having a public parameter called 'name' causes variable shadowing to occur, so this PR changes the name of the generated variable from 'name' to 'V__name' to make it less likely to cause a collision. Other generated variables may also cause collisions as well, but this collision is probably a lot more likely than other collisions.

When running the new test with the flags `t/t_name_collision.pl -CFLAGS -Werror=shadow`, it passes with the variable rename in this PR but results in a shadow error without the variable rename.

https://github.com/verilator/verilator/issues/3854