### PR TITLE
Allow for recursive methods

### DIFF
--- a/src/V3Const.cpp
+++ b/src/V3Const.cpp
@@ -3140,9 +3140,9 @@ private:
         }
     }
     void visit(AstNodeFTask* nodep) override {
+        VL_RESTORER(m_underRecFunc);
         if (nodep->recursive()) m_underRecFunc = true;
         iterateChildren(nodep);
-        m_underRecFunc = false;
     }
 
     void visit(AstFuncRef* nodep) override {

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -5211,9 +5211,13 @@ private:
         // Grab width from the output variable (if it's a function)
         if (nodep->didWidth()) return;
         if (nodep->doingWidth()) {
-            UINFO(5, "Recursive function or task call: " << nodep);
-            nodep->v3warn(E_UNSUPPORTED, "Unsupported: Recursive function or task call: "
-                                             << nodep->prettyNameQ());
+            if (nodep->classMethod()) {
+                UINFO(5, "Recursive method call: " << nodep);
+            } else {
+                UINFO(5, "Recursive function or task call: " << nodep);
+                nodep->v3warn(E_UNSUPPORTED, "Unsupported: Recursive function or task call: "
+                                                 << nodep->prettyNameQ());
+            }
             nodep->recursive(true);
             nodep->didWidth(true);
             return;

--- a/test_regress/t/t_recursive_method.pl
+++ b/test_regress/t/t_recursive_method.pl
@@ -1,0 +1,21 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2020 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_recursive_method.v
+++ b/test_regress/t/t_recursive_method.v
@@ -1,0 +1,70 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2023 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+class Fib;
+   function int get_fib(int n);
+      if (n == 0 || n == 1)
+        return n;
+      else
+        return get_fib(n - 1) + get_fib(n - 2);
+   endfunction
+endclass
+
+class FibStatic;
+   static function int get_fib(int n);
+      if (n == 0 || n == 1)
+        return n;
+      else
+        return get_fib(n - 1) + get_fib(n - 2);
+   endfunction
+endclass
+
+class Factorial;
+   static function int factorial(int n);
+      return fact(n, 1);
+   endfunction
+   static function int fact(int n, int acc);
+      if (n < 2)
+         fact = acc;
+      else
+         fact = fact(n - 1, acc * n);
+   endfunction
+endclass
+
+class Getter3 #(int T=5);
+   static function int get_3();
+      if (T == 3)
+        return 3;
+      else
+        return Getter3#(3)::get_3();
+   endfunction
+endclass
+
+module t (/*AUTOARG*/);
+
+   initial begin
+      Fib fib = new;
+      Getter3 getter3 = new;
+
+      if (fib.get_fib(0) != 0) $stop;
+      if (fib.get_fib(1) != 1) $stop;
+      if (fib.get_fib(8) != 21) $stop;
+
+      if (FibStatic::get_fib(0) != 0) $stop;
+      if (FibStatic::get_fib(1) != 1) $stop;
+      if (FibStatic::get_fib(8) != 21) $stop;
+
+      if (Factorial::factorial(0) != 1) $stop;
+      if (Factorial::factorial(1) != 1) $stop;
+      if (Factorial::factorial(6) != 720) $stop;
+
+      if (getter3.get_3() != 3) $stop;
+      if (Getter3#(3)::get_3() != 3) $stop;
+
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end
+endmodule


### PR DESCRIPTION
As we have talked in https://github.com/verilator/verilator/pull/3977 and https://github.com/verilator/verilator/pull/3961, recursive methods would work if conversion of `if` statements was disabled. This PR disables it in recursive functions and stops throwing a warning about recursive functions when a function is a method.

I have also checked that this optimization is used only if a function returns values using assignments. If there are `return` statements, Verilator converts them into assignments, but inserts jump commands after them and then there are 2 statements inside `if` and this optimization isn't used then. So the problem with optimization occurred much rarer than I thought.