### PR TITLE
Support for import-export lists in modport

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -33,6 +33,7 @@ Garrett Smith
 Geza Lore
 Gianfranco Costamagna
 Glen Gibb
+Gökçe Aydos
 Graham Rushton
 Guokai Chen
 Gustav Svensk

--- a/test_regress/t/t_interface_modport_import_export_list.pl
+++ b/test_regress/t/t_interface_modport_import_export_list.pl
@@ -1,0 +1,18 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2023 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+	fails=>0,
+);
+
+ok(1);
+1;

--- a/test_regress/t/t_interface_modport_import_export_list.v
+++ b/test_regress/t/t_interface_modport_import_export_list.v
@@ -1,0 +1,54 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// Modport import export list test
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2023 by Goekce Aydos.
+// SPDX-License-Identifier: CC0-1.0
+
+interface intf;
+	logic l;
+	function void f1();
+	endfunction
+	function void f2();
+	endfunction
+	function void f3();
+	endfunction
+	function void f4();
+	endfunction
+
+	modport mpi (
+		import f1, f2,
+		input l,
+		import f3, f4
+	);
+	modport mpo (
+		output l,
+		import f1, f2, f3, f4
+	);
+endinterface
+
+module mo (intf.mpo intf0);
+	function void ef1();
+		intf0.f1();
+		intf0.f2();
+	endfunction
+	function void ef2();
+		intf0.f3();
+		intf0.f4();
+	endfunction
+
+initial begin
+	ef1();
+	ef2();
+end
+endmodule
+
+module mi (intf.mpi intf0);
+endmodule
+
+module t;
+	intf intf0();
+	mi mi(.*);
+	mo mo(.*);
+endmodule


### PR DESCRIPTION
Verilator's parser only supported simple port lists in interface-modport declarations but not importing (or exporting) task-function port lists. This patch introduces new context variables to differentiate between simple ports and task-function ports.