### PR TITLE
Fix enum name method

### DIFF
--- a/src/V3AstNodeDType.h
+++ b/src/V3AstNodeDType.h
@@ -209,6 +209,12 @@ protected:
         m_packed = (numericUnpack != VSigning::NOSIGN);
         numeric(VSigning::fromBool(numericUnpack.isSigned()));
     }
+    AstNodeUOrStructDType(const AstNodeUOrStructDType& other)
+        : AstNodeDType(other)
+        , m_name(other.m_name)
+        , m_uniqueNum(uniqueNumInc())
+        , m_packed(other.m_packed)
+        , m_isFourstate(other.m_isFourstate) {}
 
 public:
     ASTGEN_MEMBERS_AstNodeUOrStructDType;
@@ -664,6 +670,11 @@ public:
         childDTypep(dtp);  // Only for parser
         dtypep(nullptr);  // V3Width will resolve
     }
+    AstDefImplicitDType(const AstDefImplicitDType& other)
+        : AstNodeDType(other)
+        , m_name(other.m_name)
+        , m_containerp(other.m_containerp)
+        , m_uniqueNum(uniqueNumInc()) {}
     ASTGEN_MEMBERS_AstDefImplicitDType;
     int uniqueNum() const { return m_uniqueNum; }
     bool same(const AstNode* samep) const override {

--- a/src/V3AstNodeDType.h
+++ b/src/V3AstNodeDType.h
@@ -793,6 +793,10 @@ public:
         dtypep(nullptr);  // V3Width will resolve
         widthFromSub(subDTypep());
     }
+    AstEnumDType(const AstEnumDType& other)
+        : AstNodeDType(other)
+        , m_name(other.m_name)
+        , m_uniqueNum(uniqueNumInc()) {}
     ASTGEN_MEMBERS_AstEnumDType;
 
     const char* broken() const override;

--- a/test_regress/t/t_enum_name_sformatf.py
+++ b/test_regress/t/t_enum_name_sformatf.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2024 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile()
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_enum_name_sformatf.v
+++ b/test_regress/t/t_enum_name_sformatf.v
@@ -4,13 +4,13 @@
 // without warranty, 2024 by Wilson Snyder.
 // SPDX-License-Identifier: CC0-1.0
 
-module sub #(parameter int param_a) ();
+module sub #(parameter int param_a, parameter bit [1:0] enum_param = '0) ();
    typedef enum logic [1:0] {
-       FOO,
+       FOO = enum_param,
        BAR,
        BAZ
-   } enum_t; // NOCOMMIT -- try a param dependent enum
-   enum_t the_enum;
+   } enum_t;
+   enum_t the_enum = enum_t'(1);
 
    initial $display("%s", the_enum.name());
 endmodule
@@ -30,5 +30,6 @@ module t (/*AUTOARG*/
 
    sub #(.param_a(1)) the_sub1();
    sub #(.param_a(2)) the_sub2();
+   sub #(.param_a(2), .enum_param(2'd1)) the_sub3();
 
 endmodule

--- a/test_regress/t/t_enum_name_sformatf.v
+++ b/test_regress/t/t_enum_name_sformatf.v
@@ -1,0 +1,34 @@
+// DESCRIPTION: Verilator: Demonstrate struct literal param assignment problem
+//
+// This file ONLY is placed into the Public Domain, for any use,
+// without warranty, 2024 by Wilson Snyder.
+// SPDX-License-Identifier: CC0-1.0
+
+module sub #(parameter int param_a) ();
+   typedef enum logic [1:0] {
+       FOO,
+       BAR,
+       BAZ
+   } enum_t; // NOCOMMIT -- try a param dependent enum
+   enum_t the_enum;
+
+   initial $display("%s", the_enum.name());
+endmodule
+
+module t (/*AUTOARG*/
+   // Inputs
+   clk
+   );
+
+   input clk;
+
+   // finish report
+   always @ (posedge clk) begin
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end
+
+   sub #(.param_a(1)) the_sub1();
+   sub #(.param_a(2)) the_sub2();
+
+endmodule


### PR DESCRIPTION
@wsnyder one more related to:
```
commit 2fc94557a09f2d91d9f4b14752090af5cef9dea7 (HEAD -> master)
Author: Wilson Snyder <wsnyder@wsnyder.org>
Date:   Fri Oct 11 22:37:48 2024 -0400

    Fix error on enums with x/z using .name(), and internal refactoring
```

If I use the enum `name()` method in a parametric scope I end up getting duplicate `__Venumtab_enum_name#` `VAR`s under `$unit::` which cause:
```
%Error: Internal Error: t/t_enum_name_sformatf.v:8:12: ../V3Broken.cpp:168: Broken link in node (or something without maybePointedTo): 'm_varp && !m_varp->brokeExists()' @ ./V3Ast__gen_impl.h:4694
                                                     : ... note: In instance 't.the_sub1'
-node: VARREF 0x555556fc6750 <e1270> {e8am} @dt=0x555556fc95c0@(str)uc[3:0]  __Venumtab_enum_name3 pkg=0x555556fc50e0 [RV] <- VAR 0x555556fc5200 <e1367#> {e8am} @dt=0x555556fc95c0@(str)uc[3:0]  __Venumtab_enum_name3 [CONST] [VSTATIC]  MODULETEMP
    8 |    typedef enum logic [1:0] {
      |            ^~~~
```

This is happening in `WidthVisitor::enumVarp()`.  I don't yet understand `AstEnumDType::tableMap()`, but that's where I'm headed next.  However, any advice on how to solve this is appreciated.  I'm guessing we should have the duplicate `VAR`s and all the `VARREF`s should just point to the single name table.  But I'm not sure yet.

I also don't know what will happen if the enum depends on a parameter (e.g. `FOO = some_param`).  But hopefully we can solve for both here.