### PR TITLE
Fix comparison of string parameters

### DIFF
--- a/src/V3Ast.cpp
+++ b/src/V3Ast.cpp
@@ -1082,10 +1082,10 @@ bool AstNode::sameTreeIter(const AstNode* node1p, const AstNode* node2p, bool ig
     if (!node1p && !node2p) return true;
     if (!node1p || !node2p) return false;
     if (node1p->type() != node2p->type()) return false;
-    if (node1p->dtypep() != node2p->dtypep()) return false;
     UASSERT_OBJ(
         (!node1p->dtypep() && !node2p->dtypep()) || (node1p->dtypep() && node2p->dtypep()), node1p,
         "Comparison of a node with dtypep() with a node without dtypep()\n-node2=" << node2p);
+    if (node1p->dtypep() && !node1p->dtypep()->similarDType(node2p->dtypep())) return false;
     if (!node1p->same(node2p) || (gateOnly && !node1p->isGateOptimizable())) return false;
     return (sameTreeIter(node1p->m_op1p, node2p->m_op1p, false, gateOnly)
             && sameTreeIter(node1p->m_op2p, node2p->m_op2p, false, gateOnly)

--- a/src/V3Param.cpp
+++ b/src/V3Param.cpp
@@ -394,6 +394,11 @@ class ParamProcessor final : public VNDeleter {
         }
         return nullptr;
     }
+    bool isString(AstNodeDType* nodep) {
+        if (AstBasicDType* basicp = VN_CAST(nodep->skipRefToEnump(), BasicDType))
+            return basicp->isString();
+        return false;
+    }
     void collectPins(CloneMap* clonemapp, AstNodeModule* modp, bool originalIsCopy) {
         // Grab all I/O so we can remap our pins later
         for (AstNode* stmtp = modp->stmtsp(); stmtp; stmtp = stmtp->nextp()) {
@@ -685,6 +690,7 @@ class ParamProcessor final : public VNDeleter {
             } else {
                 V3Const::constifyParamsEdit(pinp->exprp());
                 AstConst* const exprp = VN_CAST(pinp->exprp(), Const);
+                if (isString(modvarp->subDTypep())) exprp->dtypeSetString();
                 const AstConst* const origp = VN_CAST(modvarp->valuep(), Const);
                 if (!exprp) {
                     if (debug()) pinp->dumpTree("-  ");
@@ -692,6 +698,9 @@ class ParamProcessor final : public VNDeleter {
                                   << pinp->prettyNameQ() << " of " << nodep->prettyNameQ());
                     pinp->exprp()->replaceWith(new AstConst{
                         pinp->fileline(), AstConst::WidthedValue{}, modvarp->width(), 0});
+                    // } else if (origp && isString(modvarp->subDTypep()) &&
+                    // origp->num().toString() == exprp->num().toString()) {
+                    //     // string
                 } else if (origp && exprp->sameTree(origp)) {
                     // Setting parameter to its default value.  Just ignore it.
                     // This prevents making additional modules, and makes coverage more

--- a/src/V3Param.cpp
+++ b/src/V3Param.cpp
@@ -395,7 +395,7 @@ class ParamProcessor final : public VNDeleter {
         return nullptr;
     }
     bool isString(AstNodeDType* nodep) {
-        if (AstBasicDType* basicp = VN_CAST(nodep->skipRefToEnump(), BasicDType))
+        if (AstBasicDType* const basicp = VN_CAST(nodep->skipRefToEnump(), BasicDType))
             return basicp->isString();
         return false;
     }

--- a/src/V3Param.cpp
+++ b/src/V3Param.cpp
@@ -718,7 +718,8 @@ class ParamProcessor final : public VNDeleter {
                                   << pinp->prettyNameQ() << " of " << nodep->prettyNameQ());
                     pinp->exprp()->replaceWith(new AstConst{
                         pinp->fileline(), AstConst::WidthedValue{}, modvarp->width(), 0});
-                } else if (origp && exprp->sameTree(origp)) {
+                } else if (origp
+                           && V3Hasher::uncachedHash(exprp) == V3Hasher::uncachedHash(origp)) {
                     // Setting parameter to its default value.  Just ignore it.
                     // This prevents making additional modules, and makes coverage more
                     // obvious as it won't show up under a unique module page name.

--- a/src/V3Param.cpp
+++ b/src/V3Param.cpp
@@ -698,9 +698,9 @@ class ParamProcessor final : public VNDeleter {
                                   << pinp->prettyNameQ() << " of " << nodep->prettyNameQ());
                     pinp->exprp()->replaceWith(new AstConst{
                         pinp->fileline(), AstConst::WidthedValue{}, modvarp->width(), 0});
-                    // } else if (origp && isString(modvarp->subDTypep()) &&
-                    // origp->num().toString() == exprp->num().toString()) {
-                    //     // string
+                } else if (origp && isString(modvarp->subDTypep())
+                           && origp->num().toString() == exprp->num().toString()) {
+                    // string
                 } else if (origp && exprp->sameTree(origp)) {
                     // Setting parameter to its default value.  Just ignore it.
                     // This prevents making additional modules, and makes coverage more

--- a/src/V3Param.cpp
+++ b/src/V3Param.cpp
@@ -718,8 +718,7 @@ class ParamProcessor final : public VNDeleter {
                                   << pinp->prettyNameQ() << " of " << nodep->prettyNameQ());
                     pinp->exprp()->replaceWith(new AstConst{
                         pinp->fileline(), AstConst::WidthedValue{}, modvarp->width(), 0});
-                } else if (origp
-                           && V3Hasher::uncachedHash(exprp) == V3Hasher::uncachedHash(origp)) {
+                } else if (origp && exprp->sameTree(origp)) {
                     // Setting parameter to its default value.  Just ignore it.
                     // This prevents making additional modules, and makes coverage more
                     // obvious as it won't show up under a unique module page name.

--- a/src/V3Param.cpp
+++ b/src/V3Param.cpp
@@ -682,8 +682,8 @@ class ParamProcessor final : public VNDeleter {
         AstConst* const constp = VN_CAST(nodep, Const);
         // Check if it wasn't already converted
         if (constp && !constp->num().isString()) {
-            constp->replaceWith(new AstConst{constp->fileline(), AstConst::String{},
-                    constp->num().toString()});
+            constp->replaceWith(
+                new AstConst{constp->fileline(), AstConst::String{}, constp->num().toString()});
             constp->deleteTree();
         }
     }

--- a/src/V3Param.cpp
+++ b/src/V3Param.cpp
@@ -689,8 +689,13 @@ class ParamProcessor final : public VNDeleter {
                 any_overridesr = true;
             } else {
                 V3Const::constifyParamsEdit(pinp->exprp());
-                AstConst* const exprp = VN_CAST(pinp->exprp(), Const);
-                if (isString(modvarp->subDTypep())) exprp->dtypeSetString();
+                AstConst* exprp = VN_CAST(pinp->exprp(), Const);
+                if (exprp && isString(modvarp->subDTypep())) {
+                    pinp->exprp()->replaceWith(new AstConst{exprp->fileline(), AstConst::String{},
+                                                            exprp->num().toString()});
+                    exprp->deleteTree();
+                    exprp = VN_CAST(pinp->exprp(), Const);
+                }
                 const AstConst* const origp = VN_CAST(modvarp->valuep(), Const);
                 if (!exprp) {
                     if (debug()) pinp->dumpTree("-  ");

--- a/src/V3Param.cpp
+++ b/src/V3Param.cpp
@@ -691,12 +691,17 @@ class ParamProcessor final : public VNDeleter {
                 V3Const::constifyParamsEdit(pinp->exprp());
                 AstConst* exprp = VN_CAST(pinp->exprp(), Const);
                 AstConst* origp = VN_CAST(modvarp->valuep(), Const);
+                // String constants are parsed as logic arrays and converted to strings in V3Const.
+                // At this moment, some constants may have been already converted.
+                // To correctly compare constants, both should be of the same type,
+                // so they need to be converted.
                 if (exprp && isString(modvarp->subDTypep())) {
                     pinp->exprp()->replaceWith(new AstConst{exprp->fileline(), AstConst::String{},
                                                             exprp->num().toString()});
                     exprp->deleteTree();
                     exprp = VN_AS(pinp->exprp(), Const);
-                    if (origp) {
+                    // Check if it wasn't already converted
+                    if (origp && !origp->num().isString()) {
                         modvarp->valuep()->replaceWith(new AstConst{
                             origp->fileline(), AstConst::String{}, origp->num().toString()});
                         origp->deleteTree();

--- a/test_regress/t/t_class_param.v
+++ b/test_regress/t/t_class_param.v
@@ -120,6 +120,15 @@ class Getter2 #(int T=5);
    endfunction
 endclass
 
+class ClsParamString #(string S="abcde");
+   typedef ClsParamString#(S) this_type;
+   static this_type m_inst;
+   int x = 0;
+endclass
+
+typedef ClsParamString#("abcde") cls_param_string_def_t;
+typedef ClsParamString#("abcde") cls_param_string_not_def_t;
+
 module t (/*AUTOARG*/);
 
    Cls c12;
@@ -137,6 +146,8 @@ module t (/*AUTOARG*/);
    Getter1 getter1;
    Getter1 #(1) getter1_param_1;
    Getter2 getter2;
+   cls_param_string_def_t cps_def;
+   cls_param_string_not_def_t cps_not_def;
    int arr [1:0] = '{1, 2};
    initial begin
       c12 = new;
@@ -216,6 +227,16 @@ module t (/*AUTOARG*/);
       if (getter2.get_2() != 2) $stop;
       if (Getter2#()::get_2() != 2) $stop;
       if (Getter2#(2)::get_2() != 2) $stop;
+
+      cls_param_string_def_t::m_inst = new;
+      cls_param_string_def_t::m_inst.x = 1;
+      cps_def = cls_param_string_def_t::m_inst;
+      if (cps_def.x != 1) $stop;
+
+      cls_param_string_not_def_t::m_inst = new;
+      cls_param_string_not_def_t::m_inst.x = 2;
+      cps_not_def = cls_param_string_not_def_t::m_inst;
+      if (cps_not_def.x != 2) $stop;
 
       $write("*-* All Finished *-*\n");
       $finish;

--- a/test_regress/t/t_class_param.v
+++ b/test_regress/t/t_class_param.v
@@ -124,6 +124,7 @@ class ClsParamString #(string S="abcde");
    typedef ClsParamString#(S) this_type;
    static this_type m_inst;
    int x = 0;
+   string name = S;
 endclass
 
 typedef ClsParamString#("abcde") cls_param_string_def_t;
@@ -232,11 +233,13 @@ module t (/*AUTOARG*/);
       cls_param_string_def_t::m_inst.x = 1;
       cps_def = cls_param_string_def_t::m_inst;
       if (cps_def.x != 1) $stop;
+      if (cps_def.name != "abcde") $stop;
 
       cls_param_string_not_def_t::m_inst = new;
       cls_param_string_not_def_t::m_inst.x = 2;
       cps_not_def = cls_param_string_not_def_t::m_inst;
       if (cps_not_def.x != 2) $stop;
+      if (cps_not_def.name != "xyz") $stop;
 
       $write("*-* All Finished *-*\n");
       $finish;

--- a/test_regress/t/t_class_param.v
+++ b/test_regress/t/t_class_param.v
@@ -127,7 +127,7 @@ class ClsParamString #(string S="abcde");
 endclass
 
 typedef ClsParamString#("abcde") cls_param_string_def_t;
-typedef ClsParamString#("abcde") cls_param_string_not_def_t;
+typedef ClsParamString#("xyz") cls_param_string_not_def_t;
 
 module t (/*AUTOARG*/);
 


### PR DESCRIPTION
Currently, comparison of string parameters doesn't work. This leads to creation of multiple class specializations for the same value of the string parameter. If there is an assignment of objects of such classes, it throws error from V3Width.

The problem is that strings are parsed as logic arrays and they have the string type set in V3Const. During V3Param, there are a few calls of `V3Const::constifyParamsEdit` which changes the type of a string constant from logic array to string. So in V3Param some string constants have already string dtype set, while some others still have dtype of logic array. If the dtypes differ, `sameTree` method returns false and hashes are different too, so these values are treated as different values.

This PR fixes it by converting all string parameter constants that are compared in V3Param.cpp.