### PR TITLE
Support constraint random for StructArray (#5805)

### DIFF
--- a/include/verilated.h
+++ b/include/verilated.h
@@ -179,6 +179,8 @@ using VerilatedAssertDirectiveType_t = std::underlying_type<VerilatedAssertDirec
 template <typename>
 struct VlIsCustomStruct : public std::false_type {};
 
+template <typename>
+struct VlIsQueue : public std::false_type {};
 // Recursive type extraction helper
 template <typename T>
 struct ExtractInnerType {

--- a/include/verilated.h
+++ b/include/verilated.h
@@ -178,13 +178,6 @@ using VerilatedAssertDirectiveType_t = std::underlying_type<VerilatedAssertDirec
 // Type trait for custom struct
 template <typename>
 struct VlIsCustomStruct : public std::false_type {};
-
-// Recursive type extraction helper
-template <typename T>
-struct ExtractInnerType {
-    using type = T;
-};
-
 //=============================================================================
 // Utility functions
 

--- a/include/verilated.h
+++ b/include/verilated.h
@@ -181,7 +181,7 @@ struct VlIsCustomStruct : public std::false_type {};
 
 // Type trait: used to detect if array element is a custom struct (e.g. for struct arrays)
 template <typename T>
-struct ContainsCustomStruct : VlIsCustomStruct<T> {};
+struct VlContainsCustomStruct : VlIsCustomStruct<T> {};
 
 //=============================================================================
 // Utility functions

--- a/include/verilated.h
+++ b/include/verilated.h
@@ -183,7 +183,7 @@ template <typename>
 struct VlIsQueue : public std::false_type {};
 // Recursive type extraction helper
 template <typename T>
-struct ExtractInnerType {
+struct ExtractInnerType final {
     using type = T;
 };
 

--- a/include/verilated.h
+++ b/include/verilated.h
@@ -179,8 +179,6 @@ using VerilatedAssertDirectiveType_t = std::underlying_type<VerilatedAssertDirec
 template <typename>
 struct VlIsCustomStruct : public std::false_type {};
 
-template <typename>
-struct VlIsQueue : public std::false_type {};
 // Recursive type extraction helper
 template <typename T>
 struct ExtractInnerType {

--- a/include/verilated.h
+++ b/include/verilated.h
@@ -178,6 +178,9 @@ using VerilatedAssertDirectiveType_t = std::underlying_type<VerilatedAssertDirec
 // Type trait for custom struct
 template <typename>
 struct VlIsCustomStruct : public std::false_type {};
+
+template<typename T>
+struct ContainsCustomStruct : VlIsCustomStruct<T> {};
 //=============================================================================
 // Utility functions
 

--- a/include/verilated.h
+++ b/include/verilated.h
@@ -179,7 +179,7 @@ using VerilatedAssertDirectiveType_t = std::underlying_type<VerilatedAssertDirec
 template <typename>
 struct VlIsCustomStruct : public std::false_type {};
 
-template<typename T>
+template <typename T>
 struct ContainsCustomStruct : VlIsCustomStruct<T> {};
 //=============================================================================
 // Utility functions

--- a/include/verilated.h
+++ b/include/verilated.h
@@ -178,6 +178,13 @@ using VerilatedAssertDirectiveType_t = std::underlying_type<VerilatedAssertDirec
 // Type trait for custom struct
 template <typename>
 struct VlIsCustomStruct : public std::false_type {};
+
+// Recursive type extraction helper
+template <typename T>
+struct ExtractInnerType {
+    using type = T;
+};
+
 //=============================================================================
 // Utility functions
 

--- a/include/verilated.h
+++ b/include/verilated.h
@@ -183,7 +183,7 @@ template <typename>
 struct VlIsQueue : public std::false_type {};
 // Recursive type extraction helper
 template <typename T>
-struct ExtractInnerType final {
+struct ExtractInnerType {
     using type = T;
 };
 

--- a/include/verilated.h
+++ b/include/verilated.h
@@ -175,12 +175,14 @@ enum class VerilatedAssertDirectiveType : uint8_t {
 using VerilatedAssertType_t = std::underlying_type<VerilatedAssertType>::type;
 using VerilatedAssertDirectiveType_t = std::underlying_type<VerilatedAssertDirectiveType>::type;
 
-// Type trait for custom struct
+// Type trait: whether T is a user-defined custom struct
 template <typename>
 struct VlIsCustomStruct : public std::false_type {};
 
+// Type trait: used to detect if array element is a custom struct (e.g. for struct arrays)
 template <typename T>
 struct ContainsCustomStruct : VlIsCustomStruct<T> {};
+
 //=============================================================================
 // Utility functions
 

--- a/include/verilated_random.h
+++ b/include/verilated_random.h
@@ -330,42 +330,44 @@ public:
     }
     template <typename T, std::size_t N_Depth>
     void write_var(VlUnpacked<T, N_Depth>& var, int width, const char* name, int dimension,
-              std::uint32_t randmodeIdx = std::numeric_limits<std::uint32_t>::max()) {
-        if(is_inner_custom_struct<T>()){
+                   std::uint32_t randmodeIdx = std::numeric_limits<std::uint32_t>::max()) {
+        if (is_inner_custom_struct<T>()) {
             std::vector<size_t> dim_size;
             if ((dimension > 0) && (N_Depth != 0)) {
-                for(size_t dim =0; dim< dimension; ++dim){
+                for (size_t dim = 0; dim < dimension; ++dim) {
                     dim_size.push_back(var.find_length(dim));
                 }
-                std::function<void(std::vector<size_t>, int)> unroll_array = [&](std::vector<size_t> indices, int depth) {
-                    if (depth == dim_size.size()) { // Base case: All indices are set
-                        std::ostringstream oss;
-                        for (int i = 0 ;i <indices.size();++i) {
-                            oss << std::hex << std::setw(8) << std::setfill('0') << indices[i];
-                            if(i != indices.size()-1) oss<<".";
+                std::function<void(std::vector<size_t>, int)> unroll_array =
+                    [&](std::vector<size_t> indices, int depth) {
+                        if (depth == dim_size.size()) {  // Base case: All indices are set
+                            std::ostringstream oss;
+                            for (int i = 0; i < indices.size(); ++i) {
+                                oss << std::hex << std::setw(8) << std::setfill('0') << indices[i];
+                                if (i != indices.size() - 1) oss << ".";
+                            }
+                            auto& varr = var.find_element(indices);
+                            std::cout << std::string(name) + "." + oss.str() << std::endl;
+                            write_var(varr, 1, (std::string(name) + "." + oss.str()).c_str(), 1);
+                            return;
                         }
-                        auto & varr = var.find_element(indices);
-                        std::cout <<std::string(name)+"."+oss.str()<< std::endl;
-                        write_var(varr, 1 ,(std::string(name)+"."+oss.str()).c_str(), 1);
-                        return;
-                    }
-                    // Loop through the current dimension
-                    for (size_t i = 0; i < dim_size[depth]; ++i) {
-                        indices.push_back(i);
-                        unroll_array(indices, depth + 1);
-                        indices.pop_back(); // Backtrack
-                    }
-                };
-                unroll_array({},0);
+                        // Loop through the current dimension
+                        for (size_t i = 0; i < dim_size[depth]; ++i) {
+                            indices.push_back(i);
+                            unroll_array(indices, depth + 1);
+                            indices.pop_back();  // Backtrack
+                        }
+                    };
+                unroll_array({}, 0);
             }
-        }else{
+        } else {
             if ((dimension > 0) && (N_Depth != 0)) {
                 if (m_vars.find(name) != m_vars.end()) return;
-                    m_vars[name] = std::make_shared<const VlRandomArrayVarTemplate<VlUnpacked<T, N_Depth>>>(
-                    name, width, &var, dimension, randmodeIdx);
+                m_vars[name]
+                    = std::make_shared<const VlRandomArrayVarTemplate<VlUnpacked<T, N_Depth>>>(
+                        name, width, &var, dimension, randmodeIdx);
                 if (dimension > 0) {
                     idx = 0;
-                record_arr_table(var, name, dimension, {}, {});
+                    record_arr_table(var, name, dimension, {}, {});
                 }
             }
         }
@@ -404,10 +406,8 @@ public:
     template <typename T>
     typename std::enable_if<VlIsCustomStruct<T>::value, void>::type
     record_arr_table(T& var, const std::string name, int dimension, std::vector<IData> indices,
-                     std::vector<size_t> idxWidths){
-                        VL_FATAL_MT(__FILE__, __LINE__, "randomize",
-                            "Should not reach here."
-                            );
+                     std::vector<size_t> idxWidths) {
+        VL_FATAL_MT(__FILE__, __LINE__, "randomize", "Should not reach here.");
     }
     template <typename T>
     void record_arr_table(VlQueue<T>& var, const std::string name, int dimension,

--- a/include/verilated_random.h
+++ b/include/verilated_random.h
@@ -329,7 +329,8 @@ public:
         }
     }
     template <typename T, std::size_t N_Depth>
-    void write_var(VlUnpacked<T, N_Depth>& var, int width, const char* name, int dimension,
+    typename std::enable_if<!VlIsCustomStruct<T>::value, void>::type
+    write_var(VlUnpacked<T, N_Depth>& var, int width, const char* name, int dimension,
                    std::uint32_t randmodeIdx = std::numeric_limits<std::uint32_t>::max()) {
         if (m_vars.find(name) != m_vars.end()) return;
         m_vars[name] = std::make_shared<const VlRandomArrayVarTemplate<VlUnpacked<T, N_Depth>>>(
@@ -337,6 +338,18 @@ public:
         if (dimension > 0) {
             idx = 0;
             record_arr_table(var, name, dimension, {}, {});
+        }
+    }
+    template <typename T, std::size_t N_Depth>
+    typename std::enable_if<VlIsCustomStruct<T>::value, void>::type
+    write_var(VlUnpacked<T, N_Depth>& var, int width, const char* name, int dimension,
+              std::uint32_t randmodeIdx = std::numeric_limits<std::uint32_t>::max()) {
+        if ((dimension > 0) && (N_Depth != 0)) {
+            for (size_t i = 0; i < N_Depth; ++i) {
+                std::ostringstream oss;
+                oss << std::setfill('0') << std::setw(8) << i;
+                write_var(var.operator[](i), 1, (std::string(name) + ".x" + oss.str()).c_str(), 1);
+            }
         }
     }
     template <typename T_Key, typename T_Value>

--- a/include/verilated_random.h
+++ b/include/verilated_random.h
@@ -216,6 +216,7 @@ public:
     // Finds the next solution satisfying the constraints
     bool next(VlRNG& rngr);
 
+    // Process the key for associative array
     template <typename T_Key>
     typename std::enable_if<std::is_integral<T_Key>::value && (sizeof(T_Key) <= 4)>::type
     process_key(const T_Key& key, std::string& indexed_name, std::vector<size_t>& integral_index,
@@ -300,6 +301,13 @@ public:
                     "supported currently.");
     }
 
+    // Write Variable
+    template <typename T>
+    typename std::enable_if<VlIsCustomStruct<T>::value, void>::type
+    write_var(T& var, int width, const char* name, int dimension,
+              std::uint32_t randmodeIdx = std::numeric_limits<std::uint32_t>::max()) {
+        modifyMembers(var, var.memberIndices(), name);
+    }
     template <typename T>
     typename std::enable_if<!VlIsCustomStruct<T>::value, void>::type
     write_var(T& var, int width, const char* name, int dimension,
@@ -343,6 +351,7 @@ public:
             record_arr_table(var, name, dimension, {}, {});
         }
     }
+    // Helper functions to write variable
     template <typename T, std::size_t... I>
     void modifyMembers(T& obj, std::index_sequence<I...>, std::string baseName) {
         // Use the indices to access each member via std::get
@@ -352,25 +361,7 @@ public:
              0)...};
     }
 
-    template <typename T>
-    typename std::enable_if<VlIsCustomStruct<T>::value, void>::type
-    write_var(T& var, int width, const char* name, int dimension,
-              std::uint32_t randmodeIdx = std::numeric_limits<std::uint32_t>::max()) {
-        modifyMembers(var, var.memberIndices(), name);
-    }
-
-    int idx;
-    std::string generateKey(const std::string& name, int idx) {
-        if (!name.empty() && name[0] == '\\') {
-            const size_t space_pos = name.find(' ');
-            return (space_pos != std::string::npos ? name.substr(0, space_pos) : name)
-                   + std::to_string(idx);
-        }
-        const size_t bracket_pos = name.find('[');
-        return (bracket_pos != std::string::npos ? name.substr(0, bracket_pos) : name)
-               + std::to_string(idx);
-    }
-
+    // Record Array Table
     template <typename T>
     typename std::enable_if<!std::is_class<T>::value, void>::type
     record_arr_table(T& var, const std::string name, int dimension, std::vector<IData> indices,
@@ -431,6 +422,18 @@ public:
                 indices.resize(indices.size() - integral_index.size());
             }
         }
+    }
+    // Helper functions to record array table
+    int idx;
+    std::string generateKey(const std::string& name, int idx) {
+        if (!name.empty() && name[0] == '\\') {
+            const size_t space_pos = name.find(' ');
+            return (space_pos != std::string::npos ? name.substr(0, space_pos) : name)
+                   + std::to_string(idx);
+        }
+        const size_t bracket_pos = name.find('[');
+        return (bracket_pos != std::string::npos ? name.substr(0, bracket_pos) : name)
+               + std::to_string(idx);
     }
 
     void hard(std::string&& constraint);

--- a/include/verilated_random.h
+++ b/include/verilated_random.h
@@ -330,44 +330,42 @@ public:
     }
     template <typename T, std::size_t N_Depth>
     void write_var(VlUnpacked<T, N_Depth>& var, int width, const char* name, int dimension,
-                   std::uint32_t randmodeIdx = std::numeric_limits<std::uint32_t>::max()) {
-        if (is_inner_custom_struct<T>()) {
+              std::uint32_t randmodeIdx = std::numeric_limits<std::uint32_t>::max()) {
+        if(is_inner_custom_struct<T>()){
             std::vector<size_t> dim_size;
             if ((dimension > 0) && (N_Depth != 0)) {
-                for (size_t dim = 0; dim < dimension; ++dim) {
+                for(size_t dim =0; dim< dimension; ++dim){
                     dim_size.push_back(var.find_length(dim));
                 }
-                std::function<void(std::vector<size_t>, int)> unroll_array =
-                    [&](std::vector<size_t> indices, int depth) {
-                        if (depth == dim_size.size()) {  // Base case: All indices are set
-                            std::ostringstream oss;
-                            for (int i = 0; i < indices.size(); ++i) {
-                                oss << std::hex << std::setw(8) << std::setfill('0') << indices[i];
-                                if (i != indices.size() - 1) oss << ".";
-                            }
-                            auto& varr = var.find_element(indices);
-                            std::cout << std::string(name) + "." + oss.str() << std::endl;
-                            write_var(varr, 1, (std::string(name) + "." + oss.str()).c_str(), 1);
-                            return;
+                std::function<void(std::vector<size_t>, int)> unroll_array = [&](std::vector<size_t> indices, int depth) {
+                    if (depth == dim_size.size()) { // Base case: All indices are set
+                        std::ostringstream oss;
+                        for (int i = 0 ;i <indices.size();++i) {
+                            oss << std::hex << std::setw(8) << std::setfill('0') << indices[i];
+                            if(i != indices.size()-1) oss<<".";
                         }
-                        // Loop through the current dimension
-                        for (size_t i = 0; i < dim_size[depth]; ++i) {
-                            indices.push_back(i);
-                            unroll_array(indices, depth + 1);
-                            indices.pop_back();  // Backtrack
-                        }
-                    };
-                unroll_array({}, 0);
+                        auto & varr = var.find_element(indices);
+                        std::cout <<std::string(name)+"."+oss.str()<< std::endl;
+                        write_var(varr, 1 ,(std::string(name)+"."+oss.str()).c_str(), 1);
+                        return;
+                    }
+                    // Loop through the current dimension
+                    for (size_t i = 0; i < dim_size[depth]; ++i) {
+                        indices.push_back(i);
+                        unroll_array(indices, depth + 1);
+                        indices.pop_back(); // Backtrack
+                    }
+                };
+                unroll_array({},0);
             }
-        } else {
+        }else{
             if ((dimension > 0) && (N_Depth != 0)) {
                 if (m_vars.find(name) != m_vars.end()) return;
-                m_vars[name]
-                    = std::make_shared<const VlRandomArrayVarTemplate<VlUnpacked<T, N_Depth>>>(
-                        name, width, &var, dimension, randmodeIdx);
+                    m_vars[name] = std::make_shared<const VlRandomArrayVarTemplate<VlUnpacked<T, N_Depth>>>(
+                    name, width, &var, dimension, randmodeIdx);
                 if (dimension > 0) {
                     idx = 0;
-                    record_arr_table(var, name, dimension, {}, {});
+                record_arr_table(var, name, dimension, {}, {});
                 }
             }
         }
@@ -406,8 +404,10 @@ public:
     template <typename T>
     typename std::enable_if<VlIsCustomStruct<T>::value, void>::type
     record_arr_table(T& var, const std::string name, int dimension, std::vector<IData> indices,
-                     std::vector<size_t> idxWidths) {
-        VL_FATAL_MT(__FILE__, __LINE__, "randomize", "Should not reach here.");
+                     std::vector<size_t> idxWidths){
+                        VL_FATAL_MT(__FILE__, __LINE__, "randomize",
+                            "Should not reach here."
+                            );
     }
     template <typename T>
     void record_arr_table(VlQueue<T>& var, const std::string name, int dimension,

--- a/include/verilated_random.h
+++ b/include/verilated_random.h
@@ -201,7 +201,7 @@ class VlRandomizer final {
                                                                        // variables
     ArrayInfoMap m_arr_vars;  // Tracks each element in array structures for iteration
     const VlQueue<CData>* m_randmode;  // rand_mode state;
-    int idx = 0; // Internal counter for key generation
+    int idx = 0;  // Internal counter for key generation
 
     // PRIVATE METHODS
     void randomConstraint(std::ostream& os, VlRNG& rngr, int bits);
@@ -335,7 +335,7 @@ public:
               std::uint32_t randmodeIdx = std::numeric_limits<std::uint32_t>::max()) {
         modifyMembers(var, var.memberIndices(), name);
     }
-    
+
     // Register queue of non-struct types
     template <typename T>
     typename std::enable_if<!ContainsCustomStruct<T>::value, void>::type
@@ -371,7 +371,7 @@ public:
             record_arr_table(var, name, dimension, {}, {});
         }
     }
-    
+
     // Register unpacked array of structs
     template <typename T, std::size_t N_Depth>
     typename std::enable_if<ContainsCustomStruct<T>::value, void>::type
@@ -395,7 +395,6 @@ public:
     }
 
     // TODO: Register associative array of structs
-
 
     // ----------------------------------------
     // ---  Record Arrays: flat and struct  ---
@@ -513,7 +512,6 @@ public:
 
     // TODO: Add support for associative arrays of structs
     // Recursively process associative arrays of structs
-
 
     // --------------------------
     // ---  Helper functions  ---

--- a/include/verilated_random.h
+++ b/include/verilated_random.h
@@ -346,7 +346,6 @@ public:
                                 if (i != indices.size() - 1) oss << ".";
                             }
                             auto& varr = var.find_element(indices);
-                            std::cout << std::string(name) + "." + oss.str() << std::endl;
                             write_var(varr, 1, (std::string(name) + "." + oss.str()).c_str(), 1);
                             return;
                         }

--- a/include/verilated_random.h
+++ b/include/verilated_random.h
@@ -329,44 +329,26 @@ public:
         }
     }
     template <typename T, std::size_t N_Depth>
-    void write_var(VlUnpacked<T, N_Depth>& var, int width, const char* name, int dimension,
+    typename std::enable_if<!VlIsCustomStruct<T>::value, void>::type
+    write_var(VlUnpacked<T, N_Depth>& var, int width, const char* name, int dimension,
               std::uint32_t randmodeIdx = std::numeric_limits<std::uint32_t>::max()) {
-        if(is_inner_custom_struct<T>()){
-            std::vector<size_t> dim_size;
-            if ((dimension > 0) && (N_Depth != 0)) {
-                for(size_t dim =0; dim< dimension; ++dim){
-                    dim_size.push_back(var.find_length(dim));
-                }
-                std::function<void(std::vector<size_t>, int)> unroll_array = [&](std::vector<size_t> indices, int depth) {
-                    if (depth == dim_size.size()) { // Base case: All indices are set
-                        std::ostringstream oss;
-                        for (int i = 0 ;i <indices.size();++i) {
-                            oss << std::hex << std::setw(8) << std::setfill('0') << indices[i];
-                            if(i != indices.size()-1) oss<<".";
-                        }
-                        auto & varr = var.find_element(indices);
-                        std::cout <<std::string(name)+"."+oss.str()<< std::endl;
-                        write_var(varr, 1 ,(std::string(name)+"."+oss.str()).c_str(), 1);
-                        return;
-                    }
-                    // Loop through the current dimension
-                    for (size_t i = 0; i < dim_size[depth]; ++i) {
-                        indices.push_back(i);
-                        unroll_array(indices, depth + 1);
-                        indices.pop_back(); // Backtrack
-                    }
-                };
-                unroll_array({},0);
-            }
-        }else{
-            if ((dimension > 0) && (N_Depth != 0)) {
-                if (m_vars.find(name) != m_vars.end()) return;
-                    m_vars[name] = std::make_shared<const VlRandomArrayVarTemplate<VlUnpacked<T, N_Depth>>>(
-                    name, width, &var, dimension, randmodeIdx);
-                if (dimension > 0) {
-                    idx = 0;
-                record_arr_table(var, name, dimension, {}, {});
-                }
+        if (m_vars.find(name) != m_vars.end()) return;
+        m_vars[name] = std::make_shared<const VlRandomArrayVarTemplate<VlUnpacked<T, N_Depth>>>(
+            name, width, &var, dimension, randmodeIdx);
+        if (dimension > 0) {
+            idx = 0;
+            record_arr_table(var, name, dimension, {}, {});
+        }
+    }
+    template <typename T, std::size_t N_Depth>
+    typename std::enable_if<VlIsCustomStruct<T>::value, void>::type
+    write_var(VlUnpacked<T, N_Depth>& var, int width, const char* name, int dimension,
+              std::uint32_t randmodeIdx = std::numeric_limits<std::uint32_t>::max()) {
+        if ((dimension > 0) && (N_Depth != 0)) {
+            for (size_t i = 0; i < N_Depth; ++i) {
+                std::ostringstream oss;
+                oss << std::setfill('0') << std::setw(8) << i;
+                write_var(var.operator[](i), 1, (std::string(name) + ".x" + oss.str()).c_str(), 1);
             }
         }
     }
@@ -400,14 +382,6 @@ public:
         const std::string key = generateKey(name, idx);
         m_arr_vars[key] = std::make_shared<ArrayInfo>(name, &var, idx, indices, idxWidths);
         ++idx;
-    }
-    template <typename T>
-    typename std::enable_if<VlIsCustomStruct<T>::value, void>::type
-    record_arr_table(T& var, const std::string name, int dimension, std::vector<IData> indices,
-                     std::vector<size_t> idxWidths){
-                        VL_FATAL_MT(__FILE__, __LINE__, "randomize",
-                            "Should not reach here."
-                            );
     }
     template <typename T>
     void record_arr_table(VlQueue<T>& var, const std::string name, int dimension,

--- a/include/verilated_random.h
+++ b/include/verilated_random.h
@@ -329,26 +329,44 @@ public:
         }
     }
     template <typename T, std::size_t N_Depth>
-    typename std::enable_if<!VlIsCustomStruct<T>::value, void>::type
-    write_var(VlUnpacked<T, N_Depth>& var, int width, const char* name, int dimension,
+    void write_var(VlUnpacked<T, N_Depth>& var, int width, const char* name, int dimension,
               std::uint32_t randmodeIdx = std::numeric_limits<std::uint32_t>::max()) {
-        if (m_vars.find(name) != m_vars.end()) return;
-        m_vars[name] = std::make_shared<const VlRandomArrayVarTemplate<VlUnpacked<T, N_Depth>>>(
-            name, width, &var, dimension, randmodeIdx);
-        if (dimension > 0) {
-            idx = 0;
-            record_arr_table(var, name, dimension, {}, {});
-        }
-    }
-    template <typename T, std::size_t N_Depth>
-    typename std::enable_if<VlIsCustomStruct<T>::value, void>::type
-    write_var(VlUnpacked<T, N_Depth>& var, int width, const char* name, int dimension,
-              std::uint32_t randmodeIdx = std::numeric_limits<std::uint32_t>::max()) {
-        if ((dimension > 0) && (N_Depth != 0)) {
-            for (size_t i = 0; i < N_Depth; ++i) {
-                std::ostringstream oss;
-                oss << std::setfill('0') << std::setw(8) << i;
-                write_var(var.operator[](i), 1, (std::string(name) + ".x" + oss.str()).c_str(), 1);
+        if(is_inner_custom_struct<T>()){
+            std::vector<size_t> dim_size;
+            if ((dimension > 0) && (N_Depth != 0)) {
+                for(size_t dim =0; dim< dimension; ++dim){
+                    dim_size.push_back(var.find_length(dim));
+                }
+                std::function<void(std::vector<size_t>, int)> unroll_array = [&](std::vector<size_t> indices, int depth) {
+                    if (depth == dim_size.size()) { // Base case: All indices are set
+                        std::ostringstream oss;
+                        for (int i = 0 ;i <indices.size();++i) {
+                            oss << std::hex << std::setw(8) << std::setfill('0') << indices[i];
+                            if(i != indices.size()-1) oss<<".";
+                        }
+                        auto & varr = var.find_element(indices);
+                        std::cout <<std::string(name)+"."+oss.str()<< std::endl;
+                        write_var(varr, 1 ,(std::string(name)+"."+oss.str()).c_str(), 1);
+                        return;
+                    }
+                    // Loop through the current dimension
+                    for (size_t i = 0; i < dim_size[depth]; ++i) {
+                        indices.push_back(i);
+                        unroll_array(indices, depth + 1);
+                        indices.pop_back(); // Backtrack
+                    }
+                };
+                unroll_array({},0);
+            }
+        }else{
+            if ((dimension > 0) && (N_Depth != 0)) {
+                if (m_vars.find(name) != m_vars.end()) return;
+                    m_vars[name] = std::make_shared<const VlRandomArrayVarTemplate<VlUnpacked<T, N_Depth>>>(
+                    name, width, &var, dimension, randmodeIdx);
+                if (dimension > 0) {
+                    idx = 0;
+                record_arr_table(var, name, dimension, {}, {});
+                }
             }
         }
     }
@@ -382,6 +400,14 @@ public:
         const std::string key = generateKey(name, idx);
         m_arr_vars[key] = std::make_shared<ArrayInfo>(name, &var, idx, indices, idxWidths);
         ++idx;
+    }
+    template <typename T>
+    typename std::enable_if<VlIsCustomStruct<T>::value, void>::type
+    record_arr_table(T& var, const std::string name, int dimension, std::vector<IData> indices,
+                     std::vector<size_t> idxWidths){
+                        VL_FATAL_MT(__FILE__, __LINE__, "randomize",
+                            "Should not reach here."
+                            );
     }
     template <typename T>
     void record_arr_table(VlQueue<T>& var, const std::string name, int dimension,

--- a/include/verilated_random.h
+++ b/include/verilated_random.h
@@ -346,6 +346,7 @@ public:
                                 if (i != indices.size() - 1) oss << ".";
                             }
                             auto& varr = var.find_element(indices);
+                            std::cout << std::string(name) + "." + oss.str() << std::endl;
                             write_var(varr, 1, (std::string(name) + "." + oss.str()).c_str(), 1);
                             return;
                         }

--- a/include/verilated_random.h
+++ b/include/verilated_random.h
@@ -320,7 +320,7 @@ public:
     template <typename T>
     typename std::enable_if<!ContainsCustomStruct<T>::value, void>::type
     write_var(VlQueue<T>& var, int width, const char* name, int dimension,
-                   std::uint32_t randmodeIdx = std::numeric_limits<std::uint32_t>::max()) {
+              std::uint32_t randmodeIdx = std::numeric_limits<std::uint32_t>::max()) {
         if (m_vars.find(name) != m_vars.end()) return;
         m_vars[name] = std::make_shared<const VlRandomArrayVarTemplate<VlQueue<T>>>(
             name, width, &var, dimension, randmodeIdx);
@@ -344,46 +344,41 @@ public:
     template <typename T>
     typename std::enable_if<ContainsCustomStruct<T>::value, void>::type
     write_var(VlQueue<T>& var, int width, const char* name, int dimension,
-        std::uint32_t randmodeIdx = std::numeric_limits<std::uint32_t>::max()) {
-            if(dimension>0){
-                record_struct_arr(var, name, dimension, {}, {});
-            }
-        }
+              std::uint32_t randmodeIdx = std::numeric_limits<std::uint32_t>::max()) {
+        if (dimension > 0) { record_struct_arr(var, name, dimension, {}, {}); }
+    }
     template <typename T, std::size_t N_Depth>
     typename std::enable_if<ContainsCustomStruct<T>::value, void>::type
     write_var(VlUnpacked<T, N_Depth>& var, int width, const char* name, int dimension,
               std::uint32_t randmodeIdx = std::numeric_limits<std::uint32_t>::max()) {
-        if(dimension>0){
-            record_struct_arr(var, name, dimension, {}, {});
-        }
+        if (dimension > 0) { record_struct_arr(var, name, dimension, {}, {}); }
     }
     template <typename T>
     typename std::enable_if<ContainsCustomStruct<T>::value, void>::type
     record_struct_arr(T& var, const std::string name, int dimension, std::vector<IData> indices,
-        std::vector<size_t> idxWidths) {
-            std::ostringstream oss;
-            for (size_t i = 0; i < indices.size(); ++i){
-                oss << std::hex << std::setw(8) << std::setfill('0') << static_cast<int>(indices[i]);
-                if(i<indices.size()-1) oss<<".";
-            }
-            write_var(var, 1ULL,(name+"."+oss.str()).c_str(), 1ULL );
+                      std::vector<size_t> idxWidths) {
+        std::ostringstream oss;
+        for (size_t i = 0; i < indices.size(); ++i) {
+            oss << std::hex << std::setw(8) << std::setfill('0') << static_cast<int>(indices[i]);
+            if (i < indices.size() - 1) oss << ".";
+        }
+        write_var(var, 1ULL, (name + "." + oss.str()).c_str(), 1ULL);
     }
     template <typename T, std::size_t N_Depth>
     void record_struct_arr(VlUnpacked<T, N_Depth>& var, const std::string name, int dimension,
-                          std::vector<IData> indices, std::vector<size_t> idxWidths) {
-        if(dimension>0 && N_Depth!=0){
+                           std::vector<IData> indices, std::vector<size_t> idxWidths) {
+        if (dimension > 0 && N_Depth != 0) {
             idxWidths.push_back(32);
             for (size_t i = 0; i < N_Depth; ++i) {
                 indices.push_back(i);
-                record_struct_arr(var.operator[](i), name, dimension - 1, indices,
-                                 idxWidths);
+                record_struct_arr(var.operator[](i), name, dimension - 1, indices, idxWidths);
                 indices.pop_back();
             }
         }
     }
     template <typename T>
     void record_struct_arr(VlQueue<T>& var, const std::string name, int dimension,
-                          std::vector<IData> indices, std::vector<size_t> idxWidths) {
+                           std::vector<IData> indices, std::vector<size_t> idxWidths) {
         if ((dimension > 0) && (var.size() != 0)) {
             idxWidths.push_back(32);
             for (size_t i = 0; i < var.size(); ++i) {

--- a/include/verilated_random.h
+++ b/include/verilated_random.h
@@ -331,7 +331,7 @@ public:
     template <typename T, std::size_t N_Depth>
     typename std::enable_if<!VlIsCustomStruct<T>::value, void>::type
     write_var(VlUnpacked<T, N_Depth>& var, int width, const char* name, int dimension,
-                   std::uint32_t randmodeIdx = std::numeric_limits<std::uint32_t>::max()) {
+              std::uint32_t randmodeIdx = std::numeric_limits<std::uint32_t>::max()) {
         if (m_vars.find(name) != m_vars.end()) return;
         m_vars[name] = std::make_shared<const VlRandomArrayVarTemplate<VlUnpacked<T, N_Depth>>>(
             name, width, &var, dimension, randmodeIdx);

--- a/include/verilated_types.h
+++ b/include/verilated_types.h
@@ -921,6 +921,9 @@ std::string VL_TO_STRING(const VlQueue<T_Value, N_MaxSize>& obj) {
     return obj.to_string();
 }
 
+template<typename T_Value, size_t N_MaxSize>
+struct ContainsCustomStruct<VlQueue<T_Value, N_MaxSize>> : ContainsCustomStruct<T_Value> {};
+
 //===================================================================
 // Verilog associative array container
 // There are no multithreaded locks on this; the base variable must
@@ -1256,6 +1259,9 @@ std::string VL_TO_STRING(const VlAssocArray<T_Key, T_Value>& obj) {
     return obj.to_string();
 }
 
+template<typename T_Key, typename T_Value>
+struct ContainsCustomStruct<VlAssocArray<T_Key, T_Value>> : ContainsCustomStruct<T_Key> {};
+
 template <typename T_Key, typename T_Value>
 void VL_READMEM_N(bool hex, int bits, const std::string& filename,
                   VlAssocArray<T_Key, T_Value>& obj, QData start, QData end) VL_MT_SAFE {
@@ -1586,6 +1592,8 @@ std::string VL_TO_STRING(const VlUnpacked<T_Value, N_Depth>& obj) {
     return obj.to_string();
 }
 
+template<typename T, int N>
+struct ContainsCustomStruct<VlUnpacked<T, N>> : ContainsCustomStruct<T> {};
 //===================================================================
 // Helper to apply the given indices to a target expression
 

--- a/include/verilated_types.h
+++ b/include/verilated_types.h
@@ -1337,9 +1337,8 @@ public:
 
     template <std::size_t N_CurrentDimension = 0>
     int find_length(int dimension) const {
-        return find_length<N_CurrentDimension>(dimension, std::integral_constant < bool,
-                                               std::is_class<T_Value>::value
-                                                   && !VlIsCustomStruct<T_Value>::value > {});
+        return find_length<N_CurrentDimension>(dimension, std::integral_constant<bool, std::is_class<T_Value>::value && !VlIsCustomStruct<T_Value>::value>{}
+        );
     }
 
     template <std::size_t N_CurrentDimension = 0, typename U = T_Value>
@@ -1355,9 +1354,7 @@ public:
 
     template <std::size_t N_CurrentDimension = 0>
     auto& find_element(std::vector<size_t>& indices) {
-        return find_element<N_CurrentDimension>(indices, std::integral_constant < bool,
-                                                std::is_class<T_Value>::value
-                                                    && !VlIsCustomStruct<T_Value>::value > {});
+        return find_element<N_CurrentDimension>(indices,  std::integral_constant<bool, std::is_class<T_Value>::value && !VlIsCustomStruct<T_Value>::value>{});
     }
 
     T_Value& operator[](size_t index) { return m_storage[index]; }

--- a/include/verilated_types.h
+++ b/include/verilated_types.h
@@ -1337,24 +1337,23 @@ public:
 
     template <std::size_t N_CurrentDimension = 0>
     int find_length(int dimension) const {
-        return find_length<N_CurrentDimension>(dimension, std::integral_constant<bool, std::is_class<T_Value>::value && !VlIsCustomStruct<T_Value>::value>{}
-        );
+        return find_length<N_CurrentDimension>(dimension, std::is_class<T_Value>{});
     }
 
     template <std::size_t N_CurrentDimension = 0, typename U = T_Value>
-    auto& find_element(std::vector<size_t>& indices, std::false_type) {
+    auto& find_element(const std::vector<size_t>& indices, std::false_type) {
         return m_storage[indices[N_CurrentDimension]];
     }
 
     template <std::size_t N_CurrentDimension = 0, typename U = T_Value>
-    auto& find_element(std::vector<size_t>& indices, std::true_type) {
+    auto& find_element(const std::vector<size_t>& indices, std::true_type) {
         return m_storage[indices[N_CurrentDimension]]
             .template find_element<N_CurrentDimension + 1>(indices);
     }
 
     template <std::size_t N_CurrentDimension = 0>
-    auto& find_element(std::vector<size_t>& indices) {
-        return find_element<N_CurrentDimension>(indices,  std::integral_constant<bool, std::is_class<T_Value>::value && !VlIsCustomStruct<T_Value>::value>{});
+    auto& find_element(const std::vector<size_t>& indices) {
+        return find_element<N_CurrentDimension>(indices, std::is_class<T_Value>{});
     }
 
     T_Value& operator[](size_t index) { return m_storage[index]; }
@@ -1587,21 +1586,6 @@ std::string VL_TO_STRING(const VlUnpacked<T_Value, N_Depth>& obj) {
     return obj.to_string();
 }
 
-// Specialization to extract inner type recursively
-// template <typename T, std::size_t N>
-// struct ExtractInnerType<VlQueue<T, N>> {
-//     using type = typename ExtractInnerType<T>::type;
-// };
-
-template <typename T, std::size_t N>
-struct ExtractInnerType<VlUnpacked<T, N>> {
-    using type = typename ExtractInnerType<T>::type;
-};
-// Function to check if the inner type is a custom struct
-template <typename T>
-constexpr bool is_inner_custom_struct() {
-    return VlIsCustomStruct<typename ExtractInnerType<T>::type>::value;
-}
 //===================================================================
 // Helper to apply the given indices to a target expression
 

--- a/include/verilated_types.h
+++ b/include/verilated_types.h
@@ -921,7 +921,7 @@ std::string VL_TO_STRING(const VlQueue<T_Value, N_MaxSize>& obj) {
     return obj.to_string();
 }
 
-template<typename T_Value, size_t N_MaxSize>
+template <typename T_Value, size_t N_MaxSize>
 struct ContainsCustomStruct<VlQueue<T_Value, N_MaxSize>> : ContainsCustomStruct<T_Value> {};
 
 //===================================================================
@@ -1259,7 +1259,7 @@ std::string VL_TO_STRING(const VlAssocArray<T_Key, T_Value>& obj) {
     return obj.to_string();
 }
 
-template<typename T_Key, typename T_Value>
+template <typename T_Key, typename T_Value>
 struct ContainsCustomStruct<VlAssocArray<T_Key, T_Value>> : ContainsCustomStruct<T_Key> {};
 
 template <typename T_Key, typename T_Value>
@@ -1592,7 +1592,7 @@ std::string VL_TO_STRING(const VlUnpacked<T_Value, N_Depth>& obj) {
     return obj.to_string();
 }
 
-template<typename T, int N>
+template <typename T, int N>
 struct ContainsCustomStruct<VlUnpacked<T, N>> : ContainsCustomStruct<T> {};
 //===================================================================
 // Helper to apply the given indices to a target expression

--- a/include/verilated_types.h
+++ b/include/verilated_types.h
@@ -920,7 +920,8 @@ template <typename T_Value, size_t N_MaxSize>
 std::string VL_TO_STRING(const VlQueue<T_Value, N_MaxSize>& obj) {
     return obj.to_string();
 }
-
+template <typename T>
+struct VlIsQueue<VlQueue<T>> : public std::true_type {};
 //===================================================================
 // Verilog associative array container
 // There are no multithreaded locks on this; the base variable must
@@ -1339,6 +1340,7 @@ public:
     int find_length(int dimension) const {
         return find_length<N_CurrentDimension>(dimension, std::integral_constant < bool,
                                                std::is_class<T_Value>::value
+                                                   && !VlIsQueue<T_Value>::value
                                                    && !VlIsCustomStruct<T_Value>::value > {});
     }
 
@@ -1357,6 +1359,7 @@ public:
     auto& find_element(std::vector<size_t>& indices) {
         return find_element<N_CurrentDimension>(indices, std::integral_constant < bool,
                                                 std::is_class<T_Value>::value
+                                                    && !VlIsQueue<T_Value>::value
                                                     && !VlIsCustomStruct<T_Value>::value > {});
     }
 
@@ -1591,8 +1594,8 @@ std::string VL_TO_STRING(const VlUnpacked<T_Value, N_Depth>& obj) {
 }
 
 // Specialization to extract inner type recursively
-// template <typename T, std::size_t N>
-// struct ExtractInnerType<VlQueue<T, N>> {
+// template <typename T>
+// struct ExtractInnerType<VlQueue<T>> {
 //     using type = typename ExtractInnerType<T>::type;
 // };
 

--- a/include/verilated_types.h
+++ b/include/verilated_types.h
@@ -1600,7 +1600,7 @@ std::string VL_TO_STRING(const VlUnpacked<T_Value, N_Depth>& obj) {
 // };
 
 template <typename T, std::size_t N>
-struct ExtractInnerType<VlUnpacked<T, N>> {
+struct ExtractInnerType<VlUnpacked<T, N>> final {
     using type = typename ExtractInnerType<T>::type;
 };
 // Function to check if the inner type is a custom struct

--- a/include/verilated_types.h
+++ b/include/verilated_types.h
@@ -922,7 +922,7 @@ std::string VL_TO_STRING(const VlQueue<T_Value, N_MaxSize>& obj) {
 }
 
 template <typename T_Value, size_t N_MaxSize>
-struct ContainsCustomStruct<VlQueue<T_Value, N_MaxSize>> : ContainsCustomStruct<T_Value> {};
+struct VlContainsCustomStruct<VlQueue<T_Value, N_MaxSize>> : VlContainsCustomStruct<T_Value> {};
 
 //===================================================================
 // Verilog associative array container
@@ -1260,7 +1260,7 @@ std::string VL_TO_STRING(const VlAssocArray<T_Key, T_Value>& obj) {
 }
 
 template <typename T_Key, typename T_Value>
-struct ContainsCustomStruct<VlAssocArray<T_Key, T_Value>> : ContainsCustomStruct<T_Key> {};
+struct VlContainsCustomStruct<VlAssocArray<T_Key, T_Value>> : VlContainsCustomStruct<T_Key> {};
 
 template <typename T_Key, typename T_Value>
 void VL_READMEM_N(bool hex, int bits, const std::string& filename,
@@ -1593,7 +1593,7 @@ std::string VL_TO_STRING(const VlUnpacked<T_Value, N_Depth>& obj) {
 }
 
 template <typename T, int N>
-struct ContainsCustomStruct<VlUnpacked<T, N>> : ContainsCustomStruct<T> {};
+struct VlContainsCustomStruct<VlUnpacked<T, N>> : VlContainsCustomStruct<T> {};
 
 //===================================================================
 // Helper to apply the given indices to a target expression

--- a/include/verilated_types.h
+++ b/include/verilated_types.h
@@ -1337,23 +1337,24 @@ public:
 
     template <std::size_t N_CurrentDimension = 0>
     int find_length(int dimension) const {
-        return find_length<N_CurrentDimension>(dimension, std::is_class<T_Value>{});
+        return find_length<N_CurrentDimension>(dimension, std::integral_constant<bool, std::is_class<T_Value>::value && !VlIsCustomStruct<T_Value>::value>{}
+        );
     }
 
     template <std::size_t N_CurrentDimension = 0, typename U = T_Value>
-    auto& find_element(const std::vector<size_t>& indices, std::false_type) {
+    auto& find_element(std::vector<size_t>& indices, std::false_type) {
         return m_storage[indices[N_CurrentDimension]];
     }
 
     template <std::size_t N_CurrentDimension = 0, typename U = T_Value>
-    auto& find_element(const std::vector<size_t>& indices, std::true_type) {
+    auto& find_element(std::vector<size_t>& indices, std::true_type) {
         return m_storage[indices[N_CurrentDimension]]
             .template find_element<N_CurrentDimension + 1>(indices);
     }
 
     template <std::size_t N_CurrentDimension = 0>
-    auto& find_element(const std::vector<size_t>& indices) {
-        return find_element<N_CurrentDimension>(indices, std::is_class<T_Value>{});
+    auto& find_element(std::vector<size_t>& indices) {
+        return find_element<N_CurrentDimension>(indices,  std::integral_constant<bool, std::is_class<T_Value>::value && !VlIsCustomStruct<T_Value>::value>{});
     }
 
     T_Value& operator[](size_t index) { return m_storage[index]; }
@@ -1586,6 +1587,21 @@ std::string VL_TO_STRING(const VlUnpacked<T_Value, N_Depth>& obj) {
     return obj.to_string();
 }
 
+// Specialization to extract inner type recursively
+// template <typename T, std::size_t N>
+// struct ExtractInnerType<VlQueue<T, N>> {
+//     using type = typename ExtractInnerType<T>::type;
+// };
+
+template <typename T, std::size_t N>
+struct ExtractInnerType<VlUnpacked<T, N>> {
+    using type = typename ExtractInnerType<T>::type;
+};
+// Function to check if the inner type is a custom struct
+template <typename T>
+constexpr bool is_inner_custom_struct() {
+    return VlIsCustomStruct<typename ExtractInnerType<T>::type>::value;
+}
 //===================================================================
 // Helper to apply the given indices to a target expression
 

--- a/include/verilated_types.h
+++ b/include/verilated_types.h
@@ -920,8 +920,7 @@ template <typename T_Value, size_t N_MaxSize>
 std::string VL_TO_STRING(const VlQueue<T_Value, N_MaxSize>& obj) {
     return obj.to_string();
 }
-template <typename T>
-struct VlIsQueue<VlQueue<T>> : public std::true_type {};
+
 //===================================================================
 // Verilog associative array container
 // There are no multithreaded locks on this; the base variable must
@@ -1340,7 +1339,6 @@ public:
     int find_length(int dimension) const {
         return find_length<N_CurrentDimension>(dimension, std::integral_constant < bool,
                                                std::is_class<T_Value>::value
-                                                   && !VlIsQueue<T_Value>::value
                                                    && !VlIsCustomStruct<T_Value>::value > {});
     }
 
@@ -1359,7 +1357,6 @@ public:
     auto& find_element(std::vector<size_t>& indices) {
         return find_element<N_CurrentDimension>(indices, std::integral_constant < bool,
                                                 std::is_class<T_Value>::value
-                                                    && !VlIsQueue<T_Value>::value
                                                     && !VlIsCustomStruct<T_Value>::value > {});
     }
 
@@ -1594,8 +1591,8 @@ std::string VL_TO_STRING(const VlUnpacked<T_Value, N_Depth>& obj) {
 }
 
 // Specialization to extract inner type recursively
-// template <typename T>
-// struct ExtractInnerType<VlQueue<T>> {
+// template <typename T, std::size_t N>
+// struct ExtractInnerType<VlQueue<T, N>> {
 //     using type = typename ExtractInnerType<T>::type;
 // };
 

--- a/include/verilated_types.h
+++ b/include/verilated_types.h
@@ -1337,8 +1337,9 @@ public:
 
     template <std::size_t N_CurrentDimension = 0>
     int find_length(int dimension) const {
-        return find_length<N_CurrentDimension>(dimension, std::integral_constant<bool, std::is_class<T_Value>::value && !VlIsCustomStruct<T_Value>::value>{}
-        );
+        return find_length<N_CurrentDimension>(dimension, std::integral_constant < bool,
+                                               std::is_class<T_Value>::value
+                                                   && !VlIsCustomStruct<T_Value>::value > {});
     }
 
     template <std::size_t N_CurrentDimension = 0, typename U = T_Value>
@@ -1354,7 +1355,9 @@ public:
 
     template <std::size_t N_CurrentDimension = 0>
     auto& find_element(std::vector<size_t>& indices) {
-        return find_element<N_CurrentDimension>(indices,  std::integral_constant<bool, std::is_class<T_Value>::value && !VlIsCustomStruct<T_Value>::value>{});
+        return find_element<N_CurrentDimension>(indices, std::integral_constant < bool,
+                                                std::is_class<T_Value>::value
+                                                    && !VlIsCustomStruct<T_Value>::value > {});
     }
 
     T_Value& operator[](size_t index) { return m_storage[index]; }

--- a/include/verilated_types.h
+++ b/include/verilated_types.h
@@ -1600,7 +1600,7 @@ std::string VL_TO_STRING(const VlUnpacked<T_Value, N_Depth>& obj) {
 // };
 
 template <typename T, std::size_t N>
-struct ExtractInnerType<VlUnpacked<T, N>> final {
+struct ExtractInnerType<VlUnpacked<T, N>> {
     using type = typename ExtractInnerType<T>::type;
 };
 // Function to check if the inner type is a custom struct

--- a/include/verilated_types.h
+++ b/include/verilated_types.h
@@ -1594,6 +1594,7 @@ std::string VL_TO_STRING(const VlUnpacked<T_Value, N_Depth>& obj) {
 
 template <typename T, int N>
 struct ContainsCustomStruct<VlUnpacked<T, N>> : ContainsCustomStruct<T> {};
+
 //===================================================================
 // Helper to apply the given indices to a target expression
 

--- a/src/V3AstNodeExpr.h
+++ b/src/V3AstNodeExpr.h
@@ -1911,6 +1911,7 @@ public:
     }
     ASTGEN_MEMBERS_AstSFormatF;
     string name() const override VL_MT_STABLE { return m_text; }
+    void name(const string& name) override { m_text = name; }
     int instrCount() const override { return INSTR_COUNT_PLI; }
     bool sameNode(const AstNode* samep) const override {
         return text() == VN_DBG_AS(samep, SFormatF)->text();

--- a/src/V3EmitCHeaders.cpp
+++ b/src/V3EmitCHeaders.cpp
@@ -287,6 +287,7 @@ class EmitCHeader final : public EmitCConstInit {
             putns(itemp, itemp->dtypep()->cType(itemp->nameProtect(), false, false));
             puts(";\n");
         }
+
         // Three helper functions for struct constrained randomization:
         // - memberNames: Get member names
         // - getMembers: Access member references

--- a/src/V3EmitCHeaders.cpp
+++ b/src/V3EmitCHeaders.cpp
@@ -294,15 +294,13 @@ class EmitCHeader final : public EmitCConstInit {
         // - memberWidth: Retrieve member width
         // - memberDimension: Retrieve member dimension
         if (sdtypep->isConstrainedRand()) {
-            bool needComma = false;
             putns(sdtypep, "\nstd::vector<std::string> memberNames(void) const {\n");
             puts("return {");
             for (const AstMemberDType* itemp = sdtypep->membersp(); itemp;
                  itemp = VN_AS(itemp->nextp(), MemberDType)) {
-                if (!itemp->isConstrainedRand()) continue;
-                if (needComma) puts(",\n");
-                putns(itemp, "\"" + itemp->shortName() + "\"");
-                needComma = true;
+                if (itemp->isConstrainedRand()) putns(itemp, "\"" + itemp->shortName() + "\"");
+                if (itemp->nextp() && VN_AS(itemp->nextp(), MemberDType)->isConstrainedRand())
+                    puts(",\n");
             }
             puts("};\n}\n");
 
@@ -312,28 +310,25 @@ class EmitCHeader final : public EmitCConstInit {
             putns(sdtypep, "\nstd::vector<int> memberDimension(void) const {\n");
             emitMemberVector<AttributeType::Dimension>(sdtypep);
 
-            needComma = false;
             putns(sdtypep, "\nauto memberIndices(void) const {\n");
             puts("return std::index_sequence_for<");
             for (const AstMemberDType* itemp = sdtypep->membersp(); itemp;
                  itemp = VN_AS(itemp->nextp(), MemberDType)) {
-                if (!itemp->isConstrainedRand()) continue;
-                if (needComma) puts(",\n");
-                putns(itemp, itemp->dtypep()->cType("", false, false));
-                needComma = true;
+                if (itemp->isConstrainedRand())
+                    putns(itemp, itemp->dtypep()->cType("", false, false));
+                if (itemp->nextp() && VN_AS(itemp->nextp(), MemberDType)->isConstrainedRand())
+                    puts(",\n");
             }
             puts(">{};\n}\n");
 
-            needComma = false;
             putns(sdtypep, "\ntemplate <typename T>");
             putns(sdtypep, "\nauto getMembers(T& obj) {\n");
             puts("return std::tie(");
             for (const AstMemberDType* itemp = sdtypep->membersp(); itemp;
                  itemp = VN_AS(itemp->nextp(), MemberDType)) {
-                if (!itemp->isConstrainedRand()) continue;
-                if (needComma) puts(",\n");
-                putns(itemp, "obj." + itemp->nameProtect());
-                needComma = true;
+                if (itemp->isConstrainedRand()) putns(itemp, "obj." + itemp->nameProtect());
+                if (itemp->nextp() && VN_AS(itemp->nextp(), MemberDType)->isConstrainedRand())
+                    puts(", ");
             }
             puts(");\n}\n");
         }

--- a/src/V3EmitCHeaders.cpp
+++ b/src/V3EmitCHeaders.cpp
@@ -294,13 +294,15 @@ class EmitCHeader final : public EmitCConstInit {
         // - memberWidth: Retrieve member width
         // - memberDimension: Retrieve member dimension
         if (sdtypep->isConstrainedRand()) {
+            bool needComma = false;
             putns(sdtypep, "\nstd::vector<std::string> memberNames(void) const {\n");
             puts("return {");
             for (const AstMemberDType* itemp = sdtypep->membersp(); itemp;
                  itemp = VN_AS(itemp->nextp(), MemberDType)) {
-                if (itemp->isConstrainedRand()) putns(itemp, "\"" + itemp->shortName() + "\"");
-                if (itemp->nextp() && VN_AS(itemp->nextp(), MemberDType)->isConstrainedRand())
-                    puts(",\n");
+                if (!itemp->isConstrainedRand()) continue;
+                if (needComma) puts(",\n");
+                putns(itemp, "\"" + itemp->shortName() + "\"");
+                needComma = true;
             }
             puts("};\n}\n");
 
@@ -310,25 +312,28 @@ class EmitCHeader final : public EmitCConstInit {
             putns(sdtypep, "\nstd::vector<int> memberDimension(void) const {\n");
             emitMemberVector<AttributeType::Dimension>(sdtypep);
 
+            needComma = false;
             putns(sdtypep, "\nauto memberIndices(void) const {\n");
             puts("return std::index_sequence_for<");
             for (const AstMemberDType* itemp = sdtypep->membersp(); itemp;
                  itemp = VN_AS(itemp->nextp(), MemberDType)) {
-                if (itemp->isConstrainedRand())
-                    putns(itemp, itemp->dtypep()->cType("", false, false));
-                if (itemp->nextp() && VN_AS(itemp->nextp(), MemberDType)->isConstrainedRand())
-                    puts(",\n");
+                if (!itemp->isConstrainedRand()) continue;
+                if (needComma) puts(",\n");
+                putns(itemp, itemp->dtypep()->cType("", false, false));
+                needComma = true;
             }
             puts(">{};\n}\n");
 
+            needComma = false;
             putns(sdtypep, "\ntemplate <typename T>");
             putns(sdtypep, "\nauto getMembers(T& obj) {\n");
             puts("return std::tie(");
             for (const AstMemberDType* itemp = sdtypep->membersp(); itemp;
                  itemp = VN_AS(itemp->nextp(), MemberDType)) {
-                if (itemp->isConstrainedRand()) putns(itemp, "obj." + itemp->nameProtect());
-                if (itemp->nextp() && VN_AS(itemp->nextp(), MemberDType)->isConstrainedRand())
-                    puts(", ");
+                if (!itemp->isConstrainedRand()) continue;
+                if (needComma) puts(",\n");
+                putns(itemp, "obj." + itemp->nameProtect());
+                needComma = true;
             }
             puts(");\n}\n");
         }

--- a/src/V3Randomize.cpp
+++ b/src/V3Randomize.cpp
@@ -735,7 +735,8 @@ class ConstraintExprVisitor final : public VNVisitor {
         // Mark Random for structArray
         if (VN_IS(nodep->fromp(), ArraySel)) {
             AstNodeExpr* const fromp = VN_AS(nodep->fromp(), ArraySel)->fromp();
-            AstStructDType* const dtypep = VN_AS(fromp->dtypep()->skipRefp()->subDTypep()->skipRefp(), StructDType);
+            AstStructDType* const dtypep
+                = VN_AS(fromp->dtypep()->skipRefp()->subDTypep()->skipRefp(), StructDType);
             dtypep->markConstrainedRand(true);
             AstMemberDType* memberp = dtypep->membersp();
             while (memberp) {

--- a/src/V3Randomize.cpp
+++ b/src/V3Randomize.cpp
@@ -909,16 +909,15 @@ class ConstraintExprVisitor final : public VNVisitor {
         if (nodep->name() == "at" && nodep->fromp()->user1()) {
             iterateChildren(nodep);
             nodep->dumpTreeJson(cout);
-            cout<<endl;
+            cout << endl;
             AstNodeExpr* pinp = nodep->pinsp()->unlinkFrBack();
-            if(VN_IS(pinp, SFormatF)) VN_AS(pinp, SFormatF)->name("%8x");
-            AstNodeExpr* const argsp
-                = AstNode::addNext(nodep->fromp()->unlinkFrBack(), pinp);
+            if (VN_IS(pinp, SFormatF)) VN_AS(pinp, SFormatF)->name("%8x");
+            AstNodeExpr* const argsp = AstNode::addNext(nodep->fromp()->unlinkFrBack(), pinp);
             AstSFormatF* newp = nullptr;
-            if(m_structSel){
+            if (m_structSel) {
                 newp = new AstSFormatF{fl, "%@.%@", false, argsp};
-            }
-            else newp = new AstSFormatF{fl, "(select %@ %@)", false, argsp};
+            } else
+                newp = new AstSFormatF{fl, "(select %@ %@)", false, argsp};
             nodep->replaceWith(newp);
             VL_DO_DANGLING(nodep->deleteTree(), nodep);
             return;

--- a/src/V3Randomize.cpp
+++ b/src/V3Randomize.cpp
@@ -726,10 +726,13 @@ class ConstraintExprVisitor final : public VNVisitor {
             }
         }
         // Mark Random for structArray
-        if(VN_IS(nodep->fromp(), ArraySel)){
+        if (VN_IS(nodep->fromp(), ArraySel)) {
             AstNodeExpr* const fromp = VN_AS(nodep->fromp(), ArraySel)->fromp();
-            VN_AS(fromp->dtypep()->skipRefp()->subDTypep()->skipRefp(), StructDType)->markConstrainedRand(true);
-            AstMemberDType* memberp = VN_AS(fromp->dtypep()->skipRefp()->subDTypep()->skipRefp(), StructDType)->membersp();
+            VN_AS(fromp->dtypep()->skipRefp()->subDTypep()->skipRefp(), StructDType)
+                ->markConstrainedRand(true);
+            AstMemberDType* memberp
+                = VN_AS(fromp->dtypep()->skipRefp()->subDTypep()->skipRefp(), StructDType)
+                      ->membersp();
             while (memberp) {
                 if (memberp->name() == nodep->name()) {
                     memberp->markConstrainedRand(true);
@@ -741,7 +744,8 @@ class ConstraintExprVisitor final : public VNVisitor {
         iterateChildren(nodep);
         if (editFormat(nodep)) return;
         FileLine* const fl = nodep->fileline();
-        AstSFormatF* newp = new AstSFormatF{fl, nodep->fromp()->name() + "." + nodep->name(), false, nullptr};
+        AstSFormatF* newp
+            = new AstSFormatF{fl, nodep->fromp()->name() + "." + nodep->name(), false, nullptr};
         nodep->replaceWith(newp);
         VL_DO_DANGLING(pushDeletep(nodep), nodep);
     }

--- a/src/V3Randomize.cpp
+++ b/src/V3Randomize.cpp
@@ -908,8 +908,6 @@ class ConstraintExprVisitor final : public VNVisitor {
 
         if (nodep->name() == "at" && nodep->fromp()->user1()) {
             iterateChildren(nodep);
-            nodep->dumpTreeJson(cout);
-            cout << endl;
             AstNodeExpr* pinp = nodep->pinsp()->unlinkFrBack();
             if (VN_IS(pinp, SFormatF)) VN_AS(pinp, SFormatF)->name("%8x");
             AstNodeExpr* const argsp = AstNode::addNext(nodep->fromp()->unlinkFrBack(), pinp);

--- a/src/V3Randomize.cpp
+++ b/src/V3Randomize.cpp
@@ -480,7 +480,8 @@ class ConstraintExprVisitor final : public VNVisitor {
     AstVar* m_randModeVarp;  // Relevant randmode state variable
     bool m_wantSingle = false;  // Whether to merge constraint expressions with LOGAND
     VMemberMap& m_memberMap;  // Member names cached for fast lookup
-    bool m_structSel = false; // Marks when inside a struct selection, used to format "%@.%@" for struct arrays
+    bool m_structSel
+        = false;  // Marks when inside a struct selection, used to format "%@.%@" for struct arrays
 
     AstSFormatF* getConstFormat(AstNodeExpr* nodep) {
         return new AstSFormatF{nodep->fileline(), (nodep->width() & 3) ? "#b%b" : "#x%x", false,

--- a/src/V3Randomize.cpp
+++ b/src/V3Randomize.cpp
@@ -909,7 +909,7 @@ class ConstraintExprVisitor final : public VNVisitor {
         if (nodep->name() == "at" && nodep->fromp()->user1()) {
             iterateChildren(nodep);
             AstNodeExpr* pinp = nodep->pinsp()->unlinkFrBack();
-            if (VN_IS(pinp, SFormatF)) VN_AS(pinp, SFormatF)->name("%8x");
+            if (VN_IS(pinp, SFormatF) && m_structSel) VN_AS(pinp, SFormatF)->name("%8x");
             AstNodeExpr* const argsp = AstNode::addNext(nodep->fromp()->unlinkFrBack(), pinp);
             AstSFormatF* newp = nullptr;
             if (m_structSel) {

--- a/src/V3Randomize.cpp
+++ b/src/V3Randomize.cpp
@@ -744,8 +744,14 @@ class ConstraintExprVisitor final : public VNVisitor {
         iterateChildren(nodep);
         if (editFormat(nodep)) return;
         FileLine* const fl = nodep->fileline();
-        AstSFormatF* newp
-            = new AstSFormatF{fl, nodep->fromp()->name() + "." + nodep->name(), false, nullptr};
+        AstSFormatF* newp = nullptr;
+        if (VN_AS(nodep->fromp(), SFormatF)->name() == "(select %@ %@)") {
+            newp = new AstSFormatF{fl, "%@.%@." + nodep->name(), false,
+                                   VN_AS(nodep->fromp(), SFormatF)->exprsp()->cloneTreePure(true)};
+            newp->exprsp()->nextp()->name("x%8x");
+        } else
+            newp = new AstSFormatF{fl, nodep->fromp()->name() + "." + nodep->name(), false,
+                                   nullptr};
         nodep->replaceWith(newp);
         VL_DO_DANGLING(pushDeletep(nodep), nodep);
     }

--- a/src/V3Randomize.cpp
+++ b/src/V3Randomize.cpp
@@ -538,9 +538,9 @@ class ConstraintExprVisitor final : public VNVisitor {
         UASSERT_OBJ(!rhsp, nodep, "Missing emitSMT %r for " << rhsp);
         UASSERT_OBJ(!thsp, nodep, "Missing emitSMT %t for " << thsp);
         AstSFormatF* const newp = new AstSFormatF{nodep->fileline(), smtExpr, false, argsp};
-        if(m_structSel && newp->name() == "(select %@ %@)"){ // for struct arrays
+        if (m_structSel && newp->name() == "(select %@ %@)") {  // for struct arrays
             newp->name("%@.%@");
-            newp->exprsp()->nextp()->name("%8x");// x%8x
+            newp->exprsp()->nextp()->name("%8x");  // x%8x
         }
         nodep->replaceWith(newp);
         VL_DO_DANGLING(pushDeletep(nodep), nodep);
@@ -755,11 +755,11 @@ class ConstraintExprVisitor final : public VNVisitor {
         if (VN_AS(nodep->fromp(), SFormatF)->name() == "%@.%@") {
             newp = new AstSFormatF{fl, "%@.%@." + nodep->name(), false,
                                    VN_AS(nodep->fromp(), SFormatF)->exprsp()->cloneTreePure(true)};
-            newp->exprsp()->nextp()->name("%8x"); // x%8x
-        } else{
+            newp->exprsp()->nextp()->name("%8x");  // x%8x
+        } else {
             newp = new AstSFormatF{fl, nodep->fromp()->name() + "." + nodep->name(), false,
                                    nullptr};
-            }
+        }
         m_structSel = false;
         nodep->replaceWith(newp);
         VL_DO_DANGLING(pushDeletep(nodep), nodep);

--- a/src/V3Randomize.cpp
+++ b/src/V3Randomize.cpp
@@ -481,6 +481,8 @@ class ConstraintExprVisitor final : public VNVisitor {
     bool m_wantSingle = false;  // Whether to merge constraint expressions with LOGAND
     VMemberMap& m_memberMap;  // Member names cached for fast lookup
 
+    bool m_structSel = false;
+
     AstSFormatF* getConstFormat(AstNodeExpr* nodep) {
         return new AstSFormatF{nodep->fileline(), (nodep->width() & 3) ? "#b%b" : "#x%x", false,
                                nodep};
@@ -536,6 +538,10 @@ class ConstraintExprVisitor final : public VNVisitor {
         UASSERT_OBJ(!rhsp, nodep, "Missing emitSMT %r for " << rhsp);
         UASSERT_OBJ(!thsp, nodep, "Missing emitSMT %t for " << thsp);
         AstSFormatF* const newp = new AstSFormatF{nodep->fileline(), smtExpr, false, argsp};
+        if(m_structSel && newp->name() == "(select %@ %@)"){ // for struct arrays
+            newp->name("%@.%@");
+            newp->exprsp()->nextp()->name("%8x");// x%8x
+        }
         nodep->replaceWith(newp);
         VL_DO_DANGLING(pushDeletep(nodep), nodep);
     }
@@ -711,6 +717,7 @@ class ConstraintExprVisitor final : public VNVisitor {
         editSMT(nodep, nodep->fromp(), lsbp, msbp);
     }
     void visit(AstStructSel* nodep) override {
+        m_structSel = true;
         if (VN_IS(nodep->fromp()->dtypep()->skipRefp(), StructDType)) {
             AstNodeExpr* const fromp = nodep->fromp();
             if (VN_IS(fromp, StructSel)) {
@@ -745,13 +752,15 @@ class ConstraintExprVisitor final : public VNVisitor {
         if (editFormat(nodep)) return;
         FileLine* const fl = nodep->fileline();
         AstSFormatF* newp = nullptr;
-        if (VN_AS(nodep->fromp(), SFormatF)->name() == "(select %@ %@)") {
+        if (VN_AS(nodep->fromp(), SFormatF)->name() == "%@.%@") {
             newp = new AstSFormatF{fl, "%@.%@." + nodep->name(), false,
                                    VN_AS(nodep->fromp(), SFormatF)->exprsp()->cloneTreePure(true)};
-            newp->exprsp()->nextp()->name("x%8x");
-        } else
+            newp->exprsp()->nextp()->name("%8x"); // x%8x
+        } else{
             newp = new AstSFormatF{fl, nodep->fromp()->name() + "." + nodep->name(), false,
                                    nullptr};
+            }
+        m_structSel = false;
         nodep->replaceWith(newp);
         VL_DO_DANGLING(pushDeletep(nodep), nodep);
     }

--- a/src/V3Randomize.cpp
+++ b/src/V3Randomize.cpp
@@ -480,8 +480,8 @@ class ConstraintExprVisitor final : public VNVisitor {
     AstVar* m_randModeVarp;  // Relevant randmode state variable
     bool m_wantSingle = false;  // Whether to merge constraint expressions with LOGAND
     VMemberMap& m_memberMap;  // Member names cached for fast lookup
-    bool m_structSel
-        = false;  // Marks when inside a struct selection, used to format "%@.%@" for struct arrays
+    bool m_structSel = false;  // Marks when inside structSel
+                               // (used to format "%@.%@" for struct arrays)
 
     AstSFormatF* getConstFormat(AstNodeExpr* nodep) {
         return new AstSFormatF{nodep->fileline(), (nodep->width() & 3) ? "#b%b" : "#x%x", false,
@@ -538,9 +538,9 @@ class ConstraintExprVisitor final : public VNVisitor {
         UASSERT_OBJ(!rhsp, nodep, "Missing emitSMT %r for " << rhsp);
         UASSERT_OBJ(!thsp, nodep, "Missing emitSMT %t for " << thsp);
         AstSFormatF* const newp = new AstSFormatF{nodep->fileline(), smtExpr, false, argsp};
-        if (m_structSel && newp->name() == "(select %@ %@)") {  // for struct arrays
+        if (m_structSel && newp->name() == "(select %@ %@)") {
             newp->name("%@.%@");
-            newp->exprsp()->nextp()->name("%8x");  // x%8x
+            newp->exprsp()->nextp()->name("%8x");
         }
         nodep->replaceWith(newp);
         VL_DO_DANGLING(pushDeletep(nodep), nodep);
@@ -755,7 +755,7 @@ class ConstraintExprVisitor final : public VNVisitor {
         if (VN_AS(nodep->fromp(), SFormatF)->name() == "%@.%@") {
             newp = new AstSFormatF{fl, "%@.%@." + nodep->name(), false,
                                    VN_AS(nodep->fromp(), SFormatF)->exprsp()->cloneTreePure(true)};
-            newp->exprsp()->nextp()->name("%8x");  // x%8x
+            newp->exprsp()->nextp()->name("%8x");
         } else {
             newp = new AstSFormatF{fl, nodep->fromp()->name() + "." + nodep->name(), false,
                                    nullptr};

--- a/src/V3Randomize.cpp
+++ b/src/V3Randomize.cpp
@@ -540,7 +540,7 @@ class ConstraintExprVisitor final : public VNVisitor {
         AstSFormatF* const newp = new AstSFormatF{nodep->fileline(), smtExpr, false, argsp};
         if (m_structSel && newp->name() == "(select %@ %@)") {
             newp->name("%@.%@");
-            newp->exprsp()->nextp()->name("%8x");
+            newp->exprsp()->nextp()->name("%x");
         }
         nodep->replaceWith(newp);
         VL_DO_DANGLING(pushDeletep(nodep), nodep);
@@ -735,11 +735,9 @@ class ConstraintExprVisitor final : public VNVisitor {
         // Mark Random for structArray
         if (VN_IS(nodep->fromp(), ArraySel)) {
             AstNodeExpr* const fromp = VN_AS(nodep->fromp(), ArraySel)->fromp();
-            VN_AS(fromp->dtypep()->skipRefp()->subDTypep()->skipRefp(), StructDType)
-                ->markConstrainedRand(true);
-            AstMemberDType* memberp
-                = VN_AS(fromp->dtypep()->skipRefp()->subDTypep()->skipRefp(), StructDType)
-                      ->membersp();
+            AstStructDType* const dtypep = VN_AS(fromp->dtypep()->skipRefp()->subDTypep()->skipRefp(), StructDType);
+            dtypep->markConstrainedRand(true);
+            AstMemberDType* memberp = dtypep->membersp();
             while (memberp) {
                 if (memberp->name() == nodep->name()) {
                     memberp->markConstrainedRand(true);
@@ -755,7 +753,7 @@ class ConstraintExprVisitor final : public VNVisitor {
         if (VN_AS(nodep->fromp(), SFormatF)->name() == "%@.%@") {
             newp = new AstSFormatF{fl, "%@.%@." + nodep->name(), false,
                                    VN_AS(nodep->fromp(), SFormatF)->exprsp()->cloneTreePure(true)};
-            newp->exprsp()->nextp()->name("%8x");
+            newp->exprsp()->nextp()->name("%x");
         } else {
             newp = new AstSFormatF{fl, nodep->fromp()->name() + "." + nodep->name(), false,
                                    nullptr};
@@ -909,7 +907,7 @@ class ConstraintExprVisitor final : public VNVisitor {
         if (nodep->name() == "at" && nodep->fromp()->user1()) {
             iterateChildren(nodep);
             AstNodeExpr* pinp = nodep->pinsp()->unlinkFrBack();
-            if (VN_IS(pinp, SFormatF) && m_structSel) VN_AS(pinp, SFormatF)->name("%8x");
+            if (VN_IS(pinp, SFormatF) && m_structSel) VN_AS(pinp, SFormatF)->name("%x");
             AstNodeExpr* const argsp = AstNode::addNext(nodep->fromp()->unlinkFrBack(), pinp);
             AstSFormatF* newp = nullptr;
             if (m_structSel)

--- a/src/V3Randomize.cpp
+++ b/src/V3Randomize.cpp
@@ -538,9 +538,9 @@ class ConstraintExprVisitor final : public VNVisitor {
         UASSERT_OBJ(!rhsp, nodep, "Missing emitSMT %r for " << rhsp);
         UASSERT_OBJ(!thsp, nodep, "Missing emitSMT %t for " << thsp);
         AstSFormatF* const newp = new AstSFormatF{nodep->fileline(), smtExpr, false, argsp};
-        if (m_structSel && newp->name() == "(select %@ %@)") {  // for struct arrays
+        if(m_structSel && newp->name() == "(select %@ %@)"){ // for struct arrays
             newp->name("%@.%@");
-            newp->exprsp()->nextp()->name("%8x");  // x%8x
+            newp->exprsp()->nextp()->name("%8x");// x%8x
         }
         nodep->replaceWith(newp);
         VL_DO_DANGLING(pushDeletep(nodep), nodep);
@@ -755,11 +755,11 @@ class ConstraintExprVisitor final : public VNVisitor {
         if (VN_AS(nodep->fromp(), SFormatF)->name() == "%@.%@") {
             newp = new AstSFormatF{fl, "%@.%@." + nodep->name(), false,
                                    VN_AS(nodep->fromp(), SFormatF)->exprsp()->cloneTreePure(true)};
-            newp->exprsp()->nextp()->name("%8x");  // x%8x
-        } else {
+            newp->exprsp()->nextp()->name("%8x"); // x%8x
+        } else{
             newp = new AstSFormatF{fl, nodep->fromp()->name() + "." + nodep->name(), false,
                                    nullptr};
-        }
+            }
         m_structSel = false;
         nodep->replaceWith(newp);
         VL_DO_DANGLING(pushDeletep(nodep), nodep);

--- a/src/V3Randomize.cpp
+++ b/src/V3Randomize.cpp
@@ -725,11 +725,23 @@ class ConstraintExprVisitor final : public VNVisitor {
                     memberp = VN_CAST(memberp->nextp(), MemberDType);
             }
         }
+        // Mark Random for structArray
+        if(VN_IS(nodep->fromp(), ArraySel)){
+            AstNodeExpr* const fromp = VN_AS(nodep->fromp(), ArraySel)->fromp();
+            VN_AS(fromp->dtypep()->skipRefp()->subDTypep()->skipRefp(), StructDType)->markConstrainedRand(true);
+            AstMemberDType* memberp = VN_AS(fromp->dtypep()->skipRefp()->subDTypep()->skipRefp(), StructDType)->membersp();
+            while (memberp) {
+                if (memberp->name() == nodep->name()) {
+                    memberp->markConstrainedRand(true);
+                    break;
+                } else
+                    memberp = VN_CAST(memberp->nextp(), MemberDType);
+            }
+        }
         iterateChildren(nodep);
         if (editFormat(nodep)) return;
         FileLine* const fl = nodep->fileline();
-        AstSFormatF* const newp
-            = new AstSFormatF{fl, nodep->fromp()->name() + "." + nodep->name(), false, nullptr};
+        AstSFormatF* newp = new AstSFormatF{fl, nodep->fromp()->name() + "." + nodep->name(), false, nullptr};
         nodep->replaceWith(newp);
         VL_DO_DANGLING(pushDeletep(nodep), nodep);
     }

--- a/src/V3Randomize.cpp
+++ b/src/V3Randomize.cpp
@@ -480,8 +480,7 @@ class ConstraintExprVisitor final : public VNVisitor {
     AstVar* m_randModeVarp;  // Relevant randmode state variable
     bool m_wantSingle = false;  // Whether to merge constraint expressions with LOGAND
     VMemberMap& m_memberMap;  // Member names cached for fast lookup
-
-    bool m_structSel = false;
+    bool m_structSel = false; // Marks when inside a struct selection, used to format "%@.%@" for struct arrays
 
     AstSFormatF* getConstFormat(AstNodeExpr* nodep) {
         return new AstSFormatF{nodep->fileline(), (nodep->width() & 3) ? "#b%b" : "#x%x", false,
@@ -912,9 +911,9 @@ class ConstraintExprVisitor final : public VNVisitor {
             if (VN_IS(pinp, SFormatF) && m_structSel) VN_AS(pinp, SFormatF)->name("%8x");
             AstNodeExpr* const argsp = AstNode::addNext(nodep->fromp()->unlinkFrBack(), pinp);
             AstSFormatF* newp = nullptr;
-            if (m_structSel) {
+            if (m_structSel)
                 newp = new AstSFormatF{fl, "%@.%@", false, argsp};
-            } else
+            else
                 newp = new AstSFormatF{fl, "(select %@ %@)", false, argsp};
             nodep->replaceWith(newp);
             VL_DO_DANGLING(nodep->deleteTree(), nodep);

--- a/test_regress/t/t_constraint_struct_complex.v
+++ b/test_regress/t/t_constraint_struct_complex.v
@@ -113,7 +113,7 @@ class ArrayStruct;
 endclass
 
 class StructArray;
-    /* verilator lint_off SIDEEFFECT */
+    /* verilator lint_off WIDTHTRUNC */
     typedef struct {
         rand int arr[3];
         rand int a;
@@ -157,7 +157,7 @@ class StructArray;
             if (!(s_arr[1].c == 1)) $stop;
         end
     endfunction
-    /* verilator lint_off SIDEEFFECT */
+    /* verilator lint_off WIDTHTRUNC */
 endclass
 
 module t_constraint_struct_complex;

--- a/test_regress/t/t_constraint_struct_complex.v
+++ b/test_regress/t/t_constraint_struct_complex.v
@@ -112,15 +112,67 @@ class ArrayStruct;
     /* verilator lint_off SIDEEFFECT */
 endclass
 
+class StructArray;
+    /* verilator lint_off SIDEEFFECT */
+    typedef struct {
+        rand int arr[3];
+        rand int a;
+        rand bit [3:0] b;
+        bit c;
+    } struct_t;
+    rand struct_t s_arr[2];
+
+    constraint c_structArray {
+        foreach (s_arr[i]) begin
+            foreach (s_arr[i].arr[j]) s_arr[i].arr[j] inside {[0:9]};
+            s_arr[i].a inside {[10:20]};
+        end
+    }
+
+    function new();
+        foreach (s_arr[i]) begin
+            foreach (s_arr[i].arr[j]) s_arr[i].arr[j] = 'h0 + j;
+            s_arr[i].a = 'h10 + i;
+            s_arr[i].b = 'h0 + i;
+            s_arr[i].c = i;
+        end
+    endfunction
+
+    function void print();
+        foreach (s_arr[i]) begin
+            foreach (s_arr[i].arr[j]) $display("s_arr[%0d].arr[%0d] = %0d", i, j, s_arr[i].arr[j]);
+            $display("s_arr[%0d].a = %0d", i, s_arr[i].a);
+            $display("s_arr[%0d].b = %0h", i, s_arr[i].b);
+            $display("s_arr[%0d].c = %0d", i, s_arr[i].c);
+        end
+    endfunction
+
+    function void self_test();
+        foreach (s_arr[i]) begin
+            foreach (s_arr[i].arr[j]) if (!(s_arr[i].arr[j] inside {[0:9]})) $stop;
+            if (!(s_arr[i].a inside {[10:20]})) $stop;
+            if (!(s_arr[0].c == 0)) $stop;
+            if (!(s_arr[1].c == 1)) $stop;
+        end
+    endfunction
+    /* verilator lint_off SIDEEFFECT */
+endclass
+
 module t_constraint_struct_complex;
     int success;
-    ArrayStruct asc;
+    ArrayStruct as_c;
+    StructArray sa_c;
     initial begin
-        asc = new();
-        success = asc.randomize();
+        as_c = new();
+        sa_c = new();
+        success = as_c.randomize();
         if (success != 1) $stop;
-        asc.self_test();
-        // asc.print();
+        as_c.self_test();
+        // as_c.print();
+        success = sa_c.randomize();
+        if (success != 1) $stop;
+        sa_c.self_test();
+        // sa_c.print();
         $write("*-* All Finished *-*\n");
         $finish;
     end

--- a/test_regress/t/t_constraint_struct_complex.v
+++ b/test_regress/t/t_constraint_struct_complex.v
@@ -122,11 +122,13 @@ class StructArray;
     } struct_t;
     rand struct_t s_arr[2];
 
-    constraint c_structArray {
-        foreach (s_arr[i]) begin
-            foreach (s_arr[i].arr[j]) s_arr[i].arr[j] inside {[0:9]};
-            s_arr[i].a inside {[10:20]};
-        end
+    constraint c_structArray_0 {
+        foreach (s_arr[i])
+            foreach (s_arr[i].arr[j])
+                s_arr[i].arr[j] inside {[0:9]};
+    }
+    constraint c_structArray_1 {
+        foreach (s_arr[i]) s_arr[i].a inside {[10:20]};
     }
 
     function new();
@@ -142,7 +144,7 @@ class StructArray;
         foreach (s_arr[i]) begin
             foreach (s_arr[i].arr[j]) $display("s_arr[%0d].arr[%0d] = %0d", i, j, s_arr[i].arr[j]);
             $display("s_arr[%0d].a = %0d", i, s_arr[i].a);
-            $display("s_arr[%0d].b = %0h", i, s_arr[i].b);
+            $display("s_arr[%0d].b = %0d", i, s_arr[i].b);
             $display("s_arr[%0d].c = %0d", i, s_arr[i].c);
         end
     endfunction


### PR DESCRIPTION
Support for struct elements in arrays has been added. Fix #5805 
Constrained randomization is now supported for unpacked arrays, queues, and dynamic arrays where the element type is a struct.

The implementation follows the same structure as the existing array support:
write_var → record_info → call the solver.

Additionally, the structure of the `verilated_random.h` file has been reorganized and comments have been added to improve readability.