### PR TITLE
Rework multithreading handling to separate by code units that use/never use it

### DIFF
--- a/src/Makefile_obj.in
+++ b/src/Makefile_obj.in
@@ -389,7 +389,7 @@ HEADER_CC_H := $(filter-out $(NON_STANDALONE_HEADERS), $(notdir $(wildcard $(src
 header_cc: $(addsuffix __header_cc.o, $(basename $(HEADER_CC_H)))
 
 %__header_cc.cpp: %.h
-	$(PYTHON3) $(srcdir)/../bin/verilator_includer $^ > $@
+	$(PYTHON3) $(srcdir)/../bin/verilator_includer -DVL_MT_DISABLED_CODE_UNIT=1 $^ > $@
 
 .SUFFIXES:
 

--- a/src/V3Active.cpp
+++ b/src/V3Active.cpp
@@ -26,6 +26,8 @@
 //
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3Active.h
+++ b/src/V3Active.h
@@ -20,13 +20,15 @@
 #include "config_build.h"
 #include "verilatedos.h"
 
+#include "V3ThreadSafety.h"
+
 class AstNetlist;
 
 //============================================================================
 
 class V3Active final {
 public:
-    static void activeAll(AstNetlist* nodep);
+    static void activeAll(AstNetlist* nodep) VL_MT_DISABLED;
 };
 
 #endif  // Guard

--- a/src/V3ActiveTop.cpp
+++ b/src/V3ActiveTop.cpp
@@ -23,6 +23,8 @@
 //
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3ActiveTop.h
+++ b/src/V3ActiveTop.h
@@ -20,13 +20,15 @@
 #include "config_build.h"
 #include "verilatedos.h"
 
+#include "V3ThreadSafety.h"
+
 class AstNetlist;
 
 //============================================================================
 
 class V3ActiveTop final {
 public:
-    static void activeTopAll(AstNetlist* nodep);
+    static void activeTopAll(AstNetlist* nodep) VL_MT_DISABLED;
 };
 
 #endif  // Guard

--- a/src/V3Assert.cpp
+++ b/src/V3Assert.cpp
@@ -14,6 +14,8 @@
 //
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3Assert.h
+++ b/src/V3Assert.h
@@ -21,12 +21,13 @@
 #include "verilatedos.h"
 
 #include "V3Ast.h"
+#include "V3ThreadSafety.h"
 
 //============================================================================
 
 class V3Assert final {
 public:
-    static void assertAll(AstNetlist* nodep);
+    static void assertAll(AstNetlist* nodep) VL_MT_DISABLED;
 };
 
 #endif  // Guard

--- a/src/V3AssertPre.cpp
+++ b/src/V3AssertPre.cpp
@@ -19,6 +19,8 @@
 //      Transform clocking blocks into imperative logic
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3AssertPre.h
+++ b/src/V3AssertPre.h
@@ -20,13 +20,15 @@
 #include "config_build.h"
 #include "verilatedos.h"
 
+#include "V3ThreadSafety.h"
+
 class AstNetlist;
 
 //============================================================================
 
 class V3AssertPre final {
 public:
-    static void assertPreAll(AstNetlist* nodep);
+    static void assertPreAll(AstNetlist* nodep) VL_MT_DISABLED;
 };
 
 #endif  // Guard

--- a/src/V3AstNodeOther.h
+++ b/src/V3AstNodeOther.h
@@ -1034,7 +1034,7 @@ class AstExecGraph final : public AstNode {
     const string m_name;  // Name of this AstExecGraph (for uniqueness at code generation)
 
 public:
-    explicit AstExecGraph(FileLine* fl, const string& name);
+    explicit AstExecGraph(FileLine* fl, const string& name) VL_MT_DISABLED;
     ASTGEN_MEMBERS_AstExecGraph;
     ~AstExecGraph() override;
     const char* broken() const override {

--- a/src/V3AstNodes.cpp
+++ b/src/V3AstNodes.cpp
@@ -357,10 +357,10 @@ AstNodeBiop* AstEqWild::newTyped(FileLine* fl, AstNodeExpr* lhsp, AstNodeExpr* r
     }
 }
 
-AstExecGraph::AstExecGraph(FileLine* fileline, const string& name)
-    : ASTGEN_SUPER_ExecGraph(fileline)
-    , m_depGraphp{new V3Graph}
-    , m_name{name} {}
+AstExecGraph::AstExecGraph(FileLine* fileline, const string& name) VL_MT_DISABLED
+    : ASTGEN_SUPER_ExecGraph(fileline),
+      m_depGraphp{new V3Graph},
+      m_name{name} {}
 
 AstExecGraph::~AstExecGraph() { VL_DO_DANGLING(delete m_depGraphp, m_depGraphp); }
 

--- a/src/V3Begin.cpp
+++ b/src/V3Begin.cpp
@@ -26,6 +26,8 @@
 //
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3Begin.h
+++ b/src/V3Begin.h
@@ -20,13 +20,15 @@
 #include "config_build.h"
 #include "verilatedos.h"
 
+#include "V3ThreadSafety.h"
+
 class AstNetlist;
 
 //============================================================================
 
 class V3Begin final {
 public:
-    static void debeginAll(AstNetlist* nodep);
+    static void debeginAll(AstNetlist* nodep) VL_MT_DISABLED;
 };
 
 #endif  // Guard

--- a/src/V3Branch.cpp
+++ b/src/V3Branch.cpp
@@ -23,6 +23,8 @@
 //
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3Branch.h
+++ b/src/V3Branch.h
@@ -20,6 +20,8 @@
 #include "config_build.h"
 #include "verilatedos.h"
 
+#include "V3ThreadSafety.h"
+
 class AstNetlist;
 
 //============================================================================
@@ -27,7 +29,7 @@ class AstNetlist;
 class V3Branch final {
 public:
     // CONSTRUCTORS
-    static void branchAll(AstNetlist* nodep);
+    static void branchAll(AstNetlist* nodep) VL_MT_DISABLED;
 };
 
 #endif  // Guard

--- a/src/V3CCtors.cpp
+++ b/src/V3CCtors.cpp
@@ -24,6 +24,8 @@
 //      This transformation honors outputSplitCFuncs.
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3CCtors.h
+++ b/src/V3CCtors.h
@@ -20,14 +20,16 @@
 #include "config_build.h"
 #include "verilatedos.h"
 
+#include "V3ThreadSafety.h"
+
 //============================================================================
 
 class V3CCtors final {
 public:
-    static void cctorsAll();
+    static void cctorsAll() VL_MT_DISABLED;
 
 private:
-    static void evalAsserts();
+    static void evalAsserts() VL_MT_DISABLED;
 };
 
 #endif  // Guard

--- a/src/V3CUse.cpp
+++ b/src/V3CUse.cpp
@@ -22,6 +22,8 @@
 //
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3CUse.h
+++ b/src/V3CUse.h
@@ -20,11 +20,13 @@
 #include "config_build.h"
 #include "verilatedos.h"
 
+#include "V3ThreadSafety.h"
+
 //============================================================================
 
 class V3CUse final {
 public:
-    static void cUseAll();
+    static void cUseAll() VL_MT_DISABLED;
 };
 
 #endif  // Guard

--- a/src/V3Case.cpp
+++ b/src/V3Case.cpp
@@ -34,6 +34,8 @@
 //
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3Case.h
+++ b/src/V3Case.h
@@ -20,6 +20,8 @@
 #include "config_build.h"
 #include "verilatedos.h"
 
+#include "V3ThreadSafety.h"
+
 class AstNetlist;
 class AstNodeCase;
 
@@ -27,8 +29,8 @@ class AstNodeCase;
 
 class V3Case final {
 public:
-    static void caseAll(AstNetlist* nodep);
-    static void caseLint(AstNodeCase* nodep);
+    static void caseAll(AstNetlist* nodep) VL_MT_DISABLED;
+    static void caseLint(AstNodeCase* nodep) VL_MT_DISABLED;
 };
 
 #endif  // Guard

--- a/src/V3Cast.cpp
+++ b/src/V3Cast.cpp
@@ -37,6 +37,8 @@
 //
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3Cast.h
+++ b/src/V3Cast.h
@@ -20,13 +20,15 @@
 #include "config_build.h"
 #include "verilatedos.h"
 
+#include "V3ThreadSafety.h"
+
 class AstNetlist;
 
 //============================================================================
 
 class V3Cast final {
 public:
-    static void castAll(AstNetlist* nodep);
+    static void castAll(AstNetlist* nodep) VL_MT_DISABLED;
 };
 
 #endif  // Guard

--- a/src/V3Class.cpp
+++ b/src/V3Class.cpp
@@ -20,6 +20,8 @@
 //
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3Class.h
+++ b/src/V3Class.h
@@ -20,13 +20,15 @@
 #include "config_build.h"
 #include "verilatedos.h"
 
+#include "V3ThreadSafety.h"
+
 class AstNetlist;
 
 //============================================================================
 
 class V3Class final {
 public:
-    static void classAll(AstNetlist* nodep);
+    static void classAll(AstNetlist* nodep) VL_MT_DISABLED;
 };
 
 #endif  // Guard

--- a/src/V3Clean.cpp
+++ b/src/V3Clean.cpp
@@ -23,6 +23,8 @@
 //
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3Clean.h
+++ b/src/V3Clean.h
@@ -20,13 +20,15 @@
 #include "config_build.h"
 #include "verilatedos.h"
 
+#include "V3ThreadSafety.h"
+
 class AstNetlist;
 
 //============================================================================
 
 class V3Clean final {
 public:
-    static void cleanAll(AstNetlist* nodep);
+    static void cleanAll(AstNetlist* nodep) VL_MT_DISABLED;
 };
 
 #endif  // Guard

--- a/src/V3Clock.cpp
+++ b/src/V3Clock.cpp
@@ -27,6 +27,8 @@
 //
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3Clock.h
+++ b/src/V3Clock.h
@@ -20,13 +20,15 @@
 #include "config_build.h"
 #include "verilatedos.h"
 
+#include "V3ThreadSafety.h"
+
 class AstNetlist;
 
 //============================================================================
 
 class V3Clock final {
 public:
-    static void clockAll(AstNetlist* nodep);
+    static void clockAll(AstNetlist* nodep) VL_MT_DISABLED;
 };
 
 #endif  // Guard

--- a/src/V3Combine.cpp
+++ b/src/V3Combine.cpp
@@ -19,6 +19,8 @@
 //      Also drop empty CFuncs
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3Combine.h
+++ b/src/V3Combine.h
@@ -20,13 +20,15 @@
 #include "config_build.h"
 #include "verilatedos.h"
 
+#include "V3ThreadSafety.h"
+
 class AstNetlist;
 
 //============================================================================
 
 class V3Combine final {
 public:
-    static void combineAll(AstNetlist* nodep);
+    static void combineAll(AstNetlist* nodep) VL_MT_DISABLED;
 };
 
 #endif  // Guard

--- a/src/V3Common.cpp
+++ b/src/V3Common.cpp
@@ -20,6 +20,8 @@
 //
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3Common.h
+++ b/src/V3Common.h
@@ -20,11 +20,13 @@
 #include "config_build.h"
 #include "verilatedos.h"
 
+#include "V3ThreadSafety.h"
+
 //============================================================================
 
 class V3Common final {
 public:
-    static void commonAll();
+    static void commonAll() VL_MT_DISABLED;
 };
 
 #endif  // Guard

--- a/src/V3Const.cpp
+++ b/src/V3Const.cpp
@@ -20,6 +20,8 @@
 //          If operands are constant, replace this node with constant.
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3Const.h
+++ b/src/V3Const.h
@@ -21,43 +21,44 @@
 #include "verilatedos.h"
 
 #include "V3Ast.h"
+#include "V3ThreadSafety.h"
 
 //============================================================================
 
 class V3Const final {
 public:
-    static AstNode* constifyParamsEdit(AstNode* nodep);
-    static AstNodeExpr* constifyParamsEdit(AstNodeExpr* exprp) {
+    static AstNode* constifyParamsEdit(AstNode* nodep) VL_MT_DISABLED;
+    static AstNodeExpr* constifyParamsEdit(AstNodeExpr* exprp) VL_MT_DISABLED {
         return VN_AS(constifyParamsEdit(static_cast<AstNode*>(exprp)), NodeExpr);
     }
-    static AstNode* constifyParamsNoWarnEdit(AstNode* nodep);
-    static AstNodeExpr* constifyParamsNoWarnEdit(AstNodeExpr* exprp) {
+    static AstNode* constifyParamsNoWarnEdit(AstNode* nodep) VL_MT_DISABLED;
+    static AstNodeExpr* constifyParamsNoWarnEdit(AstNodeExpr* exprp) VL_MT_DISABLED {
         return VN_AS(constifyParamsNoWarnEdit(static_cast<AstNode*>(exprp)), NodeExpr);
     }
-    static AstNode* constifyGenerateParamsEdit(AstNode* nodep);
+    static AstNode* constifyGenerateParamsEdit(AstNode* nodep) VL_MT_DISABLED;
     // Only do constant pushing, without removing dead logic
-    static void constifyAllLive(AstNetlist* nodep);
+    static void constifyAllLive(AstNetlist* nodep) VL_MT_DISABLED;
     // Everything that's possible
-    static void constifyAll(AstNetlist* nodep);
+    static void constifyAll(AstNetlist* nodep) VL_MT_DISABLED;
     // Also, warn
-    static void constifyAllLint(AstNetlist* nodep);
+    static void constifyAllLint(AstNetlist* nodep) VL_MT_DISABLED;
     // C++ datatypes
-    static void constifyCpp(AstNetlist* nodep);
+    static void constifyCpp(AstNetlist* nodep) VL_MT_DISABLED;
     // Only the current node and lower
     // Return new node that may have replaced nodep
-    static AstNode* constifyEditCpp(AstNode* nodep);
-    static AstNodeExpr* constifyEditCpp(AstNodeExpr* exprp) {
+    static AstNode* constifyEditCpp(AstNode* nodep) VL_MT_DISABLED;
+    static AstNodeExpr* constifyEditCpp(AstNodeExpr* exprp) VL_MT_DISABLED {
         return VN_AS(constifyEditCpp(static_cast<AstNode*>(exprp)), NodeExpr);
     }
     // Only the current node and lower
     // Return new node that may have replaced nodep
-    static AstNode* constifyEdit(AstNode* nodep);
-    static AstNodeExpr* constifyEdit(AstNodeExpr* exprp) {
+    static AstNode* constifyEdit(AstNode* nodep) VL_MT_DISABLED;
+    static AstNodeExpr* constifyEdit(AstNodeExpr* exprp) VL_MT_DISABLED {
         return VN_AS(constifyEdit(static_cast<AstNode*>(exprp)), NodeExpr);
     }
     // Only the current node and lower, with special SenTree optimization
     // Return new node that may have replaced nodep
-    static AstNode* constifyExpensiveEdit(AstNode* nodep);
+    static AstNode* constifyExpensiveEdit(AstNode* nodep) VL_MT_DISABLED;
 };
 
 #endif  // Guard

--- a/src/V3Coverage.cpp
+++ b/src/V3Coverage.cpp
@@ -24,6 +24,8 @@
 //
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3Coverage.h
+++ b/src/V3Coverage.h
@@ -20,6 +20,8 @@
 #include "config_build.h"
 #include "verilatedos.h"
 
+#include "V3ThreadSafety.h"
+
 class AstNetlist;
 
 //============================================================================
@@ -27,7 +29,7 @@ class AstNetlist;
 class V3Coverage final {
 public:
     // CONSTRUCTORS
-    static void coverage(AstNetlist* rootp);
+    static void coverage(AstNetlist* rootp) VL_MT_DISABLED;
 };
 
 #endif  // Guard

--- a/src/V3CoverageJoin.cpp
+++ b/src/V3CoverageJoin.cpp
@@ -17,6 +17,8 @@
 //      If two COVERTOGGLEs have same VARSCOPE, combine them
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3CoverageJoin.h
+++ b/src/V3CoverageJoin.h
@@ -20,6 +20,8 @@
 #include "config_build.h"
 #include "verilatedos.h"
 
+#include "V3ThreadSafety.h"
+
 class AstNetlist;
 
 //============================================================================
@@ -27,7 +29,7 @@ class AstNetlist;
 class V3CoverageJoin final {
 public:
     // CONSTRUCTORS
-    static void coverageJoin(AstNetlist* rootp);
+    static void coverageJoin(AstNetlist* rootp) VL_MT_DISABLED;
 };
 
 #endif  // Guard

--- a/src/V3Dead.cpp
+++ b/src/V3Dead.cpp
@@ -33,6 +33,8 @@
 // here after scoping to allow more dead node removal.
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3Dead.h
+++ b/src/V3Dead.h
@@ -20,6 +20,8 @@
 #include "config_build.h"
 #include "verilatedos.h"
 
+#include "V3ThreadSafety.h"
+
 class AstNetlist;
 
 //============================================================================
@@ -27,13 +29,13 @@ class AstNetlist;
 class V3Dead final {
 public:
     // Modules, no vars/dtypes
-    static void deadifyModules(AstNetlist* nodep);
+    static void deadifyModules(AstNetlist* nodep) VL_MT_DISABLED;
     // Modules, Data types
-    static void deadifyDTypes(AstNetlist* nodep);
-    static void deadifyDTypesScoped(AstNetlist* nodep);
+    static void deadifyDTypes(AstNetlist* nodep) VL_MT_DISABLED;
+    static void deadifyDTypesScoped(AstNetlist* nodep) VL_MT_DISABLED;
     // Everything that's possible
-    static void deadifyAll(AstNetlist* nodep);
-    static void deadifyAllScoped(AstNetlist* nodep);
+    static void deadifyAll(AstNetlist* nodep) VL_MT_DISABLED;
+    static void deadifyAllScoped(AstNetlist* nodep) VL_MT_DISABLED;
 };
 
 #endif  // Guard

--- a/src/V3Delayed.cpp
+++ b/src/V3Delayed.cpp
@@ -48,6 +48,8 @@
 //
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3Delayed.h
+++ b/src/V3Delayed.h
@@ -20,13 +20,15 @@
 #include "config_build.h"
 #include "verilatedos.h"
 
+#include "V3ThreadSafety.h"
+
 class AstNetlist;
 
 //============================================================================
 
 class V3Delayed final {
 public:
-    static void delayedAll(AstNetlist* nodep);
+    static void delayedAll(AstNetlist* nodep) VL_MT_DISABLED;
 };
 
 #endif  // Guard

--- a/src/V3Depth.cpp
+++ b/src/V3Depth.cpp
@@ -23,6 +23,8 @@
 //
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3Depth.h
+++ b/src/V3Depth.h
@@ -20,13 +20,15 @@
 #include "config_build.h"
 #include "verilatedos.h"
 
+#include "V3ThreadSafety.h"
+
 class AstNetlist;
 
 //============================================================================
 
 class V3Depth final {
 public:
-    static void depthAll(AstNetlist* nodep);
+    static void depthAll(AstNetlist* nodep) VL_MT_DISABLED;
 };
 
 #endif  // Guard

--- a/src/V3DepthBlock.cpp
+++ b/src/V3DepthBlock.cpp
@@ -20,6 +20,8 @@
 //
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3DepthBlock.h
+++ b/src/V3DepthBlock.h
@@ -20,13 +20,15 @@
 #include "config_build.h"
 #include "verilatedos.h"
 
+#include "V3ThreadSafety.h"
+
 class AstNetlist;
 
 //============================================================================
 
 class V3DepthBlock final {
 public:
-    static void depthBlockAll(AstNetlist* nodep);
+    static void depthBlockAll(AstNetlist* nodep) VL_MT_DISABLED;
 };
 
 #endif  // Guard

--- a/src/V3Descope.cpp
+++ b/src/V3Descope.cpp
@@ -22,6 +22,8 @@
 //
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3Descope.h
+++ b/src/V3Descope.h
@@ -20,13 +20,15 @@
 #include "config_build.h"
 #include "verilatedos.h"
 
+#include "V3ThreadSafety.h"
+
 class AstNetlist;
 
 //============================================================================
 
 class V3Descope final {
 public:
-    static void descopeAll(AstNetlist* nodep);
+    static void descopeAll(AstNetlist* nodep) VL_MT_DISABLED;
 };
 
 #endif  // Guard

--- a/src/V3Dfg.cpp
+++ b/src/V3Dfg.cpp
@@ -14,6 +14,8 @@
 //
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3DfgAstToDfg.cpp
+++ b/src/V3DfgAstToDfg.cpp
@@ -26,6 +26,8 @@
 //
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3DfgDecomposition.cpp
+++ b/src/V3DfgDecomposition.cpp
@@ -18,6 +18,8 @@
 //
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3DfgDfgToAst.cpp
+++ b/src/V3DfgDfgToAst.cpp
@@ -26,6 +26,8 @@
 //
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3DfgOptimizer.cpp
+++ b/src/V3DfgOptimizer.cpp
@@ -18,6 +18,8 @@
 //
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3DfgOptimizer.h
+++ b/src/V3DfgOptimizer.h
@@ -21,15 +21,16 @@
 #include "verilatedos.h"
 
 #include "V3Ast.h"
+#include "V3ThreadSafety.h"
 
 //============================================================================
 
 namespace V3DfgOptimizer {
 // Extract further logic blocks from the design for additional optimization opportunities
-void extract(AstNetlist*);
+void extract(AstNetlist*) VL_MT_DISABLED;
 
 // Optimize the design
-void optimize(AstNetlist*, const string& label);
+void optimize(AstNetlist*, const string& label) VL_MT_DISABLED;
 }  // namespace V3DfgOptimizer
 
 #endif  // Guard

--- a/src/V3DfgPasses.cpp
+++ b/src/V3DfgPasses.cpp
@@ -14,6 +14,8 @@
 //
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 
 #include "V3DfgPasses.h"

--- a/src/V3DfgPasses.h
+++ b/src/V3DfgPasses.h
@@ -20,6 +20,7 @@
 #include "config_build.h"
 
 #include "V3DfgPeephole.h"
+#include "V3ThreadSafety.h"
 
 class AstModule;
 class DfgGraph;
@@ -35,7 +36,7 @@ public:
     VDouble0 m_eliminated;  // Number of common sub-expressions eliminated
     explicit V3DfgCseContext(const std::string& label)
         : m_label{label} {}
-    ~V3DfgCseContext();
+    ~V3DfgCseContext() VL_MT_DISABLED;
 };
 
 class DfgRemoveVarsContext final {
@@ -45,7 +46,7 @@ public:
     VDouble0 m_removed;  // Number of redundant variables removed
     explicit DfgRemoveVarsContext(const std::string& label)
         : m_label{label} {}
-    ~DfgRemoveVarsContext();
+    ~DfgRemoveVarsContext() VL_MT_DISABLED;
 };
 
 class V3DfgOptimizationContext final {
@@ -73,8 +74,8 @@ public:
     V3DfgCseContext m_cseContext1{m_label + " 2nd"};
     V3DfgPeepholeContext m_peepholeContext{m_label};
     DfgRemoveVarsContext m_removeVarsContext{m_label};
-    explicit V3DfgOptimizationContext(const std::string& label);
-    ~V3DfgOptimizationContext();
+    explicit V3DfgOptimizationContext(const std::string& label) VL_MT_DISABLED;
+    ~V3DfgOptimizationContext() VL_MT_DISABLED;
 
     const std::string& prefix() const { return m_prefix; }
 };
@@ -87,29 +88,29 @@ namespace V3DfgPasses {
 // Construct a DfGGraph representing the combinational logic in the given AstModule. The logic
 // that is represented by the graph is removed from the given AstModule. Returns the
 // constructed DfgGraph.
-DfgGraph* astToDfg(AstModule&, V3DfgOptimizationContext&);
+DfgGraph* astToDfg(AstModule&, V3DfgOptimizationContext&) VL_MT_DISABLED;
 
 // Optimize the given DfgGraph
-void optimize(DfgGraph&, V3DfgOptimizationContext&);
+void optimize(DfgGraph&, V3DfgOptimizationContext&) VL_MT_DISABLED;
 
 // Convert DfgGraph back into Ast, and insert converted graph back into its parent module.
 // Returns the parent module.
-AstModule* dfgToAst(DfgGraph&, V3DfgOptimizationContext&);
+AstModule* dfgToAst(DfgGraph&, V3DfgOptimizationContext&) VL_MT_DISABLED;
 
 //===========================================================================
 // Intermediate/internal operations
 //===========================================================================
 
 // Common subexpression elimination
-void cse(DfgGraph&, V3DfgCseContext&);
+void cse(DfgGraph&, V3DfgCseContext&) VL_MT_DISABLED;
 // Inline fully driven variables
-void inlineVars(const DfgGraph&);
+void inlineVars(const DfgGraph&) VL_MT_DISABLED;
 // Peephole optimizations
-void peephole(DfgGraph&, V3DfgPeepholeContext&);
+void peephole(DfgGraph&, V3DfgPeepholeContext&) VL_MT_DISABLED;
 // Remove redundant variables
-void removeVars(DfgGraph&, DfgRemoveVarsContext&);
+void removeVars(DfgGraph&, DfgRemoveVarsContext&) VL_MT_DISABLED;
 // Remove unused nodes
-void removeUnused(DfgGraph&);
+void removeUnused(DfgGraph&) VL_MT_DISABLED;
 }  // namespace V3DfgPasses
 
 #endif

--- a/src/V3DfgPeephole.cpp
+++ b/src/V3DfgPeephole.cpp
@@ -21,6 +21,8 @@
 //
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 
 #include "V3DfgPeephole.h"

--- a/src/V3DfgPeephole.h
+++ b/src/V3DfgPeephole.h
@@ -19,6 +19,8 @@
 
 #include "config_build.h"
 
+#include "V3ThreadSafety.h"
+
 #include <V3Stats.h>
 
 #define _FOR_EACH_DFG_PEEPHOLE_OPTIMIZATION_APPLY(macro, arg) macro(arg, #arg)
@@ -127,8 +129,8 @@ struct V3DfgPeepholeContext final {
     // Count of applications for each optimization (for statistics)
     std::array<VDouble0, VDfgPeepholePattern::_ENUM_END> m_count;
 
-    explicit V3DfgPeepholeContext(const std::string& label);
-    ~V3DfgPeepholeContext();
+    explicit V3DfgPeepholeContext(const std::string& label) VL_MT_DISABLED;
+    ~V3DfgPeepholeContext() VL_MT_DISABLED;
 };
 
 #endif

--- a/src/V3DfgVertices.h
+++ b/src/V3DfgVertices.h
@@ -43,8 +43,8 @@ class DfgVertexVar VL_NOT_FINAL : public DfgVertexVariadic {
     bool m_hasModRefs = false;  // This AstVar is referenced outside the DFG, but in the module
     bool m_hasExtRefs = false;  // This AstVar is referenced from outside the module
 
-    bool selfEquals(const DfgVertex& that) const final;
-    V3Hash selfHash() const final;
+    bool selfEquals(const DfgVertex& that) const final VL_MT_DISABLED;
+    V3Hash selfHash() const final VL_MT_DISABLED;
 
 public:
     DfgVertexVar(DfgGraph& dfg, VDfgType type, AstVar* varp, uint32_t initialCapacity)
@@ -92,8 +92,8 @@ class DfgConst final : public DfgVertex {
 
     V3Number m_num;  // Constant value
 
-    bool selfEquals(const DfgVertex& that) const override;
-    V3Hash selfHash() const override;
+    bool selfEquals(const DfgVertex& that) const override VL_MT_DISABLED;
+    V3Hash selfHash() const override VL_MT_DISABLED;
 
 public:
     DfgConst(DfgGraph& dfg, FileLine* flp, const V3Number& num)
@@ -158,8 +158,8 @@ class DfgSel final : public DfgVertexUnary {
     // the constant 'lsbp', and as 'DfgMux` for the non-constant 'lsbp'.
     uint32_t m_lsb = 0;  // The LSB index
 
-    bool selfEquals(const DfgVertex& that) const override;
-    V3Hash selfHash() const override;
+    bool selfEquals(const DfgVertex& that) const override VL_MT_DISABLED;
+    V3Hash selfHash() const override VL_MT_DISABLED;
 
 public:
     DfgSel(DfgGraph& dfg, FileLine* flp, AstNodeDType* dtypep)

--- a/src/V3DupFinder.cpp
+++ b/src/V3DupFinder.cpp
@@ -14,6 +14,8 @@
 //
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3DupFinder.h
+++ b/src/V3DupFinder.h
@@ -26,6 +26,7 @@
 #include "V3Ast.h"
 #include "V3Error.h"
 #include "V3Hasher.h"
+#include "V3ThreadSafety.h"
 
 #include <map>
 #include <memory>
@@ -76,14 +77,14 @@ public:
     iterator insert(AstNode* nodep) { return emplace(m_hasher(nodep), nodep); }
 
     // Erase node from data structure
-    size_type erase(AstNode* nodep);
+    size_type erase(AstNode* nodep) VL_MT_DISABLED;
 
     // Return duplicate, if one was inserted, with optional user check for sameness
-    iterator findDuplicate(AstNode* nodep, V3DupFinderUserSame* checkp = nullptr);
+    iterator findDuplicate(AstNode* nodep, V3DupFinderUserSame* checkp = nullptr) VL_MT_DISABLED;
 
     // Dump for debug
-    void dumpFile(const string& filename, bool tree);
-    void dumpFilePrefixed(const string& nameComment, bool tree = false);
+    void dumpFile(const string& filename, bool tree) VL_MT_DISABLED;
+    void dumpFilePrefixed(const string& nameComment, bool tree = false) VL_MT_DISABLED;
 };
 
 #endif  // Guard

--- a/src/V3EmitC.h
+++ b/src/V3EmitC.h
@@ -20,17 +20,19 @@
 #include "config_build.h"
 #include "verilatedos.h"
 
+#include "V3ThreadSafety.h"
+
 //============================================================================
 
 class V3EmitC final {
 public:
-    static void emitcConstPool();
-    static void emitcHeaders();
+    static void emitcConstPool() VL_MT_DISABLED;
+    static void emitcHeaders() VL_MT_DISABLED;
     static void emitcImp();
-    static void emitcInlines();
-    static void emitcModel();
-    static void emitcSyms(bool dpiHdrOnly = false);
-    static void emitcFiles();
+    static void emitcInlines() VL_MT_DISABLED;
+    static void emitcModel() VL_MT_DISABLED;
+    static void emitcSyms(bool dpiHdrOnly = false) VL_MT_DISABLED;
+    static void emitcFiles() VL_MT_DISABLED;
 };
 
 #endif  // Guard

--- a/src/V3EmitCBase.h
+++ b/src/V3EmitCBase.h
@@ -22,7 +22,7 @@
 
 #include "V3Ast.h"
 #include "V3File.h"
-#include "V3Global.h"
+#include "V3ThreadSafety.h"
 
 #include <cmath>
 #include <cstdarg>

--- a/src/V3EmitCFunc.h
+++ b/src/V3EmitCFunc.h
@@ -23,6 +23,7 @@
 #include "V3EmitCConstInit.h"
 #include "V3Global.h"
 #include "V3MemberMap.h"
+#include "V3ThreadSafety.h"
 
 #include <algorithm>
 #include <map>

--- a/src/V3EmitCMain.cpp
+++ b/src/V3EmitCMain.cpp
@@ -14,6 +14,8 @@
 //
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3EmitCMain.h
+++ b/src/V3EmitCMain.h
@@ -20,11 +20,13 @@
 #include "config_build.h"
 #include "verilatedos.h"
 
+#include "V3ThreadSafety.h"
+
 //============================================================================
 
 class V3EmitCMain final {
 public:
-    static void emit();
+    static void emit() VL_MT_DISABLED;
 };
 
 #endif  // Guard

--- a/src/V3EmitCMake.cpp
+++ b/src/V3EmitCMake.cpp
@@ -14,6 +14,8 @@
 //
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3EmitCMake.h
+++ b/src/V3EmitCMake.h
@@ -20,11 +20,13 @@
 #include "config_build.h"
 #include "verilatedos.h"
 
+#include "V3ThreadSafety.h"
+
 //============================================================================
 
 class V3EmitCMake final {
 public:
-    static void emit();
+    static void emit() VL_MT_DISABLED;
 };
 
 #endif  // Guard

--- a/src/V3EmitCModel.cpp
+++ b/src/V3EmitCModel.cpp
@@ -14,6 +14,8 @@
 //
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3EmitCSyms.cpp
+++ b/src/V3EmitCSyms.cpp
@@ -14,6 +14,8 @@
 //
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3EmitMk.cpp
+++ b/src/V3EmitMk.cpp
@@ -14,6 +14,8 @@
 //
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3EmitMk.h
+++ b/src/V3EmitMk.h
@@ -20,6 +20,8 @@
 #include "config_build.h"
 #include "verilatedos.h"
 
+#include "V3ThreadSafety.h"
+
 class V3HierBlockPlan;
 
 //============================================================================
@@ -29,8 +31,8 @@ public:
     // Number of source files after which to use parallel compiles
     static const size_t PARALLEL_FILE_CNT_THRESHOLD = 128;
 
-    static void emitmk();
-    static void emitHierVerilation(const V3HierBlockPlan* planp);
+    static void emitmk() VL_MT_DISABLED;
+    static void emitHierVerilation(const V3HierBlockPlan* planp) VL_MT_DISABLED;
 };
 
 #endif  // Guard

--- a/src/V3EmitV.h
+++ b/src/V3EmitV.h
@@ -20,6 +20,8 @@
 #include "config_build.h"
 #include "verilatedos.h"
 
+#include "V3ThreadSafety.h"
+
 class AstNode;
 class AstSenTree;
 

--- a/src/V3EmitXml.cpp
+++ b/src/V3EmitXml.cpp
@@ -14,6 +14,8 @@
 //
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3EmitXml.h
+++ b/src/V3EmitXml.h
@@ -20,11 +20,13 @@
 #include "config_build.h"
 #include "verilatedos.h"
 
+#include "V3ThreadSafety.h"
+
 //============================================================================
 
 class V3EmitXml final {
 public:
-    static void emitxml();
+    static void emitxml() VL_MT_DISABLED;
 };
 
 #endif  // Guard

--- a/src/V3Error.h
+++ b/src/V3Error.h
@@ -533,7 +533,8 @@ public:
 
 // Global versions, so that if the class doesn't define an operator, we get the functions anyway.
 void v3errorEnd(std::ostringstream& sstr) VL_RELEASE(V3Error::s().m_mutex) VL_MT_SAFE;
-void v3errorEndFatal(std::ostringstream& sstr) VL_RELEASE(V3Error::s().m_mutex) VL_MT_SAFE VL_ATTR_NORETURN;
+void v3errorEndFatal(std::ostringstream& sstr)
+    VL_RELEASE(V3Error::s().m_mutex) VL_MT_SAFE VL_ATTR_NORETURN;
 
 #ifdef VL_MT_DISABLED_CODE_UNIT
 #define VL_MT_DISABLED_CODE_UNIT_DEFINED 1

--- a/src/V3Error.h
+++ b/src/V3Error.h
@@ -24,7 +24,7 @@
 
 // Limited V3 headers here - this is a base class for Vlc etc
 #include "V3String.h"
-#ifndef V3ERROR_NO_GLOBAL_
+#ifndef VL_MT_DISABLED_CODE_UNIT
 #include "V3ThreadPool.h"
 #endif
 
@@ -518,9 +518,11 @@ public:
 
     // Internals for v3error()/v3fatal() macros only
     // Error end takes the string stream to output, be careful to seek() as needed
-    static void v3errorAcquireLock() VL_ACQUIRE(s().m_mutex);
-    static std::ostringstream& v3errorPrep(V3ErrorCode code) VL_ACQUIRE(s().m_mutex);
-    static std::ostringstream& v3errorPrepFileLine(V3ErrorCode code, const char* file, int line)
+    static void v3errorAcquireLock(bool checkStopRequest) VL_ACQUIRE(s().m_mutex);
+    static std::ostringstream& v3errorPrep(V3ErrorCode code, bool mtDisabledCodeUnit)
+        VL_ACQUIRE(s().m_mutex);
+    static std::ostringstream& v3errorPrepFileLine(V3ErrorCode code, const char* file, int line,
+                                                   bool mtDisabledCodeUnit)
         VL_ACQUIRE(s().m_mutex);
     static std::ostringstream& v3errorStr() VL_REQUIRES(s().m_mutex);
     // static, but often overridden in classes.
@@ -530,8 +532,14 @@ public:
 };
 
 // Global versions, so that if the class doesn't define an operator, we get the functions anyway.
-void v3errorEnd(std::ostringstream& sstr) VL_RELEASE(V3Error::s().m_mutex);
-void v3errorEndFatal(std::ostringstream& sstr) VL_RELEASE(V3Error::s().m_mutex) VL_ATTR_NORETURN;
+void v3errorEnd(std::ostringstream& sstr) VL_RELEASE(V3Error::s().m_mutex) VL_MT_SAFE;
+void v3errorEndFatal(std::ostringstream& sstr) VL_RELEASE(V3Error::s().m_mutex) VL_MT_SAFE VL_ATTR_NORETURN;
+
+#ifdef VL_MT_DISABLED_CODE_UNIT
+#define VL_MT_DISABLED_CODE_UNIT_DEFINED 1
+#else
+#define VL_MT_DISABLED_CODE_UNIT_DEFINED 0
+#endif
 
 // Theses allow errors using << operators: v3error("foo"<<"bar");
 // Careful, you can't put () around msg, as you would in most macro definitions.
@@ -541,9 +549,12 @@ void v3errorEndFatal(std::ostringstream& sstr) VL_RELEASE(V3Error::s().m_mutex) 
 // the comma operator (,) to guarantee the execution order here.
 #define v3errorBuildMessage(prep, msg) \
     (prep, static_cast<std::ostringstream&>(V3Error::v3errorStr() << msg))
-#define v3warnCode(code, msg) v3errorEnd(v3errorBuildMessage(V3Error::v3errorPrep(code), msg))
+#define v3warnCode(code, msg) \
+    v3errorEnd( \
+        v3errorBuildMessage(V3Error::v3errorPrep(code, VL_MT_DISABLED_CODE_UNIT_DEFINED), msg))
 #define v3warnCodeFatal(code, msg) \
-    v3errorEndFatal(v3errorBuildMessage(V3Error::v3errorPrep(code), msg))
+    v3errorEndFatal( \
+        v3errorBuildMessage(V3Error::v3errorPrep(code, VL_MT_DISABLED_CODE_UNIT_DEFINED), msg))
 #define v3warn(code, msg) v3warnCode(V3ErrorCode::code, msg)
 #define v3info(msg) v3warnCode(V3ErrorCode::EC_INFO, msg)
 #define v3error(msg) v3warnCode(V3ErrorCode::EC_ERROR, msg)
@@ -553,10 +564,13 @@ void v3errorEndFatal(std::ostringstream& sstr) VL_RELEASE(V3Error::s().m_mutex) 
 // Use this instead of fatal() to mention the source code line.
 #define v3fatalSrc(msg) \
     v3errorEndFatal(v3errorBuildMessage( \
-        V3Error::v3errorPrepFileLine(V3ErrorCode::EC_FATALSRC, __FILE__, __LINE__), msg))
+        V3Error::v3errorPrepFileLine(V3ErrorCode::EC_FATALSRC, __FILE__, __LINE__, \
+                                     VL_MT_DISABLED_CODE_UNIT_DEFINED), \
+        msg))
 // Use this when normal v3fatal is called in static method that overrides fileline.
 #define v3fatalStatic(msg) \
-    ::v3errorEndFatal(v3errorBuildMessage(V3Error::v3errorPrep(V3ErrorCode::EC_FATAL), msg))
+    ::v3errorEndFatal(v3errorBuildMessage( \
+        V3Error::v3errorPrep(V3ErrorCode::EC_FATAL, VL_MT_DISABLED_CODE_UNIT_DEFINED), msg))
 
 #define UINFO(level, stmsg) \
     do { \

--- a/src/V3Expand.cpp
+++ b/src/V3Expand.cpp
@@ -25,6 +25,8 @@
 //
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3Expand.h
+++ b/src/V3Expand.h
@@ -20,13 +20,15 @@
 #include "config_build.h"
 #include "verilatedos.h"
 
+#include "V3ThreadSafety.h"
+
 class AstNetlist;
 
 //============================================================================
 
 class V3Expand final {
 public:
-    static void expandAll(AstNetlist* nodep);
+    static void expandAll(AstNetlist* nodep) VL_MT_DISABLED;
 };
 
 #endif  // Guard

--- a/src/V3Force.cpp
+++ b/src/V3Force.cpp
@@ -37,6 +37,8 @@
 //
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3Force.h
+++ b/src/V3Force.h
@@ -21,13 +21,15 @@
 #include "config_build.h"
 #include "verilatedos.h"
 
+#include "V3ThreadSafety.h"
+
 class AstNetlist;
 
 //============================================================================
 
 class V3Force final {
 public:
-    static void forceAll(AstNetlist* nodep);
+    static void forceAll(AstNetlist* nodep) VL_MT_DISABLED;
 };
 
 #endif  // Guard

--- a/src/V3Fork.cpp
+++ b/src/V3Fork.cpp
@@ -38,6 +38,8 @@
 //
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3Fork.h
+++ b/src/V3Fork.h
@@ -21,6 +21,8 @@
 #include "config_build.h"
 #include "verilatedos.h"
 
+#include "V3ThreadSafety.h"
+
 class AstNetlist;
 
 //============================================================================
@@ -29,10 +31,10 @@ class V3Fork final {
 public:
     // Move/copy variables to "anonymous" objects if their lifetime might exceed the scope of a
     // procedure that declared them. Update the references apropriately.
-    static void makeDynamicScopes(AstNetlist* nodep);
+    static void makeDynamicScopes(AstNetlist* nodep) VL_MT_DISABLED;
     // Create tasks out of blocks/statments that can outlive processes in which they were forked.
     // Return value: number of tasks created
-    static void makeTasks(AstNetlist* nodep);
+    static void makeTasks(AstNetlist* nodep) VL_MT_DISABLED;
 };
 
 #endif  // Guard

--- a/src/V3Gate.cpp
+++ b/src/V3Gate.cpp
@@ -21,6 +21,8 @@
 //
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3Gate.h
+++ b/src/V3Gate.h
@@ -20,13 +20,15 @@
 #include "config_build.h"
 #include "verilatedos.h"
 
+#include "V3ThreadSafety.h"
+
 class AstNetlist;
 
 //============================================================================
 
 class V3Gate final {
 public:
-    static void gateAll(AstNetlist* nodep);
+    static void gateAll(AstNetlist* nodep) VL_MT_DISABLED;
 };
 
 #endif  // Guard

--- a/src/V3Global.h
+++ b/src/V3Global.h
@@ -28,7 +28,9 @@
 
 #include "V3Error.h"
 #include "V3FileLine.h"
+#include "V3Mutex.h"
 #include "V3Options.h"
+#include "V3ThreadSafety.h"
 
 #include <string>
 #include <unordered_map>
@@ -127,6 +129,7 @@ public:
     V3Global() {}
     void boot();
     void shutdown();  // Release allocated resources
+
     // ACCESSORS (general)
     AstNetlist* rootp() const VL_MT_SAFE { return m_rootp; }
     VWidthMinUsage widthMinUsage() const { return m_widthMinUsage; }
@@ -134,8 +137,8 @@ public:
     bool assertScoped() const { return m_assertScoped; }
 
     // METHODS
-    void readFiles();
-    void removeStd();
+    void readFiles() VL_MT_DISABLED;
+    void removeStd() VL_MT_DISABLED;
     void checkTree() const;
     static void dumpCheckGlobalTree(const string& stagename, int newNumber = 0,
                                     bool doDump = true);

--- a/src/V3Graph.cpp
+++ b/src/V3Graph.cpp
@@ -14,6 +14,8 @@
 //
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3Graph.h
+++ b/src/V3Graph.h
@@ -23,6 +23,7 @@
 #include "V3Error.h"
 #include "V3List.h"
 #include "V3Rtti.h"
+#include "V3ThreadSafety.h"
 
 #include <algorithm>
 
@@ -88,19 +89,20 @@ protected:
     friend class V3GraphEdge;
     friend class GraphAcyc;
     // METHODS
-    double orderDFSIterate(V3GraphVertex* vertexp);
-    void dumpEdge(std::ostream& os, const V3GraphVertex* vertexp, const V3GraphEdge* edgep);
+    double orderDFSIterate(V3GraphVertex* vertexp) VL_MT_DISABLED;
+    void dumpEdge(std::ostream& os, const V3GraphVertex* vertexp,
+                  const V3GraphEdge* edgep) VL_MT_DISABLED;
     void verticesUnlink() { m_vertices.reset(); }
     // ACCESSORS
 
 public:
-    V3Graph();
-    virtual ~V3Graph();
+    V3Graph() VL_MT_DISABLED;
+    virtual ~V3Graph() VL_MT_DISABLED;
     virtual string dotRankDir() const { return "TB"; }  // rankdir for dot plotting
 
     // METHODS
-    void clear();  // Empty it of all vertices/edges, as if making a new object
-    void clearColors();
+    void clear() VL_MT_DISABLED;  // Empty it of all vertices/edges, as if making a new object
+    void clearColors() VL_MT_DISABLED;
     bool empty() const { return m_vertices.empty(); }
 
     V3GraphVertex* verticesBeginp() const { return m_vertices.begin(); }
@@ -109,66 +111,69 @@ public:
 
     /// Assign same color to all vertices in the same weakly connected component
     /// Thus different color if there's no edges between the two subgraphs
-    void weaklyConnected(V3EdgeFuncP edgeFuncp);
+    void weaklyConnected(V3EdgeFuncP edgeFuncp) VL_MT_DISABLED;
 
     /// Assign same color to all vertices that are strongly connected
     /// Thus different color if there's no directional circuit within the subgraphs.
     /// (I.E. all loops will occur within each color, not between them.)
-    void stronglyConnected(V3EdgeFuncP edgeFuncp);
+    void stronglyConnected(V3EdgeFuncP edgeFuncp) VL_MT_DISABLED;
 
     /// Assign an ordering number to all vertexes in a tree.
     /// All nodes with no inputs will get rank 1
-    void rank(V3EdgeFuncP edgeFuncp);
-    void rank();
+    void rank(V3EdgeFuncP edgeFuncp) VL_MT_DISABLED;
+    void rank() VL_MT_DISABLED;
 
     /// Sort all vertices and edges using the V3GraphVertex::sortCmp() function
-    void sortVertices();
+    void sortVertices() VL_MT_DISABLED;
     /// Sort all edges and edges using the V3GraphEdge::sortCmp() function
-    void sortEdges();
+    void sortEdges() VL_MT_DISABLED;
 
     /// Order all vertices by rank and fanout, lowest first
     /// Sort all vertices by rank and fanout, lowest first
     /// Sort all edges by weight, lowest first
     /// Side-effect: assigns ranks to every node.
-    void order();
+    void order() VL_MT_DISABLED;
 
     // Similar to order() but does not assign ranks. Caller must
     // ensure that the graph has been ranked ahead of the call.
-    void orderPreRanked();
+    void orderPreRanked() VL_MT_DISABLED;
 
     /// Make acyclical (into a tree) by breaking a minimal subset of cutable edges.
-    void acyclic(V3EdgeFuncP edgeFuncp);
+    void acyclic(V3EdgeFuncP edgeFuncp) VL_MT_DISABLED;
 
     /// Remove any redundant edges, weights become MAX of any other weight
-    void removeRedundantEdges(V3EdgeFuncP edgeFuncp);
+    void removeRedundantEdges(V3EdgeFuncP edgeFuncp) VL_MT_DISABLED;
 
     /// Remove any redundant edges, weights become SUM of any other weight
-    void removeRedundantEdgesSum(V3EdgeFuncP edgeFuncp);
+    void removeRedundantEdgesSum(V3EdgeFuncP edgeFuncp) VL_MT_DISABLED;
 
     /// Remove any transitive edges.  E.g. if have edges A->B, B->C, and A->C
     /// then A->C is a "transitive" edge; it's implied by the first two
     /// (assuming the DAG is a dependency graph.)
     /// This algorithm can be expensive.
-    void removeTransitiveEdges();
+    void removeTransitiveEdges() VL_MT_DISABLED;
 
     /// Call loopsVertexCb on any one loop starting where specified
-    void reportLoops(V3EdgeFuncP edgeFuncp, V3GraphVertex* vertexp);
+    void reportLoops(V3EdgeFuncP edgeFuncp, V3GraphVertex* vertexp) VL_MT_DISABLED;
 
     /// Build a subgraph of all loops starting where specified
-    void subtreeLoops(V3EdgeFuncP edgeFuncp, V3GraphVertex* vertexp, V3Graph* loopGraphp);
+    void subtreeLoops(V3EdgeFuncP edgeFuncp, V3GraphVertex* vertexp,
+                      V3Graph* loopGraphp) VL_MT_DISABLED;
 
     /// Debugging
-    void dump(std::ostream& os = std::cout);
-    void dumpDotFile(const string& filename, bool colorAsSubgraph) const;
-    void dumpDotFilePrefixed(const string& nameComment, bool colorAsSubgraph = false) const;
-    void dumpDotFilePrefixedAlways(const string& nameComment, bool colorAsSubgraph = false) const;
-    void userClearVertices();
-    void userClearEdges();
-    static void selfTest();
+    void dump(std::ostream& os = std::cout) VL_MT_DISABLED;
+    void dumpDotFile(const string& filename, bool colorAsSubgraph) const VL_MT_DISABLED;
+    void dumpDotFilePrefixed(const string& nameComment,
+                             bool colorAsSubgraph = false) const VL_MT_DISABLED;
+    void dumpDotFilePrefixedAlways(const string& nameComment,
+                                   bool colorAsSubgraph = false) const VL_MT_DISABLED;
+    void userClearVertices() VL_MT_DISABLED;
+    void userClearEdges() VL_MT_DISABLED;
+    static void selfTest() VL_MT_DISABLED;
 
     // CALLBACKS
-    virtual void loopsMessageCb(V3GraphVertex* vertexp);
-    virtual void loopsVertexCb(V3GraphVertex* vertexp);
+    virtual void loopsMessageCb(V3GraphVertex* vertexp) VL_MT_DISABLED;
+    virtual void loopsVertexCb(V3GraphVertex* vertexp) VL_MT_DISABLED;
 };
 
 //============================================================================
@@ -192,24 +197,24 @@ protected:
         uint32_t m_user;  // Marker for some algorithms
     };
     // METHODS
-    void verticesPushBack(V3Graph* graphp);
+    void verticesPushBack(V3Graph* graphp) VL_MT_DISABLED;
     // ACCESSORS
     void fanout(double fanout) { m_fanout = fanout; }
     void inUnlink() { m_ins.reset(); }  // Low level; normally unlinkDelete is what you want
     void outUnlink() { m_outs.reset(); }  // Low level; normally unlinkDelete is what you want
 protected:
     // CONSTRUCTORS
-    V3GraphVertex(V3Graph* graphp, const V3GraphVertex& old);
+    V3GraphVertex(V3Graph* graphp, const V3GraphVertex& old) VL_MT_DISABLED;
 
 public:
-    explicit V3GraphVertex(V3Graph* graphp);
+    explicit V3GraphVertex(V3Graph* graphp) VL_MT_DISABLED;
     //! Clone copy constructor. Doesn't copy edges or user/userp.
-    virtual V3GraphVertex* clone(V3Graph* graphp) const {
+    virtual V3GraphVertex* clone(V3Graph* graphp) const VL_MT_DISABLED {
         return new V3GraphVertex{graphp, *this};
     }
     virtual ~V3GraphVertex() = default;
-    void unlinkEdges(V3Graph* graphp);
-    void unlinkDelete(V3Graph* graphp);
+    void unlinkEdges(V3Graph* graphp) VL_MT_DISABLED;
+    void unlinkDelete(V3Graph* graphp) VL_MT_DISABLED;
 
     // METHODS
     // Return true iff of type T
@@ -275,10 +280,10 @@ public:
     V3GraphVertex* verticesNextp() const { return m_vertices.nextp(); }
     V3GraphEdge* inBeginp() const { return m_ins.begin(); }
     bool inEmpty() const { return inBeginp() == nullptr; }
-    bool inSize1() const;
+    bool inSize1() const VL_MT_DISABLED;
     V3GraphEdge* outBeginp() const { return m_outs.begin(); }
     bool outEmpty() const { return outBeginp() == nullptr; }
-    bool outSize1() const;
+    bool outSize1() const VL_MT_DISABLED;
     V3GraphEdge* beginp(GraphWay way) const { return way.forward() ? outBeginp() : inBeginp(); }
     // METHODS
     /// Error reporting
@@ -286,13 +291,13 @@ public:
     void v3errorEndFatal(std::ostringstream& str) const
         VL_RELEASE(V3Error::s().m_mutex) VL_MT_DISABLED;
     /// Edges are routed around this vertex to point from "from" directly to "to"
-    void rerouteEdges(V3Graph* graphp);
+    void rerouteEdges(V3Graph* graphp) VL_MT_DISABLED;
     /// Find the edge connecting ap and bp, where bp is wayward from ap.
     /// If edge is not found returns nullptr. O(edges) performance.
-    V3GraphEdge* findConnectingEdgep(GraphWay way, const V3GraphVertex* waywardp);
+    V3GraphEdge* findConnectingEdgep(GraphWay way, const V3GraphVertex* waywardp) VL_MT_DISABLED;
 };
 
-std::ostream& operator<<(std::ostream& os, V3GraphVertex* vertexp);
+std::ostream& operator<<(std::ostream& os, V3GraphVertex* vertexp) VL_MT_DISABLED;
 
 //============================================================================
 
@@ -321,25 +326,26 @@ protected:
     };
     // METHODS
     void init(V3Graph* graphp, V3GraphVertex* fromp, V3GraphVertex* top, int weight,
-              bool cutable = false);
+              bool cutable = false) VL_MT_DISABLED;
     void cut() { m_weight = 0; }  // 0 weight is same as disconnected
-    void outPushBack();
-    void inPushBack();
+    void outPushBack() VL_MT_DISABLED;
+    void inPushBack() VL_MT_DISABLED;
     // CONSTRUCTORS
 protected:
     V3GraphEdge(V3Graph* graphp, V3GraphVertex* fromp, V3GraphVertex* top,
-                const V3GraphEdge& old) {
+                const V3GraphEdge& old) VL_MT_DISABLED {
         init(graphp, fromp, top, old.m_weight, old.m_cutable);
     }
 
 public:
     //! Add DAG from one node to the specified node
     V3GraphEdge(V3Graph* graphp, V3GraphVertex* fromp, V3GraphVertex* top, int weight,
-                bool cutable = false) {
+                bool cutable = false) VL_MT_DISABLED {
         init(graphp, fromp, top, weight, cutable);
     }
     //! Clone copy constructor.  Doesn't copy existing vertices or user/userp.
-    virtual V3GraphEdge* clone(V3Graph* graphp, V3GraphVertex* fromp, V3GraphVertex* top) const {
+    virtual V3GraphEdge* clone(V3Graph* graphp, V3GraphVertex* fromp,
+                               V3GraphVertex* top) const VL_MT_DISABLED {
         return new V3GraphEdge{graphp, fromp, top, *this};
     }
     virtual ~V3GraphEdge() = default;
@@ -385,9 +391,9 @@ public:
         if (!m_weight || !rhsp->m_weight) return 0;
         return top()->sortCmp(rhsp->top());
     }
-    void unlinkDelete();
-    V3GraphEdge* relinkFromp(V3GraphVertex* newFromp);
-    V3GraphEdge* relinkTop(V3GraphVertex* newTop);
+    void unlinkDelete() VL_MT_DISABLED;
+    V3GraphEdge* relinkFromp(V3GraphVertex* newFromp) VL_MT_DISABLED;
+    V3GraphEdge* relinkTop(V3GraphVertex* newTop) VL_MT_DISABLED;
     // ACCESSORS
     int weight() const { return m_weight; }
     void weight(int weight) { m_weight = weight; }

--- a/src/V3Graph.h
+++ b/src/V3Graph.h
@@ -282,8 +282,9 @@ public:
     V3GraphEdge* beginp(GraphWay way) const { return way.forward() ? outBeginp() : inBeginp(); }
     // METHODS
     /// Error reporting
-    void v3errorEnd(std::ostringstream& str) const VL_RELEASE(V3Error::s().m_mutex);
-    void v3errorEndFatal(std::ostringstream& str) const VL_RELEASE(V3Error::s().m_mutex);
+    void v3errorEnd(std::ostringstream& str) const VL_RELEASE(V3Error::s().m_mutex) VL_MT_DISABLED;
+    void v3errorEndFatal(std::ostringstream& str) const
+        VL_RELEASE(V3Error::s().m_mutex) VL_MT_DISABLED;
     /// Edges are routed around this vertex to point from "from" directly to "to"
     void rerouteEdges(V3Graph* graphp);
     /// Find the edge connecting ap and bp, where bp is wayward from ap.

--- a/src/V3GraphAcyc.cpp
+++ b/src/V3GraphAcyc.cpp
@@ -14,6 +14,8 @@
 //
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3GraphAlg.cpp
+++ b/src/V3GraphAlg.cpp
@@ -14,6 +14,8 @@
 //
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3GraphPathChecker.cpp
+++ b/src/V3GraphPathChecker.cpp
@@ -14,6 +14,8 @@
 //
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3GraphPathChecker.h
+++ b/src/V3GraphPathChecker.h
@@ -20,6 +20,7 @@
 #include "V3Error.h"
 #include "V3Graph.h"
 #include "V3GraphAlg.h"
+#include "V3ThreadSafety.h"
 
 //######################################################################
 
@@ -39,21 +40,22 @@ class GraphPathChecker final : GraphAlg<const V3Graph> {
 public:
     // CONSTRUCTORS
     explicit GraphPathChecker(const V3Graph* graphp,
-                              V3EdgeFuncP edgeFuncp = V3GraphEdge::followAlwaysTrue);
-    ~GraphPathChecker();
+                              V3EdgeFuncP edgeFuncp
+                              = V3GraphEdge::followAlwaysTrue) VL_MT_DISABLED;
+    ~GraphPathChecker() VL_MT_DISABLED;
 
     // METHODS
-    bool pathExistsFrom(const V3GraphVertex* fromp, const V3GraphVertex* top);
+    bool pathExistsFrom(const V3GraphVertex* fromp, const V3GraphVertex* top) VL_MT_DISABLED;
 
     // If have edges A->B, B->C, and A->C then A->C is considered a
     // "transitive" edge (implied by A->B and B->C) and it could be safely
     // removed. Detect such an edge.
-    bool isTransitiveEdge(const V3GraphEdge* edgep);
+    bool isTransitiveEdge(const V3GraphEdge* edgep) VL_MT_DISABLED;
 
 private:
     bool pathExistsInternal(const V3GraphVertex* ap, const V3GraphVertex* bp,
-                            unsigned* costp = nullptr);
-    void initHalfCriticalPaths(GraphWay way, bool checkOnly);
+                            unsigned* costp = nullptr) VL_MT_DISABLED;
+    void initHalfCriticalPaths(GraphWay way, bool checkOnly) VL_MT_DISABLED;
     void incGeneration() { ++m_generation; }
 
     VL_UNCOPYABLE(GraphPathChecker);

--- a/src/V3GraphTest.cpp
+++ b/src/V3GraphTest.cpp
@@ -14,6 +14,8 @@
 //
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3HierBlock.cpp
+++ b/src/V3HierBlock.cpp
@@ -72,6 +72,8 @@
 //       Used for b) and c).
 //       This options is repeated for all instantiating hierarchical blocks.
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "V3HierBlock.h"
 
 #include "V3Ast.h"

--- a/src/V3HierBlock.h
+++ b/src/V3HierBlock.h
@@ -19,7 +19,8 @@
 
 #include "verilatedos.h"
 
-#include "V3Global.h"
+#include "V3Options.h"
+#include "V3ThreadSafety.h"
 
 #include <map>
 #include <set>
@@ -56,13 +57,13 @@ private:
 
     // METHODS
     VL_UNCOPYABLE(V3HierBlock);
-    static StrGParams stringifyParams(const GParams& gparams, bool forGOption);
+    static StrGParams stringifyParams(const GParams& gparams, bool forGOption) VL_MT_DISABLED;
 
 public:
     V3HierBlock(const AstNodeModule* modp, const GParams& gparams)
         : m_modp{modp}
         , m_gparams{gparams} {}
-    ~V3HierBlock();
+    ~V3HierBlock() VL_MT_DISABLED;
 
     void addParent(V3HierBlock* parentp) { m_parents.insert(parentp); }
     void addChild(V3HierBlock* childp) { m_children.insert(childp); }
@@ -73,19 +74,19 @@ public:
     const AstNodeModule* modp() const { return m_modp; }
 
     // For emitting Makefile and CMakeLists.txt
-    V3StringList commandArgs(bool forCMake) const;
-    V3StringList hierBlockArgs() const;
-    string hierPrefix() const;
-    string hierSomeFile(bool withDir, const char* prefix, const char* suffix) const;
-    string hierWrapper(bool withDir) const;
-    string hierMk(bool withDir) const;
-    string hierLib(bool withDir) const;
-    string hierGenerated(bool withDir) const;
+    V3StringList commandArgs(bool forCMake) const VL_MT_DISABLED;
+    V3StringList hierBlockArgs() const VL_MT_DISABLED;
+    string hierPrefix() const VL_MT_DISABLED;
+    string hierSomeFile(bool withDir, const char* prefix, const char* suffix) const VL_MT_DISABLED;
+    string hierWrapper(bool withDir) const VL_MT_DISABLED;
+    string hierMk(bool withDir) const VL_MT_DISABLED;
+    string hierLib(bool withDir) const VL_MT_DISABLED;
+    string hierGenerated(bool withDir) const VL_MT_DISABLED;
     // Returns the original HDL file if it is not included in v3Global.opt.vFiles().
-    string vFileIfNecessary() const;
+    string vFileIfNecessary() const VL_MT_DISABLED;
     // Write command line arguments to .f file for this hierarchical block
-    void writeCommandArgsFile(bool forCMake) const;
-    string commandArgsFileName(bool forCMake) const;
+    void writeCommandArgsFile(bool forCMake) const VL_MT_DISABLED;
+    string commandArgsFileName(bool forCMake) const VL_MT_DISABLED;
 };
 
 //######################################################################
@@ -103,8 +104,8 @@ public:
     using const_iterator = HierMap::const_iterator;
     using HierVector = std::vector<const V3HierBlock*>;
 
-    void add(const AstNodeModule* modp, const std::vector<AstVar*>& gparams);
-    void registerUsage(const AstNodeModule* parentp, const AstNodeModule* childp);
+    void add(const AstNodeModule* modp, const std::vector<AstVar*>& gparams) VL_MT_DISABLED;
+    void registerUsage(const AstNodeModule* parentp, const AstNodeModule* childp) VL_MT_DISABLED;
 
     const_iterator begin() const { return m_blocks.begin(); }
     const_iterator end() const { return m_blocks.end(); }
@@ -112,13 +113,13 @@ public:
 
     // Returns all hierarchical blocks that sorted in leaf-first order.
     // Latter block refers only already appeared hierarchical blocks.
-    HierVector hierBlocksSorted() const;
+    HierVector hierBlocksSorted() const VL_MT_DISABLED;
 
     // Write command line arguments to .f files for child Verilation run
-    void writeCommandArgsFiles(bool forCMake) const;
-    static string topCommandArgsFileName(bool forCMake);
+    void writeCommandArgsFiles(bool forCMake) const VL_MT_DISABLED;
+    static string topCommandArgsFileName(bool forCMake) VL_MT_DISABLED;
 
-    static void createPlan(AstNetlist* nodep);
+    static void createPlan(AstNetlist* nodep) VL_MT_DISABLED;
 };
 
 #endif  // guard

