### PR TITLE
Split up trigger computation and dump functions.

### DIFF
--- a/src/V3Sched.cpp
+++ b/src/V3Sched.cpp
@@ -789,6 +789,10 @@ const TriggerKit createTriggers(AstNetlist* netlistp, AstCFunc* const initFuncp,
     // The debug code might leak signal names, so simply delete it when using --protect-ids
     if (v3Global.opt.protectIds()) dumpp->stmtsp()->unlinkFrBackWithNext()->deleteTree();
 
+    // These might get large when we have a lot of triggers, so split if necessary
+    splitCheck(funcp);
+    splitCheck(dumpp);
+
     return {vscp, funcp, dumpp, map};
 }
 

--- a/test_regress/t/t_flag_csplit_groups.py
+++ b/test_regress/t/t_flag_csplit_groups.py
@@ -124,8 +124,8 @@ test.file_grep_not(test.obj_dir + "/" + test.vm_prefix + "_classes.mk", "vm_clas
 test.file_grep_not(test.obj_dir + "/" + test.vm_prefix + "_classes.mk", "vm_classes_2")
 
 # Check combine count
-test.file_grep(test.stats, r'Node count, CFILE + (\d+)', (174 if test.vltmt else 156))
-test.file_grep(test.stats, r'Makefile targets, VM_CLASSES_FAST + (\d+)', (2 if test.vltmt else 3))
+test.file_grep(test.stats, r'Node count, CFILE + (\d+)', (191 if test.vltmt else 173))
+test.file_grep(test.stats, r'Makefile targets, VM_CLASSES_FAST + (\d+)', 2)
 test.file_grep(test.stats, r'Makefile targets, VM_CLASSES_SLOW + (\d+)', 2)
 
 test.passes()


### PR DESCRIPTION
This fixes very long C++ compilation of large configurations of the Vortex GPU with GCC.
