### PR TITLE
Fix assignments of concatenation to queue and dyn array

### DIFF
--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -4622,9 +4622,12 @@ class WidthVisitor final : public VNVisitor {
         for (AstPatMember* patp = VN_AS(nodep->itemsp(), PatMember); patp;
              patp = VN_AS(patp->nextp(), PatMember)) {
             patp->dtypep(arrayp->subDTypep());
-            AstNodeExpr* const valuep = patternMemberValueIterate(patp);
+            AstNodeExpr* const rhsp = patternMemberValueIterate(patp);
+            const bool rhsIsValue
+                = AstNode::computeCastable(rhsp->dtypep(), arrayp->subDTypep(), nullptr)
+                      .isAssignable();
             AstConsDynArray* const newap
-                = new AstConsDynArray{nodep->fileline(), true, valuep, false, newp};
+                = new AstConsDynArray{nodep->fileline(), rhsIsValue, rhsp, false, newp};
             newap->dtypeFrom(arrayp);
             newp = newap;
         }
@@ -4638,9 +4641,12 @@ class WidthVisitor final : public VNVisitor {
         for (AstPatMember* patp = VN_AS(nodep->itemsp(), PatMember); patp;
              patp = VN_AS(patp->nextp(), PatMember)) {
             patp->dtypep(arrayp->subDTypep());
-            AstNodeExpr* const valuep = patternMemberValueIterate(patp);
+            AstNodeExpr* const rhsp = patternMemberValueIterate(patp);
+            const bool rhsIsValue
+                = AstNode::computeCastable(rhsp->dtypep(), arrayp->subDTypep(), nullptr)
+                      .isAssignable();
             AstConsQueue* const newap
-                = new AstConsQueue{nodep->fileline(), true, valuep, false, newp};
+                = new AstConsQueue{nodep->fileline(), rhsIsValue, rhsp, false, newp};
             newap->dtypeFrom(arrayp);
             newp = newap;
         }

--- a/test_regress/t/t_queue_concat_assign.py
+++ b/test_regress/t/t_queue_concat_assign.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2024 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile()
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_queue_concat_assign.v
+++ b/test_regress/t/t_queue_concat_assign.v
@@ -1,0 +1,23 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2024 by Antmicro.
+// SPDX-License-Identifier: CC0-1.0
+
+module t (/*AUTOARG*/);
+   initial begin
+      bit q1[$] = {1'b1};
+      bit q2[$];
+      bit [1:0] d1[] = {2'b10};
+      bit [1:0] d2[];
+      q2 = {q1};
+      if (q2[0] != 1) $stop;
+
+      d2 = {2'b11};
+      if (d2[0] != 2'b11) $stop;
+
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end
+
+endmodule


### PR DESCRIPTION
Currently on master, assignments to queues and dynamic arrays of form `a = {b}` don't work. A compilation error is thrown, because a queue is passed to the function that expects an element as argument.
```
./Vt_queue_concat_assign___024root__DepSet_hbe0919cb__0__Slow.cpp:41:66: error: no viable conversion from 'VlQueue<CData>' (aka 'VlQueue<unsigned char>') to 'const unsigned char'
    t__DOT__unnamedblk1__DOT__q2 = VlQueue<CData/*0:0*/>::consVC(t__DOT__unnamedblk1__DOT__q1, 
                                                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
/path/verilator/test_regress/../include/verilated_types.h:532:42: note: passing argument to parameter 'lhs' here
    static VlQueue consVC(const T_Value& lhs, const VlQueue& rhs) {
                                         ^
1 error generated.
```
This PR fixes it.