### PR TITLE
Tests: Check the output in t_class_method_str_literal

### DIFF
--- a/test_regress/t/t_class_method_str_literal.v
+++ b/test_regress/t/t_class_method_str_literal.v
@@ -7,21 +7,21 @@
 module t;
 
 class T;
-    function automatic void print_str(input string a_string);
-        $display(a_string);
+    function automatic string return_str(input string a_string);
+       return a_string;
     endfunction
 
-    static function automatic void static_print_str(input string a_string);
-        $display(a_string);
+    static function automatic string static_return_str(input string a_string);
+        return a_string;
     endfunction
 endclass
 
 
 initial begin
     T t_c = new;
-    t_c.print_str("function though member");
-    t_c.static_print_str("static function through member");
-    T::static_print_str("static function through class");
+    if (t_c.return_str("A") != "A") $stop;
+    if (t_c.static_return_str("B") != "B") $stop;
+    if (T::static_return_str("C") != "C") $stop;
     $write("*-* All Finished *-*\n");
     $finish;
 end


### PR DESCRIPTION
The output of these methods isn't checked. I added missing checks. I think that it meant to test string literals, not the `$display` method. If the `$display` methods are important, I will add an .out file.
