### PR TITLE
Fix assign to input var in methods

### DIFF
--- a/src/V3LinkLValue.cpp
+++ b/src/V3LinkLValue.cpp
@@ -41,7 +41,6 @@ private:
     bool m_setContinuously = false;  // Set that var has some continuous assignment
     bool m_setStrengthSpecified = false;  // Set that var has assignment with strength specified.
     VAccess m_setRefLvalue;  // Set VarRefs to lvalues for pin assignments
-    AstNodeFTask* m_ftaskp = nullptr;  // Function or task we're inside
 
     // VISITs
     // Result handing
@@ -55,7 +54,8 @@ private:
                 // so it is needed to check only if m_setContinuously is true
                 if (m_setStrengthSpecified) nodep->varp()->hasStrengthAssignment(true);
             }
-            if (nodep->access().isWriteOrRW() && !m_ftaskp && nodep->varp()->isReadOnly()) {
+            if (nodep->access().isWriteOrRW() && !nodep->varp()->isFuncLocal()
+                && nodep->varp()->isReadOnly()) {
                 nodep->v3warn(ASSIGNIN,
                               "Assigning to input/const variable: " << nodep->prettyNameQ());
             }
@@ -283,11 +283,6 @@ private:
             // If it doesn't have to be set to WRITE, it means that it is READ.
             nodep->access(VAccess::READ);
         }
-        iterateChildren(nodep);
-    }
-    void visit(AstNodeFTask* nodep) override {
-        VL_RESTORER(m_ftaskp);
-        m_ftaskp = nodep;
         iterateChildren(nodep);
     }
     void visit(AstNodeFTaskRef* nodep) override {

--- a/test_regress/t/t_func_modify_input.pl
+++ b/test_regress/t/t_func_modify_input.pl
@@ -1,0 +1,16 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2023 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(vlt => 1);
+
+compile();
+
+ok(1);
+1;

--- a/test_regress/t/t_func_modify_input.v
+++ b/test_regress/t/t_func_modify_input.v
@@ -1,0 +1,13 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2023 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+class foo;
+   function void g(input integer x);
+      f(x);
+   endfunction
+   function void f(inout integer x);
+   endfunction
+endclass


### PR DESCRIPTION
Input arguments can be modified in ftasks, so in V3LinkLValue on a check which disallows writing to input vars, we don't produce an error if we're inside an ftask body. We know this using an ftask pointer in visitor's context.

For method calls, though, the check is first done during re-runs of V3LinkLValue in V3Task where we no longer have access to some ftasks. The ftask pointer stays null, and so the visitor produces an error.

This change modifies the check to use isFuncLocal instead of context vars.
