### PR TITLE
Make installation relocatable, and the installation testable

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,8 @@ env:
   CCACHE_COMPRESS: 1
   CCACHE_DIR: ${{ github.workspace }}/.ccache
   CCACHE_LIMIT_MULTIPLE: 0.95
+  INSTALL_DIR: ${{ github.workspace }}/install
+  RELOC_DIR: ${{ github.workspace }}/relloc
 
 defaults:
   run:
@@ -94,6 +96,7 @@ jobs:
         compiler:
           - { cc: clang, cxx: clang++ }
           - { cc: gcc,   cxx: g++     }
+        reloc: [0]
         suite: [dist-vlt-0, dist-vlt-1, dist-vlt-2, vltmt-0, vltmt-1]
         include:
           # Test with GCC 10 on ubuntu-20.04
@@ -102,14 +105,21 @@ jobs:
           - {os: ubuntu-20.04, compiler: { cc: gcc-10, cxx: g++-10 }, suite: dist-vlt-2}
           - {os: ubuntu-20.04, compiler: { cc: gcc-10, cxx: g++-10 }, suite: vltmt-0}
           - {os: ubuntu-20.04, compiler: { cc: gcc-10, cxx: g++-10 }, suite: vltmt-1}
+          # Test relocated installation - on most common platform only
+          - {os: ubuntu-22.04, compiler: { cc: gcc, cxx: g++ }, reloc: 1, suite: dist-vlt-0}
+          - {os: ubuntu-22.04, compiler: { cc: gcc, cxx: g++ }, reloc: 1, suite: dist-vlt-1}
+          - {os: ubuntu-22.04, compiler: { cc: gcc, cxx: g++ }, reloc: 1, suite: dist-vlt-2}
+          - {os: ubuntu-22.04, compiler: { cc: gcc, cxx: g++ }, reloc: 1, suite: vltmt-0}
+          - {os: ubuntu-22.04, compiler: { cc: gcc, cxx: g++ }, reloc: 1, suite: vltmt-1}
     runs-on: ${{ matrix.os }}
-    name: Test | ${{ matrix.os }} | ${{ matrix.compiler.cc }} | ${{ matrix.suite }}
+    name: Test | ${{ matrix.os }} | ${{ matrix.compiler.cc }} | ${{ matrix.reloc && 'reloc | ' || '' }} ${{ matrix.suite }}
     env:
       CI_BUILD_STAGE_NAME: test
       CI_RUNS_ON: ${{ matrix.os }}
+      CI_RELOC: ${{ matrix.reloc }}
       CC: ${{ matrix.compiler.cc }}
       CXX: ${{ matrix.compiler.cxx }}
-      CACHE_BASE_KEY: test-${{ matrix.os }}-${{ matrix.compiler.cc }}-${{ matrix.suite }}
+      CACHE_BASE_KEY: test-${{ matrix.os }}-${{ matrix.compiler.cc }}-${{ matrix.reloc }}-${{ matrix.suite }}
       CCACHE_MAXSIZE: 100M # Per build per suite (* 5 * 5 = 2500M in total)
       VERILATOR_ARCHIVE: verilator-${{ github.sha }}-${{ matrix.os }}-${{ matrix.compiler.cc }}.tar.gz
     steps:

--- a/Makefile.in
+++ b/Makefile.in
@@ -203,11 +203,21 @@ verilator.html:
 verilator.pdf: Makefile
 	$(MAKE) -C docs verilator.pdf
 
-# See uninstall also - don't put wildcards in this variable, it might uninstall other stuff
-VL_INST_BIN_FILES = verilator verilator_bin$(EXEEXT) verilator_bin_dbg$(EXEEXT) verilator_coverage_bin_dbg$(EXEEXT) \
-	verilator_ccache_report verilator_coverage verilator_difftree verilator_gantt verilator_includer verilator_profcfunc
-# Some scripts go into both the search path and pkgdatadir,
-# so they can be found by the user, and under $VERILATOR_ROOT.
+# Public executables intended to be invoked directly by the user
+# Don't put wildcards in these variables, it might cause an uninstall of other stuff
+VL_INST_PUBLIC_SCRIPT_FILES = verilator \
+                              verilator_coverage \
+                              verilator_gantt \
+                              verilator_profcfunc \
+
+VL_INST_PUBLIC_BIN_FILES = verilator_bin$(EXEEXT) \
+                           verilator_bin_dbg$(EXEEXT) \
+                           verilator_coverage_bin_dbg$(EXEEXT) \
+
+# Private executabels intended to be invoked by internals
+# Don't put wildcards in these variables, it might cause an uninstall of other stuff
+VL_INST_PRIVATE_SCRIPT_FILES = verilator_ccache_report \
+                               verilator_includer \
 
 VL_INST_INC_BLDDIR_FILES = \
 	include/verilated_config.h \
@@ -226,19 +236,34 @@ VL_INST_DATA_SRCDIR_FILES = \
 	examples/*/Makefile* \
 	examples/*/vl_* \
 
-installbin:
-	$(MKINSTALLDIRS) $(DESTDIR)$(bindir)
-	( cd ${srcdir}/bin ; $(INSTALL_PROGRAM) verilator $(DESTDIR)$(bindir)/verilator )
-	( cd ${srcdir}/bin ; $(INSTALL_PROGRAM) verilator_coverage $(DESTDIR)$(bindir)/verilator_coverage )
-	( cd ${srcdir}/bin ; $(INSTALL_PROGRAM) verilator_gantt $(DESTDIR)$(bindir)/verilator_gantt )
-	( cd ${srcdir}/bin ; $(INSTALL_PROGRAM) verilator_profcfunc $(DESTDIR)$(bindir)/verilator_profcfunc )
-	( cd bin ; $(INSTALL_PROGRAM) verilator_bin$(EXEEXT) $(DESTDIR)$(bindir)/verilator_bin$(EXEEXT) )
-	( cd bin ; $(INSTALL_PROGRAM) verilator_bin_dbg$(EXEEXT) $(DESTDIR)$(bindir)/verilator_bin_dbg$(EXEEXT) )
-	( cd bin ; $(INSTALL_PROGRAM) verilator_coverage_bin_dbg$(EXEEXT) $(DESTDIR)$(bindir)/verilator_coverage_bin_dbg$(EXEEXT) )
+mkbindirs:
 	$(MKINSTALLDIRS) $(DESTDIR)$(pkgdatadir)/bin
-	( cd ${srcdir}/bin ; $(INSTALL_PROGRAM) verilator_includer $(DESTDIR)$(pkgdatadir)/bin/verilator_includer )
-	( cd ${srcdir}/bin ; $(INSTALL_PROGRAM) verilator_ccache_report $(DESTDIR)$(pkgdatadir)/bin/verilator_ccache_report )
-	( cd ${srcdir}/bin ; $(INSTALL_PROGRAM) verilator_difftree $(DESTDIR)$(pkgdatadir)/bin/verilator_difftree )
+	$(MKINSTALLDIRS) $(DESTDIR)$(bindir)
+
+installbin: | mkbindirs
+	cd $(srcdir)/bin; \
+	for p in $(VL_INST_PUBLIC_SCRIPT_FILES) ; do \
+	  $(INSTALL_PROGRAM) $$p $(DESTDIR)$(pkgdatadir)/bin/$$p; \
+	done
+	cd bin; \
+	for p in $(VL_INST_PUBLIC_BIN_FILES) ; do \
+	  $(INSTALL_PROGRAM) $$p $(DESTDIR)$(pkgdatadir)/bin/$$p; \
+	done
+	cd $(srcdir)/bin; \
+	for p in $(VL_INST_PRIVATE_SCRIPT_FILES) ; do \
+	  $(INSTALL_PROGRAM) $$p $(DESTDIR)$(pkgdatadir)/bin/$$p; \
+	done
+
+installredirect: installbin | mkbindirs
+	cp ${srcdir}/bin/redirect ${srcdir}/bin/redirect.tmp
+	perl -p -i -e 'use File::Spec;' \
+	           -e' $$path = File::Spec->abs2rel("$(realpath $(DESTDIR)$(pkgdatadir)/bin)", "$(realpath $(DESTDIR)$(bindir))");' \
+	           -e 's/RELPATH.*/"$$path";/g' -- "${srcdir}/bin/redirect.tmp"
+	cd $(srcdir)/bin; \
+	for p in $(VL_INST_PUBLIC_SCRIPT_FILES) $(VL_INST_PUBLIC_BIN_FILES) ; do \
+	  $(INSTALL_PROGRAM) redirect.tmp $(DESTDIR)$(bindir)/$$p; \
+	done
+	rm ${srcdir}/bin/redirect.tmp
 
 # Man files can either be part of the original kit, or built in current directory
 # So important we use $^ so VPATH is searched
