### PR TITLE
Fix PLI/DPI user defined system task/function grammar (#4587)

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -137,6 +137,7 @@ Pierre-Henri Horrein
 Pieter Kapsenberg
 Piotr Binkowski
 Qingyao Sun
+Quentin Corradi
 Rafal Kapuscik
 Raynard Qiao
 Richard Myers

--- a/src/verilog.l
+++ b/src/verilog.l
@@ -630,7 +630,7 @@ vnum    {vnum1}|{vnum2}|{vnum3}|{vnum4}|{vnum5}
 
   /* Default PLI rule */
 <V95,V01NC,V01C,V05,VA5,S05,S09,S12,S17,SAX>{
-  "$"[a-zA-Z_$][a-zA-Z0-9_$]*   { const string str (yytext, yyleng);
+  "$"[a-zA-Z0-9_$]+     { const string str (yytext, yyleng);
                                   yylval.strp = PARSEP->newString(AstNode::encodeName(str));
                                   FL; return yaD_PLI;
                                 }


### PR DESCRIPTION
Fixes #4587
According to 1800-2017 36.3, 1800-2017 A.9.3, 1364-2005 20.2 and 1364-2005 A.9.3, user defined system task and function identifiers can use the same character set for the second character as all the following characters.