### PR TITLE
Add support for static method calls as default values of function arguments

### DIFF
--- a/src/V3Task.cpp
+++ b/src/V3Task.cpp
@@ -1546,6 +1546,13 @@ private:
         iterateChildren(nodep);
         m_insStmtp = nullptr;  // Next thing should be new statement
     }
+    void visit(AstVar* nodep) override {
+        if (nodep->isFuncLocal() && nodep->direction() == VDirection::INPUT && nodep->valuep()) {
+            // It's the default value of optional argument.
+            // Such values are added to function calls on this stage.
+            pushDeletep(nodep->valuep()->unlinkFrBack());
+        }
+    }
     void visit(AstStmtExpr* nodep) override {
         m_insMode = IM_BEFORE;
         m_insStmtp = nodep;

--- a/src/V3Task.cpp
+++ b/src/V3Task.cpp
@@ -1658,6 +1658,15 @@ V3TaskConnects V3Task::taskConnects(AstNodeFTaskRef* nodep, AstNode* taskStmtsp)
                                << portp->prettyNameQ() << " in function call to "
                                << nodep->taskp()->prettyTypeName());
                 newvaluep = new AstConst{nodep->fileline(), AstConst::Unsized32{}, 0};
+            } else if (AstFuncRef* const funcRefp = VN_CAST(portp->valuep(), FuncRef)) {
+                const AstNodeFTask* const funcp = funcRefp->taskp();
+                if (funcp->classMethod() && funcp->lifetime().isStatic()) {
+                    newvaluep = funcRefp->cloneTree(true);
+                } else {
+                    funcRefp->v3warn(E_UNSUPPORTED,
+                                     "Call of the function different than static method is the "
+                                     "default value of missing argument");
+                }
             } else if (!VN_IS(portp->valuep(), Const)) {
                 // The default value for this port might be a constant
                 // expression that hasn't been folded yet. Try folding it

--- a/src/V3Task.cpp
+++ b/src/V3Task.cpp
@@ -1667,7 +1667,7 @@ V3TaskConnects V3Task::taskConnects(AstNodeFTaskRef* nodep, AstNode* taskStmtsp)
                 newvaluep = new AstConst{nodep->fileline(), AstConst::Unsized32{}, 0};
             } else if (AstFuncRef* const funcRefp = VN_CAST(portp->valuep(), FuncRef)) {
                 const AstNodeFTask* const funcp = funcRefp->taskp();
-                if (funcp->classMethod() && funcp->lifetime().isStatic()) { newvaluep = funcRefp; }
+                if (funcp->classMethod() && funcp->lifetime().isStatic()) newvaluep = funcRefp;
             } else if (AstConst* const constp = VN_CAST(portp->valuep(), Const)) {
                 newvaluep = constp;
             }
@@ -1688,7 +1688,7 @@ V3TaskConnects V3Task::taskConnects(AstNodeFTaskRef* nodep, AstNode* taskStmtsp)
                     newvaluep = new AstConst{nodep->fileline(), AstConst::Unsized32{}, 0};
                 }
             }
-            newvaluep = VN_AS(portp->valuep(), NodeExpr)->cloneTree(true);
+            newvaluep = newvaluep->cloneTree(true);
             // To avoid problems with callee needing to know to deleteTree
             // or not, we make this into a pin
             UINFO(9, "Default pin for " << portp << endl);

--- a/src/V3Task.cpp
+++ b/src/V3Task.cpp
@@ -1667,10 +1667,8 @@ V3TaskConnects V3Task::taskConnects(AstNodeFTaskRef* nodep, AstNode* taskStmtsp)
                 newvaluep = new AstConst{nodep->fileline(), AstConst::Unsized32{}, 0};
             } else if (AstFuncRef* const funcRefp = VN_CAST(portp->valuep(), FuncRef)) {
                 const AstNodeFTask* const funcp = funcRefp->taskp();
-                if (funcp->classMethod() && funcp->lifetime().isStatic()) {
-                    newvaluep = funcRefp;
-                }
-            } else if (AstConst* const constp= VN_CAST(portp->valuep(), Const)) {
+                if (funcp->classMethod() && funcp->lifetime().isStatic()) { newvaluep = funcRefp; }
+            } else if (AstConst* const constp = VN_CAST(portp->valuep(), Const)) {
                 newvaluep = constp;
             }
 

