### PR TITLE
Add algorithm header to V3Os.cpp (for std::replace).

### DIFF
--- a/src/V3Os.cpp
+++ b/src/V3Os.cpp
@@ -57,6 +57,7 @@ VL_DEFINE_DEBUG_FUNCTIONS;
 // clang-format off
 #if defined(_WIN32) || defined(__MINGW32__)
 # include <windows.h>   // LONG for bcrypt.h on MINGW
+# include <algorithm>  // replace
 # include <bcrypt.h>  // BCryptGenRandom
 # include <chrono>
 # include <direct.h>  // mkdir


### PR DESCRIPTION
This PR is analogous to https://github.com/verilator/verilator/pull/3493, except a different file and a different header. Fixes MinGW builds complaining about `std` namespace not having `replace`.