### PR TITLE
Fix foreach of assocArr inside a constraint block (#5727)

### DIFF
--- a/include/verilated.cpp
+++ b/include/verilated.cpp
@@ -1080,17 +1080,16 @@ void _vl_vsformat(std::string& output, const std::string& format, va_list ap) VL
                     }
                     break;
                 }  // b / o / x
-                case 'p': {   // 'x' but parameter is string
+                case 'p': {  // 'x' but parameter is string
                     const int lbits = va_arg(ap, int);
                     const std::string* const cstrp = va_arg(ap, const std::string*);
                     std::ostringstream oss;
-                    for (unsigned char c : *cstrp) {
-                        oss << std::hex << static_cast<int>(c);
-                    }
+                    for (unsigned char c : *cstrp) { oss << std::hex << static_cast<int>(c); }
                     std::string hex_str = oss.str();
                     // Ensure the hex string is exactly 128 bits (32 hex characters)
-                    hex_str = hex_str.size() > 32 ? hex_str.substr(0, 32)
-                                                : std::string(32 - hex_str.size(), '0') + hex_str;
+                    hex_str = hex_str.size() > 32
+                                  ? hex_str.substr(0, 32)
+                                  : std::string(32 - hex_str.size(), '0') + hex_str;
                     output += hex_str;
                     break;
                 }

--- a/include/verilated.cpp
+++ b/include/verilated.cpp
@@ -918,9 +918,9 @@ void _vl_vsformat(std::string& output, const std::string& format, va_list ap) VL
             }
             case 'p': {  // 'x' but parameter is string
                 const int lbits = va_arg(ap, int);
-                const char* const cstr = va_arg(ap, const char*);
+                const std::string* const cstr = va_arg(ap, const std::string*);
                 std::ostringstream oss;
-                for (unsigned char c : std::string(cstr)) {
+                for (unsigned char c : *cstr) {
                     oss << std::hex << static_cast<int>(c);
                 }
                 std::string hex_str = oss.str();

--- a/include/verilated.cpp
+++ b/include/verilated.cpp
@@ -918,7 +918,7 @@ void _vl_vsformat(std::string& output, const std::string& format, va_list ap) VL
             }
             case 'p': {  // 'x' but parameter is string
                 const int lbits = va_arg(ap, int);
-                const std::string const cstr = va_arg(ap, std::string);
+                const std::string cstr = va_arg(ap, std::string);
                 std::ostringstream oss;
                 for (unsigned char c : cstr) { oss << std::hex << static_cast<int>(c); }
                 std::string hex_str = oss.str();

--- a/include/verilated.cpp
+++ b/include/verilated.cpp
@@ -920,7 +920,9 @@ void _vl_vsformat(std::string& output, const std::string& format, va_list ap) VL
                 const int lbits = va_arg(ap, int);
                 const char* const cstr = va_arg(ap, const char*);
                 std::ostringstream oss;
-                for (unsigned char c : std::string(cstr)) { oss << std::hex << static_cast<int>(c); }
+                for (unsigned char c : std::string(cstr)) {
+                    oss << std::hex << static_cast<int>(c);
+                }
                 std::string hex_str = oss.str();
                 if (width > 0 && widthSet) {
                     hex_str = hex_str.size() > width

--- a/include/verilated.cpp
+++ b/include/verilated.cpp
@@ -62,7 +62,7 @@
 #include <utility>
 
 #include <sys/stat.h>  // mkdir
-
+#include <iostream>
 // clang-format off
 #if defined(_WIN32) || defined(__MINGW32__)
 # include <direct.h>  // mkdir
@@ -916,6 +916,20 @@ void _vl_vsformat(std::string& output, const std::string& format, va_list ap) VL
                 }
                 break;
             }
+            case 'p': {  // 'x' but parameter is string
+                const int lbits = va_arg(ap, int);
+                const std::string* const cstrp = va_arg(ap, const std::string*);
+                std::ostringstream oss;
+                for (unsigned char c : *cstrp) { oss << std::hex << static_cast<int>(c); }
+                std::string hex_str = oss.str();
+                if (width > 0 && widthSet) {
+                    hex_str = hex_str.size() > width
+                                    ? hex_str.substr(0, width)
+                                    : std::string(width - hex_str.size(), '0') + hex_str;
+                    output += hex_str;
+                }
+                break;
+            }
             default: {
                 // Deal with all read-and-print somethings
                 const int lbits = va_arg(ap, int);
@@ -1080,19 +1094,6 @@ void _vl_vsformat(std::string& output, const std::string& format, va_list ap) VL
                     }
                     break;
                 }  // b / o / x
