### PR TITLE
[Vpi] Fix missing scopes 2

### DIFF
--- a/src/V3AstNodes.cpp
+++ b/src/V3AstNodes.cpp
@@ -1503,9 +1503,17 @@ void AstCell::dumpJson(std::ostream& str) const {
 void AstCellInline::dump(std::ostream& str) const {
     this->AstNode::dump(str);
     str << " -> " << origModName();
-    str << " [scopep=" << nodeAddr(scopep()) << "]";
 }
 void AstCellInline::dumpJson(std::ostream& str) const {
+    dumpJsonStrFunc(str, origModName);
+    dumpJsonGen(str);
+}
+void AstCellInlineScope::dump(std::ostream& str) const {
+    this->AstNode::dump(str);
+    str << " -> " << origModName();
+    str << " [scopep=" << nodeAddr(scopep()) << "]";
+}
+void AstCellInlineScope::dumpJson(std::ostream& str) const {
     dumpJsonStrFunc(str, origModName);
     dumpJsonGen(str);
 }

--- a/src/V3EmitCSyms.cpp
+++ b/src/V3EmitCSyms.cpp
@@ -315,7 +315,7 @@ class EmitCSyms final : EmitCBaseVisitorConst {
             iterateChildrenConst(nodep);
         }
     }
-    void visit(AstCellInline* nodep) override {
+    void visit(AstCellInlineScope* nodep) override {
         if (v3Global.opt.vpi()) {
             const string type
                 = (nodep->origModName() == "__BEGIN__") ? "SCOPE_OTHER" : "SCOPE_MODULE";
@@ -341,6 +341,7 @@ class EmitCSyms final : EmitCBaseVisitorConst {
                 scopeSymString(nodep->name()),
                 ScopeData{nodep, scopeSymString(nodep->name()), name_pretty, timeunit, type});
         }
+        iterateChildrenConst(nodep);
     }
     void visit(AstScopeName* nodep) override {
         const string name = nodep->scopeSymName();

--- a/src/V3Hasher.cpp
+++ b/src/V3Hasher.cpp
@@ -465,10 +465,8 @@ class HasherVisitor final : public VNVisitorConst {
         });
     }
     void visit(AstCellInline* nodep) override {
-        m_hash += hashNodeAndIterate(nodep, HASH_DTYPE, HASH_CHILDREN, [this, nodep]() {
-            m_hash += nodep->name();
-            iterateConstNull(nodep->scopep());
-        });
+        m_hash += hashNodeAndIterate(nodep, HASH_DTYPE, HASH_CHILDREN,
+                                     [this, nodep]() { m_hash += nodep->name(); });
     }
     void visit(AstNodeFTask* nodep) override {
         m_hash += hashNodeAndIterate(nodep, HASH_DTYPE, HASH_CHILDREN, [this, nodep]() {  //

--- a/src/V3Scope.cpp
+++ b/src/V3Scope.cpp
@@ -178,7 +178,9 @@ class ScopeVisitor final : public VNVisitor {
         }
     }
     void visit(AstCellInline* nodep) override {  //
-        nodep->scopep(m_scopep);
+        if (v3Global.opt.vpi()) {
+            m_scopep->addInlinesp(new AstCellInlineScope{nodep->fileline(), m_scopep, nodep});
+        }
     }
     void visit(AstActive* nodep) override {  // LCOV_EXCL_LINE
         nodep->v3fatalSrc("Actives now made after scoping");

--- a/test_regress/driver.pl
+++ b/test_regress/driver.pl
@@ -1286,6 +1286,10 @@ sub compile {
     }
 
     if ($param{make_pli}) {
+        # if make_pli is a string and not one
+        if ($param{make_pli} ne "1") {
+            $self->{pli_filename} = $param{make_pli};
+        }
         $self->oprint("Compile vpi\n") if $self->{verbose};
         my @cmd = ($ENV{CXX}, @{$param{pli_flags}},
                    "-D" . $param{tool_define},

--- a/test_regress/t/t_constraint_json_only.out
+++ b/test_regress/t/t_constraint_json_only.out
@@ -53,7 +53,7 @@
    "modulep": [
     {"type":"MODULE","name":"@CONST-POOL@","addr":"(EB)","loc":"a,0:0,0:0","origName":"@CONST-POOL@","level":0,"modPublic":false,"inLibrary":false,"dead":false,"recursiveClone":false,"recursive":false,"timeunit":"NONE","inlinesp": [],
      "stmtsp": [
-      {"type":"SCOPE","name":"@CONST-POOL@","addr":"(FB)","loc":"a,0:0,0:0","aboveScopep":"UNLINKED","aboveCellp":"UNLINKED","modp":"(EB)","varsp": [],"blocksp": []}
+      {"type":"SCOPE","name":"@CONST-POOL@","addr":"(FB)","loc":"a,0:0,0:0","aboveScopep":"UNLINKED","aboveCellp":"UNLINKED","modp":"(EB)","varsp": [],"blocksp": [],"inlinesp": []}
     ],"activesp": []}
   ]}
 ]}

--- a/test_regress/t/t_json_only_begin_hier.out
+++ b/test_regress/t/t_json_only_begin_hier.out
@@ -48,7 +48,7 @@
    "modulep": [
     {"type":"MODULE","name":"@CONST-POOL@","addr":"(BB)","loc":"a,0:0,0:0","origName":"@CONST-POOL@","level":0,"modPublic":false,"inLibrary":false,"dead":false,"recursiveClone":false,"recursive":false,"timeunit":"NONE","inlinesp": [],
      "stmtsp": [
-      {"type":"SCOPE","name":"@CONST-POOL@","addr":"(CB)","loc":"a,0:0,0:0","aboveScopep":"UNLINKED","aboveCellp":"UNLINKED","modp":"(BB)","varsp": [],"blocksp": []}
+      {"type":"SCOPE","name":"@CONST-POOL@","addr":"(CB)","loc":"a,0:0,0:0","aboveScopep":"UNLINKED","aboveCellp":"UNLINKED","modp":"(BB)","varsp": [],"blocksp": [],"inlinesp": []}
     ],"activesp": []}
   ]}
 ]}

