### PR TITLE
Add RTLMeter GitHub workflows

### DIFF
--- a/.github/workflows/reusable-rtlmeter-build.yml
+++ b/.github/workflows/reusable-rtlmeter-build.yml
@@ -1,0 +1,73 @@
+---
+# DESCRIPTION: Github actions config
+# This name is key to badges in README.rst, so we use the name build
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+name: reusable-rtlmeter-build
+
+on:
+  workflow_call:
+    inputs:
+      runs-on:
+        description: "Runner to use, e.g.: ubuntu-24.04"
+        type: string
+        required: true
+      cc:
+        description: "Compiler to use: 'gcc' or 'clang'"
+        type: string
+        required: true
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  CCACHE_DIR: ${{ github.workspace }}/ccache
+  CCACHE_MAXSIZE: 512M
+
+jobs:
+  build:
+    runs-on: ${{ inputs.runs-on }}
+    name: Build
+    steps:
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          sudo apt install ccache mold help2man libfl-dev libgoogle-perftools-dev libsystemc-dev
+
+      - name: Use saved ccache
+        uses: actions/cache@v4
+        with:
+          path: ccache
+          key: rtlmeter-build-ccache-${{ inputs.runs-on }}-${{ inputs.cc }}-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: rtlmeter-build-ccache-${{ inputs.runs-on }}-${{ inputs.cc }}
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          path: repo
+          fetch-depth: 0 # Required for 'git describe' used for 'verilator --version'
+
+      - name: Configure
+        working-directory: repo
+        run: |
+          autoconf
+          ./configure --prefix=${{ github.workspace }}/install CXX=${{ inputs.cc == 'clang' && 'clang++' || 'g++' }}
+
+      - name: Make
+        working-directory: repo
+        run: make -j $(nproc)
+
+      - name: Install
+        working-directory: repo
+        run: make install
+
+      - name: Tar up installation
+        run: tar --posix -c -z -f verilator-rtlmeter.tar.gz install
+
+      - name: Upload Verilator installation archive
+        uses: actions/upload-artifact@v4
+        with:
+          path: verilator-rtlmeter.tar.gz
+          name: verilator-rtlmeter-${{ inputs.runs-on }}-${{ inputs.cc }}
+          overwrite: true

--- a/.github/workflows/reusable-rtlmeter-run.yml
+++ b/.github/workflows/reusable-rtlmeter-run.yml
@@ -1,0 +1,118 @@
+---
+# DESCRIPTION: Github actions config
+# This name is key to badges in README.rst, so we use the name build
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+name: reusable-rtlmeter-run
+
+on:
+  workflow_call:
+    inputs:
+      runs-on:
+        description: "Runner to use, e.g.: ubuntu-24.04"
+        type: string
+        required: true
+      cc:
+        description: "Compiler to use: 'gcc' or 'clang'"
+        type: string
+        required: true
+      cases:
+        description: "RTLMeter cases to run"
+        type: string
+        required: true
+      compileArgs:
+        description: "Additional Verilator command line arguments"
+        type: string
+        default: ""
+      executeArgs:
+        description: "Additional simulator command line arguments"
+        type: string
+        default: ""
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  CCACHE_DIR: ${{ github.workspace }}/ccache
+  CCACHE_MAXSIZE: 512M
+  CCACHE_DISABLE: 1
+
+jobs:
+  run:
+    runs-on: ${{ inputs.runs-on }}
+    name: Run
+    steps:
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          sudo apt install ccache mold libfl-dev libgoogle-perftools-dev libsystemc-dev
+
+      - name: Download Verilator installation archive
+        uses: actions/download-artifact@v4
+        with:
+          name: verilator-rtlmeter-${{ inputs.runs-on }}-${{ inputs.cc }}
+
+      - name: Unpack Verilator installation archive
+        run: |
+          tar -x -z -f verilator-rtlmeter.tar.gz
+          echo "${{ github.workspace }}/install/bin" >> $GITHUB_PATH
+
+      - name: Use saved ccache
+        if: ${{ env.CCACHE_DISABLE == 0 }}
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: rtlmeter-run-ccache-${{ inputs.runs-on }}-${{ inputs.cc }}-${{ inputs.cases }}-${{ inputs.compileArgs }}-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: rtlmeter-run-ccache-${{ inputs.runs-on }}-${{ inputs.cc }}-${{ inputs.cases }}-${{ inputs.compileArgs }}
+
+      - name: Checkout RTLMeter
+        uses: actions/checkout@v4
+        with:
+          repository: "verilator/rtlmeter"
+          path: rtlmeter
+
+      - name: Setup RTLMeter venv
+        working-directory: rtlmeter
+        run: make venv
+
+      - name: Compile cases
+        working-directory: rtlmeter
+        run: |
+          ./rtlmeter run --verbose --cases='${{ inputs.cases }}' --compileArgs='${{ inputs.compileArgs }}' --executeArgs='${{ inputs.executeArgs }}' --nExecute=0
+          # My YAML highlighter sucks, so I put this comment here wiht a phony closing quote mark to make it work: '
+
+      - name: Execute cases
+        working-directory: rtlmeter
+        continue-on-error: true # Do not fail on error, so we can at leat save the successful results
+        run: |
+          ./rtlmeter run --verbose --cases='${{ inputs.cases }}' --compileArgs='${{ inputs.compileArgs }}' --executeArgs='${{ inputs.executeArgs }}'
+          # My YAML highlighter sucks, so I put this comment here wiht a phony closing quote mark to make it work: '
+
+      - name: Collate results
+        id: results
+        working-directory: rtlmeter
+        run: |
+          # 'inputs.cases' has special characters, use its md5sum as unique id
+          hash=$(md5sum <<< '${{ inputs.cases }}' | awk '{print $1}')
+          echo "hash=${hash}" >> $GITHUB_OUTPUT
+          ./rtlmeter collate > ../results-${hash}.json
+
+      - name: Report results
+        working-directory: rtlmeter
+        run: |
+          ./rtlmeter report --steps '*' --metrics '*' ../results-${{ steps.results.outputs.hash }}.json
+
+      - name: Upload results
+        uses: actions/upload-artifact@v4
+        with:
+          path: results-${{ steps.results.outputs.hash }}.json
+          name: rtlmeter-results-${{ inputs.runs-on }}-${{ inputs.cc }}-${{ steps.results.outputs.hash }}
+          overwrite: true
+          retention-days: 2
+
+      - name: Report status
+        working-directory: rtlmeter
+        run: | # This will fail the job if any of the runs failed
+          ./rtlmeter run --verbose --cases='${{ inputs.cases }}' --compileArgs='${{ inputs.compileArgs }}' --executeArgs='${{ inputs.executeArgs }}'
+          # My YAML highlighter sucks, so I put this comment here wiht a phony closing quote mark to make it work: '

