### PR TITLE
Remove redundant edges in V3Trace. No functional change

### DIFF
--- a/src/V3Trace.cpp
+++ b/src/V3Trace.cpp
@@ -755,6 +755,7 @@ class TraceVisitor final : public VNVisitor {
     void createTraceFunctions() {
         // Detect and remove duplicate values
         detectDuplicates();
+        m_graph.removeRedundantEdgesMax(&V3GraphEdge::followAlwaysTrue);
 
         // Simplify & optimize the graph
         if (dumpGraphLevel() >= 6) m_graph.dumpDotFilePrefixed("trace_pre");


### PR DESCRIPTION
Many edges added by the following lines are redundant: https://github.com/verilator/verilator/blob/3ecd58460fcd2d043ac8a6c058c3b4e810431ad0/src/V3Trace.cpp#L916-L922
This code for each writable variable reference inside a function creates an edge between that function and that variable. It results in many duplicates.
It can be seen on [the graph](https://github.com/user-attachments/files/19791330/trace_pre.pdf) generated for the following code
```systemverilog
module prim_and2 (
    input logic [9:0] in0_i
);
endmodule

module prim_onehot_mux;
  parameter int Width = 50;
  parameter int Inputs = 10;
  logic [ Width-1:0] in_i  [Inputs];
  logic [Inputs-1:0] in_mux[ Width];
  for (genvar b = 0; b < Width; ++b) begin : g_in_mux_outer
    for (genvar i = 0; i < Inputs; ++i) begin : g_in_mux_inner
      assign in_mux[b][i] = in_i[i][b];
    end
    prim_and2 u_mux_bit_and (.in0_i(in_mux[b]));
  end
endmodule
```
Then `rerouteEdges` is called, which multiplies duplicates much more:
https://github.com/verilator/verilator/blob/3ecd58460fcd2d043ac8a6c058c3b4e810431ad0/src/V3Graph.cpp#L71-L77

This PR removes the redundant edges at the beginning and reduces the memory needed by verilation of some 9k lines of code design from 138GB to 8GB.