### PR TITLE
Fix assignments with stream expressions and unpacked arrays

### DIFF
--- a/src/V3AstNodeDType.h
+++ b/src/V3AstNodeDType.h
@@ -157,7 +157,7 @@ public:
     bool generic() const VL_MT_SAFE { return m_generic; }
     void generic(bool flag) { m_generic = flag; }
     std::pair<uint32_t, uint32_t> dimensions(bool includeBasic);
-    uint32_t arrayUnpackedElements();  // 1, or total multiplication of all dimensions
+    uint32_t arrayUnpackedElements() const;  // 1, or total multiplication of all dimensions
     static int uniqueNumInc() { return ++s_uniqueNum; }
     const char* charIQWN() const {
         return (isString() ? "N" : isWide() ? "W" : isQuad() ? "Q" : "I");

--- a/src/V3AstNodes.cpp
+++ b/src/V3AstNodes.cpp
@@ -1016,11 +1016,11 @@ AstNodeDType::CTypeRecursed AstNodeDType::cTypeRecurse(bool compound, bool packe
     return info;
 }
 
-uint32_t AstNodeDType::arrayUnpackedElements() {
+uint32_t AstNodeDType::arrayUnpackedElements() const {
     uint32_t entries = 1;
-    for (AstNodeDType* dtypep = this; dtypep;) {
+    for (const AstNodeDType* dtypep = this; dtypep;) {
         dtypep = dtypep->skipRefp();  // Skip AstRefDType/AstTypedef, or return same node
-        if (AstUnpackArrayDType* const adtypep = VN_CAST(dtypep, UnpackArrayDType)) {
+        if (const AstUnpackArrayDType* const adtypep = VN_CAST(dtypep, UnpackArrayDType)) {
             entries *= adtypep->elementsConst();
             dtypep = adtypep->subDTypep();
         } else {

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -5198,11 +5198,12 @@ class WidthVisitor final : public VNVisitor {
             //
             // if (debug()) nodep->dumpTree("-    assign: ");
             AstNodeDType* const lhsDTypep
-                = nodep->lhsp()->dtypep()->skipRefp();  // Note we use rhsp for context determined
+                = nodep->lhsp()->dtypep();  // Note we use rhsp for context determined
 
             // Check width of stream and wrap if needed
             if (AstNodeStream* const streamp = VN_CAST(nodep->rhsp(), NodeStream)) {
-                const int lwidth = widthUnpacked(lhsDTypep);
+                AstNodeDType* const lhsDTypeSkippedRefp = lhsDTypep->skipRefp();
+                const int lwidth = widthUnpacked(lhsDTypeSkippedRefp);
                 const int rwidth = widthUnpacked(streamp->lhsp()->dtypep()->skipRefp());
                 if (lwidth != 0 && lwidth < rwidth) {
                     nodep->v3widthWarn(lwidth, rwidth,
@@ -5210,9 +5211,10 @@ class WidthVisitor final : public VNVisitor {
                                            << lwidth << " bits) is narrower than the stream ("
                                            << rwidth << " bits) (IEEE 1800-2023 11.4.14)");
                 }
-                if (VN_IS(lhsDTypep, NodeArrayDType)) {
+                if (VN_IS(lhsDTypeSkippedRefp, NodeArrayDType)) {
                     streamp->unlinkFrBack();
-                    nodep->rhsp(new AstCvtPackedToArray{streamp->fileline(), streamp, lhsDTypep});
+                    nodep->rhsp(new AstCvtPackedToArray{streamp->fileline(), streamp,
+                                                        lhsDTypeSkippedRefp});
                 }
             }
             if (const AstNodeStream* const streamp = VN_CAST(nodep->lhsp(), NodeStream)) {

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -5198,12 +5198,12 @@ class WidthVisitor final : public VNVisitor {
             //
             // if (debug()) nodep->dumpTree("-    assign: ");
             AstNodeDType* const lhsDTypep
-                = nodep->lhsp()->dtypep();  // Note we use rhsp for context determined
+                = nodep->lhsp()->dtypep()->skipRefp();  // Note we use rhsp for context determined
 
             // Check width of stream and wrap if needed
             if (AstNodeStream* const streamp = VN_CAST(nodep->rhsp(), NodeStream)) {
                 const int lwidth = widthUnpacked(lhsDTypep);
-                const int rwidth = widthUnpacked(streamp->lhsp()->dtypep());
+                const int rwidth = widthUnpacked(streamp->lhsp()->dtypep()->skipRefp());
                 if (lwidth != 0 && lwidth < rwidth) {
                     nodep->v3widthWarn(lwidth, rwidth,
                                        "Target fixed size variable ("
@@ -5216,8 +5216,10 @@ class WidthVisitor final : public VNVisitor {
                 }
             }
             if (const AstNodeStream* const streamp = VN_CAST(nodep->lhsp(), NodeStream)) {
-                const int lwidth = widthUnpacked(streamp->lhsp()->dtypep());
-                const int rwidth = widthUnpacked(nodep->rhsp()->dtypep());
+                const AstNodeDType* const rhsDTypep = nodep->rhsp()->dtypep()->skipRefp();
+
+                const int lwidth = widthUnpacked(streamp->lhsp()->dtypep()->skipRefp());
+                const int rwidth = widthUnpacked(rhsDTypep);
                 if (rwidth != 0 && rwidth < lwidth) {
                     nodep->v3widthWarn(lwidth, rwidth,
                                        "Stream target requires "
@@ -5225,7 +5227,7 @@ class WidthVisitor final : public VNVisitor {
                                            << " bits, but source expression only provides "
                                            << rwidth << " bits (IEEE 1800-2023 11.4.14.3)");
                 }
-                if (VN_IS(nodep->rhsp()->dtypep(), NodeArrayDType)) {
+                if (VN_IS(rhsDTypep, NodeArrayDType)) {
                     AstNodeExpr* const rhsp = nodep->rhsp()->unlinkFrBack();
                     nodep->rhsp(
                         new AstCvtArrayToPacked{rhsp->fileline(), rhsp, streamp->dtypep()});

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -1599,6 +1599,12 @@ class WidthVisitor final : public VNVisitor {
         userIterateAndNext(nodep->fromp(), WidthVP{SELF, BOTH}.p());
         // Type set in constructor
     }
+    void visit(AstCvtArrayToPacked* nodep) override {
+        if (nodep->didWidthAndSet()) return;
+        // Opaque returns, so arbitrary
+        userIterateAndNext(nodep->fromp(), WidthVP{SELF, BOTH}.p());
+        // Type set in constructor
+    }
     void visit(AstTimeImport* nodep) override {
         // LHS is a real number in seconds
         // Need to round to time units and precision
@@ -5218,6 +5224,11 @@ class WidthVisitor final : public VNVisitor {
                                            << lwidth
                                            << " bits, but source expression only provides "
                                            << rwidth << " bits (IEEE 1800-2023 11.4.14.3)");
+                }
+                if (VN_IS(nodep->rhsp()->dtypep(), NodeArrayDType)) {
+                    AstNodeExpr* const rhsp = nodep->rhsp()->unlinkFrBack();
+                    nodep->rhsp(
+                        new AstCvtArrayToPacked{rhsp->fileline(), rhsp, streamp->dtypep()});
                 }
             }
 

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -5189,6 +5189,17 @@ class WidthVisitor final : public VNVisitor {
 
             if (VN_IS(nodep->lhsp()->dtypep(), NodeArrayDType)
                 && VN_IS(nodep->rhsp(), NodeStream)) {
+                if (const AstUnpackArrayDType* const arr
+                    = VN_CAST(nodep->lhsp()->dtypep(), UnpackArrayDType)) {
+                    const int lwidth = arr->subDTypep()->width() * arr->arrayUnpackedElements();
+                    const int rwidth = nodep->rhsp()->width();
+                    if (lwidth < rwidth) {
+                        nodep->v3widthWarn(lwidth, rwidth,
+                                           "Target fixed size variable ("
+                                               << lwidth << " bits) is narrower than the stream ("
+                                               << rwidth << " bits) (IEEE 1800-2023 11.4.14)");
+                    }
+                }
                 AstNodeExpr* const rhsp = nodep->rhsp()->unlinkFrBack();
                 nodep->rhsp(new AstCvtPackedToArray{rhsp->fileline(), rhsp, lhsDTypep});
             }

--- a/test_regress/t/t_stream_unpack.v
+++ b/test_regress/t/t_stream_unpack.v
@@ -37,6 +37,9 @@ module t (/*AUTOARG*/);
       ans = { >> bit {arr} };
       `checkh(ans, bit6);
 
+      { >> bit {ans}} = arr;
+      `checkh(ans, bit6);
+
       ans_enum = enum_t'({ >> bit {arr} });
       `checkh(ans_enum, bit6);
 
@@ -47,6 +50,9 @@ module t (/*AUTOARG*/);
       `checkp(arr, "'{'h0, 'h0, 'h0, 'h1, 'h1, 'h1} ");
 
       ans = { << bit {arr} };
+      `checkh(ans, bit6);
+
+      { << bit {ans} } = arr;
       `checkh(ans, bit6);
 
       ans_enum = enum_t'({ << bit {arr} });
@@ -61,6 +67,9 @@ module t (/*AUTOARG*/);
       ans = { >> bit[1:0] {arr2} };
       `checkh(ans, bit6);
 
+      { >> bit[1:0] {ans} } = arr2;
+      `checkh(ans, bit6);
+
       ans_enum = enum_t'({ >> bit[1:0] {arr2} });
       `checkh(ans_enum, bit6);
 
@@ -68,6 +77,9 @@ module t (/*AUTOARG*/);
       `checkp(arr2, "'{'h0, 'h2, 'h3} ");
 
       ans = { << bit[1:0] {arr2} };
+      `checkh(ans, bit6);
+
+      { << bit[1:0] {ans} } = arr2;
       `checkh(ans, bit6);
 
       ans_enum = enum_t'({ << bit[1:0] {arr2} });
@@ -82,6 +94,9 @@ module t (/*AUTOARG*/);
       ans = { >> bit[5:0] {arr6} };
       `checkh(ans, bit6);
 
+      { >> bit[5:0] {ans} } = arr6;
+      `checkh(ans, bit6);
+
       ans_enum = enum_t'({ >> bit[5:0] {arr6} });
       `checkh(ans_enum, bit6);
 
@@ -92,6 +107,9 @@ module t (/*AUTOARG*/);
       `checkp(arr6, "'{'h38} ");
 
       ans = { << bit[5:0] {arr6} };
+      `checkh(ans, bit6);
+
+      { << bit[5:0] {ans} } = arr6;
       `checkh(ans, bit6);
 
       ans_enum = enum_t'({ << bit[5:0] {arr6} });

--- a/test_regress/t/t_stream_unpack.v
+++ b/test_regress/t/t_stream_unpack.v
@@ -15,10 +15,12 @@ typedef enum bit [5:0] {
 
 module t (/*AUTOARG*/);
    initial begin
-      bit arr[6];
+      typedef bit [5:0] bit6_t;
+      typedef bit bit6_unpacked_t[6];
+      bit6_unpacked_t arr;
       bit [1:0] arr2[3];
-      bit [5:0] arr6[1];
-      bit [5:0] bit6 = 6'b111000;
+      bit6_t arr6[1];
+      bit6_t bit6 = 6'b111000;
       bit [5:0] ans;
       enum_t ans_enum;
       logic [1:0] a [3] = {1, 0, 3};

--- a/test_regress/t/t_stream_unpack.v
+++ b/test_regress/t/t_stream_unpack.v
@@ -31,6 +31,9 @@ module t (/*AUTOARG*/);
       { >> bit {arr}} = bit6;
       `checkp(arr, "'{'h1, 'h1, 'h1, 'h0, 'h0, 'h0} ");
 
+      arr = { >> bit {bit6}};
+      `checkp(arr, "'{'h1, 'h1, 'h1, 'h0, 'h0, 'h0} ");
+
       ans = { >> bit {arr} };
       `checkh(ans, bit6);
 
@@ -40,6 +43,9 @@ module t (/*AUTOARG*/);
       { << bit {arr}} = bit6;
       `checkp(arr, "'{'h0, 'h0, 'h0, 'h1, 'h1, 'h1} ");
 
+      arr = { << bit {bit6}};
+      `checkp(arr, "'{'h0, 'h0, 'h0, 'h1, 'h1, 'h1} ");
+
       ans = { << bit {arr} };
       `checkh(ans, bit6);
 
@@ -47,6 +53,9 @@ module t (/*AUTOARG*/);
       `checkh(ans_enum, bit6);
 
       { >> bit[1:0] {arr2}} = bit6;
+      `checkp(arr2, "'{'h3, 'h2, 'h0} ");
+
+      arr2 = { >> bit[1:0] {bit6}};
       `checkp(arr2, "'{'h3, 'h2, 'h0} ");
 
       ans = { >> bit[1:0] {arr2} };
@@ -67,6 +76,9 @@ module t (/*AUTOARG*/);
       { >> bit [5:0] {arr6} } = bit6;
       `checkp(arr6, "'{'h38} ");
 
+      arr6 = { >> bit [5:0] {bit6}};
+      `checkp(arr6, "'{'h38} ");
+
       ans = { >> bit[5:0] {arr6} };
       `checkh(ans, bit6);
 
@@ -74,6 +86,9 @@ module t (/*AUTOARG*/);
       `checkh(ans_enum, bit6);
 
       { << bit [5:0] {arr6} } = bit6;
+      `checkp(arr6, "'{'h38} ");
+
+      arr6 = { << bit [5:0] {bit6}};
       `checkp(arr6, "'{'h38} ");
 
       ans = { << bit[5:0] {arr6} };

--- a/test_regress/t/t_stream_unpack_lhs.out
+++ b/test_regress/t/t_stream_unpack_lhs.out
@@ -1,17 +1,3 @@
-%Warning-WIDTHEXPAND: t/t_stream_unpack_lhs.v:66:29: Operator ASSIGN expects 32 bits on the Assign RHS, but Assign RHS's VARREF 'unpacked_siz_din' generates 8 bits.
-                                                   : ... note: In instance 't'
-   66 |       {>>{packed_siz_dout}} = unpacked_siz_din;
-      |                             ^
-                      ... For warning description see https://verilator.org/warn/WIDTHEXPAND?v=latest
-                      ... Use "/* verilator lint_off WIDTHEXPAND */" and lint_on around source to disable this message.
-%Warning-WIDTHEXPAND: t/t_stream_unpack_lhs.v:67:29: Operator ASSIGN expects 32 bits on the Assign RHS, but Assign RHS's VARREF 'unpacked_asc_din' generates 8 bits.
-                                                   : ... note: In instance 't'
-   67 |       {>>{packed_asc_dout}} = unpacked_asc_din;
-      |                             ^
-%Warning-WIDTHEXPAND: t/t_stream_unpack_lhs.v:68:29: Operator ASSIGN expects 32 bits on the Assign RHS, but Assign RHS's VARREF 'unpacked_des_din' generates 8 bits.
-                                                   : ... note: In instance 't'
-   68 |       {>>{packed_des_dout}} = unpacked_des_din;
-      |                             ^
 %Error-UNSUPPORTED: t/t_stream_unpack_lhs.v:113:38: Unsupported/Illegal: Assignment pattern member not underneath a supported construct: NEQ
                                                   : ... note: In instance 't'
   113 |             if (unpacked_siz_dout != '{8'h01, 8'h23, 8'h45, 8'h67}) $stop;

--- a/test_regress/t/t_stream_unpack_narrower.out
+++ b/test_regress/t/t_stream_unpack_narrower.out
@@ -14,4 +14,8 @@
                                                        : ... note: In instance 't'
    17 |     stream = {>>{packed_data2}};
       |            ^
+%Warning-WIDTHEXPAND: t/t_stream_unpack_narrower.v:18:24: Stream target requires 61 bits, but source expression only provides 32 bits (IEEE 1800-2023 11.4.14.3)
+                                                        : ... note: In instance 't'
+   18 |     {>>{packed_data2}} = stream;
+      |                        ^
 %Error: Exiting due to

--- a/test_regress/t/t_stream_unpack_narrower.out
+++ b/test_regress/t/t_stream_unpack_narrower.out
@@ -1,13 +1,17 @@
-%Warning-WIDTHEXPAND: t/t_stream_unpack_narrower.v:14:18: Stream target requires 32 bits, but source expression only provides 31 bits (IEEE 1800-2023 11.4.14.3)
+%Warning-WIDTHEXPAND: t/t_stream_unpack_narrower.v:15:18: Stream target requires 32 bits, but source expression only provides 31 bits (IEEE 1800-2023 11.4.14.3)
                                                         : ... note: In instance 't'
-   14 |     {>>{stream}} = packed_data;
+   15 |     {>>{stream}} = packed_data;
       |                  ^
                       ... For warning description see https://verilator.org/warn/WIDTHEXPAND?v=latest
                       ... Use "/* verilator lint_off WIDTHEXPAND */" and lint_on around source to disable this message.
-%Warning-WIDTHTRUNC: t/t_stream_unpack_narrower.v:15:17: Target fixed size variable (31 bits) is narrower than the stream (32 bits) (IEEE 1800-2023 11.4.14)
+%Warning-WIDTHTRUNC: t/t_stream_unpack_narrower.v:16:17: Target fixed size variable (31 bits) is narrower than the stream (32 bits) (IEEE 1800-2023 11.4.14)
                                                        : ... note: In instance 't'
-   15 |     packed_data = {>>{stream}};
+   16 |     packed_data = {>>{stream}};
       |                 ^
                      ... For warning description see https://verilator.org/warn/WIDTHTRUNC?v=latest
                      ... Use "/* verilator lint_off WIDTHTRUNC */" and lint_on around source to disable this message.
+%Warning-WIDTHTRUNC: t/t_stream_unpack_narrower.v:17:12: Target fixed size variable (32 bits) is narrower than the stream (61 bits) (IEEE 1800-2023 11.4.14)
+                                                       : ... note: In instance 't'
+   17 |     stream = {>>{packed_data2}};
+      |            ^
 %Error: Exiting due to

--- a/test_regress/t/t_stream_unpack_narrower.v
+++ b/test_regress/t/t_stream_unpack_narrower.v
@@ -15,6 +15,7 @@ module t;
     {>>{stream}} = packed_data;
     packed_data = {>>{stream}};
     stream = {>>{packed_data2}};
+    {>>{packed_data2}} = stream;
   end
 
 endmodule

--- a/test_regress/t/t_stream_unpack_narrower.v
+++ b/test_regress/t/t_stream_unpack_narrower.v
@@ -7,12 +7,14 @@
 module t;
 
   logic [30:0] packed_data;
+  logic [60:0] packed_data2;
   logic [7:0] stream[4];
 
   initial begin
     packed_data = 31'h12345678;
     {>>{stream}} = packed_data;
     packed_data = {>>{stream}};
+    stream = {>>{packed_data2}};
   end
 
 endmodule


### PR DESCRIPTION
It fixes assignments of unpacked arrays to stream expressions and stream expressions to unpacked arrays. It is done by wrapping RHS in `AstCvtPackedToArray` and `AstCvtArrayToPacked` nodes.