### PR TITLE
Add JSON AST dumps

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -438,6 +438,7 @@ PY_PROGRAMS = \
 	src/cppcheck_filtered \
 	src/flexfix \
 	src/vlcovgen \
+	src/.gdbinit.py \
 	test_regress/t/*.pf \
 	nodist/clang_check_attributes \
 	nodist/code_coverage \

--- a/bin/verilator
+++ b/bin/verilator
@@ -347,10 +347,12 @@ detailed descriptions of these arguments.
     --dump-tree                 Enable dumping Ast .tree files
     --dump-tree-addrids         Use short identifiers instead of addresses
     --dump-tree-dot             Enable dumping Ast .tree.dot debug files
+    --dump-tree-json            Enable dumping Ast .tree.json files and .tree.meta.json file
     --dump-<srcfile>            Enable dumping everything in source file
     --dumpi-dfg <level>         Enable dumping DfgGraphs to .dot files at level
     --dumpi-graph <level>       Enable dumping V3Graphs to .dot files at level
     --dumpi-tree <level>        Enable dumping Ast .tree files at level
+    --dumpi-tree-json <level>   Enable dumping Ast .tree.json files at level
     --dumpi-<srcfile> <level>   Enable dumping everything in source file at level
      -E                         Preprocess, but do not compile
     --error-limit <value>       Abort after this number of errors

--- a/ci/ci-install.bash
+++ b/ci/ci-install.bash
@@ -92,8 +92,8 @@ elif [ "$CI_BUILD_STAGE_NAME" = "test" ]; then
     sudo apt-get update ||
     sudo apt-get update
     # libfl-dev needed for internal coverage's test runs
-    sudo apt-get install gdb gtkwave lcov libfl-dev ccache ||
-    sudo apt-get install gdb gtkwave lcov libfl-dev ccache
+    sudo apt-get install gdb gtkwave lcov libfl-dev ccache jq ||
+    sudo apt-get install gdb gtkwave lcov libfl-dev ccache jq
     # Required for test_regress/t/t_dist_attributes.pl
     if [ "$CI_RUNS_ON" = "ubuntu-22.04" ]; then
       sudo apt-get install python3-clang mold ||
@@ -106,10 +106,10 @@ elif [ "$CI_BUILD_STAGE_NAME" = "test" ]; then
   elif [ "$CI_OS_NAME" = "osx" ]; then
     brew update
     # brew cask install gtkwave # fst2vcd hangs at launch, so don't bother
-    brew install ccache perl
+    brew install ccache perl jq
   elif [ "$CI_OS_NAME" = "freebsd" ]; then
     # fst2vcd fails with "Could not open '<input file>', exiting."
-    sudo pkg install -y ccache gmake perl5 python3
+    sudo pkg install -y ccache gmake perl5 python3 jq
   else
     fatal "Unknown os: '$CI_OS_NAME'"
   fi
@@ -121,6 +121,9 @@ elif [ "$CI_BUILD_STAGE_NAME" = "test" ]; then
   install-vcddiff
   # Workaround -fsanitize=address crash
   sudo sysctl -w vm.mmap_rnd_bits=28
+
+  printf "add-auto-load-safe-path %s/test_regress/.gdbinit\n" "$PWD" >> ~/.gdbinit
+  PIP_BREAK_SYSTEM_PACKAGES=1 sudo pip install git+https://github.com/antmicro/astsee.git@f863e96b59fd996610df3fe071c05c5f441cf785
 else
   ##############################################################################
   # Unknown build stage

--- a/docs/guide/exe_verilator.rst
+++ b/docs/guide/exe_verilator.rst
@@ -413,6 +413,12 @@ Summary:
    :vlopt:`--debug --no-dump-tree <--dump-tree>` may be useful if the dump
    files are large and not desired.
 
+.. option:: --dump-tree-json
+
+   Rarely needed.  Enable dumping Ast .json.tree debug files with dumping level 3,
+   which dumps the standard critical stages.  For details on the format, see
+   the Verilator Internals manual.
+
 .. option:: --dump-tree-dot
 
    Rarely needed.  Enable dumping Ast .tree.dot debug files in Graphviz
@@ -446,6 +452,11 @@ Summary:
 .. option:: --dumpi-tree <level>
 
    Rarely needed - for developer use.  Set internal Ast dumping level
+   globally to the specified value.
+
+.. option:: --dumpi-tree-json <level>
+
+   Rarely needed - for developer use.  Set internal Ast JSON dumping level
    globally to the specified value.
 
 .. option:: --dumpi-<srcfile> <level>
@@ -1789,7 +1800,8 @@ Summary:
    format is still evolving; there will be some changes in future versions.
 
    This option disables some more aggressive transformations and dumps only
-   the final state of the AST.
+   the final state of the AST. For more granular and unaltered dumps, meant
+   mainly for debugging see :vlopt:`--dump-tree-json`.
 
 .. option:: --json-only-meta-output <filename>
 

--- a/docs/guide/install.rst
+++ b/docs/guide/install.rst
@@ -126,7 +126,7 @@ Those developing Verilator itself may also want these (see internals.rst):
 ::
 
    sudo apt-get install clang clang-format-14 cmake gdb gprof graphviz lcov
-   sudo apt-get install python3-clang yapf3 bear
+   sudo apt-get install python3-clang yapf3 bear jq
    sudo pip3 install sphinx sphinx_rtd_theme sphinxcontrib-spelling breathe ruff
    cpan install Pod::Perldoc
    cpan install Parallel::Forker

--- a/docs/guide/install.rst
+++ b/docs/guide/install.rst
@@ -128,6 +128,7 @@ Those developing Verilator itself may also want these (see internals.rst):
    sudo apt-get install clang clang-format-14 cmake gdb gprof graphviz lcov
    sudo apt-get install python3-clang yapf3 bear jq
    sudo pip3 install sphinx sphinx_rtd_theme sphinxcontrib-spelling breathe ruff
+   sudo pip3 install git+https://github.com/antmicro/astsee.git
    cpan install Pod::Perldoc
    cpan install Parallel::Forker
 

--- a/docs/internals.rst
+++ b/docs/internals.rst
@@ -1846,6 +1846,20 @@ To print a node:
    pnt nodep
    # or: call dumpTreeGdb(nodep)  # aliased to "pnt" in src/.gdbinit
 
+``src/.gdbinit`` and ``src/.gdbinit.py`` define handy utilities for working with
+JSON AST dumps. For example:
+
+* ``jstash nodep`` - Perform a JSON AST dump and save it into GDB value history (e.g. ``$1``)
+* ``jtree nodep`` - Perform a JSON AST dump and pretty print it using ``astsee_verilator``.
+* ``jtree $1`` - Pretty print a dump that was previously saved by ``jstash``.
+* ``jtree nodep -d '.file, .timeunit'`` - Perform a JSON AST dump, filter out some fields and pretty print it.
+* ``jtree 0x55555613dca0`` - Pretty print using address literal (rather than actual pointer).
+* ``jtree $1 nodep`` - Diff ``nodep`` against an older dump.
+
+A detailed description of ``jstash`` and ``jtree`` can be displayed using ``gdb``'s ``help`` command.
+
+These commands require `astsee <https://github.com/antmicro/astsee>`_ to be installed.
+
 When GDB halts, it is useful to understand that the backtrace will commonly
 show the iterator functions between each invocation of ``visit`` in the
 backtrace. You will typically see a frame sequence something like:

--- a/docs/internals.rst
+++ b/docs/internals.rst
@@ -1701,7 +1701,7 @@ Similarly, the ``NETLIST`` has a list of modules referred to by its
 
 ``.tree.json``` is an alternative dump format to ``.tree`` that is meant for
 programmatic processing (e.g. with `astsee <https://github.com/antmicro/astsee>`_).
-To enable this dump format, use :vlopt:`--json-only`.
+To enable this dump format, use :vlopt:`--dump-tree-json` or :vlopt:`--json-only`.
 
 Structure:
 ::
@@ -1743,8 +1743,8 @@ Structure:
 
 .tree.meta.json Output
 ----------------
-
-.tree.meta.json contains metadata that is common across the whole AST tree.
+.tree.meta.json contains metadata that is common across the whole AST tree
+(in case of --dump-tree-json, multiple trees share one meta file).
 
 Besides de-duplication of data shared between multiple stages, .meta.json enables offloading
 unstable data (that can vary from machine-to-machine or run-to-run) from main .tree.json.

--- a/src/.gdbinit
+++ b/src/.gdbinit
@@ -20,6 +20,26 @@ document pnt
   Verilator: Print AstNode NODEP's tree
 end
 
+# Source python-based gdb config with jshow/jdiff definitions
+# (Stored in separate file, so it can be highlighted/linted/formatted as Python)
+python
+import os
+if "VERILATOR_ROOT" in os.environ:
+  gdbinit_py = os.environ["VERILATOR_ROOT"] + "/src/.gdbinit.py"
+  gdb.execute("source" + gdbinit_py)
+end
+
+define jstash
+  call (char*) &(AstNode::dumpTreeJsonGdb($arg0)[0])
+end
+document jstash
+Verilator: Perform a JSON dump of the given AST node and save it in value history (e.g. $1) for later
+inspection using jtree. The node can be a pointer identifier or an address literal.
+end
+
+alias -a js=jstash
+alias -a jt=jtree
+
 define dtf
   call AstNode::dumpTreeFileGdb($arg0, 0)
 end

--- a/src/.gdbinit.py
+++ b/src/.gdbinit.py
@@ -1,0 +1,80 @@
+# pylint: disable=line-too-long,invalid-name,multiple-statements,missing-function-docstring,missing-class-docstring,missing-module-docstring,no-else-return,too-few-public-methods,unused-argument
+# DESCRIPTION: Verilator: GDB startup file with useful define
+#
+# Copyright 2023 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify the Verilator internals under the terms
+# of either the GNU Lesser General Public License Version 3 or the Perl
+# Artistic License Version 2.0.
+#
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+######################################################################
+
+import tempfile
+import gdb  # pylint: disable=import-error
+
+
+def _get_dump(node):
+    gdb.execute(f'set $_gdb_dump_json_str = AstNode::dumpTreeJsonGdb({node})')
+    dump = gdb.execute('printf "%s", $_gdb_dump_json_str', to_string=True)
+    gdb.execute('call free($_gdb_dump_json_str)')
+    return dump
+
+
+def _tmpfile():
+    return tempfile.NamedTemporaryFile(mode="wt")  # write, text mode
+
+
+def _fwrite(file, s):
+    """Write to file and flush buffer before passing the file to astsee"""
+    file.write(s)
+    file.flush()
+
+
+class AstseeCmd(gdb.Command):
+    """Verilator: Pretty print or diff nodes using `astsee`. A node can be:
+    * an pointer identifier,
+    * an address literal,
+    * a GDB value (like `$1`) that stores a dump previously done by the `jstash` command.
+    Apart from not taking input from a file, it works exactly like `verilator_astsee`:
+    * passing one node gives you a pretty print,
+    * passing two nodes gives you a diff,
+    * for more options see `astsee` readme/help.
+    For examples see internals.rst
+    """
+
+    def __init__(self):
+        super().__init__("jtree", gdb.COMMAND_USER, gdb.COMPLETE_EXPRESSION)
+
+    def _null_check(self, old, new):
+        err = ""
+        if old == "<nullptr>\n": err += "old == <nullptr>\n"
+        if new == "<nullptr>\n": err += "new == <nullptr>"
+        if err: raise gdb.GdbError(err.strip("\n"))
+
+    def invoke(self, arg_str, from_tty):
+        from astsee import verilator_cli as astsee  # pylint: disable=import-error,import-outside-toplevel
+        # we import it here so "no module X" error would occur on typing `jtree` rather than on every gdb start
+
+        # We hack `astsee_verilator`'s arg parser to find arguments with nodes
+        # After finding them, we replace them with proper files
+        astsee_args = astsee.parser.parse_args(gdb.string_to_argv(arg_str))
+        with _tmpfile() as oldfile, _tmpfile() as newfile, _tmpfile(
+        ) as metafile:
+            if astsee_args.file:
+                _fwrite(oldfile, _get_dump(astsee_args.file))
+                astsee_args.file = oldfile.name
+            if astsee_args.newfile:
+                _fwrite(newfile, _get_dump(astsee_args.newfile))
+                astsee_args.newfile = newfile.name
+            if astsee_args.meta is None:
+                # pass
+                gdb.execute(
+                    f'call AstNode::dumpJsonMetaFileGdb("{metafile.name}")')
+                astsee_args.meta = metafile.name
+            try:
+                astsee.main(astsee_args)
+            except SystemExit as e:  # astsee prints nice errmsgs on exit(), so rethrow it as GdbError to suppress cryptic python trace
+                raise gdb.GdbError("astsee exited with non-zero code") from e
+
+
+AstseeCmd()

--- a/src/V3Ast.cpp
+++ b/src/V3Ast.cpp
@@ -1199,6 +1199,23 @@ void AstNode::checkTreeIter(const AstNode* prevBackp) const VL_MT_STABLE {
 }
 
 // cppcheck-suppress unusedFunction  // Debug only
+char* AstNode::dumpTreeJsonGdb(const AstNode* nodep) {
+    if (!nodep) return strdup("{\"addr\":\"NULL\"}\n");
+    std::stringstream nodepStream;
+    nodep->dumpTreeJson(nodepStream);
+    const std::string str = nodepStream.rdbuf()->str();
+    return strdup(str.c_str());
+}
+// cppcheck-suppress unusedFunction  // Debug only
+// identity func to allow for passing already done dumps to jtree
+char* AstNode::dumpTreeJsonGdb(const char* str) { return strdup(str); }
+// cppcheck-suppress unusedFunction  // Debug only
+// allow for passing pointer literals like 0x42.. without manual cast
+char* AstNode::dumpTreeJsonGdb(intptr_t nodep) {
+    if (!nodep) return strdup("{\"addr\":\"NULL\"}\n");
+    return dumpTreeJsonGdb((const AstNode*)nodep);
+}
+// cppcheck-suppress unusedFunction  // Debug only
 void AstNode::dumpGdb(const AstNode* nodep) {  // For GDB only  // LCOV_EXCL_LINE
     if (!nodep) {
         cout << "<nullptr>" << endl;
@@ -1365,10 +1382,11 @@ void AstNode::dumpTreeJsonFile(const string& filename, bool doDump) {
     *treejsonp << '\n';
 }
 
+void AstNode::dumpJsonMetaFileGdb(const char* filename) { dumpJsonMetaFile(filename); }
 void AstNode::dumpJsonMetaFile(const string& filename) {
     UINFO(2, "Dumping " << filename << endl);
     const std::unique_ptr<std::ofstream> treejsonp{V3File::new_ofstream(filename)};
-    if (treejsonp->fail()) v3fatal("Can't write " << filename);
+    if (treejsonp->fail()) v3fatalStatic("Can't write " << filename);
     *treejsonp << '{';
     FileLine::fileNameNumMapDumpJson(*treejsonp);
     *treejsonp << ',';

--- a/src/V3Ast.cpp
+++ b/src/V3Ast.cpp
@@ -17,7 +17,6 @@
 #include "V3PchAstMT.h"
 
 #include "V3Broken.h"
-#include "V3EmitV.h"
 #include "V3File.h"
 
 #include <iomanip>
@@ -1318,7 +1317,7 @@ void AstNode::dumpTreeAndNext(std::ostream& os, const string& indent, int maxDep
     }
 }
 
-void AstNode::dumpTreeFile(const string& filename, bool doDump, bool doCheck) {
+void AstNode::dumpTreeFile(const string& filename, bool doDump) {
     // Not const function as calls checkTree
     if (doDump) {
         {  // Write log & close
@@ -1335,14 +1334,6 @@ void AstNode::dumpTreeFile(const string& filename, bool doDump, bool doCheck) {
                 editCountSetLast();  // Next dump can indicate start from here
             }
         }
-    }
-    if (doDump && v3Global.opt.debugEmitV()) V3EmitV::debugEmitV(filename + ".v");
-    if (doCheck && (v3Global.opt.debugCheck() || ::dumpTreeLevel())) {
-        // Error check
-        checkTree();
-        // Broken isn't part of check tree because it can munge iterp's
-        // set by other steps if it is called in the middle of other operations
-        if (AstNetlist* const netp = VN_CAST(this, Netlist)) V3Broken::brokenAll(netp);
     }
 }
 

--- a/src/V3Ast.h
+++ b/src/V3Ast.h
@@ -2158,6 +2158,9 @@ public:
     string warnOther() const VL_REQUIRES(V3Error::s().m_mutex) { return fileline()->warnOther(); }
 
     virtual void dump(std::ostream& str = std::cout) const;
+    static char* dumpTreeJsonGdb(const AstNode* nodep);  // For GDB only, free()d by caller
+    static char* dumpTreeJsonGdb(const char* str);  // For GDB only, free()d by caller
+    static char* dumpTreeJsonGdb(intptr_t nodep);  // For GDB only, free()d by caller
     static void dumpGdb(const AstNode* nodep);  // For GDB only
     void dumpGdbHeader() const;
 
@@ -2219,7 +2222,8 @@ public:
     virtual void dumpTreeJsonOpGen(std::ostream& os, const string& indent) const {};
     void dumpTreeJson(std::ostream& os, const string& indent = "") const;
     void dumpTreeJsonFile(const string& filename, bool doDump = true);
-    void dumpJsonMetaFile(const string& filename);
+    static void dumpJsonMetaFileGdb(const char* filename);
+    static void dumpJsonMetaFile(const string& filename);
 
     // Render node address for dumps. By default this is just the address
     // printed as hex, but with --dump-tree-addrids we map addresses to short

--- a/src/V3Ast.h
+++ b/src/V3Ast.h
@@ -2211,7 +2211,7 @@ public:
     static void dumpTreeGdb(const AstNode* nodep);  // For GDB only
     void dumpTreeAndNext(std::ostream& os = std::cout, const string& indent = "    ",
                          int maxDepth = 0) const;
-    void dumpTreeFile(const string& filename, bool doDump = true, bool doCheck = true);
+    void dumpTreeFile(const string& filename, bool doDump = true);
     static void dumpTreeFileGdb(const AstNode* nodep, const char* filenamep = nullptr);
     void dumpTreeDot(std::ostream& os = std::cout) const;
     void dumpTreeDotFile(const string& filename, bool doDump = true);

--- a/src/V3Error.cpp
+++ b/src/V3Error.cpp
@@ -221,11 +221,15 @@ void V3ErrorGuarded::v3errorEnd(std::ostringstream& sstr, const string& extra)
                     tellManual(2);
                 }
 #ifndef V3ERROR_NO_GLOBAL_
-                if (dumpTreeLevel() || debug()) {
+                if (dumpTreeLevel() || dumpTreeJsonLevel() || debug()) {
                     V3Broken::allowMidvisitorCheck(true);
                     const V3ThreadPool::ScopedExclusiveAccess exclusiveAccess;
                     if (dumpTreeLevel()) {
                         v3Global.rootp()->dumpTreeFile(v3Global.debugFilename("final.tree", 990));
+                    }
+                    if (dumpTreeJsonLevel()) {
+                        v3Global.rootp()->dumpTreeJsonFile(
+                            v3Global.debugFilename("final.tree.json", 990));
                     }
                     if (debug()) {
                         execErrorExitCb();

--- a/src/V3Error.h
+++ b/src/V3Error.h
@@ -685,7 +685,11 @@ void v3errorEndFatal(std::ostringstream& sstr)
     VL_DEFINE_DUMP(DfgLevel, "dfg"); /* Define 'int dumpDfgLevel()' for --dumpi-level */ \
     VL_DEFINE_DUMP(GraphLevel, "graph"); /* Define 'int dumpGraphLevel()' for dumpi-graph */ \
     VL_DEFINE_DUMP(TreeLevel, "tree"); /* Define 'int dumpTreeLevel()' for dumpi-tree */ \
