### PR TITLE
Class queue equality

### DIFF
--- a/include/verilated_types.h
+++ b/include/verilated_types.h
@@ -273,6 +273,8 @@ public:
     VlQueue(VlQueue&&) = default;
     VlQueue& operator=(const VlQueue&) = default;
     VlQueue& operator=(VlQueue&&) = default;
+    bool operator==(const VlQueue& rhs) const { return m_deque == rhs.m_deque; }
+    bool operator!=(const VlQueue& rhs) const { return m_deque != rhs.m_deque; }
 
     // Standard copy constructor works. Verilog: assoca = assocb
     // Also must allow conversion from a different T_MaxSize queue
@@ -1225,6 +1227,9 @@ public:
     T_Class* operator->() const { return m_objp; }
     // For 'if (ptr)...'
     operator bool() const { return m_objp; }
+    // In SV A == B iff both are handles to the same object (IEEE 1800-2017 8.4)
+    bool operator==(const VlClassRef& rhs) const { return m_objp == rhs.m_objp; };
+    bool operator!=(const VlClassRef& rhs) const { return m_objp != rhs.m_objp; };
 };
 
 template <typename T, typename U>

--- a/include/verilated_types.h
+++ b/include/verilated_types.h
@@ -694,6 +694,8 @@ public:
     VlAssocArray(VlAssocArray&&) = default;
     VlAssocArray& operator=(const VlAssocArray&) = default;
     VlAssocArray& operator=(VlAssocArray&&) = default;
+    bool operator==(const VlAssocArray& rhs) const { return m_map == rhs.m_map; }
+    bool operator!=(const VlAssocArray& rhs) const { return m_map != rhs.m_map; }
 
     // METHODS
     T_Value& atDefault() { return m_defaultValue; }

