### PR TITLE
Refactor `AstMemberSel` creation with `AstVar`

### DIFF
--- a/src/V3AstNodeExpr.h
+++ b/src/V3AstNodeExpr.h
@@ -1564,12 +1564,7 @@ public:
         this->fromp(fromp);
         dtypep(nullptr);  // V3Width will resolve
     }
-    AstMemberSel(FileLine* fl, AstNodeExpr* fromp, AstNodeDType* dtp)
-        : ASTGEN_SUPER_MemberSel(fl)
-        , m_name{dtp->name()} {
-        this->fromp(fromp);
-        dtypep(dtp);
-    }
+    AstMemberSel(FileLine* fl, AstNodeExpr* fromp, AstVar* varp);
     ASTGEN_MEMBERS_AstMemberSel;
     void dump(std::ostream& str) const override;
     void dumpJson(std::ostream& str) const override;

--- a/src/V3AstNodes.cpp
+++ b/src/V3AstNodes.cpp
@@ -1831,6 +1831,13 @@ AstNodeUOrStructDType* AstMemberDType::getChildStructp() const {
     return VN_CAST(subdtp->skipRefp(), NodeUOrStructDType);  // Maybe nullptr
 }
 
+AstMemberSel::AstMemberSel(FileLine* fl, AstNodeExpr* fromp, AstVar* varp)
+    : ASTGEN_SUPER_MemberSel(fl)
+    , m_name{varp->name()} {
+    this->fromp(fromp);
+    this->varp(varp);
+    dtypep(varp->dtypep());
+}
 bool AstMemberSel::same(const AstNode* samep) const {
     const AstMemberSel* const sp = VN_DBG_AS(samep, MemberSel);
     return sp != nullptr && access() == sp->access() && fromp()->isSame(sp->fromp())

--- a/src/V3Fork.cpp
+++ b/src/V3Fork.cpp
@@ -46,7 +46,6 @@
 #include "V3MemberMap.h"
 
 #include <set>
-#include <vector>
 
 VL_DEFINE_DEBUG_FUNCTIONS;
 
@@ -167,9 +166,7 @@ public:
             AstMemberSel* const memberselp = new AstMemberSel{
                 varp->fileline(),
                 new AstVarRef{varp->fileline(), m_instance.m_handlep, VAccess::WRITE},
-                varp->dtypep()};
-            memberselp->name(varp->name());
-            memberselp->varp(VN_AS(memberMap.findMember(m_instance.m_classp, varp->name()), Var));
+                VN_AS(memberMap.findMember(m_instance.m_classp, varp->name()), Var)};
             AstNode* initAsgnp
                 = new AstAssign{varp->fileline(), memberselp,
                                 new AstVarRef{varp->fileline(), varp, VAccess::READ}};
@@ -307,8 +304,7 @@ class DynScopeVisitor final : public VNVisitor {
         refp->unlinkFrBack(&handle);
         AstMemberSel* const membersel = new AstMemberSel{
             refp->fileline(), new AstVarRef{refp->fileline(), dynScope.m_handlep, refp->access()},
-            refp->dtypep()};
-        membersel->name(refp->varp()->name());
+            refp->varp()};
         if (refp->varp()->direction() == VDirection::INPUT) {
             membersel->varp(
                 VN_AS(m_memberMap.findMember(dynScope.m_classp, refp->varp()->name()), Var));


### PR DESCRIPTION
There is an `AstMemberSel` constructor that's only used for member selects where we know the member variable.
However, instead of just accepting the member variable, it only accepts its `dtype`, and also does some other weird stuff.
This results in unnecessarily verbose code.

This patch simplifies that. No functional change intended.