### PR TITLE
Add CITATION.cff (#5057)

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,29 @@
+cff-version: 1.2.0
+title: Verilator
+message: >-
+  If you use this software, please cite it using the
+  metadata from this file.
+type: software
+authors:
+  - given-names: Wilson
+    family-names: Snyder
+    email: wsnyder@wsnyder.org
+    affiliation: Veripool
+  - given-names: Paul
+    family-names: Wasson
+  - given-names: Duane
+    family-names: Galbi
+# fixme: I was unable to find a DOI of a paper that was published about
+# Verilator. If you want a DOI, you can register Verilator on Zenodo, but that
+# is a bit of a hassle.
+# identifiers:
+#  - type: doi
+#    value: 10.XXXX/zenodo.XXXXXXXXX
+repository-code: 'https://github.com/verilator/verilator'
+url: 'https://veripool.org/verilator/'
+abstract: >-
+  The Verilator package converts Verilog and SystemVerilog
+  hardware description language (HDL) designs into a C++ or
+  SystemC model that, after compiling, can be executed.
+  Verilator is not a traditional simulator but a compiler.
+license: LGPL-3.0

--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -51,6 +51,7 @@ G-A. Kamendje
 Garrett Smith
 Geza Lore
 Gianfranco Costamagna
+Gijs Burghoorn
 Glen Gibb
 Gökçe Aydos
 Graham Rushton


### PR DESCRIPTION
Fixes #5057.

If you have a DOI you would like people to use for Verilator, I think it is best to add it. Otherwise, this is enough.