### PR TITLE
Improve V3Premit

### DIFF
--- a/src/V3AstNodeOther.h
+++ b/src/V3AstNodeOther.h
@@ -3253,8 +3253,7 @@ public:
 };
 class AstTraceInc final : public AstNodeStmt {
     // Trace point dump
-    // @astgen op1 := precondsp : List[AstNode] // Statements to emit before this node
-    // @astgen op2 := valuep : AstNodeExpr // Expression being traced (from decl)
+    // @astgen op1 := valuep : AstNodeExpr // Expression being traced (from decl)
     //
     // @astgen ptr := m_declp : AstTraceDecl  // Pointer to declaration
     const uint32_t m_baseCode;  // Trace code base value in function containing this AstTraceInc

--- a/src/V3EmitCImp.cpp
+++ b/src/V3EmitCImp.cpp
@@ -740,7 +740,6 @@ class EmitCTrace final : EmitCFunc {
     }
 
     void emitTraceChangeOne(AstTraceInc* nodep, int arrayindex) {
-        iterateAndNextConstNull(nodep->precondsp());
         // Note: Both VTraceType::CHANGE and VTraceType::FULL use the 'full' methods
         const std::string func = nodep->traceType() == VTraceType::CHANGE ? "chg" : "full";
         bool emitWidth = true;

--- a/test_regress/t/t_flag_expand_limit.pl
+++ b/test_regress/t/t_flag_expand_limit.pl
@@ -14,7 +14,7 @@ compile(
     verilator_flags2 => ['--expand-limit 1 --stats -fno-dfg'],
     );
 
-file_grep($Self->{stats}, qr/Optimizations, expand limited\s+(\d+)/i, 4);
+file_grep($Self->{stats}, qr/Optimizations, expand limited\s+(\d+)/i, 3);
 
 ok(1);
 1;


### PR DESCRIPTION
- Enable creating constant pool entries for RHS of simple var = const assignments
- Never extract ArraySel (it's just pointer arithmetic)
- Remove unnecessary AstTraceInc precond child tree
- Always fully recurse expressions (fix transplanted from #4617)
- General cleanup

Overall the patch is performance neutral to slightly positive, but saves ~10% peak Verialtor memory usage due to not creating temporaries (which are later expanded) for any ArraySels.