### PR TITLE
Resolve unable to add additional includes to precompiled header

### DIFF
--- a/bin/verilator
+++ b/bin/verilator
@@ -324,6 +324,7 @@ detailed descriptions of these arguments.
     --clk <signal-name>         Mark specified signal as clock
     --no-clk <signal-name>      Prevent marking specified signal as clock
     --compiler <compiler-name>  Tune for specified C++ compiler
+    --compiler-include          Include additional header in the precompiled one
     --converge-limit <loops>    Tune convergence settle time
     --coverage                  Enable all coverage
     --coverage-line             Enable line coverage

--- a/docs/guide/exe_verilator.rst
+++ b/docs/guide/exe_verilator.rst
@@ -222,6 +222,13 @@ Summary:
      expressions into sub-expressions to avoid error C1009, and breaking
      deep blocks into functions to avoid error C1061.
 
+.. option:: --compiler-include <header-path>
+
+   Specifies additional headers to be included in the final PCH header.
+   It is required to add them to this header, due to compilers'
+   limitation that allow only one precompiled header per compilation.
+   Use this instead of ::vlopt:`-CFLAGS` with `-include <header-path>`.
+
 .. option:: --converge-limit <loops>
 
    Rarely needed.  Specifies the maximum number of runtime iterations

--- a/src/V3EmitCPch.cpp
+++ b/src/V3EmitCPch.cpp
@@ -57,6 +57,11 @@ public:
         of.puts("#include \"" + symClassName() + ".h\"\n");
         of.puts("#include \"" + topClassName() + ".h\"\n");
 
+        of.puts("\n// Additional include files added using '--compiler-include'\n");
+        for (const string& filename : v3Global.opt.compilerIncludes()) {
+            of.puts("#include \"" + filename + "\"\n");
+        }
+
         of.putsEndGuard();
     }
 

--- a/src/V3Options.cpp
+++ b/src/V3Options.cpp
@@ -361,6 +361,9 @@ void V3Options::checkParameters() {
 
 void V3Options::addCppFile(const string& filename) { m_cppFiles.insert(filename); }
 void V3Options::addCFlags(const string& filename) { m_cFlags.push_back(filename); }
+void V3Options::addCompilerIncludes(const string& filename) {
+    m_compilerIncludes.insert(filename);
+}
 void V3Options::addLdLibs(const string& filename) { m_ldLibs.push_back(filename); }
 void V3Options::addMakeFlags(const string& filename) { m_makeFlags.push_back(filename); }
 void V3Options::addFuture(const string& flag) { m_futures.insert(flag); }
@@ -1186,6 +1189,7 @@ void V3Options::parseOptsList(FileLine* fl, const string& optdir, int argc,
                         << fl->warnMore() << "... Suggest 'clang', 'gcc', or 'msvc'");
         }
     });
+    DECL_OPTION("-compiler-include", CbVal, callStrSetter(&V3Options::addCompilerIncludes));
     DECL_OPTION("-coverage", CbOnOff, [this](bool flag) { coverage(flag); });
     DECL_OPTION("-converge-limit", Set, &m_convergeLimit);
     DECL_OPTION("-coverage-line", OnOff, &m_coverageLine);

--- a/src/V3Options.h
+++ b/src/V3Options.h
@@ -203,6 +203,7 @@ private:
     V3StringList m_cFlags;      // argument: user CFLAGS
     V3StringList m_ldLibs;      // argument: user LDFLAGS
     V3StringList m_makeFlags;   // argument: user MAKEFLAGS
+    V3StringSet m_compilerIncludes; // argument: user --compiler-include
     V3StringSet m_futures;      // argument: -Wfuture- list
     V3StringSet m_future0s;     // argument: -future list
     V3StringSet m_future1s;     // argument: -future1 list
@@ -434,6 +435,7 @@ public:
     // METHODS
     void addCppFile(const string& filename);
     void addCFlags(const string& filename);
+    void addCompilerIncludes(const string& filename);
     void addLdLibs(const string& filename);
     void addMakeFlags(const string& filename);
     void addLibraryFile(const string& filename);
@@ -626,6 +628,7 @@ public:
 
     const V3StringSet& cppFiles() const { return m_cppFiles; }
     const V3StringList& cFlags() const { return m_cFlags; }
+    const V3StringSet& compilerIncludes() const { return m_compilerIncludes; }
     const V3StringList& ldLibs() const { return m_ldLibs; }
     const V3StringList& makeFlags() const { return m_makeFlags; }
     const V3StringSet& libraryFiles() const { return m_libraryFiles; }

