### PR TITLE
Ensure coroutines without awaits have a co_return

### DIFF
--- a/test_regress/t/t_fork_join_none_virtual.pl
+++ b/test_regress/t/t_fork_join_none_virtual.pl
@@ -1,0 +1,22 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2023 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    verilator_flags2 => ["--exe --main --timing"],
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_fork_join_none_virtual.v
+++ b/test_regress/t/t_fork_join_none_virtual.v
@@ -1,0 +1,62 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2024 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+event evt1;
+
+typedef enum {ENUM_VALUE} enum_t;
+
+class Foo;
+  int m_member;
+  enum_t m_en;
+
+  virtual task do_something();
+    fork
+      #20 begin
+        m_member++;
+        $display("this's m_member: %0d  m_en: %s", m_member, m_en.name());
+        if (m_member != 3)
+          $stop;
+        ->evt1;
+      end
+      #10 begin
+        m_member++;
+        bar(this);
+      end
+    join_none
+  endtask
+
+  static task bar(Foo foo);
+    fork
+      begin
+        foo.m_member++;
+        $display("foo's m_member: %0d  m_en: %s", foo.m_member, foo.m_en.name());
+        if (foo.m_member != 2)
+          $stop;
+      end
+    join_none
+  endtask
+endclass
+
+class Subfoo extends Foo;
+  virtual task do_something();#5;endtask
+endclass
+
+module t();
+  initial begin
+    Subfoo subfoo;
+    Foo foo;
+    subfoo = new;
+    subfoo.do_something();
+    foo = new;
+    foo.m_member = 0;
+    foo.do_something();
+  end
+
+  always @(evt1) begin
+    $write("*-* All Finished *-*\n");
+    $finish;
+  end
+endmodule


### PR DESCRIPTION
After the V3Timing refactoring the V3SchedTiming phase could apparently move away all awaits from a coroutine without adding a co_return statement.  A sample test added to avoid breaking it again.

Fixes: 729f8b9334ce01d289e31e59a126f1611b20736b ("Move suspendable detection to a separate visitor (#4208)")