### PR TITLE
Fix randomize treated as std::randomize in classes

### DIFF
--- a/src/V3LinkResolve.cpp
+++ b/src/V3LinkResolve.cpp
@@ -113,14 +113,7 @@ class LinkResolveVisitor final : public VNVisitor {
         // NodeTask: Remember its name for later resolution
         if (m_underGenerate) nodep->underGenerate(true);
         // Remember the existing symbol table scope
-        if (m_classp) {
-            if (nodep->name() == "randomize" || nodep->name() == "srandom") {
-                nodep->v3error(nodep->prettyNameQ()
-                               << " is a predefined class method; redefinition not allowed"
-                                  " (IEEE 1800-2023 18.6.3)");
-            }
-            nodep->classMethod(true);
-        }
+        if (m_classp) nodep->classMethod(true);
         // V3LinkDot moved the isExternDef into the class, the extern proto was
         // checked to exist, and now isn't needed
         nodep->isExternDef(false);

--- a/src/V3Randomize.cpp
+++ b/src/V3Randomize.cpp
@@ -2025,20 +2025,26 @@ void V3Randomize::randomizeNetlist(AstNetlist* nodep) {
 }
 
 AstFunc* V3Randomize::newRandomizeFunc(VMemberMap& memberMap, AstClass* nodep,
-                                       const std::string& name, bool allowVirtual) {
+                                       const std::string& name, bool allowVirtual,
+                                       bool childDType) {
     AstFunc* funcp = VN_AS(memberMap.findMember(nodep, name), Func);
     if (!funcp) {
         v3Global.useRandomizeMethods(true);
         AstNodeDType* const dtypep
-            = nodep->findBitDType(32, 32, VSigning::SIGNED);  // IEEE says int return of 0/1
-        AstVar* const fvarp = new AstVar{nodep->fileline(), VVarType::MEMBER, name, dtypep};
+            = childDType
+                  ? new AstBasicDType{nodep->fileline(), VBasicDTypeKwd::INT}
+                  : nodep->findBitDType(32, 32, VSigning::SIGNED);  // IEEE says int return of 0/1
+        AstVar* const fvarp = childDType
+                                  ? new AstVar{nodep->fileline(), VVarType::MEMBER, name,
+                                               VFlagChildDType{}, dtypep}
+                                  : new AstVar{nodep->fileline(), VVarType::MEMBER, name, dtypep};
         fvarp->lifetime(VLifetime::AUTOMATIC);
         fvarp->funcLocal(true);
         fvarp->funcReturn(true);
         fvarp->direction(VDirection::OUTPUT);
         nodep->addMembersp(funcp);
         funcp = new AstFunc{nodep->fileline(), name, nullptr, fvarp};
-        funcp->dtypep(dtypep);
+        if (!childDType) funcp->dtypep(dtypep);
         funcp->classMethod(true);
         funcp->isVirtual(allowVirtual && nodep->isExtended());
         nodep->addMembersp(funcp);

--- a/src/V3Randomize.cpp
+++ b/src/V3Randomize.cpp
@@ -1703,6 +1703,7 @@ class RandomizeVisitor final : public VNVisitor {
         iterateChildren(nodep);
         if (!nodep->user1()) return;  // Doesn't need randomize, or already processed
         UINFO(9, "Define randomize() for " << nodep << endl);
+        nodep->baseMostClassp()->needRNG(true);
         AstFunc* const randomizep = V3Randomize::newRandomizeFunc(m_memberMap, nodep);
         AstVar* const fvarp = VN_AS(randomizep->fvarp(), Var);
         addPrePostCall(nodep, randomizep, "pre_randomize");
@@ -2042,8 +2043,6 @@ AstFunc* V3Randomize::newRandomizeFunc(VMemberMap& memberMap, AstClass* nodep,
         funcp->isVirtual(allowVirtual && nodep->isExtended());
         nodep->addMembersp(funcp);
         memberMap.insert(nodep, funcp);
-        AstClass* const basep = nodep->baseMostClassp();
-        basep->needRNG(true);
     }
     return funcp;
 }

--- a/src/V3Randomize.h
+++ b/src/V3Randomize.h
@@ -32,7 +32,8 @@ public:
 
     static AstFunc* newRandomizeFunc(VMemberMap& memberMap, AstClass* nodep,
                                      const std::string& name = "randomize",
-                                     bool allowVirtual = true) VL_MT_DISABLED;
+                                     bool allowVirtual = true,
+                                     bool childDType = false) VL_MT_DISABLED;
     static AstFunc* newSRandomFunc(VMemberMap& memberMap, AstClass* nodep) VL_MT_DISABLED;
 };
 

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -6025,7 +6025,6 @@ class WidthVisitor final : public VNVisitor {
             }
             UASSERT_OBJ(classp, nodep, "Should have failed in V3LinkDot");
             if (nodep->name() == "randomize") {
-                nodep->taskp(V3Randomize::newRandomizeFunc(m_memberMap, classp));
                 AstClassRefDType* const adtypep
                     = new AstClassRefDType{nodep->fileline(), classp, nullptr};
                 v3Global.rootp()->typeTablep()->addTypesp(adtypep);

--- a/test_regress/t/t_randomize_method_std.py
+++ b/test_regress/t/t_randomize_method_std.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2024 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile()
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_randomize_method_std.v
+++ b/test_regress/t/t_randomize_method_std.v
@@ -1,0 +1,22 @@
+// DESCRIPTION: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2024 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+process p;  // force importing std into top-level namespace
+
+class C;
+   function new;
+      if (randomize() != 1) $stop;
+   endfunction
+endclass
+
+module t (/*AUTOARG*/);
+   initial begin
+      C c = new;
+
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end
+endmodule


### PR DESCRIPTION
Previous error message mentioned std::randomize is unsupported, while in classes `randomize()` should refer to `this.randomize()` not `std::randomize()`. Explicit `this.randomize()` had the same problem previously, but got already fixed by #5394.