### PR TITLE
V3EmitC: Use a reference instead of a pointer for VlSelf

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -210,6 +210,7 @@ William D. Jones
 Wilson Snyder
 Xi Zhang
 Yan Xu
+Yangyu Chen
 Yinan Xu
 Yoda Lee
 Yossi Nivin

--- a/src/V3EmitCFunc.cpp
+++ b/src/V3EmitCFunc.cpp
@@ -445,8 +445,12 @@ void EmitCFunc::emitDereference(AstNode* nodep, const string& pointer) {
         putns(nodep, pointer.substr(2, pointer.length() - 3));
         puts(".");
     } else {
-        putns(nodep, pointer);
-        puts("->");
+        if (pointer == "vlSelf" && m_usevlSelfRef) {
+            puts("vlSelfRef.");
+        } else {
+            putns(nodep, pointer);
+            puts("->");
+        }
     }
 }
 

--- a/src/V3EmitCFunc.h
+++ b/src/V3EmitCFunc.h
@@ -148,6 +148,7 @@ class EmitCFunc VL_NOT_FINAL : public EmitCConstInit {
 protected:
     EmitCLazyDecls m_lazyDecls;  // Visitor for emitting lazy declarations
     bool m_useSelfForThis = false;  // Replace "this" with "vlSelf"
+    bool m_usevlSelfRef = false;  // Use vlSelfRef reference instead of vlSelf pointer
     const AstNodeModule* m_modp = nullptr;  // Current module being emitted
     const AstCFunc* m_cfuncp = nullptr;  // Current function being emitted
     bool m_instantiatesOwnProcess = false;
@@ -343,6 +344,21 @@ public:
             }
         }
 
+        if (m_useSelfForThis) {
+            m_usevlSelfRef = true;
+            /*
+             * Using reference to the vlSelf pointer will help the C++
+             * compiler to have dereferenceable hints, which can help to
+             * reduce the need for branch instructions in the generated
+             * code to allow the compiler to generate load store after the
+             * if condition (including short-circuit evaluation)
+             * speculatively and also reduce the data cache pollution when
+             * executing in the wrong path to make verilator-generated code
+             * run faster.
+             */
+            puts("auto &vlSelfRef = std::ref(*vlSelf).get();\n");
+        }
+
         if (nodep->initsp()) {
             putsDecoration(nodep, "// Init\n");
             iterateAndNextConstNull(nodep->initsp());
@@ -357,6 +373,8 @@ public:
             putsDecoration(nodep, "// Final\n");
             iterateAndNextConstNull(nodep->finalsp());
         }
+
+        m_usevlSelfRef = false;
 
         puts("}\n");
         if (nodep->ifdef() != "") puts("#endif  // " + nodep->ifdef() + "\n");


### PR DESCRIPTION
Currently, we use pointers for VlSelf and dereference it every time we process the RTL. However, when the C++ compiler sees a pointer instead of a reference, it will lose a dereferenceable attribute, so the compiler can not speculatively load the value of the pointer and must generate more branches to prevent the unnecessary deference of the pointer. This will cause more branches to be generated in the final binary, which increases the burden on CPU branch prediction. Even worse, the branch footprint in Verilator generated code on large RTL designs such as XiangShan already suppresses the size of the branch target buffer of CPUs we use now, which will cause more branch misprediction and performance degradation.

Thus, we should use a reference instead of a pointer for VlSelf to tell the C++ compiler that the value of VlSelf is always dereferenceable, and the compiler can speculatively load the value of VlSelf without generating more branches.

A simple evaluation performed on XiangShan commit 136f64975e with LLVM16 packaged by Debian (version 16.0.6 (27+b1)) based on Verilator commit 6882f8c55e with 1 thread EMU running 2 iter coremark workload on OpenXiangShan/ready-to-run commit 24ab7d76e5 on Intel 13900K shows sampled branch instructions reduced from 132746731584 to 121130263138 (-8.75%), the running time reduced from 838.95s to 753.43s (-10.19%).

This increases l1-dcache-loads from 414383597179 to 426881071898 (+3.02%) and slightly increases l1-dcache-load-misses from 33706712758 to 33967571525 (+0.77%), but the LLC load-misses are reduced from 203290290 to 139019005 (-31.62%), maybe because the branch misprediction of wrong path is reduced. I also tested this on 8 threads EMU with Clang PGO as our routine to use Verilated XiangShan on 7950X3D + LLVM 14 and 13900K + LLVM 16. All show a slight improvement in performance even though we reduced the branches with PGO on and slightly increased the load instructions. And I haven't found any performance degradation on Verilated XiangShan RTL so far.

This change also allows more compiler optimization to be performed in verilator-generated code. I am currently working on it.
