### PR TITLE
Remove dubious assert causing failures

### DIFF
--- a/include/verilated_fst_c.cpp
+++ b/include/verilated_fst_c.cpp
@@ -166,7 +166,6 @@ void VerilatedFst::declare(uint32_t code, const char* name, int dtypenum,
     const bool enabled = Super::declCode(code, hierarchicalName, bits);
     if (!enabled) return;
 
-    assert(hierarchicalName.rfind(' ') != std::string::npos);
     std::stringstream name_ss;
     name_ss << lastWord(hierarchicalName);
     if (array) name_ss << "[" << arraynum << "]";


### PR DESCRIPTION
Fixes https://github.com/cocotb/cocotb/issues/4074, which really should have been opened against this project.

As stated the `hierarchicalName` that causes issues for me was `clk`. The prefix was `""` and the name was `"clk"`. I don't see how this is an invalid name, or why `hierarchicalName` *must* have a space in it. Perhaps the condition is backwards? it must *not* have a space in it?

Pinging @gezalore.