### PR TITLE
CI: Run --sanitize on Ubuntu 22.04

### DIFF
--- a/ci/ci-script.bash
+++ b/ci/ci-script.bash
@@ -90,8 +90,8 @@ elif [ "$CI_BUILD_STAGE_NAME" = "test" ]; then
     export VERILATOR_TEST_NO_GPROF=1 # gprof is a bit different on FreeBSD, disable
   fi
 
-  # Run sanitize on Ubuntu 20.04 only
-  [ "$CI_RUNS_ON" = 'ubuntu-20.04' ] && [ "$CI_M32" = "" ] && sanitize='--sanitize' || sanitize=''
+  # Run sanitize on Ubuntu 22.04 only
+  [ "$CI_RUNS_ON" = 'ubuntu-22.04' ] && [ "$CI_M32" = "" ] && sanitize='--sanitize' || sanitize=''
 
   # Run the specified test
   ccache -z

--- a/test_regress/t/t_vthread.pl
+++ b/test_regress/t/t_vthread.pl
@@ -11,6 +11,8 @@ use IO::File;
 
 scenarios(vlt => 1);
 
+$Self->{sanitize} = 0;  # GCC takes too long otherwise
+
 sub gen {
     my $filename = shift;
     my $n = shift;


### PR DESCRIPTION
Move github CI sanitize from Ubuntu 20.04 to 22.04 to prepare ahead for 24.04.