### PR TITLE
Demonstrate unsupported scoped pattern array init (#5653)

### DIFF
--- a/test_regress/t/t_scoped_param_pattern_init_unsup.out
+++ b/test_regress/t/t_scoped_param_pattern_init_unsup.out
@@ -1,0 +1,4 @@
+%Error: t/t_scoped_param_pattern_init_unsup.v:30:22: syntax error, unexpected ':', expecting ',' or '}'
+   30 |         some_pkg::FOO: 32'h9876,
+      |                      ^
+%Error: Exiting due to

--- a/test_regress/t/t_scoped_param_pattern_init_unsup.py
+++ b/test_regress/t/t_scoped_param_pattern_init_unsup.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2024 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.lint(fails=True, expect_filename=test.golden_filename)
+
+test.passes()

--- a/test_regress/t/t_scoped_param_pattern_init_unsup.v
+++ b/test_regress/t/t_scoped_param_pattern_init_unsup.v
@@ -1,0 +1,50 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2010 by Wilson Snyder.
+// SPDX-License-Identifier: CC0-1.0
+
+`define stop $stop
+`define checkh(gotv,expv) do if ((gotv) !== (expv)) begin $write("%%Error: %s:%0d:  got='h%x exp='h%x\n", `__FILE__,`__LINE__, (gotv), (expv)); `stop; end while(0);
+
+package some_pkg;
+    localparam FOO = 5;
+    localparam BAR = 6;
+
+    typedef enum int {
+        QUX = 7
+    } pkg_enum_t;
+endpackage
+
+module t (/*AUTOARG*/
+    // Inputs
+    clk
+    );
+
+    input clk;
+    int cyc = 0;
+
+    logic [31:0] package_array [8];
+
+    always_comb package_array = '{
+        some_pkg::FOO: 32'h9876,
+        some_pkg::BAR: 32'h1212,
+        some_pkg::QUX: 32'h5432,
+        default: 0
+    };
+
+    always_ff @(posedge clk) begin
+        `checkh(package_array[5], 32'h9876);
+        `checkh(package_array[6], 32'h1212);
+        `checkh(package_array[7], 32'h5432);
+    end
+
+   always_ff @(posedge clk) begin
+       cyc <= cyc + 1;
+      if (cyc == 2) begin
+          $write("*-* All Finished *-*\n");
+          $finish;
+      end
+   end
+
+endmodule


### PR DESCRIPTION
As discussed in #5641, array init assignment pattern keys which are scoped do not currently work.  @wsnyder is working on a parser update which will make implementing this more viable.  For now, this just demonstrates the unsupported language feature.