### PR TITLE
Revert .gdbinit modified by accident.

### DIFF
--- a/test_regress/.gdbinit
+++ b/test_regress/.gdbinit
@@ -1,1 +1,1 @@
-source ~/SandBox/homecvs/v4/verilator/src/.gdbinit
+source ../src/.gdbinit


### PR DESCRIPTION
`test_regress/.gdbinit` has been modified in d42f9c095b4b13267f156062600dc99a377bab50 most likely by accident. Restore its previous content.