### PR TITLE
State-dependent constraints

### DIFF
--- a/include/verilated_random.cpp
+++ b/include/verilated_random.cpp
@@ -414,6 +414,8 @@ void VlRandomizer::hard(std::string&& constraint) {
     m_constraints.emplace_back(std::move(constraint));
 }
 
+void VlRandomizer::clear() { m_constraints.clear(); }
+
 #ifdef VL_DEBUG
 void VlRandomizer::dump() const {
     for (const auto& var : m_vars) {

--- a/include/verilated_random.h
+++ b/include/verilated_random.h
@@ -112,6 +112,7 @@ public:
         m_vars[name] = std::make_shared<const VlRandomVar>(name, width, &var);
     }
     void hard(std::string&& constraint);
+    void clear();
 #ifdef VL_DEBUG
     void dump() const;
 #endif

--- a/test_regress/t/t_constraint_json_only.out
+++ b/test_regress/t/t_constraint_json_only.out
@@ -50,162 +50,175 @@
       ],"scopeNamep": []},
       {"type":"FUNC","name":"new","addr":"(KB)","loc":"d,7:1,7:6","dtypep":"(LB)","method":true,"dpiExport":false,"dpiImport":false,"dpiOpenChild":false,"dpiOpenParent":false,"prototype":false,"recursive":false,"taskPublic":false,"cname":"new","fvarp": [],"classOrPackagep": [],
        "stmtsp": [
-        {"type":"STMTEXPR","name":"","addr":"(MB)","loc":"d,19:15,19:20",
+        {"type":"STMTEXPR","name":"","addr":"(MB)","loc":"d,8:13,8:19",
          "exprp": [
-          {"type":"TASKREF","name":"empty_setup_constraint","addr":"(NB)","loc":"d,19:15,19:20","dtypep":"(LB)","dotted":"","taskp":"(OB)","classOrPackagep":"UNLINKED","namep": [],"pinsp": [],"scopeNamep": []}
+          {"type":"CMETHODHARD","name":"write_var","addr":"(NB)","loc":"d,8:13,8:19","dtypep":"(LB)",
+           "fromp": [
+            {"type":"VARREF","name":"constraint","addr":"(OB)","loc":"d,8:13,8:19","dtypep":"(PB)","access":"RW","varp":"(QB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+          ],
+           "pinsp": [
+            {"type":"VARREF","name":"header","addr":"(RB)","loc":"d,8:13,8:19","dtypep":"(Q)","access":"WR","varp":"(P)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"},
+            {"type":"CONST","name":"64'h20","addr":"(SB)","loc":"d,8:9,8:12","dtypep":"(TB)"},
+            {"type":"CEXPR","name":"","addr":"(UB)","loc":"d,8:13,8:19","dtypep":"(Q)",
+             "exprsp": [
+              {"type":"TEXT","name":"","addr":"(VB)","loc":"d,8:13,8:19","shortText":"\"header\""}
+            ]}
+          ]}
         ]},
-        {"type":"STMTEXPR","name":"","addr":"(PB)","loc":"d,21:15,21:19",
+        {"type":"STMTEXPR","name":"","addr":"(WB)","loc":"d,9:13,9:19",
          "exprp": [
-          {"type":"TASKREF","name":"size_setup_constraint","addr":"(QB)","loc":"d,21:15,21:19","dtypep":"(LB)","dotted":"","taskp":"(RB)","classOrPackagep":"UNLINKED","namep": [],"pinsp": [],"scopeNamep": []}
+          {"type":"CMETHODHARD","name":"write_var","addr":"(XB)","loc":"d,9:13,9:19","dtypep":"(LB)",
+           "fromp": [
+            {"type":"VARREF","name":"constraint","addr":"(YB)","loc":"d,9:13,9:19","dtypep":"(PB)","access":"RW","varp":"(QB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+          ],
+           "pinsp": [
+            {"type":"VARREF","name":"length","addr":"(ZB)","loc":"d,9:13,9:19","dtypep":"(Q)","access":"WR","varp":"(R)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"},
+            {"type":"CONST","name":"64'h20","addr":"(AC)","loc":"d,8:9,8:12","dtypep":"(TB)"},
+            {"type":"CEXPR","name":"","addr":"(BC)","loc":"d,9:13,9:19","dtypep":"(Q)",
+             "exprsp": [
+              {"type":"TEXT","name":"","addr":"(CC)","loc":"d,9:13,9:19","shortText":"\"length\""}
+            ]}
+          ]}
         ]},
-        {"type":"STMTEXPR","name":"","addr":"(SB)","loc":"d,28:15,28:18",
+        {"type":"STMTEXPR","name":"","addr":"(DC)","loc":"d,10:13,10:22",
          "exprp": [
-          {"type":"TASKREF","name":"ifs_setup_constraint","addr":"(TB)","loc":"d,28:15,28:18","dtypep":"(LB)","dotted":"","taskp":"(UB)","classOrPackagep":"UNLINKED","namep": [],"pinsp": [],"scopeNamep": []}
-        ]},
-        {"type":"STMTEXPR","name":"","addr":"(VB)","loc":"d,39:15,39:23",
-         "exprp": [
-          {"type":"TASKREF","name":"arr_uniq_setup_constraint","addr":"(WB)","loc":"d,39:15,39:23","dtypep":"(LB)","dotted":"","taskp":"(XB)","classOrPackagep":"UNLINKED","namep": [],"pinsp": [],"scopeNamep": []}
-        ]},
-        {"type":"STMTEXPR","name":"","addr":"(YB)","loc":"d,46:15,46:20",
-         "exprp": [
-          {"type":"TASKREF","name":"order_setup_constraint","addr":"(ZB)","loc":"d,46:15,46:20","dtypep":"(LB)","dotted":"","taskp":"(AC)","classOrPackagep":"UNLINKED","namep": [],"pinsp": [],"scopeNamep": []}
-        ]},
-        {"type":"STMTEXPR","name":"","addr":"(BC)","loc":"d,48:15,48:18",
-         "exprp": [
-          {"type":"TASKREF","name":"dis_setup_constraint","addr":"(CC)","loc":"d,48:15,48:18","dtypep":"(LB)","dotted":"","taskp":"(DC)","classOrPackagep":"UNLINKED","namep": [],"pinsp": [],"scopeNamep": []}
-        ]},
-        {"type":"STMTEXPR","name":"","addr":"(EC)","loc":"d,54:15,54:19",
-         "exprp": [
-          {"type":"TASKREF","name":"meth_setup_constraint","addr":"(FC)","loc":"d,54:15,54:19","dtypep":"(LB)","dotted":"","taskp":"(GC)","classOrPackagep":"UNLINKED","namep": [],"pinsp": [],"scopeNamep": []}
+          {"type":"CMETHODHARD","name":"write_var","addr":"(EC)","loc":"d,10:13,10:22","dtypep":"(LB)",
+           "fromp": [
+            {"type":"VARREF","name":"constraint","addr":"(FC)","loc":"d,10:13,10:22","dtypep":"(PB)","access":"RW","varp":"(QB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+          ],
+           "pinsp": [
+            {"type":"VARREF","name":"sublength","addr":"(GC)","loc":"d,10:13,10:22","dtypep":"(Q)","access":"WR","varp":"(S)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"},
+            {"type":"CONST","name":"64'h20","addr":"(HC)","loc":"d,8:9,8:12","dtypep":"(TB)"},
+            {"type":"CEXPR","name":"","addr":"(IC)","loc":"d,10:13,10:22","dtypep":"(Q)",
+             "exprsp": [
+              {"type":"TEXT","name":"","addr":"(JC)","loc":"d,10:13,10:22","shortText":"\"sublength\""}
+            ]}
+          ]}
         ]}
       ],"scopeNamep": []},
-      {"type":"TASK","name":"empty_setup_constraint","addr":"(OB)","loc":"d,7:1,7:6","method":true,"dpiExport":false,"dpiImport":false,"dpiOpenChild":false,"dpiOpenParent":false,"prototype":false,"recursive":false,"taskPublic":false,"cname":"empty_setup_constraint","fvarp": [],"classOrPackagep": [],"stmtsp": [],"scopeNamep": []},
-      {"type":"VAR","name":"constraint","addr":"(HC)","loc":"d,19:15,19:20","dtypep":"(IC)","origName":"constraint","isSc":false,"isPrimaryIO":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"attrClocker":"UNKNOWN","lifetime":"NONE","varType":"MEMBER","dtypeName":"VlRandomizer","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
-      {"type":"TASK","name":"size_setup_constraint","addr":"(RB)","loc":"d,7:1,7:6","method":true,"dpiExport":false,"dpiImport":false,"dpiOpenChild":false,"dpiOpenParent":false,"prototype":false,"recursive":false,"taskPublic":false,"cname":"size_setup_constraint","fvarp": [],"classOrPackagep": [],
+      {"type":"FUNC","name":"randomize","addr":"(KC)","loc":"d,7:1,7:6","dtypep":"(LC)","method":true,"dpiExport":false,"dpiImport":false,"dpiOpenChild":false,"dpiOpenParent":false,"prototype":false,"recursive":false,"taskPublic":false,"cname":"randomize",
+       "fvarp": [
+        {"type":"VAR","name":"randomize","addr":"(MC)","loc":"d,7:1,7:6","dtypep":"(LC)","origName":"randomize","isSc":false,"isPrimaryIO":false,"direction":"OUTPUT","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":true,"isFuncLocal":true,"attrClocker":"UNKNOWN","lifetime":"VAUTOM","varType":"MEMBER","dtypeName":"bit","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []}
+      ],"classOrPackagep": [],
        "stmtsp": [
-        {"type":"STMTEXPR","name":"","addr":"(JC)","loc":"d,8:13,8:19",
+        {"type":"STMTEXPR","name":"","addr":"(NC)","loc":"d,7:1,7:6",
          "exprp": [
-          {"type":"CMETHODHARD","name":"write_var","addr":"(KC)","loc":"d,8:13,8:19","dtypep":"(LB)",
+          {"type":"CMETHODHARD","name":"clear","addr":"(OC)","loc":"d,7:1,7:6","dtypep":"(LB)",
            "fromp": [
-            {"type":"VARREF","name":"constraint","addr":"(LC)","loc":"d,8:13,8:19","dtypep":"(IC)","access":"RW","varp":"(HC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
-          ],
-           "pinsp": [
-            {"type":"VARREF","name":"header","addr":"(MC)","loc":"d,8:13,8:19","dtypep":"(Q)","access":"WR","varp":"(P)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"},
-            {"type":"CONST","name":"64'h20","addr":"(NC)","loc":"d,8:9,8:12","dtypep":"(OC)"},
-            {"type":"CEXPR","name":"","addr":"(PC)","loc":"d,8:13,8:19","dtypep":"(Q)",
-             "exprsp": [
-              {"type":"TEXT","name":"","addr":"(QC)","loc":"d,8:13,8:19","shortText":"\"header\""}
-            ]}
-          ]}
+            {"type":"VARREF","name":"constraint","addr":"(PC)","loc":"d,7:1,7:6","dtypep":"(PB)","access":"RW","varp":"(QB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+          ],"pinsp": []}
         ]},
-        {"type":"STMTEXPR","name":"","addr":"(RC)","loc":"d,22:18,22:20",
+        {"type":"STMTEXPR","name":"","addr":"(QC)","loc":"d,19:15,19:20",
          "exprp": [
-          {"type":"CMETHODHARD","name":"hard","addr":"(SC)","loc":"d,22:18,22:20","dtypep":"(LB)",
-           "fromp": [
-            {"type":"VARREF","name":"constraint","addr":"(TC)","loc":"d,22:18,22:20","dtypep":"(IC)","access":"RW","varp":"(HC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
-          ],
-           "pinsp": [
-            {"type":"CONST","name":"\\\"(and (bvsgt header #x00000000) (bvsle header #x00000007))\\\"","addr":"(UC)","loc":"d,22:18,22:20","dtypep":"(M)"}
-          ]}
+          {"type":"TASKREF","name":"empty_setup_constraint","addr":"(RC)","loc":"d,19:15,19:20","dtypep":"(LB)","dotted":"","taskp":"(SC)","classOrPackagep":"UNLINKED","namep": [],"pinsp": [],"scopeNamep": []}
         ]},
-        {"type":"STMTEXPR","name":"","addr":"(VC)","loc":"d,9:13,9:19",
+        {"type":"STMTEXPR","name":"","addr":"(TC)","loc":"d,21:15,21:19",
          "exprp": [
-          {"type":"CMETHODHARD","name":"write_var","addr":"(WC)","loc":"d,9:13,9:19","dtypep":"(LB)",
-           "fromp": [
-            {"type":"VARREF","name":"constraint","addr":"(XC)","loc":"d,9:13,9:19","dtypep":"(IC)","access":"RW","varp":"(HC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
-          ],
-           "pinsp": [
-            {"type":"VARREF","name":"length","addr":"(YC)","loc":"d,9:13,9:19","dtypep":"(Q)","access":"WR","varp":"(R)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"},
-            {"type":"CONST","name":"64'h20","addr":"(ZC)","loc":"d,8:9,8:12","dtypep":"(OC)"},
-            {"type":"CEXPR","name":"","addr":"(AD)","loc":"d,9:13,9:19","dtypep":"(Q)",
-             "exprsp": [
-              {"type":"TEXT","name":"","addr":"(BD)","loc":"d,9:13,9:19","shortText":"\"length\""}
-            ]}
-          ]}
+          {"type":"TASKREF","name":"size_setup_constraint","addr":"(UC)","loc":"d,21:15,21:19","dtypep":"(LB)","dotted":"","taskp":"(VC)","classOrPackagep":"UNLINKED","namep": [],"pinsp": [],"scopeNamep": []}
         ]},
-        {"type":"STMTEXPR","name":"","addr":"(CD)","loc":"d,23:14,23:16",
+        {"type":"STMTEXPR","name":"","addr":"(WC)","loc":"d,28:15,28:18",
          "exprp": [
-          {"type":"CMETHODHARD","name":"hard","addr":"(DD)","loc":"d,23:14,23:16","dtypep":"(LB)",
-           "fromp": [
-            {"type":"VARREF","name":"constraint","addr":"(ED)","loc":"d,23:14,23:16","dtypep":"(IC)","access":"RW","varp":"(HC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
-          ],
-           "pinsp": [
-            {"type":"CONST","name":"\\\"(bvsle length #x0000000f)\\\"","addr":"(FD)","loc":"d,23:14,23:16","dtypep":"(M)"}
-          ]}
+          {"type":"TASKREF","name":"ifs_setup_constraint","addr":"(XC)","loc":"d,28:15,28:18","dtypep":"(LB)","dotted":"","taskp":"(YC)","classOrPackagep":"UNLINKED","namep": [],"pinsp": [],"scopeNamep": []}
         ]},
-        {"type":"STMTEXPR","name":"","addr":"(GD)","loc":"d,24:14,24:16",
+        {"type":"STMTEXPR","name":"","addr":"(ZC)","loc":"d,39:15,39:23",
          "exprp": [
-          {"type":"CMETHODHARD","name":"hard","addr":"(HD)","loc":"d,24:14,24:16","dtypep":"(LB)",
-           "fromp": [
-            {"type":"VARREF","name":"constraint","addr":"(ID)","loc":"d,24:14,24:16","dtypep":"(IC)","access":"RW","varp":"(HC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
-          ],
-           "pinsp": [
-            {"type":"CONST","name":"\\\"(bvsge length header)\\\"","addr":"(JD)","loc":"d,24:14,24:16","dtypep":"(M)"}
-          ]}
+          {"type":"TASKREF","name":"arr_uniq_setup_constraint","addr":"(AD)","loc":"d,39:15,39:23","dtypep":"(LB)","dotted":"","taskp":"(BD)","classOrPackagep":"UNLINKED","namep": [],"pinsp": [],"scopeNamep": []}
         ]},
-        {"type":"STMTEXPR","name":"","addr":"(KD)","loc":"d,25:7,25:13",
+        {"type":"STMTEXPR","name":"","addr":"(CD)","loc":"d,46:15,46:20",
          "exprp": [
-          {"type":"CMETHODHARD","name":"hard","addr":"(LD)","loc":"d,25:7,25:13","dtypep":"(LB)",
-           "fromp": [
-            {"type":"VARREF","name":"constraint","addr":"(MD)","loc":"d,25:7,25:13","dtypep":"(IC)","access":"RW","varp":"(HC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
-          ],
-           "pinsp": [
-            {"type":"CONST","name":"\\\"length\\\"","addr":"(ND)","loc":"d,25:7,25:13","dtypep":"(M)"}
-          ]}
+          {"type":"TASKREF","name":"order_setup_constraint","addr":"(DD)","loc":"d,46:15,46:20","dtypep":"(LB)","dotted":"","taskp":"(ED)","classOrPackagep":"UNLINKED","namep": [],"pinsp": [],"scopeNamep": []}
+        ]},
+        {"type":"STMTEXPR","name":"","addr":"(FD)","loc":"d,48:15,48:18",
+         "exprp": [
+          {"type":"TASKREF","name":"dis_setup_constraint","addr":"(GD)","loc":"d,48:15,48:18","dtypep":"(LB)","dotted":"","taskp":"(HD)","classOrPackagep":"UNLINKED","namep": [],"pinsp": [],"scopeNamep": []}
+        ]},
+        {"type":"STMTEXPR","name":"","addr":"(ID)","loc":"d,54:15,54:19",
+         "exprp": [
+          {"type":"TASKREF","name":"meth_setup_constraint","addr":"(JD)","loc":"d,54:15,54:19","dtypep":"(LB)","dotted":"","taskp":"(KD)","classOrPackagep":"UNLINKED","namep": [],"pinsp": [],"scopeNamep": []}
         ]}
       ],"scopeNamep": []},
-      {"type":"TASK","name":"ifs_setup_constraint","addr":"(UB)","loc":"d,7:1,7:6","method":true,"dpiExport":false,"dpiImport":false,"dpiOpenChild":false,"dpiOpenParent":false,"prototype":false,"recursive":false,"taskPublic":false,"cname":"ifs_setup_constraint","fvarp": [],"classOrPackagep": [],"stmtsp": [],"scopeNamep": []},
-      {"type":"TASK","name":"arr_uniq_setup_constraint","addr":"(XB)","loc":"d,7:1,7:6","method":true,"dpiExport":false,"dpiImport":false,"dpiOpenChild":false,"dpiOpenParent":false,"prototype":false,"recursive":false,"taskPublic":false,"cname":"arr_uniq_setup_constraint","fvarp": [],"classOrPackagep": [],"stmtsp": [],"scopeNamep": []},
-      {"type":"TASK","name":"order_setup_constraint","addr":"(AC)","loc":"d,7:1,7:6","method":true,"dpiExport":false,"dpiImport":false,"dpiOpenChild":false,"dpiOpenParent":false,"prototype":false,"recursive":false,"taskPublic":false,"cname":"order_setup_constraint","fvarp": [],"classOrPackagep": [],"stmtsp": [],"scopeNamep": []},
-      {"type":"TASK","name":"dis_setup_constraint","addr":"(DC)","loc":"d,7:1,7:6","method":true,"dpiExport":false,"dpiImport":false,"dpiOpenChild":false,"dpiOpenParent":false,"prototype":false,"recursive":false,"taskPublic":false,"cname":"dis_setup_constraint","fvarp": [],"classOrPackagep": [],
+      {"type":"TASK","name":"empty_setup_constraint","addr":"(SC)","loc":"d,7:1,7:6","method":true,"dpiExport":false,"dpiImport":false,"dpiOpenChild":false,"dpiOpenParent":false,"prototype":false,"recursive":false,"taskPublic":false,"cname":"empty_setup_constraint","fvarp": [],"classOrPackagep": [],"stmtsp": [],"scopeNamep": []},
+      {"type":"VAR","name":"constraint","addr":"(QB)","loc":"d,19:15,19:20","dtypep":"(PB)","origName":"constraint","isSc":false,"isPrimaryIO":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"attrClocker":"UNKNOWN","lifetime":"NONE","varType":"MEMBER","dtypeName":"VlRandomizer","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
+      {"type":"TASK","name":"size_setup_constraint","addr":"(VC)","loc":"d,7:1,7:6","method":true,"dpiExport":false,"dpiImport":false,"dpiOpenChild":false,"dpiOpenParent":false,"prototype":false,"recursive":false,"taskPublic":false,"cname":"size_setup_constraint","fvarp": [],"classOrPackagep": [],
        "stmtsp": [
-        {"type":"STMTEXPR","name":"","addr":"(OD)","loc":"d,10:13,10:22",
+        {"type":"STMTEXPR","name":"","addr":"(LD)","loc":"d,22:18,22:20",
          "exprp": [
-          {"type":"CMETHODHARD","name":"write_var","addr":"(PD)","loc":"d,10:13,10:22","dtypep":"(LB)",
+          {"type":"CMETHODHARD","name":"hard","addr":"(MD)","loc":"d,22:18,22:20","dtypep":"(LB)",
            "fromp": [
-            {"type":"VARREF","name":"constraint","addr":"(QD)","loc":"d,10:13,10:22","dtypep":"(IC)","access":"RW","varp":"(HC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"constraint","addr":"(ND)","loc":"d,22:18,22:20","dtypep":"(PB)","access":"RW","varp":"(QB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ],
            "pinsp": [
-            {"type":"VARREF","name":"sublength","addr":"(RD)","loc":"d,10:13,10:22","dtypep":"(Q)","access":"WR","varp":"(S)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"},
-            {"type":"CONST","name":"64'h20","addr":"(SD)","loc":"d,8:9,8:12","dtypep":"(OC)"},
-            {"type":"CEXPR","name":"","addr":"(TD)","loc":"d,10:13,10:22","dtypep":"(Q)",
-             "exprsp": [
-              {"type":"TEXT","name":"","addr":"(UD)","loc":"d,10:13,10:22","shortText":"\"sublength\""}
-            ]}
+            {"type":"CONST","name":"\\\"(and (bvsgt header #x00000000) (bvsle header #x00000007))\\\"","addr":"(OD)","loc":"d,22:18,22:20","dtypep":"(M)"}
           ]}
         ]},
-        {"type":"STMTEXPR","name":"","addr":"(VD)","loc":"d,49:7,49:11",
+        {"type":"STMTEXPR","name":"","addr":"(PD)","loc":"d,23:14,23:16",
          "exprp": [
-          {"type":"CMETHODHARD","name":"hard","addr":"(WD)","loc":"d,49:7,49:11","dtypep":"(LB)",
+          {"type":"CMETHODHARD","name":"hard","addr":"(QD)","loc":"d,23:14,23:16","dtypep":"(LB)",
            "fromp": [
-            {"type":"VARREF","name":"constraint","addr":"(XD)","loc":"d,49:7,49:11","dtypep":"(IC)","access":"RW","varp":"(HC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"constraint","addr":"(RD)","loc":"d,23:14,23:16","dtypep":"(PB)","access":"RW","varp":"(QB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ],
            "pinsp": [
-            {"type":"CONST","name":"\\\"sublength\\\"","addr":"(YD)","loc":"d,49:12,49:21","dtypep":"(M)"}
+            {"type":"CONST","name":"\\\"(bvsle length #x0000000f)\\\"","addr":"(SD)","loc":"d,23:14,23:16","dtypep":"(M)"}
           ]}
         ]},
-        {"type":"STMTEXPR","name":"","addr":"(ZD)","loc":"d,50:7,50:14",
+        {"type":"STMTEXPR","name":"","addr":"(TD)","loc":"d,24:14,24:16",
          "exprp": [
-          {"type":"CMETHODHARD","name":"hard","addr":"(AE)","loc":"d,50:7,50:14","dtypep":"(LB)",
+          {"type":"CMETHODHARD","name":"hard","addr":"(UD)","loc":"d,24:14,24:16","dtypep":"(LB)",
            "fromp": [
-            {"type":"VARREF","name":"constraint","addr":"(BE)","loc":"d,50:7,50:14","dtypep":"(IC)","access":"RW","varp":"(HC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"constraint","addr":"(VD)","loc":"d,24:14,24:16","dtypep":"(PB)","access":"RW","varp":"(QB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ],
            "pinsp": [
-            {"type":"CONST","name":"\\\"sublength\\\"","addr":"(CE)","loc":"d,50:20,50:29","dtypep":"(M)"}
+            {"type":"CONST","name":"\\\"(bvsge length header)\\\"","addr":"(WD)","loc":"d,24:14,24:16","dtypep":"(M)"}
           ]}
         ]},
-        {"type":"STMTEXPR","name":"","addr":"(DE)","loc":"d,51:17,51:19",
+        {"type":"STMTEXPR","name":"","addr":"(XD)","loc":"d,25:7,25:13",
          "exprp": [
-          {"type":"CMETHODHARD","name":"hard","addr":"(EE)","loc":"d,51:17,51:19","dtypep":"(LB)",
+          {"type":"CMETHODHARD","name":"hard","addr":"(YD)","loc":"d,25:7,25:13","dtypep":"(LB)",
            "fromp": [
-            {"type":"VARREF","name":"constraint","addr":"(FE)","loc":"d,51:17,51:19","dtypep":"(IC)","access":"RW","varp":"(HC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"constraint","addr":"(ZD)","loc":"d,25:7,25:13","dtypep":"(PB)","access":"RW","varp":"(QB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ],
            "pinsp": [
-            {"type":"CONST","name":"\\\"(bvsle sublength length)\\\"","addr":"(GE)","loc":"d,51:17,51:19","dtypep":"(M)"}
+            {"type":"CONST","name":"\\\"length\\\"","addr":"(AE)","loc":"d,25:7,25:13","dtypep":"(M)"}
           ]}
         ]}
       ],"scopeNamep": []},
-      {"type":"TASK","name":"meth_setup_constraint","addr":"(GC)","loc":"d,7:1,7:6","method":true,"dpiExport":false,"dpiImport":false,"dpiOpenChild":false,"dpiOpenParent":false,"prototype":false,"recursive":false,"taskPublic":false,"cname":"meth_setup_constraint","fvarp": [],"classOrPackagep": [],"stmtsp": [],"scopeNamep": []}
+      {"type":"TASK","name":"ifs_setup_constraint","addr":"(YC)","loc":"d,7:1,7:6","method":true,"dpiExport":false,"dpiImport":false,"dpiOpenChild":false,"dpiOpenParent":false,"prototype":false,"recursive":false,"taskPublic":false,"cname":"ifs_setup_constraint","fvarp": [],"classOrPackagep": [],"stmtsp": [],"scopeNamep": []},
+      {"type":"TASK","name":"arr_uniq_setup_constraint","addr":"(BD)","loc":"d,7:1,7:6","method":true,"dpiExport":false,"dpiImport":false,"dpiOpenChild":false,"dpiOpenParent":false,"prototype":false,"recursive":false,"taskPublic":false,"cname":"arr_uniq_setup_constraint","fvarp": [],"classOrPackagep": [],"stmtsp": [],"scopeNamep": []},
+      {"type":"TASK","name":"order_setup_constraint","addr":"(ED)","loc":"d,7:1,7:6","method":true,"dpiExport":false,"dpiImport":false,"dpiOpenChild":false,"dpiOpenParent":false,"prototype":false,"recursive":false,"taskPublic":false,"cname":"order_setup_constraint","fvarp": [],"classOrPackagep": [],"stmtsp": [],"scopeNamep": []},
+      {"type":"TASK","name":"dis_setup_constraint","addr":"(HD)","loc":"d,7:1,7:6","method":true,"dpiExport":false,"dpiImport":false,"dpiOpenChild":false,"dpiOpenParent":false,"prototype":false,"recursive":false,"taskPublic":false,"cname":"dis_setup_constraint","fvarp": [],"classOrPackagep": [],
+       "stmtsp": [
+        {"type":"STMTEXPR","name":"","addr":"(BE)","loc":"d,49:7,49:11",
+         "exprp": [
+          {"type":"CMETHODHARD","name":"hard","addr":"(CE)","loc":"d,49:7,49:11","dtypep":"(LB)",
+           "fromp": [
+            {"type":"VARREF","name":"constraint","addr":"(DE)","loc":"d,49:7,49:11","dtypep":"(PB)","access":"RW","varp":"(QB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+          ],
+           "pinsp": [
+            {"type":"CONST","name":"\\\"sublength\\\"","addr":"(EE)","loc":"d,49:12,49:21","dtypep":"(M)"}
+          ]}
+        ]},
+        {"type":"STMTEXPR","name":"","addr":"(FE)","loc":"d,50:7,50:14",
+         "exprp": [
+          {"type":"CMETHODHARD","name":"hard","addr":"(GE)","loc":"d,50:7,50:14","dtypep":"(LB)",
+           "fromp": [
+            {"type":"VARREF","name":"constraint","addr":"(HE)","loc":"d,50:7,50:14","dtypep":"(PB)","access":"RW","varp":"(QB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+          ],
+           "pinsp": [
+            {"type":"CONST","name":"\\\"sublength\\\"","addr":"(IE)","loc":"d,50:20,50:29","dtypep":"(M)"}
+          ]}
+        ]},
+        {"type":"STMTEXPR","name":"","addr":"(JE)","loc":"d,51:17,51:19",
+         "exprp": [
+          {"type":"CMETHODHARD","name":"hard","addr":"(KE)","loc":"d,51:17,51:19","dtypep":"(LB)",
+           "fromp": [
+            {"type":"VARREF","name":"constraint","addr":"(LE)","loc":"d,51:17,51:19","dtypep":"(PB)","access":"RW","varp":"(QB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+          ],
+           "pinsp": [
+            {"type":"CONST","name":"\\\"(bvsle sublength length)\\\"","addr":"(ME)","loc":"d,51:17,51:19","dtypep":"(M)"}
+          ]}
+        ]}
+      ],"scopeNamep": []},
+      {"type":"TASK","name":"meth_setup_constraint","addr":"(KD)","loc":"d,7:1,7:6","method":true,"dpiExport":false,"dpiImport":false,"dpiOpenChild":false,"dpiOpenParent":false,"prototype":false,"recursive":false,"taskPublic":false,"cname":"meth_setup_constraint","fvarp": [],"classOrPackagep": [],"stmtsp": [],"scopeNamep": []}
     ],"activesp": [],"extendsp": []}
   ],"activesp": []}
 ],"filesp": [],
@@ -213,30 +226,31 @@
   {"type":"TYPETABLE","name":"","addr":"(C)","loc":"a,0:0,0:0","constraintRefp":"UNLINKED","emptyQueuep":"UNLINKED","queueIndexp":"UNLINKED","streamp":"UNLINKED","voidp":"(LB)",
    "typesp": [
     {"type":"BASICDTYPE","name":"logic","addr":"(GB)","loc":"d,22:14,22:15","dtypep":"(GB)","keyword":"logic","generic":true,"rangep": []},
-    {"type":"BASICDTYPE","name":"logic","addr":"(HE)","loc":"d,25:21,25:22","dtypep":"(HE)","keyword":"logic","range":"31:0","generic":true,"rangep": []},
+    {"type":"BASICDTYPE","name":"logic","addr":"(NE)","loc":"d,25:21,25:22","dtypep":"(NE)","keyword":"logic","range":"31:0","generic":true,"rangep": []},
     {"type":"BASICDTYPE","name":"string","addr":"(M)","loc":"d,71:7,71:13","dtypep":"(M)","keyword":"string","generic":true,"rangep": []},
     {"type":"BASICDTYPE","name":"int","addr":"(Q)","loc":"d,8:9,8:12","dtypep":"(Q)","keyword":"int","range":"31:0","generic":true,"rangep": []},
     {"type":"BASICDTYPE","name":"bit","addr":"(U)","loc":"d,11:9,11:12","dtypep":"(U)","keyword":"bit","generic":true,"rangep": []},
     {"type":"UNPACKARRAYDTYPE","name":"","addr":"(Y)","loc":"d,15:18,15:19","dtypep":"(Y)","isCompound":false,"declRange":"[0:1]","generic":false,"refDTypep":"(Q)","childDTypep": [],
      "rangep": [
-      {"type":"RANGE","name":"","addr":"(IE)","loc":"d,15:18,15:19","ascending":true,
+      {"type":"RANGE","name":"","addr":"(OE)","loc":"d,15:18,15:19","ascending":true,
        "leftp": [
-        {"type":"CONST","name":"32'h0","addr":"(JE)","loc":"d,15:19,15:20","dtypep":"(HE)"}
+        {"type":"CONST","name":"32'h0","addr":"(PE)","loc":"d,15:19,15:20","dtypep":"(NE)"}
       ],
        "rightp": [
-        {"type":"CONST","name":"32'h1","addr":"(KE)","loc":"d,15:19,15:20","dtypep":"(HE)"}
+        {"type":"CONST","name":"32'h1","addr":"(QE)","loc":"d,15:19,15:20","dtypep":"(NE)"}
       ]}
     ]},
     {"type":"VOIDDTYPE","name":"","addr":"(LB)","loc":"d,7:1,7:6","dtypep":"(LB)","generic":false},
     {"type":"CLASSREFDTYPE","name":"Packet","addr":"(H)","loc":"d,67:4,67:10","dtypep":"(H)","generic":false,"classp":"(O)","classOrPackagep":"(O)","paramsp": []},
-    {"type":"BASICDTYPE","name":"VlRandomizer","addr":"(IC)","loc":"d,7:1,7:6","dtypep":"(IC)","keyword":"VlRandomizer","generic":true,"rangep": []},
-    {"type":"BASICDTYPE","name":"logic","addr":"(OC)","loc":"d,8:9,8:12","dtypep":"(OC)","keyword":"logic","range":"63:0","generic":true,"rangep": []}
+    {"type":"BASICDTYPE","name":"bit","addr":"(LC)","loc":"d,7:1,7:6","dtypep":"(LC)","keyword":"bit","range":"31:0","generic":true,"rangep": []},
+    {"type":"BASICDTYPE","name":"VlRandomizer","addr":"(PB)","loc":"d,7:1,7:6","dtypep":"(PB)","keyword":"VlRandomizer","generic":true,"rangep": []},
+    {"type":"BASICDTYPE","name":"logic","addr":"(TB)","loc":"d,8:9,8:12","dtypep":"(TB)","keyword":"logic","range":"63:0","generic":true,"rangep": []}
   ]},
   {"type":"CONSTPOOL","name":"","addr":"(D)","loc":"a,0:0,0:0",
    "modulep": [
-    {"type":"MODULE","name":"@CONST-POOL@","addr":"(LE)","loc":"a,0:0,0:0","origName":"@CONST-POOL@","level":0,"modPublic":false,"inLibrary":false,"dead":false,"recursiveClone":false,"recursive":false,"timeunit":"NONE","inlinesp": [],
+    {"type":"MODULE","name":"@CONST-POOL@","addr":"(RE)","loc":"a,0:0,0:0","origName":"@CONST-POOL@","level":0,"modPublic":false,"inLibrary":false,"dead":false,"recursiveClone":false,"recursive":false,"timeunit":"NONE","inlinesp": [],
      "stmtsp": [
-      {"type":"SCOPE","name":"@CONST-POOL@","addr":"(ME)","loc":"a,0:0,0:0","aboveScopep":"UNLINKED","aboveCellp":"UNLINKED","modp":"(LE)","varsp": [],"blocksp": [],"inlinesp": []}
+      {"type":"SCOPE","name":"@CONST-POOL@","addr":"(SE)","loc":"a,0:0,0:0","aboveScopep":"UNLINKED","aboveCellp":"UNLINKED","modp":"(RE)","varsp": [],"blocksp": [],"inlinesp": []}
     ],"activesp": []}
   ]}
 ]}

--- a/test_regress/t/t_constraint_state.pl
+++ b/test_regress/t/t_constraint_state.pl
@@ -1,0 +1,22 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2019 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+
+ok(1);
+1;

--- a/test_regress/t/t_constraint_state.v
+++ b/test_regress/t/t_constraint_state.v
@@ -1,0 +1,36 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2023 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+class Packet;
+   rand int rf;
+   int state;
+
+   constraint c { rf == state; }
+
+endclass
+
+module t (/*AUTOARG*/);
+
+   Packet p;
+
+   int v;
+
+   initial begin
+      p = new;
+      p.state = 123;
+      v = p.randomize();
+      if (v != 1) $stop;
+      if (p.rf != 123) $stop;
+
+      p.state = 234;
+      v = p.randomize();
+      if (v != 1) $stop;
+      if (p.rf != 234) $stop;
+
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end
+endmodule

--- a/test_regress/t/t_constraint_xml.out
+++ b/test_regress/t/t_constraint_xml.out
@@ -48,6 +48,44 @@
           </assign>
         </func>
         <func loc="d,7,1,7,6" name="new" dtype_id="7">
+          <stmtexpr loc="d,8,13,8,19">
+            <cmethodhard loc="d,8,13,8,19" name="write_var" dtype_id="7">
+              <varref loc="d,8,13,8,19" name="constraint" dtype_id="8"/>
+              <varref loc="d,8,13,8,19" name="header" dtype_id="3"/>
+              <const loc="d,8,9,8,12" name="64&apos;h20" dtype_id="9"/>
+              <cexpr loc="d,8,13,8,19" dtype_id="3">
+                <text loc="d,8,13,8,19"/>
+              </cexpr>
+            </cmethodhard>
+          </stmtexpr>
+          <stmtexpr loc="d,9,13,9,19">
+            <cmethodhard loc="d,9,13,9,19" name="write_var" dtype_id="7">
+              <varref loc="d,9,13,9,19" name="constraint" dtype_id="8"/>
+              <varref loc="d,9,13,9,19" name="length" dtype_id="3"/>
+              <const loc="d,8,9,8,12" name="64&apos;h20" dtype_id="9"/>
+              <cexpr loc="d,9,13,9,19" dtype_id="3">
+                <text loc="d,9,13,9,19"/>
+              </cexpr>
+            </cmethodhard>
+          </stmtexpr>
+          <stmtexpr loc="d,10,13,10,22">
+            <cmethodhard loc="d,10,13,10,22" name="write_var" dtype_id="7">
+              <varref loc="d,10,13,10,22" name="constraint" dtype_id="8"/>
+              <varref loc="d,10,13,10,22" name="sublength" dtype_id="3"/>
+              <const loc="d,8,9,8,12" name="64&apos;h20" dtype_id="9"/>
+              <cexpr loc="d,10,13,10,22" dtype_id="3">
+                <text loc="d,10,13,10,22"/>
+              </cexpr>
+            </cmethodhard>
+          </stmtexpr>
+        </func>
+        <func loc="d,7,1,7,6" name="randomize" dtype_id="10">
+          <var loc="d,7,1,7,6" name="randomize" dtype_id="10" dir="output" vartype="bit" origName="randomize"/>
+          <stmtexpr loc="d,7,1,7,6">
+            <cmethodhard loc="d,7,1,7,6" name="clear" dtype_id="7">
+              <varref loc="d,7,1,7,6" name="constraint" dtype_id="8"/>
+            </cmethodhard>
+          </stmtexpr>
           <stmtexpr loc="d,19,15,19,20">
             <taskref loc="d,19,15,19,20" name="empty_setup_constraint" dtype_id="7"/>
           </stmtexpr>
@@ -73,30 +111,10 @@
         <task loc="d,7,1,7,6" name="empty_setup_constraint"/>
         <var loc="d,19,15,19,20" name="constraint" dtype_id="8" vartype="VlRandomizer" origName="constraint"/>
         <task loc="d,7,1,7,6" name="size_setup_constraint">
-          <stmtexpr loc="d,8,13,8,19">
-            <cmethodhard loc="d,8,13,8,19" name="write_var" dtype_id="7">
-              <varref loc="d,8,13,8,19" name="constraint" dtype_id="8"/>
-              <varref loc="d,8,13,8,19" name="header" dtype_id="3"/>
-              <const loc="d,8,9,8,12" name="64&apos;h20" dtype_id="9"/>
-              <cexpr loc="d,8,13,8,19" dtype_id="3">
-                <text loc="d,8,13,8,19"/>
-              </cexpr>
-            </cmethodhard>
-          </stmtexpr>
           <stmtexpr loc="d,22,18,22,20">
             <cmethodhard loc="d,22,18,22,20" name="hard" dtype_id="7">
               <varref loc="d,22,18,22,20" name="constraint" dtype_id="8"/>
               <const loc="d,22,18,22,20" name="&quot;(and (bvsgt header #x00000000) (bvsle header #x00000007))&quot;" dtype_id="2"/>
-            </cmethodhard>
-          </stmtexpr>
-          <stmtexpr loc="d,9,13,9,19">
-            <cmethodhard loc="d,9,13,9,19" name="write_var" dtype_id="7">
-              <varref loc="d,9,13,9,19" name="constraint" dtype_id="8"/>
-              <varref loc="d,9,13,9,19" name="length" dtype_id="3"/>
-              <const loc="d,8,9,8,12" name="64&apos;h20" dtype_id="9"/>
-              <cexpr loc="d,9,13,9,19" dtype_id="3">
-                <text loc="d,9,13,9,19"/>
-              </cexpr>
             </cmethodhard>
           </stmtexpr>
           <stmtexpr loc="d,23,14,23,16">
@@ -122,16 +140,6 @@
         <task loc="d,7,1,7,6" name="arr_uniq_setup_constraint"/>
         <task loc="d,7,1,7,6" name="order_setup_constraint"/>
         <task loc="d,7,1,7,6" name="dis_setup_constraint">
-          <stmtexpr loc="d,10,13,10,22">
-            <cmethodhard loc="d,10,13,10,22" name="write_var" dtype_id="7">
-              <varref loc="d,10,13,10,22" name="constraint" dtype_id="8"/>
-              <varref loc="d,10,13,10,22" name="sublength" dtype_id="3"/>
-              <const loc="d,8,9,8,12" name="64&apos;h20" dtype_id="9"/>
-              <cexpr loc="d,10,13,10,22" dtype_id="3">
-                <text loc="d,10,13,10,22"/>
-              </cexpr>
-            </cmethodhard>
-          </stmtexpr>
           <stmtexpr loc="d,49,7,49,11">
             <cmethodhard loc="d,49,7,49,11" name="hard" dtype_id="7">
               <varref loc="d,49,7,49,11" name="constraint" dtype_id="8"/>
@@ -156,18 +164,19 @@
     </package>
     <typetable loc="a,0,0,0,0">
       <basicdtype loc="d,22,14,22,15" id="6" name="logic"/>
-      <basicdtype loc="d,25,21,25,22" id="10" name="logic" left="31" right="0"/>
+      <basicdtype loc="d,25,21,25,22" id="11" name="logic" left="31" right="0"/>
       <basicdtype loc="d,71,7,71,13" id="2" name="string"/>
       <basicdtype loc="d,8,9,8,12" id="3" name="int" left="31" right="0" signed="true"/>
       <basicdtype loc="d,11,9,11,12" id="4" name="bit"/>
       <unpackarraydtype loc="d,15,18,15,19" id="5" sub_dtype_id="3">
         <range loc="d,15,18,15,19">
-          <const loc="d,15,19,15,20" name="32&apos;h0" dtype_id="10"/>
-          <const loc="d,15,19,15,20" name="32&apos;h1" dtype_id="10"/>
+          <const loc="d,15,19,15,20" name="32&apos;h0" dtype_id="11"/>
+          <const loc="d,15,19,15,20" name="32&apos;h1" dtype_id="11"/>
         </range>
       </unpackarraydtype>
       <voiddtype loc="d,7,1,7,6" id="7"/>
       <classrefdtype loc="d,67,4,67,10" id="1" name="Packet"/>
+      <basicdtype loc="d,7,1,7,6" id="10" name="bit" left="31" right="0" signed="true"/>
       <basicdtype loc="d,7,1,7,6" id="8" name="VlRandomizer"/>
       <basicdtype loc="d,8,9,8,12" id="9" name="logic" left="63" right="0"/>
     </typetable>

--- a/test_regress/t/t_randomize.out
+++ b/test_regress/t/t_randomize.out
@@ -3,10 +3,6 @@
       |                         ^~~~
                         ... For warning description see https://verilator.org/warn/CONSTRAINTIGN?v=latest
                         ... Use "/* verilator lint_off CONSTRAINTIGN */" and lint_on around source to disable this message.
-%Warning-CONSTRAINTIGN: t/t_randomize.v:38:16: State-dependent constraint ignored (unsupported)
-                                             : ... note: In instance 't'
-   38 |          array[i] inside {2, 4, 6};
-      |                ^
 %Warning-CONSTRAINTIGN: t/t_randomize.v:26:7: Constraint expression ignored (unsupported)
                                             : ... note: In instance 't'
    26 |       if (header > 4) {

--- a/test_regress/t/t_randomize_method_types_unsup.out
+++ b/test_regress/t/t_randomize_method_types_unsup.out
@@ -1,16 +1,7 @@
-%Warning-CONSTRAINTIGN: t/t_randomize_method_types_unsup.v:20:30: State-dependent constraint ignored (unsupported)
-                                                                : ... note: In instance 't'
-   20 |    constraint statedep { i < st + 2; }
-      |                              ^~
-                        ... For warning description see https://verilator.org/warn/CONSTRAINTIGN?v=latest
-                        ... Use "/* verilator lint_off CONSTRAINTIGN */" and lint_on around source to disable this message.
 %Error-UNSUPPORTED: t/t_randomize_method_types_unsup.v:19:25: Unsupported: random member variable with type 'int$[]'
    19 |    constraint dynsize { dynarr.size < 20; }
       |                         ^~~~~~
-%Warning-CONSTRAINTIGN: t/t_randomize_method_types_unsup.v:20:28: Constraint expression ignored (unsupported)
-                                                                : ... note: In instance 't'
-   20 |    constraint statedep { i < st + 2; }
-      |                            ^
+                    ... For error description see https://verilator.org/warn/UNSUPPORTED?v=latest
 %Error-UNSUPPORTED: t/t_randomize_method_types_unsup.v:12:13: Unsupported: random member variable with type 'int$[string]'
                                                             : ... note: In instance 't'
    12 |    rand int assocarr[string];


### PR DESCRIPTION
Constraint evaluation is now moved from object construction time to randomize time, but information about constrained variables is kept in the constructor (the set of potentially constraint-dependent variables cannot change at runtime).  This allows the constraints to depend on state, and opens the path towards more complex constraints, like inline, conditional or multi-phase constraints.