### PR TITLE
Support clocking blocks in virtual interfaces

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -142,6 +142,7 @@ set(HEADERS
     V3Randomize.h
     V3Reloop.h
     V3Rtti.h
+    V3Sampled.h
     V3Sched.h
     V3Scope.h
     V3Scoreboard.h
@@ -288,6 +289,7 @@ set(COMMON_SOURCES
     V3ProtectLib.cpp
     V3Randomize.cpp
     V3Reloop.cpp
+    V3Sampled.cpp
     V3Sched.cpp
     V3SchedAcyclic.cpp
     V3SchedPartition.cpp

--- a/src/Makefile_obj.in
+++ b/src/Makefile_obj.in
@@ -284,6 +284,7 @@ RAW_OBJS_PCH_ASTNOMT = \
 	V3ProtectLib.o \
 	V3Randomize.o \
 	V3Reloop.o \
+	V3Sampled.o \
 	V3Sched.o \
 	V3SchedAcyclic.o \
 	V3SchedPartition.o \

--- a/src/V3Assert.cpp
+++ b/src/V3Assert.cpp
@@ -440,6 +440,7 @@ class AssertVisitor final : public VNVisitor {
                 AstSampled* const newp = newSampledExpr(nodep);
                 relinkHandle.relink(newp);
                 newp->user1(1);
+                v3Global.setHasSampled();
             }
         }
     }

