### PR TITLE
Add `--public-ignore` to ignore public metacomments

### DIFF
--- a/bin/verilator
+++ b/bin/verilator
@@ -433,6 +433,7 @@ detailed descriptions of these arguments.
     --public-depth <level>      Mark public to specified module depth
     --public-params             Mark all parameters as public_flat
     --public-flat-rw            Mark all variables, etc as public_flat_rw
+    --public-off                Ignore all public comment markings, allowing for config files to exclusively control this
      -pvalue+<name>=<value>     Overwrite toplevel parameter
     --quiet                     Minimize additional printing
     --quiet-exit                Don't print the command on failure

--- a/bin/verilator
+++ b/bin/verilator
@@ -431,9 +431,9 @@ detailed descriptions of these arguments.
     --protect-lib <name>        Create a DPI protected library
     --public                    Mark signals as public; see docs
     --public-depth <level>      Mark public to specified module depth
-    --public-params             Mark all parameters as public_flat
     --public-flat-rw            Mark all variables, etc as public_flat_rw
     --public-ignore             Ignore all public comment markings
+    --public-params             Mark all parameters as public_flat
      -pvalue+<name>=<value>     Overwrite toplevel parameter
     --quiet                     Minimize additional printing
     --quiet-exit                Don't print the command on failure

--- a/bin/verilator
+++ b/bin/verilator
@@ -433,7 +433,7 @@ detailed descriptions of these arguments.
     --public-depth <level>      Mark public to specified module depth
     --public-params             Mark all parameters as public_flat
     --public-flat-rw            Mark all variables, etc as public_flat_rw
-    --public-off                Ignore all public comment markings, allowing for config files to exclusively control this
+    --public-ignore             Ignore all public comment markings
      -pvalue+<name>=<value>     Overwrite toplevel parameter
     --quiet                     Minimize additional printing
     --quiet-exit                Don't print the command on failure

--- a/docs/guide/exe_verilator.rst
+++ b/docs/guide/exe_verilator.rst
@@ -1234,6 +1234,12 @@ Summary:
    :code:`/*verilator public_flat_rd*/`
    metacomments.
 
+.. option:: --public-off
+
+   Ignore all
+   :code:`/*verilator public* */`
+   metacomments. This is useful for optimized vpi builds, where a sim records reads/writes, then passes those with a .vlt file.
+
 .. option:: -pvalue+<name>=<value>
 
    Overwrites the given parameter(s) of the top-level module. See

--- a/docs/guide/exe_verilator.rst
+++ b/docs/guide/exe_verilator.rst
@@ -1238,7 +1238,7 @@ Summary:
 
    Ignore all
    :code:`/*verilator public* */`
-   metacomments. This is useful for optimized vpi builds, where a sim records reads/writes, then passes those with a .vlt file.
+   metacomments. This is useful for speed-optimizing VPI builds where VPI is not being used.
    Other control flags like :vlopt:`--public`, :vlopt:`--public-depth`, etc. will also work with this, as they are not metacomments.
 
 .. option:: -pvalue+<name>=<value>

--- a/docs/guide/exe_verilator.rst
+++ b/docs/guide/exe_verilator.rst
@@ -1239,7 +1239,7 @@ Summary:
    Ignore all
    :code:`/*verilator public* */`
    metacomments. This is useful for speed-optimizing VPI builds where VPI is not being used.
-   Other control flags like :vlopt:`--public`, :vlopt:`--public-depth`, etc. will also work with this, as they are not metacomments.
+   This only affects metacomments; options such as :vlopt:`--public`, :vlopt:`--public-depth`, etc. work normally.
 
 .. option:: -pvalue+<name>=<value>
 

--- a/docs/guide/exe_verilator.rst
+++ b/docs/guide/exe_verilator.rst
@@ -1234,11 +1234,12 @@ Summary:
    :code:`/*verilator public_flat_rd*/`
    metacomments.
 
