### PR TITLE
Fix signals read via virtual iface optimized out

### DIFF
--- a/src/V3Gate.cpp
+++ b/src/V3Gate.cpp
@@ -372,6 +372,11 @@ private:
             UINFO(6, "New vertex " << varscp << endl);
             vertexp = new GateVarVertex{&m_graph, m_scopep, varscp};
             varscp->user1p(vertexp);
+            if (varscp->varp()->isUsedVirtIface()) {
+                // Can be used in a class method, which cannot be tracked statically
+                vertexp->clearReducibleAndDedupable("VirtIface");
+                vertexp->setConsumed("VirtIface");
+            }
             if (varscp->varp()->isSigPublic()) {
                 // Public signals shouldn't be changed, pli code might be messing with them
                 vertexp->clearReducibleAndDedupable("SigPublic");

--- a/test_regress/t/t_interface_virtual_opt.pl
+++ b/test_regress/t/t_interface_virtual_opt.pl
@@ -1,0 +1,21 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2003 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_interface_virtual_opt.v
+++ b/test_regress/t/t_interface_virtual_opt.v
@@ -1,0 +1,42 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2023 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+interface Bus;
+   logic [7:0] data;
+endinterface
+
+class Cls;
+   virtual Bus vbus;
+
+   function void check(logic [7:0] data);
+       if (vbus.data != data) $stop;
+   endfunction
+endclass
+
+module t (clk);
+   input clk;
+   int cyc = 0;
+
+   Bus bus();
+   virtual Bus vbus;
+   Cls obj;
+
+   assign bus.data = 'hFA;
+
+   always @(posedge clk) begin
+      cyc <= cyc + 1;
+      if (cyc == 1) begin
+         obj = new;
+         vbus = bus;
+         obj.vbus = bus;
+      end
+      else if (cyc == 2) begin
+         obj.check('hFA);
+         $write("*-* All Finished *-*\n");
+         $finish;
+      end
+   end
+endmodule


### PR DESCRIPTION
Currently, `V3Gate` optimizes out assignments to an interface if it's only read via a virtual interface.