### PR TITLE
Add V3EmitV support for sampled value functions

### DIFF
--- a/src/V3EmitV.cpp
+++ b/src/V3EmitV.cpp
@@ -401,6 +401,38 @@ class EmitVBaseVisitorConst VL_NOT_FINAL : public EmitCBaseVisitorConst {
         }
         puts(")");
     }
+    void visit(AstSampled* nodep) override {
+        putfs(nodep, "$sampled(");
+        iterateAndNextConstNull(nodep->exprp());
+        puts(")");
+    }
+    void visit(AstRose* nodep) override {
+        putfs(nodep, "$rose(");
+        iterateAndNextConstNull(nodep->exprp());
+        if (nodep->sentreep()) {
+            puts(", ");
+            iterateAndNextConstNull(nodep->sentreep());
+        }
+        puts(")");
+    }
+    void visit(AstFell* nodep) override {
+        putfs(nodep, "$fell(");
+        iterateAndNextConstNull(nodep->exprp());
+        if (nodep->sentreep()) {
+            puts(", ");
+            iterateAndNextConstNull(nodep->sentreep());
+        }
+        puts(")");
+    }
+    void visit(AstStable* nodep) override {
+        putfs(nodep, "$stable(");
+        iterateAndNextConstNull(nodep->exprp());
+        if (nodep->sentreep()) {
+            puts(", ");
+            iterateAndNextConstNull(nodep->sentreep());
+        }
+        puts(")");
+    }
     void visit(AstReturn* nodep) override {
         putfs(nodep, "return ");
         iterateAndNextConstNull(nodep->lhsp());

--- a/test_regress/t/t_debug_emitv.out
+++ b/test_regress/t/t_debug_emitv.out
@@ -310,6 +310,39 @@ module Vt_debug_emitv_t;
             $display("%g", $asinh(r));
             $display("%g", $acosh(r));
             $display("%g", $atanh(r));
+            if ($sampled(cyc[1])) begin
+                $write("");
+            end
+            if ($rose(cyc)) begin
+                $write("");
+            end
+            if ($fell(cyc)) begin
+                $write("");
+            end
+            if ($stable(cyc)) begin
+                $write("");
+            end
+            if ((! $stable(cyc))) begin
+                $write("");
+            end
+            if ($past(cyc[1])) begin
+                $write("");
+            end
+            if ($rose(cyc, @( clk))) begin
+                $write("");
+            end
+            if ($fell(cyc, @( clk))) begin
+                $write("");
+            end
+            if ($stable(cyc, @( clk))) begin
+                $write("");
+            end
+            if ((! $stable(cyc, @( clk)))) begin
+                $write("");
+            end
+            if ($past(cyc[1], 'sh5)) begin
+                $write("");
+            end
             force sum = 'sha;
             begin : unnamedblk1_1
                 integer signed __Vrepeat0;

--- a/test_regress/t/t_debug_emitv.v
+++ b/test_regress/t/t_debug_emitv.v
@@ -251,6 +251,19 @@ module t (/*AUTOARG*/
       $display("%g", $acosh(r));
       $display("%g", $atanh(r));
 
+      if ($sampled(cyc[1])) $write("");
+      if ($rose(cyc)) $write("");
+      if ($fell(cyc)) $write("");
+      if ($stable(cyc)) $write("");
+      if ($changed(cyc)) $write("");
+      if ($past(cyc[1])) $write("");
+
+      if ($rose(cyc, clk)) $write("");
+      if ($fell(cyc, clk)) $write("");
+      if ($stable(cyc, clk)) $write("");
+      if ($changed(cyc, clk)) $write("");
+      if ($past(cyc[1], 5)) $write("");
+
       force sum = 10;
       repeat (2) if (sum != 10) $stop;
       release sum;


### PR DESCRIPTION
More #5849 cleanup.  `test_regress/t/t_past_funcs.py --coverage-expr` was failing to verilate but works now with this commit.
