### PR TITLE
Fix hashes of instances of parameterized classes

### DIFF
--- a/src/V3Hasher.cpp
+++ b/src/V3Hasher.cpp
@@ -307,7 +307,7 @@ private:
     }
     void visit(AstNodeModule* nodep) override {
         m_hash += hashNodeAndIterate(nodep, HASH_DTYPE, false, [=]() {  //
-            m_hash += nodep->origName();
+            m_hash += nodep->name();
         });
     }
     void visit(AstNodePreSel* nodep) override {

--- a/test_regress/t/t_class_param_typedef.pl
+++ b/test_regress/t/t_class_param_typedef.pl
@@ -1,0 +1,21 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2022 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_class_param_typedef.v
+++ b/test_regress/t/t_class_param_typedef.v
@@ -1,0 +1,47 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2023 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+class Foo #(type T=int);
+   typedef Foo#(T) this_type;
+   function int get_x;
+      return T::get_s_x();
+   endfunction
+endclass
+
+class Bar #(type S=int);
+   typedef Bar #(S) this_type;
+   typedef Foo#(this_type) foo_type;
+   function int get_x;
+      foo_type f = new;
+      return f.get_x();
+   endfunction
+   static function int get_s_x;
+      return S::x;
+   endfunction
+endclass
+
+class Cls1;
+   static int x = 1;
+   typedef Bar#(Cls1) type_id;
+endclass
+
+class Cls2;
+   static int x = 2;
+   typedef Bar#(Cls2) type_id;
+endclass
+
+module t;
+   initial begin
+      Cls1::type_id bar1 = new;
+      Cls2::type_id bar2 = new;
+
+      if (bar1.get_x() != 1) $stop;
+      if (bar2.get_x() != 2) $stop;
+
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end
+endmodule


### PR DESCRIPTION
Currently on master, all specializations of parameterized class have the same hash. 
Hashes are used in V3Param (not only, but the problem I found is related to this stage) to check if the requested instance already exists. If two nodes have the same hash, but have different names, the map entry is overwritten: https://github.com/verilator/verilator/blob/befb415f278af51fc3ecc3dda1dfe820de023bd1/src/V3Param.cpp#L358
Due to this problem, Verilator creates another class instances instead of taking the ones that already exists. If a class has a parameterized self reference to itself, Verilator creates class instances until maximum `--module-recursion-depth` is exceeded.

This PR fixes it. It also adds throwing an error in case of a hash collision.