### PR TITLE
Fix CMake comments

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -7,6 +7,7 @@ Adam Bagley
 Adrian Sampson
 Adrien Le Masle
 Ahmed El-Mahmoudy
+Aidan McNay
 Aleksander Kiryk
 Alex Chadwick
 Alex Solomatnikov

--- a/verilator-config-version.cmake.in
+++ b/verilator-config-version.cmake.in
@@ -5,7 +5,7 @@
 # This allows specifying a minimum Verilator version.
 # Include it in your CMakeLists.txt using:
 #
-#     find_package(verilate 4.0)
+#     find_package(verilator 4.0)
 #
 # Copyright 2003-2024 by Wilson Snyder. This program is free software; you
 # can redistribute it and/or modify it under the terms of either the GNU

--- a/verilator-config.cmake.in
+++ b/verilator-config.cmake.in
@@ -4,7 +4,7 @@
 #
 # Include it in your CMakeLists.txt using:
 #
-#     find_package(verilate)
+#     find_package(verilator)
 #
 #  This script adds a verilate function.
 #


### PR DESCRIPTION
Minor fix of comments for including the CMake package for Verilator.

Context: CMake expects the package to be named `<pkg-name>Config.cmake` or `<pkg-name>-config.cmake`. Using `find_package(verilate)` results in the following error:

```
CMake Error at CMakeLists.txt:45 (find_package):
  By not providing "Findverilate.cmake" in CMAKE_MODULE_PATH this project has
  asked CMake to find a package configuration file provided by "verilate",
  but CMake did not find one.

  Could not find a package configuration file provided by "verilate" with any
  of the following names:

    verilateConfig.cmake
    verilate-config.cmake

  Add the installation prefix of "verilate" to CMAKE_PREFIX_PATH or set
  "verilate_DIR" to a directory containing one of the above files.  If
  "verilate" provides a separate development package or SDK, be sure it has
  been installed.
```