### PR TITLE
lexer: be specific to error on broken /*verilator*/ commands, ignore other

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -66,6 +66,7 @@ Gus Smith
 Gustav Svensk
 Harald Heckmann
 Hennadii Chernyshchyk
+Henner Zeller
 Howard Su
 Huang Rui
 Huanghuang Zhou

--- a/src/verilog.l
+++ b/src/verilog.l
@@ -787,7 +787,8 @@ vnum    {vnum1}|{vnum2}|{vnum3}|{vnum4}|{vnum5}
   "/*verilator unroll_full*/"           { FL; return yVL_UNROLL_FULL; }
 
   "/**/"                                { FL_FWD; FL_BRK; }
-  "/*"[^*]+"*/"                         { FL; V3ParseImp::lexVerilatorCmtBad(yylval.fl, yytext); FL_BRK; }
+  "/*"{ws}*"verilator "[^*]+"*/"        { FL; V3ParseImp::lexVerilatorCmtBad(yylval.fl, yytext); FL_BRK; } // unhandled comments
+  "/*"[^*]+"*/"                         { FL_FWD; FL_BRK; }  // Ignore single line /**/ comments
 }
 
   /************************************************************************/

--- a/test_regress/t/t_macro_generated_comment.pl
+++ b/test_regress/t/t_macro_generated_comment.pl
@@ -1,0 +1,21 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2024 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_macro_generated_comment.v
+++ b/test_regress/t/t_macro_generated_comment.v
@@ -1,0 +1,24 @@
+// DESCRIPTION: Verilator: Test comment generated from macro
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2017 by Wilson Snyder.
+// SPDX-License-Identifier: CC0-1.0
+
+`define FOO() /``* some_vendor_comment macro generated *``/
+
+module t (/*AUTOARG*/
+   // Inputs
+   clk
+   );
+
+   input clk;
+
+   `FOO()
+
+   // Test loop
+   always @ (posedge clk) begin
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end
+
+endmodule

--- a/test_regress/t/t_preproc.out
+++ b/test_regress/t/t_preproc.out
@@ -1065,3 +1065,10 @@ predef 2 2
  
 
 `line 744 "t/t_preproc.v" 0
+ 
+ 
+ 
+/* some_vendor_comment macro generated */
+/* some_vendor_comment macro generated */
+
+`line 750 "t/t_preproc.v" 0

--- a/test_regress/t/t_preproc.v
+++ b/test_regress/t/t_preproc.v
@@ -740,3 +740,9 @@ predef `SV_COV_PARTIAL 2
 //======================================================================
 // After `undefineall above, for testing --dump-defines
 `define WITH_ARG(a) (a)(a)
+
+//======================================================================
+// Macros defining comments that should show up at place of expansion
+`define MACRO_DEFINING_COMMENT() /``* some_vendor_comment macro generated *``/
+`MACRO_DEFINING_COMMENT()
+`MACRO_DEFINING_COMMENT()


### PR DESCRIPTION
Comments that contain regular comments or processing instructions meant for other tools should just be ignored, so double check that we error only on comments that look like they were meant for verilator.