### PR TITLE
Fix driving clocking block in Reactive phase

### DIFF
--- a/src/V3AstNodeOther.h
+++ b/src/V3AstNodeOther.h
@@ -961,6 +961,7 @@ public:
     std::string name() const override VL_MT_STABLE { return m_name; }
     bool isDefault() const { return m_isDefault; }
     bool isGlobal() const { return m_isGlobal; }
+    AstVar* ensureEventp(bool childDType = false);
 };
 class AstClockingItem final : public AstNode {
     // Parents:  CLOCKING

--- a/src/V3LinkDot.cpp
+++ b/src/V3LinkDot.cpp
@@ -2267,22 +2267,7 @@ class LinkDotResolveVisitor final : public VNVisitor {
         }
     }
     VSymEnt* getCreateClockingEventSymEnt(AstClocking* clockingp) {
-        if (!clockingp->eventp()) {
-            AstVar* const eventp = new AstVar{
-                clockingp->fileline(), VVarType::MODULETEMP, clockingp->name(), VFlagChildDType{},
-                new AstBasicDType{clockingp->fileline(), VBasicDTypeKwd::EVENT}};
-            eventp->lifetime(VLifetime::STATIC);
-            clockingp->eventp(eventp);
-            // Trigger the clocking event in Observed (IEEE 1800-2023 14.13)
-            clockingp->addNextHere(new AstAlwaysObserved{
-                clockingp->fileline(),
-                new AstSenTree{clockingp->fileline(), clockingp->sensesp()->cloneTree(false)},
-                new AstFireEvent{clockingp->fileline(),
-                                 new AstVarRef{clockingp->fileline(), eventp, VAccess::WRITE},
-                                 false}});
-            v3Global.setHasEvents();
-        }
-        AstVar* const eventp = clockingp->eventp();
+        AstVar* const eventp = clockingp->ensureEventp(true);
         if (!eventp->user1p()) eventp->user1p(new VSymEnt{m_statep->symsp(), eventp});
         return reinterpret_cast<VSymEnt*>(eventp->user1p());
     }

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -2911,27 +2911,8 @@ class WidthVisitor final : public VNVisitor {
             if (memberSelClass(nodep, adtypep)) return;
         } else if (AstIfaceRefDType* const adtypep = VN_CAST(fromDtp, IfaceRefDType)) {
             if (AstNode* foundp = memberSelIface(nodep, adtypep)) {
-                if (AstClocking* const clockingp = VN_CAST(foundp, Clocking)) {
-                    foundp = clockingp->eventp();
-                    if (!foundp) {
-                        AstVar* const eventp = new AstVar{
-                            clockingp->fileline(), VVarType::MODULETEMP, clockingp->name(),
-                            clockingp->findBasicDType(VBasicDTypeKwd::EVENT)};
-                        eventp->lifetime(VLifetime::STATIC);
-                        clockingp->eventp(eventp);
-                        // Trigger the clocking event in Observed (IEEE 1800-2023 14.13)
-                        clockingp->addNextHere(new AstAlwaysObserved{
-                            clockingp->fileline(),
-                            new AstSenTree{clockingp->fileline(),
-                                           clockingp->sensesp()->cloneTree(false)},
-                            new AstFireEvent{
-                                clockingp->fileline(),
-                                new AstVarRef{clockingp->fileline(), eventp, VAccess::WRITE},
-                                false}});
-                        v3Global.setHasEvents();
-                        foundp = eventp;
-                    }
-                }
+                if (AstClocking* const clockingp = VN_CAST(foundp, Clocking))
+                    foundp = clockingp->ensureEventp();
                 if (AstVar* const varp = VN_CAST(foundp, Var)) {
                     if (!varp->didWidth()) userIterate(varp, nullptr);
                     nodep->dtypep(foundp->dtypep());

--- a/test_regress/t/t_clocking_react.pl
+++ b/test_regress/t/t_clocking_react.pl
@@ -1,0 +1,21 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2024 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(vlt => 1);
+
+compile(
+    verilator_flags2 => ["--exe --main --timing"],
+    );
+
+execute(
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_clocking_react.v
+++ b/test_regress/t/t_clocking_react.v
@@ -1,0 +1,42 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2024 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+interface axi_if;
+   logic clk;
+   wire  rlast;
+   wire  rvalid;
+   clocking cb @(posedge clk);
+      inout rlast, rvalid;
+   endclocking
+endinterface
+
+module t;
+   axi_if axi_vi();
+   initial begin
+      axi_vi.clk = 1'b0;
+      #1 axi_vi.clk = 1'b1; // triggers line 26
+      #1 axi_vi.clk = 1'b0; // triggers line 29 (shouldn't happen)
+      #1 axi_vi.clk = 1'b1; // triggers line 18 (shouldn't happen)
+   end
+   initial begin
+      @(negedge axi_vi.rvalid);
+      $display("[%0t] rvalid==%b", $time, axi_vi.rvalid);
+      $display("[%0t] rlast is 1: ", $time, axi_vi.rlast === 1);
+      if (axi_vi.rlast === 1) $stop;
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end
+   initial begin
+      $display("[%0t] rvalid <= 1", $time);
+      axi_vi.cb.rvalid <= 1'b1; // assigned on first clk posedge (line 13)
+      @(posedge axi_vi.rvalid);
+      $display("[%0t] rvalid <= 0", $time);
+      axi_vi.cb.rvalid <= 1'b0; // assigned on second clk posedge (line 15), but should be on first
+      @(negedge axi_vi.clk);
+      $display("[%0t] rlast <= 1", $time);
+      axi_vi.cb.rlast <= 1'b1;  // assigned on second clk posedge (line 15), shouldn't happen
+   end
+endmodule


### PR DESCRIPTION
Whenever no-delay output clocking variables for a signal were driven in response to the signal changing, they failed to propagate the value to the signal in the same time slot, therefore waiting until the following clocking event. This change ensures that the signal assignment reacts to clockvar changes during a clocking event.

The first refactor commit can be split to a separate PR if desired.