### PR TITLE
Add expression coverage

### DIFF
--- a/bin/verilator
+++ b/bin/verilator
@@ -328,6 +328,8 @@ detailed descriptions of these arguments.
     --compiler-include          Include additional header in the precompiled one
     --converge-limit <loops>    Tune convergence settle time
     --coverage                  Enable all coverage
+    --coverage-expr             Enable expression coverage
+    --coverage-expr-max <value>     Maximum permutations allowed for an expression
     --coverage-line             Enable line coverage
     --coverage-max-width <width>   Maximum array depth for coverage
     --coverage-toggle           Enable toggle coverage

--- a/docs/guide/exe_verilator.rst
+++ b/docs/guide/exe_verilator.rst
@@ -237,7 +237,17 @@ Summary:
 .. option:: --coverage
 
    Enables all forms of coverage, an alias for :vlopt:`--coverage-line`
-   :vlopt:`--coverage-toggle` :vlopt:`--coverage-user`.
+   :vlopt:`--coverage-toggle :vlopt:`--coverage-expr`` :vlopt:`--coverage-user`.
+
+.. option:: --coverage-expr
+
+   Enables expression coverage analysis. See :ref:`Expression Coverage`.
+
+.. option:: --coverage-expr-max <value>
+
+   Rarely needed.  Specifies the maximum number of permutations able to be
+   covered for a given expression.  Defaults to 32.  Increasing may slow
+   coverage simulations and make analyzing the results unwieldy.
 
 .. option:: --coverage-line
 

--- a/docs/guide/exe_verilator_coverage.rst
+++ b/docs/guide/exe_verilator_coverage.rst
@@ -58,7 +58,7 @@ to read multiple inputs.  If no data file is specified, by default,
 Specifies the directory name to which source files with annotated coverage
 data should be written.
 
-Points are children of each line coverage- branches or toggle points.
+Points are children of each line coverage- branches, expressions or toggle points.
 When point counts are aggregated into a line, the minimum and maximum counts
 are used to determine the status of the line (complete, partial, failing)
 The count is equal to the maximum of the points.

--- a/docs/guide/simulating.rst
+++ b/docs/guide/simulating.rst
@@ -288,6 +288,22 @@ Some expressions may produce too many cover points.  Verilator limits the
 maximum number of cover poitns per expression to 32, but this may be
 controlled with :vlopt:`--coverage-expr-max`.
 
+Below is an example showing expression coverage produced from `verilator_coverage`
+as applied to the condition expression inside an if statement.  Each line
+shows the minimum number of terms and their values (e.g. `(t1==0 && t2==1)`) needed
+to reach a result for the overall expression (e.g. `=> 1`).  Each line also
+shows the number of times this combination was hit.  Note that individual lines
+are not mutually exclusive.
+
+.. code-block::
+
+   %000004         if ((~t1 && t2) || (~t3 && t4)) $write("");
+   -000002  point: comment=(t1==0 && t2==1) => 1 hier=top.t
+   -000002  point: comment=(t1==1 && t3==1) => 0 hier=top.t
+   -000004  point: comment=(t1==1 && t4==0) => 0 hier=top.t
+   -000002  point: comment=(t2==0 && t3==1) => 0 hier=top.t
+   -000003  point: comment=(t2==0 && t4==0) => 0 hier=top.t
+   -000002  point: comment=(t3==0 && t4==1) => 1 hier=top.t
 
 .. _Suppressing Coverage:
 

--- a/docs/guide/simulating.rst
+++ b/docs/guide/simulating.rst
@@ -270,6 +270,25 @@ A :option:`/*verilator&32;coverage_off*/`
 signals that do not need toggle analysis, such as RAMs and register files.
 
 
+.. _Expression Coverage:
+
+Expression Coverage
+-------------
+
+With :vlopt:`--coverage` or :vlopt:`--coverage-expr`, Verilator will
+automatically add coverage analysis at each expression, indicating with
+a truth table how every Boolean truth-table possiblity in the expression occurred.
+
+Multi-bit expressions are ignored, but sub-expressions with are entirely
+Boolean are analyzed.  Expression coverage does not fully explore the truth
+table of an expression, rather is looks at each term's contribution.  E.g.
+an AND operation will check coverage for TT, XF and FX.
+
+Some expressions may produce too many cover points.  Verilator limits the
+maximum number of cover poitns per expression to 32, but this may be
+controlled with :vlopt:`--coverage-expr-max`.
+
+
 .. _Suppressing Coverage:
 
 Suppressing Coverage

