### PR TITLE
Fix invalid lookup on array initializer (#5707)

### DIFF
--- a/test_regress/t/t_simulate_array.py
+++ b/test_regress/t/t_simulate_array.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2025 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile()
+
+test.execute(check_finished=True)
+
+test.passes()

--- a/test_regress/t/t_simulate_array.v
+++ b/test_regress/t/t_simulate_array.v
@@ -1,0 +1,24 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2025 by Wilson Snyder.
+// SPDX-License-Identifier: CC0-1.0
+
+function integer fun;
+integer array[0:0];
+begin
+    array[0] = 10;
+    fun = array[0];
+end
+endfunction
+
+module test ();
+begin
+    localparam something = fun();
+    initial begin
+      if (something !== 10) $stop;
+      $write("*-* All Finished *-*\n");
+      $finish;
+    end
+end
+endmodule


### PR DESCRIPTION
Use a generational allocator for reusing AstConst across V3Simulate::clear(), instead of using user1 (which is also used to store values of nodes).

Also fix invalid lookup on array initializer

Fixes #5707