### PR TITLE
Support empty queue as dynarray default value

### DIFF
--- a/src/V3Task.cpp
+++ b/src/V3Task.cpp
@@ -1839,10 +1839,13 @@ AstNodeFTask* V3Task::taskConnectWrapNew(AstNodeFTask* taskp, const string& newn
             newPortp->funcLocal(true);
             newTaskp->addStmtsp(newPortp);
             // Runtime-assign it to the default
-            AstAssign* const newAssignp = new AstAssign{
-                valuep->fileline(), new AstVarRef{valuep->fileline(), newPortp, VAccess::WRITE},
-                valuep->cloneTree(true)};
-            newTaskp->addStmtsp(newAssignp);
+            if (!VN_IS(valuep, EmptyQueue)) {
+                AstAssign* const newAssignp
+                    = new AstAssign{valuep->fileline(),
+                                    new AstVarRef{valuep->fileline(), newPortp, VAccess::WRITE},
+                                    valuep->cloneTree(true)};
+                newTaskp->addStmtsp(newAssignp);
+            }
         }
         oldNewVars.emplace(portp, newPortp);
         const VAccess pinAccess = portp->isWritable() ? VAccess::WRITE : VAccess::READ;

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -1228,7 +1228,7 @@ class WidthVisitor final : public VNVisitor {
     }
     void visit(AstEmptyQueue* nodep) override {
         nodep->dtypeSetEmptyQueue();
-        if (!VN_IS(nodep->backp(), Assign)) {
+        if (!VN_IS(nodep->backp(), Assign) && !VN_IS(nodep->backp(), Var)) {
             nodep->v3warn(E_UNSUPPORTED,
                           "Unsupported/Illegal: empty queue ('{}') in this context");
         }
@@ -4888,7 +4888,8 @@ class WidthVisitor final : public VNVisitor {
         }
         if (VN_IS(nodep->rhsp(), EmptyQueue)) {
             UINFO(9, "= {} -> .delete(): " << nodep);
-            if (!VN_IS(nodep->lhsp()->dtypep()->skipRefp(), QueueDType)) {
+            const AstNodeDType* const lhsDtp = nodep->lhsp()->dtypep()->skipRefp();
+            if (!VN_IS(lhsDtp, QueueDType) && !VN_IS(lhsDtp, DynArrayDType)) {
                 nodep->v3warn(E_UNSUPPORTED,
                               "Unsupported/Illegal: empty queue ('{}') in this assign context");
                 VL_DO_DANGLING(pushDeletep(nodep->unlinkFrBack()), nodep);

--- a/test_regress/t/t_dynarray_init.v
+++ b/test_regress/t/t_dynarray_init.v
@@ -13,6 +13,7 @@ module t (/*AUTOARG*/);
    int a2[] = {14, 15};
    int a3[] = '{16};
    int a4[] = {17};
+   int a5[] = {};
 
    initial begin
       `checkh(a1.size, 2);
@@ -28,6 +29,8 @@ module t (/*AUTOARG*/);
 
       `checkh(a4.size, 1);
       `checkh(a4[0], 17);
+
+      `checkh(a5.size, 0);
 
       $write("*-* All Finished *-*\n");
       $finish;

--- a/test_regress/t/t_queue_empty_pin.pl
+++ b/test_regress/t/t_queue_empty_pin.pl
@@ -1,0 +1,21 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2022 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_queue_empty_pin.v
+++ b/test_regress/t/t_queue_empty_pin.v
@@ -1,0 +1,18 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2024 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+module t (/*AUTOARG*/);
+   task tsk(int q[] = {});
+      if (q.size != 0) $stop;
+   endtask
+
+   initial begin
+      tsk();
+
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end
+endmodule


### PR DESCRIPTION
Previous error messages:
```
%Error-UNSUPPORTED: t/t_dynarray_init.v:16:15: Unsupported/Illegal: empty queue ('{}') in this assign context
                                             : ... note: In instance 't'
   16 |    int a5[] = {};
      |               ^
%Error-UNSUPPORTED: t/t_queue_empty_pin.v:8:23: Unsupported/Illegal: empty queue ('{}') in this context
                                              : ... note: In instance 't'
    8 |    task tsk(int q[] = {});
      |                       ^
```