### PR TITLE
Remove the name field from `AstVarRef`

### DIFF
--- a/src/V3Ast.cpp
+++ b/src/V3Ast.cpp
@@ -125,9 +125,7 @@ string AstNode::encodeNumber(int64_t num) {
     }
 }
 
-string AstNode::nameProtect() const VL_MT_STABLE {
-    return VIdProtect::protectIf(name(), protect());
-}
+string AstNode::nameProtect() const { return VIdProtect::protectIf(name(), protect()); }
 string AstNode::origNameProtect() const { return VIdProtect::protectIf(origName(), protect()); }
 
 string AstNode::shortName() const {
@@ -285,7 +283,7 @@ string AstNode::vpiName(const string& namein) {
     return pretty;
 }
 
-string AstNode::prettyTypeName() const VL_MT_STABLE {
+string AstNode::prettyTypeName() const {
     if (name() == "") return typeName();
     return std::string{typeName()} + " '" + prettyName() + "'";
 }

--- a/src/V3Ast.h
+++ b/src/V3Ast.h
@@ -1686,7 +1686,7 @@ public:
     static constexpr int INSTR_COUNT_PLI = 20;  // PLI routines
 
     // ACCESSORS
-    virtual string name() const VL_MT_STABLE { return ""; }
+    virtual string name() const { return ""; }
     virtual string origName() const { return ""; }
     virtual void name(const string& name) {
         this->v3fatalSrc("name() called on object without name() method");
@@ -1694,7 +1694,7 @@ public:
     virtual void tag(const string& text) {}
     virtual string tag() const { return ""; }
     virtual string verilogKwd() const { return ""; }
-    string nameProtect() const VL_MT_STABLE;  // Name with --protect-id applied
+    string nameProtect() const;  // Name with --protect-id applied
     string origNameProtect() const;  // origName with --protect-id applied
     string shortName() const;  // Name with __PVT__ removed for concatenating scopes
     static string dedotName(const string& namein);  // Name with dots removed
@@ -1707,10 +1707,10 @@ public:
     static string encodeName(const string& namein);
     static string encodeNumber(int64_t num);  // Encode number into internal C representation
     static string vcdName(const string& namein);  // Name for printing out to vcd files
-    string prettyName() const VL_MT_STABLE { return prettyName(name()); }
+    string prettyName() const { return prettyName(name()); }
     string prettyNameQ() const { return prettyNameQ(name()); }
     // "VARREF" for error messages (NOT dtype's pretty name)
-    string prettyTypeName() const VL_MT_STABLE;
+    string prettyTypeName() const;
     virtual string prettyOperatorName() const { return "operator " + prettyTypeName(); }
     FileLine* fileline() const VL_MT_SAFE { return m_fileline; }
     void fileline(FileLine* fl) { m_fileline = fl; }

--- a/src/V3AstInlines.h
+++ b/src/V3AstInlines.h
@@ -154,12 +154,15 @@ AstCExpr::AstCExpr(FileLine* fl, const string& textStmt, int setwidth, bool clea
 }
 
 AstVarRef::AstVarRef(FileLine* fl, AstVar* varp, const VAccess& access)
-    : ASTGEN_SUPER_VarRef(fl, varp->name(), varp, access) {}
+    : ASTGEN_SUPER_VarRef(fl, varp, access) {}
 // This form only allowed post-link (see above)
 AstVarRef::AstVarRef(FileLine* fl, AstVarScope* varscp, const VAccess& access)
-    : ASTGEN_SUPER_VarRef(fl, varscp->varp()->name(), varscp->varp(), access) {
+    : ASTGEN_SUPER_VarRef(fl, varscp->varp(), access) {
     varScopep(varscp);
 }
+
+string AstVarRef::name() const { return varp() ? varp()->name() : "<null>"; }
+
 bool AstVarRef::same(const AstVarRef* samep) const {
     if (varScopep()) {
         return (varScopep() == samep->varScopep() && access() == samep->access());
@@ -179,7 +182,8 @@ bool AstVarRef::sameNoLvalue(AstVarRef* samep) const {
 }
 
 AstVarXRef::AstVarXRef(FileLine* fl, AstVar* varp, const string& dotted, const VAccess& access)
-    : ASTGEN_SUPER_VarXRef(fl, varp->name(), varp, access)
+    : ASTGEN_SUPER_VarXRef(fl, varp, access)
+    , m_name{varp->name()}
     , m_dotted{dotted} {
     dtypeFrom(varp);
 }

--- a/src/V3AstNodeDType.h
+++ b/src/V3AstNodeDType.h
@@ -126,13 +126,13 @@ public:
     const char* charIQWN() const {
         return (isString() ? "N" : isWide() ? "W" : isQuad() ? "Q" : "I");
     }
-    string cType(const string& name, bool forFunc, bool isRef) const VL_MT_STABLE;
+    string cType(const string& name, bool forFunc, bool isRef) const;
     // Represents a C++ LiteralType? (can be constexpr)
     bool isLiteralType() const VL_MT_STABLE;
 
 private:
     class CTypeRecursed;
-    CTypeRecursed cTypeRecurse(bool compound) const VL_MT_STABLE;
+    CTypeRecursed cTypeRecurse(bool compound) const;
 };
 class AstNodeArrayDType VL_NOT_FINAL : public AstNodeDType {
     // Array data type, ie "some_dtype var_name [2:0]"

--- a/src/V3AstNodeOther.h
+++ b/src/V3AstNodeOther.h
@@ -1812,7 +1812,7 @@ public:
     string dpiTmpVarType(const string& varName) const;
     // Return Verilator internal type for argument: CData, SData, IData, WData
     string vlArgType(bool named, bool forReturn, bool forFunc, const string& namespc = "",
-                     bool asRef = false) const VL_MT_STABLE;
+                     bool asRef = false) const;
     string vlEnumType() const;  // Return VerilatorVarType: VLVT_UINT32, etc
     string vlEnumDir() const;  // Return VerilatorVarDir: VLVD_INOUT, etc
     string vlPropDecl(const string& propName) const;  // Return VerilatorVarProps declaration

--- a/src/V3AstNodes.cpp
+++ b/src/V3AstNodes.cpp
@@ -378,7 +378,7 @@ string AstVar::verilogKwd() const {
 }
 
 string AstVar::vlArgType(bool named, bool forReturn, bool forFunc, const string& namespc,
-                         bool asRef) const VL_MT_STABLE {
+                         bool asRef) const {
     UASSERT_OBJ(!forReturn, this,
                 "Internal data is never passed as return, but as first argument");
     string ostatic;
@@ -695,12 +695,12 @@ public:
     }
 };
 
-string AstNodeDType::cType(const string& name, bool /*forFunc*/, bool isRef) const VL_MT_STABLE {
+string AstNodeDType::cType(const string& name, bool /*forFunc*/, bool isRef) const {
     const CTypeRecursed info = cTypeRecurse(false);
     return info.render(name, isRef);
 }
 
-AstNodeDType::CTypeRecursed AstNodeDType::cTypeRecurse(bool compound) const VL_MT_STABLE {
+AstNodeDType::CTypeRecursed AstNodeDType::cTypeRecurse(bool compound) const {
     // Legacy compound argument currently just passed through and unused
     CTypeRecursed info;
 
@@ -2075,6 +2075,10 @@ void AstVarRef::dump(std::ostream& str) const {
     } else {
         str << "UNLINKED";
     }
+}
+const char* AstVarRef::broken() const {
+    BROKEN_RTN(!varp());
+    return AstNodeVarRef::broken();
 }
 bool AstVarRef::same(const AstNode* samep) const {
     return same(static_cast<const AstVarRef*>(samep));

--- a/src/V3Begin.cpp
+++ b/src/V3Begin.cpp
@@ -40,39 +40,6 @@ VL_DEFINE_DEBUG_FUNCTIONS;
 
 //######################################################################
 
-class RenameStaticVisitor final : public VNVisitor {
-private:
-    // STATE
-    const std::set<AstVar*>& m_staticFuncVarsr;  // Static variables from m_ftaskp
-    AstNodeFTask* const m_ftaskp;  // Current function/task
-
-    // VISITORS
-    void visit(AstVarRef* nodep) override {
-        const auto it = m_staticFuncVarsr.find(nodep->varp());
-        if (it != m_staticFuncVarsr.end()) nodep->name((*it)->name());
-        iterateChildren(nodep);
-    }
-
-    void visit(AstInitialStatic* nodep) override {
-        iterateChildren(nodep);
-        nodep->unlinkFrBack();
-        m_ftaskp->addHereThisAsNext(nodep);
-    }
-
-    void visit(AstNode* nodep) override { iterateChildren(nodep); }
-
-public:
-    // CONSTRUCTORS
-    RenameStaticVisitor(std::set<AstVar*>& staticFuncVars, AstNodeFTask* ftaskp, AstNode* nodep)
-        : m_staticFuncVarsr(staticFuncVars)
-        , m_ftaskp(ftaskp) {
-        iterateChildren(nodep);
-    }
-    ~RenameStaticVisitor() override = default;
-};
-
-//######################################################################
-
 class BeginState final {
 private:
     // NODE STATE
@@ -105,7 +72,6 @@ private:
     string m_unnamedScope;  // Name of begin blocks, including unnamed blocks
     int m_ifDepth = 0;  // Current if depth
     bool m_keepBegins = false;  // True if begins should not be inlined
-    std::set<AstVar*> m_staticFuncVars;  // Static variables from m_ftaskp
 
     // METHODS
 
@@ -212,7 +178,10 @@ private:
             m_ftaskp = nodep;
             m_liftedp = nullptr;
             iterateChildren(nodep);
-            RenameStaticVisitor{m_staticFuncVars, m_ftaskp, nodep};
+            nodep->foreach([&](AstInitialStatic* const initp) {
+                initp->unlinkFrBack();
+                m_ftaskp->addHereThisAsNext(initp);
+            });
             if (m_liftedp) {
                 // Place lifted nodes at beginning of stmtsp, so Var nodes appear before referenced
                 if (AstNode* const stmtsp = nodep->stmtsp()) {
@@ -222,7 +191,6 @@ private:
                 nodep->addStmtsp(m_liftedp);
                 m_liftedp = nullptr;
             }
-            m_staticFuncVars.clear();
             m_ftaskp = nullptr;
         }
     }
@@ -266,7 +234,6 @@ private:
             nodep->name(newName);
             nodep->unlinkFrBack();
             m_ftaskp->addHereThisAsNext(nodep);
-            m_staticFuncVars.insert(nodep);
             nodep->funcLocal(false);
         } else if (m_unnamedScope != "") {
             // Rename it
@@ -377,7 +344,6 @@ private:
     void visit(AstVarRef* nodep) override {
         if (nodep->varp()->user1()) {  // It was converted
             UINFO(9, "    relinVarRef " << nodep << endl);
-            nodep->name(nodep->varp()->name());
         }
         iterateChildren(nodep);
     }

--- a/src/V3EmitCBase.h
+++ b/src/V3EmitCBase.h
@@ -62,7 +62,7 @@ public:
     static string symClassAssign() {
         return symClassName() + "* const __restrict vlSymsp VL_ATTR_UNUSED = vlSelf->vlSymsp;\n";
     }
-    static string prefixNameProtect(const AstNode* nodep) VL_MT_STABLE {  // C++ name with prefix
+    static string prefixNameProtect(const AstNode* nodep) {  // C++ name with prefix
         return v3Global.opt.modPrefix() + "_" + VIdProtect::protect(nodep->name());
     }
     static bool isAnonOk(const AstVar* varp) {

--- a/src/V3EmitCImp.cpp
+++ b/src/V3EmitCImp.cpp
@@ -147,7 +147,7 @@ class EmitCGatherDependencies final : VNVisitorConst {
     }
 
 public:
-    static const std::set<std::string> gather(AstCFunc* cfuncp) VL_MT_STABLE {
+    static const std::set<std::string> gather(AstCFunc* cfuncp) {
         const EmitCGatherDependencies visitor{cfuncp};
         return std::move(visitor.m_dependencies);
     }
@@ -566,8 +566,7 @@ class EmitCImp final : EmitCFunc {
     ~EmitCImp() override = default;
 
 public:
-    static void main(const AstNodeModule* modp, bool slow,
-                     std::deque<AstCFile*>& cfilesr) VL_MT_STABLE {
+    static void main(const AstNodeModule* modp, bool slow, std::deque<AstCFile*>& cfilesr) {
         EmitCImp{modp, slow, cfilesr};
     }
 };

--- a/src/V3Gate.cpp
+++ b/src/V3Gate.cpp
@@ -176,9 +176,7 @@ public:
         , m_slow{slow} {}
     ~GateLogicVertex() override = default;
     // ACCESSORS
-    string name() const override VL_MT_STABLE {
-        return (cvtToHex(m_nodep) + "@" + scopep()->prettyName());
-    }
+    string name() const override { return (cvtToHex(m_nodep) + "@" + scopep()->prettyName()); }
     string dotColor() const override { return "purple"; }
     FileLine* fileline() const override { return nodep()->fileline(); }
     AstNode* nodep() const { return m_nodep; }

--- a/src/V3Inline.cpp
+++ b/src/V3Inline.cpp
@@ -384,7 +384,6 @@ private:
                 nodep->v3fatalSrc("Null connection?");
             }
         }
-        nodep->name(nodep->varp()->name());
     }
     void visit(AstVarXRef* nodep) override {
         // Track what scope it was originally under so V3LinkDot can resolve it

--- a/src/V3LinkParse.cpp
+++ b/src/V3LinkParse.cpp
@@ -370,9 +370,11 @@ private:
                 // Making an AstAssign (vs AstAssignW) to a wire is an error, suppress it
                 FileLine* const newfl = new FileLine{fl};
                 newfl->warnOff(V3ErrorCode::PROCASSWIRE, true);
-                auto* const assp
-                    = new AstAssign{newfl, new AstVarRef{newfl, nodep->name(), VAccess::WRITE},
-                                    VN_AS(nodep->valuep()->unlinkFrBack(), NodeExpr)};
+                // Create a ParseRef to the wire. We cannot use the var as it may be deleted if
+                // it's a port (see t_var_set_link.v)
+                auto* const assp = new AstAssign{
+                    newfl, new AstParseRef{newfl, VParseRefExp::PX_TEXT, nodep->name()},
+                    VN_AS(nodep->valuep()->unlinkFrBack(), NodeExpr)};
                 if (nodep->lifetime().isAutomatic()) {
                     nodep->addNextHere(new AstInitialAutomatic{newfl, assp});
                 } else {
@@ -381,7 +383,7 @@ private:
             }  // 4. Under blocks, it's an initial value to be under an assign
             else {
                 nodep->addNextHere(
-                    new AstAssign{fl, new AstVarRef{fl, nodep->name(), VAccess::WRITE},
+                    new AstAssign{fl, new AstVarRef{fl, nodep, VAccess::WRITE},
                                   VN_AS(nodep->valuep()->unlinkFrBack(), NodeExpr)});
             }
         }

--- a/src/V3Name.cpp
+++ b/src/V3Name.cpp
@@ -89,12 +89,7 @@ private:
             rename(nodep, false);
         }
     }
-    void visit(AstVarRef* nodep) override {
-        if (nodep->varp()) {
-            iterate(nodep->varp());
-            nodep->name(nodep->varp()->name());
-        }
-    }
+    void visit(AstVarRef* nodep) override { iterate(nodep->varp()); }
     void visit(AstCell* nodep) override {
         if (!nodep->user1()) {
             rename(nodep, (!nodep->modp()->modPublic() && !VN_IS(nodep->modp(), ClassPackage)));

--- a/src/V3ParseGrammar.cpp
+++ b/src/V3ParseGrammar.cpp
@@ -85,9 +85,10 @@ AstArg* V3ParseGrammar::argWrapList(AstNodeExpr* nodep) {
 }
 
 AstNode* V3ParseGrammar::createSupplyExpr(FileLine* fileline, const string& name, int value) {
-    AstAssignW* assignp = new AstAssignW{fileline, new AstVarRef{fileline, name, VAccess::WRITE},
-                                         value ? new AstConst{fileline, AstConst::All1{}}
-                                               : new AstConst{fileline, AstConst::All0{}}};
+    AstAssignW* assignp
+        = new AstAssignW{fileline, new AstParseRef{fileline, VParseRefExp::PX_TEXT, name},
+                         value ? new AstConst{fileline, AstConst::All1{}}
+                               : new AstConst{fileline, AstConst::All0{}}};
     AstStrengthSpec* strengthSpecp
         = new AstStrengthSpec{fileline, VStrength::SUPPLY, VStrength::SUPPLY};
     assignp->strengthSpecp(strengthSpecp);

--- a/src/V3Split.cpp
+++ b/src/V3Split.cpp
@@ -109,9 +109,7 @@ protected:
     // ACCESSORS
     // Do not make accessor for nodep(),  It may change due to
     // reordering a lower block, but we don't repair it
-    string name() const override VL_MT_STABLE {
-        return cvtToHex(m_nodep) + ' ' + m_nodep->prettyTypeName();
-    }
+    string name() const override { return cvtToHex(m_nodep) + ' ' + m_nodep->prettyTypeName(); }
     FileLine* fileline() const override { return nodep()->fileline(); }
 
 public:
@@ -148,7 +146,7 @@ public:
     SplitVarPostVertex(V3Graph* graphp, AstNode* nodep)
         : SplitNodeVertex{graphp, nodep} {}
     ~SplitVarPostVertex() override = default;
-    string name() const override VL_MT_STABLE { return string{"POST "} + SplitNodeVertex::name(); }
+    string name() const override { return string{"POST "} + SplitNodeVertex::name(); }
     string dotColor() const override { return "CadetBlue"; }
 };
 

--- a/src/V3Task.cpp
+++ b/src/V3Task.cpp
@@ -412,7 +412,6 @@ private:
                 AstVarScope* const newvscp = VN_AS(refp->varp()->user2p(), VarScope);
                 refp->varScopep(newvscp);
                 refp->varp(refp->varScopep()->varp());
-                refp->name(refp->varp()->name());
             }
         });
     }

--- a/src/V3Timing.cpp
+++ b/src/V3Timing.cpp
@@ -96,7 +96,7 @@ private:
         AstNode* const m_nodep;  // AST node represented by this graph vertex
 
         // ACCESSORS
-        string name() const override VL_MT_STABLE {
+        string name() const override {
             if (m_classp) {
                 if (VN_IS(nodep(), CFunc)) {
                     return cvtToHex(nodep()) + ' ' + classp()->name() + "::" + nodep()->name();

--- a/src/V3Tristate.cpp
+++ b/src/V3Tristate.cpp
@@ -154,7 +154,7 @@ public:
     // ACCESSORS
     AstNode* nodep() const VL_MT_STABLE { return m_nodep; }
     const AstVar* varp() const { return VN_CAST(nodep(), Var); }
-    string name() const override VL_MT_STABLE {
+    string name() const override {
         return ((isTristate() ? "tri\\n"
                  : feedsTri() ? "feed\\n"
                               : "-\\n")
@@ -672,8 +672,7 @@ class TristateVisitor final : public TristateBaseVisitor {
                                                VFlagBitPacked{}, w};  // 2-state ok; sep enable
             UINFO(9, "       newout " << newLhsp << endl);
             nodep->addStmtsp(newLhsp);
-            refp->varp(newLhsp);  // assign the new var to the varref
-            refp->name(newLhsp->name());
+            refp->varp(newLhsp);
 
             // create a new var for this drivers enable signal
             AstVar* const newEnLhsp = new AstVar{varp->fileline(), VVarType::MODULETEMP,

--- a/src/verilog.y
+++ b/src/verilog.y
@@ -2251,7 +2251,7 @@ tf_variable_identifier<varp>:           // IEEE: part of list_of_tf_variable_ide
                 id variable_dimensionListE sigAttrListE exprEqE
                         { $$ = VARDONEA($<fl>1, *$1, $2, $3);
                           if ($4) AstNode::addNext<AstNode, AstNode>(
-                                      $$, new AstAssign{$4->fileline(), new AstVarRef{$<fl>1, *$1, VAccess::WRITE}, $4}); }
+                                      $$, new AstAssign{$4->fileline(), new AstParseRef{$<fl>1, VParseRefExp::PX_TEXT, *$1}, $4}); }
         ;
 
 variable_declExpr<nodep>:               // IEEE: part of variable_decl_assignment - rhs of expr
@@ -2995,7 +2995,7 @@ netSig<varp>:                   // IEEE: net_decl_assignment -  one element from
                         { $$ = VARDONEA($<fl>1, *$1, nullptr, $2); }
         |       netId sigAttrListE '=' expr
                         { $$ = VARDONEA($<fl>1, *$1, nullptr, $2);
-                          auto* const assignp = new AstAssignW{$3, new AstVarRef{$<fl>1, *$1, VAccess::WRITE}, $4};
+                          auto* const assignp = new AstAssignW{$3, new AstParseRef{$<fl>1, VParseRefExp::PX_TEXT, *$1}, $4};
                           if (GRAMMARP->m_netStrengthp) assignp->strengthSpecp(GRAMMARP->m_netStrengthp->cloneTree(false));
                           AstNode::addNext<AstNode, AstNode>($$, assignp); }
         |       netId variable_dimensionList sigAttrListE
@@ -3912,14 +3912,14 @@ for_initializationItem<nodep>:          // IEEE: variable_assignment + for_varia
                           AstVar* const varp = VARDONEA($<fl>2, *$2, nullptr, nullptr);
                           varp->lifetime(VLifetime::AUTOMATIC);
                           $$ = varp;
-                          $$->addNext(new AstAssign{$3, new AstVarRef{$<fl>2, *$2, VAccess::WRITE}, $4}); }
+                          $$->addNext(new AstAssign{$3, new AstParseRef{$<fl>2, VParseRefExp::PX_TEXT, *$2}, $4}); }
         //                      // IEEE-2012:
         |       yVAR data_type idAny/*new*/ '=' expr
                         { VARRESET_NONLIST(VAR); VARDTYPE($2);
                           AstVar* const varp = VARDONEA($<fl>3, *$3, nullptr, nullptr);
                           varp->lifetime(VLifetime::AUTOMATIC);
                           $$ = varp;
-                          $$->addNext(new AstAssign{$4, new AstVarRef{$<fl>3, *$3, VAccess::WRITE}, $5}); }
+                          $$->addNext(new AstAssign{$4, new AstParseRef{$<fl>3, VParseRefExp::PX_TEXT, *$3}, $5}); }
         //                      // IEEE: variable_assignment
         //                      // UNSUP variable_lvalue below
         |       varRefBase '=' expr                     { $$ = new AstAssign{$2, $1, $3}; }
@@ -5614,8 +5614,8 @@ idArrayedForeach<nodeExprp>:    // IEEE: id + select (under foreach expression)
         ;
 
 // VarRef without any dots or vectorizaion
-varRefBase<varRefp>:
-                id                                      { $$ = new AstVarRef{$<fl>1, *$1, VAccess::READ}; }
+varRefBase<parseRefp>:
+                id                                      { $$ = new AstParseRef{$<fl>1, VParseRefExp::PX_TEXT, *$1}; }
         ;
 
 // ParseRef

--- a/test_regress/t/t_xml_flat.out
+++ b/test_regress/t/t_xml_flat.out
@@ -53,27 +53,27 @@
           <varscope loc="d,50,22,50,23" name="t.cell2.q" dtype_id="1"/>
           <assignalias loc="d,15,22,15,23" dtype_id="1">
             <varref loc="d,15,22,15,23" name="q" dtype_id="1"/>
-            <varref loc="d,15,22,15,23" name="q" dtype_id="1"/>
+            <varref loc="d,15,22,15,23" name="t.q" dtype_id="1"/>
           </assignalias>
           <assignalias loc="d,13,10,13,13" dtype_id="2">
             <varref loc="d,13,10,13,13" name="clk" dtype_id="2"/>
-            <varref loc="d,13,10,13,13" name="clk" dtype_id="2"/>
+            <varref loc="d,13,10,13,13" name="t.clk" dtype_id="2"/>
           </assignalias>
           <assignalias loc="d,14,16,14,17" dtype_id="1">
             <varref loc="d,14,16,14,17" name="d" dtype_id="1"/>
-            <varref loc="d,14,16,14,17" name="d" dtype_id="1"/>
+            <varref loc="d,14,16,14,17" name="t.d" dtype_id="1"/>
           </assignalias>
           <assignalias loc="d,34,24,34,27" dtype_id="2">
             <varref loc="d,34,24,34,27" name="t.clk" dtype_id="2"/>
-            <varref loc="d,34,24,34,27" name="cell1.clk" dtype_id="2"/>
+            <varref loc="d,34,24,34,27" name="t.cell1.clk" dtype_id="2"/>
           </assignalias>
           <assignalias loc="d,35,30,35,31" dtype_id="1">
             <varref loc="d,35,30,35,31" name="t.d" dtype_id="1"/>
-            <varref loc="d,35,30,35,31" name="cell1.d" dtype_id="1"/>
+            <varref loc="d,35,30,35,31" name="t.cell1.d" dtype_id="1"/>
           </assignalias>
           <assignalias loc="d,36,30,36,31" dtype_id="1">
             <varref loc="d,36,30,36,31" name="t.between" dtype_id="1"/>
-            <varref loc="d,36,30,36,31" name="cell1.q" dtype_id="1"/>
+            <varref loc="d,36,30,36,31" name="t.cell1.q" dtype_id="1"/>
           </assignalias>
           <always loc="d,41,4,41,10">
             <sentree loc="d,41,11,41,12">
@@ -88,15 +88,15 @@
           </always>
           <assignalias loc="d,48,10,48,13" dtype_id="2">
             <varref loc="d,48,10,48,13" name="t.clk" dtype_id="2"/>
-            <varref loc="d,48,10,48,13" name="cell2.clk" dtype_id="2"/>
+            <varref loc="d,48,10,48,13" name="t.cell2.clk" dtype_id="2"/>
           </assignalias>
           <assignalias loc="d,49,16,49,17" dtype_id="1">
             <varref loc="d,49,16,49,17" name="t.between" dtype_id="1"/>
-            <varref loc="d,49,16,49,17" name="cell2.d" dtype_id="1"/>
+            <varref loc="d,49,16,49,17" name="t.cell2.d" dtype_id="1"/>
           </assignalias>
           <assignalias loc="d,50,22,50,23" dtype_id="1">
             <varref loc="d,50,22,50,23" name="t.q" dtype_id="1"/>
-            <varref loc="d,50,22,50,23" name="cell2.q" dtype_id="1"/>
+            <varref loc="d,50,22,50,23" name="t.cell2.q" dtype_id="1"/>
           </assignalias>
           <contassign loc="d,53,13,53,14" dtype_id="1">
             <varref loc="d,17,22,17,29" name="t.between" dtype_id="1"/>

--- a/test_regress/t/t_xml_flat_no_inline_mod.out
+++ b/test_regress/t/t_xml_flat_no_inline_mod.out
@@ -25,11 +25,11 @@
           <varscope loc="d,7,24,7,29" name="top.f.i_clk" dtype_id="1"/>
           <assignalias loc="d,11,24,11,29" dtype_id="1">
             <varref loc="d,11,24,11,29" name="i_clk" dtype_id="1"/>
-            <varref loc="d,11,24,11,29" name="i_clk" dtype_id="1"/>
+            <varref loc="d,11,24,11,29" name="top.i_clk" dtype_id="1"/>
           </assignalias>
           <assignalias loc="d,7,24,7,29" dtype_id="1">
             <varref loc="d,7,24,7,29" name="top.i_clk" dtype_id="1"/>
-            <varref loc="d,7,24,7,29" name="f.i_clk" dtype_id="1"/>
+            <varref loc="d,7,24,7,29" name="top.f.i_clk" dtype_id="1"/>
           </assignalias>
         </scope>
       </topscope>

--- a/test_regress/t/t_xml_flat_pub_mod.out
+++ b/test_regress/t/t_xml_flat_pub_mod.out
@@ -25,11 +25,11 @@
           <varscope loc="d,7,24,7,29" name="top.f.i_clk" dtype_id="1"/>
           <assignalias loc="d,11,24,11,29" dtype_id="1">
             <varref loc="d,11,24,11,29" name="i_clk" dtype_id="1"/>
-            <varref loc="d,11,24,11,29" name="i_clk" dtype_id="1"/>
+            <varref loc="d,11,24,11,29" name="top.i_clk" dtype_id="1"/>
           </assignalias>
           <assignalias loc="d,7,24,7,29" dtype_id="1">
             <varref loc="d,7,24,7,29" name="top.i_clk" dtype_id="1"/>
-            <varref loc="d,7,24,7,29" name="f.i_clk" dtype_id="1"/>
+            <varref loc="d,7,24,7,29" name="top.f.i_clk" dtype_id="1"/>
           </assignalias>
         </scope>
       </topscope>

--- a/test_regress/t/t_xml_flat_vlvbound.out
+++ b/test_regress/t/t_xml_flat_vlvbound.out
@@ -43,19 +43,19 @@
           <varscope loc="d,17,13,17,14" name="__Vfunc_vlvbound_test.foo__1__i" dtype_id="3"/>
           <assignalias loc="d,9,25,9,28" dtype_id="1">
             <varref loc="d,9,25,9,28" name="i_a" dtype_id="1"/>
-            <varref loc="d,9,25,9,28" name="i_a" dtype_id="1"/>
+            <varref loc="d,9,25,9,28" name="vlvbound_test.i_a" dtype_id="1"/>
           </assignalias>
           <assignalias loc="d,10,25,10,28" dtype_id="1">
             <varref loc="d,10,25,10,28" name="i_b" dtype_id="1"/>
-            <varref loc="d,10,25,10,28" name="i_b" dtype_id="1"/>
+            <varref loc="d,10,25,10,28" name="vlvbound_test.i_b" dtype_id="1"/>
           </assignalias>
           <assignalias loc="d,11,25,11,28" dtype_id="2">
             <varref loc="d,11,25,11,28" name="o_a" dtype_id="2"/>
-            <varref loc="d,11,25,11,28" name="o_a" dtype_id="2"/>
+            <varref loc="d,11,25,11,28" name="vlvbound_test.o_a" dtype_id="2"/>
           </assignalias>
           <assignalias loc="d,12,25,12,28" dtype_id="2">
             <varref loc="d,12,25,12,28" name="o_b" dtype_id="2"/>
-            <varref loc="d,12,25,12,28" name="o_b" dtype_id="2"/>
+            <varref loc="d,12,25,12,28" name="vlvbound_test.o_b" dtype_id="2"/>
           </assignalias>
           <always loc="d,24,14,24,15">
             <comment loc="d,24,16,24,19" name="Function: foo"/>


### PR DESCRIPTION
Removes the `m_name` field from `AstVarRef`; instead, `AstVar`'s name is used directly.
`AstVarRef` is among the most commonly occurring nodes,
so dropping this one field is a huge win in memory use (and even a win in performance),
as evidenced by these benchmark results:

|  Design    |  Max RSS / commit 959387b6   |  Max RSS / this patch   |  Time / commit 959387b6   |  Time / this patch   |
|:-----------|-----------------------------:|------------------------:|--------------------------:|---------------------:|
| 720 kLOC   | 9.84 GB                      | 8.75 GB  (89%)          | 121.41 s                  | 117.12 s (96%)       |
| 1080 kLOC  | 12.84 GB                     | 11.37 GB (88%)          | 224.42 s                  | 213.83 s (95%)       |
| 1590 kLOC  | 16.57 GB                     | 15.18 GB (92%)          | 279 s                     | 268.21 s (96%)       |
| 2860 kLOC  | 54.37 GB                     | 48.28 GB (89%)          | 720.49 s                  | 685.27 s (95%)       |

(959387b6 is a recent mainline commit; kLOC = 1000 lines of code; Max RSS is mean maximum RSS during verilation; Time
is mean verilation time; `tcmalloc` enabled)
