### PR TITLE
Fix deadlocks in error handler

### DIFF
--- a/src/V3Error.cpp
+++ b/src/V3Error.cpp
@@ -103,13 +103,7 @@ void V3ErrorGuarded::vlAbortOrExit() VL_REQUIRES(m_mutex) {
         std::cerr << msgPrefix() << "Aborting since under --debug" << endl;
         V3Error::vlAbort();
     } else {
-        // Normal exit can't be invoked here because the program state is unknown. The stack won't
-        // unwind, no matter what exit function is used (except throwing an exception, whose can be
-        // disabled). Due to this destructors of local objects will never be executed. However,
-        // destructors of global objects (singletons) WILL be executed on std::exit(). This can
-        // lead to hangs, e.g. in V3ThreadPool. Letting the program deadlock in an error handler is
-        // quite a bad idea, so let's just exit without running any destructors.
-        std::quick_exit(1);
+        std::exit(1);
     }
 }
 

--- a/src/V3ThreadPool.h
+++ b/src/V3ThreadPool.h
@@ -232,6 +232,7 @@ private:
 
     // True when any thread requested exclusive access
     bool stopRequested() const VL_MT_SAFE {
+        if (m_exclusiveAccess) return false;
         // don't wait if shutdown already requested
         if (m_shutdown) return false;
         return m_stopRequested;

--- a/src/V3ThreadPool.h
+++ b/src/V3ThreadPool.h
@@ -125,11 +125,11 @@ class V3ThreadPool final {
         // wrong. This won't make things worse to an user - the program is already terminating at
         // this point anyway, most likely as a result of an error. Using if/abort instead of assert
         // because assert can be disabled.
-        if (m_exclusiveAccess) std::abort();
-        if (m_stopRequested) std::abort();
+        if (VL_UNCOVERABLE(m_exclusiveAccess)) std::abort();
+        if (VL_UNCOVERABLE(m_stopRequested)) std::abort();
 
-        if (!m_mutex.try_lock()) {
-            if (m_jobsInProgress != 0) {
+        if (VL_UNCOVERABLE(!m_mutex.try_lock())) {
+            if (VL_UNCOVERABLE(m_jobsInProgress != 0)) {
                 // ThreadPool shouldn't be destroyed when jobs are running and mutex is locked,
                 // something is wrong. Most likely Verilator is exiting as a result of failed
                 // assert in critical section. Just returning is dangerous, as threads and this


### PR DESCRIPTION
Prevents deadlocks from happening as a result of code executed in error handler.
Main changes:
- `std::quick_exit(1)` is used to terminate the program in error handler. This function skips execution of destructors of static objects. Destructors of local objects were never executed (stack is not unwound when any exit function is called), which could cause problems in destructors of static objects, e.g. deadlocking in V3ThreadPool.
- V3ThreadPool's destructor handles destruction in mt-disabled and exclusive-access state.
- Avoiding deadlock in `V3ThreadPool::waitIfStopRequested()` (called by `V3Error::v3errorAcquireLock`) in exclusive-access (and mt-disabled) state.