### PR TITLE
Fix selects of static members

### DIFF
--- a/src/V3AstNodeExpr.h
+++ b/src/V3AstNodeExpr.h
@@ -1454,7 +1454,7 @@ public:
     string emitVerilog() override { V3ERROR_NA_RETURN(""); }
     string emitC() override { V3ERROR_NA_RETURN(""); }
     bool cleanOut() const override { return true; }
-    bool same(const AstNode* samep) const override { return true; }  // dtype comparison does it
+    bool same(const AstNode* samep) const override;
     int instrCount() const override { return widthInstrs(); }
     AstVar* varp() const { return m_varp; }
     void varp(AstVar* nodep) { m_varp = nodep; }

--- a/src/V3AstNodeExpr.h
+++ b/src/V3AstNodeExpr.h
@@ -1428,6 +1428,7 @@ class AstMemberSel final : public AstNodeExpr {
     // @astgen op1 := fromp : AstNodeExpr
     // Don't need the class we are extracting from, as the "fromp()"'s datatype can get us to it
     string m_name;
+    VAccess m_access;  // Read or write, as in AstNodeVarRef
     AstVar* m_varp = nullptr;  // Post link, variable within class that is target of selection
 public:
     AstMemberSel(FileLine* fl, AstNodeExpr* fromp, VFlagChildDType, const string& name)
@@ -1448,6 +1449,8 @@ public:
     void dump(std::ostream& str) const override;
     string name() const override VL_MT_STABLE { return m_name; }
     void name(const string& name) override { m_name = name; }
+    VAccess access() const { return m_access; }
+    void access(const VAccess& flag) { m_access = flag; }
     string emitVerilog() override { V3ERROR_NA_RETURN(""); }
     string emitC() override { V3ERROR_NA_RETURN(""); }
     bool cleanOut() const override { return true; }

--- a/src/V3AstNodes.cpp
+++ b/src/V3AstNodes.cpp
@@ -1676,6 +1676,12 @@ AstNodeUOrStructDType* AstMemberDType::getChildStructp() const {
     return VN_CAST(subdtp, NodeUOrStructDType);  // Maybe nullptr
 }
 
+bool AstMemberSel::same(const AstNode* samep) const {
+    const AstMemberSel* const sp = static_cast<const AstMemberSel*>(samep);
+    return sp != nullptr && access() == sp->access() && fromp()->same(sp->fromp())
+           && name() == sp->name() && varp()->same(sp->varp());
+}
+
 void AstMemberSel::dump(std::ostream& str) const {
     this->AstNodeExpr::dump(str);
     str << " -> ";

--- a/src/V3LinkLValue.cpp
+++ b/src/V3LinkLValue.cpp
@@ -275,6 +275,16 @@ private:
             iterateAndNextNull(nodep->thsp());
         }
     }
