### PR TITLE
Expression coverage: do not support class references

### DIFF
--- a/src/V3Coverage.cpp
+++ b/src/V3Coverage.cpp
@@ -39,9 +39,26 @@ class ExprCoverageEligibleVisitor final : public VNVisitor {
     // STATE
     bool m_eligible = true;
 
+    void visit(AstNodeVarRef* nodep) override {
+        AstNodeDType* dtypep = nodep->varp()->dtypep();
+        // Class objecs and references not supported for expression coverage
+        // because the object may not persist until the point at which
+        // coverage data is gathered
+        // This could be resolved in the future by protecting against dereferrencing
+        // null pointers when cloning the expression for expression coverage
+        if (VN_CAST(dtypep, ClassRefDType)) {
+            m_eligible = false;
+        } else {
+            iterateChildren(nodep);
+        }
+    }
+
     void visit(AstNode* nodep) override {
-        if (!nodep->isExprCoverageEligible()) m_eligible = false;
-        iterateChildren(nodep);
+        if (!nodep->isExprCoverageEligible()) {
+            m_eligible = false;
+        } else {
+            iterateChildren(nodep);
+        }
     }
 
 public:

--- a/test_regress/t/t_cover_expr.out
+++ b/test_regress/t/t_cover_expr.out
@@ -289,6 +289,7 @@
             logic ta, tb, tc;
             initial begin
                 cls obj = new;
+                cls null_obj = null;
                 int q[5];
                 int qv[$];
         
@@ -310,6 +311,7 @@
                     ta = '0;
                 end
                 if (!bit'(obj.randomize() with {x < 100;})) $write("");
+                if (null_obj != null && null_obj.x == 5) $write("");
             end
         
             sub the_sub_1 (.p(t1), .q(t2));

--- a/test_regress/t/t_cover_expr.v
+++ b/test_regress/t/t_cover_expr.v
@@ -129,6 +129,7 @@ module t (/*AUTOARG*/
     logic ta, tb, tc;
     initial begin
         cls obj = new;
+        cls null_obj = null;
         int q[5];
         int qv[$];
 
@@ -146,6 +147,7 @@ module t (/*AUTOARG*/
             ta = '0;
         end
         if (!bit'(obj.randomize() with {x < 100;})) $write("");
+        if (null_obj != null && null_obj.x == 5) $write("");
     end
 
     sub the_sub_1 (.p(t1), .q(t2));

--- a/test_regress/t/t_cover_expr_max.out
+++ b/test_regress/t/t_cover_expr_max.out
@@ -417,6 +417,7 @@
             logic ta, tb, tc;
             initial begin
                 cls obj = new;
+                cls null_obj = null;
                 int q[5];
                 int qv[$];
         
@@ -438,6 +439,7 @@
                     ta = '0;
                 end
                 if (!bit'(obj.randomize() with {x < 100;})) $write("");
+                if (null_obj != null && null_obj.x == 5) $write("");
             end
         
             sub the_sub_1 (.p(t1), .q(t2));

--- a/test_regress/t/t_cover_expr_trace.out
+++ b/test_regress/t/t_cover_expr_trace.out
@@ -289,6 +289,7 @@
             logic ta, tb, tc;
             initial begin
                 cls obj = new;
+                cls null_obj = null;
                 int q[5];
                 int qv[$];
         
@@ -310,6 +311,7 @@
                     ta = '0;
                 end
                 if (!bit'(obj.randomize() with {x < 100;})) $write("");
+                if (null_obj != null && null_obj.x == 5) $write("");
             end
         
             sub the_sub_1 (.p(t1), .q(t2));


### PR DESCRIPTION
As mentioned in `ExprCoverageEligibleVisitor` it should be possible to enable expression coverage for class references, but the first step is to not make the sim crash when these two things are combined.