### PR TITLE
Fix Vpi Generate Scopes

### DIFF
--- a/include/verilated_vpi.cpp
+++ b/include/verilated_vpi.cpp
@@ -263,33 +263,24 @@ class VerilatedVpioScope VL_NOT_FINAL : public VerilatedVpio {
 protected:
     const VerilatedScope* const m_scopep;
     bool m_toplevel = false;
+    const char* m_name;
+    const char* m_fullname;
 
 public:
     explicit VerilatedVpioScope(const VerilatedScope* scopep)
         : m_scopep{scopep} {
-        std::string scopename = m_scopep->name();
-        std::string::size_type pos = std::string::npos;
-        // Look for '.' not inside escaped identifier
-        size_t i = 0;
-        while (i < scopename.length()) {
-            if (scopename[i] == '\\') {
-                while (i < scopename.length() && scopename[i] != ' ') ++i;
-                ++i;  // Proc ' ', it should always be there. Then grab '.' on next cycle
-            } else {
-                while (i < scopename.length() && scopename[i] != '.') ++i;
-                if (i < scopename.length()) pos = i++;
-            }
-        }
-        if (VL_UNLIKELY(pos == std::string::npos)) m_toplevel = true;
+        m_fullname = m_scopep->name();
+        if (std::strncmp(m_fullname, "TOP.", 4) == 0) m_fullname += 4;
+        m_name = m_scopep->identifier();
     }
     ~VerilatedVpioScope() override = default;
     static VerilatedVpioScope* castp(vpiHandle h) {
         return dynamic_cast<VerilatedVpioScope*>(reinterpret_cast<VerilatedVpio*>(h));
     }
-    uint32_t type() const override { return vpiScope; }
+    uint32_t type() const override { return vpiGenScope; }
     const VerilatedScope* scopep() const { return m_scopep; }
-    const char* name() const override { return m_scopep->name(); }
-    const char* fullname() const override { return m_scopep->name(); }
+    const char* name() const override { return m_name; }
+    const char* fullname() const override { return m_fullname; }
     bool toplevel() const { return m_toplevel; }
 };
 
@@ -469,22 +460,29 @@ public:
 };
 
 class VerilatedVpioModule final : public VerilatedVpioScope {
-    const char* m_name;
-    const char* m_fullname;
 
 public:
     explicit VerilatedVpioModule(const VerilatedScope* modulep)
         : VerilatedVpioScope{modulep} {
-        m_fullname = m_scopep->name();
-        if (std::strncmp(m_fullname, "TOP.", 4) == 0) m_fullname += 4;
-        m_name = m_scopep->identifier();
+        // Look for '.' not inside escaped identifier
+        const std::string scopename = m_fullname;
+        std::string::size_type pos = std::string::npos;
+        size_t i = 0;
+        while (i < scopename.length()) {
+            if (scopename[i] == '\\') {
+                while (i < scopename.length() && scopename[i] != ' ') ++i;
+                ++i;  // Proc ' ', it should always be there. Then grab '.' on next cycle
+            } else {
+                while (i < scopename.length() && scopename[i] != '.') ++i;
+                if (i < scopename.length()) pos = i++;
+            }
+        }
+        if (VL_UNLIKELY(pos == std::string::npos)) m_toplevel = true;
     }
     static VerilatedVpioModule* castp(vpiHandle h) {
         return dynamic_cast<VerilatedVpioModule*>(reinterpret_cast<VerilatedVpio*>(h));
     }
     uint32_t type() const override { return vpiModule; }
-    const char* name() const override { return m_name; }
-    const char* fullname() const override { return m_fullname; }
 };
 
 class VerilatedVpioModuleIter final : public VerilatedVpio {
@@ -507,8 +505,8 @@ public:
                 delete this;  // IEEE 37.2.2 vpi_scan at end does a vpi_release_handle
                 return nullptr;
             }
-            const VerilatedScope::Type itype = (*m_it)->type();
             const VerilatedScope* const modp = *m_it++;
+            const VerilatedScope::Type itype = modp->type();
             if (itype == VerilatedScope::SCOPE_MODULE) {
                 return (new VerilatedVpioModule{modp})->castVpiHandle();
             }
@@ -516,26 +514,54 @@ public:
     }
 };
 
