### PR TITLE
Edit gets/puts with vpiStringVal to fully support integers (#5036)

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -139,6 +139,7 @@ Miodrag Milanović
 Mladen Slijepcevic
 Morten Borup Petersen
 Mostafa Gamal
+Moubarak Jeje
 Nandu Raj
 Nathan Kohagen
 Nathan Myers

--- a/include/verilated_vpi.cpp
+++ b/include/verilated_vpi.cpp
@@ -2742,7 +2742,6 @@ vpiHandle vpi_put_value(vpiHandle object, p_vpi_value valuep, p_vpi_time /*time_
                 CData* const datap = (reinterpret_cast<CData*>(vop->varDatap()));
                 for (int i = 0; i < bytes; ++i) {
                     datap[i] = valuep->value.str[bytes - i - 1];
-                    // if (i == (words - 1)) datap[i] &= vop->mask();
                 }
             }
             return object;

--- a/include/verilated_vpi.cpp
+++ b/include/verilated_vpi.cpp
@@ -2485,8 +2485,7 @@ void vl_get_value(const VerilatedVar* varp, void* varDatap, p_vpi_value valuep,
             }
             for (i = 0; i < bytes; ++i) {
                 const char val = datap[bytes - i - 1];
-                // other simulators replace [leading?] zero chars with spaces, replicate here.
-                t_outStr[i] = val ? val : ' ';
+                t_outStr[i] = val;
             }
             t_outStr[i] = '\0';
             return;
@@ -2740,11 +2739,10 @@ vpiHandle vpi_put_value(vpiHandle object, p_vpi_value valuep, p_vpi_time /*time_
                 return object;
             } else {
                 const int bytes = VL_BYTES_I(vop->varp()->packed().elements());
-                const int len = std::strlen(valuep->value.str);
                 CData* const datap = (reinterpret_cast<CData*>(vop->varDatap()));
                 for (int i = 0; i < bytes; ++i) {
-                    // prepend with 0 values before placing string the least significant bytes
-                    datap[i] = (i < len) ? valuep->value.str[len - i - 1] : 0;
+                    datap[i] = valuep->value.str[bytes - i - 1];
+                    // if (i == (words - 1)) datap[i] &= vop->mask();
                 }
             }
             return object;

--- a/test_regress/t/t_vpi_var.cpp
+++ b/test_regress/t/t_vpi_var.cpp
@@ -736,16 +736,21 @@ int _mon_check_delayed() {
 }
 
 int _mon_check_string() {
+    const char text_byte[2] = "A";
+    const char text_half[3] = "T2";
+    const char text_word[5] = "Tree";
+    const char text_long[9] = "44Four44";
+    const char text[64] = "lorem ipsum";
     static struct {
         const char* name;
         const char* initial;
         const char* value;
     } text_test_obs[] = {
-        {"text_byte", "B", new char[2] {"A"}},  // x's dropped
-        {"text_half", "Hf", new char[3] {"T2"}},  // x's dropped
-        {"text_word", "Word", new char [5] {"Tree"}},
-        {"text_long", "Long64b", new char [9] {"44Four44"}},
-        {"text", "Verilog Test module", new char [65] {"lorem ipsum"}},
+        {"text_byte", "B", text_byte},
+        {"text_half", "Hf", text_half},
+        {"text_word", "Word", text_word},
+        {"text_long", "Long64b", text_long},
+        {"text", "Verilog Test module", text},
     };
 
     for (int i = 0; i < 5; i++) {
@@ -769,8 +774,6 @@ int _mon_check_string() {
 
         v.value.str = (PLI_BYTE8*)text_test_obs[i].value;
         vpi_put_value(vh1, &v, &t, vpiNoDelay);
-
-        delete[] text_test_obs[i].value;
     }
 
     return 0;

--- a/test_regress/t/t_vpi_var.cpp
+++ b/test_regress/t/t_vpi_var.cpp
@@ -744,17 +744,17 @@ int _mon_check_delayed() {
 }
 
 int _mon_check_string() {
-    // const char value_text_byte[2] = "A";
-    // const char value_text_half[3] = "T2";
-    // const char value_text_word[5] = "Tree";
-    // const char value_text_long[9] = "44Four44";
-    // const char value_text[64] = "lorem ipsum";
+    const char value_text_byte[2] = "A";
+    const char value_text_half[3] = "T2";
+    const char value_text_word[5] = "Tree";
+    const char value_text_long[9] = "44Four44";
+    const char value_text[64] = "lorem ipsum";
 
-    // const char initial_text_byte[2] = "A";
-    // const char initial_text_half[3] = "T2";
-    // const char initial_text_word[5] = "Tree";
-    // const char initial_text_long[9] = "44Four44";
-    // const char initial_text[64] = "Verilog Test module";
+    const char initial_text_byte[2] = "B";
+    const char initial_text_half[3] = "Hf";
+    const char initial_text_word[5] = "Word";
+    const char initial_text_long[9] = "Long64b";
+    const char initial_text[64] = "Verilog Test module";
 
     static struct {
         const char* name;
@@ -762,13 +762,13 @@ int _mon_check_string() {
         const char* value;
         const bool is_cstr;
     } text_test_obs[] = {
-        {"text_byte", new const char[2]{"B"}, new const char[2]{"A"}, true},
-        {"text_half", new const char[3]{"Hf"}, new const char[3]{"T2"}, true},
-        {"text_word", new const char[5]{"Word"}, new const char[5]{"Tree"}, true},
-        {"text_long", new const char[9]{"Long64b"}, new const char[9]{"44Four44"}, true},
-        {"text", new const char[65]{"Verilog Test module"}, new const char[65]{"lorem ipsum"}, true},
-        {"integer1", new const char[2]{(char)0x00,(char)0xab}, new const char[2]{(char)0xab,(char)0x00}, false},
-        {"integer2", new const char[2]{(char)0xab,(char)0x00}, new const char[2]{(char)0x00,(char)0xab}, false}
+        {"text_byte", initial_text_byte, value_text_byte, true},
+        {"text_half", initial_text_half, value_text_half, true},
+        {"text_word", initial_text_word, value_text_word, true},
+        {"text_long", initial_text_long, value_text_long, true},
+        {"text",      initial_text,      value_text, true},
+        {"integer1",  new const char[2]{(char)0x00,(char)0xab}, new const char[2]{(char)0xab,(char)0x00}, false},
+        {"integer2",  new const char[2]{(char)0xab,(char)0x00}, new const char[2]{(char)0x00,(char)0xab}, false}
     };
 
     for (int i = 0; i < 7; i++) {
@@ -812,9 +812,6 @@ int _mon_check_string() {
 
         // v.value.str = (PLI_BYTE8*)text_test_obs[i].value;
         // vpi_put_value(vh1, &v, &t, vpiNoDelay);
-
-        delete[] text_test_obs[i].initial;
-        delete[] text_test_obs[i].value;
     }
 
     return 0;

--- a/test_regress/t/t_vpi_var.cpp
+++ b/test_regress/t/t_vpi_var.cpp
@@ -770,7 +770,7 @@ int _mon_check_string() {
         v.value.str = (PLI_BYTE8*)text_test_obs[i].value;
         vpi_put_value(vh1, &v, &t, vpiNoDelay);
 
-        delete text_test_obs[i].value;
+        delete[] text_test_obs[i].value;
     }
 
     return 0;

--- a/test_regress/t/t_vpi_var.v
+++ b/test_regress/t/t_vpi_var.v
@@ -98,14 +98,8 @@ extern "C" int mon_check();
       if (text_word != "Tree") $stop;
       if (text_long != "44Four44") $stop;
       if (text[511:512-(8*11)] != "lorem ipsum") $stop;
-      if (integer1 != 16'hab00) begin
-         $display("integer1=%x\n",integer1);
-         $stop;
-      end
-      if (integer2 != 16'h00ab) begin
-         $display("integer2=%x\n",integer2);
-         $stop;
-      end
+      if (integer1 != 16'hab00) $stop;
+      if (integer2 != 16'h00ab) $stop;
       if (str1 != "something a lot longer than hello") $stop;
       if (real1 > 123456.7895 || real1 < 123456.7885 ) $stop;
    end

--- a/test_regress/t/t_vpi_var.v
+++ b/test_regress/t/t_vpi_var.v
@@ -93,7 +93,7 @@ extern "C" int mon_check();
       if (text_half != "T2") $stop;
       if (text_word != "Tree") $stop;
       if (text_long != "44Four44") $stop;
-      if (text != "lorem ipsum") $stop;
+      if (text[511:512-(8*11)] != "lorem ipsum") $stop;
       if (str1 != "something a lot longer than hello") $stop;
       if (real1 > 123456.7895 || real1 < 123456.7885 ) $stop;
    end

--- a/test_regress/t/t_vpi_var.v
+++ b/test_regress/t/t_vpi_var.v
@@ -49,6 +49,8 @@ extern "C" int mon_check();
    reg [31:0]      text_word    /*verilator public_flat_rw @(posedge clk) */;
    reg [63:0]      text_long    /*verilator public_flat_rw @(posedge clk) */;
    reg [511:0]     text         /*verilator public_flat_rw @(posedge clk) */;
+   reg [15:0]      integer1     /*verilator public_flat_rw @(posedge clk) */;
+   reg [15:0]      integer2     /*verilator public_flat_rw @(posedge clk) */;
 
    integer        status;
 
@@ -68,6 +70,8 @@ extern "C" int mon_check();
       text_word = "Word";
       text_long = "Long64b";
       text = "Verilog Test module";
+      integer1 = 16'h00ab;
+      integer2 = 16'hab00;
 
       real1 = 1.0;
       str1 = "hello";
@@ -94,6 +98,14 @@ extern "C" int mon_check();
       if (text_word != "Tree") $stop;
       if (text_long != "44Four44") $stop;
       if (text[511:512-(8*11)] != "lorem ipsum") $stop;
+      if (integer1 != 16'hab00) begin
+         $display("integer1=%x\n",integer1);
+         $stop;
+      end
+      if (integer2 != 16'h00ab) begin
+         $display("integer2=%x\n",integer2);
+         $stop;
+      end
       if (str1 != "something a lot longer than hello") $stop;
       if (real1 > 123456.7895 || real1 < 123456.7885 ) $stop;
    end

--- a/test_regress/t/t_vpi_var2.v
+++ b/test_regress/t/t_vpi_var2.v
@@ -67,6 +67,8 @@ extern "C" int mon_check();
    reg [31:0]      text_word;
    reg [63:0]      text_long;
    reg [511:0]     text;
+   reg [15:0]      integer1;
+   reg [15:0]      integer2;
 /*verilator public_off*/
    integer        status;
 
@@ -88,6 +90,8 @@ extern "C" int mon_check();
       text_word = "Word";
       text_long = "Long64b";
       text = "Verilog Test module";
+      integer1 = 16'h00ab;
+      integer2 = 16'hab00;
 
       real1 = 1.0;
       str1 = "hello";
@@ -114,6 +118,14 @@ extern "C" int mon_check();
       if (text_word != "Tree") $stop;
       if (text_long != "44Four44") $stop;
       if (text[511:512-(8*11)] != "lorem ipsum") $stop;
+      if (integer1 != 16'hab00) begin
+         $display("integer1=%x\n",integer1);
+         $stop;
+      end
+      if (integer2 != 16'h00ab) begin
+         $display("integer2=%x\n",integer2);
+         $stop;
+      end
       if (str1 != "something a lot longer than hello") $stop;
       if (real1 > 123456.7895 || real1 < 123456.7885 ) $stop;
    end

--- a/test_regress/t/t_vpi_var2.v
+++ b/test_regress/t/t_vpi_var2.v
@@ -113,7 +113,7 @@ extern "C" int mon_check();
       if (text_half != "T2") $stop;
       if (text_word != "Tree") $stop;
       if (text_long != "44Four44") $stop;
-      if (text != "lorem ipsum") $stop;
+      if (text[511:512-(8*11)] != "lorem ipsum") $stop;
       if (str1 != "something a lot longer than hello") $stop;
       if (real1 > 123456.7895 || real1 < 123456.7885 ) $stop;
    end

--- a/test_regress/t/t_vpi_var2.v
+++ b/test_regress/t/t_vpi_var2.v
@@ -118,14 +118,8 @@ extern "C" int mon_check();
       if (text_word != "Tree") $stop;
       if (text_long != "44Four44") $stop;
       if (text[511:512-(8*11)] != "lorem ipsum") $stop;
-      if (integer1 != 16'hab00) begin
-         $display("integer1=%x\n",integer1);
-         $stop;
-      end
-      if (integer2 != 16'h00ab) begin
-         $display("integer2=%x\n",integer2);
-         $stop;
-      end
+      if (integer1 != 16'hab00) $stop;
+      if (integer2 != 16'h00ab) $stop;
       if (str1 != "something a lot longer than hello") $stop;
       if (real1 > 123456.7895 || real1 < 123456.7885 ) $stop;
    end

--- a/test_regress/t/t_vpi_var3.v
+++ b/test_regress/t/t_vpi_var3.v
@@ -98,14 +98,8 @@ extern "C" int mon_check();
       if (text_word != "Tree") $stop;
       if (text_long != "44Four44") $stop;
       if (text[511:512-(8*11)] != "lorem ipsum") $stop;
-      if (integer1 != 16'hab00) begin
-         $display("integer1=%x\n",integer1);
-         $stop;
-      end
-      if (integer2 != 16'h00ab) begin
-         $display("integer2=%x\n",integer2);
-         $stop;
-      end
+      if (integer1 != 16'hab00) $stop;
+      if (integer2 != 16'h00ab) $stop;
       if (str1 != "something a lot longer than hello") $stop;
       if (real1 > 123456.7895 || real1 < 123456.7885 ) $stop;
    end

--- a/test_regress/t/t_vpi_var3.v
+++ b/test_regress/t/t_vpi_var3.v
@@ -49,6 +49,8 @@ extern "C" int mon_check();
    reg [31:0]      text_word;
    reg [63:0]      text_long;
    reg [511:0]     text;
+   reg [15:0]      integer1;
+   reg [15:0]      integer2;
 
    integer        status;
 
@@ -68,6 +70,8 @@ extern "C" int mon_check();
       text_word = "Word";
       text_long = "Long64b";
       text = "Verilog Test module";
+      integer1 = 16'h00ab;
+      integer2 = 16'hab00;
 
       real1 = 1.0;
       str1 = "hello";
@@ -94,6 +98,14 @@ extern "C" int mon_check();
       if (text_word != "Tree") $stop;
       if (text_long != "44Four44") $stop;
       if (text[511:512-(8*11)] != "lorem ipsum") $stop;
+      if (integer1 != 16'hab00) begin
+         $display("integer1=%x\n",integer1);
+         $stop;
+      end
+      if (integer2 != 16'h00ab) begin
+         $display("integer2=%x\n",integer2);
+         $stop;
+      end
       if (str1 != "something a lot longer than hello") $stop;
       if (real1 > 123456.7895 || real1 < 123456.7885 ) $stop;
    end

--- a/test_regress/t/t_vpi_var3.v
+++ b/test_regress/t/t_vpi_var3.v
@@ -93,7 +93,7 @@ extern "C" int mon_check();
       if (text_half != "T2") $stop;
       if (text_word != "Tree") $stop;
       if (text_long != "44Four44") $stop;
-      if (text != "lorem ipsum") $stop;
+      if (text[511:512-(8*11)] != "lorem ipsum") $stop;
       if (str1 != "something a lot longer than hello") $stop;
       if (real1 > 123456.7895 || real1 < 123456.7885 ) $stop;
    end


### PR DESCRIPTION
Resolution to issue [#5036](https://github.com/verilator/verilator/issues/5036). Removes substitution for special characters in values represented by `vpiStringVal` format. Enables format to be used to read/write any integer value.