### PR TITLE
Fix dpi context functions

### DIFF
--- a/src/V3LinkResolve.cpp
+++ b/src/V3LinkResolve.cpp
@@ -221,7 +221,8 @@ class LinkResolveVisitor final : public VNVisitor {
             letp->user2(false);
             return;
         }
-        if (nodep->taskp() && (nodep->taskp()->dpiContext() || nodep->taskp()->dpiExport())) {
+        if (nodep->taskp() && !nodep->scopeNamep()
+            && (nodep->taskp()->dpiContext() || nodep->taskp()->dpiExport())) {
             nodep->scopeNamep(new AstScopeName{nodep->fileline(), false});
         }
     }

--- a/test_regress/t/t_dpi_context.py
+++ b/test_regress/t/t_dpi_context.py
@@ -11,7 +11,7 @@ import vltest_bootstrap
 
 test.scenarios('simulator')
 
-test.compile(v_flags2=["t/t_dpi_context_c.cpp"])
+test.compile(v_flags2=["t/t_dpi_context_c.cpp", "--debug"])
 
 test.execute()
 

--- a/test_regress/t/t_dpi_context.py
+++ b/test_regress/t/t_dpi_context.py
@@ -11,7 +11,7 @@ import vltest_bootstrap
 
 test.scenarios('simulator')
 
-test.compile(v_flags2=["t/t_dpi_context_c.cpp", "--debug"])
+test.compile(v_flags2=["t/t_dpi_context_c.cpp", "--debug", "-no-dump-tree"])
 
 test.execute()
 

--- a/test_regress/t/t_dpi_context.v
+++ b/test_regress/t/t_dpi_context.v
@@ -32,6 +32,7 @@ module sub (input integer inst);
    import "DPI-C" context function int dpic_save(int value);
    import "DPI-C" context function int dpic_restore();
    import "DPI-C" context function int unsigned dpic_getcontext();
+   import "DPI-C" context function int unsigned dpic_get1();
 
    int result;
 
@@ -63,6 +64,11 @@ module sub (input integer inst);
       if (dpic_restore() != 23+inst) $stop;
    endtask
 
+   function automatic int call_dpic_get1;
+      int res = dpic_get1();
+      return res;
+   endfunction
+
    int unsigned cntxt1;
    int unsigned cntxt2;
 
@@ -74,6 +80,7 @@ module sub (input integer inst);
      end
      // svContext should be the context of the function declaration, not the context of the function call
      if (cntxt1 != cntxt2) $stop;
+     if (call_dpic_get1() != 1) $stop;
    end
 
 endmodule

--- a/test_regress/t/t_dpi_context_c.cpp
+++ b/test_regress/t/t_dpi_context_c.cpp
@@ -42,6 +42,7 @@ extern int dpic_line();
 extern int dpic_save(int value);
 extern int dpic_restore();
 extern unsigned dpic_getcontext();
+extern unsigned dpic_get1();
 }
 #endif
 
@@ -149,6 +150,10 @@ unsigned dpic_getcontext() {
     printf("%%Info: svGetScope returned scope (%p) with name %s\n",  //
            scope, svGetNameFromScope(scope));
     return (unsigned)(uintptr_t)scope;
+}
+
+unsigned dpic_get1() {
+    return 1;
 }
 
 void dpic_final() {

--- a/test_regress/t/t_dpi_context_c.cpp
+++ b/test_regress/t/t_dpi_context_c.cpp
@@ -152,9 +152,7 @@ unsigned dpic_getcontext() {
     return (unsigned)(uintptr_t)scope;
 }
 
-unsigned dpic_get1() {
-    return 1;
-}
+unsigned dpic_get1() { return 1; }
 
 void dpic_final() {
     static int s_once = 0;


### PR DESCRIPTION
The following code:
```systemverilog
module t;
   import "DPI-C" context function int get1;
   function automatic int call_dpi;
      int res = get1();
      return res;
   endfunction
endmodule
```
gives the following error when verilator is run with `--debug` flag:
```
%Error: Internal Error: ex/dpi.sv:4:17: ../V3Ast.cpp:459: Adding to non-empty, non-list op4
-node: FUNCREF 0x555556d63540 <e839#> {e4ar} @dt=0@  get1 -> FUNC 0x555556d4f700 <e603> {e2bo} @dt=0@  get1 [DPII] [PROTOTYPE]
    4 |       int res = get1();
      |                 ^~~~
```
The error is thrown, because that `AstFuncRef` is visited for the second time. It is initially in the body of `AstInitialAutomatic`, but then that node is replaced with its body: https://github.com/verilator/verilator/blob/fe1517164998cc71f81db389a1daf016be01453d/src/V3LinkResolve.cpp#L116
Then we visit its body again, because it was visited with `iterateAndNext`.

This PR prevents from assigning `scopeNamep` for the second time.