### PR TITLE
Separate tracing of const values from non-const values

### DIFF
--- a/include/verilated_fst_c.cpp
+++ b/include/verilated_fst_c.cpp
@@ -104,6 +104,7 @@ void VerilatedFst::open(const char* filename) VL_MT_SAFE_EXCLUDES(m_mutex) {
     fstWriterSetPackType(m_fst, FST_WR_PT_LZ4);
     fstWriterSetTimescaleFromString(m_fst, timeResStr().c_str());  // lintok-begin-on-ref
     if (m_useFstWriterThread) fstWriterSetParallelMode(m_fst, 1);
+    constDump(true);  // First dump must contain the const signals
     fullDump(true);  // First dump must be full for fst
 
     m_curScope.clear();

--- a/include/verilated_trace.h
+++ b/include/verilated_trace.h
@@ -212,11 +212,14 @@ protected:
 private:
     std::vector<bool> m_sigs_enabledVec;  // Staging for m_sigs_enabledp
     std::vector<CallbackRecord> m_initCbs;  // Routines to initialize tracing
+    std::vector<CallbackRecord> m_constCbs;  // Routines to perform const dump
+    std::vector<CallbackRecord> m_constOffloadCbs;  // Routines to perform offloaded const dump
     std::vector<CallbackRecord> m_fullCbs;  // Routines to perform full dump
     std::vector<CallbackRecord> m_fullOffloadCbs;  // Routines to perform offloaded full dump
     std::vector<CallbackRecord> m_chgCbs;  // Routines to perform incremental dump
     std::vector<CallbackRecord> m_chgOffloadCbs;  // Routines to perform offloaded incremental dump
     std::vector<CallbackRecord> m_cleanupCbs;  // Routines to call at the end of dump
+    bool m_constDump = true;  // Whether a const dump is required on the next call to 'dump'
     bool m_fullDump = true;  // Whether a full dump is required on the next call to 'dump'
     uint32_t m_nextCode = 0;  // Next code number to assign
     uint32_t m_numSignals = 0;  // Number of distinct signals
@@ -289,6 +292,7 @@ protected:
     uint32_t nextCode() const { return m_nextCode; }
     uint32_t numSignals() const { return m_numSignals; }
     uint32_t maxBits() const { return m_maxBits; }
+    void constDump(bool value) { m_constDump = value; }
     void fullDump(bool value) { m_fullDump = value; }
 
     double timeRes() const { return m_timeRes; }
@@ -359,6 +363,8 @@ public:
 
     void addModel(VerilatedModel*) VL_MT_SAFE_EXCLUDES(m_mutex);
     void addInitCb(initCb_t cb, void* userp) VL_MT_SAFE;
+    void addConstCb(dumpCb_t cb, void* userp) VL_MT_SAFE;
+    void addConstCb(dumpOffloadCb_t cb, void* userp) VL_MT_SAFE;
     void addFullCb(dumpCb_t cb, void* userp) VL_MT_SAFE;
     void addFullCb(dumpOffloadCb_t cb, void* userp) VL_MT_SAFE;
     void addChgCb(dumpCb_t cb, void* userp) VL_MT_SAFE;

--- a/include/verilated_trace_imp.h
+++ b/include/verilated_trace_imp.h
@@ -610,6 +610,15 @@ void VerilatedTrace<VL_SUB_T, VL_BUF_T>::dump(uint64_t timeui) VL_MT_SAFE_EXCLUD
         }
     }
 
