### PR TITLE
Make AstConstraint an AstNodeFTask

### DIFF
--- a/src/V3AstNodeOther.h
+++ b/src/V3AstNodeOther.h
@@ -1003,25 +1003,6 @@ public:
     // false, the returned VarScope will have _->dtypep()->sameTree(initp->dtypep()) return true.
     AstVarScope* findConst(AstConst* initp, bool mergeDType);
 };
-class AstConstraint final : public AstNode {
-    // Constraint
-    // @astgen op1 := itemsp : List[AstNode]
-    string m_name;  // Name of constraint
-    bool m_isStatic = false;  // static constraint
-public:
-    AstConstraint(FileLine* fl, const string& name, AstNode* itemsp)
-        : ASTGEN_SUPER_Constraint(fl)
-        , m_name(name) {
-        this->addItemsp(itemsp);
-    }
-    ASTGEN_MEMBERS_AstConstraint;
-    string name() const override VL_MT_STABLE { return m_name; }  // * = Scope name
-    bool isGateOptimizable() const override { return false; }
-    bool isPredictOptimizable() const override { return false; }
-    bool same(const AstNode* /*samep*/) const override { return true; }
-    void isStatic(bool flag) { m_isStatic = flag; }
-    bool isStatic() const { return m_isStatic; }
-};
 class AstConstraintBefore final : public AstNode {
     // Constraint solve before item
     // @astgen op1 := lhssp : List[AstNodeExpr]
@@ -2208,6 +2189,16 @@ public:
 };
 
 // === AstNodeFTask ===
