### PR TITLE
Use VAR_BASE as attr type if a select's base is a ref

### DIFF
--- a/src/V3Ast.h
+++ b/src/V3Ast.h
@@ -371,7 +371,6 @@ public:
         //
         DT_PUBLIC,                      // V3LinkParse moves to AstTypedef::attrPublic
         //
-        ENUM_BASE,                      // V3LinkResolve creates for AstPreSel, V3LinkParam removes
         ENUM_FIRST,                     // V3Width processes
         ENUM_LAST,                      // V3Width processes
         ENUM_NUM,                       // V3Width processes
@@ -379,8 +378,6 @@ public:
         ENUM_PREV,                      // V3Width processes
         ENUM_NAME,                      // V3Width processes
         ENUM_VALID,                     // V3Width processes
-        //
-        MEMBER_BASE,                    // V3LinkResolve creates for AstPreSel, V3LinkParam removes
         //
         TYPENAME,                       // V3Width processes
         //
@@ -407,9 +404,8 @@ public:
             "DIM_BITS", "DIM_DIMENSIONS", "DIM_HIGH", "DIM_INCREMENT", "DIM_LEFT",
             "DIM_LOW", "DIM_RIGHT", "DIM_SIZE", "DIM_UNPK_DIMENSIONS",
             "DT_PUBLIC",
-            "ENUM_BASE", "ENUM_FIRST", "ENUM_LAST", "ENUM_NUM",
+            "ENUM_FIRST", "ENUM_LAST", "ENUM_NUM",
             "ENUM_NEXT", "ENUM_PREV", "ENUM_NAME", "ENUM_VALID",
-            "MEMBER_BASE",
             "TYPENAME",
             "VAR_BASE", "VAR_CLOCK_ENABLE", "VAR_FORCEABLE", "VAR_PUBLIC",
             "VAR_PUBLIC_FLAT", "VAR_PUBLIC_FLAT_RD", "VAR_PUBLIC_FLAT_RW",

--- a/src/V3AstNodes.cpp
+++ b/src/V3AstNodes.cpp
@@ -869,7 +869,7 @@ AstNode* AstArraySel::baseFromp(AstNode* nodep, bool overMembers) {
             continue;
         }
         // AstNodeSelPre stashes the associated variable under an ATTROF
-        // of VAttrType::VAR_BASE/MEMBER_BASE so it isn't constified
+        // of VAttrType::VAR_BASE so it isn't constified
         else if (VN_IS(nodep, AttrOf)) {
             nodep = VN_AS(nodep, AttrOf)->fromp();
             continue;

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -1452,8 +1452,6 @@ private:
         // Don't iterate children, don't want to lose VarRef.
         switch (nodep->attrType()) {
         case VAttrType::VAR_BASE:
-        case VAttrType::MEMBER_BASE:
-        case VAttrType::ENUM_BASE:
             // Soon to be handled in V3LinkWidth SEL generation, under attrp() and newSubLsbOf
             break;
         case VAttrType::DIM_DIMENSIONS:

--- a/test_regress/t/t_class_param.v
+++ b/test_regress/t/t_class_param.v
@@ -90,6 +90,20 @@ class ClsWithParamField;
    endfunction
 endclass
 
+class DictWrapper;
+   int m_dict[string];
+endclass
+
+class DictOperator #(type T) extends T;
+   function void set(string s, int x);
+      m_dict[s] = x;
+   endfunction
+
+   function int get(string s);
+      return m_dict[s];
+   endfunction
+endclass
+
 module t (/*AUTOARG*/);
 
    Cls c12;
@@ -103,6 +117,7 @@ module t (/*AUTOARG*/);
    SelfRefClassIntParam::self_int_t src10;
    IntQueue qi;
    ClsWithParamField cls_param_field;
+   DictOperator #(DictWrapper) dict_op;
    int arr [1:0] = '{1, 2};
    initial begin
       c12 = new;
@@ -116,6 +131,7 @@ module t (/*AUTOARG*/);
       src10 = new;
       qi = new;
       cls_param_field = new;
+      dict_op = new;
       if (Cls#()::PBASE != 12) $stop;
       if (Cls#(4)::PBASE != 4) $stop;
       if (Cls8_t::PBASE != 8) $stop;
@@ -166,6 +182,9 @@ module t (/*AUTOARG*/);
 
       cls_param_field.m_queue = '{1, 5, 7};
       if (cls_param_field.get(2) != 7) $stop;
+
+      dict_op.set("abcd", 1);
+      if(dict_op.get("abcd") != 1) $stop;
 
       $write("*-* All Finished *-*\n");
       $finish;


### PR DESCRIPTION
It solves a problem with select operations on references that are unresolvable in the first pass of V3LinkDot. I mentioned the problem in https://github.com/verilator/verilator/pull/3926. The error was raised, because such references had type AstParseRef, which was unhandled in that function.
I noticed that there is no distinction between `ENUM_BASE`, `MEMBER_BASE` and `VAR_BASE` in any other place. And I think that it would be unnecessary, because all these cases are kinds of variable references. So I decided to use `VAR_BASE` no matter of what is the type of the select operation's base.