### PR TITLE
Add some missing VNUserInUse

### DIFF
--- a/src/V3Clock.cpp
+++ b/src/V3Clock.cpp
@@ -66,6 +66,9 @@ public:
 // Clock state, as a visitor of each AstNode
 
 class ClockVisitor final : public VNVisitor {
+    // NODE STATE
+    // ???
+    const VNUser1InUse m_user1InUse;
     // STATE
     AstCFunc* m_evalp = nullptr;  // The '_eval' function
     AstScope* m_scopep = nullptr;  // Current scope

--- a/src/V3EmitXml.cpp
+++ b/src/V3EmitXml.cpp
@@ -32,6 +32,7 @@ class EmitXmlFileVisitor final : public VNVisitorConst {
     // NODE STATE
     // Entire netlist:
     // AstNode::user1           -> uint64_t, number to connect crossrefs
+    const VNUser1InUse m_user1InUse;
 
     // MEMBERS
     V3OutFile* const m_ofp;

--- a/src/V3LifePost.cpp
+++ b/src/V3LifePost.cpp
@@ -129,6 +129,7 @@ class LifePostDlyVisitor final : public VNVisitor {
     // NODE STATE
     // AstVarScope::user1()    -> bool: referenced outside _eval__nba
     // AstVarScope::user4()    -> AstVarScope*: Passed to LifePostElim to substitute this var
+    const VNUser1InUse m_inuser1;
     const VNUser4InUse m_inuser4;
 
     // STATE

--- a/src/V3Order.cpp
+++ b/src/V3Order.cpp
@@ -532,6 +532,7 @@ class ProcessMoveBuildGraph final {
 
     // NODE STATE
     // AstSenTree::user1p()     -> AstSenTree:  Original AstSenTree for trigger
+    const VNUser1InUse m_user1InUse;
 
     // TYPES
     using DomainMap = std::map<const AstSenTree*, T_MoveVertex*>;
@@ -1285,10 +1286,12 @@ void OrderProcess::processMTasks() {
     // only logic, and discarding edges we know we can ignore.
     // This is quite similar to the 'm_pomGraph' of the serial code gen:
     V3Graph logicGraph;
-    OrderMTaskMoveVertexMaker create_mtask_vertex(&logicGraph);
-    ProcessMoveBuildGraph<MTaskMoveVertex> mtask_pmbg(&m_graph, &logicGraph, m_trigToSen,
-                                                      &create_mtask_vertex);
-    mtask_pmbg.build();
+    {
+        OrderMTaskMoveVertexMaker create_mtask_vertex(&logicGraph);
+        ProcessMoveBuildGraph<MTaskMoveVertex> mtask_pmbg(&m_graph, &logicGraph, m_trigToSen,
+                                                          &create_mtask_vertex);
+        mtask_pmbg.build();
+    }
 
     // Needed? We do this for m_pomGraph in serial mode, so do it here too:
     logicGraph.removeRedundantEdgesMax(&V3GraphEdge::followAlwaysTrue);


### PR DESCRIPTION
These are not all the missing cases, for example V3Timing is badly entangled with V3Const via user4, but I don't have time to fix it all. This is enough to unblock what I need at the moment.

FWIW #4646 would avoid all this.