### PR TITLE
Ignore std::randomize

### DIFF
--- a/include/verilated_std.sv
+++ b/include/verilated_std.sv
@@ -195,5 +195,7 @@ package std;
          $urandom(s.atoi());  // Set the seed using a string
       endfunction
    endclass
-   function int randomize(); endfunction
+   function int randomize();
+      randomize = 0;
+   endfunction
 endpackage

--- a/include/verilated_std.sv
+++ b/include/verilated_std.sv
@@ -195,4 +195,5 @@ package std;
          $urandom(s.atoi());  // Set the seed using a string
       endfunction
    endclass
+   function int randomize(); endfunction
 endpackage

--- a/test_regress/t/t_std_randomize_unsup_bad.out
+++ b/test_regress/t/t_std_randomize_unsup_bad.out
@@ -1,0 +1,11 @@
+%Warning-CONSTRAINTIGN: t/t_std_randomize_unsup_bad.v:10:16: std::randomize ignored (unsupported)
+                                                           : ... note: In instance 't'
+   10 |       if (std::randomize(a, b) != 1) $stop;
+      |                ^~~~~~~~~
+                        ... For warning description see https://verilator.org/warn/CONSTRAINTIGN?v=latest
+                        ... Use "/* verilator lint_off CONSTRAINTIGN */" and lint_on around source to disable this message.
+%Warning-CONSTRAINTIGN: t/t_std_randomize_unsup_bad.v:11:16: std::randomize ignored (unsupported)
+                                                           : ... note: In instance 't'
+   11 |       if (std::randomize(a, b) with { 2 < a; a < 7; b < a; } != 1) $stop;
+      |                ^~~~~~~~~
+%Error: Exiting due to

--- a/test_regress/t/t_std_randomize_unsup_bad.pl
+++ b/test_regress/t/t_std_randomize_unsup_bad.pl
@@ -1,0 +1,19 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2003 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(linter => 1);
+
+lint(
+    fails => 1,
+    expect_filename => $Self->{golden_filename},
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_std_randomize_unsup_bad.v
+++ b/test_regress/t/t_std_randomize_unsup_bad.v
@@ -1,0 +1,16 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2024 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+module t;
+   initial begin
+      int a, b;
+      if (std::randomize(a, b) != 1) $stop;
+      if (std::randomize(a, b) with { 2 < a; a < 7; b < a; } != 1) $stop;
+      if (!(2 < a && a < 7 && b < a)) $stop;
+      $write("-*-* All Finished *-*-\n");
+      $finish;
+   end
+endmodule


### PR DESCRIPTION
As std::randomize will take more effort to be fully supported, let's just parse it and ignore properly for now.