### PR TITLE
Remove conversion from if/else to cond operator

### DIFF
--- a/src/V3Const.cpp
+++ b/src/V3Const.cpp
@@ -899,7 +899,6 @@ private:
     bool m_doV = false;  // Verilog, not C++ conversion
     bool m_doGenerate = false;  // Postpone width checking inside generate
     bool m_hasJumpDelay = false;  // JumpGo or Delay under this while
-    bool m_underRecFunc = false;  // Under a recursive function
     AstNodeModule* m_modp = nullptr;  // Current module
     const AstArraySel* m_selp = nullptr;  // Current select
     const AstNode* m_scopep = nullptr;  // Current scope
@@ -3148,11 +3147,6 @@ private:
             // Just a simple constant string - the formatting is pointless
             VL_DO_DANGLING(replaceConstString(nodep, nodep->name()), nodep);
         }
-    }
-    void visit(AstNodeFTask* nodep) override {
-        VL_RESTORER(m_underRecFunc);
-        if (nodep->recursive()) m_underRecFunc = true;
-        iterateChildren(nodep);
     }
 
     void visit(AstFuncRef* nodep) override {

--- a/test_regress/t/t_class_if_assign.pl
+++ b/test_regress/t/t_class_if_assign.pl
@@ -1,0 +1,21 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2022 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_class_if_assign.v
+++ b/test_regress/t/t_class_if_assign.v
@@ -1,0 +1,40 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed into the Public Domain, for any use,
+// without warranty, 2023 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+class Cls;
+   int x;
+   function new;
+      x = 1;
+   endfunction
+endclass
+
+class ExtendCls extends Cls;
+   function new;
+      x = 2;
+   endfunction
+endclass
+
+class AnotherExtendCls extends Cls;
+   function new;
+      x = 3;
+   endfunction
+endclass
+
+module t (/*AUTOARG*/);
+   initial begin
+      Cls cls = new;
+      ExtendCls ext_cls = new;
+      AnotherExtendCls an_ext_cls = new;
+
+      if (cls.x == 1) cls = ext_cls;
+      else cls = an_ext_cls;
+
+      if (cls.x != 2) $stop;
+
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end
+endmodule

--- a/test_regress/t/t_optm_if_array.v
+++ b/test_regress/t/t_optm_if_array.v
@@ -27,21 +27,11 @@ module t (/*AUTOARG*/
    end
 
    always @(posedge clk) begin
-      if ((rstn_r == 0)) begin // Will optimize away
-         dinit[0] <= '0;
-      end
-      else begin
-         dinit[0] <= {31'd0, zero};
-      end
+      dinit[0] <= (rstn_r == 0) ? '0 : {31'd0, zero};
    end
 
    always @(posedge clk) begin
-      if ((rstn_r == 0)) begin // Will optimize away
-         dinit[1] <= 1234;
-      end
-      else begin
-         dinit[1] <= 1234;
-      end
+      dinit[1] <= (rstn_r == 0) ? 1234 : 1234;
    end
 
    initial begin

--- a/test_regress/t/t_var_life.pl
+++ b/test_regress/t/t_var_life.pl
@@ -15,7 +15,7 @@ compile(
     );
 
 if ($Self->{vlt_all}) {
-    file_grep($Self->{stats}, qr/Optimizations, Lifetime assign deletions\s+(\d+)/i, 4);
+    file_grep($Self->{stats}, qr/Optimizations, Lifetime assign deletions\s+(\d+)/i, 3);
     file_grep($Self->{stats}, qr/Optimizations, Lifetime constant prop\s+(\d+)/i, 2);
 }
 


### PR DESCRIPTION
The conversion from `if/else` statements to condition operator causes problems. One problem is that Verilator doesn't support short-circuit evaluation in the condition operator, which may lead to wrong results if the statements have side effects. Another problem is that the dtype assigned to `AstNodeCond` node may be wrong if its expressions are of different types, for example if they are of class types that derive from a common base class (I added a test with that case).

The problem with types is not hard to fix, but I think that this optimization doesn't improve the performance significantly, so maybe it would be better to remove it and leave it to c++ compiler?