### PR TITLE
split_var internal error

### DIFF
--- a/test_regress/t/t_split_var_types.py
+++ b/test_regress/t/t_split_var_types.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2024 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile(verilator_flags2=['--trace'])
+
+test.execute()
+test.passes()

--- a/test_regress/t/t_split_var_types.v
+++ b/test_regress/t/t_split_var_types.v
@@ -1,0 +1,30 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2025
+// SPDX-License-Identifier: CC0-1.0
+
+module t(/*AUTOARG*/
+    // Inputs
+    clk
+    );
+    input clk;
+
+    // Test loop
+    always @ (posedge clk) begin
+        $write("*-* All Finished *-*\n");
+        $finish;
+    end
+
+    sub the_sub (.data_out());
+
+endmodule
+
+module sub(
+    output logic [31:0][15:0] data_out
+);
+    logic [31:0][15:0] data [8] /*verilator split_var*/;
+    always begin
+        data_out = data[7];
+    end
+endmodule


### PR DESCRIPTION
Causes:
```
%Error: Internal Error: t/t_split_var_types.v:28:24: ../V3SplitVar.cpp:1124: not enough split variables
                                                   : ... note: In instance 't.the_sub'
   28 |         data_out = data[7];
      |                        ^
```

Note: `--trace` is required to observe the bug.

I don't think this one is in my way right now, but I discovered it while working on #5719.  I can add this as an unsup test or if desired someone can take it over.