### PR TITLE
Support string replication with variable

### DIFF
--- a/test_regress/t/t_math_repl_bad.out
+++ b/test_regress/t/t_math_repl_bad.out
@@ -8,15 +8,12 @@
       |         ^
                       ... For warning description see https://verilator.org/warn/WIDTHEXPAND?v=latest
                       ... Use "/* verilator lint_off WIDTHEXPAND */" and lint_on around source to disable this message.
-%Error: t/t_math_repl_bad.v:13:12: Expecting expression to be constant, but can't convert a TESTPLUSARGS to constant.
-                                 : ... In instance t
-   13 |       o = {$test$plusargs("NON-CONSTANT") {1'b1}};   
-      |            ^~~~~~~~~~~~~~
 %Error: t/t_math_repl_bad.v:13:43: Replication value isn't a constant.
                                  : ... In instance t
    13 |       o = {$test$plusargs("NON-CONSTANT") {1'b1}};   
       |                                           ^
-%Error: Internal Error: t/t_math_repl_bad.v:13:9: ../V3Width.cpp:#: Node has no type
-                                                : ... In instance t
+%Warning-WIDTHEXPAND: t/t_math_repl_bad.v:13:9: Operator ASSIGN expects 32 bits on the Assign RHS, but Assign RHS's REPLICATE generates 1 bits.
+                                              : ... In instance t
    13 |       o = {$test$plusargs("NON-CONSTANT") {1'b1}};   
       |         ^
+%Error: Exiting due to

--- a/test_regress/t/t_string_repl.pl
+++ b/test_regress/t/t_string_repl.pl
@@ -1,0 +1,21 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2022 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_string_repl.v
+++ b/test_regress/t/t_string_repl.v
@@ -1,0 +1,45 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// Use this file as a template for submitting bugs, etc.
+// This module takes a single clock input, and should either
+//      $write("*-* All Finished *-*\n");
+//      $finish;
+// on success, or $stop.
+//
+// The code as shown applies a random vector to the Test
+// module, then calculates a CRC on the Test module's outputs.
+//
+// **If you do not wish for your code to be released to the public
+// please note it here, otherwise:**
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2023 by Wilson Snyder.
+// SPDX-License-Identifier: CC0-1.0
+
+module t(/*AUTOARG*/
+   // Inputs
+   clk
+   );
+   input clk;
+
+   integer cyc = 0;
+
+   string s;
+
+   // Test loop
+   always @ (posedge clk) begin
+      cyc <= cyc + 1;
+      s = {cyc{"*"}};
+      if (cyc != s.len()) $stop;
+      if (cyc == 0 && s != "") $stop;
+      if (cyc == 1 && s != "*") $stop;
+      if (cyc == 2 && s != "**") $stop;
+      if (cyc == 3 && s != "***") $stop;
+      if (cyc == 4 && s != "****") $stop;
+      if (cyc == 5 && s != "*****") $stop;
+      if (cyc == 5) begin
+         $write("*-* All Finished *-*\n");
+         $finish;
+      end
+   end
+endmodule


### PR DESCRIPTION
This change allows using variables in exprs like `{var{arg}}` when the arg or the expected result is a string.

In the general case, replication with a variable is disallowed but the standard makes an exception for strings.
