### PR TITLE
Delete AstNode user5

### DIFF
--- a/docs/internals.rst
+++ b/docs/internals.rst
@@ -1222,9 +1222,9 @@ There are three ways data is passed between visitor functions.
 
 2. User attributes. Each ``AstNode`` (**Note.** The AST node, not the
    visitor) has five user attributes, which may be accessed as an
-   integer using the ``user1()`` through ``user5()`` methods, or as a
+   integer using the ``user1()`` through ``user4()`` methods, or as a
    pointer (of type ``AstNUser``) using the ``user1p()`` through
-   ``user5p()`` methods (a common technique lifted from graph traversal
+   ``user4p()`` methods (a common technique lifted from graph traversal
    packages).
 
    A visitor first clears the one it wants to use by calling
@@ -1653,7 +1653,7 @@ Source file and line
    file is ``a``, the 26th is ``z``, the 27th is ``aa``, and so on.
 
 User pointers
-   Shows the value of the node's user1p...user5p, if non-NULL.
+   Shows the value of the node's user1p...user4p, if non-NULL.
 
 Data type
    Many nodes have an explicit data type. "@dt=0x..." indicates the

--- a/src/V3Ast.cpp
+++ b/src/V3Ast.cpp
@@ -41,13 +41,11 @@ uint32_t VNUser1InUse::s_userCntGbl = 0;  // Hot cache line, leave adjacent
 uint32_t VNUser2InUse::s_userCntGbl = 0;  // Hot cache line, leave adjacent
 uint32_t VNUser3InUse::s_userCntGbl = 0;  // Hot cache line, leave adjacent
 uint32_t VNUser4InUse::s_userCntGbl = 0;  // Hot cache line, leave adjacent
-uint32_t VNUser5InUse::s_userCntGbl = 0;  // Hot cache line, leave adjacent
 
 bool VNUser1InUse::s_userBusy = false;
 bool VNUser2InUse::s_userBusy = false;
 bool VNUser3InUse::s_userBusy = false;
 bool VNUser4InUse::s_userBusy = false;
-bool VNUser5InUse::s_userBusy = false;
 
 int AstNodeDType::s_uniqueNum = 0;
 
@@ -1235,7 +1233,6 @@ void AstNode::dumpPtrs(std::ostream& os) const {
     if (user2p()) os << " user2p=" << cvtToHex(user2p());
     if (user3p()) os << " user3p=" << cvtToHex(user3p());
     if (user4p()) os << " user4p=" << cvtToHex(user4p());
-    if (user5p()) os << " user5p=" << cvtToHex(user5p());
     if (m_iterpp) {
         os << " iterpp=" << cvtToHex(m_iterpp);
         // This may cause address sanitizer failures as iterpp can be stale

--- a/src/V3Ast.h
+++ b/src/V3Ast.h
@@ -2758,16 +2758,10 @@ public:
     template <typename U>
     // cppcheck-suppress noExplicitConstructor
     VNRef(U&& x)
-        : std::reference_wrapper<T_Node> {
-        x
-    }
-    {}
+        : std::reference_wrapper<T_Node>{x} {}
     // cppcheck-suppress noExplicitConstructor
     VNRef(const std::reference_wrapper<T_Node>& other)
-        : std::reference_wrapper<T_Node> {
-        other
-    }
-    {}
+        : std::reference_wrapper<T_Node>{other} {}
 };
 
 static_assert(sizeof(VNRef<AstNode>) == sizeof(std::reference_wrapper<AstNode>),

--- a/src/V3AstNodes.cpp
+++ b/src/V3AstNodes.cpp
@@ -1379,7 +1379,6 @@ void AstNode::dump(std::ostream& str) const {
     if (user2p()) str << " u2=" << nodeAddr(user2p());
     if (user3p()) str << " u3=" << nodeAddr(user3p());
     if (user4p()) str << " u4=" << nodeAddr(user4p());
-    if (user5p()) str << " u5=" << nodeAddr(user5p());
     if (hasDType()) {
         // Final @ so less likely to by accident read it as a nodep
         if (dtypep() == this) {

--- a/src/V3AstUserAllocator.h
+++ b/src/V3AstUserAllocator.h
@@ -29,7 +29,7 @@
 
 template <class T_Node, class T_Data, int T_UserN>
 class AstUserAllocatorBase VL_NOT_FINAL {
-    static_assert(1 <= T_UserN && T_UserN <= 5, "Wrong user pointer number");
+    static_assert(1 <= T_UserN && T_UserN <= 4, "Wrong user pointer number");
     static_assert(std::is_base_of<AstNode, T_Node>::value, "T_Node must be an AstNode type");
 
 private:
@@ -45,11 +45,8 @@ private:
         } else if VL_CONSTEXPR_CXX17 (T_UserN == 3) {
             const VNUser user = nodep->user3u();
             return user.to<T_Data*>();
-        } else if VL_CONSTEXPR_CXX17 (T_UserN == 4) {
-            const VNUser user = nodep->user4u();
-            return user.to<T_Data*>();
         } else {
-            const VNUser user = nodep->user5u();
+            const VNUser user = nodep->user4u();
             return user.to<T_Data*>();
         }
     }
@@ -61,10 +58,8 @@ private:
             nodep->user2u(VNUser{userp});
         } else if VL_CONSTEXPR_CXX17 (T_UserN == 3) {
             nodep->user3u(VNUser{userp});
-        } else if VL_CONSTEXPR_CXX17 (T_UserN == 4) {
-            nodep->user4u(VNUser{userp});
         } else {
-            nodep->user5u(VNUser{userp});
+            nodep->user4u(VNUser{userp});
         }
     }
 
@@ -76,10 +71,8 @@ protected:
             VNUser2InUse::check();
         } else if VL_CONSTEXPR_CXX17 (T_UserN == 3) {
             VNUser3InUse::check();
-        } else if VL_CONSTEXPR_CXX17 (T_UserN == 4) {
-            VNUser4InUse::check();
         } else {
-            VNUser5InUse::check();
+            VNUser4InUse::check();
         }
     }
 
@@ -107,6 +100,8 @@ public:
 
     // Get a pointer to the user data if exists, otherwise nullptr
     T_Data* tryGet(const T_Node* nodep) { return getUserp(nodep); }
+
+    void clear() { m_allocated.clear(); }
 };
 
 // User pointer allocator classes. T_Node is the type of node the allocator should be applied to
