### PR TITLE
cleanup: remove unnecessary `unique_ptr<ostream>`

### DIFF
--- a/src/V3Ast.cpp
+++ b/src/V3Ast.cpp
@@ -1322,15 +1322,15 @@ void AstNode::dumpTreeFile(const string& filename, bool doDump) {
     if (doDump) {
         {  // Write log & close
             UINFO(2, "Dumping " << filename << endl);
-            const std::unique_ptr<std::ofstream> logsp{V3File::new_ofstream(filename)};
-            if (logsp->fail()) v3fatal("Can't write " << filename);
-            *logsp << "Verilator Tree Dump (format 0x3900) from <e" << std::dec << editCountLast();
-            *logsp << "> to <e" << std::dec << editCountGbl() << ">\n";
+            std::ofstream logsp = V3File::new_ofstream(filename);
+            if (logsp.fail()) v3fatal("Can't write " << filename);
+            logsp << "Verilator Tree Dump (format 0x3900) from <e" << std::dec << editCountLast();
+            logsp << "> to <e" << std::dec << editCountGbl() << ">\n";
             if (editCountGbl() == editCountLast() && ::dumpTreeLevel() < 9) {
-                *logsp << '\n';
-                *logsp << "No changes since last dump!\n";
+                logsp << '\n';
+                logsp << "No changes since last dump!\n";
             } else {
-                dumpTree(*logsp);
+                dumpTree(logsp);
                 editCountSetLast();  // Next dump can indicate start from here
             }
         }
@@ -1367,39 +1367,39 @@ void AstNode::dumpTreeDot(std::ostream& os) const {
 void AstNode::dumpTreeJsonFile(const string& filename, bool doDump) {
     if (!doDump) return;
     UINFO(2, "Dumping " << filename << endl);
-    const std::unique_ptr<std::ofstream> treejsonp{V3File::new_ofstream(filename)};
-    if (treejsonp->fail()) v3fatal("Can't write " << filename);
-    dumpTreeJson(*treejsonp);
-    *treejsonp << '\n';
+    std::ofstream treejsonp = V3File::new_ofstream(filename);
+    if (treejsonp.fail()) v3fatal("Can't write " << filename);
+    dumpTreeJson(treejsonp);
+    treejsonp << '\n';
 }
 
 void AstNode::dumpJsonMetaFileGdb(const char* filename) { dumpJsonMetaFile(filename); }
 void AstNode::dumpJsonMetaFile(const string& filename) {
     UINFO(2, "Dumping " << filename << endl);
-    const std::unique_ptr<std::ofstream> treejsonp{V3File::new_ofstream(filename)};
-    if (treejsonp->fail()) v3fatalStatic("Can't write " << filename);
-    *treejsonp << '{';
-    FileLine::fileNameNumMapDumpJson(*treejsonp);
-    *treejsonp << ',';
-    v3Global.idPtrMapDumpJson(*treejsonp);
-    *treejsonp << ',';
-    v3Global.ptrNamesDumpJson(*treejsonp);
-    *treejsonp << "}\n";
+    std::ofstream treejsonp = V3File::new_ofstream(filename);
+    if (treejsonp.fail()) v3fatalStatic("Can't write " << filename);
+    treejsonp << '{';
+    FileLine::fileNameNumMapDumpJson(treejsonp);
+    treejsonp << ',';
+    v3Global.idPtrMapDumpJson(treejsonp);
+    treejsonp << ',';
+    v3Global.ptrNamesDumpJson(treejsonp);
+    treejsonp << "}\n";
 }
 
 void AstNode::dumpTreeDotFile(const string& filename, bool doDump) {
     if (doDump) {
         UINFO(2, "Dumping " << filename << endl);
-        const std::unique_ptr<std::ofstream> treedotp{V3File::new_ofstream(filename)};
-        if (treedotp->fail()) v3fatal("Can't write " << filename);
-        *treedotp << "digraph vTree{\n";
-        *treedotp << "\tgraph\t[label=\"" << filename + ".dot"
-                  << "\",\n";
-        *treedotp << "\t\t labelloc=t, labeljust=l,\n";
-        *treedotp << "\t\t //size=\"7.5,10\",\n"
-                  << "];\n";
-        dumpTreeDot(*treedotp);
-        *treedotp << "}\n";
+        std::ofstream treedotp = V3File::new_ofstream(filename);
+        if (treedotp.fail()) v3fatal("Can't write " << filename);
+        treedotp << "digraph vTree{\n";
+        treedotp << "\tgraph\t[label=\"" << filename + ".dot"
+                 << "\",\n";
+        treedotp << "\t\t labelloc=t, labeljust=l,\n";
+        treedotp << "\t\t //size=\"7.5,10\",\n"
+                 << "];\n";
+        dumpTreeDot(treedotp);
+        treedotp << "}\n";
     }
 }
 

--- a/src/V3Dfg.cpp
+++ b/src/V3Dfg.cpp
@@ -192,10 +192,10 @@ void DfgGraph::dumpDot(std::ostream& os, const string& label) const {
 void DfgGraph::dumpDotFile(const string& fileName, const string& label) const {
     // This generates a file used by graphviz, https://www.graphviz.org
     // "hardcoded" parameters:
-    const std::unique_ptr<std::ofstream> os{V3File::new_ofstream(fileName)};
-    if (os->fail()) v3fatal("Cannot write to file: " << fileName);
-    dumpDot(*os.get(), label);
-    os->close();
+    std::ofstream os = V3File::new_ofstream(fileName);
+    if (os.fail()) v3fatal("Cannot write to file: " << fileName);
+    dumpDot(os, label);
+    os.close();
 }
 
 void DfgGraph::dumpDotFilePrefixed(const string& label) const {
@@ -243,22 +243,22 @@ static void dumpDotUpstreamConeFromVertex(std::ostream& os, const DfgVertex& vtx
 void DfgGraph::dumpDotUpstreamCone(const string& fileName, const DfgVertex& vtx,
                                    const string& name) const {
     // Open output file
-    const std::unique_ptr<std::ofstream> os{V3File::new_ofstream(fileName)};
-    if (os->fail()) v3fatal("Cannot write to file: " << fileName);
+    std::ofstream os = V3File::new_ofstream(fileName);
+    if (os.fail()) v3fatal("Cannot write to file: " << fileName);
 
     // Header
-    *os << "digraph dfg {\n";
-    if (!name.empty()) *os << "graph [label=\"" << name << "\", labelloc=t, labeljust=l]\n";
-    *os << "graph [rankdir=LR]\n";
+    os << "digraph dfg {\n";
+    if (!name.empty()) os << "graph [label=\"" << name << "\", labelloc=t, labeljust=l]\n";
+    os << "graph [rankdir=LR]\n";
 
     // Dump the cone
-    dumpDotUpstreamConeFromVertex(*os, vtx);
+    dumpDotUpstreamConeFromVertex(os, vtx);
 
     // Footer
-    *os << "}\n";
+    os << "}\n";
 
     // Done
-    os->close();
+    os.close();
 }
 // LCOV_EXCL_STOP
 
@@ -277,22 +277,22 @@ void DfgGraph::dumpDotAllVarConesPrefixed(const string& label) const {
         // Open output file
         const string coneName{prefix + sinkp->varp()->name()};
         const string fileName{v3Global.debugFilename(coneName) + ".dot"};
-        const std::unique_ptr<std::ofstream> os{V3File::new_ofstream(fileName)};
-        if (os->fail()) v3fatal("Cannot write to file: " << fileName);
+        std::ofstream os = V3File::new_ofstream(fileName);
+        if (os.fail()) v3fatal("Cannot write to file: " << fileName);
 
         // Header
-        *os << "digraph dfg {\n";
-        *os << "graph [label=\"" << coneName << "\", labelloc=t, labeljust=l]\n";
-        *os << "graph [rankdir=LR]\n";
+        os << "digraph dfg {\n";
+        os << "graph [label=\"" << coneName << "\", labelloc=t, labeljust=l]\n";
+        os << "graph [rankdir=LR]\n";
 
         // Dump this cone
-        dumpDotUpstreamConeFromVertex(*os, vtx);
+        dumpDotUpstreamConeFromVertex(os, vtx);
 
         // Footer
-        *os << "}\n";
+        os << "}\n";
 
         // Done with this logic cone
-        os->close();
+        os.close();
     });
 }
 

--- a/src/V3DfgPasses.cpp
+++ b/src/V3DfgPasses.cpp
@@ -84,9 +84,9 @@ V3DfgOptimizationContext::~V3DfgOptimizationContext() {
         const std::string filename = v3Global.opt.hierTopDataDir() + "/" + v3Global.opt.prefix()
                                      + "__stats_dfg_patterns__" + ident + ".txt";
         // Open, write, close
-        const std::unique_ptr<std::ofstream> ofp{V3File::new_ofstream(filename)};
-        if (ofp->fail()) v3fatal("Can't write " << filename);
-        m_patternStats.dump(m_label, *ofp);
+        std::ofstream ofp = V3File::new_ofstream(filename);
+        if (ofp.fail()) v3fatal("Can't write " << filename);
+        m_patternStats.dump(m_label, ofp);
     }
 
     // Check the stats are consistent

--- a/src/V3DupFinder.cpp
+++ b/src/V3DupFinder.cpp
@@ -54,8 +54,8 @@ V3DupFinder::iterator V3DupFinder::findDuplicate(AstNode* nodep, V3DupFinderUser
 
 void V3DupFinder::dumpFile(const string& filename, bool tree) {
     UINFO(2, "Dumping " << filename << endl);
-    const std::unique_ptr<std::ofstream> logp{V3File::new_ofstream(filename)};
-    if (logp->fail()) v3fatal("Can't write " << filename);
+    std::ofstream logp = V3File::new_ofstream(filename);
+    if (logp.fail()) v3fatal("Can't write " << filename);
 
     std::unordered_map<int, int> dist;
 
@@ -70,22 +70,22 @@ void V3DupFinder::dumpFile(const string& filename, bool tree) {
         if (it == cend()) break;
         num_in_bucket++;
     }
-    *logp << "\n*** STATS:\n\n";
-    *logp << "    #InBucket   Occurrences\n";
+    logp << "\n*** STATS:\n\n";
+    logp << "    #InBucket   Occurrences\n";
     for (const auto& i : dist) {
-        *logp << "    " << std::setw(9) << i.first << "  " << std::setw(12) << i.second << '\n';
+        logp << "    " << std::setw(9) << i.first << "  " << std::setw(12) << i.second << '\n';
     }
 
-    *logp << "\n*** Dump:\n\n";
+    logp << "\n*** Dump:\n\n";
     for (const auto& it : *this) {
         if (lasthash != it.first) {
             lasthash = it.first;
-            *logp << "    " << it.first << '\n';
+            logp << "    " << it.first << '\n';
         }
-        *logp << "\t" << it.second << '\n';
+        logp << "\t" << it.second << '\n';
         // Dumping the entire tree may make nearly N^2 sized dumps,
         // because the nodes under this one may also be in the hash table!
-        if (tree) it.second->dumpTree(*logp, "    ");
+        if (tree) it.second->dumpTree(logp, "    ");
     }
 }
 

--- a/src/V3EmitCMake.cpp
+++ b/src/V3EmitCMake.cpp
@@ -66,52 +66,51 @@ class CMakeEmitter final {
     }
 
     static void emitOverallCMake() {
-        const std::unique_ptr<std::ofstream> of{
-            V3File::new_ofstream(v3Global.opt.makeDir() + "/" + v3Global.opt.prefix() + ".cmake")};
+        std::ofstream of = V3File::new_ofstream(v3Global.opt.makeDir() + "/" + v3Global.opt.prefix() + ".cmake");
         const string name = v3Global.opt.prefix();
 
-        *of << "# Verilated -*- CMake -*-\n";
-        *of << "# DESCR"
+        of << "# Verilated -*- CMake -*-\n";
+        of << "# DESCR"
                "IPTION: Verilator output: CMake include script with class lists\n";
-        *of << "#\n";
-        *of << "# This CMake script lists generated Verilated files, for "
+        of << "#\n";
+        of << "# This CMake script lists generated Verilated files, for "
                "including in higher level CMake scripts.\n";
-        *of << "# This file is meant to be consumed by the verilate() function,\n";
-        *of << "# which becomes available after executing `find_package(verilator).\n";
+        of << "# This file is meant to be consumed by the verilate() function,\n";
+        of << "# which becomes available after executing `find_package(verilator).\n";
 
-        *of << "\n### Constants...\n";
-        cmake_set(*of, "PERL", V3OutFormatter::quoteNameControls(V3Options::getenvPERL()),
+        of << "\n### Constants...\n";
+        cmake_set(of, "PERL", V3OutFormatter::quoteNameControls(V3Options::getenvPERL()),
                   "FILEPATH", "Perl executable (from $PERL)");
-        cmake_set(*of, "VERILATOR_ROOT",
+        cmake_set(of, "VERILATOR_ROOT",
                   V3OutFormatter::quoteNameControls(V3Options::getenvVERILATOR_ROOT()), "PATH",
                   "Path to Verilator kit (from $VERILATOR_ROOT)");
 
-        *of << "\n### Compiler flags...\n";
+        of << "\n### Compiler flags...\n";
 
-        *of << "# User CFLAGS (from -CFLAGS on Verilator command line)\n";
-        cmake_set_raw(*of, name + "_USER_CFLAGS", cmake_list(v3Global.opt.cFlags()));
+        of << "# User CFLAGS (from -CFLAGS on Verilator command line)\n";
+        cmake_set_raw(of, name + "_USER_CFLAGS", cmake_list(v3Global.opt.cFlags()));
 
-        *of << "# User LDLIBS (from -LDFLAGS on Verilator command line)\n";
-        cmake_set_raw(*of, name + "_USER_LDLIBS", cmake_list(v3Global.opt.ldLibs()));
+        of << "# User LDLIBS (from -LDFLAGS on Verilator command line)\n";
+        cmake_set_raw(of, name + "_USER_LDLIBS", cmake_list(v3Global.opt.ldLibs()));
 
-        *of << "\n### Switches...\n";
+        of << "\n### Switches...\n";
 
-        *of << "# SystemC output mode?  0/1 (from --sc)\n";
-        cmake_set_raw(*of, name + "_SC", v3Global.opt.systemC() ? "1" : "0");
-        *of << "# Coverage output mode?  0/1 (from --coverage)\n";
-        cmake_set_raw(*of, name + "_COVERAGE", v3Global.opt.coverage() ? "1" : "0");
-        *of << "# Timing mode?  0/1\n";
-        cmake_set_raw(*of, name + "_TIMING", v3Global.usesTiming() ? "1" : "0");
-        *of << "# Threaded output mode?  1/N threads (from --threads)\n";
-        cmake_set_raw(*of, name + "_THREADS", cvtToStr(v3Global.opt.threads()));
-        *of << "# VCD Tracing output mode?  0/1 (from --trace)\n";
-        cmake_set_raw(*of, name + "_TRACE_VCD",
+        of << "# SystemC output mode?  0/1 (from --sc)\n";
+        cmake_set_raw(of, name + "_SC", v3Global.opt.systemC() ? "1" : "0");
+        of << "# Coverage output mode?  0/1 (from --coverage)\n";
+        cmake_set_raw(of, name + "_COVERAGE", v3Global.opt.coverage() ? "1" : "0");
+        of << "# Timing mode?  0/1\n";
+        cmake_set_raw(of, name + "_TIMING", v3Global.usesTiming() ? "1" : "0");
+        of << "# Threaded output mode?  1/N threads (from --threads)\n";
+        cmake_set_raw(of, name + "_THREADS", cvtToStr(v3Global.opt.threads()));
+        of << "# VCD Tracing output mode?  0/1 (from --trace)\n";
+        cmake_set_raw(of, name + "_TRACE_VCD",
                       (v3Global.opt.trace() && v3Global.opt.traceFormat().vcd()) ? "1" : "0");
-        *of << "# FST Tracing output mode? 0/1 (from --trace-fst)\n";
-        cmake_set_raw(*of, name + "_TRACE_FST",
+        of << "# FST Tracing output mode? 0/1 (from --trace-fst)\n";
+        cmake_set_raw(of, name + "_TRACE_FST",
                       (v3Global.opt.trace() && v3Global.opt.traceFormat().fst()) ? "1" : "0");
 
-        *of << "\n### Sources...\n";
+        of << "\n### Sources...\n";
         std::vector<string> classes_fast;
         std::vector<string> classes_slow;
         std::vector<string> support_fast;
@@ -168,68 +167,68 @@ class CMakeEmitter final {
             global.emplace_back(v3Global.opt.makeDir() + "/" + v3Global.opt.libCreate() + ".cpp");
         }
 
-        *of << "# Global classes, need linked once per executable\n";
-        cmake_set_raw(*of, name + "_GLOBAL", cmake_list(global));
-        *of << "# Generated module classes, non-fast-path, compile with low/medium optimization\n";
-        cmake_set_raw(*of, name + "_CLASSES_SLOW", cmake_list(classes_slow));
-        *of << "# Generated module classes, fast-path, compile with highest optimization\n";
-        cmake_set_raw(*of, name + "_CLASSES_FAST", cmake_list(classes_fast));
-        *of << "# Generated support classes, non-fast-path, compile with "
+        of << "# Global classes, need linked once per executable\n";
+        cmake_set_raw(of, name + "_GLOBAL", cmake_list(global));
+        of << "# Generated module classes, non-fast-path, compile with low/medium optimization\n";
+        cmake_set_raw(of, name + "_CLASSES_SLOW", cmake_list(classes_slow));
+        of << "# Generated module classes, fast-path, compile with highest optimization\n";
+        cmake_set_raw(of, name + "_CLASSES_FAST", cmake_list(classes_fast));
+        of << "# Generated support classes, non-fast-path, compile with "
                "low/medium optimization\n";
-        cmake_set_raw(*of, name + "_SUPPORT_SLOW", cmake_list(support_slow));
-        *of << "# Generated support classes, fast-path, compile with highest optimization\n";
-        cmake_set_raw(*of, name + "_SUPPORT_FAST", cmake_list(support_fast));
+        cmake_set_raw(of, name + "_SUPPORT_SLOW", cmake_list(support_slow));
+        of << "# Generated support classes, fast-path, compile with highest optimization\n";
+        cmake_set_raw(of, name + "_SUPPORT_FAST", cmake_list(support_fast));
 
-        *of << "# All dependencies\n";
-        cmake_set_raw(*of, name + "_DEPS", cmake_list(V3File::getAllDeps()));
+        of << "# All dependencies\n";
+        cmake_set_raw(of, name + "_DEPS", cmake_list(V3File::getAllDeps()));
 
-        *of << "# User .cpp files (from .cpp's on Verilator command line)\n";
-        cmake_set_raw(*of, name + "_USER_CLASSES", cmake_list(v3Global.opt.cppFiles()));
+        of << "# User .cpp files (from .cpp's on Verilator command line)\n";
+        cmake_set_raw(of, name + "_USER_CLASSES", cmake_list(v3Global.opt.cppFiles()));
         if (const V3HierBlockPlan* const planp = v3Global.hierPlanp()) {
-            *of << "# Verilate hierarchical blocks\n";
+            of << "# Verilate hierarchical blocks\n";
             // Sorted hierarchical blocks in order of leaf-first.
             const V3HierBlockPlan::HierVector& hierBlocks = planp->hierBlocksSorted();
-            *of << "get_target_property(TOP_TARGET_NAME \"${TARGET}\" NAME)\n";
+            of << "get_target_property(TOP_TARGET_NAME \"${TARGET}\" NAME)\n";
             for (V3HierBlockPlan::HierVector::const_iterator it = hierBlocks.begin();
                  it != hierBlocks.end(); ++it) {
                 const V3HierBlock* hblockp = *it;
                 const V3HierBlock::HierBlockSet& children = hblockp->children();
                 const string prefix = hblockp->hierPrefix();
-                *of << "add_library(" << prefix << " STATIC)\n";
-                *of << "target_link_libraries(${TOP_TARGET_NAME}  PRIVATE " << prefix << ")\n";
+                of << "add_library(" << prefix << " STATIC)\n";
+                of << "target_link_libraries(${TOP_TARGET_NAME}  PRIVATE " << prefix << ")\n";
                 if (!children.empty()) {
-                    *of << "target_link_libraries(" << prefix << " INTERFACE";
-                    for (const auto& childr : children) *of << " " << (childr)->hierPrefix();
-                    *of << ")\n";
+                    of << "target_link_libraries(" << prefix << " INTERFACE";
+                    for (const auto& childr : children) of << " " << (childr)->hierPrefix();
+                    of << ")\n";
                 }
-                *of << "verilate(" << prefix << " PREFIX " << prefix << " TOP_MODULE "
+                of << "verilate(" << prefix << " PREFIX " << prefix << " TOP_MODULE "
                     << hblockp->modp()->name() << " DIRECTORY "
                     << v3Global.opt.makeDir() + "/" + prefix << " SOURCES ";
                 for (const auto& childr : children) {
-                    *of << " " << v3Global.opt.makeDir() + "/" + childr->hierWrapper(true);
+                    of << " " << v3Global.opt.makeDir() + "/" + childr->hierWrapper(true);
                 }
-                *of << " ";
+                of << " ";
                 const string vFile = hblockp->vFileIfNecessary();
-                if (!vFile.empty()) *of << vFile << " ";
+                if (!vFile.empty()) of << vFile << " ";
                 const V3StringList& vFiles = v3Global.opt.vFiles();
-                for (const string& i : vFiles) *of << V3Os::filenameRealPath(i) << " ";
-                *of << " VERILATOR_ARGS ";
-                *of << "-f " << hblockp->commandArgsFileName(true)
+                for (const string& i : vFiles) of << V3Os::filenameRealPath(i) << " ";
+                of << " VERILATOR_ARGS ";
+                of << "-f " << hblockp->commandArgsFileName(true)
                     << " -CFLAGS -fPIC"  // hierarchical block will be static, but may be linked
                                          // with .so
                     << ")\n";
             }
-            *of << "\n# Verilate the top module that refers to lib-create wrappers of above\n";
-            *of << "verilate(${TOP_TARGET_NAME} PREFIX " << v3Global.opt.prefix() << " TOP_MODULE "
+            of << "\n# Verilate the top module that refers to lib-create wrappers of above\n";
+            of << "verilate(${TOP_TARGET_NAME} PREFIX " << v3Global.opt.prefix() << " TOP_MODULE "
                 << v3Global.rootp()->topModulep()->name() << " DIRECTORY "
                 << v3Global.opt.makeDir() << " SOURCES ";
             for (const auto& itr : *planp) {
-                *of << " " << v3Global.opt.makeDir() + "/" + itr.second->hierWrapper(true);
+                of << " " << v3Global.opt.makeDir() + "/" + itr.second->hierWrapper(true);
             }
-            *of << " " << cmake_list(v3Global.opt.vFiles());
-            *of << " VERILATOR_ARGS ";
-            *of << "-f " << planp->topCommandArgsFileName(true);
-            *of << ")\n";
+            of << " " << cmake_list(v3Global.opt.vFiles());
+            of << " VERILATOR_ARGS ";
+            of << "-f " << planp->topCommandArgsFileName(true);
+            of << ")\n";
         }
     }
 

--- a/src/V3ExecGraph.cpp
+++ b/src/V3ExecGraph.cpp
@@ -97,25 +97,25 @@ private:
     // Debugging
     void dumpDotFile(const V3Graph& graph, const string& filename) const {
         // This generates a file used by graphviz, https://www.graphviz.org
-        const std::unique_ptr<std::ofstream> logp{V3File::new_ofstream(filename)};
-        if (logp->fail()) v3fatal("Can't write " << filename);
+        std::ofstream logp = V3File::new_ofstream(filename);
+        if (logp.fail()) v3fatal("Can't write " << filename);
 
         // Header
-        *logp << "digraph v3graph {\n";
-        *logp << "  graph[layout=\"neato\" labelloc=t labeljust=l label=\"" << filename << "\"]\n";
-        *logp << "  node[shape=\"rect\" ratio=\"fill\" fixedsize=true]\n";
+        logp << "digraph v3graph {\n";
+        logp << "  graph[layout=\"neato\" labelloc=t labeljust=l label=\"" << filename << "\"]\n";
+        logp << "  node[shape=\"rect\" ratio=\"fill\" fixedsize=true]\n";
 
         // Thread labels
-        *logp << "\n  // Threads\n";
+        logp << "\n  // Threads\n";
         const int threadBoxWidth = 2;
         for (int i = 0; i < v3Global.opt.threads(); i++) {
-            *logp << "  t" << i << " [label=\"Thread " << i << "\" width=" << threadBoxWidth
+            logp << "  t" << i << " [label=\"Thread " << i << "\" width=" << threadBoxWidth
                   << " pos=\"" << (-threadBoxWidth / 2) << "," << -i
                   << "!\" style=\"filled\" fillcolor=\"grey\"] \n";
         }
 
         // MTask nodes
-        *logp << "\n  // MTasks\n";
+        logp << "\n  // MTasks\n";
 
         // Find minimum cost MTask for scaling MTask node widths
         uint32_t minCost = UINT32_MAX;
@@ -137,8 +137,8 @@ private:
             const int y = -thread;
             const string label = "label=\"" + mtaskp->name() + " (" + cvtToStr(startTime(mtaskp))
                                  + ":" + std::to_string(endTime(mtaskp)) + ")" + "\"";
-            *logp << "  " << mtaskp->name() << " [" << label << " width=" << nodeWidth << " pos=\""
-                  << x << "," << y << "!\"]\n";
+            logp << "  " << mtaskp->name() << " [" << label << " width=" << nodeWidth << " pos=\""
+                 << x << "," << y << "!\"]\n";
         };
 
         // Emit MTasks
@@ -147,19 +147,19 @@ private:
         }
 
         // Emit MTask dependency edges
-        *logp << "\n  // MTask dependencies\n";
+        logp << "\n  // MTask dependencies\n";
         for (const V3GraphVertex& vtx : graph.vertices()) {
             if (const ExecMTask* const mtaskp = vtx.cast<const ExecMTask>()) {
                 for (const V3GraphEdge& edge : mtaskp->outEdges()) {
                     const V3GraphVertex* const top = edge.top();
-                    *logp << "  " << vtx.name() << " -> " << top->name() << "\n";
+                    logp << "  " << vtx.name() << " -> " << top->name() << "\n";
                 }
             }
         }
 
         // Trailer
-        *logp << "}\n";
-        logp->close();
+        logp << "}\n";
+        logp.close();
     }
 
     // Variant of dumpDotFilePrefixed without --dump option check

--- a/src/V3File.h
+++ b/src/V3File.h
@@ -38,23 +38,23 @@ class AstNode;
 
 class V3File final {
 public:
-    static std::ifstream* new_ifstream(const string& filename) {
+    static std::ifstream new_ifstream(const string& filename) {
         addSrcDepend(filename);
         return new_ifstream_nodepend(filename);
     }
-    static std::ifstream* new_ifstream_nodepend(const string& filename) VL_MT_SAFE {
-        return new std::ifstream{filename.c_str()};
+    static std::ifstream new_ifstream_nodepend(const string& filename) VL_MT_SAFE {
+        return std::ifstream{filename.c_str()};
     }
-    static std::ofstream* new_ofstream(const string& filename, bool append = false) {
+    static std::ofstream new_ofstream(const string& filename, bool append = false) {
         addTgtDepend(filename);
         return new_ofstream_nodepend(filename, append);
     }
-    static std::ofstream* new_ofstream_nodepend(const string& filename, bool append = false) {
+    static std::ofstream new_ofstream_nodepend(const string& filename, bool append = false) {
         createMakeDirFor(filename);
         if (append) {
-            return new std::ofstream{filename.c_str(), std::ios::app};
+            return std::ofstream{filename.c_str(), std::ios::app};
         } else {
-            return new std::ofstream{filename.c_str()};
+            return std::ofstream{filename.c_str()};
         }
     }
     static FILE* new_fopen_w(const string& filename) {

--- a/src/V3Graph.cpp
+++ b/src/V3Graph.cpp
@@ -283,15 +283,15 @@ void V3Graph::dumpDotFilePrefixedAlways(const string& nameComment, bool colorAsS
 void V3Graph::dumpDotFile(const string& filename, bool colorAsSubgraph) const {
     // This generates a file used by graphviz, https://www.graphviz.org
     // "hardcoded" parameters:
-    const std::unique_ptr<std::ofstream> logp{V3File::new_ofstream(filename)};
-    if (logp->fail()) v3fatal("Can't write " << filename);
+    std::ofstream logp = V3File::new_ofstream(filename);
+    if (logp.fail()) v3fatal("Can't write " << filename);
 
     // Header
-    *logp << "digraph v3graph {\n";
-    *logp << "\tgraph\t[label=\"" << filename << "\",\n";
-    *logp << "\t\t labelloc=t, labeljust=l,\n";
-    *logp << "\t\t //size=\"7.5,10\",\n";
-    *logp << "\t\t rankdir=" << dotRankDir() << "];\n";
+    logp << "digraph v3graph {\n";
+    logp << "\tgraph\t[label=\"" << filename << "\",\n";
+    logp << "\t\t labelloc=t, labeljust=l,\n";
+    logp << "\t\t //size=\"7.5,10\",\n";
+    logp << "\t\t rankdir=" << dotRankDir() << "];\n";
 
     // List of all possible subgraphs
     // Collections of explicit ranks
@@ -321,26 +321,26 @@ void V3Graph::dumpDotFile(const string& filename, bool colorAsSubgraph) const {
         const V3GraphVertex* vertexp = it->second;
         numMap[vertexp] = n;
         if (subgr != vertexSubgraph) {
-            if (subgr != "") *logp << "\t};\n";
+            if (subgr != "") logp << "\t};\n";
             subgr = vertexSubgraph;
             if (subgr != "") {
-                *logp << "\tsubgraph cluster_" << subgr << " {\n";
-                *logp << "\tlabel=\"" << subgr << "\"\n";
+                logp << "\tsubgraph cluster_" << subgr << " {\n";
+                logp << "\tlabel=\"" << subgr << "\"\n";
             }
         }
-        if (subgr != "") *logp << "\t";
-        *logp << "\tn" << vertexp->dotName() << (n++) << "\t[fontsize=8 "
+        if (subgr != "") logp << "\t";
+        logp << "\tn" << vertexp->dotName() << (n++) << "\t[fontsize=8 "
               << "label=\"" << (vertexp->name() != "" ? vertexp->name() : "\\N");
-        if (vertexp->rank()) *logp << " r" << vertexp->rank();
-        if (vertexp->fanout() != 0.0) *logp << " f" << vertexp->fanout();
-        if (vertexp->color()) *logp << "\\n c" << vertexp->color();
-        *logp << "\"";
-        *logp << ", color=" << vertexp->dotColor();
-        if (vertexp->dotStyle() != "") *logp << ", style=" << vertexp->dotStyle();
-        if (vertexp->dotShape() != "") *logp << ", shape=" << vertexp->dotShape();
-        *logp << "];\n";
+        if (vertexp->rank()) logp << " r" << vertexp->rank();
+        if (vertexp->fanout() != 0.0) logp << " f" << vertexp->fanout();
+        if (vertexp->color()) logp << "\\n c" << vertexp->color();
+        logp << "\"";
+        logp << ", color=" << vertexp->dotColor();
+        if (vertexp->dotStyle() != "") logp << ", style=" << vertexp->dotStyle();
+        if (vertexp->dotShape() != "") logp << ", shape=" << vertexp->dotShape();
+        logp << "];\n";
     }
-    if (subgr != "") *logp << "\t};\n";
+    if (subgr != "") logp << "\t};\n";
 
     // Print edges
     for (const V3GraphVertex& vertex : vertices()) {
@@ -348,43 +348,43 @@ void V3Graph::dumpDotFile(const string& filename, bool colorAsSubgraph) const {
             if (edge.weight()) {
                 const int fromVnum = numMap[edge.fromp()];
                 const int toVnum = numMap[edge.top()];
-                *logp << "\tn" << edge.fromp()->dotName() << fromVnum << " -> n"
+                logp << "\tn" << edge.fromp()->dotName() << fromVnum << " -> n"
                       << edge.top()->dotName() << toVnum
                       << " ["
                       // <<"fontsize=8 label=\""<<(edge.name()!="" ? edge.name() : "\\E")<<"\""
                       << "fontsize=8 label=\"" << (edge.dotLabel() != "" ? edge.dotLabel() : "")
                       << "\""
                       << " weight=" << edge.weight() << " color=" << edge.dotColor();
-                if (edge.dotStyle() != "") *logp << " style=" << edge.dotStyle();
-                // if (edge.cutable()) *logp << ",constraint=false";  // to rank without
+                if (edge.dotStyle() != "") logp << " style=" << edge.dotStyle();
+                // if (edge.cutable()) logp << ",constraint=false";  // to rank without
                 // following edges
-                *logp << "];\n";
+                logp << "];\n";
             }
         }
     }
 
     // Print ranks
     for (const auto& dotRank : ranks) {
-        *logp << "\t{ rank=";
+        logp << "\t{ rank=";
         if (dotRank != "sink" && dotRank != "source" && dotRank != "min" && dotRank != "max") {
-            *logp << "same";
+            logp << "same";
         } else {
-            *logp << dotRank;
+            logp << dotRank;
         }
-        *logp << "; ";
+        logp << "; ";
         auto bounds = rankSets.equal_range(dotRank);
         for (auto it{bounds.first}; it != bounds.second; ++it) {
-            if (it != bounds.first) *logp << ", ";
-            *logp << 'n' << numMap[it->second] << "";
+            if (it != bounds.first) logp << ", ";
+            logp << 'n' << numMap[it->second] << "";
         }
-        *logp << " }\n";
+        logp << " }\n";
     }
 
     // Vertex::m_user end, now unused
 
     // Trailer
-    *logp << "}\n";
-    logp->close();
+    logp << "}\n";
+    logp.close();
 
     cout << "dot -Tpdf -o ~/a.pdf " << filename << "\n";
 }

--- a/src/V3HierBlock.cpp
+++ b/src/V3HierBlock.cpp
@@ -213,21 +213,21 @@ string V3HierBlock::vFileIfNecessary() const {
 }
 
 void V3HierBlock::writeCommandArgsFile(bool forCMake) const {
-    const std::unique_ptr<std::ofstream> of{V3File::new_ofstream(commandArgsFileName(forCMake))};
-    *of << "--cc\n";
+    std::ofstream of = V3File::new_ofstream(commandArgsFileName(forCMake));
+    of << "--cc\n";
 
     if (!forCMake) {
         for (const auto& hierblockp : m_children) {
-            *of << v3Global.opt.makeDir() << "/" << hierblockp->hierWrapper(true) << "\n";
+            of << v3Global.opt.makeDir() << "/" << hierblockp->hierWrapper(true) << "\n";
         }
-        *of << "-Mdir " << v3Global.opt.makeDir() << "/" << hierPrefix() << " \n";
+        of << "-Mdir " << v3Global.opt.makeDir() << "/" << hierPrefix() << " \n";
     }
-    V3HierWriteCommonInputs(this, of.get(), forCMake);
+    V3HierWriteCommonInputs(this, &of, forCMake);
     const V3StringList& commandOpts = commandArgs(false);
-    for (const string& opt : commandOpts) *of << opt << "\n";
-    *of << hierBlockArgs().front() << "\n";
-    for (const auto& hierblockp : m_children) *of << hierblockp->hierBlockArgs().front() << "\n";
-    *of << v3Global.opt.allArgsStringForHierBlock(false) << "\n";
+    for (const string& opt : commandOpts) of << opt << "\n";
+    of << hierBlockArgs().front() << "\n";
+    for (const auto& hierblockp : m_children) of << hierblockp->hierBlockArgs().front() << "\n";
+    of << v3Global.opt.allArgsStringForHierBlock(false) << "\n";
 }
 
 string V3HierBlock::commandArgsFileName(bool forCMake) const {
@@ -395,36 +395,35 @@ void V3HierBlockPlan::writeCommandArgsFiles(bool forCMake) const {
         it->second->writeCommandArgsFile(forCMake);
     }
     // For the top module
-    const std::unique_ptr<std::ofstream> of{
-        V3File::new_ofstream(topCommandArgsFileName(forCMake))};
+    std::ofstream of = V3File::new_ofstream(topCommandArgsFileName(forCMake));
     if (!forCMake) {
         // Load wrappers first not to be overwritten by the original HDL
         for (const_iterator it = begin(); it != end(); ++it) {
-            *of << it->second->hierWrapper(true) << "\n";
+            of << it->second->hierWrapper(true) << "\n";
         }
     }
-    V3HierWriteCommonInputs(nullptr, of.get(), forCMake);
+    V3HierWriteCommonInputs(nullptr, &of, forCMake);
     if (!forCMake) {
         const V3StringSet& cppFiles = v3Global.opt.cppFiles();
-        for (const string& i : cppFiles) *of << i << "\n";
-        *of << "--top-module " << v3Global.rootp()->topModulep()->name() << "\n";
-        *of << "--prefix " << v3Global.opt.prefix() << "\n";
-        *of << "-Mdir " << v3Global.opt.makeDir() << "\n";
-        *of << "--mod-prefix " << v3Global.opt.modPrefix() << "\n";
+        for (const string& i : cppFiles) of << i << "\n";
+        of << "--top-module " << v3Global.rootp()->topModulep()->name() << "\n";
+        of << "--prefix " << v3Global.opt.prefix() << "\n";
+        of << "-Mdir " << v3Global.opt.makeDir() << "\n";
+        of << "--mod-prefix " << v3Global.opt.modPrefix() << "\n";
     }
     for (const_iterator it = begin(); it != end(); ++it) {
-        *of << it->second->hierBlockArgs().front() << "\n";
+        of << it->second->hierBlockArgs().front() << "\n";
     }
 
     if (!v3Global.opt.libCreate().empty()) {
-        *of << "--lib-create " << v3Global.opt.libCreate() << "\n";
+        of << "--lib-create " << v3Global.opt.libCreate() << "\n";
     }
     if (v3Global.opt.protectKeyProvided()) {
-        *of << "--protect-key " << v3Global.opt.protectKeyDefaulted() << "\n";
+        of << "--protect-key " << v3Global.opt.protectKeyDefaulted() << "\n";
     }
-    *of << "--threads " << cvtToStr(v3Global.opt.threads()) << "\n";
-    *of << (v3Global.opt.systemC() ? "--sc" : "--cc") << "\n";
-    *of << v3Global.opt.allArgsStringForHierBlock(true) << "\n";
+    of << "--threads " << cvtToStr(v3Global.opt.threads()) << "\n";
+    of << (v3Global.opt.systemC() ? "--sc" : "--cc") << "\n";
+    of << v3Global.opt.allArgsStringForHierBlock(true) << "\n";
 }
 
 string V3HierBlockPlan::topCommandArgsFileName(bool forCMake) {

--- a/src/V3LinkDot.cpp
+++ b/src/V3LinkDot.cpp
@@ -161,9 +161,8 @@ public:
     void dumpSelf(const string& nameComment = "linkdot", bool force = false) {
         if (dumpLevel() >= 6 || force) {
             const string filename = v3Global.debugFilename(nameComment) + ".txt";
-            const std::unique_ptr<std::ofstream> logp{V3File::new_ofstream(filename)};
-            if (logp->fail()) v3fatal("Can't write " << filename);
-            std::ostream& os = *logp;
+            std::ofstream os = V3File::new_ofstream(filename);
+            if (os.fail()) v3fatal("Can't write " << filename);
             m_syms.dumpSelf(os);
             bool first = true;
             for (int samn = 0; samn < SAMN__MAX; ++samn) {

--- a/src/V3Options.cpp
+++ b/src/V3Options.cpp
@@ -1750,16 +1750,16 @@ void V3Options::parseOptsFile(FileLine* fl, const string& filename, bool rel) VL
     // Read the specified -f filename and process as arguments
     UINFO(1, "Reading Options File " << filename << endl);
 
-    const std::unique_ptr<std::ifstream> ifp{V3File::new_ifstream(filename)};
-    if (ifp->fail()) {
+    std::ifstream ifp = V3File::new_ifstream(filename);
+    if (ifp.fail()) {
         fl->v3error("Cannot open -f command file: " + filename);
         return;
     }
 
     string whole_file;
     bool inCmt = false;
-    while (!ifp->eof()) {
-        const string line = V3Os::getline(*ifp);
+    while (!ifp.eof()) {
+        const string line = V3Os::getline(ifp);
         // Strip simple comments
         string oline;
         // cppcheck-suppress StlMissingComparison

--- a/src/V3OrderParallel.cpp
+++ b/src/V3OrderParallel.cpp
@@ -554,9 +554,8 @@ public:
     static void dumpCpFilePrefixed(const V3Graph& graph, const string& nameComment) {
         const string filename = v3Global.debugFilename(nameComment) + ".txt";
         UINFO(1, "Writing " << filename << endl);
-        const std::unique_ptr<std::ofstream> ofp{V3File::new_ofstream(filename)};
-        std::ostream* const osp = &(*ofp);  // &* needed to deref unique_ptr
-        if (osp->fail()) v3fatalStatic("Can't write " << filename);
+        std::ofstream osp = V3File::new_ofstream(filename);
+        if (osp.fail()) v3fatalStatic("Can't write " << filename);
 
         // Find start vertex with longest CP
         const LogicMTask* startp = nullptr;
@@ -586,17 +585,17 @@ public:
             }
         }
 
-        *osp << "totalCost = " << totalCost
+        osp << "totalCost = " << totalCost
              << " (should match the computed critical path cost (CP) for the graph)\n";
 
         // Dump
         for (const LogicMTask* mtaskp : path) {
-            *osp << "begin mtask with cost " << mtaskp->cost() << '\n';
+            osp << "begin mtask with cost " << mtaskp->cost() << '\n';
             for (const OrderMoveVertex& mVtx : mtaskp->vertexList()) {
                 const OrderLogicVertex* const logicp = mVtx.logicp();
                 if (!logicp) continue;
                 // Show nodes with hierarchical costs
-                V3InstrCount::count(logicp->nodep(), false, osp);
+                V3InstrCount::count(logicp->nodep(), false, &osp);
             }
         }
     }

--- a/src/V3OrderProcessDomains.cpp
+++ b/src/V3OrderProcessDomains.cpp
@@ -152,8 +152,8 @@ class V3OrderProcessDomains final {
     void processEdgeReport() {
         // Make report of all signal names and what clock edges they have
         const string filename = v3Global.debugFilename(m_tag + "_order_edges.txt");
-        const std::unique_ptr<std::ofstream> logp{V3File::new_ofstream(filename)};
-        if (logp->fail()) v3fatal("Can't write " << filename);
+        std::ofstream logp = V3File::new_ofstream(filename);
+        if (logp.fail()) v3fatal("Can't write " << filename);
 
         std::deque<string> report;
 
@@ -194,9 +194,9 @@ class V3OrderProcessDomains final {
             }
         }
 
-        *logp << "Signals and their clock domains:\n";
+        logp << "Signals and their clock domains:\n";
         stable_sort(report.begin(), report.end());
-        for (const string& i : report) *logp << i << '\n';
+        for (const string& i : report) logp << i << '\n';
     }
 
     // CONSTRUCTOR

--- a/src/V3StatsReport.cpp
+++ b/src/V3StatsReport.cpp
@@ -174,8 +174,8 @@ public:
     static void calculate() { sumit(); }
 
     // CONSTRUCTORS
-    explicit StatsReport(std::ofstream* aofp)
-        : os(*aofp) {  // Need () or GCC 4.8 false warning
+    explicit StatsReport(std::ofstream& aofp)
+        : os(aofp) {  // Need () or GCC 4.8 false warning
         os << "Verilator Statistics Report\n\n";
         V3Stats::infoHeader(os, "");
         sumit();
@@ -233,14 +233,13 @@ void V3Stats::statsReport() {
     // Open stats file
     const string filename
         = v3Global.opt.hierTopDataDir() + "/" + v3Global.opt.prefix() + "__stats.txt";
-    std::ofstream* ofp{V3File::new_ofstream(filename)};
-    if (ofp->fail()) v3fatal("Can't write " << filename);
+    std::ofstream ofp = V3File::new_ofstream(filename);
+    if (ofp.fail()) v3fatal("Can't write " << filename);
 
     { StatsReport{ofp}; }  // Destruct before cleanup
 
     // Cleanup
-    ofp->close();
-    VL_DO_DANGLING(delete ofp, ofp);
+    ofp.close();
 }
 
 void V3Stats::summaryReport() {

--- a/src/V3SymTable.h
+++ b/src/V3SymTable.h
@@ -317,9 +317,9 @@ public:
         if (dumpTreeLevel()) {
             const string filename = v3Global.debugFilename(nameComment) + ".txt";
             UINFO(2, "Dumping " << filename << endl);
-            const std::unique_ptr<std::ofstream> logp{V3File::new_ofstream(filename)};
-            if (logp->fail()) v3fatal("Can't write " << filename);
-            dumpSelf(*logp, "");
+            std::ofstream logp = V3File::new_ofstream(filename);
+            if (logp.fail()) v3fatal("Can't write " << filename);
+            dumpSelf(logp, "");
         }
     }
 

--- a/src/V3TSP.cpp
+++ b/src/V3TSP.cpp
@@ -396,9 +396,9 @@ public:
     void dumpGraphFilePrefixed(const string& nameComment) const {
         if (dumpLevel()) {
             const string filename = v3Global.debugFilename(nameComment) + ".txt";
-            const std::unique_ptr<std::ofstream> logp{V3File::new_ofstream(filename)};
-            if (logp->fail()) v3fatal("Can't write " << filename);
-            dumpGraph(*logp, nameComment);
+            std::ofstream logp = V3File::new_ofstream(filename);
+            if (logp.fail()) v3fatal("Can't write " << filename);
+            dumpGraph(logp, nameComment);
         }
     }
 

--- a/src/V3Waiver.cpp
+++ b/src/V3Waiver.cpp
@@ -38,24 +38,24 @@ void V3Waiver::addEntry(V3ErrorCode errorCode, const std::string& filename, cons
 }
 
 void V3Waiver::write(const std::string& filename) VL_MT_SAFE_EXCLUDES(s_mutex) {
-    const std::unique_ptr<std::ofstream> ofp{V3File::new_ofstream(filename)};
-    if (ofp->fail()) v3fatal("Can't write " << filename);
+    std::ofstream ofp = V3File::new_ofstream(filename);
+    if (ofp.fail()) v3fatal("Can't write " << filename);
 
-    *ofp << "// DESCR"
-            "IPTION: Verilator output: Waivers generated with --waiver-output\n\n";
+    ofp << "// DESCR"
+           "IPTION: Verilator output: Waivers generated with --waiver-output\n\n";
 
-    *ofp << "`verilator_config\n\n";
+    ofp << "`verilator_config\n\n";
 
-    *ofp << "// Below you find suggested waivers. You have three options:\n";
-    *ofp << "//   1. Fix the reason for the linter warning\n";
-    *ofp << "//   2. Keep the waiver permanently if you are sure this is okay\n";
-    *ofp << "//   3. Keep the waiver temporarily to suppress the output\n\n";
+    ofp << "// Below you find suggested waivers. You have three options:\n";
+    ofp << "//   1. Fix the reason for the linter warning\n";
+    ofp << "//   2. Keep the waiver permanently if you are sure this is okay\n";
+    ofp << "//   3. Keep the waiver temporarily to suppress the output\n\n";
 
     const V3LockGuard lock{s_mutex};
 
-    if (s_waiverList.empty()) *ofp << "// No waivers needed - great!\n";
+    if (s_waiverList.empty()) ofp << "// No waivers needed - great!\n";
 
-    for (const auto& i : s_waiverList) *ofp << "// " << i << "\n\n";
+    for (const auto& i : s_waiverList) ofp << "// " << i << "\n\n";
 }
 
 V3Mutex V3Waiver::s_mutex;


### PR DESCRIPTION
I find lots of `unique_ptr<ostream>` in code, the unique_ptr indirection seems unnecessary and `*os` everywhere clutters code.

So I decide to remove it. I feel it generally makes code cleaner.

The rest changes simply fix up compile errors. It's massive but straightforward. No functional change is expected.