### PR TITLE
Fix interface bracketed array parameter access (#5678)

### DIFF
--- a/src/V3Param.cpp
+++ b/src/V3Param.cpp
@@ -1249,18 +1249,20 @@ class ParamVisitor final : public VNVisitor {
                     UINFO(9, "Hit module boundary, done looking for interface" << endl);
                     break;
                 }
-                if (const auto* const varp = VN_CAST(backp, Var)) {
+                if (const AstVar* const varp = VN_CAST(backp, Var)) {
                     if (!varp->isIfaceRef()) { continue; }
                     const AstIfaceRefDType* ifacerefp = nullptr;
-                    if (const auto* const typep = varp->childDTypep()) {
+                    if (const AstNodeDType* const typep = varp->childDTypep()) {
                         ifacerefp = VN_CAST(typep, IfaceRefDType);
                         if (!ifacerefp) {
-                            if (const auto* const unpackp = VN_CAST(typep, UnpackArrayDType)) {
+                            if (const AstUnpackArrayDType* const unpackp
+                                = VN_CAST(typep, UnpackArrayDType)) {
                                 ifacerefp = VN_CAST(typep->getChildDTypep(), IfaceRefDType);
                             }
                         }
                         if (!ifacerefp) {
-                            if (const auto* const unpackp = VN_CAST(typep, BracketArrayDType)) {
+                            if (const AstBracketArrayDType* const unpackp
+                                = VN_CAST(typep, BracketArrayDType)) {
                                 ifacerefp = VN_CAST(typep->subDTypep(), IfaceRefDType);
                             }
                         }

--- a/src/V3Param.cpp
+++ b/src/V3Param.cpp
@@ -1249,18 +1249,23 @@ class ParamVisitor final : public VNVisitor {
                     UINFO(9, "Hit module boundary, done looking for interface" << endl);
                     break;
                 }
-                if (VN_IS(backp, Var) && VN_AS(backp, Var)->isIfaceRef()
-                    && VN_AS(backp, Var)->childDTypep()
-                    && (VN_CAST(VN_CAST(backp, Var)->childDTypep(), IfaceRefDType)
-                        || (VN_CAST(VN_CAST(backp, Var)->childDTypep(), UnpackArrayDType)
-                            && VN_CAST(VN_CAST(backp, Var)->childDTypep()->getChildDTypep(),
-                                       IfaceRefDType)))) {
-                    const AstIfaceRefDType* ifacerefp
-                        = VN_CAST(VN_CAST(backp, Var)->childDTypep(), IfaceRefDType);
-                    if (!ifacerefp) {
-                        ifacerefp = VN_CAST(VN_CAST(backp, Var)->childDTypep()->getChildDTypep(),
-                                            IfaceRefDType);
+                if (const auto* const varp = VN_CAST(backp, Var)) {
+                    if (!varp->isIfaceRef()) { continue; }
+                    const AstIfaceRefDType* ifacerefp = nullptr;
+                    if (const auto* const typep = varp->childDTypep()) {
+                        ifacerefp = VN_CAST(typep, IfaceRefDType);
+                        if (!ifacerefp) {
+                            if (const auto* const unpackp = VN_CAST(typep, UnpackArrayDType)) {
+                                ifacerefp = VN_CAST(typep->getChildDTypep(), IfaceRefDType);
+                            }
+                        }
+                        if (!ifacerefp) {
+                            if (const auto* const unpackp = VN_CAST(typep, BracketArrayDType)) {
+                                ifacerefp = VN_CAST(typep->subDTypep(), IfaceRefDType);
+                            }
+                        }
                     }
+                    if (!ifacerefp) { continue; }
                     // Interfaces passed in on the port map have ifaces
                     if (const AstIface* const ifacep = ifacerefp->ifacep()) {
                         if (dotted == backp->name()) {

--- a/test_regress/t/t_interface_array_parameter_access.py
+++ b/test_regress/t/t_interface_array_parameter_access.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2024 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile()
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_interface_array_parameter_access.v
+++ b/test_regress/t/t_interface_array_parameter_access.v
@@ -1,0 +1,39 @@
+// DESCRIPTION: Verilator: Get parameter from array of interfaces
+//
+// This file ONLY is placed into the Public Domain, for any use,
+// without warranty, 2024 by Todd Strader
+// SPDX-License-Identifier: CC0-1.0
+
+interface intf
+  #(parameter int FOO = 4)
+    (input wire clk,
+     input wire rst);
+    modport modp (input  clk, rst);
+endinterface
+
+module sub (intf.modp the_intf_port [4]);
+    localparam int intf_foo = the_intf_port[0].FOO;
+
+    initial begin
+        if (intf_foo != 4) $stop;
+    end
+endmodule
+
+module t (
+    clk
+);
+    logic rst;
+    input clk;
+
+    intf the_intf [4] (.*);
+
+    sub
+    the_sub (
+        .the_intf_port   (the_intf)
+    );
+
+   always @(posedge clk) begin
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end
+endmodule


### PR DESCRIPTION
Accessing parameters from unpacked arrays of interfaces (`[1:0]`) worked, but bracketed arrays (`[2]`) was broken and would say:
```
%Error: t/t_interface_array_parameter_access.v:15:48: Parameter-resolved constants must not use dotted references: 'FOO'                                                                                                                                                                                                                                                                                                                 
                                                    : ... note: In instance 't.the_sub'                                                                                                                                                                                                                                                                                                                                                  
   15 |     localparam int intf_foo = the_intf_port[0].FOO;                                                                                                                                                                                                                                                                                                                                                                              
      |                                                ^~~                                                                                                                                                                                                                                                                                                                                                                               
```

I added `t_interface_array_parameter_access` to catch this and fixed up `ParamVisitor::visit(AstVarXRef*)`.