### PR TITLE
Fix virtual methods

### DIFF
--- a/src/V3AstNodeExpr.h
+++ b/src/V3AstNodeExpr.h
@@ -183,6 +183,7 @@ class AstNodeCCall VL_NOT_FINAL : public AstNodeExpr {
     // @astgen op2 := argsp : List[AstNodeExpr] // Note: op1 used by some sub-types only
     AstCFunc* m_funcp;
     string m_argTypes;
+    bool m_superReference = false;  // Called with super reference
 
 protected:
     AstNodeCCall(VNType t, FileLine* fl, AstCFunc* funcp, AstNodeExpr* argsp = nullptr)
@@ -213,6 +214,8 @@ public:
     string emitVerilog() final override { V3ERROR_NA_RETURN(""); }
     string emitC() final override { V3ERROR_NA_RETURN(""); }
     bool cleanOut() const final override { return true; }
+    bool superReference() const { return m_superReference; }
+    void superReference(bool flag) { m_superReference = flag; }
 };
 class AstNodeFTaskRef VL_NOT_FINAL : public AstNodeExpr {
     // A reference to a task (or function)
@@ -226,6 +229,7 @@ class AstNodeFTaskRef VL_NOT_FINAL : public AstNodeExpr {
     string m_dotted;  // Dotted part of scope the name()ed task/func is under or ""
     string m_inlinedDots;  // Dotted hierarchy flattened out
     bool m_pli = false;  // Pli system call ($name)
+    bool m_superReference = false;  // Called with super reference
     VIsCached m_purity;  // Pure state
 
 protected:
@@ -258,6 +262,8 @@ public:
     void classOrPackagep(AstNodeModule* nodep) { m_classOrPackagep = nodep; }
     bool pli() const { return m_pli; }
     void pli(bool flag) { m_pli = flag; }
+    bool superReference() const { return m_superReference; }
+    void superReference(bool flag) { m_superReference = flag; }
     bool isPure() override;
 
     string emitVerilog() final override { V3ERROR_NA_RETURN(""); }

--- a/src/V3AstNodeExpr.h
+++ b/src/V3AstNodeExpr.h
@@ -229,7 +229,6 @@ class AstNodeFTaskRef VL_NOT_FINAL : public AstNodeExpr {
     string m_dotted;  // Dotted part of scope the name()ed task/func is under or ""
     string m_inlinedDots;  // Dotted hierarchy flattened out
     bool m_pli = false;  // Pli system call ($name)
-    bool m_superReference = false;  // Called with super reference
     VIsCached m_purity;  // Pure state
 
 protected:
@@ -262,8 +261,6 @@ public:
     void classOrPackagep(AstNodeModule* nodep) { m_classOrPackagep = nodep; }
     bool pli() const { return m_pli; }
     void pli(bool flag) { m_pli = flag; }
-    bool superReference() const { return m_superReference; }
-    void superReference(bool flag) { m_superReference = flag; }
     bool isPure() override;
 
     string emitVerilog() final override { V3ERROR_NA_RETURN(""); }
@@ -4204,12 +4201,15 @@ public:
 // === AstNodeFTaskRef ===
 class AstFuncRef final : public AstNodeFTaskRef {
     // A reference to a function
+    bool m_superReference = false;  // Called with super reference
 public:
     AstFuncRef(FileLine* fl, AstParseRef* namep, AstNodeExpr* pinsp)
         : ASTGEN_SUPER_FuncRef(fl, (AstNode*)namep, pinsp) {}
     AstFuncRef(FileLine* fl, const string& name, AstNodeExpr* pinsp)
         : ASTGEN_SUPER_FuncRef(fl, name, pinsp) {}
     ASTGEN_MEMBERS_AstFuncRef;
+    bool superReference() const { return m_superReference; }
+    void superReference(bool flag) { m_superReference = flag; }
 };
 class AstMethodCall final : public AstNodeFTaskRef {
     // A reference to a member task (or function)
@@ -4246,6 +4246,7 @@ public:
 };
 class AstTaskRef final : public AstNodeFTaskRef {
     // A reference to a task
+    bool m_superReference = false;  // Called with super reference
 public:
     AstTaskRef(FileLine* fl, AstParseRef* namep, AstNodeExpr* pinsp)
         : ASTGEN_SUPER_TaskRef(fl, (AstNode*)namep, pinsp) {
@@ -4256,6 +4257,8 @@ public:
         dtypeSetVoid();
     }
     ASTGEN_MEMBERS_AstTaskRef;
+    bool superReference() const { return m_superReference; }
+    void superReference(bool flag) { m_superReference = flag; }
 };
 
 // === AstNodePreSel ===

--- a/src/V3EmitCFunc.h
+++ b/src/V3EmitCFunc.h
@@ -488,7 +488,7 @@ public:
             puts(funcp->nameProtect());
         } else if (VN_IS(funcModp, Class) && funcModp != m_modp) {
             // Calling superclass method
-            puts(prefixNameProtect(funcModp) + "::");
+            if (nodep->superReference()) puts(prefixNameProtect(funcModp) + "::");
             puts(funcp->nameProtect());
         } else if (funcp->isLoose()) {
             // Calling loose method

--- a/src/V3EmitCFunc.h
+++ b/src/V3EmitCFunc.h
@@ -486,9 +486,9 @@ public:
             // Call static method via the containing class
             puts(prefixNameProtect(funcModp) + "::");
             puts(funcp->nameProtect());
-        } else if (VN_IS(funcModp, Class) && funcModp != m_modp) {
+        } else if (nodep->superReference()) {
             // Calling superclass method
-            if (nodep->superReference()) puts(prefixNameProtect(funcModp) + "::");
+            puts(prefixNameProtect(funcModp) + "::");
             puts(funcp->nameProtect());
         } else if (funcp->isLoose()) {
             // Calling loose method

--- a/src/V3LinkDot.cpp
+++ b/src/V3LinkDot.cpp
@@ -3081,7 +3081,15 @@ private:
             m_ds.init(m_curSymp);
             iterateChildren(nodep);
         }
-        if (m_ds.m_super) nodep->superReference(true);
+
+        if (m_ds.m_super) {
+            if (AstFuncRef* const funcRefp = VN_CAST(nodep, FuncRef)) {
+                funcRefp->superReference(true);
+            } else if (AstTaskRef* const taskRefp = VN_CAST(nodep, TaskRef)) {
+                taskRefp->superReference(true);
+            }
+        }
+
         bool staticAccess = false;
         if (m_ds.m_unresolvedClass) {
             // Unable to link before V3Param

--- a/src/V3LinkDot.cpp
+++ b/src/V3LinkDot.cpp
@@ -2039,6 +2039,7 @@ private:
         DotPosition m_dotPos;  // Scope part of dotted resolution
         VSymEnt* m_dotSymp;  // SymEnt for dotted AstParse lookup
         const AstDot* m_dotp;  // Current dot
+        bool m_super;  // Starts with super reference
         bool m_unresolvedCell;  // Unresolved cell, needs help from V3Param
         bool m_unresolvedClass;  // Unresolved class reference, needs help from V3Param
         AstNode* m_unlinkedScopep;  // Unresolved scope, needs corresponding VarXRef
@@ -2050,6 +2051,7 @@ private:
             m_dotPos = DP_NONE;
             m_dotSymp = curSymp;
             m_dotp = nullptr;
+            m_super = false;
             m_dotErr = false;
             m_dotText = "";
             m_unresolvedCell = false;
@@ -2061,6 +2063,7 @@ private:
             std::ostringstream sstr;
             sstr << "ds=" << names[m_dotPos];
             sstr << "  dse" << cvtToHex(m_dotSymp);
+            sstr << "  sup=" << m_super;
             sstr << "  txt=" << m_dotText;
             sstr << "  unrCell=" << m_unresolvedCell;
             sstr << "  unrClass=" << m_unresolvedClass;
@@ -2462,6 +2465,7 @@ private:
                             const auto baseClassp = cextp->classp();
                             UASSERT_OBJ(baseClassp, nodep, "Bad superclass");
                             m_ds.m_dotSymp = m_statep->getNodeSym(baseClassp);
+                            m_ds.m_super = true;
                             UINFO(8, "     super. " << m_ds.ascii() << endl);
                         }
                     }
@@ -3077,7 +3081,7 @@ private:
             m_ds.init(m_curSymp);
             iterateChildren(nodep);
         }
