### PR TITLE
Fix `VerilatedContext::randSeed` comments

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -199,6 +199,7 @@ Steven Hugg
 Szymon Gizler
 Sören Tempel
 Teng Huang
+Thomas Manner
 Tim Hutt
 Tim Snyder
 Tobias Rosenkranz

--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -199,7 +199,7 @@ Steven Hugg
 Szymon Gizler
 Sören Tempel
 Teng Huang
-Thomas Manner
+Tom Manner
 Tim Hutt
 Tim Snyder
 Tobias Rosenkranz

--- a/include/verilated.h
+++ b/include/verilated.h
@@ -546,9 +546,9 @@ public:
     /// 1 = Set all bits to one
     /// 2 = Randomize all bits
     void randReset(int val) VL_MT_SAFE;
-    /// Set default random seed, 0 = seed it automatically
-    int randSeed() const VL_MT_SAFE { return m_s.m_randSeed; }
     /// Return default random seed
+    int randSeed() const VL_MT_SAFE { return m_s.m_randSeed; }
+    /// Set default random seed, 0 = seed it automatically
     void randSeed(int val) VL_MT_SAFE;
 
     /// Return statistic: CPU time delta from model created until now


### PR DESCRIPTION
The doc comments explaining the `VerilatedContext::randSeed` functions were above the opposite forms of the function.  This PR swaps them to the correct functions.

I realized after making the edit that I needed to add myself to CONTRIBUTORS.  It is currently two commits, if the project maintainers would prefer a single commit, I can squash them locally and update this branch.  I was a little lazy and made the changes on the web rather than cloning, because I only modified comments.