### PR TITLE
Fix vpiName extra space at string end

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -54,6 +54,7 @@ Gianfranco Costamagna
 Glen Gibb
 Gökçe Aydos
 Graham Rushton
+Guanghui Hu
 Guokai Chen
 Gus Smith
 Gustav Svensk

--- a/src/V3Ast.cpp
+++ b/src/V3Ast.cpp
@@ -268,7 +268,6 @@ string AstNode::vpiName(const string& namein) {
 
         if (specialChar) {
             if (inEscapedIdent && (specialChar == '[' || specialChar == '.')) {
-                pretty += " ";
                 pretty.insert(lastIdent, "\\");
                 inEscapedIdent = false;
             }
@@ -284,10 +283,7 @@ string AstNode::vpiName(const string& namein) {
             ++pos;
         }
     }
-    if (inEscapedIdent) {
-        pretty += " ";
-        pretty.insert(lastIdent, "\\");
-    }
+    if (inEscapedIdent) { pretty.insert(lastIdent, "\\"); }
     if (pretty[0] == 'T' && pretty.substr(0, 4) == "TOP.") pretty.replace(0, 4, "");
     if (pretty[0] == 'T' && pretty.substr(0, 5) == "TOP->") pretty.replace(0, 5, "");
     return pretty;


### PR DESCRIPTION
vpiName append an extra space char for all escaped identifiers, but language specification require escaped identifiers end with white space (space, tab, newline)