### PR TITLE
Add prepareClone and atClone APIs for Verilated models (#3503)

### DIFF
--- a/docs/guide/connecting.rst
+++ b/docs/guide/connecting.rst
@@ -128,6 +128,43 @@ in the distribution.  These headers use Doxygen comments, `///` and `//<`,
 to indicate and document those functions that are part of the Verilated
 public API.
 
+Process-Level Clone APIs
+--------------------------
+
+Modern operating systems support process-level clone (a.k.a copying, forking)
+with system call interfaces in C/C++, e.g., :code:`fork()` in Linux.
+
+However, after cloning a parent process, some resources cannot be inherited
+in the child process. For example, in POSIX systems, when you fork a process,
+the child process inherits all the memory of the parent process. However,
+only the thread that called fork is replicated in the child process. Other
+threads are not.
+
+Therefore, to support the process-level clone mechanisms, Verilator supports
+:code:`prepareClone()` and :code:`atClone()` APIs to allow the user to manually
+re-construct the model in the child process. The two APIs handle all necessary
+resources required for releasing and re-initializing before and after cloning.
+
+The two APIs are supported in the verilated models. Here is an example of usage
+with Linux :code:`fork()` and :code:`pthread_atfork` APIs:
+
+.. code-block:: C++
+
+    // static function pointers to fit pthread_atfork
+    static auto prepareClone = [](){ topp->prepareClone(); };
+    static auto atClone = [](){ topp->atClone(); };
+
+    // in main function, register the handlers:
+    pthread_atfork(prepareClone, atClone, atClone);
+
+For better flexibility, you can also manually call the handlers before and
+after :code:`fork()`.
+
+With the process-level clone APIs, users can create process-level snapshots
+for the verilated models. While the Verilator save/restore option provides
+persistent and circuit-independent snapshots, the process-level clone APIs
+enable in-memory, circuit-transparent, and highly efficient snapshots.
+
 
 Direct Programming Interface (DPI)
 ==================================

--- a/include/verilated.cpp
+++ b/include/verilated.cpp
@@ -2613,6 +2613,7 @@ void VerilatedContext::prepareClone() {
 }
 
 VerilatedVirtualBase* VerilatedContext::threadPoolpOnClone() {
+    if (VL_UNLIKELY(m_threadPool)) m_threadPool.release();
     m_threadPool = std::make_unique<VlThreadPool>(this, m_threads - 1);
     return m_threadPool.get();
 }

--- a/include/verilated.cpp
+++ b/include/verilated.cpp
@@ -2608,6 +2608,12 @@ VerilatedVirtualBase* VerilatedContext::threadPoolp() {
     return m_threadPool.get();
 }
 
+VerilatedVirtualBase* VerilatedContext::resetThreadPoolp() {
+    m_threadPool.release();
+    m_threadPool = std::make_unique<VlThreadPool>(this, m_threads - 1);
+    return m_threadPool.get();
+}
+
 VerilatedVirtualBase*
 VerilatedContext::enableExecutionProfiler(VerilatedVirtualBase* (*construct)(VerilatedContext&)) {
     if (!m_executionProfiler) m_executionProfiler.reset(construct(*this));

--- a/include/verilated.cpp
+++ b/include/verilated.cpp
@@ -2608,8 +2608,11 @@ VerilatedVirtualBase* VerilatedContext::threadPoolp() {
     return m_threadPool.get();
 }
 
-VerilatedVirtualBase* VerilatedContext::resetThreadPoolp() {
-    m_threadPool.release();
+void VerilatedContext::prepareClone() {
+    delete m_threadPool.release();
+}
+
+VerilatedVirtualBase* VerilatedContext::threadPoolpOnClone() {
     m_threadPool = std::make_unique<VlThreadPool>(this, m_threads - 1);
     return m_threadPool.get();
 }

--- a/include/verilated.h
+++ b/include/verilated.h
@@ -568,7 +568,8 @@ public:
     void addModel(VerilatedModel*);
 
     VerilatedVirtualBase* threadPoolp();
-    VerilatedVirtualBase* resetThreadPoolp();
+    void prepareClone();
+    VerilatedVirtualBase* threadPoolpOnClone();
     VerilatedVirtualBase*
     enableExecutionProfiler(VerilatedVirtualBase* (*construct)(VerilatedContext&));
 

--- a/include/verilated.h
+++ b/include/verilated.h
@@ -568,6 +568,7 @@ public:
     void addModel(VerilatedModel*);
 
     VerilatedVirtualBase* threadPoolp();
+    VerilatedVirtualBase* resetThreadPoolp();
     VerilatedVirtualBase*
     enableExecutionProfiler(VerilatedVirtualBase* (*construct)(VerilatedContext&));
 

--- a/src/V3EmitCModel.cpp
+++ b/src/V3EmitCModel.cpp
@@ -234,7 +234,11 @@ class EmitCModel final : public EmitCFunc {
         puts("const char* hierName() const override final;\n");
         puts("const char* modelName() const override final;\n");
         puts("unsigned threads() const override final;\n");
+        puts("/// Prepare for cloning the model at the process level (e.g. fork in Linux)\n");
+        puts("/// Release necessary resources. Called before cloning.\n");
         puts("void prepareClone() const;\n");
+        puts("/// Re-init after cloning the model at the process level (e.g. fork in Linux)\n");
+        puts("/// Re-allocate necessary resources. Called after cloning.\n");
         puts("void atClone() const;\n");
         if (v3Global.opt.trace()) {
             puts("std::unique_ptr<VerilatedTraceConfig> traceConfig() const override final;\n");
@@ -487,7 +491,7 @@ class EmitCModel final : public EmitCFunc {
             puts("vlSymsp->__Vm_threadPoolp = static_cast<VlThreadPool*>(");
         }
         puts("contextp()->threadPoolpOnClone()");
-        if (v3Global.opt.threads() > 1) { puts(")"); }
+        if (v3Global.opt.threads() > 1) puts(")");
         puts(";\n}\n");
 
         if (v3Global.opt.trace()) {

--- a/src/V3EmitCModel.cpp
+++ b/src/V3EmitCModel.cpp
@@ -234,7 +234,7 @@ class EmitCModel final : public EmitCFunc {
         puts("const char* hierName() const override final;\n");
         puts("const char* modelName() const override final;\n");
         puts("unsigned threads() const override final;\n");
-        puts("void at_clone() const;\n");
+        puts("void atClone() const;\n");
         if (v3Global.opt.trace()) {
             puts("std::unique_ptr<VerilatedTraceConfig> traceConfig() const override final;\n");
         }
@@ -480,7 +480,7 @@ class EmitCModel final : public EmitCFunc {
              + "\"; }\n");
         puts("unsigned " + topClassName() + "::threads() const { return "
              + cvtToStr(std::max(1, v3Global.opt.threads())) + "; }\n");
-        puts("void " + topClassName() + "::at_clone() const {\n");
+        puts("void " + topClassName() + "::atClone() const {\n");
         if (v3Global.opt.threads() > 1) {
             puts("vlSymsp->__Vm_threadPoolp = static_cast<VlThreadPool*>(");
         }

--- a/src/V3EmitCModel.cpp
+++ b/src/V3EmitCModel.cpp
@@ -234,6 +234,7 @@ class EmitCModel final : public EmitCFunc {
         puts("const char* hierName() const override final;\n");
         puts("const char* modelName() const override final;\n");
         puts("unsigned threads() const override final;\n");
+        puts("void at_clone() const;\n");
         if (v3Global.opt.trace()) {
             puts("std::unique_ptr<VerilatedTraceConfig> traceConfig() const override final;\n");
         }
@@ -479,6 +480,15 @@ class EmitCModel final : public EmitCFunc {
              + "\"; }\n");
         puts("unsigned " + topClassName() + "::threads() const { return "
              + cvtToStr(std::max(1, v3Global.opt.threads())) + "; }\n");
+        puts("void " + topClassName() + "::at_clone() const {\n");
+        if (v3Global.opt.threads() > 1) {
+            puts("vlSymsp->__Vm_threadPoolp = static_cast<VlThreadPool*>(");
+        }
+        puts("contextp()->resetThreadPoolp()");
+        if (v3Global.opt.threads() > 1) {
+            puts(")");
+        }
+        puts(";\n}\n");
 
         if (v3Global.opt.trace()) {
             puts("std::unique_ptr<VerilatedTraceConfig> " + topClassName()

--- a/src/V3EmitCModel.cpp
+++ b/src/V3EmitCModel.cpp
@@ -485,9 +485,7 @@ class EmitCModel final : public EmitCFunc {
             puts("vlSymsp->__Vm_threadPoolp = static_cast<VlThreadPool*>(");
         }
         puts("contextp()->resetThreadPoolp()");
-        if (v3Global.opt.threads() > 1) {
-            puts(")");
-        }
+        if (v3Global.opt.threads() > 1) { puts(")"); }
         puts(";\n}\n");
 
         if (v3Global.opt.trace()) {

--- a/src/V3EmitCModel.cpp
+++ b/src/V3EmitCModel.cpp
@@ -234,6 +234,7 @@ class EmitCModel final : public EmitCFunc {
         puts("const char* hierName() const override final;\n");
         puts("const char* modelName() const override final;\n");
         puts("unsigned threads() const override final;\n");
+        puts("void prepareClone() const;\n");
         puts("void atClone() const;\n");
         if (v3Global.opt.trace()) {
             puts("std::unique_ptr<VerilatedTraceConfig> traceConfig() const override final;\n");
@@ -480,11 +481,12 @@ class EmitCModel final : public EmitCFunc {
              + "\"; }\n");
         puts("unsigned " + topClassName() + "::threads() const { return "
              + cvtToStr(std::max(1, v3Global.opt.threads())) + "; }\n");
+        puts("void " + topClassName() + "::prepareClone() const { contextp()->prepareClone(); }\n");
         puts("void " + topClassName() + "::atClone() const {\n");
         if (v3Global.opt.threads() > 1) {
             puts("vlSymsp->__Vm_threadPoolp = static_cast<VlThreadPool*>(");
         }
-        puts("contextp()->resetThreadPoolp()");
+        puts("contextp()->threadPoolpOnClone()");
         if (v3Global.opt.threads() > 1) { puts(")"); }
         puts(";\n}\n");
 

--- a/src/V3EmitCSyms.cpp
+++ b/src/V3EmitCSyms.cpp
@@ -468,7 +468,7 @@ void EmitCSyms::emitSymHdr() {
 
     if (v3Global.opt.mtasks()) {
         puts("\n// MULTI-THREADING\n");
-        puts("VlThreadPool* const __Vm_threadPoolp;\n");
+        puts("VlThreadPool* __Vm_threadPoolp;\n");
         puts("bool __Vm_even_cycle__ico = false;\n");
         puts("bool __Vm_even_cycle__act = false;\n");
         puts("bool __Vm_even_cycle__nba = false;\n");

--- a/test_regress/t/t_flag_csplit.pl
+++ b/test_regress/t/t_flag_csplit.pl
@@ -97,6 +97,7 @@ sub check_cpp {
                 && $func !~ /::traceInit$/
                 && $func !~ /::traceFull$/
                 && $func !~ /::final$/
+                && $func !~ /::atClone$/
                 ) {
                 push @funcs, $func;
             }

--- a/test_regress/t/t_flag_csplit.pl
+++ b/test_regress/t/t_flag_csplit.pl
@@ -97,6 +97,7 @@ sub check_cpp {
                 && $func !~ /::traceInit$/
                 && $func !~ /::traceFull$/
                 && $func !~ /::final$/
+                && $func !~ /::prepareClone$/
                 && $func !~ /::atClone$/
                 ) {
                 push @funcs, $func;

--- a/test_regress/t/t_wrapper_clone.cpp
+++ b/test_regress/t/t_wrapper_clone.cpp
@@ -1,0 +1,67 @@
+//
+// DESCRIPTION: Verilator: Verilog Test module for the atClone API
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2020-2021 by Andreas Kuster.
+// SPDX-License-Identifier: CC0-1.0
+//
+
+#include <verilated.h>
+
+#include <unistd.h>
+#include <sys/wait.h>
+
+// These require the above. Comment prevents clang-format moving them
+#include "TestCheck.h"
+
+#include VM_PREFIX_INCLUDE
+
+// Check we properly define the version integer
+#if VERILATOR_VERSION_INTEGER < 5015000  // Added in 5.015
+#error "VERILATOR_VERSION_INTEGER not set"
+#endif
+
+double sc_time_stamp() { return 0; }
+
+void single_cycle(VM_PREFIX* top) {
+    top->clock = 1;
+    top->eval();
+
+    top->clock = 0;
+    top->eval();
+}
+
+
+int main(int argc, char** argv) {
+    std::unique_ptr<VerilatedContext> contextp{new VerilatedContext};
+    std::unique_ptr<VM_PREFIX> top{new VM_PREFIX{contextp.get()}};
+
+    top->reset = 1;
+    top->is_parent = 0;
+    for (int i = 0; i < 5; i++) {
+        single_cycle(top.get());
+    }
+
+    top->reset = 0;
+    while (!contextp->gotFinish()) {
+        single_cycle(top.get());
+
+        if (top->do_clone) {
+            int pid = fork();
+            if (pid < 0) {
+                printf("fork failed\n");
+            }
+            else if (pid == 0) {
+                printf("child: here we go\n");
+                top->atClone();
+            }
+            else {
+                while (wait(NULL) > 0);
+                printf("parent: here we go\n");
+                top->is_parent = 1;
+            }
+        }
+    }
+
+    return 0;
+}

--- a/test_regress/t/t_wrapper_clone.cpp
+++ b/test_regress/t/t_wrapper_clone.cpp
@@ -9,6 +9,7 @@
 #include <verilated.h>
 
 #include <unistd.h>
+
 #include <sys/wait.h>
 
 // These require the above. Comment prevents clang-format moving them
@@ -31,16 +32,13 @@ void single_cycle(VM_PREFIX* top) {
     top->eval();
 }
 
-
 int main(int argc, char** argv) {
     std::unique_ptr<VerilatedContext> contextp{new VerilatedContext};
     std::unique_ptr<VM_PREFIX> top{new VM_PREFIX{contextp.get()}};
 
     top->reset = 1;
     top->is_parent = 0;
-    for (int i = 0; i < 5; i++) {
-        single_cycle(top.get());
-    }
+    for (int i = 0; i < 5; i++) { single_cycle(top.get()); }
 
     top->reset = 0;
     while (!contextp->gotFinish()) {
@@ -50,13 +48,12 @@ int main(int argc, char** argv) {
             int pid = fork();
             if (pid < 0) {
                 printf("fork failed\n");
-            }
-            else if (pid == 0) {
+            } else if (pid == 0) {
                 printf("child: here we go\n");
                 top->atClone();
-            }
-            else {
-                while (wait(NULL) > 0);
+            } else {
+                while (wait(NULL) > 0)
+                    ;
                 printf("parent: here we go\n");
                 top->is_parent = 1;
             }

--- a/test_regress/t/t_wrapper_clone.cpp
+++ b/test_regress/t/t_wrapper_clone.cpp
@@ -1,10 +1,9 @@
 //
 // DESCRIPTION: Verilator: Verilog Test module for the atClone API
 //
-// This file ONLY is placed under the Creative Commons Public Domain, for
-// any use, without warranty, 2020-2021 by Andreas Kuster.
+// This file ONLY is placed into the Public Domain, for any use,
+// without warranty, 2023 by Yinan Xu.
 // SPDX-License-Identifier: CC0-1.0
-//
 
 #include <verilated.h>
 

--- a/test_regress/t/t_wrapper_clone.out
+++ b/test_regress/t/t_wrapper_clone.out
@@ -1,0 +1,15 @@
+counter =  0
+counter =  1
+counter =  2
+counter =  3
+counter =  4
+counter =  5
+child: here we go
+counter =  6
+counter =  7
+counter =  8
+parent: here we go
+counter =  6
+counter =  7
+counter =  8
+*-* All Finished *-*

--- a/test_regress/t/t_wrapper_clone.pl
+++ b/test_regress/t/t_wrapper_clone.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 if (!$::Driver) { use strict; use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
-# DESCRIPTION: Verilator: Verilog Multiple Model Test Module
+# DESCRIPTION: Verilator: Verilog Test module for the atClone API
 #
 # This file ONLY is placed into the Public Domain, for any use,
 # without warranty, 2023 by Yinan Xu.

--- a/test_regress/t/t_wrapper_clone.pl
+++ b/test_regress/t/t_wrapper_clone.pl
@@ -2,11 +2,9 @@
 if (!$::Driver) { use strict; use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
 # DESCRIPTION: Verilator: Verilog Multiple Model Test Module
 #
-# Copyright 2020-2021 by Andreas Kuster. This program is free software; you
-# can redistribute it and/or modify it under the terms of either the GNU
-# Lesser General Public License Version 3 or the Perl Artistic License
-# Version 2.0.
-# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+# This file ONLY is placed into the Public Domain, for any use,
+# without warranty, 2023 by Yinan Xu.
+# SPDX-License-Identifier: CC0-1.0
 
 scenarios(vlt_all => 1);
 

--- a/test_regress/t/t_wrapper_clone.pl
+++ b/test_regress/t/t_wrapper_clone.pl
@@ -1,0 +1,28 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use strict; use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Multiple Model Test Module
+#
+# Copyright 2020-2021 by Andreas Kuster. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(vlt_all => 1);
+
+compile(
+    make_top_shell => 0,
+    make_main => 0,
+    # link threads library, add custom .cpp code, add tracing & coverage support
+    verilator_flags2 => ["--exe $Self->{t_dir}/$Self->{name}.cpp",
+                         "-cc"],
+    threads => 1,
+    );
+
+execute(
+    check_finished => 1,
+    expect_filename => $Self->{golden_filename},
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_wrapper_clone.pl
+++ b/test_regress/t/t_wrapper_clone.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 if (!$::Driver) { use strict; use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
-# DESCRIPTION: Verilator: Verilog Test module for the atClone API
+# DESCRIPTION: Verilator: Verilog Test module for prepareClone/atClone APIs
 #
 # This file ONLY is placed into the Public Domain, for any use,
 # without warranty, 2023 by Yinan Xu.
@@ -11,10 +11,9 @@ scenarios(vlt_all => 1);
 compile(
     make_top_shell => 0,
     make_main => 0,
-    # link threads library, add custom .cpp code, add tracing & coverage support
     verilator_flags2 => ["--exe $Self->{t_dir}/$Self->{name}.cpp",
                          "-cc"],
-    threads => 1,
+    threads => $Self->{vltmt} ? 2 : 1,
     );
 
 execute(

--- a/test_regress/t/t_wrapper_clone.v
+++ b/test_regress/t/t_wrapper_clone.v
@@ -1,0 +1,40 @@
+// DESCRIPTION: Verilator: Verilog Test module for the atClone API
+//
+// This model counts from 0 to 8. It forks a child process (in C++) at 6
+// and waits for the child to simulate and exit for resumption (of the parent).
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2020-2021 by Andreas Kuster.
+// SPDX-License-Identifier: CC0-1.0
+
+module top(
+  input clock,
+  input reset,
+  input is_parent,
+  output do_clone
+);
+
+reg [3:0] counter;
+
+assign do_clone = counter == 4'h6;
+
+always @(posedge clock) begin
+  if (reset)
+    counter <= 4'h0;
+  else begin
+    counter <= counter + 4'h1;
+    $write("counter = %d\n", counter);
+    $fflush();
+  end
+
+  if (counter[3]) begin
+    if (is_parent) begin
+      $write("*-* All Finished *-*\n");
+      $fflush();
+    end
+    $finish(0);
+  end
+end
+
+
+endmodule

--- a/test_regress/t/t_wrapper_clone.v
+++ b/test_regress/t/t_wrapper_clone.v
@@ -1,4 +1,4 @@
-// DESCRIPTION: Verilator: Verilog Test module for the atClone API
+// DESCRIPTION: Verilator: Verilog Test module for prepareClone/atClone APIs
 //
 // This model counts from 0 to 8. It forks a child process (in C++) at 6
 // and waits for the child to simulate and exit for resumption (of the parent).
@@ -19,22 +19,20 @@ reg [3:0] counter;
 assign do_clone = counter == 4'h6;
 
 always @(posedge clock) begin
-  if (reset)
+  if (reset) begin
     counter <= 4'h0;
+  end
   else begin
     counter <= counter + 4'h1;
     $write("counter = %d\n", counter);
-    $fflush();
   end
 
   if (counter[3]) begin
     if (is_parent) begin
       $write("*-* All Finished *-*\n");
-      $fflush();
     end
     $finish(0);
   end
 end
-
 
 endmodule

--- a/test_regress/t/t_wrapper_clone.v
+++ b/test_regress/t/t_wrapper_clone.v
@@ -3,8 +3,8 @@
 // This model counts from 0 to 8. It forks a child process (in C++) at 6
 // and waits for the child to simulate and exit for resumption (of the parent).
 //
-// This file ONLY is placed under the Creative Commons Public Domain, for
-// any use, without warranty, 2020-2021 by Andreas Kuster.
+// This file ONLY is placed into the Public Domain, for any use,
+// without warranty, 2023 by Yinan Xu.
 // SPDX-License-Identifier: CC0-1.0
 
 module top(


### PR DESCRIPTION
This PR is to fix issue #3503. Since I'm not receiving information on other resources that are required to be re-allocated at clone, I assume the thread pool is the only thing.

This commit adds the `at_clone` member function for all verilated models to allow the user to manually clone the models without knowing about the model details.

This API would be helpful if the user copies the process using `fork` and similar OS-level mechanisms. The `at_clone` member function ensures that all model-allocated resources are re-allocated, such that the copied child process/model can simulate correctly.

A typical allocated resource is the thread pool, which every model has its own pool.

We appreciate your contributing to Verilator.  If this is your first commit, please add your name to docs/CONTRIBUTORS, and read our contributing guidelines in docs/CONTRIBUTING.rst.

**TODO**: I don't know how to add a CI testcase. I've upload my `clone.v` and `main.cpp` as the cases. The commands should be `verilator --cc --exe --build clone.v main.cpp` and `verilator --cc --exe --build clone.v main.cpp --threads 2`. Both single-thread and multi-thread models should be tested. Could you please help me on how I can add the test cases? I've uploaded them as attachments. Their outputs should be the same as follows. The `at_clone` should be a cross-platform feature though I'm using the `fork` example for test only.

[testcase.tar.gz](https://github.com/verilator/verilator/files/12448161/testcase.tar.gz)

```
counter =  0
counter =  1
counter =  2
counter =  3
counter =  4
counter =  5
parent: let's wait for the child
child: here we go
counter =  6
counter =  7
counter =  8
- clone.v:20: Verilog $finish
parent: here we go
counter =  6
counter =  7
counter =  8
- clone.v:20: Verilog $finish
```

BTW, when modifying the `__Vm_threadPoolp`, I noticed that it is commented with `TODO -- For now each model creates its own ThreadPool here, and deletes it in the destructor. ` However, I don't see the destructor deleting it. The destructor is empty at all. Plus, if I don't re-assign the `__Vm_threadPoolp` for multi-threaded models, the child process still simulates correctly, though I doubt this is the same as the older version I was trying earlier. So, I'm wondering whether I'm doing the correct thing for this `__Vm_threadPoolp` and whether it is expected to be updated.

If there is any issue, please let me know and I'll try to fix it.