+    if (VL_UNLIKELY(m_constDump)) {
+        m_constDump = false;
+        if (offload()) {
+            runOffloadedCallbacks(m_constOffloadCbs);
+        } else {
+            runCallbacks(m_constCbs);
+        }
+    }
+
     for (uint32_t i = 0; i < m_cleanupCbs.size(); ++i) {
         const CallbackRecord& cbr = m_cleanupCbs[i];
         cbr.m_cleanupCb(cbr.m_userp, self());
@@ -693,6 +702,14 @@ void VerilatedTrace<VL_SUB_T, VL_BUF_T>::addCallbackRecord(std::vector<CallbackR
 template <>
 void VerilatedTrace<VL_SUB_T, VL_BUF_T>::addInitCb(initCb_t cb, void* userp) VL_MT_SAFE {
     addCallbackRecord(m_initCbs, CallbackRecord{cb, userp});
+}
+template <>
+void VerilatedTrace<VL_SUB_T, VL_BUF_T>::addConstCb(dumpCb_t cb, void* userp) VL_MT_SAFE {
+    addCallbackRecord(m_constCbs, CallbackRecord{cb, userp});
+}
+template <>
+void VerilatedTrace<VL_SUB_T, VL_BUF_T>::addConstCb(dumpOffloadCb_t cb, void* userp) VL_MT_SAFE {
+    addCallbackRecord(m_constOffloadCbs, CallbackRecord{cb, userp});
 }
 template <>
 void VerilatedTrace<VL_SUB_T, VL_BUF_T>::addFullCb(dumpCb_t cb, void* userp) VL_MT_SAFE {

--- a/include/verilated_vcd_c.cpp
+++ b/include/verilated_vcd_c.cpp
@@ -164,6 +164,7 @@ void VerilatedVcd::openNextImp(bool incFilename) {
         }
     }
     m_isOpen = true;
+    constDump(true);  // First dump must containt the const signals
     fullDump(true);  // First dump must be full
     m_wroteBytes = 0;
 }

--- a/src/V3Ast.h
+++ b/src/V3Ast.h
@@ -1247,6 +1247,38 @@ inline std::ostream& operator<<(std::ostream& os, const VUseType& rhs) {
     return os << rhs.ascii();
 }
 
+//######################################################################
+
+class VTraceType final {
+public:
+    enum en : uint8_t {
+        CONSTANT,  // Constant value dump (once at the beginning)
+        FULL,  // Full value dump (always emitted)
+        CHANGE  // Incremental value dump (emitted only if the value changed)
+    };
+    enum en m_e;
+    VTraceType()
+        : m_e{CONSTANT} {}
+    // cppcheck-suppress noExplicitConstructor
+    constexpr VTraceType(en _e)
+        : m_e{_e} {}
+    explicit VTraceType(int _e)
+        : m_e(static_cast<en>(_e)) {}  // Need () or GCC 4.8 false warning
+    constexpr operator en() const { return m_e; }
+    const char* ascii() const {
+        static const char* const names[] = {"CONSTANT", "FULL", "CHANGE"};
+        return names[m_e];
+    }
+};
+constexpr bool operator==(const VTraceType& lhs, const VTraceType& rhs) {
+    return lhs.m_e == rhs.m_e;
+}
+constexpr bool operator==(const VTraceType& lhs, VTraceType::en rhs) { return lhs.m_e == rhs; }
+constexpr bool operator==(VTraceType::en lhs, const VTraceType& rhs) { return lhs == rhs.m_e; }
+inline std::ostream& operator<<(std::ostream& os, const VTraceType& rhs) {
+    return os << rhs.ascii();
+}
+
 // ######################################################################
 
 class VCastable final {
@@ -2656,10 +2688,16 @@ public:
     template <typename U>
     // cppcheck-suppress noExplicitConstructor
     VNRef(U&& x)
-        : std::reference_wrapper<T_Node>{x} {}
+        : std::reference_wrapper<T_Node> {
+        x
+    }
+    {}
     // cppcheck-suppress noExplicitConstructor
     VNRef(const std::reference_wrapper<T_Node>& other)
-        : std::reference_wrapper<T_Node>{other} {}
+        : std::reference_wrapper<T_Node> {
+        other
+    }
+    {}
 };
 
 static_assert(sizeof(VNRef<AstNode>) == sizeof(std::reference_wrapper<AstNode>),

--- a/src/V3Ast.h
+++ b/src/V3Ast.h
@@ -2688,16 +2688,10 @@ public:
     template <typename U>
     // cppcheck-suppress noExplicitConstructor
     VNRef(U&& x)
-        : std::reference_wrapper<T_Node> {
-        x
-    }
-    {}
+        : std::reference_wrapper<T_Node>{x} {}
     // cppcheck-suppress noExplicitConstructor
     VNRef(const std::reference_wrapper<T_Node>& other)
-        : std::reference_wrapper<T_Node> {
-        other
-    }
-    {}
+        : std::reference_wrapper<T_Node>{other} {}
 };
 
 static_assert(sizeof(VNRef<AstNode>) == sizeof(std::reference_wrapper<AstNode>),

--- a/src/V3AstNodeOther.h
+++ b/src/V3AstNodeOther.h
@@ -3243,14 +3243,14 @@ class AstTraceInc final : public AstNodeStmt {
 private:
     AstTraceDecl* m_declp;  // Pointer to declaration
     const uint32_t m_baseCode;  // Trace code base value in function containing this AstTraceInc
-    const bool m_full;  // Is this a full vs incremental dump
+    const VTraceType m_traceType;  // Is this a const/full/incremental dump
 
 public:
-    AstTraceInc(FileLine* fl, AstTraceDecl* declp, bool full, uint32_t baseCode = 0)
+    AstTraceInc(FileLine* fl, AstTraceDecl* declp, VTraceType traceType, uint32_t baseCode = 0)
         : ASTGEN_SUPER_TraceInc(fl)
         , m_declp{declp}
         , m_baseCode{baseCode}
-        , m_full{full} {
+        , m_traceType{traceType} {
         dtypeFrom(declp);
         this->valuep(
             declp->valuep()->cloneTree(true));  // TODO: maybe use reference to TraceDecl instead?
@@ -3274,7 +3274,7 @@ public:
     bool isOutputter() override { return true; }
     // but isPure()  true
     AstTraceDecl* declp() const { return m_declp; }
-    bool full() const { return m_full; }
+    VTraceType traceType() const { return m_traceType; }
     uint32_t baseCode() const { return m_baseCode; }
 };
 class AstTracePopNamePrefix final : public AstNodeStmt {

--- a/src/V3EmitCImp.cpp
+++ b/src/V3EmitCImp.cpp
@@ -769,7 +769,8 @@ class EmitCTrace final : EmitCFunc {
 
     void emitTraceChangeOne(AstTraceInc* nodep, int arrayindex) {
         iterateAndNextConstNull(nodep->precondsp());
-        const string func = nodep->full() ? "full" : "chg";
+        // Note: Both VTraceType::CHANGE and VTraceType::FULL use the 'full' methods
+        const std::string func = nodep->traceType() == VTraceType::CHANGE ? "chg" : "full";
         bool emitWidth = true;
         if (nodep->dtypep()->basicp()->isDouble()) {
             puts("bufp->" + func + "Double");
@@ -794,7 +795,10 @@ class EmitCTrace final : EmitCFunc {
 
         const uint32_t offset = (arrayindex < 0) ? 0 : (arrayindex * nodep->declp()->widthWords());
         const uint32_t code = nodep->declp()->code() + offset;
-        puts(v3Global.opt.useTraceOffload() && !nodep->full() ? "(base+" : "(oldp+");
+        // Note: Both VTraceType::CHANGE and VTraceType::FULL use the 'full' methods
+        puts(v3Global.opt.useTraceOffload() && nodep->traceType() == VTraceType::CHANGE
+                 ? "(base+"
+                 : "(oldp+");
         puts(cvtToStr(code - nodep->baseCode()));
         puts(",");
         emitTraceValue(nodep, arrayindex);


### PR DESCRIPTION
Some values emitted to the trace files are constant (e.g.: actual parameter values), and never change. Previously we used to trace these in the 'full' dumps, which also included all other truly variable signals. This patch introduces a new generated trace function 'const', to complement the 'full' and 'chg' flavour, and 'const' now only contains the constant signals, while 'full' and 'chg' contain only the truly variable signals. The generate 'full' and 'chg' trace functions now have exactly the same shape. Note that 'const' signals are still traced using the 'full*' dump methods of the trace buffers, so there is no need for a third flavour of those.