### PR TITLE
Support Clang 16

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -371,10 +371,9 @@ _MY_CXX_CHECK_OPT(CFG_CXXFLAGS_WEXTRA,-Wthread-safety)
 AC_SUBST(CFG_CXXFLAGS_WEXTRA)
 
 # Flags for coroutine support for dynamic scheduling
-_MY_CXX_CHECK_IFELSE(
-  -fcoroutines-ts,
-  [CFG_CXXFLAGS_COROUTINES="-fcoroutines-ts"],
-  [CFG_CXXFLAGS_COROUTINES="-fcoroutines"])
+_MY_CXX_CHECK_SET(CFG_CXXFLAGS_COROUTINES,-fcoroutines-ts)
+_MY_CXX_CHECK_SET(CFG_CXXFLAGS_COROUTINES,-fcoroutines)
+_MY_CXX_CHECK_SET(CFG_CXXFLAGS_COROUTINES,-fcoroutines-ts -Wno-deprecated-experimental-coroutine)
 AC_SUBST(CFG_CXXFLAGS_COROUTINES)
 
 # HAVE_COROUTINES
@@ -442,12 +441,16 @@ m4_foreach([cflag],[
         [-mno-cet],
         [-Qunused-arguments],
         [-Wno-bool-operation],
+        [-Wno-c++11-narrowing],
         [-Wno-constant-logical-operand],
+        [-Wno-non-pod-varargs],
+        [-Wno-overloaded-virtual],
         [-Wno-parentheses-equality],
         [-Wno-shadow],
         [-Wno-sign-compare],
         [-Wno-tautological-bitwise-compare],
         [-Wno-uninitialized],
+        [-Wno-unused-but-set-parameter],
         [-Wno-unused-but-set-parameter],
         [-Wno-unused-but-set-variable],
         [-Wno-unused-parameter],

--- a/configure.ac
+++ b/configure.ac
@@ -451,7 +451,6 @@ m4_foreach([cflag],[
         [-Wno-tautological-bitwise-compare],
         [-Wno-uninitialized],
         [-Wno-unused-but-set-parameter],
-        [-Wno-unused-but-set-parameter],
         [-Wno-unused-but-set-variable],
         [-Wno-unused-parameter],
         [-Wno-unused-variable]],[

--- a/include/verilated_types.h
+++ b/include/verilated_types.h
@@ -250,20 +250,6 @@ template <class T_Value, uint64_t T_numValues>
 class VlRandC final {
     T_Value m_remaining = 0;  // Number of values to pull before re-randomize
     T_Value m_lfsr = 1;  // LFSR state
-    // Polynomials are first listed at https://users.ece.cmu.edu/~koopman/lfsr/
-    static constexpr uint64_t s_polynomials[] = {
-        0x0ULL,  // 0 never used (constant, no randomization)
-        0x0ULL,  // 1
-        0x3ULL,        0x5ULL,       0x9ULL,        0x12ULL,       0x21ULL,
-        0x41ULL,       0x8eULL,      0x108ULL,      0x204ULL,      0x402ULL,
-        0x829ULL,      0x100dULL,    0x2015ULL,     0x4001ULL,
-        0x8016ULL,  // 16
-        0x10004ULL,    0x20040ULL,   0x40013ULL,    0x80004ULL,    0x100002ULL,
-        0x200001ULL,   0x400010ULL,  0x80000dULL,   0x1000004ULL,  0x2000023ULL,
-        0x4000013ULL,  0x8000004ULL, 0x10000002ULL, 0x20000029ULL, 0x40000004ULL,
-        0x80000057ULL,  // 32
-        0x100000029ULL  // 33
-    };
 
 public:
     // CONSTRUCTORS
@@ -274,6 +260,20 @@ public:
     // METHODS
     T_Value randomize(VlRNG& rngr) {
         if (VL_UNLIKELY(!m_remaining)) reseed(rngr);
+        // Polynomials are first listed at https://users.ece.cmu.edu/~koopman/lfsr/
+        static constexpr uint64_t s_polynomials[] = {
+            0x0ULL,  // 0 never used (constant, no randomization)
+            0x0ULL,  // 1
+            0x3ULL,        0x5ULL,       0x9ULL,        0x12ULL,       0x21ULL,
+            0x41ULL,       0x8eULL,      0x108ULL,      0x204ULL,      0x402ULL,
+            0x829ULL,      0x100dULL,    0x2015ULL,     0x4001ULL,
+            0x8016ULL,  // 16
+            0x10004ULL,    0x20040ULL,   0x40013ULL,    0x80004ULL,    0x100002ULL,
+            0x200001ULL,   0x400010ULL,  0x80000dULL,   0x1000004ULL,  0x2000023ULL,
+            0x4000013ULL,  0x8000004ULL, 0x10000002ULL, 0x20000029ULL, 0x40000004ULL,
+            0x80000057ULL,  // 32
+            0x100000029ULL  // 33
+        };
         constexpr uint32_t clogWidth = VL_CLOG2_CE_Q(T_numValues) + 1;
         constexpr uint32_t lfsrWidth = (clogWidth < 2) ? 2 : clogWidth;
         constexpr T_Value polynomial = static_cast<T_Value>(s_polynomials[lfsrWidth]);


### PR DESCRIPTION
Makes it possible to compile simulation code with Clang 16.

Known limitations: `nodist/clang_check_attributes` does not work with libclang 16 due to a bug in the library.

The change in `verilated_types.h` is required when simulation code is compiled with Clang and `-std=c++17` (or higher). Happens with multiple Clang versions - I've tested 10-17. Might be either a bug in Clang or a case of undefined behavior since C++17.
It is triggered in `test_regress/t/t_randc.pl` when compiling with Clang 16 because the test does not specify any `-std`, and Clang 16 uses C++17 as the default standard. Simplified test case: https://godbolt.org/z/fnhvxvrYf

EDIT: FYI: libclang 16 works when you pass `-resource-dir "$(clang -print-resource-dir)"` in compiler args. I didn't know how to implement it nicely. The libclang can come from different place than clang found in `PATH`, and it it possible that there is no clang at all, just the lib.