### PR TITLE
Disable ASLR for more tests.

### DIFF
--- a/test_regress/t/t_class_member_sens.pl
+++ b/test_regress/t/t_class_member_sens.pl
@@ -16,6 +16,7 @@ compile(
 
 execute(
     check_finished => 1,
+    aslr_off => 1,  # Some GCC versions hit an address-sanitizer bug otherwise
     );
 
 ok(1);

--- a/test_regress/t/t_flag_runtime_debug.pl
+++ b/test_regress/t/t_flag_runtime_debug.pl
@@ -18,6 +18,7 @@ compile(
 
 execute(
     check_finished => 1,
+    aslr_off => 1,  # Some GCC versions hit an address-sanitizer bug otherwise
     );
 
 file_grep("$Self->{obj_dir}/$Self->{vm_prefix}.mk", qr/VL_DEBUG=1/);


### PR DESCRIPTION
As before, these show spurious errors with some toolchains due to an address sanitizer bug.
