### PR TITLE
Support NBAs to arrays inside loops

### DIFF
--- a/docs/guide/warnings.rst
+++ b/docs/guide/warnings.rst
@@ -210,22 +210,35 @@ List Of Warnings
 
 .. option:: BLKLOOPINIT
 
-   .. TODO better example
-
-   This indicates that the initialization of an array needs to use
-   non-delayed assignments.  This is done in the interest of speed; if
-   delayed assignments were used, the simulator would have to copy large
-   arrays every cycle.  (In smaller loops, loop unrolling allows the
-   delayed assignment to work, though it's a bit slower than a non-delayed
-   assignment.)  Here's an example
+   Indicates certain constructs where non-blocking assignments to unpacked
+   arrays (memories) are not supported inside loops. These typically appear in
+   initialization/reset code:
 
    .. code-block:: sv
 
          always @(posedge clk)
             if (~reset_l)
                 for (i=0; i<`ARRAY_SIZE; i++)
-                    array[i] = 0;  // Non-delayed for verilator
+                    array[i] <= 0;  // Non-blocking assignment inside loop
+            else
+                array[address] <= data;
 
+   While this is supported in typical synthesizeable code (including the
+   example above), some complicated cases are not supported. Namely:
+
+   1. If the above loop is inside a suspendable process or fork statement.
+
+   2. If the variable is also the target of a '<=' non-blocking assignment
+   in a suspendable process or fork statement (in addition to a synthesizable
+   loop).
+
+   3. If the element type of the array is a compound type.
+
+   4. In versions before 5.026, any delayed assignment to an array.
+
+   It might slightly improve run-time performance if you change the
+   non-blocking assignment inside the loop into a blocking assignment
+   (that is: use '=' instead of '<='), if possible.
 
    This message is only seen on large or complicated loops because
    Verilator generally unrolls small loops.  You may want to try increasing

--- a/src/V3AstNodeDType.h
+++ b/src/V3AstNodeDType.h
@@ -959,6 +959,30 @@ public:
         return false;
     }
 };
+class AstNBACommitQueueDType final : public AstNodeDType {
+    // @astgen ptr := m_subDTypep : AstNodeDType  // Type of the corresponding variable
+    const bool m_partial;  // Partial element update required
+
+public:
+    AstNBACommitQueueDType(FileLine* fl, AstNodeDType* subDTypep, bool partial)
+        : ASTGEN_SUPER_NBACommitQueueDType(fl)
+        , m_partial{partial}
+        , m_subDTypep{subDTypep} {
+        dtypep(this);
+    }
+    ASTGEN_MEMBERS_AstNBACommitQueueDType;
+
+    AstNodeDType* subDTypep() const override { return m_subDTypep; }
+    bool partial() const { return m_partial; }
+    bool similarDType(const AstNodeDType* samep) const override { return this == samep; }
+    AstBasicDType* basicp() const override { return nullptr; }
+    AstNodeDType* skipRefp() const override { return (AstNodeDType*)this; }
+    AstNodeDType* skipRefToConstp() const override { return (AstNodeDType*)this; }
+    AstNodeDType* skipRefToEnump() const override { return (AstNodeDType*)this; }
+    int widthAlignBytes() const override { return 1; }
+    int widthTotalBytes() const override { return 24; }
+    bool isCompound() const override { return true; }
+};
 class AstParamTypeDType final : public AstNodeDType {
     // Parents: MODULE
     // A parameter type statement; much like a var or typedef

--- a/src/V3EmitCImp.cpp
+++ b/src/V3EmitCImp.cpp
@@ -389,6 +389,7 @@ class EmitCImp final : EmitCFunc {
                         } else if (varp->isParam()) {
                         } else if (varp->isStatic() && varp->isConst()) {
                         } else if (varp->basicp() && varp->basicp()->isTriggerVec()) {
+                        } else if (VN_IS(varp->dtypep(), NBACommitQueueDType)) {
                         } else {
                             int vects = 0;
                             AstNodeDType* elementp = varp->dtypeSkipRefp();

--- a/src/V3Localize.cpp
+++ b/src/V3Localize.cpp
@@ -63,6 +63,8 @@ class LocalizeVisitor final : public VNVisitor {
 
     // METHODS
     bool isOptimizable(AstVarScope* nodep) {
+        // Don't want to malloc/free the backing store all the time
+        if (VN_IS(nodep->dtypep(), NBACommitQueueDType)) return false;
         return ((!nodep->user1()  // Not marked as not optimizable, or ...
                                   // .. a block temp used in a single CFunc
                  || (nodep->varp()->varType() == VVarType::BLOCKTEMP

--- a/test_regress/t/t_nba_commit_queue.pl
+++ b/test_regress/t/t_nba_commit_queue.pl
@@ -1,0 +1,27 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2024 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(vlt_all => 1);
+
+compile(
+    verilator_flags2 => ["-unroll-count 1", "--stats"],
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+file_grep($Self->{stats}, qr/Dynamic NBA, variables needing commit queue without partial updates\s+(\d+)/i,
+          6);
+file_grep($Self->{stats}, qr/Dynamic NBA, variables needing commit queue with partial updates\s+(\d+)/i,
+          3);
+
+ok(1);
+1;

--- a/test_regress/t/t_nba_commit_queue.v
+++ b/test_regress/t/t_nba_commit_queue.v
@@ -1,0 +1,300 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2024 by Wilson Snyder.
+// SPDX-License-Identifier: CC0-1.0
+
+`define stop $stop
+`define checkh(gotv,expv) do if ((gotv) !== (expv)) begin $write("%%Error: %s:%0d:  got='h%x exp='h%x\n", `__FILE__,`__LINE__, (gotv), (expv)); `stop; end while(0)
+`define checkr(gotv,expv) do if ((gotv) != (expv)) begin $write("%%Error: %s:%0d:  got=%f exp=%f\n", `__FILE__,`__LINE__, (gotv), (expv)); `stop; end while(0);
+`define checks(gotv,expv) do if ((gotv) !== (expv)) begin $write("%%Error: %s:%0d:  got='%s' exp='%s'\n", `__FILE__,`__LINE__, (gotv), (expv)); `stop; end while(0);
+
+
+
+module t(clk);
+  input clk;
+
+  logic [31:0] cyc = 0;
+  always @(posedge clk) begin
+    cyc <= cyc + 1;
+    if (cyc == 99) begin
+      $write("*-* All Finished *-*\n");
+      $finish;
+    end
+  end
+
+  reg [63:0] crc = 64'h5aef0c8d_d70a4497;
+  always @ (posedge clk) crc <= {crc[62:0], crc[63] ^ crc[2] ^ crc[0]};
+
+`define at_posedge_clk_on_cycle(n) always @(posedge clk) if (cyc == n)
+
+  // Case 1: narrow packed variable, whole element updates only - 1D
+  typedef logic [31:0] elem1_t;
+  typedef elem1_t array1_t[128];
+  array1_t array1;
+  `at_posedge_clk_on_cycle(0) begin
+    for (int i = 0 ; i < 128; ++i) array1[i] = 0;
+    for (int i = 0 ; i < 128; ++i) `checkh(array1[i], 0);
+  end
+  `at_posedge_clk_on_cycle(1) begin
+    for (int i = 0 ; i < 128; ++i) `checkh(array1[i], 0);
+    for (int i = 0 ; i < 128; ++i) array1[i] <= i;
+    for (int i = 0 ; i < 128; ++i) `checkh(array1[i], 0);
+  end
+  `at_posedge_clk_on_cycle(2) begin
+    for (int i = 0 ; i < 128; ++i) `checkh(array1[i], i);
+    for (int i = 0 ; i < 128; ++i) array1[i] <= ~i;
+    for (int i = 0 ; i < 128; ++i) `checkh(array1[i], i);
+  end
+  `at_posedge_clk_on_cycle(3) begin
+    for (int i = 0 ; i < 128; ++i) `checkh(array1[i], ~i);
+    for (int i = 0 ; i < 128; ++i) array1[i] <= -1;
+    for (int i = 0 ; i < 128; ++i) `checkh(array1[i], ~i);
+  end
+  `at_posedge_clk_on_cycle(4) begin
+    for (int i = 0 ; i < 128; ++i) `checkh(array1[i], -1);
+  end
+
+  // Case 2: wide packed variable, whole element updates only - 1D
+  typedef logic [127:0] elem2_t;
+  typedef elem2_t array2_t[128];
+  array2_t array2;
+  `at_posedge_clk_on_cycle(0) begin
+    for (int i = 0 ; i < 128; ++i) array2[i] = 0;
+    for (int i = 0 ; i < 128; ++i) `checkh(array2[i], 0);
+  end
+  `at_posedge_clk_on_cycle(1) begin
+    for (int i = 0 ; i < 128; ++i) `checkh(array2[i], 0);
+    for (int i = 0 ; i < 128; ++i) array2[i] <= {4{i}};
+    for (int i = 0 ; i < 128; ++i) `checkh(array2[i], 0);
+  end
+  `at_posedge_clk_on_cycle(2) begin
+    for (int i = 0 ; i < 128; ++i) `checkh(array2[i], {4{i}});
+    for (int i = 0 ; i < 128; ++i) array2[i] <= {4{~i}};
+    for (int i = 0 ; i < 128; ++i) `checkh(array2[i], {4{i}});
+  end
+  `at_posedge_clk_on_cycle(3) begin
+    for (int i = 0 ; i < 128; ++i) `checkh(array2[i], {4{~i}});
+    for (int i = 0 ; i < 128; ++i) array2[i] <= '1;
+    for (int i = 0 ; i < 128; ++i) `checkh(array2[i], {4{~i}});
+  end
+  `at_posedge_clk_on_cycle(4) begin
+    for (int i = 0 ; i < 128; ++i) `checkh(array2[i], ~128'b0);
+  end
+
+
+  // Case 3: wide packed variable, whole element updates only - 2D
+  typedef logic [127:0] elem3_t;
+  typedef elem3_t array3sub_t[512];
+  typedef array3sub_t array3_t[128];
+  array3_t array3;
+  `at_posedge_clk_on_cycle(0) begin
+    for (int i = 0 ; i < 128; ++i) for (int j = 0 ; j < 512; ++j) array3[i][j] = 0;
+    for (int i = 0 ; i < 128; ++i) for (int j = 0 ; j < 512; ++j) `checkh(array3[i][j], 0);
+  end
+  `at_posedge_clk_on_cycle(1) begin
+    for (int i = 0 ; i < 128; ++i) for (int j = 0 ; j < 512; ++j) `checkh(array3[i][j], 0);
+    for (int i = 0 ; i < 128; ++i) for (int j = 0 ; j < 512; ++j) array3[i][j] <= {4{i}};
+    for (int i = 0 ; i < 128; ++i) for (int j = 0 ; j < 512; ++j) `checkh(array3[i][j], 0);
+  end
+  `at_posedge_clk_on_cycle(2) begin
+    for (int i = 0 ; i < 128; ++i) for (int j = 0 ; j < 512; ++j) `checkh(array3[i][j], {4{i}});
+    for (int i = 0 ; i < 128; ++i) for (int j = 0 ; j < 512; ++j) array3[i][j] <= {4{~i}};
+    for (int i = 0 ; i < 128; ++i) for (int j = 0 ; j < 512; ++j) `checkh(array3[i][j], {4{i}});
+  end
+  `at_posedge_clk_on_cycle(3) begin
+    for (int i = 0 ; i < 128; ++i) for (int j = 0 ; j < 512; ++j) `checkh(array3[i][j], {4{~i}});
+    for (int i = 0 ; i < 128; ++i) for (int j = 0 ; j < 512; ++j) array3[i][j] <= '1;
+    for (int i = 0 ; i < 128; ++i) for (int j = 0 ; j < 512; ++j) `checkh(array3[i][j], {4{~i}});
+  end
+  `at_posedge_clk_on_cycle(4) begin
+    for (int i = 0 ; i < 128; ++i) for (int j = 0 ; j < 512; ++j) `checkh(array3[i][j], ~128'b0);
+  end
+
+  // Case 4: real
+  typedef real elem4_t;
+  typedef elem4_t array4_t[128];
+  array4_t array4;
+  `at_posedge_clk_on_cycle(0) begin
+    for (int i = 0 ; i < 128; ++i) array4[i] = 1e-5;
+    for (int i = 0 ; i < 128; ++i) `checkr(array4[i], 1e-5);
+  end
+  `at_posedge_clk_on_cycle(1) begin
+    for (int i = 0 ; i < 128; ++i) `checkr(array4[i], 1e-5);
+    for (int i = 0 ; i < 128; ++i) array4[i] <= 3.14*real'(i);
+    for (int i = 0 ; i < 128; ++i) `checkr(array4[i], 1e-5);
+  end
+  `at_posedge_clk_on_cycle(2) begin
+    for (int i = 0 ; i < 128; ++i) `checkr(array4[i], 3.14*real'(i));
+    for (int i = 0 ; i < 128; ++i) array4[i] <= 2.78*real'(i);
+    for (int i = 0 ; i < 128; ++i) `checkr(array4[i], 3.14*real'(i));
+  end
+  `at_posedge_clk_on_cycle(3) begin
+    for (int i = 0 ; i < 128; ++i) `checkr(array4[i], 2.78*real'(i));
+    for (int i = 0 ; i < 128; ++i) array4[i] <= 1e50;
+    for (int i = 0 ; i < 128; ++i) `checkr(array4[i], 2.78*real'(i));
+  end
+  `at_posedge_clk_on_cycle(4) begin
+    for (int i = 0 ; i < 128; ++i) `checkr(array4[i], 1e50);
+  end
+
+  // Case 5: narrow packed variable, partial element updates - 1D
+  typedef logic [31:0] elem5_t;
+  typedef elem5_t array5_t[128];
+  array5_t array5;
+  `at_posedge_clk_on_cycle(0) begin
+    for (int i = 0 ; i < 128; ++i) array5[i] = -1;
+    for (int i = 0 ; i < 128; ++i) `checkh(array5[i], -1);
+  end
+  `at_posedge_clk_on_cycle(1) begin
+    for (int i = 0 ; i < 128; ++i) `checkh(array5[i], -1);
+    for (int i = 0 ; i < 128; ++i) array5[i][0] <= 1'b0;
+    for (int i = 0 ; i < 128; ++i) array5[i][1] <= 1'b0;
+    for (int i = 0 ; i < 128; ++i) array5[i][2] <= 1'b0;
+    for (int i = 0 ; i < 128; ++i) array5[i][1] <= 1'b1;
+    for (int i = 0 ; i < 128; ++i) `checkh(array5[i], -1);
+  end
+  `at_posedge_clk_on_cycle(2) begin
+    for (int i = 0 ; i < 128; ++i) `checkh(array5[i], 32'hffff_fffa);
+    for (int i = 0 ; i < 128; ++i) array5[i][18:16] <=  i[3:1];
+    for (int i = 0 ; i < 128; ++i) array5[i][19:17] <= ~i[2:0];
+    for (int i = 0 ; i < 128; ++i) `checkh(array5[i], 32'hffff_fffa);
+  end
+  `at_posedge_clk_on_cycle(3) begin
+    for (int i = 0 ; i < 128; ++i) `checkh(array5[i], {12'hfff, ~i[2:0], i[1], 16'hfffa});
+    for (int i = 0 ; i < 128; ++i) array5[i] <= -1;
+    for (int i = 0 ; i < 128; ++i) `checkh(array5[i], {12'hfff, ~i[2:0], i[1], 16'hfffa});
+  end
+  `at_posedge_clk_on_cycle(4) begin
+    for (int i = 0 ; i < 128; ++i) `checkh(array5[i], -1);
+  end
+
+  // Case 6: wide packed variable, partial element updates - 1D
+  typedef logic [99:0] elem6_t;
+  typedef elem6_t array6_t[128];
+  array6_t array6;
+  `at_posedge_clk_on_cycle(0) begin
+    for (int i = 0 ; i < 128; ++i) array6[i] = -1;
+    for (int i = 0 ; i < 128; ++i) `checkh(array6[i], -1);
+  end
+  `at_posedge_clk_on_cycle(1) begin
+    for (int i = 0 ; i < 128; ++i) `checkh(array6[i], -1);
+    for (int i = 0 ; i < 128; ++i) array6[i][80] <= 1'b0;
+    for (int i = 0 ; i < 128; ++i) array6[i][81] <= 1'b0;
+    for (int i = 0 ; i < 128; ++i) array6[i][82] <= 1'b0;
+    for (int i = 0 ; i < 128; ++i) array6[i][81] <= 1'b1;
+    for (int i = 0 ; i < 128; ++i) `checkh(array6[i], -1);
+  end
+  `at_posedge_clk_on_cycle(2) begin
+    for (int i = 0 ; i < 128; ++i) `checkh(array6[i], 100'hf_fffa_ffff_ffff_ffff_ffff_ffff);
+    for (int i = 0 ; i < 128; ++i) array6[i][86:84] <= ~i[3:1];
+    for (int i = 0 ; i < 128; ++i) array6[i][87:85] <=  i[2:0];
+    for (int i = 0 ; i < 128; ++i) `checkh(array6[i], 100'hf_fffa_ffff_ffff_ffff_ffff_ffff);
+  end
+  `at_posedge_clk_on_cycle(3) begin
+    for (int i = 0 ; i < 128; ++i) `checkh(array6[i], {12'hfff, i[2:0], ~i[1], 84'ha_ffff_ffff_ffff_ffff_ffff});
+    for (int i = 0 ; i < 128; ++i) array6[i] <= -1;
+    for (int i = 0 ; i < 128; ++i) `checkh(array6[i], {12'hfff, i[2:0], ~i[1], 84'ha_ffff_ffff_ffff_ffff_ffff});
+  end
+  `at_posedge_clk_on_cycle(4) begin
+    for (int i = 0 ; i < 128; ++i) `checkh(array6[i], -1);
+  end
+
+  // Case 7: variable partial updates
+  typedef logic [99:0] elem7_t;
+  typedef elem7_t array7sub_t[256];
+  typedef array7sub_t array7_t[128];
+  array7_t array7_nba;
+  array7_t array7_ref;
+  always @(posedge clk) begin
+    if (cyc == 0) begin
+      for (int i = 0 ; i < 128; ++i) for (int j = 0 ; j < 256; ++j) array7_nba[i][j] =  100'b0;
+      for (int i = 0 ; i < 128; ++i) for (int j = 0 ; j < 256; ++j) array7_ref[i][j] = ~100'b0;
+    end else begin
+      for (int i = 0 ; i < 128; ++i) for (int j = 0 ; j < 256; ++j) `checkh(array7_nba[i][j], ~array7_ref[i][j]);
+      for (int i = 0 ; i < 128; ++i) begin
+        for (int j = 0 ; j < 256; ++j) begin
+            array7_nba[i[6:0] ^ crc[30+:7]][j[7:0] ^ crc[10+:8]][7'((crc % 10) * 5) +: 5] <= ~crc[4+:5];
+            array7_ref[i[6:0] ^ crc[30+:7]][j[7:0] ^ crc[10+:8]][7'((crc % 10) * 5) +: 5]  =  crc[4+:5];
+        end
+      end
+    end
+  end
+
+  // Case 8: Mixed dynamic/non-dynamic
+  typedef longint elem8_t;
+  typedef elem8_t array8_t[4];
+  array8_t array8;
+  `at_posedge_clk_on_cycle(0) begin
+      array8[0] <= 0;
+      array8[1] <= 0;
+      array8[2] <= 0;
+      array8[3] <= 0;
+  end
+  `at_posedge_clk_on_cycle(1) begin
+      `checkh(array8[0], 0);
+      `checkh(array8[1], 0);
+      `checkh(array8[2], 0);
+      `checkh(array8[3], 0);
+      array8[1] <= 42;
+      array8[3] <= 63;
+      for (int i = 1 ; i < 3 ; ++i) array8[i] <= 2*i + 7;
+      array8[1] <= 74;
+  end
+  `at_posedge_clk_on_cycle(3) begin
+      `checkh(array8[0], 0);
+      `checkh(array8[1], 74);
+      `checkh(array8[2], 11);
+      `checkh(array8[3], 63);
+  end
+
+  // Case 9: string
+  typedef string elem9_t;
+  typedef elem9_t array9_t[10];
+  array9_t array9;
+  `at_posedge_clk_on_cycle(0) begin
+    for (int i = 0 ; i < 10; ++i) array9[i] = "squid";
+    for (int i = 0 ; i < 10; ++i) `checks(array9[i], "squid");
+  end
+  `at_posedge_clk_on_cycle(1) begin
+    for (int i = 0 ; i < 10; ++i) `checks(array9[i], "squid");
+    for (int i = 0 ; i < 10; ++i) array9[i] <= "octopus";
+    for (int i = 0 ; i < 10; ++i) `checks(array9[i], "squid");
+  end
+  `at_posedge_clk_on_cycle(2) begin
+    for (int i = 0 ; i < 10; ++i) `checks(array9[i], "octopus");
+    for (int i = 1 ; i < 9; ++i) begin
+      string tmp;
+      $sformat(tmp, "%0d-legged-cephalopod", i);
+      array9[i] <= tmp;
+    end
+    for (int i = 0 ; i < 10; ++i) `checks(array9[i], "octopus");
+  end
+  `at_posedge_clk_on_cycle(3) begin
+    `checks(array9[0], "octopus");
+    `checks(array9[1], "1-legged-cephalopod");
+    `checks(array9[2], "2-legged-cephalopod");
+    `checks(array9[3], "3-legged-cephalopod");
+    `checks(array9[4], "4-legged-cephalopod");
+    `checks(array9[5], "5-legged-cephalopod");
+    `checks(array9[6], "6-legged-cephalopod");
+    `checks(array9[7], "7-legged-cephalopod");
+    `checks(array9[8], "8-legged-cephalopod");
+    `checks(array9[9], "octopus");
+    for (int i = 0 ; i < 10; ++i) array9[i] <= "cuttlefish";
+    `checks(array9[0], "octopus");
+    `checks(array9[1], "1-legged-cephalopod");
+    `checks(array9[2], "2-legged-cephalopod");
+    `checks(array9[3], "3-legged-cephalopod");
+    `checks(array9[4], "4-legged-cephalopod");
+    `checks(array9[5], "5-legged-cephalopod");
+    `checks(array9[6], "6-legged-cephalopod");
+    `checks(array9[7], "7-legged-cephalopod");
+    `checks(array9[8], "8-legged-cephalopod");
+    `checks(array9[9], "octopus");
+  end
+  `at_posedge_clk_on_cycle(4) begin
+    for (int i = 0 ; i < 10; ++i) `checks(array9[i], "cuttlefish");
+  end
+
+endmodule

--- a/test_regress/t/t_order_blkloopinit_bad.out
+++ b/test_regress/t/t_order_blkloopinit_bad.out
@@ -1,5 +1,18 @@
-%Error-BLKLOOPINIT: t/t_order_blkloopinit_bad.v:21:19: Unsupported: Delayed assignment to array inside for loops (non-delayed is ok - see docs)
-   21 |          array[i] <= 0;   
-      |                   ^~
+%Error-BLKLOOPINIT: t/t_order_blkloopinit_bad.v:26:20: Unsupported: Non-blocking assignment to array inside loop in suspendable process or fork
+                                                     : ... note: In instance 't'
+   26 |          array1[i] <= 0;   
+      |                    ^~
                     ... For error description see https://verilator.org/warn/BLKLOOPINIT?v=latest
+%Error-BLKLOOPINIT: t/t_order_blkloopinit_bad.v:36:20: Unsupported: Non-blocking assignment to array with compound element type inside loop
+                                                     : ... note: In instance 't'
+   36 |          array2[i] <= null;   
+      |                    ^~
+%Error-BLKLOOPINIT: t/t_order_blkloopinit_bad.v:45:20: Unsupported: Non-blocking assignment to array in both loop and suspendable process/fork
+                                                     : ... note: In instance 't'
+                    t/t_order_blkloopinit_bad.v:50:20: ... Location of non-blocking assignment in suspendable process/fork
+   50 |       #1 array3[0] <= 0;
+      |                    ^~
+                    t/t_order_blkloopinit_bad.v:45:20: ... Location of non-blocking assignment inside loop
+   45 |          array3[i] <= 0;   
+      |                    ^~
 %Error: Exiting due to

--- a/test_regress/t/t_order_blkloopinit_bad.pl
+++ b/test_regress/t/t_order_blkloopinit_bad.pl
@@ -11,6 +11,7 @@ if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); di
 scenarios(vlt => 1);
 
 lint(
+    verilator_flags2 => ["--timing"],
     fails => 1,
     expect_filename => $Self->{golden_filename},
     );

--- a/test_regress/t/t_order_blkloopinit_bad.v
+++ b/test_regress/t/t_order_blkloopinit_bad.v
@@ -4,6 +4,8 @@
 // any use, without warranty, 2020 by Wilson Snyder.
 // SPDX-License-Identifier: CC0-1.0
 
+// verilator lint_off MULTIDRIVEN
+
 module t (/*AUTOARG*/
    // Outputs
    o,
@@ -14,13 +16,38 @@ module t (/*AUTOARG*/
    output int o;
 
    localparam SIZE = 65536;
-   int array [SIZE];
 
+   // Unsupported case 1: Array NBA inside suspendable
+   int array1 [SIZE];
    always @ (posedge clk) begin
+      #1;
+      o <= array1[1];
       for (int i=0; i<SIZE; i++) begin
-         array[i] <= 0;  // BLKLOOPINIT
+         array1[i] <= 0;  // BLKLOOPINIT
       end
-      o <= array[1];
+   end
+
+   // Unsupported case 2: Array NBA to compund type
+   class C; endclass
+   C array2[SIZE];
+   always @ (negedge clk) begin
+      o <= int'(array2[1] == null);
+      for (int i=0; i<SIZE; i++) begin
+         array2[i] <= null;  // BLKLOOPINIT
+      end
+   end
+
+   // Unsupported case 3: Array NBA to array also assigned in suspendable
+   int array3 [SIZE];
+   always @ (posedge clk) begin
+      o <= array3[1];
+      for (int i=0; i<SIZE; i++) begin
+         array3[i] <= 0;  // BLKLOOPINIT
+      end
+   end
+
+   always @(posedge clk) begin
+      #1 array3[0] <= 0;
    end
 
 endmodule


### PR DESCRIPTION
--- Patch 3 of 3 towards supporting NBAs to arrays inside loops. ---

Depends on #5091

For NBAs that might execute a dynamic number of times in a single
evaluation (specifically: those that assign to array elements inside
loops), we introduce a new run-time VlNBACommitQueue data-structure
(currently a vector), which stores all pending updates and the necessary
info to reconstruct the LHS reference of the AstAssignDly at run-time.

All variables needing a commit queue has their corresponding unique
commit queue.

All NBAs to a variable that requires a commit queue go through the
commit queue. This is necessary to preserve update order in sequential
code, e.g.:
 a[7] <= 10
 for (int i = 1 ; i < 10; ++i) a[i] <= i;
 a[2] <= 10
needs to end with array elements 1..9 being 1, 10, 3, 4, 5, 6, 7, 8, 9.

This enables supporting common forms of NBAs to arrays on the left hand
side of <= in non-suspendable/non-fork code. (Suspendable/fork
implementation is unclear to me so I left it unchanged, see https://github.com/verilator/verilator/issues/5084).

Any NBA that does not need a commit queue (i.e.: those that were
supported before), use the same scheme as before, and this patch should
have no effect on the generated code for those NBAs.