### PR TITLE
Add vpiDefName

### DIFF
--- a/include/verilated.cpp
+++ b/include/verilated.cpp
@@ -2995,7 +2995,7 @@ VerilatedScope::~VerilatedScope() {
 
 void VerilatedScope::configure(VerilatedSyms* symsp, const char* prefixp, const char* suffixp,
                                const char* identifier, int8_t timeunit,
-                               const Type& type) VL_MT_UNSAFE {
+                               const Type& type, const char* defName) VL_MT_UNSAFE {
     // Slowpath - called once/scope at construction
     // We don't want the space and reference-count access overhead of strings.
     m_symsp = symsp;
@@ -3011,6 +3011,7 @@ void VerilatedScope::configure(VerilatedSyms* symsp, const char* prefixp, const 
         m_namep = namep;
     }
     m_identifierp = identifier;
+    m_defNamep = defName;
     Verilated::threadContextp()->impp()->scopeInsert(this);
 }
 

--- a/include/verilated.cpp
+++ b/include/verilated.cpp
@@ -2994,8 +2994,8 @@ VerilatedScope::~VerilatedScope() {
 }
 
 void VerilatedScope::configure(VerilatedSyms* symsp, const char* prefixp, const char* suffixp,
-                               const char* identifier, int8_t timeunit,
-                               const Type& type, const char* defName) VL_MT_UNSAFE {
+                               const char* identifier, int8_t timeunit, const Type& type,
+                               const char* defName) VL_MT_UNSAFE {
     // Slowpath - called once/scope at construction
     // We don't want the space and reference-count access overhead of strings.
     m_symsp = symsp;

--- a/include/verilated.h
+++ b/include/verilated.h
@@ -607,18 +607,20 @@ private:
     const char* m_identifierp = nullptr;  // Identifier of scope (with escapes removed)
     int8_t m_timeunit = 0;  // Timeunit in negative power-of-10
     Type m_type = SCOPE_OTHER;  // Type of the scope
+    const char* m_defNamep = nullptr; // defName (module name, not instance name)
 
 public:  // But internals only - called from VerilatedModule's
     VerilatedScope() = default;
     ~VerilatedScope();
     void configure(VerilatedSyms* symsp, const char* prefixp, const char* suffixp,
-                   const char* identifier, int8_t timeunit, const Type& type) VL_MT_UNSAFE;
+                   const char* identifier, int8_t timeunit, const Type& type, const char* defName) VL_MT_UNSAFE;
     void exportInsert(int finalize, const char* namep, void* cb) VL_MT_UNSAFE;
     void varInsert(int finalize, const char* namep, void* datap, bool isParam,
                    VerilatedVarType vltype, int vlflags, int dims, ...) VL_MT_UNSAFE;
     // ACCESSORS
     const char* name() const VL_MT_SAFE_POSTINIT { return m_namep; }
     const char* identifier() const VL_MT_SAFE_POSTINIT { return m_identifierp; }
+    const char* defname() const VL_MT_SAFE_POSTINIT { return m_defNamep; }
     int8_t timeunit() const VL_MT_SAFE_POSTINIT { return m_timeunit; }
     VerilatedSyms* symsp() const VL_MT_SAFE_POSTINIT { return m_symsp; }
     VerilatedVar* varFind(const char* namep) const VL_MT_SAFE_POSTINIT;

--- a/include/verilated.h
+++ b/include/verilated.h
@@ -607,13 +607,14 @@ private:
     const char* m_identifierp = nullptr;  // Identifier of scope (with escapes removed)
     int8_t m_timeunit = 0;  // Timeunit in negative power-of-10
     Type m_type = SCOPE_OTHER;  // Type of the scope
-    const char* m_defNamep = nullptr; // defName (module name, not instance name)
+    const char* m_defNamep = nullptr;  // defName (module name, not instance name)
 
 public:  // But internals only - called from VerilatedModule's
     VerilatedScope() = default;
     ~VerilatedScope();
     void configure(VerilatedSyms* symsp, const char* prefixp, const char* suffixp,
-                   const char* identifier, int8_t timeunit, const Type& type, const char* defName) VL_MT_UNSAFE;
+                   const char* identifier, int8_t timeunit, const Type& type,
+                   const char* defName) VL_MT_UNSAFE;
     void exportInsert(int finalize, const char* namep, void* cb) VL_MT_UNSAFE;
     void varInsert(int finalize, const char* namep, void* datap, bool isParam,
                    VerilatedVarType vltype, int vlflags, int dims, ...) VL_MT_UNSAFE;

--- a/include/verilated_vpi.cpp
+++ b/include/verilated_vpi.cpp
@@ -261,6 +261,7 @@ public:
     const VerilatedScope* scopep() const { return m_scopep; }
     const char* name() const override { return m_scopep->name(); }
     const char* fullname() const override { return m_scopep->name(); }
