### PR TITLE
[Vpi] Fix missing scopes 1

### DIFF
--- a/test_regress/t/t_vpi_dump.iv.out
+++ b/test_regress/t/t_vpi_dump.iv.out
@@ -53,6 +53,14 @@ t (vpiModule) t
             vpiReg:
             t.cond_scope.scoped_sub.subsig1 (vpiReg) t.cond_scope.scoped_sub.subsig1
             t.cond_scope.scoped_sub.subsig2 (vpiReg) t.cond_scope.scoped_sub.subsig2
+        t.cond_scope.sub_wrap_gen (vpiModule) t.cond_scope.sub_wrap_gen
+            vpiInternalScope:
+            t.cond_scope.sub_wrap_gen.my_sub (vpiModule) t.cond_scope.sub_wrap_gen.my_sub
+                vpiNet:
+                t.cond_scope.sub_wrap_gen.my_sub.redundant (vpiNet) t.cond_scope.sub_wrap_gen.my_sub.redundant
+                vpiReg:
+                t.cond_scope.sub_wrap_gen.my_sub.subsig1 (vpiReg) t.cond_scope.sub_wrap_gen.my_sub.subsig1
+                t.cond_scope.sub_wrap_gen.my_sub.subsig2 (vpiReg) t.cond_scope.sub_wrap_gen.my_sub.subsig2
     t.intf_arr[0] (vpiModule) t.intf_arr[0]
     t.intf_arr[1] (vpiModule) t.intf_arr[1]
     t.outer_scope[1] (vpiGenScope) t.outer_scope[1]
@@ -226,5 +234,13 @@ t (vpiModule) t
         vpiReg:
         t.sub.subsig1 (vpiReg) t.sub.subsig1
         t.sub.subsig2 (vpiReg) t.sub.subsig2
+    t.sub_wrap (vpiModule) t.sub_wrap
+        vpiInternalScope:
+        t.sub_wrap.my_sub (vpiModule) t.sub_wrap.my_sub
+            vpiNet:
+            t.sub_wrap.my_sub.redundant (vpiNet) t.sub_wrap.my_sub.redundant
+            vpiReg:
+            t.sub_wrap.my_sub.subsig1 (vpiReg) t.sub_wrap.my_sub.subsig1
+            t.sub_wrap.my_sub.subsig2 (vpiReg) t.sub_wrap.my_sub.subsig2
 *-* All Finished *-*
-t/t_vpi_dump.v:75: $finish called at 0 (1s)
+t/t_vpi_dump.v:76: $finish called at 0 (1s)

--- a/test_regress/t/t_vpi_dump.out
+++ b/test_regress/t/t_vpi_dump.out
@@ -78,6 +78,15 @@ t (vpiModule) t
             subsig1 (vpiReg) t.cond_scope.scoped_sub.subsig1
             subsig2 (vpiReg) t.cond_scope.scoped_sub.subsig2
             vpiParameter:
+        sub_wrap_gen (vpiModule) t.cond_scope.sub_wrap_gen
+            vpiReg:
+            vpiParameter:
+            vpiInternalScope:
+            my_sub (vpiModule) t.cond_scope.sub_wrap_gen.my_sub
+                vpiReg:
+                subsig1 (vpiReg) t.cond_scope.sub_wrap_gen.my_sub.subsig1
+                subsig2 (vpiReg) t.cond_scope.sub_wrap_gen.my_sub.subsig2
+                vpiParameter:
     intf_arr[0] (vpiModule) t.intf_arr[0]
         vpiReg:
         addr (vpiReg) t.intf_arr[0].addr
@@ -286,4 +295,13 @@ t (vpiModule) t
         subsig1 (vpiReg) t.sub.subsig1
         subsig2 (vpiReg) t.sub.subsig2
         vpiParameter:
+    sub_wrap (vpiModule) t.sub_wrap
+        vpiReg:
+        vpiParameter:
+        vpiInternalScope:
+        my_sub (vpiModule) t.sub_wrap.my_sub
+            vpiReg:
+            subsig1 (vpiReg) t.sub_wrap.my_sub.subsig1
+            subsig2 (vpiReg) t.sub_wrap.my_sub.subsig2
+            vpiParameter:
 *-* All Finished *-*

--- a/test_regress/t/t_vpi_dump.v
+++ b/test_regress/t/t_vpi_dump.v
@@ -6,6 +6,7 @@
 // Version 2.0.
 // SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
 
+/* verilator public_on */
 
 typedef struct packed {
    logic [3:0][7:0] adr;  // address
@@ -95,15 +96,19 @@ module t (  /*AUTOARG*/
       end
    endgenerate
 
+   sub_wrapper sub_wrap ();
 
 
-   if (do_generate == 1) begin : cond_scope
-      sub scoped_sub ();
-      parameter int scoped_wire = 1;
-   end else begin : cond_scope_else
-      sub scoped_sub ();
-      parameter int scoped_wire = 2;
-   end
+   generate
+      if (do_generate == 1) begin : cond_scope
+         sub scoped_sub ();
+         parameter int scoped_wire = 1;
+
+         sub_wrapper sub_wrap_gen ();
+      end else begin : cond_scope_else
+         sub scoped_sub_else ();
+      end
+   endgenerate
 
 endmodule : t
 
@@ -138,3 +143,8 @@ module arr;
    end
 
 endmodule : arr
+
+
+module sub_wrapper;
+   sub my_sub ();
+endmodule


### PR DESCRIPTION
If using verilator public, not public_flat, and have a [internal scope > module with no public wires > module] chain, the module with no public wires will be missing from the scope hierarchy. This doesn't happen with public_flat, because AstCellInline handles this fine by using __DOT__ as the separator, while normal public uses ".", and so it skips this scope.

This shows two examples- one is inside a conditional generate and gets optimized out, while the other doesn't, showing that the conditional scope affects the visibility of the module.

Depends on 
 - https://github.com/verilator/verilator/pull/4838 
 - https://github.com/verilator/verilator/pull/4913