### PR TITLE
Fix dictionaries with keys of class types

### DIFF
--- a/include/verilated_types.h
+++ b/include/verilated_types.h
@@ -1629,6 +1629,10 @@ public:
     bool operator!=(const VlClassRef<T_OtherClass>& rhs) const {
         return m_objp != rhs.m_objp;
     };
+    template <typename T_OtherClass>
+    bool operator<(const VlClassRef<T_OtherClass>& rhs) const {
+        return m_objp < rhs.m_objp;
+    };
 };
 
 template <typename T, typename U>

--- a/test_regress/t/t_class_dict.pl
+++ b/test_regress/t/t_class_dict.pl
@@ -1,0 +1,21 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2020 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_class_dict.v
+++ b/test_regress/t/t_class_dict.v
@@ -1,0 +1,29 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2023 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+`define stop $stop
+`define checkh(gotv,expv) do if ((gotv) !== (expv)) begin $write("%%Error: %s:%0d:  got='h%x exp='h%x\n", `__FILE__,`__LINE__, (gotv), (expv)); $stop; end while(0);
+
+class Cls;
+   int x;
+   function new(int a);
+      x = a;
+   endfunction
+endclass
+
+module t (/*AUTOARG*/);
+   initial begin
+      int dict[Cls];
+      Cls c1 = new(1);
+      Cls c2 = new(2);
+      dict[c1] = 1;
+      dict[c2] = 2;
+      `checkh(dict[c1], 1);
+
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end
+endmodule

--- a/test_regress/t/t_class_dict.v
+++ b/test_regress/t/t_class_dict.v
@@ -22,6 +22,7 @@ module t (/*AUTOARG*/);
       dict[c1] = 1;
       dict[c2] = 2;
       `checkh(dict[c1], 1);
+      `checkh(dict[c2], 2);
 
       $write("*-* All Finished *-*\n");
       $finish;


### PR DESCRIPTION
Currently, all keys being class objects are considered equivalent. It is because the keys of std::map in c++ are compared with `<` operator and this operator isn't defined in VlClassRef. The operands are converted to `bool` values, so all VlClassRef objects that don't point to `nullptr` are treated as `true` so they are all considered as the same value.
This PR fixes it by overriding `<` operator.