### PR TITLE
fix: buffer overflow

### DIFF
--- a/Changes
+++ b/Changes
@@ -8,7 +8,7 @@ The changes in each Verilator version are described below.  The
 contributors that suggested a given feature are shown in []. Thanks!
 
 
-Verilator 4.227 devel
+Verilator 4.228 2022-10-01
 ==========================
 
 **Announcement:**

--- a/configure.ac
+++ b/configure.ac
@@ -10,7 +10,7 @@
 # Then 'make maintainer-dist'
 #AC_INIT([Verilator],[#.### YYYY-MM-DD])
 #AC_INIT([Verilator],[#.### devel])
-AC_INIT([Verilator],[4.227 devel],
+AC_INIT([Verilator],[4.228 2022-10-01],
         [https://verilator.org],
         [verilator],[https://verilator.org])
 

--- a/include/verilated_funcs.h
+++ b/include/verilated_funcs.h
@@ -2064,60 +2064,60 @@ static inline WDataOutP VL_CONST_W_8X(int obits, WDataOutP o,
     VL_C_END_(obits, 8);
 }
 //
-static inline WDataOutP VL_CONSTHI_W_1X(int obits, int lsb, WDataOutP obase,
+static inline WDataOutP VL_CONSTHI_W_1X(int obits, int lsb, WDataOutP o,
                                         EData d0) VL_MT_SAFE {
-    WDataOutP o = obase + VL_WORDS_I(lsb);
-    o[0] = d0;
+    WDataOutP ohi = o + VL_WORDS_I(lsb);
+    ohi[0] = d0;
     VL_C_END_(obits, VL_WORDS_I(lsb) + 1);
 }
-static inline WDataOutP VL_CONSTHI_W_2X(int obits, int lsb, WDataOutP obase,
+static inline WDataOutP VL_CONSTHI_W_2X(int obits, int lsb, WDataOutP o,
                                         EData d1, EData d0) VL_MT_SAFE {
-    WDataOutP o = obase + VL_WORDS_I(lsb);
-    o[0] = d0;  o[1] = d1;
+    WDataOutP ohi = o + VL_WORDS_I(lsb);
+    ohi[0] = d0;  ohi[1] = d1;
     VL_C_END_(obits, VL_WORDS_I(lsb) + 2);
 }
-static inline WDataOutP VL_CONSTHI_W_3X(int obits, int lsb, WDataOutP obase,
+static inline WDataOutP VL_CONSTHI_W_3X(int obits, int lsb, WDataOutP o,
                                         EData d2, EData d1, EData d0) VL_MT_SAFE {
-    WDataOutP o = obase + VL_WORDS_I(lsb);
-    o[0] = d0;  o[1] = d1;  o[2] = d2;
+    WDataOutP ohi = o + VL_WORDS_I(lsb);
+    ohi[0] = d0;  ohi[1] = d1;  ohi[2] = d2;
     VL_C_END_(obits, VL_WORDS_I(lsb) + 3);
 }
-static inline WDataOutP VL_CONSTHI_W_4X(int obits, int lsb, WDataOutP obase,
+static inline WDataOutP VL_CONSTHI_W_4X(int obits, int lsb, WDataOutP o,
                                         EData d3, EData d2, EData d1, EData d0) VL_MT_SAFE {
-    WDataOutP o = obase + VL_WORDS_I(lsb);
-    o[0] = d0;  o[1] = d1;  o[2] = d2;  o[3] = d3;
+    WDataOutP ohi = o + VL_WORDS_I(lsb);
+    ohi[0] = d0;  ohi[1] = d1;  ohi[2] = d2;  ohi[3] = d3;
     VL_C_END_(obits, VL_WORDS_I(lsb) + 4);
 }
-static inline WDataOutP VL_CONSTHI_W_5X(int obits, int lsb, WDataOutP obase,
+static inline WDataOutP VL_CONSTHI_W_5X(int obits, int lsb, WDataOutP o,
                                         EData d4,
                                         EData d3, EData d2, EData d1, EData d0) VL_MT_SAFE {
-    WDataOutP o = obase + VL_WORDS_I(lsb);
-    o[0] = d0;  o[1] = d1;  o[2] = d2;  o[3] = d3;
-    o[4] = d4;
+    WDataOutP ohi = o + VL_WORDS_I(lsb);
+    ohi[0] = d0;  ohi[1] = d1;  ohi[2] = d2;  ohi[3] = d3;
+    ohi[4] = d4;
     VL_C_END_(obits, VL_WORDS_I(lsb) + 5);
 }
-static inline WDataOutP VL_CONSTHI_W_6X(int obits, int lsb, WDataOutP obase,
+static inline WDataOutP VL_CONSTHI_W_6X(int obits, int lsb, WDataOutP o,
                                         EData d5, EData d4,
                                         EData d3, EData d2, EData d1, EData d0) VL_MT_SAFE {
-    WDataOutP o = obase + VL_WORDS_I(lsb);
-    o[0] = d0;  o[1] = d1;  o[2] = d2;  o[3] = d3;
-    o[4] = d4;  o[5] = d5;
+    WDataOutP ohi = o + VL_WORDS_I(lsb);
+    ohi[0] = d0;  ohi[1] = d1;  ohi[2] = d2;  ohi[3] = d3;
+    ohi[4] = d4;  ohi[5] = d5;
     VL_C_END_(obits, VL_WORDS_I(lsb) + 6);
 }
-static inline WDataOutP VL_CONSTHI_W_7X(int obits, int lsb, WDataOutP obase,
+static inline WDataOutP VL_CONSTHI_W_7X(int obits, int lsb, WDataOutP o,
                                         EData d6, EData d5, EData d4,
                                         EData d3, EData d2, EData d1, EData d0) VL_MT_SAFE {
-    WDataOutP o = obase + VL_WORDS_I(lsb);
-    o[0] = d0;  o[1] = d1;  o[2] = d2;  o[3] = d3;
-    o[4] = d4;  o[5] = d5;  o[6] = d6;
+    WDataOutP ohi = o + VL_WORDS_I(lsb);
+    ohi[0] = d0;  ohi[1] = d1;  ohi[2] = d2;  ohi[3] = d3;
+    ohi[4] = d4;  ohi[5] = d5;  ohi[6] = d6;
     VL_C_END_(obits, VL_WORDS_I(lsb) + 7);
 }
-static inline WDataOutP VL_CONSTHI_W_8X(int obits, int lsb, WDataOutP obase,
+static inline WDataOutP VL_CONSTHI_W_8X(int obits, int lsb, WDataOutP o,
                                         EData d7, EData d6, EData d5, EData d4,
                                         EData d3, EData d2, EData d1, EData d0) VL_MT_SAFE {
-    WDataOutP o = obase + VL_WORDS_I(lsb);
-    o[0] = d0;  o[1] = d1;  o[2] = d2;  o[3] = d3;
-    o[4] = d4;  o[5] = d5;  o[6] = d6;  o[7] = d7;
+    WDataOutP ohi = o + VL_WORDS_I(lsb);
+    ohi[0] = d0;  ohi[1] = d1;  ohi[2] = d2;  ohi[3] = d3;
+    ohi[4] = d4;  ohi[5] = d5;  ohi[6] = d6;  ohi[7] = d7;
     VL_C_END_(obits, VL_WORDS_I(lsb) + 8);
 }
 


### PR DESCRIPTION
Found with ASAN
Was causing some simulations to go awry

The indices used in VL_C_END_ are based on the original obase/o, but VL_CONSTHI_W_* functions modified o to be high. Eg, with `VL_CONSTHI_W_1X(6434,6400,x,0x00000008)`

This line will set o to obase[200]

     WDataOutP o = obase + VL_WORDS_I(lsb);

This line will set o[0], aka obase[200], to 8

     o[0] = d0;

This macro will write to o[201], aka obase[401], which is way out of bounds
     VL_C_END_(obits, VL_WORDS_I(lsb) + 1)

