### PR TITLE
Extend out of range Select

### DIFF
--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -993,6 +993,12 @@ class WidthVisitor final : public VNVisitor {
                                                 << " outside " << frommsb << ":" << fromlsb);
                     UINFO(1, "    Related node: " << nodep << endl);
                 }
+                // Extend it.
+                const int extendTo = nodep->msbConst() + 1;
+                AstNodeDType* const subDTypep = nodep->findLogicDType(
+                    extendTo, extendTo, nodep->fromp()->dtypep()->numeric());
+                widthCheckSized(nodep, "errorless...", nodep->fromp(), subDTypep, EXTEND_EXP,
+                                false /*noerror*/);
             }
             // iterate FINAL is two blocks above
             //

--- a/test_regress/t/t_select_bad_range4.out
+++ b/test_regress/t/t_select_bad_range4.out
@@ -72,6 +72,10 @@
                                                 : ... note: In instance 't'
    25 |       sel2 = mi[1<<29 : 0];
       |                ^
+%Warning-SELRANGE: t/t_select_bad_range4.v:25:16: Extracting 536870913 bits from only 536870873 bit number
+                                                : ... note: In instance 't'
+   25 |       sel2 = mi[1<<29 : 0];
+      |                ^
 %Warning-WIDTHTRUNC: t/t_select_bad_range4.v:25:12: Operator ASSIGN expects 4 bits on the Assign RHS, but Assign RHS's SEL generates 536870913 bits.
                                                   : ... note: In instance 't'
    25 |       sel2 = mi[1<<29 : 0];

--- a/test_regress/t/t_select_bad_range5.out
+++ b/test_regress/t/t_select_bad_range5.out
@@ -12,6 +12,10 @@
                                                 : ... note: In instance 't'
    16 |    assign mi = unk[3:2];
       |                   ^
+%Warning-WIDTHEXPAND: t/t_select_bad_range5.v:16:19: Bit extraction of var[3:0] requires 2 bit index, not 1 bits.
+                                                   : ... note: In instance 't'
+   16 |    assign mi = unk[3:2];
+      |                   ^
 %Warning-WIDTHTRUNC: t/t_select_bad_range5.v:16:14: Operator ASSIGNW expects 1 bits on the Assign RHS, but Assign RHS's SEL generates 2 bits.
                                                   : ... note: In instance 't'
    16 |    assign mi = unk[3:2];

--- a/test_regress/t/t_select_bad_range6.out
+++ b/test_regress/t/t_select_bad_range6.out
@@ -1,0 +1,11 @@
+%Warning-SELRANGE: t/t_select_bad_range6.v:13:16: Extracting 31 bits from only 12 bit number
+                                                : ... note: In instance 't'
+   13 |    assign o = i[31:1];
+      |                ^
+                   ... For warning description see https://verilator.org/warn/SELRANGE?v=latest
+                   ... Use "/* verilator lint_off SELRANGE */" and lint_on around source to disable this message.
+%Warning-SELRANGE: t/t_select_bad_range6.v:13:16: Selection index out of range: 31:1 outside 11:0
+                                                : ... note: In instance 't'
+   13 |    assign o = i[31:1];
+      |                ^
+%Error: Exiting due to

--- a/test_regress/t/t_select_bad_range6.pl
+++ b/test_regress/t/t_select_bad_range6.pl
@@ -1,0 +1,19 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2003 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(vlt => 1);
+
+compile(
+    fails => $Self->{vlt_all},
+    expect_filename => $Self->{golden_filename},
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_select_bad_range6.v
+++ b/test_regress/t/t_select_bad_range6.v
@@ -1,0 +1,21 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2024 by Wilson Snyder.
+// SPDX-License-Identifier: CC0-1.0
+
+module t (clk);
+   input clk;
+
+   logic [11:0] i;
+   logic [30:0] o;
+
+   assign o = i[31:1];
+
+   always @(posedge clk) begin
+      i = 12'h123;
+   end
+   always @(negedge clk) begin
+      $write ("Bad select %x\n", o);
+   end
+endmodule


### PR DESCRIPTION
For #5159.

The issue is that the signal only gets extended to the width of the result, but that width does not encompass the MSB. That is, `reg [11:0] a` extended to 30 bits due to `a[31:1]` (warning SELRANGE "Extracting 30 bits from only 10 bit number") still does not have a bit 31, so Dfg sees a select of 30 bits ([31:1]) from a 30 bit signal, but not from LSB 0, which is a malformed DfgSel.

I'm a bit fearful of changing V3Width but here is an attempt. Unforunately it creates some spurious extra warnings so this is not quite right. (This extension business in V3Width is a bit murky to me and even with a fix like this it will still likely produce weird results if the packed dimension have a negative LSB index.) 

Alternative is to treat the malformed input Ast as Dfg Incompatible and don't convert it to Dfg.