+    void visit(AstMemberSel* nodep) override {
+        if (m_setRefLvalue != VAccess::NOCHANGE) {
+            nodep->access(m_setRefLvalue);
+        } else {
+            // It is the only place where the access is set to member select nodes.
+            // If it doesn't have to be set to WRITE, it means that it is READ.
+            nodep->access(VAccess::READ);
+        }
+        iterateChildren(nodep);
+    }
     void visit(AstNodeFTask* nodep) override {
         VL_RESTORER(m_ftaskp);
         m_ftaskp = nodep;

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -2715,9 +2715,9 @@ private:
                     if (!varp->didWidth()) userIterate(varp, nullptr);
                     if (varp->lifetime().isStatic()) {
                         // Static fiels are moved outside the class, so they shouldn't be accessed
-                        // via object
+                        // by member select on a class object
                         AstVarRef* const varRefp
-                            = new AstVarRef{nodep->fileline(), varp, VAccess::READ};
+                            = new AstVarRef{nodep->fileline(), varp, nodep->access()};
                         varRefp->classOrPackagep(adtypep->classp());
                         nodep->replaceWith(varRefp);
                         VL_DO_DANGLING(pushDeletep(nodep), nodep);

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -2713,6 +2713,16 @@ private:
             if (AstNode* const foundp = memberSelClass(nodep, adtypep)) {
                 if (AstVar* const varp = VN_CAST(foundp, Var)) {
                     if (!varp->didWidth()) userIterate(varp, nullptr);
+                    if (varp->lifetime().isStatic()) {
+                        // Static fiels are moved outside the class, so they shouldn't be accessed
+                        // via object
+                        AstVarRef* const varRefp
+                            = new AstVarRef{nodep->fileline(), varp, VAccess::READ};
+                        varRefp->classOrPackagep(adtypep->classp());
+                        nodep->replaceWith(varRefp);
+                        VL_DO_DANGLING(pushDeletep(nodep), nodep);
+                        return;
+                    }
                     nodep->dtypep(foundp->dtypep());
                     nodep->varp(varp);
                     return;

--- a/test_regress/t/t_class_static_member_sel.pl
+++ b/test_regress/t/t_class_static_member_sel.pl
@@ -1,0 +1,21 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2022 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_class_static_member_sel.v
+++ b/test_regress/t/t_class_static_member_sel.v
@@ -36,6 +36,12 @@ endclass
 class ExtendCls extends Cls;
 endclass
 
+class Getter1;
+   function static int get_1;
+      return 1;
+   endfunction
+endclass
+
 module t (/*AUTOARG*/
    );
 
@@ -44,6 +50,7 @@ module t (/*AUTOARG*/
       Bar bar = new;
       Baz baz = new;
       ExtendCls ec = new;
+      Getter1 getter1 = new;
 
       if (foo.x != 1) $stop;
 
@@ -58,6 +65,8 @@ module t (/*AUTOARG*/
 
       ec.iw.x = 5;
       if (ec.iw.x != 5) $stop;
+
+      if (getter1.get_1 != 1) $stop;
 
       $write("*-* All Finished *-*\n");
       $finish;

--- a/test_regress/t/t_class_static_member_sel.v
+++ b/test_regress/t/t_class_static_member_sel.v
@@ -1,0 +1,47 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2023 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+class Foo;
+   static int x = 1;
+endclass
+
+class Bar;
+   Foo f;
+   function new;
+      f = new;
+   endfunction
+endclass
+
+class Baz;
+   function static Bar get_bar;
+      Bar b = new;
+      return b;
+   endfunction
+endclass
+
+module t (/*AUTOARG*/
+   );
+
+   initial begin
+      Foo foo = new;
+      Bar bar = new;
+      Baz baz = new;
+
+      if (foo.x != 1) $stop;
+
+      foo.x = 2;
+      if (foo.x != 2) $stop;
+
+      bar.f.x = 3;
+      if (bar.f.x != 3) $stop;
+
+      baz.get_bar().f.x = 4;
+      if (baz.get_bar().f.x != 4) $stop;
+
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end
+endmodule

--- a/test_regress/t/t_class_static_member_sel.v
+++ b/test_regress/t/t_class_static_member_sel.v
@@ -22,6 +22,20 @@ class Baz;
    endfunction
 endclass
 
+class IntWrapper;
+   int        x;
+endclass
+
+class Cls;
+   static IntWrapper iw;
+   function new;
+      if (iw == null) iw = new;
+   endfunction
+endclass
+
+class ExtendCls extends Cls;
+endclass
+
 module t (/*AUTOARG*/
    );
 
@@ -29,6 +43,7 @@ module t (/*AUTOARG*/
       Foo foo = new;
       Bar bar = new;
       Baz baz = new;
+      ExtendCls ec = new;
 
       if (foo.x != 1) $stop;
 
@@ -40,6 +55,9 @@ module t (/*AUTOARG*/
 
       baz.get_bar().f.x = 4;
       if (baz.get_bar().f.x != 4) $stop;
+
+      ec.iw.x = 5;
+      if (ec.iw.x != 5) $stop;
 
       $write("*-* All Finished *-*\n");
       $finish;


### PR DESCRIPTION
Currently, member select results in a compilation error if the member is static. The problem occurs only if the select is performed on a class object.
During verilation, static members are moved from AstClass to AstClassPackage, but member selects still point to the members of AstClass nodes. It passes through the rest of verilation, but c++ compiler throws an error.

Access to static members of form `<class name>::<static member>` is represented without `AstMemberSelect` or `AstMethodCall`. Instead, `AstVarRef` / `AstFuncRef` are used with the field `classOrPackagep` set.

This PR fixes it by converting AstMemberSelect to AstVarRef if the field is static. Static method calls are already handled in he same way on master.
I needed to mark AstMemberSelect nodes as READ or WRITE to pass it to AstVarRef. In simple cases I can probably get it from the node returned by the `fromp()` method, but it is harder if the member select is performed on other member select or on a function call.