### PR TITLE
Fix detecting local vars in nested forks (#4493)

### DIFF
--- a/src/V3Fork.cpp
+++ b/src/V3Fork.cpp
@@ -516,9 +516,11 @@ private:
         VL_RESTORER(m_capturedVarsp);
         VL_RESTORER(m_capturedVarRefsp);
         VL_RESTORER(m_newProcess);
+        VL_RESTORER(m_forkLocalsp);
         m_capturedVarsp = nullptr;
         m_capturedVarRefsp = nullptr;
         m_newProcess = false;
+        m_forkLocalsp.clear();
 
         iterateChildren(nodep);
 
@@ -566,7 +568,6 @@ private:
         if (!nodep->joinType().join()) {
             ++m_forkDepth;
             m_newProcess = true;
-            m_forkLocalsp.clear();
             // Nested forks get moved into separate tasks
             if (nested) {
                 visitTaskifiable(nodep);
@@ -604,9 +605,10 @@ private:
             UASSERT_OBJ(
                 !nodep->varp()->lifetime().isNone(), nodep,
                 "Variable's lifetime is unknown. Can't determine if a capture is necessary.");
-
-            AstVar* const varp = captureRef(nodep);
-            nodep->varp(varp);
+            if (m_forkLocalsp.count(nodep->varp()) == 0) {
+                AstVar* const varp = captureRef(nodep);
+                nodep->varp(varp);
+            }
         }
     }
     void visit(AstAssign* nodep) override {

--- a/test_regress/t/t_fork_none_var.pl
+++ b/test_regress/t/t_fork_none_var.pl
@@ -13,13 +13,11 @@ scenarios(simulator => 1);
 compile(
     verilator_flags2 => ["--exe --main --timing"],
     make_main => 0,
-    fails => $Self->{vlt_all},  # issue #4493
     );
 
-# issue #4493
-#execute(
-#    check_finished => 1,
-#    );
+execute(
+    check_finished => 1,
+    );
 
 ok(1);
 1;

--- a/test_regress/t/t_fork_none_var.v
+++ b/test_regress/t/t_fork_none_var.v
@@ -22,7 +22,7 @@ module t(/*AUTOARG*/);
                            fork
                               automatic int k = i;
                               begin
-                                 // issue #4493
+                                 // see issue #4493
                                  $display("[%0t] start %0d", $time, k);
                                  // UVM's arb_sequence_q[is_relevant_entries[k]].wait_for_relevant();
                                  m_mask[k] = 1;

--- a/test_regress/t/t_uvm_pkg_todo.vh
+++ b/test_regress/t/t_uvm_pkg_todo.vh
@@ -19192,9 +19192,7 @@ task uvm_sequencer_base::m_wait_for_available_sequence();
                 fork
                     automatic int k = i;
                   begin
-//TODO issue #4493 - Fix UVM fork..join_none local variable can't locate varref scope
-//TODO %Error: Internal Error: t/t_uvm_pkg_todo.vh:19203:56: ../V3Scope.cpp:80: Can't locate varref scope
-//TODO                    arb_sequence_q[is_relevant_entries[k]].sequence_ptr.wait_for_relevant();
+                    arb_sequence_q[is_relevant_entries[k]].sequence_ptr.wait_for_relevant();
                     if ($realtime != m_last_wait_relevant_time) begin
                        m_last_wait_relevant_time = $realtime ;
                        m_wait_relevant_count = 0 ;


### PR DESCRIPTION
Fixes: https://github.com/verilator/verilator/issues/4493

Sometimes in nested forks, V3Fork incorrectly tried to capture variable that was local to newly created task. This PR fixes it.