### PR TITLE
Automatically split some packed variables

### DIFF
--- a/docs/guide/exe_verilator.rst
+++ b/docs/guide/exe_verilator.rst
@@ -563,6 +563,10 @@ Summary:
 
 .. option:: -fno-assemble
 
+.. option:: -fno-auto-var-split
+
+   Do not attempt to split variables automatically.
+
 .. option:: -fno-case
 
 .. option:: -fno-combine

--- a/docs/guide/exe_verilator.rst
+++ b/docs/guide/exe_verilator.rst
@@ -563,10 +563,6 @@ Summary:
 
 .. option:: -fno-assemble
 
-.. option:: -fno-auto-var-split
-
-   Do not attempt to split variables automatically.
-
 .. option:: -fno-case
 
 .. option:: -fno-combine
@@ -647,6 +643,11 @@ Summary:
    Rarely needed. Disables one of the internal optimization steps. These
    are typically used only when recommended by a maintainer to help debug
    or work around an issue.
+
+.. option:: -fno-var-split
+
+   Do not attempt to split variables automatically. Variables explicitly
+   annotated with :option:`/*verilator&32;split_var*/` are still split.
 
 .. option:: -future0 <option>
 

--- a/docs/guide/extensions.rst
+++ b/docs/guide/extensions.rst
@@ -550,6 +550,20 @@ or "`ifdef`"'s may break other tools.
    large arrays may slow down the Verilation speed, so use this only on
    variables that require it.
 
+   Packed variables that are only referenced locally (without hiererchical
+   references) via non-overlaping, constant-indexed bit or part select
+   expressions are split automatically. This covers the somewhat comon usage
+   pattern:
+
+   .. code-block:: sv
+
+         logic [1:0][31:0] tmp;
+
+         assign tmp[0] = foo    + a;
+         assign tmp[1] = tmp[1] + b;
+         assign bar    = tmp[1] + c;
+
+
    Same as :option:`split_var` configuration file option.
 
 .. option:: /*verilator&32;tag <text...>*/

