### PR TITLE
Assign unique names for blocks in do..while loop

### DIFF
--- a/src/V3AstNodeOther.h
+++ b/src/V3AstNodeOther.h
@@ -2651,17 +2651,13 @@ public:
     bool addNewline() const { return displayType().addNewline(); }
 };
 class AstDoWhile final : public AstNodeStmt {
-    // @astgen op1 := precondsp : List[AstNode]
-    // @astgen op2 := condp : AstNodeExpr
-    // @astgen op3 := stmtsp : List[AstNode]
-    // @astgen op4 := incsp : List[AstNode]
+    // @astgen op1 := condp : AstNodeExpr
+    // @astgen op2 := stmtsp : List[AstNode]
 public:
-    AstDoWhile(FileLine* fl, AstNodeExpr* conditionp, AstNode* stmtsp = nullptr,
-               AstNode* incsp = nullptr)
+    AstDoWhile(FileLine* fl, AstNodeExpr* conditionp, AstNode* stmtsp = nullptr)
         : ASTGEN_SUPER_DoWhile(fl) {
         condp(conditionp);
         addStmtsp(stmtsp);
-        addIncsp(incsp);
     }
     ASTGEN_MEMBERS_AstDoWhile;
     bool isGateOptimizable() const override { return false; }

--- a/src/V3LinkJump.cpp
+++ b/src/V3LinkJump.cpp
@@ -132,7 +132,7 @@ private:
         // Add do_while_ prefix to blocks
         // Used to not have blocks with duplicated names
         if (AstBegin* const beginp = VN_CAST(nodep, Begin)) {
-            if (beginp->name() != "") beginp->name("do_while_" + beginp->name());
+            if (beginp->name() != "") beginp->name("__Vdo_while_" + beginp->name());
         }
 
         if (nodep->op1p()) addPrefixToBlocksRecurse(nodep->op1p());

--- a/test_regress/t/t_do_while.pl
+++ b/test_regress/t/t_do_while.pl
@@ -1,0 +1,21 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2020 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_do_while.v
+++ b/test_regress/t/t_do_while.v
@@ -1,0 +1,58 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2023 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+function automatic int get_1;
+   int a = 0;
+   do begin
+      int x = 1;
+      a += x;
+   end while (a < 0);
+   return a;
+endfunction
+
+module t (/*AUTOARG*/);
+   int a;
+   initial begin
+      if (get_1() != 1) $stop;
+
+      a = 0;
+      do begin
+         int x = 1;
+         a += x;
+         if (a == 1) begin
+            a = 2;
+         end
+      end while (a < 0);
+      if (a != 2) $stop;
+
+      a = 1;
+      do begin
+         if (a == 1) begin
+            a = 2;
+         end
+         if (a == 2) begin
+            a = 3;
+         end
+      end while (a < 0);
+      if (a != 3) $stop;
+
+      a = 1;
+      do begin
+         if (a == 1) begin
+            do begin
+               a++;
+            end while (a < 5);
+         end
+         if (a == 2) begin
+            a = 3;
+         end
+      end while (a < 0);
+      if (a != 5) $stop;
+
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end
+endmodule


### PR DESCRIPTION
It fixes the error that is thrown when there is a variable declaration in the body of a `do..while` loop.
The names of the bodies have to be distinct and if no name is provided, Verilator assigns a unique name. But due to the copying of the body in AstDoWhile conversion, the name is duplicated. And this PR adds a prefix to the copied block.

I also removed unused fields from AstDoWhile class.