### PR TITLE
Fix errant removal of some side-effecting assigns

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -171,6 +171,7 @@ Samuel Riedel
 Sean Cross
 Sebastien Van Cauwenberghe
 Sergi Granell
+Seth Pellegrino
 Srinivasan Venkataramanan
 Stefan Wallentowitz
 Stephen Henry

--- a/src/V3Dead.cpp
+++ b/src/V3Dead.cpp
@@ -311,7 +311,7 @@ class DeadVisitor final : public VNVisitor {
         // still get deleted.
     }
     void visit(AstNode* nodep) override {
-        if (nodep->isOutputter()) m_sideEffect = true;
+        if (!nodep->isPure()) m_sideEffect = true;
         iterateChildren(nodep);
         checkAll(nodep);
     }

--- a/test_regress/t/t_sys_plusargs.v
+++ b/test_regress/t/t_sys_plusargs.v
@@ -14,6 +14,7 @@ module t;
    string      sv_str;
    reg [7*8:1] p_in;
    string      sv_in;
+   integer unread;  // never read
 
    initial begin
       if ($test$plusargs("PLUS")!==1) $stop;
@@ -118,6 +119,14 @@ module t;
       p_i = 0;
       if ($value$plusargs("INT=%d", p_i)) ;
       if (p_i !== 32'd1234) $stop;
+
+      // bug5127 - assign side effect test
+      p_i = 0;
+      p_r = 0;
+      unread = $value$plusargs("INT=%d", p_i);
+      unread = $value$plusargs("REAL=%e", p_r);
+      if (p_i !== 32'd1234) $stop;
+      if (p_r !== 1.2345) $stop;
 
       $write("*-* All Finished *-*\n");
       $finish;


### PR DESCRIPTION
Prior to this snapshot, some repeated assignments and assignments to a never-read variable would get optimized away, even if the RHS of the assignment had a side-effect like writing to one of its arguments.

Now, those statements are left intact. This change is perhaps too conservative in that it keeps the variables live (and not just the assignment statements). An alternative would be instead to propogate some kind of negative value in that slot (I believe this is what LLVM calls a "poison" value) so that other optimizations can "see" the var is holds no real value.

I don't have the breadth of experience to take a principled position on whether there's any real-world verilog that would suffer signficantly from the potential de-optimization here, lacking much in the way of context on:

* What is pure vs. unpure? i.e. how likely it is that something else got "caught up" in this change
* How often never-read variables being removed was enabling other optimizations, or how much work was being avoided in not computing those values.

That said, given how almost everything in RTL-land is pure by default, I'm hopeful that the impact here is small outside the desired behavior of reading plusargs.

Many thanks to @wsnyder for the guidance on #5127 which this change is intended to address. I think I followed all of the contribution guidelines, but just let me know if I missed anything.