### PR TITLE
Support implicitly-typed variable definitions in for-loop initializers (#4945)

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -106,6 +106,7 @@ Kanad Kanhere
 Kefa Chen
 Keith Colbert
 Kevin Kiningham
+Kevin Nygaard
 Kritik Bhimani
 Krzysztof Bieganski
 Krzysztof Boronski

--- a/src/verilog.y
+++ b/src/verilog.y
@@ -3701,12 +3701,15 @@ statement_item<nodep>:          // IEEE: statement_item
         ;
 
 statementFor<beginp>:           // IEEE: part of statement
-                yFOR '(' for_initialization expr ';' for_stepE ')' stmtBlock
+                yFOR beginForParen for_initialization expr ';' for_stepE ')' stmtBlock
                         { $$ = new AstBegin{$1, "", $3, false, true};
                           $$->addStmtsp(new AstWhile{$1, $4, $8, $6}); }
-        |       yFOR '(' for_initialization ';' for_stepE ')' stmtBlock
+        |       yFOR beginForParen for_initialization ';' for_stepE ')' stmtBlock
                         { $$ = new AstBegin{$1, "", $3, false, true};
                           $$->addStmtsp(new AstWhile{$1, new AstConst{$1, AstConst::BitTrue{}}, $7, $5}); }
+        ;
+beginForParen:
+                '(' { VARRESET(); }
         ;
 
 statementVerilatorPragmas<nodep>:
@@ -3997,7 +4000,16 @@ for_initializationItem<nodep>:          // IEEE: variable_assignment + for_varia
                           $$->addNext(new AstAssign{$4, new AstParseRef{$<fl>3, VParseRefExp::PX_TEXT, *$3}, $5}); }
         //                      // IEEE: variable_assignment
         //                      // UNSUP variable_lvalue below
-        |       varRefBase '=' expr                     { $$ = new AstAssign{$2, $1, $3}; }
+        |       id/*newOrExisting*/ '=' expr
+                        { if (GRAMMARP->m_varDecl) {
+                              AstVar* const varp = VARDONEA($<fl>1, *$1, nullptr, nullptr);
+                              varp->lifetime(VLifetime::AUTOMATIC);
+                              $$ = varp;
+                              $$->addNext(new AstAssign{$2, new AstParseRef{$<fl>1, VParseRefExp::PX_TEXT, *$1}, $3});
+                          } else {
+                              $$ = new AstAssign{$2, new AstParseRef{$<fl>1, VParseRefExp::PX_TEXT, *$1}, $3};
+                          }
+                        }
         ;
 
 for_stepE<nodep>:               // IEEE: for_step + empty

--- a/src/verilog.y
+++ b/src/verilog.y
@@ -3708,8 +3708,8 @@ statementFor<beginp>:           // IEEE: part of statement
                         { $$ = new AstBegin{$1, "", $3, false, true};
                           $$->addStmtsp(new AstWhile{$1, new AstConst{$1, AstConst::BitTrue{}}, $7, $5}); }
         ;
-beginForParen:
-                '(' { VARRESET(); }
+beginForParen:  // IEEE: Part of statement (for loop beginning paren)
+                '('                                     { VARRESET(); }
         ;
 
 statementVerilatorPragmas<nodep>:

--- a/test_regress/t/t_for_comma.v
+++ b/test_regress/t/t_for_comma.v
@@ -54,6 +54,8 @@ module t (/*AUTOARG*/);
       `checkc(7);
       for (int a = 1, int b = 1; a < 3; a = a + 1, b = b + 1) begin c = c + 1 + a + b; end
       `checkc(8);
+      for (int a = 1, x = 1; a < 3; a = a + 1, x = x + 1) begin c = c + 1 + a + x; end
+      `checkc(8);
       $write("*-* All Finished *-*\n");
       $finish;
    end


### PR DESCRIPTION
- Adds support for C-style for-loop initializers
    - Current implementation supports: `for (x a = 1, y b = 2, ...)`
    - This patch extends support to:   `for (x a = 1, b = 2, ...)`
    - The implementation is a bit of a hack
- Adds unit test for new feature

This should fix #4945.

Not sure if there is a better way to do this, seems like I'm abusing `yacc`. I couldn't figure out a clean way to clear out `GRAMMARP->m_varDecl` upon entering the `for()`, so I just key off the open parentheses and clear it there.

I suppose the right way involves marking the node and traversing the AST post-tokenization, but the heavy object-oriented approach was too opaque for me to follow.