### PR TITLE
cmake: On macOS, mark weak symbols with -U linker flag

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -105,6 +105,7 @@ Nathan Myers
 Patrick Stewart
 Paul Wright
 Pawel Sagan
+Peter Debacker
 Peter Horvath
 Peter Monsson
 Philipp Wagner

--- a/verilator-config.cmake.in
+++ b/verilator-config.cmake.in
@@ -78,6 +78,10 @@ if (NOT CMAKE_CXX_COMPILER_ID MATCHES MSVC)
   endif()
 endif()
 
+if (${CMAKE_CXX_COMPILER_ID} STREQUAL "AppleClang")
+  add_link_options(-Wl,-U,__Z15vl_time_stamp64v,-U,__Z13sc_time_stampv)
+endif()
+
 define_property(TARGET
   PROPERTY VERILATOR_THREADED
   BRIEF_DOCS "Deprecated and has no effect (ignored)"


### PR DESCRIPTION
Similar fix as in #3823 but this time also in the cmake file.
Fixes #3978