--- a/test_regress/t/t_json_only_debugcheck.out
+++ b/test_regress/t/t_json_only_debugcheck.out
@@ -13,7 +13,7 @@
     {"type":"CELL","name":"$unit","addr":"(X)","loc":"a,0:0,0:0","origName":"__024unit","recursive":false,"modp":"(E)","pinsp": [],"paramsp": [],"rangep": [],"intfRefsp": []},
     {"type":"TOPSCOPE","name":"","addr":"(H)","loc":"d,11:8,11:9","senTreesp": [],
      "scopep": [
-      {"type":"SCOPE","name":"TOP","addr":"(Y)","loc":"d,11:8,11:9","aboveScopep":"UNLINKED","aboveCellp":"UNLINKED","modp":"(I)","varsp": [],"blocksp": []}
+      {"type":"SCOPE","name":"TOP","addr":"(Y)","loc":"d,11:8,11:9","aboveScopep":"UNLINKED","aboveCellp":"UNLINKED","modp":"(I)","varsp": [],"blocksp": [],"inlinesp": []}
     ]},
     {"type":"CFUNC","name":"_eval_static","addr":"(Z)","loc":"a,0:0,0:0","slow":true,"isStatic":false,"dpiExportDispatcher":false,"dpiExportImpl":false,"dpiImportPrototype":false,"dpiImportWrapper":false,"dpiContext":false,"isConstructor":false,"isDestructor":false,"isVirtual":false,"isCoroutine":false,"needProcess":false,"scopep":"(Y)","argsp": [],"initsp": [],
      "stmtsp": [
@@ -2888,7 +2888,7 @@
         ]}
       ]}
     ],"attrsp": []},
