### PR TITLE
Tests for `$typename` (#5083)

### DIFF
--- a/test_regress/t/t_typename.out
+++ b/test_regress/t/t_typename.out
@@ -1,0 +1,19 @@
+real
+int
+int
+logic
+string
+real
+logic
+bit
+bit[2:0]
+bit$[3:2]
+bit$[3:1][4:5]
+
+bit
+bit[2:0]
+int
+A::__typeimpenum1
+bit[9:1]
+STRUCTDTYPE 't.AB_t'$[0:9]
+*-* All Finished *-*

--- a/test_regress/t/t_typename.pl
+++ b/test_regress/t/t_typename.pl
@@ -15,6 +15,7 @@ compile(
 
 execute(
     check_finished => 1,
+    expect_filename => $Self->{golden_filename},
     );
 
 ok(1);

--- a/test_regress/t/t_typename.v
+++ b/test_regress/t/t_typename.v
@@ -4,8 +4,27 @@
 // any use, without warranty, 2020 by Wilson Snyder.
 // SPDX-License-Identifier: CC0-1.0
 
-`define stop $stop
-`define checks(gotv,expv) do if ((gotv) != (expv)) begin $write("%%Error: %s:%0d:  got='%s' exp='%s'\n", `__FILE__,`__LINE__, (gotv), (expv)); `stop; end while(0);
+
+`define printtype(mytype) $write({$typename(mytype), "\n"});
+
+// Copied from 20.6.1 Type name function in IEEE 1800-2017
+// source code // $typename would return
+typedef bit node; // "bit"
+node [2:0] X; // "bit [2:0]"
+int signed Y; // "int"
+
+package A;
+   enum {A,B,C=99} X; // "enum{A=32'sd0,B=32'sd1,C=32'sd99}A::e$1"
+   typedef bit [9:1'b1] word; // "A::bit[9:1]"
+endpackage : A
+
+import A::*;
+
+// moved into t
+// module top;
+//    typedef struct {node A,B;} AB_t;
+//    AB_t AB[10]; // "struct{bit A;bit B;}top.AB_t$[0:9]"
+// endmodule
 
 module t(/*AUTOARG*/);
 
@@ -16,19 +35,34 @@ module t(/*AUTOARG*/);
    mybit_t bitu32 [3:2];
    mybit_t bitu31 [3:1][4:5];
 
-   initial begin
-      `checks($typename(real), "real");
-      `checks($typename(bit), "bit");
-      `checks($typename(int), "int");
-      `checks($typename(logic), "logic");
-      `checks($typename(string), "string");
 
-      `checks($typename(r), "real");
-      `checks($typename(l), "logic");
-      `checks($typename(mybit_t), "bit");
-      `checks($typename(bitp20), "bit[2:0]");
-      `checks($typename(bitu32), "bit$[3:2]");
-      `checks($typename(bitu31), "bit$[3:1][4:5]");
+   // from LRM
+   typedef struct {node A,B;} AB_t;
+   AB_t AB[10]; // "struct{bit A;bit B;}top.AB_t$[0:9]"
+
+   initial begin
+      // $write({$typename(real), "\n"});
+      `printtype(real);
+      `printtype(int);
+      `printtype(int);
+      `printtype(logic);
+      `printtype(string);
+      `printtype(r);
+      `printtype(l);
+      `printtype(mybit_t);
+      `printtype(bitp20);
+      `printtype(bitu32);
+      `printtype(bitu31);
+
+      $write("\n");
+      // from LRM
+      `printtype(node); // bit
+      `printtype(X); // bit [2:0]
+      `printtype(Y); // int
+      `printtype(A::X); // enum{A=32'sd0,B=32'sd1,C=32'sd99}A::e$1
+      `printtype(A::word); // A::bit[9:1]
+      `printtype(AB); // struct{bit A;bit B;}top.AB_t$[0:9]
+
       $write("*-* All Finished *-*\n");
       $finish;
    end


### PR DESCRIPTION
Typename tc

According to the spec, the last three lines should be 

```
enum{A=32'sd0,B=32'sd1,C=32'sd99}A::e$1
A::bit[9:1]
struct{bit A;bit B;}top.AB_t$[0:9]
```