### PR TITLE
Fix missing assignment for wide unpacked structs

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -73,6 +73,7 @@ Jiuyang Liu
 Joey Liu
 John Coiner
 John Demme
+Jiamin Zhu
 Jonathan Drolet
 Jose Loyola
 Joseph Nwabueze

--- a/src/V3EmitCFunc.h
+++ b/src/V3EmitCFunc.h
@@ -354,6 +354,7 @@ public:
                    && !VN_IS(nodep->rhsp(), CMethodHard)  //
                    && !VN_IS(nodep->rhsp(), VarRef)  //
                    && !VN_IS(nodep->rhsp(), AssocSel)  //
+                   && !VN_IS(nodep->rhsp(), StructSel)  //
                    && !VN_IS(nodep->rhsp(), ArraySel)) {
             // Wide functions assign into the array directly, don't need separate assign statement
             m_wideTempRefp = VN_AS(nodep->lhsp(), VarRef);

--- a/test_regress/t/t_structu_wide.pl
+++ b/test_regress/t/t_structu_wide.pl
@@ -1,0 +1,22 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2003 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    verilator_flags2 => [ '-DWIDE_WIDTH=128' ],
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_structu_wide.v
+++ b/test_regress/t/t_structu_wide.v
@@ -1,0 +1,29 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2022 by Jomit626.
+// SPDX-License-Identifier: CC0-1.0
+
+`ifndef WIDE_WIDTH
+`define WIDE_WIDTH 128
+`endif
+
+module t ();
+    typedef struct {
+        bit [`WIDE_WIDTH-1:0] data;
+    } wide_t;
+
+    logic [`WIDE_WIDTH-1:0] ldata;
+    wide_t wide_0;
+
+    initial begin
+        wide_0.data = `WIDE_WIDTH'hda7ada7a;
+        ldata = wide_0.data;
+
+        if (ldata != `WIDE_WIDTH'hda7ada7a)
+            $stop();
+
+        $write("*-* All Finished *-*\n");
+        $finish();
+    end
+endmodule


### PR DESCRIPTION
``` systemverilog
module t ();
    typedef struct {
        bit [`WIDE_WIDTH-1:0] data;
    } wide_t;

    logic [`WIDE_WIDTH-1:0] ldata;
    wide_t wide_0;

    initial begin
        wide_0.data = `WIDE_WIDTH'hda7ada7a;
        ldata = wide_0.data;

        if (ldata != `WIDE_WIDTH'hda7ada7a)
            $stop();

        $write("*-* All Finished *-*\n");
        $finish();
    end
endmodule
```
with `WIDE_WIDTH=128`, this test fails. But it works with `WIDE_WIDTH=129`.

I found that it is caused by V3EmitCFunc failed to emit a complete line for `AstNodeAssign` with `AstStructSel` as its rhs.
Adding one line fixes the problem, but I am not sure if it is related to V3Premit.