### PR TITLE
FlexFix changes for successful compile on Mac OS #5360

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -26,6 +26,7 @@ Bartłomiej Chmiel
 Cameron Kirk
 Chih-Mao Chen
 Chris Bachhuber
+Chris Kjellqvist
 Chris Randall
 Christopher Taylor
 Chuxuan Wang

--- a/src/flexfix
+++ b/src/flexfix
@@ -48,13 +48,12 @@ for line in sys.stdin:
     line = re.sub(r'(#line \d+ ".*)_pretmp', r'\1', line)
     # Fix 'register' storage class specifier is deprecated and incompatible with C++17
     line = re.sub(r'register ', '', line)
-    # Fix use of 'int' instead of 'size_t' to match declaration of FlexInput and FlexOutput on Mac OS only
-    if platform.system() == "Darwin":
-        line = re.sub(r"int yyFlexLexer::LexerInput\( char\* buf, int /\* max_size \*/ \)",
-                      "size_t yyFlexLexer::LexerInput( char* buf, size_t /* max_size */ )", line)
-        line = re.sub(r"int yyFlexLexer::LexerInput\( char\* buf, int max_size \)",
-                        "size_t yyFlexLexer::LexerInput( char* buf, size_t max_size )", line)
-        line = re.sub(r"void yyFlexLexer::LexerOutput\( const char\* buf, int size \)",
-                      "void yyFlexLexer::LexerOutput( const char* buf, size_t size )", line)
+    # Force LexerInput/Output types to match those specified by the Flex declaration (might not be int on some platforms)
+    line = re.sub(r"int yyFlexLexer::LexerInput\( char\* buf, int /\* max_size \*/ \)",
+                   "yy_size_t yyFlexLexer::LexerInput( char* buf, yy_size_t /* max_size */ )", line)
+    line = re.sub(r"int yyFlexLexer::LexerInput\( char\* buf, int max_size \)",
+                    "yy_size_t yyFlexLexer::LexerInput( char* buf, yy_size_t max_size )", line)
+    line = re.sub(r"void yyFlexLexer::LexerOutput\( const char\* buf, int size \)",
+                  "void yyFlexLexer::LexerOutput( const char* buf, yy_size_t size )", line)
 
     print(line, end='')

--- a/src/flexfix
+++ b/src/flexfix
@@ -13,6 +13,7 @@
 
 import re
 import sys
+import platform
 
 for line in sys.stdin:
     # Fix flex 2.6.1 warning
@@ -47,5 +48,13 @@ for line in sys.stdin:
     line = re.sub(r'(#line \d+ ".*)_pretmp', r'\1', line)
     # Fix 'register' storage class specifier is deprecated and incompatible with C++17
     line = re.sub(r'register ', '', line)
+    # Fix use of 'int' instead of 'size_t' to match declaration of FlexInput and FlexOutput on Mac OS only
+    if platform.system() == "Darwin":
+        line = re.sub(r"int yyFlexLexer::LexerInput\( char\* buf, int /\* max_size \*/ \)",
+                      "size_t yyFlexLexer::LexerInput( char* buf, size_t /* max_size */ )", line)
+        line = re.sub(r"int yyFlexLexer::LexerInput\( char\* buf, int max_size \)",
+                        "size_t yyFlexLexer::LexerInput( char* buf, size_t max_size )", line)
+        line = re.sub(r"void yyFlexLexer::LexerOutput\( const char\* buf, int size \)",
+                      "void yyFlexLexer::LexerOutput( const char* buf, size_t size )", line)
 
     print(line, end='')


### PR DESCRIPTION
The issue is discussed in #5360. On Mac OS, `int` is used as the size type for `LexerInput` and `LexerOutput` definitions instead of `size_t`. The changes to flexfix only manifest if the platform is "Darwin" because I do not know what effect the changes will have on other platforms that haven't experienced this behavior.

After further builds, I've noticed that sometimes Flex does not need this change and correctly generates the function definitions with `size_t`, but I'm unable to figure out exactly why.