### PR TITLE
Fix methods with wide output

### DIFF
--- a/src/V3Task.cpp
+++ b/src/V3Task.cpp
@@ -1115,7 +1115,7 @@ private:
                                        "other than a single 'logic' (IEEE 1800-2017 35.5.5)");
                     }
                 }
-            } else {
+            } else if (nodep->taskPublic()) {
                 if (portp->isWide()) {
                     nodep->v3warn(E_UNSUPPORTED,
                                   "Unsupported: Public functions with return > 64 bits wide.\n"

--- a/test_regress/t/t_class_method_struct.pl
+++ b/test_regress/t/t_class_method_struct.pl
@@ -1,0 +1,21 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2020 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_class_method_struct.v
+++ b/test_regress/t/t_class_method_struct.v
@@ -1,0 +1,34 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2023 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+typedef struct packed {
+   int         x;
+   int         y;
+   int         z;
+} my_struct;
+
+class Cls;
+   function my_struct get_struct;
+      my_struct s;
+      s.x = 1;
+      s.y = 2;
+      s.z = 3;
+      return s;
+   endfunction
+endclass : Cls
+
+module t (/*AUTOARG*/);
+   initial begin
+      Cls c = new;
+      my_struct s = c.get_struct;
+      if (s.x != 1) $stop;
+      if (s.y != 2) $stop;
+      if (s.z != 3) $stop;
+
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end
+endmodule


### PR DESCRIPTION
Currently on master, an error is thrown when the size of a method output is bigger than 64. This error shouldn't be thrown in case of methods, because they aren't exported and they are converted to `void` methods with the output passed by a reference argument.