### PR TITLE
Use helpman's -n option to create man pages with useful whatis section

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -201,7 +201,8 @@ verilator.1: ${srcdir}/bin/verilator
 verilator_coverage.1: ${srcdir}/bin/verilator_coverage
 	pod2man $< $@
 %.1: ${srcdir}/bin/%
-	help2man --no-info --no-discard-stderr --version-string=- $< -o $@
+	help2man --no-info --no-discard-stderr --version-string=- \
+		-n "$(shell $< --help | head -n 3 | tail -n 1)" $< -o $@
 
 .PHONY: verilator.html
 verilator.html:


### PR DESCRIPTION
The whatis entry (the brief description found in the NAME section) for manual pages created by help2man is of the form:

 program - manual page for program

This conveys no information about what the program is for and is repetitive. The short description should contain brief information about what the program is for to aid in searching with apropos and similar programs.