--- a/src/V3Inline.cpp
+++ b/src/V3Inline.cpp
@@ -24,6 +24,8 @@
 //
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3Inline.h
+++ b/src/V3Inline.h
@@ -20,13 +20,15 @@
 #include "config_build.h"
 #include "verilatedos.h"
 
+#include "V3ThreadSafety.h"
+
 class AstNetlist;
 
 //============================================================================
 
 class V3Inline final {
 public:
-    static void inlineAll(AstNetlist* nodep);
+    static void inlineAll(AstNetlist* nodep) VL_MT_DISABLED;
 };
 
 #endif  // Guard

--- a/src/V3Inst.cpp
+++ b/src/V3Inst.cpp
@@ -21,6 +21,8 @@
 //
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3Inst.h
+++ b/src/V3Inst.h
@@ -20,6 +20,8 @@
 #include "config_build.h"
 #include "verilatedos.h"
 
+#include "V3ThreadSafety.h"
+
 class AstAssignW;
 class AstCell;
 class AstNetlist;
@@ -29,11 +31,11 @@ class AstPin;
 
 class V3Inst final {
 public:
-    static void instAll(AstNetlist* nodep);
-    static void dearrayAll(AstNetlist* nodep);
+    static void instAll(AstNetlist* nodep) VL_MT_DISABLED;
+    static void dearrayAll(AstNetlist* nodep) VL_MT_DISABLED;
     static AstAssignW* pinReconnectSimple(AstPin* pinp, AstCell* cellp, bool forTristate,
-                                          bool alwaysCvt = false);
-    static void checkOutputShort(AstPin* nodep);
+                                          bool alwaysCvt = false) VL_MT_DISABLED;
+    static void checkOutputShort(AstPin* nodep) VL_MT_DISABLED;
 };
 
 #endif  // Guard

