### PR TITLE
Consider children of AstConcat in V3InstrCount

### DIFF
--- a/src/V3InstrCount.cpp
+++ b/src/V3InstrCount.cpp
@@ -146,11 +146,9 @@ private:
     }
     void visit(AstConcat* nodep) override {
         if (m_ignoreRemaining) return;
-        // Nop.
-        //
-        // Ignore concat. The problem with counting concat is that when we
-        // have many things concatted together, it's not a single
-        // operation, but this:
+        // Ignore the cost of the concat node itself. The problem with
+        // counting concat is that when we have many things concatted
+        // together, it's not a single operation, but this:
         //
         //  concat(a, concat(b, concat(c, concat(d, ... ))))
         //
@@ -162,7 +160,8 @@ private:
         // cost is linear with the size of the data. We don't need to count
         // the concat at all to reflect a linear cost; it's already there
         // in the width of the destination (which we count) and the sum of
-        // the widths of the operands (ignored here).
+        // the cost of the operands.
+        iterateChildrenConst(nodep);
         markCost(nodep);
     }
     void visit(AstNodeIf* nodep) override {


### PR DESCRIPTION
Previously V3InstrCount used to completely ignore an AstConcat, including its children (see the rational in the comment). The problem is the operands can be huge and expensive compound expressions (especially since DFG), and not just a simple variable reference. This fix gains some MT speed improvement.