### PR TITLE
Apply DFG regularization to cyclic graphs

### DIFF
--- a/src/V3DfgOptimizer.cpp
+++ b/src/V3DfgOptimizer.cpp
@@ -295,7 +295,8 @@ void V3DfgOptimizer::optimize(AstNetlist* netlistp, const string& label) {
         // For each cyclic component
         for (auto& component : cyclicComponents) {
             if (dumpDfgLevel() >= 7) component->dumpDotFilePrefixed(ctx.prefix() + "source");
-            // TODO: Apply optimizations safe for cyclic graphs
+            // Converting back to Ast assumes the 'regularize' pass was run, so we must run it
+            V3DfgPasses::regularize(*component, ctx.m_regularizeContext);
             // Add back under the main DFG (we will convert everything back in one go)
             dfg->addGraph(*component);
         }

--- a/test_regress/t/t_dfg_regularize_circular.pl
+++ b/test_regress/t/t_dfg_regularize_circular.pl
@@ -1,0 +1,17 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2024 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(vlt => 1);
+
+compile(
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_dfg_regularize_circular.v
+++ b/test_regress/t/t_dfg_regularize_circular.v
@@ -1,0 +1,19 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2024 by Wilson Snyder.
+// SPDX-License-Identifier: CC0-1.0
+
+module A (
+  output [2:0] Y
+);
+endmodule
+
+module B;
+  wire [2:0] w1;
+  wire w2;
+  A A (
+    .Y({ w1[2], w1[0], w2 })
+  );
+  assign w1[1] = w1[2];
+endmodule


### PR DESCRIPTION
The Dfg2Ast conversion assumes the 'regularize' pass was run, but we failed to run it on cyclic sub-graphs. Do so now.

Fixes #5130.
