### PR TITLE
Fix VCD scope types

### DIFF
--- a/include/verilated_vcd_c.cpp
+++ b/include/verilated_vcd_c.cpp
@@ -410,28 +410,14 @@ void VerilatedVcd::dumpHeader() {
             if (*np == ' ') np++;
             if (*np == '\t') break;  // tab means signal name starts
             printIndent(1);
-            // Find character after name end
-            const char* sp = np;
-            while (*sp && *sp != ' ' && *sp != '\t' && !(*sp & '\x80')) sp++;
-
-            printStr("$scope ");
-            if (*sp & '\x80') {
-                switch (*sp & 0x7f) {
-                case VLT_TRACE_SCOPE_STRUCT: printStr("struct "); break;
-                case VLT_TRACE_SCOPE_INTERFACE: printStr("interface "); break;
-                case VLT_TRACE_SCOPE_UNION: printStr("union "); break;
-                default: printStr("module ");
-                }
-            } else {
-                printStr("module ");
-            }
+            printStr("$scope module ");
 
             for (; *np && *np != ' ' && *np != '\t'; np++) {
                 if (*np == '[') {
                     printStr("[");
                 } else if (*np == ']') {
                     printStr("]");
-                } else if (!(*np & '\x80')) {
+                } else {
                     *m_writep++ = *np;
                 }
             }

--- a/src/V3TraceDecl.cpp
+++ b/src/V3TraceDecl.cpp
@@ -196,10 +196,11 @@ private:
     }
 
     std::string getScopeChar(VltTraceScope sct) {
-        if (v3Global.opt.traceFormat().fst())
+        if (v3Global.opt.traceFormat().fst()) {
             return std::string(1, static_cast<char>(0x80 + sct));
-        else
+        } else {
             return std::string();
+        }
     }
 
     std::string addAboveInterface(const std::string& scopeName) {

--- a/src/V3TraceDecl.cpp
+++ b/src/V3TraceDecl.cpp
@@ -196,7 +196,10 @@ private:
     }
 
     std::string getScopeChar(VltTraceScope sct) {
-        return std::string(1, static_cast<char>(0x80 + sct));
+        if(v3Global.opt.traceFormat().fst())
+            return std::string(1, static_cast<char>(0x80 + sct));
+        else
+            return std::string();
     }
 
     std::string addAboveInterface(const std::string& scopeName) {

--- a/src/V3TraceDecl.cpp
+++ b/src/V3TraceDecl.cpp
@@ -196,7 +196,7 @@ private:
     }
 
     std::string getScopeChar(VltTraceScope sct) {
-        if(v3Global.opt.traceFormat().fst())
+        if (v3Global.opt.traceFormat().fst())
             return std::string(1, static_cast<char>(0x80 + sct));
         else
             return std::string();

--- a/test_regress/t/t_hier_block_sc_trace_vcd.out
+++ b/test_regress/t/t_hier_block_sc_trace_vcd.out
@@ -156,20 +156,20 @@ $timescale 1ps $end
      $var wire  8 N in [7:0] $end
      $var wire  8 P out [7:0] $end
     $upscope $end
-    $scope interface in $end
+    $scope module in $end
      $var wire  1 K clk $end
      $var wire  8 N data [7:0] $end
     $upscope $end
-    $scope interface out $end
+    $scope module out $end
      $var wire  1 K clk $end
      $var wire  8 O data [7:0] $end
     $upscope $end
    $upscope $end
-   $scope interface in_ifs $end
+   $scope module in_ifs $end
     $var wire  1 K clk $end
     $var wire  8 N data [7:0] $end
    $upscope $end
-   $scope interface out_ifs $end
+   $scope module out_ifs $end
     $var wire  1 K clk $end
     $var wire  8 O data [7:0] $end
    $upscope $end

--- a/test_regress/t/t_hier_block_trace_vcd.out
+++ b/test_regress/t/t_hier_block_trace_vcd.out
@@ -157,20 +157,20 @@ $timescale 1ps $end
      $var wire  8 N in [7:0] $end
      $var wire  8 P out [7:0] $end
     $upscope $end
-    $scope interface in $end
+    $scope module in $end
      $var wire  1 K clk $end
      $var wire  8 N data [7:0] $end
     $upscope $end
-    $scope interface out $end
+    $scope module out $end
      $var wire  1 K clk $end
      $var wire  8 O data [7:0] $end
     $upscope $end
    $upscope $end
-   $scope interface in_ifs $end
+   $scope module in_ifs $end
     $var wire  1 K clk $end
     $var wire  8 N data [7:0] $end
    $upscope $end
-   $scope interface out_ifs $end
+   $scope module out_ifs $end
     $var wire  1 K clk $end
     $var wire  8 O data [7:0] $end
    $upscope $end

--- a/test_regress/t/t_interface_ref_trace.out
+++ b/test_regress/t/t_interface_ref_trace.out
@@ -9,76 +9,76 @@ $timescale 1ps $end
    $var wire 32 # cyc [31:0] $end
    $scope module a $end
     $scope module ac1 $end
-     $scope interface intf_for_check $end
+     $scope module intf_for_check $end
       $var wire  1 0 clk $end
       $var wire 32 # cyc [31:0] $end
       $var wire 32 $ value [31:0] $end
-      $scope struct the_struct $end
+      $scope module the_struct $end
        $var wire 32 % val100 [31:0] $end
        $var wire 32 & val200 [31:0] $end
       $upscope $end
      $upscope $end
     $upscope $end
     $scope module ac2 $end
-     $scope interface intf_for_check $end
+     $scope module intf_for_check $end
       $var wire  1 0 clk $end
       $var wire 32 # cyc [31:0] $end
       $var wire 32 ' value [31:0] $end
-      $scope struct the_struct $end
+      $scope module the_struct $end
        $var wire 32 ( val100 [31:0] $end
        $var wire 32 ) val200 [31:0] $end
       $upscope $end
      $upscope $end
     $upscope $end
     $scope module ac3 $end
-     $scope interface intf_for_check $end
+     $scope module intf_for_check $end
       $var wire  1 0 clk $end
       $var wire 32 # cyc [31:0] $end
       $var wire 32 * value [31:0] $end
-      $scope struct the_struct $end
+      $scope module the_struct $end
        $var wire 32 + val100 [31:0] $end
        $var wire 32 , val200 [31:0] $end
       $upscope $end
      $upscope $end
     $upscope $end
     $scope module as3 $end
-     $scope interface intf_for_struct $end
+     $scope module intf_for_struct $end
       $var wire  1 0 clk $end
       $var wire 32 # cyc [31:0] $end
       $var wire 32 * value [31:0] $end
-      $scope struct the_struct $end
+      $scope module the_struct $end
        $var wire 32 + val100 [31:0] $end
        $var wire 32 , val200 [31:0] $end
       $upscope $end
      $upscope $end
     $upscope $end
-    $scope interface intf_in_sub_all $end
+    $scope module intf_in_sub_all $end
      $var wire  1 0 clk $end
      $var wire 32 # cyc [31:0] $end
      $var wire 32 * value [31:0] $end
-     $scope interface inner $end
+     $scope module inner $end
       $var wire 32 # cyc [31:0] $end
       $var wire 32 3 value [31:0] $end
      $upscope $end
-     $scope struct the_struct $end
+     $scope module the_struct $end
       $var wire 32 + val100 [31:0] $end
       $var wire 32 , val200 [31:0] $end
      $upscope $end
     $upscope $end
-    $scope interface intf_one $end
+    $scope module intf_one $end
      $var wire  1 0 clk $end
      $var wire 32 # cyc [31:0] $end
      $var wire 32 $ value [31:0] $end
-     $scope struct the_struct $end
+     $scope module the_struct $end
       $var wire 32 % val100 [31:0] $end
       $var wire 32 & val200 [31:0] $end
      $upscope $end
     $upscope $end
-    $scope interface intf_two $end
+    $scope module intf_two $end
      $var wire  1 0 clk $end
      $var wire 32 # cyc [31:0] $end
      $var wire 32 ' value [31:0] $end
-     $scope struct the_struct $end
+     $scope module the_struct $end
       $var wire 32 ( val100 [31:0] $end
       $var wire 32 ) val200 [31:0] $end
      $upscope $end
@@ -86,146 +86,146 @@ $timescale 1ps $end
    $upscope $end
    $scope module abcdefghijklmnopqrstuvwxyz $end
     $scope module ac1 $end
-     $scope interface intf_for_check $end
+     $scope module intf_for_check $end
       $var wire  1 0 clk $end
       $var wire 32 # cyc [31:0] $end
       $var wire 32 ' value [31:0] $end
-      $scope struct the_struct $end
+      $scope module the_struct $end
        $var wire 32 ( val100 [31:0] $end
        $var wire 32 ) val200 [31:0] $end
       $upscope $end
      $upscope $end
     $upscope $end
     $scope module ac2 $end
-     $scope interface intf_for_check $end
+     $scope module intf_for_check $end
       $var wire  1 0 clk $end
       $var wire 32 # cyc [31:0] $end
       $var wire 32 $ value [31:0] $end
-      $scope struct the_struct $end
+      $scope module the_struct $end
        $var wire 32 % val100 [31:0] $end
        $var wire 32 & val200 [31:0] $end
       $upscope $end
      $upscope $end
     $upscope $end
     $scope module ac3 $end
-     $scope interface intf_for_check $end
+     $scope module intf_for_check $end
       $var wire  1 0 clk $end
       $var wire 32 # cyc [31:0] $end
       $var wire 32 - value [31:0] $end
-      $scope struct the_struct $end
+      $scope module the_struct $end
        $var wire 32 . val100 [31:0] $end
        $var wire 32 / val200 [31:0] $end
       $upscope $end
      $upscope $end
     $upscope $end
     $scope module as3 $end
-     $scope interface intf_for_struct $end
+     $scope module intf_for_struct $end
       $var wire  1 0 clk $end
       $var wire 32 # cyc [31:0] $end
       $var wire 32 - value [31:0] $end
-      $scope struct the_struct $end
+      $scope module the_struct $end
        $var wire 32 . val100 [31:0] $end
        $var wire 32 / val200 [31:0] $end
       $upscope $end
      $upscope $end
     $upscope $end
-    $scope interface intf_in_sub_all $end
+    $scope module intf_in_sub_all $end
      $var wire  1 0 clk $end
      $var wire 32 # cyc [31:0] $end
      $var wire 32 - value [31:0] $end
-     $scope interface inner $end
+     $scope module inner $end
       $var wire 32 # cyc [31:0] $end
       $var wire 32 4 value [31:0] $end
      $upscope $end
-     $scope struct the_struct $end
+     $scope module the_struct $end
       $var wire 32 . val100 [31:0] $end
       $var wire 32 / val200 [31:0] $end
      $upscope $end
     $upscope $end
-    $scope interface intf_one $end
+    $scope module intf_one $end
      $var wire  1 0 clk $end
      $var wire 32 # cyc [31:0] $end
      $var wire 32 ' value [31:0] $end
-     $scope struct the_struct $end
+     $scope module the_struct $end
       $var wire 32 ( val100 [31:0] $end
       $var wire 32 ) val200 [31:0] $end
      $upscope $end
     $upscope $end
-    $scope interface intf_two $end
+    $scope module intf_two $end
      $var wire  1 0 clk $end
      $var wire 32 # cyc [31:0] $end
      $var wire 32 $ value [31:0] $end
-     $scope struct the_struct $end
+     $scope module the_struct $end
       $var wire 32 % val100 [31:0] $end
       $var wire 32 & val200 [31:0] $end
      $upscope $end
     $upscope $end
    $upscope $end
    $scope module c1 $end
-    $scope interface intf_for_check $end
+    $scope module intf_for_check $end
      $var wire  1 0 clk $end
      $var wire 32 # cyc [31:0] $end
      $var wire 32 $ value [31:0] $end
-     $scope struct the_struct $end
+     $scope module the_struct $end
       $var wire 32 % val100 [31:0] $end
       $var wire 32 & val200 [31:0] $end
      $upscope $end
     $upscope $end
    $upscope $end
    $scope module c2 $end
-    $scope interface intf_for_check $end
+    $scope module intf_for_check $end
      $var wire  1 0 clk $end
      $var wire 32 # cyc [31:0] $end
      $var wire 32 ' value [31:0] $end
-     $scope struct the_struct $end
+     $scope module the_struct $end
       $var wire 32 ( val100 [31:0] $end
       $var wire 32 ) val200 [31:0] $end
      $upscope $end
     $upscope $end
    $upscope $end
-   $scope interface intf_1 $end
+   $scope module intf_1 $end
     $var wire  1 0 clk $end
     $var wire 32 # cyc [31:0] $end
     $var wire 32 $ value [31:0] $end
-    $scope interface inner $end
+    $scope module inner $end
      $var wire 32 # cyc [31:0] $end
      $var wire 32 1 value [31:0] $end
     $upscope $end
-    $scope struct the_struct $end
+    $scope module the_struct $end
      $var wire 32 % val100 [31:0] $end
      $var wire 32 & val200 [31:0] $end
     $upscope $end
    $upscope $end
-   $scope interface intf_2 $end
+   $scope module intf_2 $end
     $var wire  1 0 clk $end
     $var wire 32 # cyc [31:0] $end
     $var wire 32 ' value [31:0] $end
-    $scope interface inner $end
+    $scope module inner $end
      $var wire 32 # cyc [31:0] $end
      $var wire 32 2 value [31:0] $end
     $upscope $end
-    $scope struct the_struct $end
+    $scope module the_struct $end
      $var wire 32 ( val100 [31:0] $end
      $var wire 32 ) val200 [31:0] $end
     $upscope $end
    $upscope $end
    $scope module s1 $end
-    $scope interface intf_for_struct $end
+    $scope module intf_for_struct $end
      $var wire  1 0 clk $end
      $var wire 32 # cyc [31:0] $end
      $var wire 32 $ value [31:0] $end
-     $scope struct the_struct $end
+     $scope module the_struct $end
       $var wire 32 % val100 [31:0] $end
       $var wire 32 & val200 [31:0] $end
      $upscope $end
     $upscope $end
    $upscope $end
    $scope module s2 $end
-    $scope interface intf_for_struct $end
+    $scope module intf_for_struct $end
      $var wire  1 0 clk $end
      $var wire 32 # cyc [31:0] $end
      $var wire 32 ' value [31:0] $end
-     $scope struct the_struct $end
+     $scope module the_struct $end
       $var wire 32 ( val100 [31:0] $end
       $var wire 32 ) val200 [31:0] $end
      $upscope $end

--- a/test_regress/t/t_trace_complex_structs.out
+++ b/test_regress/t/t_trace_complex_structs.out
@@ -37,52 +37,52 @@ $timescale 1ps $end
      $var wire 32 H a [31:0] $end
     $upscope $end
    $upscope $end
-   $scope struct v_arrp_strp[3] $end
+   $scope module v_arrp_strp[3] $end
     $var wire  1 1 b0 $end
     $var wire  1 0 b1 $end
    $upscope $end
-   $scope struct v_arrp_strp[4] $end
+   $scope module v_arrp_strp[4] $end
     $var wire  1 3 b0 $end
     $var wire  1 2 b1 $end
    $upscope $end
-   $scope struct v_arru_strp[3] $end
+   $scope module v_arru_strp[3] $end
     $var wire  1 7 b0 $end
     $var wire  1 6 b1 $end
    $upscope $end
-   $scope struct v_arru_strp[4] $end
+   $scope module v_arru_strp[4] $end
     $var wire  1 9 b0 $end
     $var wire  1 8 b1 $end
    $upscope $end
-   $scope struct v_enumb2_str $end
+   $scope module v_enumb2_str $end
     $var wire  3 E a [2:0] $end
     $var wire  3 F b [2:0] $end
    $upscope $end
-   $scope struct v_str32x2[0] $end
+   $scope module v_str32x2[0] $end
     $var wire 32 @ data [31:0] $end
    $upscope $end
-   $scope struct v_str32x2[1] $end
+   $scope module v_str32x2[1] $end
     $var wire 32 A data [31:0] $end
    $upscope $end
-   $scope struct v_strp_strp $end
-    $scope struct x0 $end
+   $scope module v_strp_strp $end
+    $scope module x0 $end
      $var wire  1 * b0 $end
      $var wire  1 ) b1 $end
     $upscope $end
-    $scope struct x1 $end
+    $scope module x1 $end
      $var wire  1 ( b0 $end
      $var wire  1 ' b1 $end
     $upscope $end
    $upscope $end
-   $scope struct v_strp $end
+   $scope module v_strp $end
     $var wire  1 & b0 $end
     $var wire  1 % b1 $end
    $upscope $end
-   $scope union v_unip_strp $end
-    $scope struct x0 $end
+   $scope module v_unip_strp $end
+    $scope module x0 $end
      $var wire  1 , b0 $end
      $var wire  1 + b1 $end
     $upscope $end
-    $scope struct x1 $end
+    $scope module x1 $end
      $var wire  1 , b0 $end
      $var wire  1 + b1 $end
     $upscope $end


### PR DESCRIPTION
This limits the custom struct/union/interface scope types to be issued only in FST traces, since they are non-standard for VCD.

Should fix #4227