### PR TITLE
Fix incorrect optimization of bit op tree

### DIFF
--- a/src/V3Const.cpp
+++ b/src/V3Const.cpp
@@ -548,7 +548,8 @@ class ConstBitOpTreeVisitor final : public VNVisitorConst {
                     restorer.restoreNow();
                     // Reach past a cast then add to frozen nodes to be added to final reduction
                     if (const AstCCast* const castp = VN_CAST(opp, CCast)) opp = castp->lhsp();
-                    m_frozenNodes.emplace_back(opp, FrozenNodeInfo{m_polarity, m_lsb});
+                    const bool pol = isXorTree() || m_polarity;  // Only AND/OR tree needs polarity
+                    m_frozenNodes.emplace_back(opp, FrozenNodeInfo{pol, m_lsb});
                     m_failed = origFailed;
                     continue;
                 }

--- a/test_regress/t/t_const_opt.pl
+++ b/test_regress/t/t_const_opt.pl
@@ -20,7 +20,7 @@ execute(
     );
 
 if ($Self->{vlt}) {
-    file_grep($Self->{stats}, qr/Optimizations, Const bit op reduction\s+(\d+)/i, 16);
+    file_grep($Self->{stats}, qr/Optimizations, Const bit op reduction\s+(\d+)/i, 29);
 }
 ok(1);
 1;


### PR DESCRIPTION
Fixes #4059

The issue was introduced in #3459 when fixing #3445.

Push a test to see if the test properly reproduces the issue.
Then I will push the fix.

ext tests passes.

I found further optimization opportunity, but it is not included in this PR. I'd like to keep this PR just bugfix.