### PR TITLE
Fix subsequent parameter declarations

### DIFF
--- a/src/verilog.y
+++ b/src/verilog.y
@@ -1876,7 +1876,9 @@ parameter_port_declarationFrontE: // IEEE: local_ or parameter_port_declaration 
         //                      // Front must execute first so VARDTYPE is ready before list of vars
                 varParamReset implicit_typeE            { /*VARRESET-in-varParam*/ VARDTYPE($2); }
         |       varParamReset data_type                 { /*VARRESET-in-varParam*/ VARDTYPE($2); }
-        |       implicit_typeE                          { /*VARRESET-in-varParam*/ VARDTYPE($1); }
+        |       implicit_typeE                          { /*VARRESET-in-varParam
+                                                          Keep previous type to handle subsequent declarations.
+                                                          This rule is also used when the previous parameter is a type parameter*/ }
         |       data_type                               { /*VARRESET-in-varParam*/ VARDTYPE($1); }
         ;
 
@@ -3058,14 +3060,7 @@ param_assignment<varp>:         // ==IEEE: param_assignment
         //                      // IEEE: constant_param_expression
         //                      // constant_param_expression: '$' is in expr
                 id/*new-parameter*/ variable_dimensionListE sigAttrListE exprOrDataTypeEqE
-                        { // To handle  #(type A=int, B=A) and properly imply B
-                          // as a type (for parsing) we need to detect "A" is a type
-                          if (AstNodeDType* const refp = VN_CAST($4, NodeDType)) {
-                            if (VSymEnt* const foundp = SYMP->symCurrentp()->findIdFallback(refp->name())) {
-                                UINFO(9, "declaring type via param assignment" << foundp->nodep() << endl);
-                                VARDTYPE(new AstParseTypeDType{$<fl>1});
-                                SYMP->reinsert(foundp->nodep()->cloneTree(false), nullptr, *$1); }}
-                          $$ = VARDONEA($<fl>1, *$1, $2, $3);
+                        { $$ = VARDONEA($<fl>1, *$1, $2, $3);
                           if ($4) $$->valuep($4); }
         ;
 

--- a/src/verilog.y
+++ b/src/verilog.y
@@ -1876,9 +1876,11 @@ parameter_port_declarationFrontE: // IEEE: local_ or parameter_port_declaration 
         //                      // Front must execute first so VARDTYPE is ready before list of vars
                 varParamReset implicit_typeE            { /*VARRESET-in-varParam*/ VARDTYPE($2); }
         |       varParamReset data_type                 { /*VARRESET-in-varParam*/ VARDTYPE($2); }
-        |       implicit_typeE                          { /*VARRESET-in-varParam
-                                                          Keep previous type to handle subsequent declarations.
-                                                          This rule is also used when the previous parameter is a type parameter*/ }
+        |       implicit_typeE
+                        { /*VARRESET-in-varParam*/
+                          // Keep previous type to handle subsequent declarations.
+                          // This rule is also used when the previous parameter is a type parameter
+                        }
         |       data_type                               { /*VARRESET-in-varParam*/ VARDTYPE($1); }
         ;
 

--- a/test_regress/t/t_param_type5.pl
+++ b/test_regress/t/t_param_type5.pl
@@ -1,0 +1,21 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2003 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_param_type5.v
+++ b/test_regress/t/t_param_type5.v
@@ -13,7 +13,7 @@ module t #(parameter int A = 0, B = 1, C = 2, type D = int, E = string);
    E str1 = "abc";
    I str2 = "";
    initial begin
-      ParamClass param_class = new;
+      automatic ParamClass param_class = new;
       if ($typename(B) != "int") $stop;
       if ($typename(C) != "int") $stop;
       if (str1.len() != 3) $stop;

--- a/test_regress/t/t_param_type5.v
+++ b/test_regress/t/t_param_type5.v
@@ -1,0 +1,27 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2023 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+class ParamClass #(string P = "ABC", R = "GDF");
+endclass
+
+module t #(parameter int A = 0, B = 1, C = 2, type D = int, E = string);
+   parameter bit F = 1'b0, G = 1'b1;
+   parameter type H = int, I = string;
+   E str1 = "abc";
+   I str2 = "";
+   initial begin
+      ParamClass param_class = new;
+      if ($typename(B) != "int") $stop;
+      if ($typename(C) != "int") $stop;
+      if (str1.len() != 3) $stop;
+      if ($typename(G) != "bit") $stop;
+      if (str2.len() != 0) $stop;
+      if ($typename(param_class.R) != "string") $stop;
+
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end
+endmodule


### PR DESCRIPTION
Parameters declared on the lists have wrong types, except the first parameter on the lists. By lists I mean `list_of_param_assignments` and `list_of_type_assignments` from grammar rules (IEEE Std 1800-2017, section 6.20.1). They have `logic_implicit` type, but I think that they should have the type provided at the beginning of the list. This PR fixes it.