### PR TITLE
Fix NBAs inside fork-joins

### DIFF
--- a/src/V3Delayed.cpp
+++ b/src/V3Delayed.cpp
@@ -474,7 +474,9 @@ private:
         m_inSuspendableOrFork = true;
         iterateChildren(nodep);
     }
-    void visit(AstCAwait* nodep) override { m_timingDomains.insert(nodep->sensesp()); }
+    void visit(AstCAwait* nodep) override {
+        if (nodep->sensesp()) m_timingDomains.insert(nodep->sensesp());
+    }
     void visit(AstFireEvent* nodep) override {
         UASSERT_OBJ(v3Global.hasEvents(), nodep, "Inconsistent");
         FileLine* const flp = nodep->fileline();

--- a/test_regress/t/t_timing_fork_nba.pl
+++ b/test_regress/t/t_timing_fork_nba.pl
@@ -1,0 +1,23 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2023 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+if (!$Self->have_coroutines) {
+    skip("No coroutine support");
+}
+else {
+    compile(
+        verilator_flags2 => ["--exe --timing"],
+        );
+}
+
+ok(1);
+1;

--- a/test_regress/t/t_timing_fork_nba.v
+++ b/test_regress/t/t_timing_fork_nba.v
@@ -1,0 +1,20 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2023 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+module t (/*AUTOARG*/
+   // Inputs
+   clk
+   );
+   input clk;
+   reg b = 0, c = 1;
+
+   always @(posedge clk) begin
+      fork
+         b <= c;
+         c <= b;
+      join
+   end
+endmodule


### PR DESCRIPTION
The change contains a testcase that makes Verilator segfault and a fix for that.

The segfault occurs, because V3Delay collects sentree pointers from AstCAwaits. Some of the sentrees are nullptrs, so Verilator segaults trying to copy them in [V3Delayed.cpp:460](https://github.com/verilator/verilator/blob/ff889fde18f52cefe48376d3010477c4a3e71229/src/V3Delayed.cpp#L460).

The solution is to skip the nullptrs.
