### PR TITLE
Remove unhandled overloads in V3InstrCount

### DIFF
--- a/src/V3InstrCount.cpp
+++ b/src/V3InstrCount.cpp
@@ -147,12 +147,6 @@ private:
         iterateAndNextConstNull(nodep->lsbp());
         iterateAndNextConstNull(nodep->widthp());
     }
-    void visit(AstSliceSel* nodep) override {  // LCOV_EXCL_LINE
-        nodep->v3fatalSrc("AstSliceSel unhandled");
-    }
-    void visit(AstMemberSel* nodep) override {  // LCOV_EXCL_LINE
-        nodep->v3fatalSrc("AstMemberSel unhandled");
-    }
     void visit(AstConcat* nodep) override {
         if (m_ignoreRemaining) return;
         // Nop.


### PR DESCRIPTION
The overload for `AstMemberSel` breaks #4321.

I think it's better to underestimate instruction count and produce a suboptimal multithreading model, than to throw a fatal error.