### PR TITLE
Optimize V3Number::opAdd

### DIFF
--- a/src/V3Number.cpp
+++ b/src/V3Number.cpp
@@ -1866,11 +1866,13 @@ V3Number& V3Number::opAdd(const V3Number& lhs, const V3Number& rhs) {
     if (lhs.isFourState() || rhs.isFourState()) return setAllBitsX();
     setZero();
     // Addem
-    int carry = 0;
-    for (int bit = 0; bit < width(); bit++) {
-        const int sum = ((lhs.bitIs1(bit) ? 1 : 0) + (rhs.bitIs1(bit) ? 1 : 0) + carry);
-        if (sum & 1) setBit(bit, 1);
-        carry = (sum >= 2);
+    uint32_t carry = 0;
+    for (int word = 0; word < words(); word++) {
+        const uint32_t lsc = lhs.wordIs1(word);
+        const uint32_t rsc = rhs.wordIs1(word);
+        const uint32_t sum = lsc + rsc + carry;
+        setWord(word, sum);
+        carry = (sum <= std::min(lsc, rsc));
     }
     return *this;
 }

--- a/src/V3Number.cpp
+++ b/src/V3Number.cpp
@@ -1866,13 +1866,13 @@ V3Number& V3Number::opAdd(const V3Number& lhs, const V3Number& rhs) {
     if (lhs.isFourState() || rhs.isFourState()) return setAllBitsX();
     setZero();
     // Addem
-    uint32_t lsc, rsc, sum, carry = 0;
+    uint64_t carry = 0;
     for (int word = 0; word < words(); word++) {
-        lsc = lhs.wordIs1(word);
-        rsc = rhs.wordIs1(word);
-        sum = lsc + rsc + carry;
+        const uint64_t lsc = lhs.wordIs1(word);
+        const uint64_t rsc = rhs.wordIs1(word);
+        const uint64_t sum = lsc + rsc + carry;
         setWord(word, sum);
-        carry = (sum <= std::min(lsc, rsc));
+        carry = sum > 0xffffffff;
     }
     return *this;
 }

--- a/src/V3Number.cpp
+++ b/src/V3Number.cpp
@@ -1866,11 +1866,11 @@ V3Number& V3Number::opAdd(const V3Number& lhs, const V3Number& rhs) {
     if (lhs.isFourState() || rhs.isFourState()) return setAllBitsX();
     setZero();
     // Addem
-    uint32_t carry = 0;
+    uint32_t lsc, rsc, sum, carry = 0;
     for (int word = 0; word < words(); word++) {
-        const uint32_t lsc = lhs.wordIs1(word);
-        const uint32_t rsc = rhs.wordIs1(word);
-        const uint32_t sum = lsc + rsc + carry;
+        lsc = lhs.wordIs1(word);
+        rsc = rhs.wordIs1(word);
+        sum = lsc + rsc + carry;
         setWord(word, sum);
         carry = (sum <= std::min(lsc, rsc));
     }

--- a/src/V3Number.cpp
+++ b/src/V3Number.cpp
@@ -1868,12 +1868,13 @@ V3Number& V3Number::opAdd(const V3Number& lhs, const V3Number& rhs) {
     // Addem
     uint64_t carry = 0;
     for (int word = 0; word < words(); word++) {
-        const uint64_t lsc = lhs.wordIs1(word);
-        const uint64_t rsc = rhs.wordIs1(word);
-        const uint64_t sum = lsc + rsc + carry;
-        setWord(word, sum);
-        carry = sum > 0xffffffff;
+        const uint64_t lwordval = lhs.m_data.num()[word].m_value;
+        const uint64_t rwordval = rhs.m_data.num()[word].m_value;
+        const uint64_t sum = lwordval + rwordval + carry;
+        m_data.num()[word].m_value = sum & 0xffffffffULL;
+        carry = sum > 0xffffffffULL;
     }
+    opCleanThis();  // Just in case it produced extra bits in result
     return *this;
 }
 V3Number& V3Number::opSub(const V3Number& lhs, const V3Number& rhs) {

--- a/src/V3Number.h
+++ b/src/V3Number.h
@@ -382,14 +382,13 @@ public:
         }
     }
     inline void setWord(int word, uint32_t value) {
-        uint32_t mask = 0xffffffff;
+        uint64_t mask = 0xffffffff;
         if (word < 0) return;
         if (word >= m_data.width()) return;
-        if (word == words()-1) mask >>= 32-m_data.width()%32;
+        if (word == words()-1) mask = (1UL<<(1+((m_data.width()-1)&31)))-1;
         uint32_t& m_value = m_data.num()[word].m_value;
         m_value &= ~mask;
         m_value |= value & mask;
-        // v.m_valueX &= ~mask;
     }
 
 private:
@@ -462,13 +461,12 @@ public:
         return ((~v.m_value & (1UL << (bit & 31))) && (v.m_valueX & (1UL << (bit & 31))));
     }
     inline uint32_t wordIs1(int word) const VL_MT_SAFE {
-        uint32_t mask = 0xffffffff;
+        uint64_t mask = 0xffffffff;
         if (!isNumber()) return 0;
         if (word < 0) return 0;
         if (word >= words()) return 0;
-        if (word == words()-1) mask >>= 32-m_data.width()%32;
+        if (word == words()-1) mask = (1UL<<(1+((m_data.width()-1)&31)))-1;
         const uint32_t value = m_data.num()[word].m_value;
-        // return v.m_value & ~v.m_valueX & mask;
         return value & mask;
     }
 private:

--- a/src/V3Number.h
+++ b/src/V3Number.h
@@ -381,13 +381,6 @@ public:
             v.m_valueX |= mask;
         }
     }
