### PR TITLE
Fix --prof-exec predicted time values

### DIFF
--- a/test_regress/t/t_gantt.pl
+++ b/test_regress/t/t_gantt.pl
@@ -45,6 +45,8 @@ run(cmd => ["$ENV{VERILATOR_ROOT}/bin/verilator_gantt",
 if ($Self->{vltmt}) {
     file_grep("$Self->{obj_dir}/gantt.log", qr/Total threads += 2/i);
     file_grep("$Self->{obj_dir}/gantt.log", qr/Total mtasks += 7/i);
+    # Predicted thread utilization should be less than 100%
+    file_grep_not("$Self->{obj_dir}/gantt.log", qr/Thread utilization =\s*\d\d\d+\.\d+%/i);
 } else {
     file_grep("$Self->{obj_dir}/gantt.log", qr/Total threads += 1/i);
     file_grep("$Self->{obj_dir}/gantt.log", qr/Total mtasks += 0/i);


### PR DESCRIPTION
Wrapping the functions in #4933 broke --prof-exec report as the predicted MTask times are computed during thread packing, but are emitted in the wrapping functions.
