### PR TITLE
Fix handling of ref types in initial values of type parameters

### DIFF
--- a/src/V3AstNodeDType.h
+++ b/src/V3AstNodeDType.h
@@ -1077,6 +1077,7 @@ public:
     AstRefDType(FileLine* fl, FlagTypeOfExpr, AstNode* typeofp)
         : ASTGEN_SUPER_RefDType(fl) {
         this->typeofp(typeofp);
+        if (AstNodeDType* const dtp = VN_CAST(typeofp, NodeDType)) refDTypep(dtp);
     }
     ASTGEN_MEMBERS_AstRefDType;
     // METHODS

--- a/src/V3Param.cpp
+++ b/src/V3Param.cpp
@@ -709,7 +709,7 @@ class ParamProcessor final : public VNDeleter {
             }
         } else if (AstParamTypeDType* const modvarp = pinp->modPTypep()) {
             AstNodeDType* const exprp = VN_CAST(pinp->exprp(), NodeDType);
-            const AstNodeDType* const origp = modvarp->subDTypep();
+            const AstNodeDType* const origp = modvarp->skipRefToEnump();
             if (!exprp) {
                 pinp->v3error("Parameter type pin value isn't a type: Param "
                               << pinp->prettyNameQ() << " of " << nodep->prettyNameQ());

--- a/test_regress/t/t_class_param_typedef.v
+++ b/test_regress/t/t_class_param_typedef.v
@@ -33,13 +33,38 @@ class Cls2;
    typedef Bar#(Cls2) type_id;
 endclass
 
+typedef int my_int;
+
+class ClsTypedefParam #(type T=my_int);
+   int x;
+endclass
+
+class uvm_sequencer #(type REQ=int, RSP=REQ);
+   int x;
+   typedef uvm_sequencer #(REQ, RSP) this_type;
+endclass
+
 module t;
    initial begin
       Cls1::type_id bar1 = new;
       Cls2::type_id bar2 = new;
 
+      ClsTypedefParam #(int) cls_int = new;
+      ClsTypedefParam#() cls_def;
+
+      uvm_sequencer #(int, int) uvm_seq1 = new;
+      uvm_sequencer #(int, int)::this_type uvm_seq2;
+
       if (bar1.get_x() != 1) $stop;
       if (bar2.get_x() != 2) $stop;
+
+      cls_int.x = 1;
+      cls_def = cls_int;
+      if (cls_def.x != 1) $stop;
+
+      uvm_seq1.x = 2;
+      uvm_seq2 = uvm_seq1;
+      if (uvm_seq2.x != 2) $stop;
 
       $write("*-* All Finished *-*\n");
       $finish;


### PR DESCRIPTION
Currently on master, Verilator can't properly detect if a parameterized class instance is the default instance if the default value of a type parameter is a reference type.
This PR fixes it.