### PR TITLE
Fix false LATCH warning on --assert 'unique else if' (#4033).

### DIFF
--- a/Changes
+++ b/Changes
@@ -19,6 +19,7 @@ Verilator 5.009 devel
 * Support $fopen as an expression.
 * Support class extends of package::class.
 * Change ZERODLY to a warning.
+* Fix false LATCH warning on --assert 'unique else if' (#4033). [Jesse Taube]
 * Fix UNDRIVEN warning seg fault (#3989). [Felix Neumärker]
 * Fix symbol entries when inheriting classes (#3995) (#3996). [Krzysztof Boroński]
 * Fix push to dynamic queue in struct (#4015). [ezchi]

--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -61,6 +61,7 @@ Jamie Iles
 Jan Van Winkel
 Jean Berniolles
 Jeremy Bennett
+Jesse Taube
 Jevin Sweval
 Jiacheng Qian
 Jiuyang Liu

--- a/src/V3Const.cpp
+++ b/src/V3Const.cpp
@@ -2975,6 +2975,7 @@ private:
                 AstNode* const thensp = nodep->thensp()->unlinkFrBackWithNext();
                 AstNode* const elsesp = nodep->elsesp()->unlinkFrBackWithNext();
                 AstIf* const ifp = new AstIf{nodep->fileline(), condp, elsesp, thensp};
+                ifp->isBoundsCheck(nodep->isBoundsCheck()); // Copy bounds check info
                 ifp->branchPred(nodep->branchPred().invert());
                 nodep->replaceWith(ifp);
                 VL_DO_DANGLING(nodep->deleteTree(), nodep);


### PR DESCRIPTION
V3Const.cpp:visit(AstNodeIf* nodep) will recreate `nodep` with "IF(NOT {x})  => IF(x) swapped if/else" but it doesn't update isBoundsCheck, which was set to suppress LATCH warning.

a57a3579c0a38: Fix false LATCH warning on 'unique if' (#3088).
