### PR TITLE
Fix `--hierarchical` finding include files (#5683)

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -20,6 +20,7 @@ Andrei Kostovski
 Andrew Miloradovsky
 Andrew Nolte
 Anthony Donlon
+Anthony Moore
 Arkadiusz Kozdra
 Arthur Rosa
 Aylon Chaim Porat

--- a/src/V3EmitMk.cpp
+++ b/src/V3EmitMk.cpp
@@ -816,22 +816,8 @@ class EmitMkHierVerilation final {
         of.puts("# Verilation of hierarchical blocks are executed in this directory\n");
         of.puts("VM_HIER_RUN_DIR := " + cwd + "\n");
         of.puts("# Common options for hierarchical blocks\n");
-
-        char buffer[1000];
-        ssize_t len = readlink("/proc/self/exe", buffer, 1000);
-
-        if (len == -1) {
-            std::cerr << "Error reading /proc/self/exe" << std::endl;
-        }
-
-        // Ensure null termination
-        //buffer[len] = '\0';
-
-        // Store the path in a const std::string
-        const std::string exe_path(buffer);
-
-        std::cout << "Executable path: " << exe_path << std::endl;
-        const string verilator_wrapper = exe_path;
+        const string fullpath_bin = V3Os::filenameRealPath(v3Global.opt.buildDepBin());
+        const string verilator_wrapper = V3Os::filenameDir(fullpath_bin) + "/verilator";
         of.puts("VM_HIER_VERILATOR := " + verilator_wrapper + "\n");
         of.puts("VM_HIER_INPUT_FILES := \\\n");
         const V3StringList& vFiles = v3Global.opt.vFiles();

--- a/src/V3EmitMk.cpp
+++ b/src/V3EmitMk.cpp
@@ -816,8 +816,22 @@ class EmitMkHierVerilation final {
         of.puts("# Verilation of hierarchical blocks are executed in this directory\n");
         of.puts("VM_HIER_RUN_DIR := " + cwd + "\n");
         of.puts("# Common options for hierarchical blocks\n");
-        const string fullpath_bin = V3Os::filenameRealPath(v3Global.opt.buildDepBin());
-        const string verilator_wrapper = V3Os::filenameDir(fullpath_bin) + "/verilator";
+
+        char buffer[1000];
+        ssize_t len = readlink("/proc/self/exe", buffer, 1000);
+
+        if (len == -1) {
+            std::cerr << "Error reading /proc/self/exe" << std::endl;
+        }
+
+        // Ensure null termination
+        //buffer[len] = '\0';
+
+        // Store the path in a const std::string
+        const std::string exe_path(buffer);
+
+        std::cout << "Executable path: " << exe_path << std::endl;
+        const string verilator_wrapper = exe_path;
         of.puts("VM_HIER_VERILATOR := " + verilator_wrapper + "\n");
         of.puts("VM_HIER_INPUT_FILES := \\\n");
         const V3StringList& vFiles = v3Global.opt.vFiles();
@@ -844,6 +858,11 @@ class EmitMkHierVerilation final {
         of.puts("\n");
         of.puts("ifndef VM_HIER_VERILATION_INCLUDED\n");
         of.puts("VM_HIER_VERILATION_INCLUDED = 1\n\n");
+
+        // Iterate over c++ list and add them to VPATH
+        for( const string& i : v3Global.opt.getIncDirUser()) {
+            of.puts("VPATH += " + V3Os::filenameRealPath(i) + "\n");
+        }
 
         of.puts(".SUFFIXES:\n");
         of.puts(".PHONY: hier_build hier_verilation hier_launch_verilator\n");

--- a/src/V3Options.cpp
+++ b/src/V3Options.cpp
@@ -79,6 +79,10 @@ public:
     DirMap m_dirMap;  // Directory listing
 
     // ACCESSOR METHODS
+    std::list<string> getIncDirUser() {
+        return m_incDirUsers;
+    }
+    // ACCESSOR METHODS
     void addIncDirUser(const string& incdir) {
         const string& dir = V3Os::filenameCleanup(incdir);
         const auto itFoundPair = m_incDirUserSet.insert(dir);
@@ -287,6 +291,7 @@ void VTimescale::parseSlashed(FileLine* fl, const char* textp, VTimescale& unitr
 //######################################################################
 // V3Options class functions
 
+std::list<string> V3Options::getIncDirUser() { return m_impp->getIncDirUser(); }
 void V3Options::addIncDirUser(const string& incdir) { m_impp->addIncDirUser(incdir); }
 void V3Options::addIncDirFallback(const string& incdir) { m_impp->addIncDirFallback(incdir); }
 void V3Options::addLangExt(const string& langext, const V3LangCode& lc) {

--- a/src/V3Options.h
+++ b/src/V3Options.h
@@ -26,6 +26,7 @@
 #include <map>
 #include <set>
 #include <string>
+#include <list>
 #include <vector>
 
 class V3OptionsImp;
@@ -466,6 +467,7 @@ public:
     bool preprocNoLine() const { return m_preprocNoLine; }
     bool underlineZero() const { return m_underlineZero; }
     string flags() const { return m_flags; }
+    std::list<string> getIncDirUser();
     bool systemC() const VL_MT_SAFE { return m_systemC; }
     bool savable() const VL_MT_SAFE { return m_savable; }
     bool stats() const { return m_stats; }


### PR DESCRIPTION
This is an attempt to fix issue #5683 . It works for me, but is not portable. 
It adds the include folders to the VPATH in the makefile. Not sure about cmake. 