--- a/src/V3InstrCount.cpp
+++ b/src/V3InstrCount.cpp
@@ -15,6 +15,8 @@
 //
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3InstrCount.h
+++ b/src/V3InstrCount.h
@@ -21,6 +21,8 @@
 #include "config_build.h"
 #include "verilatedos.h"
 
+#include "V3ThreadSafety.h"
+
 class AstNode;
 
 class V3InstrCount final {
@@ -38,7 +40,8 @@ public:
     // if we see the same node twice (across more than one call to count,
     // potentially) raises an error.
     // Optional osp is stream to dump critical path to.
-    static uint32_t count(AstNode* nodep, bool assertNoDups, std::ostream* osp = nullptr);
+    static uint32_t count(AstNode* nodep, bool assertNoDups,
+                          std::ostream* osp = nullptr) VL_MT_DISABLED;
 };
 
 #endif  // guard

--- a/src/V3Life.cpp
+++ b/src/V3Life.cpp
@@ -23,6 +23,8 @@
 //
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3Life.h
+++ b/src/V3Life.h
@@ -20,13 +20,15 @@
 #include "config_build.h"
 #include "verilatedos.h"
 
+#include "V3ThreadSafety.h"
+
 class AstNetlist;
 
 //============================================================================
 
 class V3Life final {
 public:
-    static void lifeAll(AstNetlist* nodep);
+    static void lifeAll(AstNetlist* nodep) VL_MT_DISABLED;
 };
 
 #endif  // Guard

