### PR TITLE
Run the `V3Fork` stage only if `--timing` is set

### DIFF
--- a/src/Verilator.cpp
+++ b/src/Verilator.cpp
@@ -234,10 +234,12 @@ static void process() {
             V3Inst::dearrayAll(v3Global.rootp());
             V3LinkDot::linkDotArrayed(v3Global.rootp());
 
-            // Generate classes and tasks required to maintain proper lifetimes for references in
-            // forks
-            V3Fork::makeDynamicScopes(v3Global.rootp());
-            V3Fork::makeTasks(v3Global.rootp());
+            if (v3Global.opt.timing().isSetTrue()) {
+                // Generate classes and tasks required to maintain proper lifetimes for references
+                // in forks
+                V3Fork::makeDynamicScopes(v3Global.rootp());
+                V3Fork::makeTasks(v3Global.rootp());
+            }
 
             // Task inlining & pushing BEGINs names to variables/cells
             // Begin processing must be after Param, before module inlining

--- a/test_regress/t/t_assigndly_dynamic_nofork.pl
+++ b/test_regress/t/t_assigndly_dynamic_nofork.pl
@@ -1,0 +1,27 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2019 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+top_filename("t/t_assigndly_task.v");
+
+compile(
+    verilator_flags2 => ["--timing"],
+    );
+
+foreach my $file (
+      glob_all("$Self->{obj_dir}/$Self->{vm_prefix}*.h"),
+      glob_all("$Self->{obj_dir}/$Self->{vm_prefix}*.cpp")
+    ) {
+    file_grep_not($file, qr/__Vfork_/i);
+}
+
+ok(1);
+1;


### PR DESCRIPTION
`V3Fork` is useless without `--timing`. This should bring a slight speedup when verilating `--no-timing` designs.

The new test checks that a fork isn't created for the NBA in `t_assigndly_task.v`, even if `--timing` is used (and thus `V3Fork` runs).