### PR TITLE
Visit a class body even if the class extends a parameter

### DIFF
--- a/src/V3Param.cpp
+++ b/src/V3Param.cpp
@@ -949,16 +949,18 @@ class ParamVisitor final : public VNVisitor {
 
             // Process once; note user5 will be cleared on specialization, so we will do the
             // specialized module if needed
-            if (modp->user5SetOnce()) continue;
+            if (!modp->user5SetOnce()) {
 
-            // TODO: this really should be an assert, but classes and hier_blocks are special...
-            if (modp->someInstanceName().empty()) modp->someInstanceName(modp->origName());
+                // TODO: this really should be an assert, but classes and hier_blocks are
+                // special...
+                if (modp->someInstanceName().empty()) modp->someInstanceName(modp->origName());
 
-            // Iterate the body
-            {
-                VL_RESTORER(m_modp);
-                m_modp = modp;
-                iterateChildren(modp);
+                // Iterate the body
+                {
+                    VL_RESTORER(m_modp);
+                    m_modp = modp;
+                    iterateChildren(modp);
+                }
             }
 
             // Process interface cells, then non-interface cells, which may reference an interface

--- a/test_regress/t/t_class_extends_param.v
+++ b/test_regress/t/t_class_extends_param.v
@@ -30,7 +30,7 @@ module t (/*AUTOARG*/
       endfunction
    endclass
 
-   class ExtendBar extends Bar;
+   class ExtendBar extends Bar#();
      function int get_x;
         return super.get_x();
      endfunction
@@ -39,7 +39,7 @@ module t (/*AUTOARG*/
      endfunction
    endclass
 
-   Bar bar_foo_i;
+   Bar #() bar_foo_i;
    Bar #(Baz) bar_baz_i;
    ExtendBar extend_bar_i;
 

--- a/test_regress/t/t_class_param_type.v
+++ b/test_regress/t/t_class_param_type.v
@@ -52,7 +52,7 @@ class Foo #(type IF=Empty) extends IF;
    int a = 1;
 endclass
 
-class Bar #(type A=int, type B=A) extends Foo;
+class Bar #(type A=int, type B=A) extends Foo#();
    function int get_size_A;
       return $bits(A);
    endfunction
@@ -64,13 +64,29 @@ endclass
 class Empty2;
 endclass
 
-class Baz #(type T=Empty2) extends Foo;
+class Baz #(type T=Empty2) extends Foo#();
 endclass
 
-class Getter1 extends Baz;
+class Getter1 extends Baz#();
    function int get_1;
       foo_t f = new;
       return f.a;
+   endfunction
+endclass
+
+class MyInt1;
+   int x = 1;
+endclass
+
+class MyInt2;
+   int x = 2;
+endclass
+
+class ExtendsMyInt #(type T=MyInt1) extends T;
+   typedef ExtendsMyInt#(T) this_type;
+   function int get_this_type_x;
+      this_type t = new;
+      return t.x;
    endfunction
 endclass
 
@@ -92,6 +108,9 @@ module t (/*AUTOARG*/);
       automatic SingletonUnusedDefault #(bit) sud2 = SingletonUnusedDefault#(bit)::self();
 
       automatic Getter1 getter1 = new;
+
+      automatic ExtendsMyInt#() ext1 = new;
+      automatic ExtendsMyInt#(MyInt2) ext2 = new;
 
       typedef bit my_bit_t;
       Bar#(.A(my_bit_t)) bar_a_bit = new;
@@ -122,6 +141,9 @@ module t (/*AUTOARG*/);
       if (Parcls#(cls2_t)::get_p() != 20) $stop;
 
       if (getter1.get_1() != 1) $stop;
+
+      if (ext1.get_this_type_x() != 1) $stop;
+      if (ext2.get_this_type_x() != 2) $stop;
 
       $write("*-* All Finished *-*\n");
       $finish;


### PR DESCRIPTION
It adds visiting a class body even if the class extends its parameter. Previously I thought that members of such classes shouldn't be visited, but it looks that I was wrong. It is required when there are parameterized class references inside a class body, because such references have to be linked with class definitions to be properly handled by V3Param.cpp. So I added visiting class members, but I disabled throwing an error if definitions can't be found in the first pass of V3LinkDot.cpp.

I also noticed a problem in V3Param. It happened when `workQueue` was empty (after erase of a current class) and that current class was already visited and there were some other nodes in `m_workQueue`. When `workQueue` is empty, it should be swapped with `m_workQueue`, but it didn't happen, because we exited from the loop (via `continue`), so nodes in m_workQueue` weren't handled. It happened in the test I added, but I think it would happen also without my change.

I also added `#()` to parameterized class references in tests in which I found references without it.