### PR TITLE
Add DFG 'regularize' pass, and improve variable removal

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -219,6 +219,7 @@ set(COMMON_SOURCES
     V3DfgOptimizer.cpp
     V3DfgPasses.cpp
     V3DfgPeephole.cpp
+    V3DfgRegularize.cpp
     V3DupFinder.cpp
     V3Timing.cpp
     V3EmitCBase.cpp

--- a/src/Makefile_obj.in
+++ b/src/Makefile_obj.in
@@ -233,6 +233,7 @@ RAW_OBJS_PCH_ASTNOMT = \
 	V3DfgOptimizer.o \
 	V3DfgPasses.o \
 	V3DfgPeephole.o \
+	V3DfgRegularize.o \
 	V3DupFinder.o \
 	V3EmitCMain.o \
 	V3EmitCMake.o \

--- a/src/V3Dfg.cpp
+++ b/src/V3Dfg.cpp
@@ -74,6 +74,8 @@ static void dumpDotVertex(std::ostream& os, const DfgVertex& vtx) {
         } else if (varVtxp->hasExtRefs()) {
             os << ", shape=box, style=filled, fillcolor=firebrick2";  // Red
         } else if (varVtxp->hasModRefs()) {
+            os << ", shape=box, style=filled, fillcolor=darkorange1";  // Orange
+        } else if (varVtxp->hasDfgRefs()) {
             os << ", shape=box, style=filled, fillcolor=gold2";  // Yellow
         } else if (varVtxp->keep()) {
             os << ", shape=box, style=filled, fillcolor=grey";
@@ -98,6 +100,8 @@ static void dumpDotVertex(std::ostream& os, const DfgVertex& vtx) {
         } else if (arrVtxp->hasExtRefs()) {
             os << ", shape=box3d, style=filled, fillcolor=firebrick2";  // Red
         } else if (arrVtxp->hasModRefs()) {
+            os << ", shape=box3d, style=filled, fillcolor=darkorange1";  // Orange
+        } else if (arrVtxp->hasDfgRefs()) {
             os << ", shape=box3d, style=filled, fillcolor=gold2";  // Yellow
         } else if (arrVtxp->keep()) {
             os << ", shape=box3d, style=filled, fillcolor=grey";
@@ -229,7 +233,7 @@ static void dumpDotUpstreamConeFromVertex(std::ostream& os, const DfgVertex& vtx
     // Emit all DfgVarPacked vertices that have external references driven by this vertex
     vtx.forEachSink([&](const DfgVertex& dst) {
         if (const DfgVarPacked* const varVtxp = dst.cast<DfgVarPacked>()) {
-            if (varVtxp->hasRefs()) dumpDotVertexAndSourceEdges(os, dst);
+            if (varVtxp->hasNonLocalRefs()) dumpDotVertexAndSourceEdges(os, dst);
         }
     });
 }
@@ -263,7 +267,7 @@ void DfgGraph::dumpDotAllVarConesPrefixed(const string& label) const {
         // Check if this vertex drives a variable referenced outside the DFG.
         const DfgVarPacked* const sinkp
             = vtx.findSink<DfgVarPacked>([](const DfgVarPacked& sink) {  //
-                  return sink.hasRefs();
+                  return sink.hasNonLocalRefs();
               });
 
         // We only dump cones driving an externally referenced variable

--- a/src/V3Dfg.h
+++ b/src/V3Dfg.h
@@ -504,9 +504,6 @@ public:
     // Is this a DfgConst that is all ones
     inline bool isOnes() const VL_MT_DISABLED;
 
-    // Should this vertex be inlined when rendering to Ast, or be stored to a temporary
-    inline bool inlined() const VL_MT_DISABLED;
-
     // Methods that allow DfgVertex to participate in error reporting/messaging
     void v3errorEnd(std::ostringstream& str) const VL_RELEASE(V3Error::s().m_mutex) {
         m_filelinep->v3errorEnd(str);
@@ -927,15 +924,6 @@ bool DfgVertex::isZero() const {
 
 bool DfgVertex::isOnes() const {
     if (const DfgConst* const constp = cast<DfgConst>()) return constp->isOnes();
-    return false;
-}
-
-bool DfgVertex::inlined() const {
-    // Inline vertices that drive only a single node, or are special
-    if (!hasMultipleSinks()) return true;
-    if (is<DfgConst>()) return true;
-    if (is<DfgVertexVar>()) return true;
-    if (const DfgArraySel* const selp = cast<DfgArraySel>()) return selp->bitp()->is<DfgConst>();
     return false;
 }
 

--- a/src/V3DfgDecomposition.cpp
+++ b/src/V3DfgDecomposition.cpp
@@ -329,11 +329,13 @@ class ExtractCyclicComponents final {
                 clonep = new DfgVarArray{m_dfg, aVtxp->varp()};
             }
             UASSERT_OBJ(clonep, &vtx, "Unhandled 'DfgVertexVar' sub-type");
+            if (vtx.hasModRefs()) clonep->setHasModRefs();
+            if (vtx.hasExtRefs()) clonep->setHasExtRefs();
             VertexState& cloneStatep = allocState(*clonep);
             cloneStatep.component = component;
-            // We need to mark both the original and the clone as having additional references
-            vtx.setHasModRefs();
-            clonep->setHasModRefs();
+            // We need to mark both the original and the clone as having references in other DFGs
+            vtx.setHasDfgRefs();
+            clonep->setHasDfgRefs();
         }
         return *clonep;
     }

--- a/src/V3DfgOptimizer.cpp
+++ b/src/V3DfgOptimizer.cpp
@@ -25,8 +25,6 @@
 #include "V3AstUserAllocator.h"
 #include "V3Dfg.h"
 #include "V3DfgPasses.h"
-#include "V3DfgPatternStats.h"
-#include "V3File.h"
 #include "V3Graph.h"
 #include "V3UniqueNames.h"
 
@@ -242,7 +240,7 @@ void V3DfgOptimizer::optimize(AstNetlist* netlistp, const string& label) {
     UINFO(2, __FUNCTION__ << ": " << endl);
 
     // NODE STATE
-    // AstVar::user1 -> Used by V3DfgPasses::astToDfg and DfgPassed::dfgToAst
+    // AstVar::user1 -> Used by V3DfgPasses::astToDfg
     // AstVar::user2 -> bool: Flag indicating referenced by AstVarXRef (set just below)
     // AstVar::user3 -> bool: Flag indicating written by logic not representable as DFG
     //                        (set by V3DfgPasses::astToDfg)
@@ -253,8 +251,6 @@ void V3DfgOptimizer::optimize(AstNetlist* netlistp, const string& label) {
     netlistp->foreach([](const AstVarXRef* xrefp) { xrefp->varp()->user2(true); });
 
     V3DfgOptimizationContext ctx{label};
-
-    V3DfgPatternStats patternStats;
 
     // Run the optimization phase
     for (AstNode* nodep = netlistp->modulesp(); nodep; nodep = nodep->nextp()) {
@@ -282,14 +278,6 @@ void V3DfgOptimizer::optimize(AstNetlist* netlistp, const string& label) {
         // Quick sanity check
         UASSERT_OBJ(dfg->size() == 0, nodep, "DfgGraph should have become empty");
 
-        // For each cyclic component
-        for (auto& component : cyclicComponents) {
-            if (dumpDfgLevel() >= 7) component->dumpDotFilePrefixed(ctx.prefix() + "source");
-            // TODO: Apply optimizations safe for cyclic graphs
-            // Add back under the main DFG (we will convert everything back in one go)
-            dfg->addGraph(*component);
-        }
-
         // For each acyclic component
         for (auto& component : acyclicComponents) {
             if (dumpDfgLevel() >= 7) component->dumpDotFilePrefixed(ctx.prefix() + "source");
@@ -299,33 +287,23 @@ void V3DfgOptimizer::optimize(AstNetlist* netlistp, const string& label) {
             dfg->addGraph(*component);
         }
 
-        // Accumulate patterns from the optimized graph for reporting
-        if (v3Global.opt.stats()) patternStats.accumulate(*dfg);
+        // Eliminate redundant variables. Run this on the whole acyclic DFG. It needs to traverse
+        // the module to perform variable substitutions. Doing this by component would do
+        // redundant traversals and can be extremely slow in large modules with many components.
+        V3DfgPasses::eliminateVars(*dfg, ctx.m_eliminateVarsContext);
+
+        // For each cyclic component
+        for (auto& component : cyclicComponents) {
+            if (dumpDfgLevel() >= 7) component->dumpDotFilePrefixed(ctx.prefix() + "source");
+            // TODO: Apply optimizations safe for cyclic graphs
+            // Add back under the main DFG (we will convert everything back in one go)
+            dfg->addGraph(*component);
+        }
 
         // Convert back to Ast
         if (dumpDfgLevel() >= 8) dfg->dumpDotFilePrefixed(ctx.prefix() + "whole-optimized");
         AstModule* const resultModp = V3DfgPasses::dfgToAst(*dfg, ctx);
         UASSERT_OBJ(resultModp == modp, modp, "Should be the same module");
-    }
-
-    // Print the collected patterns
-    if (v3Global.opt.stats()) {
-        // Label to lowercase, without spaces
-        std::string ident = label;
-        std::transform(ident.begin(), ident.end(), ident.begin(), [](unsigned char c) {  //
-            return c == ' ' ? '_' : std::tolower(c);
-        });
-
-        // File to dump to
-        const std::string filename = v3Global.opt.hierTopDataDir() + "/" + v3Global.opt.prefix()
-                                     + "__stats_dfg_patterns__" + ident + ".txt";
-
-        // Open, write, close
-        std::ofstream* const ofp = V3File::new_ofstream(filename);
-        if (ofp->fail()) v3fatal("Can't write " << filename);
-        patternStats.dump(label, *ofp);
-        ofp->close();
-        VL_DO_DANGLING(delete ofp, ofp);
     }
 
     V3Global::dumpCheckGlobalTree("dfg-optimize", 0, dumpTreeEitherLevel() >= 3);

--- a/src/V3DfgPasses.h
+++ b/src/V3DfgPasses.h
@@ -19,6 +19,7 @@
 
 #include "config_build.h"
 
+#include "V3DfgPatternStats.h"
 #include "V3DfgPeephole.h"
 #include "V3ThreadSafety.h"
 
@@ -39,14 +40,37 @@ public:
     ~V3DfgCseContext() VL_MT_DISABLED;
 };
 
-class DfgRemoveVarsContext final {
+class V3DfgRegularizeContext final {
+    const std::string m_label;  // Label to apply to stats
+
+    const std::string m_ident = [&]() {
+        std::string ident = m_label;
+        std::transform(ident.begin(), ident.end(), ident.begin(), [](unsigned char c) {  //
+            return c == ' ' ? '_' : std::tolower(c);
+        });
+        return ident;
+    }();
+
+public:
+    VDouble0 m_temporariesIntroduced;  // Number of temporaries introduced
+
+    const std::string& ident() const { return m_ident; }
+
+    explicit V3DfgRegularizeContext(const std::string& label)
+        : m_label{label} {}
+    ~V3DfgRegularizeContext() VL_MT_DISABLED;
+};
+
+class V3DfgEliminateVarsContext final {
     const std::string m_label;  // Label to apply to stats
 
 public:
-    VDouble0 m_removed;  // Number of redundant variables removed
-    explicit DfgRemoveVarsContext(const std::string& label)
+    VDouble0 m_varsReplaced;  // Number of variables replaced
+    VDouble0 m_varsRemoved;  // Number of variables removed
+
+    explicit V3DfgEliminateVarsContext(const std::string& label)
         : m_label{label} {}
-    ~DfgRemoveVarsContext() VL_MT_DISABLED;
+    ~V3DfgEliminateVarsContext() VL_MT_DISABLED;
 };
 
 class V3DfgOptimizationContext final {
@@ -66,14 +90,16 @@ public:
     VDouble0 m_nonRepUnknown;  // Equations non-representable due to unknown node
     VDouble0 m_nonRepVarRef;  // Equations non-representable due to variable reference
     VDouble0 m_nonRepWidth;  // Equations non-representable due to width mismatch
-    VDouble0 m_intermediateVars;  // Number of intermediate variables introduced
-    VDouble0 m_replacedVars;  // Number of variables replaced
     VDouble0 m_resultEquations;  // Number of result combinational equations
 
     V3DfgCseContext m_cseContext0{m_label + " 1st"};
     V3DfgCseContext m_cseContext1{m_label + " 2nd"};
     V3DfgPeepholeContext m_peepholeContext{m_label};
-    DfgRemoveVarsContext m_removeVarsContext{m_label};
+    V3DfgRegularizeContext m_regularizeContext{m_label};
+    V3DfgEliminateVarsContext m_eliminateVarsContext{m_label};
+
+    V3DfgPatternStats m_patternStats;
+
     explicit V3DfgOptimizationContext(const std::string& label) VL_MT_DISABLED;
     ~V3DfgOptimizationContext() VL_MT_DISABLED;
 
@@ -107,10 +133,13 @@ void cse(DfgGraph&, V3DfgCseContext&) VL_MT_DISABLED;
 void inlineVars(const DfgGraph&) VL_MT_DISABLED;
 // Peephole optimizations
 void peephole(DfgGraph&, V3DfgPeepholeContext&) VL_MT_DISABLED;
-// Remove redundant variables
-void removeVars(DfgGraph&, DfgRemoveVarsContext&) VL_MT_DISABLED;
+// Regularize graph. This must be run before converting back to Ast.
+void regularize(DfgGraph&, V3DfgRegularizeContext&) VL_MT_DISABLED;
 // Remove unused nodes
 void removeUnused(DfgGraph&) VL_MT_DISABLED;
+// Eliminate (remove or replace) redundant variables. Also removes resulting unused logic.
+void eliminateVars(DfgGraph&, V3DfgEliminateVarsContext&) VL_MT_DISABLED;
+
 }  // namespace V3DfgPasses
 
 #endif

--- a/src/V3DfgRegularize.cpp
+++ b/src/V3DfgRegularize.cpp
@@ -1,0 +1,123 @@
+// -*- mode: C++; c-file-style: "cc-mode" -*-
+//*************************************************************************
+// DESCRIPTION: Verilator: Convert DfgGraph to AstModule
+//
+// Code available from: https://verilator.org
+//
+//*************************************************************************
+//
+// Copyright 2003-2024 by Wilson Snyder. This program is free software; you
+// can redistribute it and/or modify it under the terms of either the GNU
+// Lesser General Public License Version 3 or the Perl Artistic License
+// Version 2.0.
+// SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+//
+//*************************************************************************
+//
+// - Ensures intermediate values (other than simple memory references or
+//   constants) with multiple uses are assigned to variables
+//
+//*************************************************************************
+
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
+
+#include "V3Dfg.h"
+#include "V3DfgPasses.h"
+#include "V3UniqueNames.h"
+
+VL_DEFINE_DEBUG_FUNCTIONS;
+
+class DfgRegularize final {
+    DfgGraph& m_dfg;  // The graph being processed
+    V3DfgRegularizeContext& m_ctx;  // The optimization context for stats
+
+    // For generating temporary names
+    V3UniqueNames m_tmpNames{"__VdfgRegularize_" + m_ctx.ident() + "_" + m_dfg.modulep()->name()
+                             + "_tmp"};
+
+    // Return canonical variable that can be used to hold the value of this vertex
+    DfgVarPacked* getCanonicalVariable(DfgVertex* vtxp) {
+        // First gather all existing variables fully written by this vertex
+        std::vector<DfgVarPacked*> varVtxps;
+        vtxp->forEachSink([&](DfgVertex& vtx) {
+            if (DfgVarPacked* const varVtxp = vtx.cast<DfgVarPacked>()) {
+                if (varVtxp->isDrivenFullyByDfg()) varVtxps.push_back(varVtxp);
+            }
+        });
+
+        if (!varVtxps.empty()) {
+            // There is at least one usable, existing variable. Pick the first one in source
+            // order for deterministic results.
+            std::stable_sort(varVtxps.begin(), varVtxps.end(),
+                             [](const DfgVarPacked* ap, const DfgVarPacked* bp) {
+                                 // Prefer those variables that must be kept anyway
+                                 const bool keepA = ap->keep() || ap->hasDfgRefs();
+                                 const bool keepB = bp->keep() || bp->hasDfgRefs();
+                                 if (keepA != keepB) return keepA;
+                                 // Prefer those that already have module references, so we don't
+                                 // have to support recursive substitutions.
+                                 if (ap->hasModRefs() != bp->hasModRefs()) return ap->hasModRefs();
+                                 // Otherwise source order
+                                 const FileLine& aFl = *(ap->fileline());
+                                 const FileLine& bFl = *(bp->fileline());
+                                 if (const int cmp = aFl.operatorCompare(bFl)) return cmp < 0;
+                                 // Fall back on names if all else fails
+                                 return ap->varp()->name() < bp->varp()->name();
+                             });
+            return varVtxps.front();
+        }
+
+        // We need to introduce a temporary
+        ++m_ctx.m_temporariesIntroduced;
+
+        // Add temporary AstVar to containing module
+        FileLine* const flp = vtxp->fileline();
+        const std::string name = m_tmpNames.get(vtxp->hash().toString());
+        AstVar* const varp = new AstVar{flp, VVarType::MODULETEMP, name, vtxp->dtypep()};
+        m_dfg.modulep()->addStmtsp(varp);
+
+        // Create and return a variable vertex for the temporary
+        return new DfgVarPacked{m_dfg, varp};
+    }
+
+    // Insert intermediate variables for vertices with multiple sinks (or use an existing one)
+    DfgRegularize(DfgGraph& dfg, V3DfgRegularizeContext& ctx)
+        : m_dfg{dfg}
+        , m_ctx{ctx} {
+
+        // Used by DfgVertex::hash
+        const auto userDataInUse = m_dfg.userDataInUse();
+
+        // Ensure intermediate values used multiple times are written to variables
+        for (DfgVertex *vtxp = m_dfg.opVerticesBeginp(), *nextp; vtxp; vtxp = nextp) {
+            nextp = vtxp->verticesNext();
+
+            // Operations without multiple sinks need no variables
+            if (!vtxp->hasMultipleSinks()) continue;
+            // Array selects need no variables, they are just memory references
+            if (vtxp->is<DfgArraySel>()) continue;
+
+            // This is an op which has multiple sinks. Ensure it is assigned to a variable.
+            DfgVarPacked* const varp = getCanonicalVariable(vtxp);
+            if (varp->arity()) {
+                // Existing variable
+                FileLine* const flp = varp->driverFileLine(0);
+                varp->sourceEdge(0)->unlinkSource();
+                varp->resetSources();
+                vtxp->replaceWith(varp);
+                varp->addDriver(flp, 0, vtxp);
+            } else {
+                // Temporary variable
+                vtxp->replaceWith(varp);
+                varp->addDriver(vtxp->fileline(), 0, vtxp);
+            }
+        }
+    }
+
+public:
+    static void apply(DfgGraph& dfg, V3DfgRegularizeContext& ctx) { DfgRegularize{dfg, ctx}; }
+};
+
+void V3DfgPasses::regularize(DfgGraph& dfg, V3DfgRegularizeContext& ctx) {
+    DfgRegularize::apply(dfg, ctx);
+}

--- a/src/V3DfgVertices.h
+++ b/src/V3DfgVertices.h
@@ -40,6 +40,7 @@
 
 class DfgVertexVar VL_NOT_FINAL : public DfgVertexVariadic {
     AstVar* const m_varp;  // The AstVar associated with this vertex (not owned by this vertex)
+    bool m_hasDfgRefs = false;  // This AstVar is referenced in a different DFG of the module
     bool m_hasModRefs = false;  // This AstVar is referenced outside the DFG, but in the module
     bool m_hasExtRefs = false;  // This AstVar is referenced from outside the module
 
@@ -62,11 +63,13 @@ public:
     bool isDrivenByDfg() const { return arity() > 0; }
 
     AstVar* varp() const { return m_varp; }
+    bool hasDfgRefs() const { return m_hasDfgRefs; }
+    void setHasDfgRefs() { m_hasDfgRefs = true; }
     bool hasModRefs() const { return m_hasModRefs; }
     void setHasModRefs() { m_hasModRefs = true; }
     bool hasExtRefs() const { return m_hasExtRefs; }
     void setHasExtRefs() { m_hasExtRefs = true; }
-    bool hasRefs() const { return m_hasModRefs || m_hasExtRefs; }
+    bool hasNonLocalRefs() const { return hasDfgRefs() || hasModRefs() || hasExtRefs(); }
 
     // Variable cannot be removed, even if redundant in the DfgGraph (might be used externally)
     bool keep() const {

--- a/src/astgen
+++ b/src/astgen
@@ -1294,7 +1294,7 @@ def write_dfg_dfg_to_ast(filename):
                 "void visit(Dfg{t}* vtxp) override {{\n".format(t=node.name))
             for i in range(node.arity):
                 fh.write(
-                    "    AstNodeExpr* const op{j}p = convertSource(vtxp->source<{i}>());\n"
+                    "    AstNodeExpr* const op{j}p = convertDfgVertexToAstNodeExpr(vtxp->source<{i}>());\n"
                     .format(i=i, j=i + 1))
             fh.write(
                 "    m_resultp = makeNode<Ast{t}>(vtxp".format(t=node.name))

--- a/test_regress/t/t_json_only_first.out
+++ b/test_regress/t/t_json_only_first.out
@@ -47,7 +47,7 @@
       {"type":"VARREF","name":"d","addr":"(IB)","loc":"d,49:16,49:17","dtypep":"(G)","access":"RD","varp":"(Z)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
     ],
      "lhsp": [
-      {"type":"VARREF","name":"q","addr":"(JB)","loc":"d,50:22,50:23","dtypep":"(G)","access":"WR","varp":"(CB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+      {"type":"VARREF","name":"q","addr":"(JB)","loc":"d,53:13,53:14","dtypep":"(G)","access":"WR","varp":"(CB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
     ],"timingControlp": [],"strengthSpecp": []}
   ],"activesp": []},
   {"type":"MODULE","name":"mod1__W4","addr":"(M)","loc":"d,31:8,31:12","origName":"mod1","level":3,"modPublic":false,"inLibrary":false,"dead":false,"recursiveClone":false,"recursive":false,"timeunit":"1ps","inlinesp": [],

--- a/test_regress/t/t_json_only_flat.out
+++ b/test_regress/t/t_json_only_flat.out
@@ -131,7 +131,7 @@
           {"type":"VARREF","name":"t.between","addr":"(ZC)","loc":"d,17:22,17:29","dtypep":"(H)","access":"RD","varp":"(O)","varScopep":"(HB)","classOrPackagep":"UNLINKED"}
         ],
          "lhsp": [
-          {"type":"VARREF","name":"q","addr":"(AD)","loc":"d,15:22,15:23","dtypep":"(H)","access":"WR","varp":"(G)","varScopep":"(BB)","classOrPackagep":"UNLINKED"}
+          {"type":"VARREF","name":"q","addr":"(AD)","loc":"d,53:13,53:14","dtypep":"(H)","access":"WR","varp":"(G)","varScopep":"(BB)","classOrPackagep":"UNLINKED"}
         ],"timingControlp": [],"strengthSpecp": []}
       ]}
     ]}

--- a/test_regress/t/t_xml_first.out
+++ b/test_regress/t/t_xml_first.out
@@ -51,7 +51,7 @@
       <var loc="d,50,22,50,23" name="q" dtype_id="1" dir="output" pinIndex="3" vartype="logic" origName="q"/>
       <contassign loc="d,53,13,53,14" dtype_id="1">
         <varref loc="d,49,16,49,17" name="d" dtype_id="1"/>
-        <varref loc="d,50,22,50,23" name="q" dtype_id="1"/>
+        <varref loc="d,53,13,53,14" name="q" dtype_id="1"/>
       </contassign>
     </module>
     <module loc="d,31,8,31,12" name="mod1__W4" origName="mod1">

--- a/test_regress/t/t_xml_flat.out
+++ b/test_regress/t/t_xml_flat.out
@@ -100,7 +100,7 @@
           </assignalias>
           <contassign loc="d,53,13,53,14" dtype_id="1">
             <varref loc="d,17,22,17,29" name="t.between" dtype_id="1"/>
-            <varref loc="d,15,22,15,23" name="q" dtype_id="1"/>
+            <varref loc="d,53,13,53,14" name="q" dtype_id="1"/>
           </contassign>
         </scope>
       </topscope>


### PR DESCRIPTION
This functionality used to be distributed in the removeVars pass and the final dfgToAst conversion. Instead added a new 'regularize' pass to convert DFGs into forms that can be trivially converted back to Ast, and a new 'eliminateVars' pass to remove/repalce redundant variables. This simplifies dfgToAst significantly and makes the code a bit easier to follow.

The new 'regularize' pass will ensure that every sub-expression with multiple uses is assigned to a temporary (unless it's a trivial memory reference or constant), and will also eliminate or replace redundant variables. Overall it is a performance neutral change but it does enable some later improvements which required the graph to be in this form, and this also happens to be the form required for the dfgToAst conversion.