-
+        if (m_ds.m_super) nodep->superReference(true);
         bool staticAccess = false;
         if (m_ds.m_unresolvedClass) {
             // Unable to link before V3Param

--- a/src/V3LinkDot.cpp
+++ b/src/V3LinkDot.cpp
@@ -2538,7 +2538,6 @@ private:
         // Generally resolved during Primay, but might be at param time under AstUnlinkedRef
         UASSERT_OBJ(m_statep->forPrimary() || m_statep->forPrearray(), nodep,
                     "ParseRefs should no longer exist");
-        if (nodep->name() == "super") nodep->v3warn(E_UNSUPPORTED, "Unsupported: super");
         const DotStates lastStates = m_ds;
         const bool start = (m_ds.m_dotPos == DP_NONE);  // Save, as m_dotp will be changed
         if (start) {

--- a/src/V3Randomize.cpp
+++ b/src/V3Randomize.cpp
@@ -310,6 +310,7 @@ private:
                 baseRandCallp->taskp(baseRandomizep);
                 baseRandCallp->dtypeFrom(baseRandomizep->dtypep());
                 baseRandCallp->classOrPackagep(nodep->extendsp()->classp());
+                baseRandCallp->superReference(true);
                 beginValp = baseRandCallp;
             }
         }

--- a/src/V3Task.cpp
+++ b/src/V3Task.cpp
@@ -637,6 +637,7 @@ private:
             ccallp->dtypeSetVoid();
             beginp->addNext(ccallp->makeStmt());
         }
