### PR TITLE
Use unchanged copy of parameterized class for instantation

### DIFF
--- a/src/V3Param.cpp
+++ b/src/V3Param.cpp
@@ -221,7 +221,7 @@ public:
 //######################################################################
 // Remove parameters from cells and build new modules
 
-class ParamProcessor final {
+class ParamProcessor final : public VNDeleter {
     // NODE STATE - Local
     //   AstVar::user4()        // int    Global parameter number (for naming new module)
     //                          //        (0=not processed, 1=iterated, but no number,
@@ -830,6 +830,9 @@ class ParamProcessor final {
             // user2p will also be used to check if the default instance is used.
             if (!srcModpr->user2p() && VN_IS(srcModpr, Class)) {
                 AstClass* classCopyp = VN_AS(srcModpr, Class)->cloneTree(false);
+                // It is a temporary copy of the original class node, stored in order to create
+                // another instances. It is needed only during class instantiation.
+                pushDeletep(classCopyp);
                 srcModpr->user2p(classCopyp);
                 storeOriginalParams(classCopyp);
             }
@@ -1409,8 +1412,6 @@ public:
                     // Referenced. classp became a specialized class with the default
                     // values of parameters and is not a parameterized class anymore
                     classp->isParameterized(false);
-                    // The copy is no longer needed.
-                    VL_DO_DANGLING(pushDeletep(classp->user2p()), classp);
                 }
             }
         }

--- a/test_regress/t/t_class_param_extends2.pl
+++ b/test_regress/t/t_class_param_extends2.pl
@@ -1,0 +1,21 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2022 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_class_param_extends2.v
+++ b/test_regress/t/t_class_param_extends2.v
@@ -1,0 +1,38 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2023 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+class Foo #(type T=bit);
+   int x = $bits(T);
+endclass
+
+class Bar #(type S=int) extends Foo#(S);
+endclass
+
+typedef Bar#() bar_default_t;
+
+class Baz;
+   Bar#(logic[7:0]) bar_string;
+   int bar_x;
+   function new;
+      bar_string = new;
+      bar_x = bar_string.x;
+   endfunction
+endclass
+
+typedef Baz baz_t;
+
+module t;
+   initial begin
+      bar_default_t bar_default = new;
+      baz_t baz = new;
+
+      if (bar_default.x != 32) $stop;
+      if (baz.bar_x != 8) $stop;
+
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end
+endmodule


### PR DESCRIPTION
Currently a node of a parameterized class represents also the default instance of that class. Sometimes such a node is edited during elaboration in V3Param and if another instance of that class is created, the copied body may be already changed.
Here are the ASTs of instances of the `Bar` class defined in the test I added. They were dumped using the current master.
```
    1:2: CLASS 0x5555570d4480 <e706> {d5ab}  Bar  L4 [1ps] [EXT]
    1:2:2: PARAMTYPEDTYPE 0x555557087180 <e1220#> {d5as} @dt=0x5555570c9e10@(sw32)  S -> BASICDTYPE 0x5555570c9e10 <e1219#> {d5au} @dt=this@
(sw32)  int kwd=int range=[31:0]
    1:2:2: FUNC 0x5555570cda00 <e1116> {d5ab} @dt=0@  new [METHOD]
    1:2:4: CLASSEXTENDS 0x5555570cac60 <e704> {d5bh} @dt=0@
    1:2:4:1: CLASSREFDTYPE 0x5555570d8dd0 <e1125> {d5ab} @dt=this@(w0)class:Foo__Tz1  Foo__Tz1 cpkg=0x5555570d4f00 -> CLASS 0x5555570d4f00 <e1222#> {d1ab}  Foo__Tz1  L5 [1ps] [EXT]


    1:2: CLASS 0x5555570d5200 <e1236#> {d5ab}  Bar__Tz2  L5 [1ps] [EXT]
    1:2:2: PARAMTYPEDTYPE 0x5555570877a0 <e1220#> {d5as} @dt=0x5555570c9e10@(sw32)  S -> BASICDTYPE 0x5555570c9e10 <e1219#> {d5au} @dt=this@(sw32)  int kwd=int range=[31:0]
    1:2:2:1: BASICDTYPE 0x5555570d9380 <e1237#> {d11aj} @dt=this@(w8)  logic kwd=logic range=[7:0]
    1:2:2: FUNC 0x5555570cdc00 <e1116> {d5ab} @dt=0@  new [METHOD]
    1:2:4: CLASSEXTENDS 0x5555570cbc30 <e704> {d5bh} @dt=0@
    1:2:4:1: CLASSREFDTYPE 0x5555570d92b0 <e1125> {d5ab} @dt=this@(w0)class:Foo__Tz1  Foo__Tz1 
```
There are 2 problems with them:
* parameter S of Bar__Tz2 has the same dtypep as the parameter in the instance Bar, so it's wrong. The parameter in Bar__Tz2 has also a child dtypep, which throws error in V3Broken.
* Both instances extend the same class, but Bar__Tz2 should extend a different one.

This PR fixes it. When the default instance of a class is used, a copy is stored and it is used as the original class if another instance is created.