### PR TITLE
Update class cache in V3Task instead of doing that in V3Timing

### DIFF
--- a/src/V3Task.cpp
+++ b/src/V3Task.cpp
@@ -1379,6 +1379,7 @@ private:
             m_insStmtp = nullptr;
             m_modNCalls = 0;
             iterateChildren(nodep);
+            if (AstClass* classp = VN_CAST(nodep, Class)) classp->repairCache();
         }
     }
     void visit(AstWith* nodep) override {

--- a/src/V3Timing.cpp
+++ b/src/V3Timing.cpp
@@ -101,15 +101,11 @@ private:
     };
 
     // NODE STATE
-    //  AstClass::user1()                        -> bool.               Set true if the class
-    //                                                                  member cache has been
-    //                                                                  refreshed.
     //  Ast{NodeProcedure,CFunc,Begin}::user2()  -> int.                Set to >= T_SUSP if
     //                                                                  process/task suspendable
     //                                                                  and to T_PROC if it
     //                                                                  needs process metadata.
     //  Ast{NodeProcedure,CFunc,Begin}::user3()  -> DependencyVertex*.  Vertex in m_depGraph
-    const VNUser1InUse m_user1InUse;
     const VNUser2InUse m_user2InUse;
     const VNUser3InUse m_user3InUse;
 
@@ -164,8 +160,6 @@ private:
         TimingDependencyVertex* const vxp = getDependencyVertex(nodep);
         if (nodep->needProcess()) nodep->user2(T_PROC);
         if (!m_classp) return;
-        // If class method (possibly overrides another method)
-        if (!m_classp->user1SetOnce()) m_classp->repairCache();
 
         // Go over overridden functions
 
@@ -182,7 +176,6 @@ private:
                 // actually overridden by our method. If this causes a problem, traverse to
                 // the root of the inheritance hierarchy and check if the original method is
                 // virtual or not.
-                if (!cextp->classp()->user1SetOnce()) cextp->classp()->repairCache();
                 if (auto* const overriddenp
                     = VN_CAST(cextp->classp()->findMember(nodep->name()), CFunc)) {
                     setTimingFlag(nodep, overriddenp->user2());


### PR DESCRIPTION
`V3Task` does not update class cache. Instead `V3Timing` performs that when it needs to do a lookup. This is not only inconsistent, with the way cache is updated in other places. It's also overcomplicated and can cause problems in development, or maybe even in end-usage, as the cache remains invalid after that stage  and won't be fixed if `V3Timing` is skipped. This means that after that stage look-ups can return pointers to nodes that are no longer members of the class and could've even been deleted. This has already caused me quite a headache in #4321.