### PR TITLE
Add support for foreach constraints

### DIFF
--- a/test_regress/t/t_constraint_foreach.pl
+++ b/test_regress/t/t_constraint_foreach.pl
@@ -1,0 +1,25 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2024 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+if (!$Self->have_solver) {
+    skip("No constraint solver installed");
+} else {
+    compile(
+        );
+
+    execute(
+        check_finished => 1,
+        );
+}
+
+ok(1);
+1;

--- a/test_regress/t/t_constraint_foreach.v
+++ b/test_regress/t/t_constraint_foreach.v
@@ -1,0 +1,58 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2024 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+`define check_rand(cl, field, cond) \
+begin \
+   longint prev_result; \
+   int ok = 0; \
+   for (int i = 0; i < 10; i++) begin \
+      longint result; \
+      if (!bit'(cl.randomize())) $stop; \
+      result = longint'(field); \
+      if (!(cond)) $stop; \
+      if (i > 0 && result != prev_result) ok = 1; \
+      prev_result = result; \
+   end \
+   if (ok != 1) $stop; \
+end
+
+class C;
+   rand int x;
+   int q[$] = {0, 0, 0, 0, 0};
+   constraint fore {
+      x < 7;
+      foreach(q[i])
+         x > i;
+   };
+endclass
+
+class D;
+   rand bit posit;
+   rand int x;
+   int q[$] = {0, 0, 0, 0, 0};
+   constraint fore {
+      if (posit == 1) {
+         x < 7;
+         foreach(q[i])
+            x > i;
+      } else {
+         x > -3;
+         foreach(q[i])
+            x < i;
+      }
+   };
+endclass
+
+module t;
+   initial begin
+      C c = new;
+      D d = new;
+      `check_rand(c, c.x, 4 < c.x && c.x < 7);
+      `check_rand(d, d.posit, (d.posit ? 4 : -3) < d.x && d.x < (d.posit ? 7 : 0));
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end
+endmodule

--- a/test_regress/t/t_randomize.out
+++ b/test_regress/t/t_randomize.out
@@ -4,10 +4,6 @@
       |              ^~~~
                         ... For warning description see https://verilator.org/warn/CONSTRAINTIGN?v=latest
                         ... Use "/* verilator lint_off CONSTRAINTIGN */" and lint_on around source to disable this message.
-%Warning-CONSTRAINTIGN: t/t_randomize.v:37:7: Constraint expression ignored (unsupported)
-                                            : ... note: In instance 't'
-   37 |       foreach (array[i]) {
-      |       ^~~~~~~
 %Warning-CONSTRAINTIGN: t/t_randomize.v:40:7: Constraint expression ignored (unsupported)
                                             : ... note: In instance 't'
    40 |       unique { array[0], array[1] };
@@ -16,8 +12,4 @@
                                              : ... note: In instance 't'
    43 |    constraint order { solve length before header; }
       |                       ^~~~~
-%Error-UNSUPPORTED: t/t_randomize.v:14:13: Unsupported: random member variable with type 'int$[0:1]'
-                                         : ... note: In instance 't'
-   14 |    rand int array[2];   
-      |             ^~~~~
 %Error: Exiting due to

--- a/test_regress/t/t_randomize.v
+++ b/test_regress/t/t_randomize.v
@@ -11,7 +11,7 @@ class Packet;
    rand bit if_4;
    rand bit iff_5_6;
 
-   rand int array[2];  // 2,4,6
+   /*rand*/ int array[2];  // 2,4,6  // TODO: add rand when supported
 
    constraint empty {}
 


### PR DESCRIPTION
This is a proof-of-concept implementation of foreach constraints. They are converted to foreach loops emitting their constraints. The `wantSingle` case is a bit hacky, as it depends on emitting an inline lambda like AstStmtExpr does, but this can be potentially worked around if desired, by converting foreach constraints inside ifs to particular expressions, by maintaining a stack of the if/else clauses each constraint expression appears under. I did not go down that route, as it might grow quadratic in the trivial implementation, i.e. each condition would be duplicated for each of its guarded expressions, affecting deeply nested ifs. Some intermediary variables would need to be introduced to prevent that.

Based on #5283