-    {"type":"SCOPE","name":"$unit","addr":"(JQB)","loc":"a,0:0,0:0","aboveScopep":"(Y)","aboveCellp":"(X)","modp":"(E)","varsp": [],"blocksp": []},
+    {"type":"SCOPE","name":"$unit","addr":"(JQB)","loc":"a,0:0,0:0","aboveScopep":"(Y)","aboveCellp":"(X)","modp":"(E)","varsp": [],"blocksp": [],"inlinesp": []},
     {"type":"CFUNC","name":"_ctor_var_reset","addr":"(KQB)","loc":"a,0:0,0:0","slow":true,"isStatic":false,"dpiExportDispatcher":false,"dpiExportImpl":false,"dpiImportPrototype":false,"dpiImportWrapper":false,"dpiContext":false,"isConstructor":false,"isDestructor":false,"isVirtual":false,"isCoroutine":false,"needProcess":false,"scopep":"UNLINKED","argsp": [],"initsp": [],
      "stmtsp": [
       {"type":"CRESET","name":"","addr":"(LQB)","loc":"d,17:12,17:16",
@@ -2992,7 +2992,7 @@
    "modulep": [
     {"type":"MODULE","name":"@CONST-POOL@","addr":"(VRB)","loc":"a,0:0,0:0","origName":"@CONST-POOL@","level":0,"modPublic":false,"inLibrary":false,"dead":false,"recursiveClone":false,"recursive":false,"timeunit":"NONE","inlinesp": [],
      "stmtsp": [
-      {"type":"SCOPE","name":"TOP","addr":"(WRB)","loc":"a,0:0,0:0","aboveScopep":"UNLINKED","aboveCellp":"UNLINKED","modp":"(VRB)","varsp": [],"blocksp": []}
+      {"type":"SCOPE","name":"TOP","addr":"(WRB)","loc":"a,0:0,0:0","aboveScopep":"UNLINKED","aboveCellp":"UNLINKED","modp":"(VRB)","varsp": [],"blocksp": [],"inlinesp": []}
     ],"activesp": []}
   ]}
 ]}

--- a/test_regress/t/t_json_only_first.out
+++ b/test_regress/t/t_json_only_first.out
@@ -95,7 +95,7 @@
    "modulep": [
     {"type":"MODULE","name":"@CONST-POOL@","addr":"(WB)","loc":"a,0:0,0:0","origName":"@CONST-POOL@","level":0,"modPublic":false,"inLibrary":false,"dead":false,"recursiveClone":false,"recursive":false,"timeunit":"NONE","inlinesp": [],
      "stmtsp": [
-      {"type":"SCOPE","name":"@CONST-POOL@","addr":"(XB)","loc":"a,0:0,0:0","aboveScopep":"UNLINKED","aboveCellp":"UNLINKED","modp":"(WB)","varsp": [],"blocksp": []}
+      {"type":"SCOPE","name":"@CONST-POOL@","addr":"(XB)","loc":"a,0:0,0:0","aboveScopep":"UNLINKED","aboveCellp":"UNLINKED","modp":"(WB)","varsp": [],"blocksp": [],"inlinesp": []}
     ],"activesp": []}
   ]}
 ]}

--- a/test_regress/t/t_json_only_flat.out
+++ b/test_regress/t/t_json_only_flat.out
@@ -133,7 +133,7 @@
          "lhsp": [
           {"type":"VARREF","name":"q","addr":"(AD)","loc":"d,53:13,53:14","dtypep":"(H)","access":"WR","varp":"(G)","varScopep":"(BB)","classOrPackagep":"UNLINKED"}
         ],"timingControlp": [],"strengthSpecp": []}
-      ]}
+      ],"inlinesp": []}
     ]}
   ],"activesp": []}
 ],"filesp": [],
