### PR TITLE
Fix vpiDefName issues with non-inlined scopes and dpi conflicts

### DIFF
--- a/src/V3EmitCSyms.cpp
+++ b/src/V3EmitCSyms.cpp
@@ -330,7 +330,7 @@ class EmitCSyms final : EmitCBaseVisitorConst {
             const int timeunit = m_modp->timeunit().powerOfTen();
             m_vpiScopeCandidates.emplace(scopeSymString(nodep->name()),
                                          ScopeData{nodep, scopeSymString(nodep->name()),
-                                                   name_pretty, "<null>", timeunit, type});
+                                                   name_pretty, nodep->modp()->origName(), timeunit, type});
         }
         iterateChildrenConst(nodep);
     }

--- a/src/V3EmitCSyms.cpp
+++ b/src/V3EmitCSyms.cpp
@@ -106,7 +106,8 @@ class EmitCSyms final : EmitCBaseVisitorConst {
     std::vector<ModVarPair> m_modVars;  // Each public {mod,var}
     std::map<const std::string, ScopeFuncData> m_scopeFuncs;  // Each {scope,dpi-export-func}
     std::map<const std::string, ScopeVarData> m_scopeVars;  // Each {scope,public-var}
-    ScopeNames m_scopeNames;  // Each unique AstScopeName
+    ScopeNames m_scopeNames;  // Each unique AstScopeName. Dpi scopes added later
+    ScopeNames m_dpiScopeNames;  // Each unique AstScopeName for DPI export
     ScopeNames m_vpiScopeCandidates;  // All scopes for VPI
     ScopeNameHierarchy m_vpiScopeHierarchy;  // The actual hierarchy of scopes
     int m_coverBins = 0;  // Coverage bin number
@@ -208,7 +209,7 @@ class EmitCSyms final : EmitCBaseVisitorConst {
     void varsExpand() {
         // We didn't have all m_scopes loaded when we encountered variables, so expand them now
         // It would be less code if each module inserted its own variables.
-        // Someday.  For now public isn't common.
+        // Someday.
         for (std::vector<ScopeModPair>::iterator itsc = m_scopes.begin(); itsc != m_scopes.end();
              ++itsc) {
             AstScope* const scopep = itsc->first;
@@ -282,6 +283,15 @@ class EmitCSyms final : EmitCBaseVisitorConst {
 
         if (v3Global.opt.vpi()) buildVpiHierarchy();
 
+        if (v3Global.dpi()) {
+            // add dpi scopes to m_scopeNames if not already there
+            for (const auto& scp : m_dpiScopeNames) {
+                if (m_scopeNames.find(scp.first) == m_scopeNames.end()) {
+                    m_scopeNames.emplace(scp.first, scp.second);
+                }
+            }
+        }
+
         // Sort by names, so line/process order matters less
         stable_sort(m_scopes.begin(), m_scopes.end(), CmpName());
         stable_sort(m_dpis.begin(), m_dpis.end(), CmpDpi());
@@ -330,7 +340,8 @@ class EmitCSyms final : EmitCBaseVisitorConst {
             const int timeunit = m_modp->timeunit().powerOfTen();
             m_vpiScopeCandidates.emplace(scopeSymString(nodep->name()),
                                          ScopeData{nodep, scopeSymString(nodep->name()),
-                                                   name_pretty, nodep->modp()->origName(), timeunit, type});
+                                                   name_pretty, nodep->modp()->origName(),
+                                                   timeunit, type});
         }
         iterateChildrenConst(nodep);
     }
@@ -339,19 +350,19 @@ class EmitCSyms final : EmitCBaseVisitorConst {
         // UINFO(9, "scnameins sp " << nodep->name() << " sp " << nodep->scopePrettySymName()
         // << " ss" << name << endl);
         const int timeunit = m_modp ? m_modp->timeunit().powerOfTen() : 0;
-        m_scopeNames.emplace(name, ScopeData{nodep, name, nodep->scopePrettySymName(), "<null>",
-                                             timeunit, "SCOPE_OTHER"});
+        m_dpiScopeNames.emplace(name, ScopeData{nodep, name, nodep->scopePrettySymName(), "<null>",
+                                                timeunit, "SCOPE_OTHER"});
         if (nodep->dpiExport()) {
             UASSERT_OBJ(m_cfuncp, nodep, "ScopeName not under DPI function");
             m_scopeFuncs.emplace(name + " " + m_cfuncp->name(),
                                  ScopeFuncData(nodep, m_cfuncp, m_modp));
         } else {
-            if (m_scopeNames.find(nodep->scopeDpiName()) == m_scopeNames.end()) {
+            if (m_dpiScopeNames.find(nodep->scopeDpiName()) == m_dpiScopeNames.end()) {
                 // cppcheck-suppress stlFindInsert
-                m_scopeNames.emplace(nodep->scopeDpiName(),
-                                     ScopeData{nodep, nodep->scopeDpiName(),
-                                               nodep->scopePrettyDpiName(), "<null>", timeunit,
-                                               "SCOPE_OTHER"});
+                m_dpiScopeNames.emplace(nodep->scopeDpiName(),
+                                        ScopeData{nodep, nodep->scopeDpiName(),
+                                                  nodep->scopePrettyDpiName(), "<null>", timeunit,
+                                                  "SCOPE_OTHER"});
             }
         }
     }

--- a/test_regress/t/t_vpi_dump.cpp
+++ b/test_regress/t/t_vpi_dump.cpp
@@ -127,11 +127,12 @@ void modDump(TestVpiHandle& it, int n) {
         const int type = vpi_get(vpiType, hndl);
         const char* name = vpi_get_str(vpiName, hndl);
         const char* fullname = vpi_get_str(vpiFullName, hndl);
-        printf("%s (%s) %s\n", name, strFromVpiObjType(type), fullname);
+        printf("%s (%s) %s ", name, strFromVpiObjType(type), fullname);
         if (type == vpiParameter || type == vpiConstType) {
-            for (int i = 0; i < n + 1; i++) printf("    ");
-            printf("vpiConstType=%s\n", strFromVpiConstType(vpi_get(vpiConstType, hndl)));
+            printf(" vpiConstType=%s", strFromVpiConstType(vpi_get(vpiConstType, hndl)));
         }
+        if (type == vpiModule) { printf(" vpiDefName=%s", vpi_get_str(vpiDefName, hndl)); }
+        printf("\n");
 
         if (iterate_over.find(type) == iterate_over.end()) { continue; }
         for (int type : iterate_over.at(type)) {

--- a/test_regress/t/t_vpi_dump.out
+++ b/test_regress/t/t_vpi_dump.out
@@ -1,307 +1,255 @@
-t (vpiModule) t
+t (vpiModule) t  vpiDefName=<null>
     vpiReg:
-    LONGSTART_a_very_long_name_which_will_get_hashed_a_very_long_name_which_will_get_hashed_a_very_long_name_which_will_get_hashed_a_very_long_name_which_will_get_hashed_LONGEND (vpiReg) t.LONGSTART_a_very_long_name_which_will_get_hashed_a_very_long_name_which_will_get_hashed_a_very_long_name_which_will_get_hashed_a_very_long_name_which_will_get_hashed_LONGEND
-    a (vpiReg) TOP.a
-    bus1 (vpiReg) t.bus1
-    clk (vpiReg) TOP.clk
-    count (vpiReg) t.count
-    do_generate (vpiParameter) t.do_generate
-        vpiConstType=vpiDecConst
-    fourthreetwoone (vpiRegArray) t.fourthreetwoone
+    LONGSTART_a_very_long_name_which_will_get_hashed_a_very_long_name_which_will_get_hashed_a_very_long_name_which_will_get_hashed_a_very_long_name_which_will_get_hashed_LONGEND (vpiReg) t.LONGSTART_a_very_long_name_which_will_get_hashed_a_very_long_name_which_will_get_hashed_a_very_long_name_which_will_get_hashed_a_very_long_name_which_will_get_hashed_LONGEND 
+    a (vpiReg) TOP.a 
+    bus1 (vpiReg) t.bus1 
+    clk (vpiReg) TOP.clk 
+    count (vpiReg) t.count 
+    do_generate (vpiParameter) t.do_generate  vpiConstType=vpiDecConst
+    fourthreetwoone (vpiRegArray) t.fourthreetwoone 
         vpiReg:
-        fourthreetwoone (vpiReg) t.fourthreetwoone[3]
-        fourthreetwoone (vpiReg) t.fourthreetwoone[4]
-    half_count (vpiReg) t.half_count
-    long_int (vpiParameter) t.long_int
-        vpiConstType=vpiDecConst
-    onebit (vpiReg) t.onebit
-    quads (vpiRegArray) t.quads
+        fourthreetwoone (vpiReg) t.fourthreetwoone[3] 
+        fourthreetwoone (vpiReg) t.fourthreetwoone[4] 
+    half_count (vpiReg) t.half_count 
+    long_int (vpiParameter) t.long_int  vpiConstType=vpiDecConst
+    onebit (vpiReg) t.onebit 
+    quads (vpiRegArray) t.quads 
         vpiReg:
-        quads (vpiReg) t.quads[3]
-        quads (vpiReg) t.quads[2]
-    real1 (vpiRealVar) t.real1
-    status (vpiReg) t.status
-    str1 (vpiStringVar) t.str1
-    text (vpiReg) t.text
-    text_byte (vpiReg) t.text_byte
-    text_half (vpiReg) t.text_half
-    text_long (vpiReg) t.text_long
-    text_word (vpiReg) t.text_word
-    twoone (vpiReg) t.twoone
-    x (vpiReg) TOP.x
+        quads (vpiReg) t.quads[3] 
+        quads (vpiReg) t.quads[2] 
+    real1 (vpiRealVar) t.real1 
+    status (vpiReg) t.status 
+    str1 (vpiStringVar) t.str1 
+    text (vpiReg) t.text 
+    text_byte (vpiReg) t.text_byte 
+    text_half (vpiReg) t.text_half 
+    text_long (vpiReg) t.text_long 
+    text_word (vpiReg) t.text_word 
+    twoone (vpiReg) t.twoone 
+    x (vpiReg) TOP.x 
     vpiParameter:
-    do_generate (vpiParameter) t.do_generate
-        vpiConstType=vpiDecConst
-    long_int (vpiParameter) t.long_int
-        vpiConstType=vpiDecConst
+    do_generate (vpiParameter) t.do_generate  vpiConstType=vpiDecConst
+    long_int (vpiParameter) t.long_int  vpiConstType=vpiDecConst
     vpiInternalScope:
-    arr[1] (vpiGenScope) t.arr[1]
+    arr[1] (vpiGenScope) t.arr[1] 
         vpiReg:
         vpiParameter:
         vpiInternalScope:
-        arr (vpiModule) t.arr[1].arr
+        arr (vpiModule) t.arr[1].arr  vpiDefName=<null>
             vpiReg:
-            LENGTH (vpiParameter) t.arr[1].arr.LENGTH
-                vpiConstType=vpiDecConst
-            check (vpiReg) t.arr[1].arr.check
-            rfr (vpiReg) t.arr[1].arr.rfr
-            sig (vpiReg) t.arr[1].arr.sig
-            verbose (vpiReg) t.arr[1].arr.verbose
+            LENGTH (vpiParameter) t.arr[1].arr.LENGTH  vpiConstType=vpiDecConst
+            check (vpiReg) t.arr[1].arr.check 
+            rfr (vpiReg) t.arr[1].arr.rfr 
+            sig (vpiReg) t.arr[1].arr.sig 
+            verbose (vpiReg) t.arr[1].arr.verbose 
             vpiParameter:
-            LENGTH (vpiParameter) t.arr[1].arr.LENGTH
-                vpiConstType=vpiDecConst
-    arr[2] (vpiGenScope) t.arr[2]
+            LENGTH (vpiParameter) t.arr[1].arr.LENGTH  vpiConstType=vpiDecConst
+    arr[2] (vpiGenScope) t.arr[2] 
         vpiReg:
         vpiParameter:
         vpiInternalScope:
-        arr (vpiModule) t.arr[2].arr
+        arr (vpiModule) t.arr[2].arr  vpiDefName=<null>
             vpiReg:
-            LENGTH (vpiParameter) t.arr[2].arr.LENGTH
-                vpiConstType=vpiDecConst
-            check (vpiReg) t.arr[2].arr.check
-            rfr (vpiReg) t.arr[2].arr.rfr
-            sig (vpiReg) t.arr[2].arr.sig
-            verbose (vpiReg) t.arr[2].arr.verbose
+            LENGTH (vpiParameter) t.arr[2].arr.LENGTH  vpiConstType=vpiDecConst
+            check (vpiReg) t.arr[2].arr.check 
+            rfr (vpiReg) t.arr[2].arr.rfr 
+            sig (vpiReg) t.arr[2].arr.sig 
+            verbose (vpiReg) t.arr[2].arr.verbose 
             vpiParameter:
-            LENGTH (vpiParameter) t.arr[2].arr.LENGTH
-                vpiConstType=vpiDecConst
-    cond_scope (vpiGenScope) t.cond_scope
+            LENGTH (vpiParameter) t.arr[2].arr.LENGTH  vpiConstType=vpiDecConst
+    cond_scope (vpiGenScope) t.cond_scope 
         vpiReg:
-        scoped_wire (vpiParameter) t.cond_scope.scoped_wire
-            vpiConstType=vpiDecConst
+        scoped_wire (vpiParameter) t.cond_scope.scoped_wire  vpiConstType=vpiDecConst
         vpiParameter:
-        scoped_wire (vpiParameter) t.cond_scope.scoped_wire
-            vpiConstType=vpiDecConst
+        scoped_wire (vpiParameter) t.cond_scope.scoped_wire  vpiConstType=vpiDecConst
         vpiInternalScope:
-        scoped_sub (vpiModule) t.cond_scope.scoped_sub
+        scoped_sub (vpiModule) t.cond_scope.scoped_sub  vpiDefName=<null>
             vpiReg:
-            subsig1 (vpiReg) t.cond_scope.scoped_sub.subsig1
-            subsig2 (vpiReg) t.cond_scope.scoped_sub.subsig2
+            subsig1 (vpiReg) t.cond_scope.scoped_sub.subsig1 
+            subsig2 (vpiReg) t.cond_scope.scoped_sub.subsig2 
             vpiParameter:
-        sub_wrap_gen (vpiModule) t.cond_scope.sub_wrap_gen
+        sub_wrap_gen (vpiModule) t.cond_scope.sub_wrap_gen  vpiDefName=<null>
             vpiReg:
             vpiParameter:
             vpiInternalScope:
-            my_sub (vpiModule) t.cond_scope.sub_wrap_gen.my_sub
+            my_sub (vpiModule) t.cond_scope.sub_wrap_gen.my_sub  vpiDefName=<null>
                 vpiReg:
-                subsig1 (vpiReg) t.cond_scope.sub_wrap_gen.my_sub.subsig1
-                subsig2 (vpiReg) t.cond_scope.sub_wrap_gen.my_sub.subsig2
+                subsig1 (vpiReg) t.cond_scope.sub_wrap_gen.my_sub.subsig1 
+                subsig2 (vpiReg) t.cond_scope.sub_wrap_gen.my_sub.subsig2 
                 vpiParameter:
-    intf_arr[0] (vpiModule) t.intf_arr[0]
+    intf_arr[0] (vpiModule) t.intf_arr[0]  vpiDefName=<null>
         vpiReg:
-        addr (vpiReg) t.intf_arr[0].addr
+        addr (vpiReg) t.intf_arr[0].addr 
         vpiParameter:
-    intf_arr[1] (vpiModule) t.intf_arr[1]
+    intf_arr[1] (vpiModule) t.intf_arr[1]  vpiDefName=<null>
         vpiReg:
-        addr (vpiReg) t.intf_arr[1].addr
+        addr (vpiReg) t.intf_arr[1].addr 
         vpiParameter:
-    outer_scope[1] (vpiGenScope) t.outer_scope[1]
+    outer_scope[1] (vpiGenScope) t.outer_scope[1] 
         vpiReg:
-        scoped_param (vpiParameter) t.outer_scope[1].scoped_param
-            vpiConstType=vpiDecConst
+        scoped_param (vpiParameter) t.outer_scope[1].scoped_param  vpiConstType=vpiDecConst
         vpiParameter:
-        scoped_param (vpiParameter) t.outer_scope[1].scoped_param
-            vpiConstType=vpiDecConst
+        scoped_param (vpiParameter) t.outer_scope[1].scoped_param  vpiConstType=vpiDecConst
         vpiInternalScope:
-        inner_scope[1] (vpiGenScope) t.outer_scope[1].inner_scope[1]
+        inner_scope[1] (vpiGenScope) t.outer_scope[1].inner_scope[1] 
             vpiReg:
-            scoped_param_inner (vpiParameter) t.outer_scope[1].inner_scope[1].scoped_param_inner
-                vpiConstType=vpiDecConst
+            scoped_param_inner (vpiParameter) t.outer_scope[1].inner_scope[1].scoped_param_inner  vpiConstType=vpiDecConst
             vpiParameter:
-            scoped_param_inner (vpiParameter) t.outer_scope[1].inner_scope[1].scoped_param_inner
-                vpiConstType=vpiDecConst
+            scoped_param_inner (vpiParameter) t.outer_scope[1].inner_scope[1].scoped_param_inner  vpiConstType=vpiDecConst
             vpiInternalScope:
-            arr (vpiModule) t.outer_scope[1].inner_scope[1].arr
+            arr (vpiModule) t.outer_scope[1].inner_scope[1].arr  vpiDefName=<null>
                 vpiReg:
-                LENGTH (vpiParameter) t.outer_scope[1].inner_scope[1].arr.LENGTH
-                    vpiConstType=vpiDecConst
-                check (vpiReg) t.outer_scope[1].inner_scope[1].arr.check
-                rfr (vpiReg) t.outer_scope[1].inner_scope[1].arr.rfr
-                sig (vpiReg) t.outer_scope[1].inner_scope[1].arr.sig
-                verbose (vpiReg) t.outer_scope[1].inner_scope[1].arr.verbose
+                LENGTH (vpiParameter) t.outer_scope[1].inner_scope[1].arr.LENGTH  vpiConstType=vpiDecConst
+                check (vpiReg) t.outer_scope[1].inner_scope[1].arr.check 
+                rfr (vpiReg) t.outer_scope[1].inner_scope[1].arr.rfr 
+                sig (vpiReg) t.outer_scope[1].inner_scope[1].arr.sig 
+                verbose (vpiReg) t.outer_scope[1].inner_scope[1].arr.verbose 
                 vpiParameter:
-                LENGTH (vpiParameter) t.outer_scope[1].inner_scope[1].arr.LENGTH
-                    vpiConstType=vpiDecConst
-        inner_scope[2] (vpiGenScope) t.outer_scope[1].inner_scope[2]
+                LENGTH (vpiParameter) t.outer_scope[1].inner_scope[1].arr.LENGTH  vpiConstType=vpiDecConst
+        inner_scope[2] (vpiGenScope) t.outer_scope[1].inner_scope[2] 
             vpiReg:
-            scoped_param_inner (vpiParameter) t.outer_scope[1].inner_scope[2].scoped_param_inner
-                vpiConstType=vpiDecConst
+            scoped_param_inner (vpiParameter) t.outer_scope[1].inner_scope[2].scoped_param_inner  vpiConstType=vpiDecConst
             vpiParameter:
-            scoped_param_inner (vpiParameter) t.outer_scope[1].inner_scope[2].scoped_param_inner
-                vpiConstType=vpiDecConst
+            scoped_param_inner (vpiParameter) t.outer_scope[1].inner_scope[2].scoped_param_inner  vpiConstType=vpiDecConst
             vpiInternalScope:
-            arr (vpiModule) t.outer_scope[1].inner_scope[2].arr
+            arr (vpiModule) t.outer_scope[1].inner_scope[2].arr  vpiDefName=<null>
                 vpiReg:
-                LENGTH (vpiParameter) t.outer_scope[1].inner_scope[2].arr.LENGTH
-                    vpiConstType=vpiDecConst
-                check (vpiReg) t.outer_scope[1].inner_scope[2].arr.check
-                rfr (vpiReg) t.outer_scope[1].inner_scope[2].arr.rfr
-                sig (vpiReg) t.outer_scope[1].inner_scope[2].arr.sig
-                verbose (vpiReg) t.outer_scope[1].inner_scope[2].arr.verbose
+                LENGTH (vpiParameter) t.outer_scope[1].inner_scope[2].arr.LENGTH  vpiConstType=vpiDecConst
+                check (vpiReg) t.outer_scope[1].inner_scope[2].arr.check 
+                rfr (vpiReg) t.outer_scope[1].inner_scope[2].arr.rfr 
+                sig (vpiReg) t.outer_scope[1].inner_scope[2].arr.sig 
+                verbose (vpiReg) t.outer_scope[1].inner_scope[2].arr.verbose 
                 vpiParameter:
-                LENGTH (vpiParameter) t.outer_scope[1].inner_scope[2].arr.LENGTH
-                    vpiConstType=vpiDecConst
-        inner_scope[3] (vpiGenScope) t.outer_scope[1].inner_scope[3]
+                LENGTH (vpiParameter) t.outer_scope[1].inner_scope[2].arr.LENGTH  vpiConstType=vpiDecConst
+        inner_scope[3] (vpiGenScope) t.outer_scope[1].inner_scope[3] 
             vpiReg:
-            scoped_param_inner (vpiParameter) t.outer_scope[1].inner_scope[3].scoped_param_inner
-                vpiConstType=vpiDecConst
+            scoped_param_inner (vpiParameter) t.outer_scope[1].inner_scope[3].scoped_param_inner  vpiConstType=vpiDecConst
             vpiParameter:
-            scoped_param_inner (vpiParameter) t.outer_scope[1].inner_scope[3].scoped_param_inner
-                vpiConstType=vpiDecConst
+            scoped_param_inner (vpiParameter) t.outer_scope[1].inner_scope[3].scoped_param_inner  vpiConstType=vpiDecConst
             vpiInternalScope:
-            arr (vpiModule) t.outer_scope[1].inner_scope[3].arr
+            arr (vpiModule) t.outer_scope[1].inner_scope[3].arr  vpiDefName=<null>
                 vpiReg:
-                LENGTH (vpiParameter) t.outer_scope[1].inner_scope[3].arr.LENGTH
-                    vpiConstType=vpiDecConst
-                check (vpiReg) t.outer_scope[1].inner_scope[3].arr.check
-                rfr (vpiReg) t.outer_scope[1].inner_scope[3].arr.rfr
-                sig (vpiReg) t.outer_scope[1].inner_scope[3].arr.sig
-                verbose (vpiReg) t.outer_scope[1].inner_scope[3].arr.verbose
+                LENGTH (vpiParameter) t.outer_scope[1].inner_scope[3].arr.LENGTH  vpiConstType=vpiDecConst
+                check (vpiReg) t.outer_scope[1].inner_scope[3].arr.check 
+                rfr (vpiReg) t.outer_scope[1].inner_scope[3].arr.rfr 
+                sig (vpiReg) t.outer_scope[1].inner_scope[3].arr.sig 
+                verbose (vpiReg) t.outer_scope[1].inner_scope[3].arr.verbose 
                 vpiParameter:
-                LENGTH (vpiParameter) t.outer_scope[1].inner_scope[3].arr.LENGTH
-                    vpiConstType=vpiDecConst
-    outer_scope[2] (vpiGenScope) t.outer_scope[2]
+                LENGTH (vpiParameter) t.outer_scope[1].inner_scope[3].arr.LENGTH  vpiConstType=vpiDecConst
+    outer_scope[2] (vpiGenScope) t.outer_scope[2] 
         vpiReg:
-        scoped_param (vpiParameter) t.outer_scope[2].scoped_param
-            vpiConstType=vpiDecConst
+        scoped_param (vpiParameter) t.outer_scope[2].scoped_param  vpiConstType=vpiDecConst
         vpiParameter:
-        scoped_param (vpiParameter) t.outer_scope[2].scoped_param
-            vpiConstType=vpiDecConst
+        scoped_param (vpiParameter) t.outer_scope[2].scoped_param  vpiConstType=vpiDecConst
         vpiInternalScope:
-        inner_scope[1] (vpiGenScope) t.outer_scope[2].inner_scope[1]
+        inner_scope[1] (vpiGenScope) t.outer_scope[2].inner_scope[1] 
             vpiReg:
-            scoped_param_inner (vpiParameter) t.outer_scope[2].inner_scope[1].scoped_param_inner
-                vpiConstType=vpiDecConst
+            scoped_param_inner (vpiParameter) t.outer_scope[2].inner_scope[1].scoped_param_inner  vpiConstType=vpiDecConst
             vpiParameter:
-            scoped_param_inner (vpiParameter) t.outer_scope[2].inner_scope[1].scoped_param_inner
-                vpiConstType=vpiDecConst
+            scoped_param_inner (vpiParameter) t.outer_scope[2].inner_scope[1].scoped_param_inner  vpiConstType=vpiDecConst
             vpiInternalScope:
-            arr (vpiModule) t.outer_scope[2].inner_scope[1].arr
+            arr (vpiModule) t.outer_scope[2].inner_scope[1].arr  vpiDefName=<null>
                 vpiReg:
-                LENGTH (vpiParameter) t.outer_scope[2].inner_scope[1].arr.LENGTH
-                    vpiConstType=vpiDecConst
-                check (vpiReg) t.outer_scope[2].inner_scope[1].arr.check
-                rfr (vpiReg) t.outer_scope[2].inner_scope[1].arr.rfr
-                sig (vpiReg) t.outer_scope[2].inner_scope[1].arr.sig
-                verbose (vpiReg) t.outer_scope[2].inner_scope[1].arr.verbose
+                LENGTH (vpiParameter) t.outer_scope[2].inner_scope[1].arr.LENGTH  vpiConstType=vpiDecConst
+                check (vpiReg) t.outer_scope[2].inner_scope[1].arr.check 
+                rfr (vpiReg) t.outer_scope[2].inner_scope[1].arr.rfr 
+                sig (vpiReg) t.outer_scope[2].inner_scope[1].arr.sig 
+                verbose (vpiReg) t.outer_scope[2].inner_scope[1].arr.verbose 
                 vpiParameter:
-                LENGTH (vpiParameter) t.outer_scope[2].inner_scope[1].arr.LENGTH
-                    vpiConstType=vpiDecConst
-        inner_scope[2] (vpiGenScope) t.outer_scope[2].inner_scope[2]
+                LENGTH (vpiParameter) t.outer_scope[2].inner_scope[1].arr.LENGTH  vpiConstType=vpiDecConst
+        inner_scope[2] (vpiGenScope) t.outer_scope[2].inner_scope[2] 
             vpiReg:
-            scoped_param_inner (vpiParameter) t.outer_scope[2].inner_scope[2].scoped_param_inner
-                vpiConstType=vpiDecConst
+            scoped_param_inner (vpiParameter) t.outer_scope[2].inner_scope[2].scoped_param_inner  vpiConstType=vpiDecConst
             vpiParameter:
-            scoped_param_inner (vpiParameter) t.outer_scope[2].inner_scope[2].scoped_param_inner
-                vpiConstType=vpiDecConst
+            scoped_param_inner (vpiParameter) t.outer_scope[2].inner_scope[2].scoped_param_inner  vpiConstType=vpiDecConst
             vpiInternalScope:
-            arr (vpiModule) t.outer_scope[2].inner_scope[2].arr
+            arr (vpiModule) t.outer_scope[2].inner_scope[2].arr  vpiDefName=<null>
                 vpiReg:
-                LENGTH (vpiParameter) t.outer_scope[2].inner_scope[2].arr.LENGTH
-                    vpiConstType=vpiDecConst
-                check (vpiReg) t.outer_scope[2].inner_scope[2].arr.check
-                rfr (vpiReg) t.outer_scope[2].inner_scope[2].arr.rfr
-                sig (vpiReg) t.outer_scope[2].inner_scope[2].arr.sig
-                verbose (vpiReg) t.outer_scope[2].inner_scope[2].arr.verbose
+                LENGTH (vpiParameter) t.outer_scope[2].inner_scope[2].arr.LENGTH  vpiConstType=vpiDecConst
+                check (vpiReg) t.outer_scope[2].inner_scope[2].arr.check 
+                rfr (vpiReg) t.outer_scope[2].inner_scope[2].arr.rfr 
+                sig (vpiReg) t.outer_scope[2].inner_scope[2].arr.sig 
+                verbose (vpiReg) t.outer_scope[2].inner_scope[2].arr.verbose 
                 vpiParameter:
-                LENGTH (vpiParameter) t.outer_scope[2].inner_scope[2].arr.LENGTH
-                    vpiConstType=vpiDecConst
-        inner_scope[3] (vpiGenScope) t.outer_scope[2].inner_scope[3]
+                LENGTH (vpiParameter) t.outer_scope[2].inner_scope[2].arr.LENGTH  vpiConstType=vpiDecConst
+        inner_scope[3] (vpiGenScope) t.outer_scope[2].inner_scope[3] 
             vpiReg:
-            scoped_param_inner (vpiParameter) t.outer_scope[2].inner_scope[3].scoped_param_inner
-                vpiConstType=vpiDecConst
+            scoped_param_inner (vpiParameter) t.outer_scope[2].inner_scope[3].scoped_param_inner  vpiConstType=vpiDecConst
             vpiParameter:
-            scoped_param_inner (vpiParameter) t.outer_scope[2].inner_scope[3].scoped_param_inner
-                vpiConstType=vpiDecConst
+            scoped_param_inner (vpiParameter) t.outer_scope[2].inner_scope[3].scoped_param_inner  vpiConstType=vpiDecConst
             vpiInternalScope:
-            arr (vpiModule) t.outer_scope[2].inner_scope[3].arr
+            arr (vpiModule) t.outer_scope[2].inner_scope[3].arr  vpiDefName=<null>
                 vpiReg:
-                LENGTH (vpiParameter) t.outer_scope[2].inner_scope[3].arr.LENGTH
-                    vpiConstType=vpiDecConst
-                check (vpiReg) t.outer_scope[2].inner_scope[3].arr.check
-                rfr (vpiReg) t.outer_scope[2].inner_scope[3].arr.rfr
-                sig (vpiReg) t.outer_scope[2].inner_scope[3].arr.sig
-                verbose (vpiReg) t.outer_scope[2].inner_scope[3].arr.verbose
+                LENGTH (vpiParameter) t.outer_scope[2].inner_scope[3].arr.LENGTH  vpiConstType=vpiDecConst
+                check (vpiReg) t.outer_scope[2].inner_scope[3].arr.check 
+                rfr (vpiReg) t.outer_scope[2].inner_scope[3].arr.rfr 
+                sig (vpiReg) t.outer_scope[2].inner_scope[3].arr.sig 
+                verbose (vpiReg) t.outer_scope[2].inner_scope[3].arr.verbose 
                 vpiParameter:
-                LENGTH (vpiParameter) t.outer_scope[2].inner_scope[3].arr.LENGTH
-                    vpiConstType=vpiDecConst
-    outer_scope[3] (vpiGenScope) t.outer_scope[3]
+                LENGTH (vpiParameter) t.outer_scope[2].inner_scope[3].arr.LENGTH  vpiConstType=vpiDecConst
+    outer_scope[3] (vpiGenScope) t.outer_scope[3] 
         vpiReg:
-        scoped_param (vpiParameter) t.outer_scope[3].scoped_param
-            vpiConstType=vpiDecConst
+        scoped_param (vpiParameter) t.outer_scope[3].scoped_param  vpiConstType=vpiDecConst
         vpiParameter:
-        scoped_param (vpiParameter) t.outer_scope[3].scoped_param
-            vpiConstType=vpiDecConst
+        scoped_param (vpiParameter) t.outer_scope[3].scoped_param  vpiConstType=vpiDecConst
         vpiInternalScope:
-        inner_scope[1] (vpiGenScope) t.outer_scope[3].inner_scope[1]
+        inner_scope[1] (vpiGenScope) t.outer_scope[3].inner_scope[1] 
             vpiReg:
-            scoped_param_inner (vpiParameter) t.outer_scope[3].inner_scope[1].scoped_param_inner
-                vpiConstType=vpiDecConst
+            scoped_param_inner (vpiParameter) t.outer_scope[3].inner_scope[1].scoped_param_inner  vpiConstType=vpiDecConst
             vpiParameter:
-            scoped_param_inner (vpiParameter) t.outer_scope[3].inner_scope[1].scoped_param_inner
-                vpiConstType=vpiDecConst
+            scoped_param_inner (vpiParameter) t.outer_scope[3].inner_scope[1].scoped_param_inner  vpiConstType=vpiDecConst
             vpiInternalScope:
-            arr (vpiModule) t.outer_scope[3].inner_scope[1].arr
+            arr (vpiModule) t.outer_scope[3].inner_scope[1].arr  vpiDefName=<null>
                 vpiReg:
-                LENGTH (vpiParameter) t.outer_scope[3].inner_scope[1].arr.LENGTH
-                    vpiConstType=vpiDecConst
-                check (vpiReg) t.outer_scope[3].inner_scope[1].arr.check
-                rfr (vpiReg) t.outer_scope[3].inner_scope[1].arr.rfr
-                sig (vpiReg) t.outer_scope[3].inner_scope[1].arr.sig
-                verbose (vpiReg) t.outer_scope[3].inner_scope[1].arr.verbose
+                LENGTH (vpiParameter) t.outer_scope[3].inner_scope[1].arr.LENGTH  vpiConstType=vpiDecConst
+                check (vpiReg) t.outer_scope[3].inner_scope[1].arr.check 
+                rfr (vpiReg) t.outer_scope[3].inner_scope[1].arr.rfr 
+                sig (vpiReg) t.outer_scope[3].inner_scope[1].arr.sig 
+                verbose (vpiReg) t.outer_scope[3].inner_scope[1].arr.verbose 
                 vpiParameter:
-                LENGTH (vpiParameter) t.outer_scope[3].inner_scope[1].arr.LENGTH
-                    vpiConstType=vpiDecConst
-        inner_scope[2] (vpiGenScope) t.outer_scope[3].inner_scope[2]
+                LENGTH (vpiParameter) t.outer_scope[3].inner_scope[1].arr.LENGTH  vpiConstType=vpiDecConst
+        inner_scope[2] (vpiGenScope) t.outer_scope[3].inner_scope[2] 
             vpiReg:
-            scoped_param_inner (vpiParameter) t.outer_scope[3].inner_scope[2].scoped_param_inner
-                vpiConstType=vpiDecConst
+            scoped_param_inner (vpiParameter) t.outer_scope[3].inner_scope[2].scoped_param_inner  vpiConstType=vpiDecConst
             vpiParameter:
-            scoped_param_inner (vpiParameter) t.outer_scope[3].inner_scope[2].scoped_param_inner
-                vpiConstType=vpiDecConst
+            scoped_param_inner (vpiParameter) t.outer_scope[3].inner_scope[2].scoped_param_inner  vpiConstType=vpiDecConst
             vpiInternalScope:
-            arr (vpiModule) t.outer_scope[3].inner_scope[2].arr
+            arr (vpiModule) t.outer_scope[3].inner_scope[2].arr  vpiDefName=<null>
                 vpiReg:
-                LENGTH (vpiParameter) t.outer_scope[3].inner_scope[2].arr.LENGTH
-                    vpiConstType=vpiDecConst
-                check (vpiReg) t.outer_scope[3].inner_scope[2].arr.check
-                rfr (vpiReg) t.outer_scope[3].inner_scope[2].arr.rfr
-                sig (vpiReg) t.outer_scope[3].inner_scope[2].arr.sig
-                verbose (vpiReg) t.outer_scope[3].inner_scope[2].arr.verbose
+                LENGTH (vpiParameter) t.outer_scope[3].inner_scope[2].arr.LENGTH  vpiConstType=vpiDecConst
+                check (vpiReg) t.outer_scope[3].inner_scope[2].arr.check 
+                rfr (vpiReg) t.outer_scope[3].inner_scope[2].arr.rfr 
+                sig (vpiReg) t.outer_scope[3].inner_scope[2].arr.sig 
+                verbose (vpiReg) t.outer_scope[3].inner_scope[2].arr.verbose 
                 vpiParameter:
-                LENGTH (vpiParameter) t.outer_scope[3].inner_scope[2].arr.LENGTH
-                    vpiConstType=vpiDecConst
-        inner_scope[3] (vpiGenScope) t.outer_scope[3].inner_scope[3]
+                LENGTH (vpiParameter) t.outer_scope[3].inner_scope[2].arr.LENGTH  vpiConstType=vpiDecConst
+        inner_scope[3] (vpiGenScope) t.outer_scope[3].inner_scope[3] 
             vpiReg:
-            scoped_param_inner (vpiParameter) t.outer_scope[3].inner_scope[3].scoped_param_inner
-                vpiConstType=vpiDecConst
+            scoped_param_inner (vpiParameter) t.outer_scope[3].inner_scope[3].scoped_param_inner  vpiConstType=vpiDecConst
             vpiParameter:
-            scoped_param_inner (vpiParameter) t.outer_scope[3].inner_scope[3].scoped_param_inner
-                vpiConstType=vpiDecConst
+            scoped_param_inner (vpiParameter) t.outer_scope[3].inner_scope[3].scoped_param_inner  vpiConstType=vpiDecConst
             vpiInternalScope:
-            arr (vpiModule) t.outer_scope[3].inner_scope[3].arr
+            arr (vpiModule) t.outer_scope[3].inner_scope[3].arr  vpiDefName=<null>
                 vpiReg:
-                LENGTH (vpiParameter) t.outer_scope[3].inner_scope[3].arr.LENGTH
-                    vpiConstType=vpiDecConst
-                check (vpiReg) t.outer_scope[3].inner_scope[3].arr.check
-                rfr (vpiReg) t.outer_scope[3].inner_scope[3].arr.rfr
-                sig (vpiReg) t.outer_scope[3].inner_scope[3].arr.sig
-                verbose (vpiReg) t.outer_scope[3].inner_scope[3].arr.verbose
+                LENGTH (vpiParameter) t.outer_scope[3].inner_scope[3].arr.LENGTH  vpiConstType=vpiDecConst
+                check (vpiReg) t.outer_scope[3].inner_scope[3].arr.check 
+                rfr (vpiReg) t.outer_scope[3].inner_scope[3].arr.rfr 
+                sig (vpiReg) t.outer_scope[3].inner_scope[3].arr.sig 
+                verbose (vpiReg) t.outer_scope[3].inner_scope[3].arr.verbose 
                 vpiParameter:
-                LENGTH (vpiParameter) t.outer_scope[3].inner_scope[3].arr.LENGTH
-                    vpiConstType=vpiDecConst
-    sub (vpiModule) t.sub
+                LENGTH (vpiParameter) t.outer_scope[3].inner_scope[3].arr.LENGTH  vpiConstType=vpiDecConst
+    sub (vpiModule) t.sub  vpiDefName=<null>
         vpiReg:
-        subsig1 (vpiReg) t.sub.subsig1
-        subsig2 (vpiReg) t.sub.subsig2
+        subsig1 (vpiReg) t.sub.subsig1 
+        subsig2 (vpiReg) t.sub.subsig2 
         vpiParameter:
-    sub_wrap (vpiModule) t.sub_wrap
+    sub_wrap (vpiModule) t.sub_wrap  vpiDefName=<null>
         vpiReg:
         vpiParameter:
         vpiInternalScope:
-        my_sub (vpiModule) t.sub_wrap.my_sub
+        my_sub (vpiModule) t.sub_wrap.my_sub  vpiDefName=<null>
             vpiReg:
-            subsig1 (vpiReg) t.sub_wrap.my_sub.subsig1
-            subsig2 (vpiReg) t.sub_wrap.my_sub.subsig2
+            subsig1 (vpiReg) t.sub_wrap.my_sub.subsig1 
+            subsig2 (vpiReg) t.sub_wrap.my_sub.subsig2 
             vpiParameter:
 *-* All Finished *-*

--- a/test_regress/t/t_vpi_dump.out
+++ b/test_regress/t/t_vpi_dump.out
@@ -35,7 +35,7 @@ t (vpiModule) t  vpiDefName=t
         vpiReg:
         vpiParameter:
         vpiInternalScope:
-        arr (vpiModule) t.arr[1].arr  vpiDefName=<null>
+        arr (vpiModule) t.arr[1].arr  vpiDefName=ModArr
             vpiReg:
             LENGTH (vpiParameter) t.arr[1].arr.LENGTH  vpiConstType=vpiDecConst
             check (vpiReg) t.arr[1].arr.check 
@@ -48,7 +48,7 @@ t (vpiModule) t  vpiDefName=t
         vpiReg:
         vpiParameter:
         vpiInternalScope:
-        arr (vpiModule) t.arr[2].arr  vpiDefName=<null>
+        arr (vpiModule) t.arr[2].arr  vpiDefName=ModArr
             vpiReg:
             LENGTH (vpiParameter) t.arr[2].arr.LENGTH  vpiConstType=vpiDecConst
             check (vpiReg) t.arr[2].arr.check 
@@ -97,7 +97,7 @@ t (vpiModule) t  vpiDefName=t
             vpiParameter:
             scoped_param_inner (vpiParameter) t.outer_scope[1].inner_scope[1].scoped_param_inner  vpiConstType=vpiDecConst
             vpiInternalScope:
-            arr (vpiModule) t.outer_scope[1].inner_scope[1].arr  vpiDefName=<null>
+            arr (vpiModule) t.outer_scope[1].inner_scope[1].arr  vpiDefName=ModArr
                 vpiReg:
                 LENGTH (vpiParameter) t.outer_scope[1].inner_scope[1].arr.LENGTH  vpiConstType=vpiDecConst
                 check (vpiReg) t.outer_scope[1].inner_scope[1].arr.check 
@@ -112,7 +112,7 @@ t (vpiModule) t  vpiDefName=t
             vpiParameter:
             scoped_param_inner (vpiParameter) t.outer_scope[1].inner_scope[2].scoped_param_inner  vpiConstType=vpiDecConst
             vpiInternalScope:
-            arr (vpiModule) t.outer_scope[1].inner_scope[2].arr  vpiDefName=<null>
+            arr (vpiModule) t.outer_scope[1].inner_scope[2].arr  vpiDefName=ModArr
                 vpiReg:
                 LENGTH (vpiParameter) t.outer_scope[1].inner_scope[2].arr.LENGTH  vpiConstType=vpiDecConst
                 check (vpiReg) t.outer_scope[1].inner_scope[2].arr.check 
@@ -127,7 +127,7 @@ t (vpiModule) t  vpiDefName=t
             vpiParameter:
             scoped_param_inner (vpiParameter) t.outer_scope[1].inner_scope[3].scoped_param_inner  vpiConstType=vpiDecConst
             vpiInternalScope:
-            arr (vpiModule) t.outer_scope[1].inner_scope[3].arr  vpiDefName=<null>
+            arr (vpiModule) t.outer_scope[1].inner_scope[3].arr  vpiDefName=ModArr
                 vpiReg:
                 LENGTH (vpiParameter) t.outer_scope[1].inner_scope[3].arr.LENGTH  vpiConstType=vpiDecConst
                 check (vpiReg) t.outer_scope[1].inner_scope[3].arr.check 
@@ -148,7 +148,7 @@ t (vpiModule) t  vpiDefName=t
             vpiParameter:
             scoped_param_inner (vpiParameter) t.outer_scope[2].inner_scope[1].scoped_param_inner  vpiConstType=vpiDecConst
             vpiInternalScope:
-            arr (vpiModule) t.outer_scope[2].inner_scope[1].arr  vpiDefName=<null>
+            arr (vpiModule) t.outer_scope[2].inner_scope[1].arr  vpiDefName=ModArr
                 vpiReg:
                 LENGTH (vpiParameter) t.outer_scope[2].inner_scope[1].arr.LENGTH  vpiConstType=vpiDecConst
                 check (vpiReg) t.outer_scope[2].inner_scope[1].arr.check 
@@ -163,7 +163,7 @@ t (vpiModule) t  vpiDefName=t
             vpiParameter:
             scoped_param_inner (vpiParameter) t.outer_scope[2].inner_scope[2].scoped_param_inner  vpiConstType=vpiDecConst
             vpiInternalScope:
-            arr (vpiModule) t.outer_scope[2].inner_scope[2].arr  vpiDefName=<null>
+            arr (vpiModule) t.outer_scope[2].inner_scope[2].arr  vpiDefName=ModArr
                 vpiReg:
                 LENGTH (vpiParameter) t.outer_scope[2].inner_scope[2].arr.LENGTH  vpiConstType=vpiDecConst
                 check (vpiReg) t.outer_scope[2].inner_scope[2].arr.check 
@@ -178,7 +178,7 @@ t (vpiModule) t  vpiDefName=t
             vpiParameter:
             scoped_param_inner (vpiParameter) t.outer_scope[2].inner_scope[3].scoped_param_inner  vpiConstType=vpiDecConst
             vpiInternalScope:
-            arr (vpiModule) t.outer_scope[2].inner_scope[3].arr  vpiDefName=<null>
+            arr (vpiModule) t.outer_scope[2].inner_scope[3].arr  vpiDefName=ModArr
                 vpiReg:
                 LENGTH (vpiParameter) t.outer_scope[2].inner_scope[3].arr.LENGTH  vpiConstType=vpiDecConst
                 check (vpiReg) t.outer_scope[2].inner_scope[3].arr.check 
@@ -199,7 +199,7 @@ t (vpiModule) t  vpiDefName=t
             vpiParameter:
             scoped_param_inner (vpiParameter) t.outer_scope[3].inner_scope[1].scoped_param_inner  vpiConstType=vpiDecConst
             vpiInternalScope:
-            arr (vpiModule) t.outer_scope[3].inner_scope[1].arr  vpiDefName=<null>
+            arr (vpiModule) t.outer_scope[3].inner_scope[1].arr  vpiDefName=ModArr
                 vpiReg:
                 LENGTH (vpiParameter) t.outer_scope[3].inner_scope[1].arr.LENGTH  vpiConstType=vpiDecConst
                 check (vpiReg) t.outer_scope[3].inner_scope[1].arr.check 
@@ -214,7 +214,7 @@ t (vpiModule) t  vpiDefName=t
             vpiParameter:
             scoped_param_inner (vpiParameter) t.outer_scope[3].inner_scope[2].scoped_param_inner  vpiConstType=vpiDecConst
             vpiInternalScope:
-            arr (vpiModule) t.outer_scope[3].inner_scope[2].arr  vpiDefName=<null>
+            arr (vpiModule) t.outer_scope[3].inner_scope[2].arr  vpiDefName=ModArr
                 vpiReg:
                 LENGTH (vpiParameter) t.outer_scope[3].inner_scope[2].arr.LENGTH  vpiConstType=vpiDecConst
                 check (vpiReg) t.outer_scope[3].inner_scope[2].arr.check 
@@ -229,7 +229,7 @@ t (vpiModule) t  vpiDefName=t
             vpiParameter:
             scoped_param_inner (vpiParameter) t.outer_scope[3].inner_scope[3].scoped_param_inner  vpiConstType=vpiDecConst
             vpiInternalScope:
-            arr (vpiModule) t.outer_scope[3].inner_scope[3].arr  vpiDefName=<null>
+            arr (vpiModule) t.outer_scope[3].inner_scope[3].arr  vpiDefName=ModArr
                 vpiReg:
                 LENGTH (vpiParameter) t.outer_scope[3].inner_scope[3].arr.LENGTH  vpiConstType=vpiDecConst
                 check (vpiReg) t.outer_scope[3].inner_scope[3].arr.check 

--- a/test_regress/t/t_vpi_dump.out
+++ b/test_regress/t/t_vpi_dump.out
@@ -1,4 +1,4 @@
-t (vpiModule) t  vpiDefName=<null>
+t (vpiModule) t  vpiDefName=t
     vpiReg:
     LONGSTART_a_very_long_name_which_will_get_hashed_a_very_long_name_which_will_get_hashed_a_very_long_name_which_will_get_hashed_a_very_long_name_which_will_get_hashed_LONGEND (vpiReg) t.LONGSTART_a_very_long_name_which_will_get_hashed_a_very_long_name_which_will_get_hashed_a_very_long_name_which_will_get_hashed_a_very_long_name_which_will_get_hashed_LONGEND 
     a (vpiReg) TOP.a 
@@ -63,25 +63,25 @@ t (vpiModule) t  vpiDefName=<null>
         vpiParameter:
         scoped_wire (vpiParameter) t.cond_scope.scoped_wire  vpiConstType=vpiDecConst
         vpiInternalScope:
-        scoped_sub (vpiModule) t.cond_scope.scoped_sub  vpiDefName=<null>
+        scoped_sub (vpiModule) t.cond_scope.scoped_sub  vpiDefName=ModSub
             vpiReg:
             subsig1 (vpiReg) t.cond_scope.scoped_sub.subsig1 
             subsig2 (vpiReg) t.cond_scope.scoped_sub.subsig2 
             vpiParameter:
-        sub_wrap_gen (vpiModule) t.cond_scope.sub_wrap_gen  vpiDefName=<null>
+        sub_wrap_gen (vpiModule) t.cond_scope.sub_wrap_gen  vpiDefName=ModSubWrapper
             vpiReg:
             vpiParameter:
             vpiInternalScope:
-            my_sub (vpiModule) t.cond_scope.sub_wrap_gen.my_sub  vpiDefName=<null>
+            my_sub (vpiModule) t.cond_scope.sub_wrap_gen.my_sub  vpiDefName=ModSub
                 vpiReg:
                 subsig1 (vpiReg) t.cond_scope.sub_wrap_gen.my_sub.subsig1 
                 subsig2 (vpiReg) t.cond_scope.sub_wrap_gen.my_sub.subsig2 
                 vpiParameter:
-    intf_arr[0] (vpiModule) t.intf_arr[0]  vpiDefName=<null>
+    intf_arr[0] (vpiModule) t.intf_arr[0]  vpiDefName=TestInterface
         vpiReg:
         addr (vpiReg) t.intf_arr[0].addr 
         vpiParameter:
-    intf_arr[1] (vpiModule) t.intf_arr[1]  vpiDefName=<null>
+    intf_arr[1] (vpiModule) t.intf_arr[1]  vpiDefName=TestInterface
         vpiReg:
         addr (vpiReg) t.intf_arr[1].addr 
         vpiParameter:
@@ -238,16 +238,16 @@ t (vpiModule) t  vpiDefName=<null>
                 verbose (vpiReg) t.outer_scope[3].inner_scope[3].arr.verbose 
                 vpiParameter:
                 LENGTH (vpiParameter) t.outer_scope[3].inner_scope[3].arr.LENGTH  vpiConstType=vpiDecConst
-    sub (vpiModule) t.sub  vpiDefName=<null>
+    sub (vpiModule) t.sub  vpiDefName=ModSub
         vpiReg:
         subsig1 (vpiReg) t.sub.subsig1 
         subsig2 (vpiReg) t.sub.subsig2 
         vpiParameter:
-    sub_wrap (vpiModule) t.sub_wrap  vpiDefName=<null>
+    sub_wrap (vpiModule) t.sub_wrap  vpiDefName=ModSubWrapper
         vpiReg:
         vpiParameter:
         vpiInternalScope:
-        my_sub (vpiModule) t.sub_wrap.my_sub  vpiDefName=<null>
+        my_sub (vpiModule) t.sub_wrap.my_sub  vpiDefName=ModSub
             vpiReg:
             subsig1 (vpiReg) t.sub_wrap.my_sub.subsig1 
             subsig2 (vpiReg) t.sub_wrap.my_sub.subsig2 

--- a/test_regress/t/t_vpi_dump.v
+++ b/test_regress/t/t_vpi_dump.v
@@ -65,7 +65,7 @@ module t (  /*AUTOARG*/
 
    t_bus bus1;
 
-   sub sub ();
+   ModSub sub ();
 
    TestInterface intf_arr[2]();
 
@@ -80,7 +80,7 @@ module t (  /*AUTOARG*/
    genvar i;
    generate
       for (i = 1; i <= 2; i = i + 1) begin : arr
-         arr #(.LENGTH(i)) arr ();
+         ModArr #(.LENGTH(i)) arr ();
       end
 
       for (i = 1; i <= 3; i = i + 1) begin : outer_scope
@@ -90,38 +90,38 @@ module t (  /*AUTOARG*/
          genvar j;
          for (j = 1; j <= 3; j = j + 1) begin : inner_scope
             parameter int scoped_param_inner = scoped_param + 1;
-            arr #(.LENGTH(scoped_param_inner)) arr ();
+            ModArr #(.LENGTH(scoped_param_inner)) arr ();
 
          end
       end
    endgenerate
 
-   sub_wrapper sub_wrap ();
+   ModSubWrapper sub_wrap ();
 
 
    generate
       if (do_generate == 1) begin : cond_scope
-         sub scoped_sub ();
+         ModSub scoped_sub ();
          parameter int scoped_wire = 1;
 
-         sub_wrapper sub_wrap_gen ();
+         ModSubWrapper sub_wrap_gen ();
       end else begin : cond_scope_else
-         sub scoped_sub_else ();
+         ModSub scoped_sub_else ();
       end
    endgenerate
 
 endmodule : t
 
-module sub;
+module ModSub;
    reg subsig1;
    reg subsig2;
 `ifdef IVERILOG
    // stop icarus optimizing signals away
    wire redundant = subsig1 | subsig2;
 `endif
-endmodule : sub
+endmodule : ModSub
 
-module arr;
+module ModArr;
 
    parameter LENGTH = 1;
 
@@ -142,9 +142,9 @@ module arr;
       check <= 0;
    end
 
-endmodule : arr
+endmodule : ModArr
 
 
-module sub_wrapper;
-   sub my_sub ();
+module ModSubWrapper;
+   ModSub my_sub ();
 endmodule

--- a/test_regress/t/t_vpi_dump_missing_scopes.out
+++ b/test_regress/t/t_vpi_dump_missing_scopes.out
@@ -1,29 +1,29 @@
-t (vpiModule) t
+t (vpiModule) t  vpiDefName=<null>
     vpiReg:
     vpiParameter:
     vpiInternalScope:
-    top_wrap_1 (vpiModule) t.top_wrap_1
+    top_wrap_1 (vpiModule) t.top_wrap_1  vpiDefName=<null>
         vpiReg:
         vpiParameter:
         vpiInternalScope:
-        gen_loop[0] (vpiGenScope) t.top_wrap_1.gen_loop[0]
+        gen_loop[0] (vpiGenScope) t.top_wrap_1.gen_loop[0] 
             vpiReg:
             vpiParameter:
             vpiInternalScope:
-            after_gen_loop (vpiModule) t.top_wrap_1.gen_loop[0].after_gen_loop
+            after_gen_loop (vpiModule) t.top_wrap_1.gen_loop[0].after_gen_loop  vpiDefName=<null>
                 vpiReg:
-                subsig1 (vpiReg) t.top_wrap_1.gen_loop[0].after_gen_loop.subsig1
+                subsig1 (vpiReg) t.top_wrap_1.gen_loop[0].after_gen_loop.subsig1 
                 vpiParameter:
-    top_wrap_2 (vpiModule) t.top_wrap_2
+    top_wrap_2 (vpiModule) t.top_wrap_2  vpiDefName=<null>
         vpiReg:
         vpiParameter:
         vpiInternalScope:
-        gen_loop[0] (vpiGenScope) t.top_wrap_2.gen_loop[0]
+        gen_loop[0] (vpiGenScope) t.top_wrap_2.gen_loop[0] 
             vpiReg:
             vpiParameter:
             vpiInternalScope:
-            after_gen_loop (vpiModule) t.top_wrap_2.gen_loop[0].after_gen_loop
+            after_gen_loop (vpiModule) t.top_wrap_2.gen_loop[0].after_gen_loop  vpiDefName=<null>
                 vpiReg:
-                subsig1 (vpiReg) t.top_wrap_2.gen_loop[0].after_gen_loop.subsig1
+                subsig1 (vpiReg) t.top_wrap_2.gen_loop[0].after_gen_loop.subsig1 
                 vpiParameter:
 *-* All Finished *-*

--- a/test_regress/t/t_vpi_dump_missing_scopes.out
+++ b/test_regress/t/t_vpi_dump_missing_scopes.out
@@ -1,8 +1,8 @@
-t (vpiModule) t  vpiDefName=<null>
+t (vpiModule) t  vpiDefName=t
     vpiReg:
     vpiParameter:
     vpiInternalScope:
-    top_wrap_1 (vpiModule) t.top_wrap_1  vpiDefName=<null>
+    top_wrap_1 (vpiModule) t.top_wrap_1  vpiDefName=gen_wrapper
         vpiReg:
         vpiParameter:
         vpiInternalScope:
@@ -10,11 +10,11 @@ t (vpiModule) t  vpiDefName=<null>
             vpiReg:
             vpiParameter:
             vpiInternalScope:
-            after_gen_loop (vpiModule) t.top_wrap_1.gen_loop[0].after_gen_loop  vpiDefName=<null>
+            after_gen_loop (vpiModule) t.top_wrap_1.gen_loop[0].after_gen_loop  vpiDefName=sub
                 vpiReg:
                 subsig1 (vpiReg) t.top_wrap_1.gen_loop[0].after_gen_loop.subsig1 
                 vpiParameter:
-    top_wrap_2 (vpiModule) t.top_wrap_2  vpiDefName=<null>
+    top_wrap_2 (vpiModule) t.top_wrap_2  vpiDefName=gen_wrapper
         vpiReg:
         vpiParameter:
         vpiInternalScope:
@@ -22,7 +22,7 @@ t (vpiModule) t  vpiDefName=<null>
             vpiReg:
             vpiParameter:
             vpiInternalScope:
-            after_gen_loop (vpiModule) t.top_wrap_2.gen_loop[0].after_gen_loop  vpiDefName=<null>
+            after_gen_loop (vpiModule) t.top_wrap_2.gen_loop[0].after_gen_loop  vpiDefName=sub
                 vpiReg:
                 subsig1 (vpiReg) t.top_wrap_2.gen_loop[0].after_gen_loop.subsig1 
                 vpiParameter:

--- a/test_regress/t/t_vpi_dump_no_inline.py
+++ b/test_regress/t/t_vpi_dump_no_inline.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2024 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+test.pli_filename = "t/t_vpi_dump.cpp"
+test.golden_filename = "t/t_vpi_dump.out"
+test.top_filename = "t/t_vpi_dump.v"
+
+test.compile(make_top_shell=False,
+             make_main=False,
+             make_pli=True,
+             iv_flags2=["-g2005-sv"],
+             verilator_flags2=[
+                 "--exe --vpi --public-flat-rw --no-l2name --fno-inline", test.pli_filename,
+                 test.t_dir + "/TestVpiMain.cpp"
+             ],
+             make_flags=['CPPFLAGS_ADD=-DVL_NO_LEGACY'])
+
+test.execute(use_libvpi=True,
+             expect_filename=test.golden_filename,
+             xrun_run_expect_filename=re.sub(r'\.out$', '.xrun.out', test.golden_filename),
+             iv_run_expect_filename=re.sub(r'\.out$', '.iv.out', test.golden_filename))
+
+test.passes()


### PR DESCRIPTION
vpiDefname was implemented [here](https://github.com/verilator/verilator/pull/5572) only for inlined cells. This fixes the cases where it is left as <null> for vpiModules. CC @ksstrike 

On this commit it was simple to implement for the AstScope visitor as well as the inlined one- 
https://github.com/verilator/verilator/pull/5732/commits/5365f63738c5ce33c92bea336bae14b9308ba7db

The dpi commit required a bit more work to get both dpi and vpiDefName working, since the dpi scope would be written before the more correct module scope- 
https://github.com/verilator/verilator/pull/5732/commits/b1a64f9f2958d304cd1dffd676e68fe539a8476a