### PR TITLE
Fix conflicted namespace for coroutine (#4701)

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -79,6 +79,7 @@ Jesse Taube
 Jevin Sweval
 Jiacheng Qian
 Jiamin Zhu
+Jinyan Xu
 Jiuyang Liu
 Joey Liu
 John Coiner

--- a/src/V3Sched.cpp
+++ b/src/V3Sched.cpp
@@ -429,7 +429,7 @@ void orderSequentially(AstCFunc* funcp, const LogicByScope& lbs) {
                     if (procp->isSuspendable()) {
                         funcp->slow(false);
                         subFuncp = createNewSubFuncp(scopep);
-                        subFuncp->name(subFuncp->name() + "__" + cvtToStr(scopep->user2Inc()));
+                        subFuncp->name(subFuncp->name() + "__Vtiming__" + cvtToStr(scopep->user2Inc()));
                         subFuncp->rtnType("VlCoroutine");
                         if (VN_IS(procp, Always)) {
                             subFuncp->slow(false);

--- a/test_regress/t/t_timing_debug1.out
+++ b/test_regress/t/t_timing_debug1.out
@@ -6,13 +6,13 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_static
 -V{t#,#}+    Vt_timing_debug1___024root___eval_static__TOP
 -V{t#,#}+    Vt_timing_debug1___024root___eval_initial
--V{t#,#}+    Vt_timing_debug1___024root___eval_initial__TOP__0
+-V{t#,#}+    Vt_timing_debug1___024root___eval_initial__TOP__Vtiming__0
 -V{t#,#}         Suspending process waiting for @(posedge t.clk1) at t/t_timing_sched.v:18
--V{t#,#}+    Vt_timing_debug1___024root___eval_initial__TOP__1
+-V{t#,#}+    Vt_timing_debug1___024root___eval_initial__TOP__Vtiming__1
 -V{t#,#}         Suspending process waiting for @(posedge t.clk1) at t/t_timing_sched.v:17
--V{t#,#}+    Vt_timing_debug1___024root___eval_initial__TOP__2
+-V{t#,#}+    Vt_timing_debug1___024root___eval_initial__TOP__Vtiming__2
 -V{t#,#}         Suspending process waiting for @(posedge t.clk2) at t/t_timing_sched.v:50
--V{t#,#}+    Vt_timing_debug1___024root___eval_initial__TOP__3
+-V{t#,#}+    Vt_timing_debug1___024root___eval_initial__TOP__Vtiming__3
 -V{t#,#}+    Vt_timing_debug1___024root___eval_settle
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__stl
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__stl

--- a/test_regress/t/t_timing_debug2.out
+++ b/test_regress/t/t_timing_debug2.out
@@ -35,16 +35,16 @@
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aClkClass::new
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aClkClass::_ctor_var_reset
 -V{t#,#}+    Vt_timing_debug2___024root___eval_initial
--V{t#,#}+      Vt_timing_debug2_t___eval_initial__TOP__t__0
+-V{t#,#}+      Vt_timing_debug2_t___eval_initial__TOP__t__Vtiming__0
 -V{t#,#}         Suspending process waiting for @([event] t.ec.e) at t/t_timing_class.v:111
--V{t#,#}+      Vt_timing_debug2_t___eval_initial__TOP__t__1
--V{t#,#}+      Vt_timing_debug2_t___eval_initial__TOP__t__2
--V{t#,#}+      Vt_timing_debug2_t___eval_initial__TOP__t__3
--V{t#,#}+      Vt_timing_debug2_t___eval_initial__TOP__t__4
+-V{t#,#}+      Vt_timing_debug2_t___eval_initial__TOP__t__Vtiming__1
+-V{t#,#}+      Vt_timing_debug2_t___eval_initial__TOP__t__Vtiming__2
+-V{t#,#}+      Vt_timing_debug2_t___eval_initial__TOP__t__Vtiming__3
+-V{t#,#}+      Vt_timing_debug2_t___eval_initial__TOP__t__Vtiming__4
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aClkClass::__VnoInFunc_count_5
 -V{t#,#}         Suspending process waiting for @(posedge t::ClkClass.clk) at t/t_timing_class.v:97
--V{t#,#}+      Vt_timing_debug2_t___eval_initial__TOP__t__5
--V{t#,#}+      Vt_timing_debug2_t___eval_initial__TOP__t__6
+-V{t#,#}+      Vt_timing_debug2_t___eval_initial__TOP__t__Vtiming__5
+-V{t#,#}+      Vt_timing_debug2_t___eval_initial__TOP__t__Vtiming__6
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aDelayClass::new
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aDelayClass::_ctor_var_reset
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aDelay10::new
@@ -64,7 +64,7 @@
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aAssignDelayClass::new
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aAssignDelayClass::_ctor_var_reset
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aDelay10::__VnoInFunc_do_delay
--V{t#,#}+      Vt_timing_debug2_t___eval_initial__TOP__t__7
+-V{t#,#}+      Vt_timing_debug2_t___eval_initial__TOP__t__Vtiming__7
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aForkClass::new
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aForkClass::_ctor_var_reset
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aForkClass::__VnoInFunc_do_fork
@@ -74,8 +74,8 @@
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aForkClass::__VnoInFunc_do_fork____Vfork_1__1____Vfork_2__1
 -V{t#,#}             Awaiting join of fork at: t/t_timing_class.v:250
 -V{t#,#}             Awaiting join of fork at: t/t_timing_class.v:245
--V{t#,#}+      Vt_timing_debug2_t___eval_initial__TOP__t__8
--V{t#,#}+      Vt_timing_debug2_t___eval_initial__TOP__t__9
+-V{t#,#}+      Vt_timing_debug2_t___eval_initial__TOP__t__Vtiming__8
+-V{t#,#}+      Vt_timing_debug2_t___eval_initial__TOP__t__Vtiming__9
 -V{t#,#}+    Vt_timing_debug2___024root___eval_settle
 -V{t#,#}+ Eval
 -V{t#,#}+    Vt_timing_debug2___024root___eval
@@ -1041,7 +1041,7 @@
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aDelay40::__VnoInFunc_do_sth_else
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aNoDelay::__VnoInFunc_do_delay
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aNoDelay::__VnoInFunc_do_sth_else
--V{t#,#}+      Vt_timing_debug2_t___eval_initial__TOP__t__6____Vfork_1__0
+-V{t#,#}+      Vt_timing_debug2_t___eval_initial__TOP__t__Vtiming__6____Vfork_1__0
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aAssignDelayClass::__VnoInFunc_do_assign
 -V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:76
 -V{t#,#}             Process forked at t/t_timing_class.v:76 finished
@@ -1139,7 +1139,7 @@
 -V{t#,#}         Resuming delayed processes
 -V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:136
 -V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:190
--V{t#,#}+      Vt_timing_debug2_t___eval_initial__TOP__t__6____Vfork_2__0
+-V{t#,#}+      Vt_timing_debug2_t___eval_initial__TOP__t__Vtiming__6____Vfork_2__0
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aAssignDelayClass::__VnoInFunc_do_assign
 -V{t#,#}             Resuming: Process waiting at t/t_timing_class.v:131
 -V{t#,#}+        Vt_timing_debug2_t__03a__03aClkClass::__VnoInFunc_flip


### PR DESCRIPTION
Fix the conflicted namespace for coroutine from #4701
