### PR TITLE
Fix unique..with method on queues of class objects

### DIFF
--- a/include/verilated_types.h
+++ b/include/verilated_types.h
@@ -516,7 +516,7 @@ public:
     VlQueue<IData> unique_index(Func with_func) const {
         VlQueue<IData> out;
         IData index = 0;
-        std::unordered_set<decltype(with_func(0, m_deque[0]))> saw;
+        std::set<decltype(with_func(0, m_deque[0]))> saw;
         for (const auto& i : m_deque) {
             const auto i_mapped = with_func(index, i);
             auto it = saw.find(i_mapped);

--- a/include/verilated_types.h
+++ b/include/verilated_types.h
@@ -487,7 +487,7 @@ public:
     template <typename Func>
     VlQueue unique(Func with_func) const {
         VlQueue out;
-        std::set<T_Value> saw;
+        std::set<decltype(with_func(0, m_deque[0]))> saw;
         for (const auto& i : m_deque) {
             const auto i_mapped = with_func(0, i);
             const auto it = saw.find(i_mapped);
@@ -516,7 +516,7 @@ public:
     VlQueue<IData> unique_index(Func with_func) const {
         VlQueue<IData> out;
         IData index = 0;
-        std::unordered_set<T_Value> saw;
+        std::unordered_set<decltype(with_func(0, m_deque[0]))> saw;
         for (const auto& i : m_deque) {
             const auto i_mapped = with_func(index, i);
             auto it = saw.find(i_mapped);

--- a/test_regress/t/t_queue_method.v
+++ b/test_regress/t/t_queue_method.v
@@ -10,6 +10,13 @@
 
 `define checkg(gotv,expv) do if ((gotv) !== (expv)) begin $write("%%Error: %s:%0d:  got='%g' exp='%g'\n", `__FILE__,`__LINE__, (gotv), (expv)); `stop; end while(0);
 
+class Cls;
+   int x;
+   function new(int a);
+      x = a;
+   endfunction
+endclass
+
 module t (/*AUTOARG*/);
    typedef struct packed { int x, y; } point;
    typedef struct packed { point p; int z; } point_3d;
@@ -25,10 +32,21 @@ module t (/*AUTOARG*/);
       string string_qv[$];
       point_3d points_q[$];  // Same as q and qv, but complex value type
       point_3d points_qv[$];
+      Cls cls;
+      Cls cls_q[$];
+      Cls cls_qv[$];
 
       points_q.push_back(point_3d'{point'{1, 2}, 3});
       points_q.push_back(point_3d'{point'{2, 3}, 5});
       points_q.push_back(point_3d'{point'{1, 4}, 5});
+
+
+      cls = new(1);
+      cls_q.push_back(cls);
+      cls = new(2);
+      cls_q.push_back(cls);
+      cls = new(1);
+      cls_q.push_back(cls);
 
       string_q.push_back("a");
       string_q.push_back("A");
@@ -71,6 +89,13 @@ module t (/*AUTOARG*/);
       `checkh(qi.size(), 0);
       qi = q.unique_index(x) with (x % 3); qv.sort;
       `checkh(qi.size(), 3);
+      cls_qv = cls_q.unique with (item.x);
+      `checkh(cls_qv.size(), 2);
+      cls_qv = cls_q.unique with (item.x < 10);
+      `checkh(cls_qv.size(), 1);
+      qi = cls_q.unique_index with (item.x % 2);
+      qi.sort;
+      v = $sformatf("%p", qi); `checks(v, "'{'h0, 'h1} ");
 
       q.reverse;
       v = $sformatf("%p", q); `checks(v, "'{'h3, 'h1, 'h4, 'h2, 'h2} ");


### PR DESCRIPTION
Currently on master, the `with` expression of `unique..with` method is expected to be of the same type as the elements of a queue. This PR fixes it.