### PR TITLE
Fix timing with expression on assignment LHS

### DIFF
--- a/src/V3SchedTiming.cpp
+++ b/src/V3SchedTiming.cpp
@@ -247,7 +247,6 @@ TimingKit prepareTiming(AstNetlist* const netlistp) {
         void visit(AstExprStmt* nodep) override { iterateChildren(nodep); }
 
         //--------------------
-        void visit(AstNodeExpr*) override {}  // Accelerate
         void visit(AstNode* nodep) override { iterateChildren(nodep); }
 
     public:

--- a/test_regress/t/t_timing_write_expr.pl
+++ b/test_regress/t/t_timing_write_expr.pl
@@ -1,0 +1,23 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2019 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    verilator_flags2 => ["--exe --main --timing"],
+    make_main => 0,
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_timing_write_expr.v
+++ b/test_regress/t/t_timing_write_expr.v
@@ -1,0 +1,27 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2023 by Antmicro.
+// SPDX-License-Identifier: CC0-1.0
+
+module t;
+   reg [7:0] vec1 [3:0], vec2 [3:0];
+
+   always
+      for (int i = 0; i < 4; i++)
+         vec2[i] = vec1[i];
+
+   initial begin
+      #1 vec1[0] = 8'h0f;
+      #1 vec1[1] = 8'h04;
+      #1 vec1[2] = 8'h0e;
+      #1 vec1[3] = 8'h0a;
+
+      #1
+      for (int i = 0; i < 4; i++)
+         if (vec1[i] != vec2[i]) $stop;
+
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end
+endmodule


### PR DESCRIPTION
The timing code seemed to assume that expressions cannot contain write references, which is untrue, specifically for index access on the LHS of an assignment. This PR fixes that.

Closes #4868.