### PR TITLE
Move VlProcess to verilated_types.h

### DIFF
--- a/include/verilated_timing.h
+++ b/include/verilated_timing.h
@@ -86,36 +86,6 @@ public:
 #endif
 };
 
-//===================================================================
-// VlProcess stores metadata of running processes
-
-class VlProcess final {
-    // MEMBERS
-    int m_state;  // Current state of the process
-
-public:
-    // TYPES
-    enum : int {  // Type int for compatibility with $c
-        FINISHED = 0,
-        RUNNING = 1,
-        WAITING = 2,
-        SUSPENDED = 3,
-        KILLED = 4,
-    };
-
-    // CONSTRUCTORS
-    VlProcess()
-        : m_state{RUNNING} {}
-
-    // METHODS
-    int state() { return m_state; }
-    void state(int s) { m_state = s; }
-};
-
-using VlProcessRef = std::shared_ptr<VlProcess>;
-
-inline std::string VL_TO_STRING(const VlProcessRef& p) { return std::string("process"); }
-
 //=============================================================================
 // VlCoroutineHandle is a non-copyable (but movable) coroutine handle. On resume, the handle is
 // cleared, as we assume that either the coroutine has finished and deleted itself, or, if it got

--- a/include/verilated_types.h
+++ b/include/verilated_types.h
@@ -74,6 +74,36 @@ extern std::string VL_TO_STRING_W(int words, const WDataInP obj);
 #define VL_OUTW(name, msb, lsb, words) VlWide<words> name  ///< Declare output signal, 65+ bits
 
 //===================================================================
+// VlProcess stores metadata of running processes
+
+class VlProcess final {
+    // MEMBERS
+    int m_state;  // Current state of the process
+
+public:
+    // TYPES
+    enum : int {  // Type int for compatibility with $c
+        FINISHED = 0,
+        RUNNING = 1,
+        WAITING = 2,
+        SUSPENDED = 3,
+        KILLED = 4,
+    };
+
+    // CONSTRUCTORS
+    VlProcess()
+        : m_state{RUNNING} {}
+
+    // METHODS
+    int state() { return m_state; }
+    void state(int s) { m_state = s; }
+};
+
+using VlProcessRef = std::shared_ptr<VlProcess>;
+
+inline std::string VL_TO_STRING(const VlProcessRef& p) { return std::string("process"); }
+
+//===================================================================
 // Activity trigger vector
 
 template <std::size_t T_size>  //

--- a/test_regress/t/t_mailbox_notiming.pl
+++ b/test_regress/t/t_mailbox_notiming.pl
@@ -1,0 +1,23 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2023 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    verilator_flags2 => ["--exe --main --no-timing -Wall"],
+    make_main => 0,
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_mailbox_notiming.v
+++ b/test_regress/t/t_mailbox_notiming.v
@@ -1,0 +1,33 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2023 by Wilson Snyder.
+// SPDX-License-Identifier: CC0-1.0
+
+// Methods defined by IEEE:
+//  class mailbox #(type T = dynamic_singular_type) ;
+//     function new(int bound = 0);
+//     function int num();
+//     task put( T message);
+//     function int try_put( T message);
+//     task get( ref T message );
+//     function int try_get( ref T message );
+//     task peek( ref T message );
+//     function int try_peek( ref T message );
+//  endclass
+
+`ifndef MAILBOX_T
+ `define MAILBOX_T mailbox
+`endif
+
+// verilator lint_off DECLFILENAME
+module t(/*AUTOARG*/);
+   `MAILBOX_T #(int) m;
+
+   initial begin
+      m = new(4);
+      if (m.num() != 0) $stop;
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end
+endmodule


### PR DESCRIPTION
This should fix #4362.

Process requirement was decoupled from suspendability in #4321.

So if a design has unsuspendable processes that need a VlProcess instance, it causes a C++ error, as VlProcess is defined in verilated_timing.h.

This changes moves the definiton from verilated_timing.h to verilated_types.h and adds a test that would fail before.
