### PR TITLE
Require C++14 (#4784)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -354,7 +354,7 @@ AC_SUBST(CFG_CXXFLAGS_PROFILE)
 # Macros work such that first option that passes is the one we take
 # Currently enable c++17/c++14 due to packaged SystemC dependency
 # c++17 is the newest that Verilator is regularly tested to support
-# c++11 is the oldest that Verilator supports
+# c++14 is the oldest that Verilator supports
 # gnu is required for Cygwin to compile verilated.h successfully
 #_MY_CXX_CHECK_SET(CFG_CXXFLAGS_STD_NEWEST,-std=gnu++20)
 #_MY_CXX_CHECK_SET(CFG_CXXFLAGS_STD_NEWEST,-std=c++20)
@@ -362,8 +362,6 @@ _MY_CXX_CHECK_SET(CFG_CXXFLAGS_STD_NEWEST,-std=gnu++17)
 _MY_CXX_CHECK_SET(CFG_CXXFLAGS_STD_NEWEST,-std=c++17)
 _MY_CXX_CHECK_SET(CFG_CXXFLAGS_STD_NEWEST,-std=gnu++14)
 _MY_CXX_CHECK_SET(CFG_CXXFLAGS_STD_NEWEST,-std=c++14)
-_MY_CXX_CHECK_SET(CFG_CXXFLAGS_STD_NEWEST,-std=gnu++11)
-_MY_CXX_CHECK_SET(CFG_CXXFLAGS_STD_NEWEST,-std=c++11)
 AC_SUBST(CFG_CXXFLAGS_STD_NEWEST)
 
 # Flags for compiling Verilator internals including parser, and Verilated files
@@ -521,14 +519,14 @@ _MY_LDLIBS_CHECK_IFELSE(
    fi])
 AC_SUBST(CFG_LIBS)
 
-# Need C++11 at least
-#Alternative: AX_CXX_COMPILE_STDCXX([11])
+# Need C++14 at least
+#Alternative: AX_CXX_COMPILE_STDCXX([14])
 AC_DEFUN([_MY_CXX_CHECK_CXX_VER],
-   [# _MY_CXX_CHECK_CXX_VER(flag) -- Check if compiler runs C++11
+   [# _MY_CXX_CHECK_CXX_VER(flag) -- Check if compiler runs C++14
     # Set $_my_result
     AC_LINK_IFELSE(
      [AC_LANG_PROGRAM([#include <thread>
-#if (__cplusplus < 201103L)
+#if (__cplusplus < 201402L)
 # error "Too old"
 #endif
     ], [[ ]])],
@@ -544,13 +542,13 @@ AC_DEFUN([_MY_CXX_CHECK_CXX_VER],
 # Add $CFG_CXXFLAGS_STD only if can't compile correctly otherwise,
 # as adding std= when not needed can cause errors with the C++ std library.
 CFG_CXXFLAGS_STD=$CFG_CXXFLAGS_STD_NEWEST
-AC_MSG_CHECKING(whether $CXX supports C++11)
+AC_MSG_CHECKING(whether $CXX supports C++14)
 _MY_CXX_CHECK_CXX_VER()
 AC_MSG_RESULT($_my_result)
 if test "$_my_result" = "no" ; then
    CXXFLAGS="$CXXFLAGS $CFG_CXXFLAGS_STD"
    CFG_CXX_FLAGS_CMAKE="$CFG_CXX_FLAGS_CMAKE $CFG_CXXFLAGS_STD"
-   AC_MSG_CHECKING(whether $CXX supports C++11 with $CFG_CXXFLAGS_STD)
+   AC_MSG_CHECKING(whether $CXX supports C++14 with $CFG_CXXFLAGS_STD)
    _MY_CXX_CHECK_CXX_VER()
    AC_MSG_RESULT($_my_result)
 else
@@ -560,9 +558,9 @@ else
 fi
 if test "$_my_result" = "no" ; then
    AC_MSG_NOTICE([[]])
-   AC_MSG_ERROR([[the $CXX compiler appears to not support C++11.
+   AC_MSG_ERROR([[the $CXX compiler appears to not support C++14.
 
-Verilator requires a C++11 or newer compiler.]])
+Verilator requires a C++14 or newer compiler.]])
 
 fi
 AC_SUBST(CFG_CXXFLAGS_STD)

--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -144,6 +144,7 @@ Piotr Binkowski
 Qingyao Sun
 Quentin Corradi
 Rafal Kapuscik
+Rasfunk
 Raynard Qiao
 Richard Myers
 Risto Pejašinović

--- a/docs/guide/deprecations.rst
+++ b/docs/guide/deprecations.rst
@@ -8,11 +8,8 @@ The following deprecated items are scheduled for future removal:
 
 C++11 compiler support
   Verilator currently requires a C++20 or newer compiler for timing, and a
-  C++11 or newer compiler for no-timing.
-
-  Verilator will require C++14 or newer compilers for both compiling
-  Verilator and compiling Verilated models with --no-timing no sooner than
-  January 2023.
+  C++14 or newer compiler for both compiling Verilator and compiling
+  Verilated models with --no-timing.
 
   Verilator will require C++20 or newer compilers for both compiling
   Verilator and compiling all Verilated models no sooner than January 2025.

--- a/docs/internals.rst
+++ b/docs/internals.rst
@@ -1035,11 +1035,11 @@ Coding Conventions
 ==================
 
 
-Compiler Version and C++11
+Compiler Version and C++14
 --------------------------
 
-Verilator requires C11. Verilator does not require any newer versions, but
-is maintained to build successfully with C14/C17/C20.
+Verilator requires C14. Verilator does not require any newer versions, but
+is maintained to build successfully with C17/C20.
 
 
 Indentation and Naming Style

--- a/include/verilatedos.h
+++ b/include/verilatedos.h
@@ -258,11 +258,11 @@
 #endif
 
 //=========================================================================
-// C++-2011
+// C++-2014
 
-#if __cplusplus >= 201103L || defined(__GXX_EXPERIMENTAL_CXX0X__) || defined(VL_CPPCHECK) || defined(_MSC_VER)
+#if __cplusplus >= 201402L || defined(__GXX_EXPERIMENTAL_CXX0X__) || defined(VL_CPPCHECK) || defined(_MSC_VER)
 #else
-# error "Verilator requires a C++11 or newer compiler"
+# error "Verilator requires a C++14 or newer compiler"
 #endif
 
 #ifndef VL_NO_LEGACY


### PR DESCRIPTION
C++11 is not supported by Verilator for some time now. Enforcing it now to avoid compilation issues. Also, the detected 'std' compiler flag is propagated if the detected compiler does not support at least C++14.

This change fixes the issue #4784 for me.