### PR TITLE
Style: Update clang-format config to make formatted code consistent between versions. No functional change

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -112,6 +112,9 @@ SpacesBeforeTrailingComments: 2
 SpacesInAngles:  false
 SpacesInContainerLiterals: true
 SpacesInCStyleCastParentheses: false
+SpacesInLineCommentPrefix:
+  Minimum: 0
+  Maximum: -1
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
 Standard:        Cpp11

--- a/include/verilated_funcs.h
+++ b/include/verilated_funcs.h
@@ -344,8 +344,8 @@ uint64_t vl_time_pow10(int n) VL_PURE;
 
 // Output clean
 // EMIT_RULE: VL_CLEAN:  oclean=clean; obits=lbits;
-#define VL_CLEAN_II(obits, lbits, lhs) ((lhs)&VL_MASK_I(obits))
-#define VL_CLEAN_QQ(obits, lbits, lhs) ((lhs)&VL_MASK_Q(obits))
+#define VL_CLEAN_II(obits, lbits, lhs) ((lhs) & (VL_MASK_I(obits)))
+#define VL_CLEAN_QQ(obits, lbits, lhs) ((lhs) & (VL_MASK_Q(obits)))
 
 // EMIT_RULE: VL_ASSIGNCLEAN:  oclean=clean; obits==lbits;
 #define VL_ASSIGNCLEAN_W(obits, owp, lwp) VL_CLEAN_WW((obits), (owp), (lwp))