--- a/src/V3LifePost.cpp
+++ b/src/V3LifePost.cpp
@@ -24,6 +24,8 @@
 //
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3LifePost.h
+++ b/src/V3LifePost.h
@@ -20,13 +20,15 @@
 #include "config_build.h"
 #include "verilatedos.h"
 
+#include "V3ThreadSafety.h"
+
 class AstNetlist;
 
 //============================================================================
 
 class V3LifePost final {
 public:
-    static void lifepostAll(AstNetlist* nodep);
+    static void lifepostAll(AstNetlist* nodep) VL_MT_DISABLED;
 };
 
 #endif  // Guard

--- a/src/V3LinkCells.cpp
+++ b/src/V3LinkCells.cpp
@@ -23,6 +23,8 @@
 //              Link to module that instantiates it
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3LinkCells.h
+++ b/src/V3LinkCells.h
@@ -20,6 +20,8 @@
 #include "config_build.h"
 #include "verilatedos.h"
 
+#include "V3ThreadSafety.h"
+
 class AstNetlist;
 class VInFilter;
 class V3ParseSym;
@@ -28,7 +30,7 @@ class V3ParseSym;
 
 class V3LinkCells final {
 public:
-    static void link(AstNetlist* nodep, VInFilter* filterp, V3ParseSym* parseSymp);
+    static void link(AstNetlist* nodep, VInFilter* filterp, V3ParseSym* parseSymp) VL_MT_DISABLED;
 };
 
 #endif  // Guard

--- a/src/V3LinkDot.cpp
+++ b/src/V3LinkDot.cpp
@@ -61,6 +61,8 @@
 //      b          (VSymEnt->AstCell)
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3LinkDot.h
+++ b/src/V3LinkDot.h
@@ -22,19 +22,20 @@
 
 #include "V3Ast.h"
 #include "V3Error.h"
+#include "V3ThreadSafety.h"
 
 //============================================================================
 
 enum VLinkDotStep : uint8_t { LDS_PRIMARY, LDS_PARAMED, LDS_ARRAYED, LDS_SCOPED };
 
 class V3LinkDot final {
-    static void linkDotGuts(AstNetlist* rootp, VLinkDotStep step);
+    static void linkDotGuts(AstNetlist* rootp, VLinkDotStep step) VL_MT_DISABLED;
 
 public:
-    static void linkDotPrimary(AstNetlist* nodep);
-    static void linkDotParamed(AstNetlist* nodep);
-    static void linkDotArrayed(AstNetlist* nodep);
-    static void linkDotScope(AstNetlist* nodep);
+    static void linkDotPrimary(AstNetlist* nodep) VL_MT_DISABLED;
+    static void linkDotParamed(AstNetlist* nodep) VL_MT_DISABLED;
+    static void linkDotArrayed(AstNetlist* nodep) VL_MT_DISABLED;
+    static void linkDotScope(AstNetlist* nodep) VL_MT_DISABLED;
 };
 
 #endif  // Guard

--- a/src/V3LinkInc.cpp
+++ b/src/V3LinkInc.cpp
@@ -36,6 +36,8 @@
 //
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3LinkInc.h
+++ b/src/V3LinkInc.h
@@ -20,13 +20,15 @@
 #include "config_build.h"
 #include "verilatedos.h"
 
+#include "V3ThreadSafety.h"
+
 class AstNetlist;
 
 //============================================================================
 
 class V3LinkInc final {
 public:
-    static void linkIncrements(AstNetlist* nodep);
+    static void linkIncrements(AstNetlist* nodep) VL_MT_DISABLED;
 };
 
 #endif  // Guard

--- a/src/V3LinkJump.cpp
+++ b/src/V3LinkJump.cpp
@@ -29,6 +29,8 @@
 //
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3LinkJump.h
+++ b/src/V3LinkJump.h
@@ -20,13 +20,15 @@
 #include "config_build.h"
 #include "verilatedos.h"
 
+#include "V3ThreadSafety.h"
+
 class AstNetlist;
 
 //============================================================================
 
 class V3LinkJump final {
 public:
-    static void linkJump(AstNetlist* nodep);
+    static void linkJump(AstNetlist* nodep) VL_MT_DISABLED;
 };
 
 #endif  // Guard

--- a/src/V3LinkLValue.cpp
+++ b/src/V3LinkLValue.cpp
@@ -18,6 +18,8 @@
 //          Set lvalue() attributes on appropriate VARREFs.
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3LinkLValue.h
+++ b/src/V3LinkLValue.h
@@ -20,6 +20,8 @@
 #include "config_build.h"
 #include "verilatedos.h"
 
+#include "V3ThreadSafety.h"
+
 class AstNetlist;
 class AstNode;
 