--- a/src/V3Options.cpp
+++ b/src/V3Options.cpp
@@ -1238,6 +1238,8 @@ void V3Options::parseOptsList(FileLine* fl, const string& optdir, int argc,
     DECL_OPTION("-compiler-include", CbVal, callStrSetter(&V3Options::addCompilerIncludes));
     DECL_OPTION("-converge-limit", Set, &m_convergeLimit);
     DECL_OPTION("-coverage", CbOnOff, [this](bool flag) { coverage(flag); });
+    DECL_OPTION("-coverage-expr", OnOff, &m_coverageExpr);
+    DECL_OPTION("-coverage-expr-max", Set, &m_coverageExprMax);
     DECL_OPTION("-coverage-line", OnOff, &m_coverageLine);
     DECL_OPTION("-coverage-max-width", Set, &m_coverageMaxWidth);
     DECL_OPTION("-coverage-toggle", OnOff, &m_coverageToggle);

--- a/src/V3Options.h
+++ b/src/V3Options.h
@@ -230,6 +230,7 @@ private:
     bool m_build = false;           // main switch: --build
     bool m_cmake = false;           // main switch: --make cmake
     bool m_context = true;          // main switch: --Wcontext
+    bool m_coverageExpr = false;    // main switch: --coverage-expr
     bool m_coverageLine = false;    // main switch: --coverage-block
     bool m_coverageToggle = false;  // main switch: --coverage-toggle
     bool m_coverageUnderscore = false;  // main switch: --coverage-underscore
@@ -305,6 +306,7 @@ private:
     bool m_xmlOnly = false;         // main switch: --xml-only
 
     int         m_buildJobs = -1;    // main switch: --build-jobs, -j
+    int         m_coverageExprMax = 32;    // main switch: --coverage-expr-max
     int         m_convergeLimit = 100;  // main switch: --converge-limit
     int         m_coverageMaxWidth = 256; // main switch: --coverage-max-width
     int         m_expandLimit = 64;  // main switch: --expand-limit
@@ -426,7 +428,9 @@ private:
     void addLibExtV(const string& libext);
     void optimize(int level);
     void showVersion(bool verbose);
-    void coverage(bool flag) { m_coverageLine = m_coverageToggle = m_coverageUser = flag; }
+    void coverage(bool flag) {
+        m_coverageLine = m_coverageToggle = m_coverageExpr = m_coverageUser = flag;
+    }
     static bool suffixed(const string& sw, const char* arg);
     static string parseFileArg(const string& optdir, const string& relfilename);
     string filePathCheckOneDir(const string& modname, const string& dirname);
@@ -488,8 +492,9 @@ public:
     bool cmake() const { return m_cmake; }
     bool context() const VL_MT_SAFE { return m_context; }
     bool coverage() const VL_MT_SAFE {
-        return m_coverageLine || m_coverageToggle || m_coverageUser;
+        return m_coverageLine || m_coverageToggle || m_coverageExpr || m_coverageUser;
     }
+    bool coverageExpr() const { return m_coverageExpr; }
     bool coverageLine() const { return m_coverageLine; }
     bool coverageToggle() const { return m_coverageToggle; }
     bool coverageUnderscore() const { return m_coverageUnderscore; }
@@ -565,6 +570,7 @@ public:
 
     int buildJobs() const VL_MT_SAFE { return m_buildJobs; }
     int convergeLimit() const { return m_convergeLimit; }
+    int coverageExprMax() const { return m_coverageExprMax; }
     int coverageMaxWidth() const { return m_coverageMaxWidth; }
     bool dumpTreeAddrids() const VL_MT_SAFE;
     int expandLimit() const { return m_expandLimit; }

--- a/test_regress/t/t_cover_expr.out
+++ b/test_regress/t/t_cover_expr.out
@@ -261,15 +261,13 @@
             logic ta, tb, tc;
             initial begin
                 int q[5];
-                int qv;
+                int qv[$];
         
                 q = '{1, 2, 2, 4, 3};
                 // lambas not handled
                 // NB: there is a bug w/ tracing find_first (maybe lambdas in general?)
                 //     tracing_off does not work around the bug
-        `ifndef TEST_TRACE
                 qv = q.find_first with (item[0] & item[1]);
-        `endif
                 ta = '1;
                 tb = '0;
                 tc = '0;

--- a/test_regress/t/t_cover_expr.out
+++ b/test_regress/t/t_cover_expr.out
@@ -1,0 +1,319 @@
+//      // verilator_coverage annotation
+        // DESCRIPTION: Verilator: Verilog Test module
+        //
+        // This file ONLY is placed under the Creative Commons Public Domain, for
+        // any use, without warranty, 2024 by Wilson Snyder.
+        // SPDX-License-Identifier: CC0-1.0
+        
+        module t (/*AUTOARG*/
+            // Inputs
+            clk
+            );
+        
+            input clk;
+        
+            integer cyc;
+            initial cyc=1;
+        
+            integer some_int;
+            integer other_int;
+            logic some_bool;
+        
+            wire t1 = cyc[0];
+            wire t2 = cyc[1];
+            wire t3 = cyc[2];
+            wire t4 = cyc[3];
+        
+            localparam bit ONE = 1'b1;
+            localparam bit ZERO = 1'b0;
+        
+            function automatic bit invert(bit x);
+ 000015         return ~x;
++000012  point: comment=(x==0) => 1 hier=top.t
++000015  point: comment=(x==1) => 0 hier=top.t
+            endfunction
+        
+            function automatic bit and_oper(bit a, bit b);
+%000005         return a & b;
+-000004  point: comment=(a==0) => 0 hier=top.t
+-000002  point: comment=(a==1 && b==1) => 1 hier=top.t
+-000005  point: comment=(b==0) => 0 hier=top.t
+            endfunction
+        
+            always @ (posedge clk) begin
+                cyc <= cyc + 1;
+%000004         if ((~cyc[0] && cyc[1]) || (~cyc[2] && cyc[3])) $write("");
+-000002  point: comment=(cyc[0]==0 && cyc[1]==1) => 1 hier=top.t
+-000002  point: comment=(cyc[0]==1 && cyc[2]==1) => 0 hier=top.t
+-000004  point: comment=(cyc[0]==1 && cyc[3]==0) => 0 hier=top.t
+-000002  point: comment=(cyc[1]==0 && cyc[2]==1) => 0 hier=top.t
+-000003  point: comment=(cyc[1]==0 && cyc[3]==0) => 0 hier=top.t
+-000002  point: comment=(cyc[2]==0 && cyc[3]==1) => 1 hier=top.t
+%000004         if ((~t1 && t2) || (~t3 && t4)) $write("");
+-000002  point: comment=(t1==0 && t2==1) => 1 hier=top.t
+-000002  point: comment=(t1==1 && t3==1) => 0 hier=top.t
+-000004  point: comment=(t1==1 && t4==0) => 0 hier=top.t
+-000002  point: comment=(t2==0 && t3==1) => 0 hier=top.t
+-000003  point: comment=(t2==0 && t4==0) => 0 hier=top.t
+-000002  point: comment=(t3==0 && t4==1) => 1 hier=top.t
+%000005         if (t3 && (t1 == t2)) $write("");
+-000005  point: comment=((t1 == t2)==0) => 0 hier=top.t
+-000005  point: comment=(t3==0) => 0 hier=top.t
+-000002  point: comment=(t3==1 && (t1 == t2)==1) => 1 hier=top.t
+%000005         if (123 == (124 - 32'(t1 || t2))) $write("");
+-000002  point: comment=(t1==0 && t2==0) => 0 hier=top.t
+-000005  point: comment=(t1==1) => 1 hier=top.t
+-000004  point: comment=(t2==1) => 1 hier=top.t
+%000004         some_int <= (t2 || t3) ? 345 : 567;
+-000003  point: comment=(t2==0 && t3==0) => 0 hier=top.t
+-000004  point: comment=(t2==1) => 1 hier=top.t
+-000004  point: comment=(t3==1) => 1 hier=top.t
+%000005         some_bool <= t1 && t2;
+-000004  point: comment=(t1==0) => 0 hier=top.t
+-000002  point: comment=(t1==1 && t2==1) => 1 hier=top.t
+-000005  point: comment=(t2==0) => 0 hier=top.t
+%000005         if (t1 & t2) $write("");
+-000004  point: comment=(t1==0) => 0 hier=top.t
+-000002  point: comment=(t1==1 && t2==1) => 1 hier=top.t
+-000005  point: comment=(t2==0) => 0 hier=top.t
+%000004         if ((!t1 && t2) | (~t3 && t4)) $write("");
+-000002  point: comment=(t1==0 && t2==1) => 1 hier=top.t
+-000002  point: comment=(t1==1 && t3==1) => 0 hier=top.t
+-000004  point: comment=(t1==1 && t4==0) => 0 hier=top.t
+-000002  point: comment=(t2==0 && t3==1) => 0 hier=top.t
+-000003  point: comment=(t2==0 && t4==0) => 0 hier=top.t
+-000002  point: comment=(t3==0 && t4==1) => 1 hier=top.t
+%000003         if (t1 ^ t2) $write("");
+-000002  point: comment=(t1==0 && t2==0) => 0 hier=top.t
+-000002  point: comment=(t1==0 && t2==1) => 1 hier=top.t
+-000003  point: comment=(t1==1 && t2==0) => 1 hier=top.t
+-000002  point: comment=(t1==1 && t2==1) => 0 hier=top.t
+%000005         if (~(t1 & t2)) $write("");
+-000004  point: comment=(t1==0) => 1 hier=top.t
+-000002  point: comment=(t1==1 && t2==1) => 0 hier=top.t
+-000005  point: comment=(t2==0) => 1 hier=top.t
+%000004         if (t1 -> t2) $write("");
+-000004  point: comment=(t1==0) => 1 hier=top.t
+-000003  point: comment=(t1==1 && t2==0) => 0 hier=top.t
+-000004  point: comment=(t2==1) => 1 hier=top.t
+%000003         if (t1 <-> t2) $write("");
+-000002  point: comment=(t1==0 && t2==0) => 1 hier=top.t
+-000002  point: comment=(t1==0 && t2==1) => 0 hier=top.t
+-000003  point: comment=(t1==1 && t2==0) => 0 hier=top.t
+-000002  point: comment=(t1==1 && t2==1) => 1 hier=top.t
+%000005         if (&cyc[2:0]) $write("");
+-000004  point: comment=(cyc[2:0][0]==0) => 0 hier=top.t
+-000001  point: comment=(cyc[2:0][0]==1 && cyc[2:0][1]==1 && cyc[2:0][2]==1) => 1 hier=top.t
+-000005  point: comment=(cyc[2:0][1]==0) => 0 hier=top.t
+-000005  point: comment=(cyc[2:0][2]==0) => 0 hier=top.t
+%000007         if (&cyc[3:2]) $write("");
+-000005  point: comment=(cyc[3:2][0]==0) => 0 hier=top.t
+-000000  point: comment=(cyc[3:2][0]==1 && cyc[3:2][1]==1) => 1 hier=top.t
+-000007  point: comment=(cyc[3:2][1]==0) => 0 hier=top.t
+%000005         if (|cyc[2:0]) $write("");
+-000001  point: comment=(cyc[2:0][0]==0 && cyc[2:0][1]==0 && cyc[2:0][2]==0) => 0 hier=top.t
+-000005  point: comment=(cyc[2:0][0]==1) => 1 hier=top.t
+-000004  point: comment=(cyc[2:0][1]==1) => 1 hier=top.t
+-000004  point: comment=(cyc[2:0][2]==1) => 1 hier=top.t
+%000002         if (^cyc[2:0]) $write("");
+-000001  point: comment=(cyc[2:0][0]==0 && cyc[2:0][1]==0 && cyc[2:0][2]==0) => 0 hier=top.t
+-000001  point: comment=(cyc[2:0][0]==0 && cyc[2:0][1]==0 && cyc[2:0][2]==1) => 1 hier=top.t
+-000001  point: comment=(cyc[2:0][0]==0 && cyc[2:0][1]==1 && cyc[2:0][2]==0) => 1 hier=top.t
+-000001  point: comment=(cyc[2:0][0]==0 && cyc[2:0][1]==1 && cyc[2:0][2]==1) => 0 hier=top.t
+-000002  point: comment=(cyc[2:0][0]==1 && cyc[2:0][1]==0 && cyc[2:0][2]==0) => 1 hier=top.t
+-000001  point: comment=(cyc[2:0][0]==1 && cyc[2:0][1]==0 && cyc[2:0][2]==1) => 0 hier=top.t
+-000001  point: comment=(cyc[2:0][0]==1 && cyc[2:0][1]==1 && cyc[2:0][2]==0) => 0 hier=top.t
+-000001  point: comment=(cyc[2:0][0]==1 && cyc[2:0][1]==1 && cyc[2:0][2]==1) => 1 hier=top.t
+%000005         if (|cyc[2:0] || cyc[3]) $write("");
+-000000  point: comment=(cyc[2:0][0]==0 && cyc[2:0][1]==0 && cyc[2:0][2]==0 && cyc[3]==0) => 0 hier=top.t
+-000005  point: comment=(cyc[2:0][0]==1) => 1 hier=top.t
+-000004  point: comment=(cyc[2:0][1]==1) => 1 hier=top.t
+-000004  point: comment=(cyc[2:0][2]==1) => 1 hier=top.t
+-000002  point: comment=(cyc[3]==1) => 1 hier=top.t
+%000005         if (t1 & t2 & 1'b1) $write("");
+-000000  point: comment=(1'h1==0) => 0 hier=top.t
+-000004  point: comment=(t1==0) => 0 hier=top.t
+-000002  point: comment=(t1==1 && t2==1 && 1'h1==1) => 1 hier=top.t
+-000005  point: comment=(t2==0) => 0 hier=top.t
+%000009         if (t1 & t2 & 1'b0) $write("");
+-000009  point: comment=(1'h0==0) => 0 hier=top.t
+-000004  point: comment=(t1==0) => 0 hier=top.t
+-000000  point: comment=(t1==1 && t2==1 && 1'h0==1) => 1 hier=top.t
+-000005  point: comment=(t2==0) => 0 hier=top.t
+%000005         if (t1 & t2 & ONE) $write("");
+-000000  point: comment=(ONE==0) => 0 hier=top.t
+-000004  point: comment=(t1==0) => 0 hier=top.t
+-000002  point: comment=(t1==1 && t2==1 && ONE==1) => 1 hier=top.t
+-000005  point: comment=(t2==0) => 0 hier=top.t
+%000009         if (t1 & t2 & ZERO) $write("");
+-000009  point: comment=(ZERO==0) => 0 hier=top.t
+-000004  point: comment=(t1==0) => 0 hier=top.t
+-000000  point: comment=(t1==1 && t2==1 && ZERO==1) => 1 hier=top.t
+-000005  point: comment=(t2==0) => 0 hier=top.t
+%000005         if (t1 && t2) begin
+-000004  point: comment=(t1==0) => 0 hier=top.t
+-000002  point: comment=(t1==1 && t2==1) => 1 hier=top.t
+-000005  point: comment=(t2==0) => 0 hier=top.t
+                    $write("");
+%000003         end else if (t1 || t2) begin
+-000002  point: comment=(t1==0 && t2==0) => 0 hier=top.t
+-000003  point: comment=(t1==1) => 1 hier=top.t
+-000002  point: comment=(t2==1) => 1 hier=top.t
+                    $write("");
+                end
+%000005         if (invert(t1) && t2) $write("");
+-000005  point: comment=(invert(t1)==0) => 0 hier=top.t
+-000002  point: comment=(invert(t1)==1 && t2==1) => 1 hier=top.t
+-000005  point: comment=(t2==0) => 0 hier=top.t
+                if (and_oper(t1, t2)) $write("");
+%000005         if (t2 && t3) begin
+-000005  point: comment=(t2==0) => 0 hier=top.t
+-000002  point: comment=(t2==1 && t3==1) => 1 hier=top.t
+-000005  point: comment=(t3==0) => 0 hier=top.t
+%000001             if (t1 && t2) $write("");
+-000001  point: comment=(t1==0) => 0 hier=top.t
+-000001  point: comment=(t1==1 && t2==1) => 1 hier=top.t
+-000000  point: comment=(t2==0) => 0 hier=top.t
+                end
+                if (0 == 1) begin
+                    for (int loop_var = 0; loop_var < 1; loop_var++) begin
+%000000                 if (cyc[loop_var] && t2) $write("");
+-000000  point: comment=(cyc[loop_var[4:0]+:32'h1]]==0) => 0 hier=top.t
+-000000  point: comment=(cyc[loop_var[4:0]+:32'h1]]==1 && t2==1) => 1 hier=top.t
+-000000  point: comment=(t2==0) => 0 hier=top.t
+                    end
+                end
+                // stop at the first layer even if there's more to find
+%000007         if ((cyc[3+32'(t1 && t2)+:2] == cyc[5+32'(t3 || t4)+:2]) || cyc[31]) $write("");
+-000002  point: comment=((cyc[(32'sh3 + (t1 && t2))[4:0]+:32'sh2]] == cyc[(32'sh5 + (t3 || t4))[4:0]+:32'sh2]])==0 && cyc[31]==0) => 0 hier=top.t
+-000007  point: comment=((cyc[(32'sh3 + (t1 && t2))[4:0]+:32'sh2]] == cyc[(32'sh5 + (t3 || t4))[4:0]+:32'sh2]])==1) => 1 hier=top.t
+-000000  point: comment=(cyc[31]==1) => 1 hier=top.t
+                // impossible branches and redundant terms
+%000005         if ((t1 && t2) && ~(t1 && t3) && (t1 || t4)) $write("");
+-000003  point: comment=(t1==0 && t4==0) => 0 hier=top.t
+-000004  point: comment=(t1==0) => 0 hier=top.t
+-000000  point: comment=(t1==1 && t2==1 && t3==0 && t4==1) => 1 hier=top.t
+-000001  point: comment=(t1==1 && t2==1 && t3==0) => 1 hier=top.t
+-000002  point: comment=(t1==1 && t3==1) => 0 hier=top.t
+-000005  point: comment=(t2==0) => 0 hier=top.t
+%000005         if ((cyc[0] && cyc[1]) && ~(cyc[0] && cyc[2]) && (cyc[0] || cyc[3])) $write("");
+-000003  point: comment=(cyc[0]==0 && cyc[3]==0) => 0 hier=top.t
+-000004  point: comment=(cyc[0]==0) => 0 hier=top.t
+-000000  point: comment=(cyc[0]==1 && cyc[1]==1 && cyc[2]==0 && cyc[3]==1) => 1 hier=top.t
+-000001  point: comment=(cyc[0]==1 && cyc[1]==1 && cyc[2]==0) => 1 hier=top.t
+-000002  point: comment=(cyc[0]==1 && cyc[2]==1) => 0 hier=top.t
+-000005  point: comment=(cyc[1]==0) => 0 hier=top.t
+                // demonstrate current limitations of term matching scheme
+%000005         if ((cyc[0] && cyc[1]) && ~(cyc[1-1] && cyc[2]) && (cyc[2-2] || cyc[3])) $write("");
+-000002  point: comment=(cyc[(32'sh1 - 32'sh1)[4:0]+:32'h1]]==1 && cyc[2]==1) => 0 hier=top.t
+-000003  point: comment=(cyc[(32'sh2 - 32'sh2)[4:0]+:32'h1]]==0 && cyc[3]==0) => 0 hier=top.t
+-000004  point: comment=(cyc[0]==0) => 0 hier=top.t
+-000000  point: comment=(cyc[0]==1 && cyc[1]==1 && cyc[(32'sh1 - 32'sh1)[4:0]+:32'h1]]==0 && cyc[(32'sh2 - 32'sh2)[4:0]+:32'h1]]==1) => 1 hier=top.t
+-000000  point: comment=(cyc[0]==1 && cyc[1]==1 && cyc[(32'sh1 - 32'sh1)[4:0]+:32'h1]]==0 && cyc[3]==1) => 1 hier=top.t
+-000001  point: comment=(cyc[0]==1 && cyc[1]==1 && cyc[2]==0 && cyc[(32'sh2 - 32'sh2)[4:0]+:32'h1]]==1) => 1 hier=top.t
+-000000  point: comment=(cyc[0]==1 && cyc[1]==1 && cyc[2]==0 && cyc[3]==1) => 1 hier=top.t
+-000005  point: comment=(cyc[1]==0) => 0 hier=top.t
+                //verilator coverage_off
+                if (t1 && t2) $write("");
+                //verilator coverage_on
+                if ((~t1 && t2)
+%000004             ||
+-000002  point: comment=(t1==0 && t2==1) => 1 hier=top.t
+-000002  point: comment=(t1==1 && t3==1) => 0 hier=top.t
+-000004  point: comment=(t1==1 && t4==0) => 0 hier=top.t
+-000002  point: comment=(t2==0 && t3==1) => 0 hier=top.t
+-000003  point: comment=(t2==0 && t4==0) => 0 hier=top.t
+-000002  point: comment=(t3==0 && t4==1) => 1 hier=top.t
+                   (~t3 && t4)) $write("");
+                // intentionally testing wonkified expression terms
+                if (
+                    cyc[
+                      0
+%000005             ] &
+-000004  point: comment=(cyc[0]==0) => 0 hier=top.t
+-000002  point: comment=(cyc[0]==1 && cyc[1]==1) => 1 hier=top.t
+-000005  point: comment=(cyc[1]==0) => 0 hier=top.t
+                    cyc
+                      [1]) $write("");
+                // for now each ternary condition is considered in isolation
+%000005         other_int <= t1 ? t2 ? 1 : 2 : 3;
+-000004  point: comment=(t1==0) => 0 hier=top.t
+-000005  point: comment=(t1==1) => 1 hier=top.t
+                // no expression coverage for multi-bit expressions
+                if ((cyc[1:0] & cyc[3:2]) == 2'b11) $write("");
+                // truth table is too large
+                if (^cyc[6:0]) $write("");
+                // this one is too big even for t_cover_expr_max
+                if (^cyc) $write("");
+                if (cyc==9) begin
+                    $write("*-* All Finished *-*\n");
+                    $finish;
+                end
+            end
+        
+            always_comb begin
+%000005         if (t1 && t2) $write("");
+-000005  point: comment=(t1==0) => 0 hier=top.t
+-000002  point: comment=(t1==1 && t2==1) => 1 hier=top.t
+-000005  point: comment=(t2==0) => 0 hier=top.t
+            end
+        
+            logic ta, tb, tc;
+            initial begin
+                int q[5];
+                int qv;
+        
+                q = '{1, 2, 2, 4, 3};
+                // lambas not handled
+                // NB: there is a bug w/ tracing find_first (maybe lambdas in general?)
+                //     tracing_off does not work around the bug
+        `ifndef TEST_TRACE
+                qv = q.find_first with (item[0] & item[1]);
+        `endif
+                ta = '1;
+                tb = '0;
+                tc = '0;
+%000001         while (ta || tb || tc) begin
+-000001  point: comment=(ta==0 && tb==0 && tc==0) => 0 hier=top.t
+-000000  point: comment=(ta==1) => 1 hier=top.t
+-000000  point: comment=(tb==1) => 1 hier=top.t
+-000000  point: comment=(tc==1) => 1 hier=top.t
+                    tc = tb;
+                    tb = ta;
+                    ta = '0;
+                end
+            end
+        
+            sub the_sub_1 (.p(t1), .q(t2));
+            sub the_sub_2 (.p(t3), .q(t4));
+            // TODO -- non-process expressions
+            sub the_sub_3 (.p(t1 ? t2 : t3), .q(t4));
+        
+            // TODO
+            // pragma for expr coverage off / on
+            // investigate cover point sorting in annotated source
+            // consider reporting don't care terms
+            //
+            // Branches which are statically impossible to reach are still reported.
+            // E.g.
+            // -000000  point: comment=(t1=1 && t2=1 && 1'h0=1) => 1 hier=top.t
+            // These could potentially be pruned, but they currently follow suit for
+            // what branch coverage does.  Perhaps a switch should be added to not
+            // count statically impossible things.
+        
+        endmodule
+        
+        module sub (
+            input p,
+            input q
+        );
+        
+            always_comb begin
+~000019         if (p && q) $write("");
++000017  point: comment=(p==0) => 0 hier=top.t.the_sub_*
+-000002  point: comment=(p==1 && q==1) => 1 hier=top.t.the_sub_*
++000019  point: comment=(q==0) => 0 hier=top.t.the_sub_*
+            end
+        
+        endmodule
+        

--- a/test_regress/t/t_cover_expr.py
+++ b/test_regress/t/t_cover_expr.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2024 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+from pathlib import Path
+
+test.scenarios('simulator')
+
+test.compile(verilator_flags2=['--cc', '--coverage-expr'])
+
+test.execute()
+
+# Read the input .v file and do any CHECK_COVER requests
+test.inline_checks()
+
+test.run(cmd=[
+    os.environ["VERILATOR_ROOT"] + "/bin/verilator_coverage",
+    "--annotate-points",
+    "--annotate",
+    test.obj_dir + "/annotated",
+    test.obj_dir + "/coverage.dat",
+],
+         verilator_run=True)
+
+top = Path(test.top_filename)
+test.files_identical(test.obj_dir + f"/annotated/{top.name}", test.golden_filename)
+
+test.passes()

--- a/test_regress/t/t_cover_expr.v
+++ b/test_regress/t/t_cover_expr.v
@@ -1,0 +1,163 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2024 by Wilson Snyder.
+// SPDX-License-Identifier: CC0-1.0
+
+module t (/*AUTOARG*/
+    // Inputs
+    clk
+    );
+
+    input clk;
+
+    integer cyc;
+    initial cyc=1;
+
+    integer some_int;
+    integer other_int;
+    logic some_bool;
+
+    wire t1 = cyc[0];
+    wire t2 = cyc[1];
+    wire t3 = cyc[2];
+    wire t4 = cyc[3];
+
+    localparam bit ONE = 1'b1;
+    localparam bit ZERO = 1'b0;
+
+    function automatic bit invert(bit x);
+        return ~x;
+    endfunction
+
+    function automatic bit and_oper(bit a, bit b);
+        return a & b;
+    endfunction
+
+    always @ (posedge clk) begin
+        cyc <= cyc + 1;
+        if ((~cyc[0] && cyc[1]) || (~cyc[2] && cyc[3])) $write("");
+        if ((~t1 && t2) || (~t3 && t4)) $write("");
+        if (t3 && (t1 == t2)) $write("");
+        if (123 == (124 - 32'(t1 || t2))) $write("");
+        some_int <= (t2 || t3) ? 345 : 567;
+        some_bool <= t1 && t2;
+        if (t1 & t2) $write("");
+        if ((!t1 && t2) | (~t3 && t4)) $write("");
+        if (t1 ^ t2) $write("");
+        if (~(t1 & t2)) $write("");
+        if (t1 -> t2) $write("");
+        if (t1 <-> t2) $write("");
+        if (&cyc[2:0]) $write("");
+        if (&cyc[3:2]) $write("");
+        if (|cyc[2:0]) $write("");
+        if (^cyc[2:0]) $write("");
+        if (|cyc[2:0] || cyc[3]) $write("");
+        if (t1 & t2 & 1'b1) $write("");
+        if (t1 & t2 & 1'b0) $write("");
+        if (t1 & t2 & ONE) $write("");
+        if (t1 & t2 & ZERO) $write("");
+        if (t1 && t2) begin
+            $write("");
+        end else if (t1 || t2) begin
+            $write("");
+        end
+        if (invert(t1) && t2) $write("");
+        if (and_oper(t1, t2)) $write("");
+        if (t2 && t3) begin
+            if (t1 && t2) $write("");
+        end
+        if (0 == 1) begin
+            for (int loop_var = 0; loop_var < 1; loop_var++) begin
+                if (cyc[loop_var] && t2) $write("");
+            end
+        end
+        // stop at the first layer even if there's more to find
+        if ((cyc[3+32'(t1 && t2)+:2] == cyc[5+32'(t3 || t4)+:2]) || cyc[31]) $write("");
+        // impossible branches and redundant terms
+        if ((t1 && t2) && ~(t1 && t3) && (t1 || t4)) $write("");
+        if ((cyc[0] && cyc[1]) && ~(cyc[0] && cyc[2]) && (cyc[0] || cyc[3])) $write("");
+        // demonstrate current limitations of term matching scheme
+        if ((cyc[0] && cyc[1]) && ~(cyc[1-1] && cyc[2]) && (cyc[2-2] || cyc[3])) $write("");
+        //verilator coverage_off
+        if (t1 && t2) $write("");
+        //verilator coverage_on
+        if ((~t1 && t2)
+            ||
+           (~t3 && t4)) $write("");
+        // intentionally testing wonkified expression terms
+        if (
+            cyc[
+              0
+            ] &
+            cyc
+              [1]) $write("");
+        // for now each ternary condition is considered in isolation
+        other_int <= t1 ? t2 ? 1 : 2 : 3;
+        // no expression coverage for multi-bit expressions
+        if ((cyc[1:0] & cyc[3:2]) == 2'b11) $write("");
+        // truth table is too large
+        if (^cyc[6:0]) $write("");
+        // this one is too big even for t_cover_expr_max
+        if (^cyc) $write("");
+        if (cyc==9) begin
+            $write("*-* All Finished *-*\n");
+            $finish;
+        end
+    end
+
+    always_comb begin
+        if (t1 && t2) $write("");
+    end
+
+    logic ta, tb, tc;
+    initial begin
+        int q[5];
+        int qv;
+
+        q = '{1, 2, 2, 4, 3};
+        // lambas not handled
+        // NB: there is a bug w/ tracing find_first (maybe lambdas in general?)
+        //     tracing_off does not work around the bug
+`ifndef TEST_TRACE
+        qv = q.find_first with (item[0] & item[1]);
+`endif
+        ta = '1;
+        tb = '0;
+        tc = '0;
+        while (ta || tb || tc) begin
+            tc = tb;
+            tb = ta;
+            ta = '0;
+        end
+    end
+
+    sub the_sub_1 (.p(t1), .q(t2));
+    sub the_sub_2 (.p(t3), .q(t4));
+    // TODO -- non-process expressions
+    sub the_sub_3 (.p(t1 ? t2 : t3), .q(t4));
+
+    // TODO
+    // pragma for expr coverage off / on
+    // investigate cover point sorting in annotated source
+    // consider reporting don't care terms
+    //
+    // Branches which are statically impossible to reach are still reported.
+    // E.g.
+    // -000000  point: comment=(t1=1 && t2=1 && 1'h0=1) => 1 hier=top.t
+    // These could potentially be pruned, but they currently follow suit for
+    // what branch coverage does.  Perhaps a switch should be added to not
+    // count statically impossible things.
+
+endmodule
+
+module sub (
+    input p,
+    input q
+);
+
+    always_comb begin
+        if (p && q) $write("");
+    end
+
+endmodule

--- a/test_regress/t/t_cover_expr.v
+++ b/test_regress/t/t_cover_expr.v
@@ -113,15 +113,13 @@ module t (/*AUTOARG*/
     logic ta, tb, tc;
     initial begin
         int q[5];
-        int qv;
+        int qv[$];
 
         q = '{1, 2, 2, 4, 3};
         // lambas not handled
         // NB: there is a bug w/ tracing find_first (maybe lambdas in general?)
         //     tracing_off does not work around the bug
-`ifndef TEST_TRACE
         qv = q.find_first with (item[0] & item[1]);
-`endif
         ta = '1;
         tb = '0;
         tc = '0;

--- a/test_regress/t/t_cover_expr_max.out
+++ b/test_regress/t/t_cover_expr_max.out
@@ -389,15 +389,13 @@
             logic ta, tb, tc;
             initial begin
                 int q[5];
-                int qv;
+                int qv[$];
         
                 q = '{1, 2, 2, 4, 3};
                 // lambas not handled
                 // NB: there is a bug w/ tracing find_first (maybe lambdas in general?)
                 //     tracing_off does not work around the bug
-        `ifndef TEST_TRACE
                 qv = q.find_first with (item[0] & item[1]);
-        `endif
                 ta = '1;
                 tb = '0;
                 tc = '0;

--- a/test_regress/t/t_cover_expr_max.out
+++ b/test_regress/t/t_cover_expr_max.out
@@ -1,0 +1,447 @@
+//      // verilator_coverage annotation
+        // DESCRIPTION: Verilator: Verilog Test module
+        //
+        // This file ONLY is placed under the Creative Commons Public Domain, for
+        // any use, without warranty, 2024 by Wilson Snyder.
+        // SPDX-License-Identifier: CC0-1.0
+        
+        module t (/*AUTOARG*/
+            // Inputs
+            clk
+            );
+        
+            input clk;
+        
+            integer cyc;
+            initial cyc=1;
+        
+            integer some_int;
+            integer other_int;
+            logic some_bool;
+        
+            wire t1 = cyc[0];
+            wire t2 = cyc[1];
+            wire t3 = cyc[2];
+            wire t4 = cyc[3];
+        
+            localparam bit ONE = 1'b1;
+            localparam bit ZERO = 1'b0;
+        
+            function automatic bit invert(bit x);
+ 000015         return ~x;
++000012  point: comment=(x==0) => 1 hier=top.t
++000015  point: comment=(x==1) => 0 hier=top.t
+            endfunction
+        
+            function automatic bit and_oper(bit a, bit b);
+%000005         return a & b;
+-000004  point: comment=(a==0) => 0 hier=top.t
+-000002  point: comment=(a==1 && b==1) => 1 hier=top.t
+-000005  point: comment=(b==0) => 0 hier=top.t
+            endfunction
+        
+            always @ (posedge clk) begin
+                cyc <= cyc + 1;
+%000004         if ((~cyc[0] && cyc[1]) || (~cyc[2] && cyc[3])) $write("");
+-000002  point: comment=(cyc[0]==0 && cyc[1]==1) => 1 hier=top.t
+-000002  point: comment=(cyc[0]==1 && cyc[2]==1) => 0 hier=top.t
+-000004  point: comment=(cyc[0]==1 && cyc[3]==0) => 0 hier=top.t
+-000002  point: comment=(cyc[1]==0 && cyc[2]==1) => 0 hier=top.t
+-000003  point: comment=(cyc[1]==0 && cyc[3]==0) => 0 hier=top.t
+-000002  point: comment=(cyc[2]==0 && cyc[3]==1) => 1 hier=top.t
+%000004         if ((~t1 && t2) || (~t3 && t4)) $write("");
+-000002  point: comment=(t1==0 && t2==1) => 1 hier=top.t
+-000002  point: comment=(t1==1 && t3==1) => 0 hier=top.t
+-000004  point: comment=(t1==1 && t4==0) => 0 hier=top.t
+-000002  point: comment=(t2==0 && t3==1) => 0 hier=top.t
+-000003  point: comment=(t2==0 && t4==0) => 0 hier=top.t
+-000002  point: comment=(t3==0 && t4==1) => 1 hier=top.t
+%000005         if (t3 && (t1 == t2)) $write("");
+-000005  point: comment=((t1 == t2)==0) => 0 hier=top.t
+-000005  point: comment=(t3==0) => 0 hier=top.t
+-000002  point: comment=(t3==1 && (t1 == t2)==1) => 1 hier=top.t
+%000005         if (123 == (124 - 32'(t1 || t2))) $write("");
+-000002  point: comment=(t1==0 && t2==0) => 0 hier=top.t
+-000005  point: comment=(t1==1) => 1 hier=top.t
+-000004  point: comment=(t2==1) => 1 hier=top.t
+%000004         some_int <= (t2 || t3) ? 345 : 567;
+-000003  point: comment=(t2==0 && t3==0) => 0 hier=top.t
+-000004  point: comment=(t2==1) => 1 hier=top.t
+-000004  point: comment=(t3==1) => 1 hier=top.t
+%000005         some_bool <= t1 && t2;
+-000004  point: comment=(t1==0) => 0 hier=top.t
+-000002  point: comment=(t1==1 && t2==1) => 1 hier=top.t
+-000005  point: comment=(t2==0) => 0 hier=top.t
+%000005         if (t1 & t2) $write("");
+-000004  point: comment=(t1==0) => 0 hier=top.t
+-000002  point: comment=(t1==1 && t2==1) => 1 hier=top.t
+-000005  point: comment=(t2==0) => 0 hier=top.t
+%000004         if ((!t1 && t2) | (~t3 && t4)) $write("");
+-000002  point: comment=(t1==0 && t2==1) => 1 hier=top.t
+-000002  point: comment=(t1==1 && t3==1) => 0 hier=top.t
+-000004  point: comment=(t1==1 && t4==0) => 0 hier=top.t
+-000002  point: comment=(t2==0 && t3==1) => 0 hier=top.t
+-000003  point: comment=(t2==0 && t4==0) => 0 hier=top.t
+-000002  point: comment=(t3==0 && t4==1) => 1 hier=top.t
+%000003         if (t1 ^ t2) $write("");
+-000002  point: comment=(t1==0 && t2==0) => 0 hier=top.t
+-000002  point: comment=(t1==0 && t2==1) => 1 hier=top.t
+-000003  point: comment=(t1==1 && t2==0) => 1 hier=top.t
+-000002  point: comment=(t1==1 && t2==1) => 0 hier=top.t
+%000005         if (~(t1 & t2)) $write("");
+-000004  point: comment=(t1==0) => 1 hier=top.t
+-000002  point: comment=(t1==1 && t2==1) => 0 hier=top.t
+-000005  point: comment=(t2==0) => 1 hier=top.t
+%000004         if (t1 -> t2) $write("");
+-000004  point: comment=(t1==0) => 1 hier=top.t
+-000003  point: comment=(t1==1 && t2==0) => 0 hier=top.t
+-000004  point: comment=(t2==1) => 1 hier=top.t
+%000003         if (t1 <-> t2) $write("");
+-000002  point: comment=(t1==0 && t2==0) => 1 hier=top.t
+-000002  point: comment=(t1==0 && t2==1) => 0 hier=top.t
+-000003  point: comment=(t1==1 && t2==0) => 0 hier=top.t
+-000002  point: comment=(t1==1 && t2==1) => 1 hier=top.t
+%000005         if (&cyc[2:0]) $write("");
+-000004  point: comment=(cyc[2:0][0]==0) => 0 hier=top.t
+-000001  point: comment=(cyc[2:0][0]==1 && cyc[2:0][1]==1 && cyc[2:0][2]==1) => 1 hier=top.t
+-000005  point: comment=(cyc[2:0][1]==0) => 0 hier=top.t
+-000005  point: comment=(cyc[2:0][2]==0) => 0 hier=top.t
+%000007         if (&cyc[3:2]) $write("");
+-000005  point: comment=(cyc[3:2][0]==0) => 0 hier=top.t
+-000000  point: comment=(cyc[3:2][0]==1 && cyc[3:2][1]==1) => 1 hier=top.t
+-000007  point: comment=(cyc[3:2][1]==0) => 0 hier=top.t
+%000005         if (|cyc[2:0]) $write("");
+-000001  point: comment=(cyc[2:0][0]==0 && cyc[2:0][1]==0 && cyc[2:0][2]==0) => 0 hier=top.t
+-000005  point: comment=(cyc[2:0][0]==1) => 1 hier=top.t
+-000004  point: comment=(cyc[2:0][1]==1) => 1 hier=top.t
+-000004  point: comment=(cyc[2:0][2]==1) => 1 hier=top.t
+%000002         if (^cyc[2:0]) $write("");
+-000001  point: comment=(cyc[2:0][0]==0 && cyc[2:0][1]==0 && cyc[2:0][2]==0) => 0 hier=top.t
+-000001  point: comment=(cyc[2:0][0]==0 && cyc[2:0][1]==0 && cyc[2:0][2]==1) => 1 hier=top.t
+-000001  point: comment=(cyc[2:0][0]==0 && cyc[2:0][1]==1 && cyc[2:0][2]==0) => 1 hier=top.t
+-000001  point: comment=(cyc[2:0][0]==0 && cyc[2:0][1]==1 && cyc[2:0][2]==1) => 0 hier=top.t
+-000002  point: comment=(cyc[2:0][0]==1 && cyc[2:0][1]==0 && cyc[2:0][2]==0) => 1 hier=top.t
+-000001  point: comment=(cyc[2:0][0]==1 && cyc[2:0][1]==0 && cyc[2:0][2]==1) => 0 hier=top.t
+-000001  point: comment=(cyc[2:0][0]==1 && cyc[2:0][1]==1 && cyc[2:0][2]==0) => 0 hier=top.t
+-000001  point: comment=(cyc[2:0][0]==1 && cyc[2:0][1]==1 && cyc[2:0][2]==1) => 1 hier=top.t
+%000005         if (|cyc[2:0] || cyc[3]) $write("");
+-000000  point: comment=(cyc[2:0][0]==0 && cyc[2:0][1]==0 && cyc[2:0][2]==0 && cyc[3]==0) => 0 hier=top.t
+-000005  point: comment=(cyc[2:0][0]==1) => 1 hier=top.t
+-000004  point: comment=(cyc[2:0][1]==1) => 1 hier=top.t
+-000004  point: comment=(cyc[2:0][2]==1) => 1 hier=top.t
+-000002  point: comment=(cyc[3]==1) => 1 hier=top.t
+%000005         if (t1 & t2 & 1'b1) $write("");
+-000000  point: comment=(1'h1==0) => 0 hier=top.t
+-000004  point: comment=(t1==0) => 0 hier=top.t
+-000002  point: comment=(t1==1 && t2==1 && 1'h1==1) => 1 hier=top.t
+-000005  point: comment=(t2==0) => 0 hier=top.t
+%000009         if (t1 & t2 & 1'b0) $write("");
+-000009  point: comment=(1'h0==0) => 0 hier=top.t
+-000004  point: comment=(t1==0) => 0 hier=top.t
+-000000  point: comment=(t1==1 && t2==1 && 1'h0==1) => 1 hier=top.t
+-000005  point: comment=(t2==0) => 0 hier=top.t
+%000005         if (t1 & t2 & ONE) $write("");
+-000000  point: comment=(ONE==0) => 0 hier=top.t
+-000004  point: comment=(t1==0) => 0 hier=top.t
+-000002  point: comment=(t1==1 && t2==1 && ONE==1) => 1 hier=top.t
+-000005  point: comment=(t2==0) => 0 hier=top.t
+%000009         if (t1 & t2 & ZERO) $write("");
+-000009  point: comment=(ZERO==0) => 0 hier=top.t
+-000004  point: comment=(t1==0) => 0 hier=top.t
+-000000  point: comment=(t1==1 && t2==1 && ZERO==1) => 1 hier=top.t
+-000005  point: comment=(t2==0) => 0 hier=top.t
+%000005         if (t1 && t2) begin
+-000004  point: comment=(t1==0) => 0 hier=top.t
+-000002  point: comment=(t1==1 && t2==1) => 1 hier=top.t
+-000005  point: comment=(t2==0) => 0 hier=top.t
+                    $write("");
+%000003         end else if (t1 || t2) begin
+-000002  point: comment=(t1==0 && t2==0) => 0 hier=top.t
+-000003  point: comment=(t1==1) => 1 hier=top.t
+-000002  point: comment=(t2==1) => 1 hier=top.t
+                    $write("");
+                end
+%000005         if (invert(t1) && t2) $write("");
+-000005  point: comment=(invert(t1)==0) => 0 hier=top.t
+-000002  point: comment=(invert(t1)==1 && t2==1) => 1 hier=top.t
+-000005  point: comment=(t2==0) => 0 hier=top.t
+                if (and_oper(t1, t2)) $write("");
+%000005         if (t2 && t3) begin
+-000005  point: comment=(t2==0) => 0 hier=top.t
+-000002  point: comment=(t2==1 && t3==1) => 1 hier=top.t
+-000005  point: comment=(t3==0) => 0 hier=top.t
+%000001             if (t1 && t2) $write("");
+-000001  point: comment=(t1==0) => 0 hier=top.t
+-000001  point: comment=(t1==1 && t2==1) => 1 hier=top.t
+-000000  point: comment=(t2==0) => 0 hier=top.t
+                end
+                if (0 == 1) begin
+                    for (int loop_var = 0; loop_var < 1; loop_var++) begin
+%000000                 if (cyc[loop_var] && t2) $write("");
+-000000  point: comment=(cyc[loop_var[4:0]+:32'h1]]==0) => 0 hier=top.t
+-000000  point: comment=(cyc[loop_var[4:0]+:32'h1]]==1 && t2==1) => 1 hier=top.t
+-000000  point: comment=(t2==0) => 0 hier=top.t
+                    end
+                end
+                // stop at the first layer even if there's more to find
+%000007         if ((cyc[3+32'(t1 && t2)+:2] == cyc[5+32'(t3 || t4)+:2]) || cyc[31]) $write("");
+-000002  point: comment=((cyc[(32'sh3 + (t1 && t2))[4:0]+:32'sh2]] == cyc[(32'sh5 + (t3 || t4))[4:0]+:32'sh2]])==0 && cyc[31]==0) => 0 hier=top.t
+-000007  point: comment=((cyc[(32'sh3 + (t1 && t2))[4:0]+:32'sh2]] == cyc[(32'sh5 + (t3 || t4))[4:0]+:32'sh2]])==1) => 1 hier=top.t
+-000000  point: comment=(cyc[31]==1) => 1 hier=top.t
+                // impossible branches and redundant terms
+%000005         if ((t1 && t2) && ~(t1 && t3) && (t1 || t4)) $write("");
+-000003  point: comment=(t1==0 && t4==0) => 0 hier=top.t
+-000004  point: comment=(t1==0) => 0 hier=top.t
+-000000  point: comment=(t1==1 && t2==1 && t3==0 && t4==1) => 1 hier=top.t
+-000001  point: comment=(t1==1 && t2==1 && t3==0) => 1 hier=top.t
+-000002  point: comment=(t1==1 && t3==1) => 0 hier=top.t
+-000005  point: comment=(t2==0) => 0 hier=top.t
+%000005         if ((cyc[0] && cyc[1]) && ~(cyc[0] && cyc[2]) && (cyc[0] || cyc[3])) $write("");
+-000003  point: comment=(cyc[0]==0 && cyc[3]==0) => 0 hier=top.t
+-000004  point: comment=(cyc[0]==0) => 0 hier=top.t
+-000000  point: comment=(cyc[0]==1 && cyc[1]==1 && cyc[2]==0 && cyc[3]==1) => 1 hier=top.t
+-000001  point: comment=(cyc[0]==1 && cyc[1]==1 && cyc[2]==0) => 1 hier=top.t
+-000002  point: comment=(cyc[0]==1 && cyc[2]==1) => 0 hier=top.t
+-000005  point: comment=(cyc[1]==0) => 0 hier=top.t
+                // demonstrate current limitations of term matching scheme
+%000005         if ((cyc[0] && cyc[1]) && ~(cyc[1-1] && cyc[2]) && (cyc[2-2] || cyc[3])) $write("");
+-000002  point: comment=(cyc[(32'sh1 - 32'sh1)[4:0]+:32'h1]]==1 && cyc[2]==1) => 0 hier=top.t
+-000003  point: comment=(cyc[(32'sh2 - 32'sh2)[4:0]+:32'h1]]==0 && cyc[3]==0) => 0 hier=top.t
+-000004  point: comment=(cyc[0]==0) => 0 hier=top.t
+-000000  point: comment=(cyc[0]==1 && cyc[1]==1 && cyc[(32'sh1 - 32'sh1)[4:0]+:32'h1]]==0 && cyc[(32'sh2 - 32'sh2)[4:0]+:32'h1]]==1) => 1 hier=top.t
+-000000  point: comment=(cyc[0]==1 && cyc[1]==1 && cyc[(32'sh1 - 32'sh1)[4:0]+:32'h1]]==0 && cyc[3]==1) => 1 hier=top.t
+-000001  point: comment=(cyc[0]==1 && cyc[1]==1 && cyc[2]==0 && cyc[(32'sh2 - 32'sh2)[4:0]+:32'h1]]==1) => 1 hier=top.t
+-000000  point: comment=(cyc[0]==1 && cyc[1]==1 && cyc[2]==0 && cyc[3]==1) => 1 hier=top.t
+-000005  point: comment=(cyc[1]==0) => 0 hier=top.t
+                //verilator coverage_off
+                if (t1 && t2) $write("");
+                //verilator coverage_on
+                if ((~t1 && t2)
+%000004             ||
+-000002  point: comment=(t1==0 && t2==1) => 1 hier=top.t
+-000002  point: comment=(t1==1 && t3==1) => 0 hier=top.t
+-000004  point: comment=(t1==1 && t4==0) => 0 hier=top.t
+-000002  point: comment=(t2==0 && t3==1) => 0 hier=top.t
+-000003  point: comment=(t2==0 && t4==0) => 0 hier=top.t
+-000002  point: comment=(t3==0 && t4==1) => 1 hier=top.t
+                   (~t3 && t4)) $write("");
+                // intentionally testing wonkified expression terms
+                if (
+                    cyc[
+                      0
+%000005             ] &
+-000004  point: comment=(cyc[0]==0) => 0 hier=top.t
+-000002  point: comment=(cyc[0]==1 && cyc[1]==1) => 1 hier=top.t
+-000005  point: comment=(cyc[1]==0) => 0 hier=top.t
+                    cyc
+                      [1]) $write("");
+                // for now each ternary condition is considered in isolation
+%000005         other_int <= t1 ? t2 ? 1 : 2 : 3;
+-000004  point: comment=(t1==0) => 0 hier=top.t
+-000005  point: comment=(t1==1) => 1 hier=top.t
+                // no expression coverage for multi-bit expressions
+                if ((cyc[1:0] & cyc[3:2]) == 2'b11) $write("");
+                // truth table is too large
+%000001         if (^cyc[6:0]) $write("");
+-000000  point: comment=(cyc[6:0][0]==0 && cyc[6:0][1]==0 && cyc[6:0][2]==0 && cyc[6:0][3]==0 && cyc[6:0][4]==0 && cyc[6:0][5]==0 && cyc[6:0][6]==0) => 0 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==0 && cyc[6:0][1]==0 && cyc[6:0][2]==0 && cyc[6:0][3]==0 && cyc[6:0][4]==0 && cyc[6:0][5]==0 && cyc[6:0][6]==1) => 1 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==0 && cyc[6:0][1]==0 && cyc[6:0][2]==0 && cyc[6:0][3]==0 && cyc[6:0][4]==0 && cyc[6:0][5]==1 && cyc[6:0][6]==0) => 1 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==0 && cyc[6:0][1]==0 && cyc[6:0][2]==0 && cyc[6:0][3]==0 && cyc[6:0][4]==0 && cyc[6:0][5]==1 && cyc[6:0][6]==1) => 0 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==0 && cyc[6:0][1]==0 && cyc[6:0][2]==0 && cyc[6:0][3]==0 && cyc[6:0][4]==1 && cyc[6:0][5]==0 && cyc[6:0][6]==0) => 1 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==0 && cyc[6:0][1]==0 && cyc[6:0][2]==0 && cyc[6:0][3]==0 && cyc[6:0][4]==1 && cyc[6:0][5]==0 && cyc[6:0][6]==1) => 0 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==0 && cyc[6:0][1]==0 && cyc[6:0][2]==0 && cyc[6:0][3]==0 && cyc[6:0][4]==1 && cyc[6:0][5]==1 && cyc[6:0][6]==0) => 0 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==0 && cyc[6:0][1]==0 && cyc[6:0][2]==0 && cyc[6:0][3]==0 && cyc[6:0][4]==1 && cyc[6:0][5]==1 && cyc[6:0][6]==1) => 1 hier=top.t
+-000001  point: comment=(cyc[6:0][0]==0 && cyc[6:0][1]==0 && cyc[6:0][2]==0 && cyc[6:0][3]==1 && cyc[6:0][4]==0 && cyc[6:0][5]==0 && cyc[6:0][6]==0) => 1 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==0 && cyc[6:0][1]==0 && cyc[6:0][2]==0 && cyc[6:0][3]==1 && cyc[6:0][4]==0 && cyc[6:0][5]==0 && cyc[6:0][6]==1) => 0 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==0 && cyc[6:0][1]==0 && cyc[6:0][2]==0 && cyc[6:0][3]==1 && cyc[6:0][4]==0 && cyc[6:0][5]==1 && cyc[6:0][6]==0) => 0 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==0 && cyc[6:0][1]==0 && cyc[6:0][2]==0 && cyc[6:0][3]==1 && cyc[6:0][4]==0 && cyc[6:0][5]==1 && cyc[6:0][6]==1) => 1 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==0 && cyc[6:0][1]==0 && cyc[6:0][2]==0 && cyc[6:0][3]==1 && cyc[6:0][4]==1 && cyc[6:0][5]==0 && cyc[6:0][6]==0) => 0 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==0 && cyc[6:0][1]==0 && cyc[6:0][2]==0 && cyc[6:0][3]==1 && cyc[6:0][4]==1 && cyc[6:0][5]==0 && cyc[6:0][6]==1) => 1 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==0 && cyc[6:0][1]==0 && cyc[6:0][2]==0 && cyc[6:0][3]==1 && cyc[6:0][4]==1 && cyc[6:0][5]==1 && cyc[6:0][6]==0) => 1 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==0 && cyc[6:0][1]==0 && cyc[6:0][2]==0 && cyc[6:0][3]==1 && cyc[6:0][4]==1 && cyc[6:0][5]==1 && cyc[6:0][6]==1) => 0 hier=top.t
+-000001  point: comment=(cyc[6:0][0]==0 && cyc[6:0][1]==0 && cyc[6:0][2]==1 && cyc[6:0][3]==0 && cyc[6:0][4]==0 && cyc[6:0][5]==0 && cyc[6:0][6]==0) => 1 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==0 && cyc[6:0][1]==0 && cyc[6:0][2]==1 && cyc[6:0][3]==0 && cyc[6:0][4]==0 && cyc[6:0][5]==0 && cyc[6:0][6]==1) => 0 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==0 && cyc[6:0][1]==0 && cyc[6:0][2]==1 && cyc[6:0][3]==0 && cyc[6:0][4]==0 && cyc[6:0][5]==1 && cyc[6:0][6]==0) => 0 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==0 && cyc[6:0][1]==0 && cyc[6:0][2]==1 && cyc[6:0][3]==0 && cyc[6:0][4]==0 && cyc[6:0][5]==1 && cyc[6:0][6]==1) => 1 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==0 && cyc[6:0][1]==0 && cyc[6:0][2]==1 && cyc[6:0][3]==0 && cyc[6:0][4]==1 && cyc[6:0][5]==0 && cyc[6:0][6]==0) => 0 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==0 && cyc[6:0][1]==0 && cyc[6:0][2]==1 && cyc[6:0][3]==0 && cyc[6:0][4]==1 && cyc[6:0][5]==0 && cyc[6:0][6]==1) => 1 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==0 && cyc[6:0][1]==0 && cyc[6:0][2]==1 && cyc[6:0][3]==0 && cyc[6:0][4]==1 && cyc[6:0][5]==1 && cyc[6:0][6]==0) => 1 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==0 && cyc[6:0][1]==0 && cyc[6:0][2]==1 && cyc[6:0][3]==0 && cyc[6:0][4]==1 && cyc[6:0][5]==1 && cyc[6:0][6]==1) => 0 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==0 && cyc[6:0][1]==0 && cyc[6:0][2]==1 && cyc[6:0][3]==1 && cyc[6:0][4]==0 && cyc[6:0][5]==0 && cyc[6:0][6]==0) => 0 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==0 && cyc[6:0][1]==0 && cyc[6:0][2]==1 && cyc[6:0][3]==1 && cyc[6:0][4]==0 && cyc[6:0][5]==0 && cyc[6:0][6]==1) => 1 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==0 && cyc[6:0][1]==0 && cyc[6:0][2]==1 && cyc[6:0][3]==1 && cyc[6:0][4]==0 && cyc[6:0][5]==1 && cyc[6:0][6]==0) => 1 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==0 && cyc[6:0][1]==0 && cyc[6:0][2]==1 && cyc[6:0][3]==1 && cyc[6:0][4]==0 && cyc[6:0][5]==1 && cyc[6:0][6]==1) => 0 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==0 && cyc[6:0][1]==0 && cyc[6:0][2]==1 && cyc[6:0][3]==1 && cyc[6:0][4]==1 && cyc[6:0][5]==0 && cyc[6:0][6]==0) => 1 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==0 && cyc[6:0][1]==0 && cyc[6:0][2]==1 && cyc[6:0][3]==1 && cyc[6:0][4]==1 && cyc[6:0][5]==0 && cyc[6:0][6]==1) => 0 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==0 && cyc[6:0][1]==0 && cyc[6:0][2]==1 && cyc[6:0][3]==1 && cyc[6:0][4]==1 && cyc[6:0][5]==1 && cyc[6:0][6]==0) => 0 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==0 && cyc[6:0][1]==0 && cyc[6:0][2]==1 && cyc[6:0][3]==1 && cyc[6:0][4]==1 && cyc[6:0][5]==1 && cyc[6:0][6]==1) => 1 hier=top.t
+-000001  point: comment=(cyc[6:0][0]==0 && cyc[6:0][1]==1 && cyc[6:0][2]==0 && cyc[6:0][3]==0 && cyc[6:0][4]==0 && cyc[6:0][5]==0 && cyc[6:0][6]==0) => 1 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==0 && cyc[6:0][1]==1 && cyc[6:0][2]==0 && cyc[6:0][3]==0 && cyc[6:0][4]==0 && cyc[6:0][5]==0 && cyc[6:0][6]==1) => 0 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==0 && cyc[6:0][1]==1 && cyc[6:0][2]==0 && cyc[6:0][3]==0 && cyc[6:0][4]==0 && cyc[6:0][5]==1 && cyc[6:0][6]==0) => 0 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==0 && cyc[6:0][1]==1 && cyc[6:0][2]==0 && cyc[6:0][3]==0 && cyc[6:0][4]==0 && cyc[6:0][5]==1 && cyc[6:0][6]==1) => 1 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==0 && cyc[6:0][1]==1 && cyc[6:0][2]==0 && cyc[6:0][3]==0 && cyc[6:0][4]==1 && cyc[6:0][5]==0 && cyc[6:0][6]==0) => 0 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==0 && cyc[6:0][1]==1 && cyc[6:0][2]==0 && cyc[6:0][3]==0 && cyc[6:0][4]==1 && cyc[6:0][5]==0 && cyc[6:0][6]==1) => 1 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==0 && cyc[6:0][1]==1 && cyc[6:0][2]==0 && cyc[6:0][3]==0 && cyc[6:0][4]==1 && cyc[6:0][5]==1 && cyc[6:0][6]==0) => 1 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==0 && cyc[6:0][1]==1 && cyc[6:0][2]==0 && cyc[6:0][3]==0 && cyc[6:0][4]==1 && cyc[6:0][5]==1 && cyc[6:0][6]==1) => 0 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==0 && cyc[6:0][1]==1 && cyc[6:0][2]==0 && cyc[6:0][3]==1 && cyc[6:0][4]==0 && cyc[6:0][5]==0 && cyc[6:0][6]==0) => 0 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==0 && cyc[6:0][1]==1 && cyc[6:0][2]==0 && cyc[6:0][3]==1 && cyc[6:0][4]==0 && cyc[6:0][5]==0 && cyc[6:0][6]==1) => 1 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==0 && cyc[6:0][1]==1 && cyc[6:0][2]==0 && cyc[6:0][3]==1 && cyc[6:0][4]==0 && cyc[6:0][5]==1 && cyc[6:0][6]==0) => 1 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==0 && cyc[6:0][1]==1 && cyc[6:0][2]==0 && cyc[6:0][3]==1 && cyc[6:0][4]==0 && cyc[6:0][5]==1 && cyc[6:0][6]==1) => 0 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==0 && cyc[6:0][1]==1 && cyc[6:0][2]==0 && cyc[6:0][3]==1 && cyc[6:0][4]==1 && cyc[6:0][5]==0 && cyc[6:0][6]==0) => 1 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==0 && cyc[6:0][1]==1 && cyc[6:0][2]==0 && cyc[6:0][3]==1 && cyc[6:0][4]==1 && cyc[6:0][5]==0 && cyc[6:0][6]==1) => 0 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==0 && cyc[6:0][1]==1 && cyc[6:0][2]==0 && cyc[6:0][3]==1 && cyc[6:0][4]==1 && cyc[6:0][5]==1 && cyc[6:0][6]==0) => 0 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==0 && cyc[6:0][1]==1 && cyc[6:0][2]==0 && cyc[6:0][3]==1 && cyc[6:0][4]==1 && cyc[6:0][5]==1 && cyc[6:0][6]==1) => 1 hier=top.t
+-000001  point: comment=(cyc[6:0][0]==0 && cyc[6:0][1]==1 && cyc[6:0][2]==1 && cyc[6:0][3]==0 && cyc[6:0][4]==0 && cyc[6:0][5]==0 && cyc[6:0][6]==0) => 0 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==0 && cyc[6:0][1]==1 && cyc[6:0][2]==1 && cyc[6:0][3]==0 && cyc[6:0][4]==0 && cyc[6:0][5]==0 && cyc[6:0][6]==1) => 1 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==0 && cyc[6:0][1]==1 && cyc[6:0][2]==1 && cyc[6:0][3]==0 && cyc[6:0][4]==0 && cyc[6:0][5]==1 && cyc[6:0][6]==0) => 1 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==0 && cyc[6:0][1]==1 && cyc[6:0][2]==1 && cyc[6:0][3]==0 && cyc[6:0][4]==0 && cyc[6:0][5]==1 && cyc[6:0][6]==1) => 0 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==0 && cyc[6:0][1]==1 && cyc[6:0][2]==1 && cyc[6:0][3]==0 && cyc[6:0][4]==1 && cyc[6:0][5]==0 && cyc[6:0][6]==0) => 1 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==0 && cyc[6:0][1]==1 && cyc[6:0][2]==1 && cyc[6:0][3]==0 && cyc[6:0][4]==1 && cyc[6:0][5]==0 && cyc[6:0][6]==1) => 0 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==0 && cyc[6:0][1]==1 && cyc[6:0][2]==1 && cyc[6:0][3]==0 && cyc[6:0][4]==1 && cyc[6:0][5]==1 && cyc[6:0][6]==0) => 0 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==0 && cyc[6:0][1]==1 && cyc[6:0][2]==1 && cyc[6:0][3]==0 && cyc[6:0][4]==1 && cyc[6:0][5]==1 && cyc[6:0][6]==1) => 1 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==0 && cyc[6:0][1]==1 && cyc[6:0][2]==1 && cyc[6:0][3]==1 && cyc[6:0][4]==0 && cyc[6:0][5]==0 && cyc[6:0][6]==0) => 1 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==0 && cyc[6:0][1]==1 && cyc[6:0][2]==1 && cyc[6:0][3]==1 && cyc[6:0][4]==0 && cyc[6:0][5]==0 && cyc[6:0][6]==1) => 0 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==0 && cyc[6:0][1]==1 && cyc[6:0][2]==1 && cyc[6:0][3]==1 && cyc[6:0][4]==0 && cyc[6:0][5]==1 && cyc[6:0][6]==0) => 0 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==0 && cyc[6:0][1]==1 && cyc[6:0][2]==1 && cyc[6:0][3]==1 && cyc[6:0][4]==0 && cyc[6:0][5]==1 && cyc[6:0][6]==1) => 1 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==0 && cyc[6:0][1]==1 && cyc[6:0][2]==1 && cyc[6:0][3]==1 && cyc[6:0][4]==1 && cyc[6:0][5]==0 && cyc[6:0][6]==0) => 0 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==0 && cyc[6:0][1]==1 && cyc[6:0][2]==1 && cyc[6:0][3]==1 && cyc[6:0][4]==1 && cyc[6:0][5]==0 && cyc[6:0][6]==1) => 1 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==0 && cyc[6:0][1]==1 && cyc[6:0][2]==1 && cyc[6:0][3]==1 && cyc[6:0][4]==1 && cyc[6:0][5]==1 && cyc[6:0][6]==0) => 1 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==0 && cyc[6:0][1]==1 && cyc[6:0][2]==1 && cyc[6:0][3]==1 && cyc[6:0][4]==1 && cyc[6:0][5]==1 && cyc[6:0][6]==1) => 0 hier=top.t
+-000001  point: comment=(cyc[6:0][0]==1 && cyc[6:0][1]==0 && cyc[6:0][2]==0 && cyc[6:0][3]==0 && cyc[6:0][4]==0 && cyc[6:0][5]==0 && cyc[6:0][6]==0) => 1 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==1 && cyc[6:0][1]==0 && cyc[6:0][2]==0 && cyc[6:0][3]==0 && cyc[6:0][4]==0 && cyc[6:0][5]==0 && cyc[6:0][6]==1) => 0 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==1 && cyc[6:0][1]==0 && cyc[6:0][2]==0 && cyc[6:0][3]==0 && cyc[6:0][4]==0 && cyc[6:0][5]==1 && cyc[6:0][6]==0) => 0 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==1 && cyc[6:0][1]==0 && cyc[6:0][2]==0 && cyc[6:0][3]==0 && cyc[6:0][4]==0 && cyc[6:0][5]==1 && cyc[6:0][6]==1) => 1 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==1 && cyc[6:0][1]==0 && cyc[6:0][2]==0 && cyc[6:0][3]==0 && cyc[6:0][4]==1 && cyc[6:0][5]==0 && cyc[6:0][6]==0) => 0 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==1 && cyc[6:0][1]==0 && cyc[6:0][2]==0 && cyc[6:0][3]==0 && cyc[6:0][4]==1 && cyc[6:0][5]==0 && cyc[6:0][6]==1) => 1 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==1 && cyc[6:0][1]==0 && cyc[6:0][2]==0 && cyc[6:0][3]==0 && cyc[6:0][4]==1 && cyc[6:0][5]==1 && cyc[6:0][6]==0) => 1 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==1 && cyc[6:0][1]==0 && cyc[6:0][2]==0 && cyc[6:0][3]==0 && cyc[6:0][4]==1 && cyc[6:0][5]==1 && cyc[6:0][6]==1) => 0 hier=top.t
+-000001  point: comment=(cyc[6:0][0]==1 && cyc[6:0][1]==0 && cyc[6:0][2]==0 && cyc[6:0][3]==1 && cyc[6:0][4]==0 && cyc[6:0][5]==0 && cyc[6:0][6]==0) => 0 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==1 && cyc[6:0][1]==0 && cyc[6:0][2]==0 && cyc[6:0][3]==1 && cyc[6:0][4]==0 && cyc[6:0][5]==0 && cyc[6:0][6]==1) => 1 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==1 && cyc[6:0][1]==0 && cyc[6:0][2]==0 && cyc[6:0][3]==1 && cyc[6:0][4]==0 && cyc[6:0][5]==1 && cyc[6:0][6]==0) => 1 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==1 && cyc[6:0][1]==0 && cyc[6:0][2]==0 && cyc[6:0][3]==1 && cyc[6:0][4]==0 && cyc[6:0][5]==1 && cyc[6:0][6]==1) => 0 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==1 && cyc[6:0][1]==0 && cyc[6:0][2]==0 && cyc[6:0][3]==1 && cyc[6:0][4]==1 && cyc[6:0][5]==0 && cyc[6:0][6]==0) => 1 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==1 && cyc[6:0][1]==0 && cyc[6:0][2]==0 && cyc[6:0][3]==1 && cyc[6:0][4]==1 && cyc[6:0][5]==0 && cyc[6:0][6]==1) => 0 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==1 && cyc[6:0][1]==0 && cyc[6:0][2]==0 && cyc[6:0][3]==1 && cyc[6:0][4]==1 && cyc[6:0][5]==1 && cyc[6:0][6]==0) => 0 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==1 && cyc[6:0][1]==0 && cyc[6:0][2]==0 && cyc[6:0][3]==1 && cyc[6:0][4]==1 && cyc[6:0][5]==1 && cyc[6:0][6]==1) => 1 hier=top.t
+-000001  point: comment=(cyc[6:0][0]==1 && cyc[6:0][1]==0 && cyc[6:0][2]==1 && cyc[6:0][3]==0 && cyc[6:0][4]==0 && cyc[6:0][5]==0 && cyc[6:0][6]==0) => 0 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==1 && cyc[6:0][1]==0 && cyc[6:0][2]==1 && cyc[6:0][3]==0 && cyc[6:0][4]==0 && cyc[6:0][5]==0 && cyc[6:0][6]==1) => 1 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==1 && cyc[6:0][1]==0 && cyc[6:0][2]==1 && cyc[6:0][3]==0 && cyc[6:0][4]==0 && cyc[6:0][5]==1 && cyc[6:0][6]==0) => 1 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==1 && cyc[6:0][1]==0 && cyc[6:0][2]==1 && cyc[6:0][3]==0 && cyc[6:0][4]==0 && cyc[6:0][5]==1 && cyc[6:0][6]==1) => 0 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==1 && cyc[6:0][1]==0 && cyc[6:0][2]==1 && cyc[6:0][3]==0 && cyc[6:0][4]==1 && cyc[6:0][5]==0 && cyc[6:0][6]==0) => 1 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==1 && cyc[6:0][1]==0 && cyc[6:0][2]==1 && cyc[6:0][3]==0 && cyc[6:0][4]==1 && cyc[6:0][5]==0 && cyc[6:0][6]==1) => 0 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==1 && cyc[6:0][1]==0 && cyc[6:0][2]==1 && cyc[6:0][3]==0 && cyc[6:0][4]==1 && cyc[6:0][5]==1 && cyc[6:0][6]==0) => 0 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==1 && cyc[6:0][1]==0 && cyc[6:0][2]==1 && cyc[6:0][3]==0 && cyc[6:0][4]==1 && cyc[6:0][5]==1 && cyc[6:0][6]==1) => 1 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==1 && cyc[6:0][1]==0 && cyc[6:0][2]==1 && cyc[6:0][3]==1 && cyc[6:0][4]==0 && cyc[6:0][5]==0 && cyc[6:0][6]==0) => 1 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==1 && cyc[6:0][1]==0 && cyc[6:0][2]==1 && cyc[6:0][3]==1 && cyc[6:0][4]==0 && cyc[6:0][5]==0 && cyc[6:0][6]==1) => 0 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==1 && cyc[6:0][1]==0 && cyc[6:0][2]==1 && cyc[6:0][3]==1 && cyc[6:0][4]==0 && cyc[6:0][5]==1 && cyc[6:0][6]==0) => 0 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==1 && cyc[6:0][1]==0 && cyc[6:0][2]==1 && cyc[6:0][3]==1 && cyc[6:0][4]==0 && cyc[6:0][5]==1 && cyc[6:0][6]==1) => 1 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==1 && cyc[6:0][1]==0 && cyc[6:0][2]==1 && cyc[6:0][3]==1 && cyc[6:0][4]==1 && cyc[6:0][5]==0 && cyc[6:0][6]==0) => 0 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==1 && cyc[6:0][1]==0 && cyc[6:0][2]==1 && cyc[6:0][3]==1 && cyc[6:0][4]==1 && cyc[6:0][5]==0 && cyc[6:0][6]==1) => 1 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==1 && cyc[6:0][1]==0 && cyc[6:0][2]==1 && cyc[6:0][3]==1 && cyc[6:0][4]==1 && cyc[6:0][5]==1 && cyc[6:0][6]==0) => 1 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==1 && cyc[6:0][1]==0 && cyc[6:0][2]==1 && cyc[6:0][3]==1 && cyc[6:0][4]==1 && cyc[6:0][5]==1 && cyc[6:0][6]==1) => 0 hier=top.t
+-000001  point: comment=(cyc[6:0][0]==1 && cyc[6:0][1]==1 && cyc[6:0][2]==0 && cyc[6:0][3]==0 && cyc[6:0][4]==0 && cyc[6:0][5]==0 && cyc[6:0][6]==0) => 0 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==1 && cyc[6:0][1]==1 && cyc[6:0][2]==0 && cyc[6:0][3]==0 && cyc[6:0][4]==0 && cyc[6:0][5]==0 && cyc[6:0][6]==1) => 1 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==1 && cyc[6:0][1]==1 && cyc[6:0][2]==0 && cyc[6:0][3]==0 && cyc[6:0][4]==0 && cyc[6:0][5]==1 && cyc[6:0][6]==0) => 1 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==1 && cyc[6:0][1]==1 && cyc[6:0][2]==0 && cyc[6:0][3]==0 && cyc[6:0][4]==0 && cyc[6:0][5]==1 && cyc[6:0][6]==1) => 0 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==1 && cyc[6:0][1]==1 && cyc[6:0][2]==0 && cyc[6:0][3]==0 && cyc[6:0][4]==1 && cyc[6:0][5]==0 && cyc[6:0][6]==0) => 1 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==1 && cyc[6:0][1]==1 && cyc[6:0][2]==0 && cyc[6:0][3]==0 && cyc[6:0][4]==1 && cyc[6:0][5]==0 && cyc[6:0][6]==1) => 0 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==1 && cyc[6:0][1]==1 && cyc[6:0][2]==0 && cyc[6:0][3]==0 && cyc[6:0][4]==1 && cyc[6:0][5]==1 && cyc[6:0][6]==0) => 0 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==1 && cyc[6:0][1]==1 && cyc[6:0][2]==0 && cyc[6:0][3]==0 && cyc[6:0][4]==1 && cyc[6:0][5]==1 && cyc[6:0][6]==1) => 1 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==1 && cyc[6:0][1]==1 && cyc[6:0][2]==0 && cyc[6:0][3]==1 && cyc[6:0][4]==0 && cyc[6:0][5]==0 && cyc[6:0][6]==0) => 1 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==1 && cyc[6:0][1]==1 && cyc[6:0][2]==0 && cyc[6:0][3]==1 && cyc[6:0][4]==0 && cyc[6:0][5]==0 && cyc[6:0][6]==1) => 0 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==1 && cyc[6:0][1]==1 && cyc[6:0][2]==0 && cyc[6:0][3]==1 && cyc[6:0][4]==0 && cyc[6:0][5]==1 && cyc[6:0][6]==0) => 0 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==1 && cyc[6:0][1]==1 && cyc[6:0][2]==0 && cyc[6:0][3]==1 && cyc[6:0][4]==0 && cyc[6:0][5]==1 && cyc[6:0][6]==1) => 1 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==1 && cyc[6:0][1]==1 && cyc[6:0][2]==0 && cyc[6:0][3]==1 && cyc[6:0][4]==1 && cyc[6:0][5]==0 && cyc[6:0][6]==0) => 0 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==1 && cyc[6:0][1]==1 && cyc[6:0][2]==0 && cyc[6:0][3]==1 && cyc[6:0][4]==1 && cyc[6:0][5]==0 && cyc[6:0][6]==1) => 1 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==1 && cyc[6:0][1]==1 && cyc[6:0][2]==0 && cyc[6:0][3]==1 && cyc[6:0][4]==1 && cyc[6:0][5]==1 && cyc[6:0][6]==0) => 1 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==1 && cyc[6:0][1]==1 && cyc[6:0][2]==0 && cyc[6:0][3]==1 && cyc[6:0][4]==1 && cyc[6:0][5]==1 && cyc[6:0][6]==1) => 0 hier=top.t
+-000001  point: comment=(cyc[6:0][0]==1 && cyc[6:0][1]==1 && cyc[6:0][2]==1 && cyc[6:0][3]==0 && cyc[6:0][4]==0 && cyc[6:0][5]==0 && cyc[6:0][6]==0) => 1 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==1 && cyc[6:0][1]==1 && cyc[6:0][2]==1 && cyc[6:0][3]==0 && cyc[6:0][4]==0 && cyc[6:0][5]==0 && cyc[6:0][6]==1) => 0 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==1 && cyc[6:0][1]==1 && cyc[6:0][2]==1 && cyc[6:0][3]==0 && cyc[6:0][4]==0 && cyc[6:0][5]==1 && cyc[6:0][6]==0) => 0 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==1 && cyc[6:0][1]==1 && cyc[6:0][2]==1 && cyc[6:0][3]==0 && cyc[6:0][4]==0 && cyc[6:0][5]==1 && cyc[6:0][6]==1) => 1 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==1 && cyc[6:0][1]==1 && cyc[6:0][2]==1 && cyc[6:0][3]==0 && cyc[6:0][4]==1 && cyc[6:0][5]==0 && cyc[6:0][6]==0) => 0 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==1 && cyc[6:0][1]==1 && cyc[6:0][2]==1 && cyc[6:0][3]==0 && cyc[6:0][4]==1 && cyc[6:0][5]==0 && cyc[6:0][6]==1) => 1 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==1 && cyc[6:0][1]==1 && cyc[6:0][2]==1 && cyc[6:0][3]==0 && cyc[6:0][4]==1 && cyc[6:0][5]==1 && cyc[6:0][6]==0) => 1 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==1 && cyc[6:0][1]==1 && cyc[6:0][2]==1 && cyc[6:0][3]==0 && cyc[6:0][4]==1 && cyc[6:0][5]==1 && cyc[6:0][6]==1) => 0 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==1 && cyc[6:0][1]==1 && cyc[6:0][2]==1 && cyc[6:0][3]==1 && cyc[6:0][4]==0 && cyc[6:0][5]==0 && cyc[6:0][6]==0) => 0 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==1 && cyc[6:0][1]==1 && cyc[6:0][2]==1 && cyc[6:0][3]==1 && cyc[6:0][4]==0 && cyc[6:0][5]==0 && cyc[6:0][6]==1) => 1 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==1 && cyc[6:0][1]==1 && cyc[6:0][2]==1 && cyc[6:0][3]==1 && cyc[6:0][4]==0 && cyc[6:0][5]==1 && cyc[6:0][6]==0) => 1 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==1 && cyc[6:0][1]==1 && cyc[6:0][2]==1 && cyc[6:0][3]==1 && cyc[6:0][4]==0 && cyc[6:0][5]==1 && cyc[6:0][6]==1) => 0 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==1 && cyc[6:0][1]==1 && cyc[6:0][2]==1 && cyc[6:0][3]==1 && cyc[6:0][4]==1 && cyc[6:0][5]==0 && cyc[6:0][6]==0) => 1 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==1 && cyc[6:0][1]==1 && cyc[6:0][2]==1 && cyc[6:0][3]==1 && cyc[6:0][4]==1 && cyc[6:0][5]==0 && cyc[6:0][6]==1) => 0 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==1 && cyc[6:0][1]==1 && cyc[6:0][2]==1 && cyc[6:0][3]==1 && cyc[6:0][4]==1 && cyc[6:0][5]==1 && cyc[6:0][6]==0) => 0 hier=top.t
+-000000  point: comment=(cyc[6:0][0]==1 && cyc[6:0][1]==1 && cyc[6:0][2]==1 && cyc[6:0][3]==1 && cyc[6:0][4]==1 && cyc[6:0][5]==1 && cyc[6:0][6]==1) => 1 hier=top.t
+                // this one is too big even for t_cover_expr_max
+                if (^cyc) $write("");
+                if (cyc==9) begin
+                    $write("*-* All Finished *-*\n");
+                    $finish;
+                end
+            end
+        
+            always_comb begin
+%000005         if (t1 && t2) $write("");
+-000005  point: comment=(t1==0) => 0 hier=top.t
+-000002  point: comment=(t1==1 && t2==1) => 1 hier=top.t
+-000005  point: comment=(t2==0) => 0 hier=top.t
+            end
+        
+            logic ta, tb, tc;
+            initial begin
+                int q[5];
+                int qv;
+        
+                q = '{1, 2, 2, 4, 3};
+                // lambas not handled
+                // NB: there is a bug w/ tracing find_first (maybe lambdas in general?)
+                //     tracing_off does not work around the bug
+        `ifndef TEST_TRACE
+                qv = q.find_first with (item[0] & item[1]);
+        `endif
+                ta = '1;
+                tb = '0;
+                tc = '0;
+%000001         while (ta || tb || tc) begin
+-000001  point: comment=(ta==0 && tb==0 && tc==0) => 0 hier=top.t
+-000000  point: comment=(ta==1) => 1 hier=top.t
+-000000  point: comment=(tb==1) => 1 hier=top.t
+-000000  point: comment=(tc==1) => 1 hier=top.t
+                    tc = tb;
+                    tb = ta;
+                    ta = '0;
+                end
+            end
+        
+            sub the_sub_1 (.p(t1), .q(t2));
+            sub the_sub_2 (.p(t3), .q(t4));
+            // TODO -- non-process expressions
+            sub the_sub_3 (.p(t1 ? t2 : t3), .q(t4));
+        
+            // TODO
+            // pragma for expr coverage off / on
+            // investigate cover point sorting in annotated source
+            // consider reporting don't care terms
+            //
+            // Branches which are statically impossible to reach are still reported.
+            // E.g.
+            // -000000  point: comment=(t1=1 && t2=1 && 1'h0=1) => 1 hier=top.t
+            // These could potentially be pruned, but they currently follow suit for
+            // what branch coverage does.  Perhaps a switch should be added to not
+            // count statically impossible things.
+        
+        endmodule
+        
+        module sub (
+            input p,
+            input q
+        );
+        
+            always_comb begin
+~000019         if (p && q) $write("");
++000017  point: comment=(p==0) => 0 hier=top.t.the_sub_*
+-000002  point: comment=(p==1 && q==1) => 1 hier=top.t.the_sub_*
++000019  point: comment=(q==0) => 0 hier=top.t.the_sub_*
+            end
+        
+        endmodule
+        

