### PR TITLE
Fix change detection at time 0

### DIFF
--- a/test_regress/t/t_debug_width.out
+++ b/test_regress/t/t_debug_width.out
@@ -1,4 +1,4 @@
-%Error: Internal Error: t/t_opt_const.v:534:34: ../V3Ast.cpp:#: widthMismatch detected 'lhsp()->widthMin() != rhsp()->widthMin()' @ ../V3AstNodes.cpp:#OUT:(G/wu32/1) LHS:(G/w32) RHS:(G/wu32/1)
-  534 |    always_ff @(posedge clkin_data[0], posedge myfirst, posedge mysecond)
-      |                                  ^
+%Error: Internal Error: t/t_opt_const.v:12:8: ../V3Ast.cpp:#: widthMismatch detected 'lhsp()->widthMin() != rhsp()->widthMin()' @ ../V3AstNodes.cpp:#OUT:(G/wu32/1) LHS:(G/w32) RHS:(G/wu32/1)
+   12 | module t( 
+      |        ^
                         ... See the manual at https://verilator.org/verilator_doc.html for more assistance.

--- a/test_regress/t/t_flag_csplit_groups.py
+++ b/test_regress/t/t_flag_csplit_groups.py
@@ -124,7 +124,7 @@ test.file_grep_not(test.obj_dir + "/" + test.vm_prefix + "_classes.mk", "vm_clas
 test.file_grep_not(test.obj_dir + "/" + test.vm_prefix + "_classes.mk", "vm_classes_2")
 
 # Check combine count
-test.file_grep(test.stats, r'Node count, CFILE + (\d+)', (232 if test.vltmt else 212))
+test.file_grep(test.stats, r'Node count, CFILE + (\d+)', (231 if test.vltmt else 211))
 test.file_grep(test.stats, r'Makefile targets, VM_CLASSES_FAST + (\d+)', 2)
 test.file_grep(test.stats, r'Makefile targets, VM_CLASSES_SLOW + (\d+)', 2)
 

--- a/test_regress/t/t_json_only_debugcheck.out
+++ b/test_regress/t/t_json_only_debugcheck.out
@@ -20,33 +20,33 @@
       {"type":"STMTEXPR","name":"","addr":"(AB)","loc":"d,11:8,11:9",
        "exprp": [
         {"type":"CCALL","name":"","addr":"(BB)","loc":"d,11:8,11:9","dtypep":"(CB)","funcName":"_eval_static__TOP","funcp":"(DB)","argsp": []}
-      ]}
+      ]},
+      {"type":"ASSIGN","name":"","addr":"(EB)","loc":"d,61:22,61:25","dtypep":"(FB)",
+       "rhsp": [
+        {"type":"VARREF","name":"clk","addr":"(GB)","loc":"d,61:22,61:25","dtypep":"(FB)","access":"RD","varp":"(J)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+      ],
+       "lhsp": [
+        {"type":"VARREF","name":"__Vtrigprevexpr___TOP__clk__0","addr":"(HB)","loc":"d,61:22,61:25","dtypep":"(FB)","access":"WR","varp":"(N)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+      ],"timingControlp": []}
     ],"finalsp": []},
     {"type":"CFUNC","name":"_eval_static__TOP","addr":"(DB)","loc":"d,11:8,11:9","slow":true,"isStatic":false,"dpiExportDispatcher":false,"dpiExportImpl":false,"dpiImportPrototype":false,"dpiImportWrapper":false,"dpiContext":false,"isConstructor":false,"isDestructor":false,"isVirtual":false,"isCoroutine":false,"needProcess":false,"scopep":"(Y)","argsp": [],"initsp": [],
      "stmtsp": [
-      {"type":"ASSIGN","name":"","addr":"(EB)","loc":"d,23:23,23:24","dtypep":"(R)",
+      {"type":"ASSIGN","name":"","addr":"(IB)","loc":"d,23:23,23:24","dtypep":"(R)",
        "rhsp": [
-        {"type":"CONST","name":"32'sh0","addr":"(FB)","loc":"d,23:23,23:24","dtypep":"(GB)"}
+        {"type":"CONST","name":"32'sh0","addr":"(JB)","loc":"d,23:23,23:24","dtypep":"(KB)"}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"t.cyc","addr":"(HB)","loc":"d,23:23,23:24","dtypep":"(R)","access":"WR","varp":"(Q)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"t.cyc","addr":"(LB)","loc":"d,23:23,23:24","dtypep":"(R)","access":"WR","varp":"(Q)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []}
     ],"finalsp": []},
-    {"type":"CFUNC","name":"_eval_initial","addr":"(IB)","loc":"a,0:0,0:0","slow":true,"isStatic":false,"dpiExportDispatcher":false,"dpiExportImpl":false,"dpiImportPrototype":false,"dpiImportWrapper":false,"dpiContext":false,"isConstructor":false,"isDestructor":false,"isVirtual":false,"isCoroutine":false,"needProcess":false,"scopep":"(Y)","argsp": [],"initsp": [],
+    {"type":"CFUNC","name":"_eval_initial","addr":"(MB)","loc":"a,0:0,0:0","slow":true,"isStatic":false,"dpiExportDispatcher":false,"dpiExportImpl":false,"dpiImportPrototype":false,"dpiImportWrapper":false,"dpiContext":false,"isConstructor":false,"isDestructor":false,"isVirtual":false,"isCoroutine":false,"needProcess":false,"scopep":"(Y)","argsp": [],"initsp": [],
      "stmtsp": [
-      {"type":"STMTEXPR","name":"","addr":"(JB)","loc":"d,11:8,11:9",
+      {"type":"STMTEXPR","name":"","addr":"(NB)","loc":"d,11:8,11:9",
        "exprp": [
-        {"type":"CCALL","name":"","addr":"(KB)","loc":"d,11:8,11:9","dtypep":"(CB)","funcName":"_eval_initial__TOP","funcp":"(LB)","argsp": []}
-      ]},
-      {"type":"ASSIGN","name":"","addr":"(MB)","loc":"d,61:22,61:25","dtypep":"(NB)",
-       "rhsp": [
-        {"type":"VARREF","name":"clk","addr":"(OB)","loc":"d,61:22,61:25","dtypep":"(NB)","access":"RD","varp":"(J)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
-      ],
-       "lhsp": [
-        {"type":"VARREF","name":"__Vtrigprevexpr___TOP__clk__0","addr":"(PB)","loc":"d,61:22,61:25","dtypep":"(NB)","access":"WR","varp":"(N)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
-      ],"timingControlp": []}
+        {"type":"CCALL","name":"","addr":"(OB)","loc":"d,11:8,11:9","dtypep":"(CB)","funcName":"_eval_initial__TOP","funcp":"(PB)","argsp": []}
+      ]}
     ],"finalsp": []},
-    {"type":"CFUNC","name":"_eval_initial__TOP","addr":"(LB)","loc":"d,11:8,11:9","slow":true,"isStatic":false,"dpiExportDispatcher":false,"dpiExportImpl":false,"dpiImportPrototype":false,"dpiImportWrapper":false,"dpiContext":false,"isConstructor":false,"isDestructor":false,"isVirtual":false,"isCoroutine":false,"needProcess":false,"scopep":"(Y)","argsp": [],
+    {"type":"CFUNC","name":"_eval_initial__TOP","addr":"(PB)","loc":"d,11:8,11:9","slow":true,"isStatic":false,"dpiExportDispatcher":false,"dpiExportImpl":false,"dpiImportPrototype":false,"dpiImportWrapper":false,"dpiContext":false,"isConstructor":false,"isDestructor":false,"isVirtual":false,"isCoroutine":false,"needProcess":false,"scopep":"(Y)","argsp": [],
      "initsp": [
       {"type":"VAR","name":"t.all","addr":"(QB)","loc":"d,28:11,28:14","dtypep":"(RB)","origName":"t__DOT__all","isSc":false,"isPrimaryIO":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":true,"attrClocker":"UNKNOWN","lifetime":"NONE","varType":"VAR","dtypeName":"string","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"ignorePostWrite":false,"ignoreSchedWrite":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
       {"type":"CRESET","name":"","addr":"(SB)","loc":"d,28:11,28:14","constructing":true,
@@ -70,7 +70,7 @@
       ],"timingControlp": []},
       {"type":"IF","name":"","addr":"(DC)","loc":"d,38:10,38:12",
        "condp": [
-        {"type":"NEQ","name":"","addr":"(EC)","loc":"d,38:26,38:29","dtypep":"(NB)",
+        {"type":"NEQ","name":"","addr":"(EC)","loc":"d,38:26,38:29","dtypep":"(FB)",
          "lhsp": [
           {"type":"CONST","name":"4'h4","addr":"(FC)","loc":"d,38:31,38:34","dtypep":"(AC)"}
         ],
@@ -120,7 +120,7 @@
       ],"elsesp": []},
       {"type":"IF","name":"","addr":"(ZC)","loc":"d,39:10,39:12",
        "condp": [
-        {"type":"NEQ","name":"","addr":"(AD)","loc":"d,39:34,39:37","dtypep":"(NB)",
+        {"type":"NEQ","name":"","addr":"(AD)","loc":"d,39:34,39:37","dtypep":"(FB)",
          "lhsp": [
           {"type":"CONST","name":"4'h1","addr":"(BD)","loc":"d,39:39,39:42","dtypep":"(AC)"}
         ],
@@ -194,7 +194,7 @@
       ],"elsesp": []},
       {"type":"IF","name":"","addr":"(ZD)","loc":"d,40:10,40:12",
        "condp": [
-        {"type":"NEQ","name":"","addr":"(AE)","loc":"d,40:26,40:29","dtypep":"(NB)",
+        {"type":"NEQ","name":"","addr":"(AE)","loc":"d,40:26,40:29","dtypep":"(FB)",
          "lhsp": [
           {"type":"CONST","name":"4'h1","addr":"(BE)","loc":"d,40:31,40:34","dtypep":"(AC)"}
         ],
@@ -268,7 +268,7 @@
       ],"elsesp": []},
       {"type":"IF","name":"","addr":"(ZE)","loc":"d,41:10,41:12",
        "condp": [
-        {"type":"NEQ","name":"","addr":"(AF)","loc":"d,41:42,41:45","dtypep":"(NB)",
+        {"type":"NEQ","name":"","addr":"(AF)","loc":"d,41:42,41:45","dtypep":"(FB)",
          "lhsp": [
           {"type":"CONST","name":"4'h3","addr":"(BF)","loc":"d,41:47,41:50","dtypep":"(AC)"}
         ],
@@ -366,7 +366,7 @@
       ],"elsesp": []},
       {"type":"IF","name":"","addr":"(HG)","loc":"d,42:10,42:12",
        "condp": [
-        {"type":"NEQ","name":"","addr":"(IG)","loc":"d,42:34,42:37","dtypep":"(NB)",
+        {"type":"NEQ","name":"","addr":"(IG)","loc":"d,42:34,42:37","dtypep":"(FB)",
          "lhsp": [
           {"type":"CONST","name":"4'h3","addr":"(JG)","loc":"d,42:39,42:42","dtypep":"(AC)"}
         ],
@@ -464,7 +464,7 @@
       ],"elsesp": []},
       {"type":"IF","name":"","addr":"(PH)","loc":"d,43:10,43:12",
        "condp": [
-        {"type":"NEQ","name":"","addr":"(QH)","loc":"d,43:26,43:29","dtypep":"(NB)",
+        {"type":"NEQ","name":"","addr":"(QH)","loc":"d,43:26,43:29","dtypep":"(FB)",
          "lhsp": [
           {"type":"CONST","name":"4'h3","addr":"(RH)","loc":"d,43:31,43:34","dtypep":"(AC)"}
         ],
@@ -562,7 +562,7 @@
       ],"elsesp": []},
       {"type":"IF","name":"","addr":"(XI)","loc":"d,44:10,44:12",
        "condp": [
-        {"type":"NEQ","name":"","addr":"(YI)","loc":"d,44:23,44:26","dtypep":"(NB)",
+        {"type":"NEQ","name":"","addr":"(YI)","loc":"d,44:23,44:26","dtypep":"(FB)",
          "lhsp": [
           {"type":"CONST","name":"4'h1","addr":"(ZI)","loc":"d,44:28,44:31","dtypep":"(AC)"}
         ],
@@ -612,7 +612,7 @@
       ],"elsesp": []},
       {"type":"IF","name":"","addr":"(RJ)","loc":"d,45:10,45:12",
        "condp": [
-        {"type":"NEQ","name":"","addr":"(SJ)","loc":"d,45:26,45:29","dtypep":"(NB)",
+        {"type":"NEQ","name":"","addr":"(SJ)","loc":"d,45:26,45:29","dtypep":"(FB)",
          "lhsp": [
           {"type":"CONST","name":"4'h1","addr":"(TJ)","loc":"d,45:31,45:34","dtypep":"(AC)"}
         ],
@@ -662,7 +662,7 @@
       ],"elsesp": []},
       {"type":"IF","name":"","addr":"(JK)","loc":"d,46:10,46:12",
        "condp": [
-        {"type":"NEQ","name":"","addr":"(KK)","loc":"d,46:34,46:37","dtypep":"(NB)",
+        {"type":"NEQ","name":"","addr":"(KK)","loc":"d,46:34,46:37","dtypep":"(FB)",
          "lhsp": [
           {"type":"CONST","name":"4'h4","addr":"(LK)","loc":"d,46:39,46:42","dtypep":"(AC)"}
         ],
@@ -736,7 +736,7 @@
       ],"elsesp": []},
       {"type":"IF","name":"","addr":"(JL)","loc":"d,47:10,47:12",
        "condp": [
-        {"type":"NEQ","name":"","addr":"(KL)","loc":"d,47:26,47:29","dtypep":"(NB)",
+        {"type":"NEQ","name":"","addr":"(KL)","loc":"d,47:26,47:29","dtypep":"(FB)",
          "lhsp": [
           {"type":"CONST","name":"4'h4","addr":"(LL)","loc":"d,47:31,47:34","dtypep":"(AC)"}
         ],
@@ -810,7 +810,7 @@
       ],"elsesp": []},
       {"type":"IF","name":"","addr":"(JM)","loc":"d,49:10,49:12",
        "condp": [
-        {"type":"NEQN","name":"","addr":"(KM)","loc":"d,49:23,49:25","dtypep":"(NB)",
+        {"type":"NEQN","name":"","addr":"(KM)","loc":"d,49:23,49:25","dtypep":"(FB)",
          "lhsp": [
           {"type":"CONST","name":"\\\"E03\\\"","addr":"(LM)","loc":"d,49:27,49:32","dtypep":"(RB)"}
         ],
@@ -881,7 +881,7 @@
       ],"timingControlp": []},
       {"type":"WHILE","name":"","addr":"(MN)","loc":"d,52:7,52:10","precondsp": [],
        "condp": [
-        {"type":"NEQ","name":"","addr":"(NN)","loc":"d,52:32,52:34","dtypep":"(NB)",
+        {"type":"NEQ","name":"","addr":"(NN)","loc":"d,52:32,52:34","dtypep":"(FB)",
          "lhsp": [
           {"type":"CONST","name":"4'h4","addr":"(ON)","loc":"d,52:37,52:41","dtypep":"(AC)"}
         ],
@@ -968,7 +968,7 @@
       ],"timingControlp": []},
       {"type":"IF","name":"","addr":"(RO)","loc":"d,57:10,57:12",
        "condp": [
-        {"type":"NEQN","name":"","addr":"(SO)","loc":"d,57:20,57:22","dtypep":"(NB)",
+        {"type":"NEQN","name":"","addr":"(SO)","loc":"d,57:20,57:22","dtypep":"(FB)",
          "lhsp": [
           {"type":"CONST","name":"\\\"E01E03E04\\\"","addr":"(TO)","loc":"d,57:24,57:35","dtypep":"(RB)"}
         ],
@@ -995,34 +995,34 @@
        "exprp": [
         {"type":"CMETHODHARD","name":"setBit","addr":"(DP)","loc":"d,11:8,11:9","dtypep":"(CB)",
          "fromp": [
-          {"type":"VARREF","name":"__VactTriggered","addr":"(EP)","loc":"d,11:8,11:9","dtypep":"(NB)","access":"WR","varp":"(U)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+          {"type":"VARREF","name":"__VactTriggered","addr":"(EP)","loc":"d,11:8,11:9","dtypep":"(FB)","access":"WR","varp":"(U)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
         ],
          "pinsp": [
           {"type":"CONST","name":"32'h0","addr":"(FP)","loc":"d,11:8,11:9","dtypep":"(NC)"},
-          {"type":"AND","name":"","addr":"(GP)","loc":"d,61:14,61:21","dtypep":"(NB)",
+          {"type":"AND","name":"","addr":"(GP)","loc":"d,61:14,61:21","dtypep":"(FB)",
            "lhsp": [
-            {"type":"CCAST","name":"","addr":"(HP)","loc":"d,61:22,61:25","dtypep":"(NB)","size":32,
+            {"type":"CCAST","name":"","addr":"(HP)","loc":"d,61:22,61:25","dtypep":"(FB)","size":32,
              "lhsp": [
-              {"type":"VARREF","name":"clk","addr":"(IP)","loc":"d,61:22,61:25","dtypep":"(NB)","access":"RD","varp":"(J)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+              {"type":"VARREF","name":"clk","addr":"(IP)","loc":"d,61:22,61:25","dtypep":"(FB)","access":"RD","varp":"(J)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
             ]}
           ],
            "rhsp": [
-            {"type":"NOT","name":"","addr":"(JP)","loc":"d,61:14,61:21","dtypep":"(NB)",
+            {"type":"NOT","name":"","addr":"(JP)","loc":"d,61:14,61:21","dtypep":"(FB)",
              "lhsp": [
-              {"type":"CCAST","name":"","addr":"(KP)","loc":"d,61:14,61:21","dtypep":"(NB)","size":32,
+              {"type":"CCAST","name":"","addr":"(KP)","loc":"d,61:14,61:21","dtypep":"(FB)","size":32,
                "lhsp": [
-                {"type":"VARREF","name":"__Vtrigprevexpr___TOP__clk__0","addr":"(LP)","loc":"d,61:14,61:21","dtypep":"(NB)","access":"RD","varp":"(N)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                {"type":"VARREF","name":"__Vtrigprevexpr___TOP__clk__0","addr":"(LP)","loc":"d,61:14,61:21","dtypep":"(FB)","access":"RD","varp":"(N)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
               ]}
             ]}
           ]}
         ]}
       ]},
-      {"type":"ASSIGN","name":"","addr":"(MP)","loc":"d,61:22,61:25","dtypep":"(NB)",
+      {"type":"ASSIGN","name":"","addr":"(MP)","loc":"d,61:22,61:25","dtypep":"(FB)",
        "rhsp": [
-        {"type":"VARREF","name":"clk","addr":"(NP)","loc":"d,61:22,61:25","dtypep":"(NB)","access":"RD","varp":"(J)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"clk","addr":"(NP)","loc":"d,61:22,61:25","dtypep":"(FB)","access":"RD","varp":"(J)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"__Vtrigprevexpr___TOP__clk__0","addr":"(OP)","loc":"d,61:22,61:25","dtypep":"(NB)","access":"WR","varp":"(N)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"__Vtrigprevexpr___TOP__clk__0","addr":"(OP)","loc":"d,61:22,61:25","dtypep":"(FB)","access":"WR","varp":"(N)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []},
       {"type":"TEXTBLOCK","name":"","addr":"(PP)","loc":"d,11:8,11:9","shortText":"",
        "nodesp": [
@@ -1040,16 +1040,16 @@
      "stmtsp": [
       {"type":"IF","name":"","addr":"(XP)","loc":"d,11:8,11:9",
        "condp": [
-        {"type":"AND","name":"","addr":"(YP)","loc":"d,11:8,11:9","dtypep":"(NB)",
+        {"type":"AND","name":"","addr":"(YP)","loc":"d,11:8,11:9","dtypep":"(FB)",
          "lhsp": [
           {"type":"CONST","name":"32'h1","addr":"(ZP)","loc":"d,11:8,11:9","dtypep":"(NC)"}
         ],
          "rhsp": [
-          {"type":"NOT","name":"","addr":"(AQ)","loc":"d,11:8,11:9","dtypep":"(NB)",
+          {"type":"NOT","name":"","addr":"(AQ)","loc":"d,11:8,11:9","dtypep":"(FB)",
            "lhsp": [
-            {"type":"CMETHODHARD","name":"any","addr":"(BQ)","loc":"d,11:8,11:9","dtypep":"(NB)",
+            {"type":"CMETHODHARD","name":"any","addr":"(BQ)","loc":"d,11:8,11:9","dtypep":"(FB)",
              "fromp": [
-              {"type":"VARREF","name":"__VactTriggered","addr":"(CQ)","loc":"d,11:8,11:9","dtypep":"(NB)","access":"RD","varp":"(U)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+              {"type":"VARREF","name":"__VactTriggered","addr":"(CQ)","loc":"d,11:8,11:9","dtypep":"(FB)","access":"RD","varp":"(U)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
             ],"pinsp": []}
           ]}
         ]}
@@ -1066,7 +1066,7 @@
          "rhsp": [
           {"type":"CMETHODHARD","name":"word","addr":"(IQ)","loc":"d,11:8,11:9","dtypep":"(JQ)",
            "fromp": [
-            {"type":"VARREF","name":"__VactTriggered","addr":"(KQ)","loc":"d,11:8,11:9","dtypep":"(NB)","access":"RD","varp":"(U)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"__VactTriggered","addr":"(KQ)","loc":"d,11:8,11:9","dtypep":"(FB)","access":"RD","varp":"(U)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ],
            "pinsp": [
             {"type":"CONST","name":"32'h0","addr":"(LQ)","loc":"d,11:8,11:9","dtypep":"(NC)"}
@@ -1081,16 +1081,16 @@
      "stmtsp": [
       {"type":"IF","name":"","addr":"(OQ)","loc":"d,11:8,11:9",
        "condp": [
-        {"type":"AND","name":"","addr":"(PQ)","loc":"d,11:8,11:9","dtypep":"(NB)",
+        {"type":"AND","name":"","addr":"(PQ)","loc":"d,11:8,11:9","dtypep":"(FB)",
          "lhsp": [
           {"type":"CONST","name":"32'h1","addr":"(QQ)","loc":"d,11:8,11:9","dtypep":"(NC)"}
         ],
          "rhsp": [
-          {"type":"NOT","name":"","addr":"(RQ)","loc":"d,11:8,11:9","dtypep":"(NB)",
+          {"type":"NOT","name":"","addr":"(RQ)","loc":"d,11:8,11:9","dtypep":"(FB)",
            "lhsp": [
-            {"type":"CMETHODHARD","name":"any","addr":"(SQ)","loc":"d,11:8,11:9","dtypep":"(NB)",
+            {"type":"CMETHODHARD","name":"any","addr":"(SQ)","loc":"d,11:8,11:9","dtypep":"(FB)",
              "fromp": [
-              {"type":"VARREF","name":"__VnbaTriggered","addr":"(TQ)","loc":"d,11:8,11:9","dtypep":"(NB)","access":"RD","varp":"(W)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+              {"type":"VARREF","name":"__VnbaTriggered","addr":"(TQ)","loc":"d,11:8,11:9","dtypep":"(FB)","access":"RD","varp":"(W)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
             ],"pinsp": []}
           ]}
         ]}
@@ -1107,7 +1107,7 @@
          "rhsp": [
           {"type":"CMETHODHARD","name":"word","addr":"(YQ)","loc":"d,11:8,11:9","dtypep":"(JQ)",
            "fromp": [
-            {"type":"VARREF","name":"__VnbaTriggered","addr":"(ZQ)","loc":"d,11:8,11:9","dtypep":"(NB)","access":"RD","varp":"(W)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"__VnbaTriggered","addr":"(ZQ)","loc":"d,11:8,11:9","dtypep":"(FB)","access":"RD","varp":"(W)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ],
            "pinsp": [
             {"type":"CONST","name":"32'h0","addr":"(AR)","loc":"d,11:8,11:9","dtypep":"(NC)"}
@@ -1130,7 +1130,7 @@
          "rhsp": [
           {"type":"CMETHODHARD","name":"word","addr":"(GR)","loc":"d,11:8,11:9","dtypep":"(JQ)",
            "fromp": [
-            {"type":"VARREF","name":"__VnbaTriggered","addr":"(HR)","loc":"d,11:8,11:9","dtypep":"(NB)","access":"RD","varp":"(W)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"__VnbaTriggered","addr":"(HR)","loc":"d,11:8,11:9","dtypep":"(FB)","access":"RD","varp":"(W)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ],
            "pinsp": [
             {"type":"CONST","name":"32'h0","addr":"(IR)","loc":"d,11:8,11:9","dtypep":"(NC)"}
@@ -1181,7 +1181,7 @@
          "lhsp": [
           {"type":"CCAST","name":"","addr":"(DS)","loc":"d,62:20,62:21","dtypep":"(NC)","size":32,
            "lhsp": [
-            {"type":"CONST","name":"32'sh1","addr":"(ES)","loc":"d,62:20,62:21","dtypep":"(GB)"}
+            {"type":"CONST","name":"32'sh1","addr":"(ES)","loc":"d,62:20,62:21","dtypep":"(KB)"}
           ]}
         ],
          "rhsp": [
@@ -1193,9 +1193,9 @@
       ],"timingControlp": []},
       {"type":"IF","name":"","addr":"(HS)","loc":"d,63:7,63:9",
        "condp": [
-        {"type":"EQ","name":"","addr":"(IS)","loc":"d,63:14,63:16","dtypep":"(NB)",
+        {"type":"EQ","name":"","addr":"(IS)","loc":"d,63:14,63:16","dtypep":"(FB)",
          "lhsp": [
-          {"type":"CONST","name":"32'sh0","addr":"(JS)","loc":"d,63:16,63:17","dtypep":"(GB)"}
+          {"type":"CONST","name":"32'sh0","addr":"(JS)","loc":"d,63:16,63:17","dtypep":"(KB)"}
         ],
          "rhsp": [
           {"type":"VARREF","name":"t.cyc","addr":"(KS)","loc":"d,63:11,63:14","dtypep":"(R)","access":"RD","varp":"(Q)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
@@ -1213,9 +1213,9 @@
        "elsesp": [
         {"type":"IF","name":"","addr":"(OS)","loc":"d,67:12,67:14",
          "condp": [
-          {"type":"EQ","name":"","addr":"(PS)","loc":"d,67:19,67:21","dtypep":"(NB)",
+          {"type":"EQ","name":"","addr":"(PS)","loc":"d,67:19,67:21","dtypep":"(FB)",
            "lhsp": [
-            {"type":"CONST","name":"32'sh1","addr":"(QS)","loc":"d,67:21,67:22","dtypep":"(GB)"}
+            {"type":"CONST","name":"32'sh1","addr":"(QS)","loc":"d,67:21,67:22","dtypep":"(KB)"}
           ],
            "rhsp": [
             {"type":"VARREF","name":"t.cyc","addr":"(RS)","loc":"d,67:16,67:19","dtypep":"(R)","access":"RD","varp":"(Q)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
@@ -1224,7 +1224,7 @@
          "thensp": [
           {"type":"IF","name":"","addr":"(SS)","loc":"d,68:13,68:15",
            "condp": [
-            {"type":"NEQN","name":"","addr":"(TS)","loc":"d,68:26,68:28","dtypep":"(NB)",
+            {"type":"NEQN","name":"","addr":"(TS)","loc":"d,68:26,68:28","dtypep":"(FB)",
              "lhsp": [
               {"type":"CONST","name":"\\\"E01\\\"","addr":"(US)","loc":"d,68:30,68:35","dtypep":"(RB)"}
             ],
@@ -1281,7 +1281,7 @@
           ],"elsesp": []},
           {"type":"IF","name":"","addr":"(NT)","loc":"d,69:13,69:15",
            "condp": [
-            {"type":"NEQ","name":"","addr":"(OT)","loc":"d,69:26,69:29","dtypep":"(NB)",
+            {"type":"NEQ","name":"","addr":"(OT)","loc":"d,69:26,69:29","dtypep":"(FB)",
              "lhsp": [
               {"type":"CONST","name":"4'h3","addr":"(PT)","loc":"d,69:31,69:34","dtypep":"(AC)"}
             ],
@@ -1331,7 +1331,7 @@
           ],"elsesp": []},
           {"type":"IF","name":"","addr":"(FU)","loc":"d,70:13,70:15",
            "condp": [
-            {"type":"NEQ","name":"","addr":"(GU)","loc":"d,70:29,70:32","dtypep":"(NB)",
+            {"type":"NEQ","name":"","addr":"(GU)","loc":"d,70:29,70:32","dtypep":"(FB)",
              "lhsp": [
               {"type":"CONST","name":"4'h3","addr":"(HU)","loc":"d,70:34,70:37","dtypep":"(AC)"}
             ],
@@ -1381,7 +1381,7 @@
           ],"elsesp": []},
           {"type":"IF","name":"","addr":"(XU)","loc":"d,71:13,71:15",
            "condp": [
-            {"type":"NEQ","name":"","addr":"(YU)","loc":"d,71:29,71:32","dtypep":"(NB)",
+            {"type":"NEQ","name":"","addr":"(YU)","loc":"d,71:29,71:32","dtypep":"(FB)",
              "lhsp": [
               {"type":"CONST","name":"4'h4","addr":"(ZU)","loc":"d,71:34,71:37","dtypep":"(AC)"}
             ],
@@ -1455,7 +1455,7 @@
           ],"elsesp": []},
           {"type":"IF","name":"","addr":"(XV)","loc":"d,72:13,72:15",
            "condp": [
-            {"type":"NEQ","name":"","addr":"(YV)","loc":"d,72:26,72:29","dtypep":"(NB)",
+            {"type":"NEQ","name":"","addr":"(YV)","loc":"d,72:26,72:29","dtypep":"(FB)",
              "lhsp": [
               {"type":"CONST","name":"4'h4","addr":"(ZV)","loc":"d,72:31,72:34","dtypep":"(AC)"}
             ],
@@ -1505,7 +1505,7 @@
           ],"elsesp": []},
           {"type":"IF","name":"","addr":"(PW)","loc":"d,73:13,73:15",
            "condp": [
-            {"type":"NEQ","name":"","addr":"(QW)","loc":"d,73:29,73:32","dtypep":"(NB)",
+            {"type":"NEQ","name":"","addr":"(QW)","loc":"d,73:29,73:32","dtypep":"(FB)",
              "lhsp": [
               {"type":"CONST","name":"4'h4","addr":"(RW)","loc":"d,73:34,73:37","dtypep":"(AC)"}
             ],
@@ -1555,7 +1555,7 @@
           ],"elsesp": []},
           {"type":"IF","name":"","addr":"(HX)","loc":"d,74:13,74:15",
            "condp": [
-            {"type":"NEQ","name":"","addr":"(IX)","loc":"d,74:29,74:32","dtypep":"(NB)",
+            {"type":"NEQ","name":"","addr":"(IX)","loc":"d,74:29,74:32","dtypep":"(FB)",
              "lhsp": [
               {"type":"CONST","name":"4'h3","addr":"(JX)","loc":"d,74:34,74:37","dtypep":"(AC)"}
             ],
@@ -1638,9 +1638,9 @@
          "elsesp": [
           {"type":"IF","name":"","addr":"(KY)","loc":"d,77:12,77:14",
            "condp": [
-            {"type":"EQ","name":"","addr":"(LY)","loc":"d,77:19,77:21","dtypep":"(NB)",
+            {"type":"EQ","name":"","addr":"(LY)","loc":"d,77:19,77:21","dtypep":"(FB)",
              "lhsp": [
-              {"type":"CONST","name":"32'sh2","addr":"(MY)","loc":"d,77:21,77:22","dtypep":"(GB)"}
+              {"type":"CONST","name":"32'sh2","addr":"(MY)","loc":"d,77:21,77:22","dtypep":"(KB)"}
             ],
              "rhsp": [
               {"type":"VARREF","name":"t.cyc","addr":"(NY)","loc":"d,77:16,77:19","dtypep":"(R)","access":"RD","varp":"(Q)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
@@ -1649,7 +1649,7 @@
            "thensp": [
             {"type":"IF","name":"","addr":"(OY)","loc":"d,78:13,78:15",
              "condp": [
-              {"type":"NEQN","name":"","addr":"(PY)","loc":"d,78:26,78:28","dtypep":"(NB)",
+              {"type":"NEQN","name":"","addr":"(PY)","loc":"d,78:26,78:28","dtypep":"(FB)",
                "lhsp": [
                 {"type":"CONST","name":"\\\"E03\\\"","addr":"(QY)","loc":"d,78:30,78:35","dtypep":"(RB)"}
               ],
@@ -1706,7 +1706,7 @@
             ],"elsesp": []},
             {"type":"IF","name":"","addr":"(JZ)","loc":"d,79:13,79:15",
              "condp": [
-              {"type":"NEQ","name":"","addr":"(KZ)","loc":"d,79:26,79:29","dtypep":"(NB)",
+              {"type":"NEQ","name":"","addr":"(KZ)","loc":"d,79:26,79:29","dtypep":"(FB)",
                "lhsp": [
                 {"type":"CONST","name":"4'h4","addr":"(LZ)","loc":"d,79:31,79:34","dtypep":"(AC)"}
               ],
@@ -1756,7 +1756,7 @@
             ],"elsesp": []},
             {"type":"IF","name":"","addr":"(BAB)","loc":"d,80:13,80:15",
              "condp": [
-              {"type":"NEQ","name":"","addr":"(CAB)","loc":"d,80:29,80:32","dtypep":"(NB)",
+              {"type":"NEQ","name":"","addr":"(CAB)","loc":"d,80:29,80:32","dtypep":"(FB)",
                "lhsp": [
                 {"type":"CONST","name":"4'h4","addr":"(DAB)","loc":"d,80:34,80:37","dtypep":"(AC)"}
               ],
@@ -1806,7 +1806,7 @@
             ],"elsesp": []},
             {"type":"IF","name":"","addr":"(TAB)","loc":"d,81:13,81:15",
              "condp": [
-              {"type":"NEQ","name":"","addr":"(UAB)","loc":"d,81:29,81:32","dtypep":"(NB)",
+              {"type":"NEQ","name":"","addr":"(UAB)","loc":"d,81:29,81:32","dtypep":"(FB)",
                "lhsp": [
                 {"type":"CONST","name":"4'h1","addr":"(VAB)","loc":"d,81:34,81:37","dtypep":"(AC)"}
               ],
@@ -1880,7 +1880,7 @@
             ],"elsesp": []},
             {"type":"IF","name":"","addr":"(TBB)","loc":"d,82:13,82:15",
              "condp": [
-              {"type":"NEQ","name":"","addr":"(UBB)","loc":"d,82:26,82:29","dtypep":"(NB)",
+              {"type":"NEQ","name":"","addr":"(UBB)","loc":"d,82:26,82:29","dtypep":"(FB)",
                "lhsp": [
                 {"type":"CONST","name":"4'h1","addr":"(VBB)","loc":"d,82:31,82:34","dtypep":"(AC)"}
               ],
@@ -1930,7 +1930,7 @@
             ],"elsesp": []},
             {"type":"IF","name":"","addr":"(LCB)","loc":"d,83:13,83:15",
              "condp": [
-              {"type":"NEQ","name":"","addr":"(MCB)","loc":"d,83:29,83:32","dtypep":"(NB)",
+              {"type":"NEQ","name":"","addr":"(MCB)","loc":"d,83:29,83:32","dtypep":"(FB)",
                "lhsp": [
                 {"type":"CONST","name":"4'h1","addr":"(NCB)","loc":"d,83:34,83:37","dtypep":"(AC)"}
               ],
@@ -1980,7 +1980,7 @@
             ],"elsesp": []},
             {"type":"IF","name":"","addr":"(DDB)","loc":"d,84:13,84:15",
              "condp": [
-              {"type":"NEQ","name":"","addr":"(EDB)","loc":"d,84:29,84:32","dtypep":"(NB)",
+              {"type":"NEQ","name":"","addr":"(EDB)","loc":"d,84:29,84:32","dtypep":"(FB)",
                "lhsp": [
                 {"type":"CONST","name":"4'h4","addr":"(FDB)","loc":"d,84:34,84:37","dtypep":"(AC)"}
               ],
@@ -2063,9 +2063,9 @@
            "elsesp": [
             {"type":"IF","name":"","addr":"(GEB)","loc":"d,87:12,87:14",
              "condp": [
-              {"type":"EQ","name":"","addr":"(HEB)","loc":"d,87:19,87:21","dtypep":"(NB)",
+              {"type":"EQ","name":"","addr":"(HEB)","loc":"d,87:19,87:21","dtypep":"(FB)",
                "lhsp": [
-                {"type":"CONST","name":"32'sh3","addr":"(IEB)","loc":"d,87:21,87:22","dtypep":"(GB)"}
+                {"type":"CONST","name":"32'sh3","addr":"(IEB)","loc":"d,87:21,87:22","dtypep":"(KB)"}
               ],
                "rhsp": [
                 {"type":"VARREF","name":"t.cyc","addr":"(JEB)","loc":"d,87:16,87:19","dtypep":"(R)","access":"RD","varp":"(Q)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
@@ -2074,7 +2074,7 @@
              "thensp": [
               {"type":"IF","name":"","addr":"(KEB)","loc":"d,88:13,88:15",
                "condp": [
-                {"type":"NEQN","name":"","addr":"(LEB)","loc":"d,88:26,88:28","dtypep":"(NB)",
+                {"type":"NEQN","name":"","addr":"(LEB)","loc":"d,88:26,88:28","dtypep":"(FB)",
                  "lhsp": [
                   {"type":"CONST","name":"\\\"E04\\\"","addr":"(MEB)","loc":"d,88:30,88:35","dtypep":"(RB)"}
                 ],
@@ -2131,7 +2131,7 @@
               ],"elsesp": []},
               {"type":"IF","name":"","addr":"(FFB)","loc":"d,89:13,89:15",
                "condp": [
-                {"type":"NEQ","name":"","addr":"(GFB)","loc":"d,89:26,89:29","dtypep":"(NB)",
+                {"type":"NEQ","name":"","addr":"(GFB)","loc":"d,89:26,89:29","dtypep":"(FB)",
                  "lhsp": [
                   {"type":"CONST","name":"4'h1","addr":"(HFB)","loc":"d,89:31,89:34","dtypep":"(AC)"}
                 ],
@@ -2181,7 +2181,7 @@
               ],"elsesp": []},
               {"type":"IF","name":"","addr":"(XFB)","loc":"d,90:13,90:15",
                "condp": [
-                {"type":"NEQ","name":"","addr":"(YFB)","loc":"d,90:29,90:32","dtypep":"(NB)",
+                {"type":"NEQ","name":"","addr":"(YFB)","loc":"d,90:29,90:32","dtypep":"(FB)",
                  "lhsp": [
                   {"type":"CONST","name":"4'h1","addr":"(ZFB)","loc":"d,90:34,90:37","dtypep":"(AC)"}
                 ],
@@ -2231,7 +2231,7 @@
               ],"elsesp": []},
               {"type":"IF","name":"","addr":"(PGB)","loc":"d,91:13,91:15",
                "condp": [
-                {"type":"NEQ","name":"","addr":"(QGB)","loc":"d,91:29,91:32","dtypep":"(NB)",
+                {"type":"NEQ","name":"","addr":"(QGB)","loc":"d,91:29,91:32","dtypep":"(FB)",
                  "lhsp": [
                   {"type":"CONST","name":"4'h3","addr":"(RGB)","loc":"d,91:34,91:37","dtypep":"(AC)"}
                 ],
@@ -2305,7 +2305,7 @@
               ],"elsesp": []},
               {"type":"IF","name":"","addr":"(PHB)","loc":"d,92:13,92:15",
                "condp": [
-                {"type":"NEQ","name":"","addr":"(QHB)","loc":"d,92:26,92:29","dtypep":"(NB)",
+                {"type":"NEQ","name":"","addr":"(QHB)","loc":"d,92:26,92:29","dtypep":"(FB)",
                  "lhsp": [
                   {"type":"CONST","name":"4'h3","addr":"(RHB)","loc":"d,92:31,92:34","dtypep":"(AC)"}
                 ],
@@ -2355,7 +2355,7 @@
               ],"elsesp": []},
               {"type":"IF","name":"","addr":"(HIB)","loc":"d,93:13,93:15",
                "condp": [
-                {"type":"NEQ","name":"","addr":"(IIB)","loc":"d,93:29,93:32","dtypep":"(NB)",
+                {"type":"NEQ","name":"","addr":"(IIB)","loc":"d,93:29,93:32","dtypep":"(FB)",
                  "lhsp": [
                   {"type":"CONST","name":"4'h3","addr":"(JIB)","loc":"d,93:34,93:37","dtypep":"(AC)"}
                 ],
@@ -2405,7 +2405,7 @@
               ],"elsesp": []},
               {"type":"IF","name":"","addr":"(ZIB)","loc":"d,94:13,94:15",
                "condp": [
-                {"type":"NEQ","name":"","addr":"(AJB)","loc":"d,94:29,94:32","dtypep":"(NB)",
+                {"type":"NEQ","name":"","addr":"(AJB)","loc":"d,94:29,94:32","dtypep":"(FB)",
                  "lhsp": [
                   {"type":"CONST","name":"4'h1","addr":"(BJB)","loc":"d,94:34,94:37","dtypep":"(AC)"}
                 ],
@@ -2488,9 +2488,9 @@
              "elsesp": [
               {"type":"IF","name":"","addr":"(CKB)","loc":"d,97:12,97:14",
                "condp": [
-                {"type":"EQ","name":"","addr":"(DKB)","loc":"d,97:19,97:21","dtypep":"(NB)",
+                {"type":"EQ","name":"","addr":"(DKB)","loc":"d,97:19,97:21","dtypep":"(FB)",
                  "lhsp": [
-                  {"type":"CONST","name":"32'sh63","addr":"(EKB)","loc":"d,97:21,97:23","dtypep":"(GB)"}
+                  {"type":"CONST","name":"32'sh63","addr":"(EKB)","loc":"d,97:21,97:23","dtypep":"(KB)"}
                 ],
                  "rhsp": [
                   {"type":"VARREF","name":"t.cyc","addr":"(FKB)","loc":"d,97:16,97:19","dtypep":"(R)","access":"RD","varp":"(Q)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
@@ -2532,40 +2532,40 @@
        "exprp": [
         {"type":"CCALL","name":"","addr":"(TKB)","loc":"a,0:0,0:0","dtypep":"(CB)","funcName":"_eval_triggers__act","funcp":"(BP)","argsp": []}
       ]},
-      {"type":"ASSIGN","name":"","addr":"(UKB)","loc":"a,0:0,0:0","dtypep":"(NB)",
+      {"type":"ASSIGN","name":"","addr":"(UKB)","loc":"a,0:0,0:0","dtypep":"(FB)",
        "rhsp": [
-        {"type":"CMETHODHARD","name":"any","addr":"(VKB)","loc":"a,0:0,0:0","dtypep":"(NB)",
+        {"type":"CMETHODHARD","name":"any","addr":"(VKB)","loc":"a,0:0,0:0","dtypep":"(FB)",
          "fromp": [
-          {"type":"VARREF","name":"__VactTriggered","addr":"(WKB)","loc":"a,0:0,0:0","dtypep":"(NB)","access":"RD","varp":"(U)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+          {"type":"VARREF","name":"__VactTriggered","addr":"(WKB)","loc":"a,0:0,0:0","dtypep":"(FB)","access":"RD","varp":"(U)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
         ],"pinsp": []}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"__VactExecute","addr":"(XKB)","loc":"a,0:0,0:0","dtypep":"(NB)","access":"WR","varp":"(RKB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"__VactExecute","addr":"(XKB)","loc":"a,0:0,0:0","dtypep":"(FB)","access":"WR","varp":"(RKB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []},
       {"type":"IF","name":"","addr":"(YKB)","loc":"a,0:0,0:0",
        "condp": [
-        {"type":"VARREF","name":"__VactExecute","addr":"(ZKB)","loc":"a,0:0,0:0","dtypep":"(NB)","access":"RD","varp":"(RKB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"__VactExecute","addr":"(ZKB)","loc":"a,0:0,0:0","dtypep":"(FB)","access":"RD","varp":"(RKB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],
        "thensp": [
         {"type":"STMTEXPR","name":"","addr":"(ALB)","loc":"a,0:0,0:0",
          "exprp": [
           {"type":"CMETHODHARD","name":"andNot","addr":"(BLB)","loc":"a,0:0,0:0","dtypep":"(CB)",
            "fromp": [
-            {"type":"VARREF","name":"__VpreTriggered","addr":"(CLB)","loc":"a,0:0,0:0","dtypep":"(NB)","access":"WR","varp":"(QKB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"__VpreTriggered","addr":"(CLB)","loc":"a,0:0,0:0","dtypep":"(FB)","access":"WR","varp":"(QKB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ],
            "pinsp": [
-            {"type":"VARREF","name":"__VactTriggered","addr":"(DLB)","loc":"a,0:0,0:0","dtypep":"(NB)","access":"RD","varp":"(U)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"},
-            {"type":"VARREF","name":"__VnbaTriggered","addr":"(ELB)","loc":"a,0:0,0:0","dtypep":"(NB)","access":"RD","varp":"(W)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"__VactTriggered","addr":"(DLB)","loc":"a,0:0,0:0","dtypep":"(FB)","access":"RD","varp":"(U)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"},
+            {"type":"VARREF","name":"__VnbaTriggered","addr":"(ELB)","loc":"a,0:0,0:0","dtypep":"(FB)","access":"RD","varp":"(W)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ]}
         ]},
         {"type":"STMTEXPR","name":"","addr":"(FLB)","loc":"a,0:0,0:0",
          "exprp": [
           {"type":"CMETHODHARD","name":"thisOr","addr":"(GLB)","loc":"a,0:0,0:0","dtypep":"(CB)",
            "fromp": [
-            {"type":"VARREF","name":"__VnbaTriggered","addr":"(HLB)","loc":"a,0:0,0:0","dtypep":"(NB)","access":"WR","varp":"(W)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"__VnbaTriggered","addr":"(HLB)","loc":"a,0:0,0:0","dtypep":"(FB)","access":"WR","varp":"(W)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ],
            "pinsp": [
-            {"type":"VARREF","name":"__VactTriggered","addr":"(ILB)","loc":"a,0:0,0:0","dtypep":"(NB)","access":"RD","varp":"(U)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"__VactTriggered","addr":"(ILB)","loc":"a,0:0,0:0","dtypep":"(FB)","access":"RD","varp":"(U)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ]}
         ]},
         {"type":"STMTEXPR","name":"","addr":"(JLB)","loc":"a,0:0,0:0",
@@ -2575,7 +2575,7 @@
       ],"elsesp": []},
       {"type":"CRETURN","name":"","addr":"(LLB)","loc":"a,0:0,0:0",
        "lhsp": [
-        {"type":"VARREF","name":"__VactExecute","addr":"(MLB)","loc":"a,0:0,0:0","dtypep":"(NB)","access":"RD","varp":"(RKB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"__VactExecute","addr":"(MLB)","loc":"a,0:0,0:0","dtypep":"(FB)","access":"RD","varp":"(RKB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ]}
     ],"finalsp": []},
     {"type":"CFUNC","name":"_eval_phase__nba","addr":"(NLB)","loc":"a,0:0,0:0","slow":false,"isStatic":false,"dpiExportDispatcher":false,"dpiExportImpl":false,"dpiImportPrototype":false,"dpiImportWrapper":false,"dpiContext":false,"isConstructor":false,"isDestructor":false,"isVirtual":false,"isCoroutine":false,"needProcess":false,"scopep":"(Y)","argsp": [],
@@ -2583,19 +2583,19 @@
       {"type":"VAR","name":"__VnbaExecute","addr":"(OLB)","loc":"d,11:8,11:9","dtypep":"(P)","origName":"__VnbaExecute","isSc":false,"isPrimaryIO":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":true,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":true,"attrClocker":"UNKNOWN","lifetime":"NONE","varType":"MODULETEMP","dtypeName":"bit","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"ignorePostWrite":false,"ignoreSchedWrite":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []}
     ],
      "stmtsp": [
-      {"type":"ASSIGN","name":"","addr":"(PLB)","loc":"a,0:0,0:0","dtypep":"(NB)",
+      {"type":"ASSIGN","name":"","addr":"(PLB)","loc":"a,0:0,0:0","dtypep":"(FB)",
        "rhsp": [
-        {"type":"CMETHODHARD","name":"any","addr":"(QLB)","loc":"a,0:0,0:0","dtypep":"(NB)",
+        {"type":"CMETHODHARD","name":"any","addr":"(QLB)","loc":"a,0:0,0:0","dtypep":"(FB)",
          "fromp": [
-          {"type":"VARREF","name":"__VnbaTriggered","addr":"(RLB)","loc":"a,0:0,0:0","dtypep":"(NB)","access":"RD","varp":"(W)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+          {"type":"VARREF","name":"__VnbaTriggered","addr":"(RLB)","loc":"a,0:0,0:0","dtypep":"(FB)","access":"RD","varp":"(W)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
         ],"pinsp": []}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"__VnbaExecute","addr":"(SLB)","loc":"a,0:0,0:0","dtypep":"(NB)","access":"WR","varp":"(OLB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"__VnbaExecute","addr":"(SLB)","loc":"a,0:0,0:0","dtypep":"(FB)","access":"WR","varp":"(OLB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []},
       {"type":"IF","name":"","addr":"(TLB)","loc":"a,0:0,0:0",
        "condp": [
-        {"type":"VARREF","name":"__VnbaExecute","addr":"(ULB)","loc":"a,0:0,0:0","dtypep":"(NB)","access":"RD","varp":"(OLB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"__VnbaExecute","addr":"(ULB)","loc":"a,0:0,0:0","dtypep":"(FB)","access":"RD","varp":"(OLB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],
        "thensp": [
         {"type":"STMTEXPR","name":"","addr":"(VLB)","loc":"a,0:0,0:0",
@@ -2606,13 +2606,13 @@
          "exprp": [
           {"type":"CMETHODHARD","name":"clear","addr":"(YLB)","loc":"a,0:0,0:0","dtypep":"(CB)",
            "fromp": [
-            {"type":"VARREF","name":"__VnbaTriggered","addr":"(ZLB)","loc":"a,0:0,0:0","dtypep":"(NB)","access":"WR","varp":"(W)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"__VnbaTriggered","addr":"(ZLB)","loc":"a,0:0,0:0","dtypep":"(FB)","access":"WR","varp":"(W)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ],"pinsp": []}
         ]}
       ],"elsesp": []},
       {"type":"CRETURN","name":"","addr":"(AMB)","loc":"a,0:0,0:0",
        "lhsp": [
-        {"type":"VARREF","name":"__VnbaExecute","addr":"(BMB)","loc":"a,0:0,0:0","dtypep":"(NB)","access":"RD","varp":"(OLB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"__VnbaExecute","addr":"(BMB)","loc":"a,0:0,0:0","dtypep":"(FB)","access":"RD","varp":"(OLB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ]}
     ],"finalsp": []},
     {"type":"CFUNC","name":"_eval","addr":"(F)","loc":"a,0:0,0:0","slow":false,"isStatic":false,"dpiExportDispatcher":false,"dpiExportImpl":false,"dpiImportPrototype":false,"dpiImportWrapper":false,"dpiContext":false,"isConstructor":false,"isDestructor":false,"isVirtual":false,"isCoroutine":false,"needProcess":false,"scopep":"(Y)","argsp": [],
@@ -2628,21 +2628,21 @@
        "lhsp": [
         {"type":"VARREF","name":"__VnbaIterCount","addr":"(GMB)","loc":"d,11:8,11:9","dtypep":"(T)","access":"WR","varp":"(CMB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []},
-      {"type":"ASSIGN","name":"","addr":"(HMB)","loc":"d,11:8,11:9","dtypep":"(NB)",
+      {"type":"ASSIGN","name":"","addr":"(HMB)","loc":"d,11:8,11:9","dtypep":"(FB)",
        "rhsp": [
-        {"type":"CONST","name":"1'h1","addr":"(IMB)","loc":"d,11:8,11:9","dtypep":"(NB)"}
+        {"type":"CONST","name":"1'h1","addr":"(IMB)","loc":"d,11:8,11:9","dtypep":"(FB)"}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"__VnbaContinue","addr":"(JMB)","loc":"d,11:8,11:9","dtypep":"(NB)","access":"WR","varp":"(DMB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"__VnbaContinue","addr":"(JMB)","loc":"d,11:8,11:9","dtypep":"(FB)","access":"WR","varp":"(DMB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []},
       {"type":"WHILE","name":"","addr":"(KMB)","loc":"a,0:0,0:0","precondsp": [],
        "condp": [
-        {"type":"VARREF","name":"__VnbaContinue","addr":"(LMB)","loc":"a,0:0,0:0","dtypep":"(NB)","access":"RD","varp":"(DMB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"__VnbaContinue","addr":"(LMB)","loc":"a,0:0,0:0","dtypep":"(FB)","access":"RD","varp":"(DMB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],
        "stmtsp": [
         {"type":"IF","name":"","addr":"(MMB)","loc":"a,0:0,0:0",
          "condp": [
-          {"type":"LT","name":"","addr":"(NMB)","loc":"a,0:0,0:0","dtypep":"(NB)",
+          {"type":"LT","name":"","addr":"(NMB)","loc":"a,0:0,0:0","dtypep":"(FB)",
            "lhsp": [
             {"type":"CONST","name":"32'h64","addr":"(OMB)","loc":"a,0:0,0:0","dtypep":"(NC)"}
           ],
@@ -2679,12 +2679,12 @@
          "lhsp": [
           {"type":"VARREF","name":"__VnbaIterCount","addr":"(CNB)","loc":"d,11:8,11:9","dtypep":"(T)","access":"WR","varp":"(CMB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
         ],"timingControlp": []},
-        {"type":"ASSIGN","name":"","addr":"(DNB)","loc":"d,11:8,11:9","dtypep":"(NB)",
+        {"type":"ASSIGN","name":"","addr":"(DNB)","loc":"d,11:8,11:9","dtypep":"(FB)",
          "rhsp": [
-          {"type":"CONST","name":"1'h0","addr":"(ENB)","loc":"d,11:8,11:9","dtypep":"(NB)"}
+          {"type":"CONST","name":"1'h0","addr":"(ENB)","loc":"d,11:8,11:9","dtypep":"(FB)"}
         ],
          "lhsp": [
-          {"type":"VARREF","name":"__VnbaContinue","addr":"(FNB)","loc":"d,11:8,11:9","dtypep":"(NB)","access":"WR","varp":"(DMB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+          {"type":"VARREF","name":"__VnbaContinue","addr":"(FNB)","loc":"d,11:8,11:9","dtypep":"(FB)","access":"WR","varp":"(DMB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
         ],"timingControlp": []},
         {"type":"ASSIGN","name":"","addr":"(GNB)","loc":"d,11:8,11:9","dtypep":"(T)",
          "rhsp": [
@@ -2693,21 +2693,21 @@
          "lhsp": [
           {"type":"VARREF","name":"__VactIterCount","addr":"(INB)","loc":"d,11:8,11:9","dtypep":"(T)","access":"WR","varp":"(S)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
         ],"timingControlp": []},
-        {"type":"ASSIGN","name":"","addr":"(JNB)","loc":"d,11:8,11:9","dtypep":"(NB)",
+        {"type":"ASSIGN","name":"","addr":"(JNB)","loc":"d,11:8,11:9","dtypep":"(FB)",
          "rhsp": [
-          {"type":"CONST","name":"1'h1","addr":"(KNB)","loc":"d,11:8,11:9","dtypep":"(NB)"}
+          {"type":"CONST","name":"1'h1","addr":"(KNB)","loc":"d,11:8,11:9","dtypep":"(FB)"}
         ],
          "lhsp": [
-          {"type":"VARREF","name":"__VactContinue","addr":"(LNB)","loc":"d,11:8,11:9","dtypep":"(NB)","access":"WR","varp":"(O)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+          {"type":"VARREF","name":"__VactContinue","addr":"(LNB)","loc":"d,11:8,11:9","dtypep":"(FB)","access":"WR","varp":"(O)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
         ],"timingControlp": []},
         {"type":"WHILE","name":"","addr":"(MNB)","loc":"a,0:0,0:0","precondsp": [],
          "condp": [
-          {"type":"VARREF","name":"__VactContinue","addr":"(NNB)","loc":"a,0:0,0:0","dtypep":"(NB)","access":"RD","varp":"(O)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+          {"type":"VARREF","name":"__VactContinue","addr":"(NNB)","loc":"a,0:0,0:0","dtypep":"(FB)","access":"RD","varp":"(O)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
         ],
          "stmtsp": [
           {"type":"IF","name":"","addr":"(ONB)","loc":"a,0:0,0:0",
            "condp": [
-            {"type":"LT","name":"","addr":"(PNB)","loc":"a,0:0,0:0","dtypep":"(NB)",
+            {"type":"LT","name":"","addr":"(PNB)","loc":"a,0:0,0:0","dtypep":"(FB)",
              "lhsp": [
               {"type":"CONST","name":"32'h64","addr":"(QNB)","loc":"a,0:0,0:0","dtypep":"(NC)"}
             ],
@@ -2744,38 +2744,38 @@
            "lhsp": [
             {"type":"VARREF","name":"__VactIterCount","addr":"(EOB)","loc":"d,11:8,11:9","dtypep":"(T)","access":"WR","varp":"(S)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ],"timingControlp": []},
-          {"type":"ASSIGN","name":"","addr":"(FOB)","loc":"d,11:8,11:9","dtypep":"(NB)",
+          {"type":"ASSIGN","name":"","addr":"(FOB)","loc":"d,11:8,11:9","dtypep":"(FB)",
            "rhsp": [
-            {"type":"CONST","name":"1'h0","addr":"(GOB)","loc":"d,11:8,11:9","dtypep":"(NB)"}
+            {"type":"CONST","name":"1'h0","addr":"(GOB)","loc":"d,11:8,11:9","dtypep":"(FB)"}
           ],
            "lhsp": [
-            {"type":"VARREF","name":"__VactContinue","addr":"(HOB)","loc":"d,11:8,11:9","dtypep":"(NB)","access":"WR","varp":"(O)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"__VactContinue","addr":"(HOB)","loc":"d,11:8,11:9","dtypep":"(FB)","access":"WR","varp":"(O)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ],"timingControlp": []},
           {"type":"IF","name":"","addr":"(IOB)","loc":"a,0:0,0:0",
            "condp": [
-            {"type":"CCALL","name":"","addr":"(JOB)","loc":"a,0:0,0:0","dtypep":"(NB)","funcName":"_eval_phase__act","funcp":"(PKB)","argsp": []}
+            {"type":"CCALL","name":"","addr":"(JOB)","loc":"a,0:0,0:0","dtypep":"(FB)","funcName":"_eval_phase__act","funcp":"(PKB)","argsp": []}
           ],
            "thensp": [
-            {"type":"ASSIGN","name":"","addr":"(KOB)","loc":"d,11:8,11:9","dtypep":"(NB)",
+            {"type":"ASSIGN","name":"","addr":"(KOB)","loc":"d,11:8,11:9","dtypep":"(FB)",
              "rhsp": [
-              {"type":"CONST","name":"1'h1","addr":"(LOB)","loc":"d,11:8,11:9","dtypep":"(NB)"}
+              {"type":"CONST","name":"1'h1","addr":"(LOB)","loc":"d,11:8,11:9","dtypep":"(FB)"}
             ],
              "lhsp": [
-              {"type":"VARREF","name":"__VactContinue","addr":"(MOB)","loc":"d,11:8,11:9","dtypep":"(NB)","access":"WR","varp":"(O)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+              {"type":"VARREF","name":"__VactContinue","addr":"(MOB)","loc":"d,11:8,11:9","dtypep":"(FB)","access":"WR","varp":"(O)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
             ],"timingControlp": []}
           ],"elsesp": []}
         ],"incsp": []},
         {"type":"IF","name":"","addr":"(NOB)","loc":"a,0:0,0:0",
          "condp": [
-          {"type":"CCALL","name":"","addr":"(OOB)","loc":"a,0:0,0:0","dtypep":"(NB)","funcName":"_eval_phase__nba","funcp":"(NLB)","argsp": []}
+          {"type":"CCALL","name":"","addr":"(OOB)","loc":"a,0:0,0:0","dtypep":"(FB)","funcName":"_eval_phase__nba","funcp":"(NLB)","argsp": []}
         ],
          "thensp": [
-          {"type":"ASSIGN","name":"","addr":"(POB)","loc":"d,11:8,11:9","dtypep":"(NB)",
+          {"type":"ASSIGN","name":"","addr":"(POB)","loc":"d,11:8,11:9","dtypep":"(FB)",
            "rhsp": [
-            {"type":"CONST","name":"1'h1","addr":"(QOB)","loc":"d,11:8,11:9","dtypep":"(NB)"}
+            {"type":"CONST","name":"1'h1","addr":"(QOB)","loc":"d,11:8,11:9","dtypep":"(FB)"}
           ],
            "lhsp": [
-            {"type":"VARREF","name":"__VnbaContinue","addr":"(ROB)","loc":"d,11:8,11:9","dtypep":"(NB)","access":"WR","varp":"(DMB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"__VnbaContinue","addr":"(ROB)","loc":"d,11:8,11:9","dtypep":"(FB)","access":"WR","varp":"(DMB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ],"timingControlp": []}
         ],"elsesp": []}
       ],"incsp": []}
@@ -2973,14 +2973,14 @@
       ]}
     ]},
     {"type":"REFDTYPE","name":"my_t","addr":"(VB)","loc":"d,52:12,52:16","dtypep":"(ERB)","generic":false,"typedefp":"UNLINKED","refDTypep":"(ERB)","classOrPackagep":"UNLINKED","typeofp": [],"classOrPackageOpp": [],"paramsp": []},
-    {"type":"BASICDTYPE","name":"logic","addr":"(GB)","loc":"d,23:23,23:24","dtypep":"(GB)","keyword":"logic","range":"31:0","generic":true,"rangep": []},
+    {"type":"BASICDTYPE","name":"logic","addr":"(KB)","loc":"d,23:23,23:24","dtypep":"(KB)","keyword":"logic","range":"31:0","generic":true,"rangep": []},
     {"type":"VOIDDTYPE","name":"","addr":"(CB)","loc":"d,11:8,11:9","dtypep":"(CB)","generic":false},
     {"type":"BASICDTYPE","name":"VlTriggerVec","addr":"(V)","loc":"d,11:8,11:9","dtypep":"(V)","keyword":"VlTriggerVec","generic":true,"rangep": []},
     {"type":"BASICDTYPE","name":"QData","addr":"(JQ)","loc":"d,11:8,11:9","dtypep":"(JQ)","keyword":"QData","range":"63:0","generic":true,"rangep": []},
     {"type":"BASICDTYPE","name":"logic","addr":"(GQ)","loc":"d,11:8,11:9","dtypep":"(GQ)","keyword":"logic","range":"63:0","generic":true,"rangep": []},
     {"type":"BASICDTYPE","name":"bit","addr":"(P)","loc":"d,11:8,11:9","dtypep":"(P)","keyword":"bit","generic":true,"rangep": []},
     {"type":"BASICDTYPE","name":"bit","addr":"(T)","loc":"d,11:8,11:9","dtypep":"(T)","keyword":"bit","range":"31:0","generic":true,"rangep": []},
-    {"type":"BASICDTYPE","name":"logic","addr":"(NB)","loc":"d,61:22,61:25","dtypep":"(NB)","keyword":"logic","range":"31:0","generic":true,"rangep": []},
+    {"type":"BASICDTYPE","name":"logic","addr":"(FB)","loc":"d,61:22,61:25","dtypep":"(FB)","keyword":"logic","range":"31:0","generic":true,"rangep": []},
     {"type":"BASICDTYPE","name":"logic","addr":"(AC)","loc":"d,32:11,32:14","dtypep":"(AC)","keyword":"logic","range":"31:0","generic":true,"rangep": []},
     {"type":"BASICDTYPE","name":"logic","addr":"(LC)","loc":"d,38:15,38:16","dtypep":"(LC)","keyword":"logic","range":"31:0","generic":true,"rangep": []},
     {"type":"BASICDTYPE","name":"logic","addr":"(XOB)","loc":"d,15:10,15:13","dtypep":"(XOB)","keyword":"logic","range":"7:0","generic":true,"rangep": []}

--- a/test_regress/t/t_scheduling_initial_event.py
+++ b/test_regress/t/t_scheduling_initial_event.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2025 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile(verilator_flags2=["--timing", "--binary"])
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_scheduling_initial_event.v
+++ b/test_regress/t/t_scheduling_initial_event.v
@@ -1,0 +1,107 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2025 by Wilson Snyder.
+// SPDX-License-Identifier: CC0-1.0
+
+`define stop $stop
+`define checkh(gotv,expv) do if ((gotv) !== (expv)) begin $write("%%Error: %s:%0d:  got=%0x exp=%0x (%s !== %s)\n", `__FILE__,`__LINE__, (gotv), (expv), `"gotv`", `"expv`"); `stop; end while(0);
+
+module top;
+  logic pEdge = 1'b0;
+  logic nEdge = 1'b1;
+  logic edgeP = 1'b0;
+  logic edgeN = 1'b1;
+  logic changeP = 1'b0;
+  logic changeN = 1'b1;
+
+  int pEdgeCnt = 0;
+  int nEdgeCnt = 0;
+  int edgePCnt = 0;
+  int edgeNCnt = 0;
+  int changePCnt = 0;
+  int changeNCnt = 0;
+
+  time pEdgeTime[3] = '{-1, -1, -1};
+  time nEdgeTime[3] = '{-1, -1, -1};
+  time edgePTime[3] = '{-1, -1, -1};
+  time edgeNTime[3] = '{-1, -1, -1};
+  time changePTime[3] = '{-1, -1, -1};
+  time changeNTime[3] = '{-1, -1, -1};
+
+  initial begin
+    pEdge = 1'b1;
+    nEdge = 1'b0;
+    edgeP = 1'b1;
+    edgeN = 1'b0;
+    changeP = 1'b1;
+    changeN = 1'b0;
+
+    #10;
+    pEdge = 1'b0;
+    nEdge = 1'b1;
+    edgeP = 1'b0;
+    edgeN = 1'b1;
+    changeP = 1'b0;
+    changeN = 1'b1;
+
+    #10;
+    pEdge = 1'b1;
+    nEdge = 1'b0;
+    edgeP = 1'b1;
+    edgeN = 1'b0;
+    changeP = 1'b1;
+    changeN = 1'b0;
+
+    #10;
+    $display("pEdgeCnt: %0d", pEdgeCnt);
+    $display("nEdgeCnt: %0d", nEdgeCnt);
+    $display("edgePCnt: %0d", edgePCnt);
+    $display("edgeNCnt: %0d", edgeNCnt);
+    $display("changePCnt: %0d", changePCnt);
+    $display("changeNCnt: %0d", changeNCnt);
+
+    $display("pEdgeTime: %p", pEdgeTime);
+    $display("nEdgeTime: %p", nEdgeTime);
+    $display("edgePTime: %p", edgePTime);
+    $display("edgeNTime: %p", edgeNTime);
+    $display("changePTime: %p", changePTime);
+    $display("changeNTime: %p", changeNTime);
+
+    `checkh(pEdgeCnt, 2);
+    `checkh(nEdgeCnt, 2);
+    `checkh(edgePCnt, 3);
+    `checkh(edgeNCnt, 3);
+    `checkh(changePCnt, 3);
+    `checkh(changeNCnt, 3);
+
+    `checkh(pEdgeTime[0],  0);
+    `checkh(pEdgeTime[1], 20);
+    `checkh(pEdgeTime[2], -1);
+    `checkh(nEdgeTime[0],  0);
+    `checkh(nEdgeTime[1], 20);
+    `checkh(nEdgeTime[2], -1);
+    `checkh(edgePTime[0],  0);
+    `checkh(edgePTime[1], 10);
+    `checkh(edgePTime[2], 20);
+    `checkh(edgeNTime[0],  0);
+    `checkh(edgeNTime[1], 10);
+    `checkh(edgeNTime[2], 20);
+    `checkh(changePTime[0],  0);
+    `checkh(changePTime[1], 10);
+    `checkh(changePTime[2], 20);
+    `checkh(changeNTime[0],  0);
+    `checkh(changeNTime[1], 10);
+    `checkh(changeNTime[2], 20);
+    $write("*-* All Finished *-*\n");
+    $finish;
+  end
+
+  always @(posedge pEdge) pEdgeTime[pEdgeCnt++] = $time;
+  always @(negedge nEdge) nEdgeTime[nEdgeCnt++] = $time;
+  always @(edge edgeP) edgePTime[edgePCnt++] = $time;
+  always @(edge edgeN) edgeNTime[edgeNCnt++] = $time;
+  always @(changeP) changePTime[changePCnt++] = $time;
+  always @(changeN) changeNTime[changeNCnt++] = $time;
+
+endmodule // test

--- a/test_regress/t/t_xml_debugcheck.out
+++ b/test_regress/t/t_xml_debugcheck.out
@@ -36,10 +36,14 @@
         <stmtexpr loc="d,11,8,11,9">
           <ccall loc="d,11,8,11,9" dtype_id="7" func="_eval_static__TOP"/>
         </stmtexpr>
+        <assign loc="d,61,22,61,25" dtype_id="8">
+          <varref loc="d,61,22,61,25" name="clk" dtype_id="8"/>
+          <varref loc="d,61,22,61,25" name="__Vtrigprevexpr___TOP__clk__0" dtype_id="8"/>
+        </assign>
       </cfunc>
       <cfunc loc="d,11,8,11,9" name="_eval_static__TOP">
         <assign loc="d,23,23,23,24" dtype_id="4">
-          <const loc="d,23,23,23,24" name="32&apos;sh0" dtype_id="8"/>
+          <const loc="d,23,23,23,24" name="32&apos;sh0" dtype_id="9"/>
           <varref loc="d,23,23,23,24" name="t.cyc" dtype_id="4"/>
         </assign>
       </cfunc>
@@ -47,10 +51,6 @@
         <stmtexpr loc="d,11,8,11,9">
           <ccall loc="d,11,8,11,9" dtype_id="7" func="_eval_initial__TOP"/>
         </stmtexpr>
-        <assign loc="d,61,22,61,25" dtype_id="9">
-          <varref loc="d,61,22,61,25" name="clk" dtype_id="9"/>
-          <varref loc="d,61,22,61,25" name="__Vtrigprevexpr___TOP__clk__0" dtype_id="9"/>
-        </assign>
       </cfunc>
       <cfunc loc="d,11,8,11,9" name="_eval_initial__TOP">
         <var loc="d,28,11,28,14" name="t.all" dtype_id="10" vartype="string" origName="t__DOT__all"/>
@@ -67,7 +67,7 @@
           <varref loc="d,32,7,32,8" name="t.e" dtype_id="11"/>
         </assign>
         <if loc="d,38,10,38,12">
-          <neq loc="d,38,26,38,29" dtype_id="9">
+          <neq loc="d,38,26,38,29" dtype_id="8">
             <const loc="d,38,31,38,34" name="4&apos;h4" dtype_id="11"/>
             <arraysel loc="d,38,15,38,16" dtype_id="11">
               <varref loc="d,17,12,17,16" name="__Venumtab_enum_next1" dtype_id="12"/>
@@ -97,7 +97,7 @@
           </begin>
         </if>
         <if loc="d,39,10,39,12">
-          <neq loc="d,39,34,39,37" dtype_id="9">
+          <neq loc="d,39,34,39,37" dtype_id="8">
             <const loc="d,39,39,39,42" name="4&apos;h1" dtype_id="11"/>
             <arraysel loc="d,39,15,39,16" dtype_id="11">
               <varref loc="d,17,12,17,16" name="__Venumtab_enum_next1" dtype_id="12"/>
@@ -139,7 +139,7 @@
           </begin>
         </if>
         <if loc="d,40,10,40,12">
-          <neq loc="d,40,26,40,29" dtype_id="9">
+          <neq loc="d,40,26,40,29" dtype_id="8">
             <const loc="d,40,31,40,34" name="4&apos;h1" dtype_id="11"/>
             <arraysel loc="d,40,15,40,16" dtype_id="11">
               <varref loc="d,17,12,17,16" name="__Venumtab_enum_next1" dtype_id="12"/>
@@ -181,7 +181,7 @@
           </begin>
         </if>
         <if loc="d,41,10,41,12">
-          <neq loc="d,41,42,41,45" dtype_id="9">
+          <neq loc="d,41,42,41,45" dtype_id="8">
             <const loc="d,41,47,41,50" name="4&apos;h3" dtype_id="11"/>
             <arraysel loc="d,41,15,41,16" dtype_id="11">
               <varref loc="d,17,12,17,16" name="__Venumtab_enum_next1" dtype_id="12"/>
@@ -235,7 +235,7 @@
           </begin>
         </if>
         <if loc="d,42,10,42,12">
-          <neq loc="d,42,34,42,37" dtype_id="9">
+          <neq loc="d,42,34,42,37" dtype_id="8">
             <const loc="d,42,39,42,42" name="4&apos;h3" dtype_id="11"/>
             <arraysel loc="d,42,15,42,16" dtype_id="11">
               <varref loc="d,17,12,17,16" name="__Venumtab_enum_next1" dtype_id="12"/>
@@ -289,7 +289,7 @@
           </begin>
         </if>
         <if loc="d,43,10,43,12">
-          <neq loc="d,43,26,43,29" dtype_id="9">
+          <neq loc="d,43,26,43,29" dtype_id="8">
             <const loc="d,43,31,43,34" name="4&apos;h3" dtype_id="11"/>
             <arraysel loc="d,43,15,43,16" dtype_id="11">
               <varref loc="d,17,12,17,16" name="__Venumtab_enum_next1" dtype_id="12"/>
@@ -343,7 +343,7 @@
           </begin>
         </if>
         <if loc="d,44,10,44,12">
-          <neq loc="d,44,23,44,26" dtype_id="9">
+          <neq loc="d,44,23,44,26" dtype_id="8">
             <const loc="d,44,28,44,31" name="4&apos;h1" dtype_id="11"/>
             <arraysel loc="d,44,15,44,16" dtype_id="11">
               <varref loc="d,17,12,17,16" name="__Venumtab_enum_prev1" dtype_id="15"/>
@@ -373,7 +373,7 @@
           </begin>
         </if>
         <if loc="d,45,10,45,12">
-          <neq loc="d,45,26,45,29" dtype_id="9">
+          <neq loc="d,45,26,45,29" dtype_id="8">
             <const loc="d,45,31,45,34" name="4&apos;h1" dtype_id="11"/>
             <arraysel loc="d,45,15,45,16" dtype_id="11">
               <varref loc="d,17,12,17,16" name="__Venumtab_enum_prev1" dtype_id="15"/>
@@ -403,7 +403,7 @@
           </begin>
         </if>
         <if loc="d,46,10,46,12">
-          <neq loc="d,46,34,46,37" dtype_id="9">
+          <neq loc="d,46,34,46,37" dtype_id="8">
             <const loc="d,46,39,46,42" name="4&apos;h4" dtype_id="11"/>
             <arraysel loc="d,46,15,46,16" dtype_id="11">
               <varref loc="d,17,12,17,16" name="__Venumtab_enum_prev1" dtype_id="15"/>
@@ -445,7 +445,7 @@
           </begin>
         </if>
         <if loc="d,47,10,47,12">
-          <neq loc="d,47,26,47,29" dtype_id="9">
+          <neq loc="d,47,26,47,29" dtype_id="8">
             <const loc="d,47,31,47,34" name="4&apos;h4" dtype_id="11"/>
             <arraysel loc="d,47,15,47,16" dtype_id="11">
               <varref loc="d,17,12,17,16" name="__Venumtab_enum_prev1" dtype_id="15"/>
@@ -487,7 +487,7 @@
           </begin>
         </if>
         <if loc="d,49,10,49,12">
-          <neqn loc="d,49,23,49,25" dtype_id="9">
+          <neqn loc="d,49,23,49,25" dtype_id="8">
             <const loc="d,49,27,49,32" name="&quot;E03&quot;" dtype_id="10"/>
             <arraysel loc="d,49,15,49,16" dtype_id="10">
               <varref loc="d,17,12,17,16" name="__Venumtab_enum_name1" dtype_id="16"/>
@@ -532,7 +532,7 @@
           <begin>
           </begin>
           <begin>
-            <neq loc="d,52,32,52,34" dtype_id="9">
+            <neq loc="d,52,32,52,34" dtype_id="8">
               <const loc="d,52,37,52,41" name="4&apos;h4" dtype_id="11"/>
               <ccast loc="d,52,30,52,31" dtype_id="11">
                 <varref loc="d,52,30,52,31" name="t.unnamedblk1.e" dtype_id="11"/>
@@ -583,7 +583,7 @@
           <varref loc="d,56,7,56,10" name="t.all" dtype_id="10"/>
         </assign>
         <if loc="d,57,10,57,12">
-          <neqn loc="d,57,20,57,22" dtype_id="9">
+          <neqn loc="d,57,20,57,22" dtype_id="8">
             <const loc="d,57,24,57,35" name="&quot;E01E03E04&quot;" dtype_id="10"/>
             <varref loc="d,57,15,57,18" name="t.all" dtype_id="10"/>
           </neqn>
@@ -602,23 +602,23 @@
       <cfunc loc="a,0,0,0,0" name="_eval_triggers__act">
         <stmtexpr loc="d,11,8,11,9">
           <cmethodhard loc="d,11,8,11,9" name="setBit" dtype_id="7">
-            <varref loc="d,11,8,11,9" name="__VactTriggered" dtype_id="9"/>
+            <varref loc="d,11,8,11,9" name="__VactTriggered" dtype_id="8"/>
             <const loc="d,11,8,11,9" name="32&apos;h0" dtype_id="14"/>
-            <and loc="d,61,14,61,21" dtype_id="9">
-              <ccast loc="d,61,22,61,25" dtype_id="9">
-                <varref loc="d,61,22,61,25" name="clk" dtype_id="9"/>
+            <and loc="d,61,14,61,21" dtype_id="8">
+              <ccast loc="d,61,22,61,25" dtype_id="8">
+                <varref loc="d,61,22,61,25" name="clk" dtype_id="8"/>
               </ccast>
-              <not loc="d,61,14,61,21" dtype_id="9">
-                <ccast loc="d,61,14,61,21" dtype_id="9">
-                  <varref loc="d,61,14,61,21" name="__Vtrigprevexpr___TOP__clk__0" dtype_id="9"/>
+              <not loc="d,61,14,61,21" dtype_id="8">
+                <ccast loc="d,61,14,61,21" dtype_id="8">
+                  <varref loc="d,61,14,61,21" name="__Vtrigprevexpr___TOP__clk__0" dtype_id="8"/>
                 </ccast>
               </not>
             </and>
           </cmethodhard>
         </stmtexpr>
-        <assign loc="d,61,22,61,25" dtype_id="9">
-          <varref loc="d,61,22,61,25" name="clk" dtype_id="9"/>
-          <varref loc="d,61,22,61,25" name="__Vtrigprevexpr___TOP__clk__0" dtype_id="9"/>
+        <assign loc="d,61,22,61,25" dtype_id="8">
+          <varref loc="d,61,22,61,25" name="clk" dtype_id="8"/>
+          <varref loc="d,61,22,61,25" name="__Vtrigprevexpr___TOP__clk__0" dtype_id="8"/>
         </assign>
         <textblock loc="d,11,8,11,9">
           <text loc="d,11,8,11,9"/>
@@ -632,11 +632,11 @@
       </cfunc>
       <cfunc loc="a,0,0,0,0" name="_dump_triggers__act">
         <if loc="d,11,8,11,9">
-          <and loc="d,11,8,11,9" dtype_id="9">
+          <and loc="d,11,8,11,9" dtype_id="8">
             <const loc="d,11,8,11,9" name="32&apos;h1" dtype_id="14"/>
-            <not loc="d,11,8,11,9" dtype_id="9">
-              <cmethodhard loc="d,11,8,11,9" name="any" dtype_id="9">
-                <varref loc="d,11,8,11,9" name="__VactTriggered" dtype_id="9"/>
+            <not loc="d,11,8,11,9" dtype_id="8">
+              <cmethodhard loc="d,11,8,11,9" name="any" dtype_id="8">
+                <varref loc="d,11,8,11,9" name="__VactTriggered" dtype_id="8"/>
               </cmethodhard>
             </not>
           </and>
@@ -648,7 +648,7 @@
           <and loc="d,11,8,11,9" dtype_id="17">
             <const loc="d,11,8,11,9" name="64&apos;h1" dtype_id="17"/>
             <cmethodhard loc="d,11,8,11,9" name="word" dtype_id="18">
-              <varref loc="d,11,8,11,9" name="__VactTriggered" dtype_id="9"/>
+              <varref loc="d,11,8,11,9" name="__VactTriggered" dtype_id="8"/>
               <const loc="d,11,8,11,9" name="32&apos;h0" dtype_id="14"/>
             </cmethodhard>
           </and>
@@ -659,11 +659,11 @@
       </cfunc>
       <cfunc loc="a,0,0,0,0" name="_dump_triggers__nba">
         <if loc="d,11,8,11,9">
-          <and loc="d,11,8,11,9" dtype_id="9">
+          <and loc="d,11,8,11,9" dtype_id="8">
             <const loc="d,11,8,11,9" name="32&apos;h1" dtype_id="14"/>
-            <not loc="d,11,8,11,9" dtype_id="9">
-              <cmethodhard loc="d,11,8,11,9" name="any" dtype_id="9">
-                <varref loc="d,11,8,11,9" name="__VnbaTriggered" dtype_id="9"/>
+            <not loc="d,11,8,11,9" dtype_id="8">
+              <cmethodhard loc="d,11,8,11,9" name="any" dtype_id="8">
+                <varref loc="d,11,8,11,9" name="__VnbaTriggered" dtype_id="8"/>
               </cmethodhard>
             </not>
           </and>
@@ -675,7 +675,7 @@
           <and loc="d,11,8,11,9" dtype_id="17">
             <const loc="d,11,8,11,9" name="64&apos;h1" dtype_id="17"/>
             <cmethodhard loc="d,11,8,11,9" name="word" dtype_id="18">
-              <varref loc="d,11,8,11,9" name="__VnbaTriggered" dtype_id="9"/>
+              <varref loc="d,11,8,11,9" name="__VnbaTriggered" dtype_id="8"/>
               <const loc="d,11,8,11,9" name="32&apos;h0" dtype_id="14"/>
             </cmethodhard>
           </and>
@@ -690,7 +690,7 @@
           <and loc="d,11,8,11,9" dtype_id="17">
             <const loc="d,11,8,11,9" name="64&apos;h1" dtype_id="17"/>
             <cmethodhard loc="d,11,8,11,9" name="word" dtype_id="18">
-              <varref loc="d,11,8,11,9" name="__VnbaTriggered" dtype_id="9"/>
+              <varref loc="d,11,8,11,9" name="__VnbaTriggered" dtype_id="8"/>
               <const loc="d,11,8,11,9" name="32&apos;h0" dtype_id="14"/>
             </cmethodhard>
           </and>
@@ -724,15 +724,15 @@
         <assigndly loc="d,62,11,62,13" dtype_id="4">
           <add loc="d,62,18,62,19" dtype_id="4">
             <ccast loc="d,62,20,62,21" dtype_id="14">
-              <const loc="d,62,20,62,21" name="32&apos;sh1" dtype_id="8"/>
+              <const loc="d,62,20,62,21" name="32&apos;sh1" dtype_id="9"/>
             </ccast>
             <varref loc="d,62,14,62,17" name="t.cyc" dtype_id="4"/>
           </add>
           <varref loc="d,62,7,62,10" name="__Vdly__t.cyc" dtype_id="4"/>
         </assigndly>
         <if loc="d,63,7,63,9">
-          <eq loc="d,63,14,63,16" dtype_id="9">
-            <const loc="d,63,16,63,17" name="32&apos;sh0" dtype_id="8"/>
+          <eq loc="d,63,14,63,16" dtype_id="8">
+            <const loc="d,63,16,63,17" name="32&apos;sh0" dtype_id="9"/>
             <varref loc="d,63,11,63,14" name="t.cyc" dtype_id="4"/>
           </eq>
           <begin>
@@ -743,13 +743,13 @@
           </begin>
           <begin>
             <if loc="d,67,12,67,14">
-              <eq loc="d,67,19,67,21" dtype_id="9">
-                <const loc="d,67,21,67,22" name="32&apos;sh1" dtype_id="8"/>
+              <eq loc="d,67,19,67,21" dtype_id="8">
+                <const loc="d,67,21,67,22" name="32&apos;sh1" dtype_id="9"/>
                 <varref loc="d,67,16,67,19" name="t.cyc" dtype_id="4"/>
               </eq>
               <begin>
                 <if loc="d,68,13,68,15">
-                  <neqn loc="d,68,26,68,28" dtype_id="9">
+                  <neqn loc="d,68,26,68,28" dtype_id="8">
                     <const loc="d,68,30,68,35" name="&quot;E01&quot;" dtype_id="10"/>
                     <arraysel loc="d,68,18,68,19" dtype_id="10">
                       <varref loc="d,17,12,17,16" name="__Venumtab_enum_name1" dtype_id="16"/>
@@ -783,7 +783,7 @@
                   </begin>
                 </if>
                 <if loc="d,69,13,69,15">
-                  <neq loc="d,69,26,69,29" dtype_id="9">
+                  <neq loc="d,69,26,69,29" dtype_id="8">
                     <const loc="d,69,31,69,34" name="4&apos;h3" dtype_id="11"/>
                     <arraysel loc="d,69,18,69,19" dtype_id="11">
                       <varref loc="d,17,12,17,16" name="__Venumtab_enum_next1" dtype_id="12"/>
@@ -813,7 +813,7 @@
                   </begin>
                 </if>
                 <if loc="d,70,13,70,15">
-                  <neq loc="d,70,29,70,32" dtype_id="9">
+                  <neq loc="d,70,29,70,32" dtype_id="8">
                     <const loc="d,70,34,70,37" name="4&apos;h3" dtype_id="11"/>
                     <arraysel loc="d,70,18,70,19" dtype_id="11">
                       <varref loc="d,17,12,17,16" name="__Venumtab_enum_next1" dtype_id="12"/>
@@ -843,7 +843,7 @@
                   </begin>
                 </if>
                 <if loc="d,71,13,71,15">
-                  <neq loc="d,71,29,71,32" dtype_id="9">
+                  <neq loc="d,71,29,71,32" dtype_id="8">
                     <const loc="d,71,34,71,37" name="4&apos;h4" dtype_id="11"/>
                     <arraysel loc="d,71,18,71,19" dtype_id="11">
                       <varref loc="d,17,12,17,16" name="__Venumtab_enum_next1" dtype_id="12"/>
@@ -885,7 +885,7 @@
                   </begin>
                 </if>
                 <if loc="d,72,13,72,15">
-                  <neq loc="d,72,26,72,29" dtype_id="9">
+                  <neq loc="d,72,26,72,29" dtype_id="8">
                     <const loc="d,72,31,72,34" name="4&apos;h4" dtype_id="11"/>
                     <arraysel loc="d,72,18,72,19" dtype_id="11">
                       <varref loc="d,17,12,17,16" name="__Venumtab_enum_prev1" dtype_id="15"/>
@@ -915,7 +915,7 @@
                   </begin>
                 </if>
                 <if loc="d,73,13,73,15">
-                  <neq loc="d,73,29,73,32" dtype_id="9">
+                  <neq loc="d,73,29,73,32" dtype_id="8">
                     <const loc="d,73,34,73,37" name="4&apos;h4" dtype_id="11"/>
                     <arraysel loc="d,73,18,73,19" dtype_id="11">
                       <varref loc="d,17,12,17,16" name="__Venumtab_enum_prev1" dtype_id="15"/>
@@ -945,7 +945,7 @@
                   </begin>
                 </if>
                 <if loc="d,74,13,74,15">
-                  <neq loc="d,74,29,74,32" dtype_id="9">
+                  <neq loc="d,74,29,74,32" dtype_id="8">
                     <const loc="d,74,34,74,37" name="4&apos;h3" dtype_id="11"/>
                     <arraysel loc="d,74,18,74,19" dtype_id="11">
                       <varref loc="d,17,12,17,16" name="__Venumtab_enum_prev1" dtype_id="15"/>
@@ -993,13 +993,13 @@
               </begin>
               <begin>
                 <if loc="d,77,12,77,14">
-                  <eq loc="d,77,19,77,21" dtype_id="9">
-                    <const loc="d,77,21,77,22" name="32&apos;sh2" dtype_id="8"/>
+                  <eq loc="d,77,19,77,21" dtype_id="8">
+                    <const loc="d,77,21,77,22" name="32&apos;sh2" dtype_id="9"/>
                     <varref loc="d,77,16,77,19" name="t.cyc" dtype_id="4"/>
                   </eq>
                   <begin>
                     <if loc="d,78,13,78,15">
-                      <neqn loc="d,78,26,78,28" dtype_id="9">
+                      <neqn loc="d,78,26,78,28" dtype_id="8">
                         <const loc="d,78,30,78,35" name="&quot;E03&quot;" dtype_id="10"/>
                         <arraysel loc="d,78,18,78,19" dtype_id="10">
                           <varref loc="d,17,12,17,16" name="__Venumtab_enum_name1" dtype_id="16"/>
@@ -1033,7 +1033,7 @@
                       </begin>
                     </if>
                     <if loc="d,79,13,79,15">
-                      <neq loc="d,79,26,79,29" dtype_id="9">
+                      <neq loc="d,79,26,79,29" dtype_id="8">
                         <const loc="d,79,31,79,34" name="4&apos;h4" dtype_id="11"/>
                         <arraysel loc="d,79,18,79,19" dtype_id="11">
                           <varref loc="d,17,12,17,16" name="__Venumtab_enum_next1" dtype_id="12"/>
@@ -1063,7 +1063,7 @@
                       </begin>
                     </if>
                     <if loc="d,80,13,80,15">
-                      <neq loc="d,80,29,80,32" dtype_id="9">
+                      <neq loc="d,80,29,80,32" dtype_id="8">
                         <const loc="d,80,34,80,37" name="4&apos;h4" dtype_id="11"/>
                         <arraysel loc="d,80,18,80,19" dtype_id="11">
                           <varref loc="d,17,12,17,16" name="__Venumtab_enum_next1" dtype_id="12"/>
@@ -1093,7 +1093,7 @@
                       </begin>
                     </if>
                     <if loc="d,81,13,81,15">
-                      <neq loc="d,81,29,81,32" dtype_id="9">
+                      <neq loc="d,81,29,81,32" dtype_id="8">
                         <const loc="d,81,34,81,37" name="4&apos;h1" dtype_id="11"/>
                         <arraysel loc="d,81,18,81,19" dtype_id="11">
                           <varref loc="d,17,12,17,16" name="__Venumtab_enum_next1" dtype_id="12"/>
@@ -1135,7 +1135,7 @@
                       </begin>
                     </if>
                     <if loc="d,82,13,82,15">
-                      <neq loc="d,82,26,82,29" dtype_id="9">
+                      <neq loc="d,82,26,82,29" dtype_id="8">
                         <const loc="d,82,31,82,34" name="4&apos;h1" dtype_id="11"/>
                         <arraysel loc="d,82,18,82,19" dtype_id="11">
                           <varref loc="d,17,12,17,16" name="__Venumtab_enum_prev1" dtype_id="15"/>
@@ -1165,7 +1165,7 @@
                       </begin>
                     </if>
                     <if loc="d,83,13,83,15">
-                      <neq loc="d,83,29,83,32" dtype_id="9">
+                      <neq loc="d,83,29,83,32" dtype_id="8">
                         <const loc="d,83,34,83,37" name="4&apos;h1" dtype_id="11"/>
                         <arraysel loc="d,83,18,83,19" dtype_id="11">
                           <varref loc="d,17,12,17,16" name="__Venumtab_enum_prev1" dtype_id="15"/>
@@ -1195,7 +1195,7 @@
                       </begin>
                     </if>
                     <if loc="d,84,13,84,15">
-                      <neq loc="d,84,29,84,32" dtype_id="9">
+                      <neq loc="d,84,29,84,32" dtype_id="8">
                         <const loc="d,84,34,84,37" name="4&apos;h4" dtype_id="11"/>
                         <arraysel loc="d,84,18,84,19" dtype_id="11">
                           <varref loc="d,17,12,17,16" name="__Venumtab_enum_prev1" dtype_id="15"/>
@@ -1243,13 +1243,13 @@
                   </begin>
                   <begin>
                     <if loc="d,87,12,87,14">
-                      <eq loc="d,87,19,87,21" dtype_id="9">
-                        <const loc="d,87,21,87,22" name="32&apos;sh3" dtype_id="8"/>
+                      <eq loc="d,87,19,87,21" dtype_id="8">
+                        <const loc="d,87,21,87,22" name="32&apos;sh3" dtype_id="9"/>
                         <varref loc="d,87,16,87,19" name="t.cyc" dtype_id="4"/>
                       </eq>
                       <begin>
                         <if loc="d,88,13,88,15">
-                          <neqn loc="d,88,26,88,28" dtype_id="9">
+                          <neqn loc="d,88,26,88,28" dtype_id="8">
                             <const loc="d,88,30,88,35" name="&quot;E04&quot;" dtype_id="10"/>
                             <arraysel loc="d,88,18,88,19" dtype_id="10">
                               <varref loc="d,17,12,17,16" name="__Venumtab_enum_name1" dtype_id="16"/>
@@ -1283,7 +1283,7 @@
                           </begin>
                         </if>
                         <if loc="d,89,13,89,15">
-                          <neq loc="d,89,26,89,29" dtype_id="9">
+                          <neq loc="d,89,26,89,29" dtype_id="8">
                             <const loc="d,89,31,89,34" name="4&apos;h1" dtype_id="11"/>
                             <arraysel loc="d,89,18,89,19" dtype_id="11">
                               <varref loc="d,17,12,17,16" name="__Venumtab_enum_next1" dtype_id="12"/>
@@ -1313,7 +1313,7 @@
                           </begin>
                         </if>
                         <if loc="d,90,13,90,15">
-                          <neq loc="d,90,29,90,32" dtype_id="9">
+                          <neq loc="d,90,29,90,32" dtype_id="8">
                             <const loc="d,90,34,90,37" name="4&apos;h1" dtype_id="11"/>
                             <arraysel loc="d,90,18,90,19" dtype_id="11">
                               <varref loc="d,17,12,17,16" name="__Venumtab_enum_next1" dtype_id="12"/>
@@ -1343,7 +1343,7 @@
                           </begin>
                         </if>
                         <if loc="d,91,13,91,15">
-                          <neq loc="d,91,29,91,32" dtype_id="9">
+                          <neq loc="d,91,29,91,32" dtype_id="8">
                             <const loc="d,91,34,91,37" name="4&apos;h3" dtype_id="11"/>
                             <arraysel loc="d,91,18,91,19" dtype_id="11">
                               <varref loc="d,17,12,17,16" name="__Venumtab_enum_next1" dtype_id="12"/>
@@ -1385,7 +1385,7 @@
                           </begin>
                         </if>
                         <if loc="d,92,13,92,15">
-                          <neq loc="d,92,26,92,29" dtype_id="9">
+                          <neq loc="d,92,26,92,29" dtype_id="8">
                             <const loc="d,92,31,92,34" name="4&apos;h3" dtype_id="11"/>
                             <arraysel loc="d,92,18,92,19" dtype_id="11">
                               <varref loc="d,17,12,17,16" name="__Venumtab_enum_prev1" dtype_id="15"/>
@@ -1415,7 +1415,7 @@
                           </begin>
                         </if>
                         <if loc="d,93,13,93,15">
-                          <neq loc="d,93,29,93,32" dtype_id="9">
+                          <neq loc="d,93,29,93,32" dtype_id="8">
                             <const loc="d,93,34,93,37" name="4&apos;h3" dtype_id="11"/>
                             <arraysel loc="d,93,18,93,19" dtype_id="11">
                               <varref loc="d,17,12,17,16" name="__Venumtab_enum_prev1" dtype_id="15"/>
@@ -1445,7 +1445,7 @@
                           </begin>
                         </if>
                         <if loc="d,94,13,94,15">
-                          <neq loc="d,94,29,94,32" dtype_id="9">
+                          <neq loc="d,94,29,94,32" dtype_id="8">
                             <const loc="d,94,34,94,37" name="4&apos;h1" dtype_id="11"/>
                             <arraysel loc="d,94,18,94,19" dtype_id="11">
                               <varref loc="d,17,12,17,16" name="__Venumtab_enum_prev1" dtype_id="15"/>
@@ -1493,8 +1493,8 @@
                       </begin>
                       <begin>
                         <if loc="d,97,12,97,14">
-                          <eq loc="d,97,19,97,21" dtype_id="9">
-                            <const loc="d,97,21,97,23" name="32&apos;sh63" dtype_id="8"/>
+                          <eq loc="d,97,19,97,21" dtype_id="8">
+                            <const loc="d,97,21,97,23" name="32&apos;sh63" dtype_id="9"/>
                             <varref loc="d,97,16,97,19" name="t.cyc" dtype_id="4"/>
                           </eq>
                           <begin>
@@ -1527,26 +1527,26 @@
         <stmtexpr loc="a,0,0,0,0">
           <ccall loc="a,0,0,0,0" dtype_id="7" func="_eval_triggers__act"/>
         </stmtexpr>
-        <assign loc="a,0,0,0,0" dtype_id="9">
-          <cmethodhard loc="a,0,0,0,0" name="any" dtype_id="9">
-            <varref loc="a,0,0,0,0" name="__VactTriggered" dtype_id="9"/>
+        <assign loc="a,0,0,0,0" dtype_id="8">
+          <cmethodhard loc="a,0,0,0,0" name="any" dtype_id="8">
+            <varref loc="a,0,0,0,0" name="__VactTriggered" dtype_id="8"/>
           </cmethodhard>
-          <varref loc="a,0,0,0,0" name="__VactExecute" dtype_id="9"/>
+          <varref loc="a,0,0,0,0" name="__VactExecute" dtype_id="8"/>
         </assign>
         <if loc="a,0,0,0,0">
-          <varref loc="a,0,0,0,0" name="__VactExecute" dtype_id="9"/>
+          <varref loc="a,0,0,0,0" name="__VactExecute" dtype_id="8"/>
           <begin>
             <stmtexpr loc="a,0,0,0,0">
               <cmethodhard loc="a,0,0,0,0" name="andNot" dtype_id="7">
-                <varref loc="a,0,0,0,0" name="__VpreTriggered" dtype_id="9"/>
-                <varref loc="a,0,0,0,0" name="__VactTriggered" dtype_id="9"/>
-                <varref loc="a,0,0,0,0" name="__VnbaTriggered" dtype_id="9"/>
+                <varref loc="a,0,0,0,0" name="__VpreTriggered" dtype_id="8"/>
+                <varref loc="a,0,0,0,0" name="__VactTriggered" dtype_id="8"/>
+                <varref loc="a,0,0,0,0" name="__VnbaTriggered" dtype_id="8"/>
               </cmethodhard>
             </stmtexpr>
             <stmtexpr loc="a,0,0,0,0">
               <cmethodhard loc="a,0,0,0,0" name="thisOr" dtype_id="7">
-                <varref loc="a,0,0,0,0" name="__VnbaTriggered" dtype_id="9"/>
-                <varref loc="a,0,0,0,0" name="__VactTriggered" dtype_id="9"/>
+                <varref loc="a,0,0,0,0" name="__VnbaTriggered" dtype_id="8"/>
+                <varref loc="a,0,0,0,0" name="__VactTriggered" dtype_id="8"/>
               </cmethodhard>
             </stmtexpr>
             <stmtexpr loc="a,0,0,0,0">
@@ -1555,32 +1555,32 @@
           </begin>
         </if>
         <creturn loc="a,0,0,0,0">
-          <varref loc="a,0,0,0,0" name="__VactExecute" dtype_id="9"/>
+          <varref loc="a,0,0,0,0" name="__VactExecute" dtype_id="8"/>
         </creturn>
       </cfunc>
       <cfunc loc="a,0,0,0,0" name="_eval_phase__nba">
         <var loc="d,11,8,11,9" name="__VnbaExecute" dtype_id="3" vartype="bit" origName="__VnbaExecute"/>
-        <assign loc="a,0,0,0,0" dtype_id="9">
-          <cmethodhard loc="a,0,0,0,0" name="any" dtype_id="9">
-            <varref loc="a,0,0,0,0" name="__VnbaTriggered" dtype_id="9"/>
+        <assign loc="a,0,0,0,0" dtype_id="8">
+          <cmethodhard loc="a,0,0,0,0" name="any" dtype_id="8">
+            <varref loc="a,0,0,0,0" name="__VnbaTriggered" dtype_id="8"/>
           </cmethodhard>
-          <varref loc="a,0,0,0,0" name="__VnbaExecute" dtype_id="9"/>
+          <varref loc="a,0,0,0,0" name="__VnbaExecute" dtype_id="8"/>
         </assign>
         <if loc="a,0,0,0,0">
-          <varref loc="a,0,0,0,0" name="__VnbaExecute" dtype_id="9"/>
+          <varref loc="a,0,0,0,0" name="__VnbaExecute" dtype_id="8"/>
           <begin>
             <stmtexpr loc="a,0,0,0,0">
               <ccall loc="a,0,0,0,0" dtype_id="7" func="_eval_nba"/>
             </stmtexpr>
             <stmtexpr loc="a,0,0,0,0">
               <cmethodhard loc="a,0,0,0,0" name="clear" dtype_id="7">
-                <varref loc="a,0,0,0,0" name="__VnbaTriggered" dtype_id="9"/>
+                <varref loc="a,0,0,0,0" name="__VnbaTriggered" dtype_id="8"/>
               </cmethodhard>
             </stmtexpr>
           </begin>
         </if>
         <creturn loc="a,0,0,0,0">
-          <varref loc="a,0,0,0,0" name="__VnbaExecute" dtype_id="9"/>
+          <varref loc="a,0,0,0,0" name="__VnbaExecute" dtype_id="8"/>
         </creturn>
       </cfunc>
       <cfunc loc="a,0,0,0,0" name="_eval">
@@ -1590,19 +1590,19 @@
           <const loc="d,11,8,11,9" name="32&apos;h0" dtype_id="14"/>
           <varref loc="d,11,8,11,9" name="__VnbaIterCount" dtype_id="5"/>
         </assign>
-        <assign loc="d,11,8,11,9" dtype_id="9">
-          <const loc="d,11,8,11,9" name="1&apos;h1" dtype_id="9"/>
-          <varref loc="d,11,8,11,9" name="__VnbaContinue" dtype_id="9"/>
+        <assign loc="d,11,8,11,9" dtype_id="8">
+          <const loc="d,11,8,11,9" name="1&apos;h1" dtype_id="8"/>
+          <varref loc="d,11,8,11,9" name="__VnbaContinue" dtype_id="8"/>
         </assign>
         <while loc="a,0,0,0,0">
           <begin>
           </begin>
           <begin>
-            <varref loc="a,0,0,0,0" name="__VnbaContinue" dtype_id="9"/>
+            <varref loc="a,0,0,0,0" name="__VnbaContinue" dtype_id="8"/>
           </begin>
           <begin>
             <if loc="a,0,0,0,0">
-              <lt loc="a,0,0,0,0" dtype_id="9">
+              <lt loc="a,0,0,0,0" dtype_id="8">
                 <const loc="a,0,0,0,0" name="32&apos;h64" dtype_id="14"/>
                 <varref loc="a,0,0,0,0" name="__VnbaIterCount" dtype_id="5"/>
               </lt>
@@ -1627,27 +1627,27 @@
               </add>
               <varref loc="d,11,8,11,9" name="__VnbaIterCount" dtype_id="5"/>
             </assign>
-            <assign loc="d,11,8,11,9" dtype_id="9">
-              <const loc="d,11,8,11,9" name="1&apos;h0" dtype_id="9"/>
-              <varref loc="d,11,8,11,9" name="__VnbaContinue" dtype_id="9"/>
+            <assign loc="d,11,8,11,9" dtype_id="8">
+              <const loc="d,11,8,11,9" name="1&apos;h0" dtype_id="8"/>
+              <varref loc="d,11,8,11,9" name="__VnbaContinue" dtype_id="8"/>
             </assign>
             <assign loc="d,11,8,11,9" dtype_id="5">
               <const loc="d,11,8,11,9" name="32&apos;h0" dtype_id="14"/>
               <varref loc="d,11,8,11,9" name="__VactIterCount" dtype_id="5"/>
             </assign>
-            <assign loc="d,11,8,11,9" dtype_id="9">
-              <const loc="d,11,8,11,9" name="1&apos;h1" dtype_id="9"/>
-              <varref loc="d,11,8,11,9" name="__VactContinue" dtype_id="9"/>
+            <assign loc="d,11,8,11,9" dtype_id="8">
+              <const loc="d,11,8,11,9" name="1&apos;h1" dtype_id="8"/>
+              <varref loc="d,11,8,11,9" name="__VactContinue" dtype_id="8"/>
             </assign>
             <while loc="a,0,0,0,0">
               <begin>
               </begin>
               <begin>
-                <varref loc="a,0,0,0,0" name="__VactContinue" dtype_id="9"/>
+                <varref loc="a,0,0,0,0" name="__VactContinue" dtype_id="8"/>
               </begin>
               <begin>
                 <if loc="a,0,0,0,0">
-                  <lt loc="a,0,0,0,0" dtype_id="9">
+                  <lt loc="a,0,0,0,0" dtype_id="8">
                     <const loc="a,0,0,0,0" name="32&apos;h64" dtype_id="14"/>
                     <varref loc="a,0,0,0,0" name="__VactIterCount" dtype_id="5"/>
                   </lt>
@@ -1672,27 +1672,27 @@
                   </add>
                   <varref loc="d,11,8,11,9" name="__VactIterCount" dtype_id="5"/>
                 </assign>
-                <assign loc="d,11,8,11,9" dtype_id="9">
-                  <const loc="d,11,8,11,9" name="1&apos;h0" dtype_id="9"/>
-                  <varref loc="d,11,8,11,9" name="__VactContinue" dtype_id="9"/>
+                <assign loc="d,11,8,11,9" dtype_id="8">
+                  <const loc="d,11,8,11,9" name="1&apos;h0" dtype_id="8"/>
+                  <varref loc="d,11,8,11,9" name="__VactContinue" dtype_id="8"/>
                 </assign>
                 <if loc="a,0,0,0,0">
-                  <ccall loc="a,0,0,0,0" dtype_id="9" func="_eval_phase__act"/>
+                  <ccall loc="a,0,0,0,0" dtype_id="8" func="_eval_phase__act"/>
                   <begin>
-                    <assign loc="d,11,8,11,9" dtype_id="9">
-                      <const loc="d,11,8,11,9" name="1&apos;h1" dtype_id="9"/>
-                      <varref loc="d,11,8,11,9" name="__VactContinue" dtype_id="9"/>
+                    <assign loc="d,11,8,11,9" dtype_id="8">
+                      <const loc="d,11,8,11,9" name="1&apos;h1" dtype_id="8"/>
+                      <varref loc="d,11,8,11,9" name="__VactContinue" dtype_id="8"/>
                     </assign>
                   </begin>
                 </if>
               </begin>
             </while>
             <if loc="a,0,0,0,0">
-              <ccall loc="a,0,0,0,0" dtype_id="9" func="_eval_phase__nba"/>
+              <ccall loc="a,0,0,0,0" dtype_id="8" func="_eval_phase__nba"/>
               <begin>
-                <assign loc="d,11,8,11,9" dtype_id="9">
-                  <const loc="d,11,8,11,9" name="1&apos;h1" dtype_id="9"/>
-                  <varref loc="d,11,8,11,9" name="__VnbaContinue" dtype_id="9"/>
+                <assign loc="d,11,8,11,9" dtype_id="8">
+                  <const loc="d,11,8,11,9" name="1&apos;h1" dtype_id="8"/>
+                  <varref loc="d,11,8,11,9" name="__VnbaContinue" dtype_id="8"/>
                 </assign>
               </begin>
             </if>
@@ -1831,14 +1831,14 @@
         </range>
       </unpackarraydtype>
       <refdtype loc="d,52,12,52,16" id="22" name="my_t" sub_dtype_id="2"/>
-      <basicdtype loc="d,23,23,23,24" id="8" name="logic" left="31" right="0" signed="true"/>
+      <basicdtype loc="d,23,23,23,24" id="9" name="logic" left="31" right="0" signed="true"/>
       <voiddtype loc="d,11,8,11,9" id="7"/>
       <basicdtype loc="d,11,8,11,9" id="6" name="VlTriggerVec"/>
       <basicdtype loc="d,11,8,11,9" id="18" name="QData" left="63" right="0"/>
       <basicdtype loc="d,11,8,11,9" id="17" name="logic" left="63" right="0"/>
       <basicdtype loc="d,11,8,11,9" id="3" name="bit"/>
       <basicdtype loc="d,11,8,11,9" id="5" name="bit" left="31" right="0"/>
-      <basicdtype loc="d,61,22,61,25" id="9" name="logic" left="31" right="0"/>
+      <basicdtype loc="d,61,22,61,25" id="8" name="logic" left="31" right="0"/>
       <basicdtype loc="d,32,11,32,14" id="11" name="logic" left="31" right="0"/>
       <basicdtype loc="d,38,15,38,16" id="13" name="logic" left="31" right="0"/>
       <basicdtype loc="d,15,10,15,13" id="19" name="logic" left="7" right="0"/>


### PR DESCRIPTION
Initialize "previous value" variables in the static initializer function, instead of the 'initial' blocks function. Fixes #5499