### PR TITLE
Fix dynamic casts of null values

### DIFF
--- a/include/verilated_types.h
+++ b/include/verilated_types.h
@@ -1685,6 +1685,10 @@ public:
 
 template <typename T, typename U>
 static inline bool VL_CAST_DYNAMIC(VlClassRef<T> in, VlClassRef<U>& outr) {
+    if (!in) {
+        outr = VlNull{};
+        return true;
+    }
     VlClassRef<U> casted = in.template dynamicCast<U>();
     if (VL_LIKELY(casted)) {
         outr = casted;

--- a/include/verilated_types.h
+++ b/include/verilated_types.h
@@ -1698,6 +1698,12 @@ static inline bool VL_CAST_DYNAMIC(VlClassRef<T> in, VlClassRef<U>& outr) {
     }
 }
 
+template <typename T>
+static inline bool VL_CAST_DYNAMIC(VlNull in, VlClassRef<T>& outr) {
+    outr = VlNull{};
+    return true;
+}
+
 //=============================================================================
 // VlSampleQueue stores samples for input clockvars in clocking blocks. At a clocking event,
 // samples from this queue should be written to the correct input clockvar.

--- a/test_regress/t/t_castdyn.v
+++ b/test_regress/t/t_castdyn.v
@@ -55,6 +55,12 @@ module t (/*AUTOARG*/);
       if (i != 1) $stop;
       if (b != bb) $stop;
 
+      bb = null;
+      b = bb;
+      i = $cast(bbo, b);
+      if (i != 1) $stop;
+      if (b != bb) $stop;
+
       bb = new;
       b = bb;
       bao = ba;

--- a/test_regress/t/t_castdyn.v
+++ b/test_regress/t/t_castdyn.v
@@ -9,6 +9,10 @@ endclass
 class BasedA extends Base;
 endclass
 class BasedB extends Base;
+   static function BasedB getBasedB(bit getNull);
+      BasedB b = new;
+      return getNull ? null : b;
+   endfunction
 endclass
 
 module t (/*AUTOARG*/);
@@ -56,6 +60,12 @@ module t (/*AUTOARG*/);
       if (b != bb) $stop;
 
       bb = null;
+      b = bb;
+      i = $cast(bbo, b);
+      if (i != 1) $stop;
+      if (b != bb) $stop;
+
+      bb = BasedB::getBasedB(1);
       b = bb;
       i = $cast(bbo, b);
       if (i != 1) $stop;


### PR DESCRIPTION
`$cast` of `null` values sometimes don't work. This PR fixes cases that aren't handled properly.