### PR TITLE
CI: Update upload-artifacts/download-artifacts version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,7 @@ jobs:
       run: tar --posix -c -z -f ${{ env.VERILATOR_ARCHIVE }} repo
 
     - name: Upload tar archive
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: ${{ github.workspace }}/${{ env.VERILATOR_ARCHIVE }}
         name: ${{ env.VERILATOR_ARCHIVE }}
@@ -115,7 +115,7 @@ jobs:
     steps:
 
     - name: Download tar archive
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: ${{ env.VERILATOR_ARCHIVE }}
         path: ${{ github.workspace }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -45,7 +45,7 @@ jobs:
       run: tar --posix -c -z -f ${{ env.VERILATOR_ARCHIVE }} repo
 
     - name: Upload tar archive
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: ${{ github.workspace }}/${{ env.VERILATOR_ARCHIVE }}
         name: ${{ env.VERILATOR_ARCHIVE }}
@@ -80,7 +80,7 @@ jobs:
     steps:
 
     - name: Download tar archive
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: ${{ env.VERILATOR_ARCHIVE }}
         path: ${{ github.workspace }}

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -49,7 +49,7 @@ jobs:
     - name: Zip up repository
       run: Compress-Archive -LiteralPath install -DestinationPath verilator.zip
     - name: Upload zip archive
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: ${{ github.workspace }}/repo/verilator.zip
         name: verilator-win.zip


### PR DESCRIPTION
Fix github warnings:

`Node.js 16 actions are deprecated. Please  update the following actions to use Node.js 20:  actions/upload-artifact@v3. For more information see:  https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.`
