### PR TITLE
Fix hierarchy iteration

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -156,6 +156,7 @@ Mladen Slijepcevic
 Morten Borup Petersen
 Mostafa Gamal
 Nandu Raj
+Natan Kreimer
 Nathan Graybeal
 Nathan Kohagen
 Nathan Myers

--- a/src/V3EmitCSyms.cpp
+++ b/src/V3EmitCSyms.cpp
@@ -181,7 +181,6 @@ class EmitCSyms final : EmitCBaseVisitorConst {
     /// Then add/update entry in m_scopeNames if not already there
     void varHierarchyScopes(string scp) {
 
-        // we want no result to be -1, so use ints
         string::size_type prd_pos = scp.rfind('.');
         string::size_type dot_pos = scp.rfind("__DOT__");
 
@@ -195,7 +194,7 @@ class EmitCSyms final : EmitCBaseVisitorConst {
             }
 
             // resize and advance pointers
-            if (prd_pos < dot_pos && dot_pos != string::npos) {
+            if ((prd_pos < dot_pos || prd_pos == string::npos) && dot_pos != string::npos) {
                 scp.resize(dot_pos);
                 dot_pos = scp.rfind("__DOT__");
             } else {


### PR DESCRIPTION
Current comparison of `prd_pos` with `dot_pos` doesn't take the case of `prd_pos` being `string::npos` into account.

For example: in `TOP__DOT__top__DOT__sub`, `prd_pos == string::npos`. `string::npos` is defined to be -1, but it's unsigned (https://en.cppreference.com/w/cpp/string/basic_string/npos), meaning -1 is converted to the largest integer. This results with the `else` case, which is incorrect.

In addition, we removed the misleading comment.

Fixes #5314.
Ping @AndrewNolte.