### PR TITLE
Fix a memory leak in V3Fork

### DIFF
--- a/src/V3Fork.cpp
+++ b/src/V3Fork.cpp
@@ -441,7 +441,15 @@ public:
 
         if (typesAdded) v3Global.rootp()->typeTablep()->repairCache();
     }
-    ~DynScopeVisitor() override = default;
+    ~DynScopeVisitor() override {
+        std::set<ForkDynScopeFrame*> frames;
+        for (auto node_frame : m_frames) {
+            frames.insert(node_frame.second);
+        }
+        for (auto* frame : frames) {
+            delete frame;
+        }
+    }
 };
 
 //######################################################################

--- a/src/V3Fork.cpp
+++ b/src/V3Fork.cpp
@@ -443,12 +443,8 @@ public:
     }
     ~DynScopeVisitor() override {
         std::set<ForkDynScopeFrame*> frames;
-        for (auto node_frame : m_frames) {
-            frames.insert(node_frame.second);
-        }
-        for (auto* frame : frames) {
-            delete frame;
-        }
+        for (auto node_frame : m_frames) { frames.insert(node_frame.second); }
+        for (auto* frame : frames) { delete frame; }
     }
 };
 


### PR DESCRIPTION
`ForkDynScopeFrame`s were left undeleted.