### PR TITLE
driver.py: consume all stdout from subprocess

### DIFF
--- a/test_regress/driver.py
+++ b/test_regress/driver.py
@@ -1705,7 +1705,7 @@ class VlTest:
                                 sys.stdout.flush()
                         if logfh:
                             logfh.write(data)
-                    if finished is not None:
+                    elif finished is not None:
                         break
 
                 if logfh:


### PR DESCRIPTION
This used to fail if the process terminates and the stdout has more content than the pre-allocated buffer can hold in one iteration.