### PR TITLE
Use dynamic string buffer for all VPI reads (#5145)

### DIFF
--- a/include/verilated_vpi.cpp
+++ b/include/verilated_vpi.cpp
@@ -2386,7 +2386,7 @@ static void vl_strprintf(std::string& buffer, char const* fmt, ...) {
     // if there wasn't enough space, reallocate and try again
     if (buffer.capacity() < required) {
         buffer.reserve(required * 2);
-        result = VL_VSNPRINTF(const_cast<char*>(buffer.data()), buffer.capacity(), fmt, args);
+        VL_VSNPRINTF(const_cast<char*>(buffer.data()), buffer.capacity(), fmt, args);
     }
     va_end(args);
 }

--- a/include/verilated_vpi.cpp
+++ b/include/verilated_vpi.cpp
@@ -2377,13 +2377,13 @@ static void vl_strprintf(std::string& buffer, char const* fmt, ...) {
     va_list args, args_copy;
     va_start(args, fmt);
     buffer.clear();
-    // make copy of args since we may need to call VL_VSNPRINTF more than once
+    // Make copy of args since we may need to call VL_VSNPRINTF more than once
     va_copy(args_copy, args);
-    // try VL_VSNPRINTF in existing buffer
-    int result = VL_VSNPRINTF(const_cast<char*>(buffer.data()), buffer.capacity(), fmt, args_copy);
+    // Try VL_VSNPRINTF in existing buffer
+    const int result = VL_VSNPRINTF(const_cast<char*>(buffer.data()), buffer.capacity(), fmt, args_copy);
     va_end(args_copy);
-    const int required = result + 1;  // returned size doesn't include NUL terminator
-    // if there wasn't enough space, reallocate and try again
+    const int required = result + 1;  // Returned size doesn't include NUL terminator
+    // If there wasn't enough space, reallocate and try again
     if (buffer.capacity() < required) {
         buffer.reserve(required * 2);
         VL_VSNPRINTF(const_cast<char*>(buffer.data()), buffer.capacity(), fmt, args);

--- a/include/verilated_vpi.cpp
+++ b/include/verilated_vpi.cpp
@@ -2377,9 +2377,9 @@ static void vl_strprintf(std::string& buffer, char const* fmt, ...) {
     va_list args, args_copy;
     va_start(args, fmt);
     buffer.clear();
-    // make copy of args since we may need to call vsnprintf more than once
+    // make copy of args since we may need to call VL_VSNPRINTF more than once
     va_copy(args_copy, args);
-    // try vspnrintf in existing buffer
+    // try VL_VSNPRINTF in existing buffer
     int result = VL_VSNPRINTF(const_cast<char*>(buffer.data()), buffer.capacity(), fmt, args_copy);
     va_end(args_copy);
     const int required = result + 1;  // returned size doesn't include NUL terminator

--- a/test_regress/driver.pl
+++ b/test_regress/driver.pl
@@ -1292,6 +1292,7 @@ sub compile {
         }
         $self->oprint("Compile vpi\n") if $self->{verbose};
         my @cmd = ($ENV{CXX}, @{$param{pli_flags}},
+                   "-std=c++14",
                    "-D" . $param{tool_define},
                    "-DIS_VPI", ($ENV{CFLAGS} || ''),
                    "$self->{t_dir}/$self->{pli_filename}");

--- a/test_regress/driver.pl
+++ b/test_regress/driver.pl
@@ -1292,7 +1292,6 @@ sub compile {
         }
         $self->oprint("Compile vpi\n") if $self->{verbose};
         my @cmd = ($ENV{CXX}, @{$param{pli_flags}},
-                   "-std=c++14",
                    "-D" . $param{tool_define},
                    "-DIS_VPI", ($ENV{CFLAGS} || ''),
                    "$self->{t_dir}/$self->{pli_filename}");


### PR DESCRIPTION
Closes #5145. Uses the `t_outDynamicStr` as the buffer for all VPI reads.

I'm uncertain what the proper way to do runtime programmatic error checking is. Do we just assume the programmer (me) did the correct thing? I'm assuming that since there is no exception cleanliness on VPI (C API) boundaries. If so, I'll just remove the commented out `ensure` lines.