### PR TITLE
Support function calls without parenthesis

### DIFF
--- a/src/V3LinkDot.cpp
+++ b/src/V3LinkDot.cpp
@@ -2665,12 +2665,16 @@ private:
             } else if (VN_IS(foundp->nodep(), Clocking)) {
                 m_ds.m_dotSymp = foundp;
                 ok = m_ds.m_dotPos == DP_SCOPE;
-            } else if (VN_IS(foundp->nodep(), Property)) {
-                AstFuncRef* const propRefp
-                    = new AstFuncRef{nodep->fileline(), nodep->name(), nullptr};
-                nodep->replaceWith(propRefp);
-                VL_DO_DANGLING(pushDeletep(nodep), nodep);
-                ok = m_ds.m_dotPos == DP_NONE;
+            } else if (const AstNodeFTask* const ftaskp = VN_CAST(foundp->nodep(), NodeFTask)) {
+                if (!ftaskp->isFunction()) {
+                    // The condition is true for tasks, properties and void functions.
+                    // In these cases, the parentheses may be skipped.
+                    AstFuncRef* const funcRefp
+                        = new AstFuncRef{nodep->fileline(), nodep->name(), nullptr};
+                    nodep->replaceWith(funcRefp);
+                    VL_DO_DANGLING(pushDeletep(nodep), nodep);
+                    ok = m_ds.m_dotPos == DP_NONE;
+                }
             }
             //
             if (!ok) {

--- a/test_regress/t/t_func.v
+++ b/test_regress/t/t_func.v
@@ -9,6 +9,7 @@ module t;
    reg [31:0] rglobal;
    reg [31:0] vec [1:0];
    reg [31:0] n;
+   int        abcd;
 
    initial begin
       rglobal = 1;
@@ -60,6 +61,12 @@ module t;
       inc_and_return(32'h3);
       if (rglobal !== 32'h9) $stop;
       // verilator lint_on IGNOREDRETURN
+
+      abcd = 0;
+      set_1_to_abcd;
+      if (abcd != 1) $stop;
+      set_2_to_abcd;
+      if (abcd != 2) $stop;
 
       $write("*-* All Finished *-*\n");
       $finish;
@@ -152,5 +159,13 @@ module t;
       rglobal = rglobal + inc;
       return rglobal;
    endfunction
+
+   function void set_1_to_abcd;
+      abcd = 1;
+   endfunction
+
+   task set_2_to_abcd;
+      abcd = 2;
+   endtask
 
 endmodule

--- a/test_regress/t/t_func_no_parentheses_bad.out
+++ b/test_regress/t/t_func_no_parentheses_bad.out
@@ -1,0 +1,4 @@
+%Error: t/t_func_no_parentheses_bad.v:21:11: Found definition of 'func' as a FUNC but expected a variable
+   21 |       a = func;
+      |           ^~~~
+%Error: Exiting due to

--- a/test_regress/t/t_func_no_parentheses_bad.pl
+++ b/test_regress/t/t_func_no_parentheses_bad.pl
@@ -1,0 +1,23 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2023 by Antmicro Ltd. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    fails => $Self->{vlt_all},
+    expect_filename => $Self->{golden_filename},
+    );
+
+execute(
+    check_finished => 1,
+    ) if !$Self->{vlt_all};
+
+ok(1);
+1;

--- a/test_regress/t/t_func_no_parentheses_bad.v
+++ b/test_regress/t/t_func_no_parentheses_bad.v
@@ -1,0 +1,25 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2023 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+function static int func();
+   int cnt = 0;
+   return ++cnt;
+endfunction
+
+module t (/*AUTOARG*/
+   // Inputs
+   clk
+   );
+
+   input clk;
+
+   int   a;
+   initial begin
+      a = func;
+      $stop;
+   end
+
+endmodule


### PR DESCRIPTION
It fixes https://github.com/verilator/verilator/issues/3902.
I just made the fix for properties more general: https://github.com/verilator/verilator/pull/3893.
The section 13.5 of IEEE 1800-2017 says:
> It shall be illegal to omit the parentheses in a tf_call unless the subroutine is a task, void function, or class method.
If the subroutine is a nonvoid class function method, it shall be illegal to omit the parentheses if the call is directly
recursive.

This PR fixes the task and void function cases. It doesn't work with methods, because calls without parentheses are parsed as member selects, so it requires a fix in a different visitor.