### PR TITLE
Throw error if -j has no value specified

### DIFF
--- a/examples/make_hello_c/Makefile
+++ b/examples/make_hello_c/Makefile
@@ -35,7 +35,7 @@ endif
 default:
 	@echo "-- Verilator hello-world simple example"
 	@echo "-- VERILATE & BUILD --------"
-	$(VERILATOR) -cc --exe --build -j top.v sim_main.cpp
+	$(VERILATOR) -cc --exe --build -j 1 top.v sim_main.cpp
 	@echo "-- RUN ---------------------"
 	obj_dir/Vtop
 	@echo "-- DONE --------------------"

--- a/examples/make_hello_sc/Makefile
+++ b/examples/make_hello_sc/Makefile
@@ -44,7 +44,7 @@ endif
 run:
 	@echo "-- Verilator hello-world simple example"
 	@echo "-- VERILATE & COMPILE ------"
-	$(VERILATOR) -sc --exe --build -j top.v sc_main.cpp
+	$(VERILATOR) -sc --exe --build -j 1 top.v sc_main.cpp
 	@echo "-- RUN ---------------------"
 	obj_dir/Vtop
 	@echo "-- DONE --------------------"

--- a/src/V3Options.cpp
+++ b/src/V3Options.cpp
@@ -1749,6 +1749,8 @@ void V3Options::parseOptsList(FileLine* fl, const string& optdir, int argc,
                 val = std::atoi(argv[i]);  // Can't be negative due to isdigit above
                 if (val == 0) val = std::thread::hardware_concurrency();
                 ++i;
+            } else {
+                fl->v3error("-j argument requires a value");
             }
             if (m_buildJobs == -1) m_buildJobs = val;
             if (m_verilateJobs == -1) m_verilateJobs = val;

--- a/test_regress/t/t_flag_j_bad.out
+++ b/test_regress/t/t_flag_j_bad.out
@@ -1,0 +1,2 @@
+%Error: -j argument requires a value
+%Error: Exiting due to

--- a/test_regress/t/t_flag_j_bad.py
+++ b/test_regress/t/t_flag_j_bad.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2024 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('vlt')
+test.top_filename = "t/t_flag_werror.v"
+
+test.lint(fails=True, verilator_flags=["--j"], expect_filename=test.golden_filename)
+
+test.passes()


### PR DESCRIPTION
According to manual, `-j` flag requires a value:
https://github.com/verilator/verilator/blob/c05c48aaf3cf820bdc5d34b73edc4d6bf3e7f467/bin/verilator#L386
Currently, Verilator doesn't throw error if no value was provided. This PR fixes it.
The lack of error was causing wrong handling of other arguments in case of hierarchical verilation.