### PR TITLE
Make node iteration stricter

### DIFF
--- a/src/V3Ast.cpp
+++ b/src/V3Ast.cpp
@@ -774,12 +774,6 @@ void AstNode::addHereThisAsNext(AstNode* newp) {
         newp->m_headtailp = tailp;
         tailp->m_headtailp = newp;
     }
-    // Iterator fixup
-    if (newLastp->m_iterpp) *(newLastp->m_iterpp) = this;
-    if (this->m_iterpp) {
-        *(this->m_iterpp) = newp;
-        this->m_iterpp = nullptr;
-    }
     //
     debugTreeChange(this, "-addHereThisAsNext: ", __LINE__, true);
 }
@@ -858,6 +852,7 @@ AstNode* AstNode::cloneTree(bool cloneNextLink, bool needPure) {
 void AstNode::deleteNode() {
     // private: Delete single node. Publicly call deleteTree() instead.
     UASSERT(!m_backp, "Delete called on node with backlink still set");
+    UASSERT(!m_iterpp, "Delete called on node with iterpp still set");
     editCountInc();
     // Change links of old node so we coredump if used
     this->m_nextp = reinterpret_cast<AstNode*>(0x1);
@@ -958,35 +953,39 @@ void AstNode::iterateAndNext(VNVisitor& v) {
     // This is a very hot function
     // IMPORTANT: If you replace a node that's the target of this iterator,
     // then the NEW node will be iterated on next, it isn't skipped!
-    // Future versions of this function may require the node to have a back to be iterated;
-    // there's no lower level reason yet though the back must exist.
-    AstNode* nodep = this;
-#ifdef VL_DEBUG  // Otherwise too hot of a function for debug
-    UASSERT_OBJ(!(nodep && !nodep->m_backp), nodep, "iterateAndNext node has no back");
+
+#ifdef VL_DEBUG
+    UASSERT_OBJ(m_backp, this, "iterateAndNext called on node which has no m_backp");
+    UASSERT_OBJ(!m_iterpp, this, "iterateAndNext called on node already under iteration");
 #endif
-    // cppcheck-suppress knownConditionTrueFalse
-    if (nodep) ASTNODE_PREFETCH(nodep->m_nextp);
-    while (nodep) {  // effectively: if (!this) return;  // Callers rely on this
+    ASTNODE_PREFETCH(m_nextp);
+
+    AstNode* nodep = this;
+    do {
+
         if (nodep->m_nextp) ASTNODE_PREFETCH(nodep->m_nextp->m_nextp);
-        AstNode* niterp = nodep;  // Pointer may get stomped via m_iterpp if the node is edited
-        // Desirable check, but many places where multiple iterations are OK
-        // UASSERT_OBJ(!niterp->m_iterpp, niterp, "IterateAndNext under iterateAndNext may miss
-        // edits"); Optimization note: Doing PREFETCH_RW on m_iterpp is a net even
-        // cppcheck-suppress nullPointer
-        niterp->m_iterpp = &niterp;
-        niterp->accept(v);
-        // accept may do a replaceNode and change niterp on us...
-        // niterp maybe nullptr, so need cast if printing
-        // if (niterp != nodep) UINFO(1,"iterateAndNext edited "<<cvtToHex(nodep)
-        //                             <<" now into "<<cvtToHex(niterp)<<endl);
-        if (!niterp) return;  // Perhaps node deleted inside accept
-        niterp->m_iterpp = nullptr;
-        if (VL_UNLIKELY(niterp != nodep)) {  // Edited node inside accept
+
+        // This pointer may get changed via m_iterpp if the current node is edited
+        AstNode* niterp = nodep;
+        nodep->m_iterpp = &niterp;
+        nodep->accept(v);
+
+        if (VL_UNLIKELY(niterp != nodep)) {
+            // Node edited inside 'accept' (may have been deleted entirely)
             nodep = niterp;
-        } else {  // Unchanged node (though maybe updated m_next), just continue loop
-            nodep = niterp->m_nextp;
+#ifdef VL_DEBUG
+            UASSERT_OBJ(!nodep || (nodep->m_iterpp == &niterp), nodep,
+                        "New node already being iterated elsewhere");
+#endif
+        } else {
+            // Unchanged node (though maybe updated m_next), just continue loop
+            nodep->m_iterpp = nullptr;
+            nodep = nodep->m_nextp;
+#ifdef VL_DEBUG
+            UASSERT_OBJ(!nodep || !nodep->m_iterpp, niterp, "Next node already being iterated");
+#endif
         }
-    }
+    } while (nodep);
 }
 
 void AstNode::iterateListBackwardsConst(VNVisitorConst& v) {


### PR DESCRIPTION
This is a prep patch for an experiment on removing m_iterpp (which I have in a hacked up form, and does not actually help much, 1.2% memory saving, yay...). Even if we don't land that, I think we want these changes that makes iteration a little bit stricter. Notably, there are assertions (only under VL_DEBUG, due to being in hot code), that ensure that we don't recursively iterate the same node. We used to do this in a few places (which I fixed), but this is generally not safe due to the recursive call to iterateAndNext overwriting m_iterpp, and hence any subsequent edits would be unsafe.

Apart from the direct recursion, we also need to prevent addHereThisAsNext from updating the iteration pointer. I think this is a good thing. Previously it used to force iteration to restart on the nodes inserted *before* the currently iterated node, which would also mean that the currently iterated node would then be visited again, as it became a successor of the inserted node. With this patch, iteration continues with the edited node only if it's replacing the current node, or if the new node is a successor (nextp) of the current node, but not if the edit is adding the node before the current node. I fixed the few places (V3Premit, V3Task) where we used to rely on the old behaviour. The fix is simply to explicitly iterate the new nodes you insert before the current node.

Patch is performance neutral.