### PR TITLE
Internals: Remove unused constructor. No functional change.

### DIFF
--- a/src/V3AstNodeExpr.h
+++ b/src/V3AstNodeExpr.h
@@ -585,15 +585,6 @@ class AstCMethodHard final : public AstNodeExpr {
     string m_name;  // Name of method
     bool m_pure = false;  // Pure optimizable
 public:
-    AstCMethodHard(FileLine* fl, AstNodeExpr* fromp, VFlagChildDType, const string& name,
-                   AstNodeExpr* pinsp = nullptr)
-        : ASTGEN_SUPER_CMethodHard(fl)
-        , m_name{name} {
-        // TODO: this constructor is exactly the same as the other, bar the ignored tag argument
-        this->fromp(fromp);
-        this->addPinsp(pinsp);
-        dtypep(nullptr);  // V3Width will resolve
-    }
     AstCMethodHard(FileLine* fl, AstNodeExpr* fromp, const string& name,
                    AstNodeExpr* pinsp = nullptr)
         : ASTGEN_SUPER_CMethodHard(fl)


### PR DESCRIPTION
This constructor is unused and as the comment says, it is exactly the same as the other. I think we can remove it. I think we won't need it in the future, because this node is used to represent calls to cpp methods and we need to know the dtype of `fromp` node to know to which cpp object it will be translated.