### PR TITLE
Fix astgen in CMakeLists.txt

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -144,4 +144,4 @@ Yutetsu TAKATSUKASA
 Yu-Sheng Lin
 Yves Mathieu
 Zhanglei Wang
-Ruki Wang
+ruki

--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -144,3 +144,4 @@ Yutetsu TAKATSUKASA
 Yu-Sheng Lin
 Yves Mathieu
 Zhanglei Wang
+Ruki Wang

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -328,7 +328,7 @@ add_custom_command(
     OUTPUT V3Ast__gen_forward_class_decls.h V3Dfg__gen_forward_class_decls.h
     DEPENDS ./V3Ast.h ${ASTGEN}
     COMMAND ${PYTHON3} ARGS
-    ${ASTGEN} -I"${srcdir}" --astdef V3AstNodeDType.h --astdef V3AstNodeExpr.h --astdef V3AstNodeOther.h --dfgdef V3DfgVertices.h --classes
+    ${ASTGEN} -I "${srcdir}" --astdef V3AstNodeDType.h --astdef V3AstNodeExpr.h --astdef V3AstNodeOther.h --dfgdef V3DfgVertices.h --classes
 )
 list(APPEND GENERATED_FILES V3Ast__gen_forward_class_decls.h V3Dfg__gen_forward_class_decls.h)
 # Output used directly by the `verilator` target


### PR DESCRIPTION
I added verilator as xmake package into xmake-repo. https://github.com/xmake-io/xmake-repo/pull/1735

But I got some errors when I am building project for msvc.

> usage: astgen [-h] [-I I] [--astdef ASTDEF] [--dfgdef DFGDEF] [--classes]
                       [--debug]
                       [infiles [infiles ...]]
     9>astgen : error : unrecognized arguments: -IC:/Users/runneradmin/AppData/Local/.xmake/cache/packages/2301/v/verilator/2023.1.10/source/verilator/src [C:\Users\runneradmin\AppData\Local\.xmake\cache\packages\2301\v\verilator\2023.1.10\source\verilator\build_7bc908f2\src\verilator.vcxproj]

https://github.com/xmake-io/xmake-repo/actions/runs/3907789410/jobs/6677354164