### PR TITLE
Refine dynamic NBA condition (#4770)

### DIFF
--- a/src/V3Fork.cpp
+++ b/src/V3Fork.cpp
@@ -414,7 +414,9 @@ class DynScopeVisitor final : public VNVisitor {
     void visit(AstAssignDly* nodep) override {
         if (m_procp && !nodep->user2()  // Unhandled AssignDly in function/task
             && nodep->lhsp()->exists(  // And writes to a local variable
-                [](AstVarRef* refp) { return refp->varp()->isFuncLocal(); })) {
+                [](AstVarRef* refp) {
+                    return refp->access().isWriteOrRW() && refp->varp()->isFuncLocal();
+                })) {
             nodep->user2(true);
             // Put it in a fork to prevent lifetime issues with the local
             AstFork* const forkp = new AstFork{nodep->fileline(), "", nullptr};

--- a/test_regress/t/t_assigndly_task.pl
+++ b/test_regress/t/t_assigndly_task.pl
@@ -1,0 +1,17 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2019 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_assigndly_task.v
+++ b/test_regress/t/t_assigndly_task.v
@@ -1,0 +1,22 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2023 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+module t (
+  input clk,
+  input [7:0] d,
+  input [2:0] a,
+  output [7:0] q
+);
+  always_ff @(posedge clk) tick(a);
+
+  logic [7:0] d_ = d;
+  logic [7:0] q_;
+  assign q = q_;
+
+  task automatic tick(logic [2:0] a);
+    q_[a] <= d_[a];
+  endtask
+endmodule


### PR DESCRIPTION
The condition in `V3Fork` that determines if an NBA should be put in a fork only checks if there's a reference to a local variable on the LHS of the assignment. It should also check if the reference is a write reference. Read references are OK as they do not cause lifetime issues.

Fixes #4770.