### PR TITLE
Grammar: fix unique {} constraints missing semicolon from the spec

### DIFF
--- a/src/verilog.y
+++ b/src/verilog.y
@@ -7337,7 +7337,7 @@ constraint_expression<nodep>:  // ==IEEE: constraint_expression
                           $$ = newp; }
         //                      // 1800-2012:
         //                      // IEEE: uniqueness_constraint ';'
-        |       yUNIQUE '{' range_list '}'
+        |       yUNIQUE '{' range_list '}' ';'
                         { $$ = new AstConstraintUnique{$1, $3}; }
         //                      // IEEE: expr yP_MINUSGT constraint_set
         //                      // Conflicts with expr:"expr yP_MINUSGT expr"; rule moved there

--- a/test_regress/t/t_constraint_json_only.v
+++ b/test_regress/t/t_constraint_json_only.v
@@ -37,7 +37,7 @@ class Packet;
       foreach (array[i]) {
          array[i] inside {2, 4, 6};
       }
-      unique { array[0], array[1] }
+      unique { array[0], array[1] };
    }
 
    constraint order { solve length before header; }

--- a/test_regress/t/t_constraint_xml.v
+++ b/test_regress/t/t_constraint_xml.v
@@ -37,7 +37,7 @@ class Packet;
       foreach (array[i]) {
          array[i] inside {2, 4, 6};
       }
-      unique { array[0], array[1] }
+      unique { array[0], array[1] };
    }
 
    constraint order { solve length before header; }

--- a/test_regress/t/t_randomize.v
+++ b/test_regress/t/t_randomize.v
@@ -37,7 +37,7 @@ class Packet;
       foreach (array[i]) {
          array[i] inside {2, 4, 6};
       }
-      unique { array[0], array[1] }
+      unique { array[0], array[1] };
    }
 
    constraint order { solve length before header; }


### PR DESCRIPTION
A simple grammar fix for a missing semicolon.
Found this while working on #4947.