### PR TITLE
Use runtime type info instead of `dynamic_cast` for graph type checks

### DIFF
--- a/src/V3Active.cpp
+++ b/src/V3Active.cpp
@@ -47,6 +47,7 @@ VL_DEFINE_DEBUG_FUNCTIONS;
 // Extend V3GraphVertex class for use in latch detection graph
 
 class LatchDetectGraphVertex final : public V3GraphVertex {
+    VL_RTTI_IMPLEMENTATION(LatchDetectGraphVertex, V3GraphVertex)
 public:
     enum VertexType : uint8_t { VT_BLOCK, VT_BRANCH, VT_OUTPUT };
 

--- a/src/V3Active.cpp
+++ b/src/V3Active.cpp
@@ -47,7 +47,7 @@ VL_DEFINE_DEBUG_FUNCTIONS;
 // Extend V3GraphVertex class for use in latch detection graph
 
 class LatchDetectGraphVertex final : public V3GraphVertex {
-    VL_RTTI_IMPLEMENTATION(LatchDetectGraphVertex, V3GraphVertex)
+    VL_RTTI_IMPL(LatchDetectGraphVertex, V3GraphVertex)
 public:
     enum VertexType : uint8_t { VT_BLOCK, VT_BRANCH, VT_OUTPUT };
 

--- a/src/V3Gate.cpp
+++ b/src/V3Gate.cpp
@@ -65,7 +65,7 @@ public:
 // Support classes
 
 class GateEitherVertex VL_NOT_FINAL : public V3GraphVertex {
-    VL_RTTI_IMPLEMENTATION(GateEitherVertex, V3GraphVertex)
+    VL_RTTI_IMPL(GateEitherVertex, V3GraphVertex)
     AstScope* const m_scopep;  // Scope vertex refers to
     bool m_reducible = true;  // True if this node should be able to be eliminated
     bool m_dedupable = true;  // True if this node should be able to be deduped
@@ -123,7 +123,7 @@ public:
 };
 
 class GateVarVertex final : public GateEitherVertex {
-    VL_RTTI_IMPLEMENTATION(GateVarVertex, GateEitherVertex)
+    VL_RTTI_IMPL(GateVarVertex, GateEitherVertex)
     AstVarScope* const m_varScp;
     bool m_isTop = false;
     bool m_isClock = false;
@@ -166,7 +166,7 @@ public:
 };
 
 class GateLogicVertex final : public GateEitherVertex {
-    VL_RTTI_IMPLEMENTATION(GateLogicVertex, GateEitherVertex)
+    VL_RTTI_IMPL(GateLogicVertex, GateEitherVertex)
     AstNode* const m_nodep;
     AstActive* const m_activep;  // Under what active; nullptr is ok (under cfunc or such)
     const bool m_slow;  // In slow block

--- a/src/V3Gate.cpp
+++ b/src/V3Gate.cpp
@@ -121,6 +121,11 @@ public:
     }
 };
 
+template <>
+bool V3GraphVertex::privateTypeTest<GateEitherVertex>(const V3GraphVertex* vtxp) {
+    return dynamic_cast<const GateEitherVertex*>(vtxp);
+}
+
 class GateVarVertex final : public GateEitherVertex {
     AstVarScope* const m_varScp;
     bool m_isTop = false;
@@ -578,7 +583,7 @@ public:
 
 void GateVisitor::optimizeSignals(bool allowMultiIn) {
     for (V3GraphVertex* itp = m_graph.verticesBeginp(); itp; itp = itp->verticesNextp()) {
-        GateVarVertex* const vvertexp = dynamic_cast<GateVarVertex*>(itp);
+        GateVarVertex* const vvertexp = itp->cast<GateVarVertex>();
 
         // Consider "inlining" variables
         if (!vvertexp) continue;
@@ -720,7 +725,7 @@ void GateVisitor::consumedMove() {
     // We need the "usually" block logic to do a better job at this
     for (V3GraphVertex* vertexp = m_graph.verticesBeginp(); vertexp;
          vertexp = vertexp->verticesNextp()) {
-        if (const GateVarVertex* const vvertexp = dynamic_cast<GateVarVertex*>(vertexp)) {
+        if (const GateVarVertex* const vvertexp = vertexp->cast<GateVarVertex>()) {
             if (!vvertexp->consumed() && !vvertexp->user()) {
                 UINFO(8, "Unconsumed " << vvertexp->varScp() << endl);
             }
@@ -744,7 +749,7 @@ void GateVisitor::consumedMove() {
 void GateVisitor::warnSignals() {
     AstNode::user2ClearTree();
     for (V3GraphVertex* itp = m_graph.verticesBeginp(); itp; itp = itp->verticesNextp()) {
-        if (const GateVarVertex* const vvertexp = dynamic_cast<GateVarVertex*>(itp)) {
+        if (const GateVarVertex* const vvertexp = itp->cast<GateVarVertex>()) {
             const AstVarScope* const vscp = vvertexp->varScp();
             const AstNode* const sp = vvertexp->rstSyncNodep();
             const AstNode* const ap = vvertexp->rstAsyncNodep();
@@ -1143,14 +1148,14 @@ void GateVisitor::dedupe() {
     // Traverse starting from each of the clocks
     UINFO(9, "Gate dedupe() clocks:\n");
     for (V3GraphVertex* itp = m_graph.verticesBeginp(); itp; itp = itp->verticesNextp()) {
-        if (GateVarVertex* const vvertexp = dynamic_cast<GateVarVertex*>(itp)) {
+        if (GateVarVertex* const vvertexp = itp->cast<GateVarVertex>()) {
             if (vvertexp->isClock()) deduper.dedupeTree(vvertexp);
         }
     }
     // Traverse starting from each of the outputs
     UINFO(9, "Gate dedupe() outputs:\n");
     for (V3GraphVertex* itp = m_graph.verticesBeginp(); itp; itp = itp->verticesNextp()) {
-        if (GateVarVertex* const vvertexp = dynamic_cast<GateVarVertex*>(itp)) {
+        if (GateVarVertex* const vvertexp = itp->cast<GateVarVertex>()) {
             if (vvertexp->isTop() && vvertexp->varScp()->varp()->isWritable()) {
                 deduper.dedupeTree(vvertexp);
             }
@@ -1194,8 +1199,7 @@ private:
         for (V3GraphEdge* edgep = vvertexp->inBeginp(); edgep;) {
             V3GraphEdge* oldedgep = edgep;
             edgep = edgep->inNextp();  // for recursive since the edge could be deleted
-            if (GateLogicVertex* const lvertexp
-                = dynamic_cast<GateLogicVertex*>(oldedgep->fromp())) {
+            if (GateLogicVertex* const lvertexp = oldedgep->fromp()->cast<GateLogicVertex>()) {
                 if (AstNodeAssign* const assignp = VN_CAST(lvertexp->nodep(), NodeAssign)) {
                     // if (lvertexp->outSize1() && VN_IS(assignp->lhsp(), Sel)) {
                     if (VN_IS(assignp->lhsp(), Sel) && lvertexp->outSize1()) {
@@ -1281,7 +1285,7 @@ void GateVisitor::mergeAssigns() {
     UINFO(6, "mergeAssigns\n");
     GateMergeAssignsGraphVisitor merger{&m_graph};
     for (V3GraphVertex* itp = m_graph.verticesBeginp(); itp; itp = itp->verticesNextp()) {
-        if (GateVarVertex* const vvertexp = dynamic_cast<GateVarVertex*>(itp)) {
+        if (GateVarVertex* const vvertexp = itp->cast<GateVarVertex>()) {
             merger.mergeAssignsTree(vvertexp);
         }
     }
@@ -1467,7 +1471,7 @@ void GateVisitor::decomposeClkVectors() {
     AstNode::user2ClearTree();
     GateClkDecompGraphVisitor decomposer{&m_graph};
     for (V3GraphVertex* itp = m_graph.verticesBeginp(); itp; itp = itp->verticesNextp()) {
-        if (GateVarVertex* const vertp = dynamic_cast<GateVarVertex*>(itp)) {
+        if (GateVarVertex* const vertp = itp->cast<GateVarVertex>()) {
             const AstVarScope* const vsp = vertp->varScp();
             if (vsp->varp()->attrClocker() == VVarAttrClocker::CLOCKER_YES) {
                 if (vsp->varp()->width() > 1) {

--- a/src/V3Gate.cpp
+++ b/src/V3Gate.cpp
@@ -65,6 +65,7 @@ public:
 // Support classes
 
 class GateEitherVertex VL_NOT_FINAL : public V3GraphVertex {
+    VL_RTTI_IMPLEMENTATION(GateEitherVertex, V3GraphVertex)
     AstScope* const m_scopep;  // Scope vertex refers to
     bool m_reducible = true;  // True if this node should be able to be eliminated
     bool m_dedupable = true;  // True if this node should be able to be deduped
@@ -121,12 +122,8 @@ public:
     }
 };
 
-template <>
-bool V3GraphVertex::privateTypeTest<GateEitherVertex>(const V3GraphVertex* vtxp) {
-    return dynamic_cast<const GateEitherVertex*>(vtxp);
-}
-
 class GateVarVertex final : public GateEitherVertex {
+    VL_RTTI_IMPLEMENTATION(GateVarVertex, GateEitherVertex)
     AstVarScope* const m_varScp;
     bool m_isTop = false;
     bool m_isClock = false;
@@ -169,6 +166,7 @@ public:
 };
 
 class GateLogicVertex final : public GateEitherVertex {
+    VL_RTTI_IMPLEMENTATION(GateLogicVertex, GateEitherVertex)
     AstNode* const m_nodep;
     AstActive* const m_activep;  // Under what active; nullptr is ok (under cfunc or such)
     const bool m_slow;  // In slow block

--- a/src/V3Graph.h
+++ b/src/V3Graph.h
@@ -199,6 +199,14 @@ protected:
     // CONSTRUCTORS
     V3GraphVertex(V3Graph* graphp, const V3GraphVertex& old);
 
+private:
+    // For internal use only.
+    // Note: specializations for some vertex types are provided by 'astgen'
+    template <typename T>
+    static bool privateTypeTest(const V3GraphVertex* vtxp) {
+        return typeid(T) == typeid(*vtxp);
+    }
+
 public:
     explicit V3GraphVertex(V3Graph* graphp);
     //! Clone copy constructor. Doesn't copy edges or user/userp.
@@ -208,6 +216,37 @@ public:
     virtual ~V3GraphVertex() = default;
     void unlinkEdges(V3Graph* graphp);
     void unlinkDelete(V3Graph* graphp);
+
+    // METHODS
+    // Subtype test
+    template <typename T>
+    bool is() const {
+        static_assert(std::is_base_of<V3GraphVertex, T>::value,
+                      "'T' must be a subtype of V3GraphVertex");
+        return privateTypeTest<typename std::remove_cv<T>::type>(this);
+    }
+
+    // Ensure subtype, then cast to that type
+    template <typename T>
+    T* as() {
+        UASSERT_OBJ(is<T>(), this, "V3GraphVertex is not of expected type");
+        return static_cast<T*>(this);
+    }
+    template <typename T>
+    const T* as() const {
+        UASSERT_OBJ(is<T>(), this, "V3GraphVertex is not of expected type");
+        return static_cast<const T*>(this);
+    }
+
+    // Cast to subtype, or null if different
+    template <typename T>
+    T* cast() {
+        return is<T>() ? static_cast<T*>(this) : nullptr;
+    }
+    template <typename T>
+    const T* cast() const {
+        return is<T>() ? static_cast<const T*>(this) : nullptr;
+    }
 
     // ACCESSORS
     virtual string name() const { return ""; }
@@ -257,6 +296,9 @@ public:
     V3GraphEdge* findConnectingEdgep(GraphWay way, const V3GraphVertex* waywardp);
 };
 
+// Specializations of privateTypeTest
+#include "V3GraphVertex__gen_type_tests.h"  // From ./astgen
+
 std::ostream& operator<<(std::ostream& os, V3GraphVertex* vertexp);
 
 //============================================================================
@@ -296,6 +338,14 @@ protected:
         init(graphp, fromp, top, old.m_weight, old.m_cutable);
     }
 
+private:
+    // For internal use only.
+    // Note: specializations for some vertex types are provided by 'astgen'
+    template <typename T>
+    static bool privateTypeTest(const V3GraphEdge* edgep) {
+        return typeid(T) == typeid(*edgep);
+    }
+
 public:
     //! Add DAG from one node to the specified node
     V3GraphEdge(V3Graph* graphp, V3GraphVertex* fromp, V3GraphVertex* top, int weight,
@@ -308,6 +358,36 @@ public:
     }
     virtual ~V3GraphEdge() = default;
     // METHODS
+    // Subtype test
+    template <typename T>
+    bool is() const {
+        static_assert(std::is_base_of<V3GraphEdge, T>::value,
+                      "'T' must be a subtype of V3GraphEdge");
+        return privateTypeTest<typename std::remove_cv<T>::type>(this);
+    }
+
+    // Ensure subtype, then cast to that type
+    template <typename T>
+    T* as() {
+        UASSERT(is<T>(), "V3GraphEdge is not of expected type");
+        return static_cast<T*>(this);
+    }
+    template <typename T>
+    const T* as() const {
+        UASSERT(is<T>(), "V3GraphEdge is not of expected type");
+        return static_cast<const T*>(this);
+    }
+
+    // Cast to subtype, or null if different
+    template <typename T>
+    T* cast() {
+        return is<T>() ? static_cast<T*>(this) : nullptr;
+    }
+    template <typename T>
+    const T* cast() const {
+        return is<T>() ? static_cast<const T*>(this) : nullptr;
+    }
+
     virtual string name() const { return m_fromp->name() + "->" + m_top->name(); }
     virtual string dotLabel() const { return ""; }
     virtual string dotColor() const { return cutable() ? "yellowGreen" : "red"; }
@@ -340,6 +420,9 @@ public:
     V3GraphEdge* inNextp() const { return m_ins.nextp(); }
     V3GraphEdge* nextp(GraphWay way) const { return way.forward() ? outNextp() : inNextp(); }
 };
+
+// Specializations of privateTypeTest
+#include "V3GraphEdge__gen_type_tests.h"  // From ./astgen
 
 //============================================================================
 

--- a/src/V3Graph.h
+++ b/src/V3Graph.h
@@ -172,7 +172,106 @@ public:
 
 //============================================================================
 
+// Holds list of types. For use mainly in compile-time code generation.
+template <typename... TN>
+struct VTypeList {
+    template <typename... UN>
+    constexpr VTypeList<TN..., UN...> operator+(VTypeList<UN...>) const {
+        return {};
+    }
+};
+
+namespace internal_vl {
+
+// Holds one type. Can be safely used as a return or argument type without any potential
+// limitations of held type.
+template <typename T>
+struct VTypeWrapper {
+    using type = T;
+};
+
+template <typename T0, typename... TN>
+static inline constexpr VTypeWrapper<T0> vlTlFront(VTypeList<T0, TN...>) {
+    return {};
+}
+
+}  // namespace internal_vl
+
+// Alias for front type held by type list `TL`.
+template <typename TL>
+using VTypeListFront = typename decltype(internal_vl::vlTlFront(TL{}))::type;
+
+template <typename TL1, typename TL2>
+using VJoinedTypeLists = decltype(TL1{} + TL2{});
+
+namespace internal_vl {
+
+inline static constexpr bool isClassIdOfOneOf(uintptr_t id, VTypeList<>) VL_PURE { return false; }
+
+template <typename Base0, typename... BaseN>
+inline static constexpr bool isClassIdOfOneOf(uintptr_t id, VTypeList<Base0, BaseN...>) VL_PURE {
+    return id == Base0::rttiClassId() || isClassIdOfOneOf(id, VTypeList<BaseN...>{});
+}
+
+#define INTERNAL_VL_RTTI_COMMON_IMPLEMENTATION(ThisClass) \
+private: \
+    struct RttiUniqueTypeForThisClass {}; \
+    static_assert( \
+        std::is_same<RttiUniqueTypeForThisClass, ThisClass::RttiUniqueTypeForThisClass>::value, \
+        "'ThisClass' argument (" #ThisClass ") does not match the class name"); \
+\
+public: \
+    /* Returns unique ID of the class. Useful with `isInstanceOfClassWithId()` method. */ \
+    static uintptr_t rttiClassId() VL_PURE { \
+        /* The only purpose of the following variable is to occupy an unique memory address. */ \
+        /* This address is used as an unique class ID. */ \
+        static char aStaticVariable; \
+        return reinterpret_cast<uintptr_t>(&aStaticVariable); \
+    }
+
+}  // namespace internal_vl
+
+// Call this macro at the beginning of class definition if the class derives from a
+// class with VL_RTTI_IMPLEMENTATION or VL_RTTI_IMPLEMENTATION_BASE calls.
+#define VL_RTTI_IMPLEMENTATION(ThisClass, DirectBaseClass) \
+    INTERNAL_VL_RTTI_COMMON_IMPLEMENTATION(ThisClass) \
+    static_assert( \
+        std::is_same<DirectBaseClass, \
+                     VTypeListFront<DirectBaseClass::RttiThisAndBaseClassesList>>::value, \
+        "Missing VL_RTTI_IMPLEMENTATION(...) in the direct base class (" #DirectBaseClass ")"); \
+\
+public: \
+    /* Type list containing this class and all base classes. */ \
+    using RttiThisAndBaseClassesList \
+        = VJoinedTypeLists<VTypeList<ThisClass>, \
+                           typename DirectBaseClass::RttiThisAndBaseClassesList>; \
+\
+protected: \
+    bool isInstanceOfClassWithId(uintptr_t id) const override VL_PURE { \
+        return ::internal_vl::isClassIdOfOneOf(id, RttiThisAndBaseClassesList{}); \
+    } \
+\
+private: /* Revert to private visibility after this macro */
+
+// Call this macro at the beginning of a base class to implement class type queries using
+// `p->isInstanceOfClassWithId(ClassName::rttiClassId())`.
+#define VL_RTTI_IMPLEMENTATION_BASE(ThisClass) \
+    INTERNAL_VL_RTTI_COMMON_IMPLEMENTATION(ThisClass) \
+public: \
+    /* Type list containing this class and all base classes. */ \
+    using RttiThisAndBaseClassesList = VTypeList<ThisClass>; \
+\
+protected: \
+    virtual bool isInstanceOfClassWithId(uintptr_t id) const VL_PURE { \
+        return id == rttiClassId(); \
+    } \
+\
+private: /* Revert to private visibility after this macro */
+
+//============================================================================
+
 class V3GraphVertex VL_NOT_FINAL {
+    VL_RTTI_IMPLEMENTATION_BASE(V3GraphVertex)
     // Vertices may be a 'gate'/wire statement OR a variable
 protected:
     friend class V3Graph;
@@ -199,14 +298,6 @@ protected:
     // CONSTRUCTORS
     V3GraphVertex(V3Graph* graphp, const V3GraphVertex& old);
 
-private:
-    // For internal use only.
-    // Note: specializations for some vertex types are provided by 'astgen'
-    template <typename T>
-    static bool privateTypeTest(const V3GraphVertex* vtxp) {
-        return typeid(T) == typeid(*vtxp);
-    }
-
 public:
     explicit V3GraphVertex(V3Graph* graphp);
     //! Clone copy constructor. Doesn't copy edges or user/userp.
@@ -223,7 +314,10 @@ public:
     bool is() const {
         static_assert(std::is_base_of<V3GraphVertex, T>::value,
                       "'T' must be a subtype of V3GraphVertex");
-        return privateTypeTest<typename std::remove_cv<T>::type>(this);
+        static_assert(std::is_same<typename std::remove_cv<T>::type,
+                                   VTypeListFront<typename T::RttiThisAndBaseClassesList>>::value,
+                      "Missing VL_RTTI_IMPLEMENTATION(...) call in 'T'");
+        return this->isInstanceOfClassWithId(T::rttiClassId());
     }
 
     // Ensure subtype, then cast to that type
@@ -296,14 +390,12 @@ public:
     V3GraphEdge* findConnectingEdgep(GraphWay way, const V3GraphVertex* waywardp);
 };
 
-// Specializations of privateTypeTest
-#include "V3GraphVertex__gen_type_tests.h"  // From ./astgen
-
 std::ostream& operator<<(std::ostream& os, V3GraphVertex* vertexp);
 
 //============================================================================
 
 class V3GraphEdge VL_NOT_FINAL {
+    VL_RTTI_IMPLEMENTATION_BASE(V3GraphEdge)
     // Wires/variables aren't edges.  Edges have only a single to/from vertex
 public:
     // ENUMS
@@ -338,14 +430,6 @@ protected:
         init(graphp, fromp, top, old.m_weight, old.m_cutable);
     }
 
-private:
-    // For internal use only.
-    // Note: specializations for some vertex types are provided by 'astgen'
-    template <typename T>
-    static bool privateTypeTest(const V3GraphEdge* edgep) {
-        return typeid(T) == typeid(*edgep);
-    }
-
 public:
     //! Add DAG from one node to the specified node
     V3GraphEdge(V3Graph* graphp, V3GraphVertex* fromp, V3GraphVertex* top, int weight,
@@ -363,7 +447,10 @@ public:
     bool is() const {
         static_assert(std::is_base_of<V3GraphEdge, T>::value,
                       "'T' must be a subtype of V3GraphEdge");
-        return privateTypeTest<typename std::remove_cv<T>::type>(this);
+        static_assert(std::is_same<typename std::remove_cv<T>::type,
+                                   VTypeListFront<typename T::RttiThisAndBaseClassesList>>::value,
+                      "Missing VL_RTTI_IMPLEMENTATION(...) call in 'T'");
+        return this->isInstanceOfClassWithId(T::rttiClassId());
     }
 
     // Ensure subtype, then cast to that type
@@ -420,9 +507,6 @@ public:
     V3GraphEdge* inNextp() const { return m_ins.nextp(); }
     V3GraphEdge* nextp(GraphWay way) const { return way.forward() ? outNextp() : inNextp(); }
 };
-
-// Specializations of privateTypeTest
-#include "V3GraphEdge__gen_type_tests.h"  // From ./astgen
 
 //============================================================================
 

--- a/src/V3Graph.h
+++ b/src/V3Graph.h
@@ -309,7 +309,7 @@ public:
     void unlinkDelete(V3Graph* graphp);
 
     // METHODS
-    // Subtype test
+    // Return true iff of type T
     template <typename T>
     bool is() const {
         static_assert(std::is_base_of<V3GraphVertex, T>::value,
@@ -320,7 +320,7 @@ public:
         return this->isInstanceOfClassWithId(T::rttiClassId());
     }
 
-    // Ensure subtype, then cast to that type
+    // Return cast to subtype T and assert of that type
     template <typename T>
     T* as() {
         UASSERT_OBJ(is<T>(), this, "V3GraphVertex is not of expected type");
@@ -332,7 +332,7 @@ public:
         return static_cast<const T*>(this);
     }
 
-    // Cast to subtype, or null if different
+    // Return cast to subtype T, else nullptr if different type
     template <typename T>
     T* cast() {
         return is<T>() ? static_cast<T*>(this) : nullptr;
@@ -442,7 +442,7 @@ public:
     }
     virtual ~V3GraphEdge() = default;
     // METHODS
-    // Subtype test
+    // Return true iff of type T
     template <typename T>
     bool is() const {
         static_assert(std::is_base_of<V3GraphEdge, T>::value,
@@ -453,7 +453,7 @@ public:
         return this->isInstanceOfClassWithId(T::rttiClassId());
     }
 
-    // Ensure subtype, then cast to that type
+    // Return cast to subtype T and assert of that type
     template <typename T>
     T* as() {
         UASSERT(is<T>(), "V3GraphEdge is not of expected type");
@@ -465,7 +465,7 @@ public:
         return static_cast<const T*>(this);
     }
 
-    // Cast to subtype, or null if different
+    // Return cast to subtype T, else nullptr if different type
     template <typename T>
     T* cast() {
         return is<T>() ? static_cast<T*>(this) : nullptr;

--- a/src/V3GraphAcyc.cpp
+++ b/src/V3GraphAcyc.cpp
@@ -32,7 +32,7 @@ VL_DEFINE_DEBUG_FUNCTIONS;
 //      Break the minimal number of backward edges to make the graph acyclic
 
 class GraphAcycVertex final : public V3GraphVertex {
-    VL_RTTI_IMPLEMENTATION(GraphAcycVertex, V3GraphVertex)
+    VL_RTTI_IMPL(GraphAcycVertex, V3GraphVertex)
     // user() is used for various sub-algorithm pieces
     V3GraphVertex* const m_origVertexp;  // Pointer to first vertex this represents
 protected:
@@ -57,7 +57,7 @@ public:
 //--------------------------------------------------------------------
 
 class GraphAcycEdge final : public V3GraphEdge {
-    VL_RTTI_IMPLEMENTATION(GraphAcycEdge, V3GraphEdge)
+    VL_RTTI_IMPL(GraphAcycEdge, V3GraphEdge)
     // userp() is always used to point to the head original graph edge
 private:
     using OrigEdgeList = std::list<V3GraphEdge*>;  // List of orig edges, see also GraphAcyc's decl

--- a/src/V3GraphAcyc.cpp
+++ b/src/V3GraphAcyc.cpp
@@ -32,6 +32,7 @@ VL_DEFINE_DEBUG_FUNCTIONS;
 //      Break the minimal number of backward edges to make the graph acyclic
 
 class GraphAcycVertex final : public V3GraphVertex {
+    VL_RTTI_IMPLEMENTATION(GraphAcycVertex, V3GraphVertex)
     // user() is used for various sub-algorithm pieces
     V3GraphVertex* const m_origVertexp;  // Pointer to first vertex this represents
 protected:
@@ -56,6 +57,7 @@ public:
 //--------------------------------------------------------------------
 
 class GraphAcycEdge final : public V3GraphEdge {
+    VL_RTTI_IMPLEMENTATION(GraphAcycEdge, V3GraphEdge)
     // userp() is always used to point to the head original graph edge
 private:
     using OrigEdgeList = std::list<V3GraphEdge*>;  // List of orig edges, see also GraphAcyc's decl

--- a/src/V3GraphTest.cpp
+++ b/src/V3GraphTest.cpp
@@ -72,6 +72,11 @@ public:
     string dotColor() const override { return "blue"; }
 };
 
+template <>
+bool V3GraphVertex::privateTypeTest<V3GraphTestVertex>(const V3GraphVertex* vtxp) {
+    return dynamic_cast<const V3GraphTestVertex*>(vtxp);
+}
+
 //######################################################################
 //######################################################################
 // Test vertices and nodes

--- a/src/V3GraphTest.cpp
+++ b/src/V3GraphTest.cpp
@@ -52,7 +52,7 @@ public:
 // Vertices and nodes
 
 class V3GraphTestVertex VL_NOT_FINAL : public V3GraphVertex {
-    VL_RTTI_IMPLEMENTATION(V3GraphTestVertex, V3GraphVertex)
+    VL_RTTI_IMPL(V3GraphTestVertex, V3GraphVertex)
     const string m_name;
 
 public:

--- a/src/V3GraphTest.cpp
+++ b/src/V3GraphTest.cpp
@@ -52,6 +52,7 @@ public:
 // Vertices and nodes
 
 class V3GraphTestVertex VL_NOT_FINAL : public V3GraphVertex {
+    VL_RTTI_IMPLEMENTATION(V3GraphTestVertex, V3GraphVertex)
     const string m_name;
 
 public:
@@ -71,11 +72,6 @@ public:
     // ACCESSORS
     string dotColor() const override { return "blue"; }
 };
-
-template <>
-bool V3GraphVertex::privateTypeTest<V3GraphTestVertex>(const V3GraphVertex* vtxp) {
-    return dynamic_cast<const V3GraphTestVertex*>(vtxp);
-}
 
 //######################################################################
 //######################################################################

--- a/src/V3LifePost.cpp
+++ b/src/V3LifePost.cpp
@@ -333,7 +333,7 @@ private:
         }
         for (V3GraphVertex* mtaskVxp = nodep->depGraphp()->verticesBeginp(); mtaskVxp;
              mtaskVxp = mtaskVxp->verticesNextp()) {
-            const ExecMTask* const mtaskp = dynamic_cast<ExecMTask*>(mtaskVxp);
+            const ExecMTask* const mtaskp = mtaskVxp->as<ExecMTask>();
             m_execMTaskp = mtaskp;
             m_sequence = 0;
             iterate(mtaskp->bodyp());

--- a/src/V3LinkCells.cpp
+++ b/src/V3LinkCells.cpp
@@ -77,7 +77,7 @@ public:
 };
 
 void LinkCellsGraph::loopsMessageCb(V3GraphVertex* vertexp) {
-    if (const LinkCellsVertex* const vvertexp = dynamic_cast<LinkCellsVertex*>(vertexp)) {
+    if (const LinkCellsVertex* const vvertexp = vertexp->cast<LinkCellsVertex>()) {
         vvertexp->modp()->v3warn(E_UNSUPPORTED,
                                  "Unsupported: Recursive multiple modules (module instantiates "
                                  "something leading back to itself): "
@@ -171,7 +171,7 @@ private:
         if (dumpGraphLevel()) m_graph.dumpDotFilePrefixed("linkcells");
         m_graph.rank();
         for (V3GraphVertex* itp = m_graph.verticesBeginp(); itp; itp = itp->verticesNextp()) {
-            if (const LinkCellsVertex* const vvertexp = dynamic_cast<LinkCellsVertex*>(itp)) {
+            if (const LinkCellsVertex* const vvertexp = itp->cast<LinkCellsVertex>()) {
                 // +1 so we leave level 1  for the new wrapper we'll make in a moment
                 AstNodeModule* const modp = vvertexp->modp();
                 modp->level(vvertexp->rank() + 1);

--- a/src/V3LinkCells.cpp
+++ b/src/V3LinkCells.cpp
@@ -52,7 +52,7 @@ public:
 };
 
 class LinkCellsVertex final : public V3GraphVertex {
-    VL_RTTI_IMPLEMENTATION(LinkCellsVertex, V3GraphVertex)
+    VL_RTTI_IMPL(LinkCellsVertex, V3GraphVertex)
     AstNodeModule* const m_modp;
 
 public:
@@ -70,7 +70,7 @@ public:
 };
 
 class LibraryVertex final : public V3GraphVertex {
-    VL_RTTI_IMPLEMENTATION(LibraryVertex, V3GraphVertex)
+    VL_RTTI_IMPL(LibraryVertex, V3GraphVertex)
 public:
     explicit LibraryVertex(V3Graph* graphp)
         : V3GraphVertex{graphp} {}

--- a/src/V3LinkCells.cpp
+++ b/src/V3LinkCells.cpp
@@ -52,6 +52,7 @@ public:
 };
 
 class LinkCellsVertex final : public V3GraphVertex {
+    VL_RTTI_IMPLEMENTATION(LinkCellsVertex, V3GraphVertex)
     AstNodeModule* const m_modp;
 
 public:
@@ -69,6 +70,7 @@ public:
 };
 
 class LibraryVertex final : public V3GraphVertex {
+    VL_RTTI_IMPLEMENTATION(LibraryVertex, V3GraphVertex)
 public:
     explicit LibraryVertex(V3Graph* graphp)
         : V3GraphVertex{graphp} {}

--- a/src/V3OrderGraph.h
+++ b/src/V3OrderGraph.h
@@ -102,6 +102,7 @@ public:
 // Vertex types
 
 class OrderEitherVertex VL_NOT_FINAL : public V3GraphVertex {
+    VL_RTTI_IMPLEMENTATION(OrderEitherVertex, V3GraphVertex)
     // Event domain of vertex. For OrderLogicVertex this represents the conditions when the logic
     // block must be executed. For OrderVarVertex, this is the union of the domains of all the
     // OrderLogicVertex vertices that drive the variable. If initially set to nullptr (e.g.: all
@@ -132,12 +133,8 @@ public:
     }
 };
 
-template <>
-inline bool V3GraphVertex::privateTypeTest<OrderEitherVertex>(const V3GraphVertex* vtxp) {
-    return dynamic_cast<const OrderEitherVertex*>(vtxp);
-}
-
 class OrderLogicVertex final : public OrderEitherVertex {
+    VL_RTTI_IMPLEMENTATION(OrderLogicVertex, OrderEitherVertex)
     AstNode* const m_nodep;  // The logic this vertex represents
     AstScope* const m_scopep;  // Scope the logic is under
     AstSenTree* const m_hybridp;  // Additional sensitivities for hybrid combinational logic
@@ -172,6 +169,7 @@ public:
 };
 
 class OrderVarVertex VL_NOT_FINAL : public OrderEitherVertex {
+    VL_RTTI_IMPLEMENTATION(OrderVarVertex, OrderEitherVertex)
     AstVarScope* const m_vscp;
 
 public:
@@ -193,12 +191,8 @@ public:
     // LCOV_EXCL_STOP
 };
 
-template <>
-inline bool V3GraphVertex::privateTypeTest<OrderVarVertex>(const V3GraphVertex* vtxp) {
-    return dynamic_cast<const OrderVarVertex*>(vtxp);
-}
-
 class OrderVarStdVertex final : public OrderVarVertex {
+    VL_RTTI_IMPLEMENTATION(OrderVarStdVertex, OrderVarVertex)
 public:
     // CONSTRUCTOR
     OrderVarStdVertex(OrderGraph* graphp, AstVarScope* vscp)
@@ -215,6 +209,7 @@ public:
 };
 
 class OrderVarPreVertex final : public OrderVarVertex {
+    VL_RTTI_IMPLEMENTATION(OrderVarPreVertex, OrderVarVertex)
 public:
     // CONSTRUCTOR
     OrderVarPreVertex(OrderGraph* graphp, AstVarScope* vscp)
@@ -231,6 +226,7 @@ public:
 };
 
 class OrderVarPostVertex final : public OrderVarVertex {
+    VL_RTTI_IMPLEMENTATION(OrderVarPostVertex, OrderVarVertex)
 public:
     // CONSTRUCTOR
     OrderVarPostVertex(OrderGraph* graphp, AstVarScope* vscp)
@@ -247,6 +243,7 @@ public:
 };
 
 class OrderVarPordVertex final : public OrderVarVertex {
+    VL_RTTI_IMPLEMENTATION(OrderVarPordVertex, OrderVarVertex)
 public:
     // CONSTRUCTOR
     OrderVarPordVertex(OrderGraph* graphp, AstVarScope* vscp)
@@ -266,6 +263,7 @@ public:
 // Edge type
 
 class OrderEdge final : public V3GraphEdge {
+    VL_RTTI_IMPLEMENTATION(OrderEdge, V3GraphEdge)
     friend class OrderGraph;  // Only the OrderGraph can create these
     // CONSTRUCTOR
     OrderEdge(OrderGraph* graphp, OrderEitherVertex* fromp, OrderEitherVertex* top, int weight,

--- a/src/V3OrderGraph.h
+++ b/src/V3OrderGraph.h
@@ -132,6 +132,11 @@ public:
     }
 };
 
+template <>
+inline bool V3GraphVertex::privateTypeTest<OrderEitherVertex>(const V3GraphVertex* vtxp) {
+    return dynamic_cast<const OrderEitherVertex*>(vtxp);
+}
+
 class OrderLogicVertex final : public OrderEitherVertex {
     AstNode* const m_nodep;  // The logic this vertex represents
     AstScope* const m_scopep;  // Scope the logic is under
@@ -187,6 +192,11 @@ public:
     }
     // LCOV_EXCL_STOP
 };
+
+template <>
+inline bool V3GraphVertex::privateTypeTest<OrderVarVertex>(const V3GraphVertex* vtxp) {
+    return dynamic_cast<const OrderVarVertex*>(vtxp);
+}
 
 class OrderVarStdVertex final : public OrderVarVertex {
 public:

--- a/src/V3OrderGraph.h
+++ b/src/V3OrderGraph.h
@@ -102,7 +102,7 @@ public:
 // Vertex types
 
 class OrderEitherVertex VL_NOT_FINAL : public V3GraphVertex {
-    VL_RTTI_IMPLEMENTATION(OrderEitherVertex, V3GraphVertex)
+    VL_RTTI_IMPL(OrderEitherVertex, V3GraphVertex)
     // Event domain of vertex. For OrderLogicVertex this represents the conditions when the logic
     // block must be executed. For OrderVarVertex, this is the union of the domains of all the
     // OrderLogicVertex vertices that drive the variable. If initially set to nullptr (e.g.: all
@@ -134,7 +134,7 @@ public:
 };
 
 class OrderLogicVertex final : public OrderEitherVertex {
-    VL_RTTI_IMPLEMENTATION(OrderLogicVertex, OrderEitherVertex)
+    VL_RTTI_IMPL(OrderLogicVertex, OrderEitherVertex)
     AstNode* const m_nodep;  // The logic this vertex represents
     AstScope* const m_scopep;  // Scope the logic is under
     AstSenTree* const m_hybridp;  // Additional sensitivities for hybrid combinational logic
@@ -169,7 +169,7 @@ public:
 };
 
 class OrderVarVertex VL_NOT_FINAL : public OrderEitherVertex {
-    VL_RTTI_IMPLEMENTATION(OrderVarVertex, OrderEitherVertex)
+    VL_RTTI_IMPL(OrderVarVertex, OrderEitherVertex)
     AstVarScope* const m_vscp;
 
 public:
@@ -192,7 +192,7 @@ public:
 };
 
 class OrderVarStdVertex final : public OrderVarVertex {
-    VL_RTTI_IMPLEMENTATION(OrderVarStdVertex, OrderVarVertex)
+    VL_RTTI_IMPL(OrderVarStdVertex, OrderVarVertex)
 public:
     // CONSTRUCTOR
     OrderVarStdVertex(OrderGraph* graphp, AstVarScope* vscp)
@@ -209,7 +209,7 @@ public:
 };
 
 class OrderVarPreVertex final : public OrderVarVertex {
-    VL_RTTI_IMPLEMENTATION(OrderVarPreVertex, OrderVarVertex)
+    VL_RTTI_IMPL(OrderVarPreVertex, OrderVarVertex)
 public:
     // CONSTRUCTOR
     OrderVarPreVertex(OrderGraph* graphp, AstVarScope* vscp)
@@ -226,7 +226,7 @@ public:
 };
 
 class OrderVarPostVertex final : public OrderVarVertex {
-    VL_RTTI_IMPLEMENTATION(OrderVarPostVertex, OrderVarVertex)
+    VL_RTTI_IMPL(OrderVarPostVertex, OrderVarVertex)
 public:
     // CONSTRUCTOR
     OrderVarPostVertex(OrderGraph* graphp, AstVarScope* vscp)
@@ -243,7 +243,7 @@ public:
 };
 
 class OrderVarPordVertex final : public OrderVarVertex {
-    VL_RTTI_IMPLEMENTATION(OrderVarPordVertex, OrderVarVertex)
+    VL_RTTI_IMPL(OrderVarPordVertex, OrderVarVertex)
 public:
     // CONSTRUCTOR
     OrderVarPordVertex(OrderGraph* graphp, AstVarScope* vscp)
@@ -263,7 +263,7 @@ public:
 // Edge type
 
 class OrderEdge final : public V3GraphEdge {
-    VL_RTTI_IMPLEMENTATION(OrderEdge, V3GraphEdge)
+    VL_RTTI_IMPL(OrderEdge, V3GraphEdge)
     friend class OrderGraph;  // Only the OrderGraph can create these
     // CONSTRUCTOR
     OrderEdge(OrderGraph* graphp, OrderEitherVertex* fromp, OrderEitherVertex* top, int weight,

--- a/src/V3OrderMoveGraph.h
+++ b/src/V3OrderMoveGraph.h
@@ -33,7 +33,7 @@
 class OrderMoveDomScope;
 
 class OrderMoveVertex final : public V3GraphVertex {
-    VL_RTTI_IMPLEMENTATION(OrderMoveVertex, V3GraphVertex)
+    VL_RTTI_IMPL(OrderMoveVertex, V3GraphVertex)
     enum OrderMState : uint8_t { POM_WAIT, POM_READY, POM_MOVED };
 
     OrderLogicVertex* const m_logicp;
@@ -93,7 +93,7 @@ public:
 
 // Similar to OrderMoveVertex, but modified for threaded code generation.
 class MTaskMoveVertex final : public V3GraphVertex {
-    VL_RTTI_IMPLEMENTATION(MTaskMoveVertex, V3GraphVertex)
+    VL_RTTI_IMPL(MTaskMoveVertex, V3GraphVertex)
     //  This could be more compact, since we know m_varp and m_logicp
     //  cannot both be set. Each MTaskMoveVertex represents a logic node
     //  or a var node, it can't be both.

--- a/src/V3OrderMoveGraph.h
+++ b/src/V3OrderMoveGraph.h
@@ -33,6 +33,7 @@
 class OrderMoveDomScope;
 
 class OrderMoveVertex final : public V3GraphVertex {
+    VL_RTTI_IMPLEMENTATION(OrderMoveVertex, V3GraphVertex)
     enum OrderMState : uint8_t { POM_WAIT, POM_READY, POM_MOVED };
 
     OrderLogicVertex* const m_logicp;
@@ -92,6 +93,7 @@ public:
 
 // Similar to OrderMoveVertex, but modified for threaded code generation.
 class MTaskMoveVertex final : public V3GraphVertex {
+    VL_RTTI_IMPLEMENTATION(MTaskMoveVertex, V3GraphVertex)
     //  This could be more compact, since we know m_varp and m_logicp
     //  cannot both be set. Each MTaskMoveVertex represents a logic node
     //  or a var node, it can't be both.

--- a/src/V3Partition.cpp
+++ b/src/V3Partition.cpp
@@ -511,7 +511,7 @@ static_assert(!std::is_polymorphic<SiblingMC>::value, "Should not have a vtable"
 
 // GraphEdge for the MTask graph
 class MTaskEdge final : public V3GraphEdge, public MergeCandidate {
-    VL_RTTI_IMPLEMENTATION(MTaskEdge, V3GraphEdge)
+    VL_RTTI_IMPL(MTaskEdge, V3GraphEdge)
     friend class LogicMTask;
     template <GraphWay::en T_Way>
     friend class PartPropagateCp;

--- a/src/V3Partition.cpp
+++ b/src/V3Partition.cpp
@@ -448,10 +448,10 @@ private:
 
 public:
     // METHODS
-    SiblingMC* toSiblingMC();  // Instead of dynamic_cast
-    const SiblingMC* toSiblingMC() const;  // Instead of dynamic_cast
-    MTaskEdge* toMTaskEdge();  // Instead of dynamic_cast
-    const MTaskEdge* toMTaskEdge() const;  // Instead of dynamic_cast
+    SiblingMC* toSiblingMC();  // Instead of cast<>/as<>
+    const SiblingMC* toSiblingMC() const;  // Instead of cast<>/as<>
+    MTaskEdge* toMTaskEdge();  // Instead of cast<>/as<>
+    const MTaskEdge* toMTaskEdge() const;  // Instead of cast<>/as<>
     bool mergeWouldCreateCycle() const;  // Instead of virtual method
 
     inline void rescore();
@@ -806,7 +806,7 @@ public:
         UINFO(0, "    Parallelism factor = " << parallelismFactor() << endl);
     }
     static uint32_t vertexCost(const V3GraphVertex* vertexp) {
-        return dynamic_cast<const AbstractMTask*>(vertexp)->cost();
+        return vertexp->as<const AbstractMTask>()->cost();
     }
 
 private:
@@ -857,7 +857,7 @@ static void partInitCriticalPaths(V3Graph* mtasksp) {
     // They would have been all zeroes on initial creation of the MTaskEdges.
     for (V3GraphVertex* vxp = mtasksp->verticesBeginp(); vxp; vxp = vxp->verticesNextp()) {
         for (V3GraphEdge* edgep = vxp->outBeginp(); edgep; edgep = edgep->outNextp()) {
-            MTaskEdge* const mtedgep = dynamic_cast<MTaskEdge*>(edgep);
+            MTaskEdge* const mtedgep = edgep->as<MTaskEdge>();
             mtedgep->resetCriticalPaths();
         }
     }
@@ -1966,7 +1966,7 @@ private:
     void findAdjacentTasks(const OrderVarStdVertex* varVtxp, TasksByRank& tasksByRank) {
         // Find all writer tasks for this variable, group by rank.
         for (V3GraphEdge* edgep = varVtxp->inBeginp(); edgep; edgep = edgep->inNextp()) {
-            if (const auto* const logicVtxp = dynamic_cast<OrderLogicVertex*>(edgep->fromp())) {
+            if (const auto* const logicVtxp = edgep->fromp()->cast<OrderLogicVertex>()) {
                 LogicMTask* const writerMtaskp = static_cast<LogicMTask*>(logicVtxp->userp());
                 tasksByRank[writerMtaskp->rank()].insert(writerMtaskp);
             }
@@ -2058,7 +2058,7 @@ public:
             nextp = vtxp->verticesNextp();
             // Only consider OrderVarStdVertex which reflects
             // an actual lvalue assignment; the others do not.
-            if (const OrderVarStdVertex* const vvtxp = dynamic_cast<OrderVarStdVertex*>(vtxp)) {
+            if (const OrderVarStdVertex* const vvtxp = vtxp->cast<OrderVarStdVertex>()) {
                 if (vvtxp->vscp()->varp()->isSc()) {
                     systemCVars.push_back(vvtxp);
                 } else {
@@ -2203,7 +2203,7 @@ public:
         const uint32_t thisThreadId = threadId(mtaskp);
         uint32_t result = 0;
         for (V3GraphEdge* edgep = mtaskp->inBeginp(); edgep; edgep = edgep->inNextp()) {
-            const ExecMTask* const prevp = dynamic_cast<ExecMTask*>(edgep->fromp());
+            const ExecMTask* const prevp = edgep->fromp()->as<ExecMTask>();
             if (threadId(prevp) != thisThreadId) ++result;
         }
         return result;
@@ -2248,7 +2248,7 @@ void ThreadSchedule::dumpDotFile(const V3Graph& graph, const string& filename) c
     // Find minimum cost MTask for scaling MTask node widths
     uint32_t minCost = UINT32_MAX;
     for (const V3GraphVertex* vxp = graph.verticesBeginp(); vxp; vxp = vxp->verticesNextp()) {
-        if (const ExecMTask* const mtaskp = dynamic_cast<const ExecMTask*>(vxp)) {
+        if (const ExecMTask* const mtaskp = vxp->cast<const ExecMTask>()) {
             minCost = minCost > mtaskp->cost() ? mtaskp->cost() : minCost;
         }
     }
@@ -2271,13 +2271,13 @@ void ThreadSchedule::dumpDotFile(const V3Graph& graph, const string& filename) c
 
     // Emit MTasks
     for (const V3GraphVertex* vxp = graph.verticesBeginp(); vxp; vxp = vxp->verticesNextp()) {
-        if (const ExecMTask* const mtaskp = dynamic_cast<const ExecMTask*>(vxp)) emitMTask(mtaskp);
+        if (const ExecMTask* const mtaskp = vxp->cast<const ExecMTask>()) emitMTask(mtaskp);
     }
 
     // Emit MTask dependency edges
     *logp << "\n  // MTask dependencies\n";
     for (const V3GraphVertex* vxp = graph.verticesBeginp(); vxp; vxp = vxp->verticesNextp()) {
-        if (const ExecMTask* const mtaskp = dynamic_cast<const ExecMTask*>(vxp)) {
+        if (const ExecMTask* const mtaskp = vxp->cast<const ExecMTask>()) {
             for (V3GraphEdge* edgep = mtaskp->outBeginp(); edgep; edgep = edgep->outNextp()) {
                 const V3GraphVertex* const top = edgep->top();
                 *logp << "  " << vxp->name() << " -> " << top->name() << "\n";
@@ -2365,7 +2365,7 @@ private:
 
     bool isReady(ThreadSchedule& schedule, const ExecMTask* mtaskp) {
         for (V3GraphEdge* edgeInp = mtaskp->inBeginp(); edgeInp; edgeInp = edgeInp->inNextp()) {
-            const ExecMTask* const prevp = dynamic_cast<ExecMTask*>(edgeInp->fromp());
+            const ExecMTask* const prevp = edgeInp->fromp()->as<const ExecMTask>();
             if (schedule.threadId(prevp) == ThreadSchedule::UNASSIGNED) {
                 // This predecessor is not assigned yet
                 return false;
@@ -2388,7 +2388,7 @@ public:
 
         // Build initial ready list
         for (V3GraphVertex* vxp = mtaskGraph.verticesBeginp(); vxp; vxp = vxp->verticesNextp()) {
-            ExecMTask* const mtaskp = dynamic_cast<ExecMTask*>(vxp);
+            ExecMTask* const mtaskp = vxp->as<ExecMTask>();
             if (isReady(schedule, mtaskp)) readyMTasks.insert(mtaskp);
         }
 
@@ -2409,7 +2409,7 @@ public:
                     }
                     for (V3GraphEdge* edgep = mtaskp->inBeginp(); edgep;
                          edgep = edgep->inNextp()) {
-                        const ExecMTask* const priorp = dynamic_cast<ExecMTask*>(edgep->fromp());
+                        const ExecMTask* const priorp = edgep->fromp()->as<ExecMTask>();
                         const uint32_t priorEndTime = completionTime(schedule, priorp, threadId);
                         if (priorEndTime > timeBegin) timeBegin = priorEndTime;
                     }
@@ -2449,7 +2449,7 @@ public:
             UASSERT_OBJ(erased > 0, bestMtaskp, "Should have erased something?");
             for (V3GraphEdge* edgeOutp = bestMtaskp->outBeginp(); edgeOutp;
                  edgeOutp = edgeOutp->outNextp()) {
-                ExecMTask* const nextp = dynamic_cast<ExecMTask*>(edgeOutp->top());
+                ExecMTask* const nextp = edgeOutp->top()->as<ExecMTask>();
                 // Dependent MTask should not yet be assigned to a thread
                 UASSERT(schedule.threadId(nextp) == ThreadSchedule::UNASSIGNED,
                         "Tasks after one being assigned should not be assigned yet");
@@ -2540,7 +2540,7 @@ void V3Partition::debugMTaskGraphStats(const V3Graph* graphp, const string& stag
     for (const V3GraphVertex* mtaskp = graphp->verticesBeginp(); mtaskp;
          mtaskp = mtaskp->verticesNextp()) {
         ++mtaskCount;
-        uint32_t mtaskCost = dynamic_cast<const AbstractMTask*>(mtaskp)->cost();
+        uint32_t mtaskCost = mtaskp->as<const AbstractMTask>()->cost();
         totalCost += mtaskCost;
 
         unsigned log2Cost = 0;
@@ -2928,7 +2928,7 @@ static void fillinCosts(V3Graph* execMTaskGraphp) {
 
     for (const V3GraphVertex* vxp = execMTaskGraphp->verticesBeginp(); vxp;
          vxp = vxp->verticesNextp()) {
-        ExecMTask* const mtp = dynamic_cast<ExecMTask*>(const_cast<V3GraphVertex*>(vxp));
+        ExecMTask* const mtp = const_cast<V3GraphVertex*>(vxp)->as<ExecMTask>();
         // Compute name of mtask, for hash lookup
         mtp->hashName(m_uniqueNames.get(mtp->bodyp()));
 
@@ -2949,7 +2949,7 @@ static void fillinCosts(V3Graph* execMTaskGraphp) {
     int missingProfiles = 0;
     for (const V3GraphVertex* vxp = execMTaskGraphp->verticesBeginp(); vxp;
          vxp = vxp->verticesNextp()) {
-        ExecMTask* const mtp = dynamic_cast<ExecMTask*>(const_cast<V3GraphVertex*>(vxp));
+        ExecMTask* const mtp = const_cast<V3GraphVertex*>(vxp)->as<ExecMTask>();
         const uint32_t costEstimate = costs[mtp->id()].first;
         const uint64_t costProfiled = costs[mtp->id()].second;
         UINFO(9, "ce = " << costEstimate << " cp=" << costProfiled << endl);
@@ -2978,14 +2978,14 @@ static void fillinCosts(V3Graph* execMTaskGraphp) {
 static void finalizeCosts(V3Graph* execMTaskGraphp) {
     GraphStreamUnordered ser(execMTaskGraphp, GraphWay::REVERSE);
     while (const V3GraphVertex* const vxp = ser.nextp()) {
-        ExecMTask* const mtp = dynamic_cast<ExecMTask*>(const_cast<V3GraphVertex*>(vxp));
+        ExecMTask* const mtp = const_cast<V3GraphVertex*>(vxp)->as<ExecMTask>();
         // "Priority" is the critical path from the start of the mtask, to
         // the end of the graph reachable from this mtask.  Given the
         // choice among several ready mtasks, we'll want to start the
         // highest priority one first, so we're always working on the "long
         // pole"
         for (V3GraphEdge* edgep = mtp->outBeginp(); edgep; edgep = edgep->outNextp()) {
-            const ExecMTask* const followp = dynamic_cast<ExecMTask*>(edgep->top());
+            const ExecMTask* const followp = edgep->top()->as<ExecMTask>();
             if ((followp->priority() + mtp->cost()) > mtp->priority()) {
                 mtp->priority(followp->priority() + mtp->cost());
             }
@@ -2996,7 +2996,7 @@ static void finalizeCosts(V3Graph* execMTaskGraphp) {
     // (It's common for tasks to shrink to nothing when V3LifePost
     // removes dly assignments.)
     for (V3GraphVertex* vxp = execMTaskGraphp->verticesBeginp(); vxp;) {
-        ExecMTask* const mtp = dynamic_cast<ExecMTask*>(vxp);
+        ExecMTask* const mtp = vxp->as<ExecMTask>();
         vxp = vxp->verticesNextp();  // Advance before delete
 
         // Don't rely on checking mtp->cost() == 0 to detect an empty task.
@@ -3100,7 +3100,7 @@ static void addMTaskToFunction(const ThreadSchedule& schedule, const uint32_t th
 
     // For any dependent mtask that's on another thread, signal one dependency completion.
     for (V3GraphEdge* edgep = mtaskp->outBeginp(); edgep; edgep = edgep->outNextp()) {
-        const ExecMTask* const nextp = dynamic_cast<ExecMTask*>(edgep->top());
+        const ExecMTask* const nextp = edgep->top()->as<ExecMTask>();
         if (schedule.threadId(nextp) != threadId) {
             addStrStmt("vlSelf->__Vm_mtaskstate_" + cvtToStr(nextp->id())
                        + ".signalUpstreamDone(even_cycle);\n");

--- a/src/V3Partition.cpp
+++ b/src/V3Partition.cpp
@@ -511,6 +511,7 @@ static_assert(!std::is_polymorphic<SiblingMC>::value, "Should not have a vtable"
 
 // GraphEdge for the MTask graph
 class MTaskEdge final : public V3GraphEdge, public MergeCandidate {
+    VL_RTTI_IMPLEMENTATION(MTaskEdge, V3GraphEdge)
     friend class LogicMTask;
     template <GraphWay::en T_Way>
     friend class PartPropagateCp;

--- a/src/V3PartitionGraph.h
+++ b/src/V3PartitionGraph.h
@@ -29,7 +29,7 @@
 // MTasks and graph structures
 
 class AbstractMTask VL_NOT_FINAL : public V3GraphVertex {
-    VL_RTTI_IMPLEMENTATION(AbstractMTask, V3GraphVertex)
+    VL_RTTI_IMPL(AbstractMTask, V3GraphVertex)
 public:
     explicit AbstractMTask(V3Graph* graphp)
         : V3GraphVertex{graphp} {}
@@ -39,7 +39,7 @@ public:
 };
 
 class AbstractLogicMTask VL_NOT_FINAL : public AbstractMTask {
-    VL_RTTI_IMPLEMENTATION(AbstractLogicMTask, AbstractMTask)
+    VL_RTTI_IMPL(AbstractLogicMTask, AbstractMTask)
 public:
     // TYPES
     using VxList = std::list<MTaskMoveVertex*>;
@@ -55,7 +55,7 @@ public:
 };
 
 class ExecMTask final : public AbstractMTask {
-    VL_RTTI_IMPLEMENTATION(ExecMTask, AbstractMTask)
+    VL_RTTI_IMPL(ExecMTask, AbstractMTask)
 private:
     AstMTaskBody* const m_bodyp;  // Task body
     const uint32_t m_id;  // Unique id of this mtask.

--- a/src/V3PartitionGraph.h
+++ b/src/V3PartitionGraph.h
@@ -37,6 +37,11 @@ public:
     virtual uint32_t cost() const = 0;
 };
 
+template <>
+inline bool V3GraphVertex::privateTypeTest<AbstractMTask>(const V3GraphVertex* vtxp) {
+    return dynamic_cast<const AbstractMTask*>(vtxp);
+}
+
 class AbstractLogicMTask VL_NOT_FINAL : public AbstractMTask {
 public:
     // TYPES
@@ -51,6 +56,11 @@ public:
     uint32_t id() const override = 0;  // Unique id of this mtask.
     uint32_t cost() const override = 0;
 };
+
+template <>
+inline bool V3GraphVertex::privateTypeTest<AbstractLogicMTask>(const V3GraphVertex* vtxp) {
+    return dynamic_cast<const AbstractLogicMTask*>(vtxp);
+}
 
 class ExecMTask final : public AbstractMTask {
 private:

--- a/src/V3PartitionGraph.h
+++ b/src/V3PartitionGraph.h
@@ -29,6 +29,7 @@
 // MTasks and graph structures
 
 class AbstractMTask VL_NOT_FINAL : public V3GraphVertex {
+    VL_RTTI_IMPLEMENTATION(AbstractMTask, V3GraphVertex)
 public:
     explicit AbstractMTask(V3Graph* graphp)
         : V3GraphVertex{graphp} {}
@@ -37,12 +38,8 @@ public:
     virtual uint32_t cost() const = 0;
 };
 
-template <>
-inline bool V3GraphVertex::privateTypeTest<AbstractMTask>(const V3GraphVertex* vtxp) {
-    return dynamic_cast<const AbstractMTask*>(vtxp);
-}
-
 class AbstractLogicMTask VL_NOT_FINAL : public AbstractMTask {
+    VL_RTTI_IMPLEMENTATION(AbstractLogicMTask, AbstractMTask)
 public:
     // TYPES
     using VxList = std::list<MTaskMoveVertex*>;
@@ -57,12 +54,8 @@ public:
     uint32_t cost() const override = 0;
 };
 
-template <>
-inline bool V3GraphVertex::privateTypeTest<AbstractLogicMTask>(const V3GraphVertex* vtxp) {
-    return dynamic_cast<const AbstractLogicMTask*>(vtxp);
-}
-
 class ExecMTask final : public AbstractMTask {
+    VL_RTTI_IMPLEMENTATION(ExecMTask, AbstractMTask)
 private:
     AstMTaskBody* const m_bodyp;  // Task body
     const uint32_t m_id;  // Unique id of this mtask.

--- a/src/V3Rtti.h
+++ b/src/V3Rtti.h
@@ -1,0 +1,131 @@
+// -*- mode: C++; c-file-style: "cc-mode" -*-
+//*************************************************************************
+// DESCRIPTION: Verilator: Simple and efficient Run-Time Type Information
+//
+// Code available from: https://verilator.org
+//
+//*************************************************************************
+//
+// Copyright 2003-2023 by Wilson Snyder. This program is free software; you
+// can redistribute it and/or modify it under the terms of either the GNU
+// Lesser General Public License Version 3 or the Perl Artistic License
+// Version 2.0.
+// SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+//
+//*************************************************************************
+
+#ifndef VERILATOR_V3RTTI_H_
+#define VERILATOR_V3RTTI_H_
+
+#include "verilatedos.h"
+
+#include <cstdint>
+#include <type_traits>
+
+// Holds list of types as template parameter pack.
+// Useful in compile-time code generation.
+template <typename... TN>
+struct VTypeList {
+    template <typename... UN>
+    constexpr VTypeList<TN..., UN...> operator+(VTypeList<UN...>) const {
+        return {};
+    }
+};
+
+// Holds one type.
+// Can be safely used as a return or argument type, and even instantiated, without triggering any
+// potential limitations or effects of the held type.
+template <typename T>
+struct VTypeWrapper {
+    using type_t = T;
+};
+
+// Implementation details of other constructs defined in this header.
+namespace V3RttiInternal {
+
+// Helper function for extracting first type from VTypeList.
+template <typename T0, typename... TN>
+static inline constexpr VTypeWrapper<T0> vlTypeListFront(VTypeList<T0, TN...>) {
+    return {};
+}
+
+// Overload for empty type list. Returns false.
+inline static constexpr bool isClassIdOfOneOf(uintptr_t id, VTypeList<>) VL_PURE { return false; }
+
+// Returns true iff `id` has the same value as `T::rttiClassId()`, where `T` is any type held by
+// `VTypeList` object passed as the second argument.
+template <typename Base0, typename... BaseN>
+inline static constexpr bool isClassIdOfOneOf(uintptr_t id, VTypeList<Base0, BaseN...>) VL_PURE {
+    return id == Base0::rttiClassId() || isClassIdOfOneOf(id, VTypeList<BaseN...>{});
+}
+
+}  // namespace V3RttiInternal
+
+// Alias for the first (frontmost) type held by type list `TL`.
+template <typename TL>
+using VTypeListFront = typename decltype(::V3RttiInternal::vlTypeListFront(TL{}))::type_t;
+
+// `VTypeList` holding types from type lists `TL1` followed by types from type list `TL2`.
+template <typename TL1, typename TL2>
+using VJoinedTypeLists = decltype(TL1{} + TL2{});
+
+// Common code used by VL_RTTI_COMMON_IMPL and VL_RTTI_COMMON_IMPL_BASE.
+#define V3RTTIINTERNAL_VL_RTTI_COMMON_IMPL(ThisClass) \
+private: \
+    /* A type used only for implementation of the static_assert below. */ \
+    struct RttiUniqueTypeForThisClass {}; \
+    static_assert( \
+        std::is_same<RttiUniqueTypeForThisClass, ThisClass::RttiUniqueTypeForThisClass>::value, \
+        "'ThisClass' argument (" #ThisClass ") does not match the class name"); \
+\
+public: \
+    /* Returns unique ID of the class. Useful with `isInstanceOfClassWithId()` method. */ \
+    static uintptr_t rttiClassId() VL_PURE { \
+        /* The only purpose of the following variable is to occupy an unique memory address. */ \
+        /* This address is used as an unique class ID. */ \
+        static char aStaticVariable; \
+        return reinterpret_cast<uintptr_t>(&aStaticVariable); \
+    }
+
+// Call this macro at the beginning of class definition if the class derives from a
+// class with VL_RTTI_IMPL or VL_RTTI_IMPL_BASE calls.
+#define VL_RTTI_IMPL(ThisClass, DirectBaseClass) \
+    V3RTTIINTERNAL_VL_RTTI_COMMON_IMPL(ThisClass) \
+    static_assert( \
+        std::is_same<DirectBaseClass, \
+                     VTypeListFront<DirectBaseClass::RttiThisAndBaseClassesList>>::value, \
+        "Missing VL_RTTI_IMPL(...) in the direct base class (" #DirectBaseClass ")"); \
+\
+public: \
+    /* Type list containing this class and all classes from the inheritance chain. */ \
+    using RttiThisAndBaseClassesList \
+        = VJoinedTypeLists<VTypeList<ThisClass>, \
+                           typename DirectBaseClass::RttiThisAndBaseClassesList>; \
+\
+protected: \
+    /* Returns true iff `id` has the same value as `T::rttiClassId()`, where `T` is either this \
+     * class or any class from this class' inheritance chain. */ \
+    bool isInstanceOfClassWithId(uintptr_t id) const override VL_PURE { \
+        return ::V3RttiInternal::isClassIdOfOneOf(id, RttiThisAndBaseClassesList{}); \
+    } \
+\
+private: /* Revert to private visibility after this macro */
+
+// Call this macro at the beginning of a base class to implement class type queries using
+// `p->isInstanceOfClassWithId(ClassName::rttiClassId())`.
+#define VL_RTTI_IMPL_BASE(ThisClass) \
+    V3RTTIINTERNAL_VL_RTTI_COMMON_IMPL(ThisClass) \
+public: \
+    /* Type list containing this class and all classes from the inheritance chain. */ \
+    using RttiThisAndBaseClassesList = VTypeList<ThisClass>; \
+\
+protected: \
+    /* Returns true iff `id` has the same value as value returned by this class' \
+       `rttiClassId()` method. */ \
+    virtual bool isInstanceOfClassWithId(uintptr_t id) const VL_PURE { \
+        return id == rttiClassId(); \
+    } \
+\
+private: /* Revert to private visibility after this macro */
+
+#endif  // Guard

--- a/src/V3SchedAcyclic.cpp
+++ b/src/V3SchedAcyclic.cpp
@@ -60,7 +60,7 @@ namespace {
 //  Data structures (graph types)
 
 class SchedAcyclicLogicVertex final : public V3GraphVertex {
-    VL_RTTI_IMPLEMENTATION(SchedAcyclicLogicVertex, V3GraphVertex)
+    VL_RTTI_IMPL(SchedAcyclicLogicVertex, V3GraphVertex)
     AstNode* const m_logicp;  // The logic node this vertex represents
     AstScope* const m_scopep;  // The enclosing AstScope of the logic node
 
@@ -83,7 +83,7 @@ public:
 };
 
 class SchedAcyclicVarVertex final : public V3GraphVertex {
-    VL_RTTI_IMPLEMENTATION(SchedAcyclicVarVertex, V3GraphVertex)
+    VL_RTTI_IMPL(SchedAcyclicVarVertex, V3GraphVertex)
     AstVarScope* const m_vscp;  // The AstVarScope this vertex represents
 
 public:

--- a/src/V3SchedAcyclic.cpp
+++ b/src/V3SchedAcyclic.cpp
@@ -52,24 +52,20 @@
 
 VL_DEFINE_DEBUG_FUNCTIONS;
 
-namespace V3Sched {
-
-namespace {
-
 // ##############################################################################
 //  Data structures (graph types)
 
-class LogicVertex final : public V3GraphVertex {
+class SchedAcyclicLogicVertex final : public V3GraphVertex {
     AstNode* const m_logicp;  // The logic node this vertex represents
     AstScope* const m_scopep;  // The enclosing AstScope of the logic node
 
 public:
-    LogicVertex(V3Graph* graphp, AstNode* logicp, AstScope* scopep)
+    SchedAcyclicLogicVertex(V3Graph* graphp, AstNode* logicp, AstScope* scopep)
         : V3GraphVertex{graphp}
         , m_logicp{logicp}
         , m_scopep{scopep} {}
     V3GraphVertex* clone(V3Graph* graphp) const override {
-        return new LogicVertex{graphp, logicp(), scopep()};
+        return new SchedAcyclicLogicVertex{graphp, logicp(), scopep()};
     }
 
     AstNode* logicp() const { return m_logicp; }
@@ -81,16 +77,18 @@ public:
     // LCOV_EXCL_STOP
 };
 
-class VarVertex final : public V3GraphVertex {
+class SchedAcyclicVarVertex final : public V3GraphVertex {
     AstVarScope* const m_vscp;  // The AstVarScope this vertex represents
 
 public:
-    VarVertex(V3Graph* graphp, AstVarScope* vscp)
+    SchedAcyclicVarVertex(V3Graph* graphp, AstVarScope* vscp)
         : V3GraphVertex{graphp}
         , m_vscp{vscp} {}
     AstVarScope* vscp() const { return m_vscp; }
     AstVar* varp() const { return m_vscp->varp(); }
-    V3GraphVertex* clone(V3Graph* graphp) const override { return new VarVertex{graphp, vscp()}; }
+    V3GraphVertex* clone(V3Graph* graphp) const override {
+        return new SchedAcyclicVarVertex{graphp, vscp()};
+    }
 
     // LCOV_EXCL_START // Debug code
     string name() const override VL_MT_STABLE { return m_vscp->name(); }
@@ -99,16 +97,19 @@ public:
     // LCOV_EXCL_STOP
 };
 
+namespace V3Sched {
+
+namespace {
+
 class Graph final : public V3Graph {
     void loopsVertexCb(V3GraphVertex* vtxp) override {
         // TODO: 'typeName' is an internal thing. This should be more human readable.
-        if (LogicVertex* const lvtxp = dynamic_cast<LogicVertex*>(vtxp)) {
+        if (SchedAcyclicLogicVertex* const lvtxp = vtxp->cast<SchedAcyclicLogicVertex>()) {
             AstNode* const logicp = lvtxp->logicp();
             std::cerr << logicp->fileline()->warnOtherStandalone()
                       << "     Example path: " << logicp->typeName() << endl;
         } else {
-            VarVertex* const vvtxp = dynamic_cast<VarVertex*>(vtxp);
-            UASSERT(vvtxp, "Cannot be anything else");
+            SchedAcyclicVarVertex* const vvtxp = vtxp->as<SchedAcyclicVarVertex>();
             AstVarScope* const vscp = vvtxp->vscp();
             std::cerr << vscp->fileline()->warnOtherStandalone()
                       << "     Example path: " << vscp->prettyName() << endl;
@@ -125,8 +126,8 @@ std::unique_ptr<Graph> buildGraph(const LogicByScope& lbs) {
     // AstVarScope::user1() -> VarVertx
     const VNUser1InUse user1InUse;
     const auto getVarVertex = [&](AstVarScope* vscp) {
-        if (!vscp->user1p()) vscp->user1p(new VarVertex{graphp.get(), vscp});
-        return vscp->user1u().to<VarVertex*>();
+        if (!vscp->user1p()) vscp->user1p(new SchedAcyclicVarVertex{graphp.get(), vscp});
+        return vscp->user1u().to<SchedAcyclicVarVertex*>();
     };
 
     const auto addEdge = [&](V3GraphVertex* fromp, V3GraphVertex* top, int weight, bool cuttable) {
@@ -141,13 +142,14 @@ std::unique_ptr<Graph> buildGraph(const LogicByScope& lbs) {
             // Can safely ignore Postponed as we generate them all
             if (VN_IS(nodep, AlwaysPostponed)) continue;
 
-            LogicVertex* const lvtxp = new LogicVertex{graphp.get(), nodep, scopep};
+            SchedAcyclicLogicVertex* const lvtxp
+                = new SchedAcyclicLogicVertex{graphp.get(), nodep, scopep};
             const VNUser2InUse user2InUse;
             const VNUser3InUse user3InUse;
 
             nodep->foreach([&](AstVarRef* refp) {
                 AstVarScope* const vscp = refp->varScopep();
-                VarVertex* const vvtxp = getVarVertex(vscp);
+                SchedAcyclicVarVertex* const vvtxp = getVarVertex(vscp);
                 // We want to cut the narrowest signals
                 const int weight = vscp->width() / 8 + 1;
                 // If written, add logic -> var edge
@@ -208,7 +210,7 @@ void removeNonCyclic(Graph* graphp) {
 }
 
 // Has this VarVertex been cut? (any edges in or out has been cut)
-bool isCut(const VarVertex* vtxp) {
+bool isCut(const SchedAcyclicVarVertex* vtxp) {
     for (V3GraphEdge* edgep = vtxp->inBeginp(); edgep; edgep = edgep->inNextp()) {
         if (edgep->weight() == 0) return true;
     }
@@ -218,33 +220,33 @@ bool isCut(const VarVertex* vtxp) {
     return false;
 }
 
-std::vector<VarVertex*> findCutVertices(Graph* graphp) {
-    std::vector<VarVertex*> result;
+std::vector<SchedAcyclicVarVertex*> findCutVertices(Graph* graphp) {
+    std::vector<SchedAcyclicVarVertex*> result;
     const VNUser1InUse user1InUse;  // bool: already added to result
     for (V3GraphVertex* vtxp = graphp->verticesBeginp(); vtxp; vtxp = vtxp->verticesNextp()) {
-        if (VarVertex* const vvtxp = dynamic_cast<VarVertex*>(vtxp)) {
+        if (SchedAcyclicVarVertex* const vvtxp = vtxp->cast<SchedAcyclicVarVertex>()) {
             if (!vvtxp->vscp()->user1SetOnce() && isCut(vvtxp)) result.push_back(vvtxp);
         }
     }
     return result;
 }
 
-void resetEdgeWeights(const std::vector<VarVertex*>& cutVertices) {
-    for (VarVertex* const vvtxp : cutVertices) {
+void resetEdgeWeights(const std::vector<SchedAcyclicVarVertex*>& cutVertices) {
+    for (SchedAcyclicVarVertex* const vvtxp : cutVertices) {
         for (V3GraphEdge* ep = vvtxp->inBeginp(); ep; ep = ep->inNextp()) ep->weight(1);
         for (V3GraphEdge* ep = vvtxp->outBeginp(); ep; ep = ep->outNextp()) ep->weight(1);
     }
 }
 
 // A VarVertex together with its fanout
-using Candidate = std::pair<VarVertex*, unsigned>;
+using Candidate = std::pair<SchedAcyclicVarVertex*, unsigned>;
 
 // Gather all splitting candidates that are in the same SCC as the given vertex
 void gatherSCCCandidates(V3GraphVertex* vtxp, std::vector<Candidate>& candidates) {
     if (vtxp->user()) return;  // Already done
     vtxp->user(true);
 
-    if (VarVertex* const vvtxp = dynamic_cast<VarVertex*>(vtxp)) {
+    if (SchedAcyclicVarVertex* const vvtxp = vtxp->cast<SchedAcyclicVarVertex>()) {
         AstVar* const varp = vvtxp->varp();
         const string name = varp->prettyName();
         if (!varp->user3SetOnce()  // Only consider each AstVar once
@@ -270,7 +272,7 @@ void gatherSCCCandidates(V3GraphVertex* vtxp, std::vector<Candidate>& candidates
 }
 
 // Find all variables in a loop (SCC) that are candidates for splitting to break loops.
-void reportLoopVars(Graph* graphp, VarVertex* vvtxp) {
+void reportLoopVars(Graph* graphp, SchedAcyclicVarVertex* vvtxp) {
     // Vector of variables in UNOPTFLAT loop that are candidates for splitting.
     std::vector<Candidate> candidates;
     {
@@ -325,8 +327,8 @@ void reportLoopVars(Graph* graphp, VarVertex* vvtxp) {
     V3Stats::addStat("Scheduling, split_var, candidates", splittable);
 }
 
-void reportCycles(Graph* graphp, const std::vector<VarVertex*>& cutVertices) {
-    for (VarVertex* vvtxp : cutVertices) {
+void reportCycles(Graph* graphp, const std::vector<SchedAcyclicVarVertex*>& cutVertices) {
+    for (SchedAcyclicVarVertex* vvtxp : cutVertices) {
         AstVarScope* const vscp = vvtxp->vscp();
         FileLine* const flp = vscp->fileline();
 
@@ -350,16 +352,18 @@ void reportCycles(Graph* graphp, const std::vector<VarVertex*>& cutVertices) {
     }
 }
 
-LogicByScope fixCuts(AstNetlist* netlistp, const std::vector<VarVertex*>& cutVertices) {
+LogicByScope fixCuts(AstNetlist* netlistp,
+                     const std::vector<SchedAcyclicVarVertex*>& cutVertices) {
     // For all logic that reads a cut vertex, build a map from logic -> list of cut AstVarScope
     // they read. Also build a vector of the involved logic for deterministic results.
-    std::unordered_map<LogicVertex*, std::vector<AstVarScope*>> lvtx2Cuts;
-    std::vector<LogicVertex*> lvtxps;
+    std::unordered_map<SchedAcyclicLogicVertex*, std::vector<AstVarScope*>> lvtx2Cuts;
+    std::vector<SchedAcyclicLogicVertex*> lvtxps;
     {
         const VNUser1InUse user1InUse;  // bool: already added to 'lvtxps'
-        for (VarVertex* const vvtxp : cutVertices) {
+        for (SchedAcyclicVarVertex* const vvtxp : cutVertices) {
             for (V3GraphEdge* edgep = vvtxp->outBeginp(); edgep; edgep = edgep->outNextp()) {
-                LogicVertex* const lvtxp = static_cast<LogicVertex*>(edgep->top());
+                SchedAcyclicLogicVertex* const lvtxp
+                    = static_cast<SchedAcyclicLogicVertex*>(edgep->top());
                 if (!lvtxp->logicp()->user1SetOnce()) lvtxps.push_back(lvtxp);
                 lvtx2Cuts[lvtxp].push_back(vvtxp->vscp());
             }
@@ -370,7 +374,7 @@ LogicByScope fixCuts(AstNetlist* netlistp, const std::vector<VarVertex*>& cutVer
     // explicit additional triggers on the cut variables)
     LogicByScope result;
     SenTreeFinder finder{netlistp};
-    for (LogicVertex* const lvtxp : lvtxps) {
+    for (SchedAcyclicLogicVertex* const lvtxp : lvtxps) {
         AstNode* const logicp = lvtxp->logicp();
         logicp->unlinkFrBack();
         FileLine* const flp = logicp->fileline();
@@ -412,7 +416,7 @@ LogicByScope breakCycles(AstNetlist* netlistp, LogicByScope& combinationalLogic)
     graphp->acyclic(&V3GraphEdge::followAlwaysTrue);
 
     // Find all cut vertices
-    const std::vector<VarVertex*> cutVertices = findCutVertices(graphp.get());
+    const std::vector<SchedAcyclicVarVertex*> cutVertices = findCutVertices(graphp.get());
 
     // Reset edge weights for reporting
     resetEdgeWeights(cutVertices);

--- a/src/V3SchedAcyclic.cpp
+++ b/src/V3SchedAcyclic.cpp
@@ -52,6 +52,10 @@
 
 VL_DEFINE_DEBUG_FUNCTIONS;
 
+namespace V3Sched {
+
+namespace {
+
 // ##############################################################################
 //  Data structures (graph types)
 
@@ -96,10 +100,6 @@ public:
     string dotColor() const override { return "blue"; }
     // LCOV_EXCL_STOP
 };
-
-namespace V3Sched {
-
-namespace {
 
 class Graph final : public V3Graph {
     void loopsVertexCb(V3GraphVertex* vtxp) override {

--- a/src/V3SchedAcyclic.cpp
+++ b/src/V3SchedAcyclic.cpp
@@ -60,6 +60,7 @@ namespace {
 //  Data structures (graph types)
 
 class SchedAcyclicLogicVertex final : public V3GraphVertex {
+    VL_RTTI_IMPLEMENTATION(SchedAcyclicLogicVertex, V3GraphVertex)
     AstNode* const m_logicp;  // The logic node this vertex represents
     AstScope* const m_scopep;  // The enclosing AstScope of the logic node
 
@@ -82,6 +83,7 @@ public:
 };
 
 class SchedAcyclicVarVertex final : public V3GraphVertex {
+    VL_RTTI_IMPLEMENTATION(SchedAcyclicVarVertex, V3GraphVertex)
     AstVarScope* const m_vscp;  // The AstVarScope this vertex represents
 
 public:

--- a/src/V3SchedPartition.cpp
+++ b/src/V3SchedPartition.cpp
@@ -55,7 +55,7 @@ namespace V3Sched {
 namespace {
 
 class SchedSenVertex final : public V3GraphVertex {
-    VL_RTTI_IMPLEMENTATION(SchedSenVertex, V3GraphVertex)
+    VL_RTTI_IMPL(SchedSenVertex, V3GraphVertex)
     const AstSenItem* const m_senItemp;
 
 public:
@@ -75,7 +75,7 @@ public:
 };
 
 class SchedLogicVertex final : public V3GraphVertex {
-    VL_RTTI_IMPLEMENTATION(SchedLogicVertex, V3GraphVertex)
+    VL_RTTI_IMPL(SchedLogicVertex, V3GraphVertex)
     AstScope* const m_scopep;
     AstSenTree* const m_senTreep;
     AstNode* const m_logicp;
@@ -99,7 +99,7 @@ public:
 };
 
 class SchedVarVertex final : public V3GraphVertex {
-    VL_RTTI_IMPLEMENTATION(SchedVarVertex, V3GraphVertex)
+    VL_RTTI_IMPL(SchedVarVertex, V3GraphVertex)
     const AstVarScope* const m_vscp;
 
 public:

--- a/src/V3SchedPartition.cpp
+++ b/src/V3SchedPartition.cpp
@@ -55,6 +55,7 @@ namespace V3Sched {
 namespace {
 
 class SchedSenVertex final : public V3GraphVertex {
+    VL_RTTI_IMPLEMENTATION(SchedSenVertex, V3GraphVertex)
     const AstSenItem* const m_senItemp;
 
 public:
@@ -74,6 +75,7 @@ public:
 };
 
 class SchedLogicVertex final : public V3GraphVertex {
+    VL_RTTI_IMPLEMENTATION(SchedLogicVertex, V3GraphVertex)
     AstScope* const m_scopep;
     AstSenTree* const m_senTreep;
     AstNode* const m_logicp;
@@ -97,6 +99,7 @@ public:
 };
 
 class SchedVarVertex final : public V3GraphVertex {
+    VL_RTTI_IMPLEMENTATION(SchedVarVertex, V3GraphVertex)
     const AstVarScope* const m_vscp;
 
 public:

--- a/src/V3SchedPartition.cpp
+++ b/src/V3SchedPartition.cpp
@@ -50,6 +50,10 @@
 
 VL_DEFINE_DEBUG_FUNCTIONS;
 
+namespace V3Sched {
+
+namespace {
+
 class SchedSenVertex final : public V3GraphVertex {
     const AstSenItem* const m_senItemp;
 
@@ -110,10 +114,6 @@ public:
     }
     // LCOV_EXCL_STOP
 };
-
-namespace V3Sched {
-
-namespace {
 
 class SchedGraphBuilder final : public VNVisitor {
     // NODE STATE

--- a/src/V3SchedPartition.cpp
+++ b/src/V3SchedPartition.cpp
@@ -50,10 +50,6 @@
 
 VL_DEFINE_DEBUG_FUNCTIONS;
 
-namespace V3Sched {
-
-namespace {
-
 class SchedSenVertex final : public V3GraphVertex {
     const AstSenItem* const m_senItemp;
 
@@ -114,6 +110,10 @@ public:
     }
     // LCOV_EXCL_STOP
 };
+
+namespace V3Sched {
+
+namespace {
 
 class SchedGraphBuilder final : public VNVisitor {
     // NODE STATE
@@ -299,7 +299,7 @@ void colorActiveRegion(const V3Graph& graph) {
 
     // Trace from all SchedSenVertex
     for (V3GraphVertex* vtxp = graph.verticesBeginp(); vtxp; vtxp = vtxp->verticesNextp()) {
-        if (const auto activeEventVtxp = dynamic_cast<SchedSenVertex*>(vtxp)) {
+        if (const auto activeEventVtxp = vtxp->cast<SchedSenVertex>()) {
             queue.push_back(activeEventVtxp);
         }
     }
@@ -323,9 +323,9 @@ void colorActiveRegion(const V3Graph& graph) {
         // If this is a logic vertex, also enqueue all variable vertices that are driven from this
         // logic. This will ensure that if a variable is set in the active region, then all
         // settings of that variable will be in the active region.
-        if (dynamic_cast<SchedLogicVertex*>(&vtx)) {
+        if (vtx.is<SchedLogicVertex>()) {
             for (V3GraphEdge* edgep = vtx.outBeginp(); edgep; edgep = edgep->outNextp()) {
-                UASSERT(dynamic_cast<SchedVarVertex*>(edgep->top()), "Should be var vertex");
+                UASSERT(edgep->top()->is<SchedVarVertex>(), "Should be var vertex");
                 queue.push_back(edgep->top());
             }
         }
@@ -350,7 +350,7 @@ LogicRegions partition(LogicByScope& clockedLogic, LogicByScope& combinationalLo
     LogicRegions result;
 
     for (V3GraphVertex* vtxp = graphp->verticesBeginp(); vtxp; vtxp = vtxp->verticesNextp()) {
-        if (const auto lvtxp = dynamic_cast<SchedLogicVertex*>(vtxp)) {
+        if (const auto lvtxp = vtxp->cast<SchedLogicVertex>()) {
             LogicByScope& lbs = lvtxp->color() ? result.m_act : result.m_nba;
             AstNode* const logicp = lvtxp->logicp();
             logicp->unlinkFrBack();

--- a/src/V3SchedReplicate.cpp
+++ b/src/V3SchedReplicate.cpp
@@ -60,7 +60,8 @@ enum RegionFlags : uint8_t {
 // Data structures (graph types)
 
 class SchedReplicateVertex VL_NOT_FINAL : public V3GraphVertex {
-    RegionFlags m_drivingRegions{NONE};  // The regions driving this vertex
+    VL_RTTI_IMPLEMENTATION(SchedReplicateVertex, V3GraphVertex)
+    RegionFlags m_drivingRegions{RegionFlags::NONE};  // The regions driving this vertex
 
 public:
     explicit SchedReplicateVertex(V3Graph* graphp)
@@ -87,12 +88,8 @@ public:
     // LCOV_EXCL_STOP
 };
 
-template <>
-bool V3GraphVertex::privateTypeTest<SchedReplicateVertex>(const V3GraphVertex* vtxp) {
-    return dynamic_cast<const SchedReplicateVertex*>(vtxp);
-}
-
 class SchedReplicateLogicVertex final : public SchedReplicateVertex {
+    VL_RTTI_IMPLEMENTATION(SchedReplicateLogicVertex, SchedReplicateVertex)
     AstScope* const m_scopep;  // The enclosing AstScope of the logic node
     AstSenTree* const m_senTreep;  // The sensitivity of the logic node
     AstNode* const m_logicp;  // The logic node this vertex represents
@@ -119,6 +116,7 @@ public:
 };
 
 class SchedReplicateVarVertex final : public SchedReplicateVertex {
+    VL_RTTI_IMPLEMENTATION(SchedReplicateVarVertex, SchedReplicateVertex)
     AstVarScope* const m_vscp;  // The AstVarScope this vertex represents
 
 public:

--- a/src/V3SchedReplicate.cpp
+++ b/src/V3SchedReplicate.cpp
@@ -44,6 +44,10 @@
 
 VL_DEFINE_DEBUG_FUNCTIONS;
 
+namespace V3Sched {
+
+namespace {
+
 // Driving region flags
 enum RegionFlags : uint8_t {
     NONE = 0x0,  //
@@ -138,10 +142,6 @@ public:
     string name() const override VL_MT_STABLE { return m_vscp->name(); }
     string dotShape() const override { return varp()->isPrimaryInish() ? "invhouse" : "ellipse"; }
 };
-
-namespace V3Sched {
-
-namespace {
 
 class Graph final : public V3Graph {};
 

--- a/src/V3SchedReplicate.cpp
+++ b/src/V3SchedReplicate.cpp
@@ -228,7 +228,7 @@ void propagateDrivingRegions(SchedReplicateVertex* vtxp) {
     // Compute union of driving regions of all inputs
     uint8_t drivingRegions = 0;
     for (V3GraphEdge* edgep = vtxp->inBeginp(); edgep; edgep = edgep->inNextp()) {
-        SchedReplicateVertex* const srcp = static_cast<SchedReplicateVertex*>(edgep->fromp());
+        SchedReplicateVertex* const srcp = edgep->fromp()->as<SchedReplicateVertex>();
         propagateDrivingRegions(srcp);
         drivingRegions |= srcp->drivingRegions();
     }
@@ -267,7 +267,7 @@ LogicReplicas replicateLogic(LogicRegions& logicRegionsRegions) {
     if (dumpGraphLevel() >= 6) graphp->dumpDotFilePrefixed("sched-replicate");
     // Propagate driving region flags
     for (V3GraphVertex* vtxp = graphp->verticesBeginp(); vtxp; vtxp = vtxp->verticesNextp()) {
-        propagateDrivingRegions(static_cast<SchedReplicateVertex*>(vtxp));
+        propagateDrivingRegions(vtxp->as<SchedReplicateVertex>());
     }
     // Dump for debug
     if (dumpGraphLevel() >= 6) graphp->dumpDotFilePrefixed("sched-replicate-propagated");

--- a/src/V3SchedReplicate.cpp
+++ b/src/V3SchedReplicate.cpp
@@ -60,7 +60,7 @@ enum RegionFlags : uint8_t {
 // Data structures (graph types)
 
 class SchedReplicateVertex VL_NOT_FINAL : public V3GraphVertex {
-    VL_RTTI_IMPLEMENTATION(SchedReplicateVertex, V3GraphVertex)
+    VL_RTTI_IMPL(SchedReplicateVertex, V3GraphVertex)
     RegionFlags m_drivingRegions{RegionFlags::NONE};  // The regions driving this vertex
 
 public:
@@ -89,7 +89,7 @@ public:
 };
 
 class SchedReplicateLogicVertex final : public SchedReplicateVertex {
-    VL_RTTI_IMPLEMENTATION(SchedReplicateLogicVertex, SchedReplicateVertex)
+    VL_RTTI_IMPL(SchedReplicateLogicVertex, SchedReplicateVertex)
     AstScope* const m_scopep;  // The enclosing AstScope of the logic node
     AstSenTree* const m_senTreep;  // The sensitivity of the logic node
     AstNode* const m_logicp;  // The logic node this vertex represents
@@ -116,7 +116,7 @@ public:
 };
 
 class SchedReplicateVarVertex final : public SchedReplicateVertex {
-    VL_RTTI_IMPLEMENTATION(SchedReplicateVarVertex, SchedReplicateVertex)
+    VL_RTTI_IMPL(SchedReplicateVarVertex, SchedReplicateVertex)
     AstVarScope* const m_vscp;  // The AstVarScope this vertex represents
 
 public:

--- a/src/V3Split.cpp
+++ b/src/V3Split.cpp
@@ -99,6 +99,7 @@ VL_DEFINE_DEBUG_FUNCTIONS;
 // Support classes
 
 class SplitNodeVertex VL_NOT_FINAL : public V3GraphVertex {
+    VL_RTTI_IMPLEMENTATION(SplitNodeVertex, V3GraphVertex)
     AstNode* const m_nodep;
 
 protected:
@@ -116,12 +117,8 @@ public:
     virtual AstNode* nodep() const { return m_nodep; }
 };
 
-template <>
-bool V3GraphVertex::privateTypeTest<SplitNodeVertex>(const V3GraphVertex* vtxp) {
-    return dynamic_cast<const SplitNodeVertex*>(vtxp);
-}
-
 class SplitPliVertex final : public SplitNodeVertex {
+    VL_RTTI_IMPLEMENTATION(SplitPliVertex, SplitNodeVertex)
 public:
     explicit SplitPliVertex(V3Graph* graphp, AstNode* nodep)
         : SplitNodeVertex{graphp, nodep} {}
@@ -131,6 +128,7 @@ public:
 };
 
 class SplitLogicVertex final : public SplitNodeVertex {
+    VL_RTTI_IMPLEMENTATION(SplitLogicVertex, SplitNodeVertex)
 public:
     SplitLogicVertex(V3Graph* graphp, AstNode* nodep)
         : SplitNodeVertex{graphp, nodep} {}
@@ -139,6 +137,7 @@ public:
 };
 
 class SplitVarStdVertex final : public SplitNodeVertex {
+    VL_RTTI_IMPLEMENTATION(SplitVarStdVertex, SplitNodeVertex)
 public:
     SplitVarStdVertex(V3Graph* graphp, AstNode* nodep)
         : SplitNodeVertex{graphp, nodep} {}
@@ -147,6 +146,7 @@ public:
 };
 
 class SplitVarPostVertex final : public SplitNodeVertex {
+    VL_RTTI_IMPLEMENTATION(SplitVarPostVertex, SplitNodeVertex)
 public:
     SplitVarPostVertex(V3Graph* graphp, AstNode* nodep)
         : SplitNodeVertex{graphp, nodep} {}
@@ -159,6 +159,7 @@ public:
 // Edge types
 
 class SplitEdge VL_NOT_FINAL : public V3GraphEdge {
+    VL_RTTI_IMPLEMENTATION(SplitEdge, V3GraphEdge)
     uint32_t m_ignoreInStep = 0;  // Step number that if set to, causes this edge to be ignored
     static uint32_t s_stepNum;  // Global step number
 protected:
@@ -189,12 +190,8 @@ public:
 };
 uint32_t SplitEdge::s_stepNum = 0;
 
-template <>
-bool V3GraphEdge::privateTypeTest<SplitEdge>(const V3GraphEdge* edgep) {
-    return dynamic_cast<const SplitEdge*>(edgep);
-}
-
 class SplitPostEdge final : public SplitEdge {
+    VL_RTTI_IMPLEMENTATION(SplitPostEdge, SplitEdge)
 public:
     SplitPostEdge(V3Graph* graphp, V3GraphVertex* fromp, V3GraphVertex* top)
         : SplitEdge{graphp, fromp, top, WEIGHT_NORMAL} {}
@@ -204,6 +201,7 @@ public:
 };
 
 class SplitLVEdge final : public SplitEdge {
+    VL_RTTI_IMPLEMENTATION(SplitLVEdge, SplitEdge)
 public:
     SplitLVEdge(V3Graph* graphp, V3GraphVertex* fromp, V3GraphVertex* top)
         : SplitEdge{graphp, fromp, top, WEIGHT_NORMAL} {}
@@ -213,6 +211,7 @@ public:
 };
 
 class SplitRVEdge final : public SplitEdge {
+    VL_RTTI_IMPLEMENTATION(SplitRVEdge, SplitEdge)
 public:
     SplitRVEdge(V3Graph* graphp, V3GraphVertex* fromp, V3GraphVertex* top)
         : SplitEdge{graphp, fromp, top, WEIGHT_NORMAL} {}
@@ -222,6 +221,7 @@ public:
 };
 
 class SplitScorebdEdge final : public SplitEdge {
+    VL_RTTI_IMPLEMENTATION(SplitScorebdEdge, SplitEdge)
 public:
     SplitScorebdEdge(V3Graph* graphp, V3GraphVertex* fromp, V3GraphVertex* top)
         : SplitEdge{graphp, fromp, top, WEIGHT_NORMAL} {}
@@ -231,6 +231,7 @@ public:
 };
 
 class SplitStrictEdge final : public SplitEdge {
+    VL_RTTI_IMPLEMENTATION(SplitStrictEdge, SplitEdge)
     // A strict order, based on the original statement order in the graph
     // The only non-cutable edge type
 public:

--- a/src/V3Split.cpp
+++ b/src/V3Split.cpp
@@ -99,7 +99,7 @@ VL_DEFINE_DEBUG_FUNCTIONS;
 // Support classes
 
 class SplitNodeVertex VL_NOT_FINAL : public V3GraphVertex {
-    VL_RTTI_IMPLEMENTATION(SplitNodeVertex, V3GraphVertex)
+    VL_RTTI_IMPL(SplitNodeVertex, V3GraphVertex)
     AstNode* const m_nodep;
 
 protected:
@@ -118,7 +118,7 @@ public:
 };
 
 class SplitPliVertex final : public SplitNodeVertex {
-    VL_RTTI_IMPLEMENTATION(SplitPliVertex, SplitNodeVertex)
+    VL_RTTI_IMPL(SplitPliVertex, SplitNodeVertex)
 public:
     explicit SplitPliVertex(V3Graph* graphp, AstNode* nodep)
         : SplitNodeVertex{graphp, nodep} {}
@@ -128,7 +128,7 @@ public:
 };
 
 class SplitLogicVertex final : public SplitNodeVertex {
-    VL_RTTI_IMPLEMENTATION(SplitLogicVertex, SplitNodeVertex)
+    VL_RTTI_IMPL(SplitLogicVertex, SplitNodeVertex)
 public:
     SplitLogicVertex(V3Graph* graphp, AstNode* nodep)
         : SplitNodeVertex{graphp, nodep} {}
@@ -137,7 +137,7 @@ public:
 };
 
 class SplitVarStdVertex final : public SplitNodeVertex {
-    VL_RTTI_IMPLEMENTATION(SplitVarStdVertex, SplitNodeVertex)
+    VL_RTTI_IMPL(SplitVarStdVertex, SplitNodeVertex)
 public:
     SplitVarStdVertex(V3Graph* graphp, AstNode* nodep)
         : SplitNodeVertex{graphp, nodep} {}
@@ -146,7 +146,7 @@ public:
 };
 
 class SplitVarPostVertex final : public SplitNodeVertex {
-    VL_RTTI_IMPLEMENTATION(SplitVarPostVertex, SplitNodeVertex)
+    VL_RTTI_IMPL(SplitVarPostVertex, SplitNodeVertex)
 public:
     SplitVarPostVertex(V3Graph* graphp, AstNode* nodep)
         : SplitNodeVertex{graphp, nodep} {}
@@ -159,7 +159,7 @@ public:
 // Edge types
 
 class SplitEdge VL_NOT_FINAL : public V3GraphEdge {
-    VL_RTTI_IMPLEMENTATION(SplitEdge, V3GraphEdge)
+    VL_RTTI_IMPL(SplitEdge, V3GraphEdge)
     uint32_t m_ignoreInStep = 0;  // Step number that if set to, causes this edge to be ignored
     static uint32_t s_stepNum;  // Global step number
 protected:
@@ -191,7 +191,7 @@ public:
 uint32_t SplitEdge::s_stepNum = 0;
 
 class SplitPostEdge final : public SplitEdge {
-    VL_RTTI_IMPLEMENTATION(SplitPostEdge, SplitEdge)
+    VL_RTTI_IMPL(SplitPostEdge, SplitEdge)
 public:
     SplitPostEdge(V3Graph* graphp, V3GraphVertex* fromp, V3GraphVertex* top)
         : SplitEdge{graphp, fromp, top, WEIGHT_NORMAL} {}
@@ -201,7 +201,7 @@ public:
 };
 
 class SplitLVEdge final : public SplitEdge {
-    VL_RTTI_IMPLEMENTATION(SplitLVEdge, SplitEdge)
+    VL_RTTI_IMPL(SplitLVEdge, SplitEdge)
 public:
     SplitLVEdge(V3Graph* graphp, V3GraphVertex* fromp, V3GraphVertex* top)
         : SplitEdge{graphp, fromp, top, WEIGHT_NORMAL} {}
@@ -211,7 +211,7 @@ public:
 };
 
 class SplitRVEdge final : public SplitEdge {
-    VL_RTTI_IMPLEMENTATION(SplitRVEdge, SplitEdge)
+    VL_RTTI_IMPL(SplitRVEdge, SplitEdge)
 public:
     SplitRVEdge(V3Graph* graphp, V3GraphVertex* fromp, V3GraphVertex* top)
         : SplitEdge{graphp, fromp, top, WEIGHT_NORMAL} {}
@@ -221,7 +221,7 @@ public:
 };
 
 class SplitScorebdEdge final : public SplitEdge {
-    VL_RTTI_IMPLEMENTATION(SplitScorebdEdge, SplitEdge)
+    VL_RTTI_IMPL(SplitScorebdEdge, SplitEdge)
 public:
     SplitScorebdEdge(V3Graph* graphp, V3GraphVertex* fromp, V3GraphVertex* top)
         : SplitEdge{graphp, fromp, top, WEIGHT_NORMAL} {}
@@ -231,7 +231,7 @@ public:
 };
 
 class SplitStrictEdge final : public SplitEdge {
-    VL_RTTI_IMPLEMENTATION(SplitStrictEdge, SplitEdge)
+    VL_RTTI_IMPL(SplitStrictEdge, SplitEdge)
     // A strict order, based on the original statement order in the graph
     // The only non-cutable edge type
 public:

--- a/src/V3TSP.cpp
+++ b/src/V3TSP.cpp
@@ -54,7 +54,7 @@ static void selfTestString();
 // Vertex that tracks a per-vertex key
 template <typename T_Key>
 class TspVertexTmpl final : public V3GraphVertex {
-    VL_RTTI_IMPLEMENTATION(TspVertexTmpl, V3GraphVertex)
+    VL_RTTI_IMPL(TspVertexTmpl, V3GraphVertex)
 private:
     const T_Key m_key;
 

--- a/src/V3TSP.cpp
+++ b/src/V3TSP.cpp
@@ -54,6 +54,7 @@ static void selfTestString();
 // Vertex that tracks a per-vertex key
 template <typename T_Key>
 class TspVertexTmpl final : public V3GraphVertex {
+    VL_RTTI_IMPLEMENTATION(TspVertexTmpl, V3GraphVertex)
 private:
     const T_Key m_key;
 

--- a/src/V3Task.cpp
+++ b/src/V3Task.cpp
@@ -85,7 +85,7 @@ public:
 };
 
 class TaskEdge final : public V3GraphEdge {
-    VL_RTTI_IMPLEMENTATION(TaskEdge, V3GraphEdge)
+    VL_RTTI_IMPL(TaskEdge, V3GraphEdge)
 public:
     TaskEdge(V3Graph* graphp, TaskBaseVertex* fromp, TaskBaseVertex* top)
         : V3GraphEdge{graphp, fromp, top, 1, false} {}

--- a/src/V3Task.cpp
+++ b/src/V3Task.cpp
@@ -57,11 +57,6 @@ public:
     void noInline(bool flag) { m_noInline = flag; }
 };
 
-template <>
-bool V3GraphVertex::privateTypeTest<TaskBaseVertex>(const V3GraphVertex* vtxp) {
-    return dynamic_cast<const TaskBaseVertex*>(vtxp);
-}
-
 class TaskFTaskVertex final : public TaskBaseVertex {
     // Every task gets a vertex, and we link tasks together based on funcrefs.
     AstNodeFTask* const m_nodep;
@@ -90,6 +85,7 @@ public:
 };
 
 class TaskEdge final : public V3GraphEdge {
+    VL_RTTI_IMPLEMENTATION(TaskEdge, V3GraphEdge)
 public:
     TaskEdge(V3Graph* graphp, TaskBaseVertex* fromp, TaskBaseVertex* top)
         : V3GraphEdge{graphp, fromp, top, 1, false} {}

--- a/src/V3Task.cpp
+++ b/src/V3Task.cpp
@@ -57,6 +57,11 @@ public:
     void noInline(bool flag) { m_noInline = flag; }
 };
 
+template <>
+bool V3GraphVertex::privateTypeTest<TaskBaseVertex>(const V3GraphVertex* vtxp) {
+    return dynamic_cast<const TaskBaseVertex*>(vtxp);
+}
+
 class TaskFTaskVertex final : public TaskBaseVertex {
     // Every task gets a vertex, and we link tasks together based on funcrefs.
     AstNodeFTask* const m_nodep;

--- a/src/V3Timing.cpp
+++ b/src/V3Timing.cpp
@@ -93,7 +93,7 @@ private:
     // Vertex of a dependency graph of suspendable nodes, e.g. if a node (process or task) is
     // suspendable, all its dependents should also be suspendable
     class DepVtx VL_NOT_FINAL : public V3GraphVertex {
-        VL_RTTI_IMPLEMENTATION(DepVtx, V3GraphVertex)
+        VL_RTTI_IMPL(DepVtx, V3GraphVertex)
         AstClass* const m_classp;  // Class associated with a method
         AstNode* const m_nodep;  // AST node represented by this graph vertex
 
@@ -122,7 +122,7 @@ private:
     };
 
     class SuspendDepVtx final : public DepVtx {
-        VL_RTTI_IMPLEMENTATION(SuspendDepVtx, DepVtx)
+        VL_RTTI_IMPL(SuspendDepVtx, DepVtx)
         string dotColor() const override {
             if (nodep()->user2() & T_SUSPENDER) return "red";
             if (nodep()->user2() & T_SUSPENDEE) return "blue";
@@ -136,7 +136,7 @@ private:
     };
 
     class NeedsProcDepVtx final : public DepVtx {
-        VL_RTTI_IMPLEMENTATION(NeedsProcDepVtx, DepVtx)
+        VL_RTTI_IMPL(NeedsProcDepVtx, DepVtx)
         string dotColor() const override {
             if (nodep()->user2() & T_CALLS_PROC_SELF) return "red";
             if (nodep()->user2() & T_HAS_PROC) return "blue";

--- a/src/V3Timing.cpp
+++ b/src/V3Timing.cpp
@@ -93,6 +93,7 @@ private:
     // Vertex of a dependency graph of suspendable nodes, e.g. if a node (process or task) is
     // suspendable, all its dependents should also be suspendable
     class DepVtx VL_NOT_FINAL : public V3GraphVertex {
+        VL_RTTI_IMPLEMENTATION(DepVtx, V3GraphVertex)
         AstClass* const m_classp;  // Class associated with a method
         AstNode* const m_nodep;  // AST node represented by this graph vertex
 
@@ -121,6 +122,7 @@ private:
     };
 
     class SuspendDepVtx final : public DepVtx {
+        VL_RTTI_IMPLEMENTATION(SuspendDepVtx, DepVtx)
         string dotColor() const override {
             if (nodep()->user2() & T_SUSPENDER) return "red";
             if (nodep()->user2() & T_SUSPENDEE) return "blue";
@@ -134,6 +136,7 @@ private:
     };
 
     class NeedsProcDepVtx final : public DepVtx {
+        VL_RTTI_IMPLEMENTATION(NeedsProcDepVtx, DepVtx)
         string dotColor() const override {
             if (nodep()->user2() & T_CALLS_PROC_SELF) return "red";
             if (nodep()->user2() & T_HAS_PROC) return "blue";

--- a/src/V3Trace.cpp
+++ b/src/V3Trace.cpp
@@ -56,6 +56,7 @@ VL_DEFINE_DEBUG_FUNCTIONS;
 // Graph vertexes
 
 class TraceActivityVertex final : public V3GraphVertex {
+    VL_RTTI_IMPLEMENTATION(TraceActivityVertex, V3GraphVertex)
     AstNode* const m_insertp;
     int32_t m_activityCode;
     bool m_slow;  // If always slow, we can use the same code
@@ -100,6 +101,7 @@ public:
 };
 
 class TraceCFuncVertex final : public V3GraphVertex {
+    VL_RTTI_IMPLEMENTATION(TraceCFuncVertex, V3GraphVertex)
     AstCFunc* const m_nodep;
 
 public:
@@ -115,6 +117,7 @@ public:
 };
 
 class TraceTraceVertex final : public V3GraphVertex {
+    VL_RTTI_IMPLEMENTATION(TraceTraceVertex, V3GraphVertex)
     AstTraceDecl* const m_nodep;  // TRACEINC this represents
     // nullptr, or other vertex with the real code() that duplicates this one
     TraceTraceVertex* m_duplicatep = nullptr;
@@ -137,6 +140,7 @@ public:
 };
 
 class TraceVarVertex final : public V3GraphVertex {
+    VL_RTTI_IMPLEMENTATION(TraceVarVertex, V3GraphVertex)
     AstVarScope* const m_nodep;
 
 public:

--- a/src/V3Trace.cpp
+++ b/src/V3Trace.cpp
@@ -56,7 +56,7 @@ VL_DEFINE_DEBUG_FUNCTIONS;
 // Graph vertexes
 
 class TraceActivityVertex final : public V3GraphVertex {
-    VL_RTTI_IMPLEMENTATION(TraceActivityVertex, V3GraphVertex)
+    VL_RTTI_IMPL(TraceActivityVertex, V3GraphVertex)
     AstNode* const m_insertp;
     int32_t m_activityCode;
     bool m_slow;  // If always slow, we can use the same code
@@ -101,7 +101,7 @@ public:
 };
 
 class TraceCFuncVertex final : public V3GraphVertex {
-    VL_RTTI_IMPLEMENTATION(TraceCFuncVertex, V3GraphVertex)
+    VL_RTTI_IMPL(TraceCFuncVertex, V3GraphVertex)
     AstCFunc* const m_nodep;
 
 public:
@@ -117,7 +117,7 @@ public:
 };
 
 class TraceTraceVertex final : public V3GraphVertex {
-    VL_RTTI_IMPLEMENTATION(TraceTraceVertex, V3GraphVertex)
+    VL_RTTI_IMPL(TraceTraceVertex, V3GraphVertex)
     AstTraceDecl* const m_nodep;  // TRACEINC this represents
     // nullptr, or other vertex with the real code() that duplicates this one
     TraceTraceVertex* m_duplicatep = nullptr;
@@ -140,7 +140,7 @@ public:
 };
 
 class TraceVarVertex final : public V3GraphVertex {
-    VL_RTTI_IMPLEMENTATION(TraceVarVertex, V3GraphVertex)
+    VL_RTTI_IMPL(TraceVarVertex, V3GraphVertex)
     AstVarScope* const m_nodep;
 
 public:

--- a/src/V3Tristate.cpp
+++ b/src/V3Tristate.cpp
@@ -142,7 +142,7 @@ public:
 // Graph support classes
 
 class TristateVertex final : public V3GraphVertex {
-    VL_RTTI_IMPLEMENTATION(TristateVertex, V3GraphVertex)
+    VL_RTTI_IMPL(TristateVertex, V3GraphVertex)
     AstNode* const m_nodep;
     bool m_isTristate = false;  // Logic indicates a tristate
     bool m_feedsTri = false;  // Propagates to a tristate node (on RHS)

--- a/src/V3Tristate.cpp
+++ b/src/V3Tristate.cpp
@@ -142,6 +142,7 @@ public:
 // Graph support classes
 
 class TristateVertex final : public V3GraphVertex {
+    VL_RTTI_IMPLEMENTATION(TristateVertex, V3GraphVertex)
     AstNode* const m_nodep;
     bool m_isTristate = false;  // Logic indicates a tristate
     bool m_feedsTri = false;  // Propagates to a tristate node (on RHS)

--- a/src/V3Tristate.cpp
+++ b/src/V3Tristate.cpp
@@ -222,7 +222,7 @@ private:
         UINFO(9, "  Mark tri " << level << "  " << vtxp << endl);
         if (!vtxp->varp()) {  // not a var where we stop the recursion
             for (V3GraphEdge* edgep = vtxp->outBeginp(); edgep; edgep = edgep->outNextp()) {
-                TristateVertex* const vvertexp = dynamic_cast<TristateVertex*>(edgep->top());
+                TristateVertex* const vvertexp = edgep->top()->as<TristateVertex>();
                 // Doesn't hurt to not check if already set, but by doing so when we
                 // print out the debug messages, we'll see this node at level 0 instead.
                 if (!vvertexp->isTristate()) {
@@ -234,7 +234,7 @@ private:
             // A variable is tristated.  Find all of the LHS VARREFs that
             // drive this signal now need tristate drivers
             for (V3GraphEdge* edgep = vtxp->inBeginp(); edgep; edgep = edgep->inNextp()) {
-                TristateVertex* const vvertexp = dynamic_cast<TristateVertex*>(edgep->fromp());
+                TristateVertex* const vvertexp = edgep->fromp()->as<TristateVertex>();
                 if (const AstVarRef* const refp = VN_CAST(vvertexp->nodep(), VarRef)) {
                     if (refp->access().isWriteOrRW()
                         // Doesn't hurt to not check if already set, but by doing so when we
@@ -259,7 +259,7 @@ private:
         UINFO(9, "  Mark feedstri " << level << "  " << vtxp << endl);
         if (!vtxp->varp()) {  // not a var where we stop the recursion
             for (V3GraphEdge* edgep = vtxp->inBeginp(); edgep; edgep = edgep->inNextp()) {
-                TristateVertex* const vvertexp = dynamic_cast<TristateVertex*>(edgep->fromp());
+                TristateVertex* const vvertexp = edgep->fromp()->as<TristateVertex>();
                 // Doesn't hurt to not check if already set, but by doing so when we
                 // print out the debug messages, we'll see this node at level 0 instead.
                 if (!vvertexp->feedsTri()) {

--- a/src/astgen
+++ b/src/astgen
@@ -178,12 +178,6 @@ class Node:
 AstNodes = {}
 AstNodeList = None
 
-GraphVertices = {}
-GraphVertexList = None
-
-GraphEdges = {}
-GraphEdgeList = None
-
 DfgVertices = {}
 DfgVertexList = None
 
@@ -553,57 +547,6 @@ def parseOpType(string):
     return None
 
 
-def read_graph_types(fh, vertex_types, edge_types):
-    has_errors = False
-
-    def handle_match(match, types):
-        keywrd = match.group(1)
-        if keywrd == "struct":
-            print(
-                filename + ":" + str(lineno) +
-                ": %Error: struct not allowed in graph vertex/edge declaration"
-            )
-            has_errors = True
-        classn = match.group(2)
-        supern = match.group(3)
-        super = types.get(supern)
-        if not super:
-            super = Node(supern, None)
-            types[supern] = super
-        node = types.get(classn)
-        if node:
-            node.superClass = supern
-        else:
-            node = Node(classn, super)
-            types[classn] = node
-        if super:
-            super.addSubClass(node)
-
-    re_first_part = r'^\s*(class|struct)\s*([a-zA-Z0-9_]+'
-    re_second_part = r')\s+(?:final|VL_NOT_FINAL)\s*:\s*(?:public|protected|private)?\s+([a-zA-Z0-9_]+)'
-    special_vertices = '|'.join(
-        ["AbstractMTask", "AbstractLogicMTask", "ExecMTask", "LogicMTask"])
-    if len(special_vertices) > 0:
-        special_vertices = '|' + special_vertices
-    vertex_re = re.compile(
-        f'{re_first_part}Vertex{special_vertices}{re_second_part}')
-    edge_re = re.compile(f'{re_first_part}Edge{re_second_part}')
-
-    for (lineno, line) in enumerate(fh, start=1):
-        line = line.strip()
-        if not line:
-            continue
-        match = re.search(vertex_re, line)
-        if match:
-            handle_match(match, vertex_types)
-        else:
-            match = re.search(edge_re, line)
-            if match:
-                handle_match(match, edge_types)
-    if has_errors:
-        sys.exit("%Error: Stopping due to errors reported above")
-
-
 def read_types(filename, Nodes, prefix):
     hasErrors = False
 
@@ -960,30 +903,6 @@ def write_type_tests(prefix, nodeList):
             fh.write(" }\n")
 
 
-def write_non_final_class_type_tests(prefix, nodeList):
-    with open_file("V3{p}__gen_type_tests.h".format(p=prefix)) as fh:
-        if prefix == "GraphVertex":
-            base = "V3GraphVertex"
-            variable = "vtxp"
-            enum = "VGraphVertexType"
-        elif prefix == "GraphEdge":
-            base = "V3GraphEdge"
-            variable = "edgep"
-            enum = "VGraphEdgeType"
-        for node in nodeList:
-            if node.isRoot:
-                fh.write(
-                    "template<> inline bool {b}::privateTypeTest<{n}>(const {b}*) {{ return true; }}"
-                    .format(b=base, n=node.name))
-            elif not node.isLeaf:
-                fh.write("class {n:<17} // ".format(n=node.name + ";"))
-                for superClass in node.allSuperClasses:
-                    fh.write("{n:<12}".format(n=superClass.name))
-                fh.write(
-                    "\ntemplate<> bool {b}::privateTypeTest<{n}>(const {b}* {v});\n"
-                    .format(b=base, n=node.name, v=variable))
-
-
 ################################################################################
 # Ast code genaration
 ################################################################################
@@ -1274,10 +1193,6 @@ parser.add_argument('infiles', nargs='*', help='list of input .cpp filenames')
 
 Args = parser.parse_args()
 
-source_files = glob.glob(Args.I + "/*.y")
-source_files.extend(glob.glob(Args.I + "/*.h"))
-source_files.extend(glob.glob(Args.I + "/*.cpp"))
-
 ###############################################################################
 # Read AstNode definitions
 ###############################################################################
@@ -1296,21 +1211,6 @@ AstNodes["Node"].complete()
 AstNodeList = tuple(map(lambda _: AstNodes[_], sorted(AstNodes.keys())))
 
 check_types(AstNodeList, "Ast", "Node")
-
-###############################################################################
-# Read and generate V3GraphVertex/Edge definitions
-###############################################################################
-
-for filename in source_files:
-    with open(filename, "r", encoding="utf8") as fh:
-        read_graph_types(fh, GraphVertices, GraphEdges)
-
-GraphVertices["V3GraphVertex"].complete()
-GraphEdges["V3GraphEdge"].complete()
-
-GraphVertexList = tuple(
-    map(lambda _: GraphVertices[_], sorted(GraphVertices.keys())))
-GraphEdgeList = tuple(map(lambda _: GraphEdges[_], sorted(GraphEdges.keys())))
 
 ###############################################################################
 # Read and generate DfgVertex definitions
@@ -1376,6 +1276,9 @@ check_types(DfgVertexList, "Dfg", "Vertex")
 
 read_stages(Args.I + "/Verilator.cpp")
 
+source_files = glob.glob(Args.I + "/*.y")
+source_files.extend(glob.glob(Args.I + "/*.h"))
+source_files.extend(glob.glob(Args.I + "/*.cpp"))
 for filename in source_files:
     read_refs(filename)
 
@@ -1394,11 +1297,6 @@ if Args.classes:
     write_ast_type_info("V3Ast__gen_type_info.h")
     write_ast_macros("V3Ast__gen_macros.h")
     write_ast_yystype("V3Ast__gen_yystype.h")
-    # Write V3Graph code
-    write_type_enum("GraphVertex", GraphVertexList)
-    write_non_final_class_type_tests("GraphVertex", GraphVertexList)
-    write_type_enum("GraphEdge", GraphEdgeList)
-    write_non_final_class_type_tests("GraphEdge", GraphEdgeList)
     # Write Dfg code
     write_forward_class_decls("Dfg", DfgVertexList)
     write_visitor_decls("Dfg", DfgVertexList)

--- a/src/astgen
+++ b/src/astgen
@@ -178,6 +178,12 @@ class Node:
 AstNodes = {}
 AstNodeList = None
 
+GraphVertices = {}
+GraphVertexList = None
+
+GraphEdges = {}
+GraphEdgeList = None
+
 DfgVertices = {}
 DfgVertexList = None
 
@@ -547,6 +553,57 @@ def parseOpType(string):
     return None
 
 
+def read_graph_types(fh, vertex_types, edge_types):
+    has_errors = False
+
+    def handle_match(match, types):
+        keywrd = match.group(1)
+        if keywrd == "struct":
+            print(
+                filename + ":" + str(lineno) +
+                ": %Error: struct not allowed in graph vertex/edge declaration"
+            )
+            has_errors = True
+        classn = match.group(2)
+        supern = match.group(3)
+        super = types.get(supern)
+        if not super:
+            super = Node(supern, None)
+            types[supern] = super
+        node = types.get(classn)
+        if node:
+            node.superClass = supern
+        else:
+            node = Node(classn, super)
+            types[classn] = node
+        if super:
+            super.addSubClass(node)
+
+    re_first_part = r'^\s*(class|struct)\s*([a-zA-Z0-9_]+'
+    re_second_part = r')\s+(?:final|VL_NOT_FINAL)\s*:\s*(?:public|protected|private)?\s+([a-zA-Z0-9_]+)'
+    special_vertices = '|'.join(
+        ["AbstractMTask", "AbstractLogicMTask", "ExecMTask", "LogicMTask"])
+    if len(special_vertices) > 0:
+        special_vertices = '|' + special_vertices
+    vertex_re = re.compile(
+        f'{re_first_part}Vertex{special_vertices}{re_second_part}')
+    edge_re = re.compile(f'{re_first_part}Edge{re_second_part}')
+
+    for (lineno, line) in enumerate(fh, start=1):
+        line = line.strip()
+        if not line:
+            continue
+        match = re.search(vertex_re, line)
+        if match:
+            handle_match(match, vertex_types)
+        else:
+            match = re.search(edge_re, line)
+            if match:
+                handle_match(match, edge_types)
+    if has_errors:
+        sys.exit("%Error: Stopping due to errors reported above")
+
+
 def read_types(filename, Nodes, prefix):
     hasErrors = False
 
@@ -903,6 +960,30 @@ def write_type_tests(prefix, nodeList):
             fh.write(" }\n")
 
 
+def write_non_final_class_type_tests(prefix, nodeList):
+    with open_file("V3{p}__gen_type_tests.h".format(p=prefix)) as fh:
+        if prefix == "GraphVertex":
+            base = "V3GraphVertex"
+            variable = "vtxp"
+            enum = "VGraphVertexType"
+        elif prefix == "GraphEdge":
+            base = "V3GraphEdge"
+            variable = "edgep"
+            enum = "VGraphEdgeType"
+        for node in nodeList:
+            if node.isRoot:
+                fh.write(
+                    "template<> inline bool {b}::privateTypeTest<{n}>(const {b}*) {{ return true; }}"
+                    .format(b=base, n=node.name))
+            elif not node.isLeaf:
+                fh.write("class {n:<17} // ".format(n=node.name + ";"))
+                for superClass in node.allSuperClasses:
+                    fh.write("{n:<12}".format(n=superClass.name))
+                fh.write(
+                    "\ntemplate<> bool {b}::privateTypeTest<{n}>(const {b}* {v});\n"
+                    .format(b=base, n=node.name, v=variable))
+
+
 ################################################################################
 # Ast code genaration
 ################################################################################
@@ -1193,6 +1274,10 @@ parser.add_argument('infiles', nargs='*', help='list of input .cpp filenames')
 
 Args = parser.parse_args()
 
+source_files = glob.glob(Args.I + "/*.y")
+source_files.extend(glob.glob(Args.I + "/*.h"))
+source_files.extend(glob.glob(Args.I + "/*.cpp"))
+
 ###############################################################################
 # Read AstNode definitions
 ###############################################################################
@@ -1211,6 +1296,21 @@ AstNodes["Node"].complete()
 AstNodeList = tuple(map(lambda _: AstNodes[_], sorted(AstNodes.keys())))
 
 check_types(AstNodeList, "Ast", "Node")
+
+###############################################################################
+# Read and generate V3GraphVertex/Edge definitions
+###############################################################################
+
+for filename in source_files:
+    with open(filename, "r", encoding="utf8") as fh:
+        read_graph_types(fh, GraphVertices, GraphEdges)
+
+GraphVertices["V3GraphVertex"].complete()
+GraphEdges["V3GraphEdge"].complete()
+
+GraphVertexList = tuple(
+    map(lambda _: GraphVertices[_], sorted(GraphVertices.keys())))
+GraphEdgeList = tuple(map(lambda _: GraphEdges[_], sorted(GraphEdges.keys())))
 
 ###############################################################################
 # Read and generate DfgVertex definitions
@@ -1276,9 +1376,6 @@ check_types(DfgVertexList, "Dfg", "Vertex")
 
 read_stages(Args.I + "/Verilator.cpp")
 
-source_files = glob.glob(Args.I + "/*.y")
-source_files.extend(glob.glob(Args.I + "/*.h"))
-source_files.extend(glob.glob(Args.I + "/*.cpp"))
 for filename in source_files:
     read_refs(filename)
 
@@ -1297,6 +1394,11 @@ if Args.classes:
     write_ast_type_info("V3Ast__gen_type_info.h")
     write_ast_macros("V3Ast__gen_macros.h")
     write_ast_yystype("V3Ast__gen_yystype.h")
+    # Write V3Graph code
+    write_type_enum("GraphVertex", GraphVertexList)
+    write_non_final_class_type_tests("GraphVertex", GraphVertexList)
+    write_type_enum("GraphEdge", GraphEdgeList)
+    write_non_final_class_type_tests("GraphEdge", GraphEdgeList)
     # Write Dfg code
     write_forward_class_decls("Dfg", DfgVertexList)
     write_visitor_decls("Dfg", DfgVertexList)


### PR DESCRIPTION
Adds type info generation to graph vertices and edges, similar to what's already
being done for the AST and DFG. This type info is used for downcasting generic
vertices/edges to concrete types. It brings a significant performance boost over
`dynamic_cast`, as shown by these benchmarks (mean verilation time):

|  Design    |  Commit 959387b6   |  This patch    |
|:-----------|-------------------:|---------------:|
| 720 kLOC   | 121.41 s           | 115.2  s (95%) |
| 1080 kLOC  | 224.42 s           | 202.89 s (90%) |
| 1590 kLOC  | 279 s              | 256.24 s (92%) |
| 2860 kLOC  | 720.49 s           | 672.86 s (93%) |

(959387b6 is a recent mainline commit; kLOC = 1000 lines of code; `tcmalloc` enabled)