### PR TITLE
Improve xor tree optimization

### DIFF
--- a/src/V3Const.cpp
+++ b/src/V3Const.cpp
@@ -449,9 +449,7 @@ class ConstBitOpTreeVisitor final : public VNVisitorConst {
         AstNode* lhsp = nodep->lhsp();
         AstCCast* const castp = VN_CAST(lhsp, CCast);
         if (castp) lhsp = castp->lhsp();
-        CONST_BITOP_RETURN_IF(!VN_IS(lhsp, VarRef) && !VN_IS(lhsp, Xor) && !VN_IS(lhsp, RedXor)
-                                  && !VN_IS(lhsp, ShiftR),
-                              lhsp);
+        CONST_BITOP_RETURN_IF(!isXorTree() && !VN_IS(lhsp, VarRef) && !VN_IS(lhsp, ShiftR), lhsp);
         incrOps(nodep, __LINE__);
         m_polarity = !m_polarity;
         iterateChildrenConst(nodep);

--- a/test_regress/t/t_const_opt.pl
+++ b/test_regress/t/t_const_opt.pl
@@ -20,7 +20,7 @@ execute(
     );
 
 if ($Self->{vlt}) {
-    file_grep($Self->{stats}, qr/Optimizations, Const bit op reduction\s+(\d+)/i, 29);
+    file_grep($Self->{stats}, qr/Optimizations, Const bit op reduction\s+(\d+)/i, 39);
 }
 ok(1);
 1;


### PR DESCRIPTION
While debugging #4059, I found xor tree is not fully optimized.
1 bit width of AstNot is safe on xor tree.
When the input of an AstNot cannot be optimized, then the input node should be frozen, not the AstNot node itself.


```c++
(1U 
 & ((~ 
     ((~ 
       (1U 
        & (VL_REDXOR_32( (0x2020000U & vlSelf->words_i[2U])) 
           ^ VL_REDXOR_16( (0x202U & vlSelf->words_i[3U]))))) 
      ^ 
      (~ 
       (1U 
        & (VL_REDXOR_16( (0x202U & vlSelf->words_i[2U])) 
           ^ VL_REDXOR_32( (0x2020000U & vlSelf->words_i[3U]))))))) 
    ^ 
    (~ 
     ((~ 
       (1U 
        & (~ 
           (VL_REDXOR_32( (0x2020000U & vlSelf->words_i[0U])) 
            ^ VL_REDXOR_16( (0x202U & vlSelf->words_i[1U])))))) 
      ^ 
      (~ 
       (1U 
        & (VL_REDXOR_16( (0x202U & vlSelf->words_i[0U])) 
           ^ VL_REDXOR_32( (0x2020000U & vlSelf->words_i[1U])))))))))
```
becomes as the following. ( Input design is https://github.com/verilator/verilator/issues/4059#issue-1635623058)
```c++
(1U 
 & (~ 
    (((VL_REDXOR_32( (0x2020202U & vlSelf->words_i[0U])) 
       ^ VL_REDXOR_32( (0x2020202U & vlSelf->words_i[1U]))) 
      ^ VL_REDXOR_32( (0x2020202U & vlSelf->words_i[2U]))) 
     ^ VL_REDXOR_32( (0x2020202U & vlSelf->words_i[3U])))))
```

Checked verilator_ext_tests.