### PR TITLE
Fix signed types emit in hierarchical verilation

### DIFF
--- a/src/V3EmitV.cpp
+++ b/src/V3EmitV.cpp
@@ -608,8 +608,8 @@ class EmitVBaseVisitorConst VL_NOT_FINAL : public EmitCBaseVisitorConst {
         puts(";\n");
     }
     void visit(AstBasicDType* nodep) override {
-        if (nodep->isSigned()) putfs(nodep, "signed ");
         putfs(nodep, nodep->prettyName());
+        if (nodep->isSigned()) putfs(nodep, " signed");
         if (nodep->rangep()) {
             puts(" ");
             iterateAndNextConstNull(nodep->rangep());

--- a/test_regress/t/t_debug_emitv.out
+++ b/test_regress/t/t_debug_emitv.out
@@ -7,70 +7,70 @@ module Vt_debug_emitv_t;
     ???? // ENUMITEM 'ZERO'
     32'h0
     ???? // ENUMITEM 'ONE'
-    32'h1signed int [31:0] struct packed 
-    {signed int [31:0]  a;}signed logic [2:0] struct 
-    {signed logic [2:0]  a;}logicunion 
+    32'h1int signed [31:0] struct packed 
+    {int signed [31:0]  a;}logic signed [2:0] struct 
+    {logic signed [2:0]  a;}logicunion 
     {logic a;}struct packed 
-    {signed int [31:0]  a;}bit [31:0] const struct packed 
-    {signed int [31:0]  a;}const struct packed 
-    {signed int [31:0]  a;}[0:2]struct 
-    {signed logic [2:0]  a;}union 
-    {logic a;}signed int [31:0] signed int [31:0] [0:2]logic [15:0] logic [15:0] logic [15:0] signed int [31:0] signed int [31:0] signed int [31:0] 
+    {int signed [31:0]  a;}bit [31:0] const struct packed 
+    {int signed [31:0]  a;}const struct packed 
+    {int signed [31:0]  a;}[0:2]struct 
+    {logic signed [2:0]  a;}union 
+    {logic a;}int signed [31:0] int signed [31:0] [0:2]logic [15:0] logic [15:0] logic [15:0] int signed [31:0] int signed [31:0] int signed [31:0] 
     ???? // QUEUEDTYPE
-    signed int [31:0] string
+    int signed [31:0] string
     ???? // ASSOCARRAYDTYPE
-    signed int [31:0] 
+    int signed [31:0] 
     ???? // DYNARRAYDTYPE
-    signed int [31:0] signed int [31:0] signed int [31:0] signed int [31:0] signed int [31:0] signed int [31:0] signed int [31:0] signed realstringIData [31:0] signed logic [31:0] signed int [31:0] bit [0:0] logic [0:0]  e_t;
+    int signed [31:0] int signed [31:0] int signed [31:0] int signed [31:0] int signed [31:0] int signed [31:0] int signed [31:0] real signedstringIData [31:0] logic signed [31:0] int signed [31:0] bit [0:0] logic [0:0]  e_t;
     typedef struct packed 
-    {signed int [31:0]  a;}signed logic [2:0] struct 
-    {signed logic [2:0]  a;}logicunion 
+    {int signed [31:0]  a;}logic signed [2:0] struct 
+    {logic signed [2:0]  a;}logicunion 
     {logic a;}struct packed 
-    {signed int [31:0]  a;}bit [31:0] const struct packed 
-    {signed int [31:0]  a;}const struct packed 
-    {signed int [31:0]  a;}[0:2]struct 
-    {signed logic [2:0]  a;}union 
-    {logic a;}signed int [31:0] signed int [31:0] [0:2]logic [15:0] logic [15:0] logic [15:0] signed int [31:0] signed int [31:0] signed int [31:0] 
+    {int signed [31:0]  a;}bit [31:0] const struct packed 
+    {int signed [31:0]  a;}const struct packed 
+    {int signed [31:0]  a;}[0:2]struct 
+    {logic signed [2:0]  a;}union 
+    {logic a;}int signed [31:0] int signed [31:0] [0:2]logic [15:0] logic [15:0] logic [15:0] int signed [31:0] int signed [31:0] int signed [31:0] 
     ???? // QUEUEDTYPE
-    signed int [31:0] string
+    int signed [31:0] string
     ???? // ASSOCARRAYDTYPE
-    signed int [31:0] 
+    int signed [31:0] 
     ???? // DYNARRAYDTYPE
-    signed int [31:0] signed int [31:0] signed int [31:0] signed int [31:0] signed int [31:0] signed int [31:0] signed int [31:0] signed realstringIData [31:0] signed logic [31:0] signed int [31:0] bit [0:0] logic [0:0]  ps_t;
+    int signed [31:0] int signed [31:0] int signed [31:0] int signed [31:0] int signed [31:0] int signed [31:0] int signed [31:0] real signedstringIData [31:0] logic signed [31:0] int signed [31:0] bit [0:0] logic [0:0]  ps_t;
     typedef struct 
-    {signed logic [2:0]  a;}logicunion 
+    {logic signed [2:0]  a;}logicunion 
     {logic a;}struct packed 
-    {signed int [31:0]  a;}bit [31:0] const struct packed 
-    {signed int [31:0]  a;}const struct packed 
-    {signed int [31:0]  a;}[0:2]struct 
-    {signed logic [2:0]  a;}union 
-    {logic a;}signed int [31:0] signed int [31:0] [0:2]logic [15:0] logic [15:0] logic [15:0] signed int [31:0] signed int [31:0] signed int [31:0] 
+    {int signed [31:0]  a;}bit [31:0] const struct packed 
+    {int signed [31:0]  a;}const struct packed 
+    {int signed [31:0]  a;}[0:2]struct 
+    {logic signed [2:0]  a;}union 
+    {logic a;}int signed [31:0] int signed [31:0] [0:2]logic [15:0] logic [15:0] logic [15:0] int signed [31:0] int signed [31:0] int signed [31:0] 
     ???? // QUEUEDTYPE
-    signed int [31:0] string
+    int signed [31:0] string
     ???? // ASSOCARRAYDTYPE
-    signed int [31:0] 
+    int signed [31:0] 
     ???? // DYNARRAYDTYPE
-    signed int [31:0] signed int [31:0] signed int [31:0] signed int [31:0] signed int [31:0] signed int [31:0] signed int [31:0] signed realstringIData [31:0] signed logic [31:0] signed int [31:0] bit [0:0] logic [0:0]  us_t;
+    int signed [31:0] int signed [31:0] int signed [31:0] int signed [31:0] int signed [31:0] int signed [31:0] int signed [31:0] real signedstringIData [31:0] logic signed [31:0] int signed [31:0] bit [0:0] logic [0:0]  us_t;
     typedef union 
     {logic a;}struct packed 
-    {signed int [31:0]  a;}bit [31:0] const struct packed 
-    {signed int [31:0]  a;}const struct packed 
-    {signed int [31:0]  a;}[0:2]struct 
-    {signed logic [2:0]  a;}union 
-    {logic a;}signed int [31:0] signed int [31:0] [0:2]logic [15:0] logic [15:0] logic [15:0] signed int [31:0] signed int [31:0] signed int [31:0] 
+    {int signed [31:0]  a;}bit [31:0] const struct packed 
+    {int signed [31:0]  a;}const struct packed 
+    {int signed [31:0]  a;}[0:2]struct 
+    {logic signed [2:0]  a;}union 
+    {logic a;}int signed [31:0] int signed [31:0] [0:2]logic [15:0] logic [15:0] logic [15:0] int signed [31:0] int signed [31:0] int signed [31:0] 
     ???? // QUEUEDTYPE
-    signed int [31:0] string
+    int signed [31:0] string
     ???? // ASSOCARRAYDTYPE
-    signed int [31:0] 
+    int signed [31:0] 
     ???? // DYNARRAYDTYPE
-    signed int [31:0] signed int [31:0] signed int [31:0] signed int [31:0] signed int [31:0] signed int [31:0] signed int [31:0] signed realstringIData [31:0] signed logic [31:0] signed int [31:0] bit [0:0] logic [0:0]  union_t;
+    int signed [31:0] int signed [31:0] int signed [31:0] int signed [31:0] int signed [31:0] int signed [31:0] int signed [31:0] real signedstringIData [31:0] logic signed [31:0] int signed [31:0] bit [0:0] logic [0:0]  union_t;
     struct packed 
-    {signed int [31:0]  a;} ps[0:2];
+    {int signed [31:0]  a;} ps[0:2];
     struct 
-    {signed logic [2:0]  a;} us;
+    {logic signed [2:0]  a;} us;
     union 
     {logic a;} unu;
-    signed int [31:0]  array[0:2];
+    int signed [31:0]  array[0:2];
     initial begin
         array = '{0:32'sh1, 1:32'sh2, 2:32'sh3};
     end
@@ -78,8 +78,8 @@ module Vt_debug_emitv_t;
     logic [15:0]  pubflat_r;
     logic [15:0]  pubflat_w;
     assign pubflat_w = pubflat;
-    signed int [31:0]  fd;
-    signed int [31:0]  i;
+    int signed [31:0]  fd;
+    int signed [31:0]  i;
 
     ???? // QUEUEDTYPE
      q;
@@ -93,7 +93,7 @@ module Vt_debug_emitv_t;
         $display("stmt");
     endtask
     function f;
-        input signed int [31:0]  v;
+        input int signed [31:0]  v;
         begin : label0
             $display("stmt");
             f = ((v == 'sh0) ? 'sh63 : ((~ v) + 'sh1));
@@ -102,10 +102,10 @@ module Vt_debug_emitv_t;
     endfunction
     initial begin
         begin : unnamedblk1
-            signed int [31:0]  other;
+            int signed [31:0]  other;
             begin
                 begin : unnamedblk2
-                    signed int [31:0]  i;
+                    int signed [31:0]  i;
                     i = 'sh0;
                     while ((i < 'sh3)) begin
                         begin
@@ -144,10 +144,10 @@ module Vt_debug_emitv_t;
             $display("negedge clk, pfr = %x", pubflat_r);
         end
     end
-    signed int [31:0]  cyc;
-    signed int [31:0]  fo;
-    signed int [31:0]  sum;
-    signed real r;
+    int signed [31:0]  cyc;
+    int signed [31:0]  fo;
+    int signed [31:0]  sum;
+    real signed r;
     string str;
     always @(posedge clk) begin
         begin
@@ -177,7 +177,7 @@ module Vt_debug_emitv_t;
             $readmemh(fd, array, 'sh0, 'sh0);
             sum = 'sh0;
             begin : unnamedblk3
-                signed int [31:0]  i;
+                int signed [31:0]  i;
                 i = 'sh0;
                 begin : label0
                     while ((i < cyc)) begin
@@ -308,11 +308,11 @@ module Vt_debug_emitv_t;
         end
     end
     /*verilator public_flat_rw @(posedge clk) pubflat*/
-    signed integer [31:0]  __Vrepeat0;
+    integer signed [31:0]  __Vrepeat0;
 endmodule
 package Vt_debug_emitv___024unit;
     class Vt_debug_emitv_Cls;
-        signed int [31:0]  member;
+        int signed [31:0]  member;
         member = 'sh1;
         task method;
         endtask
@@ -322,12 +322,12 @@ package Vt_debug_emitv___024unit;
 endpackage
 module Vt_debug_emitv_sub;
     task inc;
-        input signed int [31:0]  i;
-        output signed int [31:0]  o;
+        input int signed [31:0]  i;
+        output int signed [31:0]  o;
         o = ({32'h1{{1'h0, i[31:1]}}} + 32'h1);
     endtask
     function f;
-        input signed int [31:0]  v;
+        input int signed [31:0]  v;
         begin : label0
             if ((v == 'sh0)) begin
                 f = 'sh21;
@@ -337,8 +337,8 @@ module Vt_debug_emitv_sub;
             disable label0;
         end
     endfunction
-    signed real r;
+    real signed r;
 endmodule
 package Vt_debug_emitv_Pkg;
-    signed logic [31:0]  PKG_PARAM;
+    logic signed [31:0]  PKG_PARAM;
 endpackage

--- a/test_regress/t/t_hier_block_signed_logic.pl
+++ b/test_regress/t/t_hier_block_signed_logic.pl
@@ -1,0 +1,24 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2024 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    verilator_flags2 => ['--stats', '--hierarchical']
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+file_grep($Self->{obj_dir} . "/Vsub/sub.sv", /^module\s+(\S+)\s+/, "sub");
+file_grep($Self->{stats}, qr/HierBlock,\s+Hierarchical blocks\s+(\d+)/i, 1);
+
+ok(1);

--- a/test_regress/t/t_hier_block_signed_logic.v
+++ b/test_regress/t/t_hier_block_signed_logic.v
@@ -1,0 +1,51 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// Copyright 2024 by Antmicro. This program is free software; you can
+// redistribute it and/or modify it under the terms of either the GNU
+// Lesser General Public License Version 3 or the Perl Artistic License
+// Version 2.0.
+// SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+module t(/*AUTOARG*/
+   // inputs
+   clk
+);
+   input clk;
+
+   logic signed [31:0] in1 = 3;
+   logic signed [31:0] in2 = 4;
+   logic signed in_small1 = 1;
+   logic signed in_small2 = -1;
+
+   logic signed [31:0] out1;
+   logic signed [31:0] out2;
+   logic signed out_small1;
+   logic signed out_small2;
+
+   sub sub1(.in(in1), .in_small(in_small1), .out(out1), .out_small(out_small1));
+   sub sub2(.in(in2), .in_small(in_small2), .out(out2), .out_small(out_small2));
+
+   always_ff @(posedge clk) begin
+      if (out1 == signed'(-3)
+            && out2 == signed'(-4)
+            && out_small1 == signed'(1'b1)
+            && out_small2 == signed'(1'b1)) begin
+         $write("*-* All Finished *-*\n");
+         $finish;
+      end
+      else begin
+         $write("Mismatch\n");
+         $stop;
+      end
+   end
+endmodule
+
+module sub(
+   input logic signed [31:0] in,
+   input logic signed in_small,
+   output logic signed [31:0] out,
+   output logic signed out_small
+); /*verilator hier_block*/
+   assign out = -in;
+   assign out_small = -in_small;
+endmodule


### PR DESCRIPTION
Hierarchical verilation of modules marked with `/*verilator hier_block*/` with `signed` ports fails with syntax errors during Verilation. Error appears in the generated ProtectLib wrapper for a hierarchical module library.

This PR resolves this issue by fixing V3EmitV stage for `AstBasicDType` by fixing emitted keywords order.