### PR TITLE
Drop analytics_id option if VERILATOR_AUTHOR_SITE environment variable isn't set

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -91,6 +91,7 @@ datarootdir = @datarootdir@
 CFG_WITH_CCWARN = @CFG_WITH_CCWARN@
 CFG_WITH_DEFENV = @CFG_WITH_DEFENV@
 CFG_WITH_LONGTESTS = @CFG_WITH_LONGTESTS@
+CFG_WITH_GANALYTICS = @CFG_WITH_GANALYTICS@
 PACKAGE_VERSION = @PACKAGE_VERSION@
 
 #### End of system configuration section. ####
@@ -192,7 +193,7 @@ verilator_coverage.1: ${srcdir}/bin/verilator_coverage
 
 .PHONY: verilator.html
 verilator.html:
-	$(MAKE) -C docs html
+	$(MAKE) -C docs html CFG_WITH_GANALYTICS=$(CFG_WITH_GANALYTICS)
 
 # PDF needs DIST variables; but having configure.ac as dependency isn't detected
 .PHONY: verilator.pdf

--- a/configure.ac
+++ b/configure.ac
@@ -144,6 +144,25 @@ AC_ARG_ENABLE([longtests],
 AC_SUBST(CFG_WITH_LONGTESTS)
 AC_MSG_RESULT($CFG_WITH_LONGTESTS)
 
+# Whether to add Google analytics to HTML docs
+AC_MSG_CHECKING(whether to add Google analytics to generated HTML docs)
+AC_ARG_ENABLE([ganalytics],
+              [AS_HELP_STRING([--enable-ganalytics],
+			      [enable adding Google Analytics to generated HTML
+			       documents])],
+              [case "${enableval}" in
+                yes) CFG_WITH_GANALYTICS=yes ;;
+                no)  CFG_WITH_GANALYTICS=no ;;
+                *)   AC_MSG_ERROR([bad value ${enableval} for --enable-ganalytics]) ;;
+               esac],
+              [case "x${VERILATOR_AUTHOR_SITE}" in
+                x)   CFG_WITH_GANALYTICS=no ;;
+                *)   CFG_WITH_GANALYTICS=yes ;;
+               esac]
+              )
+AC_SUBST(CFG_WITH_GANALYTICS)
+AC_MSG_RESULT($CFG_WITH_GANALYTICS)
+
 # Compiler flags (ensure they are not empty to avoid configure defaults)
 CFLAGS="$CFLAGS "
 CPPFLAGS="$CPPFLAGS "

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -18,7 +18,11 @@
 RST2HTML = rst2html
 PYTHON3 = python3
 DOXYGEN = doxygen
+ANALYTICS_ID=G-D27B0C9QEB
 SPHINXOPTS ?= -c guide
+ifeq ($(CFG_WITH_GANALYTICS),yes)  # Local...
+SPHINXOPTS += -D html_theme_options.analytics_id=$(ANALYTICS_ID)
+endif
 SPHINXBUILD ?= sphinx-build
 
 SOURCEDIR = guide
@@ -66,7 +70,7 @@ pdf:
 
 html latex linkcheck spelling::
 	$(MAKE) vl-extract
-	$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS)
+	VERIATOR_WEBSITE=True $(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS)
 	$(PYTHON3) bin/vl_sphinx_fix _build
 
 help:

--- a/docs/guide/conf.py
+++ b/docs/guide/conf.py
@@ -115,7 +115,6 @@ html_theme = 'sphinx_rtd_theme'
 html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 html_theme_options = {
-    'analytics_id': 'G-D27B0C9QEB',
     'logo_only': True,
     'style_nav_header_background': "#45acf8",  # Default is #2980B9
     # 'canonical_url':


### PR DESCRIPTION
The inclusion of gtags.js causes Debian lint tool to report privacy-breach-generic tag