### PR TITLE
Allow for unreachable recursive calls

### DIFF
--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -5204,10 +5204,7 @@ private:
         // Grab width from the output variable (if it's a function)
         if (nodep->didWidth()) return;
         if (nodep->doingWidth()) {
-            UINFO(5, "Recursive function or task call: " << nodep);
-            nodep->v3warn(E_UNSUPPORTED, "Unsupported: Recursive function or task call: "
-                                             << nodep->prettyNameQ());
-            nodep->recursive(true);
+            // Possibly recursive function
             nodep->didWidth(true);
             return;
         }
@@ -5250,10 +5247,7 @@ private:
     void visit(AstProperty* nodep) override {
         if (nodep->didWidth()) return;
         if (nodep->doingWidth()) {
-            UINFO(5, "Recursive property call: " << nodep);
-            nodep->v3warn(E_UNSUPPORTED,
-                          "Unsupported: Recursive property call: " << nodep->prettyNameQ());
-            nodep->recursive(true);
+            // Possibly recursive property
             nodep->didWidth(true);
             return;
         }

--- a/src/Verilator.cpp
+++ b/src/Verilator.cpp
@@ -195,6 +195,9 @@ static void process() {
     // Must be before first constification pass drops dead code
     V3Undriven::undrivenAll(v3Global.rootp());
 
+    // Propagate constants into expressions
+    if (v3Global.opt.fConstBeforeDfg()) V3Const::constifyAllLint(v3Global.rootp());
+
     // Assertion insertion
     //    After we've added block coverage, but before other nasty transforms
     V3AssertPre::assertPreAll(v3Global.rootp());
@@ -207,9 +210,6 @@ static void process() {
         // Must do this after we know parameters and dtypes (as don't clone dtype decls)
         V3LinkLevel::wrapTop(v3Global.rootp());
     }
-
-    // Propagate constants into expressions
-    if (v3Global.opt.fConstBeforeDfg()) V3Const::constifyAllLint(v3Global.rootp());
 
     if (!(v3Global.opt.xmlOnly() && !v3Global.opt.flatten())) {
         // Split packed variables into multiple pieces to resolve UNOPTFLAT.

--- a/test_regress/t/t_assert_recursive_property_unsup.out
+++ b/test_regress/t/t_assert_recursive_property_unsup.out
@@ -1,5 +1,4 @@
 %Error-UNSUPPORTED: t/t_assert_recursive_property_unsup.v:20:4: Unsupported: Recursive property call: 'check'
-                                                              : ... In instance t
    20 |    property check(int n);
       |    ^~~~~~~~
                     ... For error description see https://verilator.org/warn/UNSUPPORTED?v=latest

--- a/test_regress/t/t_class_param.v
+++ b/test_regress/t/t_class_param.v
@@ -120,6 +120,15 @@ class Getter2 #(int T=5);
    endfunction
 endclass
 
+class Getter3 #(int T=5);
+   static function int get_3();
+      if (T == 3)
+        return 3;
+      else
+        return Getter3#(3)::get_3();
+   endfunction
+endclass
+
 module t (/*AUTOARG*/);
 
    Cls c12;
@@ -137,6 +146,7 @@ module t (/*AUTOARG*/);
    Getter1 getter1;
    Getter1 #(1) getter1_param_1;
    Getter2 getter2;
+   Getter3 getter3;
    int arr [1:0] = '{1, 2};
    initial begin
       c12 = new;
@@ -154,6 +164,7 @@ module t (/*AUTOARG*/);
       getter1 = new;
       getter1_param_1 = new;
       getter2 = new;
+      getter3 = new;
 
       if (Cls#()::PBASE != 12) $stop;
       if (Cls#(4)::PBASE != 4) $stop;
@@ -216,6 +227,10 @@ module t (/*AUTOARG*/);
       if (getter2.get_2() != 2) $stop;
       if (Getter2::get_2() != 2) $stop;
       if (Getter2#(2)::get_2() != 2) $stop;
+
+      if (getter3.get_3() != 3) $stop;
+      if (Getter3::get_3() != 3) $stop;
+      if (Getter3#(3)::get_3() != 3) $stop;
 
       $write("*-* All Finished *-*\n");
       $finish;

--- a/test_regress/t/t_func_recurse_param.out
+++ b/test_regress/t/t_func_recurse_param.out
@@ -3,14 +3,4 @@
     9 |    function automatic int recurse_self;
       |                           ^~~~~~~~~~~~
                     ... For error description see https://verilator.org/warn/UNSUPPORTED?v=latest
-%Error: t/t_func_recurse_param.v:15:26: Expecting expression to be constant, but can't determine constant for FUNCREF 'recurse_self'
-                                      : ... In instance t
-        t/t_func_recurse_param.v:9:27: ... Location of non-constant FUNC 'recurse_self': Unsupported: Recursive constant functions
-   15 |    localparam int ZERO = recurse_self(0);
-      |                          ^~~~~~~~~~~~
-%Error: t/t_func_recurse_param.v:16:28: Expecting expression to be constant, but can't determine constant for FUNCREF 'recurse_self'
-                                      : ... In instance t
-        t/t_func_recurse_param.v:9:27: ... Location of non-constant FUNC 'recurse_self': Unsupported: Recursive constant functions
-   16 |    localparam int ELEVEN = recurse_self(3);
-      |                            ^~~~~~~~~~~~
 %Error: Exiting due to

--- a/test_regress/t/t_func_recurse_param2.pl
+++ b/test_regress/t/t_func_recurse_param2.pl
@@ -1,0 +1,21 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2020 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_func_recurse_param2.v
+++ b/test_regress/t/t_func_recurse_param2.v
@@ -1,0 +1,39 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2023 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+module t (/*AUTOARG*/
+          clk);
+   parameter int X = 15;
+
+   input clk;
+
+   function int get_1();
+      if (X == 15)
+        return 1;
+      else
+        return get_1();
+   endfunction
+
+   int         out;
+   mod#(1, 1) mod_i(out);
+
+   always @(posedge clk) begin
+      if (get_1() != 1 || out != 1) $stop;
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end
+endmodule
+
+module mod#(int A = 1, int B = 2) (output int out);
+   function int get_1();
+      if (A == B)
+        return 1;
+      else
+        return get_1();
+   endfunction
+
+   initial out = get_1();
+endmodule

--- a/test_regress/t/t_func_recurse_param_bad.out
+++ b/test_regress/t/t_func_recurse_param_bad.out
@@ -3,9 +3,4 @@
     9 |    function automatic int recurse_self;
       |                           ^~~~~~~~~~~~
                     ... For error description see https://verilator.org/warn/UNSUPPORTED?v=latest
-%Error: t/t_func_recurse_param_bad.v:15:26: Expecting expression to be constant, but can't determine constant for FUNCREF 'recurse_self'
-                                          : ... In instance t
-        t/t_func_recurse_param_bad.v:9:27: ... Location of non-constant FUNC 'recurse_self': Unsupported: Recursive constant functions
-   15 |    localparam int HUGE = recurse_self(10000);   
-      |                          ^~~~~~~~~~~~
 %Error: Exiting due to


### PR DESCRIPTION
It allows for recursive calls that are unreachable due to parameter values. In order to do that, I moved the check for recursive case to V3AssertPre and moved the 2nd pass of V3Const (in which unreachable scopes are removed) before V3AssertPre.
I did it in V3AssertPre, because it has to be checked before handling of properties.