### PR TITLE
fix: build on gcc when using the spack wrapper

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -45,6 +45,7 @@ Drew Ranck
 Drew Taussig
 Driss Hafdi
 Edgar E. Iglesias
+Eric Müller
 Eric Rippey
 Ethan Sifferman
 Eyck Jentzsch

--- a/src/Makefile_obj.in
+++ b/src/Makefile_obj.in
@@ -363,7 +363,7 @@ $(TGT): $(PREDEP_H) $(OBJS)
 .SECONDARY:
 
 %.gch: %
-	$(OBJCACHE) ${CXX} ${CXXFLAGS} ${CPPFLAGSWALL} ${CFG_CXXFLAGS_PCH} $< -o $@
+	$(OBJCACHE) ${CXX} ${CXXFLAGS} ${CPPFLAGSWALL} ${CFG_CXXFLAGS_PCH} -c $< -o $@
 %.o: %.cpp
 	$(OBJCACHE) ${CXX} ${CXXFLAGS} ${CPPFLAGSWALL} -c $< -o $@
 %.o: %.c


### PR DESCRIPTION
When building `verilator` via the [spack](https://github.com/spack/spack) package manager (for a reproducible build from source; [verilator spack build recipe](https://github.com/spack/spack/blob/develop/var/spack/repos/builtin/packages/verilator/package.py); problem discussed [here](https://github.com/spack/spack/pull/47168)) we encountered a build fail (probably due to weird/odd gcc behavior when it comes to precompiled headers and the spack build flow not replicating it fully) — we believe the `-c` option is missing.

(The `cmake`-based build doesn't use `gch` files and would just work.)