### PR TITLE
Make VNDeleter a member of VNVisitor. No function change.

### DIFF
--- a/src/V3Ast.h
+++ b/src/V3Ast.h
@@ -1568,12 +1568,9 @@ public:
     /// Return edited nodep; see comments in V3Ast.cpp
     inline AstNode* iterateSubtreeReturnEdits(AstNode* nodep);
 
-    inline void pushDeletep(AstNode* nodep) {
-        deleter.pushDeletep(nodep);
-    }
-    inline void doDeletes() {
-        deleter.doDeletes();
-    }
+    inline VNDeleter& getDeleter() { return deleter; }
+    inline void pushDeletep(AstNode* nodep) { deleter.pushDeletep(nodep); }
+    inline void doDeletes() { deleter.doDeletes(); }
 };
 
 //######################################################################

--- a/src/V3Ast.h
+++ b/src/V3Ast.h
@@ -1568,9 +1568,9 @@ public:
     /// Return edited nodep; see comments in V3Ast.cpp
     inline AstNode* iterateSubtreeReturnEdits(AstNode* nodep);
 
-    inline VNDeleter& getDeleter() { return deleter; }
-    inline void pushDeletep(AstNode* nodep) { deleter.pushDeletep(nodep); }
-    inline void doDeletes() { deleter.doDeletes(); }
+    VNDeleter& getDeleter() { return deleter; }
+    void pushDeletep(AstNode* nodep) { deleter.pushDeletep(nodep); }
+    void doDeletes() { deleter.doDeletes(); }
 };
 
 //######################################################################

--- a/src/V3Ast.h
+++ b/src/V3Ast.h
@@ -1502,7 +1502,7 @@ public:
 // nodes needs to be deferred to a later time, because pointers to the
 // removed nodes might still exist.
 
-class VNDeleter {
+class VNDeleter final {
     // MEMBERS
     std::vector<AstNode*> m_deleteps;  // Nodes to delete
 

--- a/src/V3Ast.h
+++ b/src/V3Ast.h
@@ -1555,7 +1555,7 @@ public:
 // type without changing the base classes.  See "Modern C++ Design".
 
 class VNVisitor VL_NOT_FINAL : public VNVisitorConst {
-    VNDeleter deleter;  // Used to delete nodes
+    VNDeleter m_deleter;  // Used to delay deletion of nodes
 public:
     /// Call visit()s on nodep
     inline void iterate(AstNode* nodep);
@@ -1568,9 +1568,9 @@ public:
     /// Return edited nodep; see comments in V3Ast.cpp
     inline AstNode* iterateSubtreeReturnEdits(AstNode* nodep);
 
-    VNDeleter& getDeleter() { return deleter; }
-    void pushDeletep(AstNode* nodep) { deleter.pushDeletep(nodep); }
-    void doDeletes() { deleter.doDeletes(); }
+    VNDeleter& deleter() { return m_deleter; }
+    void pushDeletep(AstNode* nodep) { deleter().pushDeletep(nodep); }
+    void doDeletes() { deleter().doDeletes(); }
 };
 
 //######################################################################

--- a/src/V3Ast.h
+++ b/src/V3Ast.h
@@ -1502,7 +1502,7 @@ public:
 // nodes needs to be deferred to a later time, because pointers to the
 // removed nodes might still exist.
 
-class VNDeleter VL_NOT_FINAL {
+class VNDeleter {
     // MEMBERS
     std::vector<AstNode*> m_deleteps;  // Nodes to delete
 
@@ -1515,11 +1515,11 @@ public:
         m_deleteps.push_back(nodep);
     }
 
-    // Delete all previously pushed nodes (by callint deleteTree)
+    // Delete all previously pushed nodes (by calling deleteTree)
     void doDeletes();
 
     // Do the deletions on destruction
-    virtual ~VNDeleter() { doDeletes(); }
+    ~VNDeleter() { doDeletes(); }
 };
 
 //######################################################################
@@ -1528,7 +1528,7 @@ public:
 // This only has the constant fuctions for non-modifying visitors.
 // For more typical usage see VNVisitor
 
-class VNVisitorConst VL_NOT_FINAL : public VNDeleter {
+class VNVisitorConst VL_NOT_FINAL {
     friend class AstNode;
 
 public:
@@ -1546,6 +1546,7 @@ public:
     inline void iterateAndNextConstNullBackwards(AstNode* nodep);
 
     virtual void visit(AstNode* nodep) = 0;
+    virtual ~VNVisitorConst() {}
 #include "V3Ast__gen_visitor_decls.h"  // From ./astgen
 };
 
@@ -1554,6 +1555,7 @@ public:
 // type without changing the base classes.  See "Modern C++ Design".
 
 class VNVisitor VL_NOT_FINAL : public VNVisitorConst {
+    VNDeleter deleter;  // Used to delete nodes
 public:
     /// Call visit()s on nodep
     inline void iterate(AstNode* nodep);
@@ -1565,6 +1567,13 @@ public:
     inline void iterateAndNextNull(AstNode* nodep);
     /// Return edited nodep; see comments in V3Ast.cpp
     inline AstNode* iterateSubtreeReturnEdits(AstNode* nodep);
+
+    inline void pushDeletep(AstNode* nodep) {
+        deleter.pushDeletep(nodep);
+    }
+    inline void doDeletes() {
+        deleter.doDeletes();
+    }
 };
 
 //######################################################################

--- a/src/V3Const.cpp
+++ b/src/V3Const.cpp
@@ -716,7 +716,7 @@ public:
                 }
                 // Set width and widthMin precisely
                 resultp->dtypeChgWidth(resultWidth, 1);
-                for (AstNode* const termp : termps) deleter.pushDeletep(termp);
+                for (AstNode* const termp : termps) deleterr.pushDeletep(termp);
                 return resultp;
             }
             const ResultTerm result = v->getResultTerm();
@@ -792,7 +792,7 @@ public:
 
         // Only substitute the result if beneficial as determined by operation count
         if (visitor.m_ops <= resultOps) {
-            for (AstNode* const termp : termps) deleter.pushDeletep(termp);
+            for (AstNode* const termp : termps) deleterr.pushDeletep(termp);
             return nullptr;
         }
 
@@ -1176,10 +1176,10 @@ private:
         const int width = nodep->width();
         if (andp && isConst(andp->lhsp(), 1)) {  // 1 & BitOpTree
             newp = ConstBitOpTreeVisitor::simplify(andp->rhsp(), width, 1, m_statBitOpReduction,
-                                                   getDeleter());
+                                                   deleter());
         } else {  // BitOpTree
             newp = ConstBitOpTreeVisitor::simplify(nodep, width, 0, m_statBitOpReduction,
-                                                   getDeleter());
+                                                   deleter());
         }
 
         if (newp) {

--- a/src/V3Const.cpp
+++ b/src/V3Const.cpp
@@ -1012,7 +1012,7 @@ private:
         return (lp && rp && lp->width() == rp->width() && lp->type() == rp->type()
                 && (operandsSame(lp->lhsp(), rp->lhsp()) || operandsSame(lp->rhsp(), rp->rhsp())));
     }