-    VL_ATTR_UNUSED static int dumpTreeEitherLevel() { return dumpTreeLevel(); } \
+    VL_DEFINE_DUMP(TreeJsonLevel, \
+                   "tree-json"); /* Define 'int dumpTreeJsonLevel()' for dumpi-tree-json */ \
+    VL_ATTR_UNUSED static int dumpTreeEitherLevel() { \
+        return dumpTreeJsonLevel() >= dumpTreeLevel() ? dumpTreeJsonLevel() : dumpTreeLevel(); \
+    } \
     static_assert(true, "")
 
 //----------------------------------------------------------------------

--- a/src/V3Global.cpp
+++ b/src/V3Global.cpp
@@ -16,12 +16,15 @@
 
 #include "V3PchAstMT.h"
 
+#include "V3Error.h"
 #include "V3File.h"
 #include "V3HierBlock.h"
 #include "V3LinkCells.h"
 #include "V3Parse.h"
 #include "V3ParseSym.h"
 #include "V3Stats.h"
+
+VL_DEFINE_DEBUG_FUNCTIONS;
 
 //######################################################################
 // V3Global
@@ -106,7 +109,10 @@ string V3Global::digitsFilename(int number) {
 
 void V3Global::dumpCheckGlobalTree(const string& stagename, int newNumber, bool doDump) {
     const string treeFilename = v3Global.debugFilename(stagename + ".tree", newNumber);
-    v3Global.rootp()->dumpTreeFile(treeFilename, doDump);
+    if (dumpTreeLevel()) v3Global.rootp()->dumpTreeFile(treeFilename, doDump);
+    if (dumpTreeJsonLevel()) {
+        v3Global.rootp()->dumpTreeJsonFile(treeFilename + ".json", doDump);
+    }
     if (v3Global.opt.dumpTreeDot()) {
         v3Global.rootp()->dumpTreeDotFile(treeFilename + ".dot", doDump);
     }

--- a/src/V3Global.cpp
+++ b/src/V3Global.cpp
@@ -16,6 +16,9 @@
 
 #include "V3PchAstMT.h"
 
+#include "V3Global.h"
+
+#include "V3EmitV.h"
 #include "V3Error.h"
 #include "V3File.h"
 #include "V3HierBlock.h"
@@ -117,6 +120,15 @@ void V3Global::dumpCheckGlobalTree(const string& stagename, int newNumber, bool 
         v3Global.rootp()->dumpTreeDotFile(treeFilename + ".dot", doDump);
     }
     if (v3Global.opt.stats()) V3Stats::statsStage(stagename);
+
+    if (doDump && v3Global.opt.debugEmitV()) V3EmitV::debugEmitV(treeFilename + ".v");
+    if (v3Global.opt.debugCheck() || dumpTreeEitherLevel()) {
+        // Error check
+        v3Global.rootp()->checkTree();
+        // Broken isn't part of check tree because it can munge iterp's
+        // set by other steps if it is called in the middle of other operations
+        V3Broken::brokenAll(v3Global.rootp());
+    }
 }
 
 void V3Global::idPtrMapDumpJson(std::ostream& os) {

--- a/src/Verilator.cpp
+++ b/src/Verilator.cpp
@@ -700,7 +700,7 @@ static void verilate(const string& argString) {
 
     // Final steps
     V3Global::dumpCheckGlobalTree("final", 990, dumpTreeEitherLevel() >= 3);
-    if (v3Global.opt.jsonOnly()) {
+    if (v3Global.opt.jsonOnly() || dumpTreeJsonLevel()) {
         const string filename
             = (v3Global.opt.jsonOnlyMetaOutput().empty()
                    ? v3Global.opt.makeDir() + "/" + v3Global.opt.prefix() + ".tree.meta.json"

--- a/test_regress/t/t_dump_json.out
+++ b/test_regress/t/t_dump_json.out
@@ -1,0 +1,525 @@
+{"type":"NETLIST","name":"$root","addr":"(B)","loc":"a,0:0,0:0","timeunit":"1ps","timeprecision":"1ps","typeTablep":"(C)","constPoolp":"(D)","dollarUnitPkgp":"UNLINKED","stdPackagep":"UNLINKED","evalp":"UNLINKED","evalNbap":"UNLINKED","dpiExportTriggerp":"UNLINKED","delaySchedulerp":"UNLINKED","nbaEventp":"UNLINKED","nbaEventTriggerp":"UNLINKED","topScopep":"UNLINKED",
+ "modulesp": [
+  {"type":"MODULE","name":"t","addr":"(E)","loc":"d,19:8,19:9","origName":"t","level":2,"modPublic":false,"inLibrary":false,"dead":false,"recursiveClone":false,"recursive":false,"timeunit":"1ps","inlinesp": [],
+   "stmtsp": [
+    {"type":"PORT","name":"clk","addr":"(F)","loc":"d,21:4,21:7","exprp": []},
+    {"type":"VAR","name":"clk","addr":"(G)","loc":"d,23:10,23:13","dtypep":"UNLINKED","origName":"clk","isSc":false,"isPrimaryIO":false,"direction":"INPUT","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"attrClocker":"UNKNOWN","lifetime":"NONE","varType":"PORT","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"sensIfacep":"UNLINKED",
+     "childDTypep": [
+      {"type":"BASICDTYPE","name":"LOGIC_IMPLICIT","addr":"(H)","loc":"d,23:10,23:13","dtypep":"(H)","keyword":"LOGIC_IMPLICIT","generic":false,"rangep": []}
+    ],"delayp": [],"valuep": [],"attrsp": []},
+    {"type":"VAR","name":"cyc","addr":"(I)","loc":"d,25:12,25:15","dtypep":"UNLINKED","origName":"cyc","isSc":false,"isPrimaryIO":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"attrClocker":"UNKNOWN","lifetime":"NONE","varType":"VAR","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"sensIfacep":"UNLINKED",
+     "childDTypep": [
+      {"type":"BASICDTYPE","name":"integer","addr":"(J)","loc":"d,25:4,25:11","dtypep":"(J)","keyword":"integer","range":"31:0","generic":false,"rangep": []}
+    ],"delayp": [],
+     "valuep": [
+      {"type":"CONST","name":"?32?sh0","addr":"(K)","loc":"d,25:18,25:19","dtypep":"(L)"}
+    ],"attrsp": []},
+    {"type":"VAR","name":"crc","addr":"(M)","loc":"d,26:15,26:18","dtypep":"UNLINKED","origName":"crc","isSc":false,"isPrimaryIO":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"attrClocker":"UNKNOWN","lifetime":"NONE","varType":"VAR","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"sensIfacep":"UNLINKED",
+     "childDTypep": [
+      {"type":"BASICDTYPE","name":"logic","addr":"(N)","loc":"d,26:4,26:7","dtypep":"(N)","keyword":"logic","generic":false,
+       "rangep": [
+        {"type":"RANGE","name":"","addr":"(O)","loc":"d,26:8,26:9","ascending":false,
+         "leftp": [
+          {"type":"CONST","name":"?32?sh3f","addr":"(P)","loc":"d,26:9,26:11","dtypep":"(Q)"}
+        ],
+         "rightp": [
+          {"type":"CONST","name":"?32?sh0","addr":"(R)","loc":"d,26:12,26:13","dtypep":"(L)"}
+        ]}
+      ]}
+    ],"delayp": [],"valuep": [],"attrsp": []},
+    {"type":"VAR","name":"sum","addr":"(S)","loc":"d,27:15,27:18","dtypep":"UNLINKED","origName":"sum","isSc":false,"isPrimaryIO":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"attrClocker":"UNKNOWN","lifetime":"NONE","varType":"VAR","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"sensIfacep":"UNLINKED",
+     "childDTypep": [
+      {"type":"BASICDTYPE","name":"logic","addr":"(T)","loc":"d,27:4,27:7","dtypep":"(T)","keyword":"logic","generic":false,
+       "rangep": [
+        {"type":"RANGE","name":"","addr":"(U)","loc":"d,27:8,27:9","ascending":false,
+         "leftp": [
+          {"type":"CONST","name":"?32?sh3f","addr":"(V)","loc":"d,27:9,27:11","dtypep":"(Q)"}
+        ],
+         "rightp": [
+          {"type":"CONST","name":"?32?sh0","addr":"(W)","loc":"d,27:12,27:13","dtypep":"(L)"}
+        ]}
+      ]}
+    ],"delayp": [],"valuep": [],"attrsp": []},
+    {"type":"VAR","name":"in","addr":"(X)","loc":"d,30:16,30:18","dtypep":"UNLINKED","origName":"in","isSc":false,"isPrimaryIO":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"attrClocker":"UNKNOWN","lifetime":"NONE","varType":"WIRE","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"sensIfacep":"UNLINKED",
+     "childDTypep": [
+      {"type":"BASICDTYPE","name":"logic","addr":"(Y)","loc":"d,30:9,30:10","dtypep":"(Y)","keyword":"logic","generic":false,
+       "rangep": [
+        {"type":"RANGE","name":"","addr":"(Z)","loc":"d,30:9,30:10","ascending":false,
+         "leftp": [
+          {"type":"CONST","name":"?32?sh1f","addr":"(AB)","loc":"d,30:10,30:12","dtypep":"(BB)"}
+        ],
+         "rightp": [
+          {"type":"CONST","name":"?32?sh0","addr":"(CB)","loc":"d,30:13,30:14","dtypep":"(L)"}
+        ]}
+      ]}
+    ],"delayp": [],"valuep": [],"attrsp": []},
+    {"type":"ASSIGNW","name":"","addr":"(DB)","loc":"d,30:19,30:20","dtypep":"UNLINKED",
+     "rhsp": [
+      {"type":"SELEXTRACT","name":"","addr":"(EB)","loc":"d,30:24,30:25","dtypep":"UNLINKED",
+       "fromp": [
+        {"type":"PARSEREF","name":"crc","addr":"(FB)","loc":"d,30:21,30:24","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+      ],
+       "leftp": [
+        {"type":"CONST","name":"?32?sh1f","addr":"(GB)","loc":"d,30:25,30:27","dtypep":"(BB)"}
+      ],
+       "rightp": [
+        {"type":"CONST","name":"?32?sh0","addr":"(HB)","loc":"d,30:28,30:29","dtypep":"(L)"}
+      ],"attrp": []}
+    ],
+     "lhsp": [
+      {"type":"PARSEREF","name":"in","addr":"(IB)","loc":"d,30:16,30:18","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+    ],"timingControlp": [],"strengthSpecp": []},
+    {"type":"VAR","name":"out","addr":"(JB)","loc":"d,34:25,34:28","dtypep":"UNLINKED","origName":"out","isSc":false,"isPrimaryIO":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"attrClocker":"UNKNOWN","lifetime":"NONE","varType":"WIRE","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"sensIfacep":"UNLINKED",
+     "childDTypep": [
+      {"type":"BASICDTYPE","name":"logic","addr":"(KB)","loc":"d,34:9,34:10","dtypep":"(KB)","keyword":"logic","generic":false,
+       "rangep": [
+        {"type":"RANGE","name":"","addr":"(LB)","loc":"d,34:9,34:10","ascending":false,
+         "leftp": [
+          {"type":"CONST","name":"?32?sh1f","addr":"(MB)","loc":"d,34:10,34:12","dtypep":"(BB)"}
+        ],
+         "rightp": [
+          {"type":"CONST","name":"?32?sh0","addr":"(NB)","loc":"d,34:13,34:14","dtypep":"(L)"}
+        ]}
+      ]}
+    ],"delayp": [],"valuep": [],"attrsp": []},
+    {"type":"CELL","name":"test","addr":"(OB)","loc":"d,37:9,37:13","origName":"test","recursive":false,"modp":"(PB)",
+     "pinsp": [
+      {"type":"PIN","name":"out","addr":"(QB)","loc":"d,39:15,39:18","svDotName":true,"svImplicit":false,"modVarp":"UNLINKED","modPTypep":"UNLINKED",
+       "exprp": [
+        {"type":"SELEXTRACT","name":"","addr":"(RB)","loc":"d,39:45,39:46","dtypep":"UNLINKED",
+         "fromp": [
+          {"type":"PARSEREF","name":"out","addr":"(SB)","loc":"d,39:42,39:45","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+        ],
+         "leftp": [
+          {"type":"CONST","name":"?32?sh1f","addr":"(TB)","loc":"d,39:46,39:48","dtypep":"(BB)"}
+        ],
+         "rightp": [
+          {"type":"CONST","name":"?32?sh0","addr":"(UB)","loc":"d,39:49,39:50","dtypep":"(L)"}
+        ],"attrp": []}
+      ]},
+      {"type":"PIN","name":"clk","addr":"(VB)","loc":"d,41:15,41:18","svDotName":true,"svImplicit":false,"modVarp":"UNLINKED","modPTypep":"UNLINKED",
+       "exprp": [
+        {"type":"PARSEREF","name":"clk","addr":"(WB)","loc":"d,41:42,41:45","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+      ]},
+      {"type":"PIN","name":"in","addr":"(XB)","loc":"d,42:15,42:17","svDotName":true,"svImplicit":false,"modVarp":"UNLINKED","modPTypep":"UNLINKED",
+       "exprp": [
+        {"type":"SELEXTRACT","name":"","addr":"(YB)","loc":"d,42:44,42:45","dtypep":"UNLINKED",
+         "fromp": [
+          {"type":"PARSEREF","name":"in","addr":"(ZB)","loc":"d,42:42,42:44","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+        ],
+         "leftp": [
+          {"type":"CONST","name":"?32?sh1f","addr":"(AC)","loc":"d,42:45,42:47","dtypep":"(BB)"}
+        ],
+         "rightp": [
+          {"type":"CONST","name":"?32?sh0","addr":"(BC)","loc":"d,42:48,42:49","dtypep":"(L)"}
+        ],"attrp": []}
+      ]}
+    ],"paramsp": [],"rangep": [],"intfRefsp": []},
+    {"type":"VAR","name":"result","addr":"(CC)","loc":"d,45:16,45:22","dtypep":"UNLINKED","origName":"result","isSc":false,"isPrimaryIO":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"attrClocker":"UNKNOWN","lifetime":"NONE","varType":"WIRE","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"sensIfacep":"UNLINKED",
+     "childDTypep": [
+      {"type":"BASICDTYPE","name":"logic","addr":"(DC)","loc":"d,45:9,45:10","dtypep":"(DC)","keyword":"logic","generic":false,
+       "rangep": [
+        {"type":"RANGE","name":"","addr":"(EC)","loc":"d,45:9,45:10","ascending":false,
+         "leftp": [
+          {"type":"CONST","name":"?32?sh3f","addr":"(FC)","loc":"d,45:10,45:12","dtypep":"(Q)"}
+        ],
+         "rightp": [
+          {"type":"CONST","name":"?32?sh0","addr":"(GC)","loc":"d,45:13,45:14","dtypep":"(L)"}
+        ]}
+      ]}
+    ],"delayp": [],"valuep": [],"attrsp": []},
+    {"type":"ASSIGNW","name":"","addr":"(HC)","loc":"d,45:23,45:24","dtypep":"UNLINKED",
+     "rhsp": [
+      {"type":"REPLICATE","name":"","addr":"(IC)","loc":"d,45:25,45:26","dtypep":"(JC)",
+       "srcp": [
+        {"type":"CONCAT","name":"","addr":"(KC)","loc":"d,45:31,45:32","dtypep":"UNLINKED",
+         "lhsp": [
+          {"type":"CONST","name":"32'h0","addr":"(LC)","loc":"d,45:26,45:31","dtypep":"(MC)"}
+        ],
+         "rhsp": [
+          {"type":"PARSEREF","name":"out","addr":"(NC)","loc":"d,45:33,45:36","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+        ]}
+      ],
+       "countp": [
+        {"type":"CONST","name":"32'h1","addr":"(OC)","loc":"d,45:25,45:26","dtypep":"(MC)"}
+      ]}
+    ],
+     "lhsp": [
+      {"type":"PARSEREF","name":"result","addr":"(PC)","loc":"d,45:16,45:22","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+    ],"timingControlp": [],"strengthSpecp": []},
+    {"type":"ALWAYS","name":"","addr":"(QC)","loc":"d,48:4,48:10","keyword":"always","isSuspendable":false,"needProcess":false,"sensesp": [],
+     "stmtsp": [
+      {"type":"EVENTCONTROL","name":"","addr":"(RC)","loc":"d,48:11,48:12",
+       "sensesp": [
+        {"type":"SENTREE","name":"","addr":"(SC)","loc":"d,48:11,48:12","isMulti":false,
+         "sensesp": [
+          {"type":"SENITEM","name":"","addr":"(TC)","loc":"d,48:14,48:21","edgeType":"POS",
+           "sensp": [
+            {"type":"PARSEREF","name":"clk","addr":"(UC)","loc":"d,48:22,48:25","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+          ],"condp": []}
+        ]}
+      ],
+       "stmtsp": [
+        {"type":"BEGIN","name":"","addr":"(VC)","loc":"d,48:27,48:32","generate":false,"genfor":false,"implied":false,"needProcess":false,"unnamed":true,"genforp": [],
+         "stmtsp": [
+          {"type":"ASSIGNDLY","name":"","addr":"(WC)","loc":"d,52:11,52:13","dtypep":"UNLINKED",
+           "rhsp": [
+            {"type":"ADD","name":"","addr":"(XC)","loc":"d,52:18,52:19","dtypep":"UNLINKED",
+             "lhsp": [
+              {"type":"PARSEREF","name":"cyc","addr":"(YC)","loc":"d,52:14,52:17","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+            ],
+             "rhsp": [
+              {"type":"CONST","name":"?32?sh1","addr":"(ZC)","loc":"d,52:20,52:21","dtypep":"(L)"}
+            ]}
+          ],
+           "lhsp": [
+            {"type":"PARSEREF","name":"cyc","addr":"(AD)","loc":"d,52:7,52:10","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+          ],"timingControlp": []},
+          {"type":"ASSIGNDLY","name":"","addr":"(BD)","loc":"d,53:11,53:13","dtypep":"UNLINKED",
+           "rhsp": [
+            {"type":"REPLICATE","name":"","addr":"(CD)","loc":"d,53:14,53:15","dtypep":"(JC)",
+             "srcp": [
+              {"type":"CONCAT","name":"","addr":"(DD)","loc":"d,53:24,53:25","dtypep":"UNLINKED",
+               "lhsp": [
+                {"type":"SELEXTRACT","name":"","addr":"(ED)","loc":"d,53:18,53:19","dtypep":"UNLINKED",
+                 "fromp": [
+                  {"type":"PARSEREF","name":"crc","addr":"(FD)","loc":"d,53:15,53:18","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+                ],
+                 "leftp": [
+                  {"type":"CONST","name":"?32?sh3e","addr":"(GD)","loc":"d,53:19,53:21","dtypep":"(Q)"}
+                ],
+                 "rightp": [
+                  {"type":"CONST","name":"?32?sh0","addr":"(HD)","loc":"d,53:22,53:23","dtypep":"(L)"}
+                ],"attrp": []}
+              ],
+               "rhsp": [
+                {"type":"XOR","name":"","addr":"(ID)","loc":"d,53:43,53:44","dtypep":"UNLINKED",
+                 "lhsp": [
+                  {"type":"XOR","name":"","addr":"(JD)","loc":"d,53:34,53:35","dtypep":"UNLINKED",
+                   "lhsp": [
+                    {"type":"SELBIT","name":"","addr":"(KD)","loc":"d,53:29,53:30","dtypep":"UNLINKED",
+                     "fromp": [
+                      {"type":"PARSEREF","name":"crc","addr":"(LD)","loc":"d,53:26,53:29","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+                    ],
+                     "bitp": [
+                      {"type":"CONST","name":"?32?sh3f","addr":"(MD)","loc":"d,53:30,53:32","dtypep":"(Q)"}
+                    ],"thsp": [],"attrp": []}
+                  ],
+                   "rhsp": [
+                    {"type":"SELBIT","name":"","addr":"(ND)","loc":"d,53:39,53:40","dtypep":"UNLINKED",
+                     "fromp": [
+                      {"type":"PARSEREF","name":"crc","addr":"(OD)","loc":"d,53:36,53:39","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+                    ],
+                     "bitp": [
+                      {"type":"CONST","name":"?32?sh2","addr":"(PD)","loc":"d,53:40,53:41","dtypep":"(QD)"}
+                    ],"thsp": [],"attrp": []}
+                  ]}
+                ],
+                 "rhsp": [
+                  {"type":"SELBIT","name":"","addr":"(RD)","loc":"d,53:48,53:49","dtypep":"UNLINKED",
+                   "fromp": [
+                    {"type":"PARSEREF","name":"crc","addr":"(SD)","loc":"d,53:45,53:48","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+                  ],
+                   "bitp": [
+                    {"type":"CONST","name":"?32?sh0","addr":"(TD)","loc":"d,53:49,53:50","dtypep":"(L)"}
+                  ],"thsp": [],"attrp": []}
+                ]}
+              ]}
+            ],
+             "countp": [
+              {"type":"CONST","name":"32'h1","addr":"(UD)","loc":"d,53:14,53:15","dtypep":"(MC)"}
+            ]}
+          ],
+           "lhsp": [
+            {"type":"PARSEREF","name":"crc","addr":"(VD)","loc":"d,53:7,53:10","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+          ],"timingControlp": []},
+          {"type":"ASSIGNDLY","name":"","addr":"(WD)","loc":"d,54:11,54:13","dtypep":"UNLINKED",
+           "rhsp": [
+            {"type":"XOR","name":"","addr":"(XD)","loc":"d,54:21,54:22","dtypep":"UNLINKED",
+             "lhsp": [
+              {"type":"PARSEREF","name":"result","addr":"(YD)","loc":"d,54:14,54:20","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+            ],
+             "rhsp": [
+              {"type":"REPLICATE","name":"","addr":"(ZD)","loc":"d,54:23,54:24","dtypep":"(JC)",
+               "srcp": [
+                {"type":"CONCAT","name":"","addr":"(AE)","loc":"d,54:33,54:34","dtypep":"UNLINKED",
+                 "lhsp": [
+                  {"type":"SELEXTRACT","name":"","addr":"(BE)","loc":"d,54:27,54:28","dtypep":"UNLINKED",
+                   "fromp": [
+                    {"type":"PARSEREF","name":"sum","addr":"(CE)","loc":"d,54:24,54:27","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+                  ],
+                   "leftp": [
+                    {"type":"CONST","name":"?32?sh3e","addr":"(DE)","loc":"d,54:28,54:30","dtypep":"(Q)"}
+                  ],
+                   "rightp": [
+                    {"type":"CONST","name":"?32?sh0","addr":"(EE)","loc":"d,54:31,54:32","dtypep":"(L)"}
+                  ],"attrp": []}
+                ],
+                 "rhsp": [
+                  {"type":"XOR","name":"","addr":"(FE)","loc":"d,54:52,54:53","dtypep":"UNLINKED",
+                   "lhsp": [
+                    {"type":"XOR","name":"","addr":"(GE)","loc":"d,54:43,54:44","dtypep":"UNLINKED",
+                     "lhsp": [
+                      {"type":"SELBIT","name":"","addr":"(HE)","loc":"d,54:38,54:39","dtypep":"UNLINKED",
+                       "fromp": [
+                        {"type":"PARSEREF","name":"sum","addr":"(IE)","loc":"d,54:35,54:38","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+                      ],
+                       "bitp": [
+                        {"type":"CONST","name":"?32?sh3f","addr":"(JE)","loc":"d,54:39,54:41","dtypep":"(Q)"}
+                      ],"thsp": [],"attrp": []}
+                    ],
+                     "rhsp": [
+                      {"type":"SELBIT","name":"","addr":"(KE)","loc":"d,54:48,54:49","dtypep":"UNLINKED",
+                       "fromp": [
+                        {"type":"PARSEREF","name":"sum","addr":"(LE)","loc":"d,54:45,54:48","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+                      ],
+                       "bitp": [
+                        {"type":"CONST","name":"?32?sh2","addr":"(ME)","loc":"d,54:49,54:50","dtypep":"(QD)"}
+                      ],"thsp": [],"attrp": []}
+                    ]}
+                  ],
+                   "rhsp": [
+                    {"type":"SELBIT","name":"","addr":"(NE)","loc":"d,54:57,54:58","dtypep":"UNLINKED",
+                     "fromp": [
+                      {"type":"PARSEREF","name":"sum","addr":"(OE)","loc":"d,54:54,54:57","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+                    ],
+                     "bitp": [
+                      {"type":"CONST","name":"?32?sh0","addr":"(PE)","loc":"d,54:58,54:59","dtypep":"(L)"}
+                    ],"thsp": [],"attrp": []}
+                  ]}
+                ]}
+              ],
+               "countp": [
+                {"type":"CONST","name":"32'h1","addr":"(QE)","loc":"d,54:23,54:24","dtypep":"(MC)"}
+              ]}
+            ]}
+          ],
+           "lhsp": [
+            {"type":"PARSEREF","name":"sum","addr":"(RE)","loc":"d,54:7,54:10","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+          ],"timingControlp": []},
+          {"type":"IF","name":"","addr":"(SE)","loc":"d,55:7,55:9",
+           "condp": [
+            {"type":"EQ","name":"","addr":"(TE)","loc":"d,55:15,55:17","dtypep":"(UE)",
+             "lhsp": [
+              {"type":"PARSEREF","name":"cyc","addr":"(VE)","loc":"d,55:11,55:14","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+            ],
+             "rhsp": [
+              {"type":"CONST","name":"?32?sh0","addr":"(WE)","loc":"d,55:18,55:19","dtypep":"(L)"}
+            ]}
+          ],
+           "thensp": [
+            {"type":"BEGIN","name":"","addr":"(XE)","loc":"d,55:21,55:26","generate":false,"genfor":false,"implied":false,"needProcess":false,"unnamed":true,"genforp": [],
+             "stmtsp": [
+              {"type":"ASSIGNDLY","name":"","addr":"(YE)","loc":"d,57:14,57:16","dtypep":"UNLINKED",
+               "rhsp": [
+                {"type":"CONST","name":"64'h5aef0c8dd70a4497","addr":"(ZE)","loc":"d,57:17,57:38","dtypep":"(AF)"}
+              ],
+               "lhsp": [
+                {"type":"PARSEREF","name":"crc","addr":"(BF)","loc":"d,57:10,57:13","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+              ],"timingControlp": []},
+              {"type":"ASSIGNDLY","name":"","addr":"(CF)","loc":"d,58:14,58:16","dtypep":"UNLINKED",
+               "rhsp": [
+                {"type":"CONST","name":"'0","addr":"(DF)","loc":"d,58:17,58:19","dtypep":"(UE)"}
+              ],
+               "lhsp": [
+                {"type":"PARSEREF","name":"sum","addr":"(EF)","loc":"d,58:10,58:13","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+              ],"timingControlp": []}
+            ]}
+          ],
+           "elsesp": [
+            {"type":"IF","name":"","addr":"(FF)","loc":"d,60:12,60:14",
+             "condp": [
+              {"type":"LT","name":"","addr":"(GF)","loc":"d,60:20,60:21","dtypep":"(UE)",
+               "lhsp": [
+                {"type":"PARSEREF","name":"cyc","addr":"(HF)","loc":"d,60:16,60:19","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+              ],
+               "rhsp": [
+                {"type":"CONST","name":"?32?sha","addr":"(IF)","loc":"d,60:22,60:24","dtypep":"(JF)"}
+              ]}
+            ],
+             "thensp": [
+              {"type":"BEGIN","name":"","addr":"(KF)","loc":"d,60:26,60:31","generate":false,"genfor":false,"implied":false,"needProcess":false,"unnamed":true,"genforp": [],
+               "stmtsp": [
+                {"type":"ASSIGNDLY","name":"","addr":"(LF)","loc":"d,61:14,61:16","dtypep":"UNLINKED",
+                 "rhsp": [
+                  {"type":"CONST","name":"'0","addr":"(MF)","loc":"d,61:17,61:19","dtypep":"(UE)"}
+                ],
+                 "lhsp": [
+                  {"type":"PARSEREF","name":"sum","addr":"(NF)","loc":"d,61:10,61:13","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+                ],"timingControlp": []}
+              ]}
+            ],
+             "elsesp": [
+              {"type":"IF","name":"","addr":"(OF)","loc":"d,63:12,63:14",
+               "condp": [
+                {"type":"LT","name":"","addr":"(PF)","loc":"d,63:20,63:21","dtypep":"(UE)",
+                 "lhsp": [
+                  {"type":"PARSEREF","name":"cyc","addr":"(QF)","loc":"d,63:16,63:19","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+                ],
+                 "rhsp": [
+                  {"type":"CONST","name":"?32?sh5a","addr":"(RF)","loc":"d,63:22,63:24","dtypep":"(SF)"}
+                ]}
+              ],
+               "thensp": [
+                {"type":"BEGIN","name":"","addr":"(TF)","loc":"d,63:26,63:31","generate":false,"genfor":false,"implied":false,"needProcess":false,"unnamed":true,"genforp": [],"stmtsp": []}
+              ],
+               "elsesp": [
+                {"type":"IF","name":"","addr":"(UF)","loc":"d,65:12,65:14",
+                 "condp": [
+                  {"type":"EQ","name":"","addr":"(VF)","loc":"d,65:20,65:22","dtypep":"(UE)",
+                   "lhsp": [
+                    {"type":"PARSEREF","name":"cyc","addr":"(WF)","loc":"d,65:16,65:19","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+                  ],
+                   "rhsp": [
+                    {"type":"CONST","name":"?32?sh63","addr":"(XF)","loc":"d,65:23,65:25","dtypep":"(SF)"}
+                  ]}
+                ],
+                 "thensp": [
+                  {"type":"BEGIN","name":"","addr":"(YF)","loc":"d,65:27,65:32","generate":false,"genfor":false,"implied":false,"needProcess":false,"unnamed":true,"genforp": [],
+                   "stmtsp": [
+                    {"type":"DISPLAY","name":"","addr":"(ZF)","loc":"d,66:10,66:16",
+                     "fmtp": [
+                      {"type":"SFORMATF","name":"","addr":"(AG)","loc":"d,66:10,66:16","dtypep":"(BG)",
+                       "exprsp": [
+                        {"type":"CONST","name":"232'h5b2530745d206379633d3d253064206372633d25782073756d3d25780a","addr":"(CG)","loc":"d,66:17,66:49","dtypep":"(DG)"},
+                        {"type":"TIME","name":"","addr":"(EG)","loc":"d,66:51,66:56","dtypep":"(FG)","timeunit":"NONE"},
+                        {"type":"PARSEREF","name":"cyc","addr":"(GG)","loc":"d,66:58,66:61","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []},
+                        {"type":"PARSEREF","name":"crc","addr":"(HG)","loc":"d,66:63,66:66","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []},
+                        {"type":"PARSEREF","name":"sum","addr":"(IG)","loc":"d,66:68,66:71","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+                      ],"scopeNamep": []}
+                    ],"filep": []},
+                    {"type":"IF","name":"","addr":"(JG)","loc":"d,67:10,67:12",
+                     "condp": [
+                      {"type":"NEQCASE","name":"","addr":"(KG)","loc":"d,67:18,67:21","dtypep":"(UE)",
+                       "lhsp": [
+                        {"type":"PARSEREF","name":"crc","addr":"(LG)","loc":"d,67:14,67:17","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+                      ],
+                       "rhsp": [
+                        {"type":"CONST","name":"64'hc77bb9b3784ea091","addr":"(MG)","loc":"d,67:22,67:42","dtypep":"(AF)"}
+                      ]}
+                    ],
+                     "thensp": [
+                      {"type":"STOP","name":"","addr":"(NG)","loc":"d,67:44,67:49"}
+                    ],"elsesp": []},
+                    {"type":"IF","name":"","addr":"(OG)","loc":"d,70:10,70:12",
+                     "condp": [
+                      {"type":"NEQCASE","name":"","addr":"(PG)","loc":"d,70:18,70:21","dtypep":"(UE)",
+                       "lhsp": [
+                        {"type":"PARSEREF","name":"sum","addr":"(QG)","loc":"d,70:14,70:17","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+                      ],
+                       "rhsp": [
+                        {"type":"CONST","name":"64'h4afe43fb79d7b71e","addr":"(RG)","loc":"d,70:22,70:42","dtypep":"(AF)"}
+                      ]}
+                    ],
+                     "thensp": [
+                      {"type":"STOP","name":"","addr":"(SG)","loc":"d,70:44,70:49"}
+                    ],"elsesp": []},
+                    {"type":"DISPLAY","name":"","addr":"(TG)","loc":"d,71:10,71:16",
+                     "fmtp": [
+                      {"type":"SFORMATF","name":"","addr":"(UG)","loc":"d,71:10,71:16","dtypep":"(BG)",
+                       "exprsp": [
+                        {"type":"CONST","name":"168'h2a2d2a20416c6c2046696e6973686564202a2d2a0a","addr":"(VG)","loc":"d,71:17,71:41","dtypep":"(WG)"}
+                      ],"scopeNamep": []}
+                    ],"filep": []},
+                    {"type":"FINISH","name":"","addr":"(XG)","loc":"d,72:10,72:17"}
+                  ]}
+                ],"elsesp": []}
+              ]}
+            ]}
+          ]}
+        ]}
+      ]}
+    ]}
+  ],"activesp": []},
+  {"type":"MODULE","name":"Test","addr":"(PB)","loc":"d,78:8,78:12","origName":"Test","level":3,"modPublic":false,"inLibrary":false,"dead":false,"recursiveClone":false,"recursive":false,"timeunit":"1ps","inlinesp": [],
+   "stmtsp": [
+    {"type":"PORT","name":"out","addr":"(YG)","loc":"d,80:4,80:7","exprp": []},
+    {"type":"PORT","name":"clk","addr":"(ZG)","loc":"d,82:4,82:7","exprp": []},
+    {"type":"PORT","name":"in","addr":"(AH)","loc":"d,82:9,82:11","exprp": []},
+    {"type":"VAR","name":"clk","addr":"(BH)","loc":"d,90:10,90:13","dtypep":"UNLINKED","origName":"clk","isSc":false,"isPrimaryIO":false,"direction":"INPUT","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"attrClocker":"UNKNOWN","lifetime":"NONE","varType":"PORT","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"sensIfacep":"UNLINKED",
+     "childDTypep": [
+      {"type":"BASICDTYPE","name":"LOGIC_IMPLICIT","addr":"(CH)","loc":"d,90:10,90:13","dtypep":"(CH)","keyword":"LOGIC_IMPLICIT","generic":false,"rangep": []}
+    ],"delayp": [],"valuep": [],"attrsp": []},
+    {"type":"VAR","name":"in","addr":"(DH)","loc":"d,91:17,91:19","dtypep":"UNLINKED","origName":"in","isSc":false,"isPrimaryIO":false,"direction":"INPUT","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"attrClocker":"UNKNOWN","lifetime":"NONE","varType":"PORT","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"sensIfacep":"UNLINKED",
+     "childDTypep": [
+      {"type":"BASICDTYPE","name":"logic","addr":"(EH)","loc":"d,91:10,91:11","dtypep":"(EH)","keyword":"logic","generic":false,
+       "rangep": [
+        {"type":"RANGE","name":"","addr":"(FH)","loc":"d,91:10,91:11","ascending":false,
+         "leftp": [
+          {"type":"CONST","name":"?32?sh1f","addr":"(GH)","loc":"d,91:11,91:13","dtypep":"(BB)"}
+        ],
+         "rightp": [
+          {"type":"CONST","name":"?32?sh0","addr":"(HH)","loc":"d,91:14,91:15","dtypep":"(L)"}
+        ]}
+      ]}
+    ],"delayp": [],"valuep": [],"attrsp": []},
+    {"type":"VAR","name":"out","addr":"(IH)","loc":"d,92:22,92:25","dtypep":"UNLINKED","origName":"out","isSc":false,"isPrimaryIO":false,"direction":"OUTPUT","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"attrClocker":"UNKNOWN","lifetime":"NONE","varType":"PORT","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"sensIfacep":"UNLINKED",
+     "childDTypep": [
+      {"type":"BASICDTYPE","name":"logic","addr":"(JH)","loc":"d,92:11,92:14","dtypep":"(JH)","keyword":"logic","generic":false,
+       "rangep": [
+        {"type":"RANGE","name":"","addr":"(KH)","loc":"d,92:15,92:16","ascending":false,
+         "leftp": [
+          {"type":"CONST","name":"?32?sh1f","addr":"(LH)","loc":"d,92:16,92:18","dtypep":"(BB)"}
+        ],
+         "rightp": [
+          {"type":"CONST","name":"?32?sh0","addr":"(MH)","loc":"d,92:19,92:20","dtypep":"(L)"}
+        ]}
+      ]}
+    ],"delayp": [],"valuep": [],"attrsp": []},
+    {"type":"ALWAYS","name":"","addr":"(NH)","loc":"d,94:4,94:10","keyword":"always","isSuspendable":false,"needProcess":false,"sensesp": [],
+     "stmtsp": [
+      {"type":"EVENTCONTROL","name":"","addr":"(OH)","loc":"d,94:11,94:12",
+       "sensesp": [
+        {"type":"SENTREE","name":"","addr":"(PH)","loc":"d,94:11,94:12","isMulti":false,
+         "sensesp": [
+          {"type":"SENITEM","name":"","addr":"(QH)","loc":"d,94:13,94:20","edgeType":"POS",
+           "sensp": [
+            {"type":"PARSEREF","name":"clk","addr":"(RH)","loc":"d,94:21,94:24","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+          ],"condp": []}
+        ]}
+      ],
+       "stmtsp": [
+        {"type":"BEGIN","name":"","addr":"(SH)","loc":"d,94:26,94:31","generate":false,"genfor":false,"implied":false,"needProcess":false,"unnamed":true,"genforp": [],
+         "stmtsp": [
+          {"type":"ASSIGNDLY","name":"","addr":"(TH)","loc":"d,95:11,95:13","dtypep":"UNLINKED",
+           "rhsp": [
+            {"type":"PARSEREF","name":"in","addr":"(UH)","loc":"d,95:14,95:16","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+          ],
+           "lhsp": [
+            {"type":"PARSEREF","name":"out","addr":"(VH)","loc":"d,95:7,95:10","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+          ],"timingControlp": []}
+        ]}
+      ]}
+    ]}
+  ],"activesp": []}
+],"filesp": [],
+ "miscsp": [
+  {"type":"TYPETABLE","name":"","addr":"(C)","loc":"a,0:0,0:0","constraintRefp":"UNLINKED","emptyQueuep":"UNLINKED","queueIndexp":"UNLINKED","streamp":"UNLINKED","voidp":"(WH)",
+   "typesp": [
+    {"type":"BASICDTYPE","name":"integer","addr":"(XH)","loc":"c,31:27,31:28","dtypep":"(XH)","keyword":"integer","range":"31:0","generic":true,"rangep": []},
+    {"type":"BASICDTYPE","name":"logic","addr":"(L)","loc":"c,33:32,33:33","dtypep":"(L)","keyword":"logic","range":"31:0","generic":true,"rangep": []},
+    {"type":"BASICDTYPE","name":"logic","addr":"(UE)","loc":"c,50:22,50:24","dtypep":"(UE)","keyword":"logic","generic":true,"rangep": []},
+    {"type":"VOIDDTYPE","name":"","addr":"(WH)","loc":"c,51:21,51:30","dtypep":"(WH)","generic":false},
+    {"type":"BASICDTYPE","name":"logic","addr":"(QD)","loc":"c,119:22,119:23","dtypep":"(QD)","keyword":"logic","range":"31:0","generic":true,"rangep": []},
+    {"type":"BASICDTYPE","name":"logic","addr":"(YH)","loc":"c,121:22,121:23","dtypep":"(YH)","keyword":"logic","range":"31:0","generic":true,"rangep": []},
+    {"type":"BASICDTYPE","name":"logic","addr":"(ZH)","loc":"c,156:17,156:56","dtypep":"(ZH)","keyword":"logic","range":"295:0","generic":true,"rangep": []},
+    {"type":"BASICDTYPE","name":"string","addr":"(BG)","loc":"c,156:10,156:16","dtypep":"(BG)","keyword":"string","generic":true,"rangep": []},
+    {"type":"BASICDTYPE","name":"logic","addr":"(Q)","loc":"d,26:9,26:11","dtypep":"(Q)","keyword":"logic","range":"31:0","generic":true,"rangep": []},
+    {"type":"BASICDTYPE","name":"logic","addr":"(BB)","loc":"d,30:10,30:12","dtypep":"(BB)","keyword":"logic","range":"31:0","generic":true,"rangep": []},
+    {"type":"BASICDTYPE","name":"logic","addr":"(MC)","loc":"d,45:26,45:31","dtypep":"(MC)","keyword":"logic","range":"31:0","generic":true,"rangep": []},
+    {"type":"BASICDTYPE","name":"logic","addr":"(JC)","loc":"d,45:25,45:26","dtypep":"(JC)","keyword":"logic","generic":true,"rangep": []},
+    {"type":"BASICDTYPE","name":"logic","addr":"(AF)","loc":"d,57:17,57:38","dtypep":"(AF)","keyword":"logic","range":"63:0","generic":true,"rangep": []},
+    {"type":"BASICDTYPE","name":"logic","addr":"(JF)","loc":"d,60:22,60:24","dtypep":"(JF)","keyword":"logic","range":"31:0","generic":true,"rangep": []},
+    {"type":"BASICDTYPE","name":"logic","addr":"(SF)","loc":"d,63:22,63:24","dtypep":"(SF)","keyword":"logic","range":"31:0","generic":true,"rangep": []},
+    {"type":"BASICDTYPE","name":"logic","addr":"(DG)","loc":"d,66:17,66:49","dtypep":"(DG)","keyword":"logic","range":"231:0","generic":true,"rangep": []},
+    {"type":"BASICDTYPE","name":"QData","addr":"(FG)","loc":"d,66:51,66:56","dtypep":"(FG)","keyword":"QData","range":"63:0","generic":true,"rangep": []},
+    {"type":"BASICDTYPE","name":"logic","addr":"(WG)","loc":"d,71:17,71:41","dtypep":"(WG)","keyword":"logic","range":"167:0","generic":true,"rangep": []}
+  ]},
+  {"type":"CONSTPOOL","name":"","addr":"(D)","loc":"a,0:0,0:0",
+   "modulep": [
+    {"type":"MODULE","name":"@CONST-POOL@","addr":"(AI)","loc":"a,0:0,0:0","origName":"@CONST-POOL@","level":0,"modPublic":false,"inLibrary":false,"dead":false,"recursiveClone":false,"recursive":false,"timeunit":"NONE","inlinesp": [],
+     "stmtsp": [
+      {"type":"SCOPE","name":"@CONST-POOL@","addr":"(BI)","loc":"a,0:0,0:0","aboveScopep":"UNLINKED","aboveCellp":"UNLINKED","modp":"(AI)","varsp": [],"blocksp": []}
+    ],"activesp": []}
+  ]}
+]}

--- a/test_regress/t/t_dump_json.pl
+++ b/test_regress/t/t_dump_json.pl
@@ -1,0 +1,23 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2003 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(vlt => 1);
+
+top_filename("t/t_EXAMPLE.v");
+
+lint(
+    v_flags => ["--dump-tree-json --no-json-edit-nums"],
+    );
+
+files_identical("$Self->{obj_dir}/Vt_dump_json_001_cells.tree.json", $Self->{golden_filename}, 'logfile');
+
+ok(1);
+
+1;

--- a/test_regress/t/t_dump_json_astsee.pl
+++ b/test_regress/t/t_dump_json_astsee.pl
@@ -1,0 +1,33 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2003 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+# test whether json dumps don't "crash" astsee
+
+scenarios(vlt => 1);
+
+{
+    my $cmd = qq{astsee_verilator -h >/dev/null 2>&1};
+    print "\t$cmd\n" if $::Debug;
+    system($cmd) and do { skip("No astsee installed\n"); return 1 }
+}
+
+top_filename("t/t_EXAMPLE.v");
+
+lint(
+    v_flags => ["--lint-only --dump-tree-json"],
+    );
+
+
+run(cmd => ["cd $Self->{obj_dir} && astsee_verilator *001*.json > astsee.log"],
+    logfile => "$Self->{obj_dir}/astsee.log");
+
+ok(1);
+
+1;

--- a/test_regress/t/t_gdb_jtree.gdb
+++ b/test_regress/t/t_gdb_jtree.gdb
@@ -1,0 +1,24 @@
+# Copyright 2024 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+watch v3Global.m_rootp
+run
+python
+try: gdb.execute("jtree v3Global.m_rootp")
+except Exception: exit(1)
+try: gdb.execute("jtree v3Global.m_rootp v3Global.m_rootp")
+except Exception: exit(1)
+
+# stash and use stashed dump
+try: gdb.execute("jstash v3Global.m_rootp")
+except Exception: exit(1)
+# we assume that stash will end up in $1 (we can't use gdb.history_count() since it is not available in older gdb)
+try: gdb.execute("jtree $1")
+except Exception: exit(1)
+try: gdb.execute("jtree $1 v3Global.m_rootp")
+except Exception: exit(1)
+end
+quit 0

--- a/test_regress/t/t_gdb_jtree.pl
+++ b/test_regress/t/t_gdb_jtree.pl
@@ -1,0 +1,30 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2003 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+# test whether jtree gdb command doesn't crash
+
+scenarios(vlt => 1);
+
+{
+    my $cmd = qq{astsee_verilator -h >/dev/null 2>&1};
+    print "\t$cmd\n" if $::Debug;
+    system($cmd) and do { skip("No astsee installed\n"); return 1 }
+}
+
+setenv("VERILATOR_GDB", "gdb --return-child-result --batch-silent --quiet"
+                        . " --command $Self->{t_dir}/t_gdb_jtree.gdb");
+
+top_filename("t/t_EXAMPLE.v");
+
+lint(v_flags => ["--gdb", "--debug"]);
+
+ok(1);
+
+1;


### PR DESCRIPTION
Verilator's AST can currently be dumped into custom `.tree` representation for debug purposes. This PR adds a mostly equivalent JSON representation which is easier to process programmatically.

## Example use cases

### Tree diffing
An example of how this is useful is the [`astsee`](https://github.com/antmicro/astsee) tool which can pretty-print and diff these JSON dumps.

![diff](https://github.com/antmicro/verilator-1/assets/9216518/4a07ef4f-8b9a-47d7-9c72-181ae6125af5)

### Tree navigation
An example HTML representation for easy navigation of the AST, generated by `astsee`:

[example.zip](https://github.com/antmicro/verilator-1/files/13439928/example.zip)

### GDB commands
`astsee` can also be used from within GDB. Useful for diffing the AST at runtime, even within a single Verilator stage.

![gdb](https://github.com/antmicro/verilator-1/assets/9216518/f1821899-2e09-40c2-b898-dc31300141b3)
