### PR TITLE
Fix #4857 consider NOT when checking EQ/NEQ under AND/OR tree

### DIFF
--- a/src/V3Const.cpp
+++ b/src/V3Const.cpp
@@ -594,7 +594,7 @@ class ConstBitOpTreeVisitor final : public VNVisitorConst {
             const V3Number& compNum = constp->num();
 
             auto setPolarities = [this, &compNum](const LeafInfo& ref, const V3Number* maskp) {
-                const bool maskFlip = isOrTree();
+                const bool maskFlip = isAndTree() ^ ref.polarity();
                 int constantWidth = compNum.width();
                 if (maskp) constantWidth = std::max(constantWidth, maskp->width());
                 const int maxBitIdx = std::max(ref.lsb() + constantWidth, ref.msb() + 1);

--- a/test_regress/t/t_const_opt_dfg.pl
+++ b/test_regress/t/t_const_opt_dfg.pl
@@ -9,10 +9,11 @@ if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); di
 # SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
 
 scenarios(simulator => 1);
+top_filename("t/t_const_opt.v");
 
 compile(
-    verilator_flags2 => ["-Wno-UNOPTTHREADS", "-fno-dfg",
-                         "--stats", "$Self->{t_dir}/$Self->{name}.cpp"],
+    verilator_flags2 => ["-Wno-UNOPTTHREADS",
+                         "--stats", "$Self->{t_dir}/t_const_opt.cpp"],
     );
 
 execute(
@@ -20,7 +21,7 @@ execute(
     );
 
 if ($Self->{vlt}) {
-    file_grep($Self->{stats}, qr/Optimizations, Const bit op reduction\s+(\d+)/i, 39);
+    file_grep($Self->{stats}, qr/Optimizations, Const bit op reduction\s+(\d+)/i, 34);
 }
 ok(1);
 1;


### PR DESCRIPTION
Fix #4857 
DFG opt is necessary to trigger the bug. So .pl that enabled DFG opt. is added.

Push a test, then push the fix for it later as usual.

ext tests pass.