### PR TITLE
Fix capturing params in `randomize() with` (#5416)

### DIFF
--- a/src/V3Randomize.cpp
+++ b/src/V3Randomize.cpp
@@ -865,8 +865,10 @@ class CaptureVisitor final : public VNVisitor {
         const bool varIsFuncLocal = varRefp->varp()->isFuncLocal();
         const bool varHasAutomaticLifetime = varRefp->varp()->lifetime().isAutomatic();
         const bool varIsFieldOfCaller = AstClass::isClassExtendedFrom(callerClassp, varClassp);
+        const bool varIsParam = varRefp->varp()->isParam();
         if (refIsXref) return CaptureMode::CAP_VALUE | CaptureMode::CAP_F_XREF;
         if (varIsFuncLocal && varHasAutomaticLifetime) return CaptureMode::CAP_VALUE;
+        if (varIsParam) return CaptureMode::CAP_VALUE;
         // Static var in function (will not be inlined, because it's in class)
         if (callerIsClass && varIsFuncLocal) return CaptureMode::CAP_VALUE;
         if (callerIsClass && varIsFieldOfCaller) return CaptureMode::CAP_THIS;

--- a/test_regress/t/t_randomize_method_with_scoping.v
+++ b/test_regress/t/t_randomize_method_with_scoping.v
@@ -10,9 +10,7 @@ endclass
 class c2;
 	rand int c2_f;
 endclass
-package pkg;
-   localparam int PARAM = 42;
-endpackage
+localparam int PARAM = 42;
 class Cls;
    rand int x;
    rand enum {
@@ -41,7 +39,6 @@ class SubB extends Cls;
    int z;
 endclass
 class SubC extends SubB;
-   import pkg::*;
    c2 e = new;
    rand enum {
       AMBIG,

--- a/test_regress/t/t_randomize_method_with_scoping.v
+++ b/test_regress/t/t_randomize_method_with_scoping.v
@@ -10,7 +10,9 @@ endclass
 class c2;
 	rand int c2_f;
 endclass
-
+package pkg;
+   localparam int PARAM = 42;
+endpackage
 class Cls;
    rand int x;
    rand enum {
@@ -39,6 +41,7 @@ class SubB extends Cls;
    int z;
 endclass
 class SubC extends SubB;
+   import pkg::*;
    c2 e = new;
    rand enum {
       AMBIG,
@@ -79,6 +82,10 @@ class SubC extends SubB;
       doit &= f.randomize() with { en == AMBIG; };
       if (doit != 1) $stop;
       if (f.en != SubA::AMBIG) $stop;
+
+      doit &= f.randomize() with { x == PARAM; };
+      if (doit != 1) $stop;
+      if (f.x != PARAM) $stop;
 
       f.en = SubA::ONE_A;
       doit &= f.randomize() with { en == ONE_A; };


### PR DESCRIPTION
Fixes #5416.