### PR TITLE
V3Timing: use 64bit for delay type

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -29,6 +29,7 @@ Driss Hafdi
 Edgar E. Iglesias
 Eric Rippey
 Fan Shupei
+Felix Neumärker
 Felix Yan
 Garrett Smith
 Geza Lore

--- a/src/V3Timing.cpp
+++ b/src/V3Timing.cpp
@@ -515,7 +515,9 @@ private:
                     flp,
                     new AstMulD{flp, valuep,
                                 new AstConst{flp, AstConst::RealDouble{}, m_timescaleFactor}}};
+                valuep->dtypeSetBitSized(64, VSigning::UNSIGNED);
             } else {
+                valuep->dtypeSetBitSized(64, VSigning::UNSIGNED);
                 valuep = new AstMul{flp, valuep,
                                     new AstConst{flp, AstConst::Unsized64{},
                                                  static_cast<uint64_t>(m_timescaleFactor)}};

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -1952,14 +1952,8 @@ private:
                         newp = new AstIToRD{nodep->fileline(), nodep->fromp()->unlinkFrBack()};
                     }
                 } else if (!basicp->isDouble() && nodep->fromp()->isDouble()) {
-                    if (basicp->isSigned()) {
-                        newp
-                            = new AstRToIRoundS{nodep->fileline(), nodep->fromp()->unlinkFrBack()};
-                    } else {
-                        newp = new AstUnsigned{
-                            nodep->fileline(),
-                            new AstRToIS{nodep->fileline(), nodep->fromp()->unlinkFrBack()}};
-                    }
+                    newp = new AstRToIRoundS{nodep->fileline(), nodep->fromp()->unlinkFrBack()};
+                    newp->dtypeChgSigned(basicp->isSigned());
                 } else if (basicp->isSigned() && !nodep->fromp()->isSigned()) {
                     newp = new AstSigned{nodep->fileline(), nodep->fromp()->unlinkFrBack()};
                 } else if (!basicp->isSigned() && nodep->fromp()->isSigned()) {

--- a/test_regress/t/t_timing_wait_long.out
+++ b/test_regress/t/t_timing_wait_long.out
@@ -1,0 +1,10 @@
+Current realtime:              5000000 ==           5000000000
+Current realtime:             10000001 ==             10000001
+Current realtime:             15000000 ==             15000000
+FULL_TIME: 5000000.000000
+Current realtime:             20000000 ==             20000000
+FIT_TIME: 5000000 -- 5000000.000000
+Current realtime:             25000000 ==             25000000
+TRUNCATED_TIME:  805696 -- 805696.000000
+Current realtime:             25805696 ==             25805696
+*-* All Finished *-*

--- a/test_regress/t/t_timing_wait_long.pl
+++ b/test_regress/t/t_timing_wait_long.pl
@@ -1,0 +1,28 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2022 by Antmicro Ltd. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+if (!$Self->have_coroutines) {
+    skip("No coroutine support");
+}
+else {
+    compile(
+        verilator_flags2 => ["--exe --main --timing"],
+        make_main => 0,
+        );
+
+    execute(
+        check_finished => 1,
+        expect_filename => $Self->{golden_filename},
+        );
+}
+ok(1);
+1;

--- a/test_regress/t/t_timing_wait_long.v
+++ b/test_regress/t/t_timing_wait_long.v
@@ -1,0 +1,46 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2022 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+`timescale 1ns/1ps
+
+module timing_wait_long();
+    localparam real FULL_TIME = 5e6;
+    /* verilator lint_off WIDTHTRUNC */
+    localparam [22:0] FIT_TIME = int'(5e6);
+    localparam [21:0] TRUNCATED_TIME = int'(5e6); // 805696
+    /* verilator lint_on WIDTHTRUNC */
+
+    real realvar_time = 5e6;
+    time timevar;
+    initial begin
+        #5ms;
+        $display("Current realtime: %d == %d", time'($realtime), time'(1 * 5e9));
+
+        realvar_time = realvar_time + 1;
+        #realvar_time;
+        $display("Current realtime: %d == %d", time'($realtime), time'(2 * 5e6 + 1));
+
+        timevar = time'(realvar_time - 2);
+        #timevar;
+        $display("Current realtime: %d == %d", time'($realtime), time'(3 * 5e6));
+
+        $display("FULL_TIME: %f", FULL_TIME);
+        #FULL_TIME;
+        $display("Current realtime: %d == %d", time'($realtime), time'(4 * 5e6));
+
+        $display("FIT_TIME: %d -- %f", FIT_TIME, real'(FIT_TIME));
+        #FIT_TIME;
+        $display("Current realtime: %d == %d", time'($realtime), time'(5 * 5e6));
+
+        $display("TRUNCATED_TIME: %d -- %f", TRUNCATED_TIME, real'(TRUNCATED_TIME));
+        #TRUNCATED_TIME;
+        $display("Current realtime: %d == %d", time'($realtime), time'(5 * 5e6 + real'(int'(5e6) % 2**22)));
+
+        $write("*-* All Finished *-*\n");
+        $finish();
+    end
+
+endmodule


### PR DESCRIPTION
Fix attempt the issue of #3973 - not sure about side effects and also architecture wise.
I could also introduce `dtypeSetSigned64()` .

Other possible point to fix the problems might be:

https://github.com/verilator/verilator/blob/master/src/V3Number.cpp#L2338
https://github.com/verilator/verilator/blob/master/src/V3Timing.cpp#L512