### PR TITLE
Assign unique fork names using a static variable

### DIFF
--- a/src/V3Timing.cpp
+++ b/src/V3Timing.cpp
@@ -283,7 +283,6 @@ private:
     V3UniqueNames m_intraValueNames{"__Vintraval"};  // Intra assign delay value var names
     V3UniqueNames m_intraIndexNames{"__Vintraidx"};  // Intra assign delay index var names
     V3UniqueNames m_intraLsbNames{"__Vintralsb"};  // Intra assign delay LSB var names
-    V3UniqueNames m_forkNames{"__Vfork"};  // Fork name generator
     V3UniqueNames m_trigSchedNames{"__VtrigSched"};  // Trigger scheduler name generator
     V3UniqueNames m_dynTrigNames{"__VdynTrigger"};  // Dynamic trigger name generator
 
@@ -918,7 +917,8 @@ private:
         if (nodep->user1SetOnce()) return;
         v3Global.setUsesTiming();
         // Create a unique name for this fork
-        nodep->name(m_forkNames.get(nodep));
+        static int forkCnt = 0;
+        nodep->name("__Vfork_" + cvtToStr(++forkCnt));
         unsigned idx = 0;  // Index for naming begins
         AstNode* stmtp = nodep->stmtsp();
         // Put each statement in a begin

--- a/src/V3Timing.cpp
+++ b/src/V3Timing.cpp
@@ -277,6 +277,7 @@ private:
     AstActive* m_activep = nullptr;  // Current active
     AstNode* m_procp = nullptr;  // NodeProcedure/CFunc/Begin we're under
     double m_timescaleFactor = 1.0;  // Factor to scale delays by
+    int m_forkCnt = 0;  // Number of forks inside a module
 
     // Unique names
     V3UniqueNames m_contAssignVarNames{"__VassignWtmp"};  // Names for temp AssignW vars
@@ -563,6 +564,8 @@ private:
         m_classp = VN_CAST(nodep, Class);
         VL_RESTORER(m_timescaleFactor);
         m_timescaleFactor = calculateTimescaleFactor(nodep->timeunit());
