### PR TITLE
Support `$psprintf` system function (#4314)

### DIFF
--- a/docs/guide/warnings.rst
+++ b/docs/guide/warnings.rst
@@ -1217,6 +1217,14 @@ List Of Warnings
    :vlopt:`--no-timing` option.
 
 
+.. option:: NONSTD
+
+   Warns when a non-standard language feature is used that has a standard
+   equivalent, which might behave differently in corner cases. For example
+   :code:`$psprintf` system function is replaced by its standard equivalent
+   :code:`$sformatf`.
+
+
 .. option:: NULLPORT
 
    Warns that a null port was detected in the module definition port

--- a/src/V3Error.h
+++ b/src/V3Error.h
@@ -121,6 +121,7 @@ public:
         MULTITOP,       // Multiple top level modules
         NEWERSTD,       // Newer language standard required
         NOLATCH,        // No latch detected in always_latch block
+        NONSTD,         // Non-standard feature present in other sims
         NULLPORT,       // Null port detected in module definition
         PINCONNECTEMPTY,// Cell pin connected by name with empty reference
         PINMISSING,     // Cell pin not specified
@@ -204,7 +205,7 @@ public:
             "IMPERFECTSCH", "IMPLICIT", "IMPLICITSTATIC", "IMPORTSTAR", "IMPURE",
             "INCABSPATH", "INFINITELOOP", "INITIALDLY", "INSECURE",
             "LATCH", "LITENDIAN", "MINTYPMAXDLY", "MISINDENT", "MODDUP",
-            "MULTIDRIVEN", "MULTITOP", "NEWERSTD", "NOLATCH", "NULLPORT", "PINCONNECTEMPTY",
+            "MULTIDRIVEN", "MULTITOP", "NEWERSTD", "NOLATCH", "NONSTD", "NULLPORT", "PINCONNECTEMPTY",
             "PINMISSING", "PINNOCONNECT",  "PINNOTFOUND", "PKGNODECL", "PREPROCZERO", "PROCASSWIRE",
             "PROFOUTOFDATE", "PROTECTED", "RANDC", "REALCVT", "REDEFMACRO", "RISEFALLDLY",
             "SELRANGE", "SHORTREAL", "SIDEEFFECT", "SPLITVAR",

--- a/src/verilog.l
+++ b/src/verilog.l
@@ -251,6 +251,7 @@ vnum    {vnum1}|{vnum2}|{vnum3}|{vnum4}|{vnum5}
   "$period"             { FL; return yaTIMINGSPEC; }
   "$pow"                { FL; return yD_POW; }
   "$printtimescale"     { FL; return yD_PRINTTIMESCALE; }
+  "$psprintf"           { FL; yylval.fl->v3warn(NONSTD, "Non-standard system function.\n" << yylval.fl->warnMore() << "... Suggest use standard '$sformatf' (IEEE 1800-2023 21.3.3)"); return yD_SFORMATF; }
   "$random"             { FL; return yD_RANDOM; }
   "$readmemb"           { FL; return yD_READMEMB; }
   "$readmemh"           { FL; return yD_READMEMH; }

--- a/src/verilog.l
+++ b/src/verilog.l
@@ -251,7 +251,9 @@ vnum    {vnum1}|{vnum2}|{vnum3}|{vnum4}|{vnum5}
   "$period"             { FL; return yaTIMINGSPEC; }
   "$pow"                { FL; return yD_POW; }
   "$printtimescale"     { FL; return yD_PRINTTIMESCALE; }
-  "$psprintf"           { FL; yylval.fl->v3warn(NONSTD, "Non-standard system function.\n" << yylval.fl->warnMore() << "... Suggest use standard '$sformatf' (IEEE 1800-2023 21.3.3)"); return yD_SFORMATF; }
+  "$psprintf"           { FL; yylval.fl->v3warn(NONSTD, "Non-standard system function '" << yytext << "';"
+                                                " suggest use standard '$sformatf' (IEEE 1800-2023 21.3.3)");
+                          return yD_SFORMATF; }
   "$random"             { FL; return yD_RANDOM; }
   "$readmemb"           { FL; return yD_READMEMB; }
   "$readmemh"           { FL; return yD_READMEMH; }

--- a/test_regress/t/t_sys_psprintf.pl
+++ b/test_regress/t/t_sys_psprintf.pl
@@ -1,0 +1,22 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2024 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    verilator_flags2 => ['-Wno-NONSTD'],
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_sys_psprintf.v
+++ b/test_regress/t/t_sys_psprintf.v
@@ -1,0 +1,29 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2024 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+module t;
+
+   // Note $sformatf already tested elsewhere
+
+   reg [3:0] n;
+   reg [63:0] q;
+   reg [16*8:1] wide;
+
+   string str;
+
+   initial begin
+      n = 4'b1100;
+      q = 64'h1234_5678_abcd_0123;
+      wide = "hello-there12345";
+      str = $psprintf("n=%b q=%d w=%s", n, q, wide);
+`ifdef TEST_VERBOSE  $display("str=%0s",str);  `endif
+      if (str !== "n=1100 q= 1311768467750060323 w=hello-there12345") $stop;
+
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end
+
+endmodule

--- a/test_regress/t/t_sys_psprintf_warn_bad.out
+++ b/test_regress/t/t_sys_psprintf_warn_bad.out
@@ -1,5 +1,4 @@
-%Warning-NONSTD: t/t_sys_psprintf.v:21:13: Non-standard system function.
-                                         : ... Suggest use standard '$sformatf' (IEEE 1800-2023 21.3.3)
+%Warning-NONSTD: t/t_sys_psprintf.v:21:13: Non-standard system function '$psprintf'; suggest use standard '$sformatf' (IEEE 1800-2023 21.3.3)
    21 |       str = $psprintf("n=%b q=%d w=%s", n, q, wide);
       |             ^~~~~~~~~
                  ... For warning description see https://verilator.org/warn/NONSTD?v=latest

--- a/test_regress/t/t_sys_psprintf_warn_bad.out
+++ b/test_regress/t/t_sys_psprintf_warn_bad.out
@@ -1,0 +1,7 @@
+%Warning-NONSTD: t/t_sys_psprintf.v:21:13: Non-standard system function.
+                                         : ... Suggest use standard '$sformatf' (IEEE 1800-2023 21.3.3)
+   21 |       str = $psprintf("n=%b q=%d w=%s", n, q, wide);
+      |             ^~~~~~~~~
+                 ... For warning description see https://verilator.org/warn/NONSTD?v=latest
+                 ... Use "/* verilator lint_off NONSTD */" and lint_on around source to disable this message.
+%Error: Exiting due to

--- a/test_regress/t/t_sys_psprintf_warn_bad.pl
+++ b/test_regress/t/t_sys_psprintf_warn_bad.pl
@@ -1,0 +1,21 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2024 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(vlt => 1);
+
+top_filename("t/t_sys_psprintf.v");
+
+lint(
+    fails => 1,
+    expect_filename => $Self->{golden_filename},
+    );
+
+ok(1);
+1;


### PR DESCRIPTION
`$psprintf` is a non-standard system function present in some other simulators, and has been rejected for standardization by IEEE because of being basically the same as `$sformatf`.

To encourage users to fix their codebase, a new NONSTD warning is emitted by default, but it gets otherwise interpreted as `$sformatf` as early as during lexing. Alternatively, DEPRECATED could be re-used for this.

An alternative for quickly getting such testbenches to 'sort-of work' is to use the `--bbox-sys` flag.