-                case 'p': {  // 'x' but parameter is string
-                    const int lbits = va_arg(ap, int);
-                    const std::string* const cstrp = va_arg(ap, const std::string*);
-                    std::ostringstream oss;
-                    for (unsigned char c : *cstrp) { oss << std::hex << static_cast<int>(c); }
-                    std::string hex_str = oss.str();
-                    // Ensure the hex string is exactly 128 bits (32 hex characters)
-                    hex_str = hex_str.size() > 32
-                                  ? hex_str.substr(0, 32)
-                                  : std::string(32 - hex_str.size(), '0') + hex_str;
-                    output += hex_str;
-                    break;
-                }
                 case 'u':
                 case 'z': {  // Packed 4-state
                     const bool is_4_state = (fmt == 'z');

--- a/include/verilated.cpp
+++ b/include/verilated.cpp
@@ -56,13 +56,13 @@
 #include <cctype>
 #include <cerrno>
 #include <cstdlib>
+#include <iostream>
 #include <limits>
 #include <list>
 #include <sstream>
 #include <utility>
 
 #include <sys/stat.h>  // mkdir
-#include <iostream>
 // clang-format off
 #if defined(_WIN32) || defined(__MINGW32__)
 # include <direct.h>  // mkdir
@@ -924,8 +924,8 @@ void _vl_vsformat(std::string& output, const std::string& format, va_list ap) VL
                 std::string hex_str = oss.str();
                 if (width > 0 && widthSet) {
                     hex_str = hex_str.size() > width
-                                    ? hex_str.substr(0, width)
-                                    : std::string(width - hex_str.size(), '0') + hex_str;
+                                  ? hex_str.substr(0, width)
+                                  : std::string(width - hex_str.size(), '0') + hex_str;
                     output += hex_str;
                 }
                 break;

--- a/include/verilated.cpp
+++ b/include/verilated.cpp
@@ -918,9 +918,9 @@ void _vl_vsformat(std::string& output, const std::string& format, va_list ap) VL
             }
             case 'p': {  // 'x' but parameter is string
                 const int lbits = va_arg(ap, int);
-                const std::string cstr = va_arg(ap, std::string);
+                const char* const cstr = va_arg(ap, const char*);
                 std::ostringstream oss;
-                for (unsigned char c : cstr) { oss << std::hex << static_cast<int>(c); }
+                for (unsigned char c : std::string(cstr)) { oss << std::hex << static_cast<int>(c); }
                 std::string hex_str = oss.str();
                 if (width > 0 && widthSet) {
                     hex_str = hex_str.size() > width

--- a/include/verilated.cpp
+++ b/include/verilated.cpp
@@ -918,9 +918,9 @@ void _vl_vsformat(std::string& output, const std::string& format, va_list ap) VL
             }
             case 'p': {  // 'x' but parameter is string
                 const int lbits = va_arg(ap, int);
-                const std::string* const cstrp = va_arg(ap, const std::string*);
+                const std::string const cstr = va_arg(ap, std::string);
                 std::ostringstream oss;
-                for (unsigned char c : *cstrp) { oss << std::hex << static_cast<int>(c); }
+                for (unsigned char c : cstr) { oss << std::hex << static_cast<int>(c); }
                 std::string hex_str = oss.str();
                 if (width > 0 && widthSet) {
                     hex_str = hex_str.size() > width

--- a/include/verilated.cpp
+++ b/include/verilated.cpp
@@ -63,6 +63,7 @@
 #include <utility>
 
 #include <sys/stat.h>  // mkdir
+
 // clang-format off
 #if defined(_WIN32) || defined(__MINGW32__)
 # include <direct.h>  // mkdir

--- a/include/verilated.cpp
+++ b/include/verilated.cpp
@@ -1080,6 +1080,20 @@ void _vl_vsformat(std::string& output, const std::string& format, va_list ap) VL
                     }
                     break;
                 }  // b / o / x
+                case 'p': {   // 'x' but parameter is string
+                    const int lbits = va_arg(ap, int);
+                    const std::string* const cstrp = va_arg(ap, const std::string*);
+                    std::ostringstream oss;
+                    for (unsigned char c : *cstrp) {
+                        oss << std::hex << static_cast<int>(c);
+                    }
+                    std::string hex_str = oss.str();
+                    // Ensure the hex string is exactly 128 bits (32 hex characters)
+                    hex_str = hex_str.size() > 32 ? hex_str.substr(0, 32)
+                                                : std::string(32 - hex_str.size(), '0') + hex_str;
+                    output += hex_str;
+                    break;
+                }
                 case 'u':
                 case 'z': {  // Packed 4-state
                     const bool is_4_state = (fmt == 'z');

--- a/include/verilated.cpp
+++ b/include/verilated.cpp
@@ -920,9 +920,7 @@ void _vl_vsformat(std::string& output, const std::string& format, va_list ap) VL
                 const int lbits = va_arg(ap, int);
                 const std::string* const cstr = va_arg(ap, const std::string*);
                 std::ostringstream oss;
-                for (unsigned char c : *cstr) {
-                    oss << std::hex << static_cast<int>(c);
-                }
+                for (unsigned char c : *cstr) { oss << std::hex << static_cast<int>(c); }
                 std::string hex_str = oss.str();
                 if (width > 0 && widthSet) {
                     hex_str = hex_str.size() > width

--- a/src/V3EmitCFunc.cpp
+++ b/src/V3EmitCFunc.cpp
@@ -220,7 +220,7 @@ void EmitCFunc::displayEmit(AstNode* nodep, bool isScan) {
                 if (func != "") {
                     puts(func);
                 } else if (argp) {
-                    const bool addrof = isScan || (fmt == '@');
+                    const bool addrof = isScan || (fmt == '@') || (fmt == 'p');
                     if (addrof) puts("&(");
                     iterateConst(argp);
                     if (!addrof) emitDatap(argp);

--- a/src/V3EmitCFunc.cpp
+++ b/src/V3EmitCFunc.cpp
@@ -371,6 +371,7 @@ void EmitCFunc::displayNode(AstNode* nodep, AstScopeName* scopenamep, const stri
             case 'o': displayArg(nodep, &elistp, isScan, vfmt, ignore, 'o'); break;
             case 'h':  // FALLTHRU
             case 'x': displayArg(nodep, &elistp, isScan, vfmt, ignore, 'x'); break;
+            case 'p': displayArg(nodep, &elistp, isScan, vfmt, ignore, 'p'); break;
             case 's': displayArg(nodep, &elistp, isScan, vfmt, ignore, 's'); break;
             case 'e': displayArg(nodep, &elistp, isScan, vfmt, ignore, 'e'); break;
             case 'f': displayArg(nodep, &elistp, isScan, vfmt, ignore, 'f'); break;

--- a/src/V3Randomize.cpp
+++ b/src/V3Randomize.cpp
@@ -709,7 +709,13 @@ class ConstraintExprVisitor final : public VNVisitor {
     void visit(AstAssocSel* nodep) override {
         if (editFormat(nodep)) return;
         FileLine* const fl = nodep->fileline();
-        if (VN_IS(nodep->bitp(), CvtPackString) && VN_IS(nodep->bitp()->dtypep(), BasicDType)) {
+        if (VN_IS(nodep->bitp(),VarRef) &&VN_AS(nodep->bitp(),VarRef)->varp()->dtypep()->basicp()&& VN_AS(nodep->bitp(),VarRef)->dtypep()->basicp()->keyword() == VBasicDTypeKwd::STRING) {
+            VNRelinker handle;
+            AstNodeExpr* const idxp
+                    = new AstSFormatF{fl, "#x%32p", false, nodep->bitp()->unlinkFrBack(&handle)};
+            handle.relink(idxp);
+            editSMT(nodep, nodep->fromp(), idxp);
+        } else if (VN_IS(nodep->bitp(), CvtPackString) && VN_IS(nodep->bitp()->dtypep(), BasicDType)) {
             AstCvtPackString* const stringp = VN_AS(nodep->bitp(), CvtPackString);
             const size_t stringSize = VN_AS(stringp->lhsp(), Const)->width();
             if (stringSize > 128) {

--- a/src/V3Randomize.cpp
+++ b/src/V3Randomize.cpp
@@ -709,13 +709,17 @@ class ConstraintExprVisitor final : public VNVisitor {
     void visit(AstAssocSel* nodep) override {
         if (editFormat(nodep)) return;
         FileLine* const fl = nodep->fileline();
-        if (VN_IS(nodep->bitp(),VarRef) &&VN_AS(nodep->bitp(),VarRef)->varp()->dtypep()->basicp()&& VN_AS(nodep->bitp(),VarRef)->dtypep()->basicp()->keyword() == VBasicDTypeKwd::STRING) {
+        if (VN_IS(nodep->bitp(), VarRef)
+            && VN_AS(nodep->bitp(), VarRef)->varp()->dtypep()->basicp()
+            && VN_AS(nodep->bitp(), VarRef)->dtypep()->basicp()->keyword()
+                   == VBasicDTypeKwd::STRING) {
             VNRelinker handle;
             AstNodeExpr* const idxp
-                    = new AstSFormatF{fl, "#x%32p", false, nodep->bitp()->unlinkFrBack(&handle)};
+                = new AstSFormatF{fl, "#x%32p", false, nodep->bitp()->unlinkFrBack(&handle)};
             handle.relink(idxp);
             editSMT(nodep, nodep->fromp(), idxp);
-        } else if (VN_IS(nodep->bitp(), CvtPackString) && VN_IS(nodep->bitp()->dtypep(), BasicDType)) {
+        } else if (VN_IS(nodep->bitp(), CvtPackString)
+                   && VN_IS(nodep->bitp()->dtypep(), BasicDType)) {
             AstCvtPackString* const stringp = VN_AS(nodep->bitp(), CvtPackString);
             const size_t stringSize = VN_AS(stringp->lhsp(), Const)->width();
             if (stringSize > 128) {

--- a/src/V3Randomize.cpp
+++ b/src/V3Randomize.cpp
@@ -710,9 +710,7 @@ class ConstraintExprVisitor final : public VNVisitor {
         if (editFormat(nodep)) return;
         FileLine* const fl = nodep->fileline();
         if (VN_IS(nodep->bitp(), VarRef)
-            && VN_AS(nodep->bitp(), VarRef)->varp()->dtypep()->basicp()
-            && VN_AS(nodep->bitp(), VarRef)->dtypep()->basicp()->keyword()
-                   == VBasicDTypeKwd::STRING) {
+            && VN_AS(nodep->bitp(), VarRef)->isString()) {
             VNRelinker handle;
             AstNodeExpr* const idxp
                 = new AstSFormatF{fl, "#x%32p", false, nodep->bitp()->unlinkFrBack(&handle)};

--- a/src/V3Randomize.cpp
+++ b/src/V3Randomize.cpp
@@ -709,8 +709,7 @@ class ConstraintExprVisitor final : public VNVisitor {
     void visit(AstAssocSel* nodep) override {
         if (editFormat(nodep)) return;
         FileLine* const fl = nodep->fileline();
-        if (VN_IS(nodep->bitp(), VarRef)
-            && VN_AS(nodep->bitp(), VarRef)->isString()) {
+        if (VN_IS(nodep->bitp(), VarRef) && VN_AS(nodep->bitp(), VarRef)->isString()) {
             VNRelinker handle;
             AstNodeExpr* const idxp
                 = new AstSFormatF{fl, "#x%32p", false, nodep->bitp()->unlinkFrBack(&handle)};

--- a/test_regress/t/t_constraint_assoc_arr_basic.v
+++ b/test_regress/t/t_constraint_assoc_arr_basic.v
@@ -8,6 +8,7 @@ class constrained_associative_array_basic;
 
     rand int int_index_arr [int];
     rand int string_index_arr [string];
+    rand int string_index_arr_2 [string];
     /* verilator lint_off SIDEEFFECT */
     // Constraints for both arrays
     constraint int_index_constraints {
@@ -18,11 +19,15 @@ class constrained_associative_array_basic;
         string_index_arr["Bob"] inside {50, 60};
         string_index_arr["Charlie"] > 25;
     }
+    constraint string_index_2_constraints {
+        foreach (string_index_arr_2[i]) string_index_arr_2[i] > 10; // nodep->bitp() would be VARREF, instead of CVTPACKSTRING
+    }
 
     // Constructor to initialize arrays
     function new();
         int_index_arr = '{1: 0, 8: 0, 7: 0};
         string_index_arr = '{"Alice": 25, "Bob": 50, "Charlie": 45};
+        string_index_arr_2 = '{"key1": 15, "key2": 20, "key3": 30};
     endfunction
 
     // Function to check and display the arrays
@@ -34,6 +39,9 @@ class constrained_associative_array_basic;
             if ((name == "Alice" && string_index_arr[name] != 35) ||
                 (name == "Bob" && !(string_index_arr[name] inside {50, 60})) ||
                 (name == "Charlie" && string_index_arr[name] <= 25)) $stop;
+        end
+        foreach (string_index_arr_2[i]) begin
+            if (string_index_arr_2[i] <= 10) $stop;
         end
     endfunction
 


### PR DESCRIPTION
This patch fixes #5727 

Add a 'p' to process the string varref format.