+    const char* defname() const override { return m_scopep->defname(); }
 };
 
 class VerilatedVpioVar VL_NOT_FINAL : public VerilatedVpioVarBase {

--- a/src/V3EmitCSyms.cpp
+++ b/src/V3EmitCSyms.cpp
@@ -46,7 +46,7 @@ class EmitCSyms final : EmitCBaseVisitor {
         string m_type;
         string m_defName;
         ScopeData(const string& symName, const string& prettyName, int timeunit,
-                  const string& type, const string&defName = "")
+                  const string& type, const string& defName = "")
             : m_symName{symName}
             , m_prettyName{prettyName}
             , m_timeunit{timeunit}
@@ -317,9 +317,9 @@ class EmitCSyms final : EmitCBaseVisitor {
             const string name = nodep->scopep()->shortName() + "__DOT__" + nodep->name();
             const string name_pretty = AstNode::vpiName(name);
             const int timeunit = m_modp->timeunit().powerOfTen();
-            m_vpiScopeCandidates.insert(std::make_pair(
-                name, ScopeData(scopeSymString(name), name_pretty, timeunit, type, nodep->origModName())));
-
+            m_vpiScopeCandidates.insert(
+                std::make_pair(name, ScopeData(scopeSymString(name), name_pretty, timeunit, type,
+                                               nodep->origModName())));
         }
     }
     void visit(AstScope* nodep) override {
@@ -332,9 +332,9 @@ class EmitCSyms final : EmitCBaseVisitor {
             const string type = VN_IS(nodep->modp(), Package) ? "SCOPE_OTHER" : "SCOPE_MODULE";
             const string name_pretty = AstNode::vpiName(nodep->shortName());
             const int timeunit = m_modp->timeunit().powerOfTen();
-            m_vpiScopeCandidates.insert(
-                std::make_pair(nodep->name(), ScopeData(scopeSymString(nodep->name()), name_pretty,
-                                                        timeunit, type, nodep->modp()->origName())));
+            m_vpiScopeCandidates.insert(std::make_pair(
+                nodep->name(), ScopeData(scopeSymString(nodep->name()), name_pretty, timeunit,
+                                         type, nodep->modp()->origName())));
         }
     }
     void visit(AstScopeName* nodep) override {
@@ -342,8 +342,8 @@ class EmitCSyms final : EmitCBaseVisitor {
         // UINFO(9,"scnameins sp "<<nodep->name()<<" sp "<<nodep->scopePrettySymName()
         // <<" ss"<<name<<endl);
         const int timeunit = m_modp ? m_modp->timeunit().powerOfTen() : 0;
-        m_scopeNames.emplace(
-            name, ScopeData(name, nodep->scopePrettySymName(), timeunit, "SCOPE_MODULE", m_modp->origName()));
+        m_scopeNames.emplace(name, ScopeData(name, nodep->scopePrettySymName(), timeunit,
+                                             "SCOPE_MODULE", m_modp->origName()));
 
         if (nodep->dpiExport()) {
             UASSERT_OBJ(m_cfuncp, nodep, "ScopeName not under DPI function");

--- a/test_regress/t/t_vpi_var.cpp
+++ b/test_regress/t/t_vpi_var.cpp
@@ -263,6 +263,8 @@ int _mon_check_var() {
     CHECK_RESULT_CSTR(p, TestSimulator::top());
     p = vpi_get_str(vpiType, vh2);
     CHECK_RESULT_CSTR(p, "vpiModule");
+    p = vpi_get_str(vpiDefName, vh2);
+    CHECK_RESULT_CSTR(p, "t");
 
     TestVpiHandle vh3 = vpi_handle_by_name((PLI_BYTE8*)"onebit", vh2);
     CHECK_RESULT_NZ(vh3);
@@ -648,6 +650,8 @@ int _mon_check_putget_str(p_cb_data cb_data) {
         };
     } else {
         // setup and install
+        const char* p = nullptr;
+
         for (int i = 1; i <= 6; i++) {
             char buf[32];
             snprintf(buf, sizeof(buf), TestSimulator::rooted("arr[%d].arr"), i);
@@ -658,12 +662,18 @@ int _mon_check_putget_str(p_cb_data cb_data) {
                             = vpi_handle_by_name((PLI_BYTE8*)"check", data[i].scope));
             CHECK_RESULT_NZ(data[i].verbose
                             = vpi_handle_by_name((PLI_BYTE8*)"verbose", data[i].scope));
+            
+            p = vpi_get_str(vpiDefName, data[i].scope);
+            CHECK_RESULT_CSTR(p, "arr");
         }
-
         for (int i = 1; i <= 6; i++) {
             char buf[32];
             snprintf(buf, sizeof(buf), TestSimulator::rooted("subs[%d].subsub"), i);
             CHECK_RESULT_NZ(data[i].scope = vpi_handle_by_name((PLI_BYTE8*)buf, NULL));
+
+            p = vpi_get_str(vpiDefName, data[i].scope);
+            CHECK_RESULT_CSTR(p, "sub");
+
         }
 
         static t_cb_data cb_data;

--- a/test_regress/t/t_vpi_var.cpp
+++ b/test_regress/t/t_vpi_var.cpp
@@ -662,7 +662,7 @@ int _mon_check_putget_str(p_cb_data cb_data) {
                             = vpi_handle_by_name((PLI_BYTE8*)"check", data[i].scope));
             CHECK_RESULT_NZ(data[i].verbose
                             = vpi_handle_by_name((PLI_BYTE8*)"verbose", data[i].scope));
-            
+
             p = vpi_get_str(vpiDefName, data[i].scope);
             CHECK_RESULT_CSTR(p, "arr");
         }
@@ -673,7 +673,6 @@ int _mon_check_putget_str(p_cb_data cb_data) {
 
             p = vpi_get_str(vpiDefName, data[i].scope);
             CHECK_RESULT_CSTR(p, "sub");
-
         }
 
         static t_cb_data cb_data;


### PR DESCRIPTION
fix for https://github.com/verilator/verilator/issues/3906

Still some issues to work out. Line 346 sometimes puts out the wrong module defname, and before it had Scope_other, but I wasn't able to find a case where it wasn't actually pointing to a module instance