### PR TITLE
Make mutex classes uncopyable.

### DIFF
--- a/include/verilated.h
+++ b/include/verilated.h
@@ -175,6 +175,7 @@ public:
     /// Construct mutex (without locking it)
     VerilatedMutex() = default;
     ~VerilatedMutex() = default;
+    VL_UNCOPYABLE(VerilatedMutex);
     const VerilatedMutex& operator!() const { return *this; }  // For -fthread_safety
     /// Acquire/lock mutex
     void lock() VL_ACQUIRE() VL_MT_SAFE {

--- a/src/V3Mutex.h
+++ b/src/V3Mutex.h
@@ -85,6 +85,7 @@ public:
     /// Construct mutex (without locking it)
     V3MutexImp() = default;
     ~V3MutexImp() = default;
+    VL_UNCOPYABLE(V3MutexImp);
     const V3MutexImp& operator!() const { return *this; }  // For -fthread_safety
     /// Acquire/lock mutex
     void lock() VL_ACQUIRE() VL_MT_SAFE {


### PR DESCRIPTION
std::mutex is already uncopyable, let's make it explicit in the Verilator itself.