### PR TITLE
[Docs] Add a link to `Create-Binary Execution` to the list of examples

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -22,6 +22,7 @@ Cameron Kirk
 Chih-Mao Chen
 Chris Randall
 Chuxuan Wang
+Chykon
 Conor McCullough
 Dan Petrisko
 Daniel Bates

--- a/docs/guide/examples.rst
+++ b/docs/guide/examples.rst
@@ -9,6 +9,7 @@ Examples
 
 This section covers the following examples:
 
+* :ref:`Example Create-Binary Execution`
 * :ref:`Example C++ Execution`
 * :ref:`Example SystemC Execution`
 * :ref:`Examples in the Distribution`


### PR DESCRIPTION
No link to the [Create-Binary Execution](https://verilator.org/guide/latest/example_binary.html) subsection in the body of the [Examples](https://verilator.org/guide/latest/examples.html) section a little confusing, considering that it is indicated in the panel on the left and when you click on the `Next` button, you go to it.

This MR suggests adding a link to the `Create-Binary Execution` subsection. The result is shown below:

Before:

![Screenshot from 2024-01-04 15-09-32](https://github.com/verilator/verilator/assets/82272369/2cd01bcd-3788-4d3a-84ac-3292de0fe344)

After:

![Screenshot from 2024-01-04 15-10-07](https://github.com/verilator/verilator/assets/82272369/eeb6e798-f681-4924-ba37-d24daa84cf3f)