### PR TITLE
Fix logical expressions with class objects

### DIFF
--- a/src/V3Ast.cpp
+++ b/src/V3Ast.cpp
@@ -1063,11 +1063,11 @@ AstNode* AstNode::iterateSubtreeReturnEdits(VNVisitor& v) {
 
 //======================================================================
 
-bool AstNode::safeConversionLogicToBit() {
-    if (m_op1p && !m_op1p->safeConversionLogicToBit()) return false;
-    if (m_op2p && !m_op2p->safeConversionLogicToBit()) return false;
-    if (m_op3p && !m_op3p->safeConversionLogicToBit()) return false;
-    if (m_op4p && !m_op4p->safeConversionLogicToBit()) return false;
+bool AstNode::containsMemberAccess() {
+    if (m_op1p && !m_op1p->containsMemberAccess()) return false;
+    if (m_op2p && !m_op2p->containsMemberAccess()) return false;
+    if (m_op3p && !m_op3p->containsMemberAccess()) return false;
+    if (m_op4p && !m_op4p->containsMemberAccess()) return false;
     return true;
 }
 

--- a/src/V3Ast.cpp
+++ b/src/V3Ast.cpp
@@ -1063,6 +1063,16 @@ AstNode* AstNode::iterateSubtreeReturnEdits(VNVisitor& v) {
 
 //======================================================================
 
+bool AstNode::safeConversionLogicToBit() {
+    if (m_op1p && !m_op1p->safeConversionLogicToBit()) return false;
+    if (m_op2p && !m_op2p->safeConversionLogicToBit()) return false;
+    if (m_op3p && !m_op3p->safeConversionLogicToBit()) return false;
+    if (m_op4p && !m_op4p->safeConversionLogicToBit()) return false;
+    return true;
+}
+
+//======================================================================
+
 void AstNode::cloneRelinkTree() {
     // private: Cleanup clone() operation on whole tree. Publicly call cloneTree() instead.
     for (AstNode* nodep = this; nodep; nodep = nodep->m_nextp) {

--- a/src/V3Ast.cpp
+++ b/src/V3Ast.cpp
@@ -1068,6 +1068,7 @@ bool AstNode::containsMemberAccess() {
     if (m_op2p && m_op2p->containsMemberAccess()) return true;
     if (m_op3p && m_op3p->containsMemberAccess()) return true;
     if (m_op4p && m_op4p->containsMemberAccess()) return true;
+    if (m_nextp && m_nextp->containsMemberAccess()) return true;
     return false;
 }
 

--- a/src/V3Ast.cpp
+++ b/src/V3Ast.cpp
@@ -1064,11 +1064,11 @@ AstNode* AstNode::iterateSubtreeReturnEdits(VNVisitor& v) {
 //======================================================================
 
 bool AstNode::containsMemberAccess() {
-    if (m_op1p && !m_op1p->containsMemberAccess()) return false;
-    if (m_op2p && !m_op2p->containsMemberAccess()) return false;
-    if (m_op3p && !m_op3p->containsMemberAccess()) return false;
-    if (m_op4p && !m_op4p->containsMemberAccess()) return false;
-    return true;
+    if (m_op1p && m_op1p->containsMemberAccess()) return true;
+    if (m_op2p && m_op2p->containsMemberAccess()) return true;
+    if (m_op3p && m_op3p->containsMemberAccess()) return true;
+    if (m_op4p && m_op4p->containsMemberAccess()) return true;
+    return false;
 }
 
 //======================================================================

--- a/src/V3Ast.h
+++ b/src/V3Ast.h
@@ -167,12 +167,12 @@ inline std::ostream& operator<<(std::ostream& os, const VLifetime& rhs) {
 
 // ######################################################################
 
-class VSafeConversionLogicToBit final {
-    // Used in some nodes that cache the result of safeConversionLogicToBit method
+class VContainsMemberAccess final {
+    // Used in some nodes that cache the result of containsMemberAccess method
 public:
     enum en : uint8_t { NOT_CACHED, YES, NO };
     enum en m_e;
-    VSafeConversionLogicToBit()
+    VContainsMemberAccess()
         : m_e{NOT_CACHED} {}
     bool isCached() const { return m_e != NOT_CACHED; }
     bool isSafe() const { return m_e == YES; }
@@ -2067,7 +2067,7 @@ public:
     virtual bool isPredictOptimizable() const { return !isTimingControl(); }
     // Else a $display, etc, that must be ordered with other displays
     virtual bool isPure() { return true; }
-    virtual bool safeConversionLogicToBit();
+    virtual bool containsMemberAccess();
     // Else a AstTime etc that can't be substituted out
     virtual bool isSubstOptimizable() const { return true; }
     // An event control, delay, wait, etc.

--- a/src/V3Ast.h
+++ b/src/V3Ast.h
@@ -167,6 +167,20 @@ inline std::ostream& operator<<(std::ostream& os, const VLifetime& rhs) {
 
 // ######################################################################
 
+class VSafeConversionLogicToBit final {
+    // Used in some nodes that cache the result of safeConversionLogicToBit method
+public:
+    enum en : uint8_t { NOT_CACHED, YES, NO };
+    enum en m_e;
+    VSafeConversionLogicToBit()
+        : m_e{NOT_CACHED} {}
+    bool isCached() const { return m_e != NOT_CACHED; }
+    bool isSafe() const { return m_e == YES; }
+    void set(bool flag) { m_e = flag ? YES : NO; }
+};
+
+// ######################################################################
+
 class VPurity final {
     // Used in some nodes to cache the result of isPure method
 public:
@@ -2053,6 +2067,7 @@ public:
     virtual bool isPredictOptimizable() const { return !isTimingControl(); }
     // Else a $display, etc, that must be ordered with other displays
     virtual bool isPure() { return true; }
+    virtual bool safeConversionLogicToBit();
     // Else a AstTime etc that can't be substituted out
     virtual bool isSubstOptimizable() const { return true; }
     // An event control, delay, wait, etc.

--- a/src/V3Ast.h
+++ b/src/V3Ast.h
@@ -175,7 +175,7 @@ public:
     VContainsMemberAccess()
         : m_e{NOT_CACHED} {}
     bool isCached() const { return m_e != NOT_CACHED; }
-    bool isSafe() const { return m_e == YES; }
+    bool get() const { return m_e == YES; }
     void set(bool flag) { m_e = flag ? YES : NO; }
 };
 

--- a/src/V3AstNodeDType.h
+++ b/src/V3AstNodeDType.h
@@ -129,7 +129,7 @@ public:
     string cType(const string& name, bool forFunc, bool isRef) const;
     // Represents a C++ LiteralType? (can be constexpr)
     bool isLiteralType() const VL_MT_STABLE;
-    bool safeConversionLogicToBit() override { return true; }
+    bool containsMemberAccess() override { return true; }
 
 private:
     class CTypeRecursed;

--- a/src/V3AstNodeDType.h
+++ b/src/V3AstNodeDType.h
@@ -129,6 +129,7 @@ public:
     string cType(const string& name, bool forFunc, bool isRef) const;
     // Represents a C++ LiteralType? (can be constexpr)
     bool isLiteralType() const VL_MT_STABLE;
+    bool safeConversionLogicToBit() override { return true; }
 
 private:
     class CTypeRecursed;

--- a/src/V3AstNodeDType.h
+++ b/src/V3AstNodeDType.h
@@ -129,7 +129,7 @@ public:
     string cType(const string& name, bool forFunc, bool isRef) const;
     // Represents a C++ LiteralType? (can be constexpr)
     bool isLiteralType() const VL_MT_STABLE;
-    bool containsMemberAccess() override { return true; }
+    bool containsMemberAccess() override { return false; }
 
 private:
     class CTypeRecursed;

--- a/src/V3AstNodeExpr.h
+++ b/src/V3AstNodeExpr.h
@@ -229,7 +229,7 @@ class AstNodeFTaskRef VL_NOT_FINAL : public AstNodeExpr {
     string m_inlinedDots;  // Dotted hierarchy flattened out
     bool m_pli = false;  // Pli system call ($name)
     VPurity m_purity;  // Pure state
-    VSafeConversionLogicToBit m_safeConversion;  // Cached result of safeConversionLogicToBit
+    VContainsMemberAccess m_containsMemberAccess;  // Cached result of containsMemberAccess
 
 protected:
     AstNodeFTaskRef(VNType t, FileLine* fl, AstNode* namep, AstNodeExpr* pinsp)
@@ -262,8 +262,8 @@ public:
     bool pli() const { return m_pli; }
     void pli(bool flag) { m_pli = flag; }
     bool isPure() override;
-    bool safeConversionLogicToBit() override;
-    bool getSafeConversion() const;
+    bool containsMemberAccess() override;
+    bool containsMemberAccessImpl() const;
 
     string emitVerilog() final override { V3ERROR_NA_RETURN(""); }
     string emitC() final override { V3ERROR_NA_RETURN(""); }
@@ -1160,7 +1160,7 @@ class AstExprStmt final : public AstNodeExpr {
     // resultp is evaluated AFTER the statement(s).
     // @astgen op1 := stmtsp : List[AstNode]
     // @astgen op2 := resultp : AstNodeExpr
-    VSafeConversionLogicToBit m_safeConversion;  // Cached result of safeConversionLogicToBit
+    VContainsMemberAccess m_containsMemberAccess;  // Cached result of containsMemberAccess
 public:
     AstExprStmt(FileLine* fl, AstNode* stmtsp, AstNodeExpr* resultp)
         : ASTGEN_SUPER_ExprStmt(fl) {
@@ -1174,8 +1174,8 @@ public:
     string emitC() override { V3ERROR_NA_RETURN(""); }
     bool cleanOut() const override { return true; }
     bool isPure() override { return false; }
-    bool safeConversionLogicToBit() override;
-    bool getSafeConversion() const;
+    bool containsMemberAccess() override;
+    bool containsMemberAccessImpl() const;
     bool same(const AstNode*) const override { return true; }
 };
 class AstFError final : public AstNodeExpr {
@@ -1529,7 +1529,7 @@ public:
     int instrCount() const override { return widthInstrs(); }
     AstVar* varp() const { return m_varp; }
     void varp(AstVar* nodep) { m_varp = nodep; }
-    bool safeConversionLogicToBit() override { return false; }
+    bool containsMemberAccess() override { return false; }
 };
 class AstNewCopy final : public AstNodeExpr {
     // New as shallow copy
@@ -2757,7 +2757,7 @@ public:
     bool signedFlavor() const override { return true; }
 };
 class AstLogAnd final : public AstNodeBiop {
-    VSafeConversionLogicToBit m_safeConversion;  // Cached result of safeConversionLogicToBit
+    VContainsMemberAccess m_containsMemberAccess;  // Cached result of containsMemberAccess
 public:
     AstLogAnd(FileLine* fl, AstNodeExpr* lhsp, AstNodeExpr* rhsp)
         : ASTGEN_SUPER_LogAnd(fl, lhsp, rhsp) {
@@ -2779,8 +2779,8 @@ public:
     bool sizeMattersLhs() const override { return false; }
     bool sizeMattersRhs() const override { return false; }
     int instrCount() const override { return widthInstrs() + INSTR_COUNT_BRANCH; }
-    bool safeConversionLogicToBit() override;
-    bool getSafeConversion();
+    bool containsMemberAccess() override;
+    bool containsMemberAccessImpl();
 };
 class AstLogIf final : public AstNodeBiop {
 public:
@@ -2806,7 +2806,7 @@ public:
     int instrCount() const override { return widthInstrs() + INSTR_COUNT_BRANCH; }
 };
 class AstLogOr final : public AstNodeBiop {
-    VSafeConversionLogicToBit m_safeConversion;  // Cached result of safeConversionLogicToBit
+    VContainsMemberAccess m_containsMemberAccess;  // Cached result of containsMemberAccess
 public:
     AstLogOr(FileLine* fl, AstNodeExpr* lhsp, AstNodeExpr* rhsp)
         : ASTGEN_SUPER_LogOr(fl, lhsp, rhsp) {
@@ -2828,8 +2828,8 @@ public:
     bool sizeMattersLhs() const override { return false; }
     bool sizeMattersRhs() const override { return false; }
     int instrCount() const override { return widthInstrs() + INSTR_COUNT_BRANCH; }
-    bool safeConversionLogicToBit() override;
-    bool getSafeConversion();
+    bool containsMemberAccess() override;
+    bool containsMemberAccessImpl();
 };
 class AstLt final : public AstNodeBiop {
 public:
@@ -4162,7 +4162,7 @@ public:
         BROKEN_RTN(!fromp());
         return nullptr;
     }
-    bool safeConversionLogicToBit() override { return false; }
+    bool containsMemberAccess() override { return false; }
 };
 class AstNew final : public AstNodeFTaskRef {
     // New as constructor

--- a/src/V3AstNodeExpr.h
+++ b/src/V3AstNodeExpr.h
@@ -2775,9 +2775,10 @@ public:
     bool sizeMattersRhs() const override { return false; }
     int instrCount() const override { return widthInstrs() + INSTR_COUNT_BRANCH; }
     bool containsMemberAccess() override;
+    const char* broken() const override;
 
 private:
-    bool containsMemberAccessImpl();
+    bool containsMemberAccessImpl() const;
 };
 class AstLogIf final : public AstNodeBiop {
 public:
@@ -2826,9 +2827,10 @@ public:
     bool sizeMattersRhs() const override { return false; }
     int instrCount() const override { return widthInstrs() + INSTR_COUNT_BRANCH; }
     bool containsMemberAccess() override;
+    const char* broken() const override;
 
 private:
-    bool containsMemberAccessImpl();
+    bool containsMemberAccessImpl() const;
 };
 class AstLt final : public AstNodeBiop {
 public:

--- a/src/V3AstNodeExpr.h
+++ b/src/V3AstNodeExpr.h
@@ -229,6 +229,7 @@ class AstNodeFTaskRef VL_NOT_FINAL : public AstNodeExpr {
     string m_inlinedDots;  // Dotted hierarchy flattened out
     bool m_pli = false;  // Pli system call ($name)
     VPurity m_purity;  // Pure state
+    VSafeConversionLogicToBit m_safeConversion;  // Cached result of safeConversionLogicToBit
 
 protected:
     AstNodeFTaskRef(VNType t, FileLine* fl, AstNode* namep, AstNodeExpr* pinsp)
@@ -261,6 +262,8 @@ public:
     bool pli() const { return m_pli; }
     void pli(bool flag) { m_pli = flag; }
     bool isPure() override;
+    bool safeConversionLogicToBit() override;
+    bool getSafeConversion() const;
 
     string emitVerilog() final override { V3ERROR_NA_RETURN(""); }
     string emitC() final override { V3ERROR_NA_RETURN(""); }
@@ -1157,6 +1160,7 @@ class AstExprStmt final : public AstNodeExpr {
     // resultp is evaluated AFTER the statement(s).
     // @astgen op1 := stmtsp : List[AstNode]
     // @astgen op2 := resultp : AstNodeExpr
+    VSafeConversionLogicToBit m_safeConversion;  // Cached result of safeConversionLogicToBit
 public:
     AstExprStmt(FileLine* fl, AstNode* stmtsp, AstNodeExpr* resultp)
         : ASTGEN_SUPER_ExprStmt(fl) {
@@ -1170,6 +1174,8 @@ public:
     string emitC() override { V3ERROR_NA_RETURN(""); }
     bool cleanOut() const override { return true; }
     bool isPure() override { return false; }
+    bool safeConversionLogicToBit() override;
+    bool getSafeConversion() const;
     bool same(const AstNode*) const override { return true; }
 };
 class AstFError final : public AstNodeExpr {

--- a/src/V3AstNodeExpr.h
+++ b/src/V3AstNodeExpr.h
@@ -215,6 +215,7 @@ public:
     string emitVerilog() final override { V3ERROR_NA_RETURN(""); }
     string emitC() final override { V3ERROR_NA_RETURN(""); }
     bool cleanOut() const final override { return true; }
+    bool containsMemberAccess() override;
 };
 class AstNodeFTaskRef VL_NOT_FINAL : public AstNodeExpr {
     // A reference to a task (or function)

--- a/src/V3AstNodeExpr.h
+++ b/src/V3AstNodeExpr.h
@@ -262,7 +262,6 @@ public:
     void pli(bool flag) { m_pli = flag; }
     bool isPure() override;
     bool containsMemberAccess() override;
-
     string emitVerilog() final override { V3ERROR_NA_RETURN(""); }
     string emitC() final override { V3ERROR_NA_RETURN(""); }
     bool cleanOut() const final override { V3ERROR_NA_RETURN(true); }
@@ -2776,6 +2775,7 @@ public:
     bool sizeMattersRhs() const override { return false; }
     int instrCount() const override { return widthInstrs() + INSTR_COUNT_BRANCH; }
     bool containsMemberAccess() override;
+private:
     bool containsMemberAccessImpl();
 };
 class AstLogIf final : public AstNodeBiop {
@@ -2825,6 +2825,7 @@ public:
     bool sizeMattersRhs() const override { return false; }
     int instrCount() const override { return widthInstrs() + INSTR_COUNT_BRANCH; }
     bool containsMemberAccess() override;
+private:
     bool containsMemberAccessImpl();
 };
 class AstLt final : public AstNodeBiop {

--- a/src/V3AstNodeExpr.h
+++ b/src/V3AstNodeExpr.h
@@ -229,7 +229,6 @@ class AstNodeFTaskRef VL_NOT_FINAL : public AstNodeExpr {
     string m_inlinedDots;  // Dotted hierarchy flattened out
     bool m_pli = false;  // Pli system call ($name)
     VPurity m_purity;  // Pure state
-    VContainsMemberAccess m_containsMemberAccess;  // Cached result of containsMemberAccess
 
 protected:
     AstNodeFTaskRef(VNType t, FileLine* fl, AstNode* namep, AstNodeExpr* pinsp)
@@ -263,7 +262,6 @@ public:
     void pli(bool flag) { m_pli = flag; }
     bool isPure() override;
     bool containsMemberAccess() override;
-    bool containsMemberAccessImpl() const;
 
     string emitVerilog() final override { V3ERROR_NA_RETURN(""); }
     string emitC() final override { V3ERROR_NA_RETURN(""); }
@@ -1160,7 +1158,6 @@ class AstExprStmt final : public AstNodeExpr {
     // resultp is evaluated AFTER the statement(s).
     // @astgen op1 := stmtsp : List[AstNode]
     // @astgen op2 := resultp : AstNodeExpr
-    VContainsMemberAccess m_containsMemberAccess;  // Cached result of containsMemberAccess
 public:
     AstExprStmt(FileLine* fl, AstNode* stmtsp, AstNodeExpr* resultp)
         : ASTGEN_SUPER_ExprStmt(fl) {
@@ -1175,7 +1172,6 @@ public:
     bool cleanOut() const override { return true; }
     bool isPure() override { return false; }
     bool containsMemberAccess() override;
-    bool containsMemberAccessImpl() const;
     bool same(const AstNode*) const override { return true; }
 };
 class AstFError final : public AstNodeExpr {

--- a/src/V3AstNodeExpr.h
+++ b/src/V3AstNodeExpr.h
@@ -1171,7 +1171,6 @@ public:
     string emitC() override { V3ERROR_NA_RETURN(""); }
     bool cleanOut() const override { return true; }
     bool isPure() override { return false; }
-    bool containsMemberAccess() override;
     bool same(const AstNode*) const override { return true; }
 };
 class AstFError final : public AstNodeExpr {

--- a/src/V3AstNodeExpr.h
+++ b/src/V3AstNodeExpr.h
@@ -4122,6 +4122,7 @@ public:
         BROKEN_RTN(!fromp());
         return nullptr;
     }
+    bool containsMemberAccess() override { return true; }
 };
 class AstCNew final : public AstNodeCCall {
     // C++ new() call

--- a/src/V3AstNodeExpr.h
+++ b/src/V3AstNodeExpr.h
@@ -1523,6 +1523,7 @@ public:
     int instrCount() const override { return widthInstrs(); }
     AstVar* varp() const { return m_varp; }
     void varp(AstVar* nodep) { m_varp = nodep; }
+    bool safeConversionLogicToBit() override { return false; }
 };
 class AstNewCopy final : public AstNodeExpr {
     // New as shallow copy
@@ -2750,6 +2751,7 @@ public:
     bool signedFlavor() const override { return true; }
 };
 class AstLogAnd final : public AstNodeBiop {
+    VSafeConversionLogicToBit m_safeConversion;  // Cached result of safeConversionLogicToBit
 public:
     AstLogAnd(FileLine* fl, AstNodeExpr* lhsp, AstNodeExpr* rhsp)
         : ASTGEN_SUPER_LogAnd(fl, lhsp, rhsp) {
@@ -2771,6 +2773,8 @@ public:
     bool sizeMattersLhs() const override { return false; }
     bool sizeMattersRhs() const override { return false; }
     int instrCount() const override { return widthInstrs() + INSTR_COUNT_BRANCH; }
+    bool safeConversionLogicToBit() override;
+    bool getSafeConversion();
 };
 class AstLogIf final : public AstNodeBiop {
 public:
@@ -2796,6 +2800,7 @@ public:
     int instrCount() const override { return widthInstrs() + INSTR_COUNT_BRANCH; }
 };
 class AstLogOr final : public AstNodeBiop {
+    VSafeConversionLogicToBit m_safeConversion;  // Cached result of safeConversionLogicToBit
 public:
     AstLogOr(FileLine* fl, AstNodeExpr* lhsp, AstNodeExpr* rhsp)
         : ASTGEN_SUPER_LogOr(fl, lhsp, rhsp) {
@@ -2817,6 +2822,8 @@ public:
     bool sizeMattersLhs() const override { return false; }
     bool sizeMattersRhs() const override { return false; }
     int instrCount() const override { return widthInstrs() + INSTR_COUNT_BRANCH; }
+    bool safeConversionLogicToBit() override;
+    bool getSafeConversion();
 };
 class AstLt final : public AstNodeBiop {
 public:
@@ -4149,6 +4156,7 @@ public:
         BROKEN_RTN(!fromp());
         return nullptr;
     }
+    bool safeConversionLogicToBit() override { return false; }
 };
 class AstNew final : public AstNodeFTaskRef {
     // New as constructor

--- a/src/V3AstNodeExpr.h
+++ b/src/V3AstNodeExpr.h
@@ -1529,7 +1529,7 @@ public:
     int instrCount() const override { return widthInstrs(); }
     AstVar* varp() const { return m_varp; }
     void varp(AstVar* nodep) { m_varp = nodep; }
-    bool containsMemberAccess() override { return false; }
+    bool containsMemberAccess() override { return true; }
 };
 class AstNewCopy final : public AstNodeExpr {
     // New as shallow copy
@@ -4162,7 +4162,7 @@ public:
         BROKEN_RTN(!fromp());
         return nullptr;
     }
-    bool containsMemberAccess() override { return false; }
+    bool containsMemberAccess() override { return true; }
 };
 class AstNew final : public AstNodeFTaskRef {
     // New as constructor

--- a/src/V3AstNodeExpr.h
+++ b/src/V3AstNodeExpr.h
@@ -2775,6 +2775,7 @@ public:
     bool sizeMattersRhs() const override { return false; }
     int instrCount() const override { return widthInstrs() + INSTR_COUNT_BRANCH; }
     bool containsMemberAccess() override;
+
 private:
     bool containsMemberAccessImpl();
 };
@@ -2825,6 +2826,7 @@ public:
     bool sizeMattersRhs() const override { return false; }
     int instrCount() const override { return widthInstrs() + INSTR_COUNT_BRANCH; }
     bool containsMemberAccess() override;
+
 private:
     bool containsMemberAccessImpl();
 };

--- a/src/V3AstNodeOther.h
+++ b/src/V3AstNodeOther.h
@@ -185,7 +185,6 @@ public:
     bool isFirstInMyListOfStatements(AstNode* n) const override { return n == stmtsp(); }
     bool isPure() override;
     bool containsMemberAccess() override;
-    bool containsMemberAccessImpl() const;
     const char* broken() const override;
     void propagateAttrFrom(const AstNodeFTask* fromp) {
         // Creating a wrapper with e.g. cloneType(); preserve some attributes
@@ -199,6 +198,7 @@ public:
 
 private:
     bool getPurity() const;
+    bool containsMemberAccessImpl() const;
 };
 class AstNodeFile VL_NOT_FINAL : public AstNode {
     // Emitted Output file

--- a/src/V3AstNodeOther.h
+++ b/src/V3AstNodeOther.h
@@ -89,6 +89,7 @@ private:
     bool m_needProcess : 1;  // Implements part of a process that allocates std::process
     VLifetime m_lifetime;  // Lifetime
     VPurity m_purity;  // Pure state
+    VSafeConversionLogicToBit m_safeConversion;  // Cached result of safeConversionLogicToBit
 
 protected:
     AstNodeFTask(VNType t, FileLine* fl, const string& name, AstNode* stmtsp)
@@ -183,6 +184,8 @@ public:
     VLifetime lifetime() const { return m_lifetime; }
     bool isFirstInMyListOfStatements(AstNode* n) const override { return n == stmtsp(); }
     bool isPure() override;
+    bool safeConversionLogicToBit() override;
+    bool getSafeConversion() const;
     const char* broken() const override;
     void propagateAttrFrom(const AstNodeFTask* fromp) {
         // Creating a wrapper with e.g. cloneType(); preserve some attributes

--- a/src/V3AstNodeOther.h
+++ b/src/V3AstNodeOther.h
@@ -722,6 +722,7 @@ public:
                && finalsp() == nullptr;
     }
     bool containsMemberAccess() override;
+
 private:
     bool containsMemberAccessImpl() const;
 };

--- a/src/V3AstNodeOther.h
+++ b/src/V3AstNodeOther.h
@@ -608,6 +608,7 @@ private:
     bool m_dpiImportWrapper : 1;  // Wrapper for invoking DPI import prototype from generated code
     bool m_dpiTraceInit : 1;  // DPI trace_init
     bool m_needProcess : 1;  // Implements part of a process that allocates std::process
+    VContainsMemberAccess m_containsMemberAccess;  // Cached result of containsMemberAccess
 public:
     AstCFunc(FileLine* fl, const string& name, AstScope* scopep, const string& rtnType = "")
         : ASTGEN_SUPER_CFunc(fl) {
@@ -720,6 +721,9 @@ public:
         return argsp() == nullptr && initsp() == nullptr && stmtsp() == nullptr
                && finalsp() == nullptr;
     }
+    bool containsMemberAccess() override;
+private:
+    bool containsMemberAccessImpl() const;
 };
 class AstCLocalScope final : public AstNode {
     // Pack statements into an unnamed scope when generating C++

--- a/src/V3AstNodeOther.h
+++ b/src/V3AstNodeOther.h
@@ -608,6 +608,7 @@ private:
     bool m_dpiImportWrapper : 1;  // Wrapper for invoking DPI import prototype from generated code
     bool m_dpiTraceInit : 1;  // DPI trace_init
     bool m_needProcess : 1;  // Implements part of a process that allocates std::process
+    bool m_recursive : 1;  // Recursive or part of recursion
     VContainsMemberAccess m_containsMemberAccess;  // Cached result of containsMemberAccess
 public:
     AstCFunc(FileLine* fl, const string& name, AstScope* scopep, const string& rtnType = "")
@@ -637,6 +638,7 @@ public:
         m_dpiImportPrototype = false;
         m_dpiImportWrapper = false;
         m_dpiTraceInit = false;
+        m_recursive = false;
     }
     ASTGEN_MEMBERS_AstCFunc;
     string name() const override VL_MT_STABLE { return m_name; }
@@ -716,6 +718,8 @@ public:
     void dpiTraceInit(bool flag) { m_dpiTraceInit = flag; }
     bool dpiTraceInit() const { return m_dpiTraceInit; }
     bool isCoroutine() const { return m_rtnType == "VlCoroutine"; }
+    void recursive(bool flag) { m_recursive = flag; }
+    bool recursive() const { return m_recursive; }
     // Special methods
     bool emptyBody() const {
         return argsp() == nullptr && initsp() == nullptr && stmtsp() == nullptr

--- a/src/V3AstNodeOther.h
+++ b/src/V3AstNodeOther.h
@@ -89,7 +89,7 @@ private:
     bool m_needProcess : 1;  // Implements part of a process that allocates std::process
     VLifetime m_lifetime;  // Lifetime
     VPurity m_purity;  // Pure state
-    VSafeConversionLogicToBit m_safeConversion;  // Cached result of safeConversionLogicToBit
+    VContainsMemberAccess m_containsMemberAccess;  // Cached result of containsMemberAccess
 
 protected:
     AstNodeFTask(VNType t, FileLine* fl, const string& name, AstNode* stmtsp)
@@ -184,8 +184,8 @@ public:
     VLifetime lifetime() const { return m_lifetime; }
     bool isFirstInMyListOfStatements(AstNode* n) const override { return n == stmtsp(); }
     bool isPure() override;
-    bool safeConversionLogicToBit() override;
-    bool getSafeConversion() const;
+    bool containsMemberAccess() override;
+    bool containsMemberAccessImpl() const;
     const char* broken() const override;
     void propagateAttrFrom(const AstNodeFTask* fromp) {
         // Creating a wrapper with e.g. cloneType(); preserve some attributes

--- a/src/V3AstNodes.cpp
+++ b/src/V3AstNodes.cpp
@@ -91,21 +91,21 @@ bool AstNodeFTaskRef::getPurity() const {
     return taskp->isPure();
 }
 
-bool AstNodeFTaskRef::safeConversionLogicToBit() {
-    if (!m_safeConversion.isCached()) m_safeConversion.set(getSafeConversion());
-    return m_safeConversion.isSafe();
+bool AstNodeFTaskRef::containsMemberAccess() {
+    if (!m_containsMemberAccess.isCached()) m_containsMemberAccess.set(containsMemberAccessImpl());
+    return m_containsMemberAccess.isSafe();
 }
-bool AstNodeFTaskRef::getSafeConversion() const {
+bool AstNodeFTaskRef::containsMemberAccessImpl() const {
     AstNodeFTask* const taskp = this->taskp();
     // Unlinked yet, so treat as unsafe
     if (!taskp) return false;
 
     // First compute the safety of arguments
     for (AstNode* pinp = this->pinsp(); pinp; pinp = pinp->nextp()) {
-        if (!pinp->safeConversionLogicToBit()) return false;
+        if (!pinp->containsMemberAccess()) return false;
     }
 
-    return taskp->getSafeConversion();
+    return taskp->containsMemberAccessImpl();
 }
 
 bool AstNodeFTaskRef::isGateOptimizable() const { return m_taskp && m_taskp->isGateOptimizable(); }
@@ -997,29 +997,29 @@ AstNode* AstArraySel::baseFromp(AstNode* nodep, bool overMembers) {
     return nodep;
 }
 
-bool AstLogAnd::safeConversionLogicToBit() {
-    if (!m_safeConversion.isCached()) m_safeConversion.set(getSafeConversion());
-    return m_safeConversion.isSafe();
+bool AstLogAnd::containsMemberAccess() {
+    if (!m_containsMemberAccess.isCached()) m_containsMemberAccess.set(containsMemberAccessImpl());
+    return m_containsMemberAccess.isSafe();
 }
-bool AstLogAnd::getSafeConversion() {
+bool AstLogAnd::containsMemberAccessImpl() {
     if (!lhsp()->width1()) return false;
     if (!rhsp()->width1()) return false;
     if (!isPure()) return false;
-    if (!lhsp()->safeConversionLogicToBit()) return false;
-    if (!rhsp()->safeConversionLogicToBit()) return false;
+    if (!lhsp()->containsMemberAccess()) return false;
+    if (!rhsp()->containsMemberAccess()) return false;
     return true;
 }
 
-bool AstLogOr::safeConversionLogicToBit() {
-    if (!m_safeConversion.isCached()) m_safeConversion.set(getSafeConversion());
-    return m_safeConversion.isSafe();
+bool AstLogOr::containsMemberAccess() {
+    if (!m_containsMemberAccess.isCached()) m_containsMemberAccess.set(containsMemberAccessImpl());
+    return m_containsMemberAccess.isSafe();
 }
-bool AstLogOr::getSafeConversion() {
+bool AstLogOr::containsMemberAccessImpl() {
     if (!lhsp()->width1()) return false;
     if (!rhsp()->width1()) return false;
     if (!isPure()) return false;
-    if (!lhsp()->safeConversionLogicToBit()) return false;
-    if (!rhsp()->safeConversionLogicToBit()) return false;
+    if (!lhsp()->containsMemberAccess()) return false;
+    if (!rhsp()->containsMemberAccess()) return false;
     return true;
 }
 
@@ -2358,13 +2358,13 @@ bool AstNodeFTask::isPure() {
     if (!m_purity.isCached()) m_purity.setPurity(getPurity());
     return m_purity.isPure();
 }
-bool AstNodeFTask::safeConversionLogicToBit() {
-    if (!m_safeConversion.isCached()) m_safeConversion.set(getSafeConversion());
-    return m_safeConversion.isSafe();
+bool AstNodeFTask::containsMemberAccess() {
+    if (!m_containsMemberAccess.isCached()) m_containsMemberAccess.set(containsMemberAccessImpl());
+    return m_containsMemberAccess.isSafe();
 }
-bool AstNodeFTask::getSafeConversion() const {
+bool AstNodeFTask::containsMemberAccessImpl() const {
     for (AstNode* stmtp = stmtsp(); stmtp; stmtp = stmtp->nextp()) {
-        if (!stmtp->safeConversionLogicToBit()) return false;
+        if (!stmtp->containsMemberAccess()) return false;
     }
     return true;
 }
@@ -2389,15 +2389,15 @@ bool AstNodeFTask::getPurity() const {
     }
     return true;
 }
-bool AstExprStmt::safeConversionLogicToBit() {
-    if (!m_safeConversion.isCached()) m_safeConversion.set(getSafeConversion());
-    return m_safeConversion.isSafe();
+bool AstExprStmt::containsMemberAccess() {
+    if (!m_containsMemberAccess.isCached()) m_containsMemberAccess.set(containsMemberAccessImpl());
+    return m_containsMemberAccess.isSafe();
 }
-bool AstExprStmt::getSafeConversion() const {
+bool AstExprStmt::containsMemberAccessImpl() const {
     for (AstNode* stmtp = stmtsp(); stmtp; stmtp = stmtp->nextp()) {
-        if (!stmtp->safeConversionLogicToBit()) return false;
+        if (!stmtp->containsMemberAccess()) return false;
     }
-    if (!resultp()->safeConversionLogicToBit()) return false;
+    if (!resultp()->containsMemberAccess()) return false;
     return true;
 }
 void AstNodeBlock::dump(std::ostream& str) const {

--- a/src/V3AstNodes.cpp
+++ b/src/V3AstNodes.cpp
@@ -2402,13 +2402,6 @@ bool AstNodeFTask::getPurity() const {
     }
     return true;
 }
-bool AstExprStmt::containsMemberAccess() {
-    for (AstNode* stmtp = stmtsp(); stmtp; stmtp = stmtp->nextp()) {
-        if (stmtp->containsMemberAccess()) return true;
-    }
-    if (resultp()->containsMemberAccess()) return true;
-    return false;
-}
 void AstNodeBlock::dump(std::ostream& str) const {
     this->AstNode::dump(str);
     if (unnamed()) str << " [UNNAMED]";

--- a/src/V3AstNodes.cpp
+++ b/src/V3AstNodes.cpp
@@ -979,6 +979,32 @@ AstNode* AstArraySel::baseFromp(AstNode* nodep, bool overMembers) {
     return nodep;
 }
 
+bool AstLogAnd::safeConversionLogicToBit() {
+    if (!m_safeConversion.isCached()) m_safeConversion.set(getSafeConversion());
+    return m_safeConversion.isSafe();
+}
+bool AstLogAnd::getSafeConversion() {
+    if (!lhsp()->width1()) return false;
+    if (!rhsp()->width1()) return false;
+    if (!isPure()) return false;
+    if (!lhsp()->safeConversionLogicToBit()) return false;
+    if (!rhsp()->safeConversionLogicToBit()) return false;
+    return true;
+}
+
+bool AstLogOr::safeConversionLogicToBit() {
+    if (!m_safeConversion.isCached()) m_safeConversion.set(getSafeConversion());
+    return m_safeConversion.isSafe();
+}
+bool AstLogOr::getSafeConversion() {
+    if (!lhsp()->width1()) return false;
+    if (!rhsp()->width1()) return false;
+    if (!isPure()) return false;
+    if (!lhsp()->safeConversionLogicToBit()) return false;
+    if (!rhsp()->safeConversionLogicToBit()) return false;
+    return true;
+}
+
 const char* AstJumpBlock::broken() const {
     BROKEN_RTN(!labelp()->brokeExistsBelow());
     return nullptr;
@@ -2313,6 +2339,16 @@ void AstNodeFTask::dump(std::ostream& str) const {
 bool AstNodeFTask::isPure() {
     if (!m_purity.isCached()) m_purity.setPurity(getPurity());
     return m_purity.isPure();
+}
+bool AstNodeFTask::safeConversionLogicToBit() {
+    if (!m_safeConversion.isCached()) m_safeConversion.set(getSafeConversion());
+    return m_safeConversion.isSafe();
+}
+bool AstNodeFTask::getSafeConversion() const {
+    for (AstNode* stmtp = stmtsp(); stmtp; stmtp = stmtp->nextp()) {
+        if (!stmtp->safeConversionLogicToBit()) return false;
+    }
+    return true;
 }
 const char* AstNodeFTask::broken() const {
     BROKEN_RTN(m_purity.isCached() && m_purity.isPure() != getPurity());

--- a/src/V3AstNodes.cpp
+++ b/src/V3AstNodes.cpp
@@ -2373,6 +2373,7 @@ bool AstNodeFTask::containsMemberAccess() {
     return m_containsMemberAccess.get();
 }
 bool AstNodeFTask::containsMemberAccessImpl() const {
+    if (this->recursive()) return true;
     for (AstNode* stmtp = stmtsp(); stmtp; stmtp = stmtp->nextp()) {
         if (stmtp->containsMemberAccess()) return true;
     }
@@ -2598,6 +2599,7 @@ bool AstCFunc::containsMemberAccess() {
     return m_containsMemberAccess.get();
 }
 bool AstCFunc::containsMemberAccessImpl() const {
+    if (this->recursive()) return true;
     for (AstNode* stmtp = initsp(); stmtp; stmtp = stmtp->nextp()) {
         if (stmtp->containsMemberAccess()) return true;
     }

--- a/src/V3AstNodes.cpp
+++ b/src/V3AstNodes.cpp
@@ -101,7 +101,7 @@ bool AstNodeFTaskRef::containsMemberAccess() {
         if (pinp->containsMemberAccess()) return true;
     }
 
-    return taskp->containsMemberAccessImpl();
+    return taskp->containsMemberAccess();
 }
 
 bool AstNodeFTaskRef::isGateOptimizable() const { return m_taskp && m_taskp->isGateOptimizable(); }

--- a/src/V3AstNodes.cpp
+++ b/src/V3AstNodes.cpp
@@ -995,7 +995,7 @@ AstNode* AstArraySel::baseFromp(AstNode* nodep, bool overMembers) {
 
 bool AstLogAnd::containsMemberAccess() {
     if (!m_containsMemberAccess.isCached()) m_containsMemberAccess.set(containsMemberAccessImpl());
-    return m_containsMemberAccess.isSafe();
+    return m_containsMemberAccess.get();
 }
 bool AstLogAnd::containsMemberAccessImpl() {
     if (lhsp()->containsMemberAccess()) return true;
@@ -1005,7 +1005,7 @@ bool AstLogAnd::containsMemberAccessImpl() {
 
 bool AstLogOr::containsMemberAccess() {
     if (!m_containsMemberAccess.isCached()) m_containsMemberAccess.set(containsMemberAccessImpl());
-    return m_containsMemberAccess.isSafe();
+    return m_containsMemberAccess.get();
 }
 bool AstLogOr::containsMemberAccessImpl() {
     if (lhsp()->containsMemberAccess()) return true;
@@ -2350,7 +2350,7 @@ bool AstNodeFTask::isPure() {
 }
 bool AstNodeFTask::containsMemberAccess() {
     if (!m_containsMemberAccess.isCached()) m_containsMemberAccess.set(containsMemberAccessImpl());
-    return m_containsMemberAccess.isSafe();
+    return m_containsMemberAccess.get();
 }
 bool AstNodeFTask::containsMemberAccessImpl() const {
     for (AstNode* stmtp = stmtsp(); stmtp; stmtp = stmtp->nextp()) {

--- a/src/V3AstNodes.cpp
+++ b/src/V3AstNodes.cpp
@@ -97,12 +97,12 @@ bool AstNodeFTaskRef::containsMemberAccess() {
 }
 bool AstNodeFTaskRef::containsMemberAccessImpl() const {
     AstNodeFTask* const taskp = this->taskp();
-    // Unlinked yet, so treat as unsafe
-    if (!taskp) return false;
+    // Unlinked yet, so assume that it contains
+    if (!taskp) return true;
 
     // First compute the safety of arguments
     for (AstNode* pinp = this->pinsp(); pinp; pinp = pinp->nextp()) {
-        if (!pinp->containsMemberAccess()) return false;
+        if (pinp->containsMemberAccess()) return true;
     }
 
     return taskp->containsMemberAccessImpl();
@@ -1002,12 +1002,9 @@ bool AstLogAnd::containsMemberAccess() {
     return m_containsMemberAccess.isSafe();
 }
 bool AstLogAnd::containsMemberAccessImpl() {
-    if (!lhsp()->width1()) return false;
-    if (!rhsp()->width1()) return false;
-    if (!isPure()) return false;
-    if (!lhsp()->containsMemberAccess()) return false;
-    if (!rhsp()->containsMemberAccess()) return false;
-    return true;
+    if (lhsp()->containsMemberAccess()) return true;
+    if (rhsp()->containsMemberAccess()) return true;
+    return false;
 }
 
 bool AstLogOr::containsMemberAccess() {
@@ -1015,12 +1012,9 @@ bool AstLogOr::containsMemberAccess() {
     return m_containsMemberAccess.isSafe();
 }
 bool AstLogOr::containsMemberAccessImpl() {
-    if (!lhsp()->width1()) return false;
-    if (!rhsp()->width1()) return false;
-    if (!isPure()) return false;
-    if (!lhsp()->containsMemberAccess()) return false;
-    if (!rhsp()->containsMemberAccess()) return false;
-    return true;
+    if (lhsp()->containsMemberAccess()) return true;
+    if (rhsp()->containsMemberAccess()) return true;
+    return false;
 }
 
 const char* AstJumpBlock::broken() const {
@@ -2364,9 +2358,9 @@ bool AstNodeFTask::containsMemberAccess() {
 }
 bool AstNodeFTask::containsMemberAccessImpl() const {
     for (AstNode* stmtp = stmtsp(); stmtp; stmtp = stmtp->nextp()) {
-        if (!stmtp->containsMemberAccess()) return false;
+        if (stmtp->containsMemberAccess()) return true;
     }
-    return true;
+    return false;
 }
 const char* AstNodeFTask::broken() const {
     BROKEN_RTN(m_purity.isCached() && m_purity.isPure() != getPurity());
@@ -2395,10 +2389,10 @@ bool AstExprStmt::containsMemberAccess() {
 }
 bool AstExprStmt::containsMemberAccessImpl() const {
     for (AstNode* stmtp = stmtsp(); stmtp; stmtp = stmtp->nextp()) {
-        if (!stmtp->containsMemberAccess()) return false;
+        if (stmtp->containsMemberAccess()) return true;
     }
-    if (!resultp()->containsMemberAccess()) return false;
-    return true;
+    if (resultp()->containsMemberAccess()) return true;
+    return false;
 }
 void AstNodeBlock::dump(std::ostream& str) const {
     this->AstNode::dump(str);

--- a/src/V3AstNodes.cpp
+++ b/src/V3AstNodes.cpp
@@ -92,10 +92,6 @@ bool AstNodeFTaskRef::getPurity() const {
 }
 
 bool AstNodeFTaskRef::containsMemberAccess() {
-    if (!m_containsMemberAccess.isCached()) m_containsMemberAccess.set(containsMemberAccessImpl());
-    return m_containsMemberAccess.isSafe();
-}
-bool AstNodeFTaskRef::containsMemberAccessImpl() const {
     AstNodeFTask* const taskp = this->taskp();
     // Unlinked yet, so assume that it contains
     if (!taskp) return true;
@@ -2384,10 +2380,6 @@ bool AstNodeFTask::getPurity() const {
     return true;
 }
 bool AstExprStmt::containsMemberAccess() {
-    if (!m_containsMemberAccess.isCached()) m_containsMemberAccess.set(containsMemberAccessImpl());
-    return m_containsMemberAccess.isSafe();
-}
-bool AstExprStmt::containsMemberAccessImpl() const {
     for (AstNode* stmtp = stmtsp(); stmtp; stmtp = stmtp->nextp()) {
         if (stmtp->containsMemberAccess()) return true;
     }

--- a/src/V3AstNodes.cpp
+++ b/src/V3AstNodes.cpp
@@ -997,20 +997,30 @@ bool AstLogAnd::containsMemberAccess() {
     if (!m_containsMemberAccess.isCached()) m_containsMemberAccess.set(containsMemberAccessImpl());
     return m_containsMemberAccess.get();
 }
-bool AstLogAnd::containsMemberAccessImpl() {
+bool AstLogAnd::containsMemberAccessImpl() const {
     if (lhsp()->containsMemberAccess()) return true;
     if (rhsp()->containsMemberAccess()) return true;
     return false;
+}
+const char* AstLogAnd::broken() const {
+    BROKEN_RTN(m_containsMemberAccess.isCached()
+               && m_containsMemberAccess.get() != containsMemberAccessImpl());
+    return nullptr;
 }
 
 bool AstLogOr::containsMemberAccess() {
     if (!m_containsMemberAccess.isCached()) m_containsMemberAccess.set(containsMemberAccessImpl());
     return m_containsMemberAccess.get();
 }
-bool AstLogOr::containsMemberAccessImpl() {
+bool AstLogOr::containsMemberAccessImpl() const {
     if (lhsp()->containsMemberAccess()) return true;
     if (rhsp()->containsMemberAccess()) return true;
     return false;
+}
+const char* AstLogOr::broken() const {
+    BROKEN_RTN(m_containsMemberAccess.isCached()
+               && m_containsMemberAccess.get() != containsMemberAccessImpl());
+    return nullptr;
 }
 
 const char* AstJumpBlock::broken() const {
@@ -2360,6 +2370,8 @@ bool AstNodeFTask::containsMemberAccessImpl() const {
 }
 const char* AstNodeFTask::broken() const {
     BROKEN_RTN(m_purity.isCached() && m_purity.isPure() != getPurity());
+    BROKEN_RTN(m_containsMemberAccess.isCached()
+               && m_containsMemberAccess.get() != containsMemberAccessImpl());
     return nullptr;
 }
 bool AstNodeFTask::getPurity() const {

--- a/src/V3Const.cpp
+++ b/src/V3Const.cpp
@@ -2327,6 +2327,14 @@ private:
         iterate(nodep);  // Again?
     }
 
+    bool mayConvertToBitwise(AstNodeBiop* const nodep) {
+        if (!nodep->lhsp()->width1()) return false;
+        if (!nodep->rhsp()->width1()) return false;
+        if (!nodep->isPure()) return false;
+        if (nodep->containsMemberAccess()) return false;
+        return true;
+    }
+
     bool matchConcatRand(AstConcat* nodep) {
         //    CONCAT(RAND, RAND) - created by Chisel code
         AstRand* const aRandp = VN_CAST(nodep->lhsp(), Rand);
@@ -3585,8 +3593,8 @@ private:
     TREEOPV("AstOneHot{$lhsp.width1}",          "replaceWLhs(nodep)");
     TREEOPV("AstOneHot0{$lhsp.width1}",         "replaceNum(nodep,1)");
     // Binary AND/OR is faster than logical and/or (usually)
-    TREEOPV("AstLogAnd{nodep->containsMemberAccess()}", "AstAnd{$lhsp,$rhsp}");
-    TREEOPV("AstLogOr {nodep->containsMemberAccess()}", "AstOr{$lhsp,$rhsp}");
+    TREEOPV("AstLogAnd{mayConvertToBitwise(nodep)}", "AstAnd{$lhsp,$rhsp}");
+    TREEOPV("AstLogOr {mayConvertToBitwise(nodep)}", "AstOr{$lhsp,$rhsp}");
     TREEOPV("AstLogNot{$lhsp.width1}",  "AstNot{$lhsp}");
     // CONCAT(CONCAT({a},{b}),{c}) -> CONCAT({a},CONCAT({b},{c}))
     // CONCAT({const},CONCAT({const},{c})) -> CONCAT((constifiedCONC{const|const},{c}))

--- a/src/V3Const.cpp
+++ b/src/V3Const.cpp
@@ -2327,16 +2327,6 @@ private:
         iterate(nodep);  // Again?
     }
 
-    bool mayConvertToBitwise(AstNodeBiop* const nodep) {
-        if (!nodep->lhsp()->width1()) return false;
-        if (!nodep->rhsp()->width1()) return false;
-        if (!nodep->isPure()) return false;
-        if (nodep->exists([](const AstNodeExpr* const exprp) {
-                return VN_IS(exprp, MethodCall) || VN_IS(exprp, MemberSel);
-            }))
-            return false;
-        return true;
-    }
     bool matchConcatRand(AstConcat* nodep) {
         //    CONCAT(RAND, RAND) - created by Chisel code
         AstRand* const aRandp = VN_CAST(nodep->lhsp(), Rand);
@@ -3595,8 +3585,8 @@ private:
     TREEOPV("AstOneHot{$lhsp.width1}",          "replaceWLhs(nodep)");
     TREEOPV("AstOneHot0{$lhsp.width1}",         "replaceNum(nodep,1)");
     // Binary AND/OR is faster than logical and/or (usually)
-    TREEOPV("AstLogAnd{mayConvertToBitwise(nodep)}", "AstAnd{$lhsp,$rhsp}");
-    TREEOPV("AstLogOr {mayConvertToBitwise(nodep)}", "AstOr{$lhsp,$rhsp}");
+    TREEOPV("AstLogAnd{nodep->safeConversionLogicToBit()}", "AstAnd{$lhsp,$rhsp}");
+    TREEOPV("AstLogOr {nodep->safeConversionLogicToBit()}", "AstOr{$lhsp,$rhsp}");
     TREEOPV("AstLogNot{$lhsp.width1}",  "AstNot{$lhsp}");
     // CONCAT(CONCAT({a},{b}),{c}) -> CONCAT({a},CONCAT({b},{c}))
     // CONCAT({const},CONCAT({const},{c})) -> CONCAT((constifiedCONC{const|const},{c}))

--- a/src/V3Const.cpp
+++ b/src/V3Const.cpp
@@ -2327,6 +2327,16 @@ private:
         iterate(nodep);  // Again?
     }
 
+    bool mayConvertToBitwise(AstNodeBiop* const nodep) {
+        if (!nodep->lhsp()->width1()) return false;
+        if (!nodep->rhsp()->width1()) return false;
+        if (!nodep->isPure()) return false;
+        if (nodep->exists([](const AstNodeExpr* const exprp) {
+                return VN_IS(exprp, MethodCall) || VN_IS(exprp, MemberSel);
+            }))
+            return false;
+        return true;
+    }
     bool matchConcatRand(AstConcat* nodep) {
         //    CONCAT(RAND, RAND) - created by Chisel code
         AstRand* const aRandp = VN_CAST(nodep->lhsp(), Rand);
@@ -3585,8 +3595,8 @@ private:
     TREEOPV("AstOneHot{$lhsp.width1}",          "replaceWLhs(nodep)");
     TREEOPV("AstOneHot0{$lhsp.width1}",         "replaceNum(nodep,1)");
     // Binary AND/OR is faster than logical and/or (usually)
-    TREEOPV("AstLogAnd{$lhsp.width1, $rhsp.width1, nodep->isPure()}", "AstAnd{$lhsp,$rhsp}");
-    TREEOPV("AstLogOr {$lhsp.width1, $rhsp.width1, nodep->isPure()}", "AstOr{$lhsp,$rhsp}");
+    TREEOPV("AstLogAnd{mayConvertToBitwise(nodep)}", "AstAnd{$lhsp,$rhsp}");
+    TREEOPV("AstLogOr {mayConvertToBitwise(nodep)}", "AstOr{$lhsp,$rhsp}");
     TREEOPV("AstLogNot{$lhsp.width1}",  "AstNot{$lhsp}");
     // CONCAT(CONCAT({a},{b}),{c}) -> CONCAT({a},CONCAT({b},{c}))
     // CONCAT({const},CONCAT({const},{c})) -> CONCAT((constifiedCONC{const|const},{c}))

--- a/src/V3Const.cpp
+++ b/src/V3Const.cpp
@@ -3585,8 +3585,8 @@ private:
     TREEOPV("AstOneHot{$lhsp.width1}",          "replaceWLhs(nodep)");
     TREEOPV("AstOneHot0{$lhsp.width1}",         "replaceNum(nodep,1)");
     // Binary AND/OR is faster than logical and/or (usually)
-    TREEOPV("AstLogAnd{nodep->safeConversionLogicToBit()}", "AstAnd{$lhsp,$rhsp}");
-    TREEOPV("AstLogOr {nodep->safeConversionLogicToBit()}", "AstOr{$lhsp,$rhsp}");
+    TREEOPV("AstLogAnd{nodep->containsMemberAccess()}", "AstAnd{$lhsp,$rhsp}");
+    TREEOPV("AstLogOr {nodep->containsMemberAccess()}", "AstOr{$lhsp,$rhsp}");
     TREEOPV("AstLogNot{$lhsp.width1}",  "AstNot{$lhsp}");
     // CONCAT(CONCAT({a},{b}),{c}) -> CONCAT({a},CONCAT({b},{c}))
     // CONCAT({const},CONCAT({const},{c})) -> CONCAT((constifiedCONC{const|const},{c}))

--- a/src/V3Task.cpp
+++ b/src/V3Task.cpp
@@ -1226,6 +1226,7 @@ private:
         cfuncp->dpiExportImpl(nodep->dpiExport());
         cfuncp->dpiImportWrapper(nodep->dpiImport());
         cfuncp->dpiTraceInit(nodep->dpiTraceInit());
+        cfuncp->recursive(nodep->recursive());
         if (nodep->dpiImport() || nodep->dpiExport()) {
             cfuncp->isStatic(true);
             cfuncp->isLoose(true);

--- a/test_regress/t/t_class_short_circuit.pl
+++ b/test_regress/t/t_class_short_circuit.pl
@@ -1,0 +1,21 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2020 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_class_short_circuit.v
+++ b/test_regress/t/t_class_short_circuit.v
@@ -1,0 +1,33 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2023 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+class Cls;
+   int x;
+   function new;
+      x = 10;
+   endfunction
+   function bit set_x(int a);
+      x = a;
+      return 1;
+   endfunction
+   function int get_x;
+      return x;
+   endfunction
+endclass
+
+module t (/*AUTOARG*/);
+   initial begin
+      Cls cls;
+      if (cls != null && cls.x == 10) $stop;
+      if (cls != null && cls.get_x() == 10) $stop;
+      cls = new;
+      if (!cls.set_x(1) || cls.x != 1) $stop;
+      if (!cls.set_x(2) || cls.get_x() != 2) $stop;
+
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end
+endmodule


### PR DESCRIPTION
Logical expressions with member selects and method calls shouldn't be converted to bitwise expressions, because it may result in nullptr dereference. At the beginning I wanted to mark them as impure, but it would disable some optimizations and incrementation operations would throw errors, because they are currently only supported on pure operands. Member selects and calls of pure methods may be safely duplicated, so they are pure in some sense. So I just disabled the conversion of logical to bitwise operations if they contain method calls or member selects.