### PR TITLE
[XML Emit] fix instance names of nodes under named begin blocks (#4129)

### DIFF
--- a/Changes
+++ b/Changes
@@ -43,6 +43,7 @@ Verilator 5.009 devel
 * Fix unpacked structs under classes (#4102). [Tudor Timi]
 * Fix false ENUMVALUE on expressions and arrays.
 * Fix unnecessary verilated_std.sv waivers in --waiver-output.
+* Fix missing begin block hierarchy in --xml-only cells section (#4129). [Risto Pejašinović]
 
 
 Verilator 5.008 2023-03-04

--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -122,6 +122,7 @@ Qingyao Sun
 Rafal Kapuscik
 Raynard Qiao
 Richard Myers
+Risto Pejašinović
 Robert Balas
 Rupert Swarbrick
 Ryszard Rozak

--- a/src/V3EmitXml.cpp
+++ b/src/V3EmitXml.cpp
@@ -403,8 +403,8 @@ private:
     void visit(AstCell* nodep) override {
         if (nodep->modp()->dead()) return;
         if (!m_hasChildren) m_os << ">\n";
-        m_os << "<cell " << nodep->fileline()->xmlDetailedLocation() << " name=\"" << nodep->name()
-             << "\""
+        m_os << "<cell " << nodep->fileline()->xmlDetailedLocation()
+             << " name=\"" << nodep->name() << "\""
              << " submodname=\"" << nodep->modName() << "\""
              << " hier=\"" << m_hier + nodep->name() << "\"";
         const std::string hier = m_hier;
@@ -418,6 +418,11 @@ private:
         }
         m_hier = hier;
         m_hasChildren = true;
+    }
+    void visit(AstBegin* nodep) override {
+        VL_RESTORER(m_hier);
+        if (nodep->name() != "") m_hier += nodep->name() + ".";
+        iterateChildrenConst(nodep);
     }
     //-----
     void visit(AstNode* nodep) override { iterateChildrenConst(nodep); }

--- a/test_regress/t/t_xml_begin_hier.out
+++ b/test_regress/t/t_xml_begin_hier.out
@@ -1,0 +1,82 @@
+<?xml version="1.0" ?>
+<!-- DESCRIPTION: Verilator output: XML representation of netlist -->
+<verilator_xml>
+  <files>
+    <file id="a" filename="&lt;built-in&gt;" language="1800-2017"/>
+    <file id="b" filename="&lt;command-line&gt;" language="1800-2017"/>
+    <file id="c" filename="input.vc" language="1800-2017"/>
+    <file id="d" filename="t/t_xml_begin_hier.v" language="1800-2017"/>
+  </files>
+  <module_files>
+    <file id="d" filename="t/t_xml_begin_hier.v" language="1800-2017"/>
+  </module_files>
+  <cells>
+    <cell loc="d,22,8,22,12" name="test" submodname="test" hier="test">
+      <cell loc="d,27,21,27,31" name="submod_for" submodname="submod" hier="test.FOR_GENERATE__BRA__0__KET__.submod_for">
+        <cell loc="d,15,21,15,34" name="submod_nested" submodname="submod2" hier="test.FOR_GENERATE__BRA__0__KET__.submod_for.submod_gen.nested_gen.submod_nested"/>
+        <cell loc="d,17,17,17,26" name="submod_l1" submodname="submod2" hier="test.FOR_GENERATE__BRA__0__KET__.submod_for.submod_gen.submod_l1"/>
+        <cell loc="d,19,13,19,22" name="submod_l0" submodname="submod2" hier="test.FOR_GENERATE__BRA__0__KET__.submod_for.submod_l0"/>
+      </cell>
+      <cell loc="d,29,25,29,33" name="submod_2" submodname="submod" hier="test.FOR_GENERATE__BRA__0__KET__.genblk1.submod_2">
+        <cell loc="d,15,21,15,34" name="submod_nested" submodname="submod2" hier="test.FOR_GENERATE__BRA__0__KET__.genblk1.submod_2.submod_gen.nested_gen.submod_nested"/>
+        <cell loc="d,17,17,17,26" name="submod_l1" submodname="submod2" hier="test.FOR_GENERATE__BRA__0__KET__.genblk1.submod_2.submod_gen.submod_l1"/>
+        <cell loc="d,19,13,19,22" name="submod_l0" submodname="submod2" hier="test.FOR_GENERATE__BRA__0__KET__.genblk1.submod_2.submod_l0"/>
+      </cell>
+      <cell loc="d,31,21,31,29" name="submod_3" submodname="submod" hier="test.FOR_GENERATE__BRA__0__KET__.submod_3">
+        <cell loc="d,15,21,15,34" name="submod_nested" submodname="submod2" hier="test.FOR_GENERATE__BRA__0__KET__.submod_3.submod_gen.nested_gen.submod_nested"/>
+        <cell loc="d,17,17,17,26" name="submod_l1" submodname="submod2" hier="test.FOR_GENERATE__BRA__0__KET__.submod_3.submod_gen.submod_l1"/>
+        <cell loc="d,19,13,19,22" name="submod_l0" submodname="submod2" hier="test.FOR_GENERATE__BRA__0__KET__.submod_3.submod_l0"/>
+      </cell>
+      <cell loc="d,27,21,27,31" name="submod_for" submodname="submod" hier="test.FOR_GENERATE__BRA__1__KET__.submod_for">
+        <cell loc="d,15,21,15,34" name="submod_nested" submodname="submod2" hier="test.FOR_GENERATE__BRA__1__KET__.submod_for.submod_gen.nested_gen.submod_nested"/>
+        <cell loc="d,17,17,17,26" name="submod_l1" submodname="submod2" hier="test.FOR_GENERATE__BRA__1__KET__.submod_for.submod_gen.submod_l1"/>
+        <cell loc="d,19,13,19,22" name="submod_l0" submodname="submod2" hier="test.FOR_GENERATE__BRA__1__KET__.submod_for.submod_l0"/>
+      </cell>
+      <cell loc="d,29,25,29,33" name="submod_2" submodname="submod" hier="test.FOR_GENERATE__BRA__1__KET__.genblk1.submod_2">
+        <cell loc="d,15,21,15,34" name="submod_nested" submodname="submod2" hier="test.FOR_GENERATE__BRA__1__KET__.genblk1.submod_2.submod_gen.nested_gen.submod_nested"/>
+        <cell loc="d,17,17,17,26" name="submod_l1" submodname="submod2" hier="test.FOR_GENERATE__BRA__1__KET__.genblk1.submod_2.submod_gen.submod_l1"/>
+        <cell loc="d,19,13,19,22" name="submod_l0" submodname="submod2" hier="test.FOR_GENERATE__BRA__1__KET__.genblk1.submod_2.submod_l0"/>
+      </cell>
+      <cell loc="d,31,21,31,29" name="submod_3" submodname="submod" hier="test.FOR_GENERATE__BRA__1__KET__.submod_3">
+        <cell loc="d,15,21,15,34" name="submod_nested" submodname="submod2" hier="test.FOR_GENERATE__BRA__1__KET__.submod_3.submod_gen.nested_gen.submod_nested"/>
+        <cell loc="d,17,17,17,26" name="submod_l1" submodname="submod2" hier="test.FOR_GENERATE__BRA__1__KET__.submod_3.submod_gen.submod_l1"/>
+        <cell loc="d,19,13,19,22" name="submod_l0" submodname="submod2" hier="test.FOR_GENERATE__BRA__1__KET__.submod_3.submod_l0"/>
+      </cell>
+    </cell>
+  </cells>
+  <netlist>
+    <module loc="d,22,8,22,12" name="test" origName="test" topModule="1">
+      <var loc="d,24,12,24,13" name="N" dtype_id="1" vartype="integer" origName="N"/>
+      <begin loc="d,25,14,25,17" name="FOR_GENERATE"/>
+      <begin loc="d,27,21,27,31" name="FOR_GENERATE[0]">
+        <instance loc="d,27,21,27,31" name="submod_for" defName="submod" origName="submod_for"/>
+        <begin loc="d,28,19,28,24" name="genblk1">
+          <instance loc="d,29,25,29,33" name="submod_2" defName="submod" origName="submod_2"/>
+        </begin>
+        <instance loc="d,31,21,31,29" name="submod_3" defName="submod" origName="submod_3"/>
+      </begin>
+      <begin loc="d,27,21,27,31" name="FOR_GENERATE[1]">
+        <instance loc="d,27,21,27,31" name="submod_for" defName="submod" origName="submod_for"/>
+        <begin loc="d,28,19,28,24" name="genblk1">
+          <instance loc="d,29,25,29,33" name="submod_2" defName="submod" origName="submod_2"/>
+        </begin>
+        <instance loc="d,31,21,31,29" name="submod_3" defName="submod" origName="submod_3"/>
+      </begin>
+    </module>
+    <module loc="d,10,8,10,14" name="submod" origName="submod">
+      <begin loc="d,12,19,12,29" name="submod_gen">
+        <var loc="d,13,14,13,20" name="l1_sig" dtype_id="2" vartype="logic" origName="l1_sig"/>
+        <begin loc="d,14,23,14,33" name="nested_gen">
+          <instance loc="d,15,21,15,34" name="submod_nested" defName="submod2" origName="submod_nested"/>
+        </begin>
+        <instance loc="d,17,17,17,26" name="submod_l1" defName="submod2" origName="submod_l1"/>
+      </begin>
+      <instance loc="d,19,13,19,22" name="submod_l0" defName="submod2" origName="submod_l0"/>
+    </module>
+    <module loc="d,7,8,7,15" name="submod2" origName="submod2"/>
+    <typetable loc="a,0,0,0,0">
+      <basicdtype loc="d,24,12,24,13" id="1" name="integer" left="31" right="0" signed="true"/>
+      <basicdtype loc="d,13,14,13,20" id="2" name="logic"/>
+    </typetable>
+  </netlist>
+</verilator_xml>

--- a/test_regress/t/t_xml_begin_hier.pl
+++ b/test_regress/t/t_xml_begin_hier.pl
@@ -1,0 +1,25 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2012 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(vlt => 1);
+
+my $out_filename = "$Self->{obj_dir}/V$Self->{name}.xml";
+
+compile(
+    verilator_flags2 => ['--no-std', '--xml-only'],
+    verilator_make_gmake => 0,
+    make_top_shell => 0,
+    make_main => 0,
+    );
+
+files_identical("$out_filename", $Self->{golden_filename});
+
+ok(1);
+1;

--- a/test_regress/t/t_xml_begin_hier.v
+++ b/test_regress/t/t_xml_begin_hier.v
@@ -1,0 +1,33 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2023 by Risto Pejasinovic.
+// SPDX-License-Identifier: CC0-1.0
+
+module submod2 ();
+endmodule
+
+module submod #(
+)();
+    if(1) begin : submod_gen
+        wire l1_sig;
+        if(1) begin : nested_gen
+            submod2 submod_nested();
+        end
+        submod2 submod_l1();
+    end
+    submod2 submod_l0();
+endmodule
+
+module test(
+);
+    genvar N;
+    generate for(N=0; N<2; N=N+1)
+        begin : FOR_GENERATE
+            submod  submod_for();
+            if(1) begin
+                submod  submod_2();
+            end
+            submod  submod_3();
+    end endgenerate
+endmodule


### PR DESCRIPTION
Here is a pull request from issue #4129  @wsnyder 
I need more help to finish this. I somewhat managed to fix it and in my use case it works well now, but I am not sure if the implementation is correct as its my first attempt at Verilator internals.
All comments are welcome.

First I have a question if I understood correctly @wsnyder remark.
Here is the source verilog:

```
module submod();
endmodule

module test(
);
wire root_wire;
if(1) begin : SOME_GEN
    wire local_wire;
    submod submod_1();
    if(1) begin : OTHER_GEN
        assign root_wire = local_wire;
        submod submod_2();
    end
end
endmodule
```

And the output of the xml emit after my changes is this, I highlighted the lines that are affected by my commit (they are not new lines, just modified)
```diff
<?xml version="1.0" ?>
<!-- DESCRIPTION: Verilator output: XML representation of netlist -->
<verilator_xml>
  <files>
    <file id="c" filename="/tools/work/verilator_issue/xml/install/share/verilator/include/verilated_std.sv" language="1800-2017"/>
    <file id="a" filename="&lt;built-in&gt;" language="1800-2017"/>
    <file id="b" filename="&lt;command-line&gt;" language="1800-2017"/>
    <file id="d" filename="test.v" language="1800-2017"/>
  </files>
  <module_files>
    <file id="d" filename="test.v" language="1800-2017"/>
  </module_files>
  <cells>
    <cell loc="d,4,8,4,12" name="test" submodname="test" hier="test">
+      <cell loc="d,9,12,9,20" name="SOME_GEN.submod_1" submodname="submod" hier="test.SOME_GEN.submod_1"/>
+      <cell loc="d,12,16,12,24" name="SOME_GEN.OTHER_GEN.submod_2" submodname="submod" hier="test.SOME_GEN.OTHER_GEN.submod_2"/>
    </cell>
  </cells>
  <netlist>
    <module loc="d,4,8,4,12" name="test" origName="test" topModule="1">
      <var loc="d,6,6,6,15" name="root_wire" dtype_id="1" vartype="logic" origName="root_wire"/>
      <begin loc="d,7,15,7,23" name="SOME_GEN">
+        <var loc="d,8,10,8,20" name="SOME_GEN.local_wire" dtype_id="1" vartype="logic" origName="local_wire"/>
+        <instance loc="d,9,12,9,20" name="SOME_GEN.submod_1" defName="submod" origName="submod_1"/>
+        <begin loc="d,10,19,10,28" name="SOME_GEN.OTHER_GEN">
          <contassign loc="d,11,26,11,27" dtype_id="1">
+            <varref loc="d,11,28,11,38" name="SOME_GEN.local_wire" dtype_id="1"/>
+            <varref loc="d,11,16,11,25" name="root_wire" dtype_id="1"/>
          </contassign>
+          <instance loc="d,12,16,12,24" name="SOME_GEN.OTHER_GEN.submod_2" defName="submod" origName="submod_2"/>
        </begin>
      </begin>
    </module>
    <module loc="d,1,8,1,14" name="submod" origName="submod"/>
    <typetable loc="a,0,0,0,0">
      <voiddtype loc="c,55,21,55,30" id="2"/>
      <basicdtype loc="d,6,6,6,15" id="1" name="logic"/>
    </typetable>
  </netlist>
</verilator_xml>
```
Did I understand correctly how the XML should look?

I tested this for my use case with VPI, where I collected all the nets on the left hand side of the assigndly node, and connected to them with VPI, and I can see that the names are properly generated.
I tested it on Ibex core and a custom SoC with AXI crossbar and other protocol logic. The RTL in this design uses named begin and generate blocks extensively.

Two more questions:

1. In the cell hier attribute, do you think its better to use `name()` or `prettyName()` of instance name.
   In case of using `name()`, for generate loops will have __BRA__N__KET__ instead of [N], but this is what    VPI is expecting anyways, so in the case of VPI this string can be used as is.
2. Should there be another section similar to `<cells>` but that will describe all nets, wire and regs with the hierarchical path to them, this way its easier to retrieve signals from the design without any postprocessing of XML file.