### PR TITLE
Do not emit `BLKSEQ` on suspendable process

### DIFF
--- a/test_regress/t/t_timing_clkgen2.py
+++ b/test_regress/t/t_timing_clkgen2.py
@@ -11,7 +11,7 @@ import vltest_bootstrap
 
 test.scenarios('simulator')
 
-test.compile(verilator_flags2=["--exe --main --timing"])
+test.compile(verilator_flags2=["--exe --main --timing -Wwarn-BLKSEQ"])
 
 test.execute()
 

--- a/test_regress/t/t_timing_clkgen2.v
+++ b/test_regress/t/t_timing_clkgen2.v
@@ -17,24 +17,18 @@ module t;
    int   cnt2 = 0;
 
    always #4 clk = ~clk;
-   always @(negedge clk) begin
-       cnt1++;
-       `WRITE_VERBOSE(("[%0t] NEG clk (%b)\n", $time, clk));
-   end
    always @(posedge clk) begin
-       cnt1++;
-       `WRITE_VERBOSE(("[%0t] POS clk (%b)\n", $time, clk));
+       cnt1 <= cnt1 + 1;
+       `WRITE_VERBOSE(("[%0t] clk (%b)\n", $time, clk));
    end
 
    assign #2 clk_inv = ~clk;
    initial forever begin
        @(posedge clk_inv) cnt2++;
-       `WRITE_VERBOSE(("[%0t] POS clk_inv (%b)\n", $time, clk_inv));
-       @(negedge clk_inv) cnt2++;
-       `WRITE_VERBOSE(("[%0t] NEG clk_inv (%b)\n", $time, clk_inv));
+       `WRITE_VERBOSE(("[%0t] clk_inv (%b)\n", $time, clk_inv));
    end
 
-   initial #41 begin
+   initial #81 begin
        if (cnt1 != 10 && cnt2 != 10) $stop;
        $write("*-* All Finished *-*\n");
        $finish;


### PR DESCRIPTION
Currently, `BLKSEQ` is emitted on code like

```systemverilog
always #1 clk = ~clk;
```

But it's a perfectly valid way to generate the clock. It's even an example in the LRM (9.2.2.1).

This patch disables `BLKSEQ` for suspendables.