### PR TITLE
Fix multi-range indices assignment (#5534)

### DIFF
--- a/src/V3Randomize.cpp
+++ b/src/V3Randomize.cpp
@@ -1413,8 +1413,13 @@ class RandomizeVisitor final : public VNVisitor {
             AstVarRef* tempRefp = new AstVarRef{fl, newRandLoopIndxp, VAccess::READ};
             if (VN_IS(tempDTypep, DynArrayDType))
                 tempElementp = new AstCMethodHard{fl, tempExprp, "atWrite", tempRefp};
-            else if (VN_IS(tempDTypep, UnpackArrayDType))
-                tempElementp = new AstArraySel{fl, tempExprp, tempRefp};
+            else if (VN_IS(tempDTypep, UnpackArrayDType)){
+                AstNodeArrayDType* aryDTypep = VN_CAST(tempDTypep, NodeArrayDType);
+                tempElementp = new AstArraySel{fl, tempExprp, new AstSel{fl, new AstSub{fl, tempRefp, new AstConst{fl,static_cast<uint32_t>(aryDTypep->lo())}}, 
+                                                                            new AstConst{fl, 0},   
+                                                                            new AstConst{fl,static_cast<uint32_t>(V3Number::log2b(aryDTypep->elementsConst()) + 1)}}};
+                //tempElementp = new AstArraySel{fl, tempExprp, tempRefp};
+            }
             else if (VN_IS(tempDTypep, AssocArrayDType))
                 tempElementp = new AstAssocSel{fl, tempExprp, tempRefp};
             else if (VN_IS(tempDTypep, QueueDType))

--- a/src/V3Randomize.cpp
+++ b/src/V3Randomize.cpp
@@ -1414,7 +1414,7 @@ class RandomizeVisitor final : public VNVisitor {
             if (VN_IS(tempDTypep, DynArrayDType))
                 tempElementp = new AstCMethodHard{fl, tempExprp, "atWrite", tempRefp};
             else if (VN_IS(tempDTypep, UnpackArrayDType)) {
-                AstNodeArrayDType* aryDTypep = VN_CAST(tempDTypep, NodeArrayDType);
+                AstNodeArrayDType* const aryDTypep = VN_CAST(tempDTypep, NodeArrayDType);
                 // Adjust the bitp to ensure it covers all possible indices
                 tempElementp = new AstArraySel{
                     fl, tempExprp,

--- a/src/V3Randomize.cpp
+++ b/src/V3Randomize.cpp
@@ -1413,14 +1413,19 @@ class RandomizeVisitor final : public VNVisitor {
             AstVarRef* tempRefp = new AstVarRef{fl, newRandLoopIndxp, VAccess::READ};
             if (VN_IS(tempDTypep, DynArrayDType))
                 tempElementp = new AstCMethodHard{fl, tempExprp, "atWrite", tempRefp};
-            else if (VN_IS(tempDTypep, UnpackArrayDType)){
+            else if (VN_IS(tempDTypep, UnpackArrayDType)) {
                 AstNodeArrayDType* aryDTypep = VN_CAST(tempDTypep, NodeArrayDType);
-                tempElementp = new AstArraySel{fl, tempExprp, new AstSel{fl, new AstSub{fl, tempRefp, new AstConst{fl,static_cast<uint32_t>(aryDTypep->lo())}}, 
-                                                                            new AstConst{fl, 0},   
-                                                                            new AstConst{fl,static_cast<uint32_t>(V3Number::log2b(aryDTypep->elementsConst()) + 1)}}};
+                tempElementp = new AstArraySel{
+                    fl, tempExprp,
+                    new AstSel{
+                        fl,
+                        new AstSub{fl, tempRefp,
+                                   new AstConst{fl, static_cast<uint32_t>(aryDTypep->lo())}},
+                        new AstConst{fl, 0},
+                        new AstConst{fl, static_cast<uint32_t>(
+                                             V3Number::log2b(aryDTypep->elementsConst()) + 1)}}};
                 //tempElementp = new AstArraySel{fl, tempExprp, tempRefp};
-            }
-            else if (VN_IS(tempDTypep, AssocArrayDType))
+            } else if (VN_IS(tempDTypep, AssocArrayDType))
                 tempElementp = new AstAssocSel{fl, tempExprp, tempRefp};
             else if (VN_IS(tempDTypep, QueueDType))
                 tempElementp = new AstCMethodHard{fl, tempExprp, "atWriteAppend", tempRefp};

--- a/src/V3Randomize.cpp
+++ b/src/V3Randomize.cpp
@@ -1422,8 +1422,8 @@ class RandomizeVisitor final : public VNVisitor {
                         new AstSub{fl, tempRefp,
                                    new AstConst{fl, static_cast<uint32_t>(aryDTypep->lo())}},
                         new AstConst{fl, 0},
-                        new AstConst{fl, static_cast<uint32_t>(
-                                             V3Number::log2b(aryDTypep->hi()) + 1)}}};
+                        new AstConst{
+                            fl, static_cast<uint32_t>(V3Number::log2b(aryDTypep->hi()) + 1)}}};
                 //tempElementp = new AstArraySel{fl, tempExprp, tempRefp};
             } else if (VN_IS(tempDTypep, AssocArrayDType))
                 tempElementp = new AstAssocSel{fl, tempExprp, tempRefp};

--- a/src/V3Randomize.cpp
+++ b/src/V3Randomize.cpp
@@ -1423,7 +1423,7 @@ class RandomizeVisitor final : public VNVisitor {
                                    new AstConst{fl, static_cast<uint32_t>(aryDTypep->lo())}},
                         new AstConst{fl, 0},
                         new AstConst{fl, static_cast<uint32_t>(
-                                             V3Number::log2b(aryDTypep->elementsConst()) + 1)}}};
+                                             V3Number::log2b(aryDTypep->hi()) + 1)}}};
                 //tempElementp = new AstArraySel{fl, tempExprp, tempRefp};
             } else if (VN_IS(tempDTypep, AssocArrayDType))
                 tempElementp = new AstAssocSel{fl, tempExprp, tempRefp};

