### PR TITLE
Allow constant %m formatting

### DIFF
--- a/test_regress/t/t_initial_sformatf_m.pl
+++ b/test_regress/t/t_initial_sformatf_m.pl
@@ -1,0 +1,21 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2003 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_initial_sformatf_m.v
+++ b/test_regress/t/t_initial_sformatf_m.v
@@ -1,0 +1,30 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2023 by Todd Strader.
+// SPDX-License-Identifier: CC0-1.0
+
+module t (/*AUTOARG*/
+   // Inputs
+   clk
+   );
+   input clk;
+
+   sub_t some_sub_module(.clk);
+endmodule
+
+module sub_t (
+   input clk
+);
+   localparam string NAME = $sformatf("%m");
+
+   always @(posedge clk) begin
+      if (NAME != "t.some_sub_module") begin
+         $display("%%Error: NAME = %s", NAME);
+         $stop;
+      end
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end
+
+endmodule


### PR DESCRIPTION
Constant elaboration of `%m` via `$sformatf()` results in:
```
%Error: t/t_initial_sformatf_m.v:19:29: Expecting expression to be constant, but can't convert a SCOPENAME to constant.
                                      : ... note: In instance 't.some_sub_module'
-node: SCOPENAME 0x555556daa000 <e919> {e19bd} @dt=0x555556debba0@(G/w64) [FMT]
   19 |    localparam string NAME = $sformatf("%m");
      |                             ^~~~~~~~~
```
I believe `SCOPENAME` is an un-scoped placeholder since `%m` can't know what it is until this module has been concretely instantiated.  I tried to skip this check like so:
```
        if (m_required) {
            if (VN_IS(nodep, NodeDType) || VN_IS(nodep, Range) || VN_IS(nodep, SliceSel) || VN_IS(nodep, ScopeName)) {
                // Ignore dtypes for parameter type pins
```
and that allowed verilation to complete, but then I got:
```
Vt_initial_sformatf_m___024root__Slow.cpp:11:81: error: invalid use of non-static data member ‘Vt_initial_sformatf_m___024root::vlSymsp’                                                                                                                                                                                                                                                                                                 
   11 |                                                                                 vlSymsp->name()) ; 
      |                                                                                 ^~~~~~~                                                                                                                                                                                                                                                                                                                                          
```
because this was produced:
```
// Parameter definitions for Vt_initial_sformatf_m___024root
const std::string Vt_initial_sformatf_m___024root::t__DOT__some_sub_module__DOT__NAME = VL_SFORMATF_NX("%S",
                                                                                vlSymsp->name()) ;
```
I'm wondering if it would be better to try to make the C++ work and not worry about constifying `%m` in the AST.  Or if I need to squash the `VARSCOPE` later on:
```
    1:2:2:1: VARSCOPE 0x555556e788f0 <e1136> {e19aw} @dt=0x555556dea410@(G/str)  TOP->t__DOT__some_sub_module__DOT__NAME [T] [scopep=0x555556d87590] -> VAR 0x555556db6180 <e982> {e19aw} @dt=0x555556dea410@(G/str)  t__DOT__some_sub_module__DOT__NAME [VSTATIC]  LPARAM
```