--- a/test_regress/t/t_cover_expr_max.py
+++ b/test_regress/t/t_cover_expr_max.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2024 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+from pathlib import Path
+
+test.scenarios('simulator')
+test.top_filename = "t/t_cover_expr.v"
+
+test.compile(verilator_flags2=['--cc', '--coverage-expr', '--coverage-expr-max', '128'])
+
+test.execute()
+
+# Read the input .v file and do any CHECK_COVER requests
+test.inline_checks()
+
+test.run(cmd=[
+    os.environ["VERILATOR_ROOT"] + "/bin/verilator_coverage",
+    "--annotate-points",
+    "--annotate",
+    test.obj_dir + "/annotated",
+    test.obj_dir + "/coverage.dat",
+],
+         verilator_run=True)
+
+top = Path(test.top_filename)
+test.files_identical(test.obj_dir + f"/annotated/{top.name}", test.golden_filename)
+
+test.passes()

--- a/test_regress/t/t_cover_expr_trace.out
+++ b/test_regress/t/t_cover_expr_trace.out
@@ -261,15 +261,13 @@
             logic ta, tb, tc;
             initial begin
                 int q[5];
-                int qv;
+                int qv[$];
         
                 q = '{1, 2, 2, 4, 3};
                 // lambas not handled
                 // NB: there is a bug w/ tracing find_first (maybe lambdas in general?)
                 //     tracing_off does not work around the bug
