### PR TITLE
Add lint error on importing package within a class (#5634)

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -158,6 +158,7 @@ Nandu Raj
 Nathan Graybeal
 Nathan Kohagen
 Nathan Myers
+Nick Brereton
 Nolan Poe
 Oleh Maksymenko
 Patrick Stewart

--- a/src/V3LinkParse.cpp
+++ b/src/V3LinkParse.cpp
@@ -896,10 +896,11 @@ class LinkParseVisitor final : public VNVisitor {
         iterateChildren(nodep);
     }
     void visit(AstPackageImport* nodep) override {
-	if (m_modp && !m_ftaskp && VN_IS(m_modp, Class)) {
-	    nodep->v3error("Import statement directly within a class scope is illegal");
-	}
-	iterateChildren(nodep);
+        cleanFileline(nodep);
+        if (m_modp && !m_ftaskp && VN_IS(m_modp, Class)) {
+            nodep->v3error("Import statement directly within a class scope is illegal");
+        }
+        iterateChildren(nodep);
     }
 
     void visit(AstNode* nodep) override {

--- a/src/V3LinkParse.cpp
+++ b/src/V3LinkParse.cpp
@@ -895,12 +895,9 @@ class LinkParseVisitor final : public VNVisitor {
         }
         iterateChildren(nodep);
     }
-    void visit(AstClass* nodep) override {
-	cleanFileline(nodep);
-	for (AstNode* itemp = nodep->stmtsp(); itemp; itemp = itemp->nextp()) {
-	    if (VN_IS(itemp, PackageImport)) {
-		itemp->v3error("Import statement directly within a class scope is illegal");
-	    }
+    void visit(AstPackageImport* nodep) {
+	if (m_modp && !m_ftaskp && VN_IS(m_modp, Class)) {
+	    nodep->v3error("Import statement directly within a class scope is illegal");
 	}
 	iterateChildren(nodep);
     }

--- a/src/V3LinkParse.cpp
+++ b/src/V3LinkParse.cpp
@@ -895,7 +895,7 @@ class LinkParseVisitor final : public VNVisitor {
         }
         iterateChildren(nodep);
     }
-    void visit(AstPackageImport* nodep) {
+    void visit(AstPackageImport* nodep) override {
 	if (m_modp && !m_ftaskp && VN_IS(m_modp, Class)) {
 	    nodep->v3error("Import statement directly within a class scope is illegal");
 	}

--- a/src/V3LinkParse.cpp
+++ b/src/V3LinkParse.cpp
@@ -895,6 +895,15 @@ class LinkParseVisitor final : public VNVisitor {
         }
         iterateChildren(nodep);
     }
+    void visit(AstClass* nodep) override {
+	cleanFileline(nodep);
+	for (AstNode* itemp = nodep->stmtsp(); itemp; itemp = itemp->nextp()) {
+	    if (VN_IS(itemp, PackageImport)) {
+		itemp->v3error("Import statement directly within a class scope is illegal");
+	    }
+	}
+	iterateChildren(nodep);
+    }
 
     void visit(AstNode* nodep) override {
         // Default: Just iterate

--- a/test_regress/t/t_class_scope_import.out
+++ b/test_regress/t/t_class_scope_import.out
@@ -1,0 +1,4 @@
+%Error: t/t_class_scope_import.v:11:14: Import statement directly within a class scope is illegal
+   11 |    import pkg::*;
+      |              ^~
+%Error: Exiting due to

--- a/test_regress/t/t_class_scope_import.py
+++ b/test_regress/t/t_class_scope_import.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2024 by Nick Brereton. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('linter')
+
+test.lint(fails=True, expect_filename=test.golden_filename)
+
+test.passes()

--- a/test_regress/t/t_class_scope_import.py
+++ b/test_regress/t/t_class_scope_import.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # DESCRIPTION: Verilator: Verilog Test driver/expect definition
 #
-# Copyright 2024 by Nick Brereton. This program is free software; you
+# Copyright 2025 by Wilson Snyder. This program is free software; you
 # can redistribute it and/or modify it under the terms of either the GNU
 # Lesser General Public License Version 3 or the Perl Artistic License
 # Version 2.0.

--- a/test_regress/t/t_class_scope_import.v
+++ b/test_regress/t/t_class_scope_import.v
@@ -1,7 +1,7 @@
 // DESCRIPTION: Verilator: Verilog Test module
 //
 // This file ONLY is placed under the Creative Commons Public Domain, for
-// any use, without warranty, 2023 by Nick Brereton
+// any use, without warranty, 2025 by Wilson Snyder
 // SPDX-License-Identifier: CC0-1.0
 
 package pkg;

--- a/test_regress/t/t_class_scope_import.v
+++ b/test_regress/t/t_class_scope_import.v
@@ -1,0 +1,15 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2023 by Nick Brereton
+// SPDX-License-Identifier: CC0-1.0
+
+package pkg;
+endpackage
+
+class genericClass;
+   import pkg::*;
+endclass
+
+module tb_top();
+endmodule

--- a/test_regress/t/t_queue_unknown_sel.v
+++ b/test_regress/t/t_queue_unknown_sel.v
@@ -261,27 +261,29 @@ interface z_if;
                      import x6_trig
                      );
 endinterface
-class z_txn_class;
+package c_pkg;
    import z_pkg::*;
-   rand txn_type_t   req_txn_type;
-   rand cid_t        cid;
-   rand sid_t        sid;
-   rand ctag_t       ctag;
-   rand stag_t       stag;
-   rand size_t       size;
-   rand address_t    address;
-   rand state_t   state1;
-   rand state_t   state2;
-   rand state_t   state3;
-   rand logic               f1;
-   rand logic               f2;
-   rand logic               f3;
-   rand logic               f4;
-   data_t            data[];
-   mask_t            mask[];
-   bit                      corrupt[];
-   logic [2:0]              req_opcode;
-endclass
+   class z_txn_class;
+      rand txn_type_t   req_txn_type;
+      rand cid_t        cid;
+      rand sid_t        sid;
+      rand ctag_t       ctag;
+      rand stag_t       stag;
+      rand size_t       size;
+      rand address_t    address;
+      rand state_t   state1;
+      rand state_t   state2;
+      rand state_t   state3;
+      rand logic               f1;
+      rand logic               f2;
+      rand logic               f3;
+      rand logic               f4;
+      data_t            data[];
+      mask_t            mask[];
+      bit                      corrupt[];
+      logic [2:0]              req_opcode;
+   endclass
+endpackage
 module z_bfm_sender import z_pkg::*;
    (
     input logic clk,
@@ -289,9 +291,9 @@ module z_bfm_sender import z_pkg::*;
     z_if.sender z_if_sender
     );
    channel_t ch;
-   typedef z_txn_class z_txn_q_t[$];
+   typedef c_pkg::z_txn_class z_txn_q_t[$];
    z_txn_q_t z_txn_qs[ch.num()];
-   z_txn_class z_txn[ch.num()];
+   c_pkg::z_txn_class z_txn[ch.num()];
    always @(posedge clk or negedge reset_l) begin
       if (!reset_l) begin
          z_if_sender.x1_valid <= '0;

--- a/test_regress/t/t_queue_unknown_sel.v
+++ b/test_regress/t/t_queue_unknown_sel.v
@@ -261,29 +261,26 @@ interface z_if;
                      import x6_trig
                      );
 endinterface
-package c_pkg;
-   import z_pkg::*;
-   class z_txn_class;
-      rand txn_type_t   req_txn_type;
-      rand cid_t        cid;
-      rand sid_t        sid;
-      rand ctag_t       ctag;
-      rand stag_t       stag;
-      rand size_t       size;
-      rand address_t    address;
-      rand state_t   state1;
-      rand state_t   state2;
-      rand state_t   state3;
-      rand logic               f1;
-      rand logic               f2;
-      rand logic               f3;
-      rand logic               f4;
-      data_t            data[];
-      mask_t            mask[];
-      bit                      corrupt[];
-      logic [2:0]              req_opcode;
-   endclass
-endpackage
+class z_txn_class;
+   rand z_pkg::txn_type_t   req_txn_type;
+   rand z_pkg::cid_t        cid;
+   rand z_pkg::sid_t        sid;
+   rand z_pkg::ctag_t       ctag;
+   rand z_pkg::stag_t       stag;
+   rand z_pkg::size_t       size;
+   rand z_pkg::address_t    address;
+   rand z_pkg::state_t      state1;
+   rand z_pkg::state_t      state2;
+   rand z_pkg::state_t      state3;
+   rand logic               f1;
+   rand logic               f2;
+   rand logic               f3;
+   rand logic               f4;
+   z_pkg::data_t            data[];
+   z_pkg::mask_t            mask[];
+   bit                      corrupt[];
+   logic [2:0]              req_opcode;
+endclass
 module z_bfm_sender import z_pkg::*;
    (
     input logic clk,
@@ -291,9 +288,9 @@ module z_bfm_sender import z_pkg::*;
     z_if.sender z_if_sender
     );
    channel_t ch;
-   typedef c_pkg::z_txn_class z_txn_q_t[$];
+   typedef z_txn_class z_txn_q_t[$];
    z_txn_q_t z_txn_qs[ch.num()];
-   c_pkg::z_txn_class z_txn[ch.num()];
+   z_txn_class z_txn[ch.num()];
    always @(posedge clk or negedge reset_l) begin
       if (!reset_l) begin
          z_if_sender.x1_valid <= '0;


### PR DESCRIPTION
Add check for import statements directly within the class scope as these are illegal according to Section 26.3 of the 2017 LRM, along with a testcase to validate  the functionality.

Resolves #5634.