### PR TITLE
Fix parameter passing to ports

### DIFF
--- a/src/V3Inline.cpp
+++ b/src/V3Inline.cpp
@@ -375,6 +375,7 @@ class InlineRelinkVisitor final : public VNVisitor {
                 return;
             } else if (const AstVarRef* const vrefp = VN_CAST(varp->user2p(), VarRef)) {
                 nodep->varp(vrefp->varp());
+                nodep->classOrPackagep(vrefp->classOrPackagep());
             } else {
                 nodep->v3fatalSrc("Null connection?");
             }

--- a/src/V3Inline.cpp
+++ b/src/V3Inline.cpp
@@ -283,7 +283,7 @@ class InlineRelinkVisitor final : public VNVisitor {
             // user2p is either a const or a var.
             FileLine* const flp = nodep->fileline();
             AstConst* const exprconstp = VN_CAST(nodep->user2p(), Const);
-            AstVarRef* const exprvarrefp = VN_CAST(nodep->user2p()->cloneTree(false), VarRef);
+            AstVarRef* exprvarrefp = VN_CAST(nodep->user2p(), VarRef);
             UINFO(8, "connectto: " << nodep->user2p() << endl);
             UASSERT_OBJ(exprconstp || exprvarrefp, nodep,
                         "Unknown interconnect type; pinReconnectSimple should have cleared up");
@@ -296,17 +296,19 @@ class InlineRelinkVisitor final : public VNVisitor {
                 // remove the change detection on the output variable.
                 UINFO(9, "public pin assign: " << exprvarrefp << endl);
                 UASSERT_OBJ(!nodep->isNonOutput(), nodep, "Outputs only - inputs use AssignAlias");
-                m_modp->addStmtsp(
-                    new AstAssignW{flp, exprvarrefp, new AstVarRef{flp, nodep, VAccess::READ}});
+                m_modp->addStmtsp(new AstAssignW{flp, exprvarrefp->cloneTree(false),
+                                                 new AstVarRef{flp, nodep, VAccess::READ}});
             } else if (nodep->isSigPublic() && VN_IS(nodep->dtypep(), UnpackArrayDType)) {
                 // Public variable at this end and it is an unpacked array. We need to assign
                 // instead of aliased, because otherwise it will pass V3Slice and invalid
                 // code will be emitted.
                 UINFO(9, "assign to public and unpacked: " << nodep << endl);
+                exprvarrefp = exprvarrefp->cloneTree(false);
                 exprvarrefp->access(VAccess::READ);
                 m_modp->addStmtsp(
                     new AstAssignW{flp, new AstVarRef{flp, nodep, VAccess::WRITE}, exprvarrefp});
             } else if (nodep->isIfaceRef()) {
+                exprvarrefp = exprvarrefp->cloneTree(false);
                 exprvarrefp->access(VAccess::READ);
                 m_modp->addStmtsp(new AstAssignVarScope{
                     flp, new AstVarRef{flp, nodep, VAccess::WRITE}, exprvarrefp});
@@ -316,6 +318,7 @@ class InlineRelinkVisitor final : public VNVisitor {
             } else {
                 // Do to inlining child's variable now within the same
                 // module, so a AstVarRef not AstVarXRef below
+                exprvarrefp = exprvarrefp->cloneTree(false);
                 exprvarrefp->access(VAccess::READ);
                 m_modp->addStmtsp(new AstAssignAlias{
                     flp, new AstVarRef{flp, nodep, VAccess::WRITE}, exprvarrefp});

--- a/src/V3Inline.cpp
+++ b/src/V3Inline.cpp
@@ -283,7 +283,7 @@ class InlineRelinkVisitor final : public VNVisitor {
             // user2p is either a const or a var.
             FileLine* const flp = nodep->fileline();
             AstConst* const exprconstp = VN_CAST(nodep->user2p(), Const);
-            const AstVarRef* const exprvarrefp = VN_CAST(nodep->user2p(), VarRef);
+            AstVarRef* const exprvarrefp = VN_CAST(nodep->user2p()->cloneTree(false), VarRef);
             UINFO(8, "connectto: " << nodep->user2p() << endl);
             UASSERT_OBJ(exprconstp || exprvarrefp, nodep,
                         "Unknown interconnect type; pinReconnectSimple should have cleared up");
@@ -297,29 +297,28 @@ class InlineRelinkVisitor final : public VNVisitor {
                 UINFO(9, "public pin assign: " << exprvarrefp << endl);
                 UASSERT_OBJ(!nodep->isNonOutput(), nodep, "Outputs only - inputs use AssignAlias");
                 m_modp->addStmtsp(
-                    new AstAssignW{flp, new AstVarRef{flp, exprvarrefp->varp(), VAccess::WRITE},
-                                   new AstVarRef{flp, nodep, VAccess::READ}});
+                    new AstAssignW{flp, exprvarrefp, new AstVarRef{flp, nodep, VAccess::READ}});
             } else if (nodep->isSigPublic() && VN_IS(nodep->dtypep(), UnpackArrayDType)) {
                 // Public variable at this end and it is an unpacked array. We need to assign
                 // instead of aliased, because otherwise it will pass V3Slice and invalid
                 // code will be emitted.
                 UINFO(9, "assign to public and unpacked: " << nodep << endl);
+                exprvarrefp->access(VAccess::READ);
                 m_modp->addStmtsp(
-                    new AstAssignW{flp, new AstVarRef{flp, nodep, VAccess::WRITE},
-                                   new AstVarRef{flp, exprvarrefp->varp(), VAccess::READ}});
+                    new AstAssignW{flp, new AstVarRef{flp, nodep, VAccess::WRITE}, exprvarrefp});
             } else if (nodep->isIfaceRef()) {
-                m_modp->addStmtsp(
-                    new AstAssignVarScope{flp, new AstVarRef{flp, nodep, VAccess::WRITE},
-                                          new AstVarRef{flp, exprvarrefp->varp(), VAccess::READ}});
+                exprvarrefp->access(VAccess::READ);
+                m_modp->addStmtsp(new AstAssignVarScope{
+                    flp, new AstVarRef{flp, nodep, VAccess::WRITE}, exprvarrefp});
                 FileLine* const flbp = exprvarrefp->varp()->fileline();
                 flp->modifyStateInherit(flbp);
                 flbp->modifyStateInherit(flp);
             } else {
                 // Do to inlining child's variable now within the same
                 // module, so a AstVarRef not AstVarXRef below
-                m_modp->addStmtsp(
-                    new AstAssignAlias{flp, new AstVarRef{flp, nodep, VAccess::WRITE},
-                                       new AstVarRef{flp, exprvarrefp->varp(), VAccess::READ}});
+                exprvarrefp->access(VAccess::READ);
+                m_modp->addStmtsp(new AstAssignAlias{
+                    flp, new AstVarRef{flp, nodep, VAccess::WRITE}, exprvarrefp});
                 FileLine* const flbp = exprvarrefp->varp()->fileline();
                 flp->modifyStateInherit(flbp);
                 flbp->modifyStateInherit(flp);

--- a/test_regress/t/t_param_passed_to_port.pl
+++ b/test_regress/t/t_param_passed_to_port.pl
@@ -1,0 +1,20 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2023 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile();
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_param_passed_to_port.v
+++ b/test_regress/t/t_param_passed_to_port.v
@@ -1,0 +1,24 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2023 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+parameter int HwDataAttr[1] = '{1};
+
+module flash_mp_data_region_sel (
+   input int  region_attrs_i[1],
+   output int o
+);
+   assign o = region_attrs_i[0];
+endmodule
+
+module t;
+   int o;
+   flash_mp_data_region_sel u_hw_sel (.region_attrs_i(HwDataAttr), .o(o));
+   initial begin
+      if (o != 1) $stop;
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end
+endmodule

--- a/test_regress/t/t_param_passed_to_port.v
+++ b/test_regress/t/t_param_passed_to_port.v
@@ -7,18 +7,19 @@
 parameter int HwDataAttr[1] = '{1};
 
 module flash_mp_data_region_sel (
-   input int  region_attrs_i[1],
-   output int o
+   input int region_attrs_i[1]
 );
-   assign o = region_attrs_i[0];
-endmodule
-
-module t;
-   int o;
-   flash_mp_data_region_sel u_hw_sel (.region_attrs_i(HwDataAttr), .o(o));
    initial begin
+      int o = 0;
+      for (int i = 0; i < 1; i++) begin
+         o = region_attrs_i[i];
+      end
       if (o != 1) $stop;
       $write("*-* All Finished *-*\n");
       $finish;
    end
+endmodule
+
+module t;
+   flash_mp_data_region_sel u_hw_sel (.region_attrs_i(HwDataAttr));
 endmodule

--- a/test_regress/t/t_xml_flat.out
+++ b/test_regress/t/t_xml_flat.out
@@ -64,15 +64,15 @@
             <varref loc="d,14,16,14,17" name="t.d" dtype_id="1"/>
           </assignalias>
           <assignalias loc="d,34,24,34,27" dtype_id="2">
-            <varref loc="d,34,24,34,27" name="t.clk" dtype_id="2"/>
+            <varref loc="d,21,42,21,45" name="t.clk" dtype_id="2"/>
             <varref loc="d,34,24,34,27" name="t.cell1.clk" dtype_id="2"/>
           </assignalias>
           <assignalias loc="d,35,30,35,31" dtype_id="1">
-            <varref loc="d,35,30,35,31" name="t.d" dtype_id="1"/>
+            <varref loc="d,22,42,22,43" name="t.d" dtype_id="1"/>
             <varref loc="d,35,30,35,31" name="t.cell1.d" dtype_id="1"/>
           </assignalias>
           <assignalias loc="d,36,30,36,31" dtype_id="1">
-            <varref loc="d,36,30,36,31" name="t.between" dtype_id="1"/>
+            <varref loc="d,20,14,20,21" name="t.between" dtype_id="1"/>
             <varref loc="d,36,30,36,31" name="t.cell1.q" dtype_id="1"/>
           </assignalias>
           <always loc="d,41,4,41,10">
@@ -87,15 +87,15 @@
             </assigndly>
           </always>
           <assignalias loc="d,48,10,48,13" dtype_id="2">
-            <varref loc="d,48,10,48,13" name="t.clk" dtype_id="2"/>
+            <varref loc="d,27,42,27,45" name="t.clk" dtype_id="2"/>
             <varref loc="d,48,10,48,13" name="t.cell2.clk" dtype_id="2"/>
           </assignalias>
           <assignalias loc="d,49,16,49,17" dtype_id="1">
-            <varref loc="d,49,16,49,17" name="t.between" dtype_id="1"/>
+            <varref loc="d,25,16,25,23" name="t.between" dtype_id="1"/>
             <varref loc="d,49,16,49,17" name="t.cell2.d" dtype_id="1"/>
           </assignalias>
           <assignalias loc="d,50,22,50,23" dtype_id="1">
-            <varref loc="d,50,22,50,23" name="t.q" dtype_id="1"/>
+            <varref loc="d,26,42,26,43" name="t.q" dtype_id="1"/>
             <varref loc="d,50,22,50,23" name="t.cell2.q" dtype_id="1"/>
           </assignalias>
           <contassign loc="d,53,13,53,14" dtype_id="1">

--- a/test_regress/t/t_xml_flat_no_inline_mod.out
+++ b/test_regress/t/t_xml_flat_no_inline_mod.out
@@ -28,7 +28,7 @@
             <varref loc="d,11,24,11,29" name="top.i_clk" dtype_id="1"/>
           </assignalias>
           <assignalias loc="d,7,24,7,29" dtype_id="1">
-            <varref loc="d,7,24,7,29" name="top.i_clk" dtype_id="1"/>
+            <varref loc="d,12,7,12,8" name="top.i_clk" dtype_id="1"/>
             <varref loc="d,7,24,7,29" name="top.f.i_clk" dtype_id="1"/>
           </assignalias>
         </scope>

--- a/test_regress/t/t_xml_flat_pub_mod.out
+++ b/test_regress/t/t_xml_flat_pub_mod.out
@@ -28,7 +28,7 @@
             <varref loc="d,11,24,11,29" name="top.i_clk" dtype_id="1"/>
           </assignalias>
           <assignalias loc="d,7,24,7,29" dtype_id="1">
-            <varref loc="d,7,24,7,29" name="top.i_clk" dtype_id="1"/>
+            <varref loc="d,12,7,12,8" name="top.i_clk" dtype_id="1"/>
             <varref loc="d,7,24,7,29" name="top.f.i_clk" dtype_id="1"/>
           </assignalias>
         </scope>


### PR DESCRIPTION
It fixes https://github.com/verilator/verilator/issues/4605.
Currently on master, variable references that are created to handle inlining of modules don't have `classOrPackagep` field set. This PR fixes it.