### PR TITLE
Add support for parameterized class references in extends statement

### DIFF
--- a/src/V3LinkDot.cpp
+++ b/src/V3LinkDot.cpp
@@ -3287,7 +3287,7 @@ private:
         iterateChildren(nodep);
     }
     void visit(AstClass* nodep) override {
-        nodep->user3SetOnce();
+        if (nodep->user3SetOnce()) return;
         UINFO(5, "   " << nodep << endl);
         checkNoDot(nodep);
         VL_RESTORER(m_curSymp);

--- a/src/V3LinkDot.cpp
+++ b/src/V3LinkDot.cpp
@@ -3309,7 +3309,10 @@ private:
                                    " (IEEE 1800-2017 8.13)");
                 }
                 if (cextp->childDTypep() || cextp->dtypep()) {
-                    // Already converted. Update symbol table to link unlinked members
+                    // Already converted. Update symbol table to link unlinked members.
+                    // Base class has to be visited in a case if its extends statement
+                    // needs to be handled. Recursive inheritance was already checked.
+                    iterate(cextp->classp());
                     importSymbolsFromExtended(nodep, cextp);
                     continue;
                 }

--- a/test_regress/t/t_class_extends_param.v
+++ b/test_regress/t/t_class_extends_param.v
@@ -39,17 +39,51 @@ module t (/*AUTOARG*/
      endfunction
    endclass
 
+   class ExtendBar1 extends Bar #(Foo);
+     function int get_x;
+        return super.get_x();
+     endfunction
+     function int get_6;
+        return 2 * get_3();
+     endfunction
+   endclass
+
+   class ExtendBarBaz extends Bar #(Baz);
+     function int get_x;
+        return super.get_x();
+     endfunction
+     function int get_8;
+        return 2 * get_4();
+     endfunction
+   endclass
+
+   class ExtendExtendBar extends ExtendBar;
+      function int get_12;
+         return 4 * get_3();
+      endfunction
+   endclass
+
    Bar #() bar_foo_i;
    Bar #(Baz) bar_baz_i;
    ExtendBar extend_bar_i;
+   ExtendBar1 extend_bar1_i;
+   ExtendBarBaz extend_bar_baz_i;
+   ExtendExtendBar extend_extend_bar_i;
 
    initial begin
       bar_foo_i = new;
       bar_baz_i = new;
       extend_bar_i = new;
+      extend_bar1_i = new;
+      extend_bar_baz_i = new;
+      extend_extend_bar_i = new;
       if (bar_foo_i.get_x() == 1 && bar_foo_i.get_3() == 3 &&
           bar_baz_i.get_x() == 2 && bar_baz_i.get_4() == 4 &&
-          extend_bar_i.get_x() == 1 && extend_bar_i.get_6() == 6) begin
+          extend_bar_i.get_x() == 1 && extend_bar_i.get_6() == 6 &&
+          extend_bar_i.get_x() == 1 && extend_bar_i.get_6() == 6 &&
+          extend_bar1_i.get_x() == 1 && extend_bar1_i.get_6() == 6 &&
+          extend_bar_baz_i.get_x() == 2 && extend_bar_baz_i.get_8() == 8 &&
+          extend_extend_bar_i.get_x() == 1 && extend_extend_bar_i.get_12() == 12) begin
          $write("*-* All Finished *-*\n");
          $finish;
       end


### PR DESCRIPTION
It adds support for parameterized class references in `extends` statement.
I also simplified the `for` loop that iterates through `extendsp()` nodes. They are always of type `AstClassExtends`, so there is not need for that `if` with the cast.
I also noticed that a class could be visited a few times in one stage, so I added an `if` to prevent that.