### PR TITLE
Support Constrained Random for ArrayStruct (#5765)

### DIFF
--- a/include/verilated.cpp
+++ b/include/verilated.cpp
@@ -62,6 +62,7 @@
 #include <utility>
 
 #include <sys/stat.h>  // mkdir
+
 // clang-format off
 #if defined(_WIN32) || defined(__MINGW32__)
 # include <direct.h>  // mkdir

--- a/include/verilated.cpp
+++ b/include/verilated.cpp
@@ -62,7 +62,6 @@
 #include <utility>
 
 #include <sys/stat.h>  // mkdir
-
 // clang-format off
 #if defined(_WIN32) || defined(__MINGW32__)
 # include <direct.h>  // mkdir

--- a/include/verilated_random.h
+++ b/include/verilated_random.h
@@ -348,8 +348,8 @@ public:
         // Use the indices to access each member via std::get
         (void)std::initializer_list<int>{
             (write_var(std::get<I>(obj.getMembers(obj)),
-                       sizeof(std::get<I>(obj.getMembers(obj))) * 8,
-                       (baseName + "." + obj.memberNames()[I]).c_str(), 0),
+                       obj.memberWidth()[I],
+                       (baseName + "." + obj.memberNames()[I]).c_str(), 1),
              0)...};
     }
 

--- a/include/verilated_random.h
+++ b/include/verilated_random.h
@@ -347,8 +347,7 @@ public:
     void modifyMembers(T& obj, std::index_sequence<I...>, std::string baseName) {
         // Use the indices to access each member via std::get
         (void)std::initializer_list<int>{
-            (write_var(std::get<I>(obj.getMembers(obj)),
-                       obj.memberWidth()[I],
+            (write_var(std::get<I>(obj.getMembers(obj)), obj.memberWidth()[I],
                        (baseName + "." + obj.memberNames()[I]).c_str(), 1),
              0)...};
     }

--- a/include/verilated_random.h
+++ b/include/verilated_random.h
@@ -348,7 +348,7 @@ public:
         // Use the indices to access each member via std::get
         (void)std::initializer_list<int>{
             (write_var(std::get<I>(obj.getMembers(obj)), obj.memberWidth()[I],
-                       (baseName + "." + obj.memberNames()[I]).c_str(), 1),
+                       (baseName + "." + obj.memberNames()[I]).c_str(), obj.memberDimension()[I]),
              0)...};
     }
 

--- a/include/verilated_types.h
+++ b/include/verilated_types.h
@@ -954,6 +954,12 @@ public:
     VlAssocArray& operator=(VlAssocArray&&) = default;
     bool operator==(const VlAssocArray& rhs) const { return m_map == rhs.m_map; }
     bool operator!=(const VlAssocArray& rhs) const { return m_map != rhs.m_map; }
+    bool operator<(const VlAssocArray& rhs) const {
+        for (auto it = m_map.cbegin(), its = rhs.m_map.cbegin(); (it != m_map.end() || it != rhs.m_map.end()) ; ++it, ++its) {
+            if (it->second < its->second) return true;
+        }
+        return false;
+    }
 
     // METHODS
     T_Value& atDefault() { return m_defaultValue; }

--- a/include/verilated_types.h
+++ b/include/verilated_types.h
@@ -954,14 +954,7 @@ public:
     VlAssocArray& operator=(VlAssocArray&&) = default;
     bool operator==(const VlAssocArray& rhs) const { return m_map == rhs.m_map; }
     bool operator!=(const VlAssocArray& rhs) const { return m_map != rhs.m_map; }
-    bool operator<(const VlAssocArray& rhs) const {
-        for (auto it = m_map.cbegin(), its = rhs.m_map.cbegin();
-             (it != m_map.end() || it != rhs.m_map.end()); ++it, ++its) {
-            if (it->second < its->second) return true;
-        }
-        return false;
-    }
-
+    bool operator<(const VlAssocArray& rhs) const { return m_map < rhs.m_map; }
     // METHODS
     T_Value& atDefault() { return m_defaultValue; }
     const T_Value& atDefault() const { return m_defaultValue; }

