### PR TITLE
PreProc: do not ignore strings in joins

### DIFF
--- a/src/V3PreProc.cpp
+++ b/src/V3PreProc.cpp
@@ -1411,7 +1411,7 @@ int V3PreProcImp::getStateToken() {
             }
         }
         case ps_JOIN: {
-            if (tok == VP_SYMBOL || tok == VP_TEXT) {
+            if (tok == VP_SYMBOL || tok == VP_TEXT || tok == VP_STRING) {
                 UASSERT(!m_joinStack.empty(), "`` join stack empty, but in a ``");
                 const string lhs = m_joinStack.top();
                 m_joinStack.pop();
@@ -1423,7 +1423,7 @@ int V3PreProcImp::getStateToken() {
                 unputString(out);
                 statePop();
                 goto next_tok;
-            } else if (tok == VP_EOF || tok == VP_WHITE || tok == VP_COMMENT || tok == VP_STRING) {
+            } else if (tok == VP_EOF || tok == VP_WHITE || tok == VP_COMMENT) {
                 // Other compilers just ignore this, so no warning
                 // "Expecting symbol to terminate ``; whitespace etc cannot
                 // follow ``. Found: "+tokenName(tok)+"\n"

--- a/test_regress/t/t_preproc.out
+++ b/test_regress/t/t_preproc.out
@@ -1025,6 +1025,11 @@ Second line"""
 `line 707 "t/t_preproc.v" 0
  
  
+"string argument"
+
+`line 711 "t/t_preproc.v" 0
+ 
+ 
    
 predef 0 0
 predef 1 1
@@ -1045,4 +1050,4 @@ predef 2 2
  
  
 
-`line 729 "t/t_preproc.v" 0
+`line 733 "t/t_preproc.v" 0

--- a/test_regress/t/t_preproc.v
+++ b/test_regress/t/t_preproc.v
@@ -704,6 +704,10 @@ Second line"""
 `QQQ
 `QQQS("""QQQ defval""")
 
+// string concat bug
+`define IDENTITY(arg) ``arg
+`IDENTITY("string argument")
+
 //======================================================================
 // IEEE mandated predefines
 `undefineall  // undefineall should have no effect on these

--- a/test_regress/t/t_preproc_comments.out
+++ b/test_regress/t/t_preproc_comments.out
@@ -1028,6 +1028,11 @@ Second line"""
 """QQQ defval"""
 
 `line 707 "t/t_preproc.v" 0
+// string concat bug 
+ 
+"string argument"
+
+`line 711 "t/t_preproc.v" 0
 //====================================================================== 
 // IEEE mandated predefines 
   // undefineall should have no effect on these 
@@ -1050,4 +1055,4 @@ predef 2 2
 // After `undefineall above, for testing --dump-defines 
  
 
-`line 729 "t/t_preproc.v" 0
+`line 733 "t/t_preproc.v" 0


### PR DESCRIPTION
This adheres to the wording used in IEEE 1800-2017 22.5.1, specifying the join operator to be more of a delimiter than join:

> A `` delimits lexical tokens without introducing white space, allowing identifiers to be constructed from arguments.

Before, string RHS arguments to the join operator were silently dropped.