### PR TITLE
Fix implicit calls of base class constructors with optional arguments

### DIFF
--- a/src/V3LinkDot.cpp
+++ b/src/V3LinkDot.cpp
@@ -3301,7 +3301,7 @@ private:
             iterateChildren(nodep);
             if (isNew && !m_explicitSuperNew && m_statep->forParamed()) {
                 const AstClassExtends* const classExtendsp = VN_AS(m_modp, Class)->extendsp();
-                if (classExtendsp->classOrNullp()) {
+                if (classExtendsp && classExtendsp->classOrNullp()) {
                     AstNodeStmt* const superNewp = addImplicitSuperNewCall(VN_AS(nodep, Func));
                     iterate(superNewp);
                 }

--- a/src/V3LinkDot.cpp
+++ b/src/V3LinkDot.cpp
@@ -3630,7 +3630,15 @@ private:
     }
     void visit(AstStmtExpr* nodep) override {
         checkNoDot(nodep);
-        if (VN_IS(nodep->exprp(), New)) m_explicitSuperNew = true;
+        // check if nodep represents a super.new call;
+        if (VN_IS(nodep->exprp(), New)) {
+            // in this case it was already linked, so it doesn't have a super reference
+            m_explicitSuperNew = true;
+        } else if (const AstDot* const dotp = VN_CAST(nodep->exprp(), Dot)) {
+            if (dotp->lhsp()->name() == "super" && VN_IS(dotp->rhsp(), New)) {
+                m_explicitSuperNew = true;
+            }
+        }
         iterateChildren(nodep);
     }
 

--- a/src/V3LinkDot.cpp
+++ b/src/V3LinkDot.cpp
@@ -3296,7 +3296,7 @@ private:
         {
             m_ftaskp = nodep;
             m_ds.m_dotSymp = m_curSymp = m_statep->getNodeSym(nodep);
-            bool isNew = nodep->name() == "new";
+            const bool isNew = nodep->name() == "new";
             if (isNew) m_explicitSuperNew = false;
             iterateChildren(nodep);
             if (isNew && !m_explicitSuperNew && m_statep->forParamed()) {
@@ -3630,7 +3630,7 @@ private:
     }
     void visit(AstStmtExpr* nodep) override {
         checkNoDot(nodep);
-        // check if nodep represents a super.new call;
+        // Check if nodep represents a super.new call;
         if (VN_IS(nodep->exprp(), New)) {
             // in this case it was already linked, so it doesn't have a super reference
             m_explicitSuperNew = true;

--- a/src/V3LinkDot.cpp
+++ b/src/V3LinkDot.cpp
@@ -750,7 +750,14 @@ class LinkDotFindVisitor final : public VNVisitor {
 
     // METHODS
     void makeImplicitNew(AstClass* nodep) {
-        AstFunc* const newp = new AstFunc{nodep->fileline(), "new", nullptr, nullptr};
+        FileLine* const fl = nodep->fileline();
+        AstFunc* const newp = new AstFunc{fl, "new", nullptr, nullptr};
+        if (nodep->extendsp()) {
+            AstDot* const superNewp
+                = new AstDot{fl, false, new AstParseRef{fl, VParseRefExp::PX_ROOT, "super"},
+                             new AstNew{fl, nullptr}};
+            newp->addStmtsp(superNewp->makeStmt());
+        }
         newp->isConstructor(true);
         nodep->addMembersp(newp);
         UINFO(8, "Made implicit new for " << nodep->name() << ": " << nodep << endl);

--- a/src/V3LinkDot.cpp
+++ b/src/V3LinkDot.cpp
@@ -3421,6 +3421,7 @@ private:
         checkNoDot(nodep);
         VL_RESTORER(m_curSymp);
         VL_RESTORER(m_modSymp);
+        VL_RESTORER(m_modp);
         VL_RESTORER(m_ifClassImpNames);
         VL_RESTORER(m_insideClassExtParam);
         {

--- a/src/V3LinkDot.cpp
+++ b/src/V3LinkDot.cpp
@@ -760,7 +760,7 @@ class LinkDotFindVisitor final : public VNVisitor {
             // super.new shall be the first statement (section 8.15 of IEEE Std 1800-2017)
             // but some nodes (such as variable declarations and typedefs) should stay before
             if (VN_IS(stmtp, NodeStmt)) {
-                nodep->addHereThisAsNext(superNewStmtp);
+                stmtp->addHereThisAsNext(superNewStmtp);
                 return;
             }
         }

--- a/test_regress/t/t_class_super_new.v
+++ b/test_regress/t/t_class_super_new.v
@@ -1,7 +1,7 @@
 // DESCRIPTION: Verilator: Verilog Test module
 //
 // This file ONLY is placed under the Creative Commons Public Domain, for
-// any use, without warranty, 2022 by Antmicro Ltd.
+// any use, without warranty, 2023 by Antmicro Ltd.
 // SPDX-License-Identifier: CC0-1.0
 
 `define stop $stop
@@ -58,6 +58,21 @@ class Bar2Args extends Foo2Args;
    endfunction
 endclass
 
+class OptArgInNew;
+   int x;
+   function new (int y=1);
+      x = y;
+   endfunction
+endclass
+
+class NoNew extends OptArgInNew;
+endclass
+
+class NewWithoutSuper extends OptArgInNew;
+   function new;
+   endfunction
+endclass
+
 module t (/*AUTOARG*/
    );
 
@@ -80,6 +95,8 @@ module t (/*AUTOARG*/
    BarArg barArg;
    BarExpr barExpr;
    Bar2Args bar2Args;
+   NoNew no_new;
+   NewWithoutSuper new_without_super;
 
    initial begin
       bar = new;
@@ -94,6 +111,10 @@ module t (/*AUTOARG*/
       `checkh(barExpr.x, 16);
       bar2Args = new(2, 12);
       `checkh(bar2Args.x, 14);
+      no_new = new;
+      `checkh(no_new.x, 1);
+      new_without_super = new;
+      `checkh(new_without_super.x, 1);
 
       $write("*-* All Finished *-*\n");
       $finish;

--- a/test_regress/t/t_class_super_new.v
+++ b/test_regress/t/t_class_super_new.v
@@ -73,6 +73,21 @@ class NewWithoutSuper extends OptArgInNew;
    endfunction
 endclass
 
+class OptArgInNewParam #(parameter int P=1);
+   int x;
+   function new (int y=1);
+      x = y;
+   endfunction
+endclass
+
+class NoNewParam#(parameter int R) extends OptArgInNewParam#(R);
+endclass
+
+class NewWithoutSuperParam#(parameter int R) extends OptArgInNewParam#();
+   function new;
+   endfunction
+endclass
+
 module t (/*AUTOARG*/
    );
 
@@ -95,8 +110,10 @@ module t (/*AUTOARG*/
    BarArg barArg;
    BarExpr barExpr;
    Bar2Args bar2Args;
-   NoNew no_new;
-   NewWithoutSuper new_without_super;
+   NoNew noNew;
+   NewWithoutSuper newWithoutSuper;
+   NoNewParam#(2) noNewParam;
+   NewWithoutSuperParam#(1) newWithoutSuperParam;
 
    initial begin
       bar = new;
@@ -111,10 +128,14 @@ module t (/*AUTOARG*/
       `checkh(barExpr.x, 16);
       bar2Args = new(2, 12);
       `checkh(bar2Args.x, 14);
-      no_new = new;
-      `checkh(no_new.x, 1);
-      new_without_super = new;
-      `checkh(new_without_super.x, 1);
+      noNew = new;
+      `checkh(noNew.x, 1);
+      newWithoutSuper = new;
+      `checkh(newWithoutSuper.x, 1);
+      noNewParam = new;
+      `checkh(noNewParam.x, 1);
+      newWithoutSuperParam = new;
+      `checkh(newWithoutSuperParam.x, 1);
 
       $write("*-* All Finished *-*\n");
       $finish;


### PR DESCRIPTION
It adds super.new() calls to constructors of deriving classes that don't have explicit calls of the base class constructors. It usually works without such calls added by Verilator, because systemverilog classes are converted to c++ classes and c++ also requires compiler to insert the call of the base class constructor if a user didn't provide it. But there is a problem if the constructor has an optional argument. Verilator handles optional arguments by inserting their default values to function calls and later treats them as required arguments. So a systemverilog constructor with an optional argument is converted to a c++ constructor with a required argument. It doesn't match with the call of the constructor without arguments added by c++ compiler.