### PR TITLE
Added support for `resetall

### DIFF
--- a/src/verilog.l
+++ b/src/verilog.l
@@ -1062,7 +1062,11 @@ vnum    {vnum1}|{vnum2}|{vnum3}|{vnum4}|{vnum5}
   "`protect"                            { FL_FWD; FL_BRK; }
   "`remove_gatenames"                   { FL_FWD; FL_BRK; }  // Verilog-XL compatibility
   "`remove_netnames"                    { FL_FWD; FL_BRK; }  // Verilog-XL compatibility
-  "`resetall"                           { FL; PARSEP->lexFileline()->warnOn(V3ErrorCode::I_DEF_NETTYPE_WIRE, true);
+  "`resetall"                           { FL;
+                                          PARSEP->lexFileline()->warnOn(V3ErrorCode::I_DEF_NETTYPE_WIRE, true);
+                                          v3Global.rootp()->timeInit();
+                                          PARSEP->lexFileline()->celldefineOn(false);
+                                          PARSEP->unconnectedDrive(VOptionBool::OPT_DEFAULT_FALSE);
                                           return yaT_RESETALL; }  // Rest handled by preproc
   "`suppress_faults"                    { FL_FWD; FL_BRK; }  // Verilog-XL compatibility
   "`timescale"{ws}+[^\n\r]*             { FL; PARSEP->lexTimescaleParse(yylval.fl,


### PR DESCRIPTION
(Probably) Fixes #5728

I will not be providing a test case because I couldn't figure out a situation that works on commercial tools, is consistent with the LRM, and was fixed by this PR.

You are welcome to close this without merging if you feel it is not worth pursuing further. Or you are welcome to merge without testing if you are feeling *adventurous*. :monkey:

------

This was my failed attempt at a test case, and I don't understand the output.
```systemverilog
localparam real default_timeunit = 100s;

`timescale 10s/1s
`default_nettype none
`celldefine

localparam real before_reset_timeunit = 100s;

`resetall

localparam real after_reset_timeunit = 100s;

module tb;
    initial begin
        $display("default_timeunit:      %0f", default_timeunit);
        $display("before_reset_timeunit: %0f", before_reset_timeunit);
        $display("after_reset_timeunit:  %0f", after_reset_timeunit);
        $finish;
    end
endmodule
```
VCS Output:
```
default_timeunit:      100.000000
before_reset_timeunit: 10.000000
after_reset_timeunit:  10.000000
```
Xcelium output:
```
default_timeunit:      100000000000.000000
before_reset_timeunit: 100000000000.000000
after_reset_timeunit:  100000000000.000000
```
Verilator Output:
```
default_timeunit:      10.000000
before_reset_timeunit: 10.000000
after_reset_timeunit:  10.000000
```
My expected output (assuming default timescale of 1s/1s):
```
default_timeunit:      100.000000
before_reset_timeunit: 10.000000
after_reset_timeunit:  100.000000
```

Someone else is welcome to pick this up.