### PR TITLE
Resolve parenthesesless calls to static methods

### DIFF
--- a/src/V3LinkDot.cpp
+++ b/src/V3LinkDot.cpp
@@ -2555,13 +2555,15 @@ private:
             string expectWhat;
             bool allowScope = false;
             bool allowVar = false;
+            bool allowFTask = false;
             bool staticAccess = false;
             if (m_ds.m_dotPos == DP_PACKAGE) {
                 // {package}::{a}
                 AstNodeModule* classOrPackagep = nullptr;
-                expectWhat = "scope/variable";
+                expectWhat = "scope/variable/func";
                 allowScope = true;
                 allowVar = true;
+                allowFTask = true;
                 staticAccess = true;
                 UASSERT_OBJ(VN_IS(m_ds.m_dotp->lhsp(), ClassOrPackageRef), m_ds.m_dotp->lhsp(),
                             "Bad package link");
@@ -2642,6 +2644,14 @@ private:
                                                           << cellp->modp()->prettyNameQ());
                     }
                 }
+            } else if (allowFTask && VN_IS(foundp->nodep(), NodeFTask)) {
+                AstNodeFTask* const ftaskp = VN_AS(foundp->nodep(), NodeFTask);
+                AstTaskRef* const taskrefp =
+                    new AstTaskRef{nodep->fileline(),nodep->name(), nullptr};
+                nodep->replaceWith(taskrefp);
+                VL_DO_DANGLING(nodep->deleteTree(), nodep);
+                if (start) m_ds = lastStates;
+                return;
             } else if (AstVar* const varp = foundToVarp(foundp, nodep, VAccess::READ)) {
                 AstIfaceRefDType* const ifacerefp
                     = LinkDotState::ifaceRefFromArray(varp->subDTypep());

--- a/src/V3LinkDot.cpp
+++ b/src/V3LinkDot.cpp
@@ -2645,7 +2645,6 @@ private:
                     }
                 }
             } else if (allowFTask && VN_IS(foundp->nodep(), NodeFTask)) {
-                AstNodeFTask* const ftaskp = VN_AS(foundp->nodep(), NodeFTask);
                 AstTaskRef* const taskrefp
                     = new AstTaskRef{nodep->fileline(), nodep->name(), nullptr};
                 nodep->replaceWith(taskrefp);

--- a/src/V3LinkDot.cpp
+++ b/src/V3LinkDot.cpp
@@ -2646,8 +2646,8 @@ private:
                 }
             } else if (allowFTask && VN_IS(foundp->nodep(), NodeFTask)) {
                 AstNodeFTask* const ftaskp = VN_AS(foundp->nodep(), NodeFTask);
-                AstTaskRef* const taskrefp =
-                    new AstTaskRef{nodep->fileline(),nodep->name(), nullptr};
+                AstTaskRef* const taskrefp
+                    = new AstTaskRef{nodep->fileline(), nodep->name(), nullptr};
                 nodep->replaceWith(taskrefp);
                 VL_DO_DANGLING(nodep->deleteTree(), nodep);
                 if (start) m_ds = lastStates;

--- a/test_regress/t/t_package_export_bad.out
+++ b/test_regress/t/t_package_export_bad.out
@@ -1,27 +1,27 @@
 %Error: t/t_package_export.v:45:17: Export object not found: 'pkg1::BAD_DOES_NOT_EXIST'
    45 |    export pkg1::BAD_DOES_NOT_EXIST;
       |                 ^~~~~~~~~~~~~~~~~~
-%Error: t/t_package_export.v:60:16: Can't find definition of scope/variable: 'PARAM2'
+%Error: t/t_package_export.v:60:16: Can't find definition of scope/variable/func: 'PARAM2'
                                   : ... Suggested alternative: 'PARAM1'
    60 |    reg [pkg11::PARAM2 : 0] bus12;
       |                ^~~~~~
-%Error: t/t_package_export.v:61:16: Can't find definition of scope/variable: 'PARAM3'
+%Error: t/t_package_export.v:61:16: Can't find definition of scope/variable/func: 'PARAM3'
                                   : ... Suggested alternative: 'PARAM1'
    61 |    reg [pkg11::PARAM3 : 0] bus13;
       |                ^~~~~~
-%Error: t/t_package_export.v:64:16: Can't find definition of scope/variable: 'PARAM2'
+%Error: t/t_package_export.v:64:16: Can't find definition of scope/variable/func: 'PARAM2'
                                   : ... Suggested alternative: 'PARAM1'
    64 |    reg [pkg21::PARAM2 : 0] bus22;
       |                ^~~~~~
-%Error: t/t_package_export.v:65:16: Can't find definition of scope/variable: 'PARAM3'
+%Error: t/t_package_export.v:65:16: Can't find definition of scope/variable/func: 'PARAM3'
                                   : ... Suggested alternative: 'PARAM1'
    65 |    reg [pkg21::PARAM3 : 0] bus23;
       |                ^~~~~~
-%Error: t/t_package_export.v:68:16: Can't find definition of scope/variable: 'PARAM2'
+%Error: t/t_package_export.v:68:16: Can't find definition of scope/variable/func: 'PARAM2'
                                   : ... Suggested alternative: 'PARAM1'
    68 |    reg [pkg31::PARAM2 : 0] bus32;
       |                ^~~~~~
-%Error: t/t_package_export.v:69:16: Can't find definition of scope/variable: 'PARAM3'
+%Error: t/t_package_export.v:69:16: Can't find definition of scope/variable/func: 'PARAM3'
                                   : ... Suggested alternative: 'PARAM1'
    69 |    reg [pkg31::PARAM3 : 0] bus33;
       |                ^~~~~~

--- a/test_regress/t/t_static_function_in_class_call_without_parentheses.pl
+++ b/test_regress/t/t_static_function_in_class_call_without_parentheses.pl
@@ -1,0 +1,21 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2023 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_static_function_in_class_call_without_parentheses.v
+++ b/test_regress/t/t_static_function_in_class_call_without_parentheses.v
@@ -1,0 +1,31 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2023 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+class Foo;
+  static int m_v;
+
+  static function void set_v(int v);
+    m_v = v;
+  endfunction
+  static function int get_v();
+    // Let's see if referring to the implicit variable does not resolve into a call
+    get_v = m_v;
+  endfunction
+endclass
+
+module t();
+  initial begin
+    int v;
+
+    Foo::set_v(3);
+    // Check if a parenthesesless call to static method works
+    v = Foo::get_v;
+    if (v != 3) $stop;
+
+    $write("*-* All Finished *-*\n");
+    $finish;
+  end
+endmodule


### PR DESCRIPTION
Allows static methods that take no arguments to be called with no parentheses.