### PR TITLE
Treat parameters declared in a class body as local parameters

### DIFF
--- a/src/verilog.y
+++ b/src/verilog.y
@@ -96,6 +96,7 @@ public:
     bool m_pinAnsi = false;  // In ANSI port list
     bool m_tracingParse = true;  // Tracing disable for parser
     bool m_inImplements = false;  // Is inside class implements list
+    bool m_insideClass = false;  // Is inside a class body
     bool m_insideProperty = false;  // Is inside property declaration
     bool m_typedPropertyPort = false;  // Typed property port occurred on port lists
     bool m_modportImpExpActive
@@ -1947,7 +1948,12 @@ net_type:                       // ==IEEE: net_type
         ;
 
 varParamReset:
-                yPARAMETER                              { VARRESET_NONLIST(GPARAM); }
+                yPARAMETER
+                        { if (GRAMMARP->m_insideClass) {
+                             VARRESET_NONLIST(LPARAM);
+                          } else {
+                             VARRESET_NONLIST(GPARAM);
+                          } }
         |       yLOCALPARAM                             { VARRESET_NONLIST(LPARAM); }
         ;
 
@@ -6708,6 +6714,7 @@ class_declaration<nodep>:       // ==IEEE: part of class_declaration
                 classFront parameter_port_listE classExtendsE classImplementsE ';'
         /*mid*/         { // Allow resolving types declared in base extends class
                           if ($<scp>3) SYMP->importExtends($<scp>3);
+                          GRAMMARP->m_insideClass = true;
                         }
         /*cont*/    class_itemListE yENDCLASS endLabelE
                         { $$ = $1; $1->addMembersp($2);
@@ -6715,6 +6722,7 @@ class_declaration<nodep>:       // ==IEEE: part of class_declaration
                           $1->addExtendsp($4);
                           $1->addMembersp($7);
                           SYMP->popScope($$);
+                          GRAMMARP->m_insideClass = false;
                           GRAMMARP->endLabel($<fl>9, $1, $9); }
         ;
 

--- a/test_regress/t/t_class_param_override_local_bad.out
+++ b/test_regress/t/t_class_param_override_local_bad.out
@@ -1,0 +1,14 @@
+%Error-PINNOTFOUND: t/t_class_param_override_local_bad.v:23:30: Parameter pin not found: '__paramNumber1'
+   23 | class Cls3 implements Icls1#(2), Icls2#(0);
+      |                              ^
+                    ... For error description see https://verilator.org/warn/PINNOTFOUND?v=latest
+%Error-PINNOTFOUND: t/t_class_param_override_local_bad.v:23:41: Parameter pin not found: '__paramNumber1'
+   23 | class Cls3 implements Icls1#(2), Icls2#(0);
+      |                                         ^
+%Error-PINNOTFOUND: t/t_class_param_override_local_bad.v:29:23: Parameter pin not found: '__paramNumber1'
+   29 |       automatic Cls1#(bit) cls1 = new;
+      |                       ^~~
+%Error-PINNOTFOUND: t/t_class_param_override_local_bad.v:30:23: Parameter pin not found: '__paramNumber1'
+   30 |       automatic Cls2#(1) cls2 = new;
+      |                       ^
+%Error: Exiting due to

--- a/test_regress/t/t_class_param_override_local_bad.pl
+++ b/test_regress/t/t_class_param_override_local_bad.pl
@@ -1,0 +1,19 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2003 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(vlt => 1);
+
+lint(
+    fails => 1,
+    expect_filename => $Self->{golden_filename},
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_class_param_override_local_bad.v
+++ b/test_regress/t/t_class_param_override_local_bad.v
@@ -1,0 +1,34 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2023 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+class Cls1;
+   parameter type T = int;
+endclass
+
+class Cls2;
+   localparam int P = 0;
+endclass
+
+interface class Icls1;
+   localparam LP1 = 1;
+endclass
+
+interface class Icls2;
+   parameter LP1 = 1;
+endclass
+
+class Cls3 implements Icls1#(2), Icls2#(0);
+endclass
+
+module t (/*AUTOARG*/);
+
+   initial begin
+      automatic Cls1#(bit) cls1 = new;
+      automatic Cls2#(1) cls2 = new;
+      automatic Cls3 cls3 = new;
+      $stop;
+   end
+endmodule


### PR DESCRIPTION
In point 7) in A.10 section of IEEE Std 1800-2017, it is said that:
`In a parameter_declaration that is a class_item, the parameter keyword shall be a synonym for the
localparam keyword.`
This PR changes the parameter parsing to treat such parameters as local parameters, which cannot be overridden.