### PR TITLE
Interface inst. w/o parenthesis should not be allowed

### DIFF
--- a/test_regress/t/t_interface_inst_paren_missing_bad.out
+++ b/test_regress/t/t_interface_inst_paren_missing_bad.out
@@ -1,0 +1,1 @@
+%Error: TODO 'intf' is an unknown type in the declaration of 'intf_i'. Or did you omit the '()' for an instantiation?

--- a/test_regress/t/t_interface_inst_paren_missing_bad.pl
+++ b/test_regress/t/t_interface_inst_paren_missing_bad.pl
@@ -1,0 +1,19 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2023 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(vlt => 1);
+
+compile(
+	fails => 1,
+    expect_filename => $Self->{golden_filename},
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_interface_inst_paren_missing_bad.v
+++ b/test_regress/t/t_interface_inst_paren_missing_bad.v
@@ -1,0 +1,15 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// Interface instantiation without paranthesis
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2023 by Goekce Aydos.
+// SPDX-License-Identifier: CC0-1.0
+
+interface intf;
+endinterface
+
+module m;
+	intf intf_i;
+	initial $finish;
+endmodule


### PR DESCRIPTION
LRM A.4.1.{1,2} Module and interface instantiation:

```
interface_instantiation ::= interface_identifier [ parameter_value_assignment ] hierarchical_instance { , hierarchical_instance } ;
...
hierarchical_instance ::= name_of_instance ( [ list_of_port_connections ] )
```

I created the test case, but do not know where to error out.

Following lines parse the line:
https://github.com/verilator/verilator/blob/d67d75282c8550e7f5ac24a344517523f2d9e594/src/verilog.y#L3171-L3176

https://github.com/verilator/verilator/blob/d67d75282c8550e7f5ac24a344517523f2d9e594/src/verilog.y#L136-L160

1. AFAI understand an interface instantiation is parsed as a cell and then linked in later stages, right?
2. What does the line 140 check for?
3. Where should the code error out? Maybe `src/V3LinkParse.cpp`?
