### PR TITLE
Fix jumping over object initialization

### DIFF
--- a/src/V3AstNodeOther.h
+++ b/src/V3AstNodeOther.h
@@ -699,6 +699,16 @@ public:
                && finalsp() == nullptr;
     }
 };
+class AstCLocalScope final : public AstNode {
+    // Pack statements into an unnamed scope when generating C++
+    // @astgen op1 := stmtsp : List[AstNode]
+public:
+    AstCLocalScope(FileLine* fl, AstNode* stmtsp)
+        : ASTGEN_SUPER_CLocalScope(fl){
+        this->addStmtsp(stmtsp);
+    }
+    ASTGEN_MEMBERS_AstCLocalScope;
+};
 class AstCUse final : public AstNode {
     // C++ use of a class or #include; indicates need of forward declaration
     // Parents:  NODEMODULE

--- a/src/V3AstNodeOther.h
+++ b/src/V3AstNodeOther.h
@@ -704,7 +704,7 @@ class AstCLocalScope final : public AstNode {
     // @astgen op1 := stmtsp : List[AstNode]
 public:
     AstCLocalScope(FileLine* fl, AstNode* stmtsp)
-        : ASTGEN_SUPER_CLocalScope(fl){
+        : ASTGEN_SUPER_CLocalScope(fl) {
         this->addStmtsp(stmtsp);
     }
     ASTGEN_MEMBERS_AstCLocalScope;

--- a/src/V3Const.cpp
+++ b/src/V3Const.cpp
@@ -2288,6 +2288,13 @@ private:
             iterateChildren(nodep);
         }
     }
+    void visit(AstCLocalScope* nodep) {
+        iterateChildren(nodep);
+        if (!nodep->stmtsp()) {
+            nodep->unlinkFrBack();
+            VL_DO_DANGLING(nodep->deleteTree(), nodep);
+        }
+    }
     void visit(AstScope* nodep) override {
         // No ASSIGNW removals under scope, we've long eliminated INITIALs
         VL_RESTORER(m_wremove);

--- a/src/V3Const.cpp
+++ b/src/V3Const.cpp
@@ -2288,7 +2288,7 @@ private:
             iterateChildren(nodep);
         }
     }