--- a/test_regress/t/t_assoc_compare.pl
+++ b/test_regress/t/t_assoc_compare.pl
@@ -1,0 +1,21 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2019 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_assoc_compare.v
+++ b/test_regress/t/t_assoc_compare.v
@@ -1,0 +1,67 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2019 by Wilson Snyder.
+// SPDX-License-Identifier: CC0-1.0
+
+`define stop $stop
+`define check_comp(lhs, rhs, op, exp) if ((exp) != ((lhs) op (rhs))) begin $write("%%Error: %s:%0d: op comparison shall return 'b%x\n", `__FILE__, `__LINE__, (exp)); `stop; end
+`define check_eq(lhs, rhs) `check_comp(lhs, rhs, ==, 1'b1) `check_comp(lhs, rhs, !=, 1'b0)
+`define check_ne(lhs, rhs) `check_comp(lhs, rhs, ==, 1'b0) `check_comp(lhs, rhs, !=, 1'b1)
+
+class Cls;
+   int i;
+endclass
+
+module t;
+   initial begin
+      begin // simple case
+         int assoc1[int];
+         int assoc2[int];
+         // Two checks because == and != may not be derived from each other
+         // Empty are equal
+         `check_eq(assoc1, assoc2)
+         // Make different
+         assoc1[10] = 15;
+         assoc2[-1] = 365;
+         `check_ne(assoc1, assoc2)
+         // Make same
+         assoc1[-1] = 365;
+         assoc2[10] = 15;
+         `check_eq(assoc1, assoc2)
+         // Don't actually change
+         assoc1[-1] = 365;
+         `check_eq(assoc1, assoc2)
+         // Compare different sizes
+         assoc1[3] = 0;
+         `check_ne(assoc1, assoc2)
+      end
+      begin // check that a class as key is fine
+         int assoc1[Cls];
+         int assoc2[Cls];
+         Cls a = new;
+         Cls b = new;
+         int t;
+         assoc1[a] = 0;
+         `check_ne(assoc1, assoc2)
+         assoc2[a] = 0;
+         `check_eq(assoc1, assoc2)
+         assoc2.delete(a);
+         assoc2[b] = 0;
+         `check_ne(assoc1, assoc2)
+      end
+      begin // check that a class as value is fine
+         Cls assoc1[int];
+         Cls assoc2[int];
+         Cls a = new;
+         Cls b = new;
+         assoc1[1] = a;
+         assoc2[1] = b;
+         `check_ne(assoc1, assoc2)
+         assoc2[1] = a;
+         `check_eq(assoc1, assoc2)
+      end
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end
+endmodule

--- a/test_regress/t/t_assoc_compare.v
+++ b/test_regress/t/t_assoc_compare.v
@@ -1,4 +1,4 @@
-// DESCRIPTION: Verilator: Verilog Test module
+// DESCRIPTION: Verilator: Check == and != operations performed on associative arrays
 //
 // This file ONLY is placed under the Creative Commons Public Domain, for
 // any use, without warranty, 2023 by Ilya Barkov.
@@ -6,6 +6,7 @@
 
 `define stop $stop
 `define check_comp(lhs, rhs, op, exp) if ((exp) != ((lhs) op (rhs))) begin $write("%%Error: %s:%0d: op comparison shall return 'b%x\n", `__FILE__, `__LINE__, (exp)); `stop; end
+// Two checks because == and != may not be derived from each other
 `define check_eq(lhs, rhs) `check_comp(lhs, rhs, ==, 1'b1) `check_comp(lhs, rhs, !=, 1'b0)
 `define check_ne(lhs, rhs) `check_comp(lhs, rhs, ==, 1'b0) `check_comp(lhs, rhs, !=, 1'b1)
 
@@ -18,7 +19,6 @@ module t;
       begin // simple case
          int assoc1[int];
          int assoc2[int];
-         // Two checks because == and != may not be derived from each other
          // Empty are equal
          `check_eq(assoc1, assoc2)
          // Make different

--- a/test_regress/t/t_assoc_compare.v
+++ b/test_regress/t/t_assoc_compare.v
@@ -1,7 +1,7 @@
 // DESCRIPTION: Verilator: Verilog Test module
 //
 // This file ONLY is placed under the Creative Commons Public Domain, for
-// any use, without warranty, 2019 by Wilson Snyder.
+// any use, without warranty, 2023 by Ilya Barkov.
 // SPDX-License-Identifier: CC0-1.0
 
 `define stop $stop

--- a/test_regress/t/t_class_compare.pl
+++ b/test_regress/t/t_class_compare.pl
@@ -1,0 +1,21 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2019 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_class_compare.v
+++ b/test_regress/t/t_class_compare.v
@@ -1,0 +1,27 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2019 by Wilson Snyder.
+// SPDX-License-Identifier: CC0-1.0
+
+`define stop $stop
+`define checkb(gotv,expv) do if ((gotv) !== (expv)) begin $write("%%Error: %s:%0d:  got='b%x exp='b%x\n", `__FILE__,`__LINE__, (gotv), (expv)); $stop; end while(0);
+
+class Cls;
+   int i;
+endclass
+
+module t;
+   initial begin
+      Cls a = new;
+      Cls b = new;
+      // Two checks because == and != may not be derived from each other
+      `checkb(a != b, 1'b1)
+      `checkb(a == b, 1'b0)
+      a = b;
+      `checkb(a == b, 1'b1)
+      `checkb(a != b, 1'b0)
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end
+endmodule

--- a/test_regress/t/t_class_compare.v
+++ b/test_regress/t/t_class_compare.v
@@ -1,7 +1,7 @@
 // DESCRIPTION: Verilator: Verilog Test module
 //
 // This file ONLY is placed under the Creative Commons Public Domain, for
-// any use, without warranty, 2019 by Wilson Snyder.
+// any use, without warranty, 2023 by Ilya Barkov.
 // SPDX-License-Identifier: CC0-1.0
 
 `define stop $stop

--- a/test_regress/t/t_class_compare.v
+++ b/test_regress/t/t_class_compare.v
@@ -1,4 +1,4 @@
-// DESCRIPTION: Verilator: Verilog Test module
+// DESCRIPTION: Verilator: Check == and != operations performed on class objects
 //
 // This file ONLY is placed under the Creative Commons Public Domain, for
 // any use, without warranty, 2023 by Ilya Barkov.

--- a/test_regress/t/t_class_compare.v
+++ b/test_regress/t/t_class_compare.v
@@ -5,7 +5,10 @@
 // SPDX-License-Identifier: CC0-1.0
 
 `define stop $stop
-`define checkb(gotv,expv) do if ((gotv) !== (expv)) begin $write("%%Error: %s:%0d:  got='b%x exp='b%x\n", `__FILE__,`__LINE__, (gotv), (expv)); $stop; end while(0);
+`define check_comp(lhs, rhs, op, exp) if ((exp) != ((lhs) op (rhs))) begin $write("%%Error: %s:%0d: op comparison shall return 'b%x\n", `__FILE__, `__LINE__, (exp)); `stop; end
+// Two checks because == and != may not be derived from each other
+`define check_eq(lhs, rhs) `check_comp(lhs, rhs, ==, 1'b1) `check_comp(lhs, rhs, !=, 1'b0)
+`define check_ne(lhs, rhs) `check_comp(lhs, rhs, ==, 1'b0) `check_comp(lhs, rhs, !=, 1'b1)
 
 class Cls;
    int i;
@@ -15,12 +18,9 @@ module t;
    initial begin
       Cls a = new;
       Cls b = new;
-      // Two checks because == and != may not be derived from each other
-      `checkb(a != b, 1'b1)
-      `checkb(a == b, 1'b0)
+      `check_ne(a, b)
       a = b;
-      `checkb(a == b, 1'b1)
-      `checkb(a != b, 1'b0)
+      `check_eq(a, b)
       $write("*-* All Finished *-*\n");
       $finish;
    end

--- a/test_regress/t/t_queue_compare.pl
+++ b/test_regress/t/t_queue_compare.pl
@@ -1,0 +1,21 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2019 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_queue_compare.v
+++ b/test_regress/t/t_queue_compare.v
@@ -1,0 +1,65 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2019 by Wilson Snyder.
+// SPDX-License-Identifier: CC0-1.0
+
+`define stop $stop
+`define checkb(gotv,expv) do if ((gotv) !== (expv)) begin $write("%%Error: %s:%0d:  got='b%x exp='b%x\n", `__FILE__,`__LINE__, (gotv), (expv)); $stop; end while(0);;
+
+class Cls;
+   int i;
+endclass
+
+module t;
+   initial begin
+      begin
+         int q1[$];
+         bit[31:0] q2[$];
+         q1.push_back(1);
+         q2.push_back(1);
+         q1.push_back(-2);
+         q2.push_back(-2);
+         // Two checks because == and != may not be derived from each other
+         `checkb(q1 == q2, 1'b1)
+         `checkb(q1 != q2, 1'b0)
+
+         q2.push_back(3);
+         `checkb(q1 != q2, 1'b1)
+         `checkb(q1 == q2, 1'b0)
+      end
+      begin
+         string q1[$];
+         string q2[$];
+         q1.push_back("one");
+         q2.push_back("one");
+         q1.push_back("two");
+         q2.push_back("two");
+         `checkb(q1 == q2, 1'b1)
+         `checkb(q1 != q2, 1'b0)
+
+         q2.push_back("three");
+         `checkb(q1 != q2, 1'b1)
+         `checkb(q1 == q2, 1'b0)
+      end
+
+      begin
+         Cls a = new;
+         Cls b = new;
+         Cls q1[$];
+         Cls q2[$];
+         q1.push_back(a);
+         q2.push_back(b);
+         `checkb(q1 != q2, 1'b1)
+         `checkb(q1 == q2, 1'b0)
+
+         q1.push_back(b);
+         q2.push_front(a);
+         `checkb(q1 == q2, 1'b1)
+         `checkb(q1 != q2, 1'b0)
+      end
+
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end
+endmodule

--- a/test_regress/t/t_queue_compare.v
+++ b/test_regress/t/t_queue_compare.v
@@ -1,4 +1,4 @@
-// DESCRIPTION: Verilator: Verilog Test module
+// DESCRIPTION: Verilator: Check == and != operations performed on queues
 //
 // This file ONLY is placed under the Creative Commons Public Domain, for
 // any use, without warranty, 2023 by Ilya Barkov.
@@ -16,7 +16,7 @@ endclass
 
 module t;
    initial begin
-      begin
+      begin // integers
          int q1[$];
          bit[31:0] q2[$];
          q1.push_back(1);
@@ -28,7 +28,7 @@ module t;
          q2.push_back(3);
          `check_ne(q1, q2)
       end
-      begin
+      begin // strings
          string q1[$];
          string q2[$];
          q1.push_back("one");
@@ -41,7 +41,7 @@ module t;
          `check_ne(q1, q2)
       end
 
-      begin
+      begin // classes
          Cls a = new;
          Cls b = new;
          Cls q1[$];

--- a/test_regress/t/t_queue_compare.v
+++ b/test_regress/t/t_queue_compare.v
@@ -5,7 +5,10 @@
 // SPDX-License-Identifier: CC0-1.0
 
 `define stop $stop
-`define checkb(gotv,expv) do if ((gotv) !== (expv)) begin $write("%%Error: %s:%0d:  got='b%x exp='b%x\n", `__FILE__,`__LINE__, (gotv), (expv)); $stop; end while(0);;
+`define check_comp(lhs, rhs, op, exp) if ((exp) != ((lhs) op (rhs))) begin $write("%%Error: %s:%0d: op comparison shall return 'b%x\n", `__FILE__, `__LINE__, (exp)); `stop; end
+// Two checks because == and != may not be derived from each other
+`define check_eq(lhs, rhs) `check_comp(lhs, rhs, ==, 1'b1) `check_comp(lhs, rhs, !=, 1'b0)
+`define check_ne(lhs, rhs) `check_comp(lhs, rhs, ==, 1'b0) `check_comp(lhs, rhs, !=, 1'b1)
 
 class Cls;
    int i;
@@ -20,13 +23,10 @@ module t;
          q2.push_back(1);
          q1.push_back(-2);
          q2.push_back(-2);
-         // Two checks because == and != may not be derived from each other
-         `checkb(q1 == q2, 1'b1)
-         `checkb(q1 != q2, 1'b0)
+         `check_eq(q1, q2)
 
          q2.push_back(3);
-         `checkb(q1 != q2, 1'b1)
-         `checkb(q1 == q2, 1'b0)
+         `check_ne(q1, q2)
       end
       begin
          string q1[$];
@@ -35,12 +35,10 @@ module t;
          q2.push_back("one");
          q1.push_back("two");
          q2.push_back("two");
-         `checkb(q1 == q2, 1'b1)
-         `checkb(q1 != q2, 1'b0)
+         `check_eq(q1, q2)
 
          q2.push_back("three");
-         `checkb(q1 != q2, 1'b1)
-         `checkb(q1 == q2, 1'b0)
+         `check_ne(q1, q2)
       end
 
       begin
@@ -50,13 +48,11 @@ module t;
          Cls q2[$];
          q1.push_back(a);
          q2.push_back(b);
-         `checkb(q1 != q2, 1'b1)
-         `checkb(q1 == q2, 1'b0)
+         `check_ne(q1, q2)
 
          q1.push_back(b);
          q2.push_front(a);
-         `checkb(q1 == q2, 1'b1)
-         `checkb(q1 != q2, 1'b0)
+         `check_eq(q1, q2)
       end
 
       $write("*-* All Finished *-*\n");

--- a/test_regress/t/t_queue_compare.v
+++ b/test_regress/t/t_queue_compare.v
@@ -1,7 +1,7 @@
 // DESCRIPTION: Verilator: Verilog Test module
 //
 // This file ONLY is placed under the Creative Commons Public Domain, for
-// any use, without warranty, 2019 by Wilson Snyder.
+// any use, without warranty, 2023 by Ilya Barkov.
 // SPDX-License-Identifier: CC0-1.0
 
 `define stop $stop


### PR DESCRIPTION
Currently Verilator cannot compare for (in)equality class objects, queues and associative arrays, so the code
```systemverilog
int assoc1[int];
int assoc2[int];
if (assoc1 == assoc2) ...
```
produces an error:
```
./Vt_assoc_compare___024root__DepSet_hdcda1186__0__Slow.cpp:132:22: error: invalid operands to binary expression ('VlAssocArray<IData, VlClassRef<Vt_assoc_compare___024unit__03a__03aCls>>' (aka 'VlAssocArray<unsigned int, VlClassRef<Vt_assoc_compare___024unit__03a__03aCls>>') and 'VlAssocArray<IData, VlClassRef<Vt_assoc_compare___024unit__03a__03aCls>>' (aka 'VlAssocArray<unsigned int, VlClassRef<Vt_assoc_compare___024unit__03a__03aCls>>'))
                     != vlSelf->t__DOT__unnamedblk3__DOT__assoc2))) {
                     ^  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

I've added implementations of `operator==` and `operator!=` for `VlAssocArray`, `VlClassRef` and `VlQueue` together with respective test cases.