@@ -148,7 +148,7 @@
    "modulep": [
     {"type":"MODULE","name":"@CONST-POOL@","addr":"(BD)","loc":"a,0:0,0:0","origName":"@CONST-POOL@","level":0,"modPublic":false,"inLibrary":false,"dead":false,"recursiveClone":false,"recursive":false,"timeunit":"NONE","inlinesp": [],
      "stmtsp": [
-      {"type":"SCOPE","name":"@CONST-POOL@","addr":"(CD)","loc":"a,0:0,0:0","aboveScopep":"UNLINKED","aboveCellp":"UNLINKED","modp":"(BD)","varsp": [],"blocksp": []}
+      {"type":"SCOPE","name":"@CONST-POOL@","addr":"(CD)","loc":"a,0:0,0:0","aboveScopep":"UNLINKED","aboveCellp":"UNLINKED","modp":"(BD)","varsp": [],"blocksp": [],"inlinesp": []}
     ],"activesp": []}
   ]}
 ]}

--- a/test_regress/t/t_json_only_flat_no_inline_mod.out
+++ b/test_regress/t/t_json_only_flat_no_inline_mod.out
@@ -28,7 +28,7 @@
          "lhsp": [
           {"type":"VARREF","name":"top.f.i_clk","addr":"(T)","loc":"d,7:24,7:29","dtypep":"(H)","access":"WR","varp":"(J)","varScopep":"(N)","classOrPackagep":"UNLINKED"}
         ],"timingControlp": []}
-      ]}
+      ],"inlinesp": []}
     ]}
   ],"activesp": []}
 ],"filesp": [],
@@ -41,7 +41,7 @@
    "modulep": [
     {"type":"MODULE","name":"@CONST-POOL@","addr":"(U)","loc":"a,0:0,0:0","origName":"@CONST-POOL@","level":0,"modPublic":false,"inLibrary":false,"dead":false,"recursiveClone":false,"recursive":false,"timeunit":"NONE","inlinesp": [],
      "stmtsp": [
-      {"type":"SCOPE","name":"@CONST-POOL@","addr":"(V)","loc":"a,0:0,0:0","aboveScopep":"UNLINKED","aboveCellp":"UNLINKED","modp":"(U)","varsp": [],"blocksp": []}
+      {"type":"SCOPE","name":"@CONST-POOL@","addr":"(V)","loc":"a,0:0,0:0","aboveScopep":"UNLINKED","aboveCellp":"UNLINKED","modp":"(U)","varsp": [],"blocksp": [],"inlinesp": []}
     ],"activesp": []}
   ]}
 ]}

--- a/test_regress/t/t_json_only_flat_pub_mod.out
+++ b/test_regress/t/t_json_only_flat_pub_mod.out
@@ -28,7 +28,7 @@
          "lhsp": [
           {"type":"VARREF","name":"top.f.i_clk","addr":"(T)","loc":"d,7:24,7:29","dtypep":"(H)","access":"WR","varp":"(J)","varScopep":"(N)","classOrPackagep":"UNLINKED"}
         ],"timingControlp": []}
-      ]}
+      ],"inlinesp": []}
     ]}
   ],"activesp": []}
 ],"filesp": [],
@@ -41,7 +41,7 @@
    "modulep": [
     {"type":"MODULE","name":"@CONST-POOL@","addr":"(U)","loc":"a,0:0,0:0","origName":"@CONST-POOL@","level":0,"modPublic":false,"inLibrary":false,"dead":false,"recursiveClone":false,"recursive":false,"timeunit":"NONE","inlinesp": [],
      "stmtsp": [
-      {"type":"SCOPE","name":"@CONST-POOL@","addr":"(V)","loc":"a,0:0,0:0","aboveScopep":"UNLINKED","aboveCellp":"UNLINKED","modp":"(U)","varsp": [],"blocksp": []}
+      {"type":"SCOPE","name":"@CONST-POOL@","addr":"(V)","loc":"a,0:0,0:0","aboveScopep":"UNLINKED","aboveCellp":"UNLINKED","modp":"(U)","varsp": [],"blocksp": [],"inlinesp": []}
     ],"activesp": []}
   ]}
 ]}

