### PR TITLE
Do not remap local assign intravals in forks

### DIFF
--- a/test_regress/t/t_fork_jumpblock.pl
+++ b/test_regress/t/t_fork_jumpblock.pl
@@ -1,0 +1,23 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2019 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    verilator_flags2 => ["--exe --main --timing"],
+    make_main => 0,
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_fork_jumpblock.v
+++ b/test_regress/t/t_fork_jumpblock.v
@@ -1,0 +1,23 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed into the Public Domain, for any use,
+// without warranty, 2023 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+class bar;
+    task foo(logic r);
+        int a, b;
+        if (r) return;
+        fork a = #1 b; join_none
+    endtask
+endclass
+
+module t;
+    bar b = new;
+
+    initial begin
+        b.foo(0);
+        $write("*-* All Finished *-*\n");
+        $finish;
+    end
+endmodule


### PR DESCRIPTION
If a local intraval was remapped and added as an argument to the forked coroutine,
the compilation would result in an error due to the passed argument being undefined.
This only occurred in very specific circumstances (as you can see in the added test).

To be honest, the logic behind remapping varrefs in forks in `V3SchedTiming` needs
a rework in the future, but for now this patch fixes a compilation error in UVM.