### PR TITLE
Fix PGO profiling for multi-threaded hierarchical scenario

### DIFF
--- a/src/V3EmitCSyms.cpp
+++ b/src/V3EmitCSyms.cpp
@@ -731,8 +731,11 @@ void EmitCSyms::emitSymImp() {
         puts("#endif  // VM_TRACE\n");
     }
     if (v3Global.opt.profPgo()) {
+        // Do not overwrite data during the last hierarchical stage.
+        const string firstHierCall
+            = (v3Global.opt.hierBlocks().empty() || v3Global.opt.hierChild()) ? "true" : "false";
         puts("_vm_pgoProfiler.write(\"" + topClassName()
-             + "\", _vm_contextp__->profVltFilename());\n");
+             + "\", _vm_contextp__->profVltFilename(), " + firstHierCall + ");\n");
     }
     puts("}\n");
 

--- a/test_regress/t/t_hier_block_perf.py
+++ b/test_regress/t/t_hier_block_perf.py
@@ -11,7 +11,7 @@ import vltest_bootstrap
 
 test.scenarios('vlt_all')
 test.init_benchmarksim()
-test.cycles = (int(test.benchmark) if test.benchmark else 1000000)
+test.cycles = (int(test.benchmark) if test.benchmark else 100000)
 test.sim_time = test.cycles * 10 + 1000
 
 THREADS = int(os.environ["THREADS"]) if "THREADS" in os.environ else 4

--- a/test_regress/t/t_pgo_threads_hier.py
+++ b/test_regress/t/t_pgo_threads_hier.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2025 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('vltmt')
+test.top_filename = "t/t_hier_block_perf.v"
+cycles = 100000
+test.sim_time = cycles * 10 + 1000
+
+threads = 2
+flags = ["--hierarchical", "-Wno-UNOPTFLAT", "-DSIM_CYCLES=" + str(cycles)]
+
+test.compile(benchmarksim=1, v_flags2=["--prof-pgo"] + flags, threads=threads)
+
+test.execute(all_run_flags=[
+    "+verilator+prof+exec+start+0",
+    " +verilator+prof+exec+file+/dev/null",
+    " +verilator+prof+vlt+file+" + test.obj_dir + "/profile.vlt"])  # yapf:disable
+
+test.file_grep(test.obj_dir + "/profile.vlt", r'profile_data -model "V' + test.name + '"')
+
+# Differentiate benchmarksim results
+test.name = test.name + "_optimized"
+test.compile(
+    benchmarksim=1,
+    # Intentionally no --prof-pgo here to make sure profile data can be read in
+    # without it (that is: --prof-pgo has no effect on profile_data hash names)
+    v_flags2=flags,
+    threads=threads)
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_pgo_threads_hier_nested.py
+++ b/test_regress/t/t_pgo_threads_hier_nested.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2025 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('vltmt')
+test.top_filename = "t/t_hier_block_perf.v"
+cycles = 100000
+test.sim_time = cycles * 10 + 1000
+
+threads = 2
+config_file = test.t_dir + "/" + test.name + ".vlt"
+flags = [config_file, "--hierarchical", "-Wno-UNOPTFLAT", "-DSIM_CYCLES=" + str(cycles)]
+
+test.compile(benchmarksim=1, v_flags2=["--prof-pgo"] + flags, threads=threads)
+
+test.execute(all_run_flags=[
+    "+verilator+prof+exec+start+0",
+    " +verilator+prof+exec+file+/dev/null",
+    " +verilator+prof+vlt+file+" + test.obj_dir + "/profile.vlt"])  # yapf:disable
+
+test.file_grep(test.obj_dir + "/profile.vlt", r'profile_data -model "VTest"')
+test.file_grep(test.obj_dir + "/profile.vlt", r'profile_data -model "V' + test.name + '"')
+
+# Differentiate benchmarksim results
+test.name = test.name + "_optimized"
+test.compile(
+    benchmarksim=1,
+    # Intentionally no --prof-pgo here to make sure profile data can be read in
+    # without it (that is: --prof-pgo has no effect on profile_data hash names)
+    v_flags2=flags,
+    threads=threads)
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_pgo_threads_hier_nested.vlt
+++ b/test_regress/t/t_pgo_threads_hier_nested.vlt
@@ -1,0 +1,8 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed into the Public Domain, for any use,
+// without warranty, 2025 by Antmicro.
+// SPDX-License-Identifier: CC0-1.0
+
+`verilator_config
+hier_workers -module "Test" -workers 2


### PR DESCRIPTION
This PR prevents multi-instantiation of profVltFile when running hierarchical verilation with `--prof-pgo`. This way, hierarchical blocks that have schedules inside can be profiled as well.

In the meantime I decreased cycle count for `t_hier_block_perf` to speedup testing.