### PR TITLE
Fix randomize with foreach constraints

### DIFF
--- a/src/V3Randomize.cpp
+++ b/src/V3Randomize.cpp
@@ -913,7 +913,11 @@ class CaptureVisitor final : public VNVisitor {
         const bool varHasAutomaticLifetime = varRefp->varp()->lifetime().isAutomatic();
         const bool varIsFieldOfCaller = AstClass::isClassExtendedFrom(callerClassp, varClassp);
         const bool varIsParam = varRefp->varp()->isParam();
+        const bool varIsConstraintIterator
+            = VN_IS(varRefp->varp()->firstAbovep(), SelLoopVars)
+              && VN_IS(varRefp->varp()->firstAbovep()->firstAbovep(), ConstraintForeach);
         if (refIsXref) return CaptureMode::CAP_VALUE | CaptureMode::CAP_F_XREF;
+        if (varIsConstraintIterator) return CaptureMode::CAP_NO;
         if (varIsFuncLocal && varHasAutomaticLifetime) return CaptureMode::CAP_VALUE;
         if (varIsParam) return CaptureMode::CAP_VALUE;
         // Static var in function (will not be inlined, because it's in class)

--- a/test_regress/t/t_randomize_method_with_scoping.v
+++ b/test_regress/t/t_randomize_method_with_scoping.v
@@ -13,6 +13,7 @@ endclass
 localparam int PARAM = 42;
 class Cls;
    rand int x;
+   int q[$] = {0};
    rand enum {
       ONE_Y,
       TWO_Y
@@ -98,6 +99,8 @@ class SubC extends SubB;
       if (f.x != 0) $stop;
       doit &= f.randomize() with { x == op(local::op(op(local::op(1)))); };
       if (f.x != 1) $stop;
+      doit &= f.randomize() with { foreach (q[i]) x == i; };
+      if (f.x != 0) $stop;
    endfunction
 endclass
 


### PR DESCRIPTION
Verilator was previously trying to capture the variable by value, and complained about a broken scope (which was right, because the variable does not exist at the call site).