### PR TITLE
Fix string concatenations

### DIFF
--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -617,9 +617,11 @@ private:
         }
         if (m_vup->final()) {
             if (nodep->lhsp()->isString() || nodep->rhsp()->isString()) {
-                AstNode* const newp
-                    = new AstConcatN{nodep->fileline(), nodep->lhsp()->unlinkFrBack(),
-                                     nodep->rhsp()->unlinkFrBack()};
+                AstNodeExpr* lhsp = nodep->lhsp()->unlinkFrBack();
+                AstNodeExpr* rhsp = nodep->rhsp()->unlinkFrBack();
+                if (!lhsp->isString()) lhsp = new AstCvtPackString{lhsp->fileline(), lhsp};
+                if (!rhsp->isString()) rhsp = new AstCvtPackString{rhsp->fileline(), rhsp};
+                AstNode* const newp = new AstConcatN{nodep->fileline(), lhsp, rhsp};
                 nodep->replaceWith(newp);
                 VL_DO_DANGLING(pushDeletep(nodep), nodep);
                 return;

--- a/test_regress/t/t_concat_string.pl
+++ b/test_regress/t/t_concat_string.pl
@@ -1,0 +1,21 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2022 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_concat_string.v
+++ b/test_regress/t/t_concat_string.v
@@ -1,0 +1,24 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed into the Public Domain, for any use,
+// without warranty, 2023 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+typedef enum {efgh} en;
+
+module t (/*AUTOARG*/);
+   initial begin
+      en e;
+      string s;
+
+      s = {"a", "b"};
+      if (s != "ab") $stop;
+
+      e = efgh;
+      s = {"abcd", e.name(), "ijkl"};
+      if (s != "abcdefghijkl") $stop;
+
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end
+endmodule

--- a/test_regress/t/t_xml_debugcheck.out
+++ b/test_regress/t/t_xml_debugcheck.out
@@ -543,15 +543,17 @@
             <assign loc="d,52,14,52,15" dtype_id="10">
               <concatn loc="d,52,20,52,21" dtype_id="10">
                 <varref loc="d,52,17,52,20" name="t.all" dtype_id="10"/>
-                <arraysel loc="d,52,24,52,28" dtype_id="10">
-                  <varref loc="d,16,12,16,16" name="__Venumtab_enum_name2" dtype_id="16"/>
-                  <and loc="d,52,24,52,28" dtype_id="13">
-                    <const loc="d,52,24,52,28" name="32&apos;h7" dtype_id="14"/>
-                    <ccast loc="d,52,22,52,23" dtype_id="13">
-                      <varref loc="d,52,22,52,23" name="t.unnamedblk1.e" dtype_id="13"/>
-                    </ccast>
-                  </and>
-                </arraysel>
+                <cvtpackstring loc="d,52,24,52,28" dtype_id="10">
+                  <arraysel loc="d,52,24,52,28" dtype_id="10">
+                    <varref loc="d,16,12,16,16" name="__Venumtab_enum_name2" dtype_id="16"/>
+                    <and loc="d,52,24,52,28" dtype_id="13">
+                      <const loc="d,52,24,52,28" name="32&apos;h7" dtype_id="14"/>
+                      <ccast loc="d,52,22,52,23" dtype_id="13">
+                        <varref loc="d,52,22,52,23" name="t.unnamedblk1.e" dtype_id="13"/>
+                      </ccast>
+                    </and>
+                  </arraysel>
+                </cvtpackstring>
               </concatn>
               <varref loc="d,52,10,52,13" name="t.all" dtype_id="10"/>
             </assign>
@@ -578,7 +580,7 @@
         <assign loc="d,55,11,55,12" dtype_id="10">
           <concatn loc="d,55,17,55,18" dtype_id="10">
             <varref loc="d,55,14,55,17" name="t.all" dtype_id="10"/>
-            <const loc="d,16,12,16,16" name="&quot;E04&quot;" dtype_id="10"/>
+            <const loc="d,55,21,55,25" name="&quot;E04&quot;" dtype_id="10"/>
           </concatn>
           <varref loc="d,55,7,55,10" name="t.all" dtype_id="10"/>
         </assign>


### PR DESCRIPTION
`AstConcatN`expects arguments to be of string types. String constants sometimes have types of logic arrays, so they require to be wrapped into `AstCvtPackString`.
Currently on master, the expression `{"abcd", e.name(), "ijkl"}` causes c++ compile error.