### PR TITLE
Fix expression coverage + VarXRefs

### DIFF
--- a/src/V3Coverage.cpp
+++ b/src/V3Coverage.cpp
@@ -726,7 +726,7 @@ class CoverageVisitor final : public VNVisitor {
                 // not be flagged as redundant or impossible, however the results will
                 // still be valid, albeit messier
                 for (CoverTerm& term : l) {
-                    if (AstNodeVarRef* const refp = VN_CAST(term.m_exprp, NodeVarRef)) {
+                    if (AstVarRef* const refp = VN_CAST(term.m_exprp, VarRef)) {
                         varps[term.m_objective].insert(refp->varp());
                     } else {
                         strs[term.m_objective].insert(term.m_emitV);

--- a/test_regress/t/t_cover_expr.out
+++ b/test_regress/t/t_cover_expr.out
@@ -43,6 +43,13 @@
 -000005  point: comment=(b==0) => 0 hier=top.t
             endfunction
         
+            localparam int num_intfs = 4;
+            intf the_intfs [num_intfs-1:0] ();
+            genvar intf_i;
+            for (intf_i = 0; intf_i < num_intfs; intf_i++) begin
+                always_comb the_intfs[intf_i].t = cyc[intf_i];
+            end
+        
             always @ (posedge clk) begin
                 cyc <= cyc + 1;
 %000004         if ((~cyc[0] && cyc[1]) || (~cyc[2] && cyc[3])) $write("");
@@ -59,6 +66,13 @@
 -000002  point: comment=(cyc2[33]==0 && cyc2[34]==1) => 0 hier=top.t
 -000003  point: comment=(cyc2[33]==0 && cyc2[35]==0) => 0 hier=top.t
 -000002  point: comment=(cyc2[34]==0 && cyc2[35]==1) => 1 hier=top.t
+%000004         if ((~the_intfs[0].t && the_intfs[1].t) || (~the_intfs[2].t && the_intfs[3].t)) $write("");
+-000002  point: comment=(the_intfs[0].t==0 && the_intfs[1].t==1) => 1 hier=top.t
+-000002  point: comment=(the_intfs[0].t==1 && the_intfs[2].t==1) => 0 hier=top.t
+-000004  point: comment=(the_intfs[0].t==1 && the_intfs[3].t==0) => 0 hier=top.t
+-000002  point: comment=(the_intfs[1].t==0 && the_intfs[2].t==1) => 0 hier=top.t
+-000003  point: comment=(the_intfs[1].t==0 && the_intfs[3].t==0) => 0 hier=top.t
+-000002  point: comment=(the_intfs[2].t==0 && the_intfs[3].t==1) => 1 hier=top.t
 %000004         if ((~t1 && t2) || (~t3 && t4)) $write("");
 -000002  point: comment=(t1==0 && t2==1) => 1 hier=top.t
 -000002  point: comment=(t1==1 && t3==1) => 0 hier=top.t
@@ -324,4 +338,8 @@
             end
         
         endmodule
+        
+        interface intf();
+            logic t;
+        endinterface
         

--- a/test_regress/t/t_cover_expr.v
+++ b/test_regress/t/t_cover_expr.v
@@ -37,10 +37,18 @@ module t (/*AUTOARG*/
         return a & b;
     endfunction
 
+    localparam int num_intfs = 4;
+    intf the_intfs [num_intfs-1:0] ();
+    genvar intf_i;
+    for (intf_i = 0; intf_i < num_intfs; intf_i++) begin
+        always_comb the_intfs[intf_i].t = cyc[intf_i];
+    end
+
     always @ (posedge clk) begin
         cyc <= cyc + 1;
         if ((~cyc[0] && cyc[1]) || (~cyc[2] && cyc[3])) $write("");
         if ((~cyc2[32] && cyc2[33]) || (~cyc2[34] && cyc2[35])) $write("");
+        if ((~the_intfs[0].t && the_intfs[1].t) || (~the_intfs[2].t && the_intfs[3].t)) $write("");
         if ((~t1 && t2) || (~t3 && t4)) $write("");
         if (t3 && (t1 == t2)) $write("");
         if (123 == (124 - 32'(t1 || t2))) $write("");
@@ -163,3 +171,7 @@ module sub (
     end
 
 endmodule
+
+interface intf();
+    logic t;
+endinterface

--- a/test_regress/t/t_cover_expr_max.out
+++ b/test_regress/t/t_cover_expr_max.out
@@ -43,6 +43,13 @@
 -000005  point: comment=(b==0) => 0 hier=top.t
             endfunction
         
+            localparam int num_intfs = 4;
+            intf the_intfs [num_intfs-1:0] ();
+            genvar intf_i;
+            for (intf_i = 0; intf_i < num_intfs; intf_i++) begin
+                always_comb the_intfs[intf_i].t = cyc[intf_i];
+            end
+        
             always @ (posedge clk) begin
                 cyc <= cyc + 1;
 %000004         if ((~cyc[0] && cyc[1]) || (~cyc[2] && cyc[3])) $write("");
@@ -59,6 +66,13 @@
 -000002  point: comment=(cyc2[33]==0 && cyc2[34]==1) => 0 hier=top.t
 -000003  point: comment=(cyc2[33]==0 && cyc2[35]==0) => 0 hier=top.t
 -000002  point: comment=(cyc2[34]==0 && cyc2[35]==1) => 1 hier=top.t
+%000004         if ((~the_intfs[0].t && the_intfs[1].t) || (~the_intfs[2].t && the_intfs[3].t)) $write("");
+-000002  point: comment=(the_intfs[0].t==0 && the_intfs[1].t==1) => 1 hier=top.t
+-000002  point: comment=(the_intfs[0].t==1 && the_intfs[2].t==1) => 0 hier=top.t
+-000004  point: comment=(the_intfs[0].t==1 && the_intfs[3].t==0) => 0 hier=top.t
+-000002  point: comment=(the_intfs[1].t==0 && the_intfs[2].t==1) => 0 hier=top.t
+-000003  point: comment=(the_intfs[1].t==0 && the_intfs[3].t==0) => 0 hier=top.t
+-000002  point: comment=(the_intfs[2].t==0 && the_intfs[3].t==1) => 1 hier=top.t
 %000004         if ((~t1 && t2) || (~t3 && t4)) $write("");
 -000002  point: comment=(t1==0 && t2==1) => 1 hier=top.t
 -000002  point: comment=(t1==1 && t3==1) => 0 hier=top.t
@@ -452,4 +466,8 @@
             end
         
         endmodule
+        
+        interface intf();
+            logic t;
+        endinterface
         

--- a/test_regress/t/t_cover_expr_trace.out
+++ b/test_regress/t/t_cover_expr_trace.out
@@ -43,6 +43,13 @@
 -000005  point: comment=(b==0) => 0 hier=top.t
             endfunction
         
+            localparam int num_intfs = 4;
+            intf the_intfs [num_intfs-1:0] ();
+            genvar intf_i;
+            for (intf_i = 0; intf_i < num_intfs; intf_i++) begin
+                always_comb the_intfs[intf_i].t = cyc[intf_i];
+            end
+        
             always @ (posedge clk) begin
                 cyc <= cyc + 1;
 %000004         if ((~cyc[0] && cyc[1]) || (~cyc[2] && cyc[3])) $write("");
@@ -59,6 +66,13 @@
 -000002  point: comment=(cyc2[33]==0 && cyc2[34]==1) => 0 hier=top.t
 -000003  point: comment=(cyc2[33]==0 && cyc2[35]==0) => 0 hier=top.t
 -000002  point: comment=(cyc2[34]==0 && cyc2[35]==1) => 1 hier=top.t
+%000004         if ((~the_intfs[0].t && the_intfs[1].t) || (~the_intfs[2].t && the_intfs[3].t)) $write("");
+-000002  point: comment=(the_intfs[0].t==0 && the_intfs[1].t==1) => 1 hier=top.t
+-000002  point: comment=(the_intfs[0].t==1 && the_intfs[2].t==1) => 0 hier=top.t
+-000004  point: comment=(the_intfs[0].t==1 && the_intfs[3].t==0) => 0 hier=top.t
+-000002  point: comment=(the_intfs[1].t==0 && the_intfs[2].t==1) => 0 hier=top.t
+-000003  point: comment=(the_intfs[1].t==0 && the_intfs[3].t==0) => 0 hier=top.t
+-000002  point: comment=(the_intfs[2].t==0 && the_intfs[3].t==1) => 1 hier=top.t
 %000004         if ((~t1 && t2) || (~t3 && t4)) $write("");
 -000002  point: comment=(t1==0 && t2==1) => 1 hier=top.t
 -000002  point: comment=(t1==1 && t3==1) => 0 hier=top.t
@@ -324,4 +338,8 @@
             end
         
         endmodule
+        
+        interface intf();
+            logic t;
+        endinterface
         


### PR DESCRIPTION
Only using `varp`s for expression equivalence for VarRefs and not VarXRefs now.  Doing so for both was causing expression coverage around arrays of interfaces to be wrong since it was seeing the same VAR for different instances of the interface.  VarXRefs now use V3EmitV strings to compare with each other.