### PR TITLE
Give iterated variable in foreach loops VAUTOM lifetime

### DIFF
--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -4680,6 +4680,7 @@ private:
         FileLine* const fl = varp->fileline();
         auto* const whilep = new AstWhile{
             fl, condp, bodysp, new AstAssign{fl, new AstVarRef{fl, varp, VAccess::WRITE}, incp}};
+        varp->lifetime(VLifetime::AUTOMATIC);
         AstNode* const stmtsp = varp;  // New statements for under new Begin
         stmtsp->addNext(new AstAssign{fl, new AstVarRef{fl, varp, VAccess::WRITE}, leftp});
         stmtsp->addNext(whilep);


### PR DESCRIPTION
Those veriables exist only wiithin the scope of the loops in which they are declared.

Required for https://github.com/verilator/verilator/pull/4253