### PR TITLE
Fix queue slicing

### DIFF
--- a/src/V3Const.cpp
+++ b/src/V3Const.cpp
@@ -3655,6 +3655,7 @@ private:
 public:
     // Processing Mode Enum
     enum ProcMode : uint8_t {
+        PROC_PARAMS_NOWARN,
         PROC_PARAMS,
         PROC_GENERATE,
         PROC_LIVE,
@@ -3670,16 +3671,18 @@ public:
         , m_concswapNames{globalPass ? ("__Vconcswap_" + cvtToStr(s_globalPassNum++)) : ""} {
         // clang-format off
         switch (pmode) {
-        case PROC_PARAMS:       m_doV = true;  m_doNConst = true; m_params = true;
-                                m_required = true; break;
-        case PROC_GENERATE:     m_doV = true;  m_doNConst = true; m_params = true;
-                                m_required = true; m_doGenerate = true; break;
-        case PROC_LIVE:         break;
-        case PROC_V_WARN:       m_doV = true;  m_doNConst = true; m_warn = true; break;
-        case PROC_V_NOWARN:     m_doV = true;  m_doNConst = true; break;
-        case PROC_V_EXPENSIVE:  m_doV = true;  m_doNConst = true; m_doExpensive = true; break;
-        case PROC_CPP:          m_doV = false; m_doNConst = true; m_doCpp = true; break;
-        default:                v3fatalSrc("Bad case"); break;
+        case PROC_PARAMS_NOWARN:  m_doV = true;  m_doNConst = true; m_params = true;
+                                  m_required = false; break;
+        case PROC_PARAMS:         m_doV = true;  m_doNConst = true; m_params = true;
+                                  m_required = true; break;
+        case PROC_GENERATE:       m_doV = true;  m_doNConst = true; m_params = true;
+                                  m_required = true; m_doGenerate = true; break;
+        case PROC_LIVE:           break;
+        case PROC_V_WARN:         m_doV = true;  m_doNConst = true; m_warn = true; break;
+        case PROC_V_NOWARN:       m_doV = true;  m_doNConst = true; break;
+        case PROC_V_EXPENSIVE:    m_doV = true;  m_doNConst = true; m_doExpensive = true; break;
+        case PROC_CPP:            m_doV = false; m_doNConst = true; m_doCpp = true; break;
+        default:                  v3fatalSrc("Bad case"); break;
         }
         // clang-format on
     }
@@ -3714,6 +3717,29 @@ AstNode* V3Const::constifyParamsEdit(AstNode* nodep) {
     // Make sure we've sized everything first
     nodep = V3Width::widthParamsEdit(nodep);
     ConstVisitor visitor{ConstVisitor::PROC_PARAMS, /* globalPass: */ false};
+    if (AstVar* const varp = VN_CAST(nodep, Var)) {
+        // If a var wants to be constified, it's really a param, and
+        // we want the value to be constant.  We aren't passed just the
+        // init value because we need widthing above to handle the var's type.
+        if (varp->valuep()) visitor.mainAcceptEdit(varp->valuep());
+    } else {
+        nodep = visitor.mainAcceptEdit(nodep);
+    }
+    // Because we do edits, nodep links may get trashed and core dump this.
+    // if (debug() > 0) nodep->dumpTree("-  forceConDONE: ");
+    return nodep;
+}
+
+//! Constify this cell node's parameter list if possible
+//! @return  Pointer to the edited node.
+AstNode* V3Const::constifyParamsNoWarnEdit(AstNode* nodep) {
+    // if (debug() > 0) nodep->dumpTree("-  forceConPRE : ");
+    // Resize even if the node already has a width, because buried in the tree
+    // we may have a node we just created with signing, etc, that isn't sized yet.
+
+    // Make sure we've sized everything first
+    nodep = V3Width::widthParamsEdit(nodep);
+    ConstVisitor visitor{ConstVisitor::PROC_PARAMS_NOWARN, /* globalPass: */ false};
     if (AstVar* const varp = VN_CAST(nodep, Var)) {
         // If a var wants to be constified, it's really a param, and
         // we want the value to be constant.  We aren't passed just the

--- a/src/V3Const.h
+++ b/src/V3Const.h
@@ -30,6 +30,10 @@ public:
     static AstNodeExpr* constifyParamsEdit(AstNodeExpr* exprp) {
         return VN_AS(constifyParamsEdit(static_cast<AstNode*>(exprp)), NodeExpr);
     }
+    static AstNode* constifyParamsNoWarnEdit(AstNode* nodep);
+    static AstNodeExpr* constifyParamsNoWarnEdit(AstNodeExpr* exprp) {
+        return VN_AS(constifyParamsNoWarnEdit(static_cast<AstNode*>(exprp)), NodeExpr);
+    }
     static AstNode* constifyGenerateParamsEdit(AstNode* nodep);
     // Only do constant pushing, without removing dead logic
     static void constifyAllLive(AstNetlist* nodep);

--- a/src/V3WidthSel.cpp
+++ b/src/V3WidthSel.cpp
@@ -348,8 +348,8 @@ private:
         UINFO(6, "SELEXTRACT " << nodep << endl);
         // if (debug() >= 9) nodep->dumpTree("-  SELEX0: ");
         // Below 2 lines may change nodep->widthp()
-        V3Const::constifyParamsEdit(nodep->leftp());  // May relink pointed to node
-        V3Const::constifyParamsEdit(nodep->rightp());  // May relink pointed to node
+        V3Const::constifyParamsNoWarnEdit(nodep->leftp());  // May relink pointed to node
+        V3Const::constifyParamsNoWarnEdit(nodep->rightp());  // May relink pointed to node
         // if (debug() >= 9) nodep->dumpTree("-  SELEX3: ");
         AstNodeExpr* const fromp = nodep->fromp()->unlinkFrBack();
         const FromData fromdata = fromDataForArray(nodep, fromp);

--- a/test_regress/t/t_queue_var_slice.pl
+++ b/test_regress/t/t_queue_var_slice.pl
@@ -1,0 +1,21 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2023 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_queue_var_slice.v
+++ b/test_regress/t/t_queue_var_slice.v
@@ -1,0 +1,24 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2023 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+module t (/*AUTOARG*/
+   // Inputs
+   clk
+   );
+   input clk;
+
+   integer i = 0, q[$] = {0, 1};
+
+   always @(posedge clk) begin
+      $display("%p", q[i:i+1]);
+      q.push_back(i+2);
+      i++;
+      if (i >= 3) begin
+         $write("*-* All Finished *-*\n");
+         $finish;
+      end
+   end
+endmodule

--- a/test_regress/t/t_queue_var_slice.v
+++ b/test_regress/t/t_queue_var_slice.v
@@ -10,7 +10,8 @@ module t (/*AUTOARG*/
    );
    input clk;
 
-   integer i = 0, q[$] = {0, 1};
+   integer i = 0;
+   integer q[$] = {0, 1};
 
    always @(posedge clk) begin
       $display("%p", q[i:i+1]);

--- a/test_regress/t/t_select_bad_range4.out
+++ b/test_regress/t/t_select_bad_range4.out
@@ -52,14 +52,6 @@
                                                    : ... In instance t
    23 |       sel2 = mi[nonconst];
       |            ^
-%Error: t/t_select_bad_range4.v:24:17: Expecting expression to be constant, but variable isn't const: 'nonconst'
-                                     : ... In instance t
-   24 |       sel2 = mi[nonconst : nonconst];
-      |                 ^~~~~~~~
-%Error: t/t_select_bad_range4.v:24:28: Expecting expression to be constant, but variable isn't const: 'nonconst'
-                                     : ... In instance t
-   24 |       sel2 = mi[nonconst : nonconst];
-      |                            ^~~~~~~~
 %Error: t/t_select_bad_range4.v:24:17: First value of [a:b] isn't a constant, maybe you want +: or -:
                                      : ... In instance t
    24 |       sel2 = mi[nonconst : nonconst];


### PR DESCRIPTION
The change fixes slice operator on queues where indexes are variables. Such case occurs in UVM.

In the case of slicing operators, V3WidthSel [first constifies](https://github.com/verilator/verilator/blob/3d30527860039ee97366c338161e763afe2db447/src/V3WidthSel.cpp#L351) arguments of the operator. Then an error is produced if the sliced variable isn't a queue and the indexes didn't become constants.

I assume that that's the expected behavior, but instead an error is produced anyway, because the routine V3Const::constifyParamsEdit produces an error whenever it cannot turn a variable into a constant.

The fix does the following:
1. constifyParamsEdit is relaxed not to warn/error in the case above,
2. A new routine constifyAllParamsEdit does produce warns/errors,
3. Old calls to constifyParamsEdit are changed to constifyAllParamsEdit except for the aforementioned visitor.

^ It could be done simpler, but I think doing it this way allowed for better naming of the routines.