### PR TITLE
Add support for conditional constraints

### DIFF
--- a/src/V3AstNodeExpr.h
+++ b/src/V3AstNodeExpr.h
@@ -420,6 +420,7 @@ public:
                        const V3Number& ths) override;
     string emitVerilog() override { return "%k(%l %f? %r %k: %t)"; }
     string emitC() override { return "VL_COND_%nq%lq%rq%tq(%nw, %P, %li, %ri, %ti)"; }
+    string emitSMT() const override { return "(ite %l %r %t)"; }
     bool cleanOut() const override { return false; }  // clean if e1 & e2 clean
     bool cleanLhs() const override { return true; }
     bool cleanRhs() const override { return false; }

--- a/src/V3Randomize.cpp
+++ b/src/V3Randomize.cpp
@@ -48,7 +48,7 @@ class RandomizeMarkVisitor final : public VNVisitorConst {
 
     BaseToDerivedMap m_baseToDerivedMap;  // Mapping from base classes to classes that extend them
     AstClass* m_classp = nullptr;  // Current class
-    AstConstraintExpr* m_constraintExprp = nullptr;  // Current constraint expression
+    const AstNode* m_constraintExprp = nullptr;  // Current constraint expression
 
     // METHODS
     void markMembers(const AstClass* nodep) {
@@ -119,6 +119,15 @@ class RandomizeMarkVisitor final : public VNVisitorConst {
         m_constraintExprp = nodep;
         iterateChildrenConst(nodep);
     }
+    void visit(AstConstraintIf* nodep) override {
+        {
+            VL_RESTORER(m_constraintExprp);
+            m_constraintExprp = nodep;
+            iterateConst(nodep->condp());
+        }
+        iterateAndNextConstNull(nodep->thensp());
+        iterateAndNextConstNull(nodep->elsesp());
+    }
     void visit(AstNodeVarRef* nodep) override {
         if (!m_constraintExprp) return;
         if (!nodep->varp()->isRand()) return;
@@ -149,6 +158,7 @@ class ConstraintExprVisitor final : public VNVisitor {
 
     AstNodeFTask* const m_taskp;  // method to add write_var calls to
     AstVar* const m_genp;  // VlRandomizer variable of the class
+    bool m_wantSingle = false;  // Whether to merge constraint expressions with LOGAND
 
     bool editFormat(AstNodeExpr* nodep) {
         if (nodep->user1()) return false;
@@ -207,6 +217,34 @@ class ConstraintExprVisitor final : public VNVisitor {
         VL_DO_DANGLING(pushDeletep(nodep), nodep);
     }
 
+    AstNodeExpr* editSingle(FileLine* fl, AstNode* itemsp) {
+        if (!itemsp) return nullptr;
+
+        VL_RESTORER(m_wantSingle);
+        m_wantSingle = true;
+
+        {
+            AstBegin* const tempp
+                = new AstBegin{fl, "[EditWrapper]", itemsp->unlinkFrBackWithNext()};
+            VL_DO_DANGLING(iterateAndNextNull(tempp->stmtsp()), itemsp);
+            itemsp = tempp->stmtsp();
+            if (itemsp) itemsp->unlinkFrBackWithNext();
+            VL_DO_DANGLING(tempp->deleteTree(), tempp);
+        }
+        if (!itemsp) return nullptr;
+
+        AstNodeExpr* exprsp = VN_CAST(itemsp, NodeExpr);
+        UASSERT_OBJ(exprsp, itemsp, "Single not expression?");
+
+        if (!exprsp->nextp()) return exprsp;
+
+        std::ostringstream fmt;
+        fmt << "(and";
+        for (AstNode* itemp = exprsp; itemp; itemp = itemp->nextp()) fmt << " %@";
+        fmt << ')';
+        return new AstSFormatF{fl, fmt.str(), false, exprsp};
+    }
+
     // VISITORS
     void visit(AstNodeVarRef* nodep) override {
         if (editFormat(nodep)) return;
@@ -246,13 +284,71 @@ class ConstraintExprVisitor final : public VNVisitor {
         if (editFormat(nodep)) return;
         editSMT(nodep, nodep->lhsp(), nodep->rhsp(), nodep->thsp());
     }
+    void visit(AstNodeCond* nodep) override {
+        if (editFormat(nodep)) return;
+        if (!nodep->condp()->user1()) {
+            // Do not burden the solver if cond computable: (cond ? "then" : "else")
+            iterate(nodep->thenp());
+            iterate(nodep->elsep());
+            return;
+        }
+        // Fall back to "(ite cond then else)"
+        visit(static_cast<AstNodeTriop*>(nodep));
+    }
     void visit(AstReplicate* nodep) override {
         // Biop, but RHS is harmful
         if (editFormat(nodep)) return;
         editSMT(nodep, nodep->srcp());
     }
     void visit(AstSFormatF* nodep) override {}
-    void visit(AstConstraintExpr* nodep) override { iterateChildren(nodep); }
+    void visit(AstStmtExpr* nodep) override {}
+    void visit(AstConstraintIf* nodep) override {
+        AstNodeExpr* newp = nullptr;
+        FileLine* const fl = nodep->fileline();
+        AstNodeExpr* const thenp = editSingle(fl, nodep->thensp());
+        AstNodeExpr* const elsep = editSingle(fl, nodep->elsesp());
+        if (thenp && elsep) {
+            newp = new AstCond{fl, nodep->condp()->unlinkFrBack(), thenp, elsep};
+        } else if (thenp) {
+            newp = new AstLogIf{fl, nodep->condp()->unlinkFrBack(), thenp};
+        } else if (elsep) {
+            newp = new AstLogIf{fl, new AstNot{fl, nodep->condp()->unlinkFrBack()}, elsep};
+        }
+        if (newp) {
+            newp->user1(true);  // Assume result-dependent
+            nodep->replaceWith(new AstConstraintExpr{fl, newp});
+        } else {
+            nodep->unlinkFrBack();
+        }
+        VL_DO_DANGLING(nodep->deleteTree(), nodep);
+    }
+    void visit(AstConstraintForeach* nodep) override {
+        nodep->v3warn(CONSTRAINTIGN, "Constraint expression ignored (unsupported)");
+        VL_DO_DANGLING(nodep->unlinkFrBack()->deleteTree(), nodep);
+    }
+    void visit(AstConstraintBefore* nodep) override {
+        nodep->v3warn(CONSTRAINTIGN, "Constraint expression ignored (unsupported)");
+        VL_DO_DANGLING(nodep->unlinkFrBack()->deleteTree(), nodep);
+    }
+    void visit(AstConstraintUnique* nodep) override {
+        nodep->v3warn(CONSTRAINTIGN, "Constraint expression ignored (unsupported)");
+        VL_DO_DANGLING(nodep->unlinkFrBack()->deleteTree(), nodep);
+    }
+    void visit(AstConstraintExpr* nodep) override {
+        iterateChildren(nodep);
+        if (m_wantSingle) {
+            nodep->replaceWith(nodep->exprp()->unlinkFrBack());
+            VL_DO_DANGLING(nodep->deleteTree(), nodep);
+            return;
+        }
+        // Only hard constraints are currently supported
+        AstCMethodHard* const callp = new AstCMethodHard{
+            nodep->fileline(), new AstVarRef{nodep->fileline(), m_genp, VAccess::READWRITE},
+            "hard", nodep->exprp()->unlinkFrBack()};
+        callp->dtypeSetVoid();
+        nodep->replaceWith(callp->makeStmt());
+        VL_DO_DANGLING(nodep->deleteTree(), nodep);
+    }
     void visit(AstCMethodHard* nodep) override {
         if (editFormat(nodep)) return;
 
@@ -281,10 +377,10 @@ class ConstraintExprVisitor final : public VNVisitor {
 
 public:
     // CONSTRUCTORS
-    explicit ConstraintExprVisitor(AstConstraintExpr* nodep, AstNodeFTask* taskp, AstVar* genp)
+    explicit ConstraintExprVisitor(AstNode* nodep, AstNodeFTask* taskp, AstVar* genp)
         : m_taskp(taskp)
         , m_genp(genp) {
-        iterate(nodep);
+        iterateAndNextNull(nodep);
     }
 };
 
@@ -568,23 +664,8 @@ class RandomizeVisitor final : public VNVisitor {
         }
         randomizep->addStmtsp(setupTaskRefp->makeStmt());
 
-        while (nodep->itemsp()) {
-            AstConstraintExpr* const condsp = VN_CAST(nodep->itemsp(), ConstraintExpr);
-            if (!condsp) {
-                nodep->itemsp()->v3warn(CONSTRAINTIGN,
-                                        "Constraint expression ignored (unsupported)");
-                pushDeletep(nodep->itemsp()->unlinkFrBack());
-                continue;
-            }
-            { ConstraintExprVisitor{condsp->unlinkFrBack(), newp, genp}; }
-            // Only hard constraints are now supported
-            AstCMethodHard* const methodp = new AstCMethodHard{
-                condsp->fileline(), new AstVarRef{condsp->fileline(), genp, VAccess::READWRITE},
-                "hard", condsp->exprp()->unlinkFrBack()};
-            methodp->dtypeSetVoid();
-            taskp->addStmtsp(new AstStmtExpr{condsp->fileline(), methodp});
-            VL_DO_DANGLING(condsp->deleteTree(), condsp);
-        }
+        { ConstraintExprVisitor{nodep->itemsp(), newp, genp}; }
+        if (nodep->itemsp()) taskp->addStmtsp(nodep->itemsp()->unlinkFrBackWithNext());
         VL_DO_DANGLING(pushDeletep(nodep->unlinkFrBack()), nodep);
     }
     void visit(AstRandCase* nodep) override {

--- a/test_regress/t/t_constraint_json_only.out
+++ b/test_regress/t/t_constraint_json_only.out
@@ -1,17 +1,17 @@
 {"type":"NETLIST","name":"$root","addr":"(B)","loc":"a,0:0,0:0","timeunit":"1ps","timeprecision":"1ps","typeTablep":"(C)","constPoolp":"(D)","dollarUnitPkgp":"(E)","stdPackagep":"UNLINKED","evalp":"UNLINKED","evalNbap":"UNLINKED","dpiExportTriggerp":"UNLINKED","delaySchedulerp":"UNLINKED","nbaEventp":"UNLINKED","nbaEventTriggerp":"UNLINKED","topScopep":"UNLINKED",
  "modulesp": [
-  {"type":"MODULE","name":"t","addr":"(F)","loc":"d,65:8,65:9","origName":"t","level":0,"modPublic":false,"inLibrary":false,"dead":false,"recursiveClone":false,"recursive":false,"timeunit":"1ps","inlinesp": [],
+  {"type":"MODULE","name":"t","addr":"(F)","loc":"d,67:8,67:9","origName":"t","level":0,"modPublic":false,"inLibrary":false,"dead":false,"recursiveClone":false,"recursive":false,"timeunit":"1ps","inlinesp": [],
    "stmtsp": [
-    {"type":"VAR","name":"p","addr":"(G)","loc":"d,67:11,67:12","dtypep":"(H)","origName":"p","isSc":false,"isPrimaryIO":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"attrClocker":"UNKNOWN","lifetime":"VSTATIC","varType":"VAR","dtypeName":"Packet","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
-    {"type":"INITIAL","name":"","addr":"(I)","loc":"d,69:4,69:11","isSuspendable":false,"needProcess":false,
+    {"type":"VAR","name":"p","addr":"(G)","loc":"d,69:11,69:12","dtypep":"(H)","origName":"p","isSc":false,"isPrimaryIO":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"attrClocker":"UNKNOWN","lifetime":"VSTATIC","varType":"VAR","dtypeName":"Packet","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
+    {"type":"INITIAL","name":"","addr":"(I)","loc":"d,71:4,71:11","isSuspendable":false,"needProcess":false,
      "stmtsp": [
-      {"type":"BEGIN","name":"","addr":"(J)","loc":"d,69:12,69:17","generate":false,"genfor":false,"implied":false,"needProcess":false,"unnamed":true,"genforp": [],
+      {"type":"BEGIN","name":"","addr":"(J)","loc":"d,71:12,71:17","generate":false,"genfor":false,"implied":false,"needProcess":false,"unnamed":true,"genforp": [],
        "stmtsp": [
-        {"type":"DISPLAY","name":"","addr":"(K)","loc":"d,71:7,71:13",
+        {"type":"DISPLAY","name":"","addr":"(K)","loc":"d,73:7,73:13",
          "fmtp": [
-          {"type":"SFORMATF","name":"*-* All Finished *-*\\n","addr":"(L)","loc":"d,71:7,71:13","dtypep":"(M)","exprsp": [],"scopeNamep": []}
+          {"type":"SFORMATF","name":"*-* All Finished *-*\\n","addr":"(L)","loc":"d,73:7,73:13","dtypep":"(M)","exprsp": [],"scopeNamep": []}
         ],"filep": []},
-        {"type":"FINISH","name":"","addr":"(N)","loc":"d,72:7,72:14"}
+        {"type":"FINISH","name":"","addr":"(N)","loc":"d,74:7,74:14"}
       ]}
     ]}
   ],"activesp": []},
@@ -27,25 +27,25 @@
       {"type":"VAR","name":"if_state_ok","addr":"(W)","loc":"d,13:13,13:24","dtypep":"(U)","origName":"if_state_ok","isSc":false,"isPrimaryIO":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"attrClocker":"UNKNOWN","lifetime":"VAUTOM","varType":"MEMBER","dtypeName":"bit","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
       {"type":"VAR","name":"array","addr":"(X)","loc":"d,15:13,15:18","dtypep":"(Y)","origName":"array","isSc":false,"isPrimaryIO":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"attrClocker":"UNKNOWN","lifetime":"VAUTOM","varType":"MEMBER","dtypeName":"","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
       {"type":"VAR","name":"state","addr":"(Z)","loc":"d,17:11,17:16","dtypep":"(M)","origName":"state","isSc":false,"isPrimaryIO":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"attrClocker":"UNKNOWN","lifetime":"VAUTOM","varType":"MEMBER","dtypeName":"string","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
-      {"type":"FUNC","name":"strings_equal","addr":"(AB)","loc":"d,59:17,59:30","dtypep":"(U)","method":true,"dpiExport":false,"dpiImport":false,"dpiOpenChild":false,"dpiOpenParent":false,"prototype":false,"recursive":false,"taskPublic":false,"cname":"strings_equal",
+      {"type":"FUNC","name":"strings_equal","addr":"(AB)","loc":"d,61:17,61:30","dtypep":"(U)","method":true,"dpiExport":false,"dpiImport":false,"dpiOpenChild":false,"dpiOpenParent":false,"prototype":false,"recursive":false,"taskPublic":false,"cname":"strings_equal",
        "fvarp": [
-        {"type":"VAR","name":"strings_equal","addr":"(BB)","loc":"d,59:17,59:30","dtypep":"(U)","origName":"strings_equal","isSc":false,"isPrimaryIO":false,"direction":"OUTPUT","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":true,"isFuncLocal":true,"attrClocker":"UNKNOWN","lifetime":"VAUTOM","varType":"MEMBER","dtypeName":"bit","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []}
+        {"type":"VAR","name":"strings_equal","addr":"(BB)","loc":"d,61:17,61:30","dtypep":"(U)","origName":"strings_equal","isSc":false,"isPrimaryIO":false,"direction":"OUTPUT","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":true,"isFuncLocal":true,"attrClocker":"UNKNOWN","lifetime":"VAUTOM","varType":"MEMBER","dtypeName":"bit","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []}
       ],"classOrPackagep": [],
        "stmtsp": [
-        {"type":"VAR","name":"a","addr":"(CB)","loc":"d,59:38,59:39","dtypep":"(M)","origName":"a","isSc":false,"isPrimaryIO":false,"direction":"INPUT","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":true,"attrClocker":"UNKNOWN","lifetime":"VAUTOM","varType":"MEMBER","dtypeName":"string","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
-        {"type":"VAR","name":"b","addr":"(DB)","loc":"d,59:48,59:49","dtypep":"(M)","origName":"b","isSc":false,"isPrimaryIO":false,"direction":"INPUT","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":true,"attrClocker":"UNKNOWN","lifetime":"VAUTOM","varType":"MEMBER","dtypeName":"string","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
-        {"type":"ASSIGN","name":"","addr":"(EB)","loc":"d,60:7,60:13","dtypep":"(U)",
+        {"type":"VAR","name":"a","addr":"(CB)","loc":"d,61:38,61:39","dtypep":"(M)","origName":"a","isSc":false,"isPrimaryIO":false,"direction":"INPUT","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":true,"attrClocker":"UNKNOWN","lifetime":"VAUTOM","varType":"MEMBER","dtypeName":"string","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
+        {"type":"VAR","name":"b","addr":"(DB)","loc":"d,61:48,61:49","dtypep":"(M)","origName":"b","isSc":false,"isPrimaryIO":false,"direction":"INPUT","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":true,"attrClocker":"UNKNOWN","lifetime":"VAUTOM","varType":"MEMBER","dtypeName":"string","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
+        {"type":"ASSIGN","name":"","addr":"(EB)","loc":"d,62:7,62:13","dtypep":"(U)",
          "rhsp": [
-          {"type":"EQN","name":"","addr":"(FB)","loc":"d,60:16,60:18","dtypep":"(GB)",
+          {"type":"EQN","name":"","addr":"(FB)","loc":"d,62:16,62:18","dtypep":"(GB)",
            "lhsp": [
-            {"type":"VARREF","name":"a","addr":"(HB)","loc":"d,60:14,60:15","dtypep":"(M)","access":"RD","varp":"(CB)","varScopep":"UNLINKED","classOrPackagep":"(O)"}
+            {"type":"VARREF","name":"a","addr":"(HB)","loc":"d,62:14,62:15","dtypep":"(M)","access":"RD","varp":"(CB)","varScopep":"UNLINKED","classOrPackagep":"(O)"}
           ],
            "rhsp": [
-            {"type":"VARREF","name":"b","addr":"(IB)","loc":"d,60:19,60:20","dtypep":"(M)","access":"RD","varp":"(DB)","varScopep":"UNLINKED","classOrPackagep":"(O)"}
+            {"type":"VARREF","name":"b","addr":"(IB)","loc":"d,62:19,62:20","dtypep":"(M)","access":"RD","varp":"(DB)","varScopep":"UNLINKED","classOrPackagep":"(O)"}
           ]}
         ],
          "lhsp": [
-          {"type":"VARREF","name":"strings_equal","addr":"(JB)","loc":"d,60:7,60:13","dtypep":"(U)","access":"WR","varp":"(BB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+          {"type":"VARREF","name":"strings_equal","addr":"(JB)","loc":"d,62:7,62:13","dtypep":"(U)","access":"WR","varp":"(BB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
         ],"timingControlp": []}
       ],"scopeNamep": []},
       {"type":"FUNC","name":"new","addr":"(KB)","loc":"d,7:1,7:6","dtypep":"(LB)","method":true,"dpiExport":false,"dpiImport":false,"dpiOpenChild":false,"dpiOpenParent":false,"prototype":false,"recursive":false,"taskPublic":false,"cname":"new","fvarp": [],"classOrPackagep": [],
@@ -80,145 +80,240 @@
             ]}
           ]}
         ]},
-        {"type":"STMTEXPR","name":"","addr":"(DC)","loc":"d,10:13,10:22",
+        {"type":"STMTEXPR","name":"","addr":"(DC)","loc":"d,11:13,11:17",
          "exprp": [
-          {"type":"CMETHODHARD","name":"write_var","addr":"(EC)","loc":"d,10:13,10:22","dtypep":"(LB)",
+          {"type":"CMETHODHARD","name":"write_var","addr":"(EC)","loc":"d,11:13,11:17","dtypep":"(LB)",
            "fromp": [
-            {"type":"VARREF","name":"constraint","addr":"(FC)","loc":"d,10:13,10:22","dtypep":"(PB)","access":"RW","varp":"(QB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"constraint","addr":"(FC)","loc":"d,11:13,11:17","dtypep":"(PB)","access":"RW","varp":"(QB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ],
            "pinsp": [
-            {"type":"VARREF","name":"sublength","addr":"(GC)","loc":"d,10:13,10:22","dtypep":"(Q)","access":"WR","varp":"(S)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"},
-            {"type":"CONST","name":"64'h20","addr":"(HC)","loc":"d,8:9,8:12","dtypep":"(TB)"},
-            {"type":"CEXPR","name":"","addr":"(IC)","loc":"d,10:13,10:22","dtypep":"(Q)",
+            {"type":"VARREF","name":"if_4","addr":"(GC)","loc":"d,11:13,11:17","dtypep":"(U)","access":"WR","varp":"(T)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"},
+            {"type":"CONST","name":"64'h1","addr":"(HC)","loc":"d,11:9,11:12","dtypep":"(TB)"},
+            {"type":"CEXPR","name":"","addr":"(IC)","loc":"d,11:13,11:17","dtypep":"(U)",
              "exprsp": [
-              {"type":"TEXT","name":"","addr":"(JC)","loc":"d,10:13,10:22","shortText":"\"sublength\""}
+              {"type":"TEXT","name":"","addr":"(JC)","loc":"d,11:13,11:17","shortText":"\"if_4\""}
+            ]}
+          ]}
+        ]},
+        {"type":"STMTEXPR","name":"","addr":"(KC)","loc":"d,12:13,12:20",
+         "exprp": [
+          {"type":"CMETHODHARD","name":"write_var","addr":"(LC)","loc":"d,12:13,12:20","dtypep":"(LB)",
+           "fromp": [
+            {"type":"VARREF","name":"constraint","addr":"(MC)","loc":"d,12:13,12:20","dtypep":"(PB)","access":"RW","varp":"(QB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+          ],
+           "pinsp": [
+            {"type":"VARREF","name":"iff_5_6","addr":"(NC)","loc":"d,12:13,12:20","dtypep":"(U)","access":"WR","varp":"(V)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"},
+            {"type":"CONST","name":"64'h1","addr":"(OC)","loc":"d,11:9,11:12","dtypep":"(TB)"},
+            {"type":"CEXPR","name":"","addr":"(PC)","loc":"d,12:13,12:20","dtypep":"(U)",
+             "exprsp": [
+              {"type":"TEXT","name":"","addr":"(QC)","loc":"d,12:13,12:20","shortText":"\"iff_5_6\""}
+            ]}
+          ]}
+        ]},
+        {"type":"STMTEXPR","name":"","addr":"(RC)","loc":"d,10:13,10:22",
+         "exprp": [
+          {"type":"CMETHODHARD","name":"write_var","addr":"(SC)","loc":"d,10:13,10:22","dtypep":"(LB)",
+           "fromp": [
+            {"type":"VARREF","name":"constraint","addr":"(TC)","loc":"d,10:13,10:22","dtypep":"(PB)","access":"RW","varp":"(QB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+          ],
+           "pinsp": [
+            {"type":"VARREF","name":"sublength","addr":"(UC)","loc":"d,10:13,10:22","dtypep":"(Q)","access":"WR","varp":"(S)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"},
+            {"type":"CONST","name":"64'h20","addr":"(VC)","loc":"d,8:9,8:12","dtypep":"(TB)"},
+            {"type":"CEXPR","name":"","addr":"(WC)","loc":"d,10:13,10:22","dtypep":"(Q)",
+             "exprsp": [
+              {"type":"TEXT","name":"","addr":"(XC)","loc":"d,10:13,10:22","shortText":"\"sublength\""}
+            ]}
+          ]}
+        ]},
+        {"type":"STMTEXPR","name":"","addr":"(YC)","loc":"d,13:13,13:24",
+         "exprp": [
+          {"type":"CMETHODHARD","name":"write_var","addr":"(ZC)","loc":"d,13:13,13:24","dtypep":"(LB)",
+           "fromp": [
+            {"type":"VARREF","name":"constraint","addr":"(AD)","loc":"d,13:13,13:24","dtypep":"(PB)","access":"RW","varp":"(QB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+          ],
+           "pinsp": [
+            {"type":"VARREF","name":"if_state_ok","addr":"(BD)","loc":"d,13:13,13:24","dtypep":"(U)","access":"WR","varp":"(W)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"},
+            {"type":"CONST","name":"64'h1","addr":"(CD)","loc":"d,11:9,11:12","dtypep":"(TB)"},
+            {"type":"CEXPR","name":"","addr":"(DD)","loc":"d,13:13,13:24","dtypep":"(U)",
+             "exprsp": [
+              {"type":"TEXT","name":"","addr":"(ED)","loc":"d,13:13,13:24","shortText":"\"if_state_ok\""}
             ]}
           ]}
         ]}
       ],"scopeNamep": []},
-      {"type":"FUNC","name":"randomize","addr":"(KC)","loc":"d,7:1,7:6","dtypep":"(LC)","method":true,"dpiExport":false,"dpiImport":false,"dpiOpenChild":false,"dpiOpenParent":false,"prototype":false,"recursive":false,"taskPublic":false,"cname":"randomize",
+      {"type":"FUNC","name":"randomize","addr":"(FD)","loc":"d,7:1,7:6","dtypep":"(GD)","method":true,"dpiExport":false,"dpiImport":false,"dpiOpenChild":false,"dpiOpenParent":false,"prototype":false,"recursive":false,"taskPublic":false,"cname":"randomize",
        "fvarp": [
-        {"type":"VAR","name":"randomize","addr":"(MC)","loc":"d,7:1,7:6","dtypep":"(LC)","origName":"randomize","isSc":false,"isPrimaryIO":false,"direction":"OUTPUT","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":true,"isFuncLocal":true,"attrClocker":"UNKNOWN","lifetime":"VAUTOM","varType":"MEMBER","dtypeName":"bit","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []}
+        {"type":"VAR","name":"randomize","addr":"(HD)","loc":"d,7:1,7:6","dtypep":"(GD)","origName":"randomize","isSc":false,"isPrimaryIO":false,"direction":"OUTPUT","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":true,"isFuncLocal":true,"attrClocker":"UNKNOWN","lifetime":"VAUTOM","varType":"MEMBER","dtypeName":"bit","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []}
       ],"classOrPackagep": [],
        "stmtsp": [
-        {"type":"STMTEXPR","name":"","addr":"(NC)","loc":"d,7:1,7:6",
+        {"type":"STMTEXPR","name":"","addr":"(ID)","loc":"d,7:1,7:6",
          "exprp": [
-          {"type":"CMETHODHARD","name":"clear","addr":"(OC)","loc":"d,7:1,7:6","dtypep":"(LB)",
+          {"type":"CMETHODHARD","name":"clear","addr":"(JD)","loc":"d,7:1,7:6","dtypep":"(LB)",
            "fromp": [
-            {"type":"VARREF","name":"constraint","addr":"(PC)","loc":"d,7:1,7:6","dtypep":"(PB)","access":"RW","varp":"(QB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"constraint","addr":"(KD)","loc":"d,7:1,7:6","dtypep":"(PB)","access":"RW","varp":"(QB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ],"pinsp": []}
         ]},
-        {"type":"STMTEXPR","name":"","addr":"(QC)","loc":"d,19:15,19:20",
+        {"type":"STMTEXPR","name":"","addr":"(LD)","loc":"d,19:15,19:20",
          "exprp": [
-          {"type":"TASKREF","name":"empty_setup_constraint","addr":"(RC)","loc":"d,19:15,19:20","dtypep":"(LB)","dotted":"","taskp":"(SC)","classOrPackagep":"UNLINKED","namep": [],"pinsp": [],"scopeNamep": []}
+          {"type":"TASKREF","name":"empty_setup_constraint","addr":"(MD)","loc":"d,19:15,19:20","dtypep":"(LB)","dotted":"","taskp":"(ND)","classOrPackagep":"UNLINKED","namep": [],"pinsp": [],"scopeNamep": []}
         ]},
-        {"type":"STMTEXPR","name":"","addr":"(TC)","loc":"d,21:15,21:19",
+        {"type":"STMTEXPR","name":"","addr":"(OD)","loc":"d,21:15,21:19",
          "exprp": [
-          {"type":"TASKREF","name":"size_setup_constraint","addr":"(UC)","loc":"d,21:15,21:19","dtypep":"(LB)","dotted":"","taskp":"(VC)","classOrPackagep":"UNLINKED","namep": [],"pinsp": [],"scopeNamep": []}
+          {"type":"TASKREF","name":"size_setup_constraint","addr":"(PD)","loc":"d,21:15,21:19","dtypep":"(LB)","dotted":"","taskp":"(QD)","classOrPackagep":"UNLINKED","namep": [],"pinsp": [],"scopeNamep": []}
         ]},
-        {"type":"STMTEXPR","name":"","addr":"(WC)","loc":"d,28:15,28:18",
+        {"type":"STMTEXPR","name":"","addr":"(RD)","loc":"d,28:15,28:18",
          "exprp": [
-          {"type":"TASKREF","name":"ifs_setup_constraint","addr":"(XC)","loc":"d,28:15,28:18","dtypep":"(LB)","dotted":"","taskp":"(YC)","classOrPackagep":"UNLINKED","namep": [],"pinsp": [],"scopeNamep": []}
+          {"type":"TASKREF","name":"ifs_setup_constraint","addr":"(SD)","loc":"d,28:15,28:18","dtypep":"(LB)","dotted":"","taskp":"(TD)","classOrPackagep":"UNLINKED","namep": [],"pinsp": [],"scopeNamep": []}
         ]},
-        {"type":"STMTEXPR","name":"","addr":"(ZC)","loc":"d,39:15,39:23",
+        {"type":"STMTEXPR","name":"","addr":"(UD)","loc":"d,41:15,41:23",
          "exprp": [
-          {"type":"TASKREF","name":"arr_uniq_setup_constraint","addr":"(AD)","loc":"d,39:15,39:23","dtypep":"(LB)","dotted":"","taskp":"(BD)","classOrPackagep":"UNLINKED","namep": [],"pinsp": [],"scopeNamep": []}
+          {"type":"TASKREF","name":"arr_uniq_setup_constraint","addr":"(VD)","loc":"d,41:15,41:23","dtypep":"(LB)","dotted":"","taskp":"(WD)","classOrPackagep":"UNLINKED","namep": [],"pinsp": [],"scopeNamep": []}
         ]},
-        {"type":"STMTEXPR","name":"","addr":"(CD)","loc":"d,46:15,46:20",
+        {"type":"STMTEXPR","name":"","addr":"(XD)","loc":"d,48:15,48:20",
          "exprp": [
-          {"type":"TASKREF","name":"order_setup_constraint","addr":"(DD)","loc":"d,46:15,46:20","dtypep":"(LB)","dotted":"","taskp":"(ED)","classOrPackagep":"UNLINKED","namep": [],"pinsp": [],"scopeNamep": []}
+          {"type":"TASKREF","name":"order_setup_constraint","addr":"(YD)","loc":"d,48:15,48:20","dtypep":"(LB)","dotted":"","taskp":"(ZD)","classOrPackagep":"UNLINKED","namep": [],"pinsp": [],"scopeNamep": []}
         ]},
-        {"type":"STMTEXPR","name":"","addr":"(FD)","loc":"d,48:15,48:18",
+        {"type":"STMTEXPR","name":"","addr":"(AE)","loc":"d,50:15,50:18",
          "exprp": [
-          {"type":"TASKREF","name":"dis_setup_constraint","addr":"(GD)","loc":"d,48:15,48:18","dtypep":"(LB)","dotted":"","taskp":"(HD)","classOrPackagep":"UNLINKED","namep": [],"pinsp": [],"scopeNamep": []}
+          {"type":"TASKREF","name":"dis_setup_constraint","addr":"(BE)","loc":"d,50:15,50:18","dtypep":"(LB)","dotted":"","taskp":"(CE)","classOrPackagep":"UNLINKED","namep": [],"pinsp": [],"scopeNamep": []}
         ]},
-        {"type":"STMTEXPR","name":"","addr":"(ID)","loc":"d,54:15,54:19",
+        {"type":"STMTEXPR","name":"","addr":"(DE)","loc":"d,56:15,56:19",
          "exprp": [
-          {"type":"TASKREF","name":"meth_setup_constraint","addr":"(JD)","loc":"d,54:15,54:19","dtypep":"(LB)","dotted":"","taskp":"(KD)","classOrPackagep":"UNLINKED","namep": [],"pinsp": [],"scopeNamep": []}
+          {"type":"TASKREF","name":"meth_setup_constraint","addr":"(EE)","loc":"d,56:15,56:19","dtypep":"(LB)","dotted":"","taskp":"(FE)","classOrPackagep":"UNLINKED","namep": [],"pinsp": [],"scopeNamep": []}
         ]}
       ],"scopeNamep": []},
-      {"type":"TASK","name":"empty_setup_constraint","addr":"(SC)","loc":"d,7:1,7:6","method":true,"dpiExport":false,"dpiImport":false,"dpiOpenChild":false,"dpiOpenParent":false,"prototype":false,"recursive":false,"taskPublic":false,"cname":"empty_setup_constraint","fvarp": [],"classOrPackagep": [],"stmtsp": [],"scopeNamep": []},
+      {"type":"TASK","name":"empty_setup_constraint","addr":"(ND)","loc":"d,7:1,7:6","method":true,"dpiExport":false,"dpiImport":false,"dpiOpenChild":false,"dpiOpenParent":false,"prototype":false,"recursive":false,"taskPublic":false,"cname":"empty_setup_constraint","fvarp": [],"classOrPackagep": [],"stmtsp": [],"scopeNamep": []},
       {"type":"VAR","name":"constraint","addr":"(QB)","loc":"d,19:15,19:20","dtypep":"(PB)","origName":"constraint","isSc":false,"isPrimaryIO":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"attrClocker":"UNKNOWN","lifetime":"NONE","varType":"MEMBER","dtypeName":"VlRandomizer","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
-      {"type":"TASK","name":"size_setup_constraint","addr":"(VC)","loc":"d,7:1,7:6","method":true,"dpiExport":false,"dpiImport":false,"dpiOpenChild":false,"dpiOpenParent":false,"prototype":false,"recursive":false,"taskPublic":false,"cname":"size_setup_constraint","fvarp": [],"classOrPackagep": [],
+      {"type":"TASK","name":"size_setup_constraint","addr":"(QD)","loc":"d,7:1,7:6","method":true,"dpiExport":false,"dpiImport":false,"dpiOpenChild":false,"dpiOpenParent":false,"prototype":false,"recursive":false,"taskPublic":false,"cname":"size_setup_constraint","fvarp": [],"classOrPackagep": [],
        "stmtsp": [
-        {"type":"STMTEXPR","name":"","addr":"(LD)","loc":"d,22:18,22:20",
+        {"type":"STMTEXPR","name":"","addr":"(GE)","loc":"d,22:18,22:20",
          "exprp": [
-          {"type":"CMETHODHARD","name":"hard","addr":"(MD)","loc":"d,22:18,22:20","dtypep":"(LB)",
+          {"type":"CMETHODHARD","name":"hard","addr":"(HE)","loc":"d,22:18,22:20","dtypep":"(LB)",
            "fromp": [
-            {"type":"VARREF","name":"constraint","addr":"(ND)","loc":"d,22:18,22:20","dtypep":"(PB)","access":"RW","varp":"(QB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"constraint","addr":"(IE)","loc":"d,22:18,22:20","dtypep":"(PB)","access":"RW","varp":"(QB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ],
            "pinsp": [
-            {"type":"CONST","name":"\\\"(and (bvsgt header #x00000000) (bvsle header #x00000007))\\\"","addr":"(OD)","loc":"d,22:18,22:20","dtypep":"(M)"}
+            {"type":"CONST","name":"\\\"(and (bvsgt header #x00000000) (bvsle header #x00000007))\\\"","addr":"(JE)","loc":"d,22:18,22:20","dtypep":"(M)"}
           ]}
         ]},
-        {"type":"STMTEXPR","name":"","addr":"(PD)","loc":"d,23:14,23:16",
+        {"type":"STMTEXPR","name":"","addr":"(KE)","loc":"d,23:14,23:16",
          "exprp": [
-          {"type":"CMETHODHARD","name":"hard","addr":"(QD)","loc":"d,23:14,23:16","dtypep":"(LB)",
+          {"type":"CMETHODHARD","name":"hard","addr":"(LE)","loc":"d,23:14,23:16","dtypep":"(LB)",
            "fromp": [
-            {"type":"VARREF","name":"constraint","addr":"(RD)","loc":"d,23:14,23:16","dtypep":"(PB)","access":"RW","varp":"(QB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"constraint","addr":"(ME)","loc":"d,23:14,23:16","dtypep":"(PB)","access":"RW","varp":"(QB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ],
            "pinsp": [
-            {"type":"CONST","name":"\\\"(bvsle length #x0000000f)\\\"","addr":"(SD)","loc":"d,23:14,23:16","dtypep":"(M)"}
+            {"type":"CONST","name":"\\\"(bvsle length #x0000000f)\\\"","addr":"(NE)","loc":"d,23:14,23:16","dtypep":"(M)"}
           ]}
         ]},
-        {"type":"STMTEXPR","name":"","addr":"(TD)","loc":"d,24:14,24:16",
+        {"type":"STMTEXPR","name":"","addr":"(OE)","loc":"d,24:14,24:16",
          "exprp": [
-          {"type":"CMETHODHARD","name":"hard","addr":"(UD)","loc":"d,24:14,24:16","dtypep":"(LB)",
+          {"type":"CMETHODHARD","name":"hard","addr":"(PE)","loc":"d,24:14,24:16","dtypep":"(LB)",
            "fromp": [
-            {"type":"VARREF","name":"constraint","addr":"(VD)","loc":"d,24:14,24:16","dtypep":"(PB)","access":"RW","varp":"(QB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"constraint","addr":"(QE)","loc":"d,24:14,24:16","dtypep":"(PB)","access":"RW","varp":"(QB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ],
            "pinsp": [
-            {"type":"CONST","name":"\\\"(bvsge length header)\\\"","addr":"(WD)","loc":"d,24:14,24:16","dtypep":"(M)"}
+            {"type":"CONST","name":"\\\"(bvsge length header)\\\"","addr":"(RE)","loc":"d,24:14,24:16","dtypep":"(M)"}
           ]}
         ]},
-        {"type":"STMTEXPR","name":"","addr":"(XD)","loc":"d,25:7,25:13",
+        {"type":"STMTEXPR","name":"","addr":"(SE)","loc":"d,25:7,25:13",
          "exprp": [
-          {"type":"CMETHODHARD","name":"hard","addr":"(YD)","loc":"d,25:7,25:13","dtypep":"(LB)",
+          {"type":"CMETHODHARD","name":"hard","addr":"(TE)","loc":"d,25:7,25:13","dtypep":"(LB)",
            "fromp": [
-            {"type":"VARREF","name":"constraint","addr":"(ZD)","loc":"d,25:7,25:13","dtypep":"(PB)","access":"RW","varp":"(QB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"constraint","addr":"(UE)","loc":"d,25:7,25:13","dtypep":"(PB)","access":"RW","varp":"(QB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ],
            "pinsp": [
-            {"type":"CONST","name":"\\\"length\\\"","addr":"(AE)","loc":"d,25:7,25:13","dtypep":"(M)"}
+            {"type":"CONST","name":"\\\"length\\\"","addr":"(VE)","loc":"d,25:7,25:13","dtypep":"(M)"}
           ]}
         ]}
       ],"scopeNamep": []},
-      {"type":"TASK","name":"ifs_setup_constraint","addr":"(YC)","loc":"d,7:1,7:6","method":true,"dpiExport":false,"dpiImport":false,"dpiOpenChild":false,"dpiOpenParent":false,"prototype":false,"recursive":false,"taskPublic":false,"cname":"ifs_setup_constraint","fvarp": [],"classOrPackagep": [],"stmtsp": [],"scopeNamep": []},
-      {"type":"TASK","name":"arr_uniq_setup_constraint","addr":"(BD)","loc":"d,7:1,7:6","method":true,"dpiExport":false,"dpiImport":false,"dpiOpenChild":false,"dpiOpenParent":false,"prototype":false,"recursive":false,"taskPublic":false,"cname":"arr_uniq_setup_constraint","fvarp": [],"classOrPackagep": [],"stmtsp": [],"scopeNamep": []},
-      {"type":"TASK","name":"order_setup_constraint","addr":"(ED)","loc":"d,7:1,7:6","method":true,"dpiExport":false,"dpiImport":false,"dpiOpenChild":false,"dpiOpenParent":false,"prototype":false,"recursive":false,"taskPublic":false,"cname":"order_setup_constraint","fvarp": [],"classOrPackagep": [],"stmtsp": [],"scopeNamep": []},
-      {"type":"TASK","name":"dis_setup_constraint","addr":"(HD)","loc":"d,7:1,7:6","method":true,"dpiExport":false,"dpiImport":false,"dpiOpenChild":false,"dpiOpenParent":false,"prototype":false,"recursive":false,"taskPublic":false,"cname":"dis_setup_constraint","fvarp": [],"classOrPackagep": [],
+      {"type":"TASK","name":"ifs_setup_constraint","addr":"(TD)","loc":"d,7:1,7:6","method":true,"dpiExport":false,"dpiImport":false,"dpiOpenChild":false,"dpiOpenParent":false,"prototype":false,"recursive":false,"taskPublic":false,"cname":"ifs_setup_constraint","fvarp": [],"classOrPackagep": [],
        "stmtsp": [
-        {"type":"STMTEXPR","name":"","addr":"(BE)","loc":"d,49:7,49:11",
+        {"type":"STMTEXPR","name":"","addr":"(WE)","loc":"d,29:7,29:9",
          "exprp": [
-          {"type":"CMETHODHARD","name":"hard","addr":"(CE)","loc":"d,49:7,49:11","dtypep":"(LB)",
+          {"type":"CMETHODHARD","name":"hard","addr":"(XE)","loc":"d,29:7,29:9","dtypep":"(LB)",
            "fromp": [
-            {"type":"VARREF","name":"constraint","addr":"(DE)","loc":"d,49:7,49:11","dtypep":"(PB)","access":"RW","varp":"(QB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"constraint","addr":"(YE)","loc":"d,29:7,29:9","dtypep":"(PB)","access":"RW","varp":"(QB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ],
            "pinsp": [
-            {"type":"CONST","name":"\\\"sublength\\\"","addr":"(EE)","loc":"d,49:12,49:21","dtypep":"(M)"}
+            {"type":"CONST","name":"\\\"(=> (bvsgt header #x00000004) (= if_4 #b1))\\\"","addr":"(ZE)","loc":"d,29:7,29:9","dtypep":"(M)"}
           ]}
         ]},
-        {"type":"STMTEXPR","name":"","addr":"(FE)","loc":"d,50:7,50:14",
+        {"type":"STMTEXPR","name":"","addr":"(AF)","loc":"d,32:7,32:9",
          "exprp": [
-          {"type":"CMETHODHARD","name":"hard","addr":"(GE)","loc":"d,50:7,50:14","dtypep":"(LB)",
+          {"type":"CMETHODHARD","name":"hard","addr":"(BF)","loc":"d,32:7,32:9","dtypep":"(LB)",
            "fromp": [
-            {"type":"VARREF","name":"constraint","addr":"(HE)","loc":"d,50:7,50:14","dtypep":"(PB)","access":"RW","varp":"(QB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"constraint","addr":"(CF)","loc":"d,32:7,32:9","dtypep":"(PB)","access":"RW","varp":"(QB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ],
            "pinsp": [
-            {"type":"CONST","name":"\\\"sublength\\\"","addr":"(IE)","loc":"d,50:20,50:29","dtypep":"(M)"}
-          ]}
-        ]},
-        {"type":"STMTEXPR","name":"","addr":"(JE)","loc":"d,51:17,51:19",
-         "exprp": [
-          {"type":"CMETHODHARD","name":"hard","addr":"(KE)","loc":"d,51:17,51:19","dtypep":"(LB)",
-           "fromp": [
-            {"type":"VARREF","name":"constraint","addr":"(LE)","loc":"d,51:17,51:19","dtypep":"(PB)","access":"RW","varp":"(QB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
-          ],
-           "pinsp": [
-            {"type":"CONST","name":"\\\"(bvsle sublength length)\\\"","addr":"(ME)","loc":"d,51:17,51:19","dtypep":"(M)"}
+            {"type":"CONST","name":"\\\"(ite (or (= header #x00000005) (= header #x00000006)) (and (= iff_5_6 #b1) (= iff_5_6 #b1) (= iff_5_6 #b1)) (= iff_5_6 #b0))\\\"","addr":"(DF)","loc":"d,32:7,32:9","dtypep":"(M)"}
           ]}
         ]}
       ],"scopeNamep": []},
-      {"type":"TASK","name":"meth_setup_constraint","addr":"(KD)","loc":"d,7:1,7:6","method":true,"dpiExport":false,"dpiImport":false,"dpiOpenChild":false,"dpiOpenParent":false,"prototype":false,"recursive":false,"taskPublic":false,"cname":"meth_setup_constraint","fvarp": [],"classOrPackagep": [],"stmtsp": [],"scopeNamep": []}
+      {"type":"TASK","name":"arr_uniq_setup_constraint","addr":"(WD)","loc":"d,7:1,7:6","method":true,"dpiExport":false,"dpiImport":false,"dpiOpenChild":false,"dpiOpenParent":false,"prototype":false,"recursive":false,"taskPublic":false,"cname":"arr_uniq_setup_constraint","fvarp": [],"classOrPackagep": [],"stmtsp": [],"scopeNamep": []},
+      {"type":"TASK","name":"order_setup_constraint","addr":"(ZD)","loc":"d,7:1,7:6","method":true,"dpiExport":false,"dpiImport":false,"dpiOpenChild":false,"dpiOpenParent":false,"prototype":false,"recursive":false,"taskPublic":false,"cname":"order_setup_constraint","fvarp": [],"classOrPackagep": [],"stmtsp": [],"scopeNamep": []},
+      {"type":"TASK","name":"dis_setup_constraint","addr":"(CE)","loc":"d,7:1,7:6","method":true,"dpiExport":false,"dpiImport":false,"dpiOpenChild":false,"dpiOpenParent":false,"prototype":false,"recursive":false,"taskPublic":false,"cname":"dis_setup_constraint","fvarp": [],"classOrPackagep": [],
+       "stmtsp": [
+        {"type":"STMTEXPR","name":"","addr":"(EF)","loc":"d,51:7,51:11",
+         "exprp": [
+          {"type":"CMETHODHARD","name":"hard","addr":"(FF)","loc":"d,51:7,51:11","dtypep":"(LB)",
+           "fromp": [
+            {"type":"VARREF","name":"constraint","addr":"(GF)","loc":"d,51:7,51:11","dtypep":"(PB)","access":"RW","varp":"(QB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+          ],
+           "pinsp": [
+            {"type":"CONST","name":"\\\"sublength\\\"","addr":"(HF)","loc":"d,51:12,51:21","dtypep":"(M)"}
+          ]}
+        ]},
+        {"type":"STMTEXPR","name":"","addr":"(IF)","loc":"d,52:7,52:14",
+         "exprp": [
+          {"type":"CMETHODHARD","name":"hard","addr":"(JF)","loc":"d,52:7,52:14","dtypep":"(LB)",
+           "fromp": [
+            {"type":"VARREF","name":"constraint","addr":"(KF)","loc":"d,52:7,52:14","dtypep":"(PB)","access":"RW","varp":"(QB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+          ],
+           "pinsp": [
+            {"type":"CONST","name":"\\\"sublength\\\"","addr":"(LF)","loc":"d,52:20,52:29","dtypep":"(M)"}
+          ]}
+        ]},
+        {"type":"STMTEXPR","name":"","addr":"(MF)","loc":"d,53:17,53:19",
+         "exprp": [
+          {"type":"CMETHODHARD","name":"hard","addr":"(NF)","loc":"d,53:17,53:19","dtypep":"(LB)",
+           "fromp": [
+            {"type":"VARREF","name":"constraint","addr":"(OF)","loc":"d,53:17,53:19","dtypep":"(PB)","access":"RW","varp":"(QB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+          ],
+           "pinsp": [
+            {"type":"CONST","name":"\\\"(bvsle sublength length)\\\"","addr":"(PF)","loc":"d,53:17,53:19","dtypep":"(M)"}
+          ]}
+        ]}
+      ],"scopeNamep": []},
+      {"type":"TASK","name":"meth_setup_constraint","addr":"(FE)","loc":"d,7:1,7:6","method":true,"dpiExport":false,"dpiImport":false,"dpiOpenChild":false,"dpiOpenParent":false,"prototype":false,"recursive":false,"taskPublic":false,"cname":"meth_setup_constraint","fvarp": [],"classOrPackagep": [],
+       "stmtsp": [
+        {"type":"STMTEXPR","name":"","addr":"(QF)","loc":"d,57:7,57:9",
+         "exprp": [
+          {"type":"CMETHODHARD","name":"hard","addr":"(RF)","loc":"d,57:7,57:9","dtypep":"(LB)",
+           "fromp": [
+            {"type":"VARREF","name":"constraint","addr":"(SF)","loc":"d,57:7,57:9","dtypep":"(PB)","access":"RW","varp":"(QB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+          ],
+           "pinsp": [
+            {"type":"SFORMATF","name":"(=> %@ (= if_state_ok #b1))","addr":"(TF)","loc":"d,57:7,57:9","dtypep":"(M)",
+             "exprsp": [
+              {"type":"SFORMATF","name":"#b%b","addr":"(UF)","loc":"d,57:11,57:24","dtypep":"(M)",
+               "exprsp": [
+                {"type":"FUNCREF","name":"strings_equal","addr":"(VF)","loc":"d,57:11,57:24","dtypep":"(U)","dotted":"","taskp":"(AB)","classOrPackagep":"(O)","namep": [],
+                 "pinsp": [
+                  {"type":"ARG","name":"","addr":"(WF)","loc":"d,57:25,57:30",
+                   "exprp": [
+                    {"type":"VARREF","name":"state","addr":"(XF)","loc":"d,57:25,57:30","dtypep":"(M)","access":"RD","varp":"(Z)","varScopep":"UNLINKED","classOrPackagep":"(O)"}
+                  ]},
+                  {"type":"ARG","name":"","addr":"(YF)","loc":"d,57:32,57:36",
+                   "exprp": [
+                    {"type":"CONST","name":"\\\"ok\\\"","addr":"(ZF)","loc":"d,57:32,57:36","dtypep":"(M)"}
+                  ]}
+                ],"scopeNamep": []}
+              ],"scopeNamep": []}
+            ],"scopeNamep": []}
+          ]}
+        ]}
+      ],"scopeNamep": []}
     ],"activesp": [],"extendsp": []}
   ],"activesp": []}
 ],"filesp": [],
@@ -226,31 +321,31 @@
   {"type":"TYPETABLE","name":"","addr":"(C)","loc":"a,0:0,0:0","constraintRefp":"UNLINKED","emptyQueuep":"UNLINKED","queueIndexp":"UNLINKED","streamp":"UNLINKED","voidp":"(LB)",
    "typesp": [
     {"type":"BASICDTYPE","name":"logic","addr":"(GB)","loc":"d,22:14,22:15","dtypep":"(GB)","keyword":"logic","generic":true,"rangep": []},
-    {"type":"BASICDTYPE","name":"logic","addr":"(NE)","loc":"d,25:21,25:22","dtypep":"(NE)","keyword":"logic","range":"31:0","generic":true,"rangep": []},
-    {"type":"BASICDTYPE","name":"string","addr":"(M)","loc":"d,71:7,71:13","dtypep":"(M)","keyword":"string","generic":true,"rangep": []},
+    {"type":"BASICDTYPE","name":"logic","addr":"(AG)","loc":"d,25:21,25:22","dtypep":"(AG)","keyword":"logic","range":"31:0","generic":true,"rangep": []},
+    {"type":"BASICDTYPE","name":"string","addr":"(M)","loc":"d,73:7,73:13","dtypep":"(M)","keyword":"string","generic":true,"rangep": []},
     {"type":"BASICDTYPE","name":"int","addr":"(Q)","loc":"d,8:9,8:12","dtypep":"(Q)","keyword":"int","range":"31:0","generic":true,"rangep": []},
     {"type":"BASICDTYPE","name":"bit","addr":"(U)","loc":"d,11:9,11:12","dtypep":"(U)","keyword":"bit","generic":true,"rangep": []},
     {"type":"UNPACKARRAYDTYPE","name":"","addr":"(Y)","loc":"d,15:18,15:19","dtypep":"(Y)","isCompound":false,"declRange":"[0:1]","generic":false,"refDTypep":"(Q)","childDTypep": [],
      "rangep": [
-      {"type":"RANGE","name":"","addr":"(OE)","loc":"d,15:18,15:19","ascending":true,
+      {"type":"RANGE","name":"","addr":"(BG)","loc":"d,15:18,15:19","ascending":true,
        "leftp": [
-        {"type":"CONST","name":"32'h0","addr":"(PE)","loc":"d,15:19,15:20","dtypep":"(NE)"}
+        {"type":"CONST","name":"32'h0","addr":"(CG)","loc":"d,15:19,15:20","dtypep":"(AG)"}
       ],
        "rightp": [
-        {"type":"CONST","name":"32'h1","addr":"(QE)","loc":"d,15:19,15:20","dtypep":"(NE)"}
+        {"type":"CONST","name":"32'h1","addr":"(DG)","loc":"d,15:19,15:20","dtypep":"(AG)"}
       ]}
     ]},
     {"type":"VOIDDTYPE","name":"","addr":"(LB)","loc":"d,7:1,7:6","dtypep":"(LB)","generic":false},
-    {"type":"CLASSREFDTYPE","name":"Packet","addr":"(H)","loc":"d,67:4,67:10","dtypep":"(H)","generic":false,"classp":"(O)","classOrPackagep":"(O)","paramsp": []},
-    {"type":"BASICDTYPE","name":"bit","addr":"(LC)","loc":"d,7:1,7:6","dtypep":"(LC)","keyword":"bit","range":"31:0","generic":true,"rangep": []},
+    {"type":"CLASSREFDTYPE","name":"Packet","addr":"(H)","loc":"d,69:4,69:10","dtypep":"(H)","generic":false,"classp":"(O)","classOrPackagep":"(O)","paramsp": []},
+    {"type":"BASICDTYPE","name":"bit","addr":"(GD)","loc":"d,7:1,7:6","dtypep":"(GD)","keyword":"bit","range":"31:0","generic":true,"rangep": []},
     {"type":"BASICDTYPE","name":"VlRandomizer","addr":"(PB)","loc":"d,7:1,7:6","dtypep":"(PB)","keyword":"VlRandomizer","generic":true,"rangep": []},
     {"type":"BASICDTYPE","name":"logic","addr":"(TB)","loc":"d,8:9,8:12","dtypep":"(TB)","keyword":"logic","range":"63:0","generic":true,"rangep": []}
   ]},
   {"type":"CONSTPOOL","name":"","addr":"(D)","loc":"a,0:0,0:0",
    "modulep": [
-    {"type":"MODULE","name":"@CONST-POOL@","addr":"(RE)","loc":"a,0:0,0:0","origName":"@CONST-POOL@","level":0,"modPublic":false,"inLibrary":false,"dead":false,"recursiveClone":false,"recursive":false,"timeunit":"NONE","inlinesp": [],
+    {"type":"MODULE","name":"@CONST-POOL@","addr":"(EG)","loc":"a,0:0,0:0","origName":"@CONST-POOL@","level":0,"modPublic":false,"inLibrary":false,"dead":false,"recursiveClone":false,"recursive":false,"timeunit":"NONE","inlinesp": [],
      "stmtsp": [
-      {"type":"SCOPE","name":"@CONST-POOL@","addr":"(SE)","loc":"a,0:0,0:0","aboveScopep":"UNLINKED","aboveCellp":"UNLINKED","modp":"(RE)","varsp": [],"blocksp": [],"inlinesp": []}
+      {"type":"SCOPE","name":"@CONST-POOL@","addr":"(FG)","loc":"a,0:0,0:0","aboveScopep":"UNLINKED","aboveCellp":"UNLINKED","modp":"(EG)","varsp": [],"blocksp": [],"inlinesp": []}
     ],"activesp": []}
   ]}
 ]}

--- a/test_regress/t/t_constraint_json_only.v
+++ b/test_regress/t/t_constraint_json_only.v
@@ -31,6 +31,8 @@ class Packet;
       }
       if (header == 5 || header == 6) {
          iff_5_6 == '1;
+         iff_5_6 == '1;
+         iff_5_6 == '1;
       } else {
          iff_5_6 == '0;
       }

--- a/test_regress/t/t_constraint_operators.v
+++ b/test_regress/t/t_constraint_operators.v
@@ -23,6 +23,7 @@ class Packet;
    constraint cmps { x < x || x <= x || x > x || x >= x; }
    constraint cmpu { b < b || b <= b || b > b || b >= b; }
    constraint ext { s64'(x) != u64'(tiny); }
+   constraint cond { (tiny == 1 ? b : c) != 17; }
 
 endclass
 
@@ -43,6 +44,7 @@ module t (/*AUTOARG*/);
       if (-~p.c == 'h22) $stop;
       if (((p.b ^ p.c) & (p.b >>> p.c | p.b >> p.c | p.b << p.c)) <= 0) $stop;
       if (p.x == int'(p.tiny)) $stop;
+      if ((p.tiny == 1 ? p.b : p.c) == 17) $stop;
 
       $write("*-* All Finished *-*\n");
       $finish;

--- a/test_regress/t/t_constraint_operators.v
+++ b/test_regress/t/t_constraint_operators.v
@@ -9,6 +9,11 @@ class Packet;
    rand bit [31:0] b;
    rand bit [31:0] c;
    rand bit tiny;
+   rand bit zero;
+   rand bit one;
+   rand int out0, out1, out2, out3, out4, out5, out6;
+
+   bit state;
 
    typedef bit signed [63:0] s64;
    typedef bit [63:0] u64;
@@ -24,6 +29,34 @@ class Packet;
    constraint cmpu { b < b || b <= b || b > b || b >= b; }
    constraint ext { s64'(x) != u64'(tiny); }
    constraint cond { (tiny == 1 ? b : c) != 17; }
+   constraint zero_c { zero == 0; }
+   constraint one_c { one == 1; }
+   constraint ifelse {
+      if (one == 1) out0 == 'h333;
+
+      if (one == 0) tiny != tiny;
+      else out1 == 'h333;
+      if (one == 1) out2 == 'h333;
+      else tiny != tiny;
+      if (0) tiny != tiny;
+      else out3 == 'h333;
+      if (1) out4 == 'h333;
+      else tiny != tiny;
+
+      if (one == 1)
+         if (1) { out5 == 'h333; out5 == 'h333; out5 == 'h333; }
+         else tiny != tiny;
+      else
+         if (1) tiny != tiny;
+         else { tiny != tiny; }
+
+      if (1)
+         if (one == 1) { out6 == 'h333; out6 == 'h333; out6 == 'h333; }
+         else tiny != tiny;
+      else
+         if (one == 1) tiny != tiny;
+         else { tiny != tiny; }
+   }
 
 endclass
 
@@ -45,6 +78,16 @@ module t (/*AUTOARG*/);
       if (((p.b ^ p.c) & (p.b >>> p.c | p.b >> p.c | p.b << p.c)) <= 0) $stop;
       if (p.x == int'(p.tiny)) $stop;
       if ((p.tiny == 1 ? p.b : p.c) == 17) $stop;
+      if ((p.tiny == 1 ? p.b : p.c) == 17) $stop;
+      if (p.zero != 0) $stop;
+      if (p.one != 1) $stop;
+      if (p.out0 != 'h333) $stop;
+      if (p.out1 != 'h333) $stop;
+      if (p.out2 != 'h333) $stop;
+      if (p.out3 != 'h333) $stop;
+      if (p.out4 != 'h333) $stop;
+      if (p.out5 != 'h333) $stop;
+      if (p.out6 != 'h333) $stop;
 
       $write("*-* All Finished *-*\n");
       $finish;

--- a/test_regress/t/t_constraint_xml.out
+++ b/test_regress/t/t_constraint_xml.out
@@ -11,17 +11,17 @@
     <file id="d" filename="t/t_constraint_xml.v" language="1800-2023"/>
   </module_files>
   <cells>
-    <cell loc="d,65,8,65,9" name="t" submodname="t" hier="t"/>
+    <cell loc="d,67,8,67,9" name="t" submodname="t" hier="t"/>
   </cells>
   <netlist>
-    <module loc="d,65,8,65,9" name="t" origName="t">
-      <var loc="d,67,11,67,12" name="p" dtype_id="1" vartype="Packet" origName="p"/>
-      <initial loc="d,69,4,69,11">
-        <begin loc="d,69,12,69,17">
-          <display loc="d,71,7,71,13" displaytype="$write">
-            <sformatf loc="d,71,7,71,13" name="*-* All Finished *-*&#10;" dtype_id="2"/>
+    <module loc="d,67,8,67,9" name="t" origName="t">
+      <var loc="d,69,11,69,12" name="p" dtype_id="1" vartype="Packet" origName="p"/>
+      <initial loc="d,71,4,71,11">
+        <begin loc="d,71,12,71,17">
+          <display loc="d,73,7,73,13" displaytype="$write">
+            <sformatf loc="d,73,7,73,13" name="*-* All Finished *-*&#10;" dtype_id="2"/>
           </display>
-          <finish loc="d,72,7,72,14"/>
+          <finish loc="d,74,7,74,14"/>
         </begin>
       </initial>
     </module>
@@ -35,16 +35,16 @@
         <var loc="d,13,13,13,24" name="if_state_ok" dtype_id="4" vartype="bit" origName="if_state_ok"/>
         <var loc="d,15,13,15,18" name="array" dtype_id="5" vartype="" origName="array"/>
         <var loc="d,17,11,17,16" name="state" dtype_id="2" vartype="string" origName="state"/>
-        <func loc="d,59,17,59,30" name="strings_equal" dtype_id="4">
-          <var loc="d,59,17,59,30" name="strings_equal" dtype_id="4" dir="output" vartype="bit" origName="strings_equal"/>
-          <var loc="d,59,38,59,39" name="a" dtype_id="2" dir="input" vartype="string" origName="a"/>
-          <var loc="d,59,48,59,49" name="b" dtype_id="2" dir="input" vartype="string" origName="b"/>
-          <assign loc="d,60,7,60,13" dtype_id="4">
-            <eqn loc="d,60,16,60,18" dtype_id="6">
-              <varref loc="d,60,14,60,15" name="a" dtype_id="2"/>
-              <varref loc="d,60,19,60,20" name="b" dtype_id="2"/>
+        <func loc="d,61,17,61,30" name="strings_equal" dtype_id="4">
+          <var loc="d,61,17,61,30" name="strings_equal" dtype_id="4" dir="output" vartype="bit" origName="strings_equal"/>
+          <var loc="d,61,38,61,39" name="a" dtype_id="2" dir="input" vartype="string" origName="a"/>
+          <var loc="d,61,48,61,49" name="b" dtype_id="2" dir="input" vartype="string" origName="b"/>
+          <assign loc="d,62,7,62,13" dtype_id="4">
+            <eqn loc="d,62,16,62,18" dtype_id="6">
+              <varref loc="d,62,14,62,15" name="a" dtype_id="2"/>
+              <varref loc="d,62,19,62,20" name="b" dtype_id="2"/>
             </eqn>
-            <varref loc="d,60,7,60,13" name="strings_equal" dtype_id="4"/>
+            <varref loc="d,62,7,62,13" name="strings_equal" dtype_id="4"/>
           </assign>
         </func>
         <func loc="d,7,1,7,6" name="new" dtype_id="7">
@@ -68,6 +68,26 @@
               </cexpr>
             </cmethodhard>
           </stmtexpr>
+          <stmtexpr loc="d,11,13,11,17">
+            <cmethodhard loc="d,11,13,11,17" name="write_var" dtype_id="7">
+              <varref loc="d,11,13,11,17" name="constraint" dtype_id="8"/>
+              <varref loc="d,11,13,11,17" name="if_4" dtype_id="4"/>
+              <const loc="d,11,9,11,12" name="64&apos;h1" dtype_id="9"/>
+              <cexpr loc="d,11,13,11,17" dtype_id="4">
+                <text loc="d,11,13,11,17"/>
+              </cexpr>
+            </cmethodhard>
+          </stmtexpr>
+          <stmtexpr loc="d,12,13,12,20">
+            <cmethodhard loc="d,12,13,12,20" name="write_var" dtype_id="7">
+              <varref loc="d,12,13,12,20" name="constraint" dtype_id="8"/>
+              <varref loc="d,12,13,12,20" name="iff_5_6" dtype_id="4"/>
+              <const loc="d,11,9,11,12" name="64&apos;h1" dtype_id="9"/>
+              <cexpr loc="d,12,13,12,20" dtype_id="4">
+                <text loc="d,12,13,12,20"/>
+              </cexpr>
+            </cmethodhard>
+          </stmtexpr>
           <stmtexpr loc="d,10,13,10,22">
             <cmethodhard loc="d,10,13,10,22" name="write_var" dtype_id="7">
               <varref loc="d,10,13,10,22" name="constraint" dtype_id="8"/>
@@ -75,6 +95,16 @@
               <const loc="d,8,9,8,12" name="64&apos;h20" dtype_id="9"/>
               <cexpr loc="d,10,13,10,22" dtype_id="3">
                 <text loc="d,10,13,10,22"/>
+              </cexpr>
+            </cmethodhard>
+          </stmtexpr>
+          <stmtexpr loc="d,13,13,13,24">
+            <cmethodhard loc="d,13,13,13,24" name="write_var" dtype_id="7">
+              <varref loc="d,13,13,13,24" name="constraint" dtype_id="8"/>
+              <varref loc="d,13,13,13,24" name="if_state_ok" dtype_id="4"/>
+              <const loc="d,11,9,11,12" name="64&apos;h1" dtype_id="9"/>
+              <cexpr loc="d,13,13,13,24" dtype_id="4">
+                <text loc="d,13,13,13,24"/>
               </cexpr>
             </cmethodhard>
           </stmtexpr>
@@ -95,17 +125,17 @@
           <stmtexpr loc="d,28,15,28,18">
             <taskref loc="d,28,15,28,18" name="ifs_setup_constraint" dtype_id="7"/>
           </stmtexpr>
-          <stmtexpr loc="d,39,15,39,23">
-            <taskref loc="d,39,15,39,23" name="arr_uniq_setup_constraint" dtype_id="7"/>
+          <stmtexpr loc="d,41,15,41,23">
+            <taskref loc="d,41,15,41,23" name="arr_uniq_setup_constraint" dtype_id="7"/>
           </stmtexpr>
-          <stmtexpr loc="d,46,15,46,20">
-            <taskref loc="d,46,15,46,20" name="order_setup_constraint" dtype_id="7"/>
+          <stmtexpr loc="d,48,15,48,20">
+            <taskref loc="d,48,15,48,20" name="order_setup_constraint" dtype_id="7"/>
           </stmtexpr>
-          <stmtexpr loc="d,48,15,48,18">
-            <taskref loc="d,48,15,48,18" name="dis_setup_constraint" dtype_id="7"/>
+          <stmtexpr loc="d,50,15,50,18">
+            <taskref loc="d,50,15,50,18" name="dis_setup_constraint" dtype_id="7"/>
           </stmtexpr>
-          <stmtexpr loc="d,54,15,54,19">
-            <taskref loc="d,54,15,54,19" name="meth_setup_constraint" dtype_id="7"/>
+          <stmtexpr loc="d,56,15,56,19">
+            <taskref loc="d,56,15,56,19" name="meth_setup_constraint" dtype_id="7"/>
           </stmtexpr>
         </func>
         <task loc="d,7,1,7,6" name="empty_setup_constraint"/>
@@ -136,36 +166,67 @@
             </cmethodhard>
           </stmtexpr>
         </task>
-        <task loc="d,7,1,7,6" name="ifs_setup_constraint"/>
-        <task loc="d,7,1,7,6" name="arr_uniq_setup_constraint"/>
-        <task loc="d,7,1,7,6" name="order_setup_constraint"/>
-        <task loc="d,7,1,7,6" name="dis_setup_constraint">
-          <stmtexpr loc="d,49,7,49,11">
-            <cmethodhard loc="d,49,7,49,11" name="hard" dtype_id="7">
-              <varref loc="d,49,7,49,11" name="constraint" dtype_id="8"/>
-              <const loc="d,49,12,49,21" name="&quot;sublength&quot;" dtype_id="2"/>
+        <task loc="d,7,1,7,6" name="ifs_setup_constraint">
+          <stmtexpr loc="d,29,7,29,9">
+            <cmethodhard loc="d,29,7,29,9" name="hard" dtype_id="7">
+              <varref loc="d,29,7,29,9" name="constraint" dtype_id="8"/>
+              <const loc="d,29,7,29,9" name="&quot;(=&gt; (bvsgt header #x00000004) (= if_4 #b1))&quot;" dtype_id="2"/>
             </cmethodhard>
           </stmtexpr>
-          <stmtexpr loc="d,50,7,50,14">
-            <cmethodhard loc="d,50,7,50,14" name="hard" dtype_id="7">
-              <varref loc="d,50,7,50,14" name="constraint" dtype_id="8"/>
-              <const loc="d,50,20,50,29" name="&quot;sublength&quot;" dtype_id="2"/>
-            </cmethodhard>
-          </stmtexpr>
-          <stmtexpr loc="d,51,17,51,19">
-            <cmethodhard loc="d,51,17,51,19" name="hard" dtype_id="7">
-              <varref loc="d,51,17,51,19" name="constraint" dtype_id="8"/>
-              <const loc="d,51,17,51,19" name="&quot;(bvsle sublength length)&quot;" dtype_id="2"/>
+          <stmtexpr loc="d,32,7,32,9">
+            <cmethodhard loc="d,32,7,32,9" name="hard" dtype_id="7">
+              <varref loc="d,32,7,32,9" name="constraint" dtype_id="8"/>
+              <const loc="d,32,7,32,9" name="&quot;(ite (or (= header #x00000005) (= header #x00000006)) (and (= iff_5_6 #b1) (= iff_5_6 #b1) (= iff_5_6 #b1)) (= iff_5_6 #b0))&quot;" dtype_id="2"/>
             </cmethodhard>
           </stmtexpr>
         </task>
-        <task loc="d,7,1,7,6" name="meth_setup_constraint"/>
+        <task loc="d,7,1,7,6" name="arr_uniq_setup_constraint"/>
+        <task loc="d,7,1,7,6" name="order_setup_constraint"/>
+        <task loc="d,7,1,7,6" name="dis_setup_constraint">
+          <stmtexpr loc="d,51,7,51,11">
+            <cmethodhard loc="d,51,7,51,11" name="hard" dtype_id="7">
+              <varref loc="d,51,7,51,11" name="constraint" dtype_id="8"/>
+              <const loc="d,51,12,51,21" name="&quot;sublength&quot;" dtype_id="2"/>
+            </cmethodhard>
+          </stmtexpr>
+          <stmtexpr loc="d,52,7,52,14">
+            <cmethodhard loc="d,52,7,52,14" name="hard" dtype_id="7">
+              <varref loc="d,52,7,52,14" name="constraint" dtype_id="8"/>
+              <const loc="d,52,20,52,29" name="&quot;sublength&quot;" dtype_id="2"/>
+            </cmethodhard>
+          </stmtexpr>
+          <stmtexpr loc="d,53,17,53,19">
+            <cmethodhard loc="d,53,17,53,19" name="hard" dtype_id="7">
+              <varref loc="d,53,17,53,19" name="constraint" dtype_id="8"/>
+              <const loc="d,53,17,53,19" name="&quot;(bvsle sublength length)&quot;" dtype_id="2"/>
+            </cmethodhard>
+          </stmtexpr>
+        </task>
+        <task loc="d,7,1,7,6" name="meth_setup_constraint">
+          <stmtexpr loc="d,57,7,57,9">
+            <cmethodhard loc="d,57,7,57,9" name="hard" dtype_id="7">
+              <varref loc="d,57,7,57,9" name="constraint" dtype_id="8"/>
+              <sformatf loc="d,57,7,57,9" name="(=&gt; %@ (= if_state_ok #b1))" dtype_id="2">
+                <sformatf loc="d,57,11,57,24" name="#b%b" dtype_id="2">
+                  <funcref loc="d,57,11,57,24" name="strings_equal" dtype_id="4">
+                    <arg loc="d,57,25,57,30">
+                      <varref loc="d,57,25,57,30" name="state" dtype_id="2"/>
+                    </arg>
+                    <arg loc="d,57,32,57,36">
+                      <const loc="d,57,32,57,36" name="&quot;ok&quot;" dtype_id="2"/>
+                    </arg>
+                  </funcref>
+                </sformatf>
+              </sformatf>
+            </cmethodhard>
+          </stmtexpr>
+        </task>
       </class>
     </package>
     <typetable loc="a,0,0,0,0">
       <basicdtype loc="d,22,14,22,15" id="6" name="logic"/>
       <basicdtype loc="d,25,21,25,22" id="11" name="logic" left="31" right="0"/>
-      <basicdtype loc="d,71,7,71,13" id="2" name="string"/>
+      <basicdtype loc="d,73,7,73,13" id="2" name="string"/>
       <basicdtype loc="d,8,9,8,12" id="3" name="int" left="31" right="0" signed="true"/>
       <basicdtype loc="d,11,9,11,12" id="4" name="bit"/>
       <unpackarraydtype loc="d,15,18,15,19" id="5" sub_dtype_id="3">
@@ -175,7 +236,7 @@
         </range>
       </unpackarraydtype>
       <voiddtype loc="d,7,1,7,6" id="7"/>
-      <classrefdtype loc="d,67,4,67,10" id="1" name="Packet"/>
+      <classrefdtype loc="d,69,4,69,10" id="1" name="Packet"/>
       <basicdtype loc="d,7,1,7,6" id="10" name="bit" left="31" right="0" signed="true"/>
       <basicdtype loc="d,7,1,7,6" id="8" name="VlRandomizer"/>
       <basicdtype loc="d,8,9,8,12" id="9" name="logic" left="63" right="0"/>

--- a/test_regress/t/t_constraint_xml.v
+++ b/test_regress/t/t_constraint_xml.v
@@ -31,6 +31,8 @@ class Packet;
       }
       if (header == 5 || header == 6) {
          iff_5_6 == '1;
+         iff_5_6 == '1;
+         iff_5_6 == '1;
       } else {
          iff_5_6 == '0;
       }

--- a/test_regress/t/t_randomize.out
+++ b/test_regress/t/t_randomize.out
@@ -3,14 +3,6 @@
       |                         ^~~~
                         ... For warning description see https://verilator.org/warn/CONSTRAINTIGN?v=latest
                         ... Use "/* verilator lint_off CONSTRAINTIGN */" and lint_on around source to disable this message.
-%Warning-CONSTRAINTIGN: t/t_randomize.v:26:7: Constraint expression ignored (unsupported)
-                                            : ... note: In instance 't'
-   26 |       if (header > 4) {
-      |       ^~
-%Warning-CONSTRAINTIGN: t/t_randomize.v:29:7: Constraint expression ignored (unsupported)
-                                            : ... note: In instance 't'
-   29 |       if (header == 5 || header == 6) {
-      |       ^~
 %Warning-CONSTRAINTIGN: t/t_randomize.v:37:7: Constraint expression ignored (unsupported)
                                             : ... note: In instance 't'
    37 |       foreach (array[i]) {


### PR DESCRIPTION
First commit adds support for conditional expressions in constraints (if-then-else, `ite` in SMT-LIB2 language).
Then in the second commit, conditional constraints (`ConstraintIf{Expr, ConstraintExpr*, ConstraintExpr*}`) are flattened to conditional expressions (`ConstraintExpr{Cond{Expr, Expr, Expr} or LogIf{Expr, Expr}}`), and emitted.  ConstraintExprVisitor is now responsible for visiting all of the constraint body, instead of a single constraint expression.