### PR TITLE
Remove unknown '--' form cmake -E

### DIFF
--- a/verilator-config.cmake.in
+++ b/verilator-config.cmake.in
@@ -215,7 +215,6 @@ function(verilate TARGET)
   file(MAKE_DIRECTORY ${VDIR})
 
   set(VERILATOR_COMMAND "${CMAKE_COMMAND}" -E env "VERILATOR_ROOT=${VERILATOR_ROOT}"
-                        --
                         "${VERILATOR_BIN}" --compiler ${COMPILER}
                         --prefix ${VERILATE_PREFIX} --Mdir ${VDIR} --make cmake
                         ${VERILATOR_ARGS} ${VERILATE_VERILATOR_ARGS}


### PR DESCRIPTION
After #5063, with cmake 3.22.1, I get test failures, saying:

`cmake -E env: unknown option '--'`

I don't think the '--' is necessary so removing.

@mbikovitsky is this reasonable?