### PR TITLE
Handle static variable with assignment declaration in automatic context

### DIFF
--- a/src/V3LinkLValue.cpp
+++ b/src/V3LinkLValue.cpp
@@ -102,12 +102,11 @@ class LinkLValueVisitor final : public VNVisitor {
         }
 
         if (m_inInitialStatic && m_inFunc) {
-            const bool rhsHasIO
-                = nodep->rhsp() && nodep->rhsp()->exists([](const AstNodeVarRef* const refp) {
-                      // Exclude module I/O referenced from a function/task.
-                      return refp->varp() && refp->varp()->isIO()
-                             && refp->varp()->lifetime() != VLifetime::NONE;
-                  });
+            const bool rhsHasIO = nodep->rhsp()->exists([](const AstNodeVarRef* const refp) {
+                // Exclude module I/O referenced from a function/task.
+                return refp->varp() && refp->varp()->isIO()
+                       && refp->varp()->lifetime() != VLifetime::NONE;
+            });
             if (rhsHasIO) {
                 nodep->rhsp()->v3warn(E_UNSUPPORTED,
                                       "Static variable initializer\n"
@@ -115,7 +114,7 @@ class LinkLValueVisitor final : public VNVisitor {
                                           << "is dependent on function/task I/O variable");
             } else {
                 const bool rhsHasAutomatic
-                    = nodep->rhsp() && nodep->rhsp()->exists([](const AstNodeVarRef* const refp) {
+                    = nodep->rhsp()->exists([](const AstNodeVarRef* const refp) {
                           return refp->varp() && refp->varp()->lifetime() == VLifetime::AUTOMATIC;
                       });
                 if (rhsHasAutomatic) {

--- a/src/V3LinkLValue.cpp
+++ b/src/V3LinkLValue.cpp
@@ -101,11 +101,12 @@ class LinkLValueVisitor final : public VNVisitor {
             iterateAndNextNull(nodep->rhsp());
         }
         if (m_inInitialStatic && m_inFunc) {
-            if (const AstVarRef* const refp = VN_CAST(nodep->rhsp(), VarRef)) {
-                if (refp->varp() && refp->varp()->isIO()) {
-                    refp->v3error("Unsupported: static declaration assignment\n"
-                                  "with I/O variable inside a function/task");
-                }
+            const bool rhsHasIO = nodep->rhsp() && nodep->rhsp()->exists([](AstNodeVarRef* refp) {
+                return refp->varp() && refp->varp()->isIO();
+            });
+            if (rhsHasIO) {
+                nodep->rhsp()->v3error("Unsupported: static declaration assignment\n"
+                                       "with I/O variable inside a function/task");
             }
         }
     }

--- a/src/V3LinkLValue.cpp
+++ b/src/V3LinkLValue.cpp
@@ -110,7 +110,7 @@ class LinkLValueVisitor final : public VNVisitor {
                 nodep->rhsp()->v3warn(E_UNSUPPORTED,
                                       "Static variable declaration assignment\n"
                                           << nodep->rhsp()->warnMore()
-                                          << "with I/O variable inside a function/task");
+                                          << "is dependent on function/task I/O variable");
             }
         }
     }

--- a/src/V3LinkLValue.cpp
+++ b/src/V3LinkLValue.cpp
@@ -105,8 +105,10 @@ class LinkLValueVisitor final : public VNVisitor {
                 return refp->varp() && refp->varp()->isIO();
             });
             if (rhsHasIO) {
-                nodep->rhsp()->v3warn(E_UNSUPPORTED, "Static declaration assignment\n"
-                                                     "with I/O variable inside a function/task");
+                nodep->rhsp()->v3warn(E_UNSUPPORTED,
+                                      "Static variable declaration assignment\n"
+                                          << nodep->rhsp()->warnMore()
+                                          << "with I/O variable inside a function/task");
             }
         }
     }

