### PR TITLE
Fix typo: concurent -> concurrent

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -5,7 +5,6 @@ Please see the Verilator manual for 200+ additional contributors. Thanks to all.
 
 Adam Bagley
 Adrien Le Masle
-Ahmed El-Mahmoudy
 Aleksander Kiryk
 Alex Chadwick
 Àlex Torregrosa
@@ -175,3 +174,4 @@ Yutetsu TAKATSUKASA
 Yves Mathieu
 Zhanglei Wang
 Zixi Li
+أحمد المحمودي

--- a/src/V3Assert.cpp
+++ b/src/V3Assert.cpp
@@ -157,7 +157,7 @@ private:
             sentreep->unlinkFrBack();
             if (m_procedurep) {
                 // To support this need queue of asserts to activate
-                nodep->v3error("Unsupported: Procedural concurent assertion with"
+                nodep->v3error("Unsupported: Procedural concurrent assertion with"
                                " clocking event inside always (IEEE 1800-2917 16.14.6)");
             }
         }

--- a/test_regress/t/t_assert_procedural_clk.out
+++ b/test_regress/t/t_assert_procedural_clk.out
@@ -1,8 +1,8 @@
-%Error: t/t_assert_procedural_clk.v:21:13: Unsupported: Procedural concurent assertion with clocking event inside always (IEEE 1800-2917 16.14.6)
+%Error: t/t_assert_procedural_clk.v:21:13: Unsupported: Procedural concurrent assertion with clocking event inside always (IEEE 1800-2917 16.14.6)
                                          : ... In instance t
    21 |             assume property (@(posedge clk) cyc == 9);
       |             ^~~~~~
-%Error: t/t_assert_procedural_clk.v:22:13: Unsupported: Procedural concurent assertion with clocking event inside always (IEEE 1800-2917 16.14.6)
+%Error: t/t_assert_procedural_clk.v:22:13: Unsupported: Procedural concurrent assertion with clocking event inside always (IEEE 1800-2917 16.14.6)
                                          : ... In instance t
    22 |             assume property (@(negedge clk) cyc == 9);
       |             ^~~~~~


### PR DESCRIPTION
Please note that: أحمد المحمودي
is that arabic writting for: Ahmed El-Mahmoudy