### PR TITLE
Fix scoped array assignment literals

### DIFF
--- a/test_regress/t/t_param_pattern_init.v
+++ b/test_regress/t/t_param_pattern_init.v
@@ -7,6 +7,11 @@
 `define stop $stop
 `define checkh(gotv,expv) do if ((gotv) !== (expv)) begin $write("%%Error: %s:%0d:  got='h%x exp='h%x\n", `__FILE__,`__LINE__, (gotv), (expv)); `stop; end while(0);
 
+package some_pkg;
+    localparam FOO = 5;
+    localparam BAR = 6;
+endpackage
+
 module t (/*AUTOARG*/
     // Inputs
     clk
@@ -67,6 +72,20 @@ module t (/*AUTOARG*/
         `checkh(enum_array[0], 32'h1234);
         `checkh(enum_array[1], 32'h7777);
         `checkh(enum_array[2], 32'ha5a5);
+    end
+
+    logic [31:0] package_array [7];
+
+    import some_pkg::BAR;
+    always_comb package_array = '{
+        some_pkg::FOO: 32'h9876,
+        BAR: 32'h1212,
+        default: 0
+    };
+
+    always_ff @(posedge clk) begin
+        `checkh(package_array[5], 32'h9876);
+        `checkh(package_array[6], 32'h1212);
     end
 
    always_ff @(posedge clk) begin


### PR DESCRIPTION
One more thing since we're looking at assignment literals.  Using an `array_pattern_key` that is not in the current scope does not currently work because the `LinkDotResolveVisitor::visit(AstPatMember*)` logic assumes it can create a `AstVarRef` from the `TEXT` it's given.  I added some additional checks to `t_param_pattern_init` to demonstrate this.  I see at least two problems here.

The first is that we cannot currently parse a pattern key with a scope:
```
%Error: t/t_param_pattern_init.v:81:22: syntax error, unexpected ':', expecting ',' or '}'
   81 |         some_pkg::FOO: 32'h9876,
      |                      ^
```

I tried some things along these lines, but bison was having none of it:
```
--- a/src/verilog.y
+++ b/src/verilog.y
@@ -4028,6 +4028,8 @@ patternKey<nodep>:              // IEEE: merge structure_pattern_key, array_patt
                         { $$ = new AstConst{$<fl>1, AstConst::RealDouble{}, $1}; }
         |       id
                         { $$ = new AstText{$<fl>1, *$1}; }
+        |       scopedIdentifier
+                        { $$ = new AstText{$<fl>1, *$1}; }
         |       strAsInt
                         { $$ = $1; }
         |       simple_typeNoRef
@@ -4039,6 +4041,11 @@ patternKey<nodep>:              // IEEE: merge structure_pattern_key, array_patt
                           $$ = refp; }
         ;
 
+scopedIdentifier<string>:
+        packageClassScopeE id
+            { $$ = new string($1 + *$2); }
+        ;
+
```

But then problem number two is that even if we do explicitly import from the package so that we don't need the scope in the pattern, we need an `AstVarXRef` instead.  I think all the information is there to create one:
```
2763                        if (varp->isParam() || varp->isGenVar()) {
(rr) p varp->m_name
$18 = {static npos = <optimized out>, _M_dataplus = {<std::allocator<char>> = {<__gnu_cxx::new_allocator<char>> = {<No data fields>}, <No data fields>}, _M_p = 0x55555700a0b0 "BAR"}, _M_string_length = 3, {_M_local_buf = "BAR", '\000' <repeats 12 times>, _M_allocated_capacity = 5390658}}
(rr) p foundp->m_imported 
$19 = true
(rr) p foundp->m_classOrPackagep 
$20 = (AstNodeModule *) 0x555556eedd40
(rr) p foundp->m_classOrPackagep->m_name 
$21 = {static npos = <optimized out>, _M_dataplus = {<std::allocator<char>> = {<__gnu_cxx::new_allocator<char>> = {<No data fields>}, <No data fields>}, _M_p = 0x555556eeddf0 "some_pkg"}, _M_string_length = 8, {_M_local_buf = "some_pkg\000\000\000\000\000\000\000", _M_allocated_capacity = 7452173563440492403}}
```

However, the problem is that, in this case, the package is gone from the AST by the time we get to this point (presumably because it has no other references):
```
%Error: Internal Error: t/t_param_pattern_init.v:82:9: ../V3Broken.cpp:168: Broken link in node (or something without maybePointedTo): 'm_varp && !m_varp->brokeExists()' @ ./V3Ast__gen_impl.h:4717
                                                     : ... note: In instance 't'
   82 |         BAR: 32'h1212,
      |         ^~~
```

Questions:

- Is my parsing change going in the right direction?  AKA, do we just want `some_pkg::FOO` in a `TEXT` here?
- Is there a way to defer pruning the package so that we can make the `AstVarXRef` when evaluating the pattern members?