### PR TITLE
Fix missing type coercion in 'inside {array}'

### DIFF
--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -2700,8 +2700,11 @@ class WidthVisitor final : public VNVisitor {
             } else if (VN_IS(itemDtp, UnpackArrayDType) || VN_IS(itemDtp, DynArrayDType)
                        || VN_IS(itemDtp, QueueDType)) {
                 // Unsupported in parameters
-                inewp = new AstCMethodHard{itemp->fileline(), itemp->unlinkFrBack(), "inside",
-                                           nodep->exprp()->cloneTreePure(true)};
+                AstNodeExpr* exprp = nodep->exprp()->cloneTreePure(true);
+                inewp = new AstCMethodHard{nodep->fileline(), itemp->unlinkFrBack(), "inside",
+                                           exprp};
+                iterateCheckTyped(nodep, "inside value", exprp, itemDtp->subDTypep(), BOTH);
+                VL_DANGLING(exprp);  // Might have been replaced
                 inewp->dtypeSetBit();
                 inewp->didWidth(true);
             } else if (VN_IS(itemDtp, AssocArrayDType)) {

--- a/test_regress/t/t_inside_dyn.v
+++ b/test_regress/t/t_inside_dyn.v
@@ -7,6 +7,7 @@
 module t;
    int q[$] = '{1, 2, 3};
    bit dyn[] = '{0, 0};
+   string sq[] = '{"C", "D"};
 
    initial begin
       if (!(1 inside {q})) $stop;
@@ -15,6 +16,7 @@ module t;
 
       if (!(0 inside {dyn})) $stop;
       if (1 inside {dyn}) $stop;
+      if (!("C" inside {sq})) $stop;
 
       $write("*-* All Finished *-*\n");
       $finish;

--- a/test_regress/t/t_inside_unpacked_param.out
+++ b/test_regress/t/t_inside_unpacked_param.out
@@ -1,9 +1,9 @@
-%Error: t/t_inside_unpacked_param.v:13:43: Expecting expression to be constant, but can't convert a CMETHODHARD 'inside' to constant.
+%Error: t/t_inside_unpacked_param.v:13:35: Expecting expression to be constant, but can't convert a CMETHODHARD 'inside' to constant.
                                          : ... note: In instance 't'
    13 |    localparam HIT_INSIDE = HIT_LP inside {CHECKLIST_P};
-      |                                           ^~~~~~~~~~~
-%Error: t/t_inside_unpacked_param.v:14:45: Expecting expression to be constant, but can't convert a CMETHODHARD 'inside' to constant.
+      |                                   ^~~~~~
+%Error: t/t_inside_unpacked_param.v:14:37: Expecting expression to be constant, but can't convert a CMETHODHARD 'inside' to constant.
                                          : ... note: In instance 't'
    14 |    localparam MISS_INSIDE = MISS_LP inside {CHECKLIST_P};
-      |                                             ^~~~~~~~~~~
+      |                                     ^~~~~~
 %Error: Exiting due to


### PR DESCRIPTION
Previously resulting in a compilation error due to mismatched data types.