### PR TITLE
Reduce the number of typechecks in graphs

### DIFF
--- a/src/V3Split.cpp
+++ b/src/V3Split.cpp
@@ -176,12 +176,12 @@ public:
     void setIgnoreThisStep() { m_ignoreInStep = s_stepNum; }
     virtual bool followScoreboard() const = 0;
     static bool followScoreboard(const V3GraphEdge* edgep) {
-        const SplitEdge* const oedgep = edgep->as<SplitEdge>();
+        const SplitEdge* const oedgep = static_cast<const SplitEdge*>(edgep);
         if (oedgep->ignoreThisStep()) return false;
         return oedgep->followScoreboard();
     }
     static bool followCyclic(const V3GraphEdge* edgep) {
-        const SplitEdge* const oedgep = edgep->as<SplitEdge>();
+        const SplitEdge* const oedgep = static_cast<const SplitEdge*>(edgep);
         return (!oedgep->ignoreThisStep());
     }
     string dotStyle() const override {
@@ -332,7 +332,7 @@ protected:
                     stdp->nodep()->dumpTree("-  ");
                 }
                 for (V3GraphEdge* edgep = vertexp->inBeginp(); edgep; edgep = edgep->inNextp()) {
-                    SplitEdge* const oedgep = edgep->as<SplitEdge>();
+                    SplitEdge* const oedgep = static_cast<SplitEdge*>(edgep);
                     oedgep->setIgnoreThisStep();
                 }
             }
@@ -487,12 +487,12 @@ protected:
                 if (const SplitLogicVertex* const vvertexp = vertexp->cast<SplitLogicVertex>()) {
                     for (V3GraphEdge* edgep = vertexp->inBeginp(); edgep;
                          edgep = edgep->inNextp()) {
-                        SplitEdge* const oedgep = edgep->as<SplitEdge>();
+                        SplitEdge* const oedgep = static_cast<SplitEdge*>(edgep);
                         oedgep->setIgnoreThisStep();
                     }
                     for (V3GraphEdge* edgep = vertexp->outBeginp(); edgep;
                          edgep = edgep->outNextp()) {
-                        SplitEdge* const oedgep = edgep->as<SplitEdge>();
+                        SplitEdge* const oedgep = static_cast<SplitEdge*>(edgep);
                         oedgep->setIgnoreThisStep();
                     }
                 }
@@ -919,7 +919,7 @@ protected:
 
             bool pruneMe = true;
             for (V3GraphEdge* edgep = logicp->outBeginp(); edgep; edgep = edgep->outNextp()) {
-                const SplitEdge* const oedgep = edgep->as<const SplitEdge>();
+                const SplitEdge* const oedgep = static_cast<const SplitEdge*>(edgep);
                 if (!oedgep->ignoreThisStep()) {
                     // This if conditional depends on something we can't
                     // prune -- a variable generated in the current block.
@@ -929,7 +929,8 @@ protected:
                     // give a hint about why...
                     if (debug() >= 9) {
                         V3GraphVertex* vxp = oedgep->top();
-                        const SplitNodeVertex* const nvxp = vxp->as<const SplitNodeVertex>();
+                        const SplitNodeVertex* const nvxp
+                            = static_cast<const SplitNodeVertex*>(vxp);
                         UINFO(0, "Cannot prune if-node due to edge "
                                      << oedgep << " pointing to node " << nvxp->nodep() << endl);
                         nvxp->nodep()->dumpTree("-  ");
@@ -943,7 +944,7 @@ protected:
 
             // This if can be split; prune dependencies on it.
             for (V3GraphEdge* edgep = logicp->inBeginp(); edgep; edgep = edgep->inNextp()) {
-                SplitEdge* const oedgep = edgep->as<SplitEdge>();
+                SplitEdge* const oedgep = static_cast<SplitEdge*>(edgep);
                 oedgep->setIgnoreThisStep();
             }
         }

--- a/src/V3Tristate.cpp
+++ b/src/V3Tristate.cpp
@@ -223,7 +223,7 @@ private:
         UINFO(9, "  Mark tri " << level << "  " << vtxp << endl);
         if (!vtxp->varp()) {  // not a var where we stop the recursion
             for (V3GraphEdge* edgep = vtxp->outBeginp(); edgep; edgep = edgep->outNextp()) {
-                TristateVertex* const vvertexp = edgep->top()->as<TristateVertex>();
+                TristateVertex* const vvertexp = static_cast<TristateVertex*>(edgep->top());
                 // Doesn't hurt to not check if already set, but by doing so when we
                 // print out the debug messages, we'll see this node at level 0 instead.
                 if (!vvertexp->isTristate()) {
@@ -235,7 +235,7 @@ private:
             // A variable is tristated.  Find all of the LHS VARREFs that
             // drive this signal now need tristate drivers
             for (V3GraphEdge* edgep = vtxp->inBeginp(); edgep; edgep = edgep->inNextp()) {
-                TristateVertex* const vvertexp = edgep->fromp()->as<TristateVertex>();
+                TristateVertex* const vvertexp = static_cast<TristateVertex*>(edgep->fromp());
                 if (const AstVarRef* const refp = VN_CAST(vvertexp->nodep(), VarRef)) {
                     if (refp->access().isWriteOrRW()
                         // Doesn't hurt to not check if already set, but by doing so when we
@@ -260,7 +260,7 @@ private:
         UINFO(9, "  Mark feedstri " << level << "  " << vtxp << endl);
         if (!vtxp->varp()) {  // not a var where we stop the recursion
             for (V3GraphEdge* edgep = vtxp->inBeginp(); edgep; edgep = edgep->inNextp()) {
-                TristateVertex* const vvertexp = edgep->fromp()->as<TristateVertex>();
+                TristateVertex* const vvertexp = static_cast<TristateVertex*>(edgep->fromp());
                 // Doesn't hurt to not check if already set, but by doing so when we
                 // print out the debug messages, we'll see this node at level 0 instead.
                 if (!vvertexp->feedsTri()) {


### PR DESCRIPTION
Removes typechecks for graph vertices or edges where it is obvious what the
downcasted type should be. Mean verilation time for a few designs:

|  Design    |  Commit 959387b6   |  #4397 patch    |  This patch    |
|:-----------|-------------------:|----------------:|---------------:|
| 720 kLOC   | 121.41 s           | 115.2  s (95%)  | 114.57 s (94%) |
| 1080 kLOC  | 224.42 s           | 202.89 s (90%)  | 200.72 s (89%) |
| 1590 kLOC  | 279 s              | 256.24 s (92%)  | 253.69 s (91%) |
| 2860 kLOC  | 720.49 s           | 672.86 s (93%)  | 668.27 s (93%) |

(959387b6 is a recent mainline commit; kLOC = 1000 lines of code; kLOC = 1000 lines of code; `tcmalloc` enabled)

Requires #4397.