@@ -27,8 +29,8 @@ class AstNode;
 
 class V3LinkLValue final {
 public:
-    static void linkLValue(AstNetlist* nodep);
-    static void linkLValueSet(AstNode* nodep);
+    static void linkLValue(AstNetlist* nodep) VL_MT_DISABLED;
+    static void linkLValueSet(AstNode* nodep) VL_MT_DISABLED;
 };
 
 #endif  // Guard

--- a/src/V3LinkLevel.cpp
+++ b/src/V3LinkLevel.cpp
@@ -19,6 +19,8 @@
 //          Create new MODULE TOP with connections to below signals
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3LinkLevel.h
+++ b/src/V3LinkLevel.h
@@ -22,6 +22,7 @@
 
 #include "V3Ast.h"
 #include "V3Error.h"
+#include "V3ThreadSafety.h"
 
 #include <vector>
 
@@ -31,13 +32,13 @@ class V3LinkLevel final {
 private:
     using ModVec = std::vector<AstNodeModule*>;
 
-    static void timescaling(const ModVec& mods);
-    static void wrapTopCell(AstNetlist* rootp);
-    static void wrapTopPackages(AstNetlist* rootp);
+    static void timescaling(const ModVec& mods) VL_MT_DISABLED;
+    static void wrapTopCell(AstNetlist* rootp) VL_MT_DISABLED;
+    static void wrapTopPackages(AstNetlist* rootp) VL_MT_DISABLED;
 
 public:
-    static void modSortByLevel();
-    static void wrapTop(AstNetlist* rootp);
+    static void modSortByLevel() VL_MT_DISABLED;
+    static void wrapTop(AstNetlist* rootp) VL_MT_DISABLED;
 };
 
 #endif  // Guard

--- a/src/V3LinkParse.cpp
+++ b/src/V3LinkParse.cpp
@@ -18,6 +18,8 @@
 //          Move some attributes around
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3LinkParse.h
+++ b/src/V3LinkParse.h
@@ -20,13 +20,15 @@
 #include "config_build.h"
 #include "verilatedos.h"
 
+#include "V3ThreadSafety.h"
+
 class AstNetlist;
 
 //============================================================================
 
 class V3LinkParse final {
 public:
-    static void linkParse(AstNetlist* rootp);
+    static void linkParse(AstNetlist* rootp) VL_MT_DISABLED;
 };
 
 #endif  // Guard

--- a/src/V3LinkResolve.cpp
+++ b/src/V3LinkResolve.cpp
@@ -24,6 +24,8 @@
 //          SenItems: Convert pos/negedge of non-simple signals to temporaries
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3LinkResolve.h
+++ b/src/V3LinkResolve.h
@@ -20,13 +20,15 @@
 #include "config_build.h"
 #include "verilatedos.h"
 
+#include "V3ThreadSafety.h"
+
 class AstNetlist;
 
 //============================================================================
 
 class V3LinkResolve final {
 public:
-    static void linkResolve(AstNetlist* rootp);
+    static void linkResolve(AstNetlist* rootp) VL_MT_DISABLED;
 };
 
 #endif  // Guard

--- a/src/V3Localize.cpp
+++ b/src/V3Localize.cpp
@@ -22,6 +22,8 @@
 //
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3Localize.h
+++ b/src/V3Localize.h
@@ -20,13 +20,15 @@
 #include "config_build.h"
 #include "verilatedos.h"
 
+#include "V3ThreadSafety.h"
+
 class AstNetlist;
 
 //============================================================================
 
 class V3Localize final {
 public:
-    static void localizeAll(AstNetlist* nodep);
+    static void localizeAll(AstNetlist* nodep) VL_MT_DISABLED;
 };
 
 #endif  // Guard

--- a/src/V3MergeCond.cpp
+++ b/src/V3MergeCond.cpp
@@ -72,6 +72,8 @@
 //
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3MergeCond.h
+++ b/src/V3MergeCond.h
@@ -20,13 +20,15 @@
 #include "config_build.h"
 #include "verilatedos.h"
 
+#include "V3ThreadSafety.h"
+
 class AstNetlist;
 
 //============================================================================
 
 class V3MergeCond final {
 public:
-    static void mergeAll(AstNetlist* nodep);
+    static void mergeAll(AstNetlist* nodep) VL_MT_DISABLED;
 };
 
 #endif  // Guard

--- a/src/V3Name.cpp
+++ b/src/V3Name.cpp
@@ -19,6 +19,8 @@
 //              Prepend __PVT__ to variable names
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3Name.h
+++ b/src/V3Name.h
@@ -20,13 +20,15 @@
 #include "config_build.h"
 #include "verilatedos.h"
 
+#include "V3ThreadSafety.h"
+
 class AstNetlist;
 
 //============================================================================
 
 class V3Name final {
 public:
-    static void nameAll(AstNetlist* nodep);
+    static void nameAll(AstNetlist* nodep) VL_MT_DISABLED;
 };
 
 #endif  // Guard

--- a/src/V3Number_test.cpp
+++ b/src/V3Number_test.cpp
@@ -17,6 +17,7 @@
 // CHEAT!
 #define V3NUMBER_ASCII_BINARY
 #define V3ERROR_NO_GLOBAL_
+#define VL_MT_DISABLED_CODE_UNIT 1
 
 #include "config_build.h"
 #include "verilatedos.h"

--- a/src/V3OptionParser.cpp
+++ b/src/V3OptionParser.cpp
@@ -15,6 +15,8 @@
 //*************************************************************************
 
 #ifndef V3OPTION_PARSER_NO_VOPTION_BOOL
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "V3Global.h"
 #include "V3Options.h"
 #endif

--- a/src/V3OptionParser.h
+++ b/src/V3OptionParser.h
@@ -20,6 +20,8 @@
 #include "config_build.h"
 #include "verilatedos.h"
 
+#include "V3ThreadSafety.h"
+
 #include <functional>
 #include <memory>
 #include <string>
@@ -64,25 +66,27 @@ private:
     const std::unique_ptr<Impl> m_pimpl;
 
     // METHODS
-    ActionIfs* find(const char* optp);
+    ActionIfs* find(const char* optp) VL_MT_DISABLED;
     template <class ACT, class ARG>
-    ActionIfs& add(const string& opt, ARG arg);
-    static bool hasPrefixFNo(const char* strp);  // Returns true if strp starts with "-fno"
-    static bool hasPrefixNo(const char* strp);  // Returns true if strp starts with "-no"
+    ActionIfs& add(const string& opt, ARG arg) VL_MT_DISABLED;
+    // Returns true if strp starts with "-fno"
+    static bool hasPrefixFNo(const char* strp) VL_MT_DISABLED;
+    // Returns true if strp starts with "-no"
+    static bool hasPrefixNo(const char* strp) VL_MT_DISABLED;
 
 public:
     // METHODS
     // Returns how many args are consumed. 0 means not match
-    int parse(int idx, int argc, char* argv[]);
+    int parse(int idx, int argc, char* argv[]) VL_MT_DISABLED;
     // Find the most similar option
-    string getSuggestion(const char* str) const;
-    void addSuggestionCandidate(const string& s);
+    string getSuggestion(const char* str) const VL_MT_DISABLED;
+    void addSuggestionCandidate(const string& s) VL_MT_DISABLED;
     // Call this function after all options are registered.
-    void finalize();
+    void finalize() VL_MT_DISABLED;
 
     // CONSTRUCTORS
-    V3OptionParser();
-    ~V3OptionParser();
+    V3OptionParser() VL_MT_DISABLED;
+    ~V3OptionParser() VL_MT_DISABLED;
 };
 
 class V3OptionParser::ActionIfs VL_NOT_FINAL {
@@ -121,29 +125,33 @@ private:
 
 public:
     // METHODS
-    ActionIfs& operator()(const char* optp, Set, bool*) const;
+    ActionIfs& operator()(const char* optp, Set, bool*) const VL_MT_DISABLED;
 #ifndef V3OPTION_PARSER_NO_VOPTION_BOOL
-    ActionIfs& operator()(const char* optp, Set, VOptionBool*) const;
+    ActionIfs& operator()(const char* optp, Set, VOptionBool*) const VL_MT_DISABLED;
 #endif
-    ActionIfs& operator()(const char* optp, Set, int*) const;
-    ActionIfs& operator()(const char* optp, Set, string*) const;
+    ActionIfs& operator()(const char* optp, Set, int*) const VL_MT_DISABLED;
+    ActionIfs& operator()(const char* optp, Set, string*) const VL_MT_DISABLED;
 
-    ActionIfs& operator()(const char* optp, FOnOff, bool*) const;
-    ActionIfs& operator()(const char* optp, OnOff, bool*) const;
+    ActionIfs& operator()(const char* optp, FOnOff, bool*) const VL_MT_DISABLED;
+    ActionIfs& operator()(const char* optp, OnOff, bool*) const VL_MT_DISABLED;
 #ifndef V3OPTION_PARSER_NO_VOPTION_BOOL
-    ActionIfs& operator()(const char* optp, OnOff, VOptionBool*) const;
+    ActionIfs& operator()(const char* optp, OnOff, VOptionBool*) const VL_MT_DISABLED;
 #endif
 
-    ActionIfs& operator()(const char* optp, CbCall, std::function<void(void)>) const;
-    ActionIfs& operator()(const char* optp, CbFOnOff, std::function<void(bool)>) const;
-    ActionIfs& operator()(const char* optp, CbOnOff, std::function<void(bool)>) const;
-    ActionIfs& operator()(const char* optp, CbVal, std::function<void(int)>) const;
-    ActionIfs& operator()(const char* optp, CbVal, std::function<void(const char*)>) const;
+    ActionIfs& operator()(const char* optp, CbCall,
+                          std::function<void(void)>) const VL_MT_DISABLED;
+    ActionIfs& operator()(const char* optp, CbFOnOff,
+                          std::function<void(bool)>) const VL_MT_DISABLED;
+    ActionIfs& operator()(const char* optp, CbOnOff,
+                          std::function<void(bool)>) const VL_MT_DISABLED;
+    ActionIfs& operator()(const char* optp, CbVal, std::function<void(int)>) const VL_MT_DISABLED;
+    ActionIfs& operator()(const char* optp, CbVal,
+                          std::function<void(const char*)>) const VL_MT_DISABLED;
 
     ActionIfs& operator()(const char* optp, CbPartialMatch,
-                          std::function<void(const char*)>) const;
+                          std::function<void(const char*)>) const VL_MT_DISABLED;
     ActionIfs& operator()(const char* optp, CbPartialMatchVal,
-                          std::function<void(const char*, const char*)>) const;
+                          std::function<void(const char*, const char*)>) const VL_MT_DISABLED;
 
     // CONSTRUCTORS
     explicit AppendHelper(V3OptionParser& parser)

--- a/src/V3Options.h
+++ b/src/V3Options.h
@@ -22,6 +22,7 @@
 
 #include "V3Error.h"
 #include "V3LangCode.h"
+#include "V3ThreadSafety.h"
 
 #include <map>
 #include <set>
@@ -385,7 +386,7 @@ private:
 private:
     // METHODS
     void addArg(const string& arg);
-    void addDefine(const string& defline, bool allowPlus);
+    void addDefine(const string& defline, bool allowPlus) VL_MT_DISABLED;
     void addFuture(const string& flag);
     void addFuture0(const string& flag);
     void addFuture1(const string& flag);
@@ -426,7 +427,7 @@ public:
     void addForceInc(const string& filename);
     bool available() const VL_MT_SAFE { return m_available; }
     void ccSet();
-    void notify();
+    void notify() VL_MT_DISABLED;
 
     // ACCESSORS (options)
     bool preprocOnly() const { return m_preprocOnly; }
@@ -666,9 +667,9 @@ public:
     // Return options for child hierarchical blocks when forTop==false, otherwise returns args for
     // the top module.
     string allArgsStringForHierBlock(bool forTop) const;
-    void parseOpts(FileLine* fl, int argc, char** argv);
-    void parseOptsList(FileLine* fl, const string& optdir, int argc, char** argv);
-    void parseOptsFile(FileLine* fl, const string& filename, bool rel);
+    void parseOpts(FileLine* fl, int argc, char** argv) VL_MT_DISABLED;
+    void parseOptsList(FileLine* fl, const string& optdir, int argc, char** argv) VL_MT_DISABLED;
+    void parseOptsFile(FileLine* fl, const string& filename, bool rel) VL_MT_DISABLED;
 
     // METHODS (environment)
     // Most of these may be built into the executable with --enable-defenv,

--- a/src/V3Order.cpp
+++ b/src/V3Order.cpp
@@ -71,6 +71,8 @@
 //
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3Order.h
+++ b/src/V3Order.h
@@ -20,6 +20,8 @@
 #include "config_build.h"
 #include "verilatedos.h"
 
+#include "V3ThreadSafety.h"
+
 #include <functional>
 #include <unordered_map>
 #include <vector>
@@ -48,7 +50,7 @@ AstCFunc* order(
     bool parallel,  //
     bool slow,  //
     const ExternalDomainsProvider& externalDomains
-    = [](const AstVarScope*, std::vector<AstSenTree*>&) {});
+    = [](const AstVarScope*, std::vector<AstSenTree*>&) {}) VL_MT_DISABLED;
 
 };  // namespace V3Order
 

--- a/src/V3OrderGraph.h
+++ b/src/V3OrderGraph.h
@@ -92,10 +92,14 @@ public:
 
     // Methods to add edges representing constraints, utilizing the type system to help us ensure
     // the graph remains bipartite.
-    inline void addHardEdge(OrderLogicVertex* fromp, OrderVarVertex* top, int weight);
-    inline void addHardEdge(OrderVarVertex* fromp, OrderLogicVertex* top, int weight);
-    inline void addSoftEdge(OrderLogicVertex* fromp, OrderVarVertex* top, int weight);
-    inline void addSoftEdge(OrderVarVertex* fromp, OrderLogicVertex* top, int weight);
+    inline void addHardEdge(OrderLogicVertex* fromp, OrderVarVertex* top,
+                            int weight) VL_MT_DISABLED;
+    inline void addHardEdge(OrderVarVertex* fromp, OrderLogicVertex* top,
+                            int weight) VL_MT_DISABLED;
+    inline void addSoftEdge(OrderLogicVertex* fromp, OrderVarVertex* top,
+                            int weight) VL_MT_DISABLED;
+    inline void addSoftEdge(OrderVarVertex* fromp, OrderLogicVertex* top,
+                            int weight) VL_MT_DISABLED;
 };
 
 //======================================================================
