### PR TITLE
Add basic support for dist constraints

### DIFF
--- a/src/V3Randomize.cpp
+++ b/src/V3Randomize.cpp
@@ -640,11 +640,6 @@ class ConstraintExprVisitor final : public VNVisitor {
         // Fall back to "(ite cond then else)"
         visit(static_cast<AstNodeTriop*>(nodep));
     }
-    void visit(AstDist* nodep) override {
-        nodep->v3warn(CONSTRAINTIGN, "Constraint expression ignored (unsupported)");
-        nodep->replaceWith(new AstSFormatF{nodep->fileline(), "true", false, nullptr});
-        VL_DO_DANGLING(nodep->deleteTree(), nodep);
-    }
     void visit(AstReplicate* nodep) override {
         // Biop, but RHS is harmful
         if (editFormat(nodep)) return;
@@ -720,7 +715,7 @@ class ConstraintExprVisitor final : public VNVisitor {
         VL_DO_DANGLING(nodep->deleteTree(), nodep);
     }
     void visit(AstConstraintBefore* nodep) override {
-        nodep->v3warn(CONSTRAINTIGN, "Constraint expression ignored (unsupported)");
+        nodep->v3warn(CONSTRAINTIGN, "Constraint expression ignored (imperfect distribution)");
         VL_DO_DANGLING(nodep->unlinkFrBack()->deleteTree(), nodep);
     }
     void visit(AstConstraintUnique* nodep) override {

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -2715,7 +2715,7 @@ class WidthVisitor final : public VNVisitor {
         AstNodeExpr* newp = nullptr;
         for (AstNodeExpr *nextip, *itemp = nodep->itemsp(); itemp; itemp = nextip) {
             nextip = VN_AS(itemp->nextp(), NodeExpr);  // Will be unlinking
-            AstNodeExpr* inewp = insideItem(nodep, nodep->exprp(), itemp);
+            AstNodeExpr* const inewp = insideItem(nodep, nodep->exprp(), itemp);
             if (!inewp) continue;
             newp = newp ? new AstLogOr{nodep->fileline(), newp, inewp} : inewp;
         }
@@ -2733,8 +2733,8 @@ class WidthVisitor final : public VNVisitor {
         } else if (VN_IS(itemDtp, UnpackArrayDType) || VN_IS(itemDtp, DynArrayDType)
                    || VN_IS(itemDtp, QueueDType)) {
             // Unsupported in parameters
-            AstNodeExpr* cexprp = exprp->cloneTreePure(true);
-            AstNodeExpr* inewp
+            AstNodeExpr* const cexprp = exprp->cloneTreePure(true);
+            AstNodeExpr* const inewp
                 = new AstCMethodHard{nodep->fileline(), itemp->unlinkFrBack(), "inside", cexprp};
             iterateCheckTyped(nodep, "inside value", cexprp, itemDtp->subDTypep(), BOTH);
             VL_DANGLING(cexprp);  // Might have been replaced

--- a/test_regress/t/t_constraint_dist.py
+++ b/test_regress/t/t_constraint_dist.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2024 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+if not test.have_solver:
+    test.skip("No constraint solver installed")
+
+test.compile(verilator_flags2=['-Wno-CONSTRAINTIGN'])
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_constraint_dist.v
+++ b/test_regress/t/t_constraint_dist.v
@@ -1,0 +1,39 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2024 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+`define check_rand(cl, field, cond) \
+begin \
+   longint prev_result; \
+   int ok = 0; \
+   for (int i = 0; i < 10; i++) begin \
+      longint result; \
+      if (!bit'(cl.randomize())) $stop; \
+      result = longint'(field); \
+      if (!(cond)) $stop; \
+      if (i > 0 && result != prev_result) ok = 1; \
+      prev_result = result; \
+   end \
+   if (ok != 1) $stop; \
+end
+
+class C;
+   rand int x, y;
+   constraint distrib {
+      x dist { [1:3] := 0, [5:6], [9:15] :/ 0 };
+      y dist { [1:3] := 0, 5, 6 := 8, [9:15] :/ 0 };
+      x < 20;
+   };
+endclass
+
+module t;
+   initial begin
+      C c = new;
+      `check_rand(c, c.x, 5 <= c.x && c.x <= 6);
+      `check_rand(c, c.y, 5 <= c.y && c.y <= 6);
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end
+endmodule

--- a/test_regress/t/t_constraint_dist_unsup.out
+++ b/test_regress/t/t_constraint_dist_unsup.out
@@ -1,0 +1,17 @@
+%Warning-CONSTRAINTIGN: t/t_constraint_dist_unsup.v:27:10: Constraint expression ignored (imperfect distribution)
+                                                         : ... note: In instance 't'
+   27 |        x dist {que};
+      |          ^~~~
+                        ... For warning description see https://verilator.org/warn/CONSTRAINTIGN?v=latest
+                        ... Use "/* verilator lint_off CONSTRAINTIGN */" and lint_on around source to disable this message.
+%Warning-CONSTRAINTIGN: t/t_constraint_dist_unsup.v:28:10: Constraint expression ignored (imperfect distribution)
+                                                         : ... note: In instance 't'
+   28 |        y dist {arr};
+      |          ^~~~
+%Warning-CONSTRAINTIGN: t/t_constraint_dist_unsup.v:27:10: Unsupported: randomizing this expression, treating as state
+   27 |        x dist {que};
+      |          ^~~~
+%Warning-CONSTRAINTIGN: t/t_constraint_dist_unsup.v:28:10: Unsupported: randomizing this expression, treating as state
+   28 |        y dist {arr};
+      |          ^~~~
+%Error: Exiting due to

--- a/test_regress/t/t_constraint_dist_unsup.py
+++ b/test_regress/t/t_constraint_dist_unsup.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2024 by Wilson Snyder. This program is free software; you can
+# redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('linter')
+
+test.lint(fails=test.vlt_all, expect_filename=test.golden_filename)
+
+test.passes()

--- a/test_regress/t/t_constraint_dist_unsup.v
+++ b/test_regress/t/t_constraint_dist_unsup.v
@@ -1,0 +1,40 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2024 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+`define check_rand(cl, field, cond) \
+begin \
+   longint prev_result; \
+   int ok = 0; \
+   for (int i = 0; i < 10; i++) begin \
+      longint result; \
+      if (!bit'(cl.randomize())) $stop; \
+      result = longint'(field); \
+      if (!(cond)) $stop; \
+      if (i > 0 && result != prev_result) ok = 1; \
+      prev_result = result; \
+   end \
+   if (ok != 1) $stop; \
+end
+
+class C;
+   int que[$] = '{3, 4, 5};
+   int arr[3] = '{5, 6, 7};
+   rand int x, y;
+   constraint distrib {
+       x dist {que};
+       y dist {arr};
+   };
+endclass
+
+module t;
+   initial begin
+      C c = new;
+      `check_rand(c, c.x, 3 <= c.x && c.x <= 5);
+      `check_rand(c, c.y, 5 <= c.y && c.y <= 7);
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end
+endmodule

--- a/test_regress/t/t_randomize.out
+++ b/test_regress/t/t_randomize.out
@@ -1,4 +1,4 @@
-%Warning-CONSTRAINTIGN: t/t_randomize.v:22:14: Constraint expression ignored (unsupported)
+%Warning-CONSTRAINTIGN: t/t_randomize.v:22:14: Constraint expression ignored (imperfect distribution)
                                              : ... note: In instance 't'
    22 |       length dist { [0:1], [2:5] :/ 2, 6 := 6, 7 := 10, 1};
       |              ^~~~
@@ -8,7 +8,7 @@
                                             : ... note: In instance 't'
    40 |       unique { array[0], array[1] };
       |       ^~~~~~
-%Warning-CONSTRAINTIGN: t/t_randomize.v:43:23: Constraint expression ignored (unsupported)
+%Warning-CONSTRAINTIGN: t/t_randomize.v:43:23: Constraint expression ignored (imperfect distribution)
                                              : ... note: In instance 't'
    43 |    constraint order { solve length before header; }
       |                       ^~~~~


### PR DESCRIPTION
This implementation only excludes items with zero weights, but it can already be useful, for example when something explicitly weighed to zero is an invalid value that breaks the design.

It does not implement any actual random distribution. Should we warn about this?