### PR TITLE
Add inline for VL_ATTR_ALWINLINE, even on non GNU-C platforms

### DIFF
--- a/include/verilatedos.h
+++ b/include/verilatedos.h
@@ -138,7 +138,7 @@
 
 // Defaults for unsupported compiler features
 #ifndef VL_ATTR_ALWINLINE
-# define VL_ATTR_ALWINLINE  ///< Attribute to inline, even when not optimizing
+# define VL_ATTR_ALWINLINE inline  ///< Attribute to inline, even when not optimizing
 #endif
 #ifndef VL_ATTR_NOINLINE
 # define VL_ATTR_NOINLINE  ///< Attribute to never inline, even when optimizing


### PR DESCRIPTION
This is required to avoid multiple definition errors at link time for functions defined in headers and marked VL_ATTR_ALWINLINE.