### PR TITLE
V3Undriven: fix SIGSEV occurring when running with --public-flat-rw

### DIFF
--- a/src/V3Undriven.cpp
+++ b/src/V3Undriven.cpp
@@ -408,7 +408,8 @@ private:
                 }
                 if (entryp->isDrivenWhole() && !m_inBBox && !VN_IS(nodep, VarXRef)
                     && !VN_IS(nodep->dtypep()->skipRefp(), UnpackArrayDType)
-                    && nodep->fileline() != entryp->getNodeFileLinep() && !entryp->isUnderGen()) {
+                    && nodep->fileline() != entryp->getNodeFileLinep() && !entryp->isUnderGen()
+                    && entryp->getNodep()) {
                     if (m_alwaysCombp
                         && (!entryp->isDrivenAlwaysCombWhole()
                             || (entryp->isDrivenAlwaysCombWhole()

--- a/test_regress/t/t_lint_always_comb_multidriven_compile_public_flat.pl
+++ b/test_regress/t/t_lint_always_comb_multidriven_compile_public_flat.pl
@@ -1,0 +1,26 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2023 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(linter => 1, simulator => 1);
+
+top_filename("t/t_lint_always_comb_multidriven.v");
+
+lint(
+    verilator_flags2 => ['--public-flat-rw --lint-only'],
+    fails => 1,
+    expect_filename => "t/t_lint_always_comb_multidriven.out",
+    );
+
+compile(
+    verilator_flags2 => ['--public-flat-rw -Wno-fatal'],
+    );
+
+ok(1);
+1;


### PR DESCRIPTION
Commit 003a8cfe756f05bd34c885069fe93d4e5d0ca030 introduce lint warning for `always_comb multidriven`
However when running with `--public-flat-rw` verilator dies with segmentation fault.
`entryp->getNodep()` is `nullptr_t`
Quickfix attempt: checking value before trying to warn. I guess there is a better way... maybe @adambagley knows?

Steps to reproduce
`verilator --public-flat-rw --binary test_regress/t/t_lint_always_comb_multidriven.v`