### PR TITLE
Fix table optimization dropping coverage points (#5473)

### DIFF
--- a/src/V3Simulate.h
+++ b/src/V3Simulate.h
@@ -108,6 +108,7 @@ private:
     bool m_anyAssignComb;  ///< True if found a non-delayed assignment
     bool m_inDlyAssign;  ///< Under delayed assignment
     bool m_isImpure;  // Not pure
+    bool m_isCoverage;  // Has coverage
     int m_instrCount;  ///< Number of nodes
     int m_dataCount;  ///< Bytes of data
     AstJumpGo* m_jumpp = nullptr;  ///< Jump label we're branching from
@@ -215,6 +216,7 @@ public:
 
     bool isAssignDly() const { return m_anyAssignDly; }
     bool isImpure() const { return m_isImpure; }
+    bool isCoverage() const { return m_isCoverage; }
     int instrCount() const { return m_instrCount; }
     int dataCount() const { return m_dataCount; }
 
@@ -1185,8 +1187,7 @@ private:
         }
     }
 
-    // Ignore coverage - from a function we're inlining
-    void visit(AstCoverInc* nodep) override {}
+    void visit(AstCoverInc* nodep) override { m_isCoverage = true; }
 
     // ====
     // Known Bad
@@ -1237,6 +1238,7 @@ public:
         m_anyAssignDly = false;
         m_inDlyAssign = false;
         m_isImpure = false;
+        m_isCoverage = false;
         m_instrCount = 0;
         m_dataCount = 0;
         m_jumpp = nullptr;

--- a/src/V3Table.cpp
+++ b/src/V3Table.cpp
@@ -210,6 +210,9 @@ private:
         const double time  // max(_, 1), so we won't divide by zero
             = std::max<double>(chkvis.instrCount() * TABLE_BYTES_PER_INST + chkvis.dataCount(), 1);
         if (chkvis.isImpure()) chkvis.clearOptimizable(nodep, "Table creates side effects");
+        if (chkvis.isCoverage()) {
+            chkvis.clearOptimizable(nodep, "Table removes coverage points");
+        }
         if (!m_outWidthBytes || !m_inWidthBits) {
             chkvis.clearOptimizable(nodep, "Table has no outputs");
         }


### PR DESCRIPTION
Fixes #5473 

Tiny patch, but first attempt at ever touching Verilator internals, so feedback appreciated if something here is wrong/dumb.