--- a/.github/workflows/rtlmeter.yml
+++ b/.github/workflows/rtlmeter.yml
@@ -1,0 +1,158 @@
+---
+# DESCRIPTION: Github actions config
+# This name is key to badges in README.rst, so we use the name build
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+name: RTLMeter
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 2 * * *'  # Daily, starting at 02:00 UTC
+
+defaults:
+  run:
+    shell: bash
+
+concurrency:
+  group: RTLMeter
+  cancel-in-progress: false
+
+jobs:
+  build-gcc:
+    name: Build GCC
+    uses: ./.github/workflows/reusable-rtlmeter-build.yml
+    with:
+      runs-on: ubuntu-24.04
+      cc: gcc
+
+  build-clang:
+    name: Build Clang
+    uses: ./.github/workflows/reusable-rtlmeter-build.yml
+    with:
+      runs-on: ubuntu-24.04
+      cc: clang
+
+  run-gcc:
+    name: Run GCC | ${{ matrix.cases }}
+    needs: build-gcc
+    uses: ./.github/workflows/reusable-rtlmeter-run.yml
+    with:
+      runs-on: ubuntu-24.04
+      cc: gcc
+      cases: ${{ matrix.cases }}
+      compileArgs: ""
+      executeArgs: ""
+    strategy:
+      fail-fast: false
+      max-parallel: 2
+      matrix:
+        cases:
+          - "NVDLA:*"
+          - "OpenPiton:1x1:*"
+          - "OpenPiton:2x2:*"
+          - "OpenPiton:4x4:*"
+          # - "OpenTitan:*"
+          - "VeeR-EH1:asic*"
+          - "VeeR-EH1:default*"
+          - "VeeR-EH1:hiperf*"
+          - "VeeR-EH2:asic*"
+          - "VeeR-EH2:default*"
+          - "VeeR-EH2:hiperf*"
+          - "VeeR-EL2:asic*"
+          - "VeeR-EL2:default*"
+          - "VeeR-EL2:hiperf*"
+          - "Vortex:mini:*"
+          - "Vortex:sane:*"
+          # - "XiangShan:default-chisel3:* !*:linux"
+          # - "XiangShan:default-chisel6:* !*:linux"
+          - "XiangShan:mini-chisel3:* !*:linux"
+          # - "XiangShan:mini-chisel6:* !*:linux"
+          - "XuanTie-E902:*"
+          - "XuanTie-E906:*"
+          - "XuanTie-C906:*"
+          - "XuanTie-C910:*"
+
+  run-clang:
+    name: Run Clang | ${{ matrix.cases }}
+    needs: build-clang
+    uses: ./.github/workflows/reusable-rtlmeter-run.yml
+    with:
+      runs-on: ubuntu-24.04
+      cc: clang
+      cases: ${{ matrix.cases }}
+      compileArgs: "--threads 4"
+      executeArgs: ""
+    strategy:
+      fail-fast: false
+      max-parallel: 2
+      matrix:
+        cases:
+          - "NVDLA:*"
+          - "OpenPiton:1x1:*"
+          - "OpenPiton:2x2:*"
+          - "OpenPiton:4x4:*"
+          # - "OpenTitan:*"
+          - "VeeR-EH1:asic*"
+          - "VeeR-EH1:default*"
+          - "VeeR-EH1:hiperf*"
+          - "VeeR-EH2:asic*"
+          - "VeeR-EH2:default*"
+          - "VeeR-EH2:hiperf*"
+          - "VeeR-EL2:asic*"
+          - "VeeR-EL2:default*"
+          - "VeeR-EL2:hiperf*"
+          - "Vortex:mini:*"
+          - "Vortex:sane:*"
+          - "XiangShan:default-chisel3:* !*:linux"
+          - "XiangShan:default-chisel6:* !*:linux"
+          - "XiangShan:mini-chisel3:* !*:linux"
+          - "XiangShan:mini-chisel6:* !*:linux"
+          - "XuanTie-E902:*"
+          - "XuanTie-E906:*"
+          - "XuanTie-C906:*"
+          - "XuanTie-C910:*"
+
+  combine-results:
+    name: Combine results
+    needs:
+      - run-gcc
+      - run-clang
+    if: ${{ always() }} # Run even if dependencies failed
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Download all GCC results
+        uses: actions/download-artifact@v4
+        with:
+          pattern: rtlmeter-results-ubuntu-24.04-gcc-*
+          path: all-results-gcc-${{ github.run_id }}
+          merge-multiple: true
+      - name: Download all Clang results
+        uses: actions/download-artifact@v4
+        with:
+          pattern: rtlmeter-results-ubuntu-24.04-clang-*
+          path: all-results-clang-${{ github.run_id }}
+          merge-multiple: true
+      - name: Tar up results
+        run: |
+          # Ensure combined result directories exists in case of no results
+          mkdir -p all-results-gcc-${{ github.run_id }}
+          mkdir -p all-results-clang-${{ github.run_id }}
+          ls -la all-results*
+          # Tar up each directory
+          tar --posix -c -z -f all-results-gcc-${{ github.run_id }}.tar.gz all-results-gcc-${{ github.run_id }}
+          tar --posix -c -z -f all-results-clang-${{ github.run_id }}.tar.gz all-results-clang-${{ github.run_id }}
+      - name: Upload combined GCC results
+        uses: actions/upload-artifact@v4
+        with:
+          path: all-results-gcc-${{ github.run_id }}.tar.gz
+          name: "all-results-gcc"
+          overwrite: true
+          retention-days: 30
+      - name: Upload combined Clang results
+        uses: actions/upload-artifact@v4
+        with:
+          path: all-results-clang-${{ github.run_id }}.tar.gz
+          name: "all-results-clang"
+          overwrite: true
+          retention-days: 30


