### PR TITLE
Refactor `AstNode::checkTreeIter` function

### DIFF
--- a/src/V3Ast.cpp
+++ b/src/V3Ast.cpp
@@ -1118,9 +1118,11 @@ void AstNode::checkTreeIter(const AstNode* prevBackp) const VL_MT_STABLE {
             UASSERT_OBJ(!nodep, this, typeInfo.m_namep << " must not use " << opName << "()");
             break;
         case VNTypeInfo::OP_USED:
-            UASSERT_OBJ(nodep, this, typeInfo.m_namep << " must have non nullptr " << opName << "()");
+            UASSERT_OBJ(nodep, this,
+                        typeInfo.m_namep << " must have non nullptr " << opName << "()");
             UASSERT_OBJ(!nodep->nextp(), this,
-                        typeInfo.m_namep << "::" << opName << "() cannot have a non nullptr nextp()");
+                        typeInfo.m_namep << "::" << opName
+                                         << "() cannot have a non nullptr nextp()");
             nodep->checkTreeIter(this);
             break;
         case VNTypeInfo::OP_LIST:
@@ -1145,7 +1147,7 @@ void AstNode::checkTreeIter(const AstNode* prevBackp) const VL_MT_STABLE {
             if (nodep) {
                 UASSERT_OBJ(!nodep->nextp(), this,
                             typeInfo.m_namep << "::" << opName
-                                                << "() cannot have a non-nullptr nextp()");
+                                             << "() cannot have a non-nullptr nextp()");
                 nodep->checkTreeIter(this);
             }
             break;

--- a/src/V3Ast.cpp
+++ b/src/V3Ast.cpp
@@ -1144,7 +1144,7 @@ void AstNode::checkTreeIter(const AstNode* prevBackp) const VL_MT_STABLE {
             if (nodep) {
                 UASSERT_OBJ(!nodep->nextp(), this,
                             typeInfo.name << "::" << opName
-                                          << "() cannot have a non nullptr nextp()");
+                                          << "() cannot have a non-nullptr nextp()");
                 nodep->checkTreeIter(this);
             }
             break;

--- a/src/V3Ast.cpp
+++ b/src/V3Ast.cpp
@@ -1112,15 +1112,15 @@ void AstNode::checkTreeIter(const AstNode* prevBackp) const VL_MT_STABLE {
         case 4: nodep = op4p(); break;
         default: this->v3fatalSrc("Bad case"); break;
         }
-        const char* opName = typeInfo.opName[i - 1];
-        switch (typeInfo.opType[i - 1]) {
+        const char* opName = typeInfo.m_opNamep[i - 1];
+        switch (typeInfo.m_opType[i - 1]) {
         case VNTypeInfo::OP_UNUSED:
-            UASSERT_OBJ(!nodep, this, typeInfo.name << " must not use " << opName << "()");
+            UASSERT_OBJ(!nodep, this, typeInfo.m_namep << " must not use " << opName << "()");
             break;
         case VNTypeInfo::OP_USED:
-            UASSERT_OBJ(nodep, this, typeInfo.name << " must have non nullptr " << opName << "()");
+            UASSERT_OBJ(nodep, this, typeInfo.m_namep << " must have non nullptr " << opName << "()");
             UASSERT_OBJ(!nodep->nextp(), this,
-                        typeInfo.name << "::" << opName << "() cannot have a non nullptr nextp()");
+                        typeInfo.m_namep << "::" << opName << "() cannot have a non nullptr nextp()");
             nodep->checkTreeIter(this);
             break;
         case VNTypeInfo::OP_LIST:
@@ -1144,13 +1144,13 @@ void AstNode::checkTreeIter(const AstNode* prevBackp) const VL_MT_STABLE {
         case VNTypeInfo::OP_OPTIONAL:
             if (nodep) {
                 UASSERT_OBJ(!nodep->nextp(), this,
-                            typeInfo.name << "::" << opName
-                                          << "() cannot have a non-nullptr nextp()");
+                            typeInfo.m_namep << "::" << opName
+                                                << "() cannot have a non-nullptr nextp()");
                 nodep->checkTreeIter(this);
             }
             break;
+        default: this->v3fatalSrc("Bad case"); break;
         }
