### PR TITLE
Fix marking overridden methods as coroutines (#4120)

### DIFF
--- a/src/V3Timing.cpp
+++ b/src/V3Timing.cpp
@@ -433,12 +433,16 @@ private:
         m_procp = nodep;
         iterateChildren(nodep);
         DependencyVertex* const vxp = getDependencyVertex(nodep);
-        if (m_classp && nodep->isVirtual()
-            && !nodep->user1SetOnce()) {  // If virtual (only visit once)
+        if (m_classp && !nodep->user1SetOnce()) {  // If class method (possibly overrides another
+                                                   // method); only visit once
             // Go over overridden functions
             m_classp->repairCache();
             for (auto* cextp = m_classp->extendsp(); cextp;
                  cextp = VN_AS(cextp->nextp(), ClassExtends)) {
+                if (!cextp->classp()->user1SetOnce()) {
+                    // Repair class cache if it's not repaired already
+                    cextp->classp()->repairCache();
+                }
                 if (auto* const overriddenp
                     = VN_CAST(cextp->classp()->findMember(nodep->name()), CFunc)) {
                     if (overriddenp->user2()) {  // If suspendable

--- a/test_regress/t/t_timing_class.v
+++ b/test_regress/t/t_timing_class.v
@@ -10,10 +10,18 @@
  `define WRITE_VERBOSE(args)
 `endif
 
+class BaseClass;
+    virtual task sleep;
+    endtask
+
+    virtual task await;
+    endtask
+endclass
+
 module t;
     // =============================================
     // EVENTS
-    class EventClass;
+    class EventClass extends BaseClass;
         event e;
         int trig_count;
 
@@ -35,7 +43,7 @@ module t;
         endtask
     endclass
 
-    class WaitClass;
+    class WaitClass extends BaseClass;
         int a;
         int b;
         logic ok;
@@ -53,7 +61,7 @@ module t;
         endtask
     endclass
 
-    class LocalWaitClass;
+    class LocalWaitClass extends BaseClass;
         logic ok;
 
         function new;

--- a/test_regress/t/t_timing_debug2.out
+++ b/test_regress/t/t_timing_debug2.out
@@ -1,5 +1,7 @@
 -V{t#,#}- Verilated::debug is on. Message prefix indicates {<thread>,<sequence_number>}.
 -V{t#,#}+    Vt_timing_debug2___024root___ctor_var_reset
+-V{t#,#}+  Vt_timing_debug2___024unit__03a__03aBaseClass__Vclpkg___ctor_var_reset
+-V{t#,#}+        Vt_timing_debug2___024unit___ctor_var_reset
 -V{t#,#}+      Vt_timing_debug2_t___ctor_var_reset
 -V{t#,#}+  Vt_timing_debug2_t__03a__03aAssignDelayClass__Vclpkg___ctor_var_reset
 -V{t#,#}+  Vt_timing_debug2_t__03a__03aDelay10__Vclpkg___ctor_var_reset
@@ -17,15 +19,21 @@
 -V{t#,#}+ Initial
 -V{t#,#}+    Vt_timing_debug2___024root___eval_static
 -V{t#,#}+      Vt_timing_debug2_t___eval_static__TOP__t
+-V{t#,#}+          Vt_timing_debug2___024unit__03a__03aBaseClass::new
+-V{t#,#}+          Vt_timing_debug2___024unit__03a__03aBaseClass::_ctor_var_reset
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aEventClass::new
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aEventClass::_ctor_var_reset
+-V{t#,#}+          Vt_timing_debug2___024unit__03a__03aBaseClass::new
+-V{t#,#}+          Vt_timing_debug2___024unit__03a__03aBaseClass::_ctor_var_reset
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aWaitClass::new
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aWaitClass::_ctor_var_reset
+-V{t#,#}+          Vt_timing_debug2___024unit__03a__03aBaseClass::new
+-V{t#,#}+          Vt_timing_debug2___024unit__03a__03aBaseClass::_ctor_var_reset
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aLocalWaitClass::new
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aLocalWaitClass::_ctor_var_reset
 -V{t#,#}+    Vt_timing_debug2___024root___eval_initial
 -V{t#,#}+      Vt_timing_debug2_t___eval_initial__TOP__t__0
--V{t#,#}         Suspending process waiting for @([event] t.ec.e) at t/t_timing_class.v:80
+-V{t#,#}         Suspending process waiting for @([event] t.ec.e) at t/t_timing_class.v:88
 -V{t#,#}+      Vt_timing_debug2_t___eval_initial__TOP__t__1
 -V{t#,#}+      Vt_timing_debug2_t___eval_initial__TOP__t__2
 -V{t#,#}+      Vt_timing_debug2_t___eval_initial__TOP__t__3
@@ -57,7 +65,7 @@
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aForkClass::__Vfork_h########__0__0
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aForkClass::__Vfork_h########__0__1
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aForkClass::__Vfork_h########__0__2
--V{t#,#}             Awaiting join of fork at: t/t_timing_class.v:209
+-V{t#,#}             Awaiting join of fork at: t/t_timing_class.v:217
 -V{t#,#}+      Vt_timing_debug2_t___eval_initial__TOP__t__7
 -V{t#,#}+    Vt_timing_debug2___024root___eval_settle
 -V{t#,#}MTask0 starting
@@ -69,7 +77,7 @@
 -V{t#,#}         No triggers active
 -V{t#,#}+    Vt_timing_debug2___024root___timing_commit
 -V{t#,#}         Committing processes waiting for @([event] t.ec.e):
--V{t#,#}           - Process waiting at t/t_timing_class.v:80
+-V{t#,#}           - Process waiting at t/t_timing_class.v:88
 -V{t#,#}End-of-eval cleanup
 -V{t#,#}+++++TOP Evaluate Vt_timing_debug2::eval_step
 -V{t#,#}+    Vt_timing_debug2___024root___eval_debug_assertions
@@ -83,21 +91,21 @@
 -V{t#,#}+    Vt_timing_debug2___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug2___024root___timing_resume
 -V{t#,#}         Delayed processes:
--V{t#,#}             Awaiting time 10: Process waiting at t/t_timing_class.v:88
--V{t#,#}             Awaiting time 20: Process waiting at t/t_timing_class.v:89
--V{t#,#}             Awaiting time 10: Process waiting at t/t_timing_class.v:91
--V{t#,#}             Awaiting time 30: Process waiting at t/t_timing_class.v:101
--V{t#,#}             Awaiting time 40: Process waiting at t/t_timing_class.v:137
--V{t#,#}             Awaiting time 50: Process waiting at t/t_timing_class.v:211
--V{t#,#}             Awaiting time 20: Process waiting at t/t_timing_class.v:215
--V{t#,#}             Awaiting time 80: Process waiting at t/t_timing_class.v:220
--V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:236
+-V{t#,#}             Awaiting time 10: Process waiting at t/t_timing_class.v:96
+-V{t#,#}             Awaiting time 20: Process waiting at t/t_timing_class.v:97
+-V{t#,#}             Awaiting time 10: Process waiting at t/t_timing_class.v:99
+-V{t#,#}             Awaiting time 30: Process waiting at t/t_timing_class.v:109
+-V{t#,#}             Awaiting time 40: Process waiting at t/t_timing_class.v:145
+-V{t#,#}             Awaiting time 50: Process waiting at t/t_timing_class.v:219
+-V{t#,#}             Awaiting time 20: Process waiting at t/t_timing_class.v:223
+-V{t#,#}             Awaiting time 80: Process waiting at t/t_timing_class.v:228
+-V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:244
 -V{t#,#}         Resuming delayed processes
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:236
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:244
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aDelay10::__VnoInFunc_do_sth_else
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aDelay20::__VnoInFunc_do_delay
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:138
--V{t#,#}             Process forked at t/t_timing_class.v:210 finished
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:146
+-V{t#,#}             Process forked at t/t_timing_class.v:218 finished
 -V{t#,#}+    Vt_timing_debug2___024root___eval_act
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
 -V{t#,#}         No suspended processes waiting for dynamic trigger evaluation
@@ -123,20 +131,20 @@
 -V{t#,#}+    Vt_timing_debug2___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug2___024root___timing_resume
 -V{t#,#}         Delayed processes:
--V{t#,#}             Awaiting time 20: Process waiting at t/t_timing_class.v:88
--V{t#,#}             Awaiting time 20: Process waiting at t/t_timing_class.v:89
--V{t#,#}             Awaiting time 30: Process waiting at t/t_timing_class.v:91
--V{t#,#}             Awaiting time 30: Process waiting at t/t_timing_class.v:101
--V{t#,#}             Awaiting time 40: Process waiting at t/t_timing_class.v:137
--V{t#,#}             Awaiting time 50: Process waiting at t/t_timing_class.v:211
--V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:215
--V{t#,#}             Awaiting time 80: Process waiting at t/t_timing_class.v:220
+-V{t#,#}             Awaiting time 20: Process waiting at t/t_timing_class.v:96
+-V{t#,#}             Awaiting time 20: Process waiting at t/t_timing_class.v:97
+-V{t#,#}             Awaiting time 30: Process waiting at t/t_timing_class.v:99
+-V{t#,#}             Awaiting time 30: Process waiting at t/t_timing_class.v:109
+-V{t#,#}             Awaiting time 40: Process waiting at t/t_timing_class.v:145
+-V{t#,#}             Awaiting time 50: Process waiting at t/t_timing_class.v:219
+-V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:223
+-V{t#,#}             Awaiting time 80: Process waiting at t/t_timing_class.v:228
 -V{t#,#}         Resuming delayed processes
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:220
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:228
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aForkDelayClass::new
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aForkDelayClass::_ctor_var_reset
--V{t#,#}             Process forked at t/t_timing_class.v:214 finished
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:215
+-V{t#,#}             Process forked at t/t_timing_class.v:222 finished
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:223
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aEventClass::__VnoInFunc_wake
 -V{t#,#}+    Vt_timing_debug2___024root___eval_act
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
@@ -146,38 +154,38 @@
 -V{t#,#}+    Vt_timing_debug2___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug2___024root___timing_resume
 -V{t#,#}         Ready processes waiting for @([event] t.ec.e):
--V{t#,#}           - Process waiting at t/t_timing_class.v:80
+-V{t#,#}           - Process waiting at t/t_timing_class.v:88
 -V{t#,#}         Resuming processes waiting for @([event] t.ec.e)
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:80
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:88
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aEventClass::__VnoInFunc_sleep
--V{t#,#}         Suspending process waiting for @([event] t::EventClass.e) at t/t_timing_class.v:29
+-V{t#,#}         Suspending process waiting for @([event] t::EventClass.e) at t/t_timing_class.v:37
 -V{t#,#}+    Vt_timing_debug2___024root___eval_act
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
 -V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
--V{t#,#}           - Process waiting at t/t_timing_class.v:29
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:29
--V{t#,#}         Process waiting for @([event] t::EventClass.e) at t/t_timing_class.v:29 awaiting the post update step
+-V{t#,#}           - Process waiting at t/t_timing_class.v:37
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:37
+-V{t#,#}         Process waiting for @([event] t::EventClass.e) at t/t_timing_class.v:37 awaiting the post update step
 -V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
 -V{t#,#}         No triggers active
 -V{t#,#}         Doing post updates for processes:
--V{t#,#}           - Process waiting at t/t_timing_class.v:29
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:29
--V{t#,#}         Suspending process waiting for @([event] t::EventClass.e) at t/t_timing_class.v:29
+-V{t#,#}           - Process waiting at t/t_timing_class.v:37
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:37
+-V{t#,#}         Suspending process waiting for @([event] t::EventClass.e) at t/t_timing_class.v:37
 -V{t#,#}+    Vt_timing_debug2___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug2___024root___eval_nba
 -V{t#,#}+      Vt_timing_debug2_t___nba_sequent__TOP__t__0
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aEventClass::__VnoInFunc_inc_trig_count
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
 -V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
--V{t#,#}           - Process waiting at t/t_timing_class.v:29
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:29
--V{t#,#}         Process waiting for @([event] t::EventClass.e) at t/t_timing_class.v:29 awaiting the post update step
+-V{t#,#}           - Process waiting at t/t_timing_class.v:37
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:37
+-V{t#,#}         Process waiting for @([event] t::EventClass.e) at t/t_timing_class.v:37 awaiting the post update step
 -V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
 -V{t#,#}         No triggers active
 -V{t#,#}         Doing post updates for processes:
--V{t#,#}           - Process waiting at t/t_timing_class.v:29
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:29
--V{t#,#}         Suspending process waiting for @([event] t::EventClass.e) at t/t_timing_class.v:29
+-V{t#,#}           - Process waiting at t/t_timing_class.v:37
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:37
+-V{t#,#}         Suspending process waiting for @([event] t::EventClass.e) at t/t_timing_class.v:37
 -V{t#,#}+    Vt_timing_debug2___024root___timing_commit
 -V{t#,#}End-of-eval cleanup
 -V{t#,#}+++++TOP Evaluate Vt_timing_debug2::eval_step
@@ -187,55 +195,55 @@
 -V{t#,#}+    Vt_timing_debug2___024root___eval
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
 -V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
--V{t#,#}           - Process waiting at t/t_timing_class.v:29
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:29
--V{t#,#}         Process waiting for @([event] t::EventClass.e) at t/t_timing_class.v:29 awaiting the post update step
+-V{t#,#}           - Process waiting at t/t_timing_class.v:37
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:37
+-V{t#,#}         Process waiting for @([event] t::EventClass.e) at t/t_timing_class.v:37 awaiting the post update step
 -V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
 -V{t#,#}         'act' region trigger index 1 is active: @([true] __VdlySched.awaitingCurrentTime())
 -V{t#,#}         Doing post updates for processes:
--V{t#,#}           - Process waiting at t/t_timing_class.v:29
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:29
--V{t#,#}         Suspending process waiting for @([event] t::EventClass.e) at t/t_timing_class.v:29
+-V{t#,#}           - Process waiting at t/t_timing_class.v:37
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:37
+-V{t#,#}         Suspending process waiting for @([event] t::EventClass.e) at t/t_timing_class.v:37
 -V{t#,#}+    Vt_timing_debug2___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug2___024root___timing_resume
 -V{t#,#}         Delayed processes:
--V{t#,#}             Awaiting time 30: Process waiting at t/t_timing_class.v:88
--V{t#,#}             Awaiting time 30: Process waiting at t/t_timing_class.v:89
--V{t#,#}             Awaiting time 50: Process waiting at t/t_timing_class.v:91
--V{t#,#}             Awaiting time 80: Process waiting at t/t_timing_class.v:101
--V{t#,#}             Awaiting time 40: Process waiting at t/t_timing_class.v:137
--V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:211
+-V{t#,#}             Awaiting time 30: Process waiting at t/t_timing_class.v:96
+-V{t#,#}             Awaiting time 30: Process waiting at t/t_timing_class.v:97
+-V{t#,#}             Awaiting time 50: Process waiting at t/t_timing_class.v:99
+-V{t#,#}             Awaiting time 80: Process waiting at t/t_timing_class.v:109
+-V{t#,#}             Awaiting time 40: Process waiting at t/t_timing_class.v:145
+-V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:219
 -V{t#,#}         Resuming delayed processes
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:211
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:219
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aDelay20::__VnoInFunc_do_sth_else
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aDelay40::__VnoInFunc_do_delay
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:139
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:147
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aForkDelayClass::__VnoInFunc_do_delay
 -V{t#,#}+    Vt_timing_debug2___024root___eval_act
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
 -V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
--V{t#,#}           - Process waiting at t/t_timing_class.v:29
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:29
--V{t#,#}         Process waiting for @([event] t::EventClass.e) at t/t_timing_class.v:29 awaiting the post update step
+-V{t#,#}           - Process waiting at t/t_timing_class.v:37
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:37
+-V{t#,#}         Process waiting for @([event] t::EventClass.e) at t/t_timing_class.v:37 awaiting the post update step
 -V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
 -V{t#,#}         No triggers active
 -V{t#,#}         Doing post updates for processes:
--V{t#,#}           - Process waiting at t/t_timing_class.v:29
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:29
--V{t#,#}         Suspending process waiting for @([event] t::EventClass.e) at t/t_timing_class.v:29
+-V{t#,#}           - Process waiting at t/t_timing_class.v:37
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:37
+-V{t#,#}         Suspending process waiting for @([event] t::EventClass.e) at t/t_timing_class.v:37
 -V{t#,#}+    Vt_timing_debug2___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug2___024root___eval_nba
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
 -V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
--V{t#,#}           - Process waiting at t/t_timing_class.v:29
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:29
--V{t#,#}         Process waiting for @([event] t::EventClass.e) at t/t_timing_class.v:29 awaiting the post update step
+-V{t#,#}           - Process waiting at t/t_timing_class.v:37
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:37
+-V{t#,#}         Process waiting for @([event] t::EventClass.e) at t/t_timing_class.v:37 awaiting the post update step
 -V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
 -V{t#,#}         No triggers active
 -V{t#,#}         Doing post updates for processes:
--V{t#,#}           - Process waiting at t/t_timing_class.v:29
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:29
--V{t#,#}         Suspending process waiting for @([event] t::EventClass.e) at t/t_timing_class.v:29
+-V{t#,#}           - Process waiting at t/t_timing_class.v:37
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:37
+-V{t#,#}         Suspending process waiting for @([event] t::EventClass.e) at t/t_timing_class.v:37
 -V{t#,#}+    Vt_timing_debug2___024root___timing_commit
 -V{t#,#}End-of-eval cleanup
 -V{t#,#}+++++TOP Evaluate Vt_timing_debug2::eval_step
@@ -245,38 +253,38 @@
 -V{t#,#}+    Vt_timing_debug2___024root___eval
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
 -V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
--V{t#,#}           - Process waiting at t/t_timing_class.v:29
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:29
--V{t#,#}         Process waiting for @([event] t::EventClass.e) at t/t_timing_class.v:29 awaiting the post update step
+-V{t#,#}           - Process waiting at t/t_timing_class.v:37
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:37
+-V{t#,#}         Process waiting for @([event] t::EventClass.e) at t/t_timing_class.v:37 awaiting the post update step
 -V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
 -V{t#,#}         'act' region trigger index 1 is active: @([true] __VdlySched.awaitingCurrentTime())
 -V{t#,#}         Doing post updates for processes:
--V{t#,#}           - Process waiting at t/t_timing_class.v:29
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:29
--V{t#,#}         Suspending process waiting for @([event] t::EventClass.e) at t/t_timing_class.v:29
+-V{t#,#}           - Process waiting at t/t_timing_class.v:37
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:37
+-V{t#,#}         Suspending process waiting for @([event] t::EventClass.e) at t/t_timing_class.v:37
 -V{t#,#}+    Vt_timing_debug2___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug2___024root___timing_resume
 -V{t#,#}         Delayed processes:
--V{t#,#}             Awaiting time 40: Process waiting at t/t_timing_class.v:88
--V{t#,#}             Awaiting time 70: Process waiting at t/t_timing_class.v:89
--V{t#,#}             Awaiting time 50: Process waiting at t/t_timing_class.v:91
--V{t#,#}             Awaiting time 80: Process waiting at t/t_timing_class.v:101
--V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:137
--V{t#,#}             Awaiting time 70: Process waiting at t/t_timing_class.v:202
+-V{t#,#}             Awaiting time 40: Process waiting at t/t_timing_class.v:96
+-V{t#,#}             Awaiting time 70: Process waiting at t/t_timing_class.v:97
+-V{t#,#}             Awaiting time 50: Process waiting at t/t_timing_class.v:99
+-V{t#,#}             Awaiting time 80: Process waiting at t/t_timing_class.v:109
+-V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:145
+-V{t#,#}             Awaiting time 70: Process waiting at t/t_timing_class.v:210
 -V{t#,#}         Resuming delayed processes
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:202
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:210
 -V{t#,#}+    Vt_timing_debug2___024root___eval_act
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
 -V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
--V{t#,#}           - Process waiting at t/t_timing_class.v:29
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:29
--V{t#,#}         Process waiting for @([event] t::EventClass.e) at t/t_timing_class.v:29 awaiting the post update step
+-V{t#,#}           - Process waiting at t/t_timing_class.v:37
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:37
+-V{t#,#}         Process waiting for @([event] t::EventClass.e) at t/t_timing_class.v:37 awaiting the post update step
 -V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
 -V{t#,#}         'act' region trigger index 0 is active: @([event] t.ec.e)
 -V{t#,#}         Doing post updates for processes:
--V{t#,#}           - Process waiting at t/t_timing_class.v:29
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:29
--V{t#,#}         Process waiting for @([event] t::EventClass.e) at t/t_timing_class.v:29 awaiting resumption
+-V{t#,#}           - Process waiting at t/t_timing_class.v:37
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:37
+-V{t#,#}         Process waiting for @([event] t::EventClass.e) at t/t_timing_class.v:37 awaiting resumption
 -V{t#,#}+    Vt_timing_debug2___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug2___024root___timing_resume
 -V{t#,#}         No ready processes waiting for @([event] t.ec.e)
@@ -289,17 +297,17 @@
 -V{t#,#}+    Vt_timing_debug2___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug2___024root___timing_resume
 -V{t#,#}         Resuming processes:
--V{t#,#}           - Process waiting at t/t_timing_class.v:29
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:29
+-V{t#,#}           - Process waiting at t/t_timing_class.v:37
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:37
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aEventClass::__VnoInFunc_inc_trig_count
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aWaitClass::__VnoInFunc_await
--V{t#,#}         Suspending process waiting for @([true] ((32'sh4 == t::WaitClass.a) & (32'sh10 < t::WaitClass.b))) at t/t_timing_class.v:50
+-V{t#,#}         Suspending process waiting for @([true] ((32'sh4 == t::WaitClass.a) & (32'sh10 < t::WaitClass.b))) at t/t_timing_class.v:58
 -V{t#,#}+    Vt_timing_debug2___024root___eval_act
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
 -V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
--V{t#,#}           - Process waiting at t/t_timing_class.v:50
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:50
--V{t#,#}         Suspending process waiting for @([true] ((32'sh4 == t::WaitClass.a) & (32'sh10 < t::WaitClass.b))) at t/t_timing_class.v:50
+-V{t#,#}           - Process waiting at t/t_timing_class.v:58
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:58
+-V{t#,#}         Suspending process waiting for @([true] ((32'sh4 == t::WaitClass.a) & (32'sh10 < t::WaitClass.b))) at t/t_timing_class.v:58
 -V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
 -V{t#,#}         No triggers active
 -V{t#,#}+    Vt_timing_debug2___024root___timing_commit
@@ -308,9 +316,9 @@
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aEventClass::__VnoInFunc_inc_trig_count
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
 -V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
--V{t#,#}           - Process waiting at t/t_timing_class.v:50
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:50
--V{t#,#}         Suspending process waiting for @([true] ((32'sh4 == t::WaitClass.a) & (32'sh10 < t::WaitClass.b))) at t/t_timing_class.v:50
+-V{t#,#}           - Process waiting at t/t_timing_class.v:58
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:58
+-V{t#,#}         Suspending process waiting for @([true] ((32'sh4 == t::WaitClass.a) & (32'sh10 < t::WaitClass.b))) at t/t_timing_class.v:58
 -V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
 -V{t#,#}         No triggers active
 -V{t#,#}+    Vt_timing_debug2___024root___timing_commit
@@ -322,36 +330,36 @@
 -V{t#,#}+    Vt_timing_debug2___024root___eval
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
 -V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
--V{t#,#}           - Process waiting at t/t_timing_class.v:50
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:50
--V{t#,#}         Suspending process waiting for @([true] ((32'sh4 == t::WaitClass.a) & (32'sh10 < t::WaitClass.b))) at t/t_timing_class.v:50
+-V{t#,#}           - Process waiting at t/t_timing_class.v:58
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:58
+-V{t#,#}         Suspending process waiting for @([true] ((32'sh4 == t::WaitClass.a) & (32'sh10 < t::WaitClass.b))) at t/t_timing_class.v:58
 -V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
 -V{t#,#}         'act' region trigger index 1 is active: @([true] __VdlySched.awaitingCurrentTime())
 -V{t#,#}+    Vt_timing_debug2___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug2___024root___timing_resume
 -V{t#,#}         Delayed processes:
--V{t#,#}             Awaiting time 50: Process waiting at t/t_timing_class.v:88
--V{t#,#}             Awaiting time 70: Process waiting at t/t_timing_class.v:89
--V{t#,#}             Awaiting time 70: Process waiting at t/t_timing_class.v:91
--V{t#,#}             Awaiting time 80: Process waiting at t/t_timing_class.v:101
--V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:137
+-V{t#,#}             Awaiting time 50: Process waiting at t/t_timing_class.v:96
+-V{t#,#}             Awaiting time 70: Process waiting at t/t_timing_class.v:97
+-V{t#,#}             Awaiting time 70: Process waiting at t/t_timing_class.v:99
+-V{t#,#}             Awaiting time 80: Process waiting at t/t_timing_class.v:109
+-V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:145
 -V{t#,#}         Resuming delayed processes
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:137
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:145
 -V{t#,#}+    Vt_timing_debug2___024root___eval_act
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
 -V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
--V{t#,#}           - Process waiting at t/t_timing_class.v:50
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:50
--V{t#,#}         Suspending process waiting for @([true] ((32'sh4 == t::WaitClass.a) & (32'sh10 < t::WaitClass.b))) at t/t_timing_class.v:50
+-V{t#,#}           - Process waiting at t/t_timing_class.v:58
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:58
+-V{t#,#}         Suspending process waiting for @([true] ((32'sh4 == t::WaitClass.a) & (32'sh10 < t::WaitClass.b))) at t/t_timing_class.v:58
 -V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
 -V{t#,#}         No triggers active
 -V{t#,#}+    Vt_timing_debug2___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug2___024root___eval_nba
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
 -V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
--V{t#,#}           - Process waiting at t/t_timing_class.v:50
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:50
--V{t#,#}         Suspending process waiting for @([true] ((32'sh4 == t::WaitClass.a) & (32'sh10 < t::WaitClass.b))) at t/t_timing_class.v:50
+-V{t#,#}           - Process waiting at t/t_timing_class.v:58
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:58
+-V{t#,#}         Suspending process waiting for @([true] ((32'sh4 == t::WaitClass.a) & (32'sh10 < t::WaitClass.b))) at t/t_timing_class.v:58
 -V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
 -V{t#,#}         No triggers active
 -V{t#,#}+    Vt_timing_debug2___024root___timing_commit
@@ -363,54 +371,54 @@
 -V{t#,#}+    Vt_timing_debug2___024root___eval
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
 -V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
--V{t#,#}           - Process waiting at t/t_timing_class.v:50
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:50
--V{t#,#}         Suspending process waiting for @([true] ((32'sh4 == t::WaitClass.a) & (32'sh10 < t::WaitClass.b))) at t/t_timing_class.v:50
+-V{t#,#}           - Process waiting at t/t_timing_class.v:58
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:58
+-V{t#,#}         Suspending process waiting for @([true] ((32'sh4 == t::WaitClass.a) & (32'sh10 < t::WaitClass.b))) at t/t_timing_class.v:58
 -V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
 -V{t#,#}         'act' region trigger index 1 is active: @([true] __VdlySched.awaitingCurrentTime())
 -V{t#,#}+    Vt_timing_debug2___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug2___024root___timing_resume
 -V{t#,#}         Delayed processes:
--V{t#,#}             Awaiting time 60: Process waiting at t/t_timing_class.v:88
--V{t#,#}             Awaiting time 70: Process waiting at t/t_timing_class.v:89
--V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:91
--V{t#,#}             Awaiting time 80: Process waiting at t/t_timing_class.v:101
--V{t#,#}             Awaiting time 70: Process waiting at t/t_timing_class.v:92
+-V{t#,#}             Awaiting time 60: Process waiting at t/t_timing_class.v:96
+-V{t#,#}             Awaiting time 70: Process waiting at t/t_timing_class.v:97
+-V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:99
+-V{t#,#}             Awaiting time 80: Process waiting at t/t_timing_class.v:109
+-V{t#,#}             Awaiting time 70: Process waiting at t/t_timing_class.v:100
 -V{t#,#}         Resuming delayed processes
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:92
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:100
 -V{t#,#}+    Vt_timing_debug2___024root___eval_act
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
 -V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
--V{t#,#}           - Process waiting at t/t_timing_class.v:50
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:50
--V{t#,#}         Process waiting for @([true] ((32'sh4 == t::WaitClass.a) & (32'sh10 < t::WaitClass.b))) at t/t_timing_class.v:50 awaiting resumption
+-V{t#,#}           - Process waiting at t/t_timing_class.v:58
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:58
+-V{t#,#}         Process waiting for @([true] ((32'sh4 == t::WaitClass.a) & (32'sh10 < t::WaitClass.b))) at t/t_timing_class.v:58 awaiting resumption
 -V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
 -V{t#,#}         'act' region trigger index 2 is active: @([true] __VdynSched.evaluate())
 -V{t#,#}+    Vt_timing_debug2___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug2___024root___timing_resume
 -V{t#,#}         Resuming processes:
--V{t#,#}           - Process waiting at t/t_timing_class.v:50
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:50
+-V{t#,#}           - Process waiting at t/t_timing_class.v:58
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:58
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aLocalWaitClass::__VnoInFunc_await
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aLocalWaitClass::__Vfork_h########__0__0
--V{t#,#}         Suspending process waiting for @([true] ((32'sh2a == t::LocalWaitClass.a) | (32'sh64 != t::LocalWaitClass.b))) at t/t_timing_class.v:67
+-V{t#,#}         Suspending process waiting for @([true] ((32'sh2a == t::LocalWaitClass.a) | (32'sh64 != t::LocalWaitClass.b))) at t/t_timing_class.v:75
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aLocalWaitClass::__Vfork_h########__0__1
--V{t#,#}             Awaiting join of fork at: t/t_timing_class.v:66
+-V{t#,#}             Awaiting join of fork at: t/t_timing_class.v:74
 -V{t#,#}+    Vt_timing_debug2___024root___eval_act
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
 -V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
--V{t#,#}           - Process waiting at t/t_timing_class.v:67
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:67
--V{t#,#}         Suspending process waiting for @([true] ((32'sh2a == t::LocalWaitClass.a) | (32'sh64 != t::LocalWaitClass.b))) at t/t_timing_class.v:67
+-V{t#,#}           - Process waiting at t/t_timing_class.v:75
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:75
+-V{t#,#}         Suspending process waiting for @([true] ((32'sh2a == t::LocalWaitClass.a) | (32'sh64 != t::LocalWaitClass.b))) at t/t_timing_class.v:75
 -V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
 -V{t#,#}         No triggers active
 -V{t#,#}+    Vt_timing_debug2___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug2___024root___eval_nba
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
 -V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
--V{t#,#}           - Process waiting at t/t_timing_class.v:67
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:67
--V{t#,#}         Suspending process waiting for @([true] ((32'sh2a == t::LocalWaitClass.a) | (32'sh64 != t::LocalWaitClass.b))) at t/t_timing_class.v:67
+-V{t#,#}           - Process waiting at t/t_timing_class.v:75
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:75
+-V{t#,#}         Suspending process waiting for @([true] ((32'sh2a == t::LocalWaitClass.a) | (32'sh64 != t::LocalWaitClass.b))) at t/t_timing_class.v:75
 -V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
 -V{t#,#}         No triggers active
 -V{t#,#}+    Vt_timing_debug2___024root___timing_commit
@@ -422,45 +430,45 @@
 -V{t#,#}+    Vt_timing_debug2___024root___eval
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
 -V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
--V{t#,#}           - Process waiting at t/t_timing_class.v:67
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:67
--V{t#,#}         Suspending process waiting for @([true] ((32'sh2a == t::LocalWaitClass.a) | (32'sh64 != t::LocalWaitClass.b))) at t/t_timing_class.v:67
+-V{t#,#}           - Process waiting at t/t_timing_class.v:75
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:75
+-V{t#,#}         Suspending process waiting for @([true] ((32'sh2a == t::LocalWaitClass.a) | (32'sh64 != t::LocalWaitClass.b))) at t/t_timing_class.v:75
 -V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
 -V{t#,#}         'act' region trigger index 1 is active: @([true] __VdlySched.awaitingCurrentTime())
 -V{t#,#}+    Vt_timing_debug2___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug2___024root___timing_resume
 -V{t#,#}         Delayed processes:
--V{t#,#}             Awaiting time 70: Process waiting at t/t_timing_class.v:88
--V{t#,#}             Awaiting time 70: Process waiting at t/t_timing_class.v:89
--V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:91
--V{t#,#}             Awaiting time 80: Process waiting at t/t_timing_class.v:101
--V{t#,#}             Awaiting time 70: Process waiting at t/t_timing_class.v:68
+-V{t#,#}             Awaiting time 70: Process waiting at t/t_timing_class.v:96
+-V{t#,#}             Awaiting time 70: Process waiting at t/t_timing_class.v:97
+-V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:99
+-V{t#,#}             Awaiting time 80: Process waiting at t/t_timing_class.v:109
+-V{t#,#}             Awaiting time 70: Process waiting at t/t_timing_class.v:76
 -V{t#,#}         Resuming delayed processes
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:68
--V{t#,#}             Process forked at t/t_timing_class.v:219 finished
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:76
+-V{t#,#}             Process forked at t/t_timing_class.v:227 finished
 -V{t#,#}             Resuming: Process waiting at (null):0
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:101
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:109
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aDelay40::__VnoInFunc_do_sth_else
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aNoDelay::__VnoInFunc_do_delay
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aNoDelay::__VnoInFunc_do_sth_else
 -V{t#,#}+      Vt_timing_debug2_t____Vfork_h########__0__0
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aAssignDelayClass::__VnoInFunc_do_assign
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:154
--V{t#,#}             Process forked at t/t_timing_class.v:68 finished
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:162
+-V{t#,#}             Process forked at t/t_timing_class.v:76 finished
 -V{t#,#}+    Vt_timing_debug2___024root___eval_act
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
 -V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
--V{t#,#}           - Process waiting at t/t_timing_class.v:67
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:67
--V{t#,#}         Process waiting for @([true] ((32'sh2a == t::LocalWaitClass.a) | (32'sh64 != t::LocalWaitClass.b))) at t/t_timing_class.v:67 awaiting resumption
+-V{t#,#}           - Process waiting at t/t_timing_class.v:75
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:75
+-V{t#,#}         Process waiting for @([true] ((32'sh2a == t::LocalWaitClass.a) | (32'sh64 != t::LocalWaitClass.b))) at t/t_timing_class.v:75 awaiting resumption
 -V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
 -V{t#,#}         'act' region trigger index 2 is active: @([true] __VdynSched.evaluate())
 -V{t#,#}+    Vt_timing_debug2___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug2___024root___timing_resume
 -V{t#,#}         Resuming processes:
--V{t#,#}           - Process waiting at t/t_timing_class.v:67
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:67
--V{t#,#}             Process forked at t/t_timing_class.v:67 finished
+-V{t#,#}           - Process waiting at t/t_timing_class.v:75
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:75
+-V{t#,#}             Process forked at t/t_timing_class.v:75 finished
 -V{t#,#}             Resuming: Process waiting at (null):0
 -V{t#,#}+    Vt_timing_debug2___024root___eval_act
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
@@ -489,12 +497,12 @@
 -V{t#,#}+    Vt_timing_debug2___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug2___024root___timing_resume
 -V{t#,#}         Delayed processes:
--V{t#,#}             Awaiting time 75: Process waiting at t/t_timing_class.v:88
--V{t#,#}             Awaiting time 80: Process waiting at t/t_timing_class.v:89
--V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:91
--V{t#,#}             Awaiting time 80: Process waiting at t/t_timing_class.v:188
+-V{t#,#}             Awaiting time 75: Process waiting at t/t_timing_class.v:96
+-V{t#,#}             Awaiting time 80: Process waiting at t/t_timing_class.v:97
+-V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:99
+-V{t#,#}             Awaiting time 80: Process waiting at t/t_timing_class.v:196
 -V{t#,#}         Resuming delayed processes
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:188
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:196
 -V{t#,#}+    Vt_timing_debug2___024root___eval_act
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
 -V{t#,#}         No suspended processes waiting for dynamic trigger evaluation
@@ -520,12 +528,12 @@
 -V{t#,#}+    Vt_timing_debug2___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug2___024root___timing_resume
 -V{t#,#}         Delayed processes:
--V{t#,#}             Awaiting time 80: Process waiting at t/t_timing_class.v:88
--V{t#,#}             Awaiting time 80: Process waiting at t/t_timing_class.v:89
--V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:91
+-V{t#,#}             Awaiting time 80: Process waiting at t/t_timing_class.v:96
+-V{t#,#}             Awaiting time 80: Process waiting at t/t_timing_class.v:97
+-V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:99
 -V{t#,#}         Resuming delayed processes
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:91
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:89
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:99
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:97
 -V{t#,#}+      Vt_timing_debug2_t____Vfork_h########__0__0
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aAssignDelayClass::__VnoInFunc_do_assign
 -V{t#,#}+    Vt_timing_debug2___024root___eval_act
@@ -553,11 +561,11 @@
 -V{t#,#}+    Vt_timing_debug2___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug2___024root___timing_resume
 -V{t#,#}         Delayed processes:
--V{t#,#}             Awaiting time 85: Process waiting at t/t_timing_class.v:88
--V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:154
--V{t#,#}             Awaiting time 90: Process waiting at t/t_timing_class.v:194
+-V{t#,#}             Awaiting time 85: Process waiting at t/t_timing_class.v:96
+-V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:162
+-V{t#,#}             Awaiting time 90: Process waiting at t/t_timing_class.v:202
 -V{t#,#}         Resuming delayed processes
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:194
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:202
 -V{t#,#}+    Vt_timing_debug2___024root___eval_act
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
 -V{t#,#}         No suspended processes waiting for dynamic trigger evaluation
@@ -583,11 +591,11 @@
 -V{t#,#}+    Vt_timing_debug2___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug2___024root___timing_resume
 -V{t#,#}         Delayed processes:
--V{t#,#}             Awaiting time 90: Process waiting at t/t_timing_class.v:88
--V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:154
--V{t#,#}             Awaiting time 100: Process waiting at t/t_timing_class.v:195
+-V{t#,#}             Awaiting time 90: Process waiting at t/t_timing_class.v:96
+-V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:162
+-V{t#,#}             Awaiting time 100: Process waiting at t/t_timing_class.v:203
 -V{t#,#}         Resuming delayed processes
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:195
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:203
 -V{t#,#}+    Vt_timing_debug2___024root___eval_act
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
 -V{t#,#}         No suspended processes waiting for dynamic trigger evaluation
@@ -614,10 +622,10 @@
 -V{t#,#}+    Vt_timing_debug2___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug2___024root___timing_resume
 -V{t#,#}         Delayed processes:
--V{t#,#}             Awaiting time 100: Process waiting at t/t_timing_class.v:88
--V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:154
+-V{t#,#}             Awaiting time 100: Process waiting at t/t_timing_class.v:96
+-V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:162
 -V{t#,#}         Resuming delayed processes
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:154
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:162
 *-* All Finished *-*
 -V{t#,#}+    Vt_timing_debug2___024root___eval_act
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
@@ -642,5 +650,8 @@
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aNoDelay::~
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aDelayClass::~
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aLocalWaitClass::~
+-V{t#,#}+          Vt_timing_debug2___024unit__03a__03aBaseClass::~
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aWaitClass::~
+-V{t#,#}+          Vt_timing_debug2___024unit__03a__03aBaseClass::~
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aEventClass::~
+-V{t#,#}+          Vt_timing_debug2___024unit__03a__03aBaseClass::~


### PR DESCRIPTION
This patch fixes two cases where methods in base classes were not being marked as coroutines, even though they were being overridden by coroutines.
- One case is the class member cache not getting refreshed for searched classes.
- The other is when the overriding methods are not declared as `virtual`. In that case, the `isVirtual()` getter on such a method returns false, which led to `V3Timing` skipping the step of searching for overridden methods.

Fixes #4120.