### PR TITLE
Add method to check if there are VPI callbacks of the given type

### DIFF
--- a/include/verilated_vpi.cpp
+++ b/include/verilated_vpi.cpp
@@ -896,6 +896,9 @@ public:
         if (VL_LIKELY(it != s().m_futureCbs.cend())) return it->first.first;
         return ~0ULL;  // maxquad
     }
+    static bool hasCbs(const uint32_t reason) VL_MT_UNSAFE_ONE {
+        return !s().m_cbCurrentLists[reason].empty();
+    }
     static bool callCbs(const uint32_t reason) VL_MT_UNSAFE_ONE {
         VL_DEBUG_IF_PLI(VL_DBG_MSGF("- vpi: callCbs reason=%u\n", reason););
         assertOneCheck();
@@ -1054,6 +1057,10 @@ public:
 
 bool VerilatedVpi::callCbs(uint32_t reason) VL_MT_UNSAFE_ONE {
     return VerilatedVpiImp::callCbs(reason);
+}
+
+bool VerilatedVpi::hasCbs(uint32_t reason) VL_MT_UNSAFE_ONE {
+    return VerilatedVpiImp::hasCbs(reason);
 }
 
 // Historical, before we had multiple kinds of timed callbacks

--- a/include/verilated_vpi.h
+++ b/include/verilated_vpi.h
@@ -49,6 +49,9 @@ public:
     /// Call callbacks of arbitrary types.
     /// User wrapper code should call this from their main loops.
     static bool callCbs(uint32_t reason) VL_MT_UNSAFE_ONE;
+    /// Returns true if there are callbacks of the given reason registered.
+    /// User wrapper code should call this from their main loops.
+    static bool hasCbs(uint32_t reason) VL_MT_UNSAFE_ONE;
     /// Returns time of the next registered VPI callback, or
     /// ~(0ULL) if none are registered
     static QData cbNextDeadline() VL_MT_UNSAFE_ONE;

--- a/test_regress/t/TestVpiMain.cpp
+++ b/test_regress/t/TestVpiMain.cpp
@@ -121,7 +121,7 @@ int main(int argc, char** argv) {
             VerilatedVpi::callCbs(cbReadWriteSynch);
             VerilatedVpi::doInertialPuts();
             settle_value_callbacks();
-        } while (VerilatedVpi::evalNeeded());
+        } while (VerilatedVpi::evalNeeded() || VerilatedVpi::hasCbs(cbReadWriteSynch));
 
         top->eval_end_step();
 


### PR DESCRIPTION
This is necessary for us to determine if we should continue running the current time step.

All implementations of the VPI I've come across allow the user to keep scheduling ReadWrite phases by scheduling cbReadWriteSynch callbacks in ReadWrite phases.

- [x] Add test