### PR TITLE
ci: Enable manual Docker image build and push

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -76,11 +76,11 @@ jobs:
 
       - name: Build and Push to Docker
         uses: docker/build-push-action@v4
-        if: startsWith(github.ref, 'refs/tags/v')
+        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
         with:
           context: ${{ env.build_context }}
           build-args: SOURCE_COMMIT=${{ env.git_tag }}
           platforms: linux/arm64,linux/amd64
-          push: ${{ !env.ACT && startsWith(github.ref, 'refs/tags/v') }}
+          push: ${{ !env.ACT && (startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch') }}
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}


### PR DESCRIPTION
It appears that issue https://github.com/verilator/verilator/issues/5882 is not resolved.

In fact, the latest run (https://github.com/verilator/verilator/actions/runs/14068783824/job/39397743465) skipped the "Build and Push to Docker" step.

This PR proposes to change this behaviour, enabling the build on manually triggered CI runs (`workflow_dispatch` event).