### PR TITLE
Export VERILATOR_ROOT when building in CMake

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -128,6 +128,7 @@ Marshal Qiao
 Martin Schmidt
 Martin Stadler
 Matthew Ballance
+Michael Bikovitsky
 Michael Killough
 Michaël Lefebvre
 Michal Czyz

--- a/verilator-config.cmake.in
+++ b/verilator-config.cmake.in
@@ -214,7 +214,9 @@ function(verilate TARGET)
 
   file(MAKE_DIRECTORY ${VDIR})
 
-  set(VERILATOR_COMMAND "${VERILATOR_BIN}" --compiler ${COMPILER}
+  set(VERILATOR_COMMAND "${CMAKE_COMMAND}" -E env "VERILATOR_ROOT=${VERILATOR_ROOT}"
+                        --
+                        "${VERILATOR_BIN}" --compiler ${COMPILER}
                         --prefix ${VERILATE_PREFIX} --Mdir ${VDIR} --make cmake
                         ${VERILATOR_ARGS} ${VERILATE_VERILATOR_ARGS}
                         ${VERILATE_SOURCES})


### PR DESCRIPTION
Currently, the CMake script assumes that `VERILATOR_ROOT` is set in the environment both for the configuration and build phases (since in both phases Verilator may be invoked to re-generate the sources). Indeed, this value _must be the same_ for both phases, or Verilator will error out.

This PR makes it so that the `VERILATOR_ROOT` that's set at configuration time will always be used for subsequent builds, so that we don't have to remember to do it ourselves.