### PR TITLE
Add support for locator methods with "with" clause on assoc arrays

### DIFF
--- a/include/verilated_types.h
+++ b/include/verilated_types.h
@@ -834,7 +834,8 @@ public:
     VlQueue<T_Value> unique(Func with_func) const {
         VlQueue<T_Value> out;
         T_Key default_key;
-        std::set<decltype(with_func(default_key, m_map.begin()->second))> saw;
+        using WithType = decltype(with_func(m_map.begin()->first, m_map.begin()->second));
+        std::set<WithType> saw;
         for (const auto& i : m_map) {
             const auto i_mapped = with_func(default_key, i.second);
             const auto it = saw.find(i_mapped);
@@ -860,7 +861,8 @@ public:
     template <typename Func>
     VlQueue<T_Key> unique_index(Func with_func) const {
         VlQueue<T_Key> out;
-        std::set<decltype(with_func(m_map.begin()->first, m_map.begin()->second))> saw;
+        using WithType = decltype(with_func(m_map.begin()->first, m_map.begin()->second));
+        std::set<WithType> saw;
         for (const auto& i : m_map) {
             const auto i_mapped = with_func(i.first, i.second);
             auto it = saw.find(i_mapped);

--- a/include/verilated_types.h
+++ b/include/verilated_types.h
@@ -830,6 +830,21 @@ public:
         }
         return out;
     }
+    template <typename Func>
+    VlQueue<T_Value> unique(Func with_func) const {
+        VlQueue<T_Value> out;
+        T_Key default_key;
+        std::set<decltype(with_func(default_key, m_map.begin()->second))> saw;
+        for (const auto& i : m_map) {
+            const auto i_mapped = with_func(default_key, i.second);
+            const auto it = saw.find(i_mapped);
+            if (it == saw.end()) {
+                saw.insert(it, i_mapped);
+                out.push_back(i.second);
+            }
+        }
+        return out;
+    }
     VlQueue<T_Key> unique_index() const {
         VlQueue<T_Key> out;
         std::set<T_Key> saw;
@@ -837,6 +852,20 @@ public:
             auto it = saw.find(i.second);
             if (it == saw.end()) {
                 saw.insert(it, i.second);
+                out.push_back(i.first);
+            }
+        }
+        return out;
+    }
+    template <typename Func>
+    VlQueue<T_Key> unique_index(Func with_func) const {
+        VlQueue<T_Key> out;
+        std::set<decltype(with_func(m_map.begin()->first, m_map.begin()->second))> saw;
+        for (const auto& i : m_map) {
+            const auto i_mapped = with_func(i.first, i.second);
+            auto it = saw.find(i_mapped);
+            if (it == saw.end()) {
+                saw.insert(it, i_mapped);
                 out.push_back(i.first);
             }
         }

--- a/include/verilated_types.h
+++ b/include/verilated_types.h
@@ -934,12 +934,32 @@ public:
             });
         return VlQueue<T_Value>::cons(it->second);
     }
