### PR TITLE
Update V3Error.h

### DIFF
--- a/src/V3Error.h
+++ b/src/V3Error.h
@@ -592,12 +592,12 @@ inline void v3errorEndFatal(std::ostringstream& sstr)
 #define UINFO(level, stmsg) \
     do { \
         if (VL_UNCOVERABLE(debug() >= (level))) { \
-            cout << "- " << V3Error::lineStr(__FILE__, __LINE__) << stmsg; \
+            std::cout << "- " << V3Error::lineStr(__FILE__, __LINE__) << stmsg; \
         } \
     } while (false)
 #define UINFONL(level, stmsg) \
     do { \
-        if (VL_UNCOVERABLE(debug() >= (level))) { cout << stmsg; } \
+        if (VL_UNCOVERABLE(debug() >= (level))) { std::cout << stmsg; } \
     } while (false)
 
 #ifdef VL_DEBUG


### PR DESCRIPTION
cout need to be called by std::cout

We appreciate your contributing to Verilator.  If this is your first commit, please add your name to docs/CONTRIBUTORS, and read our contributing guidelines in docs/CONTRIBUTING.rst.
