### PR TITLE
Remove explicit CMAKE_INSTALL_PREFIX usages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,8 @@ option(
 
 find_package(Python3 COMPONENTS Interpreter)
 set(PYTHON3 ${Python3_EXECUTABLE})
-set(CMAKE_INSTALL_DATADIR ${CMAKE_INSTALL_PREFIX})
+# See also CMake built-in; CMAKE_INSTALL_PREFIX is applied by the install command.
+set(CMAKE_INSTALL_DATADIR .)
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
 include(CheckStructHasMember)
@@ -115,33 +116,33 @@ configure_file(include/verilated.mk.in include/verilated.mk @ONLY)
 
 install(
     FILES ${CMAKE_CURRENT_BINARY_DIR}/include/verilated_config.h
-    DESTINATION ${CMAKE_INSTALL_PREFIX}/include
+    DESTINATION include
 )
 install(
     FILES ${CMAKE_CURRENT_BINARY_DIR}/include/verilated.mk
-    DESTINATION ${CMAKE_INSTALL_PREFIX}/include
+    DESTINATION include
 )
 
 configure_package_config_file(
     verilator-config.cmake.in
     verilator-config.cmake
-    INSTALL_DESTINATION ${CMAKE_INSTALL_PREFIX}
+    INSTALL_DESTINATION .
 )
 
 install(
     FILES ${CMAKE_CURRENT_BINARY_DIR}/verilator-config.cmake
-    DESTINATION ${CMAKE_INSTALL_PREFIX}
+    DESTINATION .
 )
 
 configure_package_config_file(
     verilator-config-version.cmake.in
     verilator-config-version.cmake
-    INSTALL_DESTINATION ${CMAKE_INSTALL_PREFIX}
+    INSTALL_DESTINATION .
 )
 
 install(
     FILES ${CMAKE_CURRENT_BINARY_DIR}/verilator-config-version.cmake
-    DESTINATION ${CMAKE_INSTALL_PREFIX}
+    DESTINATION .
 )
 
 foreach(

--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -47,6 +47,7 @@ Edgar E. Iglesias
 Eric Rippey
 Ethan Sifferman
 Eyck Jentzsch
+Fabian Keßler
 Fan Shupei
 february cozzocrea
 Felix Neumärker


### PR DESCRIPTION
CMake supports relocatable installations.
It also already uses CMAKE_INSTALL_PREFIX as default for the install command. Explicitly using CMAKE_INSTALL_PREFIX may cause undesired behavior, when a relative path is used for installation. E.g. `DIRECTORY ${CMAKE_INSTALL_PREFIX}`(=`./install`) will be parsed to `${CMAKE_BUILD_DIRECTORY}/install/install`

We appreciate your contributing to Verilator.  If this is your first commit, please add your name to docs/CONTRIBUTORS, and read our contributing guidelines in docs/CONTRIBUTING.rst.
