### PR TITLE
Make preprocessor token limit configurable

### DIFF
--- a/bin/verilator
+++ b/bin/verilator
@@ -443,6 +443,7 @@ detailed descriptions of these arguments.
     --quiet                     Minimize additional printing
     --quiet-exit                Don't print the command on failure
     --quiet-stats               Don't print statistics
+    --preproc-token-limit       Maximum tokens on a line allowed by preprocessor
     --relative-includes         Resolve includes relative to current file
     --reloop-limit              Minimum iterations for forming loops
     --report-unoptflat          Extra diagnostics for UNOPTFLAT

--- a/bin/verilator
+++ b/bin/verilator
@@ -426,6 +426,7 @@ detailed descriptions of these arguments.
     --pipe-filter <command>     Filter all input through a script
     --pp-comments               Show preprocessor comments with -E
     --prefix <topname>          Name of top-level class
+    --preproc-token-limit       Maximum tokens on a line allowed by preprocessor
     --private                   Debugging; see docs
     --prof-c                    Compile C++ code with profiling
     --prof-cfuncs               Name functions for profiling
@@ -443,7 +444,6 @@ detailed descriptions of these arguments.
     --quiet                     Minimize additional printing
     --quiet-exit                Don't print the command on failure
     --quiet-stats               Don't print statistics
-    --preproc-token-limit       Maximum tokens on a line allowed by preprocessor
     --relative-includes         Resolve includes relative to current file
     --reloop-limit              Minimum iterations for forming loops
     --report-unoptflat          Extra diagnostics for UNOPTFLAT

--- a/docs/guide/exe_verilator.rst
+++ b/docs/guide/exe_verilator.rst
@@ -1296,9 +1296,9 @@ Summary:
 
 .. option:: --preproc-token-limit
 
-   Verilator limits the number of tokens it can process on a single line to
-   prevent infinite loops and other hangs. This argument allows configuring
-   that limit. The default is 40000 tokens.
+   Rarely needed. Configure the limit of the number of tokens Verilator
+   can process on a single line to prevent infinite loops and other hangs.
+   Defaults to 40000 tokens.
 
 .. option:: --relative-includes
 

--- a/docs/guide/exe_verilator.rst
+++ b/docs/guide/exe_verilator.rst
@@ -1294,6 +1294,12 @@ Summary:
    Disable printing the Verilation statistics report, see :ref:`Verilation
    Summary Report`.
 
+.. option:: --preproc-token-limit
+
+   Verilator limits the number of tokens it can process on a single line to
+   prevent infinite loops and other hangs. This argument allows configuring
+   that limit. The default is 40000 tokens.
+
 .. option:: --relative-includes
 
    When a file references an include file, resolve the filename relative to

--- a/docs/guide/exe_verilator.rst
+++ b/docs/guide/exe_verilator.rst
@@ -1142,6 +1142,12 @@ Summary:
    prepended to the name of the :vlopt:`--top` option, or V prepended to
    the first Verilog filename passed on the command line.
 
+.. option:: --preproc-token-limit
+
+   Rarely needed. Configure the limit of the number of tokens Verilator
+   can process on a single line to prevent infinite loops and other hangs.
+   Defaults to 40000 tokens.
+
 .. option:: --private
 
    Opposite of :vlopt:`--public`.  This is the default; this option exists for
@@ -1293,12 +1299,6 @@ Summary:
 
    Disable printing the Verilation statistics report, see :ref:`Verilation
    Summary Report`.
-
-.. option:: --preproc-token-limit
-
-   Rarely needed. Configure the limit of the number of tokens Verilator
-   can process on a single line to prevent infinite loops and other hangs.
-   Defaults to 40000 tokens.
 
 .. option:: --relative-includes
 

--- a/src/V3Options.cpp
+++ b/src/V3Options.cpp
@@ -1503,9 +1503,9 @@ void V3Options::parseOptsList(FileLine* fl, const string& optdir, int argc,
         m_prefix = valp;
     });
     DECL_OPTION("-preproc-token-limit", CbVal, [this, fl](const char* valp) {
-            m_preprocTokenLimit = std::atoi(valp);
-            if (m_preprocTokenLimit <= 0) fl->v3error("--preproc-token-limit must be > 0: " << valp);
-            });
+        m_preprocTokenLimit = std::atoi(valp);
+        if (m_preprocTokenLimit <= 0) fl->v3error("--preproc-token-limit must be > 0: " << valp);
+    });
     DECL_OPTION("-private", CbCall, [this]() { m_public = false; });
     DECL_OPTION("-prof-c", OnOff, &m_profC);
     DECL_OPTION("-prof-cfuncs", CbCall, [this]() { m_profC = m_profCFuncs = true; });

