### PR TITLE
Fix wildcard referring types (#4336)

### DIFF
--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -2121,6 +2121,10 @@ private:
                 v3Global.rootp()->typeTablep()->addTypesp(newp);
             }
         }
+        if (AstWildcardArrayDType* const wildp
+            = VN_CAST(nodep->dtypeSkipRefp(), WildcardArrayDType)) {
+            nodep->dtypep(wildp);  // Skip RefDType like for other dynamic array types
+        }
         if (VN_IS(nodep->dtypep()->skipRefToConstp(), ConstDType)) nodep->isConst(true);
         // Parameters if implicit untyped inherit from what they are assigned to
         const AstBasicDType* const bdtypep = VN_CAST(nodep->dtypep(), BasicDType);

--- a/test_regress/t/t_assoc_wildcard.v
+++ b/test_regress/t/t_assoc_wildcard.v
@@ -22,9 +22,14 @@ module t (/*AUTOARG*/
       cyc <= cyc + 1;
       begin
          // Wildcard
+         typedef string dict_t [*];
          string a [*] = '{default: "nope", "BBBBB": "fooing", 23'h434343: "baring"};
+         dict_t b = '{default: "nope", "BBBBB": "fooing", 23'h434343: "baring"};
          int k;
          string v;
+
+         v = b["CCC"]; `checks(v, "baring");
+         v = b["BBBBB"]; `checks(v, "fooing");
 
          v = a["CCC"]; `checks(v, "baring");
          v = a["BBBBB"]; `checks(v, "fooing");


### PR DESCRIPTION
This fixes https://github.com/verilator/verilator/issues/4336 by skipping refp in vars that have a wildcard-referring type.

Effectively the same is already done with other types of arrays.

