### PR TITLE
Update UNOPTFLAT warning to suggest isolate_assignments as well

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -110,6 +110,7 @@ Jiuyang Liu
 Joey Liu
 John Coiner
 John Demme
+John Khoo
 John Wehle
 Jonathan Drolet
 Jonathan Schröter

--- a/src/V3SchedAcyclic.cpp
+++ b/src/V3SchedAcyclic.cpp
@@ -317,7 +317,7 @@ void reportLoopVars(Graph* graphp, SchedAcyclicVarVertex* vvtxp) {
 
     if (splittable) {
         std::cerr << V3Error::warnMoreStandalone()
-                  << "... Suggest add /*verilator split_var*/ to appropriate variables above."
+                  << "... Suggest add /*verilator split_var*/ or /*verilator isolate_assignments*/ to appropriate variables above."
                   << std::endl;
     }
     V3Stats::addStat("Scheduling, split_var, candidates", splittable);

--- a/test_regress/t/t_unoptflat_simple_2_bad.out
+++ b/test_regress/t/t_unoptflat_simple_2_bad.out
@@ -10,5 +10,5 @@
                         t/t_unoptflat_simple_2.v:16:15:  t.x, width 3, circular fanout 1, can split_var
                     ... Candidates with the highest fanout:
                         t/t_unoptflat_simple_2.v:16:15:  t.x, width 3, circular fanout 1, can split_var
-                    ... Suggest add /*verilator split_var*/ to appropriate variables above.
+                    ... Suggest add /*verilator split_var*/ or /*verilator isolate_assignments*/ to appropriate variables above.
 %Error: Exiting due to


### PR DESCRIPTION
This is a simple update to the UNOPTFLAT warning to mention that isolate_assignments can help break some of the loops. The existence of such a metacomment is not made clear to the user attempting to debug UNOPTFLAT.