### PR TITLE
Sanitize file names from CMake before they get used as a C identifier.

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -149,3 +149,4 @@ Yutetsu TAKATSUKASA
 Yu-Sheng Lin
 Yves Mathieu
 Zhanglei Wang
+Zixi Li

--- a/verilator-config.cmake.in
+++ b/verilator-config.cmake.in
@@ -149,7 +149,7 @@ function(verilate TARGET)
     endif()
     list(GET VERILATE_SOURCES 0 TOPSRC)
     get_filename_component(_SRC_NAME ${TOPSRC} NAME_WE)
-    set(VERILATE_PREFIX V${_SRC_NAME})
+    string(MAKE_C_IDENTIFIER V${_SRC_NAME} VERILATE_PREFIX)
   endif()
 
   if (VERILATE_TOP_MODULE)


### PR DESCRIPTION
#3948 