### PR TITLE
LinkDotResolveVisitor: Revert m_ds.m_dotSymp value after visiting classes we inherit from

### DIFF
--- a/src/V3LinkDot.cpp
+++ b/src/V3LinkDot.cpp
@@ -3354,6 +3354,8 @@ private:
                     }
                 }
             }
+            m_ds.m_dotSymp = m_curSymp;
+
             iterateChildren(nodep);
         }
         // V3Width when determines types needs to find enum values and such

--- a/test_regress/t/t_class_extends_vsyment.pl
+++ b/test_regress/t/t_class_extends_vsyment.pl
@@ -1,0 +1,17 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2020 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(vlt => 1);
+
+compile(
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_class_extends_vsyment.v
+++ b/test_regress/t/t_class_extends_vsyment.v
@@ -1,0 +1,15 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2022 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+class Foo;
+endclass
+
+class Bar extends Foo;
+    int m_field = get_1();
+    function int get_1();
+        return 1;
+    endfunction
+endclass


### PR DESCRIPTION
Fixes https://github.com/verilator/verilator/issues/3995
