### PR TITLE
Add support for command-line overriding `define

### DIFF
--- a/docs/guide/warnings.rst
+++ b/docs/guide/warnings.rst
@@ -1261,6 +1261,31 @@ List Of Warnings
    Ignoring this warning will only suppress the lint check; it will
    simulate correctly.
 
+
+.. option:: OVERRIDEDEF
+
+   Warns that a macro definition within the code is being overridden by a command line directive:
+   
+   For example, running Verilator with :vlopt:`+define+DUP=def1` and
+
+   .. code-block:: sv
+      :linenos:
+      :emphasize-lines: 1
+
+         `define DUP def2 //<--- Warning
+
+   Results in:
+
+   .. code-block::
+         %Warning-OVERRIDEDEF: example.v1:20: Overriding define: 'DEF' with value: 'def2' to existing command line define value: 'def1'
+                      ... Location of previous definition, with value: '50'
+
+   While not explicitly stated in the IEEE 1800-2023 standard, this warning
+   tracks with the other simulators' behavior of overriding macro
+   definitions within code files with the definition passed in through
+   the command line.
+
+
 .. option:: PINCONNECTEMPTY
 
    .. TODO better example

--- a/src/V3Error.h
+++ b/src/V3Error.h
@@ -121,6 +121,7 @@ public:
         NOLATCH,        // No latch detected in always_latch block
         NONSTD,         // Non-standard feature present in other sims
         NULLPORT,       // Null port detected in module definition
+        OVERRIDEDEF,    // Overriding existing define macro through command line
         PINCONNECTEMPTY,// Cell pin connected by name with empty reference
         PINMISSING,     // Cell pin not specified
         PINNOCONNECT,   // Cell pin not connected
@@ -203,7 +204,7 @@ public:
             "IMPERFECTSCH", "IMPLICIT", "IMPLICITSTATIC", "IMPORTSTAR", "IMPURE",
             "INCABSPATH", "INFINITELOOP", "INITIALDLY", "INSECURE",
             "LATCH", "LITENDIAN", "MINTYPMAXDLY", "MISINDENT", "MODDUP",
-            "MULTIDRIVEN", "MULTITOP", "NEWERSTD", "NOLATCH", "NONSTD", "NULLPORT", "PINCONNECTEMPTY",
+            "MULTIDRIVEN", "MULTITOP", "NEWERSTD", "NOLATCH", "NONSTD", "NULLPORT", "OVERRIDEDEF", "PINCONNECTEMPTY",
             "PINMISSING", "PINNOCONNECT",  "PINNOTFOUND", "PKGNODECL", "PREPROCZERO", "PROCASSWIRE",
             "PROFOUTOFDATE", "PROTECTED", "RANDC", "REALCVT", "REDEFMACRO", "RISEFALLDLY",
             "SELRANGE", "SHORTREAL", "SIDEEFFECT", "SPLITVAR",

--- a/test_regress/t/t_define_override.out
+++ b/test_regress/t/t_define_override.out
@@ -1,0 +1,9 @@
+%Warning-REDEFMACRO: Redefining existing define: 'TEST_MACRO', with different value: '50'
+                     ... Location of previous definition, with value: '20'
+                     ... For warning description see https://verilator.org/warn/REDEFMACRO?v=latest
+                     ... Use "/* verilator lint_off REDEFMACRO */" and lint_on around source to disable this message.
+%Warning-OVERRIDEDEF: t/t_define_override.v:2:23: Overriding define: 'TEST_MACRO' with value: '10' to existing command line define value: '50'
+                      ... Location of previous definition, with value: '50'
+%Warning-OVERRIDEDEF: t/t_define_override.v:3:24: Overriding define: 'TEST_MACRO' with value: '100' to existing command line define value: '50'
+                      ... Location of previous definition, with value: '50'
+%Error: Exiting due to

--- a/test_regress/t/t_define_override.py
+++ b/test_regress/t/t_define_override.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2025 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('linter')
+
+test.lint(verilator_flags2=["+define+TEST_MACRO=20 +define+TEST_MACRO=50"], fails=True, expect_filename=test.golden_filename)
+
+test.passes()

--- a/test_regress/t/t_define_override.v
+++ b/test_regress/t/t_define_override.v
@@ -1,0 +1,10 @@
+`define TEST_MACRO 10
+`define TEST_MACRO 100
+module test (
+);
+    initial begin
+        $display("TEST_MACRO %d", `TEST_MACRO);
+        $finish;
+    end
+
+endmodule

--- a/test_regress/t/t_define_override_output.out
+++ b/test_regress/t/t_define_override_output.out
@@ -1,0 +1,1 @@
+TEST_MACRO          50

--- a/test_regress/t/t_define_override_output.py
+++ b/test_regress/t/t_define_override_output.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2025 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('vlt')
+test.top_filename = "t/t_define_override.v"
+
+test.compile(verilator_flags2=["-Wno-OVERRIDEDEF -Wno-REDEFMACRO +define+TEST_MACRO=20 +define+TEST_MACRO=50"])
+
+test.execute(expect_filename=test.golden_filename)
+
+test.passes()


### PR DESCRIPTION
This PR modifies the behavior of how ``+define+MACRO`` interacts with `` `define MACRO `` in line with #5900, specifically to mirror other simulators' behavior of always taking the global command-line define rather than the `` `define `` compiler directive. This PR introduces a new warning ```OVERRIDEDEF``` to detail this behavior, as well as a couple of tests to check for proper warning and override behavior.