### PR TITLE
Fix the order of evaluation of function calls

### DIFF
--- a/src/V3Task.cpp
+++ b/src/V3Task.cpp
@@ -1345,7 +1345,7 @@ private:
     AstNode* insertBeforeStmt(AstNode* nodep, AstNode* newp) {
         // Return node that must be visited, if any
         if (debug() >= 9) nodep->dumpTree("-  newstmt: ");
-        UASSERT_OBJ(m_insStmtp, nodep, "Function not underneath a statement");
+        UASSERT_OBJ(m_insStmtp, nodep, "Function call not underneath a statement");
         AstNode* visitp = nullptr;
         if (m_insMode == IM_BEFORE) {
             // Add the whole thing before insertAt

--- a/src/V3Task.cpp
+++ b/src/V3Task.cpp
@@ -350,7 +350,6 @@ private:
     // TYPES
     enum InsertMode : uint8_t {
         IM_BEFORE,  // Pointing at statement ref is in, insert before this
-        IM_AFTER,  // Pointing at last inserted stmt, insert after
         IM_WHILE_PRECOND  // Pointing to for loop, add to body end
     };
     using DpiCFuncs = std::map<const string, std::tuple<AstNodeFTask*, std::string, AstCFunc*>>;
@@ -1353,9 +1352,6 @@ private:
             UINFO(5, "     IM_Before  " << m_insStmtp << endl);
             if (debug() >= 9) newp->dumpTree("-  newfunc: ");
             m_insStmtp->addHereThisAsNext(newp);
-        } else if (m_insMode == IM_AFTER) {
-            UINFO(5, "     IM_After   " << m_insStmtp << endl);
-            m_insStmtp->addNextHere(newp);
         } else if (m_insMode == IM_WHILE_PRECOND) {
             UINFO(5, "     IM_While_Precond " << m_insStmtp << endl);
             AstWhile* const whilep = VN_AS(m_insStmtp, While);
@@ -1365,8 +1361,6 @@ private:
         } else {
             nodep->v3fatalSrc("Unknown InsertMode");
         }
-        m_insMode = IM_AFTER;
-        m_insStmtp = newp;
         return visitp;
     }
 

--- a/test_regress/t/t_func_call_order.pl
+++ b/test_regress/t/t_func_call_order.pl
@@ -1,0 +1,21 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2020 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_func_call_order.v
+++ b/test_regress/t/t_func_call_order.v
@@ -1,0 +1,34 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2023 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+`define checkd(gotv,expv) do if ((gotv) !== (expv)) begin $write("%%Error: %s:%0d:  got=%0d exp=%0d\n", `__FILE__,`__LINE__, (gotv), (expv)); $stop; end while(0);
+
+module t(/*AUTOARG*/);
+   function int assign5;
+      a = 5;
+      return 5;
+   endfunction
+   function int assign3;
+      a = 3;
+      return 3;
+   endfunction
+   function int incr;
+      a++;
+      return a;
+   endfunction
+   int a;
+   int i;
+
+   initial begin
+      a = 1;
+      i = assign5() + assign3() + incr();
+      `checkd(a, 4); `checkd(i, 12);
+
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end
+
+endmodule

--- a/test_regress/t/t_func_call_order.v
+++ b/test_regress/t/t_func_call_order.v
@@ -7,6 +7,7 @@
 `define checkd(gotv,expv) do if ((gotv) !== (expv)) begin $write("%%Error: %s:%0d:  got=%0d exp=%0d\n", `__FILE__,`__LINE__, (gotv), (expv)); $stop; end while(0);
 
 module t(/*AUTOARG*/);
+   int a;
    function int assign5;
       a = 5;
       return 5;
@@ -19,7 +20,6 @@ module t(/*AUTOARG*/);
       a++;
       return a;
    endfunction
-   int a;
    int i;
 
    initial begin

--- a/test_regress/t/t_func_call_order.v
+++ b/test_regress/t/t_func_call_order.v
@@ -20,12 +20,20 @@ module t(/*AUTOARG*/);
       a++;
       return a;
    endfunction
+   function int assign5_return_arg(int x);
+      a = 5;
+      return x;
+   endfunction
    int i;
 
    initial begin
       a = 1;
       i = assign5() + assign3() + incr();
       `checkd(a, 4); `checkd(i, 12);
+
+      a = 1;
+      i = assign5_return_arg(assign3()+incr());
+      `checkd(a, 5); `checkd(i, 7);
 
       $write("*-* All Finished *-*\n");
       $finish;


### PR DESCRIPTION
Function calls within the same expression are evaluated in a wrong order. It leads to wrong results if the functions have side effects.
I think there is no need to update the pointer pointing to the statement before which the next function body should be inserted (`m_insStmtp`). The function calls within the same expression are handled by V3Task in the same order in which they should be evaluated. If the pointer isn't updated, they are put in that order before the statement that `m_insStmtp` indicates.
This PR removes the update of that pointer.

I noticed that Verilator throws error `Function not underneath a statement` if two function calls are in the condition of a `while` loop. It happens on master too. I will try to fix it. I also changed that error message, because the problem is with the call, not with the function.