### PR TITLE
Devcontainer support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,8 @@
+{
+	"name": "Verilator Build Environment",
+
+	"build": {
+        "dockerfile": "../ci/docker/buildenv/Dockerfile"
+    }
+
+}

--- a/ci/docker/buildenv/Dockerfile
+++ b/ci/docker/buildenv/Dockerfile
@@ -8,18 +8,15 @@
 
 FROM ubuntu:22.04
 
-ARG USERNAME=verilator
-ARG USER_UID=1000
-ARG USER_GID=$USER_UID
-
 # Create the user
-RUN groupadd --gid $USER_GID $USERNAME \
-    && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME -s /bin/bash \
+RUN groupadd verilator \
+    && useradd -g verilator -m verilator -s /bin/bash \
     && apt-get update \
     && apt-get install --no-install-recommends -y sudo \
     && apt-get clean \
-    && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
-    && chmod 0440 /etc/sudoers.d/$USERNAME
+    && rm -rf /var/lib/apt/lists/* \
+    && echo verilator ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/verilator \
+    && chmod 0440 /etc/sudoers.d/verilator
 
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive \
@@ -64,7 +61,7 @@ COPY build.sh /tmp/build.sh
 
 ENV VERILATOR_AUTHOR_SITE=1
 
-USER $USERNAME
+USER verilator
 
 WORKDIR /work
 

--- a/ci/docker/buildenv/Dockerfile
+++ b/ci/docker/buildenv/Dockerfile
@@ -8,6 +8,19 @@
 
 FROM ubuntu:22.04
 
+ARG USERNAME=verilator
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+# Create the user
+RUN groupadd --gid $USER_GID $USERNAME \
+    && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME -s /bin/bash \
+    && apt-get update \
+    && apt-get install --no-install-recommends -y sudo \
+    && apt-get clean \
+    && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
+    && chmod 0440 /etc/sudoers.d/$USERNAME
+
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive \
        apt-get install --no-install-recommends -y \
@@ -50,6 +63,8 @@ RUN git clone https://github.com/veripool/vcddiff.git && \
 COPY build.sh /tmp/build.sh
 
 ENV VERILATOR_AUTHOR_SITE=1
+
+USER $USERNAME
 
 WORKDIR /work
 

--- a/ci/docker/buildenv/Dockerfile
+++ b/ci/docker/buildenv/Dockerfile
@@ -33,7 +33,6 @@ RUN apt-get update \
                         perl \
                         python3 \
                         wget \
-                        zlibc \
                         zlib1g \
                         zlib1g-dev \
     && apt-get clean \


### PR DESCRIPTION
devcontainers are a convenient way to provide users a reproducible build environment. It is currently supported by Visual Studio Code, Visual Studio and IntelliJ.

When the user opens the verilator repo in VSCode with the standard devcontainer extension installed, VSCode will ask the user if they want to reopen in the devcontainer, then build the Docker image as per our definition and then restart VSCode 'remotely' attached to the Docker container.

More information: https://code.visualstudio.com/docs/devcontainers/containers
