### PR TITLE
Fix `foreach` on empty queue under `if` in constraints

### DIFF
--- a/src/V3Randomize.cpp
+++ b/src/V3Randomize.cpp
@@ -695,11 +695,13 @@ class ConstraintExprVisitor final : public VNVisitor {
             AstNode* const cstmtp = new AstText{fl, "ret += \" \" + "};
             cstmtp->addNext(itemp);
             cstmtp->addNext(new AstText{fl, ";"});
-            AstNode* const exprsp = new AstText{fl, "([&]{ std::string ret = \"(bvand\";"};
+            AstNode* const exprsp = new AstText{fl, "([&]{ std::string ret;"};
             exprsp->addNext(new AstBegin{
                 fl, "",
                 new AstForeach{fl, nodep->arrayp()->unlinkFrBack(), new AstCStmt{fl, cstmtp}},
                 false, true});
+            exprsp->addNext(
+                new AstText{fl, "return ret.empty() ? \"#b1\" : \"(bvand \" + ret + \")\";"});
             exprsp->addNext(new AstText{fl, "return ret + \")\"; })()"});
             AstNodeExpr* const newp = new AstCExpr{fl, exprsp};
             newp->dtypeSetString();

--- a/test_regress/t/t_constraint_foreach.v
+++ b/test_regress/t/t_constraint_foreach.v
@@ -32,8 +32,16 @@ endclass
 class D;
    rand bit posit;
    rand int x;
+   int o[$];  // empty
+   int p[$] = {1};
    int q[$] = {0, 0, 0, 0, 0};
    constraint fore {
+      if (posit == 1) {
+         foreach(o[i]) o[i] > 0;
+      }
+      if (posit == 1) {
+         foreach(p[i]) p[i] > 0;
+      }
       if (posit == 1) {
          x < 7;
          foreach(q[i])


### PR DESCRIPTION
Fixes issue where a `foreach` on an empty queue under `if` generates an empty AND expression in SMT-LIB2.