### PR TITLE
Jnwabueze/scoped public

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -61,6 +61,7 @@ Jiuyang Liu
 John Coiner
 John Demme
 Jonathan Drolet
+Joseph Nwabueze
 Josh Redford
 Julie Schwartz
 Julien Margetts

--- a/src/V3AstNodeOther.h
+++ b/src/V3AstNodeOther.h
@@ -1635,6 +1635,7 @@ class AstVar final : public AstNode {
     bool m_isForceable : 1;  // May be forced/released externally from user C code
     bool m_isWrittenByDpi : 1;  // This variable can be written by a DPI Export
     bool m_isWrittenBySuspendable : 1;  // This variable can be written by a suspendable process
+    bool m_isPublicScoped : 1; // This variable is wrapped in a VPI public scope
 
     void init() {
         m_ansi = false;
@@ -1678,6 +1679,7 @@ class AstVar final : public AstNode {
         m_isForceable = false;
         m_isWrittenByDpi = false;
         m_isWrittenBySuspendable = false;
+        m_isPublicScoped = false;
         m_attrClocker = VVarAttrClocker::CLOCKER_UNKNOWN;
     }
 
@@ -1839,6 +1841,8 @@ public:
     void setWrittenByDpi() { m_isWrittenByDpi = true; }
     bool isWrittenBySuspendable() const { return m_isWrittenBySuspendable; }
     void setWrittenBySuspendable() { m_isWrittenBySuspendable = true; }
+    bool isPublicScoped() { return m_isPublicScoped; }
+    void setPublicScoped() { m_isPublicScoped = true; }
 
     // METHODS
     void name(const string& name) override { m_name = name; }

--- a/src/V3LinkParse.cpp
+++ b/src/V3LinkParse.cpp
@@ -251,7 +251,7 @@ private:
         // Maybe this variable has a signal attribute
         V3Config::applyVarAttr(m_modp, m_ftaskp, nodep);
 
-        if (v3Global.opt.publicFlatRW()) {
+        if (v3Global.opt.publicFlatRW() || nodep->isPublicScoped()) {
             switch (nodep->varType()) {
             case VVarType::VAR:  // FALLTHRU
             case VVarType::GPARAM:  // FALLTHRU

--- a/src/V3ParseGrammar.cpp
+++ b/src/V3ParseGrammar.cpp
@@ -208,6 +208,7 @@ AstVar* V3ParseGrammar::createVariable(FileLine* fileline, const string& name,
     nodep->declTyped(m_varDeclTyped);
     nodep->lifetime(m_varLifetime);
     nodep->delayp(m_netDelayp);
+    nodep->sigUserRWPublic(PARSEP->isInPublicScope());
     m_netDelayp = nullptr;
     if (GRAMMARP->m_varDecl != VVarType::UNKNOWN) nodep->combineType(GRAMMARP->m_varDecl);
     if (GRAMMARP->m_varIO != VDirection::NONE) {

--- a/src/V3ParseGrammar.cpp
+++ b/src/V3ParseGrammar.cpp
@@ -208,7 +208,9 @@ AstVar* V3ParseGrammar::createVariable(FileLine* fileline, const string& name,
     nodep->declTyped(m_varDeclTyped);
     nodep->lifetime(m_varLifetime);
     nodep->delayp(m_netDelayp);
-    nodep->sigUserRWPublic(PARSEP->isInPublicScope());
+    if (PARSEP->isInPublicScope()) {
+        nodep->setPublicScoped();
+    }
     m_netDelayp = nullptr;
     if (GRAMMARP->m_varDecl != VVarType::UNKNOWN) nodep->combineType(GRAMMARP->m_varDecl);
     if (GRAMMARP->m_varIO != VDirection::NONE) {

--- a/src/V3ParseImp.h
+++ b/src/V3ParseImp.h
@@ -144,6 +144,7 @@ class V3ParseImp final {
 
     FileLine* m_bisonLastFileline = nullptr;  // Filename/linenumber of last token
 
+    bool m_inPublicScope = false;  // Currently inside scoped public annotation
     bool m_inLibrary = false;  // Currently reading a library vs. regular file
     int m_lexKwdDepth = 0;  // Inside a `begin_keywords
     int m_lexKwdLast;  // Last LEX state in `begin_keywords
@@ -162,6 +163,8 @@ class V3ParseImp final {
     VTimescale m_timeLastUnit;  // Last `timescale's unit
 
 public:
+
+
     VL_DEFINE_DEBUG_FUNCTIONS;
     // Note these are an exception to using the filename as the debug type
     VL_DEFINE_DEBUG(Bison);  // Define 'unsigned debugBison()'
@@ -204,6 +207,9 @@ public:
     int lexKwdLastState() const { return m_lexKwdLast; }
     static const char* tokenName(int tok);
     static bool isStrengthToken(int tok);
+
+    bool isInPublicScope() const { return m_inPublicScope; }
+    void setInPublicScope(bool isPublic) { m_inPublicScope = isPublic; }
 
     void ppPushText(const string& text) {
         m_ppBuffers.push_back(text);

--- a/src/verilog.l
+++ b/src/verilog.l
@@ -755,6 +755,8 @@ vnum    {vnum1}|{vnum2}|{vnum3}|{vnum4}|{vnum5}
   "/*verilator public_flat_rd*/"        { FL; return yVL_PUBLIC_FLAT_RD; }
   "/*verilator public_flat_rw*/"        { FL; return yVL_PUBLIC_FLAT_RW; }  // The @(edge) is converted by the preproc
   "/*verilator public_module*/"         { FL; return yVL_PUBLIC_MODULE; }
+  "/*verilator public_on*/"             { FL_FWD; PARSEP->setInPublicScope(true); FL_BRK;  }
+  "/*verilator public_off*/"            { FL_FWD; PARSEP->setInPublicScope(false); FL_BRK; }
   "/*verilator sc_bv*/"                 { FL; return yVL_SC_BV; }
   "/*verilator sc_clock*/"              { FL; yylval.fl->v3warn(DEPRECATED, "sc_clock is ignored"); FL_BRK; }
   "/*verilator sformat*/"               { FL; return yVL_SFORMAT; }

--- a/test_regress/t/t_vpi_var.v
+++ b/test_regress/t/t_vpi_var.v
@@ -23,11 +23,12 @@ extern "C" int mon_check();
 `verilog
 `endif
 
+/*verilator public_on*/
    input clk;
-
-   reg          onebit          /*verilator public_flat_rw @(posedge clk) */;
-   reg [2:1]    twoone          /*verilator public_flat_rw @(posedge clk) */;
-   reg [2:1]    fourthreetwoone[4:3] /*verilator public_flat_rw @(posedge clk) */;
+   reg          onebit          ;
+   reg [2:1]    twoone          ;
+   reg [2:1]    fourthreetwoone[4:3] ;
+/*verilator public_off*/
 
    // verilator lint_off LITENDIAN
    reg [0:61]   quads[2:3]      /*verilator public_flat_rw @(posedge clk) */;


### PR DESCRIPTION
I'd like to make a feature that allows scoped `verilator public` attribute for variables. This pull request is an rough example of what I think it would look like. What's the suggested way to implement a feature like this?