### PR TITLE
Github action to build and push docker images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,12 +3,13 @@ name: Build Verilator Container
 on:
   push:
     tags: [ 'v*' ]
+  workflow_dispatch:
 
 jobs:
 
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     strategy:
       matrix:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,9 +16,13 @@ jobs:
 
     strategy:
       matrix:
-        # contexts: [ci/docker/buildenv:verilator-buildenv, ci/docker/run:verilator]
-        contexts: [ci/docker/run:verilator]
-        platforms: [linux/arm64,linux/arm/v7,linux/amd64]
+        contexts:
+          - "ci/docker/run:verilator"
+          # - "ci/docker/buildenv:verilator-buildenv"
+        platforms: 
+          - "linux/arm64"
+          - "linux/arm/v7"
+          - "linux/amd64"
 
     steps:
     - name: Checkout

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -40,6 +40,8 @@ jobs:
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
+      with:
+          buildkitd-flags: --debug
 
     - name: Login to Docker Hub
       uses: docker/login-action@v2

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,7 +19,7 @@ jobs:
         contexts:
           - "ci/docker/run:verilator"
           # - "ci/docker/buildenv:verilator-buildenv"
-        platforms: 
+        platforms:
           - "linux/arm64"
           - "linux/arm/v7"
           - "linux/amd64"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,6 +24,7 @@ jobs:
       run: |
         echo "${{ matrix.contexts }}" | sed -r 's/(.*):.*/build_context=\1/' >> "$GITHUB_ENV"
         echo "${{ matrix.contexts }}" | sed -r 's/.*:(.*)/image_name=\1/' >> "$GITHUB_ENV"
+        echo "git_tag=${GITHUB_REF#refs/*/}" >> "$GITHUB_ENV"
 
     - name: Docker meta
       id: docker_meta
@@ -51,6 +52,7 @@ jobs:
       if: startsWith(github.ref, 'refs/tags/v')
       with:
         context: ${{ env.build_context }}
