### PR TITLE
RFC: --lint-only with --no-timing/--timing conflicting priorities

### DIFF
--- a/test_regress/t/t_delay_stmtdly_bad.pl
+++ b/test_regress/t/t_delay_stmtdly_bad.pl
@@ -13,7 +13,7 @@ scenarios(vlt => 1);
 top_filename("t/t_delay.v");
 
 lint(
-    verilator_flags2 => ['--no-timing -Wall -Wno-DECLFILENAME'],
+    verilator_flags2 => ['-Wall -Wno-DECLFILENAME'],
     fails => 1,
     expect_filename => $Self->{golden_filename},
     );

--- a/test_regress/t/t_fork.pl
+++ b/test_regress/t/t_fork.pl
@@ -11,7 +11,6 @@ if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); di
 scenarios(vlt => 1);
 
 lint(
-    verilator_flags2 => ['--no-timing'],
     fails => 1,
     expect_filename => $Self->{golden_filename},
     );

--- a/test_regress/t/t_fork_bbox.pl
+++ b/test_regress/t/t_fork_bbox.pl
@@ -11,7 +11,7 @@ if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); di
 scenarios(vlt => 1);
 
 lint(
-    verilator_flags2 => ['--lint-only --no-timing --bbox-unsup'],
+    verilator_flags2 => ['--lint-only --bbox-unsup'],
     );
 
 ok(1);

--- a/test_regress/t/t_fork_disable.pl
+++ b/test_regress/t/t_fork_disable.pl
@@ -11,7 +11,7 @@ if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); di
 scenarios(linter => 1);
 
 lint(
-    verilator_flags2 => ['--lint-only --timing'],
+    verilator_flags2 => ['--lint-only'],
     fails => 1,
     expect_filename => $Self->{golden_filename},
     );

--- a/test_regress/t/t_gate_delay_unsup.pl
+++ b/test_regress/t/t_gate_delay_unsup.pl
@@ -13,7 +13,7 @@ scenarios(linter => 1);
 top_filename("t/t_gate_basic.v");
 
 lint(
-    verilator_flags2 => ["--lint-only -Wall -Wno-DECLFILENAME -Wno-UNUSED --timing"],
+    verilator_flags2 => ["--lint-only -Wall -Wno-DECLFILENAME -Wno-UNUSED"],
     fails => 1,
     expect_filename => $Self->{golden_filename},
     );

--- a/test_regress/t/t_net_delay.pl
+++ b/test_regress/t/t_net_delay.pl
@@ -11,7 +11,7 @@ if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); di
 scenarios(simulator => 1);
 
 lint(
-    verilator_flags2 => ['-Wall -Wno-DECLFILENAME --no-timing'],
+    verilator_flags2 => ['-Wall -Wno-DECLFILENAME'],
     fails => 1,
     expect_filename => $Self->{golden_filename},
     );

--- a/test_regress/t/t_timing_func_bad.pl
+++ b/test_regress/t/t_timing_func_bad.pl
@@ -13,7 +13,6 @@ scenarios(linter => 1);
 lint(
     fails => 1,
     expect_filename => $Self->{golden_filename},
-    verilator_flags2 => ['--no-timing'],
     );
 
 ok(1);

