### PR TITLE
Ignore joins in stringify in preprocessor

### DIFF
--- a/src/V3PreProc.cpp
+++ b/src/V3PreProc.cpp
@@ -1065,6 +1065,11 @@ int V3PreProcImp::getStateToken() {
                 // FALLTHRU, handle as with VP_SYMBOL_JOIN
             }
         }
+        if (state() == ps_STRIFY) {
+            // Ignore joins and symbol joins in stringify as they don't affect the final string
+            if (tok == VP_JOIN) goto next_tok;
+            if (tok == VP_SYMBOL_JOIN) tok = VP_SYMBOL;
+        }
         if (tok == VP_SYMBOL_JOIN  // not else if, can fallthru from above if()
             || tok == VP_DEFREF_JOIN || tok == VP_JOIN) {
             // a`` -> string doesn't include the ``, so can just grab next and continue

--- a/test_regress/t/t_preproc_strify_join.out
+++ b/test_regress/t/t_preproc_strify_join.out
@@ -1,0 +1,3 @@
+"foo-bar-qux"
+""foo-bar-qux""
+""

--- a/test_regress/t/t_preproc_strify_join.py
+++ b/test_regress/t/t_preproc_strify_join.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2025 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('vlt')
+
+stdout_filename = os.path.join(test.obj_dir, test.name + "__test.vpp")
+
+test.compile(verilator_flags2=['-E -P'],
+             verilator_make_gmake=False,
+             make_top_shell=False,
+             make_main=False,
+             stdout_filename=stdout_filename)
+
+test.files_identical(stdout_filename, test.golden_filename)
+
+test.passes()

--- a/test_regress/t/t_preproc_strify_join.v
+++ b/test_regress/t/t_preproc_strify_join.v
@@ -1,0 +1,19 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed into the Public Domain, for any use,
+// without warranty, 2025 by Antmicro.
+// SPDX-License-Identifier: CC0-1.0
+
+`define FOO foo
+`define BAR bar
+`define QUX qux
+`define STRIFY `"`FOO``-```BAR``-```QUX```"
+
+`define NESTED_STRIFY `"`STRIFY```"
+
+`define EMPTY
+`define EMPTY_STRIFY `"`EMPTY```"
+
+`STRIFY
+`NESTED_STRIFY
+`EMPTY_STRIFY


### PR DESCRIPTION
If we're in a join state under a stringify state, and we encounter a <code>`"</code>, we start another stringification instead of finishing the current one. This patch ignores two of the join tokens under stringification, as they don't seem to affect the resulting string.

This is to handle [this define in UVM 1.2](https://github.com/chipsalliance/uvm-verilator/blob/c68f035f9c8e965807082495c5a667729afe3aa8/src/macros/uvm_version_defines.svh#L94).

I tried other approaches:
* properly handle the `VP_STRIFY` token under `ps_JOIN`, but couldn't make it work (`flex` seemed confused about what state it's supposed to be in), I found it simpler to ignore it,
* ignore `VP_DEFREF_JOIN` as well, but that broke `t_preproc_str_undef`.