### PR TITLE
Internals: Simplify `CaptureVisitor` in `V3Randomize`

### DIFF
--- a/src/V3Randomize.cpp
+++ b/src/V3Randomize.cpp
@@ -799,8 +799,7 @@ class CaptureVisitor final : public VNVisitor {
         const bool refIsXref = VN_IS(varRefp, VarXRef);
         const bool varIsFuncLocal = varRefp->varp()->isFuncLocal();
         const bool varHasAutomaticLifetime = varRefp->varp()->lifetime().isAutomatic();
-        const bool varIsFieldOfCaller
-            = callerClassp && varClassp ? isSuperClassOf(varClassp, callerClassp) : false;
+        const bool varIsFieldOfCaller = AstClass::isClassExtendedFrom(callerClassp, varClassp);
         if (refIsXref) return CaptureMode::CAP_VALUE | CaptureMode::CAP_F_XREF;
         if (varIsFuncLocal && varHasAutomaticLifetime) return CaptureMode::CAP_VALUE;
         // Static var in function (will not be inlined, because it's in class)
@@ -841,17 +840,6 @@ class CaptureVisitor final : public VNVisitor {
         nodep->replaceWith(memberSelp);
         VL_DO_DANGLING(pushDeletep(nodep), nodep);
         m_ignore.emplace(memberSelp);
-    }
-
-    // Returns true if the first class is a superclass of the second class
-    bool isSuperClassOf(AstClass* const classIsp, AstClass* const classOfp) {
-        if (classIsp == classOfp) return true;
-        for (AstClassExtends* extendsp = classOfp->extendsp(); extendsp;
-             extendsp = VN_AS(extendsp->nextp(), ClassExtends)) {
-            AstClass* const superClassp = VN_AS(extendsp->childDTypep(), ClassRefDType)->classp();
-            if (isSuperClassOf(classIsp, superClassp)) return true;
-        }
-        return false;
     }
 
     // VISITORS


### PR DESCRIPTION
Simplifies the `CaptureVisitor` by getting rid of the lookup helper.

1. A BFS isn't needed for finding the 'nearest' superclass that owns a variable because there's only single inheritance in SystemVerilog (interface classes can't have fields),
2. Even if it was, it puts everything in a set, so we don't distinguish between different occurrences of a superclass anyway,
3. I doubt it's worth it to create this set vs. just traversing the class hierarchy every time (which is not many times per inline constraint),
4. The declaring module of a variable (and now also of a task) can be found under `AstVar::user2p()` in `V3Randomize`, so we don't need the `findDeclaringModule()` method.

No functional change intended.