### PR TITLE
Support queue's assignment `push_back/push_front('{})` (#5585)

### DIFF
--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -4266,9 +4266,10 @@ class WidthVisitor final : public VNVisitor {
             nodep->dtypep(m_vup->dtypep());
         }
         if (VN_IS(nodep->backp(), Arg) && VN_IS(nodep->backp()->backp(), MethodCall)) {
-            if (nodep->backp()->backp()->name() == "push_back") {
-                AstMethodCall* pushBackCall = static_cast<AstMethodCall*>(nodep->backp()->backp());
-                nodep->dtypep(pushBackCall->fromp()->dtypep()->subDTypep());
+            const std::string methodName = nodep->backp()->backp()->name();
+            if (methodName == "push_back" || methodName == "push_front") {
+                AstMethodCall* methodCallp = static_cast<AstMethodCall*>(nodep->backp()->backp());
+                nodep->dtypep(methodCallp->fromp()->dtypep()->subDTypep());
             }
         }
         AstNodeDType* dtypep = nodep->dtypep();

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -4265,6 +4265,12 @@ class WidthVisitor final : public VNVisitor {
         if (!nodep->dtypep() && m_vup->dtypeNullp()) {  // Get it from parent assignment/pin/etc
             nodep->dtypep(m_vup->dtypep());
         }
+        if(VN_IS( nodep->backp(), Arg) && VN_IS(nodep->backp()->backp() , MethodCall)){
+            if(nodep->backp()->backp()->name()=="push_back"){
+                AstMethodCall* pushBackCall = static_cast<AstMethodCall*>(nodep->backp()->backp());
+                nodep->dtypep(pushBackCall->fromp()->dtypep()->subDTypep());
+            }
+        }
         AstNodeDType* dtypep = nodep->dtypep();
         if (!dtypep) {
             nodep->v3warn(E_UNSUPPORTED, "Unsupported/Illegal: Assignment pattern"

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -4265,8 +4265,8 @@ class WidthVisitor final : public VNVisitor {
         if (!nodep->dtypep() && m_vup->dtypeNullp()) {  // Get it from parent assignment/pin/etc
             nodep->dtypep(m_vup->dtypep());
         }
-        if(VN_IS( nodep->backp(), Arg) && VN_IS(nodep->backp()->backp() , MethodCall)){
-            if(nodep->backp()->backp()->name()=="push_back"){
+        if (VN_IS(nodep->backp(), Arg) && VN_IS(nodep->backp()->backp(), MethodCall)) {
+            if (nodep->backp()->backp()->name() == "push_back") {
                 AstMethodCall* pushBackCall = static_cast<AstMethodCall*>(nodep->backp()->backp());
                 nodep->dtypep(pushBackCall->fromp()->dtypep()->subDTypep());
             }

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -3128,7 +3128,9 @@ class WidthVisitor final : public VNVisitor {
         // Any AstWith is checked later when know types, in methodWithArgument
         for (AstNode* pinp = nodep->pinsp(); pinp; pinp = pinp->nextp()) {
             if (AstArg* const argp = VN_CAST(pinp, Arg)) {
-                if (argp->exprp()) userIterate(argp->exprp(), WidthVP{nodep->fromp()->dtypep()->subDTypep(), BOTH}.p());
+                if (argp->exprp())
+                    userIterate(argp->exprp(),
+                                WidthVP{nodep->fromp()->dtypep()->subDTypep(), BOTH}.p());
             }
         }
         // Find the fromp dtype - should be a class

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -3128,7 +3128,7 @@ class WidthVisitor final : public VNVisitor {
         // Any AstWith is checked later when know types, in methodWithArgument
         for (AstNode* pinp = nodep->pinsp(); pinp; pinp = pinp->nextp()) {
             if (AstArg* const argp = VN_CAST(pinp, Arg)) {
-                if (argp->exprp()) userIterate(argp->exprp(), WidthVP{SELF, BOTH}.p());
+                if (argp->exprp()) userIterate(argp->exprp(), WidthVP{nodep->fromp()->dtypep()->subDTypep(), BOTH}.p());
             }
         }
         // Find the fromp dtype - should be a class
@@ -4264,13 +4264,6 @@ class WidthVisitor final : public VNVisitor {
         }
         if (!nodep->dtypep() && m_vup->dtypeNullp()) {  // Get it from parent assignment/pin/etc
             nodep->dtypep(m_vup->dtypep());
-        }
-        if (VN_IS(nodep->backp(), Arg) && VN_IS(nodep->backp()->backp(), MethodCall)) {
-            const std::string methodName = nodep->backp()->backp()->name();
-            if (methodName == "push_back" || methodName == "push_front") {
-                AstMethodCall* methodCallp = static_cast<AstMethodCall*>(nodep->backp()->backp());
-                nodep->dtypep(methodCallp->fromp()->dtypep()->subDTypep());
-            }
         }
         AstNodeDType* dtypep = nodep->dtypep();
         if (!dtypep) {

--- a/test_regress/t/t_queue_assignment.py
+++ b/test_regress/t/t_queue_assignment.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2024 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile()
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_queue_assignment.v
+++ b/test_regress/t/t_queue_assignment.v
@@ -1,0 +1,41 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2024 by PlanV GmbH.
+// SPDX-License-Identifier: CC0-1.0
+
+module t_queue_assignment;
+    typedef int T_QI[$];
+    T_QI jagged_array[$];   // int jagged_array[$][$];
+    initial begin
+        jagged_array = '{ {1}, T_QI'{2,3,4}, {5,6} };
+        // jagged_array[0][0] = 1 -- jagged_array[0] is a queue of 1 int
+        // jagged_array[1][0] = 2 -- jagged_array[1] is a queue of 3 ints
+        // jagged_array[1][1] = 3
+        // jagged_array[1][2] = 4
+        // jagged_array[2][0] = 5 -- jagged_array[2] is a queue of 2 ints
+        // jagged_array[2][1] = 6
+        jagged_array.push_back('{7});
+        jagged_array.push_back('{8, 9, 10});
+        jagged_array.push_front('{0, 1});
+        print_and_check();
+
+        $write("*-* All Finished *-*\n");
+        $finish;
+    end
+
+    task automatic print_and_check();
+        integer i, j;
+        int expected_values[][] = '{ '{0, 1}, '{1}, '{2, 3, 4}, '{5, 6}, '{7}, '{8, 9, 10} };
+
+        for (i = 0; i < jagged_array.size(); i++) begin
+            for (j = 0; j < jagged_array[i].size(); j++) begin
+                // $display("jagged_array[%0d][%0d] = %0d", i, j, jagged_array[i][j]);
+                if (jagged_array[i][j] !== expected_values[i][j]) begin
+                    $stop;
+                end
+            end
+        end
+    endtask
+
+endmodule


### PR DESCRIPTION
Hi,
This patch supports the missing feature described in #5585 . Thanks for @udayaa-init 's help.

and I added a self-test test for this.