### PR TITLE
Fix inconsistent driver resolution with typedefs

### DIFF
--- a/src/V3Inst.cpp
+++ b/src/V3Inst.cpp
@@ -521,13 +521,14 @@ public:
         }
         const AstVarRef* const connectRefp = VN_CAST(pinp->exprp(), VarRef);
         const AstVarXRef* const connectXRefp = VN_CAST(pinp->exprp(), VarXRef);
-        const AstBasicDType* const pinBasicp
-            = VN_CAST(pinVarp->dtypep(), BasicDType);  // Maybe nullptr
-        const AstBasicDType* connBasicp = nullptr;
+        const AstNodeDType* const pinDTypep = pinVarp->dtypep()->skipRefp();
+        const AstBasicDType* const pinBasicp = VN_CAST(pinDTypep, BasicDType);
+        const AstNodeDType* const connDTypep
+            = connectRefp ? connectRefp->varp()->dtypep()->skipRefp() : nullptr;
+        const AstBasicDType* const connBasicp = VN_CAST(connDTypep, BasicDType);
         AstAssignW* assignp = nullptr;
-        if (connectRefp) connBasicp = VN_CAST(connectRefp->varp()->dtypep(), BasicDType);
         //
-        if (!alwaysCvt && connectRefp && connectRefp->varp()->dtypep()->sameTree(pinVarp->dtypep())
+        if (!alwaysCvt && connectRefp && connDTypep->sameTree(pinDTypep)
             && !connectRefp->varp()->isSc()) {  // Need the signal as a 'shell' to convert types
             // Done. Same data type
         } else if (!alwaysCvt && connectRefp && connectRefp->varp()->isIfaceRef()) {

--- a/test_regress/t/t_typedef_consistency_0.pl
+++ b/test_regress/t/t_typedef_consistency_0.pl
@@ -1,0 +1,21 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2024 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_typedef_consistency_0.v
+++ b/test_regress/t/t_typedef_consistency_0.v
@@ -1,0 +1,38 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2024 by Wilson Snyder.
+// SPDX-License-Identifier: CC0-1.0
+
+package pkg;
+   typedef logic l;
+endpackage
+
+module t(/*AUTOARG*/
+   // Inputs
+   clk
+   );
+   input clk;
+
+   wire logic  o_logic;
+   // Using 'pkg::l' instead of 'logic' should make no difference
+   wire pkg::l o_alias;
+
+   sub sub_logic(o_logic);
+   sub sub_alias(o_alias);
+
+   assign o_logic = clk;
+   assign o_alias = clk;
+
+   always @(posedge clk) begin
+     $display("o_logic: %b o_alias: %b", o_logic, o_alias);
+     // Whatever the answer is, it should be the same
+     if (o_logic !== o_alias) $stop;
+     $write("*-* All Finished *-*\n");
+     $finish;
+   end
+
+endmodule
+
+module sub(output wire  o);
+endmodule


### PR DESCRIPTION
Another one where a trivial typedef makes a difference. I think there is probably still a bug in V3Tristate that it's sensitive to the insertion (or lack of) a pin connection assignment, but even then, the behaviour should not differ due to the use of a trivial typedef. This patch fixes the difference by adding skipRefp in pinReconnectSimple, but does not address the issue of sensitivity in V3Tristate itself.