### PR TITLE
Add --[no]-stop-fail option

### DIFF
--- a/bin/verilator
+++ b/bin/verilator
@@ -437,6 +437,7 @@ detailed descriptions of these arguments.
     --stats                     Create statistics file
     --stats-vars                Provide statistics on variables
     --no-std                    Prevent parsing standard library
+    --no-stop-fail              Do not call $stop when assertion fails
     --structs-packed            Convert all unpacked structures to packed structures
      -sv                        Enable SystemVerilog parsing
      +systemverilogext+<ext>    Synonym for +1800-2017ext+<ext>

--- a/docs/guide/exe_verilator.rst
+++ b/docs/guide/exe_verilator.rst
@@ -1280,6 +1280,10 @@ Summary:
 
    Prevents parsing standard library.
 
+.. option:: --no-stop-fail
+
+   Not to call $stop when assertion fails. Simulation continues.
+
 .. option:: --structs-packed
 
    Converts all unpacked structures to packed structures, and issues an

--- a/src/V3Assert.cpp
+++ b/src/V3Assert.cpp
@@ -127,7 +127,7 @@ class AssertVisitor final : public VNVisitor {
         AstNode* const bodysp = dispp;
         replaceDisplay(dispp, "%%Error");  // Convert to standard DISPLAY format
         if (exprsp) dispp->fmtp()->exprsp()->addNext(exprsp);
-        bodysp->addNext(new AstStop{nodep->fileline(), true});
+        if (v3Global.opt.stopFail()) bodysp->addNext(new AstStop{nodep->fileline(), true});
         return bodysp;
     }
 

--- a/src/V3Options.cpp
+++ b/src/V3Options.cpp
@@ -1442,6 +1442,7 @@ void V3Options::parseOptsList(FileLine* fl, const string& optdir, int argc,
         m_stats |= flag;
     });
     DECL_OPTION("-std", OnOff, &m_std);
+    DECL_OPTION("-stop-fail", OnOff, &m_stopFail);
     DECL_OPTION("-structs-packed", OnOff, &m_structsPacked);
     DECL_OPTION("-sv", CbCall, [this]() { m_defaultLanguage = V3LangCode::L1800_2017; });
 

--- a/src/V3Options.h
+++ b/src/V3Options.h
@@ -315,6 +315,7 @@ private:
     int         m_publicDepth = 0;   // main switch: --public-depth
     int         m_reloopLimit = 40; // main switch: --reloop-limit
     VOptionBool m_skipIdentical;  // main switch: --skip-identical
+    bool        m_stopFail = true;  // main switch: --stop-fail
     int         m_threads = 1;      // main switch: --threads
     int         m_threadsMaxMTasks = 0;  // main switch: --threads-max-mtasks
     VTimescale  m_timeDefaultPrec;  // main switch: --timescale
@@ -549,6 +550,7 @@ public:
     int publicDepth() const { return m_publicDepth; }
     int reloopLimit() const { return m_reloopLimit; }
     VOptionBool skipIdentical() const { return m_skipIdentical; }
+    bool stopFail() const { return m_stopFail; }
     int threads() const VL_MT_SAFE { return m_threads; }
     int threadsMaxMTasks() const { return m_threadsMaxMTasks; }
     bool mtasks() const { return (m_threads > 1); }

--- a/test_regress/t/t_assert_unique_case.out
+++ b/test_regress/t/t_assert_unique_case.out
@@ -1,0 +1,12 @@
+match_item0
+match_item0
+match_item0
+match_item0
+match_item0
+match_item0
+match_item0
+match_item0
+match_item0
+[90] %Error: t_assert_unique_case_bad.v:36: Assertion failed in top.t: unique case, but multiple matches found for '12'h388'
+*-* All Finished *-*
+match_item0

--- a/test_regress/t/t_assert_unique_case.pl
+++ b/test_regress/t/t_assert_unique_case.pl
@@ -1,0 +1,24 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2024 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+top_filename("t/t_assert_unique_case_bad.v");
+
+compile(
+    verilator_flags2 => ["-x-assign 0 --assert --no-stop-fail"],
+    );
+
+execute(
+    check_finished => 1,
+    expect_filename => $Self->{golden_filename},
+    );
+
+ok(1);
+1;


### PR DESCRIPTION
Part of #4830

When `--no-stop-fail` is set, simulation continues even when assertion fails.