--- a/test_regress/t/t_compiler_include.cpp
+++ b/test_regress/t/t_compiler_include.cpp
@@ -1,0 +1,42 @@
+// -*- mode: C++; c-file-style: "cc-mode" -*-
+//*************************************************************************
+//
+// Copyright 2009-2024 by Antmicro. This program is free software; you can
+// redistribute it and/or modify it under the terms of either the GNU
+// Lesser General Public License Version 3 or the Perl Artistic License
+// Version 2.0.
+// SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+//
+//*************************************************************************
+
+#include "svdpi.h"
+
+// These require the above. Comment prevents clang-format moving them
+#include "TestCheck.h"
+
+//======================================================================
+
+// clang-format off
+#if defined(VERILATOR)
+# include "Vt_compiler_include__Dpi.h"
+#elif defined(VCS)
+# include "../vc_hdrs.h"
+#elif defined(NC)
+# define NEED_EXTERNS
+// #elif defined(MS)
+// # define NEED_EXTERNS
+#else
+# error "Unknown simulator for DPI test"
+#endif
+// clang-format on
+
+#ifdef NEED_EXTERNS
+extern "C" {
+// If get ncsim: *F,NOFDPI: Function {foo} not found in default libdpi.
+// Then probably forgot to list a function here.
+
+extern void dpii_add(int a, int b, int* out);
+}
+#endif
+
+void dpii_add(int a, int b, int* out) { *out = a + b; }

--- a/test_regress/t/t_compiler_include.h
+++ b/test_regress/t/t_compiler_include.h
@@ -1,0 +1,6 @@
+#ifndef T_COMPILER_INCLUDE_H
+#define T_COMPILER_INCLUDE_H
+
+extern "C" int dpii_add_check(int actual, int expected) { return actual == expected; }
+
+#endif

--- a/test_regress/t/t_compiler_include.h
+++ b/test_regress/t/t_compiler_include.h
@@ -1,6 +1,14 @@
-#ifndef T_COMPILER_INCLUDE_H
-#define T_COMPILER_INCLUDE_H
+// -*- mode: C++; c-file-style: "cc-mode" -*-
+//*************************************************************************
+//
+// Copyright 2009-2024 by Antmicro. This program is free software; you can
+// redistribute it and/or modify it under the terms of either the GNU
+// Lesser General Public License Version 3 or the Perl Artistic License
+// Version 2.0.
+// SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+//
+//*************************************************************************
+
+// no header guards to check if included once in pch file
 
 extern "C" int dpii_add_check(int actual, int expected) { return actual == expected; }
-
-#endif

--- a/test_regress/t/t_compiler_include.pl
+++ b/test_regress/t/t_compiler_include.pl
@@ -1,0 +1,23 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2024 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    v_flags2 => ["t/t_compiler_include.cpp"],
+    verilator_flags2 => ["-Wall -Wno-DECLFILENAME --compiler-include $Self->{t_dir}/t_compiler_include.h"],
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_compiler_include.v
+++ b/test_regress/t/t_compiler_include.v
@@ -1,0 +1,31 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// Copyright 2024 by Antmicro. This program is free software; you can
+// redistribute it and/or modify it under the terms of either the GNU
+// Lesser General Public License Version 3 or the Perl Artistic License
+// Version 2.0.
+// SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+module t (/*AUTOARG*/);
+   int a = 123;
+   int b = 321;
+   int out;
+
+   import "DPI-C" function void dpii_add
+     (int a, int b, ref int out);
+   import "DPI-C" function int dpii_add_check
+     (int actual, int expected);
+
+   initial begin
+      dpii_add(a, b, out);
+      if (dpii_add_check(out, (a + b)) != 1) begin
+         $write("%%Error: Failure in DPI tests\n");
+         $stop;
+      end
+      else begin
+         $write("*-* All Finished *-*\n");
+         $finish;
+      end
+   end
+
+endmodule


### PR DESCRIPTION
As reported in https://github.com/verilator/verilator/issues/5139, currently `-CFLAGS -include '<header-path>'` option does not include header in the main precompiled one. This PR introduces new option `--compiler-include <header-path>` which appends include with specified header to the main precompiled header. Using this flag fixes problem with missing additional include headers.

Resolves https://github.com/verilator/verilator/issues/5139.

Sidenote: Should we warn users that use `-CFLAGS -include '<header-path>'` to use `--compiler-include` instead?