### PR TITLE
Fix the raw access to words in VlUnpacked

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -58,6 +58,7 @@ Jeremy Bennett
 Jevin Sweval
 Jiacheng Qian
 Jiuyang Liu
+Joey Liu
 John Coiner
 John Demme
 Jonathan Drolet

--- a/include/verilated_types.h
+++ b/include/verilated_types.h
@@ -1007,8 +1007,12 @@ struct VlUnpacked final {
 
     // METHODS
     // Raw access
-    WData* data() { return &m_storage[0]; }
-    const WData* data() const { return &m_storage[0]; }
+    WData* data() { return (WData*)&m_storage[0]; }
+    const WData* data() const { return (const WData*)&m_storage[0]; }
+
+    // Raw access for use with VL_ASSIGN_W()
+    operator WData*() { return data(); }
+    operator const WData*() const { return data(); }
 
     T_Value& operator[](size_t index) { return m_storage[index]; }
     const T_Value& operator[](size_t index) const { return m_storage[index]; }

--- a/src/V3AstNodeExpr.h
+++ b/src/V3AstNodeExpr.h
@@ -3760,7 +3760,10 @@ public:
     }
     string emitVerilog() override { return "%k(%l%f[%r])"; }
     string emitC() override {
-        return "%li[%ri]";
+        // Return the pointer to the selected word. No array index operator should be used here as
+        // the structure like VlUnpacked<VlWide<256>,6>[1] points to the 2nd elements of
+        // VlWide<256> instead of the 2nd word.
+        return "*((WData *)(&%li) + %ri)";
     }  // Not %k, as usually it's a small constant rhsp
     bool cleanOut() const override { return true; }
     bool cleanLhs() const override { return true; }

--- a/test_regress/t/t_assign_word_no_expand.pl
+++ b/test_regress/t/t_assign_word_no_expand.pl
@@ -1,0 +1,24 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2023 by Joey Liu. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+top_filename("t/t_expand_word_sel.v");
+
+compile(
+    verilator_flags2 => ['-fno-expand'],
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_expand_word_sel.pl
+++ b/test_regress/t/t_expand_word_sel.pl
@@ -1,0 +1,21 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2023 by Joey Liu. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_expand_word_sel.v
+++ b/test_regress/t/t_expand_word_sel.v
@@ -1,0 +1,36 @@
+module t
+  (
+   output logic [255:0] data_out
+   );
+   localparam int       NUM_STAGES = 3;
+
+   /* verilator lint_off ALWCOMBORDER */
+   /* verilator lint_off UNOPTFLAT */
+
+`define INPUT 256'hbabecafe
+
+   logic [255:0]        stage_data [NUM_STAGES+1];
+
+   genvar               stage;
+   generate
+      always_comb begin
+         stage_data[0] = `INPUT;
+      end
+      for (stage = 0; stage < NUM_STAGES; ++stage) begin : stage_gen
+         always_comb begin
+            stage_data[stage+1] = stage_data[stage];
+         end
+      end
+   endgenerate
+
+   /* verilator lint_on UNOPTFLAT */
+   /* verilator lint_on ALWCOMBORDER */
+
+   always_comb begin
+      data_out = stage_data[NUM_STAGES];
+      if (data_out !== `INPUT) $stop;
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end
+
+endmodule


### PR DESCRIPTION
Summary:
* Provides the operator overload functions for the raw access which is used by VL_ASSIGN_W.
* With the 'expand' optimizer, the small size of VL_ASSIGN_W could be expanded to a bunch of individual word assignments. We should not use the array index operator to select the words, for example, VlUnpacked<VlWide<256>, 3>[2] points to the 2nd element instead of the 2nd word.

Test Plan:
* two test cases are added to cover the scenarios with and without involving 'expand' optimizer.
* the existing test_regress cases pass.
