### PR TITLE
Fix struct literal on pattern assignment (#5552)

### DIFF
--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -5544,7 +5544,7 @@ class WidthVisitor final : public VNVisitor {
                     userIterate(modVarp->childDTypep(),
                                 WidthVP{SELF, BOTH}.p());  // May relink pointed to node
                     AstNodeDType* const setDtp = modVarp->childDTypep()->cloneTree(false);
-                    if (patternp->childDTypep() == nullptr) { patternp->childDTypep(setDtp); }
+                    if (!patternp->childDTypep()) patternp->childDTypep(setDtp);
                     userIterateChildren(nodep, WidthVP{setDtp, BOTH}.p());
                     didWidth = true;
                 }

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -5544,7 +5544,7 @@ class WidthVisitor final : public VNVisitor {
                     userIterate(modVarp->childDTypep(),
                                 WidthVP{SELF, BOTH}.p());  // May relink pointed to node
                     AstNodeDType* const setDtp = modVarp->childDTypep()->cloneTree(false);
-                    patternp->childDTypep(setDtp);
+                    if (patternp->childDTypep() == nullptr) { patternp->childDTypep(setDtp); }
                     userIterateChildren(nodep, WidthVP{setDtp, BOTH}.p());
                     didWidth = true;
                 }

--- a/test_regress/t/t_struct_literal_param.py
+++ b/test_regress/t/t_struct_literal_param.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2024 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile(verilator_flags2=["--debug"])
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_struct_literal_param.v
+++ b/test_regress/t/t_struct_literal_param.v
@@ -1,0 +1,38 @@
+// DESCRIPTION: Verilator: Demonstrate struct literal param assignment problem
+//
+// This file ONLY is placed into the Public Domain, for any use,
+// without warranty, 2024 by Wilson Snyder.
+// SPDX-License-Identifier: CC0-1.0
+
+package Some_pkg;
+    typedef struct packed {
+        int foo;
+    } some_struct_t;
+endpackage
+
+module sub #(
+    parameter Some_pkg::some_struct_t the_some_struct
+) ();
+endmodule
+
+module t (/*AUTOARG*/
+   // Inputs
+   clk
+   );
+
+   input clk;
+
+   // finish report
+   always @ (posedge clk) begin
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end
+
+   sub #(
+       .the_some_struct(
+            Some_pkg::some_struct_t'{
+                foo: 1
+            }))
+    the_sub ();
+
+endmodule


### PR DESCRIPTION
Re: #5552

A pattern's `childDTypep` can either come from the parser (if it's specified in the RTL) or, in this case, from a parameter it's being assigned to.  If there's an explicit type I assume that should always win.

This was blowing up in larger designs without `--debug` but I can only get the minimum reproducer to pop with `--debug`.
