### PR TITLE
Improve V3List user interface

### DIFF
--- a/src/V3Active.cpp
+++ b/src/V3Active.cpp
@@ -97,8 +97,8 @@ protected:
             result = vertexp->user();
             break;
         case LatchDetectGraphVertex::VT_BLOCK:  // (OR of potentially many siblings)
-            for (V3GraphEdge* edgep = vertexp->outBeginp(); edgep; edgep = edgep->outNextp()) {
-                if (latchCheckInternal(castVertexp(edgep->top()))) {
+            for (V3GraphEdge& edge : vertexp->outEdges()) {
+                if (latchCheckInternal(castVertexp(edge.top()))) {
                     result = true;
                     break;
                 }
@@ -106,9 +106,8 @@ protected:
             break;
         case LatchDetectGraphVertex::VT_BRANCH:  // (AND of both sibling)
                                                  // A BRANCH vertex always has exactly 2 siblings
-            LatchDetectGraphVertex* const ifp = castVertexp(vertexp->outBeginp()->top());
-            LatchDetectGraphVertex* const elsp
-                = castVertexp(vertexp->outBeginp()->outNextp()->top());
+            LatchDetectGraphVertex* const ifp = castVertexp(vertexp->outEdges().frontp()->top());
+            LatchDetectGraphVertex* const elsp = castVertexp(vertexp->outEdges().backp()->top());
             result = latchCheckInternal(ifp) && latchCheckInternal(elsp);
             break;
         }
@@ -170,7 +169,7 @@ public:
         for (const auto& vrp : m_outputs) {
             LatchDetectGraphVertex* const vertp = castVertexp(vrp->varp()->user1p());
             vertp->user(true);  // Identify the output vertex we are checking paths _to_
-            if (!latchCheckInternal(castVertexp(verticesBeginp()))) latch_detected = true;
+            if (!latchCheckInternal(castVertexp(vertices().frontp()))) latch_detected = true;
             if (latch_detected && !latch_expected) {
                 nodep->v3warn(
                     LATCH,

--- a/src/V3Dfg.cpp
+++ b/src/V3Dfg.cpp
@@ -38,20 +38,21 @@ void DfgGraph::addGraph(DfgGraph& other) {
     m_size += other.m_size;
     other.m_size = 0;
 
-    const auto moveVertexList = [this](V3List<DfgVertex*>& src, V3List<DfgVertex*>& dst) {
-        if (DfgVertex* vtxp = src.begin()) {
-            vtxp->m_verticesEnt.moveAppend(src, dst, vtxp);
-            do {
-                vtxp->m_userCnt = 0;
-                vtxp->m_graphp = this;
-                vtxp = vtxp->verticesNext();
-            } while (vtxp);
-        }
-    };
-
-    moveVertexList(other.m_varVertices, m_varVertices);
-    moveVertexList(other.m_constVertices, m_constVertices);
-    moveVertexList(other.m_opVertices, m_opVertices);
+    for (DfgVertexVar& vtx : other.m_varVertices) {
+        vtx.m_userCnt = 0;
+        vtx.m_graphp = this;
+    }
+    m_varVertices.splice(m_varVertices.end(), other.m_varVertices);
+    for (DfgConst& vtx : other.m_constVertices) {
+        vtx.m_userCnt = 0;
+        vtx.m_graphp = this;
+    }
+    m_constVertices.splice(m_constVertices.end(), other.m_constVertices);
+    for (DfgVertex& vtx : other.m_opVertices) {
+        vtx.m_userCnt = 0;
+        vtx.m_graphp = this;
+    }
+    m_opVertices.splice(m_opVertices.end(), other.m_opVertices);
 }
 
 static const string toDotId(const DfgVertex& vtx) { return '"' + cvtToHex(&vtx) + '"'; }

--- a/src/V3Dfg.h
+++ b/src/V3Dfg.h
@@ -149,9 +149,13 @@ protected:
 public:
     virtual ~DfgVertex() VL_MT_DISABLED;
 
+private:
+    V3ListLinks<DfgVertex>& links() { return m_links; }
+
+public:
     // List type that can store Vertex (which must be a DfgVertex) instances via m_links
     template <typename Vertex>
-    using List = V3List<DfgVertex, &DfgVertex::m_links, Vertex>;
+    using List = V3List<DfgVertex, &DfgVertex::links, Vertex>;
 
     // METHODS
 private:

--- a/src/V3DfgDfgToAst.cpp
+++ b/src/V3DfgDfgToAst.cpp
@@ -240,20 +240,18 @@ class DfgToAstVisitor final : DfgVisitor {
         // Convert the graph back to combinational assignments
 
         // The graph must have been regularized, so we only need to render assignments
-        for (DfgVertexVar *vtxp = dfg.varVerticesBeginp(), *nextp; vtxp; vtxp = nextp) {
-            nextp = vtxp->verticesNext();
-
+        for (DfgVertexVar& vtx : dfg.varVertices()) {
             // If there is no driver (this vertex is an input to the graph), then nothing to do.
-            if (!vtxp->isDrivenByDfg()) continue;
+            if (!vtx.isDrivenByDfg()) continue;
 
             // Render packed variable assignments
-            if (const DfgVarPacked* const dfgVarp = vtxp->cast<DfgVarPacked>()) {
+            if (const DfgVarPacked* const dfgVarp = vtx.cast<DfgVarPacked>()) {
                 convertVarDriver(dfgVarp);
                 continue;
             }
 
             // Render array variable assignments
-            convertArrayDiver(vtxp->as<DfgVarArray>());
+            convertArrayDiver(vtx.as<DfgVarArray>());
         }
     }
 

--- a/src/V3DfgPasses.h
+++ b/src/V3DfgPasses.h
@@ -125,7 +125,7 @@ AstModule* dfgToAst(DfgGraph&, V3DfgOptimizationContext&) VL_MT_DISABLED;
 // Common subexpression elimination
 void cse(DfgGraph&, V3DfgCseContext&) VL_MT_DISABLED;
 // Inline fully driven variables
-void inlineVars(const DfgGraph&) VL_MT_DISABLED;
+void inlineVars(DfgGraph&) VL_MT_DISABLED;
 // Peephole optimizations
 void peephole(DfgGraph&, V3DfgPeepholeContext&) VL_MT_DISABLED;
 // Regularize graph. This must be run before converting back to Ast.

--- a/src/V3DfgPeephole.cpp
+++ b/src/V3DfgPeephole.cpp
@@ -1533,12 +1533,10 @@ class V3DfgPeephole final : public DfgVisitor {
 
         // Add all vertices to the work list, and to the vertex cache.
         // This also allocates all DfgVertex::user.
-        for (DfgVertex *vtxp = m_dfg.opVerticesBeginp(), *nextp; vtxp; vtxp = nextp) {
-            nextp = vtxp->verticesNext();
-            if (VL_LIKELY(nextp)) VL_PREFETCH_RW(nextp);
-            vtxp->setUser<DfgVertex*>(m_workListp);
-            m_workListp = vtxp;
-            m_cache.cache(vtxp);
+        for (DfgVertex& vtx : m_dfg.opVertices()) {
+            vtx.setUser<DfgVertex*>(m_workListp);
+            m_workListp = &vtx;
+            m_cache.cache(&vtx);
         }
 
         // Process the work list

--- a/src/V3DfgVertices.h
+++ b/src/V3DfgVertices.h
@@ -53,13 +53,6 @@ public:
         , m_varp{varp} {}
     ASTGEN_MEMBERS_DfgVertexVar;
 
-    DfgVertexVar* verticesNext() const {
-        return static_cast<DfgVertexVar*>(DfgVertex::verticesNext());
-    }
-    DfgVertexVar* verticesPrev() const {
-        return static_cast<DfgVertexVar*>(DfgVertex::verticesPrev());
-    }
-
     bool isDrivenByDfg() const { return arity() > 0; }
 
     AstVar* varp() const { return m_varp; }
@@ -106,9 +99,6 @@ public:
         : DfgVertex{dfg, dfgType(), flp, dtypeForWidth(width)}
         , m_num{flp, static_cast<int>(width), value} {}
     ASTGEN_MEMBERS_DfgConst;
-
-    DfgConst* verticesNext() const { return static_cast<DfgConst*>(DfgVertex::verticesNext()); }
-    DfgConst* verticesPrev() const { return static_cast<DfgConst*>(DfgVertex::verticesPrev()); }
 
     V3Number& num() { return m_num; }
     const V3Number& num() const { return m_num; }

--- a/src/V3EmitCSyms.cpp
+++ b/src/V3EmitCSyms.cpp
@@ -847,11 +847,10 @@ void EmitCSyms::emitSymImp() {
         puts("// Configure profiling for PGO\n");
         if (v3Global.opt.mtasks()) {
             v3Global.rootp()->topModulep()->foreach([&](const AstExecGraph* execGraphp) {
-                for (const V3GraphVertex* vxp = execGraphp->depGraphp()->verticesBeginp(); vxp;
-                     vxp = vxp->verticesNextp()) {
-                    const ExecMTask* const mtp = static_cast<const ExecMTask*>(vxp);
-                    puts("_vm_pgoProfiler.addCounter(" + cvtToStr(mtp->id()) + ", \""
-                         + mtp->hashName() + "\");\n");
+                for (const V3GraphVertex& vtx : execGraphp->depGraphp()->vertices()) {
+                    const ExecMTask& mt = static_cast<const ExecMTask&>(vtx);
+                    puts("_vm_pgoProfiler.addCounter(" + cvtToStr(mt.id()) + ", \"" + mt.hashName()
+                         + "\");\n");
                 }
             });
         }

--- a/src/V3Graph.h
+++ b/src/V3Graph.h
@@ -115,10 +115,14 @@ protected:
         init(graphp, fromp, top, old.m_weight, old.m_cutable);
     }
 
+private:
+    V3ListLinks<V3GraphEdge>& oLinks() { return m_oLinks; }
+    V3ListLinks<V3GraphEdge>& iLinks() { return m_iLinks; }
+
 public:
     // List types to store instances of this class
-    using OList = V3List<V3GraphEdge, &V3GraphEdge::m_oLinks>;
-    using IList = V3List<V3GraphEdge, &V3GraphEdge::m_iLinks>;
+    using OList = V3List<V3GraphEdge, &V3GraphEdge::oLinks>;
+    using IList = V3List<V3GraphEdge, &V3GraphEdge::iLinks>;
 
     //! Add DAG from one node to the specified node
     V3GraphEdge(V3Graph* graphp, V3GraphVertex* fromp, V3GraphVertex* top, int weight,
@@ -220,9 +224,12 @@ protected:
     // CONSTRUCTORS
     V3GraphVertex(V3Graph* graphp, const V3GraphVertex& old) VL_MT_DISABLED;
 
+private:
+    V3ListLinks<V3GraphVertex>& links() { return m_links; }
+
 public:
     // List types to store instances of this class
-    using List = V3List<V3GraphVertex, &V3GraphVertex::m_links>;
+    using List = V3List<V3GraphVertex, &V3GraphVertex::links>;
 
     explicit V3GraphVertex(V3Graph* graphp) VL_MT_DISABLED;
     //! Clone copy constructor. Doesn't copy edges or user/userp.

--- a/src/V3Graph.h
+++ b/src/V3Graph.h
@@ -79,10 +79,272 @@ constexpr bool operator==(const GraphWay& lhs, GraphWay::en rhs) { return lhs.m_
 constexpr bool operator==(GraphWay::en lhs, const GraphWay& rhs) { return lhs == rhs.m_e; }
 
 //============================================================================
+// TODO should we have a smaller edge structure when we don't need weight etc?
+
+class V3GraphEdge VL_NOT_FINAL {
+    VL_RTTI_IMPL_BASE(V3GraphEdge)
+    // Wires/variables aren't edges.  Edges have only a single to/from vertex
+public:
+    // ENUMS
+    enum Cutable : uint8_t { NOT_CUTABLE = false, CUTABLE = true };  // For passing to V3GraphEdge
+protected:
+    friend class V3Graph;
+    friend class V3GraphVertex;
+    friend class GraphAcyc;
+    friend class GraphAcycEdge;
+
+    V3ListLinks<V3GraphEdge> m_oLinks;  // List links to store instances of this class (out edges)
+    V3ListLinks<V3GraphEdge> m_iLinks;  // List links to store instances of this class (in edges)
+    //
+    V3GraphVertex* m_fromp;  // Vertices pointing to this edge
+    V3GraphVertex* m_top;  // Vertices this edge points to
+    int m_weight;  // Weight of the connection
+    bool m_cutable;  // Interconnect may be broken in order sorting
+    union {
+        void* m_userp;  // Marker for some algorithms
+        uint64_t m_user;  // Marker for some algorithms
+    };
+    // METHODS
+    void init(V3Graph* graphp, V3GraphVertex* fromp, V3GraphVertex* top, int weight,
+              bool cutable = false) VL_MT_DISABLED;
+    void cut() { m_weight = 0; }  // 0 weight is same as disconnected
+    // CONSTRUCTORS
+protected:
+    V3GraphEdge(V3Graph* graphp, V3GraphVertex* fromp, V3GraphVertex* top,
+                const V3GraphEdge& old) VL_MT_DISABLED {
+        init(graphp, fromp, top, old.m_weight, old.m_cutable);
+    }
+
+public:
+    // List types to store instances of this class
+    using OList = V3List<V3GraphEdge, &V3GraphEdge::m_oLinks>;
+    using IList = V3List<V3GraphEdge, &V3GraphEdge::m_iLinks>;
+
+    //! Add DAG from one node to the specified node
+    V3GraphEdge(V3Graph* graphp, V3GraphVertex* fromp, V3GraphVertex* top, int weight,
+                bool cutable = false) VL_MT_DISABLED {
+        init(graphp, fromp, top, weight, cutable);
+    }
+    //! Clone copy constructor.  Doesn't copy existing vertices or user/userp.
+    virtual V3GraphEdge* clone(V3Graph* graphp, V3GraphVertex* fromp,
+                               V3GraphVertex* top) const VL_MT_DISABLED {
+        return new V3GraphEdge{graphp, fromp, top, *this};
+    }
+    virtual ~V3GraphEdge() = default;
+    // METHODS
+    // Return true iff of type T
+    template <typename T>
+    bool is() const {
+        static_assert(std::is_base_of<V3GraphEdge, T>::value,
+                      "'T' must be a subtype of V3GraphEdge");
+        static_assert(std::is_same<typename std::remove_cv<T>::type,
+                                   VTypeListFront<typename T::RttiThisAndBaseClassesList>>::value,
+                      "Missing VL_RTTI_IMPL(...) call in 'T'");
+        return this->isInstanceOfClassWithId(T::rttiClassId());
+    }
+
+    // Return cast to subtype T and assert of that type
+    template <typename T>
+    T* as() {
+        UASSERT(is<T>(), "V3GraphEdge is not of expected type");
+        return static_cast<T*>(this);
+    }
+    template <typename T>
+    const T* as() const {
+        UASSERT(is<T>(), "V3GraphEdge is not of expected type");
+        return static_cast<const T*>(this);
+    }
+
+    // Return cast to subtype T, else nullptr if different type
+    template <typename T>
+    T* cast() {
+        return is<T>() ? static_cast<T*>(this) : nullptr;
+    }
+    template <typename T>
+    const T* cast() const {
+        return is<T>() ? static_cast<const T*>(this) : nullptr;
+    }
+
+    virtual string name() const VL_MT_DISABLED;
+    virtual string dotLabel() const { return ""; }
+    virtual string dotColor() const { return cutable() ? "yellowGreen" : "red"; }
+    virtual string dotStyle() const { return cutable() ? "dashed" : ""; }
+    virtual int sortCmp(const V3GraphEdge* rhsp) const VL_MT_DISABLED;
+    void unlinkDelete() VL_MT_DISABLED;
+    void relinkFromp(V3GraphVertex* newFromp) VL_MT_DISABLED;
+    void relinkTop(V3GraphVertex* newTop) VL_MT_DISABLED;
+    // ACCESSORS
+    int weight() const { return m_weight; }
+    void weight(int weight) { m_weight = weight; }
+    bool cutable() const { return m_cutable; }
+    void cutable(bool cutable) { m_cutable = cutable; }
+    void userp(void* user) { m_userp = user; }
+    void* userp() const { return m_userp; }
+    void user(uint64_t user) { m_user = user; }
+    uint64_t user() const { return m_user; }
+    V3GraphVertex* fromp() const { return m_fromp; }
+    V3GraphVertex* top() const { return m_top; }
+    template <GraphWay::en T_Way>
+    V3GraphVertex* furtherp() const {
+        return T_Way == GraphWay::FORWARD ? top() : fromp();
+    }
+    // STATIC ACCESSORS
+    static bool followNotCutable(const V3GraphEdge* edgep) { return !edgep->m_cutable; }
+    static bool followAlwaysTrue(const V3GraphEdge*) { return true; }
+};
+
+//============================================================================
+
+class V3GraphVertex VL_NOT_FINAL {
+    VL_RTTI_IMPL_BASE(V3GraphVertex)
+    // Vertices may be a 'gate'/wire statement OR a variable
+protected:
+    friend class V3Graph;
+    friend class V3GraphEdge;
+    friend class GraphAcyc;
+    friend class GraphAlgRank;
+    V3ListLinks<V3GraphVertex> m_links;  // List links to store instances of this class
+    V3GraphEdge::OList m_outs;  // List of outbound edges
+    V3GraphEdge::IList m_ins;  // List of inbound edges
+    double m_fanout;  // Order fanout
+    uint32_t m_color;  // Color of the node
+    uint32_t m_rank;  // Rank of edge
+    union {
+        void* m_userp;  // Marker for some algorithms
+        uint32_t m_user;  // Marker for some algorithms
+    };
+    // ACCESSORS
+    void fanout(double fanout) { m_fanout = fanout; }
+
+protected:
+    // CONSTRUCTORS
+    V3GraphVertex(V3Graph* graphp, const V3GraphVertex& old) VL_MT_DISABLED;
+
+public:
+    // List types to store instances of this class
+    using List = V3List<V3GraphVertex, &V3GraphVertex::m_links>;
+
+    explicit V3GraphVertex(V3Graph* graphp) VL_MT_DISABLED;
+    //! Clone copy constructor. Doesn't copy edges or user/userp.
+    virtual V3GraphVertex* clone(V3Graph* graphp) const VL_MT_DISABLED {
+        return new V3GraphVertex{graphp, *this};
+    }
+    virtual ~V3GraphVertex() = default;
+    void unlinkEdges(V3Graph* graphp) VL_MT_DISABLED;
+    void unlinkDelete(V3Graph* graphp) VL_MT_DISABLED;
+
+    // METHODS
+    // Return true iff of type T
+    template <typename T>
+    bool is() const {
+        static_assert(std::is_base_of<V3GraphVertex, T>::value,
+                      "'T' must be a subtype of V3GraphVertex");
+        static_assert(std::is_same<typename std::remove_cv<T>::type,
+                                   VTypeListFront<typename T::RttiThisAndBaseClassesList>>::value,
+                      "Missing VL_RTTI_IMPL(...) call in 'T'");
+        return this->isInstanceOfClassWithId(T::rttiClassId());
+    }
+
+    // Return cast to subtype T and assert of that type
+    template <typename T>
+    T* as() {
+        UASSERT_OBJ(is<T>(), this, "V3GraphVertex is not of expected type");
+        return static_cast<T*>(this);
+    }
+    template <typename T>
+    const T* as() const {
+        UASSERT_OBJ(is<T>(), this, "V3GraphVertex is not of expected type");
+        return static_cast<const T*>(this);
+    }
+
+    // Return cast to subtype T, else nullptr if different type
+    template <typename T>
+    T* cast() {
+        return is<T>() ? static_cast<T*>(this) : nullptr;
+    }
+    template <typename T>
+    const T* cast() const {
+        return is<T>() ? static_cast<const T*>(this) : nullptr;
+    }
+
+    // ACCESSORS
+    virtual string name() const { return ""; }
+    virtual string dotColor() const { return "black"; }
+    virtual string dotShape() const { return ""; }
+    virtual string dotStyle() const { return ""; }
+    virtual string dotName() const { return ""; }
+    virtual string dotRank() const { return ""; }
+    virtual uint32_t rankAdder() const { return 1; }
+    virtual FileLine* fileline() const { return nullptr; }  // nullptr for unknown
+    virtual int sortCmp(const V3GraphVertex* rhsp) const {
+        // LHS goes first if of lower rank, or lower fanout
+        if (m_rank < rhsp->m_rank) return -1;
+        if (m_rank > rhsp->m_rank) return 1;
+        if (m_fanout < rhsp->m_fanout) return -1;
+        if (m_fanout > rhsp->m_fanout) return 1;
+        return 0;
+    }
+    uint32_t color() const { return m_color; }
+    void color(uint32_t color) { m_color = color; }
+    uint32_t rank() const { return m_rank; }
+    void rank(uint32_t rank) { m_rank = rank; }
+    double fanout() const { return m_fanout; }
+    void user(uint32_t user) { m_user = user; }
+    uint32_t user() const VL_MT_STABLE { return m_user; }
+    void userp(void* userp) { m_userp = userp; }
+    void* userp() const VL_MT_STABLE { return m_userp; }
+    V3GraphEdge::IList& inEdges() { return m_ins; }
+    const V3GraphEdge::IList& inEdges() const { return m_ins; }
+    template <GraphWay::en T_Way>
+    inline auto& edges();
+    template <GraphWay::en T_Way>
+    inline const auto& edges() const;
+    bool inEmpty() const { return m_ins.empty(); }
+    bool inSize1() const { return m_ins.hasSingleElement(); }
+    V3GraphEdge::OList& outEdges() { return m_outs; }
+    const V3GraphEdge::OList& outEdges() const { return m_outs; }
+    bool outEmpty() const { return m_outs.empty(); }
+    bool outSize1() const { return m_outs.hasSingleElement(); }
+    // METHODS
+    /// Error reporting
+    void v3errorEnd(std::ostringstream& str) const VL_RELEASE(V3Error::s().m_mutex) VL_MT_DISABLED;
+    void v3errorEndFatal(std::ostringstream& str) const
+        VL_RELEASE(V3Error::s().m_mutex) VL_MT_DISABLED;
+    /// Edges are routed around this vertex to point from "from" directly to "to"
+    void rerouteEdges(V3Graph* graphp) VL_MT_DISABLED;
+    // Find the edge connecting this vertex to the given vertex.
+    // If edge is not found returns nullptr. O(edges) performance.
+    template <GraphWay::en T_Way>
+    V3GraphEdge* findConnectingEdgep(V3GraphVertex* otherp) VL_MT_DISABLED;
+};
+
+std::ostream& operator<<(std::ostream& os, V3GraphVertex* vertexp) VL_MT_DISABLED;
+
+template <>
+inline auto& V3GraphVertex::edges<GraphWay::FORWARD>() {
+    return m_outs;
+}
+
+template <>
+inline auto& V3GraphVertex::edges<GraphWay::REVERSE>() {
+    return m_ins;
+}
+
+template <>
+inline const auto& V3GraphVertex::edges<GraphWay::FORWARD>() const {
+    return m_outs;
+}
+
+template <>
+inline const auto& V3GraphVertex::edges<GraphWay::REVERSE>() const {
+    return m_ins;
+}
+
+//============================================================================
 
 class V3Graph VL_NOT_FINAL {
     // MEMBERS
-    V3List<V3GraphVertex*> m_vertices;  // All vertices
+    V3GraphVertex::List m_vertices;  // All vertices
 
 protected:
     friend class V3GraphVertex;
@@ -90,9 +352,8 @@ protected:
     friend class GraphAcyc;
     // METHODS
     double orderDFSIterate(V3GraphVertex* vertexp) VL_MT_DISABLED;
-    void dumpEdge(std::ostream& os, const V3GraphVertex* vertexp,
-                  const V3GraphEdge* edgep) const VL_MT_DISABLED;
-    void verticesUnlink() { m_vertices.reset(); }
+    void dumpEdge(std::ostream& os, const V3GraphVertex& vertex,
+                  const V3GraphEdge& edge) const VL_MT_DISABLED;
     // ACCESSORS
 
 public:
@@ -103,7 +364,8 @@ public:
     // METHODS
     void clear() VL_MT_DISABLED;  // Empty it of all vertices/edges, as if making a new object
     bool empty() const { return m_vertices.empty(); }
-    V3GraphVertex* verticesBeginp() const { return m_vertices.begin(); }
+    V3GraphVertex::List& vertices() { return m_vertices; }
+    const V3GraphVertex::List& vertices() const { return m_vertices; }
 
     // METHODS - ALGORITHMS
 
@@ -180,7 +442,7 @@ public:
                              bool colorAsSubgraph = false) const VL_MT_DISABLED;
     void dumpDotFilePrefixedAlways(const string& nameComment,
                                    bool colorAsSubgraph = false) const VL_MT_DISABLED;
-    void dumpEdges(std::ostream& os, const V3GraphVertex* vertexp) const VL_MT_DISABLED;
+    void dumpEdges(std::ostream& os, const V3GraphVertex& vertex) const VL_MT_DISABLED;
     static void selfTest() VL_MT_DISABLED;
 
     class ParallelismReport final {
@@ -212,253 +474,12 @@ public:
         }
     };
 
-    ParallelismReport parallelismReport(
-        std::function<uint64_t(const V3GraphVertex*)> vertexCost) const VL_MT_DISABLED;
+    ParallelismReport
+    parallelismReport(std::function<uint64_t(const V3GraphVertex*)> vertexCost) VL_MT_DISABLED;
 
     // CALLBACKS
     virtual void loopsMessageCb(V3GraphVertex* vertexp) VL_MT_DISABLED;
     virtual void loopsVertexCb(V3GraphVertex* vertexp) VL_MT_DISABLED;
-};
-
-//============================================================================
-
-class V3GraphVertex VL_NOT_FINAL {
-    VL_RTTI_IMPL_BASE(V3GraphVertex)
-    // Vertices may be a 'gate'/wire statement OR a variable
-protected:
-    friend class V3Graph;
-    friend class V3GraphEdge;
-    friend class GraphAcyc;
-    friend class GraphAlgRank;
-    V3ListEnt<V3GraphVertex*> m_vertices;  // All vertices, linked list
-    V3List<V3GraphEdge*> m_outs;  // Outbound edges,linked list
-    V3List<V3GraphEdge*> m_ins;  // Inbound edges, linked list
-    double m_fanout;  // Order fanout
-    uint32_t m_color;  // Color of the node
-    uint32_t m_rank;  // Rank of edge
-    union {
-        void* m_userp;  // Marker for some algorithms
-        uint32_t m_user;  // Marker for some algorithms
-    };
-    // METHODS
-    void verticesPushBack(V3Graph* graphp) VL_MT_DISABLED;
-    // ACCESSORS
-    void fanout(double fanout) { m_fanout = fanout; }
-    void inUnlink() { m_ins.reset(); }  // Low level; normally unlinkDelete is what you want
-    void outUnlink() { m_outs.reset(); }  // Low level; normally unlinkDelete is what you want
-protected:
-    // CONSTRUCTORS
-    V3GraphVertex(V3Graph* graphp, const V3GraphVertex& old) VL_MT_DISABLED;
-
-public:
-    explicit V3GraphVertex(V3Graph* graphp) VL_MT_DISABLED;
-    //! Clone copy constructor. Doesn't copy edges or user/userp.
-    virtual V3GraphVertex* clone(V3Graph* graphp) const VL_MT_DISABLED {
-        return new V3GraphVertex{graphp, *this};
-    }
-    virtual ~V3GraphVertex() = default;
-    void unlinkEdges(V3Graph* graphp) VL_MT_DISABLED;
-    void unlinkDelete(V3Graph* graphp) VL_MT_DISABLED;
-
-    // METHODS
-    // Return true iff of type T
-    template <typename T>
-    bool is() const {
-        static_assert(std::is_base_of<V3GraphVertex, T>::value,
-                      "'T' must be a subtype of V3GraphVertex");
-        static_assert(std::is_same<typename std::remove_cv<T>::type,
-                                   VTypeListFront<typename T::RttiThisAndBaseClassesList>>::value,
-                      "Missing VL_RTTI_IMPL(...) call in 'T'");
-        return this->isInstanceOfClassWithId(T::rttiClassId());
-    }
-
-    // Return cast to subtype T and assert of that type
-    template <typename T>
-    T* as() {
-        UASSERT_OBJ(is<T>(), this, "V3GraphVertex is not of expected type");
-        return static_cast<T*>(this);
-    }
-    template <typename T>
-    const T* as() const {
-        UASSERT_OBJ(is<T>(), this, "V3GraphVertex is not of expected type");
-        return static_cast<const T*>(this);
-    }
-
-    // Return cast to subtype T, else nullptr if different type
-    template <typename T>
-    T* cast() {
-        return is<T>() ? static_cast<T*>(this) : nullptr;
-    }
-    template <typename T>
-    const T* cast() const {
-        return is<T>() ? static_cast<const T*>(this) : nullptr;
-    }
-
-    // ACCESSORS
-    virtual string name() const { return ""; }
-    virtual string dotColor() const { return "black"; }
-    virtual string dotShape() const { return ""; }
-    virtual string dotStyle() const { return ""; }
-    virtual string dotName() const { return ""; }
-    virtual string dotRank() const { return ""; }
-    virtual uint32_t rankAdder() const { return 1; }
-    virtual FileLine* fileline() const { return nullptr; }  // nullptr for unknown
-    virtual int sortCmp(const V3GraphVertex* rhsp) const {
-        // LHS goes first if of lower rank, or lower fanout
-        if (m_rank < rhsp->m_rank) return -1;
-        if (m_rank > rhsp->m_rank) return 1;
-        if (m_fanout < rhsp->m_fanout) return -1;
-        if (m_fanout > rhsp->m_fanout) return 1;
-        return 0;
-    }
-    uint32_t color() const { return m_color; }
-    void color(uint32_t color) { m_color = color; }
-    uint32_t rank() const { return m_rank; }
-    void rank(uint32_t rank) { m_rank = rank; }
-    double fanout() const { return m_fanout; }
-    void user(uint32_t user) { m_user = user; }
-    uint32_t user() const VL_MT_STABLE { return m_user; }
-    void userp(void* userp) { m_userp = userp; }
-    void* userp() const VL_MT_STABLE { return m_userp; }
-    // ITERATORS
-    V3GraphVertex* verticesNextp() const { return m_vertices.nextp(); }
-    V3GraphEdge* inBeginp() const { return m_ins.begin(); }
-    bool inEmpty() const { return inBeginp() == nullptr; }
-    bool inSize1() const VL_MT_DISABLED;
-    V3GraphEdge* outBeginp() const { return m_outs.begin(); }
-    bool outEmpty() const { return outBeginp() == nullptr; }
-    bool outSize1() const VL_MT_DISABLED;
-    V3GraphEdge* beginp(GraphWay way) const { return way.forward() ? outBeginp() : inBeginp(); }
-    // METHODS
-    /// Error reporting
-    void v3errorEnd(std::ostringstream& str) const VL_RELEASE(V3Error::s().m_mutex) VL_MT_DISABLED;
-    void v3errorEndFatal(std::ostringstream& str) const
-        VL_RELEASE(V3Error::s().m_mutex) VL_MT_DISABLED;
-    /// Edges are routed around this vertex to point from "from" directly to "to"
-    void rerouteEdges(V3Graph* graphp) VL_MT_DISABLED;
-    /// Find the edge connecting ap and bp, where bp is wayward from ap.
-    /// If edge is not found returns nullptr. O(edges) performance.
-    V3GraphEdge* findConnectingEdgep(GraphWay way, const V3GraphVertex* waywardp) VL_MT_DISABLED;
-};
-
-std::ostream& operator<<(std::ostream& os, V3GraphVertex* vertexp) VL_MT_DISABLED;
-
-//============================================================================
-// TODO should we have a smaller edge structure when we don't need weight etc?
-
-class V3GraphEdge VL_NOT_FINAL {
-    VL_RTTI_IMPL_BASE(V3GraphEdge)
-    // Wires/variables aren't edges.  Edges have only a single to/from vertex
-public:
-    // ENUMS
-    enum Cutable : uint8_t { NOT_CUTABLE = false, CUTABLE = true };  // For passing to V3GraphEdge
-protected:
-    friend class V3Graph;
-    friend class V3GraphVertex;
-    friend class GraphAcyc;
-    friend class GraphAcycEdge;
-
-    V3ListEnt<V3GraphEdge*> m_outs;  // Next outbound edge for same vertex (linked list)
-    V3ListEnt<V3GraphEdge*> m_ins;  // Next inbound edge for same vertex (linked list)
-    //
-    V3GraphVertex* m_fromp;  // Vertices pointing to this edge
-    V3GraphVertex* m_top;  // Vertices this edge points to
-    int m_weight;  // Weight of the connection
-    bool m_cutable;  // Interconnect may be broken in order sorting
-    union {
-        void* m_userp;  // Marker for some algorithms
-        uint64_t m_user;  // Marker for some algorithms
-    };
-    // METHODS
-    void init(V3Graph* graphp, V3GraphVertex* fromp, V3GraphVertex* top, int weight,
-              bool cutable = false) VL_MT_DISABLED;
-    void cut() { m_weight = 0; }  // 0 weight is same as disconnected
-    void outPushBack() VL_MT_DISABLED;
-    void inPushBack() VL_MT_DISABLED;
-    // CONSTRUCTORS
-protected:
-    V3GraphEdge(V3Graph* graphp, V3GraphVertex* fromp, V3GraphVertex* top,
-                const V3GraphEdge& old) VL_MT_DISABLED {
-        init(graphp, fromp, top, old.m_weight, old.m_cutable);
-    }
-
-public:
-    //! Add DAG from one node to the specified node
-    V3GraphEdge(V3Graph* graphp, V3GraphVertex* fromp, V3GraphVertex* top, int weight,
-                bool cutable = false) VL_MT_DISABLED {
-        init(graphp, fromp, top, weight, cutable);
-    }
-    //! Clone copy constructor.  Doesn't copy existing vertices or user/userp.
-    virtual V3GraphEdge* clone(V3Graph* graphp, V3GraphVertex* fromp,
-                               V3GraphVertex* top) const VL_MT_DISABLED {
-        return new V3GraphEdge{graphp, fromp, top, *this};
-    }
-    virtual ~V3GraphEdge() = default;
-    // METHODS
-    // Return true iff of type T
-    template <typename T>
-    bool is() const {
-        static_assert(std::is_base_of<V3GraphEdge, T>::value,
-                      "'T' must be a subtype of V3GraphEdge");
-        static_assert(std::is_same<typename std::remove_cv<T>::type,
-                                   VTypeListFront<typename T::RttiThisAndBaseClassesList>>::value,
-                      "Missing VL_RTTI_IMPL(...) call in 'T'");
-        return this->isInstanceOfClassWithId(T::rttiClassId());
-    }
-
-    // Return cast to subtype T and assert of that type
-    template <typename T>
-    T* as() {
-        UASSERT(is<T>(), "V3GraphEdge is not of expected type");
-        return static_cast<T*>(this);
-    }
-    template <typename T>
-    const T* as() const {
-        UASSERT(is<T>(), "V3GraphEdge is not of expected type");
-        return static_cast<const T*>(this);
-    }
-
-    // Return cast to subtype T, else nullptr if different type
-    template <typename T>
-    T* cast() {
-        return is<T>() ? static_cast<T*>(this) : nullptr;
-    }
-    template <typename T>
-    const T* cast() const {
-        return is<T>() ? static_cast<const T*>(this) : nullptr;
-    }
-
-    virtual string name() const { return m_fromp->name() + "->" + m_top->name(); }
-    virtual string dotLabel() const { return ""; }
-    virtual string dotColor() const { return cutable() ? "yellowGreen" : "red"; }
-    virtual string dotStyle() const { return cutable() ? "dashed" : ""; }
-    virtual int sortCmp(const V3GraphEdge* rhsp) const {
-        if (!m_weight || !rhsp->m_weight) return 0;
-        return top()->sortCmp(rhsp->top());
-    }
-    void unlinkDelete() VL_MT_DISABLED;
-    V3GraphEdge* relinkFromp(V3GraphVertex* newFromp) VL_MT_DISABLED;
-    V3GraphEdge* relinkTop(V3GraphVertex* newTop) VL_MT_DISABLED;
-    // ACCESSORS
-    int weight() const { return m_weight; }
-    void weight(int weight) { m_weight = weight; }
-    bool cutable() const { return m_cutable; }
-    void cutable(bool cutable) { m_cutable = cutable; }
-    void userp(void* user) { m_userp = user; }
-    void* userp() const { return m_userp; }
-    void user(uint64_t user) { m_user = user; }
-    uint64_t user() const { return m_user; }
-    V3GraphVertex* fromp() const { return m_fromp; }
-    V3GraphVertex* top() const { return m_top; }
-    V3GraphVertex* closerp(GraphWay way) const { return way.forward() ? fromp() : top(); }
-    V3GraphVertex* furtherp(GraphWay way) const { return way.forward() ? top() : fromp(); }
-    // STATIC ACCESSORS
-    static bool followNotCutable(const V3GraphEdge* edgep) { return !edgep->m_cutable; }
-    static bool followAlwaysTrue(const V3GraphEdge*) { return true; }
-    // ITERATORS
-    V3GraphEdge* outNextp() const { return m_outs.nextp(); }
-    V3GraphEdge* inNextp() const { return m_ins.nextp(); }
-    V3GraphEdge* nextp(GraphWay way) const { return way.forward() ? outNextp() : inNextp(); }
 };
 
 //============================================================================

--- a/src/V3GraphAcyc.cpp
+++ b/src/V3GraphAcyc.cpp
@@ -43,9 +43,13 @@ protected:
     uint32_t m_storedRank = 0;  // Rank held until commit to edge placement
     bool m_onWorkList = false;  // True if already on list of work to do
     bool m_deleted = false;  // True if deleted
+
+private:
+    V3ListLinks<GraphAcycVertex>& links() { return m_links; }
+
 public:
     // List type to store instances of this class
-    using List = V3List<GraphAcycVertex, &GraphAcycVertex::m_links>;
+    using List = V3List<GraphAcycVertex, &GraphAcycVertex::links>;
 
     GraphAcycVertex(V3Graph* graphp, V3GraphVertex* origVertexp)
         : V3GraphVertex{graphp}

--- a/src/V3GraphAlg.cpp
+++ b/src/V3GraphAlg.cpp
@@ -42,19 +42,15 @@ class GraphRemoveRedundant final : GraphAlg<> {
     const bool m_sumWeights;  ///< Sum, rather then maximize weights
 private:
     void main() {
-        for (V3GraphVertex* vertexp = m_graphp->verticesBeginp(); vertexp;
-             vertexp = vertexp->verticesNextp()) {
-            vertexIterate(vertexp);
-        }
+        for (V3GraphVertex& vertex : m_graphp->vertices()) vertexIterate(&vertex);
     }
     void vertexIterate(V3GraphVertex* vertexp) {
         // Clear marks
-        for (V3GraphEdge* edgep = vertexp->outBeginp(); edgep; edgep = edgep->outNextp()) {
-            edgep->top()->userp(nullptr);
-        }
+        for (V3GraphEdge& edge : vertexp->outEdges()) edge.top()->userp(nullptr);
+
         // Mark edges and detect duplications
-        for (V3GraphEdge *nextp, *edgep = vertexp->outBeginp(); edgep; edgep = nextp) {
-            nextp = edgep->outNextp();
+
+        for (V3GraphEdge* const edgep : vertexp->outEdges().unlinkable()) {
             if (followEdge(edgep)) {
                 V3GraphVertex* outVertexp = edgep->top();
                 V3GraphEdge* prevEdgep = static_cast<V3GraphEdge*>(outVertexp->userp());
@@ -112,15 +108,15 @@ public:
         : GraphAlg<>(graphp, nullptr) {}
     void go() {
         GraphPathChecker checker{m_graphp};
-        for (V3GraphVertex* vxp = m_graphp->verticesBeginp(); vxp; vxp = vxp->verticesNextp()) {
+        for (V3GraphVertex& vtx : m_graphp->vertices()) {
             V3GraphEdge* deletep = nullptr;
-            for (V3GraphEdge* edgep = vxp->outBeginp(); edgep; edgep = edgep->outNextp()) {
-                if (deletep) VL_DO_CLEAR(deletep->unlinkDelete(), deletep = nullptr);
+            for (V3GraphEdge& edge : vtx.outEdges()) {
+                if (deletep) VL_DO_DANGLING(deletep->unlinkDelete(), deletep);
                 // It should be safe to modify the graph, despite using
                 // the GraphPathChecker, as none of the modifications will
                 // change what can be reached from what, nor should they
                 // change the rank or CP of any node.
-                if (checker.isTransitiveEdge(edgep)) deletep = edgep;
+                if (checker.isTransitiveEdge(&edge)) deletep = &edge;
             }
             if (deletep) VL_DO_DANGLING(deletep->unlinkDelete(), deletep);
         }
@@ -143,10 +139,9 @@ class GraphAlgWeakly final : GraphAlg<> {
         m_graphp->clearColors();
         // Color graph
         uint32_t currentColor = 0;
-        for (V3GraphVertex* vertexp = m_graphp->verticesBeginp(); vertexp;
-             vertexp = vertexp->verticesNextp()) {
+        for (V3GraphVertex& vertex : m_graphp->vertices()) {
             currentColor++;
-            vertexIterate(vertexp, currentColor);
+            vertexIterate(&vertex, currentColor);
         }
     }
 
@@ -155,11 +150,11 @@ class GraphAlgWeakly final : GraphAlg<> {
         // then visit each of its edges, giving them the same color
         if (vertexp->color()) return;  // Already colored it
         vertexp->color(currentColor);
-        for (V3GraphEdge* edgep = vertexp->outBeginp(); edgep; edgep = edgep->outNextp()) {
-            if (followEdge(edgep)) vertexIterate(edgep->top(), currentColor);
+        for (V3GraphEdge& edge : vertexp->outEdges()) {
+            if (followEdge(&edge)) vertexIterate(edge.top(), currentColor);
         }
-        for (V3GraphEdge* edgep = vertexp->inBeginp(); edgep; edgep = edgep->inNextp()) {
-            if (followEdge(edgep)) vertexIterate(edgep->fromp(), currentColor);
+        for (V3GraphEdge& edge : vertexp->inEdges()) {
+            if (followEdge(&edge)) vertexIterate(edge.fromp(), currentColor);
         }
     }
 
@@ -192,33 +187,30 @@ class GraphAlgStrongly final : GraphAlg<> {
         //     Vertex::color    // Output subtree number (fully processed)
 
         // Clear info
-        for (V3GraphVertex* vertexp = m_graphp->verticesBeginp(); vertexp;
-             vertexp = vertexp->verticesNextp()) {
-            vertexp->color(0);
-            vertexp->user(0);
+        for (V3GraphVertex& vertex : m_graphp->vertices()) {
+            vertex.color(0);
+            vertex.user(0);
         }
         // Color graph
-        for (V3GraphVertex* vertexp = m_graphp->verticesBeginp(); vertexp;
-             vertexp = vertexp->verticesNextp()) {
-            if (!vertexp->user()) {
+        for (V3GraphVertex& vertex : m_graphp->vertices()) {
+            if (!vertex.user()) {
                 m_currentDfs++;
-                vertexIterate(vertexp);
+                vertexIterate(&vertex);
             }
         }
         // If there's a single vertex of a color, it doesn't need a subgraph
         // This simplifies the consumer's code, and reduces graph debugging clutter
-        for (V3GraphVertex* vertexp = m_graphp->verticesBeginp(); vertexp;
-             vertexp = vertexp->verticesNextp()) {
+        for (V3GraphVertex& vertex : m_graphp->vertices()) {
             bool onecolor = true;
-            for (V3GraphEdge* edgep = vertexp->outBeginp(); edgep; edgep = edgep->outNextp()) {
-                if (followEdge(edgep)) {
-                    if (vertexp->color() == edgep->top()->color()) {
+            for (V3GraphEdge& edge : vertex.outEdges()) {
+                if (followEdge(&edge)) {
+                    if (vertex.color() == edge.top()->color()) {
                         onecolor = false;
                         break;
                     }
                 }
             }
-            if (onecolor) vertexp->color(0);
+            if (onecolor) vertex.color(0);
         }
     }
 
@@ -226,9 +218,9 @@ class GraphAlgStrongly final : GraphAlg<> {
         const uint32_t thisDfsNum = m_currentDfs++;
         vertexp->user(thisDfsNum);
         vertexp->color(0);
-        for (V3GraphEdge* edgep = vertexp->outBeginp(); edgep; edgep = edgep->outNextp()) {
-            if (followEdge(edgep)) {
-                V3GraphVertex* top = edgep->top();
+        for (V3GraphEdge& edge : vertexp->outEdges()) {
+            if (followEdge(&edge)) {
+                V3GraphVertex* top = edge.top();
                 if (!top->user()) {  // Dest not computed yet
                     vertexIterate(top);
                 }
@@ -273,15 +265,13 @@ class GraphAlgRank final : GraphAlg<> {
         // Rank each vertex, ignoring cutable edges
         // Vertex::m_user begin: 1 indicates processing, 2 indicates completed
         // Clear existing ranks
-        for (V3GraphVertex* vertexp = m_graphp->verticesBeginp(); vertexp;
-             vertexp = vertexp->verticesNextp()) {
-            vertexp->rank(0);
-            vertexp->user(0);
+        for (V3GraphVertex& vertex : m_graphp->vertices()) {
+            vertex.rank(0);
+            vertex.user(0);
         }
-        for (V3GraphVertex* vertexp = m_graphp->verticesBeginp(); vertexp;
-             vertexp = vertexp->verticesNextp()) {
-            if (!vertexp->user()) {  //
-                vertexIterate(vertexp, 1);
+        for (V3GraphVertex& vertex : m_graphp->vertices()) {
+            if (!vertex.user()) {  //
+                vertexIterate(&vertex, 1);
             }
         }
     }
@@ -298,10 +288,8 @@ class GraphAlgRank final : GraphAlg<> {
         if (vertexp->rank() >= currentRank) return;  // Already processed it
         vertexp->user(1);
         vertexp->rank(currentRank);
-        for (V3GraphEdge* edgep = vertexp->outBeginp(); edgep; edgep = edgep->outNextp()) {
-            if (followEdge(edgep)) {
-                vertexIterate(edgep->top(), currentRank + vertexp->rankAdder());
-            }
+        for (V3GraphEdge& edge : vertexp->outEdges()) {
+            if (followEdge(&edge)) vertexIterate(edge.top(), currentRank + vertexp->rankAdder());
         }
         vertexp->user(2);
     }
@@ -353,8 +341,8 @@ class GraphAlgRLoops final : GraphAlg<> {
         }
         if (vertexp->user() == 2) return;  // Already processed it
         vertexp->user(1);
-        for (V3GraphEdge* edgep = vertexp->outBeginp(); edgep; edgep = edgep->outNextp()) {
-            if (followEdge(edgep)) vertexIterate(edgep->top(), currentRank);
+        for (V3GraphEdge& edge : vertexp->outEdges()) {
+            if (followEdge(&edge)) vertexIterate(edge.top(), currentRank);
         }
         vertexp->user(2);
     }
@@ -387,13 +375,13 @@ class GraphAlgSubtrees final : GraphAlg<> {
             newVertexp = vertexp->clone(m_loopGraphp);
             vertexp->userp(newVertexp);
 
-            for (V3GraphEdge* edgep = vertexp->outBeginp(); edgep; edgep = edgep->outNextp()) {
-                if (followEdge(edgep)) {
-                    V3GraphEdge* newEdgep = static_cast<V3GraphEdge*>(edgep->userp());
+            for (V3GraphEdge& edge : vertexp->outEdges()) {
+                if (followEdge(&edge)) {
+                    V3GraphEdge* newEdgep = static_cast<V3GraphEdge*>(edge.userp());
                     if (!newEdgep) {
-                        V3GraphVertex* newTop = vertexIterateAll(edgep->top());
-                        newEdgep = edgep->clone(m_loopGraphp, newVertexp, newTop);
-                        edgep->userp(newEdgep);
+                        V3GraphVertex* newTop = vertexIterateAll(edge.top());
+                        newEdgep = edge.clone(m_loopGraphp, newVertexp, newTop);
+                        edge.userp(newEdgep);
                     }
                 }
             }
@@ -438,30 +426,25 @@ struct GraphSortEdgeCmp final {
 void V3Graph::sortVertices() {
     // Sort list of vertices by rank, then fanout
     std::vector<V3GraphVertex*> vertices;
-    for (V3GraphVertex* vertexp = verticesBeginp(); vertexp; vertexp = vertexp->verticesNextp()) {
-        vertices.push_back(vertexp);
-    }
+    for (V3GraphVertex& vertex : m_vertices) vertices.push_back(&vertex);
     std::stable_sort(vertices.begin(), vertices.end(), GraphSortVertexCmp());
-    this->verticesUnlink();
-    for (V3GraphVertex* ip : vertices) ip->verticesPushBack(this);
+    // Re-insert in sorted order
+    for (V3GraphVertex* const ip : vertices) {
+        m_vertices.unlink(ip);
+        m_vertices.linkBack(ip);
+    }
 }
 
 void V3Graph::sortEdges() {
     // Sort edges by rank then fanout of node they point to
     std::vector<V3GraphEdge*> edges;
-    for (V3GraphVertex* vertexp = verticesBeginp(); vertexp; vertexp = vertexp->verticesNextp()) {
+    for (V3GraphVertex& vertex : vertices()) {
         // Make a vector
-        for (V3GraphEdge* edgep = vertexp->outBeginp(); edgep; edgep = edgep->outNextp()) {
-            edges.push_back(edgep);
-        }
+        for (V3GraphEdge& edge : vertex.outEdges()) edges.push_back(&edge);
         // Sort
         std::stable_sort(edges.begin(), edges.end(), GraphSortEdgeCmp());
-
         // Relink edges in specified order
-        // We know the vector contains all of the edges that were
-        // there originally (didn't delete or add)
-        vertexp->outUnlink();
-        for (V3GraphEdge* edgep : edges) edgep->outPushBack();
+        for (V3GraphEdge* const edgep : edges) edgep->relinkFromp(&vertex);
         // Prep for next
         edges.clear();
     }
@@ -487,8 +470,8 @@ void V3Graph::orderPreRanked() {
     // Compute fanouts
     // Vertex::m_user begin: 1 indicates processing, 2 indicates completed
     userClearVertices();
-    for (V3GraphVertex* vertexp = verticesBeginp(); vertexp; vertexp = vertexp->verticesNextp()) {
-        if (!vertexp->user()) orderDFSIterate(vertexp);
+    for (V3GraphVertex& vertex : vertices()) {
+        if (!vertex.user()) orderDFSIterate(&vertex);
     }
 
     // Sort list of vertices by rank, then fanout. Fanout is a bit of a
@@ -506,12 +489,12 @@ double V3Graph::orderDFSIterate(V3GraphVertex* vertexp) {
     UASSERT_OBJ(vertexp->user() != 1, vertexp, "Loop found, backward edges should be dead");
     vertexp->user(1);
     double fanout = 0;
-    for (V3GraphEdge* edgep = vertexp->outBeginp(); edgep; edgep = edgep->outNextp()) {
-        if (edgep->weight()) fanout += orderDFSIterate(edgep->m_top);
+    for (V3GraphEdge& edge : vertexp->outEdges()) {
+        if (edge.weight()) fanout += orderDFSIterate(edge.top());
     }
     // Just count inbound edges
-    for (V3GraphEdge* edgep = vertexp->inBeginp(); edgep; edgep = edgep->inNextp()) {
-        if (edgep->weight()) ++fanout;
+    for (V3GraphEdge& edge : vertexp->inEdges()) {
+        if (edge.weight()) ++fanout;
     }
     vertexp->fanout(fanout);
     vertexp->user(2);
@@ -524,12 +507,12 @@ double V3Graph::orderDFSIterate(V3GraphVertex* vertexp) {
 
 class GraphAlgParallelismReport final {
     // MEMBERS
-    const V3Graph& m_graph;  // The graph
+    V3Graph& m_graph;  // The graph
     const std::function<uint64_t(const V3GraphVertex*)> m_vertexCost;  // vertex cost function
     V3Graph::ParallelismReport m_report;  // The result report
 
     // CONSTRUCTORS
-    explicit GraphAlgParallelismReport(const V3Graph& graph,
+    explicit GraphAlgParallelismReport(V3Graph& graph,
                                        std::function<uint64_t(const V3GraphVertex*)> vertexCost)
         : m_graph{graph}
         , m_vertexCost{vertexCost} {
@@ -540,13 +523,13 @@ class GraphAlgParallelismReport final {
         for (const V3GraphVertex* vertexp; (vertexp = serialize.nextp());) {
             ++m_report.m_vertexCount;
             uint64_t cpCostToHere = 0;
-            for (V3GraphEdge* edgep = vertexp->inBeginp(); edgep; edgep = edgep->inNextp()) {
+            for (const V3GraphEdge& edge : vertexp->inEdges()) {
                 ++m_report.m_edgeCount;
                 // For each upstream item, add its critical path cost to
                 // the cost of this edge, to form a new candidate critical
                 // path cost to the current node. Whichever is largest is
                 // the critical path to reach the start of this node.
-                cpCostToHere = std::max(cpCostToHere, critPaths[edgep->fromp()]);
+                cpCostToHere = std::max(cpCostToHere, critPaths[edge.fromp()]);
             }
             // Include the cost of the current vertex in the critical
             // path, so it represents the critical path to the end of
@@ -564,12 +547,12 @@ class GraphAlgParallelismReport final {
 
 public:
     static V3Graph::ParallelismReport
-    apply(const V3Graph& graph, std::function<uint32_t(const V3GraphVertex*)> vertexCost) {
+    apply(V3Graph& graph, std::function<uint32_t(const V3GraphVertex*)> vertexCost) {
         return GraphAlgParallelismReport(graph, vertexCost).m_report;
     }
 };
 
 V3Graph::ParallelismReport
-V3Graph::parallelismReport(std::function<uint64_t(const V3GraphVertex*)> vertexCost) const {
+V3Graph::parallelismReport(std::function<uint64_t(const V3GraphVertex*)> vertexCost) {
     return GraphAlgParallelismReport::apply(*this, vertexCost);
 }

--- a/src/V3GraphAlg.cpp
+++ b/src/V3GraphAlg.cpp
@@ -111,7 +111,7 @@ public:
         for (V3GraphVertex& vtx : m_graphp->vertices()) {
             V3GraphEdge* deletep = nullptr;
             for (V3GraphEdge& edge : vtx.outEdges()) {
-                if (deletep) VL_DO_DANGLING(deletep->unlinkDelete(), deletep);
+                if (deletep) VL_DO_CLEAR(deletep->unlinkDelete(), deletep = nullptr);
                 // It should be safe to modify the graph, despite using
                 // the GraphPathChecker, as none of the modifications will
                 // change what can be reached from what, nor should they

--- a/src/V3GraphPathChecker.h
+++ b/src/V3GraphPathChecker.h
@@ -30,7 +30,7 @@
 ///
 /// The graph (or at least, the subset the algorithm sees through
 /// edgeFuncp) must not change during the lifetime of the checker.
-class GraphPathChecker final : GraphAlg<const V3Graph> {
+class GraphPathChecker final : GraphAlg<V3Graph> {
     // Count "generations" which increases on operations that scan through
     // the graph. Each node is marked with the last generation that scanned
     // it, to enable asserting there are no cycles, and to avoid recursing
@@ -39,9 +39,8 @@ class GraphPathChecker final : GraphAlg<const V3Graph> {
 
 public:
     // CONSTRUCTORS
-    explicit GraphPathChecker(const V3Graph* graphp,
-                              V3EdgeFuncP edgeFuncp
-                              = V3GraphEdge::followAlwaysTrue) VL_MT_DISABLED;
+    explicit GraphPathChecker(V3Graph* graphp, V3EdgeFuncP edgeFuncp
+                                               = V3GraphEdge::followAlwaysTrue) VL_MT_DISABLED;
     ~GraphPathChecker() VL_MT_DISABLED;
 
     // METHODS
@@ -55,7 +54,8 @@ public:
 private:
     bool pathExistsInternal(const V3GraphVertex* ap, const V3GraphVertex* bp,
                             unsigned* costp = nullptr) VL_MT_DISABLED;
-    void initHalfCriticalPaths(GraphWay way, bool checkOnly) VL_MT_DISABLED;
+    template <GraphWay::en T_Way>
+    void initHalfCriticalPaths(bool checkOnly) VL_MT_DISABLED;
     void incGeneration() { ++m_generation; }
 
     VL_UNCOPYABLE(GraphPathChecker);

--- a/src/V3GraphStream.h
+++ b/src/V3GraphStream.h
@@ -111,8 +111,7 @@ public:
                     const VxHolder newVx{&vtx, pos++, 0};
                     m_readyVertices.insert(newVx);
                 } else {
-                    uint32_t depCount = 0;
-                    for (const V3GraphEdge& _ : vtx.inEdges()) ++depCount;
+                    const uint32_t depCount = vtx.inEdges().size();
                     const VxHolder newVx{&vtx, pos++, depCount};
                     m_waitingVertices.emplace(&vtx, newVx);
                 }
@@ -121,8 +120,7 @@ public:
                     const VxHolder newVx{&vtx, pos++, 0};
                     m_readyVertices.insert(newVx);
                 } else {
-                    uint32_t depCount = 0;
-                    for (const V3GraphEdge& _ : vtx.outEdges()) ++depCount;
+                    const uint32_t depCount = vtx.outEdges().size();
                     const VxHolder newVx{&vtx, pos++, depCount};
                     m_waitingVertices.emplace(&vtx, newVx);
                 }
@@ -271,8 +269,7 @@ private:
         constexpr GraphWay way{T_Way};
         // Assign every vertex without an incoming edge to ready, others to waiting
         for (V3GraphVertex& vertex : graphp->vertices()) {
-            uint32_t nDeps = 0;
-            for (const V3GraphEdge& _ : vertex.edges<way.invert()>()) ++nDeps;
+            const uint32_t nDeps = vertex.edges<way.invert()>().size();
             vertex.color(nDeps);  // Using color instead of user, as user might be used by client
             if (VL_UNLIKELY(nDeps == 0)) m_nextVertices.push_back(&vertex);
         }

--- a/src/V3GraphTest.cpp
+++ b/src/V3GraphTest.cpp
@@ -259,7 +259,7 @@ public:
         gp->order();
 
         // Test debug function
-        gp->dumpEdges(std::cout, ap);
+        gp->dumpEdges(std::cout, *ap);
 
         dumpSelf();
     }

--- a/src/V3LifePost.cpp
+++ b/src/V3LifePost.cpp
@@ -149,7 +149,7 @@ class LifePostDlyVisitor final : public VNVisitor {
     // Map each dly var to its AstAssignPost* node and the location thereof
     std::unordered_map<const AstVarScope*, LifePostLocation> m_assignposts;
 
-    const V3Graph* m_mtasksGraphp = nullptr;  // Mtask tracking graph
+    V3Graph* m_mtasksGraphp = nullptr;  // Mtask tracking graph
     std::unique_ptr<GraphPathChecker> m_checker;
 
     const AstCFunc* const m_evalNbap;  // The _eval__nba function
@@ -325,9 +325,8 @@ class LifePostDlyVisitor final : public VNVisitor {
             UASSERT_OBJ(!m_mtasksGraphp, nodep, "Cannot handle more than one AstExecGraph");
             m_mtasksGraphp = nodep->depGraphp();
         }
-        for (V3GraphVertex* mtaskVxp = nodep->depGraphp()->verticesBeginp(); mtaskVxp;
-             mtaskVxp = mtaskVxp->verticesNextp()) {
-            const ExecMTask* const mtaskp = mtaskVxp->as<ExecMTask>();
+        for (V3GraphVertex& mtaskVtx : nodep->depGraphp()->vertices()) {
+            const ExecMTask* const mtaskp = mtaskVtx.as<ExecMTask>();
             m_execMTaskp = mtaskp;
             m_sequence = 0;
             iterate(mtaskp->bodyp());

--- a/src/V3LinkCells.cpp
+++ b/src/V3LinkCells.cpp
@@ -165,8 +165,8 @@ class LinkCellsVisitor final : public VNVisitor {
         m_graph.removeRedundantEdgesMax(&V3GraphEdge::followAlwaysTrue);
         if (dumpGraphLevel()) m_graph.dumpDotFilePrefixed("linkcells");
         m_graph.rank();
-        for (V3GraphVertex* itp = m_graph.verticesBeginp(); itp; itp = itp->verticesNextp()) {
-            if (const LinkCellsVertex* const vvertexp = itp->cast<LinkCellsVertex>()) {
+        for (V3GraphVertex& vtx : m_graph.vertices()) {
+            if (const LinkCellsVertex* const vvertexp = vtx.cast<LinkCellsVertex>()) {
                 // +1 so we leave level 1  for the new wrapper we'll make in a moment
                 AstNodeModule* const modp = vvertexp->modp();
                 modp->level(vvertexp->rank() + 1);

--- a/src/V3List.h
+++ b/src/V3List.h
@@ -328,6 +328,13 @@ public:
             other.m_lastp = nullptr;
         }
     }
+
+    // This is O(n)!
+    size_t size() const {
+        size_t result = 0;
+        for (auto it = begin(); it != end(); ++it) ++result;
+        return result;
+    }
 };
 
 #endif  // Guard

--- a/src/V3List.h
+++ b/src/V3List.h
@@ -1,6 +1,6 @@
 // -*- mode: C++; c-file-style: "cc-mode" -*-
 //*************************************************************************
-// DESCRIPTION: Verilator: List class with storage in existing classes
+// DESCRIPTION: Verilator: Doubly linked endogenous (intrusive) list
 //
 // Code available from: https://verilator.org
 //
@@ -20,124 +20,314 @@
 #include "config_build.h"
 #include "verilatedos.h"
 
-#include <vector>
+#include "V3Error.h"
+
+#include <type_traits>
+#include <utility>
 
 //============================================================================
+// The list links (just 2 pointers), to be instantiated as a member in the
+// list element base class 'T_Base'. They are considered mutable, even if the
+// list element is 'const', as they are only used for storing the elements in
+// a V3List. That is, you can store const elements in a V3List.
+template <typename T_Base>
+class V3ListLinks final {
+    // The V3List itself, but nothing else can access the link pointers
+    template <typename B, V3ListLinks<B> B::*, typename>
+    friend class V3List;
 
-template <class T>
-class V3List;
-template <class T>
-class V3ListEnt;
-
-template <class T>
-class V3List final {
-    // List container for linked list of elements of type *T  (T is a pointer type)
-private:
-    // MEMBERS
-    T m_headp = nullptr;  // First element
-    T m_tailp = nullptr;  // Last element
-    friend class V3ListEnt<T>;
+    T_Base* m_nextp = nullptr;  // Next element in list
+    T_Base* m_prevp = nullptr;  // Previous element in list
 
 public:
-    V3List() = default;
-    ~V3List() = default;
-    // METHODS
-    T begin() const { return m_headp; }
-    T end() const { return nullptr; }
-    T rbegin() const { return m_tailp; }
-    T rend() const { return nullptr; }
-    bool empty() const { return m_headp == nullptr; }
-    void reset() {  // clear() without walking the list
-        m_headp = nullptr;
-        m_tailp = nullptr;
-    }
-};
-
-//============================================================================
-
-template <class T>
-class V3ListEnt final {
-    // List entry for linked list of elements of type *T  (T is a pointer type)
-private:
-    // MEMBERS
-    T m_nextp = nullptr;  // Pointer to next element, nullptr=end
-    T m_prevp = nullptr;  // Pointer to previous element, nullptr=beginning
-    friend class V3List<T>;
-    static V3ListEnt* baseToListEnt(void* newbasep, size_t offset) {
-        // "this" must be an element inside of *basep
-        // Use that to determine a structure offset, then apply to the new base
-        // to get our new pointer information
-        return (V3ListEnt*)(((uint8_t*)newbasep) + offset);
-    }
-
-public:
-    V3ListEnt() = default;
-    ~V3ListEnt() {
+    V3ListLinks() = default;
+    ~V3ListLinks() {
 #ifdef VL_DEBUG
-        // Load bogus pointers so we can catch deletion bugs
-        m_nextp = reinterpret_cast<T>(1);
-        m_prevp = reinterpret_cast<T>(1);
+        m_nextp = reinterpret_cast<T_Base*>(1);
+        m_prevp = reinterpret_cast<T_Base*>(1);
 #endif
     }
-    T nextp() const { return m_nextp; }
-    T prevp() const { return m_prevp; }
-    // METHODS
-    void pushBack(V3List<T>& listr, T newp) {
-        // "this" must be an element inside of *newp
-        // cppcheck-suppress thisSubtraction
-        const size_t offset = (size_t)(uint8_t*)(this) - (size_t)(uint8_t*)(newp);
-        m_nextp = nullptr;
-        if (!listr.m_headp) listr.m_headp = newp;
-        m_prevp = listr.m_tailp;
-        if (m_prevp) baseToListEnt(m_prevp, offset)->m_nextp = newp;
-        listr.m_tailp = newp;
-    }
-    void pushFront(V3List<T>& listr, T newp) {
-        // "this" must be an element inside of *newp
-        // cppcheck-suppress thisSubtraction
-        const size_t offset = (size_t)(uint8_t*)(this) - (size_t)(uint8_t*)(newp);
-        m_nextp = listr.m_headp;
-        if (m_nextp) baseToListEnt(m_nextp, offset)->m_prevp = newp;
-        listr.m_headp = newp;
-        m_prevp = nullptr;
-        if (!listr.m_tailp) listr.m_tailp = newp;
-    }
-    // Unlink from side
-    void unlink(V3List<T>& listr, T oldp) {
-        // "this" must be an element inside of *oldp
-        // cppcheck-suppress thisSubtraction
-        const size_t offset = (size_t)(uint8_t*)(this) - (size_t)(uint8_t*)(oldp);
-        if (m_nextp) {
-            baseToListEnt(m_nextp, offset)->m_prevp = m_prevp;
-        } else {
-            listr.m_tailp = m_prevp;
-        }
-        if (m_prevp) {
-            baseToListEnt(m_prevp, offset)->m_nextp = m_nextp;
-        } else {
-            listr.m_headp = m_nextp;
-        }
-        m_prevp = m_nextp = nullptr;
-    }
-    // Remove all nodes from 'oldListr', append them to 'newListr'. 'this' must be a member of the
-    // object at 'selfp', and 'selfp' must be the head of the list in 'oldListr'.
-    void moveAppend(V3List<T>& oldListr, V3List<T>& newListr, T selfp) {
-        UASSERT(selfp == oldListr.m_headp, "Must be head of list to use 'moveAppend'");
-        const size_t offset = (size_t)(uint8_t*)(this) - (size_t)(uint8_t*)(selfp);
-        const T headp = selfp;
-        const T tailp = oldListr.m_tailp;
-        oldListr.reset();
-        if (newListr.empty()) {
-            newListr.m_headp = headp;
-            newListr.m_tailp = tailp;
-        } else {
-            baseToListEnt(newListr.m_tailp, offset)->m_nextp = headp;
-            m_prevp = newListr.m_tailp;
-            newListr.m_tailp = tailp;
-        }
-    }
+    VL_UNCOPYABLE(V3ListLinks);
+    VL_UNMOVABLE(V3ListLinks);
 };
 
 //============================================================================
+// Generic endogenous (or intrusive) doubly linked list, with links stored
+// inside the elements. The template parameters are:
+// - 'T_Base' is the base type of elements that contains the V3ListLinks
+//   instance as a data member.
+// - 'LinksPointer' is a member pointer to the links within 'T_Base'
+// - 'T_Element' is the actual type of elements, which must be the same,
+//    or a subtype of 'T_Base'.
+template <typename T_Base, V3ListLinks<T_Base> T_Base::*LinksPointer, typename T_Element = T_Base>
+class V3List final {
+    static_assert(std::is_base_of<T_Base, T_Element>::value,
+                  "'T_Element' must be a subtype of 'T_Base");
+
+    using ListType = V3List<T_Base, LinksPointer, T_Element>;
+
+    // MEMBERS
+    T_Base* m_headp = nullptr;
+    T_Base* m_lastp = nullptr;
+
+    // Given the T_Element, return the Links. The links are always mutable, even in const elements.
+    VL_ATTR_ALWINLINE
+    static V3ListLinks<T_Base>& toLinks(const T_Base* elementp) {
+        return const_cast<T_Base*>(elementp)->*LinksPointer;
+    }
+
+    VL_ATTR_ALWINLINE
+    static void prefetch(T_Base* elementp, T_Base* fallbackp) {
+        UDEBUGONLY(UASSERT(fallbackp, "Prefetch fallback pointer must be non nullptr"););
+        // This compiles to a branchless prefetch with cmove, with the address always valid
+        VL_PREFETCH_RW(elementp ? elementp : fallbackp);
+    }
+
+    // Iterator class template for V3List. This is just enough to support range based for loops
+    // and basic usage. Feel free to extend as required.
+    template <typename IteratorElement>
+    class SimpleItertatorImpl final {
+        static_assert(std::is_same<IteratorElement, T_Element>::value
+                          || std::is_same<IteratorElement, const T_Element>::value,
+                      "'SimpleItertatorImpl' must be used with element type only");
+
+        // The List itself, but nothing else can construct iterators
+        template <typename B, V3ListLinks<B> B::*P, typename>
+        friend class V3List;
+
+        using IteratorType = SimpleItertatorImpl<IteratorElement>;
+
+        T_Base* m_currp;  // Currently iterated element, or 'nullptr' for 'end()' iterator
+
+        VL_ATTR_ALWINLINE
+        SimpleItertatorImpl(T_Base* elementp)
+            : m_currp{elementp} {}
+
+    public:
+        // Dereference
+        VL_ATTR_ALWINLINE
+        IteratorElement& operator*() const {
+            UDEBUGONLY(UASSERT(m_currp, "Dereferencing end of list iterator"););
+            prefetch(toLinks(m_currp).m_nextp, m_currp);
+            return *static_cast<IteratorElement*>(m_currp);
+        }
+        // Pre increment
+        VL_ATTR_ALWINLINE
+        IteratorType& operator++() {
+            UDEBUGONLY(UASSERT(m_currp, "Pre-incrementing end of list iterator"););
+            m_currp = toLinks(m_currp).m_nextp;
+            return *this;
+        }
+        // Post increment
+        VL_ATTR_ALWINLINE
+        IteratorType operator++(int) {
+            UDEBUGONLY(UASSERT(m_currp, "Post-incrementing end of list iterator"););
+            T_Base* const elementp = m_currp;
+            m_currp = toLinks(m_currp).m_nextp;
+            return IteratorType{elementp};
+        }
+        VL_ATTR_ALWINLINE
+        bool operator==(const IteratorType& other) const { return m_currp == other.m_currp; }
+        VL_ATTR_ALWINLINE
+        bool operator!=(const IteratorType& other) const { return m_currp != other.m_currp; }
+        // Convert to const iterator
+        VL_ATTR_ALWINLINE
+        operator SimpleItertatorImpl<const IteratorElement>() const {
+            return SimpleItertatorImpl<const IteratorElement>{m_currp};
+        }
+    };
+
+    // Proxy class for creating unlinkable iterators, so we can use
+    // 'for (T_Element* const ptr : list.unlinkable()) list.unlink(ptr);'
+    class UnlinkableProxy final {
+        // The List itself, but nothing else can construct Unlinkable
+        template <typename B, V3ListLinks<B> B::*P, typename>
+        friend class V3List;
+
+        ListType& m_list;  // The proxied list
+
+        UnlinkableProxy(ListType& list)
+            : m_list{list} {}
+
+        // Unlinkable iterator class template. This only supports enough for range based for loops.
+        // If you want something fancier, use and manage the direct iterator manually.
+        template <typename IteratorElement>
+        class UnlinkableItertatorImpl final {
+            static_assert(std::is_same<IteratorElement, T_Element>::value
+                              || std::is_same<IteratorElement, const T_Element>::value,
+                          "'UnlinkableItertatorImpl' must be used with element type only");
+
+            // The UnlinkableProxy, but nothing else can construct unlinkable iterators
+            friend class UnlinkableProxy;
+
+            using IteratorType = UnlinkableItertatorImpl<IteratorElement>;
+
+            T_Base* m_currp;  // Currently iterated element, or 'nullptr' for 'end()' iterator
+            T_Base* m_nextp;  // Next element after current, or 'nullptr' for 'end()' iterator
+
+            VL_ATTR_ALWINLINE
+            UnlinkableItertatorImpl(T_Base* elementp)
+                : m_currp{elementp}
+                , m_nextp{toLinks(m_currp).m_nextp} {}
+            VL_ATTR_ALWINLINE
+            UnlinkableItertatorImpl(std::nullptr_t)
+                : m_currp{nullptr}
+                , m_nextp{nullptr} {}
+
+        public:
+            // Dereference - Note this returns a pointer.
+            VL_ATTR_ALWINLINE
+            IteratorElement* operator*() const {
+                UDEBUGONLY(UASSERT(m_currp, "Dereferencing end of list iterator"););
+                prefetch(m_nextp, m_currp);
+                return static_cast<IteratorElement*>(m_currp);
+            }
+            // Pre increment - Keeps hold of current next pointer.
+            VL_ATTR_ALWINLINE
+            IteratorType& operator++() {
+                UDEBUGONLY(UASSERT(m_currp, "Pre-incrementing end of list iterator"););
+                T_Base* const prevp = m_currp;
+                m_currp = m_nextp;
+                // This compiles to a branchless cmove. At the end, m_nextp is invalid, that's ok.
+                m_nextp = toLinks(m_nextp ? m_nextp : prevp).m_nextp;
+                return *this;
+            }
+            VL_ATTR_ALWINLINE
+            bool operator!=(const IteratorType& other) const { return m_currp != other.m_currp; }
+        };
+
+    public:
+        using iterator = UnlinkableItertatorImpl<T_Element>;
+        using const_iterator = UnlinkableItertatorImpl<const T_Element>;
+        iterator begin() {  //
+            return m_list.m_headp ? iterator{m_list.m_headp} : end();
+        }
+        const_iterator begin() const {
+            return m_list.m_headp ? const_iterator{m_list.m_headp} : end();
+        }
+        iterator end() { return iterator{nullptr}; }
+        const_iterator end() const { return const_iterator{nullptr}; }
+    };
+
+public:
+    using iterator = SimpleItertatorImpl<T_Element>;
+    using const_iterator = SimpleItertatorImpl<const T_Element>;
+
+    // CONSTRUCTOR
+    V3List() = default;
+    ~V3List() {
+#ifdef VL_DEBUG
+        m_headp = reinterpret_cast<T_Element*>(1);
+        m_lastp = reinterpret_cast<T_Element*>(1);
+#endif
+    }
+    VL_UNCOPYABLE(V3List);
+    VL_UNMOVABLE(V3List);
+
+    // METHDOS
+    bool empty() const { return !m_headp; }
+    bool hasSingleElement() const { return m_headp && m_headp == m_lastp; }
+    bool hasMultipleElements() const { return m_headp && m_headp != m_lastp; }
+
+    // These return pointers, as we often want to unlink/delete them, and can also signal empty
+    T_Element* frontp() { return static_cast<T_Element*>(m_headp); }
+    const T_Element* frontp() const { return static_cast<T_Element*>(m_headp); }
+    T_Element* backp() { return static_cast<T_Element*>(m_lastp); }
+    const T_Element* backp() const { return static_cast<T_Element*>(m_lastp); }
+
+    // Standard iterators. The iterator is only invalidated if the element it points to is
+    // unlinked. Other list operations do not invalidate the itartor. If you want to be able to
+    // unlink the currently iterated element, use 'unlinkable()' below.
+    iterator begin() { return iterator{m_headp}; }
+    const_iterator begin() const { return const_iterator{m_headp}; }
+    iterator end() { return iterator{nullptr}; }
+    const_iterator end() const { return const_iterator{nullptr}; }
+
+    // Handle to create unlinkable iterators, which allows unlinking the currently iterated
+    // element without invalidating the iterator. However, every other operation that mutates
+    // the list invalidates the unlinkable iterator!
+    UnlinkableProxy unlinkable() { return UnlinkableProxy{*this}; }
+
+    // Link (insert) existing element at front
+    void linkFront(const T_Element* elementp) {
+        auto& links = toLinks(elementp);
+        links.m_nextp = m_headp;
+        links.m_prevp = nullptr;
+        if (m_headp) toLinks(m_headp).m_prevp = const_cast<T_Element*>(elementp);
+        m_headp = const_cast<T_Element*>(elementp);
+        if (!m_lastp) m_lastp = m_headp;
+    }
+
+    // Link (insert) existing element at back
+    void linkBack(const T_Element* elementp) {
+        auto& links = toLinks(elementp);
+        links.m_nextp = nullptr;
+        links.m_prevp = m_lastp;
+        if (m_lastp) toLinks(m_lastp).m_nextp = const_cast<T_Element*>(elementp);
+        m_lastp = const_cast<T_Element*>(elementp);
+        if (!m_headp) m_headp = m_lastp;
+    }
+
+    // Unlink (remove) and return element at the front. Returns 'nullptr' if the list is empty.
+    T_Element* unlinkFront() {
+        T_Element* const headp = m_headp;
+        if (headp) {
+            m_headp = static_cast<T_Element*>(toLinks(m_headp).m_nextp);
+            if (m_headp) {
+                toLinks(m_headp).m_prevp = nullptr;
+            } else {
+                m_lastp = nullptr;
+            }
+        }
+        return headp;
+    }
+
+    // Unlink (remove) and return element at the back. Returns 'nullptr' if the list is empty.
+    T_Element* unlinkBack() {
+        T_Element* const lastp = m_lastp;
+        if (lastp) {
+            m_lastp = toLinks(m_lastp).m_prevp;
+            if (m_lastp) {
+                toLinks(m_lastp).m_nextp = nullptr;
+            } else {
+                m_headp = nullptr;
+            }
+        }
+        return lastp;
+    }
+
+    // Unlink (remove) the given element.
+    void unlink(const T_Element* elementp) {
+        auto& links = toLinks(elementp);
+        if (links.m_nextp) toLinks(links.m_nextp).m_prevp = links.m_prevp;
+        if (links.m_prevp) toLinks(links.m_prevp).m_nextp = links.m_nextp;
+        if (m_headp == elementp) m_headp = links.m_nextp;
+        if (m_lastp == elementp) m_lastp = links.m_prevp;
+        links.m_prevp = nullptr;
+        links.m_nextp = nullptr;
+    }
+
+    // Swap elements of 2 lists
+    void swap(ListType& other) {
+        std::swap(m_headp, other.m_headp);
+        std::swap(m_lastp, other.m_lastp);
+    }
+
+    // Take elements from 'other' and link (insert) them all before the given position.
+    void splice(const_iterator pos, ListType& other) {
+        if (empty()) {
+            swap(other);
+        } else if (other.empty()) {
+            return;
+        } else {
+            UASSERT(pos == end(), "Sorry, only splicing at the end is implemented at the moment");
+            toLinks(m_lastp).m_nextp = other.m_headp;
+            toLinks(other.m_headp).m_prevp = m_lastp;
+            m_lastp = other.m_lastp;
+            other.m_headp = nullptr;
+            other.m_lastp = nullptr;
+        }
+    }
+};
 
 #endif  // Guard

--- a/src/V3List.h
+++ b/src/V3List.h
@@ -195,10 +195,8 @@ class V3List final {
             VL_ATTR_ALWINLINE
             IteratorType& operator++() {
                 UDEBUGONLY(UASSERT(m_currp, "Pre-incrementing end of list iterator"););
-                T_Base* const prevp = m_currp;
                 m_currp = m_nextp;
-                // This compiles to a branchless cmove. At the end, m_nextp is invalid, that's ok.
-                m_nextp = toLinks(m_nextp ? m_nextp : prevp).m_nextp;
+                m_nextp = m_currp ? toLinks(m_currp).m_nextp : nullptr;
                 return *this;
             }
             VL_ATTR_ALWINLINE

--- a/src/V3OrderInternal.h
+++ b/src/V3OrderInternal.h
@@ -52,12 +52,12 @@ void processDomains(AstNetlist* netlistp,  //
                     const TrigToSenMap& trigToSen,  //
                     const ExternalDomainsProvider& externalDomains);
 
-std::vector<AstActive*> createSerial(const OrderGraph& orderGraph,  //
+std::vector<AstActive*> createSerial(OrderGraph& orderGraph,  //
                                      const std::string& tag,  //
                                      const TrigToSenMap& trigToSenMap,  //
                                      bool slow);
 
-AstExecGraph* createParallel(const OrderGraph& orderGraph,  //
+AstExecGraph* createParallel(OrderGraph& orderGraph,  //
                              const std::string& tag,  //
                              const TrigToSenMap& trigToSenMap,  //
                              bool slow);

--- a/src/V3OrderMoveGraph.h
+++ b/src/V3OrderMoveGraph.h
@@ -60,9 +60,11 @@ class OrderMoveVertex final : public V3GraphVertex {
         return nm;
     }
 
+    V3ListLinks<OrderMoveVertex>& links() { return m_links; }
+
 public:
     // List type to store instances of this class
-    using List = V3List<OrderMoveVertex, &OrderMoveVertex::m_links>;
+    using List = V3List<OrderMoveVertex, &OrderMoveVertex::links>;
 
     // CONSTRUCTORS
     OrderMoveVertex(OrderMoveGraph& graph, OrderLogicVertex* lVtxp,
@@ -126,9 +128,11 @@ class OrderMoveDomScope final {
     // Map from Domain/Scope to the corresponding DomScope instance
     static DomScopeMap s_dsMap;
 
+    V3ListLinks<OrderMoveDomScope>& links() { return m_links; }
+
 public:
     // List type to store instances of this class
-    using List = V3List<OrderMoveDomScope, &OrderMoveDomScope::m_links>;
+    using List = V3List<OrderMoveDomScope, &OrderMoveDomScope::links>;
 
     // STATIC MEMBERS
     static OrderMoveDomScope& getOrCreate(const AstSenTree* domainp, const AstScope* scopep) {

--- a/src/V3OrderMoveGraph.h
+++ b/src/V3OrderMoveGraph.h
@@ -198,8 +198,7 @@ public:
     OrderMoveGraphSerializer(OrderMoveGraph& moveGraph) {
         // Set V3GraphVertex::user() to the number of incoming edges (upstream dependencies)
         for (V3GraphVertex& vtx : moveGraph.vertices()) {
-            uint32_t nDeps = 0;
-            for (const V3GraphEdge& _ : vtx.inEdges()) ++nDeps;
+            const uint32_t nDeps = vtx.inEdges().size();
             vtx.user(nDeps);
         }
     }

--- a/src/V3OrderMoveGraph.h
+++ b/src/V3OrderMoveGraph.h
@@ -29,15 +29,69 @@
 #include "V3Order.h"
 #include "V3OrderGraph.h"
 
-class OrderMoveVertex;
+class OrderMoveDomScope;
+class OrderMoveGraph;
+
+//======================================================================
+// Vertex types
+
+class OrderMoveVertex final : public V3GraphVertex {
+    VL_RTTI_IMPL(OrderMoveVertex, V3GraphVertex)
+
+    // The corresponding logic vertex, or nullptr if this MoveVertex stands for a variable vertex.
+    OrderLogicVertex* const m_logicp;
+    OrderMoveDomScope& m_domScope;  // DomScope this vertex is under
+    V3ListLinks<OrderMoveVertex> m_links;  // List links to store instances of this class
+
+    // METHODS
+    std::string dotColor() const override { return logicp() ? logicp()->dotColor() : "yellow"; }
+
+    std::string name() const override VL_MT_STABLE {
+        std::string nm;
+        if (!logicp()) {
+            nm = "var";
+        } else {
+            nm = logicp()->name() + "\\n";
+            nm += "MV:";
+            nm += +" d=" + cvtToHex(logicp()->domainp());
+            nm += +" s=" + cvtToHex(logicp()->scopep());
+        }
+        if (userp()) nm += "\nu=" + cvtToHex(userp());
+        return nm;
+    }
+
+public:
+    // List type to store instances of this class
+    using List = V3List<OrderMoveVertex, &OrderMoveVertex::m_links>;
+
+    // CONSTRUCTORS
+    OrderMoveVertex(OrderMoveGraph& graph, OrderLogicVertex* lVtxp,
+                    const AstSenTree* domainp) VL_MT_DISABLED;
+    ~OrderMoveVertex() override = default;
+    VL_UNCOPYABLE(OrderMoveVertex);
+
+    OrderLogicVertex* logicp() const VL_MT_STABLE { return m_logicp; }
+    OrderMoveDomScope& domScope() const { return m_domScope; }
+};
+
+//======================================================================
+// Graph type
+
+// OrderMoveGraph is constructed from the fine-grained OrderGraph.
+// It is a slightly coarsened representation of dependencies used to drive serialization.
+class OrderMoveGraph final : public V3Graph {
+public:
+    // Build an OrderMoveGraph from an OrderGraph
+    static std::unique_ptr<OrderMoveGraph> build(OrderGraph&, const V3Order::TrigToSenMap&);
+};
 
 // Information stored for each unique (domain, scope) pair. Mainly a list of ready vertices under
 // that (domain, scope). OrderMoveDomScope instances are themselves organized into a global ready
 // list if they have ready vertices.
 class OrderMoveDomScope final {
     // STATE
-    V3List<OrderMoveVertex*> m_readyVertices;  // Ready vertices in this domain/scope
-    V3ListEnt<OrderMoveDomScope*> m_listEnt;  // List entry to store this instance
+    OrderMoveVertex::List m_readyVertices;  // Ready vertices in this domain/scope
+    V3ListLinks<OrderMoveDomScope> m_links;  // List links to store instances of this class
     bool m_isOnList = false;  // True if DomScope is already on a list through m_listEnt
     const AstSenTree* const m_domainp;  // Domain the vertices belong to
     const AstScope* const m_scopep;  // Scope the vertices belong to
@@ -73,6 +127,9 @@ class OrderMoveDomScope final {
     static DomScopeMap s_dsMap;
 
 public:
+    // List type to store instances of this class
+    using List = V3List<OrderMoveDomScope, &OrderMoveDomScope::m_links>;
+
     // STATIC MEMBERS
     static OrderMoveDomScope& getOrCreate(const AstSenTree* domainp, const AstScope* scopep) {
         return s_dsMap
@@ -92,84 +149,12 @@ public:
     VL_UNMOVABLE(OrderMoveDomScope);
 
     // MEMBERS
-    V3List<OrderMoveVertex*>& readyVertices() { return m_readyVertices; }
+    OrderMoveVertex::List& readyVertices() { return m_readyVertices; }
     const AstSenTree* domainp() const { return m_domainp; }
     const AstScope* scopep() const { return m_scopep; }
 
     bool isOnList() const { return m_isOnList; }
-    void unlinkFrom(V3List<OrderMoveDomScope*>& list) {
-        UASSERT_OBJ(m_isOnList, m_domainp, "unlinkFrom, but DomScope is not on a list");
-        m_isOnList = false;
-        m_listEnt.unlink(list, this);
-    }
-    void appendTo(V3List<OrderMoveDomScope*>& list) {
-        UASSERT_OBJ(!m_isOnList, m_domainp, "appendTo, but DomScope is already on a list");
-        m_isOnList = true;
-        m_listEnt.pushBack(list, this);
-    }
-    void prependTo(V3List<OrderMoveDomScope*>& list) {
-        UASSERT_OBJ(!m_isOnList, m_domainp, "prependTo, but DomScope is already on a list");
-        m_isOnList = true;
-        m_listEnt.pushFront(list, this);
-    }
-    OrderMoveDomScope* nextp() const { return m_listEnt.nextp(); }
-};
-
-//======================================================================
-// Graph type
-
-// OrderMoveGraph is constructed from the fine-grained OrderGraph.
-// It is a slightly coarsened representation of dependencies used to drive serialization.
-class OrderMoveGraph final : public V3Graph {
-public:
-    // Build an OrderMoveGraph from an OrderGraph
-    static std::unique_ptr<OrderMoveGraph> build(const OrderGraph&, const V3Order::TrigToSenMap&);
-};
-
-//======================================================================
-// Vertex types
-
-class OrderMoveVertex final : public V3GraphVertex {
-    VL_RTTI_IMPL(OrderMoveVertex, V3GraphVertex)
-
-    // The corresponding logic vertex, or nullptr if this MoveVertex stands for a variable vertex.
-    OrderLogicVertex* const m_logicp;
-    OrderMoveDomScope& m_domScope;  // DomScope this vertex is under
-    V3ListEnt<OrderMoveVertex*> m_listEnt;  // List entry to store this Vertex
-
-    // METHODS
-    std::string dotColor() const override { return logicp() ? logicp()->dotColor() : "yellow"; }
-
-    std::string name() const override VL_MT_STABLE {
-        std::string nm;
-        if (!logicp()) {
-            nm = "var";
-        } else {
-            nm = logicp()->name() + "\\n";
-            nm += "MV:";
-            nm += +" d=" + cvtToHex(logicp()->domainp());
-            nm += +" s=" + cvtToHex(logicp()->scopep());
-        }
-        if (userp()) nm += "\nu=" + cvtToHex(userp());
-        return nm;
-    }
-
-public:
-    // CONSTRUCTORS
-    OrderMoveVertex(OrderMoveGraph& graph, OrderLogicVertex* lVtxp,
-                    const AstSenTree* domainp) VL_MT_DISABLED;
-    ~OrderMoveVertex() override = default;
-    VL_UNCOPYABLE(OrderMoveVertex);
-
-    OrderLogicVertex* logicp() const VL_MT_STABLE { return m_logicp; }
-    OrderMoveDomScope& domScope() const { return m_domScope; }
-
-    void unlinkFrom(V3List<OrderMoveVertex*>& list) { m_listEnt.unlink(list, this); }
-    void appendTo(V3List<OrderMoveVertex*>& list) { m_listEnt.pushBack(list, this); }
-    void moveAppend(V3List<OrderMoveVertex*>& src, V3List<OrderMoveVertex*>& dst) {
-        m_listEnt.moveAppend(src, dst, this);
-    }
-    OrderMoveVertex* nextp() const { return m_listEnt.nextp(); }
+    void isOnList(bool value) { m_isOnList = value; }
 };
 
 //======================================================================
@@ -177,7 +162,7 @@ public:
 
 class OrderMoveGraphSerializer final {
     // STATE
-    V3List<OrderMoveDomScope*> m_readyDomScopeps;  // List of DomScopes which have ready vertices
+    OrderMoveDomScope::List m_readyDomScopeps;  // List of DomScopes which have ready vertices
     OrderMoveDomScope* m_nextDomScopep = nullptr;  // Next DomScope to yield from
 
     // METHODS
@@ -187,16 +172,18 @@ class OrderMoveGraphSerializer final {
         if (vtxp->logicp()) {
             // Add this vertex to the ready list of its DomScope
             OrderMoveDomScope& domScope = vtxp->domScope();
-            vtxp->appendTo(domScope.readyVertices());
+            domScope.readyVertices().linkBack(vtxp);
             // Add the DomScope to the global ready list if not there yet
-            if (!domScope.isOnList()) domScope.appendTo(m_readyDomScopeps);
+            if (!domScope.isOnList()) {
+                domScope.isOnList(true);
+                m_readyDomScopeps.linkBack(&domScope);
+            }
         } else {  // This is a bit nonsense at this point, but equivalent to the old version
             // Remove dependency on vertex we are returning. This might add vertices to
             // currReadyList.
-            for (V3GraphEdge *edgep = vtxp->outBeginp(), *nextp; edgep; edgep = nextp) {
-                nextp = edgep->outNextp();
+            for (V3GraphEdge& edge : vtxp->outEdges()) {
                 // The dependent variable
-                OrderMoveVertex* const dVtxp = edgep->top()->as<OrderMoveVertex>();
+                OrderMoveVertex* const dVtxp = edge.top()->as<OrderMoveVertex>();
                 // Update number of dependencies
                 const uint32_t nDeps = dVtxp->user() - 1;
                 dVtxp->user(nDeps);
@@ -210,11 +197,10 @@ public:
     // CONSTRUCTOR
     OrderMoveGraphSerializer(OrderMoveGraph& moveGraph) {
         // Set V3GraphVertex::user() to the number of incoming edges (upstream dependencies)
-        for (V3GraphVertex *vtxp = moveGraph.verticesBeginp(), *nextp; vtxp; vtxp = nextp) {
-            nextp = vtxp->verticesNextp();
+        for (V3GraphVertex& vtx : moveGraph.vertices()) {
             uint32_t nDeps = 0;
-            for (V3GraphEdge* edgep = vtxp->inBeginp(); edgep; edgep = edgep->inNextp()) ++nDeps;
-            vtxp->user(nDeps);
+            for (const V3GraphEdge& _ : vtx.inEdges()) ++nDeps;
+            vtx.user(nDeps);
         }
     }
     ~OrderMoveGraphSerializer() = default;
@@ -224,26 +210,27 @@ public:
     void addSeed(OrderMoveVertex* vtxp) { ready(vtxp); }
 
     OrderMoveVertex* getNext() {
-        if (!m_nextDomScopep) m_nextDomScopep = m_readyDomScopeps.begin();
-        OrderMoveDomScope* const currDomScopep = m_nextDomScopep;
+        if (!m_nextDomScopep) m_nextDomScopep = m_readyDomScopeps.frontp();
         // If nothing is ready, we are done
-        if (!currDomScopep) return nullptr;
+        if (!m_nextDomScopep) return nullptr;
+        OrderMoveDomScope& currDomScope = *m_nextDomScopep;
 
-        V3List<OrderMoveVertex*>& currReadyList = currDomScopep->readyVertices();
-        // This is the vertex we are returning now
-        OrderMoveVertex* const mVtxp = currReadyList.begin();
-        UASSERT(mVtxp, "DomScope on ready list, but has no ready vertices");
-        // Unlink vertex from ready list under the DomScope
-        mVtxp->unlinkFrom(currReadyList);
+        OrderMoveVertex::List& currReadyList = currDomScope.readyVertices();
+        UASSERT(!currReadyList.empty(), "DomScope on ready list, but has no ready vertices");
+
+        // Remove vertex from ready list under the DomScope. This is the vertex we are returning.
+        OrderMoveVertex* mVtxp = currReadyList.unlinkFront();
 
         // Nonsesne, but what we used to do
-        if (currReadyList.empty()) currDomScopep->unlinkFrom(m_readyDomScopeps);
+        if (currReadyList.empty()) {
+            currDomScope.isOnList(false);
+            m_readyDomScopeps.unlink(&currDomScope);
+        }
 
         // Remove dependency on vertex we are returning. This might add vertices to currReadyList.
-        for (V3GraphEdge *edgep = mVtxp->outBeginp(), *nextp; edgep; edgep = nextp) {
-            nextp = edgep->outNextp();
+        for (V3GraphEdge& edge : mVtxp->outEdges()) {
             // The dependent variable
-            OrderMoveVertex* const dVtxp = edgep->top()->as<OrderMoveVertex>();
+            OrderMoveVertex* const dVtxp = edge.top()->as<OrderMoveVertex>();
             // Update number of dependencies
             const uint32_t nDeps = dVtxp->user() - 1;
             dVtxp->user(nDeps);
@@ -255,9 +242,9 @@ public:
         // under the same domain.
         if (currReadyList.empty()) {
             m_nextDomScopep = nullptr;
-            for (OrderMoveDomScope* dsp = m_readyDomScopeps.begin(); dsp; dsp = dsp->nextp()) {
-                if (dsp->domainp() == currDomScopep->domainp()) {
-                    m_nextDomScopep = dsp;
+            for (OrderMoveDomScope& domScope : m_readyDomScopeps) {
+                if (domScope.domainp() == currDomScope.domainp()) {
+                    m_nextDomScopep = &domScope;
                     break;
                 }
             }

--- a/src/V3OrderParallel.cpp
+++ b/src/V3OrderParallel.cpp
@@ -241,10 +241,13 @@ class SiblingMC final : public MergeCandidate {
     V3ListLinks<SiblingMC> m_aLinks;  // List links to store instances of this class
     V3ListLinks<SiblingMC> m_bLinks;  // List links to store instances of this class
 
+    V3ListLinks<SiblingMC>& aLinks() { return m_aLinks; }
+    V3ListLinks<SiblingMC>& bLinks() { return m_bLinks; }
+
 public:
     // List type to store instances of this class
-    using AList = V3List<SiblingMC, &SiblingMC::m_aLinks>;
-    using BList = V3List<SiblingMC, &SiblingMC::m_bLinks>;
+    using AList = V3List<SiblingMC, &SiblingMC::aLinks>;
+    using BList = V3List<SiblingMC, &SiblingMC::bLinks>;
 
     // CONSTRUCTORS
     SiblingMC(LogicMTask* ap, LogicMTask* bp);

--- a/src/V3OrderParallel.cpp
+++ b/src/V3OrderParallel.cpp
@@ -278,11 +278,9 @@ public:
     MTaskEdge(V3Graph* graphp, LogicMTask* fromp, LogicMTask* top, int weight);
     // METHODS
     template <GraphWay::en T_Way>
-    LogicMTask* furtherMTaskp() const {
-        return reinterpret_cast<LogicMTask*>(this->furtherp<T_Way>());
-    }
-    LogicMTask* fromMTaskp() const { return reinterpret_cast<LogicMTask*>(fromp()); }
-    LogicMTask* toMTaskp() const { return reinterpret_cast<LogicMTask*>(top()); }
+    inline LogicMTask* furtherMTaskp() const;
+    inline LogicMTask* fromMTaskp() const;
+    inline LogicMTask* toMTaskp() const;
     bool mergeWouldCreateCycle() const;
     // Following initial assignment of critical paths, clear this MTaskEdge
     // out of the edge-map for each node and reinsert at a new location
@@ -688,6 +686,13 @@ MTaskEdge::MTaskEdge(V3Graph* graphp, LogicMTask* fromp, LogicMTask* top, int we
     fromp->addRelativeEdge<GraphWay::FORWARD>(this);
     top->addRelativeEdge<GraphWay::REVERSE>(this);
 }
+
+template <GraphWay::en T_Way>
+LogicMTask* MTaskEdge::furtherMTaskp() const {
+    return static_cast<LogicMTask*>(this->furtherp<T_Way>());
+}
+LogicMTask* MTaskEdge::fromMTaskp() const { return static_cast<LogicMTask*>(fromp()); }
+LogicMTask* MTaskEdge::toMTaskp() const { return static_cast<LogicMTask*>(top()); }
 
 bool MTaskEdge::mergeWouldCreateCycle() const {
     return LogicMTask::pathExistsFrom(fromMTaskp(), toMTaskp(), this);

--- a/src/V3OrderParallel.cpp
+++ b/src/V3OrderParallel.cpp
@@ -1216,8 +1216,7 @@ public:
 
                     // Except, if we have too many mTaskGraphp, raise the score
                     // limit and keep going...
-                    unsigned mtaskCount = 0;
-                    for (const V3GraphVertex& _ : m_mTaskGraph.vertices()) ++mtaskCount;
+                    const unsigned mtaskCount = m_mTaskGraph.vertices().size();
                     if (mtaskCount > maxMTasks) {
                         const uint32_t oldLimit = m_scoreLimit;
                         m_scoreLimit = (m_scoreLimit * 120) / 100;
@@ -2129,7 +2128,8 @@ class Partitioner final {
         if (mvtxp->logicp()) return false;
         // Count fan-in, up to 3
         unsigned fanIn = 0;
-        for (const V3GraphEdge& _ : mvtxp->inEdges()) {
+        auto& inEdges = mvtxp->inEdges();
+        for (auto it = inEdges.begin(); it != inEdges.end(); ++it) {
             if (++fanIn == 3) break;
         }
         UDEBUGONLY(UASSERT_OBJ(fanIn <= 3, mvtxp, "Should have stopped counting fanIn"););
@@ -2137,7 +2137,8 @@ class Partitioner final {
         if (fanIn <= 1) return true;
         // Count fan-out, up to 3
         unsigned fanOut = 0;
-        for (const V3GraphEdge& _ : mvtxp->outEdges()) {
+        auto& outEdges = mvtxp->outEdges();
+        for (auto it = outEdges.begin(); it != outEdges.end(); ++it) {
             if (++fanOut == 3) break;
         }
         UDEBUGONLY(UASSERT_OBJ(fanOut <= 3, mvtxp, "Should have stopped counting fanOut"););

--- a/src/V3OrderProcessDomains.cpp
+++ b/src/V3OrderProcessDomains.cpp
@@ -83,8 +83,8 @@ class V3OrderProcessDomains final {
         // Buffer to hold external sensitivities
         std::vector<AstSenTree*> externalDomainps;
         // For each vertex
-        for (V3GraphVertex* itp = m_graph.verticesBeginp(); itp; itp = itp->verticesNextp()) {
-            OrderEitherVertex* const vtxp = itp->as<OrderEitherVertex>();
+        for (V3GraphVertex& it : m_graph.vertices()) {
+            OrderEitherVertex* const vtxp = it.as<OrderEitherVertex>();
             UINFO(5, "    pdi: " << vtxp << endl);
             // Sequential logic already has its domain set
             if (vtxp->domainp()) continue;
@@ -95,10 +95,10 @@ class V3OrderProcessDomains final {
             if (lvtxp) domainp = lvtxp->hybridp();
 
             // For each incoming edge, examine the source vertex
-            for (V3GraphEdge* edgep = vtxp->inBeginp(); edgep; edgep = edgep->inNextp()) {
-                OrderEitherVertex* const fromVtxp = edgep->fromp()->as<OrderEitherVertex>();
+            for (V3GraphEdge& edge : vtxp->inEdges()) {
+                OrderEitherVertex* const fromVtxp = edge.fromp()->as<OrderEitherVertex>();
                 // Cut edge
-                if (!edgep->weight()) continue;
+                if (!edge.weight()) continue;
                 //
                 if (!fromVtxp->domainMatters()) continue;
 
@@ -162,14 +162,14 @@ class V3OrderProcessDomains final {
         std::unordered_map<VNRef<const AstSenItem>, const AstSenTree*> trigToSen;
         for (const auto& pair : m_trigToSen) trigToSen.emplace(*pair.first, pair.second);
 
-        for (V3GraphVertex* itp = m_graph.verticesBeginp(); itp; itp = itp->verticesNextp()) {
-            if (OrderVarVertex* const vvertexp = itp->cast<OrderVarVertex>()) {
+        for (V3GraphVertex& vtx : m_graph.vertices()) {
+            if (OrderVarVertex* const vvertexp = vtx.cast<OrderVarVertex>()) {
                 string name(vvertexp->vscp()->prettyName());
-                if (itp->is<OrderVarPreVertex>()) {
+                if (vtx.is<OrderVarPreVertex>()) {
                     name += " {PRE}";
-                } else if (itp->is<OrderVarPostVertex>()) {
+                } else if (vtx.is<OrderVarPostVertex>()) {
                     name += " {POST}";
-                } else if (itp->is<OrderVarPordVertex>()) {
+                } else if (vtx.is<OrderVarPordVertex>()) {
                     name += " {PORD}";
                 }
                 std::ostringstream os;

--- a/src/V3OrderSerial.cpp
+++ b/src/V3OrderSerial.cpp
@@ -31,7 +31,7 @@ VL_DEFINE_DEBUG_FUNCTIONS;
 //######################################################################
 // OrderSerial class
 
-std::vector<AstActive*> V3Order::createSerial(const OrderGraph& graph, const std::string& tag,
+std::vector<AstActive*> V3Order::createSerial(OrderGraph& graph, const std::string& tag,
                                               const TrigToSenMap& trigToSen, bool slow) {
 
     UINFO(2, "  Constructing serial code for '" + tag + "'");
@@ -45,9 +45,8 @@ std::vector<AstActive*> V3Order::createSerial(const OrderGraph& graph, const std
     OrderMoveGraphSerializer serializer{*moveGraphp};
 
     // Add initially ready vertices (those with no dependencies) to the serializer as seeds
-    for (V3GraphVertex *vtxp = moveGraphp->verticesBeginp(), *nextp; vtxp; vtxp = nextp) {
-        nextp = vtxp->verticesNextp();
-        if (vtxp->inEmpty()) serializer.addSeed(vtxp->as<OrderMoveVertex>());
+    for (V3GraphVertex& vtx : moveGraphp->vertices()) {
+        if (vtx.inEmpty()) serializer.addSeed(vtx.as<OrderMoveVertex>());
     }
 
     // Emit all logic as they become ready
@@ -68,8 +67,7 @@ std::vector<AstActive*> V3Order::createSerial(const OrderGraph& graph, const std
     }
 
     // Delete the remaining variable vertices
-    for (V3GraphVertex *vtxp = moveGraphp->verticesBeginp(), *nextp; vtxp; vtxp = nextp) {
-        nextp = vtxp->verticesNextp();
+    for (V3GraphVertex* const vtxp : moveGraphp->vertices().unlinkable()) {
         if (!vtxp->as<OrderMoveVertex>()->logicp()) {
             VL_DO_DANGLING(vtxp->unlinkDelete(moveGraphp.get()), vtxp);
         }

--- a/src/V3SchedAcyclic.cpp
+++ b/src/V3SchedAcyclic.cpp
@@ -176,8 +176,8 @@ void removeNonCyclic(Graph* graphp) {
     };
 
     // Start with vertices with no inputs or outputs
-    for (V3GraphVertex* vtxp = graphp->verticesBeginp(); vtxp; vtxp = vtxp->verticesNextp()) {
-        if (vtxp->inEmpty() || vtxp->outEmpty()) enqueue(vtxp);
+    for (V3GraphVertex& vtx : graphp->vertices()) {
+        if (vtx.inEmpty() || vtx.outEmpty()) enqueue(&vtx);
     }
 
     // Iterate while we still have candidates
@@ -189,16 +189,14 @@ void removeNonCyclic(Graph* graphp) {
 
         if (vtxp->inEmpty()) {
             // Enqueue children for consideration, remove out edges, and delete this vertex
-            for (V3GraphEdge *edgep = vtxp->outBeginp(), *nextp; edgep; edgep = nextp) {
-                nextp = edgep->outNextp();
+            for (V3GraphEdge* const edgep : vtxp->outEdges().unlinkable()) {
                 enqueue(edgep->top());
                 VL_DO_DANGLING(edgep->unlinkDelete(), edgep);
             }
             VL_DO_DANGLING(vtxp->unlinkDelete(graphp), vtxp);
         } else if (vtxp->outEmpty()) {
             // Enqueue parents for consideration, remove in edges, and delete this vertex
-            for (V3GraphEdge *edgep = vtxp->inBeginp(), *nextp; edgep; edgep = nextp) {
-                nextp = edgep->inNextp();
+            for (V3GraphEdge* const edgep : vtxp->inEdges().unlinkable()) {
                 enqueue(edgep->fromp());
                 VL_DO_DANGLING(edgep->unlinkDelete(), edgep);
             }
@@ -209,11 +207,11 @@ void removeNonCyclic(Graph* graphp) {
 
 // Has this VarVertex been cut? (any edges in or out has been cut)
 bool isCut(const SchedAcyclicVarVertex* vtxp) {
-    for (V3GraphEdge* edgep = vtxp->inBeginp(); edgep; edgep = edgep->inNextp()) {
-        if (edgep->weight() == 0) return true;
+    for (const V3GraphEdge& edge : vtxp->inEdges()) {
+        if (edge.weight() == 0) return true;
     }
-    for (V3GraphEdge* edgep = vtxp->outBeginp(); edgep; edgep = edgep->outNextp()) {
-        if (edgep->weight() == 0) return true;
+    for (const V3GraphEdge& edge : vtxp->outEdges()) {
+        if (edge.weight() == 0) return true;
     }
     return false;
 }
@@ -221,8 +219,8 @@ bool isCut(const SchedAcyclicVarVertex* vtxp) {
 std::vector<SchedAcyclicVarVertex*> findCutVertices(Graph* graphp) {
     std::vector<SchedAcyclicVarVertex*> result;
     const VNUser1InUse user1InUse;  // bool: already added to result
-    for (V3GraphVertex* vtxp = graphp->verticesBeginp(); vtxp; vtxp = vtxp->verticesNextp()) {
-        if (SchedAcyclicVarVertex* const vvtxp = vtxp->cast<SchedAcyclicVarVertex>()) {
+    for (V3GraphVertex& vtx : graphp->vertices()) {
+        if (SchedAcyclicVarVertex* const vvtxp = vtx.cast<SchedAcyclicVarVertex>()) {
             if (!vvtxp->vscp()->user1SetOnce() && isCut(vvtxp)) result.push_back(vvtxp);
         }
     }
@@ -231,8 +229,8 @@ std::vector<SchedAcyclicVarVertex*> findCutVertices(Graph* graphp) {
 
 void resetEdgeWeights(const std::vector<SchedAcyclicVarVertex*>& cutVertices) {
     for (SchedAcyclicVarVertex* const vvtxp : cutVertices) {
-        for (V3GraphEdge* ep = vvtxp->inBeginp(); ep; ep = ep->inNextp()) ep->weight(1);
-        for (V3GraphEdge* ep = vvtxp->outBeginp(); ep; ep = ep->outNextp()) ep->weight(1);
+        for (V3GraphEdge& e : vvtxp->inEdges()) e.weight(1);
+        for (V3GraphEdge& e : vvtxp->outEdges()) e.weight(1);
     }
 }
 
@@ -253,18 +251,18 @@ void gatherSCCCandidates(V3GraphVertex* vtxp, std::vector<Candidate>& candidates
             && name.find("__Vcell") == string::npos) {
             // Also compute the fanout of this vertex
             unsigned fanout = 0;
-            for (V3GraphEdge* ep = vtxp->outBeginp(); ep; ep = ep->outNextp()) ++fanout;
+            for (const V3GraphEdge& _ : vtxp->outEdges()) ++fanout;
             candidates.emplace_back(vvtxp, fanout);
         }
     }
 
     // Iterate through all the vertices within the same strongly connected component (same color)
-    for (V3GraphEdge* edgep = vtxp->outBeginp(); edgep; edgep = edgep->outNextp()) {
-        V3GraphVertex* const top = edgep->top();
+    for (V3GraphEdge& edge : vtxp->outEdges()) {
+        V3GraphVertex* const top = edge.top();
         if (top->color() == vtxp->color()) gatherSCCCandidates(top, candidates);
     }
-    for (V3GraphEdge* edgep = vtxp->inBeginp(); edgep; edgep = edgep->inNextp()) {
-        V3GraphVertex* const fromp = edgep->fromp();
+    for (V3GraphEdge& edge : vtxp->inEdges()) {
+        V3GraphVertex* const fromp = edge.fromp();
         if (fromp->color() == vtxp->color()) gatherSCCCandidates(fromp, candidates);
     }
 }
@@ -359,9 +357,9 @@ LogicByScope fixCuts(AstNetlist* netlistp,
     {
         const VNUser1InUse user1InUse;  // bool: already added to 'lvtxps'
         for (SchedAcyclicVarVertex* const vvtxp : cutVertices) {
-            for (V3GraphEdge* edgep = vvtxp->outBeginp(); edgep; edgep = edgep->outNextp()) {
+            for (V3GraphEdge& edge : vvtxp->outEdges()) {
                 SchedAcyclicLogicVertex* const lvtxp
-                    = static_cast<SchedAcyclicLogicVertex*>(edgep->top());
+                    = static_cast<SchedAcyclicLogicVertex*>(edge.top());
                 if (!lvtxp->logicp()->user1SetOnce()) lvtxps.push_back(lvtxp);
                 lvtx2Cuts[lvtxp].push_back(vvtxp->vscp());
             }

--- a/src/V3SchedAcyclic.cpp
+++ b/src/V3SchedAcyclic.cpp
@@ -250,8 +250,7 @@ void gatherSCCCandidates(V3GraphVertex* vtxp, std::vector<Candidate>& candidates
             && name.find("__Vdly") == string::npos  // Ignore internal signals
             && name.find("__Vcell") == string::npos) {
             // Also compute the fanout of this vertex
-            unsigned fanout = 0;
-            for (const V3GraphEdge& _ : vtxp->outEdges()) ++fanout;
+            const unsigned fanout = vtxp->outEdges().size();
             candidates.emplace_back(vvtxp, fanout);
         }
     }

--- a/src/V3SchedReplicate.cpp
+++ b/src/V3SchedReplicate.cpp
@@ -225,8 +225,8 @@ void propagateDrivingRegions(SchedReplicateVertex* vtxp) {
 
     // Compute union of driving regions of all inputs
     uint8_t drivingRegions = 0;
-    for (V3GraphEdge* edgep = vtxp->inBeginp(); edgep; edgep = edgep->inNextp()) {
-        SchedReplicateVertex* const srcp = edgep->fromp()->as<SchedReplicateVertex>();
+    for (V3GraphEdge& edge : vtxp->inEdges()) {
+        SchedReplicateVertex* const srcp = edge.fromp()->as<SchedReplicateVertex>();
         propagateDrivingRegions(srcp);
         drivingRegions |= srcp->drivingRegions();
     }
@@ -240,8 +240,8 @@ void propagateDrivingRegions(SchedReplicateVertex* vtxp) {
 
 LogicReplicas replicate(Graph* graphp) {
     LogicReplicas result;
-    for (V3GraphVertex* vtxp = graphp->verticesBeginp(); vtxp; vtxp = vtxp->verticesNextp()) {
-        if (SchedReplicateLogicVertex* const lvtxp = vtxp->cast<SchedReplicateLogicVertex>()) {
+    for (V3GraphVertex& vtx : graphp->vertices()) {
+        if (SchedReplicateLogicVertex* const lvtxp = vtx.cast<SchedReplicateLogicVertex>()) {
             const auto replicateTo = [&](LogicByScope& lbs) {
                 lbs.add(lvtxp->scopep(), lvtxp->senTreep(), lvtxp->logicp()->cloneTree(false));
             };
@@ -264,8 +264,8 @@ LogicReplicas replicateLogic(LogicRegions& logicRegionsRegions) {
     // Dump for debug
     if (dumpGraphLevel() >= 6) graphp->dumpDotFilePrefixed("sched-replicate");
     // Propagate driving region flags
-    for (V3GraphVertex* vtxp = graphp->verticesBeginp(); vtxp; vtxp = vtxp->verticesNextp()) {
-        propagateDrivingRegions(vtxp->as<SchedReplicateVertex>());
+    for (V3GraphVertex& vtx : graphp->vertices()) {
+        propagateDrivingRegions(vtx.as<SchedReplicateVertex>());
     }
     // Dump for debug
     if (dumpGraphLevel() >= 6) graphp->dumpDotFilePrefixed("sched-replicate-propagated");

--- a/src/V3Split.cpp
+++ b/src/V3Split.cpp
@@ -320,9 +320,9 @@ protected:
         for (V3GraphVertex& vertex : m_graph.vertices()) {
             if (vertex.outEmpty() && vertex.is<SplitVarStdVertex>()) {
                 if (debug() >= 9) {
-                    const SplitVarStdVertex& std = static_cast<SplitVarStdVertex&>(vertex);
-                    UINFO(0, "Will prune deps on var " << std.nodep() << endl);
-                    std.nodep()->dumpTree("-  ");
+                    const SplitVarStdVertex& sVtx = static_cast<SplitVarStdVertex&>(vertex);
+                    UINFO(0, "Will prune deps on var " << sVtx.nodep() << endl);
+                    sVtx.nodep()->dumpTree("-  ");
                 }
                 for (V3GraphEdge& edge : vertex.inEdges()) {
                     SplitEdge& oedge = static_cast<SplitEdge&>(edge);

--- a/src/V3Split.cpp
+++ b/src/V3Split.cpp
@@ -317,17 +317,16 @@ protected:
     }
 
     void pruneDepsOnInputs() {
-        for (V3GraphVertex* vertexp = m_graph.verticesBeginp(); vertexp;
-             vertexp = vertexp->verticesNextp()) {
-            if (!vertexp->outBeginp() && vertexp->is<SplitVarStdVertex>()) {
+        for (V3GraphVertex& vertex : m_graph.vertices()) {
+            if (vertex.outEmpty() && vertex.is<SplitVarStdVertex>()) {
                 if (debug() >= 9) {
-                    const SplitVarStdVertex* const stdp = static_cast<SplitVarStdVertex*>(vertexp);
-                    UINFO(0, "Will prune deps on var " << stdp->nodep() << endl);
-                    stdp->nodep()->dumpTree("-  ");
+                    const SplitVarStdVertex& std = static_cast<SplitVarStdVertex&>(vertex);
+                    UINFO(0, "Will prune deps on var " << std.nodep() << endl);
+                    std.nodep()->dumpTree("-  ");
                 }
-                for (V3GraphEdge* edgep = vertexp->inBeginp(); edgep; edgep = edgep->inNextp()) {
-                    SplitEdge* const oedgep = static_cast<SplitEdge*>(edgep);
-                    oedgep->setIgnoreThisStep();
+                for (V3GraphEdge& edge : vertex.inEdges()) {
+                    SplitEdge& oedge = static_cast<SplitEdge&>(edge);
+                    oedge.setIgnoreThisStep();
                 }
             }
         }
@@ -475,19 +474,16 @@ protected:
 
         // For reordering this single block only, mark all logic
         // vertexes not involved with this step as unimportant
-        for (V3GraphVertex* vertexp = m_graph.verticesBeginp(); vertexp;
-             vertexp = vertexp->verticesNextp()) {
-            if (!vertexp->user()) {
-                if (const SplitLogicVertex* const vvertexp = vertexp->cast<SplitLogicVertex>()) {
-                    for (V3GraphEdge* edgep = vertexp->inBeginp(); edgep;
-                         edgep = edgep->inNextp()) {
-                        SplitEdge* const oedgep = static_cast<SplitEdge*>(edgep);
-                        oedgep->setIgnoreThisStep();
+        for (V3GraphVertex& vertex : m_graph.vertices()) {
+            if (!vertex.user()) {
+                if (const SplitLogicVertex* const vvertexp = vertex.cast<SplitLogicVertex>()) {
+                    for (V3GraphEdge& edge : vertex.inEdges()) {
+                        SplitEdge& oedge = static_cast<SplitEdge&>(edge);
+                        oedge.setIgnoreThisStep();
                     }
-                    for (V3GraphEdge* edgep = vertexp->outBeginp(); edgep;
-                         edgep = edgep->outNextp()) {
-                        SplitEdge* const oedgep = static_cast<SplitEdge*>(edgep);
-                        oedgep->setIgnoreThisStep();
+                    for (V3GraphEdge& edge : vertex.outEdges()) {
+                        SplitEdge& oedge = static_cast<SplitEdge&>(edge);
+                        oedge.setIgnoreThisStep();
                     }
                 }
             }
@@ -904,18 +900,17 @@ protected:
         // For any 'if' node whose deps have all been pruned
         // (meaning, its conditional expression only looks at primary
         // inputs) prune all edges that depend on the 'if'.
-        for (V3GraphVertex* vertexp = m_graph.verticesBeginp(); vertexp;
-             vertexp = vertexp->verticesNextp()) {
-            const SplitLogicVertex* const logicp = vertexp->cast<const SplitLogicVertex>();
+        for (V3GraphVertex& vertex : m_graph.vertices()) {
+            SplitLogicVertex* const logicp = vertex.cast<SplitLogicVertex>();
             if (!logicp) continue;
 
             const AstNodeIf* const ifNodep = VN_CAST(logicp->nodep(), NodeIf);
             if (!ifNodep) continue;
 
             bool pruneMe = true;
-            for (V3GraphEdge* edgep = logicp->outBeginp(); edgep; edgep = edgep->outNextp()) {
-                const SplitEdge* const oedgep = static_cast<const SplitEdge*>(edgep);
-                if (!oedgep->ignoreThisStep()) {
+            for (const V3GraphEdge& edge : logicp->outEdges()) {
+                const SplitEdge& oedge = static_cast<const SplitEdge&>(edge);
+                if (!oedge.ignoreThisStep()) {
                     // This if conditional depends on something we can't
                     // prune -- a variable generated in the current block.
                     pruneMe = false;
@@ -923,11 +918,11 @@ protected:
                     // When we can't prune dependencies on the conditional,
                     // give a hint about why...
                     if (debug() >= 9) {
-                        V3GraphVertex* vxp = oedgep->top();
+                        V3GraphVertex* vxp = oedge.top();
                         const SplitNodeVertex* const nvxp
                             = static_cast<const SplitNodeVertex*>(vxp);
                         UINFO(0, "Cannot prune if-node due to edge "
-                                     << oedgep << " pointing to node " << nvxp->nodep() << endl);
+                                     << &oedge << " pointing to node " << nvxp->nodep() << endl);
                         nvxp->nodep()->dumpTree("-  ");
                     }
 
@@ -938,9 +933,9 @@ protected:
             if (!pruneMe) continue;
 
             // This if can be split; prune dependencies on it.
-            for (V3GraphEdge* edgep = logicp->inBeginp(); edgep; edgep = edgep->inNextp()) {
-                SplitEdge* const oedgep = static_cast<SplitEdge*>(edgep);
-                oedgep->setIgnoreThisStep();
+            for (V3GraphEdge& edge : logicp->inEdges()) {
+                SplitEdge& oedge = static_cast<SplitEdge&>(edge);
+                oedge.setIgnoreThisStep();
             }
         }
 

--- a/src/V3TSP.cpp
+++ b/src/V3TSP.cpp
@@ -415,8 +415,7 @@ public:
         std::vector<T_Key> result;
         for (const V3GraphVertex& vtx : vertices()) {
             const Vertex* const tspvp = castVertexp(&vtx);
-            uint32_t degree = 0;
-            for (const V3GraphEdge& _ : vtx.outEdges()) degree++;
+            const uint32_t degree = vtx.outEdges().size();
             if (degree & 1) result.push_back(tspvp->key());
         }
         return result;

--- a/src/V3Task.cpp
+++ b/src/V3Task.cpp
@@ -153,8 +153,8 @@ private:
                             << vxp->impureNode()->warnContextSecondary());
         }
         // And, we need to check all tasks this task calls
-        for (V3GraphEdge* edgep = vxp->outBeginp(); edgep; edgep = edgep->outNextp()) {
-            checkPurity(nodep, static_cast<TaskBaseVertex*>(edgep->top()));
+        for (V3GraphEdge& edge : vxp->outEdges()) {
+            checkPurity(nodep, static_cast<TaskBaseVertex*>(edge.top()));
         }
     }
     TaskFTaskVertex* getFTaskVertex(AstNodeFTask* nodep) {

--- a/src/V3VariableOrder.cpp
+++ b/src/V3VariableOrder.cpp
@@ -275,9 +275,8 @@ void V3VariableOrder::orderAll(AstNetlist* netlistp) {
     // Gather MTask affinities
     if (v3Global.opt.mtasks()) {
         netlistp->topModulep()->foreach([&](AstExecGraph* execGraphp) {
-            for (const V3GraphVertex* vtxp = execGraphp->depGraphp()->verticesBeginp(); vtxp;
-                 vtxp = vtxp->verticesNextp()) {
-                GatherMTaskAffinity::apply(vtxp->as<const ExecMTask>(), mTaskAffinity);
+            for (const V3GraphVertex& vtx : execGraphp->depGraphp()->vertices()) {
+                GatherMTaskAffinity::apply(vtx.as<const ExecMTask>(), mTaskAffinity);
             }
         });
     }


### PR DESCRIPTION
The endogenous V3List is great, but its user interface is a bit painful. I added a new implementation that looks a lot more like std::list. I know you have a thing about templates, but this is really a lot easier to work with. It works with range based for loops, and have type safe `list.push_back(element)` and similar. You just need to understand how to declare it which I will highlight below.

Draft as I only done DFG in case you want to veto this. If not I will do the other users of V3List as well. 

Ignore the code movement in V3Dfg.h, that was necessary as the elements must be declared before the lists that contain them. The other code shows how the usage changes.