--- a/src/V3LinkLValue.cpp
+++ b/src/V3LinkLValue.cpp
@@ -102,7 +102,9 @@ class LinkLValueVisitor final : public VNVisitor {
         }
         if (m_inInitialStatic && m_inFunc) {
             const bool rhsHasIO = nodep->rhsp() && nodep->rhsp()->exists([](AstNodeVarRef* refp) {
-                return refp->varp() && refp->varp()->isIO();
+                // Exclude module I/O referenced from a function/task.
+                return refp->varp() && refp->varp()->isIO()
+                       && refp->varp()->lifetime() != VLifetime::NONE;
             });
             if (rhsHasIO) {
                 nodep->rhsp()->v3warn(E_UNSUPPORTED,

--- a/src/V3LinkLValue.cpp
+++ b/src/V3LinkLValue.cpp
@@ -105,8 +105,8 @@ class LinkLValueVisitor final : public VNVisitor {
                 return refp->varp() && refp->varp()->isIO();
             });
             if (rhsHasIO) {
-                nodep->rhsp()->v3error("Unsupported: static declaration assignment\n"
-                                       "with I/O variable inside a function/task");
+                nodep->rhsp()->v3warn(E_UNSUPPORTED, "Static declaration assignment\n"
+                                                     "with I/O variable inside a function/task");
             }
         }
     }

--- a/test_regress/t/t_var_static_assign_decl_bad.out
+++ b/test_regress/t/t_var_static_assign_decl_bad.out
@@ -1,23 +1,23 @@
-%Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:70:18: Static variable declaration assignment
-                                                          : with I/O variable inside a function/task
-   70 |      logic tmp = in;
+%Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:107:18: Static variable declaration assignment
+                                                           : with I/O variable inside a function/task
+  107 |      logic tmp = in;
       |                  ^~
                     ... For error description see https://verilator.org/warn/UNSUPPORTED?v=latest
-%Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:75:18: Static variable declaration assignment
-                                                          : with I/O variable inside a function/task
-   75 |      logic tmp = in;
-      |                  ^~
-%Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:86:25: Static variable declaration assignment
-                                                          : with I/O variable inside a function/task
-   86 |      static logic tmp = in;
-      |                         ^~
-%Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:98:18: Static variable declaration assignment
-                                                          : with I/O variable inside a function/task
-   98 |      logic tmp = out;
-      |                  ^~~
-%Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:103:21: Static variable declaration assignment
+%Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:112:18: Static variable declaration assignment
                                                            : with I/O variable inside a function/task
-  103 |      logic tmp = in + 1;
+  112 |      logic tmp = in;
+      |                  ^~
+%Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:117:25: Static variable declaration assignment
+                                                           : with I/O variable inside a function/task
+  117 |      static logic tmp = in;
+      |                         ^~
+%Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:122:18: Static variable declaration assignment
+                                                           : with I/O variable inside a function/task
+  122 |      logic tmp = out;
+      |                  ^~~
+%Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:127:21: Static variable declaration assignment
+                                                           : with I/O variable inside a function/task
+  127 |      logic tmp = in + 1;
       |                     ^
 %Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:9:15: Static variable declaration assignment
                                                          : with I/O variable inside a function/task

--- a/test_regress/t/t_var_static_assign_decl_bad.out
+++ b/test_regress/t/t_var_static_assign_decl_bad.out
@@ -1,0 +1,49 @@
+%Error: t/t_var_static_assign_decl_bad.v:70:18: Unsupported: static declaration assignment
+with I/O variable inside a function/task
+   70 |      logic tmp = in;
+      |                  ^~
+%Error: t/t_var_static_assign_decl_bad.v:75:18: Unsupported: static declaration assignment
+with I/O variable inside a function/task
+   75 |      logic tmp = in;
+      |                  ^~
+%Error: t/t_var_static_assign_decl_bad.v:86:25: Unsupported: static declaration assignment
+with I/O variable inside a function/task
+   86 |      static logic tmp = in;
+      |                         ^~
+%Error: t/t_var_static_assign_decl_bad.v:98:18: Unsupported: static declaration assignment
+with I/O variable inside a function/task
+   98 |      logic tmp = out;
+      |                  ^~~
+%Error: t/t_var_static_assign_decl_bad.v:9:15: Unsupported: static declaration assignment
+with I/O variable inside a function/task
+    9 |   logic tmp = in;
+      |               ^~
+%Error: t/t_var_static_assign_decl_bad.v:14:15: Unsupported: static declaration assignment
+with I/O variable inside a function/task
+   14 |   logic tmp = in;
+      |               ^~
+%Error: t/t_var_static_assign_decl_bad.v:20:18: Unsupported: static declaration assignment
+with I/O variable inside a function/task
+   20 |      logic tmp = in;
+      |                  ^~
+%Error: t/t_var_static_assign_decl_bad.v:25:18: Unsupported: static declaration assignment
+with I/O variable inside a function/task
+   25 |      logic tmp = in;
+      |                  ^~
+%Error: t/t_var_static_assign_decl_bad.v:32:18: Unsupported: static declaration assignment
+with I/O variable inside a function/task
+   32 |      logic tmp = in;
+      |                  ^~
+%Error: t/t_var_static_assign_decl_bad.v:37:18: Unsupported: static declaration assignment
+with I/O variable inside a function/task
+   37 |      logic tmp = in;
+      |                  ^~
+%Error: t/t_var_static_assign_decl_bad.v:44:18: Unsupported: static declaration assignment
+with I/O variable inside a function/task
+   44 |      logic tmp = in;
+      |                  ^~
+%Error: t/t_var_static_assign_decl_bad.v:49:18: Unsupported: static declaration assignment
+with I/O variable inside a function/task
+   49 |      logic tmp = in;
+      |                  ^~
+%Error: Exiting due to

