### PR TITLE
Fix variable used to track already created previous value variables

### DIFF
--- a/src/V3SenExprBuilder.h
+++ b/src/V3SenExprBuilder.h
@@ -94,24 +94,21 @@ class SenExprBuilder final {
         const auto rdCurr = [=]() { return getCurr(exprp); };
 
         AstNode* scopeExprp = exprp;
-        if (AstVarRef* const refp = VN_CAST(exprp, VarRef)) {
-            scopeExprp = refp->varScopep()->varp();
-        }
+        if (AstVarRef* const refp = VN_CAST(exprp, VarRef)) scopeExprp = refp->varScopep();
         // Create the 'previous value' variable
         auto it = m_prev.find(*scopeExprp);
         if (it == m_prev.end()) {
-            // For readability, use the scoped signal name if the trigger is a simple AstVarRef
-            string name;
-            if (AstVarRef* const refp = VN_CAST(exprp, VarRef)) {
-                AstVarScope* vscp = refp->varScopep();
-                name = "__Vtrigrprev__" + vscp->scopep()->nameDotless() + "__"
-                       + vscp->varp()->name();
-            } else {
-                name = m_prevNames.get(exprp);
-            }
-
             AstVarScope* prevp;
             if (m_scopep->isTop()) {
+                // For readability, use the scoped signal name if the trigger is a simple AstVarRef
+                string name;
+                if (AstVarRef* const refp = VN_CAST(exprp, VarRef)) {
+                    AstVarScope* const vscp = refp->varScopep();
+                    name = "__" + vscp->scopep()->nameDotless() + "__" + vscp->varp()->name();
+                    name = m_prevNames.get(name);
+                } else {
+                    name = m_prevNames.get(exprp);
+                }
                 prevp = m_scopep->createTemp(name, exprp->dtypep());
             } else {
                 AstVar* const varp = new AstVar{flp, VVarType::BLOCKTEMP, m_prevNames.get(exprp),

--- a/test_regress/t/t_event_control_scope_var.pl
+++ b/test_regress/t/t_event_control_scope_var.pl
@@ -1,0 +1,22 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2003 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    verilator_flags2 => ['-fno-inline', '-Wno-WIDTHTRUNC'],
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_event_control_scope_var.v
+++ b/test_regress/t/t_event_control_scope_var.v
@@ -1,0 +1,61 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2023 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+module test_mod(input reg clk, input reg reset, output integer result);
+  always @(reset) begin
+    result <= 1;
+  end
+endmodule
+
+module Dut(input clk);
+  integer num;
+  integer result1;
+  integer result2;
+  reg reset1;
+  reg reset2;
+  initial begin
+    reset1 = $random;
+    reset2 = $random;
+  end
+  always @(posedge clk) begin
+    num <= num + 1;
+    if (num == 5) begin
+      reset1 <= 1'b1;
+    end
+    if (num == 10) begin
+      // display to prevent optimalization
+      $display("result1: %d", result1);
+      $display("result2: %d", result2);
+      $write("*-* All Finished *-*\n");
+      $finish;
+    end
+  end
+  always @(reset1) begin
+    reset2 <= t.reset;
+  end
+
+  test_mod t (
+    .clk(clk),
+    .reset(reset1),
+    .result(result1)
+  );
+  test_mod t2 (
+    .clk(clk),
+    .reset(reset2),
+    .result(result2));
+  endmodule
+
+module Dut_wrapper(input clk);
+
+  Dut d(.clk(clk));
+  Dut d2(.clk(clk));
+endmodule
+
+module t (/*AUTOARG*/
+   clk);
+  input clk;
+  Dut_wrapper d_w(.clk(clk));
+endmodule

--- a/test_regress/t/t_protect_ids_key.out
+++ b/test_regress/t/t_protect_ids_key.out
@@ -28,7 +28,7 @@
   <map from="PSHzgK" to="__VpreTriggered"/>
   <map from="PSEGxK" to="__Vscope_t__secret_inst"/>
   <map from="PS25fg" to="__Vtask_dpix_a_task__1__i"/>
-  <map from="PS2vhB" to="__Vtrigrprev__TOP__clk"/>
+  <map from="PSJN3f" to="__Vtrigprevexpr___TOP__clk__0"/>
   <map from="PSyTg5" to="_ctor_var_reset"/>
   <map from="PSvIGv" to="_dump_triggers__act"/>
   <map from="PSYUIn" to="_dump_triggers__nba"/>

--- a/test_regress/t/t_xml_debugcheck.out
+++ b/test_regress/t/t_xml_debugcheck.out
@@ -22,7 +22,7 @@
     <module loc="d,10,8,10,9" name="$root" origName="$root" topModule="1" public="true">
       <var loc="d,14,10,14,13" name="clk" dtype_id="1" dir="input" pinIndex="1" vartype="logic" origName="clk" clocker="true" public="true"/>
       <var loc="d,23,9,23,10" name="t.e" dtype_id="2" vartype="my_t" origName="e"/>
-      <var loc="d,10,8,10,9" name="__Vtrigrprev__TOP__clk" dtype_id="1" vartype="logic" origName="__Vtrigrprev__TOP__clk"/>
+      <var loc="d,10,8,10,9" name="__Vtrigprevexpr___TOP__clk__0" dtype_id="1" vartype="logic" origName="__Vtrigprevexpr___TOP__clk__0"/>
       <var loc="d,10,8,10,9" name="__VactContinue" dtype_id="3" vartype="bit" origName="__VactContinue"/>
       <var loc="d,22,17,22,20" name="t.cyc" dtype_id="4" vartype="integer" origName="cyc"/>
       <var loc="d,10,8,10,9" name="__VactIterCount" dtype_id="5" vartype="bit" origName="__VactIterCount"/>
@@ -49,7 +49,7 @@
         </stmtexpr>
         <assign loc="d,60,22,60,25" dtype_id="9">
           <varref loc="d,60,22,60,25" name="clk" dtype_id="9"/>
-          <varref loc="d,60,22,60,25" name="__Vtrigrprev__TOP__clk" dtype_id="9"/>
+          <varref loc="d,60,22,60,25" name="__Vtrigprevexpr___TOP__clk__0" dtype_id="9"/>
         </assign>
       </cfunc>
       <cfunc loc="d,10,8,10,9" name="_eval_initial__TOP">
@@ -607,7 +607,7 @@
             </ccast>
             <not loc="d,60,14,60,21" dtype_id="9">
               <ccast loc="d,60,14,60,21" dtype_id="9">
-                <varref loc="d,60,14,60,21" name="__Vtrigrprev__TOP__clk" dtype_id="9"/>
+                <varref loc="d,60,14,60,21" name="__Vtrigprevexpr___TOP__clk__0" dtype_id="9"/>
               </ccast>
             </not>
           </and>
@@ -618,7 +618,7 @@
         </assign>
         <assign loc="d,60,22,60,25" dtype_id="9">
           <varref loc="d,60,22,60,25" name="clk" dtype_id="9"/>
-          <varref loc="d,60,22,60,25" name="__Vtrigrprev__TOP__clk" dtype_id="9"/>
+          <varref loc="d,60,22,60,25" name="__Vtrigprevexpr___TOP__clk__0" dtype_id="9"/>
         </assign>
         <textblock loc="d,10,8,10,9">
           <text loc="d,10,8,10,9"/>
@@ -1688,7 +1688,7 @@
           <varref loc="d,23,9,23,10" name="t.e" dtype_id="2"/>
         </creset>
         <creset loc="d,10,8,10,9">
-          <varref loc="d,10,8,10,9" name="__Vtrigrprev__TOP__clk" dtype_id="1"/>
+          <varref loc="d,10,8,10,9" name="__Vtrigprevexpr___TOP__clk__0" dtype_id="1"/>
         </creset>
       </cfunc>
       <cuse loc="a,0,0,0,0" name="$unit"/>


### PR DESCRIPTION
Ref: https://github.com/verilator/verilator/pull/4014

It looks like in some cases different ``AstVarScope`` can point to the same ``AstVar``. This PR changes variable used to track already created previous value variables from ``AstVar`` to ``AstVarScope`` as well as changes ``AstVarRef`` condition to also use ``m_prevNames`` to generate unique name.
 
This PR should fix issue reported in: https://github.com/verilator/verilator/pull/4014#issuecomment-1487467289. Draft as I'm still working on test-case that can reproduce original issue.