### PR TITLE
Internals: Add V3ThreadSafety 

### DIFF
--- a/include/verilatedos.h
+++ b/include/verilatedos.h
@@ -94,20 +94,6 @@
 // Function requires a capability inbound (-fthread-safety)
 #define VL_CAPABILITY(x) \
         VL_CLANG_ATTR(capability(x))
-// Function requires not having a capability inbound (-fthread-safety)
-#define VL_REQUIRES(x) \
-        VL_CLANG_ATTR(annotate("REQUIRES")) \
-        VL_CLANG_ATTR(requires_capability(x))
-// Name of capability/lock (-fthread-safety)
-#define VL_GUARDED_BY(x) \
-        VL_CLANG_ATTR(annotate("GUARDED_BY")) \
-        VL_CLANG_ATTR(guarded_by(x))
-// The data that the annotated pointer points to is protected by the given capability.
-// The pointer itself is not protected.
-// Allowed on: pointer data member. (-fthread-safety)
-#define VL_PT_GUARDED_BY(x) \
-        VL_CLANG_ATTR(annotate("PT_GUARDED_BY")) \
-        VL_CLANG_ATTR(pt_guarded_by(x))
 // Name of mutex protecting this variable (-fthread-safety)
 #define VL_EXCLUDES(x) \
         VL_CLANG_ATTR(annotate("EXCLUDES")) \
@@ -123,6 +109,32 @@
 // Allowed on: function, method. (-fthread-safety)
 #define VL_ASSERT_CAPABILITY(x) \
         VL_CLANG_ATTR(assert_capability(x))
+
+// Require mutex locks only in code units which work with enabled multi-threading.
+#if !defined(VL_MT_DISABLED_CODE_UNIT)
+// Function requires not having a capability inbound (-fthread-safety)
+# define VL_REQUIRES(x) \
+        VL_CLANG_ATTR(annotate("REQUIRES")) \
+        VL_CLANG_ATTR(requires_capability(x))
+// Name of capability/lock (-fthread-safety)
+# define VL_GUARDED_BY(x) \
+        VL_CLANG_ATTR(annotate("GUARDED_BY")) \
+        VL_CLANG_ATTR(guarded_by(x))
+// The data that the annotated pointer points to is protected by the given capability.
+// The pointer itself is not protected.
+// Allowed on: pointer data member. (-fthread-safety)
+# define VL_PT_GUARDED_BY(x) \
+        VL_CLANG_ATTR(annotate("PT_GUARDED_BY")) \
+        VL_CLANG_ATTR(pt_guarded_by(x))
+#else
+// Keep annotations for clang_check_attributes
+# define VL_REQUIRES(x) \
+        VL_CLANG_ATTR(annotate("REQUIRES"))
+# define VL_GUARDED_BY(x) \
+        VL_CLANG_ATTR(annotate("GUARDED_BY"))
+# define VL_PT_GUARDED_BY(x) \
+        VL_CLANG_ATTR(annotate("PT_GUARDED_BY"))
+#endif
 
 // Defaults for unsupported compiler features
 #ifndef VL_ATTR_ALWINLINE

--- a/include/verilatedos.h
+++ b/include/verilatedos.h
@@ -430,6 +430,11 @@ using ssize_t = uint32_t;  ///< signed size_t; returned from read()
     Type(const Type& other) = delete; \
     Type& operator=(const Type&) = delete
 
