### PR TITLE
handle constant format field widths

### DIFF
--- a/src/V3Simulate.h
+++ b/src/V3Simulate.h
@@ -1084,12 +1084,19 @@ private:
             const string format = nodep->text();
             auto pos = format.cbegin();
             bool inPct = false;
+            string width;
             for (; pos != format.cend(); ++pos) {
                 if (!inPct && pos[0] == '%') {
                     inPct = true;
+                    width = "";
                 } else if (!inPct) {  // Normal text
                     result += *pos;
                 } else {  // Format character
+                    if ('0' <= pos[0] && pos[0] <= '9') {
+                        width += pos[0];
+                        continue;
+                    }
+
                     inPct = false;
 
                     if (V3Number::displayedFmtLegal(tolower(pos[0]), false)) {
@@ -1101,7 +1108,7 @@ private:
                                 nodep, "Argument for $display like statement is not constant");
                             break;
                         }
-                        const string pformat = std::string{"%"} + pos[0];
+                        const string pformat = std::string{"%"} + width + pos[0];
                         result += constp->num().displayed(nodep, pformat);
                     } else {
                         switch (tolower(pos[0])) {

--- a/src/V3Simulate.h
+++ b/src/V3Simulate.h
@@ -1092,7 +1092,7 @@ private:
                 } else if (!inPct) {  // Normal text
                     result += *pos;
                 } else {  // Format character
-                    if ('0' <= pos[0] && pos[0] <= '9') {
+                    if (std::isdigit(pos[0])) {
                         width += pos[0];
                         continue;
                     }

--- a/test_regress/t/t_const_string_func.v
+++ b/test_regress/t/t_const_string_func.v
@@ -8,12 +8,15 @@ module t ();
 
    function automatic string foo_func();
       foo_func = "FOO";
+      foo_func = $sformatf("%sBAR", foo_func);
+      for (int i = 0; i < 4; i++)
+         foo_func = $sformatf("%s%0d", foo_func, i);
    endfunction
 
    localparam string the_foo = foo_func();
 
    initial begin
-      if (the_foo != "FOO") $stop;
+      if (the_foo != "FOOBAR0123") $stop;
       $write("*-* All Finished *-*\n");
       $finish;
    end


### PR DESCRIPTION
Follow on to #3945 .  I'm now getting:
```
%Error: t/t_const_string_func.v:16:32: Expecting expression to be constant, but can't determine constant for FUNCREF 'foo_func'
                                     : ... In instance t
        t/t_const_string_func.v:13:21: ... Location of non-constant SFORMATF '%@%0~': Unknown $display-like format code.
        t/t_const_string_func.v:16:32: ... Called from foo_func() with parameters:
```
because `WidthVisitor::visit(AstSFormatF*)` converts `%s%0d` to `%@%0~` for reasons I do not yet understand.  First off, any pointers on understanding why this transform happens?  And secondly, is this format string conversion happening to early, and that's why `SimulateVisitor::visit(AstSFormatF*)` panics?  Or does that visitor need to be taught about these transmogrified format codes?