### PR TITLE
Fix dicts declared with reference types

### DIFF
--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -6209,7 +6209,8 @@ private:
 
     void checkClassAssign(AstNode* nodep, const char* side, AstNode* rhsp,
                           AstNodeDType* lhsDTypep) {
-        if (VN_IS(lhsDTypep, ClassRefDType) && !VN_IS(rhsp->dtypep(), ClassRefDType)) {
+        if (VN_IS(lhsDTypep, ClassRefDType)
+            && !(rhsp->dtypep() && VN_IS(rhsp->dtypep()->skipRefp(), ClassRefDType))) {
             if (auto* const constp = VN_CAST(rhsp, Const)) {
                 if (constp->num().isNull()) return;
             }

--- a/test_regress/t/t_dict_ref_type.pl
+++ b/test_regress/t/t_dict_ref_type.pl
@@ -1,0 +1,21 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2022 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_dict_ref_type.v
+++ b/test_regress/t/t_dict_ref_type.v
@@ -1,0 +1,68 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2023 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+class Foo1;
+   int x = 1;
+   function int get_x;
+      return x;
+   endfunction
+endclass
+
+class Foo2;
+   int x = 2;
+   function int get_x;
+      return x;
+   endfunction
+endclass
+
+class Bar;
+   typedef Foo1 foo_t;
+   protected foo_t m_dict[int];
+
+   function void set(int key);
+      foo_t default_value = new;
+      m_dict[key] = default_value;
+   endfunction
+   function foo_t get(int key);
+      return m_dict[key];
+   endfunction
+endclass
+
+class Baz #(type T=Foo1);
+  protected T m_dict[int];
+
+  function void set(int key);
+     T default_value = new;
+     m_dict[key] = default_value;
+   endfunction
+   function T get(int key);
+      return m_dict[key];
+   endfunction
+endclass
+
+module t (/*AUTOARG*/
+   );
+
+   initial begin
+      Bar bar_i = new;
+      Baz baz_1_i = new;
+      Baz #(Foo2) baz_2_i = new;
+
+      bar_i.set(1);
+      baz_1_i.set(2);
+      baz_2_i.set(3);
+
+      if (bar_i.get(1).get_x() == 1 &&
+          baz_1_i.get(2).get_x() == 1 &&
+          baz_2_i.get(3).get_x() == 2) begin
+         $write("*-* All Finished *-*\n");
+         $finish;
+      end
+      else begin
+         $stop;
+      end
+   end
+endmodule


### PR DESCRIPTION
Assignments to dictionary elements threw errors if the types of RHSs were reference types. I fixed it.