### PR TITLE
V3Timing: Deep traversal of class inheritance

### DIFF
--- a/src/V3Timing.cpp
+++ b/src/V3Timing.cpp
@@ -152,16 +152,17 @@ private:
         if (m_classp->extendsp()) extends.push(m_classp->extendsp());
 
         while (!extends.empty()) {
-            auto* ext_list = extends.front();
+            AstClassExtends* ext_list = extends.front();
             extends.pop();
 
-            for (auto* cextp = ext_list; cextp; cextp = VN_AS(cextp->nextp(), ClassExtends)) {
+            for (AstClassExtends* cextp = ext_list; cextp;
+                 cextp = VN_AS(cextp->nextp(), ClassExtends)) {
                 // TODO: It is possible that a methods the same name in the base class is not
                 // actually overridden by our method. If this causes a problem, traverse to
                 // the root of the inheritance hierarchy and check if the original method is
                 // virtual or not.
                 if (!cextp->classp()->user1SetOnce()) cextp->classp()->repairCache();
-                if (auto* const overriddenp
+                if (AstCFunc* const overriddenp
                     = VN_CAST(cextp->classp()->findMember(nodep->name()), CFunc)) {
                     if (overriddenp->user2()) {  // If it's suspendable
                         nodep->user2(true);  // Then we are also suspendable
@@ -176,7 +177,7 @@ private:
                         new V3GraphEdge{&m_depGraph, overriddenVxp, vxp, 1};
                     }
                 } else {
-                    auto* more_extends = cextp->classp()->extendsp();
+                    AstClassExtends* more_extends = cextp->classp()->extendsp();
                     if (more_extends) extends.push(more_extends);
                 }
             }

--- a/test_regress/t/t_suspendable_deep.pl
+++ b/test_regress/t/t_suspendable_deep.pl
@@ -1,0 +1,18 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2023 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(vlt => 1);
+
+compile(
+    verilator_flags2 => ["--timing"],
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_suspendable_deep.v
+++ b/test_regress/t/t_suspendable_deep.v
@@ -1,0 +1,35 @@
+// DESCRIPTION: Verilator: Verilog Test module for specialized type default values
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2023 by Antmicro.
+// SPDX-License-Identifier: CC0-1.0
+
+`timescale 1ns/1ns
+
+event evt;
+
+class Baz;
+  virtual task do_something(); endtask
+endclass
+
+class Foo extends Baz;
+endclass
+
+class Bar extends Foo;
+  virtual task do_something();
+    @evt $display("Hello");
+  endtask
+endclass
+
+module top();
+  initial begin
+    Bar bar;
+    bar = new;
+
+    fork
+      #10 bar.do_something();
+      #20 $display("world!");
+      #10 ->evt;
+    join
+  end
+endmodule


### PR DESCRIPTION
When building the graph for suspendability/coroutine propagation, only a single layer of class inheritance is being checked. This means that if a suspendable method overrides a method that wasn't overriden by the class we inherit from directly, the suspendability won't be propagated to the overriden method.

This PR fixes this issue.