### PR TITLE
Fix VPI + SYMRSVDWORD intersection (#5687)

### DIFF
--- a/src/V3Ast.cpp
+++ b/src/V3Ast.cpp
@@ -222,12 +222,14 @@ string AstNode::vpiName(const string& namein) {
     // This is slightly different from prettyName, in that when we encounter escaped characters,
     // we change that identifier to an escaped identifier, wrapping it with '\' and ' '
     // as specified in LRM 23.6
+    string name = namein;
+    if (0 == namein.substr(0, 7).compare("__SYM__")) { name = namein.substr(7); }
     string pretty;
-    pretty.reserve(namein.length());
+    pretty.reserve(name.length());
     bool inEscapedIdent = false;
     int lastIdent = 0;
 
-    for (const char* pos = namein.c_str(); *pos;) {
+    for (const char* pos = name.c_str(); *pos;) {
         char specialChar = 0;
         if (pos[0] == '-' && pos[1] == '>') {  // ->
             specialChar = '.';

--- a/test_regress/t/t_vpi_var.cpp
+++ b/test_regress/t/t_vpi_var.cpp
@@ -405,6 +405,16 @@ int _mon_check_var() {
         CHECK_RESULT_CSTR(p, "vpiConstant");
     }
 
+    // C++ keyword collision
+    {
+        TestVpiHandle vh10 = VPI_HANDLE("nullptr");
+        CHECK_RESULT_NZ(vh10);
+        vpi_get_value(vh10, &tmpValue);
+        CHECK_RESULT(tmpValue.value.integer, 123);
+        p = vpi_get_str(vpiType, vh10);
+        CHECK_RESULT_CSTR(p, "vpiParameter");
+    }
+
     // non-integer variables
     tmpValue.format = vpiRealVal;
     {

--- a/test_regress/t/t_vpi_var.py
+++ b/test_regress/t/t_vpi_var.py
@@ -17,7 +17,7 @@ test.compile(make_top_shell=False,
              sim_time=2100,
              iv_flags2=["-g2005-sv -D USE_VPI_NOT_DPI -DWAVES"],
              v_flags2=["+define+USE_VPI_NOT_DPI"],
-             verilator_flags2=["--exe --vpi --no-l2name", test.pli_filename])
+             verilator_flags2=["-Wno-SYMRSVDWORD --exe --vpi --no-l2name", test.pli_filename])
 
 test.execute(use_libvpi=True, all_run_flags=['+PLUS +INT=1234 +STRSTR'])
 

--- a/test_regress/t/t_vpi_var.v
+++ b/test_regress/t/t_vpi_var.v
@@ -55,6 +55,9 @@ extern "C" int mon_check();
 
    real           real1          /*verilator public_flat_rw */;
    string         str1           /*verilator public_flat_rw */;
+   // specifically public and not public_flat_rw here so as to induce the C++
+   // keyword collision
+   localparam int nullptr        /*verilator public */ = 123;
 
    sub sub();
 

--- a/test_regress/t/t_vpi_var2.py
+++ b/test_regress/t/t_vpi_var2.py
@@ -18,7 +18,7 @@ test.compile(make_top_shell=False,
              sim_time=2100,
              iv_flags2=["-g2005-sv -D USE_VPI_NOT_DPI -DWAVES -DT_VPI_VAR2"],
              v_flags2=["+define+USE_VPI_NOT_DPI"],
-             verilator_flags2=["--exe --vpi --no-l2name", test.pli_filename])
+             verilator_flags2=["-Wno-SYMRSVDWORD --exe --vpi --no-l2name", test.pli_filename])
 
 test.execute(use_libvpi=True, all_run_flags=['+PLUS +INT=1234 +STRSTR'])
 

--- a/test_regress/t/t_vpi_var2.v
+++ b/test_regress/t/t_vpi_var2.v
@@ -74,6 +74,7 @@ extern "C" int mon_check();
 /*verilator public_flat_rw_on*/
    real           real1;
    string         str1;
+   localparam int nullptr = 123;
 /*verilator public_off*/
 
    sub sub();

--- a/test_regress/t/t_vpi_var3.v
+++ b/test_regress/t/t_vpi_var3.v
@@ -55,6 +55,7 @@ extern "C" int mon_check();
 
    real           real1;
    string         str1;
+   localparam int nullptr = 123;
 
    sub sub();
 


### PR DESCRIPTION
Signals which are C++ keyword collisions get a `__SYM__` prefix which prevents C++ compilation problems, but the prefix is also bleeding into the VPI model which is unnecessary / unwanted.

I'm not super pumped about the string manipulation fix in `AstNode::vpiName()`, though I do see that this method is already very stringy.  Given that, how should we fix this?

- The way I already have it in the PR?
- By keeping a separate `m_vpiName` in the `AstNode`? (expensive memory-wise)
- By keeping an `m_keyword` bool in `AstNode` and exposing  separate `vpiName()` getter which doesn't apply the `__SYM__`? (makes `name()` more complicated / slower)
-  Something else?
