### PR TITLE
Add increasing of stack size when possible (#5071)

### DIFF
--- a/include/verilated.cpp
+++ b/include/verilated.cpp
@@ -3119,10 +3119,6 @@ void Verilated::scTraceBeforeElaborationError() VL_MT_SAFE {
 
 void Verilated::stackCheck(QData needSize) VL_MT_UNSAFE {
     // Slowpath - Called only when constructing
-#ifndef _VL_TEST_RLIMIT_FAIL
-#define _VL_TEST_RLIMIT_FAIL 0
-#endif
-
 #ifdef _VL_HAVE_GETRLIMIT
     QData haveSize = 0;
     rlimit rlim;
@@ -3137,7 +3133,11 @@ void Verilated::stackCheck(QData needSize) VL_MT_UNSAFE {
     if (VL_UNLIKELY(haveSize && needSize && haveSize < requestSize)) {
         // Try to increase the stack limit to the requested size
         rlim.rlim_cur = requestSize;
-        if (_VL_TEST_RLIMIT_FAIL || setrlimit(RLIMIT_STACK, &rlim)) {
+        if (
+#ifdef _VL_TEST_RLIMIT_FAIL
+            true ||
+#endif
+            setrlimit(RLIMIT_STACK, &rlim)) {
             VL_PRINTF_MT("%%Warning: System has stack size %" PRIu64 " kb"
                          " which may be too small; however, failed to request more"
                          " using 'ulimit -s %" PRIu64 "'\n",

--- a/include/verilated.cpp
+++ b/include/verilated.cpp
@@ -3139,7 +3139,7 @@ void Verilated::stackCheck(QData needSize) VL_MT_UNSAFE {
 #endif
             setrlimit(RLIMIT_STACK, &rlim)) {
             VL_PRINTF_MT("%%Warning: System has stack size %" PRIu64 " kb"
-                         " which may be too small; however, failed to request more"
+                         " which may be too small; failed to request more"
                          " using 'ulimit -s %" PRIu64 "'\n",
                          haveSize / 1024, requestSize);
         }

--- a/include/verilated.cpp
+++ b/include/verilated.cpp
@@ -3119,6 +3119,10 @@ void Verilated::scTraceBeforeElaborationError() VL_MT_SAFE {
 
 void Verilated::stackCheck(QData needSize) VL_MT_UNSAFE {
     // Slowpath - Called only when constructing
+#ifndef _VL_TEST_RLIMIT_FAIL
+#define _VL_TEST_RLIMIT_FAIL 0
+#endif
+
 #ifdef _VL_HAVE_GETRLIMIT
     QData haveSize = 0;
     rlimit rlim;
@@ -3133,9 +3137,9 @@ void Verilated::stackCheck(QData needSize) VL_MT_UNSAFE {
     if (VL_UNLIKELY(haveSize && needSize && haveSize < requestSize)) {
         // Try to increase the stack limit to the requested size
         rlim.rlim_cur = requestSize;
-        if (setrlimit(RLIMIT_STACK, &rlim)) {
+        if (_VL_TEST_RLIMIT_FAIL || setrlimit(RLIMIT_STACK, &rlim)) {
             VL_PRINTF_MT("%%Warning: System has stack size %" PRIu64 " kb"
-                         " which may be too small; however, we fail to request more"
+                         " which may be too small; however, failed to request more"
                          " using 'ulimit -s %" PRIu64 "'\n",
                          haveSize / 1024, requestSize);
         }

--- a/test_regress/t/t_stack_check.pl
+++ b/test_regress/t/t_stack_check.pl
@@ -16,6 +16,5 @@ compile(
 
 execute();
 
-file_grep($Self->{run_log_filename}, qr/.*%Warning: System has stack size/);
 ok(1);
 1;

--- a/test_regress/t/t_stack_check_fail.pl
+++ b/test_regress/t/t_stack_check_fail.pl
@@ -1,0 +1,23 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2003-2024 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+top_filename("t/t_stack_check.v");
+
+scenarios(vlt => 1);
+
+compile(
+    verilator_flags2 => ['--binary --debug-stack-check', '--CFLAGS', '"-D_VL_TEST_RLIMIT_FAIL=1"'],
+    );
+
+execute();
+
+file_grep($Self->{run_log_filename}, qr/.*%Warning: System has stack size/);
+ok(1);
+1;

--- a/test_regress/t/t_stack_check_fail.pl
+++ b/test_regress/t/t_stack_check_fail.pl
@@ -13,7 +13,7 @@ top_filename("t/t_stack_check.v");
 scenarios(vlt => 1);
 
 compile(
-    verilator_flags2 => ['--binary --debug-stack-check', '--CFLAGS', '"-D_VL_TEST_RLIMIT_FAIL=1"'],
+    verilator_flags2 => ['--binary --debug-stack-check', '--CFLAGS', '"-D_VL_TEST_RLIMIT_FAIL"'],
     );
 
 execute();


### PR DESCRIPTION
We use `setrlimit` on Linux platforms to request a larger stack if the predicted model size is greater than the current stack size.

We raise a warning message if we fail to increase the stack size to the requested target. This may not always stop the simulation.

We appreciate your contributing to Verilator.  If this is your first commit, please add your name to docs/CONTRIBUTORS, and read our contributing guidelines in docs/CONTRIBUTING.rst.