+    template <typename Func>
+    VlQueue<T_Value> min(Func with_func) const {
+        if (m_map.empty()) return VlQueue<T_Value>();
+        const auto it = std::min_element(
+            m_map.begin(), m_map.end(),
+            [&with_func](const std::pair<T_Key, T_Value>& a, const std::pair<T_Key, T_Value>& b) {
+                return with_func(a.first, a.second) < with_func(b.first, b.second);
+            });
+        return VlQueue<T_Value>::cons(it->second);
+    }
     VlQueue<T_Value> max() const {
         if (m_map.empty()) return VlQueue<T_Value>();
         const auto it = std::max_element(
             m_map.begin(), m_map.end(),
             [](const std::pair<T_Key, T_Value>& a, const std::pair<T_Key, T_Value>& b) {
                 return a.second < b.second;
+            });
+        return VlQueue<T_Value>::cons(it->second);
+    }
+    template <typename Func>
+    VlQueue<T_Value> max(Func with_func) const {
+        if (m_map.empty()) return VlQueue<T_Value>();
+        const auto it = std::max_element(
+            m_map.begin(), m_map.end(),
+            [&with_func](const std::pair<T_Key, T_Value>& a, const std::pair<T_Key, T_Value>& b) {
+                return with_func(a.first, a.second) < with_func(b.first, b.second);
             });
         return VlQueue<T_Value>::cons(it->second);
     }

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -3219,10 +3219,12 @@ private:
             if (!nodep->firstAbovep()) newp->dtypeSetVoid();
         } else if (nodep->name() == "min" || nodep->name() == "max" || nodep->name() == "unique"
                    || nodep->name() == "unique_index") {
+            AstWith* const withp = methodWithArgument(
+                nodep, false, true, nullptr, nodep->findUInt32DType(), adtypep->subDTypep());
             methodOkArguments(nodep, 0, 0);
             methodCallLValueRecurse(nodep, nodep->fromp(), VAccess::READ);
             newp = new AstCMethodHard{nodep->fileline(), nodep->fromp()->unlinkFrBack(),
-                                      nodep->name()};
+                                      nodep->name(), withp};
             if (nodep->name() == "unique_index") {
                 newp->dtypep(queueDTypeIndexedBy(adtypep->keyDTypep()));
             } else {

--- a/test_regress/t/t_assoc_method.v
+++ b/test_regress/t/t_assoc_method.v
@@ -87,12 +87,21 @@ module t (/*AUTOARG*/);
 
       qv = q.min;
       v = $sformatf("%p", qv); `checks(v, "'{'h1} ");
+      points_qv = points_q.min(p) with (p.x + p.y);
+      if (points_qv[0].x != 1 || points_qv[0].y != 2) $stop;
+
       qv = q.max;
       v = $sformatf("%p", qv); `checks(v, "'{'h4} ");
+      points_qv = points_q.max(p) with (p.x + p.y);
+      if (points_qv[0].x != 2 || points_qv[0].y != 4) $stop;
 
       qv = qe.min;
       v = $sformatf("%p", qv); `checks(v, "'{}");
+      qv = qe.min(x) with (x + 1);
+      v = $sformatf("%p", qv); `checks(v, "'{}");
       qv = qe.max;
+      v = $sformatf("%p", qv); `checks(v, "'{}");
+      qv = qe.max(x) with (x + 1);
       v = $sformatf("%p", qv); `checks(v, "'{}");
 
       // Reduction methods

--- a/test_regress/t/t_assoc_method.v
+++ b/test_regress/t/t_assoc_method.v
@@ -9,11 +9,14 @@
 `define checks(gotv,expv) do if ((gotv) !== (expv)) begin $write("%%Error: %s:%0d:  got='%s' exp='%s'\n", `__FILE__,`__LINE__, (gotv), (expv)); `stop; end while(0);
 
 module t (/*AUTOARG*/);
+   typedef struct { int x, y; } point;
    initial begin
       int q[int];
       int qe[int];  // Empty
       int qv[$];  // Value returns
       int qi[$];  // Index returns
+      point points_q[int];
+      point points_qv[$];
       int i;
       string v;
 
@@ -36,6 +39,16 @@ module t (/*AUTOARG*/);
       v = $sformatf("%p", qi); `checks(v, "'{'ha, 'hb, 'hd, 'he} ");
       qi = qe.unique_index;
       v = $sformatf("%p", qi); `checks(v, "'{}");
+
+      points_q[0] = point'{1, 2};
+      points_q[1] = point'{2, 4};
+      points_q[5] = point'{1, 4};
+
+      points_qv = points_q.unique(p) with (p.x);
+      `checkh(points_qv.size, 2);
+      qi = points_q.unique_index(p) with (p.x + p.y);
+      qi.sort;
+      v = $sformatf("%p", qi); `checks(v, "'{'h0, 'h1, 'h5} ");
 
       // These require an with clause or are illegal
       // TODO add a lint check that with clause is provided


### PR DESCRIPTION
It adds support for `with` clause to the following methods of associative array: `min`, `max`, `unique` and `unique_index`.