### PR TITLE
Use SystemC BITS_PER_DIGIT in VL_ASSIGN_SBW

### DIFF
--- a/include/verilated_funcs.h
+++ b/include/verilated_funcs.h
@@ -508,19 +508,18 @@ static inline void VL_ASSIGNBIT_WO(int bit, WDataOutP owp) VL_MT_SAFE {
     { (svar).write(rd); }
 #define VL_ASSIGN_SBQ(obits, svar, rd) \
     { (svar).write(rd); }
-#define VL_SC_BITS_PER_DIGIT 30  // This comes from sc_nbdefs.h BITS_PER_DIGIT
 #define VL_ASSIGN_SBW(obits, svar, rwp) \
     { \
         sc_dt::sc_biguint<(obits)> _butemp; \
         int32_t lsb = 0; \
         uint32_t* chunkp = _butemp.get_raw(); \
-        while (lsb + VL_SC_BITS_PER_DIGIT < (obits)) { \
+        while (lsb + BITS_PER_DIGIT < (obits)) { \
             static_assert(std::is_same<IData, EData>::value, "IData and EData mismatch"); \
-            const uint32_t data = VL_SEL_IWII(lsb + VL_SC_BITS_PER_DIGIT + 1, (rwp).data(), lsb, \
-                                              VL_SC_BITS_PER_DIGIT); \
-            *chunkp = data & VL_MASK_E(VL_SC_BITS_PER_DIGIT); \
+            const uint32_t data \
+                = VL_SEL_IWII(lsb + BITS_PER_DIGIT + 1, (rwp).data(), lsb, BITS_PER_DIGIT); \
+            *chunkp = data & VL_MASK_E(BITS_PER_DIGIT); \
             ++chunkp; \
-            lsb += VL_SC_BITS_PER_DIGIT; \
+            lsb += BITS_PER_DIGIT; \
         } \
         if (lsb < (obits)) { \
             const uint32_t msb_data = VL_SEL_IWII((obits) + 1, (rwp).data(), lsb, (obits)-lsb); \


### PR DESCRIPTION
When using Verilator with SystemC 3.0.0, test [t_var_sc_bv.pl](https://github.com/verilator/verilator/blob/master/test_regress/t/t_var_sc_bv.pl) fails on https://github.com/verilator/verilator/blob/02dd33b60e938aa6d619207c1f8b01d2093ee50b/test_regress/t/t_var_sc_bv.cpp#L154

with error:
```
free(): invalid pointer
```

As an aftermath of https://github.com/verilator/verilator/pull/3513, assignment of [sc_biguint](https://github.com/accellera-official/systemc/blob/176a3b04e30607cded81cb60194719df506069e3/src/sysc/datatypes/int/sc_biguint.h#L86) is performed by accessing its internal representation. This representation was changed between versions 2.3.4 and 3.0.0. The change that led to test failure was https://github.com/accellera-official/systemc/commit/e9c401ebfcdfa67333fd64bbf60fd29697c51475 which changed `BITS_PER_DIGIT` value  from `30` to `32` which is used by our assignment macro for offset calculation.

The mismatched `VL_SC_BITS_PER_DIGIT` caused `m_free` variable to be overwritten with some non-zero value which caused 
`~sc_unsigned` to trigger [`free`](https://github.com/bminor/glibc/blob/eb370158794d7c64740a257ab2246ab46b90306a/stdlib/stdlib.h#L687) on non-heap allocated `sc_unsigned::digit` variable. This led to `free(): invalid pointer` runtime simulation error. Failure occurred when `obits` `VL_ASSIGN_SBW` parameter was set to 255 (which was greater than `lsb` in that case).

The fix consists of using `BITS_PER_DIGIT` directly in `VL_ASSIGN_SBW` instead of relying on hard-coded `VL_SC_BITS_PER_DIGIT` value.

Direct call to `BITS_PER_DIGIT` macro was already done in similar `VL_ASSIGN_WSB`,  but not in `VL_ASSIGN_SBW`.