### PR TITLE
Fix names of foreach blocks

### DIFF
--- a/src/V3LinkDot.cpp
+++ b/src/V3LinkDot.cpp
@@ -158,6 +158,7 @@ private:
     std::array<ScopeAliasMap, SAMN__MAX> m_scopeAliasMap;  // Map of <lhs,rhs> aliases
     std::vector<VSymEnt*> m_ifaceVarSyms;  // List of AstIfaceRefDType's to be imported
     IfaceModSyms m_ifaceModSyms;  // List of AstIface+Symbols to be processed
+    int m_stepNumber;  // Number of the step
     bool m_forPrimary;  // First link
     bool m_forPrearray;  // Compress cell__[array] refs
     bool m_forScopeCreation;  // Remove VarXRefs for V3Scope
@@ -204,6 +205,7 @@ public:
     LinkDotState(AstNetlist* rootp, VLinkDotStep step)
         : m_syms{rootp} {
         UINFO(4, __FUNCTION__ << ": " << endl);
+        m_stepNumber = int(step);
         m_forPrimary = (step == LDS_PRIMARY);
         m_forPrearray = (step == LDS_PARAMED || step == LDS_PRIMARY);
         m_forScopeCreation = (step == LDS_SCOPED);
@@ -217,6 +219,7 @@ public:
 
     // ACCESSORS
     VSymGraph* symsp() { return &m_syms; }
+    int stepNumber() const { return m_stepNumber; }
     bool forPrimary() const { return m_forPrimary; }
     bool forPrearray() const { return m_forPrearray; }
     bool forScopeCreation() const { return m_forScopeCreation; }
@@ -1017,9 +1020,13 @@ class LinkDotFindVisitor final : public VNVisitor {
             for (AstNode* stmtp = nodep->stmtsp(); stmtp; stmtp = stmtp->nextp()) {
                 if (VN_IS(stmtp, Var) || VN_IS(stmtp, Foreach)) {
                     std::string name;
+                    std::string stepStr;
+                    if (m_statep->stepNumber()) {
+                        stepStr = std::to_string(m_statep->stepNumber()) + "_";
+                    }
                     do {
                         ++m_modBlockNum;
-                        name = "unnamedblk" + cvtToStr(m_modBlockNum);
+                        name = "unnamedblk" + stepStr + cvtToStr(m_modBlockNum);
                         // Increment again if earlier pass of V3LinkDot claimed this name
                     } while (m_curSymp->findIdFlat(name));
                     nodep->name(name);

--- a/src/V3LinkDot.cpp
+++ b/src/V3LinkDot.cpp
@@ -158,10 +158,7 @@ private:
     std::array<ScopeAliasMap, SAMN__MAX> m_scopeAliasMap;  // Map of <lhs,rhs> aliases
     std::vector<VSymEnt*> m_ifaceVarSyms;  // List of AstIfaceRefDType's to be imported
     IfaceModSyms m_ifaceModSyms;  // List of AstIface+Symbols to be processed
-    int m_stepNumber;  // Number of the step
-    bool m_forPrimary;  // First link
-    bool m_forPrearray;  // Compress cell__[array] refs
-    bool m_forScopeCreation;  // Remove VarXRefs for V3Scope
+    const VLinkDotStep m_step;  // Operational step
 
 public:
     // METHODS
@@ -203,9 +200,9 @@ public:
 
     // CONSTRUCTORS
     LinkDotState(AstNetlist* rootp, VLinkDotStep step)
-        : m_syms{rootp} {
+        : m_syms{rootp}
+        , m_step(step) {
         UINFO(4, __FUNCTION__ << ": " << endl);
-        m_stepNumber = int(step);
         m_forPrimary = (step == LDS_PRIMARY);
         m_forPrearray = (step == LDS_PARAMED || step == LDS_PRIMARY);
         m_forScopeCreation = (step == LDS_SCOPED);
@@ -1020,10 +1017,7 @@ class LinkDotFindVisitor final : public VNVisitor {
             for (AstNode* stmtp = nodep->stmtsp(); stmtp; stmtp = stmtp->nextp()) {
                 if (VN_IS(stmtp, Var) || VN_IS(stmtp, Foreach)) {
                     std::string name;
-                    std::string stepStr;
-                    if (m_statep->stepNumber()) {
-                        stepStr = std::to_string(m_statep->stepNumber()) + "_";
-                    }
+                    const std::string stepStr = m_statep->step() == PRIMARY ? "" : std::to_string(m_statep->stepNumber()) + "_";
                     do {
                         ++m_modBlockNum;
                         name = "unnamedblk" + stepStr + cvtToStr(m_modBlockNum);

--- a/test_regress/t/t_foreach_blkname.v
+++ b/test_regress/t/t_foreach_blkname.v
@@ -12,5 +12,8 @@ module t;
       end
       foreach (a[i]) begin
       end
+      begin
+         int x;
+      end
    endfunction
 endmodule

--- a/test_regress/t/t_randcase_bad.out
+++ b/test_regress/t/t_randcase_bad.out
@@ -1,2 +1,2 @@
-[0] %Error: t_randcase_bad.v:12: Assertion failed in top.t.unnamedblk1: All randcase items had 0 weights (IEEE 1800-2017 18.16)
+[0] %Error: t_randcase_bad.v:12: Assertion failed in top.t.unnamedblk2_1: All randcase items had 0 weights (IEEE 1800-2017 18.16)
 *-* All Finished *-*


### PR DESCRIPTION
Currently on master, if there is an unnamed block after a `foreach` loop, the error `Duplicate declaration of block` is thrown.
It happens, because blocks created for the purposes of `foreach` loops are created when other blocks have the names already assigned. If the block is unnamed, Verilator assigns the name with the smallest number that isn't already in the symbol table. It is done during creation of the symbol table, so names of the blocks that are after the current one aren't in the symbol table at that moment. It results in name conflict if an unnamed block is inserted to AST before a block that has its name already assigned.

I fixed it by adding the number of the current linking step to the names assigned to unnamed blocks.