### PR TITLE
Internals: Decouple Bison class/package symbol table parsing from Link symbol table

### DIFF
--- a/src/V3AstNodeExpr.h
+++ b/src/V3AstNodeExpr.h
@@ -1191,6 +1191,8 @@ class AstDot final : public AstNodeExpr {
     // These are eliminated in the link stage
     // @astgen op1 := lhsp : AstNodeExpr
     // @astgen op2 := rhsp : AstNodeExpr
+    //
+    // We don't have a list of elements as it's probably legal to do '(foo.bar).(baz.bap)'
     const bool m_colon;  // Is a "::" instead of a "." (lhs must be package/class)
 public:
     AstDot(FileLine* fl, bool colon, AstNodeExpr* lhsp, AstNodeExpr* rhsp)

--- a/src/verilog.y
+++ b/src/verilog.y
@@ -7295,12 +7295,12 @@ packageClassScopeItem<nodeExprp>:   // IEEE: package_scope or [package_scope]::[
                 idCC
         /*mid*/         { SYMP->nextId($<scp>1); }
         /*cont*/    yP_COLONCOLON
-                        { $$ = new AstClassOrPackageRef{$<fl>1, *$1, $<scp>1, nullptr}; $<scp>$ = $<scp>1; }
+                        { $$ = new AstClassOrPackageRef{$<fl>1, *$1, nullptr, nullptr}; $<scp>$ = $<scp>1; }
         //
         |       idCC parameter_value_assignmentClass
         /*mid*/         { SYMP->nextId($<scp>1); }   // Change next *after* we handle parameters, not before
         /*cont*/    yP_COLONCOLON
-                        { $$ = new AstClassOrPackageRef{$<fl>1, *$1, $<scp>1, $2}; $<scp>$ = $<scp>1; }
+                        { $$ = new AstClassOrPackageRef{$<fl>1, *$1, nullptr, $2}; $<scp>$ = $<scp>1; }
         ;
 
 dollarUnitNextId<nodeExprp>:    // $unit

--- a/test_regress/t/t_class_mod_bad.out
+++ b/test_regress/t/t_class_mod_bad.out
@@ -1,5 +1,7 @@
-%Error: t/t_class_mod_bad.v:21:7: '::' expected to reference a class/package but referenced 'MODULE 'M''
-                                : ... Suggest '.' instead of '::'
+%Error: t/t_class_mod_bad.v:21:7: Package/class for ':: reference' not found: 'M'
+   21 |       M::Cls p;
+      |       ^
+%Error: t/t_class_mod_bad.v:21:7: Package/class for 'class/package reference' not found: 'M'
    21 |       M::Cls p;
       |       ^
 %Error: Exiting due to

--- a/test_regress/t/t_class_ref_bad.out
+++ b/test_regress/t/t_class_ref_bad.out
@@ -1,4 +1,5 @@
-%Error: Internal Error: t/t_class_ref_bad.v:15:11: ../V3LinkDot.cpp:#: Bad package link
+%Error: t/t_class_ref_bad.v:15:11: Package/class for ':: reference' not found: 'ClsRigh'
+                                 : ... Suggested alternative: 'ClsRight'
    15 |       s = ClsRigh::m_s;   
       |           ^~~~~~~
-                        ... See the manual at https://verilator.org/verilator_doc.html for more assistance.
+%Error: Exiting due to


### PR DESCRIPTION
Both Bison and V3LinkDot have symbol tables.  Previously the Bison symbol table passes the resolved class/packages but nothing else into the Ast which V3LinkDot required to resolve some, but not parameterized classes.  This change decouples this, making V3LinkDot less sensitive to parsing, and also moves towards some later parser enhancements.

This was not intended to break any existing code that previously was legal and parsed correctly, but some errors have changed.  This was difficult to get passing on the regressions, so there may be edge cases needing cleanup - once merged, file a new bug if so.

