### PR TITLE
Include used language spec in preprocessor output

### DIFF
--- a/src/V3PreShell.cpp
+++ b/src/V3PreShell.cpp
@@ -95,7 +95,7 @@ protected:
         if (modfilename.empty()) return false;
 
         // Set language standard up front
-        if (!v3Global.opt.preprocOnly()) {
+        if (!v3Global.opt.preprocOnly() || v3Global.opt.preprocResolve()) {
             // Letting lex parse this saves us from having to specially en/decode
             // from the V3LangCode to the various Lex BEGIN states. The language
             // of this source file is updated here, in case there have been any

--- a/test_regress/t/t_preproc_resolve.out
+++ b/test_regress/t/t_preproc_resolve.out
@@ -1,3 +1,7 @@
+`begin_keywords "1800-2023"
+`verilator_config
+lint_off -rule NONSTD
+`begin_keywords "1800-2023"
 `timescale 1ns/1ps
 module top( 
    input logic clk,
@@ -10,6 +14,7 @@ module top(
       .out_signal(top_out)
    );
 endmodule
+`begin_keywords "1800-2023"
 `timescale 1ns/1ps
 module submod( 
    input logic clk,

--- a/test_regress/t/t_preproc_resolve.py
+++ b/test_regress/t/t_preproc_resolve.py
@@ -16,7 +16,9 @@ stdout_filename = os.path.join(test.obj_dir, test.name + ".out")
 test.compile(
     # Override default flags
     v_flags=[''],
-    verilator_flags=["-E -P --preproc-resolve -y t/t_preproc_resolve"],
+    verilator_flags=[
+        "-E -P --preproc-resolve t/t_preproc_resolve_config.vlt -y t/t_preproc_resolve"
+    ],
     verilator_flags2=[''],
     verilator_flags3=[''],
     verilator_make_gmake=False,

--- a/test_regress/t/t_preproc_resolve_config.vlt
+++ b/test_regress/t/t_preproc_resolve_config.vlt
@@ -1,0 +1,8 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2025 by Antmicro.
+// SPDX-License-Identifier: CC0-1.0
+
+`verilator_config
+lint_off -rule NONSTD


### PR DESCRIPTION
This PR makes to always print language specs in preprocessor output, not only if we are not in preprocessor-only mode.

This fixes issue with using preprocess-only mode together with verilator config file. Currently such file is appended to rest of the verilog files and when it is fed back to verilator, it complains about syntax error.

I'm not entire sure why it wasn't emitted in preprocessor-only mode - I tried to check this in git history, but it looks like it was like this from the beginning. I think it makes sense to just always emit this. If you disagree, I can add additional flag that will enable this behavior in preprocessor-only mode.