### PR TITLE
Handle references of static members of type aliases of param classes

### DIFF
--- a/test_regress/t/t_class_param.v
+++ b/test_regress/t/t_class_param.v
@@ -70,6 +70,17 @@ class IntQueue;
    endfunction
 endclass
 
+class ClsStatic;
+   static int   x = 1;
+   static function int get_2;
+      return 2;
+   endfunction
+endclass
+
+class ClsParam #(type T);
+   typedef T param_t;
+endclass
+
 module t (/*AUTOARG*/);
 
    Cls c12;
@@ -138,6 +149,9 @@ module t (/*AUTOARG*/);
       Sum#(int)::add(arr[0]);
       if(Sum#(int)::sum != 16) $stop;
       if(Sum#(real)::sum != 0) $stop;
+
+      if (ClsParam#(ClsStatic)::param_t::x != 1) $stop;
+      if (ClsParam#(ClsStatic)::param_t::get_2() != 2) $stop;
 
       $write("*-* All Finished *-*\n");
       $finish;


### PR DESCRIPTION
It adds a possibility to reference static members of type aliases declared in parameterized classes.
I decided to create separate `unresolved` flags for class references and cells, because they are handled in a different way.

When a parameterized class reference is present on the LHS of a dot, then the RHS shouldn't be linked in the first pass of V3LinkDot. It is currently implemented on master, but only if LHS consists of a parameterized class reference only. In this PR, I added passing unresolvedClass flag from inner dot expressions to outer ones, making possible to handle complex references. Then dot references, that were already linked, are updated in V3Param.

I am not sure what to do when both `unresolved` flags are set to true. I couldn't even create such an example.