### PR TITLE
Remove C-style cast in VPI_HANDLE

### DIFF
--- a/test_regress/t/TestSimulator.h
+++ b/test_regress/t/TestSimulator.h
@@ -81,4 +81,5 @@ public:
     }
 };
 
-#define VPI_HANDLE(signal) vpi_handle_by_name((PLI_BYTE8*)TestSimulator::rooted(signal), NULL);
+#define VPI_HANDLE(signal) \
+    vpi_handle_by_name(const_cast<char*>(TestSimulator::rooted(signal)), NULL);

--- a/test_regress/t/TestSimulator.h
+++ b/test_regress/t/TestSimulator.h
@@ -82,4 +82,4 @@ public:
 };
 
 #define VPI_HANDLE(signal) \
-    vpi_handle_by_name(const_cast<PLI_BYTE8*>(TestSimulator::rooted(signal)), NULL);
+    vpi_handle_by_name(const_cast<PLI_BYTE8*>(TestSimulator::rooted(signal)), nullptr);

--- a/test_regress/t/TestSimulator.h
+++ b/test_regress/t/TestSimulator.h
@@ -82,4 +82,4 @@ public:
 };
 
 #define VPI_HANDLE(signal) \
-    vpi_handle_by_name(const_cast<char*>(TestSimulator::rooted(signal)), NULL);
+    vpi_handle_by_name(const_cast<PLI_BYTE8*>(TestSimulator::rooted(signal)), NULL);


### PR DESCRIPTION
Makes the Codacy check happy.  Also admits that we're ditching `const` here (thanks VPI).