### PR TITLE
Use LogOr on inside operator expansion

### DIFF
--- a/src/V3AstNodes.cpp
+++ b/src/V3AstNodes.cpp
@@ -319,7 +319,7 @@ AstNodeExpr* AstInsideRange::newAndFromInside(AstNodeExpr* exprp, AstNodeExpr* l
     AstNodeExpr* const bp = new AstLte{fileline(), exprp->cloneTreePure(true), rhsp};
     ap->fileline()->modifyWarnOff(V3ErrorCode::UNSIGNED, true);
     bp->fileline()->modifyWarnOff(V3ErrorCode::CMPCONST, true);
-    return new AstAnd{fileline(), ap, bp};
+    return new AstLogAnd{fileline(), ap, bp};
 }
 
 AstConst* AstConst::parseParamLiteral(FileLine* fl, const string& literal) {

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -2572,7 +2572,7 @@ class WidthVisitor final : public VNVisitor {
                                             itemp->unlinkFrBack());
             }
             if (newp) {
-                newp = new AstOr{nodep->fileline(), newp, inewp};
+                newp = new AstLogOr{nodep->fileline(), newp, inewp};
             } else {
                 newp = inewp;
             }


### PR DESCRIPTION
This will help introducing constrained randomization, as SMT solvers treat booleans and 1-bit vectors as incompatible types.

Split from #4947