### PR TITLE
Fix C++ compile errors when passing class refs as task arg

### DIFF
--- a/include/verilated_types.h
+++ b/include/verilated_types.h
@@ -1166,7 +1166,8 @@ public:
     // CONSTRUCTORS
     VlClassRef() = default;
     // Init with nullptr
-    explicit VlClassRef(VlNull){};
+    // cppcheck-suppress noExplicitConstructor
+    VlClassRef(VlNull){};
     template <typename... T_Args>
     VlClassRef(VlDeleter& deleter, T_Args&&... args)
         // () required here to avoid narrowing conversion warnings,
@@ -1187,6 +1188,16 @@ public:
     }
     // cppcheck-suppress noExplicitConstructor
     VlClassRef(VlClassRef&& moved)
+        : m_objp{vlstd::exchange(moved.m_objp, nullptr)} {}
+    // cppcheck-suppress noExplicitConstructor
+    template <typename T_OtherClass>
+    VlClassRef(const VlClassRef<T_OtherClass>& copied)
+        : m_objp{copied.m_objp} {
+        refCountInc();
+    }
+    // cppcheck-suppress noExplicitConstructor
+    template <typename T_OtherClass>
+    VlClassRef(VlClassRef<T_OtherClass>&& moved)
         : m_objp{vlstd::exchange(moved.m_objp, nullptr)} {}
     ~VlClassRef() { refCountDec(); }
 

--- a/test_regress/t/t_class_ref_as_arg_cast.pl
+++ b/test_regress/t/t_class_ref_as_arg_cast.pl
@@ -1,0 +1,17 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2023 by Antmicro Ltd. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_class_ref_as_arg_cast.v
+++ b/test_regress/t/t_class_ref_as_arg_cast.v
@@ -1,0 +1,21 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2023 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+class Foo;
+  static task bar(Foo f);
+  endtask
+endclass
+
+class Qux extends Foo;
+endclass
+
+module t;
+  initial begin
+    Qux qux = new;
+    Foo::bar(qux);
+    Foo::bar(null);
+  end
+endmodule


### PR DESCRIPTION
1. Fixes passing a null reference as a task argument. Before this patch it would cause a C++ compile error like `cannot convert ‘VlNull’ to ‘VlClassRef<...>’`.

2. Fixes passing a class reference as a task argument when the argument is a reference to a base class. Before the patch it would cause a C++ compile error like `cannot convert ‘VlClassRef<{DERIVED_CLASS}>’ to ‘VlClassRef<{BASE_CLASS}>`.