+class VerilatedVpioScopeIter final : public VerilatedVpio {
+    const std::vector<const VerilatedScope*>* m_vec;
+    std::vector<const VerilatedScope*>::const_iterator m_it;
+
+public:
+    explicit VerilatedVpioScopeIter(const std::vector<const VerilatedScope*>& vec)
+        : m_vec{&vec} {
+        m_it = m_vec->begin();
+    }
+    ~VerilatedVpioScopeIter() override = default;
+    static VerilatedVpioScopeIter* castp(vpiHandle h) {
+        return dynamic_cast<VerilatedVpioScopeIter*>(reinterpret_cast<VerilatedVpio*>(h));
+    }
+    uint32_t type() const override { return vpiIterator; }
+    vpiHandle dovpi_scan() override {
+        while (true) {
+            if (m_it == m_vec->end()) {
+                delete this;  // IEEE 37.2.2 vpi_scan at end does a vpi_release_handle
+                return nullptr;
+            }
+            const VerilatedScope* const modp = *m_it++;
+            const VerilatedScope::Type itype = modp->type();
+            if (itype == VerilatedScope::SCOPE_OTHER) {
+                return (new VerilatedVpioScope{modp})->castVpiHandle();
+            } else if (itype == VerilatedScope::SCOPE_MODULE) {
+                return (new VerilatedVpioModule{modp})->castVpiHandle();
+            }
+        }
+    }
+};
+
+static const char* d_unit = "$unit";
 class VerilatedVpioPackage final : public VerilatedVpioScope {
-    std::string m_name;
-    std::string m_fullname;
+    std::string m_fullname_string;
 
 public:
     explicit VerilatedVpioPackage(const VerilatedScope* modulep)
         : VerilatedVpioScope{modulep} {
-        const char* sfullname = m_scopep->name();
-        if (std::strncmp(sfullname, "TOP.", 4) == 0) sfullname += 4;
-        m_fullname = std::string{sfullname} + "::";
-        if (m_fullname == "\\$unit ::") m_fullname = "$unit::";
-        m_name = std::string(m_scopep->identifier());
-        if (m_name == "\\$unit ") m_name = "$unit";
+        m_fullname_string = std::string{m_fullname} + "::";
+        if (m_fullname_string == "\\$unit ::") m_fullname_string = "$unit::";
+
+        if (strcmp(m_name, "\\$unit ") == 0) { m_name = d_unit; }
     }
     static VerilatedVpioPackage* castp(vpiHandle h) {
         return dynamic_cast<VerilatedVpioPackage*>(reinterpret_cast<VerilatedVpio*>(h));
     }
+    const char* fullname() const override { return m_fullname_string.c_str(); }
     uint32_t type() const override { return vpiPackage; }
-    const char* name() const override { return m_name.c_str(); }
-    const char* fullname() const override { return m_fullname.c_str(); }
 };
 
 class VerilatedVpioInstanceIter final : public VerilatedVpio {
@@ -1978,12 +2004,20 @@ vpiHandle vpi_iterate(PLI_INT32 type, vpiHandle object) {
         return ((new VerilatedVpioVarIter{vop, true})->castVpiHandle());
     }
     case vpiModule: {
-        const VerilatedVpioModule* const vop = VerilatedVpioModule::castp(object);
+        const VerilatedVpioScope* const vop = VerilatedVpioScope::castp(object);
         const VerilatedHierarchyMap* const map = VerilatedImp::hierarchyMap();
         const VerilatedScope* const modp = vop ? vop->scopep() : nullptr;
         const auto it = vlstd::as_const(map)->find(const_cast<VerilatedScope*>(modp));
         if (it == map->end()) return nullptr;
         return ((new VerilatedVpioModuleIter{it->second})->castVpiHandle());
+    }
+    case vpiInternalScope: {
+        const VerilatedVpioScope* const vop = VerilatedVpioScope::castp(object);
+        const VerilatedHierarchyMap* const map = VerilatedImp::hierarchyMap();
+        const VerilatedScope* const modp = vop ? vop->scopep() : nullptr;
+        const auto it = vlstd::as_const(map)->find(const_cast<VerilatedScope*>(modp));
+        if (it == map->end()) return nullptr;
+        return ((new VerilatedVpioScopeIter{it->second})->castVpiHandle());
     }
     case vpiInstance: {
         if (object) return nullptr;

--- a/src/V3EmitCSyms.cpp
+++ b/src/V3EmitCSyms.cpp
@@ -253,7 +253,6 @@ class EmitCSyms final : EmitCBaseVisitorConst {
     void buildVpiHierarchy() {
         for (ScopeNames::const_iterator it = m_scopeNames.begin(); it != m_scopeNames.end();
              ++it) {
-            if (it->second.m_type != "SCOPE_MODULE") continue;
 
             const string symName = it->second.m_symName;
             string above = symName;

--- a/test_regress/t/t_time_vpi_c.cpp
+++ b/test_regress/t/t_time_vpi_c.cpp
@@ -74,7 +74,7 @@ void dpi_show(svScope obj) {
 void vpi_show(vpiHandle obj) {
     const char* namep;
     if (obj) {
-        namep = vpi_get_str(vpiName, obj);
+        namep = vpi_get_str(vpiFullName, obj);
     } else {
         namep = "global";
     }

--- a/test_regress/t/t_vpi_dump.cpp
+++ b/test_regress/t/t_vpi_dump.cpp
@@ -38,7 +38,7 @@ std::map<int32_t, std::vector<int32_t>> iterate_over = [] {
     };
 
     std::vector<int32_t> module_options = {
-        vpiModule,  // Aldec SEGV on mixed language
+        // vpiModule,  // Aldec SEGV on mixed language
         // vpiModuleArray,       // Aldec SEGV on mixed language
         // vpiIODecl,            // Don't care about these
         vpiMemory, vpiIntegerVar, vpiRealVar,

--- a/test_regress/t/t_vpi_dump.iv.out
+++ b/test_regress/t/t_vpi_dump.iv.out
@@ -4,13 +4,6 @@ t (vpiModule) t
     t.clk (vpiNet) t.clk
     vpiReg:
     t.x (vpiReg) t.x
-    vpiModule:
-    t.sub (vpiModule) t.sub
-        vpiNet:
-        t.sub.redundant (vpiNet) t.sub.redundant
-        vpiReg:
-        t.sub.subsig1 (vpiReg) t.sub.subsig1
-        t.sub.subsig2 (vpiReg) t.sub.subsig2
     vpiParameter:
     t.do_generate (vpiParameter) t.do_generate
         vpiConstType=vpiBinaryConst
@@ -22,16 +15,6 @@ t (vpiModule) t
     a (vpiPort) (null)
     vpiInternalScope:
     t.arr[1] (vpiGenScope) t.arr[1]
-        vpiModule:
-        t.arr[1].arr (vpiModule) t.arr[1].arr
-            vpiReg:
-            t.arr[1].arr.check (vpiReg) t.arr[1].arr.check
-            t.arr[1].arr.rfr (vpiReg) t.arr[1].arr.rfr
-            t.arr[1].arr.sig (vpiReg) t.arr[1].arr.sig
-            t.arr[1].arr.verbose (vpiReg) t.arr[1].arr.verbose
-            vpiParameter:
-            t.arr[1].arr.LENGTH (vpiParameter) t.arr[1].arr.LENGTH
-                vpiConstType=vpiBinaryConst
         vpiParameter:
         t.arr[1].i (vpiParameter) t.arr[1].i
             vpiConstType=vpiBinaryConst
@@ -46,16 +29,6 @@ t (vpiModule) t
             t.arr[1].arr.LENGTH (vpiParameter) t.arr[1].arr.LENGTH
                 vpiConstType=vpiBinaryConst
     t.arr[2] (vpiGenScope) t.arr[2]
-        vpiModule:
-        t.arr[2].arr (vpiModule) t.arr[2].arr
-            vpiReg:
-            t.arr[2].arr.check (vpiReg) t.arr[2].arr.check
-            t.arr[2].arr.rfr (vpiReg) t.arr[2].arr.rfr
-            t.arr[2].arr.sig (vpiReg) t.arr[2].arr.sig
-            t.arr[2].arr.verbose (vpiReg) t.arr[2].arr.verbose
-            vpiParameter:
-            t.arr[2].arr.LENGTH (vpiParameter) t.arr[2].arr.LENGTH
-                vpiConstType=vpiBinaryConst
         vpiParameter:
         t.arr[2].i (vpiParameter) t.arr[2].i
             vpiConstType=vpiBinaryConst
@@ -70,13 +43,6 @@ t (vpiModule) t
             t.arr[2].arr.LENGTH (vpiParameter) t.arr[2].arr.LENGTH
                 vpiConstType=vpiBinaryConst
     t.cond_scope (vpiGenScope) t.cond_scope
-        vpiModule:
-        t.cond_scope.scoped_sub (vpiModule) t.cond_scope.scoped_sub
-            vpiNet:
-            t.cond_scope.scoped_sub.redundant (vpiNet) t.cond_scope.scoped_sub.redundant
-            vpiReg:
-            t.cond_scope.scoped_sub.subsig1 (vpiReg) t.cond_scope.scoped_sub.subsig1
-            t.cond_scope.scoped_sub.subsig2 (vpiReg) t.cond_scope.scoped_sub.subsig2
         vpiParameter:
         t.cond_scope.scoped_wire (vpiParameter) t.cond_scope.scoped_wire
             vpiConstType=vpiBinaryConst
@@ -87,6 +53,8 @@ t (vpiModule) t
             vpiReg:
             t.cond_scope.scoped_sub.subsig1 (vpiReg) t.cond_scope.scoped_sub.subsig1
             t.cond_scope.scoped_sub.subsig2 (vpiReg) t.cond_scope.scoped_sub.subsig2
+    t.intf_arr[0] (vpiModule) t.intf_arr[0]
+    t.intf_arr[1] (vpiModule) t.intf_arr[1]
     t.outer_scope[1] (vpiGenScope) t.outer_scope[1]
         vpiParameter:
         t.outer_scope[1].i (vpiParameter) t.outer_scope[1].i
@@ -95,16 +63,6 @@ t (vpiModule) t
             vpiConstType=vpiBinaryConst
         vpiInternalScope:
         t.outer_scope[1].inner_scope[1] (vpiGenScope) t.outer_scope[1].inner_scope[1]
-            vpiModule:
-            t.outer_scope[1].inner_scope[1].arr (vpiModule) t.outer_scope[1].inner_scope[1].arr
-                vpiReg:
-                t.outer_scope[1].inner_scope[1].arr.check (vpiReg) t.outer_scope[1].inner_scope[1].arr.check
-                t.outer_scope[1].inner_scope[1].arr.rfr (vpiReg) t.outer_scope[1].inner_scope[1].arr.rfr
-                t.outer_scope[1].inner_scope[1].arr.sig (vpiReg) t.outer_scope[1].inner_scope[1].arr.sig
-                t.outer_scope[1].inner_scope[1].arr.verbose (vpiReg) t.outer_scope[1].inner_scope[1].arr.verbose
-                vpiParameter:
-                t.outer_scope[1].inner_scope[1].arr.LENGTH (vpiParameter) t.outer_scope[1].inner_scope[1].arr.LENGTH
-                    vpiConstType=vpiBinaryConst
             vpiParameter:
             t.outer_scope[1].inner_scope[1].j (vpiParameter) t.outer_scope[1].inner_scope[1].j
                 vpiConstType=vpiBinaryConst
@@ -121,16 +79,6 @@ t (vpiModule) t
                 t.outer_scope[1].inner_scope[1].arr.LENGTH (vpiParameter) t.outer_scope[1].inner_scope[1].arr.LENGTH
                     vpiConstType=vpiBinaryConst
         t.outer_scope[1].inner_scope[2] (vpiGenScope) t.outer_scope[1].inner_scope[2]
-            vpiModule:
-            t.outer_scope[1].inner_scope[2].arr (vpiModule) t.outer_scope[1].inner_scope[2].arr
-                vpiReg:
-                t.outer_scope[1].inner_scope[2].arr.check (vpiReg) t.outer_scope[1].inner_scope[2].arr.check
-                t.outer_scope[1].inner_scope[2].arr.rfr (vpiReg) t.outer_scope[1].inner_scope[2].arr.rfr
-                t.outer_scope[1].inner_scope[2].arr.sig (vpiReg) t.outer_scope[1].inner_scope[2].arr.sig
-                t.outer_scope[1].inner_scope[2].arr.verbose (vpiReg) t.outer_scope[1].inner_scope[2].arr.verbose
-                vpiParameter:
-                t.outer_scope[1].inner_scope[2].arr.LENGTH (vpiParameter) t.outer_scope[1].inner_scope[2].arr.LENGTH
-                    vpiConstType=vpiBinaryConst
             vpiParameter:
             t.outer_scope[1].inner_scope[2].j (vpiParameter) t.outer_scope[1].inner_scope[2].j
                 vpiConstType=vpiBinaryConst
@@ -147,16 +95,6 @@ t (vpiModule) t
                 t.outer_scope[1].inner_scope[2].arr.LENGTH (vpiParameter) t.outer_scope[1].inner_scope[2].arr.LENGTH
                     vpiConstType=vpiBinaryConst
         t.outer_scope[1].inner_scope[3] (vpiGenScope) t.outer_scope[1].inner_scope[3]
-            vpiModule:
-            t.outer_scope[1].inner_scope[3].arr (vpiModule) t.outer_scope[1].inner_scope[3].arr
-                vpiReg:
-                t.outer_scope[1].inner_scope[3].arr.check (vpiReg) t.outer_scope[1].inner_scope[3].arr.check
-                t.outer_scope[1].inner_scope[3].arr.rfr (vpiReg) t.outer_scope[1].inner_scope[3].arr.rfr
-                t.outer_scope[1].inner_scope[3].arr.sig (vpiReg) t.outer_scope[1].inner_scope[3].arr.sig
-                t.outer_scope[1].inner_scope[3].arr.verbose (vpiReg) t.outer_scope[1].inner_scope[3].arr.verbose
-                vpiParameter:
-                t.outer_scope[1].inner_scope[3].arr.LENGTH (vpiParameter) t.outer_scope[1].inner_scope[3].arr.LENGTH
-                    vpiConstType=vpiBinaryConst
             vpiParameter:
             t.outer_scope[1].inner_scope[3].j (vpiParameter) t.outer_scope[1].inner_scope[3].j
                 vpiConstType=vpiBinaryConst
@@ -180,16 +118,6 @@ t (vpiModule) t
             vpiConstType=vpiBinaryConst
         vpiInternalScope:
         t.outer_scope[2].inner_scope[1] (vpiGenScope) t.outer_scope[2].inner_scope[1]
-            vpiModule:
-            t.outer_scope[2].inner_scope[1].arr (vpiModule) t.outer_scope[2].inner_scope[1].arr
-                vpiReg:
-                t.outer_scope[2].inner_scope[1].arr.check (vpiReg) t.outer_scope[2].inner_scope[1].arr.check
-                t.outer_scope[2].inner_scope[1].arr.rfr (vpiReg) t.outer_scope[2].inner_scope[1].arr.rfr
-                t.outer_scope[2].inner_scope[1].arr.sig (vpiReg) t.outer_scope[2].inner_scope[1].arr.sig
-                t.outer_scope[2].inner_scope[1].arr.verbose (vpiReg) t.outer_scope[2].inner_scope[1].arr.verbose
-                vpiParameter:
-                t.outer_scope[2].inner_scope[1].arr.LENGTH (vpiParameter) t.outer_scope[2].inner_scope[1].arr.LENGTH
-                    vpiConstType=vpiBinaryConst
             vpiParameter:
             t.outer_scope[2].inner_scope[1].j (vpiParameter) t.outer_scope[2].inner_scope[1].j
                 vpiConstType=vpiBinaryConst
@@ -206,16 +134,6 @@ t (vpiModule) t
                 t.outer_scope[2].inner_scope[1].arr.LENGTH (vpiParameter) t.outer_scope[2].inner_scope[1].arr.LENGTH
                     vpiConstType=vpiBinaryConst
         t.outer_scope[2].inner_scope[2] (vpiGenScope) t.outer_scope[2].inner_scope[2]
-            vpiModule:
-            t.outer_scope[2].inner_scope[2].arr (vpiModule) t.outer_scope[2].inner_scope[2].arr
-                vpiReg:
-                t.outer_scope[2].inner_scope[2].arr.check (vpiReg) t.outer_scope[2].inner_scope[2].arr.check
-                t.outer_scope[2].inner_scope[2].arr.rfr (vpiReg) t.outer_scope[2].inner_scope[2].arr.rfr
-                t.outer_scope[2].inner_scope[2].arr.sig (vpiReg) t.outer_scope[2].inner_scope[2].arr.sig
-                t.outer_scope[2].inner_scope[2].arr.verbose (vpiReg) t.outer_scope[2].inner_scope[2].arr.verbose
-                vpiParameter:
-                t.outer_scope[2].inner_scope[2].arr.LENGTH (vpiParameter) t.outer_scope[2].inner_scope[2].arr.LENGTH
-                    vpiConstType=vpiBinaryConst
             vpiParameter:
             t.outer_scope[2].inner_scope[2].j (vpiParameter) t.outer_scope[2].inner_scope[2].j
                 vpiConstType=vpiBinaryConst
@@ -232,16 +150,6 @@ t (vpiModule) t
                 t.outer_scope[2].inner_scope[2].arr.LENGTH (vpiParameter) t.outer_scope[2].inner_scope[2].arr.LENGTH
                     vpiConstType=vpiBinaryConst
         t.outer_scope[2].inner_scope[3] (vpiGenScope) t.outer_scope[2].inner_scope[3]
-            vpiModule:
-            t.outer_scope[2].inner_scope[3].arr (vpiModule) t.outer_scope[2].inner_scope[3].arr
-                vpiReg:
-                t.outer_scope[2].inner_scope[3].arr.check (vpiReg) t.outer_scope[2].inner_scope[3].arr.check
-                t.outer_scope[2].inner_scope[3].arr.rfr (vpiReg) t.outer_scope[2].inner_scope[3].arr.rfr
-                t.outer_scope[2].inner_scope[3].arr.sig (vpiReg) t.outer_scope[2].inner_scope[3].arr.sig
-                t.outer_scope[2].inner_scope[3].arr.verbose (vpiReg) t.outer_scope[2].inner_scope[3].arr.verbose
-                vpiParameter:
-                t.outer_scope[2].inner_scope[3].arr.LENGTH (vpiParameter) t.outer_scope[2].inner_scope[3].arr.LENGTH
-                    vpiConstType=vpiBinaryConst
             vpiParameter:
             t.outer_scope[2].inner_scope[3].j (vpiParameter) t.outer_scope[2].inner_scope[3].j
                 vpiConstType=vpiBinaryConst
@@ -265,16 +173,6 @@ t (vpiModule) t
             vpiConstType=vpiBinaryConst
         vpiInternalScope:
         t.outer_scope[3].inner_scope[1] (vpiGenScope) t.outer_scope[3].inner_scope[1]
-            vpiModule:
-            t.outer_scope[3].inner_scope[1].arr (vpiModule) t.outer_scope[3].inner_scope[1].arr
-                vpiReg:
-                t.outer_scope[3].inner_scope[1].arr.check (vpiReg) t.outer_scope[3].inner_scope[1].arr.check
-                t.outer_scope[3].inner_scope[1].arr.rfr (vpiReg) t.outer_scope[3].inner_scope[1].arr.rfr
-                t.outer_scope[3].inner_scope[1].arr.sig (vpiReg) t.outer_scope[3].inner_scope[1].arr.sig
-                t.outer_scope[3].inner_scope[1].arr.verbose (vpiReg) t.outer_scope[3].inner_scope[1].arr.verbose
-                vpiParameter:
-                t.outer_scope[3].inner_scope[1].arr.LENGTH (vpiParameter) t.outer_scope[3].inner_scope[1].arr.LENGTH
-                    vpiConstType=vpiBinaryConst
             vpiParameter:
             t.outer_scope[3].inner_scope[1].j (vpiParameter) t.outer_scope[3].inner_scope[1].j
                 vpiConstType=vpiBinaryConst
@@ -291,16 +189,6 @@ t (vpiModule) t
                 t.outer_scope[3].inner_scope[1].arr.LENGTH (vpiParameter) t.outer_scope[3].inner_scope[1].arr.LENGTH
                     vpiConstType=vpiBinaryConst
         t.outer_scope[3].inner_scope[2] (vpiGenScope) t.outer_scope[3].inner_scope[2]
-            vpiModule:
-            t.outer_scope[3].inner_scope[2].arr (vpiModule) t.outer_scope[3].inner_scope[2].arr
-                vpiReg:
-                t.outer_scope[3].inner_scope[2].arr.check (vpiReg) t.outer_scope[3].inner_scope[2].arr.check
-                t.outer_scope[3].inner_scope[2].arr.rfr (vpiReg) t.outer_scope[3].inner_scope[2].arr.rfr
-                t.outer_scope[3].inner_scope[2].arr.sig (vpiReg) t.outer_scope[3].inner_scope[2].arr.sig
-                t.outer_scope[3].inner_scope[2].arr.verbose (vpiReg) t.outer_scope[3].inner_scope[2].arr.verbose
-                vpiParameter:
-                t.outer_scope[3].inner_scope[2].arr.LENGTH (vpiParameter) t.outer_scope[3].inner_scope[2].arr.LENGTH
-                    vpiConstType=vpiBinaryConst
             vpiParameter:
             t.outer_scope[3].inner_scope[2].j (vpiParameter) t.outer_scope[3].inner_scope[2].j
                 vpiConstType=vpiBinaryConst
@@ -317,16 +205,6 @@ t (vpiModule) t
                 t.outer_scope[3].inner_scope[2].arr.LENGTH (vpiParameter) t.outer_scope[3].inner_scope[2].arr.LENGTH
                     vpiConstType=vpiBinaryConst
         t.outer_scope[3].inner_scope[3] (vpiGenScope) t.outer_scope[3].inner_scope[3]
-            vpiModule:
-            t.outer_scope[3].inner_scope[3].arr (vpiModule) t.outer_scope[3].inner_scope[3].arr
-                vpiReg:
-                t.outer_scope[3].inner_scope[3].arr.check (vpiReg) t.outer_scope[3].inner_scope[3].arr.check
-                t.outer_scope[3].inner_scope[3].arr.rfr (vpiReg) t.outer_scope[3].inner_scope[3].arr.rfr
-                t.outer_scope[3].inner_scope[3].arr.sig (vpiReg) t.outer_scope[3].inner_scope[3].arr.sig
-                t.outer_scope[3].inner_scope[3].arr.verbose (vpiReg) t.outer_scope[3].inner_scope[3].arr.verbose
-                vpiParameter:
-                t.outer_scope[3].inner_scope[3].arr.LENGTH (vpiParameter) t.outer_scope[3].inner_scope[3].arr.LENGTH
-                    vpiConstType=vpiBinaryConst
             vpiParameter:
             t.outer_scope[3].inner_scope[3].j (vpiParameter) t.outer_scope[3].inner_scope[3].j
                 vpiConstType=vpiBinaryConst
@@ -349,4 +227,4 @@ t (vpiModule) t
         t.sub.subsig1 (vpiReg) t.sub.subsig1
         t.sub.subsig2 (vpiReg) t.sub.subsig2
 *-* All Finished *-*
-t/t_vpi_dump.v:65: $finish called at 0 (1s)
+t/t_vpi_dump.v:75: $finish called at 0 (1s)

--- a/test_regress/t/t_vpi_dump.out
+++ b/test_regress/t/t_vpi_dump.out
@@ -29,141 +29,261 @@ t (vpiModule) t
     text_word (vpiReg) t.text_word
     twoone (vpiReg) t.twoone
     x (vpiReg) TOP.x
-    vpiModule:
-    arr (vpiModule) t.arr[1].arr
-        vpiReg:
-        LENGTH (vpiParameter) t.arr[1].arr.LENGTH
-            vpiConstType=vpiDecConst
-        check (vpiReg) t.arr[1].arr.check
-        rfr (vpiReg) t.arr[1].arr.rfr
-        sig (vpiReg) t.arr[1].arr.sig
-        verbose (vpiReg) t.arr[1].arr.verbose
-        vpiParameter:
-        LENGTH (vpiParameter) t.arr[1].arr.LENGTH
-            vpiConstType=vpiDecConst
-    arr (vpiModule) t.arr[2].arr
-        vpiReg:
-        LENGTH (vpiParameter) t.arr[2].arr.LENGTH
-            vpiConstType=vpiDecConst
-        check (vpiReg) t.arr[2].arr.check
-        rfr (vpiReg) t.arr[2].arr.rfr
-        sig (vpiReg) t.arr[2].arr.sig
-        verbose (vpiReg) t.arr[2].arr.verbose
-        vpiParameter:
-        LENGTH (vpiParameter) t.arr[2].arr.LENGTH
-            vpiConstType=vpiDecConst
-    scoped_sub (vpiModule) t.cond_scope.scoped_sub
-        vpiReg:
-        subsig1 (vpiReg) t.cond_scope.scoped_sub.subsig1
-        subsig2 (vpiReg) t.cond_scope.scoped_sub.subsig2
-        vpiParameter:
-    arr (vpiModule) t.outer_scope[1].inner_scope[1].arr
-        vpiReg:
-        LENGTH (vpiParameter) t.outer_scope[1].inner_scope[1].arr.LENGTH
-            vpiConstType=vpiDecConst
-        check (vpiReg) t.outer_scope[1].inner_scope[1].arr.check
-        rfr (vpiReg) t.outer_scope[1].inner_scope[1].arr.rfr
-        sig (vpiReg) t.outer_scope[1].inner_scope[1].arr.sig
-        verbose (vpiReg) t.outer_scope[1].inner_scope[1].arr.verbose
-        vpiParameter:
-        LENGTH (vpiParameter) t.outer_scope[1].inner_scope[1].arr.LENGTH
-            vpiConstType=vpiDecConst
-    arr (vpiModule) t.outer_scope[1].inner_scope[2].arr
-        vpiReg:
-        LENGTH (vpiParameter) t.outer_scope[1].inner_scope[2].arr.LENGTH
-            vpiConstType=vpiDecConst
-        check (vpiReg) t.outer_scope[1].inner_scope[2].arr.check
-        rfr (vpiReg) t.outer_scope[1].inner_scope[2].arr.rfr
-        sig (vpiReg) t.outer_scope[1].inner_scope[2].arr.sig
-        verbose (vpiReg) t.outer_scope[1].inner_scope[2].arr.verbose
-        vpiParameter:
-        LENGTH (vpiParameter) t.outer_scope[1].inner_scope[2].arr.LENGTH
-            vpiConstType=vpiDecConst
-    arr (vpiModule) t.outer_scope[1].inner_scope[3].arr
-        vpiReg:
-        LENGTH (vpiParameter) t.outer_scope[1].inner_scope[3].arr.LENGTH
-            vpiConstType=vpiDecConst
-        check (vpiReg) t.outer_scope[1].inner_scope[3].arr.check
-        rfr (vpiReg) t.outer_scope[1].inner_scope[3].arr.rfr
-        sig (vpiReg) t.outer_scope[1].inner_scope[3].arr.sig
-        verbose (vpiReg) t.outer_scope[1].inner_scope[3].arr.verbose
-        vpiParameter:
-        LENGTH (vpiParameter) t.outer_scope[1].inner_scope[3].arr.LENGTH
-            vpiConstType=vpiDecConst
-    arr (vpiModule) t.outer_scope[2].inner_scope[1].arr
-        vpiReg:
-        LENGTH (vpiParameter) t.outer_scope[2].inner_scope[1].arr.LENGTH
-            vpiConstType=vpiDecConst
-        check (vpiReg) t.outer_scope[2].inner_scope[1].arr.check
-        rfr (vpiReg) t.outer_scope[2].inner_scope[1].arr.rfr
-        sig (vpiReg) t.outer_scope[2].inner_scope[1].arr.sig
-        verbose (vpiReg) t.outer_scope[2].inner_scope[1].arr.verbose
-        vpiParameter:
-        LENGTH (vpiParameter) t.outer_scope[2].inner_scope[1].arr.LENGTH
-            vpiConstType=vpiDecConst
-    arr (vpiModule) t.outer_scope[2].inner_scope[2].arr
-        vpiReg:
-        LENGTH (vpiParameter) t.outer_scope[2].inner_scope[2].arr.LENGTH
-            vpiConstType=vpiDecConst
-        check (vpiReg) t.outer_scope[2].inner_scope[2].arr.check
-        rfr (vpiReg) t.outer_scope[2].inner_scope[2].arr.rfr
-        sig (vpiReg) t.outer_scope[2].inner_scope[2].arr.sig
-        verbose (vpiReg) t.outer_scope[2].inner_scope[2].arr.verbose
-        vpiParameter:
-        LENGTH (vpiParameter) t.outer_scope[2].inner_scope[2].arr.LENGTH
-            vpiConstType=vpiDecConst
-    arr (vpiModule) t.outer_scope[2].inner_scope[3].arr
-        vpiReg:
-        LENGTH (vpiParameter) t.outer_scope[2].inner_scope[3].arr.LENGTH
-            vpiConstType=vpiDecConst
-        check (vpiReg) t.outer_scope[2].inner_scope[3].arr.check
-        rfr (vpiReg) t.outer_scope[2].inner_scope[3].arr.rfr
-        sig (vpiReg) t.outer_scope[2].inner_scope[3].arr.sig
-        verbose (vpiReg) t.outer_scope[2].inner_scope[3].arr.verbose
-        vpiParameter:
-        LENGTH (vpiParameter) t.outer_scope[2].inner_scope[3].arr.LENGTH
-            vpiConstType=vpiDecConst
-    arr (vpiModule) t.outer_scope[3].inner_scope[1].arr
-        vpiReg:
-        LENGTH (vpiParameter) t.outer_scope[3].inner_scope[1].arr.LENGTH
-            vpiConstType=vpiDecConst
-        check (vpiReg) t.outer_scope[3].inner_scope[1].arr.check
-        rfr (vpiReg) t.outer_scope[3].inner_scope[1].arr.rfr
-        sig (vpiReg) t.outer_scope[3].inner_scope[1].arr.sig
-        verbose (vpiReg) t.outer_scope[3].inner_scope[1].arr.verbose
-        vpiParameter:
-        LENGTH (vpiParameter) t.outer_scope[3].inner_scope[1].arr.LENGTH
-            vpiConstType=vpiDecConst
-    arr (vpiModule) t.outer_scope[3].inner_scope[2].arr
-        vpiReg:
-        LENGTH (vpiParameter) t.outer_scope[3].inner_scope[2].arr.LENGTH
-            vpiConstType=vpiDecConst
-        check (vpiReg) t.outer_scope[3].inner_scope[2].arr.check
-        rfr (vpiReg) t.outer_scope[3].inner_scope[2].arr.rfr
-        sig (vpiReg) t.outer_scope[3].inner_scope[2].arr.sig
-        verbose (vpiReg) t.outer_scope[3].inner_scope[2].arr.verbose
-        vpiParameter:
-        LENGTH (vpiParameter) t.outer_scope[3].inner_scope[2].arr.LENGTH
-            vpiConstType=vpiDecConst
-    arr (vpiModule) t.outer_scope[3].inner_scope[3].arr
-        vpiReg:
-        LENGTH (vpiParameter) t.outer_scope[3].inner_scope[3].arr.LENGTH
-            vpiConstType=vpiDecConst
-        check (vpiReg) t.outer_scope[3].inner_scope[3].arr.check
-        rfr (vpiReg) t.outer_scope[3].inner_scope[3].arr.rfr
-        sig (vpiReg) t.outer_scope[3].inner_scope[3].arr.sig
-        verbose (vpiReg) t.outer_scope[3].inner_scope[3].arr.verbose
-        vpiParameter:
-        LENGTH (vpiParameter) t.outer_scope[3].inner_scope[3].arr.LENGTH
-            vpiConstType=vpiDecConst
-    sub (vpiModule) t.sub
-        vpiReg:
-        subsig1 (vpiReg) t.sub.subsig1
-        subsig2 (vpiReg) t.sub.subsig2
-        vpiParameter:
     vpiParameter:
     do_generate (vpiParameter) t.do_generate
         vpiConstType=vpiDecConst
     long_int (vpiParameter) t.long_int
         vpiConstType=vpiDecConst
+    vpiInternalScope:
+    arr[1] (vpiGenScope) t.arr[1]
+        vpiReg:
+        vpiParameter:
+        vpiInternalScope:
+        arr (vpiModule) t.arr[1].arr
+            vpiReg:
+            LENGTH (vpiParameter) t.arr[1].arr.LENGTH
+                vpiConstType=vpiDecConst
+            check (vpiReg) t.arr[1].arr.check
+            rfr (vpiReg) t.arr[1].arr.rfr
+            sig (vpiReg) t.arr[1].arr.sig
+            verbose (vpiReg) t.arr[1].arr.verbose
+            vpiParameter:
+            LENGTH (vpiParameter) t.arr[1].arr.LENGTH
+                vpiConstType=vpiDecConst
+    arr[2] (vpiGenScope) t.arr[2]
+        vpiReg:
+        vpiParameter:
+        vpiInternalScope:
+        arr (vpiModule) t.arr[2].arr
+            vpiReg:
+            LENGTH (vpiParameter) t.arr[2].arr.LENGTH
+                vpiConstType=vpiDecConst
+            check (vpiReg) t.arr[2].arr.check
+            rfr (vpiReg) t.arr[2].arr.rfr
+            sig (vpiReg) t.arr[2].arr.sig
+            verbose (vpiReg) t.arr[2].arr.verbose
+            vpiParameter:
+            LENGTH (vpiParameter) t.arr[2].arr.LENGTH
+                vpiConstType=vpiDecConst
+    cond_scope (vpiGenScope) t.cond_scope
+        vpiReg:
+        scoped_wire (vpiParameter) t.cond_scope.scoped_wire
+            vpiConstType=vpiDecConst
+        vpiParameter:
+        scoped_wire (vpiParameter) t.cond_scope.scoped_wire
+            vpiConstType=vpiDecConst
+        vpiInternalScope:
+        scoped_sub (vpiModule) t.cond_scope.scoped_sub
+            vpiReg:
+            subsig1 (vpiReg) t.cond_scope.scoped_sub.subsig1
+            subsig2 (vpiReg) t.cond_scope.scoped_sub.subsig2
+            vpiParameter:
+    intf_arr[0] (vpiModule) t.intf_arr[0]
+        vpiReg:
+        addr (vpiReg) t.intf_arr[0].addr
+        vpiParameter:
+    intf_arr[1] (vpiModule) t.intf_arr[1]
+        vpiReg:
+        addr (vpiReg) t.intf_arr[1].addr
+        vpiParameter:
+    outer_scope[1] (vpiGenScope) t.outer_scope[1]
+        vpiReg:
+        scoped_param (vpiParameter) t.outer_scope[1].scoped_param
+            vpiConstType=vpiDecConst
+        vpiParameter:
+        scoped_param (vpiParameter) t.outer_scope[1].scoped_param
+            vpiConstType=vpiDecConst
+        vpiInternalScope:
+        inner_scope[1] (vpiGenScope) t.outer_scope[1].inner_scope[1]
+            vpiReg:
+            scoped_param_inner (vpiParameter) t.outer_scope[1].inner_scope[1].scoped_param_inner
+                vpiConstType=vpiDecConst
+            vpiParameter:
+            scoped_param_inner (vpiParameter) t.outer_scope[1].inner_scope[1].scoped_param_inner
+                vpiConstType=vpiDecConst
+            vpiInternalScope:
+            arr (vpiModule) t.outer_scope[1].inner_scope[1].arr
+                vpiReg:
+                LENGTH (vpiParameter) t.outer_scope[1].inner_scope[1].arr.LENGTH
+                    vpiConstType=vpiDecConst
+                check (vpiReg) t.outer_scope[1].inner_scope[1].arr.check
+                rfr (vpiReg) t.outer_scope[1].inner_scope[1].arr.rfr
+                sig (vpiReg) t.outer_scope[1].inner_scope[1].arr.sig
+                verbose (vpiReg) t.outer_scope[1].inner_scope[1].arr.verbose
+                vpiParameter:
+                LENGTH (vpiParameter) t.outer_scope[1].inner_scope[1].arr.LENGTH
+                    vpiConstType=vpiDecConst
+        inner_scope[2] (vpiGenScope) t.outer_scope[1].inner_scope[2]
+            vpiReg:
+            scoped_param_inner (vpiParameter) t.outer_scope[1].inner_scope[2].scoped_param_inner
+                vpiConstType=vpiDecConst
+            vpiParameter:
+            scoped_param_inner (vpiParameter) t.outer_scope[1].inner_scope[2].scoped_param_inner
+                vpiConstType=vpiDecConst
+            vpiInternalScope:
+            arr (vpiModule) t.outer_scope[1].inner_scope[2].arr
+                vpiReg:
+                LENGTH (vpiParameter) t.outer_scope[1].inner_scope[2].arr.LENGTH
+                    vpiConstType=vpiDecConst
+                check (vpiReg) t.outer_scope[1].inner_scope[2].arr.check
+                rfr (vpiReg) t.outer_scope[1].inner_scope[2].arr.rfr
+                sig (vpiReg) t.outer_scope[1].inner_scope[2].arr.sig
+                verbose (vpiReg) t.outer_scope[1].inner_scope[2].arr.verbose
+                vpiParameter:
+                LENGTH (vpiParameter) t.outer_scope[1].inner_scope[2].arr.LENGTH
+                    vpiConstType=vpiDecConst
+        inner_scope[3] (vpiGenScope) t.outer_scope[1].inner_scope[3]
+            vpiReg:
+            scoped_param_inner (vpiParameter) t.outer_scope[1].inner_scope[3].scoped_param_inner
+                vpiConstType=vpiDecConst
+            vpiParameter:
+            scoped_param_inner (vpiParameter) t.outer_scope[1].inner_scope[3].scoped_param_inner
+                vpiConstType=vpiDecConst
+            vpiInternalScope:
+            arr (vpiModule) t.outer_scope[1].inner_scope[3].arr
+                vpiReg:
+                LENGTH (vpiParameter) t.outer_scope[1].inner_scope[3].arr.LENGTH
+                    vpiConstType=vpiDecConst
+                check (vpiReg) t.outer_scope[1].inner_scope[3].arr.check
+                rfr (vpiReg) t.outer_scope[1].inner_scope[3].arr.rfr
+                sig (vpiReg) t.outer_scope[1].inner_scope[3].arr.sig
+                verbose (vpiReg) t.outer_scope[1].inner_scope[3].arr.verbose
+                vpiParameter:
+                LENGTH (vpiParameter) t.outer_scope[1].inner_scope[3].arr.LENGTH
+                    vpiConstType=vpiDecConst
+    outer_scope[2] (vpiGenScope) t.outer_scope[2]
+        vpiReg:
+        scoped_param (vpiParameter) t.outer_scope[2].scoped_param
+            vpiConstType=vpiDecConst
+        vpiParameter:
+        scoped_param (vpiParameter) t.outer_scope[2].scoped_param
+            vpiConstType=vpiDecConst
+        vpiInternalScope:
+        inner_scope[1] (vpiGenScope) t.outer_scope[2].inner_scope[1]
+            vpiReg:
+            scoped_param_inner (vpiParameter) t.outer_scope[2].inner_scope[1].scoped_param_inner
+                vpiConstType=vpiDecConst
+            vpiParameter:
+            scoped_param_inner (vpiParameter) t.outer_scope[2].inner_scope[1].scoped_param_inner
+                vpiConstType=vpiDecConst
+            vpiInternalScope:
+            arr (vpiModule) t.outer_scope[2].inner_scope[1].arr
+                vpiReg:
+                LENGTH (vpiParameter) t.outer_scope[2].inner_scope[1].arr.LENGTH
+                    vpiConstType=vpiDecConst
+                check (vpiReg) t.outer_scope[2].inner_scope[1].arr.check
+                rfr (vpiReg) t.outer_scope[2].inner_scope[1].arr.rfr
+                sig (vpiReg) t.outer_scope[2].inner_scope[1].arr.sig
+                verbose (vpiReg) t.outer_scope[2].inner_scope[1].arr.verbose
+                vpiParameter:
+                LENGTH (vpiParameter) t.outer_scope[2].inner_scope[1].arr.LENGTH
+                    vpiConstType=vpiDecConst
+        inner_scope[2] (vpiGenScope) t.outer_scope[2].inner_scope[2]
+            vpiReg:
+            scoped_param_inner (vpiParameter) t.outer_scope[2].inner_scope[2].scoped_param_inner
+                vpiConstType=vpiDecConst
+            vpiParameter:
+            scoped_param_inner (vpiParameter) t.outer_scope[2].inner_scope[2].scoped_param_inner
+                vpiConstType=vpiDecConst
+            vpiInternalScope:
+            arr (vpiModule) t.outer_scope[2].inner_scope[2].arr
+                vpiReg:
+                LENGTH (vpiParameter) t.outer_scope[2].inner_scope[2].arr.LENGTH
+                    vpiConstType=vpiDecConst
+                check (vpiReg) t.outer_scope[2].inner_scope[2].arr.check
+                rfr (vpiReg) t.outer_scope[2].inner_scope[2].arr.rfr
+                sig (vpiReg) t.outer_scope[2].inner_scope[2].arr.sig
+                verbose (vpiReg) t.outer_scope[2].inner_scope[2].arr.verbose
+                vpiParameter:
+                LENGTH (vpiParameter) t.outer_scope[2].inner_scope[2].arr.LENGTH
+                    vpiConstType=vpiDecConst
+        inner_scope[3] (vpiGenScope) t.outer_scope[2].inner_scope[3]
+            vpiReg:
+            scoped_param_inner (vpiParameter) t.outer_scope[2].inner_scope[3].scoped_param_inner
+                vpiConstType=vpiDecConst
+            vpiParameter:
+            scoped_param_inner (vpiParameter) t.outer_scope[2].inner_scope[3].scoped_param_inner
+                vpiConstType=vpiDecConst
+            vpiInternalScope:
+            arr (vpiModule) t.outer_scope[2].inner_scope[3].arr
+                vpiReg:
+                LENGTH (vpiParameter) t.outer_scope[2].inner_scope[3].arr.LENGTH
+                    vpiConstType=vpiDecConst
+                check (vpiReg) t.outer_scope[2].inner_scope[3].arr.check
+                rfr (vpiReg) t.outer_scope[2].inner_scope[3].arr.rfr
+                sig (vpiReg) t.outer_scope[2].inner_scope[3].arr.sig
+                verbose (vpiReg) t.outer_scope[2].inner_scope[3].arr.verbose
+                vpiParameter:
+                LENGTH (vpiParameter) t.outer_scope[2].inner_scope[3].arr.LENGTH
+                    vpiConstType=vpiDecConst
+    outer_scope[3] (vpiGenScope) t.outer_scope[3]
+        vpiReg:
+        scoped_param (vpiParameter) t.outer_scope[3].scoped_param
+            vpiConstType=vpiDecConst
+        vpiParameter:
+        scoped_param (vpiParameter) t.outer_scope[3].scoped_param
+            vpiConstType=vpiDecConst
+        vpiInternalScope:
+        inner_scope[1] (vpiGenScope) t.outer_scope[3].inner_scope[1]
+            vpiReg:
+            scoped_param_inner (vpiParameter) t.outer_scope[3].inner_scope[1].scoped_param_inner
+                vpiConstType=vpiDecConst
+            vpiParameter:
+            scoped_param_inner (vpiParameter) t.outer_scope[3].inner_scope[1].scoped_param_inner
+                vpiConstType=vpiDecConst
+            vpiInternalScope:
+            arr (vpiModule) t.outer_scope[3].inner_scope[1].arr
+                vpiReg:
+                LENGTH (vpiParameter) t.outer_scope[3].inner_scope[1].arr.LENGTH
+                    vpiConstType=vpiDecConst
+                check (vpiReg) t.outer_scope[3].inner_scope[1].arr.check
+                rfr (vpiReg) t.outer_scope[3].inner_scope[1].arr.rfr
+                sig (vpiReg) t.outer_scope[3].inner_scope[1].arr.sig
+                verbose (vpiReg) t.outer_scope[3].inner_scope[1].arr.verbose
+                vpiParameter:
+                LENGTH (vpiParameter) t.outer_scope[3].inner_scope[1].arr.LENGTH
+                    vpiConstType=vpiDecConst
+        inner_scope[2] (vpiGenScope) t.outer_scope[3].inner_scope[2]
+            vpiReg:
+            scoped_param_inner (vpiParameter) t.outer_scope[3].inner_scope[2].scoped_param_inner
+                vpiConstType=vpiDecConst
+            vpiParameter:
+            scoped_param_inner (vpiParameter) t.outer_scope[3].inner_scope[2].scoped_param_inner
+                vpiConstType=vpiDecConst
+            vpiInternalScope:
+            arr (vpiModule) t.outer_scope[3].inner_scope[2].arr
+                vpiReg:
+                LENGTH (vpiParameter) t.outer_scope[3].inner_scope[2].arr.LENGTH
+                    vpiConstType=vpiDecConst
+                check (vpiReg) t.outer_scope[3].inner_scope[2].arr.check
+                rfr (vpiReg) t.outer_scope[3].inner_scope[2].arr.rfr
+                sig (vpiReg) t.outer_scope[3].inner_scope[2].arr.sig
+                verbose (vpiReg) t.outer_scope[3].inner_scope[2].arr.verbose
+                vpiParameter:
+                LENGTH (vpiParameter) t.outer_scope[3].inner_scope[2].arr.LENGTH
+                    vpiConstType=vpiDecConst
+        inner_scope[3] (vpiGenScope) t.outer_scope[3].inner_scope[3]
+            vpiReg:
+            scoped_param_inner (vpiParameter) t.outer_scope[3].inner_scope[3].scoped_param_inner
+                vpiConstType=vpiDecConst
+            vpiParameter:
+            scoped_param_inner (vpiParameter) t.outer_scope[3].inner_scope[3].scoped_param_inner
+                vpiConstType=vpiDecConst
+            vpiInternalScope:
+            arr (vpiModule) t.outer_scope[3].inner_scope[3].arr
+                vpiReg:
+                LENGTH (vpiParameter) t.outer_scope[3].inner_scope[3].arr.LENGTH
+                    vpiConstType=vpiDecConst
+                check (vpiReg) t.outer_scope[3].inner_scope[3].arr.check
+                rfr (vpiReg) t.outer_scope[3].inner_scope[3].arr.rfr
+                sig (vpiReg) t.outer_scope[3].inner_scope[3].arr.sig
+                verbose (vpiReg) t.outer_scope[3].inner_scope[3].arr.verbose
+                vpiParameter:
+                LENGTH (vpiParameter) t.outer_scope[3].inner_scope[3].arr.LENGTH
+                    vpiConstType=vpiDecConst
+    sub (vpiModule) t.sub
+        vpiReg:
+        subsig1 (vpiReg) t.sub.subsig1
+        subsig2 (vpiReg) t.sub.subsig2
+        vpiParameter:
 *-* All Finished *-*

--- a/test_regress/t/t_vpi_dump.v
+++ b/test_regress/t/t_vpi_dump.v
@@ -13,6 +13,14 @@ typedef struct packed {
    int              sel;  // select
 } t_bus;
 
+interface TestInterface();
+
+   logic [31:0] addr;
+   modport source (input addr);
+
+endinterface
+
+
 module t (  /*AUTOARG*/
     // Outputs
     x,
@@ -57,6 +65,8 @@ module t (  /*AUTOARG*/
    t_bus bus1;
 
    sub sub ();
+
+   TestInterface intf_arr[2]();
 
 
    initial begin


### PR DESCRIPTION
This gets us a lot closer to parity with Xcelium / Icarus, and only adds extra verilated code if vpi is turned on.

Addresses https://github.com/verilator/verilator/issues/3609
Depends on https://github.com/verilator/verilator/pull/4838

- small refactors:
  - move common logic for name/fullname to VerilatedVpioScope
  - move top detection logic to VerilatedVpioModule (I think we can use hier[0] to detect this instead)
- emit SCOPE_OTHER objects in v3emit
- Add vpiInternalScope case to vpi_iterate, which returns the new VerilatedVpioScopeIter that cycles through both vpiGenScope and vpiModule objects