### PR TITLE
Fix --output-groups leftover files issue

### DIFF
--- a/src/V3EmitMk.cpp
+++ b/src/V3EmitMk.cpp
@@ -346,12 +346,14 @@ private:
                     }
                 }
 
-                if (bucket.m_concatenatedFilenames.size() == 1) {
+                bool lastBucketAndLeftovers
+                    = (i + 1 == list.m_bucketsNum) && (fileIt != list.m_files.end());
+                if (bucket.m_concatenatedFilenames.size() > 1 || lastBucketAndLeftovers) {
+                    m_outputFiles.push_back(std::move(bucket));
+                } else if (bucket.m_concatenatedFilenames.size() == 1) {
                     // Unwrap the bucket if it contains only one file.
                     m_outputFiles.push_back(
                         {std::move(bucket.m_concatenatedFilenames.front()), {}});
-                } else if (bucket.m_concatenatedFilenames.size() > 1) {
-                    m_outputFiles.push_back(std::move(bucket));
                 }
                 // Most likely no bucket will be empty in normal situations. If it happen the
                 // bucket will just be dropped.
@@ -359,6 +361,8 @@ private:
             for (; fileIt != list.m_files.end(); ++fileIt) {
                 // The Work List is out of buckets, but some files were left.
                 // Add them to the last bucket.
+                UASSERT(m_outputFiles.back().isConcatenatingFile(),
+                        "Cannot add leftover files to a single file");
                 m_outputFiles.back().m_concatenatedFilenames.push_back(fileIt->m_filename);
             }
         }

--- a/src/V3EmitMk.cpp
+++ b/src/V3EmitMk.cpp
@@ -346,7 +346,7 @@ private:
                     }
                 }
 
-                bool lastBucketAndLeftovers
+                const bool lastBucketAndLeftovers
                     = (i + 1 == list.m_bucketsNum) && (fileIt != list.m_files.end());
                 if (bucket.m_concatenatedFilenames.size() > 1 || lastBucketAndLeftovers) {
                     m_outputFiles.push_back(std::move(bucket));


### PR DESCRIPTION
I was getting asserts from `assertFilesSame()` because this:
```
                // The Work List is out of buckets, but some files were left.
                // Add them to the last bucket.
```
doesn't make sense if the last thing on `m_outputFiles` isn't a concatenated file.  This happens when the last thing to be added to the vector is unwrapped:
```
                    // Unwrap the bucket if it contains only one file.
```

If I just add the assert, it catches the problem for me earlier.  And if I detect that we're going to need to add leftover files and don't unwrap the last bucket then things work for me.

I have no idea how to concoct a test for this which would set up the exact cpp files with the scores needed to demonstrate the problem.  If there's any advice for doing so, please let me know.

cc @mglb 