### PR TITLE
Fix foreach unnamedblk error

### DIFF
--- a/src/V3LinkDot.cpp
+++ b/src/V3LinkDot.cpp
@@ -1015,7 +1015,7 @@ class LinkDotFindVisitor final : public VNVisitor {
             // places such as tasks, where "task ...; begin ... end"
             // are common.
             for (AstNode* stmtp = nodep->stmtsp(); stmtp; stmtp = stmtp->nextp()) {
-                if (VN_IS(stmtp, Var) || VN_IS(stmtp, Foreach)) {
+                if (VN_IS(stmtp, Var)) {
                     std::string name;
                     do {
                         ++m_modBlockNum;

--- a/test_regress/t/t_foreach_nest_block.pl
+++ b/test_regress/t/t_foreach_nest_block.pl
@@ -1,0 +1,17 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2023 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_foreach_nest_block.v
+++ b/test_regress/t/t_foreach_nest_block.v
@@ -1,0 +1,45 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// The code as shown applies a random vector to the Test
+// module, then calculates a CRC on the Test module's outputs.
+//
+// **If you do not wish for your code to be released to the public
+// please note it here, otherwise:**
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2023 by Jomit626.
+// SPDX-License-Identifier: CC0-1.0
+//
+
+module t();
+    function static void func0();
+        for(int i=0;i<16;i++) begin
+        end
+    endfunction
+
+    task static task0(bit data[]);
+        foreach (data[i]) begin
+        end
+    endtask
+
+    task static task1(bit data[]);
+        foreach (data[i]) begin
+        end
+    endtask
+
+    bit [31:0] a0[];
+    bit [31:0] a1[];
+
+    initial begin
+        foreach (a0[i]) begin
+        end
+
+        begin
+
+          foreach (a1[i]) begin
+          end
+
+        end
+    end
+
+endmodule


### PR DESCRIPTION
Here is a test I trimmed from a testbench.

``` systemverilog
module t();
    function static void func0();
        for(int i=0;i<16;i++) begin
        end
    endfunction
    task static task0(bit data[]);
        foreach (data[i]) begin
        end
    endtask
    task static task1(bit data[]);
        foreach (data[i]) begin
        end
    endtask
    bit [31:0] a0[];
    bit [31:0] a1[];
    initial begin
        foreach (a0[i]) begin
        end
        begin
          foreach (a1[i]) begin
          end
        end
    end
endmodule
```
```
%Error: t/t_foreach_nest_block.v:37:9: Duplicate declaration of block: 'unnamedblk3'
                                     : ... In instance t
   37 |         begin
      |         ^~~~~
        t/t_foreach_nest_block.v:34:9: ... Location of original declaration
   34 |         foreach (a0[i]) begin
      |         ^~~~~~~
%Error: Exiting due to 1 error(s)
```
Vt_foreach_nest_block_018_const.tree:
```
    1:2: INITIAL 0x5555568484c0 <e735> {e33af}
->  1:2:2: BEGIN 0x555556847220 <e715> {e33an}  unnamedblk2 [UNNAMED]
    1:2:2:1: BEGIN 0x55555684dc80 <e1355> {e34aj} [UNNAMED] [IMPLIED]
    1:2:2:1:1: VAR 0x55555679ebd0 <e1306> {e34av} @dt=0x55555679a1b0@(G/sw32)  i [LOOP] [VAUTOM]  BLOCKTEMP
    1:2:2:1:1: ASSIGN 0x55555684dbc0 <e1349> {e34av} @dt=0x55555679a1b0@(G/sw32)
    1:2:2:1:1:1: CONST 0x5555567a2460 <e1523> {e34av} @dt=0x55555684f6c0@(G/sw32)  32'h0
    1:2:2:1:1:2: VARREF 0x55555684dab0 <e1347> {e34av} @dt=0x55555679a1b0@(G/sw32)  i [LV] => VAR 0x55555679ebd0 <e1306> {e34av} @dt=0x55555679a1b0@(G/sw32)  i [LOOP] [VAUTOM]  BLOCKTEMP
    1:2:2:1:1: WHILE 0x55555684d9f0 <e1350> {e34av}
    1:2:2:1:1:2: LTS 0x55555684de30 <e1374> {e34av} @dt=0x5555567a5fb0@(G/w1)
    1:2:2:1:1:2:1: VARREF 0x55555684d2a0 <e1370> {e34av} @dt=0x55555679a1b0@(G/sw32)  i [RV] <- VAR 0x55555679ebd0 <e1306> {e34av} @dt=0x55555679a1b0@(G/sw32)  i [LOOP] [VAUTOM]  BLOCKTEMP
    1:2:2:1:1:2:2: CMETHODHARD 0x5555567a2640 <e1371> {e34av} @dt=0x55555679a1b0@(G/sw32)  size
    1:2:2:1:1:2:2:1: VARREF 0x55555684d190 <e1315> {e34as} @dt=0x5555567a21e0@(w0)[]  a0 [RV] <- VAR 0x5555567c7c40 <e1288> {e30aq} @dt=0x5555567a21e0@(w0)[]  a0 [VSTATIC]  VAR    
    1:2:2:1:1:3: BEGIN 0x555556847800 <e1353> {e34az} [UNNAMED]
    1:2:2:1:1:4: ASSIGN 0x55555684d930 <e1340> {e34av} @dt=0x55555679a1b0@(G/sw32)
    1:2:2:1:1:4:1: ADD 0x55555684d760 <e1389> {e34av} @dt=0x55555679a1b0@(G/sw32)
    1:2:2:1:1:4:1:1: CONST 0x55555684d470 <e1524> {e34av} @dt=0x55555684f6c0@(G/sw32)  32'h1
    1:2:2:1:1:4:1:2: VARREF 0x55555684d650 <e1333> {e34av} @dt=0x55555679a1b0@(G/sw32)  i [RV] <- VAR 0x55555679ebd0 <e1306> {e34av} @dt=0x55555679a1b0@(G/sw32)  i [LOOP] [VAUTOM]  BLOCKTEMP
    1:2:2:1:1:4:2: VARREF 0x55555684d820 <e1339> {e34av} @dt=0x55555679a1b0@(G/sw32)  i [LV] => VAR 0x55555679ebd0 <e1306> {e34av} @dt=0x55555679a1b0@(G/sw32)  i [LOOP] [VAUTOM]  BLOCKTEMP
->  1:2:2:1: BEGIN 0x555556847b70 <e733> {e37aj}  unnamedblk3 [UNNAMED]
    1:2:2:1:1: BEGIN 0x55555684eff0 <e1441> {e39al} [UNNAMED] [IMPLIED]
    1:2:2:1:1:1: VAR 0x55555679ef30 <e1392> {e39ax} @dt=0x55555679a1b0@(G/sw32)  i [LOOP] [VAUTOM]  BLOCKTEMP
    1:2:2:1:1:1: ASSIGN 0x55555684ef30 <e1435> {e39ax} @dt=0x55555679a1b0@(G/sw32)
    1:2:2:1:1:1:1: CONST 0x55555684e240 <e1525> {e39ax} @dt=0x55555684f6c0@(G/sw32)  32'h0
```
The first pass of V3LinkDot generates `unnamedblk2` ta depth 3 and `unnamedblk3` at depth 4. When the second pass of V3LinkDot vitis the unnamed block just below `unnamedblk2` at depth 4, it didn't see `unnamedblk3` at and then generates another `unnamedblk3`.

https://github.com/verilator/verilator/blob/545caba72048cc813262eb29c4c4c6f8c2ab14b3/src/V3LinkDot.cpp#L1011-L1029

Discard commit 90c61c7 by removing `|| VN_IS(stmtp, Foreach)` can fix it.
And commit 035bf13 alone is enough to solve both #3885 and #3321