### PR TITLE
Fix #5782 internal error of split_var

### DIFF
--- a/test_regress/t/t_split_var_types.py
+++ b/test_regress/t/t_split_var_types.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2024 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile(verilator_flags2=['--trace'])
+
+test.execute()
+test.passes()

--- a/test_regress/t/t_split_var_types.v
+++ b/test_regress/t/t_split_var_types.v
@@ -1,0 +1,30 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2025
+// SPDX-License-Identifier: CC0-1.0
+
+module t(/*AUTOARG*/
+    // Inputs
+    clk
+    );
+    input clk;
+
+    // Test loop
+    always @ (posedge clk) begin
+        $write("*-* All Finished *-*\n");
+        $finish;
+    end
+
+    sub the_sub (.data_out());
+
+endmodule
+
+module sub(
+    output logic [31:0][15:0] data_out
+);
+    logic [31:0][15:0] data [8] /*verilator split_var*/;
+    always begin
+        data_out = data[7];
+    end
+endmodule

--- a/test_regress/t/t_split_var_types.v
+++ b/test_regress/t/t_split_var_types.v
@@ -16,11 +16,12 @@ module t(/*AUTOARG*/
         $finish;
     end
 
-    sub the_sub (.data_out());
+    bug5782 u_bug5782(.data_out());
 
 endmodule
 
-module sub(
+// #5782 internal error with --trace. Bit range is not properly handled.
+module bug5782 (
     output logic [31:0][15:0] data_out
 );
     logic [31:0][15:0] data [8] /*verilator split_var*/;


### PR DESCRIPTION
Fixes #5782
The related code used basicp even for packed arrays.
It caused wrong hi(), and lo().

As usual, a test to reproduce the error is pushed, then fix later.

The test is from #5781 . Thank you @toddstrader 