### PR TITLE
Fix clang_check_attributes TypeError when accessing compilation database

### DIFF
--- a/nodist/clang_check_attributes
+++ b/nodist/clang_check_attributes
@@ -1146,7 +1146,7 @@ def main():
     for refid, file in enumerate(cmdline.file):
         filename = os.path.abspath(file)
         root = default_compilation_root
-        cxxflags = []
+        cxxflags = common_cxxflags[:]
         if compdb:
             entry = compdb.getCompileCommands(filename)
             if entry is None:
@@ -1165,9 +1165,7 @@ def main():
                 # compiler executable name/path. CIndex (libclang) always
                 # implicitly prepends executable name, so it shouldn't be passed
                 # here.
-                cxxflags = common_cxxflags + entry_args[1:]
-        else:
-            cxxflags = common_cxxflags[:]
+                cxxflags.extend(entry_args[1:])
 
         compile_command = CompileCommand(refid, filename, cxxflags, root)
         compile_commands_list.append(compile_command)

--- a/nodist/clang_check_attributes
+++ b/nodist/clang_check_attributes
@@ -38,6 +38,7 @@ else:
         def __getattr__(cls, name: str) -> clang.cindex.CursorKind:
             return getattr(clang.cindex.CursorKind, name)
 
+    # pylint: disable-next=invalid-enum-extension
     class CursorKind(clang.cindex.CursorKind, metaclass=CursorKindMeta):
         pass
 

--- a/nodist/clang_check_attributes
+++ b/nodist/clang_check_attributes
@@ -1149,7 +1149,11 @@ def main():
         cxxflags = []
         if compdb:
             entry = compdb.getCompileCommands(filename)
-            entry_list = list(entry)
+            if entry is None:
+                print(f"%Error: reading compile commands failed: {filename}", file=sys.stderr)
+                entry_list = []
+            else:
+                entry_list = list(entry)
             # Compilation database can contain multiple entries for single file,
             # e.g. when it has been updated by appending new entries.
             # Use last entry for the file, if it exists, as it is the newest one.


### PR DESCRIPTION
Resolves: https://github.com/verilator/verilator/issues/5619.

As the [`getCompileCommands`](https://github.com/llvm/llvm-project/blob/a160e51500ea625b97618d882b97b06367978ea4/clang/tools/libclang/CXCompilationDatabase.cpp#L55) from libclang clang python wrapper may return None type we cannot assume that the entries for the file will present.

I'd added a warning to catch those situations. No error is issued as we would like to continue checks even when some files are missing from the compilation database.

The warning issued for CursorKind is irrelevant when it comes to type checking as this is only for python LSPs to catch types for python-clang library and it is not a part of runtime. I'd disabled this warning only for this line.

@wsnyder Could we add ubuntu-24.10 to the CI workflow?