### PR TITLE
Fix complex user type problem with --x-assign

### DIFF
--- a/src/V3LinkDot.cpp
+++ b/src/V3LinkDot.cpp
@@ -1333,9 +1333,10 @@ class LinkDotFindVisitor final : public VNVisitor {
                     } else {
                         findvarp->combineType(nodep);
                         findvarp->fileline()->modifyStateInherit(nodep->fileline());
-                        if (nodep->getChildDTypep()->numeric().isSigned()
-                            && !findvarp->getChildDTypep()->numeric().isSigned()) {
-                            findvarp->getChildDTypep()->numeric(VSigning{true});
+                        UASSERT_OBJ(nodep->subDTypep(), nodep, "Var has no type");
+                        if (nodep->subDTypep()->numeric().isSigned()
+                            && !findvarp->subDTypep()->numeric().isSigned()) {
+                            findvarp->subDTypep()->numeric(VSigning{true});
                         }
                         AstBasicDType* const bdtypep
                             = VN_CAST(findvarp->childDTypep(), BasicDType);

--- a/test_regress/t/t_user_type_xassign.py
+++ b/test_regress/t/t_user_type_xassign.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2024 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile()
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_user_type_xassign.v
+++ b/test_regress/t/t_user_type_xassign.v
@@ -1,0 +1,43 @@
+// DESCRIPTION: Verilator: Demonstrate complex user typea problem with --x-assign
+//
+// This file ONLY is placed into the Public Domain, for any use,
+// without warranty, 2024 by Wilson Snyder.
+// SPDX-License-Identifier: CC0-1.0
+
+module t (/*AUTOARG*/
+   // Inputs
+   clk
+   );
+
+   input clk;
+
+   typedef logic [31:0] int_t;
+   typedef int_t [6:0] bar_t;
+   bar_t the_bar;
+
+   logic [31:0] thing_one;
+   always_comb begin
+       for (int sel = 0; sel < 1; sel++)
+           thing_one = the_bar[sel];
+   end
+
+   virtual class SomeClass;
+       static function logic compare(int a, int b);
+           return a > b;
+       endfunction
+   endclass
+
+   logic [31:0] thing_two;
+   always_comb begin
+       for (int sel_a = 0; sel_a < 1; sel_a++)
+           thing_two = the_bar[sel_a];
+   end
+
+   // finish report
+   always @ (posedge clk) begin
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end
+
+
+endmodule


### PR DESCRIPTION
We found this strange confluence of things that causes Verilator to throw an internal error if running with `--x-assign unique`.  Basically, `LinkDotFindVisitor` tries to use a VAR's `getChildDTypep()` on an `XTEMP` that is being checked by a `CONDBOUND`.  I have no idea how or why the virtual class factors into it, but I need it to get this thing to pop.

I don't yet know where to go from here.  `AstVar` says that `op1` / `childDTypep` is optional.  So:

- Should `LinkDotFindVisitor` be able to tolerate `VAR`s with no `childDType`?
- Should `VAR`s never reach `LinkDotFindVisitor` with no `childDType`?  And if so, why?
- Is `AstVar` wrong and `childDType` should not actually be optional?

NB: does not *actually* fix the problem yet.