### PR TITLE
Internals: Fix removing nodes in V3Life

### DIFF
--- a/src/V3Life.cpp
+++ b/src/V3Life.cpp
@@ -46,17 +46,17 @@ class LifeState final {
 public:
     VDouble0 m_statAssnDel;  // Statistic tracking
     VDouble0 m_statAssnCon;  // Statistic tracking
-    std::vector<AstNode*> m_unlinkps;
+    std::vector<AstNode*> m_deleteps;
 
     // CONSTRUCTORS
     LifeState() = default;
     ~LifeState() {
         V3Stats::addStatSum("Optimizations, Lifetime assign deletions", m_statAssnDel);
         V3Stats::addStatSum("Optimizations, Lifetime constant prop", m_statAssnCon);
-        for (AstNode* ip : m_unlinkps) VL_DO_DANGLING(ip->unlinkFrBack()->deleteTree(), ip);
+        for (AstNode* ip : m_deleteps) { VL_DO_DANGLING(ip->deleteTree(), ip); }
     }
     // METHODS
-    void pushUnlinkDeletep(AstNode* nodep) { m_unlinkps.push_back(nodep); }
+    void pushDeletep(AstNode* nodep) { m_deleteps.push_back(nodep); }
 };
 
 //######################################################################
@@ -145,7 +145,8 @@ public:
                 // above our current iteration point.
                 if (debug() > 4) oldassp->dumpTree("-      REMOVE/SAMEBLK: ");
                 entp->complexAssign();
-                VL_DO_DANGLING(m_statep->pushUnlinkDeletep(oldassp), oldassp);
+                oldassp->unlinkFrBack();
+                VL_DO_DANGLING(m_statep->pushDeletep(oldassp), oldassp);
                 ++m_statep->m_statAssnDel;
             }
         }

--- a/test_regress/t/t_func_cond.pl
+++ b/test_regress/t/t_func_cond.pl
@@ -1,0 +1,21 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2020 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_func_cond.v
+++ b/test_regress/t/t_func_cond.v
@@ -1,0 +1,26 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2024 by Antmicro.
+// SPDX-License-Identifier: CC0-1.0
+
+module t;
+  function automatic logic func_with_cond(logic x);
+    return x ? func_with_case(0) : 0;
+  endfunction
+
+  function automatic logic func_with_case(logic x);
+    logic result = 1'b0;
+    unique case (1'b0)
+      1'b0: result = x;
+      1'b1: result = x;
+    endcase
+    return result;
+  endfunction
+
+  initial begin
+    if (func_with_cond(0)) $stop;
+    $write("*-* All Finished *-*\n");
+    $finish;
+  end
+endmodule


### PR DESCRIPTION
Currently on master, when a node is classified to be removed, it is added to a vector. A the end of the stage, all nodes on that vector are unlinked and removed. Between adding it to the vector and removing it, V3Const optimizations may take place, which may remove nodes added to the vector. In such a case we get seg fault, because we dereference `nullptr` when we unlink a node from the vector.

I fixed it by unlinking a node at the moment of adding it to the vector. This way V3Const visitor won't access it.
