### PR TITLE
Allow all verilation threads to use large stack size

### DIFF
--- a/bin/verilator
+++ b/bin/verilator
@@ -204,10 +204,13 @@ sub aslr_off {
 
 sub ulimit_stack_unlimited {
     return "" if !$opt_unlimited_stack;
-    system("ulimit -s unlimited 2>/dev/null");
+    # Beware that with pthreads, ulimit -s unlimited only applies to the
+    # main thread, while additional threads would have default stack size.
+    my $limit = 32*1024*1024;  # 32GiB (units in 1KiB)
+    system("ulimit -s $limit 2>/dev/null");
     my $status = $?;
     if ($status == 0) {
-        return "ulimit -s unlimited 2>/dev/null; exec ";
+        return "ulimit -s $limit 2>/dev/null; exec ";
     } else {
         return "";
     }


### PR DESCRIPTION
Without `--no-unlimited-stack` we used to use `ulimit -s unlimited` to set the stack size to, well, unlimited.

Beware that with the pthread implementation (used by std::thread), this only applies to the main thread, and any other threads created for `--verilate-jobs` will still use the default stack size (there is no std C++ way to influence this as far as I know).

from `man pthread_create`:

```
Under the NPTL threading implementation, if the RLIMIT_STACK soft resource
limit at the  time  the program started has any value other than "unlimited",
then it determines the default stack size of new threads.  Using
pthread_attr_setstacksize(3), the stack size attribute can be  explicitly  set
in  the  attr argument used to create a thread, in order to obtain a stack size
other than the de‐ fault.  If the RLIMIT_STACK resource limit is set to
"unlimited", a per-architecture value is used for the stack size.
```

The default for x86-64 is 2MB.

Using 'ulimit -s \<large number\>' instead will apply to all threads.

This patch sets the limit to 32GiB, to apply to all threads.
