### PR TITLE
Use variable used to generate name to track created previous value variables

### DIFF
--- a/src/V3SenExprBuilder.h
+++ b/src/V3SenExprBuilder.h
@@ -93,8 +93,12 @@ class SenExprBuilder final {
         FileLine* const flp = exprp->fileline();
         const auto rdCurr = [=]() { return getCurr(exprp); };
 
+        AstNode* scopeExprp = exprp;
+        if (AstVarRef* const refp = VN_CAST(exprp, VarRef)) {
+            scopeExprp = refp->varScopep()->varp();
+        }
         // Create the 'previous value' variable
-        auto it = m_prev.find(*exprp);
+        auto it = m_prev.find(*scopeExprp);
         if (it == m_prev.end()) {
             // For readability, use the scoped signal name if the trigger is a simple AstVarRef
             string name;
@@ -117,7 +121,7 @@ class SenExprBuilder final {
                 prevp = new AstVarScope{flp, m_scopep, varp};
                 m_scopep->addVarsp(prevp);
             }
-            it = m_prev.emplace(*exprp, prevp).first;
+            it = m_prev.emplace(*scopeExprp, prevp).first;
 
             // Add the initializer init
             AstAssign* const initp = new AstAssign{flp, new AstVarRef{flp, prevp, VAccess::WRITE},

--- a/test_regress/t/t_event_control_prev_name_collision.pl
+++ b/test_regress/t/t_event_control_prev_name_collision.pl
@@ -1,0 +1,22 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2003 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    verilator_flags2 => ["-fno-inline"],
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_event_control_prev_name_collision.v
+++ b/test_regress/t/t_event_control_prev_name_collision.v
@@ -1,0 +1,98 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2023 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+module S(
+  input  reset,
+         io_i,
+  output io_o
+);
+  reg s;
+  always @(posedge reset) begin
+    if (reset) begin
+      s <= 1'h0;
+    end
+    else begin
+      s <= io_i;
+    end
+  end
+  assign io_o = s;
+endmodule
+
+module Q(
+  input        reset_e,
+  input        reset_d,
+  output       ready_e
+);
+
+  wire       reset_n;
+  wire       io_v;
+  wire       io_e;
+  S e (
+    .io_i  (),
+    .reset  (reset_e | ~reset_n),
+    .io_o (io_e)
+  );
+  S v (
+    .io_i  (io_e),
+    .reset  (reset_e),
+    .io_o (io_v)
+  );
+  assign reset_n = ~reset_d;
+  assign ready_e = io_v;
+endmodule
+
+module Test(
+  input        	reset,
+  output        valid
+);
+  wire ready_e;
+
+  Q q (
+    .reset_e (reset),
+    .reset_d (reset),
+    .ready_e (ready_e)
+  );
+
+  assign valid = ready_e;
+endmodule
+
+module Test2(
+  input         reset,
+  input         valid
+);
+  always begin
+    if (~reset & valid) begin
+        $fatal;
+    end
+  end
+endmodule
+
+module Dut(
+  input  reset
+);
+  wire        valid_g;
+
+  Test t (
+    .reset       (reset),
+    .valid       (valid_g)
+  );
+  Test2 t2 (
+    .reset       (reset),
+    .valid       (valid_g)
+  );
+endmodule
+
+module t (/*AUTOARG*/
+   );
+  reg  [$bits(dut.reset)-1:0] reset;
+
+  Dut dut (
+      .reset(reset)
+  );
+  initial begin
+    $write("*-* All Finished *-*\n");
+    $finish;
+  end
+endmodule


### PR DESCRIPTION
Currently ``AstNodeExpr`` is used to map already created previous value variables, but when there are 2 different ``AstNodeExpr`` that points to the same ``AstVar``, verilator creates invalid C++ with same variable declared twice.

This PR changes to use ``AstVar`` to map previously created variables when ``AstNodeExpr`` is ``AstVarRef``.

Test case uses ``-fno-inline`` only to further simplify test-case. This problem was originally noticed without ``-fno-inline`` flag.
