### PR TITLE
Fix select operation on assoc array with wide keys

### DIFF
--- a/src/V3EmitCFunc.h
+++ b/src/V3EmitCFunc.h
@@ -386,11 +386,7 @@ public:
         AstAssocArrayDType* const adtypep
             = VN_AS(nodep->fromp()->dtypep()->skipRefp(), AssocArrayDType);
         UASSERT_OBJ(adtypep, nodep, "Associative select on non-associative type");
-        if (adtypep->keyDTypep()->isWide()) {
-            emitCvtWideArray(nodep->bitp(), nodep->fromp());
-        } else {
-            iterateAndNextConstNull(nodep->bitp());
-        }
+        iterateAndNextConstNull(nodep->bitp());
         puts(")");
     }
     void visit(AstWildcardSel* nodep) override {

--- a/test_regress/t/t_assoc.v
+++ b/test_regress/t/t_assoc.v
@@ -102,8 +102,11 @@ module t (/*AUTOARG*/
       begin
          // Wide-wides - need special array container classes, ick.
          logic [91:2] a [ logic [65:1] ];
+         int          b [ bit [99:0] ];
          a[~65'hfe] = ~ 90'hfee;
          `checkh(a[~65'hfe], ~ 90'hfee);
+         b[100'b1] = 1;
+         `checkh(b[100'b1], 1);
       end
 
       begin


### PR DESCRIPTION
It fixes select operation on assoc arrays that have wide keys and non-wide values.
Currently on master, a compile error is thrown, because the call of `VL_CVT_W_A` is inserted:
https://github.com/verilator/verilator/blob/23fe5c1b9386228afe80a42b95e91cde8462d1c4/include/verilated_types.h#L268-L273
and the type of the 2nd argument doesn't match with the type of the values when it isn't wide.
I think that the call of this function is not needed, because arguments of methods of assoc arrays should already have correct types.