-    void visit(AstCLocalScope* nodep) {
+    void visit(AstCLocalScope* nodep) override {
         iterateChildren(nodep);
         if (!nodep->stmtsp()) {
             nodep->unlinkFrBack();

--- a/src/V3EmitCFunc.h
+++ b/src/V3EmitCFunc.h
@@ -883,6 +883,11 @@ public:
         iterateAndNextConstNull(nodep->endStmtsp());
         puts("}\n");
     }
+    void visit(AstCLocalScope* nodep) override {
+        puts("{\n");
+        iterateAndNextConstNull(nodep->stmtsp());
+        puts("}\n");
+    }
     void visit(AstJumpGo* nodep) override {
         puts("goto __Vlabel" + cvtToStr(nodep->labelp()->blockp()->labelNum()) + ";\n");
     }

--- a/src/V3Timing.cpp
+++ b/src/V3Timing.cpp
@@ -645,7 +645,7 @@ private:
         FileLine* const flp = forkp->fileline();
         // If we're in a function, insert the sync var directly before the fork
         AstNode* const insertBeforep = m_classp ? forkp : nullptr;
-        AstCLocalScope* cscopep = tempNeedCLocalScope(flp, insertBeforep);
+        tempNeedCLocalScope(flp, insertBeforep);
         AstVarScope* forkVscp
             = createTemp(flp, forkp->name() + "__sync", getCreateForkSyncDTypep(), insertBeforep);
         unsigned joinCount = 0;  // Needed for join counter
@@ -934,7 +934,7 @@ private:
         // Insert new vars before the timing control if we're in a function; in a process we can't
         // do that. These intra-assignment vars will later be passed to forked processes by value.
         AstNode* const insertBeforep = m_classp ? controlp : nullptr;
-        AstCLocalScope* cscopep = tempNeedCLocalScope(flp, insertBeforep);
+        tempNeedCLocalScope(flp, insertBeforep);
         // Function for replacing values with intermediate variables
         const auto replaceWithIntermediate = [&](AstNodeExpr* const valuep,
                                                  const std::string& name) {

--- a/test_regress/t/t_jumps_uninit_destructor_call.pl
+++ b/test_regress/t/t_jumps_uninit_destructor_call.pl
@@ -1,0 +1,23 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2023 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    verilator_flags2 => ["--exe --main --timing"],
+    make_main => 0,
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_jumps_uninit_destructor_call.v
+++ b/test_regress/t/t_jumps_uninit_destructor_call.v
@@ -1,0 +1,31 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2023 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+class Foo;
+  task automatic return_before_fork(bit b);
+    if (b) begin
+      // This is going to translate to a `goto` statement.
+      return;
+    end
+    // This will instantiate a `VlForkSync` object (local to the call, as we are under a class)
+    fork
+      #10 $display("forked process");
+    join
+    // This is where we jump to from the aforementioned goto. If we don't wrap the `VlForkSync`
+    // object in a scope that ends before that point, we will end up calling its destructor
+    // without having it initialized first.
+  endtask
+endclass
+
+module t();
+  initial begin
+    Foo foo;
+    foo = new;
+    foo.return_before_fork(1'b1);
+    $write("*-* All Finished *-*\n");
+    $finish;
+  end
+endmodule

--- a/test_regress/t/t_jumps_uninit_destructor_call.v
+++ b/test_regress/t/t_jumps_uninit_destructor_call.v
@@ -3,8 +3,15 @@
 // This file ONLY is placed under the Creative Commons Public Domain, for
 // any use, without warranty, 2023 by Antmicro Ltd.
 // SPDX-License-Identifier: CC0-1.0
-
 class Foo;
+  string arra[2];
+  string arrb[string];
+
+  function new();
+    arra = '{"baz", "boo"};
+    arrb = '{"baz": "inga!", "boo": "..."};
+  endfunction
+
   task automatic return_before_fork(bit b);
     if (b) begin
       // This is going to translate to a `goto` statement.
@@ -18,6 +25,12 @@ class Foo;
     // object in a scope that ends before that point, we will end up calling its destructor
     // without having it initialized first.
   endtask
+  task automatic return_before_select(bit b, int idx);
+    if (b) return; // goto
+    // This will create two temporary strings used to select from `arrb` and assign to it.
+    arrb[arra[idx]] = #10 "yah!";
+    // jump here
+  endtask
 endclass
 
 module t();
@@ -25,6 +38,7 @@ module t();
     Foo foo;
     foo = new;
     foo.return_before_fork(1'b1);
+    foo.return_before_select(1'b1, 1);
     $write("*-* All Finished *-*\n");
     $finish;
   end


### PR DESCRIPTION
V3LinkJump generates `goto`s which can cause jumps over initalizations of objects that are within the same scope we are jumping into. This will result in a compilation error, or worse, in case the compiler dosn't recognize this issue, it would cause the destructor to be called on an unintialized object.

Eg. (from the included regression test):

```cxx
Vt_jumps_uninit_destructor_call___024unit__03a__03aFoo__Vclpkg__DepSet_hd4244f18__0.cpp:24:9: error: jump to label ‘__Vlabel1’
   24 |         __Vlabel1: ;
      |         ^~~~~~~~~
Vt_jumps_uninit_destructor_call___024unit__03a__03aFoo__Vclpkg__DepSet_hd4244f18__0.cpp:17:18: note:   from here
   17 |             goto __Vlabel1;
      |                  ^~~~~~~~~
Vt_jumps_uninit_destructor_call___024unit__03a__03aFoo__Vclpkg__DepSet_hd4244f18__0.cpp:19:20: note:   crosses initialization of ‘VlForkSync __Vfork_1__sync’
   19 |         VlForkSync __Vfork_1__sync;
      |
```

One way to avoid this issue, is to wrap the part of code that instantiates the object and uses it into a separate scope. Jumping over that scope is going to be safe, because the entire lifetime of that object would be contained wtihin it. To achieve this, I added a new node called `AstCLocalScope`. It doesn't have any functional use besides informing verilator that the code generated from statements underneath it needs to be contained in a dedicated, unnamed C/C++ scope in the final generated code. Whenever we are inside of an `AstJumpBlock` we can use it to solve this issue.