### PR TITLE
Tests: Don't use indices in check_rand

### DIFF
--- a/test_regress/t/t_constraint_dist.v
+++ b/test_regress/t/t_constraint_dist.v
@@ -8,12 +8,15 @@
 begin \
    longint prev_result; \
    int ok = 0; \
-   for (int i = 0; i < 10; i++) begin \
+   if (!bit'(cl.randomize())) $stop; \
+   prev_result = longint'(field); \
+   if (!(cond)) $stop; \
+   repeat(9) begin \
       longint result; \
       if (!bit'(cl.randomize())) $stop; \
       result = longint'(field); \
       if (!(cond)) $stop; \
-      if (i > 0 && result != prev_result) ok = 1; \
+      if (result != prev_result) ok = 1; \
       prev_result = result; \
    end \
    if (ok != 1) $stop; \

--- a/test_regress/t/t_constraint_foreach.v
+++ b/test_regress/t/t_constraint_foreach.v
@@ -8,12 +8,15 @@
 begin \
    longint prev_result; \
    int ok = 0; \
-   for (int i = 0; i < 10; i++) begin \
+   if (!bit'(cl.randomize())) $stop; \
+   prev_result = longint'(field); \
+   if (!(cond)) $stop; \
+   repeat(9) begin \
       longint result; \
       if (!bit'(cl.randomize())) $stop; \
       result = longint'(field); \
       if (!(cond)) $stop; \
-      if (i > 0 && result != prev_result) ok = 1; \
+      if (result != prev_result) ok = 1; \
       prev_result = result; \
    end \
    if (ok != 1) $stop; \

--- a/test_regress/t/t_constraint_inheritance.v
+++ b/test_regress/t/t_constraint_inheritance.v
@@ -8,12 +8,15 @@
 begin \
    longint prev_result; \
    int ok = 0; \
-   for (int i = 0; i < 10; i++) begin \
+   if (!bit'(cl.randomize())) $stop; \
+   prev_result = longint'(field); \
+   if (!(cond)) $stop; \
+   repeat(9) begin \
       longint result; \
       if (!bit'(cl.randomize())) $stop; \
       result = longint'(field); \
       if (!(cond)) $stop; \
-      if (i > 0 && result != prev_result) ok = 1; \
+      if (result != prev_result) ok = 1; \
       prev_result = result; \
    end \
    if (ok != 1) $stop; \

--- a/test_regress/t/t_constraint_inheritance_with.v
+++ b/test_regress/t/t_constraint_inheritance_with.v
@@ -8,12 +8,15 @@
 begin \
    longint prev_result; \
    int ok = 0; \
-   for (int i = 0; i < 10; i++) begin \
+   if (!bit'(cl.randomize() with { constr; })) $stop; \
+   prev_result = longint'(field); \
+   if (!(cond)) $stop; \
+   repeat(9) begin \
       longint result; \
       if (!bit'(cl.randomize() with { constr; })) $stop; \
       result = longint'(field); \
       if (!(cond)) $stop; \
-      if (i > 0 && result != prev_result) ok = 1; \
+      if (result != prev_result) ok = 1; \
       prev_result = result; \
    end \
    if (ok != 1) $stop; \

--- a/test_regress/t/t_randomize_array.v
+++ b/test_regress/t/t_randomize_array.v
@@ -8,11 +8,13 @@
 begin \
    longint prev_result; \
    int ok = 0; \
-   for (int i = 0; i < 10; i++) begin \
+   void'(cl.randomize()); \
+   prev_result = longint'(field); \
+   repeat(9) begin \
       longint result; \
       void'(cl.randomize()); \
       result = longint'(field); \
-      if (i > 0 && result != prev_result) ok = 1; \
+      if (result != prev_result) ok = 1; \
       prev_result = result; \
    end \
    if (ok != 1) $stop; \

--- a/test_regress/t/t_randomize_array_constraints.v
+++ b/test_regress/t/t_randomize_array_constraints.v
@@ -8,11 +8,13 @@
 begin \
    longint prev_result; \
    int ok = 0; \
-   for (int i = 0; i < 10; i++) begin \
+   void'(cl.randomize()); \
+   prev_result = longint'(field); \
+   repeat(9) begin \
       longint result; \
       void'(cl.randomize()); \
       result = longint'(field); \
-      if (i > 0 && result != prev_result) ok = 1; \
+      if (result != prev_result) ok = 1; \
       prev_result = result; \
    end \
    if (ok != 1) $stop; \

--- a/test_regress/t/t_randomize_method.v
+++ b/test_regress/t/t_randomize_method.v
@@ -8,11 +8,13 @@
 begin \
    longint prev_result; \
    int ok = 0; \
-   for (int i = 0; i < 10; i++) begin \
+   void'(cl.randomize()); \
+   prev_result = longint'(field); \
+   repeat(9) begin \
       longint result; \
       void'(cl.randomize()); \
       result = longint'(field); \
-      if (i > 0 && result != prev_result) ok = 1; \
+      if (result != prev_result) ok = 1; \
       prev_result = result; \
    end \
    if (ok != 1) $stop; \

--- a/test_regress/t/t_randomize_method_with.v
+++ b/test_regress/t/t_randomize_method_with.v
@@ -8,11 +8,13 @@
 begin \
    longint prev_result; \
    int ok = 0; \
-   for (int i = 0; i < 10; i++) begin \
+   void'(cl.randomize()); \
+   prev_result = longint'(field); \
+   repeat(9) begin \
       longint result; \
       void'(cl.randomize()); \
       result = longint'(field); \
-      if (i > 0 && result != prev_result) ok = 1; \
+      if (result != prev_result) ok = 1; \
       prev_result = result; \
    end \
    if (ok != 1) $stop; \

--- a/test_regress/t/t_randomize_queue_constraints.v
+++ b/test_regress/t/t_randomize_queue_constraints.v
@@ -8,12 +8,15 @@
 begin \
    longint prev_result; \
    int ok = 0; \
-   for (int i = 0; i < 10; i++) begin \
+   if (!bit'(cl.randomize())) $stop; \
+   prev_result = longint'(field); \
+   if (!(cond)) $stop; \
+   repeat(9) begin \
       longint result; \
       if (!bit'(cl.randomize())) $stop; \
       result = longint'(field); \
       if (!(cond)) $stop; \
-      if (i > 0 && result != prev_result) ok = 1; \
+      if (result != prev_result) ok = 1; \
       prev_result = result; \
    end \
    if (ok != 1) $stop; \


### PR DESCRIPTION
I noticed a problem with overridden symbols in https://github.com/verilator/verilator/blob/master/test_regress/t/t_randomize_array.v.
When we pass an expression with a variable `i` to the `check_rand` macro, like here: https://github.com/verilator/verilator/blob/83081aaefc1a89ce9c38d1102e9ad5029009f247/test_regress/t/t_randomize_array.v#L58
That `i` is resolved to the one defined in the macro:
https://github.com/verilator/verilator/blob/83081aaefc1a89ce9c38d1102e9ad5029009f247/test_regress/t/t_randomize_array.v#L11

This problem may cause false positive test results, because we unintentionally iterate through the array and if each element was initialized with a different value, it would pass even if we removed the call to `randomize` inside the macro.

I decided to change that macro in each of the tests.