### PR TITLE
Fix unbalanced V3LockGuard locking

### DIFF
--- a/include/verilated.cpp
+++ b/include/verilated.cpp
@@ -3228,7 +3228,7 @@ void VerilatedAssertOneThread::fatal_different() VL_MT_SAFE {
 //===========================================================================
 // VlDeleter:: Methods
 
-void VlDeleter::deleteAll() {
+void VlDeleter::deleteAll() VL_EXCLUDES(m_mutex) VL_EXCLUDES(m_deleteMutex) VL_MT_SAFE {
     while (true) {
         {
             VerilatedLockGuard lock{m_mutex};

--- a/include/verilated.h
+++ b/include/verilated.h
@@ -214,26 +214,6 @@ class VL_SCOPED_CAPABILITY VerilatedLockGuard final {
 private:
     VerilatedMutex& m_mutexr;
 
-    // lock() and unlock() are private to avoid mistakes related to manual unlocking and locking of
-    // the LockGuard object. Double unlock is an undefined behavior, so if the mutex is unlocked
-    // and not locked again, it will be unlocked the second time in destructor. If you really need
-    // to manually (un)lock a mutex somewhere, do it directly on the mutex, probably also skipping
-    // use of the LockGuard altogether.
-
-    /// Lock the mutex
-    void lock() VL_ACQUIRE() VL_MT_SAFE { m_mutexr.lock(); }
-    /// Unlock the mutex
-    void unlock() VL_RELEASE() VL_MT_SAFE { m_mutexr.unlock(); }
-    /// Acquire/lock mutex and check for stop request.
-    /// It tries to lock the mutex and if it fails, it check if stop request was send.
-    /// It returns after locking mutex.
-    /// This function should be extracted to V3ThreadPool, but due to clang thread-safety
-    /// limitations it needs to be placed here.
-    void lockCheckStopRequest(std::function<void()> checkStopRequestFunction)
-        VL_ACQUIRE() VL_MT_SAFE {
-        m_mutexr.lockCheckStopRequest(checkStopRequestFunction);
-    }
-
 public:
     /// Construct and hold given mutex lock until destruction or unlock()
     explicit VerilatedLockGuard(VerilatedMutex& mutexr) VL_ACQUIRE(mutexr) VL_MT_SAFE

--- a/include/verilated_threads.h
+++ b/include/verilated_threads.h
@@ -173,7 +173,7 @@ public:
         VerilatedLockGuard lock{m_mutex};
         while (m_ready.empty()) {
             m_waiting = true;
-            m_cv.wait(lock);
+            m_cv.wait(m_mutex);
         }
         m_waiting = false;
         // As noted above this is inefficient if our ready list is ever

--- a/include/verilated_trace.h
+++ b/include/verilated_trace.h
@@ -75,7 +75,7 @@ public:
     // Get an element from the front of the queue. Blocks if none available
     T get() VL_MT_SAFE_EXCLUDES(m_mutex) {
         VerilatedLockGuard lock{m_mutex};
-        m_cv.wait(lock, [this]() VL_REQUIRES(m_mutex) { return !m_queue.empty(); });
+        m_cv.wait(m_mutex, [this]() VL_REQUIRES(m_mutex) { return !m_queue.empty(); });
         assert(!m_queue.empty());
         T value = m_queue.front();
         m_queue.pop_front();

--- a/include/verilated_trace_imp.h
+++ b/include/verilated_trace_imp.h
@@ -482,7 +482,7 @@ VL_ATTR_NOINLINE void VerilatedTrace<VL_SUB_T, VL_BUF_T>::ParallelWorkerData::wa
     // We have been spinning for a while, so yield the thread
     VerilatedLockGuard lock{m_mutex};
     m_waiting = true;
-    m_cv.wait(lock, [this] { return m_ready.load(std::memory_order_relaxed); });
+    m_cv.wait(m_mutex, [this] { return m_ready.load(std::memory_order_relaxed); });
     m_waiting = false;
 }
 

--- a/include/verilated_types.h
+++ b/include/verilated_types.h
@@ -1138,7 +1138,7 @@ public:
     }
 
     // Deletes all queued garbage objects.
-    void deleteAll() VL_MT_SAFE;
+    void deleteAll() VL_EXCLUDES(m_mutex) VL_EXCLUDES(m_deleteMutex) VL_MT_SAFE;
 };
 
 //===================================================================

--- a/src/V3Mutex.h
+++ b/src/V3Mutex.h
@@ -133,17 +133,6 @@ class VL_SCOPED_CAPABILITY V3LockGuardImp final {
 private:
     T& m_mutexr;
 
-    // lock() and unlock() are private to avoid mistakes related to manual unlocking and locking of
-    // the LockGuard object. Double unlock is an undefined behavior, so if the mutex is unlocked
-    // and not locked again, it will be unlocked the second time in destructor. If you really need
-    // to manually (un)lock a mutex somewhere, do it directly on the mutex, probably also skipping
-    // use of the LockGuard altogether.
-
-    /// Lock the mutex.
-    void lock() VL_ACQUIRE() VL_MT_SAFE { m_mutexr.lock(); }
-    /// Unlock the mutex.
-    void unlock() VL_RELEASE() VL_MT_SAFE { m_mutexr.unlock(); }
-
 public:
     /// Construct and hold given mutex lock until destruction or unlock()
     explicit V3LockGuardImp(T& mutexr) VL_ACQUIRE(mutexr) VL_MT_SAFE

--- a/src/V3ThreadPool.h
+++ b/src/V3ThreadPool.h
@@ -166,11 +166,10 @@ private:
     }
 
     // Waits until exclusive access job completes its job
-    void waitStopRequested(V3LockGuard& stoppedJobLock) VL_REQUIRES(m_stoppedJobsMutex);
+    void waitStopRequested() VL_REQUIRES(m_stoppedJobsMutex);
 
     // Waits until all other jobs are stopped
-    void waitOtherThreads(V3LockGuard& stoppedJobLock) VL_MT_SAFE_EXCLUDES(m_mutex)
-        VL_REQUIRES(m_stoppedJobsMutex);
+    void waitOtherThreads() VL_MT_SAFE_EXCLUDES(m_mutex) VL_REQUIRES(m_stoppedJobsMutex);
 
     template <typename T>
     void pushJob(std::shared_ptr<std::promise<T>>& prom, std::function<T()>&& f) VL_MT_SAFE;

--- a/src/V3ThreadPool.h
+++ b/src/V3ThreadPool.h
@@ -67,9 +67,10 @@ class V3ThreadPool final {
     // CONSTRUCTORS
     V3ThreadPool() = default;
     ~V3ThreadPool() {
-        V3LockGuard lock{m_mutex};
-        m_queue = {};  // make sure queue is empty
-        lock.unlock();
+        {
+            V3LockGuard lock{m_mutex};
+            m_queue = {};  // make sure queue is empty
+        }
         resize(0);
     }
 
@@ -82,7 +83,7 @@ public:
     }
 
     // Resize thread pool to n workers (queue must be empty)
-    void resize(unsigned n) VL_MT_UNSAFE;
+    void resize(unsigned n) VL_MT_UNSAFE VL_EXCLUDES(m_mutex) VL_EXCLUDES(m_stoppedJobsMutex);
 
     // Enqueue a job for asynchronous execution
     // Due to missing support for lambda annotations in c++11,


### PR DESCRIPTION
There were a few cases where `unlock()` has been called on a lock guard without following with `lock()`. As a result, the lock guard's destructor called `unlock()` on already unlocked mutex. [Double unlock of a std::mutex is an undefined behavior](https://en.cppreference.com/w/cpp/thread/mutex/unlock). This has been fixed.
Additionally, the `lock()` and `unlock()` in V3LockGuard were made private to avoid such mistakes in the future.