### PR TITLE
Fix output arguments of methods called in forks

### DIFF
--- a/src/V3LinkLValue.cpp
+++ b/src/V3LinkLValue.cpp
@@ -300,6 +300,13 @@ private:
             }
         }
     }
+    void visit(AstCMethodHard* nodep) override {
+        VL_RESTORER(m_setRefLvalue);
+        iterate(nodep->fromp());
+        m_setRefLvalue = VAccess::NOCHANGE;
+        // Arguments have access() assigned in V3Width
+        iterateAndNextNull(nodep->pinsp());
+    }
 
     void visit(AstNode* nodep) override { iterateChildren(nodep); }
 

--- a/src/Verilator.cpp
+++ b/src/Verilator.cpp
@@ -160,7 +160,6 @@ static void process() {
         //   This requires some width calculations and constant propagation
         V3Param::param(v3Global.rootp());
         V3LinkDot::linkDotParamed(v3Global.rootp());  // Cleanup as made new modules
-        V3LinkLValue::linkLValue(v3Global.rootp());  // Resolve new VarRefs
         V3Error::abortIfErrors();
 
         // Remove any modules that were parameterized and are no longer referenced.
@@ -186,6 +185,8 @@ static void process() {
 
         // Calculate and check widths, edit tree to TRUNC/EXTRACT any width mismatches
         V3Width::width(v3Global.rootp());
+
+        V3LinkLValue::linkLValue(v3Global.rootp());  // Resolve new VarRefs
 
         V3Error::abortIfErrors();
 

--- a/test_regress/t/t_fork_output_arg.pl
+++ b/test_regress/t/t_fork_output_arg.pl
@@ -1,0 +1,23 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2023 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    verilator_flags2 => ["--exe --main --timing"],
+    make_main => 0,
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_fork_output_arg.v
+++ b/test_regress/t/t_fork_output_arg.v
@@ -1,0 +1,26 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2023 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+class Cls;
+   int x = 100;
+   task get_x(output int arg);
+      arg = x;
+   endtask
+endclass
+
+module t();
+   Cls c = new;
+   initial begin
+      int o;
+      fork
+         c.get_x(o);
+      join_any
+      if (o != 100) $stop;
+
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end
+endmodule

--- a/test_regress/t/t_fork_output_arg.v
+++ b/test_regress/t/t_fork_output_arg.v
@@ -11,15 +11,18 @@ class Cls;
    endtask
 endclass
 
-module t();
+task automatic test;
+   int o;
    Cls c = new;
-   initial begin
-      int o;
-      fork
-         c.get_x(o);
-      join_any
-      if (o != 100) $stop;
+   fork
+      c.get_x(o);
+   join_any
+   if (o != 100) $stop;
+endtask
 
+module t();
+   initial begin
+      test();
       $write("*-* All Finished *-*\n");
       $finish;
    end


### PR DESCRIPTION
Currently on master, method calls with output arguments don't modify these arguments if they are inside `fork..join_any` and `fork..join_none` blocks. The problem happens, because Verilator sets wrong value to `access()` field of an argument. It marks a reference as `READ`, so the variable is passed to a fork by copy and the original variable isn't modified.

This PR fixes it by moving the 2nd pass of V3LinkLValue after V3Width. It is the earliest place where it can be done, because methods are linked in V3Width.