### PR TITLE
Don't rename member selects

### DIFF
--- a/src/V3Name.cpp
+++ b/src/V3Name.cpp
@@ -107,12 +107,6 @@ private:
             iterateChildren(nodep);
         }
     }
-    void visit(AstMemberSel* nodep) override {
-        if (!nodep->user1()) {
-            rename(nodep, false);
-            iterateChildren(nodep);
-        }
-    }
     void visit(AstScope* nodep) override {
         if (!nodep->user1SetOnce()) {
             if (nodep->aboveScopep()) iterate(nodep->aboveScopep());

--- a/src/V3Name.cpp
+++ b/src/V3Name.cpp
@@ -103,7 +103,19 @@ private:
     }
     void visit(AstMemberDType* nodep) override {
         if (!nodep->user1()) {
-            rename(nodep, false);
+            rename(nodep, true);
+            iterateChildren(nodep);
+        }
+    }
+    void visit(AstMemberSel* nodep) override {
+        if (!nodep->user1()) {
+            rename(nodep, true);
+            iterateChildren(nodep);
+        }
+    }
+    void visit(AstStructSel* nodep) override {
+        if (!nodep->user1()) {
+            rename(nodep, true);
             iterateChildren(nodep);
         }
     }

--- a/test_regress/t/t_class_field_name.pl
+++ b/test_regress/t/t_class_field_name.pl
@@ -1,0 +1,21 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2020 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_class_field_name.v
+++ b/test_regress/t/t_class_field_name.v
@@ -1,0 +1,21 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2023 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+class Cls;
+   int queue;
+endclass
+
+module t (/*AUTOARG*/);
+
+   initial begin
+      Cls cls = new;
+      cls.queue = 1;
+      if (cls.queue == 1) begin
+         $write("*-* All Finished *-*\n");
+         $finish;
+      end
+   end
+endmodule


### PR DESCRIPTION
Verilator throws Internal Error when a class field has the same name as one of STL members. It tries to rename AstMemberSel object, but objects of that class don't have names.This PR fixes it.