### PR TITLE
Don't link AstRefDType if it has parameterized class ref (#4164)

### DIFF
--- a/src/V3LinkDot.cpp
+++ b/src/V3LinkDot.cpp
@@ -3424,6 +3424,12 @@ private:
         if (nodep->user3SetOnce()) return;
         if (AstNode* const cpackagep = nodep->classOrPackageOpp()) {
             if (AstClassOrPackageRef* const cpackagerefp = VN_CAST(cpackagep, ClassOrPackageRef)) {
+                if (cpackagerefp->paramsp()) {
+                    // Unable to link before the instantiation of parameter classes.
+                    // The class reference node has to be visited to properly link parameters.
+                    iterate(cpackagep);
+                    return;
+                }
                 nodep->classOrPackagep(cpackagerefp->classOrPackagep());
                 if (!VN_IS(nodep->classOrPackagep(), Class)
                     && !VN_IS(nodep->classOrPackagep(), Package)) {

--- a/test_regress/t/t_class_param_func_return.pl
+++ b/test_regress/t/t_class_param_func_return.pl
@@ -1,0 +1,21 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2022 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_class_param_func_return.v
+++ b/test_regress/t/t_class_param_func_return.v
@@ -1,0 +1,45 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2023 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+class Foo #(type T=int);
+   typedef Foo default_type;
+   typedef Foo#(T) this_type;
+
+   T x;
+
+   function default_type get_default();
+      default_type o = new;
+      return o;
+   endfunction
+
+   function this_type get_this();
+      this_type o = new;
+      return o;
+   endfunction
+endclass
+
+module t (/*AUTOARG*/);
+
+   Foo f_def1, f_def2;
+   Foo#(bit) f_bit1, f_bit2;
+   initial begin
+      f_def1 = new;
+      f_bit1 = new;
+
+      f_def2 = f_def1.get_default();
+      if ($bits(f_def2.x) != 32) $stop;
+      f_def2 = f_def1.get_this();
+      if ($bits(f_def2.x) != 32) $stop;
+
+      f_def2 = f_bit1.get_default();
+      if ($bits(f_def2.x) != 32) $stop;
+      f_bit2 = f_bit1.get_this();
+      if ($bits(f_bit2.x) != 1) $stop;
+
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end
+endmodule

--- a/test_regress/t/t_class_typedef.v
+++ b/test_regress/t/t_class_typedef.v
@@ -4,18 +4,41 @@
 // any use, without warranty, 2020 by Wilson Snyder.
 // SPDX-License-Identifier: CC0-1.0
 
-// Parse check
 class uvm_resource_types;
    typedef int rsrc_q_t;
 endclass
+
 class uvm_resource_pool;
    uvm_resource_types::rsrc_q_t rtab [string];
+endclass
 
-   uvm_resource_types#(1,2,3)::rsrc_q_t rtab_paramed [string];
+virtual class C#(parameter type T = logic, parameter SIZE = 1);
+    typedef logic [SIZE-1:0] t_vector;
+    typedef T t_array [SIZE-1:0];
+    typedef struct {
+        t_vector m0 [2*SIZE-1:0];
+        t_array m1;
+    } t_struct;
 endclass
 
 module t (/*AUTOARG*/);
    initial begin
+      uvm_resource_pool pool = new;
+      typedef logic [7:0] t_t0;
+      C#(t_t0,3)::t_vector v0;
+      C#(t_t0,3)::t_array a0;
+      C#(bit,4)::t_struct s0;
+
+      pool.rtab["a"] = 1;
+      if ($bits(pool.rtab["a"]) != 32) $stop;
+
+      if ($bits(v0) != 3) $stop;
+      if ($size(a0) != 3) $stop;
+      if ($bits(a0[0]) != 8) $stop;
+      if ($size(s0.m0) != 8) $stop;
+      if ($size(s0.m1) != 4) $stop;
+      if ($bits(s0.m1[2]) != 1) $stop;
+
       $write("*-* All Finished *-*\n");
       $finish;
    end


### PR DESCRIPTION
It (partially) fixes references to typedefs declared in parameterized classes. It also fixes https://github.com/verilator/verilator/issues/4164.
The problem still occurs if we have a reference to a typedef declared in a parameterized class, but we don't provide parameters in this reference.

I removed this line from a test `uvm_resource_types#(1,2,3)::rsrc_q_t rtab_paramed [string];`, because it was incorrect. That class is not a parameterized class.