--- a/src/V3Options.cpp
+++ b/src/V3Options.cpp
@@ -1502,6 +1502,10 @@ void V3Options::parseOptsList(FileLine* fl, const string& optdir, int argc,
         validateIdentifier(fl, valp, "--prefix");
         m_prefix = valp;
     });
+    DECL_OPTION("-preproc-token-limit", CbVal, [this, fl](const char* valp) {
+            m_preprocTokenLimit = std::atoi(valp);
+            if (m_preprocTokenLimit <= 0) fl->v3error("--preproc-token-limit must be > 0: " << valp);
+            });
     DECL_OPTION("-private", CbCall, [this]() { m_public = false; });
     DECL_OPTION("-prof-c", OnOff, &m_profC);
     DECL_OPTION("-prof-cfuncs", CbCall, [this]() { m_profC = m_profCFuncs = true; });
@@ -1538,10 +1542,6 @@ void V3Options::parseOptsList(FileLine* fl, const string& optdir, int argc,
     DECL_OPTION("-quiet-stats", OnOff, &m_quietStats);
 
     DECL_OPTION("-relative-includes", OnOff, &m_relativeIncludes);
-    DECL_OPTION("-preproc-token-limit", CbVal, [this, fl](const char* valp) {
-        m_preprocTokenLimit = std::atoi(valp);
-        if (m_preprocTokenLimit <= 0) fl->v3error("--preproc-token-limit must be > 0: " << valp);
-    });
     DECL_OPTION("-reloop-limit", CbVal, [this, fl](const char* valp) {
         m_reloopLimit = std::atoi(valp);
         if (m_reloopLimit < 2) fl->v3error("--reloop-limit must be >= 2: " << valp);

--- a/src/V3Options.cpp
+++ b/src/V3Options.cpp
@@ -1538,6 +1538,10 @@ void V3Options::parseOptsList(FileLine* fl, const string& optdir, int argc,
     DECL_OPTION("-quiet-stats", OnOff, &m_quietStats);
 
     DECL_OPTION("-relative-includes", OnOff, &m_relativeIncludes);
+    DECL_OPTION("-preproc-token-limit", CbVal, [this, fl](const char* valp) {
+        m_preprocTokenLimit = std::atoi(valp);
+        if (m_preprocTokenLimit <= 0) fl->v3error("--preproc-token-limit must be > 0: " << valp);
+    });
     DECL_OPTION("-reloop-limit", CbVal, [this, fl](const char* valp) {
         m_reloopLimit = std::atoi(valp);
         if (m_reloopLimit < 2) fl->v3error("--reloop-limit must be >= 2: " << valp);

--- a/src/V3Options.h
+++ b/src/V3Options.h
@@ -324,8 +324,8 @@ private:
     int         m_outputSplitCFuncs = -1;  // main switch: --output-split-cfuncs
     int         m_outputSplitCTrace = -1;  // main switch: --output-split-ctrace
     int         m_pinsBv = 65;       // main switch: --pins-bv
-    int         m_publicDepth = 0;   // main switch: --public-depth
     int         m_preprocTokenLimit = 40000; // main switch: --preproc-token-limit
+    int         m_publicDepth = 0;   // main switch: --public-depth
     int         m_reloopLimit = 40; // main switch: --reloop-limit
     VOptionBool m_skipIdentical;  // main switch: --skip-identical
     bool        m_stopFail = true;  // main switch: --stop-fail

--- a/src/V3Options.h
+++ b/src/V3Options.h
@@ -325,6 +325,7 @@ private:
     int         m_outputSplitCTrace = -1;  // main switch: --output-split-ctrace
     int         m_pinsBv = 65;       // main switch: --pins-bv
     int         m_publicDepth = 0;   // main switch: --public-depth
+    int         m_preprocTokenLimit = 40000; // main switch: --preproc-token-limit
     int         m_reloopLimit = 40; // main switch: --reloop-limit
     VOptionBool m_skipIdentical;  // main switch: --skip-identical
     bool        m_stopFail = true;  // main switch: --stop-fail
@@ -465,6 +466,7 @@ public:
     bool preprocOnly() const { return m_preprocOnly; }
     bool makePhony() const { return m_makePhony; }
     bool preprocNoLine() const { return m_preprocNoLine; }
+    int preprocTokenLimit() const { return m_preprocTokenLimit; }
     bool underlineZero() const { return m_underlineZero; }
     string flags() const { return m_flags; }
     bool systemC() const VL_MT_SAFE { return m_systemC; }

--- a/src/V3PreProc.cpp
+++ b/src/V3PreProc.cpp
@@ -963,9 +963,9 @@ int V3PreProcImp::getRawToken() {
         if (m_lastLineno != m_lexp->m_tokFilelinep->lineno()) {
             m_lastLineno = m_lexp->m_tokFilelinep->lineno();
             m_tokensOnLine = 0;
-        } else if (++m_tokensOnLine > LINE_TOKEN_MAX) {
-            error("Too many preprocessor tokens on a line (>" + cvtToStr(LINE_TOKEN_MAX)
-                  + "); perhaps recursive `define");
+        } else if (++m_tokensOnLine > v3Global.opt.preprocTokenLimit()) {
+            error("Too many preprocessor tokens on a line (>"
+                  + cvtToStr(v3Global.opt.preprocTokenLimit()) + "); perhaps recursive `define");
             tok = VP_EOF_ERROR;
         }
 

--- a/src/V3PreProc.h
+++ b/src/V3PreProc.h
@@ -42,7 +42,6 @@ public:
     // CONSTANTS
     enum MiscConsts {
         DEFINE_RECURSION_LEVEL_MAX = 1000,  // How many `def substitutions before an error
-        LINE_TOKEN_MAX = 40000,  // How many tokens on a line before an error
         INCLUDE_DEPTH_MAX = 500,  // How many `includes deep before an error
         // Streams deep (sometimes `def deep) before an error.
         // Set more than DEFINE_RECURSION_LEVEL_MAX or INCLUDE_DEPTH_MAX.

--- a/test_regress/t/t_flag_values_bad.out
+++ b/test_regress/t/t_flag_values_bad.out
@@ -1,4 +1,5 @@
 %Error: --output-split-cfuncs must be >= 0: -1
 %Error: --output-split-ctrace must be >= 0: -1
+%Error: --preproc-token-limit must be > 0: 0
 %Error: --reloop-limit must be >= 2: -1
 %Error: Exiting due to

--- a/test_regress/t/t_pp_circ_subst_bad2.out
+++ b/test_regress/t/t_pp_circ_subst_bad2.out
@@ -1,0 +1,3 @@
+%Error: t/t_pp_circ_subst_bad.v:8:40002: Too many preprocessor tokens on a line (>20000); perhaps recursive `define
+%Error: t/t_pp_circ_subst_bad.v:8:1: syntax error, unexpected IDENTIFIER
+%Error: Exiting due to

--- a/test_regress/t/t_pp_circ_subst_bad2.py
+++ b/test_regress/t/t_pp_circ_subst_bad2.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # DESCRIPTION: Verilator: Verilog Test driver/expect definition
 #
-# Copyright 2024 by Wilson Snyder. This program is free software; you
+# Copyright 2025 by Wilson Snyder. This program is free software; you
 # can redistribute it and/or modify it under the terms of either the GNU
 # Lesser General Public License Version 3 or the Perl Artistic License
 # Version 2.0.
@@ -9,12 +9,10 @@
 
 import vltest_bootstrap
 
-test.scenarios('vlt')
+test.scenarios('linter')
+test.top_filename = "t/t_pp_circ_subst_bad.v"
 
-test.lint(verilator_flags2=[
-    "--output-split-cfuncs -1", "--output-split-ctrace -1", "--preproc-token-limit 0",
-    "--reloop-limit -1"
-],
+test.lint(verilator_flags2=["--preproc-token-limit 20000"],
           fails=True,
           expect_filename=test.golden_filename)
 


### PR DESCRIPTION
Allows users to set the per-line token limit. Useful for complex macros/code generation.

This was also discussed in https://github.com/verilator/verilator/issues/2771.