### PR TITLE
Fix the error message when the type of ref argument is wrong

### DIFF
--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -5577,12 +5577,14 @@ private:
                 const AstArg* const argp = tconnect.second;
                 AstNode* const pinp = argp->exprp();
                 if (!pinp) continue;  // Argument error we'll find later
+                AstNodeDType* const portDTypep = portp->dtypep()->skipRefToEnump();
+                const AstNodeDType* const pinDTypep = pinp->dtypep()->skipRefToEnump();
                 if (portp->direction() == VDirection::REF
-                    && !similarDTypeRecurse(portp->dtypep(), pinp->dtypep())) {
+                    && !similarDTypeRecurse(portDTypep, pinDTypep)) {
                     pinp->v3error("Ref argument requires matching types;"
                                   << " port " << portp->prettyNameQ() << " requires "
-                                  << portp->dtypep()->prettyDTypeName() << " but connection is "
-                                  << pinp->dtypep()->prettyDTypeName() << ".");
+                                  << portDTypep->prettyDTypeName() << " but connection is "
+                                  << pinDTypep->prettyDTypeName() << ".");
                 } else if (portp->isWritable() && pinp->width() != portp->width()) {
                     pinp->v3warn(E_UNSUPPORTED, "Unsupported: Function output argument "
                                                     << portp->prettyNameQ() << " requires "
@@ -5593,10 +5595,10 @@ private:
                     // (get an ASSIGN with EXTEND on the lhs instead of rhs)
                 }
                 if (!portp->basicp() || portp->basicp()->isOpaque()) {
-                    checkClassAssign(nodep, "Function Argument", pinp, portp->dtypep());
-                    userIterate(pinp, WidthVP{portp->dtypep(), FINAL}.p());
+                    checkClassAssign(nodep, "Function Argument", pinp, portDTypep);
+                    userIterate(pinp, WidthVP{portDTypep, FINAL}.p());
                 } else {
-                    iterateCheckAssign(nodep, "Function Argument", pinp, FINAL, portp->dtypep());
+                    iterateCheckAssign(nodep, "Function Argument", pinp, FINAL, portDTypep);
                 }
             }
         }
@@ -6402,7 +6404,7 @@ private:
         return false;
     }
     void checkClassAssign(AstNode* nodep, const char* side, AstNode* rhsp,
-                          AstNodeDType* lhsDTypep) {
+                          const AstNodeDType* const lhsDTypep) {
         if (AstClassRefDType* const lhsClassRefp = VN_CAST(lhsDTypep->skipRefp(), ClassRefDType)) {
             UASSERT_OBJ(rhsp->dtypep(), rhsp, "Node has no type");
             AstNodeDType* const rhsDtypep = rhsp->dtypep()->skipRefp();
@@ -6415,7 +6417,7 @@ private:
                                 << rhsDtypep->prettyTypeName());
         }
     }
-    static bool similarDTypeRecurse(AstNodeDType* node1p, AstNodeDType* node2p) {
+    static bool similarDTypeRecurse(const AstNodeDType* const node1p, const AstNodeDType* const node2p) {
         return node1p->skipRefp()->similarDType(node2p->skipRefp());
     }
     void iterateCheckFileDesc(AstNode* nodep, AstNode* underp, Stage stage) {

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -5581,8 +5581,8 @@ private:
                     && !similarDTypeRecurse(portp->dtypep(), pinp->dtypep())) {
                     pinp->v3error("Ref argument requires matching types;"
                                   << " port " << portp->prettyNameQ() << " requires "
-                                  << portp->prettyTypeName() << " but connection is "
-                                  << pinp->prettyTypeName() << ".");
+                                  << portp->dtypep()->prettyDTypeName() << " but connection is "
+                                  << pinp->dtypep()->prettyDTypeName() << ".");
                 } else if (portp->isWritable() && pinp->width() != portp->width()) {
                     pinp->v3warn(E_UNSUPPORTED, "Unsupported: Function output argument "
                                                     << portp->prettyNameQ() << " requires "

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -6417,7 +6417,8 @@ private:
                                 << rhsDtypep->prettyTypeName());
         }
     }
-    static bool similarDTypeRecurse(const AstNodeDType* const node1p, const AstNodeDType* const node2p) {
+    static bool similarDTypeRecurse(const AstNodeDType* const node1p,
+                                    const AstNodeDType* const node2p) {
         return node1p->skipRefp()->similarDType(node2p->skipRefp());
     }
     void iterateCheckFileDesc(AstNode* nodep, AstNode* underp, Stage stage) {

--- a/test_regress/t/t_class_param_enum_bad.out
+++ b/test_regress/t/t_class_param_enum_bad.out
@@ -2,7 +2,7 @@
                                         : ... In instance t
    20 |       Converter#(bit) conv2 = conv1;
       |                               ^~~~~
-%Error-ENUMVALUE: t/t_class_param_enum_bad.v:21:19: Implicit conversion to enum 'T' from 'logic[31:0]' (IEEE 1800-2017 6.19.3)
+%Error-ENUMVALUE: t/t_class_param_enum_bad.v:21:19: Implicit conversion to enum 'ENUMDTYPE '$unit::enum_t'' from 'logic[31:0]' (IEEE 1800-2017 6.19.3)
                                                   : ... In instance t
                                                   : ... Suggest use enum's mnemonic, or static cast
    21 |       conv1.toInt(0);

--- a/test_regress/t/t_func_refio_bad.out
+++ b/test_regress/t/t_func_refio_bad.out
@@ -1,4 +1,4 @@
-%Error: t/t_func_refio_bad.v:16:17: Ref argument requires matching types; port 'q' requires  but connection is logic[31:0].
+%Error: t/t_func_refio_bad.v:16:17: Ref argument requires matching types; port 'q' requires integer[$] but connection is logic[31:0].
                                   : ... In instance t
    16 |       queue_set(42);   
       |                 ^~

--- a/test_regress/t/t_func_refio_bad.out
+++ b/test_regress/t/t_func_refio_bad.out
@@ -1,4 +1,4 @@
-%Error: t/t_func_refio_bad.v:16:17: Ref argument requires matching types; port 'q' requires VAR 'q' but connection is CONST '?32?sh2a'.
+%Error: t/t_func_refio_bad.v:16:17: Ref argument requires matching types; port 'q' requires  but connection is logic[31:0].
                                   : ... In instance t
    16 |       queue_set(42);   
       |                 ^~

--- a/test_regress/t/t_var_ref_bad2.out
+++ b/test_regress/t/t_var_ref_bad2.out
@@ -2,7 +2,7 @@
                                : ... In instance t
    13 |       bad_const_set = 32'h4567;   
       |       ^~~~~~~~~~~~~
-%Error: t/t_var_ref_bad2.v:23:17: Ref argument requires matching types; port 'int_ref' requires VAR 'int_ref' but connection is VARREF 'bad_non_int'.
+%Error: t/t_var_ref_bad2.v:23:17: Ref argument requires matching types; port 'int_ref' requires int but connection is byte.
                                 : ... In instance t
    23 |       checkset2(bad_non_int);   
       |                 ^~~~~~~~~~~


### PR DESCRIPTION
Current error message is confusing. It is about the types of AST nodes, but it is printed when the data types differ. I changed it. I also added some `const` specifiers.