### PR TITLE
Docs: Fix typo in the call condition of designp->nextTimeSlot()

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -76,6 +76,7 @@ James Shi
 Jamey Hicks
 Jamie Iles
 Jan Van Winkel
+Jiangjie Weng
 Jean Berniolles
 Jeremy Bennett
 Jesse Taube

--- a/docs/guide/connecting.rst
+++ b/docs/guide/connecting.rst
@@ -500,7 +500,7 @@ the user should call:
      any delayed events pending,
    * :code:`designp->nextTimeSlot()`, which returns the simulation time of the
      next delayed event. This method can only be called if
-     :code:`designp->nextTimeSlot()` returned :code:`true`.
+     :code:`designp->eventsPending()` returned :code:`true`.
 
 Call :code:`eventsPending()` to check if you should continue with the
 simulation, and then :code:`nextTimeSlot()` to move simulation time forward.


### PR DESCRIPTION
>    **designp->nextTimeSlot()**, which returns the simulation time of the next delayed event. This method
can only be called if **designp->nextTimeSlot()** returned true.  

The document mentions that calling `designp->nextTimeSlot()` requires that `designp->nextTimeSlot()` return `true`, which is obviously unreasonable.  
From the context and the main.cpp generated by verilator, it should be `designp->eventsPending()`.