--- a/src/V3Number.cpp
+++ b/src/V3Number.cpp
@@ -314,8 +314,7 @@ void V3Number::create(const char* sourcep) {
 
             case 'o':
             case 'c': {
-                switch (std::tolower(*cp)) {
-                // clang-format off
+                switch (std::tolower(*cp)) {  // clang-format off
                 case '0': setBit(obit++, 0); setBit(obit++, 0);  setBit(obit++, 0);  break;
                 case '1': setBit(obit++, 1); setBit(obit++, 0);  setBit(obit++, 0);  break;
                 case '2': setBit(obit++, 0); setBit(obit++, 1);  setBit(obit++, 0);  break;
@@ -335,8 +334,7 @@ void V3Number::create(const char* sourcep) {
             }
 
             case 'h': {
-                switch (std::tolower(*cp)) {
-                    // clang-format off
+                switch (std::tolower(*cp)) {  // clang-format off
                 case '0': setBit(obit++,0); setBit(obit++,0); setBit(obit++,0); setBit(obit++,0); break;
                 case '1': setBit(obit++,1); setBit(obit++,0); setBit(obit++,0); setBit(obit++,0); break;
                 case '2': setBit(obit++,0); setBit(obit++,1); setBit(obit++,0); setBit(obit++,0); break;

--- a/test_regress/t/t_dpi_qw_c.cpp
+++ b/test_regress/t/t_dpi_qw_c.cpp
@@ -33,7 +33,7 @@ void poke_value(int i) {
     const char* const scopeNamep = svGetNameFromScope(svGetScope());
     printf("svGetNameFromScope=\"%s\"\n", scopeNamep);
 
-// clang-format off
+    // clang-format off
 #ifdef VERILATOR
     static int didDump = 0;
     if (didDump++ == 0) {

--- a/test_regress/t/t_dpi_var.cpp
+++ b/test_regress/t/t_dpi_var.cpp
@@ -121,7 +121,7 @@ int main(int argc, char** argv) {
                                                         // Note null name - we're flattening it out
                                                         ""}};
 
-// clang-format off
+    // clang-format off
 #ifdef VERILATOR
 # ifdef TEST_VERBOSE
     contextp->scopesDump();

--- a/test_regress/t/t_mem_multi_io2.cpp
+++ b/test_regress/t/t_mem_multi_io2.cpp
@@ -48,7 +48,7 @@ int main()
 #endif
 
     // loop through every possibility and check the result
-// clang-format off
+    // clang-format off
 #ifdef SYSTEMC_VERSION
     sc_start(1, SC_NS);
 # define ASSIGN(s, v) s.write(v)

--- a/test_regress/t/t_trace_two_cc.cpp
+++ b/test_regress/t/t_trace_two_cc.cpp
@@ -37,7 +37,7 @@ int main(int argc, char** argv) {
     ap = new VM_PREFIX{contextp.get(), "topa"};
     bp = new Vt_trace_two_b{contextp.get(), "topb"};
 
-// clang-format off
+    // clang-format off
 #ifdef TEST_HDR_TRACE
     contextp->traceEverOn(true);
 # ifdef TEST_FST

--- a/test_regress/t/t_var_sc_bv.cpp
+++ b/test_regress/t/t_var_sc_bv.cpp
@@ -108,21 +108,20 @@ int main()
 
 #endif
 
-    // clang-format off
 #ifdef SYSTEMC_VERSION
     sc_start(1, SC_NS);
 #else
     tb->eval();
 #endif
     // This testcase is testing multi-thread safe VL_ASSIGN_SBW and VL_ASSIGN_WSB macros.
-    // Testbench is assigning different number of bits from VlWide input_var variable to different inputs.
-    // Values around multiple of 30 (i.e. BITS_PER_DIGIT defined in SystemC sc_nbdefs.h) are tested with the special care, since
-    // it is the value by which the data_ptr of sc_biguint underlying data type is increased by (and not expected 32, as width of uint32_t).
-    // Correctness of the output is compared against the 'old' macro, which is correct but has multi-threaded issue since it's using range function.
-    // Second part is testing VL_ASSIGN_WSB in a reverse way, it is reading signals from the previous test,
-    // and comparing the output with (fraction) of VlWide input_var variable.
-
-    // clang-format on
+    // Testbench is assigning different number of bits from VlWide input_var variable to different
+    // inputs. Values around multiple of 30 (i.e. BITS_PER_DIGIT defined in SystemC sc_nbdefs.h)
+    // are tested with the special care, since it is the value by which the data_ptr of sc_biguint
+    // underlying data type is increased by (and not expected 32, as width of uint32_t).
+    // Correctness of the output is compared against the 'old' macro, which is correct but has
+    // multi-threaded issue since it's using range function. Second part is testing VL_ASSIGN_WSB
+    // in a reverse way, it is reading signals from the previous test, and comparing the output
+    // with (fraction) of VlWide input_var variable.
     VL_ASSIGN_SBW(29, i_29_s, input_var);
     VL_ASSIGN_SBW_MT_ISSUE(29, i_29_old_s, input_var);
     VL_ASSIGN_SBW(30, i_30_s, input_var);

--- a/test_regress/t/t_var_sc_bv.cpp
+++ b/test_regress/t/t_var_sc_bv.cpp
@@ -108,7 +108,7 @@ int main()
 
 #endif
 
-// clang-format off
+    // clang-format off
 #ifdef SYSTEMC_VERSION
     sc_start(1, SC_NS);
 #else

--- a/test_regress/t/t_vpi_time_cb.cpp
+++ b/test_regress/t/t_vpi_time_cb.cpp
@@ -35,11 +35,9 @@ int main(int argc, char** argv) {
                                                         // Note null name - we're flattening it out
                                                         ""}};
 
-    // clang-format off
 #ifdef TEST_VERBOSE
     contextp->scopesDump();
 #endif
-    // clang-format on
 
 #if VM_TRACE
     contextp->traceEverOn(true);

--- a/test_regress/t/t_vpi_time_cb.cpp
+++ b/test_regress/t/t_vpi_time_cb.cpp
@@ -35,7 +35,7 @@ int main(int argc, char** argv) {
                                                         // Note null name - we're flattening it out
                                                         ""}};
 
-// clang-format off
+    // clang-format off
 #ifdef TEST_VERBOSE
     contextp->scopesDump();
 #endif

--- a/test_regress/t/t_vpi_zero_time_cb.cpp
+++ b/test_regress/t/t_vpi_zero_time_cb.cpp
@@ -116,7 +116,7 @@ int main(int argc, char** argv) {
                                                         // Note null name - we're flattening it out
                                                         ""}};
 
-// clang-format off
+    // clang-format off
 #ifdef VERILATOR
 # ifdef TEST_VERBOSE
     contextp->scopesDump();


### PR DESCRIPTION
I noticed my clang-format always add a space after `//` in the `//#######...` comments in almost every file. It's probably because newer clang-format has different default configuration for this. So I added an explicit option (`SpacesInLineCommentPrefix`) to the config file, and also manually changed some indents in the code. Now clang-format-14 (used in CI) and clang-format-17 (latest release) should produce the same result.

Also noticed that some files use `// clang-format off` to prevent removal of spaces after `#` in nested preprocessors (e.g. [here](https://github.com/verilator/verilator/blob/v5.016/include/verilated.h#L41-L74)), but some other places don't have the space ([here](https://github.com/verilator/verilator/blob/v5.016/include/verilated_funcs.h#L27-L29)). If we want the indent spaces maybe can add `IndentPPDirectives: AfterHash` and `PPIndentWidth: 1` option to avoid the `// clang-format off`?