### PR TITLE
Fix timing logs

### DIFF
--- a/include/verilated_timing.h
+++ b/include/verilated_timing.h
@@ -116,7 +116,7 @@ public:
     // Move the handle, leaving a nullptr
     VlCoroutineHandle(VlCoroutineHandle&& moved)
         : m_coro{std::exchange(moved.m_coro, nullptr)}
-        , m_process{moved.m_process}
+        , m_process{std::exchange(moved.m_process, nullptr)}
         , m_fileline{moved.m_fileline} {}
     // Destroy if the handle isn't null
     ~VlCoroutineHandle() {
@@ -133,6 +133,8 @@ public:
     // Move the handle, leaving a null handle
     auto& operator=(VlCoroutineHandle&& moved) {
         m_coro = std::exchange(moved.m_coro, nullptr);
+        m_process = std::exchange(moved.m_process, nullptr);
+        m_fileline = moved.m_fileline;
         return *this;
     }
     // Resume the coroutine if the handle isn't null and the process isn't killed

--- a/test_regress/t/t_timing_debug1.out
+++ b/test_regress/t/t_timing_debug1.out
@@ -74,13 +74,13 @@
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Delayed processes:
--V{t#,#}             Awaiting time 3: Process waiting at t/t_timing_sched.v:52
+-V{t#,#}             Awaiting time 3: Process waiting at t/t_timing_sched.v:10
 -V{t#,#}             Awaiting time 3: Process waiting at t/t_timing_sched.v:10
 -V{t#,#}             Awaiting time 11: Process waiting at t/t_timing_sched.v:13
--V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:10
+-V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:52
 -V{t#,#}             Awaiting time 11: Process waiting at t/t_timing_sched.v:13
 -V{t#,#}         Resuming delayed processes
--V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:13
+-V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:10
 -V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:10
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_comb__TOP__0
@@ -134,13 +134,13 @@
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Delayed processes:
--V{t#,#}             Awaiting time 6: Process waiting at t/t_timing_sched.v:52
--V{t#,#}             Awaiting time 7: Process waiting at t/t_timing_sched.v:10
--V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:13
--V{t#,#}             Awaiting time 11: Process waiting at t/t_timing_sched.v:10
--V{t#,#}             Awaiting time 11: Process waiting at t/t_timing_sched.v:17
+-V{t#,#}             Awaiting time 6: Process waiting at t/t_timing_sched.v:10
+-V{t#,#}             Awaiting time 7: Process waiting at t/t_timing_sched.v:17
+-V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:52
+-V{t#,#}             Awaiting time 11: Process waiting at t/t_timing_sched.v:13
+-V{t#,#}             Awaiting time 11: Process waiting at t/t_timing_sched.v:13
 -V{t#,#}         Resuming delayed processes
--V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:17
+-V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:10
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_comb__TOP__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
@@ -173,13 +173,13 @@
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Delayed processes:
--V{t#,#}             Awaiting time 7: Process waiting at t/t_timing_sched.v:52
+-V{t#,#}             Awaiting time 7: Process waiting at t/t_timing_sched.v:17
 -V{t#,#}             Awaiting time 9: Process waiting at t/t_timing_sched.v:10
--V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:13
--V{t#,#}             Awaiting time 11: Process waiting at t/t_timing_sched.v:10
--V{t#,#}             Awaiting time 11: Process waiting at t/t_timing_sched.v:10
+-V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:52
+-V{t#,#}             Awaiting time 11: Process waiting at t/t_timing_sched.v:13
+-V{t#,#}             Awaiting time 11: Process waiting at t/t_timing_sched.v:13
 -V{t#,#}         Resuming delayed processes
--V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:10
+-V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:17
 -V{t#,#}         Suspending process waiting for @(posedge t.clk1) at t/t_timing_sched.v:17
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_comb__TOP__0
@@ -207,10 +207,10 @@
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Delayed processes:
--V{t#,#}             Awaiting time 9: Process waiting at t/t_timing_sched.v:52
--V{t#,#}             Awaiting time 11: Process waiting at t/t_timing_sched.v:10
--V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:13
--V{t#,#}             Awaiting time 11: Process waiting at t/t_timing_sched.v:10
+-V{t#,#}             Awaiting time 9: Process waiting at t/t_timing_sched.v:10
+-V{t#,#}             Awaiting time 11: Process waiting at t/t_timing_sched.v:13
+-V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:52
+-V{t#,#}             Awaiting time 11: Process waiting at t/t_timing_sched.v:13
 -V{t#,#}         Resuming delayed processes
 -V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:10
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
@@ -259,14 +259,14 @@
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Delayed processes:
--V{t#,#}             Awaiting time 11: Process waiting at t/t_timing_sched.v:52
--V{t#,#}             Awaiting time 11: Process waiting at t/t_timing_sched.v:10
--V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:13
+-V{t#,#}             Awaiting time 11: Process waiting at t/t_timing_sched.v:13
+-V{t#,#}             Awaiting time 11: Process waiting at t/t_timing_sched.v:13
+-V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:52
 -V{t#,#}             Awaiting time 12: Process waiting at t/t_timing_sched.v:10
 -V{t#,#}             Awaiting time 13: Process waiting at t/t_timing_sched.v:17
 -V{t#,#}         Resuming delayed processes
--V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:17
--V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:10
+-V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:13
+-V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:13
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_comb__TOP__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
@@ -324,14 +324,14 @@
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Delayed processes:
--V{t#,#}             Awaiting time 12: Process waiting at t/t_timing_sched.v:52
 -V{t#,#}             Awaiting time 12: Process waiting at t/t_timing_sched.v:10
--V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:13
+-V{t#,#}             Awaiting time 12: Process waiting at t/t_timing_sched.v:50
+-V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:52
 -V{t#,#}             Awaiting time 22: Process waiting at t/t_timing_sched.v:13
--V{t#,#}             Awaiting time 13: Process waiting at t/t_timing_sched.v:50
+-V{t#,#}             Awaiting time 13: Process waiting at t/t_timing_sched.v:17
 -V{t#,#}         Resuming delayed processes
+-V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:10
 -V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:50
--V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:13
 -V{t#,#}         Suspending process waiting for @(posedge t.clk2) at t/t_timing_sched.v:50
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_comb__TOP__0
@@ -367,12 +367,12 @@
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Delayed processes:
--V{t#,#}             Awaiting time 13: Process waiting at t/t_timing_sched.v:52
+-V{t#,#}             Awaiting time 13: Process waiting at t/t_timing_sched.v:17
 -V{t#,#}             Awaiting time 15: Process waiting at t/t_timing_sched.v:10
--V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:13
--V{t#,#}             Awaiting time 22: Process waiting at t/t_timing_sched.v:10
+-V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:52
+-V{t#,#}             Awaiting time 22: Process waiting at t/t_timing_sched.v:13
 -V{t#,#}         Resuming delayed processes
--V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:10
+-V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:17
 -V{t#,#}         Suspending process waiting for @(posedge t.clk1) at t/t_timing_sched.v:17
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_comb__TOP__0
@@ -400,11 +400,11 @@
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Delayed processes:
--V{t#,#}             Awaiting time 15: Process waiting at t/t_timing_sched.v:52
--V{t#,#}             Awaiting time 22: Process waiting at t/t_timing_sched.v:10
--V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:13
+-V{t#,#}             Awaiting time 15: Process waiting at t/t_timing_sched.v:10
+-V{t#,#}             Awaiting time 22: Process waiting at t/t_timing_sched.v:13
+-V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:52
 -V{t#,#}         Resuming delayed processes
--V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:13
+-V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:10
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_comb__TOP__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
@@ -457,12 +457,12 @@
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Delayed processes:
--V{t#,#}             Awaiting time 18: Process waiting at t/t_timing_sched.v:52
--V{t#,#}             Awaiting time 19: Process waiting at t/t_timing_sched.v:10
--V{t#,#}             Awaiting time 22: Process waiting at t/t_timing_sched.v:10
--V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:17
+-V{t#,#}             Awaiting time 18: Process waiting at t/t_timing_sched.v:10
+-V{t#,#}             Awaiting time 19: Process waiting at t/t_timing_sched.v:17
+-V{t#,#}             Awaiting time 22: Process waiting at t/t_timing_sched.v:13
+-V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:52
 -V{t#,#}         Resuming delayed processes
--V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:17
+-V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:10
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_comb__TOP__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
@@ -495,12 +495,12 @@
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Delayed processes:
--V{t#,#}             Awaiting time 19: Process waiting at t/t_timing_sched.v:52
+-V{t#,#}             Awaiting time 19: Process waiting at t/t_timing_sched.v:17
 -V{t#,#}             Awaiting time 21: Process waiting at t/t_timing_sched.v:10
--V{t#,#}             Awaiting time 22: Process waiting at t/t_timing_sched.v:10
--V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:10
+-V{t#,#}             Awaiting time 22: Process waiting at t/t_timing_sched.v:13
+-V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:52
 -V{t#,#}         Resuming delayed processes
--V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:10
+-V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:17
 -V{t#,#}         Suspending process waiting for @(posedge t.clk1) at t/t_timing_sched.v:17
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_comb__TOP__0
@@ -528,9 +528,9 @@
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Delayed processes:
--V{t#,#}             Awaiting time 21: Process waiting at t/t_timing_sched.v:52
--V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:10
--V{t#,#}             Awaiting time 22: Process waiting at t/t_timing_sched.v:10
+-V{t#,#}             Awaiting time 21: Process waiting at t/t_timing_sched.v:10
+-V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:52
+-V{t#,#}             Awaiting time 22: Process waiting at t/t_timing_sched.v:13
 -V{t#,#}         Resuming delayed processes
 -V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:10
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
@@ -579,12 +579,12 @@
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Delayed processes:
--V{t#,#}             Awaiting time 22: Process waiting at t/t_timing_sched.v:52
--V{t#,#}             Awaiting time 25: Process waiting at t/t_timing_sched.v:10
+-V{t#,#}             Awaiting time 22: Process waiting at t/t_timing_sched.v:13
+-V{t#,#}             Awaiting time 25: Process waiting at t/t_timing_sched.v:17
 -V{t#,#}             Awaiting time 24: Process waiting at t/t_timing_sched.v:10
--V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:17
+-V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:52
 -V{t#,#}         Resuming delayed processes
--V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:17
+-V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:13
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_comb__TOP__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
@@ -617,12 +617,12 @@
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Delayed processes:
--V{t#,#}             Awaiting time 24: Process waiting at t/t_timing_sched.v:52
--V{t#,#}             Awaiting time 25: Process waiting at t/t_timing_sched.v:10
--V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:10
+-V{t#,#}             Awaiting time 24: Process waiting at t/t_timing_sched.v:10
+-V{t#,#}             Awaiting time 25: Process waiting at t/t_timing_sched.v:17
+-V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:52
 -V{t#,#}             Awaiting time 33: Process waiting at t/t_timing_sched.v:13
 -V{t#,#}         Resuming delayed processes
--V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:13
+-V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:10
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_comb__TOP__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
@@ -655,12 +655,12 @@
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Delayed processes:
--V{t#,#}             Awaiting time 25: Process waiting at t/t_timing_sched.v:52
+-V{t#,#}             Awaiting time 25: Process waiting at t/t_timing_sched.v:17
 -V{t#,#}             Awaiting time 27: Process waiting at t/t_timing_sched.v:10
--V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:10
--V{t#,#}             Awaiting time 33: Process waiting at t/t_timing_sched.v:10
+-V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:52
+-V{t#,#}             Awaiting time 33: Process waiting at t/t_timing_sched.v:13
 -V{t#,#}         Resuming delayed processes
--V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:10
+-V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:17
 -V{t#,#}         Suspending process waiting for @(posedge t.clk1) at t/t_timing_sched.v:17
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_comb__TOP__0
@@ -688,9 +688,9 @@
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Delayed processes:
--V{t#,#}             Awaiting time 27: Process waiting at t/t_timing_sched.v:52
--V{t#,#}             Awaiting time 33: Process waiting at t/t_timing_sched.v:10
--V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:10
+-V{t#,#}             Awaiting time 27: Process waiting at t/t_timing_sched.v:10
+-V{t#,#}             Awaiting time 33: Process waiting at t/t_timing_sched.v:13
+-V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:52
 -V{t#,#}         Resuming delayed processes
 -V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:10
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
@@ -739,12 +739,12 @@
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Delayed processes:
--V{t#,#}             Awaiting time 30: Process waiting at t/t_timing_sched.v:52
--V{t#,#}             Awaiting time 31: Process waiting at t/t_timing_sched.v:10
--V{t#,#}             Awaiting time 33: Process waiting at t/t_timing_sched.v:10
--V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:17
+-V{t#,#}             Awaiting time 30: Process waiting at t/t_timing_sched.v:10
+-V{t#,#}             Awaiting time 31: Process waiting at t/t_timing_sched.v:17
+-V{t#,#}             Awaiting time 33: Process waiting at t/t_timing_sched.v:13
+-V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:52
 -V{t#,#}         Resuming delayed processes
--V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:17
+-V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:10
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_comb__TOP__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
@@ -777,12 +777,12 @@
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Delayed processes:
--V{t#,#}             Awaiting time 31: Process waiting at t/t_timing_sched.v:52
+-V{t#,#}             Awaiting time 31: Process waiting at t/t_timing_sched.v:17
 -V{t#,#}             Awaiting time 33: Process waiting at t/t_timing_sched.v:10
--V{t#,#}             Awaiting time 33: Process waiting at t/t_timing_sched.v:10
--V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:10
+-V{t#,#}             Awaiting time 33: Process waiting at t/t_timing_sched.v:13
+-V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:52
 -V{t#,#}         Resuming delayed processes
--V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:10
+-V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:17
 -V{t#,#}         Suspending process waiting for @(posedge t.clk1) at t/t_timing_sched.v:17
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_comb__TOP__0
@@ -810,11 +810,11 @@
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Delayed processes:
--V{t#,#}             Awaiting time 33: Process waiting at t/t_timing_sched.v:52
+-V{t#,#}             Awaiting time 33: Process waiting at t/t_timing_sched.v:13
 -V{t#,#}             Awaiting time 33: Process waiting at t/t_timing_sched.v:10
--V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:10
+-V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:52
 -V{t#,#}         Resuming delayed processes
--V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:10
+-V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:13
 -V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:10
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_comb__TOP__0
@@ -883,11 +883,11 @@
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Delayed processes:
--V{t#,#}             Awaiting time 34: Process waiting at t/t_timing_sched.v:52
+-V{t#,#}             Awaiting time 34: Process waiting at t/t_timing_sched.v:50
 -V{t#,#}             Awaiting time 36: Process waiting at t/t_timing_sched.v:10
 -V{t#,#}             Awaiting time 44: Process waiting at t/t_timing_sched.v:13
--V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:17
--V{t#,#}             Awaiting time 37: Process waiting at t/t_timing_sched.v:50
+-V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:52
+-V{t#,#}             Awaiting time 37: Process waiting at t/t_timing_sched.v:17
 -V{t#,#}         Resuming delayed processes
 -V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:50
 -V{t#,#}         Suspending process waiting for @(posedge t.clk2) at t/t_timing_sched.v:50
@@ -917,12 +917,12 @@
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Delayed processes:
--V{t#,#}             Awaiting time 36: Process waiting at t/t_timing_sched.v:52
--V{t#,#}             Awaiting time 37: Process waiting at t/t_timing_sched.v:10
+-V{t#,#}             Awaiting time 36: Process waiting at t/t_timing_sched.v:10
+-V{t#,#}             Awaiting time 37: Process waiting at t/t_timing_sched.v:17
 -V{t#,#}             Awaiting time 44: Process waiting at t/t_timing_sched.v:13
--V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:17
+-V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:52
 -V{t#,#}         Resuming delayed processes
--V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:17
+-V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:10
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_comb__TOP__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
@@ -955,12 +955,12 @@
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Delayed processes:
--V{t#,#}             Awaiting time 37: Process waiting at t/t_timing_sched.v:52
+-V{t#,#}             Awaiting time 37: Process waiting at t/t_timing_sched.v:17
 -V{t#,#}             Awaiting time 39: Process waiting at t/t_timing_sched.v:10
 -V{t#,#}             Awaiting time 44: Process waiting at t/t_timing_sched.v:13
--V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:10
+-V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:52
 -V{t#,#}         Resuming delayed processes
--V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:10
+-V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:17
 -V{t#,#}         Suspending process waiting for @(posedge t.clk1) at t/t_timing_sched.v:17
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_comb__TOP__0
@@ -988,11 +988,11 @@
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Delayed processes:
--V{t#,#}             Awaiting time 39: Process waiting at t/t_timing_sched.v:52
--V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:10
+-V{t#,#}             Awaiting time 39: Process waiting at t/t_timing_sched.v:10
+-V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:52
 -V{t#,#}             Awaiting time 44: Process waiting at t/t_timing_sched.v:13
 -V{t#,#}         Resuming delayed processes
--V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:13
+-V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:10
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_comb__TOP__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
@@ -1045,12 +1045,12 @@
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Delayed processes:
--V{t#,#}             Awaiting time 42: Process waiting at t/t_timing_sched.v:52
--V{t#,#}             Awaiting time 43: Process waiting at t/t_timing_sched.v:10
--V{t#,#}             Awaiting time 44: Process waiting at t/t_timing_sched.v:10
--V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:17
+-V{t#,#}             Awaiting time 42: Process waiting at t/t_timing_sched.v:10
+-V{t#,#}             Awaiting time 43: Process waiting at t/t_timing_sched.v:17
+-V{t#,#}             Awaiting time 44: Process waiting at t/t_timing_sched.v:13
+-V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:52
 -V{t#,#}         Resuming delayed processes
--V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:17
+-V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:10
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_comb__TOP__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
@@ -1083,12 +1083,12 @@
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Delayed processes:
--V{t#,#}             Awaiting time 43: Process waiting at t/t_timing_sched.v:52
+-V{t#,#}             Awaiting time 43: Process waiting at t/t_timing_sched.v:17
 -V{t#,#}             Awaiting time 45: Process waiting at t/t_timing_sched.v:10
--V{t#,#}             Awaiting time 44: Process waiting at t/t_timing_sched.v:10
--V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:10
+-V{t#,#}             Awaiting time 44: Process waiting at t/t_timing_sched.v:13
+-V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:52
 -V{t#,#}         Resuming delayed processes
--V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:10
+-V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:17
 -V{t#,#}         Suspending process waiting for @(posedge t.clk1) at t/t_timing_sched.v:17
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_comb__TOP__0
@@ -1116,11 +1116,11 @@
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Delayed processes:
--V{t#,#}             Awaiting time 44: Process waiting at t/t_timing_sched.v:52
+-V{t#,#}             Awaiting time 44: Process waiting at t/t_timing_sched.v:13
 -V{t#,#}             Awaiting time 45: Process waiting at t/t_timing_sched.v:10
--V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:10
+-V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:52
 -V{t#,#}         Resuming delayed processes
--V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:10
+-V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:13
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_comb__TOP__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
@@ -1153,11 +1153,11 @@
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Delayed processes:
--V{t#,#}             Awaiting time 45: Process waiting at t/t_timing_sched.v:52
--V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:10
+-V{t#,#}             Awaiting time 45: Process waiting at t/t_timing_sched.v:10
+-V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:52
 -V{t#,#}             Awaiting time 55: Process waiting at t/t_timing_sched.v:13
 -V{t#,#}         Resuming delayed processes
--V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:13
+-V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:10
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_comb__TOP__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
@@ -1204,12 +1204,12 @@
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Delayed processes:
--V{t#,#}             Awaiting time 48: Process waiting at t/t_timing_sched.v:52
--V{t#,#}             Awaiting time 49: Process waiting at t/t_timing_sched.v:10
--V{t#,#}             Awaiting time 55: Process waiting at t/t_timing_sched.v:10
--V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:17
+-V{t#,#}             Awaiting time 48: Process waiting at t/t_timing_sched.v:10
+-V{t#,#}             Awaiting time 49: Process waiting at t/t_timing_sched.v:17
+-V{t#,#}             Awaiting time 55: Process waiting at t/t_timing_sched.v:13
+-V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:52
 -V{t#,#}         Resuming delayed processes
--V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:17
+-V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:10
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_comb__TOP__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
@@ -1242,12 +1242,12 @@
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Delayed processes:
--V{t#,#}             Awaiting time 49: Process waiting at t/t_timing_sched.v:52
+-V{t#,#}             Awaiting time 49: Process waiting at t/t_timing_sched.v:17
 -V{t#,#}             Awaiting time 51: Process waiting at t/t_timing_sched.v:10
--V{t#,#}             Awaiting time 55: Process waiting at t/t_timing_sched.v:10
--V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:10
+-V{t#,#}             Awaiting time 55: Process waiting at t/t_timing_sched.v:13
+-V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:52
 -V{t#,#}         Resuming delayed processes
--V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:10
+-V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:17
 -V{t#,#}         Suspending process waiting for @(posedge t.clk1) at t/t_timing_sched.v:17
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_comb__TOP__0
@@ -1275,9 +1275,9 @@
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Delayed processes:
--V{t#,#}             Awaiting time 51: Process waiting at t/t_timing_sched.v:52
--V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:10
--V{t#,#}             Awaiting time 55: Process waiting at t/t_timing_sched.v:10
+-V{t#,#}             Awaiting time 51: Process waiting at t/t_timing_sched.v:10
+-V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:52
+-V{t#,#}             Awaiting time 55: Process waiting at t/t_timing_sched.v:13
 -V{t#,#}         Resuming delayed processes
 -V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:10
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
@@ -1326,12 +1326,12 @@
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Delayed processes:
--V{t#,#}             Awaiting time 54: Process waiting at t/t_timing_sched.v:52
--V{t#,#}             Awaiting time 55: Process waiting at t/t_timing_sched.v:10
--V{t#,#}             Awaiting time 55: Process waiting at t/t_timing_sched.v:10
--V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:17
+-V{t#,#}             Awaiting time 54: Process waiting at t/t_timing_sched.v:10
+-V{t#,#}             Awaiting time 55: Process waiting at t/t_timing_sched.v:17
+-V{t#,#}             Awaiting time 55: Process waiting at t/t_timing_sched.v:13
+-V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:52
 -V{t#,#}         Resuming delayed processes
--V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:17
+-V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:10
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_comb__TOP__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
@@ -1364,13 +1364,13 @@
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Delayed processes:
--V{t#,#}             Awaiting time 55: Process waiting at t/t_timing_sched.v:52
--V{t#,#}             Awaiting time 55: Process waiting at t/t_timing_sched.v:10
--V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:10
+-V{t#,#}             Awaiting time 55: Process waiting at t/t_timing_sched.v:13
+-V{t#,#}             Awaiting time 55: Process waiting at t/t_timing_sched.v:17
+-V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:52
 -V{t#,#}             Awaiting time 57: Process waiting at t/t_timing_sched.v:10
 -V{t#,#}         Resuming delayed processes
--V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:10
--V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:10
+-V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:13
+-V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:17
 -V{t#,#}         Suspending process waiting for @(posedge t.clk1) at t/t_timing_sched.v:17
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_comb__TOP__0
@@ -1431,10 +1431,10 @@
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Delayed processes:
--V{t#,#}             Awaiting time 56: Process waiting at t/t_timing_sched.v:52
+-V{t#,#}             Awaiting time 56: Process waiting at t/t_timing_sched.v:50
 -V{t#,#}             Awaiting time 57: Process waiting at t/t_timing_sched.v:10
 -V{t#,#}             Awaiting time 66: Process waiting at t/t_timing_sched.v:13
--V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:50
+-V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:52
 -V{t#,#}         Resuming delayed processes
 -V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:50
 -V{t#,#}         Suspending process waiting for @(posedge t.clk2) at t/t_timing_sched.v:50
@@ -1464,11 +1464,11 @@
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Delayed processes:
--V{t#,#}             Awaiting time 57: Process waiting at t/t_timing_sched.v:52
--V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:10
+-V{t#,#}             Awaiting time 57: Process waiting at t/t_timing_sched.v:10
+-V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:52
 -V{t#,#}             Awaiting time 66: Process waiting at t/t_timing_sched.v:13
 -V{t#,#}         Resuming delayed processes
--V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:13
+-V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:10
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_comb__TOP__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
@@ -1521,12 +1521,12 @@
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Delayed processes:
--V{t#,#}             Awaiting time 60: Process waiting at t/t_timing_sched.v:52
--V{t#,#}             Awaiting time 61: Process waiting at t/t_timing_sched.v:10
--V{t#,#}             Awaiting time 66: Process waiting at t/t_timing_sched.v:10
--V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:17
+-V{t#,#}             Awaiting time 60: Process waiting at t/t_timing_sched.v:10
+-V{t#,#}             Awaiting time 61: Process waiting at t/t_timing_sched.v:17
+-V{t#,#}             Awaiting time 66: Process waiting at t/t_timing_sched.v:13
+-V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:52
 -V{t#,#}         Resuming delayed processes
--V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:17
+-V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:10
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_comb__TOP__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
@@ -1559,12 +1559,12 @@
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Delayed processes:
--V{t#,#}             Awaiting time 61: Process waiting at t/t_timing_sched.v:52
+-V{t#,#}             Awaiting time 61: Process waiting at t/t_timing_sched.v:17
 -V{t#,#}             Awaiting time 63: Process waiting at t/t_timing_sched.v:10
--V{t#,#}             Awaiting time 66: Process waiting at t/t_timing_sched.v:10
--V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:10
+-V{t#,#}             Awaiting time 66: Process waiting at t/t_timing_sched.v:13
+-V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:52
 -V{t#,#}         Resuming delayed processes
--V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:10
+-V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:17
 -V{t#,#}         Suspending process waiting for @(posedge t.clk1) at t/t_timing_sched.v:17
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_comb__TOP__0
@@ -1592,9 +1592,9 @@
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Delayed processes:
--V{t#,#}             Awaiting time 63: Process waiting at t/t_timing_sched.v:52
--V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:10
--V{t#,#}             Awaiting time 66: Process waiting at t/t_timing_sched.v:10
+-V{t#,#}             Awaiting time 63: Process waiting at t/t_timing_sched.v:10
+-V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:52
+-V{t#,#}             Awaiting time 66: Process waiting at t/t_timing_sched.v:13
 -V{t#,#}         Resuming delayed processes
 -V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:10
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
@@ -1643,12 +1643,12 @@
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Delayed processes:
--V{t#,#}             Awaiting time 66: Process waiting at t/t_timing_sched.v:52
--V{t#,#}             Awaiting time 67: Process waiting at t/t_timing_sched.v:10
+-V{t#,#}             Awaiting time 66: Process waiting at t/t_timing_sched.v:13
+-V{t#,#}             Awaiting time 67: Process waiting at t/t_timing_sched.v:17
 -V{t#,#}             Awaiting time 66: Process waiting at t/t_timing_sched.v:10
--V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:17
+-V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:52
 -V{t#,#}         Resuming delayed processes
--V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:17
+-V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:13
 -V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:10
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_comb__TOP__0
@@ -1685,12 +1685,12 @@
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Delayed processes:
--V{t#,#}             Awaiting time 67: Process waiting at t/t_timing_sched.v:52
--V{t#,#}             Awaiting time 77: Process waiting at t/t_timing_sched.v:10
+-V{t#,#}             Awaiting time 67: Process waiting at t/t_timing_sched.v:17
+-V{t#,#}             Awaiting time 77: Process waiting at t/t_timing_sched.v:13
 -V{t#,#}             Awaiting time 69: Process waiting at t/t_timing_sched.v:10
--V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:13
+-V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:52
 -V{t#,#}         Resuming delayed processes
--V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:13
+-V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:17
 -V{t#,#}         Suspending process waiting for @(posedge t.clk1) at t/t_timing_sched.v:17
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_comb__TOP__0
@@ -1718,9 +1718,9 @@
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Delayed processes:
--V{t#,#}             Awaiting time 69: Process waiting at t/t_timing_sched.v:52
--V{t#,#}             Awaiting time 77: Process waiting at t/t_timing_sched.v:10
--V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:10
+-V{t#,#}             Awaiting time 69: Process waiting at t/t_timing_sched.v:10
+-V{t#,#}             Awaiting time 77: Process waiting at t/t_timing_sched.v:13
+-V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:52
 -V{t#,#}         Resuming delayed processes
 -V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:10
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
@@ -1769,12 +1769,12 @@
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Delayed processes:
--V{t#,#}             Awaiting time 72: Process waiting at t/t_timing_sched.v:52
--V{t#,#}             Awaiting time 73: Process waiting at t/t_timing_sched.v:10
--V{t#,#}             Awaiting time 77: Process waiting at t/t_timing_sched.v:10
--V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:17
+-V{t#,#}             Awaiting time 72: Process waiting at t/t_timing_sched.v:10
+-V{t#,#}             Awaiting time 73: Process waiting at t/t_timing_sched.v:17
+-V{t#,#}             Awaiting time 77: Process waiting at t/t_timing_sched.v:13
+-V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:52
 -V{t#,#}         Resuming delayed processes
--V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:17
+-V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:10
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_comb__TOP__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
@@ -1807,12 +1807,12 @@
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Delayed processes:
--V{t#,#}             Awaiting time 73: Process waiting at t/t_timing_sched.v:52
+-V{t#,#}             Awaiting time 73: Process waiting at t/t_timing_sched.v:17
 -V{t#,#}             Awaiting time 75: Process waiting at t/t_timing_sched.v:10
--V{t#,#}             Awaiting time 77: Process waiting at t/t_timing_sched.v:10
--V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:10
+-V{t#,#}             Awaiting time 77: Process waiting at t/t_timing_sched.v:13
+-V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:52
 -V{t#,#}         Resuming delayed processes
--V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:10
+-V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:17
 -V{t#,#}         Suspending process waiting for @(posedge t.clk1) at t/t_timing_sched.v:17
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_comb__TOP__0
@@ -1840,9 +1840,9 @@
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Delayed processes:
--V{t#,#}             Awaiting time 75: Process waiting at t/t_timing_sched.v:52
--V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:10
--V{t#,#}             Awaiting time 77: Process waiting at t/t_timing_sched.v:10
+-V{t#,#}             Awaiting time 75: Process waiting at t/t_timing_sched.v:10
+-V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:52
+-V{t#,#}             Awaiting time 77: Process waiting at t/t_timing_sched.v:13
 -V{t#,#}         Resuming delayed processes
 -V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:10
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
@@ -1891,12 +1891,12 @@
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Delayed processes:
--V{t#,#}             Awaiting time 77: Process waiting at t/t_timing_sched.v:52
--V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:10
+-V{t#,#}             Awaiting time 77: Process waiting at t/t_timing_sched.v:13
+-V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:52
 -V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:10
 -V{t#,#}             Awaiting time 79: Process waiting at t/t_timing_sched.v:17
 -V{t#,#}         Resuming delayed processes
--V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:17
+-V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:13
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_comb__TOP__0
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
@@ -1954,16 +1954,16 @@
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Delayed processes:
--V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:52
 -V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:10
--V{t#,#}             Awaiting time 79: Process waiting at t/t_timing_sched.v:10
+-V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:52
+-V{t#,#}             Awaiting time 79: Process waiting at t/t_timing_sched.v:17
 -V{t#,#}             Awaiting time 88: Process waiting at t/t_timing_sched.v:13
 -V{t#,#}             Awaiting time 78: Process waiting at t/t_timing_sched.v:50
 -V{t#,#}         Resuming delayed processes
--V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:50
--V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:13
-*-* All Finished *-*
 -V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:10
+-V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:52
+*-* All Finished *-*
+-V{t#,#}             Resuming: Process waiting at t/t_timing_sched.v:50
 -V{t#,#}         Suspending process waiting for @(posedge t.clk2) at t/t_timing_sched.v:50
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
 -V{t#,#}+    Vt_timing_debug1___024root___act_comb__TOP__0

--- a/test_regress/t/t_timing_debug2.out
+++ b/test_regress/t/t_timing_debug2.out
@@ -106,16 +106,16 @@
 -V{t#,#}+    Vt_timing_debug2___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug2___024root___timing_resume
 -V{t#,#}         Delayed processes:
--V{t#,#}             Awaiting time 5: Process waiting at t/t_timing_class.v:119
--V{t#,#}             Awaiting time 10: Process waiting at t/t_timing_class.v:120
--V{t#,#}             Awaiting time 10: Process waiting at t/t_timing_class.v:122
--V{t#,#}             Awaiting time 30: Process waiting at t/t_timing_class.v:136
--V{t#,#}             Awaiting time 20: Process waiting at t/t_timing_class.v:173
--V{t#,#}             Awaiting time 50: Process waiting at t/t_timing_class.v:247
+-V{t#,#}             Awaiting time 5: Process waiting at t/t_timing_class.v:131
+-V{t#,#}             Awaiting time 10: Process waiting at t/t_timing_class.v:173
+-V{t#,#}             Awaiting time 10: Process waiting at t/t_timing_class.v:247
+-V{t#,#}             Awaiting time 30: Process waiting at t/t_timing_class.v:257
+-V{t#,#}             Awaiting time 20: Process waiting at t/t_timing_class.v:119
+-V{t#,#}             Awaiting time 50: Process waiting at t/t_timing_class.v:122
 -V{t#,#}             Awaiting time 20: Process waiting at t/t_timing_class.v:252
--V{t#,#}             Awaiting time 80: Process waiting at t/t_timing_class.v:257
+-V{t#,#}             Awaiting time 80: Process waiting at t/t_timing_class.v:136
 -V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:274
--V{t#,#}             Awaiting time 40: Process waiting at t/t_timing_class.v:131
+-V{t#,#}             Awaiting time 40: Process waiting at t/t_timing_class.v:120
 -V{t#,#}         Resuming delayed processes
 -V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:131
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aClkClass::__VnoInFunc_flip
@@ -167,23 +167,23 @@
 -V{t#,#}+    Vt_timing_debug2___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug2___024root___timing_resume
 -V{t#,#}         Delayed processes:
--V{t#,#}             Awaiting time 10: Process waiting at t/t_timing_class.v:119
--V{t#,#}             Awaiting time 10: Process waiting at t/t_timing_class.v:120
--V{t#,#}             Awaiting time 20: Process waiting at t/t_timing_class.v:122
--V{t#,#}             Awaiting time 30: Process waiting at t/t_timing_class.v:136
+-V{t#,#}             Awaiting time 10: Process waiting at t/t_timing_class.v:247
 -V{t#,#}             Awaiting time 10: Process waiting at t/t_timing_class.v:173
--V{t#,#}             Awaiting time 50: Process waiting at t/t_timing_class.v:247
--V{t#,#}             Awaiting time 40: Process waiting at t/t_timing_class.v:252
--V{t#,#}             Awaiting time 80: Process waiting at t/t_timing_class.v:257
+-V{t#,#}             Awaiting time 20: Process waiting at t/t_timing_class.v:252
+-V{t#,#}             Awaiting time 30: Process waiting at t/t_timing_class.v:257
+-V{t#,#}             Awaiting time 10: Process waiting at t/t_timing_class.v:131
+-V{t#,#}             Awaiting time 50: Process waiting at t/t_timing_class.v:122
+-V{t#,#}             Awaiting time 40: Process waiting at t/t_timing_class.v:120
+-V{t#,#}             Awaiting time 80: Process waiting at t/t_timing_class.v:136
 -V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:274
--V{t#,#}             Awaiting time 20: Process waiting at t/t_timing_class.v:131
+-V{t#,#}             Awaiting time 20: Process waiting at t/t_timing_class.v:119
 -V{t#,#}         Resuming delayed processes
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:131
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:247
 -V{t#,#}             Process forked at t/t_timing_class.v:246 finished
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:274
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:173
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aDelay10::__VnoInFunc_do_sth_else
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aDelay20::__VnoInFunc_do_delay
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:174
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:131
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aClkClass::__VnoInFunc_flip
 -V{t#,#}+    Vt_timing_debug2___024root___eval_act
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
@@ -219,15 +219,15 @@
 -V{t#,#}+    Vt_timing_debug2___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug2___024root___timing_resume
 -V{t#,#}         Delayed processes:
--V{t#,#}             Awaiting time 15: Process waiting at t/t_timing_class.v:119
--V{t#,#}             Awaiting time 20: Process waiting at t/t_timing_class.v:120
--V{t#,#}             Awaiting time 30: Process waiting at t/t_timing_class.v:122
--V{t#,#}             Awaiting time 20: Process waiting at t/t_timing_class.v:136
--V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:173
--V{t#,#}             Awaiting time 50: Process waiting at t/t_timing_class.v:247
--V{t#,#}             Awaiting time 40: Process waiting at t/t_timing_class.v:252
--V{t#,#}             Awaiting time 80: Process waiting at t/t_timing_class.v:257
--V{t#,#}             Awaiting time 30: Process waiting at t/t_timing_class.v:131
+-V{t#,#}             Awaiting time 15: Process waiting at t/t_timing_class.v:131
+-V{t#,#}             Awaiting time 20: Process waiting at t/t_timing_class.v:252
+-V{t#,#}             Awaiting time 30: Process waiting at t/t_timing_class.v:174
+-V{t#,#}             Awaiting time 20: Process waiting at t/t_timing_class.v:119
+-V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:274
+-V{t#,#}             Awaiting time 50: Process waiting at t/t_timing_class.v:122
+-V{t#,#}             Awaiting time 40: Process waiting at t/t_timing_class.v:120
+-V{t#,#}             Awaiting time 80: Process waiting at t/t_timing_class.v:136
+-V{t#,#}             Awaiting time 30: Process waiting at t/t_timing_class.v:257
 -V{t#,#}         Resuming delayed processes
 -V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:131
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aClkClass::__VnoInFunc_flip
@@ -279,23 +279,23 @@
 -V{t#,#}+    Vt_timing_debug2___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug2___024root___timing_resume
 -V{t#,#}         Delayed processes:
+-V{t#,#}             Awaiting time 20: Process waiting at t/t_timing_class.v:252
 -V{t#,#}             Awaiting time 20: Process waiting at t/t_timing_class.v:119
--V{t#,#}             Awaiting time 20: Process waiting at t/t_timing_class.v:120
--V{t#,#}             Awaiting time 30: Process waiting at t/t_timing_class.v:122
--V{t#,#}             Awaiting time 20: Process waiting at t/t_timing_class.v:136
--V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:173
--V{t#,#}             Awaiting time 50: Process waiting at t/t_timing_class.v:247
--V{t#,#}             Awaiting time 40: Process waiting at t/t_timing_class.v:252
--V{t#,#}             Awaiting time 80: Process waiting at t/t_timing_class.v:257
--V{t#,#}             Awaiting time 30: Process waiting at t/t_timing_class.v:131
+-V{t#,#}             Awaiting time 30: Process waiting at t/t_timing_class.v:174
+-V{t#,#}             Awaiting time 20: Process waiting at t/t_timing_class.v:131
+-V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:274
+-V{t#,#}             Awaiting time 50: Process waiting at t/t_timing_class.v:122
+-V{t#,#}             Awaiting time 40: Process waiting at t/t_timing_class.v:120
+-V{t#,#}             Awaiting time 80: Process waiting at t/t_timing_class.v:136
+-V{t#,#}             Awaiting time 30: Process waiting at t/t_timing_class.v:257
 -V{t#,#}         Resuming delayed processes
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:131
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:252
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aForkDelayClass::new
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aForkDelayClass::_ctor_var_reset
 -V{t#,#}             Process forked at t/t_timing_class.v:251 finished
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:257
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:119
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aEventClass::__VnoInFunc_wake
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:252
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:131
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aClkClass::__VnoInFunc_flip
 -V{t#,#}+    Vt_timing_debug2___024root___eval_act
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
@@ -373,13 +373,13 @@
 -V{t#,#}+    Vt_timing_debug2___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug2___024root___timing_resume
 -V{t#,#}         Delayed processes:
--V{t#,#}             Awaiting time 25: Process waiting at t/t_timing_class.v:119
--V{t#,#}             Awaiting time 30: Process waiting at t/t_timing_class.v:120
--V{t#,#}             Awaiting time 30: Process waiting at t/t_timing_class.v:122
+-V{t#,#}             Awaiting time 25: Process waiting at t/t_timing_class.v:131
+-V{t#,#}             Awaiting time 30: Process waiting at t/t_timing_class.v:257
+-V{t#,#}             Awaiting time 30: Process waiting at t/t_timing_class.v:174
 -V{t#,#}             Awaiting time 80: Process waiting at t/t_timing_class.v:136
--V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:173
--V{t#,#}             Awaiting time 50: Process waiting at t/t_timing_class.v:247
--V{t#,#}             Awaiting time 40: Process waiting at t/t_timing_class.v:131
+-V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:274
+-V{t#,#}             Awaiting time 50: Process waiting at t/t_timing_class.v:122
+-V{t#,#}             Awaiting time 40: Process waiting at t/t_timing_class.v:120
 -V{t#,#}         Resuming delayed processes
 -V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:131
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aClkClass::__VnoInFunc_flip
@@ -463,20 +463,20 @@
 -V{t#,#}+    Vt_timing_debug2___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug2___024root___timing_resume
 -V{t#,#}         Delayed processes:
--V{t#,#}             Awaiting time 30: Process waiting at t/t_timing_class.v:119
--V{t#,#}             Awaiting time 30: Process waiting at t/t_timing_class.v:120
--V{t#,#}             Awaiting time 30: Process waiting at t/t_timing_class.v:122
+-V{t#,#}             Awaiting time 30: Process waiting at t/t_timing_class.v:174
+-V{t#,#}             Awaiting time 30: Process waiting at t/t_timing_class.v:257
+-V{t#,#}             Awaiting time 30: Process waiting at t/t_timing_class.v:131
 -V{t#,#}             Awaiting time 80: Process waiting at t/t_timing_class.v:136
--V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:173
--V{t#,#}             Awaiting time 50: Process waiting at t/t_timing_class.v:247
--V{t#,#}             Awaiting time 40: Process waiting at t/t_timing_class.v:131
+-V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:274
+-V{t#,#}             Awaiting time 50: Process waiting at t/t_timing_class.v:122
+-V{t#,#}             Awaiting time 40: Process waiting at t/t_timing_class.v:120
 -V{t#,#}         Resuming delayed processes
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:131
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:174
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aDelay20::__VnoInFunc_do_sth_else
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aDelay40::__VnoInFunc_do_delay
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:175
--V{t#,#}+        Vt_timing_debug2_t__03a__03aClkClass::__VnoInFunc_flip
 -V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:131
+-V{t#,#}+        Vt_timing_debug2_t__03a__03aClkClass::__VnoInFunc_flip
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:257
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aForkDelayClass::__VnoInFunc_do_delay
 -V{t#,#}+    Vt_timing_debug2___024root___eval_act
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
@@ -536,15 +536,15 @@
 -V{t#,#}+    Vt_timing_debug2___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug2___024root___timing_resume
 -V{t#,#}         Delayed processes:
--V{t#,#}             Awaiting time 35: Process waiting at t/t_timing_class.v:119
--V{t#,#}             Awaiting time 70: Process waiting at t/t_timing_class.v:120
--V{t#,#}             Awaiting time 40: Process waiting at t/t_timing_class.v:122
+-V{t#,#}             Awaiting time 35: Process waiting at t/t_timing_class.v:131
+-V{t#,#}             Awaiting time 70: Process waiting at t/t_timing_class.v:175
+-V{t#,#}             Awaiting time 40: Process waiting at t/t_timing_class.v:120
 -V{t#,#}             Awaiting time 80: Process waiting at t/t_timing_class.v:136
--V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:173
--V{t#,#}             Awaiting time 50: Process waiting at t/t_timing_class.v:247
+-V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:274
+-V{t#,#}             Awaiting time 50: Process waiting at t/t_timing_class.v:122
 -V{t#,#}             Awaiting time 70: Process waiting at t/t_timing_class.v:238
 -V{t#,#}         Resuming delayed processes
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:238
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:131
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aClkClass::__VnoInFunc_flip
 -V{t#,#}+    Vt_timing_debug2___024root___eval_act
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
@@ -626,16 +626,16 @@
 -V{t#,#}+    Vt_timing_debug2___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug2___024root___timing_resume
 -V{t#,#}         Delayed processes:
--V{t#,#}             Awaiting time 40: Process waiting at t/t_timing_class.v:119
--V{t#,#}             Awaiting time 70: Process waiting at t/t_timing_class.v:120
--V{t#,#}             Awaiting time 40: Process waiting at t/t_timing_class.v:122
+-V{t#,#}             Awaiting time 40: Process waiting at t/t_timing_class.v:120
+-V{t#,#}             Awaiting time 70: Process waiting at t/t_timing_class.v:175
+-V{t#,#}             Awaiting time 40: Process waiting at t/t_timing_class.v:131
 -V{t#,#}             Awaiting time 80: Process waiting at t/t_timing_class.v:136
--V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:173
--V{t#,#}             Awaiting time 70: Process waiting at t/t_timing_class.v:247
--V{t#,#}             Awaiting time 50: Process waiting at t/t_timing_class.v:131
+-V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:274
+-V{t#,#}             Awaiting time 70: Process waiting at t/t_timing_class.v:238
+-V{t#,#}             Awaiting time 50: Process waiting at t/t_timing_class.v:122
 -V{t#,#}         Resuming delayed processes
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:120
 -V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:131
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:247
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aClkClass::__VnoInFunc_flip
 -V{t#,#}+    Vt_timing_debug2___024root___eval_act
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
@@ -721,12 +721,12 @@
 -V{t#,#}+    Vt_timing_debug2___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug2___024root___timing_resume
 -V{t#,#}         Delayed processes:
--V{t#,#}             Awaiting time 45: Process waiting at t/t_timing_class.v:119
--V{t#,#}             Awaiting time 70: Process waiting at t/t_timing_class.v:120
+-V{t#,#}             Awaiting time 45: Process waiting at t/t_timing_class.v:131
+-V{t#,#}             Awaiting time 70: Process waiting at t/t_timing_class.v:175
 -V{t#,#}             Awaiting time 50: Process waiting at t/t_timing_class.v:122
 -V{t#,#}             Awaiting time 80: Process waiting at t/t_timing_class.v:136
--V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:173
--V{t#,#}             Awaiting time 70: Process waiting at t/t_timing_class.v:131
+-V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:274
+-V{t#,#}             Awaiting time 70: Process waiting at t/t_timing_class.v:238
 -V{t#,#}         Resuming delayed processes
 -V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:131
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aClkClass::__VnoInFunc_flip
@@ -781,102 +781,102 @@
 -V{t#,#}+    Vt_timing_debug2___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug2___024root___timing_resume
 -V{t#,#}         Delayed processes:
--V{t#,#}             Awaiting time 50: Process waiting at t/t_timing_class.v:119
--V{t#,#}             Awaiting time 70: Process waiting at t/t_timing_class.v:120
 -V{t#,#}             Awaiting time 50: Process waiting at t/t_timing_class.v:122
+-V{t#,#}             Awaiting time 70: Process waiting at t/t_timing_class.v:175
+-V{t#,#}             Awaiting time 50: Process waiting at t/t_timing_class.v:131
 -V{t#,#}             Awaiting time 80: Process waiting at t/t_timing_class.v:136
--V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:173
--V{t#,#}             Awaiting time 70: Process waiting at t/t_timing_class.v:131
+-V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:274
+-V{t#,#}             Awaiting time 70: Process waiting at t/t_timing_class.v:238
+-V{t#,#}         Resuming delayed processes
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:122
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:131
+-V{t#,#}+        Vt_timing_debug2_t__03a__03aClkClass::__VnoInFunc_flip
+-V{t#,#}+    Vt_timing_debug2___024root___eval_act
+-V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
+-V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
+-V{t#,#}           - Process waiting at t/t_timing_class.v:58
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:58
+-V{t#,#}         Suspending process waiting for @([true] ((32'sh4 == t::WaitClass.a) & (32'sh10 < t::WaitClass.b))) at t/t_timing_class.v:58
+-V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
+-V{t#,#}         No triggers active
+-V{t#,#}+    Vt_timing_debug2___024root___timing_commit
+-V{t#,#}+    Vt_timing_debug2___024root___eval_nba
+-V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
+-V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
+-V{t#,#}           - Process waiting at t/t_timing_class.v:58
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:58
+-V{t#,#}         Suspending process waiting for @([true] ((32'sh4 == t::WaitClass.a) & (32'sh10 < t::WaitClass.b))) at t/t_timing_class.v:58
+-V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
+-V{t#,#}         No triggers active
+-V{t#,#}+    Vt_timing_debug2___024root___timing_commit
+-V{t#,#}End-of-eval cleanup
+-V{t#,#}+++++TOP Evaluate Vt_timing_debug2::eval_step
+-V{t#,#}+    Vt_timing_debug2___024root___eval_debug_assertions
+-V{t#,#}MTask0 starting
+-V{t#,#}+ Eval
+-V{t#,#}+    Vt_timing_debug2___024root___eval
+-V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
+-V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
+-V{t#,#}           - Process waiting at t/t_timing_class.v:58
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:58
+-V{t#,#}         Suspending process waiting for @([true] ((32'sh4 == t::WaitClass.a) & (32'sh10 < t::WaitClass.b))) at t/t_timing_class.v:58
+-V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
+-V{t#,#}         'act' region trigger index 1 is active: @([true] __VdlySched.awaitingCurrentTime())
+-V{t#,#}+    Vt_timing_debug2___024root___timing_commit
+-V{t#,#}+    Vt_timing_debug2___024root___timing_resume
+-V{t#,#}         Delayed processes:
+-V{t#,#}             Awaiting time 55: Process waiting at t/t_timing_class.v:131
+-V{t#,#}             Awaiting time 70: Process waiting at t/t_timing_class.v:175
+-V{t#,#}             Awaiting time 60: Process waiting at t/t_timing_class.v:123
+-V{t#,#}             Awaiting time 80: Process waiting at t/t_timing_class.v:136
+-V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:274
+-V{t#,#}             Awaiting time 70: Process waiting at t/t_timing_class.v:238
 -V{t#,#}         Resuming delayed processes
 -V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:131
+-V{t#,#}+        Vt_timing_debug2_t__03a__03aClkClass::__VnoInFunc_flip
+-V{t#,#}+    Vt_timing_debug2___024root___eval_act
+-V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
+-V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
+-V{t#,#}           - Process waiting at t/t_timing_class.v:58
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:58
+-V{t#,#}         Suspending process waiting for @([true] ((32'sh4 == t::WaitClass.a) & (32'sh10 < t::WaitClass.b))) at t/t_timing_class.v:58
+-V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
+-V{t#,#}         No triggers active
+-V{t#,#}+    Vt_timing_debug2___024root___timing_commit
+-V{t#,#}+    Vt_timing_debug2___024root___eval_nba
+-V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
+-V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
+-V{t#,#}           - Process waiting at t/t_timing_class.v:58
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:58
+-V{t#,#}         Suspending process waiting for @([true] ((32'sh4 == t::WaitClass.a) & (32'sh10 < t::WaitClass.b))) at t/t_timing_class.v:58
+-V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
+-V{t#,#}         No triggers active
+-V{t#,#}+    Vt_timing_debug2___024root___timing_commit
+-V{t#,#}End-of-eval cleanup
+-V{t#,#}+++++TOP Evaluate Vt_timing_debug2::eval_step
+-V{t#,#}+    Vt_timing_debug2___024root___eval_debug_assertions
+-V{t#,#}MTask0 starting
+-V{t#,#}+ Eval
+-V{t#,#}+    Vt_timing_debug2___024root___eval
+-V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
+-V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
+-V{t#,#}           - Process waiting at t/t_timing_class.v:58
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:58
+-V{t#,#}         Suspending process waiting for @([true] ((32'sh4 == t::WaitClass.a) & (32'sh10 < t::WaitClass.b))) at t/t_timing_class.v:58
+-V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
+-V{t#,#}         'act' region trigger index 1 is active: @([true] __VdlySched.awaitingCurrentTime())
+-V{t#,#}+    Vt_timing_debug2___024root___timing_commit
+-V{t#,#}+    Vt_timing_debug2___024root___timing_resume
+-V{t#,#}         Delayed processes:
+-V{t#,#}             Awaiting time 60: Process waiting at t/t_timing_class.v:123
+-V{t#,#}             Awaiting time 70: Process waiting at t/t_timing_class.v:175
+-V{t#,#}             Awaiting time 60: Process waiting at t/t_timing_class.v:131
+-V{t#,#}             Awaiting time 80: Process waiting at t/t_timing_class.v:136
+-V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:274
+-V{t#,#}             Awaiting time 70: Process waiting at t/t_timing_class.v:238
+-V{t#,#}         Resuming delayed processes
 -V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:123
--V{t#,#}+        Vt_timing_debug2_t__03a__03aClkClass::__VnoInFunc_flip
--V{t#,#}+    Vt_timing_debug2___024root___eval_act
--V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
--V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
--V{t#,#}           - Process waiting at t/t_timing_class.v:58
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:58
--V{t#,#}         Suspending process waiting for @([true] ((32'sh4 == t::WaitClass.a) & (32'sh10 < t::WaitClass.b))) at t/t_timing_class.v:58
--V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
--V{t#,#}         No triggers active
--V{t#,#}+    Vt_timing_debug2___024root___timing_commit
--V{t#,#}+    Vt_timing_debug2___024root___eval_nba
--V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
--V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
--V{t#,#}           - Process waiting at t/t_timing_class.v:58
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:58
--V{t#,#}         Suspending process waiting for @([true] ((32'sh4 == t::WaitClass.a) & (32'sh10 < t::WaitClass.b))) at t/t_timing_class.v:58
--V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
--V{t#,#}         No triggers active
--V{t#,#}+    Vt_timing_debug2___024root___timing_commit
--V{t#,#}End-of-eval cleanup
--V{t#,#}+++++TOP Evaluate Vt_timing_debug2::eval_step
--V{t#,#}+    Vt_timing_debug2___024root___eval_debug_assertions
--V{t#,#}MTask0 starting
--V{t#,#}+ Eval
--V{t#,#}+    Vt_timing_debug2___024root___eval
--V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
--V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
--V{t#,#}           - Process waiting at t/t_timing_class.v:58
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:58
--V{t#,#}         Suspending process waiting for @([true] ((32'sh4 == t::WaitClass.a) & (32'sh10 < t::WaitClass.b))) at t/t_timing_class.v:58
--V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 1 is active: @([true] __VdlySched.awaitingCurrentTime())
--V{t#,#}+    Vt_timing_debug2___024root___timing_commit
--V{t#,#}+    Vt_timing_debug2___024root___timing_resume
--V{t#,#}         Delayed processes:
--V{t#,#}             Awaiting time 55: Process waiting at t/t_timing_class.v:119
--V{t#,#}             Awaiting time 70: Process waiting at t/t_timing_class.v:120
--V{t#,#}             Awaiting time 60: Process waiting at t/t_timing_class.v:122
--V{t#,#}             Awaiting time 80: Process waiting at t/t_timing_class.v:136
--V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:173
--V{t#,#}             Awaiting time 70: Process waiting at t/t_timing_class.v:131
--V{t#,#}         Resuming delayed processes
 -V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:131
--V{t#,#}+        Vt_timing_debug2_t__03a__03aClkClass::__VnoInFunc_flip
--V{t#,#}+    Vt_timing_debug2___024root___eval_act
--V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
--V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
--V{t#,#}           - Process waiting at t/t_timing_class.v:58
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:58
--V{t#,#}         Suspending process waiting for @([true] ((32'sh4 == t::WaitClass.a) & (32'sh10 < t::WaitClass.b))) at t/t_timing_class.v:58
--V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
--V{t#,#}         No triggers active
--V{t#,#}+    Vt_timing_debug2___024root___timing_commit
--V{t#,#}+    Vt_timing_debug2___024root___eval_nba
--V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
--V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
--V{t#,#}           - Process waiting at t/t_timing_class.v:58
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:58
--V{t#,#}         Suspending process waiting for @([true] ((32'sh4 == t::WaitClass.a) & (32'sh10 < t::WaitClass.b))) at t/t_timing_class.v:58
--V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
--V{t#,#}         No triggers active
--V{t#,#}+    Vt_timing_debug2___024root___timing_commit
--V{t#,#}End-of-eval cleanup
--V{t#,#}+++++TOP Evaluate Vt_timing_debug2::eval_step
--V{t#,#}+    Vt_timing_debug2___024root___eval_debug_assertions
--V{t#,#}MTask0 starting
--V{t#,#}+ Eval
--V{t#,#}+    Vt_timing_debug2___024root___eval
--V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
--V{t#,#}         Suspended processes waiting for dynamic trigger evaluation:
--V{t#,#}           - Process waiting at t/t_timing_class.v:58
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:58
--V{t#,#}         Suspending process waiting for @([true] ((32'sh4 == t::WaitClass.a) & (32'sh10 < t::WaitClass.b))) at t/t_timing_class.v:58
--V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 1 is active: @([true] __VdlySched.awaitingCurrentTime())
--V{t#,#}+    Vt_timing_debug2___024root___timing_commit
--V{t#,#}+    Vt_timing_debug2___024root___timing_resume
--V{t#,#}         Delayed processes:
--V{t#,#}             Awaiting time 60: Process waiting at t/t_timing_class.v:119
--V{t#,#}             Awaiting time 70: Process waiting at t/t_timing_class.v:120
--V{t#,#}             Awaiting time 60: Process waiting at t/t_timing_class.v:122
--V{t#,#}             Awaiting time 80: Process waiting at t/t_timing_class.v:136
--V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:173
--V{t#,#}             Awaiting time 70: Process waiting at t/t_timing_class.v:131
--V{t#,#}         Resuming delayed processes
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:131
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:173
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aClkClass::__VnoInFunc_flip
 -V{t#,#}+    Vt_timing_debug2___024root___eval_act
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
@@ -930,14 +930,14 @@
 -V{t#,#}+    Vt_timing_debug2___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug2___024root___timing_resume
 -V{t#,#}         Delayed processes:
--V{t#,#}             Awaiting time 65: Process waiting at t/t_timing_class.v:119
--V{t#,#}             Awaiting time 70: Process waiting at t/t_timing_class.v:120
--V{t#,#}             Awaiting time 70: Process waiting at t/t_timing_class.v:122
+-V{t#,#}             Awaiting time 65: Process waiting at t/t_timing_class.v:131
+-V{t#,#}             Awaiting time 70: Process waiting at t/t_timing_class.v:238
+-V{t#,#}             Awaiting time 70: Process waiting at t/t_timing_class.v:76
 -V{t#,#}             Awaiting time 80: Process waiting at t/t_timing_class.v:136
--V{t#,#}             Awaiting time 70: Process waiting at t/t_timing_class.v:131
--V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:76
+-V{t#,#}             Awaiting time 70: Process waiting at t/t_timing_class.v:175
+-V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:274
 -V{t#,#}         Resuming delayed processes
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:76
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:131
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aClkClass::__VnoInFunc_flip
 -V{t#,#}+    Vt_timing_debug2___024root___eval_act
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
@@ -973,23 +973,23 @@
 -V{t#,#}+    Vt_timing_debug2___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug2___024root___timing_resume
 -V{t#,#}         Delayed processes:
--V{t#,#}             Awaiting time 70: Process waiting at t/t_timing_class.v:119
--V{t#,#}             Awaiting time 70: Process waiting at t/t_timing_class.v:120
--V{t#,#}             Awaiting time 70: Process waiting at t/t_timing_class.v:122
--V{t#,#}             Awaiting time 80: Process waiting at t/t_timing_class.v:136
+-V{t#,#}             Awaiting time 70: Process waiting at t/t_timing_class.v:76
+-V{t#,#}             Awaiting time 70: Process waiting at t/t_timing_class.v:238
 -V{t#,#}             Awaiting time 70: Process waiting at t/t_timing_class.v:131
--V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:131
+-V{t#,#}             Awaiting time 80: Process waiting at t/t_timing_class.v:136
+-V{t#,#}             Awaiting time 70: Process waiting at t/t_timing_class.v:175
+-V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:274
 -V{t#,#}         Resuming delayed processes
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:131
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:76
 -V{t#,#}             Process forked at t/t_timing_class.v:76 finished
 -V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:131
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aClkClass::__VnoInFunc_flip
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:131
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:238
 -V{t#,#}             Process forked at t/t_timing_class.v:256 finished
--V{t#,#}             Resuming: Process waiting at (null):0
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:250
 -V{t#,#}             Process forked at t/t_timing_class.v:250 finished
--V{t#,#}             Resuming: Process waiting at (null):0
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:136
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:245
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:175
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aDelay40::__VnoInFunc_do_sth_else
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aNoDelay::__VnoInFunc_do_delay
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aNoDelay::__VnoInFunc_do_sth_else
@@ -1009,7 +1009,7 @@
 -V{t#,#}           - Process waiting at t/t_timing_class.v:75
 -V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:75
 -V{t#,#}             Process forked at t/t_timing_class.v:75 finished
--V{t#,#}             Resuming: Process waiting at (null):0
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:74
 -V{t#,#}+    Vt_timing_debug2___024root___eval_act
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
 -V{t#,#}         No suspended processes waiting for dynamic trigger evaluation
@@ -1037,15 +1037,15 @@
 -V{t#,#}+    Vt_timing_debug2___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug2___024root___timing_resume
 -V{t#,#}         Delayed processes:
--V{t#,#}             Awaiting time 75: Process waiting at t/t_timing_class.v:119
--V{t#,#}             Awaiting time 75: Process waiting at t/t_timing_class.v:120
--V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:122
--V{t#,#}             Awaiting time 80: Process waiting at t/t_timing_class.v:224
+-V{t#,#}             Awaiting time 75: Process waiting at t/t_timing_class.v:131
+-V{t#,#}             Awaiting time 75: Process waiting at t/t_timing_class.v:224
+-V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:274
+-V{t#,#}             Awaiting time 80: Process waiting at t/t_timing_class.v:136
 -V{t#,#}             Awaiting time 80: Process waiting at t/t_timing_class.v:190
 -V{t#,#}         Resuming delayed processes
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:190
--V{t#,#}+        Vt_timing_debug2_t__03a__03aClkClass::__VnoInFunc_flip
 -V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:131
+-V{t#,#}+        Vt_timing_debug2_t__03a__03aClkClass::__VnoInFunc_flip
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:224
 -V{t#,#}+    Vt_timing_debug2___024root___eval_act
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
 -V{t#,#}         No suspended processes waiting for dynamic trigger evaluation
@@ -1071,16 +1071,16 @@
 -V{t#,#}+    Vt_timing_debug2___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug2___024root___timing_resume
 -V{t#,#}         Delayed processes:
--V{t#,#}             Awaiting time 80: Process waiting at t/t_timing_class.v:119
--V{t#,#}             Awaiting time 80: Process waiting at t/t_timing_class.v:120
--V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:122
--V{t#,#}             Awaiting time 80: Process waiting at t/t_timing_class.v:224
+-V{t#,#}             Awaiting time 80: Process waiting at t/t_timing_class.v:136
+-V{t#,#}             Awaiting time 80: Process waiting at t/t_timing_class.v:190
+-V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:274
+-V{t#,#}             Awaiting time 80: Process waiting at t/t_timing_class.v:131
 -V{t#,#}         Resuming delayed processes
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:224
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:122
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:136
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:190
 -V{t#,#}+      Vt_timing_debug2_t____Vfork_2__0
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aAssignDelayClass::__VnoInFunc_do_assign
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:230
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:131
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aClkClass::__VnoInFunc_flip
 -V{t#,#}+    Vt_timing_debug2___024root___eval_act
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
@@ -1107,13 +1107,13 @@
 -V{t#,#}+    Vt_timing_debug2___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug2___024root___timing_resume
 -V{t#,#}         Delayed processes:
--V{t#,#}             Awaiting time 85: Process waiting at t/t_timing_class.v:119
--V{t#,#}             Awaiting time 85: Process waiting at t/t_timing_class.v:120
+-V{t#,#}             Awaiting time 85: Process waiting at t/t_timing_class.v:230
+-V{t#,#}             Awaiting time 85: Process waiting at t/t_timing_class.v:131
 -V{t#,#}             Awaiting time 90: Process waiting at t/t_timing_class.v:190
--V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:131
+-V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:274
 -V{t#,#}         Resuming delayed processes
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:230
 -V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:131
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:231
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aClkClass::__VnoInFunc_flip
 -V{t#,#}+    Vt_timing_debug2___024root___eval_act
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
@@ -1140,13 +1140,13 @@
 -V{t#,#}+    Vt_timing_debug2___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug2___024root___timing_resume
 -V{t#,#}         Delayed processes:
--V{t#,#}             Awaiting time 90: Process waiting at t/t_timing_class.v:119
--V{t#,#}             Awaiting time 90: Process waiting at t/t_timing_class.v:120
--V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:190
--V{t#,#}             Awaiting time 100: Process waiting at t/t_timing_class.v:131
+-V{t#,#}             Awaiting time 90: Process waiting at t/t_timing_class.v:190
+-V{t#,#}             Awaiting time 90: Process waiting at t/t_timing_class.v:131
+-V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:274
+-V{t#,#}             Awaiting time 100: Process waiting at t/t_timing_class.v:231
 -V{t#,#}         Resuming delayed processes
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:131
 -V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:190
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:131
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aClkClass::__VnoInFunc_flip
 -V{t#,#}+    Vt_timing_debug2___024root___eval_act
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act
@@ -1174,9 +1174,9 @@
 -V{t#,#}+    Vt_timing_debug2___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug2___024root___timing_resume
 -V{t#,#}         Delayed processes:
--V{t#,#}             Awaiting time 95: Process waiting at t/t_timing_class.v:119
--V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:120
--V{t#,#}             Awaiting time 100: Process waiting at t/t_timing_class.v:131
+-V{t#,#}             Awaiting time 95: Process waiting at t/t_timing_class.v:131
+-V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:274
+-V{t#,#}             Awaiting time 100: Process waiting at t/t_timing_class.v:231
 -V{t#,#}         Resuming delayed processes
 -V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:131
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aClkClass::__VnoInFunc_flip
@@ -1205,13 +1205,13 @@
 -V{t#,#}+    Vt_timing_debug2___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug2___024root___timing_resume
 -V{t#,#}         Delayed processes:
--V{t#,#}             Awaiting time 100: Process waiting at t/t_timing_class.v:119
--V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:120
+-V{t#,#}             Awaiting time 100: Process waiting at t/t_timing_class.v:231
+-V{t#,#}             Awaiting time 101: Process waiting at t/t_timing_class.v:274
 -V{t#,#}             Awaiting time 100: Process waiting at t/t_timing_class.v:131
 -V{t#,#}         Resuming delayed processes
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:131
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:231
 *-* All Finished *-*
--V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:120
+-V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:131
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aClkClass::__VnoInFunc_flip
 -V{t#,#}+    Vt_timing_debug2___024root___eval_act
 -V{t#,#}+    Vt_timing_debug2___024root___eval_triggers__act


### PR DESCRIPTION
VlCoroutineHandles have overloaded assignment operator that doesn't move fileline and process pointers.
That can lead to confusing logs and disturb process control through std::process.

This PR fixes that.
