### PR TITLE
Lock the same mutex reference as specified in VL_ACQUIRE.

### DIFF
--- a/include/verilated.h
+++ b/include/verilated.h
@@ -218,7 +218,7 @@ public:
     /// Construct and hold given mutex lock until destruction or unlock()
     explicit VerilatedLockGuard(VerilatedMutex& mutexr) VL_ACQUIRE(mutexr) VL_MT_SAFE
         : m_mutexr(mutexr) {  // Need () or GCC 4.8 false warning
-        m_mutexr.lock();
+        mutexr.lock();
     }
     /// Destruct and unlock the mutex
     ~VerilatedLockGuard() VL_RELEASE() { m_mutexr.unlock(); }

--- a/src/V3Mutex.h
+++ b/src/V3Mutex.h
@@ -137,7 +137,7 @@ public:
     /// Construct and hold given mutex lock until destruction or unlock()
     explicit V3LockGuardImp(T& mutexr) VL_ACQUIRE(mutexr) VL_MT_SAFE
         : m_mutexr(mutexr) {  // Need () or GCC 4.8 false warning
-        m_mutexr.lock();
+        mutexr.lock();
     }
     /// Destruct and unlock the mutex
     ~V3LockGuardImp() VL_RELEASE() { m_mutexr.unlock(); }


### PR DESCRIPTION
The lock guard's constructor should lock the same mutex as specified in `VL_ACQUIRE`. See [reference `MutexLocker`](https://clang.llvm.org/docs/ThreadSafetyAnalysis.html#mutex-h) in Clang's documentation.

This makes no difference in almost all cases, as the thread safety analysis ignores constructors. The problem surfaces when Clang is compiled with [code disabling checks in constructors](https://github.com/llvm/llvm-project/blob/39a0677784d1b53f2d6e33af2a53e915f3f62c86/clang/lib/Analysis/ThreadSafety.cpp#L2253-L2256) removed.