@@ -120,7 +115,5 @@ template <class T_Node, class T_Data>
 class AstUser3Allocator final : public AstUserAllocatorBase<T_Node, T_Data, 3> {};
 template <class T_Node, class T_Data>
 class AstUser4Allocator final : public AstUserAllocatorBase<T_Node, T_Data, 4> {};
-template <class T_Node, class T_Data>
-class AstUser5Allocator final : public AstUserAllocatorBase<T_Node, T_Data, 5> {};
 
 #endif  // Guard

--- a/src/V3Gate.cpp
+++ b/src/V3Gate.cpp
@@ -766,15 +766,22 @@ class GateDedupeHash final : public V3DupFinderUserSame {
 private:
     // NODE STATE
     // Ast*::user2p     -> parent AstNodeAssign* for this rhsp
-    // Ast*::user3p     -> AstActive* of assign, for isSame() in test for duplicate
-    //                     Set to nullptr if this assign's tree was later replaced
-    // Ast*::user5p     -> AstNode* of assign if condition, for isSame() in test for duplicate
-    //                     Set to nullptr if this assign's tree was later replaced
+    // AstNodeExpr::user3p -> see AuxAstNodeExpr via m_aux
     // VNUser1InUse    m_inuser1;      (Allocated for use in GateVisitor)
     // VNUser2InUse    m_inuser2;      (Allocated for use in GateVisitor)
     const VNUser3InUse m_inuser3;
     // VNUser4InUse    m_inuser4;      (Allocated for use in V3Hasher via V3DupFinder)
-    const VNUser5InUse m_inuser5;
+
+    struct AuxAstNodeExpr final {
+        // AstActive* of assign, for isSame() in test for duplicate. Set to nullptr if this
+        // assign's tree was later replaced
+        AstActive* activep = nullptr;
+        // AstNodeExpr* of assign if condition, for isSame() in test for duplicate. Set to nullptr
+        // if this assign's tree was later replaced
+        AstNodeExpr* condp = nullptr;
+    };
+
+    AstUser3Allocator<AstNodeExpr, AuxAstNodeExpr> m_auxNodeExpr;
 
     V3DupFinder m_dupFinder;  // Duplicate finder for rhs of assigns
     std::unordered_set<AstNode*> m_nodeDeleteds;  // Any node in this hash was deleted
@@ -814,41 +821,49 @@ public:
     // or could be a rhs variable in a tree we're not replacing (or not yet anyways)
     void hashReplace(AstNode* oldp, AstNode* newp) {
         UINFO(9, "replacing " << (void*)oldp << " with " << (void*)newp << endl);
-        // We could update the user3p and user5p but the resulting node
+        // We could update the activep and condp but the resulting node
         // still has incorrect hash.  We really need to remove all hash on
         // the whole hash entry tree involving the replaced node and
         // rehash.  That's complicated and this is rare, so just remove it
         // from consideration.
         m_nodeDeleteds.insert(oldp);
     }
-    bool isReplaced(AstNode* nodep) {
+    bool isReplaced(AstNodeExpr* nodep) {
         // Assignment may have been hashReplaced, if so consider non-match (effectively removed)
-        UASSERT_OBJ(!VN_IS(nodep, NodeAssign), nodep, "Dedup attempt on non-assign");
-        AstNode* const extra1p = nodep->user3p();
-        AstNode* const extra2p = nodep->user5p();
-        return ((extra1p && m_nodeDeleteds.find(extra1p) != m_nodeDeleteds.end())
-                || (extra2p && m_nodeDeleteds.find(extra2p) != m_nodeDeleteds.end()));
+        const auto& aux = m_auxNodeExpr(nodep);
+        AstActive* const activep = aux.activep;
+        AstNodeExpr* const condp = aux.condp;
+        return (activep && m_nodeDeleteds.count(activep))
+               || (condp && m_nodeDeleteds.count(condp));
     }
 
     // Callback from V3DupFinder::findDuplicate
     bool isSame(AstNode* node1p, AstNode* node2p) override {
+        AstNodeExpr* const expr1p = VN_AS(node1p, NodeExpr);
+        AstNodeExpr* const expr2p = VN_AS(node2p, NodeExpr);
+
         // Assignment may have been hashReplaced, if so consider non-match (effectively removed)
-        if (isReplaced(node1p) || isReplaced(node2p)) {
+        if (isReplaced(expr1p) || isReplaced(expr2p)) {
             // UINFO(9, "isSame hit on replaced "<<(void*)node1p<<" "<<(void*)node2p<<endl);
             return false;
         }
-        return same(node1p->user3p(), node2p->user3p()) && same(node1p->user5p(), node2p->user5p())
+
+        const auto& aux1 = m_auxNodeExpr(expr1p);
+        const auto& aux2 = m_auxNodeExpr(expr2p);
+
+        return same(aux1.activep, aux2.activep) && same(aux1.condp, aux2.condp)
                && node1p->user2p()->type() == node2p->user2p()->type();
     }
 
-    const AstNodeAssign* hashAndFindDupe(AstNodeAssign* assignp, AstNode* extra1p,
-                                         AstNode* extra2p) {
+    const AstNodeAssign* hashAndFindDupe(AstNodeAssign* assignp, AstActive* extra1p,
+                                         AstNodeExpr* extra2p) {
         // Legal for extra1p/2p to be nullptr, we'll compare with other assigns with extras also
         // nullptr
-        AstNode* const rhsp = assignp->rhsp();
+        AstNodeExpr* const rhsp = assignp->rhsp();
         rhsp->user2p(assignp);
-        rhsp->user3p(extra1p);
-        rhsp->user5p(extra2p);
+        auto& aux = m_auxNodeExpr(rhsp);
+        aux.activep = extra1p;
+        aux.condp = extra2p;
 
         const auto inserted = m_dupFinder.insert(rhsp);
         const auto dupit = m_dupFinder.findDuplicate(rhsp, this);
@@ -865,13 +880,14 @@ public:
 
     void check() {
         for (const auto& itr : m_dupFinder) {
-            AstNode* const nodep = itr.second;
-            const AstNode* const activep = nodep->user3p();
-            const AstNode* const condVarp = nodep->user5p();
+            AstNodeExpr* const nodep = VN_AS(itr.second, NodeExpr);
+            const auto& aux = m_auxNodeExpr(nodep);
+            const AstActive* const activep = aux.activep;
+            const AstNodeExpr* const condVarp = aux.condp;
             if (!isReplaced(nodep)) {
                 // This class won't break if activep isn't an active, or
                 // ifVar isn't a var, but this is checking the caller's construction.
-                UASSERT_OBJ(!activep || (!VN_DELETED(activep) && VN_IS(activep, Active)), nodep,
+                UASSERT_OBJ(!activep || (!VN_DELETED(activep)), nodep,
                             "V3DupFinder check failed, lost active pointer");
                 UASSERT_OBJ(!condVarp || !VN_DELETED(condVarp), nodep,
                             "V3DupFinder check failed, lost if pointer");
@@ -899,7 +915,7 @@ private:
     // STATE
     GateDedupeHash m_ghash;  // Hash used to find dupes of rhs of assign
     AstNodeAssign* m_assignp = nullptr;  // Assign found for dedupe
-    AstNode* m_ifCondp = nullptr;  // IF condition that assign is under
+    AstNodeExpr* m_ifCondp = nullptr;  // IF condition that assign is under
     bool m_always = false;  // Assign is under an always
     bool m_dedupable = true;  // Determined the assign to be dedupable
 

--- a/src/V3Inline.cpp
+++ b/src/V3Inline.cpp
@@ -343,8 +343,8 @@ private:
                     newdp->cellName(newcellp->name());
                     // Tag the old ifacerefp to ensure it leaves no stale
                     // reference to the inlined cell.
-                    newdp->user5(false);
-                    ifacerefp->user5(true);
+                    newdp->user1(false);
+                    ifacerefp->user1(true);
                 }
             }
         }
@@ -454,8 +454,8 @@ class InlineVisitor final : public VNVisitor {
 private:
     // NODE STATE
     // Cleared entire netlist
-    //  AstIfaceRefDType::user5p()  // Whether the cell pointed to by this
-    //                              // AstIfaceRefDType has been inlined
+    //  AstIfaceRefDType::user1()  // Whether the cell pointed to by this
+    //                             // AstIfaceRefDType has been inlined
     //  Input:
     //   AstNodeModule::user1p()    // ModuleState instance (via m_moduleState)
     // Cleared each cell
@@ -464,7 +464,6 @@ private:
     //   AstVar::user3()        // bool    Don't alias the user2, keep it as signal
     //   AstCell::user4         // AstCell* of the created clone
     const VNUser4InUse m_inuser4;
-    const VNUser5InUse m_inuser5;
 
     ModuleStateUser1Allocator& m_moduleState;
 
@@ -586,7 +585,7 @@ private:
         m_modp = nullptr;
     }
     void visit(AstIfaceRefDType* nodep) override {
-        if (nodep->user5()) {
+        if (nodep->user1()) {
             // The cell has been removed so let's make sure we don't leave a reference to it
             // This dtype may still be in use by the AstAssignVarScope created earlier
             // but that'll get cleared up later

--- a/src/V3InstrCount.h
+++ b/src/V3InstrCount.h
@@ -36,7 +36,7 @@ public:
     // If nodep is an AstActive, returns 0.
     // If nodep contains nested AstActives, raises an error.
     //
-    // If assertNoDups is true, marks user5 on each AstNode scanned.  Then
+    // If assertNoDups is true, marks user1 on each AstNode scanned.  Then
     // if we see the same node twice (across more than one call to count,
     // potentially) raises an error.
     // Optional osp is stream to dump critical path to.

--- a/src/V3LinkDot.cpp
+++ b/src/V3LinkDot.cpp
@@ -2004,10 +2004,7 @@ private:
     //  *::user2p()             -> See LinkDotState
     //  *::user3()              // bool. Processed
     //  *::user4()              -> See LinkDotState
-    // Cleared on Cell
-    //  AstVar::user5()         // bool. True if pin used in this cell
     const VNUser3InUse m_inuser3;
-    const VNUser5InUse m_inuser5;
 
     // TYPES
     enum DotPosition : uint8_t {
@@ -2034,6 +2031,7 @@ private:
                                          // They are added to the set only in linkDotPrimary.
     bool m_insideClassExtParam = false;  // Inside a class from m_extendsParam
     bool m_explicitSuperNew = false;  // Hit a "super.new" call inside a "new" function
+    std::map<AstNode*, AstPin*> m_usedPins;  // Pin used in this cell, map to duplicate
 
     struct DotStates {
         DotPosition m_dotPos;  // Scope part of dotted resolution
@@ -2162,15 +2160,15 @@ private:
         UASSERT_OBJ(ifaceTopVarp, nodep, "Can't find interface var ref: " << findName);
         return ifaceTopVarp;
     }
-    void markAndCheckPinDup(AstNode* nodep, AstNode* refp, const char* whatp) {
-        if (refp->user5p() && refp->user5p() != nodep) {
+    void markAndCheckPinDup(AstPin* nodep, AstNode* refp, const char* whatp) {
+        const auto pair = m_usedPins.emplace(refp, nodep);
+        if (!pair.second) {
+            AstNode* const origp = pair.first->second;
             nodep->v3error("Duplicate " << whatp << " connection: " << nodep->prettyNameQ() << '\n'
                                         << nodep->warnContextPrimary() << '\n'
-                                        << refp->user5p()->warnOther()
-                                        << "... Location of original " << whatp << " connection\n"
-                                        << refp->user5p()->warnContextSecondary());
-        } else {
-            refp->user5p(nodep);
+                                        << origp->warnOther() << "... Location of original "
+                                        << whatp << " connection\n"
+                                        << origp->warnContextSecondary());
         }
     }
     VSymEnt* getCreateClockingEventSymEnt(AstClocking* clockingp) {
@@ -2314,7 +2312,7 @@ private:
     void visit(AstCell* nodep) override {
         // Cell: Recurse inside or cleanup not founds
         checkNoDot(nodep);
-        AstNode::user5ClearTree();
+        m_usedPins.clear();
         UASSERT_OBJ(nodep->modp(), nodep,
                     "Cell has unlinked module");  // V3LinkCell should have errored out
         VL_RESTORER(m_cellp);
@@ -2343,7 +2341,7 @@ private:
     void visit(AstClassRefDType* nodep) override {
         // Cell: Recurse inside or cleanup not founds
         checkNoDot(nodep);
-        AstNode::user5ClearTree();
+        m_usedPins.clear();
         UASSERT_OBJ(nodep->classp(), nodep, "ClassRef has unlinked class");
         UASSERT_OBJ(m_statep->forPrimary() || !nodep->paramsp(), nodep,
                     "class reference parameter not removed by V3Param");
@@ -2905,7 +2903,7 @@ private:
     void visit(AstClassOrPackageRef* nodep) override {
         // Class: Recurse inside or cleanup not founds
         // checkNoDot not appropriate, can be under a dot
-        AstNode::user5ClearTree();
+        m_usedPins.clear();
         UASSERT_OBJ(m_statep->forPrimary() || VN_IS(nodep->classOrPackageNodep(), ParamTypeDType)
                         || nodep->classOrPackagep(),
                     nodep, "ClassRef has unlinked class");

--- a/src/V3Partition.cpp
+++ b/src/V3Partition.cpp
@@ -2662,9 +2662,9 @@ uint32_t V3Partition::setupMTaskDeps(V3Graph* mtasksp) {
     // coarsening algorithm assumes that the graph is connected.
     m_entryMTaskp = new LogicMTask{mtasksp, nullptr};
 
-    // The V3InstrCount within LogicMTask will set user5 on each AST
+    // The V3InstrCount within LogicMTask will set user1 on each AST
     // node, to assert that we never count any node twice.
-    const VNUser5InUse user5inUse;
+    const VNUser1InUse user1inUse;
 
     // Create the LogicMTasks for each MTaskMoveVertex
     for (V3GraphVertex *vtxp = m_fineDepsGraphp->verticesBeginp(), *nextp; vtxp; vtxp = nextp) {

--- a/src/V3Simulate.h
+++ b/src/V3Simulate.h
@@ -36,6 +36,7 @@
 #include "verilatedos.h"
 
 #include "V3Ast.h"
+#include "V3AstUserAllocator.h"
 #include "V3Error.h"
 #include "V3Task.h"
 #include "V3Width.h"
@@ -76,18 +77,24 @@ private:
     // NODE STATE
     // Cleared on each always/assignw
     const VNUser1InUse m_inuser1;
-    const VNUser2InUse m_inuser2;
-    const VNUser3InUse m_inuser3;
 
-    // Checking:
-    //  AstVar(Scope)::user1()  -> VarUsage.  Set true to indicate tracking as lvalue/rvalue
-    // Simulating:
-    //  AstConst::user2()       -> bool. This AstConst (allocated by this class) is in use
-    //  AstVar(Scope)::user3()  -> AstConst*. Input value of variable or node
-    //    (and output for non-delayed assignments)
-    //  AstVar(Scope)::user2()  -> AstCont*. Output value of variable (delayed assignments)
+    // AstVar/AstVarScope::user1p()     -> See AuxAstVar via m_varAux
+    // AstConst::user1()    -> bool. This AstConst (allocated by this class) is in use
 
     enum VarUsage : uint8_t { VU_NONE = 0, VU_LV = 1, VU_RV = 2, VU_LVDLY = 4 };
+
+    struct AuxVariable final {
+        // Checking:
+        //  Set true to indicate tracking as lvalue/rvalue
+        uint8_t usage = VU_NONE;
+        // Simulating:
+        //  Output value of variable (delayed assignments)
+        AstNodeExpr* outValuep = nullptr;
+        //  Input value of variable or node (and output for non-delayed assignments)
+        AstNodeExpr* valuep = nullptr;
+    };
+
+    AstUser1Allocator<AstNode, AuxVariable> m_varAux;
 
     // STATE
     // Major mode
@@ -223,14 +230,14 @@ private:
         bool allocNewConst = true;
         if (!freeList.empty()) {
             constp = freeList.front();
-            if (!constp->user2()) {
+            if (!constp->user1()) {
                 // Front of free list is free, reuse it (otherwise allocate new node)
                 allocNewConst = false;  // No need to allocate
                 // Mark the AstConst node as used, and move it to the back of the free list. This
                 // ensures that when all AstConst instances within the list are used, then the
                 // front of the list will be marked as used, in which case the enclosing 'if' will
                 // fail and we fall back to allocation.
-                constp->user2(1);
+                constp->user1(1);
                 freeList.pop_front();
                 freeList.push_back(constp);
                 // configure const
@@ -241,7 +248,7 @@ private:
             // Need to allocate new constant
             constp = new AstConst{nodep->fileline(), AstConst::DTyped{}, nodep->dtypep()};
             // Mark as in use, add to free list for later reuse
-            constp->user2(1);
+            constp->user1(1);
             freeList.push_back(constp);
         }
         return constp;
@@ -273,7 +280,7 @@ private:
     }
     AstConst* newConst(AstNode* nodep) {
         // Set a constant value for this node
-        if (!VN_IS(nodep->user3p(), Const)) {
+        if (!VN_IS(m_varAux(nodep).valuep, Const)) {
             AstConst* const constp = allocConst(nodep);
             setValue(nodep, constp);
             return constp;
@@ -283,7 +290,7 @@ private:
     }
     AstConst* newOutConst(AstNode* nodep) {
         // Set a var-output constant value for this node
-        if (!VN_IS(nodep->user2p(), Const)) {
+        if (!VN_IS(m_varAux(nodep).outValuep, Const)) {
             AstConst* const constp = allocConst(nodep);
             setOutValue(nodep, constp);
             return constp;
@@ -293,10 +300,10 @@ private:
     }
 
 public:
-    AstNodeExpr* fetchValueNull(AstNode* nodep) { return VN_AS(nodep->user3p(), NodeExpr); }
+    AstNodeExpr* fetchValueNull(AstNode* nodep) { return m_varAux(nodep).valuep; }
 
 private:
-    AstNodeExpr* fetchOutValueNull(AstNode* nodep) { return VN_AS(nodep->user2p(), NodeExpr); }
+    AstNodeExpr* fetchOutValueNull(AstNode* nodep) { return m_varAux(nodep).outValuep; }
     AstConst* fetchConstNull(AstNode* nodep) { return VN_CAST(fetchValueNull(nodep), Const); }
     AstConst* fetchOutConstNull(AstNode* nodep) {
         return VN_CAST(fetchOutValueNull(nodep), Const);
@@ -332,15 +339,15 @@ public:
     }
 
 private:
-    void setValue(AstNode* nodep, const AstNodeExpr* valuep) {
+    void setValue(AstNode* nodep, AstNodeExpr* valuep) {
         UASSERT_OBJ(valuep, nodep, "Simulate setting null value");
         UINFO(9, "     set val " << valuep->name() << " on " << nodep << endl);
-        nodep->user3p((void*)valuep);
+        m_varAux(nodep).valuep = valuep;
     }
-    void setOutValue(AstNode* nodep, const AstNodeExpr* valuep) {
+    void setOutValue(AstNode* nodep, AstNodeExpr* valuep) {
         UASSERT_OBJ(valuep, nodep, "Simulate setting null value");
         UINFO(9, "     set oval " << valuep->name() << " on " << nodep << endl);
-        nodep->user2p((void*)valuep);
+        m_varAux(nodep).outValuep = valuep;
     }
 
     void checkNodeInfo(AstNode* nodep, bool ignorePredict = false) {
@@ -429,26 +436,26 @@ private:
             clearOptimizable(nodep, "Array references/not basic");
         if (nodep->access().isWriteOrRW()) {
             if (m_inDlyAssign) {
-                if (!(vscp->user1() & VU_LVDLY)) {
-                    vscp->user1(vscp->user1() | VU_LVDLY);
+                if (!(m_varAux(vscp).usage & VU_LVDLY)) {
+                    m_varAux(vscp).usage |= VU_LVDLY;
                     if (m_checkOnly) varRefCb(nodep);
                 }
             } else {  // nondly asn
-                if (!(vscp->user1() & VU_LV)) {
-                    if (!m_params && (vscp->user1() & VU_RV)) {
+                if (!(m_varAux(vscp).usage & VU_LV)) {
+                    if (!m_params && (m_varAux(vscp).usage & VU_RV)) {
                         clearOptimizable(nodep, "Var read & write");
                     }
-                    vscp->user1(vscp->user1() | VU_LV);
+                    m_varAux(vscp).usage |= VarUsage::VU_LV;
                     if (m_checkOnly) varRefCb(nodep);
                 }
             }
         }
         if (nodep->access().isReadOrRW()) {
-            if (!(vscp->user1() & VU_RV)) {
-                if (!m_params && (vscp->user1() & VU_LV)) {
+            if (!(m_varAux(vscp).usage & VU_RV)) {
+                if (!m_params && (m_varAux(vscp).usage & VU_LV)) {
                     clearOptimizable(nodep, "Var write & read");
                 }
-                vscp->user1(vscp->user1() | VU_RV);
+                m_varAux(vscp).usage |= VU_RV;
                 const bool isConst = (nodep->varp()->isConst() || nodep->varp()->isParam())
                                      && nodep->varp()->valuep();
                 AstNodeExpr* const valuep
@@ -717,7 +724,7 @@ private:
             AstNodeExpr* const valuep = newTrackedClone(fetchValue(nodep->rhsp()));
             UINFO(9, "     set val[" << index << "] = " << valuep << endl);
             // Values are in the "real" tree under the InitArray so can eventually extract it,
-            // Not in the usual setValue (pointed to by user2/3p)
+            // Not in the usual setValue (via m_varAux)
             initp->addIndexValuep(index, valuep);
             if (debug() >= 9) initp->dumpTree("-  array: ");
             assignOutValue(nodep, vscp, initp);
@@ -1224,8 +1231,7 @@ public:
         m_jumpp = nullptr;
 
         AstNode::user1ClearTree();
-        AstNode::user2ClearTree();  // Also marks all elements in m_constps as free
-        AstNode::user3ClearTree();
+        m_varAux.clear();
     }
     void mainTableCheck(AstNode* nodep) {
         setMode(true /*scoped*/, true /*checking*/, false /*params*/);

--- a/src/V3Timing.cpp
+++ b/src/V3Timing.cpp
@@ -183,7 +183,7 @@ private:
     const VNUser1InUse m_user1InUse;
     const VNUser2InUse m_user2InUse;
     const VNUser3InUse m_user3InUse;
-    const VNUser5InUse m_user5InUse;
+    const VNUser4InUse m_user4InUse;
 
     // STATE
     VMemberMap m_memberMap;  // Member names cached for fast lookup
@@ -214,8 +214,8 @@ private:
                 classp = VN_CAST(funcp->scopep()->modp(), Class);
             }
         }
-        if (!nodep->user5p()) nodep->user5p(new NeedsProcDepVtx{&m_procGraph, nodep, classp});
-        return nodep->user5u().to<NeedsProcDepVtx*>();
+        if (!nodep->user4p()) nodep->user4p(new NeedsProcDepVtx{&m_procGraph, nodep, classp});
+        return nodep->user4u().to<NeedsProcDepVtx*>();
     }
     // Pass timing flag between nodes
     bool passFlag(const AstNode* from, AstNode* to, NodeFlag flag) {


### PR DESCRIPTION
This saves about 5% memory. V3AstUserAllocator is appropriate for most use cases, performance is marginally up as we are mostly D-cache bound on large designs.