### PR TITLE
Fix wrong utimes() param

### DIFF
--- a/src/V3Os.cpp
+++ b/src/V3Os.cpp
@@ -318,9 +318,7 @@ void V3Os::filesystemFlushBuildDir(const string& dirname) {
     // Attempt to force out written directory, for NFS like file systems.
 #if !defined(_MSC_VER) && !defined(__MINGW32__)
     // Linux kernel may not reread from NFS unless timestamp modified
-    struct timeval tv;
-    gettimeofday(&tv, NULL);
-    const int err = utimes(dirname.c_str(), &tv);
+    const int err = utimes(dirname.c_str(), nullptr);
     // Not an error
     if (err != 0) UINFO(1, "-Info: File not utimed: " << dirname << endl);
 #endif


### PR DESCRIPTION
`utimes()` expects to receive array with two timevals (or NULL pointer) -
times[0] for access time and times[1] for modification time.
We have been passing pointer to only one timeval instead.

This bugfix calls `utimes()` with NULL which is equivalent of
passing array with two timevals equal to current time.

ref: https://linux.die.net/man/2/utimes
