### PR TITLE
Don't mark static function variables as funcLocal

### DIFF
--- a/src/V3LinkResolve.cpp
+++ b/src/V3LinkResolve.cpp
@@ -101,7 +101,7 @@ private:
     void visit(AstVar* nodep) override {
         iterateChildren(nodep);
         if (m_classp && !nodep->isParam()) nodep->varType(VVarType::MEMBER);
-        if (m_ftaskp) nodep->funcLocal(true);
+        if (m_ftaskp && !nodep->lifetime().isStatic()) nodep->funcLocal(true);
         if (nodep->isSigModPublic()) {
             nodep->sigModPublic(false);  // We're done with this attribute
             m_modp->modPublic(true);  // Avoid flattening if signals are exposed


### PR DESCRIPTION
Static function variables shouldn't be marked as local variables. They are even moved outside the function in V3Begin. This change is needed for https://github.com/verilator/verilator/pull/4437, because modification of a static variable is a side effect and function that has has such a modification in its body is impure.