### PR TITLE
fix user type parameter conflation

### DIFF
--- a/src/V3Param.cpp
+++ b/src/V3Param.cpp
@@ -347,7 +347,17 @@ class ParamProcessor final {
             if (dtypep->isRanged()) {
                 key += "[" + cvtToStr(dtypep->left()) + ":" + cvtToStr(dtypep->right()) + "]";
             }
+        } else if (const AstPackArrayDType* const dtypep = VN_CAST(nodep, PackArrayDType)) {
+            key += dtypep->prettyDTypeName(true);
+        } else if (const AstInitArray* const initp = VN_CAST(nodep, InitArray)) {
+            key += "{";
+            for (auto it : initp->map()) {
+                key += it.second->valuep()->name();
+                key += ",";
+            }
+            key += "}";
         }
+        UASSERT_OBJ(!key.empty(), nodep, "Parameter yielded no value string");
         return key;
     }
 

--- a/src/V3Param.cpp
+++ b/src/V3Param.cpp
@@ -348,14 +348,21 @@ class ParamProcessor final {
                 key += "[" + cvtToStr(dtypep->left()) + ":" + cvtToStr(dtypep->right()) + "]";
             }
         } else if (const AstPackArrayDType* const dtypep = VN_CAST(nodep, PackArrayDType)) {
-            key += dtypep->prettyDTypeName(true);
+            key += "[";
+            key += cvtToStr(dtypep->left());
+            key += ":";
+            key += cvtToStr(dtypep->right());
+            key += "] ";
+            key += paramValueString(dtypep->subDTypep());
         } else if (const AstInitArray* const initp = VN_CAST(nodep, InitArray)) {
             key += "{";
             for (auto it : initp->map()) {
-                key += it.second->valuep()->name();
+                key += paramValueString(it.second->valuep());
                 key += ",";
             }
             key += "}";
+        } else if (const AstNodeDType* const dtypep = VN_CAST(nodep, NodeDType)) {
+            key += dtypep->prettyDTypeName(true);
         }
         UASSERT_OBJ(!key.empty(), nodep, "Parameter yielded no value string");
         return key;

--- a/test_regress/t/t_interface_derived_type.py
+++ b/test_regress/t/t_interface_derived_type.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2024 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile()
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_interface_derived_type.v
+++ b/test_regress/t/t_interface_derived_type.v
@@ -1,0 +1,39 @@
+// DESCRIPTION: Verilator: SystemVerilog interface test module
+//
+// This file ONLY is placed into the Public Domain, for any use,
+// without warranty, 2012 by Iztok Jeras.
+// SPDX-License-Identifier: CC0-1.0
+
+interface intf #(parameter type data_t = bit) ();
+    data_t data;
+endinterface
+
+module t (/*AUTOARG*/
+   // Inputs
+   clk
+   );
+
+   input clk;
+
+   // finish report
+   always @ (posedge clk) begin
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end
+
+   sub #(.width(8)) sub8 ();
+   sub #(.width(16)) sub16 ();
+
+endmodule
+
+module sub #(parameter int width) ();
+    typedef struct packed {
+        logic [0:0] [width-1:0] field;
+    } user_type_t;
+
+    intf #(.data_t(user_type_t)) the_intf ();
+
+    logic [width-1:0] signal;
+
+    always_comb the_intf.data.field = signal;
+endmodule

--- a/test_regress/t/t_interface_derived_type.v
+++ b/test_regress/t/t_interface_derived_type.v
@@ -4,8 +4,22 @@
 // without warranty, 2012 by Iztok Jeras.
 // SPDX-License-Identifier: CC0-1.0
 
-interface intf #(parameter type data_t = bit) ();
+interface intf #(
+    parameter type data_t = bit,
+    parameter int arr[2][4]
+) ();
     data_t data;
+    // TODO -- some kind of issue with multi-dimensional array constness:
+    // %Error: t/t_interface_derived_type.v:12:12: Expecting expression to be constant, but variable isn't const: 'arr'
+    //                                           : ... note: In instance 't.sub16'
+    //    19 |     logic [arr[0][0]-1:0] other_data;
+    //       |            ^~~
+    // `define SHOW_2D_BUG
+    `ifdef SHOW_2D_BUG
+    logic [arr[0][0]-1:0] other_data;
+    `else
+    logic [$bits(data)-1:0] other_data;
+    `endif
 endinterface
 
 module t (/*AUTOARG*/
@@ -21,19 +35,28 @@ module t (/*AUTOARG*/
       $finish;
    end
 
-   sub #(.width(8)) sub8 ();
-   sub #(.width(16)) sub16 ();
+   sub #(.width(8), .arr('{'{8, 2, 3, 4}, '{1, 2, 3, 4}})) sub8 ();
+   sub #(.width(16), .arr('{'{16, 2, 3, 4}, '{1, 2, 3, 4}})) sub16 ();
 
 endmodule
 
-module sub #(parameter int width) ();
+module sub #(
+    parameter int width,
+    parameter int arr[2][4]
+) ();
     typedef struct packed {
-        logic [0:0] [width-1:0] field;
+        logic [3:3] [0:0] [width-1:0] field;
     } user_type_t;
 
-    intf #(.data_t(user_type_t)) the_intf ();
+    intf #(
+        .data_t(user_type_t),
+        .arr(arr)
+    ) the_intf ();
 
     logic [width-1:0] signal;
 
-    always_comb the_intf.data.field = signal;
+    always_comb begin
+        the_intf.data.field = signal;
+        the_intf.other_data = signal;
+    end
 endmodule


### PR DESCRIPTION
Without the fix both `the_intf` interfaces will have the same parameters even though they should not:
```
%Warning-WIDTHTRUNC: t/t_interface_derived_type.v:38:37: Operator ASSIGN expects 8 bits on the Assign RHS, but Assign RHS's VARREF 'signal' generates 16 bits.
                                                       : ... note: In instance 't.sub16'
   38 |     always_comb the_intf.data.field = signal;
      |                                     ^
```

With the assert but without the fix, the test fails like so:
```
%Error: Internal Error: t/t_interface_derived_type.v:31:15: ../V3Param.cpp:360: Parameter yielded no value string
   31 |         logic [0:0] [width-1:0] field;
      |               ^
```
which gives us a little more to go on.