### PR TITLE
Fix `rand` dynamic arrays with null handles

### DIFF
--- a/src/V3Randomize.cpp
+++ b/src/V3Randomize.cpp
@@ -1471,9 +1471,12 @@ class RandomizeVisitor final : public VNVisitor {
             AstMethodCall* const callp = new AstMethodCall{fl, exprp, "randomize", nullptr};
             callp->taskp(memberFuncp);
             callp->dtypeFrom(memberFuncp);
-            return new AstAssign{
+            AstAssign* const assignp = new AstAssign{
                 fl, new AstVarRef{fl, outputVarp, VAccess::WRITE},
                 new AstAnd{fl, new AstVarRef{fl, outputVarp, VAccess::READ}, callp}};
+            return new AstIf{
+                fl, new AstNeq{fl, exprp->cloneTree(false), new AstConst{fl, AstConst::Null{}}},
+                assignp};
         } else if (AstDynArrayDType* const dynarrayDtp = VN_CAST(memberDtp, DynArrayDType)) {
             return createArrayForeachLoop(fl, dynarrayDtp, exprp, outputVarp);
         } else if (AstQueueDType* const queueDtp = VN_CAST(memberDtp, QueueDType)) {

--- a/test_regress/t/t_randomize_array.v
+++ b/test_regress/t/t_randomize_array.v
@@ -72,6 +72,7 @@ class unconstrained_dynamic_array_test;
   rand int dynamic_array_1d[];
   rand int dynamic_array_2d[][];
   rand Cls class_dynamic_array[];
+  rand Cls class_dynamic_array_null[];
 
   function new();
     // Initialize 1D dynamic array
@@ -94,6 +95,8 @@ class unconstrained_dynamic_array_test;
       class_dynamic_array[i] = new;
     end
 
+    class_dynamic_array_null = new[2];
+
   endfunction
 
   function void check_randomization();
@@ -107,6 +110,9 @@ class unconstrained_dynamic_array_test;
     end
     foreach (class_dynamic_array[i]) begin
       `check_rand(this, class_dynamic_array[i].x)
+    end
+    foreach (class_dynamic_array_null[i]) begin
+      if (class_dynamic_array_null[i] != null) $stop;
     end
   endfunction
 


### PR DESCRIPTION
Currently, simulation throws `null pointer dereference` error if `rand` queue contains `null` handles. According to the Standard, `randomize()` should be called only on initialized elements of the queue and `null` values should be omitted. This PR fixes it.