### PR TITLE
Fix interface array assignments (#5270) (#5633)

### DIFF
--- a/src/V3Inst.cpp
+++ b/src/V3Inst.cpp
@@ -469,16 +469,15 @@ private:
 
     void visit(AstAssign* nodep) override {
         if (AstArraySel* const arrselp = VN_CAST(nodep->rhsp(), ArraySel)) {
-	    // handle single element selection from RHS array
+            // handle single element selection from RHS array
             if (const AstUnpackArrayDType* const arrp
                 = VN_CAST(arrselp->fromp()->dtypep(), UnpackArrayDType)) {
                 if (!VN_IS(arrp->subDTypep(), IfaceRefDType)) return;
                 V3Const::constifyParamsEdit(arrselp->bitp());
                 const AstConst* const constp = VN_CAST(arrselp->bitp(), Const);
                 if (!constp) {
-                    nodep->v3warn(
-                        E_UNSUPPORTED,
-                        "Non-constant index in RHS interface array selection");
+                    nodep->v3warn(E_UNSUPPORTED,
+                                  "Non-constant index in RHS interface array selection");
                     return;
                 }
                 const string index = AstNode::encodeNumber(constp->toSInt());
@@ -487,8 +486,8 @@ private:
                 const AstVarRef* const varrefp = VN_CAST(arrselp->fromp(), VarRef);
                 UASSERT_OBJ(varrefp, arrselp, "No interface varref under array");
                 AstVarXRef* const newp = new AstVarXRef{
-                        nodep->fileline(), varrefp->name() + "__BRA__" + index + "__KET__", "",
-                        VAccess::READ};
+                    nodep->fileline(), varrefp->name() + "__BRA__" + index + "__KET__", "",
+                    VAccess::READ};
                 newp->dtypep(arrp->subDTypep());
                 newp->classOrPackagep(varrefp->classOrPackagep());
                 arrselp->addNextHere(newp);
@@ -499,23 +498,21 @@ private:
                 = VN_CAST(nodep->lhsp()->dtypep(), UnpackArrayDType)) {
                 if (const AstUnpackArrayDType* const rhsarrp
                     = VN_CAST(nodep->rhsp()->dtypep(), UnpackArrayDType)) {
-		    // copy between arrays
+                    // copy between arrays
                     if (!VN_IS(lhsarrp->subDTypep(), IfaceRefDType)) return;
                     if (!VN_IS(rhsarrp->subDTypep(), IfaceRefDType)) return;
                     if (lhsarrp->elementsConst() != rhsarrp->elementsConst()) {
-                        nodep->v3warn(
-                            E_UNSUPPORTED,
-                            "Array size mismatch in interface assignment");
+                        nodep->v3warn(E_UNSUPPORTED,
+                                      "Array size mismatch in interface assignment");
                         return;
                     }
                     for (int i = 0; i < lhsarrp->elementsConst(); ++i) {
                         const string index = AstNode::encodeNumber(i);
                         AstNodeExpr* lhsp = nullptr;
-                        if (const AstVarRef* const varrefp
-                            = VN_CAST(nodep->lhsp(), VarRef)) {
+                        if (const AstVarRef* const varrefp = VN_CAST(nodep->lhsp(), VarRef)) {
                             AstVarXRef* const newvarrefp = new AstVarXRef{
-                                nodep->fileline(), varrefp->name() + "__BRA__" + index + "__KET__", "",
-                                VAccess::WRITE};
+                                nodep->fileline(), varrefp->name() + "__BRA__" + index + "__KET__",
+                                "", VAccess::WRITE};
                             newvarrefp->dtypep(lhsarrp->subDTypep());
                             newvarrefp->classOrPackagep(varrefp->classOrPackagep());
                             lhsp = newvarrefp;
@@ -524,12 +521,12 @@ private:
                             AstMemberSel* membselp = prevselp->cloneTree(false);
                             AstArraySel* newarrselp = new AstArraySel(
                                 nodep->fileline(), membselp,
-                                new AstConst(nodep->fileline(), V3Number(nodep->fileline(), 32, i)));
+                                new AstConst(nodep->fileline(),
+                                             V3Number(nodep->fileline(), 32, i)));
                             lhsp = newarrselp;
                         } else {
-                            nodep->v3warn(
-                                E_UNSUPPORTED,
-                                "Unsupported lhs node type in array assignment");
+                            nodep->v3warn(E_UNSUPPORTED,
+                                          "Unsupported lhs node type in array assignment");
                             return;
                         }
                         const AstVarRef* const rhsrefp = VN_CAST(nodep->rhsp(), VarRef);

--- a/src/V3Inst.cpp
+++ b/src/V3Inst.cpp
@@ -467,7 +467,7 @@ private:
         }
     }
 
-    void visit(AstAssign* nodep) {
+    void visit(AstAssign* nodep) override {
         if (AstArraySel* const arrselp = VN_CAST(nodep->rhsp(), ArraySel)) {
 	    // handle single element selection from RHS array
             if (const AstUnpackArrayDType* const arrp

--- a/src/V3Inst.cpp
+++ b/src/V3Inst.cpp
@@ -495,9 +495,7 @@ private:
             if (const AstUnpackArrayDType* const arrp
                 = VN_CAST(arrslicep->fromp()->dtypep(), UnpackArrayDType)) {
                 if (!VN_IS(arrp->subDTypep(), IfaceRefDType)) return;
-                // fatal here because mismatch between dearray and unfixed SliceSel
-                // leaves the tree in a bad state and causes an internal error
-                arrslicep->v3fatal("Unsupported: interface slices");
+                arrslicep->v3warn(E_UNSUPPORTED, "Interface slices unsupported");
                 return;
             }
         } else {

--- a/test_regress/t/t_interface_dearray.py
+++ b/test_regress/t/t_interface_dearray.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2025 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile()
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_interface_dearray.v
+++ b/test_regress/t/t_interface_dearray.v
@@ -24,7 +24,7 @@ module tb_top();
    end
 
    initial begin
-      a_t aa = a[0];
+      static a_t aa = a[0];
 
       b = a;
 
@@ -38,7 +38,7 @@ module tb_top();
       g[0] = a[0];
 
       for (int i = 0; i < 6; ++i) begin
-	 d.vif[i] = g[i];
+         d.vif[i] = g[i];
       end
 
       $write("*-* All Finished *-*\n");

--- a/test_regress/t/t_interface_dearray.v
+++ b/test_regress/t/t_interface_dearray.v
@@ -19,10 +19,6 @@ module tb_top();
    C c, d, e;
    a_array_t g;
 
-   for (genvar j = 0; j < 6; j++) begin
-      initial g[j] = a[j];
-   end
-
    initial begin
       static a_t aa = a[0];
 
@@ -36,9 +32,15 @@ module tb_top();
       d.vif[1] = a[1];
 
       g[0] = a[0];
+      g = a;
+
+      d.vif[0] = g[0];
+      d.vif = g;
+
+      e = new();
 
       for (int i = 0; i < 6; ++i) begin
-         d.vif[i] = g[i];
+         e.vif[i] = g[i];
       end
 
       $write("*-* All Finished *-*\n");

--- a/test_regress/t/t_interface_dearray.v
+++ b/test_regress/t/t_interface_dearray.v
@@ -7,16 +7,26 @@
 interface A;
 endinterface
 
+typedef virtual A a_t;
+typedef a_t a_array_t[6];
+
 class C;
-   virtual A vif[6];
+   a_array_t vif;
 endclass
 
 module tb_top();
    A a[6](), b[6]();
-   C c, d;
+   C c, d, e;
+   a_array_t g;
+
+   for (genvar j = 0; j < 6; j++) begin
+      initial g[j] = a[j];
+   end
 
    initial begin
-      virtual A aa = a[0];
+      a_t aa = a[0];
+
+      b = a;
 
       c = new();
       c.vif = a;
@@ -25,9 +35,14 @@ module tb_top();
       d.vif[0] = a[0];
       d.vif[1] = a[1];
 
-      b = a;
+      g[0] = a[0];
+
+      for (int i = 0; i < 6; ++i) begin
+	 d.vif[i] = g[i];
+      end
 
       $write("*-* All Finished *-*\n");
       $finish;
    end
+
 endmodule

--- a/test_regress/t/t_interface_dearray.v
+++ b/test_regress/t/t_interface_dearray.v
@@ -1,0 +1,33 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2025 by Wilson Snyder
+// SPDX-License-Identifier: CC0-1.0
+
+interface A;
+endinterface
+
+class C;
+   virtual A vif[6];
+endclass
+
+module tb_top();
+   A a[6](), b[6]();
+   C c, d;
+
+   initial begin
+      virtual A aa = a[0];
+
+      c = new();
+      c.vif = a;
+
+      d = new();
+      d.vif[0] = a[0];
+      d.vif[1] = a[1];
+
+      b = a;
+
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end
+endmodule

--- a/test_regress/t/t_interface_dearray_bad.out
+++ b/test_regress/t/t_interface_dearray_bad.out
@@ -1,0 +1,21 @@
+%Error-UNSUPPORTED: t/t_interface_dearray_bad.v:25:13: Array size mismatch in interface assignment
+                                                     : ... note: In instance 'tb_top'
+   25 |       c.vif = b;
+      |             ^
+                    ... For error description see https://verilator.org/warn/UNSUPPORTED?v=latest
+%Error: t/t_interface_dearray_bad.v:30:23: Expecting expression to be constant, but variable isn't const: 'i'
+                                         : ... note: In instance 'tb_top'
+   30 |          d.vif[i] = a[i];
+      |                       ^
+%Error-UNSUPPORTED: t/t_interface_dearray_bad.v:30:19: Non-constant index in RHS interface array selection
+                                                     : ... note: In instance 'tb_top'
+   30 |          d.vif[i] = a[i];
+      |                   ^
+%Error-UNSUPPORTED: t/t_interface_dearray_bad.v:34:16: Interface slices unsupported
+                                                     : ... note: In instance 'tb_top'
+   34 |       e.vif = b[0:5];
+      |                ^
+%Error: Internal Error: t/t_interface_dearray_bad.v:25:15: ../V3Broken.cpp:#: Broken link in node (or something without maybePointedTo): 'm_varp && !m_varp->brokeExists()' @ ./V3Ast__gen_impl.h:#
+                                                         : ... note: In instance 'tb_top'
+   25 |       c.vif = b;
+      |               ^

--- a/test_regress/t/t_interface_dearray_bad.out
+++ b/test_regress/t/t_interface_dearray_bad.out
@@ -7,10 +7,10 @@
                                          : ... note: In instance 'tb_top'
    30 |          d.vif[i] = a[i];
       |                       ^
-%Error-UNSUPPORTED: t/t_interface_dearray_bad.v:30:19: Non-constant index in RHS interface array selection
+%Error-UNSUPPORTED: t/t_interface_dearray_bad.v:30:23: Non-constant index in RHS interface array selection
                                                      : ... note: In instance 'tb_top'
    30 |          d.vif[i] = a[i];
-      |                   ^
+      |                       ^
 %Error-UNSUPPORTED: t/t_interface_dearray_bad.v:34:16: Interface slices unsupported
                                                      : ... note: In instance 'tb_top'
    34 |       e.vif = b[0:5];

--- a/test_regress/t/t_interface_dearray_bad.py
+++ b/test_regress/t/t_interface_dearray_bad.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2025 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('linter')
+
+test.lint(fails=True, expect_filename=test.golden_filename)
+
+test.passes()

--- a/test_regress/t/t_interface_dearray_bad.v
+++ b/test_regress/t/t_interface_dearray_bad.v
@@ -1,0 +1,40 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2025 by Wilson Snyder
+// SPDX-License-Identifier: CC0-1.0
+
+interface A;
+endinterface
+
+typedef virtual A a_t;
+typedef a_t a_array_t[6];
+
+class C;
+   a_array_t vif;
+endclass
+
+module tb_top();
+   A a[6](), b[7]();
+   C c, d, e;
+   a_array_t g;
+
+   initial begin
+
+      c = new();
+      c.vif = b;
+
+      d = new();
+
+      for (int i = 0; i < 6; ++i) begin
+         d.vif[i] = a[i];
+      end
+
+      e = new();
+      e.vif = b[0:5];
+
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end
+
+endmodule


### PR DESCRIPTION
Handle assignments of interface arrays to virtual interfaces and adds a test case.

resolves #5633, resolves #5270.