--- a/test_regress/t/t_timing_unset1_lint.out
+++ b/test_regress/t/t_timing_unset1_lint.out
@@ -1,0 +1,50 @@
+%Error-NEEDTIMINGOPT: t/t_notiming.v:12:8: Use --timing or --no-timing to specify how delays should be handled
+                                         : ... In instance t
+   12 |        #1
+      |        ^
+                      ... For error description see https://verilator.org/warn/NEEDTIMINGOPT?v=latest
+%Error-NEEDTIMINGOPT: t/t_notiming.v:13:8: Use --timing or --no-timing to specify how forks should be handled
+                                         : ... In instance t
+   13 |        fork @e; @e; join;
+      |        ^~~~
+%Error-NEEDTIMINGOPT: t/t_notiming.v:14:8: Use --timing or --no-timing to specify how event controls should be handled
+                                         : ... In instance t
+   14 |        @e
+      |        ^
+%Error-NEEDTIMINGOPT: t/t_notiming.v:15:8: Use --timing or --no-timing to specify how wait statements should be handled
+                                         : ... In instance t
+   15 |        wait(x == 4)
+      |        ^~~~
+%Error-NEEDTIMINGOPT: t/t_notiming.v:16:12: Use --timing or --no-timing to specify how timing controls should be handled
+                                          : ... In instance t
+   16 |        x = #1 8;
+      |            ^
+%Error-NEEDTIMINGOPT: t/t_notiming.v:19:8: Use --timing or --no-timing to specify how event controls should be handled
+                                         : ... In instance t
+   19 |        @e
+      |        ^
+%Error-NEEDTIMINGOPT: t/t_notiming.v:26:12: Use --timing or --no-timing to specify how delays should be handled
+                                          : ... In instance t
+   26 |    initial #1 ->e;
+      |            ^
+%Error-NEEDTIMINGOPT: t/t_notiming.v:27:12: Use --timing or --no-timing to specify how delays should be handled
+                                          : ... In instance t
+   27 |    initial #2 $stop;  
+      |            ^
+%Error-NEEDTIMINGOPT: t/t_notiming.v:33:10: Use --timing or --no-timing to specify how mailbox::put() should be handled
+                                          : ... In instance t
+   33 |        m.put(i);
+      |          ^~~
+%Error-NEEDTIMINGOPT: t/t_notiming.v:34:10: Use --timing or --no-timing to specify how mailbox::get() should be handled
+                                          : ... In instance t
+   34 |        m.get(i);
+      |          ^~~
+%Error-NEEDTIMINGOPT: t/t_notiming.v:35:10: Use --timing or --no-timing to specify how mailbox::peek() should be handled
+                                          : ... In instance t
+   35 |        m.peek(i);
+      |          ^~~~
+%Error-NEEDTIMINGOPT: t/t_notiming.v:36:10: Use --timing or --no-timing to specify how semaphore::get() should be handled
+                                          : ... In instance t
+   36 |        s.get();
+      |          ^~~
+%Error: Exiting due to

