### PR TITLE
Fix V3EmitV for non-zero based arrays

### DIFF
--- a/src/V3EmitV.cpp
+++ b/src/V3EmitV.cpp
@@ -602,22 +602,28 @@ class EmitVBaseVisitorConst VL_NOT_FINAL : public EmitCBaseVisitorConst {
     }
     void visit(AstSel* nodep) override {
         iterateAndNextConstNull(nodep->fromp());
+        int offset = 0;
+        AstNodeDType* const dtypep = nodep->fromp()->dtypep();
+        if (VN_IS(dtypep, BasicDType)) {
+            AstBasicDType* const basicDtypep = VN_AS(dtypep, BasicDType);
+            offset = basicDtypep->lo();
+        }
         puts("[");
         if (VN_IS(nodep->lsbp(), Const)) {
             if (nodep->widthp()->isOne()) {
-                if (VN_IS(nodep->lsbp(), Const)) {
-                    puts(cvtToStr(VN_AS(nodep->lsbp(), Const)->toSInt()));
-                } else {
-                    iterateAndNextConstNull(nodep->lsbp());
-                }
+                puts(cvtToStr(VN_AS(nodep->lsbp(), Const)->toSInt() + offset));
             } else {
                 puts(cvtToStr(VN_AS(nodep->lsbp(), Const)->toSInt()
-                              + VN_AS(nodep->widthp(), Const)->toSInt() - 1));
+                              + VN_AS(nodep->widthp(), Const)->toSInt() + offset - 1));
                 puts(":");
-                puts(cvtToStr(VN_AS(nodep->lsbp(), Const)->toSInt()));
+                puts(cvtToStr(VN_AS(nodep->lsbp(), Const)->toSInt() + offset));
             }
         } else {
             iterateAndNextConstNull(nodep->lsbp());
+            if (offset != 0) {
+                puts(" + ");
+                puts(cvtToStr(offset));
+            }
             putfs(nodep, "+:");
             iterateAndNextConstNull(nodep->widthp());
             puts("]");

--- a/test_regress/t/t_cover_expr.out
+++ b/test_regress/t/t_cover_expr.out
@@ -15,6 +15,9 @@
             integer cyc;
             initial cyc=1;
         
+            logic [63:32] cyc2;
+            always_comb cyc2 = cyc;
+        
             integer some_int;
             integer other_int;
             logic some_bool;
@@ -49,6 +52,13 @@
 -000002  point: comment=(cyc[1]==0 && cyc[2]==1) => 0 hier=top.t
 -000003  point: comment=(cyc[1]==0 && cyc[3]==0) => 0 hier=top.t
 -000002  point: comment=(cyc[2]==0 && cyc[3]==1) => 1 hier=top.t
+%000004         if ((~cyc2[32] && cyc2[33]) || (~cyc2[34] && cyc2[35])) $write("");
+-000002  point: comment=(cyc2[32]==0 && cyc2[33]==1) => 1 hier=top.t
+-000002  point: comment=(cyc2[32]==1 && cyc2[34]==1) => 0 hier=top.t
+-000004  point: comment=(cyc2[32]==1 && cyc2[35]==0) => 0 hier=top.t
+-000002  point: comment=(cyc2[33]==0 && cyc2[34]==1) => 0 hier=top.t
+-000003  point: comment=(cyc2[33]==0 && cyc2[35]==0) => 0 hier=top.t
+-000002  point: comment=(cyc2[34]==0 && cyc2[35]==1) => 1 hier=top.t
 %000004         if ((~t1 && t2) || (~t3 && t4)) $write("");
 -000002  point: comment=(t1==0 && t2==1) => 1 hier=top.t
 -000002  point: comment=(t1==1 && t3==1) => 0 hier=top.t

--- a/test_regress/t/t_cover_expr.v
+++ b/test_regress/t/t_cover_expr.v
@@ -14,6 +14,9 @@ module t (/*AUTOARG*/
     integer cyc;
     initial cyc=1;
 
+    logic [63:32] cyc2;
+    always_comb cyc2 = cyc;
+
     integer some_int;
     integer other_int;
     logic some_bool;
@@ -37,6 +40,7 @@ module t (/*AUTOARG*/
     always @ (posedge clk) begin
         cyc <= cyc + 1;
         if ((~cyc[0] && cyc[1]) || (~cyc[2] && cyc[3])) $write("");
+        if ((~cyc2[32] && cyc2[33]) || (~cyc2[34] && cyc2[35])) $write("");
         if ((~t1 && t2) || (~t3 && t4)) $write("");
         if (t3 && (t1 == t2)) $write("");
         if (123 == (124 - 32'(t1 || t2))) $write("");

--- a/test_regress/t/t_cover_expr_max.out
+++ b/test_regress/t/t_cover_expr_max.out
@@ -15,6 +15,9 @@
             integer cyc;
             initial cyc=1;
         
+            logic [63:32] cyc2;
+            always_comb cyc2 = cyc;
+        
             integer some_int;
             integer other_int;
             logic some_bool;
@@ -49,6 +52,13 @@
 -000002  point: comment=(cyc[1]==0 && cyc[2]==1) => 0 hier=top.t
 -000003  point: comment=(cyc[1]==0 && cyc[3]==0) => 0 hier=top.t
 -000002  point: comment=(cyc[2]==0 && cyc[3]==1) => 1 hier=top.t
+%000004         if ((~cyc2[32] && cyc2[33]) || (~cyc2[34] && cyc2[35])) $write("");
+-000002  point: comment=(cyc2[32]==0 && cyc2[33]==1) => 1 hier=top.t
+-000002  point: comment=(cyc2[32]==1 && cyc2[34]==1) => 0 hier=top.t
+-000004  point: comment=(cyc2[32]==1 && cyc2[35]==0) => 0 hier=top.t
+-000002  point: comment=(cyc2[33]==0 && cyc2[34]==1) => 0 hier=top.t
+-000003  point: comment=(cyc2[33]==0 && cyc2[35]==0) => 0 hier=top.t
+-000002  point: comment=(cyc2[34]==0 && cyc2[35]==1) => 1 hier=top.t
 %000004         if ((~t1 && t2) || (~t3 && t4)) $write("");
 -000002  point: comment=(t1==0 && t2==1) => 1 hier=top.t
 -000002  point: comment=(t1==1 && t3==1) => 0 hier=top.t

--- a/test_regress/t/t_cover_expr_trace.out
+++ b/test_regress/t/t_cover_expr_trace.out
@@ -15,6 +15,9 @@
             integer cyc;
             initial cyc=1;
         
+            logic [63:32] cyc2;
+            always_comb cyc2 = cyc;
+        
             integer some_int;
             integer other_int;
             logic some_bool;
@@ -49,6 +52,13 @@
 -000002  point: comment=(cyc[1]==0 && cyc[2]==1) => 0 hier=top.t
 -000003  point: comment=(cyc[1]==0 && cyc[3]==0) => 0 hier=top.t
 -000002  point: comment=(cyc[2]==0 && cyc[3]==1) => 1 hier=top.t
+%000004         if ((~cyc2[32] && cyc2[33]) || (~cyc2[34] && cyc2[35])) $write("");
+-000002  point: comment=(cyc2[32]==0 && cyc2[33]==1) => 1 hier=top.t
+-000002  point: comment=(cyc2[32]==1 && cyc2[34]==1) => 0 hier=top.t
+-000004  point: comment=(cyc2[32]==1 && cyc2[35]==0) => 0 hier=top.t
+-000002  point: comment=(cyc2[33]==0 && cyc2[34]==1) => 0 hier=top.t
+-000003  point: comment=(cyc2[33]==0 && cyc2[35]==0) => 0 hier=top.t
+-000002  point: comment=(cyc2[34]==0 && cyc2[35]==1) => 1 hier=top.t
 %000004         if ((~t1 && t2) || (~t3 && t4)) $write("");
 -000002  point: comment=(t1==0 && t2==1) => 1 hier=top.t
 -000002  point: comment=(t1==1 && t3==1) => 0 hier=top.t

--- a/test_regress/t/t_debug_emitv.out
+++ b/test_regress/t/t_debug_emitv.out
@@ -28,6 +28,15 @@ module Vt_debug_emitv_t;
     initial begin
         array = '{0:32'sh1, 1:32'sh2, 2:32'sh3};
     end
+    logic [63:32]  downto_32;
+    downto_32 = 32'h0;
+    function ident;
+        input int signed value;
+        begin : label0
+            ident = value;
+            disable label0;
+        end
+    endfunction
     initial begin
         begin
             if ($test$plusargs(40'h48454c4c4f)) begin
@@ -44,6 +53,22 @@ module Vt_debug_emitv_t;
             end
             else begin
                 $display("+TEST= not found");
+            end
+            if (downto_32[33]) begin
+                $write("");
+            end
+            if (downto_32[(ident('sh21) - 'h20)[5:0] + 32
+                +:'h1]]) begin
+                $write("");
+            end
+            if ((| downto_32[48:40])) begin
+                $write("");
+            end
+            if ((| downto_32[57:55])) begin
+                $write("");
+            end
+            if ((| downto_32[60:54])) begin
+                $write("");
             end
         end
     end

--- a/test_regress/t/t_debug_emitv.v
+++ b/test_regress/t/t_debug_emitv.v
@@ -61,6 +61,12 @@ module t (/*AUTOARG*/
    integer i1;
    int array[3];
    initial array = '{1,2,3};
+   logic [63:32] downto_32 = '0;
+
+   function automatic int ident(int value);
+       return value;
+   endfunction
+
    initial begin
       if ($test$plusargs("HELLO")) $display("Hello argument found.");
       if (Pkg::FOO == 0) $write("");
@@ -69,6 +75,11 @@ module t (/*AUTOARG*/
          $display("value was %d", i1);
       else
          $display("+TEST= not found");
+      if (downto_32[33]) $write("");
+      if (downto_32[ident(33)]) $write("");
+      if (|downto_32[48:40]) $write("");
+      if (|downto_32[55+:3]) $write("");
+      if (|downto_32[60-:7]) $write("");
    end
 
    bit [6:5][4:3][2:1] arraymanyd[10:11][12:13][14:15];


### PR DESCRIPTION
Fixes V3EmitV for cases where a dtype's range does not start at zero.  Not looking at up-to ranges in this PR since a) that's not on my critical path b) they're also broken regardless of where the range starts.

Also removed a pointless branch in `EmitVBaseVisitorConst::visit(AstSel)`.