### PR TITLE
Fix BLKANDNBLK for VARXREFs

### DIFF
--- a/src/V3Unknown.cpp
+++ b/src/V3Unknown.cpp
@@ -127,7 +127,7 @@ class UnknownVisitor final : public VNVisitor {
             AstNodeExpr* const selExprp = prep->cloneTree(true);
             AstNodeExpr* currentExprp = selExprp;
             while (AstNodeExpr* itrSelExprp = VN_AS(currentExprp->op1p(), NodeExpr)) {
-                if (AstVarRef* const selRefp = VN_CAST(itrSelExprp, VarRef)) {
+                if (AstNodeVarRef* const selRefp = VN_CAST(itrSelExprp, NodeVarRef)) {
                     // Mark the variable reference as READ access to avoid assignment issues
                     selRefp->access(VAccess::READ);
                     break;

--- a/test_regress/t/t_array_non_blocking_loop.py
+++ b/test_regress/t/t_array_non_blocking_loop.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2024 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile()
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_array_non_blocking_loop.v
+++ b/test_regress/t/t_array_non_blocking_loop.v
@@ -1,0 +1,38 @@
+// DESCRIPTION: Verilator: Demonstrate struct literal param assignment problem
+//
+// This file ONLY is placed into the Public Domain, for any use,
+// without warranty, 2024 by Wilson Snyder.
+// SPDX-License-Identifier: CC0-1.0
+
+
+interface intf
+  #(
+    parameter int write_data_width) ();
+    logic [write_data_width-1:0] writedata;
+endinterface
+module t( /*AUTOARG*/
+    clk
+);
+
+    input clk;
+    generate
+        genvar num_chunks;
+        for (num_chunks = 1; num_chunks <= 2; num_chunks++) begin : gen_n
+            localparam int decoded_width = 55 * num_chunks;
+                intf #(
+                    .write_data_width(decoded_width))
+                the_intf ();
+                always @(posedge clk) begin
+                    for (int i = 0; i < decoded_width; i++)
+                        the_intf.writedata[i] <= '1;
+                    $display("%0d", the_intf.writedata);
+                end
+        end
+    endgenerate
+
+   // finish report
+   always @ (posedge clk) begin
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end
+endmodule


### PR DESCRIPTION
Without this change the new test gives me the confusing message of:
```
%Error-BLKANDNBLK: t/t_array_non_blocking_loop.v:11:34: Unsupported: Blocked and non-blocking assignments to same variable: 'writedata'                                                                                                                                                                                                                                                                                                  
                                                      : ... note: In instance 't.gen_n[2].the_intf'      
   11 |     logic [write_data_width-1:0] writedata;                                                                                                                                                                                                                                                                                                                                                                                      
      |                                  ^~~~~~~~~                                                                                                                                                                  
                   t/t_array_non_blocking_loop.v:27:43: ... Location of blocking assignment                                                                                                                                                                                                                                                                                                                                              
   27 |                         the_intf.writedata[i] <= '1;                                                                                                                                                        
      |                                           ^                                                                                                                                                                 
                   t/t_array_non_blocking_loop.v:27:43: ... Location of nonblocking assignment                                                                                                                      
   27 |                         the_intf.writedata[i] <= '1;                                                                                                                                                        
      |                                           ^                    
```

The problem (if I understand correctly) is that `replaceBoundLvalue()` was only chasing `VARREF`s through `SEL`s but was not handling `VARXREF`s.