--- a/src/V3Clock.cpp
+++ b/src/V3Clock.cpp
@@ -160,11 +160,11 @@ class ClockVisitor final : public VNVisitor {
     //========== Move sampled assignments
     void visit(AstVarScope* nodep) override {
         AstVar* varp = nodep->varp();
-        if (varp->valuep() && varp->name().substr(0, 10) == "__Vsampled") {
+        if (varp->valuep() && varp->name().substr(0, strlen("__Vsampled")) == "__Vsampled") {
             m_evalp->addInitsp(new AstAssign{
                 nodep->fileline(), new AstVarRef{nodep->fileline(), nodep, VAccess::WRITE},
                 VN_AS(varp->valuep()->unlinkFrBack(), NodeExpr)});
-            varp->direction(VDirection::NONE);  // restore defaults
+            varp->direction(VDirection::NONE);  // Restore defaults
             varp->primaryIO(false);
         }
     }

--- a/src/V3Global.h
+++ b/src/V3Global.h
@@ -114,6 +114,7 @@ class V3Global final {
     bool m_dpi = false;  // Need __Dpi include files
     bool m_hasEvents = false;  // Design uses SystemVerilog named events
     bool m_hasClasses = false;  // Design uses SystemVerilog classes
+    bool m_hasSampled = false;  // Design uses SAMPLED expresions
     bool m_hasVirtIfaces = false;  // Design uses virtual interfaces
     bool m_usesProbDist = false;  // Uses $dist_*
     bool m_usesStdPackage = false;  // Design uses the std package
@@ -168,6 +169,8 @@ public:
     void setHasEvents() { m_hasEvents = true; }
     bool hasClasses() const { return m_hasClasses; }
     void setHasClasses() { m_hasClasses = true; }
+    bool hasSampled() const { return m_hasSampled; }
+    void setHasSampled() { m_hasSampled = true; }
     bool hasVirtIfaces() const { return m_hasVirtIfaces; }
     void setHasVirtIfaces() { m_hasVirtIfaces = true; }
     bool usesProbDist() const { return m_usesProbDist; }

--- a/src/V3LinkDot.cpp
+++ b/src/V3LinkDot.cpp
@@ -3062,11 +3062,14 @@ class LinkDotResolveVisitor final : public VNVisitor {
                 // AstVarXRef's even though they are in the same module detect
                 // this and convert to normal VarRefs
                 if (!m_statep->forPrearray() && !m_statep->forScopeCreation()) {
-                    if (VN_IS(nodep->dtypep(), IfaceRefDType)) {
-                        AstVarRef* const newrefp
-                            = new AstVarRef{nodep->fileline(), nodep->varp(), nodep->access()};
-                        nodep->replaceWith(newrefp);
-                        VL_DO_DANGLING(nodep->deleteTree(), nodep);
+                    if (const AstIfaceRefDType* const ifaceDtp
+                        = VN_CAST(nodep->dtypep(), IfaceRefDType)) {
+                        if (!ifaceDtp->isVirtual()) {
+                            AstVarRef* const newrefp
+                                = new AstVarRef{nodep->fileline(), nodep->varp(), nodep->access()};
+                            nodep->replaceWith(newrefp);
+                            VL_DO_DANGLING(nodep->deleteTree(), nodep);
+                        }
                     }
                 }
             } else {

--- a/src/V3LinkLValue.cpp
+++ b/src/V3LinkLValue.cpp
@@ -50,7 +50,8 @@ class LinkLValueVisitor final : public VNVisitor {
                 // so it is needed to check only if m_setContinuously is true
                 if (m_setStrengthSpecified) nodep->varp()->hasStrengthAssignment(true);
             }
-            if (const AstClockingItem* itemp = VN_CAST(nodep->varp()->backp(), ClockingItem)) {
+            if (const AstClockingItem* const itemp
+                = VN_CAST(nodep->varp()->backp(), ClockingItem)) {
                 UINFO(5, "ClkOut " << nodep << endl);
                 if (itemp->outputp()) nodep->varp(itemp->outputp()->varp());
             }
@@ -286,7 +287,8 @@ class LinkLValueVisitor final : public VNVisitor {
         if (m_setRefLvalue != VAccess::NOCHANGE) {
             nodep->access(m_setRefLvalue);
             if (nodep->varp() && nodep->access().isWriteOrRW()) {
-                if (const AstClockingItem* itemp = VN_CAST(nodep->varp()->backp(), ClockingItem)) {
+                if (const AstClockingItem* const itemp
+                    = VN_CAST(nodep->varp()->backp(), ClockingItem)) {
                     UINFO(5, "ClkOut " << nodep << endl);
                     if (itemp->outputp()) nodep->varp(itemp->outputp()->varp());
                 }

--- a/src/V3LinkLValue.cpp
+++ b/src/V3LinkLValue.cpp
@@ -285,6 +285,12 @@ class LinkLValueVisitor final : public VNVisitor {
     void visit(AstMemberSel* nodep) override {
         if (m_setRefLvalue != VAccess::NOCHANGE) {
             nodep->access(m_setRefLvalue);
+            if (nodep->varp() && nodep->access().isWriteOrRW()) {
+                if (const AstClockingItem* itemp = VN_CAST(nodep->varp()->backp(), ClockingItem)) {
+                    UINFO(5, "ClkOut " << nodep << endl);
+                    if (itemp->outputp()) nodep->varp(itemp->outputp()->varp());
+                }
+            }
         } else {
             // It is the only place where the access is set to member select nodes.
             // If it doesn't have to be set to WRITE, it means that it is READ.

--- a/src/V3OrderProcessDomains.cpp
+++ b/src/V3OrderProcessDomains.cpp
@@ -93,6 +93,13 @@ class V3OrderProcessDomains final {
             // For logic, start with the explicit hybrid sensitivities
             OrderLogicVertex* const lvtxp = vtxp->cast<OrderLogicVertex>();
             if (lvtxp) domainp = lvtxp->hybridp();
+            if (domainp)
+                UINFO(6, "      hybr d=" << cvtToHex(domainp)
+                                         << (domainp == m_deleteDomainp ? " [DEL]"
+                                             : domainp->hasCombo()      ? " [COMB]"
+                                             : domainp->isMulti()       ? " [MULT]"
+                                                                        : "")
+                                         << " " << vtxp << endl);
 
             // For each incoming edge, examine the source vertex
             for (V3GraphEdge& edge : vtxp->inEdges()) {
@@ -104,6 +111,12 @@ class V3OrderProcessDomains final {
 
                 AstSenTree* fromDomainp = fromVtxp->domainp();
 
+                UINFO(6, "      from d=" << cvtToHex(fromDomainp)
+                                         << (fromDomainp == m_deleteDomainp ? " [DEL]"
+                                             : fromDomainp->hasCombo()      ? " [COMB]"
+                                             : fromDomainp->isMulti()       ? " [MULT]"
+                                                                            : "")
+                                         << " " << vtxp << endl);
                 UASSERT(fromDomainp == m_deleteDomainp || !fromDomainp->hasCombo(),
                         "There should be no need for combinational domains");
 
@@ -113,6 +126,12 @@ class V3OrderProcessDomains final {
                     externalDomainps.clear();
                     m_externalDomains(vscp, externalDomainps);
                     for (AstSenTree* const externalDomainp : externalDomainps) {
+                        UINFO(6, "      xtrn d=" << cvtToHex(externalDomainp)
+                                                 << (externalDomainp == m_deleteDomainp ? " [DEL]"
+                                                     : externalDomainp->hasCombo()      ? " [COMB]"
+                                                     : externalDomainp->isMulti()       ? " [MULT]"
+                                                                                        : "")
+                                                 << " " << vtxp << " because of " << vscp << endl);
                         UASSERT_OBJ(!externalDomainp->hasCombo(), vscp,
                                     "There should be no need for combinational domains");
                         fromDomainp = combineDomains(fromDomainp, externalDomainp);

--- a/src/V3OrderProcessDomains.cpp
+++ b/src/V3OrderProcessDomains.cpp
@@ -58,6 +58,15 @@ class V3OrderProcessDomains final {
 
     // METHODS
 
+    // Dump a domain for debugging
+    std::string debugDomain(AstSenTree* domainp) {
+        return cvtToHex(domainp)
+               + (domainp == m_deleteDomainp ? " [DEL]"
+                  : domainp->hasCombo()      ? " [COMB]"
+                  : domainp->isMulti()       ? " [MULT]"
+                                             : "");
+    }
+
     // Make a domain that merges the two domains
     AstSenTree* combineDomains(AstSenTree* ap, AstSenTree* bp) {
         if (ap == bp) return ap;
@@ -93,13 +102,7 @@ class V3OrderProcessDomains final {
             // For logic, start with the explicit hybrid sensitivities
             OrderLogicVertex* const lvtxp = vtxp->cast<OrderLogicVertex>();
             if (lvtxp) domainp = lvtxp->hybridp();
-            if (domainp)
-                UINFO(6, "      hybr d=" << cvtToHex(domainp)
-                                         << (domainp == m_deleteDomainp ? " [DEL]"
-                                             : domainp->hasCombo()      ? " [COMB]"
-                                             : domainp->isMulti()       ? " [MULT]"
-                                                                        : "")
-                                         << " " << vtxp << endl);
+            if (domainp) UINFO(6, "      hybr d=" << debugDomain(domainp) << " " << vtxp << endl);
 
             // For each incoming edge, examine the source vertex
             for (V3GraphEdge& edge : vtxp->inEdges()) {
@@ -111,12 +114,7 @@ class V3OrderProcessDomains final {
 
                 AstSenTree* fromDomainp = fromVtxp->domainp();
 
-                UINFO(6, "      from d=" << cvtToHex(fromDomainp)
-                                         << (fromDomainp == m_deleteDomainp ? " [DEL]"
-                                             : fromDomainp->hasCombo()      ? " [COMB]"
-                                             : fromDomainp->isMulti()       ? " [MULT]"
-                                                                            : "")
-                                         << " " << vtxp << endl);
+                UINFO(6, "      from d=" << debugDomain(fromDomainp) << " " << fromVtxp << endl);
                 UASSERT(fromDomainp == m_deleteDomainp || !fromDomainp->hasCombo(),
                         "There should be no need for combinational domains");
 
@@ -126,12 +124,8 @@ class V3OrderProcessDomains final {
                     externalDomainps.clear();
                     m_externalDomains(vscp, externalDomainps);
                     for (AstSenTree* const externalDomainp : externalDomainps) {
-                        UINFO(6, "      xtrn d=" << cvtToHex(externalDomainp)
-                                                 << (externalDomainp == m_deleteDomainp ? " [DEL]"
-                                                     : externalDomainp->hasCombo()      ? " [COMB]"
-                                                     : externalDomainp->isMulti()       ? " [MULT]"
-                                                                                        : "")
-                                                 << " " << vtxp << " because of " << vscp << endl);
+                        UINFO(6, "      xtrn d=" << debugDomain(externalDomainp) << " " << fromVtxp
+                                                 << " because of " << vscp << endl);
                         UASSERT_OBJ(!externalDomainp->hasCombo(), vscp,
                                     "There should be no need for combinational domains");
                         fromDomainp = combineDomains(fromDomainp, externalDomainp);
@@ -159,12 +153,7 @@ class V3OrderProcessDomains final {
             // Set the domain of the vertex
             vtxp->domainp(domainp);
 
-            UINFO(5, "      done d=" << cvtToHex(domainp)
-                                     << (domainp == m_deleteDomainp ? " [DEL]"
-                                         : domainp->hasCombo()      ? " [COMB]"
-                                         : domainp->isMulti()       ? " [MULT]"
-                                                                    : "")
-                                     << " " << vtxp << endl);
+            UINFO(5, "      done d=" << debugDomain(domainp) << " " << vtxp << endl);
         }
     }
 

--- a/src/V3OrderSerial.cpp
+++ b/src/V3OrderSerial.cpp
@@ -34,7 +34,7 @@ VL_DEFINE_DEBUG_FUNCTIONS;
 std::vector<AstActive*> V3Order::createSerial(OrderGraph& graph, const std::string& tag,
                                               const TrigToSenMap& trigToSen, bool slow) {
 
-    UINFO(2, "  Constructing serial code for '" + tag + "'");
+    UINFO(2, "  Constructing serial code for '" + tag + "'" << endl);
 
     // Build the move graph
     OrderMoveDomScope::clear();

--- a/src/V3OrderSerial.cpp
+++ b/src/V3OrderSerial.cpp
@@ -34,7 +34,7 @@ VL_DEFINE_DEBUG_FUNCTIONS;
 std::vector<AstActive*> V3Order::createSerial(OrderGraph& graph, const std::string& tag,
                                               const TrigToSenMap& trigToSen, bool slow) {
 
-    UINFO(2, "  Constructing serial code for '" + tag + "'" << endl);
+    UINFO(2, "  Constructing serial code for '" + tag + "'\n");
 
     // Build the move graph
     OrderMoveDomScope::clear();

--- a/src/V3Sampled.cpp
+++ b/src/V3Sampled.cpp
@@ -1,0 +1,109 @@
+// -*- mode: C++; c-file-style: "cc-mode" -*-
+//*************************************************************************
+// DESCRIPTION: Verilator: Removal of SAMPLED
+//
+// Code available from: https://verilator.org
+//
+//*************************************************************************
+//
+// Copyright 2003-2024 by Wilson Snyder. This program is free software; you
+// can redistribute it and/or modify it under the terms of either the GNU
+// Lesser General Public License Version 3 or the Perl Artistic License
+// Version 2.0.
+// SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+//
+//*************************************************************************
+// V3Sampled's Transformations:
+//
+// Top Scope:
+//   Replace each variable reference under SAMPLED with a new variable.
+//   Remove SAMPLED.
+//
+//*************************************************************************
+
+#include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
+
+#include "V3Sampled.h"
+
+VL_DEFINE_DEBUG_FUNCTIONS;
+
+//######################################################################
+// Clock state, as a visitor of each AstNode
+
+class SampledVisitor final : public VNVisitor {
+    // NODE STATE
+    // ???
+    const VNUser1InUse m_user1InUse;
+    // STATE
+    AstScope* m_scopep = nullptr;  // Current scope
+    bool m_inSampled = false;  // True inside a sampled expression
+
+    // METHODS
+
+    AstVarScope* createSampledVar(AstVarScope* vscp) {
+        if (vscp->user1p()) return VN_AS(vscp->user1p(), VarScope);
+        const AstVar* const varp = vscp->varp();
+        const string newvarname
+            = string{"__Vsampled_"} + vscp->scopep()->nameDotless() + "__" + varp->name();
+        FileLine* const flp = vscp->fileline();
+        AstVar* const newvarp = new AstVar{flp, VVarType::MODULETEMP, newvarname, varp->dtypep()};
+        m_scopep->modp()->addStmtsp(newvarp);
+        AstVarScope* const newvscp = new AstVarScope{flp, m_scopep, newvarp};
+        newvarp->direction(VDirection::INPUT);  // inform V3Sched that it will be driven later
+        newvarp->primaryIO(true);
+        vscp->user1p(newvscp);
+        m_scopep->addVarsp(newvscp);
+        // At the top of _eval, assign them (we use valuep here as temporary storage during
+        // V3Sched)
+        newvarp->valuep(new AstVarRef{flp, vscp, VAccess::READ});
+        UINFO(4, "New Sampled: " << newvscp << endl);
+        return newvscp;
+    }
+
+    // VISITORS
+    void visit(AstScope* nodep) override {
+        VL_RESTORER(m_scopep);
+        {
+            m_scopep = nodep;
+            iterateChildren(nodep);
+        }
+    }
+    void visit(AstSampled* nodep) override {
+        VL_RESTORER(m_inSampled);
+        {
+            m_inSampled = true;
+            iterateChildren(nodep);
+            nodep->replaceWith(nodep->exprp()->unlinkFrBack());
+            VL_DO_DANGLING(pushDeletep(nodep), nodep);
+        }
+    }
+    void visit(AstVarRef* nodep) override {
+        iterateChildren(nodep);
+        if (m_inSampled && !nodep->user1SetOnce()) {
+            UASSERT_OBJ(nodep->access().isReadOnly(), nodep, "Should have failed in V3Access");
+            AstVarScope* const varscp = nodep->varScopep();
+            AstVarScope* const lastscp = createSampledVar(varscp);
+            AstNode* const newp = new AstVarRef{nodep->fileline(), lastscp, VAccess::READ};
+            newp->user1SetOnce();  // Don't sample this one
+            nodep->replaceWith(newp);
+            VL_DO_DANGLING(pushDeletep(nodep), nodep);
+        }
+    }
+
+    //--------------------
+    void visit(AstNode* nodep) override { iterateChildren(nodep); }
+
+public:
+    // CONSTRUCTORS
+    explicit SampledVisitor(AstNetlist* netlistp) { iterate(netlistp); }
+    ~SampledVisitor() override = default;
+};
+
+//######################################################################
+// Sampled class functions
+
+void V3Sampled::sampledAll(AstNetlist* nodep) {
+    UINFO(2, __FUNCTION__ << ": " << endl);
+    { SampledVisitor{nodep}; }  // Destruct before checking
+    V3Global::dumpCheckGlobalTree("sampled", 0, dumpTreeEitherLevel() >= 3);
+}

--- a/src/V3Sampled.h
+++ b/src/V3Sampled.h
@@ -1,0 +1,34 @@
+// -*- mode: C++; c-file-style: "cc-mode" -*-
+//*************************************************************************
+// DESCRIPTION: Verilator: Removal of SAMPLED
+//
+// Code available from: https://verilator.org
+//
+//*************************************************************************
+//
+// Copyright 2003-2024 by Wilson Snyder. This program is free software; you
+// can redistribute it and/or modify it under the terms of either the GNU
+// Lesser General Public License Version 3 or the Perl Artistic License
+// Version 2.0.
+// SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+//
+//*************************************************************************
+
+#ifndef VERILATOR_V3SAMPLED_H_
+#define VERILATOR_V3SAMPLED_H_
+
+#include "config_build.h"
+#include "verilatedos.h"
+
+#include "V3ThreadSafety.h"
+
+class AstNetlist;
+
+//============================================================================
+
+class V3Sampled final {
+public:
+    static void sampledAll(AstNetlist* nodep) VL_MT_DISABLED;
+};
+
+#endif  // Guard

--- a/src/V3Sched.h
+++ b/src/V3Sched.h
@@ -98,6 +98,8 @@ struct LogicRegions final {
     LogicByScope m_pre;  // AstAssignPre logic in 'act' region
     LogicByScope m_act;  // 'act' region logic
     LogicByScope m_nba;  // 'nba' region logic
+    LogicByScope m_obs;  // AstAlwaysObserved logic in 'obs' region
+    LogicByScope m_react;  // AstAlwaysReactive logic in 're' region
 
     LogicRegions() = default;
     VL_UNCOPYABLE(LogicRegions);
@@ -111,6 +113,8 @@ struct LogicReplicas final {
     LogicByScope m_ico;  // Logic replicated into the 'ico' (Input Combinational) region
     LogicByScope m_act;  // Logic replicated into the 'act' region
     LogicByScope m_nba;  // Logic replicated into the 'nba' region
+    LogicByScope m_obs;  // Logic replicated into the 'obs' region
+    LogicByScope m_react;  // Logic replicated into the 're' region
 
     LogicReplicas() = default;
     VL_UNCOPYABLE(LogicReplicas);

--- a/src/V3SchedReplicate.cpp
+++ b/src/V3SchedReplicate.cpp
@@ -50,7 +50,9 @@ enum RegionFlags : uint8_t {
     NONE = 0x0,  //
     INPUT = 0x1,  // Variable/logic is driven from top level input
     ACTIVE = 0x2,  // Variable/logic is driven from 'act' region logic
-    NBA = 0x4  // Variable/logic is driven from 'nba' region logic
+    NBA = 0x4,  // Variable/logic is driven from 'nba' region logic
+    OBSERVED = 0x8,  // Variable/logic is driven from 'obs' region logic
+    REACTIVE = 0x10,  // Variable/logic is driven from 're' region logic
 };
 
 //##############################################################################
@@ -79,7 +81,34 @@ public:
         case INPUT | NBA: return "magenta";
         case ACTIVE | NBA: return "cyan";
         case INPUT | ACTIVE | NBA: return "gray80";  // don't want white on white background
-        default: v3fatal("There are only 3 region bits"); return "";
+
+        case REACTIVE: return "gray60";
+        case REACTIVE | INPUT: return "lightcoral";
+        case REACTIVE | ACTIVE: return "lightgreen";
+        case REACTIVE | NBA: return "lightblue";
+        case REACTIVE | INPUT | ACTIVE: return "lightyellow";
+        case REACTIVE | INPUT | NBA: return "lightpink";
+        case REACTIVE | ACTIVE | NBA: return "lightcyan";
+        case REACTIVE | INPUT | ACTIVE | NBA: return "gray90";
+
+        case OBSERVED: return "gray20";
+        case OBSERVED | INPUT: return "darkred";
+        case OBSERVED | ACTIVE: return "darkgreen";
+        case OBSERVED | NBA: return "darkblue";
+        case OBSERVED | INPUT | ACTIVE: return "gold";
+        case OBSERVED | INPUT | NBA: return "purple";
+        case OBSERVED | ACTIVE | NBA: return "darkcyan";
+        case OBSERVED | INPUT | ACTIVE | NBA: return "gray30";
+
+        case REACTIVE | OBSERVED: return "gray40";
+        case REACTIVE | OBSERVED | INPUT: return "indianred";
+        case REACTIVE | OBSERVED | ACTIVE: return "olive";
+        case REACTIVE | OBSERVED | NBA: return "dodgerBlue";
+        case REACTIVE | OBSERVED | INPUT | ACTIVE: return "khaki";
+        case REACTIVE | OBSERVED | INPUT | NBA: return "plum";
+        case REACTIVE | OBSERVED | ACTIVE | NBA: return "lightSeaGreen";
+        case REACTIVE | OBSERVED | INPUT | ACTIVE | NBA: return "gray50";
+        default: v3fatal("There are only 5 region bits"); return "";
         }
     }
     // LCOV_EXCL_STOP
@@ -213,6 +242,8 @@ std::unique_ptr<Graph> buildGraph(const LogicRegions& logicRegions) {
     for (const auto& pair : logicRegions.m_pre) addLogic(ACTIVE, pair.first, pair.second);
     for (const auto& pair : logicRegions.m_act) addLogic(ACTIVE, pair.first, pair.second);
     for (const auto& pair : logicRegions.m_nba) addLogic(NBA, pair.first, pair.second);
+    for (const auto& pair : logicRegions.m_obs) addLogic(OBSERVED, pair.first, pair.second);
+    for (const auto& pair : logicRegions.m_react) addLogic(REACTIVE, pair.first, pair.second);
 
     return graphp;
 }
@@ -251,6 +282,8 @@ LogicReplicas replicate(Graph* graphp) {
             if (targetRegions & INPUT) replicateTo(result.m_ico);
             if (targetRegions & ACTIVE) replicateTo(result.m_act);
             if (targetRegions & NBA) replicateTo(result.m_nba);
+            if (targetRegions & OBSERVED) replicateTo(result.m_obs);
+            if (targetRegions & REACTIVE) replicateTo(result.m_react);
         }
     }
     return result;

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -2814,6 +2814,7 @@ class WidthVisitor final : public VNVisitor {
                 nodep->dtypep(varp->dtypep());
                 nodep->varp(varp);
                 nodep->didWidth(true);
+                if (nodep->access().isWriteOrRW()) V3LinkLValue::linkLValueSet(nodep);
                 if (AstIfaceRefDType* const adtypep
                     = VN_CAST(nodep->fromp()->dtypep(), IfaceRefDType)) {
                     nodep->varp()->sensIfacep(adtypep->ifacep());
@@ -2849,6 +2850,7 @@ class WidthVisitor final : public VNVisitor {
                     }
                 }
                 if (AstVar* const varp = VN_CAST(foundp, Var)) {
+                    if (!varp->didWidth()) userIterate(varp, nullptr);
                     nodep->dtypep(foundp->dtypep());
                     nodep->varp(varp);
                     AstIface* const ifacep = adtypep->ifacep();

--- a/src/Verilator.cpp
+++ b/src/Verilator.cpp
@@ -439,7 +439,7 @@ static void process() {
             V3ActiveTop::activeTopAll(v3Global.rootp());
 
             // Remove SAMPLED
-            V3Sampled::sampledAll(v3Global.rootp());
+            if (v3Global.hasSampled()) V3Sampled::sampledAll(v3Global.rootp());
 
             if (v3Global.opt.stats()) V3Stats::statsStageAll(v3Global.rootp(), "PreOrder");
 

--- a/src/Verilator.cpp
+++ b/src/Verilator.cpp
@@ -81,6 +81,7 @@
 #include "V3ProtectLib.h"
 #include "V3Randomize.h"
 #include "V3Reloop.h"
+#include "V3Sampled.h"
 #include "V3Sched.h"
 #include "V3Scope.h"
 #include "V3Scoreboard.h"
@@ -436,6 +437,9 @@ static void process() {
             // Differs from V3Active, because identical clocks may be pushed
             // down to a module and now be identical
             V3ActiveTop::activeTopAll(v3Global.rootp());
+
+            // Remove SAMPLED
+            V3Sampled::sampledAll(v3Global.rootp());
 
             if (v3Global.opt.stats()) V3Stats::statsStageAll(v3Global.rootp(), "PreOrder");
 

--- a/test_regress/t/t_clocking_virtual.pl
+++ b/test_regress/t/t_clocking_virtual.pl
@@ -1,0 +1,22 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2022 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    verilator_flags2 => ["--exe --main --timing"],
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_clocking_virtual.v
+++ b/test_regress/t/t_clocking_virtual.v
@@ -5,19 +5,29 @@
 // SPDX-License-Identifier: CC0-1.0
 
 interface Iface;
-   logic clk = 1'b0, inp = 1'b0;
+   logic clk = 1'b0, inp = 1'b0, io = 1'b0;
    clocking cb @(posedge clk);
-       input #3 inp;
+       input #7 inp;
+       inout io;
    endclocking
    always @(posedge clk) inp <= 1'b1;
-   always #1 clk = ~clk;
+   always #5 clk <= ~clk;
 endinterface
 
 module main;
    initial begin
-      #2;
+      #6;
+      t.mod1.cb.io <= 1'b1;
+      if (t.mod0.io != 1'b0) $stop;
+      if (t.mod1.cb.io != 1'b0) $stop;
       if (t.mod1.cb.inp != 1'b0) $stop;
-      #4;
+      @(posedge t.mod0.io)
+      if ($time != 15) $stop;
+      if (t.mod0.io != 1'b1) $stop;
+      if (t.mod1.cb.io != 1'b0) $stop;
+      #1
+      if (t.mod0.cb.io != 1'b1) $stop;
+      if (t.mod1.cb.io != 1'b1) $stop;
       if (t.mod1.cb.inp != 1'b1) $stop;
    end
 endmodule
@@ -27,7 +37,7 @@ module t;
    Iface mod0();
    virtual Iface mod1 = mod0;
    initial begin
-      #7;
+      #20;
       $write("*-* All Finished *-*\n");
       $finish;
    end

--- a/test_regress/t/t_clocking_virtual.v
+++ b/test_regress/t/t_clocking_virtual.v
@@ -5,19 +5,22 @@
 // SPDX-License-Identifier: CC0-1.0
 
 interface Iface;
-   logic clk = 1'b0, inp = 1'b0, io = 1'b0;
+   logic clk = 1'b0, inp = 1'b0, io = 1'b0, out = 1'b0, out2 = 1'b0;
    clocking cb @(posedge clk);
        input #7 inp;
+       output out;
        inout io;
    endclocking
    always @(posedge clk) inp <= 1'b1;
    always #5 clk <= ~clk;
+   assign out2 = out;
 endinterface
 
 module main;
    initial begin
       #6;
       t.mod1.cb.io <= 1'b1;
+      t.mod1.cb.out <= 1'b1;
       if (t.mod0.io != 1'b0) $stop;
       if (t.mod1.cb.io != 1'b0) $stop;
       if (t.mod1.cb.inp != 1'b0) $stop;
@@ -29,6 +32,11 @@ module main;
       if (t.mod0.cb.io != 1'b1) $stop;
       if (t.mod1.cb.io != 1'b1) $stop;
       if (t.mod1.cb.inp != 1'b1) $stop;
+   end
+   initial begin
+      @(posedge t.mod0.out)
+      if ($time != 15) $stop;
+      if (t.mod1.out2 != 1'b1) $stop;
    end
 endmodule
 

--- a/test_regress/t/t_clocking_virtual.v
+++ b/test_regress/t/t_clocking_virtual.v
@@ -32,6 +32,18 @@ module main;
       if (t.mod0.cb.io != 1'b1) $stop;
       if (t.mod1.cb.io != 1'b1) $stop;
       if (t.mod1.cb.inp != 1'b1) $stop;
+      #8;
+      t.mod0.inp = 1'b0;
+      if (t.mod0.cb.inp != 1'b1) $stop;
+      @(t.mod1.cb)
+      if ($time != 25) $stop;
+      if (t.mod0.cb.inp != 1'b1) $stop;
+      t.mod0.inp = 1'b0;
+      @(t.mod0.cb)
+      if ($time != 35) $stop;
+      if (t.mod0.cb.inp != 1'b0) $stop;
+      $write("*-* All Finished *-*\n");
+      $finish;
    end
    initial begin
       @(posedge t.mod0.out)
@@ -44,9 +56,4 @@ module t;
    main main1();
    Iface mod0();
    virtual Iface mod1 = mod0;
-   initial begin
-      #20;
-      $write("*-* All Finished *-*\n");
-      $finish;
-   end
 endmodule

--- a/test_regress/t/t_clocking_virtual.v
+++ b/test_regress/t/t_clocking_virtual.v
@@ -1,0 +1,34 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2024 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+interface Iface;
+   logic clk = 1'b0, inp = 1'b0;
+   clocking cb @(posedge clk);
+       input #3 inp;
+   endclocking
+   always @(posedge clk) inp <= 1'b1;
+   always #1 clk = ~clk;
+endinterface
+
+module main;
+   initial begin
+      #2;
+      if (t.mod1.cb.inp != 1'b0) $stop;
+      #4;
+      if (t.mod1.cb.inp != 1'b1) $stop;
+   end
+endmodule
+
+module t;
+   main main1();
+   Iface mod0();
+   virtual Iface mod1 = mod0;
+   initial begin
+      #7;
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end
+endmodule


### PR DESCRIPTION
These changes add support for accessing clocking blocks through virtual interfaces.
Unfortunately I am not very satisfied with the solution I came up with, because although it does work, there are two major hacks in place. I will be very grateful if you have better ideas for any of them, especially that clocking blocks are directly advised by the standard to be used in tandem with virtual interfaces.

The first hack lies in the first commit, which deals in general with combinational logic dependent on `$sampled` (most of this logic is normally eliminated by V3Gate, but the bug shows already on existing tests with `-fno-gate`, and might show elsewhere; the bug fix is needed here exactly because virtual-interface-sensitive variables cannot optimized by V3Gate).
The variables were formerly created and replaced after V3Sched, and therefore the logic depending on them could be ignored, assigned redundantly, or too early (because V3Sched believes it should be triggered when the variable updates, not when its sampled value updates).
My change creates the temporary variables for sampled values, replaces their references before V3Sched in a new phase (V3Sampled) and marks them as global inputs, so that V3Sched treats them correctly as unknowns that can change before every evaluation. They would otherwise need special triggers that would be moved from variable triggers at the end/beginning of each cycle (which would arguably be too complex given that the proportion of sampled variables to normal variables should be quite low).
The 'hack' is that their original value is stored as valuep of the new replacement variable, until V3Clock, which adds all the relevant ASSIGNs, and removes the valuep. It turned out to need to act based on variable name, because valuep can be still present on some variables (namely omitting this makes some hier and vpi tests fail).

And the second hack lies in V3Width. The transformation done there is basically unlinked `MEMBERSEL{MEMBERSEL{vifaceref, "cb_name"}, "clockvar_name"}` to linked `MEMBERSEL{vifaceref, "clockvar_name"}`.
In order to avoid introducing a new short-lived DType for the clocking blocks (it would be created when visiting the nested MEMBERSEL and then instantly dropped in the parent visitor), I decided to convert clocking block references to clocking block event references (which is almost correct), and then in the parent visitor, detect that fromp is a clocking block event reference (and look for members in the clocking block). This involves checking of firstAbovep, which is sufficient, but probably fragile.

The last commit should not be very controversial, but is in fact a bit separate from the rest, as it does not directly involve basic functionality.

Also included are some debugging message changes that made development easier.

Do you want me to split some of the changes into a separate PR? I tried to make the commits as independent as possible to make reviewing easier.