### PR TITLE
Internals: Check whether V3ERROR_NO_GLOBAL_ is not already defined. No functional change.

### DIFF
--- a/src/VlcBucket.h
+++ b/src/VlcBucket.h
@@ -20,7 +20,9 @@
 #include "config_build.h"
 #include "verilatedos.h"
 
+#ifndef V3ERROR_NO_GLOBAL_
 #define V3ERROR_NO_GLOBAL_
+#endif
 #include "V3Error.h"
 
 //********************************************************************

--- a/src/VlcMain.cpp
+++ b/src/VlcMain.cpp
@@ -24,7 +24,9 @@
 #include "verilatedos.h"
 
 // Cheat for speed and compile .cpp files into one object TODO: Reconsider
+#ifndef V3ERROR_NO_GLOBAL_
 #define V3ERROR_NO_GLOBAL_
+#endif
 #include "V3Error.h"
 static int debug() { return V3Error::debugDefault(); }
 #include "V3Error.cpp"

--- a/src/VlcPoint.h
+++ b/src/VlcPoint.h
@@ -25,7 +25,9 @@
 #include <unordered_map>
 #include <vector>
 
+#ifndef V3ERROR_NO_GLOBAL_
 #define V3ERROR_NO_GLOBAL_
+#endif
 #include "verilated_cov_key.h"
 
 #include "V3Error.h"


### PR DESCRIPTION
Pre-PR to: https://github.com/verilator/verilator/pull/4228
Check whether ``V3ERROR_NO_GLOBAL_`` is not already defined.