### PR TITLE
Fix this in a constructor

### DIFF
--- a/include/verilated_types.h
+++ b/include/verilated_types.h
@@ -1477,7 +1477,7 @@ class VlClass VL_NOT_FINAL : public VlDeletable {
 
 public:
     // CONSTRUCTORS
-    VlClass() = default;
+    VlClass() { refCountInc(); }
     VlClass(const VlClass& copied) {}
     ~VlClass() override = default;
 };
@@ -1526,8 +1526,9 @@ public:
         // () required here to avoid narrowing conversion warnings,
         // when a new() has an e.g. CData type and passed a 1U.
         : m_objp{new T_Class(std::forward<T_Args>(args)...)} {
+        // refCountInc was moved to the constructor of T_Class
+        // to fix self references in constructor.
         m_objp->m_deleterp = &deleter;
-        refCountInc();
     }
     // Explicit to avoid implicit conversion from 0
     explicit VlClassRef(T_Class* objp)

--- a/test_regress/t/t_class_this_constructor.pl
+++ b/test_regress/t/t_class_this_constructor.pl
@@ -1,0 +1,21 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2020 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_class_this_constructor.v
+++ b/test_regress/t/t_class_this_constructor.v
@@ -1,0 +1,26 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2023 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+class Cls;
+   bit x = 1'b0;
+   function new;
+      Cls c;
+      if (c == this) begin
+         x = 1'b1;
+      end
+   endfunction
+endclass
+
+module t (/*AUTOARG*/);
+   Cls c;
+   initial begin
+      c = new;
+      if (c.x) $stop;
+
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end
+endmodule


### PR DESCRIPTION
Currently, using `this` in a constructor gives segmentation fault. This PR fixes it.
The problem happens, because `m_deleterp` is set and a ref counter is incremented after a call of an object constructor:
https://github.com/verilator/verilator/blob/732d03f4e5999879adf53de5864fa09849d84e29/include/verilated_types.h#L1525-L1531
A ref counter is decremented in a destructor and if it is 0, `m_deleterp` is used.
If we have a reference to `this` in a constructor of a systemverilog class, it is wrapped into `VlClassRef` using this constructor: https://github.com/verilator/verilator/blob/732d03f4e5999879adf53de5864fa09849d84e29/include/verilated_types.h#L1533-L1536 and then that `VlClassRef` object is removed, so a ref counter is set back to 0. Then `m_deleterp` is used, which is nullptr at that moment, because the program didn't return from a constructor and didn't set it yet, which gives seg fault.

I fixed it by moving a ref counter incrementation to the constructor of VlClass, which is a base class for all classes. This way a ref counter won't be set back to 0 during the creation of an object and the problem won't occur.