--- a/test_regress/t/t_var_static_assign_decl_bad.out
+++ b/test_regress/t/t_var_static_assign_decl_bad.out
@@ -1,52 +1,53 @@
-%Error: t/t_var_static_assign_decl_bad.v:70:18: Unsupported: static declaration assignment
+%Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:70:18: Static declaration assignment
 with I/O variable inside a function/task
    70 |      logic tmp = in;
       |                  ^~
-%Error: t/t_var_static_assign_decl_bad.v:75:18: Unsupported: static declaration assignment
+                    ... For error description see https://verilator.org/warn/UNSUPPORTED?v=latest
+%Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:75:18: Static declaration assignment
 with I/O variable inside a function/task
    75 |      logic tmp = in;
       |                  ^~
-%Error: t/t_var_static_assign_decl_bad.v:86:25: Unsupported: static declaration assignment
+%Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:86:25: Static declaration assignment
 with I/O variable inside a function/task
    86 |      static logic tmp = in;
       |                         ^~
-%Error: t/t_var_static_assign_decl_bad.v:98:18: Unsupported: static declaration assignment
+%Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:98:18: Static declaration assignment
 with I/O variable inside a function/task
    98 |      logic tmp = out;
       |                  ^~~
-%Error: t/t_var_static_assign_decl_bad.v:103:21: Unsupported: static declaration assignment
+%Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:103:21: Static declaration assignment
 with I/O variable inside a function/task
   103 |      logic tmp = in + 1;
       |                     ^
-%Error: t/t_var_static_assign_decl_bad.v:9:15: Unsupported: static declaration assignment
+%Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:9:15: Static declaration assignment
 with I/O variable inside a function/task
     9 |   logic tmp = in;
       |               ^~
-%Error: t/t_var_static_assign_decl_bad.v:14:15: Unsupported: static declaration assignment
+%Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:14:15: Static declaration assignment
 with I/O variable inside a function/task
    14 |   logic tmp = in;
       |               ^~
-%Error: t/t_var_static_assign_decl_bad.v:20:18: Unsupported: static declaration assignment
+%Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:20:18: Static declaration assignment
 with I/O variable inside a function/task
    20 |      logic tmp = in;
       |                  ^~
-%Error: t/t_var_static_assign_decl_bad.v:25:18: Unsupported: static declaration assignment
+%Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:25:18: Static declaration assignment
 with I/O variable inside a function/task
    25 |      logic tmp = in;
       |                  ^~
-%Error: t/t_var_static_assign_decl_bad.v:32:18: Unsupported: static declaration assignment
+%Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:32:18: Static declaration assignment
 with I/O variable inside a function/task
    32 |      logic tmp = in;
       |                  ^~
-%Error: t/t_var_static_assign_decl_bad.v:37:18: Unsupported: static declaration assignment
+%Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:37:18: Static declaration assignment
 with I/O variable inside a function/task
    37 |      logic tmp = in;
       |                  ^~
-%Error: t/t_var_static_assign_decl_bad.v:44:18: Unsupported: static declaration assignment
+%Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:44:18: Static declaration assignment
 with I/O variable inside a function/task
    44 |      logic tmp = in;
       |                  ^~
-%Error: t/t_var_static_assign_decl_bad.v:49:18: Unsupported: static declaration assignment
+%Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:49:18: Static declaration assignment
 with I/O variable inside a function/task
    49 |      logic tmp = in;
       |                  ^~

--- a/test_regress/t/t_var_static_assign_decl_bad.out
+++ b/test_regress/t/t_var_static_assign_decl_bad.out
@@ -1,54 +1,54 @@
 %Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:107:18: Static variable declaration assignment