--- a/src/V3Options.cpp
+++ b/src/V3Options.cpp
@@ -1311,6 +1311,7 @@ void V3Options::parseOptsList(FileLine* fl, const string& optdir, int argc,
 
     DECL_OPTION("-facyc-simp", FOnOff, &m_fAcycSimp);
     DECL_OPTION("-fassemble", FOnOff, &m_fAssemble);
+    DECL_OPTION("-fauto-split-var", FOnOff, &m_fAutoSplitVar);
     DECL_OPTION("-fcase", FOnOff, &m_fCase);
     DECL_OPTION("-fcombine", FOnOff, &m_fCombine);
     DECL_OPTION("-fconst", FOnOff, &m_fConst);
@@ -2146,6 +2147,7 @@ void V3Options::optimize(int level) {
     const bool flag = level > 0;
     m_fAcycSimp = flag;
     m_fAssemble = flag;
+    m_fAutoSplitVar = flag;
     m_fCase = flag;
     m_fCombine = flag;
     m_fConst = flag;

--- a/src/V3Options.cpp
+++ b/src/V3Options.cpp
@@ -1311,7 +1311,6 @@ void V3Options::parseOptsList(FileLine* fl, const string& optdir, int argc,
 
     DECL_OPTION("-facyc-simp", FOnOff, &m_fAcycSimp);
     DECL_OPTION("-fassemble", FOnOff, &m_fAssemble);
-    DECL_OPTION("-fauto-split-var", FOnOff, &m_fAutoSplitVar);
     DECL_OPTION("-fcase", FOnOff, &m_fCase);
     DECL_OPTION("-fcombine", FOnOff, &m_fCombine);
     DECL_OPTION("-fconst", FOnOff, &m_fConst);
@@ -1357,6 +1356,7 @@ void V3Options::parseOptsList(FileLine* fl, const string& optdir, int argc,
     DECL_OPTION("-fsubst-const", FOnOff, &m_fSubstConst);
     DECL_OPTION("-ftable", FOnOff, &m_fTable);
     DECL_OPTION("-ftaskify-all-forked", FOnOff, &m_fTaskifyAll).undocumented();  // Debug
+    DECL_OPTION("-fvar-split", FOnOff, &m_fVarSplit);
 
     DECL_OPTION("-G", CbPartialMatch, [this](const char* optp) { addParameter(optp, false); });
     DECL_OPTION("-gate-stmts", Set, &m_gateStmts);
@@ -2147,7 +2147,6 @@ void V3Options::optimize(int level) {
     const bool flag = level > 0;
     m_fAcycSimp = flag;
     m_fAssemble = flag;
-    m_fAutoSplitVar = flag;
     m_fCase = flag;
     m_fCombine = flag;
     m_fConst = flag;
@@ -2170,6 +2169,7 @@ void V3Options::optimize(int level) {
     m_fSubst = flag;
     m_fSubstConst = flag;
     m_fTable = flag;
+    m_fVarSplit = flag;
     // And set specific optimization levels
     if (level >= 3) {
         m_inlineMult = -1;  // Maximum inlining

--- a/src/V3Options.h
+++ b/src/V3Options.h
@@ -380,6 +380,7 @@ private:
     // MEMBERS (optimizations)
     bool m_fAcycSimp;    // main switch: -fno-acyc-simp: acyclic pre-optimizations
     bool m_fAssemble;    // main switch: -fno-assemble: assign assemble
+    bool m_fAutoSplitVar;  // main switch: -fno-auto-split-var: automatic variable splitting
     bool m_fCase;        // main switch: -fno-case: case tree conversion
     bool m_fCombine;     // main switch: -fno-combine: common icode packing
     bool m_fConst;       // main switch: -fno-const: constant folding
@@ -682,6 +683,7 @@ public:
     // ACCESSORS (optimization options)
     bool fAcycSimp() const { return m_fAcycSimp; }
     bool fAssemble() const { return m_fAssemble; }
+    bool fAutoSplitVar() const { return m_fAutoSplitVar; }
     bool fCase() const { return m_fCase; }
     bool fCombine() const { return m_fCombine; }
     bool fConst() const { return m_fConst; }

--- a/src/V3Options.h
+++ b/src/V3Options.h
@@ -380,7 +380,6 @@ private:
     // MEMBERS (optimizations)
     bool m_fAcycSimp;    // main switch: -fno-acyc-simp: acyclic pre-optimizations
     bool m_fAssemble;    // main switch: -fno-assemble: assign assemble
-    bool m_fAutoSplitVar;  // main switch: -fno-auto-split-var: automatic variable splitting
     bool m_fCase;        // main switch: -fno-case: case tree conversion
     bool m_fCombine;     // main switch: -fno-combine: common icode packing
     bool m_fConst;       // main switch: -fno-const: constant folding
@@ -412,6 +411,7 @@ private:
     bool m_fSubstConst;  // main switch: -fno-subst-const: final constant substitution
     bool m_fTable;       // main switch: -fno-table: lookup table creation
     bool m_fTaskifyAll = false;  // main switch: --ftaskify-all-forked
+    bool m_fVarSplit;    // main switch: -fno-var-split: automatic variable splitting
     // clang-format on
 
     bool m_available = false;  // Set to true at the end of option parsing
@@ -683,7 +683,6 @@ public:
     // ACCESSORS (optimization options)
     bool fAcycSimp() const { return m_fAcycSimp; }
     bool fAssemble() const { return m_fAssemble; }
-    bool fAutoSplitVar() const { return m_fAutoSplitVar; }
     bool fCase() const { return m_fCase; }
     bool fCombine() const { return m_fCombine; }
     bool fConst() const { return m_fConst; }
@@ -719,6 +718,7 @@ public:
     bool fSubstConst() const { return m_fSubstConst; }
     bool fTable() const { return m_fTable; }
     bool fTaskifyAll() const { return m_fTaskifyAll; }
+    bool fVarSplit() const { return m_fVarSplit; }
 
     string traceClassBase() const VL_MT_SAFE { return m_traceFormat.classBase(); }
     string traceClassLang() const { return m_traceFormat.classBase() + (systemC() ? "Sc" : "C"); }

--- a/src/V3SplitVar.cpp
+++ b/src/V3SplitVar.cpp
@@ -1223,8 +1223,7 @@ class SplitPackedVarVisitor final : public VNVisitor, public SplitVarImpl {
     // Find Vars only referenced through non-overlapping constant selects,
     // and set their user2 to mark them as split candidates
     static void findCandidates(const RefsInModule& refSets,
-        const std::unordered_set<AstVar*>& hasXrefs
-    ) {
+                               const std::unordered_set<AstVar*>& hasXrefs) {
         // Inclusive index range
         using Range = std::pair<int32_t, int32_t>;
 

--- a/src/V3SplitVar.cpp
+++ b/src/V3SplitVar.cpp
@@ -114,6 +114,7 @@
 
 #include "V3SplitVar.h"
 
+#include "V3AstUserAllocator.h"
 #include "V3Stats.h"
 #include "V3UniqueNames.h"
 
@@ -539,19 +540,19 @@ class SplitUnpackedVarVisitor final : public VNVisitor, public SplitVarImpl {
         }
     }
     void visit(AstVar* nodep) override {
+        m_refsForPackedSplit[m_modp].add(nodep);
         if (!nodep->attrSplitVar()) return;  // Nothing to do
         if (!cannotSplitReason(nodep)) {
             m_refs.registerVar(nodep);
             UINFO(4, nodep->name() << " is added to candidate list.\n");
         }
-        m_refsForPackedSplit[m_modp].add(nodep);
     }
     void visit(AstVarRef* nodep) override {
+        m_refsForPackedSplit[m_modp].add(nodep);
         if (!nodep->varp()->attrSplitVar()) return;  // Nothing to do
         if (m_refs.tryAdd(m_contextp, nodep, m_inFTaskp)) {
             m_foundTargetVar.insert(nodep->varp());
         }
-        m_refsForPackedSplit[m_modp].add(nodep);
     }
     void visit(AstSel* nodep) override {
         if (VN_IS(nodep->fromp(), VarRef)) m_refsForPackedSplit[m_modp].add(nodep);
@@ -954,6 +955,11 @@ public:
 };
 
 class SplitPackedVarVisitor final : public VNVisitor, public SplitVarImpl {
+    // NODE STATE
+    //  AstVar::user2()  -> Automatically considered candidate
+    //  AstVar::user3()  -> Used only in findCandidates
+    const VNUser2InUse m_user2InUse;
+
     AstNetlist* const m_netp;
     const AstNodeModule* m_modp = nullptr;  // Current module (just for log)
     int m_numSplit = 0;  // Total number of split variables
@@ -963,10 +969,12 @@ class SplitPackedVarVisitor final : public VNVisitor, public SplitVarImpl {
         if (!cannotSplitTaskReason(nodep)) iterateChildren(nodep);
     }
     void visit(AstVar* nodep) override {
-        if (!nodep->attrSplitVar()) return;  // Nothing to do
+        if (!nodep->attrSplitVar() && !nodep->user2()) return;  // Nothing to do
         if (const char* const reason = cannotSplitReason(nodep, true)) {
-            warnNoSplit(nodep, nodep, reason);
-            nodep->attrSplitVar(false);
+            if (nodep->attrSplitVar()) {
+                warnNoSplit(nodep, nodep, reason);
+                nodep->attrSplitVar(false);
+            }
         } else {  // Finally find a good candidate
             const bool inserted = m_refs.emplace(nodep, PackedVarRef{nodep}).second;
             if (inserted) UINFO(4, nodep->prettyNameQ() << " is added to candidate list.\n");
@@ -977,7 +985,7 @@ class SplitPackedVarVisitor final : public VNVisitor, public SplitVarImpl {
         visit(varp);
         const auto refit = m_refs.find(varp);
         if (refit == m_refs.end()) return;  // variable without split_var metacomment
-        UASSERT_OBJ(varp->attrSplitVar(), varp, "split_var attribute must be attached");
+        UASSERT_OBJ(varp->attrSplitVar() || varp->user2(), varp, "must be a split candidate");
         UASSERT_OBJ(!nodep->classOrPackagep(), nodep,
                     "variable in package must have been dropped beforehand.");
         const AstBasicDType* const basicp = refit->second.basicp();
@@ -999,7 +1007,7 @@ class SplitPackedVarVisitor final : public VNVisitor, public SplitVarImpl {
             iterateChildren(nodep);
             return;  // Variable without split_var metacomment
         }
-        UASSERT_OBJ(varp->attrSplitVar(), varp, "split_var attribute must be attached");
+        UASSERT_OBJ(varp->attrSplitVar() || varp->user2(), varp, "must be a split candidate");
 
         const std::array<AstConst*, 2> consts
             = {{VN_CAST(nodep->lsbp(), Const),
@@ -1013,7 +1021,10 @@ class SplitPackedVarVisitor final : public VNVisitor, public SplitVarImpl {
                          << " [" << consts[0]->toSInt() << ":+" << consts[1]->toSInt()
                          << "] lsb:" << refit->second.basicp()->lo() << "\n");
         } else {
-            warnNoSplit(vrefp->varp(), nodep, "its bit range cannot be determined statically");
+            if (varp->attrSplitVar()) {
+                warnNoSplit(vrefp->varp(), nodep, "its bit range cannot be determined statically");
+                varp->attrSplitVar(false);
+            }
             if (!consts[0]) {
                 UINFO(4, "LSB " << nodep->lsbp() << " is expected to be constant, but not\n");
             }
@@ -1021,7 +1032,6 @@ class SplitPackedVarVisitor final : public VNVisitor, public SplitVarImpl {
                 UINFO(4, "WIDTH " << nodep->widthp() << " is expected to be constant, but not\n");
             }
             m_refs.erase(varp);
-            varp->attrSplitVar(false);
             iterateChildren(nodep);
         }
     }
@@ -1196,12 +1206,98 @@ class SplitPackedVarVisitor final : public VNVisitor, public SplitVarImpl {
         m_refs.clear();  // Done
     }
 
+    // Find Vars only referenced through non-overlapping constant selects,
+    // and set their user2 to mark them as split candidates
+    static void findCandidates(const RefsInModule& refSets) {
+        // Inclusive index range
+        using Range = std::pair<int32_t, int32_t>;
+
+        // Store one VarInfo per AstVar via user3
+        struct VarInfo final {
+            bool ineligible = false;  // Ineligible for automatic consideration
+            std::vector<Range> ranges;  // [lsb, msb] inclusive of Sels
+        };
+        const VNUser3InUse user3InUse;
+        AstUser3Allocator<AstVar, VarInfo> varInfos;
+
+        // Gather all Sels selecting from each variable, also mark if ineligible
+        for (const AstVarRef* const vrefp : refSets.m_refs) {
+            AstVar* const varp = vrefp->varp();
+            VarInfo& info = varInfos(varp);
+            if (info.ineligible) continue;
+            // Function return values seem not safe for splitting, even though
+            // the code above seems like it's tryinig to handle them.
+            if (varp->isFuncReturn()) {
+                info.ineligible = true;
+                continue;
+            }
+            // Don't consider ports, we don't know what is connected to them at this point
+            if (varp->isIO()) {
+                info.ineligible = true;
+                continue;
+            }
+            // Ineligible if it is not being Sel from
+            AstSel* const selp = VN_CAST(vrefp->firstAbovep(), Sel);
+            if (!selp || vrefp != selp->fromp()) {
+                info.ineligible = true;
+                continue;
+            }
+            // Ineligible if the selection range is not constant
+            AstConst* const lsbConstp = VN_CAST(selp->lsbp(), Const);
+            if (!lsbConstp) {
+                info.ineligible = true;
+                continue;
+            }
+            AstConst* const widthConstp = VN_CAST(selp->widthp(), Const);
+            if (!widthConstp) {
+                info.ineligible = true;
+                continue;
+            }
+            // All good, record the selection range
+            const int32_t lsb = lsbConstp->toSInt();
+            const int32_t msb = lsb + widthConstp->toSInt() - 1;
+            info.ranges.emplace_back(lsb, msb);
+        }
+
+        // Check the usage of each variable
+        for (AstVar* const varp : refSets.m_vars) {
+            VarInfo* const infop = varInfos.tryGet(varp);
+            if (!infop) continue;
+            // Don't consider if ineligible
+            if (infop->ineligible) continue;
+            // Sort ranges by LSB then MSB
+            std::sort(infop->ranges.begin(), infop->ranges.end(),
+                      [](const Range& a, const Range& b) {
+                          if (a.first != b.first) return a.first < b.first;
+                          return a.second < b.second;
+                      });
+            // Check for overlapping but non-identical ranges
+            bool overlap = false;
+            for (size_t i = 0; i + 1 < infop->ranges.size(); ++i) {
+                const Range& a = infop->ranges[i];
+                const Range& b = infop->ranges[i + 1];
+                // OK if the two ranges are the same
+                if (a == b) continue;
+                // OK if they don't overlap
+                if (a.second < b.first) continue;
+                // Overlap found
+                overlap = true;
+                break;
+            }
+            // If no overlapping ranges, consider it for automatic splitting
+            varp->user2(!overlap);
+        }
+    }
+
 public:
     // When reusing the information from SplitUnpackedVarVisitor
     SplitPackedVarVisitor(AstNetlist* nodep, SplitVarRefsMap& refs)
         : m_netp{nodep} {
         // If you want ignore refs and walk the tne entire AST,
         // just call iterateChildren(m_modp) and split() for each module
+        if (v3Global.opt.fAutoSplitVar()) {
+            for (const auto& i : refs) findCandidates(i.second);
+        }
         for (auto& i : refs) {
             m_modp = i.first;
             i.second.visit(this);

--- a/test_regress/t/t_func_ref_bad.py
+++ b/test_regress/t/t_func_ref_bad.py
@@ -11,8 +11,6 @@ import vltest_bootstrap
 
 test.scenarios('vlt')
 
-test.lint(verilator_flags2=["-fno-auto-split-var"],
-          fails=True,
-          expect_filename=test.golden_filename)
+test.lint(verilator_flags2=["-fno-var-split"], fails=True, expect_filename=test.golden_filename)
 
 test.passes()

--- a/test_regress/t/t_func_ref_bad.py
+++ b/test_regress/t/t_func_ref_bad.py
@@ -11,6 +11,8 @@ import vltest_bootstrap
 
 test.scenarios('vlt')
 
-test.lint(fails=True, expect_filename=test.golden_filename)
+test.lint(verilator_flags2=["-fno-auto-split-var"],
+          fails=True,
+          expect_filename=test.golden_filename)
 
 test.passes()

--- a/test_regress/t/t_gate_inline_wide_noexclude_sel.py
+++ b/test_regress/t/t_gate_inline_wide_noexclude_sel.py
@@ -11,9 +11,10 @@ import vltest_bootstrap
 
 test.scenarios('vlt')
 
-test.lint(verilator_flags2=['--stats', '--expand-limit 5', '-fno-auto-split-var'])
+test.lint(verilator_flags2=['--stats', '--expand-limit 5', '-fno-var-split'])
 
 test.file_grep(test.stats, r'Optimizations, Gate excluded wide expressions\s+(\d+)', 1)
 test.file_grep(test.stats, r'Optimizations, Gate sigs deleted\s+(\d+)', 9)
+test.file_grep(test.stats, r'SplitVar, packed variables split automatically\s+(\d+)', 0)
 
 test.passes()

--- a/test_regress/t/t_gate_inline_wide_noexclude_sel.py
+++ b/test_regress/t/t_gate_inline_wide_noexclude_sel.py
@@ -11,7 +11,7 @@ import vltest_bootstrap
 
 test.scenarios('vlt')
 
-test.lint(verilator_flags2=['--stats', '--expand-limit 5'])
+test.lint(verilator_flags2=['--stats', '--expand-limit 5', '-fno-auto-split-var'])
 
 test.file_grep(test.stats, r'Optimizations, Gate excluded wide expressions\s+(\d+)', 1)
 test.file_grep(test.stats, r'Optimizations, Gate sigs deleted\s+(\d+)', 9)

--- a/test_regress/t/t_opt_const.py
+++ b/test_regress/t/t_opt_const.py
@@ -17,5 +17,6 @@ test.execute()
 
 if test.vlt:
     test.file_grep(test.stats, r'Optimizations, Const bit op reduction\s+(\d+)', 44)
+    test.file_grep(test.stats, r'SplitVar, packed variables split automatically\s+(\d+)', 1)
 
 test.passes()

--- a/test_regress/t/t_opt_const.py
+++ b/test_regress/t/t_opt_const.py
@@ -16,6 +16,6 @@ test.compile(verilator_flags2=["-Wno-UNOPTTHREADS", "-fno-dfg", "--stats", test.
 test.execute()
 
 if test.vlt:
-    test.file_grep(test.stats, r'Optimizations, Const bit op reduction\s+(\d+)', 45)
+    test.file_grep(test.stats, r'Optimizations, Const bit op reduction\s+(\d+)', 44)
 
 test.passes()

--- a/test_regress/t/t_opt_const_dfg.py
+++ b/test_regress/t/t_opt_const_dfg.py
@@ -18,5 +18,6 @@ test.execute()
 
 if test.vlt:
     test.file_grep(test.stats, r'Optimizations, Const bit op reduction\s+(\d+)', 39)
+    test.file_grep(test.stats, r'SplitVar, packed variables split automatically\s+(\d+)', 1)
 
 test.passes()

--- a/test_regress/t/t_opt_const_dfg.py
+++ b/test_regress/t/t_opt_const_dfg.py
@@ -17,6 +17,6 @@ test.compile(verilator_flags2=["-Wno-UNOPTTHREADS", "--stats", test.t_dir + "/t_
 test.execute()
 
 if test.vlt:
-    test.file_grep(test.stats, r'Optimizations, Const bit op reduction\s+(\d+)', 40)
+    test.file_grep(test.stats, r'Optimizations, Const bit op reduction\s+(\d+)', 39)
 
 test.passes()

--- a/test_regress/t/t_order_blkandnblk_bad.out
+++ b/test_regress/t/t_order_blkandnblk_bad.out
@@ -1,11 +1,11 @@
-%Error-BLKANDNBLK: t/t_order_blkandnblk_bad.v:17:21: Unsupported: Blocked and non-blocking assignments to same variable: 't.array'
-   17 |    logic [1:0][3:0] array;
+%Error-BLKANDNBLK: t/t_order_blkandnblk_bad.v:18:21: Unsupported: Blocked and non-blocking assignments to same variable: 't.array'
+   18 |    logic [1:0][3:0] array;
       |                     ^~~~~
-                   t/t_order_blkandnblk_bad.v:19:25: ... Location of blocking assignment
-   19 |    always_comb array[0] = i;
+                   t/t_order_blkandnblk_bad.v:20:25: ... Location of blocking assignment
+   20 |    always_comb array[0] = i;
       |                         ^
-                   t/t_order_blkandnblk_bad.v:22:15: ... Location of nonblocking assignment
-   22 |      array[1] <= array[0];
+                   t/t_order_blkandnblk_bad.v:23:15: ... Location of nonblocking assignment
+   23 |      array[1] <= array[0];
       |               ^~
                    ... For error description see https://verilator.org/warn/BLKANDNBLK?v=latest
 %Error: Exiting due to

--- a/test_regress/t/t_order_blkandnblk_bad.v
+++ b/test_regress/t/t_order_blkandnblk_bad.v
@@ -8,10 +8,11 @@ module t (/*AUTOARG*/
    // Outputs
    o,
    // Inputs
-   clk, i
+   clk, i, idx
    );
    input clk;
    input [3:0] i;
+   input idx;
    output [3:0] o;
 
    logic [1:0][3:0] array;
@@ -21,6 +22,6 @@ module t (/*AUTOARG*/
    always @ (posedge clk)
      array[1] <= array[0];
 
-   assign o = array[1];
+   assign o = array[idx];
 
 endmodule

--- a/test_regress/t/t_split_var_0.py
+++ b/test_regress/t/t_split_var_0.py
@@ -19,6 +19,7 @@ test.compile(verilator_flags2=['--stats', test.t_dir + "/t_split_var_0.vlt"],
 
 test.execute()
 
-test.file_grep(test.stats, r'SplitVar,\s+Split packed variables\s+(\d+)', 15)
-test.file_grep(test.stats, r'SplitVar,\s+Split unpacked arrays\s+(\d+)', 27)
+test.file_grep(test.stats, r'SplitVar,\s+packed variables split automatically\s+(\d+)', 0)
+test.file_grep(test.stats, r'SplitVar,\s+packed variables split due to attribute\s+(\d+)', 15)
+test.file_grep(test.stats, r'SplitVar,\s+unpacked arrays split due to attribute\s+(\d+)', 27)
 test.passes()

--- a/test_regress/t/t_split_var_2_trace.py
+++ b/test_regress/t/t_split_var_2_trace.py
@@ -21,7 +21,7 @@ test.compile(verilator_flags2=['--cc --trace --stats +define+TEST_ATTRIBUTES'],
 test.execute()
 
 test.vcd_identical(test.trace_filename, test.golden_filename)
-test.file_grep(test.stats, r'SplitVar,\s+Split packed variables\s+(\d+)', 12)
-test.file_grep(test.stats, r'SplitVar,\s+Split unpacked arrays\s+(\d+)', 27)
+test.file_grep(test.stats, r'SplitVar,\s+packed variables split due to attribute\s+(\d+)', 12)
+test.file_grep(test.stats, r'SplitVar,\s+unpacked arrays split due to attribute\s+(\d+)', 27)
 
 test.passes()

--- a/test_regress/t/t_split_var_3_wreal.py
+++ b/test_regress/t/t_split_var_3_wreal.py
@@ -15,7 +15,7 @@ test.compile(verilator_flags2=['--stats'])
 
 test.execute()
 
-test.file_grep(test.stats, r'SplitVar,\s+Split packed variables\s+(\d+)', 0)
-test.file_grep(test.stats, r'SplitVar,\s+Split unpacked arrays\s+(\d+)', 3)
+test.file_grep(test.stats, r'SplitVar,\s+packed variables split due to attribute\s+(\d+)', 0)
+test.file_grep(test.stats, r'SplitVar,\s+unpacked arrays split due to attribute\s+(\d+)', 3)
 
 test.passes()

--- a/test_regress/t/t_split_var_4.py
+++ b/test_regress/t/t_split_var_4.py
@@ -15,7 +15,7 @@ test.compile(verilator_flags2=['--stats', '-DENABLE_SPLIT_VAR=1'])
 
 test.execute()
 
-test.file_grep(test.stats, r'SplitVar,\s+Split packed variables\s+(\d+)', 1)
-test.file_grep(test.stats, r'SplitVar,\s+Split unpacked arrays\s+(\d+)', 0)
+test.file_grep(test.stats, r'SplitVar,\s+packed variables split due to attribute\s+(\d+)', 1)
+test.file_grep(test.stats, r'SplitVar,\s+unpacked arrays split due to attribute\s+(\d+)', 0)
 
 test.passes()

--- a/test_regress/t/t_split_var_5.py
+++ b/test_regress/t/t_split_var_5.py
@@ -16,7 +16,7 @@ test.compile(verilator_flags2=['--stats'])
 
 test.execute()
 
-test.file_grep(test.stats, r'SplitVar,\s+Split packed variables\s+(\d+)', 0)
-test.file_grep(test.stats, r'SplitVar,\s+Split unpacked arrays\s+(\d+)', 0)
+test.file_grep(test.stats, r'SplitVar,\s+packed variables split due to attribute\s+(\d+)', 0)
+test.file_grep(test.stats, r'SplitVar,\s+unpacked arrays split due to attribute\s+(\d+)', 0)
 
 test.passes()

--- a/test_regress/t/t_split_var_auto.py
+++ b/test_regress/t/t_split_var_auto.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2025 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile(verilator_flags2=["--stats"])
+
+test.execute()
+
+test.file_grep(test.stats, r'SplitVar, packed variables split automatically\s+(\d+)', 1)
+
+test.passes()

--- a/test_regress/t/t_split_var_auto.v
+++ b/test_regress/t/t_split_var_auto.v
@@ -1,0 +1,85 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2025 by Wilson Snyder.
+// SPDX-License-Identifier: CC0-1.0
+
+`define stop $stop
+`define checkh(gotv,expv) do if ((gotv) !== (expv)) begin $write("%%Error: %s:%0d:  got=%0x exp=%0x (%s !== %s)\n", `__FILE__,`__LINE__, (gotv), (expv), `"gotv`", `"expv`"); `stop; end while(0);
+
+module t(/*AUTOARG*/
+   // Inputs
+   clk
+   );
+
+  input clk;
+
+  logic [31:0] cnt = 0;
+
+  logic [31:0] out0;
+  logic [31:0] out1;
+  logic [31:0] out2;
+  logic [31:0] out3;
+
+  // Splittable
+  sub #(.ADDEND(1), .FORCEABLE(1'b0)) sub_0(clk, cnt, out0);
+  // Unsplittable due to hierarchical reference
+  sub #(.ADDEND(2), .FORCEABLE(1'b0)) sub_1(clk, cnt, out1);
+  // Unsplittable due to hiererchical reference
+  sub #(.ADDEND(3), .FORCEABLE(1'b0)) sub_2(clk, cnt, out2);
+  // Unsplittable due to forceable attribute
+  sub #(.ADDEND(4), .FORCEABLE(1'b1)) sub_3(clk, cnt, out3);
+
+  task print();
+    // This hierarchical reference should prevent automatic splitting
+    $display("sub_2.gen_else.tmp[9]: %02d", sub_2.gen_else.tmp[9]);
+  endtask
+
+  always @(posedge clk) begin
+    `checkh(out0, cnt + 32'd10);
+    `checkh(out1, cnt + 32'd20);
+    `checkh(out2, cnt + 32'd30);
+    `checkh(out3, cnt + 32'd40);
+
+     // This hierarchical reference should prevent automatic splitting
+     $display("sub_1.gen_else.tmp[9]: %02d", sub_1.gen_else.tmp[9]);
+     print();
+
+     cnt <= cnt + 32'd1;
+
+     if (cnt == 20) begin
+         $write("*-* All Finished *-*\n");
+         $finish;
+     end
+  end
+
+endmodule
+
+module sub #(
+  parameter logic [31:0] ADDEND,
+  parameter logic FORCEABLE
+) (
+  input wire clk,
+  input logic [31:0] i,
+  output logic [31:0] o
+);
+  /* verilator lint_off UNOPTFLAT */
+  // Both branches do the same thing, difference is the 'forceable' attribute
+  if (FORCEABLE) begin : gen_then
+    wire logic [9:0][31:0] tmp /* verilator forceable */;
+    assign tmp[0] = i;
+    for (genvar n = 1; n < 10; ++n) begin
+      assign tmp[n] = tmp[n-1] + ADDEND;
+    end
+    assign o = tmp[9] + ADDEND;
+  end else begin : gen_else
+    wire logic [9:0][31:0] tmp;
+    assign tmp[0] = i;
+    for (genvar n = 1; n < 10; ++n) begin
+      assign tmp[n] = tmp[n-1] + ADDEND;
+    end
+    assign o = tmp[9] + ADDEND;
+  end
+
+  /* verilator lint_on UNOPTFLAT */
+endmodule


### PR DESCRIPTION
This patch adds a heuristic to V3SplitVar, and it attempts to split up packed variables that are only referenced via constant-index, non-overlapping bit/range selects. This can eliminate some UNOPTFLAT cases.

Here is the effect on simulation speed:
```
execute - Sim speed [kHz] - higher is better
╒═══════════════════════════════════╤════╤════╤══════════════════╤══════════════════╤════════════╤═════════╕
│ Case                              │ #A │ #B │           Mean A │           Mean B │ Gain (B/A) │ p-value │
╞═══════════════════════════════════╪════╪════╪══════════════════╪══════════════════╪════════════╪═════════╡
│ OpenTitan:default:sha             │  5 │  5 │   6.36 (± 3.89%) │   7.29 (± 1.20%) │      1.15x │    0.00 │
│ VeeR-EH1:default:cmark            │  5 │  5 │ 198.64 (± 0.58%) │ 200.75 (± 0.31%) │      1.01x │    0.02 │
│ VeeR-EH2:default:cmark_iccm_mt    │  5 │  5 │  42.42 (± 1.67%) │  42.31 (± 0.40%) │      1.00x │    0.78 │
│ VeeR-EL2:default:dhry             │  5 │  5 │ 106.15 (± 1.16%) │ 114.74 (± 0.69%) │      1.08x │    0.00 │
│ Vortex:mini:sgemm                 │  5 │  5 │  56.27 (± 0.90%) │ 140.37 (± 1.89%) │      2.49x │    0.00 │
│ Vortex:sane:saxpy                 │  5 │  5 │   2.13 (± 0.83%) │   6.28 (± 1.33%) │      2.95x │    0.00 │
│ XiangShan:mini-chisel3:microbench │  5 │  5 │   5.30 (± 2.06%) │   5.31 (± 1.58%) │      1.00x │    0.95 │
│ XiangShan:mini-chisel6:cmark      │  5 │  5 │   5.90 (± 1.69%) │   5.90 (± 2.06%) │      1.00x │    0.93 │
│ XuanTie-C906:default:cmark        │  5 │  5 │  44.01 (± 1.25%) │  64.33 (± 0.93%) │      1.46x │    0.00 │
│ XuanTie-C910:default:memcpy       │  5 │  5 │   3.94 (± 0.76%) │   4.29 (± 1.28%) │      1.09x │    0.00 │
│ XuanTie-E902:default:memcpy       │  5 │  5 │  44.38 (± 1.02%) │  44.21 (± 0.92%) │      1.00x │    0.62 │
│ XuanTie-E906:default:cmark        │  5 │  5 │  32.17 (± 0.78%) │  31.99 (± 0.67%) │      0.99x │    0.30 │
╞═══════════════════════════════════╪════╪════╪══════════════════╪══════════════════╪════════════╪═════════╡
│ Geometric mean                    │    │    │                  │                  │      1.25x │         │
│ Geometric mean - pVal < 0.05      │    │    │                  │                  │      1.47x │         │
╘═══════════════════════════════════╧════╧════╧══════════════════╧══════════════════╧════════════╧═════════╛
```

On the bigger Vortex case, where this gets you almost 3x, this patch reduces the number of UNOPTFLAT warnings from 4991 to 877 by splitting up 350 variables.

On XuanTie-C906, it eliminates all 100 UNOPTFLAT warnings.

It also seems this is otherwise fairly performance neutral so I think it should be ok to turn on by default.

I am somewhat concerned this will shake out more bugs in V3SplitVar, like it did #5842, though it passes with everything I have.
