### PR TITLE
Fix unexpected RefDType

### DIFF
--- a/src/V3EmitCFunc.h
+++ b/src/V3EmitCFunc.h
@@ -383,7 +383,8 @@ public:
     void visit(AstAssocSel* nodep) override {
         iterateAndNextConstNull(nodep->fromp());
         putbs(".at(");
-        AstAssocArrayDType* const adtypep = VN_AS(nodep->fromp()->dtypep(), AssocArrayDType);
+        AstAssocArrayDType* const adtypep
+            = VN_AS(nodep->fromp()->dtypep()->skipRefp(), AssocArrayDType);
         UASSERT_OBJ(adtypep, nodep, "Associative select on non-associative type");
         if (adtypep->keyDTypep()->isWide()) {
             emitCvtWideArray(nodep->bitp(), nodep->fromp());
@@ -395,7 +396,8 @@ public:
     void visit(AstWildcardSel* nodep) override {
         iterateAndNextConstNull(nodep->fromp());
         putbs(".at(");
-        AstWildcardArrayDType* const adtypep = VN_AS(nodep->fromp()->dtypep(), WildcardArrayDType);
+        AstWildcardArrayDType* const adtypep
+            = VN_AS(nodep->fromp()->dtypep()->skipRefp(), WildcardArrayDType);
         UASSERT_OBJ(adtypep, nodep, "Wildcard select on non-wildcard-associative type");
         iterateAndNextConstNull(nodep->bitp());
         puts(")");

--- a/test_regress/t/t_assoc.v
+++ b/test_regress/t/t_assoc.v
@@ -23,7 +23,8 @@ module t (/*AUTOARG*/
       begin
          // Type
          typedef bit [3:0] nibble_t;
-         string a [nibble_t];
+         typedef string dict_t [nibble_t];
+         dict_t a;
          string b [nibble_t];
          nibble_t k;
          string v;


### PR DESCRIPTION
This fixes a problem with emitting assoc arrays declared using a typedefed type.

Without the change, the included test causes cast failure (Assoc expected but got RefDType). The solution adds missing skipRefp in a type dereference.

I made a similar change in the corresponding code for wildcards, but couldn't test it due to https://github.com/verilator/verilator/issues/4336.
