### PR TITLE
Fix references to members of results of static methods

### DIFF
--- a/src/V3LinkDot.cpp
+++ b/src/V3LinkDot.cpp
@@ -3049,7 +3049,8 @@ private:
             }
             UASSERT_OBJ(cpackagerefp->classOrPackagep(), m_ds.m_dotp->lhsp(), "Bad package link");
             nodep->classOrPackagep(cpackagerefp->classOrPackagep());
-            m_ds.m_dotPos = DP_SCOPE;
+            // Class/package :: HERE function() . method_called_on_function_return_value()
+            m_ds.m_dotPos = DP_MEMBER;
             m_ds.m_dotp = nullptr;
         } else if (m_ds.m_dotp && m_ds.m_dotPos == DP_FINAL) {
             nodep->dotted(m_ds.m_dotText);  // Maybe ""

--- a/test_regress/t/t_class_static_member_sel.v
+++ b/test_regress/t/t_class_static_member_sel.v
@@ -42,6 +42,18 @@ class Getter1;
    endfunction
 endclass
 
+class uvm_root;
+   int x;
+   static uvm_root m_inst;
+   static function uvm_root get_inst();
+      if (m_inst == null) m_inst = new;
+      return m_inst;
+   endfunction
+   function int get_7();
+      return 7;
+   endfunction
+endclass
+
 module t (/*AUTOARG*/
    );
 
@@ -67,6 +79,11 @@ module t (/*AUTOARG*/
       if (ec.iw.x != 5) $stop;
 
       if (getter1.get_1 != 1) $stop;
+
+      uvm_root::get_inst().x = 6;
+      if (uvm_root::get_inst().x != 6) $stop;
+
+      if (uvm_root::get_inst().get_7() != 7) $stop;
 
       $write("*-* All Finished *-*\n");
       $finish;


### PR DESCRIPTION
Currently on master, member selects or method calls performed on results of static methods don't work.
This PR fixes it, by setting `m_ds.m_dotPos` to the correct value. The same is done for other functions:
https://github.com/verilator/verilator/blob/242f661644c17bcaef6b3c7b7930e43b1a3ddda2/src/V3LinkDot.cpp#L3067-L3070