### PR TITLE
Added failing test for iff use in assert property

### DIFF
--- a/test_regress/t/t_assert_property_iff_unsup.pl
+++ b/test_regress/t/t_assert_property_iff_unsup.pl
@@ -1,0 +1,16 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2008 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(vlt => 1);
+
+lint();
+
+ok(1);
+1;

--- a/test_regress/t/t_assert_property_iff_unsup.v
+++ b/test_regress/t/t_assert_property_iff_unsup.v
@@ -1,0 +1,9 @@
+module test(
+  input clk,
+  input rst,
+  input x
+);
+
+a: assert property (disable iff(rst !== 1'b0) @(posedge clk) !x);
+
+endmodule


### PR DESCRIPTION
As requested in #1482, here is a testcase that still fails the Verilog parser.
I've checked this in edaplayground.com with the Riviera  simulator as well as one of the BIG3 at work and both compile this example just fne.
In my specific case, I don't care much for the assertion itself, but would rather have it not cause a compilation failure.
Sorry for taking this long.
