### PR TITLE
Support `rand` dynamic arrays of objects (#5557)

### DIFF
--- a/src/V3Randomize.cpp
+++ b/src/V3Randomize.cpp
@@ -1380,7 +1380,7 @@ class RandomizeVisitor final : public VNVisitor {
         return newp;
     }
     AstNodeStmt* createArrayForeachLoop(FileLine* const fl, AstNodeDType* const dtypep,
-                                        AstNodeExpr* exprp) {
+                                        AstNodeExpr* exprp, AstVar* const outputVarp) {
         V3UniqueNames* uniqueNamep = new V3UniqueNames{"__Vrandarr"};
         AstNodeDType* tempDTypep = dtypep;
         AstVar* randLoopIndxp = nullptr;
@@ -1399,7 +1399,8 @@ class RandomizeVisitor final : public VNVisitor {
         auto createForeachLoop = [&](AstNodeExpr* tempElementp, AstVar* randLoopIndxp) {
             AstSelLoopVars* const randLoopVarp
                 = new AstSelLoopVars{fl, exprp->cloneTree(false), randLoopIndxp};
-            return new AstForeach{fl, randLoopVarp, newRandStmtsp(fl, tempElementp, nullptr)};
+            return new AstForeach{fl, randLoopVarp,
+                                  newRandStmtsp(fl, tempElementp, nullptr, outputVarp)};
         };
         AstNodeExpr* tempElementp = nullptr;
         while (VN_IS(tempDTypep, DynArrayDType) || VN_IS(tempDTypep, UnpackArrayDType)
@@ -1432,7 +1433,8 @@ class RandomizeVisitor final : public VNVisitor {
         stmtsp = createForeachLoop(tempElementp, randLoopIndxp);
         return stmtsp;
     }
-    AstNodeStmt* newRandStmtsp(FileLine* fl, AstNodeExpr* exprp, AstVar* randcVarp, int offset = 0,
+    AstNodeStmt* newRandStmtsp(FileLine* fl, AstNodeExpr* exprp, AstVar* randcVarp,
+                               AstVar* const outputVarp, int offset = 0,
                                AstMemberDType* memberp = nullptr) {
         AstNodeDType* const memberDtp
             = memberp ? memberp->subDTypep()->skipRefp() : exprp->dtypep()->skipRefp();
@@ -1444,13 +1446,13 @@ class RandomizeVisitor final : public VNVisitor {
                 AstNodeStmt* randp = nullptr;
                 if (structDtp->packed()) {
                     randp = newRandStmtsp(fl, stmtsp ? exprp->cloneTree(false) : exprp, nullptr,
-                                          offset, smemberp);
+                                          outputVarp, offset, smemberp);
                 } else {
                     AstStructSel* structSelp
                         = new AstStructSel{fl, exprp->cloneTree(false), smemberp->name()};
                     structSelp->dtypep(smemberp->childDTypep());
                     if (!structSelp->dtypep()) structSelp->dtypep(smemberp->subDTypep());
-                    randp = newRandStmtsp(fl, structSelp, nullptr);
+                    randp = newRandStmtsp(fl, structSelp, nullptr, outputVarp);
                 }
                 stmtsp = stmtsp ? stmtsp->addNext(randp) : randp;
             }
@@ -1462,23 +1464,25 @@ class RandomizeVisitor final : public VNVisitor {
                 return nullptr;
             }
             AstMemberDType* const firstMemberp = unionDtp->membersp();
-            return newRandStmtsp(fl, exprp, nullptr, offset, firstMemberp);
+            return newRandStmtsp(fl, exprp, nullptr, outputVarp, offset, firstMemberp);
         } else if (AstClassRefDType* const classRefDtp = VN_CAST(memberDtp, ClassRefDType)) {
             AstFunc* const memberFuncp
                 = V3Randomize::newRandomizeFunc(m_memberMap, classRefDtp->classp());
             AstMethodCall* const callp = new AstMethodCall{fl, exprp, "randomize", nullptr};
             callp->taskp(memberFuncp);
             callp->dtypeFrom(memberFuncp);
-            return new AstStmtExpr{fl, callp};
+            return new AstAssign{
+                fl, new AstVarRef{fl, outputVarp, VAccess::WRITE},
+                new AstAnd{fl, new AstVarRef{fl, outputVarp, VAccess::READ}, callp}};
         } else if (AstDynArrayDType* const dynarrayDtp = VN_CAST(memberDtp, DynArrayDType)) {
-            return createArrayForeachLoop(fl, dynarrayDtp, exprp);
+            return createArrayForeachLoop(fl, dynarrayDtp, exprp, outputVarp);
         } else if (AstQueueDType* const queueDtp = VN_CAST(memberDtp, QueueDType)) {
-            return createArrayForeachLoop(fl, queueDtp, exprp);
+            return createArrayForeachLoop(fl, queueDtp, exprp, outputVarp);
         } else if (AstUnpackArrayDType* const unpackarrayDtp
                    = VN_CAST(memberDtp, UnpackArrayDType)) {
-            return createArrayForeachLoop(fl, unpackarrayDtp, exprp);
+            return createArrayForeachLoop(fl, unpackarrayDtp, exprp, outputVarp);
         } else if (AstAssocArrayDType* const assocarrayDtp = VN_CAST(memberDtp, AssocArrayDType)) {
-            return createArrayForeachLoop(fl, assocarrayDtp, exprp);
+            return createArrayForeachLoop(fl, assocarrayDtp, exprp, outputVarp);
         } else {
             AstNodeExpr* valp;
             if (AstEnumDType* const enumDtp = VN_CAST(memberp ? memberp->subDTypep()->subDTypep()
@@ -1684,7 +1688,7 @@ class RandomizeVisitor final : public VNVisitor {
             } else {
                 AstVar* const randcVarp = newRandcVarsp(memberVarp);
                 AstVarRef* const refp = new AstVarRef{fl, classp, memberVarp, VAccess::WRITE};
-                AstNodeStmt* const stmtp = newRandStmtsp(fl, refp, randcVarp);
+                AstNodeStmt* const stmtp = newRandStmtsp(fl, refp, randcVarp, basicFvarp);
                 basicRandomizep->addStmtsp(new AstBegin{fl, "", stmtp});
             }
         });

--- a/src/V3Randomize.cpp
+++ b/src/V3Randomize.cpp
@@ -145,8 +145,14 @@ class RandomizeMarkVisitor final : public VNVisitor {
                 if (!varp) continue;
                 // If member is randomizable and of class type, mark its class
                 if (varp->rand().isRandomizable()) {
-                    if (const AstClassRefDType* const classRefp
-                        = VN_CAST(varp->dtypep()->skipRefp(), ClassRefDType)) {
+                    const AstNodeDType* const varDtypep = varp->dtypep()->skipRefp();
+                    const AstClassRefDType* classRefp = VN_CAST(varDtypep, ClassRefDType);
+                    if (!classRefp) {
+                        const AstNodeDType* subDTypep = varDtypep->subDTypep();
+                        if (subDTypep) subDTypep = subDTypep->skipRefp();
+                        classRefp = VN_CAST(subDTypep, ClassRefDType);
+                    }
+                    if (classRefp) {
                         AstClass* const rclassp = classRefp->classp();
                         if (!rclassp->user1()) {
                             rclassp->user1(IS_RANDOMIZED);

--- a/src/V3Randomize.cpp
+++ b/src/V3Randomize.cpp
@@ -1465,7 +1465,7 @@ class RandomizeVisitor final : public VNVisitor {
             }
             AstMemberDType* const firstMemberp = unionDtp->membersp();
             return newRandStmtsp(fl, exprp, nullptr, outputVarp, offset, firstMemberp);
-        } else if (AstClassRefDType* const classRefDtp = VN_CAST(memberDtp, ClassRefDType)) {
+        } else if (const AstClassRefDType* const classRefDtp = VN_CAST(memberDtp, ClassRefDType)) {
             AstFunc* const memberFuncp
                 = V3Randomize::newRandomizeFunc(m_memberMap, classRefDtp->classp());
             AstMethodCall* const callp = new AstMethodCall{fl, exprp, "randomize", nullptr};

--- a/src/V3Randomize.cpp
+++ b/src/V3Randomize.cpp
@@ -1457,6 +1457,13 @@ class RandomizeVisitor final : public VNVisitor {
             }
             AstMemberDType* const firstMemberp = unionDtp->membersp();
             return newRandStmtsp(fl, exprp, nullptr, offset, firstMemberp);
+        } else if (AstClassRefDType* const classRefDtp = VN_CAST(memberDtp, ClassRefDType)) {
+            AstFunc* const memberFuncp
+                = V3Randomize::newRandomizeFunc(m_memberMap, classRefDtp->classp());
+            AstMethodCall* const callp = new AstMethodCall{fl, exprp, "randomize", nullptr};
+            callp->taskp(memberFuncp);
+            callp->dtypeFrom(memberFuncp);
+            return new AstStmtExpr{fl, callp};
         } else if (AstDynArrayDType* const dynarrayDtp = VN_CAST(memberDtp, DynArrayDType)) {
             return createArrayForeachLoop(fl, dynarrayDtp, exprp);
         } else if (AstQueueDType* const queueDtp = VN_CAST(memberDtp, QueueDType)) {

--- a/test_regress/t/t_constraint_dist.v
+++ b/test_regress/t/t_constraint_dist.v
@@ -8,12 +8,15 @@
 begin \
    longint prev_result; \
    int ok = 0; \
-   for (int i = 0; i < 10; i++) begin \
+   if (!bit'(cl.randomize())) $stop; \
+   prev_result = longint'(field); \
+   if (!(cond)) $stop; \
+   repeat(9) begin \
       longint result; \
       if (!bit'(cl.randomize())) $stop; \
       result = longint'(field); \
       if (!(cond)) $stop; \
-      if (i > 0 && result != prev_result) ok = 1; \
+      if (result != prev_result) ok = 1; \
       prev_result = result; \
    end \
    if (ok != 1) $stop; \

--- a/test_regress/t/t_constraint_foreach.v
+++ b/test_regress/t/t_constraint_foreach.v
@@ -8,12 +8,15 @@
 begin \
    longint prev_result; \
    int ok = 0; \
-   for (int i = 0; i < 10; i++) begin \
+   if (!bit'(cl.randomize())) $stop; \
+   prev_result = longint'(field); \
+   if (!(cond)) $stop; \
+   repeat(9) begin \
       longint result; \
       if (!bit'(cl.randomize())) $stop; \
       result = longint'(field); \
       if (!(cond)) $stop; \
-      if (i > 0 && result != prev_result) ok = 1; \
+      if (result != prev_result) ok = 1; \
       prev_result = result; \
    end \
    if (ok != 1) $stop; \

--- a/test_regress/t/t_constraint_inheritance.v
+++ b/test_regress/t/t_constraint_inheritance.v
@@ -8,12 +8,15 @@
 begin \
    longint prev_result; \
    int ok = 0; \
-   for (int i = 0; i < 10; i++) begin \
+   if (!bit'(cl.randomize())) $stop; \
+   prev_result = longint'(field); \
+   if (!(cond)) $stop; \
+   repeat(9) begin \
       longint result; \
       if (!bit'(cl.randomize())) $stop; \
       result = longint'(field); \
       if (!(cond)) $stop; \
-      if (i > 0 && result != prev_result) ok = 1; \
+      if (result != prev_result) ok = 1; \
       prev_result = result; \
    end \
    if (ok != 1) $stop; \

--- a/test_regress/t/t_constraint_inheritance_with.v
+++ b/test_regress/t/t_constraint_inheritance_with.v
@@ -8,12 +8,15 @@
 begin \
    longint prev_result; \
    int ok = 0; \
-   for (int i = 0; i < 10; i++) begin \
+   if (!bit'(cl.randomize() with { constr; })) $stop; \
+   prev_result = longint'(field); \
+   if (!(cond)) $stop; \
+   repeat(9) begin \
       longint result; \
       if (!bit'(cl.randomize() with { constr; })) $stop; \
       result = longint'(field); \
       if (!(cond)) $stop; \
-      if (i > 0 && result != prev_result) ok = 1; \
+      if (result != prev_result) ok = 1; \
       prev_result = result; \
    end \
    if (ok != 1) $stop; \

--- a/test_regress/t/t_randomize_array.v
+++ b/test_regress/t/t_randomize_array.v
@@ -8,11 +8,13 @@
 begin \
    longint prev_result; \
    int ok = 0; \
-   for (int i = 0; i < 10; i++) begin \
+   void'(cl.randomize()); \
+   prev_result = longint'(field); \
+   repeat(9) begin \
       longint result; \
       void'(cl.randomize()); \
       result = longint'(field); \
-      if (i > 0 && result != prev_result) ok = 1; \
+      if (result != prev_result) ok = 1; \
       prev_result = result; \
    end \
    if (ok != 1) $stop; \

--- a/test_regress/t/t_randomize_array.v
+++ b/test_regress/t/t_randomize_array.v
@@ -63,10 +63,15 @@ class unconstrained_unpacked_array_test;
 
 endclass
 
+class Cls;
+  rand int x = 1;
+endclass
+
 class unconstrained_dynamic_array_test;
 
   rand int dynamic_array_1d[];
   rand int dynamic_array_2d[][];
+  rand Cls class_dynamic_array[];
 
   function new();
     // Initialize 1D dynamic array
@@ -83,6 +88,12 @@ class unconstrained_dynamic_array_test;
         dynamic_array_2d[i][j] = 'h0 + i + j;
       end
     end
+
+    class_dynamic_array = new[5];
+    foreach(class_dynamic_array[i]) begin
+      class_dynamic_array[i] = new;
+    end
+
   endfunction
 
   function void check_randomization();
@@ -93,6 +104,9 @@ class unconstrained_dynamic_array_test;
       foreach (dynamic_array_2d[i][j]) begin
         `check_rand(this, dynamic_array_2d[i][j])
       end
+    end
+    foreach (class_dynamic_array[i]) begin
+      `check_rand(this, class_dynamic_array[i].x)
     end
   endfunction
 

--- a/test_regress/t/t_randomize_array_constraints.v
+++ b/test_regress/t/t_randomize_array_constraints.v
@@ -8,11 +8,13 @@
 begin \
    longint prev_result; \
    int ok = 0; \
-   for (int i = 0; i < 10; i++) begin \
+   void'(cl.randomize()); \
+   prev_result = longint'(field); \
+   repeat(9) begin \
       longint result; \
       void'(cl.randomize()); \
       result = longint'(field); \
-      if (i > 0 && result != prev_result) ok = 1; \
+      if (result != prev_result) ok = 1; \
       prev_result = result; \
    end \
    if (ok != 1) $stop; \

--- a/test_regress/t/t_randomize_method.v
+++ b/test_regress/t/t_randomize_method.v
@@ -8,11 +8,13 @@
 begin \
    longint prev_result; \
    int ok = 0; \
-   for (int i = 0; i < 10; i++) begin \
+   void'(cl.randomize()); \
+   prev_result = longint'(field); \
+   repeat(9) begin \
       longint result; \
       void'(cl.randomize()); \
       result = longint'(field); \
-      if (i > 0 && result != prev_result) ok = 1; \
+      if (result != prev_result) ok = 1; \
       prev_result = result; \
    end \
    if (ok != 1) $stop; \

--- a/test_regress/t/t_randomize_method_with.v
+++ b/test_regress/t/t_randomize_method_with.v
@@ -8,11 +8,13 @@
 begin \
    longint prev_result; \
    int ok = 0; \
-   for (int i = 0; i < 10; i++) begin \
+   void'(cl.randomize()); \
+   prev_result = longint'(field); \
+   repeat(9) begin \
       longint result; \
       void'(cl.randomize()); \
       result = longint'(field); \
-      if (i > 0 && result != prev_result) ok = 1; \
+      if (result != prev_result) ok = 1; \
       prev_result = result; \
    end \
    if (ok != 1) $stop; \

--- a/test_regress/t/t_randomize_queue_constraints.v
+++ b/test_regress/t/t_randomize_queue_constraints.v
@@ -8,12 +8,15 @@
 begin \
    longint prev_result; \
    int ok = 0; \
-   for (int i = 0; i < 10; i++) begin \
+   if (!bit'(cl.randomize())) $stop; \
+   prev_result = longint'(field); \
+   if (!(cond)) $stop; \
+   repeat(9) begin \
       longint result; \
       if (!bit'(cl.randomize())) $stop; \
       result = longint'(field); \
       if (!(cond)) $stop; \
-      if (i > 0 && result != prev_result) ok = 1; \
+      if (result != prev_result) ok = 1; \
       prev_result = result; \
    end \
    if (ok != 1) $stop; \


### PR DESCRIPTION
It fixes https://github.com/verilator/verilator/issues/5557.
It also contains changes from https://github.com/verilator/verilator/pull/5561, because `null pointer dereference` would be thrown otherwise, because we would go beyond array and elements would be `null`.