### PR TITLE
Prevent static access to non-static class member

### DIFF
--- a/test_regress/t/t_class_fwd_cc.v
+++ b/test_regress/t/t_class_fwd_cc.v
@@ -15,7 +15,7 @@ package Pkg;
       endfunction
    endclass
    class Fwd;
-      function Fwd m_uvm_get_root();
+      static function Fwd m_uvm_get_root();
          return null;
       endfunction
    endclass

--- a/test_regress/t/t_class_member_bad3.out
+++ b/test_regress/t/t_class_member_bad3.out
@@ -1,0 +1,7 @@
+%Error: t/t_class_member_bad3.v:16:12: Static access to non-static member variable 'member'
+   16 |       Foo::member = 1;
+      |            ^~~~~~
+%Error: t/t_class_member_bad3.v:17:12: Static access to non-static task/function 'method'
+   17 |       Foo::method();
+      |            ^~~~~~
+%Error: Exiting due to

--- a/test_regress/t/t_class_member_bad3.pl
+++ b/test_regress/t/t_class_member_bad3.pl
@@ -1,0 +1,19 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2023 by Antmicro Ltd. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(linter => 1);
+
+lint(
+    fails => 1,
+    expect_filename => $Self->{golden_filename},
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_class_member_bad3.v
+++ b/test_regress/t/t_class_member_bad3.v
@@ -1,0 +1,19 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2023 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+class Foo;
+   int member;
+
+   task method; endtask
+endclass
+
+module t;
+   initial begin
+      Foo foo = new;
+      Foo::member = 1;
+      Foo::method();
+   end
+endmodule


### PR DESCRIPTION
Before this patch, it was possible to access non-static class members using static access, which resulted in C++ compilation errors. This adds verilation-time checks for such situations.