### PR TITLE
Link with pthreads on Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ verilator-config-version.cmake
 /test_regress/snapshot/
 xmverilog.*
 xrun.history
+
+# Normal CMake build directory
+/build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
 include(CheckStructHasMember)
 include(ExternalProject)
+include(FindThreads)
 
 if (NOT WIN32)
     message(WARNING "CMake support on Linux/OSX is experimental.")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -488,6 +488,8 @@ add_dependencies(${verilator}
     V3PreLex_yy_cpp${CMAKE_BUILD_TYPE}
 )
 
+target_link_libraries(${verilator} PRIVATE Threads::Threads)
+
 # verilated_cov_key.h is only regenerated in a single-configuration environment.
 # This limitation can be lifted when `add_dependencies` will support generator
 # expressions. See https://gitlab.kitware.com/cmake/cmake/issues/19467


### PR DESCRIPTION
When building on Linux (at least using GCC 8.5) you need to pass `-lpthread` otherwise you get an undefined symbol error for `pthread_create`.

With this change the standard CMake build process works on RHEL 8, which is much easier than autoconf etc!

We appreciate your contributing to Verilator.  If this is your first commit, please add your name to docs/CONTRIBUTORS, and read our contributing guidelines in docs/CONTRIBUTING.rst.

I have not tested it on Windows/Mac.