### PR TITLE
Fix rand fields of reference types

### DIFF
--- a/src/V3Randomize.cpp
+++ b/src/V3Randomize.cpp
@@ -55,7 +55,7 @@ private:
             for (auto* memberp = classp->stmtsp(); memberp; memberp = memberp->nextp()) {
                 // If member is rand and of class type, mark its class
                 if (VN_IS(memberp, Var) && VN_AS(memberp, Var)->isRand()) {
-                    if (const auto* const classRefp = VN_CAST(memberp->dtypep(), ClassRefDType)) {
+                    if (const auto* const classRefp = VN_CAST(memberp->dtypep()->skipRefp(), ClassRefDType)) {
                         auto* const rclassp = classRefp->classp();
                         if (!rclassp->user1()) {
                             rclassp->user1(true);
@@ -100,7 +100,7 @@ private:
         iterateChildrenConst(nodep);
         if (nodep->name() != "randomize") return;
         if (const AstClassRefDType* const classRefp
-            = VN_CAST(nodep->fromp()->dtypep(), ClassRefDType)) {
+            = VN_CAST(nodep->fromp()->dtypep()->skipRefp(), ClassRefDType)) {
             AstClass* const classp = classRefp->classp();
             classp->user1(true);
             markMembers(classp);

--- a/src/V3Randomize.cpp
+++ b/src/V3Randomize.cpp
@@ -55,7 +55,8 @@ private:
             for (auto* memberp = classp->stmtsp(); memberp; memberp = memberp->nextp()) {
                 // If member is rand and of class type, mark its class
                 if (VN_IS(memberp, Var) && VN_AS(memberp, Var)->isRand()) {
-                    if (const auto* const classRefp = VN_CAST(memberp->dtypep()->skipRefp(), ClassRefDType)) {
+                    if (const auto* const classRefp
+                        = VN_CAST(memberp->dtypep()->skipRefp(), ClassRefDType)) {
                         auto* const rclassp = classRefp->classp();
                         if (!rclassp->user1()) {
                             rclassp->user1(true);

--- a/test_regress/t/t_randomize_method.v
+++ b/test_regress/t/t_randomize_method.v
@@ -113,6 +113,19 @@ class DeriveAndContainClsWithInt extends ClsWithInt;
    endfunction
 endclass
 
+class ClsUsedOnlyHere;
+   rand int a;
+endclass
+
+typedef ClsUsedOnlyHere cls_used_only_here_t;
+
+class ClsContainUsedOnlyHere;
+   rand cls_used_only_here_t c;
+   function new;
+      c = new;
+   endfunction
+endclass
+
 module t (/*AUTOARG*/);
 
    DerivedCls derived;
@@ -121,6 +134,7 @@ module t (/*AUTOARG*/);
    ContainsNull cont;
    DeriveClsWithInt der_int;
    DeriveAndContainClsWithInt der_contain;
+   ClsContainUsedOnlyHere cls_cont_used;
 
    initial begin
       int rand_result;
@@ -130,6 +144,7 @@ module t (/*AUTOARG*/);
       der_int = new;
       der_contain = new;
       base = derived;
+      cls_cont_used = new;
       for (int i = 0; i < 10; i++) begin
          rand_result = base.randomize();
          rand_result = other.randomize();
@@ -166,6 +181,7 @@ module t (/*AUTOARG*/);
       `check_rand(der_int, der_int.a);
       `check_rand(der_contain, der_contain.cls1.a);
       `check_rand(der_contain, der_contain.a);
+      `check_rand(cls_cont_used, cls_cont_used.c.a);
 
       $write("*-* All Finished *-*\n");
       $finish;

--- a/test_regress/t/t_uvm_pkg_todo.vh
+++ b/test_regress/t/t_uvm_pkg_todo.vh
@@ -21078,15 +21078,21 @@ typedef class uvm_tlm_extension_base;
 class uvm_tlm_generic_payload extends uvm_sequence_item;
    rand bit [63:0]             m_address;
    rand uvm_tlm_command_e          m_command;
-   rand byte unsigned             m_data[];
+   //TODO issue-4625 - Rand fields of dynamic array types
+   //TODO %Error-UNSUPPORTED: t/t_uvm_pkg_todo.vh:21081:35: Unsupported: random member variable with type 'byte[]'
+   /*TODO rand*/ byte unsigned             m_data[];
    rand int unsigned           m_length;
    rand uvm_tlm_response_status_e  m_response_status;
    bit m_dmi;
-   rand byte unsigned          m_byte_enable[];
+   //TODO issue-4625 - Rand fields of dynamic array types
+   //TODO %Error-UNSUPPORTED: t/t_uvm_pkg_todo.vh:21081:35: Unsupported: random member variable with type 'byte[]'
+   /*TODO rand*/ byte unsigned          m_byte_enable[];
    rand int unsigned m_byte_enable_length;
    rand int unsigned m_streaming_width;
    protected uvm_tlm_extension_base m_extensions [uvm_tlm_extension_base];
-   local rand uvm_tlm_extension_base m_rand_exts[];
+   //TODO issue-4625 - Rand fields of dynamic array types
+   //TODO %Error-UNSUPPORTED: t/t_uvm_pkg_todo.vh:21081:35: Unsupported: random member variable with type 'CLASSREFDTYPE 'uvm_tlm_extension_base'[]'
+   local /*rand*/ uvm_tlm_extension_base m_rand_exts[];
    typedef uvm_object_registry#(uvm_tlm_generic_payload,"uvm_tlm_generic_payload") type_id;
    static function uvm_tlm_generic_payload type_id_create (string name="",
                                      uvm_component parent=null,
@@ -22450,7 +22456,9 @@ class uvm_reg_item extends uvm_sequence_item;
   uvm_elem_kind_e element_kind;
   uvm_object element;
   rand uvm_access_e kind;
-  rand uvm_reg_data_t value[];
+  //TODO issue-4625 - Rand fields of dynamic array types
+  //TODO %Error-UNSUPPORTED: t/t_uvm_pkg_todo.vh:21081:35: Unsupported: random member variable with type 'bit[]'
+  /*rand*/ uvm_reg_data_t value[];
   constraint max_values { value.size() > 0 && value.size() < 1000; }
   rand uvm_reg_addr_t offset;
   uvm_status_e status;
@@ -26870,7 +26878,9 @@ class uvm_reg_fifo extends uvm_reg;
     local uvm_reg_field value;
     local int m_set_cnt;
     local int unsigned m_size;
-    rand uvm_reg_data_t fifo[$];
+    //TODO issue-4625 - Rand fields of dynamic array types
+    //TODO %Error-UNSUPPORTED: t/t_uvm_pkg_todo.vh:21081:35: Unsupported: random member variable with type 'bit[$]'
+    /*rand*/ uvm_reg_data_t fifo[$];
     constraint valid_fifo_size {
       fifo.size() <= m_size;
     }


### PR DESCRIPTION
It adds missing calls of `skipRefp()` in V3Randomize. In two places they are missing, but in others they are present. It results in a situation that sometimes empty `randomize` methods are generated.
Currently, in `RandomizeMarkVisitor` reference types pointing to class types aren't considered as class types.This visitor marks classes that need to have `randomize` method generated. If a class isn't marked, but there is a `rand` field of its type in a class that is marked, `randomize` is generated anyway:
https://github.com/verilator/verilator/blob/34708bbba100d7006dcfe1da5e8af7881f7ac095/src/V3Randomize.cpp#L338
but its body is empty, because only marked classes are visited and have bodies of their `randomize` methods generated:
https://github.com/verilator/verilator/blob/34708bbba100d7006dcfe1da5e8af7881f7ac095/src/V3Randomize.cpp#L296

This fix enables visiting classes that previously weren't visited. It results in a few `UNSUPPORTED` warnings on UVM.