### PR TITLE
Support integer atom type ports in hierarchical verilation mode

### DIFF
--- a/src/V3EmitV.cpp
+++ b/src/V3EmitV.cpp
@@ -611,6 +611,9 @@ class EmitVBaseVisitorConst VL_NOT_FINAL : public EmitCBaseVisitorConst {
     void visit(AstBasicDType* nodep) override {
         putfs(nodep, nodep->prettyName());
         if (nodep->isSigned()) putfs(nodep, " signed");
+        // Do not emit ranges for integer atoms.
+        if (nodep->keyword().isIntNumeric() && !nodep->keyword().isBitLogic()) return;
+
         if (nodep->rangep()) {
             puts(" ");
             iterateAndNextConstNull(nodep->rangep());

--- a/test_regress/t/t_debug_emitv.out
+++ b/test_regress/t/t_debug_emitv.out
@@ -7,70 +7,70 @@ module Vt_debug_emitv_t;
     ???? // ENUMITEM 'ZERO'
     32'h0
     ???? // ENUMITEM 'ONE'
-    32'h1int signed [31:0] struct packed 
-    {int signed [31:0]  a;}logic signed [2:0] struct 
+    32'h1int signedstruct packed 
+    {int signed a;}logic signed [2:0] struct 
     {logic signed [2:0]  a;}logicunion 
     {logic a;}struct packed 
-    {int signed [31:0]  a;}bit [31:0] const struct packed 
-    {int signed [31:0]  a;}const struct packed 
-    {int signed [31:0]  a;}[0:2]struct 
+    {int signed a;}bit [31:0] const struct packed 
+    {int signed a;}const struct packed 
+    {int signed a;}[0:2]struct 
     {logic signed [2:0]  a;}union 
-    {logic a;}int signed [31:0] int signed [31:0] [0:2]logic [15:0] logic [15:0] logic [15:0] int signed [31:0] int signed [31:0] int signed [31:0] 
+    {logic a;}int signedint signed[0:2]logic [15:0] logic [15:0] logic [15:0] int signedint signedint signed
     ???? // QUEUEDTYPE
-    int signed [31:0] string
+    int signedstring
     ???? // ASSOCARRAYDTYPE
-    int signed [31:0] 
+    int signed
     ???? // DYNARRAYDTYPE
-    int signed [31:0] int signed [31:0] int signed [31:0] int signed [31:0] int signed [31:0] int signed [31:0] int signed [31:0] real signedstringIData [31:0] logic signed [31:0] int signed [31:0]  e_t;
+    int signedint signedint signedint signedint signedint signedint signedreal signedstringIDatalogic signed [31:0] int signed e_t;
     typedef struct packed 
-    {int signed [31:0]  a;}logic signed [2:0] struct 
+    {int signed a;}logic signed [2:0] struct 
     {logic signed [2:0]  a;}logicunion 
     {logic a;}struct packed 
-    {int signed [31:0]  a;}bit [31:0] const struct packed 
-    {int signed [31:0]  a;}const struct packed 
-    {int signed [31:0]  a;}[0:2]struct 
+    {int signed a;}bit [31:0] const struct packed 
+    {int signed a;}const struct packed 
+    {int signed a;}[0:2]struct 
     {logic signed [2:0]  a;}union 
-    {logic a;}int signed [31:0] int signed [31:0] [0:2]logic [15:0] logic [15:0] logic [15:0] int signed [31:0] int signed [31:0] int signed [31:0] 
+    {logic a;}int signedint signed[0:2]logic [15:0] logic [15:0] logic [15:0] int signedint signedint signed
     ???? // QUEUEDTYPE
-    int signed [31:0] string
+    int signedstring
     ???? // ASSOCARRAYDTYPE
-    int signed [31:0] 
+    int signed
     ???? // DYNARRAYDTYPE
-    int signed [31:0] int signed [31:0] int signed [31:0] int signed [31:0] int signed [31:0] int signed [31:0] int signed [31:0] real signedstringIData [31:0] logic signed [31:0] int signed [31:0]  ps_t;
+    int signedint signedint signedint signedint signedint signedint signedreal signedstringIDatalogic signed [31:0] int signed ps_t;
     typedef struct 
     {logic signed [2:0]  a;}logicunion 
     {logic a;}struct packed 
-    {int signed [31:0]  a;}bit [31:0] const struct packed 
-    {int signed [31:0]  a;}const struct packed 
-    {int signed [31:0]  a;}[0:2]struct 
+    {int signed a;}bit [31:0] const struct packed 
+    {int signed a;}const struct packed 
+    {int signed a;}[0:2]struct 
     {logic signed [2:0]  a;}union 
-    {logic a;}int signed [31:0] int signed [31:0] [0:2]logic [15:0] logic [15:0] logic [15:0] int signed [31:0] int signed [31:0] int signed [31:0] 
+    {logic a;}int signedint signed[0:2]logic [15:0] logic [15:0] logic [15:0] int signedint signedint signed
     ???? // QUEUEDTYPE
-    int signed [31:0] string
+    int signedstring
     ???? // ASSOCARRAYDTYPE
-    int signed [31:0] 
+    int signed
     ???? // DYNARRAYDTYPE
-    int signed [31:0] int signed [31:0] int signed [31:0] int signed [31:0] int signed [31:0] int signed [31:0] int signed [31:0] real signedstringIData [31:0] logic signed [31:0] int signed [31:0]  us_t;
+    int signedint signedint signedint signedint signedint signedint signedreal signedstringIDatalogic signed [31:0] int signed us_t;
     typedef union 
     {logic a;}struct packed 
-    {int signed [31:0]  a;}bit [31:0] const struct packed 
-    {int signed [31:0]  a;}const struct packed 
-    {int signed [31:0]  a;}[0:2]struct 
+    {int signed a;}bit [31:0] const struct packed 
+    {int signed a;}const struct packed 
+    {int signed a;}[0:2]struct 
     {logic signed [2:0]  a;}union 
-    {logic a;}int signed [31:0] int signed [31:0] [0:2]logic [15:0] logic [15:0] logic [15:0] int signed [31:0] int signed [31:0] int signed [31:0] 
+    {logic a;}int signedint signed[0:2]logic [15:0] logic [15:0] logic [15:0] int signedint signedint signed
     ???? // QUEUEDTYPE
-    int signed [31:0] string
+    int signedstring
     ???? // ASSOCARRAYDTYPE
-    int signed [31:0] 
+    int signed
     ???? // DYNARRAYDTYPE
-    int signed [31:0] int signed [31:0] int signed [31:0] int signed [31:0] int signed [31:0] int signed [31:0] int signed [31:0] real signedstringIData [31:0] logic signed [31:0] int signed [31:0]  union_t;
+    int signedint signedint signedint signedint signedint signedint signedreal signedstringIDatalogic signed [31:0] int signed union_t;
     struct packed 
-    {int signed [31:0]  a;} ps[0:2];
+    {int signed a;} ps[0:2];
     struct 
     {logic signed [2:0]  a;} us;
     union 
     {logic a;} unu;
-    int signed [31:0]  array[0:2];
+    int signed array[0:2];
     initial begin
         array = '{0:32'sh1, 1:32'sh2, 2:32'sh3};
     end
@@ -78,8 +78,8 @@ module Vt_debug_emitv_t;
     logic [15:0]  pubflat_r;
     logic [15:0]  pubflat_w;
     assign pubflat_w = pubflat;
-    int signed [31:0]  fd;
-    int signed [31:0]  i;
+    int signed fd;
+    int signed i;
 
     ???? // QUEUEDTYPE
      q;
@@ -93,7 +93,7 @@ module Vt_debug_emitv_t;
         $display("stmt");
     endtask
     function f;
-        input int signed [31:0]  v;
+        input int signed v;
         begin : label0
             $display("stmt");
             f = ((v == 'sh0) ? 'sh63 : ((~ v) + 'sh1));
@@ -102,10 +102,10 @@ module Vt_debug_emitv_t;
     endfunction
     initial begin
         begin : unnamedblk1
-            int signed [31:0]  other;
+            int signed other;
             begin
                 begin : unnamedblk2
-                    int signed [31:0]  i;
+                    int signed i;
                     i = 'sh0;
                     while ((i < 'sh3)) begin
                         begin
@@ -144,9 +144,9 @@ module Vt_debug_emitv_t;
             $display("negedge clk, pfr = %x", pubflat_r);
         end
     end
-    int signed [31:0]  cyc;
-    int signed [31:0]  fo;
-    int signed [31:0]  sum;
+    int signed cyc;
+    int signed fo;
+    int signed sum;
     real signed r;
     string str;
     always @(posedge clk) begin
@@ -177,7 +177,7 @@ module Vt_debug_emitv_t;
             $readmemh(fd, array, 'sh0, 'sh0);
             sum = 'sh0;
             begin : unnamedblk3
-                int signed [31:0]  i;
+                int signed i;
                 i = 'sh0;
                 begin : label0
                     while ((i < cyc)) begin
@@ -298,7 +298,7 @@ module Vt_debug_emitv_t;
             $display("%g", $atanh(r));
             force sum = 'sha;
             begin : unnamedblk1_1
-                integer signed [31:0]  __Vrepeat0;
+                integer signed __Vrepeat0;
                 __Vrepeat0 = 'sh2;
                 while ((__Vrepeat0 > 32'h0)) begin
                     if ((sum != 'sha)) begin
@@ -314,7 +314,7 @@ module Vt_debug_emitv_t;
 endmodule
 package Vt_debug_emitv___024unit;
     class Vt_debug_emitv_Cls;
-        int signed [31:0]  member;
+        int signed member;
         member = 'sh1;
         task method;
         endtask
@@ -324,12 +324,12 @@ package Vt_debug_emitv___024unit;
 endpackage
 module Vt_debug_emitv_sub;
     task inc;
-        input int signed [31:0]  i;
-        output int signed [31:0]  o;
+        input int signed i;
+        output int signed o;
         o = ({32'h1{{1'h0, i[31:1]}}} + 32'h1);
     endtask
     function f;
-        input int signed [31:0]  v;
+        input int signed v;
         begin : label0
             if ((v == 'sh0)) begin
                 f = 'sh21;

--- a/test_regress/t/t_hier_block_int.py
+++ b/test_regress/t/t_hier_block_int.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2025 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile(verilator_flags2=['--stats', '--hierarchical'])
+
+test.execute()
+
+test.file_grep(test.obj_dir + "/Vsub/sub.sv", r'^module\s+(\S+)\s+', "sub")
+test.file_grep(test.stats, r'HierBlock,\s+Hierarchical blocks\s+(\d+)', 1)
+
+test.passes()

--- a/test_regress/t/t_hier_block_int.v
+++ b/test_regress/t/t_hier_block_int.v
@@ -1,0 +1,50 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// Copyright 2025 by Antmicro. This program is free software; you can
+// redistribute it and/or modify it under the terms of either the GNU
+// Lesser General Public License Version 3 or the Perl Artistic License
+// Version 2.0.
+// SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+module t(/*AUTOARG*/
+   // inputs
+   clk
+);
+   input clk;
+
+   byte out1;
+   shortint out2;
+   int out3;
+   longint out4;
+   integer out5;
+   time out6;
+
+   sub sub(out1, out2, out3, out4, out5, out6);
+
+   always_ff @(posedge clk) begin
+      if (out1 == 1 && out2 == 2 && out3 == 3 && out4 == 4 && out5 == 5 && out6 == 6) begin
+         $write("*-* All Finished *-*\n");
+         $finish;
+      end
+      else begin
+         $write("Mismatch\n");
+         $stop;
+      end
+   end
+endmodule
+
+module sub(
+   output byte out1,
+   output shortint out2,
+   output int out3,
+   output longint out4,
+   output integer out5,
+   output time out6
+); /*verilator hier_block*/
+   assign out1 = 1;
+   assign out2 = 2;
+   assign out3 = 3;
+   assign out4 = 4;
+   assign out5 = 5;
+   assign out6 = 6;
+endmodule


### PR DESCRIPTION
This PR adds support for using integer atoms as hier_block ports. 

The fix involves changing V3EmitV to skip emitting ranges for `integer_atom_type` types (IEEE 1800-2023 A.2.2.1) thus resolving syntax errors in a SystemVerilog hierarchical wrapper.