### PR TITLE
Fix #4832 of incorrect bit-op-tree optimization

### DIFF
--- a/src/V3Const.cpp
+++ b/src/V3Const.cpp
@@ -541,6 +541,8 @@ class ConstBitOpTreeVisitor final : public VNVisitorConst {
             CONST_BITOP_RETURN_IF(m_failed, nodep->rhsp());
             restorer.disableRestore();  // Now all checks passed
         } else if (nodep->type() == m_rootp->type()) {  // And, Or, Xor
+            // subtree under NOT can be optimized only in XOR tree.
+            CONST_BITOP_RETURN_IF(!m_polarity && !isXorTree(), nodep);
             incrOps(nodep, __LINE__);
             for (const bool right : {false, true}) {
                 VL_RESTORER(m_leafp);
@@ -556,6 +558,7 @@ class ConstBitOpTreeVisitor final : public VNVisitorConst {
                     // Reach past a cast then add to frozen nodes to be added to final reduction
                     if (const AstCCast* const castp = VN_CAST(opp, CCast)) opp = castp->lhsp();
                     const bool pol = isXorTree() || m_polarity;  // Only AND/OR tree needs polarity
+                    UASSERT(pol, "AND/OR tree expects m_polarity==true");
                     m_frozenNodes.emplace_back(opp, FrozenNodeInfo{pol, m_lsb});
                     m_failed = origFailed;
                     continue;


### PR DESCRIPTION
Fixes #4832.

`a & b` in `!(a & b) & c` has to be untouched, but was not.

As usual, push the test to reproduce #4832, then will push the fix for it later.

I'm a bit surprised at how long such a simple bug has been there.

ext tests pass.