### PR TITLE
Fix multiple edge timing controls in class methods (#4318)

### DIFF
--- a/src/V3Timing.cpp
+++ b/src/V3Timing.cpp
@@ -572,10 +572,12 @@ private:
     void visit(AstScope* nodep) override {
         VL_RESTORER(m_scopep);
         m_scopep = nodep;
-        VL_RESTORER(m_senExprBuilderp);
         SenExprBuilder senExprBuilder{m_scopep};
-        m_senExprBuilderp = &senExprBuilder;
-        iterateChildren(nodep);
+        {  // Restore m_senExprBuilderp before destroying senExprBuilder
+            VL_RESTORER(m_senExprBuilderp);
+            m_senExprBuilderp = &senExprBuilder;
+            iterateChildren(nodep);
+        }
     }
     void visit(AstActive* nodep) override {
         m_activep = nodep;

--- a/test_regress/t/t_timing_class.v
+++ b/test_regress/t/t_timing_class.v
@@ -80,9 +80,32 @@ module t;
         endtask
     endclass
 
+    class ClkClass;
+        logic clk;
+        int count;
+
+        function new;
+            clk = 0;
+            count = 0;
+        endfunction
+
+        task flip;
+            clk = ~clk;
+        endtask;
+
+        task count_5;
+            @(posedge clk) count++;
+            @(posedge clk) count++;
+            @(posedge clk) count++;
+            @(posedge clk) count++;
+            @(posedge clk) count++;
+        endtask
+    endclass
+
     EventClass ec = new;
     WaitClass wc = new;
     LocalWaitClass lc = new;
+    ClkClass cc = new;
 
     initial begin
         @ec.e;
@@ -105,8 +128,13 @@ module t;
         `WRITE_VERBOSE(("Event in class triggered at time %0t!\n", $time));
     end
 
+    always #5 cc.flip;
+
+    initial cc.count_5;
+
     initial begin
         #80
+        if (cc.count != 5) $stop;
         if (ec.trig_count != 3) $stop;
         if (!wc.ok) $stop;
         if (!lc.ok) $stop;

--- a/test_regress/t/t_timing_debug2.out
+++ b/test_regress/t/t_timing_debug2.out
@@ -4,6 +4,7 @@
 -V{t#,#}+        Vt_timing_debug2___024unit___ctor_var_reset
 -V{t#,#}+      Vt_timing_debug2_t___ctor_var_reset
 -V{t#,#}+  Vt_timing_debug2_t__03a__03aAssignDelayClass__Vclpkg___ctor_var_reset
+-V{t#,#}+  Vt_timing_debug2_t__03a__03aClkClass__Vclpkg___ctor_var_reset
 -V{t#,#}+  Vt_timing_debug2_t__03a__03aDelay10__Vclpkg___ctor_var_reset
 -V{t#,#}+  Vt_timing_debug2_t__03a__03aDelay20__Vclpkg___ctor_var_reset
 -V{t#,#}+  Vt_timing_debug2_t__03a__03aDelay40__Vclpkg___ctor_var_reset
@@ -31,14 +32,19 @@
 -V{t#,#}+          Vt_timing_debug2___024unit__03a__03aBaseClass::_ctor_var_reset
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aLocalWaitClass::new
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aLocalWaitClass::_ctor_var_reset
+-V{t#,#}+        Vt_timing_debug2_t__03a__03aClkClass::new
+-V{t#,#}+        Vt_timing_debug2_t__03a__03aClkClass::_ctor_var_reset
 -V{t#,#}+    Vt_timing_debug2___024root___eval_initial
 -V{t#,#}+      Vt_timing_debug2_t___eval_initial__TOP__t__0
--V{t#,#}         Suspending process waiting for @([event] t.ec.e) at t/t_timing_class.v:88
+-V{t#,#}         Suspending process waiting for @([event] t.ec.e) at t/t_timing_class.v:111
 -V{t#,#}+      Vt_timing_debug2_t___eval_initial__TOP__t__1
 -V{t#,#}+      Vt_timing_debug2_t___eval_initial__TOP__t__2
 -V{t#,#}+      Vt_timing_debug2_t___eval_initial__TOP__t__3
 -V{t#,#}+      Vt_timing_debug2_t___eval_initial__TOP__t__4
+-V{t#,#}+        Vt_timing_debug2_t__03a__03aClkClass::__VnoInFunc_count_5
+-V{t#,#}         Suspending process waiting for @(posedge t::ClkClass.clk) at t/t_timing_class.v:97
 -V{t#,#}+      Vt_timing_debug2_t___eval_initial__TOP__t__5
+-V{t#,#}+      Vt_timing_debug2_t___eval_initial__TOP__t__6
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aDelayClass::new
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aDelayClass::_ctor_var_reset
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aDelay10::new
@@ -58,7 +64,7 @@
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aAssignDelayClass::new
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aAssignDelayClass::_ctor_var_reset
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aDelay10::__VnoInFunc_do_delay
--V{t#,#}+      Vt_timing_debug2_t___eval_initial__TOP__t__6
+-V{t#,#}+      Vt_timing_debug2_t___eval_initial__TOP__t__7
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aForkClass::new
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aForkClass::_ctor_var_reset
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aForkClass::__VnoInFunc_do_fork
@@ -66,20 +72,24 @@
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aForkClass::__Vfork_1__1
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aForkClass::__Vfork_2__0
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aForkClass::__Vfork_2__1
--V{t#,#}             Awaiting join of fork at: t/t_timing_class.v:222
--V{t#,#}             Awaiting join of fork at: t/t_timing_class.v:217
--V{t#,#}+      Vt_timing_debug2_t___eval_initial__TOP__t__7
+-V{t#,#}             Awaiting join of fork at: t/t_timing_class.v:250
+-V{t#,#}             Awaiting join of fork at: t/t_timing_class.v:245
+-V{t#,#}+      Vt_timing_debug2_t___eval_initial__TOP__t__8
+-V{t#,#}+      Vt_timing_debug2_t___eval_initial__TOP__t__9
 -V{t#,#}+    Vt_timing_debug2___024root___eval_settle
 -V{t#,#}MTask0 starting
 -V{t#,#}+ Eval
 -V{t#,#}+    Vt_timing_debug2___024root___eval
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
--V{t#,#}         No suspended processes waiting for dynamic trigger evaluation
+-V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
+-V{t#,#}           - Process waiting at t/t_timing_class.v:97
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:97
+-V{t#,#}         Suspending process waiting for @(posedge t::ClkClass.clk) at t/t_timing_class.v:97
 -V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
 -V{t#,#}         No triggers active
 -V{t#,#}+    Vt_timing_debug2___024root___timing_commit
 -V{t#,#}         Committing processes waiting for @([event] t.ec.e):
--V{t#,#}           - Process waiting at t/t_timing_class.v:88
+-V{t#,#}           - Process waiting at t/t_timing_class.v:111
 -V{t#,#}End-of-eval cleanup
 -V{t#,#}+++++TOP Evaluate Vt_timing_debug2::eval_step
 -V{t#,#}+    Vt_timing_debug2___024root___eval_debug_assertions
@@ -87,36 +97,57 @@
 -V{t#,#}+ Eval
 -V{t#,#}+    Vt_timing_debug2___024root___eval
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
--V{t#,#}         No suspended processes waiting for dynamic trigger evaluation
+-V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
+-V{t#,#}           - Process waiting at t/t_timing_class.v:97
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:97
+-V{t#,#}         Suspending process waiting for @(posedge t::ClkClass.clk) at t/t_timing_class.v:97
 -V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
 -V{t#,#}         'act' region trigger index 1 is active: @([true] __VdlySched.awaitingCurrentTime())
 -V{t#,#}+    Vt_timing_debug2___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug2___024root___timing_resume
 -V{t#,#}         Delayed processes:
--V{t#,#}             Awaiting time 10: Process waiting at t/t_timing_class.v:96
--V{t#,#}             Awaiting time 20: Process waiting at t/t_timing_class.v:97
--V{t#,#}             Awaiting time 10: Process waiting at t/t_timing_class.v:99
--V{t#,#}             Awaiting time 30: Process waiting at t/t_timing_class.v:109
--V{t#,#}             Awaiting time 40: Process waiting at t/t_timing_class.v:145
--V{t#,#}             Awaiting time 50: Process waiting at t/t_timing_class.v:219
--V{t#,#}             Awaiting time 20: Process waiting at t/t_timing_class.v:224
--V{t#,#}             Awaiting time 80: Process waiting at t/t_timing_class.v:229
--V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:246
+-V{t#,#}             Awaiting time 5: Process waiting at t/t_timing_class.v:119
+-V{t#,#}             Awaiting time 10: Process waiting at t/t_timing_class.v:120
+-V{t#,#}             Awaiting time 10: Process waiting at t/t_timing_class.v:122
+-V{t#,#}             Awaiting time 30: Process waiting at t/t_timing_class.v:136
+-V{t#,#}             Awaiting time 20: Process waiting at t/t_timing_class.v:173
+-V{t#,#}             Awaiting time 50: Process waiting at t/t_timing_class.v:247
+-V{t#,#}             Awaiting time 20: Process waiting at t/t_timing_class.v:252
+-V{t#,#}             Awaiting time 80: Process waiting at t/t_timing_class.v:257
+-V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:274
+-V{t#,#}             Awaiting time 40: Process waiting at t/t_timing_class.v:131
 -V{t#,#}         Resuming delayed processes
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:246
--V{t#,#}+        Vt_timing_debug2_t__03a__03aDelay10::__VnoInFunc_do_sth_else
--V{t#,#}+        Vt_timing_debug2_t__03a__03aDelay20::__VnoInFunc_do_delay
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:146
--V{t#,#}             Process forked at t/t_timing_class.v:218 finished
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:131
+-V{t#,#}+        Vt_timing_debug2_t__03a__03aClkClass::__VnoInFunc_flip
 -V{t#,#}+    Vt_timing_debug2___024root___eval_act
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
--V{t#,#}         No suspended processes waiting for dynamic trigger evaluation
+-V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
+-V{t#,#}           - Process waiting at t/t_timing_class.v:97
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:97
+-V{t#,#}         Process waiting for @(posedge t::ClkClass.clk) at t/t_timing_class.v:97 awaiting resumption
+-V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
+-V{t#,#}         'act' region trigger index 2 is active: @([true] __VdynSched.evaluate())
+-V{t#,#}+    Vt_timing_debug2___024root___timing_commit
+-V{t#,#}+    Vt_timing_debug2___024root___timing_resume
+-V{t#,#}         Resuming processes:
+-V{t#,#}           - Process waiting at t/t_timing_class.v:97
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:97
+-V{t#,#}         Suspending process waiting for @(posedge t::ClkClass.clk) at t/t_timing_class.v:98
+-V{t#,#}+    Vt_timing_debug2___024root___eval_act
+-V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
+-V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
+-V{t#,#}           - Process waiting at t/t_timing_class.v:98
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:98
+-V{t#,#}         Suspending process waiting for @(posedge t::ClkClass.clk) at t/t_timing_class.v:98
 -V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
 -V{t#,#}         No triggers active
 -V{t#,#}+    Vt_timing_debug2___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug2___024root___eval_nba
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
--V{t#,#}         No suspended processes waiting for dynamic trigger evaluation
+-V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
+-V{t#,#}           - Process waiting at t/t_timing_class.v:98
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:98
+-V{t#,#}         Suspending process waiting for @(posedge t::ClkClass.clk) at t/t_timing_class.v:98
 -V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
 -V{t#,#}         No triggers active
 -V{t#,#}+    Vt_timing_debug2___024root___timing_commit
@@ -127,44 +158,169 @@
 -V{t#,#}+ Eval
 -V{t#,#}+    Vt_timing_debug2___024root___eval
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
--V{t#,#}         No suspended processes waiting for dynamic trigger evaluation
+-V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
+-V{t#,#}           - Process waiting at t/t_timing_class.v:98
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:98
+-V{t#,#}         Suspending process waiting for @(posedge t::ClkClass.clk) at t/t_timing_class.v:98
 -V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
 -V{t#,#}         'act' region trigger index 1 is active: @([true] __VdlySched.awaitingCurrentTime())
 -V{t#,#}+    Vt_timing_debug2___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug2___024root___timing_resume
 -V{t#,#}         Delayed processes:
--V{t#,#}             Awaiting time 20: Process waiting at t/t_timing_class.v:96
--V{t#,#}             Awaiting time 20: Process waiting at t/t_timing_class.v:97
--V{t#,#}             Awaiting time 30: Process waiting at t/t_timing_class.v:99
--V{t#,#}             Awaiting time 30: Process waiting at t/t_timing_class.v:109
--V{t#,#}             Awaiting time 40: Process waiting at t/t_timing_class.v:145
--V{t#,#}             Awaiting time 50: Process waiting at t/t_timing_class.v:219
--V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:224
--V{t#,#}             Awaiting time 80: Process waiting at t/t_timing_class.v:229
+-V{t#,#}             Awaiting time 10: Process waiting at t/t_timing_class.v:119
+-V{t#,#}             Awaiting time 10: Process waiting at t/t_timing_class.v:120
+-V{t#,#}             Awaiting time 20: Process waiting at t/t_timing_class.v:122
+-V{t#,#}             Awaiting time 30: Process waiting at t/t_timing_class.v:136
+-V{t#,#}             Awaiting time 10: Process waiting at t/t_timing_class.v:173
+-V{t#,#}             Awaiting time 50: Process waiting at t/t_timing_class.v:247
+-V{t#,#}             Awaiting time 40: Process waiting at t/t_timing_class.v:252
+-V{t#,#}             Awaiting time 80: Process waiting at t/t_timing_class.v:257
+-V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:274
+-V{t#,#}             Awaiting time 20: Process waiting at t/t_timing_class.v:131
 -V{t#,#}         Resuming delayed processes
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:229
--V{t#,#}+        Vt_timing_debug2_t__03a__03aForkDelayClass::new
--V{t#,#}+        Vt_timing_debug2_t__03a__03aForkDelayClass::_ctor_var_reset
--V{t#,#}             Process forked at t/t_timing_class.v:223 finished
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:224
--V{t#,#}+        Vt_timing_debug2_t__03a__03aEventClass::__VnoInFunc_wake
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:131
+-V{t#,#}             Process forked at t/t_timing_class.v:246 finished
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:274
+-V{t#,#}+        Vt_timing_debug2_t__03a__03aDelay10::__VnoInFunc_do_sth_else
+-V{t#,#}+        Vt_timing_debug2_t__03a__03aDelay20::__VnoInFunc_do_delay
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:174
+-V{t#,#}+        Vt_timing_debug2_t__03a__03aClkClass::__VnoInFunc_flip
 -V{t#,#}+    Vt_timing_debug2___024root___eval_act
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
--V{t#,#}         No suspended processes waiting for dynamic trigger evaluation
+-V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
+-V{t#,#}           - Process waiting at t/t_timing_class.v:98
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:98
+-V{t#,#}         Suspending process waiting for @(posedge t::ClkClass.clk) at t/t_timing_class.v:98
+-V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
+-V{t#,#}         No triggers active
+-V{t#,#}+    Vt_timing_debug2___024root___timing_commit
+-V{t#,#}+    Vt_timing_debug2___024root___eval_nba
+-V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
+-V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
+-V{t#,#}           - Process waiting at t/t_timing_class.v:98
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:98
+-V{t#,#}         Suspending process waiting for @(posedge t::ClkClass.clk) at t/t_timing_class.v:98
+-V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
+-V{t#,#}         No triggers active
+-V{t#,#}+    Vt_timing_debug2___024root___timing_commit
+-V{t#,#}End-of-eval cleanup
+-V{t#,#}+++++TOP Evaluate Vt_timing_debug2::eval_step
+-V{t#,#}+    Vt_timing_debug2___024root___eval_debug_assertions
+-V{t#,#}MTask0 starting
+-V{t#,#}+ Eval
+-V{t#,#}+    Vt_timing_debug2___024root___eval
+-V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
+-V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
+-V{t#,#}           - Process waiting at t/t_timing_class.v:98
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:98
+-V{t#,#}         Suspending process waiting for @(posedge t::ClkClass.clk) at t/t_timing_class.v:98
+-V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
+-V{t#,#}         'act' region trigger index 1 is active: @([true] __VdlySched.awaitingCurrentTime())
+-V{t#,#}+    Vt_timing_debug2___024root___timing_commit
+-V{t#,#}+    Vt_timing_debug2___024root___timing_resume
+-V{t#,#}         Delayed processes:
+-V{t#,#}             Awaiting time 15: Process waiting at t/t_timing_class.v:119
+-V{t#,#}             Awaiting time 20: Process waiting at t/t_timing_class.v:120
+-V{t#,#}             Awaiting time 30: Process waiting at t/t_timing_class.v:122
+-V{t#,#}             Awaiting time 20: Process waiting at t/t_timing_class.v:136
+-V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:173
+-V{t#,#}             Awaiting time 50: Process waiting at t/t_timing_class.v:247
+-V{t#,#}             Awaiting time 40: Process waiting at t/t_timing_class.v:252
+-V{t#,#}             Awaiting time 80: Process waiting at t/t_timing_class.v:257
+-V{t#,#}             Awaiting time 30: Process waiting at t/t_timing_class.v:131
+-V{t#,#}         Resuming delayed processes
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:131
+-V{t#,#}+        Vt_timing_debug2_t__03a__03aClkClass::__VnoInFunc_flip
+-V{t#,#}+    Vt_timing_debug2___024root___eval_act
+-V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
+-V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
+-V{t#,#}           - Process waiting at t/t_timing_class.v:98
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:98
+-V{t#,#}         Process waiting for @(posedge t::ClkClass.clk) at t/t_timing_class.v:98 awaiting resumption
+-V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
+-V{t#,#}         'act' region trigger index 2 is active: @([true] __VdynSched.evaluate())
+-V{t#,#}+    Vt_timing_debug2___024root___timing_commit
+-V{t#,#}+    Vt_timing_debug2___024root___timing_resume
+-V{t#,#}         Resuming processes:
+-V{t#,#}           - Process waiting at t/t_timing_class.v:98
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:98
+-V{t#,#}         Suspending process waiting for @(posedge t::ClkClass.clk) at t/t_timing_class.v:99
+-V{t#,#}+    Vt_timing_debug2___024root___eval_act
+-V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
+-V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
+-V{t#,#}           - Process waiting at t/t_timing_class.v:99
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:99
+-V{t#,#}         Suspending process waiting for @(posedge t::ClkClass.clk) at t/t_timing_class.v:99
+-V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
+-V{t#,#}         No triggers active
+-V{t#,#}+    Vt_timing_debug2___024root___timing_commit
+-V{t#,#}+    Vt_timing_debug2___024root___eval_nba
+-V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
+-V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
+-V{t#,#}           - Process waiting at t/t_timing_class.v:99
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:99
+-V{t#,#}         Suspending process waiting for @(posedge t::ClkClass.clk) at t/t_timing_class.v:99
+-V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
+-V{t#,#}         No triggers active
+-V{t#,#}+    Vt_timing_debug2___024root___timing_commit
+-V{t#,#}End-of-eval cleanup
+-V{t#,#}+++++TOP Evaluate Vt_timing_debug2::eval_step
+-V{t#,#}+    Vt_timing_debug2___024root___eval_debug_assertions
+-V{t#,#}MTask0 starting
+-V{t#,#}+ Eval
+-V{t#,#}+    Vt_timing_debug2___024root___eval
+-V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
+-V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
+-V{t#,#}           - Process waiting at t/t_timing_class.v:99
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:99
+-V{t#,#}         Suspending process waiting for @(posedge t::ClkClass.clk) at t/t_timing_class.v:99
+-V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
+-V{t#,#}         'act' region trigger index 1 is active: @([true] __VdlySched.awaitingCurrentTime())
+-V{t#,#}+    Vt_timing_debug2___024root___timing_commit
+-V{t#,#}+    Vt_timing_debug2___024root___timing_resume
+-V{t#,#}         Delayed processes:
+-V{t#,#}             Awaiting time 20: Process waiting at t/t_timing_class.v:119
+-V{t#,#}             Awaiting time 20: Process waiting at t/t_timing_class.v:120
+-V{t#,#}             Awaiting time 30: Process waiting at t/t_timing_class.v:122
+-V{t#,#}             Awaiting time 20: Process waiting at t/t_timing_class.v:136
+-V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:173
+-V{t#,#}             Awaiting time 50: Process waiting at t/t_timing_class.v:247
+-V{t#,#}             Awaiting time 40: Process waiting at t/t_timing_class.v:252
+-V{t#,#}             Awaiting time 80: Process waiting at t/t_timing_class.v:257
+-V{t#,#}             Awaiting time 30: Process waiting at t/t_timing_class.v:131
+-V{t#,#}         Resuming delayed processes
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:131
+-V{t#,#}+        Vt_timing_debug2_t__03a__03aForkDelayClass::new
+-V{t#,#}+        Vt_timing_debug2_t__03a__03aForkDelayClass::_ctor_var_reset
+-V{t#,#}             Process forked at t/t_timing_class.v:251 finished
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:257
+-V{t#,#}+        Vt_timing_debug2_t__03a__03aEventClass::__VnoInFunc_wake
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:252
+-V{t#,#}+        Vt_timing_debug2_t__03a__03aClkClass::__VnoInFunc_flip
+-V{t#,#}+    Vt_timing_debug2___024root___eval_act
+-V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
+-V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
+-V{t#,#}           - Process waiting at t/t_timing_class.v:99
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:99
+-V{t#,#}         Suspending process waiting for @(posedge t::ClkClass.clk) at t/t_timing_class.v:99
 -V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
 -V{t#,#}         'act' region trigger index 0 is active: @([event] t.ec.e)
 -V{t#,#}+    Vt_timing_debug2___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug2___024root___timing_resume
 -V{t#,#}         Ready processes waiting for @([event] t.ec.e):
--V{t#,#}           - Process waiting at t/t_timing_class.v:88
+-V{t#,#}           - Process waiting at t/t_timing_class.v:111
 -V{t#,#}         Resuming processes waiting for @([event] t.ec.e)
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:88
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:111
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aEventClass::__VnoInFunc_sleep
 -V{t#,#}         Suspending process waiting for @([event] t::EventClass.e) at t/t_timing_class.v:37
 -V{t#,#}+    Vt_timing_debug2___024root___eval_act
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
 -V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
+-V{t#,#}           - Process waiting at t/t_timing_class.v:99
+-V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
 -V{t#,#}           - Process waiting at t/t_timing_class.v:37
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:99
+-V{t#,#}         Suspending process waiting for @(posedge t::ClkClass.clk) at t/t_timing_class.v:99
 -V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:37
 -V{t#,#}         Process waiting for @([event] t::EventClass.e) at t/t_timing_class.v:37 awaiting the post update step
 -V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
@@ -179,7 +335,11 @@
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aEventClass::__VnoInFunc_inc_trig_count
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
 -V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
+-V{t#,#}           - Process waiting at t/t_timing_class.v:99
+-V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
 -V{t#,#}           - Process waiting at t/t_timing_class.v:37
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:99
+-V{t#,#}         Suspending process waiting for @(posedge t::ClkClass.clk) at t/t_timing_class.v:99
 -V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:37
 -V{t#,#}         Process waiting for @([event] t::EventClass.e) at t/t_timing_class.v:37 awaiting the post update step
 -V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
@@ -197,7 +357,11 @@
 -V{t#,#}+    Vt_timing_debug2___024root___eval
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
 -V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
+-V{t#,#}           - Process waiting at t/t_timing_class.v:99
+-V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
 -V{t#,#}           - Process waiting at t/t_timing_class.v:37
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:99
+-V{t#,#}         Suspending process waiting for @(posedge t::ClkClass.clk) at t/t_timing_class.v:99
 -V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:37
 -V{t#,#}         Process waiting for @([event] t::EventClass.e) at t/t_timing_class.v:37 awaiting the post update step
 -V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
@@ -209,22 +373,119 @@
 -V{t#,#}+    Vt_timing_debug2___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug2___024root___timing_resume
 -V{t#,#}         Delayed processes:
--V{t#,#}             Awaiting time 30: Process waiting at t/t_timing_class.v:96
--V{t#,#}             Awaiting time 30: Process waiting at t/t_timing_class.v:97
--V{t#,#}             Awaiting time 50: Process waiting at t/t_timing_class.v:99
--V{t#,#}             Awaiting time 80: Process waiting at t/t_timing_class.v:109
--V{t#,#}             Awaiting time 40: Process waiting at t/t_timing_class.v:145
--V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:219
+-V{t#,#}             Awaiting time 25: Process waiting at t/t_timing_class.v:119
+-V{t#,#}             Awaiting time 30: Process waiting at t/t_timing_class.v:120
+-V{t#,#}             Awaiting time 30: Process waiting at t/t_timing_class.v:122
+-V{t#,#}             Awaiting time 80: Process waiting at t/t_timing_class.v:136
+-V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:173
+-V{t#,#}             Awaiting time 50: Process waiting at t/t_timing_class.v:247
+-V{t#,#}             Awaiting time 40: Process waiting at t/t_timing_class.v:131
 -V{t#,#}         Resuming delayed processes
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:219
--V{t#,#}+        Vt_timing_debug2_t__03a__03aDelay20::__VnoInFunc_do_sth_else
--V{t#,#}+        Vt_timing_debug2_t__03a__03aDelay40::__VnoInFunc_do_delay
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:147
--V{t#,#}+        Vt_timing_debug2_t__03a__03aForkDelayClass::__VnoInFunc_do_delay
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:131
+-V{t#,#}+        Vt_timing_debug2_t__03a__03aClkClass::__VnoInFunc_flip
+-V{t#,#}+    Vt_timing_debug2___024root___eval_act
+-V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
+-V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
+-V{t#,#}           - Process waiting at t/t_timing_class.v:99
+-V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
+-V{t#,#}           - Process waiting at t/t_timing_class.v:37
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:99
+-V{t#,#}         Process waiting for @(posedge t::ClkClass.clk) at t/t_timing_class.v:99 awaiting resumption
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:37
+-V{t#,#}         Process waiting for @([event] t::EventClass.e) at t/t_timing_class.v:37 awaiting the post update step
+-V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
+-V{t#,#}         'act' region trigger index 2 is active: @([true] __VdynSched.evaluate())
+-V{t#,#}         Doing post updates for processes:
+-V{t#,#}           - Process waiting at t/t_timing_class.v:37
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:37
+-V{t#,#}         Suspending process waiting for @([event] t::EventClass.e) at t/t_timing_class.v:37
+-V{t#,#}+    Vt_timing_debug2___024root___timing_commit
+-V{t#,#}+    Vt_timing_debug2___024root___timing_resume
+-V{t#,#}         Resuming processes:
+-V{t#,#}           - Process waiting at t/t_timing_class.v:99
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:99
+-V{t#,#}         Suspending process waiting for @(posedge t::ClkClass.clk) at t/t_timing_class.v:100
 -V{t#,#}+    Vt_timing_debug2___024root___eval_act
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
 -V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
 -V{t#,#}           - Process waiting at t/t_timing_class.v:37
+-V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
+-V{t#,#}           - Process waiting at t/t_timing_class.v:100
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:37
+-V{t#,#}         Process waiting for @([event] t::EventClass.e) at t/t_timing_class.v:37 awaiting the post update step
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:100
+-V{t#,#}         Suspending process waiting for @(posedge t::ClkClass.clk) at t/t_timing_class.v:100
+-V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
+-V{t#,#}         No triggers active
+-V{t#,#}         Doing post updates for processes:
+-V{t#,#}           - Process waiting at t/t_timing_class.v:37
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:37
+-V{t#,#}         Suspending process waiting for @([event] t::EventClass.e) at t/t_timing_class.v:37
+-V{t#,#}+    Vt_timing_debug2___024root___timing_commit
+-V{t#,#}+    Vt_timing_debug2___024root___eval_nba
+-V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
+-V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
+-V{t#,#}           - Process waiting at t/t_timing_class.v:100
+-V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
+-V{t#,#}           - Process waiting at t/t_timing_class.v:37
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:100
+-V{t#,#}         Suspending process waiting for @(posedge t::ClkClass.clk) at t/t_timing_class.v:100
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:37
+-V{t#,#}         Process waiting for @([event] t::EventClass.e) at t/t_timing_class.v:37 awaiting the post update step
+-V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
+-V{t#,#}         No triggers active
+-V{t#,#}         Doing post updates for processes:
+-V{t#,#}           - Process waiting at t/t_timing_class.v:37
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:37
+-V{t#,#}         Suspending process waiting for @([event] t::EventClass.e) at t/t_timing_class.v:37
+-V{t#,#}+    Vt_timing_debug2___024root___timing_commit
+-V{t#,#}End-of-eval cleanup
+-V{t#,#}+++++TOP Evaluate Vt_timing_debug2::eval_step
+-V{t#,#}+    Vt_timing_debug2___024root___eval_debug_assertions
+-V{t#,#}MTask0 starting
+-V{t#,#}+ Eval
+-V{t#,#}+    Vt_timing_debug2___024root___eval
+-V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
+-V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
+-V{t#,#}           - Process waiting at t/t_timing_class.v:100
+-V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
+-V{t#,#}           - Process waiting at t/t_timing_class.v:37
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:100
+-V{t#,#}         Suspending process waiting for @(posedge t::ClkClass.clk) at t/t_timing_class.v:100
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:37
+-V{t#,#}         Process waiting for @([event] t::EventClass.e) at t/t_timing_class.v:37 awaiting the post update step
+-V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
+-V{t#,#}         'act' region trigger index 1 is active: @([true] __VdlySched.awaitingCurrentTime())
+-V{t#,#}         Doing post updates for processes:
+-V{t#,#}           - Process waiting at t/t_timing_class.v:37
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:37
+-V{t#,#}         Suspending process waiting for @([event] t::EventClass.e) at t/t_timing_class.v:37
+-V{t#,#}+    Vt_timing_debug2___024root___timing_commit
+-V{t#,#}+    Vt_timing_debug2___024root___timing_resume
+-V{t#,#}         Delayed processes:
+-V{t#,#}             Awaiting time 30: Process waiting at t/t_timing_class.v:119
+-V{t#,#}             Awaiting time 30: Process waiting at t/t_timing_class.v:120
+-V{t#,#}             Awaiting time 30: Process waiting at t/t_timing_class.v:122
+-V{t#,#}             Awaiting time 80: Process waiting at t/t_timing_class.v:136
+-V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:173
+-V{t#,#}             Awaiting time 50: Process waiting at t/t_timing_class.v:247
+-V{t#,#}             Awaiting time 40: Process waiting at t/t_timing_class.v:131
+-V{t#,#}         Resuming delayed processes
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:131
+-V{t#,#}+        Vt_timing_debug2_t__03a__03aDelay20::__VnoInFunc_do_sth_else
+-V{t#,#}+        Vt_timing_debug2_t__03a__03aDelay40::__VnoInFunc_do_delay
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:175
+-V{t#,#}+        Vt_timing_debug2_t__03a__03aClkClass::__VnoInFunc_flip
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:131
+-V{t#,#}+        Vt_timing_debug2_t__03a__03aForkDelayClass::__VnoInFunc_do_delay
+-V{t#,#}+    Vt_timing_debug2___024root___eval_act
+-V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
+-V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
+-V{t#,#}           - Process waiting at t/t_timing_class.v:100
+-V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
+-V{t#,#}           - Process waiting at t/t_timing_class.v:37
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:100
+-V{t#,#}         Suspending process waiting for @(posedge t::ClkClass.clk) at t/t_timing_class.v:100
 -V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:37
 -V{t#,#}         Process waiting for @([event] t::EventClass.e) at t/t_timing_class.v:37 awaiting the post update step
 -V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
@@ -237,7 +498,11 @@
 -V{t#,#}+    Vt_timing_debug2___024root___eval_nba
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
 -V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
+-V{t#,#}           - Process waiting at t/t_timing_class.v:100
+-V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
 -V{t#,#}           - Process waiting at t/t_timing_class.v:37
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:100
+-V{t#,#}         Suspending process waiting for @(posedge t::ClkClass.clk) at t/t_timing_class.v:100
 -V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:37
 -V{t#,#}         Process waiting for @([event] t::EventClass.e) at t/t_timing_class.v:37 awaiting the post update step
 -V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
@@ -255,7 +520,11 @@
 -V{t#,#}+    Vt_timing_debug2___024root___eval
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
 -V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
+-V{t#,#}           - Process waiting at t/t_timing_class.v:100
+-V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
 -V{t#,#}           - Process waiting at t/t_timing_class.v:37
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:100
+-V{t#,#}         Suspending process waiting for @(posedge t::ClkClass.clk) at t/t_timing_class.v:100
 -V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:37
 -V{t#,#}         Process waiting for @([event] t::EventClass.e) at t/t_timing_class.v:37 awaiting the post update step
 -V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
@@ -267,18 +536,115 @@
 -V{t#,#}+    Vt_timing_debug2___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug2___024root___timing_resume
 -V{t#,#}         Delayed processes:
--V{t#,#}             Awaiting time 40: Process waiting at t/t_timing_class.v:96
--V{t#,#}             Awaiting time 70: Process waiting at t/t_timing_class.v:97
--V{t#,#}             Awaiting time 50: Process waiting at t/t_timing_class.v:99
--V{t#,#}             Awaiting time 80: Process waiting at t/t_timing_class.v:109
--V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:145
--V{t#,#}             Awaiting time 70: Process waiting at t/t_timing_class.v:210
+-V{t#,#}             Awaiting time 35: Process waiting at t/t_timing_class.v:119
+-V{t#,#}             Awaiting time 70: Process waiting at t/t_timing_class.v:120
+-V{t#,#}             Awaiting time 40: Process waiting at t/t_timing_class.v:122
+-V{t#,#}             Awaiting time 80: Process waiting at t/t_timing_class.v:136
+-V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:173
+-V{t#,#}             Awaiting time 50: Process waiting at t/t_timing_class.v:247
+-V{t#,#}             Awaiting time 70: Process waiting at t/t_timing_class.v:238
 -V{t#,#}         Resuming delayed processes
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:210
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:238
+-V{t#,#}+        Vt_timing_debug2_t__03a__03aClkClass::__VnoInFunc_flip
+-V{t#,#}+    Vt_timing_debug2___024root___eval_act
+-V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
+-V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
+-V{t#,#}           - Process waiting at t/t_timing_class.v:100
+-V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
+-V{t#,#}           - Process waiting at t/t_timing_class.v:37
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:100
+-V{t#,#}         Process waiting for @(posedge t::ClkClass.clk) at t/t_timing_class.v:100 awaiting resumption
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:37
+-V{t#,#}         Process waiting for @([event] t::EventClass.e) at t/t_timing_class.v:37 awaiting the post update step
+-V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
+-V{t#,#}         'act' region trigger index 2 is active: @([true] __VdynSched.evaluate())
+-V{t#,#}         Doing post updates for processes:
+-V{t#,#}           - Process waiting at t/t_timing_class.v:37
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:37
+-V{t#,#}         Suspending process waiting for @([event] t::EventClass.e) at t/t_timing_class.v:37
+-V{t#,#}+    Vt_timing_debug2___024root___timing_commit
+-V{t#,#}+    Vt_timing_debug2___024root___timing_resume
+-V{t#,#}         Resuming processes:
+-V{t#,#}           - Process waiting at t/t_timing_class.v:100
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:100
+-V{t#,#}         Suspending process waiting for @(posedge t::ClkClass.clk) at t/t_timing_class.v:101
 -V{t#,#}+    Vt_timing_debug2___024root___eval_act
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
 -V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
 -V{t#,#}           - Process waiting at t/t_timing_class.v:37
+-V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
+-V{t#,#}           - Process waiting at t/t_timing_class.v:101
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:37
+-V{t#,#}         Process waiting for @([event] t::EventClass.e) at t/t_timing_class.v:37 awaiting the post update step
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:101
+-V{t#,#}         Suspending process waiting for @(posedge t::ClkClass.clk) at t/t_timing_class.v:101
+-V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
+-V{t#,#}         No triggers active
+-V{t#,#}         Doing post updates for processes:
+-V{t#,#}           - Process waiting at t/t_timing_class.v:37
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:37
+-V{t#,#}         Suspending process waiting for @([event] t::EventClass.e) at t/t_timing_class.v:37
+-V{t#,#}+    Vt_timing_debug2___024root___timing_commit
+-V{t#,#}+    Vt_timing_debug2___024root___eval_nba
+-V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
+-V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
+-V{t#,#}           - Process waiting at t/t_timing_class.v:101
+-V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
+-V{t#,#}           - Process waiting at t/t_timing_class.v:37
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:101
+-V{t#,#}         Suspending process waiting for @(posedge t::ClkClass.clk) at t/t_timing_class.v:101
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:37
+-V{t#,#}         Process waiting for @([event] t::EventClass.e) at t/t_timing_class.v:37 awaiting the post update step
+-V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
+-V{t#,#}         No triggers active
+-V{t#,#}         Doing post updates for processes:
+-V{t#,#}           - Process waiting at t/t_timing_class.v:37
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:37
+-V{t#,#}         Suspending process waiting for @([event] t::EventClass.e) at t/t_timing_class.v:37
+-V{t#,#}+    Vt_timing_debug2___024root___timing_commit
+-V{t#,#}End-of-eval cleanup
+-V{t#,#}+++++TOP Evaluate Vt_timing_debug2::eval_step
+-V{t#,#}+    Vt_timing_debug2___024root___eval_debug_assertions
+-V{t#,#}MTask0 starting
+-V{t#,#}+ Eval
+-V{t#,#}+    Vt_timing_debug2___024root___eval
+-V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
+-V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
+-V{t#,#}           - Process waiting at t/t_timing_class.v:101
+-V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
+-V{t#,#}           - Process waiting at t/t_timing_class.v:37
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:101
+-V{t#,#}         Suspending process waiting for @(posedge t::ClkClass.clk) at t/t_timing_class.v:101
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:37
+-V{t#,#}         Process waiting for @([event] t::EventClass.e) at t/t_timing_class.v:37 awaiting the post update step
+-V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
+-V{t#,#}         'act' region trigger index 1 is active: @([true] __VdlySched.awaitingCurrentTime())
+-V{t#,#}         Doing post updates for processes:
+-V{t#,#}           - Process waiting at t/t_timing_class.v:37
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:37
+-V{t#,#}         Suspending process waiting for @([event] t::EventClass.e) at t/t_timing_class.v:37
+-V{t#,#}+    Vt_timing_debug2___024root___timing_commit
+-V{t#,#}+    Vt_timing_debug2___024root___timing_resume
+-V{t#,#}         Delayed processes:
+-V{t#,#}             Awaiting time 40: Process waiting at t/t_timing_class.v:119
+-V{t#,#}             Awaiting time 70: Process waiting at t/t_timing_class.v:120
+-V{t#,#}             Awaiting time 40: Process waiting at t/t_timing_class.v:122
+-V{t#,#}             Awaiting time 80: Process waiting at t/t_timing_class.v:136
+-V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:173
+-V{t#,#}             Awaiting time 70: Process waiting at t/t_timing_class.v:247
+-V{t#,#}             Awaiting time 50: Process waiting at t/t_timing_class.v:131
+-V{t#,#}         Resuming delayed processes
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:131
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:247
+-V{t#,#}+        Vt_timing_debug2_t__03a__03aClkClass::__VnoInFunc_flip
+-V{t#,#}+    Vt_timing_debug2___024root___eval_act
+-V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
+-V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
+-V{t#,#}           - Process waiting at t/t_timing_class.v:101
+-V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
+-V{t#,#}           - Process waiting at t/t_timing_class.v:37
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:101
+-V{t#,#}         Suspending process waiting for @(posedge t::ClkClass.clk) at t/t_timing_class.v:101
 -V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:37
 -V{t#,#}         Process waiting for @([event] t::EventClass.e) at t/t_timing_class.v:37 awaiting the post update step
 -V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
@@ -293,7 +659,10 @@
 -V{t#,#}         Resuming processes waiting for @([event] t.ec.e)
 -V{t#,#}+    Vt_timing_debug2___024root___eval_act
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
--V{t#,#}         No suspended processes waiting for dynamic trigger evaluation
+-V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
+-V{t#,#}           - Process waiting at t/t_timing_class.v:101
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:101
+-V{t#,#}         Suspending process waiting for @(posedge t::ClkClass.clk) at t/t_timing_class.v:101
 -V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
 -V{t#,#}         'act' region trigger index 2 is active: @([true] __VdynSched.evaluate())
 -V{t#,#}+    Vt_timing_debug2___024root___timing_commit
@@ -307,7 +676,11 @@
 -V{t#,#}+    Vt_timing_debug2___024root___eval_act
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
 -V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
+-V{t#,#}           - Process waiting at t/t_timing_class.v:101
+-V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
 -V{t#,#}           - Process waiting at t/t_timing_class.v:58
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:101
+-V{t#,#}         Suspending process waiting for @(posedge t::ClkClass.clk) at t/t_timing_class.v:101
 -V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:58
 -V{t#,#}         Suspending process waiting for @([true] ((32'sh4 == t::WaitClass.a) & (32'sh10 < t::WaitClass.b))) at t/t_timing_class.v:58
 -V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
@@ -318,7 +691,11 @@
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aEventClass::__VnoInFunc_inc_trig_count
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
 -V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
+-V{t#,#}           - Process waiting at t/t_timing_class.v:101
+-V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
 -V{t#,#}           - Process waiting at t/t_timing_class.v:58
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:101
+-V{t#,#}         Suspending process waiting for @(posedge t::ClkClass.clk) at t/t_timing_class.v:101
 -V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:58
 -V{t#,#}         Suspending process waiting for @([true] ((32'sh4 == t::WaitClass.a) & (32'sh10 < t::WaitClass.b))) at t/t_timing_class.v:58
 -V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
@@ -332,7 +709,11 @@
 -V{t#,#}+    Vt_timing_debug2___024root___eval
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
 -V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
+-V{t#,#}           - Process waiting at t/t_timing_class.v:101
+-V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
 -V{t#,#}           - Process waiting at t/t_timing_class.v:58
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:101
+-V{t#,#}         Suspending process waiting for @(posedge t::ClkClass.clk) at t/t_timing_class.v:101
 -V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:58
 -V{t#,#}         Suspending process waiting for @([true] ((32'sh4 == t::WaitClass.a) & (32'sh10 < t::WaitClass.b))) at t/t_timing_class.v:58
 -V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
@@ -340,13 +721,32 @@
 -V{t#,#}+    Vt_timing_debug2___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug2___024root___timing_resume
 -V{t#,#}         Delayed processes:
--V{t#,#}             Awaiting time 50: Process waiting at t/t_timing_class.v:96
--V{t#,#}             Awaiting time 70: Process waiting at t/t_timing_class.v:97
--V{t#,#}             Awaiting time 70: Process waiting at t/t_timing_class.v:99
--V{t#,#}             Awaiting time 80: Process waiting at t/t_timing_class.v:109
--V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:145
+-V{t#,#}             Awaiting time 45: Process waiting at t/t_timing_class.v:119
+-V{t#,#}             Awaiting time 70: Process waiting at t/t_timing_class.v:120
+-V{t#,#}             Awaiting time 50: Process waiting at t/t_timing_class.v:122
+-V{t#,#}             Awaiting time 80: Process waiting at t/t_timing_class.v:136
+-V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:173
+-V{t#,#}             Awaiting time 70: Process waiting at t/t_timing_class.v:131
 -V{t#,#}         Resuming delayed processes
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:145
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:131
+-V{t#,#}+        Vt_timing_debug2_t__03a__03aClkClass::__VnoInFunc_flip
+-V{t#,#}+    Vt_timing_debug2___024root___eval_act
+-V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
+-V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
+-V{t#,#}           - Process waiting at t/t_timing_class.v:101
+-V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
+-V{t#,#}           - Process waiting at t/t_timing_class.v:58
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:101
+-V{t#,#}         Process waiting for @(posedge t::ClkClass.clk) at t/t_timing_class.v:101 awaiting resumption
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:58
+-V{t#,#}         Suspending process waiting for @([true] ((32'sh4 == t::WaitClass.a) & (32'sh10 < t::WaitClass.b))) at t/t_timing_class.v:58
+-V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
+-V{t#,#}         'act' region trigger index 2 is active: @([true] __VdynSched.evaluate())
+-V{t#,#}+    Vt_timing_debug2___024root___timing_commit
+-V{t#,#}+    Vt_timing_debug2___024root___timing_resume
+-V{t#,#}         Resuming processes:
+-V{t#,#}           - Process waiting at t/t_timing_class.v:101
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:101
 -V{t#,#}+    Vt_timing_debug2___024root___eval_act
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
 -V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
@@ -381,13 +781,103 @@
 -V{t#,#}+    Vt_timing_debug2___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug2___024root___timing_resume
 -V{t#,#}         Delayed processes:
--V{t#,#}             Awaiting time 60: Process waiting at t/t_timing_class.v:96
--V{t#,#}             Awaiting time 70: Process waiting at t/t_timing_class.v:97
--V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:99
--V{t#,#}             Awaiting time 80: Process waiting at t/t_timing_class.v:109
--V{t#,#}             Awaiting time 70: Process waiting at t/t_timing_class.v:100
+-V{t#,#}             Awaiting time 50: Process waiting at t/t_timing_class.v:119
+-V{t#,#}             Awaiting time 70: Process waiting at t/t_timing_class.v:120
+-V{t#,#}             Awaiting time 50: Process waiting at t/t_timing_class.v:122
+-V{t#,#}             Awaiting time 80: Process waiting at t/t_timing_class.v:136
+-V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:173
+-V{t#,#}             Awaiting time 70: Process waiting at t/t_timing_class.v:131
 -V{t#,#}         Resuming delayed processes
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:100
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:131
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:123
+-V{t#,#}+        Vt_timing_debug2_t__03a__03aClkClass::__VnoInFunc_flip
+-V{t#,#}+    Vt_timing_debug2___024root___eval_act
+-V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
+-V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
+-V{t#,#}           - Process waiting at t/t_timing_class.v:58
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:58
+-V{t#,#}         Suspending process waiting for @([true] ((32'sh4 == t::WaitClass.a) & (32'sh10 < t::WaitClass.b))) at t/t_timing_class.v:58
+-V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
+-V{t#,#}         No triggers active
+-V{t#,#}+    Vt_timing_debug2___024root___timing_commit
+-V{t#,#}+    Vt_timing_debug2___024root___eval_nba
+-V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
+-V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
+-V{t#,#}           - Process waiting at t/t_timing_class.v:58
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:58
+-V{t#,#}         Suspending process waiting for @([true] ((32'sh4 == t::WaitClass.a) & (32'sh10 < t::WaitClass.b))) at t/t_timing_class.v:58
+-V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
+-V{t#,#}         No triggers active
+-V{t#,#}+    Vt_timing_debug2___024root___timing_commit
+-V{t#,#}End-of-eval cleanup
+-V{t#,#}+++++TOP Evaluate Vt_timing_debug2::eval_step
+-V{t#,#}+    Vt_timing_debug2___024root___eval_debug_assertions
+-V{t#,#}MTask0 starting
+-V{t#,#}+ Eval
+-V{t#,#}+    Vt_timing_debug2___024root___eval
+-V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
+-V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
+-V{t#,#}           - Process waiting at t/t_timing_class.v:58
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:58
+-V{t#,#}         Suspending process waiting for @([true] ((32'sh4 == t::WaitClass.a) & (32'sh10 < t::WaitClass.b))) at t/t_timing_class.v:58
+-V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
+-V{t#,#}         'act' region trigger index 1 is active: @([true] __VdlySched.awaitingCurrentTime())
+-V{t#,#}+    Vt_timing_debug2___024root___timing_commit
+-V{t#,#}+    Vt_timing_debug2___024root___timing_resume
+-V{t#,#}         Delayed processes:
+-V{t#,#}             Awaiting time 55: Process waiting at t/t_timing_class.v:119
+-V{t#,#}             Awaiting time 70: Process waiting at t/t_timing_class.v:120
+-V{t#,#}             Awaiting time 60: Process waiting at t/t_timing_class.v:122
+-V{t#,#}             Awaiting time 80: Process waiting at t/t_timing_class.v:136
+-V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:173
+-V{t#,#}             Awaiting time 70: Process waiting at t/t_timing_class.v:131
+-V{t#,#}         Resuming delayed processes
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:131
+-V{t#,#}+        Vt_timing_debug2_t__03a__03aClkClass::__VnoInFunc_flip
+-V{t#,#}+    Vt_timing_debug2___024root___eval_act
+-V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
+-V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
+-V{t#,#}           - Process waiting at t/t_timing_class.v:58
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:58
+-V{t#,#}         Suspending process waiting for @([true] ((32'sh4 == t::WaitClass.a) & (32'sh10 < t::WaitClass.b))) at t/t_timing_class.v:58
+-V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
+-V{t#,#}         No triggers active
+-V{t#,#}+    Vt_timing_debug2___024root___timing_commit
+-V{t#,#}+    Vt_timing_debug2___024root___eval_nba
+-V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
+-V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
+-V{t#,#}           - Process waiting at t/t_timing_class.v:58
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:58
+-V{t#,#}         Suspending process waiting for @([true] ((32'sh4 == t::WaitClass.a) & (32'sh10 < t::WaitClass.b))) at t/t_timing_class.v:58
+-V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
+-V{t#,#}         No triggers active
+-V{t#,#}+    Vt_timing_debug2___024root___timing_commit
+-V{t#,#}End-of-eval cleanup
+-V{t#,#}+++++TOP Evaluate Vt_timing_debug2::eval_step
+-V{t#,#}+    Vt_timing_debug2___024root___eval_debug_assertions
+-V{t#,#}MTask0 starting
+-V{t#,#}+ Eval
+-V{t#,#}+    Vt_timing_debug2___024root___eval
+-V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
+-V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
+-V{t#,#}           - Process waiting at t/t_timing_class.v:58
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:58
+-V{t#,#}         Suspending process waiting for @([true] ((32'sh4 == t::WaitClass.a) & (32'sh10 < t::WaitClass.b))) at t/t_timing_class.v:58
+-V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
+-V{t#,#}         'act' region trigger index 1 is active: @([true] __VdlySched.awaitingCurrentTime())
+-V{t#,#}+    Vt_timing_debug2___024root___timing_commit
+-V{t#,#}+    Vt_timing_debug2___024root___timing_resume
+-V{t#,#}         Delayed processes:
+-V{t#,#}             Awaiting time 60: Process waiting at t/t_timing_class.v:119
+-V{t#,#}             Awaiting time 70: Process waiting at t/t_timing_class.v:120
+-V{t#,#}             Awaiting time 60: Process waiting at t/t_timing_class.v:122
+-V{t#,#}             Awaiting time 80: Process waiting at t/t_timing_class.v:136
+-V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:173
+-V{t#,#}             Awaiting time 70: Process waiting at t/t_timing_class.v:131
+-V{t#,#}         Resuming delayed processes
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:131
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:173
+-V{t#,#}+        Vt_timing_debug2_t__03a__03aClkClass::__VnoInFunc_flip
 -V{t#,#}+    Vt_timing_debug2___024root___eval_act
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
 -V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
@@ -440,25 +930,71 @@
 -V{t#,#}+    Vt_timing_debug2___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug2___024root___timing_resume
 -V{t#,#}         Delayed processes:
--V{t#,#}             Awaiting time 70: Process waiting at t/t_timing_class.v:96
--V{t#,#}             Awaiting time 70: Process waiting at t/t_timing_class.v:97
--V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:99
--V{t#,#}             Awaiting time 80: Process waiting at t/t_timing_class.v:109
--V{t#,#}             Awaiting time 70: Process waiting at t/t_timing_class.v:76
+-V{t#,#}             Awaiting time 65: Process waiting at t/t_timing_class.v:119
+-V{t#,#}             Awaiting time 70: Process waiting at t/t_timing_class.v:120
+-V{t#,#}             Awaiting time 70: Process waiting at t/t_timing_class.v:122
+-V{t#,#}             Awaiting time 80: Process waiting at t/t_timing_class.v:136
+-V{t#,#}             Awaiting time 70: Process waiting at t/t_timing_class.v:131
+-V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:76
 -V{t#,#}         Resuming delayed processes
 -V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:76
--V{t#,#}             Process forked at t/t_timing_class.v:228 finished
+-V{t#,#}+        Vt_timing_debug2_t__03a__03aClkClass::__VnoInFunc_flip
+-V{t#,#}+    Vt_timing_debug2___024root___eval_act
+-V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
+-V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
+-V{t#,#}           - Process waiting at t/t_timing_class.v:75
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:75
+-V{t#,#}         Suspending process waiting for @([true] ((32'sh2a == t::LocalWaitClass.a) | (32'sh64 != t::LocalWaitClass.b))) at t/t_timing_class.v:75
+-V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
+-V{t#,#}         No triggers active
+-V{t#,#}+    Vt_timing_debug2___024root___timing_commit
+-V{t#,#}+    Vt_timing_debug2___024root___eval_nba
+-V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
+-V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
+-V{t#,#}           - Process waiting at t/t_timing_class.v:75
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:75
+-V{t#,#}         Suspending process waiting for @([true] ((32'sh2a == t::LocalWaitClass.a) | (32'sh64 != t::LocalWaitClass.b))) at t/t_timing_class.v:75
+-V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
+-V{t#,#}         No triggers active
+-V{t#,#}+    Vt_timing_debug2___024root___timing_commit
+-V{t#,#}End-of-eval cleanup
+-V{t#,#}+++++TOP Evaluate Vt_timing_debug2::eval_step
+-V{t#,#}+    Vt_timing_debug2___024root___eval_debug_assertions
+-V{t#,#}MTask0 starting
+-V{t#,#}+ Eval
+-V{t#,#}+    Vt_timing_debug2___024root___eval
+-V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
+-V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
+-V{t#,#}           - Process waiting at t/t_timing_class.v:75
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:75
+-V{t#,#}         Suspending process waiting for @([true] ((32'sh2a == t::LocalWaitClass.a) | (32'sh64 != t::LocalWaitClass.b))) at t/t_timing_class.v:75
+-V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
+-V{t#,#}         'act' region trigger index 1 is active: @([true] __VdlySched.awaitingCurrentTime())
+-V{t#,#}+    Vt_timing_debug2___024root___timing_commit
+-V{t#,#}+    Vt_timing_debug2___024root___timing_resume
+-V{t#,#}         Delayed processes:
+-V{t#,#}             Awaiting time 70: Process waiting at t/t_timing_class.v:119
+-V{t#,#}             Awaiting time 70: Process waiting at t/t_timing_class.v:120
+-V{t#,#}             Awaiting time 70: Process waiting at t/t_timing_class.v:122
+-V{t#,#}             Awaiting time 80: Process waiting at t/t_timing_class.v:136
+-V{t#,#}             Awaiting time 70: Process waiting at t/t_timing_class.v:131
+-V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:131
+-V{t#,#}         Resuming delayed processes
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:131
+-V{t#,#}             Process forked at t/t_timing_class.v:76 finished
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:131
+-V{t#,#}+        Vt_timing_debug2_t__03a__03aClkClass::__VnoInFunc_flip
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:131
+-V{t#,#}             Process forked at t/t_timing_class.v:256 finished
 -V{t#,#}             Resuming: Process waiting at (null):0
--V{t#,#}             Process forked at t/t_timing_class.v:222 finished
+-V{t#,#}             Process forked at t/t_timing_class.v:250 finished
 -V{t#,#}             Resuming: Process waiting at (null):0
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:109
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:136
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aDelay40::__VnoInFunc_do_sth_else
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aNoDelay::__VnoInFunc_do_delay
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aNoDelay::__VnoInFunc_do_sth_else
 -V{t#,#}+      Vt_timing_debug2_t____Vfork_1__0
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aAssignDelayClass::__VnoInFunc_do_assign
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:162
--V{t#,#}             Process forked at t/t_timing_class.v:76 finished
 -V{t#,#}+    Vt_timing_debug2___024root___eval_act
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
 -V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
@@ -501,12 +1037,15 @@
 -V{t#,#}+    Vt_timing_debug2___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug2___024root___timing_resume
 -V{t#,#}         Delayed processes:
--V{t#,#}             Awaiting time 75: Process waiting at t/t_timing_class.v:96
--V{t#,#}             Awaiting time 80: Process waiting at t/t_timing_class.v:97
--V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:99
--V{t#,#}             Awaiting time 80: Process waiting at t/t_timing_class.v:196
+-V{t#,#}             Awaiting time 75: Process waiting at t/t_timing_class.v:119
+-V{t#,#}             Awaiting time 75: Process waiting at t/t_timing_class.v:120
+-V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:122
+-V{t#,#}             Awaiting time 80: Process waiting at t/t_timing_class.v:224
+-V{t#,#}             Awaiting time 80: Process waiting at t/t_timing_class.v:190
 -V{t#,#}         Resuming delayed processes
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:196
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:190
+-V{t#,#}+        Vt_timing_debug2_t__03a__03aClkClass::__VnoInFunc_flip
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:131
 -V{t#,#}+    Vt_timing_debug2___024root___eval_act
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
 -V{t#,#}         No suspended processes waiting for dynamic trigger evaluation
@@ -532,14 +1071,17 @@
 -V{t#,#}+    Vt_timing_debug2___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug2___024root___timing_resume
 -V{t#,#}         Delayed processes:
--V{t#,#}             Awaiting time 80: Process waiting at t/t_timing_class.v:96
--V{t#,#}             Awaiting time 80: Process waiting at t/t_timing_class.v:97
--V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:99
+-V{t#,#}             Awaiting time 80: Process waiting at t/t_timing_class.v:119
+-V{t#,#}             Awaiting time 80: Process waiting at t/t_timing_class.v:120
+-V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:122
+-V{t#,#}             Awaiting time 80: Process waiting at t/t_timing_class.v:224
 -V{t#,#}         Resuming delayed processes
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:99
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:97
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:224
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:122
 -V{t#,#}+      Vt_timing_debug2_t____Vfork_2__0
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aAssignDelayClass::__VnoInFunc_do_assign
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:230
+-V{t#,#}+        Vt_timing_debug2_t__03a__03aClkClass::__VnoInFunc_flip
 -V{t#,#}+    Vt_timing_debug2___024root___eval_act
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
 -V{t#,#}         No suspended processes waiting for dynamic trigger evaluation
@@ -565,11 +1107,14 @@
 -V{t#,#}+    Vt_timing_debug2___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug2___024root___timing_resume
 -V{t#,#}         Delayed processes:
--V{t#,#}             Awaiting time 85: Process waiting at t/t_timing_class.v:96
--V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:162
--V{t#,#}             Awaiting time 90: Process waiting at t/t_timing_class.v:202
+-V{t#,#}             Awaiting time 85: Process waiting at t/t_timing_class.v:119
+-V{t#,#}             Awaiting time 85: Process waiting at t/t_timing_class.v:120
+-V{t#,#}             Awaiting time 90: Process waiting at t/t_timing_class.v:190
+-V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:131
 -V{t#,#}         Resuming delayed processes
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:202
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:131
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:231
+-V{t#,#}+        Vt_timing_debug2_t__03a__03aClkClass::__VnoInFunc_flip
 -V{t#,#}+    Vt_timing_debug2___024root___eval_act
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
 -V{t#,#}         No suspended processes waiting for dynamic trigger evaluation
@@ -595,11 +1140,14 @@
 -V{t#,#}+    Vt_timing_debug2___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug2___024root___timing_resume
 -V{t#,#}         Delayed processes:
--V{t#,#}             Awaiting time 90: Process waiting at t/t_timing_class.v:96
--V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:162
--V{t#,#}             Awaiting time 100: Process waiting at t/t_timing_class.v:203
+-V{t#,#}             Awaiting time 90: Process waiting at t/t_timing_class.v:119
+-V{t#,#}             Awaiting time 90: Process waiting at t/t_timing_class.v:120
+-V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:190
+-V{t#,#}             Awaiting time 100: Process waiting at t/t_timing_class.v:131
 -V{t#,#}         Resuming delayed processes
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:203
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:131
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:190
+-V{t#,#}+        Vt_timing_debug2_t__03a__03aClkClass::__VnoInFunc_flip
 -V{t#,#}+    Vt_timing_debug2___024root___eval_act
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
 -V{t#,#}         No suspended processes waiting for dynamic trigger evaluation
@@ -626,11 +1174,45 @@
 -V{t#,#}+    Vt_timing_debug2___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug2___024root___timing_resume
 -V{t#,#}         Delayed processes:
--V{t#,#}             Awaiting time 100: Process waiting at t/t_timing_class.v:96
--V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:162
+-V{t#,#}             Awaiting time 95: Process waiting at t/t_timing_class.v:119
+-V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:120
+-V{t#,#}             Awaiting time 100: Process waiting at t/t_timing_class.v:131
 -V{t#,#}         Resuming delayed processes
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:162
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:131
+-V{t#,#}+        Vt_timing_debug2_t__03a__03aClkClass::__VnoInFunc_flip
+-V{t#,#}+    Vt_timing_debug2___024root___eval_act
+-V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
+-V{t#,#}         No suspended processes waiting for dynamic trigger evaluation
+-V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
+-V{t#,#}         No triggers active
+-V{t#,#}+    Vt_timing_debug2___024root___timing_commit
+-V{t#,#}+    Vt_timing_debug2___024root___eval_nba
+-V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
+-V{t#,#}         No suspended processes waiting for dynamic trigger evaluation
+-V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
+-V{t#,#}         No triggers active
+-V{t#,#}+    Vt_timing_debug2___024root___timing_commit
+-V{t#,#}End-of-eval cleanup
+-V{t#,#}+++++TOP Evaluate Vt_timing_debug2::eval_step
+-V{t#,#}+    Vt_timing_debug2___024root___eval_debug_assertions
+-V{t#,#}MTask0 starting
+-V{t#,#}+ Eval
+-V{t#,#}+    Vt_timing_debug2___024root___eval
+-V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
+-V{t#,#}         No suspended processes waiting for dynamic trigger evaluation
+-V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
+-V{t#,#}         'act' region trigger index 1 is active: @([true] __VdlySched.awaitingCurrentTime())
+-V{t#,#}+    Vt_timing_debug2___024root___timing_commit
+-V{t#,#}+    Vt_timing_debug2___024root___timing_resume
+-V{t#,#}         Delayed processes:
+-V{t#,#}             Awaiting time 100: Process waiting at t/t_timing_class.v:119
+-V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:120
+-V{t#,#}             Awaiting time 100: Process waiting at t/t_timing_class.v:131
+-V{t#,#}         Resuming delayed processes
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:131
 *-* All Finished *-*
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:120
+-V{t#,#}+        Vt_timing_debug2_t__03a__03aClkClass::__VnoInFunc_flip
 -V{t#,#}+    Vt_timing_debug2___024root___eval_act
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
 -V{t#,#}         No suspended processes waiting for dynamic trigger evaluation
@@ -653,6 +1235,7 @@
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aDelayClass::~
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aNoDelay::~
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aDelayClass::~
+-V{t#,#}+        Vt_timing_debug2_t__03a__03aClkClass::~
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aLocalWaitClass::~
 -V{t#,#}+          Vt_timing_debug2___024unit__03a__03aBaseClass::~
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aWaitClass::~


### PR DESCRIPTION
Multiple edge timing controls in class methods would cause compilation errors on the generated C++ code. This is because the `SenExprBuilder` used for these would get recreated per timing control, resulting in duplicate variable names. The fix is to have a single `SenExprBuilder` per scope.

Fixes #4318.