### PR TITLE
Allow for recursive methods

### DIFF
--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -5204,9 +5204,13 @@ private:
         // Grab width from the output variable (if it's a function)
         if (nodep->didWidth()) return;
         if (nodep->doingWidth()) {
-            UINFO(5, "Recursive function or task call: " << nodep);
-            nodep->v3warn(E_UNSUPPORTED, "Unsupported: Recursive function or task call: "
-                                             << nodep->prettyNameQ());
+            if (nodep->classMethod()) {
+                UINFO(5, "Recursive method call: " << nodep);
+            } else {
+                UINFO(5, "Recursive function or task call: " << nodep);
+                nodep->v3warn(E_UNSUPPORTED, "Unsupported: Recursive function or task call: "
+                                                 << nodep->prettyNameQ());
+            }
             nodep->recursive(true);
             nodep->didWidth(true);
             return;

--- a/test_regress/t/t_recursive_method.pl
+++ b/test_regress/t/t_recursive_method.pl
@@ -1,0 +1,21 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2020 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_recursive_method.v
+++ b/test_regress/t/t_recursive_method.v
@@ -1,0 +1,40 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2023 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+class Fib;
+   function int get_fib(int n);
+      if (n == 0 || n == 1)
+        return n;
+      else
+        return get_fib(n - 1) + get_fib(n - 2);
+   endfunction
+endclass
+
+class FibStatic;
+   static function int get_fib(int n);
+      if (n == 0 || n == 1)
+        return n;
+      else
+        return get_fib(n - 1) + get_fib(n - 2);
+   endfunction
+endclass
+
+module t (/*AUTOARG*/);
+
+   initial begin
+      Fib fib = new;
+      if (fib.get_fib(0) != 0) $stop;
+      if (fib.get_fib(1) != 1) $stop;
+      if (fib.get_fib(8) != 21) $stop;
+
+      if (FibStatic::get_fib(0) != 0) $stop;
+      if (FibStatic::get_fib(1) != 1) $stop;
+      if (FibStatic::get_fib(8) != 21) $stop;
+
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end
+endmodule


### PR DESCRIPTION
Recursive class methods work if the warning is skipped. They also aren't inlined and the scheduler skips methods.
However I wonder if it should skip them. Maybe it should handle them if a class has a field that is a reference to a variable declared outside the class? I am not sure if it is possible in systemverilog. But if not, I think that recursive class methods can be allowed.