### PR TITLE
Resolve lvalues after parameterization

### DIFF
--- a/src/Verilator.cpp
+++ b/src/Verilator.cpp
@@ -152,6 +152,7 @@ static void process() {
     //   This requires some width calculations and constant propagation
     V3Param::param(v3Global.rootp());
     V3LinkDot::linkDotParamed(v3Global.rootp());  // Cleanup as made new modules
+    V3LinkLValue::linkLValue(v3Global.rootp()); // Resolve new VarRefs
     V3Error::abortIfErrors();
 
     // Remove any modules that were parameterized and are no longer referenced.

--- a/src/Verilator.cpp
+++ b/src/Verilator.cpp
@@ -152,7 +152,7 @@ static void process() {
     //   This requires some width calculations and constant propagation
     V3Param::param(v3Global.rootp());
     V3LinkDot::linkDotParamed(v3Global.rootp());  // Cleanup as made new modules
-    V3LinkLValue::linkLValue(v3Global.rootp()); // Resolve new VarRefs
+    V3LinkLValue::linkLValue(v3Global.rootp());  // Resolve new VarRefs
     V3Error::abortIfErrors();
 
     // Remove any modules that were parameterized and are no longer referenced.

--- a/test_regress/t/t_class_param_lvalue.pl
+++ b/test_regress/t/t_class_param_lvalue.pl
@@ -1,0 +1,17 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2023 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(linter => 1);
+
+lint(
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_class_param_lvalue.v
+++ b/test_regress/t/t_class_param_lvalue.v
@@ -1,0 +1,15 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2023 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+class Foo;
+endclass
+
+class Bar #(type BASE=Foo) extends BASE;
+  task body();
+    int v = 0;
+    v = 1;
+  endtask
+endclass


### PR DESCRIPTION
Fixes #4130

Some variable references stay as ParseRefs until classes get properly parametrized. After they become VerRefs `LinkLValueVisitor` will be able to set lvalues appropriately.