### PR TITLE
Fix try-lock spuriously fail in V3ThreadPool destructor (#4931)

### DIFF
--- a/src/V3ThreadPool.h
+++ b/src/V3ThreadPool.h
@@ -139,7 +139,15 @@ class V3ThreadPool final {
             std::abort();
         }
 
-        if (VL_UNCOVERABLE(!m_mutex.try_lock())) {
+        bool m_mutex_locked = m_mutex.try_lock();
+        // try_lock can sometimes spontaneously fail even when mutex is not locked,
+        // make sure this isn't the case
+        for (int i = 0; i < VL_LOCK_SPINS; ++i) {
+            if (VL_LIKELY(m_mutex_locked)) break;
+            VL_CPU_RELAX();
+            m_mutex_locked = m_mutex.try_lock();
+        }
+        if (VL_UNCOVERABLE(!m_mutex_locked)) {
             if (VL_UNCOVERABLE(m_jobsInProgress != 0)) {
                 // ThreadPool shouldn't be destroyed when jobs are running and mutex is locked,
                 // something is wrong. Most likely Verilator is exiting as a result of failed


### PR DESCRIPTION
Fixes: https://github.com/verilator/verilator/issues/4931

try_lock can fail even when mutex is not locked: https://en.cppreference.com/w/cpp/thread/mutex/try_lock
