### PR TITLE
Fix scheduling of external force signals (#4577)

### DIFF
--- a/src/V3Force.cpp
+++ b/src/V3Force.cpp
@@ -283,8 +283,8 @@ class ForceConvertVisitor final : public VNVisitor {
         // If this signal is marked externally forceable, create the public force signals
         if (nodep->varp()->isForceable()) {
             const ForceComponentsVarScope& fc = getForceComponents(nodep);
-            fc.m_enVscp->varp()->sigPublic(true);
-            fc.m_valVscp->varp()->sigPublic(true);
+            fc.m_enVscp->varp()->sigUserRWPublic(true);
+            fc.m_valVscp->varp()->sigUserRWPublic(true);
         }
     }
 


### PR DESCRIPTION
Used to set the wrong public flag on forceEn/forceVal, which means they were not included in ICO as necessary, but V3Gate tended to inline them, so this was hard to hit.