### PR TITLE
Fix sysc VL_ASSIGN_SBW biguint sign desynchronization

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -19,6 +19,7 @@ Andrew Nolte
 Anthony Donlon
 Arkadiusz Kozdra
 Aylon Chaim Porat
+Bartłomiej Chmiel
 Cameron Kirk
 Chih-Mao Chen
 Chris Randall

--- a/include/verilated_funcs.h
+++ b/include/verilated_funcs.h
@@ -520,6 +520,7 @@ static inline void VL_ASSIGNBIT_WO(int bit, WDataOutP owp) VL_MT_SAFE {
             const uint32_t msb_data = VL_SEL_IWII((obits) + 1, (rwp).data(), lsb, (obits)-lsb); \
             *chunkp = msb_data & VL_MASK_E((obits)-lsb); \
         } \
+        _butemp.set(0, *(rwp).data() & 1); \
         (svar).write(_butemp); \
     }
 

--- a/include/verilated_funcs.h
+++ b/include/verilated_funcs.h
@@ -520,7 +520,7 @@ static inline void VL_ASSIGNBIT_WO(int bit, WDataOutP owp) VL_MT_SAFE {
             const uint32_t msb_data = VL_SEL_IWII((obits) + 1, (rwp).data(), lsb, (obits)-lsb); \
             *chunkp = msb_data & VL_MASK_E((obits)-lsb); \
         } \
-        _butemp.set(0, *(rwp).data() & 1); \
+        _butemp.set(0, *(rwp).data() & 1); /* force update the sign */ \
         (svar).write(_butemp); \
     }
 

--- a/test_regress/t/t_vl_assign_sbw.cpp
+++ b/test_regress/t/t_vl_assign_sbw.cpp
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: CC0-1.0
 
 #include VM_PREFIX_INCLUDE
+
 #include <systemc.h>
 
 #include <sysc/kernel/sc_simcontext.h>
@@ -19,11 +20,17 @@ int sc_main(int argc, char* argv[]) {
     tb->in(in);
     tb->out(out);
 
+    bool pass = out.read().iszero();
+
     sc_start(1, SC_NS);
 
-    if (out == val) VL_PRINTF("*-* All Finished *-*\n");
+    pass &= !out.read().iszero();
+    pass &= out == val;
 
     tb->final();
     VL_DO_DANGLING(delete tb, tb);
+
+    if (pass) { VL_PRINTF("*-* All Finished *-*\n"); }
+
     return 0;
 }

--- a/test_regress/t/t_vl_assign_sbw.cpp
+++ b/test_regress/t/t_vl_assign_sbw.cpp
@@ -1,0 +1,29 @@
+// -*- mode: C++; c-file-style: "cc-mode" -*-
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2024 by Antmicro.
+// SPDX-License-Identifier: CC0-1.0
+
+#include VM_PREFIX_INCLUDE
+#include <systemc.h>
+
+#include <sysc/kernel/sc_simcontext.h>
+
+int sc_main(int argc, char* argv[]) {
+    using namespace sc_core;
+
+    VM_PREFIX* tb = new VM_PREFIX{"t"};
+    constexpr int val = 1;
+    sc_signal<sc_biguint<256>> SC_NAMED(in, val);
+    sc_signal<sc_biguint<256>> SC_NAMED(out);
+
+    tb->in(in);
+    tb->out(out);
+
+    sc_start(1, SC_NS);
+
+    if (out == val) VL_PRINTF("*-* All Finished *-*\n");
+
+    tb->final();
+    VL_DO_DANGLING(delete tb, tb);
+    return 0;
+}

--- a/test_regress/t/t_vl_assign_sbw.pl
+++ b/test_regress/t/t_vl_assign_sbw.pl
@@ -1,0 +1,24 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2024 by Antmicro. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    make_top_shell => 0,
+    make_main => 0,
+    verilator_flags2 => ["--exe --pins-sc-biguint --sc $Self->{t_dir}/t_vl_assign_sbw.cpp"],
+);
+
+execute(
+    check_finished => 1
+);
+
+ok(1);
+1;

