### PR TITLE
Fix static function wrappers

### DIFF
--- a/src/V3AstNodeOther.h
+++ b/src/V3AstNodeOther.h
@@ -193,6 +193,7 @@ public:
         isHideLocal(fromp->isHideLocal());
         isHideProtected(fromp->isHideProtected());
         isVirtual(fromp->isVirtual());
+        isStatic(fromp->isStatic());
         lifetime(fromp->lifetime());
         underGenerate(fromp->underGenerate());
     }

--- a/test_regress/t/t_class_static_default_arg.py
+++ b/test_regress/t/t_class_static_default_arg.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2024 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile()
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_class_static_default_arg.v
+++ b/test_regress/t/t_class_static_default_arg.v
@@ -1,0 +1,27 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2024 by Antmicro.
+// SPDX-License-Identifier: CC0-1.0
+
+class Foo;
+   static function bit get_first(bit q[$] = {1'b1});
+      return q[0];
+   endfunction
+endclass
+
+module t (/*AUTOARG*/);
+
+   initial begin
+      bit first;
+      bit arg[$] = {1'b0, 1'b1};
+      first = Foo::get_first();
+      if (first != 1) $stop;
+      first = Foo::get_first(arg);
+      if (first != 0) $stop;
+
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end
+
+endmodule


### PR DESCRIPTION
In order to handle optional argument of a queue type, a function wrapper is used. Currently on master it is always automatic. It causes c++ compilation errors if an original method is static. This PR fixes it.