### PR TITLE
Support unpacked array Constrained Randomization (#5437)

### DIFF
--- a/include/verilated_random.cpp
+++ b/include/verilated_random.cpp
@@ -252,9 +252,7 @@ static Process& getSolver() {
 
 void copystream(std::iostream& input, std::ostream& output) {
     std::string line;
-    while (std::getline(input, line)) {
-        output << line << "\n";
-    }
+    while (std::getline(input, line)) { output << line << "\n"; }
 }
 
 std::pair<std::string, bool> readUntilBalanced(std::iostream& stream) {
@@ -277,15 +275,13 @@ std::pair<std::string, bool> readUntilBalanced(std::iostream& stream) {
 
         if (started && parenCount <= 0) {
             if (parenCount < 0) {
-                endFlag = true; // Indicate that we have extra closing parenthesis
+                endFlag = true;  // Indicate that we have extra closing parenthesis
             }
             break;
         }
     }
     // Remove trailing space and return the balanced expression and end flag
-    if (!result.empty() && result.back() == ' ') {
-        result.pop_back();
-    }
+    if (!result.empty() && result.back() == ' ') { result.pop_back(); }
     return {result, endFlag};
 }
 
@@ -294,9 +290,7 @@ std::string trim(const std::string& str) {
     result.erase(result.find_last_not_of(" \n\r\t") + 1);
     result.erase(0, result.find_first_not_of(" \n\r\t"));
     // Remove trailing ')' if it exists
-    while (!result.empty() && result.back() == ')') {
-        result.pop_back();
-    }
+    while (!result.empty() && result.back() == ')') { result.pop_back(); }
     return result;
 }
 struct ParsedExpr {
@@ -307,12 +301,8 @@ struct ParsedExpr {
 };
 std::string extractNextToken(const std::string& expr, size_t& pos) {
     // Skip any leading whitespace
-    while (pos < expr.size() && isspace(expr[pos])) {
-        ++pos;
-    }
-    if (pos >= expr.size()) {
-        return "";
-    }
+    while (pos < expr.size() && isspace(expr[pos])) { ++pos; }
+    if (pos >= expr.size()) { return ""; }
     // Handle nested structures by balancing parentheses
     if (expr[pos] == '(') {
         int parenCount = 0;
@@ -366,16 +356,15 @@ ParsedExpr parseExpr(const std::string& expr) {
         result = parseSelectExpr(expr, pos);
         std::cout << "[SELECT Parsing] Array Name: " << result.name << std::endl;
         std::cout << "Indices: ";
-        for (const auto& idx : result.indices) {
-            std::cout << idx << " ";
-        }
+        for (const auto& idx : result.indices) { std::cout << idx << " "; }
         std::cout << std::endl;
     } else {
         // Simple assignment (just trim and assign the result)
         size_t nameEnd = token.find(' ');
         result.name = token.substr(0, nameEnd);
         result.value = trim(expr.substr(pos));
-        std::cout << "[SIMPLE Parsing] Name: " << result.name << ", Value: " << result.value << std::endl;
+        std::cout << "[SIMPLE Parsing] Name: " << result.name << ", Value: " << result.value
+                  << std::endl;
     }
     return result;
 }
@@ -535,13 +524,12 @@ bool VlRandomizer::parseSolution(std::iostream& f) {
         if (it != m_vars.end()) {
             const VlRandomVar& varr = *it->second;
             if (parsed.isSelectOperation) {
-                std::cout << "Assigning value '" << parsed.value 
-                    << "' to array/variable '" << parsed.name 
-                    << "' at index '" << parsed.idx << "'" << std::endl;
+                std::cout << "Assigning value '" << parsed.value << "' to array/variable '"
+                          << parsed.name << "' at index '" << parsed.idx << "'" << std::endl;
                 varr.set(parsed.idx, parsed.value);
             } else {
-                std::cout << "Assigning value '" << parsed.value 
-                    << "' to variable '" << parsed.name << "'" << std::endl;
+                std::cout << "Assigning value '" << parsed.value << "' to variable '"
+                          << parsed.name << "'" << std::endl;
                 varr.set("", parsed.value);
             }
         }

--- a/include/verilated_random.cpp
+++ b/include/verilated_random.cpp
@@ -250,6 +250,7 @@ static Process& getSolver() {
     while (getline(s_solver, s)) {}
     return s_solver;
 }
+
 std::string readUntilBalanced(std::istream& stream) {
     std::string result;
     std::string token;
@@ -267,6 +268,7 @@ std::string readUntilBalanced(std::istream& stream) {
     }
     return result;
 }
+
 std::string parseNestedSelect(const std::string& nested_select_expr,
                               std::vector<std::string>& indices) {
     std::istringstream nestedStream(nested_select_expr);
@@ -280,6 +282,7 @@ std::string parseNestedSelect(const std::string& nested_select_expr,
     indices.push_back(idx);
     return name;
 }
+
 std::string flattenIndices(const std::vector<std::string>& indices, const VlRandomVar* var) {
     int flattenedIndex = 0;
     int multiplier = 1;
@@ -427,13 +430,12 @@ bool VlRandomizer::next(VlRNG& rngr) {
     }
     for (int i = 0; i < _VL_SOLVER_HASH_LEN_TOTAL && sat; i++) {
         f << "(assert ";
-        std::ostringstream outputStream;
         randomConstraint(f, rngr, _VL_SOLVER_HASH_LEN);
-        std::cout << outputStream.str() << std::endl;
         f << ")\n";
         f << "\n(check-sat)\n";
         sat = parseSolution(f);
     }
+
     f << "(reset)\n";
     return true;
 }
@@ -441,6 +443,7 @@ bool VlRandomizer::next(VlRNG& rngr) {
 bool VlRandomizer::parseSolution(std::iostream& f) {
     std::string sat;
     do { std::getline(f, sat); } while (sat == "");
+
     if (sat == "unsat") return false;
     if (sat != "sat") {
         std::stringstream msg;
@@ -462,6 +465,7 @@ bool VlRandomizer::parseSolution(std::iostream& f) {
                    "Internal: Unable to parse solver's response: invalid S-expression");
         return false;
     }
+
     while (true) {
         f >> c;
         if (c == ')') break;
@@ -470,7 +474,7 @@ bool VlRandomizer::parseSolution(std::iostream& f) {
                        "Internal: Unable to parse solver's response: invalid S-expression");
             return false;
         }
-        std::string name, value, idx;
+        std::string name, idx, value;
         std::vector<std::string> indices;
         f >> name;
         indices.clear();

--- a/include/verilated_random.cpp
+++ b/include/verilated_random.cpp
@@ -301,16 +301,15 @@ std::string flattenIndices(const std::vector<std::string>& indices, const VlRand
         }
         int length = var->getLength(i);
         if (length == -1) {
-            VL_WARN_MT(__FILE__, __LINE__, "randomize", "Internal: Wrong Call: Only RandomArray can call getLength()");
+            VL_WARN_MT(__FILE__, __LINE__, "randomize",
+                       "Internal: Wrong Call: Only RandomArray can call getLength()");
             break;
         }
         flattenedIndex += indexValue * multiplier;
         multiplier *= length;
     }
     std::string hexString = std::to_string(flattenedIndex);
-    while (hexString.size() < 8) {
-        hexString.insert(0, "0");
-    }
+    while (hexString.size() < 8) { hexString.insert(0, "0"); }
     return "#x" + hexString;
 }
 //======================================================================

--- a/include/verilated_random.cpp
+++ b/include/verilated_random.cpp
@@ -22,10 +22,10 @@
 
 #include "verilated_random.h"
 
+#include <iomanip>
 #include <iostream>
 #include <sstream>
 #include <streambuf>
-#include <iomanip>
 
 #define _VL_SOLVER_HASH_LEN 1
 #define _VL_SOLVER_HASH_LEN_TOTAL 4
@@ -267,7 +267,8 @@ std::string readUntilBalanced(std::istream& stream) {
     }
     return result;
 }
-std::string parseNestedSelect(const std::string& nested_select_expr, std::vector<std::string>& indices) {
+std::string parseNestedSelect(const std::string& nested_select_expr,
+                              std::vector<std::string>& indices) {
     std::istringstream nestedStream(nested_select_expr);
     std::string name, idx;
     nestedStream >> name;
@@ -488,7 +489,9 @@ bool VlRandomizer::parseSolution(std::iostream& f) {
         if (indices.size() > 1) {
             std::string flattenedIndex = flattenIndices(indices, &varr);
             varr.set(flattenedIndex, value);
-        } else { varr.set(idx, value); }
+        } else {
+            varr.set(idx, value);
+        }
     }
     return true;
 }

--- a/include/verilated_random.cpp
+++ b/include/verilated_random.cpp
@@ -255,7 +255,7 @@ std::string readUntilBalanced(std::istream& stream) {
     std::string token;
     int parenCount = 1;
     while (stream >> token) {
-        for (char c : token) {
+        for (const char c : token) {
             if (c == '(') {
                 ++parenCount;
             } else if (c == ')') {
@@ -274,7 +274,7 @@ std::string parseNestedSelect(const std::string& nested_select_expr,
     std::string name, idx;
     nestedStream >> name;
     if (name == "(select") {
-        std::string further_nested_expr = readUntilBalanced(nestedStream);
+        const std::string further_nested_expr = readUntilBalanced(nestedStream);
         name = parseNestedSelect(further_nested_expr, indices);
     }
     std::getline(nestedStream, idx, ')');
@@ -282,7 +282,7 @@ std::string parseNestedSelect(const std::string& nested_select_expr,
     return name;
 }
 
-std::string flattenIndices(const std::vector<std::string>& indices, const VlRandomVar* var) {
+std::string flattenIndices(const std::vector<std::string>& indices, const VlRandomVar* const var) {
     int flattenedIndex = 0;
     int multiplier = 1;
     for (int i = indices.size() - 1; i >= 0; --i) {
@@ -299,7 +299,7 @@ std::string flattenIndices(const std::vector<std::string>& indices, const VlRand
         } else {
             indexValue = std::strtoul(trimmedIndex.c_str(), nullptr, 10);
         }
-        int length = var->getLength(i);
+        const int length = var->getLength(i);
         if (length == -1) {
             VL_WARN_MT(__FILE__, __LINE__, "randomize",
                        "Internal: Wrong Call: Only RandomArray can call getLength()");
@@ -469,19 +469,19 @@ bool VlRandomizer::parseSolution(std::iostream& f) {
         f >> name;
         indices.clear();
         if (name == "(select") {
-            std::string selectExpr = readUntilBalanced(f);
+            const std::string selectExpr = readUntilBalanced(f);
             name = parseNestedSelect(selectExpr, indices);
             idx = indices[0];
         }
         std::getline(f, value, ')');
-        auto it = m_vars.find(name);
+        const auto it = m_vars.find(name);
         if (it == m_vars.end()) continue;
         const VlRandomVar& varr = *it->second;
         if (m_randmode && !varr.randModeIdxNone()) {
             if (!(m_randmode->at(varr.randModeIdx()))) continue;
         }
         if (indices.size() > 1) {
-            std::string flattenedIndex = flattenIndices(indices, &varr);
+            const std::string flattenedIndex = flattenIndices(indices, &varr);
             varr.set(flattenedIndex, value);
         } else {
             varr.set(idx, value);

--- a/include/verilated_random.cpp
+++ b/include/verilated_random.cpp
@@ -250,6 +250,135 @@ static Process& getSolver() {
     return s_solver;
 }
 
+void copystream(std::iostream& input, std::ostream& output) {
+    std::string line;
+    while (std::getline(input, line)) {
+        output << line << "\n";
+    }
+}
+
+std::pair<std::string, bool> readUntilBalanced(std::iostream& stream) {
+    std::string result;
+    std::string token;
+    int parenCount = 0;
+    bool started = false;
+    bool endFlag = false;
+
+    while (stream >> token) {
+        for (char c : token) {
+            if (c == '(') {
+                parenCount++;
+                started = true;
+            } else if (c == ')') {
+                parenCount--;
+            }
+        }
+        result += token + " ";
+
+        if (started && parenCount <= 0) {
+            if (parenCount < 0) {
+                endFlag = true; // Indicate that we have extra closing parenthesis
+            }
+            break;
+        }
+    }
+    // Remove trailing space and return the balanced expression and end flag
+    if (!result.empty() && result.back() == ' ') {
+        result.pop_back();
+    }
+    return {result, endFlag};
+}
+
+std::string trim(const std::string& str) {
+    std::string result = str;
+    result.erase(result.find_last_not_of(" \n\r\t") + 1);
+    result.erase(0, result.find_first_not_of(" \n\r\t"));
+    // Remove trailing ')' if it exists
+    while (!result.empty() && result.back() == ')') {
+        result.pop_back();
+    }
+    return result;
+}
+struct ParsedExpr {
+    std::string name;
+    std::vector<std::string> indices;
+    std::string value;
+    bool isSelectOperation = false;
+};
+std::string extractNextToken(const std::string& expr, size_t& pos) {
+    // Skip any leading whitespace
+    while (pos < expr.size() && isspace(expr[pos])) {
+        ++pos;
+    }
+    if (pos >= expr.size()) {
+        return "";
+    }
+    // Handle nested structures by balancing parentheses
+    if (expr[pos] == '(') {
+        int parenCount = 0;
+        size_t startPos = pos;
+        do {
+            if (expr[pos] == '(') {
+                parenCount++;
+            } else if (expr[pos] == ')') {
+                parenCount--;
+            }
+            ++pos;
+        } while (pos < expr.size() && parenCount > 0);
+        return expr.substr(startPos, pos - startPos);
+    }
+
+    // Handle simple tokens (until next whitespace or parentheses)
+    size_t startPos = pos;
+    while (pos < expr.size() && !isspace(expr[pos]) && expr[pos] != '(' && expr[pos] != ')') {
+        ++pos;
+    }
+    return expr.substr(startPos, pos - startPos);
+}
+ParsedExpr parseSelectExpr(const std::string& expr, size_t& pos) {
+    ParsedExpr result;
+    result.isSelectOperation = true;
+
+    std::string token;
+    while (pos < expr.size()) {
+        token = extractNextToken(expr, pos);
+        if (token == "(select") {
+            // Recursively parse the next select expression
+            ParsedExpr innerResult = parseSelectExpr(expr, pos);
+            result.name = innerResult.name;
+            result.indices = innerResult.indices;
+        } else if (!token.empty() && token[0] != '(') {
+            result.name = token;  // The array or variable name
+        } else if (!token.empty()) {
+            result.indices.push_back(trim(token));  // The indices for the select operation
+        }
+    }
+    return result;
+}
+ParsedExpr parseExpr(const std::string& expr) {
+    ParsedExpr result;
+
+    size_t pos = 0;
+    std::string token = extractNextToken(expr, pos);
+
+    if (token == "(select") {
+        // If it's a select operation, parse it
+        result = parseSelectExpr(expr, pos);
+        std::cout << "[SELECT Parsing] Array Name: " << result.name << std::endl;
+        std::cout << "Indices: ";
+        for (const auto& idx : result.indices) {
+            std::cout << idx << " ";
+        }
+        std::cout << std::endl;
+    } else {
+        // Simple assignment (just trim and assign the result)
+        size_t nameEnd = token.find(' ');
+        result.name = token.substr(0, nameEnd);
+        result.value = trim(expr.substr(pos));
+        std::cout << "[SIMPLE Parsing] Name: " << result.name << ", Value: " << result.value << std::endl;
+    }
+    return result;
+}
 //======================================================================
 // VlRandomizer:: Methods
 
@@ -356,7 +485,8 @@ bool VlRandomizer::next(VlRNG& rngr) {
         f << "(reset)\n";
         return false;
     }
-
+    std::cout << sat << std::endl;
+    /*
     for (int i = 0; i < _VL_SOLVER_HASH_LEN_TOTAL && sat; i++) {
         f << "(assert ";
         randomConstraint(f, rngr, _VL_SOLVER_HASH_LEN);
@@ -364,7 +494,7 @@ bool VlRandomizer::next(VlRNG& rngr) {
         f << "\n(check-sat)\n";
         sat = parseSolution(f);
     }
-
+    */
     f << "(reset)\n";
     return true;
 }
@@ -372,7 +502,7 @@ bool VlRandomizer::next(VlRNG& rngr) {
 bool VlRandomizer::parseSolution(std::iostream& f) {
     std::string sat;
     do { std::getline(f, sat); } while (sat == "");
-
+    dump();
     if (sat == "unsat") return false;
     if (sat != "sat") {
         std::stringstream msg;
@@ -394,34 +524,29 @@ bool VlRandomizer::parseSolution(std::iostream& f) {
                    "Internal: Unable to parse solver's response: invalid S-expression");
         return false;
     }
-
     while (true) {
-        f >> c;
-        if (c == ')') break;
-        if (c != '(') {
-            VL_WARN_MT(__FILE__, __LINE__, "randomize",
-                       "Internal: Unable to parse solver's response: invalid S-expression");
-            return false;
-        }
+        auto [expr, endFlag] = readUntilBalanced(f);
+        std::cout << " Received result in parseSolution: " << expr << std::endl;
+        if (expr.empty()) break;
 
-        std::string name, idx, value;
-        f >> name;
-        if (name == "(select") {
-            f >> name;
-            std::getline(f, idx, ')');
+        ParsedExpr parsed = parseExpr(expr);
+        std::cout << " In parseSolution: " << std::endl;
+        auto it = m_vars.find(parsed.name);
+        if (it != m_vars.end()) {
+            const VlRandomVar& varr = *it->second;
+            if (parsed.isSelectOperation) {
+                std::cout << "Assigning value '" << parsed.value 
+                    << "' to array/variable '" << parsed.name 
+                    << "' at index '" << parsed.idx << "'" << std::endl;
+                varr.set(parsed.idx, parsed.value);
+            } else {
+                std::cout << "Assigning value '" << parsed.value 
+                    << "' to variable '" << parsed.name << "'" << std::endl;
+                varr.set("", parsed.value);
+            }
         }
-        std::getline(f, value, ')');
-
-        auto it = m_vars.find(name);
-        if (it == m_vars.end()) continue;
-        const VlRandomVar& varr = *it->second;
-        if (m_randmode && !varr.randModeIdxNone()) {
-            if (!(m_randmode->at(varr.randModeIdx()))) continue;
-        }
-
-        varr.set(idx, value);
+        if (endFlag) break;
     }
-
     return true;
 }
 

--- a/include/verilated_random.h
+++ b/include/verilated_random.h
@@ -36,8 +36,8 @@ class VlRandomVar VL_NOT_FINAL {
     const char* const m_name;  // Variable name
     void* const m_datap;  // Reference to variable data
     const int m_width;  // Variable width in bits
-    const std::uint32_t m_randModeIdx;  // rand_mode index
     const int m_dimension;  //Variable dimension, default is 0
+    const std::uint32_t m_randModeIdx;  // rand_mode index
 
 public:
     VlRandomVar(const char* name, int width, void* datap, int dimension, std::uint32_t randModeIdx)

--- a/include/verilated_random.h
+++ b/include/verilated_random.h
@@ -27,9 +27,7 @@
 
 #include "verilated.h"
 
-#include <iostream>
 #include <ostream>
-#include <sstream>
 
 //=============================================================================
 // VlRandomExpr and subclasses represent expressions for the constraint solver.

--- a/include/verilated_random.h
+++ b/include/verilated_random.h
@@ -27,8 +27,8 @@
 
 #include "verilated.h"
 
-#include <ostream>
 #include <iostream>
+#include <ostream>
 #include <sstream>
 
 //=============================================================================
@@ -65,7 +65,8 @@ public:
 template <typename T>
 class VlRandomQueueVar final : public VlRandomVar {
 public:
-    VlRandomQueueVar(const char* name, int width, void* datap, int dimension, std::uint32_t randModeIdx)
+    VlRandomQueueVar(const char* name, int width, void* datap, int dimension,
+                     std::uint32_t randModeIdx)
         : VlRandomVar{name, width, datap, dimension, randModeIdx} {}
     void* datap(int idx) const override {
         return &static_cast<T*>(VlRandomVar::datap(idx))->atWrite(idx);
@@ -98,25 +99,22 @@ public:
 template <typename T>
 class VlRandomArrayVar final : public VlRandomVar {
 public:
-    VlRandomArrayVar(const char* name, int width, void* datap, int dimension, std::uint32_t randModeIdx)
+    VlRandomArrayVar(const char* name, int width, void* datap, int dimension,
+                     std::uint32_t randModeIdx)
         : VlRandomVar{name, width, datap, dimension, randModeIdx} {}
-    
+
     void* datap(int idx) const override {
         std::cout << "datap: " << std::endl;
         return &static_cast<T*>(VlRandomVar::datap(idx))->operator[](idx);
     }
 
     void emitSelect(std::ostream& s, const std::vector<int>& indices) const {
-        
+
         std::cout << "emitSelect called with indices: ";
-        for (const auto& idx : indices) {
-            std::cout << idx << " ";
-        }
+        for (const auto& idx : indices) { std::cout << idx << " "; }
         std::cout << std::endl;
 
-        for (size_t idx = 0; idx < indices.size(); ++idx) {
-            s << "(select ";
-        }
+        for (size_t idx = 0; idx < indices.size(); ++idx) { s << "(select "; }
         s << name();
 
         for (size_t idx = 0; idx < indices.size(); ++idx) {
@@ -126,7 +124,7 @@ public:
             }
             s << ")";
         }
-}
+    }
 
     void emitGetValue(std::ostream& s) const override {
         auto var = static_cast<const T*>(datap(0));
@@ -148,13 +146,12 @@ public:
             //selectStatements += selectStatementStream.str();
             emitSelect(s, indices);
             int currentDimension = total_dimensions - 1;
-            while (currentDimension >= 0 && ++indices[currentDimension] >= lengths[currentDimension]) {
+            while (currentDimension >= 0
+                   && ++indices[currentDimension] >= lengths[currentDimension]) {
                 indices[currentDimension] = 0;
                 --currentDimension;
             }
-            if (currentDimension < 0) {
-                break;
-            }
+            if (currentDimension < 0) { break; }
         }
         //std::cout << selectStatements;
     }
@@ -184,7 +181,6 @@ public:
         s << ')';
     }
     */
-    
 };
 //=============================================================================
 // VlRandomizer is the object holding constraints and variable references.
@@ -213,17 +209,18 @@ public:
                    std::uint32_t randmodeIdx = std::numeric_limits<std::uint32_t>::max()) {
         if (m_vars.find(name) != m_vars.end()) return;
         // TODO: make_unique once VlRandomizer is per-instance not per-ref
-        m_vars[name] = std::make_shared<const VlRandomVar>(name, width, &var, dimension, randmodeIdx);
+        m_vars[name]
+            = std::make_shared<const VlRandomVar>(name, width, &var, dimension, randmodeIdx);
     }
     template <typename T>
     void write_var(VlQueue<T>& var, int width, const char* name, int dimension,
                    std::uint32_t randmodeIdx = std::numeric_limits<std::uint32_t>::max()) {
         if (m_vars.find(name) != m_vars.end()) return;
-        m_vars[name]
-            = std::make_shared<const VlRandomQueueVar<VlQueue<T>>>(name, width, &var, dimension, randmodeIdx);
+        m_vars[name] = std::make_shared<const VlRandomQueueVar<VlQueue<T>>>(
+            name, width, &var, dimension, randmodeIdx);
         std::cout << "queue-Unpacked: " << name << std::endl;
     }
-    
+
     template <typename T, std::size_t N>
     void write_var(VlUnpacked<T, N>& var, int width, const char* name, int dimension,
                    std::uint32_t randmodeIdx = std::numeric_limits<std::uint32_t>::max()) {
@@ -236,17 +233,21 @@ public:
                 write_var(var[i], width, element_name.c_str(), dimension - 1, randmodeIdx);
             }
         } else {
-        
-            m_vars[name] = std::make_shared<const VlRandomArrayVar<VlUnpacked<T, N>>>(name, width, &var, dimension, randmodeIdx);
 
-            std::cout << "Array-Unpacked: " << m_vars[name] << "N = " << N << ", Dimension = " << dimension << ", Name = " << name << std::endl;
+            m_vars[name] = std::make_shared<const VlRandomArrayVar<VlUnpacked<T, N>>>(name, width,
+        &var, dimension, randmodeIdx);
+
+            std::cout << "Array-Unpacked: " << m_vars[name] << "N = " << N << ", Dimension = " <<
+        dimension << ", Name = " << name << std::endl;
         }
         */
-        m_vars[name] = std::make_shared<const VlRandomArrayVar<VlUnpacked<T, N>>>(name, width, &var, dimension, randmodeIdx);
+        m_vars[name] = std::make_shared<const VlRandomArrayVar<VlUnpacked<T, N>>>(
+            name, width, &var, dimension, randmodeIdx);
 
-        std::cout << "Array-Unpacked: " << m_vars[name] << "N = " << N << ", Dimension = " << dimension << ", Name = " << name << std::endl;
+        std::cout << "Array-Unpacked: " << m_vars[name] << "N = " << N
+                  << ", Dimension = " << dimension << ", Name = " << name << std::endl;
     }
-    
+
     void hard(std::string&& constraint);
     void clear();
     void set_randmode(const VlQueue<CData>& randmode) { m_randmode = &randmode; }

--- a/include/verilated_random.h
+++ b/include/verilated_random.h
@@ -147,7 +147,7 @@ public:
                 indices[currentDimension] = 0;
                 --currentDimension;
             }
-            if (currentDimension < 0) { break; }
+            if (currentDimension < 0) break;
         }
     }
 
@@ -162,7 +162,7 @@ public:
         int totalLength = 1;
         for (int dim = 0; dim < dimension(); ++dim) {
             int length = getLength(dim);
-            if (length == -1) { return 0; }
+            if (length == -1) return 0;
             totalLength *= length;
         }
         return width() * totalLength;

--- a/include/verilated_random.h
+++ b/include/verilated_random.h
@@ -103,10 +103,10 @@ public:
         : VlRandomVar{name, width, datap, dimension, randModeIdx} {}
 
     void* datap(int idx) const override {
-        if (idx < 0) { return &static_cast<T*>(VlRandomVar::datap(0))->operator[](0); }
+        if (idx < 0) return &static_cast<T*>(VlRandomVar::datap(0))->operator[](0);
         std::vector<size_t> indices(dimension());
         for (int dim = dimension() - 1; dim >= 0; --dim) {
-            int length = getLength(dim);
+            const int length = getLength(dim);
             indices[dim] = idx % length;
             idx /= length;
         }
@@ -114,7 +114,7 @@ public:
     }
 
     void emitSelect(std::ostream& s, const std::vector<int>& indices) const {
-        for (size_t idx = 0; idx < indices.size(); ++idx) { s << "(select "; }
+        for (size_t idx = 0; idx < indices.size(); ++idx) s << "(select ";
         s << name();
         for (size_t idx = 0; idx < indices.size(); ++idx) {
             s << " #x";
@@ -126,16 +126,16 @@ public:
     }
 
     int getLength(int dimension) const override {
-        auto var = static_cast<const T*>(datap(-1));
-        int lenth = var->find_length(dimension);
+        const auto var = static_cast<const T*>(datap(-1));
+        const int lenth = var->find_length(dimension);
         return lenth;
     }
 
     void emitGetValue(std::ostream& s) const override {
-        int total_dimensions = dimension();
+        const int total_dimensions = dimension();
         std::vector<int> lengths;
         for (int dim = 0; dim < total_dimensions; dim++) {
-            int len = getLength(dim);
+            const int len = getLength(dim);
             lengths.push_back(len);
         }
         std::vector<int> indices(total_dimensions, 0);
@@ -153,20 +153,22 @@ public:
 
     void emitType(std::ostream& s) const override {
         if (dimension() > 0) {
-            for (int i = 0; i < dimension(); ++i) { s << "(Array (_ BitVec 32) "; }
+            for (int i = 0; i < dimension(); ++i) s << "(Array (_ BitVec 32) ";
             s << "(_ BitVec " << width() << ")";
-            for (int i = 0; i < dimension(); ++i) { s << ")"; }
+            for (int i = 0; i < dimension(); ++i) s << ")";
         }
     }
+
     int totalWidth() const override {
         int totalLength = 1;
         for (int dim = 0; dim < dimension(); ++dim) {
-            int length = getLength(dim);
+            const int length = getLength(dim);
             if (length == -1) return 0;
             totalLength *= length;
         }
         return width() * totalLength;
     }
+
     void emitExtract(std::ostream& s, int i) const override {
         const int j = i / width();
         i = i % width();

--- a/include/verilated_random.h
+++ b/include/verilated_random.h
@@ -60,7 +60,7 @@ public:
     virtual void emitExtract(std::ostream& s, int i) const;
     virtual void emitType(std::ostream& s) const;
     virtual int totalWidth() const;
-    virtual int getLength(int dimension) const {return -1;}
+    virtual int getLength(int dimension) const { return -1; }
 };
 
 template <typename T>

--- a/include/verilated_types.h
+++ b/include/verilated_types.h
@@ -1338,7 +1338,8 @@ public:
     template <std::size_t CurrentDimension = 0>
     auto& find_element(const std::vector<size_t>& indices) {
         if constexpr (std::is_class_v<T_Value>) {
-            return m_storage[indices[CurrentDimension]].template find_element<CurrentDimension + 1>(indices);
+            return m_storage[indices[CurrentDimension]]
+                .template find_element<CurrentDimension + 1>(indices);
         } else {
             return m_storage[indices[CurrentDimension]];
         }

--- a/include/verilated_types.h
+++ b/include/verilated_types.h
@@ -1350,8 +1350,8 @@ public:
 
     template <std::size_t CurrentDimension = 0, typename U = T_Value>
     auto& find_element(const std::vector<size_t>& indices, std::true_type) {
-        return m_storage[indices[CurrentDimension]]
-            .template find_element<CurrentDimension + 1>(indices);
+        return m_storage[indices[CurrentDimension]].template find_element<CurrentDimension + 1>(
+            indices);
     }
 
     template <std::size_t CurrentDimension = 0>

--- a/include/verilated_types.h
+++ b/include/verilated_types.h
@@ -1323,26 +1323,40 @@ public:
     const WData* data() const { return &m_storage[0]; }
 
     std::size_t size() const { return T_Depth; }
-    template <std::size_t CurrentDimension = 0>
-    int find_length(int dimension) const {
+    // To fit C++14
+    template <std::size_t CurrentDimension = 0, typename U = T_Value>
+    int find_length(int dimension, std::false_type) const {
+        return size();
+    }
+
+    template <std::size_t CurrentDimension = 0, typename U = T_Value>
+    int find_length(int dimension, std::true_type) const {
         if (dimension == CurrentDimension) {
             return size();
         } else {
-            if constexpr (std::is_class_v<T_Value>) {
-                return m_storage[0].template find_length<CurrentDimension + 1>(dimension);
-            } else {
-                return size();
-            }
+            return m_storage[0].template find_length<CurrentDimension + 1>(dimension);
         }
     }
+
+    template <std::size_t CurrentDimension = 0>
+    int find_length(int dimension) const {
+        return find_length<CurrentDimension>(dimension, std::is_class<T_Value>{});
+    }
+
+    template <std::size_t CurrentDimension = 0, typename U = T_Value>
+    auto& find_element(const std::vector<size_t>& indices, std::false_type) {
+        return m_storage[indices[CurrentDimension]];
+    }
+
+    template <std::size_t CurrentDimension = 0, typename U = T_Value>
+    auto& find_element(const std::vector<size_t>& indices, std::true_type) {
+        return m_storage[indices[CurrentDimension]]
+            .template find_element<CurrentDimension + 1>(indices);
+    }
+
     template <std::size_t CurrentDimension = 0>
     auto& find_element(const std::vector<size_t>& indices) {
-        if constexpr (std::is_class_v<T_Value>) {
-            return m_storage[indices[CurrentDimension]]
-                .template find_element<CurrentDimension + 1>(indices);
-        } else {
-            return m_storage[indices[CurrentDimension]];
-        }
+        return find_element<CurrentDimension>(indices, std::is_class<T_Value>{});
     }
 
     T_Value& operator[](size_t index) { return m_storage[index]; }

--- a/include/verilated_types.h
+++ b/include/verilated_types.h
@@ -1337,6 +1337,15 @@ public:
         }
     }
 
+    template <std::size_t CurrentDimension = 0>
+    auto& find_element(const std::vector<size_t>& indices) {
+        if constexpr (std::is_class_v<T_Value>) {
+            return m_storage[indices[CurrentDimension]].template find_element<CurrentDimension + 1>(indices);
+        } else {
+            return m_storage[indices[CurrentDimension]];
+        }
+    }
+
     T_Value& operator[](size_t index) { return m_storage[index]; }
     const T_Value& operator[](size_t index) const { return m_storage[index]; }
 

--- a/include/verilated_types.h
+++ b/include/verilated_types.h
@@ -1322,6 +1322,21 @@ public:
     WData* data() { return &m_storage[0]; }
     const WData* data() const { return &m_storage[0]; }
 
+    std::size_t size() const { return T_Depth; }
+    // Find the length at a specific dimension
+    template <std::size_t CurrentDimension = 0>
+    int find_length(int dimension) const {
+        if (dimension == CurrentDimension) {
+            return size();
+        } else {
+            if constexpr (std::is_class_v<T_Value>) {
+                return m_storage[0].template find_length<CurrentDimension + 1>(dimension);
+            } else {
+                return size();
+            }
+        }
+    }
+
     T_Value& operator[](size_t index) { return m_storage[index]; }
     const T_Value& operator[](size_t index) const { return m_storage[index]; }
 

--- a/include/verilated_types.h
+++ b/include/verilated_types.h
@@ -1323,7 +1323,6 @@ public:
     const WData* data() const { return &m_storage[0]; }
 
     std::size_t size() const { return T_Depth; }
-    // Find the length at a specific dimension
     template <std::size_t CurrentDimension = 0>
     int find_length(int dimension) const {
         if (dimension == CurrentDimension) {
@@ -1336,7 +1335,6 @@ public:
             }
         }
     }
-
     template <std::size_t CurrentDimension = 0>
     auto& find_element(const std::vector<size_t>& indices) {
         if constexpr (std::is_class_v<T_Value>) {

--- a/src/V3AstNodeExpr.h
+++ b/src/V3AstNodeExpr.h
@@ -4147,6 +4147,7 @@ public:
     }
     string emitVerilog() override { return "%k(%l%f[%r])"; }
     string emitC() override { return "%li%k[%ri]"; }
+    string emitSMT() const override { return "(select %l %r)"; }
     bool cleanOut() const override { return true; }
     bool cleanLhs() const override { return false; }
     bool cleanRhs() const override { return true; }

--- a/src/V3Randomize.cpp
+++ b/src/V3Randomize.cpp
@@ -598,7 +598,8 @@ class ConstraintExprVisitor final : public VNVisitor {
                 "write_var"};
             uint32_t dimension = 0;
             if (VN_IS(varp->dtypep(), UnpackArrayDType)) {
-                std::pair<uint32_t, uint32_t> dims = varp->dtypep()->dimensions(/*includeBasic=*/true);
+                std::pair<uint32_t, uint32_t> dims
+                    = varp->dtypep()->dimensions(/*includeBasic=*/true);
                 uint32_t packedDimensions = dims.first;
                 uint32_t unpackedDimensions = dims.second;
                 dimension = unpackedDimensions;
@@ -622,8 +623,8 @@ class ConstraintExprVisitor final : public VNVisitor {
                 methodp->addPinsp(
                     new AstConst{varp->fileline(), AstConst::Unsized64{}, randMode.index});
             }
-            methodp->addPinsp(new AstConst{varp->dtypep()->fileline(), AstConst::Unsized64{},
-                                           dimension});
+            methodp->addPinsp(
+                new AstConst{varp->dtypep()->fileline(), AstConst::Unsized64{}, dimension});
             AstNodeFTask* initTaskp = m_inlineInitTaskp;
             if (!initTaskp) {
                 varp->user3(true);  // Mark as set up in new()

--- a/src/V3Randomize.cpp
+++ b/src/V3Randomize.cpp
@@ -598,10 +598,9 @@ class ConstraintExprVisitor final : public VNVisitor {
                 "write_var"};
             uint32_t dimension = 0;
             if (VN_IS(varp->dtypep(), UnpackArrayDType)) {
-                std::pair<uint32_t, uint32_t> dims
+                const std::pair<uint32_t, uint32_t> dims
                     = varp->dtypep()->dimensions(/*includeBasic=*/true);
-                uint32_t packedDimensions = dims.first;
-                uint32_t unpackedDimensions = dims.second;
+                const uint32_t unpackedDimensions = dims.second;
                 dimension = unpackedDimensions;
             }
             methodp->dtypeSetVoid();

--- a/src/V3Randomize.cpp
+++ b/src/V3Randomize.cpp
@@ -618,12 +618,12 @@ class ConstraintExprVisitor final : public VNVisitor {
                 = new AstCExpr{varp->fileline(), "\"" + smtName + "\"", varp->width()};
             varnamep->dtypep(varp->dtypep());
             methodp->addPinsp(varnamep);
+            methodp->addPinsp(
+                new AstConst{varp->dtypep()->fileline(), AstConst::Unsized64{}, dimension});
             if (randMode.usesMode) {
                 methodp->addPinsp(
                     new AstConst{varp->fileline(), AstConst::Unsized64{}, randMode.index});
             }
-            methodp->addPinsp(
-                new AstConst{varp->dtypep()->fileline(), AstConst::Unsized64{}, dimension});
             AstNodeFTask* initTaskp = m_inlineInitTaskp;
             if (!initTaskp) {
                 varp->user3(true);  // Mark as set up in new()

--- a/test_regress/t/t_randomize_array_constraints.py
+++ b/test_regress/t/t_randomize_array_constraints.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2024 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+if not test.have_solver:
+    test.skip("No constraint solver installed")
+
+test.compile()
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_randomize_array_constraints.v
+++ b/test_regress/t/t_randomize_array_constraints.v
@@ -34,7 +34,14 @@ class con_rand_1d_array_test;
   function void check_randomization();
     foreach (data[i]) begin
       `check_rand(this, data[i])
+      if (data[i] inside {8'h10, 8'h20, 8'h30, 8'h40, 8'h50}) begin
+        $display("data[%0d] = %h is valid", i, data[i]);
+      end else begin
+        $display("Error: data[%0d] = %h is out of bounds", i, data[i]);
+        $stop;
+      end
     end
+
   endfunction
 
 endclass
@@ -57,6 +64,12 @@ class con_rand_2d_array_test;
   function void check_randomization();
     foreach (data[i, j]) begin
       `check_rand(this, data[i][j])
+      if (data[i][j] >= 8'h10 && data[i][j] <= 8'h50) begin
+        $display("data[%0d][%0d] = %h is valid", i, j, data[i][j]);
+      end else begin
+        $display("Error: data[%0d][%0d] = %h is out of bounds", i, j, data[i][j]);
+        $stop;
+      end
     end
   endfunction
 
@@ -86,6 +99,24 @@ class con_rand_3d_array_test;
   function void check_randomization();
     foreach (data[i, j, k]) begin
       `check_rand(this, data[i][j][k])
+      if (data[i][j][k] >= 8'h10 && data[i][j][k] <= 8'h50) begin
+
+        if (i > 0 && data[i][j][k] <= data[i-1][j][k] + 8'h05) begin
+          $display("Error: data[%0d][%0d][%0d] = %h does not satisfy i > 0 constraint", i, j, k, data[i][j][k]);
+          $stop;
+        end
+
+        if (j > 0 && data[i][j][k] <= data[i][j-1][k]) begin
+          $display("Error: data[%0d][%0d][%0d] = %h does not satisfy j > 0 constraint", i, j, k, data[i][j][k]);
+          $stop;
+        end
+
+        $display("data[%0d][%0d][%0d] = %h is valid", i, j, k, data[i][j][k]);
+
+      end else begin
+        $display("Error: data[%0d][%0d][%0d] = %h is out of bounds", i, j, k, data[i][j][k]);
+        $stop;
+      end
     end
   endfunction
 
@@ -99,18 +130,21 @@ module t_randomize_array_constraints;
 
   initial begin
     // Test 1: Randomization for 1D array
+    $display("Test 1: Randomization for 1D array:");
     rand_test_1 = new();
     repeat(2) begin
       rand_test_1.check_randomization();
     end
 
     // Test 2: Randomization for 2D array
+    $display("Test 2: Randomization for 2D array:");
     rand_test_2 = new();
     repeat(2) begin
       rand_test_2.check_randomization();
     end
 
     // Test 3: Randomization for 3D array
+    $display("Test 3: Randomization for 3D array:");
     rand_test_3 = new();
     repeat(2) begin
       rand_test_3.check_randomization();

--- a/test_regress/t/t_randomize_array_constraints.v
+++ b/test_regress/t/t_randomize_array_constraints.v
@@ -1,0 +1,122 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2024 by PlanV GmbH.
+// SPDX-License-Identifier: CC0-1.0
+
+`define check_rand(cl, field) \
+begin \
+   longint prev_result; \
+   int ok = 0; \
+   for (int i = 0; i < 10; i++) begin \
+      longint result; \
+      void'(cl.randomize()); \
+      result = longint'(field); \
+      if (i > 0 && result != prev_result) ok = 1; \
+      prev_result = result; \
+   end \
+   if (ok != 1) $stop; \
+end
+
+class con_rand_1d_array_test;
+  rand bit [7:0] data[5];
+
+  constraint c_data {
+    foreach (data[i]) {
+      data[i] inside {8'h10, 8'h20, 8'h30, 8'h40, 8'h50};
+    }
+  }
+
+  function new();
+    data = '{default: 'h0};
+  endfunction
+
+  function void check_randomization();
+    foreach (data[i]) begin
+      `check_rand(this, data[i])
+    end
+  endfunction
+
+endclass
+
+
+class con_rand_2d_array_test;
+  rand bit [7:0] data[3][3];
+
+  constraint c_data {
+    foreach (data[i, j]) {
+      data[i][j] >= 8'h10;
+      data[i][j] <= 8'h50;
+    }
+  }
+
+  function new();
+    data = '{default: '{default: 'h0}};
+  endfunction
+
+  function void check_randomization();
+    foreach (data[i, j]) begin
+      `check_rand(this, data[i][j])
+    end
+  endfunction
+
+endclass
+
+
+class con_rand_3d_array_test;
+  rand bit [7:0] data[2][2][2];
+
+  constraint c_data {
+    foreach (data[i, j, k]) {
+      data[i][j][k] >= 8'h10;
+      data[i][j][k] <= 8'h50;
+      if (i > 0) {
+        data[i][j][k] > data[i-1][j][k] + 8'h05;
+      }
+      if (j > 0) {
+        data[i][j][k] > data[i][j-1][k];
+      }
+    }
+  }
+
+  function new();
+    data = '{default: '{default: '{default: 'h0}}};
+  endfunction
+
+  function void check_randomization();
+    foreach (data[i, j, k]) begin
+      `check_rand(this, data[i][j][k])
+    end
+  endfunction
+
+endclass
+
+
+module t_randomize_array_constraints;
+  con_rand_1d_array_test rand_test_1;
+  con_rand_2d_array_test rand_test_2;
+  con_rand_3d_array_test rand_test_3;
+
+  initial begin
+    // Test 1: Randomization for 1D array
+    rand_test_1 = new();
+    repeat(2) begin
+      rand_test_1.check_randomization();
+    end
+
+    // Test 2: Randomization for 2D array
+    rand_test_2 = new();
+    repeat(2) begin
+      rand_test_2.check_randomization();
+    end
+
+    // Test 3: Randomization for 3D array
+    rand_test_3 = new();
+    repeat(2) begin
+      rand_test_3.check_randomization();
+    end
+
+    $write("*-* All Finished *-*\n");
+    $finish;
+  end
+endmodule


### PR DESCRIPTION
Hello，

Happy to share that we can currently support constrained randomization for unpacked array!

This patch enables constrained randomization for unpacked arrays, as described in the related issue #5437 . By leveraging smt-lib2 logic QF_ABV, we can now treat unpacked arrays as a single array data type rather than breaking them into individual elements.

To achieve this, we need additional information, such as the length of each dimension and the total number of dimensions. The main changes are in the verilated_random section and minor changes are in src/V3Randomize.

Since this is a relatively complex change, I’m open to any suggestions for improvement. If you have any extra need, please let me know!