--- a/src/V3Randomize.cpp
+++ b/src/V3Randomize.cpp
@@ -1415,6 +1415,7 @@ class RandomizeVisitor final : public VNVisitor {
                 tempElementp = new AstCMethodHard{fl, tempExprp, "atWrite", tempRefp};
             else if (VN_IS(tempDTypep, UnpackArrayDType)) {
                 AstNodeArrayDType* aryDTypep = VN_CAST(tempDTypep, NodeArrayDType);
+                // Adjust the bitp to ensure it covers all possible indices
                 tempElementp = new AstArraySel{
                     fl, tempExprp,
                     new AstSel{
@@ -1424,7 +1425,6 @@ class RandomizeVisitor final : public VNVisitor {
                         new AstConst{fl, 0},
                         new AstConst{
                             fl, static_cast<uint32_t>(V3Number::log2b(aryDTypep->hi()) + 1)}}};
-                //tempElementp = new AstArraySel{fl, tempExprp, tempRefp};
             } else if (VN_IS(tempDTypep, AssocArrayDType))
                 tempElementp = new AstAssocSel{fl, tempExprp, tempRefp};
             else if (VN_IS(tempDTypep, QueueDType))

--- a/test_regress/t/t_randomize_array.v
+++ b/test_regress/t/t_randomize_array.v
@@ -34,10 +34,12 @@ endclass
 class unconstrained_unpacked_array_test;
 
   rand bit [2:0] [15:0] unpacked_array [3][5];
+  rand int unpacked_array1 [9:3][4:8];
   function new();
     unpacked_array = '{ '{default: '{default: 'h0}},
                         '{default: '{default: 'h1}},
                         '{default: '{default: 'h2}}};
+    unpacked_array1 = '{default: '{default: 0}};
   endfunction
 
   function void check_randomization();
@@ -46,6 +48,9 @@ class unconstrained_unpacked_array_test;
         // At the innermost packed level, invoke check_rand
         `check_rand(this, this.unpacked_array[i][j])
       end
+    end
+    foreach (unpacked_array1[i, j]) begin
+      `check_rand(this, this.unpacked_array1[i][j])
     end
   endfunction
 

--- a/test_regress/t/t_randomize_array.v
+++ b/test_regress/t/t_randomize_array.v
@@ -35,7 +35,7 @@ class unconstrained_unpacked_array_test;
 
   rand bit [2:0] [15:0] unpacked_array [3][5];
   rand int unpacked_array1 [9:3][4:8];
-  rand int unpacked_array2 [3:9][8:4]; 
+  rand int unpacked_array2 [3:9][8:4];
   function new();
     unpacked_array = '{ '{default: '{default: 'h0}},
                         '{default: '{default: 'h1}},

--- a/test_regress/t/t_randomize_array.v
+++ b/test_regress/t/t_randomize_array.v
@@ -35,11 +35,13 @@ class unconstrained_unpacked_array_test;
 
   rand bit [2:0] [15:0] unpacked_array [3][5];
   rand int unpacked_array1 [9:3][4:8];
+  rand int unpacked_array2 [3:9][8:4]; 
   function new();
     unpacked_array = '{ '{default: '{default: 'h0}},
                         '{default: '{default: 'h1}},
                         '{default: '{default: 'h2}}};
     unpacked_array1 = '{default: '{default: 0}};
+    unpacked_array2 = '{default: '{default: 0}};
   endfunction
 
   function void check_randomization();
@@ -51,6 +53,9 @@ class unconstrained_unpacked_array_test;
     end
     foreach (unpacked_array1[i, j]) begin
       `check_rand(this, this.unpacked_array1[i][j])
+    end
+    foreach (unpacked_array2[i, j]) begin
+      `check_rand(this, this.unpacked_array2[i][j])
     end
   endfunction
 


### PR DESCRIPTION
This patches fix the wrong assignment when dealing with `unpacked_arr[9:3][4:8]`-like type and addes the part to the test.

Thanks to @udayaa-init  for kind help.

After this patch and #5537, all found and reported issues have been solved and all array types' basic randomzation is fully supported.