### PR TITLE
Allow Mingw Compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ if (NOT WIN32)
     message(WARNING "CMake support on Linux/OSX is experimental.")
 endif()
 
-if (MSVC)
+if (WIN32)
     if (DEFINED ENV{WIN_FLEX_BISON})
         set(WIN_FLEX_BISON "$ENV{WIN_FLEX_BISON}")
     endif()

--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -26,7 +26,6 @@ Conor McCullough
 Dan Petrisko
 Daniel Bates
 David Horton
-David Ledger
 David Metz
 David Stanford
 David Turner

--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -26,6 +26,7 @@ Conor McCullough
 Dan Petrisko
 Daniel Bates
 David Horton
+David Ledger
 David Metz
 David Stanford
 David Turner

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -504,7 +504,7 @@ if (WIN32)
     if(MINGW)
         target_compile_options(${verilator} PRIVATE -Wa,-mbig-obj)
         target_link_options(${verilator} PRIVATE -Wl,--stack,10000000)
-    else
+    else()
         target_compile_options(${verilator} PRIVATE /bigobj)
         target_link_options(${verilator} PRIVATE /STACK:10000000)
     endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -501,13 +501,16 @@ target_include_directories(${verilator}
 )
 
 if (WIN32)
-    target_compile_options(${verilator} PRIVATE /bigobj)
+    if (MSVC)
+        target_compile_options(${verilator} PRIVATE /bigobj)
+        target_link_options(${verilator} PRIVATE /STACK:10000000)
+    endif()
+
     target_compile_definitions(${verilator} PRIVATE
         YY_NO_UNISTD_H
     )
     target_include_directories(${verilator} PRIVATE ../platform/win32)
     target_link_libraries(${verilator} PRIVATE bcrypt psapi)
-    target_link_options(${verilator} PRIVATE /STACK:10000000)
 endif()
 
 install(TARGETS ${verilator})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -466,7 +466,7 @@ set_target_properties(${verilator} PROPERTIES
     #UNITY_BUILD $<IF:$<CONFIG:DEBUG>,FALSE,${CMAKE_UNITY_BUILD}>
     MSVC_RUNTIME_LIBRARY  MultiThreaded$<IF:$<CONFIG:Release>,,DebugDLL>
     #JOB_POOL_LINK         one_job      # Linking takes lots of resources
-    INTERPROCEDURAL_OPTIMIZATION_RELEASE  TRUE
+    INTERPROCEDURAL_OPTIMIZATION_RELEASE  $<IF:MINGW,FALSE,TRUE>
 )
 
 add_dependencies(${verilator}
@@ -503,7 +503,7 @@ target_include_directories(${verilator}
 if (WIN32)
     if(MINGW)
         target_compile_options(${verilator} PRIVATE -Wa,-mbig-obj)
-        target_link_options(${verilator} PRIVATE -Wl,--stack,10000000)
+        target_link_options(${verilator} PRIVATE -Wl,--stack,10000000 -mconsole -lcomctl32 -DWIN_32_LEAN_AND_MEAN)
     else()
         target_compile_options(${verilator} PRIVATE /bigobj)
         target_link_options(${verilator} PRIVATE /STACK:10000000)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -501,7 +501,10 @@ target_include_directories(${verilator}
 )
 
 if (WIN32)
-    if (MSVC)
+    if(MINGW)
+        target_compile_options(${verilator} PRIVATE -Wa,-mbig-obj)
+        target_link_options(${verilator} PRIVATE -Wl,--stack,10000000)
+    else
         target_compile_options(${verilator} PRIVATE /bigobj)
         target_link_options(${verilator} PRIVATE /STACK:10000000)
     endif()


### PR DESCRIPTION
I've changed some minor components of the cmake scripts that enabled compilation of verilator using mingw on windows.

 - I've checked compilation still works for MSVC.
 - I've checked compilation works for mingw (specifically version 13.2.0 from MSYS2).

Summary of changes:
- The environmental variable on windows is needed for all windows compilations (not just MSVC).
- The flags provided for the linux build were not valid for gcc or clang (in gcc mode).