### PR TITLE
Fix -j option without argument in hierarchical verilation

### DIFF
--- a/test_regress/t/t_flag_j_hier.py
+++ b/test_regress/t/t_flag_j_hier.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2024 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('vlt')
+
+test.compile(verilator_flags2=['--hierarchical -j --build-jobs 2'])
+
+test.passes()

--- a/test_regress/t/t_flag_j_hier.v
+++ b/test_regress/t/t_flag_j_hier.v
@@ -1,0 +1,14 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2024 by Antmicro.
+// SPDX-License-Identifier: CC0-1.0
+
+module t (/*AUTOARG*/);
+   logic a;
+   s u_s(.a(a));
+endmodule
+
+module s(output logic a);
+   /*verilator hier_block*/
+endmodule


### PR DESCRIPTION
Currently, Verilator throws error if `-j` argument is provided without a value in case of hierarchical verilation. This happens because `-j` and the argument that is next on the arguments list are removed from the command that is invoked on hierarchical blocks.
This PR fixes it by checking if the next argument is a number and removes it only if it is.