### PR TITLE
Support assigning unpacked arrays to queues (#5924)

### DIFF
--- a/include/verilated_funcs.h
+++ b/include/verilated_funcs.h
@@ -233,49 +233,10 @@ static inline std::string VL_CVT_N_CSTR(const char* lhsp) VL_PURE {
     return lhsp ? std::string{lhsp} : ""s;
 }
 
-template <std::size_t N_Depth>
-static inline VlQueue<std::string> VL_CVT_UNPACK_TO_Q(const VlUnpacked<std::string, N_Depth>& q) VL_PURE {
-    VlQueue<std::string> ret;
-    for (size_t i = 0; i < N_Depth; ++i)
-        ret.push_back(q[i]);
-    return ret;
-}
-
-template <std::size_t N_Depth>
-static inline VlQueue<CData> VL_CVT_UNPACK_TO_Q(const VlUnpacked<CData, N_Depth>& q) VL_PURE {
-    VlQueue<CData> ret;
-    for (size_t i = 0; i < N_Depth; ++i)
-        ret.push_back(q[i]);
-    return ret;
-}
-
-template <std::size_t N_Depth>
-static inline VlQueue<SData> VL_CVT_UNPACK_TO_Q(const VlUnpacked<SData, N_Depth>& q) VL_PURE {
-    VlQueue<SData> ret;
-    for (size_t i = 0; i < N_Depth; ++i)
-        ret.push_back(q[i]);
-    return ret;
-}
-
-template <std::size_t N_Depth>
-static inline VlQueue<IData> VL_CVT_UNPACK_TO_Q(const VlUnpacked<IData, N_Depth>& q) VL_PURE {
-    VlQueue<IData> ret;
-    for (size_t i = 0; i < N_Depth; ++i)
-        ret.push_back(q[i]);
-    return ret;
-}
-
-template <std::size_t N_Depth>
-static inline VlQueue<QData> VL_CVT_UNPACK_TO_Q(const VlUnpacked<QData, N_Depth>& q) VL_PURE {
-    VlQueue<QData> ret;
-    for (size_t i = 0; i < N_Depth; ++i)
-        ret.push_back(q[i]);
-    return ret;
-}
-
-template <std::size_t N_Depth, std::size_t N_Words>
-static inline VlQueue<VlWide<N_Words>> VL_CVT_UNPACK_TO_Q(const VlUnpacked<VlWide<N_Words>, N_Depth>& q) VL_PURE {
-    VlQueue<VlWide<N_Words>> ret;
+// Return queue from an unpacked array
+template <typename T, std::size_t N_Depth>
+static inline VlQueue<T> VL_CVT_UNPACK_TO_Q(const VlUnpacked<T, N_Depth>& q) VL_PURE {
+    VlQueue<T> ret;
     for (size_t i = 0; i < N_Depth; ++i)
         ret.push_back(q[i]);
     return ret;

--- a/include/verilated_funcs.h
+++ b/include/verilated_funcs.h
@@ -233,6 +233,54 @@ static inline std::string VL_CVT_N_CSTR(const char* lhsp) VL_PURE {
     return lhsp ? std::string{lhsp} : ""s;
 }
 
+template <std::size_t N_Depth>
+static inline VlQueue<std::string> VL_CVT_UNPACK_TO_Q(const VlUnpacked<std::string, N_Depth>& q) VL_PURE {
+    VlQueue<std::string> ret;
+    for (size_t i = 0; i < N_Depth; ++i) 
+        ret.push_back(q[i]);
+    return ret;
+}
+
+template <std::size_t N_Depth>
+static inline VlQueue<CData> VL_CVT_UNPACK_TO_Q(const VlUnpacked<CData, N_Depth>& q) VL_PURE {
+    VlQueue<CData> ret;
+    for (size_t i = 0; i < N_Depth; ++i) 
+        ret.push_back(q[i]);
+    return ret;
+}
+
+template <std::size_t N_Depth>
+static inline VlQueue<SData> VL_CVT_UNPACK_TO_Q(const VlUnpacked<SData, N_Depth>& q) VL_PURE {
+    VlQueue<SData> ret;
+    for (size_t i = 0; i < N_Depth; ++i) 
+        ret.push_back(q[i]);
+    return ret;
+}
+
+template <std::size_t N_Depth>
+static inline VlQueue<IData> VL_CVT_UNPACK_TO_Q(const VlUnpacked<IData, N_Depth>& q) VL_PURE {
+    VlQueue<IData> ret;
+    for (size_t i = 0; i < N_Depth; ++i) 
+        ret.push_back(q[i]);
+    return ret;
+}
+
+template <std::size_t N_Depth>
+static inline VlQueue<QData> VL_CVT_UNPACK_TO_Q(const VlUnpacked<QData, N_Depth>& q) VL_PURE {
+    VlQueue<QData> ret;
+    for (size_t i = 0; i < N_Depth; ++i) 
+        ret.push_back(q[i]);
+    return ret;
+}
+
+template <std::size_t N_Depth, std::size_t N_Words>
+static inline VlQueue<VlWide<N_Words>> VL_CVT_UNPACK_TO_Q(const VlUnpacked<VlWide<N_Words>, N_Depth>& q) VL_PURE {
+    VlQueue<VlWide<N_Words>> ret;
+    for (size_t i = 0; i < N_Depth; ++i) 
+        ret.push_back(q[i]);
+    return ret;
+}
+
 // Return double from lhs (numeric) unsigned
 double VL_ITOR_D_W(int lbits, WDataInP const lwp) VL_PURE;
 static inline double VL_ITOR_D_I(int, IData lhs) VL_PURE {

--- a/include/verilated_funcs.h
+++ b/include/verilated_funcs.h
@@ -236,7 +236,7 @@ static inline std::string VL_CVT_N_CSTR(const char* lhsp) VL_PURE {
 template <std::size_t N_Depth>
 static inline VlQueue<std::string> VL_CVT_UNPACK_TO_Q(const VlUnpacked<std::string, N_Depth>& q) VL_PURE {
     VlQueue<std::string> ret;
-    for (size_t i = 0; i < N_Depth; ++i) 
+    for (size_t i = 0; i < N_Depth; ++i)
         ret.push_back(q[i]);
     return ret;
 }
@@ -244,7 +244,7 @@ static inline VlQueue<std::string> VL_CVT_UNPACK_TO_Q(const VlUnpacked<std::stri
 template <std::size_t N_Depth>
 static inline VlQueue<CData> VL_CVT_UNPACK_TO_Q(const VlUnpacked<CData, N_Depth>& q) VL_PURE {
     VlQueue<CData> ret;
-    for (size_t i = 0; i < N_Depth; ++i) 
+    for (size_t i = 0; i < N_Depth; ++i)
         ret.push_back(q[i]);
     return ret;
 }
@@ -252,7 +252,7 @@ static inline VlQueue<CData> VL_CVT_UNPACK_TO_Q(const VlUnpacked<CData, N_Depth>
 template <std::size_t N_Depth>
 static inline VlQueue<SData> VL_CVT_UNPACK_TO_Q(const VlUnpacked<SData, N_Depth>& q) VL_PURE {
     VlQueue<SData> ret;
-    for (size_t i = 0; i < N_Depth; ++i) 
+    for (size_t i = 0; i < N_Depth; ++i)
         ret.push_back(q[i]);
     return ret;
 }
@@ -260,7 +260,7 @@ static inline VlQueue<SData> VL_CVT_UNPACK_TO_Q(const VlUnpacked<SData, N_Depth>
 template <std::size_t N_Depth>
 static inline VlQueue<IData> VL_CVT_UNPACK_TO_Q(const VlUnpacked<IData, N_Depth>& q) VL_PURE {
     VlQueue<IData> ret;
-    for (size_t i = 0; i < N_Depth; ++i) 
+    for (size_t i = 0; i < N_Depth; ++i)
         ret.push_back(q[i]);
     return ret;
 }
@@ -268,7 +268,7 @@ static inline VlQueue<IData> VL_CVT_UNPACK_TO_Q(const VlUnpacked<IData, N_Depth>
 template <std::size_t N_Depth>
 static inline VlQueue<QData> VL_CVT_UNPACK_TO_Q(const VlUnpacked<QData, N_Depth>& q) VL_PURE {
     VlQueue<QData> ret;
-    for (size_t i = 0; i < N_Depth; ++i) 
+    for (size_t i = 0; i < N_Depth; ++i)
         ret.push_back(q[i]);
     return ret;
 }
@@ -276,7 +276,7 @@ static inline VlQueue<QData> VL_CVT_UNPACK_TO_Q(const VlUnpacked<QData, N_Depth>
 template <std::size_t N_Depth, std::size_t N_Words>
 static inline VlQueue<VlWide<N_Words>> VL_CVT_UNPACK_TO_Q(const VlUnpacked<VlWide<N_Words>, N_Depth>& q) VL_PURE {
     VlQueue<VlWide<N_Words>> ret;
-    for (size_t i = 0; i < N_Depth; ++i) 
+    for (size_t i = 0; i < N_Depth; ++i)
         ret.push_back(q[i]);
     return ret;
 }

--- a/src/V3AstNodeExpr.h
+++ b/src/V3AstNodeExpr.h
@@ -1156,6 +1156,20 @@ public:
     string emitC() override { V3ERROR_NA_RETURN(""); }
     bool cleanOut() const override { return true; }
 };
+class AstCvtUnpackedToQueue final : public AstNodeExpr {
+    // Cast from unpacked array to dynamic/unpacked queue data type
+    // @astgen op1 := fromp : AstNodeExpr
+public:
+    AstCvtUnpackedToQueue(FileLine* fl, AstNodeExpr* fromp, AstNodeDType* dtp)
+        : ASTGEN_SUPER_CvtUnpackedToQueue(fl) {
+        this->fromp(fromp);
+        dtypeFrom(dtp);
+    }
+    ASTGEN_MEMBERS_AstCvtUnpackedToQueue;
+    string emitVerilog() override { V3ERROR_NA_RETURN(""); }
+    string emitC() override { return "VL_CVT_UNPACK_TO_Q(%P, %li)"; }
+    bool cleanOut() const override { return true; }
+};
 class AstDist final : public AstNodeExpr {
     // @astgen op1 := exprp : AstNodeExpr
     // @astgen op2 := itemsp : List[AstDistItem]

--- a/src/V3EmitCFunc.h
+++ b/src/V3EmitCFunc.h
@@ -392,6 +392,11 @@ public:
         emitOpName(nodep, nodep->emitC(), nodep->fromp(), elemDTypep, nullptr);
     }
 
+    void visit(AstCvtUnpackedToQueue* nodep) override {
+        AstNodeDType* const elemDTypep = nodep->fromp()->dtypep()->subDTypep();
+        emitOpName(nodep, nodep->emitC(), nodep->fromp(), elemDTypep, nullptr);
+    }
+
     void visit(AstNodeAssign* nodep) override {
         bool paren = true;
         bool decind = false;

--- a/src/V3Premit.cpp
+++ b/src/V3Premit.cpp
@@ -288,6 +288,10 @@ class PremitVisitor final : public VNVisitor {
         iterateChildren(nodep);
         checkNode(nodep);
     }
+    void visit(AstCvtUnpackedToQueue* nodep) override {
+        iterateChildren(nodep);
+        checkNode(nodep);
+    }
     void visit(AstSel* nodep) override {
         iterateAndNextNull(nodep->fromp());
         {  // Only the 'from' is part of the assignment LHS

--- a/test_regress/t/t_unpacked_to_queue.py
+++ b/test_regress/t/t_unpacked_to_queue.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2024 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile()
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_unpacked_to_queue.v
+++ b/test_regress/t/t_unpacked_to_queue.v
@@ -17,14 +17,14 @@
 
 class check #(parameter WIDTH=8);
     static function automatic void check_array (int n,
-                                    logic [WIDTH-1:0] array []);      
+                                    logic [WIDTH-1:0] array []);
         for (int r=0; r<n; r++) begin
             `checkh(array[r], WIDTH'(r))
         end
     endfunction
 
     static function automatic void check_string (int n,
-                                    string array []);      
+                                    string array []);
         for (int r=0; r<n; r++) begin
             `checks(array[r], "test")
         end

--- a/test_regress/t/t_unpacked_to_queue.v
+++ b/test_regress/t/t_unpacked_to_queue.v
@@ -1,0 +1,85 @@
+// DESCRIPTION: Verilator: Casting queues and dynamic arrays
+// into queues as function arguments
+//
+// This file ONLY is placed into the Public Domain, for any use,
+// without warranty, 2025 by Wilson Snyder.
+// SPDX-License-Identifier: CC0-1.0
+
+`define stop $stop()
+`define checkh(gotv,expv) do if ((gotv) !== (expv)) begin \
+    $write("%%Error: %s:%0d:  got=%0x exp=%0x (%s !== %s)\n", \
+    `__FILE__,`__LINE__, (gotv), (expv), `"gotv`", `"expv`"); \
+    `stop; end while(0);
+`define checks(gotv,expv) do if ((gotv) != (expv)) begin \
+    $write("%%Error: %s:%0d:  got='%s' exp='%s'\n", \
+    `__FILE__,`__LINE__, (gotv), (expv)); `stop; end while(0);
+
+
+class check #(parameter WIDTH=8);
+    static function automatic void check_array (int n,
+                                    logic [WIDTH-1:0] array []);      
+        for (int r=0; r<n; r++) begin
+            `checkh(array[r], WIDTH'(r))
+        end
+    endfunction
+
+    static function automatic void check_string (int n,
+                                    string array []);      
+        for (int r=0; r<n; r++) begin
+            `checks(array[r], "test")
+        end
+    endfunction
+endclass
+
+module test();
+
+    localparam NUM_ELEMS = 4;
+
+    string       array_s  [NUM_ELEMS];
+
+    logic [7:0]  array_8  [NUM_ELEMS];
+    logic [15:0] array_16 [NUM_ELEMS];
+    logic [31:0] array_32 [NUM_ELEMS];
+    logic [63:0] array_64 [NUM_ELEMS];
+    logic [95:0] array_96 [NUM_ELEMS];
+
+    logic [7:0]  queue_8  [$];
+    logic [15:0] queue_16 [$];
+    logic [31:0] queue_32 [$];
+    logic [63:0] queue_64 [$];
+    logic [95:0] queue_96 [$];
+
+
+    initial begin
+        for (int i = 0; i < NUM_ELEMS; i++) begin
+            array_s[i]  = "test";
+            array_8[i]  = 8'(i);
+            array_16[i] = 16'(i);
+            array_32[i] = 32'(i);
+            array_64[i] = 64'(i);
+            array_96[i] = 96'(i);
+            queue_8.push_back(8'(i));
+            queue_16.push_back(16'(i));
+            queue_32.push_back(32'(i));
+            queue_64.push_back(64'(i));
+            queue_96.push_back(96'(i));
+        end
+
+        check#(1)::check_string(NUM_ELEMS, array_s);
+
+        check#(8)::check_array(NUM_ELEMS, array_8);
+        check#(16)::check_array(NUM_ELEMS, array_16);
+        check#(32)::check_array(NUM_ELEMS, array_32);
+        check#(64)::check_array(NUM_ELEMS, array_64);
+        check#(96)::check_array(NUM_ELEMS, array_96);
+
+        check#(8)::check_array(NUM_ELEMS, queue_8);
+        check#(16)::check_array(NUM_ELEMS, queue_16);
+        check#(32)::check_array(NUM_ELEMS, queue_32);
+        check#(64)::check_array(NUM_ELEMS, queue_64);
+        check#(96)::check_array(NUM_ELEMS, queue_96);
+
+        $display("All checks passed");
+        $finish();
+    end
+endmodule

--- a/test_regress/t/t_unpacked_to_queue.v
+++ b/test_regress/t/t_unpacked_to_queue.v
@@ -35,19 +35,33 @@ module test();
 
     localparam NUM_ELEMS = 4;
 
-    string       array_s  [NUM_ELEMS];
+    typedef string       array_s_t  [NUM_ELEMS];
+    typedef logic [7:0]  array_8_t  [NUM_ELEMS];
+    typedef logic [15:0] array_16_t [NUM_ELEMS];
+    typedef logic [31:0] array_32_t [NUM_ELEMS];
+    typedef logic [63:0] array_64_t [NUM_ELEMS];
+    typedef logic [95:0] array_96_t [NUM_ELEMS];
 
-    logic [7:0]  array_8  [NUM_ELEMS];
-    logic [15:0] array_16 [NUM_ELEMS];
-    logic [31:0] array_32 [NUM_ELEMS];
-    logic [63:0] array_64 [NUM_ELEMS];
-    logic [95:0] array_96 [NUM_ELEMS];
+    typedef string       queue_s_t  [$];
+    typedef logic [7:0]  queue_8_t  [$];
+    typedef logic [15:0] queue_16_t [$];
+    typedef logic [31:0] queue_32_t [$];
+    typedef logic [63:0] queue_64_t [$];
+    typedef logic [95:0] queue_96_t [$];
 
-    logic [7:0]  queue_8  [$];
-    logic [15:0] queue_16 [$];
-    logic [31:0] queue_32 [$];
-    logic [63:0] queue_64 [$];
-    logic [95:0] queue_96 [$];
+    array_s_t  array_s;
+    array_8_t  array_8;
+    array_16_t array_16;
+    array_32_t array_32;
+    array_64_t array_64;
+    array_96_t array_96;
+
+    queue_s_t  queue_s;
+    queue_8_t  queue_8;
+    queue_16_t queue_16;
+    queue_32_t queue_32;
+    queue_64_t queue_64;
+    queue_96_t queue_96;
 
 
     initial begin
@@ -58,6 +72,7 @@ module test();
             array_32[i] = 32'(i);
             array_64[i] = 64'(i);
             array_96[i] = 96'(i);
+            queue_s.push_back("test");
             queue_8.push_back(8'(i));
             queue_16.push_back(16'(i));
             queue_32.push_back(32'(i));
@@ -66,13 +81,13 @@ module test();
         end
 
         check#(1)::check_string(NUM_ELEMS, array_s);
-
         check#(8)::check_array(NUM_ELEMS, array_8);
         check#(16)::check_array(NUM_ELEMS, array_16);
         check#(32)::check_array(NUM_ELEMS, array_32);
         check#(64)::check_array(NUM_ELEMS, array_64);
         check#(96)::check_array(NUM_ELEMS, array_96);
 
+        check#(1)::check_string(NUM_ELEMS, queue_s);
         check#(8)::check_array(NUM_ELEMS, queue_8);
         check#(16)::check_array(NUM_ELEMS, queue_16);
         check#(32)::check_array(NUM_ELEMS, queue_32);


### PR DESCRIPTION
This PR will eventually contain changes to enable casting VlUnpacked to VlQueue when passing in an unpacked array into a function call defined with a dynamic array as an argument, resolving #5924. Currently, it only contains the base self-checking tests as I don't have much time this week to dig into actually implementing the feature.

One question I did have though @wsnyder, was you mentioned testing both dynamic arrays and queues. Did you mean how it is currently implemented in my test case or did you mean having two different functions that each uses an array or queue as their argument a la:
```
static function automatic void check_array (int n, logic [WIDTH-1:0] array []);      
        for (int r=0; r<n; r++) begin
            `checkh(array[r], WIDTH'(r))
        end
    endfunction

static function automatic void check_queue (int n, logic [WIDTH-1:0] queue [$]);      
        for (int r=0; r<n; r++) begin
            `checkh(queue[r], WIDTH'(r))
        end
    endfunction
```