### PR TITLE
Throw error if class types don't match

### DIFF
--- a/test_regress/t/t_class_assign_bad.out
+++ b/test_regress/t/t_class_assign_bad.out
@@ -1,17 +1,33 @@
-%Error: t/t_class_assign_bad.v:16:9: Assign RHS expects a CLASSREFDTYPE 'Cls'
+%Error: t/t_class_assign_bad.v:25:9: Assign RHS expects a CLASSREFDTYPE 'Cls'
                                    : ... In instance t
-   16 |       c = 0;
+   25 |       c = 0;
       |         ^
-%Error: t/t_class_assign_bad.v:17:9: Assign RHS expects a CLASSREFDTYPE 'Cls'
+%Error: t/t_class_assign_bad.v:26:9: Assign RHS expects a CLASSREFDTYPE 'Cls'
                                    : ... In instance t
-   17 |       c = 1;
+   26 |       c = 1;
       |         ^
-%Error: t/t_class_assign_bad.v:18:7: Function Argument expects a CLASSREFDTYPE 'Cls'
+%Error: t/t_class_assign_bad.v:27:9: Assign RHS expects a CLASSREFDTYPE 'Cls'
                                    : ... In instance t
-   18 |       t(0);
+   27 |       c = c2;
+      |         ^
+%Error: t/t_class_assign_bad.v:28:13: Assign RHS expects a CLASSREFDTYPE 'ClsExt'
+                                    : ... In instance t
+   28 |       c_ext = c;
+      |             ^
+%Error: t/t_class_assign_bad.v:30:7: Function Argument expects a CLASSREFDTYPE 'Cls'
+                                   : ... In instance t
+   30 |       t(0);
       |       ^
-%Error: t/t_class_assign_bad.v:19:7: Function Argument expects a CLASSREFDTYPE 'Cls'
+%Error: t/t_class_assign_bad.v:31:7: Function Argument expects a CLASSREFDTYPE 'Cls'
                                    : ... In instance t
-   19 |       t(1);
+   31 |       t(1);
+      |       ^
+%Error: t/t_class_assign_bad.v:32:7: Function Argument expects a CLASSREFDTYPE 'Cls'
+                                   : ... In instance t
+   32 |       t(c2);
+      |       ^
+%Error: t/t_class_assign_bad.v:33:7: Function Argument expects a CLASSREFDTYPE 'ClsExt'
+                                   : ... In instance t
+   33 |       f(c);
       |       ^
 %Error: Exiting due to

--- a/test_regress/t/t_class_assign_bad.v
+++ b/test_regress/t/t_class_assign_bad.v
@@ -7,15 +7,29 @@
 class Cls;
 endclass : Cls
 
+class Cls2;
+endclass
+
+class ClsExt extends Cls;
+endclass
+
 module t (/*AUTOARG*/);
    Cls c;
+   Cls2 c2;
+   ClsExt c_ext;
 
    task t(Cls c); endtask
+   function f(ClsExt c); endfunction
 
    initial begin
       c = 0;
       c = 1;
+      c = c2;
+      c_ext = c;
+
       t(0);
       t(1);
+      t(c2);
+      f(c);
    end
 endmodule

--- a/test_regress/t/t_class_new_bad.out
+++ b/test_regress/t/t_class_new_bad.out
@@ -14,11 +14,7 @@
                                  : ... In instance t
    34 |       c1 = new[2];
       |            ^~~
-%Error: t/t_class_new_bad.v:34:10: Assign RHS expects a CLASSREFDTYPE 'ClsNoArg'
-                                 : ... In instance t
-   34 |       c1 = new[2];
-      |          ^
-%Error: Internal Error: t/t_class_new_bad.v:34:10: ../V3Width.cpp:#: Node has no type
+%Error: Internal Error: t/t_class_new_bad.v:34:12: ../V3Width.cpp:#: Node has no type
                                                  : ... In instance t
    34 |       c1 = new[2];
-      |          ^
+      |            ^~~


### PR DESCRIPTION
Currently, Verilator checks only if two types are class types. In this PR I add checking if class types are the same or if LHS (or function formal argument) is a base class of RHS.