-    default: this->v3fatalSrc("Bad case"); break;
     }
 }
 

--- a/src/V3Ast.cpp
+++ b/src/V3Ast.cpp
@@ -1149,6 +1149,7 @@ void AstNode::checkTreeIter(const AstNode* prevBackp) const VL_MT_STABLE {
             }
             break;
         }
+        default: this->v3fatalSrc("Bad case");
     }
 }
 

--- a/src/V3Ast.cpp
+++ b/src/V3Ast.cpp
@@ -55,12 +55,16 @@ bool VNUser5InUse::s_userBusy = false;
 int AstNodeDType::s_uniqueNum = 0;
 
 //######################################################################
-// V3AstType
+// VNType
+
+const VNTypeInfo VNType::typeInfoTable[] = {
+#include "V3Ast__gen_type_info.h"  // From ./astgen
+};
 
 std::ostream& operator<<(std::ostream& os, VNType rhs);
 
 //######################################################################
-// Creators
+// AstNode
 
 AstNode::AstNode(VNType t, FileLine* fl)
     : m_type{t}
@@ -1098,9 +1102,53 @@ bool AstNode::sameTreeIter(const AstNode* node1p, const AstNode* node2p, bool ig
 void AstNode::checkTreeIter(const AstNode* prevBackp) const VL_MT_STABLE {
     // private: Check a tree and children
     UASSERT_OBJ(prevBackp == this->backp(), this, "Back node inconsistent");
-    switch (this->type()) {
-#include "V3Ast__gen_op_checks.h"
-    default: VL_UNREACHABLE;  // LCOV_EXCL_LINE
+    const VNTypeInfo& typeInfo = *type().typeInfo();
+    for (int i = 1; i <= 4; i++) {
+        AstNode* nodep = nullptr;
+        switch (i) {
+        case 1: nodep = op1p(); break;
+        case 2: nodep = op2p(); break;
+        case 3: nodep = op3p(); break;
+        case 4: nodep = op4p(); break;
+        }
+        const char* opName = typeInfo.opName[i - 1];
+        switch (typeInfo.opType[i - 1]) {
+        case VNTypeInfo::OP_UNUSED:
+            UASSERT_OBJ(!nodep, this, typeInfo.name << " must not use " << opName << "()");
+            break;
+        case VNTypeInfo::OP_USED:
+            UASSERT_OBJ(nodep, this, typeInfo.name << " must have non nullptr " << opName << "()");
+            UASSERT_OBJ(!nodep->nextp(), this,
+                        typeInfo.name << "::" << opName << "() cannot have a non nullptr nextp()");
+            nodep->checkTreeIter(this);
+            break;
+        case VNTypeInfo::OP_LIST:
+            if (const AstNode* const headp = nodep) {
+                const AstNode* backp = this;
+                const AstNode* tailp = headp;
+                const AstNode* opp = headp;
+                do {
+                    opp->checkTreeIter(backp);
+                    UASSERT_OBJ(opp == headp || !opp->nextp() || !opp->m_headtailp, opp,
+                                "Headtailp should be null in middle of lists");
+                    backp = tailp = opp;
+                    opp = opp->nextp();
+                } while (opp);
+                UASSERT_OBJ(headp->m_headtailp == tailp, headp,
+                            "Tail in headtailp is inconsistent");
+                UASSERT_OBJ(tailp->m_headtailp == headp, tailp,
+                            "Head in headtailp is inconsistent");
+            }
+            break;
+        case VNTypeInfo::OP_OPTIONAL:
+            if (nodep) {
+                UASSERT_OBJ(!nodep->nextp(), this,
+                            typeInfo.name << "::" << opName
+                                          << "() cannot have a non nullptr nextp()");
+                nodep->checkTreeIter(this);
+            }
+            break;
+        }
     }
 }
 

--- a/src/V3Ast.cpp
+++ b/src/V3Ast.cpp
@@ -1149,7 +1149,7 @@ void AstNode::checkTreeIter(const AstNode* prevBackp) const VL_MT_STABLE {
             }
             break;
         }
-        default: this->v3fatalSrc("Bad case");
+    default: this->v3fatalSrc("Bad case");
     }
 }
 

