### PR TITLE
Non-constant replication in concats

### DIFF
--- a/test_regress/t/t_json_only_debugcheck.out
+++ b/test_regress/t/t_json_only_debugcheck.out
@@ -895,26 +895,29 @@
        "stmtsp": [
         {"type":"ASSIGN","name":"","addr":"(RN)","loc":"d,53:14,53:15","dtypep":"(RB)",
          "rhsp": [
-          {"type":"CONCATN","name":"","addr":"(SN)","loc":"d,53:20,53:21","dtypep":"(RB)",
+          {"type":"CVTPACKSTRING","name":"","addr":"(SN)","loc":"d,53:20,53:21","dtypep":"(RB)",
            "lhsp": [
-            {"type":"VARREF","name":"t.all","addr":"(TN)","loc":"d,53:17,53:20","dtypep":"(RB)","access":"RD","varp":"(QB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
-          ],
-           "rhsp": [
-            {"type":"CVTPACKSTRING","name":"","addr":"(UN)","loc":"d,53:24,53:28","dtypep":"(RB)",
+            {"type":"CONCATN","name":"","addr":"(TN)","loc":"d,53:20,53:21","dtypep":"(RB)",
              "lhsp": [
-              {"type":"ARRAYSEL","name":"","addr":"(VN)","loc":"d,53:24,53:28","dtypep":"(RB)",
-               "fromp": [
-                {"type":"VARREF","name":"__Venumtab_enum_name2","addr":"(WN)","loc":"d,17:12,17:16","dtypep":"(OM)","access":"RD","varp":"(PM)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
-              ],
-               "bitp": [
-                {"type":"AND","name":"","addr":"(XN)","loc":"d,53:24,53:28","dtypep":"(LC)",
-                 "lhsp": [
-                  {"type":"CONST","name":"32'h7","addr":"(YN)","loc":"d,53:24,53:28","dtypep":"(NC)"}
+              {"type":"VARREF","name":"t.all","addr":"(UN)","loc":"d,53:17,53:20","dtypep":"(RB)","access":"RD","varp":"(QB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            ],
+             "rhsp": [
+              {"type":"CVTPACKSTRING","name":"","addr":"(VN)","loc":"d,53:24,53:28","dtypep":"(RB)",
+               "lhsp": [
+                {"type":"ARRAYSEL","name":"","addr":"(WN)","loc":"d,53:24,53:28","dtypep":"(RB)",
+                 "fromp": [
+                  {"type":"VARREF","name":"__Venumtab_enum_name2","addr":"(XN)","loc":"d,17:12,17:16","dtypep":"(OM)","access":"RD","varp":"(PM)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                 ],
-                 "rhsp": [
-                  {"type":"CCAST","name":"","addr":"(ZN)","loc":"d,53:22,53:23","dtypep":"(LC)","size":32,
+                 "bitp": [
+                  {"type":"AND","name":"","addr":"(YN)","loc":"d,53:24,53:28","dtypep":"(LC)",
                    "lhsp": [
-                    {"type":"VARREF","name":"t.unnamedblk1.e","addr":"(AO)","loc":"d,53:22,53:23","dtypep":"(LC)","access":"RD","varp":"(UB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"CONST","name":"32'h7","addr":"(ZN)","loc":"d,53:24,53:28","dtypep":"(NC)"}
+                  ],
+                   "rhsp": [
+                    {"type":"CCAST","name":"","addr":"(AO)","loc":"d,53:22,53:23","dtypep":"(LC)","size":32,
+                     "lhsp": [
+                      {"type":"VARREF","name":"t.unnamedblk1.e","addr":"(BO)","loc":"d,53:22,53:23","dtypep":"(LC)","access":"RD","varp":"(UB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    ]}
                   ]}
                 ]}
               ]}
@@ -922,496 +925,499 @@
           ]}
         ],
          "lhsp": [
-          {"type":"VARREF","name":"t.all","addr":"(BO)","loc":"d,53:10,53:13","dtypep":"(RB)","access":"WR","varp":"(QB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+          {"type":"VARREF","name":"t.all","addr":"(CO)","loc":"d,53:10,53:13","dtypep":"(RB)","access":"WR","varp":"(QB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
         ],"timingControlp": []}
       ],
        "incsp": [
-        {"type":"ASSIGN","name":"","addr":"(CO)","loc":"d,52:45,52:46","dtypep":"(AC)",
+        {"type":"ASSIGN","name":"","addr":"(DO)","loc":"d,52:45,52:46","dtypep":"(AC)",
          "rhsp": [
-          {"type":"ARRAYSEL","name":"","addr":"(DO)","loc":"d,52:49,52:53","dtypep":"(AC)",
+          {"type":"ARRAYSEL","name":"","addr":"(EO)","loc":"d,52:49,52:53","dtypep":"(AC)",
            "fromp": [
-            {"type":"VARREF","name":"__Venumtab_enum_next0","addr":"(EO)","loc":"d,17:12,17:16","dtypep":"(IC)","access":"RD","varp":"(JC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"__Venumtab_enum_next0","addr":"(FO)","loc":"d,17:12,17:16","dtypep":"(IC)","access":"RD","varp":"(JC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ],
            "bitp": [
-            {"type":"AND","name":"","addr":"(FO)","loc":"d,52:49,52:53","dtypep":"(LC)",
+            {"type":"AND","name":"","addr":"(GO)","loc":"d,52:49,52:53","dtypep":"(LC)",
              "lhsp": [
-              {"type":"CONST","name":"32'h7","addr":"(GO)","loc":"d,52:49,52:53","dtypep":"(NC)"}
+              {"type":"CONST","name":"32'h7","addr":"(HO)","loc":"d,52:49,52:53","dtypep":"(NC)"}
             ],
              "rhsp": [
-              {"type":"CCAST","name":"","addr":"(HO)","loc":"d,52:47,52:48","dtypep":"(LC)","size":32,
+              {"type":"CCAST","name":"","addr":"(IO)","loc":"d,52:47,52:48","dtypep":"(LC)","size":32,
                "lhsp": [
-                {"type":"VARREF","name":"t.unnamedblk1.e","addr":"(IO)","loc":"d,52:47,52:48","dtypep":"(LC)","access":"RD","varp":"(UB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                {"type":"VARREF","name":"t.unnamedblk1.e","addr":"(JO)","loc":"d,52:47,52:48","dtypep":"(LC)","access":"RD","varp":"(UB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
               ]}
             ]}
           ]}
         ],
          "lhsp": [
-          {"type":"VARREF","name":"t.unnamedblk1.e","addr":"(JO)","loc":"d,52:43,52:44","dtypep":"(AC)","access":"WR","varp":"(UB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+          {"type":"VARREF","name":"t.unnamedblk1.e","addr":"(KO)","loc":"d,52:43,52:44","dtypep":"(AC)","access":"WR","varp":"(UB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
         ],"timingControlp": []}
       ]},
-      {"type":"ASSIGN","name":"","addr":"(KO)","loc":"d,55:9,55:10","dtypep":"(AC)",
+      {"type":"ASSIGN","name":"","addr":"(LO)","loc":"d,55:9,55:10","dtypep":"(AC)",
        "rhsp": [
-        {"type":"CONST","name":"4'h4","addr":"(LO)","loc":"d,55:13,55:17","dtypep":"(AC)"}
+        {"type":"CONST","name":"4'h4","addr":"(MO)","loc":"d,55:13,55:17","dtypep":"(AC)"}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"t.e","addr":"(MO)","loc":"d,55:7,55:8","dtypep":"(AC)","access":"WR","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"t.e","addr":"(NO)","loc":"d,55:7,55:8","dtypep":"(AC)","access":"WR","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []},
-      {"type":"ASSIGN","name":"","addr":"(NO)","loc":"d,56:11,56:12","dtypep":"(RB)",
+      {"type":"ASSIGN","name":"","addr":"(OO)","loc":"d,56:11,56:12","dtypep":"(RB)",
        "rhsp": [
-        {"type":"CONCATN","name":"","addr":"(OO)","loc":"d,56:17,56:18","dtypep":"(RB)",
+        {"type":"CVTPACKSTRING","name":"","addr":"(PO)","loc":"d,56:17,56:18","dtypep":"(RB)",
          "lhsp": [
-          {"type":"VARREF","name":"t.all","addr":"(PO)","loc":"d,56:14,56:17","dtypep":"(RB)","access":"RD","varp":"(QB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
-        ],
-         "rhsp": [
-          {"type":"CONST","name":"\\\"E04\\\"","addr":"(QO)","loc":"d,56:21,56:25","dtypep":"(RB)"}
+          {"type":"CONCATN","name":"","addr":"(QO)","loc":"d,56:17,56:18","dtypep":"(RB)",
+           "lhsp": [
+            {"type":"VARREF","name":"t.all","addr":"(RO)","loc":"d,56:14,56:17","dtypep":"(RB)","access":"RD","varp":"(QB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+          ],
+           "rhsp": [
+            {"type":"CONST","name":"\\\"E04\\\"","addr":"(SO)","loc":"d,56:21,56:25","dtypep":"(RB)"}
+          ]}
         ]}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"t.all","addr":"(RO)","loc":"d,56:7,56:10","dtypep":"(RB)","access":"WR","varp":"(QB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"t.all","addr":"(TO)","loc":"d,56:7,56:10","dtypep":"(RB)","access":"WR","varp":"(QB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []},
-      {"type":"IF","name":"","addr":"(SO)","loc":"d,57:10,57:12",
+      {"type":"IF","name":"","addr":"(UO)","loc":"d,57:10,57:12",
        "condp": [
-        {"type":"NEQN","name":"","addr":"(TO)","loc":"d,57:20,57:23","dtypep":"(NB)",
+        {"type":"NEQN","name":"","addr":"(VO)","loc":"d,57:20,57:23","dtypep":"(NB)",
          "lhsp": [
-          {"type":"CONST","name":"\\\"E01E03E04\\\"","addr":"(UO)","loc":"d,57:25,57:36","dtypep":"(RB)"}
+          {"type":"CONST","name":"\\\"E01E03E04\\\"","addr":"(WO)","loc":"d,57:25,57:36","dtypep":"(RB)"}
         ],
          "rhsp": [
-          {"type":"VARREF","name":"t.all","addr":"(VO)","loc":"d,57:15,57:18","dtypep":"(RB)","access":"RD","varp":"(QB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+          {"type":"VARREF","name":"t.all","addr":"(XO)","loc":"d,57:15,57:18","dtypep":"(RB)","access":"RD","varp":"(QB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
         ]}
       ],
        "thensp": [
-        {"type":"DISPLAY","name":"","addr":"(WO)","loc":"d,57:45,57:51",
+        {"type":"DISPLAY","name":"","addr":"(YO)","loc":"d,57:45,57:51",
          "fmtp": [
-          {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:57:  got='%@' exp='E01E03E04'\\n","addr":"(XO)","loc":"d,57:45,57:51","dtypep":"(RB)",
+          {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:57:  got='%@' exp='E01E03E04'\\n","addr":"(ZO)","loc":"d,57:45,57:51","dtypep":"(RB)",
            "exprsp": [
-            {"type":"VARREF","name":"t.all","addr":"(YO)","loc":"d,57:124,57:127","dtypep":"(RB)","access":"RD","varp":"(QB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"t.all","addr":"(AP)","loc":"d,57:124,57:127","dtypep":"(RB)","access":"RD","varp":"(QB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ],"scopeNamep": []}
         ],"filep": []},
-        {"type":"STOP","name":"","addr":"(ZO)","loc":"d,57:146,57:151"}
+        {"type":"STOP","name":"","addr":"(BP)","loc":"d,57:146,57:151"}
       ],"elsesp": []}
     ],"finalsp": []},
-    {"type":"CFUNC","name":"_eval_final","addr":"(AP)","loc":"a,0:0,0:0","slow":true,"isStatic":false,"dpiExportDispatcher":false,"dpiExportImpl":false,"dpiImportPrototype":false,"dpiImportWrapper":false,"dpiContext":false,"isConstructor":false,"isDestructor":false,"isVirtual":false,"isCoroutine":false,"needProcess":false,"scopep":"(Y)","argsp": [],"initsp": [],"stmtsp": [],"finalsp": []},
-    {"type":"CFUNC","name":"_eval_settle","addr":"(BP)","loc":"a,0:0,0:0","slow":true,"isStatic":false,"dpiExportDispatcher":false,"dpiExportImpl":false,"dpiImportPrototype":false,"dpiImportWrapper":false,"dpiContext":false,"isConstructor":false,"isDestructor":false,"isVirtual":false,"isCoroutine":false,"needProcess":false,"scopep":"(Y)","argsp": [],"initsp": [],"stmtsp": [],"finalsp": []},
-    {"type":"CFUNC","name":"_eval_triggers__act","addr":"(CP)","loc":"a,0:0,0:0","slow":false,"isStatic":false,"dpiExportDispatcher":false,"dpiExportImpl":false,"dpiImportPrototype":false,"dpiImportWrapper":false,"dpiContext":false,"isConstructor":false,"isDestructor":false,"isVirtual":false,"isCoroutine":false,"needProcess":false,"scopep":"(Y)","argsp": [],"initsp": [],
+    {"type":"CFUNC","name":"_eval_final","addr":"(CP)","loc":"a,0:0,0:0","slow":true,"isStatic":false,"dpiExportDispatcher":false,"dpiExportImpl":false,"dpiImportPrototype":false,"dpiImportWrapper":false,"dpiContext":false,"isConstructor":false,"isDestructor":false,"isVirtual":false,"isCoroutine":false,"needProcess":false,"scopep":"(Y)","argsp": [],"initsp": [],"stmtsp": [],"finalsp": []},
+    {"type":"CFUNC","name":"_eval_settle","addr":"(DP)","loc":"a,0:0,0:0","slow":true,"isStatic":false,"dpiExportDispatcher":false,"dpiExportImpl":false,"dpiImportPrototype":false,"dpiImportWrapper":false,"dpiContext":false,"isConstructor":false,"isDestructor":false,"isVirtual":false,"isCoroutine":false,"needProcess":false,"scopep":"(Y)","argsp": [],"initsp": [],"stmtsp": [],"finalsp": []},
+    {"type":"CFUNC","name":"_eval_triggers__act","addr":"(EP)","loc":"a,0:0,0:0","slow":false,"isStatic":false,"dpiExportDispatcher":false,"dpiExportImpl":false,"dpiImportPrototype":false,"dpiImportWrapper":false,"dpiContext":false,"isConstructor":false,"isDestructor":false,"isVirtual":false,"isCoroutine":false,"needProcess":false,"scopep":"(Y)","argsp": [],"initsp": [],
      "stmtsp": [
-      {"type":"STMTEXPR","name":"","addr":"(DP)","loc":"d,11:8,11:9",
+      {"type":"STMTEXPR","name":"","addr":"(FP)","loc":"d,11:8,11:9",
        "exprp": [
-        {"type":"CMETHODHARD","name":"set","addr":"(EP)","loc":"d,11:8,11:9","dtypep":"(CB)",
+        {"type":"CMETHODHARD","name":"set","addr":"(GP)","loc":"d,11:8,11:9","dtypep":"(CB)",
          "fromp": [
-          {"type":"VARREF","name":"__VactTriggered","addr":"(FP)","loc":"d,11:8,11:9","dtypep":"(NB)","access":"WR","varp":"(U)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+          {"type":"VARREF","name":"__VactTriggered","addr":"(HP)","loc":"d,11:8,11:9","dtypep":"(NB)","access":"WR","varp":"(U)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
         ],
          "pinsp": [
-          {"type":"CONST","name":"32'h0","addr":"(GP)","loc":"d,11:8,11:9","dtypep":"(NC)"},
-          {"type":"AND","name":"","addr":"(HP)","loc":"d,61:14,61:21","dtypep":"(NB)",
+          {"type":"CONST","name":"32'h0","addr":"(IP)","loc":"d,11:8,11:9","dtypep":"(NC)"},
+          {"type":"AND","name":"","addr":"(JP)","loc":"d,61:14,61:21","dtypep":"(NB)",
            "lhsp": [
-            {"type":"CCAST","name":"","addr":"(IP)","loc":"d,61:22,61:25","dtypep":"(NB)","size":32,
+            {"type":"CCAST","name":"","addr":"(KP)","loc":"d,61:22,61:25","dtypep":"(NB)","size":32,
              "lhsp": [
-              {"type":"VARREF","name":"clk","addr":"(JP)","loc":"d,61:22,61:25","dtypep":"(NB)","access":"RD","varp":"(J)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+              {"type":"VARREF","name":"clk","addr":"(LP)","loc":"d,61:22,61:25","dtypep":"(NB)","access":"RD","varp":"(J)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
             ]}
           ],
            "rhsp": [
-            {"type":"NOT","name":"","addr":"(KP)","loc":"d,61:14,61:21","dtypep":"(NB)",
+            {"type":"NOT","name":"","addr":"(MP)","loc":"d,61:14,61:21","dtypep":"(NB)",
              "lhsp": [
-              {"type":"CCAST","name":"","addr":"(LP)","loc":"d,61:14,61:21","dtypep":"(NB)","size":32,
+              {"type":"CCAST","name":"","addr":"(NP)","loc":"d,61:14,61:21","dtypep":"(NB)","size":32,
                "lhsp": [
-                {"type":"VARREF","name":"__Vtrigprevexpr___TOP__clk__0","addr":"(MP)","loc":"d,61:14,61:21","dtypep":"(NB)","access":"RD","varp":"(N)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                {"type":"VARREF","name":"__Vtrigprevexpr___TOP__clk__0","addr":"(OP)","loc":"d,61:14,61:21","dtypep":"(NB)","access":"RD","varp":"(N)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
               ]}
             ]}
           ]}
         ]}
       ]},
-      {"type":"ASSIGN","name":"","addr":"(NP)","loc":"d,61:22,61:25","dtypep":"(NB)",
+      {"type":"ASSIGN","name":"","addr":"(PP)","loc":"d,61:22,61:25","dtypep":"(NB)",
        "rhsp": [
-        {"type":"VARREF","name":"clk","addr":"(OP)","loc":"d,61:22,61:25","dtypep":"(NB)","access":"RD","varp":"(J)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"clk","addr":"(QP)","loc":"d,61:22,61:25","dtypep":"(NB)","access":"RD","varp":"(J)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"__Vtrigprevexpr___TOP__clk__0","addr":"(PP)","loc":"d,61:22,61:25","dtypep":"(NB)","access":"WR","varp":"(N)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"__Vtrigprevexpr___TOP__clk__0","addr":"(RP)","loc":"d,61:22,61:25","dtypep":"(NB)","access":"WR","varp":"(N)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []},
-      {"type":"TEXTBLOCK","name":"","addr":"(QP)","loc":"d,11:8,11:9","shortText":"",
+      {"type":"TEXTBLOCK","name":"","addr":"(SP)","loc":"d,11:8,11:9","shortText":"",
        "nodesp": [
-        {"type":"TEXT","name":"","addr":"(RP)","loc":"d,11:8,11:9","shortText":"#ifdef VL_DEBUG..."},
-        {"type":"TEXT","name":"","addr":"(SP)","loc":"d,11:8,11:9","shortText":"if (VL_UNLIKELY(vlSymsp->_vm_contextp__->debug())) {..."},
-        {"type":"STMTEXPR","name":"","addr":"(TP)","loc":"a,0:0,0:0",
+        {"type":"TEXT","name":"","addr":"(TP)","loc":"d,11:8,11:9","shortText":"#ifdef VL_DEBUG..."},
+        {"type":"TEXT","name":"","addr":"(UP)","loc":"d,11:8,11:9","shortText":"if (VL_UNLIKELY(vlSymsp->_vm_contextp__->debug())) {..."},
+        {"type":"STMTEXPR","name":"","addr":"(VP)","loc":"a,0:0,0:0",
          "exprp": [
-          {"type":"CCALL","name":"","addr":"(UP)","loc":"a,0:0,0:0","dtypep":"(CB)","funcName":"_dump_triggers__act","funcp":"(VP)","argsp": []}
+          {"type":"CCALL","name":"","addr":"(WP)","loc":"a,0:0,0:0","dtypep":"(CB)","funcName":"_dump_triggers__act","funcp":"(XP)","argsp": []}
         ]},
-        {"type":"TEXT","name":"","addr":"(WP)","loc":"d,11:8,11:9","shortText":"}..."},
-        {"type":"TEXT","name":"","addr":"(XP)","loc":"d,11:8,11:9","shortText":"#endif..."}
+        {"type":"TEXT","name":"","addr":"(YP)","loc":"d,11:8,11:9","shortText":"}..."},
+        {"type":"TEXT","name":"","addr":"(ZP)","loc":"d,11:8,11:9","shortText":"#endif..."}
       ]}
     ],"finalsp": []},
-    {"type":"CFUNC","name":"_dump_triggers__act","addr":"(VP)","loc":"a,0:0,0:0","slow":true,"isStatic":false,"dpiExportDispatcher":false,"dpiExportImpl":false,"dpiImportPrototype":false,"dpiImportWrapper":false,"dpiContext":false,"isConstructor":false,"isDestructor":false,"isVirtual":false,"isCoroutine":false,"needProcess":false,"scopep":"(Y)","argsp": [],"initsp": [],
+    {"type":"CFUNC","name":"_dump_triggers__act","addr":"(XP)","loc":"a,0:0,0:0","slow":true,"isStatic":false,"dpiExportDispatcher":false,"dpiExportImpl":false,"dpiImportPrototype":false,"dpiImportWrapper":false,"dpiContext":false,"isConstructor":false,"isDestructor":false,"isVirtual":false,"isCoroutine":false,"needProcess":false,"scopep":"(Y)","argsp": [],"initsp": [],
      "stmtsp": [
-      {"type":"IF","name":"","addr":"(YP)","loc":"d,11:8,11:9",
+      {"type":"IF","name":"","addr":"(AQ)","loc":"d,11:8,11:9",
        "condp": [
-        {"type":"AND","name":"","addr":"(ZP)","loc":"d,11:8,11:9","dtypep":"(NB)",
+        {"type":"AND","name":"","addr":"(BQ)","loc":"d,11:8,11:9","dtypep":"(NB)",
          "lhsp": [
-          {"type":"CONST","name":"32'h1","addr":"(AQ)","loc":"d,11:8,11:9","dtypep":"(NC)"}
+          {"type":"CONST","name":"32'h1","addr":"(CQ)","loc":"d,11:8,11:9","dtypep":"(NC)"}
         ],
          "rhsp": [
-          {"type":"NOT","name":"","addr":"(BQ)","loc":"d,11:8,11:9","dtypep":"(NB)",
+          {"type":"NOT","name":"","addr":"(DQ)","loc":"d,11:8,11:9","dtypep":"(NB)",
            "lhsp": [
-            {"type":"CMETHODHARD","name":"any","addr":"(CQ)","loc":"d,11:8,11:9","dtypep":"(NB)",
+            {"type":"CMETHODHARD","name":"any","addr":"(EQ)","loc":"d,11:8,11:9","dtypep":"(NB)",
              "fromp": [
-              {"type":"VARREF","name":"__VactTriggered","addr":"(DQ)","loc":"d,11:8,11:9","dtypep":"(NB)","access":"RD","varp":"(U)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+              {"type":"VARREF","name":"__VactTriggered","addr":"(FQ)","loc":"d,11:8,11:9","dtypep":"(NB)","access":"RD","varp":"(U)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
             ],"pinsp": []}
           ]}
         ]}
       ],
        "thensp": [
-        {"type":"TEXT","name":"","addr":"(EQ)","loc":"d,11:8,11:9","shortText":"VL_DBG_MSGF(\"         No triggers active\\n\");..."}
+        {"type":"TEXT","name":"","addr":"(GQ)","loc":"d,11:8,11:9","shortText":"VL_DBG_MSGF(\"         No triggers active\\n\");..."}
       ],"elsesp": []},
-      {"type":"IF","name":"","addr":"(FQ)","loc":"d,11:8,11:9",
+      {"type":"IF","name":"","addr":"(HQ)","loc":"d,11:8,11:9",
        "condp": [
-        {"type":"AND","name":"","addr":"(GQ)","loc":"d,11:8,11:9","dtypep":"(HQ)",
+        {"type":"AND","name":"","addr":"(IQ)","loc":"d,11:8,11:9","dtypep":"(JQ)",
          "lhsp": [
-          {"type":"CONST","name":"64'h1","addr":"(IQ)","loc":"d,11:8,11:9","dtypep":"(HQ)"}
+          {"type":"CONST","name":"64'h1","addr":"(KQ)","loc":"d,11:8,11:9","dtypep":"(JQ)"}
         ],
          "rhsp": [
-          {"type":"CMETHODHARD","name":"word","addr":"(JQ)","loc":"d,11:8,11:9","dtypep":"(KQ)",
+          {"type":"CMETHODHARD","name":"word","addr":"(LQ)","loc":"d,11:8,11:9","dtypep":"(MQ)",
            "fromp": [
-            {"type":"VARREF","name":"__VactTriggered","addr":"(LQ)","loc":"d,11:8,11:9","dtypep":"(NB)","access":"RD","varp":"(U)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"__VactTriggered","addr":"(NQ)","loc":"d,11:8,11:9","dtypep":"(NB)","access":"RD","varp":"(U)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ],
            "pinsp": [
-            {"type":"CONST","name":"32'h0","addr":"(MQ)","loc":"d,11:8,11:9","dtypep":"(NC)"}
+            {"type":"CONST","name":"32'h0","addr":"(OQ)","loc":"d,11:8,11:9","dtypep":"(NC)"}
           ]}
         ]}
       ],
        "thensp": [
-        {"type":"TEXT","name":"","addr":"(NQ)","loc":"d,11:8,11:9","shortText":"VL_DBG_MSGF(\"         'act' region trigger index 0 is active: @(posedge clk)\\n\");..."}
+        {"type":"TEXT","name":"","addr":"(PQ)","loc":"d,11:8,11:9","shortText":"VL_DBG_MSGF(\"         'act' region trigger index 0 is active: @(posedge clk)\\n\");..."}
       ],"elsesp": []}
     ],"finalsp": []},
-    {"type":"CFUNC","name":"_dump_triggers__nba","addr":"(OQ)","loc":"a,0:0,0:0","slow":true,"isStatic":false,"dpiExportDispatcher":false,"dpiExportImpl":false,"dpiImportPrototype":false,"dpiImportWrapper":false,"dpiContext":false,"isConstructor":false,"isDestructor":false,"isVirtual":false,"isCoroutine":false,"needProcess":false,"scopep":"(Y)","argsp": [],"initsp": [],
+    {"type":"CFUNC","name":"_dump_triggers__nba","addr":"(QQ)","loc":"a,0:0,0:0","slow":true,"isStatic":false,"dpiExportDispatcher":false,"dpiExportImpl":false,"dpiImportPrototype":false,"dpiImportWrapper":false,"dpiContext":false,"isConstructor":false,"isDestructor":false,"isVirtual":false,"isCoroutine":false,"needProcess":false,"scopep":"(Y)","argsp": [],"initsp": [],
      "stmtsp": [
-      {"type":"IF","name":"","addr":"(PQ)","loc":"d,11:8,11:9",
+      {"type":"IF","name":"","addr":"(RQ)","loc":"d,11:8,11:9",
        "condp": [
-        {"type":"AND","name":"","addr":"(QQ)","loc":"d,11:8,11:9","dtypep":"(NB)",
+        {"type":"AND","name":"","addr":"(SQ)","loc":"d,11:8,11:9","dtypep":"(NB)",
          "lhsp": [
-          {"type":"CONST","name":"32'h1","addr":"(RQ)","loc":"d,11:8,11:9","dtypep":"(NC)"}
+          {"type":"CONST","name":"32'h1","addr":"(TQ)","loc":"d,11:8,11:9","dtypep":"(NC)"}
         ],
          "rhsp": [
-          {"type":"NOT","name":"","addr":"(SQ)","loc":"d,11:8,11:9","dtypep":"(NB)",
+          {"type":"NOT","name":"","addr":"(UQ)","loc":"d,11:8,11:9","dtypep":"(NB)",
            "lhsp": [
-            {"type":"CMETHODHARD","name":"any","addr":"(TQ)","loc":"d,11:8,11:9","dtypep":"(NB)",
+            {"type":"CMETHODHARD","name":"any","addr":"(VQ)","loc":"d,11:8,11:9","dtypep":"(NB)",
              "fromp": [
-              {"type":"VARREF","name":"__VnbaTriggered","addr":"(UQ)","loc":"d,11:8,11:9","dtypep":"(NB)","access":"RD","varp":"(W)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+              {"type":"VARREF","name":"__VnbaTriggered","addr":"(WQ)","loc":"d,11:8,11:9","dtypep":"(NB)","access":"RD","varp":"(W)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
             ],"pinsp": []}
           ]}
         ]}
       ],
        "thensp": [
-        {"type":"TEXT","name":"","addr":"(VQ)","loc":"d,11:8,11:9","shortText":"VL_DBG_MSGF(\"         No triggers active\\n\");..."}
+        {"type":"TEXT","name":"","addr":"(XQ)","loc":"d,11:8,11:9","shortText":"VL_DBG_MSGF(\"         No triggers active\\n\");..."}
       ],"elsesp": []},
-      {"type":"IF","name":"","addr":"(WQ)","loc":"d,11:8,11:9",
+      {"type":"IF","name":"","addr":"(YQ)","loc":"d,11:8,11:9",
        "condp": [
-        {"type":"AND","name":"","addr":"(XQ)","loc":"d,11:8,11:9","dtypep":"(HQ)",
+        {"type":"AND","name":"","addr":"(ZQ)","loc":"d,11:8,11:9","dtypep":"(JQ)",
          "lhsp": [
-          {"type":"CONST","name":"64'h1","addr":"(YQ)","loc":"d,11:8,11:9","dtypep":"(HQ)"}
+          {"type":"CONST","name":"64'h1","addr":"(AR)","loc":"d,11:8,11:9","dtypep":"(JQ)"}
         ],
          "rhsp": [
-          {"type":"CMETHODHARD","name":"word","addr":"(ZQ)","loc":"d,11:8,11:9","dtypep":"(KQ)",
+          {"type":"CMETHODHARD","name":"word","addr":"(BR)","loc":"d,11:8,11:9","dtypep":"(MQ)",
            "fromp": [
-            {"type":"VARREF","name":"__VnbaTriggered","addr":"(AR)","loc":"d,11:8,11:9","dtypep":"(NB)","access":"RD","varp":"(W)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"__VnbaTriggered","addr":"(CR)","loc":"d,11:8,11:9","dtypep":"(NB)","access":"RD","varp":"(W)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ],
            "pinsp": [
-            {"type":"CONST","name":"32'h0","addr":"(BR)","loc":"d,11:8,11:9","dtypep":"(NC)"}
+            {"type":"CONST","name":"32'h0","addr":"(DR)","loc":"d,11:8,11:9","dtypep":"(NC)"}
           ]}
         ]}
       ],
        "thensp": [
-        {"type":"TEXT","name":"","addr":"(CR)","loc":"d,11:8,11:9","shortText":"VL_DBG_MSGF(\"         'nba' region trigger index 0 is active: @(posedge clk)\\n\");..."}
+        {"type":"TEXT","name":"","addr":"(ER)","loc":"d,11:8,11:9","shortText":"VL_DBG_MSGF(\"         'nba' region trigger index 0 is active: @(posedge clk)\\n\");..."}
       ],"elsesp": []}
     ],"finalsp": []},
-    {"type":"CFUNC","name":"_eval_act","addr":"(DR)","loc":"a,0:0,0:0","slow":false,"isStatic":false,"dpiExportDispatcher":false,"dpiExportImpl":false,"dpiImportPrototype":false,"dpiImportWrapper":false,"dpiContext":false,"isConstructor":false,"isDestructor":false,"isVirtual":false,"isCoroutine":false,"needProcess":false,"scopep":"(Y)","argsp": [],"initsp": [],"stmtsp": [],"finalsp": []},
+    {"type":"CFUNC","name":"_eval_act","addr":"(FR)","loc":"a,0:0,0:0","slow":false,"isStatic":false,"dpiExportDispatcher":false,"dpiExportImpl":false,"dpiImportPrototype":false,"dpiImportWrapper":false,"dpiContext":false,"isConstructor":false,"isDestructor":false,"isVirtual":false,"isCoroutine":false,"needProcess":false,"scopep":"(Y)","argsp": [],"initsp": [],"stmtsp": [],"finalsp": []},
     {"type":"CFUNC","name":"_eval_nba","addr":"(G)","loc":"a,0:0,0:0","slow":false,"isStatic":false,"dpiExportDispatcher":false,"dpiExportImpl":false,"dpiImportPrototype":false,"dpiImportWrapper":false,"dpiContext":false,"isConstructor":false,"isDestructor":false,"isVirtual":false,"isCoroutine":false,"needProcess":false,"scopep":"(Y)","argsp": [],"initsp": [],
      "stmtsp": [
-      {"type":"IF","name":"","addr":"(ER)","loc":"d,11:8,11:9",
+      {"type":"IF","name":"","addr":"(GR)","loc":"d,11:8,11:9",
        "condp": [
-        {"type":"AND","name":"","addr":"(FR)","loc":"d,11:8,11:9","dtypep":"(HQ)",
+        {"type":"AND","name":"","addr":"(HR)","loc":"d,11:8,11:9","dtypep":"(JQ)",
          "lhsp": [
-          {"type":"CONST","name":"64'h1","addr":"(GR)","loc":"d,11:8,11:9","dtypep":"(HQ)"}
+          {"type":"CONST","name":"64'h1","addr":"(IR)","loc":"d,11:8,11:9","dtypep":"(JQ)"}
         ],
          "rhsp": [
-          {"type":"CMETHODHARD","name":"word","addr":"(HR)","loc":"d,11:8,11:9","dtypep":"(KQ)",
+          {"type":"CMETHODHARD","name":"word","addr":"(JR)","loc":"d,11:8,11:9","dtypep":"(MQ)",
            "fromp": [
-            {"type":"VARREF","name":"__VnbaTriggered","addr":"(IR)","loc":"d,11:8,11:9","dtypep":"(NB)","access":"RD","varp":"(W)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"__VnbaTriggered","addr":"(KR)","loc":"d,11:8,11:9","dtypep":"(NB)","access":"RD","varp":"(W)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ],
            "pinsp": [
-            {"type":"CONST","name":"32'h0","addr":"(JR)","loc":"d,11:8,11:9","dtypep":"(NC)"}
+            {"type":"CONST","name":"32'h0","addr":"(LR)","loc":"d,11:8,11:9","dtypep":"(NC)"}
           ]}
         ]}
       ],
        "thensp": [
-        {"type":"STMTEXPR","name":"","addr":"(KR)","loc":"d,65:10,65:11",
+        {"type":"STMTEXPR","name":"","addr":"(MR)","loc":"d,65:10,65:11",
          "exprp": [
-          {"type":"CCALL","name":"","addr":"(LR)","loc":"d,65:10,65:11","dtypep":"(CB)","funcName":"_nba_sequent__TOP__0","funcp":"(MR)","argsp": []}
+          {"type":"CCALL","name":"","addr":"(NR)","loc":"d,65:10,65:11","dtypep":"(CB)","funcName":"_nba_sequent__TOP__0","funcp":"(OR)","argsp": []}
         ]}
       ],"elsesp": []}
     ],"finalsp": []},
-    {"type":"CFUNC","name":"_nba_sequent__TOP__0","addr":"(MR)","loc":"d,65:10,65:11","slow":false,"isStatic":false,"dpiExportDispatcher":false,"dpiExportImpl":false,"dpiImportPrototype":false,"dpiImportWrapper":false,"dpiContext":false,"isConstructor":false,"isDestructor":false,"isVirtual":false,"isCoroutine":false,"needProcess":false,"scopep":"(Y)","argsp": [],
+    {"type":"CFUNC","name":"_nba_sequent__TOP__0","addr":"(OR)","loc":"d,65:10,65:11","slow":false,"isStatic":false,"dpiExportDispatcher":false,"dpiExportImpl":false,"dpiImportPrototype":false,"dpiImportWrapper":false,"dpiContext":false,"isConstructor":false,"isDestructor":false,"isVirtual":false,"isCoroutine":false,"needProcess":false,"scopep":"(Y)","argsp": [],
      "initsp": [
-      {"type":"VAR","name":"__Vdly__t.cyc","addr":"(NR)","loc":"d,23:17,23:20","dtypep":"(R)","origName":"__Vdly__t__DOT__cyc","isSc":false,"isPrimaryIO":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":true,"attrClocker":"UNKNOWN","lifetime":"NONE","varType":"BLOCKTEMP","dtypeName":"integer","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
-      {"type":"CRESET","name":"","addr":"(OR)","loc":"d,23:17,23:20",
+      {"type":"VAR","name":"__Vdly__t.cyc","addr":"(PR)","loc":"d,23:17,23:20","dtypep":"(R)","origName":"__Vdly__t__DOT__cyc","isSc":false,"isPrimaryIO":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":true,"attrClocker":"UNKNOWN","lifetime":"NONE","varType":"BLOCKTEMP","dtypeName":"integer","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
+      {"type":"CRESET","name":"","addr":"(QR)","loc":"d,23:17,23:20",
        "varrefp": [
-        {"type":"VARREF","name":"__Vdly__t.cyc","addr":"(PR)","loc":"d,23:17,23:20","dtypep":"(R)","access":"WR","varp":"(NR)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"__Vdly__t.cyc","addr":"(RR)","loc":"d,23:17,23:20","dtypep":"(R)","access":"WR","varp":"(PR)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ]},
-      {"type":"VAR","name":"__Vdly__t.e","addr":"(QR)","loc":"d,24:9,24:10","dtypep":"(M)","origName":"__Vdly__t__DOT__e","isSc":false,"isPrimaryIO":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":true,"attrClocker":"UNKNOWN","lifetime":"NONE","varType":"BLOCKTEMP","dtypeName":"my_t","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
-      {"type":"CRESET","name":"","addr":"(RR)","loc":"d,24:9,24:10",
+      {"type":"VAR","name":"__Vdly__t.e","addr":"(SR)","loc":"d,24:9,24:10","dtypep":"(M)","origName":"__Vdly__t__DOT__e","isSc":false,"isPrimaryIO":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":true,"attrClocker":"UNKNOWN","lifetime":"NONE","varType":"BLOCKTEMP","dtypeName":"my_t","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
+      {"type":"CRESET","name":"","addr":"(TR)","loc":"d,24:9,24:10",
        "varrefp": [
-        {"type":"VARREF","name":"__Vdly__t.e","addr":"(SR)","loc":"d,24:9,24:10","dtypep":"(M)","access":"WR","varp":"(QR)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"__Vdly__t.e","addr":"(UR)","loc":"d,24:9,24:10","dtypep":"(M)","access":"WR","varp":"(SR)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ]},
-      {"type":"VAR","name":"__Vtemp_1","addr":"(TR)","loc":"d,68:126,68:130","dtypep":"(RB)","origName":"__Vtemp_1","isSc":false,"isPrimaryIO":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"attrClocker":"UNKNOWN","lifetime":"NONE","varType":"STMTTEMP","dtypeName":"string","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
-      {"type":"VAR","name":"__Vtemp_2","addr":"(UR)","loc":"d,78:126,78:130","dtypep":"(RB)","origName":"__Vtemp_2","isSc":false,"isPrimaryIO":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"attrClocker":"UNKNOWN","lifetime":"NONE","varType":"STMTTEMP","dtypeName":"string","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
-      {"type":"VAR","name":"__Vtemp_3","addr":"(VR)","loc":"d,88:126,88:130","dtypep":"(RB)","origName":"__Vtemp_3","isSc":false,"isPrimaryIO":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"attrClocker":"UNKNOWN","lifetime":"NONE","varType":"STMTTEMP","dtypeName":"string","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []}
+      {"type":"VAR","name":"__Vtemp_1","addr":"(VR)","loc":"d,68:126,68:130","dtypep":"(RB)","origName":"__Vtemp_1","isSc":false,"isPrimaryIO":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"attrClocker":"UNKNOWN","lifetime":"NONE","varType":"STMTTEMP","dtypeName":"string","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
+      {"type":"VAR","name":"__Vtemp_2","addr":"(WR)","loc":"d,78:126,78:130","dtypep":"(RB)","origName":"__Vtemp_2","isSc":false,"isPrimaryIO":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"attrClocker":"UNKNOWN","lifetime":"NONE","varType":"STMTTEMP","dtypeName":"string","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
+      {"type":"VAR","name":"__Vtemp_3","addr":"(XR)","loc":"d,88:126,88:130","dtypep":"(RB)","origName":"__Vtemp_3","isSc":false,"isPrimaryIO":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"attrClocker":"UNKNOWN","lifetime":"NONE","varType":"STMTTEMP","dtypeName":"string","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []}
     ],
      "stmtsp": [
-      {"type":"ASSIGNPRE","name":"","addr":"(WR)","loc":"d,65:10,65:11","dtypep":"(AC)",
+      {"type":"ASSIGNPRE","name":"","addr":"(YR)","loc":"d,65:10,65:11","dtypep":"(AC)",
        "rhsp": [
-        {"type":"VARREF","name":"t.e","addr":"(XR)","loc":"d,65:10,65:11","dtypep":"(AC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"t.e","addr":"(ZR)","loc":"d,65:10,65:11","dtypep":"(AC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"__Vdly__t.e","addr":"(YR)","loc":"d,65:10,65:11","dtypep":"(AC)","access":"WR","varp":"(QR)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"__Vdly__t.e","addr":"(AS)","loc":"d,65:10,65:11","dtypep":"(AC)","access":"WR","varp":"(SR)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []},
-      {"type":"ASSIGNPRE","name":"","addr":"(ZR)","loc":"d,62:7,62:10","dtypep":"(R)",
+      {"type":"ASSIGNPRE","name":"","addr":"(BS)","loc":"d,62:7,62:10","dtypep":"(R)",
        "rhsp": [
-        {"type":"VARREF","name":"t.cyc","addr":"(AS)","loc":"d,62:7,62:10","dtypep":"(R)","access":"RD","varp":"(Q)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"t.cyc","addr":"(CS)","loc":"d,62:7,62:10","dtypep":"(R)","access":"RD","varp":"(Q)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"__Vdly__t.cyc","addr":"(BS)","loc":"d,62:7,62:10","dtypep":"(R)","access":"WR","varp":"(NR)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"__Vdly__t.cyc","addr":"(DS)","loc":"d,62:7,62:10","dtypep":"(R)","access":"WR","varp":"(PR)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []},
-      {"type":"ASSIGNDLY","name":"","addr":"(CS)","loc":"d,62:11,62:13","dtypep":"(R)",
+      {"type":"ASSIGNDLY","name":"","addr":"(ES)","loc":"d,62:11,62:13","dtypep":"(R)",
        "rhsp": [
-        {"type":"ADD","name":"","addr":"(DS)","loc":"d,62:18,62:19","dtypep":"(R)",
+        {"type":"ADD","name":"","addr":"(FS)","loc":"d,62:18,62:19","dtypep":"(R)",
          "lhsp": [
-          {"type":"CCAST","name":"","addr":"(ES)","loc":"d,62:20,62:21","dtypep":"(NC)","size":32,
+          {"type":"CCAST","name":"","addr":"(GS)","loc":"d,62:20,62:21","dtypep":"(NC)","size":32,
            "lhsp": [
-            {"type":"CONST","name":"32'sh1","addr":"(FS)","loc":"d,62:20,62:21","dtypep":"(GB)"}
+            {"type":"CONST","name":"32'sh1","addr":"(HS)","loc":"d,62:20,62:21","dtypep":"(GB)"}
           ]}
         ],
          "rhsp": [
-          {"type":"VARREF","name":"t.cyc","addr":"(GS)","loc":"d,62:14,62:17","dtypep":"(R)","access":"RD","varp":"(Q)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+          {"type":"VARREF","name":"t.cyc","addr":"(IS)","loc":"d,62:14,62:17","dtypep":"(R)","access":"RD","varp":"(Q)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
         ]}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"__Vdly__t.cyc","addr":"(HS)","loc":"d,62:7,62:10","dtypep":"(R)","access":"WR","varp":"(NR)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"__Vdly__t.cyc","addr":"(JS)","loc":"d,62:7,62:10","dtypep":"(R)","access":"WR","varp":"(PR)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []},
-      {"type":"IF","name":"","addr":"(IS)","loc":"d,63:7,63:9",
+      {"type":"IF","name":"","addr":"(KS)","loc":"d,63:7,63:9",
        "condp": [
-        {"type":"EQ","name":"","addr":"(JS)","loc":"d,63:14,63:16","dtypep":"(NB)",
+        {"type":"EQ","name":"","addr":"(LS)","loc":"d,63:14,63:16","dtypep":"(NB)",
          "lhsp": [
-          {"type":"CONST","name":"32'sh0","addr":"(KS)","loc":"d,63:16,63:17","dtypep":"(GB)"}
+          {"type":"CONST","name":"32'sh0","addr":"(MS)","loc":"d,63:16,63:17","dtypep":"(GB)"}
         ],
          "rhsp": [
-          {"type":"VARREF","name":"t.cyc","addr":"(LS)","loc":"d,63:11,63:14","dtypep":"(R)","access":"RD","varp":"(Q)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+          {"type":"VARREF","name":"t.cyc","addr":"(NS)","loc":"d,63:11,63:14","dtypep":"(R)","access":"RD","varp":"(Q)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
         ]}
       ],
        "thensp": [
-        {"type":"ASSIGNDLY","name":"","addr":"(MS)","loc":"d,65:12,65:14","dtypep":"(AC)",
+        {"type":"ASSIGNDLY","name":"","addr":"(OS)","loc":"d,65:12,65:14","dtypep":"(AC)",
          "rhsp": [
-          {"type":"CONST","name":"4'h1","addr":"(NS)","loc":"d,65:15,65:18","dtypep":"(AC)"}
+          {"type":"CONST","name":"4'h1","addr":"(PS)","loc":"d,65:15,65:18","dtypep":"(AC)"}
         ],
          "lhsp": [
-          {"type":"VARREF","name":"__Vdly__t.e","addr":"(OS)","loc":"d,65:10,65:11","dtypep":"(AC)","access":"WR","varp":"(QR)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+          {"type":"VARREF","name":"__Vdly__t.e","addr":"(QS)","loc":"d,65:10,65:11","dtypep":"(AC)","access":"WR","varp":"(SR)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
         ],"timingControlp": []}
       ],
        "elsesp": [
-        {"type":"IF","name":"","addr":"(PS)","loc":"d,67:12,67:14",
+        {"type":"IF","name":"","addr":"(RS)","loc":"d,67:12,67:14",
          "condp": [
-          {"type":"EQ","name":"","addr":"(QS)","loc":"d,67:19,67:21","dtypep":"(NB)",
+          {"type":"EQ","name":"","addr":"(SS)","loc":"d,67:19,67:21","dtypep":"(NB)",
            "lhsp": [
-            {"type":"CONST","name":"32'sh1","addr":"(RS)","loc":"d,67:21,67:22","dtypep":"(GB)"}
+            {"type":"CONST","name":"32'sh1","addr":"(TS)","loc":"d,67:21,67:22","dtypep":"(GB)"}
           ],
            "rhsp": [
-            {"type":"VARREF","name":"t.cyc","addr":"(SS)","loc":"d,67:16,67:19","dtypep":"(R)","access":"RD","varp":"(Q)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"t.cyc","addr":"(US)","loc":"d,67:16,67:19","dtypep":"(R)","access":"RD","varp":"(Q)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ]}
         ],
          "thensp": [
-          {"type":"IF","name":"","addr":"(TS)","loc":"d,68:13,68:15",
+          {"type":"IF","name":"","addr":"(VS)","loc":"d,68:13,68:15",
            "condp": [
-            {"type":"NEQN","name":"","addr":"(US)","loc":"d,68:26,68:29","dtypep":"(NB)",
+            {"type":"NEQN","name":"","addr":"(WS)","loc":"d,68:26,68:29","dtypep":"(NB)",
              "lhsp": [
-              {"type":"CONST","name":"\\\"E01\\\"","addr":"(VS)","loc":"d,68:31,68:36","dtypep":"(RB)"}
+              {"type":"CONST","name":"\\\"E01\\\"","addr":"(XS)","loc":"d,68:31,68:36","dtypep":"(RB)"}
             ],
              "rhsp": [
-              {"type":"ARRAYSEL","name":"","addr":"(WS)","loc":"d,68:20,68:24","dtypep":"(RB)",
+              {"type":"ARRAYSEL","name":"","addr":"(YS)","loc":"d,68:20,68:24","dtypep":"(RB)",
                "fromp": [
-                {"type":"VARREF","name":"__Venumtab_enum_name2","addr":"(XS)","loc":"d,17:12,17:16","dtypep":"(OM)","access":"RD","varp":"(PM)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                {"type":"VARREF","name":"__Venumtab_enum_name2","addr":"(ZS)","loc":"d,17:12,17:16","dtypep":"(OM)","access":"RD","varp":"(PM)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
               ],
                "bitp": [
-                {"type":"AND","name":"","addr":"(YS)","loc":"d,68:20,68:24","dtypep":"(LC)",
+                {"type":"AND","name":"","addr":"(AT)","loc":"d,68:20,68:24","dtypep":"(LC)",
                  "lhsp": [
-                  {"type":"CONST","name":"32'h7","addr":"(ZS)","loc":"d,68:20,68:24","dtypep":"(NC)"}
+                  {"type":"CONST","name":"32'h7","addr":"(BT)","loc":"d,68:20,68:24","dtypep":"(NC)"}
                 ],
                  "rhsp": [
-                  {"type":"CCAST","name":"","addr":"(AT)","loc":"d,68:18,68:19","dtypep":"(LC)","size":32,
+                  {"type":"CCAST","name":"","addr":"(CT)","loc":"d,68:18,68:19","dtypep":"(LC)","size":32,
                    "lhsp": [
-                    {"type":"VARREF","name":"t.e","addr":"(BT)","loc":"d,68:18,68:19","dtypep":"(LC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"t.e","addr":"(DT)","loc":"d,68:18,68:19","dtypep":"(LC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ]}
                 ]}
               ]}
             ]}
           ],
            "thensp": [
-            {"type":"ASSIGN","name":"","addr":"(CT)","loc":"d,68:126,68:130","dtypep":"(RB)",
+            {"type":"ASSIGN","name":"","addr":"(ET)","loc":"d,68:126,68:130","dtypep":"(RB)",
              "rhsp": [
-              {"type":"ARRAYSEL","name":"","addr":"(DT)","loc":"d,68:126,68:130","dtypep":"(RB)",
+              {"type":"ARRAYSEL","name":"","addr":"(FT)","loc":"d,68:126,68:130","dtypep":"(RB)",
                "fromp": [
-                {"type":"VARREF","name":"__Venumtab_enum_name2","addr":"(ET)","loc":"d,17:12,17:16","dtypep":"(OM)","access":"RD","varp":"(PM)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                {"type":"VARREF","name":"__Venumtab_enum_name2","addr":"(GT)","loc":"d,17:12,17:16","dtypep":"(OM)","access":"RD","varp":"(PM)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
               ],
                "bitp": [
-                {"type":"AND","name":"","addr":"(FT)","loc":"d,68:126,68:130","dtypep":"(LC)",
+                {"type":"AND","name":"","addr":"(HT)","loc":"d,68:126,68:130","dtypep":"(LC)",
                  "lhsp": [
-                  {"type":"CONST","name":"32'h7","addr":"(GT)","loc":"d,68:126,68:130","dtypep":"(NC)"}
+                  {"type":"CONST","name":"32'h7","addr":"(IT)","loc":"d,68:126,68:130","dtypep":"(NC)"}
                 ],
                  "rhsp": [
-                  {"type":"CCAST","name":"","addr":"(HT)","loc":"d,68:124,68:125","dtypep":"(LC)","size":32,
+                  {"type":"CCAST","name":"","addr":"(JT)","loc":"d,68:124,68:125","dtypep":"(LC)","size":32,
                    "lhsp": [
-                    {"type":"VARREF","name":"t.e","addr":"(IT)","loc":"d,68:124,68:125","dtypep":"(LC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"t.e","addr":"(KT)","loc":"d,68:124,68:125","dtypep":"(LC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ]}
                 ]}
               ]}
             ],
              "lhsp": [
-              {"type":"VARREF","name":"__Vtemp_1","addr":"(JT)","loc":"d,68:126,68:130","dtypep":"(RB)","access":"WR","varp":"(TR)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+              {"type":"VARREF","name":"__Vtemp_1","addr":"(LT)","loc":"d,68:126,68:130","dtypep":"(RB)","access":"WR","varp":"(VR)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
             ],"timingControlp": []},
-            {"type":"DISPLAY","name":"","addr":"(KT)","loc":"d,68:45,68:51",
+            {"type":"DISPLAY","name":"","addr":"(MT)","loc":"d,68:45,68:51",
              "fmtp": [
-              {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:68:  got='%@' exp='E01'\\n","addr":"(LT)","loc":"d,68:45,68:51","dtypep":"(RB)",
+              {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:68:  got='%@' exp='E01'\\n","addr":"(NT)","loc":"d,68:45,68:51","dtypep":"(RB)",
                "exprsp": [
-                {"type":"VARREF","name":"__Vtemp_1","addr":"(MT)","loc":"d,68:126,68:130","dtypep":"(RB)","access":"RD","varp":"(TR)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                {"type":"VARREF","name":"__Vtemp_1","addr":"(OT)","loc":"d,68:126,68:130","dtypep":"(RB)","access":"RD","varp":"(VR)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
               ],"scopeNamep": []}
             ],"filep": []},
-            {"type":"STOP","name":"","addr":"(NT)","loc":"d,68:143,68:148"}
+            {"type":"STOP","name":"","addr":"(PT)","loc":"d,68:143,68:148"}
           ],"elsesp": []},
-          {"type":"IF","name":"","addr":"(OT)","loc":"d,69:13,69:15",
+          {"type":"IF","name":"","addr":"(QT)","loc":"d,69:13,69:15",
            "condp": [
-            {"type":"NEQ","name":"","addr":"(PT)","loc":"d,69:26,69:29","dtypep":"(NB)",
+            {"type":"NEQ","name":"","addr":"(RT)","loc":"d,69:26,69:29","dtypep":"(NB)",
              "lhsp": [
-              {"type":"CONST","name":"4'h3","addr":"(QT)","loc":"d,69:31,69:34","dtypep":"(AC)"}
+              {"type":"CONST","name":"4'h3","addr":"(ST)","loc":"d,69:31,69:34","dtypep":"(AC)"}
             ],
              "rhsp": [
-              {"type":"ARRAYSEL","name":"","addr":"(RT)","loc":"d,69:20,69:24","dtypep":"(AC)",
+              {"type":"ARRAYSEL","name":"","addr":"(TT)","loc":"d,69:20,69:24","dtypep":"(AC)",
                "fromp": [
-                {"type":"VARREF","name":"__Venumtab_enum_next0","addr":"(ST)","loc":"d,17:12,17:16","dtypep":"(IC)","access":"RD","varp":"(JC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                {"type":"VARREF","name":"__Venumtab_enum_next0","addr":"(UT)","loc":"d,17:12,17:16","dtypep":"(IC)","access":"RD","varp":"(JC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
               ],
                "bitp": [
-                {"type":"AND","name":"","addr":"(TT)","loc":"d,69:20,69:24","dtypep":"(LC)",
+                {"type":"AND","name":"","addr":"(VT)","loc":"d,69:20,69:24","dtypep":"(LC)",
                  "lhsp": [
-                  {"type":"CONST","name":"32'h7","addr":"(UT)","loc":"d,69:20,69:24","dtypep":"(NC)"}
+                  {"type":"CONST","name":"32'h7","addr":"(WT)","loc":"d,69:20,69:24","dtypep":"(NC)"}
                 ],
                  "rhsp": [
-                  {"type":"CCAST","name":"","addr":"(VT)","loc":"d,69:18,69:19","dtypep":"(LC)","size":32,
+                  {"type":"CCAST","name":"","addr":"(XT)","loc":"d,69:18,69:19","dtypep":"(LC)","size":32,
                    "lhsp": [
-                    {"type":"VARREF","name":"t.e","addr":"(WT)","loc":"d,69:18,69:19","dtypep":"(LC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"t.e","addr":"(YT)","loc":"d,69:18,69:19","dtypep":"(LC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ]}
                 ]}
               ]}
             ]}
           ],
            "thensp": [
-            {"type":"DISPLAY","name":"","addr":"(XT)","loc":"d,69:43,69:49",
+            {"type":"DISPLAY","name":"","addr":"(ZT)","loc":"d,69:43,69:49",
              "fmtp": [
-              {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:69:  got='h%x exp='h3\\n","addr":"(YT)","loc":"d,69:43,69:49","dtypep":"(RB)",
+              {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:69:  got='h%x exp='h3\\n","addr":"(AU)","loc":"d,69:43,69:49","dtypep":"(RB)",
                "exprsp": [
-                {"type":"ARRAYSEL","name":"","addr":"(ZT)","loc":"d,69:124,69:128","dtypep":"(AC)",
+                {"type":"ARRAYSEL","name":"","addr":"(BU)","loc":"d,69:124,69:128","dtypep":"(AC)",
                  "fromp": [
-                  {"type":"VARREF","name":"__Venumtab_enum_next0","addr":"(AU)","loc":"d,17:12,17:16","dtypep":"(IC)","access":"RD","varp":"(JC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"__Venumtab_enum_next0","addr":"(CU)","loc":"d,17:12,17:16","dtypep":"(IC)","access":"RD","varp":"(JC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                 ],
                  "bitp": [
-                  {"type":"AND","name":"","addr":"(BU)","loc":"d,69:124,69:128","dtypep":"(LC)",
+                  {"type":"AND","name":"","addr":"(DU)","loc":"d,69:124,69:128","dtypep":"(LC)",
                    "lhsp": [
-                    {"type":"CONST","name":"32'h7","addr":"(CU)","loc":"d,69:124,69:128","dtypep":"(NC)"}
+                    {"type":"CONST","name":"32'h7","addr":"(EU)","loc":"d,69:124,69:128","dtypep":"(NC)"}
                   ],
                    "rhsp": [
-                    {"type":"CCAST","name":"","addr":"(DU)","loc":"d,69:122,69:123","dtypep":"(LC)","size":32,
+                    {"type":"CCAST","name":"","addr":"(FU)","loc":"d,69:122,69:123","dtypep":"(LC)","size":32,
                      "lhsp": [
-                      {"type":"VARREF","name":"t.e","addr":"(EU)","loc":"d,69:122,69:123","dtypep":"(LC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"t.e","addr":"(GU)","loc":"d,69:122,69:123","dtypep":"(LC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ]}
                   ]}
                 ]}
               ],"scopeNamep": []}
             ],"filep": []},
-            {"type":"STOP","name":"","addr":"(FU)","loc":"d,69:139,69:144"}
+            {"type":"STOP","name":"","addr":"(HU)","loc":"d,69:139,69:144"}
           ],"elsesp": []},
-          {"type":"IF","name":"","addr":"(GU)","loc":"d,70:13,70:15",
+          {"type":"IF","name":"","addr":"(IU)","loc":"d,70:13,70:15",
            "condp": [
-            {"type":"NEQ","name":"","addr":"(HU)","loc":"d,70:29,70:32","dtypep":"(NB)",
+            {"type":"NEQ","name":"","addr":"(JU)","loc":"d,70:29,70:32","dtypep":"(NB)",
              "lhsp": [
-              {"type":"CONST","name":"4'h3","addr":"(IU)","loc":"d,70:34,70:37","dtypep":"(AC)"}
+              {"type":"CONST","name":"4'h3","addr":"(KU)","loc":"d,70:34,70:37","dtypep":"(AC)"}
             ],
              "rhsp": [
-              {"type":"ARRAYSEL","name":"","addr":"(JU)","loc":"d,70:20,70:24","dtypep":"(AC)",
+              {"type":"ARRAYSEL","name":"","addr":"(LU)","loc":"d,70:20,70:24","dtypep":"(AC)",
                "fromp": [
-                {"type":"VARREF","name":"__Venumtab_enum_next0","addr":"(KU)","loc":"d,17:12,17:16","dtypep":"(IC)","access":"RD","varp":"(JC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                {"type":"VARREF","name":"__Venumtab_enum_next0","addr":"(MU)","loc":"d,17:12,17:16","dtypep":"(IC)","access":"RD","varp":"(JC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
               ],
                "bitp": [
-                {"type":"AND","name":"","addr":"(LU)","loc":"d,70:20,70:24","dtypep":"(LC)",
+                {"type":"AND","name":"","addr":"(NU)","loc":"d,70:20,70:24","dtypep":"(LC)",
                  "lhsp": [
-                  {"type":"CONST","name":"32'h7","addr":"(MU)","loc":"d,70:20,70:24","dtypep":"(NC)"}
+                  {"type":"CONST","name":"32'h7","addr":"(OU)","loc":"d,70:20,70:24","dtypep":"(NC)"}
                 ],
                  "rhsp": [
-                  {"type":"CCAST","name":"","addr":"(NU)","loc":"d,70:18,70:19","dtypep":"(LC)","size":32,
+                  {"type":"CCAST","name":"","addr":"(PU)","loc":"d,70:18,70:19","dtypep":"(LC)","size":32,
                    "lhsp": [
-                    {"type":"VARREF","name":"t.e","addr":"(OU)","loc":"d,70:18,70:19","dtypep":"(LC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"t.e","addr":"(QU)","loc":"d,70:18,70:19","dtypep":"(LC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ]}
                 ]}
               ]}
             ]}
           ],
            "thensp": [
-            {"type":"DISPLAY","name":"","addr":"(PU)","loc":"d,70:46,70:52",
+            {"type":"DISPLAY","name":"","addr":"(RU)","loc":"d,70:46,70:52",
              "fmtp": [
-              {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:70:  got='h%x exp='h3\\n","addr":"(QU)","loc":"d,70:46,70:52","dtypep":"(RB)",
+              {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:70:  got='h%x exp='h3\\n","addr":"(SU)","loc":"d,70:46,70:52","dtypep":"(RB)",
                "exprsp": [
-                {"type":"ARRAYSEL","name":"","addr":"(RU)","loc":"d,70:127,70:131","dtypep":"(AC)",
+                {"type":"ARRAYSEL","name":"","addr":"(TU)","loc":"d,70:127,70:131","dtypep":"(AC)",
                  "fromp": [
-                  {"type":"VARREF","name":"__Venumtab_enum_next0","addr":"(SU)","loc":"d,17:12,17:16","dtypep":"(IC)","access":"RD","varp":"(JC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"__Venumtab_enum_next0","addr":"(UU)","loc":"d,17:12,17:16","dtypep":"(IC)","access":"RD","varp":"(JC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                 ],
                  "bitp": [
-                  {"type":"AND","name":"","addr":"(TU)","loc":"d,70:127,70:131","dtypep":"(LC)",
+                  {"type":"AND","name":"","addr":"(VU)","loc":"d,70:127,70:131","dtypep":"(LC)",
                    "lhsp": [
-                    {"type":"CONST","name":"32'h7","addr":"(UU)","loc":"d,70:127,70:131","dtypep":"(NC)"}
+                    {"type":"CONST","name":"32'h7","addr":"(WU)","loc":"d,70:127,70:131","dtypep":"(NC)"}
                   ],
                    "rhsp": [
-                    {"type":"CCAST","name":"","addr":"(VU)","loc":"d,70:125,70:126","dtypep":"(LC)","size":32,
+                    {"type":"CCAST","name":"","addr":"(XU)","loc":"d,70:125,70:126","dtypep":"(LC)","size":32,
                      "lhsp": [
-                      {"type":"VARREF","name":"t.e","addr":"(WU)","loc":"d,70:125,70:126","dtypep":"(LC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"t.e","addr":"(YU)","loc":"d,70:125,70:126","dtypep":"(LC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ]}
                   ]}
                 ]}
               ],"scopeNamep": []}
             ],"filep": []},
-            {"type":"STOP","name":"","addr":"(XU)","loc":"d,70:145,70:150"}
+            {"type":"STOP","name":"","addr":"(ZU)","loc":"d,70:145,70:150"}
           ],"elsesp": []},
-          {"type":"IF","name":"","addr":"(YU)","loc":"d,71:13,71:15",
+          {"type":"IF","name":"","addr":"(AV)","loc":"d,71:13,71:15",
            "condp": [
-            {"type":"NEQ","name":"","addr":"(ZU)","loc":"d,71:29,71:32","dtypep":"(NB)",
+            {"type":"NEQ","name":"","addr":"(BV)","loc":"d,71:29,71:32","dtypep":"(NB)",
              "lhsp": [
-              {"type":"CONST","name":"4'h4","addr":"(AV)","loc":"d,71:34,71:37","dtypep":"(AC)"}
+              {"type":"CONST","name":"4'h4","addr":"(CV)","loc":"d,71:34,71:37","dtypep":"(AC)"}
             ],
              "rhsp": [
-              {"type":"ARRAYSEL","name":"","addr":"(BV)","loc":"d,71:20,71:24","dtypep":"(AC)",
+              {"type":"ARRAYSEL","name":"","addr":"(DV)","loc":"d,71:20,71:24","dtypep":"(AC)",
                "fromp": [
-                {"type":"VARREF","name":"__Venumtab_enum_next0","addr":"(CV)","loc":"d,17:12,17:16","dtypep":"(IC)","access":"RD","varp":"(JC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                {"type":"VARREF","name":"__Venumtab_enum_next0","addr":"(EV)","loc":"d,17:12,17:16","dtypep":"(IC)","access":"RD","varp":"(JC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
               ],
                "bitp": [
-                {"type":"AND","name":"","addr":"(DV)","loc":"d,71:20,71:24","dtypep":"(LC)",
+                {"type":"AND","name":"","addr":"(FV)","loc":"d,71:20,71:24","dtypep":"(LC)",
                  "lhsp": [
-                  {"type":"CONST","name":"32'h7","addr":"(EV)","loc":"d,71:20,71:24","dtypep":"(NC)"}
+                  {"type":"CONST","name":"32'h7","addr":"(GV)","loc":"d,71:20,71:24","dtypep":"(NC)"}
                 ],
                  "rhsp": [
-                  {"type":"ARRAYSEL","name":"","addr":"(FV)","loc":"d,71:20,71:24","dtypep":"(LC)",
+                  {"type":"ARRAYSEL","name":"","addr":"(HV)","loc":"d,71:20,71:24","dtypep":"(LC)",
                    "fromp": [
-                    {"type":"VARREF","name":"__Venumtab_enum_next0","addr":"(GV)","loc":"d,17:12,17:16","dtypep":"(IC)","access":"RD","varp":"(JC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"__Venumtab_enum_next0","addr":"(IV)","loc":"d,17:12,17:16","dtypep":"(IC)","access":"RD","varp":"(JC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ],
                    "bitp": [
-                    {"type":"AND","name":"","addr":"(HV)","loc":"d,71:20,71:24","dtypep":"(LC)",
+                    {"type":"AND","name":"","addr":"(JV)","loc":"d,71:20,71:24","dtypep":"(LC)",
                      "lhsp": [
-                      {"type":"CONST","name":"32'h7","addr":"(IV)","loc":"d,71:20,71:24","dtypep":"(NC)"}
+                      {"type":"CONST","name":"32'h7","addr":"(KV)","loc":"d,71:20,71:24","dtypep":"(NC)"}
                     ],
                      "rhsp": [
-                      {"type":"CCAST","name":"","addr":"(JV)","loc":"d,71:18,71:19","dtypep":"(LC)","size":32,
+                      {"type":"CCAST","name":"","addr":"(LV)","loc":"d,71:18,71:19","dtypep":"(LC)","size":32,
                        "lhsp": [
-                        {"type":"VARREF","name":"t.e","addr":"(KV)","loc":"d,71:18,71:19","dtypep":"(LC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                        {"type":"VARREF","name":"t.e","addr":"(MV)","loc":"d,71:18,71:19","dtypep":"(LC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                       ]}
                     ]}
                   ]}
@@ -1420,33 +1426,33 @@
             ]}
           ],
            "thensp": [
-            {"type":"DISPLAY","name":"","addr":"(LV)","loc":"d,71:46,71:52",
+            {"type":"DISPLAY","name":"","addr":"(NV)","loc":"d,71:46,71:52",
              "fmtp": [
-              {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:71:  got='h%x exp='h4\\n","addr":"(MV)","loc":"d,71:46,71:52","dtypep":"(RB)",
+              {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:71:  got='h%x exp='h4\\n","addr":"(OV)","loc":"d,71:46,71:52","dtypep":"(RB)",
                "exprsp": [
-                {"type":"ARRAYSEL","name":"","addr":"(NV)","loc":"d,71:127,71:131","dtypep":"(AC)",
+                {"type":"ARRAYSEL","name":"","addr":"(PV)","loc":"d,71:127,71:131","dtypep":"(AC)",
                  "fromp": [
-                  {"type":"VARREF","name":"__Venumtab_enum_next0","addr":"(OV)","loc":"d,17:12,17:16","dtypep":"(IC)","access":"RD","varp":"(JC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"__Venumtab_enum_next0","addr":"(QV)","loc":"d,17:12,17:16","dtypep":"(IC)","access":"RD","varp":"(JC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                 ],
                  "bitp": [
-                  {"type":"AND","name":"","addr":"(PV)","loc":"d,71:127,71:131","dtypep":"(LC)",
+                  {"type":"AND","name":"","addr":"(RV)","loc":"d,71:127,71:131","dtypep":"(LC)",
                    "lhsp": [
-                    {"type":"CONST","name":"32'h7","addr":"(QV)","loc":"d,71:127,71:131","dtypep":"(NC)"}
+                    {"type":"CONST","name":"32'h7","addr":"(SV)","loc":"d,71:127,71:131","dtypep":"(NC)"}
                   ],
                    "rhsp": [
-                    {"type":"ARRAYSEL","name":"","addr":"(RV)","loc":"d,71:127,71:131","dtypep":"(LC)",
+                    {"type":"ARRAYSEL","name":"","addr":"(TV)","loc":"d,71:127,71:131","dtypep":"(LC)",
                      "fromp": [
-                      {"type":"VARREF","name":"__Venumtab_enum_next0","addr":"(SV)","loc":"d,17:12,17:16","dtypep":"(IC)","access":"RD","varp":"(JC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"__Venumtab_enum_next0","addr":"(UV)","loc":"d,17:12,17:16","dtypep":"(IC)","access":"RD","varp":"(JC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ],
                      "bitp": [
-                      {"type":"AND","name":"","addr":"(TV)","loc":"d,71:127,71:131","dtypep":"(LC)",
+                      {"type":"AND","name":"","addr":"(VV)","loc":"d,71:127,71:131","dtypep":"(LC)",
                        "lhsp": [
-                        {"type":"CONST","name":"32'h7","addr":"(UV)","loc":"d,71:127,71:131","dtypep":"(NC)"}
+                        {"type":"CONST","name":"32'h7","addr":"(WV)","loc":"d,71:127,71:131","dtypep":"(NC)"}
                       ],
                        "rhsp": [
-                        {"type":"CCAST","name":"","addr":"(VV)","loc":"d,71:125,71:126","dtypep":"(LC)","size":32,
+                        {"type":"CCAST","name":"","addr":"(XV)","loc":"d,71:125,71:126","dtypep":"(LC)","size":32,
                          "lhsp": [
-                          {"type":"VARREF","name":"t.e","addr":"(WV)","loc":"d,71:125,71:126","dtypep":"(LC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                          {"type":"VARREF","name":"t.e","addr":"(YV)","loc":"d,71:125,71:126","dtypep":"(LC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                         ]}
                       ]}
                     ]}
@@ -1454,138 +1460,138 @@
                 ]}
               ],"scopeNamep": []}
             ],"filep": []},
-            {"type":"STOP","name":"","addr":"(XV)","loc":"d,71:145,71:150"}
+            {"type":"STOP","name":"","addr":"(ZV)","loc":"d,71:145,71:150"}
           ],"elsesp": []},
-          {"type":"IF","name":"","addr":"(YV)","loc":"d,72:13,72:15",
+          {"type":"IF","name":"","addr":"(AW)","loc":"d,72:13,72:15",
            "condp": [
-            {"type":"NEQ","name":"","addr":"(ZV)","loc":"d,72:26,72:29","dtypep":"(NB)",
+            {"type":"NEQ","name":"","addr":"(BW)","loc":"d,72:26,72:29","dtypep":"(NB)",
              "lhsp": [
-              {"type":"CONST","name":"4'h4","addr":"(AW)","loc":"d,72:31,72:34","dtypep":"(AC)"}
+              {"type":"CONST","name":"4'h4","addr":"(CW)","loc":"d,72:31,72:34","dtypep":"(AC)"}
             ],
              "rhsp": [
-              {"type":"ARRAYSEL","name":"","addr":"(BW)","loc":"d,72:20,72:24","dtypep":"(AC)",
+              {"type":"ARRAYSEL","name":"","addr":"(DW)","loc":"d,72:20,72:24","dtypep":"(AC)",
                "fromp": [
-                {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(CW)","loc":"d,17:12,17:16","dtypep":"(CJ)","access":"RD","varp":"(DJ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(EW)","loc":"d,17:12,17:16","dtypep":"(CJ)","access":"RD","varp":"(DJ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
               ],
                "bitp": [
-                {"type":"AND","name":"","addr":"(DW)","loc":"d,72:20,72:24","dtypep":"(LC)",
+                {"type":"AND","name":"","addr":"(FW)","loc":"d,72:20,72:24","dtypep":"(LC)",
                  "lhsp": [
-                  {"type":"CONST","name":"32'h7","addr":"(EW)","loc":"d,72:20,72:24","dtypep":"(NC)"}
+                  {"type":"CONST","name":"32'h7","addr":"(GW)","loc":"d,72:20,72:24","dtypep":"(NC)"}
                 ],
                  "rhsp": [
-                  {"type":"CCAST","name":"","addr":"(FW)","loc":"d,72:18,72:19","dtypep":"(LC)","size":32,
+                  {"type":"CCAST","name":"","addr":"(HW)","loc":"d,72:18,72:19","dtypep":"(LC)","size":32,
                    "lhsp": [
-                    {"type":"VARREF","name":"t.e","addr":"(GW)","loc":"d,72:18,72:19","dtypep":"(LC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"t.e","addr":"(IW)","loc":"d,72:18,72:19","dtypep":"(LC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ]}
                 ]}
               ]}
             ]}
           ],
            "thensp": [
-            {"type":"DISPLAY","name":"","addr":"(HW)","loc":"d,72:43,72:49",
+            {"type":"DISPLAY","name":"","addr":"(JW)","loc":"d,72:43,72:49",
              "fmtp": [
-              {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:72:  got='h%x exp='h4\\n","addr":"(IW)","loc":"d,72:43,72:49","dtypep":"(RB)",
+              {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:72:  got='h%x exp='h4\\n","addr":"(KW)","loc":"d,72:43,72:49","dtypep":"(RB)",
                "exprsp": [
-                {"type":"ARRAYSEL","name":"","addr":"(JW)","loc":"d,72:124,72:128","dtypep":"(AC)",
+                {"type":"ARRAYSEL","name":"","addr":"(LW)","loc":"d,72:124,72:128","dtypep":"(AC)",
                  "fromp": [
-                  {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(KW)","loc":"d,17:12,17:16","dtypep":"(CJ)","access":"RD","varp":"(DJ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(MW)","loc":"d,17:12,17:16","dtypep":"(CJ)","access":"RD","varp":"(DJ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                 ],
                  "bitp": [
-                  {"type":"AND","name":"","addr":"(LW)","loc":"d,72:124,72:128","dtypep":"(LC)",
+                  {"type":"AND","name":"","addr":"(NW)","loc":"d,72:124,72:128","dtypep":"(LC)",
                    "lhsp": [
-                    {"type":"CONST","name":"32'h7","addr":"(MW)","loc":"d,72:124,72:128","dtypep":"(NC)"}
+                    {"type":"CONST","name":"32'h7","addr":"(OW)","loc":"d,72:124,72:128","dtypep":"(NC)"}
                   ],
                    "rhsp": [
-                    {"type":"CCAST","name":"","addr":"(NW)","loc":"d,72:122,72:123","dtypep":"(LC)","size":32,
+                    {"type":"CCAST","name":"","addr":"(PW)","loc":"d,72:122,72:123","dtypep":"(LC)","size":32,
                      "lhsp": [
-                      {"type":"VARREF","name":"t.e","addr":"(OW)","loc":"d,72:122,72:123","dtypep":"(LC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"t.e","addr":"(QW)","loc":"d,72:122,72:123","dtypep":"(LC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ]}
                   ]}
                 ]}
               ],"scopeNamep": []}
             ],"filep": []},
-            {"type":"STOP","name":"","addr":"(PW)","loc":"d,72:139,72:144"}
+            {"type":"STOP","name":"","addr":"(RW)","loc":"d,72:139,72:144"}
           ],"elsesp": []},
-          {"type":"IF","name":"","addr":"(QW)","loc":"d,73:13,73:15",
+          {"type":"IF","name":"","addr":"(SW)","loc":"d,73:13,73:15",
            "condp": [
-            {"type":"NEQ","name":"","addr":"(RW)","loc":"d,73:29,73:32","dtypep":"(NB)",
+            {"type":"NEQ","name":"","addr":"(TW)","loc":"d,73:29,73:32","dtypep":"(NB)",
              "lhsp": [
-              {"type":"CONST","name":"4'h4","addr":"(SW)","loc":"d,73:34,73:37","dtypep":"(AC)"}
+              {"type":"CONST","name":"4'h4","addr":"(UW)","loc":"d,73:34,73:37","dtypep":"(AC)"}
             ],
              "rhsp": [
-              {"type":"ARRAYSEL","name":"","addr":"(TW)","loc":"d,73:20,73:24","dtypep":"(AC)",
+              {"type":"ARRAYSEL","name":"","addr":"(VW)","loc":"d,73:20,73:24","dtypep":"(AC)",
                "fromp": [
-                {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(UW)","loc":"d,17:12,17:16","dtypep":"(CJ)","access":"RD","varp":"(DJ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(WW)","loc":"d,17:12,17:16","dtypep":"(CJ)","access":"RD","varp":"(DJ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
               ],
                "bitp": [
-                {"type":"AND","name":"","addr":"(VW)","loc":"d,73:20,73:24","dtypep":"(LC)",
+                {"type":"AND","name":"","addr":"(XW)","loc":"d,73:20,73:24","dtypep":"(LC)",
                  "lhsp": [
-                  {"type":"CONST","name":"32'h7","addr":"(WW)","loc":"d,73:20,73:24","dtypep":"(NC)"}
+                  {"type":"CONST","name":"32'h7","addr":"(YW)","loc":"d,73:20,73:24","dtypep":"(NC)"}
                 ],
                  "rhsp": [
-                  {"type":"CCAST","name":"","addr":"(XW)","loc":"d,73:18,73:19","dtypep":"(LC)","size":32,
+                  {"type":"CCAST","name":"","addr":"(ZW)","loc":"d,73:18,73:19","dtypep":"(LC)","size":32,
                    "lhsp": [
-                    {"type":"VARREF","name":"t.e","addr":"(YW)","loc":"d,73:18,73:19","dtypep":"(LC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"t.e","addr":"(AX)","loc":"d,73:18,73:19","dtypep":"(LC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ]}
                 ]}
               ]}
             ]}
           ],
            "thensp": [
-            {"type":"DISPLAY","name":"","addr":"(ZW)","loc":"d,73:46,73:52",
+            {"type":"DISPLAY","name":"","addr":"(BX)","loc":"d,73:46,73:52",
              "fmtp": [
-              {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:73:  got='h%x exp='h4\\n","addr":"(AX)","loc":"d,73:46,73:52","dtypep":"(RB)",
+              {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:73:  got='h%x exp='h4\\n","addr":"(CX)","loc":"d,73:46,73:52","dtypep":"(RB)",
                "exprsp": [
-                {"type":"ARRAYSEL","name":"","addr":"(BX)","loc":"d,73:127,73:131","dtypep":"(AC)",
+                {"type":"ARRAYSEL","name":"","addr":"(DX)","loc":"d,73:127,73:131","dtypep":"(AC)",
                  "fromp": [
-                  {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(CX)","loc":"d,17:12,17:16","dtypep":"(CJ)","access":"RD","varp":"(DJ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(EX)","loc":"d,17:12,17:16","dtypep":"(CJ)","access":"RD","varp":"(DJ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                 ],
                  "bitp": [
-                  {"type":"AND","name":"","addr":"(DX)","loc":"d,73:127,73:131","dtypep":"(LC)",
+                  {"type":"AND","name":"","addr":"(FX)","loc":"d,73:127,73:131","dtypep":"(LC)",
                    "lhsp": [
-                    {"type":"CONST","name":"32'h7","addr":"(EX)","loc":"d,73:127,73:131","dtypep":"(NC)"}
+                    {"type":"CONST","name":"32'h7","addr":"(GX)","loc":"d,73:127,73:131","dtypep":"(NC)"}
                   ],
                    "rhsp": [
-                    {"type":"CCAST","name":"","addr":"(FX)","loc":"d,73:125,73:126","dtypep":"(LC)","size":32,
+                    {"type":"CCAST","name":"","addr":"(HX)","loc":"d,73:125,73:126","dtypep":"(LC)","size":32,
                      "lhsp": [
-                      {"type":"VARREF","name":"t.e","addr":"(GX)","loc":"d,73:125,73:126","dtypep":"(LC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"t.e","addr":"(IX)","loc":"d,73:125,73:126","dtypep":"(LC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ]}
                   ]}
                 ]}
               ],"scopeNamep": []}
             ],"filep": []},
-            {"type":"STOP","name":"","addr":"(HX)","loc":"d,73:145,73:150"}
+            {"type":"STOP","name":"","addr":"(JX)","loc":"d,73:145,73:150"}
           ],"elsesp": []},
-          {"type":"IF","name":"","addr":"(IX)","loc":"d,74:13,74:15",
+          {"type":"IF","name":"","addr":"(KX)","loc":"d,74:13,74:15",
            "condp": [
-            {"type":"NEQ","name":"","addr":"(JX)","loc":"d,74:29,74:32","dtypep":"(NB)",
+            {"type":"NEQ","name":"","addr":"(LX)","loc":"d,74:29,74:32","dtypep":"(NB)",
              "lhsp": [
-              {"type":"CONST","name":"4'h3","addr":"(KX)","loc":"d,74:34,74:37","dtypep":"(AC)"}
+              {"type":"CONST","name":"4'h3","addr":"(MX)","loc":"d,74:34,74:37","dtypep":"(AC)"}
             ],
              "rhsp": [
-              {"type":"ARRAYSEL","name":"","addr":"(LX)","loc":"d,74:20,74:24","dtypep":"(AC)",
+              {"type":"ARRAYSEL","name":"","addr":"(NX)","loc":"d,74:20,74:24","dtypep":"(AC)",
                "fromp": [
-                {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(MX)","loc":"d,17:12,17:16","dtypep":"(CJ)","access":"RD","varp":"(DJ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(OX)","loc":"d,17:12,17:16","dtypep":"(CJ)","access":"RD","varp":"(DJ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
               ],
                "bitp": [
-                {"type":"AND","name":"","addr":"(NX)","loc":"d,74:20,74:24","dtypep":"(LC)",
+                {"type":"AND","name":"","addr":"(PX)","loc":"d,74:20,74:24","dtypep":"(LC)",
                  "lhsp": [
-                  {"type":"CONST","name":"32'h7","addr":"(OX)","loc":"d,74:20,74:24","dtypep":"(NC)"}
+                  {"type":"CONST","name":"32'h7","addr":"(QX)","loc":"d,74:20,74:24","dtypep":"(NC)"}
                 ],
                  "rhsp": [
-                  {"type":"ARRAYSEL","name":"","addr":"(PX)","loc":"d,74:20,74:24","dtypep":"(LC)",
+                  {"type":"ARRAYSEL","name":"","addr":"(RX)","loc":"d,74:20,74:24","dtypep":"(LC)",
                    "fromp": [
-                    {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(QX)","loc":"d,17:12,17:16","dtypep":"(CJ)","access":"RD","varp":"(DJ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(SX)","loc":"d,17:12,17:16","dtypep":"(CJ)","access":"RD","varp":"(DJ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ],
                    "bitp": [
-                    {"type":"AND","name":"","addr":"(RX)","loc":"d,74:20,74:24","dtypep":"(LC)",
+                    {"type":"AND","name":"","addr":"(TX)","loc":"d,74:20,74:24","dtypep":"(LC)",
                      "lhsp": [
-                      {"type":"CONST","name":"32'h7","addr":"(SX)","loc":"d,74:20,74:24","dtypep":"(NC)"}
+                      {"type":"CONST","name":"32'h7","addr":"(UX)","loc":"d,74:20,74:24","dtypep":"(NC)"}
                     ],
                      "rhsp": [
-                      {"type":"CCAST","name":"","addr":"(TX)","loc":"d,74:18,74:19","dtypep":"(LC)","size":32,
+                      {"type":"CCAST","name":"","addr":"(VX)","loc":"d,74:18,74:19","dtypep":"(LC)","size":32,
                        "lhsp": [
-                        {"type":"VARREF","name":"t.e","addr":"(UX)","loc":"d,74:18,74:19","dtypep":"(LC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                        {"type":"VARREF","name":"t.e","addr":"(WX)","loc":"d,74:18,74:19","dtypep":"(LC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                       ]}
                     ]}
                   ]}
@@ -1594,33 +1600,33 @@
             ]}
           ],
            "thensp": [
-            {"type":"DISPLAY","name":"","addr":"(VX)","loc":"d,74:46,74:52",
+            {"type":"DISPLAY","name":"","addr":"(XX)","loc":"d,74:46,74:52",
              "fmtp": [
-              {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:74:  got='h%x exp='h3\\n","addr":"(WX)","loc":"d,74:46,74:52","dtypep":"(RB)",
+              {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:74:  got='h%x exp='h3\\n","addr":"(YX)","loc":"d,74:46,74:52","dtypep":"(RB)",
                "exprsp": [
-                {"type":"ARRAYSEL","name":"","addr":"(XX)","loc":"d,74:127,74:131","dtypep":"(AC)",
+                {"type":"ARRAYSEL","name":"","addr":"(ZX)","loc":"d,74:127,74:131","dtypep":"(AC)",
                  "fromp": [
-                  {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(YX)","loc":"d,17:12,17:16","dtypep":"(CJ)","access":"RD","varp":"(DJ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(AY)","loc":"d,17:12,17:16","dtypep":"(CJ)","access":"RD","varp":"(DJ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                 ],
                  "bitp": [
-                  {"type":"AND","name":"","addr":"(ZX)","loc":"d,74:127,74:131","dtypep":"(LC)",
+                  {"type":"AND","name":"","addr":"(BY)","loc":"d,74:127,74:131","dtypep":"(LC)",
                    "lhsp": [
-                    {"type":"CONST","name":"32'h7","addr":"(AY)","loc":"d,74:127,74:131","dtypep":"(NC)"}
+                    {"type":"CONST","name":"32'h7","addr":"(CY)","loc":"d,74:127,74:131","dtypep":"(NC)"}
                   ],
                    "rhsp": [
-                    {"type":"ARRAYSEL","name":"","addr":"(BY)","loc":"d,74:127,74:131","dtypep":"(LC)",
+                    {"type":"ARRAYSEL","name":"","addr":"(DY)","loc":"d,74:127,74:131","dtypep":"(LC)",
                      "fromp": [
-                      {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(CY)","loc":"d,17:12,17:16","dtypep":"(CJ)","access":"RD","varp":"(DJ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(EY)","loc":"d,17:12,17:16","dtypep":"(CJ)","access":"RD","varp":"(DJ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ],
                      "bitp": [
-                      {"type":"AND","name":"","addr":"(DY)","loc":"d,74:127,74:131","dtypep":"(LC)",
+                      {"type":"AND","name":"","addr":"(FY)","loc":"d,74:127,74:131","dtypep":"(LC)",
                        "lhsp": [
-                        {"type":"CONST","name":"32'h7","addr":"(EY)","loc":"d,74:127,74:131","dtypep":"(NC)"}
+                        {"type":"CONST","name":"32'h7","addr":"(GY)","loc":"d,74:127,74:131","dtypep":"(NC)"}
                       ],
                        "rhsp": [
-                        {"type":"CCAST","name":"","addr":"(FY)","loc":"d,74:125,74:126","dtypep":"(LC)","size":32,
+                        {"type":"CCAST","name":"","addr":"(HY)","loc":"d,74:125,74:126","dtypep":"(LC)","size":32,
                          "lhsp": [
-                          {"type":"VARREF","name":"t.e","addr":"(GY)","loc":"d,74:125,74:126","dtypep":"(LC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                          {"type":"VARREF","name":"t.e","addr":"(IY)","loc":"d,74:125,74:126","dtypep":"(LC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                         ]}
                       ]}
                     ]}
@@ -1628,215 +1634,215 @@
                 ]}
               ],"scopeNamep": []}
             ],"filep": []},
-            {"type":"STOP","name":"","addr":"(HY)","loc":"d,74:145,74:150"}
+            {"type":"STOP","name":"","addr":"(JY)","loc":"d,74:145,74:150"}
           ],"elsesp": []},
-          {"type":"ASSIGNDLY","name":"","addr":"(IY)","loc":"d,75:12,75:14","dtypep":"(AC)",
+          {"type":"ASSIGNDLY","name":"","addr":"(KY)","loc":"d,75:12,75:14","dtypep":"(AC)",
            "rhsp": [
-            {"type":"CONST","name":"4'h3","addr":"(JY)","loc":"d,75:15,75:18","dtypep":"(AC)"}
+            {"type":"CONST","name":"4'h3","addr":"(LY)","loc":"d,75:15,75:18","dtypep":"(AC)"}
           ],
            "lhsp": [
-            {"type":"VARREF","name":"__Vdly__t.e","addr":"(KY)","loc":"d,75:10,75:11","dtypep":"(AC)","access":"WR","varp":"(QR)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"__Vdly__t.e","addr":"(MY)","loc":"d,75:10,75:11","dtypep":"(AC)","access":"WR","varp":"(SR)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ],"timingControlp": []}
         ],
          "elsesp": [
-          {"type":"IF","name":"","addr":"(LY)","loc":"d,77:12,77:14",
+          {"type":"IF","name":"","addr":"(NY)","loc":"d,77:12,77:14",
            "condp": [
-            {"type":"EQ","name":"","addr":"(MY)","loc":"d,77:19,77:21","dtypep":"(NB)",
+            {"type":"EQ","name":"","addr":"(OY)","loc":"d,77:19,77:21","dtypep":"(NB)",
              "lhsp": [
-              {"type":"CONST","name":"32'sh2","addr":"(NY)","loc":"d,77:21,77:22","dtypep":"(GB)"}
+              {"type":"CONST","name":"32'sh2","addr":"(PY)","loc":"d,77:21,77:22","dtypep":"(GB)"}
             ],
              "rhsp": [
-              {"type":"VARREF","name":"t.cyc","addr":"(OY)","loc":"d,77:16,77:19","dtypep":"(R)","access":"RD","varp":"(Q)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+              {"type":"VARREF","name":"t.cyc","addr":"(QY)","loc":"d,77:16,77:19","dtypep":"(R)","access":"RD","varp":"(Q)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
             ]}
           ],
            "thensp": [
-            {"type":"IF","name":"","addr":"(PY)","loc":"d,78:13,78:15",
+            {"type":"IF","name":"","addr":"(RY)","loc":"d,78:13,78:15",
              "condp": [
-              {"type":"NEQN","name":"","addr":"(QY)","loc":"d,78:26,78:29","dtypep":"(NB)",
+              {"type":"NEQN","name":"","addr":"(SY)","loc":"d,78:26,78:29","dtypep":"(NB)",
                "lhsp": [
-                {"type":"CONST","name":"\\\"E03\\\"","addr":"(RY)","loc":"d,78:31,78:36","dtypep":"(RB)"}
+                {"type":"CONST","name":"\\\"E03\\\"","addr":"(TY)","loc":"d,78:31,78:36","dtypep":"(RB)"}
               ],
                "rhsp": [
-                {"type":"ARRAYSEL","name":"","addr":"(SY)","loc":"d,78:20,78:24","dtypep":"(RB)",
+                {"type":"ARRAYSEL","name":"","addr":"(UY)","loc":"d,78:20,78:24","dtypep":"(RB)",
                  "fromp": [
-                  {"type":"VARREF","name":"__Venumtab_enum_name2","addr":"(TY)","loc":"d,17:12,17:16","dtypep":"(OM)","access":"RD","varp":"(PM)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"__Venumtab_enum_name2","addr":"(VY)","loc":"d,17:12,17:16","dtypep":"(OM)","access":"RD","varp":"(PM)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                 ],
                  "bitp": [
-                  {"type":"AND","name":"","addr":"(UY)","loc":"d,78:20,78:24","dtypep":"(LC)",
+                  {"type":"AND","name":"","addr":"(WY)","loc":"d,78:20,78:24","dtypep":"(LC)",
                    "lhsp": [
-                    {"type":"CONST","name":"32'h7","addr":"(VY)","loc":"d,78:20,78:24","dtypep":"(NC)"}
+                    {"type":"CONST","name":"32'h7","addr":"(XY)","loc":"d,78:20,78:24","dtypep":"(NC)"}
                   ],
                    "rhsp": [
-                    {"type":"CCAST","name":"","addr":"(WY)","loc":"d,78:18,78:19","dtypep":"(LC)","size":32,
+                    {"type":"CCAST","name":"","addr":"(YY)","loc":"d,78:18,78:19","dtypep":"(LC)","size":32,
                      "lhsp": [
-                      {"type":"VARREF","name":"t.e","addr":"(XY)","loc":"d,78:18,78:19","dtypep":"(LC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"t.e","addr":"(ZY)","loc":"d,78:18,78:19","dtypep":"(LC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ]}
                   ]}
                 ]}
               ]}
             ],
              "thensp": [
-              {"type":"ASSIGN","name":"","addr":"(YY)","loc":"d,78:126,78:130","dtypep":"(RB)",
+              {"type":"ASSIGN","name":"","addr":"(AZ)","loc":"d,78:126,78:130","dtypep":"(RB)",
                "rhsp": [
-                {"type":"ARRAYSEL","name":"","addr":"(ZY)","loc":"d,78:126,78:130","dtypep":"(RB)",
+                {"type":"ARRAYSEL","name":"","addr":"(BZ)","loc":"d,78:126,78:130","dtypep":"(RB)",
                  "fromp": [
-                  {"type":"VARREF","name":"__Venumtab_enum_name2","addr":"(AZ)","loc":"d,17:12,17:16","dtypep":"(OM)","access":"RD","varp":"(PM)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"__Venumtab_enum_name2","addr":"(CZ)","loc":"d,17:12,17:16","dtypep":"(OM)","access":"RD","varp":"(PM)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                 ],
                  "bitp": [
-                  {"type":"AND","name":"","addr":"(BZ)","loc":"d,78:126,78:130","dtypep":"(LC)",
+                  {"type":"AND","name":"","addr":"(DZ)","loc":"d,78:126,78:130","dtypep":"(LC)",
                    "lhsp": [
-                    {"type":"CONST","name":"32'h7","addr":"(CZ)","loc":"d,78:126,78:130","dtypep":"(NC)"}
+                    {"type":"CONST","name":"32'h7","addr":"(EZ)","loc":"d,78:126,78:130","dtypep":"(NC)"}
                   ],
                    "rhsp": [
-                    {"type":"CCAST","name":"","addr":"(DZ)","loc":"d,78:124,78:125","dtypep":"(LC)","size":32,
+                    {"type":"CCAST","name":"","addr":"(FZ)","loc":"d,78:124,78:125","dtypep":"(LC)","size":32,
                      "lhsp": [
-                      {"type":"VARREF","name":"t.e","addr":"(EZ)","loc":"d,78:124,78:125","dtypep":"(LC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"t.e","addr":"(GZ)","loc":"d,78:124,78:125","dtypep":"(LC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ]}
                   ]}
                 ]}
               ],
                "lhsp": [
-                {"type":"VARREF","name":"__Vtemp_2","addr":"(FZ)","loc":"d,78:126,78:130","dtypep":"(RB)","access":"WR","varp":"(UR)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                {"type":"VARREF","name":"__Vtemp_2","addr":"(HZ)","loc":"d,78:126,78:130","dtypep":"(RB)","access":"WR","varp":"(WR)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
               ],"timingControlp": []},
-              {"type":"DISPLAY","name":"","addr":"(GZ)","loc":"d,78:45,78:51",
+              {"type":"DISPLAY","name":"","addr":"(IZ)","loc":"d,78:45,78:51",
                "fmtp": [
-                {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:78:  got='%@' exp='E03'\\n","addr":"(HZ)","loc":"d,78:45,78:51","dtypep":"(RB)",
+                {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:78:  got='%@' exp='E03'\\n","addr":"(JZ)","loc":"d,78:45,78:51","dtypep":"(RB)",
                  "exprsp": [
-                  {"type":"VARREF","name":"__Vtemp_2","addr":"(IZ)","loc":"d,78:126,78:130","dtypep":"(RB)","access":"RD","varp":"(UR)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"__Vtemp_2","addr":"(KZ)","loc":"d,78:126,78:130","dtypep":"(RB)","access":"RD","varp":"(WR)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                 ],"scopeNamep": []}
               ],"filep": []},
-              {"type":"STOP","name":"","addr":"(JZ)","loc":"d,78:143,78:148"}
+              {"type":"STOP","name":"","addr":"(LZ)","loc":"d,78:143,78:148"}
             ],"elsesp": []},
-            {"type":"IF","name":"","addr":"(KZ)","loc":"d,79:13,79:15",
+            {"type":"IF","name":"","addr":"(MZ)","loc":"d,79:13,79:15",
              "condp": [
-              {"type":"NEQ","name":"","addr":"(LZ)","loc":"d,79:26,79:29","dtypep":"(NB)",
+              {"type":"NEQ","name":"","addr":"(NZ)","loc":"d,79:26,79:29","dtypep":"(NB)",
                "lhsp": [
-                {"type":"CONST","name":"4'h4","addr":"(MZ)","loc":"d,79:31,79:34","dtypep":"(AC)"}
+                {"type":"CONST","name":"4'h4","addr":"(OZ)","loc":"d,79:31,79:34","dtypep":"(AC)"}
               ],
                "rhsp": [
-                {"type":"ARRAYSEL","name":"","addr":"(NZ)","loc":"d,79:20,79:24","dtypep":"(AC)",
+                {"type":"ARRAYSEL","name":"","addr":"(PZ)","loc":"d,79:20,79:24","dtypep":"(AC)",
                  "fromp": [
-                  {"type":"VARREF","name":"__Venumtab_enum_next0","addr":"(OZ)","loc":"d,17:12,17:16","dtypep":"(IC)","access":"RD","varp":"(JC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"__Venumtab_enum_next0","addr":"(QZ)","loc":"d,17:12,17:16","dtypep":"(IC)","access":"RD","varp":"(JC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                 ],
                  "bitp": [
-                  {"type":"AND","name":"","addr":"(PZ)","loc":"d,79:20,79:24","dtypep":"(LC)",
+                  {"type":"AND","name":"","addr":"(RZ)","loc":"d,79:20,79:24","dtypep":"(LC)",
                    "lhsp": [
-                    {"type":"CONST","name":"32'h7","addr":"(QZ)","loc":"d,79:20,79:24","dtypep":"(NC)"}
+                    {"type":"CONST","name":"32'h7","addr":"(SZ)","loc":"d,79:20,79:24","dtypep":"(NC)"}
                   ],
                    "rhsp": [
-                    {"type":"CCAST","name":"","addr":"(RZ)","loc":"d,79:18,79:19","dtypep":"(LC)","size":32,
+                    {"type":"CCAST","name":"","addr":"(TZ)","loc":"d,79:18,79:19","dtypep":"(LC)","size":32,
                      "lhsp": [
-                      {"type":"VARREF","name":"t.e","addr":"(SZ)","loc":"d,79:18,79:19","dtypep":"(LC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"t.e","addr":"(UZ)","loc":"d,79:18,79:19","dtypep":"(LC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ]}
                   ]}
                 ]}
               ]}
             ],
              "thensp": [
-              {"type":"DISPLAY","name":"","addr":"(TZ)","loc":"d,79:43,79:49",
+              {"type":"DISPLAY","name":"","addr":"(VZ)","loc":"d,79:43,79:49",
                "fmtp": [
-                {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:79:  got='h%x exp='h4\\n","addr":"(UZ)","loc":"d,79:43,79:49","dtypep":"(RB)",
+                {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:79:  got='h%x exp='h4\\n","addr":"(WZ)","loc":"d,79:43,79:49","dtypep":"(RB)",
                  "exprsp": [
-                  {"type":"ARRAYSEL","name":"","addr":"(VZ)","loc":"d,79:124,79:128","dtypep":"(AC)",
+                  {"type":"ARRAYSEL","name":"","addr":"(XZ)","loc":"d,79:124,79:128","dtypep":"(AC)",
                    "fromp": [
-                    {"type":"VARREF","name":"__Venumtab_enum_next0","addr":"(WZ)","loc":"d,17:12,17:16","dtypep":"(IC)","access":"RD","varp":"(JC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"__Venumtab_enum_next0","addr":"(YZ)","loc":"d,17:12,17:16","dtypep":"(IC)","access":"RD","varp":"(JC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ],
                    "bitp": [
-                    {"type":"AND","name":"","addr":"(XZ)","loc":"d,79:124,79:128","dtypep":"(LC)",
+                    {"type":"AND","name":"","addr":"(ZZ)","loc":"d,79:124,79:128","dtypep":"(LC)",
                      "lhsp": [
-                      {"type":"CONST","name":"32'h7","addr":"(YZ)","loc":"d,79:124,79:128","dtypep":"(NC)"}
+                      {"type":"CONST","name":"32'h7","addr":"(AAB)","loc":"d,79:124,79:128","dtypep":"(NC)"}
                     ],
                      "rhsp": [
-                      {"type":"CCAST","name":"","addr":"(ZZ)","loc":"d,79:122,79:123","dtypep":"(LC)","size":32,
+                      {"type":"CCAST","name":"","addr":"(BAB)","loc":"d,79:122,79:123","dtypep":"(LC)","size":32,
                        "lhsp": [
-                        {"type":"VARREF","name":"t.e","addr":"(AAB)","loc":"d,79:122,79:123","dtypep":"(LC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                        {"type":"VARREF","name":"t.e","addr":"(CAB)","loc":"d,79:122,79:123","dtypep":"(LC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                       ]}
                     ]}
                   ]}
                 ],"scopeNamep": []}
               ],"filep": []},
-              {"type":"STOP","name":"","addr":"(BAB)","loc":"d,79:139,79:144"}
+              {"type":"STOP","name":"","addr":"(DAB)","loc":"d,79:139,79:144"}
             ],"elsesp": []},
-            {"type":"IF","name":"","addr":"(CAB)","loc":"d,80:13,80:15",
+            {"type":"IF","name":"","addr":"(EAB)","loc":"d,80:13,80:15",
              "condp": [
-              {"type":"NEQ","name":"","addr":"(DAB)","loc":"d,80:29,80:32","dtypep":"(NB)",
+              {"type":"NEQ","name":"","addr":"(FAB)","loc":"d,80:29,80:32","dtypep":"(NB)",
                "lhsp": [
-                {"type":"CONST","name":"4'h4","addr":"(EAB)","loc":"d,80:34,80:37","dtypep":"(AC)"}
+                {"type":"CONST","name":"4'h4","addr":"(GAB)","loc":"d,80:34,80:37","dtypep":"(AC)"}
               ],
                "rhsp": [
-                {"type":"ARRAYSEL","name":"","addr":"(FAB)","loc":"d,80:20,80:24","dtypep":"(AC)",
+                {"type":"ARRAYSEL","name":"","addr":"(HAB)","loc":"d,80:20,80:24","dtypep":"(AC)",
                  "fromp": [
-                  {"type":"VARREF","name":"__Venumtab_enum_next0","addr":"(GAB)","loc":"d,17:12,17:16","dtypep":"(IC)","access":"RD","varp":"(JC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"__Venumtab_enum_next0","addr":"(IAB)","loc":"d,17:12,17:16","dtypep":"(IC)","access":"RD","varp":"(JC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                 ],
                  "bitp": [
-                  {"type":"AND","name":"","addr":"(HAB)","loc":"d,80:20,80:24","dtypep":"(LC)",
+                  {"type":"AND","name":"","addr":"(JAB)","loc":"d,80:20,80:24","dtypep":"(LC)",
                    "lhsp": [
-                    {"type":"CONST","name":"32'h7","addr":"(IAB)","loc":"d,80:20,80:24","dtypep":"(NC)"}
+                    {"type":"CONST","name":"32'h7","addr":"(KAB)","loc":"d,80:20,80:24","dtypep":"(NC)"}
                   ],
                    "rhsp": [
-                    {"type":"CCAST","name":"","addr":"(JAB)","loc":"d,80:18,80:19","dtypep":"(LC)","size":32,
+                    {"type":"CCAST","name":"","addr":"(LAB)","loc":"d,80:18,80:19","dtypep":"(LC)","size":32,
                      "lhsp": [
-                      {"type":"VARREF","name":"t.e","addr":"(KAB)","loc":"d,80:18,80:19","dtypep":"(LC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"t.e","addr":"(MAB)","loc":"d,80:18,80:19","dtypep":"(LC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ]}
                   ]}
                 ]}
               ]}
             ],
              "thensp": [
-              {"type":"DISPLAY","name":"","addr":"(LAB)","loc":"d,80:46,80:52",
+              {"type":"DISPLAY","name":"","addr":"(NAB)","loc":"d,80:46,80:52",
                "fmtp": [
-                {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:80:  got='h%x exp='h4\\n","addr":"(MAB)","loc":"d,80:46,80:52","dtypep":"(RB)",
+                {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:80:  got='h%x exp='h4\\n","addr":"(OAB)","loc":"d,80:46,80:52","dtypep":"(RB)",
                  "exprsp": [
-                  {"type":"ARRAYSEL","name":"","addr":"(NAB)","loc":"d,80:127,80:131","dtypep":"(AC)",
+                  {"type":"ARRAYSEL","name":"","addr":"(PAB)","loc":"d,80:127,80:131","dtypep":"(AC)",
                    "fromp": [
-                    {"type":"VARREF","name":"__Venumtab_enum_next0","addr":"(OAB)","loc":"d,17:12,17:16","dtypep":"(IC)","access":"RD","varp":"(JC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"__Venumtab_enum_next0","addr":"(QAB)","loc":"d,17:12,17:16","dtypep":"(IC)","access":"RD","varp":"(JC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ],
                    "bitp": [
-                    {"type":"AND","name":"","addr":"(PAB)","loc":"d,80:127,80:131","dtypep":"(LC)",
+                    {"type":"AND","name":"","addr":"(RAB)","loc":"d,80:127,80:131","dtypep":"(LC)",
                      "lhsp": [
-                      {"type":"CONST","name":"32'h7","addr":"(QAB)","loc":"d,80:127,80:131","dtypep":"(NC)"}
+                      {"type":"CONST","name":"32'h7","addr":"(SAB)","loc":"d,80:127,80:131","dtypep":"(NC)"}
                     ],
                      "rhsp": [
-                      {"type":"CCAST","name":"","addr":"(RAB)","loc":"d,80:125,80:126","dtypep":"(LC)","size":32,
+                      {"type":"CCAST","name":"","addr":"(TAB)","loc":"d,80:125,80:126","dtypep":"(LC)","size":32,
                        "lhsp": [
-                        {"type":"VARREF","name":"t.e","addr":"(SAB)","loc":"d,80:125,80:126","dtypep":"(LC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                        {"type":"VARREF","name":"t.e","addr":"(UAB)","loc":"d,80:125,80:126","dtypep":"(LC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                       ]}
                     ]}
                   ]}
                 ],"scopeNamep": []}
               ],"filep": []},
-              {"type":"STOP","name":"","addr":"(TAB)","loc":"d,80:145,80:150"}
+              {"type":"STOP","name":"","addr":"(VAB)","loc":"d,80:145,80:150"}
             ],"elsesp": []},
-            {"type":"IF","name":"","addr":"(UAB)","loc":"d,81:13,81:15",
+            {"type":"IF","name":"","addr":"(WAB)","loc":"d,81:13,81:15",
              "condp": [
-              {"type":"NEQ","name":"","addr":"(VAB)","loc":"d,81:29,81:32","dtypep":"(NB)",
+              {"type":"NEQ","name":"","addr":"(XAB)","loc":"d,81:29,81:32","dtypep":"(NB)",
                "lhsp": [
-                {"type":"CONST","name":"4'h1","addr":"(WAB)","loc":"d,81:34,81:37","dtypep":"(AC)"}
+                {"type":"CONST","name":"4'h1","addr":"(YAB)","loc":"d,81:34,81:37","dtypep":"(AC)"}
               ],
                "rhsp": [
-                {"type":"ARRAYSEL","name":"","addr":"(XAB)","loc":"d,81:20,81:24","dtypep":"(AC)",
+                {"type":"ARRAYSEL","name":"","addr":"(ZAB)","loc":"d,81:20,81:24","dtypep":"(AC)",
                  "fromp": [
-                  {"type":"VARREF","name":"__Venumtab_enum_next0","addr":"(YAB)","loc":"d,17:12,17:16","dtypep":"(IC)","access":"RD","varp":"(JC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"__Venumtab_enum_next0","addr":"(ABB)","loc":"d,17:12,17:16","dtypep":"(IC)","access":"RD","varp":"(JC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                 ],
                  "bitp": [
-                  {"type":"AND","name":"","addr":"(ZAB)","loc":"d,81:20,81:24","dtypep":"(LC)",
+                  {"type":"AND","name":"","addr":"(BBB)","loc":"d,81:20,81:24","dtypep":"(LC)",
                    "lhsp": [
-                    {"type":"CONST","name":"32'h7","addr":"(ABB)","loc":"d,81:20,81:24","dtypep":"(NC)"}
+                    {"type":"CONST","name":"32'h7","addr":"(CBB)","loc":"d,81:20,81:24","dtypep":"(NC)"}
                   ],
                    "rhsp": [
-                    {"type":"ARRAYSEL","name":"","addr":"(BBB)","loc":"d,81:20,81:24","dtypep":"(LC)",
+                    {"type":"ARRAYSEL","name":"","addr":"(DBB)","loc":"d,81:20,81:24","dtypep":"(LC)",
                      "fromp": [
-                      {"type":"VARREF","name":"__Venumtab_enum_next0","addr":"(CBB)","loc":"d,17:12,17:16","dtypep":"(IC)","access":"RD","varp":"(JC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"__Venumtab_enum_next0","addr":"(EBB)","loc":"d,17:12,17:16","dtypep":"(IC)","access":"RD","varp":"(JC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ],
                      "bitp": [
-                      {"type":"AND","name":"","addr":"(DBB)","loc":"d,81:20,81:24","dtypep":"(LC)",
+                      {"type":"AND","name":"","addr":"(FBB)","loc":"d,81:20,81:24","dtypep":"(LC)",
                        "lhsp": [
-                        {"type":"CONST","name":"32'h7","addr":"(EBB)","loc":"d,81:20,81:24","dtypep":"(NC)"}
+                        {"type":"CONST","name":"32'h7","addr":"(GBB)","loc":"d,81:20,81:24","dtypep":"(NC)"}
                       ],
                        "rhsp": [
-                        {"type":"CCAST","name":"","addr":"(FBB)","loc":"d,81:18,81:19","dtypep":"(LC)","size":32,
+                        {"type":"CCAST","name":"","addr":"(HBB)","loc":"d,81:18,81:19","dtypep":"(LC)","size":32,
                          "lhsp": [
-                          {"type":"VARREF","name":"t.e","addr":"(GBB)","loc":"d,81:18,81:19","dtypep":"(LC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                          {"type":"VARREF","name":"t.e","addr":"(IBB)","loc":"d,81:18,81:19","dtypep":"(LC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                         ]}
                       ]}
                     ]}
@@ -1845,33 +1851,33 @@
               ]}
             ],
              "thensp": [
-              {"type":"DISPLAY","name":"","addr":"(HBB)","loc":"d,81:46,81:52",
+              {"type":"DISPLAY","name":"","addr":"(JBB)","loc":"d,81:46,81:52",
                "fmtp": [
-                {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:81:  got='h%x exp='h1\\n","addr":"(IBB)","loc":"d,81:46,81:52","dtypep":"(RB)",
+                {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:81:  got='h%x exp='h1\\n","addr":"(KBB)","loc":"d,81:46,81:52","dtypep":"(RB)",
                  "exprsp": [
-                  {"type":"ARRAYSEL","name":"","addr":"(JBB)","loc":"d,81:127,81:131","dtypep":"(AC)",
+                  {"type":"ARRAYSEL","name":"","addr":"(LBB)","loc":"d,81:127,81:131","dtypep":"(AC)",
                    "fromp": [
-                    {"type":"VARREF","name":"__Venumtab_enum_next0","addr":"(KBB)","loc":"d,17:12,17:16","dtypep":"(IC)","access":"RD","varp":"(JC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"__Venumtab_enum_next0","addr":"(MBB)","loc":"d,17:12,17:16","dtypep":"(IC)","access":"RD","varp":"(JC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ],
                    "bitp": [
-                    {"type":"AND","name":"","addr":"(LBB)","loc":"d,81:127,81:131","dtypep":"(LC)",
+                    {"type":"AND","name":"","addr":"(NBB)","loc":"d,81:127,81:131","dtypep":"(LC)",
                      "lhsp": [
-                      {"type":"CONST","name":"32'h7","addr":"(MBB)","loc":"d,81:127,81:131","dtypep":"(NC)"}
+                      {"type":"CONST","name":"32'h7","addr":"(OBB)","loc":"d,81:127,81:131","dtypep":"(NC)"}
                     ],
                      "rhsp": [
-                      {"type":"ARRAYSEL","name":"","addr":"(NBB)","loc":"d,81:127,81:131","dtypep":"(LC)",
+                      {"type":"ARRAYSEL","name":"","addr":"(PBB)","loc":"d,81:127,81:131","dtypep":"(LC)",
                        "fromp": [
-                        {"type":"VARREF","name":"__Venumtab_enum_next0","addr":"(OBB)","loc":"d,17:12,17:16","dtypep":"(IC)","access":"RD","varp":"(JC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                        {"type":"VARREF","name":"__Venumtab_enum_next0","addr":"(QBB)","loc":"d,17:12,17:16","dtypep":"(IC)","access":"RD","varp":"(JC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                       ],
                        "bitp": [
-                        {"type":"AND","name":"","addr":"(PBB)","loc":"d,81:127,81:131","dtypep":"(LC)",
+                        {"type":"AND","name":"","addr":"(RBB)","loc":"d,81:127,81:131","dtypep":"(LC)",
                          "lhsp": [
-                          {"type":"CONST","name":"32'h7","addr":"(QBB)","loc":"d,81:127,81:131","dtypep":"(NC)"}
+                          {"type":"CONST","name":"32'h7","addr":"(SBB)","loc":"d,81:127,81:131","dtypep":"(NC)"}
                         ],
                          "rhsp": [
-                          {"type":"CCAST","name":"","addr":"(RBB)","loc":"d,81:125,81:126","dtypep":"(LC)","size":32,
+                          {"type":"CCAST","name":"","addr":"(TBB)","loc":"d,81:125,81:126","dtypep":"(LC)","size":32,
                            "lhsp": [
-                            {"type":"VARREF","name":"t.e","addr":"(SBB)","loc":"d,81:125,81:126","dtypep":"(LC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                            {"type":"VARREF","name":"t.e","addr":"(UBB)","loc":"d,81:125,81:126","dtypep":"(LC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                           ]}
                         ]}
                       ]}
@@ -1879,138 +1885,138 @@
                   ]}
                 ],"scopeNamep": []}
               ],"filep": []},
-              {"type":"STOP","name":"","addr":"(TBB)","loc":"d,81:145,81:150"}
+              {"type":"STOP","name":"","addr":"(VBB)","loc":"d,81:145,81:150"}
             ],"elsesp": []},
-            {"type":"IF","name":"","addr":"(UBB)","loc":"d,82:13,82:15",
+            {"type":"IF","name":"","addr":"(WBB)","loc":"d,82:13,82:15",
              "condp": [
-              {"type":"NEQ","name":"","addr":"(VBB)","loc":"d,82:26,82:29","dtypep":"(NB)",
+              {"type":"NEQ","name":"","addr":"(XBB)","loc":"d,82:26,82:29","dtypep":"(NB)",
                "lhsp": [
-                {"type":"CONST","name":"4'h1","addr":"(WBB)","loc":"d,82:31,82:34","dtypep":"(AC)"}
+                {"type":"CONST","name":"4'h1","addr":"(YBB)","loc":"d,82:31,82:34","dtypep":"(AC)"}
               ],
                "rhsp": [
-                {"type":"ARRAYSEL","name":"","addr":"(XBB)","loc":"d,82:20,82:24","dtypep":"(AC)",
+                {"type":"ARRAYSEL","name":"","addr":"(ZBB)","loc":"d,82:20,82:24","dtypep":"(AC)",
                  "fromp": [
-                  {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(YBB)","loc":"d,17:12,17:16","dtypep":"(CJ)","access":"RD","varp":"(DJ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(ACB)","loc":"d,17:12,17:16","dtypep":"(CJ)","access":"RD","varp":"(DJ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                 ],
                  "bitp": [
-                  {"type":"AND","name":"","addr":"(ZBB)","loc":"d,82:20,82:24","dtypep":"(LC)",
+                  {"type":"AND","name":"","addr":"(BCB)","loc":"d,82:20,82:24","dtypep":"(LC)",
                    "lhsp": [
-                    {"type":"CONST","name":"32'h7","addr":"(ACB)","loc":"d,82:20,82:24","dtypep":"(NC)"}
+                    {"type":"CONST","name":"32'h7","addr":"(CCB)","loc":"d,82:20,82:24","dtypep":"(NC)"}
                   ],
                    "rhsp": [
-                    {"type":"CCAST","name":"","addr":"(BCB)","loc":"d,82:18,82:19","dtypep":"(LC)","size":32,
+                    {"type":"CCAST","name":"","addr":"(DCB)","loc":"d,82:18,82:19","dtypep":"(LC)","size":32,
                      "lhsp": [
-                      {"type":"VARREF","name":"t.e","addr":"(CCB)","loc":"d,82:18,82:19","dtypep":"(LC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"t.e","addr":"(ECB)","loc":"d,82:18,82:19","dtypep":"(LC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ]}
                   ]}
                 ]}
               ]}
             ],
              "thensp": [
-              {"type":"DISPLAY","name":"","addr":"(DCB)","loc":"d,82:43,82:49",
+              {"type":"DISPLAY","name":"","addr":"(FCB)","loc":"d,82:43,82:49",
                "fmtp": [
-                {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:82:  got='h%x exp='h1\\n","addr":"(ECB)","loc":"d,82:43,82:49","dtypep":"(RB)",
+                {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:82:  got='h%x exp='h1\\n","addr":"(GCB)","loc":"d,82:43,82:49","dtypep":"(RB)",
                  "exprsp": [
-                  {"type":"ARRAYSEL","name":"","addr":"(FCB)","loc":"d,82:124,82:128","dtypep":"(AC)",
+                  {"type":"ARRAYSEL","name":"","addr":"(HCB)","loc":"d,82:124,82:128","dtypep":"(AC)",
                    "fromp": [
-                    {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(GCB)","loc":"d,17:12,17:16","dtypep":"(CJ)","access":"RD","varp":"(DJ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(ICB)","loc":"d,17:12,17:16","dtypep":"(CJ)","access":"RD","varp":"(DJ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ],
                    "bitp": [
-                    {"type":"AND","name":"","addr":"(HCB)","loc":"d,82:124,82:128","dtypep":"(LC)",
+                    {"type":"AND","name":"","addr":"(JCB)","loc":"d,82:124,82:128","dtypep":"(LC)",
                      "lhsp": [
-                      {"type":"CONST","name":"32'h7","addr":"(ICB)","loc":"d,82:124,82:128","dtypep":"(NC)"}
+                      {"type":"CONST","name":"32'h7","addr":"(KCB)","loc":"d,82:124,82:128","dtypep":"(NC)"}
                     ],
                      "rhsp": [
-                      {"type":"CCAST","name":"","addr":"(JCB)","loc":"d,82:122,82:123","dtypep":"(LC)","size":32,
+                      {"type":"CCAST","name":"","addr":"(LCB)","loc":"d,82:122,82:123","dtypep":"(LC)","size":32,
                        "lhsp": [
-                        {"type":"VARREF","name":"t.e","addr":"(KCB)","loc":"d,82:122,82:123","dtypep":"(LC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                        {"type":"VARREF","name":"t.e","addr":"(MCB)","loc":"d,82:122,82:123","dtypep":"(LC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                       ]}
                     ]}
                   ]}
                 ],"scopeNamep": []}
               ],"filep": []},
-              {"type":"STOP","name":"","addr":"(LCB)","loc":"d,82:139,82:144"}
+              {"type":"STOP","name":"","addr":"(NCB)","loc":"d,82:139,82:144"}
             ],"elsesp": []},
-            {"type":"IF","name":"","addr":"(MCB)","loc":"d,83:13,83:15",
+            {"type":"IF","name":"","addr":"(OCB)","loc":"d,83:13,83:15",
              "condp": [
-              {"type":"NEQ","name":"","addr":"(NCB)","loc":"d,83:29,83:32","dtypep":"(NB)",
+              {"type":"NEQ","name":"","addr":"(PCB)","loc":"d,83:29,83:32","dtypep":"(NB)",
                "lhsp": [
-                {"type":"CONST","name":"4'h1","addr":"(OCB)","loc":"d,83:34,83:37","dtypep":"(AC)"}
+                {"type":"CONST","name":"4'h1","addr":"(QCB)","loc":"d,83:34,83:37","dtypep":"(AC)"}
               ],
                "rhsp": [
-                {"type":"ARRAYSEL","name":"","addr":"(PCB)","loc":"d,83:20,83:24","dtypep":"(AC)",
+                {"type":"ARRAYSEL","name":"","addr":"(RCB)","loc":"d,83:20,83:24","dtypep":"(AC)",
                  "fromp": [
-                  {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(QCB)","loc":"d,17:12,17:16","dtypep":"(CJ)","access":"RD","varp":"(DJ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(SCB)","loc":"d,17:12,17:16","dtypep":"(CJ)","access":"RD","varp":"(DJ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                 ],
                  "bitp": [
-                  {"type":"AND","name":"","addr":"(RCB)","loc":"d,83:20,83:24","dtypep":"(LC)",
+                  {"type":"AND","name":"","addr":"(TCB)","loc":"d,83:20,83:24","dtypep":"(LC)",
                    "lhsp": [
-                    {"type":"CONST","name":"32'h7","addr":"(SCB)","loc":"d,83:20,83:24","dtypep":"(NC)"}
+                    {"type":"CONST","name":"32'h7","addr":"(UCB)","loc":"d,83:20,83:24","dtypep":"(NC)"}
                   ],
                    "rhsp": [
-                    {"type":"CCAST","name":"","addr":"(TCB)","loc":"d,83:18,83:19","dtypep":"(LC)","size":32,
+                    {"type":"CCAST","name":"","addr":"(VCB)","loc":"d,83:18,83:19","dtypep":"(LC)","size":32,
                      "lhsp": [
-                      {"type":"VARREF","name":"t.e","addr":"(UCB)","loc":"d,83:18,83:19","dtypep":"(LC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"t.e","addr":"(WCB)","loc":"d,83:18,83:19","dtypep":"(LC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ]}
                   ]}
                 ]}
               ]}
             ],
              "thensp": [
-              {"type":"DISPLAY","name":"","addr":"(VCB)","loc":"d,83:46,83:52",
+              {"type":"DISPLAY","name":"","addr":"(XCB)","loc":"d,83:46,83:52",
                "fmtp": [
-                {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:83:  got='h%x exp='h1\\n","addr":"(WCB)","loc":"d,83:46,83:52","dtypep":"(RB)",
+                {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:83:  got='h%x exp='h1\\n","addr":"(YCB)","loc":"d,83:46,83:52","dtypep":"(RB)",
                  "exprsp": [
-                  {"type":"ARRAYSEL","name":"","addr":"(XCB)","loc":"d,83:127,83:131","dtypep":"(AC)",
+                  {"type":"ARRAYSEL","name":"","addr":"(ZCB)","loc":"d,83:127,83:131","dtypep":"(AC)",
                    "fromp": [
-                    {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(YCB)","loc":"d,17:12,17:16","dtypep":"(CJ)","access":"RD","varp":"(DJ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(ADB)","loc":"d,17:12,17:16","dtypep":"(CJ)","access":"RD","varp":"(DJ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ],
                    "bitp": [
-                    {"type":"AND","name":"","addr":"(ZCB)","loc":"d,83:127,83:131","dtypep":"(LC)",
+                    {"type":"AND","name":"","addr":"(BDB)","loc":"d,83:127,83:131","dtypep":"(LC)",
                      "lhsp": [
-                      {"type":"CONST","name":"32'h7","addr":"(ADB)","loc":"d,83:127,83:131","dtypep":"(NC)"}
+                      {"type":"CONST","name":"32'h7","addr":"(CDB)","loc":"d,83:127,83:131","dtypep":"(NC)"}
                     ],
                      "rhsp": [
-                      {"type":"CCAST","name":"","addr":"(BDB)","loc":"d,83:125,83:126","dtypep":"(LC)","size":32,
+                      {"type":"CCAST","name":"","addr":"(DDB)","loc":"d,83:125,83:126","dtypep":"(LC)","size":32,
                        "lhsp": [
-                        {"type":"VARREF","name":"t.e","addr":"(CDB)","loc":"d,83:125,83:126","dtypep":"(LC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                        {"type":"VARREF","name":"t.e","addr":"(EDB)","loc":"d,83:125,83:126","dtypep":"(LC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                       ]}
                     ]}
                   ]}
                 ],"scopeNamep": []}
               ],"filep": []},
-              {"type":"STOP","name":"","addr":"(DDB)","loc":"d,83:145,83:150"}
+              {"type":"STOP","name":"","addr":"(FDB)","loc":"d,83:145,83:150"}
             ],"elsesp": []},
-            {"type":"IF","name":"","addr":"(EDB)","loc":"d,84:13,84:15",
+            {"type":"IF","name":"","addr":"(GDB)","loc":"d,84:13,84:15",
              "condp": [
-              {"type":"NEQ","name":"","addr":"(FDB)","loc":"d,84:29,84:32","dtypep":"(NB)",
+              {"type":"NEQ","name":"","addr":"(HDB)","loc":"d,84:29,84:32","dtypep":"(NB)",
                "lhsp": [
-                {"type":"CONST","name":"4'h4","addr":"(GDB)","loc":"d,84:34,84:37","dtypep":"(AC)"}
+                {"type":"CONST","name":"4'h4","addr":"(IDB)","loc":"d,84:34,84:37","dtypep":"(AC)"}
               ],
                "rhsp": [
-                {"type":"ARRAYSEL","name":"","addr":"(HDB)","loc":"d,84:20,84:24","dtypep":"(AC)",
+                {"type":"ARRAYSEL","name":"","addr":"(JDB)","loc":"d,84:20,84:24","dtypep":"(AC)",
                  "fromp": [
-                  {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(IDB)","loc":"d,17:12,17:16","dtypep":"(CJ)","access":"RD","varp":"(DJ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(KDB)","loc":"d,17:12,17:16","dtypep":"(CJ)","access":"RD","varp":"(DJ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                 ],
                  "bitp": [
-                  {"type":"AND","name":"","addr":"(JDB)","loc":"d,84:20,84:24","dtypep":"(LC)",
+                  {"type":"AND","name":"","addr":"(LDB)","loc":"d,84:20,84:24","dtypep":"(LC)",
                    "lhsp": [
-                    {"type":"CONST","name":"32'h7","addr":"(KDB)","loc":"d,84:20,84:24","dtypep":"(NC)"}
+                    {"type":"CONST","name":"32'h7","addr":"(MDB)","loc":"d,84:20,84:24","dtypep":"(NC)"}
                   ],
                    "rhsp": [
-                    {"type":"ARRAYSEL","name":"","addr":"(LDB)","loc":"d,84:20,84:24","dtypep":"(LC)",
+                    {"type":"ARRAYSEL","name":"","addr":"(NDB)","loc":"d,84:20,84:24","dtypep":"(LC)",
                      "fromp": [
-                      {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(MDB)","loc":"d,17:12,17:16","dtypep":"(CJ)","access":"RD","varp":"(DJ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(ODB)","loc":"d,17:12,17:16","dtypep":"(CJ)","access":"RD","varp":"(DJ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ],
                      "bitp": [
-                      {"type":"AND","name":"","addr":"(NDB)","loc":"d,84:20,84:24","dtypep":"(LC)",
+                      {"type":"AND","name":"","addr":"(PDB)","loc":"d,84:20,84:24","dtypep":"(LC)",
                        "lhsp": [
-                        {"type":"CONST","name":"32'h7","addr":"(ODB)","loc":"d,84:20,84:24","dtypep":"(NC)"}
+                        {"type":"CONST","name":"32'h7","addr":"(QDB)","loc":"d,84:20,84:24","dtypep":"(NC)"}
                       ],
                        "rhsp": [
-                        {"type":"CCAST","name":"","addr":"(PDB)","loc":"d,84:18,84:19","dtypep":"(LC)","size":32,
+                        {"type":"CCAST","name":"","addr":"(RDB)","loc":"d,84:18,84:19","dtypep":"(LC)","size":32,
                          "lhsp": [
-                          {"type":"VARREF","name":"t.e","addr":"(QDB)","loc":"d,84:18,84:19","dtypep":"(LC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                          {"type":"VARREF","name":"t.e","addr":"(SDB)","loc":"d,84:18,84:19","dtypep":"(LC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                         ]}
                       ]}
                     ]}
@@ -2019,33 +2025,33 @@
               ]}
             ],
              "thensp": [
-              {"type":"DISPLAY","name":"","addr":"(RDB)","loc":"d,84:46,84:52",
+              {"type":"DISPLAY","name":"","addr":"(TDB)","loc":"d,84:46,84:52",
                "fmtp": [
-                {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:84:  got='h%x exp='h4\\n","addr":"(SDB)","loc":"d,84:46,84:52","dtypep":"(RB)",
+                {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:84:  got='h%x exp='h4\\n","addr":"(UDB)","loc":"d,84:46,84:52","dtypep":"(RB)",
                  "exprsp": [
-                  {"type":"ARRAYSEL","name":"","addr":"(TDB)","loc":"d,84:127,84:131","dtypep":"(AC)",
+                  {"type":"ARRAYSEL","name":"","addr":"(VDB)","loc":"d,84:127,84:131","dtypep":"(AC)",
                    "fromp": [
-                    {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(UDB)","loc":"d,17:12,17:16","dtypep":"(CJ)","access":"RD","varp":"(DJ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(WDB)","loc":"d,17:12,17:16","dtypep":"(CJ)","access":"RD","varp":"(DJ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ],
                    "bitp": [
-                    {"type":"AND","name":"","addr":"(VDB)","loc":"d,84:127,84:131","dtypep":"(LC)",
+                    {"type":"AND","name":"","addr":"(XDB)","loc":"d,84:127,84:131","dtypep":"(LC)",
                      "lhsp": [
-                      {"type":"CONST","name":"32'h7","addr":"(WDB)","loc":"d,84:127,84:131","dtypep":"(NC)"}
+                      {"type":"CONST","name":"32'h7","addr":"(YDB)","loc":"d,84:127,84:131","dtypep":"(NC)"}
                     ],
                      "rhsp": [
-                      {"type":"ARRAYSEL","name":"","addr":"(XDB)","loc":"d,84:127,84:131","dtypep":"(LC)",
+                      {"type":"ARRAYSEL","name":"","addr":"(ZDB)","loc":"d,84:127,84:131","dtypep":"(LC)",
                        "fromp": [
-                        {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(YDB)","loc":"d,17:12,17:16","dtypep":"(CJ)","access":"RD","varp":"(DJ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                        {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(AEB)","loc":"d,17:12,17:16","dtypep":"(CJ)","access":"RD","varp":"(DJ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                       ],
                        "bitp": [
-                        {"type":"AND","name":"","addr":"(ZDB)","loc":"d,84:127,84:131","dtypep":"(LC)",
+                        {"type":"AND","name":"","addr":"(BEB)","loc":"d,84:127,84:131","dtypep":"(LC)",
                          "lhsp": [
-                          {"type":"CONST","name":"32'h7","addr":"(AEB)","loc":"d,84:127,84:131","dtypep":"(NC)"}
+                          {"type":"CONST","name":"32'h7","addr":"(CEB)","loc":"d,84:127,84:131","dtypep":"(NC)"}
                         ],
                          "rhsp": [
-                          {"type":"CCAST","name":"","addr":"(BEB)","loc":"d,84:125,84:126","dtypep":"(LC)","size":32,
+                          {"type":"CCAST","name":"","addr":"(DEB)","loc":"d,84:125,84:126","dtypep":"(LC)","size":32,
                            "lhsp": [
-                            {"type":"VARREF","name":"t.e","addr":"(CEB)","loc":"d,84:125,84:126","dtypep":"(LC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                            {"type":"VARREF","name":"t.e","addr":"(EEB)","loc":"d,84:125,84:126","dtypep":"(LC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                           ]}
                         ]}
                       ]}
@@ -2053,215 +2059,215 @@
                   ]}
                 ],"scopeNamep": []}
               ],"filep": []},
-              {"type":"STOP","name":"","addr":"(DEB)","loc":"d,84:145,84:150"}
+              {"type":"STOP","name":"","addr":"(FEB)","loc":"d,84:145,84:150"}
             ],"elsesp": []},
-            {"type":"ASSIGNDLY","name":"","addr":"(EEB)","loc":"d,85:12,85:14","dtypep":"(AC)",
+            {"type":"ASSIGNDLY","name":"","addr":"(GEB)","loc":"d,85:12,85:14","dtypep":"(AC)",
              "rhsp": [
-              {"type":"CONST","name":"4'h4","addr":"(FEB)","loc":"d,85:15,85:18","dtypep":"(AC)"}
+              {"type":"CONST","name":"4'h4","addr":"(HEB)","loc":"d,85:15,85:18","dtypep":"(AC)"}
             ],
              "lhsp": [
-              {"type":"VARREF","name":"__Vdly__t.e","addr":"(GEB)","loc":"d,85:10,85:11","dtypep":"(AC)","access":"WR","varp":"(QR)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+              {"type":"VARREF","name":"__Vdly__t.e","addr":"(IEB)","loc":"d,85:10,85:11","dtypep":"(AC)","access":"WR","varp":"(SR)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
             ],"timingControlp": []}
           ],
            "elsesp": [
-            {"type":"IF","name":"","addr":"(HEB)","loc":"d,87:12,87:14",
+            {"type":"IF","name":"","addr":"(JEB)","loc":"d,87:12,87:14",
              "condp": [
-              {"type":"EQ","name":"","addr":"(IEB)","loc":"d,87:19,87:21","dtypep":"(NB)",
+              {"type":"EQ","name":"","addr":"(KEB)","loc":"d,87:19,87:21","dtypep":"(NB)",
                "lhsp": [
-                {"type":"CONST","name":"32'sh3","addr":"(JEB)","loc":"d,87:21,87:22","dtypep":"(GB)"}
+                {"type":"CONST","name":"32'sh3","addr":"(LEB)","loc":"d,87:21,87:22","dtypep":"(GB)"}
               ],
                "rhsp": [
-                {"type":"VARREF","name":"t.cyc","addr":"(KEB)","loc":"d,87:16,87:19","dtypep":"(R)","access":"RD","varp":"(Q)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                {"type":"VARREF","name":"t.cyc","addr":"(MEB)","loc":"d,87:16,87:19","dtypep":"(R)","access":"RD","varp":"(Q)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
               ]}
             ],
              "thensp": [
-              {"type":"IF","name":"","addr":"(LEB)","loc":"d,88:13,88:15",
+              {"type":"IF","name":"","addr":"(NEB)","loc":"d,88:13,88:15",
                "condp": [
-                {"type":"NEQN","name":"","addr":"(MEB)","loc":"d,88:26,88:29","dtypep":"(NB)",
+                {"type":"NEQN","name":"","addr":"(OEB)","loc":"d,88:26,88:29","dtypep":"(NB)",
                  "lhsp": [
-                  {"type":"CONST","name":"\\\"E04\\\"","addr":"(NEB)","loc":"d,88:31,88:36","dtypep":"(RB)"}
+                  {"type":"CONST","name":"\\\"E04\\\"","addr":"(PEB)","loc":"d,88:31,88:36","dtypep":"(RB)"}
                 ],
                  "rhsp": [
-                  {"type":"ARRAYSEL","name":"","addr":"(OEB)","loc":"d,88:20,88:24","dtypep":"(RB)",
+                  {"type":"ARRAYSEL","name":"","addr":"(QEB)","loc":"d,88:20,88:24","dtypep":"(RB)",
                    "fromp": [
-                    {"type":"VARREF","name":"__Venumtab_enum_name2","addr":"(PEB)","loc":"d,17:12,17:16","dtypep":"(OM)","access":"RD","varp":"(PM)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"__Venumtab_enum_name2","addr":"(REB)","loc":"d,17:12,17:16","dtypep":"(OM)","access":"RD","varp":"(PM)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ],
                    "bitp": [
-                    {"type":"AND","name":"","addr":"(QEB)","loc":"d,88:20,88:24","dtypep":"(LC)",
+                    {"type":"AND","name":"","addr":"(SEB)","loc":"d,88:20,88:24","dtypep":"(LC)",
                      "lhsp": [
-                      {"type":"CONST","name":"32'h7","addr":"(REB)","loc":"d,88:20,88:24","dtypep":"(NC)"}
+                      {"type":"CONST","name":"32'h7","addr":"(TEB)","loc":"d,88:20,88:24","dtypep":"(NC)"}
                     ],
                      "rhsp": [
-                      {"type":"CCAST","name":"","addr":"(SEB)","loc":"d,88:18,88:19","dtypep":"(LC)","size":32,
+                      {"type":"CCAST","name":"","addr":"(UEB)","loc":"d,88:18,88:19","dtypep":"(LC)","size":32,
                        "lhsp": [
-                        {"type":"VARREF","name":"t.e","addr":"(TEB)","loc":"d,88:18,88:19","dtypep":"(LC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                        {"type":"VARREF","name":"t.e","addr":"(VEB)","loc":"d,88:18,88:19","dtypep":"(LC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                       ]}
                     ]}
                   ]}
                 ]}
               ],
                "thensp": [
-                {"type":"ASSIGN","name":"","addr":"(UEB)","loc":"d,88:126,88:130","dtypep":"(RB)",
+                {"type":"ASSIGN","name":"","addr":"(WEB)","loc":"d,88:126,88:130","dtypep":"(RB)",
                  "rhsp": [
-                  {"type":"ARRAYSEL","name":"","addr":"(VEB)","loc":"d,88:126,88:130","dtypep":"(RB)",
+                  {"type":"ARRAYSEL","name":"","addr":"(XEB)","loc":"d,88:126,88:130","dtypep":"(RB)",
                    "fromp": [
-                    {"type":"VARREF","name":"__Venumtab_enum_name2","addr":"(WEB)","loc":"d,17:12,17:16","dtypep":"(OM)","access":"RD","varp":"(PM)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"__Venumtab_enum_name2","addr":"(YEB)","loc":"d,17:12,17:16","dtypep":"(OM)","access":"RD","varp":"(PM)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ],
                    "bitp": [
-                    {"type":"AND","name":"","addr":"(XEB)","loc":"d,88:126,88:130","dtypep":"(LC)",
+                    {"type":"AND","name":"","addr":"(ZEB)","loc":"d,88:126,88:130","dtypep":"(LC)",
                      "lhsp": [
-                      {"type":"CONST","name":"32'h7","addr":"(YEB)","loc":"d,88:126,88:130","dtypep":"(NC)"}
+                      {"type":"CONST","name":"32'h7","addr":"(AFB)","loc":"d,88:126,88:130","dtypep":"(NC)"}
                     ],
                      "rhsp": [
-                      {"type":"CCAST","name":"","addr":"(ZEB)","loc":"d,88:124,88:125","dtypep":"(LC)","size":32,
+                      {"type":"CCAST","name":"","addr":"(BFB)","loc":"d,88:124,88:125","dtypep":"(LC)","size":32,
                        "lhsp": [
-                        {"type":"VARREF","name":"t.e","addr":"(AFB)","loc":"d,88:124,88:125","dtypep":"(LC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                        {"type":"VARREF","name":"t.e","addr":"(CFB)","loc":"d,88:124,88:125","dtypep":"(LC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                       ]}
                     ]}
                   ]}
                 ],
                  "lhsp": [
-                  {"type":"VARREF","name":"__Vtemp_3","addr":"(BFB)","loc":"d,88:126,88:130","dtypep":"(RB)","access":"WR","varp":"(VR)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"__Vtemp_3","addr":"(DFB)","loc":"d,88:126,88:130","dtypep":"(RB)","access":"WR","varp":"(XR)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                 ],"timingControlp": []},
-                {"type":"DISPLAY","name":"","addr":"(CFB)","loc":"d,88:45,88:51",
+                {"type":"DISPLAY","name":"","addr":"(EFB)","loc":"d,88:45,88:51",
                  "fmtp": [
-                  {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:88:  got='%@' exp='E04'\\n","addr":"(DFB)","loc":"d,88:45,88:51","dtypep":"(RB)",
+                  {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:88:  got='%@' exp='E04'\\n","addr":"(FFB)","loc":"d,88:45,88:51","dtypep":"(RB)",
                    "exprsp": [
-                    {"type":"VARREF","name":"__Vtemp_3","addr":"(EFB)","loc":"d,88:126,88:130","dtypep":"(RB)","access":"RD","varp":"(VR)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"__Vtemp_3","addr":"(GFB)","loc":"d,88:126,88:130","dtypep":"(RB)","access":"RD","varp":"(XR)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ],"scopeNamep": []}
                 ],"filep": []},
-                {"type":"STOP","name":"","addr":"(FFB)","loc":"d,88:143,88:148"}
+                {"type":"STOP","name":"","addr":"(HFB)","loc":"d,88:143,88:148"}
               ],"elsesp": []},
-              {"type":"IF","name":"","addr":"(GFB)","loc":"d,89:13,89:15",
+              {"type":"IF","name":"","addr":"(IFB)","loc":"d,89:13,89:15",
                "condp": [
-                {"type":"NEQ","name":"","addr":"(HFB)","loc":"d,89:26,89:29","dtypep":"(NB)",
+                {"type":"NEQ","name":"","addr":"(JFB)","loc":"d,89:26,89:29","dtypep":"(NB)",
                  "lhsp": [
-                  {"type":"CONST","name":"4'h1","addr":"(IFB)","loc":"d,89:31,89:34","dtypep":"(AC)"}
+                  {"type":"CONST","name":"4'h1","addr":"(KFB)","loc":"d,89:31,89:34","dtypep":"(AC)"}
                 ],
                  "rhsp": [
-                  {"type":"ARRAYSEL","name":"","addr":"(JFB)","loc":"d,89:20,89:24","dtypep":"(AC)",
+                  {"type":"ARRAYSEL","name":"","addr":"(LFB)","loc":"d,89:20,89:24","dtypep":"(AC)",
                    "fromp": [
-                    {"type":"VARREF","name":"__Venumtab_enum_next0","addr":"(KFB)","loc":"d,17:12,17:16","dtypep":"(IC)","access":"RD","varp":"(JC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"__Venumtab_enum_next0","addr":"(MFB)","loc":"d,17:12,17:16","dtypep":"(IC)","access":"RD","varp":"(JC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ],
                    "bitp": [
-                    {"type":"AND","name":"","addr":"(LFB)","loc":"d,89:20,89:24","dtypep":"(LC)",
+                    {"type":"AND","name":"","addr":"(NFB)","loc":"d,89:20,89:24","dtypep":"(LC)",
                      "lhsp": [
-                      {"type":"CONST","name":"32'h7","addr":"(MFB)","loc":"d,89:20,89:24","dtypep":"(NC)"}
+                      {"type":"CONST","name":"32'h7","addr":"(OFB)","loc":"d,89:20,89:24","dtypep":"(NC)"}
                     ],
                      "rhsp": [
-                      {"type":"CCAST","name":"","addr":"(NFB)","loc":"d,89:18,89:19","dtypep":"(LC)","size":32,
+                      {"type":"CCAST","name":"","addr":"(PFB)","loc":"d,89:18,89:19","dtypep":"(LC)","size":32,
                        "lhsp": [
-                        {"type":"VARREF","name":"t.e","addr":"(OFB)","loc":"d,89:18,89:19","dtypep":"(LC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                        {"type":"VARREF","name":"t.e","addr":"(QFB)","loc":"d,89:18,89:19","dtypep":"(LC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                       ]}
                     ]}
                   ]}
                 ]}
               ],
                "thensp": [
-                {"type":"DISPLAY","name":"","addr":"(PFB)","loc":"d,89:43,89:49",
+                {"type":"DISPLAY","name":"","addr":"(RFB)","loc":"d,89:43,89:49",
                  "fmtp": [
-                  {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:89:  got='h%x exp='h1\\n","addr":"(QFB)","loc":"d,89:43,89:49","dtypep":"(RB)",
+                  {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:89:  got='h%x exp='h1\\n","addr":"(SFB)","loc":"d,89:43,89:49","dtypep":"(RB)",
                    "exprsp": [
-                    {"type":"ARRAYSEL","name":"","addr":"(RFB)","loc":"d,89:124,89:128","dtypep":"(AC)",
+                    {"type":"ARRAYSEL","name":"","addr":"(TFB)","loc":"d,89:124,89:128","dtypep":"(AC)",
                      "fromp": [
-                      {"type":"VARREF","name":"__Venumtab_enum_next0","addr":"(SFB)","loc":"d,17:12,17:16","dtypep":"(IC)","access":"RD","varp":"(JC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"__Venumtab_enum_next0","addr":"(UFB)","loc":"d,17:12,17:16","dtypep":"(IC)","access":"RD","varp":"(JC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ],
                      "bitp": [
-                      {"type":"AND","name":"","addr":"(TFB)","loc":"d,89:124,89:128","dtypep":"(LC)",
+                      {"type":"AND","name":"","addr":"(VFB)","loc":"d,89:124,89:128","dtypep":"(LC)",
                        "lhsp": [
-                        {"type":"CONST","name":"32'h7","addr":"(UFB)","loc":"d,89:124,89:128","dtypep":"(NC)"}
+                        {"type":"CONST","name":"32'h7","addr":"(WFB)","loc":"d,89:124,89:128","dtypep":"(NC)"}
                       ],
                        "rhsp": [
-                        {"type":"CCAST","name":"","addr":"(VFB)","loc":"d,89:122,89:123","dtypep":"(LC)","size":32,
+                        {"type":"CCAST","name":"","addr":"(XFB)","loc":"d,89:122,89:123","dtypep":"(LC)","size":32,
                          "lhsp": [
-                          {"type":"VARREF","name":"t.e","addr":"(WFB)","loc":"d,89:122,89:123","dtypep":"(LC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                          {"type":"VARREF","name":"t.e","addr":"(YFB)","loc":"d,89:122,89:123","dtypep":"(LC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                         ]}
                       ]}
                     ]}
                   ],"scopeNamep": []}
                 ],"filep": []},
-                {"type":"STOP","name":"","addr":"(XFB)","loc":"d,89:139,89:144"}
+                {"type":"STOP","name":"","addr":"(ZFB)","loc":"d,89:139,89:144"}
               ],"elsesp": []},
-              {"type":"IF","name":"","addr":"(YFB)","loc":"d,90:13,90:15",
+              {"type":"IF","name":"","addr":"(AGB)","loc":"d,90:13,90:15",
                "condp": [
-                {"type":"NEQ","name":"","addr":"(ZFB)","loc":"d,90:29,90:32","dtypep":"(NB)",
+                {"type":"NEQ","name":"","addr":"(BGB)","loc":"d,90:29,90:32","dtypep":"(NB)",
                  "lhsp": [
-                  {"type":"CONST","name":"4'h1","addr":"(AGB)","loc":"d,90:34,90:37","dtypep":"(AC)"}
+                  {"type":"CONST","name":"4'h1","addr":"(CGB)","loc":"d,90:34,90:37","dtypep":"(AC)"}
                 ],
                  "rhsp": [
-                  {"type":"ARRAYSEL","name":"","addr":"(BGB)","loc":"d,90:20,90:24","dtypep":"(AC)",
+                  {"type":"ARRAYSEL","name":"","addr":"(DGB)","loc":"d,90:20,90:24","dtypep":"(AC)",
                    "fromp": [
-                    {"type":"VARREF","name":"__Venumtab_enum_next0","addr":"(CGB)","loc":"d,17:12,17:16","dtypep":"(IC)","access":"RD","varp":"(JC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"__Venumtab_enum_next0","addr":"(EGB)","loc":"d,17:12,17:16","dtypep":"(IC)","access":"RD","varp":"(JC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ],
                    "bitp": [
-                    {"type":"AND","name":"","addr":"(DGB)","loc":"d,90:20,90:24","dtypep":"(LC)",
+                    {"type":"AND","name":"","addr":"(FGB)","loc":"d,90:20,90:24","dtypep":"(LC)",
                      "lhsp": [
-                      {"type":"CONST","name":"32'h7","addr":"(EGB)","loc":"d,90:20,90:24","dtypep":"(NC)"}
+                      {"type":"CONST","name":"32'h7","addr":"(GGB)","loc":"d,90:20,90:24","dtypep":"(NC)"}
                     ],
                      "rhsp": [
-                      {"type":"CCAST","name":"","addr":"(FGB)","loc":"d,90:18,90:19","dtypep":"(LC)","size":32,
+                      {"type":"CCAST","name":"","addr":"(HGB)","loc":"d,90:18,90:19","dtypep":"(LC)","size":32,
                        "lhsp": [
-                        {"type":"VARREF","name":"t.e","addr":"(GGB)","loc":"d,90:18,90:19","dtypep":"(LC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                        {"type":"VARREF","name":"t.e","addr":"(IGB)","loc":"d,90:18,90:19","dtypep":"(LC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                       ]}
                     ]}
                   ]}
                 ]}
               ],
                "thensp": [
-                {"type":"DISPLAY","name":"","addr":"(HGB)","loc":"d,90:46,90:52",
+                {"type":"DISPLAY","name":"","addr":"(JGB)","loc":"d,90:46,90:52",
                  "fmtp": [
-                  {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:90:  got='h%x exp='h1\\n","addr":"(IGB)","loc":"d,90:46,90:52","dtypep":"(RB)",
+                  {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:90:  got='h%x exp='h1\\n","addr":"(KGB)","loc":"d,90:46,90:52","dtypep":"(RB)",
                    "exprsp": [
-                    {"type":"ARRAYSEL","name":"","addr":"(JGB)","loc":"d,90:127,90:131","dtypep":"(AC)",
+                    {"type":"ARRAYSEL","name":"","addr":"(LGB)","loc":"d,90:127,90:131","dtypep":"(AC)",
                      "fromp": [
-                      {"type":"VARREF","name":"__Venumtab_enum_next0","addr":"(KGB)","loc":"d,17:12,17:16","dtypep":"(IC)","access":"RD","varp":"(JC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"__Venumtab_enum_next0","addr":"(MGB)","loc":"d,17:12,17:16","dtypep":"(IC)","access":"RD","varp":"(JC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ],
                      "bitp": [
-                      {"type":"AND","name":"","addr":"(LGB)","loc":"d,90:127,90:131","dtypep":"(LC)",
+                      {"type":"AND","name":"","addr":"(NGB)","loc":"d,90:127,90:131","dtypep":"(LC)",
                        "lhsp": [
-                        {"type":"CONST","name":"32'h7","addr":"(MGB)","loc":"d,90:127,90:131","dtypep":"(NC)"}
+                        {"type":"CONST","name":"32'h7","addr":"(OGB)","loc":"d,90:127,90:131","dtypep":"(NC)"}
                       ],
                        "rhsp": [
-                        {"type":"CCAST","name":"","addr":"(NGB)","loc":"d,90:125,90:126","dtypep":"(LC)","size":32,
+                        {"type":"CCAST","name":"","addr":"(PGB)","loc":"d,90:125,90:126","dtypep":"(LC)","size":32,
                          "lhsp": [
-                          {"type":"VARREF","name":"t.e","addr":"(OGB)","loc":"d,90:125,90:126","dtypep":"(LC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                          {"type":"VARREF","name":"t.e","addr":"(QGB)","loc":"d,90:125,90:126","dtypep":"(LC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                         ]}
                       ]}
                     ]}
                   ],"scopeNamep": []}
                 ],"filep": []},
-                {"type":"STOP","name":"","addr":"(PGB)","loc":"d,90:145,90:150"}
+                {"type":"STOP","name":"","addr":"(RGB)","loc":"d,90:145,90:150"}
               ],"elsesp": []},
-              {"type":"IF","name":"","addr":"(QGB)","loc":"d,91:13,91:15",
+              {"type":"IF","name":"","addr":"(SGB)","loc":"d,91:13,91:15",
                "condp": [
-                {"type":"NEQ","name":"","addr":"(RGB)","loc":"d,91:29,91:32","dtypep":"(NB)",
+                {"type":"NEQ","name":"","addr":"(TGB)","loc":"d,91:29,91:32","dtypep":"(NB)",
                  "lhsp": [
-                  {"type":"CONST","name":"4'h3","addr":"(SGB)","loc":"d,91:34,91:37","dtypep":"(AC)"}
+                  {"type":"CONST","name":"4'h3","addr":"(UGB)","loc":"d,91:34,91:37","dtypep":"(AC)"}
                 ],
                  "rhsp": [
-                  {"type":"ARRAYSEL","name":"","addr":"(TGB)","loc":"d,91:20,91:24","dtypep":"(AC)",
+                  {"type":"ARRAYSEL","name":"","addr":"(VGB)","loc":"d,91:20,91:24","dtypep":"(AC)",
                    "fromp": [
-                    {"type":"VARREF","name":"__Venumtab_enum_next0","addr":"(UGB)","loc":"d,17:12,17:16","dtypep":"(IC)","access":"RD","varp":"(JC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"__Venumtab_enum_next0","addr":"(WGB)","loc":"d,17:12,17:16","dtypep":"(IC)","access":"RD","varp":"(JC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ],
                    "bitp": [
-                    {"type":"AND","name":"","addr":"(VGB)","loc":"d,91:20,91:24","dtypep":"(LC)",
+                    {"type":"AND","name":"","addr":"(XGB)","loc":"d,91:20,91:24","dtypep":"(LC)",
                      "lhsp": [
-                      {"type":"CONST","name":"32'h7","addr":"(WGB)","loc":"d,91:20,91:24","dtypep":"(NC)"}
+                      {"type":"CONST","name":"32'h7","addr":"(YGB)","loc":"d,91:20,91:24","dtypep":"(NC)"}
                     ],
                      "rhsp": [
-                      {"type":"ARRAYSEL","name":"","addr":"(XGB)","loc":"d,91:20,91:24","dtypep":"(LC)",
+                      {"type":"ARRAYSEL","name":"","addr":"(ZGB)","loc":"d,91:20,91:24","dtypep":"(LC)",
                        "fromp": [
-                        {"type":"VARREF","name":"__Venumtab_enum_next0","addr":"(YGB)","loc":"d,17:12,17:16","dtypep":"(IC)","access":"RD","varp":"(JC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                        {"type":"VARREF","name":"__Venumtab_enum_next0","addr":"(AHB)","loc":"d,17:12,17:16","dtypep":"(IC)","access":"RD","varp":"(JC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                       ],
                        "bitp": [
-                        {"type":"AND","name":"","addr":"(ZGB)","loc":"d,91:20,91:24","dtypep":"(LC)",
+                        {"type":"AND","name":"","addr":"(BHB)","loc":"d,91:20,91:24","dtypep":"(LC)",
                          "lhsp": [
-                          {"type":"CONST","name":"32'h7","addr":"(AHB)","loc":"d,91:20,91:24","dtypep":"(NC)"}
+                          {"type":"CONST","name":"32'h7","addr":"(CHB)","loc":"d,91:20,91:24","dtypep":"(NC)"}
                         ],
                          "rhsp": [
-                          {"type":"CCAST","name":"","addr":"(BHB)","loc":"d,91:18,91:19","dtypep":"(LC)","size":32,
+                          {"type":"CCAST","name":"","addr":"(DHB)","loc":"d,91:18,91:19","dtypep":"(LC)","size":32,
                            "lhsp": [
-                            {"type":"VARREF","name":"t.e","addr":"(CHB)","loc":"d,91:18,91:19","dtypep":"(LC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                            {"type":"VARREF","name":"t.e","addr":"(EHB)","loc":"d,91:18,91:19","dtypep":"(LC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                           ]}
                         ]}
                       ]}
@@ -2270,33 +2276,33 @@
                 ]}
               ],
                "thensp": [
-                {"type":"DISPLAY","name":"","addr":"(DHB)","loc":"d,91:46,91:52",
+                {"type":"DISPLAY","name":"","addr":"(FHB)","loc":"d,91:46,91:52",
                  "fmtp": [
-                  {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:91:  got='h%x exp='h3\\n","addr":"(EHB)","loc":"d,91:46,91:52","dtypep":"(RB)",
+                  {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:91:  got='h%x exp='h3\\n","addr":"(GHB)","loc":"d,91:46,91:52","dtypep":"(RB)",
                    "exprsp": [
-                    {"type":"ARRAYSEL","name":"","addr":"(FHB)","loc":"d,91:127,91:131","dtypep":"(AC)",
+                    {"type":"ARRAYSEL","name":"","addr":"(HHB)","loc":"d,91:127,91:131","dtypep":"(AC)",
                      "fromp": [
-                      {"type":"VARREF","name":"__Venumtab_enum_next0","addr":"(GHB)","loc":"d,17:12,17:16","dtypep":"(IC)","access":"RD","varp":"(JC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"__Venumtab_enum_next0","addr":"(IHB)","loc":"d,17:12,17:16","dtypep":"(IC)","access":"RD","varp":"(JC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ],
                      "bitp": [
-                      {"type":"AND","name":"","addr":"(HHB)","loc":"d,91:127,91:131","dtypep":"(LC)",
+                      {"type":"AND","name":"","addr":"(JHB)","loc":"d,91:127,91:131","dtypep":"(LC)",
                        "lhsp": [
-                        {"type":"CONST","name":"32'h7","addr":"(IHB)","loc":"d,91:127,91:131","dtypep":"(NC)"}
+                        {"type":"CONST","name":"32'h7","addr":"(KHB)","loc":"d,91:127,91:131","dtypep":"(NC)"}
                       ],
                        "rhsp": [
-                        {"type":"ARRAYSEL","name":"","addr":"(JHB)","loc":"d,91:127,91:131","dtypep":"(LC)",
+                        {"type":"ARRAYSEL","name":"","addr":"(LHB)","loc":"d,91:127,91:131","dtypep":"(LC)",
                          "fromp": [
-                          {"type":"VARREF","name":"__Venumtab_enum_next0","addr":"(KHB)","loc":"d,17:12,17:16","dtypep":"(IC)","access":"RD","varp":"(JC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                          {"type":"VARREF","name":"__Venumtab_enum_next0","addr":"(MHB)","loc":"d,17:12,17:16","dtypep":"(IC)","access":"RD","varp":"(JC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                         ],
                          "bitp": [
-                          {"type":"AND","name":"","addr":"(LHB)","loc":"d,91:127,91:131","dtypep":"(LC)",
+                          {"type":"AND","name":"","addr":"(NHB)","loc":"d,91:127,91:131","dtypep":"(LC)",
                            "lhsp": [
-                            {"type":"CONST","name":"32'h7","addr":"(MHB)","loc":"d,91:127,91:131","dtypep":"(NC)"}
+                            {"type":"CONST","name":"32'h7","addr":"(OHB)","loc":"d,91:127,91:131","dtypep":"(NC)"}
                           ],
                            "rhsp": [
-                            {"type":"CCAST","name":"","addr":"(NHB)","loc":"d,91:125,91:126","dtypep":"(LC)","size":32,
+                            {"type":"CCAST","name":"","addr":"(PHB)","loc":"d,91:125,91:126","dtypep":"(LC)","size":32,
                              "lhsp": [
-                              {"type":"VARREF","name":"t.e","addr":"(OHB)","loc":"d,91:125,91:126","dtypep":"(LC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                              {"type":"VARREF","name":"t.e","addr":"(QHB)","loc":"d,91:125,91:126","dtypep":"(LC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                             ]}
                           ]}
                         ]}
@@ -2304,138 +2310,138 @@
                     ]}
                   ],"scopeNamep": []}
                 ],"filep": []},
-                {"type":"STOP","name":"","addr":"(PHB)","loc":"d,91:145,91:150"}
+                {"type":"STOP","name":"","addr":"(RHB)","loc":"d,91:145,91:150"}
               ],"elsesp": []},
-              {"type":"IF","name":"","addr":"(QHB)","loc":"d,92:13,92:15",
+              {"type":"IF","name":"","addr":"(SHB)","loc":"d,92:13,92:15",
                "condp": [
-                {"type":"NEQ","name":"","addr":"(RHB)","loc":"d,92:26,92:29","dtypep":"(NB)",
+                {"type":"NEQ","name":"","addr":"(THB)","loc":"d,92:26,92:29","dtypep":"(NB)",
                  "lhsp": [
-                  {"type":"CONST","name":"4'h3","addr":"(SHB)","loc":"d,92:31,92:34","dtypep":"(AC)"}
+                  {"type":"CONST","name":"4'h3","addr":"(UHB)","loc":"d,92:31,92:34","dtypep":"(AC)"}
                 ],
                  "rhsp": [
-                  {"type":"ARRAYSEL","name":"","addr":"(THB)","loc":"d,92:20,92:24","dtypep":"(AC)",
+                  {"type":"ARRAYSEL","name":"","addr":"(VHB)","loc":"d,92:20,92:24","dtypep":"(AC)",
                    "fromp": [
-                    {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(UHB)","loc":"d,17:12,17:16","dtypep":"(CJ)","access":"RD","varp":"(DJ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(WHB)","loc":"d,17:12,17:16","dtypep":"(CJ)","access":"RD","varp":"(DJ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ],
                    "bitp": [
-                    {"type":"AND","name":"","addr":"(VHB)","loc":"d,92:20,92:24","dtypep":"(LC)",
+                    {"type":"AND","name":"","addr":"(XHB)","loc":"d,92:20,92:24","dtypep":"(LC)",
                      "lhsp": [
-                      {"type":"CONST","name":"32'h7","addr":"(WHB)","loc":"d,92:20,92:24","dtypep":"(NC)"}
+                      {"type":"CONST","name":"32'h7","addr":"(YHB)","loc":"d,92:20,92:24","dtypep":"(NC)"}
                     ],
                      "rhsp": [
-                      {"type":"CCAST","name":"","addr":"(XHB)","loc":"d,92:18,92:19","dtypep":"(LC)","size":32,
+                      {"type":"CCAST","name":"","addr":"(ZHB)","loc":"d,92:18,92:19","dtypep":"(LC)","size":32,
                        "lhsp": [
-                        {"type":"VARREF","name":"t.e","addr":"(YHB)","loc":"d,92:18,92:19","dtypep":"(LC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                        {"type":"VARREF","name":"t.e","addr":"(AIB)","loc":"d,92:18,92:19","dtypep":"(LC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                       ]}
                     ]}
                   ]}
                 ]}
               ],
                "thensp": [
-                {"type":"DISPLAY","name":"","addr":"(ZHB)","loc":"d,92:43,92:49",
+                {"type":"DISPLAY","name":"","addr":"(BIB)","loc":"d,92:43,92:49",
                  "fmtp": [
-                  {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:92:  got='h%x exp='h3\\n","addr":"(AIB)","loc":"d,92:43,92:49","dtypep":"(RB)",
+                  {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:92:  got='h%x exp='h3\\n","addr":"(CIB)","loc":"d,92:43,92:49","dtypep":"(RB)",
                    "exprsp": [
-                    {"type":"ARRAYSEL","name":"","addr":"(BIB)","loc":"d,92:124,92:128","dtypep":"(AC)",
+                    {"type":"ARRAYSEL","name":"","addr":"(DIB)","loc":"d,92:124,92:128","dtypep":"(AC)",
                      "fromp": [
-                      {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(CIB)","loc":"d,17:12,17:16","dtypep":"(CJ)","access":"RD","varp":"(DJ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(EIB)","loc":"d,17:12,17:16","dtypep":"(CJ)","access":"RD","varp":"(DJ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ],
                      "bitp": [
-                      {"type":"AND","name":"","addr":"(DIB)","loc":"d,92:124,92:128","dtypep":"(LC)",
+                      {"type":"AND","name":"","addr":"(FIB)","loc":"d,92:124,92:128","dtypep":"(LC)",
                        "lhsp": [
-                        {"type":"CONST","name":"32'h7","addr":"(EIB)","loc":"d,92:124,92:128","dtypep":"(NC)"}
+                        {"type":"CONST","name":"32'h7","addr":"(GIB)","loc":"d,92:124,92:128","dtypep":"(NC)"}
                       ],
                        "rhsp": [
-                        {"type":"CCAST","name":"","addr":"(FIB)","loc":"d,92:122,92:123","dtypep":"(LC)","size":32,
+                        {"type":"CCAST","name":"","addr":"(HIB)","loc":"d,92:122,92:123","dtypep":"(LC)","size":32,
                          "lhsp": [
-                          {"type":"VARREF","name":"t.e","addr":"(GIB)","loc":"d,92:122,92:123","dtypep":"(LC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                          {"type":"VARREF","name":"t.e","addr":"(IIB)","loc":"d,92:122,92:123","dtypep":"(LC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                         ]}
                       ]}
                     ]}
                   ],"scopeNamep": []}
                 ],"filep": []},
-                {"type":"STOP","name":"","addr":"(HIB)","loc":"d,92:139,92:144"}
+                {"type":"STOP","name":"","addr":"(JIB)","loc":"d,92:139,92:144"}
               ],"elsesp": []},
-              {"type":"IF","name":"","addr":"(IIB)","loc":"d,93:13,93:15",
+              {"type":"IF","name":"","addr":"(KIB)","loc":"d,93:13,93:15",
                "condp": [
-                {"type":"NEQ","name":"","addr":"(JIB)","loc":"d,93:29,93:32","dtypep":"(NB)",
+                {"type":"NEQ","name":"","addr":"(LIB)","loc":"d,93:29,93:32","dtypep":"(NB)",
                  "lhsp": [
-                  {"type":"CONST","name":"4'h3","addr":"(KIB)","loc":"d,93:34,93:37","dtypep":"(AC)"}
+                  {"type":"CONST","name":"4'h3","addr":"(MIB)","loc":"d,93:34,93:37","dtypep":"(AC)"}
                 ],
                  "rhsp": [
-                  {"type":"ARRAYSEL","name":"","addr":"(LIB)","loc":"d,93:20,93:24","dtypep":"(AC)",
+                  {"type":"ARRAYSEL","name":"","addr":"(NIB)","loc":"d,93:20,93:24","dtypep":"(AC)",
                    "fromp": [
-                    {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(MIB)","loc":"d,17:12,17:16","dtypep":"(CJ)","access":"RD","varp":"(DJ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(OIB)","loc":"d,17:12,17:16","dtypep":"(CJ)","access":"RD","varp":"(DJ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ],
                    "bitp": [
-                    {"type":"AND","name":"","addr":"(NIB)","loc":"d,93:20,93:24","dtypep":"(LC)",
+                    {"type":"AND","name":"","addr":"(PIB)","loc":"d,93:20,93:24","dtypep":"(LC)",
                      "lhsp": [
-                      {"type":"CONST","name":"32'h7","addr":"(OIB)","loc":"d,93:20,93:24","dtypep":"(NC)"}
+                      {"type":"CONST","name":"32'h7","addr":"(QIB)","loc":"d,93:20,93:24","dtypep":"(NC)"}
                     ],
                      "rhsp": [
-                      {"type":"CCAST","name":"","addr":"(PIB)","loc":"d,93:18,93:19","dtypep":"(LC)","size":32,
+                      {"type":"CCAST","name":"","addr":"(RIB)","loc":"d,93:18,93:19","dtypep":"(LC)","size":32,
                        "lhsp": [
-                        {"type":"VARREF","name":"t.e","addr":"(QIB)","loc":"d,93:18,93:19","dtypep":"(LC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                        {"type":"VARREF","name":"t.e","addr":"(SIB)","loc":"d,93:18,93:19","dtypep":"(LC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                       ]}
                     ]}
                   ]}
                 ]}
               ],
                "thensp": [
-                {"type":"DISPLAY","name":"","addr":"(RIB)","loc":"d,93:46,93:52",
+                {"type":"DISPLAY","name":"","addr":"(TIB)","loc":"d,93:46,93:52",
                  "fmtp": [
-                  {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:93:  got='h%x exp='h3\\n","addr":"(SIB)","loc":"d,93:46,93:52","dtypep":"(RB)",
+                  {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:93:  got='h%x exp='h3\\n","addr":"(UIB)","loc":"d,93:46,93:52","dtypep":"(RB)",
                    "exprsp": [
-                    {"type":"ARRAYSEL","name":"","addr":"(TIB)","loc":"d,93:127,93:131","dtypep":"(AC)",
+                    {"type":"ARRAYSEL","name":"","addr":"(VIB)","loc":"d,93:127,93:131","dtypep":"(AC)",
                      "fromp": [
-                      {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(UIB)","loc":"d,17:12,17:16","dtypep":"(CJ)","access":"RD","varp":"(DJ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(WIB)","loc":"d,17:12,17:16","dtypep":"(CJ)","access":"RD","varp":"(DJ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ],
                      "bitp": [
-                      {"type":"AND","name":"","addr":"(VIB)","loc":"d,93:127,93:131","dtypep":"(LC)",
+                      {"type":"AND","name":"","addr":"(XIB)","loc":"d,93:127,93:131","dtypep":"(LC)",
                        "lhsp": [
-                        {"type":"CONST","name":"32'h7","addr":"(WIB)","loc":"d,93:127,93:131","dtypep":"(NC)"}
+                        {"type":"CONST","name":"32'h7","addr":"(YIB)","loc":"d,93:127,93:131","dtypep":"(NC)"}
                       ],
                        "rhsp": [
-                        {"type":"CCAST","name":"","addr":"(XIB)","loc":"d,93:125,93:126","dtypep":"(LC)","size":32,
+                        {"type":"CCAST","name":"","addr":"(ZIB)","loc":"d,93:125,93:126","dtypep":"(LC)","size":32,
                          "lhsp": [
-                          {"type":"VARREF","name":"t.e","addr":"(YIB)","loc":"d,93:125,93:126","dtypep":"(LC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                          {"type":"VARREF","name":"t.e","addr":"(AJB)","loc":"d,93:125,93:126","dtypep":"(LC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                         ]}
                       ]}
                     ]}
                   ],"scopeNamep": []}
                 ],"filep": []},
-                {"type":"STOP","name":"","addr":"(ZIB)","loc":"d,93:145,93:150"}
+                {"type":"STOP","name":"","addr":"(BJB)","loc":"d,93:145,93:150"}
               ],"elsesp": []},
-              {"type":"IF","name":"","addr":"(AJB)","loc":"d,94:13,94:15",
+              {"type":"IF","name":"","addr":"(CJB)","loc":"d,94:13,94:15",
                "condp": [
-                {"type":"NEQ","name":"","addr":"(BJB)","loc":"d,94:29,94:32","dtypep":"(NB)",
+                {"type":"NEQ","name":"","addr":"(DJB)","loc":"d,94:29,94:32","dtypep":"(NB)",
                  "lhsp": [
-                  {"type":"CONST","name":"4'h1","addr":"(CJB)","loc":"d,94:34,94:37","dtypep":"(AC)"}
+                  {"type":"CONST","name":"4'h1","addr":"(EJB)","loc":"d,94:34,94:37","dtypep":"(AC)"}
                 ],
                  "rhsp": [
-                  {"type":"ARRAYSEL","name":"","addr":"(DJB)","loc":"d,94:20,94:24","dtypep":"(AC)",
+                  {"type":"ARRAYSEL","name":"","addr":"(FJB)","loc":"d,94:20,94:24","dtypep":"(AC)",
                    "fromp": [
-                    {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(EJB)","loc":"d,17:12,17:16","dtypep":"(CJ)","access":"RD","varp":"(DJ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(GJB)","loc":"d,17:12,17:16","dtypep":"(CJ)","access":"RD","varp":"(DJ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ],
                    "bitp": [
-                    {"type":"AND","name":"","addr":"(FJB)","loc":"d,94:20,94:24","dtypep":"(LC)",
+                    {"type":"AND","name":"","addr":"(HJB)","loc":"d,94:20,94:24","dtypep":"(LC)",
                      "lhsp": [
-                      {"type":"CONST","name":"32'h7","addr":"(GJB)","loc":"d,94:20,94:24","dtypep":"(NC)"}
+                      {"type":"CONST","name":"32'h7","addr":"(IJB)","loc":"d,94:20,94:24","dtypep":"(NC)"}
                     ],
                      "rhsp": [
-                      {"type":"ARRAYSEL","name":"","addr":"(HJB)","loc":"d,94:20,94:24","dtypep":"(LC)",
+                      {"type":"ARRAYSEL","name":"","addr":"(JJB)","loc":"d,94:20,94:24","dtypep":"(LC)",
                        "fromp": [
-                        {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(IJB)","loc":"d,17:12,17:16","dtypep":"(CJ)","access":"RD","varp":"(DJ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                        {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(KJB)","loc":"d,17:12,17:16","dtypep":"(CJ)","access":"RD","varp":"(DJ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                       ],
                        "bitp": [
-                        {"type":"AND","name":"","addr":"(JJB)","loc":"d,94:20,94:24","dtypep":"(LC)",
+                        {"type":"AND","name":"","addr":"(LJB)","loc":"d,94:20,94:24","dtypep":"(LC)",
                          "lhsp": [
-                          {"type":"CONST","name":"32'h7","addr":"(KJB)","loc":"d,94:20,94:24","dtypep":"(NC)"}
+                          {"type":"CONST","name":"32'h7","addr":"(MJB)","loc":"d,94:20,94:24","dtypep":"(NC)"}
                         ],
                          "rhsp": [
-                          {"type":"CCAST","name":"","addr":"(LJB)","loc":"d,94:18,94:19","dtypep":"(LC)","size":32,
+                          {"type":"CCAST","name":"","addr":"(NJB)","loc":"d,94:18,94:19","dtypep":"(LC)","size":32,
                            "lhsp": [
-                            {"type":"VARREF","name":"t.e","addr":"(MJB)","loc":"d,94:18,94:19","dtypep":"(LC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                            {"type":"VARREF","name":"t.e","addr":"(OJB)","loc":"d,94:18,94:19","dtypep":"(LC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                           ]}
                         ]}
                       ]}
@@ -2444,33 +2450,33 @@
                 ]}
               ],
                "thensp": [
-                {"type":"DISPLAY","name":"","addr":"(NJB)","loc":"d,94:46,94:52",
+                {"type":"DISPLAY","name":"","addr":"(PJB)","loc":"d,94:46,94:52",
                  "fmtp": [
-                  {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:94:  got='h%x exp='h1\\n","addr":"(OJB)","loc":"d,94:46,94:52","dtypep":"(RB)",
+                  {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:94:  got='h%x exp='h1\\n","addr":"(QJB)","loc":"d,94:46,94:52","dtypep":"(RB)",
                    "exprsp": [
-                    {"type":"ARRAYSEL","name":"","addr":"(PJB)","loc":"d,94:127,94:131","dtypep":"(AC)",
+                    {"type":"ARRAYSEL","name":"","addr":"(RJB)","loc":"d,94:127,94:131","dtypep":"(AC)",
                      "fromp": [
-                      {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(QJB)","loc":"d,17:12,17:16","dtypep":"(CJ)","access":"RD","varp":"(DJ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(SJB)","loc":"d,17:12,17:16","dtypep":"(CJ)","access":"RD","varp":"(DJ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ],
                      "bitp": [
-                      {"type":"AND","name":"","addr":"(RJB)","loc":"d,94:127,94:131","dtypep":"(LC)",
+                      {"type":"AND","name":"","addr":"(TJB)","loc":"d,94:127,94:131","dtypep":"(LC)",
                        "lhsp": [
-                        {"type":"CONST","name":"32'h7","addr":"(SJB)","loc":"d,94:127,94:131","dtypep":"(NC)"}
+                        {"type":"CONST","name":"32'h7","addr":"(UJB)","loc":"d,94:127,94:131","dtypep":"(NC)"}
                       ],
                        "rhsp": [
-                        {"type":"ARRAYSEL","name":"","addr":"(TJB)","loc":"d,94:127,94:131","dtypep":"(LC)",
+                        {"type":"ARRAYSEL","name":"","addr":"(VJB)","loc":"d,94:127,94:131","dtypep":"(LC)",
                          "fromp": [
-                          {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(UJB)","loc":"d,17:12,17:16","dtypep":"(CJ)","access":"RD","varp":"(DJ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                          {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(WJB)","loc":"d,17:12,17:16","dtypep":"(CJ)","access":"RD","varp":"(DJ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                         ],
                          "bitp": [
-                          {"type":"AND","name":"","addr":"(VJB)","loc":"d,94:127,94:131","dtypep":"(LC)",
+                          {"type":"AND","name":"","addr":"(XJB)","loc":"d,94:127,94:131","dtypep":"(LC)",
                            "lhsp": [
-                            {"type":"CONST","name":"32'h7","addr":"(WJB)","loc":"d,94:127,94:131","dtypep":"(NC)"}
+                            {"type":"CONST","name":"32'h7","addr":"(YJB)","loc":"d,94:127,94:131","dtypep":"(NC)"}
                           ],
                            "rhsp": [
-                            {"type":"CCAST","name":"","addr":"(XJB)","loc":"d,94:125,94:126","dtypep":"(LC)","size":32,
+                            {"type":"CCAST","name":"","addr":"(ZJB)","loc":"d,94:125,94:126","dtypep":"(LC)","size":32,
                              "lhsp": [
-                              {"type":"VARREF","name":"t.e","addr":"(YJB)","loc":"d,94:125,94:126","dtypep":"(LC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                              {"type":"VARREF","name":"t.e","addr":"(AKB)","loc":"d,94:125,94:126","dtypep":"(LC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                             ]}
                           ]}
                         ]}
@@ -2478,521 +2484,521 @@
                     ]}
                   ],"scopeNamep": []}
                 ],"filep": []},
-                {"type":"STOP","name":"","addr":"(ZJB)","loc":"d,94:145,94:150"}
+                {"type":"STOP","name":"","addr":"(BKB)","loc":"d,94:145,94:150"}
               ],"elsesp": []},
-              {"type":"ASSIGNDLY","name":"","addr":"(AKB)","loc":"d,95:12,95:14","dtypep":"(AC)",
+              {"type":"ASSIGNDLY","name":"","addr":"(CKB)","loc":"d,95:12,95:14","dtypep":"(AC)",
                "rhsp": [
-                {"type":"CONST","name":"4'h1","addr":"(BKB)","loc":"d,95:15,95:18","dtypep":"(AC)"}
+                {"type":"CONST","name":"4'h1","addr":"(DKB)","loc":"d,95:15,95:18","dtypep":"(AC)"}
               ],
                "lhsp": [
-                {"type":"VARREF","name":"__Vdly__t.e","addr":"(CKB)","loc":"d,95:10,95:11","dtypep":"(AC)","access":"WR","varp":"(QR)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                {"type":"VARREF","name":"__Vdly__t.e","addr":"(EKB)","loc":"d,95:10,95:11","dtypep":"(AC)","access":"WR","varp":"(SR)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
               ],"timingControlp": []}
             ],
              "elsesp": [
-              {"type":"IF","name":"","addr":"(DKB)","loc":"d,97:12,97:14",
+              {"type":"IF","name":"","addr":"(FKB)","loc":"d,97:12,97:14",
                "condp": [
-                {"type":"EQ","name":"","addr":"(EKB)","loc":"d,97:19,97:21","dtypep":"(NB)",
+                {"type":"EQ","name":"","addr":"(GKB)","loc":"d,97:19,97:21","dtypep":"(NB)",
                  "lhsp": [
-                  {"type":"CONST","name":"32'sh63","addr":"(FKB)","loc":"d,97:21,97:23","dtypep":"(GB)"}
+                  {"type":"CONST","name":"32'sh63","addr":"(HKB)","loc":"d,97:21,97:23","dtypep":"(GB)"}
                 ],
                  "rhsp": [
-                  {"type":"VARREF","name":"t.cyc","addr":"(GKB)","loc":"d,97:16,97:19","dtypep":"(R)","access":"RD","varp":"(Q)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"t.cyc","addr":"(IKB)","loc":"d,97:16,97:19","dtypep":"(R)","access":"RD","varp":"(Q)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                 ]}
               ],
                "thensp": [
-                {"type":"DISPLAY","name":"","addr":"(HKB)","loc":"d,98:10,98:16",
+                {"type":"DISPLAY","name":"","addr":"(JKB)","loc":"d,98:10,98:16",
                  "fmtp": [
-                  {"type":"SFORMATF","name":"*-* All Finished *-*\\n","addr":"(IKB)","loc":"d,98:10,98:16","dtypep":"(RB)","exprsp": [],"scopeNamep": []}
+                  {"type":"SFORMATF","name":"*-* All Finished *-*\\n","addr":"(KKB)","loc":"d,98:10,98:16","dtypep":"(RB)","exprsp": [],"scopeNamep": []}
                 ],"filep": []},
-                {"type":"FINISH","name":"","addr":"(JKB)","loc":"d,99:10,99:17"}
+                {"type":"FINISH","name":"","addr":"(LKB)","loc":"d,99:10,99:17"}
               ],"elsesp": []}
             ]}
           ]}
         ]}
       ]},
-      {"type":"ASSIGNPOST","name":"","addr":"(KKB)","loc":"d,62:7,62:10","dtypep":"(R)",
+      {"type":"ASSIGNPOST","name":"","addr":"(MKB)","loc":"d,62:7,62:10","dtypep":"(R)",
        "rhsp": [
-        {"type":"VARREF","name":"__Vdly__t.cyc","addr":"(LKB)","loc":"d,62:7,62:10","dtypep":"(R)","access":"RD","varp":"(NR)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"__Vdly__t.cyc","addr":"(NKB)","loc":"d,62:7,62:10","dtypep":"(R)","access":"RD","varp":"(PR)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"t.cyc","addr":"(MKB)","loc":"d,62:7,62:10","dtypep":"(R)","access":"WR","varp":"(Q)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"t.cyc","addr":"(OKB)","loc":"d,62:7,62:10","dtypep":"(R)","access":"WR","varp":"(Q)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []},
-      {"type":"ASSIGNPOST","name":"","addr":"(NKB)","loc":"d,65:10,65:11","dtypep":"(AC)",
+      {"type":"ASSIGNPOST","name":"","addr":"(PKB)","loc":"d,65:10,65:11","dtypep":"(AC)",
        "rhsp": [
-        {"type":"VARREF","name":"__Vdly__t.e","addr":"(OKB)","loc":"d,65:10,65:11","dtypep":"(AC)","access":"RD","varp":"(QR)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"__Vdly__t.e","addr":"(QKB)","loc":"d,65:10,65:11","dtypep":"(AC)","access":"RD","varp":"(SR)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"t.e","addr":"(PKB)","loc":"d,65:10,65:11","dtypep":"(AC)","access":"WR","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"t.e","addr":"(RKB)","loc":"d,65:10,65:11","dtypep":"(AC)","access":"WR","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []}
     ],"finalsp": []},
-    {"type":"CFUNC","name":"_eval_phase__act","addr":"(QKB)","loc":"a,0:0,0:0","slow":false,"isStatic":false,"dpiExportDispatcher":false,"dpiExportImpl":false,"dpiImportPrototype":false,"dpiImportWrapper":false,"dpiContext":false,"isConstructor":false,"isDestructor":false,"isVirtual":false,"isCoroutine":false,"needProcess":false,"scopep":"(Y)","argsp": [],
+    {"type":"CFUNC","name":"_eval_phase__act","addr":"(SKB)","loc":"a,0:0,0:0","slow":false,"isStatic":false,"dpiExportDispatcher":false,"dpiExportImpl":false,"dpiImportPrototype":false,"dpiImportWrapper":false,"dpiContext":false,"isConstructor":false,"isDestructor":false,"isVirtual":false,"isCoroutine":false,"needProcess":false,"scopep":"(Y)","argsp": [],
      "initsp": [
-      {"type":"VAR","name":"__VpreTriggered","addr":"(RKB)","loc":"d,11:8,11:9","dtypep":"(V)","origName":"__VpreTriggered","isSc":false,"isPrimaryIO":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":true,"attrClocker":"UNKNOWN","lifetime":"NONE","varType":"MODULETEMP","dtypeName":"VlTriggerVec","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
-      {"type":"VAR","name":"__VactExecute","addr":"(SKB)","loc":"d,11:8,11:9","dtypep":"(P)","origName":"__VactExecute","isSc":false,"isPrimaryIO":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":true,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":true,"attrClocker":"UNKNOWN","lifetime":"NONE","varType":"MODULETEMP","dtypeName":"bit","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []}
+      {"type":"VAR","name":"__VpreTriggered","addr":"(TKB)","loc":"d,11:8,11:9","dtypep":"(V)","origName":"__VpreTriggered","isSc":false,"isPrimaryIO":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":true,"attrClocker":"UNKNOWN","lifetime":"NONE","varType":"MODULETEMP","dtypeName":"VlTriggerVec","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
+      {"type":"VAR","name":"__VactExecute","addr":"(UKB)","loc":"d,11:8,11:9","dtypep":"(P)","origName":"__VactExecute","isSc":false,"isPrimaryIO":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":true,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":true,"attrClocker":"UNKNOWN","lifetime":"NONE","varType":"MODULETEMP","dtypeName":"bit","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []}
     ],
      "stmtsp": [
-      {"type":"STMTEXPR","name":"","addr":"(TKB)","loc":"a,0:0,0:0",
+      {"type":"STMTEXPR","name":"","addr":"(VKB)","loc":"a,0:0,0:0",
        "exprp": [
-        {"type":"CCALL","name":"","addr":"(UKB)","loc":"a,0:0,0:0","dtypep":"(CB)","funcName":"_eval_triggers__act","funcp":"(CP)","argsp": []}
+        {"type":"CCALL","name":"","addr":"(WKB)","loc":"a,0:0,0:0","dtypep":"(CB)","funcName":"_eval_triggers__act","funcp":"(EP)","argsp": []}
       ]},
-      {"type":"ASSIGN","name":"","addr":"(VKB)","loc":"a,0:0,0:0","dtypep":"(NB)",
+      {"type":"ASSIGN","name":"","addr":"(XKB)","loc":"a,0:0,0:0","dtypep":"(NB)",
        "rhsp": [
-        {"type":"CMETHODHARD","name":"any","addr":"(WKB)","loc":"a,0:0,0:0","dtypep":"(NB)",
+        {"type":"CMETHODHARD","name":"any","addr":"(YKB)","loc":"a,0:0,0:0","dtypep":"(NB)",
          "fromp": [
-          {"type":"VARREF","name":"__VactTriggered","addr":"(XKB)","loc":"a,0:0,0:0","dtypep":"(NB)","access":"RD","varp":"(U)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+          {"type":"VARREF","name":"__VactTriggered","addr":"(ZKB)","loc":"a,0:0,0:0","dtypep":"(NB)","access":"RD","varp":"(U)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
         ],"pinsp": []}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"__VactExecute","addr":"(YKB)","loc":"a,0:0,0:0","dtypep":"(NB)","access":"WR","varp":"(SKB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"__VactExecute","addr":"(ALB)","loc":"a,0:0,0:0","dtypep":"(NB)","access":"WR","varp":"(UKB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []},
-      {"type":"IF","name":"","addr":"(ZKB)","loc":"a,0:0,0:0",
+      {"type":"IF","name":"","addr":"(BLB)","loc":"a,0:0,0:0",
        "condp": [
-        {"type":"VARREF","name":"__VactExecute","addr":"(ALB)","loc":"a,0:0,0:0","dtypep":"(NB)","access":"RD","varp":"(SKB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"__VactExecute","addr":"(CLB)","loc":"a,0:0,0:0","dtypep":"(NB)","access":"RD","varp":"(UKB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],
        "thensp": [
-        {"type":"STMTEXPR","name":"","addr":"(BLB)","loc":"a,0:0,0:0",
+        {"type":"STMTEXPR","name":"","addr":"(DLB)","loc":"a,0:0,0:0",
          "exprp": [
-          {"type":"CMETHODHARD","name":"andNot","addr":"(CLB)","loc":"a,0:0,0:0","dtypep":"(CB)",
+          {"type":"CMETHODHARD","name":"andNot","addr":"(ELB)","loc":"a,0:0,0:0","dtypep":"(CB)",
            "fromp": [
-            {"type":"VARREF","name":"__VpreTriggered","addr":"(DLB)","loc":"a,0:0,0:0","dtypep":"(NB)","access":"WR","varp":"(RKB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"__VpreTriggered","addr":"(FLB)","loc":"a,0:0,0:0","dtypep":"(NB)","access":"WR","varp":"(TKB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ],
            "pinsp": [
-            {"type":"VARREF","name":"__VactTriggered","addr":"(ELB)","loc":"a,0:0,0:0","dtypep":"(NB)","access":"RD","varp":"(U)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"},
-            {"type":"VARREF","name":"__VnbaTriggered","addr":"(FLB)","loc":"a,0:0,0:0","dtypep":"(NB)","access":"RD","varp":"(W)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"__VactTriggered","addr":"(GLB)","loc":"a,0:0,0:0","dtypep":"(NB)","access":"RD","varp":"(U)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"},
+            {"type":"VARREF","name":"__VnbaTriggered","addr":"(HLB)","loc":"a,0:0,0:0","dtypep":"(NB)","access":"RD","varp":"(W)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ]}
         ]},
-        {"type":"STMTEXPR","name":"","addr":"(GLB)","loc":"a,0:0,0:0",
+        {"type":"STMTEXPR","name":"","addr":"(ILB)","loc":"a,0:0,0:0",
          "exprp": [
-          {"type":"CMETHODHARD","name":"thisOr","addr":"(HLB)","loc":"a,0:0,0:0","dtypep":"(CB)",
+          {"type":"CMETHODHARD","name":"thisOr","addr":"(JLB)","loc":"a,0:0,0:0","dtypep":"(CB)",
            "fromp": [
-            {"type":"VARREF","name":"__VnbaTriggered","addr":"(ILB)","loc":"a,0:0,0:0","dtypep":"(NB)","access":"WR","varp":"(W)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"__VnbaTriggered","addr":"(KLB)","loc":"a,0:0,0:0","dtypep":"(NB)","access":"WR","varp":"(W)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ],
            "pinsp": [
-            {"type":"VARREF","name":"__VactTriggered","addr":"(JLB)","loc":"a,0:0,0:0","dtypep":"(NB)","access":"RD","varp":"(U)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"__VactTriggered","addr":"(LLB)","loc":"a,0:0,0:0","dtypep":"(NB)","access":"RD","varp":"(U)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ]}
         ]},
-        {"type":"STMTEXPR","name":"","addr":"(KLB)","loc":"a,0:0,0:0",
+        {"type":"STMTEXPR","name":"","addr":"(MLB)","loc":"a,0:0,0:0",
          "exprp": [
-          {"type":"CCALL","name":"","addr":"(LLB)","loc":"a,0:0,0:0","dtypep":"(CB)","funcName":"_eval_act","funcp":"(DR)","argsp": []}
+          {"type":"CCALL","name":"","addr":"(NLB)","loc":"a,0:0,0:0","dtypep":"(CB)","funcName":"_eval_act","funcp":"(FR)","argsp": []}
         ]}
       ],"elsesp": []},
-      {"type":"CRETURN","name":"","addr":"(MLB)","loc":"a,0:0,0:0",
+      {"type":"CRETURN","name":"","addr":"(OLB)","loc":"a,0:0,0:0",
        "lhsp": [
-        {"type":"VARREF","name":"__VactExecute","addr":"(NLB)","loc":"a,0:0,0:0","dtypep":"(NB)","access":"RD","varp":"(SKB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"__VactExecute","addr":"(PLB)","loc":"a,0:0,0:0","dtypep":"(NB)","access":"RD","varp":"(UKB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ]}
     ],"finalsp": []},
-    {"type":"CFUNC","name":"_eval_phase__nba","addr":"(OLB)","loc":"a,0:0,0:0","slow":false,"isStatic":false,"dpiExportDispatcher":false,"dpiExportImpl":false,"dpiImportPrototype":false,"dpiImportWrapper":false,"dpiContext":false,"isConstructor":false,"isDestructor":false,"isVirtual":false,"isCoroutine":false,"needProcess":false,"scopep":"(Y)","argsp": [],
+    {"type":"CFUNC","name":"_eval_phase__nba","addr":"(QLB)","loc":"a,0:0,0:0","slow":false,"isStatic":false,"dpiExportDispatcher":false,"dpiExportImpl":false,"dpiImportPrototype":false,"dpiImportWrapper":false,"dpiContext":false,"isConstructor":false,"isDestructor":false,"isVirtual":false,"isCoroutine":false,"needProcess":false,"scopep":"(Y)","argsp": [],
      "initsp": [
-      {"type":"VAR","name":"__VnbaExecute","addr":"(PLB)","loc":"d,11:8,11:9","dtypep":"(P)","origName":"__VnbaExecute","isSc":false,"isPrimaryIO":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":true,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":true,"attrClocker":"UNKNOWN","lifetime":"NONE","varType":"MODULETEMP","dtypeName":"bit","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []}
+      {"type":"VAR","name":"__VnbaExecute","addr":"(RLB)","loc":"d,11:8,11:9","dtypep":"(P)","origName":"__VnbaExecute","isSc":false,"isPrimaryIO":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":true,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":true,"attrClocker":"UNKNOWN","lifetime":"NONE","varType":"MODULETEMP","dtypeName":"bit","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []}
     ],
      "stmtsp": [
-      {"type":"ASSIGN","name":"","addr":"(QLB)","loc":"a,0:0,0:0","dtypep":"(NB)",
+      {"type":"ASSIGN","name":"","addr":"(SLB)","loc":"a,0:0,0:0","dtypep":"(NB)",
        "rhsp": [
-        {"type":"CMETHODHARD","name":"any","addr":"(RLB)","loc":"a,0:0,0:0","dtypep":"(NB)",
+        {"type":"CMETHODHARD","name":"any","addr":"(TLB)","loc":"a,0:0,0:0","dtypep":"(NB)",
          "fromp": [
-          {"type":"VARREF","name":"__VnbaTriggered","addr":"(SLB)","loc":"a,0:0,0:0","dtypep":"(NB)","access":"RD","varp":"(W)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+          {"type":"VARREF","name":"__VnbaTriggered","addr":"(ULB)","loc":"a,0:0,0:0","dtypep":"(NB)","access":"RD","varp":"(W)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
         ],"pinsp": []}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"__VnbaExecute","addr":"(TLB)","loc":"a,0:0,0:0","dtypep":"(NB)","access":"WR","varp":"(PLB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"__VnbaExecute","addr":"(VLB)","loc":"a,0:0,0:0","dtypep":"(NB)","access":"WR","varp":"(RLB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []},
-      {"type":"IF","name":"","addr":"(ULB)","loc":"a,0:0,0:0",
+      {"type":"IF","name":"","addr":"(WLB)","loc":"a,0:0,0:0",
        "condp": [
-        {"type":"VARREF","name":"__VnbaExecute","addr":"(VLB)","loc":"a,0:0,0:0","dtypep":"(NB)","access":"RD","varp":"(PLB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"__VnbaExecute","addr":"(XLB)","loc":"a,0:0,0:0","dtypep":"(NB)","access":"RD","varp":"(RLB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],
        "thensp": [
-        {"type":"STMTEXPR","name":"","addr":"(WLB)","loc":"a,0:0,0:0",
-         "exprp": [
-          {"type":"CCALL","name":"","addr":"(XLB)","loc":"a,0:0,0:0","dtypep":"(CB)","funcName":"_eval_nba","funcp":"(G)","argsp": []}
-        ]},
         {"type":"STMTEXPR","name":"","addr":"(YLB)","loc":"a,0:0,0:0",
          "exprp": [
-          {"type":"CMETHODHARD","name":"clear","addr":"(ZLB)","loc":"a,0:0,0:0","dtypep":"(CB)",
+          {"type":"CCALL","name":"","addr":"(ZLB)","loc":"a,0:0,0:0","dtypep":"(CB)","funcName":"_eval_nba","funcp":"(G)","argsp": []}
+        ]},
+        {"type":"STMTEXPR","name":"","addr":"(AMB)","loc":"a,0:0,0:0",
+         "exprp": [
+          {"type":"CMETHODHARD","name":"clear","addr":"(BMB)","loc":"a,0:0,0:0","dtypep":"(CB)",
            "fromp": [
-            {"type":"VARREF","name":"__VnbaTriggered","addr":"(AMB)","loc":"a,0:0,0:0","dtypep":"(NB)","access":"WR","varp":"(W)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"__VnbaTriggered","addr":"(CMB)","loc":"a,0:0,0:0","dtypep":"(NB)","access":"WR","varp":"(W)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ],"pinsp": []}
         ]}
       ],"elsesp": []},
-      {"type":"CRETURN","name":"","addr":"(BMB)","loc":"a,0:0,0:0",
+      {"type":"CRETURN","name":"","addr":"(DMB)","loc":"a,0:0,0:0",
        "lhsp": [
-        {"type":"VARREF","name":"__VnbaExecute","addr":"(CMB)","loc":"a,0:0,0:0","dtypep":"(NB)","access":"RD","varp":"(PLB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"__VnbaExecute","addr":"(EMB)","loc":"a,0:0,0:0","dtypep":"(NB)","access":"RD","varp":"(RLB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ]}
     ],"finalsp": []},
     {"type":"CFUNC","name":"_eval","addr":"(F)","loc":"a,0:0,0:0","slow":false,"isStatic":false,"dpiExportDispatcher":false,"dpiExportImpl":false,"dpiImportPrototype":false,"dpiImportWrapper":false,"dpiContext":false,"isConstructor":false,"isDestructor":false,"isVirtual":false,"isCoroutine":false,"needProcess":false,"scopep":"(Y)","argsp": [],
      "initsp": [
-      {"type":"VAR","name":"__VnbaIterCount","addr":"(DMB)","loc":"d,11:8,11:9","dtypep":"(T)","origName":"__VnbaIterCount","isSc":false,"isPrimaryIO":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":true,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":true,"attrClocker":"UNKNOWN","lifetime":"NONE","varType":"MODULETEMP","dtypeName":"bit","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
-      {"type":"VAR","name":"__VnbaContinue","addr":"(EMB)","loc":"d,11:8,11:9","dtypep":"(P)","origName":"__VnbaContinue","isSc":false,"isPrimaryIO":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":true,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":true,"attrClocker":"UNKNOWN","lifetime":"NONE","varType":"MODULETEMP","dtypeName":"bit","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []}
+      {"type":"VAR","name":"__VnbaIterCount","addr":"(FMB)","loc":"d,11:8,11:9","dtypep":"(T)","origName":"__VnbaIterCount","isSc":false,"isPrimaryIO":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":true,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":true,"attrClocker":"UNKNOWN","lifetime":"NONE","varType":"MODULETEMP","dtypeName":"bit","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
+      {"type":"VAR","name":"__VnbaContinue","addr":"(GMB)","loc":"d,11:8,11:9","dtypep":"(P)","origName":"__VnbaContinue","isSc":false,"isPrimaryIO":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":true,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":true,"attrClocker":"UNKNOWN","lifetime":"NONE","varType":"MODULETEMP","dtypeName":"bit","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []}
     ],
      "stmtsp": [
-      {"type":"ASSIGN","name":"","addr":"(FMB)","loc":"d,11:8,11:9","dtypep":"(T)",
+      {"type":"ASSIGN","name":"","addr":"(HMB)","loc":"d,11:8,11:9","dtypep":"(T)",
        "rhsp": [
-        {"type":"CONST","name":"32'h0","addr":"(GMB)","loc":"d,11:8,11:9","dtypep":"(NC)"}
+        {"type":"CONST","name":"32'h0","addr":"(IMB)","loc":"d,11:8,11:9","dtypep":"(NC)"}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"__VnbaIterCount","addr":"(HMB)","loc":"d,11:8,11:9","dtypep":"(T)","access":"WR","varp":"(DMB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"__VnbaIterCount","addr":"(JMB)","loc":"d,11:8,11:9","dtypep":"(T)","access":"WR","varp":"(FMB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []},
-      {"type":"ASSIGN","name":"","addr":"(IMB)","loc":"d,11:8,11:9","dtypep":"(NB)",
+      {"type":"ASSIGN","name":"","addr":"(KMB)","loc":"d,11:8,11:9","dtypep":"(NB)",
        "rhsp": [
-        {"type":"CONST","name":"1'h1","addr":"(JMB)","loc":"d,11:8,11:9","dtypep":"(NB)"}
+        {"type":"CONST","name":"1'h1","addr":"(LMB)","loc":"d,11:8,11:9","dtypep":"(NB)"}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"__VnbaContinue","addr":"(KMB)","loc":"d,11:8,11:9","dtypep":"(NB)","access":"WR","varp":"(EMB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"__VnbaContinue","addr":"(MMB)","loc":"d,11:8,11:9","dtypep":"(NB)","access":"WR","varp":"(GMB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []},
-      {"type":"WHILE","name":"","addr":"(LMB)","loc":"a,0:0,0:0","precondsp": [],
+      {"type":"WHILE","name":"","addr":"(NMB)","loc":"a,0:0,0:0","precondsp": [],
        "condp": [
-        {"type":"VARREF","name":"__VnbaContinue","addr":"(MMB)","loc":"a,0:0,0:0","dtypep":"(NB)","access":"RD","varp":"(EMB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"__VnbaContinue","addr":"(OMB)","loc":"a,0:0,0:0","dtypep":"(NB)","access":"RD","varp":"(GMB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],
        "stmtsp": [
-        {"type":"IF","name":"","addr":"(NMB)","loc":"a,0:0,0:0",
+        {"type":"IF","name":"","addr":"(PMB)","loc":"a,0:0,0:0",
          "condp": [
-          {"type":"LT","name":"","addr":"(OMB)","loc":"a,0:0,0:0","dtypep":"(NB)",
+          {"type":"LT","name":"","addr":"(QMB)","loc":"a,0:0,0:0","dtypep":"(NB)",
            "lhsp": [
-            {"type":"CONST","name":"32'h64","addr":"(PMB)","loc":"a,0:0,0:0","dtypep":"(NC)"}
+            {"type":"CONST","name":"32'h64","addr":"(RMB)","loc":"a,0:0,0:0","dtypep":"(NC)"}
           ],
            "rhsp": [
-            {"type":"VARREF","name":"__VnbaIterCount","addr":"(QMB)","loc":"a,0:0,0:0","dtypep":"(T)","access":"RD","varp":"(DMB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"__VnbaIterCount","addr":"(SMB)","loc":"a,0:0,0:0","dtypep":"(T)","access":"RD","varp":"(FMB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ]}
         ],
          "thensp": [
-          {"type":"TEXTBLOCK","name":"","addr":"(RMB)","loc":"a,0:0,0:0","shortText":"",
+          {"type":"TEXTBLOCK","name":"","addr":"(TMB)","loc":"a,0:0,0:0","shortText":"",
            "nodesp": [
-            {"type":"TEXT","name":"","addr":"(SMB)","loc":"a,0:0,0:0","shortText":"#ifdef VL_DEBUG..."},
-            {"type":"STMTEXPR","name":"","addr":"(TMB)","loc":"a,0:0,0:0",
+            {"type":"TEXT","name":"","addr":"(UMB)","loc":"a,0:0,0:0","shortText":"#ifdef VL_DEBUG..."},
+            {"type":"STMTEXPR","name":"","addr":"(VMB)","loc":"a,0:0,0:0",
              "exprp": [
-              {"type":"CCALL","name":"","addr":"(UMB)","loc":"a,0:0,0:0","dtypep":"(CB)","funcName":"_dump_triggers__nba","funcp":"(OQ)","argsp": []}
+              {"type":"CCALL","name":"","addr":"(WMB)","loc":"a,0:0,0:0","dtypep":"(CB)","funcName":"_dump_triggers__nba","funcp":"(QQ)","argsp": []}
             ]},
-            {"type":"TEXT","name":"","addr":"(VMB)","loc":"a,0:0,0:0","shortText":"#endif..."},
-            {"type":"TEXT","name":"","addr":"(WMB)","loc":"a,0:0,0:0","shortText":"VL_FATAL_MT(\"t/t_enum_type_methods.v\", 11, \"\", "},
-            {"type":"TEXT","name":"","addr":"(XMB)","loc":"a,0:0,0:0","shortText":"\"NBA region did not converge.\");..."}
+            {"type":"TEXT","name":"","addr":"(XMB)","loc":"a,0:0,0:0","shortText":"#endif..."},
+            {"type":"TEXT","name":"","addr":"(YMB)","loc":"a,0:0,0:0","shortText":"VL_FATAL_MT(\"t/t_enum_type_methods.v\", 11, \"\", "},
+            {"type":"TEXT","name":"","addr":"(ZMB)","loc":"a,0:0,0:0","shortText":"\"NBA region did not converge.\");..."}
           ]}
         ],"elsesp": []},
-        {"type":"ASSIGN","name":"","addr":"(YMB)","loc":"d,11:8,11:9","dtypep":"(T)",
+        {"type":"ASSIGN","name":"","addr":"(ANB)","loc":"d,11:8,11:9","dtypep":"(T)",
          "rhsp": [
-          {"type":"ADD","name":"","addr":"(ZMB)","loc":"d,11:8,11:9","dtypep":"(T)",
+          {"type":"ADD","name":"","addr":"(BNB)","loc":"d,11:8,11:9","dtypep":"(T)",
            "lhsp": [
-            {"type":"CCAST","name":"","addr":"(ANB)","loc":"d,11:8,11:9","dtypep":"(NC)","size":32,
+            {"type":"CCAST","name":"","addr":"(CNB)","loc":"d,11:8,11:9","dtypep":"(NC)","size":32,
              "lhsp": [
-              {"type":"CONST","name":"32'h1","addr":"(BNB)","loc":"d,11:8,11:9","dtypep":"(NC)"}
+              {"type":"CONST","name":"32'h1","addr":"(DNB)","loc":"d,11:8,11:9","dtypep":"(NC)"}
             ]}
           ],
            "rhsp": [
-            {"type":"VARREF","name":"__VnbaIterCount","addr":"(CNB)","loc":"d,11:8,11:9","dtypep":"(T)","access":"RD","varp":"(DMB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"__VnbaIterCount","addr":"(ENB)","loc":"d,11:8,11:9","dtypep":"(T)","access":"RD","varp":"(FMB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ]}
         ],
          "lhsp": [
-          {"type":"VARREF","name":"__VnbaIterCount","addr":"(DNB)","loc":"d,11:8,11:9","dtypep":"(T)","access":"WR","varp":"(DMB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+          {"type":"VARREF","name":"__VnbaIterCount","addr":"(FNB)","loc":"d,11:8,11:9","dtypep":"(T)","access":"WR","varp":"(FMB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
         ],"timingControlp": []},
-        {"type":"ASSIGN","name":"","addr":"(ENB)","loc":"d,11:8,11:9","dtypep":"(NB)",
+        {"type":"ASSIGN","name":"","addr":"(GNB)","loc":"d,11:8,11:9","dtypep":"(NB)",
          "rhsp": [
-          {"type":"CONST","name":"1'h0","addr":"(FNB)","loc":"d,11:8,11:9","dtypep":"(NB)"}
+          {"type":"CONST","name":"1'h0","addr":"(HNB)","loc":"d,11:8,11:9","dtypep":"(NB)"}
         ],
          "lhsp": [
-          {"type":"VARREF","name":"__VnbaContinue","addr":"(GNB)","loc":"d,11:8,11:9","dtypep":"(NB)","access":"WR","varp":"(EMB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+          {"type":"VARREF","name":"__VnbaContinue","addr":"(INB)","loc":"d,11:8,11:9","dtypep":"(NB)","access":"WR","varp":"(GMB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
         ],"timingControlp": []},
-        {"type":"ASSIGN","name":"","addr":"(HNB)","loc":"d,11:8,11:9","dtypep":"(T)",
+        {"type":"ASSIGN","name":"","addr":"(JNB)","loc":"d,11:8,11:9","dtypep":"(T)",
          "rhsp": [
-          {"type":"CONST","name":"32'h0","addr":"(INB)","loc":"d,11:8,11:9","dtypep":"(NC)"}
+          {"type":"CONST","name":"32'h0","addr":"(KNB)","loc":"d,11:8,11:9","dtypep":"(NC)"}
         ],
          "lhsp": [
-          {"type":"VARREF","name":"__VactIterCount","addr":"(JNB)","loc":"d,11:8,11:9","dtypep":"(T)","access":"WR","varp":"(S)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+          {"type":"VARREF","name":"__VactIterCount","addr":"(LNB)","loc":"d,11:8,11:9","dtypep":"(T)","access":"WR","varp":"(S)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
         ],"timingControlp": []},
-        {"type":"ASSIGN","name":"","addr":"(KNB)","loc":"d,11:8,11:9","dtypep":"(NB)",
+        {"type":"ASSIGN","name":"","addr":"(MNB)","loc":"d,11:8,11:9","dtypep":"(NB)",
          "rhsp": [
-          {"type":"CONST","name":"1'h1","addr":"(LNB)","loc":"d,11:8,11:9","dtypep":"(NB)"}
+          {"type":"CONST","name":"1'h1","addr":"(NNB)","loc":"d,11:8,11:9","dtypep":"(NB)"}
         ],
          "lhsp": [
-          {"type":"VARREF","name":"__VactContinue","addr":"(MNB)","loc":"d,11:8,11:9","dtypep":"(NB)","access":"WR","varp":"(O)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+          {"type":"VARREF","name":"__VactContinue","addr":"(ONB)","loc":"d,11:8,11:9","dtypep":"(NB)","access":"WR","varp":"(O)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
         ],"timingControlp": []},
-        {"type":"WHILE","name":"","addr":"(NNB)","loc":"a,0:0,0:0","precondsp": [],
+        {"type":"WHILE","name":"","addr":"(PNB)","loc":"a,0:0,0:0","precondsp": [],
          "condp": [
-          {"type":"VARREF","name":"__VactContinue","addr":"(ONB)","loc":"a,0:0,0:0","dtypep":"(NB)","access":"RD","varp":"(O)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+          {"type":"VARREF","name":"__VactContinue","addr":"(QNB)","loc":"a,0:0,0:0","dtypep":"(NB)","access":"RD","varp":"(O)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
         ],
          "stmtsp": [
-          {"type":"IF","name":"","addr":"(PNB)","loc":"a,0:0,0:0",
+          {"type":"IF","name":"","addr":"(RNB)","loc":"a,0:0,0:0",
            "condp": [
-            {"type":"LT","name":"","addr":"(QNB)","loc":"a,0:0,0:0","dtypep":"(NB)",
+            {"type":"LT","name":"","addr":"(SNB)","loc":"a,0:0,0:0","dtypep":"(NB)",
              "lhsp": [
-              {"type":"CONST","name":"32'h64","addr":"(RNB)","loc":"a,0:0,0:0","dtypep":"(NC)"}
+              {"type":"CONST","name":"32'h64","addr":"(TNB)","loc":"a,0:0,0:0","dtypep":"(NC)"}
             ],
              "rhsp": [
-              {"type":"VARREF","name":"__VactIterCount","addr":"(SNB)","loc":"a,0:0,0:0","dtypep":"(T)","access":"RD","varp":"(S)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+              {"type":"VARREF","name":"__VactIterCount","addr":"(UNB)","loc":"a,0:0,0:0","dtypep":"(T)","access":"RD","varp":"(S)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
             ]}
           ],
            "thensp": [
-            {"type":"TEXTBLOCK","name":"","addr":"(TNB)","loc":"a,0:0,0:0","shortText":"",
+            {"type":"TEXTBLOCK","name":"","addr":"(VNB)","loc":"a,0:0,0:0","shortText":"",
              "nodesp": [
-              {"type":"TEXT","name":"","addr":"(UNB)","loc":"a,0:0,0:0","shortText":"#ifdef VL_DEBUG..."},
-              {"type":"STMTEXPR","name":"","addr":"(VNB)","loc":"a,0:0,0:0",
+              {"type":"TEXT","name":"","addr":"(WNB)","loc":"a,0:0,0:0","shortText":"#ifdef VL_DEBUG..."},
+              {"type":"STMTEXPR","name":"","addr":"(XNB)","loc":"a,0:0,0:0",
                "exprp": [
-                {"type":"CCALL","name":"","addr":"(WNB)","loc":"a,0:0,0:0","dtypep":"(CB)","funcName":"_dump_triggers__act","funcp":"(VP)","argsp": []}
+                {"type":"CCALL","name":"","addr":"(YNB)","loc":"a,0:0,0:0","dtypep":"(CB)","funcName":"_dump_triggers__act","funcp":"(XP)","argsp": []}
               ]},
-              {"type":"TEXT","name":"","addr":"(XNB)","loc":"a,0:0,0:0","shortText":"#endif..."},
-              {"type":"TEXT","name":"","addr":"(YNB)","loc":"a,0:0,0:0","shortText":"VL_FATAL_MT(\"t/t_enum_type_methods.v\", 11, \"\", "},
-              {"type":"TEXT","name":"","addr":"(ZNB)","loc":"a,0:0,0:0","shortText":"\"Active region did not converge.\");..."}
+              {"type":"TEXT","name":"","addr":"(ZNB)","loc":"a,0:0,0:0","shortText":"#endif..."},
+              {"type":"TEXT","name":"","addr":"(AOB)","loc":"a,0:0,0:0","shortText":"VL_FATAL_MT(\"t/t_enum_type_methods.v\", 11, \"\", "},
+              {"type":"TEXT","name":"","addr":"(BOB)","loc":"a,0:0,0:0","shortText":"\"Active region did not converge.\");..."}
             ]}
           ],"elsesp": []},
-          {"type":"ASSIGN","name":"","addr":"(AOB)","loc":"d,11:8,11:9","dtypep":"(T)",
+          {"type":"ASSIGN","name":"","addr":"(COB)","loc":"d,11:8,11:9","dtypep":"(T)",
            "rhsp": [
-            {"type":"ADD","name":"","addr":"(BOB)","loc":"d,11:8,11:9","dtypep":"(T)",
+            {"type":"ADD","name":"","addr":"(DOB)","loc":"d,11:8,11:9","dtypep":"(T)",
              "lhsp": [
-              {"type":"CCAST","name":"","addr":"(COB)","loc":"d,11:8,11:9","dtypep":"(NC)","size":32,
+              {"type":"CCAST","name":"","addr":"(EOB)","loc":"d,11:8,11:9","dtypep":"(NC)","size":32,
                "lhsp": [
-                {"type":"CONST","name":"32'h1","addr":"(DOB)","loc":"d,11:8,11:9","dtypep":"(NC)"}
+                {"type":"CONST","name":"32'h1","addr":"(FOB)","loc":"d,11:8,11:9","dtypep":"(NC)"}
               ]}
             ],
              "rhsp": [
-              {"type":"VARREF","name":"__VactIterCount","addr":"(EOB)","loc":"d,11:8,11:9","dtypep":"(T)","access":"RD","varp":"(S)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+              {"type":"VARREF","name":"__VactIterCount","addr":"(GOB)","loc":"d,11:8,11:9","dtypep":"(T)","access":"RD","varp":"(S)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
             ]}
           ],
            "lhsp": [
-            {"type":"VARREF","name":"__VactIterCount","addr":"(FOB)","loc":"d,11:8,11:9","dtypep":"(T)","access":"WR","varp":"(S)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"__VactIterCount","addr":"(HOB)","loc":"d,11:8,11:9","dtypep":"(T)","access":"WR","varp":"(S)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ],"timingControlp": []},
-          {"type":"ASSIGN","name":"","addr":"(GOB)","loc":"d,11:8,11:9","dtypep":"(NB)",
+          {"type":"ASSIGN","name":"","addr":"(IOB)","loc":"d,11:8,11:9","dtypep":"(NB)",
            "rhsp": [
-            {"type":"CONST","name":"1'h0","addr":"(HOB)","loc":"d,11:8,11:9","dtypep":"(NB)"}
+            {"type":"CONST","name":"1'h0","addr":"(JOB)","loc":"d,11:8,11:9","dtypep":"(NB)"}
           ],
            "lhsp": [
-            {"type":"VARREF","name":"__VactContinue","addr":"(IOB)","loc":"d,11:8,11:9","dtypep":"(NB)","access":"WR","varp":"(O)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"__VactContinue","addr":"(KOB)","loc":"d,11:8,11:9","dtypep":"(NB)","access":"WR","varp":"(O)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ],"timingControlp": []},
-          {"type":"IF","name":"","addr":"(JOB)","loc":"a,0:0,0:0",
+          {"type":"IF","name":"","addr":"(LOB)","loc":"a,0:0,0:0",
            "condp": [
-            {"type":"CCALL","name":"","addr":"(KOB)","loc":"a,0:0,0:0","dtypep":"(NB)","funcName":"_eval_phase__act","funcp":"(QKB)","argsp": []}
+            {"type":"CCALL","name":"","addr":"(MOB)","loc":"a,0:0,0:0","dtypep":"(NB)","funcName":"_eval_phase__act","funcp":"(SKB)","argsp": []}
           ],
            "thensp": [
-            {"type":"ASSIGN","name":"","addr":"(LOB)","loc":"d,11:8,11:9","dtypep":"(NB)",
+            {"type":"ASSIGN","name":"","addr":"(NOB)","loc":"d,11:8,11:9","dtypep":"(NB)",
              "rhsp": [
-              {"type":"CONST","name":"1'h1","addr":"(MOB)","loc":"d,11:8,11:9","dtypep":"(NB)"}
+              {"type":"CONST","name":"1'h1","addr":"(OOB)","loc":"d,11:8,11:9","dtypep":"(NB)"}
             ],
              "lhsp": [
-              {"type":"VARREF","name":"__VactContinue","addr":"(NOB)","loc":"d,11:8,11:9","dtypep":"(NB)","access":"WR","varp":"(O)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+              {"type":"VARREF","name":"__VactContinue","addr":"(POB)","loc":"d,11:8,11:9","dtypep":"(NB)","access":"WR","varp":"(O)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
             ],"timingControlp": []}
           ],"elsesp": []}
         ],"incsp": []},
-        {"type":"IF","name":"","addr":"(OOB)","loc":"a,0:0,0:0",
+        {"type":"IF","name":"","addr":"(QOB)","loc":"a,0:0,0:0",
          "condp": [
-          {"type":"CCALL","name":"","addr":"(POB)","loc":"a,0:0,0:0","dtypep":"(NB)","funcName":"_eval_phase__nba","funcp":"(OLB)","argsp": []}
+          {"type":"CCALL","name":"","addr":"(ROB)","loc":"a,0:0,0:0","dtypep":"(NB)","funcName":"_eval_phase__nba","funcp":"(QLB)","argsp": []}
         ],
          "thensp": [
-          {"type":"ASSIGN","name":"","addr":"(QOB)","loc":"d,11:8,11:9","dtypep":"(NB)",
+          {"type":"ASSIGN","name":"","addr":"(SOB)","loc":"d,11:8,11:9","dtypep":"(NB)",
            "rhsp": [
-            {"type":"CONST","name":"1'h1","addr":"(ROB)","loc":"d,11:8,11:9","dtypep":"(NB)"}
+            {"type":"CONST","name":"1'h1","addr":"(TOB)","loc":"d,11:8,11:9","dtypep":"(NB)"}
           ],
            "lhsp": [
-            {"type":"VARREF","name":"__VnbaContinue","addr":"(SOB)","loc":"d,11:8,11:9","dtypep":"(NB)","access":"WR","varp":"(EMB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"__VnbaContinue","addr":"(UOB)","loc":"d,11:8,11:9","dtypep":"(NB)","access":"WR","varp":"(GMB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ],"timingControlp": []}
         ],"elsesp": []}
       ],"incsp": []}
     ],"finalsp": []},
-    {"type":"CFUNC","name":"_eval_debug_assertions","addr":"(TOB)","loc":"d,11:8,11:9","slow":false,"isStatic":false,"dpiExportDispatcher":false,"dpiExportImpl":false,"dpiImportPrototype":false,"dpiImportWrapper":false,"dpiContext":false,"isConstructor":false,"isDestructor":false,"isVirtual":false,"isCoroutine":false,"needProcess":false,"scopep":"UNLINKED","argsp": [],"initsp": [],
+    {"type":"CFUNC","name":"_eval_debug_assertions","addr":"(VOB)","loc":"d,11:8,11:9","slow":false,"isStatic":false,"dpiExportDispatcher":false,"dpiExportImpl":false,"dpiImportPrototype":false,"dpiImportWrapper":false,"dpiContext":false,"isConstructor":false,"isDestructor":false,"isVirtual":false,"isCoroutine":false,"needProcess":false,"scopep":"UNLINKED","argsp": [],"initsp": [],
      "stmtsp": [
-      {"type":"IF","name":"","addr":"(UOB)","loc":"d,15:10,15:13",
+      {"type":"IF","name":"","addr":"(WOB)","loc":"d,15:10,15:13",
        "condp": [
-        {"type":"AND","name":"","addr":"(VOB)","loc":"d,15:10,15:13","dtypep":"(K)",
+        {"type":"AND","name":"","addr":"(XOB)","loc":"d,15:10,15:13","dtypep":"(K)",
          "lhsp": [
-          {"type":"VARREF","name":"clk","addr":"(WOB)","loc":"d,15:10,15:13","dtypep":"(K)","access":"RD","varp":"(J)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+          {"type":"VARREF","name":"clk","addr":"(YOB)","loc":"d,15:10,15:13","dtypep":"(K)","access":"RD","varp":"(J)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
         ],
          "rhsp": [
-          {"type":"CONST","name":"8'hfe","addr":"(XOB)","loc":"d,15:10,15:13","dtypep":"(YOB)"}
+          {"type":"CONST","name":"8'hfe","addr":"(ZOB)","loc":"d,15:10,15:13","dtypep":"(APB)"}
         ]}
       ],
        "thensp": [
-        {"type":"CSTMT","name":"","addr":"(ZOB)","loc":"d,15:10,15:13",
+        {"type":"CSTMT","name":"","addr":"(BPB)","loc":"d,15:10,15:13",
          "exprsp": [
-          {"type":"TEXT","name":"","addr":"(APB)","loc":"d,15:10,15:13","shortText":"Verilated::overWidthError(\"clk\");"}
+          {"type":"TEXT","name":"","addr":"(CPB)","loc":"d,15:10,15:13","shortText":"Verilated::overWidthError(\"clk\");"}
         ]}
       ],"elsesp": []}
     ],"finalsp": []},
-    {"type":"CFUNC","name":"_ctor_var_reset","addr":"(BPB)","loc":"d,11:8,11:9","slow":true,"isStatic":false,"dpiExportDispatcher":false,"dpiExportImpl":false,"dpiImportPrototype":false,"dpiImportWrapper":false,"dpiContext":false,"isConstructor":false,"isDestructor":false,"isVirtual":false,"isCoroutine":false,"needProcess":false,"scopep":"UNLINKED","argsp": [],"initsp": [],
+    {"type":"CFUNC","name":"_ctor_var_reset","addr":"(DPB)","loc":"d,11:8,11:9","slow":true,"isStatic":false,"dpiExportDispatcher":false,"dpiExportImpl":false,"dpiImportPrototype":false,"dpiImportWrapper":false,"dpiContext":false,"isConstructor":false,"isDestructor":false,"isVirtual":false,"isCoroutine":false,"needProcess":false,"scopep":"UNLINKED","argsp": [],"initsp": [],
      "stmtsp": [
-      {"type":"CRESET","name":"","addr":"(CPB)","loc":"d,15:10,15:13",
+      {"type":"CRESET","name":"","addr":"(EPB)","loc":"d,15:10,15:13",
        "varrefp": [
-        {"type":"VARREF","name":"clk","addr":"(DPB)","loc":"d,15:10,15:13","dtypep":"(K)","access":"WR","varp":"(J)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"clk","addr":"(FPB)","loc":"d,15:10,15:13","dtypep":"(K)","access":"WR","varp":"(J)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ]},
-      {"type":"CRESET","name":"","addr":"(EPB)","loc":"d,23:17,23:20",
+      {"type":"CRESET","name":"","addr":"(GPB)","loc":"d,23:17,23:20",
        "varrefp": [
-        {"type":"VARREF","name":"t.cyc","addr":"(FPB)","loc":"d,23:17,23:20","dtypep":"(R)","access":"WR","varp":"(Q)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"t.cyc","addr":"(HPB)","loc":"d,23:17,23:20","dtypep":"(R)","access":"WR","varp":"(Q)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ]},
-      {"type":"CRESET","name":"","addr":"(GPB)","loc":"d,24:9,24:10",
+      {"type":"CRESET","name":"","addr":"(IPB)","loc":"d,24:9,24:10",
        "varrefp": [
-        {"type":"VARREF","name":"t.e","addr":"(HPB)","loc":"d,24:9,24:10","dtypep":"(M)","access":"WR","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"t.e","addr":"(JPB)","loc":"d,24:9,24:10","dtypep":"(M)","access":"WR","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ]},
-      {"type":"CRESET","name":"","addr":"(IPB)","loc":"d,11:8,11:9",
+      {"type":"CRESET","name":"","addr":"(KPB)","loc":"d,11:8,11:9",
        "varrefp": [
-        {"type":"VARREF","name":"__Vtrigprevexpr___TOP__clk__0","addr":"(JPB)","loc":"d,11:8,11:9","dtypep":"(K)","access":"WR","varp":"(N)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"__Vtrigprevexpr___TOP__clk__0","addr":"(LPB)","loc":"d,11:8,11:9","dtypep":"(K)","access":"WR","varp":"(N)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ]}
     ],"finalsp": []},
-    {"type":"CUSE","name":"$unit","addr":"(KPB)","loc":"a,0:0,0:0","useType":"INT_FWD"}
+    {"type":"CUSE","name":"$unit","addr":"(MPB)","loc":"a,0:0,0:0","useType":"INT_FWD"}
   ],"activesp": []},
   {"type":"PACKAGE","name":"$unit","addr":"(E)","loc":"a,0:0,0:0","origName":"__024unit","level":0,"modPublic":false,"inLibrary":true,"dead":false,"recursiveClone":false,"recursive":false,"timeunit":"NONE","inlinesp": [],
    "stmtsp": [
     {"type":"VAR","name":"__Venumtab_enum_next0","addr":"(JC)","loc":"d,17:12,17:16","dtypep":"(IC)","origName":"__Venumtab_enum_next0","isSc":false,"isPrimaryIO":false,"direction":"NONE","isConst":true,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"attrClocker":"UNKNOWN","lifetime":"VSTATIC","varType":"MODULETEMP","dtypeName":"","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],
      "valuep": [
-      {"type":"INITARRAY","name":"","addr":"(LPB)","loc":"d,17:12,17:16","dtypep":"(IC)","initList":" [1]=(MPB) [3]=(NPB) [4]=(OPB)",
+      {"type":"INITARRAY","name":"","addr":"(NPB)","loc":"d,17:12,17:16","dtypep":"(IC)","initList":" [1]=(OPB) [3]=(PPB) [4]=(QPB)",
        "defaultp": [
-        {"type":"CONST","name":"4'h0","addr":"(PPB)","loc":"d,17:12,17:16","dtypep":"(AC)"}
+        {"type":"CONST","name":"4'h0","addr":"(RPB)","loc":"d,17:12,17:16","dtypep":"(AC)"}
       ],
        "initsp": [
-        {"type":"INITITEM","name":"","addr":"(MPB)","loc":"d,17:12,17:16",
-         "valuep": [
-          {"type":"CONST","name":"4'h3","addr":"(QPB)","loc":"d,19:30,19:31","dtypep":"(AC)"}
-        ]},
-        {"type":"INITITEM","name":"","addr":"(NPB)","loc":"d,17:12,17:16",
-         "valuep": [
-          {"type":"CONST","name":"4'h4","addr":"(RPB)","loc":"d,20:30,20:31","dtypep":"(AC)"}
-        ]},
         {"type":"INITITEM","name":"","addr":"(OPB)","loc":"d,17:12,17:16",
          "valuep": [
-          {"type":"CONST","name":"4'h1","addr":"(SPB)","loc":"d,18:30,18:31","dtypep":"(AC)"}
+          {"type":"CONST","name":"4'h3","addr":"(SPB)","loc":"d,19:30,19:31","dtypep":"(AC)"}
+        ]},
+        {"type":"INITITEM","name":"","addr":"(PPB)","loc":"d,17:12,17:16",
+         "valuep": [
+          {"type":"CONST","name":"4'h4","addr":"(TPB)","loc":"d,20:30,20:31","dtypep":"(AC)"}
+        ]},
+        {"type":"INITITEM","name":"","addr":"(QPB)","loc":"d,17:12,17:16",
+         "valuep": [
+          {"type":"CONST","name":"4'h1","addr":"(UPB)","loc":"d,18:30,18:31","dtypep":"(AC)"}
         ]}
       ]}
     ],"attrsp": []},
     {"type":"VAR","name":"__Venumtab_enum_prev1","addr":"(DJ)","loc":"d,17:12,17:16","dtypep":"(CJ)","origName":"__Venumtab_enum_prev1","isSc":false,"isPrimaryIO":false,"direction":"NONE","isConst":true,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"attrClocker":"UNKNOWN","lifetime":"VSTATIC","varType":"MODULETEMP","dtypeName":"","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],
      "valuep": [
-      {"type":"INITARRAY","name":"","addr":"(TPB)","loc":"d,17:12,17:16","dtypep":"(CJ)","initList":" [1]=(UPB) [3]=(VPB) [4]=(WPB)",
+      {"type":"INITARRAY","name":"","addr":"(VPB)","loc":"d,17:12,17:16","dtypep":"(CJ)","initList":" [1]=(WPB) [3]=(XPB) [4]=(YPB)",
        "defaultp": [
-        {"type":"CONST","name":"4'h0","addr":"(XPB)","loc":"d,17:12,17:16","dtypep":"(AC)"}
+        {"type":"CONST","name":"4'h0","addr":"(ZPB)","loc":"d,17:12,17:16","dtypep":"(AC)"}
       ],
        "initsp": [
-        {"type":"INITITEM","name":"","addr":"(UPB)","loc":"d,17:12,17:16",
-         "valuep": [
-          {"type":"CONST","name":"4'h4","addr":"(YPB)","loc":"d,20:30,20:31","dtypep":"(AC)"}
-        ]},
-        {"type":"INITITEM","name":"","addr":"(VPB)","loc":"d,17:12,17:16",
-         "valuep": [
-          {"type":"CONST","name":"4'h1","addr":"(ZPB)","loc":"d,18:30,18:31","dtypep":"(AC)"}
-        ]},
         {"type":"INITITEM","name":"","addr":"(WPB)","loc":"d,17:12,17:16",
          "valuep": [
-          {"type":"CONST","name":"4'h3","addr":"(AQB)","loc":"d,19:30,19:31","dtypep":"(AC)"}
+          {"type":"CONST","name":"4'h4","addr":"(AQB)","loc":"d,20:30,20:31","dtypep":"(AC)"}
+        ]},
+        {"type":"INITITEM","name":"","addr":"(XPB)","loc":"d,17:12,17:16",
+         "valuep": [
+          {"type":"CONST","name":"4'h1","addr":"(BQB)","loc":"d,18:30,18:31","dtypep":"(AC)"}
+        ]},
+        {"type":"INITITEM","name":"","addr":"(YPB)","loc":"d,17:12,17:16",
+         "valuep": [
+          {"type":"CONST","name":"4'h3","addr":"(CQB)","loc":"d,19:30,19:31","dtypep":"(AC)"}
         ]}
       ]}
     ],"attrsp": []},
     {"type":"VAR","name":"__Venumtab_enum_name2","addr":"(PM)","loc":"d,17:12,17:16","dtypep":"(OM)","origName":"__Venumtab_enum_name2","isSc":false,"isPrimaryIO":false,"direction":"NONE","isConst":true,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"attrClocker":"UNKNOWN","lifetime":"VSTATIC","varType":"MODULETEMP","dtypeName":"","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],
      "valuep": [
-      {"type":"INITARRAY","name":"","addr":"(BQB)","loc":"d,17:12,17:16","dtypep":"(OM)","initList":" [1]=(CQB) [3]=(DQB) [4]=(EQB)",
+      {"type":"INITARRAY","name":"","addr":"(DQB)","loc":"d,17:12,17:16","dtypep":"(OM)","initList":" [1]=(EQB) [3]=(FQB) [4]=(GQB)",
        "defaultp": [
-        {"type":"CONST","name":"\\\"\\\"","addr":"(FQB)","loc":"d,17:12,17:16","dtypep":"(RB)"}
+        {"type":"CONST","name":"\\\"\\\"","addr":"(HQB)","loc":"d,17:12,17:16","dtypep":"(RB)"}
       ],
        "initsp": [
-        {"type":"INITITEM","name":"","addr":"(CQB)","loc":"d,17:12,17:16",
-         "valuep": [
-          {"type":"CONST","name":"\\\"E01\\\"","addr":"(GQB)","loc":"d,17:12,17:16","dtypep":"(RB)"}
-        ]},
-        {"type":"INITITEM","name":"","addr":"(DQB)","loc":"d,17:12,17:16",
-         "valuep": [
-          {"type":"CONST","name":"\\\"E03\\\"","addr":"(HQB)","loc":"d,17:12,17:16","dtypep":"(RB)"}
-        ]},
         {"type":"INITITEM","name":"","addr":"(EQB)","loc":"d,17:12,17:16",
          "valuep": [
-          {"type":"CONST","name":"\\\"E04\\\"","addr":"(IQB)","loc":"d,17:12,17:16","dtypep":"(RB)"}
+          {"type":"CONST","name":"\\\"E01\\\"","addr":"(IQB)","loc":"d,17:12,17:16","dtypep":"(RB)"}
+        ]},
+        {"type":"INITITEM","name":"","addr":"(FQB)","loc":"d,17:12,17:16",
+         "valuep": [
+          {"type":"CONST","name":"\\\"E03\\\"","addr":"(JQB)","loc":"d,17:12,17:16","dtypep":"(RB)"}
+        ]},
+        {"type":"INITITEM","name":"","addr":"(GQB)","loc":"d,17:12,17:16",
+         "valuep": [
+          {"type":"CONST","name":"\\\"E04\\\"","addr":"(KQB)","loc":"d,17:12,17:16","dtypep":"(RB)"}
         ]}
       ]}
     ],"attrsp": []},
-    {"type":"SCOPE","name":"$unit","addr":"(JQB)","loc":"a,0:0,0:0","aboveScopep":"(Y)","aboveCellp":"(X)","modp":"(E)","varsp": [],"blocksp": [],"inlinesp": []},
-    {"type":"CFUNC","name":"_ctor_var_reset","addr":"(KQB)","loc":"a,0:0,0:0","slow":true,"isStatic":false,"dpiExportDispatcher":false,"dpiExportImpl":false,"dpiImportPrototype":false,"dpiImportWrapper":false,"dpiContext":false,"isConstructor":false,"isDestructor":false,"isVirtual":false,"isCoroutine":false,"needProcess":false,"scopep":"UNLINKED","argsp": [],"initsp": [],
+    {"type":"SCOPE","name":"$unit","addr":"(LQB)","loc":"a,0:0,0:0","aboveScopep":"(Y)","aboveCellp":"(X)","modp":"(E)","varsp": [],"blocksp": [],"inlinesp": []},
+    {"type":"CFUNC","name":"_ctor_var_reset","addr":"(MQB)","loc":"a,0:0,0:0","slow":true,"isStatic":false,"dpiExportDispatcher":false,"dpiExportImpl":false,"dpiImportPrototype":false,"dpiImportWrapper":false,"dpiContext":false,"isConstructor":false,"isDestructor":false,"isVirtual":false,"isCoroutine":false,"needProcess":false,"scopep":"UNLINKED","argsp": [],"initsp": [],
      "stmtsp": [
-      {"type":"CRESET","name":"","addr":"(LQB)","loc":"d,17:12,17:16",
-       "varrefp": [
-        {"type":"VARREF","name":"__Venumtab_enum_next0","addr":"(MQB)","loc":"d,17:12,17:16","dtypep":"(IC)","access":"WR","varp":"(JC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
-      ]},
       {"type":"CRESET","name":"","addr":"(NQB)","loc":"d,17:12,17:16",
        "varrefp": [
-        {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(OQB)","loc":"d,17:12,17:16","dtypep":"(CJ)","access":"WR","varp":"(DJ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"__Venumtab_enum_next0","addr":"(OQB)","loc":"d,17:12,17:16","dtypep":"(IC)","access":"WR","varp":"(JC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ]},
       {"type":"CRESET","name":"","addr":"(PQB)","loc":"d,17:12,17:16",
        "varrefp": [
-        {"type":"VARREF","name":"__Venumtab_enum_name2","addr":"(QQB)","loc":"d,17:12,17:16","dtypep":"(OM)","access":"WR","varp":"(PM)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(QQB)","loc":"d,17:12,17:16","dtypep":"(CJ)","access":"WR","varp":"(DJ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+      ]},
+      {"type":"CRESET","name":"","addr":"(RQB)","loc":"d,17:12,17:16",
+       "varrefp": [
+        {"type":"VARREF","name":"__Venumtab_enum_name2","addr":"(SQB)","loc":"d,17:12,17:16","dtypep":"(OM)","access":"WR","varp":"(PM)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ]}
     ],"finalsp": []}
   ],"activesp": []}
 ],
  "filesp": [
-  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck__Syms.cpp","addr":"(RQB)","loc":"a,0:0,0:0","source":true,"slow":true,"tblockp": []},
-  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck__Syms.h","addr":"(SQB)","loc":"a,0:0,0:0","source":false,"slow":true,"tblockp": []},
-  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck.h","addr":"(TQB)","loc":"a,0:0,0:0","source":false,"slow":false,"tblockp": []},
-  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck.cpp","addr":"(UQB)","loc":"a,0:0,0:0","source":true,"slow":false,"tblockp": []},
-  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck_$root.h","addr":"(VQB)","loc":"a,0:0,0:0","source":false,"slow":false,"tblockp": []},
-  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck_$unit.h","addr":"(WQB)","loc":"a,0:0,0:0","source":false,"slow":false,"tblockp": []},
-  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck_$root__Slow.cpp","addr":"(XQB)","loc":"a,0:0,0:0","source":true,"slow":true,"tblockp": []},
-  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck_$root__DepSet_h########__0__Slow.cpp","addr":"(YQB)","loc":"a,0:0,0:0","source":true,"slow":true,"tblockp": []},
-  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck_$root__DepSet_h########__0__Slow.cpp","addr":"(ZQB)","loc":"a,0:0,0:0","source":true,"slow":true,"tblockp": []},
-  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck_$root__DepSet_h########__0.cpp","addr":"(ARB)","loc":"a,0:0,0:0","source":true,"slow":false,"tblockp": []},
-  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck_$root__DepSet_h########__0.cpp","addr":"(BRB)","loc":"a,0:0,0:0","source":true,"slow":false,"tblockp": []},
-  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck_$unit__Slow.cpp","addr":"(CRB)","loc":"a,0:0,0:0","source":true,"slow":true,"tblockp": []},
-  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck_$unit__DepSet_h########__0__Slow.cpp","addr":"(DRB)","loc":"a,0:0,0:0","source":true,"slow":true,"tblockp": []}
+  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck__Syms.cpp","addr":"(TQB)","loc":"a,0:0,0:0","source":true,"slow":true,"tblockp": []},
+  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck__Syms.h","addr":"(UQB)","loc":"a,0:0,0:0","source":false,"slow":true,"tblockp": []},
+  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck.h","addr":"(VQB)","loc":"a,0:0,0:0","source":false,"slow":false,"tblockp": []},
+  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck.cpp","addr":"(WQB)","loc":"a,0:0,0:0","source":true,"slow":false,"tblockp": []},
+  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck_$root.h","addr":"(XQB)","loc":"a,0:0,0:0","source":false,"slow":false,"tblockp": []},
+  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck_$unit.h","addr":"(YQB)","loc":"a,0:0,0:0","source":false,"slow":false,"tblockp": []},
+  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck_$root__Slow.cpp","addr":"(ZQB)","loc":"a,0:0,0:0","source":true,"slow":true,"tblockp": []},
+  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck_$root__DepSet_h########__0__Slow.cpp","addr":"(ARB)","loc":"a,0:0,0:0","source":true,"slow":true,"tblockp": []},
+  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck_$root__DepSet_h########__0__Slow.cpp","addr":"(BRB)","loc":"a,0:0,0:0","source":true,"slow":true,"tblockp": []},
+  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck_$root__DepSet_h########__0.cpp","addr":"(CRB)","loc":"a,0:0,0:0","source":true,"slow":false,"tblockp": []},
+  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck_$root__DepSet_h########__0.cpp","addr":"(DRB)","loc":"a,0:0,0:0","source":true,"slow":false,"tblockp": []},
+  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck_$unit__Slow.cpp","addr":"(ERB)","loc":"a,0:0,0:0","source":true,"slow":true,"tblockp": []},
+  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck_$unit__DepSet_h########__0__Slow.cpp","addr":"(FRB)","loc":"a,0:0,0:0","source":true,"slow":true,"tblockp": []}
 ],
  "miscsp": [
   {"type":"TYPETABLE","name":"","addr":"(C)","loc":"a,0:0,0:0","constraintRefp":"UNLINKED","emptyQueuep":"UNLINKED","queueIndexp":"UNLINKED","streamp":"UNLINKED","voidp":"(CB)",
    "typesp": [
     {"type":"BASICDTYPE","name":"logic","addr":"(K)","loc":"d,33:24,33:27","dtypep":"(K)","keyword":"logic","generic":true,"rangep": []},
     {"type":"BASICDTYPE","name":"logic","addr":"(NC)","loc":"d,53:16,53:17","dtypep":"(NC)","keyword":"logic","range":"31:0","generic":true,"rangep": []},
-    {"type":"BASICDTYPE","name":"logic","addr":"(ERB)","loc":"d,17:17,17:18","dtypep":"(ERB)","keyword":"logic","range":"3:0","generic":true,"rangep": []},
-    {"type":"ENUMDTYPE","name":"t.my_t","addr":"(FRB)","loc":"d,17:12,17:16","dtypep":"(FRB)","enum":true,"generic":false,"refDTypep":"(ERB)","childDTypep": [],
+    {"type":"BASICDTYPE","name":"logic","addr":"(GRB)","loc":"d,17:17,17:18","dtypep":"(GRB)","keyword":"logic","range":"3:0","generic":true,"rangep": []},
+    {"type":"ENUMDTYPE","name":"t.my_t","addr":"(HRB)","loc":"d,17:12,17:16","dtypep":"(HRB)","enum":true,"generic":false,"refDTypep":"(GRB)","childDTypep": [],
      "itemsp": [
-      {"type":"ENUMITEM","name":"E01","addr":"(GRB)","loc":"d,18:24,18:27","dtypep":"(AC)","rangep": [],
+      {"type":"ENUMITEM","name":"E01","addr":"(IRB)","loc":"d,18:24,18:27","dtypep":"(AC)","rangep": [],
        "valuep": [
-        {"type":"CONST","name":"4'h1","addr":"(HRB)","loc":"d,18:30,18:31","dtypep":"(AC)"}
+        {"type":"CONST","name":"4'h1","addr":"(JRB)","loc":"d,18:30,18:31","dtypep":"(AC)"}
       ]},
-      {"type":"ENUMITEM","name":"E03","addr":"(IRB)","loc":"d,19:24,19:27","dtypep":"(AC)","rangep": [],
+      {"type":"ENUMITEM","name":"E03","addr":"(KRB)","loc":"d,19:24,19:27","dtypep":"(AC)","rangep": [],
        "valuep": [
-        {"type":"CONST","name":"4'h3","addr":"(JRB)","loc":"d,19:30,19:31","dtypep":"(AC)"}
+        {"type":"CONST","name":"4'h3","addr":"(LRB)","loc":"d,19:30,19:31","dtypep":"(AC)"}
       ]},
-      {"type":"ENUMITEM","name":"E04","addr":"(KRB)","loc":"d,20:24,20:27","dtypep":"(AC)","rangep": [],
+      {"type":"ENUMITEM","name":"E04","addr":"(MRB)","loc":"d,20:24,20:27","dtypep":"(AC)","rangep": [],
        "valuep": [
-        {"type":"CONST","name":"4'h4","addr":"(LRB)","loc":"d,20:30,20:31","dtypep":"(AC)"}
+        {"type":"CONST","name":"4'h4","addr":"(NRB)","loc":"d,20:30,20:31","dtypep":"(AC)"}
       ]}
     ]},
     {"type":"BASICDTYPE","name":"integer","addr":"(R)","loc":"d,23:4,23:11","dtypep":"(R)","keyword":"integer","range":"31:0","generic":true,"rangep": []},
-    {"type":"REFDTYPE","name":"my_t","addr":"(M)","loc":"d,24:4,24:8","dtypep":"(FRB)","generic":false,"typedefp":"UNLINKED","refDTypep":"(FRB)","classOrPackagep":"UNLINKED","typeofp": [],"classOrPackageOpp": [],"paramsp": []},
+    {"type":"REFDTYPE","name":"my_t","addr":"(M)","loc":"d,24:4,24:8","dtypep":"(HRB)","generic":false,"typedefp":"UNLINKED","refDTypep":"(HRB)","classOrPackagep":"UNLINKED","typeofp": [],"classOrPackageOpp": [],"paramsp": []},
     {"type":"BASICDTYPE","name":"string","addr":"(RB)","loc":"d,28:4,28:10","dtypep":"(RB)","keyword":"string","generic":true,"rangep": []},
-    {"type":"UNPACKARRAYDTYPE","name":"","addr":"(IC)","loc":"d,17:12,17:16","dtypep":"(IC)","isCompound":false,"declRange":"[7:0]","generic":false,"refDTypep":"(FRB)","childDTypep": [],
+    {"type":"UNPACKARRAYDTYPE","name":"","addr":"(IC)","loc":"d,17:12,17:16","dtypep":"(IC)","isCompound":false,"declRange":"[7:0]","generic":false,"refDTypep":"(HRB)","childDTypep": [],
      "rangep": [
-      {"type":"RANGE","name":"","addr":"(MRB)","loc":"d,17:12,17:16","ascending":false,
+      {"type":"RANGE","name":"","addr":"(ORB)","loc":"d,17:12,17:16","ascending":false,
        "leftp": [
-        {"type":"CONST","name":"32'h7","addr":"(NRB)","loc":"d,17:12,17:16","dtypep":"(NC)"}
+        {"type":"CONST","name":"32'h7","addr":"(PRB)","loc":"d,17:12,17:16","dtypep":"(NC)"}
       ],
        "rightp": [
-        {"type":"CONST","name":"32'h0","addr":"(ORB)","loc":"d,17:12,17:16","dtypep":"(NC)"}
+        {"type":"CONST","name":"32'h0","addr":"(QRB)","loc":"d,17:12,17:16","dtypep":"(NC)"}
       ]}
     ]},
-    {"type":"UNPACKARRAYDTYPE","name":"","addr":"(CJ)","loc":"d,17:12,17:16","dtypep":"(CJ)","isCompound":false,"declRange":"[7:0]","generic":false,"refDTypep":"(FRB)","childDTypep": [],
+    {"type":"UNPACKARRAYDTYPE","name":"","addr":"(CJ)","loc":"d,17:12,17:16","dtypep":"(CJ)","isCompound":false,"declRange":"[7:0]","generic":false,"refDTypep":"(HRB)","childDTypep": [],
      "rangep": [
-      {"type":"RANGE","name":"","addr":"(PRB)","loc":"d,17:12,17:16","ascending":false,
+      {"type":"RANGE","name":"","addr":"(RRB)","loc":"d,17:12,17:16","ascending":false,
        "leftp": [
-        {"type":"CONST","name":"32'h7","addr":"(QRB)","loc":"d,17:12,17:16","dtypep":"(NC)"}
+        {"type":"CONST","name":"32'h7","addr":"(SRB)","loc":"d,17:12,17:16","dtypep":"(NC)"}
       ],
        "rightp": [
-        {"type":"CONST","name":"32'h0","addr":"(RRB)","loc":"d,17:12,17:16","dtypep":"(NC)"}
+        {"type":"CONST","name":"32'h0","addr":"(TRB)","loc":"d,17:12,17:16","dtypep":"(NC)"}
       ]}
     ]},
     {"type":"UNPACKARRAYDTYPE","name":"","addr":"(OM)","loc":"d,17:12,17:16","dtypep":"(OM)","isCompound":true,"declRange":"[7:0]","generic":false,"refDTypep":"(RB)","childDTypep": [],
      "rangep": [
-      {"type":"RANGE","name":"","addr":"(SRB)","loc":"d,17:12,17:16","ascending":false,
+      {"type":"RANGE","name":"","addr":"(URB)","loc":"d,17:12,17:16","ascending":false,
        "leftp": [
-        {"type":"CONST","name":"32'h7","addr":"(TRB)","loc":"d,17:12,17:16","dtypep":"(NC)"}
+        {"type":"CONST","name":"32'h7","addr":"(VRB)","loc":"d,17:12,17:16","dtypep":"(NC)"}
       ],
        "rightp": [
-        {"type":"CONST","name":"32'h0","addr":"(URB)","loc":"d,17:12,17:16","dtypep":"(NC)"}
+        {"type":"CONST","name":"32'h0","addr":"(WRB)","loc":"d,17:12,17:16","dtypep":"(NC)"}
       ]}
     ]},
-    {"type":"REFDTYPE","name":"my_t","addr":"(VB)","loc":"d,52:12,52:16","dtypep":"(FRB)","generic":false,"typedefp":"UNLINKED","refDTypep":"(FRB)","classOrPackagep":"UNLINKED","typeofp": [],"classOrPackageOpp": [],"paramsp": []},
+    {"type":"REFDTYPE","name":"my_t","addr":"(VB)","loc":"d,52:12,52:16","dtypep":"(HRB)","generic":false,"typedefp":"UNLINKED","refDTypep":"(HRB)","classOrPackagep":"UNLINKED","typeofp": [],"classOrPackageOpp": [],"paramsp": []},
     {"type":"BASICDTYPE","name":"logic","addr":"(GB)","loc":"d,23:23,23:24","dtypep":"(GB)","keyword":"logic","range":"31:0","generic":true,"rangep": []},
     {"type":"VOIDDTYPE","name":"","addr":"(CB)","loc":"d,11:8,11:9","dtypep":"(CB)","generic":false},
     {"type":"BASICDTYPE","name":"VlTriggerVec","addr":"(V)","loc":"d,11:8,11:9","dtypep":"(V)","keyword":"VlTriggerVec","generic":true,"rangep": []},
-    {"type":"BASICDTYPE","name":"QData","addr":"(KQ)","loc":"d,11:8,11:9","dtypep":"(KQ)","keyword":"QData","range":"63:0","generic":true,"rangep": []},
-    {"type":"BASICDTYPE","name":"logic","addr":"(HQ)","loc":"d,11:8,11:9","dtypep":"(HQ)","keyword":"logic","range":"63:0","generic":true,"rangep": []},
+    {"type":"BASICDTYPE","name":"QData","addr":"(MQ)","loc":"d,11:8,11:9","dtypep":"(MQ)","keyword":"QData","range":"63:0","generic":true,"rangep": []},
+    {"type":"BASICDTYPE","name":"logic","addr":"(JQ)","loc":"d,11:8,11:9","dtypep":"(JQ)","keyword":"logic","range":"63:0","generic":true,"rangep": []},
     {"type":"BASICDTYPE","name":"bit","addr":"(P)","loc":"d,11:8,11:9","dtypep":"(P)","keyword":"bit","generic":true,"rangep": []},
     {"type":"BASICDTYPE","name":"bit","addr":"(T)","loc":"d,11:8,11:9","dtypep":"(T)","keyword":"bit","range":"31:0","generic":true,"rangep": []},
     {"type":"BASICDTYPE","name":"logic","addr":"(NB)","loc":"d,61:22,61:25","dtypep":"(NB)","keyword":"logic","range":"31:0","generic":true,"rangep": []},
     {"type":"BASICDTYPE","name":"logic","addr":"(AC)","loc":"d,32:11,32:14","dtypep":"(AC)","keyword":"logic","range":"31:0","generic":true,"rangep": []},
     {"type":"BASICDTYPE","name":"logic","addr":"(LC)","loc":"d,38:17,38:21","dtypep":"(LC)","keyword":"logic","range":"31:0","generic":true,"rangep": []},
-    {"type":"BASICDTYPE","name":"logic","addr":"(YOB)","loc":"d,15:10,15:13","dtypep":"(YOB)","keyword":"logic","range":"7:0","generic":true,"rangep": []}
+    {"type":"BASICDTYPE","name":"logic","addr":"(APB)","loc":"d,15:10,15:13","dtypep":"(APB)","keyword":"logic","range":"7:0","generic":true,"rangep": []}
   ]},
   {"type":"CONSTPOOL","name":"","addr":"(D)","loc":"a,0:0,0:0",
    "modulep": [
-    {"type":"MODULE","name":"@CONST-POOL@","addr":"(VRB)","loc":"a,0:0,0:0","origName":"@CONST-POOL@","level":0,"modPublic":false,"inLibrary":false,"dead":false,"recursiveClone":false,"recursive":false,"timeunit":"NONE","inlinesp": [],
+    {"type":"MODULE","name":"@CONST-POOL@","addr":"(XRB)","loc":"a,0:0,0:0","origName":"@CONST-POOL@","level":0,"modPublic":false,"inLibrary":false,"dead":false,"recursiveClone":false,"recursive":false,"timeunit":"NONE","inlinesp": [],
      "stmtsp": [
-      {"type":"SCOPE","name":"TOP","addr":"(WRB)","loc":"a,0:0,0:0","aboveScopep":"UNLINKED","aboveCellp":"UNLINKED","modp":"(VRB)","varsp": [],"blocksp": [],"inlinesp": []}
+      {"type":"SCOPE","name":"TOP","addr":"(YRB)","loc":"a,0:0,0:0","aboveScopep":"UNLINKED","aboveCellp":"UNLINKED","modp":"(XRB)","varsp": [],"blocksp": [],"inlinesp": []}
     ],"activesp": []}
   ]}
 ]}

--- a/test_regress/t/t_string_repl.v
+++ b/test_regress/t/t_string_repl.v
@@ -24,12 +24,12 @@ module t(/*AUTOARG*/
 
    integer cyc = 0;
 
-   string s;
+   string s, s2;
 
    // Test loop
    always @ (posedge clk) begin
       cyc <= cyc + 1;
-      s = {cyc{"*"}};
+      s = {s2, {cyc{"*"}}};
       if (cyc != s.len()) $stop;
       if (cyc == 0 && s != "") $stop;
       if (cyc == 1 && s != "*") $stop;

--- a/test_regress/t/t_xml_debugcheck.out
+++ b/test_regress/t/t_xml_debugcheck.out
@@ -541,20 +541,22 @@
           </begin>
           <begin>
             <assign loc="d,53,14,53,15" dtype_id="10">
-              <concatn loc="d,53,20,53,21" dtype_id="10">
-                <varref loc="d,53,17,53,20" name="t.all" dtype_id="10"/>
-                <cvtpackstring loc="d,53,24,53,28" dtype_id="10">
-                  <arraysel loc="d,53,24,53,28" dtype_id="10">
-                    <varref loc="d,17,12,17,16" name="__Venumtab_enum_name2" dtype_id="16"/>
-                    <and loc="d,53,24,53,28" dtype_id="13">
-                      <const loc="d,53,24,53,28" name="32&apos;h7" dtype_id="14"/>
-                      <ccast loc="d,53,22,53,23" dtype_id="13">
-                        <varref loc="d,53,22,53,23" name="t.unnamedblk1.e" dtype_id="13"/>
-                      </ccast>
-                    </and>
-                  </arraysel>
-                </cvtpackstring>
-              </concatn>
+              <cvtpackstring loc="d,53,20,53,21" dtype_id="10">
+                <concatn loc="d,53,20,53,21" dtype_id="10">
+                  <varref loc="d,53,17,53,20" name="t.all" dtype_id="10"/>
+                  <cvtpackstring loc="d,53,24,53,28" dtype_id="10">
+                    <arraysel loc="d,53,24,53,28" dtype_id="10">
+                      <varref loc="d,17,12,17,16" name="__Venumtab_enum_name2" dtype_id="16"/>
+                      <and loc="d,53,24,53,28" dtype_id="13">
+                        <const loc="d,53,24,53,28" name="32&apos;h7" dtype_id="14"/>
+                        <ccast loc="d,53,22,53,23" dtype_id="13">
+                          <varref loc="d,53,22,53,23" name="t.unnamedblk1.e" dtype_id="13"/>
+                        </ccast>
+                      </and>
+                    </arraysel>
+                  </cvtpackstring>
+                </concatn>
+              </cvtpackstring>
               <varref loc="d,53,10,53,13" name="t.all" dtype_id="10"/>
             </assign>
           </begin>
@@ -578,10 +580,12 @@
           <varref loc="d,55,7,55,8" name="t.e" dtype_id="11"/>
         </assign>
         <assign loc="d,56,11,56,12" dtype_id="10">
-          <concatn loc="d,56,17,56,18" dtype_id="10">
-            <varref loc="d,56,14,56,17" name="t.all" dtype_id="10"/>
-            <const loc="d,56,21,56,25" name="&quot;E04&quot;" dtype_id="10"/>
-          </concatn>
+          <cvtpackstring loc="d,56,17,56,18" dtype_id="10">
+            <concatn loc="d,56,17,56,18" dtype_id="10">
+              <varref loc="d,56,14,56,17" name="t.all" dtype_id="10"/>
+              <const loc="d,56,21,56,25" name="&quot;E04&quot;" dtype_id="10"/>
+            </concatn>
+          </cvtpackstring>
           <varref loc="d,56,7,56,10" name="t.all" dtype_id="10"/>
         </assign>
         <if loc="d,57,10,57,12">


### PR DESCRIPTION
The string type has to be propagated during PRELIM phase already for AstReplicate to allow non-constants as the replication count.

The changes enforce string dtype propagation in AstConcat and AstReplicate, as well as other places using `iterateCheckString`.