--- a/test_regress/t/t_json_only_flat_vlvbound.out
+++ b/test_regress/t/t_json_only_flat_vlvbound.out
@@ -288,7 +288,7 @@
             {"type":"VARREF","name":"o_b","addr":"(NF)","loc":"d,25:10,25:13","dtypep":"(K)","access":"WR","varp":"(L)","varScopep":"(U)","classOrPackagep":"UNLINKED"}
           ],"timingControlp": []}
         ]}
-      ]}
+      ],"inlinesp": []}
     ]},
     {"type":"VAR","name":"__Vfunc_vlvbound_test.foo__0__Vfuncout","addr":"(AB)","loc":"d,15:34,15:37","dtypep":"(K)","origName":"__Vfunc_vlvbound_test__DOT__foo__0__Vfuncout","isSc":false,"isPrimaryIO":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"attrClocker":"UNKNOWN","lifetime":"NONE","varType":"BLOCKTEMP","dtypeName":"logic","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
     {"type":"VAR","name":"__Vfunc_vlvbound_test.foo__0__val","addr":"(CB)","loc":"d,15:57,15:60","dtypep":"(H)","origName":"__Vfunc_vlvbound_test__DOT__foo__0__val","isSc":false,"isPrimaryIO":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"attrClocker":"UNKNOWN","lifetime":"NONE","varType":"BLOCKTEMP","dtypeName":"logic","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
@@ -317,7 +317,7 @@
    "modulep": [
     {"type":"MODULE","name":"@CONST-POOL@","addr":"(OF)","loc":"a,0:0,0:0","origName":"@CONST-POOL@","level":0,"modPublic":false,"inLibrary":false,"dead":false,"recursiveClone":false,"recursive":false,"timeunit":"NONE","inlinesp": [],
      "stmtsp": [
-      {"type":"SCOPE","name":"@CONST-POOL@","addr":"(PF)","loc":"a,0:0,0:0","aboveScopep":"UNLINKED","aboveCellp":"UNLINKED","modp":"(OF)","varsp": [],"blocksp": []}
+      {"type":"SCOPE","name":"@CONST-POOL@","addr":"(PF)","loc":"a,0:0,0:0","aboveScopep":"UNLINKED","aboveCellp":"UNLINKED","modp":"(OF)","varsp": [],"blocksp": [],"inlinesp": []}
     ],"activesp": []}
   ]}
 ]}

--- a/test_regress/t/t_json_only_output.out
+++ b/test_regress/t/t_json_only_output.out
@@ -14,7 +14,7 @@
    "modulep": [
     {"type":"MODULE","name":"@CONST-POOL@","addr":"(H)","loc":"a,0:0,0:0","origName":"@CONST-POOL@","level":0,"modPublic":false,"inLibrary":false,"dead":false,"recursiveClone":false,"recursive":false,"timeunit":"NONE","inlinesp": [],
      "stmtsp": [
-      {"type":"SCOPE","name":"@CONST-POOL@","addr":"(I)","loc":"a,0:0,0:0","aboveScopep":"UNLINKED","aboveCellp":"UNLINKED","modp":"(H)","varsp": [],"blocksp": []}
+      {"type":"SCOPE","name":"@CONST-POOL@","addr":"(I)","loc":"a,0:0,0:0","aboveScopep":"UNLINKED","aboveCellp":"UNLINKED","modp":"(H)","varsp": [],"blocksp": [],"inlinesp": []}
     ],"activesp": []}
   ]}
 ]}

--- a/test_regress/t/t_json_only_tag.out
+++ b/test_regress/t/t_json_only_tag.out
@@ -93,7 +93,7 @@
    "modulep": [
     {"type":"MODULE","name":"@CONST-POOL@","addr":"(AC)","loc":"a,0:0,0:0","origName":"@CONST-POOL@","level":0,"modPublic":false,"inLibrary":false,"dead":false,"recursiveClone":false,"recursive":false,"timeunit":"NONE","inlinesp": [],
      "stmtsp": [
-      {"type":"SCOPE","name":"@CONST-POOL@","addr":"(BC)","loc":"a,0:0,0:0","aboveScopep":"UNLINKED","aboveCellp":"UNLINKED","modp":"(AC)","varsp": [],"blocksp": []}
+      {"type":"SCOPE","name":"@CONST-POOL@","addr":"(BC)","loc":"a,0:0,0:0","aboveScopep":"UNLINKED","aboveCellp":"UNLINKED","modp":"(AC)","varsp": [],"blocksp": [],"inlinesp": []}
     ],"activesp": []}
   ]}
 ]}

