### PR TITLE
No ptrs in tests

### DIFF
--- a/test_regress/t/t_assert_ctl_arg.cpp
+++ b/test_regress/t/t_assert_ctl_arg.cpp
@@ -21,93 +21,93 @@ double sc_time_stamp() { return main_time; }
 int errors = 0;
 
 void verilatedTest() {
-    const std::unique_ptr<VerilatedContext> contextp{new VerilatedContext};
+    VerilatedContext context;
     // Assert enable/disable
-    contextp->assertOn(true);
-    TEST_CHECK_NZ(contextp->assertOn());
-    contextp->assertOn(false);
-    TEST_CHECK_Z(contextp->assertOn());
-    TEST_CHECK_Z(contextp->assertOnGet(1, 1));
+    context.assertOn(true);
+    TEST_CHECK_NZ(context.assertOn());
+    context.assertOn(false);
+    TEST_CHECK_Z(context.assertOn());
+    TEST_CHECK_Z(context.assertOnGet(1, 1));
 
     // Setting one type
-    contextp->assertOnSet(1, 1);
-    TEST_CHECK_NZ(contextp->assertOnGet(1, 1));
-    TEST_CHECK_NZ(contextp->assertOn());
-    TEST_CHECK_Z(contextp->assertOnGet(2, 2));
+    context.assertOnSet(1, 1);
+    TEST_CHECK_NZ(context.assertOnGet(1, 1));
+    TEST_CHECK_NZ(context.assertOn());
+    TEST_CHECK_Z(context.assertOnGet(2, 2));
 
     // Setting types
-    contextp->assertOn(false);
-    contextp->assertOnSet(1, 3);
-    TEST_CHECK_NZ(contextp->assertOnGet(1, 3));
-    TEST_CHECK_NZ(contextp->assertOnGet(1, 2));
-    TEST_CHECK_NZ(contextp->assertOnGet(1, 1));
-    TEST_CHECK_Z(contextp->assertOnGet(1, 0));
-    TEST_CHECK_Z(contextp->assertOnGet(2, 0));
-    TEST_CHECK_Z(contextp->assertOnGet(0, 0));
+    context.assertOn(false);
+    context.assertOnSet(1, 3);
+    TEST_CHECK_NZ(context.assertOnGet(1, 3));
+    TEST_CHECK_NZ(context.assertOnGet(1, 2));
+    TEST_CHECK_NZ(context.assertOnGet(1, 1));
+    TEST_CHECK_Z(context.assertOnGet(1, 0));
+    TEST_CHECK_Z(context.assertOnGet(2, 0));
+    TEST_CHECK_Z(context.assertOnGet(0, 0));
 
     // Setting multiple types separately
-    contextp->assertOn(false);
-    contextp->assertOnSet(0, 1);
-    contextp->assertOnSet(1, 2);
-    contextp->assertOnSet(2, 3);
-    TEST_CHECK_NZ(contextp->assertOn());
-    TEST_CHECK_Z(contextp->assertOnGet(0, 1));
-    TEST_CHECK_Z(contextp->assertOnGet(1, 1));
-    TEST_CHECK_NZ(contextp->assertOnGet(1, 2));
-    TEST_CHECK_NZ(contextp->assertOnGet(2, 1));
-    TEST_CHECK_NZ(contextp->assertOnGet(2, 2));
-    TEST_CHECK_NZ(contextp->assertOnGet(2, 3));
-    TEST_CHECK_Z(contextp->assertOnGet(0, 2));
-    TEST_CHECK_Z(contextp->assertOnGet(4, 1));
-    TEST_CHECK_Z(contextp->assertOnGet(8, 7));
+    context.assertOn(false);
+    context.assertOnSet(0, 1);
+    context.assertOnSet(1, 2);
+    context.assertOnSet(2, 3);
+    TEST_CHECK_NZ(context.assertOn());
+    TEST_CHECK_Z(context.assertOnGet(0, 1));
+    TEST_CHECK_Z(context.assertOnGet(1, 1));
+    TEST_CHECK_NZ(context.assertOnGet(1, 2));
+    TEST_CHECK_NZ(context.assertOnGet(2, 1));
+    TEST_CHECK_NZ(context.assertOnGet(2, 2));
+    TEST_CHECK_NZ(context.assertOnGet(2, 3));
+    TEST_CHECK_Z(context.assertOnGet(0, 2));
+    TEST_CHECK_Z(context.assertOnGet(4, 1));
+    TEST_CHECK_Z(context.assertOnGet(8, 7));
 
     // Clearing selected types
-    contextp->assertOn(true);
-    contextp->assertOnClear(1, 3);
-    contextp->assertOnClear(1, 4);
-    TEST_CHECK_Z(contextp->assertOnGet(1, 1));
-    TEST_CHECK_Z(contextp->assertOnGet(1, 2));
-    TEST_CHECK_Z(contextp->assertOnGet(1, 4));
-    contextp->assertOnClear(4, 4);
-    TEST_CHECK_Z(contextp->assertOnGet(4, 4));
-    TEST_CHECK_NZ(contextp->assertOnGet(4, 1));
-    TEST_CHECK_NZ(contextp->assertOnGet(4, 2));
-    TEST_CHECK_NZ(contextp->assertOn());
+    context.assertOn(true);
+    context.assertOnClear(1, 3);
+    context.assertOnClear(1, 4);
+    TEST_CHECK_Z(context.assertOnGet(1, 1));
+    TEST_CHECK_Z(context.assertOnGet(1, 2));
+    TEST_CHECK_Z(context.assertOnGet(1, 4));
+    context.assertOnClear(4, 4);
+    TEST_CHECK_Z(context.assertOnGet(4, 4));
+    TEST_CHECK_NZ(context.assertOnGet(4, 1));
+    TEST_CHECK_NZ(context.assertOnGet(4, 2));
+    TEST_CHECK_NZ(context.assertOn());
 
     // Clearing all assert types
-    contextp->assertOn(true);
-    contextp->assertOnClear(255, 7);
+    context.assertOn(true);
+    context.assertOnClear(255, 7);
     // Everything is disabled except internal asserts
-    TEST_CHECK_NZ(contextp->assertOn());
-    contextp->assertOn(false);
+    TEST_CHECK_NZ(context.assertOn());
+    context.assertOn(false);
     // Now everything is disabled
-    TEST_CHECK_Z(contextp->assertOn());
+    TEST_CHECK_Z(context.assertOn());
 }
 int main(int argc, char** argv) {
     verilatedTest();
     if (errors) return 10;
 
-    const std::unique_ptr<VerilatedContext> contextp{new VerilatedContext};
-    contextp->threads(1);
-    contextp->commandArgs(argc, argv);
-    contextp->debug(0);
+    VerilatedContext context;
+    context.threads(1);
+    context.commandArgs(argc, argv);
+    context.debug(0);
 
     srand48(5);
 
-    const std::unique_ptr<VM_PREFIX> topp{new VM_PREFIX{"top"}};
+    VM_PREFIX top{"top"};
     constexpr uint64_t sim_time = 100;
-    while ((contextp->time() < sim_time) && !contextp->gotFinish()) {
-        topp->clk = !topp->clk;
-        topp->eval();
-        contextp->timeInc(1);
+    while ((context.time() < sim_time) && !context.gotFinish()) {
+        top.clk = !top.clk;
+        top.eval();
+        context.timeInc(1);
     }
     const std::string filename = std::string{VL_STRINGIFY(TEST_OBJ_DIR) "/coverage.dat"};
-    contextp->coveragep()->write(filename);
+    context.coveragep()->write(filename);
 
-    if (!contextp->gotFinish()) {
+    if (!context.gotFinish()) {
         vl_fatal(__FILE__, __LINE__, "main", "%Error: Timeout; never got a $finish");
     }
-    topp->final();
+    top.final();
 
     return 0;
 }

--- a/test_regress/t/t_clk_inp_init.cpp
+++ b/test_regress/t/t_clk_inp_init.cpp
@@ -11,40 +11,40 @@ void oneTest(int argc, char** argv, int seed) {
     VL_PRINTF("== Seed=%d\n", seed);
 #endif
 
-    const std::unique_ptr<VerilatedContext> contextp{new VerilatedContext};
-    contextp->commandArgs(argc, argv);
+    VerilatedContext context;
+    context.commandArgs(argc, argv);
 
     // Randomise initial state
     srand48(seed);
     srand48(5);
-    contextp->randReset(123);
+    context.randReset(123);
 
     // Construct the Verilated model, from Vtop.h generated from Verilating
-    const std::unique_ptr<VM_PREFIX> topp{new VM_PREFIX{contextp.get()}};
+    VM_PREFIX top{&context};
 
     // Start not in reset
-    topp->rst_n = 1;
-    topp->clk = 0;
-    topp->eval();
+    top.rst_n = 1;
+    top.clk = 0;
+    top.eval();
 
     // Tick for a little bit
-    while (contextp->time() < sim_time && !contextp->gotFinish()) {
-        topp->clk = 0;
-        topp->eval();
+    while (context.time() < sim_time && !context.gotFinish()) {
+        top.clk = 0;
+        top.eval();
 
-        contextp->timeInc(5);
+        context.timeInc(5);
 
-        topp->clk = 1;
-        topp->eval();
+        top.clk = 1;
+        top.eval();
 
-        contextp->timeInc(5);
+        context.timeInc(5);
     }
 
-    if (!contextp->gotFinish()) {
+    if (!context.gotFinish()) {
         vl_fatal(__FILE__, __LINE__, "main", "%Error: Timeout; never got a $finish");
     }
 
-    topp->final();
+    top.final();
 }
 
 int main(int argc, char** argv) {

--- a/test_regress/t/t_comb_input_0.cpp
+++ b/test_regress/t/t_comb_input_0.cpp
@@ -14,27 +14,25 @@
 #include "Vt_comb_input_0.h"
 #include "Vt_comb_input_0__Syms.h"
 
-#include <memory>
-
 int main(int argc, char** argv) {
-    const std::unique_ptr<VerilatedContext> contextp{new VerilatedContext};
-    contextp->debug(0);
-    contextp->commandArgs(argc, argv);
+    VerilatedContext context;
+    context.debug(0);
+    context.commandArgs(argc, argv);
     srand48(5);
 
-    const std::unique_ptr<VM_PREFIX> topp{new VM_PREFIX};
-    topp->inc = 1;
-    topp->clk = false;
-    topp->eval();
+    VM_PREFIX top;
+    top.inc = 1;
+    top.clk = false;
+    top.eval();
 
-    while (!contextp->gotFinish() && contextp->time() < 100000) {
-        contextp->timeInc(5);
-        if (topp->clk) topp->inc += 1;
-        topp->clk = !topp->clk;
-        topp->eval();
+    while (!context.gotFinish() && context.time() < 100000) {
+        context.timeInc(5);
+        if (top.clk) top.inc += 1;
+        top.clk = !top.clk;
+        top.eval();
     }
 
-    if (!contextp->gotFinish()) {
+    if (!context.gotFinish()) {
         vl_fatal(__FILE__, __LINE__, "main", "%Error: Timeout; never got a $finish");
     }
     return 0;

--- a/test_regress/t/t_comb_input_1.cpp
+++ b/test_regress/t/t_comb_input_1.cpp
@@ -17,24 +17,24 @@
 #include <memory>
 
 int main(int argc, char** argv) {
-    const std::unique_ptr<VerilatedContext> contextp{new VerilatedContext};
-    contextp->debug(0);
-    contextp->commandArgs(argc, argv);
+    VerilatedContext context;
+    context.debug(0);
+    context.commandArgs(argc, argv);
     srand48(5);
 
-    const std::unique_ptr<VM_PREFIX> topp{new VM_PREFIX};
-    topp->inc = 1;
-    topp->clk = false;
-    topp->eval();
+    VM_PREFIX top;
+    top.inc = 1;
+    top.clk = false;
+    top.eval();
 
-    while (!contextp->gotFinish() && contextp->time() < 100000) {
-        contextp->timeInc(5);
-        if (topp->clk) topp->inc += 1;
-        topp->clk = !topp->clk;
-        topp->eval();
+    while (!context.gotFinish() && context.time() < 100000) {
+        context.timeInc(5);
+        if (top.clk) top.inc += 1;
+        top.clk = !top.clk;
+        top.eval();
     }
 
-    if (!contextp->gotFinish()) {
+    if (!context.gotFinish()) {
         vl_fatal(__FILE__, __LINE__, "main", "%Error: Timeout; never got a $finish");
     }
     return 0;

--- a/test_regress/t/t_comb_input_2.cpp
+++ b/test_regress/t/t_comb_input_2.cpp
@@ -14,27 +14,25 @@
 #include "Vt_comb_input_2.h"
 #include "Vt_comb_input_2__Syms.h"
 
-#include <memory>
-
 int main(int argc, char** argv) {
-    const std::unique_ptr<VerilatedContext> contextp{new VerilatedContext};
-    contextp->debug(0);
-    contextp->commandArgs(argc, argv);
+    VerilatedContext context;
+    context.debug(0);
+    context.commandArgs(argc, argv);
     srand48(5);
 
-    const std::unique_ptr<VM_PREFIX> topp{new VM_PREFIX};
-    topp->inc = 1;
-    topp->clk = false;
-    topp->eval();
+    VM_PREFIX top;
+    top.inc = 1;
+    top.clk = false;
+    top.eval();
 
-    while (!contextp->gotFinish() && contextp->time() < 100000) {
-        contextp->timeInc(5);
-        if (topp->clk) topp->inc += 1;
-        topp->clk = !topp->clk;
-        topp->eval();
+    while (!context.gotFinish() && context.time() < 100000) {
+        context.timeInc(5);
+        if (top.clk) top.inc += 1;
+        top.clk = !top.clk;
+        top.eval();
     }
 
-    if (!contextp->gotFinish()) {
+    if (!context.gotFinish()) {
         vl_fatal(__FILE__, __LINE__, "main", "%Error: Timeout; never got a $finish");
     }
     return 0;

--- a/test_regress/t/t_dpi_var.cpp
+++ b/test_regress/t/t_dpi_var.cpp
@@ -111,38 +111,36 @@ void mon_eval() {
 //======================================================================
 
 int main(int argc, char** argv) {
-    const std::unique_ptr<VerilatedContext> contextp{new VerilatedContext};
+    VerilatedContext context;
 
     uint64_t sim_time = 1100;
-    contextp->debug(0);
-    contextp->commandArgs(argc, argv);
+    context.debug(0);
+    context.commandArgs(argc, argv);
 
-    const std::unique_ptr<VM_PREFIX> topp{new VM_PREFIX{contextp.get(),
-                                                        // Note null name - we're flattening it out
-                                                        ""}};
+    VM_PREFIX top{&context, ""};  // Note null name - we're flattening it out
 
     // clang-format off
 #ifdef VERILATOR
 # ifdef TEST_VERBOSE
-    contextp->scopesDump();
+    context.scopesDump();
 # endif
 #endif
     // clang-format on
 
-    topp->eval();
-    topp->clk = 0;
-    contextp->timeInc(10);
+    top.eval();
+    top.clk = 0;
+    context.timeInc(10);
 
-    while (contextp->time() < sim_time && !contextp->gotFinish()) {
-        contextp->timeInc(1);
-        topp->eval();
-        topp->clk = !topp->clk;
+    while (context.time() < sim_time && !context.gotFinish()) {
+        context.timeInc(1);
+        top.eval();
+        top.clk = !top.clk;
         // mon_do();
     }
-    if (!contextp->gotFinish()) {
+    if (!context.gotFinish()) {
         vl_fatal(__FILE__, __LINE__, "main", "%Error: Timeout; never got a $finish");
     }
-    topp->final();
+    top.final();
 
     return 0;
 }

--- a/test_regress/t/t_export_packed_struct.cpp
+++ b/test_regress/t/t_export_packed_struct.cpp
@@ -115,12 +115,12 @@ typedef struct packed {
 int errors = 0;
 
 int main(int argc, char** argv) {
-    const std::unique_ptr<VerilatedContext> contextp{new VerilatedContext};
-    contextp->debug(0);
-    contextp->randReset(2);
-    contextp->commandArgs(argc, argv);
+    VerilatedContext context;
+    context.debug(0);
+    context.randReset(2);
+    context.commandArgs(argc, argv);
 
-    const std::unique_ptr<VM_PREFIX> adder{new VM_PREFIX{contextp.get()}};
+    VM_PREFIX adder{&context};
 
     {
         IN_T in1, in2;
@@ -138,10 +138,10 @@ int main(int argc, char** argv) {
         in2.__SYM__nullptr[3] = 0x30;
         in2.get__0.a = 0x20;
 
-        adder->op1 = in1.get();
-        adder->op2 = in2.get();
-        adder->eval();
-        out.set(adder->out);
+        adder.op1 = in1.get();
+        adder.op2 = in2.get();
+        adder.eval();
+        out.set(adder.out);
 
         TEST_CHECK_EQ(out.__SYM__nullptr[0], 0x11);
         TEST_CHECK_EQ(out.__SYM__nullptr[1], 0x22);
@@ -159,10 +159,10 @@ int main(int argc, char** argv) {
         op1a.b = 0x1fe;
         op1b.b = 0x1ef;
 
-        adder->op1a = op1a.get();
-        adder->op1b = op1b.get();
-        adder->eval();
-        out1.set(adder->out1);
+        adder.op1a = op1a.get();
+        adder.op1b = op1b.get();
+        adder.eval();
+        out1.set(adder.out1);
 
         TEST_CHECK_EQ(out1.a, op1a.a + op1b.a);
         TEST_CHECK_EQ(out1.b, op1a.b + op1b.b);
@@ -177,10 +177,10 @@ int main(int argc, char** argv) {
         op2a.c = 0x11212;
         op2b.c = 0x12121;
 
-        adder->op2a = op2a.get();
-        adder->op2b = op2b.get();
-        adder->eval();
-        out2.set(adder->out2);
+        adder.op2a = op2a.get();
+        adder.op2b = op2b.get();
+        adder.eval();
+        out2.set(adder.out2);
 
         TEST_CHECK_EQ(out2.a, op2a.a + op2b.a);
         TEST_CHECK_EQ(out2.b, op2a.b + op2b.b);
@@ -198,10 +198,10 @@ int main(int argc, char** argv) {
         op3a.d = 0x123232323ULL;
         op3b.d = 0x32323232ULL;
 
-        adder->op3a = op3a.get();
-        adder->op3b = op3b.get();
-        adder->eval();
-        out3.set(adder->out3);
+        adder.op3a = op3a.get();
+        adder.op3b = op3b.get();
+        adder.eval();
+        out3.set(adder.out3);
 
         TEST_CHECK_EQ(out3.a, op3a.a + op3b.a);
         TEST_CHECK_EQ(out3.b, op3a.b + op3b.b);
@@ -226,10 +226,10 @@ int main(int argc, char** argv) {
         op4a.e[2] = 0xe;
         op4b.e[2] = 0xf;
 
-        adder->op4a = op4a.get();
-        adder->op4b = op4b.get();
-        adder->eval();
-        out4.set(adder->out4);
+        adder.op4a = op4a.get();
+        adder.op4b = op4b.get();
+        adder.eval();
+        out4.set(adder.out4);
 
         TEST_CHECK_EQ(out4.a, op4a.a + op4b.a);
         TEST_CHECK_EQ(out4.b, op4a.b + op4b.b);

--- a/test_regress/t/t_export_packed_struct2.cpp
+++ b/test_regress/t/t_export_packed_struct2.cpp
@@ -64,12 +64,12 @@ endclass  //cls
 int errors = 0;
 
 int main(int argc, char** argv) {
-    const std::unique_ptr<VerilatedContext> contextp{new VerilatedContext};
-    contextp->debug(0);
-    contextp->randReset(2);
-    contextp->commandArgs(argc, argv);
+    VerilatedContext context;
+    context.debug(0);
+    context.randReset(2);
+    context.commandArgs(argc, argv);
 
-    const std::unique_ptr<VM_PREFIX> adder{new VM_PREFIX{contextp.get()}};
+    VM_PREFIX adder{&context};
 
     {
         IN_T in;
@@ -86,13 +86,13 @@ int main(int argc, char** argv) {
         }
         in.anon.a = 0x1;
 
-        adder->op1 = in.get();
-        adder->eval();
-        out.set(adder->out);
+        adder.op1 = in.get();
+        adder.eval();
+        out.set(adder.out);
 
         std::memset(reinterpret_cast<void*>(&tmp), 0xff, sizeof(tmp));
         // `set` function should clear upper bits of `tmp.a`
-        tmp.set(adder->rootp->add__DOT__op2->__PVT__in);
+        tmp.set(adder.rootp->add__DOT__op2->__PVT__in);
 
         for (int i = 0; i < 3; ++i) {
             for (int j = 0; j < 3; ++j) {

--- a/test_regress/t/t_flag_lib_dpi_main.cpp
+++ b/test_regress/t/t_flag_lib_dpi_main.cpp
@@ -18,25 +18,25 @@
 int main(int argc, char** argv, char**) {
     // Setup context, defaults, and parse command line
     Verilated::debug(0);
-    const std::unique_ptr<VerilatedContext> contextp{new VerilatedContext};
-    contextp->commandArgs(argc, argv);
+    VerilatedContext context;
+    context.commandArgs(argc, argv);
 
     // Construct the Verilated model, from Vtop.h generated from Verilating
-    const std::unique_ptr<Vt_flag_lib_dpi> topp{new Vt_flag_lib_dpi{contextp.get()}};
+    Vt_flag_lib_dpi top{&context};
 
     // Simulate until $finish
-    while (!contextp->gotFinish()) {
+    while (!context.gotFinish()) {
         // Evaluate model
-        topp->eval();
+        top.eval();
         // Advance time
-        contextp->timeInc(1);
+        context.timeInc(1);
     }
 
-    if (!contextp->gotFinish()) {
+    if (!context.gotFinish()) {
         VL_DEBUG_IF(VL_PRINTF("+ Exiting without $finish; no events left\n"););
     }
 
     // Final model cleanup
-    topp->final();
+    top.final();
     return 0;
 }

--- a/test_regress/t/t_force_mid.cpp
+++ b/test_regress/t/t_force_mid.cpp
@@ -13,34 +13,33 @@
 #include "Vt_force_mid.h"
 // General headers
 #include "verilated.h"
-std::unique_ptr<Vt_force_mid> topp;
+
 int main(int argc, char** argv) {
     uint64_t sim_time = 1100;
-    const std::unique_ptr<VerilatedContext> contextp{new VerilatedContext};
-    contextp->commandArgs(argc, argv);
-    contextp->debug(0);
+    VerilatedContext context;
+    Vt_force_mid top{"top"};
+    context.commandArgs(argc, argv);
+    context.debug(0);
     srand48(5);
-    topp.reset(new Vt_force_mid{"top"});
-    topp->topin = 0x9;
-    topp->eval();
+    top.topin = 0x9;
+    top.eval();
     {
-        topp->clk = false;
-        contextp->timeInc(10 * MAIN_TIME_MULTIPLIER);
+        top.clk = false;
+        context.timeInc(10 * MAIN_TIME_MULTIPLIER);
     }
-    while ((contextp->time() < sim_time * MAIN_TIME_MULTIPLIER) && !contextp->gotFinish()) {
-        topp->clk = !topp->clk;
-        topp->eval();
-        contextp->timeInc(1 * MAIN_TIME_MULTIPLIER);
-        contextp->timeInc(1 * MAIN_TIME_MULTIPLIER);
-        contextp->timeInc(1 * MAIN_TIME_MULTIPLIER);
-        contextp->timeInc(1 * MAIN_TIME_MULTIPLIER);
-        contextp->timeInc(1 * MAIN_TIME_MULTIPLIER);
+    while ((context.time() < sim_time * MAIN_TIME_MULTIPLIER) && !context.gotFinish()) {
+        top.clk = !top.clk;
+        top.eval();
+        context.timeInc(1 * MAIN_TIME_MULTIPLIER);
+        context.timeInc(1 * MAIN_TIME_MULTIPLIER);
+        context.timeInc(1 * MAIN_TIME_MULTIPLIER);
+        context.timeInc(1 * MAIN_TIME_MULTIPLIER);
+        context.timeInc(1 * MAIN_TIME_MULTIPLIER);
     }
-    if (!contextp->gotFinish()) {
+    if (!context.gotFinish()) {
         vl_fatal(__FILE__, __LINE__, "main", "%Error: Timeout; never got a $finish");
     }
-    topp->final();
+    top.final();
 
-    topp.reset();
     return 0;
 }

--- a/test_regress/t/t_forceable_net.cpp
+++ b/test_regress/t/t_forceable_net.cpp
@@ -17,102 +17,102 @@
 #include VM_PREFIX_ROOT_INCLUDE
 
 int main(int argc, char** argv) {
-    const std::unique_ptr<VerilatedContext> contextp{new VerilatedContext};
-    contextp->debug(0);
-    contextp->commandArgs(argc, argv);
+    VerilatedContext context;
+    context.debug(0);
+    context.commandArgs(argc, argv);
     srand48(5);
 
-    const std::unique_ptr<VM_PREFIX> topp{new VM_PREFIX{"top"}};
+    VM_PREFIX top{"top"};
 
-    topp->clk = false;
-    topp->rst = true;
-    topp->eval();
+    top.clk = false;
+    top.rst = true;
+    top.eval();
 #if VM_TRACE
-    contextp->traceEverOn(true);
-    std::unique_ptr<VerilatedVcdC> tfp{new VerilatedVcdC};
-    topp->trace(tfp.get(), 99);
-    tfp->open(VL_STRINGIFY(TEST_OBJ_DIR) "/simx.vcd");
-    tfp->dump(contextp->time());
+    context.traceEverOn(true);
+    VerilatedVcdC tf;
+    top.trace(&tf, 99);
+    tf.open(VL_STRINGIFY(TEST_OBJ_DIR) "/simx.vcd");
+    tf.dump(context.time());
 #endif
-    contextp->timeInc(5);
+    context.timeInc(5);
 
-    topp->clk = true;
-    topp->eval();
-    topp->rst = false;
-    topp->eval();
+    top.clk = true;
+    top.eval();
+    top.rst = false;
+    top.eval();
 #if VM_TRACE
-    tfp->dump(contextp->time());
+    tf.dump(context.time());
 #endif
-    contextp->timeInc(5);
+    context.timeInc(5);
 
-    while (contextp->time() < 1000 && !contextp->gotFinish()) {
-        topp->clk = !topp->clk;
-        topp->eval();
+    while (context.time() < 1000 && !context.gotFinish()) {
+        top.clk = !top.clk;
+        top.eval();
 
-        if (topp->clk) {
+        if (top.clk) {
             bool needsSecondEval = false;
 
-            if (topp->cyc == 3) {
-                topp->rootp->t__DOT__net_1__VforceEn = 1;
-                topp->rootp->t__DOT__net_1__VforceVal = 0;
+            if (top.cyc == 3) {
+                top.rootp->t__DOT__net_1__VforceEn = 1;
+                top.rootp->t__DOT__net_1__VforceVal = 0;
                 needsSecondEval = true;
             }
-            if (topp->cyc == 5) {
-                topp->rootp->t__DOT__net_1__VforceVal = 1;
+            if (top.cyc == 5) {
+                top.rootp->t__DOT__net_1__VforceVal = 1;
                 needsSecondEval = true;
             }
-            if (topp->cyc == 8) {
-                topp->rootp->t__DOT__net_1__VforceEn = 0;
-                needsSecondEval = true;
-            }
-
-            if (topp->cyc == 4) {
-                topp->rootp->t__DOT__net_8__VforceEn = 0xff;
-                topp->rootp->t__DOT__net_8__VforceVal = 0x5f;
-                needsSecondEval = true;
-            }
-            if (topp->cyc == 6) {
-                topp->rootp->t__DOT__net_8__VforceVal = 0xf5;
-                needsSecondEval = true;
-            }
-            if (topp->cyc == 9) {
-                topp->rootp->t__DOT__net_8__VforceEn = 0;
+            if (top.cyc == 8) {
+                top.rootp->t__DOT__net_1__VforceEn = 0;
                 needsSecondEval = true;
             }
 
-            if (topp->cyc == 10) {
-                topp->rootp->t__DOT__net_1__VforceEn = 1;
-                topp->rootp->t__DOT__net_8__VforceEn = 0xff;
-                topp->rootp->t__DOT__net_1__VforceVal = 1;
-                topp->rootp->t__DOT__net_8__VforceVal = 0x5a;
+            if (top.cyc == 4) {
+                top.rootp->t__DOT__net_8__VforceEn = 0xff;
+                top.rootp->t__DOT__net_8__VforceVal = 0x5f;
                 needsSecondEval = true;
             }
-            if (topp->cyc == 12) {
-                topp->rootp->t__DOT__net_1__VforceVal = 0;
-                topp->rootp->t__DOT__net_8__VforceVal = 0xa5;
+            if (top.cyc == 6) {
+                top.rootp->t__DOT__net_8__VforceVal = 0xf5;
                 needsSecondEval = true;
             }
-            if (topp->cyc == 14) {
-                topp->rootp->t__DOT__net_1__VforceEn = 0;
-                topp->rootp->t__DOT__net_8__VforceEn = 0;
+            if (top.cyc == 9) {
+                top.rootp->t__DOT__net_8__VforceEn = 0;
                 needsSecondEval = true;
             }
 
-            if (needsSecondEval) topp->eval();
+            if (top.cyc == 10) {
+                top.rootp->t__DOT__net_1__VforceEn = 1;
+                top.rootp->t__DOT__net_8__VforceEn = 0xff;
+                top.rootp->t__DOT__net_1__VforceVal = 1;
+                top.rootp->t__DOT__net_8__VforceVal = 0x5a;
+                needsSecondEval = true;
+            }
+            if (top.cyc == 12) {
+                top.rootp->t__DOT__net_1__VforceVal = 0;
+                top.rootp->t__DOT__net_8__VforceVal = 0xa5;
+                needsSecondEval = true;
+            }
+            if (top.cyc == 14) {
+                top.rootp->t__DOT__net_1__VforceEn = 0;
+                top.rootp->t__DOT__net_8__VforceEn = 0;
+                needsSecondEval = true;
+            }
+
+            if (needsSecondEval) top.eval();
         }
 #if VM_TRACE
-        tfp->dump(contextp->time());
+        tf.dump(context.time());
 #endif
-        contextp->timeInc(5);
+        context.timeInc(5);
     }
 
-    if (!contextp->gotFinish()) {
+    if (!context.gotFinish()) {
         vl_fatal(__FILE__, __LINE__, "main", "%Error: Timeout; never got a $finish");
     }
 
-    topp->final();
+    top.final();
 #if VM_TRACE
-    tfp->close();
+    tf.close();
 #endif
 
     return 0;

--- a/test_regress/t/t_forceable_var.cpp
+++ b/test_regress/t/t_forceable_var.cpp
@@ -17,102 +17,102 @@
 #include VM_PREFIX_ROOT_INCLUDE
 
 int main(int argc, char** argv) {
-    const std::unique_ptr<VerilatedContext> contextp{new VerilatedContext};
-    contextp->debug(0);
-    contextp->commandArgs(argc, argv);
+    VerilatedContext context;
+    context.debug(0);
+    context.commandArgs(argc, argv);
     srand48(5);
 
-    const std::unique_ptr<VM_PREFIX> topp{new VM_PREFIX{"top"}};
+    VM_PREFIX top{"top"};
 
-    topp->clk = false;
-    topp->rst = true;
-    topp->eval();
+    top.clk = false;
+    top.rst = true;
+    top.eval();
 #if VM_TRACE
-    contextp->traceEverOn(true);
-    std::unique_ptr<VerilatedVcdC> tfp{new VerilatedVcdC};
-    topp->trace(tfp.get(), 99);
-    tfp->open(VL_STRINGIFY(TEST_OBJ_DIR) "/simx.vcd");
-    tfp->dump(contextp->time());
+    context.traceEverOn(true);
+    VerilatedVcdC tf;
+    top.trace(&tf, 99);
+    tf.open(VL_STRINGIFY(TEST_OBJ_DIR) "/simx.vcd");
+    tf.dump(context.time());
 #endif
-    contextp->timeInc(5);
+    context.timeInc(5);
 
-    topp->clk = true;
-    topp->eval();
-    topp->rst = false;
-    topp->eval();
+    top.clk = true;
+    top.eval();
+    top.rst = false;
+    top.eval();
 #if VM_TRACE
-    tfp->dump(contextp->time());
+    tf.dump(context.time());
 #endif
-    contextp->timeInc(5);
+    context.timeInc(5);
 
-    while (contextp->time() < 1000 && !contextp->gotFinish()) {
-        topp->clk = !topp->clk;
-        topp->eval();
+    while (context.time() < 1000 && !context.gotFinish()) {
+        top.clk = !top.clk;
+        top.eval();
 
-        if (topp->clk) {
+        if (top.clk) {
             bool needsSecondEval = false;
 
-            if (topp->cyc == 13) {
-                topp->rootp->t__DOT__var_1__VforceEn = 1;
-                topp->rootp->t__DOT__var_1__VforceVal = 1;
+            if (top.cyc == 13) {
+                top.rootp->t__DOT__var_1__VforceEn = 1;
+                top.rootp->t__DOT__var_1__VforceVal = 1;
                 needsSecondEval = true;
             }
-            if (topp->cyc == 15) {
-                topp->rootp->t__DOT__var_1__VforceVal = 0;
+            if (top.cyc == 15) {
+                top.rootp->t__DOT__var_1__VforceVal = 0;
                 needsSecondEval = true;
             }
-            if (topp->cyc == 18) {
-                topp->rootp->t__DOT__var_1__VforceEn = 0;
-                needsSecondEval = true;
-            }
-
-            if (topp->cyc == 14) {
-                topp->rootp->t__DOT__var_8__VforceEn = 0xff;
-                topp->rootp->t__DOT__var_8__VforceVal = 0xf5;
-                needsSecondEval = true;
-            }
-            if (topp->cyc == 16) {
-                topp->rootp->t__DOT__var_8__VforceVal = 0x5f;
-                needsSecondEval = true;
-            }
-            if (topp->cyc == 19) {
-                topp->rootp->t__DOT__var_8__VforceEn = 0;
+            if (top.cyc == 18) {
+                top.rootp->t__DOT__var_1__VforceEn = 0;
                 needsSecondEval = true;
             }
 
-            if (topp->cyc == 20) {
-                topp->rootp->t__DOT__var_1__VforceEn = 1;
-                topp->rootp->t__DOT__var_8__VforceEn = 0xff;
-                topp->rootp->t__DOT__var_1__VforceVal = 1;
-                topp->rootp->t__DOT__var_8__VforceVal = 0x5a;
+            if (top.cyc == 14) {
+                top.rootp->t__DOT__var_8__VforceEn = 0xff;
+                top.rootp->t__DOT__var_8__VforceVal = 0xf5;
                 needsSecondEval = true;
             }
-            if (topp->cyc == 22) {
-                topp->rootp->t__DOT__var_1__VforceVal = 0;
-                topp->rootp->t__DOT__var_8__VforceVal = 0xa5;
+            if (top.cyc == 16) {
+                top.rootp->t__DOT__var_8__VforceVal = 0x5f;
                 needsSecondEval = true;
             }
-            if (topp->cyc == 24) {
-                topp->rootp->t__DOT__var_1__VforceEn = 0;
-                topp->rootp->t__DOT__var_8__VforceEn = 0;
+            if (top.cyc == 19) {
+                top.rootp->t__DOT__var_8__VforceEn = 0;
                 needsSecondEval = true;
             }
 
-            if (needsSecondEval) topp->eval();
+            if (top.cyc == 20) {
+                top.rootp->t__DOT__var_1__VforceEn = 1;
+                top.rootp->t__DOT__var_8__VforceEn = 0xff;
+                top.rootp->t__DOT__var_1__VforceVal = 1;
+                top.rootp->t__DOT__var_8__VforceVal = 0x5a;
+                needsSecondEval = true;
+            }
+            if (top.cyc == 22) {
+                top.rootp->t__DOT__var_1__VforceVal = 0;
+                top.rootp->t__DOT__var_8__VforceVal = 0xa5;
+                needsSecondEval = true;
+            }
+            if (top.cyc == 24) {
+                top.rootp->t__DOT__var_1__VforceEn = 0;
+                top.rootp->t__DOT__var_8__VforceEn = 0;
+                needsSecondEval = true;
+            }
+
+            if (needsSecondEval) top.eval();
         }
 #if VM_TRACE
-        tfp->dump(contextp->time());
+        tf.dump(context.time());
 #endif
-        contextp->timeInc(5);
+        context.timeInc(5);
     }
 
-    if (!contextp->gotFinish()) {
+    if (!context.gotFinish()) {
         vl_fatal(__FILE__, __LINE__, "main", "%Error: Timeout; never got a $finish");
     }
 
-    topp->final();
+    top.final();
 #if VM_TRACE
-    tfp->close();
+    tf.close();
 #endif
 
     return 0;

--- a/test_regress/t/t_gantt_two.cpp
+++ b/test_regress/t/t_gantt_two.cpp
@@ -15,29 +15,29 @@
 int main(int argc, char** argv) {
     srand48(5);
 
-    const std::unique_ptr<VerilatedContext> contextp{new VerilatedContext};
+    VerilatedContext context;
     // VL_USE_THREADS define is set in t_gantt_two.py
-    contextp->threads(TEST_USE_THREADS);
-    contextp->debug(0);
-    contextp->commandArgs(argc, argv);
+    context.threads(TEST_USE_THREADS);
+    context.debug(0);
+    context.commandArgs(argc, argv);
 
-    std::unique_ptr<VM_PREFIX> topap{new VM_PREFIX{contextp.get(), "topa"}};
-    std::unique_ptr<VM_PREFIX> topbp{new VM_PREFIX{contextp.get(), "topb"}};
+    VM_PREFIX topa{&context, "topa"};
+    VM_PREFIX topb{&context, "topb"};
 
-    topap->clk = false;
-    topap->eval();
-    topbp->clk = false;
-    topbp->eval();
+    topa.clk = false;
+    topa.eval();
+    topb.clk = false;
+    topb.eval();
 
-    contextp->timeInc(10);
-    while ((contextp->time() < 1100) && !contextp->gotFinish()) {
-        topap->clk = !topap->clk;
-        topap->eval();
-        topbp->clk = !topbp->clk;
-        topbp->eval();
-        contextp->timeInc(5);
+    context.timeInc(10);
+    while ((context.time() < 1100) && !context.gotFinish()) {
+        topa.clk = !topa.clk;
+        topa.eval();
+        topb.clk = !topb.clk;
+        topb.eval();
+        context.timeInc(5);
     }
-    if (!contextp->gotFinish()) {
+    if (!context.gotFinish()) {
         vl_fatal(__FILE__, __LINE__, "main", "%Error: Timeout; never got a $finish");
     }
     return 0;

--- a/test_regress/t/t_hier_block_cmake/main.cpp
+++ b/test_regress/t/t_hier_block_cmake/main.cpp
@@ -9,22 +9,23 @@
 //
 //*************************************************************************
 
-#include <memory>
 #include "Vt_hier_block.h"
 
-int main(int argc, char *argv[]) {
-    const std::unique_ptr<VerilatedContext> contextp{new VerilatedContext};
+#include <memory>
+
+int main(int argc, char* argv[]) {
+    VerilatedContext context;
     // TEST_THREADS is set in t_hier_block_cmake.py
-    contextp->threads(TEST_THREADS);
-    contextp->commandArgs(argc, argv);
-    std::unique_ptr<Vt_hier_block> top{new Vt_hier_block{contextp.get(), "top"}};
-    for (int i = 0; i < 100 && !contextp->gotFinish(); ++i) {
-        top->eval();
-        top->clk ^= 1;
+    context.threads(TEST_THREADS);
+    context.commandArgs(argc, argv);
+    Vt_hier_block top{&context, "top"};
+    for (int i = 0; i < 100 && !context.gotFinish(); ++i) {
+        top.eval();
+        top.clk ^= 1;
     }
-    if (!contextp->gotFinish()) {
+    if (!context.gotFinish()) {
         vl_fatal(__FILE__, __LINE__, "main", "%Error: Timeout; never got a $finish");
     }
-    top->final();
+    top.final();
     return 0;
 }

--- a/test_regress/t/t_interface_virtual_sched_ico.cpp
+++ b/test_regress/t/t_interface_virtual_sched_ico.cpp
@@ -17,34 +17,34 @@
 #include <memory>
 
 int main(int argc, char** argv) {
-    const std::unique_ptr<VerilatedContext> contextp{new VerilatedContext};
-    contextp->debug(0);
-    contextp->commandArgs(argc, argv);
+    VerilatedContext context;
+    context.debug(0);
+    context.commandArgs(argc, argv);
     srand48(5);
 
-    const std::unique_ptr<VM_PREFIX> topp{new VM_PREFIX};
-    topp->clk = false;
-    topp->inc1 = 1;
-    topp->eval();
-    topp->inc2 = 1;
-    topp->eval();
+    VM_PREFIX top;
+    top.clk = false;
+    top.inc1 = 1;
+    top.eval();
+    top.inc2 = 1;
+    top.eval();
 
     bool flop = true;
-    while (!contextp->gotFinish() && contextp->time() < 100000) {
-        contextp->timeInc(5);
-        if (topp->clk) {
+    while (!context.gotFinish() && context.time() < 100000) {
+        context.timeInc(5);
+        if (top.clk) {
             if (flop) {
-                topp->inc1 += 1;
+                top.inc1 += 1;
             } else {
-                topp->inc2 += 1;
+                top.inc2 += 1;
             }
             flop = !flop;
         }
-        topp->clk = !topp->clk;
-        topp->eval();
+        top.clk = !top.clk;
+        top.eval();
     }
 
-    if (!contextp->gotFinish()) {
+    if (!context.gotFinish()) {
         vl_fatal(__FILE__, __LINE__, "main", "%Error: Timeout; never got a $finish");
     }
     return 0;

--- a/test_regress/t/t_math_pow7.cpp
+++ b/test_regress/t/t_math_pow7.cpp
@@ -12,30 +12,30 @@
 
 int errors = 0;
 
-std::unique_ptr<VM_PREFIX> topp;
 int main(int argc, char** argv) {
     vluint64_t sim_time = 1100;
-    const std::unique_ptr<VerilatedContext> contextp{new VerilatedContext};
-    contextp->commandArgs(argc, argv);
-    topp.reset(new VM_PREFIX{"top"});
+    {
+        VerilatedContext context;
+        context.commandArgs(argc, argv);
+        VM_PREFIX top{"top"};
 
-    topp->eval();
-    { contextp->timeInc(10); }
+        top.eval();
+        { context.timeInc(10); }
 
-    int cyc = 0;
+        int cyc = 0;
 
-    while ((contextp->time() < sim_time) && !contextp->gotFinish()) {
-        topp->eval();
-        contextp->timeInc(5);
+        while ((context.time() < sim_time) && !context.gotFinish()) {
+            top.eval();
+            context.timeInc(5);
 
-        ++cyc;
-        if (cyc > 10) break;
+            ++cyc;
+            if (cyc > 10) break;
+        }
+
+        TEST_CHECK_EQ(top.out_data, 1);
+
+        top.final();
     }
-
-    TEST_CHECK_EQ(topp->out_data, 1);
-
-    topp->final();
-    topp.reset();
 
     printf("*-* All Finished *-*\n");
     return errors != 0;

--- a/test_regress/t/t_no_trace_top.cpp
+++ b/test_regress/t/t_no_trace_top.cpp
@@ -20,25 +20,25 @@ int main(int argc, char** argv) {
     Verilated::debug(0);
     Verilated::traceEverOn(true);
     Verilated::commandArgs(argc, argv);
+    {
+        VM_PREFIX top{"top"};
 
-    std::unique_ptr<VM_PREFIX> top{new VM_PREFIX{"top"}};
+        VerilatedVcdC tf;
+        top.trace(&tf, 99);
+        tf.open(VL_STRINGIFY(TEST_OBJ_DIR) "/simno_trace_top.vcd");
 
-    std::unique_ptr<VerilatedVcdC> tfp{new VerilatedVcdC};
-    top->trace(tfp.get(), 99);
-    tfp->open(VL_STRINGIFY(TEST_OBJ_DIR) "/simno_trace_top.vcd");
+        top.clk = 0;
 
-    top->clk = 0;
-
-    while (main_time < 1900) {  // Creates 2 files
-        top->clk = !top->clk;
-        top->eval();
-        tfp->dump((unsigned int)(main_time));
-        ++main_time;
+        while (main_time < 1900) {  // Creates 2 files
+            top.clk = !top.clk;
+            top.eval();
+            tf.dump((unsigned int)(main_time));
+            ++main_time;
+        }
+        tf.close();
+        top.final();
     }
-    tfp->close();
-    top->final();
-    tfp.reset();
-    top.reset();
+
     printf("*-* All Finished *-*\n");
     return 0;
 }

--- a/test_regress/t/t_public_clk.cpp
+++ b/test_regress/t/t_public_clk.cpp
@@ -12,30 +12,28 @@
 // General headers
 #include "verilated.h"
 
-std::unique_ptr<Vt_public_clk> topp;
 int main(int argc, char** argv) {
     vluint64_t sim_time = 1100;
-    const std::unique_ptr<VerilatedContext> contextp{new VerilatedContext};
-    contextp->debug(0);
-    contextp->commandArgs(argc, argv);
+    VerilatedContext context;
+    context.debug(0);
+    context.commandArgs(argc, argv);
     srand48(5);
-    topp.reset(new VM_PREFIX{"top"});
+    VM_PREFIX top{"top"};
 
-    topp->rootp->t__DOT__clk = 0;
-    topp->eval();
-    { contextp->timeInc(10); }
+    top.rootp->t__DOT__clk = 0;
+    top.eval();
+    { context.timeInc(10); }
 
-    while ((contextp->time() < sim_time) && !contextp->gotFinish()) {
-        topp->rootp->t__DOT__clk = !topp->rootp->t__DOT__clk;
-        topp->eval();
-        contextp->timeInc(5);
+    while ((context.time() < sim_time) && !context.gotFinish()) {
+        top.rootp->t__DOT__clk = !top.rootp->t__DOT__clk;
+        top.eval();
+        context.timeInc(5);
     }
 
-    if (!contextp->gotFinish()) {
+    if (!context.gotFinish()) {
         vl_fatal(__FILE__, __LINE__, "main", "%Error: Timeout; never got a $finish");
     }
-    topp->final();
+    top.final();
 
-    topp.reset();
     return 0;
 }

--- a/test_regress/t/t_public_seq.cpp
+++ b/test_regress/t/t_public_seq.cpp
@@ -12,34 +12,32 @@
 // General headers
 #include "verilated.h"
 
-std::unique_ptr<Vt_public_seq> topp;
 int main(int argc, char** argv) {
     vluint64_t sim_time = 1100;
-    const std::unique_ptr<VerilatedContext> contextp{new VerilatedContext};
-    contextp->debug(0);
-    contextp->commandArgs(argc, argv);
+    VerilatedContext context;
+    context.debug(0);
+    context.commandArgs(argc, argv);
     srand48(5);
-    topp.reset(new VM_PREFIX{"top"});
+    VM_PREFIX top{"top"};
 
-    topp->clk = 0;
-    topp->eval();
-    { contextp->timeInc(10); }
+    top.clk = 0;
+    top.eval();
+    { context.timeInc(10); }
 
     int cyc = 0;
 
-    while ((contextp->time() < sim_time) && !contextp->gotFinish()) {
-        if (cyc >= 5) ++topp->rootp->t__DOT__pub_byte;
-        topp->eval();
-        topp->clk = !topp->clk;
-        topp->eval();
-        contextp->timeInc(5);
-        if (topp->clk) cyc++;
+    while ((context.time() < sim_time) && !context.gotFinish()) {
+        if (cyc >= 5) ++top.rootp->t__DOT__pub_byte;
+        top.eval();
+        top.clk = !top.clk;
+        top.eval();
+        context.timeInc(5);
+        if (top.clk) cyc++;
     }
-    if (!contextp->gotFinish()) {
+    if (!context.gotFinish()) {
         vl_fatal(__FILE__, __LINE__, "main", "%Error: Timeout; never got a $finish");
     }
-    topp->final();
+    top.final();
 
-    topp.reset();
     return 0;
 }

--- a/test_regress/t/t_scope_map.cpp
+++ b/test_regress/t/t_scope_map.cpp
@@ -18,23 +18,23 @@
 const unsigned long long dt_2 = 3;
 
 int main(int argc, char** argv) {
-    const std::unique_ptr<VerilatedContext> contextp{new VerilatedContext};
+    VerilatedContext context;
 
-    VM_PREFIX* top = new VM_PREFIX{contextp.get(), "top"};
+    VM_PREFIX top{&context, "top"};
 
-    contextp->debug(0);
-    contextp->traceEverOn(true);
+    context.debug(0);
+    context.traceEverOn(true);
 
-    VerilatedVcdC* tfp = new VerilatedVcdC;
-    top->trace(tfp, 99);
-    tfp->open(VL_STRINGIFY(TEST_OBJ_DIR) "/simx.vcd");
+    VerilatedVcdC tf;
+    top.trace(&tf, 99);
+    tf.open(VL_STRINGIFY(TEST_OBJ_DIR) "/simx.vcd");
 
-    top->CLK = 0;
-    top->eval();
-    tfp->dump(contextp->time());
-    contextp->timeInc(1);
+    top.CLK = 0;
+    top.eval();
+    tf.dump(context.time());
+    context.timeInc(1);
 
-    const VerilatedScopeNameMap* scopeMapp = contextp->scopeNameMap();
+    const VerilatedScopeNameMap* scopeMapp = context.scopeNameMap();
     for (VerilatedScopeNameMap::const_iterator it = scopeMapp->begin(); it != scopeMapp->end();
          ++it) {
 #ifdef TEST_VERBOSE
@@ -104,16 +104,16 @@ int main(int argc, char** argv) {
         }
     }
 
-    top->CLK = 0;
-    top->eval();
-    tfp->dump(contextp->time());
-    contextp->timeInc(1);
+    top.CLK = 0;
+    top.eval();
+    tf.dump(context.time());
+    context.timeInc(1);
 
     // Posedge on clock, expect all the public bits to flip
-    top->CLK = 1;
-    top->eval();
-    tfp->dump(contextp->time());
-    contextp->timeInc(1);
+    top.CLK = 1;
+    top.eval();
+    tf.dump(context.time());
+    context.timeInc(1);
 
     for (VerilatedScopeNameMap::const_iterator it = scopeMapp->begin(); it != scopeMapp->end();
          ++it) {
@@ -151,15 +151,13 @@ int main(int argc, char** argv) {
         }
     }
 
-    top->CLK = 0;
-    top->eval();
-    tfp->dump(contextp->time());
-    contextp->timeInc(1);
+    top.CLK = 0;
+    top.eval();
+    tf.dump(context.time());
+    context.timeInc(1);
 
-    tfp->close();
-    top->final();
-    VL_DO_DANGLING(delete tfp, tfp);
-    VL_DO_DANGLING(delete top, top);
+    tf.close();
+    top.final();
 
     VL_PRINTF("*-* All Finished *-*\n");
 

--- a/test_regress/t/t_trace_cat.cpp
+++ b/test_regress/t/t_trace_cat.cpp
@@ -31,44 +31,44 @@ int main(int argc, char** argv) {
     Verilated::traceEverOn(true);
     Verilated::commandArgs(argc, argv);
 
-    std::unique_ptr<VM_PREFIX> top{new VM_PREFIX{"top"}};
+    {
+        VM_PREFIX top{"top"};
 
-    std::unique_ptr<VerilatedVcdC> tfp{new VerilatedVcdC};
-    top->trace(tfp.get(), 99);
+        VerilatedVcdC* tfp = new VerilatedVcdC;
+        top.trace(tfp, 99);
 
-    // Test for traceCapable - randomly-ish selected this test
-    TEST_CHECK_EQ(top->traceCapable, true);
+        // Test for traceCapable - randomly-ish selected this test
+        TEST_CHECK_EQ(top.traceCapable, true);
 
-    tfp->open(trace_name());
+        tfp->open(trace_name());
 
-    top->clk = 0;
+        top.clk = 0;
 
-    while (main_time < 190) {  // Creates 2 files
-        top->clk = !top->clk;
-        top->eval();
+        while (main_time < 190) {  // Creates 2 files
+            top.clk = !top.clk;
+            top.eval();
 
-        if ((main_time % 100) == 0) {
+            if ((main_time % 100) == 0) {
 #if defined(T_TRACE_CAT)
-            tfp->openNext(true);
+                tfp->openNext(true);
 #elif defined(T_TRACE_CAT_REOPEN)
-            tfp->close();
-            tfp->open(trace_name());
+                tfp->close();
+                tfp->open(trace_name());
 #elif defined(T_TRACE_CAT_RENEW)
-            tfp->close();
-            tfp.reset(new VerilatedVcdC);
-            top->trace(tfp.get(), 99);
-            tfp->open(trace_name());
+                tfp->close();
+                tfp = new VerilatedVcdC;
+                top.trace(tfp, 99);
+                tfp->open(trace_name());
 #else
 #error "Unknown test"
 #endif
+            }
+            tfp->dump((unsigned int)(main_time));
+            ++main_time;
         }
-        tfp->dump((unsigned int)(main_time));
-        ++main_time;
+        tfp->close();
+        top.final();
     }
-    tfp->close();
-    top->final();
-    tfp.reset();
-    top.reset();
     printf("*-* All Finished *-*\n");
     return errors;
 }

--- a/test_regress/t/t_trace_cat_fst.cpp
+++ b/test_regress/t/t_trace_cat_fst.cpp
@@ -27,30 +27,31 @@ int main(int argc, char** argv) {
     Verilated::traceEverOn(true);
     Verilated::commandArgs(argc, argv);
 
-    std::unique_ptr<VM_PREFIX> top{new VM_PREFIX{"top"}};
+    {
+        VM_PREFIX top{"top"};
 
-    std::unique_ptr<VerilatedFstC> tfp{new VerilatedFstC};
-    top->trace(tfp.get(), 99);
+        VerilatedFstC tf;
+        top.trace(&tf, 99);
 
-    tfp->open(trace_name());
+        tf.open(trace_name());
 
-    top->clk = 0;
+        top.clk = 0;
 
-    while (main_time < 190) {  // Creates 2 files
-        top->clk = !top->clk;
-        top->eval();
+        while (main_time < 190) {  // Creates 2 files
+            top.clk = !top.clk;
+            top.eval();
 
-        if ((main_time % 100) == 0) {
-            tfp->close();
-            tfp->open(trace_name());
+            if ((main_time % 100) == 0) {
+                tf.close();
+                tf.open(trace_name());
+            }
+            tf.dump((unsigned int)(main_time));
+            ++main_time;
         }
-        tfp->dump((unsigned int)(main_time));
-        ++main_time;
+        tf.close();
+        top.final();
     }
-    tfp->close();
-    top->final();
-    tfp.reset();
-    top.reset();
+
     printf("*-* All Finished *-*\n");
     return 0;
 }

--- a/test_regress/t/t_trace_dumpvars_dyn.cpp
+++ b/test_regress/t/t_trace_dumpvars_dyn.cpp
@@ -31,35 +31,37 @@ int main(int argc, char** argv) {
     Verilated::traceEverOn(true);
     Verilated::commandArgs(argc, argv);
 
-    std::unique_ptr<VM_PREFIX> top{new VM_PREFIX{"top"}};
+    {
 
-    std::unique_ptr<TRACE_CLASS> tfp{new TRACE_CLASS};
+        VM_PREFIX top{"top"};
+
+        TRACE_CLASS tf;
 
 #if defined(T_TRACE_DUMPVARS_DYN_VCD_0) || defined(T_TRACE_DUMPVARS_DYN_FST_0)
-    tfp->dumpvars(0, "");
+        tf.dumpvars(0, "");
 #elif defined(T_TRACE_DUMPVARS_DYN_VCD_1) || defined(T_TRACE_DUMPVARS_DYN_FST_1)
-    tfp->dumpvars(99, "t");  // This should not match "top."
-    tfp->dumpvars(1, "top.t.cyc");  // A signal
-    tfp->dumpvars(1, "top.t.sub1a");  // Scope
-    tfp->dumpvars(2, "top.t.sub1b");  // Scope
+        tf.dumpvars(99, "t");  // This should not match "top."
+        tf.dumpvars(1, "top.t.cyc");  // A signal
+        tf.dumpvars(1, "top.t.sub1a");  // Scope
+        tf.dumpvars(2, "top.t.sub1b");  // Scope
 #else
 #error "Bad test"
 #endif
 
-    top->trace(tfp.get(), 99);
-    tfp->open(VL_STRINGIFY(TEST_OBJ_DIR) "/" TRACE_FILE_NAME);
-    top->clk = 0;
+        top.trace(&tf, 99);
+        tf.open(VL_STRINGIFY(TEST_OBJ_DIR) "/" TRACE_FILE_NAME);
+        top.clk = 0;
 
-    while (main_time <= 20) {
-        top->eval();
-        tfp->dump((unsigned int)(main_time));
-        ++main_time;
-        top->clk = !top->clk;
+        while (main_time <= 20) {
+            top.eval();
+            tf.dump((unsigned int)(main_time));
+            ++main_time;
+            top.clk = !top.clk;
+        }
+        tf.close();
+        top.final();
     }
-    tfp->close();
-    top->final();
-    tfp.reset();
-    top.reset();
+
     printf("*-* All Finished *-*\n");
     return 0;
 }

--- a/test_regress/t/t_trace_no_top_name2.cpp
+++ b/test_regress/t/t_trace_no_top_name2.cpp
@@ -30,24 +30,25 @@ int main(int argc, char** argv) {
     Verilated::commandArgs(argc, argv);
 
     // This test is to specifically check "" as the below upper model name
-    std::unique_ptr<VM_PREFIX> top{new VM_PREFIX{""}};
+    VM_PREFIX top{""};
 
-    std::unique_ptr<TRACE_CLASS> tfp{new TRACE_CLASS};
+    TRACE_CLASS tf;
 
-    top->trace(tfp.get(), 99);
-    tfp->open(VL_STRINGIFY(TEST_OBJ_DIR) "/" TRACE_FILE_NAME);
-    top->clk = 0;
+    {
+        top.trace(&tf, 99);
+        tf.open(VL_STRINGIFY(TEST_OBJ_DIR) "/" TRACE_FILE_NAME);
+        top.clk = 0;
 
-    while (main_time <= 20) {
-        top->eval();
-        tfp->dump((unsigned int)(main_time));
-        ++main_time;
-        top->clk = !top->clk;
+        while (main_time <= 20) {
+            top.eval();
+            tf.dump((unsigned int)(main_time));
+            ++main_time;
+            top.clk = !top.clk;
+        }
+        tf.close();
+        top.final();
     }
-    tfp->close();
-    top->final();
-    tfp.reset();
-    top.reset();
+
     printf("*-* All Finished *-*\n");
     return 0;
 }

--- a/test_regress/t/t_trace_noflag_bad_c.cpp
+++ b/test_regress/t/t_trace_noflag_bad_c.cpp
@@ -12,13 +12,13 @@
 #include VM_PREFIX_INCLUDE
 
 int main(int argc, char** argv) {
-    std::unique_ptr<VerilatedContext> contextp{new VerilatedContext};
-    contextp->traceEverOn(true);
-    std::unique_ptr<VerilatedVcdC> tfp{new VerilatedVcdC};
-    const std::unique_ptr<VM_PREFIX> topp{new VM_PREFIX{contextp.get()}};
-    topp->trace(tfp.get(), 99);  // Error!
-    tfp->open(VL_STRINGIFY(TEST_OBJ_DIR) "/dump.vcd");  // Error! shall put to the next line!
-    tfp->dump(0);
-    tfp->close();
+    VerilatedContext context;
+    context.traceEverOn(true);
+    VerilatedVcdC tf;
+    VM_PREFIX top{&context};
+    top.trace(&tf, 99);  // Error!
+    tf.open(VL_STRINGIFY(TEST_OBJ_DIR) "/dump.vcd");  // Error! shall put to the next line!
+    tf.dump(0);
+    tf.close();
     return 0;
 }

--- a/test_regress/t/t_trace_open_wrong_order_bad.cpp
+++ b/test_regress/t/t_trace_open_wrong_order_bad.cpp
@@ -12,14 +12,14 @@
 #include VM_PREFIX_INCLUDE
 
 int main(int argc, char** argv) {
-    std::unique_ptr<VerilatedContext> contextp{new VerilatedContext};
-    std::unique_ptr<VerilatedVcdC> tfp{new VerilatedVcdC};
-    std::unique_ptr<VM_PREFIX> top{new VM_PREFIX{contextp.get(), "top"}};
+    VerilatedContext context;
+    VerilatedVcdC tf;
+    VM_PREFIX top{&context, "top"};
 
-    contextp->traceEverOn(true);
-    tfp->open(VL_STRINGIFY(TEST_OBJ_DIR) "/dump.vcd");  // Error! shall put to the next line!
-    top->trace(tfp.get(), 99);  // Error!
-    tfp->dump(0);
-    tfp->close();
+    context.traceEverOn(true);
+    tf.open(VL_STRINGIFY(TEST_OBJ_DIR) "/dump.vcd");  // Error! shall put to the next line!
+    top.trace(&tf, 99);  // Error!
+    tf.dump(0);
+    tf.close();
     return 0;
 }

--- a/test_regress/t/t_trace_public_func.cpp
+++ b/test_regress/t/t_trace_public_func.cpp
@@ -32,25 +32,26 @@ int main(int argc, char** argv) {
     Verilated::traceEverOn(true);
     Verilated::commandArgs(argc, argv);
 
-    std::unique_ptr<VM_PREFIX> top{new VM_PREFIX{"top"}};
+    {
+        VM_PREFIX top{"top"};
 
-    std::unique_ptr<VerilatedVcdC> tfp{new VerilatedVcdC};
-    top->trace(tfp.get(), 99);
-    tfp->open(VL_STRINGIFY(TEST_OBJ_DIR) "/simx.vcd");
+        VerilatedVcdC tf;
+        top.trace(&tf, 99);
+        tf.open(VL_STRINGIFY(TEST_OBJ_DIR) "/simx.vcd");
 
-    while (main_time <= 20) {
-        top->CLK = (main_time / dt_2) % 2;
-        top->eval();
+        while (main_time <= 20) {
+            top.CLK = (main_time / dt_2) % 2;
+            top.eval();
 
-        top->t->glbl->setGSR(main_time < 7);
+            top.t->glbl->setGSR(main_time < 7);
 
-        tfp->dump((unsigned int)(main_time));
-        ++main_time;
+            tf.dump((unsigned int)(main_time));
+            ++main_time;
+        }
+        tf.close();
+        top.final();
     }
-    tfp->close();
-    top->final();
-    tfp.reset();
-    top.reset();
+
     printf("*-* All Finished *-*\n");
     return 0;
 }

--- a/test_regress/t/t_trace_rollover.cpp
+++ b/test_regress/t/t_trace_rollover.cpp
@@ -21,26 +21,27 @@ int main(int argc, char** argv) {
     Verilated::traceEverOn(true);
     Verilated::commandArgs(argc, argv);
 
-    std::unique_ptr<VM_PREFIX> top{new VM_PREFIX{"top"}};
+    {
+        VM_PREFIX top{"top"};
 
-    std::unique_ptr<VerilatedVcdC> tfp{new VerilatedVcdC};
-    top->trace(tfp.get(), 99);
+        VerilatedVcdC tf;
+        top.trace(&tf, 99);
 
-    tfp->rolloverSize(1000);  // But will be increased to 8kb chunk size
-    tfp->open(VL_STRINGIFY(TEST_OBJ_DIR) "/simrollover.vcd");
+        tf.rolloverSize(1000);  // But will be increased to 8kb chunk size
+        tf.open(VL_STRINGIFY(TEST_OBJ_DIR) "/simrollover.vcd");
 
-    top->clk = 0;
+        top.clk = 0;
 
-    while (main_time < 1900) {  // Creates 2 files
-        top->clk = !top->clk;
-        top->eval();
-        tfp->dump((unsigned int)(main_time));
-        ++main_time;
+        while (main_time < 1900) {  // Creates 2 files
+            top.clk = !top.clk;
+            top.eval();
+            tf.dump((unsigned int)(main_time));
+            ++main_time;
+        }
+        tf.close();
+        top.final();
     }
-    tfp->close();
-    top->final();
-    tfp.reset();
-    top.reset();
+
     printf("*-* All Finished *-*\n");
     return 0;
 }

--- a/test_regress/t/t_trace_two_cc.cpp
+++ b/test_regress/t/t_trace_two_cc.cpp
@@ -23,73 +23,67 @@
 // Compile in place
 #include "Vt_trace_two_b__ALL.cpp"
 
-VM_PREFIX* ap;
-Vt_trace_two_b* bp;
-
 int main(int argc, char** argv) {
-    const std::unique_ptr<VerilatedContext> contextp{new VerilatedContext};
+    VerilatedContext context;
 
     uint64_t sim_time = 1100;
-    contextp->debug(0);
-    contextp->commandArgs(argc, argv);
-    contextp->traceEverOn(true);
+    context.debug(0);
+    context.commandArgs(argc, argv);
+    context.traceEverOn(true);
     srand48(5);
-    ap = new VM_PREFIX{contextp.get(), "topa"};
-    bp = new Vt_trace_two_b{contextp.get(), "topb"};
+    VM_PREFIX a{&context, "topa"};
+    Vt_trace_two_b b{&context, "topb"};
 
     // clang-format off
 #ifdef TEST_HDR_TRACE
-    contextp->traceEverOn(true);
+    context.traceEverOn(true);
 # ifdef TEST_FST
-    VerilatedFstC* tfp = new VerilatedFstC;
-    ap->trace(tfp, 99);
-    bp->trace(tfp, 99);
-    tfp->open(VL_STRINGIFY(TEST_OBJ_DIR) "/simx.fst");
+    VerilatedFstC tf;
+    a.trace(&tf, 99);
+    b.trace(&tf, 99);
+    tf.open(VL_STRINGIFY(TEST_OBJ_DIR) "/simx.fst");
 # else
-    VerilatedVcdC* tfp = new VerilatedVcdC;
-    ap->trace(tfp, 99);
-    bp->trace(tfp, 99);
-    tfp->open(VL_STRINGIFY(TEST_OBJ_DIR) "/simx.vcd");
+    VerilatedVcdC tf;
+    a.trace(&tf, 99);
+    b.trace(&tf, 99);
+    tf.open(VL_STRINGIFY(TEST_OBJ_DIR) "/simx.vcd");
 # endif
 #endif
     // clang-format on
 
 #ifdef TEST_HDR_TRACE
-    ap->eval_step();
-    bp->eval_step();
-    ap->eval_end_step();
-    bp->eval_end_step();
-    if (tfp) tfp->dump(contextp->time());
+    a.eval_step();
+    b.eval_step();
+    a.eval_end_step();
+    b.eval_end_step();
+    tf.dump(context.time());
 #endif
 
     {
-        ap->clk = false;
-        contextp->timeInc(10);
+        a.clk = false;
+        context.timeInc(10);
     }
-    while (contextp->time() < sim_time && !contextp->gotFinish()) {
-        ap->clk = !ap->clk;
-        bp->clk = ap->clk;
-        ap->eval_step();
-        bp->eval_step();
-        ap->eval_end_step();
-        bp->eval_end_step();
+    while (context.time() < sim_time && !context.gotFinish()) {
+        a.clk = !a.clk;
+        b.clk = a.clk;
+        a.eval_step();
+        b.eval_step();
+        a.eval_end_step();
+        b.eval_end_step();
 #ifdef TEST_HDR_TRACE
-        if (tfp) tfp->dump(contextp->time());
+        tf.dump(context.time());
 #endif
-        contextp->timeInc(5);
+        context.timeInc(5);
     }
-    if (!contextp->gotFinish()) {
+    if (!context.gotFinish()) {
         vl_fatal(__FILE__, __LINE__, "main", "%Error: Timeout; never got a $finish");
     }
-    ap->final();
-    bp->final();
+    a.final();
+    b.final();
 
 #ifdef TEST_HDR_TRACE
-    if (tfp) tfp->close();
-    VL_DO_DANGLING(delete tfp, tfp);
+    tf.close();
 #endif
 
-    VL_DO_DANGLING(delete ap, ap);
-    VL_DO_DANGLING(delete bp, bp);
     return 0;
 }

--- a/test_regress/t/t_tri_top_en_out.cpp
+++ b/test_regress/t/t_tri_top_en_out.cpp
@@ -15,154 +15,152 @@ int main(int argc, char** argv, char**) {
     int errors;
     // Setup context, defaults, and parse command line
     Verilated::debug(0);
-    const std::unique_ptr<VerilatedContext> contextp{new VerilatedContext};
-    contextp->commandArgs(argc, argv);
+    VerilatedContext context;
+    context.commandArgs(argc, argv);
     // Construct the Verilated model, from Vtop.h generated from Verilating
-    const std::unique_ptr<Vt_tri_top_en_out> topp{new Vt_tri_top_en_out{contextp.get()}};
+    Vt_tri_top_en_out top{&context};
 
     // Initial input
-    topp->drv_en = 0;
-    topp->single_bit_io = rand() & 1;
-    topp->bidir_single_bit_io = rand() & 1;
-    topp->bus_64_io = 0;
-    topp->bidir_bus_64_io = rand() & 0xffffffffffffffff;
-    topp->bus_128_io[0] = 0;
-    topp->bus_128_io[1] = 0;
-    topp->bus_128_io[2] = 0;
-    topp->bus_128_io[3] = 0;
-    topp->bidir_bus_128_io[0] = rand() & 0xffffffff;
-    topp->bidir_bus_128_io[1] = rand() & 0xffffffff;
-    topp->bidir_bus_128_io[2] = rand() & 0xffffffff;
-    topp->bidir_bus_128_io[3] = rand() & 0xffffffff;
-    topp->sub_io = rand() & 1;
-    topp->test_en = 1;
+    top.drv_en = 0;
+    top.single_bit_io = rand() & 1;
+    top.bidir_single_bit_io = rand() & 1;
+    top.bus_64_io = 0;
+    top.bidir_bus_64_io = rand() & 0xffffffffffffffff;
+    top.bus_128_io[0] = 0;
+    top.bus_128_io[1] = 0;
+    top.bus_128_io[2] = 0;
+    top.bus_128_io[3] = 0;
+    top.bidir_bus_128_io[0] = rand() & 0xffffffff;
+    top.bidir_bus_128_io[1] = rand() & 0xffffffff;
+    top.bidir_bus_128_io[2] = rand() & 0xffffffff;
+    top.bidir_bus_128_io[3] = rand() & 0xffffffff;
+    top.sub_io = rand() & 1;
+    top.test_en = 1;
 
     errors = 0;
 
     // Simulate until $finish
-    while (!contextp->gotFinish()) {
+    while (!context.gotFinish()) {
         // Evaluate model
-        topp->eval();
+        top.eval();
 
         // Advance time (to scheduled events)
-        if (!topp->eventsPending()) break;
-        contextp->time(topp->nextTimeSlot());
+        if (!top.eventsPending()) break;
+        context.time(top.nextTimeSlot());
 
         // We want to check that the __en and __out signals can be accessed
-        printf("Info:(cpp): drv_en = %x\n", topp->drv_en);
-        printf("Info:(cpp): bidir_single_bit_io__en = %x\n", topp->bidir_single_bit_io__en);
-        printf("Info:(cpp): bidir_bus_64_io__en = %x\n", (unsigned int)topp->bidir_bus_64_io__en);
-        printf("Info:(cpp): bidir_bus_128_io__en = %x,%x,%x,%x\n", topp->bidir_bus_128_io__en[3],
-               topp->bidir_bus_128_io__en[2], topp->bidir_bus_128_io__en[1],
-               topp->bidir_bus_128_io__en[0]);
-        printf("Info:(cpp): sub_io__en = %x\n", topp->sub_io__en);
-        printf("Info:(cpp): bidir_single_bit_io = %x\n", topp->bidir_single_bit_io__out);
-        printf("Info:(cpp): bidir_bus_64_io = %x\n", (unsigned int)topp->bidir_bus_64_io__out);
-        printf("Info:(cpp): bidir_bus_128_io = %x,%x,%x,%x\n", topp->bidir_bus_128_io__out[3],
-               topp->bidir_bus_128_io__out[2], topp->bidir_bus_128_io__out[1],
-               topp->bidir_bus_128_io__out[0]);
-        printf("Info:(cpp): sub_io = %x\n", topp->sub_io__out);
+        printf("Info:(cpp): drv_en = %x\n", top.drv_en);
+        printf("Info:(cpp): bidir_single_bit_io__en = %x\n", top.bidir_single_bit_io__en);
+        printf("Info:(cpp): bidir_bus_64_io__en = %x\n", (unsigned int)top.bidir_bus_64_io__en);
+        printf("Info:(cpp): bidir_bus_128_io__en = %x,%x,%x,%x\n", top.bidir_bus_128_io__en[3],
+               top.bidir_bus_128_io__en[2], top.bidir_bus_128_io__en[1],
+               top.bidir_bus_128_io__en[0]);
+        printf("Info:(cpp): sub_io__en = %x\n", top.sub_io__en);
+        printf("Info:(cpp): bidir_single_bit_io = %x\n", top.bidir_single_bit_io__out);
+        printf("Info:(cpp): bidir_bus_64_io = %x\n", (unsigned int)top.bidir_bus_64_io__out);
+        printf("Info:(cpp): bidir_bus_128_io = %x,%x,%x,%x\n", top.bidir_bus_128_io__out[3],
+               top.bidir_bus_128_io__out[2], top.bidir_bus_128_io__out[1],
+               top.bidir_bus_128_io__out[0]);
+        printf("Info:(cpp): sub_io = %x\n", top.sub_io__out);
 
         // Loop back if verilog is driving
         // Verilator will not do this for itself
         // We must implement the top-level resolution
-        if (topp->sub_io__en) { topp->sub_io = topp->sub_io__out; }
-        if (topp->bidir_single_bit_io__en) {
-            topp->bidir_single_bit_io = topp->bidir_single_bit_io__out;
+        if (top.sub_io__en) { top.sub_io = top.sub_io__out; }
+        if (top.bidir_single_bit_io__en) {
+            top.bidir_single_bit_io = top.bidir_single_bit_io__out;
         }
         // For bus signals, overwrite the bits which are driven by verilog, preserve the others
-        if (topp->bidir_bus_64_io__en) {
-            topp->bidir_bus_64_io = ((~topp->bidir_bus_64_io__en) & topp->bidir_bus_64_io)
-                                    | (topp->bidir_bus_64_io__en & topp->bidir_bus_64_io__out);
+        if (top.bidir_bus_64_io__en) {
+            top.bidir_bus_64_io = ((~top.bidir_bus_64_io__en) & top.bidir_bus_64_io)
+                                  | (top.bidir_bus_64_io__en & top.bidir_bus_64_io__out);
         }
         for (int i = 0; i < 4; i++) {
-            if (topp->bidir_bus_128_io__en[i]) {
-                topp->bidir_bus_128_io[i]
-                    = ((~topp->bidir_bus_128_io__en[i]) & topp->bidir_bus_128_io[i])
-                      | (topp->bidir_bus_128_io__en[i] & topp->bidir_bus_128_io__out[i]);
+            if (top.bidir_bus_128_io__en[i]) {
+                top.bidir_bus_128_io[i]
+                    = ((~top.bidir_bus_128_io__en[i]) & top.bidir_bus_128_io[i])
+                      | (top.bidir_bus_128_io__en[i] & top.bidir_bus_128_io__out[i]);
             }
         }
 
         // Has the verilog code finished a test loop?
-        if (topp->loop_done == 1) {
+        if (top.loop_done == 1) {
 
             // Check the expected __en output
 
-            if (topp->drv_en & 0x1) {
-                TEST_CHECK_EQ(uint64_t(topp->sub_io__en), 1);
-                TEST_CHECK_EQ(uint64_t(topp->bidir_single_bit_io__en), 1);
+            if (top.drv_en & 0x1) {
+                TEST_CHECK_EQ(uint64_t(top.sub_io__en), 1);
+                TEST_CHECK_EQ(uint64_t(top.bidir_single_bit_io__en), 1);
             } else {
-                TEST_CHECK_EQ(uint64_t(topp->sub_io__en), 0);
-                TEST_CHECK_EQ(uint64_t(topp->bidir_single_bit_io__en), 0);
+                TEST_CHECK_EQ(uint64_t(top.sub_io__en), 0);
+                TEST_CHECK_EQ(uint64_t(top.bidir_single_bit_io__en), 0);
             }
 
             for (int i = 0; i < 4; i++) {
                 // __en enabled?
-                if ((topp->drv_en & (1 << i)) != 0) {
-                    TEST_CHECK_EQ(uint64_t(topp->bidir_bus_64_io__en >> (i * 16) & 0xffff),
-                                  0xffff);
-                    TEST_CHECK_EQ(uint64_t(topp->bidir_bus_128_io__en[i]), 0xffffffff);
+                if ((top.drv_en & (1 << i)) != 0) {
+                    TEST_CHECK_EQ(uint64_t(top.bidir_bus_64_io__en >> (i * 16) & 0xffff), 0xffff);
+                    TEST_CHECK_EQ(uint64_t(top.bidir_bus_128_io__en[i]), 0xffffffff);
                 }
                 // __en not enabled
                 else {
-                    TEST_CHECK_EQ(uint64_t(topp->bidir_bus_64_io__en >> (i * 16) & 0xffff),
-                                  0x0000);
-                    TEST_CHECK_EQ(uint64_t(topp->bidir_bus_128_io__en[i]), 0x00000000);
+                    TEST_CHECK_EQ(uint64_t(top.bidir_bus_64_io__en >> (i * 16) & 0xffff), 0x0000);
+                    TEST_CHECK_EQ(uint64_t(top.bidir_bus_128_io__en[i]), 0x00000000);
                 }
             }  // for
-            if (topp->drv_en == 15) {
-                topp->test_en = 0;
+            if (top.drv_en == 15) {
+                top.test_en = 0;
             } else {
-                topp->drv_en++;
+                top.drv_en++;
 
                 // Drive the bits verilog shouldn't be driving
-                if (topp->drv_en & 1) {
-                    topp->single_bit_io = rand() & 1;
-                    topp->bidir_single_bit_io = rand() & 1;
-                    topp->sub_io = rand() & 1;
-                    topp->bidir_bus_64_io
-                        = ((rand() & 0xffff) << 0) | (topp->bidir_bus_64_io & 0xffffffffffff0000);
-                    topp->bidir_bus_128_io[0] = rand() & 0xffffffff;
+                if (top.drv_en & 1) {
+                    top.single_bit_io = rand() & 1;
+                    top.bidir_single_bit_io = rand() & 1;
+                    top.sub_io = rand() & 1;
+                    top.bidir_bus_64_io
+                        = ((rand() & 0xffff) << 0) | (top.bidir_bus_64_io & 0xffffffffffff0000);
+                    top.bidir_bus_128_io[0] = rand() & 0xffffffff;
                 } else {
-                    topp->single_bit_io = 0;
-                    topp->bidir_single_bit_io = 0;
-                    topp->sub_io = 0;
-                    topp->bidir_bus_64_io = (topp->bidir_bus_64_io & 0xffffffffffff0000);
-                    topp->bidir_bus_128_io[0] = 0;
+                    top.single_bit_io = 0;
+                    top.bidir_single_bit_io = 0;
+                    top.sub_io = 0;
+                    top.bidir_bus_64_io = (top.bidir_bus_64_io & 0xffffffffffff0000);
+                    top.bidir_bus_128_io[0] = 0;
                 }
-                if (topp->drv_en & 2) {
-                    topp->bidir_bus_64_io
-                        = ((rand() & 0xffff) << 16) | (topp->bidir_bus_64_io & 0xffffffff0000ffff);
-                    topp->bidir_bus_128_io[1] = rand() & 0xffffffff;
+                if (top.drv_en & 2) {
+                    top.bidir_bus_64_io
+                        = ((rand() & 0xffff) << 16) | (top.bidir_bus_64_io & 0xffffffff0000ffff);
+                    top.bidir_bus_128_io[1] = rand() & 0xffffffff;
                 } else {
-                    topp->bidir_bus_64_io = (topp->bidir_bus_64_io & 0xffffffff0000ffff);
-                    topp->bidir_bus_128_io[1] = 0;
+                    top.bidir_bus_64_io = (top.bidir_bus_64_io & 0xffffffff0000ffff);
+                    top.bidir_bus_128_io[1] = 0;
                 }
-                if (topp->drv_en & 4) {
-                    topp->bidir_bus_64_io = (((uint64_t)(rand() & 0xffff)) << 32)
-                                            | (topp->bidir_bus_64_io & 0xffff0000ffffffff);
-                    topp->bidir_bus_128_io[2] = rand() & 0xffffffff;
+                if (top.drv_en & 4) {
+                    top.bidir_bus_64_io = (((uint64_t)(rand() & 0xffff)) << 32)
+                                          | (top.bidir_bus_64_io & 0xffff0000ffffffff);
+                    top.bidir_bus_128_io[2] = rand() & 0xffffffff;
                 } else {
-                    topp->bidir_bus_64_io = (topp->bidir_bus_64_io & 0xffff0000ffffffff);
-                    topp->bidir_bus_128_io[2] = 0;
+                    top.bidir_bus_64_io = (top.bidir_bus_64_io & 0xffff0000ffffffff);
+                    top.bidir_bus_128_io[2] = 0;
                 }
-                if (topp->drv_en & 8) {
-                    topp->bidir_bus_64_io = (((uint64_t)(rand() & 0xffff)) << 48)
-                                            | (topp->bidir_bus_64_io & 0x0000ffffffffffff);
-                    topp->bidir_bus_128_io[3] = rand() & 0xffffffff;
+                if (top.drv_en & 8) {
+                    top.bidir_bus_64_io = (((uint64_t)(rand() & 0xffff)) << 48)
+                                          | (top.bidir_bus_64_io & 0x0000ffffffffffff);
+                    top.bidir_bus_128_io[3] = rand() & 0xffffffff;
                 } else {
-                    topp->bidir_bus_64_io = (topp->bidir_bus_64_io & 0x0000ffffffffffff);
-                    topp->bidir_bus_128_io[3] = 0;
+                    top.bidir_bus_64_io = (top.bidir_bus_64_io & 0x0000ffffffffffff);
+                    top.bidir_bus_128_io[3] = 0;
                 }
             }
             // Invert the input side
-            topp->bidir_single_bit_io = (~topp->bidir_single_bit_io) & 0x1;
-            topp->bidir_bus_64_io = ~topp->bidir_bus_64_io;
-            for (int i = 0; i < 4; i++) { topp->bidir_bus_128_io[i] = ~topp->bidir_bus_128_io[i]; }
+            top.bidir_single_bit_io = (~top.bidir_single_bit_io) & 0x1;
+            top.bidir_bus_64_io = ~top.bidir_bus_64_io;
+            for (int i = 0; i < 4; i++) { top.bidir_bus_128_io[i] = ~top.bidir_bus_128_io[i]; }
         }  // if (loop_done)
         if (errors != 0) break;
     }
     // Final model cleanup
-    topp->final();
+    top.final();
     return 0;
 }

--- a/test_regress/t/t_vpi_const_type.cpp
+++ b/test_regress/t/t_vpi_const_type.cpp
@@ -146,57 +146,52 @@ void (*vlog_startup_routines[])() = {vpi_compat_bootstrap, 0};
 #else
 
 int main(int argc, char** argv) {
-    const std::unique_ptr<VerilatedContext> contextp{new VerilatedContext};
+    VerilatedContext context;
 
     uint64_t sim_time = 1100;
-    contextp->debug(0);
-    contextp->commandArgs(argc, argv);
+    context.debug(0);
+    context.commandArgs(argc, argv);
     // We're going to be checking for these errors so don't crash out
-    contextp->fatalOnVpiError(0);
+    context.fatalOnVpiError(0);
 
     {
         // Construct and destroy
-        const std::unique_ptr<VM_PREFIX> topp{
-            new VM_PREFIX{contextp.get(),
-                          // Note null name - we're flattening it out
-                          ""}};
+        VM_PREFIX top{&context, ""};  // Note null name - we're flattening it out
     }
 
     // Test second construction
-    const std::unique_ptr<VM_PREFIX> topp{new VM_PREFIX{contextp.get(),
-                                                        // Note null name - we're flattening it out
-                                                        ""}};
+    VM_PREFIX top{&context, ""};  // Note null name - we're flattening it out
 
 #ifdef VERILATOR
 #ifdef TEST_VERBOSE
-    contextp->scopesDump();
+    context.scopesDump();
 #endif
 #endif
 
 #if VM_TRACE
-    contextp->traceEverOn(true);
+    context.traceEverOn(true);
     VL_PRINTF("Enabling waves...\n");
     VerilatedVcdC* tfp = new VerilatedVcdC;
-    topp->trace(tfp, 99);
+    top.trace(tfp, 99);
     tfp->open(STRINGIFY(TEST_OBJ_DIR) "/simx.vcd");
 #endif
 
-    topp->eval();
-    contextp->timeInc(10);
+    top.eval();
+    context.timeInc(10);
 
-    while (contextp->time() < sim_time && !contextp->gotFinish()) {
-        contextp->timeInc(1);
-        topp->eval();
+    while (context.time() < sim_time && !context.gotFinish()) {
+        context.timeInc(1);
+        top.eval();
         VerilatedVpi::callValueCbs();
         // mon_do();
 #if VM_TRACE
-        if (tfp) tfp->dump(contextp->time());
+        if (tfp) tfp->dump(context.time());
 #endif
     }
-    if (!contextp->gotFinish()) {
+    if (!context.gotFinish()) {
         vl_fatal(FILENM, __LINE__, "main", "%Error: Timeout; never got a $finish");
     }
-    topp->final();
+    top.final();
 
 #if VM_TRACE
     if (tfp) tfp->close();

--- a/test_regress/t/t_vpi_escape.cpp
+++ b/test_regress/t/t_vpi_escape.cpp
@@ -349,48 +349,46 @@ void (*vlog_startup_routines[])() = {vpi_compat_bootstrap, 0};
 
 double sc_time_stamp() { return main_time; }
 int main(int argc, char** argv) {
-    const std::unique_ptr<VerilatedContext> contextp{new VerilatedContext};
+    VerilatedContext context;
 
     uint64_t sim_time = 1100;
-    contextp->debug(0);
-    contextp->commandArgs(argc, argv);
+    context.debug(0);
+    context.commandArgs(argc, argv);
 
-    const std::unique_ptr<VM_PREFIX> topp{new VM_PREFIX{contextp.get(),
-                                                        // Note null name - we're flattening it out
-                                                        ""}};
+    VM_PREFIX top{&context, ""};  // Note null name - we're flattening it out
 
 #ifdef VERILATOR
 #ifdef TEST_VERBOSE
-    contextp->scopesDump();
+    context.scopesDump();
 #endif
 #endif
 
 #if VM_TRACE
-    contextp->traceEverOn(true);
+    context.traceEverOn(true);
     VL_PRINTF("Enabling waves...\n");
     VerilatedVcdC* tfp = new VerilatedVcdC;
-    topp->trace(tfp, 99);
+    top.trace(tfp, 99);
     tfp->open(STRINGIFY(TEST_OBJ_DIR) "/simx.vcd");
 #endif
 
-    topp->eval();
-    topp->clk = 0;
+    top.eval();
+    top.clk = 0;
     main_time += 10;
 
-    while (vl_time_stamp64() < sim_time && !contextp->gotFinish()) {
+    while (vl_time_stamp64() < sim_time && !context.gotFinish()) {
         main_time += 1;
-        topp->eval();
+        top.eval();
         VerilatedVpi::callValueCbs();
-        topp->clk = !topp->clk;
+        top.clk = !top.clk;
         // mon_do();
 #if VM_TRACE
         if (tfp) tfp->dump(main_time);
 #endif
     }
-    if (!contextp->gotFinish()) {
+    if (!context.gotFinish()) {
         vl_fatal(__FILE__, __LINE__, "main", "%Error: Timeout; never got a $finish");
     }
-    topp->final();
+    top.final();
 
 #if VM_TRACE
     if (tfp) tfp->close();

--- a/test_regress/t/t_vpi_get.cpp
+++ b/test_regress/t/t_vpi_get.cpp
@@ -240,48 +240,46 @@ void (*vlog_startup_routines[])() = {vpi_compat_bootstrap, 0};
 
 #else
 int main(int argc, char** argv) {
-    const std::unique_ptr<VerilatedContext> contextp{new VerilatedContext};
+    VerilatedContext context;
 
     uint64_t sim_time = 1100;
-    contextp->debug(0);
-    contextp->commandArgs(argc, argv);
+    context.debug(0);
+    context.commandArgs(argc, argv);
 
-    const std::unique_ptr<VM_PREFIX> topp{new VM_PREFIX{contextp.get(),
-                                                        // Note null name - we're flattening it out
-                                                        ""}};
+    VM_PREFIX top{&context, ""};  // Note null name - we're flattening it out
 
 #ifdef VERILATOR
 #ifdef TEST_VERBOSE
-    contextp->scopesDump();
+    context.scopesDump();
 #endif
 #endif
 
 #if VM_TRACE
-    contextp->traceEverOn(true);
+    context.traceEverOn(true);
     VL_PRINTF("Enabling waves...\n");
     VerilatedVcdC* tfp = new VerilatedVcdC;
-    topp->trace(tfp, 99);
+    top.trace(tfp, 99);
     tfp->open(VL_STRINGIFY(TEST_OBJ_DIR) "/simx.vcd");
 #endif
 
-    topp->eval();
-    topp->clk = 0;
-    contextp->timeInc(10);
+    top.eval();
+    top.clk = 0;
+    context.timeInc(10);
 
-    while (contextp->time() < sim_time && !contextp->gotFinish()) {
-        contextp->timeInc(1);
-        topp->eval();
+    while (context.time() < sim_time && !context.gotFinish()) {
+        context.timeInc(1);
+        top.eval();
         VerilatedVpi::callValueCbs();
-        topp->clk = !topp->clk;
+        top.clk = !top.clk;
         // mon_do();
 #if VM_TRACE
-        if (tfp) tfp->dump(contextp->time());
+        if (tfp) tfp->dump(context.time());
 #endif
     }
-    if (!contextp->gotFinish()) {
+    if (!context.gotFinish()) {
         vl_fatal(FILENM, __LINE__, "main", "%Error: Timeout; never got a $finish");
     }
-    topp->final();
+    top.final();
 
 #if VM_TRACE
     if (tfp) tfp->close();

--- a/test_regress/t/t_vpi_memory.cpp
+++ b/test_regress/t/t_vpi_memory.cpp
@@ -253,50 +253,48 @@ void (*vlog_startup_routines[])() = {vpi_compat_bootstrap, 0};
 #else
 
 int main(int argc, char** argv) {
-    const std::unique_ptr<VerilatedContext> contextp{new VerilatedContext};
+    VerilatedContext context;
 
     uint64_t sim_time = 1100;
-    contextp->debug(0);
-    contextp->commandArgs(argc, argv);
+    context.debug(0);
+    context.commandArgs(argc, argv);
     // We're going to be checking for these errors so don't crash out
-    contextp->fatalOnVpiError(0);
+    context.fatalOnVpiError(0);
 
-    const std::unique_ptr<VM_PREFIX> topp{new VM_PREFIX{contextp.get(),
-                                                        // Note null name - we're flattening it out
-                                                        ""}};
+    VM_PREFIX top{&context, ""};  // Note null name - we're flattening it out
 
 #ifdef VERILATOR
 #ifdef TEST_VERBOSE
-    contextp->scopesDump();
+    context.scopesDump();
 #endif
 #endif
 
 #if VM_TRACE
-    contextp->traceEverOn(true);
+    context.traceEverOn(true);
     VL_PRINTF("Enabling waves...\n");
     VerilatedVcdC* tfp = new VerilatedVcdC;
-    topp->trace(tfp, 99);
+    top.trace(tfp, 99);
     tfp->open(VL_STRINGIFY(TEST_OBJ_DIR) "/simx.vcd");
 #endif
 
-    topp->eval();
-    topp->clk = 0;
-    contextp->timeInc(10);
+    top.eval();
+    top.clk = 0;
+    context.timeInc(10);
 
-    while (contextp->time() < sim_time && !contextp->gotFinish()) {
-        contextp->timeInc(1);
-        topp->eval();
+    while (context.time() < sim_time && !context.gotFinish()) {
+        context.timeInc(1);
+        top.eval();
         VerilatedVpi::callValueCbs();
-        topp->clk = !topp->clk;
+        top.clk = !top.clk;
         // mon_do();
 #if VM_TRACE
-        if (tfp) tfp->dump(contextp->time());
+        if (tfp) tfp->dump(context.time());
 #endif
     }
-    if (!contextp->gotFinish()) {
+    if (!context.gotFinish()) {
         vl_fatal(FILENM, __LINE__, "main", "%Error: Timeout; never got a $finish");
     }
-    topp->final();
+    top.final();
 
 #if VM_TRACE
     if (tfp) tfp->close();

--- a/test_regress/t/t_vpi_module.cpp
+++ b/test_regress/t/t_vpi_module.cpp
@@ -172,59 +172,54 @@ void (*vlog_startup_routines[])() = {vpi_compat_bootstrap, 0};
 #else
 
 int main(int argc, char** argv) {
-    const std::unique_ptr<VerilatedContext> contextp{new VerilatedContext};
+    VerilatedContext context;
 
     uint64_t sim_time = 1100;
-    contextp->debug(0);
-    contextp->commandArgs(argc, argv);
+    context.debug(0);
+    context.commandArgs(argc, argv);
     // We're going to be checking for these errors so don't crash out
-    contextp->fatalOnVpiError(0);
+    context.fatalOnVpiError(0);
 
     {
         // Construct and destroy
-        const std::unique_ptr<VM_PREFIX> topp{
-            new VM_PREFIX{contextp.get(),
-                          // Note null name - we're flattening it out
-                          ""}};
+        VM_PREFIX top{&context, ""};  // Note null name - we're flattening it out
     }
 
     // Test second construction
-    const std::unique_ptr<VM_PREFIX> topp{new VM_PREFIX{contextp.get(),
-                                                        // Note null name - we're flattening it out
-                                                        ""}};
+    VM_PREFIX top{&context, ""};  // Note null name - we're flattening it out
 
 #ifdef VERILATOR
 #ifdef TEST_VERBOSE
-    contextp->scopesDump();
+    context.scopesDump();
 #endif
 #endif
 
 #if VM_TRACE
-    contextp->traceEverOn(true);
+    context.traceEverOn(true);
     VL_PRINTF("Enabling waves...\n");
     VerilatedVcdC* tfp = new VerilatedVcdC;
-    topp->trace(tfp, 99);
+    top.trace(tfp, 99);
     tfp->open(STRINGIFY(TEST_OBJ_DIR) "/simx.vcd");
 #endif
 
-    topp->eval();
-    topp->clk = 0;
-    contextp->timeInc(10);
+    top.eval();
+    top.clk = 0;
+    context.timeInc(10);
 
-    while (contextp->time() < sim_time && !contextp->gotFinish()) {
-        contextp->timeInc(1);
-        topp->eval();
+    while (context.time() < sim_time && !context.gotFinish()) {
+        context.timeInc(1);
+        top.eval();
         VerilatedVpi::callValueCbs();
-        topp->clk = !topp->clk;
+        top.clk = !top.clk;
         // mon_do();
 #if VM_TRACE
-        if (tfp) tfp->dump(contextp->time());
+        if (tfp) tfp->dump(context.time());
 #endif
     }
-    if (!contextp->gotFinish()) {
+    if (!context.gotFinish()) {
         vl_fatal(FILENM, __LINE__, "main", "%Error: Timeout; never got a $finish");
     }
-    topp->final();
+    top.final();
 
 #if VM_TRACE
     if (tfp) tfp->close();

--- a/test_regress/t/t_vpi_module_empty.cpp
+++ b/test_regress/t/t_vpi_module_empty.cpp
@@ -90,33 +90,31 @@ void (*vlog_startup_routines[])() = {vpi_compat_bootstrap, 0};
 #else
 
 int main(int argc, char** argv) {
-    const std::unique_ptr<VerilatedContext> contextp{new VerilatedContext};
+    VerilatedContext context;
 
     uint64_t sim_time = 1100;
-    contextp->debug(0);
-    contextp->commandArgs(argc, argv);
+    context.debug(0);
+    context.commandArgs(argc, argv);
     // we're going to be checking for these errors do don't crash out
-    contextp->fatalOnVpiError(0);
+    context.fatalOnVpiError(0);
 
     // Test second construction
-    const std::unique_ptr<VM_PREFIX> topp{new VM_PREFIX{contextp.get(),
-                                                        // Note null name - we're flattening it out
-                                                        ""}};
+    VM_PREFIX top{&context, ""};  // Note null name - we're flattening it out
 
 #ifdef VERILATOR
 #ifdef TEST_VERBOSE
-    contextp->scopesDump();
+    context.scopesDump();
 #endif
 #endif
 
-    topp->eval();
+    top.eval();
     VerilatedVpi::callValueCbs();
     TestVpiHandle vh = vpi_handle_by_name((PLI_BYTE8*)"top.sv_if_i.a", NULL);
     CHECK_RESULT_NZ(vh);
     TestVpiHandle it = vpi_iterate(vpiModule, NULL);
     CHECK_RESULT_NZ(it);
 
-    topp->final();
+    top.final();
     return 0;
 }
 

--- a/test_regress/t/t_vpi_package.cpp
+++ b/test_regress/t/t_vpi_package.cpp
@@ -193,57 +193,52 @@ void (*vlog_startup_routines[])() = {vpi_compat_bootstrap, 0};
 #else
 
 int main(int argc, char** argv) {
-    const std::unique_ptr<VerilatedContext> contextp{new VerilatedContext};
+    VerilatedContext context;
 
     uint64_t sim_time = 1100;
-    contextp->debug(0);
-    contextp->commandArgs(argc, argv);
+    context.debug(0);
+    context.commandArgs(argc, argv);
     // We're going to be checking for these errors so don't crash out
-    contextp->fatalOnVpiError(0);
+    context.fatalOnVpiError(0);
 
     {
         // Construct and destroy
-        const std::unique_ptr<VM_PREFIX> topp{
-            new VM_PREFIX{contextp.get(),
-                          // Note null name - we're flattening it out
-                          ""}};
+        VM_PREFIX top{&context, ""};  // Note null name - we're flattening it out
     }
 
     // Test second construction
-    const std::unique_ptr<VM_PREFIX> topp{new VM_PREFIX{contextp.get(),
-                                                        // Note null name - we're flattening it out
-                                                        ""}};
+    VM_PREFIX top{&context, ""};  // Note null name - we're flattening it out
 
 #ifdef VERILATOR
 #ifdef TEST_VERBOSE
-    contextp->scopesDump();
+    context.scopesDump();
 #endif
 #endif
 
 #if VM_TRACE
-    contextp->traceEverOn(true);
+    context.traceEverOn(true);
     VL_PRINTF("Enabling waves...\n");
     VerilatedVcdC* tfp = new VerilatedVcdC;
-    topp->trace(tfp, 99);
+    top.trace(tfp, 99);
     tfp->open(STRINGIFY(TEST_OBJ_DIR) "/simx.vcd");
 #endif
 
-    topp->eval();
-    contextp->timeInc(10);
+    top.eval();
+    context.timeInc(10);
 
-    while (contextp->time() < sim_time && !contextp->gotFinish()) {
-        contextp->timeInc(1);
-        topp->eval();
+    while (context.time() < sim_time && !context.gotFinish()) {
+        context.timeInc(1);
+        top.eval();
         VerilatedVpi::callValueCbs();
         // mon_do();
 #if VM_TRACE
-        if (tfp) tfp->dump(contextp->time());
+        if (tfp) tfp->dump(context.time());
 #endif
     }
-    if (!contextp->gotFinish()) {
+    if (!context.gotFinish()) {
         vl_fatal(FILENM, __LINE__, "main", "%Error: Timeout; never got a $finish");
     }
-    topp->final();
+    top.final();
 
 #if VM_TRACE
     if (tfp) tfp->close();

--- a/test_regress/t/t_vpi_param.cpp
+++ b/test_regress/t/t_vpi_param.cpp
@@ -247,50 +247,47 @@ void (*vlog_startup_routines[])() = {vpi_compat_bootstrap, 0};
 #else
 
 int main(int argc, char** argv) {
-    const std::unique_ptr<VerilatedContext> contextp{new VerilatedContext};
+    VerilatedContext context;
 
     uint64_t sim_time = 1100;
-    contextp->debug(0);
-    contextp->commandArgs(argc, argv);
+    context.debug(0);
+    context.commandArgs(argc, argv);
     // We're going to be checking for these errors so don't crash out
-    contextp->fatalOnVpiError(0);
-
-    const std::unique_ptr<VM_PREFIX> topp{new VM_PREFIX{contextp.get(),
-                                                        // Note null name - we're flattening it out
-                                                        ""}};
+    context.fatalOnVpiError(0);
+    VM_PREFIX top{&context, ""};  // Note null name - we're flattening it out
 
 #ifdef VERILATOR
 #ifdef TEST_VERBOSE
-    contextp->scopesDump();
+    context.scopesDump();
 #endif
 #endif
 
 #if VM_TRACE
-    contextp->traceEverOn(true);
+    context.traceEverOn(true);
     VL_PRINTF("Enabling waves...\n");
     VerilatedVcdC* tfp = new VerilatedVcdC;
-    topp->trace(tfp, 99);
+    top.trace(tfp, 99);
     tfp->open(VL_STRINGIFY(TEST_OBJ_DIR) "/simx.vcd");
 #endif
 
-    topp->eval();
-    topp->clk = 0;
-    contextp->timeInc(10);
+    top.eval();
+    top.clk = 0;
+    context.timeInc(10);
 
-    while (contextp->time() < sim_time && !contextp->gotFinish()) {
-        contextp->timeInc(1);
-        topp->eval();
+    while (context.time() < sim_time && !context.gotFinish()) {
+        context.timeInc(1);
+        top.eval();
         VerilatedVpi::callValueCbs();
-        topp->clk = !topp->clk;
+        top.clk = !top.clk;
         // mon_do();
 #if VM_TRACE
-        if (tfp) tfp->dump(contextp->time());
+        if (tfp) tfp->dump(context.time());
 #endif
     }
-    if (!contextp->gotFinish()) {
+    if (!context.gotFinish()) {
         vl_fatal(FILENM, __LINE__, "main", "%Error: Timeout; never got a $finish");
     }
-    topp->final();
+    top.final();
 
 #if VM_TRACE
     if (tfp) tfp->close();

--- a/test_regress/t/t_vpi_public_depth.cpp
+++ b/test_regress/t/t_vpi_public_depth.cpp
@@ -183,59 +183,54 @@ void (*vlog_startup_routines[])() = {vpi_compat_bootstrap, 0};
 #else
 
 int main(int argc, char** argv) {
-    const std::unique_ptr<VerilatedContext> contextp{new VerilatedContext};
+    VerilatedContext context;
 
     uint64_t sim_time = 1100;
-    contextp->debug(0);
-    contextp->commandArgs(argc, argv);
+    context.debug(0);
+    context.commandArgs(argc, argv);
     // We're going to be checking for these errors so don't crash out
-    contextp->fatalOnVpiError(0);
+    context.fatalOnVpiError(0);
 
     {
         // Construct and destroy
-        const std::unique_ptr<VM_PREFIX> topp{
-            new VM_PREFIX{contextp.get(),
-                          // Note null name - we're flattening it out
-                          ""}};
+        VM_PREFIX top{&context, ""};  // Note null name - we're flattening it out
     }
 
     // Test second construction
-    const std::unique_ptr<VM_PREFIX> topp{new VM_PREFIX{contextp.get(),
-                                                        // Note null name - we're flattening it out
-                                                        ""}};
+    VM_PREFIX top{&context, ""};  // Note null name - we're flattening it out
 
 #ifdef VERILATOR
 #ifdef TEST_VERBOSE
-    contextp->scopesDump();
+    context.scopesDump();
 #endif
 #endif
 
 #if VM_TRACE
-    contextp->traceEverOn(true);
+    context.traceEverOn(true);
     VL_PRINTF("Enabling waves...\n");
     VerilatedVcdC* tfp = new VerilatedVcdC;
-    topp->trace(tfp, 99);
+    top.trace(tfp, 99);
     tfp->open(STRINGIFY(TEST_OBJ_DIR) "/simx.vcd");
 #endif
 
-    topp->eval();
-    topp->clk = 0;
-    contextp->timeInc(10);
+    top.eval();
+    top.clk = 0;
+    context.timeInc(10);
 
-    while (contextp->time() < sim_time && !contextp->gotFinish()) {
-        contextp->timeInc(1);
-        topp->eval();
+    while (context.time() < sim_time && !context.gotFinish()) {
+        context.timeInc(1);
+        top.eval();
         VerilatedVpi::callValueCbs();
-        topp->clk = !topp->clk;
+        top.clk = !top.clk;
         // mon_do();
 #if VM_TRACE
-        if (tfp) tfp->dump(contextp->time());
+        if (tfp) tfp->dump(context.time());
 #endif
     }
-    if (!contextp->gotFinish()) {
+    if (!context.gotFinish()) {
         vl_fatal(FILENM, __LINE__, "main", "%Error: Timeout; never got a $finish");
     }
-    topp->final();
+    top.final();
 
 #if VM_TRACE
     if (tfp) tfp->close();

--- a/test_regress/t/t_vpi_unimpl.cpp
+++ b/test_regress/t/t_vpi_unimpl.cpp
@@ -163,54 +163,52 @@ extern "C" int mon_check() {
 //======================================================================
 
 int main(int argc, char** argv) {
-    const std::unique_ptr<VerilatedContext> contextp{new VerilatedContext};
+    VerilatedContext context;
 
     uint64_t sim_time = 1100;
-    contextp->commandArgs(argc, argv);
-    // contextp->debug(9);
+    context.commandArgs(argc, argv);
+    // context.debug(9);
     // We're going to be checking for these errors so don't crash out
-    contextp->fatalOnVpiError(0);
+    context.fatalOnVpiError(0);
 
-    const std::unique_ptr<VM_PREFIX> topp{new VM_PREFIX{contextp.get(),
-                                                        // Note null name - we're flattening it out
-                                                        ""}};
+    VM_PREFIX top{&context, ""};  // Note null name - we're flattening it out
 
 #ifdef VERILATOR
 #ifdef TEST_VERBOSE
-    contextp->scopesDump();
+    context.scopesDump();
 #endif
 #endif
 
 #if VM_TRACE
-    contextp->traceEverOn(true);
+    context.traceEverOn(true);
     VL_PRINTF("Enabling waves...\n");
-    VerilatedVcdC* tfp = new VerilatedVcdC;
-    topp->trace(tfp, 99);
-    tfp->open(VL_STRINGIFY(TEST_OBJ_DIR) "/simx.vcd");
+    VerilatedVcdC tf;
+    top.trace(&tf, 99);
+    tf.open(VL_STRINGIFY(TEST_OBJ_DIR) "/simx.vcd");
 #endif
 
-    topp->eval();
-    topp->clk = 0;
-    contextp->timeInc(10);
+    top.eval();
+    top.clk = 0;
+    context.timeInc(10);
 
-    while (contextp->time() < sim_time && !contextp->gotFinish()) {
-        contextp->timeInc(1);
-        topp->eval();
+    while (context.time() < sim_time && !context.gotFinish()) {
+        context.timeInc(1);
+        top.eval();
         // VerilatedVpi::callValueCbs();   // Make sure can link without verilated_vpi.h included
-        topp->clk = !topp->clk;
+        top.clk = !top.clk;
         // mon_do();
 #if VM_TRACE
-        if (tfp) tfp->dump(contextp->time());
+        tf.dump(context.time());
 #endif
     }
     if (!callback_count) vl_fatal(FILENM, __LINE__, "main", "%Error: never got callbacks");
-    if (!contextp->gotFinish()) {
+    if (!context.gotFinish()) {
         vl_fatal(FILENM, __LINE__, "main", "%Error: Timeout; never got a $finish");
     }
-    topp->final();
+    top.final();
 
 #if VM_TRACE
-    if (tfp) tfp->close();
+    tf.close();
 #endif
 
     return 0;

--- a/test_regress/t/t_wrapper_context.cpp
+++ b/test_regress/t/t_wrapper_context.cpp
@@ -90,37 +90,37 @@ void sim(VM_PREFIX* topp) {
 
 int main(int argc, char** argv) {
     // Create contexts
-    std::unique_ptr<VerilatedContext> context0p{new VerilatedContext};
-    std::unique_ptr<VerilatedContext> context1p{new VerilatedContext};
+    VerilatedContext context0;
+    VerilatedContext context1;
 
     // configuration
-    context0p->threads(1);
-    context1p->threads(1);
-    context0p->fatalOnError(false);
-    context1p->fatalOnError(false);
-    context0p->traceEverOn(true);
-    context1p->traceEverOn(true);
+    context0.threads(1);
+    context1.threads(1);
+    context0.fatalOnError(false);
+    context1.fatalOnError(false);
+    context0.traceEverOn(true);
+    context1.traceEverOn(true);
 
     // error number checks
-    TEST_CHECK_EQ(context0p->errorCount(), 0);
-    TEST_CHECK_EQ(context1p->errorCount(), 0);
-    context0p->errorCount(1);
-    TEST_CHECK_EQ(context0p->errorCount(), 1);
-    context0p->errorCount(0);
-    TEST_CHECK_EQ(context0p->errorCount(), 0);
+    TEST_CHECK_EQ(context0.errorCount(), 0);
+    TEST_CHECK_EQ(context1.errorCount(), 0);
+    context0.errorCount(1);
+    TEST_CHECK_EQ(context0.errorCount(), 1);
+    context0.errorCount(0);
+    TEST_CHECK_EQ(context0.errorCount(), 0);
 
     // instantiate verilated design
-    std::unique_ptr<VM_PREFIX> top0p{new VM_PREFIX{context0p.get(), "top0"}};
-    std::unique_ptr<VM_PREFIX> top1p{new VM_PREFIX{context1p.get(), "top1"}};
+    VM_PREFIX top0{&context0, "top0"};
+    VM_PREFIX top1{&context1, "top1"};
 
-    top0p->trace_number = 0;
-    top0p->trace_number = 1;
+    top0.trace_number = 0;
+    top0.trace_number = 1;
 
     std::cout << "Below '%Error: ... Verilog $stop' is expected as part of the test\n";
 
     // create threads
-    std::thread t0(sim, top0p.get());
-    std::thread t1(sim, top1p.get());
+    std::thread t0(sim, &top0);
+    std::thread t1(sim, &top1);
 
     // wait to finish
     t0.join();
@@ -131,7 +131,7 @@ int main(int argc, char** argv) {
     if (errors) {
         std::cout << "Error: comparison errors" << std::endl;
         pass = false;
-    } else if (top0p->done_o && top1p->done_o) {
+    } else if (top0.done_o && top1.done_o) {
         std::cout << "*-* All Finished *-*" << std::endl;
     } else {
         std::cout << "Error: Early termination!" << std::endl;
@@ -139,8 +139,8 @@ int main(int argc, char** argv) {
     }
 
     // final model cleanup
-    top0p->final();
-    top1p->final();
+    top0.final();
+    top1.final();
 
     // exit successful
     return pass ? 0 : 10;

--- a/test_regress/t/t_wrapper_del_context_bad.cpp
+++ b/test_regress/t/t_wrapper_del_context_bad.cpp
@@ -11,14 +11,14 @@
 
 int main(int argc, char** argv) {
     // Create contexts
-    VerilatedContext* contextp{new VerilatedContext};
+    VerilatedContext context;
 
     // Ideally we'd do this, but then address sanitizer blows up
     // delete contextp;  // Test mistake - deleting contextp
-    contextp->selfTestClearMagic();
+    context.selfTestClearMagic();
 
     // instantiate verilated design
-    std::unique_ptr<VM_PREFIX> topp{new VM_PREFIX{contextp, "TOP"}};
+    VM_PREFIX top{&context, "TOP"};
 
     return 0;
 }

--- a/test_regress/t/t_wrapper_reuse_context_bad.cpp
+++ b/test_regress/t/t_wrapper_reuse_context_bad.cpp
@@ -11,13 +11,13 @@
 
 int main(int argc, char** argv) {
     // Create contexts
-    VerilatedContext* contextp{new VerilatedContext};
+    VerilatedContext context;
 
     for (int i = 0; i < 2; ++i) {
-        std::unique_ptr<VM_PREFIX> topp{new VM_PREFIX{contextp, "TOP"}};
-        topp->eval();
-        contextp->timeInc(1);
-        topp->eval();
+        VM_PREFIX top{&context, "TOP"};
+        top.eval();
+        context.timeInc(1);
+        top.eval();
     }
 
     return 0;


### PR DESCRIPTION
Removed unique_ptrs in tests. This is a minor change, but brings tests time to a few minutes lower (which isn't much over about 20 minutes, but it is still something). Test behaviour is unchanged, I just use the stack instead of the heap, except for a couple of tests in which this effectively broke their behaviour.

A difference in timings can be observed by those runs (hopefully they are accessible):
Old: https://github.com/ThePseudo/verilator/actions/runs/11084147074/job/30799251142
New: https://github.com/ThePseudo/verilator/actions/runs/11093679267/job/30820380106