### PR TITLE
Fix selects on unpacked structs

### DIFF
--- a/src/V3AstNodeExpr.h
+++ b/src/V3AstNodeExpr.h
@@ -1932,7 +1932,10 @@ public:
     void name(const string& name) override { m_name = name; }
     string emitVerilog() override { V3ERROR_NA_RETURN(""); }
     string emitC() override { V3ERROR_NA_RETURN(""); }
-    bool cleanOut() const override { return VN_IS(fromp()->dtypep()->skipRefp(), StructDType); }
+    bool cleanOut() const override {
+        // Not a union
+        return VN_IS(fromp()->dtypep()->skipRefp(), StructDType);
+    }
     bool same(const AstNode* samep) const override {
         const AstStructSel* const sp = static_cast<const AstStructSel*>(samep);
         return m_name == sp->m_name;

--- a/src/V3AstNodeExpr.h
+++ b/src/V3AstNodeExpr.h
@@ -1932,7 +1932,7 @@ public:
     void name(const string& name) override { m_name = name; }
     string emitVerilog() override { V3ERROR_NA_RETURN(""); }
     string emitC() override { V3ERROR_NA_RETURN(""); }
-    bool cleanOut() const override { return false; }
+    bool cleanOut() const override { return true; }
     bool same(const AstNode* samep) const override {
         const AstStructSel* const sp = static_cast<const AstStructSel*>(samep);
         return m_name == sp->m_name;

--- a/src/V3AstNodeExpr.h
+++ b/src/V3AstNodeExpr.h
@@ -1914,7 +1914,7 @@ public:
     bool same(const AstNode* /*samep*/) const override { return true; }
 };
 class AstStructSel final : public AstNodeExpr {
-    // Unpacked struct member access
+    // Unpacked struct/union member access
     // Parents: math|stmt
     // Children: varref, math
     // @astgen op1 := fromp : AstNodeExpr
@@ -1932,7 +1932,7 @@ public:
     void name(const string& name) override { m_name = name; }
     string emitVerilog() override { V3ERROR_NA_RETURN(""); }
     string emitC() override { V3ERROR_NA_RETURN(""); }
-    bool cleanOut() const override { return true; }
+    bool cleanOut() const override { return VN_IS(fromp()->dtypep()->skipRefp(), StructDType); }
     bool same(const AstNode* samep) const override {
         const AstStructSel* const sp = static_cast<const AstStructSel*>(samep);
         return m_name == sp->m_name;

--- a/src/V3Clean.cpp
+++ b/src/V3Clean.cpp
@@ -235,11 +235,6 @@ private:
         operandTriop(nodep);
         setClean(nodep, nodep->cleanOut());
     }
-    void visit(AstStructSel* nodep) override {
-        iterateChildren(nodep);
-        AstStructDType* dtypep = VN_CAST(nodep->dtypep()->skipRefp(), StructDType);
-        setClean(nodep, dtypep && !dtypep->packed());
-    }
     void visit(AstUCFunc* nodep) override {
         iterateChildren(nodep);
         computeCppWidth(nodep);

--- a/test_regress/t/t_unpacked_struct_sel.pl
+++ b/test_regress/t/t_unpacked_struct_sel.pl
@@ -1,0 +1,21 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2022 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_unpacked_struct_sel.v
+++ b/test_regress/t/t_unpacked_struct_sel.v
@@ -1,0 +1,20 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed into the Public Domain, for any use,
+// without warranty, 2023 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+typedef struct {
+   bit [3:0] byte_en;
+} my_struct;
+
+module t (/*AUTOARG*/);
+   initial begin
+      my_struct ms;
+      ms.byte_en[0] = 1;
+      if (ms.byte_en[0] != 1) $stop;
+
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end
+endmodule


### PR DESCRIPTION
The handling of AstStructSel in V3Clean requires a small change. Instead of `dtypep` of AstStructSel (which means the dtype of the result of the select), we should check the dtypep of object on which the select is performed. If it is a struct (I think that AstStructSel is only used with unpacked structs/unions), no bit masks are required. AstNodeExpr has a special method to mark whether the node requires a cleaning or not, so I changed that method and no special visit in V3Clean is needed.