### PR TITLE
Const string func

### DIFF
--- a/src/V3AstNodeExpr.h
+++ b/src/V3AstNodeExpr.h
@@ -4543,7 +4543,7 @@ public:
         dtypeSetString();
     }
     ASTGEN_MEMBERS_AstCvtPackString;
-    void numberOperate(V3Number& out, const V3Number& lhs) override { V3ERROR_NA; }
+    void numberOperate(V3Number& out, const V3Number& lhs) override { out.opAssign(lhs); }
     string emitVerilog() override { return "%f$_CAST(%l)"; }
     string emitC() override { return "VL_CVT_PACK_STR_N%lq(%lW, %li)"; }
     bool cleanOut() const override { return true; }

--- a/src/V3Number.cpp
+++ b/src/V3Number.cpp
@@ -2201,8 +2201,8 @@ V3Number& V3Number::opAssignNonXZ(const V3Number& lhs, bool ignoreXZ) {
             m_data.m_isNull = true;
         } else if (isString()) {
             if (VL_UNLIKELY(!lhs.isString())) {
-                // Non-compatible types, erase value.
-                m_data.str() = "";
+                // Numbers can still be strings
+                m_data.str() = lhs.toString();
             } else {
                 m_data.str() = lhs.m_data.str();
             }

--- a/test_regress/t/t_const_string_func.pl
+++ b/test_regress/t/t_const_string_func.pl
@@ -1,0 +1,21 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2023 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_const_string_func.v
+++ b/test_regress/t/t_const_string_func.v
@@ -1,0 +1,20 @@
+// DESCRIPTION: Verilator: constant string functions
+//
+// This file ONLY is placed into the Public Domain, for any use,
+// without warranty, 2023 by Wilson Snyder
+// SPDX-License-Identifier: CC0-1.0
+
+module t ();
+
+   function automatic string foo_func();
+      foo_func = "FOO";
+   endfunction
+
+   localparam string the_foo = foo_func();
+
+   initial begin
+      if (the_foo != "FOO") $stop;
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end
+endmodule


### PR DESCRIPTION
String assignments aren't working in constant functions.

The `V3Number` change is because when the num for the `CONST` here is created:
```
    1:2:1: VAR 0x555556c61c80 <e607#> {e9be} @dt=0@  foo_func OUTPUT [FUNCRTN] [VAUTOM]  VAR
    1:2:1:1: BASICDTYPE 0x555556cc95f0 <e606#> {e9ax} @dt=this@(str)  string kwd=string
    1:2:3: ASSIGN 0x555556cc3550 <e410> {e10aq} @dt=0@
    1:2:3:1: CONST 0x555556c87e00 <e411> {e10as} @dt=0x555556cc9790@(G/w24)  24'h464f4f
    1:2:3:2: VARREF 0x555556c58480 <e610#> {e10ah} @dt=0@  foo_func [LV] => VAR 0x555556c61c80 <e607#> {e9be} @dt=0@  foo_func OUTPUT [FUNCRTN] [VAUTOM]  VAR
```
it isn't being created as a string.

I'm sure it's possible to have it detect the type of `foo_func`, but I'm also not sure why we can't assign numbers to strings as strings are just packed byte vectors.