### PR TITLE
Fix interface comparison

### DIFF
--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -6670,7 +6670,8 @@ private:
                 // child node's width to end up correct for the assignment (etc)
                 widthCheckSized(nodep, side, VN_AS(underp, NodeExpr), expDTypep, extendRule,
                                 warnOn);
-            } else if (!VN_IS(expDTypep->skipRefp(), IfaceRefDType)
+            } else if (!VN_IS(nodep, Eq) && !VN_IS(nodep, Neq)
+                       && !VN_IS(expDTypep->skipRefp(), IfaceRefDType)
                        && VN_IS(underp->dtypep()->skipRefp(), IfaceRefDType)) {
                 underp->v3error(ucfirst(nodep->prettyOperatorName())
                                 << " expected non-interface on " << side << " but "

--- a/test_regress/t/t_interface_virtual.out
+++ b/test_regress/t/t_interface_virtual.out
@@ -1,3 +1,7 @@
+va==vb? 1
+va!=vb? 0
+va==vb? 0
+va!=vb? 1
 va.addr=aa va.data=11 ia.addr=aa ia.data=11
 vb.addr=bb vb.data=22 ib.addr=bb ib.data=22
 ca.fa.addr=a0 ca.fa.data=11 ca.fa.addr=b0 ca.fb.data=22

--- a/test_regress/t/t_interface_virtual.v
+++ b/test_regress/t/t_interface_virtual.v
@@ -33,7 +33,12 @@ module t (/*AUTOARG*/);
 
    initial begin
       va = ia;
+      vb = ia;
+      $display("va==vb? %b", va==vb);
+      $display("va!=vb? %b", va!=vb);
       vb = ib;
+      $display("va==vb? %b", va==vb);
+      $display("va!=vb? %b", va!=vb);
 
       ca = new;
       cb = new;


### PR DESCRIPTION
This patch enables `==` and `!=`-comparison of (virtual) interfaces.

Interfaces are treated simply like pointers, and this is consistent with proprietary simulators.

IEEE explicitly allows these operations, at least for virtual interfaces, but it doesn't specify their semantics.