-                                                           : with I/O variable inside a function/task
+                                                           : is dependent on function/task I/O variable
   107 |      logic tmp = in;
       |                  ^~
                     ... For error description see https://verilator.org/warn/UNSUPPORTED?v=latest
 %Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:112:18: Static variable declaration assignment
-                                                           : with I/O variable inside a function/task
+                                                           : is dependent on function/task I/O variable
   112 |      logic tmp = in;
       |                  ^~
 %Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:117:25: Static variable declaration assignment
-                                                           : with I/O variable inside a function/task
+                                                           : is dependent on function/task I/O variable
   117 |      static logic tmp = in;
       |                         ^~
 %Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:122:18: Static variable declaration assignment
-                                                           : with I/O variable inside a function/task
+                                                           : is dependent on function/task I/O variable
   122 |      logic tmp = out;
       |                  ^~~
 %Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:127:21: Static variable declaration assignment
-                                                           : with I/O variable inside a function/task
+                                                           : is dependent on function/task I/O variable
   127 |      logic tmp = in + 1;
       |                     ^
 %Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:9:15: Static variable declaration assignment
-                                                         : with I/O variable inside a function/task
+                                                         : is dependent on function/task I/O variable
     9 |   logic tmp = in;
       |               ^~
 %Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:14:15: Static variable declaration assignment
-                                                          : with I/O variable inside a function/task
+                                                          : is dependent on function/task I/O variable
    14 |   logic tmp = in;
       |               ^~
 %Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:20:18: Static variable declaration assignment
-                                                          : with I/O variable inside a function/task
+                                                          : is dependent on function/task I/O variable
    20 |      logic tmp = in;
       |                  ^~
 %Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:25:18: Static variable declaration assignment
-                                                          : with I/O variable inside a function/task
+                                                          : is dependent on function/task I/O variable
    25 |      logic tmp = in;
       |                  ^~
 %Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:32:18: Static variable declaration assignment
-                                                          : with I/O variable inside a function/task
+                                                          : is dependent on function/task I/O variable
    32 |      logic tmp = in;
       |                  ^~
 %Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:37:18: Static variable declaration assignment
-                                                          : with I/O variable inside a function/task
+                                                          : is dependent on function/task I/O variable
    37 |      logic tmp = in;
       |                  ^~
 %Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:44:18: Static variable declaration assignment
-                                                          : with I/O variable inside a function/task
+                                                          : is dependent on function/task I/O variable
    44 |      logic tmp = in;
       |                  ^~
 %Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:49:18: Static variable declaration assignment
-                                                          : with I/O variable inside a function/task
+                                                          : is dependent on function/task I/O variable
    49 |      logic tmp = in;
       |                  ^~
 %Error: Exiting due to

--- a/test_regress/t/t_var_static_assign_decl_bad.out
+++ b/test_regress/t/t_var_static_assign_decl_bad.out
@@ -1,54 +1,54 @@
-%Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:70:18: Static declaration assignment
-with I/O variable inside a function/task
+%Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:70:18: Static variable declaration assignment
+                                                          : with I/O variable inside a function/task
    70 |      logic tmp = in;
       |                  ^~
                     ... For error description see https://verilator.org/warn/UNSUPPORTED?v=latest
-%Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:75:18: Static declaration assignment
-with I/O variable inside a function/task
+%Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:75:18: Static variable declaration assignment
+                                                          : with I/O variable inside a function/task
    75 |      logic tmp = in;
       |                  ^~
-%Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:86:25: Static declaration assignment
-with I/O variable inside a function/task
+%Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:86:25: Static variable declaration assignment
+                                                          : with I/O variable inside a function/task
    86 |      static logic tmp = in;
       |                         ^~
-%Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:98:18: Static declaration assignment
-with I/O variable inside a function/task
+%Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:98:18: Static variable declaration assignment
+                                                          : with I/O variable inside a function/task
    98 |      logic tmp = out;
       |                  ^~~
-%Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:103:21: Static declaration assignment
-with I/O variable inside a function/task
+%Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:103:21: Static variable declaration assignment
+                                                           : with I/O variable inside a function/task
   103 |      logic tmp = in + 1;
       |                     ^
-%Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:9:15: Static declaration assignment
-with I/O variable inside a function/task
+%Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:9:15: Static variable declaration assignment
+                                                         : with I/O variable inside a function/task
     9 |   logic tmp = in;
       |               ^~
-%Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:14:15: Static declaration assignment
-with I/O variable inside a function/task
+%Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:14:15: Static variable declaration assignment
+                                                          : with I/O variable inside a function/task
    14 |   logic tmp = in;
       |               ^~
