### PR TITLE
Generate one trigger per SenItem instead of per SenTree

### DIFF
--- a/src/V3Clock.cpp
+++ b/src/V3Clock.cpp
@@ -31,7 +31,7 @@
 
 #include "V3Clock.h"
 
-#include "V3Sched.h"
+#include "V3Const.h"
 
 VL_DEFINE_DEBUG_FUNCTIONS;
 
@@ -176,6 +176,11 @@ public:
     // CONSTRUCTORS
     explicit ClockVisitor(AstNetlist* netlistp) {
         m_evalp = netlistp->evalp();
+        // Simplify all SenTrees
+        for (AstSenTree* senTreep = netlistp->topScopep()->senTreesp(); senTreep;
+             senTreep = VN_AS(senTreep->nextp(), SenTree)) {
+            V3Const::constifyExpensiveEdit(senTreep);
+        }
         iterate(netlistp);
     }
     ~ClockVisitor() override = default;

--- a/src/V3Order.cpp
+++ b/src/V3Order.cpp
@@ -132,7 +132,7 @@ AstCFunc* V3Order::order(AstNetlist* netlistp,  //
     // Order it
     orderOrderGraph(*graph, tag);
     // Assign sensitivity domains to combinational logic
-    processDomains(netlistp, *graph, tag, trigToSen, externalDomains);
+    processDomains(netlistp, *graph, tag, externalDomains);
 
     if (parallel) {
         // Construct the parallel ExecGraph

--- a/src/V3Order.h
+++ b/src/V3Order.h
@@ -40,8 +40,8 @@ namespace V3Order {
 
 // Callable to add extra external Triggers to a variable
 using ExternalDomainsProvider = std::function<void(const AstVarScope*, std::vector<AstSenTree*>&)>;
-// Map from Trigger expression to original Sensitivity tree
-using TrigToSenMap = std::unordered_map<const AstSenItem*, const AstSenTree*>;
+// Map from Trigger Sensitivity tree to original Sensitivity tree
+using TrigToSenMap = std::unordered_map<const AstSenTree*, const AstSenTree*>;
 
 AstCFunc* order(
     AstNetlist* netlistp,  //

--- a/src/V3OrderGraphBuilder.cpp
+++ b/src/V3OrderGraphBuilder.cpp
@@ -134,9 +134,8 @@ class OrderGraphBuilder final : public VNVisitor {
 
         // This is the original sensitivity of the block (i.e.: not the ref into the TRIGGERVEC)
 
-        const AstSenTree* const senTreep = nodep->sensesp()->hasCombo()
-                                               ? nodep->sensesp()
-                                               : m_trigToSen.at(nodep->sensesp()->sensesp());
+        const AstSenTree* const senTreep
+            = nodep->sensesp()->hasCombo() ? nodep->sensesp() : m_trigToSen.at(nodep->sensesp());
 
         m_inClocked = senTreep->hasClocked();
 

--- a/src/V3OrderInternal.h
+++ b/src/V3OrderInternal.h
@@ -48,7 +48,6 @@ void orderOrderGraph(OrderGraph& graph, const std::string& tag);
 void processDomains(AstNetlist* netlistp,  //
                     OrderGraph& graph,  //
                     const std::string& tag,  //
-                    const TrigToSenMap& trigToSen,  //
                     const ExternalDomainsProvider& externalDomains);
 
 std::vector<AstActive*> createSerial(OrderGraph& orderGraph,  //

--- a/src/V3OrderMoveGraph.cpp
+++ b/src/V3OrderMoveGraph.cpp
@@ -111,7 +111,7 @@ class OrderMoveGraphBuilder final {
                 if (senTreep->sensesp()->nextp()) return nullptr;
 
                 // Find the original AstSenTree
-                auto it = m_trigToSen.find(senTreep->sensesp());
+                auto it = m_trigToSen.find(senTreep);
                 if (it == m_trigToSen.end()) return nullptr;
 
                 // If more than one AstSenItems on the original, then not a simple AstSenTree

--- a/src/V3OrderProcessDomains.cpp
+++ b/src/V3OrderProcessDomains.cpp
@@ -39,9 +39,6 @@ class V3OrderProcessDomains final {
     // STATE
     OrderGraph& m_graph;  // The ordering graph
 
-    // Map from Trigger reference AstSenItem to the original AstSenTree
-    const V3Order::TrigToSenMap& m_trigToSen;
-
     // This is a function provided by the invoker of the ordering that can provide additional
     // sensitivity expression that when triggered indicates the passed AstVarScope might have
     // changed external to the code being ordered.
@@ -165,11 +162,6 @@ class V3OrderProcessDomains final {
 
         std::deque<string> report;
 
-        // Rebuild the trigger to original AstSenTree map using equality key comparison, as
-        // merging domains have created new AstSenTree instances which are not in the map
-        std::unordered_map<VNRef<const AstSenItem>, const AstSenTree*> trigToSen;
-        for (const auto& pair : m_trigToSen) trigToSen.emplace(*pair.first, pair.second);
-
         for (V3GraphVertex& vtx : m_graph.vertices()) {
             if (OrderVarVertex* const vvertexp = vtx.cast<OrderVarVertex>()) {
                 string name(vvertexp->vscp()->prettyName());
@@ -190,12 +182,7 @@ class V3OrderProcessDomains final {
                     for (AstSenItem* senItemp = senTreep->sensesp(); senItemp;
                          senItemp = VN_AS(senItemp->nextp(), SenItem)) {
                         if (senItemp != senTreep->sensesp()) os << " or ";
-                        const auto it = trigToSen.find(*senItemp);
-                        if (it != trigToSen.end()) {
-                            V3EmitV::verilogForTree(it->second, os);
-                        } else {
-                            V3EmitV::verilogForTree(senItemp, os);
-                        }
+                        V3EmitV::verilogForTree(senItemp, os);
                     }
                 }
                 report.push_back(os.str());
@@ -209,10 +196,8 @@ class V3OrderProcessDomains final {
 
     // CONSTRUCTOR
     V3OrderProcessDomains(AstNetlist* netlistp, OrderGraph& graph, const string& tag,
-                          const V3Order::TrigToSenMap& trigToSen,
                           const V3Order::ExternalDomainsProvider& externalDomains)
         : m_graph{graph}
-        , m_trigToSen{trigToSen}
         , m_externalDomains{externalDomains}
         , m_finder{netlistp}
         , m_tag{tag} {
@@ -238,16 +223,14 @@ class V3OrderProcessDomains final {
 public:
     // Order the logic
     static void apply(AstNetlist* netlistp, OrderGraph& graph, const string& tag,
-                      const V3Order::TrigToSenMap& trigToSen,
                       const V3Order::ExternalDomainsProvider& externalDomains) {
-        V3OrderProcessDomains{netlistp, graph, tag, trigToSen, externalDomains};
+        V3OrderProcessDomains{netlistp, graph, tag, externalDomains};
     }
 };
 
 void V3Order::processDomains(AstNetlist* netlistp,  //
                              OrderGraph& graph,  //
                              const std::string& tag,  //
-                             const V3Order::TrigToSenMap& trigToSen,  //
                              const ExternalDomainsProvider& externalDomains) {
-    V3OrderProcessDomains::apply(netlistp, graph, tag, trigToSen, externalDomains);
+    V3OrderProcessDomains::apply(netlistp, graph, tag, externalDomains);
 }

--- a/src/V3SenExprBuilder.h
+++ b/src/V3SenExprBuilder.h
@@ -151,7 +151,7 @@ class SenExprBuilder final {
         return prevp;
     }
 
-    std::pair<AstNodeExpr*, bool> createTerm(AstSenItem* senItemp) {
+    std::pair<AstNodeExpr*, bool> createTerm(const AstSenItem* senItemp) {
         FileLine* const flp = senItemp->fileline();
         AstNodeExpr* const senp = senItemp->sensp();
 
@@ -210,6 +210,15 @@ class SenExprBuilder final {
 public:
     // Returns the expression computing the trigger, and a bool indicating that
     // this trigger should be fired on the first evaluation (at initialization)
+    std::pair<AstNodeExpr*, bool> build(const AstSenItem* senItemp) {
+        auto term = createTerm(senItemp);
+        if (AstNodeExpr* const condp = senItemp->condp()) {
+            term.first = new AstAnd{senItemp->fileline(), condp->cloneTreePure(false), term.first};
+        }
+        return term;
+    }
+
+    // Like above, but for a whole SenTree
     std::pair<AstNodeExpr*, bool> build(const AstSenTree* senTreep) {
         FileLine* const flp = senTreep->fileline();
         AstNodeExpr* resultp = nullptr;
@@ -218,8 +227,6 @@ public:
              senItemp = VN_AS(senItemp->nextp(), SenItem)) {
             const auto& pair = createTerm(senItemp);
             if (AstNodeExpr* termp = pair.first) {
-                AstNodeExpr* const condp = senItemp->condp();
-                if (condp) termp = new AstAnd{flp, condp->cloneTreePure(false), termp};
                 resultp = resultp ? new AstOr{flp, resultp, termp} : termp;
                 firedAtInitialization |= pair.second;
             }

--- a/test_regress/t/t_timing_debug1.out
+++ b/test_regress/t/t_timing_debug1.out
@@ -18,9 +18,13 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__stl
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__stl
 -V{t#,#}         'stl' region trigger index 0 is active: Internal 'stl' trigger - first iteration
--V{t#,#}         'stl' region trigger index 1 is active: @([hybrid] t.clk1 or [hybrid] __VassignWtmp_h########__0 or [hybrid] __VassignWgen_h########__0)
--V{t#,#}         'stl' region trigger index 2 is active: @([hybrid] t.clk2 or [hybrid] __VassignWtmp_h########__0 or [hybrid] __VassignWgen_h########__0)
--V{t#,#}         'stl' region trigger index 3 is active: @([hybrid] t.c1)
+-V{t#,#}         'stl' region trigger index 1 is active: @([hybrid] t.clk1)
+-V{t#,#}         'stl' region trigger index 2 is active: @([hybrid] __VassignWtmp_h########__0)
+-V{t#,#}         'stl' region trigger index 3 is active: @([hybrid] __VassignWgen_h########__0)
+-V{t#,#}         'stl' region trigger index 4 is active: @([hybrid] t.clk2)
+-V{t#,#}         'stl' region trigger index 5 is active: @([hybrid] __VassignWtmp_h########__0)
+-V{t#,#}         'stl' region trigger index 6 is active: @([hybrid] __VassignWgen_h########__0)
+-V{t#,#}         'stl' region trigger index 7 is active: @([hybrid] t.c1)
 -V{t#,#}+    Vt_timing_debug1___024root___eval_stl
 -V{t#,#}+    Vt_timing_debug1___024root___stl_sequent__TOP__0
 -V{t#,#}+    Vt_timing_debug1___024root___act_sequent__TOP__0
@@ -31,8 +35,10 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__stl
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__stl
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__stl
--V{t#,#}         'stl' region trigger index 1 is active: @([hybrid] t.clk1 or [hybrid] __VassignWtmp_h########__0 or [hybrid] __VassignWgen_h########__0)
--V{t#,#}         'stl' region trigger index 2 is active: @([hybrid] t.clk2 or [hybrid] __VassignWtmp_h########__0 or [hybrid] __VassignWgen_h########__0)
+-V{t#,#}         'stl' region trigger index 2 is active: @([hybrid] __VassignWtmp_h########__0)
+-V{t#,#}         'stl' region trigger index 3 is active: @([hybrid] __VassignWgen_h########__0)
+-V{t#,#}         'stl' region trigger index 5 is active: @([hybrid] __VassignWtmp_h########__0)
+-V{t#,#}         'stl' region trigger index 6 is active: @([hybrid] __VassignWgen_h########__0)
 -V{t#,#}+    Vt_timing_debug1___024root___eval_stl
 -V{t#,#}+    Vt_timing_debug1___024root___act_sequent__TOP__0
 -V{t#,#}+    Vt_timing_debug1___024root___act_sequent__TOP__1
@@ -45,9 +51,13 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 0 is active: @([hybrid] t.clk1 or [hybrid] __VassignWtmp_h########__0 or [hybrid] __VassignWgen_h########__0)
--V{t#,#}         'act' region trigger index 1 is active: @([hybrid] t.clk2 or [hybrid] __VassignWtmp_h########__0 or [hybrid] __VassignWgen_h########__0)
--V{t#,#}         'act' region trigger index 2 is active: @([hybrid] t.c1)
+-V{t#,#}         'act' region trigger index 0 is active: @([hybrid] t.clk1)
+-V{t#,#}         'act' region trigger index 1 is active: @([hybrid] __VassignWtmp_h########__0)
+-V{t#,#}         'act' region trigger index 2 is active: @([hybrid] __VassignWgen_h########__0)
+-V{t#,#}         'act' region trigger index 3 is active: @([hybrid] t.clk2)
+-V{t#,#}         'act' region trigger index 4 is active: @([hybrid] __VassignWtmp_h########__0)
+-V{t#,#}         'act' region trigger index 5 is active: @([hybrid] __VassignWgen_h########__0)
+-V{t#,#}         'act' region trigger index 6 is active: @([hybrid] t.c1)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}         Committing processes waiting for @(posedge t.clk1):
 -V{t#,#}           - Process waiting at t/t_timing_sched.v:18
@@ -80,7 +90,7 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 4 is active: @([true] __VdlySched.awaitingCurrentTime())
+-V{t#,#}         'act' region trigger index 8 is active: @([true] __VdlySched.awaitingCurrentTime())
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Delayed processes:
@@ -94,8 +104,8 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 0 is active: @([hybrid] t.clk1 or [hybrid] __VassignWtmp_h########__0 or [hybrid] __VassignWgen_h########__0)
--V{t#,#}         'act' region trigger index 3 is active: @(posedge t.clk1)
+-V{t#,#}         'act' region trigger index 0 is active: @([hybrid] t.clk1)
+-V{t#,#}         'act' region trigger index 7 is active: @(posedge t.clk1)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Ready processes waiting for @(posedge t.clk1):
@@ -115,7 +125,8 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 0 is active: @([hybrid] t.clk1 or [hybrid] __VassignWtmp_h########__0 or [hybrid] __VassignWgen_h########__0)
+-V{t#,#}         'act' region trigger index 1 is active: @([hybrid] __VassignWtmp_h########__0)
+-V{t#,#}         'act' region trigger index 2 is active: @([hybrid] __VassignWgen_h########__0)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}         Committing processes waiting for @(posedge t.clk2):
 -V{t#,#}           - Process waiting at t/t_timing_sched.v:18
@@ -145,7 +156,7 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 4 is active: @([true] __VdlySched.awaitingCurrentTime())
+-V{t#,#}         'act' region trigger index 8 is active: @([true] __VdlySched.awaitingCurrentTime())
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Delayed processes:
@@ -160,7 +171,7 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 0 is active: @([hybrid] t.clk1 or [hybrid] __VassignWtmp_h########__0 or [hybrid] __VassignWgen_h########__0)
+-V{t#,#}         'act' region trigger index 0 is active: @([hybrid] t.clk1)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
@@ -169,7 +180,8 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 0 is active: @([hybrid] t.clk1 or [hybrid] __VassignWtmp_h########__0 or [hybrid] __VassignWgen_h########__0)
+-V{t#,#}         'act' region trigger index 1 is active: @([hybrid] __VassignWtmp_h########__0)
+-V{t#,#}         'act' region trigger index 2 is active: @([hybrid] __VassignWgen_h########__0)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
@@ -196,7 +208,7 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 4 is active: @([true] __VdlySched.awaitingCurrentTime())
+-V{t#,#}         'act' region trigger index 8 is active: @([true] __VdlySched.awaitingCurrentTime())
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Delayed processes:
@@ -233,7 +245,7 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 4 is active: @([true] __VdlySched.awaitingCurrentTime())
+-V{t#,#}         'act' region trigger index 8 is active: @([true] __VdlySched.awaitingCurrentTime())
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Delayed processes:
@@ -247,8 +259,8 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 0 is active: @([hybrid] t.clk1 or [hybrid] __VassignWtmp_h########__0 or [hybrid] __VassignWgen_h########__0)
--V{t#,#}         'act' region trigger index 3 is active: @(posedge t.clk1)
+-V{t#,#}         'act' region trigger index 0 is active: @([hybrid] t.clk1)
+-V{t#,#}         'act' region trigger index 7 is active: @(posedge t.clk1)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Ready processes waiting for @(posedge t.clk1):
@@ -264,7 +276,8 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 0 is active: @([hybrid] t.clk1 or [hybrid] __VassignWtmp_h########__0 or [hybrid] __VassignWgen_h########__0)
+-V{t#,#}         'act' region trigger index 1 is active: @([hybrid] __VassignWtmp_h########__0)
+-V{t#,#}         'act' region trigger index 2 is active: @([hybrid] __VassignWgen_h########__0)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
@@ -292,7 +305,7 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 4 is active: @([true] __VdlySched.awaitingCurrentTime())
+-V{t#,#}         'act' region trigger index 8 is active: @([true] __VdlySched.awaitingCurrentTime())
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Delayed processes:
@@ -307,8 +320,8 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 1 is active: @([hybrid] t.clk2 or [hybrid] __VassignWtmp_h########__0 or [hybrid] __VassignWgen_h########__0)
--V{t#,#}         'act' region trigger index 5 is active: @(posedge t.clk2)
+-V{t#,#}         'act' region trigger index 3 is active: @([hybrid] t.clk2)
+-V{t#,#}         'act' region trigger index 9 is active: @(posedge t.clk2)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Ready processes waiting for @(posedge t.clk2):
@@ -327,8 +340,9 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 1 is active: @([hybrid] t.clk2 or [hybrid] __VassignWtmp_h########__0 or [hybrid] __VassignWgen_h########__0)
--V{t#,#}         'act' region trigger index 2 is active: @([hybrid] t.c1)
+-V{t#,#}         'act' region trigger index 4 is active: @([hybrid] __VassignWtmp_h########__0)
+-V{t#,#}         'act' region trigger index 5 is active: @([hybrid] __VassignWgen_h########__0)
+-V{t#,#}         'act' region trigger index 6 is active: @([hybrid] t.c1)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}         Committing processes waiting for @(posedge t.clk1):
 -V{t#,#}           - Process waiting at t/t_timing_sched.v:18
@@ -358,7 +372,7 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 4 is active: @([true] __VdlySched.awaitingCurrentTime())
+-V{t#,#}         'act' region trigger index 8 is active: @([true] __VdlySched.awaitingCurrentTime())
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Delayed processes:
@@ -376,7 +390,7 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 0 is active: @([hybrid] t.clk1 or [hybrid] __VassignWtmp_h########__0 or [hybrid] __VassignWgen_h########__0)
+-V{t#,#}         'act' region trigger index 0 is active: @([hybrid] t.clk1)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}         Committing processes waiting for @(posedge t.clk2):
 -V{t#,#}           - Process waiting at t/t_timing_sched.v:50
@@ -387,7 +401,8 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 0 is active: @([hybrid] t.clk1 or [hybrid] __VassignWtmp_h########__0 or [hybrid] __VassignWgen_h########__0)
+-V{t#,#}         'act' region trigger index 1 is active: @([hybrid] __VassignWtmp_h########__0)
+-V{t#,#}         'act' region trigger index 2 is active: @([hybrid] __VassignWgen_h########__0)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
@@ -414,7 +429,7 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 4 is active: @([true] __VdlySched.awaitingCurrentTime())
+-V{t#,#}         'act' region trigger index 8 is active: @([true] __VdlySched.awaitingCurrentTime())
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Delayed processes:
@@ -451,7 +466,7 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 4 is active: @([true] __VdlySched.awaitingCurrentTime())
+-V{t#,#}         'act' region trigger index 8 is active: @([true] __VdlySched.awaitingCurrentTime())
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Delayed processes:
@@ -465,8 +480,8 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 0 is active: @([hybrid] t.clk1 or [hybrid] __VassignWtmp_h########__0 or [hybrid] __VassignWgen_h########__0)
--V{t#,#}         'act' region trigger index 3 is active: @(posedge t.clk1)
+-V{t#,#}         'act' region trigger index 0 is active: @([hybrid] t.clk1)
+-V{t#,#}         'act' region trigger index 7 is active: @(posedge t.clk1)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Ready processes waiting for @(posedge t.clk1):
@@ -486,7 +501,8 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 0 is active: @([hybrid] t.clk1 or [hybrid] __VassignWtmp_h########__0 or [hybrid] __VassignWgen_h########__0)
+-V{t#,#}         'act' region trigger index 1 is active: @([hybrid] __VassignWtmp_h########__0)
+-V{t#,#}         'act' region trigger index 2 is active: @([hybrid] __VassignWgen_h########__0)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}         Committing processes waiting for @(posedge t.clk2):
 -V{t#,#}           - Process waiting at t/t_timing_sched.v:18
@@ -516,7 +532,7 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 4 is active: @([true] __VdlySched.awaitingCurrentTime())
+-V{t#,#}         'act' region trigger index 8 is active: @([true] __VdlySched.awaitingCurrentTime())
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Delayed processes:
@@ -531,7 +547,7 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 0 is active: @([hybrid] t.clk1 or [hybrid] __VassignWtmp_h########__0 or [hybrid] __VassignWgen_h########__0)
+-V{t#,#}         'act' region trigger index 0 is active: @([hybrid] t.clk1)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
@@ -540,7 +556,8 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 0 is active: @([hybrid] t.clk1 or [hybrid] __VassignWtmp_h########__0 or [hybrid] __VassignWgen_h########__0)
+-V{t#,#}         'act' region trigger index 1 is active: @([hybrid] __VassignWtmp_h########__0)
+-V{t#,#}         'act' region trigger index 2 is active: @([hybrid] __VassignWgen_h########__0)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
@@ -567,7 +584,7 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 4 is active: @([true] __VdlySched.awaitingCurrentTime())
+-V{t#,#}         'act' region trigger index 8 is active: @([true] __VdlySched.awaitingCurrentTime())
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Delayed processes:
@@ -604,7 +621,7 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 4 is active: @([true] __VdlySched.awaitingCurrentTime())
+-V{t#,#}         'act' region trigger index 8 is active: @([true] __VdlySched.awaitingCurrentTime())
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Delayed processes:
@@ -618,8 +635,8 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 0 is active: @([hybrid] t.clk1 or [hybrid] __VassignWtmp_h########__0 or [hybrid] __VassignWgen_h########__0)
--V{t#,#}         'act' region trigger index 3 is active: @(posedge t.clk1)
+-V{t#,#}         'act' region trigger index 0 is active: @([hybrid] t.clk1)
+-V{t#,#}         'act' region trigger index 7 is active: @(posedge t.clk1)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Ready processes waiting for @(posedge t.clk1):
@@ -635,7 +652,8 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 0 is active: @([hybrid] t.clk1 or [hybrid] __VassignWtmp_h########__0 or [hybrid] __VassignWgen_h########__0)
+-V{t#,#}         'act' region trigger index 1 is active: @([hybrid] __VassignWtmp_h########__0)
+-V{t#,#}         'act' region trigger index 2 is active: @([hybrid] __VassignWgen_h########__0)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
@@ -663,7 +681,7 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 4 is active: @([true] __VdlySched.awaitingCurrentTime())
+-V{t#,#}         'act' region trigger index 8 is active: @([true] __VdlySched.awaitingCurrentTime())
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Delayed processes:
@@ -678,7 +696,7 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 1 is active: @([hybrid] t.clk2 or [hybrid] __VassignWtmp_h########__0 or [hybrid] __VassignWgen_h########__0)
+-V{t#,#}         'act' region trigger index 3 is active: @([hybrid] t.clk2)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
@@ -687,7 +705,8 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 1 is active: @([hybrid] t.clk2 or [hybrid] __VassignWtmp_h########__0 or [hybrid] __VassignWgen_h########__0)
+-V{t#,#}         'act' region trigger index 4 is active: @([hybrid] __VassignWtmp_h########__0)
+-V{t#,#}         'act' region trigger index 5 is active: @([hybrid] __VassignWgen_h########__0)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
@@ -714,7 +733,7 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 4 is active: @([true] __VdlySched.awaitingCurrentTime())
+-V{t#,#}         'act' region trigger index 8 is active: @([true] __VdlySched.awaitingCurrentTime())
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Delayed processes:
@@ -729,7 +748,7 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 0 is active: @([hybrid] t.clk1 or [hybrid] __VassignWtmp_h########__0 or [hybrid] __VassignWgen_h########__0)
+-V{t#,#}         'act' region trigger index 0 is active: @([hybrid] t.clk1)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
@@ -738,7 +757,8 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 0 is active: @([hybrid] t.clk1 or [hybrid] __VassignWtmp_h########__0 or [hybrid] __VassignWgen_h########__0)
+-V{t#,#}         'act' region trigger index 1 is active: @([hybrid] __VassignWtmp_h########__0)
+-V{t#,#}         'act' region trigger index 2 is active: @([hybrid] __VassignWgen_h########__0)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
@@ -765,7 +785,7 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 4 is active: @([true] __VdlySched.awaitingCurrentTime())
+-V{t#,#}         'act' region trigger index 8 is active: @([true] __VdlySched.awaitingCurrentTime())
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Delayed processes:
@@ -802,7 +822,7 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 4 is active: @([true] __VdlySched.awaitingCurrentTime())
+-V{t#,#}         'act' region trigger index 8 is active: @([true] __VdlySched.awaitingCurrentTime())
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Delayed processes:
@@ -816,8 +836,8 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 0 is active: @([hybrid] t.clk1 or [hybrid] __VassignWtmp_h########__0 or [hybrid] __VassignWgen_h########__0)
--V{t#,#}         'act' region trigger index 3 is active: @(posedge t.clk1)
+-V{t#,#}         'act' region trigger index 0 is active: @([hybrid] t.clk1)
+-V{t#,#}         'act' region trigger index 7 is active: @(posedge t.clk1)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Ready processes waiting for @(posedge t.clk1):
@@ -833,7 +853,8 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 0 is active: @([hybrid] t.clk1 or [hybrid] __VassignWtmp_h########__0 or [hybrid] __VassignWgen_h########__0)
+-V{t#,#}         'act' region trigger index 1 is active: @([hybrid] __VassignWtmp_h########__0)
+-V{t#,#}         'act' region trigger index 2 is active: @([hybrid] __VassignWgen_h########__0)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
@@ -861,7 +882,7 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 4 is active: @([true] __VdlySched.awaitingCurrentTime())
+-V{t#,#}         'act' region trigger index 8 is active: @([true] __VdlySched.awaitingCurrentTime())
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Delayed processes:
@@ -876,7 +897,7 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 0 is active: @([hybrid] t.clk1 or [hybrid] __VassignWtmp_h########__0 or [hybrid] __VassignWgen_h########__0)
+-V{t#,#}         'act' region trigger index 0 is active: @([hybrid] t.clk1)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
@@ -885,7 +906,8 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 0 is active: @([hybrid] t.clk1 or [hybrid] __VassignWtmp_h########__0 or [hybrid] __VassignWgen_h########__0)
+-V{t#,#}         'act' region trigger index 1 is active: @([hybrid] __VassignWtmp_h########__0)
+-V{t#,#}         'act' region trigger index 2 is active: @([hybrid] __VassignWgen_h########__0)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
@@ -912,7 +934,7 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 4 is active: @([true] __VdlySched.awaitingCurrentTime())
+-V{t#,#}         'act' region trigger index 8 is active: @([true] __VdlySched.awaitingCurrentTime())
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Delayed processes:
@@ -949,7 +971,7 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 4 is active: @([true] __VdlySched.awaitingCurrentTime())
+-V{t#,#}         'act' region trigger index 8 is active: @([true] __VdlySched.awaitingCurrentTime())
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Delayed processes:
@@ -964,10 +986,10 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 0 is active: @([hybrid] t.clk1 or [hybrid] __VassignWtmp_h########__0 or [hybrid] __VassignWgen_h########__0)
--V{t#,#}         'act' region trigger index 1 is active: @([hybrid] t.clk2 or [hybrid] __VassignWtmp_h########__0 or [hybrid] __VassignWgen_h########__0)
--V{t#,#}         'act' region trigger index 3 is active: @(posedge t.clk1)
--V{t#,#}         'act' region trigger index 5 is active: @(posedge t.clk2)
+-V{t#,#}         'act' region trigger index 0 is active: @([hybrid] t.clk1)
+-V{t#,#}         'act' region trigger index 3 is active: @([hybrid] t.clk2)
+-V{t#,#}         'act' region trigger index 7 is active: @(posedge t.clk1)
+-V{t#,#}         'act' region trigger index 9 is active: @(posedge t.clk2)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Ready processes waiting for @(posedge t.clk1):
@@ -993,9 +1015,11 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 0 is active: @([hybrid] t.clk1 or [hybrid] __VassignWtmp_h########__0 or [hybrid] __VassignWgen_h########__0)
--V{t#,#}         'act' region trigger index 1 is active: @([hybrid] t.clk2 or [hybrid] __VassignWtmp_h########__0 or [hybrid] __VassignWgen_h########__0)
--V{t#,#}         'act' region trigger index 2 is active: @([hybrid] t.c1)
+-V{t#,#}         'act' region trigger index 1 is active: @([hybrid] __VassignWtmp_h########__0)
+-V{t#,#}         'act' region trigger index 2 is active: @([hybrid] __VassignWgen_h########__0)
+-V{t#,#}         'act' region trigger index 4 is active: @([hybrid] __VassignWtmp_h########__0)
+-V{t#,#}         'act' region trigger index 5 is active: @([hybrid] __VassignWgen_h########__0)
+-V{t#,#}         'act' region trigger index 6 is active: @([hybrid] t.c1)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}         Committing processes waiting for @(posedge t.clk1):
 -V{t#,#}           - Process waiting at t/t_timing_sched.v:18
@@ -1027,7 +1051,7 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 4 is active: @([true] __VdlySched.awaitingCurrentTime())
+-V{t#,#}         'act' region trigger index 8 is active: @([true] __VdlySched.awaitingCurrentTime())
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Delayed processes:
@@ -1065,7 +1089,7 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 4 is active: @([true] __VdlySched.awaitingCurrentTime())
+-V{t#,#}         'act' region trigger index 8 is active: @([true] __VdlySched.awaitingCurrentTime())
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Delayed processes:
@@ -1080,7 +1104,7 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 0 is active: @([hybrid] t.clk1 or [hybrid] __VassignWtmp_h########__0 or [hybrid] __VassignWgen_h########__0)
+-V{t#,#}         'act' region trigger index 0 is active: @([hybrid] t.clk1)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
@@ -1089,7 +1113,8 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 0 is active: @([hybrid] t.clk1 or [hybrid] __VassignWtmp_h########__0 or [hybrid] __VassignWgen_h########__0)
+-V{t#,#}         'act' region trigger index 1 is active: @([hybrid] __VassignWtmp_h########__0)
+-V{t#,#}         'act' region trigger index 2 is active: @([hybrid] __VassignWgen_h########__0)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
@@ -1116,7 +1141,7 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 4 is active: @([true] __VdlySched.awaitingCurrentTime())
+-V{t#,#}         'act' region trigger index 8 is active: @([true] __VdlySched.awaitingCurrentTime())
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Delayed processes:
@@ -1153,7 +1178,7 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 4 is active: @([true] __VdlySched.awaitingCurrentTime())
+-V{t#,#}         'act' region trigger index 8 is active: @([true] __VdlySched.awaitingCurrentTime())
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Delayed processes:
@@ -1167,8 +1192,8 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 0 is active: @([hybrid] t.clk1 or [hybrid] __VassignWtmp_h########__0 or [hybrid] __VassignWgen_h########__0)
--V{t#,#}         'act' region trigger index 3 is active: @(posedge t.clk1)
+-V{t#,#}         'act' region trigger index 0 is active: @([hybrid] t.clk1)
+-V{t#,#}         'act' region trigger index 7 is active: @(posedge t.clk1)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Ready processes waiting for @(posedge t.clk1):
@@ -1188,7 +1213,8 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 0 is active: @([hybrid] t.clk1 or [hybrid] __VassignWtmp_h########__0 or [hybrid] __VassignWgen_h########__0)
+-V{t#,#}         'act' region trigger index 1 is active: @([hybrid] __VassignWtmp_h########__0)
+-V{t#,#}         'act' region trigger index 2 is active: @([hybrid] __VassignWgen_h########__0)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}         Committing processes waiting for @(posedge t.clk2):
 -V{t#,#}           - Process waiting at t/t_timing_sched.v:18
@@ -1218,7 +1244,7 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 4 is active: @([true] __VdlySched.awaitingCurrentTime())
+-V{t#,#}         'act' region trigger index 8 is active: @([true] __VdlySched.awaitingCurrentTime())
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Delayed processes:
@@ -1233,7 +1259,7 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 0 is active: @([hybrid] t.clk1 or [hybrid] __VassignWtmp_h########__0 or [hybrid] __VassignWgen_h########__0)
+-V{t#,#}         'act' region trigger index 0 is active: @([hybrid] t.clk1)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
@@ -1242,7 +1268,8 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 0 is active: @([hybrid] t.clk1 or [hybrid] __VassignWtmp_h########__0 or [hybrid] __VassignWgen_h########__0)
+-V{t#,#}         'act' region trigger index 1 is active: @([hybrid] __VassignWtmp_h########__0)
+-V{t#,#}         'act' region trigger index 2 is active: @([hybrid] __VassignWgen_h########__0)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
@@ -1269,7 +1296,7 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 4 is active: @([true] __VdlySched.awaitingCurrentTime())
+-V{t#,#}         'act' region trigger index 8 is active: @([true] __VdlySched.awaitingCurrentTime())
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Delayed processes:
@@ -1306,7 +1333,7 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 4 is active: @([true] __VdlySched.awaitingCurrentTime())
+-V{t#,#}         'act' region trigger index 8 is active: @([true] __VdlySched.awaitingCurrentTime())
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Delayed processes:
@@ -1320,7 +1347,7 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 1 is active: @([hybrid] t.clk2 or [hybrid] __VassignWtmp_h########__0 or [hybrid] __VassignWgen_h########__0)
+-V{t#,#}         'act' region trigger index 3 is active: @([hybrid] t.clk2)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
@@ -1329,7 +1356,8 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 1 is active: @([hybrid] t.clk2 or [hybrid] __VassignWtmp_h########__0 or [hybrid] __VassignWgen_h########__0)
+-V{t#,#}         'act' region trigger index 4 is active: @([hybrid] __VassignWtmp_h########__0)
+-V{t#,#}         'act' region trigger index 5 is active: @([hybrid] __VassignWgen_h########__0)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
@@ -1356,7 +1384,7 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 4 is active: @([true] __VdlySched.awaitingCurrentTime())
+-V{t#,#}         'act' region trigger index 8 is active: @([true] __VdlySched.awaitingCurrentTime())
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Delayed processes:
@@ -1370,8 +1398,8 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 0 is active: @([hybrid] t.clk1 or [hybrid] __VassignWtmp_h########__0 or [hybrid] __VassignWgen_h########__0)
--V{t#,#}         'act' region trigger index 3 is active: @(posedge t.clk1)
+-V{t#,#}         'act' region trigger index 0 is active: @([hybrid] t.clk1)
+-V{t#,#}         'act' region trigger index 7 is active: @(posedge t.clk1)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Ready processes waiting for @(posedge t.clk1):
@@ -1387,7 +1415,8 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 0 is active: @([hybrid] t.clk1 or [hybrid] __VassignWtmp_h########__0 or [hybrid] __VassignWgen_h########__0)
+-V{t#,#}         'act' region trigger index 1 is active: @([hybrid] __VassignWtmp_h########__0)
+-V{t#,#}         'act' region trigger index 2 is active: @([hybrid] __VassignWgen_h########__0)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
@@ -1415,7 +1444,7 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 4 is active: @([true] __VdlySched.awaitingCurrentTime())
+-V{t#,#}         'act' region trigger index 8 is active: @([true] __VdlySched.awaitingCurrentTime())
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Delayed processes:
@@ -1430,7 +1459,7 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 0 is active: @([hybrid] t.clk1 or [hybrid] __VassignWtmp_h########__0 or [hybrid] __VassignWgen_h########__0)
+-V{t#,#}         'act' region trigger index 0 is active: @([hybrid] t.clk1)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
@@ -1439,7 +1468,8 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 0 is active: @([hybrid] t.clk1 or [hybrid] __VassignWtmp_h########__0 or [hybrid] __VassignWgen_h########__0)
+-V{t#,#}         'act' region trigger index 1 is active: @([hybrid] __VassignWtmp_h########__0)
+-V{t#,#}         'act' region trigger index 2 is active: @([hybrid] __VassignWgen_h########__0)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
@@ -1466,7 +1496,7 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 4 is active: @([true] __VdlySched.awaitingCurrentTime())
+-V{t#,#}         'act' region trigger index 8 is active: @([true] __VdlySched.awaitingCurrentTime())
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Delayed processes:
@@ -1503,7 +1533,7 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 4 is active: @([true] __VdlySched.awaitingCurrentTime())
+-V{t#,#}         'act' region trigger index 8 is active: @([true] __VdlySched.awaitingCurrentTime())
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Delayed processes:
@@ -1517,8 +1547,8 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 0 is active: @([hybrid] t.clk1 or [hybrid] __VassignWtmp_h########__0 or [hybrid] __VassignWgen_h########__0)
--V{t#,#}         'act' region trigger index 3 is active: @(posedge t.clk1)
+-V{t#,#}         'act' region trigger index 0 is active: @([hybrid] t.clk1)
+-V{t#,#}         'act' region trigger index 7 is active: @(posedge t.clk1)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Ready processes waiting for @(posedge t.clk1):
@@ -1534,7 +1564,8 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 0 is active: @([hybrid] t.clk1 or [hybrid] __VassignWtmp_h########__0 or [hybrid] __VassignWgen_h########__0)
+-V{t#,#}         'act' region trigger index 1 is active: @([hybrid] __VassignWtmp_h########__0)
+-V{t#,#}         'act' region trigger index 2 is active: @([hybrid] __VassignWgen_h########__0)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
@@ -1562,7 +1593,7 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 4 is active: @([true] __VdlySched.awaitingCurrentTime())
+-V{t#,#}         'act' region trigger index 8 is active: @([true] __VdlySched.awaitingCurrentTime())
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Delayed processes:
@@ -1577,7 +1608,7 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 0 is active: @([hybrid] t.clk1 or [hybrid] __VassignWtmp_h########__0 or [hybrid] __VassignWgen_h########__0)
+-V{t#,#}         'act' region trigger index 0 is active: @([hybrid] t.clk1)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
@@ -1586,7 +1617,8 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 0 is active: @([hybrid] t.clk1 or [hybrid] __VassignWtmp_h########__0 or [hybrid] __VassignWgen_h########__0)
+-V{t#,#}         'act' region trigger index 1 is active: @([hybrid] __VassignWtmp_h########__0)
+-V{t#,#}         'act' region trigger index 2 is active: @([hybrid] __VassignWgen_h########__0)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
@@ -1613,7 +1645,7 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 4 is active: @([true] __VdlySched.awaitingCurrentTime())
+-V{t#,#}         'act' region trigger index 8 is active: @([true] __VdlySched.awaitingCurrentTime())
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Delayed processes:
@@ -1630,8 +1662,8 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 1 is active: @([hybrid] t.clk2 or [hybrid] __VassignWtmp_h########__0 or [hybrid] __VassignWgen_h########__0)
--V{t#,#}         'act' region trigger index 5 is active: @(posedge t.clk2)
+-V{t#,#}         'act' region trigger index 3 is active: @([hybrid] t.clk2)
+-V{t#,#}         'act' region trigger index 9 is active: @(posedge t.clk2)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}         Committing processes waiting for @(posedge t.clk1):
 -V{t#,#}           - Process waiting at t/t_timing_sched.v:17
@@ -1652,8 +1684,9 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 1 is active: @([hybrid] t.clk2 or [hybrid] __VassignWtmp_h########__0 or [hybrid] __VassignWgen_h########__0)
--V{t#,#}         'act' region trigger index 2 is active: @([hybrid] t.c1)
+-V{t#,#}         'act' region trigger index 4 is active: @([hybrid] __VassignWtmp_h########__0)
+-V{t#,#}         'act' region trigger index 5 is active: @([hybrid] __VassignWgen_h########__0)
+-V{t#,#}         'act' region trigger index 6 is active: @([hybrid] t.c1)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}         Committing processes waiting for @(posedge t.clk1):
 -V{t#,#}           - Process waiting at t/t_timing_sched.v:18
@@ -1683,7 +1716,7 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 4 is active: @([true] __VdlySched.awaitingCurrentTime())
+-V{t#,#}         'act' region trigger index 8 is active: @([true] __VdlySched.awaitingCurrentTime())
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Delayed processes:
@@ -1720,7 +1753,7 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 4 is active: @([true] __VdlySched.awaitingCurrentTime())
+-V{t#,#}         'act' region trigger index 8 is active: @([true] __VdlySched.awaitingCurrentTime())
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Delayed processes:
@@ -1734,8 +1767,8 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 0 is active: @([hybrid] t.clk1 or [hybrid] __VassignWtmp_h########__0 or [hybrid] __VassignWgen_h########__0)
--V{t#,#}         'act' region trigger index 3 is active: @(posedge t.clk1)
+-V{t#,#}         'act' region trigger index 0 is active: @([hybrid] t.clk1)
+-V{t#,#}         'act' region trigger index 7 is active: @(posedge t.clk1)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Ready processes waiting for @(posedge t.clk1):
@@ -1755,7 +1788,8 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 0 is active: @([hybrid] t.clk1 or [hybrid] __VassignWtmp_h########__0 or [hybrid] __VassignWgen_h########__0)
+-V{t#,#}         'act' region trigger index 1 is active: @([hybrid] __VassignWtmp_h########__0)
+-V{t#,#}         'act' region trigger index 2 is active: @([hybrid] __VassignWgen_h########__0)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}         Committing processes waiting for @(posedge t.clk2):
 -V{t#,#}           - Process waiting at t/t_timing_sched.v:18
@@ -1785,7 +1819,7 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 4 is active: @([true] __VdlySched.awaitingCurrentTime())
+-V{t#,#}         'act' region trigger index 8 is active: @([true] __VdlySched.awaitingCurrentTime())
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Delayed processes:
@@ -1800,7 +1834,7 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 0 is active: @([hybrid] t.clk1 or [hybrid] __VassignWtmp_h########__0 or [hybrid] __VassignWgen_h########__0)
+-V{t#,#}         'act' region trigger index 0 is active: @([hybrid] t.clk1)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
@@ -1809,7 +1843,8 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 0 is active: @([hybrid] t.clk1 or [hybrid] __VassignWtmp_h########__0 or [hybrid] __VassignWgen_h########__0)
+-V{t#,#}         'act' region trigger index 1 is active: @([hybrid] __VassignWtmp_h########__0)
+-V{t#,#}         'act' region trigger index 2 is active: @([hybrid] __VassignWgen_h########__0)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
@@ -1836,7 +1871,7 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 4 is active: @([true] __VdlySched.awaitingCurrentTime())
+-V{t#,#}         'act' region trigger index 8 is active: @([true] __VdlySched.awaitingCurrentTime())
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Delayed processes:
@@ -1873,7 +1908,7 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 4 is active: @([true] __VdlySched.awaitingCurrentTime())
+-V{t#,#}         'act' region trigger index 8 is active: @([true] __VdlySched.awaitingCurrentTime())
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Delayed processes:
@@ -1887,8 +1922,8 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 0 is active: @([hybrid] t.clk1 or [hybrid] __VassignWtmp_h########__0 or [hybrid] __VassignWgen_h########__0)
--V{t#,#}         'act' region trigger index 3 is active: @(posedge t.clk1)
+-V{t#,#}         'act' region trigger index 0 is active: @([hybrid] t.clk1)
+-V{t#,#}         'act' region trigger index 7 is active: @(posedge t.clk1)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Ready processes waiting for @(posedge t.clk1):
@@ -1904,7 +1939,8 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 0 is active: @([hybrid] t.clk1 or [hybrid] __VassignWtmp_h########__0 or [hybrid] __VassignWgen_h########__0)
+-V{t#,#}         'act' region trigger index 1 is active: @([hybrid] __VassignWtmp_h########__0)
+-V{t#,#}         'act' region trigger index 2 is active: @([hybrid] __VassignWgen_h########__0)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
@@ -1932,7 +1968,7 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 4 is active: @([true] __VdlySched.awaitingCurrentTime())
+-V{t#,#}         'act' region trigger index 8 is active: @([true] __VdlySched.awaitingCurrentTime())
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Delayed processes:
@@ -1948,8 +1984,8 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 0 is active: @([hybrid] t.clk1 or [hybrid] __VassignWtmp_h########__0 or [hybrid] __VassignWgen_h########__0)
--V{t#,#}         'act' region trigger index 1 is active: @([hybrid] t.clk2 or [hybrid] __VassignWtmp_h########__0 or [hybrid] __VassignWgen_h########__0)
+-V{t#,#}         'act' region trigger index 0 is active: @([hybrid] t.clk1)
+-V{t#,#}         'act' region trigger index 3 is active: @([hybrid] t.clk2)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
@@ -1960,8 +1996,10 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 0 is active: @([hybrid] t.clk1 or [hybrid] __VassignWtmp_h########__0 or [hybrid] __VassignWgen_h########__0)
--V{t#,#}         'act' region trigger index 1 is active: @([hybrid] t.clk2 or [hybrid] __VassignWtmp_h########__0 or [hybrid] __VassignWgen_h########__0)
+-V{t#,#}         'act' region trigger index 1 is active: @([hybrid] __VassignWtmp_h########__0)
+-V{t#,#}         'act' region trigger index 2 is active: @([hybrid] __VassignWgen_h########__0)
+-V{t#,#}         'act' region trigger index 4 is active: @([hybrid] __VassignWtmp_h########__0)
+-V{t#,#}         'act' region trigger index 5 is active: @([hybrid] __VassignWgen_h########__0)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
@@ -1989,7 +2027,7 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 4 is active: @([true] __VdlySched.awaitingCurrentTime())
+-V{t#,#}         'act' region trigger index 8 is active: @([true] __VdlySched.awaitingCurrentTime())
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Delayed processes:
@@ -2026,7 +2064,7 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 4 is active: @([true] __VdlySched.awaitingCurrentTime())
+-V{t#,#}         'act' region trigger index 8 is active: @([true] __VdlySched.awaitingCurrentTime())
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Delayed processes:
@@ -2040,8 +2078,8 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 0 is active: @([hybrid] t.clk1 or [hybrid] __VassignWtmp_h########__0 or [hybrid] __VassignWgen_h########__0)
--V{t#,#}         'act' region trigger index 3 is active: @(posedge t.clk1)
+-V{t#,#}         'act' region trigger index 0 is active: @([hybrid] t.clk1)
+-V{t#,#}         'act' region trigger index 7 is active: @(posedge t.clk1)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Ready processes waiting for @(posedge t.clk1):
@@ -2057,7 +2095,8 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 0 is active: @([hybrid] t.clk1 or [hybrid] __VassignWtmp_h########__0 or [hybrid] __VassignWgen_h########__0)
+-V{t#,#}         'act' region trigger index 1 is active: @([hybrid] __VassignWtmp_h########__0)
+-V{t#,#}         'act' region trigger index 2 is active: @([hybrid] __VassignWgen_h########__0)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
@@ -2085,7 +2124,7 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 4 is active: @([true] __VdlySched.awaitingCurrentTime())
+-V{t#,#}         'act' region trigger index 8 is active: @([true] __VdlySched.awaitingCurrentTime())
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Delayed processes:
@@ -2100,7 +2139,7 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 0 is active: @([hybrid] t.clk1 or [hybrid] __VassignWtmp_h########__0 or [hybrid] __VassignWgen_h########__0)
+-V{t#,#}         'act' region trigger index 0 is active: @([hybrid] t.clk1)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
@@ -2109,7 +2148,8 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 0 is active: @([hybrid] t.clk1 or [hybrid] __VassignWtmp_h########__0 or [hybrid] __VassignWgen_h########__0)
+-V{t#,#}         'act' region trigger index 1 is active: @([hybrid] __VassignWtmp_h########__0)
+-V{t#,#}         'act' region trigger index 2 is active: @([hybrid] __VassignWgen_h########__0)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
@@ -2136,7 +2176,7 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 4 is active: @([true] __VdlySched.awaitingCurrentTime())
+-V{t#,#}         'act' region trigger index 8 is active: @([true] __VdlySched.awaitingCurrentTime())
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Delayed processes:
@@ -2173,7 +2213,7 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 4 is active: @([true] __VdlySched.awaitingCurrentTime())
+-V{t#,#}         'act' region trigger index 8 is active: @([true] __VdlySched.awaitingCurrentTime())
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Delayed processes:
@@ -2187,8 +2227,8 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 0 is active: @([hybrid] t.clk1 or [hybrid] __VassignWtmp_h########__0 or [hybrid] __VassignWgen_h########__0)
--V{t#,#}         'act' region trigger index 3 is active: @(posedge t.clk1)
+-V{t#,#}         'act' region trigger index 0 is active: @([hybrid] t.clk1)
+-V{t#,#}         'act' region trigger index 7 is active: @(posedge t.clk1)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Ready processes waiting for @(posedge t.clk1):
@@ -2204,7 +2244,8 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 0 is active: @([hybrid] t.clk1 or [hybrid] __VassignWtmp_h########__0 or [hybrid] __VassignWgen_h########__0)
+-V{t#,#}         'act' region trigger index 1 is active: @([hybrid] __VassignWtmp_h########__0)
+-V{t#,#}         'act' region trigger index 2 is active: @([hybrid] __VassignWgen_h########__0)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act
@@ -2232,7 +2273,7 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 4 is active: @([true] __VdlySched.awaitingCurrentTime())
+-V{t#,#}         'act' region trigger index 8 is active: @([true] __VdlySched.awaitingCurrentTime())
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Delayed processes:
@@ -2247,8 +2288,8 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 1 is active: @([hybrid] t.clk2 or [hybrid] __VassignWtmp_h########__0 or [hybrid] __VassignWgen_h########__0)
--V{t#,#}         'act' region trigger index 5 is active: @(posedge t.clk2)
+-V{t#,#}         'act' region trigger index 3 is active: @([hybrid] t.clk2)
+-V{t#,#}         'act' region trigger index 9 is active: @(posedge t.clk2)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Ready processes waiting for @(posedge t.clk2):
@@ -2267,8 +2308,9 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 1 is active: @([hybrid] t.clk2 or [hybrid] __VassignWtmp_h########__0 or [hybrid] __VassignWgen_h########__0)
--V{t#,#}         'act' region trigger index 2 is active: @([hybrid] t.c1)
+-V{t#,#}         'act' region trigger index 4 is active: @([hybrid] __VassignWtmp_h########__0)
+-V{t#,#}         'act' region trigger index 5 is active: @([hybrid] __VassignWgen_h########__0)
+-V{t#,#}         'act' region trigger index 6 is active: @([hybrid] t.c1)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}         Committing processes waiting for @(posedge t.clk1):
 -V{t#,#}           - Process waiting at t/t_timing_sched.v:18
@@ -2298,7 +2340,7 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 4 is active: @([true] __VdlySched.awaitingCurrentTime())
+-V{t#,#}         'act' region trigger index 8 is active: @([true] __VdlySched.awaitingCurrentTime())
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}         Delayed processes:
@@ -2318,7 +2360,7 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 0 is active: @([hybrid] t.clk1 or [hybrid] __VassignWtmp_h########__0 or [hybrid] __VassignWgen_h########__0)
+-V{t#,#}         'act' region trigger index 0 is active: @([hybrid] t.clk1)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}         Committing processes waiting for @(posedge t.clk2):
 -V{t#,#}           - Process waiting at t/t_timing_sched.v:50
@@ -2329,7 +2371,8 @@
 -V{t#,#}+    Vt_timing_debug1___024root___eval_phase__act
 -V{t#,#}+    Vt_timing_debug1___024root___eval_triggers__act
 -V{t#,#}+    Vt_timing_debug1___024root___dump_triggers__act
--V{t#,#}         'act' region trigger index 0 is active: @([hybrid] t.clk1 or [hybrid] __VassignWtmp_h########__0 or [hybrid] __VassignWgen_h########__0)
+-V{t#,#}         'act' region trigger index 1 is active: @([hybrid] __VassignWtmp_h########__0)
+-V{t#,#}         'act' region trigger index 2 is active: @([hybrid] __VassignWgen_h########__0)
 -V{t#,#}+    Vt_timing_debug1___024root___timing_commit
 -V{t#,#}+    Vt_timing_debug1___024root___timing_resume
 -V{t#,#}+    Vt_timing_debug1___024root___eval_act


### PR DESCRIPTION
This has no real effect on simple designs, but have a minor performance benefit (2-10%) on designs with complex clocking, or those with a lot of UNOPTFLAT, due to reducing the total number of trigger bits.