### PR TITLE
Mark AstDot as unresolved if one of its components is unresolved

### DIFF
--- a/test_regress/t/t_class_param_extends.v
+++ b/test_regress/t/t_class_param_extends.v
@@ -34,8 +34,10 @@ class Getter2;
 endclass
 
 class Foo #(type T=Getter1);
+   T foo_field;
    int x;
    function new(int y);
+      foo_field = new;
       x = y;
    endfunction
 endclass
@@ -49,6 +51,10 @@ class Bar #(type S=Getter2) extends Foo#(S);
 
    function int get_field_int;
       return field.get_int();
+   endfunction
+
+   function int get_foo_field_int;
+      return foo_field.get_int();
    endfunction
 endclass
 
@@ -81,6 +87,7 @@ module t (/*AUTOARG*/);
 
       if (b.x != 1) $stop;
       if (b.get_field_int() != 2) $stop;
+      if (b.get_foo_field_int() != 2) $stop;
 
       $write("*-* All Finished *-*\n");
       $finish;


### PR DESCRIPTION
It partially fixes handling of dot references, by setting `m_ds.m_unresolvedClass` to true if one of the components of a dot reference can't be resolved in the first pass of V3LinkDot.
Currently on master, if there is a method call `x.func()`, where x is unresolvable, the node that represents `x` part is removed:
https://github.com/verilator/verilator/blob/2ce7a348dfbc6f16eb744064b26a1e9184768a71/src/V3LinkDot.cpp#L2435-L2444
The error isn't thrown in that pass, but in the second pass we are left with `func()` node only, so the method call can't be linked properly.