### PR TITLE
Fix class parameters of enum types

### DIFF
--- a/src/V3Param.cpp
+++ b/src/V3Param.cpp
@@ -307,7 +307,9 @@ class ParamProcessor final : public VNDeleter {
     }
 
     static string paramValueString(const AstNode* nodep) {
-        if (const AstRefDType* const refp = VN_CAST(nodep, RefDType)) { nodep = refp->skipRefp(); }
+        if (const AstRefDType* const refp = VN_CAST(nodep, RefDType)) {
+            nodep = refp->skipRefToEnump();
+        }
         string key = nodep->name();
         if (const AstIfaceRefDType* const ifrtp = VN_CAST(nodep, IfaceRefDType)) {
             if (ifrtp->cellp() && ifrtp->cellp()->modp()) {
@@ -344,7 +346,9 @@ class ParamProcessor final : public VNDeleter {
         // TODO: This parameter value number lookup via a constructed key string is not
         //       particularly robust for type parameters. We should really have a type
         //       equivalence predicate function.
-        if (const AstRefDType* const refp = VN_CAST(nodep, RefDType)) nodep = refp->skipRefp();
+        if (const AstRefDType* const refp = VN_CAST(nodep, RefDType)) {
+            nodep = refp->skipRefToEnump();
+        }
         const string paramStr = paramValueString(nodep);
         // cppcheck-has-bug-suppress unreadVariable
         V3Hash hash = V3Hasher::uncachedHash(nodep) + paramStr;

--- a/test_regress/t/t_class_param_enum.pl
+++ b/test_regress/t/t_class_param_enum.pl
@@ -1,0 +1,21 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2022 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_class_param_enum.v
+++ b/test_regress/t/t_class_param_enum.v
@@ -1,0 +1,25 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed into the Public Domain, for any use,
+// without warranty, 2023 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+typedef enum bit {A = 0, B = 1} enum_t;
+
+class Converter #(type T);
+   function int toInt(T t);
+      return int'(t);
+   endfunction
+endclass
+
+module t;
+   initial begin
+      Converter#(enum_t) conv1 = new;
+      Converter#(bit) conv2 = new;
+      if (conv1.toInt(A) != 0) $stop;
+      if (conv2.toInt(1) != 1) $stop;
+
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end
+endmodule

--- a/test_regress/t/t_class_param_enum_bad.out
+++ b/test_regress/t/t_class_param_enum_bad.out
@@ -1,0 +1,11 @@
+%Error: t/t_class_param_enum_bad.v:20:31: Assign RHS expects a CLASSREFDTYPE 'Converter__Tz2', got CLASSREFDTYPE 'Converter__Tz1'
+                                        : ... In instance t
+   20 |       Converter#(bit) conv2 = conv1;
+      |                               ^~~~~
+%Error-ENUMVALUE: t/t_class_param_enum_bad.v:21:19: Implicit conversion to enum 'T' from 'logic[31:0]' (IEEE 1800-2017 6.19.3)
+                                                  : ... In instance t
+                                                  : ... Suggest use enum's mnemonic, or static cast
+   21 |       conv1.toInt(0);
+      |                   ^
+                  ... For error description see https://verilator.org/warn/ENUMVALUE?v=latest
+%Error: Exiting due to

--- a/test_regress/t/t_class_param_enum_bad.pl
+++ b/test_regress/t/t_class_param_enum_bad.pl
@@ -1,0 +1,19 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2022 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    fails => 1,
+    expect_filename => $Self->{golden_filename},
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_class_param_enum_bad.v
+++ b/test_regress/t/t_class_param_enum_bad.v
@@ -1,0 +1,24 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2023 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+typedef enum bit {A = 0, B = 1} enum_t;
+
+class Converter #(type T);
+   function int toInt(T t);
+      return int'(t);
+   endfunction
+endclass
+
+module t;
+   initial begin
+      Converter#(enum_t) conv1 = new;
+      // enum types does not match with other types (sections 6.22.1 and 6.22.4 of IEEE Std 1800-2017)
+      // The assignment and the function call should throw an error.
+      Converter#(bit) conv2 = conv1;
+      conv1.toInt(0);
+      $stop;
+   end
+endmodule


### PR DESCRIPTION
Currently on master, if we have a class instance parameterized with enum type and a class instance parameterized with the type of the fields of that enum, these both instances will be of the same type after parameter instantiation. If the instance parameterized with the enum is processed first, the parameter will point to enum type. It will throw error about implicit conversion if non-enum value is passed to the method that expects an argument of type of the parameter.