### PR TITLE
Fix static methods with prototypes

### DIFF
--- a/src/V3LinkDot.cpp
+++ b/src/V3LinkDot.cpp
@@ -3246,7 +3246,16 @@ private:
         UINFO(5, "   " << nodep << endl);
         checkNoDot(nodep);
         if (nodep->isExternDef()) {
-            if (!m_curSymp->findIdFallback("extern " + nodep->name())) {
+            if (const VSymEnt* const foundp
+                = m_curSymp->findIdFallback("extern " + nodep->name())) {
+                const AstNodeFTask* const funcProtop = VN_AS(foundp->nodep(), NodeFTask);
+                // Copy specifiers.
+                // External definition cannot have any specifiers, so no value will be overwritten.
+                nodep->isHideLocal(funcProtop->isHideLocal());
+                nodep->isHideProtected(funcProtop->isHideProtected());
+                nodep->isVirtual(funcProtop->isVirtual());
+                nodep->lifetime(funcProtop->lifetime());
+            } else {
                 nodep->v3error("extern not found that declares " + nodep->prettyNameQ());
             }
         }

--- a/test_regress/t/t_class_extern.v
+++ b/test_regress/t/t_class_extern.v
@@ -9,6 +9,7 @@ class Cls;
    extern function int ext_f_np;
    extern function int ext_f_p();
    extern function int ext_f_i(int in);
+   extern static function int get_1();
    extern task ext_t_np;
    extern task ext_t_p();
    extern task ext_t_i(int in);
@@ -24,6 +25,10 @@ endfunction
 
 function int Cls::ext_f_i(int in);
    return in+1;
+endfunction
+
+function int Cls::get_1();
+   return 1;
 endfunction
 
 task Cls::ext_t_np();
@@ -46,5 +51,6 @@ module t (/*AUTOARG*/);
       if (c.ext_f_np() != 1) $stop;
       if (c.ext_f_p() != 2) $stop;
       if (c.ext_f_i(10) != 11) $stop;
+      if (Cls::get_1() != 1) $stop;
    end
 endmodule


### PR DESCRIPTION
Currently on master, `static` methods aren't marked as `static` if they are predeclared with `extern` keyword. They are verilated without errors, but the compilation fails.
This PR fixes it.

I thought that the errors about static access to non-static methods could be enabled again (https://github.com/verilator/verilator/issues/4077). Unfortunately, false errors are then still thrown on UVM. The problem partially occurs, because sometimes a node representing a call of a function is visited before a node representing the definition of that function and at that moment, the function isn't marked as `static` yet. When I tried to visit the definition of a function during linking its call, there were other problems with linking caused by wrong values of `m_ds` and `m_curSymp`. They can probably be resolved, but there are also other cases in which false errors are thrown. Maybe it is better to change the way of how the static access to non-static members is recognized.