--- a/test_regress/t/t_timing_unset1_lint.pl
+++ b/test_regress/t/t_timing_unset1_lint.pl
@@ -1,0 +1,22 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2022 by Antmicro Ltd. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+top_filename("t/t_notiming.v");
+
+lint(
+    verilator_flags2 => ['-Wall -Wno-DECLFILENAME'],
+    # --timing/--no-timing not specified (lint only)
+    expect_filename => $Self->{golden_filename},
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_timing_unset2_lint.out
+++ b/test_regress/t/t_timing_unset2_lint.out
@@ -1,0 +1,26 @@
+%Error-NEEDTIMINGOPT: t/t_timing_off.v:25:8: Use --timing or --no-timing to specify how event controls should be handled
+                                           : ... In instance t
+   25 |        @e1;
+      |        ^
+                      ... For error description see https://verilator.org/warn/NEEDTIMINGOPT?v=latest
+%Error-NEEDTIMINGOPT: t/t_timing_off.v:33:12: Use --timing or --no-timing to specify how delays should be handled
+                                            : ... In instance t
+   33 |    initial #2 ->e1;
+      |            ^
+%Error-NEEDTIMINGOPT: t/t_timing_off.v:37:12: Use --timing or --no-timing to specify how delays should be handled
+                                            : ... In instance t
+   37 |    initial #3 $stop;  
+      |            ^
+%Error-NEEDTIMINGOPT: t/t_timing_off.v:38:12: Use --timing or --no-timing to specify how delays should be handled
+                                            : ... In instance t
+   38 |    initial #1 @(e1, e2) #1 $stop;  
+      |            ^
+%Error-NEEDTIMINGOPT: t/t_timing_off.v:38:15: Use --timing or --no-timing to specify how event controls should be handled
+                                            : ... In instance t
+   38 |    initial #1 @(e1, e2) #1 $stop;  
+      |               ^
+%Error-NEEDTIMINGOPT: t/t_timing_off.v:38:25: Use --timing or --no-timing to specify how delays should be handled
+                                            : ... In instance t
+   38 |    initial #1 @(e1, e2) #1 $stop;  
+      |                         ^
+%Error: Exiting due to

--- a/test_regress/t/t_timing_unset2_lint.pl
+++ b/test_regress/t/t_timing_unset2_lint.pl
@@ -1,0 +1,22 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2022 by Antmicro Ltd. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+top_filename("t/t_timing_off.v");
+
+lint(
+    verilator_flags2 => ['-Wall -Wno-DECLFILENAME'],
+    # --timing/--no-timing not specified (lint only)
+    expect_filename => $Self->{golden_filename},
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_timing_unset3_lint.out
+++ b/test_regress/t/t_timing_unset3_lint.out
@@ -1,0 +1,6 @@
+%Error-NEEDTIMINGOPT: t/t_clocking_notiming.v:11:8: Use --timing or --no-timing to specify how clocking output skew greater than #0 should be handled
+                                                  : ... In instance t
+   11 |        output #1 out;
+      |        ^~~~~~
+                      ... For error description see https://verilator.org/warn/NEEDTIMINGOPT?v=latest
+%Error: Exiting due to

--- a/test_regress/t/t_timing_unset3_lint.pl
+++ b/test_regress/t/t_timing_unset3_lint.pl
@@ -1,0 +1,22 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2022 by Antmicro Ltd. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+top_filename("t/t_clocking_notiming.v");
+
+lint(
+    verilator_flags2 => ['-Wall -Wno-DECLFILENAME'],
+    # --timing/--no-timing not specified (lint only)
+    expect_filename => $Self->{golden_filename},
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_wait.pl
+++ b/test_regress/t/t_wait.pl
@@ -11,7 +11,7 @@ if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); di
 scenarios(linter => 1);
 
 lint(
-    verilator_flags2 => ['--lint-only --no-timing'],
+    verilator_flags2 => ['--lint-only'],
     fails => 1,
     expect_filename => $Self->{golden_filename},
     );


### PR DESCRIPTION
Request For Comments before I work on fixing this matter.


**The Issue:**

Why is verilator concerned with timing options when used --lint-only ?  Concerning enough to exit with a non-zero exit status.

Timing is only of concern to simulation.
For the purposes of linting there are only these areas the linter should be concerned with:

  * Is the input verilog well formed and a valid syntax ?
  * Is it possible to detect a feature used in the verilog, that verilator does not support, or has a known concern with ?
  * Will the use of the feature causes verilator in codegen/compile mode cause a fatal error, because it does not support syntax or the verilog construct and does not ignore its presence.

At the very least the linter should not exit with a non-zero exit status due to the presence of timing directives in verilog code, but the caller did not provide any of the new timing options --no-timing/--timing.  This behaviour seems like over reach of the feature.

Maybe verilator should only warn the user, just once per file, where a timing construct is detected, but no option was provided to the linter on the command line.  At the moment this is a terminal failure, even through it is not a problem with the syntax of the verilog, no a problem for verilator to code-gen if provided the necessary options it now needs.
The priority focus for the linter is code syntax.



**The 2 Commits (are a DRAFT) to understand the nature of the use case:**

The file that are changed (already exist in the project) restore the original command line to the tests from before the Timing Support patch.
Instead of making them pass (without needing the new options), the author added the new options.

The primary focus of this issue would be to make these tests pass.
At this time  and while in draft status all these tests will fail.


This issue serves as an opportunity to explain why the existing behaviour is a better than the above.

Thanks for your input.