### PR TITLE
if-statement/ternary dataflow bug

### DIFF
--- a/test_regress/t/t_if_statement.pl
+++ b/test_regress/t/t_if_statement.pl
@@ -1,0 +1,19 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2019 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile();
+
+execute(
+    check_finished => 1,
+    );
+ok(1);
+1;

--- a/test_regress/t/t_if_statement.v
+++ b/test_regress/t/t_if_statement.v
@@ -1,0 +1,44 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2020 by Wilson Snyder.
+// SPDX-License-Identifier: CC0-1.0
+
+module t
+  (/*AUTOARG*/
+   // Inputs
+   clk
+   );
+
+    input clk;
+    int wordQ [$];
+    logic[99:0] myint;
+    int error_count = 0;
+    initial begin
+        // Ternary Example
+        wordQ.push_back(100);
+        myint = wordQ.size() > 0 ? 100'(wordQ.pop_front()) : 100'(99);
+
+        if (myint != 100) begin
+            error_count += 1;
+            $display("Expected myint=%0d, not %0d", 100, myint);
+        end
+
+        // If statement Example
+        wordQ.push_back(100);
+        if (wordQ.size() > 0) begin
+            myint = 100'(wordQ.pop_front());
+        end else begin
+            myint = 100'(99);
+        end
+
+        if (myint != 100) begin
+            error_count += 1;
+            $display("Expected myint=%0d, not %0d", 100, myint);
+        end
+        if (error_count != 0) begin
+            $error("Encountered %0d errors", error_count);
+        end
+        $finish;
+    end
+endmodule


### PR DESCRIPTION
I've encountered this bug with if-statements/contitional-expressions that are moving data larger than 32 bits.
e.g.:
```
        if (wordQ.size() > 0) begin
            myint = 100'(wordQ.pop_front());
        end else begin
            myint = 100'(99);
        end
```

 The emitted C++ code can come out as this:
```  
    VL_EXTENDS_WI(100,32, __Vtemp_h8963a0fe__1, vlSelf->t__DOT__wordQ.pop_front());
    t__DOT__myint[0U] = (VL_LTS_III(32, 0U, vlSelf->t__DOT__wordQ.size())
                          ? __Vtemp_h8963a0fe__1[0U]
                          : 0x63U);
    t__DOT__myint[1U] = (VL_LTS_III(32, 0U, vlSelf->t__DOT__wordQ.size())
                          ? __Vtemp_h8963a0fe__1[1U]
                          : 0U);
    t__DOT__myint[2U] = (VL_LTS_III(32, 0U, vlSelf->t__DOT__wordQ.size())
                          ? __Vtemp_h8963a0fe__1[2U]
                          : 0U);
    t__DOT__myint[3U] = (VL_LTS_III(32, 0U, vlSelf->t__DOT__wordQ.size())
                          ? (0xfU & __Vtemp_h8963a0fe__1[3U])
                          : 0U);
```
OR
```
VL_COND_WIWW(100, __Vtemp_11, VL_LTS_III(32, 0U, vlSelf->wordQ.size()), vlSelf->wordQ.pop_front(), __Vtemp_9);
```

Both of which use the value of `pop_front` without accounting for side effects.

Source code/test is included in the pull request, but I'm not familiar with with the C++ emission part of verilator. Which files/modules should I look at to try and fix this?