### PR TITLE
V3Common.cpp::makeVlToString: fix `VL_TOSTRING_W` statement generation (#4188)

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -14,7 +14,7 @@ Ameya Vikram Singh
 Andreas Kuster
 Andrew Nolte
 Arkadiusz Kozdra
-Aylon Porat
+Aylon Chaim Porat
 Cameron Kirk
 Chris Randall
 Chuxuan Wang

--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -14,6 +14,7 @@ Ameya Vikram Singh
 Andreas Kuster
 Andrew Nolte
 Arkadiusz Kozdra
+Aylon Porat
 Cameron Kirk
 Chris Randall
 Chuxuan Wang

--- a/src/V3Common.cpp
+++ b/src/V3Common.cpp
@@ -82,11 +82,13 @@ static void makeVlToString(AstNodeUOrStructDType* nodep) {
         }
         stmt += VIdProtect::protect(itemp->prettyName()) + ":\" + ";
         if (VN_IS(itemp->dtypep()->skipRefp(), BasicDType) && itemp->isWide()) {
-            stmt += "VL_TO_STRING_W";
+            stmt += "VL_TO_STRING_W(";
+            stmt += cvtToStr(itemp->widthWords());
+            stmt += ", ";
         } else {
-            stmt += "VL_TO_STRING";
+            stmt += "VL_TO_STRING(";
         }
-        stmt += "(obj." + itemp->nameProtect() + ");\n";
+        stmt += "obj." + itemp->nameProtect() + ");\n";
         funcp->addStmtsp(new AstCStmt{nodep->fileline(), stmt});
     }
     funcp->addStmtsp(new AstCStmt{nodep->fileline(), "out += \"}\";\n"});

--- a/test_regress/t/t_trace_wide_struct.pl
+++ b/test_regress/t/t_trace_wide_struct.pl
@@ -1,0 +1,16 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2003 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile (verilator_flags2 => ['--trace --trace-structs'],);
+
+ok(1);
+1;

--- a/test_regress/t/t_trace_wide_struct.v
+++ b/test_regress/t/t_trace_wide_struct.v
@@ -1,0 +1,23 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2011 by Wilson Snyder.
+// SPDX-License-Identifier: CC0-1.0
+
+module t (/*AUTOARG*/
+   // Inputs
+   clk
+   );
+   input clk;
+
+   typedef struct {
+       logic [64:0] long_signal;
+   } mystruct_t;
+
+   mystruct_t mystruct;
+
+   initial begin
+       $finish;
+   end
+
+endmodule


### PR DESCRIPTION
add the inclusion of the missing width argument

This is a fix for #4188 

We appreciate your contributing to Verilator.  If this is your first commit, please add your name to docs/CONTRIBUTORS, and read our contributing guidelines in docs/CONTRIBUTING.rst.
