### PR TITLE
Fix references to ports in forks

### DIFF
--- a/src/V3Ast.h
+++ b/src/V3Ast.h
@@ -903,7 +903,7 @@ public:
         TRIWIRE,
         TRI0,
         TRI1,
-        PORT,  // Temp type used in parser only
+        PORT,  // Used in parser and V3Fork to recognize ports
         BLOCKTEMP,
         MODULETEMP,
         STMTTEMP,

--- a/src/V3Fork.cpp
+++ b/src/V3Fork.cpp
@@ -616,6 +616,7 @@ class ForkVisitor final : public VNVisitor {
         if (m_forkDepth && !nodep->varp()->isFuncLocal() && nodep->varp()->isClassMember()) return;
 
         if (m_forkDepth && (m_forkLocalsp.count(nodep->varp()) == 0)
+            && nodep->varp()->varType() != VVarType::PORT  // Basically static, so it's safe
             && !nodep->varp()->lifetime().isStatic()) {
             if (nodep->access().isWriteOrRW()
                 && (!nodep->isClassHandleValue() || nodep->user2())) {

--- a/test_regress/t/t_fork_port.pl
+++ b/test_regress/t/t_fork_port.pl
@@ -1,0 +1,22 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2003 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(vlt => 1);
+
+compile(
+    verilator_flags2 => ["--exe --main --timing"],
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_fork_port.v
+++ b/test_regress/t/t_fork_port.v
@@ -1,0 +1,19 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2024 by Antmicro.
+// SPDX-License-Identifier: CC0-1.0
+
+module t;
+   logic x;
+   sub s(x);
+   initial #1 x = 1;
+endmodule
+
+module sub(input x);
+   initial fork begin
+      @x;
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end join_any
+endmodule


### PR DESCRIPTION
Fixes `V3Fork` not understanding the lifetime of ports, which is effectively static.
