### PR TITLE
Instantiate a parameterized class only if it's used

### DIFF
--- a/src/V3AstNodeOther.h
+++ b/src/V3AstNodeOther.h
@@ -2118,6 +2118,7 @@ class AstClass final : public AstNodeModule {
     bool m_interfaceClass = false;  // Interface class
     bool m_needRNG = false;  // Need RNG, uses srandom/randomize
     bool m_virtual = false;  // Virtual class
+    bool m_parameterized = false;  // Parameterized class
     void insertCache(AstNode* nodep);
 
 public:
@@ -2151,6 +2152,8 @@ public:
     void isVirtual(bool flag) { m_virtual = flag; }
     bool needRNG() const { return m_needRNG; }
     void needRNG(bool flag) { m_needRNG = flag; }
+    bool isParameterized() const { return m_parameterized; }
+    void isParameterized(bool flag) { m_parameterized = flag; }
     // Return true if this class is an extension of base class (SLOW)
     // Accepts nullptrs
     static bool isClassExtendedFrom(const AstClass* refClassp, const AstClass* baseClassp);

--- a/src/verilog.y
+++ b/src/verilog.y
@@ -6775,6 +6775,7 @@ class_declaration<nodep>:       // ==IEEE: part of class_declaration
                         }
         /*cont*/    class_itemListE yENDCLASS endLabelE
                         { $$ = $1; $1->addMembersp($2);
+                          if ($2) $1->isParameterized(true);
                           $1->addExtendsp($3);
                           $1->addExtendsp($4);
                           $1->addMembersp($7);

--- a/test_regress/t/t_class_extends_int_param_bad.out
+++ b/test_regress/t/t_class_extends_int_param_bad.out
@@ -1,5 +1,5 @@
 %Error: t/t_class_extends_int_param_bad.v:9:23: Attempting to extend using non-class
                                               : ... In instance t
-    9 |    class bar #(type T=int) extends T;
+    9 |    class Bar #(type T=int) extends T;
       |                       ^~~
 %Error: Exiting due to

--- a/test_regress/t/t_class_extends_param_unused.pl
+++ b/test_regress/t/t_class_extends_param_unused.pl
@@ -1,0 +1,21 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2020 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_class_extends_param_unused.v
+++ b/test_regress/t/t_class_extends_param_unused.v
@@ -4,13 +4,12 @@
 // any use, without warranty, 2023 by Antmicro Ltd.
 // SPDX-License-Identifier: CC0-1.0
 
+class Foo#(type T = logic) extends T;
+endclass
+
 module t (/*AUTOARG*/);
-
-   class Bar #(type T=int) extends T;
-   endclass
-
    initial begin
-      Bar#() bar;
-      $stop;
+      $write("*-* All Finished *-*\n");
+      $finish;
    end
 endmodule

--- a/test_regress/t/t_class_param_type.v
+++ b/test_regress/t/t_class_param_type.v
@@ -90,6 +90,16 @@ class ExtendsMyInt #(type T=MyInt1) extends T;
    endfunction
 endclass
 
+class StaticX;
+   static int val = 1;
+endclass
+
+class GetStaticXVal #(type T = int);
+   static function int get;
+      return T::val;
+   endfunction
+endclass
+
 module t (/*AUTOARG*/);
 
    initial begin
@@ -111,6 +121,8 @@ module t (/*AUTOARG*/);
 
       automatic ExtendsMyInt#() ext1 = new;
       automatic ExtendsMyInt#(MyInt2) ext2 = new;
+
+      automatic GetStaticXVal#(StaticX) get_statix_x_val = new;
 
       typedef bit my_bit_t;
       Bar#(.A(my_bit_t)) bar_a_bit = new;
@@ -144,6 +156,8 @@ module t (/*AUTOARG*/);
 
       if (ext1.get_this_type_x() != 1) $stop;
       if (ext2.get_this_type_x() != 2) $stop;
+
+      if (get_statix_x_val.get() != 1) $stop;
 
       $write("*-* All Finished *-*\n");
       $finish;

--- a/test_regress/t/t_class_param_unused_default.pl
+++ b/test_regress/t/t_class_param_unused_default.pl
@@ -1,0 +1,21 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2020 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_class_param_unused_default.v
+++ b/test_regress/t/t_class_param_unused_default.v
@@ -1,0 +1,26 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2023 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+class Bar#(type T = int);
+   T t;
+   function new;
+      t = new;
+   endfunction
+endclass
+
+class Baz;
+   int x = 1;
+endclass
+
+module t (/*AUTOARG*/);
+   initial begin
+      Bar#(Baz) bar_baz = new;
+      if (bar_baz.t.x != 1) $stop;
+
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end
+endmodule


### PR DESCRIPTION
Currently on master, instances of parameterized classes with default parameter values are always created, no matter if they are used or not. It causes problems if the default value of a parameter is incorrect. It is quite often in UVM, for example: https://github.com/chipsalliance/uvm-verilator/blob/eb0cef0c4154386381196ec0142ed876bfc2ed1b/src/comps/uvm_pair.svh#L67 (the default value of `T1` is int and `new` on the object of that type is called).

This PR fixes it. A specialized class is created only if it is referenced in some AstNodeModule that isn't a parameterized class (but it can be a specialized instance of a parameterized class).