### PR TITLE
V3EmitMk.cpp: Makefile generator escape for CFLAGS/LDFLAGS/Mdir 

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -18,6 +18,7 @@ Cameron Kirk
 Chris Randall
 Chuxuan Wang
 Conor McCullough
+Darryl L. Miles
 Dan Petrisko
 Daniel Bates
 David Horton


### PR DESCRIPTION
Full comment in commit log. Expecting squish-merge.

This is just undergoing some testing on Windows and Linux to attempt to break it, **I am after feedback** on how well received this change may be.

The basic requirement is for the 3 arguments to remain completely unchanged between the input executable arguments passed to verilator and the way they are presented to the toolchain commands.

Verilator uses a Makefile in the middle, so they need to be encoded to pass-thru.