--- a/test_regress/t/t_vl_assign_sbw.v
+++ b/test_regress/t/t_vl_assign_sbw.v
@@ -15,4 +15,15 @@ module t(
    logic tmp = $c(0);
    typedef logic[255:0] biguint;
    assign out = in + biguint'(tmp);
+
+   always @(out) begin
+      if (in !== 1) begin
+         $write("'in' mismatch: (1 !== %d)\n", logic'(in));
+         $stop;
+      end
+      else if (out !== 1) begin
+         $write("'out' mismatch: (1 !== %d)\n", logic'(out));
+         $stop;
+      end
+   end
 endmodule

--- a/test_regress/t/t_vl_assign_sbw.v
+++ b/test_regress/t/t_vl_assign_sbw.v
@@ -1,0 +1,18 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// Copyright 2024 by Antmicro. This program is free software; you can
+// redistribute it and/or modify it under the terms of either the GNU
+// Lesser General Public License Version 3 or the Perl Artistic License
+// Version 2.0.
+// SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+module t(
+   input [255:0] in,
+   output [255:0] out
+   );
+
+   // do not optimize assignment
+   logic tmp = $c(0);
+   typedef logic[255:0] biguint;
+   assign out = in + biguint'(tmp);
+endmodule


### PR DESCRIPTION
A while ago a patch to Verilator has been submitted that addressed a certain race condition in SystemC models: [#3513](https://github.com/verilator/verilator/pull/3513).
After that patch, the `VL_ASSIGN_SBW` macro writes into a SystemC variable by directly accessing the underlying array. But the original code did more than change that array; it all starts with:
* [`sc_biguint::range()`](https://github.com/accellera-official/systemc/blob/5fc1469339775b54b1fcc2020ac744a58be5b50e/src/sysc/datatypes/int/sc_unsigned.h#L1170) (or actually `sc_unsigned::range`, as it's inherited from `sc_unsigned`) which returns `sc_unsigned_subref` which is then assigned:
* via [`operator=`](https://github.com/accellera-official/systemc/blob/5fc1469339775b54b1fcc2020ac744a58be5b50e/src/sysc/datatypes/int/sc_unsigned_subref.inc#L200) which calls (for each assigned bit):
* [`sc_unsigned::set(i, v)`](https://github.com/accellera-official/systemc/blob/5fc1469339775b54b1fcc2020ac744a58be5b50e/src/sysc/datatypes/int/sc_unsigned.h#L1266) which calls:
* [`sc_unsigned::set(i)` or `sc_unsigned::clear(i)`](https://github.com/accellera-official/systemc/blob/5fc1469339775b54b1fcc2020ac744a58be5b50e/src/sysc/datatypes/int/sc_nbcommon.inc#L2435) which does a bunch of things, but the most important for us is:
* [`convert_2C_to_SM`](https://github.com/accellera-official/systemc/blob/5fc1469339775b54b1fcc2020ac744a58be5b50e/src/sysc/datatypes/int/sc_unsigned.h#L2003) which assigns to `this->sgn` the return value of:
* [`convert_unsigned_2C_to_SM()`](https://github.com/accellera-official/systemc/blob/5fc1469339775b54b1fcc2020ac744a58be5b50e/src/sysc/datatypes/int/sc_nbutils.h#L886) which returns:
* [`check_for_zero(SC_POS, ...)`](https://github.com/accellera-official/systemc/blob/5fc1469339775b54b1fcc2020ac744a58be5b50e/src/sysc/datatypes/int/sc_nbutils.h#L694) which returns `SC_ZERO` if the given number is zero (`SC_POS` otherwise).

So either `SC_ZERO` or `SC_POS` should be assigned to `sc_biguint`'s `sgn` field. But if we manipulate the underlying array directly, that never happens.

At the very least, `sgn` is used for [`iszero()`](https://github.com/accellera-official/systemc/blob/5fc1469339775b54b1fcc2020ac744a58be5b50e/src/sysc/datatypes/int/sc_unsigned.cpp#L2149), but possibly also in other places.

The fix updates `sc_unsigned::sgn` after the assignment in `VL_ASSIGN_SBW`.