### PR TITLE
Pass m_unresolvedClass to the outer dot expr only if it exists

### DIFF
--- a/src/V3LinkDot.cpp
+++ b/src/V3LinkDot.cpp
@@ -2440,13 +2440,13 @@ private:
                 }
             }
         }
-        const bool unresolvedClass = m_ds.m_unresolvedClass;
         if (start) {
             m_ds = lastStates;
         } else {
+            const bool unresolvedClass = m_ds.m_unresolvedClass;
             m_ds.m_dotp = lastStates.m_dotp;
+            m_ds.m_unresolvedClass |= unresolvedClass;
         }
-        m_ds.m_unresolvedClass |= unresolvedClass;
     }
     void visit(AstSenItem* nodep) override {
         VL_RESTORER(m_inSens);

--- a/test_regress/t/t_class_param.v
+++ b/test_regress/t/t_class_param.v
@@ -81,6 +81,15 @@ class ClsParam #(type T);
    typedef T param_t;
 endclass
 
+class ClsWithParamField;
+   int m_field = Sum#(int)::sum;
+   int m_queue[$];
+
+   function int get(int index);
+      return m_queue[index];
+   endfunction
+endclass
+
 module t (/*AUTOARG*/);
 
    Cls c12;
@@ -93,6 +102,7 @@ module t (/*AUTOARG*/);
    SelfRefClassIntParam src1;
    SelfRefClassIntParam::self_int_t src10;
    IntQueue qi;
+   ClsWithParamField cls_param_field;
    int arr [1:0] = '{1, 2};
    initial begin
       c12 = new;
@@ -105,6 +115,7 @@ module t (/*AUTOARG*/);
       src1 = new;
       src10 = new;
       qi = new;
+      cls_param_field = new;
       if (Cls#()::PBASE != 12) $stop;
       if (Cls#(4)::PBASE != 4) $stop;
       if (Cls8_t::PBASE != 8) $stop;
@@ -152,6 +163,9 @@ module t (/*AUTOARG*/);
 
       if (ClsParam#(ClsStatic)::param_t::x != 1) $stop;
       if (ClsParam#(ClsStatic)::param_t::get_2() != 2) $stop;
+
+      cls_param_field.m_queue = '{1, 5, 7};
+      if (cls_param_field.get(2) != 7) $stop;
 
       $write("*-* All Finished *-*\n");
       $finish;


### PR DESCRIPTION
I found a problem with `m_unresolvedClass` field. This flag is passed to the outer dot state even if that dot state is not related to a dot expression, but to a class definition. It results in marking all next class members as unable to resolve, even if they don't have any parameter references in their definitions. Currently selects need to be visited in the first pass of V3LinkDot, so an error was raised on the test I added.

Unfortunately, the problem with selects is more general. Currently, we don't iterate through the body of a class that extends its parameter, but there may be selects in its methods. And if they are, an error is raised.
Here is an example (I simplified one of classed from UVM):
```systemverilog
class Cls;
endclass

class uvm_port_base #(type T=Cls) extends T;
   int m_dict[string];
   
   function void set (string s, int x);
      m_dict[s] = x;
   endfunction
endclass
```
Fix for that case will probably make my test passed too, but I think that this PR is needed anyway, because resolvable class fields shouldn't be marked as unresolved.