### PR TITLE
Fix hash and comparison function for AstBasicDType

### DIFF
--- a/src/V3AstNodes.cpp
+++ b/src/V3AstNodes.cpp
@@ -277,11 +277,9 @@ int AstBasicDType::widthTotalBytes() const {
 
 bool AstBasicDType::same(const AstNode* samep) const {
     const AstBasicDType* const sp = static_cast<const AstBasicDType*>(samep);
-    if (!rangep() && !sp->rangep()) {
-        return m == sp->m && numeric() == sp->numeric();
-    } else {
-        return rangep() && rangep()->sameTree(sp->rangep());
-    }
+    if (!(m == sp->m) || numeric() != sp->numeric()) return false;
+    if (!rangep() && !sp->rangep()) return true;
+    return rangep() && rangep()->sameTree(sp->rangep());
 }
 
 int AstNodeUOrStructDType::widthTotalBytes() const {

--- a/src/V3AstNodes.cpp
+++ b/src/V3AstNodes.cpp
@@ -277,10 +277,10 @@ int AstBasicDType::widthTotalBytes() const {
 
 bool AstBasicDType::same(const AstNode* samep) const {
     const AstBasicDType* const sp = static_cast<const AstBasicDType*>(samep);
-    if (!rangep() && !sp->rangep() && m == sp->m) {
-        return true;
+    if (!rangep() && !sp->rangep()) {
+        return m == sp->m && numeric() == sp->numeric();
     } else {
-        return m == sp->m && rangep() && rangep()->sameTree(sp->rangep());
+        return rangep() && rangep()->sameTree(sp->rangep());
     }
 }
 

--- a/src/V3Hasher.cpp
+++ b/src/V3Hasher.cpp
@@ -143,6 +143,7 @@ private:
     void visit(AstBasicDType* nodep) override {
         m_hash += hashNodeAndIterate(nodep, false, HASH_CHILDREN, [=]() {
             m_hash += nodep->keyword();
+            m_hash += nodep->numeric();
             m_hash += nodep->nrange().left();
             m_hash += nodep->nrange().right();
         });


### PR DESCRIPTION
The 'numeric' field (signed/unsigned) of AstBasicDType didn't participate in the hash and comparison function, it may cause some other problems. It seems that the signing keywords can be applied to only basic types, so I assume there're no other similar problems.
It was caught when I was testing the new algorithm for deparam. I think this bug can be covered by future PRs so the test file is not added here.