### PR TITLE
Fix bound queue printing

### DIFF
--- a/include/verilated_types.h
+++ b/include/verilated_types.h
@@ -891,8 +891,8 @@ public:
     }
 };
 
-template <class T_Value>
-std::string VL_TO_STRING(const VlQueue<T_Value>& obj) {
+template <class T_Value, size_t T_MaxSize>
+std::string VL_TO_STRING(const VlQueue<T_Value, T_MaxSize>& obj) {
     return obj.to_string();
 }
 

--- a/test_regress/t/t_queue.v
+++ b/test_regress/t/t_queue.v
@@ -104,6 +104,7 @@ module t (/*AUTOARG*/
       begin
          // Strings
          string q[$];
+         string p[$:3];
          string v;
          int j = 0;
 
@@ -134,6 +135,7 @@ module t (/*AUTOARG*/
          //Unsup: `checkh(q[$], "b2");
 
          v = $sformatf("%p", q); `checks(v, "'{\"f2\", \"f1\", \"b1\", \"b2\"} ");
+         v = $sformatf("%p", p); `checks(v, "'{}");
 
          //Unsup: q.delete(1);
          //Unsup: v = q[1]; `checks(v, "b1");


### PR DESCRIPTION
`VL_TO_STRING` implementation for `VlQueue` only accepts parameterization of its subtype. `T_MaxSize` is assumed to be the default (= 0, i.e. unbound). Compilation fails when a bound queue is to be converted to string.

This PR adds a test of that case and a fix.