@@ -114,9 +118,9 @@ class OrderEitherVertex VL_NOT_FINAL : public V3GraphVertex {
 
 protected:
     // CONSTRUCTOR
-    OrderEitherVertex(OrderGraph* graphp, AstSenTree* domainp)
-        : V3GraphVertex{graphp}
-        , m_domainp{domainp} {}
+    OrderEitherVertex(OrderGraph* graphp, AstSenTree* domainp) VL_MT_DISABLED
+        : V3GraphVertex{graphp},
+          m_domainp{domainp} {}
     ~OrderEitherVertex() override = default;
 
 public:
@@ -125,7 +129,7 @@ public:
 
     // ACCESSORS
     AstSenTree* domainp() const VL_MT_STABLE { return m_domainp; }
-    void domainp(AstSenTree* domainp) {
+    void domainp(AstSenTree* domainp) VL_MT_DISABLED {
 #if VL_DEBUG
         UASSERT(!m_domainp, "Domain should only be set once");
 #endif
@@ -142,11 +146,11 @@ class OrderLogicVertex final : public OrderEitherVertex {
 public:
     // CONSTRUCTOR
     OrderLogicVertex(OrderGraph* graphp, AstScope* scopep, AstSenTree* domainp,
-                     AstSenTree* hybridp, AstNode* nodep)
-        : OrderEitherVertex{graphp, domainp}
-        , m_nodep{nodep}
-        , m_scopep{scopep}
-        , m_hybridp{hybridp} {
+                     AstSenTree* hybridp, AstNode* nodep) VL_MT_DISABLED
+        : OrderEitherVertex{graphp, domainp},
+          m_nodep{nodep},
+          m_scopep{scopep},
+          m_hybridp{hybridp} {
         UASSERT_OBJ(scopep, nodep, "Must not be null");
         UASSERT_OBJ(!(domainp && hybridp), nodep, "Cannot have bot domainp and hybridp set");
     }
@@ -174,9 +178,9 @@ class OrderVarVertex VL_NOT_FINAL : public OrderEitherVertex {
 
 public:
     // CONSTRUCTOR
-    OrderVarVertex(OrderGraph* graphp, AstVarScope* vscp)
-        : OrderEitherVertex{graphp, nullptr}
-        , m_vscp{vscp} {}
+    OrderVarVertex(OrderGraph* graphp, AstVarScope* vscp) VL_MT_DISABLED
+        : OrderEitherVertex{graphp, nullptr},
+          m_vscp{vscp} {}
     ~OrderVarVertex() override = default;
 
     // ACCESSORS
@@ -195,7 +199,7 @@ class OrderVarStdVertex final : public OrderVarVertex {
     VL_RTTI_IMPL(OrderVarStdVertex, OrderVarVertex)
 public:
     // CONSTRUCTOR
-    OrderVarStdVertex(OrderGraph* graphp, AstVarScope* vscp)
+    OrderVarStdVertex(OrderGraph* graphp, AstVarScope* vscp) VL_MT_DISABLED
         : OrderVarVertex{graphp, vscp} {}
     ~OrderVarStdVertex() override = default;
 
@@ -212,7 +216,7 @@ class OrderVarPreVertex final : public OrderVarVertex {
     VL_RTTI_IMPL(OrderVarPreVertex, OrderVarVertex)
 public:
     // CONSTRUCTOR
-    OrderVarPreVertex(OrderGraph* graphp, AstVarScope* vscp)
+    OrderVarPreVertex(OrderGraph* graphp, AstVarScope* vscp) VL_MT_DISABLED
         : OrderVarVertex{graphp, vscp} {}
     ~OrderVarPreVertex() override = default;
 
@@ -229,7 +233,7 @@ class OrderVarPostVertex final : public OrderVarVertex {
     VL_RTTI_IMPL(OrderVarPostVertex, OrderVarVertex)
 public:
     // CONSTRUCTOR
-    OrderVarPostVertex(OrderGraph* graphp, AstVarScope* vscp)
+    OrderVarPostVertex(OrderGraph* graphp, AstVarScope* vscp) VL_MT_DISABLED
         : OrderVarVertex{graphp, vscp} {}
     ~OrderVarPostVertex() override = default;
 
@@ -246,7 +250,7 @@ class OrderVarPordVertex final : public OrderVarVertex {
     VL_RTTI_IMPL(OrderVarPordVertex, OrderVarVertex)
 public:
     // CONSTRUCTOR
-    OrderVarPordVertex(OrderGraph* graphp, AstVarScope* vscp)
+    OrderVarPordVertex(OrderGraph* graphp, AstVarScope* vscp) VL_MT_DISABLED
         : OrderVarVertex{graphp, vscp} {}
     ~OrderVarPordVertex() override = default;
 
@@ -267,8 +271,7 @@ class OrderEdge final : public V3GraphEdge {
     friend class OrderGraph;  // Only the OrderGraph can create these
     // CONSTRUCTOR
     OrderEdge(OrderGraph* graphp, OrderEitherVertex* fromp, OrderEitherVertex* top, int weight,
-              bool cutable)
-        : V3GraphEdge{graphp, fromp, top, weight, cutable} {}
+              bool cutable) VL_MT_DISABLED : V3GraphEdge{graphp, fromp, top, weight, cutable} {}
     ~OrderEdge() override = default;
 
     // LCOV_EXCL_START // Debug code
@@ -279,16 +282,20 @@ class OrderEdge final : public V3GraphEdge {
 //======================================================================
 // Inline methods
 
-void OrderGraph::addHardEdge(OrderLogicVertex* fromp, OrderVarVertex* top, int weight) {
+void OrderGraph::addHardEdge(OrderLogicVertex* fromp, OrderVarVertex* top,
+                             int weight) VL_MT_DISABLED {
     new OrderEdge{this, fromp, top, weight, /* cutable: */ false};
 }
-void OrderGraph::addHardEdge(OrderVarVertex* fromp, OrderLogicVertex* top, int weight) {
+void OrderGraph::addHardEdge(OrderVarVertex* fromp, OrderLogicVertex* top,
+                             int weight) VL_MT_DISABLED {
     new OrderEdge{this, fromp, top, weight, /* cutable: */ false};
 }
-void OrderGraph::addSoftEdge(OrderLogicVertex* fromp, OrderVarVertex* top, int weight) {
+void OrderGraph::addSoftEdge(OrderLogicVertex* fromp, OrderVarVertex* top,
+                             int weight) VL_MT_DISABLED {
     new OrderEdge{this, fromp, top, weight, /* cutable: */ true};
 }
-void OrderGraph::addSoftEdge(OrderVarVertex* fromp, OrderLogicVertex* top, int weight) {
+void OrderGraph::addSoftEdge(OrderVarVertex* fromp, OrderLogicVertex* top,
+                             int weight) VL_MT_DISABLED {
     new OrderEdge{this, fromp, top, weight, /* cutable: */ true};
 }
 

--- a/src/V3OrderMoveGraph.h
+++ b/src/V3OrderMoveGraph.h
@@ -27,6 +27,7 @@
 #include "V3Ast.h"
 #include "V3Graph.h"
 #include "V3OrderGraph.h"
+#include "V3ThreadSafety.h"
 
 #include <unordered_map>
 
@@ -49,11 +50,11 @@ protected:
     V3ListEnt<OrderMoveVertex*> m_readyVerticesE;  // List of ready under domain/scope
 public:
     // CONSTRUCTORS
-    OrderMoveVertex(V3Graph* graphp, OrderLogicVertex* logicp)
-        : V3GraphVertex{graphp}
-        , m_logicp{logicp}
-        , m_state{POM_WAIT}
-        , m_domScopep{nullptr} {}
+    OrderMoveVertex(V3Graph* graphp, OrderLogicVertex* logicp) VL_MT_DISABLED
+        : V3GraphVertex{graphp},
+          m_logicp{logicp},
+          m_state{POM_WAIT},
+          m_domScopep{nullptr} {}
     ~OrderMoveVertex() override = default;
 
     // METHODS
@@ -78,11 +79,11 @@ public:
     }
     OrderLogicVertex* logicp() const VL_MT_STABLE { return m_logicp; }
     bool isWait() const { return m_state == POM_WAIT; }
-    void setReady() {
+    void setReady() VL_MT_DISABLED {
         UASSERT(m_state == POM_WAIT, "Wait->Ready on node not in proper state");
         m_state = POM_READY;
     }
-    void setMoved() {
+    void setMoved() VL_MT_DISABLED {
         UASSERT(m_state == POM_READY, "Ready->Moved on node not in proper state");
         m_state = POM_MOVED;
     }
@@ -103,11 +104,10 @@ class MTaskMoveVertex final : public V3GraphVertex {
 
 public:
     MTaskMoveVertex(V3Graph* graphp, OrderLogicVertex* logicp, const OrderEitherVertex* varp,
-                    const AstSenTree* domainp)
-        : V3GraphVertex{graphp}
-        , m_logicp{logicp}
-        , m_varp{varp}
-        , m_domainp{domainp} {
+                    const AstSenTree* domainp) VL_MT_DISABLED : V3GraphVertex{graphp},
+                                                                m_logicp{logicp},
+                                                                m_varp{varp},
+                                                                m_domainp{domainp} {
         UASSERT(!(logicp && varp), "MTaskMoveVertex: logicp and varp may not both be set!\n");
     }
     ~MTaskMoveVertex() override = default;

--- a/src/V3Param.cpp
+++ b/src/V3Param.cpp
@@ -44,6 +44,8 @@
 //
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3Param.h
+++ b/src/V3Param.h
@@ -20,13 +20,15 @@
 #include "config_build.h"
 #include "verilatedos.h"
 
+#include "V3ThreadSafety.h"
+
 class AstNetlist;
 
 //============================================================================
 
 class V3Param final {
 public:
-    static void param(AstNetlist* rootp);
+    static void param(AstNetlist* rootp) VL_MT_DISABLED;
 };
 
 #endif  // Guard

--- a/src/V3Parse.h
+++ b/src/V3Parse.h
@@ -22,6 +22,7 @@
 
 #include "V3Error.h"
 #include "V3Global.h"
+#include "V3ThreadSafety.h"
 
 class AstNetlist;
 class VInFilter;
@@ -39,16 +40,16 @@ private:
 
 public:
     // We must allow reading multiple files into one parser
-    V3Parse(AstNetlist* rootp, VInFilter* filterp, V3ParseSym* symp);
-    ~V3Parse();
+    V3Parse(AstNetlist* rootp, VInFilter* filterp, V3ParseSym* symp) VL_MT_DISABLED;
+    ~V3Parse() VL_MT_DISABLED;
 
     // METHODS
     // Preprocess and read the Verilog file specified into the netlist database
     void parseFile(FileLine* fileline, const string& modname, bool inLibrary,
-                   const string& errmsg);
+                   const string& errmsg) VL_MT_DISABLED;
 
     // Push preprocessed text to the lexer
-    static void ppPushText(V3ParseImp* impp, const string& text);
+    static void ppPushText(V3ParseImp* impp, const string& text) VL_MT_DISABLED;
 };
 
 #endif  // Guard

--- a/src/V3ParseGrammar.cpp
+++ b/src/V3ParseGrammar.cpp
@@ -16,6 +16,8 @@
 
 #define YYDEBUG 1  // Nicer errors
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "V3Ast.h"  // This must be before V3ParseBison.cpp, as we don't want #defines to conflict
 
 VL_DEFINE_DEBUG_FUNCTIONS;

--- a/src/V3ParseImp.cpp
+++ b/src/V3ParseImp.cpp
@@ -22,6 +22,8 @@
 //           V3Lexer.yy.cpp     Flex output
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3ParseImp.h
+++ b/src/V3ParseImp.h
@@ -25,6 +25,7 @@
 #include "V3Global.h"
 #include "V3Parse.h"
 #include "V3ParseSym.h"
+#include "V3ThreadSafety.h"
 
 #include <algorithm>
 #include <deque>
@@ -126,7 +127,7 @@ struct V3ParseBisonYYSType {
 #include "V3Ast__gen_yystype.h"
     };
 };
-std::ostream& operator<<(std::ostream& os, const V3ParseBisonYYSType& rhs);
+std::ostream& operator<<(std::ostream& os, const V3ParseBisonYYSType& rhs) VL_MT_DISABLED;
 
 #define YYSTYPE V3ParseBisonYYSType
 
@@ -173,21 +174,21 @@ public:
 
     void tagNodep(AstNode* nodep) { m_tagNodep = nodep; }
     AstNode* tagNodep() const { return m_tagNodep; }
-    void lexTimescaleParse(FileLine* fl, const char* textp);
+    void lexTimescaleParse(FileLine* fl, const char* textp) VL_MT_DISABLED;
     void timescaleMod(FileLine* fl, AstNodeModule* modp, bool unitSet, double unitVal,
-                      bool precSet, double precVal);
+                      bool precSet, double precVal) VL_MT_DISABLED;
     VTimescale timeLastUnit() const { return m_timeLastUnit; }
 
     FileLine* lexFileline() const { return m_lexFileline; }
     FileLine* lexCopyOrSameFileLine() { return lexFileline()->copyOrSameFileLine(); }
-    static void lexErrorPreprocDirective(FileLine* fl, const char* textp);
-    static string lexParseTag(const char* textp);
-    static double lexParseTimenum(const char* text);
-    void lexPpline(const char* textp);
-    void lexVerilatorCmtLint(FileLine* fl, const char* textp, bool warnOff);
-    void lexVerilatorCmtLintSave(const FileLine* fl);
-    void lexVerilatorCmtLintRestore(FileLine* fl);
-    static void lexVerilatorCmtBad(FileLine* fl, const char* textp);
+    static void lexErrorPreprocDirective(FileLine* fl, const char* textp) VL_MT_DISABLED;
+    static string lexParseTag(const char* textp) VL_MT_DISABLED;
+    static double lexParseTimenum(const char* text) VL_MT_DISABLED;
+    void lexPpline(const char* textp) VL_MT_DISABLED;
+    void lexVerilatorCmtLint(FileLine* fl, const char* textp, bool warnOff) VL_MT_DISABLED;
+    void lexVerilatorCmtLintSave(const FileLine* fl) VL_MT_DISABLED;
+    void lexVerilatorCmtLintRestore(FileLine* fl) VL_MT_DISABLED;
+    static void lexVerilatorCmtBad(FileLine* fl, const char* textp) VL_MT_DISABLED;
 
     void lexPushKeywords(int state) {
         ++m_lexKwdDepth;
@@ -202,14 +203,14 @@ public:
         }
     }
     int lexKwdLastState() const { return m_lexKwdLast; }
-    static const char* tokenName(int tok);
-    static bool isStrengthToken(int tok);
+    static const char* tokenName(int tok) VL_MT_DISABLED;
+    static bool isStrengthToken(int tok) VL_MT_DISABLED;
 
     void ppPushText(const string& text) {
         m_ppBuffers.push_back(text);
         if (lexFileline()->contentp()) lexFileline()->contentp()->pushText(text);
     }
-    size_t ppInputToLex(char* buf, size_t max_size);
+    size_t ppInputToLex(char* buf, size_t max_size) VL_MT_DISABLED;
 
     static V3ParseImp* parsep() { return s_parsep; }
 
@@ -251,12 +252,12 @@ public:
     void unconnectedDrive(const VOptionBool flag) { m_unconnectedDrive = flag; }
 
     // Interactions with parser
-    int bisonParse();
+    int bisonParse() VL_MT_DISABLED;
 
     // Interactions with lexer
-    void lexNew();
-    void lexDestroy();
-    static int stateVerilogRecent();  // Parser -> lexer communication
+    void lexNew() VL_MT_DISABLED;
+    void lexDestroy() VL_MT_DISABLED;
+    static int stateVerilogRecent() VL_MT_DISABLED;  // Parser -> lexer communication
     int lexPrevToken() const { return m_lexPrevToken; }  // Parser -> lexer communication
     size_t flexPpInputToLex(char* buf, size_t max_size) { return ppInputToLex(buf, max_size); }
 
@@ -285,28 +286,29 @@ public:
         m_lexKwdLast = stateVerilogRecent();
         m_timeLastUnit = v3Global.opt.timeDefaultUnit();
     }
-    ~V3ParseImp();
-    void parserClear();
-    void lexUnputString(const char* textp, size_t length);
+    ~V3ParseImp() VL_MT_DISABLED;
+    void parserClear() VL_MT_DISABLED;
+    void lexUnputString(const char* textp, size_t length) VL_MT_DISABLED;
 
     // METHODS
     // Preprocess and read the Verilog file specified into the netlist database
-    int tokenToBison();  // Pass token to bison
+    int tokenToBison() VL_MT_DISABLED;  // Pass token to bison
 
     void parseFile(FileLine* fileline, const string& modfilename, bool inLibrary,
-                   const string& errmsg);
-    void dumpInputsFile();
+                   const string& errmsg) VL_MT_DISABLED;
+    void dumpInputsFile() VL_MT_DISABLED;
 
 private:
-    void lexFile(const string& modname);
-    void yylexReadTok();
-    void tokenPull();
-    void tokenPipeline();  // Internal; called from tokenToBison
-    void tokenPipelineSym();
-    size_t tokenPipeScanParam(size_t depth);
-    size_t tokenPipeScanType(size_t depth);
-    const V3ParseBisonYYSType* tokenPeekp(size_t depth);
-    void preprocDumps(std::ostream& os, bool forInputs);
+    void preprocDumps(std::ostream& os);
+    void lexFile(const string& modname) VL_MT_DISABLED;
+    void yylexReadTok() VL_MT_DISABLED;
+    void tokenPull() VL_MT_DISABLED;
+    void tokenPipeline() VL_MT_DISABLED;  // Internal; called from tokenToBison
+    void tokenPipelineSym() VL_MT_DISABLED;
+    size_t tokenPipeScanParam(size_t depth) VL_MT_DISABLED;
+    size_t tokenPipeScanType(size_t depth) VL_MT_DISABLED;
+    const V3ParseBisonYYSType* tokenPeekp(size_t depth) VL_MT_DISABLED;
+    void preprocDumps(std::ostream& os, bool forInputs) VL_MT_DISABLED;
 };
 
 #endif  // Guard

--- a/src/V3ParseLex.cpp
+++ b/src/V3ParseLex.cpp
@@ -14,6 +14,8 @@
 //
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3Partition.cpp
+++ b/src/V3Partition.cpp
@@ -14,6 +14,8 @@
 //
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3Partition.h
+++ b/src/V3Partition.h
@@ -23,6 +23,7 @@
 #include "V3Graph.h"
 #include "V3OrderGraph.h"
 #include "V3OrderMoveGraph.h"
+#include "V3ThreadSafety.h"
 
 #include <list>
 #include <unordered_map>
@@ -51,24 +52,24 @@ public:
 
     // Fill in the provided empty graph with AbstractLogicMTask's and their
     // interdependencies.
-    void go(V3Graph* mtasksp);
+    void go(V3Graph* mtasksp) VL_MT_DISABLED;
 
-    static void selfTest();
-    static void selfTestNormalizeCosts();
+    static void selfTest() VL_MT_DISABLED;
+    static void selfTestNormalizeCosts() VL_MT_DISABLED;
 
     // Print out a hash of the shape of graphp.  Only needed to debug the
     // origin of some nondeterminism; otherwise this is pretty useless.
-    static void hashGraphDebug(const V3Graph* graphp, const char* debugName);
+    static void hashGraphDebug(const V3Graph* graphp, const char* debugName) VL_MT_DISABLED;
 
     // Print debug stats about graphp whose nodes must be AbstractMTask's.
-    static void debugMTaskGraphStats(const V3Graph* graphp, const string& stage);
+    static void debugMTaskGraphStats(const V3Graph* graphp, const string& stage) VL_MT_DISABLED;
 
     // Operate on the final ExecMTask graph, immediately prior to code
     // generation time.
-    static void finalize(AstNetlist* netlistp);
+    static void finalize(AstNetlist* netlistp) VL_MT_DISABLED;
 
 private:
-    uint32_t setupMTaskDeps(V3Graph* mtasksp);
+    uint32_t setupMTaskDeps(V3Graph* mtasksp) VL_MT_DISABLED;
 
     VL_UNCOPYABLE(V3Partition);
 };

--- a/src/V3PartitionGraph.h
+++ b/src/V3PartitionGraph.h
@@ -31,8 +31,7 @@
 class AbstractMTask VL_NOT_FINAL : public V3GraphVertex {
     VL_RTTI_IMPL(AbstractMTask, V3GraphVertex)
 public:
-    explicit AbstractMTask(V3Graph* graphp)
-        : V3GraphVertex{graphp} {}
+    explicit AbstractMTask(V3Graph* graphp) VL_MT_DISABLED : V3GraphVertex{graphp} {}
     ~AbstractMTask() override = default;
     virtual uint32_t id() const = 0;
     virtual uint32_t cost() const = 0;
@@ -44,8 +43,7 @@ public:
     // TYPES
     using VxList = std::list<MTaskMoveVertex*>;
     // CONSTRUCTORS
-    explicit AbstractLogicMTask(V3Graph* graphp)
-        : AbstractMTask{graphp} {}
+    explicit AbstractLogicMTask(V3Graph* graphp) VL_MT_DISABLED : AbstractMTask{graphp} {}
     ~AbstractLogicMTask() override = default;
     // METHODS
     // Set of logic vertices in this mtask. Order is not significant.
@@ -70,10 +68,10 @@ private:
     VL_UNCOPYABLE(ExecMTask);
 
 public:
-    ExecMTask(V3Graph* graphp, AstMTaskBody* bodyp, uint32_t id)
-        : AbstractMTask{graphp}
-        , m_bodyp{bodyp}
-        , m_id{id} {}
+    ExecMTask(V3Graph* graphp, AstMTaskBody* bodyp, uint32_t id) VL_MT_DISABLED
+        : AbstractMTask{graphp},
+          m_bodyp{bodyp},
+          m_id{id} {}
     AstMTaskBody* bodyp() const { return m_bodyp; }
     uint32_t id() const override VL_MT_SAFE { return m_id; }
     uint32_t priority() const { return m_priority; }

--- a/src/V3PreProc.cpp
+++ b/src/V3PreProc.cpp
@@ -14,6 +14,8 @@
 //
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3PreProc.h
+++ b/src/V3PreProc.h
@@ -23,6 +23,7 @@
 #include "V3Error.h"
 #include "V3FileLine.h"
 #include "V3Global.h"
+#include "V3ThreadSafety.h"
 
 #include <iostream>
 #include <list>
@@ -57,7 +58,7 @@ public:
     virtual bool isEof() const = 0;  // Return true on EOF.
     virtual void insertUnreadback(const string& text) = 0;
 
-    FileLine* fileline();  ///< File/Line number for last getline call
+    FileLine* fileline() VL_MT_DISABLED;  ///< File/Line number for last getline call
 
     // CONTROL METHODS
     // These options control how the parsing proceeds
@@ -96,7 +97,7 @@ protected:
     void configure(FileLine* fl);
 
 public:
-    static V3PreProc* createPreProc(FileLine* fl);
+    static V3PreProc* createPreProc(FileLine* fl) VL_MT_DISABLED;
     virtual ~V3PreProc() = default;  // LCOV_EXCL_LINE  // Persistent
 };
 

--- a/src/V3PreShell.cpp
+++ b/src/V3PreShell.cpp
@@ -14,6 +14,8 @@
 //
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3PreShell.h
+++ b/src/V3PreShell.h
@@ -22,6 +22,7 @@
 
 #include "V3Error.h"
 #include "V3FileLine.h"
+#include "V3ThreadSafety.h"
 
 class V3ParseImp;
 class VInFilter;
@@ -32,15 +33,15 @@ class VSpellCheck;
 class V3PreShell final {
     // Static class for calling preprocessor
 public:
-    static void boot();
-    static void shutdown();
+    static void boot() VL_MT_DISABLED;
+    static void shutdown() VL_MT_DISABLED;
     static bool preproc(FileLine* fl, const string& modname, VInFilter* filterp,
-                        V3ParseImp* parsep, const string& errmsg);
-    static void preprocInclude(FileLine* fl, const string& modname);
-    static void defineCmdLine(const string& name, const string& value);
-    static void undef(const string& name);
-    static void dumpDefines(std::ostream& os);
-    static void candidateDefines(VSpellCheck* spellerp);
+                        V3ParseImp* parsep, const string& errmsg) VL_MT_DISABLED;
+    static void preprocInclude(FileLine* fl, const string& modname) VL_MT_DISABLED;
+    static void defineCmdLine(const string& name, const string& value) VL_MT_DISABLED;
+    static void undef(const string& name) VL_MT_DISABLED;
+    static void dumpDefines(std::ostream& os) VL_MT_DISABLED;
+    static void candidateDefines(VSpellCheck* spellerp) VL_MT_DISABLED;
 };
 
 #endif  // Guard

--- a/src/V3Premit.cpp
+++ b/src/V3Premit.cpp
@@ -24,6 +24,8 @@
 //
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3Premit.h
+++ b/src/V3Premit.h
@@ -20,13 +20,15 @@
 #include "config_build.h"
 #include "verilatedos.h"
 
+#include "V3ThreadSafety.h"
+
 class AstNetlist;
 
 //============================================================================
 
 class V3Premit final {
 public:
-    static void premitAll(AstNetlist* nodep);
+    static void premitAll(AstNetlist* nodep) VL_MT_DISABLED;
 };
 
 #endif  // Guard

--- a/src/V3ProtectLib.cpp
+++ b/src/V3ProtectLib.cpp
@@ -14,6 +14,8 @@
 //
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3ProtectLib.h
+++ b/src/V3ProtectLib.h
@@ -20,11 +20,13 @@
 #include "config_build.h"
 #include "verilatedos.h"
 
+#include "V3ThreadSafety.h"
+
 //============================================================================
 
 class V3ProtectLib final {
 public:
-    static void protect();
+    static void protect() VL_MT_DISABLED;
 };
 
 #endif  // Guard

--- a/src/V3Randomize.cpp
+++ b/src/V3Randomize.cpp
@@ -24,6 +24,8 @@
 //
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3Randomize.h
+++ b/src/V3Randomize.h
@@ -20,16 +20,18 @@
 #include "config_build.h"
 #include "verilatedos.h"
 
+#include "V3ThreadSafety.h"
+
 class AstClass;
 class AstFunc;
 class AstNetlist;
 
 class V3Randomize final {
 public:
-    static void randomizeNetlist(AstNetlist* nodep);
+    static void randomizeNetlist(AstNetlist* nodep) VL_MT_DISABLED;
 
-    static AstFunc* newRandomizeFunc(AstClass* nodep);
-    static AstFunc* newSRandomFunc(AstClass* nodep);
+    static AstFunc* newRandomizeFunc(AstClass* nodep) VL_MT_DISABLED;
+    static AstFunc* newSRandomFunc(AstClass* nodep) VL_MT_DISABLED;
 };
 
 #endif  // Guard

--- a/src/V3Reloop.cpp
+++ b/src/V3Reloop.cpp
@@ -29,6 +29,8 @@
 //
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3Reloop.h
+++ b/src/V3Reloop.h
@@ -20,13 +20,15 @@
 #include "config_build.h"
 #include "verilatedos.h"
 
+#include "V3ThreadSafety.h"
+
 class AstNetlist;
 
 //============================================================================
 
 class V3Reloop final {
 public:
-    static void reloopAll(AstNetlist* nodep);
+    static void reloopAll(AstNetlist* nodep) VL_MT_DISABLED;
 };
 
 #endif  // Guard

--- a/src/V3Sched.cpp
+++ b/src/V3Sched.cpp
@@ -35,6 +35,8 @@
 //
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3Sched.h
+++ b/src/V3Sched.h
@@ -21,6 +21,7 @@
 #include "verilatedos.h"
 
 #include "V3Ast.h"
+#include "V3ThreadSafety.h"
 
 #include <functional>
 #include <unordered_map>
@@ -130,12 +131,12 @@ public:
     AstNodeStmt* m_postUpdates = nullptr;  // Post updates for the trigger eval function
 
     // Remaps external domains using the specified trigger map
-    std::map<const AstVarScope*, std::vector<AstSenTree*>>
-    remapDomains(const std::unordered_map<const AstSenTree*, AstSenTree*>& trigMap) const;
+    std::map<const AstVarScope*, std::vector<AstSenTree*>> remapDomains(
+        const std::unordered_map<const AstSenTree*, AstSenTree*>& trigMap) const VL_MT_DISABLED;
     // Creates a timing resume call (if needed, else returns null)
-    AstCCall* createResume(AstNetlist* const netlistp);
+    AstCCall* createResume(AstNetlist* const netlistp) VL_MT_DISABLED;
     // Creates a timing commit call (if needed, else returns null)
-    AstCCall* createCommit(AstNetlist* const netlistp);
+    AstCCall* createCommit(AstNetlist* const netlistp) VL_MT_DISABLED;
 
     TimingKit() = default;
     TimingKit(LogicByScope&& lbs, AstNodeStmt* postUpdates,
@@ -149,19 +150,20 @@ public:
 };
 
 // Creates the timing kit and marks variables written by suspendables
-TimingKit prepareTiming(AstNetlist* const netlistp);
+TimingKit prepareTiming(AstNetlist* const netlistp) VL_MT_DISABLED;
 
 // Transforms fork sub-statements into separate functions
-void transformForks(AstNetlist* const netlistp);
+void transformForks(AstNetlist* const netlistp) VL_MT_DISABLED;
 
 // Top level entry point to scheduling
-void schedule(AstNetlist*);
+void schedule(AstNetlist*) VL_MT_DISABLED;
 
 // Sub-steps
-LogicByScope breakCycles(AstNetlist* netlistp, const LogicByScope& combinationalLogic);
+LogicByScope breakCycles(AstNetlist* netlistp,
+                         const LogicByScope& combinationalLogic) VL_MT_DISABLED;
 LogicRegions partition(LogicByScope& clockedLogic, LogicByScope& combinationalLogic,
-                       LogicByScope& hybridLogic);
-LogicReplicas replicateLogic(LogicRegions&);
+                       LogicByScope& hybridLogic) VL_MT_DISABLED;
+LogicReplicas replicateLogic(LogicRegions&) VL_MT_DISABLED;
 
 }  // namespace V3Sched
 

--- a/src/V3SchedAcyclic.cpp
+++ b/src/V3SchedAcyclic.cpp
@@ -33,6 +33,8 @@
 //
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3SchedPartition.cpp
+++ b/src/V3SchedPartition.cpp
@@ -34,6 +34,8 @@
 //
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3SchedReplicate.cpp
+++ b/src/V3SchedReplicate.cpp
@@ -34,6 +34,8 @@
 //
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3SchedTiming.cpp
+++ b/src/V3SchedTiming.cpp
@@ -24,6 +24,8 @@
 //
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3Scope.cpp
+++ b/src/V3Scope.cpp
@@ -21,6 +21,8 @@
 //
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3Scope.h
+++ b/src/V3Scope.h
@@ -20,13 +20,15 @@
 #include "config_build.h"
 #include "verilatedos.h"
 
+#include "V3ThreadSafety.h"
+
 class AstNetlist;
 
 //============================================================================
 
 class V3Scope final {
 public:
-    static void scopeAll(AstNetlist* nodep);
+    static void scopeAll(AstNetlist* nodep) VL_MT_DISABLED;
 };
 
 #endif  // Guard

--- a/src/V3Scoreboard.cpp
+++ b/src/V3Scoreboard.cpp
@@ -14,6 +14,8 @@
 //
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3Scoreboard.h
+++ b/src/V3Scoreboard.h
@@ -22,6 +22,7 @@
 
 #include "V3Error.h"
 #include "V3PairingHeap.h"
+#include "V3ThreadSafety.h"
 
 //===============================================================================================
 // V3Scoreboard is essentially a heap that can be hinted that some elements have changed keys, at
@@ -139,7 +140,7 @@ public:
 // ######################################################################
 
 namespace V3ScoreboardBase {
-void selfTest();
+void selfTest() VL_MT_DISABLED;
 }  // namespace V3ScoreboardBase
 
 #endif  // Guard

--- a/src/V3Slice.cpp
+++ b/src/V3Slice.cpp
@@ -35,6 +35,8 @@
 // simplified to look primarily for SLICESELs.
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3Slice.h
+++ b/src/V3Slice.h
@@ -20,13 +20,15 @@
 #include "config_build.h"
 #include "verilatedos.h"
 
+#include "V3ThreadSafety.h"
+
 class AstNetlist;
 
 //============================================================================
 
 class V3Slice final {
 public:
-    static void sliceAll(AstNetlist* nodep);
+    static void sliceAll(AstNetlist* nodep) VL_MT_DISABLED;
 };
 
 #endif  // Guard

--- a/src/V3Split.cpp
+++ b/src/V3Split.cpp
@@ -77,6 +77,8 @@
 //
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3Split.h
+++ b/src/V3Split.h
@@ -20,14 +20,16 @@
 #include "config_build.h"
 #include "verilatedos.h"
 
+#include "V3ThreadSafety.h"
+
 class AstNetlist;
 
 //============================================================================
 
 class V3Split final {
 public:
-    static void splitReorderAll(AstNetlist* nodep);
-    static void splitAlwaysAll(AstNetlist* nodep);
+    static void splitReorderAll(AstNetlist* nodep) VL_MT_DISABLED;
+    static void splitAlwaysAll(AstNetlist* nodep) VL_MT_DISABLED;
 };
 
 #endif  // Guard

--- a/src/V3SplitAs.cpp
+++ b/src/V3SplitAs.cpp
@@ -21,6 +21,8 @@
 //
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3SplitAs.h
+++ b/src/V3SplitAs.h
@@ -20,13 +20,15 @@
 #include "config_build.h"
 #include "verilatedos.h"
 
+#include "V3ThreadSafety.h"
+
 class AstNetlist;
 
 //============================================================================
 
 class V3SplitAs final {
 public:
-    static void splitAsAll(AstNetlist* nodep);
+    static void splitAsAll(AstNetlist* nodep) VL_MT_DISABLED;
 };
 
 #endif  // Guard

--- a/src/V3SplitVar.cpp
+++ b/src/V3SplitVar.cpp
@@ -110,6 +110,8 @@
 //
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3SplitVar.h
+++ b/src/V3SplitVar.h
@@ -19,17 +19,19 @@
 
 //============================================================================
 
+#include "V3ThreadSafety.h"
+
 class AstNetlist;
 class AstVar;
 
 class V3SplitVar final {
 public:
     // Split variables marked with split_var metacomment.
-    static void splitVariable(AstNetlist* nodep);
+    static void splitVariable(AstNetlist* nodep) VL_MT_DISABLED;
 
     // Return true if the variable can be split.
     // This check is not perfect.
-    static bool canSplitVar(const AstVar* varp);
+    static bool canSplitVar(const AstVar* varp) VL_MT_DISABLED;
 };
 
 #endif  // Guard

--- a/src/V3Subst.cpp
+++ b/src/V3Subst.cpp
@@ -22,6 +22,8 @@
 //
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3Subst.h
+++ b/src/V3Subst.h
@@ -20,13 +20,15 @@
 #include "config_build.h"
 #include "verilatedos.h"
 
+#include "V3ThreadSafety.h"
+
 class AstNetlist;
 
 //============================================================================
 
 class V3Subst final {
 public:
-    static void substituteAll(AstNetlist* nodep);
+    static void substituteAll(AstNetlist* nodep) VL_MT_DISABLED;
 };
 
 #endif  // Guard

--- a/src/V3TSP.cpp
+++ b/src/V3TSP.cpp
@@ -19,6 +19,8 @@
 //
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3TSP.h
+++ b/src/V3TSP.h
@@ -22,6 +22,7 @@
 #include "verilatedos.h"
 
 #include "V3Error.h"
+#include "V3ThreadSafety.h"
 
 #include <vector>
 
@@ -49,9 +50,9 @@ using StateVec = std::vector<const TspStateBase*>;
 
 // Given an unsorted set of TspState's, sort them to minimize
 // the transition cost for walking the sorted list.
-void tspSort(const StateVec& states, StateVec* resultp);
+void tspSort(const StateVec& states, StateVec* resultp) VL_MT_DISABLED;
 
-void selfTest();
+void selfTest() VL_MT_DISABLED;
 }  // namespace V3TSP
 
 #endif  // Guard

--- a/src/V3Table.cpp
+++ b/src/V3Table.cpp
@@ -21,6 +21,8 @@
 //
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3Table.h
+++ b/src/V3Table.h
@@ -20,13 +20,15 @@
 #include "config_build.h"
 #include "verilatedos.h"
 
+#include "V3ThreadSafety.h"
+
 class AstNetlist;
 
 //============================================================================
 
 class V3Table final {
 public:
-    static void tableAll(AstNetlist* nodep);
+    static void tableAll(AstNetlist* nodep) VL_MT_DISABLED;
 };
 
 #endif  // Guard

--- a/src/V3Task.cpp
+++ b/src/V3Task.cpp
@@ -23,6 +23,8 @@
 //
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3Task.h
+++ b/src/V3Task.h
@@ -22,6 +22,7 @@
 
 #include "V3Ast.h"
 #include "V3Error.h"
+#include "V3ThreadSafety.h"
 
 #include <utility>
 #include <vector>
@@ -51,19 +52,20 @@ class V3Task final {
     static const char* const s_dpiTemporaryVarSuffix;
 
 public:
-    static void taskAll(AstNetlist* nodep);
+    static void taskAll(AstNetlist* nodep) VL_MT_DISABLED;
     /// Return vector of [port, pin-connects-to]  (SLOW)
     static V3TaskConnects taskConnects(AstNodeFTaskRef* nodep, AstNode* taskStmtsp,
-                                       V3TaskConnectState* statep = nullptr);
+                                       V3TaskConnectState* statep = nullptr) VL_MT_DISABLED;
     static void taskConnectWrap(AstNodeFTaskRef* nodep, const V3TaskConnects& tconnects,
                                 V3TaskConnectState* statep,
-                                const std::set<const AstVar*>& argWrap);
+                                const std::set<const AstVar*>& argWrap) VL_MT_DISABLED;
     static AstNodeFTask* taskConnectWrapNew(AstNodeFTask* taskp, const string& newname,
                                             const V3TaskConnects& tconnects,
-                                            const std::set<const AstVar*>& argWrap);
+                                            const std::set<const AstVar*>& argWrap) VL_MT_DISABLED;
     static string assignInternalToDpi(AstVar* portp, bool isPtr, const string& frSuffix,
-                                      const string& toSuffix, const string& frPrefix = "");
-    static string assignDpiToInternal(const string& lhsName, AstVar* rhsp);
+                                      const string& toSuffix,
+                                      const string& frPrefix = "") VL_MT_DISABLED;
+    static string assignDpiToInternal(const string& lhsName, AstVar* rhsp) VL_MT_DISABLED;
     static const char* dpiTemporaryVarSuffix() VL_MT_SAFE { return s_dpiTemporaryVarSuffix; }
 };
 

