### PR TITLE
Fix public + interfaces

### DIFF
--- a/test_regress/t/t_public_interface.py
+++ b/test_regress/t/t_public_interface.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2024 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile()
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_public_interface.v
+++ b/test_regress/t/t_public_interface.v
@@ -1,0 +1,31 @@
+// DESCRIPTION: Verilator: SystemVerilog interface test module
+//
+// This file ONLY is placed into the Public Domain, for any use,
+// without warranty, 2012 by Iztok Jeras.
+// SPDX-License-Identifier: CC0-1.0
+
+interface intf
+    (input wire clk,
+     input wire rst);
+    modport intf_modp (input clk, rst);
+endinterface
+
+module sub
+/*verilator public_on*/
+   (intf.intf_modp intf_port);
+
+   // finish report
+   always @ (posedge intf_port.clk) begin
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end
+/*verilator public_off*/
+endmodule
+
+module t
+    (clk);
+    input clk   /*verilator public*/ ;
+    logic rst;
+    intf the_intf (.clk, .rst);
+    sub the_sub (.intf_port (the_intf));
+endmodule


### PR DESCRIPTION
@wsnyder I don't yet understand how, but f58aee2 appears to have broken a lot of our interface based code.  More specifically, Verilator is producing broken C++:
```
In file included from Vt_public_interface__ALL.cpp:18:
Vt_public_interface__Syms.cpp: In constructor âVt_public_interface__Syms::Vt_public_interface__Syms(VerilatedContext*, const char*, Vt_public_interface*)â:
Vt_public_interface__Syms.cpp:48:79: error: âclass Vt_public_interface_subâ has no member named âintf_portâ
   48 |         __Vscope_t__the_sub.varInsert(__Vfinal,"intf_port", &(TOP__t__the_sub.intf_port), false, VLVT_UINT8,VLVD_NODIR|VLVF_PUB_RW,0);
      |                                                                               ^~~~~~~~~
```

I'm not sure what the end goal of that commit is, but can it be reverted for now until this can be fixed?  Or could you suggest how to approach a fix?  I haven't looked very closely at this failure yet.