### PR TITLE
Install public executables into bindir instead of pkgdatadir (#5140)

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -270,7 +270,7 @@ installbin: | mkbindirs
 	done
 	perl -p -i -e 'use File::Spec;' \
 	           -e' $$path = File::Spec->abs2rel("$(realpath $(DESTDIR)$(pkgdatadir))", "$(realpath $(DESTDIR)$(bindir))");' \
-	           -e 's/my \$$verilator_pkdatadir_relpath = .*/my \$$verilator_pkdatadir_relpath = "$$path";/g' \
+	           -e 's/my \$$verilator_pkgdatadir_relpath = .*/my \$$verilator_pkgdatadir_relpath = "$$path";/g' \
 	           -- "$(DESTDIR)/$(bindir)/verilator"
 	cd bin; \
 	for p in $(VL_INST_PUBLIC_BIN_FILES) ; do \

--- a/Makefile.in
+++ b/Makefile.in
@@ -266,11 +266,15 @@ mkbindirs:
 installbin: | mkbindirs
 	cd $(srcdir)/bin; \
 	for p in $(VL_INST_PUBLIC_SCRIPT_FILES) ; do \
-	  $(INSTALL_PROGRAM) $$p $(DESTDIR)$(pkgdatadir)/bin/$$p; \
+	  $(INSTALL_PROGRAM) $$p $(DESTDIR)$(bindir)/$$p; \
 	done
+	perl -p -i -e 'use File::Spec;' \
+	           -e' $$path = File::Spec->abs2rel("$(realpath $(DESTDIR)$(pkgdatadir))", "$(realpath $(DESTDIR)$(bindir))");' \
+	           -e 's/my \$$verilator_pkdatadir_relpath = .*/my \$$verilator_pkdatadir_relpath = "$$path";/g' \
+	           -- "$(DESTDIR)/$(bindir)/verilator"
 	cd bin; \
 	for p in $(VL_INST_PUBLIC_BIN_FILES) ; do \
-	  $(INSTALL_PROGRAM) $$p $(DESTDIR)$(pkgdatadir)/bin/$$p; \
+	  $(INSTALL_PROGRAM) $$p $(DESTDIR)$(bindir)/$$p; \
 	done
 	cd $(srcdir)/bin; \
 	for p in $(VL_INST_PRIVATE_SCRIPT_FILES) ; do \
@@ -280,11 +284,11 @@ installbin: | mkbindirs
 installredirect: installbin | mkbindirs
 	cp ${srcdir}/bin/redirect ${srcdir}/bin/redirect.tmp
 	perl -p -i -e 'use File::Spec;' \
-	           -e' $$path = File::Spec->abs2rel("$(realpath $(DESTDIR)$(pkgdatadir)/bin)", "$(realpath $(DESTDIR)$(bindir))");' \
+	           -e' $$path = File::Spec->abs2rel("$(realpath $(DESTDIR)$(bindir))", "$(realpath $(DESTDIR)$(pkgdatadir)/bin)");' \
 	           -e 's/RELPATH.*/"$$path";/g' -- "${srcdir}/bin/redirect.tmp"
 	cd $(srcdir)/bin; \
 	for p in $(VL_INST_PUBLIC_SCRIPT_FILES) $(VL_INST_PUBLIC_BIN_FILES) ; do \
-	  $(INSTALL_PROGRAM) redirect.tmp $(DESTDIR)$(bindir)/$$p; \
+	  $(INSTALL_PROGRAM) redirect.tmp $(DESTDIR)$(pkgdatadir)/bin/$$p; \
 	done
 	rm ${srcdir}/bin/redirect.tmp
 

--- a/bin/verilator
+++ b/bin/verilator
@@ -69,9 +69,9 @@ if (! GetOptions(
     pod2usage(-exitstatus => 2, -verbose => 0);
 }
 
-# WARNING: $verilator_pkdatadir_relpath is substituted during Verilator 'make install'
-my $verilator_pkdatadir_relpath = "..";
-my $verilator_root = realpath("$RealBin/$verilator_pkdatadir_relpath");
+# WARNING: $verilator_pkgdatadir_relpath is substituted during Verilator 'make install'
+my $verilator_pkgdatadir_relpath = "..";
+my $verilator_root = realpath("$RealBin/$verilator_pkgdatadir_relpath");
 if (defined $ENV{VERILATOR_ROOT}) {
     if ((!-d $ENV{VERILATOR_ROOT}) || $verilator_root ne realpath($ENV{VERILATOR_ROOT})) {
         warn "%Error: verilator: VERILATOR_ROOT is set to inconsistent path. Suggest leaving it unset.\n";

--- a/bin/verilator
+++ b/bin/verilator
@@ -69,7 +69,9 @@ if (! GetOptions(
     pod2usage(-exitstatus => 2, -verbose => 0);
 }
 
-my $verilator_root = realpath("$RealBin/..");
+# WARNING: $verilator_pkdatadir_relpath is substituted during Verilator 'make install'
+my $verilator_pkdatadir_relpath = "..";
+my $verilator_root = realpath("$RealBin/$verilator_pkdatadir_relpath");
 if (defined $ENV{VERILATOR_ROOT}) {
     if ((!-d $ENV{VERILATOR_ROOT}) || $verilator_root ne realpath($ENV{VERILATOR_ROOT})) {
         warn "%Error: verilator: VERILATOR_ROOT is set to inconsistent path. Suggest leaving it unset.\n";

--- a/nodist/install_test
+++ b/nodist/install_test
@@ -31,7 +31,10 @@ def test():
         print("== stage 0")
         run("/bin/rm -rf " + blddir)
         run("/bin/mkdir -p " + blddir)
-        run("cd " + blddir + " && " + srcdir + "/configure --prefix " + prefix)
+        # Matches Ubuntu's e.g. /usr/share/pkgconfig/verilator.pc
+        run("cd " + blddir + " && " + srcdir + "/configure --prefix " + prefix +
+            " --exec-prefix " + prefix + " --datarootdir " + prefix + "/share" + " --includedir " +
+            prefix + "/share/verilator/include")
         run("cd " + blddir + " && make -j " + str(calc_jobs()))
 
     # Install it under the prefix

--- a/test_regress/t/t_flag_help.py
+++ b/test_regress/t/t_flag_help.py
@@ -14,26 +14,22 @@ test.scenarios('dist')
 # See also t_flag_version.py
 
 
-def check(interpreter, prog):
+def check(prog):
     logfile = test.obj_dir + "/t_help__" + os.path.basename(prog) + ".log"
 
-    test.run(fails=False,
-             cmd=[interpreter, prog, "--help"],
-             logfile=logfile,
-             tee=False,
-             verilator_run=True)
+    test.run(fails=False, cmd=[prog, "--help"], logfile=logfile, tee=False, verilator_run=True)
 
     test.file_grep(logfile, r'(DISTRIBUTION|usage:)')
 
 
-check("perl", os.environ["VERILATOR_ROOT"] + "/bin/verilator")
-check("perl", os.environ["VERILATOR_ROOT"] + "/bin/verilator_coverage")
+check(os.environ["VERILATOR_ROOT"] + "/bin/verilator")
+check(os.environ["VERILATOR_ROOT"] + "/bin/verilator_coverage")
 
-check("python3", os.environ["VERILATOR_ROOT"] + "/bin/verilator_ccache_report")
-check("python3", os.environ["VERILATOR_ROOT"] + "/bin/verilator_gantt")
-check("python3", os.environ["VERILATOR_ROOT"] + "/bin/verilator_profcfunc")
+check(os.environ["VERILATOR_ROOT"] + "/bin/verilator_ccache_report")
+check(os.environ["VERILATOR_ROOT"] + "/bin/verilator_gantt")
+check(os.environ["VERILATOR_ROOT"] + "/bin/verilator_profcfunc")
 
 if os.path.exists(os.environ["VERILATOR_ROOT"] + "/bin/verilator_difftree"):
-    check("python3", os.environ["VERILATOR_ROOT"] + "/bin/verilator_difftree")
+    check(os.environ["VERILATOR_ROOT"] + "/bin/verilator_difftree")
 
 test.passes()


### PR DESCRIPTION
I found a minimally invasive way to respect the FHS, by swapping the redirect scripts and actual executables. Remember the reason we needed the redirect scritps, is because we want pkgdatadir to have the same layout as the source tree for testing purposes. With the swap (so in the installation pkdatadir/bin/ contains redirects to bindir/), it works just fine.

To do this, we need to do one install-time patch to the `verilator` wrapper script, to tell it the relative path between bindir and pkgdatadir.

VERILATOR_ROOT, just like before, points to pkgdatadir (or the source tree), and is used to pick up everything else.

---

Instead of installing redirect scripts in to bindir, and real executables in to pkgdatadir/bin, we now put the real executables into bindir, and add redirect scripts into pkgdatadir/bin. (That is, we redirect in the opposite direction as before).

This enables the same relocatable and testable installations as before without putting architecture specific binaries into pkgdatadir, so hopefully we now conform to the Linux Filesystem Hierarchy Standard.

This requires a small fixup in the installed `verilator` script to hardcode the relative path between bindir and pkgdatadir.

Fixes #5140
