### PR TITLE
clang_check_attributes: add missing dataclass decorator

### DIFF
--- a/nodist/clang_check_attributes
+++ b/nodist/clang_check_attributes
@@ -955,6 +955,7 @@ def run_analysis(ccl: Iterable[CompileCommand], pccl: Iterable[CompileCommand],
                                          compile_command.directory)
 
 
+@dataclass
 class ParallelAnalysisProcess:
     cav: Optional[CallAnnotationsValidator] = None
     diags: set[Diagnostic] = dataclasses.field(default_factory=set)


### PR DESCRIPTION
Fixes: https://github.com/verilator/verilator/issues/4604