### PR TITLE
Move suspendable detection to a separate visitor

### DIFF
--- a/docs/internals.rst
+++ b/docs/internals.rst
@@ -638,7 +638,22 @@ condition. See the `Timing Pass` section for more details.
 Timing Pass
 ~~~~~~~~~~~
 
-The visitor in ``V3Timing.cpp`` transforms each timing control into a ``co_await``.
+There are two visitors in ``V3Timing.cpp``.
+
+The first one, ``TimingSuspendableVisitor``, does not perform any AST
+transformations. It is responsible for marking processes and C++ functions that
+contain timing controls as suspendable. Processes that call suspendable
+functions are also marked as suspendable. Functions that call, are overridden
+by, or override suspendable functions are marked as suspendable as well.
+
+The visitor keeps a dependency graph of functions and processes to handle such
+cases. A function or process is dependent on a function if it calls it. A
+virtual class method is dependent on another class method if it calls it,
+overrides it, or is overriden by it.
+
+The second visitor in ``V3Timing.cpp``, ``TimingControlVisitor``, uses the
+information provided by ``TimingSuspendableVisitor`` and transforms each timing
+control into a ``co_await``.
 
 * event controls are turned into ``co_await`` on a trigger scheduler's
   ``trigger`` method. The awaited trigger scheduler is the one corresponding to
@@ -670,14 +685,9 @@ Each sub-statement of a ``fork`` is put in an ``AstBegin`` node for easier
 grouping. In a later step, each of these gets transformed into a new, separate
 function. See the `Forks` section for more detail.
 
-Processes that use awaits are marked as suspendable. Later, during ``V3Sched``,
-they are transformed into coroutines. Functions that use awaits get the return
-type of ``VlCoroutine``. This immediately makes them coroutines. Note that if a
-process calls a function that is a coroutine, the call gets wrapped in an
-await, which means the process itself will be marked as suspendable. A virtual
-function is a coroutine if any of its overriding or overridden functions are
-coroutines. The visitor keeps a dependency graph of functions and processes to
-handle such cases.
+Suspendable functions get the return type of ``VlCoroutine``, which makes them
+coroutines. Later, during ``V3Sched``, suspendable processes are also
+transformed into coroutines.
 
 Scheduling with timing
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/test_regress/t/t_semaphore_always.pl
+++ b/test_regress/t/t_semaphore_always.pl
@@ -1,0 +1,27 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2023 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+if (!$Self->have_coroutines) {
+    skip("No coroutine support");
+}
+else {
+    compile(
+        verilator_flags2 => ["--timing"],
+        );
+
+    execute(
+        check_finished => 1,
+        );
+}
+
+ok(1);
+1;

--- a/test_regress/t/t_semaphore_always.v
+++ b/test_regress/t/t_semaphore_always.v
@@ -1,0 +1,23 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2023 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+module t (/*AUTOARG*/
+   // Inputs
+   clk
+   );
+   input clk;
+   semaphore s = new;
+
+   initial begin
+      s.put();
+   end
+
+   always @(posedge clk) begin
+      s.get();
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end
+endmodule


### PR DESCRIPTION
Currently, `V3Timing.cpp` contains a single visitor that simultaneously detects which parts of the AST are suspendable and also modifies the AST to use more C++-like constructs. There are problems with this approach:
- It's hard to understand what's happening. People hate reading this code.
- It's bug prone, see #4169. There are still some bugs related to this when verilating UVM. At least one bug is easily reproducible on current `master` (see the test case added in this PR).

This patch makes the implementation of the detection and propagation of the suspendable property simpler and easier to read. More importantly, there are no more jumps around the AST with the `visit` functions, which in some cases could result in incorrect visitor context while in the `visit` function. See the added test, which would cause Verilator to segfault before this patch.

In testing, verilation performance was not shown to be affected by this change. Though there is a slight performance improvement from this patch, due to adding one more check before refreshing class member cache.
