### PR TITLE
fix file_grep_count() error message

### DIFF
--- a/test_regress/driver.py
+++ b/test_regress/driver.py
@@ -2459,8 +2459,8 @@ class VlTest:
             return
         count = len(re.findall(regexp, contents))
         if expcount != count:
-            self.error("File_grep_count: " + filename + ": Got='" + count + "' Expected='" +
-                       expcount + "' in regexp: '" + regexp + "'")
+            self.error("File_grep_count: " + filename + ": Got='" + str(count) + "' Expected='" +
+                       str(expcount) + "' in regexp: '" + regexp + "'")
 
     def file_grep_any(self, filenames: list, regexp, expvalue=None) -> None:
         for filename in filenames:


### PR DESCRIPTION
Noticed this while working on #5549.

Without this one gets:
```
  File "/usr/scratch/local/devs/verilator/test_regress/driver.py", line 2450, in file_grep_count                                                                                                                                                                                                                                                                                                                                         
    self.error("File_grep_count: " + filename + ": Got='" + count + "' Expected='" +                                                                                                                                                                                                                                                                                                                                                     
TypeError: can only concatenate str (not "int") to str                                                                                                                                                                                                                                                                                                                                                                                   
```