### PR TITLE
catch exception directory_iterator and have cmake use sv in include dir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,6 +118,7 @@ install(DIRECTORY include TYPE DATA FILES_MATCHING
     PATTERN "include/verilated.mk"
     PATTERN "include/*.[chv]"
     PATTERN "include/*.cpp"
+    PATTERN "include/*.sv"
     PATTERN "include/gtkwave/*.[chv]*"
     PATTERN "include/vltstd/*.[chv]*"
 )

--- a/src/V3Options.cpp
+++ b/src/V3Options.cpp
@@ -489,8 +489,10 @@ string V3Options::fileExists(const string& filename) {
         std::set<string>* setp = &(diriter->second);
 
 #ifdef _MSC_VER
+      try {
         for (const auto& dirEntry : std::filesystem::directory_iterator(dir.c_str()))
             setp->insert(dirEntry.path().filename().string());
+      } catch(std::filesystem::filesystem_error const& ex) { return ""; }
 #else
         if (DIR* const dirp = opendir(dir.c_str())) {
             while (struct dirent* direntp = readdir(dirp)) setp->insert(direntp->d_name);

--- a/src/V3Options.h
+++ b/src/V3Options.h
@@ -267,11 +267,7 @@ private:
     bool m_relativeIncludes = false; // main switch: --relative-includes
     bool m_reportUnoptflat = false; // main switch: --report-unoptflat
     bool m_savable = false;         // main switch: --savable
-#ifdef _MSC_VER
-    bool m_std = false;             // main switch: --std
-#else
     bool m_std = true;              // main switch: --std
-#endif
     bool m_structsPacked = false;   // main switch: --structs-packed
     bool m_systemC = false;         // main switch: --sc: System C instead of simple C++
     bool m_stats = false;           // main switch: --stats


### PR DESCRIPTION
To resolve https://github.com/verilator/verilator/issues/3933
We appreciate your contributing to Verilator.  If this is your first commit, please add your name to docs/CONTRIBUTORS, and read our contributing guidelines in docs/CONTRIBUTING.rst.
