### PR TITLE
Fix duplicate static names in blocks in functions (#4144)

### DIFF
--- a/src/V3Begin.cpp
+++ b/src/V3Begin.cpp
@@ -78,6 +78,7 @@ private:
 
     string dot(const string& a, const string& b) {
         if (a == "") return b;
+        if (b == "") return a;
         return a + "__DOT__" + b;
     }
 
@@ -246,7 +247,8 @@ private:
     void visit(AstVar* nodep) override {
         // If static variable, move it outside a function.
         if (nodep->lifetime().isStatic() && m_ftaskp) {
-            const std::string newName = m_ftaskp->name() + "__Vstatic__" + nodep->name();
+            const std::string newName
+                = m_ftaskp->name() + "__Vstatic__" + dot(m_unnamedScope, nodep->name());
             nodep->name(newName);
             nodep->unlinkFrBack();
             m_ftaskp->addHereThisAsNext(nodep);

--- a/test_regress/t/t_static_dup_name.pl
+++ b/test_regress/t/t_static_dup_name.pl
@@ -1,0 +1,23 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2003 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+$Self->{verilated_randReset} = 1;
+
+compile(
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_static_dup_name.v
+++ b/test_regress/t/t_static_dup_name.v
@@ -1,0 +1,34 @@
+// DESCRIPTION: Verilator: Verilog Test module
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2020 by Wilson Snyder.
+// SPDX-License-Identifier: CC0-1.0
+
+module t;
+
+  function do_stuff();
+    static int some_int;
+    begin: block0
+      static int some_int;
+    end
+    begin: block1
+      static int some_int;
+    end
+    begin
+      static int some_int;
+    end
+    begin: block2
+      begin: block3
+        static int some_int;
+      end
+      begin
+        static int some_int;
+      end
+    end
+  endfunction
+
+  initial begin
+    $write("*-* All Finished *-*\n");
+    $finish();
+  end
+
+endmodule


### PR DESCRIPTION
Static variables of functions are created in the function. When blocks in a function use identical names for static variables, we need to name those variables properly.

Fixes #4144