-    static bool matchOrAndNot(AstNodeBiop* nodep) {
+    bool matchOrAndNot(AstNodeBiop* nodep) {
         // AstOr{$a, AstAnd{AstNot{$b}, $c}} if $a.width1, $a==$b => AstOr{$a,$c}
         // Someday we'll sort the biops completely and this can be simplified
         // This often results from our simplified clock generation:
@@ -1043,7 +1043,7 @@ private:
         if (!operandsSame(ap, bp)) return false;
         // Do it
         cp->unlinkFrBack();
-        VL_DO_DANGLING(andp->unlinkFrBack()->deleteTree(), andp);
+        VL_DO_DANGLING(pushDeletep(andp->unlinkFrBack()), andp);
         VL_DANGLING(notp);
         // Replace whichever branch is now dangling
         if (nodep->rhsp()) {

--- a/src/V3Const.cpp
+++ b/src/V3Const.cpp
@@ -673,7 +673,7 @@ public:
     // Reduction ops are transformed in the same way.
     // &{v[0], v[1]} => 2'b11 == (2'b11 & v)
     static AstNodeExpr* simplify(AstNodeExpr* nodep, int resultWidth, unsigned externalOps,
-                                 VDouble0& reduction, VNDeleter& deleter) {
+                                 VDouble0& reduction, VNDeleter& deleterr) {
         UASSERT_OBJ(1 <= resultWidth && resultWidth <= 64, nodep, "resultWidth out of range");
 
         // Walk tree, gathering all terms referenced in expression

--- a/src/V3Order.cpp
+++ b/src/V3Order.cpp
@@ -901,7 +901,7 @@ class OrderProcess final {
         , m_deleteDomainp{makeDeleteDomainSenTree(netlistp->fileline())}
         , m_tag{tag}
         , m_slow{slow} {
-        deleter.pushDeletep(m_deleteDomainp);
+        m_deleter.pushDeletep(m_deleteDomainp);
     }
 
     ~OrderProcess() = default;
@@ -1224,7 +1224,7 @@ AstActive* OrderProcess::processMoveOneLogic(const OrderLogicVertex* lvertexp,
         needProcess = procp->needProcess();
         if (suspendable) slow = slow && !VN_IS(procp, Always);
         nodep = procp->stmtsp();
-        deleter.pushDeletep(procp);
+        m_deleter.pushDeletep(procp);
     }
 
     // Put suspendable processes into individual functions on their own
@@ -1271,7 +1271,7 @@ AstActive* OrderProcess::processMoveOneLogic(const OrderLogicVertex* lvertexp,
         if (nodep->backp()) nodep->unlinkFrBack();
 
         if (domainp == m_deleteDomainp) {
-            VL_DO_DANGLING(deleter.pushDeletep(nodep), nodep);
+            VL_DO_DANGLING(m_deleter.pushDeletep(nodep), nodep);
         } else {
             newFuncpr->addStmtsp(nodep);
             // Add in the number of nodes we're adding

--- a/src/V3Order.cpp
+++ b/src/V3Order.cpp
@@ -829,7 +829,7 @@ class OrderProcess final {
     friend class OrderMoveDomScope;
     V3List<OrderMoveDomScope*> m_pomReadyDomScope;  // List of ready domain/scope pairs, by loopId
     std::map<std::pair<AstNodeModule*, std::string>, unsigned> m_funcNums;  // Function ordinals
-    VNDeleter m_deleter;  // Used to delete nodes
+    VNDeleter m_deleter;  // Used to delay deletion of nodes
 
     // METHODS
 

--- a/src/V3Order.cpp
+++ b/src/V3Order.cpp
@@ -829,7 +829,7 @@ class OrderProcess final {
     friend class OrderMoveDomScope;
     V3List<OrderMoveDomScope*> m_pomReadyDomScope;  // List of ready domain/scope pairs, by loopId
     std::map<std::pair<AstNodeModule*, std::string>, unsigned> m_funcNums;  // Function ordinals
-    VNDeleter deleter;  // Used to delete nodes
+    VNDeleter m_deleter;  // Used to delete nodes
 
     // METHODS
 

--- a/src/V3Param.cpp
+++ b/src/V3Param.cpp
@@ -277,7 +277,7 @@ class ParamProcessor final {
     using DefaultValueMap = std::map<std::string, AstConst*>;
     // Default parameter values of hierarchical blocks
     std::map<AstNodeModule*, DefaultValueMap> m_defaultParameterValues;
-    VNDeleter m_deleter;  // Used to delete nodes
+    VNDeleter m_deleter;  // Used to delay deletion of nodes
 
     // METHODS
 

--- a/src/V3Param.cpp
+++ b/src/V3Param.cpp
@@ -223,7 +223,7 @@ public:
 //######################################################################
 // Remove parameters from cells and build new modules
 
-class ParamProcessor final : public VNDeleter {
+class ParamProcessor final {
     // NODE STATE - Local
     //   AstVar::user4()        // int    Global parameter number (for naming new module)
     //                          //        (0=not processed, 1=iterated, but no number,
@@ -277,6 +277,7 @@ class ParamProcessor final : public VNDeleter {
     using DefaultValueMap = std::map<std::string, AstConst*>;
     // Default parameter values of hierarchical blocks
     std::map<AstNodeModule*, DefaultValueMap> m_defaultParameterValues;
+    VNDeleter deleter;  // Used to delete nodes
 
     // METHODS
 
@@ -868,7 +869,7 @@ class ParamProcessor final : public VNDeleter {
                 AstClass* classCopyp = VN_AS(srcModpr, Class)->cloneTree(false);
                 // It is a temporary copy of the original class node, stored in order to create
                 // another instances. It is needed only during class instantiation.
-                pushDeletep(classCopyp);
+                deleter.pushDeletep(classCopyp);
                 srcModpr->user4p(classCopyp);
                 storeOriginalParams(classCopyp);
             }

--- a/src/V3Param.cpp
+++ b/src/V3Param.cpp
@@ -869,7 +869,7 @@ class ParamProcessor final {
                 AstClass* classCopyp = VN_AS(srcModpr, Class)->cloneTree(false);
                 // It is a temporary copy of the original class node, stored in order to create
                 // another instances. It is needed only during class instantiation.
-                deleter.pushDeletep(classCopyp);
+                m_deleter.pushDeletep(classCopyp);
                 srcModpr->user4p(classCopyp);
                 storeOriginalParams(classCopyp);
             }

--- a/src/V3Param.cpp
+++ b/src/V3Param.cpp
@@ -277,7 +277,7 @@ class ParamProcessor final {
     using DefaultValueMap = std::map<std::string, AstConst*>;
     // Default parameter values of hierarchical blocks
     std::map<AstNodeModule*, DefaultValueMap> m_defaultParameterValues;
-    VNDeleter deleter;  // Used to delete nodes
+    VNDeleter m_deleter;  // Used to delete nodes
 
     // METHODS
 


### PR DESCRIPTION
It makes VNDeleter object a member of VNVIsitor, as was proposed in the discussion in https://github.com/verilator/verilator/pull/4552. It also replaces calls of `deleteTree` with `pushDeletep` in static methods in V3Const.