### PR TITLE
Fix comparison of class objects

### DIFF
--- a/include/verilated_types.h
+++ b/include/verilated_types.h
@@ -1509,9 +1509,13 @@ public:
     operator bool() const { return m_objp; }
     // In SV A == B iff both are handles to the same object (IEEE 1800-2017 8.4)
     template <typename T_OtherClass>
-    bool operator==(const VlClassRef<T_OtherClass>& rhs) const { return m_objp == rhs.m_objp; };
+    bool operator==(const VlClassRef<T_OtherClass>& rhs) const {
+        return m_objp == rhs.m_objp;
+    };
     template <typename T_OtherClass>
-    bool operator!=(const VlClassRef<T_OtherClass>& rhs) const { return m_objp != rhs.m_objp; };
+    bool operator!=(const VlClassRef<T_OtherClass>& rhs) const {
+        return m_objp != rhs.m_objp;
+    };
 };
 
 template <typename T, typename U>

--- a/include/verilated_types.h
+++ b/include/verilated_types.h
@@ -1508,8 +1508,10 @@ public:
     // For 'if (ptr)...'
     operator bool() const { return m_objp; }
     // In SV A == B iff both are handles to the same object (IEEE 1800-2017 8.4)
-    bool operator==(const VlClassRef& rhs) const { return m_objp == rhs.m_objp; };
-    bool operator!=(const VlClassRef& rhs) const { return m_objp != rhs.m_objp; };
+    template <typename T_OtherClass>
+    bool operator==(const VlClassRef<T_OtherClass>& rhs) const { return m_objp == rhs.m_objp; };
+    template <typename T_OtherClass>
+    bool operator!=(const VlClassRef<T_OtherClass>& rhs) const { return m_objp != rhs.m_objp; };
 };
 
 template <typename T, typename U>

--- a/test_regress/t/t_class_compare.v
+++ b/test_regress/t/t_class_compare.v
@@ -14,13 +14,22 @@ class Cls;
    int i;
 endclass
 
+class ExtendCls extends Cls;
+endclass
+
 module t;
    initial begin
       Cls a = new;
       Cls b = new;
+      ExtendCls ext = new;
       `check_ne(a, b)
+      `check_ne(a, ext)
+      `check_ne(ext, a)
       a = b;
       `check_eq(a, b)
+      a = ext;
+      `check_eq(a, ext)
+      `check_eq(ext, a)
       $write("*-* All Finished *-*\n");
       $finish;
    end


### PR DESCRIPTION
Currently on master, the comparison of class objects throws compilation error if the object on the LHS of `==` is of a derived class, but on the RHS there is an object of the base class. The problem occurs, because the `==` and `!=` operators expects their operands to be of the same type (`VlClassRef` of the same class).
This PR fixes it.