-%Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:20:18: Static declaration assignment
-with I/O variable inside a function/task
+%Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:20:18: Static variable declaration assignment
+                                                          : with I/O variable inside a function/task
    20 |      logic tmp = in;
       |                  ^~
-%Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:25:18: Static declaration assignment
-with I/O variable inside a function/task
+%Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:25:18: Static variable declaration assignment
+                                                          : with I/O variable inside a function/task
    25 |      logic tmp = in;
       |                  ^~
-%Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:32:18: Static declaration assignment
-with I/O variable inside a function/task
+%Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:32:18: Static variable declaration assignment
+                                                          : with I/O variable inside a function/task
    32 |      logic tmp = in;
       |                  ^~
-%Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:37:18: Static declaration assignment
-with I/O variable inside a function/task
+%Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:37:18: Static variable declaration assignment
+                                                          : with I/O variable inside a function/task
    37 |      logic tmp = in;
       |                  ^~
-%Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:44:18: Static declaration assignment
-with I/O variable inside a function/task
+%Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:44:18: Static variable declaration assignment
+                                                          : with I/O variable inside a function/task
    44 |      logic tmp = in;
       |                  ^~
-%Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:49:18: Static declaration assignment
-with I/O variable inside a function/task
+%Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:49:18: Static variable declaration assignment
+                                                          : with I/O variable inside a function/task
    49 |      logic tmp = in;
       |                  ^~
 %Error: Exiting due to

--- a/test_regress/t/t_var_static_assign_decl_bad.out
+++ b/test_regress/t/t_var_static_assign_decl_bad.out
@@ -1,54 +1,66 @@
-%Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:107:18: Static variable declaration assignment
+%Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:101:17: Static variable initializer
                                                            : is dependent on function/task I/O variable
-  107 |      logic tmp = in;
-      |                  ^~
+  101 |     logic tmp = in;
+      |                 ^~
                     ... For error description see https://verilator.org/warn/UNSUPPORTED?v=latest
-%Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:112:18: Static variable declaration assignment
+%Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:106:17: Static variable initializer
                                                            : is dependent on function/task I/O variable
-  112 |      logic tmp = in;
-      |                  ^~
-%Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:117:25: Static variable declaration assignment
+  106 |     logic tmp = in;
+      |                 ^~
+%Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:111:24: Static variable initializer
                                                            : is dependent on function/task I/O variable
-  117 |      static logic tmp = in;
-      |                         ^~
-%Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:122:18: Static variable declaration assignment
+  111 |     static logic tmp = in;
+      |                        ^~
+%Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:116:17: Static variable initializer
                                                            : is dependent on function/task I/O variable
-  122 |      logic tmp = out;
-      |                  ^~~
-%Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:127:21: Static variable declaration assignment
+  116 |     logic tmp = out;
+      |                 ^~~
+%Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:121:20: Static variable initializer
                                                            : is dependent on function/task I/O variable
-  127 |      logic tmp = in + 1;
-      |                     ^
-%Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:9:15: Static variable declaration assignment
+  121 |     logic tmp = in + 1;
+      |                    ^
+%Error: t/t_var_static_assign_decl_bad.v:126:26: Static variable initializer
+                                               : is dependent on automatic variable
+  126 |     static int foo = tmp + 1;
+      |                          ^
+%Error: t/t_var_static_assign_decl_bad.v:132:26: Static variable initializer
+                                               : is dependent on automatic variable
+  132 |     static int foo = tmp + 1;
+      |                          ^
+%Error: t/t_var_static_assign_decl_bad.v:138:29: Static variable initializer
+                                               : is dependent on automatic variable
+  138 |     static logic func_var = loc;
+      |                             ^~~
+%Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:9:15: Static variable initializer
                                                          : is dependent on function/task I/O variable
     9 |   logic tmp = in;
       |               ^~
-%Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:14:15: Static variable declaration assignment
+%Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:14:15: Static variable initializer
                                                           : is dependent on function/task I/O variable
    14 |   logic tmp = in;
       |               ^~
-%Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:20:18: Static variable declaration assignment
+%Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:20:17: Static variable initializer
                                                           : is dependent on function/task I/O variable
-   20 |      logic tmp = in;
-      |                  ^~
-%Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:25:18: Static variable declaration assignment
+   20 |     logic tmp = in;
+      |                 ^~
+%Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:25:17: Static variable initializer
                                                           : is dependent on function/task I/O variable
