### PR TITLE
ensure make flows do not call python3 with absolute system path (like perl)

### DIFF
--- a/Changes
+++ b/Changes
@@ -45,6 +45,7 @@ Verilator 5.027 devel
 * Fix elaborating foreach loops (#5285). [Arkadiusz Kozdra, Antmicro Ltd.]
 * Fix initializing static array in dynamic arrays and queues (#5287). [Baruch Sterin]
 * Fix randomizing current object with `rand` class instance member (#5292). [Krzysztof Bieganski, Antmicro Ltd.]
+* Fix Python3 path discovery in make flows to avoid mixing system and user python interpreters (#5307) [Markus Krause]
 
 
 Verilator 5.026 2024-06-15

--- a/src/V3EmitCMake.cpp
+++ b/src/V3EmitCMake.cpp
@@ -81,7 +81,10 @@ class CMakeEmitter final {
 
         *of << "\n### Constants...\n";
         cmake_set(*of, "PERL", V3OutFormatter::quoteNameControls(V3Options::getenvPERL()),
-                  "FILEPATH", "Perl executable (from $PERL)");
+                  "FILEPATH", "Perl executable (from $PERL, defaults to 'perl' if not set)");
+        cmake_set(*of, "PYTHON3", V3OutFormatter::quoteNameControls(V3Options::getenvPYTHON3()),
+                  "FILEPATH",
+                  "Python3 executable (from $PYTHON3, defaults to 'python3' if not set)");
         cmake_set(*of, "VERILATOR_ROOT",
                   V3OutFormatter::quoteNameControls(V3Options::getenvVERILATOR_ROOT()), "PATH",
                   "Path to Verilator kit (from $VERILATOR_ROOT)");

--- a/src/V3EmitMk.cpp
+++ b/src/V3EmitMk.cpp
@@ -151,8 +151,11 @@ public:
             of.puts("default: lib" + v3Global.opt.prefix() + "\n");
         }
         of.puts("\n### Constants...\n");
-        of.puts("# Perl executable (from $PERL)\n");
+        of.puts("# Perl executable (from $PERL, defaults to 'perl' if not set)\n");
         of.puts("PERL = " + V3OutFormatter::quoteNameControls(V3Options::getenvPERL()) + "\n");
+        of.puts("# Python3 executable (from $PYTHON3, defaults to 'python3' if not set)\n");
+        of.puts("PYTHON3 = " + V3OutFormatter::quoteNameControls(V3Options::getenvPYTHON3())
+                + "\n");
         of.puts("# Path to Verilator kit (from $VERILATOR_ROOT)\n");
         of.puts("VERILATOR_ROOT = "
                 + V3OutFormatter::quoteNameControls(V3Options::getenvVERILATOR_ROOT()) + "\n");

--- a/src/V3Options.cpp
+++ b/src/V3Options.cpp
@@ -637,6 +637,8 @@ string V3Options::getenvBuiltins(const string& var) {
         return getenvMAKE();
     } else if (var == "PERL") {
         return getenvPERL();
+    } else if (var == "PYTHON3") {
+        return getenvPYTHON3();
     } else if (var == "SYSTEMC") {
         return getenvSYSTEMC();
     } else if (var == "SYSTEMC_ARCH") {
@@ -664,6 +666,10 @@ string V3Options::getenvMAKEFLAGS() {  //
 
 string V3Options::getenvPERL() {  //
     return V3Os::filenameCleanup(V3Os::getenvStr("PERL", "perl"));
+}
+
+string V3Options::getenvPYTHON3() {  //
+    return V3Os::filenameCleanup(V3Os::getenvStr("PYTHON3", "python3"));
 }
 
 string V3Options::getenvSYSTEMC() {
@@ -1955,6 +1961,7 @@ void V3Options::showVersion(bool verbose) {
     cout << "Environment:\n";
     cout << "    MAKE               = " << V3Os::getenvStr("MAKE", "") << "\n";
     cout << "    PERL               = " << V3Os::getenvStr("PERL", "") << "\n";
+    cout << "    PYTHON3            = " << V3Os::getenvStr("PYTHON3", "") << "\n";
     cout << "    SYSTEMC            = " << V3Os::getenvStr("SYSTEMC", "") << "\n";
     cout << "    SYSTEMC_ARCH       = " << V3Os::getenvStr("SYSTEMC_ARCH", "") << "\n";
     cout << "    SYSTEMC_INCLUDE    = " << V3Os::getenvStr("SYSTEMC_INCLUDE", "") << "\n";

--- a/src/V3Options.h
+++ b/src/V3Options.h
@@ -720,6 +720,7 @@ public:
     static string getenvMAKE();
     static string getenvMAKEFLAGS();
     static string getenvPERL();
+    static string getenvPYTHON3();
     static string getenvSYSTEMC();
     static string getenvSYSTEMC_ARCH();
     static string getenvSYSTEMC_INCLUDE();

--- a/test_regress/t/t_flag_getenv.pl
+++ b/test_regress/t/t_flag_getenv.pl
@@ -20,7 +20,7 @@ run(
     verilator_run => 1,
     );
 
-foreach my $var (qw(MAKE PERL SYSTEMC SYSTEMC_ARCH SYSTEMC_LIBDIR VERILATOR_ROOT)) {
+foreach my $var (qw(MAKE PERL PYTHON3 SYSTEMC SYSTEMC_ARCH SYSTEMC_LIBDIR VERILATOR_ROOT)) {
     run(
         cmd => ["$ENV{VERILATOR_ROOT}/bin/verilator --getenv ${var}"],
         logfile => "$Self->{obj_dir}/simx.log",


### PR DESCRIPTION
Fixes #5307

local build and make test is passing, verified the ouput of Vtop.mk, which now also ensures PYTHON3 does not default to a full system path to avoid environment mix ups

now looks like this:
![grafik](https://github.com/user-attachments/assets/679bebd8-688a-4551-9ab5-a2eea322722b)
