### PR TITLE
Support inside range with implicit type conversion

### DIFF
--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -2544,7 +2544,9 @@ class WidthVisitor final : public VNVisitor {
                      EXTEND_EXP);
         for (AstNode *nextip, *itemp = nodep->itemsp(); itemp; itemp = nextip) {
             nextip = itemp->nextp();  // iterate may cause the node to get replaced
-            iterateCheck(nodep, "Inside Item", itemp, CONTEXT_DET, FINAL, subDTypep, EXTEND_EXP);
+            // InsideRange will get replaced with Lte&Gte and finalized later
+            if (!VN_IS(itemp, InsideRange))
+                iterateCheck(nodep, "Inside Item", itemp, CONTEXT_DET, FINAL, subDTypep, EXTEND_EXP);
         }
 
         if (debug() >= 9) nodep->dumpTree("-  inside-in: ");

--- a/test_regress/t/t_inside.v
+++ b/test_regress/t/t_inside.v
@@ -57,6 +57,7 @@ module t;
       `checkh ((4'd3 inside {[4'd1:4'd2], [4'd3:4'd5]}), 1'b1);
       `checkh ((4'd4 inside {[4'd1:4'd2], [4'd3:4'd5]}), 1'b1);
       `checkh ((4'd5 inside {[4'd1:4'd2], [4'd3:4'd5]}), 1'b1);
+      `checkh ((4.0 inside {[4'd1:4'd2], [4'd3:4'd5]}), 1'b1);
       //
       // Unsupported $ bound
       //


### PR DESCRIPTION
Found this while working on randomization constraints.

Error message without the change:
```
%Error: Internal Error: t/t_inside.v:60:28: ../V3EmitCFunc.h:1437: Unknown node type reached emitter: INSIDERANGE                                             
   60 |       do if (((4.0 inside {[4'd1:4'd2], [4'd3:4'd5]})) !== (1'b1)) begin $write("%%Error: %s:%0d:  got='h%x exp='h%x\n", "t/t_inside.v",60, ((4.0 inside {[4'd1:4'd2], [4'd3:4'd5]})), (1'b1)); $stop; end while(0);;
      |                            ^                                           
                        ... See the manual at https://verilator.org/verilator_doc.html for more assistance.
```