### PR TITLE
Bump CMake config minimum version to 3.13 (#4389)

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -165,6 +165,7 @@ Varun Koyyalagunta
 Vassilis Papaefstathiou
 Veripool API Bot
 Victor Besyakov
+Vito Gamberini
 William D. Jones
 Wilson Snyder
 Xi Zhang

--- a/verilator-config.cmake.in
+++ b/verilator-config.cmake.in
@@ -19,8 +19,7 @@
 #
 ######################################################################
 
-cmake_minimum_required(VERSION 3.12)
-cmake_policy(SET CMP0074 NEW)
+cmake_minimum_required(VERSION 3.13)
 
 # Prefer VERILATOR_ROOT from environment
 if (DEFINED ENV{VERILATOR_ROOT})


### PR DESCRIPTION
This also removes the unnecessary `cmake_policy()` line, calling `cmake_minimum_required()` [automatically sets the associated CMake policies](https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html). 