--- a/src/V3Task.cpp
+++ b/src/V3Task.cpp
@@ -1668,13 +1668,13 @@ V3TaskConnects V3Task::taskConnects(AstNodeFTaskRef* nodep, AstNode* taskStmtsp)
             } else if (AstFuncRef* const funcRefp = VN_CAST(portp->valuep(), FuncRef)) {
                 const AstNodeFTask* const funcp = funcRefp->taskp();
                 if (funcp->classMethod() && funcp->lifetime().isStatic()) {
-                    newvaluep = funcRefp->cloneTree(true);
-                } else {
-                    funcRefp->v3warn(E_UNSUPPORTED,
-                                     "Call of the function different than static method is the "
-                                     "default value of missing argument");
+                    newvaluep = funcRefp;
                 }
-            } else if (!VN_IS(portp->valuep(), Const)) {
+            } else if (AstConst* const constp= VN_CAST(portp->valuep(), Const)) {
+                newvaluep = constp;
+            }
+
+            if (!newvaluep) {
                 // The default value for this port might be a constant
                 // expression that hasn't been folded yet. Try folding it
                 // now; we don't have much to lose if it fails.
@@ -1688,12 +1688,9 @@ V3TaskConnects V3Task::taskConnects(AstNodeFTaskRef* nodep, AstNode* taskStmtsp)
                                       << portp->prettyNameQ() << " in function call to "
                                       << nodep->taskp()->prettyTypeName());
                     newvaluep = new AstConst{nodep->fileline(), AstConst::Unsized32{}, 0};
-                } else {
-                    newvaluep = newvaluep->cloneTree(true);
                 }
-            } else {
-                newvaluep = VN_AS(portp->valuep(), NodeExpr)->cloneTree(true);
             }
+            newvaluep = VN_AS(portp->valuep(), NodeExpr)->cloneTree(true);
             // To avoid problems with callee needing to know to deleteTree
             // or not, we make this into a pin
             UINFO(9, "Default pin for " << portp << endl);

--- a/src/V3Task.cpp
+++ b/src/V3Task.cpp
@@ -1549,7 +1549,7 @@ private:
     void visit(AstVar* nodep) override {
         if (nodep->isFuncLocal() && nodep->direction() == VDirection::INPUT && nodep->valuep()) {
             // It's the default value of optional argument.
-            // Such values are added to function calls on this stage.
+            // Such values are added to function calls on this stage and aren't needed here.
             pushDeletep(nodep->valuep()->unlinkFrBack());
         }
     }

--- a/test_regress/t/t_func_defaults.v
+++ b/test_regress/t/t_func_defaults.v
@@ -19,12 +19,28 @@ function automatic logic [1:0] foo
    return x + y;
 endfunction
 
+class Foo;
+   static int x;
+   function static int get_x;
+      return x;
+   endfunction
+endclass
+
+function int mult2(int x = Foo::get_x());
+   return 2 * x;
+endfunction
+
 module t (/*AUTOARG*/);
    logic [1:0] foo_val;
 
    initial begin
       foo_val = foo();
       if (foo_val != 2'b10) $stop;
+
+      if (mult2(1) != 2) $stop;
+      if (mult2() != 0) $stop;
+      Foo::x = 30;
+      if (mult2() != 60) $stop;
 
       $write("*-* All Finished *-*\n");
       $finish;


### PR DESCRIPTION
Currently on master, Verilator requires default values to be constants (or expressions that can be evaluated in the compile-time). I think that we can allow some other expressions.
This PR adds support for calls of static methods by inserting them as arguments to func refs (the same is done for default values that are constants). They are already linked, so there is no problem with changed places of these calls.