### PR TITLE
V3LockGuard: Add constructor for adopting already locked mutex.

### DIFF
--- a/src/V3Error.h
+++ b/src/V3Error.h
@@ -531,7 +531,7 @@ public:
 
 // Global versions, so that if the class doesn't define an operator, we get the functions anyway.
 void v3errorEnd(std::ostringstream& sstr) VL_RELEASE(V3Error::s().m_mutex);
-void v3errorEndFatal(std::ostringstream& sstr) VL_RELEASE(V3Error::s().m_mutex);
+void v3errorEndFatal(std::ostringstream& sstr) VL_RELEASE(V3Error::s().m_mutex) VL_ATTR_NORETURN;
 
 // Theses allow errors using << operators: v3error("foo"<<"bar");
 // Careful, you can't put () around msg, as you would in most macro definitions.

--- a/src/V3Mutex.h
+++ b/src/V3Mutex.h
@@ -139,12 +139,17 @@ private:
     T& m_mutexr;
 
 public:
-    /// Construct and hold given mutex lock until destruction or unlock()
+    /// Lock given mutex and hold it for the object lifetime.
     explicit V3LockGuardImp(T& mutexr) VL_ACQUIRE(mutexr) VL_MT_SAFE
         : m_mutexr(mutexr) {  // Need () or GCC 4.8 false warning
         mutexr.lock();
     }
-    /// Destruct and unlock the mutex
+    /// Take already locked mutex, and and hold the lock for the object lifetime.
+    explicit V3LockGuardImp(T& mutexr, std::adopt_lock_t) VL_REQUIRES(mutexr) VL_MT_SAFE
+        : m_mutexr(mutexr) {  // Need () or GCC 4.8 false warning
+    }
+
+    /// Unlock the mutex
     ~V3LockGuardImp() VL_RELEASE() { m_mutexr.unlock(); }
 };
 

--- a/src/V3ThreadPool.cpp
+++ b/src/V3ThreadPool.cpp
@@ -64,8 +64,6 @@ void V3ThreadPool::suspendMultithreading() VL_MT_SAFE VL_EXCLUDES(m_mutex)
 
     if (!m_mutex.try_lock()) {
         v3fatal("Tried to suspend thread pool when other thread uses it.");
-        assert(0);  // LCOV_EXCL_LINE
-        VL_UNREACHABLE;
     }
     V3LockGuard lock{m_mutex, std::adopt_lock_t{}};
 