--- a/test_regress/t/t_var_port_json_only.out
+++ b/test_regress/t/t_var_port_json_only.out
@@ -99,7 +99,7 @@
    "modulep": [
     {"type":"MODULE","name":"@CONST-POOL@","addr":"(AC)","loc":"a,0:0,0:0","origName":"@CONST-POOL@","level":0,"modPublic":false,"inLibrary":false,"dead":false,"recursiveClone":false,"recursive":false,"timeunit":"NONE","inlinesp": [],
      "stmtsp": [
-      {"type":"SCOPE","name":"@CONST-POOL@","addr":"(BC)","loc":"a,0:0,0:0","aboveScopep":"UNLINKED","aboveCellp":"UNLINKED","modp":"(AC)","varsp": [],"blocksp": []}
+      {"type":"SCOPE","name":"@CONST-POOL@","addr":"(BC)","loc":"a,0:0,0:0","aboveScopep":"UNLINKED","aboveCellp":"UNLINKED","modp":"(AC)","varsp": [],"blocksp": [],"inlinesp": []}
     ],"activesp": []}
   ]}
 ]}

--- a/test_regress/t/t_vpi_dump_missing_scopes.iv.out
+++ b/test_regress/t/t_vpi_dump_missing_scopes.iv.out
@@ -1,0 +1,20 @@
+t (vpiModule) t
+    vpiInternalScope:
+    t.top_wrap_1 (vpiModule) t.top_wrap_1
+        vpiInternalScope:
+        t.top_wrap_1.gen_loop[0] (vpiGenScope) t.top_wrap_1.gen_loop[0]
+            vpiParameter:
+            t.top_wrap_1.gen_loop[0].i (vpiParameter) t.top_wrap_1.gen_loop[0].i
+                vpiConstType=vpiBinaryConst
+            vpiInternalScope:
+            t.top_wrap_1.gen_loop[0].after_gen_loop (vpiModule) t.top_wrap_1.gen_loop[0].after_gen_loop
+    t.top_wrap_2 (vpiModule) t.top_wrap_2
+        vpiInternalScope:
+        t.top_wrap_2.gen_loop[0] (vpiGenScope) t.top_wrap_2.gen_loop[0]
+            vpiParameter:
+            t.top_wrap_2.gen_loop[0].i (vpiParameter) t.top_wrap_2.gen_loop[0].i
+                vpiConstType=vpiBinaryConst
+            vpiInternalScope:
+            t.top_wrap_2.gen_loop[0].after_gen_loop (vpiModule) t.top_wrap_2.gen_loop[0].after_gen_loop
+*-* All Finished *-*
+t/t_vpi_dump_missing_scopes.v:21: $finish called at 0 (1s)

--- a/test_regress/t/t_vpi_dump_missing_scopes.out
+++ b/test_regress/t/t_vpi_dump_missing_scopes.out
@@ -1,0 +1,29 @@
+t (vpiModule) t
+    vpiReg:
+    vpiParameter:
+    vpiInternalScope:
+    top_wrap_1 (vpiModule) t.top_wrap_1
+        vpiReg:
+        vpiParameter:
+        vpiInternalScope:
+        gen_loop[0] (vpiGenScope) t.top_wrap_1.gen_loop[0]
+            vpiReg:
+            vpiParameter:
+            vpiInternalScope:
+            after_gen_loop (vpiModule) t.top_wrap_1.gen_loop[0].after_gen_loop
+                vpiReg:
+                subsig1 (vpiReg) t.top_wrap_1.gen_loop[0].after_gen_loop.subsig1
+                vpiParameter:
+    top_wrap_2 (vpiModule) t.top_wrap_2
+        vpiReg:
+        vpiParameter:
+        vpiInternalScope:
+        gen_loop[0] (vpiGenScope) t.top_wrap_2.gen_loop[0]
+            vpiReg:
+            vpiParameter:
+            vpiInternalScope:
+            after_gen_loop (vpiModule) t.top_wrap_2.gen_loop[0].after_gen_loop
+                vpiReg:
+                subsig1 (vpiReg) t.top_wrap_2.gen_loop[0].after_gen_loop.subsig1
+                vpiParameter:
+*-* All Finished *-*

