### PR TITLE
Make rand-assign independent of rand-init

### DIFF
--- a/include/verilated.cpp
+++ b/include/verilated.cpp
@@ -412,6 +412,8 @@ IData VL_RAND_RESET_I(int obits) VL_MT_SAFE {
     data &= VL_MASK_I(obits);
     return data;
 }
+IData VL_RAND_RESET_ASSIGN_I(int obits) VL_MT_SAFE { return VL_RANDOM_I() & VL_MASK_I(obits); }
+
 QData VL_RAND_RESET_Q(int obits) VL_MT_SAFE {
     if (Verilated::threadContextp()->randReset() == 0) return 0;
     QData data = ~0ULL;
@@ -421,9 +423,17 @@ QData VL_RAND_RESET_Q(int obits) VL_MT_SAFE {
     data &= VL_MASK_Q(obits);
     return data;
 }
+
+QData VL_RAND_RESET_ASSIGN_Q(int obits) VL_MT_SAFE { return VL_RANDOM_Q() & VL_MASK_Q(obits); }
+
 WDataOutP VL_RAND_RESET_W(int obits, WDataOutP outwp) VL_MT_SAFE {
     for (int i = 0; i < VL_WORDS_I(obits) - 1; ++i) outwp[i] = VL_RAND_RESET_I(32);
     outwp[VL_WORDS_I(obits) - 1] = VL_RAND_RESET_I(32) & VL_MASK_E(obits);
+    return outwp;
+}
+WDataOutP VL_RAND_RESET_ASSIGN_W(int obits, WDataOutP outwp) VL_MT_SAFE {
+    for (int i = 0; i < VL_WORDS_I(obits) - 1; ++i) outwp[i] = VL_RAND_RESET_ASSIGN_I(32);
+    outwp[VL_WORDS_I(obits) - 1] = VL_RAND_RESET_ASSIGN_I(32) & VL_MASK_E(obits);
     return outwp;
 }
 WDataOutP VL_ZERO_RESET_W(int obits, WDataOutP outwp) VL_MT_SAFE {

--- a/include/verilated_funcs.h
+++ b/include/verilated_funcs.h
@@ -106,6 +106,14 @@ extern IData VL_RAND_RESET_I(int obits) VL_MT_SAFE;
 extern QData VL_RAND_RESET_Q(int obits) VL_MT_SAFE;
 /// Random reset a signal of given width (init time only)
 extern WDataOutP VL_RAND_RESET_W(int obits, WDataOutP outwp) VL_MT_SAFE;
+
+/// Random reset a signal of given width (assign time only)
+extern IData VL_RAND_RESET_ASSIGN_I(int obits) VL_MT_SAFE;
+/// Random reset a signal of given width (assign time only)
+extern QData VL_RAND_RESET_ASSIGN_Q(int obits) VL_MT_SAFE;
+/// Random reset a signal of given width (assign time only)
+extern WDataOutP VL_RAND_RESET_ASSIGN_W(int obits, WDataOutP outwp) VL_MT_SAFE;
+
 /// Zero reset a signal (slow - else use VL_ZERO_W)
 extern WDataOutP VL_ZERO_RESET_W(int obits, WDataOutP outwp) VL_MT_SAFE;
 

--- a/src/V3AstNodeExpr.h
+++ b/src/V3AstNodeExpr.h
@@ -1744,13 +1744,27 @@ public:
                        : (m_urandom ? "%f$urandom()" : "%f$random()");
     }
     string emitC() override {
-        return m_reset ? "VL_RAND_RESET_%nq(%nw, %P)"
-               : seedp()
-                   // cppcheck-has-bug-suppress knownConditionTrueFalse
-                   ? (urandom() ? "VL_URANDOM_SEEDED_%nq%lq(%li)"  //
-                                : "VL_RANDOM_SEEDED_%nq%lq(%li)")
-                   : (isWide() ? "VL_RANDOM_%nq(%nw, %P)"  //
-                               : "VL_RANDOM_%nq()");
+        if (m_reset) {
+            if (v3Global.opt.xAssign() == "unique") {
+                return "VL_RAND_RESET_ASSIGN_%nq(%nw, %P)";
+            } else {
+                // This follow xInitial Randomization
+                return "VL_RAND_RESET_%nq(%nw, %P)";
+            }
+        }
+        if (seedp()) {
+            if (urandom()) {
+                return "VL_URANDOM_SEEDED_%nq%lq(%li)";
+            } else {
+                return "VL_RANDOM_SEEDED_%nq%lq(%li)";
+            }
+        }
+
+        if (isWide()) {
+            return "VL_RANDOM_%nq(%nw, %P)";
+        } else {
+            return "VL_RANDOM_%nq()";
+        }
     }
     bool cleanOut() const override { return false; }
     bool isGateOptimizable() const override { return false; }

--- a/src/V3AstNodeExpr.h
+++ b/src/V3AstNodeExpr.h
@@ -1748,7 +1748,7 @@ public:
             if (v3Global.opt.xAssign() == "unique") {
                 return "VL_RAND_RESET_ASSIGN_%nq(%nw, %P)";
             } else {
-                // This follow xInitial Randomization
+                // This follows xInitial randomization
                 return "VL_RAND_RESET_%nq(%nw, %P)";
             }
         }

--- a/test_regress/t/t_var_types.pl
+++ b/test_regress/t/t_var_types.pl
@@ -13,6 +13,7 @@ scenarios(simulator => 1);
 $Self->{verilated_randReset} = 1;  # allow checking if we initialize vars to zero only when needed
 
 compile(
+    verilator_flags2 => ["--x-assign 1"],
     );
 
 execute(

--- a/test_regress/t/t_x_assign.cpp
+++ b/test_regress/t/t_x_assign.cpp
@@ -45,10 +45,17 @@ int main(int argc, const char** argv) {
     top->clk = 1;
     top->eval();
 
+#if defined(T_X_ASSIGN_UNIQUE_0) || defined(T_X_ASSIGN_UNIQUE_1)
+    if (top->o_int == 0 || top->o_int == -1) {
+        vl_fatal(__FILE__, __LINE__, "TOP.t", "x assign was not unique");
+        exit(1);
+    }
+#else
     if (top->o != EXPECTED) {
         vl_fatal(__FILE__, __LINE__, "TOP.t", "incorrect module output");
         exit(1);
     }
+#endif
 
     VL_DO_DANGLING(delete top, top);
     std::cout << "*-* All Finished *-*" << std::endl;

--- a/test_regress/t/t_x_assign.v
+++ b/test_regress/t/t_x_assign.v
@@ -8,9 +8,11 @@
 
 module t_x_assign(
    input wire clk,
-   output reg o
+   output reg o,
+   output reg[31:0] o_int
 );
    always @(posedge clk) begin
       if (1'bx) o <= 1'd1; else o <= 1'd0;
+      o_int <= 'x;
    end
 endmodule


### PR DESCRIPTION
`--x-assign` unique does not work if `+verilator+rand+reset` is not also set to unique. This PR makes the undefined initial and the x assign independent as the documentation would imply. This is one proposed solution, but I think the rand code could use a simplification or a refactor. It's a bit confusing having both build and runtime args for something that in my opinion should be a runtime only thing