### PR TITLE
Use STATIC lifetime for variables created from clocking items

### DIFF
--- a/src/V3LinkDot.cpp
+++ b/src/V3LinkDot.cpp
@@ -1174,6 +1174,7 @@ class LinkDotFindVisitor final : public VNVisitor {
         }
         AstVar* const newvarp = new AstVar{nodep->fileline(), VVarType::MODULETEMP, varname,
                                            VFlagChildDType{}, dtypep};
+        newvarp->lifetime(VLifetime::STATIC);
         nodep->varp(newvarp);
         iterate(nodep->exprp());
     }


### PR DESCRIPTION
Clocking blocks operate on static resources, so their I/O variables should be declared as having static lifetime.

Note: this bears importance in context of https://github.com/verilator/verilator/pull/4253