### PR TITLE
V3ThreadPool: Add sequential thread index and thread count getter

### DIFF
--- a/src/V3ThreadPool.cpp
+++ b/src/V3ThreadPool.cpp
@@ -51,6 +51,8 @@ void V3ThreadPool::resize(unsigned n) VL_MT_UNSAFE VL_EXCLUDES(m_mutex)
         for (unsigned int i = 1; i < n; ++i) {
             m_workers.emplace_back(&V3ThreadPool::startWorker, this, i);
         }
+        // Synchronization for size().
+        std::atomic_thread_fence(std::memory_order_release);
     }
 }
 

--- a/src/V3ThreadPool.cpp
+++ b/src/V3ThreadPool.cpp
@@ -39,14 +39,13 @@ void V3ThreadPool::resize(unsigned n) VL_MT_UNSAFE VL_EXCLUDES(m_mutex)
         m_cv.notify_all();
         m_stoppedJobsCV.notify_all();
     }
-    while (!m_workers.empty()) {
-        m_workers.front().join();
-        m_workers.pop_front();
-    }
+    for (auto& worker : m_workers) { worker.join(); }
+    m_workers.clear();
     if (n > 1) {
         V3LockGuard lock{m_mutex};
         // Start new threads
         m_shutdown = false;
+        m_workers.reserve(n - 1);
         for (unsigned int i = 1; i < n; ++i) {
             m_workers.emplace_back(&V3ThreadPool::startWorker, this, i);
         }

--- a/src/V3ThreadPool.cpp
+++ b/src/V3ThreadPool.cpp
@@ -23,6 +23,8 @@
 // c++11 requires definition of static constexpr as well as declaration
 constexpr unsigned int V3ThreadPool::FUTUREWAITFOR_MS;
 
+thread_local std::size_t V3ThreadPool::s_threadId{V3ThreadPool::mainThreadId()};
+
 void V3ThreadPool::resize(unsigned n) VL_MT_UNSAFE VL_EXCLUDES(m_mutex)
     VL_EXCLUDES(m_stoppedJobsMutex) {
     // This function is not thread-safe and can result in race between threads
@@ -53,6 +55,7 @@ void V3ThreadPool::resize(unsigned n) VL_MT_UNSAFE VL_EXCLUDES(m_mutex)
 }
 
 void V3ThreadPool::startWorker(V3ThreadPool* selfThreadp, int id) VL_MT_SAFE {
+    s_threadId = id;
     selfThreadp->workerJobLoop(id);
 }
 

--- a/src/V3ThreadPool.h
+++ b/src/V3ThreadPool.h
@@ -26,6 +26,7 @@
 #include <mutex>
 #include <queue>
 #include <thread>
+#include <vector>
 
 namespace future_type {
 template <typename T>
@@ -54,7 +55,7 @@ class V3ThreadPool final {
     // `wait` function is not atomic, but we are guarding `m_queue` that is
     // used by this condition_variable, so clang checks that we have mutex locked
     std::condition_variable_any m_cv;  // Conditions to wake up workers
-    std::list<std::thread> m_workers;  // Worker threads
+    std::vector<std::thread> m_workers;  // Worker threads
     V3Mutex m_stoppedJobsMutex;  // Used to signal stopped jobs
     // Conditions to wake up stopped jobs
     std::condition_variable_any m_stoppedJobsCV VL_GUARDED_BY(m_stoppedJobsMutex);

--- a/src/V3ThreadPool.h
+++ b/src/V3ThreadPool.h
@@ -94,6 +94,7 @@ public:
 
     // Returns number of threads (including main thread).
     std::size_t size() const VL_MT_SAFE {
+        std::atomic_thread_fence(std::memory_order_acquire);
         return m_workers.size() + 1;
     }
 


### PR DESCRIPTION
Illustrative use case example:
```c++
std::vector<V3ExampleWorker> visitors;
std::deque<std::future<void>> startedJobs;
// ...
visitors = std::vector<V3ExampleWorker>(V3ThreadPool::s().size()); 
// ...
void visit(AstExample* nodep) override {
    startedJobs.push_back(V3ThreadPool::s().enqueue([this, nodep]() {
        visitors[V3ThreadPool::s().currentThreadId()].visit(nodep);
    }));
}
// ...
visit(v3Global.rootp());
for (auto& startedJob : startedJobs) {
    V3ThreadPool::s().waitForFuture(startedJob);
}
for (auto& visitor : visitors) {
    // Collect and process stats or other data from each thread.
}
```

Personally I want to use it in https://github.com/verilator/verilator/pull/4228 (for validation only) and in future in parallelization of V3Expand (for easy mapping between a thread and its data in an array, something like in the example above).