### PR TITLE
Fix -Wunused-but-set-variable clang warning

### DIFF
--- a/src/V3Begin.cpp
+++ b/src/V3Begin.cpp
@@ -462,8 +462,7 @@ AstNode* V3Begin::convertToWhile(AstForeach* nodep) {
                 rightp->dtypeSetSigned32();
                 rightp->protect(false);
                 loopp = createForeachLoop(nodep, bodyPointp, varp, leftp, rightp, VNType::atLt);
-            } else if (const AstAssocArrayDType* const adtypep
-                       = VN_CAST(fromDtp, AssocArrayDType)) {
+            } else if (VN_IS(fromDtp, AssocArrayDType)) {
                 // Make this: var KEY_TYPE index;
                 //            bit index__Vfirst;
                 //            index__Vfirst = 0;

--- a/src/V3EmitCConstInit.h
+++ b/src/V3EmitCConstInit.h
@@ -48,8 +48,7 @@ protected:
         VL_RESTORER(m_inUnpacked);
         VL_RESTORER(m_unpackedWord);
         m_inUnpacked = true;
-        if (const AstAssocArrayDType* const dtypep
-            = VN_CAST(nodep->dtypep()->skipRefp(), AssocArrayDType)) {
+        if (VN_IS(nodep->dtypep()->skipRefp(), AssocArrayDType)) {
             // Note the double {{ initializer. The first { starts the initializer of the
             // VlUnpacked, and the second starts the initializer of m_storage within the
             // VlUnpacked.

--- a/src/V3Hasher.cpp
+++ b/src/V3Hasher.cpp
@@ -368,7 +368,7 @@ class HasherVisitor final : public VNVisitorConst {
         m_hash += hashNodeAndIterate(nodep, HASH_DTYPE, HASH_CHILDREN, []() {});
     }
     void visit(AstInitArray* nodep) override {
-        if (const AstAssocArrayDType* const dtypep = VN_CAST(nodep->dtypep(), AssocArrayDType)) {
+        if (VN_IS(nodep->dtypep(), AssocArrayDType)) {
             if (nodep->defaultp()) {
                 m_hash
                     += hashNodeAndIterate(nodep->defaultp(), HASH_DTYPE, HASH_CHILDREN, []() {});

--- a/src/V3SenExprBuilder.h
+++ b/src/V3SenExprBuilder.h
@@ -139,8 +139,7 @@ class SenExprBuilder final {
                 return prevp;
             }
 
-            if (AstUnpackArrayDType* const dtypep
-                = VN_CAST(exprp->dtypep()->skipRefp(), UnpackArrayDType)) {
+            if (VN_IS(exprp->dtypep()->skipRefp(), UnpackArrayDType)) {
                 AstCMethodHard* const cmhp = new AstCMethodHard{flp, wrPrev(), "assign", rdCurr()};
                 cmhp->dtypeSetVoid();
                 m_postUpdates.push_back(cmhp->makeStmt());

--- a/src/V3Split.cpp
+++ b/src/V3Split.cpp
@@ -476,7 +476,7 @@ protected:
         // vertexes not involved with this step as unimportant
         for (V3GraphVertex& vertex : m_graph.vertices()) {
             if (!vertex.user()) {
-                if (const SplitLogicVertex* const vvertexp = vertex.cast<SplitLogicVertex>()) {
+                if (vertex.is<SplitLogicVertex>()) {
                     for (V3GraphEdge& edge : vertex.inEdges()) {
                         SplitEdge& oedge = static_cast<SplitEdge&>(edge);
                         oedge.setIgnoreThisStep();


### PR DESCRIPTION
This PR fixes code that was flagged with new clang warning: https://clang.llvm.org/docs/DiagnosticsReference.html#wunused-but-set-parameter.

After this fix, Verilator codebase compiles under current development version of clang as of commit https://github.com/llvm/llvm-project/commit/30e5d7190d39fe4f0982435d4fb5043e64acdc9f.

No functional change.