### PR TITLE
Internals: Move getenvStr to verilatedos. No functional change intended.

### DIFF
--- a/include/verilatedos.h
+++ b/include/verilatedos.h
@@ -614,8 +614,13 @@ static inline double VL_ROUND(double n) {
 //=========================================================================
 // Time and performance
 
+#include <string>
+
 namespace VlOs {
 
+/// Get environment variable
+extern std::string getenvStr(const std::string& envvar,
+                             const std::string& defaultValue) VL_MT_SAFE;
 extern uint64_t memUsageBytes() VL_MT_SAFE;  ///< Return memory usage in bytes, or 0 if unknown
 
 // Internal: Record CPU time, starting point on construction, and current delta from that

--- a/include/verilatedos_c.h
+++ b/include/verilatedos_c.h
@@ -100,4 +100,30 @@ uint64_t memUsageBytes() VL_MT_SAFE {
 }
 
 //=========================================================================
+// VlOs::getenvStr implementation
+
+std::string getenvStr(const std::string& envvar, const std::string& defaultValue) VL_MT_SAFE {
+    std::string ret;
+#if defined(_MSC_VER)
+    // Note: MinGW does not offer _dupenv_s
+    const char* envvalue = nullptr;
+    _dupenv_s((char**)&envvalue, nullptr, envvar.c_str());
+    if (envvalue != nullptr) {
+        const std::string result{envvalue};
+        free((void*)envvalue);
+        ret = result;
+    } else {
+        ret = defaultValue;
+    }
+#else
+    if (const char* const envvalue = getenv(envvar.c_str())) {
+        ret = envvalue;
+    } else {
+        ret = defaultValue;
+    }
+#endif
+    return ret;
+}
+
+//=========================================================================
 }  //namespace VlOs

--- a/src/V3Os.cpp
+++ b/src/V3Os.cpp
@@ -86,26 +86,7 @@ VL_DEFINE_DEBUG_FUNCTIONS;
 // Environment
 
 string V3Os::getenvStr(const string& envvar, const string& defaultValue) {
-    string ret = "";
-#if defined(_MSC_VER)
-    // Note: MinGW does not offer _dupenv_s
-    const char* envvalue = nullptr;
-    _dupenv_s((char**)&envvalue, nullptr, envvar.c_str());
-    if (envvalue != nullptr) {
-        const std::string result{envvalue};
-        free((void*)envvalue);
-        ret = result;
-    } else {
-        ret = defaultValue;
-    }
-#else
-    if (const char* const envvalue = getenv(envvar.c_str())) {
-        ret = envvalue;
-    } else {
-        ret = defaultValue;
-    }
-#endif
-    return VString::escapeStringForPath(ret);
+    return VString::escapeStringForPath(VlOs::getenvStr(envvar, defaultValue));
 }
 
 void V3Os::setenvStr(const string& envvar, const string& value, const string& why) {

--- a/src/V3Os.cpp
+++ b/src/V3Os.cpp
@@ -103,7 +103,7 @@ void V3Os::setenvStr(const string& envvar, const string& value, const string& wh
     // setenv() replaced by putenv() in Solaris environment. Prototype is different
     // putenv() requires NAME=VALUE format
     const string vareq = envvar + "=" + value;
-    putenv(const_cast<char*>(vareq.c_str()));
+    putenv(strdup(vareq.c_str()));  // will leak if setting the same variable again
 #endif
 }
 


### PR DESCRIPTION
Split from #4947.


By the way, I also noticed that the putenv path in V3Os::setenvStr might be incorrect with a potential use-after-free condition from 9165233657641b3a92b371b88e7bc7e095c66017 on, introduced by 2e9ade61b25edb39542183ef9900f2c4b0dfd16d (fixing a memory leak - https://github.com/verilator/verilator/issues/184#issuecomment-568277475). While msvcrt putenv only reads it once and allocates a copy ([documentation](https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/putenv-wputenv) does not mention anything, sources: [reactos](https://doxygen.reactos.org/df/def/putenv_8c.html), [wine](https://github.com/wine-mirror/wine/blob/040b2a9c75666527af6ca79d9146095c8ed6a3cf/dlls/msvcrt/environ.c#L362)) and freeing is okay, other libc implementations put the raw pointer into environment, which turns invalid by the time setenvStr returns, when it deallocates the string. (This includes Solaris mentioned in the comment, per [man page](https://docs.oracle.com/cd/E88353_01/html/E37843/putenv-3c.html) and [code from opensolaris](https://github.com/kofemann/opensolaris/blob/80192cd83bf665e708269dae856f9145f7190f74/usr/src/lib/libc/port/gen/getenv.c#L340); [glibc](https://elixir.bootlin.com/glibc/glibc-2.39/source/stdlib/putenv.c#L52) and [various](http://bxr.su/NetBSD/lib/libc/stdlib/putenv.c#putenv) [BSD](http://bxr.su/FreeBSD/lib/libc/stdlib/getenv.c#setenv) [flavors](http://bxr.su/OpenBSD/lib/libc/stdlib/setenv.c#putenv) do that as well.)
Do you think it needs attention?