### PR TITLE
Optimize `callValueCbs`

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -43,6 +43,7 @@ Guokai Chen
 Gustav Svensk
 G-A. Kamendje
 Harald Heckmann
+Hennadii Chernyshchyk
 Howard Su
 Huang Rui
 Huanghuang Zhou
@@ -108,6 +109,7 @@ Mostafa Gamal
 Nandu Raj
 Nathan Kohagen
 Nathan Myers
+Oleh Maksymenko
 Patrick Stewart
 Paul Wright
 Pawel Sagan

--- a/include/verilated_vpi.cpp
+++ b/include/verilated_vpi.cpp
@@ -165,6 +165,7 @@ class VerilatedVpioVarBase VL_NOT_FINAL : public VerilatedVpio {
 protected:
     const VerilatedVar* m_varp = nullptr;
     const VerilatedScope* m_scopep = nullptr;
+    std::string m_fullname;
     const VerilatedRange& get_range() const {
         // Determine number of dimensions and return outermost
         return (m_varp->dims() > 1) ? m_varp->unpacked() : m_varp->packed();
@@ -173,11 +174,13 @@ protected:
 public:
     VerilatedVpioVarBase(const VerilatedVar* varp, const VerilatedScope* scopep)
         : m_varp{varp}
-        , m_scopep{scopep} {}
+        , m_scopep{scopep}
+        , m_fullname{std::string(m_scopep->name()) + '.' + name()} {}
     explicit VerilatedVpioVarBase(const VerilatedVpioVarBase* varp) {
         if (varp) {
             m_varp = varp->m_varp;
             m_scopep = varp->m_scopep;
+            m_fullname = varp->m_fullname;
         }
     }
     static VerilatedVpioVarBase* castp(vpiHandle h) {
@@ -188,11 +191,7 @@ public:
     uint32_t size() const override { return get_range().elements(); }
     const VerilatedRange* rangep() const override { return &get_range(); }
     const char* name() const override { return m_varp->name(); }
-    const char* fullname() const override {
-        static thread_local std::string t_out;
-        t_out = std::string{m_scopep->name()} + "." + name();
-        return t_out.c_str();
-    }
+    const char* fullname() const override { return m_fullname.c_str(); }
 };
 
 class VerilatedVpioParam final : public VerilatedVpioVarBase {

--- a/include/verilated_vpi.cpp
+++ b/include/verilated_vpi.cpp
@@ -645,23 +645,22 @@ public:
                 continue;
             }
             VerilatedVpiCbHolder& ho = *it++;
-            if (VerilatedVpioVar* const varop = VerilatedVpioVar::castp(ho.cb_datap()->obj)) {
-                void* const newDatap = varop->varDatap();
-                void* const prevDatap
-                    = varop->prevDatap();  // Was malloced when we added the callback
-                VL_DEBUG_IF_PLI(VL_DBG_MSGF("- vpi: value_test %s v[0]=%d/%d %p %p\n",
-                                            varop->fullname(), *(static_cast<CData*>(newDatap)),
-                                            *(static_cast<CData*>(prevDatap)), newDatap,
-                                            prevDatap););
-                if (std::memcmp(prevDatap, newDatap, varop->entSize()) != 0) {
-                    VL_DEBUG_IF_PLI(VL_DBG_MSGF("- vpi: value_callback %" PRId64 " %s v[0]=%d\n",
-                                                ho.id(), varop->fullname(),
-                                                *(static_cast<CData*>(newDatap))););
-                    update.insert(varop);
-                    vpi_get_value(ho.cb_datap()->obj, ho.cb_datap()->value);
-                    (ho.cb_rtnp())(ho.cb_datap());
-                    called = true;
-                }
+            VerilatedVpioVar* const varop = reinterpret_cast<VerilatedVpioVar*>(ho.cb_datap()->obj);
+            void* const newDatap = varop->varDatap();
+            void* const prevDatap
+                = varop->prevDatap();  // Was malloced when we added the callback
+            VL_DEBUG_IF_PLI(VL_DBG_MSGF("- vpi: value_test %s v[0]=%d/%d %p %p\n",
+                                        varop->fullname(), *(static_cast<CData*>(newDatap)),
+                                        *(static_cast<CData*>(prevDatap)), newDatap,
+                                        prevDatap););
+            if (std::memcmp(prevDatap, newDatap, varop->entSize()) != 0) {
+                VL_DEBUG_IF_PLI(VL_DBG_MSGF("- vpi: value_callback %" PRId64 " %s v[0]=%d\n",
+                                            ho.id(), varop->fullname(),
+                                            *(static_cast<CData*>(newDatap))););
+                update.insert(varop);
+                vpi_get_value(ho.cb_datap()->obj, ho.cb_datap()->value);
+                (ho.cb_rtnp())(ho.cb_datap());
+                called = true;
             }
             if (was_last) break;
         }

--- a/include/verilated_vpi.cpp
+++ b/include/verilated_vpi.cpp
@@ -175,7 +175,7 @@ public:
     VerilatedVpioVarBase(const VerilatedVar* varp, const VerilatedScope* scopep)
         : m_varp{varp}
         , m_scopep{scopep}
-        , m_fullname{std::string(m_scopep->name()) + '.' + name()} {}
+        , m_fullname{std::string{m_scopep->name()} + '.' + name()} {}
     explicit VerilatedVpioVarBase(const VerilatedVpioVarBase* varp) {
         if (varp) {
             m_varp = varp->m_varp;


### PR DESCRIPTION
We noticed that adding callbacks using VPI increases the simulation time. Here is how it looks in our case:
![ksnip_20230501-153428](https://user-images.githubusercontent.com/22453358/235452227-c3eb9753-a091-4d60-89fa-03c4b91d7bb3.png)
As you can see `callValueCbs` call takes about 19/20 of the time. So we tried to optimize it a little bit.

We noticed that `fullname` inside `vpi_get_value` takes a lot of time because it allocates a new string on each call:
https://github.com/verilator/verilator/blob/3e986517c314ce68938b60c52273fd29f47b24bf/include/verilated_vpi.cpp#L191-L196
We tried to store the value inside the `VerilatedVpioVarBase`. It improved the performance:
![изображение](https://user-images.githubusercontent.com/22453358/235452897-10c9178a-7b66-4789-b3df-9689ee329c55.png)

But most of the time is still taken by `VerilatedVpioVar::castp` that uses `dynamic_cast` under the hood. But inside `callValueCbs` we iterate only on handles that were registered for `cbValueChange` and do something only if the pointer is `VerilatedVpioVar` and silently skip it otherwise. But we can remove this check and leave passing the correct object to the user responsibility. I think it's better then silently do not call the callback anyway. This improves the performance by a lot:
![изображение](https://user-images.githubusercontent.com/22453358/235453608-b0bdc84b-a9b4-47b0-95e6-c9bd07e6f3ae.png)
