### PR TITLE
Add support for setuphold

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -134,6 +134,7 @@ Krzysztof Boronski
 Krzysztof Boroński
 Krzysztof Obłonczek
 Krzysztof Starecki
+Krzysztof Sychla
 Kuba Ober
 Larry Doolittle
 Liam Braun

--- a/src/V3AstNodeOther.h
+++ b/src/V3AstNodeOther.h
@@ -3341,13 +3341,13 @@ public:
 };
 class AstSetuphold final : public AstNodeStmt {
     // Verilog $setuphold
-    // @astgen op1 := refevp : AstSenItem
-    // @astgen op2 := dataevp : AstSenItem
-    // @astgen op3 := delrefp : Optional[AstSenItem]
-    // @astgen op4 := deldatap : Optional[AstSenItem]
+    // @astgen op1 := refevp : AstNodeExpr
+    // @astgen op2 := dataevp : AstNodeExpr
+    // @astgen op3 := delrefp : Optional[AstNodeExpr]
+    // @astgen op4 := deldatap : Optional[AstNodeExpr]
 public:
-    AstSetuphold(FileLine* fl, AstSenItem* refevp, AstSenItem* dataevp,
-                 AstSenItem* delrefp = nullptr, AstSenItem* deldatap = nullptr)
+    AstSetuphold(FileLine* fl, AstNodeExpr* refevp, AstNodeExpr* dataevp,
+                 AstNodeExpr* delrefp = nullptr, AstNodeExpr* deldatap = nullptr)
         : ASTGEN_SUPER_Setuphold(fl) {
         this->refevp(refevp);
         this->dataevp(dataevp);

--- a/src/V3AstNodeOther.h
+++ b/src/V3AstNodeOther.h
@@ -3339,6 +3339,24 @@ public:
     int instrCount() const override { return INSTR_COUNT_PLI; }
     bool sameNode(const AstNode* /*samep*/) const override { return true; }
 };
+class AstSetuphold final : public AstNodeStmt {
+    // Verilog $setuphold
+    // @astgen op1 := refevp : AstSenItem
+    // @astgen op2 := dataevp : AstSenItem
+    // @astgen op3 := delrefp : Optional[AstSenItem]
+    // @astgen op4 := deldatap : Optional[AstSenItem]
+public:
+    AstSetuphold(FileLine* fl, AstSenItem* refevp, AstSenItem* dataevp,
+                 AstSenItem* delrefp = nullptr, AstSenItem* deldatap = nullptr)
+        : ASTGEN_SUPER_Setuphold(fl) {
+        this->refevp(refevp);
+        this->dataevp(dataevp);
+        this->delrefp(delrefp);
+        this->deldatap(deldatap);
+    }
+    ASTGEN_MEMBERS_AstSetuphold;
+    bool sameNode(const AstNode* /*samep*/) const override { return true; }
+};
 class AstStackTraceT final : public AstNodeStmt {
     // $stacktrace used as task
 public:

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -1377,6 +1377,33 @@ class WidthVisitor final : public VNVisitor {
         }
     }
 
+    void visit(AstSetuphold* nodep) override {
+        FileLine* const flp = nodep->fileline();
+
+        AstAssignW* newp = nullptr;
+
+        if (nodep->delrefp() != nullptr) {
+            AstNodeVarRef* lhsp = nodep->delrefp()->varrefp()->cloneTreePure(false);
+            lhsp->access(VAccess::WRITE);
+            AstNodeVarRef* rhsp = nodep->refevp()->varrefp()->cloneTreePure(false);
+            newp = new AstAssignW{flp, lhsp, rhsp};
+        }
+
+        if (nodep->deldatap() != nullptr) {
+            AstNodeVarRef* lhsp = nodep->deldatap()->varrefp()->cloneTreePure(false);
+            lhsp->access(VAccess::WRITE);
+            AstNodeVarRef* rhsp = nodep->dataevp()->varrefp()->cloneTreePure(false);
+
+            if (newp == nullptr) {
+                newp = new AstAssignW{flp, lhsp, rhsp};
+            } else {
+                newp->addNextHere(new AstAssignW{flp, lhsp, rhsp});
+            }
+        }
+
+        nodep->replaceWith(newp);
+    }
+
     void visit(AstStable* nodep) override {
         if (m_vup->prelim()) {
             iterateCheckSizedSelf(nodep, "LHS", nodep->exprp(), SELF, BOTH);

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -1401,6 +1401,11 @@ class WidthVisitor final : public VNVisitor {
             }
         }
 
+        if (!newp) {
+            pushDeletep(nodep->unlinkFrBack());
+            return;
+        }
+
         nodep->replaceWith(newp);
     }
 

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -1382,17 +1382,38 @@ class WidthVisitor final : public VNVisitor {
 
         AstAssignW* newp = nullptr;
 
-        if (nodep->delrefp() != nullptr) {
-            AstNodeVarRef* lhsp = VN_AS(nodep->delrefp()->cloneTreePure(false), VarRef);
-            lhsp->access(VAccess::WRITE);
-            AstNodeVarRef* rhsp = VN_AS(nodep->refevp()->cloneTreePure(false), VarRef);
+        if (nodep->delrefp()) {
+            AstNodeExpr* const lhsp = nodep->delrefp()->cloneTreePure(false);
+            AstNodeExpr* const rhsp = nodep->refevp()->cloneTreePure(false);
+            if (AstNodeVarRef* varRefp = VN_CAST(lhsp, NodeVarRef)) {
+                varRefp->access(VAccess::WRITE);
+                varRefp->varp()->setForcedByCode();
+            }
+
+            if (AstNodePreSel* selp = VN_CAST(lhsp, NodePreSel)) {
+                if (AstNodeVarRef* varRefp = VN_CAST(selp->fromp(), NodeVarRef)) {
+                    varRefp->access(VAccess::WRITE);
+                    varRefp->varp()->setForcedByCode();
+                }
+            }
+
             newp = new AstAssignW{flp, lhsp, rhsp};
         }
 
-        if (nodep->deldatap() != nullptr) {
-            AstNodeVarRef* lhsp = VN_AS(nodep->deldatap()->cloneTreePure(false), VarRef);
-            lhsp->access(VAccess::WRITE);
-            AstNodeVarRef* rhsp = VN_AS(nodep->dataevp()->cloneTreePure(false), VarRef);
+        if (nodep->deldatap()) {
+            AstNodeExpr* const lhsp = nodep->deldatap()->cloneTreePure(false);
+            AstNodeExpr* const rhsp = nodep->dataevp()->cloneTreePure(false);
+            if (AstNodeVarRef* varRefp = VN_CAST(lhsp, NodeVarRef)) {
+                varRefp->access(VAccess::WRITE);
+                varRefp->varp()->setForcedByCode();
+            }
+
+            if (AstNodePreSel* selp = VN_CAST(lhsp, NodePreSel)) {
+                if (AstNodeVarRef* varRefp = VN_CAST(selp->fromp(), NodeVarRef)) {
+                    varRefp->access(VAccess::WRITE);
+                    varRefp->varp()->setForcedByCode();
+                }
+            }
 
             if (newp == nullptr) {
                 newp = new AstAssignW{flp, lhsp, rhsp};

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -1383,16 +1383,16 @@ class WidthVisitor final : public VNVisitor {
         AstAssignW* newp = nullptr;
 
         if (nodep->delrefp() != nullptr) {
-            AstNodeVarRef* lhsp = nodep->delrefp()->varrefp()->cloneTreePure(false);
+            AstNodeVarRef* lhsp = VN_AS(nodep->delrefp()->cloneTreePure(false), VarRef);
             lhsp->access(VAccess::WRITE);
-            AstNodeVarRef* rhsp = nodep->refevp()->varrefp()->cloneTreePure(false);
+            AstNodeVarRef* rhsp = VN_AS(nodep->refevp()->cloneTreePure(false), VarRef);
             newp = new AstAssignW{flp, lhsp, rhsp};
         }
 
         if (nodep->deldatap() != nullptr) {
-            AstNodeVarRef* lhsp = nodep->deldatap()->varrefp()->cloneTreePure(false);
+            AstNodeVarRef* lhsp = VN_AS(nodep->deldatap()->cloneTreePure(false), VarRef);
             lhsp->access(VAccess::WRITE);
-            AstNodeVarRef* rhsp = nodep->dataevp()->varrefp()->cloneTreePure(false);
+            AstNodeVarRef* rhsp = VN_AS(nodep->dataevp()->cloneTreePure(false), VarRef);
 
             if (newp == nullptr) {
                 newp = new AstAssignW{flp, lhsp, rhsp};

--- a/src/verilog.l
+++ b/src/verilog.l
@@ -79,7 +79,7 @@ static double lexParseDouble(FileLine* fl, const char* textp, size_t length) {
 %o 25000
 
 %s V95 V01NC V01C V05 S05 S09 S12 S17 S23
-%s ATTRMODE QQQ STRING TABLE
+%s ATTRMODE QQQ STRING TABLE EDGEDESC
 %s VA5 SAX VLT
 %s SYSCHDR SYSCINT SYSCIMP SYSCIMPH SYSCCTOR SYSCDTOR
 
@@ -328,6 +328,7 @@ vnum    {vnum1}|{vnum2}|{vnum3}|{vnum4}|{vnum5}
   "default"             { FL; return yDEFAULT; }
   "defparam"            { FL; return yDEFPARAM; }
   "disable"             { FL; return yDISABLE; }
+  "edge"/{ws}*"["       { FL; yy_push_state(EDGEDESC); return yEDGE; }
   "edge"                { FL; return yEDGE; }
   "else"                { FL; return yELSE; }
   "end"                 { FL; return yEND; }
@@ -1022,6 +1023,13 @@ vnum    {vnum1}|{vnum2}|{vnum3}|{vnum4}|{vnum5}
 <TABLE>.                { yymore(); }
 <TABLE><<EOF>>          { FL; yylval.fl->v3error("EOF in 'table'");
                           yyleng = 0; yy_pop_state(); FL_BRK; yyterminate(); }
+
+<EDGEDESC>{
+  01|10|[01][zZxX]|[zZxX][01]  { FL; return yaEDGEDESC; }
+}
+<EDGEDESC>","|"["         { FL; return yytext[0]; }
+<EDGEDESC>{ws}            { FL_FWD; FL_BRK; }  /* otherwise ignore white-space */
+<EDGEDESC>"]"             { FL; yy_pop_state(); return yytext[0]; }
 
   /************************************************************************/
   /* Preprocessor */

--- a/src/verilog.l
+++ b/src/verilog.l
@@ -271,7 +271,7 @@ vnum    {vnum1}|{vnum2}|{vnum3}|{vnum4}|{vnum5}
   "$rtoi"               { FL; return yD_RTOI; }
   "$sampled"            { FL; return yD_SAMPLED; }
   "$setup"              { FL; return yaTIMINGSPEC; }
-  "$setuphold"          { FL; return yaTIMINGSPEC; }
+  "$setuphold"          { FL; return yD_SETUPHOLD; }
   "$sformat"            { FL; return yD_SFORMAT; }
   "$sformatf"           { FL; return yD_SFORMATF; }
   "$shortrealtobits"    { FL; return yD_SHORTREALTOBITS; }

--- a/src/verilog.y
+++ b/src/verilog.y
@@ -5764,14 +5764,37 @@ tableEntry<udpTableLinep>:      // IEEE: combinational_entry + sequential_entry
 //************************************************
 // Specify
 
-specify_block<nodep>:           // ==IEEE: specify_block
-                ySPECIFY yD_SETUPHOLD '(' senitem ',' senitem ',' expr ',' expr ')' ';' yENDSPECIFY  { $$ = nullptr; }
-        |       ySPECIFY yD_SETUPHOLD '(' senitem ',' senitem ',' expr ',' expr ',' idAnyE ')' ';' yENDSPECIFY  { $$ = nullptr; }
-        |       ySPECIFY yD_SETUPHOLD '(' senitem ',' senitem ',' expr ',' expr ',' idAnyE ',' minTypMaxE ')' ';' yENDSPECIFY  { $$ = nullptr; }
-        |       ySPECIFY yD_SETUPHOLD '(' senitem ',' senitem ',' expr ',' expr ',' idAnyE ',' minTypMaxE ',' minTypMaxE ')' ';' yENDSPECIFY  { $$ = nullptr; }
-        |       ySPECIFY yD_SETUPHOLD '(' senitem ',' senitem ',' expr ',' expr ',' idAnyE ',' minTypMaxE ',' minTypMaxE ',' senitemE ')' ';' yENDSPECIFY  { $$ = new AstSetuphold{$2, $4, $6, $18}; }
-        |       ySPECIFY yD_SETUPHOLD '(' senitem ',' senitem ',' expr ',' expr ',' idAnyE ',' minTypMaxE ',' minTypMaxE ',' senitemE ',' senitemE ')' ';' yENDSPECIFY  { $$ = new AstSetuphold{$2, $4, $6, $18, $20}; }
+specify_block<nodep>:               // ==IEEE: specify_block
+                ySPECIFY specify_itemList yENDSPECIFY   { $$ = $2; }
         |       ySPECIFY yENDSPECIFY                    { $$ = nullptr; }
+        ;
+
+specify_itemList<nodep>:            // IEEE: { specify_item }
+                specify_item                            { $$ = $1; }
+        |       specify_itemList specify_item           { $$ = addNextNull($1, $2); }
+        ;
+
+specify_item<nodep>:                // ==IEEE: specify_item
+                specparam_declaration                   { $$ = $1; }
+        |       system_timing_check                     { $$ = $1; }
+        |       yaTIMINGSPEC junkToSemiList ';'         { $$ = nullptr; }
+        ;
+
+specparam_declaration<nodep>:       // ==IEEE: specparam_declaration
+                ySPECPARAM junkToSemiList ';'           { $$ = nullptr; }
+        ;
+
+system_timing_check<nodep>:         // ==IEEE: system_timing_check
+                setuphold_timing_check                      { $$ = $1; }
+        ;
+
+setuphold_timing_check<nodep>:      // ==IEEE: $setuphold_timing_check
+                yD_SETUPHOLD '(' senitem ',' senitem ',' expr ',' expr ')' ';' { $$ = nullptr; }
+        |       yD_SETUPHOLD '(' senitem ',' senitem ',' expr ',' expr ',' idAnyE ')' ';' { $$ = nullptr; }
+        |       yD_SETUPHOLD '(' senitem ',' senitem ',' expr ',' expr ',' idAnyE ',' minTypMaxE ')' ';' { $$ = nullptr; }
+        |       yD_SETUPHOLD '(' senitem ',' senitem ',' expr ',' expr ',' idAnyE ',' minTypMaxE ',' minTypMaxE ')' ';' { $$ = nullptr; }
+        |       yD_SETUPHOLD '(' senitem ',' senitem ',' expr ',' expr ',' idAnyE ',' minTypMaxE ',' minTypMaxE ',' senitemE ')' ';' { $$ = new AstSetuphold{$1, $3, $5, $17}; }
+        |       yD_SETUPHOLD '(' senitem ',' senitem ',' expr ',' expr ',' idAnyE ',' minTypMaxE ',' minTypMaxE ',' senitemE ',' senitemE ')' ';' { $$ = new AstSetuphold{$1, $3, $5, $17, $19}; }
         ;
 
 idAnyE<strp>:
@@ -5784,21 +5807,6 @@ senitemE<senItemp>:
         |       senitem                                   { $$ = $1; }
         ;
 
-
-specifyJunkList:
-                specifyJunk                             { } /* ignored */
-        |       specifyJunkList specifyJunk             { } /* ignored */
-        ;
-
-specifyJunk:
-                BISONPRE_NOT(ySPECIFY,yENDSPECIFY)      { }
-        |       ySPECIFY specifyJunk yENDSPECIFY        { }
-        |       error {}
-        ;
-
-specparam_declaration<nodep>:           // ==IEEE: specparam_declaration
-                ySPECPARAM junkToSemiList ';'           { $$ = nullptr; }
-        ;
 
 junkToSemiList:
                 junkToSemi                              { } /* ignored */

--- a/src/verilog.y
+++ b/src/verilog.y
@@ -5775,9 +5775,8 @@ specify_itemList<nodep>:            // IEEE: { specify_item }
         ;
 
 specify_item<nodep>:                // ==IEEE: specify_item
-                specparam_declaration                   { $$ = $1; }
-        |       system_timing_check                     { $$ = $1; }
-        |       yaTIMINGSPEC junkToSemiList ';'         { $$ = nullptr; }
+                system_timing_check                     { $$ = $1; }
+        |       junkToSemiList ';'                      { $$ = nullptr; }
         ;
 
 specparam_declaration<nodep>:       // ==IEEE: specparam_declaration
@@ -5828,7 +5827,7 @@ junkToSemiList:
         ;
 
 junkToSemi:
-                BISONPRE_NOT(';',yENDSPECIFY,yENDMODULE)        { }
+                BISONPRE_NOT(';',yENDSPECIFY,yENDMODULE,yD_SETUPHOLD)        { }
         |       error {}
         ;
 

--- a/src/verilog.y
+++ b/src/verilog.y
@@ -916,6 +916,7 @@ BISONPRE_VERSION(3.7,%define api.header.include {"V3ParseBison.h"})
 %token<fl>              yD_ROSE_GCLK    "$rose_gclk"
 %token<fl>              yD_RTOI         "$rtoi"
 %token<fl>              yD_SAMPLED      "$sampled"
+%token<fl>              yD_SETUPHOLD    "$setuphold"
 %token<fl>              yD_SFORMAT      "$sformat"
 %token<fl>              yD_SFORMATF     "$sformatf"
 %token<fl>              yD_SHORTREALTOBITS "$shortrealtobits"
@@ -3108,6 +3109,11 @@ delayExpr<nodeExprp>:
 minTypMax<nodeExprp>:           // IEEE: mintypmax_expression and constant_mintypmax_expression
                 delayExpr                               { $$ = $1; }
         |       delayExpr ':' delayExpr ':' delayExpr   { $$ = $3; MINTYPMAXDLYUNSUP($3); DEL($1); DEL($5); }
+        ;
+
+minTypMaxE<nodeExprp>:
+                /*empty*/                               { $$ = nullptr; }
+        |       minTypMax                               { $$ = $1; }
         ;
 
 netSigList<varp>:               // IEEE: list_of_port_identifiers
@@ -5759,9 +5765,25 @@ tableEntry<udpTableLinep>:      // IEEE: combinational_entry + sequential_entry
 // Specify
 
 specify_block<nodep>:           // ==IEEE: specify_block
-                ySPECIFY specifyJunkList yENDSPECIFY    { $$ = nullptr; }
+                ySPECIFY yD_SETUPHOLD '(' senitem ',' senitem ',' expr ',' expr ')' ';' yENDSPECIFY  { $$ = nullptr; }
+        |       ySPECIFY yD_SETUPHOLD '(' senitem ',' senitem ',' expr ',' expr ',' idAnyE ')' ';' yENDSPECIFY  { $$ = nullptr; }
+        |       ySPECIFY yD_SETUPHOLD '(' senitem ',' senitem ',' expr ',' expr ',' idAnyE ',' minTypMaxE ')' ';' yENDSPECIFY  { $$ = nullptr; }
+        |       ySPECIFY yD_SETUPHOLD '(' senitem ',' senitem ',' expr ',' expr ',' idAnyE ',' minTypMaxE ',' minTypMaxE ')' ';' yENDSPECIFY  { $$ = nullptr; }
+        |       ySPECIFY yD_SETUPHOLD '(' senitem ',' senitem ',' expr ',' expr ',' idAnyE ',' minTypMaxE ',' minTypMaxE ',' senitemE ')' ';' yENDSPECIFY  { $$ = new AstSetuphold{$2, $4, $6, $18}; }
+        |       ySPECIFY yD_SETUPHOLD '(' senitem ',' senitem ',' expr ',' expr ',' idAnyE ',' minTypMaxE ',' minTypMaxE ',' senitemE ',' senitemE ')' ';' yENDSPECIFY  { $$ = new AstSetuphold{$2, $4, $6, $18, $20}; }
         |       ySPECIFY yENDSPECIFY                    { $$ = nullptr; }
         ;
+
+idAnyE<strp>:
+                /*empty*/                               { $$ = nullptr; }
+        |       idAny                                   { $$ = $1; }
+        ;
+
+senitemE<senItemp>:
+                /*empty*/                               { $$ = nullptr; }
+        |       senitem                                   { $$ = $1; }
+        ;
+
 
 specifyJunkList:
                 specifyJunk                             { } /* ignored */

--- a/src/verilog.y
+++ b/src/verilog.y
@@ -5788,12 +5788,12 @@ system_timing_check<nodep>:         // ==IEEE: system_timing_check
         ;
 
 setuphold_timing_check<nodep>:      // ==IEEE: $setuphold_timing_check
-                yD_SETUPHOLD '(' timing_check_event ',' timing_check_event ',' expr ',' expr ')' ';' { $$ = nullptr; }
-        |       yD_SETUPHOLD '(' timing_check_event ',' timing_check_event ',' expr ',' expr ',' idAnyE ')' ';' { $$ = nullptr; }
-        |       yD_SETUPHOLD '(' timing_check_event ',' timing_check_event ',' expr ',' expr ',' idAnyE ',' minTypMaxE ')' ';' { $$ = nullptr; }
-        |       yD_SETUPHOLD '(' timing_check_event ',' timing_check_event ',' expr ',' expr ',' idAnyE ',' minTypMaxE ',' minTypMaxE ')' ';' { $$ = nullptr; }
-        |       yD_SETUPHOLD '(' timing_check_event ',' timing_check_event ',' expr ',' expr ',' idAnyE ',' minTypMaxE ',' minTypMaxE ',' delayed_referenceE ')' ';' { $$ = new AstSetuphold{$1, $3, $5, $17}; }
-        |       yD_SETUPHOLD '(' timing_check_event ',' timing_check_event ',' expr ',' expr ',' idAnyE ',' minTypMaxE ',' minTypMaxE ',' delayed_referenceE ',' delayed_referenceE ')' ';' { $$ = new AstSetuphold{$1, $3, $5, $17, $19}; }
+                yD_SETUPHOLD '(' timing_check_event ',' timing_check_event ',' timing_check_limit ',' timing_check_limit ')' ';' { $$ = nullptr; }
+        |       yD_SETUPHOLD '(' timing_check_event ',' timing_check_event ',' timing_check_limit ',' timing_check_limit ',' idAnyE ')' ';' { $$ = nullptr; }
+        |       yD_SETUPHOLD '(' timing_check_event ',' timing_check_event ',' timing_check_limit ',' timing_check_limit ',' idAnyE ',' minTypMaxE ')' ';' { $$ = nullptr; }
+        |       yD_SETUPHOLD '(' timing_check_event ',' timing_check_event ',' timing_check_limit ',' timing_check_limit ',' idAnyE ',' minTypMaxE ',' minTypMaxE ')' ';' { $$ = nullptr; }
+        |       yD_SETUPHOLD '(' timing_check_event ',' timing_check_event ',' timing_check_limit ',' timing_check_limit ',' idAnyE ',' minTypMaxE ',' minTypMaxE ',' delayed_referenceE ')' ';' { $$ = new AstSetuphold{$1, $3, $5, $17}; }
+        |       yD_SETUPHOLD '(' timing_check_event ',' timing_check_event ',' timing_check_limit ',' timing_check_limit ',' idAnyE ',' minTypMaxE ',' minTypMaxE ',' delayed_referenceE ',' delayed_referenceE ')' ';' { $$ = new AstSetuphold{$1, $3, $5, $17, $19}; }
         ;
 
 timing_check_event<nodeExprp>:      // ==IEEE: $timing_check_event
@@ -5805,6 +5805,11 @@ timing_check_event<nodeExprp>:      // ==IEEE: $timing_check_event
         |       yPOSEDGE terminal_identifier yP_ANDANDAND expr        { $$ = $2; }
         |       yNEGEDGE terminal_identifier yP_ANDANDAND expr        { $$ = $2; }
         |       yEDGE terminal_identifier yP_ANDANDAND expr           { $$ = $2; }
+        ;
+
+timing_check_limit<nodeExprp>:
+                expr                      { $$ = $1; }
+        |       expr ':' expr ':' expr    { $$ = $3; }
         ;
 
 delayed_referenceE<nodeExprp>:

--- a/src/verilog.y
+++ b/src/verilog.y
@@ -5792,8 +5792,8 @@ setuphold_timing_check<nodep>:      // ==IEEE: $setuphold_timing_check
         |       yD_SETUPHOLD '(' timing_check_event ',' timing_check_event ',' expr ',' expr ',' idAnyE ')' ';' { $$ = nullptr; }
         |       yD_SETUPHOLD '(' timing_check_event ',' timing_check_event ',' expr ',' expr ',' idAnyE ',' minTypMaxE ')' ';' { $$ = nullptr; }
         |       yD_SETUPHOLD '(' timing_check_event ',' timing_check_event ',' expr ',' expr ',' idAnyE ',' minTypMaxE ',' minTypMaxE ')' ';' { $$ = nullptr; }
-        |       yD_SETUPHOLD '(' timing_check_event ',' timing_check_event ',' expr ',' expr ',' idAnyE ',' minTypMaxE ',' minTypMaxE ',' terminal_identifierE ')' ';' { $$ = new AstSetuphold{$1, $3, $5, $17}; }
-        |       yD_SETUPHOLD '(' timing_check_event ',' timing_check_event ',' expr ',' expr ',' idAnyE ',' minTypMaxE ',' minTypMaxE ',' terminal_identifierE ',' terminal_identifierE ')' ';' { $$ = new AstSetuphold{$1, $3, $5, $17, $19}; }
+        |       yD_SETUPHOLD '(' timing_check_event ',' timing_check_event ',' expr ',' expr ',' idAnyE ',' minTypMaxE ',' minTypMaxE ',' delayed_referenceE ')' ';' { $$ = new AstSetuphold{$1, $3, $5, $17}; }
+        |       yD_SETUPHOLD '(' timing_check_event ',' timing_check_event ',' expr ',' expr ',' idAnyE ',' minTypMaxE ',' minTypMaxE ',' delayed_referenceE ',' delayed_referenceE ')' ';' { $$ = new AstSetuphold{$1, $3, $5, $17, $19}; }
         ;
 
 timing_check_event<nodeExprp>:      // ==IEEE: $timing_check_event
@@ -5807,13 +5807,13 @@ timing_check_event<nodeExprp>:      // ==IEEE: $timing_check_event
         |       yEDGE terminal_identifier yP_ANDANDAND expr           { $$ = $2; }
         ;
 
-terminal_identifier<nodeExprp>:
-                id                  { $$ = new AstParseRef{$<fl>1, VParseRefExp::PX_TEXT, *$1, nullptr, nullptr}; }
+delayed_referenceE<nodeExprp>:
+                /*empty*/                               { $$ = nullptr; }
+        |       terminal_identifier                     { $$ = $1; }
         ;
 
-terminal_identifierE<nodeExprp>:
-                /*empty*/               { $$ = nullptr; }
-        |       terminal_identifier     { $$ = $1; }
+terminal_identifier<nodeExprp>:
+                idArrayed     { $$ = $1; }
         ;
 
 idAnyE<strp>:

--- a/src/verilog.y
+++ b/src/verilog.y
@@ -443,6 +443,8 @@ BISONPRE_VERSION(3.7,%define api.header.include {"V3ParseBison.h"})
 // IEEE: string_literal
 %token<strp>            yaSTRING        "STRING"
 %token<strp>            yaSTRING__IGNORE "STRING-ignored"       // Used when expr:string not allowed
+// IEEE: edge_descriptor
+%token<nump>            yaEDGEDESC        "EDGE DESCRIPTOR"
 
 %token<fl>              yaTIMINGSPEC    "TIMING SPEC ELEMENT"
 
@@ -5797,14 +5799,21 @@ setuphold_timing_check<nodep>:      // ==IEEE: $setuphold_timing_check
         ;
 
 timing_check_event<nodeExprp>:      // ==IEEE: $timing_check_event
-                terminal_identifier                                   { $$ = $1; }
-        |       yPOSEDGE terminal_identifier                          { $$ = $2; }
-        |       yNEGEDGE terminal_identifier                          { $$ = $2; }
-        |       yEDGE terminal_identifier                             { $$ = $2; }
-        |       terminal_identifier yP_ANDANDAND expr                 { $$ = $1; }
-        |       yPOSEDGE terminal_identifier yP_ANDANDAND expr        { $$ = $2; }
-        |       yNEGEDGE terminal_identifier yP_ANDANDAND expr        { $$ = $2; }
-        |       yEDGE terminal_identifier yP_ANDANDAND expr           { $$ = $2; }
+                terminal_identifier                                                         { $$ = $1; }
+        |       yPOSEDGE terminal_identifier                                                { $$ = $2; }
+        |       yNEGEDGE terminal_identifier                                                { $$ = $2; }
+        |       yEDGE terminal_identifier                                                   { $$ = $2; }
+        |       yEDGE '[' edge_descriptor_list ']' terminal_identifier                      { $$ = $5; }
+        |       terminal_identifier yP_ANDANDAND expr                                       { $$ = $1; }
+        |       yPOSEDGE terminal_identifier yP_ANDANDAND expr                              { $$ = $2; }
+        |       yNEGEDGE terminal_identifier yP_ANDANDAND expr                              { $$ = $2; }
+        |       yEDGE terminal_identifier yP_ANDANDAND expr                                 { $$ = $2; }
+        |       yEDGE '[' edge_descriptor_list ']' terminal_identifier yP_ANDANDAND expr    { $$ = $5; }
+        ;
+
+edge_descriptor_list:
+                yaEDGEDESC                            {  }
+        |       edge_descriptor_list ',' yaEDGEDESC   {  }
         ;
 
 timing_check_limit<nodeExprp>:

--- a/src/verilog.y
+++ b/src/verilog.y
@@ -5789,24 +5789,38 @@ system_timing_check<nodep>:         // ==IEEE: system_timing_check
         ;
 
 setuphold_timing_check<nodep>:      // ==IEEE: $setuphold_timing_check
-                yD_SETUPHOLD '(' senitem ',' senitem ',' expr ',' expr ')' ';' { $$ = nullptr; }
-        |       yD_SETUPHOLD '(' senitem ',' senitem ',' expr ',' expr ',' idAnyE ')' ';' { $$ = nullptr; }
-        |       yD_SETUPHOLD '(' senitem ',' senitem ',' expr ',' expr ',' idAnyE ',' minTypMaxE ')' ';' { $$ = nullptr; }
-        |       yD_SETUPHOLD '(' senitem ',' senitem ',' expr ',' expr ',' idAnyE ',' minTypMaxE ',' minTypMaxE ')' ';' { $$ = nullptr; }
-        |       yD_SETUPHOLD '(' senitem ',' senitem ',' expr ',' expr ',' idAnyE ',' minTypMaxE ',' minTypMaxE ',' senitemE ')' ';' { $$ = new AstSetuphold{$1, $3, $5, $17}; }
-        |       yD_SETUPHOLD '(' senitem ',' senitem ',' expr ',' expr ',' idAnyE ',' minTypMaxE ',' minTypMaxE ',' senitemE ',' senitemE ')' ';' { $$ = new AstSetuphold{$1, $3, $5, $17, $19}; }
+                yD_SETUPHOLD '(' timing_check_event ',' timing_check_event ',' expr ',' expr ')' ';' { $$ = nullptr; }
+        |       yD_SETUPHOLD '(' timing_check_event ',' timing_check_event ',' expr ',' expr ',' idAnyE ')' ';' { $$ = nullptr; }
+        |       yD_SETUPHOLD '(' timing_check_event ',' timing_check_event ',' expr ',' expr ',' idAnyE ',' minTypMaxE ')' ';' { $$ = nullptr; }
+        |       yD_SETUPHOLD '(' timing_check_event ',' timing_check_event ',' expr ',' expr ',' idAnyE ',' minTypMaxE ',' minTypMaxE ')' ';' { $$ = nullptr; }
+        |       yD_SETUPHOLD '(' timing_check_event ',' timing_check_event ',' expr ',' expr ',' idAnyE ',' minTypMaxE ',' minTypMaxE ',' terminal_identifierE ')' ';' { $$ = new AstSetuphold{$1, $3, $5, $17}; }
+        |       yD_SETUPHOLD '(' timing_check_event ',' timing_check_event ',' expr ',' expr ',' idAnyE ',' minTypMaxE ',' minTypMaxE ',' terminal_identifierE ',' terminal_identifierE ')' ';' { $$ = new AstSetuphold{$1, $3, $5, $17, $19}; }
+        ;
+
+timing_check_event<nodeExprp>:      // ==IEEE: $timing_check_event
+                terminal_identifier                                   { $$ = $1; }
+        |       yPOSEDGE terminal_identifier                          { $$ = $2; }
+        |       yNEGEDGE terminal_identifier                          { $$ = $2; }
+        |       yEDGE terminal_identifier                             { $$ = $2; }
+        |       terminal_identifier yP_ANDANDAND expr                 { $$ = $1; }
+        |       yPOSEDGE terminal_identifier yP_ANDANDAND expr        { $$ = $2; }
+        |       yNEGEDGE terminal_identifier yP_ANDANDAND expr        { $$ = $2; }
+        |       yEDGE terminal_identifier yP_ANDANDAND expr           { $$ = $2; }
+        ;
+
+terminal_identifier<nodeExprp>:
+                id                  { $$ = new AstParseRef{$<fl>1, VParseRefExp::PX_TEXT, *$1, nullptr, nullptr}; }
+        ;
+
+terminal_identifierE<nodeExprp>:
+                /*empty*/               { $$ = nullptr; }
+        |       terminal_identifier     { $$ = $1; }
         ;
 
 idAnyE<strp>:
                 /*empty*/                               { $$ = nullptr; }
         |       idAny                                   { $$ = $1; }
         ;
-
-senitemE<senItemp>:
-                /*empty*/                               { $$ = nullptr; }
-        |       senitem                                   { $$ = $1; }
-        ;
-
 
 junkToSemiList:
                 junkToSemi                              { } /* ignored */

--- a/test_regress/t/t_gate_basic.v
+++ b/test_regress/t/t_gate_basic.v
@@ -77,7 +77,6 @@ module t (/*AUTOARG*/
     $recrem();
     $removal();
     $setup();
-    $setuphold();
     $skew();
     $timeskew();
     $width();

--- a/test_regress/t/t_setuphold.py
+++ b/test_regress/t/t_setuphold.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2025 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile()
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_setuphold.v
+++ b/test_regress/t/t_setuphold.v
@@ -7,11 +7,13 @@
 module t (/*AUTOARG*/
    // Inputs
    clk,
-   d
+   d,
+   t_in
    );
 
    input clk;
    input d;
+   input t_in;
    wire delayed_CLK;
    wire delayed_D;
    reg notifier;
@@ -52,6 +54,8 @@ module t (/*AUTOARG*/
       $setuphold (negedge fake_CLK, negedge fake_D &&& sh1, 0, 0);
       $setuphold (edge fake_CLK, edge fake_D &&& sh1, 0, 0);
       $setuphold (edge [0Z, z1, 10] fake_CLK, edge [01, x0, 0X] fake_CLK &&& sh1, 0, 0);
+
+      $setuphold (posedge clk, negedge d, 0, 0, notifier, (0:0:0), 0, t_in);
    endspecify
 
    initial begin

--- a/test_regress/t/t_setuphold.v
+++ b/test_regress/t/t_setuphold.v
@@ -32,6 +32,7 @@ module t (/*AUTOARG*/
       $setuphold (posedge sh1, negedge sh3, 0, 0, notifier,,, sh2, sh4);
       $setuphold (posedge clk, negedge d, 0, 0);
       $setuphold (posedge clk, negedge d, (0:0:0), (0:0:0));
+      $setuphold (posedge clk, negedge d, 0:0:0, 0:0:0);
       $setuphold (posedge clk, negedge d, 0, 0,,,,,);
       $setuphold (posedge clk &&& sh1, BL_X[0], 0, 0, ,,,delayed_CLK, BL_0);
       $setuphold (posedge clk &&& sh1, BL_1, 0, 0, ,,,delayed_CLK, BL_X2[4:1]);

--- a/test_regress/t/t_setuphold.v
+++ b/test_regress/t/t_setuphold.v
@@ -15,6 +15,10 @@ module t (/*AUTOARG*/
    wire delayed_CLK;
    wire delayed_D;
    reg notifier;
+   wire [1:0] BL_X = 2'b11;
+   wire [5:0] BL_X2;
+   wire BL_0;
+   wire [3:0] BL_1 = 4'b1100;
 
    logic[3:0] sh1 = 1;
    logic[3:0] sh2 = 2;
@@ -27,11 +31,17 @@ module t (/*AUTOARG*/
       $setuphold (posedge clk, negedge d, 0, 0, notifier,,, delayed_CLK, delayed_D);
       $setuphold (posedge sh1, negedge sh3, 0, 0, notifier,,, sh2, sh4);
       $setuphold (posedge clk, negedge d, 0, 0);
+      $setuphold (posedge clk, negedge d, (0:0:0), (0:0:0));
       $setuphold (posedge clk, negedge d, 0, 0,,,,,);
+      $setuphold (posedge clk &&& sh1, BL_X[0], 0, 0, ,,,delayed_CLK, BL_0);
+      $setuphold (posedge clk &&& sh1, BL_1, 0, 0, ,,,delayed_CLK, BL_X2[4:1]);
    endspecify
 
    initial begin
       if (sh1 != sh2 || sh3 != sh4) begin
+         $stop;
+      end
+      if (BL_0 != BL_X[0] || BL_1 != BL_X2[4:1]) begin
          $stop;
       end
    end

--- a/test_regress/t/t_setuphold.v
+++ b/test_regress/t/t_setuphold.v
@@ -1,0 +1,49 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2025 by Antmicro.
+// SPDX-License-Identifier: CC0-1.0
+
+module t (/*AUTOARG*/
+   // Inputs
+   clk,
+   d
+   );
+
+   input clk;
+   input d;
+   wire delayed_CLK;
+   wire delayed_D;
+   reg notifier;
+
+   logic[3:0] sh1 = 1;
+   logic[3:0] sh2 = 2;
+   logic[3:0] sh3 = 3;
+   logic[3:0] sh4 = 4;
+
+   int cyc = 0;
+
+   specify
+      $setuphold (posedge clk, negedge d, 0, 0, notifier,,, delayed_CLK, delayed_D);
+      $setuphold (posedge sh1, negedge sh3, 0, 0, notifier,,, sh2, sh4);
+      $setuphold (posedge clk, negedge d, 0, 0);
+   endspecify
+
+   initial begin
+      if (sh1 != sh2 || sh3 != sh4) begin
+         $stop;
+      end
+   end
+
+   always @(posedge clk) begin
+      cyc <= cyc + 1;
+      $display("%d %d", clk, delayed_CLK);
+      if (delayed_CLK != clk || delayed_D != d) begin
+         $stop;
+      end
+      if (cyc == 10) begin
+         $display("*-* All Finished *-*");
+         $finish;
+      end
+   end
+endmodule

--- a/test_regress/t/t_setuphold.v
+++ b/test_regress/t/t_setuphold.v
@@ -19,27 +19,46 @@ module t (/*AUTOARG*/
    wire [5:0] BL_X2;
    wire BL_0;
    wire [3:0] BL_1 = 4'b1100;
+   wire fake_CLK;
+   wire fake_D;
 
    logic[3:0] sh1 = 1;
    logic[3:0] sh2 = 2;
    logic[3:0] sh3 = 3;
    logic[3:0] sh4 = 4;
+   logic[3:0] sh5 = 5;
+   logic[3:0] sh6 = 6;
 
    int cyc = 0;
 
    specify
-      $setuphold (posedge clk, negedge d, 0, 0, notifier,,, delayed_CLK, delayed_D);
+      $setuphold (posedge clk, negedge d, 0, 0, notifier, (0:0:0), 0, delayed_CLK, delayed_D);
       $setuphold (posedge sh1, negedge sh3, 0, 0, notifier,,, sh2, sh4);
+      $setuphold (posedge sh5, negedge d, 0, 0, notifier,,, sh6);
+      $setuphold (posedge clk, negedge d, 0, 0, notifier, (1:2:3), (0:0:0));
+      $setuphold (posedge clk, negedge d, 0, 0, notifier, (1:2:3));
+      $setuphold (posedge clk, negedge d, 0, 0, notifier);
+      $setuphold (posedge clk, negedge d, 0, 0);
       $setuphold (posedge clk, negedge d, 0, 0);
       $setuphold (posedge clk, negedge d, (0:0:0), (0:0:0));
       $setuphold (posedge clk, negedge d, 0:0:0, 0:0:0);
       $setuphold (posedge clk, negedge d, 0, 0,,,,,);
+
       $setuphold (posedge clk &&& sh1, BL_X[0], 0, 0, ,,,delayed_CLK, BL_0);
       $setuphold (posedge clk &&& sh1, BL_1, 0, 0, ,,,delayed_CLK, BL_X2[4:1]);
+
+      $setuphold (fake_CLK, fake_D &&& sh1, 0, 0);
+      $setuphold (posedge fake_CLK, posedge fake_D &&& sh1, 0, 0);
+      $setuphold (negedge fake_CLK, negedge fake_D &&& sh1, 0, 0);
+      $setuphold (edge fake_CLK, edge fake_D &&& sh1, 0, 0);
+      $setuphold (edge [0Z, z1, 10] fake_CLK, edge [01, x0, 0X] fake_CLK &&& sh1, 0, 0);
    endspecify
 
    initial begin
       if (sh1 != sh2 || sh3 != sh4) begin
+         $stop;
+      end
+      if (sh5 != sh6) begin
          $stop;
       end
       if (BL_0 != BL_X[0] || BL_1 != BL_X2[4:1]) begin

--- a/test_regress/t/t_setuphold.v
+++ b/test_regress/t/t_setuphold.v
@@ -27,6 +27,7 @@ module t (/*AUTOARG*/
       $setuphold (posedge clk, negedge d, 0, 0, notifier,,, delayed_CLK, delayed_D);
       $setuphold (posedge sh1, negedge sh3, 0, 0, notifier,,, sh2, sh4);
       $setuphold (posedge clk, negedge d, 0, 0);
+      $setuphold (posedge clk, negedge d, 0, 0,,,,,);
    endspecify
 
    initial begin


### PR DESCRIPTION
This PR adds support for $setuphold system task explicit delayed signals assignment. It does not implement the timing check. The setuphold calls are replaced in the AST with wire assignments for the delayed signals, like so:
``` 
specify
    $setuphold (posedge clk, negedge d, 0, 0, notifier,,, delayed_CLK, delayed_D);
endspecify
```
Replaced with:
```
assign delayed_CLK = clk;
assign delayed_D = d;
```
Along with the UDP changes (https://github.com/verilator/verilator/pull/5807), this will allow for post-synthesis simulation with PDKs such as ASAP7 (tested with OpenROAD-flow-scripts `aes` example).