### PR TITLE
Keep one member map for randomize method creation

### DIFF
--- a/src/V3Randomize.cpp
+++ b/src/V3Randomize.cpp
@@ -758,7 +758,8 @@ class RandomizeVisitor final : public VNVisitor {
                         "Unsupported: random member variable with type of a current class");
                     continue;
                 }
-                AstFunc* const memberFuncp = V3Randomize::newRandomizeFunc(m_memberMap, classRefp->classp());
+                AstFunc* const memberFuncp
+                    = V3Randomize::newRandomizeFunc(m_memberMap, classRefp->classp());
                 AstMethodCall* const callp = new AstMethodCall{
                     fl, new AstVarRef{fl, memberVarp, VAccess::WRITE}, "randomize", nullptr};
                 callp->taskp(memberFuncp);
@@ -995,7 +996,8 @@ void V3Randomize::randomizeNetlist(AstNetlist* nodep) {
     V3Global::dumpCheckGlobalTree("randomize", 0, dumpTreeEitherLevel() >= 3);
 }
 
-AstFunc* V3Randomize::newRandomizeFunc(VMemberMap& memberMap, AstClass* nodep, const std::string& name) {
+AstFunc* V3Randomize::newRandomizeFunc(VMemberMap& memberMap, AstClass* nodep,
+                                       const std::string& name) {
     AstFunc* funcp = VN_AS(memberMap.findMember(nodep, name), Func);
     if (!funcp) {
         v3Global.useRandomizeMethods(true);

--- a/src/V3Randomize.h
+++ b/src/V3Randomize.h
@@ -26,13 +26,15 @@ class AstClass;
 class AstFunc;
 class AstNetlist;
 
+class VMemberMap;
+
 class V3Randomize final {
 public:
     static void randomizeNetlist(AstNetlist* nodep) VL_MT_DISABLED;
 
-    static AstFunc* newRandomizeFunc(AstClass* nodep,
+    static AstFunc* newRandomizeFunc(VMemberMap& memberMap, AstClass* nodep,
                                      const std::string& name = "randomize") VL_MT_DISABLED;
-    static AstFunc* newSRandomFunc(AstClass* nodep) VL_MT_DISABLED;
+    static AstFunc* newSRandomFunc(VMemberMap& memberMap, AstClass* nodep) VL_MT_DISABLED;
 };
 
 #endif  // Guard

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -3716,13 +3716,11 @@ class WidthVisitor final : public VNVisitor {
                                        adtypep->findBitDType(), adtypep);
             methodOkArguments(nodep, 0, 0);
             methodCallLValueRecurse(nodep, nodep->fromp(), VAccess::WRITE);
-            V3Randomize::newRandomizeFunc(first_classp);
-            m_memberMap.clear();
+            V3Randomize::newRandomizeFunc(m_memberMap, first_classp);
         } else if (nodep->name() == "srandom") {
             methodOkArguments(nodep, 1, 1);
             methodCallLValueRecurse(nodep, nodep->fromp(), VAccess::WRITE);
-            V3Randomize::newSRandomFunc(first_classp);
-            m_memberMap.clear();
+            V3Randomize::newSRandomFunc(m_memberMap, first_classp);
         }
         UASSERT_OBJ(first_classp, nodep, "Unlinked");
         for (AstClass* classp = first_classp; classp;) {
@@ -5956,10 +5954,9 @@ class WidthVisitor final : public VNVisitor {
             AstClass* const classp = VN_CAST(nodep->classOrPackagep(), Class);
             UASSERT_OBJ(classp, nodep, "Should have failed in V3LinkDot");
             if (nodep->name() == "randomize") {
-                nodep->taskp(V3Randomize::newRandomizeFunc(classp));
-                m_memberMap.clear();
+                nodep->taskp(V3Randomize::newRandomizeFunc(m_memberMap, classp));
             } else if (nodep->name() == "srandom") {
-                nodep->taskp(V3Randomize::newSRandomFunc(classp));
+                nodep->taskp(V3Randomize::newSRandomFunc(m_memberMap, classp));
                 m_memberMap.clear();
             } else if (nodep->name() == "get_randstate") {
                 methodOkArguments(nodep, 0, 0);


### PR DESCRIPTION
Currently, `VMemberMap` gets rebuilt on each call to `V4Randomize::newRandomizeFunc` (and `newSRandomFunc`). This patch fixes that by requiring a `VMemberMap` be passed in as reference.