### PR TITLE
Jnwabueze/enum error

### DIFF
--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -235,7 +235,7 @@ private:
     const bool m_paramsOnly;  // Computing parameter value; limit operation
     const bool m_doGenerate;  // Do errors later inside generate statement
     int m_dtTables = 0;  // Number of created data type tables
-    TableMap m_tableMap;  // Created tables so can remove duplicates
+    static TableMap m_tableMap;  // Created tables so can remove duplicates
     std::map<const AstNodeDType*, AstQueueDType*>
         m_queueDTypeIndexed;  // Queues with given index type
 
@@ -7415,3 +7415,5 @@ void V3Width::widthCommit(AstNetlist* nodep) {
     { WidthCommitVisitor{nodep}; }  // Destruct before checking
     V3Global::dumpCheckGlobalTree("widthcommit", 0, dumpTree() >= 6);
 }
+
+WidthVisitor::TableMap WidthVisitor::m_tableMap;

--- a/test_regress/t/t_enum_const_methods.v
+++ b/test_regress/t/t_enum_const_methods.v
@@ -6,21 +6,28 @@
 
 module t ();
 
+
    typedef enum [1:0] {E0, E1, E2} enm_t;
 
-   function automatic enm_t get_first();
+   // function automatic enm_t get_first();
+   //    enm_t enm;
+   //    return enm.first;
+   // endfunction
+
+   // localparam enm_t enum_first = get_first();
+
+   // function automatic enm_t get_last();
+   //    enm_t enm;
+   //    return enm.last;
+   // endfunction
+
+   // localparam enm_t enum_last = get_last();
+
+   function automatic enm_t get_2();
       enm_t enm;
-      return enm.first;
+      enm = enm.first;
+      return enm.next;
    endfunction
-
-   localparam enm_t enum_first = get_first();
-
-   function automatic enm_t get_last();
-      enm_t enm;
-      return enm.last;
-   endfunction
-
-   localparam enm_t enum_last = get_last();
 
    function automatic enm_t get_second();
       enm_t enm;
@@ -28,19 +35,19 @@ module t ();
       return enm.next;
    endfunction
 
-   localparam enm_t enum_second = get_second();
+   localparam enm_t enum_second = get_2();
 
-   function automatic string get_name(enm_t enm);
-      return enm.name;
-   endfunction
+   // function automatic string get_name(enm_t enm);
+   //    return enm.name;
+   // endfunction
 
-   localparam string e0_name = get_name(E0);
+   // localparam string e0_name = get_name(E0);
 
    initial begin
-      if (enum_first != E0) $stop;
-      if (enum_last != E2) $stop;
-      if (enum_second != E1) $stop;
-      if (e0_name != "E0") $stop;
+      // if (enum_first != E0) $stop;
+      // if (enum_last != E2) $stop;
+      // if (enum_second != E1) $stop;
+      // if (e0_name != "E0") $stop;
       $write("*-* All Finished *-*\n");
       $finish;
    end

--- a/test_regress/t/t_enum_const_methods.v
+++ b/test_regress/t/t_enum_const_methods.v
@@ -6,28 +6,21 @@
 
 module t ();
 
-
    typedef enum [1:0] {E0, E1, E2} enm_t;
 
-   // function automatic enm_t get_first();
-   //    enm_t enm;
-   //    return enm.first;
-   // endfunction
-
-   // localparam enm_t enum_first = get_first();
-
-   // function automatic enm_t get_last();
-   //    enm_t enm;
-   //    return enm.last;
-   // endfunction
-
-   // localparam enm_t enum_last = get_last();
-
-   function automatic enm_t get_2();
+   function automatic enm_t get_first();
       enm_t enm;
-      enm = enm.first;
-      return enm.next;
+      return enm.first;
    endfunction
+
+   localparam enm_t enum_first = get_first();
+
+   function automatic enm_t get_last();
+      enm_t enm;
+      return enm.last;
+   endfunction
+
+   localparam enm_t enum_last = get_last();
 
    function automatic enm_t get_second();
       enm_t enm;
@@ -35,19 +28,28 @@ module t ();
       return enm.next;
    endfunction
 
-   localparam enm_t enum_second = get_2();
+   localparam enm_t enum_second = get_second();
 
-   // function automatic string get_name(enm_t enm);
-   //    return enm.name;
-   // endfunction
+   function automatic string get_name(enm_t enm);
+      return enm.name;
+   endfunction
 
-   // localparam string e0_name = get_name(E0);
+   localparam string e0_name = get_name(E0);
+
+   function automatic enm_t get_2();
+      enm_t enm;
+      enm = E0;
+      return enm.next.next;
+   endfunction
+
+   localparam enm_t enum_2 = get_2();
 
    initial begin
-      // if (enum_first != E0) $stop;
-      // if (enum_last != E2) $stop;
-      // if (enum_second != E1) $stop;
-      // if (e0_name != "E0") $stop;
+      if (enum_first != E0) $stop;
+      if (enum_last != E2) $stop;
+      if (enum_second != E1) $stop;
+      if (e0_name != "E0") $stop;
+      if (enum_2 != E2) $stop;
       $write("*-* All Finished *-*\n");
       $finish;
    end


### PR DESCRIPTION
This appears to fix #3999 on the surface; The tableMap doesnt persist across width visitors so the type is duplicated in future passes then deleted by DupVar/LinkDot. @wsnyder, is this fix suitable (if it passes regressions) or should the tableMap perhaps read the ast tree somehow when the WidthVisitor starts up?
