### PR TITLE
Adding support for class method calling without parenthesis

### DIFF
--- a/src/V3LinkDot.cpp
+++ b/src/V3LinkDot.cpp
@@ -2027,7 +2027,6 @@ private:
     };  // DOT {member-name} [DOT...]
 
     // STATE
-    AstClass* m_classp = nullptr;  // Class we're inside
     LinkDotState* const m_statep;  // State, including dotted symbol table
     VSymEnt* m_curSymp = nullptr;  // SymEnt for current lookup point
     VSymEnt* m_modSymp = nullptr;  // SymEnt for current module
@@ -3233,9 +3232,6 @@ private:
     void visit(AstNodeFTask* nodep) override {
         UINFO(5, "   " << nodep << endl);
         checkNoDot(nodep);
-        if (m_classp) {
-            nodep->classMethod(true);
-        }
         if (nodep->isExternDef()) {
             if (!m_curSymp->findIdFallback("extern " + nodep->name())) {
                 nodep->v3error("extern not found that declares " + nodep->prettyNameQ());
@@ -3282,7 +3278,6 @@ private:
     }
     void visit(AstClass* nodep) override {
         nodep->user3SetOnce();
-        m_classp = nodep;
         UINFO(5, "   " << nodep << endl);
         checkNoDot(nodep);
         VL_RESTORER(m_curSymp);

--- a/src/V3LinkParse.cpp
+++ b/src/V3LinkParse.cpp
@@ -135,6 +135,9 @@ private:
     // VISITs
     void visit(AstNodeFTask* nodep) override {
         if (!nodep->user1SetOnce()) {  // Process only once.
+            // Mark class methods
+            if (VN_IS(m_modp, Class)) nodep->classMethod(true);
+
             V3Config::applyFTask(m_modp, nodep);
             cleanFileline(nodep);
             VL_RESTORER(m_ftaskp);

--- a/test_regress/t/t_class_method.v
+++ b/test_regress/t/t_class_method.v
@@ -11,20 +11,9 @@ class Cls;
    function int get_methoda; return imembera; endfunction
    task set_methoda(input int val); imembera = val; endtask
    function void setv_methoda(input int val); imembera = val; endfunction
-   function void call_int_fn ();
-     int local_i;
-
-     local_i = get_methoda();
-     if (local_i != 30) $stop;
-     local_i++;
-     local_i = get_methoda;
-     if (local_i != 30) $stop;
-   endfunction : call_int_fn
-
 endclass : Cls
 
 module t (/*AUTOARG*/);
-
    initial begin
       Cls c;
       if (c != null) $stop;
@@ -36,8 +25,6 @@ module t (/*AUTOARG*/);
       c.setv_methoda(30);
       if (c.get_methoda() != 30) $stop;
       if (c.get_methoda != 30) $stop;
-      c.call_int_fn;
-      c.call_int_fn();
       $write("*-* All Finished *-*\n");
       $finish;
    end

--- a/test_regress/t/t_class_method.v
+++ b/test_regress/t/t_class_method.v
@@ -15,6 +15,7 @@ endclass : Cls
 
 module t (/*AUTOARG*/);
    initial begin
+     int tmp_i;
       Cls c;
       if (c != null) $stop;
       c = new;
@@ -24,7 +25,9 @@ module t (/*AUTOARG*/);
       if (c.get_methoda() != 20) $stop;
       c.setv_methoda(30);
       if (c.get_methoda() != 30) $stop;
-      if (c.get_methoda != 30) $stop;
+      c.setv_methoda(300);
+      tmp_i = c.get_methoda;
+      if (tmp_i != 300) $stop;
       $write("*-* All Finished *-*\n");
       $finish;
    end

--- a/test_regress/t/t_class_method.v
+++ b/test_regress/t/t_class_method.v
@@ -11,9 +11,20 @@ class Cls;
    function int get_methoda; return imembera; endfunction
    task set_methoda(input int val); imembera = val; endtask
    function void setv_methoda(input int val); imembera = val; endfunction
+   function void call_int_fn ();
+     int local_i;
+
+     local_i = get_methoda();
+     if (local_i != 30) $stop;
+     local_i++;
+     local_i = get_methoda;
+     if (local_i != 30) $stop;
+   endfunction : call_int_fn
+
 endclass : Cls
 
 module t (/*AUTOARG*/);
+
    initial begin
       Cls c;
       if (c != null) $stop;
@@ -25,6 +36,8 @@ module t (/*AUTOARG*/);
       c.setv_methoda(30);
       if (c.get_methoda() != 30) $stop;
       if (c.get_methoda != 30) $stop;
+      c.call_int_fn;
+      c.call_int_fn();
       $write("*-* All Finished *-*\n");
       $finish;
    end


### PR DESCRIPTION
This PR adds support for class method calls without parenthesis. SV LRM allows class methods (void/non-void) to be called without parenthesis. However, Verilator throws a syntax error. It is not uncommon in SV to call a method as part of $display etc. without parens.
