### PR TITLE
Use `std::packaged_task` as a job wrapper; add and use `V3ThreadPool::ScopedExclusiveAccess`

### DIFF
--- a/include/verilatedos.h
+++ b/include/verilatedos.h
@@ -119,6 +119,10 @@
 // Allowed on: function, method. (-fthread-safety)
 #define VL_RETURN_CAPABILITY(x) \
         VL_CLANG_ATTR(lock_returned(x))
+// Assert that capability is already held.
+// Allowed on: function, method. (-fthread-safety)
+#define VL_ASSERT_CAPABILITY(x) \
+        VL_CLANG_ATTR(assert_capability(x))
 
 // Defaults for unsupported compiler features
 #ifndef VL_ATTR_ALWINLINE

--- a/src/V3EmitCImp.cpp
+++ b/src/V3EmitCImp.cpp
@@ -932,11 +932,11 @@ void V3EmitC::emitcImp() {
         const AstNodeModule* const modp = VN_AS(nodep, NodeModule);
         cfiles.emplace_back();
         auto& slowCfilesr = cfiles.back();
-        futures.push_back(V3ThreadPool::s().enqueue<void>(
+        futures.push_back(V3ThreadPool::s().enqueue(
             [modp, &slowCfilesr]() { EmitCImp::main(modp, /* slow: */ true, slowCfilesr); }));
         cfiles.emplace_back();
         auto& fastCfilesr = cfiles.back();
-        futures.push_back(V3ThreadPool::s().enqueue<void>(
+        futures.push_back(V3ThreadPool::s().enqueue(
             [modp, &fastCfilesr]() { EmitCImp::main(modp, /* slow: */ false, fastCfilesr); }));
     }
 
@@ -944,12 +944,12 @@ void V3EmitC::emitcImp() {
     if (v3Global.opt.trace() && !v3Global.opt.lintOnly()) {
         cfiles.emplace_back();
         auto& slowCfilesr = cfiles.back();
-        futures.push_back(V3ThreadPool::s().enqueue<void>([&slowCfilesr]() {
+        futures.push_back(V3ThreadPool::s().enqueue([&slowCfilesr]() {
             EmitCTrace::main(v3Global.rootp()->topModulep(), /* slow: */ true, slowCfilesr);
         }));
         cfiles.emplace_back();
         auto& fastCfilesr = cfiles.back();
-        futures.push_back(V3ThreadPool::s().enqueue<void>([&fastCfilesr]() {
+        futures.push_back(V3ThreadPool::s().enqueue([&fastCfilesr]() {
             EmitCTrace::main(v3Global.rootp()->topModulep(), /* slow: */ false, fastCfilesr);
         }));
     }

--- a/src/V3Error.cpp
+++ b/src/V3Error.cpp
@@ -222,7 +222,8 @@ void V3ErrorGuarded::v3errorEnd(std::ostringstream& sstr, const string& extra)
 #ifndef V3ERROR_NO_GLOBAL_
                 if (dumpTreeLevel() || debug()) {
                     V3Broken::allowMidvisitorCheck(true);
-                    V3ThreadPool::s().requestExclusiveAccess([&]() VL_REQUIRES(m_mutex) {
+                    V3ThreadPool::s().requestExclusiveAccess([&]() {
+                        m_mutex.assumeLocked();
                         if (dumpTreeLevel()) {
                             v3Global.rootp()->dumpTreeFile(
                                 v3Global.debugFilename("final.tree", 990));

--- a/src/V3Error.cpp
+++ b/src/V3Error.cpp
@@ -222,21 +222,18 @@ void V3ErrorGuarded::v3errorEnd(std::ostringstream& sstr, const string& extra)
 #ifndef V3ERROR_NO_GLOBAL_
                 if (dumpTreeLevel() || debug()) {
                     V3Broken::allowMidvisitorCheck(true);
-                    V3ThreadPool::s().requestExclusiveAccess([&]() {
-                        m_mutex.assumeLocked();
-                        if (dumpTreeLevel()) {
-                            v3Global.rootp()->dumpTreeFile(
-                                v3Global.debugFilename("final.tree", 990));
-                        }
-                        if (debug()) {
-                            execErrorExitCb();
-                            V3Stats::statsFinalAll(v3Global.rootp());
-                            V3Stats::statsReport();
-                        }
-                        // Abort in exclusive access to make sure other threads
-                        // don't change error code
-                        vlAbortOrExit();
-                    });
+                    const V3ThreadPool::ScopedExclusiveAccess exclusiveAccess;
+                    if (dumpTreeLevel()) {
+                        v3Global.rootp()->dumpTreeFile(v3Global.debugFilename("final.tree", 990));
+                    }
+                    if (debug()) {
+                        execErrorExitCb();
+                        V3Stats::statsFinalAll(v3Global.rootp());
+                        V3Stats::statsReport();
+                    }
+                    // Abort in exclusive access to make sure other threads
+                    // don't change error code
+                    vlAbortOrExit();
                 }
 #endif
             }

--- a/src/V3Mutex.h
+++ b/src/V3Mutex.h
@@ -109,6 +109,10 @@ public:
     bool try_lock() VL_TRY_ACQUIRE(true) VL_MT_SAFE {
         return V3MutexConfig::s().enable() ? m_mutex.try_lock() : true;
     }
+    /// Assume that the mutex is already held. Purely for Clang thread safety analyzer.
+    void assumeLocked() VL_ASSERT_CAPABILITY(this) VL_MT_SAFE {}
+    /// Pretend that the mutex is being unlocked. Purely for Clang thread safety analyzer.
+    void pretendUnlock() VL_RELEASE() VL_MT_SAFE {}
     /// Acquire/lock mutex and check for stop request
     /// It tries to lock the mutex and if it fails, it check if stop request was send.
     /// It returns after locking mutex.

--- a/src/V3ThreadPool.cpp
+++ b/src/V3ThreadPool.cpp
@@ -61,7 +61,7 @@ void V3ThreadPool::workerJobLoop(int id) VL_MT_SAFE {
     while (true) {
         // Wait for a notification
         waitIfStopRequested();
-        any_packaged_task job;
+        VAnyPackagedTask job;
         {
             V3LockGuard lock(m_mutex);
             m_cv.wait(m_mutex, [&]() VL_REQUIRES(m_mutex) {

--- a/src/V3ThreadPool.cpp
+++ b/src/V3ThreadPool.cpp
@@ -116,11 +116,10 @@ void V3ThreadPool::selfTest() {
 
     auto firstJob = [&](int sleep) -> void {
         std::this_thread::sleep_for(std::chrono::milliseconds{sleep});
-        s().requestExclusiveAccess([&]() {
-            commonValue = 10;
-            std::this_thread::sleep_for(std::chrono::milliseconds{sleep + 10});
-            UASSERT(commonValue == 10, "unexpected commonValue = " << commonValue);
-        });
+        const V3ThreadPool::ScopedExclusiveAccess exclusiveAccess;
+        commonValue = 10;
+        std::this_thread::sleep_for(std::chrono::milliseconds{sleep + 10});
+        UASSERT(commonValue == 10, "unexpected commonValue = " << commonValue);
     };
     auto secondJob = [&](int sleep) -> void {
         commonMutex.lock();

--- a/src/V3ThreadPool.h
+++ b/src/V3ThreadPool.h
@@ -29,13 +29,51 @@
 
 //============================================================================
 
+// Callable, type-erased wrapper for std::package_task<Signature> with any Signature.
+class any_packaged_task final {
+    struct PTWrapperBase {
+        virtual ~PTWrapperBase() {}
+        virtual void operator()() = 0;
+    };
+
+    template <typename Signature>
+    struct PTWrapper final : PTWrapperBase {
+        std::packaged_task<Signature> m_pt;
+
+        PTWrapper(std::packaged_task<Signature>&& pt)
+            : m_pt(std::move(pt)) {}
+
+        void operator()() final override { m_pt(); }
+    };
+
+    std::unique_ptr<PTWrapperBase> m_ptWrapperp = nullptr;
+
+public:
+    template <typename Signature>
+    any_packaged_task(std::packaged_task<Signature>&& pt)
+        : m_ptWrapperp{std::make_unique<PTWrapper<Signature>>(std::move(pt))} {}
+
+    any_packaged_task() = default;
+    ~any_packaged_task() = default;
+
+    any_packaged_task(const any_packaged_task&) = delete;
+    any_packaged_task& operator=(const any_packaged_task&) = delete;
+
+    any_packaged_task(any_packaged_task&&) = default;
+    any_packaged_task& operator=(any_packaged_task&&) = default;
+
+    void operator()() {
+        // UASSERT(m_pt_wrapper, "Tried to call uninitialized any_package_wrapper");
+        (*m_ptWrapperp)();
+    }
+};
+
 class V3ThreadPool final {
     // MEMBERS
     static constexpr unsigned int FUTUREWAITFOR_MS = 100;
-    using job_t = std::function<void()>;
 
-    mutable V3Mutex m_mutex;  // Mutex for use by m_queue
-    std::queue<job_t> m_queue VL_GUARDED_BY(m_mutex);  // Queue of jobs
+    V3Mutex m_mutex;  // Mutex for use by m_queue
+    std::queue<any_packaged_task> m_queue VL_GUARDED_BY(m_mutex);  // Queue of jobs
     // We don't need to guard this condition_variable as
     // both `notify_one` and `notify_all` functions are atomic,
     // `wait` function is not atomic, but we are guarding `m_queue` that is
@@ -79,8 +117,8 @@ public:
     // will call it. `VL_MT_START` here indicates that
     // every function call inside this `std::function` requires
     // annotations.
-    template <typename T>
-    std::future<T> enqueue(std::function<T()>&& f) VL_MT_START;
+    template <typename Callable>
+    auto enqueue(Callable&& f) VL_MT_START;
 
     // Request exclusive access to processing.
     // It sends request to stop all other threads and waits for them to stop.
@@ -88,7 +126,9 @@ public:
     // they can be stopped.
     // When all other threads are stopped, this function executes the job
     // and resumes execution of other jobs.
-    void requestExclusiveAccess(const job_t&& exclusiveAccessJob) VL_MT_SAFE;
+    template <typename Callable>
+    void requestExclusiveAccess(Callable&& exclusiveAccessJob) VL_MT_SAFE
+        VL_EXCLUDES(m_stoppedJobsMutex);
 
     // Check if other thread requested exclusive access to processing,
     // if so, it waits for it to complete. Afterwards it is resumed.
@@ -151,9 +191,6 @@ private:
     // Waits until all other jobs are stopped
     void waitOtherThreads() VL_MT_SAFE_EXCLUDES(m_mutex) VL_REQUIRES(m_stoppedJobsMutex);
 
-    template <typename T>
-    void pushJob(std::shared_ptr<std::promise<T>>& prom, std::function<T()>&& f) VL_MT_SAFE;
-
     void workerJobLoop(int id) VL_MT_SAFE;
 
     static void startWorker(V3ThreadPool* selfThreadp, int id) VL_MT_SAFE;
@@ -175,29 +212,41 @@ T V3ThreadPool::waitForFuture(std::future<T>& future) VL_MT_SAFE_EXCLUDES(m_mute
     }
 }
 
-template <typename T>
-std::future<T> V3ThreadPool::enqueue(std::function<T()>&& f) VL_MT_START {
-    std::shared_ptr<std::promise<T>> prom = std::make_shared<std::promise<T>>();
-    std::future<T> result = prom->get_future();
-    pushJob(prom, std::move(f));
-    const V3LockGuard guard{m_mutex};
-    m_cv.notify_one();
-    return result;
+template <typename Callable>
+auto V3ThreadPool::enqueue(Callable&& f) VL_MT_START {
+    using result_type = decltype(f());
+    auto&& job = std::packaged_task<result_type()>{std::forward<Callable>(f)};
+    auto future = job.get_future();
+    if (willExecuteSynchronously()) {
+        job();
+    } else {
+        {
+            const V3LockGuard guard{m_mutex};
+            m_queue.push(std::move(job));
+        }
+        m_cv.notify_one();
+    }
+    return future;
 }
 
-template <typename T>
-void V3ThreadPool::pushJob(std::shared_ptr<std::promise<T>>& prom,
-                           std::function<T()>&& f) VL_MT_SAFE {
+template <typename Callable>
+void V3ThreadPool::requestExclusiveAccess(Callable&& exclusiveAccessJob) VL_MT_SAFE
+    VL_EXCLUDES(m_stoppedJobsMutex) {
     if (willExecuteSynchronously()) {
-        prom->set_value(f());
+        exclusiveAccessJob();
     } else {
-        const V3LockGuard guard{m_mutex};
-        m_queue.push([prom, f] { prom->set_value(f()); });
+        V3LockGuard stoppedJobLock{m_stoppedJobsMutex};
+        // if some other job already requested exclusive access
+        // wait until it stops
+        if (stopRequested()) { waitStopRequested(); }
+        m_stopRequested = true;
+        waitOtherThreads();
+        m_exclusiveAccess = true;
+        exclusiveAccessJob();
+        m_exclusiveAccess = false;
+        m_stopRequested = false;
+        m_stoppedJobsCV.notify_all();
     }
 }
-
-template <>
-void V3ThreadPool::pushJob<void>(std::shared_ptr<std::promise<void>>& prom,
-                                 std::function<void()>&& f) VL_MT_SAFE;
 
 #endif  // Guard


### PR DESCRIPTION
The PR contains two related changes:

## Use `std::packaged_job` for wrapping promise and job function together.

This change removed one level of indirection (`std::function`) and use of `shared_ptr`. The promise is most likely inlined inside `packaged_task`.

The `std::function` has been removed by using template type parameter as a type of enqueued job function.

I had to replace remaining `std::function` with custom class (`any_packaged_task`) because `std::function` supports only callables that are copyable, and `packaged_task` is not copyable due to promise stored inside it.

Structure of a job stored in the queue looked like this:
```
std::function(
    lambda_in_pushJob(
        shared_ptr(
            job_promise
        ),
        std::function(
            job_lambda
        )
    )
)
```

Now it looks like this:
```
any_packaged_task(
    std::packaged_task(
        [implicit job_promise],
        job_lambda
    )
)
```

## Replace lambdas passed to `requestExclusiveAccess()` with code blocks guarded by `V3ThreadPool::ScopedExclusiveAccess` object.

This change improves work of thread safety analyzer. There is no lambda anymore, the code is executed directly in the context of function containing it.

Until now, lambdas had to be either annotated with list of already locked mutexes (those annotations were not checked for validity due to lambda being wrapped in std::function and executed in the context of `requestExclusiveAccess()`), or use `assumeLocked()` (again, not verified with outside context).