@@ -281,8 +306,11 @@ installdata:
 
 # We don't trust rm -rf, so rmdir instead as it will fail if user put in other files
 uninstall:
-	-cd $(DESTDIR)$(bindir) && rm -f $(VL_INST_BIN_FILES)
-	-cd $(DESTDIR)$(pkgdatadir)/bin && rm -f $(VL_INST_BIN_FILES)
+	-cd $(DESTDIR)$(bindir) && rm -f $(VL_INST_PUBLIC_SCRIPT_FILES)
+	-cd $(DESTDIR)$(bindir) && rm -f $(VL_INST_PUBLIC_BIN_FILES)
+	-cd $(DESTDIR)$(pkgdatadir)/bin && rm -f $(VL_INST_PUBLIC_SCRIPT_FILES)
+	-cd $(DESTDIR)$(pkgdatadir)/bin && rm -f $(VL_INST_PUBLIC_BIN_FILES)
+	-cd $(DESTDIR)$(pkgdatadir)/bin && rm -f $(VL_INST_PRIVATE_SCRIPT_FILES)
 	-cd $(DESTDIR)$(mandir)/man1 && rm -f $(VL_INST_MAN_FILES)
 	-cd $(DESTDIR)$(pkgdatadir) && rm -f $(VL_INST_INC_BLDDIR_FILES)
 	-cd $(DESTDIR)$(pkgdatadir) && rm -f $(VL_INST_INC_SRCDIR_FILES)
@@ -311,7 +339,7 @@ uninstall:
 	-rmdir $(DESTDIR)$(pkgconfigdir)
 
 install: all_nomsg install-all
-install-all: installbin installman installdata install-msg
+install-all: installbin installredirect installman installdata install-msg
 
 install-here: installman info
 

--- a/bin/redirect
+++ b/bin/redirect
@@ -1,0 +1,22 @@
+#!/usr/bin/env perl
+######################################################################
+#
+# Copyright 2003-2024 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+#
+######################################################################
+
+require 5.006_001;
+use warnings;
+use FindBin qw($RealBin $RealScript);
+use strict;
+
+my $relpath = RELPATH;  # Substituted during Verilator 'make install'
+
+unshift @ARGV, $RealScript;
+
+exec { "$RealBin/$relpath/$RealScript" } @ARGV;
+die "%Error: Exec failed,";

--- a/bin/verilator
+++ b/bin/verilator
@@ -15,6 +15,7 @@ use Getopt::Long;
 use FindBin qw($RealBin $RealScript);
 use IO::File;
 use Pod::Usage;
+use Cwd qw(realpath);
 
 use strict;
 use vars qw($Debug @Opt_Verilator_Sw);
