### PR TITLE
Do not typecheck in node child getters in release builds

### DIFF
--- a/src/astgen
+++ b/src/astgen
@@ -948,7 +948,7 @@ def write_ast_macros(filename):
                 if not op:
                     continue
                 name, monad, kind = op
-                retrieve = ("VN_AS(op{n}p(), {kind})" if kind != "Node" else
+                retrieve = ("VN_DBG_AS(op{n}p(), {kind})" if kind != "Node" else
                             "op{n}p()").format(n=n, kind=kind)
                 if monad == "List":
                     emitBlock('''\

--- a/src/astgen
+++ b/src/astgen
@@ -948,8 +948,8 @@ def write_ast_macros(filename):
                 if not op:
                     continue
                 name, monad, kind = op
-                retrieve = ("VN_DBG_AS(op{n}p(), {kind})" if kind != "Node" else
-                            "op{n}p()").format(n=n, kind=kind)
+                retrieve = ("VN_DBG_AS(op{n}p(), {kind})" if kind != "Node"
+                            else "op{n}p()").format(n=n, kind=kind)
                 if monad == "List":
                     emitBlock('''\
                     Ast{kind}* {name}() const VL_MT_STABLE {{ return {retrieve}; }}


### PR DESCRIPTION
Replaces the `VN_AS` cast in child node getters with a `reinterpret_cast`.
The type assertion is unnecessary, as the only way to set these pointers is through properly-typed setters.
Dropping it brings a significant performance benefit. Mean verilation time for a few designs:

|  Design    |  Commit 959387b6   |  This patch    |
|:-----------|-------------------:|---------------:|
| 720 kLOC   | 121.41 s           | 116.84 s (96%) |
| 1080 kLOC  | 224.42 s           | 214.29 s (95%) |
| 1590 kLOC  | 279 s              | 262.22 s (94%) |
| 2860 kLOC  | 720.49 s           | 682.76 s (95%) |

(959387b6 is a recent mainline commit; kLOC = 1000 lines of code; `tcmalloc` enabled)
 