### PR TITLE
Avoid using <tab> in the middle of lines

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -15,13 +15,13 @@
 #
 #****************************************************************************/
 #
-# make all	to compile and build Verilator.
-# make install	to install it.
-# make TAGS	to update tags tables.
+# make all      to compile and build Verilator.
+# make install  to install it.
+# make TAGS     to update tags tables.
 #
 # make clean  or  make mostlyclean
 #      Delete all files from the current directory that are normally
-#      created by building the program.	 Don't delete the files that
+#      created by building the program.  Don't delete the files that
 #      record the configuration.  Also preserve files that could be made
 #      by building, but normally aren't because the distribution comes
 #      with them.
@@ -153,7 +153,7 @@ msg_test: all_nomsg
 	@echo
 
 .PHONY: test
-ifeq ($(CFG_WITH_LONGTESTS),yes)	# Local... Else don't burden users
+ifeq ($(CFG_WITH_LONGTESTS),yes)  # Local... Else don't burden users
 test: smoke-test test_regress
 # examples is part of test_regress's test_regress/t/t_a2_examples.pl
 # (because that allows it to run in parallel with other test_regress's)
@@ -462,7 +462,7 @@ config.status: configure
 	./config.status --recheck
 
 configure: configure.ac
-ifeq ($(CFG_WITH_CCWARN),yes)	# Local... Else don't burden users
+ifeq ($(CFG_WITH_CCWARN),yes)  # Local... Else don't burden users
 	autoconf --warnings=all
 else
 	autoconf
