### PR TITLE
tests: disable ASLR on verialtor compile/execute

### DIFF
--- a/test_regress/t/t_trace_ub_misaligned_address.pl
+++ b/test_regress/t/t_trace_ub_misaligned_address.pl
@@ -20,6 +20,7 @@ compile(
 
 execute(
     check_finished => 1,
+    aslr_off => 1,  # Some GCC versions hit an address-sanitizer bug otherwise
     );
 
 # Make sure that there are no additional messages (such as runtime messages


### PR DESCRIPTION
The t_trace_ub_misaligned_address yields non-deterministic 'AddressSanitizer:DEADLYSIGNAL' failures on my dev platform. This is due to a bug in address-sanitizer/gcc, likely the same one that cause our CI problems earlier (see also eg https://gitlab.archlinux.org/archlinux/packaging/packages/gcc/-/issues/6)

Disabling address space layout randomization makes this go away (and also has the benefit of making the runs more deterministic), so this patch disables ASLR for verialtor `compile` and `execute` steps in the test driver.