### PR TITLE
Support compiling Verilator with gcc/clang precompiled headers

### DIFF
--- a/Changes
+++ b/Changes
@@ -19,6 +19,7 @@ Verilator 5.017 devel
 * Support randc (#4349).
 * Support resizing function call inout arguments (#4467).
 * Support converting parameters inside modules to localparams (#4511). [Anthony Donlon]
+* Support compilation with precompiled headers with Make and GCC or CLang.
 * Change lint_off to not propagate upwards to files including where the lint_off is.
 * Optimize empty expression statements (#4544).
 * Fix conversion of impure logical expressions to bit expressions (#487 partial) (#4437). [Ryszard Rozak, Antmicro Ltd.]

--- a/configure.ac
+++ b/configure.ac
@@ -560,6 +560,21 @@ Verilator requires a C++11 or newer compiler.]])
 fi
 AC_SUBST(CFG_CXXFLAGS_STD)
 
+# Compiler precompiled header options (assumes either gcc or clang++)
+AC_MSG_CHECKING([for $CXX precompile header include option])
+if $CXX --help | grep include-pch >/dev/null 2>/dev/null ; then
+   # clang
+   CFG_CXXFLAGS_PCH_I=-include-pch
+   CFG_GCH_IF_CLANG=.gch
+else
+   # GCC
+   CFG_CXXFLAGS_PCH_I=-include
+   CFG_GCH_IF_CLANG=
+fi
+AC_MSG_RESULT($CFG_CXXFLAGS_PCH_I)
+AC_SUBST(CFG_CXXFLAGS_PCH_I)
+AC_SUBST(CFG_GCH_IF_CLANG)
+
 # Checks for library functions.
 AC_CHECK_MEMBER([struct stat.st_mtim.tv_nsec],
     [AC_DEFINE([HAVE_STAT_NSEC],[1],[Defined if struct stat has st_mtim.tv_nsec])],

--- a/src/Makefile_obj.in
+++ b/src/Makefile_obj.in
@@ -67,6 +67,11 @@ CFG_CXXFLAGS_PARSER = @CFG_CXXFLAGS_PARSER@
 CFG_CXXFLAGS_WEXTRA = @CFG_CXXFLAGS_WEXTRA@
 CFG_LDFLAGS_SRC = @CFG_LDFLAGS_SRC@
 CFG_LIBS = @CFG_LIBS@
+CFG_CXXFLAGS_PCH = -x c++-header
+# Compiler option to put in front of filename to read precompiled header
+CFG_CXXFLAGS_PCH_I = @CFG_CXXFLAGS_PCH_I@
+# Compiler's filename prefix for precompiled headers, .gch if clang, empty if GCC
+CFG_GCH_IF_CLANG = @CFG_GCH_IF_CLANG@
 
 #### End of system configuration section. ####
 
@@ -130,6 +135,11 @@ FLEXFIX = $(srcdir)/flexfix
 VLCOVGEN = $(srcdir)/vlcovgen
 
 ######################################################################
+# CCACHE flags (via environment as no command line option available)
+CCACHE_SLOPPINESS ?= pch_defines,time_macros
+export CCACHE_SLOPPINESS
+
+######################################################################
 #### Top level
 
 all: make_info $(TGT)
@@ -151,16 +161,54 @@ maintainer-copy::
 #### Top executable
 
 RAW_OBJS = \
+	V3Const__gen.o \
+	V3Error.o \
+	V3FileLine.o \
+	V3Graph.o \
+	V3GraphAcyc.o \
+	V3GraphAlg.o \
+	V3GraphPathChecker.o \
+	V3GraphTest.o \
+	V3Hash.o \
+	V3OptionParser.o \
+	V3Os.o \
+	V3ParseGrammar.o \
+	V3ParseImp.o \
+	V3ParseLex.o \
+	V3PreProc.o \
+	V3PreShell.o \
+	V3String.o \
+	V3ThreadPool.o \
+	V3Waiver.o \
 	Verilator.o \
+
+RAW_OBJS_PCH_ASTMT = \
+	V3Ast.o \
+	V3AstNodes.o \
+	V3Broken.o \
+	V3Config.o \
+	V3EmitCBase.o \
+	V3EmitCConstPool.o \
+	V3EmitCFunc.o \
+	V3EmitCHeaders.o \
+	V3EmitCImp.o \
+	V3EmitCInlines.o \
+	V3EmitV.o \
+	V3File.o \
+	V3Global.o \
+	V3Hasher.o \
+	V3Number.o \
+	V3Options.o \
+	V3Stats.o \
+	V3StatsReport.o \
+
+RAW_OBJS_PCH_ASTNOMT = \
 	V3Active.o \
 	V3ActiveTop.o \
 	V3Assert.o \
 	V3AssertPre.o \
-	V3Ast.o \
-	V3AstNodes.o \
 	V3Begin.o \
 	V3Branch.o \
-	V3Broken.o \
 	V3CCtors.o \
 	V3CUse.o \
 	V3Case.o \
@@ -170,8 +218,6 @@ RAW_OBJS = \
 	V3Clock.o \
 	V3Combine.o \
 	V3Common.o \
-	V3Config.o \
-	V3Const__gen.o \
 	V3Coverage.o \
 	V3CoverageJoin.o \
 	V3Dead.o \
@@ -187,34 +233,16 @@ RAW_OBJS = \
 	V3DfgPasses.o \
 	V3DfgPeephole.o \
 	V3DupFinder.o \
-	V3EmitCBase.o \
-	V3EmitCConstPool.o \
-	V3EmitCFunc.o \
-	V3EmitCHeaders.o \
-	V3EmitCImp.o \
-	V3EmitCInlines.o \
 	V3EmitCMain.o \
 	V3EmitCMake.o \
 	V3EmitCModel.o \
 	V3EmitCSyms.o \
 	V3EmitMk.o \
-	V3EmitV.o \
 	V3EmitXml.o \
-	V3Error.o \
 	V3Expand.o \
-	V3File.o \
-	V3FileLine.o \
 	V3Force.o \
 	V3Fork.o \
 	V3Gate.o \
-	V3Global.o \
-	V3Graph.o \
-	V3GraphAcyc.o \
-	V3GraphAlg.o \
-	V3GraphPathChecker.o \
-	V3GraphTest.o \
-	V3Hash.o \
-	V3Hasher.o \
 	V3HierBlock.o \
 	V3Inline.o \
 	V3Inst.o \
@@ -233,18 +261,9 @@ RAW_OBJS = \
 	V3Localize.o \
 	V3MergeCond.o \
 	V3Name.o \
-	V3Number.o \
-	V3OptionParser.o \
-	V3Options.o \
 	V3Order.o \
-	V3Os.o \
 	V3Param.o \
-	V3ParseGrammar.o \
-	V3ParseImp.o \
-	V3ParseLex.o \
 	V3Partition.o \
-	V3PreProc.o \
-	V3PreShell.o \
 	V3Premit.o \
 	V3ProtectLib.o \
 	V3Randomize.o \
@@ -260,14 +279,10 @@ RAW_OBJS = \
 	V3Split.o \
 	V3SplitAs.o \
 	V3SplitVar.o \
-	V3Stats.o \
-	V3StatsReport.o \
-	V3String.o \
 	V3Subst.o \
 	V3TSP.o \
 	V3Table.o \
 	V3Task.o \
-	V3ThreadPool.o \
 	V3Timing.o \
 	V3Trace.o \
 	V3TraceDecl.o \
@@ -276,7 +291,6 @@ RAW_OBJS = \
 	V3Unknown.o \
 	V3Unroll.o \
 	V3VariableOrder.o \
-	V3Waiver.o \
 	V3Width.o \
 	V3WidthCommit.o \
 	V3WidthSel.o \
@@ -286,21 +300,21 @@ VLCOV_OBJS = \
 	VlcMain.o \
 
 NON_STANDALONE_HEADERS = \
-	V3AstInlines.h  \
-	V3AstNodeDType.h  \
-	V3AstNodeExpr.h  \
-	V3AstNodeOther.h  \
-	V3DfgVertices.h  \
+	V3AstInlines.h \
+	V3AstNodeDType.h \
+	V3AstNodeExpr.h \
+	V3AstNodeOther.h \
+	V3DfgVertices.h \
 	V3ThreadPool.h \
 	V3WidthRemove.h \
 
 AST_DEFS := \
-  V3AstNodeDType.h \
-  V3AstNodeExpr.h \
-  V3AstNodeOther.h \
+	V3AstNodeDType.h \
+	V3AstNodeExpr.h \
+	V3AstNodeOther.h \
 
 DFG_DEFS := \
-  V3DfgVertices.h
+	V3DfgVertices.h
 
 #### astgen common flags
 
@@ -312,7 +326,7 @@ ASTGENFLAGS += $(foreach f,$(DFG_DEFS),--dfgdef $f)
 
 ifeq ($(VL_VLCOV),)
 PREDEP_H = V3Ast__gen_forward_class_decls.h
-OBJS += $(RAW_OBJS)
+OBJS += $(RAW_OBJS) $(RAW_OBJS_PCH_ASTMT) $(RAW_OBJS_PCH_ASTNOMT)
 else
 PREDEP_H =
 OBJS += $(VLCOV_OBJS)
@@ -332,6 +346,8 @@ V3Number_test: V3Number_test.o
 
 .SECONDARY:
 
+%.gch: %
+	$(OBJCACHE) ${CXX} ${CXXFLAGS} ${CPPFLAGSWALL} ${CFG_CXXFLAGS_PCH} $< -o $@
 %.o: %.cpp
 	$(OBJCACHE) ${CXX} ${CXXFLAGS} ${CPPFLAGSWALL} -c $< -o $@
 %.o: %.c
@@ -348,6 +364,22 @@ V3ParseImp.o: V3ParseImp.cpp V3ParseBison.c
 
 V3PreProc.o: V3PreProc.cpp V3PreLex.yy.cpp
 	$(OBJCACHE) ${CXX} ${CXXFLAGS} ${CPPFLAGSPARSER} -c $< -o $@
+
+define CXX_ASTMT_template
+$(1): $(basename $(1)).cpp V3PchAstMT.h.gch
+	$(OBJCACHE) ${CXX} ${CXXFLAGS} ${CPPFLAGSWALL} ${CFG_CXXFLAGS_PCH_I} V3PchAstMT.h${CFG_GCH_IF_CLANG} -c $(srcdir)/$(basename $(1)).cpp -o $(1)
+
+endef
+
+$(foreach obj,$(RAW_OBJS_PCH_ASTMT),$(eval $(call CXX_ASTMT_template,$(obj))))
+
+define CXX_ASTNOMT_template
+$(1): $(basename $(1)).cpp V3PchAstNoMT.h.gch
+	$(OBJCACHE) ${CXX} ${CXXFLAGS} ${CPPFLAGSWALL} ${CFG_CXXFLAGS_PCH_I} V3PchAstNoMT.h${CFG_GCH_IF_CLANG} -c $(srcdir)/$(basename $(1)).cpp -o $(1)
+
+endef
+
+$(foreach obj,$(RAW_OBJS_PCH_ASTNOMT),$(eval $(call CXX_ASTNOMT_template,$(obj))))
 
 #### Generated files
 

--- a/src/V3Active.cpp
+++ b/src/V3Active.cpp
@@ -26,16 +26,11 @@
 //
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
-
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
 #include "V3Active.h"
 
-#include "V3Ast.h"
 #include "V3Const.h"
-#include "V3Global.h"
 #include "V3Graph.h"
 
 #include <unordered_map>

--- a/src/V3ActiveTop.cpp
+++ b/src/V3ActiveTop.cpp
@@ -23,16 +23,11 @@
 //
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
-
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
 #include "V3ActiveTop.h"
 
-#include "V3Ast.h"
 #include "V3Const.h"
-#include "V3Global.h"
 #include "V3SenTree.h"
 
 VL_DEFINE_DEBUG_FUNCTIONS;

--- a/src/V3Assert.cpp
+++ b/src/V3Assert.cpp
@@ -14,16 +14,10 @@
 //
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
-
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
 #include "V3Assert.h"
 
-#include "V3Ast.h"
-#include "V3Error.h"
-#include "V3Global.h"
 #include "V3Stats.h"
 
 VL_DEFINE_DEBUG_FUNCTIONS;

--- a/src/V3AssertPre.cpp
+++ b/src/V3AssertPre.cpp
@@ -19,16 +19,11 @@
 //      Transform clocking blocks into imperative logic
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
-
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
 #include "V3AssertPre.h"
 
-#include "V3Ast.h"
 #include "V3Const.h"
-#include "V3Global.h"
 #include "V3Task.h"
 #include "V3UniqueNames.h"
 

--- a/src/V3Ast.cpp
+++ b/src/V3Ast.cpp
@@ -14,16 +14,11 @@
 //
 //*************************************************************************
 
-#include "config_build.h"
-#include "verilatedos.h"
-
-#include "V3Ast.h"
+#include "V3PchAstMT.h"
 
 #include "V3Broken.h"
 #include "V3EmitV.h"
 #include "V3File.h"
-#include "V3Global.h"
-#include "V3String.h"
 
 #include <iomanip>
 #include <memory>

--- a/src/V3AstNodes.cpp
+++ b/src/V3AstNodes.cpp
@@ -14,6 +14,8 @@
 //
 //*************************************************************************
 
+#include "V3PchAstMT.h"
+
 #include "config_build.h"
 #include "verilatedos.h"
 

--- a/src/V3Begin.cpp
+++ b/src/V3Begin.cpp
@@ -26,17 +26,9 @@
 //
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
-
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
 #include "V3Begin.h"
-
-#include "V3Ast.h"
-#include "V3Global.h"
-
-#include <algorithm>
 
 VL_DEFINE_DEBUG_FUNCTIONS;
 

--- a/src/V3Branch.cpp
+++ b/src/V3Branch.cpp
@@ -23,17 +23,9 @@
 //
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
-
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
 #include "V3Branch.h"
-
-#include "V3Ast.h"
-#include "V3Global.h"
-
-#include <map>
 
 VL_DEFINE_DEBUG_FUNCTIONS;
 

--- a/src/V3Broken.cpp
+++ b/src/V3Broken.cpp
@@ -22,13 +22,9 @@
 //
 //*************************************************************************
 
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstMT.h"
 
 #include "V3Broken.h"
-
-#include "V3Ast.h"
-#include "V3Global.h"
 
 // This visitor does not edit nodes, and is called at error-exit, so should use constant iterators
 #include "V3AstConstOnly.h"

--- a/src/V3CCtors.cpp
+++ b/src/V3CCtors.cpp
@@ -24,17 +24,12 @@
 //      This transformation honors outputSplitCFuncs.
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
-
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
 #include "V3CCtors.h"
 
 #include "V3EmitCBase.h"
-#include "V3Global.h"
 
-#include <algorithm>
 #include <list>
 
 VL_DEFINE_DEBUG_FUNCTIONS;

--- a/src/V3CUse.cpp
+++ b/src/V3CUse.cpp
@@ -22,19 +22,9 @@
 //
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
-
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
 #include "V3CUse.h"
-
-#include "V3Ast.h"
-#include "V3FileLine.h"
-#include "V3Global.h"
-
-#include <map>
-#include <utility>
 
 VL_DEFINE_DEBUG_FUNCTIONS;
 

--- a/src/V3Case.cpp
+++ b/src/V3Case.cpp
@@ -34,18 +34,11 @@
 //
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
-
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
 #include "V3Case.h"
 
-#include "V3Ast.h"
-#include "V3Global.h"
 #include "V3Stats.h"
-
-#include <algorithm>
 
 VL_DEFINE_DEBUG_FUNCTIONS;
 

--- a/src/V3Cast.cpp
+++ b/src/V3Cast.cpp
@@ -37,17 +37,9 @@
 //
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
-
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
 #include "V3Cast.h"
-
-#include "V3Ast.h"
-#include "V3Global.h"
-
-#include <algorithm>
 
 VL_DEFINE_DEBUG_FUNCTIONS;
 

--- a/src/V3Class.cpp
+++ b/src/V3Class.cpp
@@ -20,15 +20,10 @@
 //
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
-
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
 #include "V3Class.h"
 
-#include "V3Ast.h"
-#include "V3Global.h"
 #include "V3UniqueNames.h"
 
 VL_DEFINE_DEBUG_FUNCTIONS;

--- a/src/V3Clean.cpp
+++ b/src/V3Clean.cpp
@@ -23,17 +23,9 @@
 //
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
-
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
 #include "V3Clean.h"
-
-#include "V3Ast.h"
-#include "V3Global.h"
-
-#include <algorithm>
 
 VL_DEFINE_DEBUG_FUNCTIONS;
 

--- a/src/V3Clock.cpp
+++ b/src/V3Clock.cpp
@@ -27,18 +27,11 @@
 //
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
-
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
 #include "V3Clock.h"
 
-#include "V3Ast.h"
-#include "V3Global.h"
 #include "V3Sched.h"
-
-#include <algorithm>
 
 VL_DEFINE_DEBUG_FUNCTIONS;
 

--- a/src/V3Combine.cpp
+++ b/src/V3Combine.cpp
@@ -19,17 +19,12 @@
 //      Also drop empty CFuncs
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
-
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
 #include "V3Combine.h"
 
-#include "V3Ast.h"
 #include "V3AstUserAllocator.h"
 #include "V3DupFinder.h"
-#include "V3Global.h"
 #include "V3Stats.h"
 
 #include <list>

--- a/src/V3Common.cpp
+++ b/src/V3Common.cpp
@@ -20,16 +20,11 @@
 //
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
-
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
 #include "V3Common.h"
 
-#include "V3Ast.h"
 #include "V3EmitCBase.h"
-#include "V3Global.h"
 
 VL_DEFINE_DEBUG_FUNCTIONS;
 

--- a/src/V3Config.cpp
+++ b/src/V3Config.cpp
@@ -14,17 +14,13 @@
 //
 //*************************************************************************
 
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstMT.h"
 
 #include "V3Config.h"
 
-#include "V3Global.h"
 #include "V3String.h"
 
-#include <map>
 #include <set>
-#include <string>
 #include <unordered_map>
 
 VL_DEFINE_DEBUG_FUNCTIONS;

--- a/src/V3Coverage.cpp
+++ b/src/V3Coverage.cpp
@@ -24,17 +24,10 @@
 //
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
-
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
 #include "V3Coverage.h"
 
-#include "V3Ast.h"
-#include "V3Global.h"
-
-#include <map>
 #include <unordered_map>
 
 VL_DEFINE_DEBUG_FUNCTIONS;

--- a/src/V3CoverageJoin.cpp
+++ b/src/V3CoverageJoin.cpp
@@ -17,15 +17,11 @@
 //      If two COVERTOGGLEs have same VARSCOPE, combine them
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
-
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
 #include "V3CoverageJoin.h"
 
 #include "V3DupFinder.h"
-#include "V3Global.h"
 #include "V3Stats.h"
 
 #include <vector>

--- a/src/V3Dead.cpp
+++ b/src/V3Dead.cpp
@@ -33,17 +33,10 @@
 // here after scoping to allow more dead node removal.
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
-
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
 #include "V3Dead.h"
 
-#include "V3Ast.h"
-#include "V3Global.h"
-
-#include <map>
 #include <vector>
 
 VL_DEFINE_DEBUG_FUNCTIONS;

--- a/src/V3Delayed.cpp
+++ b/src/V3Delayed.cpp
@@ -48,20 +48,13 @@
 //
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
-
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
 #include "V3Delayed.h"
 
-#include "V3Ast.h"
-#include "V3Global.h"
 #include "V3Stats.h"
 
-#include <algorithm>
 #include <deque>
-#include <map>
 
 VL_DEFINE_DEBUG_FUNCTIONS;
 

--- a/src/V3Depth.cpp
+++ b/src/V3Depth.cpp
@@ -23,18 +23,11 @@
 //
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
-
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
 #include "V3Depth.h"
 
-#include "V3Ast.h"
-#include "V3Global.h"
 #include "V3UniqueNames.h"
-
-#include <algorithm>
 
 VL_DEFINE_DEBUG_FUNCTIONS;
 

--- a/src/V3DepthBlock.cpp
+++ b/src/V3DepthBlock.cpp
@@ -20,18 +20,11 @@
 //
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
-
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
 #include "V3DepthBlock.h"
 
-#include "V3Ast.h"
 #include "V3EmitCBase.h"
-#include "V3Global.h"
-
-#include <algorithm>
 
 VL_DEFINE_DEBUG_FUNCTIONS;
 

--- a/src/V3Descope.cpp
+++ b/src/V3Descope.cpp
@@ -22,18 +22,11 @@
 //
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
-
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
 #include "V3Descope.h"
 
-#include "V3Ast.h"
 #include "V3EmitCBase.h"
-#include "V3Global.h"
-
-#include <map>
 
 VL_DEFINE_DEBUG_FUNCTIONS;
 

--- a/src/V3Dfg.cpp
+++ b/src/V3Dfg.cpp
@@ -14,10 +14,7 @@
 //
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
-
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
 #include "V3Dfg.h"
 

--- a/src/V3DfgAstToDfg.cpp
+++ b/src/V3DfgAstToDfg.cpp
@@ -26,16 +26,10 @@
 //
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
-#include "config_build.h"
-#include "verilatedos.h"
-
-#include "V3Ast.h"
 #include "V3Dfg.h"
 #include "V3DfgPasses.h"
-#include "V3Error.h"
-#include "V3Global.h"
 
 VL_DEFINE_DEBUG_FUNCTIONS;
 

--- a/src/V3DfgDecomposition.cpp
+++ b/src/V3DfgDecomposition.cpp
@@ -18,10 +18,7 @@
 //
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
-
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
 #include "V3Dfg.h"
 #include "V3File.h"

--- a/src/V3DfgDfgToAst.cpp
+++ b/src/V3DfgDfgToAst.cpp
@@ -26,16 +26,12 @@
 //
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
-
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
 #include "V3Dfg.h"
 #include "V3DfgPasses.h"
 #include "V3UniqueNames.h"
 
-#include <algorithm>
 #include <unordered_map>
 
 VL_DEFINE_DEBUG_FUNCTIONS;

--- a/src/V3DfgOptimizer.cpp
+++ b/src/V3DfgOptimizer.cpp
@@ -18,19 +18,13 @@
 //
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
-
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
 #include "V3DfgOptimizer.h"
 
-#include "V3Ast.h"
 #include "V3AstUserAllocator.h"
 #include "V3Dfg.h"
 #include "V3DfgPasses.h"
-#include "V3Error.h"
-#include "V3Global.h"
 #include "V3Graph.h"
 #include "V3UniqueNames.h"
 

--- a/src/V3DfgPasses.cpp
+++ b/src/V3DfgPasses.cpp
@@ -14,17 +14,13 @@
 //
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
-
-#include "config_build.h"
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
 #include "V3DfgPasses.h"
 
 #include "V3Dfg.h"
 #include "V3Global.h"
 #include "V3String.h"
-
-#include <algorithm>
 
 VL_DEFINE_DEBUG_FUNCTIONS;
 

--- a/src/V3DfgPeephole.cpp
+++ b/src/V3DfgPeephole.cpp
@@ -21,18 +21,14 @@
 //
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
-
-#include "config_build.h"
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
 #include "V3DfgPeephole.h"
 
-#include "V3Ast.h"
 #include "V3Dfg.h"
 #include "V3DfgPasses.h"
 #include "V3Stats.h"
 
-#include <algorithm>
 #include <cctype>
 
 VL_DEFINE_DEBUG_FUNCTIONS;

--- a/src/V3DupFinder.cpp
+++ b/src/V3DupFinder.cpp
@@ -14,20 +14,13 @@
 //
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
-
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
 #include "V3DupFinder.h"
 
-#include "V3Ast.h"
 #include "V3File.h"
-#include "V3Global.h"
 
-#include <algorithm>
 #include <iomanip>
-#include <map>
 #include <memory>
 
 VL_DEFINE_DEBUG_FUNCTIONS;

--- a/src/V3EmitCBase.cpp
+++ b/src/V3EmitCBase.cpp
@@ -14,8 +14,7 @@
 //
 //*************************************************************************
 
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstMT.h"
 
 #include "V3EmitCBase.h"
 

--- a/src/V3EmitCConstPool.cpp
+++ b/src/V3EmitCConstPool.cpp
@@ -14,15 +14,12 @@
 //
 //*************************************************************************
 
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstMT.h"
 
 #include "V3EmitC.h"
 #include "V3EmitCConstInit.h"
 #include "V3File.h"
-#include "V3Global.h"
 #include "V3Stats.h"
-#include "V3String.h"
 
 #include <algorithm>
 #include <cinttypes>

--- a/src/V3EmitCFunc.cpp
+++ b/src/V3EmitCFunc.cpp
@@ -14,13 +14,10 @@
 //
 //*************************************************************************
 
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstMT.h"
 
 #include "V3EmitCFunc.h"
 
-#include "V3Global.h"
-#include "V3String.h"
 #include "V3TSP.h"
 
 #include <map>

--- a/src/V3EmitCHeaders.cpp
+++ b/src/V3EmitCHeaders.cpp
@@ -14,13 +14,10 @@
 //
 //*************************************************************************
 
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstMT.h"
 
-#include "V3Ast.h"
 #include "V3EmitC.h"
 #include "V3EmitCConstInit.h"
-#include "V3Global.h"
 
 #include <algorithm>
 #include <cstdint>

--- a/src/V3EmitCImp.cpp
+++ b/src/V3EmitCImp.cpp
@@ -14,14 +14,10 @@
 //
 //*************************************************************************
 
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstMT.h"
 
-#include "V3Ast.h"
 #include "V3EmitC.h"
 #include "V3EmitCFunc.h"
-#include "V3Global.h"
-#include "V3String.h"
 #include "V3ThreadPool.h"
 #include "V3UniqueNames.h"
 

--- a/src/V3EmitCInlines.cpp
+++ b/src/V3EmitCInlines.cpp
@@ -14,12 +14,10 @@
 //
 //*************************************************************************
 
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstMT.h"
 
 #include "V3EmitC.h"
 #include "V3EmitCBase.h"
-#include "V3Global.h"
 #include "V3Stats.h"
 
 #include <map>

--- a/src/V3EmitCMain.cpp
+++ b/src/V3EmitCMain.cpp
@@ -14,16 +14,12 @@
 //
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
-
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
 #include "V3EmitCMain.h"
 
 #include "V3EmitC.h"
 #include "V3EmitCBase.h"
-#include "V3Global.h"
 
 #include <map>
 

--- a/src/V3EmitCMake.cpp
+++ b/src/V3EmitCMake.cpp
@@ -14,15 +14,11 @@
 //
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
-
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
 #include "V3EmitCMake.h"
 
 #include "V3EmitCBase.h"
-#include "V3Global.h"
 #include "V3HierBlock.h"
 #include "V3Os.h"
 

--- a/src/V3EmitCModel.cpp
+++ b/src/V3EmitCModel.cpp
@@ -14,14 +14,10 @@
 //
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
-
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
 #include "V3EmitC.h"
 #include "V3EmitCFunc.h"
-#include "V3Global.h"
 #include "V3UniqueNames.h"
 
 #include <algorithm>

--- a/src/V3EmitCSyms.cpp
+++ b/src/V3EmitCSyms.cpp
@@ -14,14 +14,10 @@
 //
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
-
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
 #include "V3EmitC.h"
 #include "V3EmitCBase.h"
-#include "V3Global.h"
 #include "V3LanguageWords.h"
 #include "V3PartitionGraph.h"
 

--- a/src/V3EmitMk.cpp
+++ b/src/V3EmitMk.cpp
@@ -14,15 +14,11 @@
 //
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
-
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
 #include "V3EmitMk.h"
 
 #include "V3EmitCBase.h"
-#include "V3Global.h"
 #include "V3HierBlock.h"
 #include "V3Os.h"
 

--- a/src/V3EmitV.cpp
+++ b/src/V3EmitV.cpp
@@ -14,16 +14,12 @@
 //
 //*************************************************************************
 
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstMT.h"
 
 #include "V3EmitV.h"
 
 #include "V3EmitCBase.h"
-#include "V3Global.h"
 
-#include <algorithm>
-#include <map>
 #include <vector>
 
 VL_DEFINE_DEBUG_FUNCTIONS;

--- a/src/V3EmitXml.cpp
+++ b/src/V3EmitXml.cpp
@@ -14,16 +14,11 @@
 //
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
-
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
 #include "V3EmitXml.h"
 
 #include "V3EmitCBase.h"
-#include "V3Global.h"
-#include "V3String.h"
 
 #include <map>
 #include <vector>

--- a/src/V3Expand.cpp
+++ b/src/V3Expand.cpp
@@ -25,19 +25,12 @@
 //
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
-
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
 #include "V3Expand.h"
 
-#include "V3Ast.h"
 #include "V3Const.h"
-#include "V3Global.h"
 #include "V3Stats.h"
-
-#include <algorithm>
 
 VL_DEFINE_DEBUG_FUNCTIONS;
 

--- a/src/V3File.cpp
+++ b/src/V3File.cpp
@@ -14,13 +14,10 @@
 //
 //*************************************************************************
 
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstMT.h"
 
 #include "V3File.h"
 
-#include "V3Ast.h"
-#include "V3Global.h"
 #include "V3Os.h"
 #include "V3String.h"
 

--- a/src/V3Force.cpp
+++ b/src/V3Force.cpp
@@ -37,16 +37,11 @@
 //
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
-
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
 #include "V3Force.h"
 
 #include "V3AstUserAllocator.h"
-#include "V3Error.h"
-#include "V3Global.h"
 
 VL_DEFINE_DEBUG_FUNCTIONS;
 

--- a/src/V3Fork.cpp
+++ b/src/V3Fork.cpp
@@ -38,21 +38,13 @@
 //
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
-
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
 #include "V3Fork.h"
 
-#include "V3Ast.h"
 #include "V3AstNodeExpr.h"
-#include "V3Error.h"
-#include "V3Global.h"
 #include "V3MemberMap.h"
 
-#include <algorithm>
-#include <map>
 #include <set>
 #include <vector>
 

--- a/src/V3Gate.cpp
+++ b/src/V3Gate.cpp
@@ -21,22 +21,16 @@
 //
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
-
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
 #include "V3Gate.h"
 
-#include "V3Ast.h"
 #include "V3AstUserAllocator.h"
 #include "V3Const.h"
 #include "V3DupFinder.h"
-#include "V3Global.h"
 #include "V3Graph.h"
 #include "V3Stats.h"
 
-#include <algorithm>
 #include <list>
 #include <unordered_map>
 #include <unordered_set>

--- a/src/V3Global.cpp
+++ b/src/V3Global.cpp
@@ -14,12 +14,8 @@
 //
 //*************************************************************************
 
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstMT.h"
 
-#include "V3Global.h"
-
-#include "V3Ast.h"
 #include "V3File.h"
 #include "V3HierBlock.h"
 #include "V3LinkCells.h"

--- a/src/V3Hasher.cpp
+++ b/src/V3Hasher.cpp
@@ -14,8 +14,7 @@
 //
 //*************************************************************************
 
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstMT.h"
 
 #include "V3Hasher.h"
 

--- a/src/V3HierBlock.cpp
+++ b/src/V3HierBlock.cpp
@@ -72,12 +72,10 @@
 //       Used for b) and c).
 //       This options is repeated for all instantiating hierarchical blocks.
 
-#define VL_MT_DISABLED_CODE_UNIT 1
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
 #include "V3HierBlock.h"
 
-#include "V3Ast.h"
-#include "V3Error.h"
 #include "V3File.h"
 #include "V3Os.h"
 #include "V3Stats.h"

--- a/src/V3Inline.cpp
+++ b/src/V3Inline.cpp
@@ -24,21 +24,14 @@
 //
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
-
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
 #include "V3Inline.h"
 
-#include "V3Ast.h"
 #include "V3AstUserAllocator.h"
-#include "V3Global.h"
 #include "V3Inst.h"
 #include "V3Stats.h"
-#include "V3String.h"
 
-#include <algorithm>
 #include <unordered_set>
 #include <vector>
 

--- a/src/V3Inst.cpp
+++ b/src/V3Inst.cpp
@@ -21,18 +21,11 @@
 //
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
-
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
 #include "V3Inst.h"
 
-#include "V3Ast.h"
 #include "V3Const.h"
-#include "V3Global.h"
-
-#include <algorithm>
 
 VL_DEFINE_DEBUG_FUNCTIONS;
 

--- a/src/V3InstrCount.cpp
+++ b/src/V3InstrCount.cpp
@@ -15,14 +15,9 @@
 //
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
-
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
 #include "V3InstrCount.h"
-
-#include "V3Ast.h"
 
 #include <iomanip>
 

--- a/src/V3Interface.cpp
+++ b/src/V3Interface.cpp
@@ -23,15 +23,9 @@
 //
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
-
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
 #include "V3Interface.h"
-
-#include "V3Ast.h"
-#include "V3Global.h"
 
 VL_DEFINE_DEBUG_FUNCTIONS;
 

--- a/src/V3Life.cpp
+++ b/src/V3Life.cpp
@@ -23,19 +23,13 @@
 //
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
-
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
 #include "V3Life.h"
 
-#include "V3Ast.h"
 #include "V3Const.h"
-#include "V3Global.h"
 #include "V3Stats.h"
 
-#include <map>
 #include <vector>
 
 VL_DEFINE_DEBUG_FUNCTIONS;

--- a/src/V3LifePost.cpp
+++ b/src/V3LifePost.cpp
@@ -24,15 +24,10 @@
 //
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
-
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
 #include "V3LifePost.h"
 
-#include "V3Ast.h"
-#include "V3Global.h"
 #include "V3GraphPathChecker.h"
 #include "V3PartitionGraph.h"
 #include "V3Stats.h"

--- a/src/V3LinkCells.cpp
+++ b/src/V3LinkCells.cpp
@@ -23,21 +23,14 @@
 //              Link to module that instantiates it
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
-
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
 #include "V3LinkCells.h"
 
-#include "V3Ast.h"
-#include "V3Global.h"
 #include "V3Graph.h"
 #include "V3Parse.h"
 #include "V3SymTable.h"
 
-#include <algorithm>
-#include <map>
 #include <unordered_set>
 #include <vector>
 

--- a/src/V3LinkDot.cpp
+++ b/src/V3LinkDot.cpp
@@ -61,22 +61,15 @@
 //      b          (VSymEnt->AstCell)
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
-
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
 #include "V3LinkDot.h"
 
-#include "V3Ast.h"
-#include "V3Global.h"
 #include "V3Graph.h"
 #include "V3MemberMap.h"
 #include "V3String.h"
 #include "V3SymTable.h"
 
-#include <algorithm>
-#include <map>
 #include <vector>
 
 VL_DEFINE_DEBUG_FUNCTIONS;

--- a/src/V3LinkInc.cpp
+++ b/src/V3LinkInc.cpp
@@ -36,15 +36,9 @@
 //
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
-
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
 #include "V3LinkInc.h"
-
-#include "V3Ast.h"
-#include "V3Global.h"
 
 #include <algorithm>
 

--- a/src/V3LinkJump.cpp
+++ b/src/V3LinkJump.cpp
@@ -29,18 +29,12 @@
 //
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
-
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
 #include "V3LinkJump.h"
 
-#include "V3Ast.h"
 #include "V3AstUserAllocator.h"
-#include "V3Global.h"
 
-#include <algorithm>
 #include <vector>
 
 VL_DEFINE_DEBUG_FUNCTIONS;

--- a/src/V3LinkLValue.cpp
+++ b/src/V3LinkLValue.cpp
@@ -18,17 +18,9 @@
 //          Set lvalue() attributes on appropriate VARREFs.
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
-
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
 #include "V3LinkLValue.h"
-
-#include "V3Ast.h"
-#include "V3Global.h"
-
-#include <map>
 
 VL_DEFINE_DEBUG_FUNCTIONS;
 

--- a/src/V3LinkLevel.cpp
+++ b/src/V3LinkLevel.cpp
@@ -19,18 +19,10 @@
 //          Create new MODULE TOP with connections to below signals
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
-
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
 #include "V3LinkLevel.h"
 
-#include "V3Ast.h"
-#include "V3Global.h"
-
-#include <algorithm>
-#include <map>
 #include <vector>
 
 VL_DEFINE_DEBUG_FUNCTIONS;

--- a/src/V3LinkParse.cpp
+++ b/src/V3LinkParse.cpp
@@ -18,19 +18,12 @@
 //          Move some attributes around
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
-
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
 #include "V3LinkParse.h"
 
-#include "V3Ast.h"
 #include "V3Config.h"
-#include "V3Global.h"
 
-#include <algorithm>
-#include <map>
 #include <set>
 #include <vector>
 

--- a/src/V3LinkResolve.cpp
+++ b/src/V3LinkResolve.cpp
@@ -24,20 +24,12 @@
 //          SenItems: Convert pos/negedge of non-simple signals to temporaries
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
-
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
 #include "V3LinkResolve.h"
 
-#include "V3Ast.h"
-#include "V3Global.h"
 #include "V3String.h"
 #include "V3Task.h"
-
-#include <algorithm>
-#include <map>
 
 VL_DEFINE_DEBUG_FUNCTIONS;
 

--- a/src/V3Localize.cpp
+++ b/src/V3Localize.cpp
@@ -22,16 +22,11 @@
 //
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
-
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
 #include "V3Localize.h"
 
-#include "V3Ast.h"
 #include "V3AstUserAllocator.h"
-#include "V3Global.h"
 #include "V3Stats.h"
 
 #include <vector>

--- a/src/V3MergeCond.cpp
+++ b/src/V3MergeCond.cpp
@@ -72,17 +72,12 @@
 //
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
-
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
 #include "V3MergeCond.h"
 
-#include "V3Ast.h"
 #include "V3AstUserAllocator.h"
 #include "V3DupFinder.h"
-#include "V3Global.h"
 #include "V3Hasher.h"
 #include "V3Stats.h"
 

--- a/src/V3Name.cpp
+++ b/src/V3Name.cpp
@@ -19,15 +19,10 @@
 //              Prepend __PVT__ to variable names
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
-
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
 #include "V3Name.h"
 
-#include "V3Ast.h"
-#include "V3Global.h"
 #include "V3LanguageWords.h"
 
 VL_DEFINE_DEBUG_FUNCTIONS;

--- a/src/V3Number.cpp
+++ b/src/V3Number.cpp
@@ -14,13 +14,9 @@
 //
 //*************************************************************************
 
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstMT.h"
 
 #include "V3Number.h"
-
-#include "V3Ast.h"
-#include "V3Global.h"
 
 #include <algorithm>
 #include <cerrno>

--- a/src/V3Options.cpp
+++ b/src/V3Options.cpp
@@ -14,12 +14,10 @@
 //
 //*************************************************************************
 
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstMT.h"
 
 #include "V3Options.h"
 
-#include "V3Ast.h"
 #include "V3Error.h"
 #include "V3File.h"
 #include "V3Global.h"

--- a/src/V3Order.cpp
+++ b/src/V3Order.cpp
@@ -71,19 +71,14 @@
 //
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
-
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
 #include "V3Order.h"
 
-#include "V3Ast.h"
 #include "V3AstUserAllocator.h"
 #include "V3Const.h"
 #include "V3EmitV.h"
 #include "V3File.h"
-#include "V3Global.h"
 #include "V3Graph.h"
 #include "V3GraphStream.h"
 #include "V3List.h"
@@ -96,10 +91,8 @@
 #include "V3SplitVar.h"
 #include "V3Stats.h"
 
-#include <algorithm>
 #include <deque>
 #include <iomanip>
-#include <map>
 #include <memory>
 #include <sstream>
 #include <unordered_map>

--- a/src/V3Param.cpp
+++ b/src/V3Param.cpp
@@ -44,17 +44,12 @@
 //
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
-
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
 #include "V3Param.h"
 
-#include "V3Ast.h"
 #include "V3Case.h"
 #include "V3Const.h"
-#include "V3Global.h"
 #include "V3Hasher.h"
 #include "V3Os.h"
 #include "V3Parse.h"
@@ -63,7 +58,6 @@
 
 #include <cctype>
 #include <deque>
-#include <map>
 #include <memory>
 #include <vector>
 

--- a/src/V3Partition.cpp
+++ b/src/V3Partition.cpp
@@ -14,10 +14,7 @@
 //
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
-
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
 #include "V3Partition.h"
 
@@ -34,7 +31,6 @@
 #include "V3Stats.h"
 #include "V3UniqueNames.h"
 
-#include <algorithm>
 #include <array>
 #include <list>
 #include <memory>

--- a/src/V3PchAstMT.h
+++ b/src/V3PchAstMT.h
@@ -1,0 +1,42 @@
+// -*- mode: C++; c-file-style: "cc-mode" -*-
+//*************************************************************************
+// Code available from: https://verilator.org
+//
+// Copyright 2003-2023 by Wilson Snyder. This program is free software; you
+// can redistribute it and/or modify it under the terms of either the GNU
+// Lesser General Public License Version 3 or the Perl Artistic License
+// Version 2.0.
+// SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+//
+//*************************************************************************
+// DESCRIPTION: Verilator: Precompilable header of V3Ast, multithreaded
+//
+//*************************************************************************
+
+#ifndef VERILATOR_V3PCHASTMT_H_
+#define VERILATOR_V3PCHASTMT_H_
+
+#ifdef VL_PCH_INCLUDED
+#error "Including multiple V3Pch*.h flavors"
+#endif
+#define VL_PCH_INCLUDED
+
+#include "config_build.h"
+#include "verilatedos.h"
+
+#include <algorithm>
+
+#include "V3Ast.h"
+#include "V3Broken.h"
+#include "V3Error.h"
+#include "V3FileLine.h"
+#include "V3FunctionTraits.h"
+#include "V3Global.h"
+#include "V3Mutex.h"
+#include "V3Number.h"
+#include "V3Options.h"
+#include "V3StdFuture.h"
+#include "V3String.h"
+#include "V3ThreadSafety.h"
+
+#endif  // Guard

--- a/src/V3PchAstNoMT.h
+++ b/src/V3PchAstNoMT.h
@@ -1,0 +1,46 @@
+// -*- mode: C++; c-file-style: "cc-mode" -*-
+//*************************************************************************
+// Code available from: https://verilator.org
+//
+// Copyright 2003-2023 by Wilson Snyder. This program is free software; you
+// can redistribute it and/or modify it under the terms of either the GNU
+// Lesser General Public License Version 3 or the Perl Artistic License
+// Version 2.0.
+// SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+//
+//*************************************************************************
+// DESCRIPTION: Verilator: Precompilable header of V3Ast, non-multithreaded
+//
+//*************************************************************************
+
+#ifndef VERILATOR_V3PCHASTNOMT_H_
+#define VERILATOR_V3PCHASTNOMT_H_
+
+#ifdef VL_PCH_INCLUDED
+#error "Including multiple V3Pch*.h flavors"
+#endif
+#define VL_PCH_INCLUDED
+
+#define VL_MT_DISABLED_CODE_UNIT 1
+
+#include "config_build.h"
+#include "verilatedos.h"
+
+#include <algorithm>
+#include <map>
+#include <utility>
+
+#include "V3Ast.h"
+#include "V3Broken.h"
+#include "V3Error.h"
+#include "V3FileLine.h"
+#include "V3FunctionTraits.h"
+#include "V3Global.h"
+#include "V3Mutex.h"
+#include "V3Number.h"
+#include "V3Options.h"
+#include "V3StdFuture.h"
+#include "V3String.h"
+#include "V3ThreadSafety.h"
+
+#endif  // Guard

--- a/src/V3Premit.cpp
+++ b/src/V3Premit.cpp
@@ -24,19 +24,12 @@
 //
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
-
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
 #include "V3Premit.h"
 
-#include "V3Ast.h"
-#include "V3Global.h"
 #include "V3Stats.h"
 #include "V3UniqueNames.h"
-
-#include <algorithm>
 
 VL_DEFINE_DEBUG_FUNCTIONS;
 

--- a/src/V3ProtectLib.cpp
+++ b/src/V3ProtectLib.cpp
@@ -14,14 +14,10 @@
 //
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
-
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
 #include "V3ProtectLib.h"
 
-#include "V3Global.h"
 #include "V3Hasher.h"
 #include "V3String.h"
 #include "V3Task.h"

--- a/src/V3Randomize.cpp
+++ b/src/V3Randomize.cpp
@@ -24,14 +24,10 @@
 //
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
-
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
 #include "V3Randomize.h"
 
-#include "V3Ast.h"
 #include "V3MemberMap.h"
 
 VL_DEFINE_DEBUG_FUNCTIONS;

--- a/src/V3Reloop.cpp
+++ b/src/V3Reloop.cpp
@@ -29,18 +29,11 @@
 //
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
-
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
 #include "V3Reloop.h"
 
-#include "V3Ast.h"
-#include "V3Global.h"
 #include "V3Stats.h"
-
-#include <algorithm>
 
 VL_DEFINE_DEBUG_FUNCTIONS;
 

--- a/src/V3Sched.cpp
+++ b/src/V3Sched.cpp
@@ -35,14 +35,10 @@
 //
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
-
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
 #include "V3Sched.h"
 
-#include "V3Ast.h"
 #include "V3EmitCBase.h"
 #include "V3EmitV.h"
 #include "V3Order.h"

--- a/src/V3SchedAcyclic.cpp
+++ b/src/V3SchedAcyclic.cpp
@@ -33,14 +33,8 @@
 //
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
-#include "config_build.h"
-#include "verilatedos.h"
-
-#include "V3Ast.h"
-#include "V3Error.h"
-#include "V3Global.h"
 #include "V3Graph.h"
 #include "V3Sched.h"
 #include "V3SenTree.h"

--- a/src/V3SchedPartition.cpp
+++ b/src/V3SchedPartition.cpp
@@ -34,15 +34,9 @@
 //
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
-#include "config_build.h"
-#include "verilatedos.h"
-
-#include "V3Ast.h"
 #include "V3EmitV.h"
-#include "V3Error.h"
-#include "V3Global.h"
 #include "V3Graph.h"
 #include "V3Sched.h"
 

--- a/src/V3SchedReplicate.cpp
+++ b/src/V3SchedReplicate.cpp
@@ -34,13 +34,8 @@
 //
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
-#include "config_build.h"
-#include "verilatedos.h"
-
-#include "V3Ast.h"
-#include "V3Error.h"
 #include "V3Graph.h"
 #include "V3Sched.h"
 

--- a/src/V3SchedTiming.cpp
+++ b/src/V3SchedTiming.cpp
@@ -24,13 +24,9 @@
 //
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
-
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
 #include "V3EmitCBase.h"
-#include "V3Error.h"
 #include "V3Sched.h"
 
 #include <unordered_map>

--- a/src/V3Scope.cpp
+++ b/src/V3Scope.cpp
@@ -21,18 +21,10 @@
 //
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
-
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
 #include "V3Scope.h"
 
-#include "V3Ast.h"
-#include "V3Global.h"
-
-#include <algorithm>
-#include <map>
 #include <unordered_map>
 #include <unordered_set>
 

--- a/src/V3Scoreboard.cpp
+++ b/src/V3Scoreboard.cpp
@@ -14,10 +14,7 @@
 //
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
-
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
 #include "V3Scoreboard.h"
 

--- a/src/V3Slice.cpp
+++ b/src/V3Slice.cpp
@@ -35,15 +35,9 @@
 // simplified to look primarily for SLICESELs.
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
-
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
 #include "V3Slice.h"
-
-#include "V3Ast.h"
-#include "V3Global.h"
 
 VL_DEFINE_DEBUG_FUNCTIONS;
 

--- a/src/V3Split.cpp
+++ b/src/V3Split.cpp
@@ -77,20 +77,13 @@
 //
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
-
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
 #include "V3Split.h"
 
-#include "V3Ast.h"
-#include "V3Global.h"
 #include "V3Graph.h"
 #include "V3Stats.h"
 
-#include <algorithm>
-#include <map>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>

--- a/src/V3SplitAs.cpp
+++ b/src/V3SplitAs.cpp
@@ -21,18 +21,11 @@
 //
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
-
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
 #include "V3SplitAs.h"
 
-#include "V3Ast.h"
-#include "V3Global.h"
 #include "V3Stats.h"
-
-#include <map>
 
 VL_DEFINE_DEBUG_FUNCTIONS;
 

--- a/src/V3SplitVar.cpp
+++ b/src/V3SplitVar.cpp
@@ -110,20 +110,13 @@
 //
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
-
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
 #include "V3SplitVar.h"
 
-#include "V3Ast.h"
-#include "V3Global.h"
 #include "V3Stats.h"
 #include "V3UniqueNames.h"
 
-#include <algorithm>  // sort
-#include <map>
 #include <set>
 #include <vector>
 

--- a/src/V3Stats.cpp
+++ b/src/V3Stats.cpp
@@ -14,13 +14,9 @@
 //
 //*************************************************************************
 
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstMT.h"
 
 #include "V3Stats.h"
-
-#include "V3Ast.h"
-#include "V3Global.h"
 
 // This visitor does not edit nodes, and is called at error-exit, so should use constant iterators
 #include "V3AstConstOnly.h"

--- a/src/V3StatsReport.cpp
+++ b/src/V3StatsReport.cpp
@@ -14,17 +14,14 @@
 //
 //*************************************************************************
 
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstMT.h"
 
-#include "V3Ast.h"
 #include "V3File.h"
 #include "V3Global.h"
 #include "V3Os.h"
 #include "V3Stats.h"
 
 #include <iomanip>
-#include <map>
 #include <unordered_map>
 
 VL_DEFINE_DEBUG_FUNCTIONS;

--- a/src/V3Subst.cpp
+++ b/src/V3Subst.cpp
@@ -22,15 +22,10 @@
 //
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
-
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
 #include "V3Subst.h"
 
-#include "V3Ast.h"
-#include "V3Global.h"
 #include "V3Stats.h"
 
 #include <algorithm>

--- a/src/V3TSP.cpp
+++ b/src/V3TSP.cpp
@@ -19,19 +19,13 @@
 //
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
-
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
 #include "V3TSP.h"
 
-#include "V3Error.h"
 #include "V3File.h"
-#include "V3Global.h"
 #include "V3Graph.h"
 
-#include <algorithm>
 #include <cmath>
 #include <list>
 #include <memory>

--- a/src/V3Table.cpp
+++ b/src/V3Table.cpp
@@ -21,15 +21,10 @@
 //
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
-
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
 #include "V3Table.h"
 
-#include "V3Ast.h"
-#include "V3Global.h"
 #include "V3Simulate.h"
 #include "V3Stats.h"
 

--- a/src/V3Task.cpp
+++ b/src/V3Task.cpp
@@ -23,21 +23,15 @@
 //
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
-
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
 #include "V3Task.h"
 
-#include "V3Ast.h"
 #include "V3Const.h"
 #include "V3EmitCBase.h"
-#include "V3Global.h"
 #include "V3Graph.h"
 #include "V3LinkLValue.h"
 
-#include <map>
 #include <tuple>
 
 VL_DEFINE_DEBUG_FUNCTIONS;

--- a/src/V3ThreadPool.h
+++ b/src/V3ThreadPool.h
@@ -17,7 +17,7 @@
 #ifndef _V3THREADPOOL_H_
 #define _V3THREADPOOL_H_ 1
 
-#if defined(VL_MT_DISABLED_CODE_UNIT)
+#ifdef VL_MT_DISABLED_CODE_UNIT
 #error "Source file has been declared as MT_DISABLED, threads use is prohibited."
 #endif
 

--- a/src/V3Timing.cpp
+++ b/src/V3Timing.cpp
@@ -60,17 +60,12 @@
 //
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
-
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
 #include "V3Timing.h"
 
-#include "V3Ast.h"
 #include "V3Const.h"
 #include "V3EmitV.h"
-#include "V3Global.h"
 #include "V3Graph.h"
 #include "V3MemberMap.h"
 #include "V3SenExprBuilder.h"

--- a/src/V3Trace.cpp
+++ b/src/V3Trace.cpp
@@ -35,21 +35,16 @@
 //
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
-
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
 #include "V3Trace.h"
 
 #include "V3DupFinder.h"
 #include "V3EmitCBase.h"
-#include "V3Global.h"
 #include "V3Graph.h"
 #include "V3Stats.h"
 
 #include <limits>
-#include <map>
 #include <set>
 
 VL_DEFINE_DEBUG_FUNCTIONS;

--- a/src/V3TraceDecl.cpp
+++ b/src/V3TraceDecl.cpp
@@ -20,10 +20,7 @@
 //
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
-
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
 #include "V3TraceDecl.h"
 
@@ -31,10 +28,8 @@
 
 #include "V3Config.h"
 #include "V3EmitCBase.h"
-#include "V3Global.h"
 #include "V3Stats.h"
 
-#include <algorithm>
 #include <functional>
 #include <limits>
 #include <vector>

--- a/src/V3Tristate.cpp
+++ b/src/V3Tristate.cpp
@@ -115,21 +115,13 @@
 // unsupported.
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
-
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
 #include "V3Tristate.h"
 
-#include "V3Ast.h"
-#include "V3Global.h"
 #include "V3Graph.h"
 #include "V3Inst.h"
 #include "V3Stats.h"
-
-#include <algorithm>
-#include <map>
 
 VL_DEFINE_DEBUG_FUNCTIONS;
 

--- a/src/V3Undriven.cpp
+++ b/src/V3Undriven.cpp
@@ -23,19 +23,12 @@
 //
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
-
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
 #include "V3Undriven.h"
 
-#include "V3Ast.h"
-#include "V3Global.h"
 #include "V3Stats.h"
-#include "V3String.h"
 
-#include <algorithm>
 #include <vector>
 
 VL_DEFINE_DEBUG_FUNCTIONS;

--- a/src/V3Unknown.cpp
+++ b/src/V3Unknown.cpp
@@ -28,20 +28,13 @@
 //
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
-
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
 #include "V3Unknown.h"
 
-#include "V3Ast.h"
 #include "V3Const.h"
-#include "V3Global.h"
 #include "V3Stats.h"
 #include "V3UniqueNames.h"
-
-#include <algorithm>
 
 VL_DEFINE_DEBUG_FUNCTIONS;
 

--- a/src/V3Unroll.cpp
+++ b/src/V3Unroll.cpp
@@ -24,20 +24,13 @@
 //
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
-
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
 #include "V3Unroll.h"
 
-#include "V3Ast.h"
 #include "V3Const.h"
-#include "V3Global.h"
 #include "V3Simulate.h"
 #include "V3Stats.h"
-
-#include <algorithm>
 
 VL_DEFINE_DEBUG_FUNCTIONS;
 

--- a/src/V3VariableOrder.cpp
+++ b/src/V3VariableOrder.cpp
@@ -20,20 +20,14 @@
 //
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
-
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
 #include "V3VariableOrder.h"
 
-#include "V3Ast.h"
 #include "V3AstUserAllocator.h"
 #include "V3EmitCBase.h"
-#include "V3Global.h"
 #include "V3TSP.h"
 
-#include <algorithm>
 #include <vector>
 
 VL_DEFINE_DEBUG_FUNCTIONS;

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -63,23 +63,17 @@
 // iterateSubtreeReturnEdits.
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
-
-#include "config_build.h"
-#include "verilatedos.h"
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
 #include "V3Width.h"
 
 #include "V3Const.h"
-#include "V3Global.h"
 #include "V3MemberMap.h"
 #include "V3Number.h"
 #include "V3Randomize.h"
 #include "V3String.h"
 #include "V3Task.h"
 #include "V3WidthCommit.h"
-
-#include <algorithm>
 
 // More code; this file was getting too large; see actions there
 #define VERILATOR_V3WIDTH_CPP_

--- a/src/V3WidthCommit.cpp
+++ b/src/V3WidthCommit.cpp
@@ -20,7 +20,7 @@
 //
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
 #include "config_build.h"
 #include "verilatedos.h"

--- a/src/V3WidthSel.cpp
+++ b/src/V3WidthSel.cpp
@@ -26,14 +26,9 @@
 //
 //*************************************************************************
 
-#define VL_MT_DISABLED_CODE_UNIT 1
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
-#include "config_build.h"
-#include "verilatedos.h"
-
-#include "V3Ast.h"
 #include "V3Const.h"
-#include "V3Global.h"
 #include "V3Width.h"
 
 VL_DEFINE_DEBUG_FUNCTIONS;


### PR DESCRIPTION
Enable faster compiling of Verilator itself (about 2x) using GCC or CLang's precompiled header capability.

