### PR TITLE
Skip class field linking if any of its super classes is a param

### DIFF
--- a/test_regress/t/t_class_extends_param.v
+++ b/test_regress/t/t_class_extends_param.v
@@ -7,7 +7,7 @@
 module t (/*AUTOARG*/
    );
 
-   class foo;
+   class Foo;
       int x = 1;
       function int get_x;
          return x;
@@ -17,10 +17,10 @@ module t (/*AUTOARG*/
       endfunction
    endclass
 
-   class bar #(type T=foo) extends T;
+   class Bar #(type T=Foo) extends T;
    endclass
 
-   class baz;
+   class Baz;
       int x = 2;
       function int get_x;
          return x;
@@ -30,14 +30,26 @@ module t (/*AUTOARG*/
       endfunction
    endclass
 
-   bar bar_foo_i;
-   bar #(baz) bar_baz_i;
+   class ExtendBar extends Bar;
+     function int get_x;
+        return super.get_x();
+     endfunction
+     function int get_6;
+        return 2 * get_3();
+     endfunction
+   endclass
+
+   Bar bar_foo_i;
+   Bar #(Baz) bar_baz_i;
+   ExtendBar extend_bar_i;
 
    initial begin
       bar_foo_i = new;
       bar_baz_i = new;
+      extend_bar_i = new;
       if (bar_foo_i.get_x() == 1 && bar_foo_i.get_3() == 3 &&
-          bar_baz_i.get_x() == 2 && bar_baz_i.get_4() == 4) begin
+          bar_baz_i.get_x() == 2 && bar_baz_i.get_4() == 4 &&
+          extend_bar_i.get_x() == 1 && extend_bar_i.get_6() == 6) begin
          $write("*-* All Finished *-*\n");
          $finish;
       end


### PR DESCRIPTION
Currently, linking of class fields is skipped in the first pass of V3LinkDot if a class extends (directly) its parameter. It is done in this way, because at the first pass of V3LinkDot parameters aren't resolved yet, so references to fields of the base class can't be linked. In this PR I made this behavior more general. Linking of class fields is skipped if any super class extends its parameter.