+class AstConstraint final : public AstNodeFTask {
+    // Constraint
+public:
+    AstConstraint(FileLine* fl, const string& name, AstNode* stmtsp)
+        : ASTGEN_SUPER_Constraint(fl, name, stmtsp) {}
+    ASTGEN_MEMBERS_AstConstraint;
+    AstNodeFTask* cloneType(const string& name) override {
+        return new AstConstraint{fileline(), name, nullptr};
+    }
+};
 class AstFunc final : public AstNodeFTask {
     // A function inside a module
 public:

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -2817,18 +2817,18 @@ class WidthVisitor final : public VNVisitor {
                     VL_DO_DANGLING(pushDeletep(nodep), nodep);
                     return true;
                 }
-                if (VN_IS(foundp, NodeFTask)) {
-                    nodep->replaceWith(new AstMethodCall{nodep->fileline(),
-                                                         nodep->fromp()->unlinkFrBack(),
-                                                         nodep->name(), nullptr});
-                    VL_DO_DANGLING(pushDeletep(nodep), nodep);
-                    return true;
-                }
                 if (VN_IS(foundp, Constraint)) {
                     // We don't support constraints yet, so just keep as unlinked for now
                     // Presumably we'll next see a constraint_mode AstMethodCall
                     nodep->dtypep(nodep->findConstraintRefDType());
                     UINFO(9, "Unsupported constraint select " << nodep << endl);
+                    return true;
+                }
+                if (VN_IS(foundp, NodeFTask)) {
+                    nodep->replaceWith(new AstMethodCall{nodep->fileline(),
+                                                         nodep->fromp()->unlinkFrBack(),
+                                                         nodep->name(), nullptr});
+                    VL_DO_DANGLING(pushDeletep(nodep), nodep);
                     return true;
                 }
                 UINFO(1, "found object " << foundp << endl);

--- a/src/verilog.y
+++ b/src/verilog.y
@@ -7275,7 +7275,7 @@ class_constraint<constraintp>:  // ==IEEE: class_constraint
         //                      // UNSUP: We have the unsupported warning on the randomize() call, so don't bother on
         //                      // constraint blocks. When we support randomize we need to make AST nodes for below rules
                 constraintStaticE yCONSTRAINT dynamic_override_specifiersE constraintIdNew constraint_block
-                        { $$ = $4; $$->isStatic($1); $$->addItemsp($5); SYMP->popScope($$); }
+                        { $$ = $4; $$->isStatic($1); $$->addStmtsp($5); SYMP->popScope($$); }
         |       constraintStaticE yCONSTRAINT dynamic_override_specifiersE constraintIdNew '{' '}'
                         { $$ = $4; $$->isStatic($1); SYMP->popScope($$); }
         //                      // IEEE: constraint_prototype + constraint_prototype_qualifier

--- a/test_regress/t/t_constraint_json_only.out
+++ b/test_regress/t/t_constraint_json_only.out
@@ -1,17 +1,17 @@
 {"type":"NETLIST","name":"$root","addr":"(B)","loc":"a,0:0,0:0","timeunit":"1ps","timeprecision":"1ps","typeTablep":"(C)","constPoolp":"(D)","dollarUnitPkgp":"(E)","stdPackagep":"UNLINKED","evalp":"UNLINKED","evalNbap":"UNLINKED","dpiExportTriggerp":"UNLINKED","delaySchedulerp":"UNLINKED","nbaEventp":"UNLINKED","nbaEventTriggerp":"UNLINKED","topScopep":"UNLINKED",
  "modulesp": [
-  {"type":"MODULE","name":"t","addr":"(F)","loc":"d,53:8,53:9","origName":"t","level":0,"modPublic":false,"inLibrary":false,"dead":false,"recursiveClone":false,"recursive":false,"timeunit":"1ps","inlinesp": [],
+  {"type":"MODULE","name":"t","addr":"(F)","loc":"d,65:8,65:9","origName":"t","level":0,"modPublic":false,"inLibrary":false,"dead":false,"recursiveClone":false,"recursive":false,"timeunit":"1ps","inlinesp": [],
    "stmtsp": [
-    {"type":"VAR","name":"p","addr":"(G)","loc":"d,55:11,55:12","dtypep":"(H)","origName":"p","isSc":false,"isPrimaryIO":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"attrClocker":"UNKNOWN","lifetime":"VSTATIC","varType":"VAR","dtypeName":"Packet","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
-    {"type":"INITIAL","name":"","addr":"(I)","loc":"d,57:4,57:11","isSuspendable":false,"needProcess":false,
+    {"type":"VAR","name":"p","addr":"(G)","loc":"d,67:11,67:12","dtypep":"(H)","origName":"p","isSc":false,"isPrimaryIO":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"attrClocker":"UNKNOWN","lifetime":"VSTATIC","varType":"VAR","dtypeName":"Packet","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
+    {"type":"INITIAL","name":"","addr":"(I)","loc":"d,69:4,69:11","isSuspendable":false,"needProcess":false,
      "stmtsp": [
-      {"type":"BEGIN","name":"","addr":"(J)","loc":"d,57:12,57:17","generate":false,"genfor":false,"implied":false,"needProcess":false,"unnamed":true,"genforp": [],
+      {"type":"BEGIN","name":"","addr":"(J)","loc":"d,69:12,69:17","generate":false,"genfor":false,"implied":false,"needProcess":false,"unnamed":true,"genforp": [],
        "stmtsp": [
-        {"type":"DISPLAY","name":"","addr":"(K)","loc":"d,59:7,59:13",
+        {"type":"DISPLAY","name":"","addr":"(K)","loc":"d,71:7,71:13",
          "fmtp": [
-          {"type":"SFORMATF","name":"*-* All Finished *-*\\n","addr":"(L)","loc":"d,59:7,59:13","dtypep":"(M)","exprsp": [],"scopeNamep": []}
+          {"type":"SFORMATF","name":"*-* All Finished *-*\\n","addr":"(L)","loc":"d,71:7,71:13","dtypep":"(M)","exprsp": [],"scopeNamep": []}
         ],"filep": []},
-        {"type":"FINISH","name":"","addr":"(N)","loc":"d,60:7,60:14"}
+        {"type":"FINISH","name":"","addr":"(N)","loc":"d,72:7,72:14"}
       ]}
     ]}
   ],"activesp": []},
@@ -24,36 +24,60 @@
       {"type":"VAR","name":"sublength","addr":"(S)","loc":"d,10:13,10:22","dtypep":"(Q)","origName":"sublength","isSc":false,"isPrimaryIO":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"attrClocker":"UNKNOWN","lifetime":"VAUTOM","varType":"MEMBER","dtypeName":"int","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
       {"type":"VAR","name":"if_4","addr":"(T)","loc":"d,11:13,11:17","dtypep":"(U)","origName":"if_4","isSc":false,"isPrimaryIO":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"attrClocker":"UNKNOWN","lifetime":"VAUTOM","varType":"MEMBER","dtypeName":"bit","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
       {"type":"VAR","name":"iff_5_6","addr":"(V)","loc":"d,12:13,12:20","dtypep":"(U)","origName":"iff_5_6","isSc":false,"isPrimaryIO":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"attrClocker":"UNKNOWN","lifetime":"VAUTOM","varType":"MEMBER","dtypeName":"bit","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
-      {"type":"VAR","name":"array","addr":"(W)","loc":"d,14:13,14:18","dtypep":"(X)","origName":"array","isSc":false,"isPrimaryIO":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"attrClocker":"UNKNOWN","lifetime":"VAUTOM","varType":"MEMBER","dtypeName":"","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
-      {"type":"FUNC","name":"new","addr":"(Y)","loc":"d,7:1,7:6","dtypep":"(Z)","method":true,"dpiExport":false,"dpiImport":false,"dpiOpenChild":false,"dpiOpenParent":false,"prototype":false,"recursive":false,"taskPublic":false,"cname":"new","fvarp": [],"classOrPackagep": [],"stmtsp": [],"scopeNamep": []}
+      {"type":"VAR","name":"if_state_ok","addr":"(W)","loc":"d,13:13,13:24","dtypep":"(U)","origName":"if_state_ok","isSc":false,"isPrimaryIO":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"attrClocker":"UNKNOWN","lifetime":"VAUTOM","varType":"MEMBER","dtypeName":"bit","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
+      {"type":"VAR","name":"array","addr":"(X)","loc":"d,15:13,15:18","dtypep":"(Y)","origName":"array","isSc":false,"isPrimaryIO":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"attrClocker":"UNKNOWN","lifetime":"VAUTOM","varType":"MEMBER","dtypeName":"","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
+      {"type":"VAR","name":"state","addr":"(Z)","loc":"d,17:11,17:16","dtypep":"(M)","origName":"state","isSc":false,"isPrimaryIO":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"attrClocker":"UNKNOWN","lifetime":"VAUTOM","varType":"MEMBER","dtypeName":"string","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
+      {"type":"FUNC","name":"strings_equal","addr":"(AB)","loc":"d,59:17,59:30","dtypep":"(U)","method":true,"dpiExport":false,"dpiImport":false,"dpiOpenChild":false,"dpiOpenParent":false,"prototype":false,"recursive":false,"taskPublic":false,"cname":"strings_equal",
+       "fvarp": [
+        {"type":"VAR","name":"strings_equal","addr":"(BB)","loc":"d,59:17,59:30","dtypep":"(U)","origName":"strings_equal","isSc":false,"isPrimaryIO":false,"direction":"OUTPUT","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":true,"isFuncLocal":true,"attrClocker":"UNKNOWN","lifetime":"VAUTOM","varType":"MEMBER","dtypeName":"bit","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []}
+      ],"classOrPackagep": [],
+       "stmtsp": [
+        {"type":"VAR","name":"a","addr":"(CB)","loc":"d,59:38,59:39","dtypep":"(M)","origName":"a","isSc":false,"isPrimaryIO":false,"direction":"INPUT","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":true,"attrClocker":"UNKNOWN","lifetime":"VAUTOM","varType":"MEMBER","dtypeName":"string","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
+        {"type":"VAR","name":"b","addr":"(DB)","loc":"d,59:48,59:49","dtypep":"(M)","origName":"b","isSc":false,"isPrimaryIO":false,"direction":"INPUT","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":true,"attrClocker":"UNKNOWN","lifetime":"VAUTOM","varType":"MEMBER","dtypeName":"string","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
+        {"type":"ASSIGN","name":"","addr":"(EB)","loc":"d,60:7,60:13","dtypep":"(U)",
+         "rhsp": [
+          {"type":"EQN","name":"","addr":"(FB)","loc":"d,60:16,60:18","dtypep":"(GB)",
+           "lhsp": [
+            {"type":"VARREF","name":"a","addr":"(HB)","loc":"d,60:14,60:15","dtypep":"(M)","access":"RD","varp":"(CB)","varScopep":"UNLINKED","classOrPackagep":"(O)"}
+          ],
+           "rhsp": [
+            {"type":"VARREF","name":"b","addr":"(IB)","loc":"d,60:19,60:20","dtypep":"(M)","access":"RD","varp":"(DB)","varScopep":"UNLINKED","classOrPackagep":"(O)"}
+          ]}
+        ],
+         "lhsp": [
+          {"type":"VARREF","name":"strings_equal","addr":"(JB)","loc":"d,60:7,60:13","dtypep":"(U)","access":"WR","varp":"(BB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        ],"timingControlp": []}
+      ],"scopeNamep": []},
+      {"type":"FUNC","name":"new","addr":"(KB)","loc":"d,7:1,7:6","dtypep":"(LB)","method":true,"dpiExport":false,"dpiImport":false,"dpiOpenChild":false,"dpiOpenParent":false,"prototype":false,"recursive":false,"taskPublic":false,"cname":"new","fvarp": [],"classOrPackagep": [],"stmtsp": [],"scopeNamep": []}
     ],"activesp": [],"extendsp": []}
   ],"activesp": []}
 ],"filesp": [],
  "miscsp": [
-  {"type":"TYPETABLE","name":"","addr":"(C)","loc":"a,0:0,0:0","constraintRefp":"UNLINKED","emptyQueuep":"UNLINKED","queueIndexp":"UNLINKED","streamp":"UNLINKED","voidp":"(Z)",
+  {"type":"TYPETABLE","name":"","addr":"(C)","loc":"a,0:0,0:0","constraintRefp":"UNLINKED","emptyQueuep":"UNLINKED","queueIndexp":"UNLINKED","streamp":"UNLINKED","voidp":"(LB)",
    "typesp": [
-    {"type":"BASICDTYPE","name":"logic","addr":"(AB)","loc":"d,22:21,22:22","dtypep":"(AB)","keyword":"logic","range":"31:0","generic":true,"rangep": []},
-    {"type":"BASICDTYPE","name":"string","addr":"(M)","loc":"d,59:7,59:13","dtypep":"(M)","keyword":"string","generic":true,"rangep": []},
+    {"type":"BASICDTYPE","name":"logic","addr":"(GB)","loc":"d,22:14,22:15","dtypep":"(GB)","keyword":"logic","generic":true,"rangep": []},
+    {"type":"BASICDTYPE","name":"logic","addr":"(MB)","loc":"d,25:21,25:22","dtypep":"(MB)","keyword":"logic","range":"31:0","generic":true,"rangep": []},
+    {"type":"BASICDTYPE","name":"string","addr":"(M)","loc":"d,71:7,71:13","dtypep":"(M)","keyword":"string","generic":true,"rangep": []},
     {"type":"BASICDTYPE","name":"int","addr":"(Q)","loc":"d,8:9,8:12","dtypep":"(Q)","keyword":"int","range":"31:0","generic":true,"rangep": []},
     {"type":"BASICDTYPE","name":"bit","addr":"(U)","loc":"d,11:9,11:12","dtypep":"(U)","keyword":"bit","generic":true,"rangep": []},
-    {"type":"UNPACKARRAYDTYPE","name":"","addr":"(X)","loc":"d,14:18,14:19","dtypep":"(X)","isCompound":false,"declRange":"[0:1]","generic":false,"refDTypep":"(Q)","childDTypep": [],
+    {"type":"UNPACKARRAYDTYPE","name":"","addr":"(Y)","loc":"d,15:18,15:19","dtypep":"(Y)","isCompound":false,"declRange":"[0:1]","generic":false,"refDTypep":"(Q)","childDTypep": [],
      "rangep": [
-      {"type":"RANGE","name":"","addr":"(BB)","loc":"d,14:18,14:19","ascending":true,
+      {"type":"RANGE","name":"","addr":"(NB)","loc":"d,15:18,15:19","ascending":true,
        "leftp": [
-        {"type":"CONST","name":"32'h0","addr":"(CB)","loc":"d,14:19,14:20","dtypep":"(AB)"}
+        {"type":"CONST","name":"32'h0","addr":"(OB)","loc":"d,15:19,15:20","dtypep":"(MB)"}
       ],
        "rightp": [
-        {"type":"CONST","name":"32'h1","addr":"(DB)","loc":"d,14:19,14:20","dtypep":"(AB)"}
+        {"type":"CONST","name":"32'h1","addr":"(PB)","loc":"d,15:19,15:20","dtypep":"(MB)"}
       ]}
     ]},
-    {"type":"VOIDDTYPE","name":"","addr":"(Z)","loc":"d,7:1,7:6","dtypep":"(Z)","generic":false},
-    {"type":"CLASSREFDTYPE","name":"Packet","addr":"(H)","loc":"d,55:4,55:10","dtypep":"(H)","generic":false,"classp":"(O)","classOrPackagep":"(O)","paramsp": []}
+    {"type":"VOIDDTYPE","name":"","addr":"(LB)","loc":"d,7:1,7:6","dtypep":"(LB)","generic":false},
+    {"type":"CLASSREFDTYPE","name":"Packet","addr":"(H)","loc":"d,67:4,67:10","dtypep":"(H)","generic":false,"classp":"(O)","classOrPackagep":"(O)","paramsp": []}
   ]},
   {"type":"CONSTPOOL","name":"","addr":"(D)","loc":"a,0:0,0:0",
    "modulep": [
-    {"type":"MODULE","name":"@CONST-POOL@","addr":"(EB)","loc":"a,0:0,0:0","origName":"@CONST-POOL@","level":0,"modPublic":false,"inLibrary":false,"dead":false,"recursiveClone":false,"recursive":false,"timeunit":"NONE","inlinesp": [],
+    {"type":"MODULE","name":"@CONST-POOL@","addr":"(QB)","loc":"a,0:0,0:0","origName":"@CONST-POOL@","level":0,"modPublic":false,"inLibrary":false,"dead":false,"recursiveClone":false,"recursive":false,"timeunit":"NONE","inlinesp": [],
      "stmtsp": [
-      {"type":"SCOPE","name":"@CONST-POOL@","addr":"(FB)","loc":"a,0:0,0:0","aboveScopep":"UNLINKED","aboveCellp":"UNLINKED","modp":"(EB)","varsp": [],"blocksp": [],"inlinesp": []}
+      {"type":"SCOPE","name":"@CONST-POOL@","addr":"(RB)","loc":"a,0:0,0:0","aboveScopep":"UNLINKED","aboveCellp":"UNLINKED","modp":"(QB)","varsp": [],"blocksp": [],"inlinesp": []}
     ],"activesp": []}
   ]}
 ]}

--- a/test_regress/t/t_constraint_json_only.v
+++ b/test_regress/t/t_constraint_json_only.v
@@ -10,8 +10,11 @@ class Packet;
    rand int sublength; // 0..15
    rand bit if_4;
    rand bit iff_5_6;
+   rand bit if_state_ok;
 
    rand int array[2];  // 2,4,6
+
+   string state;
 
    constraint empty {}
 
@@ -47,6 +50,15 @@ class Packet;
       disable soft sublength;
       sublength <= length;
    }
+
+   constraint meth {
+      if (strings_equal(state, "ok"))
+         if_state_ok == '1;
+   }
+
+   function bit strings_equal(string a, string b);
+      return a == b;
+   endfunction
 
 endclass
 

--- a/test_regress/t/t_constraint_xml.out
+++ b/test_regress/t/t_constraint_xml.out
@@ -11,17 +11,17 @@
     <file id="d" filename="t/t_constraint_xml.v" language="1800-2023"/>
   </module_files>
   <cells>
-    <cell loc="d,53,8,53,9" name="t" submodname="t" hier="t"/>
+    <cell loc="d,65,8,65,9" name="t" submodname="t" hier="t"/>
   </cells>
   <netlist>
-    <module loc="d,53,8,53,9" name="t" origName="t">
-      <var loc="d,55,11,55,12" name="p" dtype_id="1" vartype="Packet" origName="p"/>
-      <initial loc="d,57,4,57,11">
-        <begin loc="d,57,12,57,17">
-          <display loc="d,59,7,59,13" displaytype="$write">
-            <sformatf loc="d,59,7,59,13" name="*-* All Finished *-*&#10;" dtype_id="2"/>
+    <module loc="d,65,8,65,9" name="t" origName="t">
+      <var loc="d,67,11,67,12" name="p" dtype_id="1" vartype="Packet" origName="p"/>
+      <initial loc="d,69,4,69,11">
+        <begin loc="d,69,12,69,17">
+          <display loc="d,71,7,71,13" displaytype="$write">
+            <sformatf loc="d,71,7,71,13" name="*-* All Finished *-*&#10;" dtype_id="2"/>
           </display>
-          <finish loc="d,60,7,60,14"/>
+          <finish loc="d,72,7,72,14"/>
         </begin>
       </initial>
     </module>
@@ -32,171 +32,202 @@
         <var loc="d,10,13,10,22" name="sublength" dtype_id="3" vartype="int" origName="sublength"/>
         <var loc="d,11,13,11,17" name="if_4" dtype_id="4" vartype="bit" origName="if_4"/>
         <var loc="d,12,13,12,20" name="iff_5_6" dtype_id="4" vartype="bit" origName="iff_5_6"/>
-        <var loc="d,14,13,14,18" name="array" dtype_id="5" vartype="" origName="array"/>
-        <constraint loc="d,16,15,16,20" name="empty"/>
-        <constraint loc="d,18,15,18,19" name="size">
-          <constraintexpr loc="d,19,18,19,20">
-            <and loc="d,19,18,19,20" dtype_id="6">
-              <lts loc="d,19,14,19,15" dtype_id="6">
-                <const loc="d,19,16,19,17" name="32&apos;sh0" dtype_id="7"/>
-                <varref loc="d,19,7,19,13" name="header" dtype_id="3"/>
+        <var loc="d,13,13,13,24" name="if_state_ok" dtype_id="4" vartype="bit" origName="if_state_ok"/>
+        <var loc="d,15,13,15,18" name="array" dtype_id="5" vartype="" origName="array"/>
+        <var loc="d,17,11,17,16" name="state" dtype_id="2" vartype="string" origName="state"/>
+        <constraint loc="d,19,15,19,20" name="empty"/>
+        <constraint loc="d,21,15,21,19" name="size">
+          <constraintexpr loc="d,22,18,22,20">
+            <and loc="d,22,18,22,20" dtype_id="6">
+              <lts loc="d,22,14,22,15" dtype_id="6">
+                <const loc="d,22,16,22,17" name="32&apos;sh0" dtype_id="7"/>
+                <varref loc="d,22,7,22,13" name="header" dtype_id="3"/>
               </lts>
-              <gtes loc="d,19,28,19,30" dtype_id="6">
-                <const loc="d,19,31,19,32" name="32&apos;sh7" dtype_id="7"/>
-                <varref loc="d,19,21,19,27" name="header" dtype_id="3"/>
+              <gtes loc="d,22,28,22,30" dtype_id="6">
+                <const loc="d,22,31,22,32" name="32&apos;sh7" dtype_id="7"/>
+                <varref loc="d,22,21,22,27" name="header" dtype_id="3"/>
               </gtes>
             </and>
           </constraintexpr>
-          <constraintexpr loc="d,20,14,20,16">
-            <gtes loc="d,20,14,20,16" dtype_id="6">
-              <const loc="d,20,17,20,19" name="32&apos;shf" dtype_id="7"/>
-              <varref loc="d,20,7,20,13" name="length" dtype_id="3"/>
+          <constraintexpr loc="d,23,14,23,16">
+            <gtes loc="d,23,14,23,16" dtype_id="6">
+              <const loc="d,23,17,23,19" name="32&apos;shf" dtype_id="7"/>
+              <varref loc="d,23,7,23,13" name="length" dtype_id="3"/>
             </gtes>
           </constraintexpr>
-          <constraintexpr loc="d,21,14,21,16">
-            <gtes loc="d,21,14,21,16" dtype_id="6">
-              <varref loc="d,21,7,21,13" name="length" dtype_id="3"/>
-              <varref loc="d,21,17,21,23" name="header" dtype_id="3"/>
+          <constraintexpr loc="d,24,14,24,16">
+            <gtes loc="d,24,14,24,16" dtype_id="6">
+              <varref loc="d,24,7,24,13" name="length" dtype_id="3"/>
+              <varref loc="d,24,17,24,23" name="header" dtype_id="3"/>
             </gtes>
           </constraintexpr>
-          <constraintexpr loc="d,22,7,22,13">
-            <varref loc="d,22,7,22,13" name="length" dtype_id="3"/>
+          <constraintexpr loc="d,25,7,25,13">
+            <varref loc="d,25,7,25,13" name="length" dtype_id="3"/>
           </constraintexpr>
         </constraint>
-        <constraint loc="d,25,15,25,18" name="ifs">
-          <if loc="d,26,7,26,9">
-            <lts loc="d,26,18,26,19" dtype_id="6">
-              <const loc="d,26,20,26,21" name="32&apos;sh4" dtype_id="7"/>
-              <varref loc="d,26,11,26,17" name="header" dtype_id="3"/>
+        <constraint loc="d,28,15,28,18" name="ifs">
+          <if loc="d,29,7,29,9">
+            <lts loc="d,29,18,29,19" dtype_id="6">
+              <const loc="d,29,20,29,21" name="32&apos;sh4" dtype_id="7"/>
+              <varref loc="d,29,11,29,17" name="header" dtype_id="3"/>
             </lts>
             <begin>
-              <constraintexpr loc="d,27,15,27,17">
-                <varref loc="d,27,10,27,14" name="if_4" dtype_id="6"/>
+              <constraintexpr loc="d,30,15,30,17">
+                <varref loc="d,30,10,30,14" name="if_4" dtype_id="6"/>
               </constraintexpr>
             </begin>
           </if>
-          <if loc="d,29,7,29,9">
-            <or loc="d,29,23,29,25" dtype_id="6">
-              <eq loc="d,29,18,29,20" dtype_id="6">
-                <const loc="d,29,21,29,22" name="32&apos;sh5" dtype_id="7"/>
-                <varref loc="d,29,11,29,17" name="header" dtype_id="3"/>
+          <if loc="d,32,7,32,9">
+            <or loc="d,32,23,32,25" dtype_id="6">
+              <eq loc="d,32,18,32,20" dtype_id="6">
+                <const loc="d,32,21,32,22" name="32&apos;sh5" dtype_id="7"/>
+                <varref loc="d,32,11,32,17" name="header" dtype_id="3"/>
               </eq>
-              <eq loc="d,29,33,29,35" dtype_id="6">
-                <const loc="d,29,36,29,37" name="32&apos;sh6" dtype_id="7"/>
-                <varref loc="d,29,26,29,32" name="header" dtype_id="3"/>
+              <eq loc="d,32,33,32,35" dtype_id="6">
+                <const loc="d,32,36,32,37" name="32&apos;sh6" dtype_id="7"/>
+                <varref loc="d,32,26,32,32" name="header" dtype_id="3"/>
               </eq>
             </or>
             <begin>
-              <constraintexpr loc="d,30,18,30,20">
-                <varref loc="d,30,10,30,17" name="iff_5_6" dtype_id="6"/>
+              <constraintexpr loc="d,33,18,33,20">
+                <varref loc="d,33,10,33,17" name="iff_5_6" dtype_id="6"/>
               </constraintexpr>
             </begin>
             <begin>
-              <constraintexpr loc="d,32,18,32,20">
-                <not loc="d,32,18,32,20" dtype_id="4">
-                  <varref loc="d,32,10,32,17" name="iff_5_6" dtype_id="4"/>
+              <constraintexpr loc="d,35,18,35,20">
+                <not loc="d,35,18,35,20" dtype_id="4">
+                  <varref loc="d,35,10,35,17" name="iff_5_6" dtype_id="4"/>
                 </not>
               </constraintexpr>
             </begin>
           </if>
         </constraint>
-        <constraint loc="d,36,15,36,23" name="arr_uniq">
-          <constraintforeach loc="d,37,7,37,14">
-            <selloopvars loc="d,37,21,37,22">
-              <varref loc="d,37,16,37,21" name="array" dtype_id="5"/>
-              <var loc="d,37,22,37,23" name="i" dtype_id="8" vartype="integer" origName="i"/>
+        <constraint loc="d,39,15,39,23" name="arr_uniq">
+          <constraintforeach loc="d,40,7,40,14">
+            <selloopvars loc="d,40,21,40,22">
+              <varref loc="d,40,16,40,21" name="array" dtype_id="5"/>
+              <var loc="d,40,22,40,23" name="i" dtype_id="8" vartype="integer" origName="i"/>
             </selloopvars>
-            <constraintexpr loc="d,38,19,38,25">
-              <or loc="d,38,19,38,25" dtype_id="6">
-                <or loc="d,38,19,38,25" dtype_id="6">
-                  <eqwild loc="d,38,27,38,28" dtype_id="6">
-                    <arraysel loc="d,38,15,38,16" dtype_id="3">
-                      <varref loc="d,38,10,38,15" name="array" dtype_id="5"/>
-                      <sel loc="d,38,16,38,17" dtype_id="9">
-                        <varref loc="d,38,16,38,17" name="i" dtype_id="8"/>
-                        <const loc="d,38,16,38,17" name="32&apos;h0" dtype_id="10"/>
-                        <const loc="d,38,16,38,17" name="32&apos;h1" dtype_id="10"/>
+            <constraintexpr loc="d,41,19,41,25">
+              <or loc="d,41,19,41,25" dtype_id="6">
+                <or loc="d,41,19,41,25" dtype_id="6">
+                  <eqwild loc="d,41,27,41,28" dtype_id="6">
+                    <arraysel loc="d,41,15,41,16" dtype_id="3">
+                      <varref loc="d,41,10,41,15" name="array" dtype_id="5"/>
+                      <sel loc="d,41,16,41,17" dtype_id="9">
+                        <varref loc="d,41,16,41,17" name="i" dtype_id="8"/>
+                        <const loc="d,41,16,41,17" name="32&apos;h0" dtype_id="10"/>
+                        <const loc="d,41,16,41,17" name="32&apos;h1" dtype_id="10"/>
                       </sel>
                     </arraysel>
-                    <const loc="d,38,27,38,28" name="32&apos;sh2" dtype_id="7"/>
+                    <const loc="d,41,27,41,28" name="32&apos;sh2" dtype_id="7"/>
                   </eqwild>
-                  <eqwild loc="d,38,30,38,31" dtype_id="6">
-                    <arraysel loc="d,38,15,38,16" dtype_id="3">
-                      <varref loc="d,38,10,38,15" name="array" dtype_id="5"/>
-                      <sel loc="d,38,16,38,17" dtype_id="9">
-                        <varref loc="d,38,16,38,17" name="i" dtype_id="8"/>
-                        <const loc="d,38,16,38,17" name="32&apos;h0" dtype_id="10"/>
-                        <const loc="d,38,16,38,17" name="32&apos;h1" dtype_id="10"/>
+                  <eqwild loc="d,41,30,41,31" dtype_id="6">
+                    <arraysel loc="d,41,15,41,16" dtype_id="3">
+                      <varref loc="d,41,10,41,15" name="array" dtype_id="5"/>
+                      <sel loc="d,41,16,41,17" dtype_id="9">
+                        <varref loc="d,41,16,41,17" name="i" dtype_id="8"/>
+                        <const loc="d,41,16,41,17" name="32&apos;h0" dtype_id="10"/>
+                        <const loc="d,41,16,41,17" name="32&apos;h1" dtype_id="10"/>
                       </sel>
                     </arraysel>
-                    <const loc="d,38,30,38,31" name="32&apos;sh4" dtype_id="7"/>
+                    <const loc="d,41,30,41,31" name="32&apos;sh4" dtype_id="7"/>
                   </eqwild>
                 </or>
-                <eqwild loc="d,38,33,38,34" dtype_id="6">
-                  <arraysel loc="d,38,15,38,16" dtype_id="3">
-                    <varref loc="d,38,10,38,15" name="array" dtype_id="5"/>
-                    <sel loc="d,38,16,38,17" dtype_id="9">
-                      <varref loc="d,38,16,38,17" name="i" dtype_id="8"/>
-                      <const loc="d,38,16,38,17" name="32&apos;h0" dtype_id="10"/>
-                      <const loc="d,38,16,38,17" name="32&apos;h1" dtype_id="10"/>
+                <eqwild loc="d,41,33,41,34" dtype_id="6">
+                  <arraysel loc="d,41,15,41,16" dtype_id="3">
+                    <varref loc="d,41,10,41,15" name="array" dtype_id="5"/>
+                    <sel loc="d,41,16,41,17" dtype_id="9">
+                      <varref loc="d,41,16,41,17" name="i" dtype_id="8"/>
+                      <const loc="d,41,16,41,17" name="32&apos;h0" dtype_id="10"/>
+                      <const loc="d,41,16,41,17" name="32&apos;h1" dtype_id="10"/>
                     </sel>
                   </arraysel>
-                  <const loc="d,38,33,38,34" name="32&apos;sh6" dtype_id="7"/>
+                  <const loc="d,41,33,41,34" name="32&apos;sh6" dtype_id="7"/>
                 </eqwild>
               </or>
             </constraintexpr>
           </constraintforeach>
-          <constraintunique loc="d,40,7,40,13">
-            <arraysel loc="d,40,21,40,22" dtype_id="3">
-              <varref loc="d,40,16,40,21" name="array" dtype_id="5"/>
-              <const loc="d,40,22,40,23" name="1&apos;h0" dtype_id="9"/>
+          <constraintunique loc="d,43,7,43,13">
+            <arraysel loc="d,43,21,43,22" dtype_id="3">
+              <varref loc="d,43,16,43,21" name="array" dtype_id="5"/>
+              <const loc="d,43,22,43,23" name="1&apos;h0" dtype_id="9"/>
             </arraysel>
-            <arraysel loc="d,40,31,40,32" dtype_id="3">
-              <varref loc="d,40,26,40,31" name="array" dtype_id="5"/>
-              <const loc="d,40,32,40,33" name="1&apos;h1" dtype_id="9"/>
+            <arraysel loc="d,43,31,43,32" dtype_id="3">
+              <varref loc="d,43,26,43,31" name="array" dtype_id="5"/>
+              <const loc="d,43,32,43,33" name="1&apos;h1" dtype_id="9"/>
             </arraysel>
           </constraintunique>
         </constraint>
-        <constraint loc="d,43,15,43,20" name="order">
-          <constraintbefore loc="d,43,23,43,28">
-            <varref loc="d,43,29,43,35" name="length" dtype_id="3"/>
-            <varref loc="d,43,43,43,49" name="header" dtype_id="3"/>
+        <constraint loc="d,46,15,46,20" name="order">
+          <constraintbefore loc="d,46,23,46,28">
+            <varref loc="d,46,29,46,35" name="length" dtype_id="3"/>
+            <varref loc="d,46,43,46,49" name="header" dtype_id="3"/>
           </constraintbefore>
         </constraint>
-        <constraint loc="d,45,15,45,18" name="dis">
-          <constraintexpr loc="d,46,7,46,11">
-            <varref loc="d,46,12,46,21" name="sublength" dtype_id="3"/>
+        <constraint loc="d,48,15,48,18" name="dis">
+          <constraintexpr loc="d,49,7,49,11">
+            <varref loc="d,49,12,49,21" name="sublength" dtype_id="3"/>
           </constraintexpr>
-          <constraintexpr loc="d,47,7,47,14">
-            <varref loc="d,47,20,47,29" name="sublength" dtype_id="3"/>
+          <constraintexpr loc="d,50,7,50,14">
+            <varref loc="d,50,20,50,29" name="sublength" dtype_id="3"/>
           </constraintexpr>
-          <constraintexpr loc="d,48,17,48,19">
-            <ltes loc="d,48,17,48,19" dtype_id="6">
-              <varref loc="d,48,7,48,16" name="sublength" dtype_id="3"/>
-              <varref loc="d,48,20,48,26" name="length" dtype_id="3"/>
+          <constraintexpr loc="d,51,17,51,19">
+            <ltes loc="d,51,17,51,19" dtype_id="6">
+              <varref loc="d,51,7,51,16" name="sublength" dtype_id="3"/>
+              <varref loc="d,51,20,51,26" name="length" dtype_id="3"/>
             </ltes>
           </constraintexpr>
         </constraint>
+        <constraint loc="d,54,15,54,19" name="meth">
+          <if loc="d,55,7,55,9">
+            <funcref loc="d,55,11,55,24" name="strings_equal" dtype_id="4">
+              <arg loc="d,55,25,55,30">
+                <varref loc="d,55,25,55,30" name="state" dtype_id="2"/>
+              </arg>
+              <arg loc="d,55,32,55,36">
+                <const loc="d,55,32,55,36" name="&quot;ok&quot;" dtype_id="2"/>
+              </arg>
+            </funcref>
+            <begin>
+              <constraintexpr loc="d,56,22,56,24">
+                <varref loc="d,56,10,56,21" name="if_state_ok" dtype_id="6"/>
+              </constraintexpr>
+            </begin>
+          </if>
+        </constraint>
+        <func loc="d,59,17,59,30" name="strings_equal" dtype_id="4">
+          <var loc="d,59,17,59,30" name="strings_equal" dtype_id="4" dir="output" vartype="bit" origName="strings_equal"/>
+          <var loc="d,59,38,59,39" name="a" dtype_id="2" dir="input" vartype="string" origName="a"/>
+          <var loc="d,59,48,59,49" name="b" dtype_id="2" dir="input" vartype="string" origName="b"/>
+          <assign loc="d,60,7,60,13" dtype_id="4">
+            <eqn loc="d,60,16,60,18" dtype_id="6">
+              <varref loc="d,60,14,60,15" name="a" dtype_id="2"/>
+              <varref loc="d,60,19,60,20" name="b" dtype_id="2"/>
+            </eqn>
+            <varref loc="d,60,7,60,13" name="strings_equal" dtype_id="4"/>
+          </assign>
+        </func>
         <func loc="d,7,1,7,6" name="new" dtype_id="11"/>
       </class>
     </package>
     <typetable loc="a,0,0,0,0">
-      <basicdtype loc="d,19,14,19,15" id="6" name="logic"/>
-      <basicdtype loc="d,22,21,22,22" id="10" name="logic" left="31" right="0"/>
-      <basicdtype loc="d,59,7,59,13" id="2" name="string"/>
-      <basicdtype loc="d,37,22,37,23" id="8" name="integer" left="31" right="0" signed="true"/>
+      <basicdtype loc="d,22,14,22,15" id="6" name="logic"/>
+      <basicdtype loc="d,25,21,25,22" id="10" name="logic" left="31" right="0"/>
+      <basicdtype loc="d,71,7,71,13" id="2" name="string"/>
+      <basicdtype loc="d,40,22,40,23" id="8" name="integer" left="31" right="0" signed="true"/>
       <basicdtype loc="d,8,9,8,12" id="3" name="int" left="31" right="0" signed="true"/>
       <basicdtype loc="d,11,9,11,12" id="4" name="bit"/>
-      <unpackarraydtype loc="d,14,18,14,19" id="5" sub_dtype_id="3">
-        <range loc="d,14,18,14,19">
-          <const loc="d,14,19,14,20" name="32&apos;h0" dtype_id="10"/>
-          <const loc="d,14,19,14,20" name="32&apos;h1" dtype_id="10"/>
+      <unpackarraydtype loc="d,15,18,15,19" id="5" sub_dtype_id="3">
+        <range loc="d,15,18,15,19">
+          <const loc="d,15,19,15,20" name="32&apos;h0" dtype_id="10"/>
+          <const loc="d,15,19,15,20" name="32&apos;h1" dtype_id="10"/>
         </range>
       </unpackarraydtype>
-      <basicdtype loc="d,29,18,29,20" id="9" name="logic" signed="true"/>
+      <basicdtype loc="d,32,18,32,20" id="9" name="logic" signed="true"/>
       <voiddtype loc="d,7,1,7,6" id="11"/>
-      <classrefdtype loc="d,55,4,55,10" id="1" name="Packet"/>
-      <basicdtype loc="d,19,16,19,17" id="7" name="logic" left="31" right="0" signed="true"/>
+      <classrefdtype loc="d,67,4,67,10" id="1" name="Packet"/>
+      <basicdtype loc="d,22,16,22,17" id="7" name="logic" left="31" right="0" signed="true"/>
     </typetable>
   </netlist>
 </verilator_xml>

--- a/test_regress/t/t_constraint_xml.v
+++ b/test_regress/t/t_constraint_xml.v
@@ -10,8 +10,11 @@ class Packet;
    rand int sublength; // 0..15
    rand bit if_4;
    rand bit iff_5_6;
+   rand bit if_state_ok;
 
    rand int array[2];  // 2,4,6
+
+   string state;
 
    constraint empty {}
 
@@ -47,6 +50,15 @@ class Packet;
       disable soft sublength;
       sublength <= length;
    }
+
+   constraint meth {
+      if (strings_equal(state, "ok"))
+         if_state_ok == '1;
+   }
+
+   function bit strings_equal(string a, string b);
+      return a == b;
+   endfunction
 
 endclass
 


### PR DESCRIPTION
This will help resolving references (e.g. static vs non-static), as well as reduce code. The new test describes one case of such a broken reference.

Previous error:
```
%Error: t/t_constraint_xml.v:55:11: Cannot call non-static member function 'strings_equal' without object (IEEE 1800-2023 8.10)
                                  : ... note: In instance 't'
   55 |       if (strings_equal(state, "ok"))
      |           ^~~~~~~~~~~~~
```