-        `ifndef TEST_TRACE
                 qv = q.find_first with (item[0] & item[1]);
-        `endif
                 ta = '1;
                 tb = '0;
                 tc = '0;

--- a/test_regress/t/t_cover_expr_trace.out
+++ b/test_regress/t/t_cover_expr_trace.out
@@ -1,0 +1,319 @@
+//      // verilator_coverage annotation
+        // DESCRIPTION: Verilator: Verilog Test module
+        //
+        // This file ONLY is placed under the Creative Commons Public Domain, for
+        // any use, without warranty, 2024 by Wilson Snyder.
+        // SPDX-License-Identifier: CC0-1.0
+        
+        module t (/*AUTOARG*/
+            // Inputs
+            clk
+            );
+        
+            input clk;
+        
+            integer cyc;
+            initial cyc=1;
+        
+            integer some_int;
+            integer other_int;
+            logic some_bool;
+        
+            wire t1 = cyc[0];
+            wire t2 = cyc[1];
+            wire t3 = cyc[2];
+            wire t4 = cyc[3];
+        
+            localparam bit ONE = 1'b1;
+            localparam bit ZERO = 1'b0;
+        
+            function automatic bit invert(bit x);
+ 000015         return ~x;
++000012  point: comment=(x==0) => 1 hier=top.t
++000015  point: comment=(x==1) => 0 hier=top.t
+            endfunction
+        
+            function automatic bit and_oper(bit a, bit b);
+%000005         return a & b;
+-000004  point: comment=(a==0) => 0 hier=top.t
+-000002  point: comment=(a==1 && b==1) => 1 hier=top.t
+-000005  point: comment=(b==0) => 0 hier=top.t
+            endfunction
+        
+            always @ (posedge clk) begin
+                cyc <= cyc + 1;
+%000004         if ((~cyc[0] && cyc[1]) || (~cyc[2] && cyc[3])) $write("");
+-000002  point: comment=(cyc[0]==0 && cyc[1]==1) => 1 hier=top.t
+-000002  point: comment=(cyc[0]==1 && cyc[2]==1) => 0 hier=top.t
+-000004  point: comment=(cyc[0]==1 && cyc[3]==0) => 0 hier=top.t
+-000002  point: comment=(cyc[1]==0 && cyc[2]==1) => 0 hier=top.t
+-000003  point: comment=(cyc[1]==0 && cyc[3]==0) => 0 hier=top.t
+-000002  point: comment=(cyc[2]==0 && cyc[3]==1) => 1 hier=top.t
+%000004         if ((~t1 && t2) || (~t3 && t4)) $write("");
+-000002  point: comment=(t1==0 && t2==1) => 1 hier=top.t
+-000002  point: comment=(t1==1 && t3==1) => 0 hier=top.t
+-000004  point: comment=(t1==1 && t4==0) => 0 hier=top.t
+-000002  point: comment=(t2==0 && t3==1) => 0 hier=top.t
+-000003  point: comment=(t2==0 && t4==0) => 0 hier=top.t
+-000002  point: comment=(t3==0 && t4==1) => 1 hier=top.t
+%000005         if (t3 && (t1 == t2)) $write("");
+-000005  point: comment=((t1 == t2)==0) => 0 hier=top.t
+-000005  point: comment=(t3==0) => 0 hier=top.t
+-000002  point: comment=(t3==1 && (t1 == t2)==1) => 1 hier=top.t
+%000005         if (123 == (124 - 32'(t1 || t2))) $write("");
+-000002  point: comment=(t1==0 && t2==0) => 0 hier=top.t
+-000005  point: comment=(t1==1) => 1 hier=top.t
+-000004  point: comment=(t2==1) => 1 hier=top.t
+%000004         some_int <= (t2 || t3) ? 345 : 567;
+-000003  point: comment=(t2==0 && t3==0) => 0 hier=top.t
+-000004  point: comment=(t2==1) => 1 hier=top.t
+-000004  point: comment=(t3==1) => 1 hier=top.t
+%000005         some_bool <= t1 && t2;
+-000004  point: comment=(t1==0) => 0 hier=top.t
+-000002  point: comment=(t1==1 && t2==1) => 1 hier=top.t
+-000005  point: comment=(t2==0) => 0 hier=top.t
+%000005         if (t1 & t2) $write("");
+-000004  point: comment=(t1==0) => 0 hier=top.t
+-000002  point: comment=(t1==1 && t2==1) => 1 hier=top.t
+-000005  point: comment=(t2==0) => 0 hier=top.t
+%000004         if ((!t1 && t2) | (~t3 && t4)) $write("");
+-000002  point: comment=(t1==0 && t2==1) => 1 hier=top.t
+-000002  point: comment=(t1==1 && t3==1) => 0 hier=top.t
+-000004  point: comment=(t1==1 && t4==0) => 0 hier=top.t
+-000002  point: comment=(t2==0 && t3==1) => 0 hier=top.t
+-000003  point: comment=(t2==0 && t4==0) => 0 hier=top.t
+-000002  point: comment=(t3==0 && t4==1) => 1 hier=top.t
+%000003         if (t1 ^ t2) $write("");
+-000002  point: comment=(t1==0 && t2==0) => 0 hier=top.t
+-000002  point: comment=(t1==0 && t2==1) => 1 hier=top.t
+-000003  point: comment=(t1==1 && t2==0) => 1 hier=top.t
+-000002  point: comment=(t1==1 && t2==1) => 0 hier=top.t
+%000005         if (~(t1 & t2)) $write("");
+-000004  point: comment=(t1==0) => 1 hier=top.t
+-000002  point: comment=(t1==1 && t2==1) => 0 hier=top.t
+-000005  point: comment=(t2==0) => 1 hier=top.t
+%000004         if (t1 -> t2) $write("");
+-000004  point: comment=(t1==0) => 1 hier=top.t
+-000003  point: comment=(t1==1 && t2==0) => 0 hier=top.t
+-000004  point: comment=(t2==1) => 1 hier=top.t
+%000003         if (t1 <-> t2) $write("");
+-000002  point: comment=(t1==0 && t2==0) => 1 hier=top.t
+-000002  point: comment=(t1==0 && t2==1) => 0 hier=top.t
+-000003  point: comment=(t1==1 && t2==0) => 0 hier=top.t
+-000002  point: comment=(t1==1 && t2==1) => 1 hier=top.t
+%000005         if (&cyc[2:0]) $write("");
+-000004  point: comment=(cyc[2:0][0]==0) => 0 hier=top.t
+-000001  point: comment=(cyc[2:0][0]==1 && cyc[2:0][1]==1 && cyc[2:0][2]==1) => 1 hier=top.t
+-000005  point: comment=(cyc[2:0][1]==0) => 0 hier=top.t
+-000005  point: comment=(cyc[2:0][2]==0) => 0 hier=top.t
+%000007         if (&cyc[3:2]) $write("");
+-000005  point: comment=(cyc[3:2][0]==0) => 0 hier=top.t
+-000000  point: comment=(cyc[3:2][0]==1 && cyc[3:2][1]==1) => 1 hier=top.t
+-000007  point: comment=(cyc[3:2][1]==0) => 0 hier=top.t
+%000005         if (|cyc[2:0]) $write("");
+-000001  point: comment=(cyc[2:0][0]==0 && cyc[2:0][1]==0 && cyc[2:0][2]==0) => 0 hier=top.t
+-000005  point: comment=(cyc[2:0][0]==1) => 1 hier=top.t
+-000004  point: comment=(cyc[2:0][1]==1) => 1 hier=top.t
+-000004  point: comment=(cyc[2:0][2]==1) => 1 hier=top.t
+%000002         if (^cyc[2:0]) $write("");
+-000001  point: comment=(cyc[2:0][0]==0 && cyc[2:0][1]==0 && cyc[2:0][2]==0) => 0 hier=top.t
+-000001  point: comment=(cyc[2:0][0]==0 && cyc[2:0][1]==0 && cyc[2:0][2]==1) => 1 hier=top.t
+-000001  point: comment=(cyc[2:0][0]==0 && cyc[2:0][1]==1 && cyc[2:0][2]==0) => 1 hier=top.t
+-000001  point: comment=(cyc[2:0][0]==0 && cyc[2:0][1]==1 && cyc[2:0][2]==1) => 0 hier=top.t
+-000002  point: comment=(cyc[2:0][0]==1 && cyc[2:0][1]==0 && cyc[2:0][2]==0) => 1 hier=top.t
+-000001  point: comment=(cyc[2:0][0]==1 && cyc[2:0][1]==0 && cyc[2:0][2]==1) => 0 hier=top.t
+-000001  point: comment=(cyc[2:0][0]==1 && cyc[2:0][1]==1 && cyc[2:0][2]==0) => 0 hier=top.t
+-000001  point: comment=(cyc[2:0][0]==1 && cyc[2:0][1]==1 && cyc[2:0][2]==1) => 1 hier=top.t
+%000005         if (|cyc[2:0] || cyc[3]) $write("");
+-000000  point: comment=(cyc[2:0][0]==0 && cyc[2:0][1]==0 && cyc[2:0][2]==0 && cyc[3]==0) => 0 hier=top.t
+-000005  point: comment=(cyc[2:0][0]==1) => 1 hier=top.t
+-000004  point: comment=(cyc[2:0][1]==1) => 1 hier=top.t
+-000004  point: comment=(cyc[2:0][2]==1) => 1 hier=top.t
+-000002  point: comment=(cyc[3]==1) => 1 hier=top.t
+%000005         if (t1 & t2 & 1'b1) $write("");
+-000000  point: comment=(1'h1==0) => 0 hier=top.t
+-000004  point: comment=(t1==0) => 0 hier=top.t
+-000002  point: comment=(t1==1 && t2==1 && 1'h1==1) => 1 hier=top.t
+-000005  point: comment=(t2==0) => 0 hier=top.t
+%000009         if (t1 & t2 & 1'b0) $write("");
+-000009  point: comment=(1'h0==0) => 0 hier=top.t
+-000004  point: comment=(t1==0) => 0 hier=top.t
+-000000  point: comment=(t1==1 && t2==1 && 1'h0==1) => 1 hier=top.t
+-000005  point: comment=(t2==0) => 0 hier=top.t
+%000005         if (t1 & t2 & ONE) $write("");
+-000000  point: comment=(ONE==0) => 0 hier=top.t
+-000004  point: comment=(t1==0) => 0 hier=top.t
+-000002  point: comment=(t1==1 && t2==1 && ONE==1) => 1 hier=top.t
+-000005  point: comment=(t2==0) => 0 hier=top.t
+%000009         if (t1 & t2 & ZERO) $write("");
+-000009  point: comment=(ZERO==0) => 0 hier=top.t
+-000004  point: comment=(t1==0) => 0 hier=top.t
+-000000  point: comment=(t1==1 && t2==1 && ZERO==1) => 1 hier=top.t
+-000005  point: comment=(t2==0) => 0 hier=top.t
+%000005         if (t1 && t2) begin
+-000004  point: comment=(t1==0) => 0 hier=top.t
+-000002  point: comment=(t1==1 && t2==1) => 1 hier=top.t
+-000005  point: comment=(t2==0) => 0 hier=top.t
+                    $write("");
+%000003         end else if (t1 || t2) begin
+-000002  point: comment=(t1==0 && t2==0) => 0 hier=top.t
+-000003  point: comment=(t1==1) => 1 hier=top.t
+-000002  point: comment=(t2==1) => 1 hier=top.t
+                    $write("");
+                end
+%000005         if (invert(t1) && t2) $write("");
+-000005  point: comment=(invert(t1)==0) => 0 hier=top.t
+-000002  point: comment=(invert(t1)==1 && t2==1) => 1 hier=top.t
+-000005  point: comment=(t2==0) => 0 hier=top.t
+                if (and_oper(t1, t2)) $write("");
+%000005         if (t2 && t3) begin
+-000005  point: comment=(t2==0) => 0 hier=top.t
+-000002  point: comment=(t2==1 && t3==1) => 1 hier=top.t
+-000005  point: comment=(t3==0) => 0 hier=top.t
+%000001             if (t1 && t2) $write("");
+-000001  point: comment=(t1==0) => 0 hier=top.t
+-000001  point: comment=(t1==1 && t2==1) => 1 hier=top.t
+-000000  point: comment=(t2==0) => 0 hier=top.t
+                end
+                if (0 == 1) begin
+                    for (int loop_var = 0; loop_var < 1; loop_var++) begin
+%000000                 if (cyc[loop_var] && t2) $write("");
+-000000  point: comment=(cyc[loop_var[4:0]+:32'h1]]==0) => 0 hier=top.t
+-000000  point: comment=(cyc[loop_var[4:0]+:32'h1]]==1 && t2==1) => 1 hier=top.t
+-000000  point: comment=(t2==0) => 0 hier=top.t
+                    end
+                end
+                // stop at the first layer even if there's more to find
+%000007         if ((cyc[3+32'(t1 && t2)+:2] == cyc[5+32'(t3 || t4)+:2]) || cyc[31]) $write("");
+-000002  point: comment=((cyc[(32'sh3 + (t1 && t2))[4:0]+:32'sh2]] == cyc[(32'sh5 + (t3 || t4))[4:0]+:32'sh2]])==0 && cyc[31]==0) => 0 hier=top.t
+-000007  point: comment=((cyc[(32'sh3 + (t1 && t2))[4:0]+:32'sh2]] == cyc[(32'sh5 + (t3 || t4))[4:0]+:32'sh2]])==1) => 1 hier=top.t
+-000000  point: comment=(cyc[31]==1) => 1 hier=top.t
+                // impossible branches and redundant terms
+%000005         if ((t1 && t2) && ~(t1 && t3) && (t1 || t4)) $write("");
+-000003  point: comment=(t1==0 && t4==0) => 0 hier=top.t
+-000004  point: comment=(t1==0) => 0 hier=top.t
+-000000  point: comment=(t1==1 && t2==1 && t3==0 && t4==1) => 1 hier=top.t
+-000001  point: comment=(t1==1 && t2==1 && t3==0) => 1 hier=top.t
+-000002  point: comment=(t1==1 && t3==1) => 0 hier=top.t
+-000005  point: comment=(t2==0) => 0 hier=top.t
+%000005         if ((cyc[0] && cyc[1]) && ~(cyc[0] && cyc[2]) && (cyc[0] || cyc[3])) $write("");
+-000003  point: comment=(cyc[0]==0 && cyc[3]==0) => 0 hier=top.t
+-000004  point: comment=(cyc[0]==0) => 0 hier=top.t
+-000000  point: comment=(cyc[0]==1 && cyc[1]==1 && cyc[2]==0 && cyc[3]==1) => 1 hier=top.t
+-000001  point: comment=(cyc[0]==1 && cyc[1]==1 && cyc[2]==0) => 1 hier=top.t
+-000002  point: comment=(cyc[0]==1 && cyc[2]==1) => 0 hier=top.t
+-000005  point: comment=(cyc[1]==0) => 0 hier=top.t
+                // demonstrate current limitations of term matching scheme
+%000005         if ((cyc[0] && cyc[1]) && ~(cyc[1-1] && cyc[2]) && (cyc[2-2] || cyc[3])) $write("");
+-000002  point: comment=(cyc[(32'sh1 - 32'sh1)[4:0]+:32'h1]]==1 && cyc[2]==1) => 0 hier=top.t
+-000003  point: comment=(cyc[(32'sh2 - 32'sh2)[4:0]+:32'h1]]==0 && cyc[3]==0) => 0 hier=top.t
+-000004  point: comment=(cyc[0]==0) => 0 hier=top.t
+-000000  point: comment=(cyc[0]==1 && cyc[1]==1 && cyc[(32'sh1 - 32'sh1)[4:0]+:32'h1]]==0 && cyc[(32'sh2 - 32'sh2)[4:0]+:32'h1]]==1) => 1 hier=top.t
+-000000  point: comment=(cyc[0]==1 && cyc[1]==1 && cyc[(32'sh1 - 32'sh1)[4:0]+:32'h1]]==0 && cyc[3]==1) => 1 hier=top.t
+-000001  point: comment=(cyc[0]==1 && cyc[1]==1 && cyc[2]==0 && cyc[(32'sh2 - 32'sh2)[4:0]+:32'h1]]==1) => 1 hier=top.t
+-000000  point: comment=(cyc[0]==1 && cyc[1]==1 && cyc[2]==0 && cyc[3]==1) => 1 hier=top.t
+-000005  point: comment=(cyc[1]==0) => 0 hier=top.t
+                //verilator coverage_off
+                if (t1 && t2) $write("");
+                //verilator coverage_on
+                if ((~t1 && t2)
+%000004             ||
+-000002  point: comment=(t1==0 && t2==1) => 1 hier=top.t
+-000002  point: comment=(t1==1 && t3==1) => 0 hier=top.t
+-000004  point: comment=(t1==1 && t4==0) => 0 hier=top.t
+-000002  point: comment=(t2==0 && t3==1) => 0 hier=top.t
+-000003  point: comment=(t2==0 && t4==0) => 0 hier=top.t
+-000002  point: comment=(t3==0 && t4==1) => 1 hier=top.t
+                   (~t3 && t4)) $write("");
+                // intentionally testing wonkified expression terms
+                if (
+                    cyc[
+                      0
+%000005             ] &
+-000004  point: comment=(cyc[0]==0) => 0 hier=top.t
+-000002  point: comment=(cyc[0]==1 && cyc[1]==1) => 1 hier=top.t
+-000005  point: comment=(cyc[1]==0) => 0 hier=top.t
+                    cyc
+                      [1]) $write("");
+                // for now each ternary condition is considered in isolation
+%000005         other_int <= t1 ? t2 ? 1 : 2 : 3;
+-000004  point: comment=(t1==0) => 0 hier=top.t
+-000005  point: comment=(t1==1) => 1 hier=top.t
+                // no expression coverage for multi-bit expressions
+                if ((cyc[1:0] & cyc[3:2]) == 2'b11) $write("");
+                // truth table is too large
+                if (^cyc[6:0]) $write("");
+                // this one is too big even for t_cover_expr_max
+                if (^cyc) $write("");
+                if (cyc==9) begin
+                    $write("*-* All Finished *-*\n");
+                    $finish;
+                end
+            end
+        
+            always_comb begin
+%000005         if (t1 && t2) $write("");
+-000005  point: comment=(t1==0) => 0 hier=top.t
+-000002  point: comment=(t1==1 && t2==1) => 1 hier=top.t
+-000005  point: comment=(t2==0) => 0 hier=top.t
+            end
+        
+            logic ta, tb, tc;
+            initial begin
+                int q[5];
+                int qv;
+        
+                q = '{1, 2, 2, 4, 3};
+                // lambas not handled
+                // NB: there is a bug w/ tracing find_first (maybe lambdas in general?)
+                //     tracing_off does not work around the bug
+        `ifndef TEST_TRACE
+                qv = q.find_first with (item[0] & item[1]);
+        `endif
+                ta = '1;
+                tb = '0;
+                tc = '0;
+%000001         while (ta || tb || tc) begin
+-000001  point: comment=(ta==0 && tb==0 && tc==0) => 0 hier=top.t
+-000000  point: comment=(ta==1) => 1 hier=top.t
+-000000  point: comment=(tb==1) => 1 hier=top.t
+-000000  point: comment=(tc==1) => 1 hier=top.t
+                    tc = tb;
+                    tb = ta;
+                    ta = '0;
+                end
+            end
+        
+            sub the_sub_1 (.p(t1), .q(t2));
+            sub the_sub_2 (.p(t3), .q(t4));
+            // TODO -- non-process expressions
+            sub the_sub_3 (.p(t1 ? t2 : t3), .q(t4));
+        
+            // TODO
+            // pragma for expr coverage off / on
+            // investigate cover point sorting in annotated source
+            // consider reporting don't care terms
+            //
+            // Branches which are statically impossible to reach are still reported.
+            // E.g.
+            // -000000  point: comment=(t1=1 && t2=1 && 1'h0=1) => 1 hier=top.t
+            // These could potentially be pruned, but they currently follow suit for
+            // what branch coverage does.  Perhaps a switch should be added to not
+            // count statically impossible things.
+        
+        endmodule
+        
+        module sub (
+            input p,
+            input q
+        );
+        
+            always_comb begin
+~000019         if (p && q) $write("");
++000017  point: comment=(p==0) => 0 hier=top.t.the_sub_*
+-000002  point: comment=(p==1 && q==1) => 1 hier=top.t.the_sub_*
++000019  point: comment=(q==0) => 0 hier=top.t.the_sub_*
+            end
+        
+        endmodule
+        

--- a/test_regress/t/t_cover_expr_trace.py
+++ b/test_regress/t/t_cover_expr_trace.py
@@ -13,7 +13,7 @@ from pathlib import Path
 test.scenarios('simulator')
 test.top_filename = "t/t_cover_expr.v"
 
-test.compile(verilator_flags2=['--cc', '--coverage-expr', '--trace', "-DTEST_TRACE"])
+test.compile(verilator_flags2=['--cc', '--coverage-expr', '--trace'])
 
 test.execute()
 

--- a/test_regress/t/t_cover_expr_trace.py
+++ b/test_regress/t/t_cover_expr_trace.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2024 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+from pathlib import Path
+
+test.scenarios('simulator')
+test.top_filename = "t/t_cover_expr.v"
+
+test.compile(verilator_flags2=['--cc', '--coverage-expr', '--trace', "-DTEST_TRACE"])
+
+test.execute()
+
+# Read the input .v file and do any CHECK_COVER requests
+test.inline_checks()
+
+test.run(cmd=[
+    os.environ["VERILATOR_ROOT"] + "/bin/verilator_coverage",
+    "--annotate-points",
+    "--annotate",
+    test.obj_dir + "/annotated",
+    test.obj_dir + "/coverage.dat",
+],
+         verilator_run=True)
+
+top = Path(test.top_filename)
+test.files_identical(test.obj_dir + f"/annotated/{top.name}", test.golden_filename)
+
+test.passes()

--- a/test_regress/t/t_opt_const_cov.py
+++ b/test_regress/t/t_opt_const_cov.py
@@ -16,6 +16,6 @@ test.compile(verilator_flags2=["-Wno-UNOPTTHREADS", "--stats", "--coverage", "--
 test.execute()
 
 if test.vlt:
-    test.file_grep(test.stats, r'Optimizations, Const bit op reduction\s+(\d+)', 144)
+    test.file_grep(test.stats, r'Optimizations, Const bit op reduction\s+(\d+)', 620)
 
 test.passes()

--- a/test_regress/t/t_wrapper_context_top0.out
+++ b/test_regress/t/t_wrapper_context_top0.out
@@ -75,5 +75,8 @@ C 'ft/t_wrapper_context.vl38n4pagev_line/topoblockS38-39htop0.top'
 C 'ft/t_wrapper_context.vl40n7pagev_branch/topoifS40htop0.top' 0
 C 'ft/t_wrapper_context.vl40n8pagev_branch/topoelseS46htop0.top' 34
 C 'ft/t_wrapper_context.vl41n11pagev_line/topoelsehtop0.top' 0
+C 'ft/t_wrapper_context.vl41n27pagev_expr/topo((counter >= 32'sh5)==0) => 0htop0.top' 0
+C 'ft/t_wrapper_context.vl41n27pagev_expr/topo((counter >= 32'sh5)==1 && stop==1) => 1htop0.top' 0
+C 'ft/t_wrapper_context.vl41n27pagev_expr/topo(stop==0) => 0htop0.top' 0
 C 'ft/t_wrapper_context.vl47n10pagev_branch/topoifS47-49htop0.top' 1
 C 'ft/t_wrapper_context.vl47n11pagev_branch/topoelsehtop0.top' 33

--- a/test_regress/t/t_wrapper_context_top1.out
+++ b/test_regress/t/t_wrapper_context_top1.out
@@ -75,5 +75,8 @@ C 'ft/t_wrapper_context.vl38n4pagev_line/topoblockS38-39htop1.top'
 C 'ft/t_wrapper_context.vl40n7pagev_branch/topoifS40htop1.top' 19
 C 'ft/t_wrapper_context.vl40n8pagev_branch/topoelseS46htop1.top' 0
 C 'ft/t_wrapper_context.vl41n11pagev_line/topoelsehtop1.top' 18
+C 'ft/t_wrapper_context.vl41n27pagev_expr/topo((counter >= 32'sh5)==0) => 0htop1.top' 18
+C 'ft/t_wrapper_context.vl41n27pagev_expr/topo((counter >= 32'sh5)==1 && stop==1) => 1htop1.top' 1
+C 'ft/t_wrapper_context.vl41n27pagev_expr/topo(stop==0) => 0htop1.top' 0
 C 'ft/t_wrapper_context.vl47n10pagev_branch/topoifS47-49htop1.top' 0
 C 'ft/t_wrapper_context.vl47n11pagev_branch/topoelsehtop1.top' 0


### PR DESCRIPTION
Adds expression coverage.  More questions than answers at present so I wanted to get some thoughts before I sink a bunch of time on this.  The proof-of-concept currently produces this:
```
%000005        if ((~t1 && t2) || (~t3 && t4)) begin
-000002  point: comment=t1=0 t2=1 hier=top.t
-000002  point: comment=t1=1 t3=1 hier=top.t
-000004  point: comment=t1=1 t4=0 hier=top.t
-000002  point: comment=t2=0 t3=1 hier=top.t
-000003  point: comment=t2=0 t4=0 hier=top.t
-000002  point: comment=t3=0 t4=1 hier=top.t
```

Major questions to start:

- Any problems with the basic idea?
- Is there a better way to get the string of an `AstNodeExpr`?
- Can we just jam the decoded truth table into the cover point's comment for now?

Relates to #4677