### PR TITLE
Support passing constraints to --xml-only output (still otherwise unsupported)

### DIFF
--- a/Changes
+++ b/Changes
@@ -20,6 +20,7 @@ Verilator 5.019 devel
 **Minor:**
 
 * Support ccache when compiling Verilator with CMake (#4678). [Anthony Donlon]
+* Support passing constraints to --xml-only output (still otherwise unsupported) (#4683). [Shahid Ikram]
 * Remove deprecated options (#4663). [Geza Lore]
 * Optimize timing-delayed queue (#4584). [qrqiuren]
 * Fix VPI TOP level variable iteration (#3919) (#4618). [Marlon James]

--- a/src/V3Ast.cpp
+++ b/src/V3Ast.cpp
@@ -1447,17 +1447,20 @@ AstNodeDType* AstNode::findBitRangeDType(const VNumRange& range, int widthMin,
 AstBasicDType* AstNode::findInsertSameDType(AstBasicDType* nodep) {
     return v3Global.rootp()->typeTablep()->findInsertSameDType(nodep);
 }
+AstNodeDType* AstNode::findConstraintRefDType() const {
+    return v3Global.rootp()->typeTablep()->findConstraintRefDType(fileline());
+}
 AstNodeDType* AstNode::findEmptyQueueDType() const {
     return v3Global.rootp()->typeTablep()->findEmptyQueueDType(fileline());
 }
 AstNodeDType* AstNode::findQueueIndexDType() const {
     return v3Global.rootp()->typeTablep()->findQueueIndexDType(fileline());
 }
-AstNodeDType* AstNode::findVoidDType() const {
-    return v3Global.rootp()->typeTablep()->findVoidDType(fileline());
-}
 AstNodeDType* AstNode::findStreamDType() const {
     return v3Global.rootp()->typeTablep()->findStreamDType(fileline());
+}
+AstNodeDType* AstNode::findVoidDType() const {
+    return v3Global.rootp()->typeTablep()->findVoidDType(fileline());
 }
 
 static const AstNodeDType* computeCastableBase(const AstNodeDType* nodep) {

--- a/src/V3Ast.h
+++ b/src/V3Ast.h
@@ -2121,8 +2121,8 @@ public:
     void dtypeSetUInt32() { dtypep(findUInt32DType()); }  // Twostate
     void dtypeSetUInt64() { dtypep(findUInt64DType()); }  // Twostate
     void dtypeSetEmptyQueue() { dtypep(findEmptyQueueDType()); }
-    void dtypeSetVoid() { dtypep(findVoidDType()); }
     void dtypeSetStream() { dtypep(findStreamDType()); }
+    void dtypeSetVoid() { dtypep(findVoidDType()); }
 
     // Data type locators
     AstNodeDType* findBitDType() const { return findBasicDType(VBasicDTypeKwd::LOGIC); }
@@ -2132,10 +2132,11 @@ public:
     AstNodeDType* findUInt32DType() const { return findBasicDType(VBasicDTypeKwd::UINT32); }
     AstNodeDType* findUInt64DType() const { return findBasicDType(VBasicDTypeKwd::UINT64); }
     AstNodeDType* findCHandleDType() const { return findBasicDType(VBasicDTypeKwd::CHANDLE); }
+    AstNodeDType* findConstraintRefDType() const;
     AstNodeDType* findEmptyQueueDType() const;
-    AstNodeDType* findVoidDType() const;
-    AstNodeDType* findStreamDType() const;
     AstNodeDType* findQueueIndexDType() const;
+    AstNodeDType* findStreamDType() const;
+    AstNodeDType* findVoidDType() const;
     AstNodeDType* findBitDType(int width, int widthMin, VSigning numeric) const;
     AstNodeDType* findLogicDType(int width, int widthMin, VSigning numeric) const;
     AstNodeDType* findLogicRangeDType(const VNumRange& range, int widthMin,

--- a/src/V3AstNodeDType.h
+++ b/src/V3AstNodeDType.h
@@ -622,6 +622,32 @@ public:
         return false;
     }
 };
+class AstConstraintRefDType final : public AstNodeDType {
+    // For e.g. a reference to constraint for constraint_mode
+public:
+    explicit AstConstraintRefDType(FileLine* fl)
+        : ASTGEN_SUPER_ConstraintRefDType(fl) {
+        dtypep(this);
+    }
+    ASTGEN_MEMBERS_AstConstraintRefDType;
+    bool hasDType() const override { return true; }
+    bool maybePointedTo() const override { return true; }
+    bool undead() const override { return true; }
+    AstNodeDType* subDTypep() const override VL_MT_SAFE { return nullptr; }
+    AstNodeDType* virtRefDTypep() const override { return nullptr; }
+    void virtRefDTypep(AstNodeDType* nodep) override {}
+    bool similarDType(const AstNodeDType* samep) const override { return this == samep; }
+    AstBasicDType* basicp() const override VL_MT_STABLE { return nullptr; }
+    // cppcheck-suppress csyleCast
+    AstNodeDType* skipRefp() const override VL_MT_STABLE { return (AstNodeDType*)this; }
+    // cppcheck-suppress csyleCast
+    AstNodeDType* skipRefToConstp() const override { return (AstNodeDType*)this; }
+    // cppcheck-suppress csyleCast
+    AstNodeDType* skipRefToEnump() const override { return (AstNodeDType*)this; }
+    int widthAlignBytes() const override { return 1; }
+    int widthTotalBytes() const override { return 1; }
+    bool isCompound() const override { return false; }
+};
 class AstDefImplicitDType final : public AstNodeDType {
     // For parsing enum/struct/unions that are declared with a variable rather than typedef
     // This allows "var enum {...} a,b" to share the enum definition for both variables

--- a/src/V3AstNodeExpr.h
+++ b/src/V3AstNodeExpr.h
@@ -1062,6 +1062,29 @@ public:
     // May return nullptr on parse failure.
     static AstConst* parseParamLiteral(FileLine* fl, const string& literal);
 };
+class AstConstraintRef final : public AstNodeExpr {
+    // A reference to a constraint identifier
+    // Not saving pointer to constraint yet, as constraint_mode is an unsupported construct
+    // @astgen op4 := scopeNamep : Optional[AstScopeName]
+    AstNodeModule* m_classOrPackagep = nullptr;  // Class/package of the constraint
+    string m_name;  // Name of constraint
+
+public:
+    AstConstraintRef(FileLine* fl, const string& name)
+        : ASTGEN_SUPER_ConstraintRef(fl)
+        , m_name{name} {
+        dtypep(findConstraintRefDType());
+    }
+    ASTGEN_MEMBERS_AstConstraintRef;
+    string name() const override VL_MT_STABLE { return m_name; }  // * = Var name
+    void name(const string& name) override { m_name = name; }
+    AstNodeModule* classOrPackagep() const { return m_classOrPackagep; }
+    void classOrPackagep(AstNodeModule* nodep) { m_classOrPackagep = nodep; }
+
+    string emitVerilog() final override { V3ERROR_NA_RETURN(""); }
+    string emitC() final override { V3ERROR_NA_RETURN(""); }
+    bool cleanOut() const final override { V3ERROR_NA_RETURN(true); }
+};
 class AstCvtDynArrayToPacked final : public AstNodeExpr {
     // Cast from dynamic queue data type to packed array
     // @astgen op1 := fromp : AstNodeExpr
@@ -1905,6 +1928,7 @@ public:
     string emitVerilog() override { V3ERROR_NA_RETURN(""); }
     string emitC() override { V3ERROR_NA_RETURN(""); }
     bool cleanOut() const override { V3ERROR_NA_RETURN(true); }
+    bool hasDType() const override { return false; }
 };
 class AstSetAssoc final : public AstNodeExpr {
     // Set an assoc array element and return object, '{}

--- a/src/V3AstNodes.cpp
+++ b/src/V3AstNodes.cpp
@@ -1096,6 +1096,14 @@ void AstTypeTable::repairCache() {
     }
 }
 
+AstConstraintRefDType* AstTypeTable::findConstraintRefDType(FileLine* fl) {
+    if (VL_UNLIKELY(!m_constraintRefp)) {
+        AstConstraintRefDType* const newp = new AstConstraintRefDType{fl};
+        addTypesp(newp);
+        m_constraintRefp = newp;
+    }
+    return m_constraintRefp;
+}
 AstEmptyQueueDType* AstTypeTable::findEmptyQueueDType(FileLine* fl) {
     if (VL_UNLIKELY(!m_emptyQueuep)) {
         AstEmptyQueueDType* const newp = new AstEmptyQueueDType{fl};
@@ -1104,16 +1112,6 @@ AstEmptyQueueDType* AstTypeTable::findEmptyQueueDType(FileLine* fl) {
     }
     return m_emptyQueuep;
 }
-
-AstVoidDType* AstTypeTable::findVoidDType(FileLine* fl) {
-    if (VL_UNLIKELY(!m_voidp)) {
-        AstVoidDType* const newp = new AstVoidDType{fl};
-        addTypesp(newp);
-        m_voidp = newp;
-    }
-    return m_voidp;
-}
-
 AstStreamDType* AstTypeTable::findStreamDType(FileLine* fl) {
     if (VL_UNLIKELY(!m_streamp)) {
         AstStreamDType* const newp = new AstStreamDType{fl};
@@ -1122,7 +1120,6 @@ AstStreamDType* AstTypeTable::findStreamDType(FileLine* fl) {
     }
     return m_streamp;
 }
-
 AstQueueDType* AstTypeTable::findQueueIndexDType(FileLine* fl) {
     if (VL_UNLIKELY(!m_queueIndexp)) {
         AstQueueDType* const newp = new AstQueueDType{fl, AstNode::findUInt32DType(), nullptr};
@@ -1130,6 +1127,14 @@ AstQueueDType* AstTypeTable::findQueueIndexDType(FileLine* fl) {
         m_queueIndexp = newp;
     }
     return m_queueIndexp;
+}
+AstVoidDType* AstTypeTable::findVoidDType(FileLine* fl) {
+    if (VL_UNLIKELY(!m_voidp)) {
+        AstVoidDType* const newp = new AstVoidDType{fl};
+        addTypesp(newp);
+        m_voidp = newp;
+    }
+    return m_voidp;
 }
 
 AstBasicDType* AstTypeTable::findBasicDType(FileLine* fl, VBasicDTypeKwd kwd) {
@@ -1467,7 +1472,7 @@ void AstClassPackage::cloneRelink() {
     if (m_classp && m_classp->clonep()) m_classp = m_classp->clonep();
 }
 bool AstClass::isCacheableChild(const AstNode* nodep) {
-    return (VN_IS(nodep, Var) || VN_IS(nodep, EnumItemRef)
+    return (VN_IS(nodep, Var) || VN_IS(nodep, Constraint) || VN_IS(nodep, EnumItemRef)
             || (VN_IS(nodep, NodeFTask) && !VN_AS(nodep, NodeFTask)->isExternProto())
             || VN_IS(nodep, CFunc));
 }

--- a/src/V3LinkInc.cpp
+++ b/src/V3LinkInc.cpp
@@ -129,7 +129,7 @@ private:
         // Done the loop
         m_insStmtp = nullptr;  // Next thing should be new statement
     }
-    void visit(AstForeach* nodep) override {
+    void visit(AstNodeForeach* nodep) override {
         // Special, as statements need to be put in different places
         // Body insert just before themselves
         m_insStmtp = nullptr;  // First thing should be new statement

--- a/src/V3LinkJump.cpp
+++ b/src/V3LinkJump.cpp
@@ -245,7 +245,7 @@ private:
             whilep->addHereThisAsNext(copiedBodyp);
         }
     }
-    void visit(AstForeach* nodep) override {
+    void visit(AstNodeForeach* nodep) override {
         VL_RESTORER(m_loopp);
         {
             m_loopp = nodep;

--- a/src/V3LinkParse.cpp
+++ b/src/V3LinkParse.cpp
@@ -242,6 +242,10 @@ private:
         }
     }
     void visit(AstNodeDType* nodep) override { visitIterateNodeDType(nodep); }
+    void visit(AstConstraint* nodep) override {
+        v3Global.useRandomizeMethods(true);
+        iterateChildren(nodep);
+    }
     void visit(AstEnumDType* nodep) override {
         if (nodep->name() == "") {
             nodep->name(nameFromTypedef(nodep));  // Might still remain ""
@@ -533,7 +537,7 @@ private:
         VL_DO_DANGLING(nodep->deleteTree(), nodep);
     }
 
-    void visit(AstForeach* nodep) override {
+    void visit(AstNodeForeach* nodep) override {
         // FOREACH(array, loopvars, body)
         UINFO(9, "FOREACH " << nodep << endl);
         cleanFileline(nodep);

--- a/src/V3Randomize.cpp
+++ b/src/V3Randomize.cpp
@@ -358,6 +358,10 @@ private:
         addPrePostCall(nodep, funcp, "post_randomize");
         nodep->user1(false);
     }
+    void visit(AstConstraint* nodep) override {
+        nodep->v3warn(CONSTRAINTIGN, "Constraint ignored (unsupported)");
+        if (!v3Global.opt.xmlOnly()) VL_DO_DANGLING(pushDeletep(nodep->unlinkFrBack()), nodep);
+    }
     void visit(AstRandCase* nodep) override {
         // RANDCASE
         //   CASEITEM expr1 : stmt1

--- a/test_regress/t/t_constraint_method_bad.out
+++ b/test_regress/t/t_constraint_method_bad.out
@@ -1,0 +1,5 @@
+%Error: t/t_constraint_method_bad.v:13:12: No such constraint method 'bad_method'
+                                         : ... note: In instance 't'
+   13 |       cons.bad_method(1);   
+      |            ^~~~~~~~~~
+%Error: Exiting due to

--- a/test_regress/t/t_constraint_method_bad.pl
+++ b/test_regress/t/t_constraint_method_bad.pl
@@ -1,0 +1,19 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2020 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(linter => 1);
+
+lint(
+    fails => $Self->{vlt_all},
+    expect_filename => $Self->{golden_filename},
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_constraint_method_bad.v
+++ b/test_regress/t/t_constraint_method_bad.v
@@ -1,0 +1,19 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2023 by Wilson Snyder.
+// SPDX-License-Identifier: CC0-1.0
+
+class Packet;
+   rand int m_one;
+
+   constraint cons { m_one > 0 && m_one < 2; }
+
+   task test1;
+      cons.bad_method(1);  // BAD
+   endtask
+
+endclass
+
+module t (/*AUTOARG*/);
+endmodule

--- a/test_regress/t/t_constraint_mode.v
+++ b/test_regress/t/t_constraint_mode.v
@@ -5,20 +5,17 @@
 // SPDX-License-Identifier: CC0-1.0
 
 class Packet;
-   rand int one;
+   rand int m_one;
 
-   constraint a { one > 0 && one < 2; }
+   constraint cons { m_one > 0 && m_one < 2; }
+
+   Packet self;
 
    task test1;
-      // TODO Verilator ignores this setting currently, always returning 1 (rand on)
-      one.rand_mode(0);
-      one.rand_mode(1);
-      if (one.rand_mode() != 1) $stop;
-
       // TODO Verilator ignores this setting currently, always returning 0 (constraint off)
-      a.constraint_mode(1);
-      a.constraint_mode(0);
-      if (a.constraint_mode() != 0) $stop;
+      cons.constraint_mode(1);
+      cons.constraint_mode(0);
+      if (cons.constraint_mode() != 0) $stop;
    endtask
 
 endclass
@@ -34,23 +31,34 @@ module t (/*AUTOARG*/);
       v = p.randomize();
       if (v != 1) $stop;
 `ifndef VERILATOR
-      if (p.one != 1) $stop;
+      if (p.m_one != 1) $stop;
 `endif
 
+      // IEEE: function void object[.constraint_identifier].constraint_mode(bit on_off);
+      // IEEE: function int object.constraint_identifier.constraint_mode();
+
       // TODO Verilator ignores this setting currently, always returning 1 (rand on)
-      p.one.rand_mode(0);
-      p.one.rand_mode(1);
-      if (p.one.rand_mode() != 1) $stop;
+      // TODO test that these control constraints as specified
+      p.constraint_mode(0);
+      p.constraint_mode(1);
+      // Not legal to get current constraint_mode() value on a class-only call
 
       // TODO Verilator ignores this setting currently, always returning 0 (constraint off)
-      p.a.constraint_mode(1);
-      p.a.constraint_mode(0);
-      if (p.a.constraint_mode() != 0) $stop;
+      // TODO test that these control constraints as specified
+      p.cons.constraint_mode(1);
+      p.cons.constraint_mode(0);
+      if (p.cons.constraint_mode() != 0) $stop;
+
+      // TODO Verilator ignores this setting currently, always returning 0 (constraint off)
+      // TODO test that these control constraints as specified
+      p.self = p;
+      p.self.cons.constraint_mode(1);
+      p.self.cons.constraint_mode(0);
+      if (p.self.cons.constraint_mode() != 0) $stop;
 
       p.test1();
 
       // TODO test can't redefine constraint_mode
-      // TODO test can't redefine rand_mode
       // TODO test can't call constraint_mode on non-constraint
 
       $write("*-* All Finished *-*\n");

--- a/test_regress/t/t_constraint_mode.v
+++ b/test_regress/t/t_constraint_mode.v
@@ -9,7 +9,7 @@ class Packet;
 
    constraint cons { m_one > 0 && m_one < 2; }
 
-   Packet self;
+   Packet other;
 
    task test1;
       // TODO Verilator ignores this setting currently, always returning 0 (constraint off)
@@ -51,10 +51,10 @@ module t (/*AUTOARG*/);
 
       // TODO Verilator ignores this setting currently, always returning 0 (constraint off)
       // TODO test that these control constraints as specified
-      p.self = p;
-      p.self.cons.constraint_mode(1);
-      p.self.cons.constraint_mode(0);
-      if (p.self.cons.constraint_mode() != 0) $stop;
+      p.other = new;
+      p.other.cons.constraint_mode(1);
+      p.other.cons.constraint_mode(0);
+      if (p.other.cons.constraint_mode() != 0) $stop;
 
       p.test1();
 

--- a/test_regress/t/t_constraint_mode_warn_bad.out
+++ b/test_regress/t/t_constraint_mode_warn_bad.out
@@ -32,18 +32,18 @@
                                                    : ... note: In instance 't'
    50 |       if (p.cons.constraint_mode() != 0) $stop;
       |                  ^~~~~~~~~~~~~~~
-%Warning-CONSTRAINTIGN: t/t_constraint_mode.v:55:19: constraint_mode ignored (unsupported)
+%Warning-CONSTRAINTIGN: t/t_constraint_mode.v:55:20: constraint_mode ignored (unsupported)
                                                    : ... note: In instance 't'
-   55 |       p.self.cons.constraint_mode(1);
-      |                   ^~~~~~~~~~~~~~~
-%Warning-CONSTRAINTIGN: t/t_constraint_mode.v:56:19: constraint_mode ignored (unsupported)
+   55 |       p.other.cons.constraint_mode(1);
+      |                    ^~~~~~~~~~~~~~~
+%Warning-CONSTRAINTIGN: t/t_constraint_mode.v:56:20: constraint_mode ignored (unsupported)
                                                    : ... note: In instance 't'
-   56 |       p.self.cons.constraint_mode(0);
-      |                   ^~~~~~~~~~~~~~~
-%Warning-CONSTRAINTIGN: t/t_constraint_mode.v:57:23: constraint_mode ignored (unsupported)
+   56 |       p.other.cons.constraint_mode(0);
+      |                    ^~~~~~~~~~~~~~~
+%Warning-CONSTRAINTIGN: t/t_constraint_mode.v:57:24: constraint_mode ignored (unsupported)
                                                    : ... note: In instance 't'
-   57 |       if (p.self.cons.constraint_mode() != 0) $stop;
-      |                       ^~~~~~~~~~~~~~~
+   57 |       if (p.other.cons.constraint_mode() != 0) $stop;
+      |                        ^~~~~~~~~~~~~~~
 %Warning-CONSTRAINTIGN: t/t_constraint_mode.v:10:15: Constraint ignored (unsupported)
                                                    : ... note: In instance 't'
    10 |    constraint cons { m_one > 0 && m_one < 2; }

--- a/test_regress/t/t_constraint_mode_warn_bad.out
+++ b/test_regress/t/t_constraint_mode_warn_bad.out
@@ -1,54 +1,51 @@
-%Warning-CONSTRAINTIGN: t/t_constraint_mode.v:10:4: Constraint ignored (unsupported)
-   10 |    constraint a { one > 0 && one < 2; }
-      |    ^~~~~~~~~~
+%Warning-CONSTRAINTIGN: t/t_constraint_mode.v:16:12: constraint_mode ignored (unsupported)
+                                                   : ... note: In instance 't'
+   16 |       cons.constraint_mode(1);
+      |            ^~~~~~~~~~~~~~~
                         ... For warning description see https://verilator.org/warn/CONSTRAINTIGN?v=latest
                         ... Use "/* verilator lint_off CONSTRAINTIGN */" and lint_on around source to disable this message.
-%Warning-CONSTRAINTIGN: t/t_constraint_mode.v:14:11: rand_mode ignored (unsupported)
+%Warning-CONSTRAINTIGN: t/t_constraint_mode.v:17:12: constraint_mode ignored (unsupported)
                                                    : ... note: In instance 't'
-   14 |       one.rand_mode(0);
-      |           ^~~~~~~~~
-%Warning-CONSTRAINTIGN: t/t_constraint_mode.v:15:11: rand_mode ignored (unsupported)
+   17 |       cons.constraint_mode(0);
+      |            ^~~~~~~~~~~~~~~
+%Warning-CONSTRAINTIGN: t/t_constraint_mode.v:18:16: constraint_mode ignored (unsupported)
                                                    : ... note: In instance 't'
-   15 |       one.rand_mode(1);
-      |           ^~~~~~~~~
-%Warning-CONSTRAINTIGN: t/t_constraint_mode.v:16:15: rand_mode ignored (unsupported)
-                                                   : ... note: In instance 't'
-   16 |       if (one.rand_mode() != 1) $stop;
-      |               ^~~~~~~~~
-%Warning-CONSTRAINTIGN: t/t_constraint_mode.v:19:9: constraint_mode ignored (unsupported)
+   18 |       if (cons.constraint_mode() != 0) $stop;
+      |                ^~~~~~~~~~~~~~~
+%Warning-CONSTRAINTIGN: t/t_constraint_mode.v:42:9: Unsupported: 'constraint_mode' called on object
                                                   : ... note: In instance 't'
-   19 |       a.constraint_mode(1);
+   42 |       p.constraint_mode(0);
       |         ^~~~~~~~~~~~~~~
-%Warning-CONSTRAINTIGN: t/t_constraint_mode.v:20:9: constraint_mode ignored (unsupported)
+%Warning-CONSTRAINTIGN: t/t_constraint_mode.v:43:9: Unsupported: 'constraint_mode' called on object
                                                   : ... note: In instance 't'
-   20 |       a.constraint_mode(0);
+   43 |       p.constraint_mode(1);
       |         ^~~~~~~~~~~~~~~
-%Warning-CONSTRAINTIGN: t/t_constraint_mode.v:21:13: constraint_mode ignored (unsupported)
+%Warning-CONSTRAINTIGN: t/t_constraint_mode.v:48:14: constraint_mode ignored (unsupported)
                                                    : ... note: In instance 't'
-   21 |       if (a.constraint_mode() != 0) $stop;
-      |             ^~~~~~~~~~~~~~~
-%Warning-CONSTRAINTIGN: t/t_constraint_mode.v:41:13: rand_mode ignored (unsupported)
+   48 |       p.cons.constraint_mode(1);
+      |              ^~~~~~~~~~~~~~~
+%Warning-CONSTRAINTIGN: t/t_constraint_mode.v:49:14: constraint_mode ignored (unsupported)
                                                    : ... note: In instance 't'
-   41 |       p.one.rand_mode(0);
-      |             ^~~~~~~~~
-%Warning-CONSTRAINTIGN: t/t_constraint_mode.v:42:13: rand_mode ignored (unsupported)
+   49 |       p.cons.constraint_mode(0);
+      |              ^~~~~~~~~~~~~~~
+%Warning-CONSTRAINTIGN: t/t_constraint_mode.v:50:18: constraint_mode ignored (unsupported)
                                                    : ... note: In instance 't'
-   42 |       p.one.rand_mode(1);
-      |             ^~~~~~~~~
-%Warning-CONSTRAINTIGN: t/t_constraint_mode.v:43:17: rand_mode ignored (unsupported)
+   50 |       if (p.cons.constraint_mode() != 0) $stop;
+      |                  ^~~~~~~~~~~~~~~
+%Warning-CONSTRAINTIGN: t/t_constraint_mode.v:55:19: constraint_mode ignored (unsupported)
                                                    : ... note: In instance 't'
-   43 |       if (p.one.rand_mode() != 1) $stop;
-      |                 ^~~~~~~~~
-%Warning-CONSTRAINTIGN: t/t_constraint_mode.v:46:11: constraint_mode ignored (unsupported)
+   55 |       p.self.cons.constraint_mode(1);
+      |                   ^~~~~~~~~~~~~~~
+%Warning-CONSTRAINTIGN: t/t_constraint_mode.v:56:19: constraint_mode ignored (unsupported)
                                                    : ... note: In instance 't'
-   46 |       p.a.constraint_mode(1);
-      |           ^~~~~~~~~~~~~~~
-%Warning-CONSTRAINTIGN: t/t_constraint_mode.v:47:11: constraint_mode ignored (unsupported)
+   56 |       p.self.cons.constraint_mode(0);
+      |                   ^~~~~~~~~~~~~~~
+%Warning-CONSTRAINTIGN: t/t_constraint_mode.v:57:23: constraint_mode ignored (unsupported)
                                                    : ... note: In instance 't'
-   47 |       p.a.constraint_mode(0);
-      |           ^~~~~~~~~~~~~~~
-%Warning-CONSTRAINTIGN: t/t_constraint_mode.v:48:15: constraint_mode ignored (unsupported)
+   57 |       if (p.self.cons.constraint_mode() != 0) $stop;
+      |                       ^~~~~~~~~~~~~~~
+%Warning-CONSTRAINTIGN: t/t_constraint_mode.v:10:15: Constraint ignored (unsupported)
                                                    : ... note: In instance 't'
-   48 |       if (p.a.constraint_mode() != 0) $stop;
-      |               ^~~~~~~~~~~~~~~
+   10 |    constraint cons { m_one > 0 && m_one < 2; }
+      |               ^~~~
 %Error: Exiting due to

--- a/test_regress/t/t_constraint_xml.out
+++ b/test_regress/t/t_constraint_xml.out
@@ -1,0 +1,202 @@
+<?xml version="1.0" ?>
+<!-- DESCRIPTION: Verilator output: XML representation of netlist -->
+<verilator_xml>
+  <files>
+    <file id="a" filename="&lt;built-in&gt;" language="1800-2017"/>
+    <file id="b" filename="&lt;command-line&gt;" language="1800-2017"/>
+    <file id="c" filename="input.vc" language="1800-2017"/>
+    <file id="d" filename="t/t_constraint_xml.v" language="1800-2017"/>
+  </files>
+  <module_files>
+    <file id="d" filename="t/t_constraint_xml.v" language="1800-2017"/>
+  </module_files>
+  <cells>
+    <cell loc="d,53,8,53,9" name="t" submodname="t" hier="t"/>
+  </cells>
+  <netlist>
+    <module loc="d,53,8,53,9" name="t" origName="t">
+      <var loc="d,55,11,55,12" name="p" dtype_id="1" vartype="Packet" origName="p"/>
+      <initial loc="d,57,4,57,11">
+        <begin loc="d,57,12,57,17">
+          <display loc="d,59,7,59,13" displaytype="$write">
+            <sformatf loc="d,59,7,59,13" name="*-* All Finished *-*&#10;" dtype_id="2"/>
+          </display>
+          <finish loc="d,60,7,60,14"/>
+        </begin>
+      </initial>
+    </module>
+    <package loc="a,0,0,0,0" name="$unit" origName="__024unit">
+      <class loc="d,7,1,7,6" name="Packet" origName="Packet">
+        <var loc="d,8,13,8,19" name="header" dtype_id="3" vartype="int" origName="header"/>
+        <var loc="d,9,13,9,19" name="length" dtype_id="3" vartype="int" origName="length"/>
+        <var loc="d,10,13,10,22" name="sublength" dtype_id="3" vartype="int" origName="sublength"/>
+        <var loc="d,11,13,11,17" name="if_4" dtype_id="4" vartype="bit" origName="if_4"/>
+        <var loc="d,12,13,12,20" name="iff_5_6" dtype_id="4" vartype="bit" origName="iff_5_6"/>
+        <var loc="d,14,13,14,18" name="array" dtype_id="5" vartype="" origName="array"/>
+        <constraint loc="d,16,15,16,20" name="empty"/>
+        <constraint loc="d,18,15,18,19" name="size">
+          <constraintexpr loc="d,19,18,19,20">
+            <and loc="d,19,18,19,20" dtype_id="6">
+              <lts loc="d,19,14,19,15" dtype_id="6">
+                <const loc="d,19,16,19,17" name="32&apos;sh0" dtype_id="7"/>
+                <varref loc="d,19,7,19,13" name="header" dtype_id="3"/>
+              </lts>
+              <gtes loc="d,19,28,19,30" dtype_id="6">
+                <const loc="d,19,31,19,32" name="32&apos;sh7" dtype_id="7"/>
+                <varref loc="d,19,21,19,27" name="header" dtype_id="3"/>
+              </gtes>
+            </and>
+          </constraintexpr>
+          <constraintexpr loc="d,20,14,20,16">
+            <gtes loc="d,20,14,20,16" dtype_id="6">
+              <const loc="d,20,17,20,19" name="32&apos;shf" dtype_id="7"/>
+              <varref loc="d,20,7,20,13" name="length" dtype_id="3"/>
+            </gtes>
+          </constraintexpr>
+          <constraintexpr loc="d,21,14,21,16">
+            <gtes loc="d,21,14,21,16" dtype_id="6">
+              <varref loc="d,21,7,21,13" name="length" dtype_id="3"/>
+              <varref loc="d,21,17,21,23" name="header" dtype_id="3"/>
+            </gtes>
+          </constraintexpr>
+          <constraintexpr loc="d,22,7,22,13">
+            <varref loc="d,22,7,22,13" name="length" dtype_id="3"/>
+          </constraintexpr>
+        </constraint>
+        <constraint loc="d,25,15,25,18" name="ifs">
+          <if loc="d,26,7,26,9">
+            <lts loc="d,26,18,26,19" dtype_id="6">
+              <const loc="d,26,20,26,21" name="32&apos;sh4" dtype_id="7"/>
+              <varref loc="d,26,11,26,17" name="header" dtype_id="3"/>
+            </lts>
+            <begin>
+              <constraintexpr loc="d,27,15,27,17">
+                <varref loc="d,27,10,27,14" name="if_4" dtype_id="6"/>
+              </constraintexpr>
+            </begin>
+          </if>
+          <if loc="d,29,7,29,9">
+            <or loc="d,29,23,29,25" dtype_id="6">
+              <eq loc="d,29,18,29,20" dtype_id="6">
+                <const loc="d,29,21,29,22" name="32&apos;sh5" dtype_id="7"/>
+                <varref loc="d,29,11,29,17" name="header" dtype_id="3"/>
+              </eq>
+              <eq loc="d,29,33,29,35" dtype_id="6">
+                <const loc="d,29,36,29,37" name="32&apos;sh6" dtype_id="7"/>
+                <varref loc="d,29,26,29,32" name="header" dtype_id="3"/>
+              </eq>
+            </or>
+            <begin>
+              <constraintexpr loc="d,30,18,30,20">
+                <varref loc="d,30,10,30,17" name="iff_5_6" dtype_id="6"/>
+              </constraintexpr>
+            </begin>
+            <begin>
+              <constraintexpr loc="d,32,18,32,20">
+                <not loc="d,32,18,32,20" dtype_id="4">
+                  <varref loc="d,32,10,32,17" name="iff_5_6" dtype_id="4"/>
+                </not>
+              </constraintexpr>
+            </begin>
+          </if>
+        </constraint>
+        <constraint loc="d,36,15,36,23" name="arr_uniq">
+          <constraintforeach loc="d,37,7,37,14">
+            <selloopvars loc="d,37,21,37,22">
+              <varref loc="d,37,16,37,21" name="array" dtype_id="5"/>
+              <var loc="d,37,22,37,23" name="i" dtype_id="8" vartype="integer" origName="i"/>
+            </selloopvars>
+            <constraintexpr loc="d,38,19,38,25">
+              <or loc="d,38,19,38,25" dtype_id="6">
+                <or loc="d,38,19,38,25" dtype_id="6">
+                  <eqwild loc="d,38,27,38,28" dtype_id="6">
+                    <arraysel loc="d,38,15,38,16" dtype_id="3">
+                      <varref loc="d,38,10,38,15" name="array" dtype_id="5"/>
+                      <sel loc="d,38,16,38,17" dtype_id="9">
+                        <varref loc="d,38,16,38,17" name="i" dtype_id="8"/>
+                        <const loc="d,38,16,38,17" name="32&apos;h0" dtype_id="10"/>
+                        <const loc="d,38,16,38,17" name="32&apos;h1" dtype_id="10"/>
+                      </sel>
+                    </arraysel>
+                    <const loc="d,38,27,38,28" name="32&apos;sh2" dtype_id="7"/>
+                  </eqwild>
+                  <eqwild loc="d,38,30,38,31" dtype_id="6">
+                    <arraysel loc="d,38,15,38,16" dtype_id="3">
+                      <varref loc="d,38,10,38,15" name="array" dtype_id="5"/>
+                      <sel loc="d,38,16,38,17" dtype_id="9">
+                        <varref loc="d,38,16,38,17" name="i" dtype_id="8"/>
+                        <const loc="d,38,16,38,17" name="32&apos;h0" dtype_id="10"/>
+                        <const loc="d,38,16,38,17" name="32&apos;h1" dtype_id="10"/>
+                      </sel>
+                    </arraysel>
+                    <const loc="d,38,30,38,31" name="32&apos;sh4" dtype_id="7"/>
+                  </eqwild>
+                </or>
+                <eqwild loc="d,38,33,38,34" dtype_id="6">
+                  <arraysel loc="d,38,15,38,16" dtype_id="3">
+                    <varref loc="d,38,10,38,15" name="array" dtype_id="5"/>
+                    <sel loc="d,38,16,38,17" dtype_id="9">
+                      <varref loc="d,38,16,38,17" name="i" dtype_id="8"/>
+                      <const loc="d,38,16,38,17" name="32&apos;h0" dtype_id="10"/>
+                      <const loc="d,38,16,38,17" name="32&apos;h1" dtype_id="10"/>
+                    </sel>
+                  </arraysel>
+                  <const loc="d,38,33,38,34" name="32&apos;sh6" dtype_id="7"/>
+                </eqwild>
+              </or>
+            </constraintexpr>
+          </constraintforeach>
+          <constraintunique loc="d,40,7,40,13">
+            <arraysel loc="d,40,21,40,22" dtype_id="3">
+              <varref loc="d,40,16,40,21" name="array" dtype_id="5"/>
+              <const loc="d,40,22,40,23" name="1&apos;h0" dtype_id="9"/>
+            </arraysel>
+            <arraysel loc="d,40,31,40,32" dtype_id="3">
+              <varref loc="d,40,26,40,31" name="array" dtype_id="5"/>
+              <const loc="d,40,32,40,33" name="1&apos;h1" dtype_id="9"/>
+            </arraysel>
+          </constraintunique>
+        </constraint>
+        <constraint loc="d,43,15,43,20" name="order">
+          <constraintbefore loc="d,43,23,43,28">
+            <varref loc="d,43,29,43,35" name="length" dtype_id="3"/>
+            <varref loc="d,43,43,43,49" name="header" dtype_id="3"/>
+          </constraintbefore>
+        </constraint>
+        <constraint loc="d,45,15,45,18" name="dis">
+          <constraintexpr loc="d,46,7,46,11">
+            <varref loc="d,46,12,46,21" name="sublength" dtype_id="3"/>
+          </constraintexpr>
+          <constraintexpr loc="d,47,7,47,14">
+            <varref loc="d,47,20,47,29" name="sublength" dtype_id="3"/>
+          </constraintexpr>
+          <constraintexpr loc="d,48,17,48,19">
+            <ltes loc="d,48,17,48,19" dtype_id="6">
+              <varref loc="d,48,7,48,16" name="sublength" dtype_id="3"/>
+              <varref loc="d,48,20,48,26" name="length" dtype_id="3"/>
+            </ltes>
+          </constraintexpr>
+        </constraint>
+        <func loc="d,7,1,7,6" name="new" dtype_id="11"/>
+      </class>
+    </package>
+    <typetable loc="a,0,0,0,0">
+      <basicdtype loc="d,19,14,19,15" id="6" name="logic"/>
+      <basicdtype loc="d,22,21,22,22" id="10" name="logic" left="31" right="0"/>
+      <basicdtype loc="d,59,7,59,13" id="2" name="string"/>
+      <basicdtype loc="d,37,22,37,23" id="8" name="integer" left="31" right="0" signed="true"/>
+      <basicdtype loc="d,8,9,8,12" id="3" name="int" left="31" right="0" signed="true"/>
+      <basicdtype loc="d,11,9,11,12" id="4" name="bit"/>
+      <unpackarraydtype loc="d,14,18,14,19" id="5" sub_dtype_id="3">
+        <range loc="d,14,18,14,19">
+          <const loc="d,14,19,14,20" name="32&apos;h0" dtype_id="10"/>
+          <const loc="d,14,19,14,20" name="32&apos;h1" dtype_id="10"/>
+        </range>
+      </unpackarraydtype>
+      <basicdtype loc="d,29,18,29,20" id="9" name="logic" signed="true"/>
+      <voiddtype loc="d,7,1,7,6" id="11"/>
+      <classrefdtype loc="d,55,4,55,10" id="1" name="Packet"/>
+      <basicdtype loc="d,19,16,19,17" id="7" name="logic" left="31" right="0" signed="true"/>
+    </typetable>
+  </netlist>
+</verilator_xml>

--- a/test_regress/t/t_constraint_xml.pl
+++ b/test_regress/t/t_constraint_xml.pl
@@ -1,0 +1,25 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2019 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(vlt => 1);
+
+my $out_filename = "$Self->{obj_dir}/V$Self->{name}.xml";
+
+compile(
+    verilator_flags2 => ['--no-std', '--xml-only', '-Wno-CONSTRAINTIGN'],
+    verilator_make_gmake => 0,
+    make_top_shell => 0,
+    make_main => 0,
+    );
+
+files_identical($out_filename, $Self->{golden_filename});
+
+ok(1);
+1;

--- a/test_regress/t/t_constraint_xml.v
+++ b/test_regress/t/t_constraint_xml.v
@@ -55,15 +55,7 @@ module t (/*AUTOARG*/);
    Packet p;
 
    initial begin
-
-      int v;
-      // TODO not testing constrained values
-      v = p.randomize();
-      if (v != 1) $stop;
-      v = p.randomize() with {};
-      if (v != 1) $stop;
-      // TODO not testing other randomize forms as unused in UVM
-
+      // Not testing use of constraints
       $write("*-* All Finished *-*\n");
       $finish;
    end

--- a/test_regress/t/t_dist_warn_coverage.pl
+++ b/test_regress/t/t_dist_warn_coverage.pl
@@ -31,7 +31,6 @@ foreach my $s (
     'Unsupported: Ranges ignored in port-lists',  # Hard to hit
     'dynamic new() not expected in this context (expected under an assign)',  # Instead get syntax error
     # Not yet analyzed
-    ' is not an in/out/inout/param/interface: ',
     ' loading non-variable',
     '--pipe-filter protocol error, unexpected: ',
     '/*verilator sformat*/ can only be applied to last argument of ',

--- a/test_regress/t/t_foreach_nindex_bad.out
+++ b/test_regress/t/t_foreach_nindex_bad.out
@@ -1,4 +1,5 @@
 %Error: t/t_foreach_nindex_bad.v:12:34: foreach loop variables exceed number of indices of array
+                                      : ... note: In instance 't'
    12 |       foreach (array[i, j, badk, badl]);   
       |                                  ^~~~
 %Error: Exiting due to

--- a/test_regress/t/t_randomize.out
+++ b/test_regress/t/t_randomize.out
@@ -1,36 +1,31 @@
-%Error-UNSUPPORTED: t/t_randomize.v:11:4: Unsupported: extern constraint
-   11 |    extern constraint ex;
-      |    ^~~~~~
-                    ... For error description see https://verilator.org/warn/UNSUPPORTED?v=latest
-%Warning-CONSTRAINTIGN: t/t_randomize.v:13:4: Constraint ignored (unsupported)
-   13 |    constraint a { header > 0 && header < 1000; }
-      |    ^~~~~~~~~~
+%Warning-CONSTRAINTIGN: t/t_randomize.v:16:15: Constraint ignored (unsupported)
+                                             : ... note: In instance 't'
+   16 |    constraint empty {}
+      |               ^~~~~
+                        ... For warning description see https://verilator.org/warn/CONSTRAINTIGN?v=latest
                         ... Use "/* verilator lint_off CONSTRAINTIGN */" and lint_on around source to disable this message.
-%Warning-CONSTRAINTIGN: t/t_randomize.v:14:4: Constraint ignored (unsupported)
-   14 |    constraint b {
-      |    ^~~~~~~~~~
-%Warning-CONSTRAINTIGN: t/t_randomize.v:19:4: Constraint ignored (unsupported)
-   19 |    constraint c {
-      |    ^~~~~~~~~~
-%Warning-CONSTRAINTIGN: t/t_randomize.v:23:4: Constraint ignored (unsupported)
-   23 |    constraint d {
-      |    ^~~~~~~~~~
-%Error-UNSUPPORTED: t/t_randomize.v:29:29: Unsupported: solve before
-   29 |    constraint order { solve length before header; }
-      |                             ^~~~~~
-%Warning-CONSTRAINTIGN: t/t_randomize.v:29:4: Constraint ignored (unsupported)
-   29 |    constraint order { solve length before header; }
-      |    ^~~~~~~~~~
-%Error-UNSUPPORTED: t/t_randomize.v:32:9: Unsupported: dist
-   32 |       x dist { [100:102] :/ 1, 200 := 2, 300 := 5, 400};
-      |         ^~~~
-%Warning-CONSTRAINTIGN: t/t_randomize.v:30:4: Constraint ignored (unsupported)
-   30 |    constraint dis {
-      |    ^~~~~~~~~~
-%Error-UNSUPPORTED: t/t_randomize.v:37:1: Unsupported: extern constraint
-   37 | constraint Packet::ex { header > 0 };
-      | ^~~~~~~~~~
-%Error: t/t_randomize.v:37:23: syntax error, unexpected '{'
-   37 | constraint Packet::ex { header > 0 };
-      |                       ^
+%Warning-CONSTRAINTIGN: t/t_randomize.v:18:15: Constraint ignored (unsupported)
+                                             : ... note: In instance 't'
+   18 |    constraint size {
+      |               ^~~~
+%Warning-CONSTRAINTIGN: t/t_randomize.v:25:15: Constraint ignored (unsupported)
+                                             : ... note: In instance 't'
+   25 |    constraint ifs {
+      |               ^~~
+%Warning-CONSTRAINTIGN: t/t_randomize.v:36:15: Constraint ignored (unsupported)
+                                             : ... note: In instance 't'
+   36 |    constraint arr_uniq {
+      |               ^~~~~~~~
+%Warning-CONSTRAINTIGN: t/t_randomize.v:43:15: Constraint ignored (unsupported)
+                                             : ... note: In instance 't'
+   43 |    constraint order { solve length before header; }
+      |               ^~~~~
+%Warning-CONSTRAINTIGN: t/t_randomize.v:45:15: Constraint ignored (unsupported)
+                                             : ... note: In instance 't'
+   45 |    constraint dis {
+      |               ^~~
+%Error-UNSUPPORTED: t/t_randomize.v:14:13: Unsupported: random member variable with type 'int$[0:1]'
+                                         : ... note: In instance 't'
+   14 |    rand int array[2];   
+      |             ^~~~~
 %Error: Exiting due to

--- a/test_regress/t/t_randomize_extern.out
+++ b/test_regress/t/t_randomize_extern.out
@@ -1,0 +1,11 @@
+%Error-UNSUPPORTED: t/t_randomize_extern.v:8:4: Unsupported: pure constraint
+    8 |    pure constraint pur;
+      |    ^~~~
+                    ... For error description see https://verilator.org/warn/UNSUPPORTED?v=latest
+%Error-UNSUPPORTED: t/t_randomize_extern.v:17:4: Unsupported: extern constraint
+   17 |    extern constraint ex;
+      |    ^~~~~~
+%Error-UNSUPPORTED: t/t_randomize_extern.v:21:1: Unsupported: extern constraint
+   21 | constraint Packet::ex { header == 2; }
+      | ^~~~~~~~~~
+%Error: Exiting due to

--- a/test_regress/t/t_randomize_extern.pl
+++ b/test_regress/t/t_randomize_extern.pl
@@ -1,0 +1,19 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2019 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(vlt => 1);
+
+lint(
+    fails => 1,
+    expect_filename => $Self->{golden_filename},
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_randomize_extern.v
+++ b/test_regress/t/t_randomize_extern.v
@@ -1,0 +1,42 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2020 by Wilson Snyder.
+// SPDX-License-Identifier: CC0-1.0
+
+class Base;
+   pure constraint pur;
+endclass
+
+class Packet extends Base;
+   rand int header;
+   rand int length;
+
+   constraint pur { length == 3; }
+
+   extern constraint ex;
+
+endclass
+
+constraint Packet::ex { header == 2; }
+
+module t (/*AUTOARG*/);
+
+   Packet p;
+
+   initial begin
+
+      int v;
+      v = p.randomize();
+      if (v != 1) $stop;
+      if (p.header != 2) $stop;
+      if (p.length != 3) $stop;
+      v = p.randomize(1);
+      if (v != 1) $stop;
+      if (p.header != 2) $stop;
+      if (p.length != 3) $stop;
+
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end
+endmodule

--- a/test_regress/t/t_randomize_rand_mode.pl
+++ b/test_regress/t/t_randomize_rand_mode.pl
@@ -1,0 +1,23 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2019 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    verilator_flags2 => ['-Wno-CONSTRAINTIGN'],
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+
+ok(1);
+1;

--- a/test_regress/t/t_randomize_rand_mode.v
+++ b/test_regress/t/t_randomize_rand_mode.v
@@ -7,7 +7,7 @@
 class Packet;
    rand int m_one;
 
-   Packet self;
+   Packet other;
 
    task test1;
       // TODO Verilator ignores this setting currently, always returning 1 (rand on)

--- a/test_regress/t/t_randomize_rand_mode.v
+++ b/test_regress/t/t_randomize_rand_mode.v
@@ -1,0 +1,56 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2023 by Wilson Snyder.
+// SPDX-License-Identifier: CC0-1.0
+
+class Packet;
+   rand int m_one;
+
+   Packet self;
+
+   task test1;
+      // TODO Verilator ignores this setting currently, always returning 1 (rand on)
+      // TODO test that these control randomization as specified
+      m_one.rand_mode(0);
+      m_one.rand_mode(1);
+      if (m_one.rand_mode() != 1) $stop;
+   endtask
+
+endclass
+
+module t (/*AUTOARG*/);
+
+   Packet p;
+
+   int v;
+
+   initial begin
+      p = new;
+      v = p.randomize();
+      if (v != 1) $stop;
+`ifndef VERILATOR
+      if (p.m_one != 1) $stop;
+`endif
+
+      // IEEE: function void object[.random_variable].rand_mode(bit on_off);
+      // IEEE: function int object.random_variable.rand_mode();
+
+      // TODO Verilator ignores this setting currently, always returning 1 (rand on)
+      // TODO test that these control randomization as specified
+      p.rand_mode(0);
+      p.rand_mode(1);
+      // Not legal to get current rand() value on a class-only call
+
+      // TODO Verilator ignores this setting currently, always returning 1 (rand on)
+      // TODO test that these control randomization as specified
+      p.m_one.rand_mode(0);
+      p.m_one.rand_mode(1);
+      if (p.m_one.rand_mode() != 1) $stop;
+
+      // TODO test can't redefine rand_mode
+
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end
+endmodule

--- a/test_regress/t/t_randomize_rand_mode_warn_bad.out
+++ b/test_regress/t/t_randomize_rand_mode_warn_bad.out
@@ -1,0 +1,35 @@
+%Warning-CONSTRAINTIGN: t/t_randomize_rand_mode.v:15:13: rand_mode ignored (unsupported)
+                                                       : ... note: In instance 't'
+   15 |       m_one.rand_mode(0);
+      |             ^~~~~~~~~
+                        ... For warning description see https://verilator.org/warn/CONSTRAINTIGN?v=latest
+                        ... Use "/* verilator lint_off CONSTRAINTIGN */" and lint_on around source to disable this message.
+%Warning-CONSTRAINTIGN: t/t_randomize_rand_mode.v:16:13: rand_mode ignored (unsupported)
+                                                       : ... note: In instance 't'
+   16 |       m_one.rand_mode(1);
+      |             ^~~~~~~~~
+%Warning-CONSTRAINTIGN: t/t_randomize_rand_mode.v:17:17: rand_mode ignored (unsupported)
+                                                       : ... note: In instance 't'
+   17 |       if (m_one.rand_mode() != 1) $stop;
+      |                 ^~~~~~~~~
+%Warning-CONSTRAINTIGN: t/t_randomize_rand_mode.v:41:9: rand_mode ignored (unsupported)
+                                                      : ... note: In instance 't'
+   41 |       p.rand_mode(0);
+      |         ^~~~~~~~~
+%Warning-CONSTRAINTIGN: t/t_randomize_rand_mode.v:42:9: rand_mode ignored (unsupported)
+                                                      : ... note: In instance 't'
+   42 |       p.rand_mode(1);
+      |         ^~~~~~~~~
+%Warning-CONSTRAINTIGN: t/t_randomize_rand_mode.v:47:15: rand_mode ignored (unsupported)
+                                                       : ... note: In instance 't'
+   47 |       p.m_one.rand_mode(0);
+      |               ^~~~~~~~~
+%Warning-CONSTRAINTIGN: t/t_randomize_rand_mode.v:48:15: rand_mode ignored (unsupported)
+                                                       : ... note: In instance 't'
+   48 |       p.m_one.rand_mode(1);
+      |               ^~~~~~~~~
+%Warning-CONSTRAINTIGN: t/t_randomize_rand_mode.v:49:19: rand_mode ignored (unsupported)
+                                                       : ... note: In instance 't'
+   49 |       if (p.m_one.rand_mode() != 1) $stop;
+      |                   ^~~~~~~~~
+%Error: Exiting due to

--- a/test_regress/t/t_randomize_rand_mode_warn_bad.pl
+++ b/test_regress/t/t_randomize_rand_mode_warn_bad.pl
@@ -1,0 +1,21 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2019 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(vlt => 1);
+
+top_filename("t/t_randomize_rand_mode.v");
+
+lint(
+    fails => 1,
+    expect_filename => $Self->{golden_filename},
+    );
+
+ok(1);
+1;


### PR DESCRIPTION
This parses constraint blocks, and allows --xml-only to see all of the parsed elements.
As previously, constraints are otherwise still ignored and do not affect randomization.
