### PR TITLE
Fix task calls as fork statements

### DIFF
--- a/test_regress/t/t_timing_debug2.out
+++ b/test_regress/t/t_timing_debug2.out
@@ -526,7 +526,7 @@
 -V{t#,#}         Resuming delayed processes
 -V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:91
 -V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:89
--V{t#,#}+      Vt_timing_debug2_t____Vfork_h########__0__1
+-V{t#,#}+      Vt_timing_debug2_t____Vfork_h########__0__0
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aAssignDelayClass::__VnoInFunc_do_assign
 -V{t#,#}+    Vt_timing_debug2___024root___eval_act
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act

--- a/test_regress/t/t_timing_fork_taskcall.pl
+++ b/test_regress/t/t_timing_fork_taskcall.pl
@@ -1,0 +1,28 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2023 by Antmicro Ltd. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+if (!$Self->have_coroutines) {
+    skip("No coroutine support");
+}
+else {
+    compile(
+        verilator_flags2 => ["--exe --main --timing"],
+        make_main => 0,
+        );
+
+    execute(
+        check_finished => 1,
+        );
+}
+
+ok(1);
+1;

--- a/test_regress/t/t_timing_fork_taskcall.v
+++ b/test_regress/t/t_timing_fork_taskcall.v
@@ -1,0 +1,23 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2023 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+module t;
+  task foo;
+    #1 if ($time != 1) $stop;
+    #1 if ($time != 2) $stop;
+    #1 if ($time != 3) $stop;
+  endtask
+
+  initial fork
+    foo;
+    foo;
+    foo;
+    #4 begin
+      $write("*-* All Finished *-*\n");
+      $finish;
+    end
+  join
+endmodule


### PR DESCRIPTION
This is a fun one.

Before this patch, calling tasks directly under forks would result in each statement of these tasks being executed concurrently. This was due to Verilator inlining tasks most of the time. Such inlined tasks' statements would simply replace the original call, and there would be no indication that these used to be grouped together. Ultimately resulting in `V3Timing` treating each statement as a separate process. Something like this:
```systemverilog
    task foo;
        #1 if ($time != 1) $stop;
        #1 if ($time != 2) $stop;
        #1 if ($time != 3) $stop;
    endtask

    initial fork foo; join
```
would turn into this:
```systemverilog
    initial fork
        #1 if ($time != 1) $stop;
        #1 if ($time != 2) $stop;
        #1 if ($time != 3) $stop;
    join
```

The solution is simply to wrap each fork sub-statement in a begin in `V3Begin` (except for the ones that are begins, as that would be pointless). `V3Begin` is already aware of forks, and is supposed to avoid issues like this one, so it seems like a natural fit. This also protects us from similar bugs, i.e. if some statement gets replaced or expanded into multiple statements.
