### PR TITLE
Fix unpacked struct == and != operators (#4234)

### DIFF
--- a/src/V3EmitCHeaders.cpp
+++ b/src/V3EmitCHeaders.cpp
@@ -22,7 +22,9 @@
 #include "V3Global.h"
 
 #include <algorithm>
+#include <cstdint>
 #include <set>
+#include <string>
 #include <vector>
 
 VL_DEFINE_DEBUG_FUNCTIONS;
@@ -241,16 +243,22 @@ class EmitCHeader final : public EmitCConstInit {
         puts("return ");
         for (const AstMemberDType* itemp = sdtypep->membersp(); itemp;
              itemp = VN_AS(itemp->nextp(), MemberDType)) {
-            puts(itemp->nameProtect() + " == " + "rhs." + itemp->nameProtect());
-            if (itemp->nextp())
-                puts(" &&\n    ");
-            else
-                puts(";\n");
+            if (itemp != sdtypep->membersp()) puts("\n    && ");
+            if (AstUnpackArrayDType* const adtypep
+                = VN_CAST(itemp->subDTypep(), UnpackArrayDType)) {
+                for (uint32_t i = 0; i < adtypep->arrayUnpackedElements(); i++) {
+                    if (i != 0) puts("\n    && ");
+                    puts(itemp->nameProtect() + "[" + std::to_string(i) + "U] == " + "rhs."
+                         + itemp->nameProtect() + "[" + std::to_string(i) + "U]");
+                }
+            } else {
+                puts(itemp->nameProtect() + " == " + "rhs." + itemp->nameProtect());
+            }
         }
-        puts("}");
-        puts("\nbool operator!=(const " + EmitCBase::prefixNameProtect(sdtypep) + "& rhs){\n");
-        puts("return !(*this == rhs);\n");
+        puts(";\n");
         puts("}\n");
+        puts("bool operator!=(const " + EmitCBase::prefixNameProtect(sdtypep) + "& rhs){\n");
+        puts("return !(*this == rhs);\n}\n");
         puts("};\n");
     }
     void emitStructs(const AstNodeModule* modp) {

--- a/src/V3EmitCHeaders.cpp
+++ b/src/V3EmitCHeaders.cpp
@@ -236,6 +236,21 @@ class EmitCHeader final : public EmitCConstInit {
             puts(itemp->dtypep()->cType(itemp->nameProtect(), false, false));
             puts(";\n");
         }
+
+        puts("\nbool operator==(const " + EmitCBase::prefixNameProtect(sdtypep) + "& rhs){\n");
+        puts("return ");
+        for (const AstMemberDType* itemp = sdtypep->membersp(); itemp;
+             itemp = VN_AS(itemp->nextp(), MemberDType)) {
+            puts(itemp->nameProtect() + " == " + "rhs." + itemp->nameProtect());
+            if (itemp->nextp())
+                puts(" &&\n    ");
+            else
+                puts(";\n");
+        }
+        puts("}");
+        puts("\nbool operator!=(const " + EmitCBase::prefixNameProtect(sdtypep) + "& rhs){\n");
+        puts("return !(*this == rhs);\n");
+        puts("}\n");
         puts("};\n");
     }
     void emitStructs(const AstNodeModule* modp) {

--- a/test_regress/t/t_unpacked_struct_eq.pl
+++ b/test_regress/t/t_unpacked_struct_eq.pl
@@ -1,0 +1,21 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2004 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_unpacked_struct_eq.v
+++ b/test_regress/t/t_unpacked_struct_eq.v
@@ -1,0 +1,22 @@
+module t;
+    typedef struct {
+        struct {
+            logic m0;
+            logic [3:0] m1;
+            logic m2;
+        } sub;
+    } struct_t;
+    struct_t s1;
+    struct_t s2;
+
+    assign {s1.sub.m0, s1.sub.m1, s1.sub.m2} = {1'b0, 4'h5, 1'b1};
+    assign {s2.sub.m0, s2.sub.m1, s2.sub.m2} = {1'b0, 4'h5, 1'b1};
+
+    initial begin
+        if(s1 != s2) begin
+            $fatal;
+        end
+        $write("*-* All Finished *-*\n");
+        $finish;
+    end
+endmodule

--- a/test_regress/t/t_unpacked_struct_eq.v
+++ b/test_regress/t/t_unpacked_struct_eq.v
@@ -1,22 +1,51 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// Use this file as a template for submitting bugs, etc.
+// This module takes a single clock input, and should either
+//      $write("*-* All Finished *-*\n");
+//      $finish;
+// on success, or $stop.
+//
+// The code as shown applies a random vector to the Test
+// module, then calculates a CRC on the Test module's outputs.
+//
+// **If you do not wish for your code to be released to the public
+// please note it here, otherwise:**
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2023 by Wilson Snyder.
+// SPDX-License-Identifier: CC0-1.0
+
 module t;
     typedef struct {
+        string txt;
         struct {
             logic m0;
             logic [3:0] m1;
-            logic m2;
         } sub;
+        logic [7:0] arr[2];
     } struct_t;
     struct_t s1;
     struct_t s2;
 
-    assign {s1.sub.m0, s1.sub.m1, s1.sub.m2} = {1'b0, 4'h5, 1'b1};
-    assign {s2.sub.m0, s2.sub.m1, s2.sub.m2} = {1'b0, 4'h5, 1'b1};
+    assign {s1.sub.m0, s1.sub.m1} = {1'b0, 4'h5};
+    assign {s2.sub.m0, s2.sub.m1} = {1'b0, 4'h5};
+    assign s1.txt = "text";
+    assign s2.txt = "text";
+    assign s1.arr[0] = 8'h77;
+    assign s2.arr[0] = 8'h77;
+    assign s1.arr[1] = 8'h33;
+    assign s2.arr[1] = 8'h33;
 
     initial begin
         if(s1 != s2) begin
             $fatal;
         end
-        $write("*-* All Finished *-*\n");
-        $finish;
+        if(s1 == s2) begin
+            $write("*-* All Finished *-*\n");
+            $finish;
+        end else begin
+            $fatal;
+        end
     end
 endmodule


### PR DESCRIPTION
From issue #4234 .

@wsnyder @kbieganski 
If I understood correctly this is what you meant:

In generated file `Vtest2__024root.h`  in definition  of unpacked structure this is the added code:

for a testcase:

```systemverilog
module t;
    typedef struct {
        struct {
            logic m0;
            logic [3:0] m1;
            logic m2;
        } sub;
    } struct_t;
    struct_t s1;
    struct_t s2;

    assign {s1.sub.m0, s1.sub.m1, s1.sub.m2} = {1'b0, 4'h5, 1'b1};
    assign {s2.sub.m0, s2.sub.m1, s2.sub.m2} = {1'b0, 4'h5, 1'b1};
    
    initial begin
        if(s1 != s2) begin
            $fatal();
        end else begin
            $finish();
        end
    end

endmodule
```

```diff
struct Vtest2___struct4 {
    CData/*0:0*/ __PVT__m0;
    CData/*3:0*/ __PVT__m1;
    CData/*0:0*/ __PVT__m2;

+    bool operator==(const Vtest2___struct4& rhs){
+        return __PVT__m0 == rhs.__PVT__m0 &&
+            __PVT__m1 == rhs.__PVT__m1 &&
+            __PVT__m2 == rhs.__PVT__m2;
+    }
+    bool operator!=(const Vtest2___struct4& rhs){
+        return !(*this == rhs);
+    }
};

struct Vtest2_t__DOT__struct_t__struct3 {
    Vtest2___struct4 __PVT__sub;

+    bool operator==(const Vtest2_t__DOT__struct_t__struct3& rhs){
+        return __PVT__sub == rhs.__PVT__sub;
+    }
+    bool operator!=(const Vtest2_t__DOT__struct_t__struct3& rhs){
+        return !(*this == rhs);
+    }
};

```