### PR TITLE
allow VL_VALUE_STRING_MAX_WORDS to be overriden

### DIFF
--- a/include/verilated_vpi.cpp
+++ b/include/verilated_vpi.cpp
@@ -1751,13 +1751,13 @@ void vl_get_value(const VerilatedVar* varp, void* varDatap, p_vpi_value valuep,
         int i;
         if (bits > t_outStrSz) {
             // limit maximum size of output to size of buffer to prevent overrun.
-            bits = t_outStrSz;
             VL_VPI_WARNING_(
                 __FILE__, __LINE__,
                 "%s: Truncating string value of %s for %s"
                 " as buffer size (%d, VL_VALUE_STRING_MAX_WORDS=%d) is less than required (%d)",
                 __func__, VerilatedVpiError::strFromVpiVal(valuep->format), fullname, t_outStrSz,
                 VL_VALUE_STRING_MAX_WORDS, bits);
+            bits = t_outStrSz;
         }
         for (i = 0; i < bits; ++i) {
             const char val = (datap[i >> 3] >> (i & 7)) & 1;

--- a/include/verilatedos.h
+++ b/include/verilatedos.h
@@ -426,7 +426,11 @@ using ssize_t = uint32_t;  ///< signed size_t; returned from read()
 // Verilated function size macros
 
 #define VL_MULS_MAX_WORDS 16  ///< Max size in words of MULS operation
-#define VL_VALUE_STRING_MAX_WORDS 64  ///< Max size in words of String conversion operation
+
+#ifndef VL_VALUE_STRING_MAX_WORDS
+    #define VL_VALUE_STRING_MAX_WORDS 64  ///< Max size in words of String conversion operation
+#endif
+
 #define VL_VALUE_STRING_MAX_CHARS (VL_VALUE_STRING_MAX_WORDS * VL_EDATASIZE / VL_BYTESIZE)
 
 //=========================================================================


### PR DESCRIPTION
This allows VL_VALUE_STRING_MAX_WORDS to be overridden with -DVL_VALUE_STRING_MAX_WORDS=<max>, and also fixes the warning message to provide useful bits/t_outStrSz comparison.

