### PR TITLE
Update install.rst help2man dependency

### DIFF
--- a/docs/guide/install.rst
+++ b/docs/guide/install.rst
@@ -39,7 +39,7 @@ In brief, to install from git:
 ::
 
    # Prerequisites:
-   #sudo apt-get install git perl python3 make autoconf g++ flex bison ccache
+   #sudo apt-get install git help2man perl python3 make autoconf g++ flex bison ccache
    #sudo apt-get install libgoogle-perftools-dev numactl perl-doc
    #sudo apt-get install libfl2  # Ubuntu only (ignore if gives error)
    #sudo apt-get install libfl-dev  # Ubuntu only (ignore if gives error)


### PR DESCRIPTION
Added "help2man" package in "# Prerequisites" section of "Git Quick Install" section to match "Extended Build Instructions" section in the docs.

We appreciate your contributing to Verilator.  If this is your first commit, please add your name to docs/CONTRIBUTORS, and read our contributing guidelines in docs/CONTRIBUTING.rst.
