### PR TITLE
Add Verilog Playground to README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -73,6 +73,18 @@ to migrate SystemVerilog to C++/SystemC, or want high-speed simulation of
 designs, Verilator is the tool for you.
 
 
+Verilog Playground
+==================
+
+Verilog Playground is a Verilog / SystemVerilog online simulator that has
+Verilator on its core. It converts the code to C++ using Verilator, and
+then converts the C++ code to JavaScript using Emscripten.
+
+Website: https://verilog-playground.github.io
+
+.. image:: https://github.com/verilog-playground/art/raw/ea775d95664f92fbba2eddffff865a58d73a8608/animation.gif
+    :target: https://verilog-playground.github.io
+
 Performance
 ===========
 

--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -59,6 +59,7 @@ Huang Rui
 Huanghuang Zhou
 HungMingWu
 HyungKi Jeong
+Ícaro Lima
 Ilya Barkov
 Iru Cai
 Ivan Vnučec


### PR DESCRIPTION
Hello Verilator developers!

I created the [Verilog Playground](https://verilog-playground.github.io) using Verilator and I think it is a good idea to add it to the readme since the playground is an easy way for users to check Verilator capabilities without needing to download or setup anything.

Thanks!