### PR TITLE
Fix assertion failure in V3Gate

### DIFF
--- a/src/V3Gate.cpp
+++ b/src/V3Gate.cpp
@@ -850,7 +850,6 @@ class GateInline final {
                 // Remove Variable vertex
                 VL_DO_DANGLING(vVtxp->unlinkDelete(&m_graph), vVtxp);
                 // Remove driving logic and vertex
-                m_hasPending.erase(logicp);
                 VL_DO_DANGLING(logicp->unlinkFrBack()->deleteTree(), logicp);
                 VL_DO_DANGLING(lVtxp->unlinkDelete(&m_graph), lVtxp);
             }

--- a/src/V3Gate.cpp
+++ b/src/V3Gate.cpp
@@ -822,6 +822,7 @@ class GateInline final {
 
                 if (debug() >= 9) dstVtxp->nodep()->dumpTree("      inside: ");
 
+                UASSERT_OBJ(logicp != dstVtxp->nodep(), logicp, "unexpected match");
                 recordSubstitution(vscp, substp, dstVtxp->nodep());
 
                 // If the new replacement referred to a signal,

--- a/src/V3Gate.cpp
+++ b/src/V3Gate.cpp
@@ -656,6 +656,9 @@ public:
         return m_substitutionp;
     }
     const std::vector<AstVarScope*>& readVscps() const { return m_readVscps; }
+    bool varAssigned(const AstVarScope* scopep) const {
+        return m_lhsVarRef && (m_lhsVarRef->varScopep() == scopep);
+    }
 };
 
 //######################################################################
@@ -772,6 +775,8 @@ class GateInline final {
 
             // Was it ok?
             if (!okVisitor.isSimple()) continue;
+            // If the varScope is already removed from logicp, no need to try substitution.
+            if (!okVisitor.varAssigned(vVtxp->varScp())) continue;
 
             // Does it read multiple source variables?
             if (okVisitor.readVscps().size() > 1) {
@@ -822,7 +827,8 @@ class GateInline final {
 
                 if (debug() >= 9) dstVtxp->nodep()->dumpTree("      inside: ");
 
-                UASSERT_OBJ(logicp != dstVtxp->nodep(), logicp, "unexpected match");
+                UASSERT_OBJ(logicp != dstVtxp->nodep(), logicp,
+                            "Circular logic should have been rejected by okVisitor");
                 recordSubstitution(vscp, substp, dstVtxp->nodep());
 
                 // If the new replacement referred to a signal,

--- a/src/V3Gate.cpp
+++ b/src/V3Gate.cpp
@@ -843,6 +843,7 @@ class GateInline final {
                 // Remove Variable vertex
                 VL_DO_DANGLING(vVtxp->unlinkDelete(&m_graph), vVtxp);
                 // Remove driving logic and vertex
+                m_hasPending.erase(logicp);
                 VL_DO_DANGLING(logicp->unlinkFrBack()->deleteTree(), logicp);
                 VL_DO_DANGLING(lVtxp->unlinkDelete(&m_graph), lVtxp);
             }

--- a/test_regress/t/t_gate_opt.pl
+++ b/test_regress/t/t_gate_opt.pl
@@ -1,0 +1,20 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2003 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile();
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_gate_opt.v
+++ b/test_regress/t/t_gate_opt.v
@@ -1,0 +1,37 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2024 by Yutetsu TAKATSUKASA.
+// SPDX-License-Identifier: CC0-1.0
+
+// bug5101
+module t ();
+
+   logic [1:0] in0, in1, out;
+   logic sel;
+   assign in0 = 1;
+   assign in1 = 2;
+   assign sel = 1'b1;
+
+   initial begin
+      $display("out:%d", out);
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end
+
+   bug5101 u_bug5101(.in0, .in1, .sel, .out);
+endmodule
+
+
+module bug5101(input wire [1:0] in0, input wire [1:0] in1, input wire sel, output logic [1:0] out);
+   // verilator no_inline_module
+   function logic [1:0] incr(input [1:0] in);
+      logic [1:0] tmp;
+      tmp = in + 1;
+      return tmp;
+  endfunction
+
+  always_comb
+     if (sel) out = in0;
+     else out = incr(in1);
+endmodule


### PR DESCRIPTION
https://github.com/verilator/verilator/blob/298e0f24d1931cc884ce9620aa73d66026fb9764/src/V3Gate.cpp#L683-L684
A  registered AstNode in `m_hasPending`  remains even after it is deleted.
https://github.com/verilator/verilator/blob/298e0f24d1931cc884ce9620aa73d66026fb9764/src/V3Gate.cpp#L846

If a newly created AstNode is allocated to the same address as the deleted one, a check in line 693 fails because early exit in line 690 does not work; `m_hasPending` has the entry for the AstNode though it is for the deleted AstNode.

https://github.com/verilator/verilator/blob/298e0f24d1931cc884ce9620aa73d66026fb9764/src/V3Gate.cpp#L689-L693

I could not make a small test  to reproduce this.