### PR TITLE
Add V3Broken check for cache

### DIFF
--- a/src/V3AstNodeOther.h
+++ b/src/V3AstNodeOther.h
@@ -2172,6 +2172,7 @@ public:
         const auto it = m_members.find(name);
         return (it == m_members.end()) ? nullptr : it->second;
     }
+    int memberCount() const { return m_members.size(); }
     bool isExtended() const { return m_extended; }
     void isExtended(bool flag) { m_extended = flag; }
     bool isInterfaceClass() const { return m_interfaceClass; }

--- a/src/V3LinkLevel.cpp
+++ b/src/V3LinkLevel.cpp
@@ -88,6 +88,12 @@ void V3LinkLevel::modSortByLevel() {
     UASSERT_OBJ(!v3Global.rootp()->modulesp(), v3Global.rootp(), "Unlink didn't work");
     for (AstNodeModule* nodep : mods) v3Global.rootp()->addModulesp(nodep);
     UINFO(9, "modSortByLevel() done\n");  // Comment required for gcc4.6.3 / bug666
+
+    v3Global.rootp()->forall([](AstClass* nodep) -> bool {
+        nodep->repairCache();
+        return true;
+    });
+
     V3Global::dumpCheckGlobalTree("cells", false, dumpTreeLevel() >= 3);
 }
 


### PR DESCRIPTION
See #4347 for the context.

There are some places in which classes get modified in ways that would require their member-lookup cache to be updated with a call to `repairCache`, however this call is missing from some of them.