### PR TITLE
Basic constrained queue randomization

### DIFF
--- a/test_regress/t/t_randomize_method_types_unsup.out
+++ b/test_regress/t/t_randomize_method_types_unsup.out
@@ -1,11 +1,16 @@
-%Error-UNSUPPORTED: t/t_randomize_method_types_unsup.v:14:25: Unsupported: random member variable with type 'int$[]'
+%Warning-CONSTRAINTIGN: t/t_randomize_method_types_unsup.v:14:32: Unsupported: randomizing this expression, treating as state
    14 |    constraint dynsize { dynarr.size < 20; }
-      |                         ^~~~~~
-                    ... For error description see https://verilator.org/warn/UNSUPPORTED?v=latest
+      |                                ^~~~
+                        ... For warning description see https://verilator.org/warn/CONSTRAINTIGN?v=latest
+                        ... Use "/* verilator lint_off CONSTRAINTIGN */" and lint_on around source to disable this message.
 %Error-UNSUPPORTED: t/t_randomize_method_types_unsup.v:8:13: Unsupported: random member variable with type 'int$[string]'
                                                            : ... note: In instance 't'
     8 |    rand int assocarr[string];
       |             ^~~~~~~~
+%Error-UNSUPPORTED: t/t_randomize_method_types_unsup.v:9:13: Unsupported: random member variable with type 'int$[]'
+                                                           : ... note: In instance 't'
+    9 |    rand int dynarr[];
+      |             ^~~~~~
 %Error-UNSUPPORTED: t/t_randomize_method_types_unsup.v:10:13: Unsupported: random member variable with type 'int$[0:4]'
                                                             : ... note: In instance 't'
    10 |    rand int unpackarr[5];

--- a/test_regress/t/t_randomize_queue_constraints.py
+++ b/test_regress/t/t_randomize_queue_constraints.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2024 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+if not test.have_solver:
+    test.skip("No constraint solver installed")
+
+test.compile()
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_randomize_queue_constraints.v
+++ b/test_regress/t/t_randomize_queue_constraints.v
@@ -1,0 +1,50 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2024 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+`define check_rand(cl, field, cond) \
+begin \
+   longint prev_result; \
+   int ok = 0; \
+   for (int i = 0; i < 10; i++) begin \
+      longint result; \
+      if (!bit'(cl.randomize())) $stop; \
+      result = longint'(field); \
+      if (!(cond)) $stop; \
+      if (i > 0 && result != prev_result) ok = 1; \
+      prev_result = result; \
+   end \
+   if (ok != 1) $stop; \
+end
+
+class Foo;
+  rand int m_intQueue[$];
+  rand int m_idx;
+
+  function new;
+    m_intQueue = '{10{0}};
+  endfunction
+
+  constraint int_queue_c {
+    m_idx inside {[0:9]};
+    m_intQueue[m_idx] == m_idx + 1;
+    foreach (m_intQueue[i]) {
+      m_intQueue[i] inside {[0:127]};
+    }
+  }
+endclass
+
+module t_randomize_queue_constraints;
+  initial begin
+    Foo foo = new;
+
+    `check_rand(foo, foo.m_idx, foo.m_idx inside {[0:9]} && foo.m_intQueue[foo.m_idx] == foo.m_idx + 1);
+    $display("Queue: %p", foo.m_intQueue);
+    `check_rand(foo, foo.m_intQueue[3], foo.m_intQueue[5] inside {[0:127]});
+    $display("Queue: %p", foo.m_intQueue);
+    $write("*-* All Finished *-*\n");
+    $finish;
+  end
+endmodule


### PR DESCRIPTION
This change takes advantage of [QF_ABV](https://smt-lib.org/logics-all.shtml#QF_ABV) logic, which extends [QF_BV](https://smt-lib.org/logics-all.shtml#QF_BV) with [ArraysEx](https://smt-lib.org/theories-ArraysEx.shtml) theory (supported in all of Z3, CVC4 and CVC5). This allows for result-dependent indices in particular, and can be further extended to randomization of associative arrays if needed in the future.

Note that non-constrained queues still report an error of unsupported data type. As is getting a random index of a non-rand queue.