-.. option:: --public-off
+.. option:: --public-ignore
 
    Ignore all
    :code:`/*verilator public* */`
    metacomments. This is useful for optimized vpi builds, where a sim records reads/writes, then passes those with a .vlt file.
+   Other control flags like :vlopt:`--public`, :vlopt:`--public-depth`, etc. will also work with this, as they are not metacomments.
 
 .. option:: -pvalue+<name>=<value>
 

--- a/docs/guide/exe_verilator.rst
+++ b/docs/guide/exe_verilator.rst
@@ -1211,6 +1211,13 @@ Summary:
    module specifically enabled it with
    :option:`/*verilator&32;inline_module*/`.
 
+
+.. option:: --public-depth <level>
+
+   Enables public as with :vlopt:`--public-flat-rw`, but only to the specified depth of modules.
+   It operates at the module maximum level, so if a module's cells are A.B.X and A.X, the
+   a --public-depth 3 must be used to make module X public, and both A.B.X and A.X will be public.
+
 .. option:: --public-flat-rw
 
    Declares all variables, ports, and wires public as if they had
@@ -1221,12 +1228,13 @@ Summary:
    in mis-simulation of generated clocks.  Instead of this global option,
    marking only those signals that need public_flat_rw is typically
    significantly better performing.
+   
+.. option:: --public-ignore
 
-.. option:: --public-depth <level>
-
-   Enables public as with :vlopt:`--public-flat-rw`, but only to the specified depth of modules.
-   It operates at the module maximum level, so if a module's cells are A.B.X and A.X, the
-   a --public-depth 3 must be used to make module X public, and both A.B.X and A.X will be public.
+   Ignore all
+   :code:`/*verilator public* */`
+   metacomments. This is useful for speed-optimizing VPI builds where VPI is not being used.
+   This only affects metacomments; options such as :vlopt:`--public`, :vlopt:`--public-depth`, etc. work normally.
 
 .. option:: --public-params
 
@@ -1234,12 +1242,6 @@ Summary:
    :code:`/*verilator public_flat_rd*/`
    metacomments.
 
-.. option:: --public-ignore
-
-   Ignore all
-   :code:`/*verilator public* */`
-   metacomments. This is useful for speed-optimizing VPI builds where VPI is not being used.
-   This only affects metacomments; options such as :vlopt:`--public`, :vlopt:`--public-depth`, etc. work normally.
 
 .. option:: -pvalue+<name>=<value>
 

