### PR TITLE
Internals: rename VPurity class and related functions. No functional change

### DIFF
--- a/src/V3Ast.h
+++ b/src/V3Ast.h
@@ -167,16 +167,16 @@ inline std::ostream& operator<<(std::ostream& os, const VLifetime& rhs) {
 
 // ######################################################################
 
-class VPurity final {
-    // Used in some nodes to cache the result of isPure method
+class VIsCached final {
+    // Used in some nodes to cache results of boolean methods
 public:
-    enum en : uint8_t { NOT_CACHED, PURE, IMPURE };
+    enum en : uint8_t { NOT_CACHED, YES, NO };
     enum en m_e;
-    VPurity()
+    VIsCached()
         : m_e{NOT_CACHED} {}
     bool isCached() const { return m_e != NOT_CACHED; }
-    bool isPure() const { return m_e == PURE; }
-    void setPurity(bool pure) { m_e = pure ? PURE : IMPURE; }
+    bool get() const { return m_e == YES; }
+    void set(bool flag) { m_e = flag ? YES : NO; }
     void clearCache() { m_e = NOT_CACHED; }
 };
 

--- a/src/V3AstNodeExpr.h
+++ b/src/V3AstNodeExpr.h
@@ -70,7 +70,7 @@ class AstNodeBiop VL_NOT_FINAL : public AstNodeExpr {
     // Binary expression
     // @astgen op1 := lhsp : AstNodeExpr
     // @astgen op2 := rhsp : AstNodeExpr
-    VPurity m_purity;  // Pure state
+    VIsCached m_purity;  // Pure state
 
 protected:
     AstNodeBiop(VNType t, FileLine* fl, AstNodeExpr* lhsp, AstNodeExpr* rhsp)
@@ -228,7 +228,7 @@ class AstNodeFTaskRef VL_NOT_FINAL : public AstNodeExpr {
     string m_dotted;  // Dotted part of scope the name()ed task/func is under or ""
     string m_inlinedDots;  // Dotted hierarchy flattened out
     bool m_pli = false;  // Pli system call ($name)
-    VPurity m_purity;  // Pure state
+    VIsCached m_purity;  // Pure state
 
 protected:
     AstNodeFTaskRef(VNType t, FileLine* fl, AstNode* namep, AstNodeExpr* pinsp)
@@ -276,7 +276,7 @@ class AstNodePreSel VL_NOT_FINAL : public AstNodeExpr {
     // @astgen op2 := rhsp : AstNodeExpr
     // @astgen op3 := thsp : Optional[AstNodeExpr]
     // @astgen op4 := attrp : Optional[AstAttrOf]
-    VPurity m_purity;  // Pure state
+    VIsCached m_purity;  // Pure state
 
 protected:
     AstNodePreSel(VNType t, FileLine* fl, AstNodeExpr* fromp, AstNodeExpr* rhsp, AstNodeExpr* thsp)
@@ -309,7 +309,7 @@ class AstNodeQuadop VL_NOT_FINAL : public AstNodeExpr {
     // @astgen op2 := rhsp : AstNodeExpr
     // @astgen op3 := thsp : AstNodeExpr
     // @astgen op4 := fhsp : AstNodeExpr
-    VPurity m_purity;  // Pure state
+    VIsCached m_purity;  // Pure state
 
 protected:
     AstNodeQuadop(VNType t, FileLine* fl, AstNodeExpr* lhsp, AstNodeExpr* rhsp, AstNodeExpr* thsp,
@@ -365,7 +365,7 @@ class AstNodeTriop VL_NOT_FINAL : public AstNodeExpr {
     // @astgen op1 := lhsp : AstNodeExpr
     // @astgen op2 := rhsp : AstNodeExpr
     // @astgen op3 := thsp : AstNodeExpr
-    VPurity m_purity;  // Pure state
+    VIsCached m_purity;  // Pure state
 
 protected:
     AstNodeTriop(VNType t, FileLine* fl, AstNodeExpr* lhsp, AstNodeExpr* rhsp, AstNodeExpr* thsp)
@@ -446,7 +446,7 @@ public:
 class AstNodeUniop VL_NOT_FINAL : public AstNodeExpr {
     // Unary expression
     // @astgen op1 := lhsp : AstNodeExpr
-    VPurity m_purity;  // Pure state
+    VIsCached m_purity;  // Pure state
 
 protected:
     AstNodeUniop(VNType t, FileLine* fl, AstNodeExpr* lhsp)

--- a/src/V3AstNodeExpr.h
+++ b/src/V3AstNodeExpr.h
@@ -101,7 +101,7 @@ public:
     void clearCachedPurity() override;
 
 private:
-    bool getPurity() const { return lhsp()->isPure() && rhsp()->isPure(); }
+    bool getPurityRecurse() const { return lhsp()->isPure() && rhsp()->isPure(); }
 };
 class AstNodeBiCom VL_NOT_FINAL : public AstNodeBiop {
     // Binary expr with commutative properties
@@ -268,7 +268,7 @@ public:
     void clearCachedPurity() override;
 
 private:
-    bool getPurity() const;
+    bool getPurityRecurse() const;
 };
 class AstNodePreSel VL_NOT_FINAL : public AstNodeExpr {
     // Something that becomes an AstSel
@@ -299,7 +299,7 @@ public:
     void clearCachedPurity() override;
 
 private:
-    bool getPurity() const {
+    bool getPurityRecurse() const {
         return fromp()->isPure() && rhsp()->isPure() && (!thsp() || thsp()->isPure());
     }
 };
@@ -343,7 +343,7 @@ public:
     void clearCachedPurity() override;
 
 private:
-    bool getPurity() const {
+    bool getPurityRecurse() const {
         return lhsp()->isPure() && rhsp()->isPure() && thsp()->isPure() && fhsp()->isPure();
     }
 };
@@ -396,7 +396,9 @@ public:
     void clearCachedPurity() override;
 
 private:
-    bool getPurity() const { return lhsp()->isPure() && rhsp()->isPure() && thsp()->isPure(); }
+    bool getPurityRecurse() const {
+        return lhsp()->isPure() && rhsp()->isPure() && thsp()->isPure();
+    }
 };
 class AstNodeCond VL_NOT_FINAL : public AstNodeTriop {
     // @astgen alias op1 := condp

--- a/src/V3AstNodeOther.h
+++ b/src/V3AstNodeOther.h
@@ -88,7 +88,7 @@ private:
     bool m_virtual : 1;  // Virtual method in class
     bool m_needProcess : 1;  // Implements part of a process that allocates std::process
     VLifetime m_lifetime;  // Lifetime
-    VPurity m_purity;  // Pure state
+    VIsCached m_purity;  // Pure state
 
 protected:
     AstNodeFTask(VNType t, FileLine* fl, const string& name, AstNode* stmtsp)

--- a/src/V3AstNodeOther.h
+++ b/src/V3AstNodeOther.h
@@ -195,7 +195,7 @@ public:
     }
 
 private:
-    bool getPurity() const;
+    bool getPurityRecurse() const;
 };
 class AstNodeFile VL_NOT_FINAL : public AstNode {
     // Emitted Output file

--- a/src/V3AstNodes.cpp
+++ b/src/V3AstNodes.cpp
@@ -51,7 +51,7 @@ AstIface* AstIfaceRefDType::ifaceViaCellp() const {
 const char* AstNodeFTaskRef::broken() const {
     BROKEN_RTN(m_taskp && !m_taskp->brokeExists());
     BROKEN_RTN(m_classOrPackagep && !m_classOrPackagep->brokeExists());
-    BROKEN_RTN(m_purity.isCached() && m_purity.isPure() != getPurity());
+    BROKEN_RTN(m_purity.isCached() && m_purity.get() != getPurity());
     return nullptr;
 }
 
@@ -68,8 +68,8 @@ bool AstNodeFTaskRef::isPure() {
         // cached.
         return false;
     } else {
-        if (!m_purity.isCached()) m_purity.setPurity(this->getPurity());
-        return m_purity.isPure();
+        if (!m_purity.isCached()) m_purity.set(this->getPurity());
+        return m_purity.get();
     }
 }
 
@@ -146,11 +146,11 @@ const char* AstNodeCCall::broken() const {
 }
 bool AstNodeCCall::isPure() { return funcp()->dpiPure(); }
 bool AstNodeUniop::isPure() {
-    if (!m_purity.isCached()) m_purity.setPurity(lhsp()->isPure());
-    return m_purity.isPure();
+    if (!m_purity.isCached()) m_purity.set(lhsp()->isPure());
+    return m_purity.get();
 }
 const char* AstNodeUniop::broken() const {
-    BROKEN_RTN(m_purity.isCached() && m_purity.isPure() != lhsp()->isPure());
+    BROKEN_RTN(m_purity.isCached() && m_purity.get() != lhsp()->isPure());
     return nullptr;
 }
 void AstNodeUniop::clearCachedPurity() {
@@ -159,11 +159,11 @@ void AstNodeUniop::clearCachedPurity() {
 }
 
 bool AstNodeBiop::isPure() {
-    if (!m_purity.isCached()) m_purity.setPurity(getPurity());
-    return m_purity.isPure();
+    if (!m_purity.isCached()) m_purity.set(getPurity());
+    return m_purity.get();
 }
 const char* AstNodeBiop::broken() const {
-    BROKEN_RTN(m_purity.isCached() && m_purity.isPure() != getPurity());
+    BROKEN_RTN(m_purity.isCached() && m_purity.get() != getPurity());
     return nullptr;
 }
 void AstNodeBiop::clearCachedPurity() {
@@ -172,11 +172,11 @@ void AstNodeBiop::clearCachedPurity() {
 }
 
 bool AstNodeTriop::isPure() {
-    if (!m_purity.isCached()) m_purity.setPurity(getPurity());
-    return m_purity.isPure();
+    if (!m_purity.isCached()) m_purity.set(getPurity());
+    return m_purity.get();
 }
 const char* AstNodeTriop::broken() const {
-    BROKEN_RTN(m_purity.isCached() && m_purity.isPure() != getPurity());
+    BROKEN_RTN(m_purity.isCached() && m_purity.get() != getPurity());
     return nullptr;
 }
 void AstNodeTriop::clearCachedPurity() {
@@ -185,11 +185,11 @@ void AstNodeTriop::clearCachedPurity() {
 }
 
 bool AstNodePreSel::isPure() {
-    if (!m_purity.isCached()) m_purity.setPurity(getPurity());
-    return m_purity.isPure();
+    if (!m_purity.isCached()) m_purity.set(getPurity());
+    return m_purity.get();
 }
 const char* AstNodePreSel::broken() const {
-    BROKEN_RTN(m_purity.isCached() && m_purity.isPure() != getPurity());
+    BROKEN_RTN(m_purity.isCached() && m_purity.get() != getPurity());
     return nullptr;
 }
 void AstNodePreSel::clearCachedPurity() {
@@ -198,11 +198,11 @@ void AstNodePreSel::clearCachedPurity() {
 }
 
 bool AstNodeQuadop::isPure() {
-    if (!m_purity.isCached()) m_purity.setPurity(getPurity());
-    return m_purity.isPure();
+    if (!m_purity.isCached()) m_purity.set(getPurity());
+    return m_purity.get();
 }
 const char* AstNodeQuadop::broken() const {
-    BROKEN_RTN(m_purity.isCached() && m_purity.isPure() != getPurity());
+    BROKEN_RTN(m_purity.isCached() && m_purity.get() != getPurity());
     return nullptr;
 }
 void AstNodeQuadop::clearCachedPurity() {
@@ -2311,11 +2311,11 @@ void AstNodeFTask::dump(std::ostream& str) const {
     if ((dpiImport() || dpiExport()) && cname() != name()) str << " [c=" << cname() << "]";
 }
 bool AstNodeFTask::isPure() {
-    if (!m_purity.isCached()) m_purity.setPurity(getPurity());
-    return m_purity.isPure();
+    if (!m_purity.isCached()) m_purity.set(getPurity());
+    return m_purity.get();
 }
 const char* AstNodeFTask::broken() const {
-    BROKEN_RTN(m_purity.isCached() && m_purity.isPure() != getPurity());
+    BROKEN_RTN(m_purity.isCached() && m_purity.get() != getPurity());
     return nullptr;
 }
 bool AstNodeFTask::getPurity() const {

--- a/src/V3AstNodes.cpp
+++ b/src/V3AstNodes.cpp
@@ -51,7 +51,7 @@ AstIface* AstIfaceRefDType::ifaceViaCellp() const {
 const char* AstNodeFTaskRef::broken() const {
     BROKEN_RTN(m_taskp && !m_taskp->brokeExists());
     BROKEN_RTN(m_classOrPackagep && !m_classOrPackagep->brokeExists());
-    BROKEN_RTN(m_purity.isCached() && m_purity.get() != getPurity());
+    BROKEN_RTN(m_purity.isCached() && m_purity.get() != getPurityRecurse());
     return nullptr;
 }
 
@@ -68,7 +68,7 @@ bool AstNodeFTaskRef::isPure() {
         // cached.
         return false;
     } else {
-        if (!m_purity.isCached()) m_purity.set(this->getPurity());
+        if (!m_purity.isCached()) m_purity.set(this->getPurityRecurse());
         return m_purity.get();
     }
 }
@@ -78,7 +78,7 @@ void AstNodeFTaskRef::clearCachedPurity() {
     if (AstNodeExpr* const exprp = VN_CAST(backp(), NodeExpr)) exprp->clearCachedPurity();
 }
 
-bool AstNodeFTaskRef::getPurity() const {
+bool AstNodeFTaskRef::getPurityRecurse() const {
     AstNodeFTask* const taskp = this->taskp();
     // Unlinked yet, so treat as impure
     if (!taskp) return false;
@@ -159,11 +159,11 @@ void AstNodeUniop::clearCachedPurity() {
 }
 
 bool AstNodeBiop::isPure() {
-    if (!m_purity.isCached()) m_purity.set(getPurity());
+    if (!m_purity.isCached()) m_purity.set(getPurityRecurse());
     return m_purity.get();
 }
 const char* AstNodeBiop::broken() const {
-    BROKEN_RTN(m_purity.isCached() && m_purity.get() != getPurity());
+    BROKEN_RTN(m_purity.isCached() && m_purity.get() != getPurityRecurse());
     return nullptr;
 }
 void AstNodeBiop::clearCachedPurity() {
@@ -172,11 +172,11 @@ void AstNodeBiop::clearCachedPurity() {
 }
 
 bool AstNodeTriop::isPure() {
-    if (!m_purity.isCached()) m_purity.set(getPurity());
+    if (!m_purity.isCached()) m_purity.set(getPurityRecurse());
     return m_purity.get();
 }
 const char* AstNodeTriop::broken() const {
-    BROKEN_RTN(m_purity.isCached() && m_purity.get() != getPurity());
+    BROKEN_RTN(m_purity.isCached() && m_purity.get() != getPurityRecurse());
     return nullptr;
 }
 void AstNodeTriop::clearCachedPurity() {
@@ -185,11 +185,11 @@ void AstNodeTriop::clearCachedPurity() {
 }
 
 bool AstNodePreSel::isPure() {
-    if (!m_purity.isCached()) m_purity.set(getPurity());
+    if (!m_purity.isCached()) m_purity.set(getPurityRecurse());
     return m_purity.get();
 }
 const char* AstNodePreSel::broken() const {
-    BROKEN_RTN(m_purity.isCached() && m_purity.get() != getPurity());
+    BROKEN_RTN(m_purity.isCached() && m_purity.get() != getPurityRecurse());
     return nullptr;
 }
 void AstNodePreSel::clearCachedPurity() {
@@ -198,11 +198,11 @@ void AstNodePreSel::clearCachedPurity() {
 }
 
 bool AstNodeQuadop::isPure() {
-    if (!m_purity.isCached()) m_purity.set(getPurity());
+    if (!m_purity.isCached()) m_purity.set(getPurityRecurse());
     return m_purity.get();
 }
 const char* AstNodeQuadop::broken() const {
-    BROKEN_RTN(m_purity.isCached() && m_purity.get() != getPurity());
+    BROKEN_RTN(m_purity.isCached() && m_purity.get() != getPurityRecurse());
     return nullptr;
 }
 void AstNodeQuadop::clearCachedPurity() {
@@ -2311,14 +2311,14 @@ void AstNodeFTask::dump(std::ostream& str) const {
     if ((dpiImport() || dpiExport()) && cname() != name()) str << " [c=" << cname() << "]";
 }
 bool AstNodeFTask::isPure() {
-    if (!m_purity.isCached()) m_purity.set(getPurity());
+    if (!m_purity.isCached()) m_purity.set(getPurityRecurse());
     return m_purity.get();
 }
 const char* AstNodeFTask::broken() const {
-    BROKEN_RTN(m_purity.isCached() && m_purity.get() != getPurity());
+    BROKEN_RTN(m_purity.isCached() && m_purity.get() != getPurityRecurse());
     return nullptr;
 }
-bool AstNodeFTask::getPurity() const {
+bool AstNodeFTask::getPurityRecurse() const {
     if (this->dpiImport()) return this->dpiPure();
     // Check the list of statements if it contains any impure statement
     // or any write reference to a variable that isn't an automatic function local.


### PR DESCRIPTION
These changes were proposed in: https://github.com/verilator/verilator/pull/4508.
