### PR TITLE
Fix dumping of AstMethodCall

### DIFF
--- a/src/V3AstNodeExpr.h
+++ b/src/V3AstNodeExpr.h
@@ -4052,7 +4052,6 @@ public:
         BROKEN_RTN(!fromp());
         return nullptr;
     }
-    void dump(std::ostream& str) const override;
 };
 class AstNew final : public AstNodeFTaskRef {
     // New as constructor

--- a/src/V3AstNodes.cpp
+++ b/src/V3AstNodes.cpp
@@ -1672,15 +1672,6 @@ const char* AstMemberSel::broken() const {
     BROKEN_RTN(m_varp && !m_varp->brokeExists());
     return nullptr;
 }
-void AstMethodCall::dump(std::ostream& str) const {
-    this->AstNodeFTaskRef::dump(str);
-    str << " -> ";
-    if (taskp()) {
-        taskp()->dump(str);
-    } else {
-        str << " -> UNLINKED";
-    }
-}
 void AstModportFTaskRef::dump(std::ostream& str) const {
     this->AstNode::dump(str);
     if (isExport()) str << " EXPORT";


### PR DESCRIPTION
Currently, `AstMethodCall::dump()` prints a link to a method two times:
`METHODCALL 0x5555570a0a00 <e661#> {d10at} @dt=0x5555570a35f0@(sw32)  get_1 pkg=0x555557049b00 -> FUNC 0x55555706bd00 <e645#> {d2ar} @dt=0x5555570a35f0@(sw32)  get_1 [METHOD] -> FUNC 0x55555706bd00 <e645#> {d2ar} @dt=0x5555570a35f0@(sw32)  get_1 [METHOD]`
This PR fixes it.