@@ -501,7 +501,7 @@ distclean maintainer-clean::
 TAGFILES=${srcdir}/*/*.cpp ${srcdir}/*/*.h ${srcdir}/*/*.in \
 	${srcdir}/*.in ${srcdir}/*.pod
 
-TAGS:	$(TAGFILES)
+TAGS: $(TAGFILES)
 	etags $(TAGFILES)
 
 .PHONY: doxygen

--- a/examples/make_tracing_c/Makefile_obj
+++ b/examples/make_tracing_c/Makefile_obj
@@ -31,7 +31,7 @@ CPPFLAGS += -DVL_DEBUG=1
 # Turn on some more compiler lint flags (when configured appropriately)
 # For testing inside Verilator, "configure --enable-ccwarn" will do this
 # automatically; otherwise you may want this unconditionally enabled
-ifeq ($(CFG_WITH_CCWARN),yes)	# Local... Else don't burden users
+ifeq ($(CFG_WITH_CCWARN),yes)  # Local... Else don't burden users
 USER_CPPFLAGS_WALL += -W -Werror -Wall
 endif
 

--- a/examples/make_tracing_sc/Makefile_obj
+++ b/examples/make_tracing_sc/Makefile_obj
@@ -30,7 +30,7 @@ CPPFLAGS += -Wno-deprecated
 # Turn on some more flags (when configured appropriately)
 # For testing inside Verilator, "configure --enable-ccwarn" will do this
 # automatically; otherwise you may want this unconditionally enabled
-ifeq ($(CFG_WITH_CCWARN),yes)	# Local... Else don't burden users
+ifeq ($(CFG_WITH_CCWARN),yes)  # Local... Else don't burden users
 USER_CPPFLAGS_WALL += -W -Werror -Wall
 endif
 

--- a/include/verilated.mk.in
+++ b/include/verilated.mk.in
@@ -67,7 +67,7 @@ VK_CPPFLAGS_ALWAYS += \
 		-DVM_TRACE_VCD=$(VM_TRACE_VCD) \
 		$(CFG_CXXFLAGS_NO_UNUSED) \
 
-ifeq ($(CFG_WITH_CCWARN),yes)	# Local... Else don't burden users
+ifeq ($(CFG_WITH_CCWARN),yes)  # Local... Else don't burden users
 VK_CPPFLAGS_WALL += -Wall $(CFG_CXXFLAGS_WEXTRA) -Werror
 endif
 

--- a/install-sh
+++ b/install-sh
@@ -106,7 +106,7 @@ done
 
 if [ x"$src" = x ]
 then
-	echo "install:	no input file specified"
+	echo "install: no input file specified"
 	exit 1
 else
 	true
@@ -137,7 +137,7 @@ else
 
 	if [ x"$dst" = x ]
 	then
-		echo "install:	no destination specified"
+		echo "install: no destination specified"
 		exit 1
 	else
 		true

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -50,7 +50,7 @@ obj_dbg:
 .PHONY: ../bin/verilator_bin$(EXEEXT) ../bin/verilator_bin_dbg$(EXEEXT) ../bin/verilator_coverage_bin_dbg$(EXEEXT)
 
 opt: ../bin/verilator_bin$(EXEEXT)
-ifeq ($(VERILATOR_NO_OPT_BUILD),1)	# Faster laptop development... One build
+ifeq ($(VERILATOR_NO_OPT_BUILD),1)  # Faster laptop development... One build
 ../bin/verilator_bin$(EXEEXT): ../bin/verilator_bin_dbg$(EXEEXT)
 	-cp -p $< $@.tmp
 	-mv -f $@.tmp $@
@@ -70,7 +70,7 @@ dbg: ../bin/verilator_bin_dbg$(EXEEXT) ../bin/verilator_coverage_bin_dbg$(EXEEXT
 	$(MAKE) -C obj_dbg       TGT=../$@ VL_DEBUG=1 VL_VLCOV=1 -f ../Makefile_obj
 
 ifneq ($(VERILATOR_NO_OPT_BUILD),1)  # Faster laptop development... don't rebuild each commit
- ifneq ($(UNDER_GIT),)	# If local git tree... else don't burden users
+ ifneq ($(UNDER_GIT),)  # If local git tree... else don't burden users
 GIT_CHANGE_DEP = ${srcdir}/../.git/logs/HEAD
  endif
 endif
@@ -78,7 +78,7 @@ endif
 prefiles::
 prefiles:: config_rev.h
 # This output goes into srcdir if locally configured, as we need to distribute it as part of the kit.
-config_rev.h:	${srcdir}/config_rev $(GIT_CHANGE_DEP)
+config_rev.h: ${srcdir}/config_rev $(GIT_CHANGE_DEP)
 	$(PYTHON3) ${srcdir}/config_rev ${srcdir} >$@
 
 # Human convenience

--- a/src/Makefile_obj.in
+++ b/src/Makefile_obj.in
@@ -94,9 +94,9 @@ LIBS = $(CFG_LIBS) -lm
 
 CPPFLAGS += -MMD
 CPPFLAGS += -I. -I$(bldsrc) -I$(srcdir) -I$(incdir) -I../../include
-#CPPFLAGS += -DVL_LEAK_CHECKS 	# If running valgrind or other hunting tool
+#CPPFLAGS += -DVL_LEAK_CHECKS  # If running valgrind or other hunting tool
 CPPFLAGS += -MP # Only works on recent GCC versions
-ifeq ($(CFG_WITH_CCWARN),yes)	# Local... Else don't burden users
+ifeq ($(CFG_WITH_CCWARN),yes)  # Local... Else don't burden users
 CPPFLAGS += -W -Wall $(CFG_CXXFLAGS_WEXTRA) $(CFG_CXXFLAGS_SRC) -Werror
 #CPPFLAGS += -pedantic-errors
 else
@@ -114,7 +114,7 @@ ifeq ($(CFG_WITH_DEFENV),yes)
  CPPFLAGS += -DDEFENV_SYSTEMC_ARCH=\"$(SYSTEMC_ARCH)\"
  CPPFLAGS += -DDEFENV_SYSTEMC_INCLUDE=\"$(SYSTEMC_INCLUDE)\"
  CPPFLAGS += -DDEFENV_SYSTEMC_LIBDIR=\"$(SYSTEMC_LIBDIR)\"
- ifeq ($(VERILATOR_ROOT),)	# Use what we're given, or intuit
+ ifeq ($(VERILATOR_ROOT),)  # Use what we're given, or intuit
   CPPFLAGS += -DDEFENV_VERILATOR_ROOT=\"$(pkgdatadir)\"
  else
   CPPFLAGS += -DDEFENV_VERILATOR_ROOT=\"$(VERILATOR_ROOT)\"
@@ -155,7 +155,7 @@ RAW_OBJS = \
 	V3ActiveTop.o \
 	V3Assert.o \
 	V3AssertPre.o \
-	V3Ast.o	\
+	V3Ast.o \
 	V3AstNodes.o \
 	V3Begin.o \
 	V3Branch.o \
@@ -323,26 +323,26 @@ V3Number_test: V3Number_test.o
 
 #### Modules
 
-%__gen.cpp:	%.cpp $(ASTGEN) $(AST_DEFS) $(DFG_DEFS)
+%__gen.cpp: %.cpp $(ASTGEN) $(AST_DEFS) $(DFG_DEFS)
 	$(PYTHON3) $(ASTGEN) $(ASTGENFLAGS) $*.cpp
 
 .SECONDARY:
 
-%.o:	%.cpp
+%.o: %.cpp
 	$(OBJCACHE) ${CXX} ${CXXFLAGS} ${CPPFLAGSWALL} -c $< -o $@
-%.o:	%.c
+%.o: %.c
 	$(OBJCACHE) ${CC}  ${CFLAGS} ${CPPFLAGSWALL} -c $< -o $@
 
-V3ParseLex.o:	V3ParseLex.cpp V3Lexer.yy.cpp V3ParseBison.c
+V3ParseLex.o: V3ParseLex.cpp V3Lexer.yy.cpp V3ParseBison.c
 	$(OBJCACHE) ${CXX} ${CXXFLAGS} ${CPPFLAGSPARSER} -c $< -o $@
 
-V3ParseGrammar.o:	V3ParseGrammar.cpp V3ParseBison.c
+V3ParseGrammar.o: V3ParseGrammar.cpp V3ParseBison.c
 	$(OBJCACHE) ${CXX} ${CXXFLAGS} ${CPPFLAGSPARSER} -c $< -o $@
 
-V3ParseImp.o:	V3ParseImp.cpp V3ParseBison.c
+V3ParseImp.o: V3ParseImp.cpp V3ParseBison.c
 	$(OBJCACHE) ${CXX} ${CXXFLAGS} ${CPPFLAGSPARSER} -c $< -o $@
 
-V3PreProc.o:	V3PreProc.cpp V3PreLex.yy.cpp
+V3PreProc.o: V3PreProc.cpp V3PreLex.yy.cpp
 	$(OBJCACHE) ${CXX} ${CXXFLAGS} ${CPPFLAGSPARSER} -c $< -o $@
 
 #### Generated files
@@ -366,14 +366,14 @@ V3ParseBison.c: verilog.y $(BISONPRE)
 	@echo "If you get errors from verilog.y below, try upgrading bison to version 1.875 or newer."
 	$(PYTHON3) $(BISONPRE) --yacc ${YACC} -d -v -o V3ParseBison.c $<
 
-V3Lexer_pregen.yy.cpp:	verilog.l V3ParseBison.h $(HEADERS)
+V3Lexer_pregen.yy.cpp: verilog.l V3ParseBison.h $(HEADERS)
 	${LEX} --version
 	${LEX} ${LFLAGS} -o$@ $<
 
-V3Lexer.yy.cpp:	V3Lexer_pregen.yy.cpp $(FLEXFIX)
+V3Lexer.yy.cpp: V3Lexer_pregen.yy.cpp $(FLEXFIX)
 	$(PYTHON3) $(FLEXFIX) V3Lexer <$< >$@
 
-V3PreLex_pregen.yy.cpp:	V3PreLex.l $(HEADERS)
+V3PreLex_pregen.yy.cpp: V3PreLex.l $(HEADERS)
 	${LEX} --version
 	${LEX} ${LFLAGS} -o$@ $<
 


### PR DESCRIPTION
Doing so invites confusion and different views by different editors.
Three special-cases left, where any alternative is worse.