+        VL_RESTORER(m_forkCnt);
+        m_forkCnt = 0;
         iterateChildren(nodep);
     }
     void visit(AstScope* nodep) override {
@@ -917,8 +920,7 @@ private:
         if (nodep->user1SetOnce()) return;
         v3Global.setUsesTiming();
         // Create a unique name for this fork
-        static int forkCnt = 0;
-        nodep->name("__Vfork_" + cvtToStr(++forkCnt));
+        nodep->name("__Vfork_" + cvtToStr(++m_forkCnt));
         unsigned idx = 0;  // Index for naming begins
         AstNode* stmtp = nodep->stmtsp();
         // Put each statement in a begin

--- a/test_regress/t/t_timing_debug1.out
+++ b/test_regress/t/t_timing_debug1.out
@@ -26,9 +26,9 @@
 -V{t#,#}+    Vt_timing_debug1___024root___stl_sequent__TOP__2
 -V{t#,#}+    Vt_timing_debug1___024root___act_comb__TOP__2
 -V{t#,#}+    Vt_timing_debug1___024root___stl_comb__TOP__1
--V{t#,#}+    Vt_timing_debug1___024root____Vfork_h########__0__0
+-V{t#,#}+    Vt_timing_debug1___024root____Vfork_1__0
 -V{t#,#}+    Vt_timing_debug1___024root___stl_comb__TOP__2
--V{t#,#}+    Vt_timing_debug1___024root____Vfork_h########__0__0
+-V{t#,#}+    Vt_timing_debug1___024root____Vfork_2__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__stl
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__stl
 -V{t#,#}         No triggers active
@@ -49,9 +49,9 @@
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_sequent__TOP__0
--V{t#,#}+    Vt_timing_debug1___024root____Vfork_h########__0__0
+-V{t#,#}+    Vt_timing_debug1___024root____Vfork_1__0
 -V{t#,#}+    Vt_timing_debug1___024root___act_sequent__TOP__1
--V{t#,#}+    Vt_timing_debug1___024root____Vfork_h########__0__0
+-V{t#,#}+    Vt_timing_debug1___024root____Vfork_2__0
 -V{t#,#}+    Vt_timing_debug1___024root___act_comb__TOP__2
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
@@ -91,7 +91,7 @@
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_sequent__TOP__0
--V{t#,#}+    Vt_timing_debug1___024root____Vfork_h########__0__0
+-V{t#,#}+    Vt_timing_debug1___024root____Vfork_1__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         'act' region trigger index 3 is active: @(posedge t.clk1)
@@ -150,7 +150,7 @@
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_sequent__TOP__0
--V{t#,#}+    Vt_timing_debug1___024root____Vfork_h########__0__0
+-V{t#,#}+    Vt_timing_debug1___024root____Vfork_1__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         No triggers active
@@ -222,7 +222,7 @@
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_sequent__TOP__0
--V{t#,#}+    Vt_timing_debug1___024root____Vfork_h########__0__0
+-V{t#,#}+    Vt_timing_debug1___024root____Vfork_1__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         'act' region trigger index 3 is active: @(posedge t.clk1)
@@ -276,7 +276,7 @@
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_sequent__TOP__1
--V{t#,#}+    Vt_timing_debug1___024root____Vfork_h########__0__0
+-V{t#,#}+    Vt_timing_debug1___024root____Vfork_2__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         'act' region trigger index 5 is active: @(posedge t.clk2)
@@ -344,7 +344,7 @@
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_sequent__TOP__0
--V{t#,#}+    Vt_timing_debug1___024root____Vfork_h########__0__0
+-V{t#,#}+    Vt_timing_debug1___024root____Vfork_1__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         No triggers active
@@ -414,7 +414,7 @@
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_sequent__TOP__0
--V{t#,#}+    Vt_timing_debug1___024root____Vfork_h########__0__0
+-V{t#,#}+    Vt_timing_debug1___024root____Vfork_1__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         'act' region trigger index 3 is active: @(posedge t.clk1)
@@ -472,7 +472,7 @@
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_sequent__TOP__0
--V{t#,#}+    Vt_timing_debug1___024root____Vfork_h########__0__0
+-V{t#,#}+    Vt_timing_debug1___024root____Vfork_1__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         No triggers active
@@ -542,7 +542,7 @@
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_sequent__TOP__0
--V{t#,#}+    Vt_timing_debug1___024root____Vfork_h########__0__0
+-V{t#,#}+    Vt_timing_debug1___024root____Vfork_1__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         'act' region trigger index 3 is active: @(posedge t.clk1)
@@ -594,7 +594,7 @@
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_sequent__TOP__1
--V{t#,#}+    Vt_timing_debug1___024root____Vfork_h########__0__0
+-V{t#,#}+    Vt_timing_debug1___024root____Vfork_2__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         No triggers active
@@ -632,7 +632,7 @@
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_sequent__TOP__0
--V{t#,#}+    Vt_timing_debug1___024root____Vfork_h########__0__0
+-V{t#,#}+    Vt_timing_debug1___024root____Vfork_1__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         No triggers active
@@ -702,7 +702,7 @@
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_sequent__TOP__0
--V{t#,#}+    Vt_timing_debug1___024root____Vfork_h########__0__0
+-V{t#,#}+    Vt_timing_debug1___024root____Vfork_1__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         'act' region trigger index 3 is active: @(posedge t.clk1)
@@ -754,7 +754,7 @@
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_sequent__TOP__0
--V{t#,#}+    Vt_timing_debug1___024root____Vfork_h########__0__0
+-V{t#,#}+    Vt_timing_debug1___024root____Vfork_1__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         No triggers active
@@ -826,9 +826,9 @@
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_sequent__TOP__0
--V{t#,#}+    Vt_timing_debug1___024root____Vfork_h########__0__0
+-V{t#,#}+    Vt_timing_debug1___024root____Vfork_1__0
 -V{t#,#}+    Vt_timing_debug1___024root___act_sequent__TOP__1
--V{t#,#}+    Vt_timing_debug1___024root____Vfork_h########__0__0
+-V{t#,#}+    Vt_timing_debug1___024root____Vfork_2__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         'act' region trigger index 3 is active: @(posedge t.clk1)
@@ -932,7 +932,7 @@
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_sequent__TOP__0
--V{t#,#}+    Vt_timing_debug1___024root____Vfork_h########__0__0
+-V{t#,#}+    Vt_timing_debug1___024root____Vfork_1__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         No triggers active
@@ -1002,7 +1002,7 @@
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_sequent__TOP__0
--V{t#,#}+    Vt_timing_debug1___024root____Vfork_h########__0__0
+-V{t#,#}+    Vt_timing_debug1___024root____Vfork_1__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         'act' region trigger index 3 is active: @(posedge t.clk1)
@@ -1060,7 +1060,7 @@
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_sequent__TOP__0
--V{t#,#}+    Vt_timing_debug1___024root____Vfork_h########__0__0
+-V{t#,#}+    Vt_timing_debug1___024root____Vfork_1__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         No triggers active
@@ -1130,7 +1130,7 @@
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_sequent__TOP__1
--V{t#,#}+    Vt_timing_debug1___024root____Vfork_h########__0__0
+-V{t#,#}+    Vt_timing_debug1___024root____Vfork_2__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         No triggers active
@@ -1167,7 +1167,7 @@
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_sequent__TOP__0
--V{t#,#}+    Vt_timing_debug1___024root____Vfork_h########__0__0
+-V{t#,#}+    Vt_timing_debug1___024root____Vfork_1__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         'act' region trigger index 3 is active: @(posedge t.clk1)
@@ -1219,7 +1219,7 @@
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_sequent__TOP__0
--V{t#,#}+    Vt_timing_debug1___024root____Vfork_h########__0__0
+-V{t#,#}+    Vt_timing_debug1___024root____Vfork_1__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         No triggers active
@@ -1289,7 +1289,7 @@
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_sequent__TOP__0
--V{t#,#}+    Vt_timing_debug1___024root____Vfork_h########__0__0
+-V{t#,#}+    Vt_timing_debug1___024root____Vfork_1__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         'act' region trigger index 3 is active: @(posedge t.clk1)
@@ -1341,7 +1341,7 @@
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_sequent__TOP__0
--V{t#,#}+    Vt_timing_debug1___024root____Vfork_h########__0__0
+-V{t#,#}+    Vt_timing_debug1___024root____Vfork_1__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         No triggers active
@@ -1383,7 +1383,7 @@
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_sequent__TOP__1
--V{t#,#}+    Vt_timing_debug1___024root____Vfork_h########__0__0
+-V{t#,#}+    Vt_timing_debug1___024root____Vfork_2__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         'act' region trigger index 5 is active: @(posedge t.clk2)
@@ -1478,7 +1478,7 @@
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_sequent__TOP__0
--V{t#,#}+    Vt_timing_debug1___024root____Vfork_h########__0__0
+-V{t#,#}+    Vt_timing_debug1___024root____Vfork_1__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         'act' region trigger index 3 is active: @(posedge t.clk1)
@@ -1536,7 +1536,7 @@
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_sequent__TOP__0
--V{t#,#}+    Vt_timing_debug1___024root____Vfork_h########__0__0
+-V{t#,#}+    Vt_timing_debug1___024root____Vfork_1__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         No triggers active
@@ -1606,7 +1606,7 @@
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_sequent__TOP__0
--V{t#,#}+    Vt_timing_debug1___024root____Vfork_h########__0__0
+-V{t#,#}+    Vt_timing_debug1___024root____Vfork_1__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         'act' region trigger index 3 is active: @(posedge t.clk1)
@@ -1660,9 +1660,9 @@
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_sequent__TOP__0
--V{t#,#}+    Vt_timing_debug1___024root____Vfork_h########__0__0
+-V{t#,#}+    Vt_timing_debug1___024root____Vfork_1__0
 -V{t#,#}+    Vt_timing_debug1___024root___act_sequent__TOP__1
--V{t#,#}+    Vt_timing_debug1___024root____Vfork_h########__0__0
+-V{t#,#}+    Vt_timing_debug1___024root____Vfork_2__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         No triggers active
@@ -1732,7 +1732,7 @@
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_sequent__TOP__0
--V{t#,#}+    Vt_timing_debug1___024root____Vfork_h########__0__0
+-V{t#,#}+    Vt_timing_debug1___024root____Vfork_1__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         'act' region trigger index 3 is active: @(posedge t.clk1)
@@ -1784,7 +1784,7 @@
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_sequent__TOP__0
--V{t#,#}+    Vt_timing_debug1___024root____Vfork_h########__0__0
+-V{t#,#}+    Vt_timing_debug1___024root____Vfork_1__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         No triggers active
@@ -1854,7 +1854,7 @@
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_sequent__TOP__0
--V{t#,#}+    Vt_timing_debug1___024root____Vfork_h########__0__0
+-V{t#,#}+    Vt_timing_debug1___024root____Vfork_1__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         'act' region trigger index 3 is active: @(posedge t.clk1)
@@ -1906,7 +1906,7 @@
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_sequent__TOP__1
--V{t#,#}+    Vt_timing_debug1___024root____Vfork_h########__0__0
+-V{t#,#}+    Vt_timing_debug1___024root____Vfork_2__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         'act' region trigger index 5 is active: @(posedge t.clk2)
@@ -1976,7 +1976,7 @@
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_sequent__TOP__0
--V{t#,#}+    Vt_timing_debug1___024root____Vfork_h########__0__0
+-V{t#,#}+    Vt_timing_debug1___024root____Vfork_1__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
 -V{t#,#}         No triggers active

--- a/test_regress/t/t_timing_debug2.out
+++ b/test_regress/t/t_timing_debug2.out
@@ -62,10 +62,10 @@
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aForkClass::new
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aForkClass::_ctor_var_reset
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aForkClass::__VnoInFunc_do_fork
--V{t#,#}+        Vt_timing_debug2_t__03a__03aForkClass::__Vfork_4__0
--V{t#,#}+        Vt_timing_debug2_t__03a__03aForkClass::__Vfork_4__1
--V{t#,#}+        Vt_timing_debug2_t__03a__03aForkClass::__Vfork_5__0
--V{t#,#}+        Vt_timing_debug2_t__03a__03aForkClass::__Vfork_5__1
+-V{t#,#}+        Vt_timing_debug2_t__03a__03aForkClass::__Vfork_1__0
+-V{t#,#}+        Vt_timing_debug2_t__03a__03aForkClass::__Vfork_1__1
+-V{t#,#}+        Vt_timing_debug2_t__03a__03aForkClass::__Vfork_2__0
+-V{t#,#}+        Vt_timing_debug2_t__03a__03aForkClass::__Vfork_2__1
 -V{t#,#}             Awaiting join of fork at: t/t_timing_class.v:222
 -V{t#,#}             Awaiting join of fork at: t/t_timing_class.v:217
 -V{t#,#}+      Vt_timing_debug2_t___eval_initial__TOP__t__7
@@ -402,9 +402,9 @@
 -V{t#,#}           - Process waiting at t/t_timing_class.v:58
 -V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:58
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aLocalWaitClass::__VnoInFunc_await
--V{t#,#}+        Vt_timing_debug2_t__03a__03aLocalWaitClass::__Vfork_3__0
+-V{t#,#}+        Vt_timing_debug2_t__03a__03aLocalWaitClass::__Vfork_1__0
 -V{t#,#}         Suspending process waiting for @([true] ((32'sh2a == t::LocalWaitClass.a) | (32'sh64 != t::LocalWaitClass.b))) at t/t_timing_class.v:75
--V{t#,#}+        Vt_timing_debug2_t__03a__03aLocalWaitClass::__Vfork_3__1
+-V{t#,#}+        Vt_timing_debug2_t__03a__03aLocalWaitClass::__Vfork_1__1
 -V{t#,#}             Awaiting join of fork at: t/t_timing_class.v:74
 -V{t#,#}+    Vt_timing_debug2___024root___eval_act
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act

--- a/test_regress/t/t_timing_debug2.out
+++ b/test_regress/t/t_timing_debug2.out
@@ -62,10 +62,10 @@
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aForkClass::new
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aForkClass::_ctor_var_reset
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aForkClass::__VnoInFunc_do_fork
--V{t#,#}+        Vt_timing_debug2_t__03a__03aForkClass::__Vfork_h########__0__0
--V{t#,#}+        Vt_timing_debug2_t__03a__03aForkClass::__Vfork_h########__0__1
--V{t#,#}+        Vt_timing_debug2_t__03a__03aForkClass::__Vfork_h########__0__0
--V{t#,#}+        Vt_timing_debug2_t__03a__03aForkClass::__Vfork_h########__0__1
+-V{t#,#}+        Vt_timing_debug2_t__03a__03aForkClass::__Vfork_4__0
+-V{t#,#}+        Vt_timing_debug2_t__03a__03aForkClass::__Vfork_4__1
+-V{t#,#}+        Vt_timing_debug2_t__03a__03aForkClass::__Vfork_5__0
+-V{t#,#}+        Vt_timing_debug2_t__03a__03aForkClass::__Vfork_5__1
 -V{t#,#}             Awaiting join of fork at: t/t_timing_class.v:222
 -V{t#,#}             Awaiting join of fork at: t/t_timing_class.v:217
 -V{t#,#}+      Vt_timing_debug2_t___eval_initial__TOP__t__7
@@ -402,9 +402,9 @@
 -V{t#,#}           - Process waiting at t/t_timing_class.v:58
 -V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:58
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aLocalWaitClass::__VnoInFunc_await
--V{t#,#}+        Vt_timing_debug2_t__03a__03aLocalWaitClass::__Vfork_h########__0__0
+-V{t#,#}+        Vt_timing_debug2_t__03a__03aLocalWaitClass::__Vfork_3__0
 -V{t#,#}         Suspending process waiting for @([true] ((32'sh2a == t::LocalWaitClass.a) | (32'sh64 != t::LocalWaitClass.b))) at t/t_timing_class.v:75
--V{t#,#}+        Vt_timing_debug2_t__03a__03aLocalWaitClass::__Vfork_h########__0__1
+-V{t#,#}+        Vt_timing_debug2_t__03a__03aLocalWaitClass::__Vfork_3__1
 -V{t#,#}             Awaiting join of fork at: t/t_timing_class.v:74
 -V{t#,#}+    Vt_timing_debug2___024root___eval_act
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
@@ -455,7 +455,7 @@
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aDelay40::__VnoInFunc_do_sth_else
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aNoDelay::__VnoInFunc_do_delay
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aNoDelay::__VnoInFunc_do_sth_else
--V{t#,#}+      Vt_timing_debug2_t____Vfork_h########__0__0
+-V{t#,#}+      Vt_timing_debug2_t____Vfork_1__0
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aAssignDelayClass::__VnoInFunc_do_assign
 -V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:162
 -V{t#,#}             Process forked at t/t_timing_class.v:76 finished
@@ -538,7 +538,7 @@
 -V{t#,#}         Resuming delayed processes
 -V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:99
 -V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:97
--V{t#,#}+      Vt_timing_debug2_t____Vfork_h########__0__0
+-V{t#,#}+      Vt_timing_debug2_t____Vfork_2__0
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aAssignDelayClass::__VnoInFunc_do_assign
 -V{t#,#}+    Vt_timing_debug2___024root___eval_act
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act

--- a/test_regress/t/t_timing_fork_rec_method.pl
+++ b/test_regress/t/t_timing_fork_rec_method.pl
@@ -1,0 +1,23 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2023 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    verilator_flags2 => ["--exe --main --timing"],
+    make_main => 0,
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_timing_fork_rec_method.v
+++ b/test_regress/t/t_timing_fork_rec_method.v
@@ -1,0 +1,27 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2023 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+class RecFork;
+   int cnt = 0;
+   task run(int n);
+      if (n > 0) begin
+         cnt++;
+         fork
+            run(n - 1);
+         join
+      end
+   endtask
+endclass
+
+module t;
+   initial begin
+      automatic RecFork rec = new;
+      rec.run(7);
+      if (rec.cnt != 7) $stop;
+      $write("*-* All Finished *-*\n");
+      $finish;
+  end
+endmodule


### PR DESCRIPTION
Currently on master, if there is a recursive method call inside a fork, Verilator hangs in infinite loop in V3Hasher.
This PR fixes it by removing the use of V3Hasher in assignments of names of forks.
It doesn't remove the root problem, because it may still occur somewhere else if a recursive call is hashed, but I think it's better to not compute hashes if we don't need to.