### PR TITLE
Fix typos in `:vlopt:` command usage in docs (#5355)

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -123,6 +123,7 @@ Krzysztof Obłonczek
 Kuba Ober
 Larry Doolittle
 Liam Braun
+Luca Colagrande
 Ludwig Rogiers
 Lukasz Dalek
 Maarten De Braekeleer

--- a/docs/guide/verilating.rst
+++ b/docs/guide/verilating.rst
@@ -304,9 +304,9 @@ GNU Make
 ========
 
 Verilator defaults to creating GNU Make makefiles for the model.  Verilator
-will call make automatically when the :vlopt:'--build' option is used.
+will call make automatically when the :vlopt:`--build` option is used.
 
-If calling Verilator from a makefile, the :vlopt:'-MMD' option will create
+If calling Verilator from a makefile, the :vlopt:`-MMD` option will create
 a dependency file, allowing Make to only run Verilator if input Verilog
 files change.
 

--- a/docs/guide/verilating.rst
+++ b/docs/guide/verilating.rst
@@ -306,7 +306,7 @@ GNU Make
 Verilator defaults to creating GNU Make makefiles for the model.  Verilator
 will call make automatically when the :vlopt:`--build` option is used.
 
-If calling Verilator from a makefile, the :vlopt:`-MMD` option will create
+If calling Verilator from a makefile, the :vlopt:`--MMD` option will create
 a dependency file, allowing Make to only run Verilator if input Verilog
 files change.
 


### PR DESCRIPTION
This PR fixes the issue described in https://github.com/verilator/verilator/issues/5355.

I grepped the docs for the `:.*:'.*'` regex and these are all occurrences which I could find. Adding this grep to the CI might be useful to avoid this in the future.