-   25 |      logic tmp = in;
-      |                  ^~
-%Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:32:18: Static variable declaration assignment
+   25 |     logic tmp = in;
+      |                 ^~
+%Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:32:17: Static variable initializer
                                                           : is dependent on function/task I/O variable
-   32 |      logic tmp = in;
-      |                  ^~
-%Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:37:18: Static variable declaration assignment
+   32 |     logic tmp = in;
+      |                 ^~
+%Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:37:17: Static variable initializer
                                                           : is dependent on function/task I/O variable
-   37 |      logic tmp = in;
-      |                  ^~
-%Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:44:18: Static variable declaration assignment
+   37 |     logic tmp = in;
+      |                 ^~
+%Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:44:17: Static variable initializer
                                                           : is dependent on function/task I/O variable
-   44 |      logic tmp = in;
-      |                  ^~
-%Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:49:18: Static variable declaration assignment
+   44 |     logic tmp = in;
+      |                 ^~
+%Error-UNSUPPORTED: t/t_var_static_assign_decl_bad.v:49:17: Static variable initializer
                                                           : is dependent on function/task I/O variable
-   49 |      logic tmp = in;
-      |                  ^~
+   49 |     logic tmp = in;
+      |                 ^~
 %Error: Exiting due to

--- a/test_regress/t/t_var_static_assign_decl_bad.out
+++ b/test_regress/t/t_var_static_assign_decl_bad.out
@@ -14,6 +14,10 @@ with I/O variable inside a function/task
 with I/O variable inside a function/task
    98 |      logic tmp = out;
       |                  ^~~
+%Error: t/t_var_static_assign_decl_bad.v:103:21: Unsupported: static declaration assignment
+with I/O variable inside a function/task
+  103 |      logic tmp = in + 1;
+      |                     ^
 %Error: t/t_var_static_assign_decl_bad.v:9:15: Unsupported: static declaration assignment
 with I/O variable inside a function/task
     9 |   logic tmp = in;