--- a/test_regress/t/t_vpi_dump_missing_scopes.pl
+++ b/test_regress/t/t_vpi_dump_missing_scopes.pl
@@ -1,0 +1,34 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2024 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+skip("Known compiler limitation")
+    if $Self->cxx_version =~ /\(GCC\) 4.4/;
+
+compile(
+    make_top_shell => 0,
+    make_main => 0,
+    make_pli => "t_vpi_dump.cpp",
+    iv_flags2 => ["-g2005-sv"],
+    verilator_flags2 => ["--exe --vpi --public-flat-rw --no-l2name $Self->{t_dir}/t_vpi_dump.cpp $Self->{t_dir}/TestVpiMain.cpp"],
+    make_flags => 'CPPFLAGS_ADD=-DVL_NO_LEGACY',
+    );
+
+execute(
+    use_libvpi => 1,
+    check_finished => 1,
+    expect_filename => $Self->{golden_filename},
+    xrun_run_expect_filename => ($Self->{golden_filename} =~ s/\.out$/.xrun.out/r),
+    iv_run_expect_filename => ($Self->{golden_filename} =~ s/\.out$/.iv.out/r),
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_vpi_dump_missing_scopes.v
+++ b/test_regress/t/t_vpi_dump_missing_scopes.v
@@ -1,0 +1,46 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// Copyright 2010 by Wilson Snyder. This program is free software; you can
+// redistribute it and/or modify it under the terms of either the GNU
+// Lesser General Public License Version 3 or the Perl Artistic License
+// Version 2.0.
+// SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+
+// using public_on causes one to be AstCellInline, and that one has correct scope
+// without this, both are AstCellInline, and both are wrong
+
+/* verilator public_on */
+
+module t (  /*AUTOARG*/
+);
+
+
+   initial begin
+      $write("*-* All Finished *-*\n");
+      $finish();
+   end
+
+
+   gen_wrapper top_wrap_1 ();
+   gen_wrapper top_wrap_2 ();
+
+endmodule : t
+
+module sub;
+   reg subsig1;
+endmodule : sub
+
+
+module gen_wrapper;
+   genvar i;
+   generate
+      for (i = 0; i < 1; i++) begin : gen_loop
+
+         // This fixes the scope
+         // localparam int x  = 2;
+
+         sub after_gen_loop ();
+      end
+   endgenerate
+endmodule


### PR DESCRIPTION
Fixes gen scopes not getting generated when a scope with no wires is used more than once in the final hierarchy. There's some more thoughts on the original tc here on why this happened https://github.com/AndrewNolte/verilator/pull/1/files

The earliest error I could tell is in Scope.tree (35), where a Cellinline is assigned a single scope, even though it's used in multiple scopes.

Other ideas I had for fixing this:
- create one cell inline per scope. This had issues because they can't have duplicate names
- create multiple cell inlines, and fix the name to be more specific. This had issues because it couldn't find the gen_loop
- EmitCSyms solution- I think it should be possible to iterate scopes up to each scope that we visit, but this is a bit of a hack given that there's issues earlier on in the Verilation process, and it could increase build time for vpi quite a bit

I thought it was related to https://github.com/verilator/verilator/pull/4918, but these are actually independent, as in neither fix corrects both. I still have this pr depending on that however, you can view the individual changes here https://github.com/verilator/verilator/pull/4965/files/b58d6234fa4c36bab88537c4fe38e672b8beb653..9e8a24b35b92a56ab4612ae441d632d2a0ba4732