### PR TITLE
Don't handle AstSelBit if the fromp() is unresolved

### DIFF
--- a/src/V3LinkDot.cpp
+++ b/src/V3LinkDot.cpp
@@ -2779,6 +2779,8 @@ private:
                     // may be true only in the first stage of linking.
                     // Mark that the Dot statement can't be resolved.
                     m_ds.m_unresolvedClass = true;
+                    // If the symbol was a scope name, it would be resolved.
+                    if (m_ds.m_dotPos == DP_SCOPE) m_ds.m_dotPos = DP_MEMBER;
                 } else {
                     // Cells/interfaces can't be implicit
                     const bool isCell = foundp ? VN_IS(foundp->nodep(), Cell) : false;
@@ -3173,6 +3175,11 @@ private:
     void visit(AstSelBit* nodep) override {
         if (nodep->user3SetOnce()) return;
         iterateAndNextNull(nodep->fromp());
+        if (m_ds.m_unresolvedClass) {
+            UASSERT_OBJ(m_ds.m_dotPos != DP_SCOPE, nodep,
+                        "Object of unresolved class on scope position in dotted reference");
+            return;
+        }
         if (m_ds.m_dotPos
             == DP_SCOPE) {  // Already under dot, so this is {modulepart} DOT {modulepart}
             UINFO(9, "  deferring until after a V3Param pass: " << nodep << endl);

--- a/test_regress/t/t_class_extends_param.v
+++ b/test_regress/t/t_class_extends_param.v
@@ -63,12 +63,23 @@ module t (/*AUTOARG*/
       endfunction
    endclass
 
+   class FooDict;
+      Foo q[int];
+   endclass
+
+   class ExtendFooDict#(type BASE=FooDict) extends BASE;
+      function int get_x_of_item(int i);
+         return q[i].x;
+      endfunction
+   endclass
+
    Bar #() bar_foo_i;
    Bar #(Baz) bar_baz_i;
    ExtendBar extend_bar_i;
    ExtendBar1 extend_bar1_i;
    ExtendBarBaz extend_bar_baz_i;
    ExtendExtendBar extend_extend_bar_i;
+   ExtendFooDict extend_foo_dict_i;
 
    initial begin
       bar_foo_i = new;
@@ -77,18 +88,26 @@ module t (/*AUTOARG*/
       extend_bar1_i = new;
       extend_bar_baz_i = new;
       extend_extend_bar_i = new;
-      if (bar_foo_i.get_x() == 1 && bar_foo_i.get_3() == 3 &&
-          bar_baz_i.get_x() == 2 && bar_baz_i.get_4() == 4 &&
-          extend_bar_i.get_x() == 1 && extend_bar_i.get_6() == 6 &&
-          extend_bar_i.get_x() == 1 && extend_bar_i.get_6() == 6 &&
-          extend_bar1_i.get_x() == 1 && extend_bar1_i.get_6() == 6 &&
-          extend_bar_baz_i.get_x() == 2 && extend_bar_baz_i.get_8() == 8 &&
-          extend_extend_bar_i.get_x() == 1 && extend_extend_bar_i.get_12() == 12) begin
-         $write("*-* All Finished *-*\n");
-         $finish;
-      end
-      else begin
-         $stop;
-      end
+      extend_foo_dict_i = new;
+      extend_foo_dict_i.q[1] = new;
+
+      if (bar_foo_i.get_x() != 1) $stop;
+      if (bar_foo_i.get_3() != 3) $stop;
+      if (bar_baz_i.get_x() != 2) $stop;
+      if (bar_baz_i.get_4() != 4) $stop;
+      if (extend_bar_i.get_x() != 1) $stop;
+      if (extend_bar_i.get_6() != 6) $stop;
+      if (extend_bar_i.get_x() != 1) $stop;
+      if (extend_bar_i.get_6() != 6) $stop;
+      if (extend_bar1_i.get_x() != 1) $stop;
+      if (extend_bar1_i.get_6() != 6) $stop;
+      if (extend_bar_baz_i.get_x() != 2) $stop;
+      if (extend_bar_baz_i.get_8() != 8) $stop;
+      if (extend_extend_bar_i.get_x() != 1) $stop;
+      if (extend_extend_bar_i.get_12() != 12) $stop;
+      if (extend_foo_dict_i.get_x_of_item(1) != 1) $stop;
+
+      $write("*-* All Finished *-*\n");
+      $finish;
    end
 endmodule


### PR DESCRIPTION
It fixes the handling of select operations on unresolved objects.
Currently on master, if we have a select operation on unresolved object in a dot reference, e. g `q[i].x;` from the test I added, it is converted to `AstCellArrayRef`.

The problem was caused by setting m_ds.m_dotPos to DP_SCOPE in AstDot* handling and then keeping this value if the reference is unresolvable. I think that if the symbol of AstParseRef* was a scope, it would be found. So if we didn't find a definition of a symbol and we are under a class with parameterized `extends`, the symbol means an object or a function, so I assign the next dot position, which is a member.