### PR TITLE
Use more standard syntax for avoiding unused variable warnings

### DIFF
--- a/include/verilated.cpp
+++ b/include/verilated.cpp
@@ -112,7 +112,8 @@ thread_local Verilated::ThreadLocal Verilated::t_s;
 
 #ifndef VL_USER_FINISH  ///< Define this to override the vl_finish function
 void vl_finish(const char* filename, int linenum, const char* hier) VL_MT_UNSAFE {
-    if (false && hier) {}  // Unused argument
+    // hier is unused in the default implementation.
+    (void)hier;
     VL_PRINTF(  // Not VL_PRINTF_MT, already on main thread
         "- %s:%d: Verilog $finish\n", filename, linenum);
     Verilated::threadContextp()->gotFinish(true);
@@ -140,7 +141,8 @@ void vl_stop(const char* filename, int linenum, const char* hier) VL_MT_UNSAFE {
 
 #ifndef VL_USER_FATAL  ///< Define this to override the vl_fatal function
 void vl_fatal(const char* filename, int linenum, const char* hier, const char* msg) VL_MT_UNSAFE {
-    if (false && hier) {}
+    // hier is unused in the default implementation.
+    (void)hier;
     Verilated::threadContextp()->gotError(true);
     Verilated::threadContextp()->gotFinish(true);
     if (filename && filename[0]) {
@@ -178,7 +180,8 @@ void vl_stop_maybe(const char* filename, int linenum, const char* hier, bool may
 
 #ifndef VL_USER_WARN  ///< Define this to override the vl_warn function
 void vl_warn(const char* filename, int linenum, const char* hier, const char* msg) VL_MT_UNSAFE {
-    if (false && hier) {}
+    // hier is unused in the default implementation.
+    (void)hier;
     if (filename && filename[0]) {
         // Not VL_PRINTF_MT, already on main thread
         VL_PRINTF("%%Warning: %s:%d: %s\n", filename, linenum, msg);

--- a/src/V3CCtors.cpp
+++ b/src/V3CCtors.cpp
@@ -67,10 +67,10 @@ class V3CCtorsBuilder final {
         string preventUnusedStmt;
         if (m_type.isClass()) {
             funcp->argTypes(EmitCBase::symClassVar());
-            preventUnusedStmt = "if (false && vlSymsp) {}  // Prevent unused\n";
+            preventUnusedStmt = "(void)vlSymsp;  // Prevent unused variable warning\n";
         } else if (m_type.isCoverage()) {
             funcp->argTypes("bool first");
-            preventUnusedStmt = "if (false && first) {}  // Prevent unused\n";
+            preventUnusedStmt = "(void)first;  // Prevent unused variable warning\n";
         }
         if (!preventUnusedStmt.empty()) {
             funcp->addStmtsp(new AstCStmt{m_modp->fileline(), preventUnusedStmt});

--- a/src/V3EmitCFunc.h
+++ b/src/V3EmitCFunc.h
@@ -286,7 +286,7 @@ public:
             m_lazyDecls.declared(nodep);  // Defined here, so no longer needs declaration
             if (!nodep->isStatic()) {  // Standard prologue
                 m_useSelfForThis = true;
-                puts("if (false && vlSelf) {}  // Prevent unused\n");
+                puts("(void)vlSelf;  // Prevent unused variable warning\n");
                 if (!VN_IS(m_modp, Class)) puts(symClassAssign());
             }
         }

--- a/src/V3EmitCImp.cpp
+++ b/src/V3EmitCImp.cpp
@@ -293,7 +293,7 @@ class EmitCImp final : EmitCFunc {
         }
 
         puts("\nvoid " + modName + "::" + protect("__Vconfigure") + "(bool first) {\n");
-        puts("if (false && first) {}  // Prevent unused\n");
+        puts("(void)first;  // Prevent unused variable warning\n");
         if (v3Global.opt.coverage()) {
             puts(modName + "__" + protect("_configure_coverage") + "(this, first);\n");
         }

--- a/src/V3EmitCModel.cpp
+++ b/src/V3EmitCModel.cpp
@@ -548,7 +548,7 @@ class EmitCModel final : public EmitCFunc {
              + +"::trace()' shall not be called after '" + v3Global.opt.traceClassBase()
              + "C::open()'.\");\n");
         puts(/**/ "}\n");
-        puts(/**/ "if (false && levels && options) {}  // Prevent unused\n");
+        puts(/**/ "(void)levels; (void)options; // Prevent unused variable warning\n");
         puts(/**/ "tfp->spTrace()->addModel(this);\n");
         puts(/**/ "tfp->spTrace()->addInitCb(&" + protect("trace_init") + ", &(vlSymsp->TOP));\n");
         puts(/**/ topModNameProtected + "__" + protect("trace_register")

--- a/src/V3Trace.cpp
+++ b/src/V3Trace.cpp
@@ -533,7 +533,7 @@ class TraceVisitor final : public VNVisitor {
                     addInitStr("const uint32_t base VL_ATTR_UNUSED = "
                                "vlSymsp->__Vm_baseCode + "
                                + cvtToStr(baseCode) + ";\n");
-                    addInitStr("if (false && bufp) {}  // Prevent unused\n");
+                    addInitStr("(void)bufp;  // Prevent unused variable warning\n");
                 } else {
                     addInitStr("uint32_t* const oldp VL_ATTR_UNUSED = "
                                "bufp->oldp(vlSymsp->__Vm_baseCode + "


### PR DESCRIPTION
This is the standard way of avoiding unused variable warnings in C/C++. Since C++17 there is also the `[[maybe_unused]]` attribute but that would be a bigger change since it has to be applied to the declaration.

We appreciate your contributing to Verilator.  If this is your first commit, please add your name to docs/CONTRIBUTORS, and read our contributing guidelines in docs/CONTRIBUTING.rst.
