### PR TITLE
Support method calls without parenthesis

### DIFF
--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -2669,6 +2669,12 @@ private:
                     nodep->replaceWith(adfoundp->cloneTree(false));
                     return;
                 }
+                if (AstNodeFTask* const methodp = VN_CAST(foundp, NodeFTask)) {
+                    nodep->replaceWith(new AstMethodCall{nodep->fileline(),
+                                                         nodep->fromp()->unlinkFrBack(),
+                                                         nodep->name(), nullptr});
+                    return;
+                }
                 UINFO(1, "found object " << foundp << endl);
                 nodep->v3fatalSrc("MemberSel of non-variable\n"
                                   << nodep->warnContextPrimary() << '\n'

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -2667,12 +2667,14 @@ private:
                 }
                 if (AstEnumItemRef* const adfoundp = VN_CAST(foundp, EnumItemRef)) {
                     nodep->replaceWith(adfoundp->cloneTree(false));
+                    VL_DO_DANGLING(pushDeletep(nodep), nodep);
                     return;
                 }
                 if (AstNodeFTask* const methodp = VN_CAST(foundp, NodeFTask)) {
                     nodep->replaceWith(new AstMethodCall{nodep->fileline(),
                                                          nodep->fromp()->unlinkFrBack(),
                                                          nodep->name(), nullptr});
+                    VL_DO_DANGLING(pushDeletep(nodep), nodep);
                     return;
                 }
                 UINFO(1, "found object " << foundp << endl);

--- a/test_regress/t/t_class_method.v
+++ b/test_regress/t/t_class_method.v
@@ -24,6 +24,7 @@ module t (/*AUTOARG*/);
       if (c.get_methoda() != 20) $stop;
       c.setv_methoda(30);
       if (c.get_methoda() != 30) $stop;
+      if (c.get_methoda != 30) $stop;
       $write("*-* All Finished *-*\n");
       $finish;
    end


### PR DESCRIPTION
It adds a possibility to call a method without `()`. It also removes a node that is replaced.