### PR TITLE
sformatf internal error

### DIFF
--- a/src/V3LinkResolve.cpp
+++ b/src/V3LinkResolve.cpp
@@ -76,12 +76,14 @@ class LinkResolveVisitor final : public VNVisitor {
         }
     }
     void visit(AstInitialAutomatic* nodep) override {
-        iterateChildren(nodep);
         // Initial assignments under function/tasks can just be simple
         // assignments without the initial
         if (m_ftaskp) {
             nodep->replaceWith(nodep->stmtsp()->unlinkFrBackWithNext());
             VL_DO_DANGLING(pushDeletep(nodep), nodep);
+        } else {
+            // No need for this if a parent function/task is already iterating
+            iterateChildren(nodep);
         }
     }
     void visit(AstNodeCoverOrAssert* nodep) override {

--- a/src/V3LinkResolve.cpp
+++ b/src/V3LinkResolve.cpp
@@ -76,14 +76,12 @@ class LinkResolveVisitor final : public VNVisitor {
         }
     }
     void visit(AstInitialAutomatic* nodep) override {
+        iterateChildren(nodep);
         // Initial assignments under function/tasks can just be simple
         // assignments without the initial
         if (m_ftaskp) {
             nodep->replaceWith(nodep->stmtsp()->unlinkFrBackWithNext());
             VL_DO_DANGLING(pushDeletep(nodep), nodep);
-        } else {
-            // No need for this if a parent function/task is already iterating
-            iterateChildren(nodep);
         }
     }
     void visit(AstNodeCoverOrAssert* nodep) override {
@@ -378,6 +376,7 @@ class LinkResolveVisitor final : public VNVisitor {
         expectFormat(nodep, nodep->text(), nodep->exprsp(), true);
     }
     void visit(AstSFormatF* nodep) override {
+        if (nodep->user2SetOnce()) return;
         iterateChildren(nodep);
         // Cleanup old-school displays without format arguments
         if (!nodep->hasFormat()) {

--- a/test_regress/t/t_initial_assign_sformatf.pl
+++ b/test_regress/t/t_initial_assign_sformatf.pl
@@ -1,0 +1,21 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2003 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_initial_assign_sformatf.v
+++ b/test_regress/t/t_initial_assign_sformatf.v
@@ -1,0 +1,32 @@
+// DESCRIPTION: Verilator: SystemVerilog interface test module
+//
+// This file ONLY is placed into the Public Domain, for any use,
+// without warranty, 2012 by Iztok Jeras.
+// SPDX-License-Identifier: CC0-1.0
+
+interface intf();
+
+   function automatic string get_scope;
+      string the_scope = $sformatf("%m");
+      return the_scope;
+   endfunction
+
+   initial $display(get_scope());
+endinterface
+
+module t (/*AUTOARG*/
+   // Inputs
+   clk
+   );
+
+   input clk;
+
+   // finish report
+   always @ (posedge clk) begin
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end
+
+   intf the_intf();
+
+endmodule

--- a/test_regress/t/t_initial_assign_sformatf_debug.pl
+++ b/test_regress/t/t_initial_assign_sformatf_debug.pl
@@ -1,0 +1,24 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2003 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+top_filename("t/t_initial_assign_sformatf.v");
+
+compile(
+    verilator_flags2 => ['--debug'],
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;


### PR DESCRIPTION
This problem only occurs when run with `--debug`.  The problem is that `AstSFormatF::scopeNamep()` is being called twice on the same node.  If I understand correctly, this is happening because in when visiting `INITIALAUTOMATIC` in `linkResolve()`:
```
    void visit(AstInitialAutomatic* nodep) override {
        iterateChildren(nodep);
        // Initial assignments under function/tasks can just be simple
        // assignments without the initial
        if (m_ftaskp) {
            nodep->replaceWith(nodep->stmtsp()->unlinkFrBackWithNext());
            VL_DO_DANGLING(pushDeletep(nodep), nodep);
        }
    }
```

we replace the `INITIALAUTOMATIC` with `stmtsp` after iterating the children.  The problem is that the parent, `FUNC` in this case, is already iterating so the `SFORMATF` gets visited twice.

My fix appears to work, but I am not certain it is safe.  Can we assume that the `stmtsp` that replaces the `AstInitialAutomatic` will always be iterated by the ongoing `iterateChildren()` in the `AstNodeFTask` visitor?
