### PR TITLE
Internals: refactor for better clang thread-safety analysis

### DIFF
--- a/src/V3EmitCBase.cpp
+++ b/src/V3EmitCBase.cpp
@@ -57,12 +57,17 @@ string EmitCBaseVisitorConst::funcNameProtect(const AstCFunc* nodep, const AstNo
     return name;
 }
 
-AstCFile* EmitCBaseVisitorConst::newCFile(const string& filename, bool slow, bool source,
-                                          bool add) {
+AstCFile* EmitCBaseVisitorConst::newCFile(const string& filename, bool slow, bool source) {
+    AstCFile* const cfilep = createCFile(filename, slow, source);
+    v3Global.rootp()->addFilesp(cfilep);
+    return cfilep;
+}
+
+AstCFile* EmitCBaseVisitorConst::createCFile(const string& filename, bool slow,
+                                             bool source) VL_MT_SAFE {
     AstCFile* const cfilep = new AstCFile{v3Global.rootp()->fileline(), filename};
     cfilep->slow(slow);
     cfilep->source(source);
-    if (add) v3Global.rootp()->addFilesp(cfilep);
     return cfilep;
 }
 

--- a/src/V3EmitCBase.h
+++ b/src/V3EmitCBase.h
@@ -85,6 +85,7 @@ public:
     // METHODS
     V3OutCFile* ofp() const VL_MT_SAFE { return m_ofp; }
     void puts(const string& str) { ofp()->puts(str); }
+    void putsHeader() { ofp()->putsHeader(); }
     void putbs(const string& str) { ofp()->putbs(str); }
     void putsDecoration(const string& str) {
         if (v3Global.opt.decoration()) puts(str);
@@ -106,7 +107,8 @@ public:
     static string topClassName() VL_MT_SAFE {  // Return name of top wrapper module
         return v3Global.opt.prefix();
     }
-    static AstCFile* newCFile(const string& filename, bool slow, bool source, bool add = true);
+    static AstCFile* newCFile(const string& filename, bool slow, bool source);
+    static AstCFile* createCFile(const string& filename, bool slow, bool source) VL_MT_SAFE;
     string cFuncArgs(const AstCFunc* nodep);
     void emitCFuncHeader(const AstCFunc* funcp, const AstNodeModule* modp, bool withScope);
     void emitCFuncDecl(const AstCFunc* funcp, const AstNodeModule* modp, bool cLinkage = false);

--- a/src/V3EmitCImp.cpp
+++ b/src/V3EmitCImp.cpp
@@ -174,8 +174,7 @@ class EmitCImp final : EmitCFunc {
             // Unfortunately we have some lint checks here, so we can't just skip processing.
             // We should move them to a different stage.
             const string filename = VL_DEV_NULL;
-            m_cfilesr.push_back(
-                newCFile(filename, /* slow: */ m_slow, /* source: */ true, /* add */ false));
+            m_cfilesr.push_back(createCFile(filename, /* slow: */ m_slow, /* source: */ true));
             m_ofp = new V3OutCFile{filename};
         } else {
             string filename = v3Global.opt.makeDir() + "/" + prefixNameProtect(m_fileModp);
@@ -185,12 +184,11 @@ class EmitCImp final : EmitCFunc {
             }
             if (m_slow) filename += "__Slow";
             filename += ".cpp";
-            m_cfilesr.push_back(
-                newCFile(filename, /* slow: */ m_slow, /* source: */ true, /* add */ false));
+            m_cfilesr.push_back(createCFile(filename, /* slow: */ m_slow, /* source: */ true));
             m_ofp = v3Global.opt.systemC() ? new V3OutScFile{filename} : new V3OutCFile{filename};
         }
 
-        ofp()->putsHeader();
+        putsHeader();
         puts("// DESCRIPTION: Verilator output: Design implementation internals\n");
         puts("// See " + topClassName() + ".h for the primary calling header\n");
 
@@ -597,7 +595,7 @@ class EmitCTrace final : EmitCFunc {
         if (m_slow) filename += "__Slow";
         filename += ".cpp";
 
-        AstCFile* const cfilep = newCFile(filename, m_slow, true /*source*/, false /*add*/);
+        AstCFile* const cfilep = createCFile(filename, m_slow, true /*source*/);
         cfilep->support(true);
         m_cfilesr.push_back(cfilep);
 
@@ -606,9 +604,9 @@ class EmitCTrace final : EmitCFunc {
         } else {
             m_ofp = new V3OutCFile{filename};
         }
-        m_ofp->putsHeader();
-        m_ofp->puts("// DESCR"
-                    "IPTION: Verilator output: Tracing implementation internals\n");
+        putsHeader();
+        puts("// DESCR"
+             "IPTION: Verilator output: Tracing implementation internals\n");
 
         // Includes
         puts("#include \"" + v3Global.opt.traceSourceLang() + ".h\"\n");


### PR DESCRIPTION
Ref: https://github.com/verilator/verilator/pull/3608

This PR refactors some functions for better clang thread-safety analysis.  No functional change intended.