+        ccallp->superReference(refp->superReference());
 
         // Convert complicated outputs to temp signals
         {

--- a/src/V3Task.cpp
+++ b/src/V3Task.cpp
@@ -637,7 +637,12 @@ private:
             ccallp->dtypeSetVoid();
             beginp->addNext(ccallp->makeStmt());
         }
-        ccallp->superReference(refp->superReference());
+
+        if (const AstFuncRef* const funcRefp = VN_CAST(refp, FuncRef)) {
+            ccallp->superReference(funcRefp->superReference());
+        } else if (const AstTaskRef* const taskRefp = VN_CAST(refp, TaskRef)) {
+            ccallp->superReference(taskRefp->superReference());
+        }
 
         // Convert complicated outputs to temp signals
         {

--- a/test_regress/t/t_class_virtual.v
+++ b/test_regress/t/t_class_virtual.v
@@ -22,11 +22,32 @@ class VB extends VBase;
    endfunction
 endclass
 
+bit passed = 1'b0;
+
+virtual class uvm_phase;
+   virtual function void exec_func;
+   endfunction
+endclass
+
+class uvm_topdown_phase extends uvm_phase;
+   function void traverse;
+      exec_func();
+   endfunction
+endclass
+
+class uvm_build_phase extends uvm_topdown_phase;
+   virtual function void exec_func;
+      passed = 1'b1;
+   endfunction
+endclass
+
 module t;
    initial begin
       VA va = new;
       VB vb = new;
       VBase b;
+
+      uvm_build_phase ph;
 
       if (va.hello() != 2) $stop;
       if (vb.hello() != 3) $stop;
@@ -35,6 +56,11 @@ module t;
       if (b.hello() != 2) $stop;
       b = vb;
       if (b.hello() != 3) $stop;
+
+      ph = new;
+      ph.traverse();
+      if (!passed) $stop;
+
       $write("*-* All Finished *-*\n");
       $finish;
    end

--- a/test_regress/t/t_class_virtual.v
+++ b/test_regress/t/t_class_virtual.v
@@ -22,22 +22,21 @@ class VB extends VBase;
    endfunction
 endclass
 
-bit passed = 1'b0;
-
 virtual class uvm_phase;
-   virtual function void exec_func;
+   virtual function int exec_func;
+      return 0;
    endfunction
 endclass
 
 class uvm_topdown_phase extends uvm_phase;
-   function void traverse;
-      exec_func();
+   function int get1;
+      return exec_func();
    endfunction
 endclass
 
 class uvm_build_phase extends uvm_topdown_phase;
-   virtual function void exec_func;
-      passed = 1'b1;
+   virtual function int exec_func;
+      return 1;
    endfunction
 endclass
 
@@ -58,8 +57,7 @@ module t;
       if (b.hello() != 3) $stop;
 
       ph = new;
-      ph.traverse();
-      if (!passed) $stop;
+      if (ph.get1() != 1) $stop;
 
       $write("*-* All Finished *-*\n");
       $finish;

--- a/test_regress/t/t_class_virtual.v
+++ b/test_regress/t/t_class_virtual.v
@@ -40,6 +40,21 @@ class uvm_build_phase extends uvm_topdown_phase;
    endfunction
 endclass
 
+virtual class Cls;
+   uvm_phase ph;
+endclass
+
+class ExtendsCls extends Cls;
+   function new;
+      uvm_build_phase bp = new;
+      ph = bp;
+   endfunction
+
+   function int get1;
+      return super.ph.exec_func();
+   endfunction
+endclass
+
 module t;
    initial begin
       VA va = new;
@@ -47,6 +62,7 @@ module t;
       VBase b;
 
       uvm_build_phase ph;
+      ExtendsCls ec;
 
       if (va.hello() != 2) $stop;
       if (vb.hello() != 3) $stop;
@@ -58,6 +74,9 @@ module t;
 
       ph = new;
       if (ph.get1() != 1) $stop;
+
+      ec = new;
+      if (ec.get1() != 1) $stop;
 
       $write("*-* All Finished *-*\n");
       $finish;


### PR DESCRIPTION
Currently on master, virtual methods don't work properly if they are called from a method of a class that don't override them. The wrong behavior is caused by emitting calls of methods defined in a base class with `<base class name>::` prefix. This prefix is needed to handle function calls with `super` references. In this PR, I mark such calls and use this prefix only in their case. Virtual methods work properly with this fix.