### PR TITLE
Fix clearing trigger of events with no sentrees

### DIFF
--- a/src/V3EmitCSyms.cpp
+++ b/src/V3EmitCSyms.cpp
@@ -550,21 +550,18 @@ void EmitCSyms::emitSymHdr() {
 
     if (v3Global.hasEvents()) {
         if (v3Global.assignsEvents()) {
-            puts("void enqueueTriggeredEventForClearing(VlAssignableEvent& event) {\n");
+            puts("void fireEvent(VlAssignableEvent& event) {\n");
         } else {
-            puts("void enqueueTriggeredEventForClearing(VlEvent& event) {\n");
+            puts("void fireEvent(VlEvent& event) {\n");
         }
-        puts("#ifdef VL_DEBUG\n");
-        puts("if (VL_UNLIKELY(!event.isTriggered())) {\n");
-        puts("VL_FATAL_MT(__FILE__, __LINE__, __FILE__, \"event passed to "
-             "'enqueueTriggeredEventForClearing' was not triggered\");\n");
-        puts("}\n");
-        puts("#endif\n");
+        puts("if (VL_LIKELY(!event.isTriggered())) {\n");
         if (v3Global.assignsEvents()) {
             puts("__Vm_triggeredEvents.push_back(event);\n");
         } else {
             puts("__Vm_triggeredEvents.push_back(&event);\n");
         }
+        puts("}\n");
+        puts("event.fire();\n");
         puts("}\n");
         puts("void clearTriggeredEvents() {\n");
         if (v3Global.assignsEvents()) {

--- a/src/V3SenExprBuilder.h
+++ b/src/V3SenExprBuilder.h
@@ -192,14 +192,6 @@ class SenExprBuilder final {
                 AstCMethodHard* const clearp = new AstCMethodHard{flp, currp(), "clearFired"};
                 clearp->dtypeSetVoid();
                 ifp->addThensp(clearp->makeStmt());
-
-                // Enqueue for clearing 'triggered' state on next eval
-                AstTextBlock* const blockp = new AstTextBlock{flp};
-                ifp->addThensp(blockp);
-                const auto add = [&](const string& text) { blockp->addText(flp, text, true); };
-                add("vlSymsp->enqueueTriggeredEventForClearing(");
-                blockp->addNodesp(currp());
-                add(");\n");
             }
 
             // Get 'fired' state

--- a/test_regress/t/t_event.v
+++ b/test_regress/t/t_event.v
@@ -18,6 +18,7 @@ module t(/*AUTOARG*/
 
    event e1;
    event e2;
+   event e3;
 `ifndef IVERILOG
    event ev [3:0];
 `endif
@@ -50,16 +51,21 @@ module t(/*AUTOARG*/
             if (last_event != 0) $stop;
             -> e1;
             if (!e1.triggered) $stop;
+            if (e3.triggered) $stop;
+            -> e3;
+            if (!e3.triggered) $stop;
          end
          11: begin
             if (last_event != 32'b10) $stop;
             last_event = 0;
+            if (e3.triggered) $stop;
          end
          //
          13: begin
             if (last_event != 0) $stop;
             ->> e2;
             if (e2.triggered) $stop;
+            if (e3.triggered) $stop;
          end
          14: begin
             if (last_event != 32'b100) $stop;


### PR DESCRIPTION
Previously `e3` from the added test would stay triggered indefinitely.