### PR TITLE
Support cross-module clockvars access

### DIFF
--- a/src/V3AstNodeExpr.h
+++ b/src/V3AstNodeExpr.h
@@ -5645,6 +5645,7 @@ public:
     inline AstVarXRef(FileLine* fl, AstVar* varp, const string& dotted, const VAccess& access);
     ASTGEN_MEMBERS_AstVarXRef;
     string name() const override VL_MT_STABLE { return m_name; }  // * = Var name
+    void name(const std::string& name) override { m_name = name; }  // * = Var name
     void dump(std::ostream& str) const override;
     void dumpJson(std::ostream& str) const override;
     string dotted() const { return m_dotted; }

--- a/src/V3AstNodeOther.h
+++ b/src/V3AstNodeOther.h
@@ -926,8 +926,7 @@ class AstClocking final : public AstNode {
     // Children: SENITEM, CLOCKING ITEMs, VARs
     // @astgen op1 := sensesp : AstSenItem
     // @astgen op2 := itemsp : List[AstClockingItem]
-    // @astgen op3 := varsp : List[AstVar]
-    // @astgen op4 := eventp : Optional[AstVar]
+    // @astgen op3 := eventp : Optional[AstVar]
     std::string m_name;  // Clocking block name
     const bool m_isDefault = false;  // True if default clocking
     const bool m_isGlobal = false;  // True if global clocking

--- a/src/V3Clock.cpp
+++ b/src/V3Clock.cpp
@@ -95,7 +95,6 @@ class ClockVisitor final : public VNVisitor {
             = string{"__Vsampled__"} + vscp->scopep()->nameDotless() + "__" + varp->name();
         FileLine* const flp = vscp->fileline();
         AstVar* const newvarp = new AstVar{flp, VVarType::MODULETEMP, newvarname, varp->dtypep()};
-        newvarp->noReset(true);  // Reset by below assign
         m_scopep->modp()->addStmtsp(newvarp);
         AstVarScope* const newvscp = new AstVarScope{flp, m_scopep, newvarp};
         vscp->user1p(newvscp);

--- a/src/V3LinkDot.cpp
+++ b/src/V3LinkDot.cpp
@@ -2875,6 +2875,7 @@ class LinkDotResolveVisitor final : public VNVisitor {
                 }
             } else if (VN_IS(foundp->nodep(), Clocking)) {
                 m_ds.m_dotSymp = foundp;
+                if (m_ds.m_dotText != "") m_ds.m_dotText += "." + nodep->name();
                 ok = m_ds.m_dotPos == DP_SCOPE;
             } else if (const AstNodeFTask* const ftaskp = VN_CAST(foundp->nodep(), NodeFTask)) {
 

--- a/src/V3Scope.cpp
+++ b/src/V3Scope.cpp
@@ -51,7 +51,6 @@ class ScopeVisitor final : public VNVisitor {
     // STATE, for passing down one level of hierarchy (may need save/restore)
     AstCell* m_aboveCellp = nullptr;  // Cell that instantiates this module
     AstScope* m_aboveScopep = nullptr;  // Scope that instantiates this scope
-    AstClocking* m_clockingp = nullptr;  // Current clocking block
 
     std::unordered_map<AstNodeModule*, AstScope*> m_packageScopes;  // Scopes for each package
     VarScopeMap m_varScopes;  // Varscopes created for each scope and var
@@ -243,15 +242,6 @@ class ScopeVisitor final : public VNVisitor {
         // We iterate under the *clone*
         iterateChildren(clonep);
     }
-    void visit(AstClocking* nodep) override {
-        VL_RESTORER(m_clockingp);
-        m_clockingp = nodep;
-        UINFO(4, "    CLOCKING " << nodep << endl);
-        iterateChildren(nodep);
-        if (nodep->varsp()) m_scopep->modp()->addStmtsp(nodep->varsp()->unlinkFrBackWithNext());
-        if (nodep->eventp()) m_scopep->modp()->addStmtsp(nodep->eventp()->unlinkFrBack());
-        VL_DO_DANGLING(pushDeletep(nodep->unlinkFrBack()), nodep);
-    }
     void visit(AstNodeFTask* nodep) override {
         // Add to list of blocks under this scope
         UINFO(4, "    FTASK " << nodep << endl);
@@ -270,9 +260,7 @@ class ScopeVisitor final : public VNVisitor {
     }
     void visit(AstVar* nodep) override {
         // Make new scope variable
-        if (m_clockingp) {
-            nodep->name(VString::dot(m_clockingp->name(), "__DOT__", nodep->name()));
-        } else if (!nodep->user1p()) {
+        if (!nodep->user1p()) {
             AstScope* scopep = m_scopep;
             if (AstIfaceRefDType* const ifacerefp = VN_CAST(nodep->dtypep(), IfaceRefDType)) {
                 // Attach every non-virtual interface variable its inner scope

--- a/test_regress/t/t_clocking_xref.pl
+++ b/test_regress/t/t_clocking_xref.pl
@@ -1,0 +1,22 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2022 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    verilator_flags2 => ["--exe --main --timing"],
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_clocking_xref.v
+++ b/test_regress/t/t_clocking_xref.v
@@ -1,0 +1,46 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2024 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+module mod;
+   logic clk = 1'b0;
+   logic inp = 1'b0;
+   clocking cb @(posedge clk);
+       input #3 inp;
+   endclocking
+   always @(posedge clk) inp <= 1'b1;
+   always #1 clk = ~clk;
+endmodule
+
+module main;
+   logic clk = 1'b0;
+   logic inp = 1'b0;
+   always begin
+      #2
+      if (t.mod1.cb.inp != 1'b0) $stop;
+      if (t.main1.cbb.inp != 1'b0) $stop;
+      if (t.main2.cbb.inp != 1'b0) $stop;
+      #4;
+      if (t.mod1.cb.inp != 1'b1) $stop;
+      if (t.main1.cbb.inp != 1'b1) $stop;
+      if (t.main2.cbb.inp != 1'b1) $stop;
+   end
+   clocking cbb @(posedge clk);
+       input #3 inp;
+   endclocking
+   always @(posedge clk) inp <= 1'b1;
+   always #1 clk = ~clk;
+endmodule
+
+module t;
+   main main1();
+   mod mod1();
+   main main2();
+   initial begin
+      #7;
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end
+endmodule


### PR DESCRIPTION
By removing clocking blocks earlier (V3AssertPre instead of V3Scope), we do not need to deal with both resolving scopes and relinking moved clockvars in a single LinkDot pass.

Because VarXRefs are relinked so many times, we need to rename variables and all their references exactly when they are moved out of the clocking block. Only then can it be removed.

Therefore, AssertPre has to resolve cells' modules first, in order to rename variables before their VarXRefs. This changes traversal order, but should not break anything.


Before, XRefs to clockvars were silently changed to XRefs to normal variables they referred to, immediately after being constructed. (I tried setting user3 on fresh XRefs in LinkDot, which would save one duplicate symbol lookup for each XRef, but apparently this delays modport failures for some reason, so I left it.)
The changes should minimally reduce the elaboration-time memory footprint and give a tiny verilation speedup when clocking blocks are present in the design.