### PR TITLE
Add Docker pre-commit hook (#5238) (#5452)

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,7 @@
+- id: verilator
+  name: verilator-lint
+  description: Runs verilator Docker image to lint (System) Verilog designs
+  args: [--lint-only, -Wall]
+  language: docker_image
+  entry: verilator/verilator:v5.026
+  types_or: ["verilog", "system-verilog"]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,5 +3,5 @@
   description: Runs verilator Docker image to lint (System) Verilog designs
   args: [--lint-only]
   language: docker_image
-  entry: verilator/verilator:v5.026
+  entry: verilator/verilator:latest
   types_or: ["verilog", "system-verilog"]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,7 +1,8 @@
+---
 - id: verilator
   name: verilator-lint
   description: Runs verilator Docker image to lint (System) Verilog designs
   args: [--lint-only]
   language: docker_image
   entry: verilator/verilator:latest
-  types_or: ["verilog", "system-verilog"]
+  types_or: [verilog, system-verilog]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,7 +1,7 @@
 - id: verilator
   name: verilator-lint
   description: Runs verilator Docker image to lint (System) Verilog designs
-  args: [--lint-only, -Wall]
+  args: [--lint-only]
   language: docker_image
   entry: verilator/verilator:v5.026
   types_or: ["verilog", "system-verilog"]

--- a/ci/docker/buildenv/README.rst
+++ b/ci/docker/buildenv/README.rst
@@ -1,6 +1,8 @@
 .. Copyright 2003-2024 by Wilson Snyder.
 .. SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
 
+.. _Verilator Build Docker Container
+
 Verilator Build Docker Container
 ================================
 

--- a/ci/docker/buildenv/README.rst
+++ b/ci/docker/buildenv/README.rst
@@ -1,8 +1,6 @@
 .. Copyright 2003-2024 by Wilson Snyder.
 .. SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
 
-.. _Verilator Build Docker Container
-
 Verilator Build Docker Container
 ================================
 

--- a/docs/guide/install.rst
+++ b/docs/guide/install.rst
@@ -32,7 +32,7 @@ pre-commit Quick Install
 =============================
 
 You can use verliator's `pre-commit <https://pre-commit.com/>`_ hook to lint your code before committing it.
-It encapsulates the :doc:`../../ci/docker/buildenv/README.rst`, so you need docker on your system to use it.
+It encapsulates the :doc:`Verilator Build Docker Container <../../ci/docker/buildenv/README.rst>`, so you need docker on your system to use it.
 The verilator image will be downloaded automatically.
 To use the hook, add the following entry to your `.pre-commit-config.yaml`:
 

--- a/docs/guide/install.rst
+++ b/docs/guide/install.rst
@@ -31,7 +31,7 @@ For other distributions, refer to `Repology Verilator Distro Packages
 pre-commit Quick Install
 =============================
 
-You can use verliator's `pre-commit<https://pre-commit.com/>`_ hook to lint your code before committing it.
+You can use verliator's `pre-commit <https://pre-commit.com/>`_ hook to lint your code before committing it.
 It encapsulates the :ref:`Verilator Build Docker Container`, so you need docker on your system to use it.
 The verilator image will be downloaded automatically.
 To use the hook, add the following entry to your `.pre-commit-config.yaml`:

--- a/docs/guide/install.rst
+++ b/docs/guide/install.rst
@@ -36,7 +36,7 @@ It encapsulates the :ref:`Verilator Build Docker Container`, so you need docker 
 The verilator image will be downloaded automatically.
 To use the hook, add the following entry to your `.pre-commit-config.yaml`:
 
-:: code-block:: yaml
+.. code-block:: yaml
 
    repos:
      - repo: https://github.com/verilator/verilator

--- a/docs/guide/install.rst
+++ b/docs/guide/install.rst
@@ -32,7 +32,7 @@ pre-commit Quick Install
 =============================
 
 You can use verliator's `pre-commit <https://pre-commit.com/>`_ hook to lint your code before committing it.
-It encapsulates the :doc:`Verilator Build Docker Container <../../ci/docker/buildenv/README.rst>`, so you need docker on your system to use it.
+It encapsulates the :ref:`Verilator Build Docker Container`_, so you need docker on your system to use it.
 The verilator image will be downloaded automatically.
 To use the hook, add the following entry to your :code:`.pre-commit-config.yaml`:
 

--- a/docs/guide/install.rst
+++ b/docs/guide/install.rst
@@ -40,7 +40,7 @@ To use the hook, add the following entry to your :code:`.pre-commit-config.yaml`
 
    repos:
      - repo: https://github.com/verilator/verilator
-       rev: v5.026
+       rev: v5.026  # or later
        hooks:
          - id: verilator
 

--- a/docs/guide/install.rst
+++ b/docs/guide/install.rst
@@ -34,7 +34,7 @@ pre-commit Quick Install
 You can use verliator's `pre-commit <https://pre-commit.com/>`_ hook to lint your code before committing it.
 It encapsulates the :doc:`Verilator Build Docker Container <../../ci/docker/buildenv/README.rst>`, so you need docker on your system to use it.
 The verilator image will be downloaded automatically.
-To use the hook, add the following entry to your `.pre-commit-config.yaml`:
+To use the hook, add the following entry to your :code:`.pre-commit-config.yaml`:
 
 .. code-block:: yaml
 

--- a/docs/guide/install.rst
+++ b/docs/guide/install.rst
@@ -32,7 +32,7 @@ pre-commit Quick Install
 =============================
 
 You can use verliator's `pre-commit <https://pre-commit.com/>`_ hook to lint your code before committing it.
-It encapsulates the :doc:`../../../ci/docker/buildenv/README.rst`, so you need docker on your system to use it.
+It encapsulates the :doc:`../../ci/docker/buildenv/README.rst`, so you need docker on your system to use it.
 The verilator image will be downloaded automatically.
 To use the hook, add the following entry to your `.pre-commit-config.yaml`:
 

--- a/docs/guide/install.rst
+++ b/docs/guide/install.rst
@@ -26,6 +26,24 @@ package:
 For other distributions, refer to `Repology Verilator Distro Packages
 <https://repology.org/project/verilator>`__.
 
+.. _pre-commit Quick Install:
+
+pre-commit Quick Install
+=============================
+
+You can use verliator's `pre-commit<https://pre-commit.com/>`_ hook to lint your code before committing it.
+It encapsulates the :ref:`Verilator Build Docker Container`, so you need docker on your system to use it.
+The verilator image will be downloaded automatically.
+To use the hook, add the following entry to your `.pre-commit-config.yaml`:
+
+:: code-block:: yaml
+
+   repos:
+     - repo: https://github.com/verilator/verilator
+       rev: v5.026
+       hooks:
+         - id: verilator
+
 .. _Git Install:
 
 Git Quick Install

--- a/docs/guide/install.rst
+++ b/docs/guide/install.rst
@@ -32,7 +32,7 @@ pre-commit Quick Install
 =============================
 
 You can use verliator's `pre-commit <https://pre-commit.com/>`_ hook to lint your code before committing it.
-It encapsulates the :ref:`Verilator Build Docker Container`, so you need docker on your system to use it.
+It encapsulates the :doc:`../../../ci/docker/buildenv/README.rst`, so you need docker on your system to use it.
 The verilator image will be downloaded automatically.
 To use the hook, add the following entry to your `.pre-commit-config.yaml`:
 


### PR DESCRIPTION
Add pre-commit hook as discussed in https://github.com/verilator/verilator/issues/5238. This is following https://pre-commit.com/#new-hooks at the example of https://github.com/hadolint/hadolint/blob/742b76e3b9b4d45d6716771b0f1fae2fa0069104/.pre-commit-hooks.yaml.