### PR TITLE
Improve parser error recovery

### DIFF
--- a/src/verilog.y
+++ b/src/verilog.y
@@ -7030,14 +7030,14 @@ class_declaration<nodep>:       // ==IEEE: part of class_declaration
         /*mid*/         { // Allow resolving types declared in base extends class
                           if ($<scp>3) SYMP->importExtends($<scp>3);
                         }
-        /*cont*/    class_itemListE yENDCLASS endLabelE
+        /*cont*/    class_itemListEnd endLabelE
                         { $$ = $1; $1->addMembersp($2);
                           if ($2) $1->isParameterized(true);
                           $1->addExtendsp($3);
                           $1->addExtendsp($4);
                           $1->addMembersp($7);
                           SYMP->popScope($$);
-                          GRAMMARP->endLabel($<fl>9, $1, $9); }
+                          GRAMMARP->endLabel($<fl>8, $1, $8); }
         ;
 
 classFront<classp>:             // IEEE: part of class_declaration
@@ -7216,9 +7216,11 @@ localNextId<nodeExprp>:         // local
 
 //^^^=========
 
-class_itemListE<nodep>:
-                /* empty */                             { $$ = nullptr; }
-        |       class_itemList                          { $$ = $1; }
+class_itemListEnd<nodep>:
+                yENDCLASS                               { $$ = nullptr; }
+        |       class_itemList yENDCLASS                { $$ = $1; }
+        |       error yENDCLASS                         { $$ = nullptr; }
+        |       class_itemList error yENDCLASS          { $$ = $1; }
         ;
 
 class_itemList<nodep>:


### PR DESCRIPTION
There are three commits, each doing a separate improvement, and they can be submitted separately if desired.

First, covergroup identifiers were parsed as classes, so their names were later parsed as type identifiers rather than identifiers, causing many parse errors later on if the covergroups are used anywhere. Changing it to AstConstraint makes a bit more sense, as they are accessed as something similar to class fields.

Second, more `error` tokens are added to the parser, so that it can recover from invalid syntax used as part of cover points or constraints. Since they are normally both part of class syntax, the subsequent items would otherwise fall back to the `error ';'` rule in class item, which is not likely to be the correct intention of the programmer, and result in more errors.

The last commit modifies the grammar a bit more, in order to add error recovery right before endclass token. It allows to have a syntax error inside a class that is not followed by a semicolon, which will terminate the class symbol in more cases. It would otherwise, again, seek for the next semicolon in the rest of file, still believing that the next statement is part of the class, until a stray endclass is found after a correct class item (which never happens).

This involved changing the grammar a bit to avoid shift-reduce conflicts, as the error token needs to (in all 'conflicting' places) appear after the same item already present on the bottom-up parsing stack, and the `somethingListE` parsing pattern seems incompatible with it. That's because a partial somethingList would need to be reduced to somethingListE first, despite still having the potential to include another item (from the parser's perspective). If there is some way to avoid that manual grammar expansion, I would be happy to learn it.

I investigated the last part for functions/tasks/modules/blocks, but their syntax is a bit more complicated, and such token popping would involve making the grammar larger and probably less understandable/maintainable, and I doubt whether it is worth the effort if grammar expansion cannot be avoided.