### PR TITLE
Fix streaming of unpacked arrays concatenations

### DIFF
--- a/src/V3Premit.cpp
+++ b/src/V3Premit.cpp
@@ -198,7 +198,7 @@ class PremitVisitor final : public VNVisitor {
     void visit(AstNodeAssign* nodep) override {
         START_STATEMENT_OR_RETURN(nodep);
 
-        if (AstCvtArrayToPacked* packedp = VN_CAST(nodep->lhsp(), CvtArrayToPacked)) {
+        if (AstCvtArrayToPacked* const packedp = VN_CAST(nodep->lhsp(), CvtArrayToPacked)) {
             // AstCvtArrayToPacked is converted to VL_PACK, which returns rvalue,
             // so it shouldn't be on the LHS. It is now replaced with unpacking of RHS.
             AstNodeExpr* const exprLhsp = packedp->fromp()->unlinkFrBack();

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -613,13 +613,27 @@ class WidthVisitor final : public VNVisitor {
                 iterateCheckSizedSelf(nodep, "LHS", nodep->lhsp(), SELF, BOTH);
                 iterateCheckSizedSelf(nodep, "RHS", nodep->rhsp(), SELF, BOTH);
 
-                if (VN_IS(nodep->lhsp()->dtypep(), UnpackArrayDType)) {
+                if (AstUnpackArrayDType* const unpackDTypep
+                    = VN_CAST(nodep->lhsp()->dtypep(), UnpackArrayDType)) {
+                    const int unpackMinBits = unpackDTypep->arrayUnpackedElements()
+                                              * unpackDTypep->subDTypep()->widthMin();
+                    const int unpackBits = unpackDTypep->arrayUnpackedElements()
+                                           * unpackDTypep->subDTypep()->width();
                     AstNodeExpr* const lhsp = nodep->lhsp()->unlinkFrBack();
-                    nodep->lhsp(new AstCvtArrayToPacked{lhsp->fileline(), lhsp, lhsp->dtypep()});
+                    nodep->lhsp(new AstCvtArrayToPacked{lhsp->fileline(), lhsp, nullptr});
+                    nodep->lhsp()->dtypeSetLogicUnsized(unpackBits, unpackMinBits,
+                                                        VSigning::UNSIGNED);
                 }
-                if (VN_IS(nodep->rhsp()->dtypep(), UnpackArrayDType)) {
+                if (AstUnpackArrayDType* const unpackDTypep
+                    = VN_CAST(nodep->rhsp()->dtypep(), UnpackArrayDType)) {
+                    const int unpackMinBits = unpackDTypep->arrayUnpackedElements()
+                                              * unpackDTypep->subDTypep()->widthMin();
+                    const int unpackBits = unpackDTypep->arrayUnpackedElements()
+                                           * unpackDTypep->subDTypep()->width();
                     AstNodeExpr* const rhsp = nodep->rhsp()->unlinkFrBack();
-                    nodep->rhsp(new AstCvtArrayToPacked{rhsp->fileline(), rhsp, rhsp->dtypep()});
+                    nodep->rhsp(new AstCvtArrayToPacked{rhsp->fileline(), rhsp, nullptr});
+                    nodep->rhsp()->dtypeSetLogicUnsized(unpackBits, unpackMinBits,
+                                                        VSigning::UNSIGNED);
                 }
                 nodep->dtypeSetLogicUnsized(nodep->lhsp()->width() + nodep->rhsp()->width(),
                                             nodep->lhsp()->widthMin() + nodep->rhsp()->widthMin(),

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -612,6 +612,15 @@ class WidthVisitor final : public VNVisitor {
             } else {
                 iterateCheckSizedSelf(nodep, "LHS", nodep->lhsp(), SELF, BOTH);
                 iterateCheckSizedSelf(nodep, "RHS", nodep->rhsp(), SELF, BOTH);
+
+                if (VN_IS(nodep->lhsp()->dtypep(), UnpackArrayDType)) {
+                    AstNodeExpr* const lhsp = nodep->lhsp()->unlinkFrBack();
+                    nodep->lhsp(new AstCvtArrayToPacked{lhsp->fileline(), lhsp, lhsp->dtypep()});
+                }
+                if (VN_IS(nodep->rhsp()->dtypep(), UnpackArrayDType)) {
+                    AstNodeExpr* const rhsp = nodep->rhsp()->unlinkFrBack();
+                    nodep->rhsp(new AstCvtArrayToPacked{rhsp->fileline(), rhsp, rhsp->dtypep()});
+                }
                 nodep->dtypeSetLogicUnsized(nodep->lhsp()->width() + nodep->rhsp()->width(),
                                             nodep->lhsp()->widthMin() + nodep->rhsp()->widthMin(),
                                             VSigning::UNSIGNED);

--- a/test_regress/t/t_stream_unpack.v
+++ b/test_regress/t/t_stream_unpack.v
@@ -25,6 +25,8 @@ module t (/*AUTOARG*/);
       logic [1:0] b [3] = {1, 2, 0};
       logic c [4] = {1, 1, 0, 0};
       logic [15:0] d;
+      logic [3:0] e [2];
+      logic f [8];
 
       { >> bit {arr}} = bit6;
       `checkp(arr, "'{'h1, 'h1, 'h1, 'h0, 'h0, 'h0} ");
@@ -83,8 +85,16 @@ module t (/*AUTOARG*/);
       d = { >> {a, b, c}};
       `checkh(d, 16'b0100110110001100);
 
+      { >> {e, f}} = d;
+      `checkp(e, "'{'h4, 'hd} ");
+      `checkp(f, "'{'h1, 'h0, 'h0, 'h0, 'h1, 'h1, 'h0, 'h0} ");
+
       d = { << 4 {a, b, c}};
       `checkh(d, 16'b1100100011010100);
+
+      { << 2 {e, f}} = d;
+      `checkp(e, "'{'h1, 'h7} ");
+      `checkp(f, "'{'h0, 'h0, 'h1, 'h0, 'h0, 'h0, 'h1, 'h1} ");
 
       $write("*-* All Finished *-*\n");
       $finish;

--- a/test_regress/t/t_stream_unpack.v
+++ b/test_regress/t/t_stream_unpack.v
@@ -21,6 +21,10 @@ module t (/*AUTOARG*/);
       bit [5:0] bit6 = 6'b111000;
       bit [5:0] ans;
       enum_t ans_enum;
+      logic [1:0] a [3] = {1, 0, 3};
+      logic [1:0] b [3] = {1, 2, 0};
+      logic c [4] = {1, 1, 0, 0};
+      logic [15:0] d;
 
       { >> bit {arr}} = bit6;
       `checkp(arr, "'{'h1, 'h1, 'h1, 'h0, 'h0, 'h0} ");
@@ -75,6 +79,12 @@ module t (/*AUTOARG*/);
 
       ans_enum = enum_t'({ << bit[5:0] {arr6} });
       `checkh(ans_enum, bit6);
+
+      d = { >> {a, b, c}};
+      `checkh(d, 16'b0100110110001100);
+
+      d = { << 4 {a, b, c}};
+      `checkh(d, 16'b1100100011010100);
 
       $write("*-* All Finished *-*\n");
       $finish;


### PR DESCRIPTION
Stream expressions containing concatenation of unpacked arrays don't work on master. This PR fixes it by wrapping unpacked arrays into `AstCvtArrayToPacked`.