### PR TITLE
Fix cinlude check

### DIFF
--- a/src/V3FunctionTraits.h
+++ b/src/V3FunctionTraits.h
@@ -19,7 +19,7 @@
 
 #include "verilatedos.h"
 
-#include <stddef.h>
+#include <cstddef>
 #include <tuple>
 #include <type_traits>
 

--- a/test_regress/t/t_dist_cinclude.pl
+++ b/test_regress/t/t_dist_cinclude.pl
@@ -9,49 +9,50 @@ if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); di
 # SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
 
 use IO::File;
+use File::Spec::Functions 'catfile';
 
 scenarios(dist => 1);
 
 my $root = "..";
 my $Debug;
 
-if (!-r "$root/.git") {
+if (!-r catfile($root, ".git")) {
     skip("Not in a git repository");
 } else {
     ### Must trim output before and after our file list
     my $files = `cd $root && git ls-files --exclude-standard`;
     print "ST $files\n" if $Debug;
-    $files =~ s/\s+/ /g;
-    my $cmd = "cd $root && fgrep -n include $files | sort";
-    my $grep = `$cmd`;
-    foreach my $line (split /\n/, $grep) {
-        next if $line =~ m!include/vltstd/vpi_user.h!;  # IEEE Standard file - can't change it
-        next if $line =~ m!include/gtkwave/!;  # Standard file - can't change it
-        my $hit;
-        $hit = 1 if $line =~ /\bassert\.h/;
-        $hit = 1 if $line =~ /\bctype\.h/;
-        $hit = 1 if $line =~ /\berrno\.h/;
-        $hit = 1 if $line =~ /\bfloat\.h/;
-        $hit = 1 if $line =~ /\blimits\.h/;
-        $hit = 1 if $line =~ /\blocale\.h/;
-        $hit = 1 if $line =~ /\bmath\.h/;
-        $hit = 1 if $line =~ /\bsetjmp\.h/;
-        $hit = 1 if $line =~ /\bsignal\.h/;
-        $hit = 1 if $line =~ /\bstdarg\.h/;
-        $hit = 1 if $line =~ /\bstdbool\.h/;
-        $hit = 1 if $line =~ /\bstddef\.h/;
-        #Not yet: $hit = 1 if $line =~ /\bstdint\.h/;
-        $hit = 1 if $line =~ /\bstdio\.h/;
-        $hit = 1 if $line =~ /\bstdlib\.h/;
-        $hit = 1 if $line =~ /\bstring\.h/;
-        $hit = 1 if $line =~ /\btime\.h/ && $line !~ m!sys/time.h!;
-        next if !$hit;
-        print "$line\n";
-        $names{$1} = 1 if $line =~ /^([^:]+)/;
+    foreach my $file (split /\n/, $files) {
+        # next if $file =~ m!include/vltstd/vpi_user.h!;  # IEEE Standard file - can't change it
+        next if $file =~ m!include/gtkwave/!;  # Standard file - can't change it
+        my $filename = catfile($root, $file);
+        @lines = split /\n/, file_contents($filename);
+        @include_lines = grep(/include/, @lines);
+        foreach my $line (@include_lines) {
+            my $hit;
+            $hit = 1 if $line =~ /\bassert\.h/;
+            $hit = 1 if $line =~ /\bctype\.h/;
+            $hit = 1 if $line =~ /\berrno\.h/;
+            $hit = 1 if $line =~ /\bfloat\.h/;
+            $hit = 1 if $line =~ /\blimits\.h/;
+            $hit = 1 if $line =~ /\blocale\.h/;
+            $hit = 1 if $line =~ /\bmath\.h/;
+            $hit = 1 if $line =~ /\bsetjmp\.h/;
+            $hit = 1 if $line =~ /\bsignal\.h/;
+            $hit = 1 if $line =~ /\bstdarg\.h/;
+            $hit = 1 if $line =~ /\bstdbool\.h/;
+            $hit = 1 if $line =~ /\bstddef\.h/;
+            #Not yet: $hit = 1 if $line =~ /\bstdint\.h/;
+            $hit = 1 if $line =~ /\bstdio\.h/;
+            $hit = 1 if $line =~ /\bstdlib\.h/;
+            $hit = 1 if $line =~ /\bstring\.h/;
+            $hit = 1 if $line =~ /\btime\.h/ && $line !~ m!sys/time.h!;
+            next if !$hit;
+            $names{"$filename: $line"} = 1;
+        }
     }
-
     if (keys %names) {
-        error("Files like stdint.h instead of cstdint: ", join(' ', sort keys %names));
+		error("Files like stdint.h instead of cstdint:\n    ", join("\n    ", sort keys %names));
     }
 }
 

--- a/test_regress/t/t_dist_cinclude.pl
+++ b/test_regress/t/t_dist_cinclude.pl
@@ -23,7 +23,7 @@ if (!-r catfile($root, ".git")) {
     my $files = `cd $root && git ls-files --exclude-standard`;
     print "ST $files\n" if $Debug;
     foreach my $file (split /\n/, $files) {
-        # next if $file =~ m!include/vltstd/vpi_user.h!;  # IEEE Standard file - can't change it
+        next if $file =~ m!include/vltstd/vpi_user.h!;  # IEEE Standard file - can't change it
         next if $file =~ m!include/gtkwave/!;  # Standard file - can't change it
         my $filename = catfile($root, $file);
         @lines = split /\n/, file_contents($filename);


### PR DESCRIPTION
1. Move files processing in `t_dist_cinclude.pl` from system to pure perl to avoid issues with string length limitations.
2. Prettify print of offending includes.
3. Fix `stddef` include.
4. Use system-independent `catfile` to combine paths -- do we need it?