### PR TITLE
Fix queue insertion at end

### DIFF
--- a/include/verilated_types.h
+++ b/include/verilated_types.h
@@ -545,7 +545,7 @@ public:
 
     // function void q.insert(index, value);
     void insert(int32_t index, const T_Value& value) {
-        if (VL_UNLIKELY(index < 0 || index >= m_deque.size())) return;
+        if (VL_UNLIKELY(index < 0 || index > m_deque.size())) { return; }
         m_deque.insert(m_deque.begin() + index, value);
     }
 

--- a/include/verilated_types.h
+++ b/include/verilated_types.h
@@ -545,7 +545,7 @@ public:
 
     // function void q.insert(index, value);
     void insert(int32_t index, const T_Value& value) {
-        if (VL_UNLIKELY(index < 0 || index > m_deque.size())) { return; }
+        if (VL_UNLIKELY(index < 0 || index > m_deque.size())) return;
         m_deque.insert(m_deque.begin() + index, value);
     }
 

--- a/test_regress/t/t_queue_insert_at_end.pl
+++ b/test_regress/t/t_queue_insert_at_end.pl
@@ -1,0 +1,21 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2023 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_queue_insert_at_end.v
+++ b/test_regress/t/t_queue_insert_at_end.v
@@ -1,0 +1,23 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2023 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+module t();
+  initial begin
+    int queue[$];
+
+    queue.insert(0, 0);
+    if (queue.size() != 1) $stop;
+
+    queue.insert(1, 1);
+    if (queue.size() != 2) $stop;
+
+    if (queue[0] != 0) $stop;
+    if (queue[1] != 1) $stop;
+
+    $write("*-* All Finished *-*\n");
+    $finish;
+  end
+endmodule


### PR DESCRIPTION
> The insert() method inserts the given item at the specified index position.
If the index argument has any bits with unknown (x/z) value, or is negative, or is **greater** than the current
size of the queue, then the method call shall have no effect on the queue and may cause a warning to be
issued.