### PR TITLE
Backward compatibility for `TRACE` option & Fix missing C++ regeneration when Verilog files are updated

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -249,6 +249,7 @@ Yutetsu TAKATSUKASA
 Yves Mathieu
 Zhanglei Wang
 Zhou Shen
+Zhouyi Shen
 Zixi Li
 أحمد المحمودي
 404allen404

--- a/verilator-config.cmake.in
+++ b/verilator-config.cmake.in
@@ -442,6 +442,7 @@ function(verilate TARGET)
         json_get_list(JSOURCES_SUPPORT_SLOW "${MANIFEST}" sources support_slow)
         json_get_list(JSOURCES_SUPPORT_FAST "${MANIFEST}" sources support_fast)
         json_get_list(JSOURCES_USER_CLASSES "${MANIFEST}" sources user_classes)
+        json_get_list(JSOURCES_DEPS "${MANIFEST}" sources deps)
 
         file(WRITE ${VDIR}/${VERILATE_PREFIX}.cmake
             "# Verilated -*- CMake -*-\n"

--- a/verilator-config.cmake.in
+++ b/verilator-config.cmake.in
@@ -227,11 +227,19 @@ endfunction()
 function(verilate TARGET)
     cmake_parse_arguments(
         VERILATE
-        "COVERAGE;SYSTEMC;TRACE_FST;TRACE_SAIF;TRACE_VCD;TRACE_STRUCTS"
+        "COVERAGE;SYSTEMC;TRACE_FST;TRACE_SAIF;TRACE_VCD;TRACE;TRACE_STRUCTS"
         "PREFIX;TOP_MODULE;THREADS;TRACE_THREADS;DIRECTORY"
         "SOURCES;VERILATOR_ARGS;INCLUDE_DIRS;OPT_SLOW;OPT_FAST;OPT_GLOBAL"
         ${ARGN}
     )
+
+    if (VERILATE_TRACE)
+        if (NOT VERILATE_TRACE_VCD)
+            set(VERILATE_TRACE_VCD TRUE)
+        endif()
+        message(DEPRECATION "The `TRACE` argument is deprecated. Please use `TRACE_VCD` instead.")
+    endif()
+
     if(NOT VERILATE_SOURCES)
         message(FATAL_ERROR "Need at least one source")
     endif()


### PR DESCRIPTION
- Add backward compatibility for `TRACE` option
  - Add `TRACE` option again. And when `TRACE` option is set, print a deprecation notice and set `TRACE_VCD` option. So that legacy code remains compatible.
  > The replacement of `TRACE` with `TRACE_VCD` and some other choices can be confusing. It raises linkage errors in older code that previously built successfully, making the root cause difficult to identify.
- Fix missing C++ regeneration when Verilog files are updated
  - The dependencies in `${VDIR}/${VERILATE_PREFIX}.cmake` were missing, which prevented C++ files from being re-generated when Verilog files were updated. This has now been fixed by adding the dependencies.
  > Can’t believe this fatal bug slipped through! It seems to have been introduced a month ago in commit 6a48d3b.