@@ -79,8 +77,6 @@ void V3ThreadPool::resumeMultithreading() VL_MT_SAFE VL_EXCLUDES(m_mutex)
     VL_EXCLUDES(m_stoppedJobsMutex) {
     if (!m_mutex.try_lock()) {
         v3fatal("Tried to resume thread pool when other thread uses it.");
-        assert(0);  // LCOV_EXCL_LINE
-        VL_UNREACHABLE;
     }
     {
         V3LockGuard lock{m_mutex, std::adopt_lock_t{}};

--- a/src/V3ThreadPool.cpp
+++ b/src/V3ThreadPool.cpp
@@ -136,9 +136,8 @@ bool V3ThreadPool::waitIfStopRequested() VL_MT_SAFE VL_EXCLUDES(m_stoppedJobsMut
 void V3ThreadPool::waitForResumeRequest() VL_REQUIRES(m_stoppedJobsMutex) {
     ++m_stoppedJobs;
     m_exclusiveAccessThreadCV.notify_one();
-    m_stoppedJobsCV.wait(m_stoppedJobsMutex, [&]() VL_REQUIRES(m_stoppedJobsMutex) {
-        return !m_stopRequested;
-    });
+    m_stoppedJobsCV.wait(m_stoppedJobsMutex,
+                         [&]() VL_REQUIRES(m_stoppedJobsMutex) { return !m_stopRequested; });
     --m_stoppedJobs;
 }
 
@@ -146,7 +145,7 @@ void V3ThreadPool::stopOtherThreads() VL_MT_SAFE_EXCLUDES(m_mutex)
     VL_REQUIRES(m_stoppedJobsMutex) {
     m_stopRequested = true;
     {
-        V3LockGuard lock {m_mutex};
+        V3LockGuard lock{m_mutex};
         m_cv.notify_all();
     }
     m_exclusiveAccessThreadCV.wait(m_stoppedJobsMutex, [&]() VL_REQUIRES(m_stoppedJobsMutex) {
@@ -216,12 +215,14 @@ void V3ThreadPool::selfTest() {
         selfTestMtDisabled();
         {
             V3LockGuard lock{V3ThreadPool::s().m_mutex};
-            UASSERT(V3ThreadPool::s().m_multithreadingSuspended, "Multithreading should be suspended at this point");
+            UASSERT(V3ThreadPool::s().m_multithreadingSuspended,
+                    "Multithreading should be suspended at this point");
         }
     }
     {
         V3LockGuard lock{V3ThreadPool::s().m_mutex};
-        UASSERT(!V3ThreadPool::s().m_multithreadingSuspended, "Multithreading should not be suspended at this point");
+        UASSERT(!V3ThreadPool::s().m_multithreadingSuspended,
+                "Multithreading should not be suspended at this point");
     }
 }
 

--- a/src/V3ThreadPool.cpp
+++ b/src/V3ThreadPool.cpp
@@ -75,9 +75,7 @@ void V3ThreadPool::suspendMultithreading() VL_MT_SAFE VL_EXCLUDES(m_mutex)
 
 void V3ThreadPool::resumeMultithreading() VL_MT_SAFE VL_EXCLUDES(m_mutex)
     VL_EXCLUDES(m_stoppedJobsMutex) {
-    if (!m_mutex.try_lock()) {
-        v3fatal("Tried to resume thread pool when other thread uses it.");
-    }
+    if (!m_mutex.try_lock()) { v3fatal("Tried to resume thread pool when other thread uses it."); }
     {
         V3LockGuard lock{m_mutex, std::adopt_lock_t{}};
         UASSERT(m_multithreadingSuspended, "Multithreading is not suspended");

--- a/src/V3ThreadPool.cpp
+++ b/src/V3ThreadPool.cpp
@@ -19,7 +19,6 @@
 #include "V3ThreadPool.h"
 
 #include "V3Error.h"
-#include "V3ThreadSafety.h"
 
 // c++11 requires definition of static constexpr as well as declaration
 constexpr unsigned int V3ThreadPool::FUTUREWAITFOR_MS;
@@ -221,6 +220,14 @@ void V3ThreadPool::selfTest() {
     {
         const V3MtDisabledLockGuard mtDisabler{v3MtDisabledLock()};
         selfTestMtDisabled();
+        {
+            V3LockGuard lock{V3ThreadPool::s().m_mutex};
+            UASSERT(V3ThreadPool::s().m_multithreadingSuspended, "Multithreading should be suspended at this point");
+        }
+    }
+    {
+        V3LockGuard lock{V3ThreadPool::s().m_mutex};
+        UASSERT(!V3ThreadPool::s().m_multithreadingSuspended, "Multithreading should not be suspended at this point");
     }
 }
 

--- a/src/V3ThreadPool.h
+++ b/src/V3ThreadPool.h
@@ -103,7 +103,7 @@ class V3ThreadPool final {
 
     // Indicates whether multithreading has been suspended.
     // Used for error detection in resumeMultithreading only. You probably should use
-    // m_exclusiveAcces for information whether something should be run in current thread.
+    // m_exclusiveAccess for information whether something should be run in current thread.
     bool m_multithreadingSuspended VL_GUARDED_BY(m_mutex) = false;
 
     // CONSTRUCTORS
@@ -113,7 +113,7 @@ class V3ThreadPool final {
             if (m_jobsInProgress != 0) {
                 // ThreadPool shouldn't be destroyed when jobs are running and mutex is locked,
                 // something is wrong. Most likely Verilator is exitting as a result of failed
-                // assert in critical section. Do noting, let it exit.
+                // assert in critical section. Do nothing, let it exit.
                 return;
             }
         } else {

--- a/src/V3ThreadSafety.h
+++ b/src/V3ThreadSafety.h
@@ -36,8 +36,8 @@ class VL_CAPABILITY("lock") V3MtDisabledLock final {
     VL_UNMOVABLE(V3MtDisabledLock);
 
 public:
-    constexpr void lock() VL_ACQUIRE() VL_MT_SAFE {}
-    constexpr void unlock() VL_RELEASE() VL_MT_SAFE {}
+    void lock() VL_ACQUIRE() VL_MT_SAFE;
+    void unlock() VL_RELEASE() VL_MT_SAFE;
 
     static constexpr V3MtDisabledLock& instance()
         VL_RETURN_CAPABILITY(V3MtDisabledLock::s_mtDisabledLock) {

--- a/src/V3ThreadSafety.h
+++ b/src/V3ThreadSafety.h
@@ -36,7 +36,9 @@ class VL_CAPABILITY("lock") V3MtDisabledLock final {
     VL_UNMOVABLE(V3MtDisabledLock);
 
 public:
+    // lock() will disable multithreading while in MT Disabled regions
     void lock() VL_ACQUIRE() VL_MT_SAFE;
+    // unlock() will reenable multithreading while in MT Disabled regions
     void unlock() VL_RELEASE() VL_MT_SAFE;
 
     static constexpr V3MtDisabledLock& instance()


### PR DESCRIPTION
Pre-PR to: https://github.com/verilator/verilator/pull/4228

Add constructor for adopting already locked mutex.