### PR TITLE
Fix DPI function type alias (#4148)

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -142,6 +142,7 @@ Tobias Wölfel
 Todd Strader
 Tomasz Gorochowik
 Topa Topino
+Toru Niina
 Tymoteusz Blazejczyk
 Udi Finkelstein
 Unai Martinez-Corral

--- a/src/V3EmitCSyms.cpp
+++ b/src/V3EmitCSyms.cpp
@@ -432,7 +432,8 @@ void EmitCSyms::emitSymHdr() {
             if (funcp->dpiExportImpl()) {
                 const string cbtype
                     = protect(v3Global.opt.prefix() + "__Vcb_" + funcp->cname() + "_t");
-                types["using " + cbtype + " = void (*) (" + cFuncArgs(funcp) + ");\n"] = 1;
+                const string functype = funcp->rtnTypeVoid() + " (*) (" + cFuncArgs(funcp) + ")";
+                types["using " + cbtype + " = " + functype + ";\n"] = 1;
             }
         }
         for (const auto& i : types) puts(i.first);

--- a/test_regress/t/t_timing_dpi.cpp
+++ b/test_regress/t/t_timing_dpi.cpp
@@ -1,0 +1,12 @@
+// -*- mode: C++; c-file-style: "cc-mode" -*-
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2023 by Toru Niina.
+// SPDX-License-Identifier: CC0-1.0
+
+#include "Vt_timing_dpi__Dpi.h"
+
+int tb_c_wait() {
+    tb_sv_wait(10);
+    return 0;
+}

--- a/test_regress/t/t_timing_dpi.pl
+++ b/test_regress/t/t_timing_dpi.pl
@@ -1,0 +1,28 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This file ONLY is placed under the Creative Commons Public Domain, for
+# any use, without warranty, 2023 by Toru Niina.
+# SPDX-License-Identifier: CC0-1.0
+
+
+scenarios(vlt => 1);
+
+if (!$Self->have_coroutines) {
+    skip("No coroutine support")
+}
+else {
+    compile(
+        v_flags2 => ["t/t_timing_dpi.cpp"],
+        verilator_flags2 => ["--exe --main --timing"],
+        make_main => 0,
+        );
+
+    execute(
+        check_finished => 1,
+        );
+}
+
+ok(1);
+1

--- a/test_regress/t/t_timing_dpi.v
+++ b/test_regress/t/t_timing_dpi.v
@@ -1,0 +1,46 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2023 by Toru Niina.
+// SPDX-License-Identifier: CC0-1.0
+
+`ifdef TEST_VERBOSE
+ `define WRITE_VERBOSE(msg) $write(msg)
+`else
+ `define WRITE_VERBOSE(msg)
+`endif
+
+`default_nettype none
+`timescale 1ns/1ps
+
+module t;
+
+    localparam cycle = 1000.0 / 100.0;
+    localparam halfcycle = 0.5 * cycle;
+
+    logic clk = '0;
+
+    import "DPI-C" context task tb_c_wait();
+
+    export "DPI-C" task tb_sv_wait;
+    task automatic tb_sv_wait(input int n);
+        `WRITE_VERBOSE("tb_sv_wait start...");
+        repeat(n) @(negedge clk);
+        `WRITE_VERBOSE("tb_sv_wait done!");
+    endtask
+
+    always #halfcycle clk = ~clk;
+
+    initial begin
+        `WRITE_VERBOSE("test start");
+        repeat(10) @(posedge clk);
+        `WRITE_VERBOSE("calling tb_c_wait...");
+        tb_c_wait();
+        `WRITE_VERBOSE("tb_c_wait finish");
+        repeat(10) @(posedge clk);
+        $write("*-* All Finished *-*\n");
+        $finish;
+    end
+
+    initial #(cycle*30) $stop; // timeout
+endmodule


### PR DESCRIPTION
Hi,

I have written a simple patch that fixes #4148.

It uses `AstCFunc::rtnTypeVoid` to generate DPI type aliases when emitting the Sym header file.

Could you take a look at it when you have a moment?
Thanks in advance.