### PR TITLE
Make VL_LOCK_SPINS configurable and increase default 100x

### DIFF
--- a/include/verilated.h
+++ b/include/verilated.h
@@ -164,7 +164,9 @@ inline constexpr size_t roundUpToMultipleOf(size_t value) {
 // Return current thread ID (or 0), not super fast, cache if needed
 extern uint32_t VL_THREAD_ID() VL_MT_SAFE;
 
+#ifndef VL_LOCK_SPINS
 #define VL_LOCK_SPINS 50000  /// Number of times to spin for a mutex before yielding
+#endif
 
 /// Mutex, wrapped to allow -fthread_safety checks
 class VL_CAPABILITY("mutex") VerilatedMutex final {

--- a/test_regress/Makefile_obj
+++ b/test_regress/Makefile_obj
@@ -39,6 +39,9 @@ CPPFLAGS += $(CPPFLAGS_DRIVER)
 CPPFLAGS += $(CPPFLAGS_DRIVER2)
 CPPFLAGS += $(CPPFLAGS_ADD)
 
+# Reduce spin count for faster testing
+CPPFLAGS += -DVL_LOCK_SPINS=10000
+
 ifeq ($(CFG_WITH_LONGTESTS),yes)
   ifeq ($(DRIVER_STD),newest)
     CPPFLAGS += $(CFG_CXXFLAGS_STD)


### PR DESCRIPTION
It's unlikely one value fits all use case, so making VL_LOCK_SPINS configurable at model build time.

Increasing the default is to help reduce the likelihood of threads having to yield at simulation time in real runs, where we expect to have thread count matched to the core count.

For testing, we keep the old value to reduce contention.