### PR TITLE
Add class name in the error msg about calling 'new' on virtual class

### DIFF
--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -3840,8 +3840,8 @@ class WidthVisitor final : public VNVisitor {
                 classp->v3fatalSrc("Can't find class's new");
             }
             if (classp->isVirtual() || classp->isInterfaceClass()) {
-                nodep->v3error(
-                    "Illegal to call 'new' using an abstract virtual class (IEEE 1800-2017 8.21)");
+                nodep->v3error("Illegal to call 'new' using an abstract virtual class "
+                               + classp->origName() + " (IEEE 1800-2017 8.21)");
             }
         } else {  // super.new case
             // in this case class and taskp() should be properly linked in V3LinkDot.cpp during

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -3841,7 +3841,8 @@ class WidthVisitor final : public VNVisitor {
             }
             if (classp->isVirtual() || classp->isInterfaceClass()) {
                 nodep->v3error("Illegal to call 'new' using an abstract virtual class "
-                               +  AstNode::prettyNameQ(classp->origName()) + " (IEEE 1800-2017 8.21)");
+                               + AstNode::prettyNameQ(classp->origName())
+                               + " (IEEE 1800-2017 8.21)");
             }
         } else {  // super.new case
             // in this case class and taskp() should be properly linked in V3LinkDot.cpp during

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -3841,7 +3841,7 @@ class WidthVisitor final : public VNVisitor {
             }
             if (classp->isVirtual() || classp->isInterfaceClass()) {
                 nodep->v3error("Illegal to call 'new' using an abstract virtual class "
-                               + classp->origName() + " (IEEE 1800-2017 8.21)");
+                               +  AstNode::prettyNameQ(classp->origName()) + " (IEEE 1800-2017 8.21)");
             }
         } else {  // super.new case
             // in this case class and taskp() should be properly linked in V3LinkDot.cpp during

--- a/test_regress/t/t_class_param_virtual_bad.out
+++ b/test_regress/t/t_class_param_virtual_bad.out
@@ -1,8 +1,8 @@
-%Error: t/t_class_param_virtual_bad.v:13:11: Illegal to call 'new' using an abstract virtual class VBase (IEEE 1800-2017 8.21)
+%Error: t/t_class_param_virtual_bad.v:13:11: Illegal to call 'new' using an abstract virtual class 'VBase' (IEEE 1800-2017 8.21)
                                            : ... note: In instance 't'
    13 |       t = new;
       |           ^~~
-%Error: t/t_class_param_virtual_bad.v:23:28: Illegal to call 'new' using an abstract virtual class ClsVirt (IEEE 1800-2017 8.21)
+%Error: t/t_class_param_virtual_bad.v:23:28: Illegal to call 'new' using an abstract virtual class 'ClsVirt' (IEEE 1800-2017 8.21)
                                            : ... note: In instance 't'
    23 |       ClsVirt#(VBase) cv = new;   
       |                            ^~~

--- a/test_regress/t/t_class_param_virtual_bad.out
+++ b/test_regress/t/t_class_param_virtual_bad.out
@@ -1,0 +1,9 @@
+%Error: t/t_class_param_virtual_bad.v:13:11: Illegal to call 'new' using an abstract virtual class VBase (IEEE 1800-2017 8.21)
+                                           : ... note: In instance 't'
+   13 |       t = new;
+      |           ^~~
+%Error: t/t_class_param_virtual_bad.v:23:28: Illegal to call 'new' using an abstract virtual class ClsVirt (IEEE 1800-2017 8.21)
+                                           : ... note: In instance 't'
+   23 |       ClsVirt#(VBase) cv = new;   
+      |                            ^~~
+%Error: Exiting due to

--- a/test_regress/t/t_class_param_virtual_bad.pl
+++ b/test_regress/t/t_class_param_virtual_bad.pl
@@ -1,0 +1,19 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2020 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(vlt => 1);
+
+lint(
+    fails => 1,
+    expect_filename => $Self->{golden_filename},
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_class_param_virtual_bad.v
+++ b/test_regress/t/t_class_param_virtual_bad.v
@@ -1,0 +1,26 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2023 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+virtual class VBase;
+endclass
+
+class Cls#(parameter type T = VBase);
+   T t;
+   function new;
+      t = new;
+   endfunction
+endclass
+
+virtual class ClsVirt#(parameter type T);
+endclass
+
+module t;
+   initial begin
+      Cls c = new;  // Error
+      ClsVirt#(VBase) cv = new;  // Error
+      $stop;
+   end
+endmodule

--- a/test_regress/t/t_class_virtual_bad.out
+++ b/test_regress/t/t_class_virtual_bad.out
@@ -1,4 +1,4 @@
-%Error: t/t_class_virtual_bad.v:12:17: Illegal to call 'new' using an abstract virtual class (IEEE 1800-2017 8.21)
+%Error: t/t_class_virtual_bad.v:12:17: Illegal to call 'new' using an abstract virtual class VBase (IEEE 1800-2017 8.21)
                                      : ... note: In instance 't'
    12 |       VBase b = new;   
       |                 ^~~

--- a/test_regress/t/t_class_virtual_bad.out
+++ b/test_regress/t/t_class_virtual_bad.out
@@ -1,4 +1,4 @@
-%Error: t/t_class_virtual_bad.v:12:17: Illegal to call 'new' using an abstract virtual class VBase (IEEE 1800-2017 8.21)
+%Error: t/t_class_virtual_bad.v:12:17: Illegal to call 'new' using an abstract virtual class 'VBase' (IEEE 1800-2017 8.21)
                                      : ... note: In instance 't'
    12 |       VBase b = new;   
       |                 ^~~

--- a/test_regress/t/t_implements_new_bad.out
+++ b/test_regress/t/t_implements_new_bad.out
@@ -1,4 +1,4 @@
-%Error: t/t_implements_new_bad.v:13:11: Illegal to call 'new' using an abstract virtual class Icls (IEEE 1800-2017 8.21)
+%Error: t/t_implements_new_bad.v:13:11: Illegal to call 'new' using an abstract virtual class 'Icls' (IEEE 1800-2017 8.21)
                                       : ... note: In instance 't'
    13 |       c = new;   
       |           ^~~

--- a/test_regress/t/t_implements_new_bad.out
+++ b/test_regress/t/t_implements_new_bad.out
@@ -1,4 +1,4 @@
-%Error: t/t_implements_new_bad.v:13:11: Illegal to call 'new' using an abstract virtual class (IEEE 1800-2017 8.21)
+%Error: t/t_implements_new_bad.v:13:11: Illegal to call 'new' using an abstract virtual class Icls (IEEE 1800-2017 8.21)
                                       : ... note: In instance 't'
    13 |       c = new;   
       |           ^~~


### PR DESCRIPTION
I think it is helpful to have a class name in that error message.