### PR DESCRIPTION
Add the GitHub Actions workflows for running RTLMeter.

Runs start daily, at 02:00 UTC, on ubuntu-24.04. There are 2 runs:
- Using GCC, with default verilator options
- Using Clang, with "--threads 4"

Each run uses a maximum of 2 runners in parallel (so max 4 in total), and takes slightly over 2 hours to complete.

The jobs will fail if a benchmark is broken, so this already serves as a regression test for the included designs.

For now, performance metrics are recorded as artefacts of the run but not otherwise published.

Performance metrics are always recorded for all successful jobs, even if some cases are failing.

---

RTLMeter now lives here: https://github.com/verilator/rtlmeter

I'm still working on the dashboard, which will come in May.

Additionally:
- OpenTitan is currently failing in the cppbuild step, most likely due to the 50d7f2afc, though I have not bisected at this point
- Some flavours of XiangShan are failing to compile with GCC, due to hitting some algorithmic bottleneck in the compiler

These are currently not run as they would always fail.

Cases that don't fit into the 16GB memory available on the GitHub runners are also not run.

Otherwise this is quite ready, to add uploading to the dashboard, the workflow will need a new job after the current "Combine results", but I expect no other significant changes.

I'm waiting for a manual run on my fork to pass successfully, if that is done, it should be good to merge.