--- a/include/verilated_types.h
+++ b/include/verilated_types.h
@@ -955,7 +955,8 @@ public:
     bool operator==(const VlAssocArray& rhs) const { return m_map == rhs.m_map; }
     bool operator!=(const VlAssocArray& rhs) const { return m_map != rhs.m_map; }
     bool operator<(const VlAssocArray& rhs) const {
-        for (auto it = m_map.cbegin(), its = rhs.m_map.cbegin(); (it != m_map.end() || it != rhs.m_map.end()) ; ++it, ++its) {
+        for (auto it = m_map.cbegin(), its = rhs.m_map.cbegin();
+             (it != m_map.end() || it != rhs.m_map.end()); ++it, ++its) {
             if (it->second < its->second) return true;
         }
         return false;

--- a/src/V3EmitCHeaders.cpp
+++ b/src/V3EmitCHeaders.cpp
@@ -269,17 +269,15 @@ class EmitCHeader final : public EmitCConstInit {
             for (const AstMemberDType* itemp = sdtypep->membersp(); itemp;
                  itemp = VN_AS(itemp->nextp(), MemberDType)) {
                 if (itemp->isConstrainedRand()
-                    && (VN_IS(itemp->dtypep(), UnpackArrayDType) || VN_IS(itemp->dtypep(), DynArrayDType) || VN_IS(itemp->dtypep(), QueueDType)
-                        || VN_IS(itemp->dtypep(), AssocArrayDType))){
-                    AstNodeDType * dtype = itemp->dtypep();
-                    while (dtype->isCompound())
-                    {
-                        dtype = dtype->subDTypep();
-                    }
+                    && (VN_IS(itemp->dtypep(), UnpackArrayDType)
+                        || VN_IS(itemp->dtypep(), DynArrayDType)
+                        || VN_IS(itemp->dtypep(), QueueDType)
+                        || VN_IS(itemp->dtypep(), AssocArrayDType))) {
+                    AstNodeDType* dtype = itemp->dtypep();
+                    while (dtype->isCompound()) { dtype = dtype->subDTypep(); }
                     putns(itemp, std::to_string(dtype->width()));
                     //putns(itemp, std::to_string(itemp->dtypep()->subDTypep()->width()));
-                }
-                else if (itemp->isConstrainedRand())
+                } else if (itemp->isConstrainedRand())
                     putns(itemp, std::to_string(itemp->width()));
 
                 if (itemp->nextp() && VN_AS(itemp->nextp(), MemberDType)->isConstrainedRand())
@@ -292,7 +290,9 @@ class EmitCHeader final : public EmitCConstInit {
             for (const AstMemberDType* itemp = sdtypep->membersp(); itemp;
                  itemp = VN_AS(itemp->nextp(), MemberDType)) {
                 if (itemp->isConstrainedRand()
-                    && (VN_IS(itemp->dtypep(), UnpackArrayDType) || VN_IS(itemp->dtypep(), DynArrayDType) || VN_IS(itemp->dtypep(), QueueDType)
+                    && (VN_IS(itemp->dtypep(), UnpackArrayDType)
+                        || VN_IS(itemp->dtypep(), DynArrayDType)
+                        || VN_IS(itemp->dtypep(), QueueDType)
                         || VN_IS(itemp->dtypep(), AssocArrayDType)))
                     putns(itemp, std::to_string(itemp->dtypep()->dimensions(true).second));
                 else if (itemp->isConstrainedRand())
@@ -302,7 +302,6 @@ class EmitCHeader final : public EmitCConstInit {
                     puts(",\n");
             }
             puts("};\n}\n");
-
 
             putns(sdtypep, "\nauto memberIndices(void) const {\n");
             puts("return std::index_sequence_for<");

--- a/src/V3EmitCHeaders.cpp
+++ b/src/V3EmitCHeaders.cpp
@@ -253,6 +253,7 @@ class EmitCHeader final : public EmitCConstInit {
         // - getMembers: Access member references
         // - memberIndices: Retrieve member indices
         // - memberWidth: Retrieve member width
+        // - memberDimension: Retrieve member dimension
         if (sdtypep->isConstrainedRand()) {
             putns(sdtypep, "\nstd::vector<std::string> memberNames(void) const {\n");
             puts("return {");
@@ -274,12 +275,12 @@ class EmitCHeader final : public EmitCConstInit {
                         || VN_IS(itemp->dtypep(), QueueDType)
                         || VN_IS(itemp->dtypep(), AssocArrayDType))) {
                     AstNodeDType* dtype = itemp->dtypep();
+                    // Traverse to the innermost sub-dtype to get the width
                     while (dtype->subDTypep()) { dtype = dtype->subDTypep(); }
                     putns(itemp, std::to_string(dtype->width()));
-                    //putns(itemp, std::to_string(itemp->dtypep()->subDTypep()->width()));
                 } else if (itemp->isConstrainedRand())
                     putns(itemp, std::to_string(itemp->width()));
-
+                // Add comma if there is a next constrained random member
                 if (itemp->nextp() && VN_AS(itemp->nextp(), MemberDType)->isConstrainedRand())
                     puts(",\n");
             }
@@ -297,7 +298,7 @@ class EmitCHeader final : public EmitCConstInit {
                     putns(itemp, std::to_string(itemp->dtypep()->dimensions(true).second));
                 else if (itemp->isConstrainedRand())
                     putns(itemp, std::to_string(0));
-
+                // Add comma if there is a next constrained random member
                 if (itemp->nextp() && VN_AS(itemp->nextp(), MemberDType)->isConstrainedRand())
                     puts(",\n");
             }

--- a/src/V3EmitCHeaders.cpp
+++ b/src/V3EmitCHeaders.cpp
@@ -274,9 +274,7 @@ class EmitCHeader final : public EmitCConstInit {
                         || VN_IS(itemp->dtypep(), QueueDType)
                         || VN_IS(itemp->dtypep(), AssocArrayDType))) {
                     AstNodeDType* dtype = itemp->dtypep();
-                    while (VN_IS(dtype, NodeArrayDType) && dtype->isCompound()) {
-                        dtype = dtype->subDTypep();
-                    }
+                    while (!VN_IS(dtype, RefDType) && dtype->isCompound()) { dtype = dtype->subDTypep(); }
                     putns(itemp, std::to_string(dtype->width()));
                     //putns(itemp, std::to_string(itemp->dtypep()->subDTypep()->width()));
                 } else if (itemp->isConstrainedRand())

--- a/src/V3EmitCHeaders.cpp
+++ b/src/V3EmitCHeaders.cpp
@@ -274,7 +274,9 @@ class EmitCHeader final : public EmitCConstInit {
                         || VN_IS(itemp->dtypep(), QueueDType)
                         || VN_IS(itemp->dtypep(), AssocArrayDType))) {
                     AstNodeDType* dtype = itemp->dtypep();
-                    while (VN_IS(dtype, NodeArrayDType) && dtype->isCompound()) { dtype = dtype->subDTypep(); }
+                    while (VN_IS(dtype, NodeArrayDType) && dtype->isCompound()) {
+                        dtype = dtype->subDTypep();
+                    }
                     putns(itemp, std::to_string(dtype->width()));
                     //putns(itemp, std::to_string(itemp->dtypep()->subDTypep()->width()));
                 } else if (itemp->isConstrainedRand())

--- a/src/V3EmitCHeaders.cpp
+++ b/src/V3EmitCHeaders.cpp
@@ -268,7 +268,9 @@ class EmitCHeader final : public EmitCConstInit {
             puts("return {");
             for (const AstMemberDType* itemp = sdtypep->membersp(); itemp;
                  itemp = VN_AS(itemp->nextp(), MemberDType)) {
-                if (itemp->isConstrainedRand()) putns(itemp, std::to_string(itemp->width()));
+                if(itemp->isConstrainedRand() && (VN_IS(itemp->dtypep(),DynArrayDType) || VN_IS(itemp->dtypep(),QueueDType) ||  VN_IS(itemp->dtypep(),AssocArrayDType))) putns(itemp, std::to_string(itemp->dtypep()->subDTypep()->width()));
+                else if (itemp->isConstrainedRand()) putns(itemp, std::to_string(itemp->width()));
+
                 if (itemp->nextp() && VN_AS(itemp->nextp(), MemberDType)->isConstrainedRand())
                     puts(",\n");
             }

--- a/src/V3EmitCHeaders.cpp
+++ b/src/V3EmitCHeaders.cpp
@@ -268,8 +268,12 @@ class EmitCHeader final : public EmitCConstInit {
             puts("return {");
             for (const AstMemberDType* itemp = sdtypep->membersp(); itemp;
                  itemp = VN_AS(itemp->nextp(), MemberDType)) {
-                if(itemp->isConstrainedRand() && (VN_IS(itemp->dtypep(),DynArrayDType) || VN_IS(itemp->dtypep(),QueueDType) ||  VN_IS(itemp->dtypep(),AssocArrayDType))) putns(itemp, std::to_string(itemp->dtypep()->subDTypep()->width()));
-                else if (itemp->isConstrainedRand()) putns(itemp, std::to_string(itemp->width()));
+                if (itemp->isConstrainedRand()
+                    && (VN_IS(itemp->dtypep(), DynArrayDType) || VN_IS(itemp->dtypep(), QueueDType)
+                        || VN_IS(itemp->dtypep(), AssocArrayDType)))
+                    putns(itemp, std::to_string(itemp->dtypep()->subDTypep()->width()));
+                else if (itemp->isConstrainedRand())
+                    putns(itemp, std::to_string(itemp->width()));
 
                 if (itemp->nextp() && VN_AS(itemp->nextp(), MemberDType)->isConstrainedRand())
                     puts(",\n");

--- a/src/V3EmitCHeaders.cpp
+++ b/src/V3EmitCHeaders.cpp
@@ -274,7 +274,9 @@ class EmitCHeader final : public EmitCConstInit {
                         || VN_IS(itemp->dtypep(), QueueDType)
                         || VN_IS(itemp->dtypep(), AssocArrayDType))) {
                     AstNodeDType* dtype = itemp->dtypep();
-                    while (!VN_IS(dtype, RefDType) && dtype->isCompound()) { dtype = dtype->subDTypep(); }
+                    while (!VN_IS(dtype, RefDType) && dtype->isCompound()) {
+                        dtype = dtype->subDTypep();
+                    }
                     putns(itemp, std::to_string(dtype->width()));
                     //putns(itemp, std::to_string(itemp->dtypep()->subDTypep()->width()));
                 } else if (itemp->isConstrainedRand())

--- a/src/V3EmitCHeaders.cpp
+++ b/src/V3EmitCHeaders.cpp
@@ -274,9 +274,7 @@ class EmitCHeader final : public EmitCConstInit {
                         || VN_IS(itemp->dtypep(), QueueDType)
                         || VN_IS(itemp->dtypep(), AssocArrayDType))) {
                     AstNodeDType* dtype = itemp->dtypep();
-                    while (!VN_IS(dtype, RefDType) && dtype->isCompound()) {
-                        dtype = dtype->subDTypep();
-                    }
+                    while (dtype->subDTypep()) { dtype = dtype->subDTypep(); }
                     putns(itemp, std::to_string(dtype->width()));
                     //putns(itemp, std::to_string(itemp->dtypep()->subDTypep()->width()));
                 } else if (itemp->isConstrainedRand())

--- a/src/V3EmitCHeaders.cpp
+++ b/src/V3EmitCHeaders.cpp
@@ -274,7 +274,7 @@ class EmitCHeader final : public EmitCConstInit {
                         || VN_IS(itemp->dtypep(), QueueDType)
                         || VN_IS(itemp->dtypep(), AssocArrayDType))) {
                     AstNodeDType* dtype = itemp->dtypep();
-                    while (dtype->isCompound()) { dtype = dtype->subDTypep(); }
+                    while (VN_IS(dtype, NodeArrayDType) && dtype->isCompound()) { dtype = dtype->subDTypep(); }
                     putns(itemp, std::to_string(dtype->width()));
                     //putns(itemp, std::to_string(itemp->dtypep()->subDTypep()->width()));
                 } else if (itemp->isConstrainedRand())

--- a/src/V3EmitCHeaders.cpp
+++ b/src/V3EmitCHeaders.cpp
@@ -243,10 +243,9 @@ class EmitCHeader final : public EmitCConstInit {
     enum class AttributeType { Width, Dimension };
     // Get member attribute based on type
     int getNodeAttribute(const AstMemberDType* itemp, AttributeType type) {
-        const bool isArrayType = VN_IS(itemp->dtypep(), UnpackArrayDType)
-                            || VN_IS(itemp->dtypep(), DynArrayDType)
-                            || VN_IS(itemp->dtypep(), QueueDType)
-                            || VN_IS(itemp->dtypep(), AssocArrayDType);
+        const bool isArrayType
+            = VN_IS(itemp->dtypep(), UnpackArrayDType) || VN_IS(itemp->dtypep(), DynArrayDType)
+              || VN_IS(itemp->dtypep(), QueueDType) || VN_IS(itemp->dtypep(), AssocArrayDType);
         switch (type) {
         case AttributeType::Width: {
             if (isArrayType) {
@@ -272,7 +271,7 @@ class EmitCHeader final : public EmitCConstInit {
         puts("return {");
         bool needComma = false;
         for (const AstMemberDType* itemp = sdtypep->membersp(); itemp;
-            itemp = VN_AS(itemp->nextp(), MemberDType)) {
+             itemp = VN_AS(itemp->nextp(), MemberDType)) {
             if (!itemp->isConstrainedRand()) continue;
             // Comma handling: add before element except first
             if (needComma) puts(",\n");

--- a/src/V3EmitCHeaders.cpp
+++ b/src/V3EmitCHeaders.cpp
@@ -252,12 +252,23 @@ class EmitCHeader final : public EmitCConstInit {
         // - memberNames: Get member names
         // - getMembers: Access member references
         // - memberIndices: Retrieve member indices
+        // - memberWidth: Retrieve member width
         if (sdtypep->isConstrainedRand()) {
             putns(sdtypep, "\nstd::vector<std::string> memberNames(void) const {\n");
             puts("return {");
             for (const AstMemberDType* itemp = sdtypep->membersp(); itemp;
                  itemp = VN_AS(itemp->nextp(), MemberDType)) {
                 if (itemp->isConstrainedRand()) putns(itemp, "\"" + itemp->shortName() + "\"");
+                if (itemp->nextp() && VN_AS(itemp->nextp(), MemberDType)->isConstrainedRand())
+                    puts(",\n");
+            }
+            puts("};\n}\n");
+
+            putns(sdtypep, "\nstd::vector<int> memberWidth(void) const {\n");
+            puts("return {");
+            for (const AstMemberDType* itemp = sdtypep->membersp(); itemp;
+                 itemp = VN_AS(itemp->nextp(), MemberDType)) {
+                if (itemp->isConstrainedRand()) putns(itemp, std::to_string(itemp->width()));
                 if (itemp->nextp() && VN_AS(itemp->nextp(), MemberDType)->isConstrainedRand())
                     puts(",\n");
             }

--- a/src/V3EmitCHeaders.cpp
+++ b/src/V3EmitCHeaders.cpp
@@ -261,7 +261,6 @@ class EmitCHeader final : public EmitCConstInit {
             return isArrayType ? itemp->dtypep()->dimensions(true).second : 0;
         }
         default: {
-            v3error("Unknown attribute type");
             return 0;
         }
         }

--- a/src/V3Randomize.cpp
+++ b/src/V3Randomize.cpp
@@ -713,9 +713,12 @@ class ConstraintExprVisitor final : public VNVisitor {
     }
     void visit(AstStructSel* nodep) override {
         if (VN_IS(nodep->fromp()->dtypep()->skipRefp(), StructDType)) {
-            AstMemberDType* memberp
-                = VN_AS(nodep->fromp()->dtypep()->skipRefp(), StructDType)->membersp();
-            while (memberp->nextp()) {
+            AstNodeExpr* const fromp = nodep->fromp();
+            if (VN_IS(fromp, StructSel)) {
+                VN_AS(fromp->dtypep()->skipRefp(), StructDType)->markConstrainedRand(true);
+            }
+            AstMemberDType* memberp = VN_AS(fromp->dtypep()->skipRefp(), StructDType)->membersp();
+            while (memberp) {
                 if (memberp->name() == nodep->name()) {
                     memberp->markConstrainedRand(true);
                     break;

--- a/test_regress/t/t_constraint_struct_complex.py
+++ b/test_regress/t/t_constraint_struct_complex.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2025 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+if not test.have_solver:
+    test.skip("No constraint solver installed")
+
+test.compile()
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_constraint_struct_complex.v
+++ b/test_regress/t/t_constraint_struct_complex.v
@@ -7,7 +7,11 @@
 class ArrayStruct;
     /* verilator lint_off SIDEEFFECT */
     // Struct with an unpacked array
+    typedef int arr_3_t[3];
+    typedef int arr_4_t[4];
     typedef struct {
+        rand arr_3_t arr_3;
+        arr_4_t arr_4;
         rand int arr[3];
     } unpacked_struct_t;
 
@@ -43,7 +47,10 @@ class ArrayStruct;
     rand multi_dim_struct_t s5;
     rand mixed_struct_t s6;
 
-    constraint c_unpacked { foreach (s1.arr[i]) s1.arr[i] inside {1, 2, 3, 4}; }
+    constraint c_unpacked { 
+        foreach (s1.arr[i]) s1.arr[i] inside {1, 2, 3, 4};
+        foreach (s1.arr_3[i]) s1.arr_3[i] inside {11, 22, 33, 44, 55};     
+    }
     constraint c_dynamic { foreach (s2.arr[i]) s2.arr[i] inside {[10:20]}; }
     constraint c_queue { foreach (s3.arr[i]) s3.arr[i] inside {[100:200]}; }
     constraint c_assoc {
@@ -58,6 +65,8 @@ class ArrayStruct;
 
     function new();
         s1.arr = '{1, 2, 3};
+        s1.arr_3 = '{1, 2, 3};
+        s1.arr_4 = '{0, 2, 3, 4};
         s2.arr = new[3];
         foreach(s2.arr[i]) begin
             s2.arr[i] = 'h0 + i;
@@ -76,6 +85,8 @@ class ArrayStruct;
 
     function void print();
         foreach (s1.arr[i]) $display("s1.arr[%0d] = %0d", i, s1.arr[i]);
+        foreach (s1.arr_3[i]) $display("s1.arr_3[%0d] = %0d", i, s1.arr_3[i]);
+        foreach (s1.arr_4[i]) $display("s1.arr_4[%0d] = %0d", i, s1.arr_4[i]);
         foreach (s2.arr[i]) $display("s2.arr[%0d] = %0d", i, s2.arr[i]);
         foreach (s3.arr[i]) $display("s3.arr[%0d] = %0d", i, s3.arr[i]);
         foreach (s4.arr[i]) $display("s4.arr[\"%s\"] = %0d", i, s4.arr[i]);
@@ -86,6 +97,9 @@ class ArrayStruct;
     // Self-test function to verify constraints
     function void self_test();
         foreach (s1.arr[i]) if (!(s1.arr[i] inside {1, 2, 3, 4})) $stop;
+        foreach (s1.arr_3[i]) if (!(s1.arr_3[i] inside {11, 22, 33, 44, 55})) $stop;
+        // Note: s1.arr_4[0] is not rand
+        if ((s1.arr_4[0] != 0) || (s1.arr_4[1] != 2) || (s1.arr_4[2] != 3) || (s1.arr_4[3] != 4)) $stop;
         foreach (s2.arr[i]) if (!(s2.arr[i] inside {[10:20]})) $stop;
         foreach (s3.arr[i]) if (!(s3.arr[i] inside {[100:200]})) $stop;
         if (!(s4.arr["one"] inside {[10:50]})) $stop;

--- a/test_regress/t/t_constraint_struct_complex.v
+++ b/test_regress/t/t_constraint_struct_complex.v
@@ -151,7 +151,7 @@ class StructConstraintClass;
     function new();
         s1.arr = '{1, 2, 3};
         s2.arr = new[3];
-        //s2.arr = '{default:0};
+        s2.arr = '{default:0};
         s3.arr.push_back(100);
         s3.arr.push_back(200);
         s3.arr.push_back(300);

--- a/test_regress/t/t_constraint_struct_complex.v
+++ b/test_regress/t/t_constraint_struct_complex.v
@@ -1,0 +1,221 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2025 by PlanV GmbH.
+// SPDX-License-Identifier: CC0-1.0
+
+/*
+// For pull request: Struct containing all array types
+typedef struct {
+    int unpacked_arr[3];     // Unpacked array
+    int dynamic_arr[];       // Dynamic array
+    int queue_arr[$];        // Queue
+    int assoc_arr[string];   // Associative array (string index)
+    int multi_dim_arr[2][3]; // Multi-dimensional array
+    int mix_arr[3][];        // Mixed array (unpacked + dynamic)
+} big_struct_t;
+
+// For pull request: Randomized class for big_struct_t with self-test
+class BigStructClass;
+    rand big_struct_t big;
+
+    // Constraints for all array types
+    constraint c_unpacked { foreach (big.unpacked_arr[i]) big.unpacked_arr[i] inside {1, 2, 3, 4}; }
+    constraint c_dynamic { big.dynamic_arr.size() == 3; foreach (big.dynamic_arr[i]) big.dynamic_arr[i] inside {[10:20]}; }
+    constraint c_queue { big.queue_arr.size() inside {[2:5]}; foreach (big.queue_arr[i]) big.queue_arr[i] inside {[100:200]}; }
+    constraint c_assoc {
+        big.assoc_arr.num() == 3;
+        big.assoc_arr.exists("one"); big.assoc_arr["one"] inside {[10:50]};
+        big.assoc_arr.exists("two"); big.assoc_arr["two"] inside {[51:100]};
+        big.assoc_arr.exists("three"); big.assoc_arr["three"] inside {[101:150]};
+    }
+    constraint c_multi_dim { foreach (big.multi_dim_arr[i, j]) big.multi_dim_arr[i][j] inside {[0:9]}; }
+    constraint c_mix {
+        foreach (big.mix_arr[i]) big.mix_arr[i].size() inside {[1:4]};
+        foreach (big.mix_arr[i, j]) big.mix_arr[i][j] inside {[50:100]};
+    }
+
+    // Self-test function to verify constraints
+    function void self_test();
+        foreach (big.unpacked_arr[i]) if (!(big.unpacked_arr[i] inside {1, 2, 3, 4})) 
+            $stop;
+        if (big.dynamic_arr.size() != 3) 
+            $stop;
+        foreach (big.dynamic_arr[i]) if (!(big.dynamic_arr[i] inside {[10:20]})) 
+            $stop;
+        if (!(big.queue_arr.size() inside {[2:5]})) 
+            $stop;
+        foreach (big.queue_arr[i]) if (!(big.queue_arr[i] inside {[100:200]})) 
+            $stop;
+        if (big.assoc_arr.num() != 3) 
+            $stop;
+        if (!big.assoc_arr.exists("one") || !(big.assoc_arr["one"] inside {[10:50]})) 
+            $stop;
+        if (!big.assoc_arr.exists("two") || !(big.assoc_arr["two"] inside {[51:100]})) 
+            $stop;
+        if (!big.assoc_arr.exists("three") || !(big.assoc_arr["three"] inside {[101:150]})) 
+            $stop;
+        foreach (big.multi_dim_arr[i, j]) if (!(big.multi_dim_arr[i][j] inside {[0:9]})) 
+            $stop;
+        foreach (big.mix_arr[i]) if (!(big.mix_arr[i].size() inside {[1:4]})) 
+            $stop;
+        foreach (big.mix_arr[i, j]) if (!(big.mix_arr[i][j] inside {[50:100]})) 
+            $stop;
+    endfunction
+endclass
+
+module t_constraint_struct_complex;
+    initial begin
+    BigStructClass big_struct_inst = new();
+
+    repeat (5) begin // Run multiple randomizations
+        if (!big_struct_inst.randomize()) 
+        $stop;  // Stop if randomization fails
+
+        $display("\n===== Randomized Test =====");
+        $display("Unpacked Array: %p", big_struct_inst.big.unpacked_arr);
+        $display("Dynamic Array: %p", big_struct_inst.big.dynamic_arr);
+        $display("Queue: %p", big_struct_inst.big.queue_arr);
+        $display("Associative Array: %p", big_struct_inst.big.assoc_arr);
+        $display("Multi-Dimensional Array: %p", big_struct_inst.big.multi_dim_arr);
+        $display("Mixed Array:");
+        foreach (big_struct_inst.big.mix_arr[i]) 
+        $display("  mix_arr[%0d] = %p", i, big_struct_inst.big.mix_arr[i]);
+
+        // Perform self-test
+        big_struct_inst.self_test();
+    end
+
+    $finish;
+    end
+endmodule
+
+*/
+
+// =========================
+// For Debugging: t_constraint_struct_complex
+
+
+class StructConstraintClass;
+    /* verilator lint_off SIDEEFFECT */
+    // Struct with an unpacked array
+    typedef struct {
+        rand int arr[3];
+    } unpacked_struct_t;
+
+    // Struct with a dynamic array
+    typedef struct {
+        rand int arr[];
+    } dynamic_struct_t;
+
+    // Struct with a queue
+    typedef struct {
+        rand int arr[$];
+    } queue_struct_t;
+
+    // Struct with an associative array (string as index)
+    typedef struct {
+        rand int arr[string];
+    } associative_struct_t;
+
+    // Struct with a multi-dimensional array
+    typedef struct {
+        rand int arr[2][3];
+    } multi_dim_struct_t;
+
+    // Struct with a mix of dynamic and unpacked arrays
+    typedef struct {
+        rand int mix_arr[3][];
+    } mixed_struct_t;
+
+    rand unpacked_struct_t s1;
+    rand dynamic_struct_t s2;
+    rand queue_struct_t s3;
+    rand associative_struct_t s4;
+    rand multi_dim_struct_t s5;
+    rand mixed_struct_t s6;
+
+    constraint c_unpacked { foreach (s1.arr[i]) s1.arr[i] inside {1, 2, 3, 4}; }
+    constraint c_dynamic { foreach (s2.arr[i]) s2.arr[i] inside {[10:20]}; }
+    constraint c_queue { foreach (s3.arr[i]) s3.arr[i] inside {[100:200]}; }
+    constraint c_assoc {
+        s4.arr["one"] inside {[10:50]};
+        s4.arr["two"] inside {[51:100]};
+        s4.arr["three"] inside {[101:150]};
+    }
+    constraint c_multi_dim { foreach (s5.arr[i, j]) s5.arr[i][j] inside {[0:9]}; }
+    constraint c_mix {
+        foreach (s6.mix_arr[i, j]) s6.mix_arr[i][j] inside {[50:100]};
+    }
+
+    function new();
+        s1.arr = '{1, 2, 3};
+        s2.arr = new[3];
+        s2.arr = '{default:0};
+        s3.arr.push_back(100);
+        s3.arr.push_back(200);
+        s3.arr.push_back(300);
+        s4.arr["one"] = 1000;
+        s4.arr["two"] = 2000;
+        s4.arr["three"] = 3000;
+        s5.arr = '{ '{default:0}, '{default:0} };
+        foreach (s6.mix_arr[i]) begin
+            s6.mix_arr[i] = new[i + 1];
+        end
+    endfunction
+
+    // Self-test function to verify constraints
+    function void self_test();
+        foreach (s1.arr[i]) if (!(s1.arr[i] inside {1, 2, 3, 4})) begin
+            $display("Error: s1.arr[%0d] = %0d is out of range", i, s1.arr[i]);
+            $stop;
+        end
+        foreach (s2.arr[i]) if (!(s2.arr[i] inside {[10:20]})) begin
+            $display("Error: s2.arr[%0d] = %0d is out of range", i, s2.arr[i]);
+            $stop;
+        end
+        foreach (s3.arr[i]) if (!(s3.arr[i] inside {[100:200]})) begin
+            $display("Error: s3.arr[%0d] = %0d is out of range", i, s3.arr[i]);
+            $stop;
+        end
+        if (!(s4.arr["one"] inside {[10:50]})) begin
+            $display("Error: s4.arr[\"one\"] = %0d is out of range", s4.arr["one"]);
+            $stop;
+        end
+        if (!(s4.arr["two"] inside {[51:100]})) begin
+            $display("Error: s4.arr[\"two\"] = %0d is out of range", s4.arr["two"]);
+            $stop;
+        end
+        if (!(s4.arr["three"] inside {[101:150]})) begin
+            $display("Error: s4.arr[\"three\"] = %0d is out of range", s4.arr["three"]);
+            $stop;
+        end
+        foreach (s5.arr[i, j]) if (!(s5.arr[i][j] inside {[0:9]})) begin
+            $display("Error: s5.arr[%0d][%0d] = %0d is out of range", i, j, s5.arr[i][j]);
+            $stop;
+        end
+        foreach (s6.mix_arr[i]) if (s6.mix_arr[i].size() == 0) begin
+            $display("Error: s6.mix_arr[%0d] is empty", i);
+            $stop;
+        end
+        foreach (s6.mix_arr[i, j]) if (!(s6.mix_arr[i][j] inside {[50:100]})) begin
+            $display("Error: s6.mix_arr[%0d][%0d] = %0d is out of range", i, j, s6.mix_arr[i][j]);
+            $stop;
+        end
+    endfunction
+    /* verilator lint_off SIDEEFFECT */
+endclass
+
+module t_constraint_struct_complex;
+    int success;
+    StructConstraintClass scc;
+    initial begin
+        scc = new();
+        success = scc.randomize();
+        if (success != 1) $stop;
+        scc.self_test();
+        $write("*-* All Finished *-*\n");
+        $finish;
+    end
+
+endmodule

--- a/test_regress/t/t_constraint_struct_complex.v
+++ b/test_regress/t/t_constraint_struct_complex.v
@@ -47,9 +47,9 @@ class ArrayStruct;
     rand multi_dim_struct_t s5;
     rand mixed_struct_t s6;
 
-    constraint c_unpacked { 
+    constraint c_unpacked {
         foreach (s1.arr[i]) s1.arr[i] inside {1, 2, 3, 4};
-        foreach (s1.arr_3[i]) s1.arr_3[i] inside {11, 22, 33, 44, 55};     
+        foreach (s1.arr_3[i]) s1.arr_3[i] inside {11, 22, 33, 44, 55};
     }
     constraint c_dynamic { foreach (s2.arr[i]) s2.arr[i] inside {[10:20]}; }
     constraint c_queue { foreach (s3.arr[i]) s3.arr[i] inside {[100:200]}; }

--- a/test_regress/t/t_constraint_struct_complex.v
+++ b/test_regress/t/t_constraint_struct_complex.v
@@ -4,99 +4,7 @@
 // any use, without warranty, 2025 by PlanV GmbH.
 // SPDX-License-Identifier: CC0-1.0
 
-/*
-// For pull request: Struct containing all array types
-typedef struct {
-    int unpacked_arr[3];     // Unpacked array
-    int dynamic_arr[];       // Dynamic array
-    int queue_arr[$];        // Queue
-    int assoc_arr[string];   // Associative array (string index)
-    int multi_dim_arr[2][3]; // Multi-dimensional array
-    int mix_arr[3][];        // Mixed array (unpacked + dynamic)
-} big_struct_t;
-
-// For pull request: Randomized class for big_struct_t with self-test
-class BigStructClass;
-    rand big_struct_t big;
-
-    // Constraints for all array types
-    constraint c_unpacked { foreach (big.unpacked_arr[i]) big.unpacked_arr[i] inside {1, 2, 3, 4}; }
-    constraint c_dynamic { big.dynamic_arr.size() == 3; foreach (big.dynamic_arr[i]) big.dynamic_arr[i] inside {[10:20]}; }
-    constraint c_queue { big.queue_arr.size() inside {[2:5]}; foreach (big.queue_arr[i]) big.queue_arr[i] inside {[100:200]}; }
-    constraint c_assoc {
-        big.assoc_arr.num() == 3;
-        big.assoc_arr.exists("one"); big.assoc_arr["one"] inside {[10:50]};
-        big.assoc_arr.exists("two"); big.assoc_arr["two"] inside {[51:100]};
-        big.assoc_arr.exists("three"); big.assoc_arr["three"] inside {[101:150]};
-    }
-    constraint c_multi_dim { foreach (big.multi_dim_arr[i, j]) big.multi_dim_arr[i][j] inside {[0:9]}; }
-    constraint c_mix {
-        foreach (big.mix_arr[i]) big.mix_arr[i].size() inside {[1:4]};
-        foreach (big.mix_arr[i, j]) big.mix_arr[i][j] inside {[50:100]};
-    }
-
-    // Self-test function to verify constraints
-    function void self_test();
-        foreach (big.unpacked_arr[i]) if (!(big.unpacked_arr[i] inside {1, 2, 3, 4}))
-            $stop;
-        if (big.dynamic_arr.size() != 3)
-            $stop;
-        foreach (big.dynamic_arr[i]) if (!(big.dynamic_arr[i] inside {[10:20]}))
-            $stop;
-        if (!(big.queue_arr.size() inside {[2:5]}))
-            $stop;
-        foreach (big.queue_arr[i]) if (!(big.queue_arr[i] inside {[100:200]}))
-            $stop;
-        if (big.assoc_arr.num() != 3)
-            $stop
-        if (!big.assoc_arr.exists("one") || !(big.assoc_arr["one"] inside {[10:50]}))
-            $stop;
-        if (!big.assoc_arr.exists("two") || !(big.assoc_arr["two"] inside {[51:100]}))
-            $stop;
-        if (!big.assoc_arr.exists("three") || !(big.assoc_arr["three"] inside {[101:150]}))
-            $stop;
-        foreach (big.multi_dim_arr[i, j]) if (!(big.multi_dim_arr[i][j] inside {[0:9]}))
-            $stop;
-        foreach (big.mix_arr[i]) if (!(big.mix_arr[i].size() inside {[1:4]}))
-            $stop;
-        foreach (big.mix_arr[i, j]) if (!(big.mix_arr[i][j] inside {[50:100]}))
-            $stop;
-    endfunction
-endclass
-
-module t_constraint_struct_complex;
-    initial begin
-    BigStructClass big_struct_inst = new();
-
-    repeat (5) begin // Run multiple randomizations
-        if (!big_struct_inst.randomize())
-        $stop;  // Stop if randomization fails
-
-        $display("\n===== Randomized Test =====");
-        $display("Unpacked Array: %p", big_struct_inst.big.unpacked_arr);
-        $display("Dynamic Array: %p", big_struct_inst.big.dynamic_arr);
-        $display("Queue: %p", big_struct_inst.big.queue_arr);
-        $display("Associative Array: %p", big_struct_inst.big.assoc_arr);
-        $display("Multi-Dimensional Array: %p", big_struct_inst.big.multi_dim_arr);
-        $display("Mixed Array:");
-        foreach (big_struct_inst.big.mix_arr[i])
-        $display("  mix_arr[%0d] = %p", i, big_struct_inst.big.mix_arr[i]);
-
-        // Perform self-test
-        big_struct_inst.self_test();
-    end
-
-    $finish;
-    end
-endmodule
-
-*/
-
-// =========================
-// For Debugging: t_constraint_struct_complex
-
-
-class StructConstraintClass;
+class ArrayStruct;
     /* verilator lint_off SIDEEFFECT */
     // Struct with an unpacked array
     typedef struct {
@@ -151,7 +59,9 @@ class StructConstraintClass;
     function new();
         s1.arr = '{1, 2, 3};
         s2.arr = new[3];
-        s2.arr = '{default:0};
+        foreach(s2.arr[i]) begin
+            s2.arr[i] = 'h0 + i;
+        end
         s3.arr.push_back(100);
         s3.arr.push_back(200);
         s3.arr.push_back(300);
@@ -164,56 +74,39 @@ class StructConstraintClass;
         end
     endfunction
 
+    function void print();
+        foreach (s1.arr[i]) $display("s1.arr[%0d] = %0d", i, s1.arr[i]);
+        foreach (s2.arr[i]) $display("s2.arr[%0d] = %0d", i, s2.arr[i]);
+        foreach (s3.arr[i]) $display("s3.arr[%0d] = %0d", i, s3.arr[i]);
+        foreach (s4.arr[i]) $display("s4.arr[\"%s\"] = %0d", i, s4.arr[i]);
+        foreach (s5.arr[i, j]) $display("s5.arr[%0d][%0d] = %0d", i, j, s5.arr[i][j]);
+        foreach (s6.mix_arr[i, j]) $display("s6.mix_arr[%0d][%0d] = %0d", i, j, s6.mix_arr[i][j]);
+    endfunction
+
     // Self-test function to verify constraints
     function void self_test();
-        foreach (s1.arr[i]) if (!(s1.arr[i] inside {1, 2, 3, 4})) begin
-            $display("Error: s1.arr[%0d] = %0d is out of range", i, s1.arr[i]);
-            $stop;
-        end
-        foreach (s2.arr[i]) if (!(s2.arr[i] inside {[10:20]})) begin
-            $display("Error: s2.arr[%0d] = %0d is out of range", i, s2.arr[i]);
-            $stop;
-        end
-        foreach (s3.arr[i]) if (!(s3.arr[i] inside {[100:200]})) begin
-            $display("Error: s3.arr[%0d] = %0d is out of range", i, s3.arr[i]);
-            $stop;
-        end
-        if (!(s4.arr["one"] inside {[10:50]})) begin
-            $display("Error: s4.arr[\"one\"] = %0d is out of range", s4.arr["one"]);
-            $stop;
-        end
-        if (!(s4.arr["two"] inside {[51:100]})) begin
-            $display("Error: s4.arr[\"two\"] = %0d is out of range", s4.arr["two"]);
-            $stop;
-        end
-        if (!(s4.arr["three"] inside {[101:150]})) begin
-            $display("Error: s4.arr[\"three\"] = %0d is out of range", s4.arr["three"]);
-            $stop;
-        end
-        foreach (s5.arr[i, j]) if (!(s5.arr[i][j] inside {[0:9]})) begin
-            $display("Error: s5.arr[%0d][%0d] = %0d is out of range", i, j, s5.arr[i][j]);
-            $stop;
-        end
-        foreach (s6.mix_arr[i]) if (s6.mix_arr[i].size() == 0) begin
-            $display("Error: s6.mix_arr[%0d] is empty", i);
-            $stop;
-        end
-        foreach (s6.mix_arr[i, j]) if (!(s6.mix_arr[i][j] inside {[50:100]})) begin
-            $display("Error: s6.mix_arr[%0d][%0d] = %0d is out of range", i, j, s6.mix_arr[i][j]);
-            $stop;
-        end
+        foreach (s1.arr[i]) if (!(s1.arr[i] inside {1, 2, 3, 4})) $stop;
+        foreach (s2.arr[i]) if (!(s2.arr[i] inside {[10:20]})) $stop;
+        foreach (s3.arr[i]) if (!(s3.arr[i] inside {[100:200]})) $stop;
+        if (!(s4.arr["one"] inside {[10:50]})) $stop;
+        if (!(s4.arr["two"] inside {[51:100]})) $stop;
+        if (!(s4.arr["three"] inside {[101:150]})) $stop;
+        foreach (s5.arr[i, j]) if (!(s5.arr[i][j] inside {[0:9]})) $stop;
+        foreach (s6.mix_arr[i]) if (s6.mix_arr[i].size() == 0) $stop;
+        foreach (s6.mix_arr[i, j]) if (!(s6.mix_arr[i][j] inside {[50:100]})) $stop;
     endfunction
     /* verilator lint_off SIDEEFFECT */
 endclass
 
 module t_constraint_struct_complex;
     int success;
-    StructConstraintClass scc;
+    ArrayStruct asc;
     initial begin
-        scc = new();
-        success = scc.randomize();
+        asc = new();
+        success = asc.randomize();
         if (success != 1) $stop;
-        scc.self_test();
+        asc.self_test();
+        // asc.print();
         $write("*-* All Finished *-*\n");
         $finish;
     end

--- a/test_regress/t/t_constraint_struct_complex.v
+++ b/test_regress/t/t_constraint_struct_complex.v
@@ -151,7 +151,7 @@ class StructConstraintClass;
     function new();
         s1.arr = '{1, 2, 3};
         s2.arr = new[3];
-        s2.arr = '{default:0};
+        //s2.arr = '{default:0};
         s3.arr.push_back(100);
         s3.arr.push_back(200);
         s3.arr.push_back(300);

--- a/test_regress/t/t_constraint_struct_complex.v
+++ b/test_regress/t/t_constraint_struct_complex.v
@@ -37,29 +37,29 @@ class BigStructClass;
 
     // Self-test function to verify constraints
     function void self_test();
-        foreach (big.unpacked_arr[i]) if (!(big.unpacked_arr[i] inside {1, 2, 3, 4})) 
+        foreach (big.unpacked_arr[i]) if (!(big.unpacked_arr[i] inside {1, 2, 3, 4}))
             $stop;
-        if (big.dynamic_arr.size() != 3) 
+        if (big.dynamic_arr.size() != 3)
             $stop;
-        foreach (big.dynamic_arr[i]) if (!(big.dynamic_arr[i] inside {[10:20]})) 
+        foreach (big.dynamic_arr[i]) if (!(big.dynamic_arr[i] inside {[10:20]}))
             $stop;
-        if (!(big.queue_arr.size() inside {[2:5]})) 
+        if (!(big.queue_arr.size() inside {[2:5]}))
             $stop;
-        foreach (big.queue_arr[i]) if (!(big.queue_arr[i] inside {[100:200]})) 
+        foreach (big.queue_arr[i]) if (!(big.queue_arr[i] inside {[100:200]}))
             $stop;
-        if (big.assoc_arr.num() != 3) 
+        if (big.assoc_arr.num() != 3)
+            $stop
+        if (!big.assoc_arr.exists("one") || !(big.assoc_arr["one"] inside {[10:50]}))
             $stop;
-        if (!big.assoc_arr.exists("one") || !(big.assoc_arr["one"] inside {[10:50]})) 
+        if (!big.assoc_arr.exists("two") || !(big.assoc_arr["two"] inside {[51:100]}))
             $stop;
-        if (!big.assoc_arr.exists("two") || !(big.assoc_arr["two"] inside {[51:100]})) 
+        if (!big.assoc_arr.exists("three") || !(big.assoc_arr["three"] inside {[101:150]}))
             $stop;
-        if (!big.assoc_arr.exists("three") || !(big.assoc_arr["three"] inside {[101:150]})) 
+        foreach (big.multi_dim_arr[i, j]) if (!(big.multi_dim_arr[i][j] inside {[0:9]}))
             $stop;
-        foreach (big.multi_dim_arr[i, j]) if (!(big.multi_dim_arr[i][j] inside {[0:9]})) 
+        foreach (big.mix_arr[i]) if (!(big.mix_arr[i].size() inside {[1:4]}))
             $stop;
-        foreach (big.mix_arr[i]) if (!(big.mix_arr[i].size() inside {[1:4]})) 
-            $stop;
-        foreach (big.mix_arr[i, j]) if (!(big.mix_arr[i][j] inside {[50:100]})) 
+        foreach (big.mix_arr[i, j]) if (!(big.mix_arr[i][j] inside {[50:100]}))
             $stop;
     endfunction
 endclass
@@ -69,7 +69,7 @@ module t_constraint_struct_complex;
     BigStructClass big_struct_inst = new();
 
     repeat (5) begin // Run multiple randomizations
-        if (!big_struct_inst.randomize()) 
+        if (!big_struct_inst.randomize())
         $stop;  // Stop if randomization fails
 
         $display("\n===== Randomized Test =====");
@@ -79,7 +79,7 @@ module t_constraint_struct_complex;
         $display("Associative Array: %p", big_struct_inst.big.assoc_arr);
         $display("Multi-Dimensional Array: %p", big_struct_inst.big.multi_dim_arr);
         $display("Mixed Array:");
-        foreach (big_struct_inst.big.mix_arr[i]) 
+        foreach (big_struct_inst.big.mix_arr[i])
         $display("  mix_arr[%0d] = %p", i, big_struct_inst.big.mix_arr[i]);
 
         // Perform self-test


### PR DESCRIPTION
After the #5759, verilator can support the basic struct's constrained random.

This patches fixes the case when constrained-randomizing a struct, whose elements are arrays.

```
typedef struct {
        rand int arr[3];
} unpacked_struct_t;
```

Now verilator can support all kinds of arrays as the element in struct, including packed/unpacked, dyn_arr, queue, associative_arr, multi-dimensional_arr, and mixed types of arrays.

It fixes the issue #5765.