### PR TITLE
Partial support for empty escaped identifier (#4590)

### DIFF
--- a/src/V3Ast.cpp
+++ b/src/V3Ast.cpp
@@ -123,6 +123,9 @@ string AstNode::encodeName(const string& namein) {
             out += "__0" + hex.str();
         }
     }
+    if (out.empty()) {
+        out = "__EMPTY__";
+    }
     // Shorten names
     // TODO long term use VName in place of "string name"
     // Then we also won't need to save the table of hashed values

--- a/src/verilog.l
+++ b/src/verilog.l
@@ -87,7 +87,7 @@ ws      [ \t\f\r]+
 wsnr    [ \t\f]+
 crnl    [\r]*[\n]
 id      [a-zA-Z_][a-zA-Z0-9_$]*
-escid   \\[^ \t\f\r\n]+
+escid   \\[^ \t\f\r\n]*
 word    [a-zA-Z0-9_]+
 vnum1   [0-9]*?[''][sS]?[bcodhBCODH][ \t\n]*[A-Fa-f0-9xXzZ_?]*
 vnum2   [0-9]*?[''][sS]?[01xXzZ]


### PR DESCRIPTION
Empty escaped identifiers are allowed by the Verilog standard A.9.3 escaped_identifier this commit adds them to the grammar and gives them the name __EMPTY__ at the name encoding step.

Tries to fix #4590, the provided test compiles but I don't know if it is correct.
For instance I don't know if VPI can reference it correctly.