### PR TITLE
Mention docker hub explicitly

### DIFF
--- a/ci/docker/run/README.rst
+++ b/ci/docker/run/README.rst
@@ -11,10 +11,10 @@ easily as a docker image, e.g.:
 
    docker run -ti verilator/verilator:latest --version
 
-This will install the container, run the latest Verilator and print
+This will pull the container from [docker hub](https://hub.docker.com/r/verilator/verilator), run the latest Verilator and print
 Verilator's version.
 
-Containers are automatically built for all released versions, so you may
+Containers are automatically built and pushed to docker hub for all released versions, so you may
 easily compare results across versions, e.g.:
 
 ::

--- a/ci/docker/run/README.rst
+++ b/ci/docker/run/README.rst
@@ -11,7 +11,8 @@ easily as a docker image, e.g.:
 
    docker run -ti verilator/verilator:latest --version
 
-This will pull the container from [docker hub](https://hub.docker.com/r/verilator/verilator), run the latest Verilator and print
+This will pull the container from `docker hub
+<https://hub.docker.com/r/verilator/verilator>`_, run the latest Verilator and print
 Verilator's version.
 
 Containers are automatically built and pushed to docker hub for all released versions, so you may

--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -25,6 +25,7 @@ Aylon Chaim Porat
 Bartłomiej Chmiel
 Cameron Kirk
 Chih-Mao Chen
+Chris Bachhuber
 Chris Randall
 Christopher Taylor
 Chuxuan Wang


### PR DESCRIPTION
To avoid issues such as https://github.com/verilator/verilator/issues/5238 in future.