### PR TITLE
Fix randomize_method test

### DIFF
--- a/test_regress/t/t_randomize_method.v
+++ b/test_regress/t/t_randomize_method.v
@@ -4,6 +4,20 @@
 // any use, without warranty, 2020 by Wilson Snyder.
 // SPDX-License-Identifier: CC0-1.0
 
+`define check_rand(cl, field) \
+begin \
+   longint prev_result; \
+   int ok = 0; \
+   for (int i = 0; i < 10; i++) begin \
+      longint result; \
+      void'(cl.randomize()); \
+      result = longint'(field); \
+      if (i > 0 && result != prev_result) ok = 1; \
+      prev_result = result; \
+   end \
+   if (ok != 1) $stop; \
+end
+
 typedef enum bit[15:0] {
    ONE   = 3,
    TWO   = 5,
@@ -83,12 +97,6 @@ class ContainsNull;
 endclass
 
 module t (/*AUTOARG*/);
-   bit ok = 0;
-   longint checksum;
-
-   task checksum_next(longint x);
-      checksum = x ^ {checksum[62:0],checksum[63]^checksum[2]^checksum[0]};
-   endtask;
 
    DerivedCls derived;
    OtherCls other;
@@ -97,12 +105,11 @@ module t (/*AUTOARG*/);
 
    initial begin
       int rand_result;
-      longint prev_checksum;
+      derived = new;
+      other = new;
+      cont = new;
+      base = derived;
       for (int i = 0; i < 10; i++) begin
-         derived = new;
-         other = new;
-         cont = new;
-         base = derived;
          rand_result = base.randomize();
          rand_result = other.randomize();
          rand_result = cont.randomize();
@@ -113,32 +120,24 @@ module t (/*AUTOARG*/);
          if (derived.k != 0) $stop;
          if (other.v != 0) $stop;
          if (cont.b != null) $stop;
-         checksum = 0;
-         checksum_next(longint'(derived.i.a));
-         checksum_next(longint'(derived.i.b));
-         checksum_next(longint'(derived.i.c));
-         checksum_next(longint'(derived.j));
-         checksum_next(longint'(derived.l));
-         checksum_next(longint'(other.w));
-         checksum_next(longint'(other.x));
-         checksum_next(longint'(other.y));
-         checksum_next(longint'(other.z));
-         checksum_next(longint'(other.str.x));
-         checksum_next(longint'(other.str.y));
-         checksum_next(longint'(other.str.z));
-         checksum_next(longint'(other.str.s.a));
-         checksum_next(longint'(other.str.s.b));
-         checksum_next(longint'(other.str.s.c));
-         $write("checksum: %d\n", checksum);
-         if (i > 0 && checksum != prev_checksum) begin
-            ok = 1;
-         end
-         prev_checksum = checksum;
       end
-      if (ok) begin
-         $write("*-* All Finished *-*\n");
-         $finish;
-      end
-      else $stop;
+      `check_rand(derived, derived.i.a);
+      `check_rand(derived, derived.i.b);
+      `check_rand(derived, derived.i.c);
+      `check_rand(derived, derived.j);
+      `check_rand(derived, derived.l);
+      `check_rand(other, other.w);
+      `check_rand(other, other.x);
+      `check_rand(other, other.y);
+      `check_rand(other, other.z);
+      `check_rand(other, other.str.x);
+      `check_rand(other, other.str.y);
+      `check_rand(other, other.str.z);
+      `check_rand(other, other.str.s.a);
+      `check_rand(other, other.str.s.b);
+      `check_rand(other, other.str.s.c);
+
+      $write("*-* All Finished *-*\n");
+      $finish;
    end
 endmodule


### PR DESCRIPTION
This test tests only if at least one of the fields is randomized, because the results are accumulated into one variable and if only one field is randomized, the variable differs in every iteration. I fixed it and now each variable is checked separately.