### PR TITLE
V3Number- $realtobits incorrect type in a package function

### DIFF
--- a/test_regress/t/t_package.v
+++ b/test_regress/t/t_package.v
@@ -23,6 +23,12 @@ package p2;
    function [3:0] plustwo(input [3:0] i);
       plustwo = i+2;
    endfunction
+
+   function automatic bit realCompare(real r);
+      logic[63:0] b = $realtobits(r);
+      return b > 0;
+   endfunction
+
 endpackage
 
 module t (/*AUTOARG*/
@@ -55,10 +61,12 @@ endmodule
 module t2;
    import p::*;
    import p2::plustwo;
+   import p2::realCompare;
    import p2::package2_type_t;
    package_type_t vp;
    package2_type_t vp2;
    initial begin
+      bit x = realCompare(1.0);
       if (plusone(1) !== 2) $stop;
       if (plustwo(1) !== 3) $stop;
       if (p::pi !== 123 && p::pi !== 124) $stop;  // may race with other initial, so either value


### PR DESCRIPTION
This produces
```
vlt/t_package: ==================================================
        perl /usr/scratch/anolte/local/vlts/hrt-verilator/test_regress/../bin/verilator --prefix Vt_package ../obj_vlt/t_package/Vt_package__main.cpp --exe --make gmake --x-assign unique -cc -Mdir obj_vlt/t_package --fdedup --debug-check --comp-limit-members 10 --clk clk  -f input.vc +define+TEST_OBJ_DIR=obj_vlt/t_package +define+TEST_DUMPFILE=obj_vlt/t_package/simx.vcd t/t_package.v    > obj_vlt/t_package/vlt_compile.log
%Error: Internal Error: t/t_package.v:30:16: ../V3Number.cpp:1727: Number operation called with non-logic (double or string) argument: '1.0"
   30 |       return b > 0;
      |                ^
                        ... See the manual at https://verilator.org/verilator_doc.html for more assistance.
%Warning: vlt/t_package: Exec of perl failed: %Error: Internal Error: t/t_package.v:30:16: ../V3Number.cpp:1727: Number operation called with non-logic (double or string) argument: '1.0"

vlt/t_package: %Error: Exec of perl failed: %Error: Internal Error: t/t_package.v:30:16: ../V3Number.cpp:1727: Number operation called with non-logic (double or string) argument: '1.0"
vlt/t_package: FAILED: Exec of perl failed: %Error: Internal Error: t/t_package.v:30:16: ../V3Number.cpp:1727: Number operation called with non-logic (double or string) argument: '1.0"
==SUMMARY: Passed 0  Failed 1  Time 0:00
```

It seems like it assumes the return type of $realtobits is a double when used in a package function.