### PR TITLE
Internals: Emit rand constraint right away. No functional change intended.

### DIFF
--- a/include/verilated_random.cpp
+++ b/include/verilated_random.cpp
@@ -303,7 +303,7 @@ void VlRandomizer::randomConstraint(std::ostream& os, VlRNG& rngr, int bits) {
         if (varBits > 2) os << " (bvxor";
         for (const auto& var : m_vars) {
             for (int j = 0; j < var.second->width(); j++, varBitsLeft--) {
-                bool doEmit = VL_RANDOM_RNG_I(rngr) % varBitsLeft < varBitsWant;
+                const bool doEmit = (VL_RANDOM_RNG_I(rngr) % varBitsLeft) < varBitsWant;
                 if (doEmit) {
                     os << " ((_ extract " << j << ' ' << j << ") " << var.second->name() << ')';
                     if (--varBitsWant == 0) break;

--- a/include/verilated_random.cpp
+++ b/include/verilated_random.cpp
@@ -297,7 +297,7 @@ bool VlRandomVar::set(std::string&& val) const {
 }
 
 void VlRandomizer::randomConstraint(std::ostream& os, VlRNG& rngr, int bits) {
-    IData hash = VL_RANDOM_RNG_I(rngr) & ((1 << bits) - 1);
+    const IData hash = VL_RANDOM_RNG_I(rngr) & ((1 << bits) - 1);
     std::vector<std::unique_ptr<const VlRandomExpr>> varbits;
     for (const auto& var : m_vars) {
         for (int i = 0; i < var.second->width(); i++)

--- a/include/verilated_random.h
+++ b/include/verilated_random.h
@@ -33,6 +33,7 @@
 class VlRandomExpr VL_NOT_FINAL {
 public:
     virtual void emit(std::ostream& s) const = 0;
+    virtual ~VlRandomExpr() = default;
 };
 class VlRandomVar final : public VlRandomExpr {
     const char* const m_name;  // Variable name
@@ -55,19 +56,6 @@ public:
     void emit(std::ostream& s) const override;
 };
 
-class VlRandomConst final : public VlRandomExpr {
-    const QData m_val;  // Constant value
-    const int m_width;  // Constant width in bits
-
-public:
-    VlRandomConst(QData val, int width)
-        : m_val{val}
-        , m_width{width} {
-        assert(width <= sizeof(m_val) * 8);
-    }
-    void emit(std::ostream& s) const override;
-};
-
 class VlRandomExtract final : public VlRandomExpr {
     const std::shared_ptr<const VlRandomExpr> m_expr;  // Sub-expression
     const unsigned m_idx;  // Extracted index
@@ -76,19 +64,6 @@ public:
     VlRandomExtract(std::shared_ptr<const VlRandomExpr> expr, unsigned idx)
         : m_expr{expr}
         , m_idx{idx} {}
-    void emit(std::ostream& s) const override;
-};
-
-class VlRandomBinOp final : public VlRandomExpr {
-    const char* const m_op;  // Binary operation identifier
-    const std::shared_ptr<const VlRandomExpr> m_lhs, m_rhs;  // Sub-expressions
-
-public:
-    VlRandomBinOp(const char* op, std::shared_ptr<const VlRandomExpr> lhs,
-                  std::shared_ptr<const VlRandomExpr> rhs)
-        : m_op{op}
-        , m_lhs{lhs}
-        , m_rhs{rhs} {}
     void emit(std::ostream& s) const override;
 };
 
@@ -103,7 +78,7 @@ class VlRandomizer final {
     const VlQueue<CData>* m_randmode;  // rand_mode state;
 
     // PRIVATE METHODS
-    std::shared_ptr<const VlRandomExpr> randomConstraint(VlRNG& rngr, int bits);
+    void randomConstraint(std::ostream& os, VlRNG& rngr, int bits);
     bool parseSolution(std::iostream& file);
 
 public:

--- a/include/verilated_random.h
+++ b/include/verilated_random.h
@@ -30,12 +30,7 @@
 //=============================================================================
 // VlRandomExpr and subclasses represent expressions for the constraint solver.
 
-class VlRandomExpr VL_NOT_FINAL {
-public:
-    virtual void emit(std::ostream& s) const = 0;
-    virtual ~VlRandomExpr() = default;
-};
-class VlRandomVar final : public VlRandomExpr {
+class VlRandomVar final {
     const char* const m_name;  // Variable name
     void* const m_datap;  // Reference to variable data
     const int m_width;  // Variable width in bits
@@ -53,18 +48,6 @@ public:
     std::uint32_t randModeIdx() const { return m_randModeIdx; }
     bool randModeIdxNone() const { return randModeIdx() == std::numeric_limits<unsigned>::max(); }
     bool set(std::string&&) const;
-    void emit(std::ostream& s) const override;
-};
-
-class VlRandomExtract final : public VlRandomExpr {
-    const std::shared_ptr<const VlRandomExpr> m_expr;  // Sub-expression
-    const unsigned m_idx;  // Extracted index
-
-public:
-    VlRandomExtract(std::shared_ptr<const VlRandomExpr> expr, unsigned idx)
-        : m_expr{expr}
-        , m_idx{idx} {}
-    void emit(std::ostream& s) const override;
 };
 
 //=============================================================================
@@ -94,6 +77,7 @@ public:
                    std::uint32_t randmodeIdx = std::numeric_limits<std::uint32_t>::max()) {
         auto it = m_vars.find(name);
         if (it != m_vars.end()) return;
+        // TODO: make_unique once VlRandomizer is per-instance not per-ref
         m_vars[name] = std::make_shared<const VlRandomVar>(name, width, &var, randmodeIdx);
     }
     void hard(std::string&& constraint);


### PR DESCRIPTION
This change gets rid of most of the shared pointers and useless memory allocations during constrained randomization.  Also takes advantage of higher-arity bvxor/concat to reduce amount of data sent to the solver.