### PR TITLE
Support NBAs in non-inlined functions/tasks (#4496)

### DIFF
--- a/src/V3AstNodeOther.h
+++ b/src/V3AstNodeOther.h
@@ -1191,6 +1191,8 @@ class AstNetlist final : public AstNode {
     AstCFunc* m_evalNbap = nullptr;  // The '_eval__nba' function
     AstVarScope* m_dpiExportTriggerp = nullptr;  // The DPI export trigger variable
     AstVar* m_delaySchedulerp = nullptr;  // The delay scheduler variable
+    AstVarScope* m_nbaEventp = nullptr;  // The NBA event variable
+    AstVarScope* m_nbaEventTriggerp = nullptr;  // If set to 1, the NBA event should get triggered
     AstTopScope* m_topScopep = nullptr;  // The singleton AstTopScope under the top module
     VTimescale m_timeunit;  // Global time unit
     VTimescale m_timeprecision;  // Global time precision
@@ -1220,6 +1222,10 @@ public:
     void dpiExportTriggerp(AstVarScope* varScopep) { m_dpiExportTriggerp = varScopep; }
     AstVar* delaySchedulerp() const { return m_delaySchedulerp; }
     void delaySchedulerp(AstVar* const varScopep) { m_delaySchedulerp = varScopep; }
+    AstVarScope* nbaEventp() const { return m_nbaEventp; }
+    void nbaEventp(AstVarScope* const varScopep) { m_nbaEventp = varScopep; }
+    AstVarScope* nbaEventTriggerp() const { return m_nbaEventTriggerp; }
+    void nbaEventTriggerp(AstVarScope* const varScopep) { m_nbaEventTriggerp = varScopep; }
     void stdPackagep(AstPackage* const packagep) { m_stdPackagep = packagep; }
     AstPackage* stdPackagep() const { return m_stdPackagep; }
     AstTopScope* topScopep() const { return m_topScopep; }

--- a/src/V3AstNodes.cpp
+++ b/src/V3AstNodes.cpp
@@ -1939,6 +1939,8 @@ const char* AstNetlist::broken() const {
     BROKEN_RTN(m_dpiExportTriggerp && !m_dpiExportTriggerp->brokeExists());
     BROKEN_RTN(m_topScopep && !m_topScopep->brokeExists());
     BROKEN_RTN(m_delaySchedulerp && !m_delaySchedulerp->brokeExists());
+    BROKEN_RTN(m_nbaEventp && !m_nbaEventp->brokeExists());
+    BROKEN_RTN(m_nbaEventTriggerp && !m_nbaEventTriggerp->brokeExists());
     return nullptr;
 }
 AstPackage* AstNetlist::dollarUnitPkgAddp() {

--- a/src/V3Delayed.cpp
+++ b/src/V3Delayed.cpp
@@ -527,8 +527,12 @@ private:
         m_nextDlyp
             = VN_CAST(nodep->nextp(), AssignDly);  // Next assignment in same block, maybe nullptr.
         if (m_cfuncp) {
-            nodep->v3warn(E_UNSUPPORTED,
-                          "Unsupported: Delayed assignment inside public function/task");
+            if (!v3Global.rootp()->nbaEventp()) {
+                nodep->v3warn(
+                    E_NOTIMING,
+                    "Delayed assignment in a non-inlined function/task requires --timing");
+            }
+            return;
         }
         UASSERT_OBJ(m_procp, nodep, "Delayed assignment not under process");
         const bool isArray = VN_IS(nodep->lhsp(), ArraySel)

--- a/test_regress/t/t_assigndly_dynamic.pl
+++ b/test_regress/t/t_assigndly_dynamic.pl
@@ -1,0 +1,32 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2019 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    verilator_flags2 => ["--exe --main --timing"],
+    make_main => 0,
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+compile(
+    verilator_flags2 => ["--exe --main --timing +define+WITH_DELAY"],
+    make_main => 0,
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_assigndly_dynamic.v
+++ b/test_regress/t/t_assigndly_dynamic.v
@@ -1,0 +1,55 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed into the Public Domain, for any use,
+// without warranty, 2023 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+`ifdef WITH_DELAY
+`define DELAY #1
+`define TIME_AFTER_FIRST_WAIT 2
+`define TIME_AFTER_SECOND_WAIT 3
+`else
+`define DELAY
+`define TIME_AFTER_FIRST_WAIT 1
+`define TIME_AFTER_SECOND_WAIT 1
+`endif
+
+class nba_waiter;
+    // Task taken from UVM
+    task wait_for_nba_region;
+        int nba;
+        int next_nba;
+        next_nba++;
+        nba <= `DELAY next_nba;
+        @(nba);
+    endtask
+endclass
+
+module t;
+    nba_waiter waiter = new;
+    event e;
+    int cnt = 0;
+
+    initial begin
+        #1 ->e;
+        if (cnt != 0) $stop;
+        cnt++;
+        waiter.wait_for_nba_region;
+        ->e;
+        if (cnt != 2) $stop;
+        if ($time != `TIME_AFTER_FIRST_WAIT) $stop;
+        cnt++;
+        waiter.wait_for_nba_region;
+        if (cnt != 4) $stop;
+        if ($time != `TIME_AFTER_SECOND_WAIT) $stop;
+        $write("*-* All Finished *-*\n");
+        $finish;
+    end
+
+    initial begin
+        @e if (cnt != 1) $stop;
+        cnt++;
+        @e if (cnt != 3) $stop;
+        cnt++;
+    end
+endmodule

--- a/test_regress/t/t_assigndly_dynamic_notiming.out
+++ b/test_regress/t/t_assigndly_dynamic_notiming.out
@@ -1,0 +1,6 @@
+%Error-NOTIMING: t/t_assigndly_dynamic_notiming.v:10:13: Delayed assignment in a non-inlined function/task requires --timing
+                                                       : ... note: In instance '$unit::foo'
+   10 |         qux <= '1;
+      |             ^~
+                 ... For error description see https://verilator.org/warn/NOTIMING?v=latest
+%Error: Exiting due to

--- a/test_regress/t/t_assigndly_dynamic_notiming.pl
+++ b/test_regress/t/t_assigndly_dynamic_notiming.pl
@@ -1,0 +1,20 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2019 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    verilator_flags2 => ["--no-timing"],
+    fails => 1,
+    expect_filename => $Self->{golden_filename},
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_assigndly_dynamic_notiming.v
+++ b/test_regress/t/t_assigndly_dynamic_notiming.v
@@ -1,0 +1,12 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed into the Public Domain, for any use,
+// without warranty, 2023 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+class foo;
+    task bar;
+        int qux;
+        qux <= '1;
+    endtask
+endclass

--- a/test_regress/t/t_uvm_pkg_todo.vh
+++ b/test_regress/t/t_uvm_pkg_todo.vh
@@ -866,9 +866,7 @@ task uvm_wait_for_nba_region;
   int nba;
   int next_nba;
   next_nba++;
-//TODO issue #4496 - Delayed assignment inside public function/task
-//TODO  %Error-UNSUPPORTED: t/t_uvm_pkg_todo.vh:875:7: Unsupported: Delayed assignment inside public function/task
-//TODO  nba <= next_nba;
+  nba <= next_nba;
   @(nba);
 endtask
 function automatic void uvm_split_string (string str, byte sep, ref string values[$]);


### PR DESCRIPTION
Closes #4496

Before this patch, non-blocking assignments in non-inlined functions/tasks
resulted in an error like:

```
%Error-UNSUPPORTED: ...: Unsupported: Delayed assignment inside public function/task
```

That's because `V3Delayed` requires access to the process that contains the
assignment. That's not really possible if it's in a non-inlined function,
especially a virtual one.

A subtler problem is the lifetime of variables on the LHS of the assignment. In
an inlined function, these variables are static, so there is no issue. However,
if we're dealing with a non-static local variable, we have to make sure that it
still exists during the NBA region (or that the assignment is cancelled).

This patch adds support for NBAs in non-inlined functions/tasks as long as
`--timing` is used. This is an unfortunate limitation, but there are arguments
for this solution:
* Existing mechanisms for intra-assignment delays are reused, which requires a
  lot less effort than rolling a completely new solution,
* The lifetime issue is automatically solved thanks to using coroutines,
* The main motivation behind this is UVM and verification code that uses
UVM, which requires `--timing` anyway.

It must be said that this solution is not fully valid. It's easy to find
counterexamples that are scheduled incorrectly:

```systemverilog
module t;
    logic[15:0] nba;
    event e;

    task foo(logic recurse);
        if (recurse) foo(0);
        nba <= 'hDEAD;
    endtask

    always @e begin
        foo(0);
        nba <= 'hBEEF;
    end

    initial begin
        ->e;
        #1 $display("nba = %x", nba); // Should be 'beef',
                                      // prints 'dead'
        $finish;
    end
endmodule
```

In fact, I think it's impossible to have fully correct scheduling in Verilator
as long as there are basically two separate event queues (a static one and a
dynamic one).

However, I believe it is a good first pass, and probably enough for most use
cases.