### PR TITLE
Force parallel build for projects with a lot of files

### DIFF
--- a/src/V3EmitMk.h
+++ b/src/V3EmitMk.h
@@ -26,6 +26,8 @@ class V3HierBlockPlan;
 
 class V3EmitMk final {
 public:
+    static const size_t PARALLEL_FILE_CNT_THRESHOLD = 128;
+
     static void emitmk();
     static void emitHierVerilation(const V3HierBlockPlan* planp);
 };

--- a/src/V3EmitMk.h
+++ b/src/V3EmitMk.h
@@ -26,6 +26,7 @@ class V3HierBlockPlan;
 
 class V3EmitMk final {
 public:
+    // Number of source files after which to use parallel compiles
     static const size_t PARALLEL_FILE_CNT_THRESHOLD = 128;
 
     static void emitmk();

--- a/src/Verilator.cpp
+++ b/src/Verilator.cpp
@@ -565,6 +565,13 @@ static void process() {
     reportStatsIfEnabled();
 
     if (!v3Global.opt.lintOnly() && !v3Global.opt.xmlOnly() && !v3Global.opt.dpiHdrOnly()) {
+        size_t src_f_cnt = 0;
+        for (AstNode* nodep = v3Global.rootp()->filesp(); nodep; nodep = nodep->nextp()) {
+            const AstCFile* cfilep = VN_CAST(nodep, CFile);
+            src_f_cnt += (cfilep && cfilep->source()) ? 1 : 0;
+        }
+        if (src_f_cnt >= V3EmitMk::PARALLEL_FILE_CNT_THRESHOLD) v3Global.useParallelBuild(true);
+
         // Makefile must be after all other emitters
         if (v3Global.opt.main()) V3EmitCMain::emit();
         if (v3Global.opt.cmake()) V3EmitCMake::emit();

--- a/src/Verilator.cpp
+++ b/src/Verilator.cpp
@@ -567,8 +567,8 @@ static void process() {
     if (!v3Global.opt.lintOnly() && !v3Global.opt.xmlOnly() && !v3Global.opt.dpiHdrOnly()) {
         size_t src_f_cnt = 0;
         for (AstNode* nodep = v3Global.rootp()->filesp(); nodep; nodep = nodep->nextp()) {
-            const AstCFile* cfilep = VN_CAST(nodep, CFile);
-            src_f_cnt += (cfilep && cfilep->source()) ? 1 : 0;
+            if (const AstCFile* cfilep = VN_CAST(nodep, CFile))
+                src_f_cnt += cfilep->source() ? 1 : 0;
         }
         if (src_f_cnt >= V3EmitMk::PARALLEL_FILE_CNT_THRESHOLD) v3Global.useParallelBuild(true);
 


### PR DESCRIPTION
Solves #4113

By using parallel builds we can avoid passing extremely long file lists to `verilator_includer`.