### PR TITLE
Fix unstable output of VHashSha256 (#4452)

### DIFF
--- a/src/V3String.cpp
+++ b/src/V3String.cpp
@@ -237,9 +237,8 @@ static void sha256Block(uint32_t* h, const uint32_t* chunk) VL_PURE {
     // Initialize working variables to current hash value
     for (unsigned i = 0; i < 8; i++) ah[i] = h[i];
     // Compression function main loop
+    uint32_t w[16] = {};
     for (unsigned i = 0; i < 4; ++i) {
-        uint32_t w[16];
-
         for (unsigned j = 0; j < 16; ++j) {
             if (i == 0) {
                 w[j] = *p++;


### PR DESCRIPTION
`VHashSha256` generates unstable hashes on some platforms and build setting (#4452). The cause of it is that the hasher reuse a variable inside the curly brackets of a for-loop, but the value of it is not guaranteed to be stable between iterations. This patch now fixes it.