### PR TITLE
Fix using identifiers end with '_' on Windows

### DIFF
--- a/src/V3Ast.cpp
+++ b/src/V3Ast.cpp
@@ -107,7 +107,10 @@ string AstNode::encodeName(const string& namein) {
         } else if (pos[0] == '_') {
             out += pos[0];
             if (pos + 1 == namein.end()) break;
-            if (pos[1] == '_') out += "__05F";  // hex(_) = 0x5F
+            if (pos[1] == '_') {
+                ++pos;
+                out += "__05F";  // hex(_) = 0x5F
+            }
         } else {
             // Need the leading 0 so this will never collide with
             // a user identifier nor a temp we create in Verilator.

--- a/src/V3Ast.cpp
+++ b/src/V3Ast.cpp
@@ -100,7 +100,7 @@ string AstNode::encodeName(const string& namein) {
     // Encode signal name raw from parser, then not called again on same signal
     string out;
     const size_t len = namein.length();
-    const char* buf = namein.data();
+    const char* const buf = namein.data();
     out.reserve(len);
     for (size_t i = 0; i < len; ++i) {
         const char ch = buf[i];

--- a/src/V3Ast.cpp
+++ b/src/V3Ast.cpp
@@ -99,27 +99,21 @@ AstNode* AstNode::abovep() const {
 string AstNode::encodeName(const string& namein) {
     // Encode signal name raw from parser, then not called again on same signal
     string out;
-    const size_t len = namein.length();
-    const char* const buf = namein.data();
-    out.reserve(len);
-    for (size_t i = 0; i < len; ++i) {
-        const char ch = buf[i];
-        if (i == 0 ? std::isalpha(ch) : std::isalnum(ch)) {  // digits can't lead identifiers
-            out += ch;
-        } else if (ch == '_') {
-            out += ch;
-            const char nextCh = buf[i + 1];
-            if (nextCh == '\0') break;
-            if (nextCh == '_') {
-                out += "__05F";  // hex(_) = 0x5F
-                ++i;
-            }
+    out.reserve(namein.size());
+    for (auto pos = namein.begin(); pos != namein.end(); ++pos) {
+        if ((pos == namein.begin()) ? std::isalpha(pos[0])  // digits can't lead identifiers
+                                    : std::isalnum(pos[0])) {
+            out += pos[0];
+        } else if (pos[0] == '_') {
+            out += pos[0];
+            if (pos + 1 == namein.end()) break;
+            if (pos[1] == '_') out += "__05F";  // hex(_) = 0x5F
         } else {
             // Need the leading 0 so this will never collide with
             // a user identifier nor a temp we create in Verilator.
             // We also do *NOT* use __DOT__ etc, as we search for those
             // in some replacements, and don't want to mangle the user's names.
-            const unsigned val = ch & 0xff;  // Mask to avoid sign extension
+            const unsigned val = pos[0] & 0xff;  // Mask to avoid sign extension
             std::stringstream hex;
             hex << std::setfill('0') << std::setw(2) << std::hex << val;
             out += "__0" + hex.str();

--- a/test_regress/t/t_var_escape.out
+++ b/test_regress/t/t_var_escape.out
@@ -11,9 +11,11 @@ $timescale 1ps $end
    $var wire 1 # clk $end
    $var wire 32 ( cyc [31:0] $end
    $var wire 1 $ escaped_normal $end
-   $var wire 1 $ double__underscore $end
-   $var wire 1 $ 9num $end
-   $var wire 1 $ bra[ket]slash/dash-colon:9backslash\done $end
+   $var wire 1 % double__underscore $end
+   $var wire 1 $ underscore_at_the_end_ $end
+   $var wire 1 $ double__underscore_at_the_end__ $end
+   $var wire 1 & 9num $end
+   $var wire 1 ' bra[ket]slash/dash-colon:9backslash\done $end
    $var wire 1 $ wire $end
    $var wire 1 $ check_alias $end
    $var wire 1 $ check:alias $end

--- a/test_regress/t/t_var_escape.v
+++ b/test_regress/t/t_var_escape.v
@@ -21,6 +21,15 @@ module t (/*AUTOARG*/
    output  double__underscore ;
    wire  double__underscore = cyc[0];
 
+   wire  underscore_at_the_end_          = cyc[0];
+   wire  double__underscore_at_the_end__ = cyc[0];
+
+   // Only underscores, ignored in trace
+   wire  _    = cyc[0];
+   wire  __   = cyc[0];
+   wire  ___  = cyc[0];
+   wire  ____ = cyc[0];
+
    // C doesn't allow leading non-alpha, so must escape
    output \9num ;
    wire \9num = cyc[0];
@@ -45,7 +54,12 @@ module t (/*AUTOARG*/
       cyc <= cyc + 1;
       if (escaped_normal != cyc[0]) $stop;
       if (\escaped_normal != cyc[0]) $stop;
-      if (double__underscore != cyc[0]) $stop;
+      if (underscore_at_the_end_ != cyc[0]) $stop;
+      if (double__underscore_at_the_end__ != cyc[0]) $stop;
+      if (_ != cyc[0]) $stop;
+      if (__ != cyc[0]) $stop;
+      if (___ != cyc[0]) $stop;
+      if (____ != cyc[0]) $stop;
       if (\9num != cyc[0]) $stop;
       if (\bra[ket]slash/dash-colon:9backslash\done != cyc[0]) $stop;
       if (\wire != cyc[0]) $stop;


### PR DESCRIPTION
On Windows' debug version binary, the program crashes if the input source code contains any identifiers end with '_'. The cause is that MSVC's STL checks out-of-bounds access when using string iterators. It's now replaced with pointer operations to avoid the problem.