### PR TITLE
Fix infinite recursion due to recursive functions/tasks

### DIFF
--- a/src/V3AstNodes.cpp
+++ b/src/V3AstNodes.cpp
@@ -76,7 +76,12 @@ bool AstNodeFTaskRef::isPure() {
         // cached.
         return false;
     } else {
-        if (!m_purity.isCached()) m_purity.set(this->getPurityRecurse());
+        if (!m_purity.isCached()) {
+            m_purity.set(true);  // To prevent infinite recursion, set to true before getting
+                                 // the actual purity. If there are impure statements in the
+                                 // task/function, they'll taint this call anyway.
+            m_purity.set(this->getPurityRecurse());
+        }
         return m_purity.get();
     }
 }

--- a/test_regress/t/t_infinite_recursion.pl
+++ b/test_regress/t/t_infinite_recursion.pl
@@ -11,7 +11,7 @@ if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); di
 scenarios(vlt => 1);
 
 lint(
-    verilator_flags2 => ["--no-unlimited-stack -Wno-lint"],
+    verilator_flags2 => ["--no-unlimited-stack"],
     );
 
 ok(1);

--- a/test_regress/t/t_infinite_recursion.pl
+++ b/test_regress/t/t_infinite_recursion.pl
@@ -1,0 +1,18 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2023 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(vlt => 1);
+
+lint(
+    verilator_flags2 => ["--no-unlimited-stack -Wno-lint"],
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_infinite_recursion.v
+++ b/test_regress/t/t_infinite_recursion.v
@@ -12,7 +12,7 @@ class cls;
 endclass
 module t;
    cls obj;
-   task t;
+   task static t;
       int _ = obj.randomize() with {1 == 1;};
    endtask
 endmodule

--- a/test_regress/t/t_infinite_recursion.v
+++ b/test_regress/t/t_infinite_recursion.v
@@ -1,0 +1,18 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2024 by Antmicro.
+// SPDX-License-Identifier: CC0-1.0
+
+class cls;
+   task t; t; endtask
+   task pre_randomize;
+      t;
+   endtask
+endclass
+module t;
+   cls obj;
+   task t;
+      int _ = obj.randomize() with {1 == 1;};
+   endtask
+endmodule


### PR DESCRIPTION
Fixes Verilator looping in an infinite recursion in certain cases related to recursive functions/tasks (see test case).