### PR TITLE
DFG: Allow inlining of variabels driven from forced vars

### DIFF
--- a/src/V3DfgPasses.cpp
+++ b/src/V3DfgPasses.cpp
@@ -160,13 +160,10 @@ void V3DfgPasses::inlineVars(DfgGraph& dfg) {
                 DfgVertex* const driverp = varp->source(0);
 
                 // We must keep the original driver in certain cases, when swapping them would
-                // not be functionally or technically (implementation reasons) equivalent
+                // not be functionally or technically (implementation reasons) equivalent:
+                // 1. If driven from a SystemC variable (assignment is non-trivial)
                 if (DfgVertexVar* const driverVarp = driverp->cast<DfgVarPacked>()) {
-                    const AstVar* const astVarp = driverVarp->varp();
-                    // If driven from a SystemC variable
-                    if (astVarp->isSc()) continue;
-                    // If the variable is forced
-                    if (astVarp->isForced()) continue;
+                    if (driverVarp->varp()->isSc()) continue;
                 }
 
                 varp->forEachSinkEdge([=](DfgEdge& edge) { edge.relinkSource(driverp); });

--- a/test_regress/t/t_dfg_inline_forced.pl
+++ b/test_regress/t/t_dfg_inline_forced.pl
@@ -1,0 +1,17 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2024 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(vlt => 1);
+
+compile(
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_dfg_inline_forced.v
+++ b/test_regress/t/t_dfg_inline_forced.v
@@ -1,0 +1,24 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2024 by Wilson Snyder.
+// SPDX-License-Identifier: CC0-1.0
+
+module top(input wire clk);
+
+    logic [1:0][31:0] i;
+    logic o;
+
+    always @(posedge clk) begin
+        force i = 64'hFFFFFFFF_FFFFFFFF;
+    end
+
+    sub sub_i(.i(i), .o(o));
+endmodule
+
+module sub (
+    input  logic [63:0] i,
+    output logic o
+);
+    assign o = |i;
+endmodule


### PR DESCRIPTION
Not sure why this was disabled before, but it seems legal to me to change

'forced A' -> 'B' -> 'C'

into

'forced A' -> 'B',
'forced A' -> 'C'

Fixes #5249