### PR TITLE
Fix install instructions for attribute checks, do the same in CI

### DIFF
--- a/ci/ci-install.bash
+++ b/ci/ci-install.bash
@@ -96,9 +96,8 @@ elif [ "$CI_BUILD_STAGE_NAME" = "test" ]; then
     sudo apt-get install gdb gtkwave lcov libfl-dev ccache
     # Required for test_regress/t/t_dist_attributes.pl
     if [ "$CI_RUNS_ON" = "ubuntu-22.04" ]; then
-      sudo apt-get install libclang-dev mold ||
-      sudo apt-get install libclang-dev mold
-      pip3 install clang==14.0
+      sudo apt-get install python3-clang mold ||
+      sudo apt-get install python3-clang mold
     fi
     if [ "$CI_RUNS_ON" = "ubuntu-20.04" ] || [ "$CI_RUNS_ON" = "ubuntu-22.04" ]; then
       sudo apt-get install libsystemc-dev ||

--- a/docs/guide/install.rst
+++ b/docs/guide/install.rst
@@ -126,8 +126,8 @@ Those developing Verilator itself may also want these (see internals.rst):
 ::
 
    sudo apt-get install clang clang-format-14 cmake gdb gprof graphviz lcov
-   sudo apt-get install libclang-dev yapf3 bear
-   sudo pip3 install clang sphinx sphinx_rtd_theme sphinxcontrib-spelling breathe ruff
+   sudo apt-get install python3-clang yapf3 bear
+   sudo pip3 install sphinx sphinx_rtd_theme sphinxcontrib-spelling breathe ruff
    cpan install Pod::Perldoc
    cpan install Parallel::Forker
 


### PR DESCRIPTION
On Ubuntu 22.04, pip install clang picks up a mismatched version by default. There are 'apt' packages with correct dependencies, so use those instead.