+// Declare a class as unmovable; put after a private:
+#define VL_UNMOVABLE(Type) \
+    Type(Type&& other) = delete; \
+    Type& operator=(Type&&) = delete
+
 //=========================================================================
 // Verilated function size macros
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -151,6 +151,7 @@ set(HEADERS
     V3Table.h
     V3Task.h
     V3ThreadPool.h
+    V3ThreadSafety.h
     V3Timing.h
     V3Trace.h
     V3TraceDecl.h

--- a/src/Makefile_obj.in
+++ b/src/Makefile_obj.in
@@ -389,7 +389,7 @@ HEADER_CC_H := $(filter-out $(NON_STANDALONE_HEADERS), $(notdir $(wildcard $(src
 header_cc: $(addsuffix __header_cc.o, $(basename $(HEADER_CC_H)))
 
 %__header_cc.cpp: %.h
-	$(PYTHON3) $(srcdir)/../bin/verilator_includer -DVL_MT_DISABLED_CODE_UNIT=1 $^ > $@
+	$(PYTHON3) $(srcdir)/../bin/verilator_includer $^ > $@
 
 .SUFFIXES:
 

--- a/src/Makefile_obj.in
+++ b/src/Makefile_obj.in
@@ -289,6 +289,7 @@ NON_STANDALONE_HEADERS = \
 	V3AstNodeExpr.h  \
 	V3AstNodeOther.h  \
 	V3DfgVertices.h  \
+	V3ThreadPool.h \
 	V3WidthCommit.h  \
 
 AST_DEFS := \
@@ -298,81 +299,6 @@ AST_DEFS := \
 
 DFG_DEFS := \
   V3DfgVertices.h
-
-# Following objects are strictly checked for multi-thread safety.
-# Code in those objects is allowed to call Verilator code only from other
-# objects from this list.
-MT_ENABLED_OBJS := \
-	V3Ast.o \
-	V3AstNodes.o \
-	V3Config.o \
-	V3EmitCBase.o \
-	V3EmitCConstPool.o \
-	V3EmitCFunc.o \
-	V3EmitCHeaders.o \
-	V3EmitCImp.o \
-	V3EmitCInlines.o \
-	V3EmitV.o \
-	V3Broken.o \
-	V3Error.o \
-	V3File.o \
-	V3FileLine.o \
-	V3Global.o \
-	V3Hash.o \
-	V3Hasher.o \
-	V3Number.o \
-	V3Options.o \
-	V3Os.o \
-	V3Stats.o \
-	V3StatsReport.o \
-	V3String.o \
-	V3ThreadPool.o \
-	V3Waiver.o
-
-# Following objects are strictly checked for multi-thread safety.
-# Code in those objects is allowed to call Verilator code from all other
-# objects. However, it must assure that no other threads are working when
-# the code from objects in MT_DISABLED_OBJS list is called.
-MT_CONTROL_OBJS := \
-	Verilator.o
-
-# Following objects are only partially checked for thread-safety.
-# Mutexes are not required to be held when calling code that requires them.
-# Proper locking and unlocking is still checked in order to avoid deadlocks.
-# Code in those objects is allowed to call Verilator code from both
-# MT_DISABLED_OBJS and MT_ENABLED_OBJS.
-MT_DISABLED_OBJS := \
-	$(filter-out ${MT_CONTROL_OBJS} ${MT_ENABLED_OBJS},${RAW_OBJS}, ${VLCOV_OBJS})
-
-# For header_cc
-
-HEADER_CC_H := $(filter-out $(NON_STANDALONE_HEADERS), $(notdir $(wildcard $(srcdir)/*.h)))
-HEADER_CC_OBJS := $(addsuffix __header_cc.o, $(basename $(HEADER_CC_H)))
-
-# Equivalent of MT_ENABLED_OBJS
-MT_ENABLED_HEADER_CC_OBJS := \
-	V3ThreadPool__header_cc.o
-
-# Equivalent of MT_DISABLED_OBJS
-MT_DISABLED_HEADER_CC_OBJS := \
-	$(filter-out ${MT_ENABLED_HEADER_CC_OBJS},${HEADER_CC_OBJS})
-
-${MT_ENABLED_HEADER_CC_OBJS}: PRIV_MT_CPPFLAGS :=
-
-${MT_DISABLED_HEADER_CC_OBJS}: PRIV_MT_CPPFLAGS := \
-	-DVL_MT_DISABLED_CODE_UNIT=1 \
-	-DV3ERROR_NO_GLOBAL_=1
-
-# Per-object multithreading controlling flags
-
-${MT_ENABLED_OBJS} ${MT_ENABLED_HEADER_CC_OBJS}: PRIV_MT_CPPFLAGS :=
-
-${MT_CONTROL_OBJS}: PRIV_MT_CPPFLAGS := \
-	-DVL_MT_CONTROL_CODE_UNIT=1
-
-${MT_DISABLED_OBJS} ${MT_DISABLED_HEADER_CC_OBJS}: PRIV_MT_CPPFLAGS := \
-	-DVL_MT_DISABLED_CODE_UNIT=1 \
-	-DV3ERROR_NO_GLOBAL_=1
 
 #### astgen common flags
 
@@ -405,21 +331,21 @@ V3Number_test: V3Number_test.o
 .SECONDARY:
 
 %.o: %.cpp
-	$(OBJCACHE) ${CXX} ${CXXFLAGS} ${CPPFLAGSWALL} ${PRIV_MT_CPPFLAGS} -c $< -o $@
+	$(OBJCACHE) ${CXX} ${CXXFLAGS} ${CPPFLAGSWALL} -c $< -o $@
 %.o: %.c
 	$(OBJCACHE) ${CC}  ${CFLAGS} ${CPPFLAGSWALL} -c $< -o $@
 
 V3ParseLex.o: V3ParseLex.cpp V3Lexer.yy.cpp V3ParseBison.c
-	$(OBJCACHE) ${CXX} ${CXXFLAGS} ${CPPFLAGSPARSER} ${PRIV_MT_CPPFLAGS} -c $< -o $@
+	$(OBJCACHE) ${CXX} ${CXXFLAGS} ${CPPFLAGSPARSER} -c $< -o $@
 
 V3ParseGrammar.o: V3ParseGrammar.cpp V3ParseBison.c
-	$(OBJCACHE) ${CXX} ${CXXFLAGS} ${CPPFLAGSPARSER} ${PRIV_MT_CPPFLAGS} -c $< -o $@
+	$(OBJCACHE) ${CXX} ${CXXFLAGS} ${CPPFLAGSPARSER} -c $< -o $@
 
 V3ParseImp.o: V3ParseImp.cpp V3ParseBison.c
-	$(OBJCACHE) ${CXX} ${CXXFLAGS} ${CPPFLAGSPARSER} ${PRIV_MT_CPPFLAGS} -c $< -o $@
+	$(OBJCACHE) ${CXX} ${CXXFLAGS} ${CPPFLAGSPARSER} -c $< -o $@
 
 V3PreProc.o: V3PreProc.cpp V3PreLex.yy.cpp
-	$(OBJCACHE) ${CXX} ${CXXFLAGS} ${CPPFLAGSPARSER} ${PRIV_MT_CPPFLAGS} -c $< -o $@
+	$(OBJCACHE) ${CXX} ${CXXFLAGS} ${CPPFLAGSPARSER} -c $< -o $@
 
 #### Generated files
 
@@ -457,11 +383,13 @@ V3PreLex.yy.cpp: V3PreLex_pregen.yy.cpp $(FLEXFIX)
 	$(PYTHON3) $(FLEXFIX) V3PreLex <$< >$@
 
 # For t_dist_header_cc
+HEADER_CC_H := $(filter-out $(NON_STANDALONE_HEADERS), $(notdir $(wildcard $(srcdir)/*.h)))
+
 .PHONY: header_cc
-header_cc: $(HEADER_CC_OBJS)
+header_cc: $(addsuffix __header_cc.o, $(basename $(HEADER_CC_H)))
 
 %__header_cc.cpp: %.h
-	$(PYTHON3) $(srcdir)/../bin/verilator_includer $^ > $@
+	$(PYTHON3) $(srcdir)/../bin/verilator_includer -DVL_MT_DISABLED_CODE_UNIT=1 $^ > $@
 
 .SUFFIXES:
 

--- a/src/Makefile_obj.in
+++ b/src/Makefile_obj.in
@@ -299,6 +299,81 @@ AST_DEFS := \
 DFG_DEFS := \
   V3DfgVertices.h
 
+# Following objects are strictly checked for multi-thread safety.
+# Code in those objects is allowed to call Verilator code only from other
+# objects from this list.
+MT_ENABLED_OBJS := \
+	V3Ast.o \
+	V3AstNodes.o \
+	V3Config.o \
+	V3EmitCBase.o \
+	V3EmitCConstPool.o \
+	V3EmitCFunc.o \
+	V3EmitCHeaders.o \
+	V3EmitCImp.o \
+	V3EmitCInlines.o \
+	V3EmitV.o \
+	V3Broken.o \
+	V3Error.o \
+	V3File.o \
+	V3FileLine.o \
+	V3Global.o \
+	V3Hash.o \
+	V3Hasher.o \
+	V3Number.o \
+	V3Options.o \
+	V3Os.o \
+	V3Stats.o \
+	V3StatsReport.o \
+	V3String.o \
+	V3ThreadPool.o \
+	V3Waiver.o
+
+# Following objects are strictly checked for multi-thread safety.
+# Code in those objects is allowed to call Verilator code from all other
+# objects. However, it must assure that no other threads are working when
+# the code from objects in MT_DISABLED_OBJS list is called.
+MT_CONTROL_OBJS := \
+	Verilator.o
+
+# Following objects are only partially checked for thread-safety.
+# Mutexes are not required to be held when calling code that requires them.
+# Proper locking and unlocking is still checked in order to avoid deadlocks.
+# Code in those objects is allowed to call Verilator code from both
+# MT_DISABLED_OBJS and MT_ENABLED_OBJS.
+MT_DISABLED_OBJS := \
+	$(filter-out ${MT_CONTROL_OBJS} ${MT_ENABLED_OBJS},${RAW_OBJS}, ${VLCOV_OBJS})
+
+# For header_cc
+
+HEADER_CC_H := $(filter-out $(NON_STANDALONE_HEADERS), $(notdir $(wildcard $(srcdir)/*.h)))
+HEADER_CC_OBJS := $(addsuffix __header_cc.o, $(basename $(HEADER_CC_H)))
+
+# Equivalent of MT_ENABLED_OBJS
+MT_ENABLED_HEADER_CC_OBJS := \
+	V3ThreadPool__header_cc.o
+
+# Equivalent of MT_DISABLED_OBJS
+MT_DISABLED_HEADER_CC_OBJS := \
+	$(filter-out ${MT_ENABLED_HEADER_CC_OBJS},${HEADER_CC_OBJS})
+
+${MT_ENABLED_HEADER_CC_OBJS}: PRIV_MT_CPPFLAGS :=
+
+${MT_DISABLED_HEADER_CC_OBJS}: PRIV_MT_CPPFLAGS := \
+	-DVL_MT_DISABLED_CODE_UNIT=1 \
+	-DV3ERROR_NO_GLOBAL_=1
+
+# Per-object multithreading controlling flags
+
+${MT_ENABLED_OBJS} ${MT_ENABLED_HEADER_CC_OBJS}: PRIV_MT_CPPFLAGS :=
+
+${MT_CONTROL_OBJS}: PRIV_MT_CPPFLAGS := \
+	-DVL_MT_CONTROL_CODE_UNIT=1
+
+${MT_DISABLED_OBJS} ${MT_DISABLED_HEADER_CC_OBJS}: PRIV_MT_CPPFLAGS := \
+	-DVL_MT_DISABLED_CODE_UNIT=1 \
+	-DV3ERROR_NO_GLOBAL_=1
+
 #### astgen common flags
 
 ASTGENFLAGS = -I $(srcdir)
@@ -330,21 +405,21 @@ V3Number_test: V3Number_test.o
 .SECONDARY:
 
 %.o: %.cpp
-	$(OBJCACHE) ${CXX} ${CXXFLAGS} ${CPPFLAGSWALL} -c $< -o $@
+	$(OBJCACHE) ${CXX} ${CXXFLAGS} ${CPPFLAGSWALL} ${PRIV_MT_CPPFLAGS} -c $< -o $@
 %.o: %.c
 	$(OBJCACHE) ${CC}  ${CFLAGS} ${CPPFLAGSWALL} -c $< -o $@
 
 V3ParseLex.o: V3ParseLex.cpp V3Lexer.yy.cpp V3ParseBison.c
-	$(OBJCACHE) ${CXX} ${CXXFLAGS} ${CPPFLAGSPARSER} -c $< -o $@
+	$(OBJCACHE) ${CXX} ${CXXFLAGS} ${CPPFLAGSPARSER} ${PRIV_MT_CPPFLAGS} -c $< -o $@
 
 V3ParseGrammar.o: V3ParseGrammar.cpp V3ParseBison.c
-	$(OBJCACHE) ${CXX} ${CXXFLAGS} ${CPPFLAGSPARSER} -c $< -o $@
+	$(OBJCACHE) ${CXX} ${CXXFLAGS} ${CPPFLAGSPARSER} ${PRIV_MT_CPPFLAGS} -c $< -o $@
 
 V3ParseImp.o: V3ParseImp.cpp V3ParseBison.c
-	$(OBJCACHE) ${CXX} ${CXXFLAGS} ${CPPFLAGSPARSER} -c $< -o $@
+	$(OBJCACHE) ${CXX} ${CXXFLAGS} ${CPPFLAGSPARSER} ${PRIV_MT_CPPFLAGS} -c $< -o $@
 
 V3PreProc.o: V3PreProc.cpp V3PreLex.yy.cpp
-	$(OBJCACHE) ${CXX} ${CXXFLAGS} ${CPPFLAGSPARSER} -c $< -o $@
+	$(OBJCACHE) ${CXX} ${CXXFLAGS} ${CPPFLAGSPARSER} ${PRIV_MT_CPPFLAGS} -c $< -o $@
 
 #### Generated files
 
@@ -382,10 +457,8 @@ V3PreLex.yy.cpp: V3PreLex_pregen.yy.cpp $(FLEXFIX)
 	$(PYTHON3) $(FLEXFIX) V3PreLex <$< >$@
 
 # For t_dist_header_cc
-HEADER_CC_H := $(filter-out $(NON_STANDALONE_HEADERS), $(notdir $(wildcard $(srcdir)/*.h)))
-
 .PHONY: header_cc
-header_cc: $(addsuffix __header_cc.o, $(basename $(HEADER_CC_H)))
+header_cc: $(HEADER_CC_OBJS)
 
 %__header_cc.cpp: %.h
 	$(PYTHON3) $(srcdir)/../bin/verilator_includer $^ > $@

--- a/src/V3ThreadPool.cpp
+++ b/src/V3ThreadPool.cpp
@@ -111,6 +111,10 @@ void V3ThreadPool::stopOtherThreads() VL_MT_SAFE_EXCLUDES(m_mutex)
     --m_stoppedJobs;
 }
 
+void V3ThreadPool::selfTestMtDisabled() {
+    // empty
+}
+
 void V3ThreadPool::selfTest() {
     V3Mutex commonMutex;
     int commonValue{0};
@@ -164,6 +168,10 @@ void V3ThreadPool::selfTest() {
     futuresInt.push_back(s().enqueue(forthJob));
     auto result = V3ThreadPool::waitForFutures(futuresInt);
     UASSERT(result.back() == 1234, "unexpected future result = " << result.back());
+    {
+        const V3MtDisabledLockGuard mtDisabler{v3MtDisabledLock()};
+        selfTestMtDisabled();
+    }
 }
 
 V3MtDisabledLock V3MtDisabledLock::s_mtDisabledLock;

--- a/src/V3ThreadPool.cpp
+++ b/src/V3ThreadPool.cpp
@@ -165,3 +165,5 @@ void V3ThreadPool::selfTest() {
     auto result = V3ThreadPool::waitForFutures(futuresInt);
     UASSERT(result.back() == 1234, "unexpected future result = " << result.back());
 }
+
+V3MtDisabledLock V3MtDisabledLock::s_mtDisabledLock;

--- a/src/V3ThreadPool.h
+++ b/src/V3ThreadPool.h
@@ -17,6 +17,10 @@
 #ifndef _V3THREADPOOL_H_
 #define _V3THREADPOOL_H_ 1
 
+#if defined(VL_MT_DISABLED_CODE_UNIT)
+#error "Source file has been declared as MT_DISABLED, threads use is prohibited."
+#endif
+
 #include "V3Mutex.h"
 
 #include <condition_variable>

--- a/src/V3ThreadPool.h
+++ b/src/V3ThreadPool.h
@@ -168,6 +168,7 @@ public:
     }
 
     static void selfTest();
+    static void selfTestMtDisabled() VL_MT_DISABLED;
 
 private:
     template <typename T>

--- a/src/V3ThreadPool.h
+++ b/src/V3ThreadPool.h
@@ -22,6 +22,7 @@
 #endif
 
 #include "V3Mutex.h"
+#include "V3ThreadSafety.h"
 
 #include <condition_variable>
 #include <functional>

--- a/src/V3ThreadSafety.h
+++ b/src/V3ThreadSafety.h
@@ -1,0 +1,71 @@
+// -*- mode: C++; c-file-style: "cc-mode" -*-
+//*************************************************************************
+// DESCRIPTION: Verilator: Definitions for thread safety checing
+//
+// Code available from: https://verilator.org
+//
+//*************************************************************************
+//
+// Copyright 2003-2023 by Wilson Snyder. This program is free software; you
+// can redistribute it and/or modify it under the terms of either the GNU
+// Lesser General Public License Version 3 or the Perl Artistic License
+// Version 2.0.
+// SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+//
+//*************************************************************************
+
+#ifndef VERILATOR_V3THREADSAFETY_H_
+#define VERILATOR_V3THREADSAFETY_H_
+
+#include <verilatedos.h>
+
+#include <V3Mutex.h>
+
+// A class that works as an indicator of MT_DISABLED context.
+// It uses Clang's thread safety analysis (-fthread-safety) to do its work.
+// Its use will most likely be optimized out (or at least reduced to a few insignificant symbols
+// or instructions) during compilation.
+class VL_CAPABILITY("lock") V3MtDisabledLock final {
+    friend class V3MtDisabledLockInstanceAccessor;
+
+    static V3MtDisabledLock s_mtDisabledLock;
+
+    constexpr V3MtDisabledLock() = default;
+    ~V3MtDisabledLock() = default;
+    VL_UNCOPYABLE(V3MtDisabledLock);
+    VL_UNMOVABLE(V3MtDisabledLock);
+
+public:
+    constexpr void lock() VL_ACQUIRE() VL_MT_SAFE {}
+    constexpr void unlock() VL_RELEASE() VL_MT_SAFE {}
+
+    static constexpr V3MtDisabledLock& instance()
+        VL_RETURN_CAPABILITY(V3MtDisabledLock::s_mtDisabledLock) {
+        return s_mtDisabledLock;
+    }
+};
+
+// A class providing mutable access to V3MtDisabledLock::s_mtDisabledLock.
+// This is a class because VL_RETURN_CAPABILITY works only on methods, not free functions.
+// This is not a method in V3MtDisabledLock itself as a method declaration inside #ifdef block
+// woudl break ODR.
+class V3MtDisabledLockInstanceAccessor final {
+public:
+    constexpr V3MtDisabledLock& operator()() const
+        VL_RETURN_CAPABILITY(V3MtDisabledLock::s_mtDisabledLock) {
+        return V3MtDisabledLock::s_mtDisabledLock;
+    }
+};
+// Create a global object which can be called like a function.
+static constexpr V3MtDisabledLockInstanceAccessor v3MtDisabledLock VL_ATTR_UNUSED;
+
+using V3MtDisabledLockGuard = V3LockGuardImp<V3MtDisabledLock>;
+
+// Annotated function can be called only in MT_DISABLED context, i.e. either in a code unit
+// compiled with VL_MT_DISABLED_CODE_UNIT preprocessor definition, or after obtaining a lock on
+// v3MtDisabledLock().
+#define VL_MT_DISABLED \
+    VL_CLANG_ATTR(annotate("MT_DISABLED")) \
+    VL_REQUIRES(V3MtDisabledLock::instance())
+
+#endif  // guard

--- a/src/Verilator.cpp
+++ b/src/Verilator.cpp
@@ -91,7 +91,6 @@
 #include "V3Table.h"
 #include "V3Task.h"
 #include "V3ThreadPool.h"
-#include "V3ThreadSafety.h"
 #include "V3Timing.h"
 #include "V3Trace.h"
 #include "V3TraceDecl.h"

--- a/src/Verilator.cpp
+++ b/src/Verilator.cpp
@@ -91,6 +91,7 @@
 #include "V3Table.h"
 #include "V3Task.h"
 #include "V3ThreadPool.h"
+#include "V3ThreadSafety.h"
 #include "V3Timing.h"
 #include "V3Trace.h"
 #include "V3TraceDecl.h"


### PR DESCRIPTION
Pre-PR to: https://github.com/verilator/verilator/pull/4228

Add V3ThreadSafety that allows to disable multithreading by locking ``s_mtDisabledLock`` from V3ThreadPool. This PR only adds implementation, actual usage will be in separate PR to limit changes in single PR.