### PR TITLE
Fix class reference assignment checking

### DIFF
--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -6377,7 +6377,7 @@ private:
     }
     void checkClassAssign(AstNode* nodep, const char* side, AstNode* rhsp,
                           AstNodeDType* lhsDTypep) {
-        if (AstClassRefDType* const lhsClassRefp = VN_CAST(lhsDTypep, ClassRefDType)) {
+        if (AstClassRefDType* const lhsClassRefp = VN_CAST(lhsDTypep->skipRefp(), ClassRefDType)) {
             UASSERT_OBJ(rhsp->dtypep(), rhsp, "Node has no type");
             AstNodeDType* const rhsDtypep = rhsp->dtypep()->skipRefp();
             if (AstClassRefDType* const rhsClassRefp = VN_CAST(rhsDtypep, ClassRefDType)) {
@@ -6385,7 +6385,7 @@ private:
             } else if (auto* const constp = VN_CAST(rhsp, Const)) {
                 if (constp->num().isNull()) return;
             }
-            nodep->v3error(side << " expects a " << lhsDTypep->prettyTypeName() << ", got "
+            nodep->v3error(side << " expects a " << lhsClassRefp->prettyTypeName() << ", got "
                                 << rhsDtypep->prettyTypeName());
         }
     }

--- a/test_regress/t/t_class_assign_bad.out
+++ b/test_regress/t/t_class_assign_bad.out
@@ -1,33 +1,37 @@
-%Error: t/t_class_assign_bad.v:25:9: Assign RHS expects a CLASSREFDTYPE 'Cls', got BASICDTYPE 'logic'
+%Error: t/t_class_assign_bad.v:28:9: Assign RHS expects a CLASSREFDTYPE 'Cls', got BASICDTYPE 'logic'
                                    : ... In instance t
-   25 |       c = 0;
+   28 |       c = 0;
       |         ^
-%Error: t/t_class_assign_bad.v:26:9: Assign RHS expects a CLASSREFDTYPE 'Cls', got BASICDTYPE 'logic'
+%Error: t/t_class_assign_bad.v:29:9: Assign RHS expects a CLASSREFDTYPE 'Cls', got BASICDTYPE 'logic'
                                    : ... In instance t
-   26 |       c = 1;
+   29 |       c = 1;
       |         ^
-%Error: t/t_class_assign_bad.v:27:9: Assign RHS expects a CLASSREFDTYPE 'Cls', got CLASSREFDTYPE 'Cls2'
+%Error: t/t_class_assign_bad.v:30:9: Assign RHS expects a CLASSREFDTYPE 'Cls', got CLASSREFDTYPE 'Cls2'
                                    : ... In instance t
-   27 |       c = c2;
+   30 |       c = c2;
       |         ^
-%Error: t/t_class_assign_bad.v:28:13: Assign RHS expects a CLASSREFDTYPE 'ClsExt', got CLASSREFDTYPE 'Cls'
+%Error: t/t_class_assign_bad.v:31:13: Assign RHS expects a CLASSREFDTYPE 'ClsExt', got CLASSREFDTYPE 'Cls'
                                     : ... In instance t
-   28 |       c_ext = c;
+   31 |       c_ext = c;
       |             ^
-%Error: t/t_class_assign_bad.v:30:7: Function Argument expects a CLASSREFDTYPE 'Cls', got BASICDTYPE 'logic'
+%Error: t/t_class_assign_bad.v:32:11: Assign RHS expects a CLASSREFDTYPE 'Cls2', got CLASSREFDTYPE 'Cls'
+                                    : ... In instance t
+   32 |       ct2 = c;
+      |           ^
+%Error: t/t_class_assign_bad.v:34:7: Function Argument expects a CLASSREFDTYPE 'Cls', got BASICDTYPE 'logic'
                                    : ... In instance t
-   30 |       t(0);
+   34 |       t(0);
       |       ^
-%Error: t/t_class_assign_bad.v:31:7: Function Argument expects a CLASSREFDTYPE 'Cls', got BASICDTYPE 'logic'
+%Error: t/t_class_assign_bad.v:35:7: Function Argument expects a CLASSREFDTYPE 'Cls', got BASICDTYPE 'logic'
                                    : ... In instance t
-   31 |       t(1);
+   35 |       t(1);
       |       ^
-%Error: t/t_class_assign_bad.v:32:7: Function Argument expects a CLASSREFDTYPE 'Cls', got CLASSREFDTYPE 'Cls2'
+%Error: t/t_class_assign_bad.v:36:7: Function Argument expects a CLASSREFDTYPE 'Cls', got CLASSREFDTYPE 'Cls2'
                                    : ... In instance t
-   32 |       t(c2);
+   36 |       t(c2);
       |       ^
-%Error: t/t_class_assign_bad.v:33:7: Function Argument expects a CLASSREFDTYPE 'ClsExt', got CLASSREFDTYPE 'Cls'
+%Error: t/t_class_assign_bad.v:37:7: Function Argument expects a CLASSREFDTYPE 'ClsExt', got CLASSREFDTYPE 'Cls'
                                    : ... In instance t
-   33 |       f(c);
+   37 |       f(c);
       |       ^
 %Error: Exiting due to

--- a/test_regress/t/t_class_assign_bad.v
+++ b/test_regress/t/t_class_assign_bad.v
@@ -13,9 +13,12 @@ endclass
 class ClsExt extends Cls;
 endclass
 
+typedef Cls2 cls2_t;
+
 module t (/*AUTOARG*/);
    Cls c;
    Cls2 c2;
+   cls2_t ct2;
    ClsExt c_ext;
 
    task t(Cls c); endtask
@@ -26,6 +29,7 @@ module t (/*AUTOARG*/);
       c = 1;
       c = c2;
       c_ext = c;
+      ct2 = c;
 
       t(0);
       t(1);


### PR DESCRIPTION
Currently on master, if there is a class assignment and the LHS is of a typedefed class type, the check of that assignment is skipped. This PR fixes it.