### PR TITLE
-j 1 for single test

### DIFF
--- a/test_regress/t/vltest_bootstrap.py
+++ b/test_regress/t/vltest_bootstrap.py
@@ -14,4 +14,4 @@ os.chdir(os.path.dirname(os.path.realpath(__file__)) + "/..")
 # Avoid chdir leaving the .. which confuses later commands
 os.environ['PWD'] = os.getcwd()
 args = list(map(lambda arg: re.sub(r'.*/test_regress/', '', arg), sys.argv))
-os.execl("./driver.py", "--bootstrapped", *args)
+os.execl("./driver.py", "--bootstrapped", "-j", "1", *args)


### PR DESCRIPTION
Otherwise this will happen:
```
$ t/t_interface.py --debug --rr
INFO:root:In driver.py, ARGV=./driver.py t/t_interface.py --debug --rr
driver.py: Found 8 cores, using -j 8
%Error: Unable to use -j > 1 with --gdb* and --rr* options
```

This can be worked around with `-j 1`, but that seems a little silly when running a single test.

Also, I don't understand how `--bootstrapped` works.  I initially thought I'd make `driver.py` ignore the `-j` flag if running under `--bootstrapped`, but that isn't an `argparse` argument and I don't even see it anywhere else in the repo:
```
$ git grep bootstrapped
test_regress/t/vltest_bootstrap.py:os.execl("./driver.py", "--bootstrapped", *args)
```

I'm happy to do it the other way if someone can explain to me how `--bootstrapped` works.