### PR TITLE
Fix attempted to destroy locked thread pool error

### DIFF
--- a/src/V3ThreadPool.h
+++ b/src/V3ThreadPool.h
@@ -115,6 +115,7 @@ class V3ThreadPool final {
     // CONSTRUCTORS
     V3ThreadPool() = default;
     ~V3ThreadPool() {
+        m_shutdown = true;
         if (m_multithreadingSuspended) {
             // Ideally we shouldn't deal with this and just call the std::abort. However,
             // std::exit(0) (which invokes this destructor) is called in multiple places with

--- a/src/V3ThreadPool.h
+++ b/src/V3ThreadPool.h
@@ -144,7 +144,7 @@ class V3ThreadPool final {
         // try to obtain lock with timeout
         // we need to wait for workers to start waiting
         // on condition variable to perform destruction
-        constexpr int spins = 10s / 1ms;
+        constexpr int spins = 1s / 1ms;
         for (int i = 0; i < spins; ++i) {
             if (VL_LIKELY(m_mutex_locked)) break;
             std::this_thread::sleep_for(1ms);


### PR DESCRIPTION
After increasing number of splits, splitted cfuncs and verilate jobs in the `t_sv_cpu.pl` test, I was able to still reproduce issue https://github.com/verilator/verilator/issues/4931.

Flags for `t_sv_cpu.pl` test:
```
verilator_flags2 => ["-y t/t_sv_cpu_code +libext+.sv+ +incdir+t/t_sv_cpu_code --top-module t",
                         "--timescale-override 1ns/1ps --output-split 100000 --output-split-cfuncs 100000 --verilate-jobs 100"],
```
Issue appears once per ~5mins during repeated runs in gdb.

I have identified that simply spin-locking mutex `VL_LOCK_SPINS` times (currently set to 50000) does not give enough time for the workers to release lock while waiting on the `std::condition_variable_any`; `m_cv`.

This issue appears during successful runs, thus clean exit is required not to fail test suite.

I propose the following fixe to this problem: 
- add timeout for locking mutex in `~ThreadPool`; this will give more time for workers to terminate gracefully, or unlock mutex while waiting on `condition_variable` `m_cv`. Timeout is currently set to 10 seconds.

This is not an ideal solution to this problem. It probably slows down Verilator shutdown, by waiting in `~ThreadPool` destructor for all workers to finish instead of killing them. Additionally, there still exist a chance that destruction will not be successful and will end with `std::abort`.