### PR TITLE
Allow for rand fields in base classes

### DIFF
--- a/test_regress/t/t_randomize_method.v
+++ b/test_regress/t/t_randomize_method.v
@@ -96,23 +96,46 @@ class ContainsNull;
    rand BaseCls b;
 endclass
 
+class ClsWithInt;
+   rand int a;
+   int b;
+endclass
+
+class DeriveClsWithInt extends ClsWithInt;
+endclass
+
+class DeriveAndContainClsWithInt extends ClsWithInt;
+   rand ClsWithInt cls1;
+   ClsWithInt cls2;
+   function new;
+      cls1 = new;
+      cls2 = new;
+   endfunction
+endclass
+
 module t (/*AUTOARG*/);
 
    DerivedCls derived;
    OtherCls other;
    BaseCls base;
    ContainsNull cont;
+   DeriveClsWithInt der_int;
+   DeriveAndContainClsWithInt der_contain;
 
    initial begin
       int rand_result;
       derived = new;
       other = new;
       cont = new;
+      der_int = new;
+      der_contain = new;
       base = derived;
       for (int i = 0; i < 10; i++) begin
          rand_result = base.randomize();
          rand_result = other.randomize();
          rand_result = cont.randomize();
+         rand_result = der_int.randomize();
+         rand_result = der_contain.randomize();
          if (!(derived.l inside {ONE, TWO, THREE, FOUR})) $stop;
          if (!(other.str.s.c inside {ONE, TWO, THREE, FOUR})) $stop;
          if (!(other.str.y inside {ONE, TWO, THREE, FOUR})) $stop;
@@ -120,6 +143,10 @@ module t (/*AUTOARG*/);
          if (derived.k != 0) $stop;
          if (other.v != 0) $stop;
          if (cont.b != null) $stop;
+         if (der_int.b != 0) $stop;
+         if (der_contain.cls2.a != 0) $stop;
+         if (der_contain.cls1.b != 0) $stop;
+         if (der_contain.b != 0) $stop;
       end
       `check_rand(derived, derived.i.a);
       `check_rand(derived, derived.i.b);
@@ -136,6 +163,9 @@ module t (/*AUTOARG*/);
       `check_rand(other, other.str.s.a);
       `check_rand(other, other.str.s.b);
       `check_rand(other, other.str.s.c);
+      `check_rand(der_int, der_int.a);
+      `check_rand(der_contain, der_contain.cls1.a);
+      `check_rand(der_contain, der_contain.a);
 
       $write("*-* All Finished *-*\n");
       $finish;

--- a/test_regress/t/t_randomize_method_types_unsup.out
+++ b/test_regress/t/t_randomize_method_types_unsup.out
@@ -1,18 +1,22 @@
-%Error-UNSUPPORTED: t/t_randomize_method_types_unsup.v:12:13: Unsupported: random member variables with type 'int[string]'
+%Error-UNSUPPORTED: t/t_randomize_method_types_unsup.v:12:13: Unsupported: random member variable with type 'int[string]'
                                                             : ... In instance t
    12 |    rand int assocarr[string];
       |             ^~~~~~~~
                     ... For error description see https://verilator.org/warn/UNSUPPORTED?v=latest
-%Error-UNSUPPORTED: t/t_randomize_method_types_unsup.v:13:13: Unsupported: random member variables with type 'int[]'
+%Error-UNSUPPORTED: t/t_randomize_method_types_unsup.v:13:13: Unsupported: random member variable with type 'int[]'
                                                             : ... In instance t
    13 |    rand int dynarr[];
       |             ^~~~~~
-%Error-UNSUPPORTED: t/t_randomize_method_types_unsup.v:14:13: Unsupported: random member variables with type 'int$[0:4]'
+%Error-UNSUPPORTED: t/t_randomize_method_types_unsup.v:14:13: Unsupported: random member variable with type 'int$[0:4]'
                                                             : ... In instance t
    14 |    rand int unpackarr[5];
       |             ^~~~~~~~~
-%Error-UNSUPPORTED: t/t_randomize_method_types_unsup.v:15:15: Unsupported: random member variables with type '$unit::Union'
+%Error-UNSUPPORTED: t/t_randomize_method_types_unsup.v:15:15: Unsupported: random member variable with type '$unit::Union'
                                                             : ... In instance t
    15 |    rand Union uni;
       |               ^~~
+%Error-UNSUPPORTED: t/t_randomize_method_types_unsup.v:16:13: Unsupported: random member variable with type of a current class
+                                                            : ... In instance t
+   16 |    rand Cls cls;
+      |             ^~~
 %Error: Exiting due to

--- a/test_regress/t/t_randomize_method_types_unsup.v
+++ b/test_regress/t/t_randomize_method_types_unsup.v
@@ -13,6 +13,7 @@ class Cls;
    rand int dynarr[];
    rand int unpackarr[5];
    rand Union uni;
+   rand Cls cls;
 endclass
 
 module t (/*AUTOARG*/);


### PR DESCRIPTION
It fixes the handling of rand fields of base classes.
If currently on master a class extends a class with a rand field, an error is thrown from V3Scope. I fixed it and simplified the handling of such case by calling `super.randomize()` instead of iterating through a base class definition and assigning a randomized values to each of its fields separately.
Another problem is that Verilator hangs in infinite loop if a class has a field of a type of its base class. This PR fixes it too.
If a class has a rand field of its own type, an error from V3Task is thrown, so I decided to throw Unsupported warning instead.