### PR TITLE
Fix error on duplicated declaration of gen block

### DIFF
--- a/src/V3LinkDot.cpp
+++ b/src/V3LinkDot.cpp
@@ -280,7 +280,7 @@ public:
         } else if (foundp->imported()) {  // From package
             // We don't throw VARHIDDEN as if the import is later the symbol
             // table's import wouldn't warn
-        } else if (VN_IS(nodep, Begin) && VN_IS(fnodep, Begin)
+        } else if (forPrimary() && VN_IS(nodep, Begin) && VN_IS(fnodep, Begin)
                    && VN_AS(nodep, Begin)->generate()) {
             // Begin: ... blocks often replicate under genif/genfor, so
             // suppress duplicate checks.  See t_gen_forif.v for an example.

--- a/test_regress/t/t_duplicated_gen_blocks_bad.out
+++ b/test_regress/t/t_duplicated_gen_blocks_bad.out
@@ -1,0 +1,15 @@
+%Error: t/t_duplicated_gen_blocks_bad.v:11:12: Duplicate declaration of block: 'block'
+                                             : ... note: In instance 't'
+   11 |    begin : block
+      |            ^~~~~
+        t/t_duplicated_gen_blocks_bad.v:9:12: ... Location of original declaration
+    9 |    begin : block
+      |            ^~~~~
+%Error: t/t_duplicated_gen_blocks_bad.v:15:23: Duplicate declaration of block: 'block1'
+                                             : ... note: In instance 't'
+   15 |    if (X > 1) begin : block1
+      |                       ^~~~~~
+        t/t_duplicated_gen_blocks_bad.v:13:23: ... Location of original declaration
+   13 |    if (X > 0) begin : block1
+      |                       ^~~~~~
+%Error: Exiting due to

--- a/test_regress/t/t_duplicated_gen_blocks_bad.py
+++ b/test_regress/t/t_duplicated_gen_blocks_bad.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2024 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('linter')
+
+test.lint(fails=True, expect_filename=test.golden_filename)
+
+test.passes()

--- a/test_regress/t/t_duplicated_gen_blocks_bad.v
+++ b/test_regress/t/t_duplicated_gen_blocks_bad.v
@@ -1,0 +1,17 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2024 by Antmicro.
+// SPDX-License-Identifier: CC0-1.0
+
+module t (/*AUTOARG*/);
+   parameter X = 2;
+   begin : block
+   end
+   begin : block
+   end
+   if (X > 0) begin : block1
+   end
+   if (X > 1) begin : block1
+   end
+endmodule


### PR DESCRIPTION
Generate blocks were skipped in the duplication checking. This PR enables the checking on them after the V3Param stage, when we know which blocks are kept.