### PR TITLE
Fix scope identifiers being decoded twice

### DIFF
--- a/src/V3EmitCSyms.cpp
+++ b/src/V3EmitCSyms.cpp
@@ -156,7 +156,6 @@ class EmitCSyms final : EmitCBaseVisitorConst {
     }
 
     static string scopeDecodeIdentifier(const string& scpname) {
-        string out = scpname;
         string::size_type pos = string::npos;
 
         // Remove hierarchy
@@ -172,17 +171,7 @@ class EmitCSyms final : EmitCBaseVisitorConst {
             }
         }
 
-        if (pos != std::string::npos) out.erase(0, pos + 1);
-
-        // Decode all escaped characters
-        while ((pos = out.find("__0")) != string::npos) {
-            unsigned int x;
-            std::stringstream ss;
-            ss << std::hex << out.substr(pos + 3, 2);
-            ss >> x;
-            out.replace(pos, 5, 1, (char)x);
-        }
-        return out;
+        return pos != string::npos ? scpname.substr(pos + 1) : scpname;
     }
 
     /// (scp, m_vpiScopeCandidates, m_scopeNames) -> m_scopeNames

--- a/test_regress/t/t_vpi_escape.cpp
+++ b/test_regress/t/t_vpi_escape.cpp
@@ -135,6 +135,16 @@ int _mon_check_iter() {
         TEST_CHECK_CSTR(p, "<null>");  // Unsupported
     }
 
+    TestVpiHandle vh_null_name = MY_VPI_HANDLE("___0_");
+    TEST_CHECK_NZ(vh_null_name);
+    p = vpi_get_str(vpiName, vh_null_name);
+    TEST_CHECK_CSTR(p, "___0_");
+
+    TestVpiHandle vh_hex_name = MY_VPI_HANDLE("___0F_");
+    TEST_CHECK_NZ(vh_hex_name);
+    p = vpi_get_str(vpiName, vh_hex_name);
+    TEST_CHECK_CSTR(p, "___0F_");
+
     TestVpiHandle vh10 = vpi_iterate(vpiReg, vh2);
     TEST_CHECK_NZ(vh10);
     TEST_CHECK_EQ(vpi_get(vpiType, vh10), vpiIterator);

--- a/test_regress/t/t_vpi_escape.v
+++ b/test_regress/t/t_vpi_escape.v
@@ -63,6 +63,10 @@ extern "C" int mon_check();
 
    sub \mod.with_dot (.cyc(cyc));
 
+   // Check if scope names are not decoded twice
+   sub ___0F_ (.cyc(cyc));
+   sub ___0_ (.cyc(cyc));
+
    initial begin
 
 `ifdef VERILATOR


### PR DESCRIPTION
This PR fixes an issue in V3EmitCSyms phase where scope identifiers were decoded twice, where only one special-character decoding is sufficient.

This bug appears when a scope identifier name has a group of characters that look like encoded character, for instance `__0_`.
Those characters were then decoded twice (by `AstNode::prettyName` and `scopeDecodeIdentifier`) causing VPI name mismatches and, in case of `__0_`, compilation errors:

```cpp
In file included from Vt_vpi_escape__ALL.cpp:10:
./Vt_vpi_escape__Syms.cpp:37:91: error: no viable conversion from 'basic_string<char>' to 'const char *'
   37 |     __Vscope_t__02ehas__02edots_____05F_0_.configure(this, name(), "\\t.has.dots .___0_", "_\000"s, -12, VerilatedScope::SCOPE_MODULE);
      |                                                                                           ^~~~~~~~
../../../include/verilated.h:724:32: note: passing argument to parameter 'identifier' here
  724 |                    const char* identifier, int8_t timeunit, const Type& type) VL_MT_UNSAFE;
      |                                ^
1 error generated.
```

This particular error was caused by [putsQuoted](https://github.com/verilator/verilator/blob/7854118883cdce48124cb92962f9a27626e2345a/src/V3File.cpp#L836) that appended C++14 string literal suffix to the string with null byte character that arose after the second decoding.