### PR TITLE
Add support for class members of unpacked struct type

### DIFF
--- a/src/V3AstNodeExpr.h
+++ b/src/V3AstNodeExpr.h
@@ -1450,7 +1450,7 @@ public:
     void name(const string& name) override { m_name = name; }
     string emitVerilog() override { V3ERROR_NA_RETURN(""); }
     string emitC() override { V3ERROR_NA_RETURN(""); }
-    bool cleanOut() const override { return false; }
+    bool cleanOut() const override { return true; }
     bool same(const AstNode* samep) const override { return true; }  // dtype comparison does it
     int instrCount() const override { return widthInstrs(); }
     AstVar* varp() const { return m_varp; }

--- a/test_regress/t/t_struct_assign.v
+++ b/test_regress/t/t_struct_assign.v
@@ -9,7 +9,12 @@ module t (/*AUTOARG*/);
       int fst, snd;
    } pair_t;
 
+   class Cls;
+      pair_t p;
+   endclass
+
    pair_t a, b;
+   Cls c = new;
 
    initial begin
       a.fst = 1;
@@ -21,6 +26,15 @@ module t (/*AUTOARG*/);
 
       $display("(%d, %d) (%d, %d)", a.fst, a.snd, b.fst, b.snd);
       $display("%%p=%p", a);
+
+      c.p.fst = 5;
+      if (c.p.fst != 5) $stop;
+      a = c.p;
+      if (a.fst != 5) $stop;
+      c.p = b;
+      if (c.p.fst != 3) $stop;
+      if (c.p.snd != 4) $stop;
+
       $write("*-* All Finished *-*\n");
       $finish;
    end


### PR DESCRIPTION
Currently on master, assigning a class member of unpacked struct type throws compilation error, because V3Clean inserts `&` operation and this operation isn't defined on arguments of type int and struct. These `&` operations are inserted to get only the requested fields of variable of bit vector type, because such variables (for example packed arrays of type `logic`) are translated to variables of type `int` in c++. There is no need to do it in case of accessing members of classes, because systemverilog classes are translated to c++ classes and each field is translated separately. Since the fields aren't joined, we don't need perform `&` operation with the mask.