+        build-args: SOURCE_COMMIT=${{ env.git_tag }}
         platforms: linux/arm64,linux/arm/v7,linux/amd64
         push: ${{ !env.ACT && startsWith(github.ref, 'refs/tags/v') }}
         tags: ${{ steps.docker_meta.outputs.tags }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,10 +15,6 @@ jobs:
         contexts:
           - "ci/docker/run:verilator"
           # - "ci/docker/buildenv:verilator-buildenv"
-        platforms:
-          - "linux/arm64"
-          - "linux/arm/v7"
-          - "linux/amd64"
 
     steps:
     - name: Checkout
@@ -55,7 +51,7 @@ jobs:
       if: startsWith(github.ref, 'refs/tags/v')
       with:
         context: ${{ env.build_context }}
-        platforms: ${{ matrix.platforms }}
+        platforms: linux/arm64,linux/arm/v7,linux/amd64
         push: ${{ !env.ACT && startsWith(github.ref, 'refs/tags/v') }}
         tags: ${{ steps.docker_meta.outputs.tags }}
         labels: ${{ steps.docker_meta.outputs.labels }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,61 @@
+name: Build Verilator Container
+
+on:
+  push:
+    tags: [ 'v*' ]
+
+env:
+  # Get the docker hub namespace from the repository configuration variable
+  DOCKER_HUB_NAMESPACE: ${{ vars.DOCKER_HUB_NAMESPACE }}
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        # contexts: [ci/docker/buildenv:verilator-buildenv, ci/docker/run:verilator]
+        contexts: [ci/docker/run:verilator]
+        platforms: [linux/arm64,linux/arm/v7,linux/amd64]
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Extract context variables
+      run: |
+        echo "${{ matrix.contexts }}" | sed -r 's/(.*):.*/build_context=\1/' >> "$GITHUB_ENV"
+        echo "${{ matrix.contexts }}" | sed -r 's/.*:(.*)/image_name=\1/' >> "$GITHUB_ENV"
+
+    - name: Docker meta
+      id: docker_meta
+      uses: docker/metadata-action@v4
+      with:
+        images: |
+          ${{ env.DOCKER_HUB_NAMESPACE }}/${{ env.image_name }}
+        tags: |
+          type=match,pattern=(v.*),group=1
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Login to Docker Hub
+      uses: docker/login-action@v2
+      with:
+        username: ${{ secrets.DOCKER_HUB_USER }}
+        password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+    - name: Build and Push to Docker
+      uses: docker/build-push-action@v4
+      if: startsWith(github.ref, 'refs/tags/v')
+      with:
+        context: ${{ env.build_context }}
+        platforms: ${{ matrix.platforms }}
+        push: ${{ !env.ACT && startsWith(github.ref, 'refs/tags/v') }}
+        tags: ${{ steps.docker_meta.outputs.tags }}
+        labels: ${{ steps.docker_meta.outputs.labels }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,10 +4,6 @@ on:
   push:
     tags: [ 'v*' ]
 
-env:
-  # Get the docker hub namespace from the repository configuration variable
-  DOCKER_HUB_NAMESPACE: ${{ vars.DOCKER_HUB_NAMESPACE }}
-
 jobs:
 
   build:
@@ -38,7 +34,7 @@ jobs:
       uses: docker/metadata-action@v4
       with:
         images: |
-          ${{ env.DOCKER_HUB_NAMESPACE }}/${{ env.image_name }}
+          ${{ secrets.DOCKER_HUB_NAMESPACE }}/${{ env.image_name }}
         tags: |
           type=match,pattern=(v.*),group=1
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -53,7 +53,7 @@ jobs:
       with:
         context: ${{ env.build_context }}
         build-args: SOURCE_COMMIT=${{ env.git_tag }}
-        platforms: linux/arm64,linux/arm/v7,linux/amd64
+        platforms: linux/arm64,linux/amd64
         push: ${{ !env.ACT && startsWith(github.ref, 'refs/tags/v') }}
         tags: ${{ steps.docker_meta.outputs.tags }}
         labels: ${{ steps.docker_meta.outputs.labels }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,6 +9,16 @@ on:
   push:
     tags: [ 'v*' ]
   workflow_dispatch:
+    inputs:
+      manual_tag:
+        description: 'Git tag to use for image build'
+        required: true
+        type: string
+      add_latest_tag:
+        description: 'Tag workflow_dispatch docker image as "latest"'
+        required: true
+        type: boolean
+        default: false
 
 jobs:
 
@@ -32,6 +42,11 @@ jobs:
         echo "${{ matrix.contexts }}" | sed -r 's/.*:(.*)/image_name=\1/' >> "$GITHUB_ENV"
         echo "git_tag=${GITHUB_REF#refs/*/}" >> "$GITHUB_ENV"
 
+    - name: Use manual tag
+      if: ${{ inputs.manual_tag }}
+      run: |
+        echo "git_tag=${{ inputs.manual_tag }}" >> "$GITHUB_ENV"
+
     - name: Docker meta
       id: docker_meta
       uses: docker/metadata-action@v4
@@ -39,7 +54,9 @@ jobs:
         images: |
           ${{ secrets.DOCKER_HUB_NAMESPACE }}/${{ env.image_name }}
         tags: |
-          type=match,pattern=(v.*),group=1
+          type=match,pattern=(v.*),group=1,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+          type=raw,value=${{ inputs.manual_tag }},enable=${{ inputs.manual_tag != '' }}
+          type=raw,value=latest,enable=${{ inputs.add_latest_tag == true }}
 
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v2

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,3 +1,8 @@
+# Build and push verilator docker image when tags are pushed to the repository.
+# The following secrets must be configured in the github repository:
+# DOCKER_HUB_NAMESPACE: docker hub namespace.
+# DOCKER_HUB_USER: user name for logging into docker hub
+# DOCKER_HUB_ACCESS_TOKEN: docker hub access token.
 name: Build Verilator Container
 
 on:

--- a/README.rst
+++ b/README.rst
@@ -13,6 +13,8 @@
     :target: https://codecov.io/gh/verilator/verilator
 .. image:: https://github.com/verilator/verilator/workflows/build/badge.svg
     :target: https://github.com/verilator/verilator/actions?query=workflow%3Abuild
+.. image:: https://img.shields.io/docker/pulls/verilator/verilator
+    :target: https://hub.docker.com/r/verilator/verilator
 
 
 Welcome to Verilator

--- a/ci/docker/run/Dockerfile
+++ b/ci/docker/run/Dockerfile
@@ -45,7 +45,7 @@ RUN git clone "${REPO}" verilator && \
     git checkout "${SOURCE_COMMIT}" && \
     autoconf && \
     ./configure && \
-    make -j "$(nproc)" && \
+    make && \
     make install && \
     cd .. && \
     rm -r verilator

--- a/ci/docker/run/Dockerfile
+++ b/ci/docker/run/Dockerfile
@@ -19,10 +19,16 @@ RUN apt-get update \
                         ccache \
                         flex \
                         git \
+                        help2man \
+                        libfl2 \
                         libfl-dev \
                         libgoogle-perftools-dev \
+                        numactl \
                         perl \
+                        perl-doc \
                         python3 \
+                        zlib1g \
+                        zlib1g-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -70,6 +70,7 @@ Joey Liu
 John Coiner
 John Demme
 Jonathan Drolet
+Jose Loyola
 Joseph Nwabueze
 Josep Sans
 Josh Redford


### PR DESCRIPTION
This PR enables a github action to build and push verilator docker image when tags are pushed to the repository (fixes #3720).
The following secrets must be configured in the repository using [these steps](https://docs.github.com/en/rest/actions/secrets?apiVersion=2022-11-28#create-or-update-an-organization-secret):

- `DOCKER_HUB_NAMESPACE`: docker hub namespace (should be `verilator`).
- `DOCKER_HUB_USER`: user name for logging into docker hub (must be a member of the `verilator` namespace).
- `DOCKER_HUB_ACCESS_TOKEN`: docker hub access token. See [this page](https://docs.docker.com/docker-hub/access-tokens/) for instructions on how to create a token.

I validated the flow works by pushing to [jloyola/verilator](https://hub.docker.com/r/jloyola/verilator/tags).
The action builds images for `linux/amd64` and `linux/arm64`.
The images are tagged with the same string used by the git tag.
