### PR TITLE
Add support for condition operator on class objects

### DIFF
--- a/src/V3Ast.h
+++ b/src/V3Ast.h
@@ -1817,6 +1817,7 @@ public:
 
     // ACCESSORS for specific types
     // Alas these can't be virtual or they break when passed a nullptr
+    inline bool isOfClassType() const;
     inline bool isZero() const;
     inline bool isOne() const;
     inline bool isNeqZero() const;

--- a/src/V3Ast.h
+++ b/src/V3Ast.h
@@ -1817,7 +1817,7 @@ public:
 
     // ACCESSORS for specific types
     // Alas these can't be virtual or they break when passed a nullptr
-    inline bool isOfClassType() const;
+    inline bool isClassHandleValue() const;
     inline bool isZero() const;
     inline bool isOne() const;
     inline bool isNeqZero() const;

--- a/src/V3AstInlines.h
+++ b/src/V3AstInlines.h
@@ -41,7 +41,7 @@ bool AstNode::isString() const VL_MT_STABLE {
 }
 bool AstNode::isSigned() const VL_MT_STABLE { return dtypep() && dtypep()->isSigned(); }
 
-bool AstNode::isOfClassType() const {
+bool AstNode::isClassHandleValue() const {
     return (VN_IS(this, Const) && VN_AS(this, Const)->num().isNull())
            || VN_IS(dtypep(), ClassRefDType);
 }

--- a/src/V3AstInlines.h
+++ b/src/V3AstInlines.h
@@ -41,6 +41,10 @@ bool AstNode::isString() const VL_MT_STABLE {
 }
 bool AstNode::isSigned() const VL_MT_STABLE { return dtypep() && dtypep()->isSigned(); }
 
+bool AstNode::isOfClassType() const {
+    return (VN_IS(this, Const) && VN_AS(this, Const)->num().isNull())
+           || VN_IS(dtypep(), ClassRefDType);
+}
 bool AstNode::isZero() const {
     return (VN_IS(this, Const) && VN_AS(this, Const)->num().isEqZero());
 }

--- a/src/V3Const.cpp
+++ b/src/V3Const.cpp
@@ -3405,9 +3405,9 @@ private:
     TREEOPS("AstCond {$lhsp.isNeqZero}",        "replaceWIteratedRhs(nodep)");
     TREEOP ("AstCond{$condp.castNot,       $thenp, $elsep}", "AstCond{$condp->castNot()->lhsp(), $elsep, $thenp}");
     TREEOP ("AstNodeCond{$condp.width1, $thenp.width1,   $thenp.isAllOnes, $elsep}", "AstLogOr {$condp, $elsep}");  // a?1:b == a||b
-    TREEOP ("AstNodeCond{$condp.width1, $thenp.width1,   $thenp,    $elsep.isZero, !$elsep.isOfClassType}", "AstLogAnd{$condp, $thenp}");  // a?b:0 == a&&b
+    TREEOP ("AstNodeCond{$condp.width1, $thenp.width1,   $thenp,    $elsep.isZero, !$elsep.isClassHandleValue}", "AstLogAnd{$condp, $thenp}");  // a?b:0 == a&&b
     TREEOP ("AstNodeCond{$condp.width1, $thenp.width1,   $thenp, $elsep.isAllOnes}", "AstLogOr {AstNot{$condp}, $thenp}");  // a?b:1 == ~a||b
-    TREEOP ("AstNodeCond{$condp.width1, $thenp.width1,   $thenp.isZero, !$thenp.isOfClassType,   $elsep}", "AstLogAnd{AstNot{$condp}, $elsep}");  // a?0:b == ~a&&b
+    TREEOP ("AstNodeCond{$condp.width1, $thenp.width1,   $thenp.isZero, !$thenp.isClassHandleValue,   $elsep}", "AstLogAnd{AstNot{$condp}, $elsep}");  // a?0:b == ~a&&b
     TREEOP ("AstNodeCond{!$condp.width1, operandBoolShift(nodep->condp())}", "replaceBoolShift(nodep->condp())");
     // Prefer constants on left, since that often needs a shift, it lets
     // constant red remove the shift

--- a/src/V3Const.cpp
+++ b/src/V3Const.cpp
@@ -3405,9 +3405,9 @@ private:
     TREEOPS("AstCond {$lhsp.isNeqZero}",        "replaceWIteratedRhs(nodep)");
     TREEOP ("AstCond{$condp.castNot,       $thenp, $elsep}", "AstCond{$condp->castNot()->lhsp(), $elsep, $thenp}");
     TREEOP ("AstNodeCond{$condp.width1, $thenp.width1,   $thenp.isAllOnes, $elsep}", "AstLogOr {$condp, $elsep}");  // a?1:b == a||b
-    TREEOP ("AstNodeCond{$condp.width1, $thenp.width1,   $thenp,    $elsep.isZero}", "AstLogAnd{$condp, $thenp}");  // a?b:0 == a&&b
+    TREEOP ("AstNodeCond{$condp.width1, $thenp.width1,   $thenp,    $elsep.isZero, !$elsep.isOfClassType}", "AstLogAnd{$condp, $thenp}");  // a?b:0 == a&&b
     TREEOP ("AstNodeCond{$condp.width1, $thenp.width1,   $thenp, $elsep.isAllOnes}", "AstLogOr {AstNot{$condp}, $thenp}");  // a?b:1 == ~a||b
-    TREEOP ("AstNodeCond{$condp.width1, $thenp.width1,   $thenp.isZero,    $elsep}", "AstLogAnd{AstNot{$condp}, $elsep}");  // a?0:b == ~a&&b
+    TREEOP ("AstNodeCond{$condp.width1, $thenp.width1,   $thenp.isZero, !$thenp.isOfClassType,   $elsep}", "AstLogAnd{AstNot{$condp}, $elsep}");  // a?0:b == ~a&&b
     TREEOP ("AstNodeCond{!$condp.width1, operandBoolShift(nodep->condp())}", "replaceBoolShift(nodep->condp())");
     // Prefer constants on left, since that often needs a shift, it lets
     // constant red remove the shift

--- a/src/V3EmitCFunc.h
+++ b/src/V3EmitCFunc.h
@@ -1059,9 +1059,33 @@ public:
             putbs("(");
             iterateAndNextConstNull(nodep->condp());
             putbs(" ? ");
+            // All class types are castable to each other. If they are of different types,
+            // a compilation error will be thrown, so an explicit cast is required. Types were
+            // already checked by V3Width and dtypep of a condition operator is a type of their
+            // common base class, so both classes can be safetly casted.
+            const AstClassRefDType* const thenClassDtypep
+                = VN_CAST(nodep->thenp()->dtypep(), ClassRefDType);
+            const AstClassRefDType* const elseClassDtypep
+                = VN_CAST(nodep->elsep()->dtypep(), ClassRefDType);
+            const bool castRequired = thenClassDtypep && elseClassDtypep
+                                      && (thenClassDtypep->classp() != elseClassDtypep->classp());
+            bool thenCastRequired = false;
+            bool elseCastRequired = false;
+            std::string castStr;
+            if (castRequired) {
+                const AstClass* const commonBaseClassp
+                    = VN_AS(nodep->dtypep(), ClassRefDType)->classp();
+                if (thenClassDtypep->classp() != commonBaseClassp) thenCastRequired = true;
+                if (elseClassDtypep->classp() != commonBaseClassp) elseCastRequired = true;
+                castStr = "static_cast<" + nodep->dtypep()->cType("", false, false) + ">(";
+            }
+            if (thenCastRequired) putbs(castStr);
             iterateAndNextConstNull(nodep->thenp());
+            if (thenCastRequired) putbs(")");
             putbs(" : ");
+            if (elseCastRequired) putbs(castStr);
             iterateAndNextConstNull(nodep->elsep());
+            if (elseCastRequired) putbs(")");
             puts(")");
         }
     }

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -508,9 +508,9 @@ private:
             if (thenDTypep->skipRefp() == elseDTypep->skipRefp()) {
                 // TODO might need a broader equation, use the Castable function?
                 nodep->dtypeFrom(thenDTypep);
-            } else if (nodep->thenp()->isOfClassType() || nodep->elsep()->isOfClassType()) {
+            } else if (nodep->thenp()->isClassHandleValue() || nodep->elsep()->isClassHandleValue()) {
                 AstNodeDType* commonClassTypep = nullptr;
-                if (nodep->thenp()->isOfClassType() && nodep->elsep()->isOfClassType()) {
+                if (nodep->thenp()->isClassHandleValue() && nodep->elsep()->isClassHandleValue()) {
                     // Get the most-deriving class type that both arguments can be casted to.
                     commonClassTypep
                         = getCommonClassTypep(nodep->thenp(), nodep->elsep(), nodep->fileline());
@@ -7329,10 +7329,11 @@ private:
     int getDepthOfClassHierarchyRec(const AstClass* const classp) {
         // Return the number of classes between the current class and its most base class
         // (inclusive)
-        if (!classp->extendsp())
+        if (!classp->extendsp()) {
             return 1;
-        else
+        } else {
             return 1 + getDepthOfClassHierarchyRec(classp->extendsp()->classp());
+        }
     }
     AstClass* getCommonBaseClass(AstClass* class1p, AstClass* class2p) {
         // Return the first common base class or nullptr if it doesn't exist.
@@ -7344,9 +7345,8 @@ private:
         }
         while (depth1 > depth2) {
             class1p = class1p->extendsp()->classp();
-            depth1--;
+            --depth1;
         }
-
         while (class1p != class2p) {
             class1p = class1p->extendsp() ? class1p->extendsp()->classp() : nullptr;
             class2p = class2p->extendsp() ? class2p->extendsp()->classp() : nullptr;
@@ -7361,7 +7361,7 @@ private:
         // If no common class type exists, return nullptr.
         if (VN_IS(nodep1, Const)) std::swap(nodep1, nodep2);
         if (AstConst* const constp = VN_CAST(nodep2, Const)) {
-            if (constp->num().isNull() && nodep1->isOfClassType()) {
+            if (constp->num().isNull() && nodep1->isClassHandleValue()) {
                 return nodep1->dtypep()->cloneTree(false);
             } else {
                 return nullptr;

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -503,9 +503,26 @@ private:
             //  the size of this subexpression only.
             // Second call (final()) m_vup->width() is probably the expression size, so
             //  the expression includes the size of the output too.
-            if (nodep->thenp()->dtypep()->skipRefp() == nodep->elsep()->dtypep()->skipRefp()) {
+            const AstNodeDType* const thenDTypep = nodep->thenp()->dtypep();
+            const AstNodeDType* const elseDTypep = nodep->elsep()->dtypep();
+            if (thenDTypep->skipRefp() == elseDTypep->skipRefp()) {
                 // TODO might need a broader equation, use the Castable function?
-                nodep->dtypeFrom(nodep->thenp()->dtypep());
+                nodep->dtypeFrom(thenDTypep);
+            } else if (nodep->thenp()->isOfClassType() || nodep->elsep()->isOfClassType()) {
+                AstNodeDType* commonClassTypep = nullptr;
+                if (nodep->thenp()->isOfClassType() && nodep->elsep()->isOfClassType()) {
+                    // Get the most-deriving class type that both arguments can be casted to.
+                    commonClassTypep
+                        = getCommonClassTypep(nodep->thenp(), nodep->elsep(), nodep->fileline());
+                }
+                if (commonClassTypep) {
+                    nodep->dtypep(commonClassTypep);
+                } else {
+                    nodep->v3error("Incompatible types of operands of condition operator: "
+                                   << thenDTypep->prettyTypeName() << " and "
+                                   << elseDTypep->prettyTypeName());
+                    nodep->dtypeFrom(thenDTypep);
+                }
             } else if (nodep->thenp()->isDouble() || nodep->elsep()->isDouble()) {
                 nodep->dtypeSetDouble();
             } else if (nodep->thenp()->isString() || nodep->elsep()->isString()) {
@@ -7308,6 +7325,63 @@ private:
         if (VN_IS(nodep, UnsizedArrayDType)) return true;
         if (nodep->subDTypep()) return hasOpenArrayIterateDType(nodep->subDTypep()->skipRefp());
         return false;
+    }
+    int getDepthOfClassHierarchyRec(const AstClass* const classp) {
+        // Return the number of classes between the current class and its most base class
+        // (inclusive)
+        if (!classp->extendsp())
+            return 1;
+        else
+            return 1 + getDepthOfClassHierarchyRec(classp->extendsp()->classp());
+    }
+    AstClass* getCommonBaseClass(AstClass* class1p, AstClass* class2p) {
+        // Return the first common base class or nullptr if it doesn't exist.
+        int depth1 = getDepthOfClassHierarchyRec(class1p);
+        int depth2 = getDepthOfClassHierarchyRec(class2p);
+        if (depth2 > depth1) {
+            std::swap(depth1, depth2);
+            std::swap(class1p, class2p);
+        }
+        while (depth1 > depth2) {
+            class1p = class1p->extendsp()->classp();
+            depth1--;
+        }
+
+        while (class1p != class2p) {
+            class1p = class1p->extendsp() ? class1p->extendsp()->classp() : nullptr;
+            class2p = class2p->extendsp() ? class2p->extendsp()->classp() : nullptr;
+        }
+        // Possibly nullptr if no common base class exists
+        return class1p;
+    }
+    AstNodeDType* getCommonClassTypep(AstNode* nodep1, AstNode* nodep2, FileLine* const fl) {
+        // Return the class type that both nodep1 and nodep2 are castable to.
+        // If both are null, return the type of null constant.
+        // If one is a class and one is null, return AstClassRefDType that points to that class.
+        // If no common class type exists, return nullptr.
+        if (VN_IS(nodep1, Const)) std::swap(nodep1, nodep2);
+        if (AstConst* const constp = VN_CAST(nodep2, Const)) {
+            if (constp->num().isNull() && nodep1->isOfClassType()) {
+                return nodep1->dtypep()->cloneTree(false);
+            } else {
+                return nullptr;
+            }
+        }
+        AstClass* class1p = nullptr;
+        AstClass* class2p = nullptr;
+        if (const AstClassRefDType* const classRefDtypep
+            = VN_CAST(nodep1->dtypep(), ClassRefDType)) {
+            class1p = classRefDtypep->classp();
+        }
+        if (const AstClassRefDType* const classRefDtypep
+            = VN_CAST(nodep2->dtypep(), ClassRefDType)) {
+            class2p = classRefDtypep->classp();
+        }
+        if (!class1p || !class2p) return nullptr;
+        if (AstClass* const commonBaseClassp = getCommonBaseClass(class1p, class2p)) {
+            return new AstClassRefDType{fl, commonBaseClassp, nullptr};
+        }
+        return nullptr;
     }
 
     //----------------------------------------------------------------------

--- a/test_regress/t/t_class_assign_cond.pl
+++ b/test_regress/t/t_class_assign_cond.pl
@@ -1,0 +1,21 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2022 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_class_assign_cond.v
+++ b/test_regress/t/t_class_assign_cond.v
@@ -1,0 +1,70 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed into the Public Domain, for any use,
+// without warranty, 2023 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+class Cls;
+   int f;
+   function new(int x);
+      f = x;
+   endfunction
+endclass
+
+class ExtendCls extends Cls;
+   function new(int x);
+      super.new(x);
+   endfunction
+endclass
+
+class AnotherExtendCls extends Cls;
+   function new(int x);
+      super.new(x);
+   endfunction
+endclass
+
+class ExtendExtendCls extends ExtendCls;
+   function new(int x);
+      super.new(x);
+   endfunction
+endclass
+
+module t (/*AUTOARG*/);
+   initial begin
+      Cls cls1 = null, cls2 = null;
+      ExtendCls ext_cls = null;
+      AnotherExtendCls an_ext_cls = null;
+      ExtendExtendCls ext_ext_cls = null;
+
+      cls1 = (cls1 == null) ? cls2 : cls1;
+      if (cls1 != null) $stop;
+
+      cls1 = new(1);
+      cls1 = (cls1 == null) ? cls2 : cls1;
+      if (cls1.f != 1) $stop;
+
+      cls1 = (cls1 != null) ? cls2 : cls1;
+      if (cls1 != null) $stop;
+
+      cls1 = new(1);
+      cls2 = new(2);
+      cls1 = (cls1 != null) ? cls2 : cls1;
+      if (cls1.f != 2) $stop;
+
+      cls1 = null;
+      cls1 = (ext_cls != null) ? ext_cls : cls2;
+      if (cls1.f != 2) $stop;
+
+      ext_cls = new(3);
+      cls1 = (ext_cls != null) ? ext_cls : cls2;
+      if (cls1.f != 3) $stop;
+
+      ext_ext_cls = new(4);
+      an_ext_cls = new(5);
+      cls1 = (ext_ext_cls.f != 4) ? ext_ext_cls : an_ext_cls;
+      if (cls1.f != 5) $stop;
+
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end
+endmodule

--- a/test_regress/t/t_class_assign_cond_bad.out
+++ b/test_regress/t/t_class_assign_cond_bad.out
@@ -1,0 +1,21 @@
+%Error: t/t_class_assign_cond_bad.v:22:25: Incompatible types of operands of condition operator: CLASSREFDTYPE 'Cls1' and CLASSREFDTYPE 'Cls2'
+                                         : ... In instance t
+   22 |       c1 = (c1 != null) ? c1 : c2;
+      |                         ^
+%Error: t/t_class_assign_cond_bad.v:23:10: Assign RHS expects a CLASSREFDTYPE 'Cls1', got CLASSREFDTYPE 'Cls2'
+                                         : ... In instance t
+   23 |       c1 = (c1 != null) ? c2 : c2;
+      |          ^
+%Error: t/t_class_assign_cond_bad.v:24:25: Incompatible types of operands of condition operator: BASICDTYPE 'logic' and CLASSREFDTYPE 'Cls2'
+                                         : ... In instance t
+   24 |       c2 = (c1 == null) ? 1'b1 : c2;
+      |                         ^
+%Error: t/t_class_assign_cond_bad.v:24:10: Assign RHS expects a CLASSREFDTYPE 'Cls2', got BASICDTYPE 'logic'
+                                         : ... In instance t
+   24 |       c2 = (c1 == null) ? 1'b1 : c2;
+      |          ^
+%Error: t/t_class_assign_cond_bad.v:25:29: Incompatible types of operands of condition operator: CLASSREFDTYPE 'ExtCls1' and CLASSREFDTYPE 'Cls1'
+                                         : ... In instance t
+   25 |       ext_c1 = (c1 == null) ? ext_c1 : c1;
+      |                             ^
+%Error: Exiting due to

--- a/test_regress/t/t_class_assign_cond_bad.pl
+++ b/test_regress/t/t_class_assign_cond_bad.pl
@@ -1,0 +1,19 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2022 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    fails => 1,
+    expect_filename => $Self->{golden_filename},
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_class_assign_cond_bad.v
+++ b/test_regress/t/t_class_assign_cond_bad.v
@@ -1,0 +1,27 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2023 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+class Cls1;
+endclass
+
+class Cls2;
+endclass
+
+class ExtCls1;
+endclass
+
+module t (/*AUTOARG*/);
+   Cls1 c1;
+   Cls2 c2;
+   ExtCls1 ext_c1;
+
+   initial begin
+      c1 = (c1 != null) ? c1 : c2;
+      c1 = (c1 != null) ? c2 : c2;
+      c2 = (c1 == null) ? 1'b1 : c2;
+      ext_c1 = (c1 == null) ? ext_c1 : c1;
+   end
+endmodule


### PR DESCRIPTION
It adds support for condition operator on class objects.
I added getting the type of the result of condition expression. I did it in the following way: if one of the operands is null and the other is null or a class object, the type of the expression is the type of the 2nd operand. If both operands are class objects, I look for their most-deriving common base class.
I also needed to disable the conversion of AstCond to logical expressions if the operands are of class types.
Then I noticed a problem with generated c++ code. Currently, all `VlClassRef` types are convertible to each other. If we have operands of different class types, gcc throws error that each type can be converted to the other. So I added casts to the type of the result of condition operator if they are needed.