--- a/src/V3Timing.cpp
+++ b/src/V3Timing.cpp
@@ -44,6 +44,8 @@
 //
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3Timing.h
+++ b/src/V3Timing.h
@@ -21,12 +21,13 @@
 #include "verilatedos.h"
 
 #include "V3Ast.h"
+#include "V3ThreadSafety.h"
 
 //============================================================================
 
 class V3Timing final {
 public:
-    static void timingAll(AstNetlist* nodep);
+    static void timingAll(AstNetlist* nodep) VL_MT_DISABLED;
 };
 
 #endif  // Guard

--- a/src/V3Trace.cpp
+++ b/src/V3Trace.cpp
@@ -35,6 +35,8 @@
 //
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3Trace.h
+++ b/src/V3Trace.h
@@ -20,13 +20,15 @@
 #include "config_build.h"
 #include "verilatedos.h"
 
+#include "V3ThreadSafety.h"
+
 class AstNetlist;
 
 //============================================================================
 
 class V3Trace final {
 public:
-    static void traceAll(AstNetlist* nodep);
+    static void traceAll(AstNetlist* nodep) VL_MT_DISABLED;
 };
 
 #endif  // Guard

--- a/src/V3TraceDecl.cpp
+++ b/src/V3TraceDecl.cpp
@@ -20,6 +20,8 @@
 //
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3TraceDecl.h
+++ b/src/V3TraceDecl.h
@@ -20,13 +20,15 @@
 #include "config_build.h"
 #include "verilatedos.h"
 
