### PR TITLE
Set the global `usesTiming` flag if forks exist, once again

### DIFF
--- a/src/V3Timing.cpp
+++ b/src/V3Timing.cpp
@@ -216,6 +216,13 @@ private:
         m_procp = nodep;
         iterateChildren(nodep);
     }
+    void visit(AstFork* nodep) override {
+        v3Global.setUsesTiming();  // Even if there are no event controls, we have to set this flag
+                                   // so that transformForks() in V3SchedTiming gets called and
+                                   // removes all forks and begins
+        if (nodep->isTimingControl() && m_procp) m_procp->user2(T_SUSP);
+        iterateChildren(nodep);
+    }
     void visit(AstNode* nodep) override {
         if (nodep->isTimingControl()) {
             v3Global.setUsesTiming();

--- a/test_regress/t/t_timing_fork_no_timing_ctrl.pl
+++ b/test_regress/t/t_timing_fork_no_timing_ctrl.pl
@@ -1,0 +1,28 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2023 by Antmicro Ltd. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+if (!$Self->have_coroutines) {
+    skip("No coroutine support");
+}
+else {
+    compile(
+        verilator_flags2 => ["--exe --main --timing"],
+        make_main => 0,
+        );
+
+    execute(
+        check_finished => 1,
+        );
+}
+
+ok(1);
+1;

--- a/test_regress/t/t_timing_fork_no_timing_ctrl.v
+++ b/test_regress/t/t_timing_fork_no_timing_ctrl.v
@@ -1,0 +1,15 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2023 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+module t;
+   initial
+      fork
+         begin
+            $write("*-* All Finished *-*\n");
+            $finish;
+         end
+      join_none
+endmodule


### PR DESCRIPTION
This reintroduces the fix from https://github.com/verilator/verilator/pull/3801. I believe this regression was caused by https://github.com/verilator/verilator/pull/4208. This time I'm adding a test.