### PR TITLE
Avoid null pointer dereference from #4810

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -4,6 +4,7 @@ under the Developer Certificate of Origin (https://developercertificate.org/).
 Please see the Verilator manual for 200+ additional contributors. Thanks to all.
 
 Adam Bagley
+Adrian Sampson
 Adrien Le Masle
 Ahmed El-Mahmoudy
 Aleksander Kiryk

--- a/src/V3TraceDecl.cpp
+++ b/src/V3TraceDecl.cpp
@@ -259,10 +259,12 @@ class TraceDeclVisitor final : public VNVisitor {
             const std::string name = path.substr(pos == string::npos ? 0 : pos + 1);
 
             // Compute the type of the scope being fixed up
-            AstNodeModule* const modp = scopep->aboveCellp()->modp();
-            const VTracePrefixType scopeType = VN_IS(modp, Iface)
-                                                   ? VTracePrefixType::SCOPE_INTERFACE
-                                                   : VTracePrefixType::SCOPE_MODULE;
+            const AstCell* const cellp = scopep->aboveCellp();
+            const VTracePrefixType scopeType = cellp ? (
+                VN_IS((cellp->modp()), Iface)
+                                ? VTracePrefixType::SCOPE_INTERFACE
+                                : VTracePrefixType::SCOPE_MODULE
+                ) : VTracePrefixType::SCOPE_MODULE;
 
             // Push the scope prefix
             AstNodeStmt* const pushp = new AstTracePushPrefix{flp, name, scopeType};


### PR DESCRIPTION
With `-fno-inline`, for top-level modules, `scopep->aboveCellp()` is null. So we crash in the call to `modp()`. This is the simplest possible way I can see to avoid the crash, i.e., to check for a null "parent" and default to `SCOPE_MODULE`. I confess that I'm not sure this is the right fix (e.g., perhaps the scope should have a parent even with `-fno-inline`), but it at least seems plausible.