### PR TITLE
A type safe, generic interface for AstNode 'user' data

### DIFF
--- a/src/V3Ast.h
+++ b/src/V3Ast.h
@@ -1569,6 +1569,7 @@ protected:
 // clang-format off
 class VNUser1InUse final : VNUserInUseBase {
 protected:
+    friend class VNUser1Accessor;
     friend class AstNode;
     static uint32_t s_userCntGbl;  // Count of which usage of userp() this is
     static bool s_userBusy;  // Count is in use
@@ -1580,6 +1581,7 @@ public:
 };
 class VNUser2InUse final : VNUserInUseBase {
 protected:
+    friend class VNUser2Accessor;
     friend class AstNode;
     static uint32_t s_userCntGbl;  // Count of which usage of userp() this is
     static bool s_userBusy;  // Count is in use
@@ -1591,6 +1593,7 @@ public:
 };
 class VNUser3InUse final : VNUserInUseBase {
 protected:
+    friend class VNUser3Accessor;
     friend class AstNode;
     static uint32_t s_userCntGbl;  // Count of which usage of userp() this is
     static bool s_userBusy;  // Count is in use
@@ -1602,6 +1605,7 @@ public:
 };
 class VNUser4InUse final : VNUserInUseBase {
 protected:
+    friend class VNUser4Accessor;
     friend class AstNode;
     static uint32_t s_userCntGbl;  // Count of which usage of userp() this is
     static bool s_userBusy;  // Count is in use
@@ -1804,6 +1808,11 @@ class AstNode VL_NOT_FINAL {
 
     AstNode* m_clonep = nullptr;  // Pointer to clone/source of node (only for *LAST* cloneTree())
     static int s_cloneCntGbl;  // Count of which userp is set
+
+    friend class VNUser1Accessor;
+    friend class VNUser2Accessor;
+    friend class VNUser3Accessor;
+    friend class VNUser4Accessor;
 
     // This member ordering both allows 64 bit alignment and puts associated data together
     VNUser m_user1u{0};  // Contains any information the user iteration routine wants

--- a/src/V3VNUserHandle.h
+++ b/src/V3VNUserHandle.h
@@ -1,0 +1,204 @@
+// -*- mode: C++; c-file-style: "cc-mode" -*-
+//*************************************************************************
+// DESCRIPTION: Verilator: Utility to hang advanced data structures of
+// AstNode::user*p() pointers with automatic memory management.
+//
+// Code available from: https://verilator.org
+//
+//*************************************************************************
+//
+// Copyright 2003-2023 by Wilson Snyder. This program is free software; you
+// can redistribute it and/or modify it under the terms of either the GNU
+// Lesser General Public License Version 3 or the Perl Artistic License
+// Version 2.0.
+// SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+//
+//*************************************************************************
+
+#ifndef VERILATOR_V3VNUSERHANDLE_H_
+#define VERILATOR_V3VNUSERHANDLE_H_
+
+#include "config_build.h"
+#include "verilatedos.h"
+
+#include "V3Ast.h"
+
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+//============================================================================
+// VNAux is juts a type pair, to be passed to VNUser*Handle as type parameter
+//============================================================================
+
+template <typename T_Node, typename T_Data>
+struct VNAux final {
+    static_assert(std::is_base_of<AstNode, T_Node>::value, "T_Node must be an AstNode type");
+    using Node = T_Node;
+    using Data = T_Data;
+};
+
+//============================================================================
+// Simple accessors for the 4 user fields
+//============================================================================
+
+class VNUser1Accessor final {
+public:
+    static VNUser& user(AstNode* nodep) { return nodep->m_user1u; }
+    static VNUser user(const AstNode* nodep) { return nodep->m_user1u; }
+    static uint32_t& nodeGeneration(AstNode* nodep) { return nodep->m_user1Cnt; }
+    static uint32_t nodeGeneration(const AstNode* nodep) { return nodep->m_user1Cnt; }
+    static uint32_t currentGeneration() { return VNUser1InUse::s_userCntGbl; }
+};
+
+class VNUser2Accessor final {
+public:
+    static VNUser& user(AstNode* nodep) { return nodep->m_user2u; }
+    static VNUser user(const AstNode* nodep) { return nodep->m_user2u; }
+    static uint32_t& nodeGeneration(AstNode* nodep) { return nodep->m_user2Cnt; }
+    static uint32_t nodeGeneration(const AstNode* nodep) { return nodep->m_user2Cnt; }
+    static uint32_t currentGeneration() { return VNUser2InUse::s_userCntGbl; }
+};
+
+class VNUser3Accessor final {
+public:
+    static VNUser& user(AstNode* nodep) { return nodep->m_user3u; }
+    static VNUser user(const AstNode* nodep) { return nodep->m_user3u; }
+    static uint32_t& nodeGeneration(AstNode* nodep) { return nodep->m_user3Cnt; }
+    static uint32_t nodeGeneration(const AstNode* nodep) { return nodep->m_user3Cnt; }
+    static uint32_t currentGeneration() { return VNUser3InUse::s_userCntGbl; }
+};
+
+class VNUser4Accessor final {
+public:
+    static VNUser& user(AstNode* nodep) { return nodep->m_user4u; }
+    static VNUser user(const AstNode* nodep) { return nodep->m_user4u; }
+    static uint32_t& nodeGeneration(AstNode* nodep) { return nodep->m_user4Cnt; }
+    static uint32_t nodeGeneration(const AstNode* nodep) { return nodep->m_user4Cnt; }
+    static uint32_t currentGeneration() { return VNUser4InUse::s_userCntGbl; }
+};
+
+//============================================================================
+// Implementation of access to the user data for one node type (Aux::Node)
+//============================================================================
+
+// There are 2 implementation flavours: Data held directly vs indirectly
+template <typename Accessor, typename Aux, bool Indirect>
+class VNUserHandleImpl;
+
+// Implementation for Data held directly
+template <typename Accessor, typename Aux>
+class VNUserHandleImpl<Accessor, Aux, /* Indirect: */ false> VL_NOT_FINAL {
+    using Node = typename Aux::Node;
+    using Data = typename Aux::Data;
+    static_assert(sizeof(Data) <= sizeof(VNUser), "'Data' does not fit directly");
+
+protected:
+    VNUserHandleImpl() = default;
+    ~VNUserHandleImpl() = default;
+    VL_UNCOPYABLE(VNUserHandleImpl);
+
+public:
+    // Get a reference to the user data. If not current, construct it with given arguments.
+    template <typename... Args>
+    Data& operator()(Node* nodep, Args&&... args) {
+        Data* const storagep = reinterpret_cast<Data*>(&Accessor::user(nodep));
+        if (Accessor::nodeGeneration(nodep) != Accessor::currentGeneration()) {
+            Accessor::nodeGeneration(nodep) = Accessor::currentGeneration();
+            new (storagep) Data{std::forward<Args>(args)...};
+        }
+        return *storagep;
+    }
+
+    // Get a reference to the user data. The node is const, so it must be current.
+    Data& operator()(const Node* nodep) {
+        UASSERT_OBJ(Accessor::nodeGeneration(nodep) == Accessor::currentGeneration(), nodep,
+                    "User data is stale on const AstNode");
+        return *Accessor::user(nodep).template to<Data*>();
+    }
+};
+
+// Implementation for Data held indirectly
+template <typename Accessor, typename Aux>
+class VNUserHandleImpl<Accessor, Aux, /* Indirect: */ true> VL_NOT_FINAL {
+    using Node = typename Aux::Node;
+    using Data = typename Aux::Data;
+    static_assert(sizeof(Data) > sizeof(VNUser), "'Data' should fit directly");
+
+    std::deque<Data> m_allocated;
+
+protected:
+    VNUserHandleImpl() = default;
+    ~VNUserHandleImpl() = default;
+    VL_UNCOPYABLE(VNUserHandleImpl);
+
+public:
+    // Get a reference to the user data. If not current, construct it with given arguments.
+    template <typename... Args>
+    Data& operator()(Node* nodep, Args&&... args) {
+        if (Accessor::nodeGeneration(nodep) != Accessor::currentGeneration()) {
+            Accessor::nodeGeneration(nodep) = Accessor::currentGeneration();
+            m_allocated.emplace_back(std::forward<Args>(args)...);
+            Accessor::user(nodep) = VNUser{&m_allocated.back()};
+        }
+        return *Accessor::user(nodep).template to<Data*>();
+    }
+
+    // Get a reference to the user data. The node is const, so it must be current.
+    Data& operator()(const Node* nodep) {
+        UASSERT_OBJ(Accessor::nodeGeneration(nodep) == Accessor::currentGeneration(), nodep,
+                    "User data is stale on const AstNode");
+        return *Accessor::user(nodep).template to<Data*>();
+    }
+};
+
+//============================================================================
+// This is a variadic 'unroller' template that eventually derives from
+// VNUserHandleImpl for each VNAux parameter passed to it
+//============================================================================
+
+// Generic template
+template <typename Accessor, typename AuxFirst, typename... AuxRest>
+class VNUserHandleTemplate;
+
+// Specialization for two or more Aux arguments
+template <typename Accessor, typename Aux1, typename Aux2, typename... AuxRest>
+class VNUserHandleTemplate<Accessor, Aux1, Aux2, AuxRest...> VL_NOT_FINAL
+    : public VNUserHandleTemplate<Accessor, Aux1>,  // Single argument version
+      public VNUserHandleTemplate<Accessor, Aux2, AuxRest...>  // Generic version
+{
+public:
+    using VNUserHandleTemplate<Accessor, Aux1>::operator();
+    using VNUserHandleTemplate<Accessor, Aux2, AuxRest...>::operator();
+};
+
+// Specialization for one Aux argument - just derives from the implementation
+template <typename Accessor, typename Aux>
+class VNUserHandleTemplate<Accessor, Aux> VL_NOT_FINAL
+    : public VNUserHandleImpl<Accessor, Aux, (sizeof(typename Aux::Data) > sizeof(VNUser))> {
+    static_assert(std::is_same<Aux, VNAux<typename Aux::Node, typename Aux::Data>>::value,
+                  "Don't invent your own 'VNAux'!");
+};
+
+//============================================================================
+// The actual AstNode 'user' data handlers, to be used in client code
+//============================================================================
+
+template <typename... T_VNAuxs>
+class VNUser1Handle final : public VNUserHandleTemplate<VNUser1Accessor, T_VNAuxs...> {
+    const VNUser1InUse m_user1InUse;
+};
+template <typename... T_VNAuxs>
+class VNUser2Handle final : public VNUserHandleTemplate<VNUser2Accessor, T_VNAuxs...> {
+    const VNUser2InUse m_user2InUse;
+};
+template <typename... T_VNAuxs>
+class VNUser3Handle final : public VNUserHandleTemplate<VNUser3Accessor, T_VNAuxs...> {
+    const VNUser3InUse m_user3InUse;
+};
+template <typename... T_VNAuxs>
+class VNUser4Handle final : public VNUserHandleTemplate<VNUser4Accessor, T_VNAuxs...> {
+    const VNUser4InUse m_user4InUse;
+};
+
+#endif  // Guard


### PR DESCRIPTION
I hope you like templates :grin:.

This is a proposal for a new, type safe, generic, and efficient interface for accessing the `AstNode` user fields. I would like to propose for this to be the universal mechanism for accessing the user data in the nodes.

Improvements over the current APIs:
- Uniformity: This can replace both the `AstNode::user*` methods, and the `AstNodeUser*Allocator` classes.
- Type safety: you can only access the user data on nodes that you declared in the type of `VNUser*Handle`, and the associated data is strongly typed, eliminating the need for casts in the user code.
- Disambiguation: You can declare different [non overlapping] node types to have different associated data types. This improves the static safety of keeping different kind of data associated with different types of nodes under the same user data field (e.g.: bools on Vars but node pointers on Stmts).
- Enforced documentation: You no longer need to add the "NODE STATE" section in comments, it is all encoded in the code as types, and the program does not type check if you fail to update the declaration correctly.
- Memory efficiency: You can now easily store any 8 byte structure directly within the user data field, so you no longer need 2 user fields for 2 bools for example (you need to give a type with 2 bools as the associated data, preferably a struct with well named fields).

Otherwise the efficiency is the same or better as the current APIs. Anything less or equal to a pointer is stored directly (as if using AstNode::user*), and anything larger than a pointer is automatically allocated in a `std::deque` by value and is held indirectly.

FWIW I believe this is all just C++11.

We can change names of things.

I have only applied to user1 in V3Delayed as a demonstration to get feedback (and discovered some out of date comments and unnecessary type ascriptions in the process), but I'm fairly sure *all* usage of the AstNode::user* methods could be replace with this new mechanism, if you are happy with it. I probably won't have time to do them all in one go though.

TODO:
- [ ] A static assertion that the VNAux::Nodes are not overlapping subtypes