### PR TITLE
Fix ++/-- under statements

### DIFF
--- a/src/V3LinkInc.cpp
+++ b/src/V3LinkInc.cpp
@@ -288,11 +288,11 @@ private:
             operp = new AstAdd{fl, readp->cloneTree(true), newconstp};
         }
 
-        AstAssign* assignp;
         if (VN_IS(nodep, PreAdd) || VN_IS(nodep, PreSub)) {
             // PreAdd/PreSub operations
             // Immediately after declaration - increment it by one
-            assignp = new AstAssign{fl, new AstVarRef{fl, varp, VAccess::WRITE}, operp};
+            AstAssign* const assignp
+                = new AstAssign{fl, new AstVarRef{fl, varp, VAccess::WRITE}, operp};
             insertNextToStmt(nodep, assignp);
             // Immediately after incrementing - assign it to the original variable
             assignp->addNextHere(new AstAssign{fl, writep->cloneTree(true),
@@ -300,8 +300,8 @@ private:
         } else {
             // PostAdd/PostSub operations
             // Assign the original variable to the temporary one
-            assignp = new AstAssign{fl, new AstVarRef{fl, varp, VAccess::WRITE},
-                                    readp->cloneTree(true)};
+            AstAssign* const assignp = new AstAssign{fl, new AstVarRef{fl, varp, VAccess::WRITE},
+                                                     readp->cloneTree(true)};
             insertNextToStmt(nodep, assignp);
             // Increment the original variable by one
             assignp->addNextHere(new AstAssign{fl, writep->cloneTree(true), operp});

--- a/src/V3LinkInc.cpp
+++ b/src/V3LinkInc.cpp
@@ -267,11 +267,10 @@ private:
 
         AstConst* const constp = VN_AS(nodep->lhsp(), Const);
         UASSERT_OBJ(nodep, constp, "Expecting CONST");
-        const AstNode* const backp = nodep->backp();
         AstConst* const newconstp = constp->cloneTree(true);
 
         // Prepare a temporary variable
-        FileLine* const fl = backp->fileline();
+        FileLine* const fl = nodep->fileline();
         const string name = string{"__Vincrement"} + cvtToStr(++m_modIncrementsNum);
         AstVar* const varp = new AstVar{
             fl, VVarType::BLOCKTEMP, name, VFlagChildDType{},

--- a/src/V3LinkInc.cpp
+++ b/src/V3LinkInc.cpp
@@ -68,23 +68,23 @@ private:
     bool m_unsupportedHere = false;  // Used to detect where it's not supported yet
 
     // METHODS
-    void insertOnTop(AstNode *newp) {
-        // Add the thing on top of current TFunc/Module
-        AstNode* stmtsp;
+    void insertOnTop(AstNode* newp) {
+        // Add the thing directly under the current TFunc/Module
+        AstNode* stmtsp = nullptr;
         if (m_ftaskp) {
             stmtsp = m_ftaskp->stmtsp();
         } else if (m_modp) {
             stmtsp = m_modp->stmtsp();
         }
-        stmtsp->unlinkFrBackWithNext();
-        newp->addNext(stmtsp);
+        UASSERT(stmtsp, "Variable not under FTASK/MODULE");
+        newp->addNext(stmtsp->unlinkFrBackWithNext());
         if (m_ftaskp) {
             m_ftaskp->addStmtsp(newp);
         } else if (m_modp) {
             m_modp->addStmtsp(newp);
         }
     }
-    void insertBeforeStmt(AstNode* nodep, AstNode* newp) {
+    void insertNextToStmt(AstNode* nodep, AstNode* newp) {
         // Return node that must be visited, if any
         if (debug() >= 9) newp->dumpTree("-  newstmt: ");
         UASSERT_OBJ(m_insStmtp, nodep, "Function not underneath a statement");
@@ -293,7 +293,7 @@ private:
             // PreAdd/PreSub operations
             // Immediately after declaration - increment it by one
             assignp = new AstAssign{fl, new AstVarRef{fl, varp, VAccess::WRITE}, operp};
-            insertBeforeStmt(nodep, assignp);
+            insertNextToStmt(nodep, assignp);
             // Immediately after incrementing - assign it to the original variable
             assignp->addNextHere(new AstAssign{fl, writep->cloneTree(true),
                                                new AstVarRef{fl, varp, VAccess::READ}});
@@ -301,8 +301,8 @@ private:
             // PostAdd/PostSub operations
             // Assign the original variable to the temporary one
             assignp = new AstAssign{fl, new AstVarRef{fl, varp, VAccess::WRITE},
-                                               readp->cloneTree(true)};
-            insertBeforeStmt(nodep, assignp);
+                                    readp->cloneTree(true)};
+            insertNextToStmt(nodep, assignp);
             // Increment the original variable by one
             assignp->addNextHere(new AstAssign{fl, writep->cloneTree(true), operp});
         }

--- a/test_regress/t/t_inc_relink.pl
+++ b/test_regress/t/t_inc_relink.pl
@@ -1,0 +1,18 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2023 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    verilator_flags2 => ["-Wno-WIDTHTRUNC"],
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_inc_relink.v
+++ b/test_regress/t/t_inc_relink.v
@@ -1,0 +1,37 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2023 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+// Test if temporary vars are relinked if not used directly under FTASK.
+
+package A;  // Create JUMPBLOCK; use n++ in it
+   task t;
+      automatic int n;
+      if ($random) return;
+      n = n++;
+   endtask
+endpackage
+
+package B;  // Create IF; use n++ in it
+   int n;
+   task t;
+      if ($random) n = n++;
+   endtask
+endpackage
+
+module C;  // Like above but in a module
+   int n = 0;
+
+   initial if ($random) n = n++;
+endmodule
+
+module t;  // Actually use those to test relinking
+   C c;
+
+   initial begin
+      A::t();
+      B::t();
+   end
+endmodule


### PR DESCRIPTION
Currently declarations of temporary variables of expressions like a++, a-- etc. are created right before the incr/decr operation.

This can lead to errors if the operator is used, for instance, in an if. That is because several parts of V3Task assume that variables are declared directly under ftask/module nodes -- if it's not like that, then there are problems with relinking variables in inlined functions.

This change makes V3LinkInc create a var directly under the current ftask/module.
It also changes the FileLine used for the var, now it points to the --/++ op instead of its parent node, which IMO improves error messages.
