### PR TITLE
Execute t_emit_accessors (#5689)

### DIFF
--- a/test_regress/t/t_emit_accessors.py
+++ b/test_regress/t/t_emit_accessors.py
@@ -13,4 +13,6 @@ test.scenarios('vlt')
 
 test.compile(make_main=False, verilator_flags2=["--emit-accessors", "--exe", test.pli_filename])
 
+test.execute()
+
 test.passes()


### PR DESCRIPTION
`t_emit_accessors` was being compiled but not executed.
