### PR TITLE
Fix consecutive `#0`s

### DIFF
--- a/include/verilated_timing.h
+++ b/include/verilated_timing.h
@@ -165,6 +165,9 @@ class VlDelayScheduler final {
     VerilatedContext& m_context;
     VlDelayedCoroutineQueue m_queue;  // Coroutines to be restored at a certain simulation time
     std::vector<VlCoroutineHandle> m_zeroDelayed;  // Coroutines waiting for #0
+    std::vector<VlCoroutineHandle> m_zeroDlyResumed;  // Coroutines that waited for #0 and are
+                                                      // to be resumed. Kept as a field to avoid
+                                                      // reallocation.
 
 public:
     // CONSTRUCTORS

--- a/test_regress/t/t_timing_zerodly_consecutive.pl
+++ b/test_regress/t/t_timing_zerodly_consecutive.pl
@@ -1,0 +1,22 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2020 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    verilator_flags2 => ["--exe --main --timing"],
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_timing_zerodly_consecutive.v
+++ b/test_regress/t/t_timing_zerodly_consecutive.v
@@ -1,0 +1,14 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2024 by Antmicro.
+// SPDX-License-Identifier: CC0-1.0
+
+module t;
+  initial begin
+    #0;
+    #0;
+    $write("*-* All Finished *-*\n");
+    $finish;
+  end
+endmodule


### PR DESCRIPTION
Fixes an issue where if a coroutine resumed from `#0` suspends on `#0` again caused segfaults or infinite looping. See added comments for more details.