### PR TITLE
Test case for interfaces with incorrect localparam values (#3858)

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -64,6 +64,7 @@ Jonathan Drolet
 Josh Redford
 Julie Schwartz
 Julien Margetts
+Justin Thiel
 Kaleb Barrett
 Kamil Rakoczy
 Kanad Kanhere

--- a/test_regress/t/t_interface_localparam_incorrect.pl
+++ b/test_regress/t/t_interface_localparam_incorrect.pl
@@ -1,0 +1,22 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2023 by Justin Thiel. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+);
+
+execute(
+    check_finished => 1,
+);
+
+ok(1);
+1;
+

--- a/test_regress/t/t_interface_localparam_incorrect.v
+++ b/test_regress/t/t_interface_localparam_incorrect.v
@@ -1,0 +1,54 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed into the Public Domain, for any use,
+// without warranty, 2023 by Justin Thiel.
+// SPDX-License-Identifier: CC0-1.0
+
+interface SimpleIntf
+#(
+   parameter int symbolsPerBeat = 16
+)
+();
+
+   // This value is calculated incorrectly for other instances of
+   // this interface when it is accessed via the HDL for any other
+   // instance of this interface
+   localparam int symbolsPerBeatDivBy2  = symbolsPerBeat/2;
+
+   localparam bit mismatch = (symbolsPerBeat != (2*symbolsPerBeatDivBy2) );
+
+   initial begin
+      $write("%m: symbolsPerBeat %d, symbolsPerBeatDivBy2 %d, mismatch %d\n", symbolsPerBeat, symbolsPerBeatDivBy2, mismatch);
+      if (mismatch) $stop;
+   end
+
+endinterface
+
+module Core(
+   SimpleIntf intf
+);
+
+   // NOTE: When this line is commented out the test will pass
+   localparam intf_symbolsPerBeatDivBy2 = intf.symbolsPerBeatDivBy2;
+
+   localparam int core_intf_symbolsPerBeat = 64;
+   SimpleIntf #(.symbolsPerBeat(core_intf_symbolsPerBeat)) core_intf ();
+
+endmodule
+
+module t();
+
+    SimpleIntf intf();
+
+    Core
+    theCore (
+       .intf
+    );
+
+    initial begin
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end
+
+endmodule
+


### PR DESCRIPTION
It appears that the value of symbolsPerBeatDivBy2 is not recomputed for new interfaces.

```
top.t.intf:              symbolsPerBeat  16, symbolsPerBeatDivBy2  8, mismatch 0
top.t.theCore.core_intf: symbolsPerBeat  64, symbolsPerBeatDivBy2  8, mismatch 1
```

In this case 'intf' is created and symbolsPerBeatDivBy2 is extracted from the interface in a submodule. Once this is done future interfaces of the same type (i.e. 'core_intf' above) seem to inherit the symbolsPerBeatDivBy2 computed for the first declared interface ('intf') even though the symbolsPerBeat (which determines the correct value for symbolsPerBeatDivBy2) value is different for the second instantiated interface.
