### PR TITLE
Internals: Move `dpiTemporaryVarSuffix()` to header. No functional change.

### DIFF
--- a/src/V3Task.cpp
+++ b/src/V3Task.cpp
@@ -1554,6 +1554,8 @@ public:
 //######################################################################
 // Task class functions
 
+const char* const V3Task::s_dpiTemporaryVarSuffix = "__Vcvt";
+
 V3TaskConnects V3Task::taskConnects(AstNodeFTaskRef* nodep, AstNode* taskStmtsp) {
     // Output list will be in order of the port declaration variables (so
     // func calls are made right in C)
@@ -1809,11 +1811,6 @@ string V3Task::assignDpiToInternal(const string& lhsName, AstVar* varp) {
         }
     }
     return statements;
-}
-
-const char* V3Task::dpiTemporaryVarSuffix() {
-    static const char* const suffix = "__Vcvt";
-    return suffix;
 }
 
 void V3Task::taskAll(AstNetlist* nodep) {

--- a/src/V3Task.h
+++ b/src/V3Task.h
@@ -34,6 +34,8 @@ using V3TaskConnects = std::vector<V3TaskConnect>;  // [ [port, pin-connects-to]
 //============================================================================
 
 class V3Task final {
+    static const char* const s_dpiTemporaryVarSuffix;
+
 public:
     static void taskAll(AstNetlist* nodep);
     /// Return vector of [port, pin-connects-to]  (SLOW)
@@ -41,7 +43,7 @@ public:
     static string assignInternalToDpi(AstVar* portp, bool isPtr, const string& frSuffix,
                                       const string& toSuffix, const string& frPrefix = "");
     static string assignDpiToInternal(const string& lhsName, AstVar* rhsp);
-    static const char* dpiTemporaryVarSuffix();
+    static const char* dpiTemporaryVarSuffix() VL_MT_SAFE { return s_dpiTemporaryVarSuffix; }
 };
 
 #endif  // Guard


### PR DESCRIPTION
Pre-PR to: https://github.com/verilator/verilator/pull/4228
Move static variable from function to class header.