### PR TITLE
Not to emit LATCH warning for automatic variables

### DIFF
--- a/src/V3Active.cpp
+++ b/src/V3Active.cpp
@@ -314,7 +314,7 @@ class ActiveLatchCheckVisitor final : public VNVisitorConst {
     void visit(AstVarRef* nodep) override {
         const AstVar* const varp = nodep->varp();
         if (nodep->access().isWriteOrRW() && varp->isSignal() && !varp->isUsedLoopIdx()
-            && !varp->isFuncLocalSticky()) {
+            && !varp->isFuncLocalSticky() && !varp->lifetime().isAutomatic()) {
             m_graph.addAssignment(nodep);
         }
     }

--- a/test_regress/t/t_lint_latch_8.py
+++ b/test_regress/t/t_lint_latch_8.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2024 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('vlt')
+
+test.lint()
+
+test.passes()

--- a/test_regress/t/t_lint_latch_8.v
+++ b/test_regress/t/t_lint_latch_8.v
@@ -1,0 +1,29 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed into the Public Domain, for any use,
+// without warranty, 2025 by Yutetsu TAKATSUKASA
+// SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+module t(input wire clk);
+
+   logic [2:0] v = 3'd0;
+   logic [2:0] v_plus_1;
+
+   always_comb begin : blk_comb
+      if (v[0]) begin : blk_if
+          automatic logic [2:0] tmp0;  // This automatic variable cannot be a latch
+          tmp0 = v + 3'd1;
+          v_plus_1 = tmp0;
+      end else begin : blk_else
+          v_plus_1 = v | 3'd1;
+      end
+   end
+
+   always @(posedge clk) begin : blk_ff
+      automatic logic [2:0] tmp_auto;
+      tmp_auto = v_plus_1;
+      v <= tmp_auto;
+      $display("v:%d", v);
+  end
+
+endmodule


### PR DESCRIPTION
automatic variable cannot be a latch.
Add a test first, then push the fix later.

[LATCH warning is shown](https://github.com/verilator/verilator/actions/runs/14279644925/job/40027608298?pr=5918#step:6:285)  without fdcdadd8df61ab3d474b11f723b6a3e296f53efd .