### PR TITLE
Enable cmake-based installs to run driver.pl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,7 +98,14 @@ set(PACKAGE_VERSION ${PROJECT_VERSION})
 
 configure_file(include/verilated_config.h.in include/verilated_config.h @ONLY)
 
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/include/verilated_config.h DESTINATION ${CMAKE_INSTALL_PREFIX}/include)
+include(cmake/ConfigureVerilated.cmake)
+configure_verilated_mk(include/verilated.mk.in include/verilated.mk)
+
+install(FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/include/verilated_config.h
+    ${CMAKE_CURRENT_BINARY_DIR}/include/verilated.mk
+    DESTINATION ${CMAKE_INSTALL_PREFIX}/include
+)
 
 configure_package_config_file(verilator-config.cmake.in verilator-config.cmake
     INSTALL_DESTINATION ${CMAKE_INSTALL_PREFIX}
@@ -114,13 +121,25 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/verilator-config-version.cmake DESTINA
 
 foreach (program
     verilator
-    verilator_gantt
     verilator_ccache_report
+    verilator_coverage
     verilator_difftree
+    verilator_gantt
+    verilator_includer
     verilator_profcfunc
 )
     install(PROGRAMS bin/${program} TYPE BIN)
 endforeach()
+
+if(VERILATOR_INSTALL_GDBINIT)
+    foreach(program
+        .gdbinit
+        .gdbinit.py
+    )
+        install(PROGRAMS src/${program} DESTINATION ${CMAKE_INSTALL_PREFIX}/src)
+    endforeach()
+endif()
+
 
 install(DIRECTORY examples TYPE DATA FILES_MATCHING
     PATTERN "examples/*/*.[chv]*"
@@ -129,8 +148,6 @@ install(DIRECTORY examples TYPE DATA FILES_MATCHING
 )
 
 install(DIRECTORY include TYPE DATA FILES_MATCHING
-    PATTERN "include/verilated_config.h"
-    PATTERN "include/verilated.mk"
     PATTERN "include/*.[chv]"
     PATTERN "include/*.cpp"
     PATTERN "include/*.sv"

--- a/cmake/ConfigureVerilated.cmake
+++ b/cmake/ConfigureVerilated.cmake
@@ -1,0 +1,126 @@
+# *****************************************************************************
+#
+# DESCRIPTION: Utility CMake functions
+#
+# *****************************************************************************
+#
+# Copyright 2003-2024 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+#
+# ****************************************************************************/
+
+include(CheckCXXCompilerFlag)
+
+function(check_flag result flag)
+  set(${result} PARENT_SCOPE)
+  check_cxx_compiler_flag(${flag} "CXX_SUPPORT${flag}")
+
+  if(${CXX_SUPPORT${flag}})
+    set(${result} ${flag} PARENT_SCOPE)
+  endif()
+endfunction()
+
+function(check_flag_list result)
+  foreach(flag IN LISTS ARGN)
+    check_flag(flag_result ${flag})
+    list(APPEND flags ${flag_result})
+  endforeach()
+
+  string(REPLACE ";" " " flags "${flags}")
+  set(${result} ${flags} PARENT_SCOPE)
+endfunction()
+
+function(check_set result)
+  foreach(flag IN LISTS ARGN)
+    check_flag(flag_result ${flag})
+    set(${result} ${flag_result} PARENT_SCOPE)
+
+    if(flag_result)
+      return()
+    endif()
+  endforeach()
+endfunction()
+
+function(configure_verilated_mk mk_path_in mk_path_out)
+  set(AR ${CMAKE_AR})
+  set(CXX ${CMAKE_CXX_COMPILER})
+  set(LINK ${CMAKE_CXX_COMPILER})
+  set(OBJCACHE ${CMAKE_CXX_COMPILER_LAUNCHER})
+
+  find_package(Perl)
+  set(PERL ${PERL_EXECUTABLE})
+  set(PYTHON3 ${Python3_EXECUTABLE})
+
+  set(CFG_WITH_CCWARN "no")
+
+  if(ENABLE_CCWARN)
+    set(CFG_WITH_CCWARN "yes")
+  endif()
+
+  set(CFG_WITH_LONGTESTS "no")
+
+  if(ENABLE_LONGTESTS)
+    set(CFG_WITH_LONGTESTS "yes")
+  endif()
+
+  check_flag(CFG_CXXFLAGS_PROFILE "-pg")
+
+  check_set(CFG_CXXFLAGS_STD_NEWEST
+    "-std=gnu++17"
+    "-std=c++17"
+    "-std=gnu++14"
+    "-std=c++14"
+  )
+
+  check_flag_list(CFG_CXXFLAGS_NO_UNUSED
+    "-faligned-new"
+    "-fbracket-depth=4096"
+    "-fcf-protection=none"
+    "-mno-cet"
+    "-Qunused-arguments"
+    "-Wno-bool-operation"
+    "-Wno-c++11-narrowing"
+    "-Wno-constant-logical-operand"
+    "-Wno-non-pod-varargs"
+    "-Wno-parentheses-equality"
+    "-Wno-shadow"
+    "-Wno-sign-compare"
+    "-Wno-tautological-bitwise-compare"
+    "-Wno-tautological-compare"
+    "-Wno-uninitialized"
+    "-Wno-unused-but-set-parameter"
+    "-Wno-unused-but-set-variable"
+    "-Wno-unused-parameter"
+    "-Wno-unused-variable"
+  )
+
+  check_flag_list(CFG_CXXFLAGS_WEXTRA
+    "-Wextra"
+    "-Wfloat-conversion"
+    "-Wlogical-op"
+    "-Wthread-safety"
+  )
+
+  check_set(CFG_CXXFLAGS_COROUTINES
+    "-fcoroutines-ts"
+    "-fcoroutines"
+  )
+
+  set(CFG_CXXFLAGS_PCH_I "-include")
+
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    set(CGF_GCH_IF_CLANG ".gch")
+  endif()
+
+  check_flag_list(CFG_LDLIBS_THREADS
+    "-mt"
+    "-pthread"
+    "-lpthread"
+    "-latomic"
+  )
+
+  configure_file(${mk_path_in} ${mk_path_out} @ONLY)
+endfunction()


### PR DESCRIPTION
This is an attempt to get `driver.pl` working when `VERILATOR_ROOT` is a CMake install of Verilator, to wit:

* driver.pl expects an autoconf'd Makefile, `verilated.mk`. This patch hacks together a CMake function that does mostly the same things to generate that file. YMMV

* `verilator_coverage` and `verilator_includer` were missing from the program install list, this patch adds them

* driver.pl seems to expect `src/.gdbinit` and `src/.gdbinit.py` to be installed to `VERILATOR_ROOT`. Installing a "src" folder is odd in CMake land, so this is gated behind a variable. If this isn't what's intended, please let me know

* There seem to be some poorly documented dependencies, for example I'm perfectly unclear on what the autoconf build is doing with `bear` other than the driver yells at me about it because CMake isn't doing the same thing