--- a/test_regress/t/t_var_static_assign_decl_bad.pl
+++ b/test_regress/t/t_var_static_assign_decl_bad.pl
@@ -1,0 +1,19 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2024 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+lint(
+    fails => 1,
+    expect_filename => $Self->{golden_filename},
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_var_static_assign_decl_bad.v
+++ b/test_regress/t/t_var_static_assign_decl_bad.v
@@ -50,9 +50,46 @@ program prog;
    endtask
 endprogram
 
-module mod(input in, input clk);
+module no_warn#(PARAM = 1)(input in, input clk);
+  typedef enum {A, B} enum_t;
+
   // Do not warn on variables under modules.
   logic tmp = in;
+
+  // Do not warn on assignment with module var.
+  function static func;
+    static logic func_var = tmp;
+  endfunction
+
+  // Do not warn on constant assignments.
+  function static func_param;
+    static logic func_var = PARAM;
+    static logic func_enum = A;
+  endfunction
+
+  // Do not warn on non-IO assignments.
+  function static func_local;
+    automatic logic loc;
+    static logic func_var = loc;
+  endfunction
+
+   // Do not warn on assignment referencing module I/O.
+   function static func_module_input;
+     logic tmp = in;
+   endfunction
+
+   // Do not warn on automatic assignment.
+   function automatic func_auto;
+     input logic in;
+     logic tmp = in;
+   endfunction
+
+   // Do not warn on assignment separate from declaration.
+   function static func_decl_and_assign;
+     input logic in;
+     logic tmp;
+     tmp = in;
+   endfunction
 
   // Do not warn on variables under blocks.
   initial begin
@@ -75,22 +112,9 @@ module t(input clk);
      logic tmp = in;
    endtask
 
-   function automatic func_auto;
-     input logic in;
-     // Do not warn on automatic assignment.
-     logic tmp = in;
-   endfunction
-
    function automatic func_auto_with_static;
      input logic in;
      static logic tmp = in;
-   endfunction
-
-   function static func_decl_and_assign;
-     input logic in;
-     logic tmp;
-     // Do not warn on assignment separate from declaration.
-     tmp = in;
    endfunction
 
    function static func_assign_out;
@@ -112,7 +136,7 @@ module t(input clk);
    prog prog;
 
    logic in;
-   mod mod(.in(in), .clk(clk));
+   no_warn no_warn(.in(in), .clk(clk));
 
    initial begin
       $write("*-* All Finished *-*\n");

--- a/test_regress/t/t_var_static_assign_decl_bad.v
+++ b/test_regress/t/t_var_static_assign_decl_bad.v
@@ -1,0 +1,111 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2024 by Antmicro.
+// SPDX-License-Identifier: CC0-1.0
+
+function static func_stat;
+  input logic in;
+  logic tmp = in;
+endfunction
+
+task static task_stat;
+  input logic in;
+  logic tmp = in;
+endtask
+
+package pkg;
+   function static func_stat;
+     input logic in;
+     logic tmp = in;
+   endfunction
+
+   task static task_stat;
+     input logic in;
+     logic tmp = in;
+   endtask
+endpackage
+
+interface iface;
+   function static func_stat;
+     input logic in;
+     logic tmp = in;
+   endfunction
+
+   task static task_stat;
+     input logic in;
+     logic tmp = in;
+   endtask
+endinterface
+
+program prog;
+   function static func_stat;
+     input logic in;
+     logic tmp = in;
+   endfunction
+
+   task static task_stat;
+     input logic in;
+     logic tmp = in;
+   endtask
+endprogram
+
+module mod(input in, input clk);
+  // Do not warn on variables under modules.
+  logic tmp = in;
+
+  // Do not warn on variables under blocks.
+  initial begin
+    logic init_tmp = in;
+  end
+
+  always @(posedge clk) begin
+    logic always_tmp = in;
+  end
+endmodule
+
+module t(input clk);
+   function static func_stat;
+     input logic in;
+     logic tmp = in;
+   endfunction
+
+   task static task_stat;
+     input logic in;
+     logic tmp = in;
+   endtask
+
+   function automatic func_auto;
+     input logic in;
+     // Do not warn on automatic assignment.
+     logic tmp = in;
+   endfunction
+
+   function automatic func_auto_with_static;
+     input logic in;
+     static logic tmp = in;
+   endfunction
+
+   function static func_decl_and_assign;
+     input logic in;
+     logic tmp;
+     // Do not warn on assignment separate from declaration.
+     tmp = in;
+   endfunction
+
+   function static func_assign_out;
+     output logic out;
+     logic tmp = out;
+   endfunction
+
+   iface iface();
+   prog prog;
+
+   logic in;
+   mod mod(.in(in), .clk(clk));
+
+   initial begin
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end
+endmodule

--- a/test_regress/t/t_var_static_assign_decl_bad.v
+++ b/test_regress/t/t_var_static_assign_decl_bad.v
@@ -98,6 +98,11 @@ module t(input clk);
      logic tmp = out;
    endfunction
 
+   function static func_assign_expr;
+     input logic in;
+     logic tmp = in + 1;
+   endfunction
+
    iface iface();
    prog prog;
 

--- a/test_regress/t/t_var_static_assign_decl_bad.v
+++ b/test_regress/t/t_var_static_assign_decl_bad.v
@@ -15,39 +15,39 @@ task static task_stat;
 endtask
 
 package pkg;
-   function static func_stat;
-     input logic in;
-     logic tmp = in;
-   endfunction
+  function static func_stat;
+    input logic in;
+    logic tmp = in;
+  endfunction
 
-   task static task_stat;
-     input logic in;
-     logic tmp = in;
-   endtask
+  task static task_stat;
+    input logic in;
+    logic tmp = in;
+  endtask
 endpackage
 
 interface iface;
-   function static func_stat;
-     input logic in;
-     logic tmp = in;
-   endfunction
+  function static func_stat;
+    input logic in;
+    logic tmp = in;
+  endfunction
 
-   task static task_stat;
-     input logic in;
-     logic tmp = in;
-   endtask
+  task static task_stat;
+    input logic in;
+    logic tmp = in;
+  endtask
 endinterface
 
 program prog;
-   function static func_stat;
-     input logic in;
-     logic tmp = in;
-   endfunction
+  function static func_stat;
+    input logic in;
+    logic tmp = in;
+  endfunction
 
-   task static task_stat;
-     input logic in;
-     logic tmp = in;
-   endtask
+  task static task_stat;
+    input logic in;
+    logic tmp = in;
+  endtask
 endprogram
 
 module no_warn#(PARAM = 1)(input in, input clk);
@@ -67,29 +67,23 @@ module no_warn#(PARAM = 1)(input in, input clk);
     static logic func_enum = A;
   endfunction
 
-  // Do not warn on non-IO assignments.
-  function static func_local;
-    automatic logic loc;
-    static logic func_var = loc;
+  // Do not warn on assignment referencing module I/O.
+  function static func_module_input;
+    logic tmp = in;
   endfunction
 
-   // Do not warn on assignment referencing module I/O.
-   function static func_module_input;
-     logic tmp = in;
-   endfunction
+  // Do not warn on automatic assignment.
+  function automatic func_auto;
+    input logic in;
+    logic tmp = in;
+  endfunction
 
-   // Do not warn on automatic assignment.
-   function automatic func_auto;
-     input logic in;
-     logic tmp = in;
-   endfunction
-
-   // Do not warn on assignment separate from declaration.
-   function static func_decl_and_assign;
-     input logic in;
-     logic tmp;
-     tmp = in;
-   endfunction
+  // Do not warn on assignment separate from declaration.
+  function static func_decl_and_assign;
+    input logic in;
+    logic tmp;
+    tmp = in;
+  endfunction
 
   // Do not warn on variables under blocks.
   initial begin
@@ -102,44 +96,56 @@ module no_warn#(PARAM = 1)(input in, input clk);
 endmodule
 
 module t(input clk);
-   function static func_stat;
-     input logic in;
-     logic tmp = in;
-   endfunction
+  function static func_stat;
+    input logic in;
+    logic tmp = in;
+  endfunction
 
-   task static task_stat;
-     input logic in;
-     logic tmp = in;
-   endtask
+  task static task_stat;
+    input logic in;
+    logic tmp = in;
+  endtask
 
-   function automatic func_auto_with_static;
-     input logic in;
-     static logic tmp = in;
-   endfunction
+  function automatic func_auto_with_static;
+    input logic in;
+    static logic tmp = in;
+  endfunction
 
-   function static func_assign_out;
-     output logic out;
-     logic tmp = out;
-   endfunction
+  function static func_assign_out;
+    output logic out;
+    logic tmp = out;
+  endfunction
 
-   function static func_assign_expr;
-     input logic in;
-     logic tmp = in + 1;
-   endfunction
+  function static func_assign_expr;
+    input logic in;
+    logic tmp = in + 1;
+  endfunction
 
-   function static func_module_input;
-     // Do not warn on assignment referencing module I/O.
-     logic tmp = clk;
-   endfunction
+  function static int func_assign_static_in_to_auto(input int i);
+    automatic int tmp = i;
+    static int foo = tmp + 1;
+    return foo;
+  endfunction
 
-   iface iface();
-   prog prog;
+  function static int func_assign_auto_to_static();
+    automatic int tmp = 0;
+    static int foo = tmp + 1;
+    return foo;
+  endfunction
 
-   logic in;
-   no_warn no_warn(.in(in), .clk(clk));
+  function static func_local;
+    automatic logic loc;
+    static logic func_var = loc;
+  endfunction
 
-   initial begin
-      $write("*-* All Finished *-*\n");
-      $finish;
-   end
+  iface iface();
+  prog prog;
+
+  logic in;
+  no_warn no_warn(.in(in), .clk(clk));
+
+  initial begin
+    $write("*-* All Finished *-*\n");
+    $finish;
+  end
 endmodule

--- a/test_regress/t/t_var_static_assign_decl_bad.v
+++ b/test_regress/t/t_var_static_assign_decl_bad.v
@@ -103,6 +103,11 @@ module t(input clk);
      logic tmp = in + 1;
    endfunction
 
+   function static func_module_input;
+     // Do not warn on assignment referencing module I/O.
+     logic tmp = clk;
+   endfunction
+
    iface iface();
    prog prog;
 


### PR DESCRIPTION
When running the following example:
```verilog
module t;
   function static func;
     input in;
     logic tmp = in;
   endfunction

   initial begin
      $write("*-* All Finished *-*\n");
      $finish;
   end
endmodule
```

Verilator crashes with an error `../V3Scope.cpp:74: Can't locate varref scope`.
The `tmp` variable in the function above is implicitly static, thus the assignment is wrapped with `AstInitialStatic` and moved out of the function block in `V3Begin`. This mechanism is effective when two `static` variables are assigned, however it is not when lifetimes does not match. For instance when `automatic` variable (in this case `in`) is assigned to `static` one. This assignment breaks `V3Scope` phase where scopes cannot be established as the `AstInitialStatic` references automatic variables defined in that function.

The PR moves such assignments out of the `AstInitialStatic` block to prevent moving it by `V3Begin` phase thus preventing `V3Scope` errors. It should be noted that this changes semantics of the assignment; it is executed as automatic rather than static.