--- a/src/V3Options.cpp
+++ b/src/V3Options.cpp
@@ -1511,8 +1511,11 @@ void V3Options::parseOptsList(FileLine* fl, const string& optdir, int argc,
         v3Global.dpi(true);
     });
     DECL_OPTION("-public-params", CbOnOff, [this](bool flag) {
-        m_public_params = flag;
+        m_publicParams = flag;
         v3Global.dpi(true);
+    });
+    DECL_OPTION("-public-off", CbOnOff, [this](bool flag) {
+        m_publicOff = flag;
     });
     DECL_OPTION("-quiet", CbOnOff, [this](bool flag) {
         m_quietExit = flag;

--- a/src/V3Options.cpp
+++ b/src/V3Options.cpp
@@ -1514,7 +1514,7 @@ void V3Options::parseOptsList(FileLine* fl, const string& optdir, int argc,
         m_publicParams = flag;
         v3Global.dpi(true);
     });
-    DECL_OPTION("-public-off", CbOnOff, [this](bool flag) {
+    DECL_OPTION("-public-ignore", CbOnOff, [this](bool flag) {
         m_publicOff = flag;
     });
     DECL_OPTION("-quiet", CbOnOff, [this](bool flag) {

--- a/src/V3Options.cpp
+++ b/src/V3Options.cpp
@@ -1514,9 +1514,7 @@ void V3Options::parseOptsList(FileLine* fl, const string& optdir, int argc,
         m_publicParams = flag;
         v3Global.dpi(true);
     });
-    DECL_OPTION("-public-ignore", CbOnOff, [this](bool flag) {
-        m_publicOff = flag;
-    });
+    DECL_OPTION("-public-ignore", CbOnOff, [this](bool flag) { m_publicOff = flag; });
     DECL_OPTION("-quiet", CbOnOff, [this](bool flag) {
         m_quietExit = flag;
         m_quietStats = flag;

--- a/src/V3Options.cpp
+++ b/src/V3Options.cpp
@@ -1510,11 +1510,11 @@ void V3Options::parseOptsList(FileLine* fl, const string& optdir, int argc,
         m_publicFlatRW = flag;
         v3Global.dpi(true);
     });
+    DECL_OPTION("-public-ignore", CbOnOff, [this](bool flag) { m_publicOff = flag; });
     DECL_OPTION("-public-params", CbOnOff, [this](bool flag) {
         m_publicParams = flag;
         v3Global.dpi(true);
     });
-    DECL_OPTION("-public-ignore", CbOnOff, [this](bool flag) { m_publicOff = flag; });
     DECL_OPTION("-quiet", CbOnOff, [this](bool flag) {
         m_quietExit = flag;
         m_quietStats = flag;

--- a/src/V3Options.cpp
+++ b/src/V3Options.cpp
@@ -1510,7 +1510,7 @@ void V3Options::parseOptsList(FileLine* fl, const string& optdir, int argc,
         m_publicFlatRW = flag;
         v3Global.dpi(true);
     });
-    DECL_OPTION("-public-ignore", CbOnOff, [this](bool flag) { m_publicOff = flag; });
+    DECL_OPTION("-public-ignore", CbOnOff, [this](bool flag) { m_publicIgnore = flag; });
     DECL_OPTION("-public-params", CbOnOff, [this](bool flag) {
         m_publicParams = flag;
         v3Global.dpi(true);

--- a/src/V3Options.h
+++ b/src/V3Options.h
@@ -273,7 +273,8 @@ private:
     bool m_protectIds = false;      // main switch: --protect-ids
     bool m_public = false;          // main switch: --public
     bool m_publicFlatRW = false;    // main switch: --public-flat-rw
-    bool m_public_params = false;   // main switch: --public-params
+    bool m_publicParams = false;   // main switch: --public-params
+    bool m_publicOff = false;   // main switch: --public-params
     bool m_quietExit = false;       // main switch: --quiet-exit
     bool m_quietStats = false;      // main switch: --quiet-stats
     bool m_relativeIncludes = false;  // main switch: --relative-includes
@@ -541,10 +542,11 @@ public:
     bool usesProfiler() const { return profExec() || profPgo(); }
     bool protectIds() const VL_MT_SAFE { return m_protectIds; }
     bool allPublic() const { return m_public; }
-    bool publicParams() const { return m_public_params; }
+    bool publicParams() const { return m_publicParams; }
+    bool publicOff() const { return m_publicOff; }
     bool publicFlatRW() const { return m_publicFlatRW; }
     int publicDepth() const { return m_publicDepth; }
-    bool anyPublicFlat() const { return m_public_params || m_publicFlatRW || m_publicDepth; }
+    bool anyPublicFlat() const { return m_publicParams || m_publicFlatRW || m_publicDepth; }
     bool lintOnly() const VL_MT_SAFE { return m_lintOnly; }
     bool ignc() const { return m_ignc; }
     bool quietExit() const VL_MT_SAFE { return m_quietExit; }

--- a/src/V3Options.h
+++ b/src/V3Options.h
@@ -273,8 +273,8 @@ private:
     bool m_protectIds = false;      // main switch: --protect-ids
     bool m_public = false;          // main switch: --public
     bool m_publicFlatRW = false;    // main switch: --public-flat-rw
-    bool m_publicParams = false;   // main switch: --public-params
-    bool m_publicOff = false;   // main switch: --public-params
+    bool m_publicParams = false;    // main switch: --public-params
+    bool m_publicIgnore = false;    // main switch: --public-ignore
     bool m_quietExit = false;       // main switch: --quiet-exit
     bool m_quietStats = false;      // main switch: --quiet-stats
     bool m_relativeIncludes = false;  // main switch: --relative-includes
@@ -543,7 +543,7 @@ public:
     bool protectIds() const VL_MT_SAFE { return m_protectIds; }
     bool allPublic() const { return m_public; }
     bool publicParams() const { return m_publicParams; }
-    bool publicOff() const { return m_publicOff; }
+    bool publicOff() const { return m_publicIgnore; }
     bool publicFlatRW() const { return m_publicFlatRW; }
     int publicDepth() const { return m_publicDepth; }
     bool anyPublicFlat() const { return m_publicParams || m_publicFlatRW || m_publicDepth; }

--- a/src/V3Options.h
+++ b/src/V3Options.h
@@ -273,8 +273,8 @@ private:
     bool m_protectIds = false;      // main switch: --protect-ids
     bool m_public = false;          // main switch: --public
     bool m_publicFlatRW = false;    // main switch: --public-flat-rw
-    bool m_publicParams = false;    // main switch: --public-params
     bool m_publicIgnore = false;    // main switch: --public-ignore
+    bool m_publicParams = false;    // main switch: --public-params
     bool m_quietExit = false;       // main switch: --quiet-exit
     bool m_quietStats = false;      // main switch: --quiet-stats
     bool m_relativeIncludes = false;  // main switch: --relative-includes

--- a/src/V3PreProc.cpp
+++ b/src/V3PreProc.cpp
@@ -486,7 +486,7 @@ void V3PreProcImp::comment(const string& text) {
             //}
             // else ignore the comment we don't recognize
         }  // else no assertions
-    } else if (vlcomment) {
+    } else if (vlcomment && !(v3Global.opt.publicOff() && VString::startsWith(cmd, "public"))) {
         if (VString::startsWith(cmd, "public_flat_rw")) {
             // "/*verilator public_flat_rw @(foo) */" -> "/*verilator public_flat_rw*/ @(foo)"
             string::size_type endOfCmd = std::strlen("public_flat_rw");

--- a/test_regress/t/t_vpi_public_depth.cpp
+++ b/test_regress/t/t_vpi_public_depth.cpp
@@ -26,6 +26,8 @@
 #include "Vt_vpi_public_depth__Dpi.h"
 #elif defined(T_VPI_PUBLIC_DEPTH_OFF)
 #include "Vt_vpi_public_depth_off__Dpi.h"
+#elif defined(T_VPI_PUBLIC_OFF)
+#include "Vt_vpi_public_off__Dpi.h"
 #else
 #error "Bad test"
 #endif
@@ -86,6 +88,15 @@ int mon_check() {
     TestVpiHandle topmod_done_should_be_0 = (vpi_scan(it));
     it.freed();  // IEEE 37.2.2 vpi_scan at end does a vpi_release_handle
     CHECK_RESULT_Z(topmod_done_should_be_0);
+
+    TestVpiHandle mod_a = vpi_handle_by_name(const_cast<PLI_BYTE8*>("\\mod.a "), topmod);
+    #if defined(T_VPI_PUBLIC_OFF)
+    // metacomment from below should get ignored
+    CHECK_RESULT_Z(mod_a);
+    return 0;
+    #endif
+
+    CHECK_RESULT_NZ(mod_a);
 
     TestVpiHandle it2 = vpi_iterate(vpiModule, topmod);
     CHECK_RESULT_NZ(it2);

--- a/test_regress/t/t_vpi_public_depth.cpp
+++ b/test_regress/t/t_vpi_public_depth.cpp
@@ -91,7 +91,7 @@ int mon_check() {
 
     TestVpiHandle mod_a = vpi_handle_by_name(const_cast<PLI_BYTE8*>("\\mod.a "), topmod);
     #if defined(T_VPI_PUBLIC_OFF)
-    // metacomment from below should get ignored
+    // metacomment from module A should be ignored
     CHECK_RESULT_Z(mod_a);
     return 0;
     #endif

--- a/test_regress/t/t_vpi_public_depth.cpp
+++ b/test_regress/t/t_vpi_public_depth.cpp
@@ -90,11 +90,11 @@ int mon_check() {
     CHECK_RESULT_Z(topmod_done_should_be_0);
 
     TestVpiHandle mod_a = vpi_handle_by_name(const_cast<PLI_BYTE8*>("\\mod.a "), topmod);
-    #if defined(T_VPI_PUBLIC_OFF)
+#if defined(T_VPI_PUBLIC_OFF)
     // metacomment from module A should be ignored
     CHECK_RESULT_Z(mod_a);
     return 0;
-    #endif
+#endif
 
     CHECK_RESULT_NZ(mod_a);
 

--- a/test_regress/t/t_vpi_public_depth.v
+++ b/test_regress/t/t_vpi_public_depth.v
@@ -65,7 +65,7 @@ module A(/*AUTOARG*/
    clk, a, b
    );
 
-   // this comment should get ignored for public-off
+   // this comment should get ignored for public-ignore
    input clk /* verilator public_flat_rw */;
 
    input a, b;

--- a/test_regress/t/t_vpi_public_depth.v
+++ b/test_regress/t/t_vpi_public_depth.v
@@ -65,7 +65,8 @@ module A(/*AUTOARG*/
    clk, a, b
    );
 
-   input clk;
+   // this comment should get ignored for public-off
+   input clk /* verilator public_flat_rw */;
 
    input a, b;
    output x;

--- a/test_regress/t/t_vpi_public_off.py
+++ b/test_regress/t/t_vpi_public_off.py
@@ -18,7 +18,8 @@ test.compile(make_top_shell=False,
              make_pli=True,
              iv_flags2=["-g2005-sv"],
              verilator_flags2=[
-                 "+define+USE_DOLLAR_C32 --exe --vpi --no-l2name", test.pli_filename,
+                 "+define+USE_DOLLAR_C32 --exe --vpi --no-l2name",
+                 test.pli_filename,
                  "--public-depth 1 --public-ignore",
              ],
              make_flags=['CPPFLAGS_ADD=-DTEST_VPI_PUBLIC_OFF'])

--- a/test_regress/t/t_vpi_public_off.py
+++ b/test_regress/t/t_vpi_public_off.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2024 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+test.pli_filename = "t/t_vpi_public_depth.cpp"
+test.top_filename = "t/t_vpi_public_depth.v"
+
+test.compile(make_top_shell=False,
+             make_main=False,
+             make_pli=True,
+             iv_flags2=["-g2005-sv"],
+             verilator_flags2=[
+                 "+define+USE_DOLLAR_C32 --exe --vpi --no-l2name", test.pli_filename,
+                 "--public-depth 1 --public-off",
+             ],
+             make_flags=['CPPFLAGS_ADD=-DTEST_VPI_PUBLIC_OFF'])
+
+test.execute(use_libvpi=True)
+
+test.passes()

--- a/test_regress/t/t_vpi_public_off.py
+++ b/test_regress/t/t_vpi_public_off.py
@@ -19,7 +19,7 @@ test.compile(make_top_shell=False,
              iv_flags2=["-g2005-sv"],
              verilator_flags2=[
                  "+define+USE_DOLLAR_C32 --exe --vpi --no-l2name", test.pli_filename,
-                 "--public-depth 1 --public-off",
+                 "--public-depth 1 --public-ignore",
              ],
              make_flags=['CPPFLAGS_ADD=-DTEST_VPI_PUBLIC_OFF'])
 


### PR DESCRIPTION
This adds --public-off, which disables verilator public metacomments. This is useful for passing in along with a vlt config file with a minimal set of publicized signals.

I also fixed the casing on m_publicParams