### PR TITLE
Fix handling forced assigns in V3Life

### DIFF
--- a/src/V3Life.cpp
+++ b/src/V3Life.cpp
@@ -287,8 +287,8 @@ class LifeVisitor final : public VNVisitor {
         }
     }
     void visit(AstNodeAssign* nodep) override {
-        if (nodep->isTimingControl()) {
-            // V3Life doesn't understand time sense - don't optimize
+        if (nodep->isTimingControl() || VN_IS(nodep, AssignForce)) {
+            // V3Life doesn't understand time sense nor force assigns - don't optimize
             setNoopt();
             iterateChildren(nodep);
             return;

--- a/test_regress/t/t_force_assign.py
+++ b/test_regress/t/t_force_assign.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2025 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile()
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_force_assign.v
+++ b/test_regress/t/t_force_assign.v
@@ -1,0 +1,24 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2025 by Antmicro.
+// SPDX-License-Identifier: CC0-1.0
+
+module t;
+  reg [2:0] a = 0;
+
+  initial begin
+    a = 1;
+    if (a != 1) $stop;
+
+    force a = 2;
+    if (a != 2) $stop;
+
+    a = 3;
+    if (a != 2) $stop;
+
+    $write("*-* All Finished *-*\n");
+    $finish;
+  end
+
+endmodule


### PR DESCRIPTION
This PR fixes the problem with `force` assigns in V3Life phase (https://github.com/verilator/verilator/issues/5721#issuecomment-2594333949). Nodes of type `AstAssignForce` were incorrectly treated as `AstNodeAssign` leading to incorrect deletion of such nodes.

Note: this fixes case when we have such statements in the same `AstActive` block, more elaborate cases need to be additionally fixed in V3Force.
