### PR TITLE
Add a test for type parameters in virtual interfaces

### DIFF
--- a/test_regress/t/t_interface_virtual_param.v
+++ b/test_regress/t/t_interface_virtual_param.v
@@ -8,12 +8,23 @@ interface Bus #(parameter int W = 1, X = 2);
    logic [W-1:0] data;
 endinterface
 
+interface BusTyped #(parameter type T);
+   T data;
+endinterface
+
+typedef struct packed {
+   logic         x;
+} my_logic_t;
+
 module t;
    Bus#(6, 3) intf1();
    virtual Bus#(6, 3) vintf1 = intf1;
 
    Bus intf2();
    virtual Bus#(.W(1), .X(2)) vintf2 = intf2;
+
+   BusTyped#(my_logic_t) intf3();
+   virtual BusTyped#(my_logic_t) vintf3 = intf3;
 
    initial begin
       intf1.data = '1;
@@ -23,6 +34,9 @@ module t;
       intf2.data = '1;
       if (vintf2.data != 1'b1) $stop;
       if (vintf2.X != 2) $stop;
+
+      intf3.data.x = '1;
+      if (vintf3.data.x != 1'b1) $stop;
 
       $write("*-* All Finished *-*\n");
       $finish;


### PR DESCRIPTION
It adds a test of type parameters in virtual interfaces. It was mentioned in https://github.com/verilator/verilator/pull/4286.