+#include "V3ThreadSafety.h"
+
 class AstNetlist;
 
 //============================================================================
 
 class V3TraceDecl final {
 public:
-    static void traceDeclAll(AstNetlist* nodep);
+    static void traceDeclAll(AstNetlist* nodep) VL_MT_DISABLED;
 };
 
 #endif  // Guard

--- a/src/V3Tristate.cpp
+++ b/src/V3Tristate.cpp
@@ -115,6 +115,8 @@
 // unsupported.
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3Tristate.h
+++ b/src/V3Tristate.h
@@ -20,13 +20,15 @@
 #include "config_build.h"
 #include "verilatedos.h"
 
+#include "V3ThreadSafety.h"
+
 class AstNetlist;
 
 //============================================================================
 
 class V3Tristate final {
 public:
-    static void tristateAll(AstNetlist* nodep);
+    static void tristateAll(AstNetlist* nodep) VL_MT_DISABLED;
 };
 
 #endif  // Guard

--- a/src/V3Undriven.cpp
+++ b/src/V3Undriven.cpp
@@ -23,6 +23,8 @@
 //
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3Undriven.h
+++ b/src/V3Undriven.h
@@ -20,13 +20,15 @@
 #include "config_build.h"
 #include "verilatedos.h"
 
+#include "V3ThreadSafety.h"
+
 class AstNetlist;
 
 //============================================================================
 
 class V3Undriven final {
 public:
-    static void undrivenAll(AstNetlist* nodep);
+    static void undrivenAll(AstNetlist* nodep) VL_MT_DISABLED;
 };
 
 #endif  // Guard

--- a/src/V3Unknown.cpp
+++ b/src/V3Unknown.cpp
@@ -28,6 +28,8 @@
 //
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3Unknown.h
+++ b/src/V3Unknown.h
@@ -20,13 +20,15 @@
 #include "config_build.h"
 #include "verilatedos.h"
 
+#include "V3ThreadSafety.h"
+
 class AstNetlist;
 
 //============================================================================
 
 class V3Unknown final {
 public:
-    static void unknownAll(AstNetlist* nodep);
+    static void unknownAll(AstNetlist* nodep) VL_MT_DISABLED;
 };
 
 #endif  // Guard

--- a/src/V3Unroll.cpp
+++ b/src/V3Unroll.cpp
@@ -24,6 +24,8 @@
 //
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3Unroll.h
+++ b/src/V3Unroll.h
@@ -22,6 +22,7 @@
 
 #include "V3Ast.h"
 #include "V3Error.h"
+#include "V3ThreadSafety.h"
 
 //============================================================================
 /// Unroller with saved state, so caller can determine when pushDelete's are executed.
@@ -35,18 +36,18 @@ class UnrollStateful final {
 
 public:
     // CONSTRUCTORS
-    UnrollStateful();
-    ~UnrollStateful();
+    UnrollStateful() VL_MT_DISABLED;
+    ~UnrollStateful() VL_MT_DISABLED;
     // METHODS
-    void unrollGen(AstNodeFor* nodep, const string& beginName);
-    void unrollAll(AstNetlist* nodep);
+    void unrollGen(AstNodeFor* nodep, const string& beginName) VL_MT_DISABLED;
+    void unrollAll(AstNetlist* nodep) VL_MT_DISABLED;
 };
 
 //============================================================================
 
 class V3Unroll final {
 public:
-    static void unrollAll(AstNetlist* nodep);
+    static void unrollAll(AstNetlist* nodep) VL_MT_DISABLED;
 };
 
 #endif  // Guard

--- a/src/V3VariableOrder.cpp
+++ b/src/V3VariableOrder.cpp
@@ -20,6 +20,8 @@
 //
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3VariableOrder.h
+++ b/src/V3VariableOrder.h
@@ -20,11 +20,13 @@
 #include "config_build.h"
 #include "verilatedos.h"
 
+#include "V3ThreadSafety.h"
+
 //============================================================================
 
 class V3VariableOrder final {
 public:
-    static void orderAll();
+    static void orderAll() VL_MT_DISABLED;
 };
 
 #endif  // Guard

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -124,7 +124,8 @@ std::ostream& operator<<(std::ostream& str, const Castable& rhs) {
     v3errorEnd( \
         v3errorBuildMessage(V3Error::v3errorPrep((lhs) < (rhs)   ? V3ErrorCode::WIDTHTRUNC \
                                                  : (lhs) > (rhs) ? V3ErrorCode::WIDTHEXPAND \
-                                                                 : V3ErrorCode::WIDTH), \
+                                                                 : V3ErrorCode::WIDTH, \
+                                                 VL_MT_DISABLED_CODE_UNIT), \
                             msg))
 
 //######################################################################

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -63,6 +63,8 @@
 // iterateSubtreeReturnEdits.
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3Width.h
+++ b/src/V3Width.h
@@ -20,6 +20,8 @@
 #include "config_build.h"
 #include "verilatedos.h"
 
+#include "V3ThreadSafety.h"
+
 class AstNetlist;
 class AstNode;
 class AstNodeDType;
@@ -28,18 +30,18 @@ class AstNodeDType;
 
 class V3Width final {
 public:
-    static void width(AstNetlist* nodep);
-    static AstNode* widthParamsEdit(AstNode* nodep);
-    static AstNode* widthGenerateParamsEdit(AstNode* nodep);
+    static void width(AstNetlist* nodep) VL_MT_DISABLED;
+    static AstNode* widthParamsEdit(AstNode* nodep) VL_MT_DISABLED;
+    static AstNode* widthGenerateParamsEdit(AstNode* nodep) VL_MT_DISABLED;
     // Final step... Mark all widths as equal
-    static void widthCommit(AstNetlist* nodep);
+    static void widthCommit(AstNetlist* nodep) VL_MT_DISABLED;
 
-    static AstNodeDType* getCommonClassTypep(AstNode* nodep1, AstNode* nodep2);
+    static AstNodeDType* getCommonClassTypep(AstNode* nodep1, AstNode* nodep2) VL_MT_DISABLED;
 
     // For use only in WidthVisitor
     // Replace AstSelBit, etc with AstSel/AstArraySel
     // Returns replacement node if nodep was deleted, or null if none.
-    static AstNode* widthSelNoIterEdit(AstNode* nodep);
+    static AstNode* widthSelNoIterEdit(AstNode* nodep) VL_MT_DISABLED;
 };
 
 #endif  // Guard

--- a/src/V3WidthSel.cpp
+++ b/src/V3WidthSel.cpp
@@ -26,6 +26,8 @@
 //
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/Verilator.cpp
+++ b/src/Verilator.cpp
@@ -14,6 +14,8 @@
 //
 //*************************************************************************
 
+#define VL_MT_CONTROL_CODE_UNIT 1
+
 #include "V3Active.h"
 #include "V3ActiveTop.h"
 #include "V3Assert.h"

--- a/src/VlcMain.cpp
+++ b/src/VlcMain.cpp
@@ -15,6 +15,8 @@
 //*************************************************************************
 
 // clang-format off
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "config_build.h"
 #ifndef HAVE_CONFIG_PACKAGE
 # error "Something failed during ./configure as config_package.h is incomplete. Perhaps you used autoreconf, don't."

--- a/src/VlcOptions.h
+++ b/src/VlcOptions.h
@@ -20,6 +20,8 @@
 #include "config_build.h"
 #include "verilatedos.h"
 
+#include "V3ThreadSafety.h"
+
 #include "config_rev.h"
 
 #include <map>
@@ -47,7 +49,7 @@ class VlcOptions final {
 
 private:
     // METHODS
-    static void showVersion(bool verbose);
+    static void showVersion(bool verbose) VL_MT_DISABLED;
 
 public:
     // CONSTRUCTORS
@@ -55,8 +57,8 @@ public:
     ~VlcOptions() = default;
 
     // METHODS
-    void parseOptsList(int argc, char** argv);
-    void addReadFile(const string& filename);
+    void parseOptsList(int argc, char** argv) VL_MT_DISABLED;
+    void addReadFile(const string& filename) VL_MT_DISABLED;
 
     // ACCESSORS (options)
     const VlStringSet& readFiles() const { return m_readFiles; }
@@ -70,7 +72,7 @@ public:
     string writeInfoFile() const { return m_writeInfoFile; }
 
     // METHODS (from main)
-    static string version();
+    static string version() VL_MT_DISABLED;
 };
 
 //######################################################################

--- a/src/VlcTop.cpp
+++ b/src/VlcTop.cpp
@@ -14,6 +14,8 @@
 //
 //*************************************************************************
 
+#define VL_MT_DISABLED_CODE_UNIT 1
+
 #include "VlcTop.h"
 
 #include "V3Error.h"

--- a/src/verilog.y
+++ b/src/verilog.y
@@ -120,15 +120,16 @@ public:
     }
 
     // METHODS
-    AstArg* argWrapList(AstNodeExpr* nodep);
+    AstArg* argWrapList(AstNodeExpr* nodep) VL_MT_DISABLED;
     bool allTracingOn(FileLine* fl) {
         return v3Global.opt.trace() && m_tracingParse && fl->tracingOn();
     }
-    AstRange* scrubRange(AstNodeRange* rangep);
-    AstNodeDType* createArray(AstNodeDType* basep, AstNodeRange* rangep, bool isPacked);
+    AstRange* scrubRange(AstNodeRange* rangep) VL_MT_DISABLED;
+    AstNodeDType* createArray(AstNodeDType* basep, AstNodeRange* rangep,
+                              bool isPacked) VL_MT_DISABLED;
     AstVar* createVariable(FileLine* fileline, const string& name, AstNodeRange* arrayp,
-                           AstNode* attrsp);
-    AstNode* createSupplyExpr(FileLine* fileline, const string& name, int value);
+                           AstNode* attrsp) VL_MT_DISABLED;
+    AstNode* createSupplyExpr(FileLine* fileline, const string& name, int value) VL_MT_DISABLED;
     AstText* createTextQuoted(FileLine* fileline, const string& text) {
         string newtext = deQuote(fileline, text);
         return new AstText{fileline, newtext};
@@ -254,7 +255,7 @@ public:
             return createArray(dtypep, rangearraysp, isPacked);
         }
     }
-    string deQuote(FileLine* fileline, string text);
+    string deQuote(FileLine* fileline, string text) VL_MT_DISABLED;
     void checkDpiVer(FileLine* fileline, const string& str) {
         if (str != "DPI-C" && !v3Global.opt.bboxSys()) {
             fileline->v3error("Unsupported DPI type '" << str << "': Use 'DPI-C'");


### PR DESCRIPTION
## Description

Verilator code units (.cpp files, and as a result .o files) were split into 3 groups:

- MT_DISABLED
- MT_ENABLED
- MT_CONTROL

Grouping is done in `Makefile_obj.in` and signalled to the compiler through preprocessor defines passed using `-D` flags.

### MT_DISABLED Code Units

- Have PP define `VL_MT_DISABLED_CODE_UNIT=1`.
- All code in those units is assumed to not support multithreading:
  - Can be executed only in the main thread
  - Any worker threads, if they exist, are not allowed to do anything at all while MT_DISABLED code is being executed.
  - Thread safety analysis is performed in limited manner:
    - All `VL_REQUIRES`, `VL_GUARDED_BY`, `VL_PT_GUARDED_BY` are ignored, so mutex locking is not required (but allowed). This is safe due to the assumption that only one thread is in use.
    - If there is any mutex locking, proper lock-unlock pairing is still checked and required. Also, `VL_EXCLUDES` is still enforced.
- `V3ThreadPool.h` is not allowed to be included. This rule is enforced by the compiler.
- Every declaration of function/method defined in one of those units must be annotated with `VL_MT_DISABLED`.
  Enforced by `t_a5_attributes_src.pl` test.
  - Exception: declarations in the .cpp file itself. Everything in MT_DISABLED .cpp files is implicitly marked as `VL_MT_DISABLED`.
- Can call:
  - MT_DISABLED code
  - MT_ENABLED code
    - This is currently safe only for MT_ENABLED code that does not use multithreading (all utility code
    - Todo: actually disable multithreading in such cases, so even MT_ENABLED code that schedules jobs will use only one thread.

### MT_ENABLED Code Units

- No extra PP defines.
- All code in those units is assumed to be fully aware of multithreading.
  - Thread safety analysis is performed without limitations.
- Can use V3ThreadPool.
- Can call:
  - MT_ENABLED code

### MT_CONTROL Code Units

In practice the code unit with `main()`, i.e. "Verilator.cpp".

- Have PP define `VL_MT_CONTROL_CODE_UNIT=1`.
- Is allowed to control multithreading, which includes:
  - Changing threads count. Unenforced and not checked currently.
  - Locking `v3MtDisabledLock()`, which allows running MT_DISABLED code. Enforced by the compiler.
- All code in those units is assumed to be aware of multithreading.
  - Thread safety analysis is performed without limitations.
- Can call:
  - MT_ENABLED code
  - MT_CONTROL code
  - MT_DISABLED code (after locking `v3MtDisabledLock()`)

## Rationale

Parallelization of new stages requires that more and more global code is also parallelized, e.g. by requiring a mutex locking when some resource is accessed. To give an example, something I'm working on - mutex-guarded access to the type table and the AST.

Without MT_DISABLED feature introduced in this PR we would need to refactor the whole codebase in order to properly handle global resource's new locking requirements. This can result in literally months of extra work just to thread-safe code that will never run in presence of an active background job, which currently includes almost all stages.

With most stages marked as MT_DISABLED we only need to parallelize:

- The stage we're parallelizing.
- Stages called by the parallelized stage.
- Global and utility code.

This will allow us to introduce actual improvements a lot faster and with greater quality.

## Implementation details

Nothing complicated, actually. Code in MT_DISABLED Code Units is forced to use `VL_MT_DISABLED` annotation, which wraps `VL_REQUIRES(V3MtDisabledLock::instance())`. Globally accessible `V3MtDisabledLock::instance()` returns a const reference, which can't be locked. As a result, code in MT_ENABLED Code Units is not able to call code requiring it. Code in MT_DISABLED Code Units has no such problem, as `VL_REQUIRES` is ignored there. Code in MT_CONTROL Code Unit is given (via definition under `#ifdef VL_MT_CONTROL_CODE_UNIT`) access to `v3MtDisabledLock()`, which returns mutable (and lockable) reference to the lock object.

The lock class (`V3MtDisabledLock`) doesn't have any data members and does nothing from C++ point of view. It is probably even optimized-out from compiled code. However, it has Clang thread safety annotations, which is all that matter to the thread safety analyzer.

## Commits

The commits were organized to allow commit-after-commit review. Everything is changed once - when a commit introduces or changes something it is not changed anymore in any commits following it.

> - Move `dpiTemporaryVarSuffix()` to header.
> - Add VL_UNMOVABLE.
> - Check whether V3ERROR_NO_GLOBAL_ is not already defined.

Small refactoring. Prepares code for the actual feature implementation.

> - MT_DISABLED implementation.

Introduces the feature implementation into codebase.

> - Add option for generating `compile_commands.json` using `bear`.
> - CI: Install and use `bear`.
> - clang_check_attributes: Add support for compile_commands.json.

We have different compilation flags (more precisely, different defines) in different source files. We need to pass that information to tests. I think `compile_commands.json` is one of the easiest and probably most useful ways of doing it.

> - clang_check_attributes: Add MT_DISABLED annotation checking.
> - clang_check_attributes: Improve error handling.
> - Update tests.

Extends `t_a5_attributes_src.pl` test with VL_MT_DISABLED annotation checks.
Error handling in `clang_check_attributes` has been slightly improved - it now displays Clang errors when they appear during parsing.

> - Add annotations where necessary.

Adds annotations where they are needed. Annotations were added in two passes:
- First: every declaration reported by `t_a5_attributes_src.pl` test.
- Second: functions that call code annotated in the first pass. All these functions were reported by clang thanks to thread safety analyzer. This pass required a few compilation cycles, as some newly annotated functions caused other functions that use them to fail.

Note: Clangd can be used instead of a compilation in the second pass to get a continuously updating report.

Note 2: Please review this last. It's really big commit and really boring one.

> - Execute MT_DISABLED stages with `v3MtDisabledLock` locked.

Can be seen as the third annotating pass: all thread safety analyzer errors from `Verilator.cpp` were resolved by calling MT_DISABLED functions in sections where `v3MtDisabledLock` is locked.

Note: "Ignore whitespace" feature is recommended when viewing the diff.

> - V3LockGuard: Add constructor for adopting already locked mutex.

Adds support for `std::adopt_lock_t` https://en.cppreference.com/w/cpp/thread/lock_tag_t

> - Rename and slightly change other threads stopping/resuming methods.
> - Suspend multithreading in MtDisabled sections.

Make `v3MtDisabledLock` work as extended version of Exclusive Access scope. Extra requirement here:
- No job is in progress (worker threads have to be stopped in "waiting for a job" point).
- Jobs queue has to be empty.

When any thread performs a job and stop in `waitIfStopRequested()` called inside the job as a result of call to `stopOtherThreads()` called from `v3MtDisabledLock` locking implementation, it causes an assertion fail due to the first requirement.

> - t_dist_attributes_bad: perform test using compile_commands.json.
> - t_dist_attributes_bad: test VL_MT_DISABLED annotation checking.

Test for checking of `VL_MT_DISABLED` annotations and use of compile_commands.json.
