### PR TITLE
Fix VPI parameter iteration

### DIFF
--- a/include/verilated_vpi.cpp
+++ b/include/verilated_vpi.cpp
@@ -419,10 +419,19 @@ public:
             }
             if (m_onlyParams && !m_it->second.isParam()) continue;
             if (VL_UNLIKELY(m_topscopep)) {
-                if (const VerilatedVar* topvarp = m_topscopep->varFind(m_it->second.name()))
-                    return ((new VerilatedVpioVar{topvarp, m_topscopep})->castVpiHandle());
+                if (const VerilatedVar* topvarp = m_topscopep->varFind(m_it->second.name())) {
+                    if (topvarp->isParam()) {
+                        return ((new VerilatedVpioParam{topvarp, m_topscopep})->castVpiHandle());
+                    } else {
+                        return ((new VerilatedVpioVar{topvarp, m_topscopep})->castVpiHandle());
+                    }
+                }
             }
-            return ((new VerilatedVpioVar{&(m_it->second), m_scopep})->castVpiHandle());
+            if (m_it->second.isParam()) {
+                return ((new VerilatedVpioParam{&(m_it->second), m_scopep})->castVpiHandle());
+            } else {
+                return ((new VerilatedVpioVar{&(m_it->second), m_scopep})->castVpiHandle());
+            }
         }
     }
 };

--- a/test_regress/t/t_vpi_package.cpp
+++ b/test_regress/t/t_vpi_package.cpp
@@ -75,7 +75,9 @@ int count_params(TestVpiHandle& handle, int expectedParams) {
     int params = 0;
     while (true) {
         TestVpiHandle handle = vpi_scan(it);
-        if (handle == NULL) break;
+        if (!handle) break;
+        const int vpi_type = vpi_get(vpiType, handle);
+        CHECK_RESULT(vpi_type, vpiParameter);
         params++;
     }
     it.freed();


### PR DESCRIPTION
No check is done for parameter vs variable when iterating.
`vpi_handle_by_name` does the check, so iterating vs getting the handle directly would get a different object.