### PR TITLE
Fix compilation error on unreachable disable fork / wait fork

### DIFF
--- a/test_regress/t/t_disable_fork3.v
+++ b/test_regress/t/t_disable_fork3.v
@@ -4,6 +4,13 @@
 // any use, without warranty, 2023 by Antmicro Ltd.
 // SPDX-License-Identifier: CC0-1.0
 
+class C;
+   task proc;
+      disable fork;
+      wait fork;
+   endtask
+endclass
+
 module t;
    initial begin
       fork begin


### PR DESCRIPTION
Becuase no caller nodes are ever marked as creating processes, no vlProcess argument is added, and using it results in an undefined name at compilation time.

Also limited process tracking propagation to correctly stop at fork boundary regardless of whether the fork is blocking or not (previously the propagation was excessive but otherwise harmless).
And also cleaned up a bit of unreachable code: only AstBegin can appear directly under an AstFork, so NodeCCall can never see any nonzero m_underFork. This can be submitted separately if desired.