### PR TITLE
Fix/Improve propagation of process

### DIFF
--- a/src/V3EmitCFunc.cpp
+++ b/src/V3EmitCFunc.cpp
@@ -419,10 +419,10 @@ void EmitCFunc::emitCCallArgs(const AstNodeCCall* nodep, const string& selfPoint
     }
     if (nodep->funcp()->needProcess()) {
         if (comma) puts(", ");
-        if (VN_IS(nodep->backp(), CAwait)) {
-            puts("std::make_shared<VlProcess>()");
-        } else {
+        if (VN_IS(nodep->backp(), CAwait) || !nodep->funcp()->isCoroutine()) {
             puts("vlProcess");
+        } else {
+            puts("std::make_shared<VlProcess>()");
         }
         comma = true;
     }

--- a/src/V3EmitCFunc.cpp
+++ b/src/V3EmitCFunc.cpp
@@ -420,9 +420,9 @@ void EmitCFunc::emitCCallArgs(const AstNodeCCall* nodep, const string& selfPoint
     if (nodep->funcp()->needProcess()) {
         if (comma) puts(", ");
         if (VN_IS(nodep->backp(), CAwait)) {
-            puts("vlProcess");
-        } else {
             puts("std::make_shared<VlProcess>()");
+        } else {
+            puts("vlProcess");
         }
         comma = true;
     }

--- a/src/V3EmitCFunc.h
+++ b/src/V3EmitCFunc.h
@@ -151,9 +151,6 @@ protected:
     bool m_instantiatesOwnProcess = false;
 
     bool constructorNeedsProcess(AstClass* classp) {
-        // This function is called only once per emitted constructor code, so this is fine.
-        classp->repairCache();
-
         const AstNode* const newp = classp->findMember("new");
         if (!newp) return false;
         const AstCFunc* const ctorp = VN_CAST(newp, CFunc);

--- a/src/V3EmitCFunc.h
+++ b/src/V3EmitCFunc.h
@@ -269,7 +269,6 @@ public:
         puts(nodep->nameProtect() + "\\n\"); );\n");
 
         // Instantiate a process class if it's going to be needed somewhere later
-        bool needsProcessDef = false;
         nodep->forall([&](const AstNodeCCall* ccallp) -> bool {
             if (ccallp->funcp()->needProcess() && !VN_IS(ccallp->backp(), CAwait)) {
                 if (!nodep->needProcess() && !m_instantiatesOwnProcess) {

--- a/src/V3EmitCFunc.h
+++ b/src/V3EmitCFunc.h
@@ -150,7 +150,7 @@ protected:
     const AstCFunc* m_cfuncp = nullptr;  // Current function being emitted
     bool m_instantiatesOwnProcess = false;
 
-    bool constructorNeedsProcess(AstClass* classp) {
+    bool constructorNeedsProcess(const AstClass* const classp) {
         const AstNode* const newp = classp->findMember("new");
         if (!newp) return false;
         const AstCFunc* const ctorp = VN_CAST(newp, CFunc);
@@ -159,10 +159,9 @@ protected:
         return ctorp->needProcess();
     }
 
-    bool constructorNeedsProcess(AstNodeDType* dtypep) {
-        if (AstClassRefDType* crefdtypep = VN_CAST(dtypep, ClassRefDType)) {
+    bool constructorNeedsProcess(const AstNodeDType* const dtypep) {
+        if (const AstClassRefDType* const crefdtypep = VN_CAST(dtypep, ClassRefDType))
             return constructorNeedsProcess(crefdtypep->classp());
-        }
         return false;
     }
 
@@ -230,7 +229,7 @@ public:
         }
     }
     template <typename T>
-    string optionalProcArg(T* nodep) {
+    string optionalProcArg(const T* const nodep) {
         return (nodep && constructorNeedsProcess(nodep)) ? "vlProcess, " : "";
     }
 
@@ -254,7 +253,7 @@ public:
         if (!nodep->baseCtors().empty()) {
             puts(": ");
             puts(nodep->baseCtors());
-            AstClass* classp = VN_CAST(nodep->scopep()->modp(), Class);
+            const AstClass* const classp = VN_CAST(nodep->scopep()->modp(), Class);
             bool baseCtorCall = false;
             // Find call to super.new to get the arguments
             for (AstNode* stmtp = nodep->stmtsp(); stmtp; stmtp = stmtp->nextp()) {

--- a/src/V3EmitCFunc.h
+++ b/src/V3EmitCFunc.h
@@ -150,9 +150,9 @@ protected:
     const AstCFunc* m_cfuncp = nullptr;  // Current function being emitted
     bool m_instantiatesOwnProcess = false;
 
-    bool constructorNeedsProcess(AstClass* classp) {
-        AstNode* newp = classp->findMember("new");
-        AstCFunc* ctor = newp ? VN_CAST(newp, CFunc) : nullptr;
+    bool constructorNeedsProcess(const AstClass* classp) {
+        const AstNode* newp = classp->findMember("new");
+        const AstCFunc* ctor = newp ? VN_CAST(newp, CFunc) : nullptr;
         UASSERT_OBJ(ctor ? ctor->isConstructor() : true, ctor, "`new` is not a constructor!");
         return ctor ? ctor->needProcess() : false;
     }

--- a/src/V3EmitCFunc.h
+++ b/src/V3EmitCFunc.h
@@ -297,7 +297,8 @@ public:
 
         // Instantiate a process class if it's going to be needed somewhere later
         nodep->forall([&](const AstNodeCCall* ccallp) -> bool {
-            if (ccallp->funcp()->needProcess() && !VN_IS(ccallp->backp(), CAwait)) {
+            if (ccallp->funcp()->needProcess()
+                && (ccallp->funcp()->isCoroutine() == VN_IS(ccallp->backp(), CAwait))) {
                 if (!nodep->needProcess() && !m_instantiatesOwnProcess) {
                     m_instantiatesOwnProcess = true;
                     return false;

--- a/src/V3EmitCFunc.h
+++ b/src/V3EmitCFunc.h
@@ -150,7 +150,10 @@ protected:
     const AstCFunc* m_cfuncp = nullptr;  // Current function being emitted
     bool m_instantiatesOwnProcess = false;
 
-    bool constructorNeedsProcess(const AstClass* classp) {
+    bool constructorNeedsProcess(AstClass* classp) {
+        // This function is called only once per emitted constructor code, so this is fine.
+        classp->repairCache();
+
         const AstNode* newp = classp->findMember("new");
         const AstCFunc* ctor = newp ? VN_CAST(newp, CFunc) : nullptr;
         UASSERT_OBJ(ctor ? ctor->isConstructor() : true, ctor, "`new` is not a constructor!");

--- a/src/V3Sched.cpp
+++ b/src/V3Sched.cpp
@@ -274,7 +274,6 @@ void orderSequentially(AstCFunc* funcp, const LogicByScope& lbs) {
                         subFuncp = createNewSubFuncp(scopep);
                         subFuncp->name(subFuncp->name() + "__" + cvtToStr(scopep->user2Inc()));
                         subFuncp->rtnType("VlCoroutine");
-                        if (procp->needProcess()) subFuncp->setNeedProcess();
                         if (VN_IS(procp, Always)) {
                             subFuncp->slow(false);
                             FileLine* const flp = procp->fileline();
@@ -283,6 +282,7 @@ void orderSequentially(AstCFunc* funcp, const LogicByScope& lbs) {
                         }
                     }
                     subFuncp->addStmtsp(bodyp);
+                    if (procp->needProcess()) subFuncp->setNeedProcess();
                     splitCheck(subFuncp);
                 }
             } else {

--- a/src/V3Task.cpp
+++ b/src/V3Task.cpp
@@ -1380,6 +1380,8 @@ private:
             m_modNCalls = 0;
             iterateChildren(nodep);
         }
+        if (AstClass* classp = VN_CAST(nodep, Class))
+            classp->repairCache();
     }
     void visit(AstWith* nodep) override {
         if (nodep->user1SetOnce()) {

--- a/src/V3Task.cpp
+++ b/src/V3Task.cpp
@@ -1380,8 +1380,7 @@ private:
             m_modNCalls = 0;
             iterateChildren(nodep);
         }
-        if (AstClass* classp = VN_CAST(nodep, Class))
-            classp->repairCache();
+        if (AstClass* classp = VN_CAST(nodep, Class)) classp->repairCache();
     }
     void visit(AstWith* nodep) override {
         if (nodep->user1SetOnce()) {

--- a/src/V3Timing.cpp
+++ b/src/V3Timing.cpp
@@ -354,6 +354,14 @@ public:
                            && (static_cast<DepVtx*>(e->top())->nodep()->user2() & T_SUSPENDEE);
                 });
         }
+
+        // Workaround for killing `always` processes (doing that is pretty much UB)
+        // TODO: Disallow killing `always` at runtime
+        nodep->forall([&](AstAlways* nodep) -> bool {
+            if (nodep->user2() & T_HAS_PROC) nodep->user2(nodep->user2() | T_SUSPENDEE);
+            return true;
+        });
+
         if (dumpGraphLevel() >= 6) m_procGraph.dumpDotFilePrefixed("proc_deps");
     }
     ~TimingSuspendableVisitor() override = default;

--- a/src/V3Timing.cpp
+++ b/src/V3Timing.cpp
@@ -71,9 +71,9 @@ enum NodeFlag : uint8_t {
 };
 
 enum ForkType : uint8_t {
-    F_NONE = 0,
-    F_MIGHT_SUSPEND = 1 << 0,
-    F_MIGHT_NEED_PROC = 1 << 1,
+    F_NONE = 0,  // Not under a fork
+    F_MIGHT_SUSPEND = 1 << 0,  // Fork might suspend the execution of current process
+    F_MIGHT_NEED_PROC = 1 << 1,  // Fork might need a process (any fork really)
 };
 
 enum PropagationType : uint8_t {
@@ -83,7 +83,7 @@ enum PropagationType : uint8_t {
 };
 
 // ######################################################################
-//  Detect nodes affected by timing
+//  Detect nodes affected by timing and/or requiring a process
 
 class TimingSuspendableVisitor final : public VNVisitor {
 private:
@@ -162,7 +162,7 @@ private:
     // STATE
     AstClass* m_classp = nullptr;  // Current class
     AstNode* m_procp = nullptr;  // NodeProcedure/CFunc/Begin we're under
-    uint8_t m_underFork = F_NONE;
+    uint8_t m_underFork = F_NONE;  // F_NONE or flags of a fork we are under
     V3Graph m_suspGraph;  // Dependency graph where a node is a dependency of another if it being
                           // suspendable makes the other node suspendable
     V3Graph m_procGraph;  // Dependency graph where a node is a dependency of another if it being

--- a/src/V3Timing.cpp
+++ b/src/V3Timing.cpp
@@ -91,7 +91,7 @@ private:
         // ACCESSORS
         string name() const override VL_MT_STABLE {
             if (m_classp) {
-                if (AstCFunc* cfunc = VN_CAST(nodep(), CFunc)) {
+                if (VN_IS(nodep(), CFunc)) {
                     return cvtToHex(nodep()) + ' ' + classp()->name() + "::" + nodep()->name();
                 }
             }

--- a/src/V3Timing.cpp
+++ b/src/V3Timing.cpp
@@ -64,10 +64,10 @@ VL_DEFINE_DEBUG_FUNCTIONS;
 // ######################################################################
 
 enum NodeFlag : uint8_t {
-    T_SUSPENDEE = 1,  // Suspendable (due to dependence on another suspendable)
-    T_SUSPENDER = 2,  // Suspendable (has timing control)
-    T_HAS_PROC = 4,  // Has an associated std::process
-    T_CALLS_PROC_SELF = 8,  // Calls std::process::self
+    T_SUSPENDEE = 1 << 0,  // Suspendable (due to dependence on another suspendable)
+    T_SUSPENDER = 1 << 1,  // Suspendable (has timing control)
+    T_HAS_PROC = 1 << 2,  // Has an associated std::process
+    T_CALLS_PROC_SELF = 1 << 3,  // Calls std::process::self
 };
 
 enum ForkType : uint8_t {

--- a/src/V3Timing.cpp
+++ b/src/V3Timing.cpp
@@ -84,7 +84,7 @@ private:
     // TYPES
     // Vertex of a dependency graph of suspendable nodes, e.g. if a node (process or task) is
     // suspendable, all its dependents should also be suspendable
-    class DepVtx : public V3GraphVertex {
+    class DepVtx VL_NOT_FINAL : public V3GraphVertex {
         AstClass* const m_classp;  // Class associated with a method
         AstNode* const m_nodep;  // AST node represented by this graph vertex
 

--- a/test_regress/t/t_process_propagation.pl
+++ b/test_regress/t/t_process_propagation.pl
@@ -1,0 +1,23 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2003 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    verilator_flags2 => ["--exe --main --timing"],
+    make_main => 0,
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_process_propagation.v
+++ b/test_regress/t/t_process_propagation.v
@@ -1,0 +1,68 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2023 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+event evt1, evt2;
+
+class Foo;
+  process p;
+  bit event_received;
+
+  function new();
+    p = process::self();
+  endfunction
+
+  virtual task ewait();
+    @evt1 $display("Foo received event `evt1`");
+    event_received = 1;
+    ->evt2;
+  endtask
+endclass
+
+class Bar extends Foo;
+  function new();
+    super.new();
+    $display("Constructing Bar");
+  endfunction
+
+  virtual task ewait();
+    @evt1 $display("Bar received event `evt1`");
+    event_received = 1;
+  endtask
+endclass
+
+module t();
+  initial begin
+    process p;
+    Foo foo;
+    Bar bar;
+
+    fork
+      begin
+        foo = new;
+        foo.ewait();
+      end
+      begin
+        bar = new;
+        p = process::self();
+        bar.ewait();
+      end
+    join_none
+
+    p.kill();
+
+    ->evt1;
+
+    @evt2 begin
+      if (!foo.event_received)
+        $stop;
+      if (bar.event_received)
+        $stop;
+
+      $write("*-* All Finished *-*\n");
+      $finish;
+    end
+  end
+endmodule


### PR DESCRIPTION
This PR aims to solve issues related to "process propagation". That is creating and passing the extra `vlProcess` argument between functions.

The changes are:
* **Decoupling process propagation from suspendability propagation**. Suspendability and needsProcess are two properties that are propagated in V3Tming through AST. They change the signatures of generated functions and they propagate with certain rules that ensure that the generated code does not contain mismatches between signatures and is logically equivalent to the System Verilog input. The current solution assumed that needsProcess implies suspendability. However, this is simply not true. It might've worked in some cases, given that runtime cost aside, marking a function as suspendable, even if it doesn't suspend, does not cause problems. However, this is not a case for constructors, as they simply cannot be turned into coroutines. They are not allowed to be suspendable at all.

* **Support passing `vlProcess` as constructor argument**. The code responsible for generating calls to constructors uses some hardcoded elements to create a call. Those did not take into account a possibility that a constructor might require a process. My proposed change also takes into account the possibile need of passing `vlProcess` to constructor's initializer list.

* **Other changes to the logic of process propagation**
  * Processes are now passed down (from caller to callee) to reach all suspendable callees. This ensures that we pass the correct `vlProcess` to the scheduler when we are waiting.
  * If a callee needs a process, but we don't, we instantiate the process in our own scope, so the same process will be passed to any number of callees that require it (unless those are forked, then they get a new `VlProcess`).

* **Improved graph dumps**. Given that this PR modifies the graphs, there are slight cosmetic/debug changes made to the graphs. Methods get names that make it easier to identify them. The colors of nodes also differentiate between sources of propagation and nodes to which a property got propagated.