### PR TITLE
Fix Windows include gates in filesystemFlush implementation.

### DIFF
--- a/src/V3Os.cpp
+++ b/src/V3Os.cpp
@@ -300,7 +300,7 @@ void V3Os::createDir(const string& dirname) {
 void V3Os::filesystemFlush(const string& dirname) {
     // NFS caches stat() calls so to get up-to-date information must
     // do a open or opendir on the filename.
-#ifdef _MSC_VER
+#if defined(_MSC_VER) || defined(__MINGW32__)
     if (int fd = ::open(dirname.c_str(), O_RDONLY)) {  // LCOV_EXCL_BR_LINE
         if (fd > 0) ::close(fd);
     }
@@ -316,7 +316,7 @@ void V3Os::filesystemFlush(const string& dirname) {
 
 void V3Os::filesystemFlushBuildDir(const string& dirname) {
     // Attempt to force out written directory, for NFS like file systems.
-#ifndef _MSC_VER
+#if !defined(_MSC_VER) && !defined(__MINGW32__)
     // Linux kernel may not reread from NFS unless timestamp modified
     struct timeval tv;
     gettimeofday(&tv, NULL);


### PR DESCRIPTION
Commit b15ef49c5 broke MinGW builds with an error along the lines of:

```
../V3Os.cpp: In static member function 'static void V3Os::filesystemFlushBuildDir(const string&)':
../V3Os.cpp:322:5: error: 'gettimeofday' was not declared in this scope; did you mean 'mingw_gettimeofday'?
  322 |     gettimeofday(&tv, NULL);
      |     ^~~~~~~~~~~~
      |     mingw_gettimeofday
../V3Os.cpp:323:21: error: 'utimes' was not declared in this scope; did you mean 'utime'?
  323 |     const int err = utimes(dirname.c_str(), &tv);
      |                     ^~~~~~
      |                     utime
```

This patch adds some `ifdef`s that should be applied to MinGW builds as well as MSVC builds to fix compiler errors.