### PR TITLE
Fix width extension of operands of `inside` operator

### DIFF
--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -2670,36 +2670,37 @@ class WidthVisitor final : public VNVisitor {
         }
 
         AstBasicDType* dtype = VN_CAST(nodep->exprp()->dtypep(), BasicDType);
-        AstNodeDType* subDTypep = nullptr;
+        AstNodeDType* expDTypep = nullptr;
 
         if (dtype && dtype->isString()) {
             nodep->dtypeSetString();
-            subDTypep = nodep->findStringDType();
+            expDTypep = nodep->findStringDType();
         } else if (dtype && dtype->isDouble()) {
             nodep->dtypeSetDouble();
-            subDTypep = nodep->findDoubleDType();
+            expDTypep = nodep->findDoubleDType();
         } else {
             // Take width as maximum across all items
             int width = nodep->exprp()->width();
             int mwidth = nodep->exprp()->widthMin();
+            bool isFourstate = nodep->exprp()->dtypep()->isFourstate();
             for (const AstNode* itemp = nodep->itemsp(); itemp; itemp = itemp->nextp()) {
                 width = std::max(width, itemp->width());
                 mwidth = std::max(mwidth, itemp->widthMin());
+                isFourstate |= itemp->dtypep()->isFourstate();
             }
             nodep->dtypeSetBit();
             const VSigning numeric = nodep->exprp()->dtypep()->numeric();
-            subDTypep = nodep->exprp()->dtypep()->isFourstate()
-                            ? nodep->findLogicDType(width, mwidth, numeric)
-                            : nodep->findBitDType(width, mwidth, numeric);
+            expDTypep = isFourstate ? nodep->findLogicDType(width, mwidth, numeric)
+                                    : nodep->findBitDType(width, mwidth, numeric);
         }
 
-        iterateCheck(nodep, "Inside expression", nodep->exprp(), CONTEXT_DET, FINAL, subDTypep,
+        iterateCheck(nodep, "Inside expression", nodep->exprp(), CONTEXT_DET, FINAL, expDTypep,
                      EXTEND_EXP);
         for (AstNode *nextip, *itemp = nodep->itemsp(); itemp; itemp = nextip) {
             nextip = itemp->nextp();  // iterate may cause the node to get replaced
             // InsideRange will get replaced with Lte&Gte and finalized later
             if (!VN_IS(itemp, InsideRange))
-                iterateCheck(nodep, "Inside Item", itemp, CONTEXT_DET, FINAL, subDTypep,
+                iterateCheck(nodep, "Inside Item", itemp, CONTEXT_DET, FINAL, expDTypep,
                              EXTEND_EXP);
         }
 

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -2687,7 +2687,10 @@ class WidthVisitor final : public VNVisitor {
                 mwidth = std::max(mwidth, itemp->widthMin());
             }
             nodep->dtypeSetBit();
-            subDTypep = nodep->findLogicDType(width, mwidth, nodep->exprp()->dtypep()->numeric());
+            const VSigning numeric = nodep->exprp()->dtypep()->numeric();
+            subDTypep = nodep->exprp()->dtypep()->isFourstate()
+                            ? nodep->findLogicDType(width, mwidth, numeric)
+                            : nodep->findBitDType(width, mwidth, numeric);
         }
 
         iterateCheck(nodep, "Inside expression", nodep->exprp(), CONTEXT_DET, FINAL, subDTypep,

--- a/test_regress/t/t_inside_extend.py
+++ b/test_regress/t/t_inside_extend.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2024 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile(verilator_flags2=["-Wno-WIDTH"])
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_inside_extend.v
+++ b/test_regress/t/t_inside_extend.v
@@ -1,0 +1,21 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2024 by Antmicro.
+// SPDX-License-Identifier: CC0-1.0
+
+typedef enum bit [4:0] {V0 = 1} my_enum;
+class Cls;
+  my_enum sp = V0;
+endclass
+
+module t (/*AUTOARG*/);
+   initial begin
+      Cls c = new;
+      int i = 0;
+      if (i inside {c.sp}) $stop;
+
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end
+endmodule


### PR DESCRIPTION
If there is width mismatch in `inside` operator, all operands are extended to the width of the widest operand. Currently on master, the type of an extended operand is `logic`, which is 4-state, so we enter into this case (`inside` is converted to `==?`): https://github.com/verilator/verilator/blob/29fb82d3b792369dad7d488b8191071e3c01076f/src/V3Unknown.cpp#L241-L243
This PR fixes it. The type of extended operand is 4-state only if at least one of the operands is 4-state. Otherwise it is 2-state.
