### PR TITLE
Internals: Allow `AstNode` in `AstClass` iteration methods

### DIFF
--- a/src/V3Ast.h
+++ b/src/V3Ast.h
@@ -2503,7 +2503,7 @@ protected:
     static void dumpJsonStr(std::ostream& os, const std::string& name, const std::string& val);
     static void dumpJsonPtr(std::ostream& os, const std::string& name, const AstNode* const valp);
 
-private:
+protected:
     void iterateListBackwardsConst(VNVisitorConst& v);
 
     // For internal use only.

--- a/src/V3AstNodeOther.h
+++ b/src/V3AstNodeOther.h
@@ -2353,9 +2353,7 @@ public:
             extendsp->classp()->foreachMember(f);
         }
         for (AstNode* stmtp = stmtsp(); stmtp; stmtp = stmtp->nextp()) {
-            if (T_Node* memberp = AstNode::privateCast<T_Node, decltype(stmtp)>(stmtp)) {
-                f(this, memberp);
-            }
+            if (AstNode::privateTypeTest<T_Node>(stmtp)) f(this, static_cast<T_Node*>(stmtp));
         }
     }
     // Same as above, but stops after first match
@@ -2370,8 +2368,8 @@ public:
             if (extendsp->classp()->existsMember(p)) return true;
         }
         for (AstNode* stmtp = stmtsp(); stmtp; stmtp = stmtp->nextp()) {
-            if (T_Node* memberp = AstNode::privateCast<T_Node, decltype(stmtp)>(stmtp)) {
-                if (p(this, memberp)) return true;
+            if (AstNode::privateTypeTest<T_Node>(stmtp)) {
+                if (p(this, static_cast<T_Node*>(stmtp))) return true;
             }
         }
         return false;


### PR DESCRIPTION
Currently these methods fail to compile if a function that expects an `AstNode` is passed to them (due to `uselessCast`).

This patch fixes that. No functional change intended.