### PR TITLE
CUse: include missing class forward declarations

### DIFF
--- a/src/V3CUse.cpp
+++ b/src/V3CUse.cpp
@@ -69,7 +69,6 @@ class CUseVisitor final : public VNVisitor {
     }
     void visit(AstCFunc* nodep) override {
         if (nodep->user1SetOnce()) return;  // Process once
-
         iterateAndNextNull(nodep->argsp());
 
         {
@@ -83,7 +82,6 @@ class CUseVisitor final : public VNVisitor {
     }
     void visit(AstCReturn* nodep) override {
         if (nodep->user1SetOnce()) return;  // Process once
-
         if (m_dtypesImplOnly) {
             for (AstNode* exprp = nodep->op1p(); exprp; exprp = exprp->nextp()) {
                 if (exprp->dtypep())

--- a/src/V3CUse.cpp
+++ b/src/V3CUse.cpp
@@ -45,7 +45,6 @@ class CUseVisitor final : public VNVisitor {
     const VNUser1InUse m_inuser1;
 
     // MEMBERS
-    bool m_impOnly = false;  // In details needed only for implementation
     AstNodeModule* const m_modp;  // Current module
     std::set<std::pair<VUseType, std::string>> m_didUse;  // What we already used
 
@@ -61,13 +60,7 @@ class CUseVisitor final : public VNVisitor {
     // VISITORS
     void visit(AstClassRefDType* nodep) override {
         if (nodep->user1SetOnce()) return;  // Process once
-        if (!m_impOnly) addNewUse(nodep, VUseType::INT_FWD_CLASS, nodep->classp()->name());
-        // Need to include extends() when we implement, but no need for pointers to know
-        VL_RESTORER(m_impOnly);
-        {
-            m_impOnly = true;
-            iterateChildren(nodep->classp());  // This also gets all extend classes
-        }
+        addNewUse(nodep, VUseType::INT_FWD_CLASS, nodep->classp()->name());
     }
     void visit(AstNodeDType* nodep) override {
         if (nodep->user1SetOnce()) return;  // Process once

--- a/src/V3CUse.cpp
+++ b/src/V3CUse.cpp
@@ -84,8 +84,7 @@ class CUseVisitor final : public VNVisitor {
         if (nodep->user1SetOnce()) return;  // Process once
         if (m_dtypesImplOnly) {
             for (AstNode* exprp = nodep->op1p(); exprp; exprp = exprp->nextp()) {
-                if (exprp->dtypep())
-                    iterate(exprp->dtypep());
+                if (exprp->dtypep()) iterate(exprp->dtypep());
             }
         } else {
             iterateChildren(nodep);

--- a/src/V3CUse.cpp
+++ b/src/V3CUse.cpp
@@ -72,6 +72,8 @@ class CUseVisitor final : public VNVisitor {
         if (stypep && stypep->classOrPackagep()) {
             addNewUse(nodep, VUseType::INT_INCLUDE, stypep->classOrPackagep()->name());
             iterateChildren(stypep);
+        } else if (AstClassRefDType* const classp = VN_CAST(nodep->skipRefp(), ClassRefDType)) {
+            addNewUse(nodep, VUseType::INT_FWD_CLASS, classp->name());
         }
     }
     void visit(AstNode* nodep) override {

--- a/src/V3EmitCBase.cpp
+++ b/src/V3EmitCBase.cpp
@@ -224,21 +224,12 @@ void EmitCBaseVisitorConst::emitVarDecl(const AstVar* nodep, bool asRef) {
 }
 
 void EmitCBaseVisitorConst::emitModCUse(const AstNodeModule* modp, VUseType useType) {
-    string nl;
-    for (AstNode* itemp = modp->stmtsp(); itemp; itemp = itemp->nextp()) {
-        if (AstCUse* const usep = VN_CAST(itemp, CUse)) {
-            if (usep->useType() == useType) {
-                if (usep->useType().isInclude()) {
-                    puts("#include \"" + prefixNameProtect(usep) + ".h\"\n");
-                }
-                if (usep->useType().isFwdClass()) {
-                    puts("class " + prefixNameProtect(usep) + ";\n");
-                }
-                nl = "\n";
-            }
-        }
-    }
-    puts(nl);
+    bool nl;
+    forModCUse(modp, useType, [&](string entry) {
+        puts(entry);
+        nl = true;
+    });
+    if (nl) puts("\n");
 }
 
 void EmitCBaseVisitorConst::emitTextSection(const AstNodeModule* modp, VNType type) {

--- a/src/V3EmitCBase.cpp
+++ b/src/V3EmitCBase.cpp
@@ -224,7 +224,7 @@ void EmitCBaseVisitorConst::emitVarDecl(const AstVar* nodep, bool asRef) {
 }
 
 void EmitCBaseVisitorConst::emitModCUse(const AstNodeModule* modp, VUseType useType) {
-    bool nl;
+    bool nl = false;
     forModCUse(modp, useType, [&](string entry) {
         puts(entry);
         nl = true;

--- a/src/V3EmitCBase.h
+++ b/src/V3EmitCBase.h
@@ -113,6 +113,21 @@ public:
     void emitCFuncHeader(const AstCFunc* funcp, const AstNodeModule* modp, bool withScope);
     void emitCFuncDecl(const AstCFunc* funcp, const AstNodeModule* modp, bool cLinkage = false);
     void emitVarDecl(const AstVar* nodep, bool asRef = false);
+    template <typename F>
+    static void forModCUse(const AstNodeModule* modp, VUseType useType, F action) {
+        for (AstNode* itemp = modp->stmtsp(); itemp; itemp = itemp->nextp()) {
+            if (AstCUse* const usep = VN_CAST(itemp, CUse)) {
+                if (usep->useType() == useType) {
+                    if (usep->useType().isInclude()) {
+                        action("#include \"" + prefixNameProtect(usep) + ".h\"\n");
+                    }
+                    if (usep->useType().isFwdClass()) {
+                        action("class " + prefixNameProtect(usep) + ";\n");
+                    }
+                }
+            }
+        }
+    }
     void emitModCUse(const AstNodeModule* modp, VUseType useType);
     void emitTextSection(const AstNodeModule* modp, VNType type);
 

--- a/src/V3EmitCHeaders.cpp
+++ b/src/V3EmitCHeaders.cpp
@@ -22,7 +22,7 @@
 #include "V3Global.h"
 
 #include <algorithm>
-#include <unordered_set>
+#include <set>
 #include <vector>
 
 VL_DEFINE_DEBUG_FUNCTIONS;
@@ -360,7 +360,7 @@ class EmitCHeader final : public EmitCConstInit {
         if (v3Global.opt.coverage()) puts("#include \"verilated_cov.h\"\n");
         if (v3Global.usesTiming()) puts("#include \"verilated_timing.h\"\n");
 
-        std::unordered_set<string> cuse_set;
+        std::set<string> cuse_set;
         auto add_to_cuse_set = [&](string s) { cuse_set.insert(s); };
 
         forModCUse(modp, VUseType::INT_INCLUDE, add_to_cuse_set);

--- a/test_regress/t/t_cuse_forward.pl
+++ b/test_regress/t/t_cuse_forward.pl
@@ -1,0 +1,17 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2023 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(vlt => 1);
+
+compile(
+       );
+
+ok(1);
+1;

--- a/test_regress/t/t_cuse_forward.v
+++ b/test_regress/t/t_cuse_forward.v
@@ -1,0 +1,39 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2023 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+class Baz;
+endclass
+
+class Bar#(type T) extends T;
+endclass
+
+class Foo;
+  typedef struct {
+    int field;
+  } Zee;
+
+  task t1();
+    // Refer to Baz CLASSREFDTYPE node in implementation (via CLASSEXTENDS)
+    Bar#(Baz) b = new;
+  endtask
+  // Refer to the very same Baz CLASSREFDTYPE node again, this time within interface
+  task t2(Bar#(Baz)::T b);
+  endtask
+endclass
+
+class Moo;
+  // Use Foo::Zee to cause inclusion of Foo's header file
+  Foo::Zee z;
+endclass
+
+module t();
+  initial begin
+    // Use Moo in top module to add Moo to root, causing inclusion of Foo header into
+    // root header.
+    Moo moo;
+    moo = new;
+  end
+endmodule


### PR DESCRIPTION
* Organizes forward declarations into a single block in design internal headers
* Simplifies visiting `AstClassRefDType`s and prevents marking types as implementation-only (it's unnecessary and unused, because implmenetations get the `__Syms` header file. It also resulted in skipping them on later visits, where they could've been deemed necessary to be forward-delared in interfaces, ie. headers.)
* Adds `CUse`s for `AstClassRefDType`s that are pointed to by typeref nodes that are not `AstClassRefDType`
* Ignores types referenced in function bodies only.