### PR TITLE
VPI: vpi_get() should return vpiUndefined when error occurs

### DIFF
--- a/include/verilated_vpi.cpp
+++ b/include/verilated_vpi.cpp
@@ -1991,41 +1991,41 @@ PLI_INT32 vpi_get(PLI_INT32 property, vpiHandle object) {
     }
     case vpiType: {
         const VerilatedVpio* const vop = VerilatedVpio::castp(object);
-        if (VL_UNLIKELY(!vop)) return 0;
+        if (VL_UNLIKELY(!vop)) return vpiUndefined;
         return vop->type();
     }
     case vpiConstType: {
         const VerilatedVpio* const vop = VerilatedVpio::castp(object);
-        if (VL_UNLIKELY(!vop)) return 0;
+        if (VL_UNLIKELY(!vop)) return vpiUndefined;
         return vop->constType();
     }
     case vpiDirection: {
         // By forethought, the directions already are vpi enumerated
         const VerilatedVpioVarBase* const vop = VerilatedVpioVarBase::castp(object);
-        if (VL_UNLIKELY(!vop)) return 0;
+        if (VL_UNLIKELY(!vop)) return vpiUndefined;
         return vop->varp()->vldir();
     }
     case vpiScalar:  // FALLTHRU
     case vpiVector: {
         const VerilatedVpioVarBase* const vop = VerilatedVpioVarBase::castp(object);
-        if (VL_UNLIKELY(!vop)) return 0;
+        if (VL_UNLIKELY(!vop)) return vpiUndefined;
         return (property == vpiVector) ^ (vop->varp()->dims() == 0);
     }
     case vpiSize: {
         const VerilatedVpioVarBase* const vop = VerilatedVpioVarBase::castp(object);
-        if (VL_UNLIKELY(!vop)) return 0;
+        if (VL_UNLIKELY(!vop)) return vpiUndefined;
         return vop->size();
     }
     default:
-        VL_VPI_WARNING_(__FILE__, __LINE__, "%s: Unsupported type %s, nothing will be returned",
-                        __func__, VerilatedVpiError::strFromVpiProp(property));
-        return 0;
+        VL_VPI_ERROR_(__FILE__, __LINE__, "%s: Unsupported property %s, nothing will be returned",
+                      __func__, VerilatedVpiError::strFromVpiProp(property));
+        return vpiUndefined;
     }
 }
 
 PLI_INT64 vpi_get64(PLI_INT32 /*property*/, vpiHandle /*object*/) {
     VL_VPI_UNIMP_();
-    return 0;
+    return vpiUndefined;
 }
 
 PLI_BYTE8* vpi_get_str(PLI_INT32 property, vpiHandle object) {

--- a/test_regress/t/t_vpi_memory.cpp
+++ b/test_regress/t/t_vpi_memory.cpp
@@ -152,10 +152,10 @@ void _mem_check(const char* name, int size, int left, int right, int words) {
         // make sure trying to get properties that don't exist
         // doesn't crash
         TestVpiHandle iter_h = vpi_iterate(vpiMemoryWord, mem_h);
-        int should_be_0 = vpi_get(vpiSize, iter_h);
-        TEST_CHECK_EQ(should_be_0, 0);
-        should_be_0 = vpi_get(vpiIndex, iter_h);
-        TEST_CHECK_EQ(should_be_0, 0);
+        int should_be_undefined = vpi_get(vpiSize, iter_h);
+        TEST_CHECK_EQ(should_be_undefined, vpiUndefined);
+        should_be_undefined = vpi_get(vpiIndex, iter_h);
+        TEST_CHECK_EQ(should_be_undefined, vpiUndefined);
         vpiHandle should_be_NULL = vpi_handle(vpiLeftRange, iter_h);
         TEST_CHECK_EQ(should_be_NULL, 0);
         should_be_NULL = vpi_handle(vpiRightRange, iter_h);


### PR DESCRIPTION
See IEEE 1800-2017 section 38.6:

> Should an error occur, **vpi_get()** shall return **vpiUndefined**.
