### PR TITLE
Add support for constraining AstSel

### DIFF
--- a/src/V3AstNodeExpr.h
+++ b/src/V3AstNodeExpr.h
@@ -4678,6 +4678,7 @@ public:
                : isWide()        ? "VL_SEL_%nq%lq%rq%tq(%nw,%lw, %P, %li, %ri, %ti)"
                                  : "VL_SEL_%nq%lq%rq%tq(%lw, %P, %li, %ri, %ti)";
     }
+    string emitSMT() const override { return "((_ extract %t %r) %l)"; }
     bool cleanOut() const override { return false; }
     bool cleanLhs() const override { return true; }
     bool cleanRhs() const override { return true; }

--- a/test_regress/t/t_constraint_operators.v
+++ b/test_regress/t/t_constraint_operators.v
@@ -8,6 +8,7 @@ class Packet;
    rand int x;
    rand bit [31:0] b;
    rand bit [31:0] c;
+   rand bit [31:0] d;
    rand bit tiny;
    rand bit zero;
    rand bit one;
@@ -31,6 +32,7 @@ class Packet;
    constraint cond { (tiny == 1 ? b : c) != 17; }
    constraint zero_c { zero == 0; }
    constraint one_c { one == 1; }
+   constraint sel { d[15:8] == 8'h55; }
    constraint ifelse {
       if (one == 1) out0 == 'h333;
 
@@ -88,6 +90,7 @@ module t (/*AUTOARG*/);
       if (p.out4 != 'h333) $stop;
       if (p.out5 != 'h333) $stop;
       if (p.out6 != 'h333) $stop;
+      if (p.d[15:8] != 'h55) $stop;
 
       $write("*-* All Finished *-*\n");
       $finish;


### PR DESCRIPTION
Added missing AstSel::emitSMT function, also useful for packed struct fields (those are AstSel after V3Width).