### PR TITLE
Fix initialization order of initial static after function/task

### DIFF
--- a/test_regress/t/t_var_static.pl
+++ b/test_regress/t/t_var_static.pl
@@ -16,6 +16,7 @@ compile(
 
 execute(
     check_finished => 1,
+    all_run_flags => ['+plusarg=value'],
     );
 
 ok(1);

--- a/test_regress/t/t_var_static.v
+++ b/test_regress/t/t_var_static.v
@@ -52,10 +52,17 @@ module t (/*AUTOARG*/
    function automatic int f_au_au ();
       automatic int au = 2; au++; return au;
    endfunction
+   string plusarg                 = "";
+   bit has_plusarg                = |($value$plusargs("plusarg=%s", plusarg));
 
    int v;
 
    initial begin
+      if (has_plusarg) begin
+        if (plusarg == "") begin
+          $fatal(1, "%m: +plusarg must not be empty");
+        end
+      end
       v = f_no_no(); `checkh(v, 3);
       v = f_no_no(); `checkh(v,   4);
       v = f_no_st(); `checkh(v, 3);


### PR DESCRIPTION
Currently ``renameAndStaticsRecurse`` always visits ``nextp``. If ``nextp`` of ``AstNodeFTask`` is ``AstInitialStatic`` we are moving it to this ``AstNodeFTask``. This sometimes can lead to situation where in generated code initial value is placed after code that sets its value.

This PR replaces ``renameAndStaticsRecurse`` function with visitor that visits ``AstNodeFTask`` sub-tree.