### PR TITLE
Prevent splitting if statements with impure conditions

### DIFF
--- a/src/V3Split.cpp
+++ b/src/V3Split.cpp
@@ -983,6 +983,7 @@ protected:
     }
     void visit(AstNodeIf* nodep) override {
         UINFO(4, "     IF " << nodep << endl);
+        if (!nodep->condp()->isPure()) m_noReorderWhy = "Impure IF condition";
         m_curIfConditional = nodep;
         iterateAndNextNull(nodep->condp());
         m_curIfConditional = nullptr;

--- a/src/V3Split.cpp
+++ b/src/V3Split.cpp
@@ -984,9 +984,11 @@ protected:
     void visit(AstNodeIf* nodep) override {
         UINFO(4, "     IF " << nodep << endl);
         if (!nodep->condp()->isPure()) m_noReorderWhy = "Impure IF condition";
-        m_curIfConditional = nodep;
-        iterateAndNextNull(nodep->condp());
-        m_curIfConditional = nullptr;
+        {
+            VL_RESTORER(m_curIfConditional);
+            m_curIfConditional = nodep;
+            iterateAndNextNull(nodep->condp());
+        }
         scanBlock(nodep->thensp());
         scanBlock(nodep->elsesp());
     }

--- a/test_regress/t/t_dpi_if_cond.pl
+++ b/test_regress/t/t_dpi_if_cond.pl
@@ -1,0 +1,22 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2024 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    v_flags2 => ["t/t_dpi_if_cond_c.cpp"],
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_dpi_if_cond.v
+++ b/test_regress/t/t_dpi_if_cond.v
@@ -37,4 +37,3 @@ module t (/*AUTOARG*/
     end
   end
 endmodule
-

--- a/test_regress/t/t_dpi_if_cond.v
+++ b/test_regress/t/t_dpi_if_cond.v
@@ -1,0 +1,40 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// Copyright 2024 by Antmicro. This program is free software; you can
+// redistribute it and/or modify it under the terms of either the GNU
+// Lesser General Public License Version 3 or the Perl Artistic License
+// Version 2.0.
+// SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+module t (/*AUTOARG*/
+  // Inputs
+  clk
+  );
+
+  input clk;
+
+  integer counter = 0;
+  import "DPI-C" context function int  dpii_increment(inout int counter);
+
+  function void func();
+  endfunction : func
+
+  always @(posedge clk) begin
+    if(dpii_increment(counter) == 1) begin
+      // unreachable
+      func();
+
+      // add impure statement for splitting
+      $write("");
+    end
+    else if (counter == 1) begin
+      $write("*-* All Finished *-*\n");
+      $finish;
+    end
+    else begin
+      $write("DPI called too many times: %d\n", counter);
+      $stop;
+    end
+  end
+endmodule
+

--- a/test_regress/t/t_dpi_if_cond_c.cpp
+++ b/test_regress/t/t_dpi_if_cond_c.cpp
@@ -1,0 +1,46 @@
+// -*- mode: C++; c-file-style: "cc-mode" -*-
+//*************************************************************************
+//
+// Copyright 2024 by Antmicro. This program is free software; you can
+// redistribute it and/or modify it under the terms of either the GNU
+// Lesser General Public License Version 3 or the Perl Artistic License
+// Version 2.0.
+// SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+//
+//*************************************************************************
+
+#include "svdpi.h"
+
+#include <cstdio>
+#include <cstring>
+
+// These require the above. Comment prevents clang-format moving them
+#include "TestCheck.h"
+
+//======================================================================
+
+// clang-format off
+#if defined(VERILATOR)
+# include "Vt_dpi_if_cond__Dpi.h"
+#elif defined(VCS)
+# include "../vc_hdrs.h"
+#elif defined(NC)
+# define NEED_EXTERNS
+#else
+# error "Unknown simulator for DPI test"
+#endif
+// clang-format on
+
+#ifdef NEED_EXTERNS
+extern "C" {
+// If get ncsim: *F,NOFDPI: Function {foo} not found in default libdpi.
+// Then probably forgot to list a function here.
+
+extern int dpii_increment(int* counter);
+}
+#endif
+
+int dpii_increment(int* counter) {
+    ++(*counter);
+    return 0;
+}


### PR DESCRIPTION
Since the change https://github.com/verilator/verilator/commit/e24197fd16e63b4dede06d46adc33129d38db67c, conditions in `IF` statements are wrapped in a lambda function to enable condition short-circuiting. This implies that each time an `IF` condition is evaluated, this lambda function is invoked. 

While it isn't a problem when conditions are _pure_, for impure ones it induces unwanted side-effects. This issue arises in `V3Split` pass, where `IF` statements are split in a way that a condition is duplicated and a body is split. Since, the `IF` condition is below this node, it doesn't prevent splitting it, thus the bug arises. This problem was resolved for `IF`s with conditions that mutate VarRefs, however it is not implemented for DPI calls. 

This fix prevents splitting such `IF` statements based on `isPure()` output for a condition.