### PR TITLE
Fix incorrect generation of register in VCD tracing (#4004)

### DIFF
--- a/include/verilated_vcd_c.cpp
+++ b/include/verilated_vcd_c.cpp
@@ -553,6 +553,10 @@ void VerilatedVcd::declBus(uint32_t code, const char* name, bool array, int arra
                            int lsb) {
     declare(code, name, "wire", array, arraynum, false, true, msb, lsb);
 }
+void VerilatedVcd::declReg(uint32_t code, const char* name, bool array, int arraynum, int msb,
+                           int lsb) {
+    declare(code, name, "reg", array, arraynum, false, true, msb, lsb);
+}
 void VerilatedVcd::declQuad(uint32_t code, const char* name, bool array, int arraynum, int msb,
                             int lsb) {
     declare(code, name, "wire", array, arraynum, false, true, msb, lsb);

--- a/include/verilated_vcd_c.h
+++ b/include/verilated_vcd_c.h
@@ -143,6 +143,7 @@ public:
     void declEvent(uint32_t code, const char* name, bool array, int arraynum);
     void declBit(uint32_t code, const char* name, bool array, int arraynum);
     void declBus(uint32_t code, const char* name, bool array, int arraynum, int msb, int lsb);
+    void declReg(uint32_t code, const char* name, bool array, int arraynum, int msb, int lsb);
     void declQuad(uint32_t code, const char* name, bool array, int arraynum, int msb, int lsb);
     void declArray(uint32_t code, const char* name, bool array, int arraynum, int msb, int lsb);
     void declDouble(uint32_t code, const char* name, bool array, int arraynum);

--- a/src/V3EmitCImp.cpp
+++ b/src/V3EmitCImp.cpp
@@ -646,7 +646,12 @@ class EmitCTrace final : EmitCFunc {
         } else if (nodep->isQuad()) {
             puts("tracep->declQuad");
         } else if (nodep->bitRange().ranged()) {
-            puts("tracep->declBus");
+            if(nodep->varType() == VVarType::VAR) {
+                puts("tracep->declReg");
+            }
+            else {
+                puts("tracep->declBus");
+            }
         } else if (nodep->dtypep()->basicp()->isEvent()) {
             puts("tracep->declEvent");
         } else {
@@ -674,6 +679,7 @@ class EmitCTrace final : EmitCFunc {
             // fstVarType
             const VVarType vartype = nodep->varType();
             const VBasicDTypeKwd kwd = nodep->declKwd();
+
             string fstvt;
             // Doubles have special decoding properties, so must indicate if a double
             if (nodep->dtypep()->basicp()->isDouble()) {


### PR DESCRIPTION
This fixes issue #4004.

Fix - 

1. Only declBus was used to emit signals
2. Added a declReg function which emits registers
3. Updated emit stage to check if logic variable and then emit declReg

Should not break existing code. I tried it with examples/make_tracing_c and `count_c` is emitted as a register.