--- a/src/V3Ast.cpp
+++ b/src/V3Ast.cpp
@@ -1110,6 +1110,7 @@ void AstNode::checkTreeIter(const AstNode* prevBackp) const VL_MT_STABLE {
         case 2: nodep = op2p(); break;
         case 3: nodep = op3p(); break;
         case 4: nodep = op4p(); break;
+        default: this->v3fatalSrc("Bad case"); break;
         }
         const char* opName = typeInfo.opName[i - 1];
         switch (typeInfo.opType[i - 1]) {
@@ -1149,7 +1150,7 @@ void AstNode::checkTreeIter(const AstNode* prevBackp) const VL_MT_STABLE {
             }
             break;
         }
-    default: this->v3fatalSrc("Bad case");
+    default: this->v3fatalSrc("Bad case"); break;
     }
 }
 

--- a/src/V3Ast.h
+++ b/src/V3Ast.h
@@ -99,14 +99,14 @@ using MTaskIdSet = std::set<int>;  // Set of mtaskIds for Var sorting
 //######################################################################
 
 struct VNTypeInfo {
-    const char* name;
+    const char* m_namep;
     enum uint8_t {
         OP_UNUSED,
         OP_USED,
         OP_LIST,
         OP_OPTIONAL,
-    } opType[4];
-    const char* opName[4];
+    } m_opType[4];
+    const char* m_opNamep[4];
 };
 
 class VNType final {

--- a/src/V3Ast.h
+++ b/src/V3Ast.h
@@ -98,7 +98,20 @@ using MTaskIdSet = std::set<int>;  // Set of mtaskIds for Var sorting
 
 //######################################################################
 
+struct VNTypeInfo {
+    const char* name;
+    enum uint8_t {
+        OP_UNUSED,
+        OP_USED,
+        OP_LIST,
+        OP_OPTIONAL,
+    } opType[4];
+    const char* opName[4];
+};
+
 class VNType final {
+    static const VNTypeInfo typeInfoTable[];
+
 public:
 #include "V3Ast__gen_type_enum.h"  // From ./astgen
     // Above include has:
@@ -111,6 +124,7 @@ public:
     constexpr VNType(en _e) VL_MT_SAFE : m_e{_e} {}
     explicit VNType(int _e)
         : m_e(static_cast<en>(_e)) {}  // Need () or GCC 4.8 false warning
+    const VNTypeInfo* typeInfo() const VL_MT_SAFE { return &typeInfoTable[m_e]; }
     constexpr operator en() const VL_MT_SAFE { return m_e; }
 };
 constexpr bool operator==(const VNType& lhs, const VNType& rhs) VL_PURE {

--- a/src/astgen
+++ b/src/astgen
@@ -920,7 +920,7 @@ def write_ast_type_info(filename):
                     opTypeList.append('OP_UNUSED')
                     opNameList.append('op{0}p'.format(n))
                 else:
-                    name, monad, kind = op
+                    name, monad, _ = op
                     if not monad:
                         opTypeList.append('OP_USED')
                     elif monad == "Optional":
@@ -929,10 +929,8 @@ def write_ast_type_info(filename):
                         opTypeList.append('OP_LIST')
                     opNameList.append(name)
             # opTypeStr = ', '.join(opTypeList)
-            opTypeStr = ', '.join(
-                list(map(lambda s: 'VNTypeInfo::{0}'.format(s), opTypeList)))
-            opNameStr = ', '.join(
-                list(map(lambda s: '"{0}"'.format(s), opNameList)))
+            opTypeStr = ', '.join(['VNTypeInfo::{0}'.format(s) for s in opTypeList])
+            opNameStr = ', '.join(['"{0}"'.format(s) for s in opNameList])
             fh.write(
                 '    {{ "Ast{name}", {{{opTypeStr}}}, {{{opNameStr}}} }},\n'.
                 format(

--- a/src/astgen
+++ b/src/astgen
@@ -246,7 +246,7 @@ class Cpt:
         with open_file(self.out_filename) as fho:
             togen = self.out_lines
             for line in togen:
-                if type(line) is str:
+                if isinstance(line, str):
                     self.out_lines = [line]
                 else:
                     self.out_lines = []

--- a/src/astgen
+++ b/src/astgen
@@ -929,7 +929,8 @@ def write_ast_type_info(filename):
                         opTypeList.append('OP_LIST')
                     opNameList.append(name)
             # opTypeStr = ', '.join(opTypeList)
-            opTypeStr = ', '.join(['VNTypeInfo::{0}'.format(s) for s in opTypeList])
+            opTypeStr = ', '.join(
+                ['VNTypeInfo::{0}'.format(s) for s in opTypeList])
             opNameStr = ', '.join(['"{0}"'.format(s) for s in opNameList])
             fh.write(
                 '    {{ "Ast{name}", {{{opTypeStr}}}, {{{opNameStr}}} }},\n'.

--- a/src/astgen
+++ b/src/astgen
@@ -908,6 +908,40 @@ def write_type_tests(prefix, nodeList):
 ################################################################################
 
 
+def write_ast_type_info(filename):
+    with open_file(filename) as fh:
+        for node in sorted(filter(lambda _: _.isLeaf, AstNodeList),
+                           key=lambda _: _.typeId):
+            opTypeList = []
+            opNameList = []
+            for n in range(1, 5):
+                op = node.getOp(n)
+                if not op:
+                    opTypeList.append('OP_UNUSED')
+                    opNameList.append('op{0}p'.format(n))
+                else:
+                    name, monad, kind = op
+                    if not monad:
+                        opTypeList.append('OP_USED')
+                    elif monad == "Optional":
+                        opTypeList.append('OP_OPTIONAL')
+                    elif monad == "List":
+                        opTypeList.append('OP_LIST')
+                    opNameList.append(name)
+            # opTypeStr = ', '.join(opTypeList)
+            opTypeStr = ', '.join(
+                list(map(lambda s: 'VNTypeInfo::{0}'.format(s), opTypeList)))
+            opNameStr = ', '.join(
+                list(map(lambda s: '"{0}"'.format(s), opNameList)))
+            fh.write(
+                '    {{ "Ast{name}", {{{opTypeStr}}}, {{{opNameStr}}} }},\n'.
+                format(
+                    name=node.name,
+                    opTypeStr=opTypeStr,
+                    opNameStr=opNameStr,
+                ))
+
+
 def write_ast_macros(filename):
     with open_file(filename) as fh:
 
@@ -996,91 +1030,6 @@ def write_ast_yystype(filename):
             fh.write("Ast{t}* {m}p;\n".format(t=node.name,
                                               m=node.name[0].lower() +
                                               node.name[1:]))
-
-
-def write_ast_op_checks(filename):
-    with open_file(filename) as fh:
-
-        indent = ""
-
-        def emitBlock(pattern, **fmt):
-            fh.write(
-                textwrap.indent(textwrap.dedent(pattern),
-                                indent).format(**fmt))
-
-        for node in AstNodeList:
-            if not node.isLeaf:
-                continue
-
-            emitBlock('''\
-                case VNType::at{nodeName}: {{
-                    const Ast{nodeName}* const currp = static_cast<const Ast{nodeName}*>(this);
-                ''',
-                      nodeName=node.name)
-            indent = "    "
-            for n in range(1, 5):
-                op = node.getOp(n)
-                emitBlock("// Checking op{n}p\n", n=n)
-                if op:
-                    name, monad, kind = op
-                    if not monad:
-                        emitBlock('''\
-                            UASSERT_OBJ(currp->{opName}(), currp, "Ast{nodeName} must have non nullptr {opName}()");
-                            UASSERT_OBJ(!currp->{opName}()->nextp(), currp, "Ast{nodeName}::{opName}() cannot have a non nullptr nextp()");
-                            currp->{opName}()->checkTreeIter(currp);
-                            ''',
-                                  n=n,
-                                  nodeName=node.name,
-                                  opName=name)
-                    elif monad == "Optional":
-                        emitBlock('''\
-                            if (Ast{kind}* const opp = currp->{opName}()) {{
-                                UASSERT_OBJ(!currp->{opName}()->nextp(), currp, "Ast{nodeName}::{opName}() cannot have a non nullptr nextp()");
-                                opp->checkTreeIter(currp);
-                            }}
-                            ''',
-                                  n=n,
-                                  nodeName=node.name,
-                                  opName=name,
-                                  kind=kind)
-                    elif monad == "List":
-                        emitBlock('''\
-                            if (const Ast{kind}* const headp = currp->{opName}()) {{
-                                const AstNode* backp = currp;
-                                const Ast{kind}* tailp = headp;
-                                const Ast{kind}* opp = headp;
-                                do {{
-                                    opp->checkTreeIter(backp);
-                                    UASSERT_OBJ(opp == headp || !opp->nextp() || !opp->m_headtailp, opp, "Headtailp should be null in middle of lists");
-                                    backp = tailp = opp;
-                                    opp = {next};
-                                }} while (opp);
-                                // cppcheck-suppress knownConditionTrueFalse
-                                if (false && headp && tailp) {{}}  // Prevent unused
-                                UASSERT_OBJ(headp->m_headtailp == tailp, headp, "Tail in headtailp is inconsistent");
-                                UASSERT_OBJ(tailp->m_headtailp == headp, tailp, "Head in headtailp is inconsistent");
-                            }}
-                            ''',
-                                  n=n,
-                                  nodeName=node.name,
-                                  opName=name,
-                                  kind=kind,
-                                  next="VN_AS(opp->nextp(), {kind})".format(
-                                      kind=kind)
-                                  if kind != "Node" else "opp->nextp()")
-                    else:
-                        sys.exit("Unknown operand type")
-                else:
-                    emitBlock('''\
-                        UASSERT_OBJ(!currp->op{n}p(), currp, "Ast{nodeName} does not use op{n}p()");
-                        ''',
-                              n=n,
-                              nodeName=node.name)
-            indent = ""
-            emitBlock('''\
-                    break;
-                }}
-                ''')
 
 
 ################################################################################
@@ -1346,9 +1295,9 @@ if Args.classes:
     write_visitor_defns("Ast", AstNodeList, "VNVisitorConst")
     write_type_enum("Ast", AstNodeList)
     write_type_tests("Ast", AstNodeList)
+    write_ast_type_info("V3Ast__gen_type_info.h")
     write_ast_macros("V3Ast__gen_macros.h")
     write_ast_yystype("V3Ast__gen_yystype.h")
-    write_ast_op_checks("V3Ast__gen_op_checks.h")
     # Write Dfg code
     write_forward_class_decls("Dfg", DfgVertexList)
     write_visitor_decls("Dfg", DfgVertexList)


### PR DESCRIPTION
The old `AstNode::checkTreeIter` function used a big switch-case statement to determine the checking operation for different node type. It seems to be fine on Linux, but the generated V3Ast.cpp.obj object file by MSVC is about 62MB due to the complexity of the function, and what's wrose is that it require about 336kB of the stack per call function call, on Windows (GCC can make it dynamically allocate the stack frame but MSVC seems not). This makes the program easy to stack-overflow especially with the default configuration of 1MB stack size. So the giant function is rewritten and it's now using a new `VNTypeInfo` table which saves the types and names for each `op[1-4]p` for each `AstNode`s, so the operation can be implemented with simpler code by looking-up the table.

The content in the new generated `V3Ast__gen_type_info.h` file looks like

``` C++
    { "AstActive", {VNTypeInfo::OP_OPTIONAL, VNTypeInfo::OP_LIST, VNTypeInfo::OP_UNUSED, VNTypeInfo::OP_UNUSED}, {"sensesStorep", "stmtsp", "op3p", "op4p"} },
    { "AstBind", {VNTypeInfo::OP_LIST, VNTypeInfo::OP_UNUSED, VNTypeInfo::OP_UNUSED, VNTypeInfo::OP_UNUSED}, {"cellsp", "op2p", "op3p", "op4p"} },
    ...
```


To my surprise, this simple optimization reduces the size of the final binary files by about 3MB.

Linux:
```
old
  21337720 verilator_bin
 104657192 verilator_bin_dbg
new
  18435328 verilator_bin
 100067480 verilator_bin_dbg
```

Windows:
```
old
  11908608 verilator_bin.exe
  34540032 verilator_bin_dbg.exe
new
   9884672 verilator_bin.exe
  28452352 verilator_bin_dbg.exe
```