### PR TITLE
Fix try_put method of unbounded mailbox

### DIFF
--- a/include/verilated_std.sv
+++ b/include/verilated_std.sv
@@ -47,7 +47,7 @@ package std;
       endtask
 
       function int try_put(T message);
-         if (num() < m_bound) begin
+         if (m_bound == 0 || num() < m_bound) begin
             m_queue.push_back(message);
             return 1;
          end

--- a/test_regress/t/t_mailbox_unbounded.pl
+++ b/test_regress/t/t_mailbox_unbounded.pl
@@ -1,0 +1,23 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2020 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    verilator_flags2 => ["--exe --main --timing -Wall"],
+    make_main => 0,
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_mailbox_unbounded.v
+++ b/test_regress/t/t_mailbox_unbounded.v
@@ -1,0 +1,30 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2023 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+// verilator lint_off DECLFILENAME
+
+module t(/*AUTOARG*/);
+   mailbox #(int) m;
+   int     msg = 0;
+   int     out = 0;
+
+   initial begin
+      m = new;
+      fork
+         begin
+            #10;  // So later then get() starts below
+            msg = 1;
+            if (m.try_put(msg) != 1) $stop;
+         end
+         begin
+            m.get(out);
+            if (out != 1) $stop;
+         end
+      join
+
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end
+endmodule


### PR DESCRIPTION
The condition for unbounded case is missing in `try_put` method of `mailbox`. This PR adds it.