### PR TITLE
Fix typedefs pointing to parameterized classes

### DIFF
--- a/src/V3Param.cpp
+++ b/src/V3Param.cpp
@@ -1151,6 +1151,9 @@ class ParamVisitor final : public VNVisitor {
     }
     void visit(AstClassRefDType* nodep) override { visitCellOrClassRef(nodep, false); }
     void visit(AstClassOrPackageRef* nodep) override {
+        // If it points to a typedef it is not really a class reference. That typedef will be
+        // visited anyway (from its parent node), so even if it points to a parameterized class
+        // type, the instance will be created.
         if (!VN_IS(nodep->classOrPackageNodep(), Typedef)) visitCellOrClassRef(nodep, false);
     }
 

--- a/src/V3Param.cpp
+++ b/src/V3Param.cpp
@@ -1150,7 +1150,9 @@ class ParamVisitor final : public VNVisitor {
         if (nodep->ifacep()) visitCellOrClassRef(nodep, true);
     }
     void visit(AstClassRefDType* nodep) override { visitCellOrClassRef(nodep, false); }
-    void visit(AstClassOrPackageRef* nodep) override { visitCellOrClassRef(nodep, false); }
+    void visit(AstClassOrPackageRef* nodep) override {
+        if (!VN_IS(nodep->classOrPackageNodep(), Typedef)) visitCellOrClassRef(nodep, false);
+    }
 
     // Make sure all parameters are constantified
     void visit(AstVar* nodep) override {

--- a/test_regress/t/t_class_param_typedef2.pl
+++ b/test_regress/t/t_class_param_typedef2.pl
@@ -1,0 +1,21 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2022 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_class_param_typedef2.v
+++ b/test_regress/t/t_class_param_typedef2.v
@@ -1,0 +1,34 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2023 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+virtual class Virt;
+endclass
+
+class MyInt;
+  int x;
+endclass
+
+class uvm_object_registry #(
+    type T = Virt
+);
+  static function T create_object();
+    T obj = new();
+    obj.x = 1;
+    return obj;
+  endfunction
+endclass
+
+typedef uvm_object_registry#(MyInt) type_id;
+
+module t;
+  initial begin
+    MyInt mi = type_id::create_object();
+    if (mi.x != 1) $stop;
+
+    $write("*-* All Finished *-*\n");
+    $finish;
+  end
+endmodule


### PR DESCRIPTION
`::` references with typedefed types are parsed using `AstClassOrPackageRef` node. This is the AST of `type_id::create_object()` (from the test I added):
```
    1:2:2:2:3: DOT 0x555556e05ef0 <e845#> {d28az} @dt=0@ [::]
    1:2:2:2:3:1: CLASSORPACKAGEREF 0x555556e11520 <e841#> {d28aq} @dt=0@  type_id cpkg=0x555556e134a0 -> TYPEDEF 0x555556e134a0 <e828#> {d24bl} @dt=0@  type_id -> REFDTYPE 0x555556e133b0 <e827#> {d24aj} @dt=0@  uvm_object_registry -> UNLINKED
    1:2:2:2:3:2: FUNCREF 0x555556dfdb80 <e842#> {d28az} @dt=0@  create_object -> UNLINKED
```
Currently on master, if `AstClassOrPackageRef` node points to a typedef which points to a parameterized class type, Verilator treats it as a reference to an instance with default parameters and marks that it is used. It causes problems if the default values of parameters are incorrect, e.g. the default type is a virtual class and `new` is used on an object of that type (like in the test I added).

This PR fixes the problem, by skipping these false class references.