-    inline void setWord(int word, uint32_t value) {
-        uint64_t mask = 0xffffffff;
-        if (word == words()-1) mask = (1UL<<(1+((m_data.width()-1)&31)))-1;
-        uint32_t& m_value = m_data.num()[word].m_value;
-        m_value &= ~mask;
-        m_value |= value & mask;
-    }
 
 private:
     char bitIs(int bit) const {
@@ -458,13 +451,7 @@ public:
         const ValueAndX v = m_data.num()[bit / 32];
         return ((~v.m_value & (1UL << (bit & 31))) && (v.m_valueX & (1UL << (bit & 31))));
     }
-    inline uint32_t wordIs1(int word) const VL_MT_SAFE {
-        uint64_t mask = 0xffffffff;
-        if (!isNumber()) return 0;
-        if (word == words()-1) mask = (1UL<<(1+((m_data.width()-1)&31)))-1;
-        const uint32_t value = m_data.num()[word].m_value;
-        return value & mask;
-    }
+
 private:
     uint32_t bitsValue(int lsb, int nbits) const VL_MT_SAFE {
         uint32_t v = 0;

--- a/src/V3Number.h
+++ b/src/V3Number.h
@@ -381,6 +381,16 @@ public:
             v.m_valueX |= mask;
         }
     }
+    void setWord(int word, uint32_t value) {
+        uint32_t mask = 0xffffffff;
+        if (word < 0) return;
+        if (word >= m_data.width()) return;
+        if (word == words()-1) mask >>= 32-m_data.width()%32;
+        ValueAndX& v = m_data.num()[word];
+        v.m_value &= ~mask;
+        v.m_value |= value & mask;
+        v.m_valueX &= ~mask;
+    }
 
 private:
     char bitIs(int bit) const {
@@ -451,7 +461,15 @@ public:
         const ValueAndX v = m_data.num()[bit / 32];
         return ((~v.m_value & (1UL << (bit & 31))) && (v.m_valueX & (1UL << (bit & 31))));
     }
-
+    uint32_t wordIs1(int word) const VL_MT_SAFE {
+        uint32_t mask = 0xffffffff;
+        if (!isNumber()) return 0;
+        if (word < 0) return 0;
+        if (word >= words()) return 0;
+        if (word == words()-1) mask >>= 32-m_data.width()%32;
+        const ValueAndX v = m_data.num()[word];
+        return v.m_value & ~v.m_valueX & mask;
+    }
 private:
     uint32_t bitsValue(int lsb, int nbits) const VL_MT_SAFE {
         uint32_t v = 0;

--- a/src/V3Number.h
+++ b/src/V3Number.h
@@ -381,15 +381,15 @@ public:
             v.m_valueX |= mask;
         }
     }
-    void setWord(int word, uint32_t value) {
+    inline void setWord(int word, uint32_t value) {
         uint32_t mask = 0xffffffff;
         if (word < 0) return;
         if (word >= m_data.width()) return;
         if (word == words()-1) mask >>= 32-m_data.width()%32;
-        ValueAndX& v = m_data.num()[word];
-        v.m_value &= ~mask;
-        v.m_value |= value & mask;
-        v.m_valueX &= ~mask;
+        uint32_t& m_value = m_data.num()[word].m_value;
+        m_value &= ~mask;
+        m_value |= value & mask;
+        // v.m_valueX &= ~mask;
     }
 
 private:
@@ -461,14 +461,15 @@ public:
         const ValueAndX v = m_data.num()[bit / 32];
         return ((~v.m_value & (1UL << (bit & 31))) && (v.m_valueX & (1UL << (bit & 31))));
     }
-    uint32_t wordIs1(int word) const VL_MT_SAFE {
+    inline uint32_t wordIs1(int word) const VL_MT_SAFE {
         uint32_t mask = 0xffffffff;
         if (!isNumber()) return 0;
         if (word < 0) return 0;
         if (word >= words()) return 0;
         if (word == words()-1) mask >>= 32-m_data.width()%32;
-        const ValueAndX v = m_data.num()[word];
-        return v.m_value & ~v.m_valueX & mask;
+        const uint32_t value = m_data.num()[word].m_value;
+        // return v.m_value & ~v.m_valueX & mask;
+        return value & mask;
     }
 private:
     uint32_t bitsValue(int lsb, int nbits) const VL_MT_SAFE {

--- a/src/V3Number.h
+++ b/src/V3Number.h
@@ -383,8 +383,6 @@ public:
     }
     inline void setWord(int word, uint32_t value) {
         uint64_t mask = 0xffffffff;
-        if (word < 0) return;
-        if (word >= m_data.width()) return;
         if (word == words()-1) mask = (1UL<<(1+((m_data.width()-1)&31)))-1;
         uint32_t& m_value = m_data.num()[word].m_value;
         m_value &= ~mask;
@@ -463,8 +461,6 @@ public:
     inline uint32_t wordIs1(int word) const VL_MT_SAFE {
         uint64_t mask = 0xffffffff;
         if (!isNumber()) return 0;
-        if (word < 0) return 0;
-        if (word >= words()) return 0;
         if (word == words()-1) mask = (1UL<<(1+((m_data.width()-1)&31)))-1;
         const uint32_t value = m_data.num()[word].m_value;
         return value & mask;


### PR DESCRIPTION
@kboronski-ant has noticed that verilation of the parts of UVM that Verilator already supports spends ~40% of the total time in V3Number::opAdd.

This change modifies opAdd so that it adds numbers iterating by words instead of bits, just like it's done in opMul.

I runned verilation of UVM with and without the change, 100 times each. With the modification it takes ~73.3% of the old time.
