### PR TITLE
Propagate class timescale to class package

### DIFF
--- a/src/V3Class.cpp
+++ b/src/V3Class.cpp
@@ -67,6 +67,7 @@ private:
         nodep->editCountInc();
         nodep->classOrPackagep(packagep);
         packagep->classp(nodep);
+        packagep->timeunit(nodep->timeunit());
         v3Global.rootp()->addModulesp(packagep);
         // Add package to hierarchy
         AstCell* const cellp = new AstCell{packagep->fileline(),

--- a/test_regress/t/t_timing_class_static_delay.pl
+++ b/test_regress/t/t_timing_class_static_delay.pl
@@ -1,0 +1,23 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2023 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(vlt => 1);
+
+compile(
+    verilator_flags2 => ["--exe --main --timing"],
+    make_main => 0,
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_timing_class_static_delay.v
+++ b/test_regress/t/t_timing_class_static_delay.v
@@ -1,0 +1,30 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2023 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+`define DELAY 10
+
+class Foo;
+  task wait_dynamically();
+    #`DELAY;
+  endtask
+
+  static task wait_statically();
+    #`DELAY;
+  endtask
+endclass
+
+module t;
+  Foo foo = new;
+
+  initial begin
+    foo.wait_dynamically();
+    if ($time != `DELAY) $stop;
+    Foo::wait_statically();
+    if ($time != 2*`DELAY) $stop;
+    $write("*-* All Finished *-*\n");
+    $finish;
+  end
+endmodule


### PR DESCRIPTION
Without this propagation, the class package's `timeunit` is set to `NONE`. This breaks the delay scaling in `V3Timing`, resulting in all delays in static methods being reduced to `#0`.