### PR TITLE
Fix interface and struct pattern collision (#5640)

### DIFF
--- a/src/V3LinkDot.cpp
+++ b/src/V3LinkDot.cpp
@@ -2760,9 +2760,11 @@ class LinkDotResolveVisitor final : public VNVisitor {
             // Lookup
             if (VSymEnt* const foundp = m_curSymp->findIdFallback(textp->text())) {
                 if (AstVar* const varp = VN_CAST(foundp->nodep(), Var)) {
-                    // Attach found Text reference to PatMember
-                    nodep->varrefp(new AstVarRef{nodep->fileline(), varp, VAccess::READ});
-                    UINFO(9, indent() << " new " << nodep->varrefp() << endl);
+                    if (varp->isParam() || varp->isGenVar()) {
+                        // Attach found Text reference to PatMember
+                        nodep->varrefp(new AstVarRef{nodep->fileline(), varp, VAccess::READ});
+                        UINFO(9, indent() << " new " << nodep->varrefp() << endl);
+                    }
                 }
             }
         }

--- a/src/V3LinkDot.cpp
+++ b/src/V3LinkDot.cpp
@@ -2766,6 +2766,12 @@ class LinkDotResolveVisitor final : public VNVisitor {
                         UINFO(9, indent() << " new " << nodep->varrefp() << endl);
                     }
                 }
+                if (AstEnumItem* const itemp = VN_CAST(foundp->nodep(), EnumItem)) {
+                    // Attach enum item value to PatMember
+                    nodep->varrefp(
+                        new AstEnumItemRef{nodep->fileline(), itemp, foundp->classOrPackagep()});
+                    UINFO(9, indent() << " new " << itemp << endl);
+                }
             }
         }
         iterateChildren(nodep);

--- a/test_regress/t/t_interface_and_struct_pattern.py
+++ b/test_regress/t/t_interface_and_struct_pattern.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2024 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile()
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_interface_and_struct_pattern.v
+++ b/test_regress/t/t_interface_and_struct_pattern.v
@@ -1,0 +1,59 @@
+// DESCRIPTION: Verilator: SystemVerilog interface test module
+//
+// This file ONLY is placed into the Public Domain, for any use,
+// without warranty, 2012 by Iztok Jeras.
+// SPDX-License-Identifier: CC0-1.0
+
+package Package_pkg;
+    typedef struct packed {
+        int bar;
+        int baz;
+    } pkg_struct_t;
+endpackage
+
+interface intf
+  #(parameter type data_type = bit)
+    (input wire clk,
+     input wire rst);
+    data_type data;
+    modport source (
+        input clk, rst,
+        output data
+    );
+endinterface
+
+module sub (
+    intf.source bar,
+    input clk,
+    input rst);
+
+    typedef struct packed {
+        int foo;
+        int baz;
+    } struct_t;
+
+    intf #(.data_type(struct_t)) the_intf (.*);
+
+    Package_pkg::pkg_struct_t output_bar = Package_pkg::pkg_struct_t'{
+        bar: the_intf.data.foo,
+        baz: the_intf.data.baz
+    };
+endmodule
+
+module t(clk);
+    input clk;
+     logic rst;
+
+    intf bar (.*);
+    sub the_sub (
+        .bar(bar),
+        .clk,
+        .rst
+    );
+
+   // finish report
+   always @ (posedge clk) begin
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end
+endmodule

--- a/test_regress/t/t_param_pattern_init.v
+++ b/test_regress/t/t_param_pattern_init.v
@@ -7,7 +7,13 @@
 `define stop $stop
 `define checkh(gotv,expv) do if ((gotv) !== (expv)) begin $write("%%Error: %s:%0d:  got='h%x exp='h%x\n", `__FILE__,`__LINE__, (gotv), (expv)); `stop; end while(0);
 
-module t (/*AUTOARG*/);
+module t (/*AUTOARG*/
+    // Inputs
+    clk
+    );
+
+    input clk;
+    int cyc = 0;
 
    localparam int unsigned SPI_INDEX = 0;
    localparam int unsigned I2C_INDEX = 1;
@@ -26,8 +32,49 @@ module t (/*AUTOARG*/);
       `checkh(AHB_ADDR[3], 32'h0);
       `checkh(AHB_ADDR[4], 32'h80003000);
       `checkh(AHB_ADDR[5], 32'h0);
-      $write("*-* All Finished *-*\n");
-      $finish;
+   end
+
+   genvar genvar_i;
+   for (genvar_i = 0; genvar_i < 2; genvar_i++) begin: the_gen
+       logic [31:0] gen_array [10];
+
+       always_comb gen_array = '{
+           genvar_i: 32'habcd,
+           default: 0
+       };
+
+       always_ff @(posedge clk) begin
+           `checkh(gen_array[genvar_i], 32'habcd);
+       end
+   end
+
+   typedef enum int {
+       ENUM_A = 0,
+       ENUM_B,
+       ENUM_C
+   } enum_t;
+
+   logic [31:0] enum_array [11];
+
+   always_comb enum_array = '{
+       ENUM_A: 32'h1234,
+       ENUM_B: 32'h7777,
+       ENUM_C: 32'ha5a5,
+       default: 0
+    };
+
+    always_ff @(posedge clk) begin
+        `checkh(enum_array[0], 32'h1234);
+        `checkh(enum_array[1], 32'h7777);
+        `checkh(enum_array[2], 32'ha5a5);
+    end
+
+   always_ff @(posedge clk) begin
+       cyc <= cyc + 1;
+      if (cyc == 2) begin
+          $write("*-* All Finished *-*\n");
+          $finish;
+      end
    end
 
 endmodule


### PR DESCRIPTION
#5596 causes internal errors when there is a collision between struct field names and other identifiers (in this case an interface).  `t_interface_and_struct_pattern.py` demonstrates the problem:
```
%Error: Internal Error: t/t_interface_and_struct_pattern.v:38:23: ../V3Width.cpp:2318: Unlinked varref
                                                                : ... note: In instance 't.the_sub'
   38 |         bar: the_intf.data.foo,
      |                       ^~~~
```

`A.6.7.1` says:
```
array_pattern_key ::= constant_expression | assignment_pattern_key
```

So I believe my change is needed to enforce the constness.

@gregdavill I think this is necessary, but you may want to test this against your use case to make sure I haven't broken you.  However, the test from #5596 is still working.

@wsnyder I first tried to solve this with `AstVar::isConst()` but then I noticed this:
```
(rr) p AstNode::dumpGdb(varp)
This=VAR 0x555556eedd40 back=0x555556eede60 next=0x555557004000 headtail=0x55555700f290 op1p=0x555556f7b980 op3p=0x555556f7ca50 user1p=0x555556f80cf0
  Fileline = t/t_param_pattern_init.v:12:28: 
  VAR 0x555556eedd40 <e609> {f12bc} u1=0x555556f80cf0 @dt=0@  SPI_INDEX [VSTATIC]  LPARAM
$4 = void
(rr) p varp->m_isConst 
$5 = false
(rr) p varp->m_varType 
$6 = {m_e = VVarType::LPARAM}
```
which seems counterintuitive to me.  Why is a localparam not `isConst()`?

Also, you mentioned in #5631 about creating an issue and a PR.  I'm not quite sure if I understand the implementation details here.  Can you elaborate on what the right workflow is?  AKA, where should the main conversation be?  I the issue or in the PR?

Regardless, I'll open an issue in a minute which points at this guy.