@@ -65,6 +66,18 @@ if (! GetOptions(
           "<>"               => sub {},      # Ignored
     )) {
     pod2usage(-exitstatus => 2, -verbose => 0);
+}
+
+my $verilator_root = realpath("$RealBin/..");
+if (defined $ENV{VERILATOR_ROOT}) {
+    if ((!-d $ENV{VERILATOR_ROOT}) || $verilator_root ne realpath($ENV{VERILATOR_ROOT})) {
+        warn "%Error: verilator: VERILATOR_ROOT is set to inconsistent path. Suggest leaving it unset.\n";
+        warn "%Error: VERILATOR_ROOT=$ENV{VERILATOR_ROOT}\n";
+        exit 1;
+    }
+} else {
+    print "export VERILATOR_ROOT='$verilator_root'\n" if $Debug;
+    $ENV{VERILATOR_ROOT} = $verilator_root;
 }
 
 if ($opt_gdbbt && !gdb_works()) {
@@ -151,30 +164,13 @@ sub debug {
 # Builds
 
 sub verilator_bin {
-    my $bin = "";
-    # Use VERILATOR_ROOT if defined, else assume verilator_bin is in the search path
     my $basename = ($ENV{VERILATOR_BIN}
                     || ($Debug ? "verilator_bin_dbg" : "verilator_bin"));
-    if (defined($ENV{VERILATOR_ROOT})) {
-        my $dir = $ENV{VERILATOR_ROOT};
-        if (-x "$dir/bin/$basename"
-            || -x "$dir/bin/$basename.exe") {  # From a "make install" into VERILATOR_ROOT
-            $bin = "$dir/bin/$basename";
-        } else {
-            $bin = "$dir/$basename";  # From pointing to kit directory
-        }
+    if (-x "$RealBin/$basename" || -x "$RealBin/$basename.exe") {
+        return "$RealBin/$basename";
     } else {
-        if (-x "$RealBin/$basename"
-            || -x "$RealBin/$basename.exe") {
-            $bin = "$RealBin/$basename";  # From path/to/verilator with verilator_bin installed
-        } else {
-            $bin = $basename;  # Find in PATH
-        }
-        # Note we don't look under bin/$basename which would be right if running
-        # in the kit dir. Running that would likely break, since
-        # VERILATOR_ROOT wouldn't be set and Verilator won't find internal files.
+        return $basename;  # Find in PATH
     }
-    return $bin;
 }
 
 #######################################################################

--- a/test_regress/Makefile
+++ b/test_regress/Makefile
@@ -16,7 +16,7 @@
 default: test
 
 # This must point to the root of the VERILATOR kit
-VERILATOR_ROOT := $(shell pwd)/..
+VERILATOR_ROOT ?= $(shell pwd)/..
 export VERILATOR_ROOT
 
 # Pick up PERL and other variable settings

--- a/test_regress/driver.pl
+++ b/test_regress/driver.pl
@@ -12,6 +12,8 @@ BEGIN {
     }
     $ENV{MAKE} ||= "make";
     $ENV{CXX} ||= "c++";
+    !defined $ENV{TEST_REGRESS} or die "TEST_REGRESS environment variable is already set";
+    $ENV{TEST_REGRESS} = Cwd::getcwd();
 }
 
 use Getopt::Long;
@@ -2484,7 +2486,7 @@ sub _vcd_read {
 our $_Cxx_Version;
 
 sub cxx_version {
-    $_Cxx_Version ||= `$ENV{MAKE} -C $ENV{VERILATOR_ROOT}/test_regress -f Makefile print-cxx-version`;
+    $_Cxx_Version ||= `$ENV{MAKE} -C $ENV{TEST_REGRESS} -f Makefile print-cxx-version`;
     return $_Cxx_Version;
 }
 

--- a/test_regress/t/t_a1_first_cc.pl
+++ b/test_regress/t/t_a1_first_cc.pl
@@ -16,7 +16,7 @@ scenarios(simulator => 1);
 
 $DEBUG_QUIET = "--debug --debugi 0 --gdbbt --no-dump-tree";
 
-run(cmd => ["perl", "../bin/verilator", $DEBUG_QUIET, "-V"],
+run(cmd => ["perl", "$ENV{VERILATOR_ROOT}/bin/verilator", $DEBUG_QUIET, "-V"],
     verilator_run => 1,
     );
 

--- a/test_regress/t/t_a5_attributes_include.pl
+++ b/test_regress/t/t_a5_attributes_include.pl
@@ -10,8 +10,13 @@ if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); di
 
 scenarios(dist => 1);
 rerunnable(0);
+
+my $root = "..";
+
 if ($ENV{VERILATOR_TEST_NO_ATTRIBUTES}) {
     skip("Skipping due to VERILATOR_TEST_NO_ATTRIBUTES");
+} elsif (!-r "$root/.git") {
+    skip("Not in a git repository");
 } else {
     check();
 }

--- a/test_regress/t/t_assert_comp_bad.pl
+++ b/test_regress/t/t_assert_comp_bad.pl
@@ -10,53 +10,59 @@ if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); di
 
 scenarios(simulator => 1);
 
-compile(
-    verilator_flags2 => ['--assert'],
-    nc_flags2 => ['+assert'],
-    vcs_flags2 => ['-assert svaext'],
-    fails => 1,
-    expect_filename => $Self->{golden_filename},
-    );
+my $root = "..";
 
-extract(
-    in => $Self->{top_filename},
-    out => "../docs/gen/ex_USERWARN_faulty.rst",
-    regexp => qr/\$warn.*User/);
+if (!-r "$root/.git") {
+    skip("Not in a git repository");
+} else {
+    compile(
+        verilator_flags2 => ['--assert'],
+        nc_flags2 => ['+assert'],
+        vcs_flags2 => ['-assert svaext'],
+        fails => 1,
+        expect_filename => $Self->{golden_filename},
+        );
 
-extract(
-    in => $Self->{top_filename},
-    out => "../docs/gen/ex_USERERROR_faulty.rst",
-    regexp => qr/\$error.*User/);
+    extract(
+        in => $Self->{top_filename},
+        out => "../docs/gen/ex_USERWARN_faulty.rst",
+        regexp => qr/\$warn.*User/);
 
-extract(
-    in => $Self->{top_filename},
-    out => "../docs/gen/ex_USERINFO_faulty.rst",
-    regexp => qr/\$info.*User/);
+    extract(
+        in => $Self->{top_filename},
+        out => "../docs/gen/ex_USERERROR_faulty.rst",
+        regexp => qr/\$error.*User/);
 
-extract(
-    in => $Self->{top_filename},
-    out => "../docs/gen/ex_USERFATAL_faulty.rst",
-    regexp => qr/\$fatal.*User/);
+    extract(
+        in => $Self->{top_filename},
+        out => "../docs/gen/ex_USERINFO_faulty.rst",
+        regexp => qr/\$info.*User/);
 
-extract(
-    in => $Self->{golden_filename},
-    out => "../docs/gen/ex_USERWARN_msg.rst",
-    regexp => qr/USERWARN:.* User/);
+    extract(
+        in => $Self->{top_filename},
+        out => "../docs/gen/ex_USERFATAL_faulty.rst",
+        regexp => qr/\$fatal.*User/);
 
-extract(
-    in => $Self->{golden_filename},
-    out => "../docs/gen/ex_USERERROR_msg.rst",
-    regexp => qr/USERERROR:.* User/);
+    extract(
+        in => $Self->{golden_filename},
+        out => "../docs/gen/ex_USERWARN_msg.rst",
+        regexp => qr/USERWARN:.* User/);
 
-extract(
-    in => $Self->{golden_filename},
-    out => "../docs/gen/ex_USERINFO_msg.rst",
-    regexp => qr/-Info:.* User/);
+    extract(
+        in => $Self->{golden_filename},
+        out => "../docs/gen/ex_USERERROR_msg.rst",
+        regexp => qr/USERERROR:.* User/);
 
-extract(
-    in => $Self->{golden_filename},
-    out => "../docs/gen/ex_USERFATAL_msg.rst",
-    regexp => qr/USERFATAL/);
+    extract(
+        in => $Self->{golden_filename},
+        out => "../docs/gen/ex_USERINFO_msg.rst",
+        regexp => qr/-Info:.* User/);
+
+    extract(
+        in => $Self->{golden_filename},
+        out => "../docs/gen/ex_USERFATAL_msg.rst",
+        regexp => qr/USERFATAL/);
+}
 
 ok(1);
 1;

--- a/test_regress/t/t_cover_line_cc.pl
+++ b/test_regress/t/t_cover_line_cc.pl
@@ -24,7 +24,7 @@ execute(
 # Read the input .v file and do any CHECK_COVER requests
 inline_checks();
 
-run(cmd => ["../bin/verilator_coverage",
+run(cmd => ["$ENV{VERILATOR_ROOT}/bin/verilator_coverage",
             "--annotate-points",
             "--annotate", "$Self->{obj_dir}/annotated",
             "$Self->{obj_dir}/coverage.dat"],
@@ -34,7 +34,7 @@ run(cmd => ["../bin/verilator_coverage",
 files_identical("$Self->{obj_dir}/annotated/t_cover_line.v", $Self->{golden_filename});
 
 # Also try lcov
-run(cmd => ["../bin/verilator_coverage",
+run(cmd => ["$ENV{VERILATOR_ROOT}/bin/verilator_coverage",
             "--write-info", "$Self->{obj_dir}/coverage.info",
             "$Self->{obj_dir}/coverage.dat"],
     verilator_run => 1,

--- a/test_regress/t/t_cover_line_cc_vlt.pl
+++ b/test_regress/t/t_cover_line_cc_vlt.pl
@@ -24,7 +24,7 @@ execute(
 # Read the input .v file and do any CHECK_COVER requests
 inline_checks();
 
-run(cmd => ["../bin/verilator_coverage",
+run(cmd => ["$ENV{VERILATOR_ROOT}/bin/verilator_coverage",
             "--annotate-points",
             "--annotate", "$Self->{obj_dir}/annotated",
             "$Self->{obj_dir}/coverage.dat",

--- a/test_regress/t/t_cover_line_trace.pl
+++ b/test_regress/t/t_cover_line_trace.pl
@@ -20,7 +20,7 @@ execute(
     check_finished => 1,
     );
 
-run(cmd => ["../bin/verilator_coverage",
+run(cmd => ["$ENV{VERILATOR_ROOT}/bin/verilator_coverage",
             "--annotate-points",
             "--annotate", "$Self->{obj_dir}/annotated",
             "$Self->{obj_dir}/coverage.dat",

--- a/test_regress/t/t_cover_toggle.pl
+++ b/test_regress/t/t_cover_toggle.pl
@@ -26,7 +26,7 @@ file_grep_not("$Self->{obj_dir}/coverage.dat", "largeish");
 file_grep($Self->{stats}, qr/Coverage, Toggle points joined\s+(\d+)/i, 23)
     if $Self->{vlt_all};
 
-run(cmd => ["../bin/verilator_coverage",
+run(cmd => ["$ENV{VERILATOR_ROOT}/bin/verilator_coverage",
             "--annotate", "$Self->{obj_dir}/annotated",
             "$Self->{obj_dir}/coverage.dat",
             ],
@@ -35,7 +35,7 @@ run(cmd => ["../bin/verilator_coverage",
 
 files_identical("$Self->{obj_dir}/annotated/$Self->{name}.v", $Self->{golden_filename});
 
-run(cmd => ["../bin/verilator_coverage",
+run(cmd => ["$ENV{VERILATOR_ROOT}/bin/verilator_coverage",
             "--annotate-points",
             "--annotate", "$Self->{obj_dir}/annotated-points",
             "$Self->{obj_dir}/coverage.dat",

--- a/test_regress/t/t_dfg_peephole.pl
+++ b/test_regress/t/t_dfg_peephole.pl
@@ -10,84 +10,90 @@ if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); di
 
 scenarios(vlt_all => 1);
 
-$Self->{sim_time} = 2000000;
+my $root = "..";
 
-# Read optimizations
-my @optimizations = ();
-{
-    my $hdrFile = "../src/V3DfgPeephole.h";
-    my $hdrFh = IO::File->new("<$hdrFile") or error("$! $hdrFile");
-    my $prevOpt = "";
-    my $lineno = 0;
-    while (defined(my $line = $hdrFh->getline)) {
-        $lineno = $lineno + 1;
-        next if $line !~ /^\s*_FOR_EACH_DFG_PEEPHOLE_OPTIMIZATION_APPLY\(macro, (\w+)\)/;
-        my $opt = $1;
-        error("$hdrFile:$linenno: '$opt; is not in sorted order") if $prevOpt gt $opt;
-        $prevOpt = $opt;
-        push @optimizations, $opt;
+if (!-r "$root/.git") {
+    skip("Not in a git repository");
+} else {
+    $Self->{sim_time} = 2000000;
+
+    # Read optimizations
+    my @optimizations = ();
+    {
+        my $hdrFile = "../src/V3DfgPeephole.h";
+        my $hdrFh = IO::File->new("<$hdrFile") or error("$! $hdrFile");
+        my $prevOpt = "";
+        my $lineno = 0;
+        while (defined(my $line = $hdrFh->getline)) {
+            $lineno = $lineno + 1;
+            next if $line !~ /^\s*_FOR_EACH_DFG_PEEPHOLE_OPTIMIZATION_APPLY\(macro, (\w+)\)/;
+            my $opt = $1;
+            error("$hdrFile:$linenno: '$opt; is not in sorted order") if $prevOpt gt $opt;
+            $prevOpt = $opt;
+            push @optimizations, $opt;
+        }
+        error("no optimizations defined in $hdrFile") if scalar @optimizations == 0;
     }
-    error("no optimizations defined in $hdrFile") if scalar @optimizations == 0;
-}
 
-# Generate the equivalence checks and declaration boilerplate
-my $rdFile = "$Self->{top_filename}";
-my $plistFile = "$Self->{obj_dir}/portlist.vh";
-my $pdeclFile = "$Self->{obj_dir}/portdecl.vh";
-my $checkFile = "$Self->{obj_dir}/checks.h";
-my $rdFh = IO::File->new("<$rdFile") or error("$! $rdFile");
-my $plistFh = IO::File->new(">$plistFile") or error("$! $plistFile");
-my $pdeclFh = IO::File->new(">$pdeclFile") or error("$! $pdeclFile");
-my $checkFh = IO::File->new(">$checkFile") or error("$! $checkFile");
-while (defined(my $line = $rdFh->getline)) {
-    next if $line !~ /^\s*.*`signal\((\w+),/;
-    my $signal = $1;
-    print $plistFh "$signal,\n";
-    print $pdeclFh "output $signal;\n";
-    print $checkFh "if (ref.$signal != opt.$signal) {\n";
-    print $checkFh "    std::cout << \"Mismatched $signal\" << std::endl;\n";
-    print $checkFh "    std::cout << \"Ref: 0x\" << std::hex << (ref.$signal + 0) << std::endl;\n";
-    print $checkFh "    std::cout << \"Opt: 0x\" << std::hex << (opt.$signal + 0) << std::endl;\n";
-    print $checkFh "    std::exit(1);\n";
-    print $checkFh "}\n";
-}
-close $rdFile;
-close $wrFile;
+    # Generate the equivalence checks and declaration boilerplate
+    my $rdFile = "$Self->{top_filename}";
+    my $plistFile = "$Self->{obj_dir}/portlist.vh";
+    my $pdeclFile = "$Self->{obj_dir}/portdecl.vh";
+    my $checkFile = "$Self->{obj_dir}/checks.h";
+    my $rdFh = IO::File->new("<$rdFile") or error("$! $rdFile");
+    my $plistFh = IO::File->new(">$plistFile") or error("$! $plistFile");
+    my $pdeclFh = IO::File->new(">$pdeclFile") or error("$! $pdeclFile");
+    my $checkFh = IO::File->new(">$checkFile") or error("$! $checkFile");
+    while (defined(my $line = $rdFh->getline)) {
+        next if $line !~ /^\s*.*`signal\((\w+),/;
+        my $signal = $1;
+        print $plistFh "$signal,\n";
+        print $pdeclFh "output $signal;\n";
+        print $checkFh "if (ref.$signal != opt.$signal) {\n";
+        print $checkFh "    std::cout << \"Mismatched $signal\" << std::endl;\n";
+        print $checkFh "    std::cout << \"Ref: 0x\" << std::hex << (ref.$signal + 0) << std::endl;\n";
+        print $checkFh "    std::cout << \"Opt: 0x\" << std::hex << (opt.$signal + 0) << std::endl;\n";
+        print $checkFh "    std::exit(1);\n";
+        print $checkFh "}\n";
+    }
+    close $rdFile;
+    close $wrFile;
 
 
-# Compile un-optimized
-compile(
-    verilator_flags2 => ["--stats", "--build", "-fno-dfg", "+incdir+$Self->{obj_dir}",
-                         "-Mdir", "$Self->{obj_dir}/obj_ref", "--prefix", "Vref"],
-    );
+    # Compile un-optimized
+    compile(
+        verilator_flags2 => ["--stats", "--build", "-fno-dfg", "+incdir+$Self->{obj_dir}",
+                             "-Mdir", "$Self->{obj_dir}/obj_ref", "--prefix", "Vref"],
+        );
 
-# Compile optimized - also builds executable
-compile(
-    verilator_flags2 => ["--stats", "--build", "--exe", "+incdir+$Self->{obj_dir}",
-                         "-Mdir", "$Self->{obj_dir}/obj_opt", "--prefix", "Vopt",
-                         "-fno-const-before-dfg", # Otherwise V3Const makes testing painful
-                         "--dump-dfg", # To fill code coverage
-                         "-CFLAGS \"-I .. -I ../obj_ref\"",
-                         "../obj_ref/Vref__ALL.a",
-                         "../../t/$Self->{name}.cpp"],
-    );
+    # Compile optimized - also builds executable
+    compile(
+        verilator_flags2 => ["--stats", "--build", "--exe", "+incdir+$Self->{obj_dir}",
+                             "-Mdir", "$Self->{obj_dir}/obj_opt", "--prefix", "Vopt",
+                             "-fno-const-before-dfg", # Otherwise V3Const makes testing painful
+                             "--dump-dfg", # To fill code coverage
+                             "-CFLAGS \"-I .. -I ../obj_ref\"",
+                             "../obj_ref/Vref__ALL.a",
+                             "../../t/$Self->{name}.cpp"],
+        );
 
-# Execute test to check equivalence
-execute(
-    executable => "$Self->{obj_dir}/obj_opt/Vopt",
-    check_finished => 1,
-    );
+    # Execute test to check equivalence
+    execute(
+        executable => "$Self->{obj_dir}/obj_opt/Vopt",
+        check_finished => 1,
+        );
 
-sub check {
-  my $name = shift;
-  $name = lc $name;
-  $name =~ s/_/ /g;
-  file_grep("$Self->{obj_dir}/obj_opt/Vopt__stats.txt", qr/DFG\s+(pre|post) inline Peephole, ${name}\s+([1-9]\d*)/i);
-}
+    sub check {
+      my $name = shift;
+      $name = lc $name;
+      $name =~ s/_/ /g;
+      file_grep("$Self->{obj_dir}/obj_opt/Vopt__stats.txt", qr/DFG\s+(pre|post) inline Peephole, ${name}\s+([1-9]\d*)/i);
+    }
 
-# Check all optimizations defined in
-foreach my $opt (@optimizations) {
-    check($opt);
+    # Check all optimizations defined in
+    foreach my $opt (@optimizations) {
+        check($opt);
+    }
 }
 
 ok(1);

--- a/test_regress/t/t_difftree.pl
+++ b/test_regress/t/t_difftree.pl
@@ -10,11 +10,16 @@ if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); di
 
 scenarios(dist => 1);
 
-run(cmd => ["cd $Self->{obj_dir} && $ENV{VERILATOR_ROOT}/bin/verilator_difftree"
-            . " $Self->{t_dir}/t_difftree.a.tree $Self->{t_dir}/t_difftree.b.tree > diff.log"],
-    check_finished => 0);
+if (!-x "$ENV{VERILATOR_ROOT}/bin/verilator_difftree") {
+    skip("No verilator_difftree available")
+}
+else {
+    run(cmd => ["cd $Self->{obj_dir} && $ENV{VERILATOR_ROOT}/bin/verilator_difftree"
+                . " $Self->{t_dir}/t_difftree.a.tree $Self->{t_dir}/t_difftree.b.tree > diff.log"],
+        check_finished => 0);
 
-files_identical("$Self->{obj_dir}/diff.log", $Self->{golden_filename}, 'logfile');
+    files_identical("$Self->{obj_dir}/diff.log", $Self->{golden_filename}, 'logfile');
+}
 
 ok(1);
 

--- a/test_regress/t/t_dist_attributes_bad.pl
+++ b/test_regress/t/t_dist_attributes_bad.pl
@@ -13,8 +13,13 @@ use JSON::PP;
 use IO::File;
 
 scenarios(dist => 1);
+
+my $root = "..";
+
 if ($ENV{VERILATOR_TEST_NO_ATTRIBUTES}) {
     skip("Skipping due to VERILATOR_TEST_NO_ATTRIBUTES");
+} elsif (!-r "$root/.git") {
+    skip("Not in a git repository");
 } else {
     check();
 }

--- a/test_regress/t/t_dist_whitespace.pl
+++ b/test_regress/t/t_dist_whitespace.pl
@@ -10,83 +10,87 @@ if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); di
 
 scenarios(dist => 1);
 
-my $root = "..";
-my $Debug;
+if (!-r "$root/.git") {
+    skip("Not in a git repository");
+} else {
+    my $root = "..";
+    my $Debug;
 
-### Must trim output before and after our file list
-my %files = %{get_source_files($root)};
+    ### Must trim output before and after our file list
+    my %files = %{get_source_files($root)};
 
-my $any = 0;
-foreach my $file (sort keys %files) {
-    my $filename = "$root/$file";
-    next if !-f $filename;  # git file might be deleted but not yet staged
-    my $contents = file_contents($filename);
-    if ($file =~ /(\.out|\.dat)$/) {
-        # Ignore golden files
-        next;
-    } elsif ($contents =~ /[\001\002\003\004\005\006]/) {
-        # Ignore binary files
-        next;
-    }
-    if ($contents !~ /\n$/s && $contents ne "") {
-        $warns{$file} = "Missing trailing newline in $file";
-    }
-    if ($contents =~ /[ \t]\n/
-        || $contents =~ m/\n\n+$/) {  # Regexp repeated below
-        my $eol_ws_exempt = ($file =~ /spelling.txt$/
-                             || $file =~ m!/gtkwave/!);
-        next if $eol_ws_exempt;
-        if ($ENV{HARNESS_UPDATE_GOLDEN}) {
-            my $changes = undef;
-            $changes = 1 if ($contents =~ s/[ \t]+\n/\n/g);
-            $changes = 1 if (!$eol_ws_exempt && $contents =~ s/\n\n+$/\n/g);
-            next if (!$changes);
-            $warns{$file} = "Updated whitespace at $file";
-            write_wholefile($filename, $contents);
+    my $any = 0;
+    foreach my $file (sort keys %files) {
+        my $filename = "$root/$file";
+        next if !-f $filename;  # git file might be deleted but not yet staged
+        my $contents = file_contents($filename);
+        if ($file =~ /(\.out|\.dat)$/) {
+            # Ignore golden files
+            next;
+        } elsif ($contents =~ /[\001\002\003\004\005\006]/) {
+            # Ignore binary files
             next;
         }
-        my @lines = split(/\n/, $contents);
-        my $line_no = 0;
-        foreach my $line (@lines) {
-            $line_no++;
-            # Trim trailing carriage-return (ASCII 0x0d) and form feed (0x0c),
-            # as we expect a few of those
-            $line =~ s/[\x{d}\x{c}]//g;
-            if ($line =~ /\s$/) {
-                $warns{$file} = "Trailing whitespace at $file:$line_no";
-                $warns{$file} .= " (last character is ASCII " . ord(substr($line, -1, 1)) . ")";
+        if ($contents !~ /\n$/s && $contents ne "") {
+            $warns{$file} = "Missing trailing newline in $file";
+        }
+        if ($contents =~ /[ \t]\n/
+            || $contents =~ m/\n\n+$/) {  # Regexp repeated below
+            my $eol_ws_exempt = ($file =~ /spelling.txt$/
+                                 || $file =~ m!/gtkwave/!);
+            next if $eol_ws_exempt;
+            if ($ENV{HARNESS_UPDATE_GOLDEN}) {
+                my $changes = undef;
+                $changes = 1 if ($contents =~ s/[ \t]+\n/\n/g);
+                $changes = 1 if (!$eol_ws_exempt && $contents =~ s/\n\n+$/\n/g);
+                next if (!$changes);
+                $warns{$file} = "Updated whitespace at $file";
+                write_wholefile($filename, $contents);
+                next;
+            }
+            my @lines = split(/\n/, $contents);
+            my $line_no = 0;
+            foreach my $line (@lines) {
+                $line_no++;
+                # Trim trailing carriage-return (ASCII 0x0d) and form feed (0x0c),
+                # as we expect a few of those
+                $line =~ s/[\x{d}\x{c}]//g;
+                if ($line =~ /\s$/) {
+                    $warns{$file} = "Trailing whitespace at $file:$line_no";
+                    $warns{$file} .= " (last character is ASCII " . ord(substr($line, -1, 1)) . ")";
+                }
+            }
+            if ($contents =~ m/\n\n+$/ && !$eol_ws_exempt) {  # Regexp repeated above
+                $warns{$file} = "Trailing newlines at EOF in $file";
             }
         }
-        if ($contents =~ m/\n\n+$/ && !$eol_ws_exempt) {  # Regexp repeated above
-            $warns{$file} = "Trailing newlines at EOF in $file";
+        # Unicode checker; should this be done in another file?
+        # No way to auto-fix.
+        # Files with \r are flagged elsewhere, right?
+        if ($contents =~ /[^[:alnum:][:punct:] \t\r\n]/) {
+            my $unicode_exempt = ($file =~ /Changes$/
+                                  || $file =~ /CONTRIBUTORS$/
+                                  || $file =~ /contributors.rst$/
+                                  || $file =~ /spelling.txt$/);
+            next if $unicode_exempt;
+            $warns{$file} = "Warning: non-ASCII contents in $file\n";
         }
+        ++$any;
     }
-    # Unicode checker; should this be done in another file?
-    # No way to auto-fix.
-    # Files with \r are flagged elsewhere, right?
-    if ($contents =~ /[^[:alnum:][:punct:] \t\r\n]/) {
-        my $unicode_exempt = ($file =~ /Changes$/
-                              || $file =~ /CONTRIBUTORS$/
-                              || $file =~ /contributors.rst$/
-                              || $file =~ /spelling.txt$/);
-        next if $unicode_exempt;
-        $warns{$file} = "Warning: non-ASCII contents in $file\n";
-    }
-    ++$any;
-}
-$any > 50 or error("Too few source files found");
+    $any > 50 or error("Too few source files found");
 
-if (keys %warns) {
-    # First warning lists everything as that's shown in the driver summary
-    if ($ENV{HARNESS_UPDATE_GOLDEN}) {
-        error("Updated files with whitespace errors: ", join(' ', sort keys %warns));
-        error("To auto-fix: HARNESS_UPDATE_GOLDEN=1 {command} or --golden");
-    } else {
-        error("Files have whitespace errors: ", join(' ', sort keys %warns));
-        error("To auto-fix: HARNESS_UPDATE_GOLDEN=1 {command} or --golden");
-    }
-    foreach my $file (sort keys %warns) {
-        error($warns{$file});
+    if (keys %warns) {
+        # First warning lists everything as that's shown in the driver summary
+        if ($ENV{HARNESS_UPDATE_GOLDEN}) {
+            error("Updated files with whitespace errors: ", join(' ', sort keys %warns));
+            error("To auto-fix: HARNESS_UPDATE_GOLDEN=1 {command} or --golden");
+        } else {
+            error("Files have whitespace errors: ", join(' ', sort keys %warns));
+            error("To auto-fix: HARNESS_UPDATE_GOLDEN=1 {command} or --golden");
+        }
+        foreach my $file (sort keys %warns) {
+            error($warns{$file});
+        }
     }
 }
 

--- a/test_regress/t/t_flag_f.vc
+++ b/test_regress/t/t_flag_f.vc
@@ -1,8 +1,8 @@
 // Test that environment substitutions work
 # This is also a comment (in several simulators)
--f $VERILATOR_ROOT/test_regress/t/t_flag_f__2.vc
+-f $TEST_REGRESS/t/t_flag_f__2.vc
 // Env var with .v file, and parens
 // Double slash below is intentional, as allowed in other tools
-${VERILATOR_ROOT}/test_regress/t//t_flag_f__3.v
+${TEST_REGRESS}/t//t_flag_f__3.v
 // Test -f
--F $VERILATOR_ROOT/test_regress/t/tsub/t_flag_f_tsub.vc
+-F $TEST_REGRESS/t/tsub/t_flag_f_tsub.vc

--- a/test_regress/t/t_flag_getenv.pl
+++ b/test_regress/t/t_flag_getenv.pl
@@ -13,7 +13,7 @@ scenarios(vlt => 1);
 setenv('FOOBARTEST', "gotit");
 
 run(
-    cmd => ["../bin/verilator --getenv FOOBARTEST"],
+    cmd => ["$ENV{VERILATOR_ROOT}/bin/verilator --getenv FOOBARTEST"],
     expect => 'gotit
 ',
     logfile => "$Self->{obj_dir}/simx.log",
@@ -22,7 +22,7 @@ run(
 
 foreach my $var (qw(MAKE PERL SYSTEMC SYSTEMC_ARCH SYSTEMC_LIBDIR VERILATOR_ROOT)) {
     run(
-        cmd => ["../bin/verilator --getenv ${var}"],
+        cmd => ["$ENV{VERILATOR_ROOT}/bin/verilator --getenv ${var}"],
         logfile => "$Self->{obj_dir}/simx.log",
         verilator_run => 1,
         );

--- a/test_regress/t/t_flag_help.pl
+++ b/test_regress/t/t_flag_help.pl
@@ -30,13 +30,16 @@ sub check {
     file_grep($logfile, qr/(DISTRIBUTION|usage:)/i);
 }
 
-check("perl", "../bin/verilator");
-check("perl", "../bin/verilator_coverage");
+check("perl", "$ENV{VERILATOR_ROOT}/bin/verilator");
+check("perl", "$ENV{VERILATOR_ROOT}/bin/verilator_coverage");
 
-check("python3", "../bin/verilator_ccache_report");
-check("python3", "../bin/verilator_difftree");
-check("python3", "../bin/verilator_gantt");
-check("python3", "../bin/verilator_profcfunc");
+check("python3", "$ENV{VERILATOR_ROOT}/bin/verilator_ccache_report");
+check("python3", "$ENV{VERILATOR_ROOT}/bin/verilator_gantt");
+check("python3", "$ENV{VERILATOR_ROOT}/bin/verilator_profcfunc");
+
+if (-x "$ENV{VERILATOR_ROOT}/bin/verilator_difftree") {
+    check("python3", "$ENV{VERILATOR_ROOT}/bin/verilator_difftree");
+}
 
 ok(1);
 1;

--- a/test_regress/t/t_flag_help_valgrind.pl
+++ b/test_regress/t/t_flag_help_valgrind.pl
@@ -9,7 +9,7 @@ if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); di
 # SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
 
 run(fails => 0,
-    cmd => ["../bin/verilator", "--help", "--valgrind"],
+    cmd => ["$ENV{VERILATOR_ROOT}/bin/verilator", "--help", "--valgrind"],
     tee => 0,
     verilator_run => 1,
     );

--- a/test_regress/t/t_flag_nofile_bad.pl
+++ b/test_regress/t/t_flag_nofile_bad.pl
@@ -10,7 +10,7 @@ if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); di
 
 scenarios(vlt => 1);
 
-run(cmd => ["../bin/verilator --lint-only"],
+run(cmd => ["$ENV{VERILATOR_ROOT}/bin/verilator --lint-only"],
     fails => 1,
     logfile => "$Self->{obj_dir}/sim.log",
     expect_filename => $Self->{golden_filename},

--- a/test_regress/t/t_flag_noop_bad.pl
+++ b/test_regress/t/t_flag_noop_bad.pl
@@ -10,7 +10,7 @@ if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); di
 
 scenarios(vlt => 1);
 
-run(cmd => ["../bin/verilator",
+run(cmd => ["$ENV{VERILATOR_ROOT}/bin/verilator",
             "t_flag_noop_bad.v"],
     fails => 1,
     logfile => "$Self->{obj_dir}/sim.log",

--- a/test_regress/t/t_flag_supported.pl
+++ b/test_regress/t/t_flag_supported.pl
@@ -12,7 +12,7 @@ scenarios(vlt => 1);
 
 if ($Self->have_coroutines) {
     run(
-        cmd => ["../bin/verilator --get-supported COROUTINES"],
+        cmd => ["$ENV{VERILATOR_ROOT}/bin/verilator --get-supported COROUTINES"],
         expect => '1
 ',
         logfile => "$Self->{obj_dir}/vlt_coroutines.log",
@@ -22,7 +22,7 @@ if ($Self->have_coroutines) {
 
 if ($Self->have_sc) {
     run(
-        cmd => ["../bin/verilator --get-supported SYSTEMC"],
+        cmd => ["$ENV{VERILATOR_ROOT}/bin/verilator --get-supported SYSTEMC"],
         expect => '1
 ',
         logfile => "$Self->{obj_dir}/vlt_systemc.log",
@@ -31,7 +31,7 @@ if ($Self->have_sc) {
 }
 
 run(
-    cmd => ["../bin/verilator --get-supported DOES_NOT_EXIST"],
+    cmd => ["$ENV{VERILATOR_ROOT}/bin/verilator --get-supported DOES_NOT_EXIST"],
     expect => '',
     logfile => "$Self->{obj_dir}/vlt_does_not_exist.log",
     verilator_run => 1,

--- a/test_regress/t/t_flag_version.pl
+++ b/test_regress/t/t_flag_version.pl
@@ -12,11 +12,11 @@ scenarios(dist => 1);
 
 foreach my $prog (
     # See also t_flag_help.pl
-    "../bin/verilator",
-    "../bin/verilator_coverage",
-    #"../bin/verilator_difftree",
-    #"../bin/verilator_gantt",
-    #"../bin/verilator_profcfunc",
+    "$ENV{VERILATOR_ROOT}/bin/verilator",
+    "$ENV{VERILATOR_ROOT}/bin/verilator_coverage",
+    #"$ENV{VERILATOR_ROOT}/bin/verilator_difftree",
+    #"$ENV{VERILATOR_ROOT}/bin/verilator_gantt",
+    #"$ENV{VERILATOR_ROOT}/bin/verilator_profcfunc",
     ) {
     run(fails => 0,
         cmd => ["perl", $prog,

--- a/test_regress/t/t_lint_didnotconverge_bad.pl
+++ b/test_regress/t/t_lint_didnotconverge_bad.pl
@@ -10,24 +10,30 @@ if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); di
 
 scenarios(vlt => 1);
 
-compile(
-    verilator_flags2 => ["--prof-cfuncs"],
-    );
+my $root = "..";
 
-execute(
-    fails => 1,
-    expect_filename => $Self->{golden_filename},
-    );
+if (!-r "$root/.git") {
+    skip("Not in a git repository");
+} else {
+    compile(
+        verilator_flags2 => ["--prof-cfuncs"],
+        );
 
-extract(
-    in => $Self->{top_filename},
-    out => "../docs/gen/ex_DIDNOTCONVERGE_faulty.rst",
-    lines => "16-17");
+    execute(
+        fails => 1,
+        expect_filename => $Self->{golden_filename},
+        );
 
-extract(
-    in => $Self->{golden_filename},
-    out => "../docs/gen/ex_DIDNOTCONVERGE_msg.rst",
-    lines => "1-2");
+    extract(
+        in => $Self->{top_filename},
+        out => "../docs/gen/ex_DIDNOTCONVERGE_faulty.rst",
+        lines => "16-17");
+
+    extract(
+        in => $Self->{golden_filename},
+        out => "../docs/gen/ex_DIDNOTCONVERGE_msg.rst",
+        lines => "1-2");
+}
 
 ok(1);
 1;

--- a/test_regress/t/t_lint_didnotconverge_nodbg_bad.pl
+++ b/test_regress/t/t_lint_didnotconverge_nodbg_bad.pl
@@ -10,21 +10,27 @@ if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); di
 
 scenarios(vlt => 1);
 
-top_filename("t/t_lint_didnotconverge_bad.v");
+my $root = "..";
 
-compile(
-    make_flags => 'CPPFLAGS_ADD=-UVL_DEBUG',
-    );
+if (!-r "$root/.git") {
+    skip("Not in a git repository");
+} else {
+    top_filename("t/t_lint_didnotconverge_bad.v");
 
-execute(
-    fails => 1,
-    expect_filename => $Self->{golden_filename},
-    );
+    compile(
+        make_flags => 'CPPFLAGS_ADD=-UVL_DEBUG',
+        );
 
-extract(
-    in => $Self->{golden_filename},
-    out => "../docs/gen/ex_DIDNOTCONVERGE_nodbg_msg.rst",
-    lines => "1");
+    execute(
+        fails => 1,
+        expect_filename => $Self->{golden_filename},
+        );
+
+    extract(
+        in => $Self->{golden_filename},
+        out => "../docs/gen/ex_DIDNOTCONVERGE_nodbg_msg.rst",
+        lines => "1");
+}
 
 ok(1);
 1;

--- a/test_regress/t/t_lint_multidriven_bad.pl
+++ b/test_regress/t/t_lint_multidriven_bad.pl
@@ -10,20 +10,26 @@ if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); di
 
 scenarios(linter => 1);
 
-lint(
-    fails => 1,
-    expect_filename => $Self->{golden_filename},
-    );
+my $root = "..";
 
-extract(
-    in => $Self->{top_filename},
-    out => "../docs/gen/ex_MULTIDRIVEN_faulty.rst",
-    lines => "31-36");
+if (!-r "$root/.git") {
+    skip("Not in a git repository");
+} else {
+    lint(
+        fails => 1,
+        expect_filename => $Self->{golden_filename},
+        );
 
-extract(
-    in => $Self->{golden_filename},
-    out => "../docs/gen/ex_MULTIDRIVEN_msg.rst",
-    lines => "10,11,14");
+    extract(
+        in => $Self->{top_filename},
+        out => "../docs/gen/ex_MULTIDRIVEN_faulty.rst",
+        lines => "31-36");
+
+    extract(
+        in => $Self->{golden_filename},
+        out => "../docs/gen/ex_MULTIDRIVEN_msg.rst",
+        lines => "10,11,14");
+}
 
 ok(1);
 1;

--- a/test_regress/t/t_lint_stmtdly_bad.pl
+++ b/test_regress/t/t_lint_stmtdly_bad.pl
@@ -10,21 +10,27 @@ if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); di
 
 scenarios(vlt => 1);
 
-lint(
-    verilator_flags2 => ["--no-timing"],
-    fails => 1,
-    expect_filename => $Self->{golden_filename},
-    );
+my $root = "..";
 
-extract(
-    in => $Self->{top_filename},
-    out => "../docs/gen/ex_STMTDLY_faulty.rst",
-    lines => "10");
+if (!-r "$root/.git") {
+    skip("Not in a git repository");
+} else {
+    lint(
+        verilator_flags2 => ["--no-timing"],
+        fails => 1,
+        expect_filename => $Self->{golden_filename},
+        );
 
-extract(
-    in => $Self->{golden_filename},
-    out => "../docs/gen/ex_STMTDLY_msg.rst",
-    lines => "1");
+    extract(
+        in => $Self->{top_filename},
+        out => "../docs/gen/ex_STMTDLY_faulty.rst",
+        lines => "10");
+
+    extract(
+        in => $Self->{golden_filename},
+        out => "../docs/gen/ex_STMTDLY_msg.rst",
+        lines => "1");
+}
 
 ok(1);
 1;

--- a/test_regress/t/t_lint_widthexpand_docs_bad.pl
+++ b/test_regress/t/t_lint_widthexpand_docs_bad.pl
@@ -10,27 +10,33 @@ if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); di
 
 scenarios(linter => 1);
 
-lint(
-    verilator_flags2 => ["--lint-only"],
-    fails => $Self->{vlt_all},
-    expect_filename => $Self->{golden_filename},
-    );
+my $root = "..";
 
-extract(
-    in => $Self->{top_filename},
-    out => "../docs/gen/ex_WIDTHEXPAND_1_faulty.rst",
-    lines => "8-10");
+if (!-r "$root/.git") {
+    skip("Not in a git repository");
+} else {
+    lint(
+        verilator_flags2 => ["--lint-only"],
+        fails => $Self->{vlt_all},
+        expect_filename => $Self->{golden_filename},
+        );
 
-extract(
-    in => $Self->{golden_filename},
-    out => "../docs/gen/ex_WIDTHEXPAND_1_msg.rst",
-    lineno_adjust => -7,
-    regexp => qr/Warning-WIDTH/);
+    extract(
+        in => $Self->{top_filename},
+        out => "../docs/gen/ex_WIDTHEXPAND_1_faulty.rst",
+        lines => "8-10");
 
-extract(
-    in => $Self->{top_filename},
-    out => "../docs/gen/ex_WIDTHEXPAND_1_fixed.rst",
-    lines => "18");
+    extract(
+        in => $Self->{golden_filename},
+        out => "../docs/gen/ex_WIDTHEXPAND_1_msg.rst",
+        lineno_adjust => -7,
+        regexp => qr/Warning-WIDTH/);
+
+    extract(
+        in => $Self->{top_filename},
+        out => "../docs/gen/ex_WIDTHEXPAND_1_fixed.rst",
+        lines => "18");
+}
 
 ok(1);
 1;

--- a/test_regress/t/t_mod_dollar$.pl
+++ b/test_regress/t/t_mod_dollar$.pl
@@ -12,7 +12,7 @@ scenarios(vlt => 1);
 
 # This doesn't use the general compile rule as we want to make sure we form
 # prefix properly using post-escaped identifiers
-run(cmd => ["../bin/verilator",
+run(cmd => ["$ENV{VERILATOR_ROOT}/bin/verilator",
             "--cc",
             "--Mdir " . $Self->{obj_dir} . "/t_mod_dollar",
             "--exe --build --main",

--- a/test_regress/t/t_preproc_debugi.pl
+++ b/test_regress/t/t_preproc_debugi.pl
@@ -12,7 +12,7 @@ scenarios(vlt => 1);
 
 # Hit the debug statements in the preprocessor for internal coverage
 
-run(cmd => ["../bin/verilator",
+run(cmd => ["$ENV{VERILATOR_ROOT}/bin/verilator",
             "-E",
             "t/t_preproc_debugi.v",
             "--debug",

--- a/test_regress/t/t_var_bad_hide_docs.pl
+++ b/test_regress/t/t_var_bad_hide_docs.pl
@@ -10,22 +10,28 @@ if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); di
 
 scenarios(linter => 1);
 
-lint(
-    verilator_flags2 => ["--lint-only -Wwarn-VARHIDDEN"],
-    fails => $Self->{vlt_all},
-    expect_filename => $Self->{golden_filename},
-    );
+my $root = "..";
 
-extract(
-    in => $Self->{top_filename},
-    out => "../docs/gen/ex_VARHIDDEN_faulty.rst",
-    regexp => qr/(module t|integer|endmodule)/);
+if (!-r "$root/.git") {
+    skip("Not in a git repository");
+} else {
+    lint(
+        verilator_flags2 => ["--lint-only -Wwarn-VARHIDDEN"],
+        fails => $Self->{vlt_all},
+        expect_filename => $Self->{golden_filename},
+        );
 
-extract(
-    in => $Self->{golden_filename},
-    out => "../docs/gen/ex_VARHIDDEN_msg.rst",
-    lineno_adjust => -6,
-    regexp => qr/(var_bad_hide)/);
+    extract(
+        in => $Self->{top_filename},
+        out => "../docs/gen/ex_VARHIDDEN_faulty.rst",
+        regexp => qr/(module t|integer|endmodule)/);
+
+    extract(
+        in => $Self->{golden_filename},
+        out => "../docs/gen/ex_VARHIDDEN_msg.rst",
+        lineno_adjust => -6,
+        regexp => qr/(var_bad_hide)/);
+}
 
 ok(1);
 1;

--- a/test_regress/t/t_verilated_header.pl
+++ b/test_regress/t/t_verilated_header.pl
@@ -11,7 +11,7 @@ if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); di
 scenarios(simulator_st => 1);
 
 compile(
-    verilator_flags2 => ['+incdir+../include'],
+    verilator_flags2 => ["+incdir+$ENV{VERILATOR_ROOT}/include"],
     );
 
 execute(

--- a/test_regress/t/t_vlcov_debugi.pl
+++ b/test_regress/t/t_vlcov_debugi.pl
@@ -15,7 +15,7 @@ foreach my $basename ("t_vlcov_data_a.dat",
                       "t_vlcov_data_c.dat",
                       "t_vlcov_data_d.dat",
     ) {
-    run(cmd => ["../bin/verilator_coverage",
+    run(cmd => ["$ENV{VERILATOR_ROOT}/bin/verilator_coverage",
                 "t/${basename}",
                 "--debug",
                 "--debugi 9",

--- a/test_regress/t/t_vlcov_flag_invalid_bad.pl
+++ b/test_regress/t/t_vlcov_flag_invalid_bad.pl
@@ -10,7 +10,7 @@ if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); di
 
 scenarios(vlt => 1);
 
-run(cmd => ["../bin/verilator_coverage", '--invalid-dash'],
+run(cmd => ["$ENV{VERILATOR_ROOT}/bin/verilator_coverage", '--invalid-dash'],
     logfile => $Self->{run_log_filename},
     fails => 1,
     expect_filename => $Self->{golden_filename},

--- a/test_regress/t/t_vlcov_info.pl
+++ b/test_regress/t/t_vlcov_info.pl
@@ -10,7 +10,7 @@ if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); di
 
 scenarios(dist => 1);
 
-run(cmd => ["../bin/verilator_coverage",
+run(cmd => ["$ENV{VERILATOR_ROOT}/bin/verilator_coverage",
             "--write-info", "$Self->{obj_dir}/coverage.info",
             "t/t_vlcov_data_a.dat",
             "t/t_vlcov_data_b.dat",

--- a/test_regress/t/t_vlcov_merge.pl
+++ b/test_regress/t/t_vlcov_merge.pl
@@ -10,7 +10,7 @@ if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); di
 
 scenarios(dist => 1);
 
-run(cmd => ["../bin/verilator_coverage",
+run(cmd => ["$ENV{VERILATOR_ROOT}/bin/verilator_coverage",
             "--no-unlink", "--nounlink",
             "--write", "$Self->{obj_dir}/coverage.dat",
             "t/t_vlcov_data_a.dat",

--- a/test_regress/t/t_vlcov_nfound_bad.pl
+++ b/test_regress/t/t_vlcov_nfound_bad.pl
@@ -11,7 +11,7 @@ if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); di
 scenarios(dist => 1);
 
 run(fails => 1,
-    cmd => ["../bin/verilator_coverage",
+    cmd => ["$ENV{VERILATOR_ROOT}/bin/verilator_coverage",
             "t/t_NOT_FOUND",],
     logfile => $Self->{run_log_filename},
     expect_filename => $Self->{golden_filename},

--- a/test_regress/t/t_vlcov_rank.pl
+++ b/test_regress/t/t_vlcov_rank.pl
@@ -10,7 +10,7 @@ if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); di
 
 scenarios(dist => 1);
 
-run(cmd => ["../bin/verilator_coverage",
+run(cmd => ["$ENV{VERILATOR_ROOT}/bin/verilator_coverage",
             "--rank",
             "t/t_vlcov_data_a.dat",
             "t/t_vlcov_data_b.dat",

--- a/test_regress/t/t_vlcov_rewrite.pl
+++ b/test_regress/t/t_vlcov_rewrite.pl
@@ -15,7 +15,7 @@ foreach my $basename ("t_vlcov_data_a.dat",
                       "t_vlcov_data_c.dat",
                       "t_vlcov_data_d.dat",
     ) {
-    run(cmd => ["../bin/verilator_coverage",
+    run(cmd => ["$ENV{VERILATOR_ROOT}/bin/verilator_coverage",
                 "t/${basename}",
                 "--write", "$Self->{obj_dir}/${basename}"
         ],

--- a/test_regress/t/t_vlcov_unlink.pl
+++ b/test_regress/t/t_vlcov_unlink.pl
@@ -15,7 +15,7 @@ scenarios(dist => 1);
 my $tmp = "$Self->{obj_dir}/copied.dat";
 File::Copy::copy("$Self->{t_dir}/t_vlcov_data_a.dat", $tmp);
 
-run(cmd => ["../bin/verilator_coverage",
+run(cmd => ["$ENV{VERILATOR_ROOT}/bin/verilator_coverage",
             "--unlink",
             $tmp,
             "--write", "$Self->{obj_dir}/output.dat"],


### PR DESCRIPTION
It makes the installation relocatable based on the discussion in #4893.

All real executables are installed in the pkgdatadir/bin, and a redirect script is installed in the bindir for the public executables.

I also fixed up the tests so they can be run against an installation with
`env VERILATOR_ROOT=path/to/share/verilator make -C path/to/test_regress`

The remaining 2 test failures are due to the .out files mismatching because of the change to test_regress/input.vc.

If you are happy with this otherwise I will fix those remaining 2 failures and add a CI job to test against a relocated installation.