### PR TITLE
Fix array trace splitting

### DIFF
--- a/src/V3Trace.cpp
+++ b/src/V3Trace.cpp
@@ -708,7 +708,13 @@ class TraceVisitor final : public VNVisitor {
                 // Track splitting due to size
                 UASSERT_OBJ(incFulp->nodeCount() == incChgp->nodeCount(), declp,
                             "Should have equal cost");
-                subStmts += incChgp->nodeCount();
+                auto range = declp->arrayRange();
+                if (range.ranged()) {
+                    // 2x because each element is a TraceInc and a VarRef
+                    subStmts += range.elements() * 2;
+                } else {
+                    subStmts += incChgp->nodeCount();
+                }
 
                 // Track partitioning
                 nCodes += declp->codeInc();

--- a/src/V3Trace.cpp
+++ b/src/V3Trace.cpp
@@ -708,7 +708,7 @@ class TraceVisitor final : public VNVisitor {
                 // Track splitting due to size
                 UASSERT_OBJ(incFulp->nodeCount() == incChgp->nodeCount(), declp,
                             "Should have equal cost");
-                auto range = declp->arrayRange();
+                const VNumRange range = declp->arrayRange();
                 if (range.ranged()) {
                     // 2x because each element is a TraceInc and a VarRef
                     subStmts += range.elements() * 2;

--- a/test_regress/t/t_mem_trace_split.py
+++ b/test_regress/t/t_mem_trace_split.py
@@ -14,7 +14,8 @@ test.scenarios('simulator')
 test.compile(verilator_flags2=["--trace", "--trace-structs", "--output-split-ctrace", "32"])
 
 if test.vlt_all:
-    test.file_grep_count(test.obj_dir + "/V" + test.name + "__Trace__0.cpp", r'void Vt.*trace_chg_.*sub.*{', 3)
+    test.file_grep_count(test.obj_dir + "/V" + test.name + "__Trace__0.cpp",
+                         r'void Vt.*trace_chg_.*sub.*{', 3)
 
 test.execute()
 

--- a/test_regress/t/t_mem_trace_split.py
+++ b/test_regress/t/t_mem_trace_split.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2024 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile(verilator_flags2=["--trace", "--trace-structs", "--output-split-ctrace", "32"])
+
+if test.vlt_all:
+    test.file_grep_count(test.obj_dir + "/V" + test.name + "__Trace__0.cpp", r'void Vt.*trace_chg_.*sub.*{', 3)
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_mem_trace_split.v
+++ b/test_regress/t/t_mem_trace_split.v
@@ -1,0 +1,31 @@
+// DESCRIPTION: Verilator: Demonstrate complex user typea problem with --x-assign
+//
+// This file ONLY is placed into the Public Domain, for any use,
+// without warranty, 2024 by Wilson Snyder.
+// SPDX-License-Identifier: CC0-1.0
+
+module t (/*AUTOARG*/
+   // Inputs
+   clk
+   );
+
+   input clk;
+
+   logic [31:0] mem_a [32];
+   logic [15:0] mem_b [32];
+
+   int cyc = 0;
+
+   // finish report
+   always @ (posedge clk) begin
+      cyc <= cyc + 1;
+      mem_a[cyc] <= cyc;
+      mem_b[cyc] <= 16'(cyc);
+      if (cyc == 10) begin
+         $write("*-* All Finished *-*\n");
+         $finish;
+      end
+   end
+
+
+endmodule


### PR DESCRIPTION
When trace funcs are being split, arrays only count as one via `nodeCount()` but are expanded to one `chg*Data()` per word later on.  This can cause unexpectedly large `__Trace__#.cpp` files which then translates to long object build times.  Accounting for this expansion ahead of time brings things back to the expected behavior.