### PR TITLE
Support concatenation of unpacked arrays

### DIFF
--- a/src/V3Slice.cpp
+++ b/src/V3Slice.cpp
@@ -67,11 +67,6 @@ class SliceVisitor final : public VNVisitor {
 
     // METHODS
 
-    static bool areCompatible(const AstNodeDType* atypep, const AstNodeDType* btypep) {
-        if (atypep->type() == btypep->type() && atypep->same(btypep)) return true;
-        return atypep->isIntegralOrPacked() && btypep->isIntegralOrPacked();
-    }
-
     AstNodeExpr* cloneAndSel(AstNode* nodep, int elements, int elemIdx) {
         // Insert an ArraySel, except for a few special cases
         const AstUnpackArrayDType* const arrayp
@@ -132,7 +127,9 @@ class SliceVisitor final : public VNVisitor {
                     m_assignError = true;
                 }
                 const AstNodeDType* itemRawDTypep = itemp->dtypep()->skipRefp();
-                if (areCompatible(expectedItemDTypep, itemRawDTypep)) {
+                const VCastable castable
+                    = AstNode::computeCastable(expectedItemDTypep, itemRawDTypep, itemp);
+                if (castable == VCastable::SAMEISH || castable == VCastable::COMPATIBLE) {
                     if (i == elemIdx) {
                         newp = itemp->cloneTreePure(false);
                         break;

--- a/src/V3Slice.cpp
+++ b/src/V3Slice.cpp
@@ -159,8 +159,9 @@ class SliceVisitor final : public VNVisitor {
                             newp = new AstArraySel{nodep->fileline(), itemp->cloneTreePure(false),
                                                    offset};
                         }
+
                         if (!m_assignError && elemIdx + 1 == elements
-                            && i + itemDTypep->elementsConst() < elements) {
+                            && i + itemDTypep->elementsConst() > elements) {
                             nodep->v3error("Array initialization has too many elements. "
                                            << elements << " elements are expected, but at least "
                                            << i + itemDTypep->elementsConst()

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -4120,6 +4120,7 @@ private:
         PatVecMap patmap = patVectorMap(nodep, range);
         UINFO(9, "ent " << range.left() << " to " << range.right() << endl);
         AstNode* newp = nullptr;
+        bool allConstant = true;
         for (int entn = 0, ent = range.left(); entn < range.elements();
              ++entn, ent += range.leftToRightInc()) {
             AstPatMember* newpatp = nullptr;
@@ -4129,7 +4130,7 @@ private:
                 if (defaultp) {
                     newpatp = defaultp->cloneTree(false);
                     patp = newpatp;
-                } else {
+                } else if (!VN_IS(arrayDtp, UnpackArrayDType) || allConstant) {
                     nodep->v3error("Assignment pattern missed initializing elements: " << ent);
                 }
             } else {
@@ -4140,6 +4141,7 @@ private:
             if (patp) {
                 // Don't want the RHS an array
                 patp->dtypep(arrayDtp->subDTypep());
+                allConstant &= VN_IS(patp->lhssp(), Const);
                 AstNodeExpr* const valuep = patternMemberValueIterate(patp);
                 if (VN_IS(arrayDtp, UnpackArrayDType)) {
                     if (!newp) {

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -4130,7 +4130,10 @@ private:
                 if (defaultp) {
                     newpatp = defaultp->cloneTree(false);
                     patp = newpatp;
-                } else if (!VN_IS(arrayDtp, UnpackArrayDType) || allConstant) {
+                } else if (!(VN_IS(arrayDtp, UnpackArrayDType) && !allConstant)) {
+                    // If arrayDtp is an unpacked array and item is not constant,
+                    // the number of elemnt cannot be determined here as the dtype of each element
+                    // is not set yet. V3Slice checks for such cases.
                     nodep->v3error("Assignment pattern missed initializing elements: " << ent);
                 }
             } else {

--- a/test_regress/t/t_unpacked_concat.pl
+++ b/test_regress/t/t_unpacked_concat.pl
@@ -1,0 +1,21 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2019 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    );
+execute(
+    check_finished => 1,
+    );
+
+
+ok(1);
+1;

--- a/test_regress/t/t_unpacked_concat.v
+++ b/test_regress/t/t_unpacked_concat.v
@@ -1,0 +1,102 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed into the Public Domain, for any use,
+// without warranty, 2023 by Yutetsu TAKATSUKASA.
+// SPDX-License-Identifier: CC0-1.0
+
+module t (/*AUTOARG*/
+   // Inputs
+   clk
+   );
+
+   input clk;
+
+   typedef int AI3[1:3];
+   AI3 A3;
+   int A9[1:9];
+
+   logic [2:0] s0;
+   logic [2:0] s1[1:3];
+   logic [2:0] s2[3:1];
+   logic [2:0] s3[2:8];
+   logic [2:0] s4[8:2];
+
+   initial begin
+      s0 = 3'd1;
+      s1[1] = 3'd2;
+      s1[2] = 3'd3;
+      s1[3] = 3'd4;
+      s2[1] = 3'd5;
+      s2[2] = 3'd6;
+      s2[3] = 3'd7;
+
+      A3 = '{1, 2, 3};
+      A9 = {A3, 4, 5, A3, 6};
+      if (A9[1] != 1) $stop;
+      if (A9[2] != 2) $stop;
+      if (A9[3] != 3) $stop;
+      if (A9[4] != 4) $stop;
+      if (A9[5] != 5) $stop;
+      if (A9[6] != 1) $stop;
+      if (A9[7] != 2) $stop;
+      if (A9[8] != 3) $stop;
+      if (A9[9] != 6) $stop;
+
+      s3 = {s0, s1, s2};
+      if (s3[2] != s0) $stop;
+      if (s3[3] != s1[1]) $stop;
+      if (s3[4] != s1[2]) $stop;
+      if (s3[5] != s1[3]) $stop;
+      if (s3[6] != s2[3]) $stop;
+      if (s3[7] != s2[2]) $stop;
+      if (s3[8] != s2[1]) $stop;
+
+      s3[2:8] = {s0, s1[1:2], s1[3], s2[3], s2[2:1]};
+      if (s3[2] != s0) $stop;
+      if (s3[3] != s1[1]) $stop;
+      if (s3[4] != s1[2]) $stop;
+      if (s3[5] != s1[3]) $stop;
+      if (s3[6] != s2[3]) $stop;
+      if (s3[7] != s2[2]) $stop;
+      if (s3[8] != s2[1]) $stop;
+
+      s3 = {s0, s1[1], s1[2:3], s2[3:2], s2[1]};
+      if (s3[2] != s0) $stop;
+      if (s3[3] != s1[1]) $stop;
+      if (s3[4] != s1[2]) $stop;
+      if (s3[5] != s1[3]) $stop;
+      if (s3[6] != s2[3]) $stop;
+      if (s3[7] != s2[2]) $stop;
+      if (s3[8] != s2[1]) $stop;
+
+      s4 = {s0, s1, s2};
+      if (s4[8] != s0) $stop;
+      if (s4[7] != s1[1]) $stop;
+      if (s4[6] != s1[2]) $stop;
+      if (s4[5] != s1[3]) $stop;
+      if (s4[4] != s2[3]) $stop;
+      if (s4[3] != s2[2]) $stop;
+      if (s4[2] != s2[1]) $stop;
+
+      s4[8:2] = {s0, s1[1:2], s1[3], s2[3], s2[2:1]};
+      if (s4[8] != s0) $stop;
+      if (s4[7] != s1[1]) $stop;
+      if (s4[6] != s1[2]) $stop;
+      if (s4[5] != s1[3]) $stop;
+      if (s4[4] != s2[3]) $stop;
+      if (s4[3] != s2[2]) $stop;
+      if (s4[2] != s2[1]) $stop;
+
+      s4 = {s0, s1[1], s1[2:3], s2[3:2], s2[1]};
+      if (s4[8] != s0) $stop;
+      if (s4[7] != s1[1]) $stop;
+      if (s4[6] != s1[2]) $stop;
+      if (s4[5] != s1[3]) $stop;
+      if (s4[4] != s2[3]) $stop;
+      if (s4[3] != s2[2]) $stop;
+      if (s4[2] != s2[1]) $stop;
+
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end
+endmodule

--- a/test_regress/t/t_unpacked_concat_bad.out
+++ b/test_regress/t/t_unpacked_concat_bad.out
@@ -3,8 +3,4 @@
    17 |    localparam bit_int_t count_bits [1:0] = {2{$bits(count_t)}};
       |                                              ^
                     ... For error description see https://verilator.org/warn/UNSUPPORTED?v=latest
-%Error: t/t_unpacked_concat_bad.v:17:46: Assignment pattern missed initializing elements: 0
-                                       : ... note: In instance 't'
-   17 |    localparam bit_int_t count_bits [1:0] = {2{$bits(count_t)}};
-      |                                              ^
 %Error: Exiting due to

--- a/test_regress/t/t_unpacked_concat_bad2.out
+++ b/test_regress/t/t_unpacked_concat_bad2.out
@@ -1,0 +1,10 @@
+%Error: t/t_unpacked_concat_bad2.v:26:23: Array initialization has too many elements. 4 elements are expected, but at least 5 elements exist.
+   26 |       s2 = {s1, s0, s0, s0};
+      |                       ^
+%Error: t/t_unpacked_concat_bad2.v:28:17: Item is incompatible with the array type.
+   28 |       s2 = {s0, s3};
+      |                 ^~
+%Error: t/t_unpacked_concat_bad2.v:30:19: Item is incompatible with the array type.
+   30 |       A9_logic = {A3, 4, 5, A3, 6};
+      |                   ^~
+%Error: Exiting due to

--- a/test_regress/t/t_unpacked_concat_bad2.out
+++ b/test_regress/t/t_unpacked_concat_bad2.out
@@ -1,3 +1,6 @@
+%Error: t/t_unpacked_concat_bad2.v:25:15: Array initialization has too many elements. 2 elements are expected, but at least 5 elements exist.
+   25 |       s1 = {s0, s2};
+      |               ^
 %Error: t/t_unpacked_concat_bad2.v:26:23: Array initialization has too many elements. 4 elements are expected, but at least 5 elements exist.
    26 |       s2 = {s1, s0, s0, s0};
       |                       ^

--- a/test_regress/t/t_unpacked_concat_bad2.pl
+++ b/test_regress/t/t_unpacked_concat_bad2.pl
@@ -1,0 +1,19 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2019 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(vlt => 1);
+
+lint(
+    fails => 1,
+    expect_filename => $Self->{golden_filename},
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_unpacked_concat_bad2.v
+++ b/test_regress/t/t_unpacked_concat_bad2.v
@@ -1,0 +1,34 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed into the Public Domain, for any use,
+// without warranty, 2023 by Yutetsu TAKATSUKASA.
+// SPDX-License-Identifier: CC0-1.0
+
+module t (/*AUTOARG*/
+   // Inputs
+   clk
+   );
+
+   input clk;
+
+   logic [7:0] s0;
+   logic [7:0] s1[1:2];
+   logic [7:0] s2[1:4];
+   logic [7:0] s3[2][2];
+
+   typedef int AI3[1:3];
+   AI3 A3;
+   logic [31:0] A9_logic[1:9];
+
+   initial begin
+      // RHS has too many elements.
+      s1 = {s0, s2};
+      s2 = {s1, s0, s0, s0};
+      // Incompatible type
+      s2 = {s0, s3};
+
+      A9_logic = {A3, 4, 5, A3, 6};
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end
+endmodule


### PR DESCRIPTION
1800-2017 10.10.1 says

```systemverilog
A9 = {A3, 4, 5, A3, 6}; // legal, gives A9='{1,2,3,4,5,1,2,3,6}
```

where
```systemverilog
typedef int AI3[1:3];
AI3 A3;
int A9[1:9];
A3 = '{1, 2, 3};
```

This PR supports this. I push a test then will push code later as usual.