### PR TITLE
Internals: clean up begin blocks and lifetimes in foreach loops

### DIFF
--- a/src/V3Begin.cpp
+++ b/src/V3Begin.cpp
@@ -327,6 +327,7 @@ private:
 
     // VISITORS
     void visit(AstNodeFTaskRef* nodep) override {
+        UASSERT_OBJ(nodep->taskp(), nodep, "unlinked");
         if (nodep->taskp()->user1()) {  // It was converted
             UINFO(9, "    relinkFTask " << nodep << endl);
             nodep->name(nodep->taskp()->name());

--- a/src/V3LinkDot.cpp
+++ b/src/V3LinkDot.cpp
@@ -1487,6 +1487,7 @@ class LinkDotFindVisitor final : public VNVisitor {
                     // We use an int type, this might get changed in V3Width when types resolve
                     argrefp = new AstVar{parserefp->fileline(), VVarType::BLOCKTEMP,
                                          parserefp->name(), argp->findSigned32DType()};
+                    argrefp->lifetime(VLifetime::AUTOMATIC);
                     parserefp->replaceWith(argrefp);
                     VL_DO_DANGLING(parserefp->deleteTree(), parserefp);
                     // Insert argref's name into symbol table

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -4954,6 +4954,7 @@ class WidthVisitor final : public VNVisitor {
                     AstVar* const first_varp = new AstVar{
                         fl, VVarType::BLOCKTEMP, varp->name() + "__Vfirst", VFlagBitPacked{}, 1};
                     first_varp->usedLoopIdx(true);
+                    first_varp->lifetime(VLifetime::AUTOMATIC);
                     AstNodeExpr* const firstp = new AstMethodCall{
                         fl, fromp->cloneTreePure(false), "first",
                         new AstArg{fl, "", new AstVarRef{fl, varp, VAccess::READWRITE}}};
@@ -4976,7 +4977,7 @@ class WidthVisitor final : public VNVisitor {
                     stmtsp->addNext(first_varp);
                     stmtsp->addNext(
                         new AstIf{fl, new AstNeq{fl, new AstConst{fl, 0}, firstp}, ifbodyp});
-                    loopp = new AstBegin{nodep->fileline(), "", stmtsp, false, true};
+                    loopp = stmtsp;
                     // Prep for next
                     fromDtp = fromDtp->subDTypep();
                 } else {
@@ -5036,12 +5037,10 @@ class WidthVisitor final : public VNVisitor {
         FileLine* const fl = varp->fileline();
         auto* const whilep = new AstWhile{
             fl, condp, bodysp, new AstAssign{fl, new AstVarRef{fl, varp, VAccess::WRITE}, incp}};
-        varp->lifetime(VLifetime::AUTOMATIC);
         AstNode* const stmtsp = varp;  // New statements for under new Begin
         stmtsp->addNext(new AstAssign{fl, new AstVarRef{fl, varp, VAccess::WRITE}, leftp});
         stmtsp->addNext(whilep);
-        AstNode* const newp = new AstBegin{nodep->fileline(), "", stmtsp, false, true};
-        return newp;
+        return stmtsp;
     }
 
     void visit(AstNodeAssign* nodep) override {

--- a/src/verilog.y
+++ b/src/verilog.y
@@ -3646,7 +3646,8 @@ statement_item<nodep>:          // IEEE: statement_item
         |       statementFor                            { $$ = $1; }
         |       yDO stmtBlock yWHILE '(' expr ')' ';'   { $$ = new AstDoWhile{$1, $5, $2}; }
         //                      // IEEE says array_identifier here, but dotted accepted in VMM and 1800-2009
-        |       yFOREACH '(' idClassSelForeach ')' stmtBlock    { $$ = new AstForeach{$1, $3, $5}; }
+        |       yFOREACH '(' idClassSelForeach ')' stmtBlock
+                        { $$ = new AstBegin{$1, "", new AstForeach{$1, $3, $5}, false, true}; }
         //
         //                      // IEEE: jump_statement
         |       yRETURN ';'                             { $$ = new AstReturn{$1}; }


### PR DESCRIPTION
According to IEEE 1800-2023 12.7.3, the loop creates an implicit block around it, containing declarations of the loop variables with automatic lifetime.

No functional change intended.

This is a pre-pull for #5283 (and therefore a pre-pre-pull for #5302).