### PR TITLE
Fix +: and -: unpacked array slicing when array has nonzero low index. (#5345)

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -77,6 +77,7 @@ Iru Cai
 Ivan Vnučec
 Iztok Jeras
 Jake Merdich
+James Bailey
 James Hanlon
 James Hutchinson
 James Pallister

--- a/src/V3WidthSel.cpp
+++ b/src/V3WidthSel.cpp
@@ -551,8 +551,10 @@ class WidthSelVisitor final : public VNVisitor {
                 // down array: msb/hi -: width
                 // up array:   msb/lo +: width
                 // up array:   lsb/hi -: width
-                const int32_t msb = VN_IS(nodep, SelPlus) ? rhs + width - 1 : rhs;
-                const int32_t lsb = VN_IS(nodep, SelPlus) ? rhs : rhs - width + 1;
+                const int32_t msb
+                    = (VN_IS(nodep, SelPlus) ? rhs + width - 1 : rhs) - fromRange.lo();
+                const int32_t lsb
+                    = (VN_IS(nodep, SelPlus) ? rhs : rhs - width + 1) - fromRange.lo();
                 AstSliceSel* const newp = new AstSliceSel{
                     nodep->fileline(), fromp, VNumRange{msb, lsb, fromRange.ascending()}};
                 nodep->replaceWith(newp);

--- a/test_regress/t/t_unpacked_slice.v
+++ b/test_regress/t/t_unpacked_slice.v
@@ -9,45 +9,45 @@
 
 module t (/*AUTOARG*/);
 
-   parameter int sliceddn[7:0] = '{'h100, 'h101, 'h102, 'h103, 'h104, 'h105, 'h106, 'h107};
-   parameter int slicedup[0:7] = '{'h100, 'h101, 'h102, 'h103, 'h104, 'h105, 'h106, 'h107};
+   parameter int sliceddn[4:-3] = '{'h100, 'h101, 'h102, 'h103, 'h104, 'h105, 'h106, 'h107};
+   parameter int slicedup[-3:4] = '{'h100, 'h101, 'h102, 'h103, 'h104, 'h105, 'h106, 'h107};
    int alldn[7:0];
    int allup[0:7];
    int twodn[1:0];
    int twoup[0:1];
 
    initial begin
-      `checkh(sliceddn[7], 'h100);
-      alldn[7:0] = sliceddn[7:0];
+      `checkh(sliceddn[4], 'h100);
+      alldn[7:0] = sliceddn[4:-3];
       `checkh(alldn[7], 'h100);
-      alldn[7:0] = sliceddn[0 +: 8];  // down: lsb/lo +: width
+      alldn[7:0] = sliceddn[-3 +: 8];  // down: lsb/lo +: width
       `checkh(alldn[7], 'h100);
-      alldn[7:0] = sliceddn[7 -: 8];  // down: msb/hi -: width
+      alldn[7:0] = sliceddn[4 -: 8];  // down: msb/hi -: width
       `checkh(alldn[7], 'h100);
-      twodn[1:0] = sliceddn[6:5];
+      twodn[1:0] = sliceddn[3:2];
       `checkh(twodn[1], 'h101);
       `checkh(twodn[0], 'h102);
-      twodn[1:0] = sliceddn[4 +: 2];
+      twodn[1:0] = sliceddn[1 +: 2];
       `checkh(twodn[1], 'h102);
       `checkh(twodn[0], 'h103);
-      twodn[1:0] = sliceddn[4 -: 2];
+      twodn[1:0] = sliceddn[1 -: 2];
       `checkh(twodn[1], 'h103);
       `checkh(twodn[0], 'h104);
 
-      `checkh(slicedup[7], 'h107);
-      allup[0:7] = slicedup[0:7];
+      `checkh(slicedup[4], 'h107);
+      allup[0:7] = slicedup[-3:4];
       `checkh(alldn[7], 'h100);
-      allup[0:7] = slicedup[0 +: 8];  // up: msb/lo +: width
+      allup[0:7] = slicedup[-3 +: 8];  // up: msb/lo +: width
       `checkh(alldn[7], 'h100);
-      allup[0:7] = slicedup[7 -: 8];  // up: lsb/hi -: width
+      allup[0:7] = slicedup[4 -: 8];  // up: lsb/hi -: width
       `checkh(alldn[7], 'h100);
-      twoup[0:1] = slicedup[5:6];
+      twoup[0:1] = slicedup[2:3];
       `checkh(twoup[1], 'h106);
       `checkh(twoup[0], 'h105);
-      twoup[0:1] = slicedup[4 +: 2];
+      twoup[0:1] = slicedup[1 +: 2];
       `checkh(twoup[1], 'h105);
       `checkh(twoup[0], 'h104);
-      twoup[0:1] = slicedup[4 -: 2];
+      twoup[0:1] = slicedup[1 -: 2];
       `checkh(twoup[1], 'h104);
       `checkh(twoup[0], 'h103);
 


### PR DESCRIPTION
Resolves #5345

Subtracts low index of unpacked array from msb & lsb calculations during plus/minus slice replacement. This is necessary when the low index is not zero, and I think was simply missed previously as this may not be a common coding style.

I have updated the existing t_unpacked_slice test so that it defines the source array parameters to have a negative low indices. I believe this should expand test coverage to this particular issue without sacrificing existing coverage. I'm open to this deserving its own test though.

I have done very few pull requests on github so please let me know if I've done something incorrectly here.