### PR TITLE
Fix object destruction after a copy constructor (#4540)

### DIFF
--- a/include/verilated_types.h
+++ b/include/verilated_types.h
@@ -1478,7 +1478,7 @@ class VlClass VL_NOT_FINAL : public VlDeletable {
 public:
     // CONSTRUCTORS
     VlClass() { refCountInc(); }
-    VlClass(const VlClass& copied) {}
+    VlClass(const VlClass& copied) { refCountInc(); }
     ~VlClass() override = default;
 };
 

--- a/test_regress/t/t_class_copy2.pl
+++ b/test_regress/t/t_class_copy2.pl
@@ -1,0 +1,21 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2020 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_class_copy2.v
+++ b/test_regress/t/t_class_copy2.v
@@ -1,0 +1,36 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2023 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+`define stop $stop
+`define checkh(gotv,expv) do if ((gotv) !== (expv)) begin $write("%%Error: %s:%0d:  got='h%x exp='h%x\n", `__FILE__,`__LINE__, (gotv), (expv)); $stop; end while(0);
+
+class Cls;
+   bit x = 1;
+endclass
+
+module t (/*AUTOARG*/);
+   Cls obj1;
+   Cls obj2;
+
+   initial begin
+      obj1 = new;
+      `checkh(obj1.x, 1);
+
+      obj1.x = 0;
+      obj2 = new obj1;
+      `checkh(obj2.x, 0);
+
+      obj2.x = 1;
+      `checkh(obj1.x, 0);
+      `checkh(obj2.x, 1);
+
+      obj2.x = 0;
+      `checkh(obj2.x, 0);
+
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end
+endmodule


### PR DESCRIPTION
It fixes https://github.com/verilator/verilator/issues/4540.
