### PR TITLE
Fix toggle coverage aggregation

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -119,6 +119,7 @@ Kritik Bhimani
 Krzysztof Bieganski
 Krzysztof Boronski
 Krzysztof Boroński
+Krzysztof Obłonczek
 Kuba Ober
 Larry Doolittle
 Liam Braun

--- a/src/VlcSource.h
+++ b/src/VlcSource.h
@@ -20,6 +20,7 @@
 #include "config_build.h"
 #include "verilatedos.h"
 
+#include <limits>
 #include <map>
 #include <set>
 #include <utility>
@@ -36,7 +37,7 @@ class VlcSourceCount final {
 
     // MEMBERS
     const int m_lineno;  ///< Line number
-    uint64_t m_count = 0;  ///< Count
+    uint64_t m_count = std::numeric_limits<uint64_t>::max();  ///< Count
     bool m_ok = false;  ///< Coverage is above threshold
     PointsSet m_points;  // Points on this line
 
@@ -53,13 +54,11 @@ public:
 
     // METHODS
     void incCount(uint64_t count, bool ok) {
-        if (!m_count) {
-            m_count = count;
+        if (m_count == std::numeric_limits<uint64_t>::max())
             m_ok = ok;
-        } else {
-            m_count = std::min(m_count, count);
-            if (!ok) m_ok = false;
-        }
+        else
+            m_ok = m_ok && ok;
+        m_count = std::min(m_count, count);
     }
     void insertPoint(const VlcPoint* pointp) { m_points.emplace(pointp); }
     PointsSet& points() { return m_points; }

--- a/test_regress/t/t_cover_line.out
+++ b/test_regress/t/t_cover_line.out
@@ -221,7 +221,7 @@
 +000020  point: comment=block
  000020       $write("");  // Always covered
 +000020  point: comment=block
- 000020       if (0) begin  // CHECK_COVER(0,"top.t.b*",0)
+%000000       if (0) begin  // CHECK_COVER(0,"top.t.b*",0)
 -000000  point: comment=if
 +000020  point: comment=else
                  // Make sure that we don't optimize away zero buckets
@@ -350,7 +350,7 @@
                  // because under coverage_module_off
 %000001          $write("");
 -000001  point: comment=if
-%000001          if (0) ;  // CHECK_COVER(0,"top.t.o1",1)
+%000000          if (0) ;  // CHECK_COVER(0,"top.t.o1",1)
 -000000  point: comment=if
 -000001  point: comment=else
               end

--- a/test_regress/t/t_cover_toggle_min.out
+++ b/test_regress/t/t_cover_toggle_min.out
@@ -1,0 +1,6 @@
+TN:verilator_coverage
+SF:t/t_cover_toggle_min.v
+DA:10,0
+DA:11,0
+DA:12,1
+end_of_record

--- a/test_regress/t/t_cover_toggle_min.pl
+++ b/test_regress/t/t_cover_toggle_min.pl
@@ -1,0 +1,34 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2024 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    verilator_flags2 => ['--binary', '--coverage-toggle'],
+    );
+
+execute(
+    all_run_flags => [" +verilator+coverage+file+$Self->{obj_dir}/coverage.dat"],
+    check_finished => 1,
+    );
+
+if (-e ("$Self->{obj_dir}/coverage.dat")) {  # Don't try to write .info if test was skipped
+    run(cmd => ["$ENV{VERILATOR_ROOT}/bin/verilator_coverage",
+            "-write-info", "$Self->{obj_dir}/coverage.info",
+            "$Self->{obj_dir}/coverage.dat",
+            ],
+    verilator_run => 1,
+    );
+
+    files_identical("$Self->{obj_dir}/coverage.info", $Self->{golden_filename});
+}
+
+ok(1);
+1;

--- a/test_regress/t/t_cover_toggle_min.v
+++ b/test_regress/t/t_cover_toggle_min.v
@@ -1,0 +1,22 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// Copyright 2024 by Antmicro. This program is free software; you can
+// redistribute it and/or modify it under the terms of either the GNU
+// Lesser General Public License Version 3 or the Perl Artistic License
+// Version 2.0.
+// SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+module t();
+    logic[1:0] a;
+    logic[1:0] b;
+    logic[1:0] c;
+
+    initial begin
+        #1 a = 2'b01;
+        #1 b = 2'b10;
+        #1 c = 2'b11;
+        #1 c = 2'b10;
+        $write("*-* All Finished *-*\n");
+        $finish;
+    end
+endmodule

--- a/test_regress/t/t_vlcov_info.out
+++ b/test_regress/t/t_vlcov_info.out
@@ -1,4 +1,4 @@
 TN:verilator_coverage
 SF:file1.sp
-DA:159,1
+DA:159,0
 end_of_record


### PR DESCRIPTION
Documentation of `verilator_coverage` states that
```
Converting from the Verilator coverage data format to the info format is
lossy; the info will have all forms of coverage merged line coverage, and
if there are multiple coverage points on a single line they will merge.
The minimum coverage across all merged points will be used to report
coverage of the line.
```
This is however not how it's implemented. Previously the logic would overstate the coverage in cases when multiple coverage points on the same line had this order in `coverage.dat` file:
```
C 'point 1' 5
C 'point 2' 0
C 'point 3' 2
C 'point 4' 4
```
i.e. some zero coverage count was followed (and ended) with nonzero coverage count. In these minimum from these last nonzero points would be selected instead of minimum from all the points.

This PR fixes the logic to correctly compute the minimum from all coverage points on a single line.