### PR TITLE
Make V3Const.cpp parseable without errors

### DIFF
--- a/src/V3Const.cpp
+++ b/src/V3Const.cpp
@@ -41,6 +41,14 @@
 
 VL_DEFINE_DEBUG_FUNCTIONS;
 
+#define TREE_SKIP_VISIT(...)
+#define TREEOP1(...)
+#define TREEOPA(...)
+#define TREEOP(...)
+#define TREEOPS(...)
+#define TREEOPC(...)
+#define TREEOPV(...)
+
 //######################################################################
 // Utilities
 

--- a/src/astgen
+++ b/src/astgen
@@ -245,8 +245,8 @@ class Cpt:
                     self.output_func(lambda self: self._output_line())
                     self.tree_line(func)
                     didln = False
-                elif not re.match(r'^\s*/[/\*]\s*TREE', line) and re.search(
-                        r'\s+TREE', line):
+                elif not re.match(r'^\s*(#define|/[/\*])\s*TREE',
+                                  line) and re.search(r'\s+TREE', line):
                     self.error("Unknown astgen line: " + line)
                 else:
                     self.print(line)


### PR DESCRIPTION
This change removes all errors (hundreds of them) emitted by code completion tools, like clangd, in V3Const.cpp. As a result code analysis and completion when editing this file works a lot better.

The dummy macro defines are copied to V3Const__gen.cpp just like other C++ code. This is not a problem because all uses of those symbols were already replaced by astgen.