### PR TITLE
Support property calls without parenthesis

### DIFF
--- a/src/V3LinkDot.cpp
+++ b/src/V3LinkDot.cpp
@@ -2669,7 +2669,8 @@ private:
                 m_ds.m_dotSymp = foundp;
                 ok = m_ds.m_dotPos == DP_SCOPE;
             } else if (VN_IS(foundp->nodep(), Property)) {
-                AstFuncRef* const propRefp = new AstFuncRef{nodep->fileline(), nodep->name(), nullptr};
+                AstFuncRef* const propRefp
+                    = new AstFuncRef{nodep->fileline(), nodep->name(), nullptr};
                 nodep->replaceWith(propRefp);
                 VL_DO_DANGLING(pushDeletep(nodep), nodep);
                 ok = m_ds.m_dotPos == DP_NONE;

--- a/src/V3LinkDot.cpp
+++ b/src/V3LinkDot.cpp
@@ -2668,6 +2668,11 @@ private:
             } else if (VN_IS(foundp->nodep(), Clocking)) {
                 m_ds.m_dotSymp = foundp;
                 ok = m_ds.m_dotPos == DP_SCOPE;
+            } else if (VN_IS(foundp->nodep(), Property)) {
+                AstFuncRef* const propRefp = new AstFuncRef{nodep->fileline(), nodep->name(), nullptr};
+                nodep->replaceWith(propRefp);
+                VL_DO_DANGLING(pushDeletep(nodep), nodep);
+                ok = m_ds.m_dotPos == DP_NONE;
             }
             //
             if (!ok) {

--- a/test_regress/t/t_assert_named_property.v
+++ b/test_regress/t/t_assert_named_property.v
@@ -54,8 +54,16 @@ module t (/*AUTOARG*/
         // Assertion should fail
         expected_fails += 1;
      end
+
+   logic out = 1;
+
+    property prop_a;
+        @(posedge clk) disable iff (cyc <= 10) out;
+    endproperty
+
    assert property(disable iff (cyc < 5) check_if_gt_5(cyc + 1));
    assert property(@(posedge clk) pass_assertion(cyc));
+   assert property (prop_a) else $error($sformatf("property check failed :assert: (False)"));
 
    always @(posedge clk) begin
       if (expected_fails == 2) begin


### PR DESCRIPTION
It fixes https://github.com/verilator/verilator/issues/3879.