### PR TITLE
CI: Cancel previous runs for pull requests automatically

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
 
   build:
     concurrency:
-      group: ${{ github.job }}-${{ strategy.job-index }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
+      group: build-${{ strategy.job-index }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
       cancel-in-progress: true
     strategy:
       fail-fast: false
@@ -100,7 +100,7 @@ jobs:
   test:
     needs: build
     concurrency:
-      group: ${{ github.job }}-${{ strategy.job-index }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
+      group: test-${{ strategy.job-index }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
       cancel-in-progress: true
     strategy:
       fail-fast: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
 
   build:
     concurrency:
-      group: ${{ github.workflow }}-${{ strategy.job-index }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
+      group: ${{ github.job }}-${{ strategy.job-index }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
       cancel-in-progress: true
     strategy:
       fail-fast: false
@@ -100,7 +100,7 @@ jobs:
   test:
     needs: build
     concurrency:
-      group: ${{ github.workflow }}-${{ strategy.job-index }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
+      group: ${{ github.job }}-${{ strategy.job-index }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
       cancel-in-progress: true
     strategy:
       fail-fast: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,12 +23,13 @@ defaults:
     shell: bash
     working-directory: repo
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
 
   build:
-    concurrency:
-      group: build-${{ strategy.job-index }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
-      cancel-in-progress: true
     strategy:
       fail-fast: false
       matrix:
@@ -99,9 +100,6 @@ jobs:
 
   test:
     needs: build
-    concurrency:
-      group: test-${{ strategy.job-index }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
-      cancel-in-progress: true
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,9 @@ defaults:
 jobs:
 
   build:
+    concurrency:
+      group: ${{ github.workflow }}-${{ strategy.job-index }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
+      cancel-in-progress: true
     strategy:
       fail-fast: false
       matrix:
@@ -96,6 +99,9 @@ jobs:
 
   test:
     needs: build
+    concurrency:
+      group: ${{ github.workflow }}-${{ strategy.job-index }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
+      cancel-in-progress: true
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -28,7 +28,7 @@ jobs:
     name: run on windows
     runs-on: windows-latest
     concurrency:
-      group: ${{ github.job }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
+      group: windows-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
       cancel-in-progress: true
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -28,7 +28,7 @@ jobs:
     name: run on windows
     runs-on: windows-latest
     concurrency:
-      group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
+      group: ${{ github.job }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
       cancel-in-progress: true
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -27,6 +27,9 @@ jobs:
    windows:
     name: run on windows
     runs-on: windows-latest
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
+      cancel-in-progress: true
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -22,14 +22,15 @@ defaults:
   run:
     working-directory: repo
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
 
    windows:
     name: run on windows
     runs-on: windows-latest
-    concurrency:
-      group: windows-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
-      cancel-in-progress: true
     steps:
     - uses: actions/checkout@v3
       with:


### PR DESCRIPTION
This PR make it possible to automatically cancel CI runs for old commits after a new commit is pushed for PRs. It adds `concurrency` properties to handle the repeated runs [(doc here)](https://docs.github.com/en/actions/using-jobs/using-concurrency). This can save lots of time if contributors update their pulls but the last run is not finished (since the jobs require queuing). It only affects runs triggered by pulls but not by direct push to the repo.

Test:
[From PR](https://github.com/donlon/verilator/pull/3)
[From repo](https://github.com/donlon/verilator/commits/pr/ci-auto-cancel)