### PR TITLE
Fix typo in trace command descriptions

### DIFF
--- a/bin/verilator
+++ b/bin/verilator
@@ -461,8 +461,8 @@ detailed descriptions of these arguments.
     --trace-coverage            Enable tracing of coverage
     --trace-depth <levels>      Depth of tracing
     --trace-fst                 Enable FST waveform creation
-    --trace-max-array <depth>   Maximum bit width for tracing
-    --trace-max-width <width>   Maximum array depth for tracing
+    --trace-max-array <depth>   Maximum array depth for tracing
+    --trace-max-width <width>   Maximum bit width for tracing
     --trace-params              Enable tracing of parameters
     --trace-structs             Enable tracing structure names
     --trace-threads <threads>   Enable FST waveform creation on separate threads

--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -217,3 +217,4 @@ Zhanglei Wang
 Zhou Shen
 Zixi Li
 أحمد المحمودي
+404allen404


### PR DESCRIPTION
Corrected the descriptions for --trace-max-array and --trace-max-width options
