### PR TITLE
Fix --x-initial and --x-assign random stability (#2662)

### DIFF
--- a/include/verilated.cpp
+++ b/include/verilated.cpp
@@ -406,37 +406,60 @@ IData VL_URANDOM_SEEDED_II(IData seed) VL_MT_SAFE {
     Verilated::threadContextp()->randSeed(static_cast<int>(seed));
     return VL_RANDOM_I();
 }
-IData VL_RAND_RESET_I(int obits) VL_MT_SAFE {
+static QData VL_RANDOM_RESET_Q_GUTS(std::array<uint64_t, 2>& state) {
+    state[1] ^= state[0];
+    state[0] = (((state[0] << 55) | (state[0] >> 9)) ^ state[1] ^ (state[1] << 14));
+    state[1] = (state[1] << 36) | (state[1] >> 28);
+    return state[0] + state[1];
+}
+static QData VL_RANDOM_RESET_Q(uint64_t salt) {
+    std::array<uint64_t, 2> state;
+    state[0] = Verilated::threadContextp()->randSeed() ^ salt;
+    state[1] = state[0];
+    return VL_RANDOM_RESET_Q_GUTS(state);
+}
+static IData VL_RANDOM_RESET_I(uint64_t salt) { return VL_RANDOM_RESET_Q(salt); }
+IData VL_RAND_RESET_I(int obits, uint64_t salt) VL_MT_SAFE {
     if (Verilated::threadContextp()->randReset() == 0) return 0;
     IData data = ~0;
     if (Verilated::threadContextp()->randReset() != 1) {  // if 2, randomize
-        data = VL_RANDOM_I();
+        data = VL_RANDOM_RESET_I(salt);
     }
     data &= VL_MASK_I(obits);
     return data;
 }
-IData VL_RAND_RESET_ASSIGN_I(int obits) VL_MT_SAFE { return VL_RANDOM_I() & VL_MASK_I(obits); }
+IData VL_RAND_RESET_ASSIGN_I(int obits, uint64_t salt) VL_MT_SAFE {
+    return VL_RANDOM_RESET_I(salt) & VL_MASK_I(obits);
+}
 
-QData VL_RAND_RESET_Q(int obits) VL_MT_SAFE {
+QData VL_RAND_RESET_Q(int obits, uint64_t salt) VL_MT_SAFE {
     if (Verilated::threadContextp()->randReset() == 0) return 0;
     QData data = ~0ULL;
     if (Verilated::threadContextp()->randReset() != 1) {  // if 2, randomize
-        data = VL_RANDOM_Q();
+        data = VL_RANDOM_RESET_Q(salt);
     }
     data &= VL_MASK_Q(obits);
     return data;
 }
 
-QData VL_RAND_RESET_ASSIGN_Q(int obits) VL_MT_SAFE { return VL_RANDOM_Q() & VL_MASK_Q(obits); }
+QData VL_RAND_RESET_ASSIGN_Q(int obits, uint64_t salt) VL_MT_SAFE {
+    return VL_RANDOM_RESET_Q(salt) & VL_MASK_Q(obits);
+}
 
-WDataOutP VL_RAND_RESET_W(int obits, WDataOutP outwp) VL_MT_SAFE {
-    for (int i = 0; i < VL_WORDS_I(obits) - 1; ++i) outwp[i] = VL_RAND_RESET_I(32);
-    outwp[VL_WORDS_I(obits) - 1] = VL_RAND_RESET_I(32) & VL_MASK_E(obits);
+WDataOutP VL_RAND_RESET_W(int obits, WDataOutP outwp, uint64_t salt) VL_MT_SAFE {
+    std::array<uint64_t, 2> state;
+    state[0] = Verilated::threadContextp()->randSeed() ^ salt;
+    state[1] = state[0];
+    for (int i = 0; i < VL_WORDS_I(obits) - 1; ++i) outwp[i] = VL_RANDOM_RESET_Q_GUTS(state);
+    outwp[VL_WORDS_I(obits) - 1] = VL_RANDOM_RESET_Q_GUTS(state) & VL_MASK_E(obits);
     return outwp;
 }
-WDataOutP VL_RAND_RESET_ASSIGN_W(int obits, WDataOutP outwp) VL_MT_SAFE {
-    for (int i = 0; i < VL_WORDS_I(obits) - 1; ++i) outwp[i] = VL_RAND_RESET_ASSIGN_I(32);
-    outwp[VL_WORDS_I(obits) - 1] = VL_RAND_RESET_ASSIGN_I(32) & VL_MASK_E(obits);
+WDataOutP VL_RAND_RESET_ASSIGN_W(int obits, WDataOutP outwp, uint64_t salt) VL_MT_SAFE {
+    std::array<uint64_t, 2> state;
+    state[0] = Verilated::threadContextp()->randSeed() ^ salt;
+    state[1] = state[0];
+    for (int i = 0; i < VL_WORDS_I(obits) - 1; ++i) outwp[i] = VL_RANDOM_RESET_Q_GUTS(state);
+    outwp[VL_WORDS_I(obits) - 1] = VL_RANDOM_RESET_Q_GUTS(state) & VL_MASK_E(obits);
     return outwp;
 }
 WDataOutP VL_ZERO_RESET_W(int obits, WDataOutP outwp) VL_MT_SAFE {
@@ -2159,9 +2182,11 @@ void VlReadMem::setData(void* valuep, const std::string& rhs) {
     // Shift value in
     for (const auto& i : rhs) {
         const char c = std::tolower(i);
-        const int value = (c == 'x' || c == 'z') ? VL_RAND_RESET_I(m_hex ? 4 : 1)
-                          : (c >= 'a')           ? (c - 'a' + 10)
-                                                 : (c - '0');
+        const int value
+            = (c == 'x' || c == 'z')
+                  ? VL_RAND_RESET_I(m_hex ? 4 : 1, 0x01234567890abcdefull)  //  NOCOMMIT
+              : (c >= 'a') ? (c - 'a' + 10)
+                           : (c - '0');
         if (m_bits <= 8) {
             CData* const datap = reinterpret_cast<CData*>(valuep);
             if (!innum) *datap = 0;

--- a/include/verilated.cpp
+++ b/include/verilated.cpp
@@ -408,7 +408,7 @@ IData VL_URANDOM_SEEDED_II(IData seed) VL_MT_SAFE {
     return VL_RANDOM_I();
 }
 
-IData VL_SCOPED_RAND_RESET_I(int obits, uint64_t scopeHash, uint64_t salt) VL_MT_SAFE {
+IData VL_SCOPED_RAND_RESET_I(int obits, uint64_t scopeHash, uint64_t salt) VL_MT_UNSAFE {
     if (Verilated::threadContextp()->randReset() == 0) return 0;
     IData data = ~0;
     if (Verilated::threadContextp()->randReset() != 1) {  // if 2, randomize
@@ -419,7 +419,7 @@ IData VL_SCOPED_RAND_RESET_I(int obits, uint64_t scopeHash, uint64_t salt) VL_MT
     return data;
 }
 
-QData VL_SCOPED_RAND_RESET_Q(int obits, uint64_t scopeHash, uint64_t salt) VL_MT_SAFE {
+QData VL_SCOPED_RAND_RESET_Q(int obits, uint64_t scopeHash, uint64_t salt) VL_MT_UNSAFE {
     if (Verilated::threadContextp()->randReset() == 0) return 0;
     QData data = ~0ULL;
     if (Verilated::threadContextp()->randReset() != 1) {  // if 2, randomize
@@ -431,7 +431,7 @@ QData VL_SCOPED_RAND_RESET_Q(int obits, uint64_t scopeHash, uint64_t salt) VL_MT
 }
 
 WDataOutP VL_SCOPED_RAND_RESET_W(int obits, WDataOutP outwp, uint64_t scopeHash,
-                                 uint64_t salt) VL_MT_SAFE {
+                                 uint64_t salt) VL_MT_UNSAFE {
     if (Verilated::threadContextp()->randReset() != 2) { return VL_RAND_RESET_W(obits, outwp); }
     VlRNG rng(Verilated::threadContextp()->randSeed() ^ scopeHash ^ salt);
     for (int i = 0; i < VL_WORDS_I(obits) - 1; ++i) outwp[i] = rng.rand64();

--- a/include/verilated.cpp
+++ b/include/verilated.cpp
@@ -45,7 +45,6 @@
 //     and DPI libraries are not needed there.
 //=========================================================================
 
-#include "verilated.h"
 #define VERILATOR_VERILATED_CPP_
 
 #include "verilated_config.h"

--- a/include/verilated.cpp
+++ b/include/verilated.cpp
@@ -421,7 +421,8 @@ static QData VL_RANDOM_RESET_Q(uint64_t scopeHash, uint64_t salt) {
     return VL_RANDOM_RESET_Q_GUTS(state);
 }
 static IData VL_RANDOM_RESET_I(uint64_t scopeHash, uint64_t salt) { return VL_RANDOM_RESET_Q(scopeHash, salt); }
-IData VL_RAND_RESET_I(int obits, uint64_t scopeHash, uint64_t salt) VL_MT_SAFE {
+
+IData VL_SCOPED_RAND_RESET_I(int obits, uint64_t scopeHash, uint64_t salt) VL_MT_SAFE {
     if (Verilated::threadContextp()->randReset() == 0) return 0;
     IData data = ~0;
     if (Verilated::threadContextp()->randReset() != 1) {  // if 2, randomize
@@ -430,11 +431,8 @@ IData VL_RAND_RESET_I(int obits, uint64_t scopeHash, uint64_t salt) VL_MT_SAFE {
     data &= VL_MASK_I(obits);
     return data;
 }
-IData VL_RAND_RESET_ASSIGN_I(int obits, uint64_t scopeHash, uint64_t salt) VL_MT_SAFE {
-    return VL_RANDOM_RESET_I(scopeHash, salt) & VL_MASK_I(obits);
-}
 
-QData VL_RAND_RESET_Q(int obits, uint64_t scopeHash, uint64_t salt) VL_MT_SAFE {
+QData VL_SCOPED_RAND_RESET_Q(int obits, uint64_t scopeHash, uint64_t salt) VL_MT_SAFE {
     if (Verilated::threadContextp()->randReset() == 0) return 0;
     QData data = ~0ULL;
     if (Verilated::threadContextp()->randReset() != 1) {  // if 2, randomize
@@ -444,11 +442,7 @@ QData VL_RAND_RESET_Q(int obits, uint64_t scopeHash, uint64_t salt) VL_MT_SAFE {
     return data;
 }
 
-QData VL_RAND_RESET_ASSIGN_Q(int obits, uint64_t scopeHash, uint64_t salt) VL_MT_SAFE {
-    return VL_RANDOM_RESET_Q(scopeHash, salt) & VL_MASK_Q(obits);
-}
-
-WDataOutP VL_RAND_RESET_W(int obits, WDataOutP outwp, uint64_t scopeHash, uint64_t salt) VL_MT_SAFE {
+WDataOutP VL_SCOPED_RAND_RESET_W(int obits, WDataOutP outwp, uint64_t scopeHash, uint64_t salt) VL_MT_SAFE {
     std::array<uint64_t, 2> state;
     state[0] = Verilated::threadContextp()->randSeed() ^ scopeHash ^ salt;
     state[1] = state[0];
@@ -456,12 +450,38 @@ WDataOutP VL_RAND_RESET_W(int obits, WDataOutP outwp, uint64_t scopeHash, uint64
     outwp[VL_WORDS_I(obits) - 1] = VL_RANDOM_RESET_Q_GUTS(state) & VL_MASK_E(obits);
     return outwp;
 }
-WDataOutP VL_RAND_RESET_ASSIGN_W(int obits, WDataOutP outwp, uint64_t scopeHash, uint64_t salt) VL_MT_SAFE {
-    std::array<uint64_t, 2> state;
-    state[0] = Verilated::threadContextp()->randSeed() ^ scopeHash ^ salt;
-    state[1] = state[0];
-    for (int i = 0; i < VL_WORDS_I(obits) - 1; ++i) outwp[i] = VL_RANDOM_RESET_Q_GUTS(state);
-    outwp[VL_WORDS_I(obits) - 1] = VL_RANDOM_RESET_Q_GUTS(state) & VL_MASK_E(obits);
+
+IData VL_RAND_RESET_I(int obits) VL_MT_SAFE {
+    if (Verilated::threadContextp()->randReset() == 0) return 0;
+    IData data = ~0;
+    if (Verilated::threadContextp()->randReset() != 1) {  // if 2, randomize
+        data = VL_RANDOM_I();
+    }
+    data &= VL_MASK_I(obits);
+    return data;
+}
+IData VL_RAND_RESET_ASSIGN_I(int obits) VL_MT_SAFE { return VL_RANDOM_I() & VL_MASK_I(obits); }
+
+QData VL_RAND_RESET_Q(int obits) VL_MT_SAFE {
+    if (Verilated::threadContextp()->randReset() == 0) return 0;
+    QData data = ~0ULL;
+    if (Verilated::threadContextp()->randReset() != 1) {  // if 2, randomize
+        data = VL_RANDOM_Q();
+    }
+    data &= VL_MASK_Q(obits);
+    return data;
+}
+
+QData VL_RAND_RESET_ASSIGN_Q(int obits) VL_MT_SAFE { return VL_RANDOM_Q() & VL_MASK_Q(obits); }
+
+WDataOutP VL_RAND_RESET_W(int obits, WDataOutP outwp) VL_MT_SAFE {
+    for (int i = 0; i < VL_WORDS_I(obits) - 1; ++i) outwp[i] = VL_RAND_RESET_I(32);
+    outwp[VL_WORDS_I(obits) - 1] = VL_RAND_RESET_I(32) & VL_MASK_E(obits);
+    return outwp;
+}
+WDataOutP VL_RAND_RESET_ASSIGN_W(int obits, WDataOutP outwp) VL_MT_SAFE {
+    for (int i = 0; i < VL_WORDS_I(obits) - 1; ++i) outwp[i] = VL_RAND_RESET_ASSIGN_I(32);
+    outwp[VL_WORDS_I(obits) - 1] = VL_RAND_RESET_ASSIGN_I(32) & VL_MASK_E(obits);
     return outwp;
 }
 WDataOutP VL_ZERO_RESET_W(int obits, WDataOutP outwp) VL_MT_SAFE {
@@ -2184,12 +2204,9 @@ void VlReadMem::setData(void* valuep, const std::string& rhs) {
     // Shift value in
     for (const auto& i : rhs) {
         const char c = std::tolower(i);
-        const int value
-            = (c == 'x' || c == 'z')
-                                        // NOCOMMIT -- scope
-                  ? VL_RAND_RESET_I(m_hex ? 4 : 1, 0x123, 0x01234567890abcdefull)  //  NOCOMMIT
-              : (c >= 'a') ? (c - 'a' + 10)
-                           : (c - '0');
+        const int value = (c == 'x' || c == 'z') ? VL_RAND_RESET_I(m_hex ? 4 : 1)
+                          : (c >= 'a')           ? (c - 'a' + 10)
+                                                 : (c - '0');
         if (m_bits <= 8) {
             CData* const datap = reinterpret_cast<CData*>(valuep);
             if (!innum) *datap = 0;

--- a/include/verilated.cpp
+++ b/include/verilated.cpp
@@ -420,7 +420,9 @@ static QData VL_RANDOM_RESET_Q(uint64_t scopeHash, uint64_t salt) {
     state[1] = state[0];
     return VL_RANDOM_RESET_Q_GUTS(state);
 }
-static IData VL_RANDOM_RESET_I(uint64_t scopeHash, uint64_t salt) { return VL_RANDOM_RESET_Q(scopeHash, salt); }
+static IData VL_RANDOM_RESET_I(uint64_t scopeHash, uint64_t salt) {
+    return VL_RANDOM_RESET_Q(scopeHash, salt);
+}
 
 IData VL_SCOPED_RAND_RESET_I(int obits, uint64_t scopeHash, uint64_t salt) VL_MT_SAFE {
     if (Verilated::threadContextp()->randReset() == 0) return 0;
@@ -442,7 +444,8 @@ QData VL_SCOPED_RAND_RESET_Q(int obits, uint64_t scopeHash, uint64_t salt) VL_MT
     return data;
 }
 
-WDataOutP VL_SCOPED_RAND_RESET_W(int obits, WDataOutP outwp, uint64_t scopeHash, uint64_t salt) VL_MT_SAFE {
+WDataOutP VL_SCOPED_RAND_RESET_W(int obits, WDataOutP outwp, uint64_t scopeHash,
+                                 uint64_t salt) VL_MT_SAFE {
     std::array<uint64_t, 2> state;
     state[0] = Verilated::threadContextp()->randSeed() ^ scopeHash ^ salt;
     state[1] = state[0];

--- a/include/verilated.cpp
+++ b/include/verilated.cpp
@@ -1759,13 +1759,13 @@ uint64_t VL_HASH(const char* key) VL_PURE {
     const unsigned char* data2 = (const unsigned char*)data;
 
     switch (len & 7) {
-    case 7: h ^= uint64_t(data2[6]) << 48;
-    case 6: h ^= uint64_t(data2[5]) << 40;
-    case 5: h ^= uint64_t(data2[4]) << 32;
-    case 4: h ^= uint64_t(data2[3]) << 24;
-    case 3: h ^= uint64_t(data2[2]) << 16;
-    case 2: h ^= uint64_t(data2[1]) << 8;
-    case 1: h ^= uint64_t(data2[0]); h *= m;
+    case 7: h ^= uint64_t(data2[6]) << 48; /* fallthrough */
+    case 6: h ^= uint64_t(data2[5]) << 40; /* fallthrough */
+    case 5: h ^= uint64_t(data2[4]) << 32; /* fallthrough */
+    case 4: h ^= uint64_t(data2[3]) << 24; /* fallthrough */
+    case 3: h ^= uint64_t(data2[2]) << 16; /* fallthrough */
+    case 2: h ^= uint64_t(data2[1]) << 8; /* fallthrough */
+    case 1: h ^= uint64_t(data2[0]); h *= m; /* fallthrough */
     };
 
     h ^= h >> r;

--- a/include/verilated_funcs.h
+++ b/include/verilated_funcs.h
@@ -102,12 +102,12 @@ inline IData VL_URANDOM_RANGE_I(IData hi, IData lo) {
 }
 
 /// Random reset a signal of given width (init time only, var-specific PRNG)
-extern IData VL_SCOPED_RAND_RESET_I(int obits, uint64_t scopeHash, uint64_t salt) VL_MT_SAFE;
+extern IData VL_SCOPED_RAND_RESET_I(int obits, uint64_t scopeHash, uint64_t salt) VL_MT_UNSAFE;
 /// Random reset a signal of given width (init time only, var-specific PRNG)
-extern QData VL_SCOPED_RAND_RESET_Q(int obits, uint64_t scopeHash, uint64_t salt) VL_MT_SAFE;
+extern QData VL_SCOPED_RAND_RESET_Q(int obits, uint64_t scopeHash, uint64_t salt) VL_MT_UNSAFE;
 /// Random reset a signal of given width (init time only, var-specific PRNG)
 extern WDataOutP VL_SCOPED_RAND_RESET_W(int obits, WDataOutP outwp, uint64_t scopeHash,
-                                        uint64_t salt) VL_MT_SAFE;
+                                        uint64_t salt) VL_MT_UNSAFE;
 
 /// Random reset a signal of given width (init time only)
 extern IData VL_RAND_RESET_I(int obits) VL_MT_SAFE;

--- a/include/verilated_funcs.h
+++ b/include/verilated_funcs.h
@@ -25,6 +25,7 @@
 #define VERILATOR_VERILATED_FUNCS_H_
 
 #include "verilated.h"
+
 #include <cstdint>
 #ifndef VERILATOR_VERILATED_H_INTERNAL_
 #error "verilated_funcs.h should only be included by verilated.h"
@@ -108,7 +109,8 @@ extern IData VL_SCOPED_RAND_RESET_I(int obits, uint64_t scopeHash, uint64_t salt
 /// Random reset a signal of given width (init time only, var-specific PRNG)
 extern QData VL_SCOPED_RAND_RESET_Q(int obits, uint64_t scopeHash, uint64_t salt) VL_MT_SAFE;
 /// Random reset a signal of given width (init time only, var-specific PRNG)
-extern WDataOutP VL_SCOPED_RAND_RESET_W(int obits, WDataOutP outwp, uint64_t scopeHash, uint64_t salt) VL_MT_SAFE;
+extern WDataOutP VL_SCOPED_RAND_RESET_W(int obits, WDataOutP outwp, uint64_t scopeHash,
+                                        uint64_t salt) VL_MT_SAFE;
 
 /// Random reset a signal of given width (init time only)
 extern IData VL_RAND_RESET_I(int obits) VL_MT_SAFE;

--- a/include/verilated_funcs.h
+++ b/include/verilated_funcs.h
@@ -24,6 +24,7 @@
 #ifndef VERILATOR_VERILATED_FUNCS_H_
 #define VERILATOR_VERILATED_FUNCS_H_
 
+#include "verilated.h"
 #include <cstdint>
 #ifndef VERILATOR_VERILATED_H_INTERNAL_
 #error "verilated_funcs.h should only be included by verilated.h"
@@ -102,19 +103,26 @@ inline IData VL_URANDOM_RANGE_I(IData hi, IData lo) {
     }
 }
 
+/// Random reset a signal of given width (init time only, var-specific PRNG)
+extern IData VL_SCOPED_RAND_RESET_I(int obits, uint64_t scopeHash, uint64_t salt) VL_MT_SAFE;
+/// Random reset a signal of given width (init time only, var-specific PRNG)
+extern QData VL_SCOPED_RAND_RESET_Q(int obits, uint64_t scopeHash, uint64_t salt) VL_MT_SAFE;
+/// Random reset a signal of given width (init time only, var-specific PRNG)
+extern WDataOutP VL_SCOPED_RAND_RESET_W(int obits, WDataOutP outwp, uint64_t scopeHash, uint64_t salt) VL_MT_SAFE;
+
 /// Random reset a signal of given width (init time only)
-extern IData VL_RAND_RESET_I(int obits, uint64_t scopeHash, uint64_t salt) VL_MT_SAFE;
+extern IData VL_RAND_RESET_I(int obits) VL_MT_SAFE;
 /// Random reset a signal of given width (init time only)
-extern QData VL_RAND_RESET_Q(int obits, uint64_t scopeHash, uint64_t salt) VL_MT_SAFE;
+extern QData VL_RAND_RESET_Q(int obits) VL_MT_SAFE;
 /// Random reset a signal of given width (init time only)
-extern WDataOutP VL_RAND_RESET_W(int obits, WDataOutP outwp, uint64_t scopeHash, uint64_t salt) VL_MT_SAFE;
+extern WDataOutP VL_RAND_RESET_W(int obits, WDataOutP outwp) VL_MT_SAFE;
 
 /// Random reset a signal of given width (assign time only)
-extern IData VL_RAND_RESET_ASSIGN_I(int obits, uint64_t scopeHash, uint64_t salt) VL_MT_SAFE;
+extern IData VL_RAND_RESET_ASSIGN_I(int obits) VL_MT_SAFE;
 /// Random reset a signal of given width (assign time only)
-extern QData VL_RAND_RESET_ASSIGN_Q(int obits, uint64_t scopeHash, uint64_t salt) VL_MT_SAFE;
+extern QData VL_RAND_RESET_ASSIGN_Q(int obits) VL_MT_SAFE;
 /// Random reset a signal of given width (assign time only)
-extern WDataOutP VL_RAND_RESET_ASSIGN_W(int obits, WDataOutP outwp, uint64_t scopeHash, uint64_t salt) VL_MT_SAFE;
+extern WDataOutP VL_RAND_RESET_ASSIGN_W(int obits, WDataOutP outwp) VL_MT_SAFE;
 
 /// Zero reset a signal (slow - else use VL_ZERO_W)
 extern WDataOutP VL_ZERO_RESET_W(int obits, WDataOutP outwp) VL_MT_SAFE;

--- a/include/verilated_funcs.h
+++ b/include/verilated_funcs.h
@@ -24,9 +24,6 @@
 #ifndef VERILATOR_VERILATED_FUNCS_H_
 #define VERILATOR_VERILATED_FUNCS_H_
 
-#include "verilated.h"
-
-#include <cstdint>
 #ifndef VERILATOR_VERILATED_H_INTERNAL_
 #error "verilated_funcs.h should only be included by verilated.h"
 #endif
@@ -2817,6 +2814,8 @@ inline IData VL_VALUEPLUSARGS_INQ(int rbits, const std::string& ld, double& rdr)
     return got;
 }
 extern IData VL_VALUEPLUSARGS_INN(int, const std::string& ld, std::string& rdr) VL_MT_SAFE;
+
+uint64_t VL_HASH(const char* key) VL_PURE;
 
 //======================================================================
 

--- a/include/verilated_funcs.h
+++ b/include/verilated_funcs.h
@@ -103,18 +103,18 @@ inline IData VL_URANDOM_RANGE_I(IData hi, IData lo) {
 }
 
 /// Random reset a signal of given width (init time only)
-extern IData VL_RAND_RESET_I(int obits, uint64_t salt) VL_MT_SAFE;
+extern IData VL_RAND_RESET_I(int obits, uint64_t scopeHash, uint64_t salt) VL_MT_SAFE;
 /// Random reset a signal of given width (init time only)
-extern QData VL_RAND_RESET_Q(int obits, uint64_t salt) VL_MT_SAFE;
+extern QData VL_RAND_RESET_Q(int obits, uint64_t scopeHash, uint64_t salt) VL_MT_SAFE;
 /// Random reset a signal of given width (init time only)
-extern WDataOutP VL_RAND_RESET_W(int obits, WDataOutP outwp, uint64_t salt) VL_MT_SAFE;
+extern WDataOutP VL_RAND_RESET_W(int obits, WDataOutP outwp, uint64_t scopeHash, uint64_t salt) VL_MT_SAFE;
 
 /// Random reset a signal of given width (assign time only)
-extern IData VL_RAND_RESET_ASSIGN_I(int obits, uint64_t salt) VL_MT_SAFE;
+extern IData VL_RAND_RESET_ASSIGN_I(int obits, uint64_t scopeHash, uint64_t salt) VL_MT_SAFE;
 /// Random reset a signal of given width (assign time only)
-extern QData VL_RAND_RESET_ASSIGN_Q(int obits, uint64_t salt) VL_MT_SAFE;
+extern QData VL_RAND_RESET_ASSIGN_Q(int obits, uint64_t scopeHash, uint64_t salt) VL_MT_SAFE;
 /// Random reset a signal of given width (assign time only)
-extern WDataOutP VL_RAND_RESET_ASSIGN_W(int obits, WDataOutP outwp, uint64_t salt) VL_MT_SAFE;
+extern WDataOutP VL_RAND_RESET_ASSIGN_W(int obits, WDataOutP outwp, uint64_t scopeHash, uint64_t salt) VL_MT_SAFE;
 
 /// Zero reset a signal (slow - else use VL_ZERO_W)
 extern WDataOutP VL_ZERO_RESET_W(int obits, WDataOutP outwp) VL_MT_SAFE;

--- a/include/verilated_funcs.h
+++ b/include/verilated_funcs.h
@@ -24,6 +24,7 @@
 #ifndef VERILATOR_VERILATED_FUNCS_H_
 #define VERILATOR_VERILATED_FUNCS_H_
 
+#include <cstdint>
 #ifndef VERILATOR_VERILATED_H_INTERNAL_
 #error "verilated_funcs.h should only be included by verilated.h"
 #endif
@@ -102,18 +103,18 @@ inline IData VL_URANDOM_RANGE_I(IData hi, IData lo) {
 }
 
 /// Random reset a signal of given width (init time only)
-extern IData VL_RAND_RESET_I(int obits) VL_MT_SAFE;
+extern IData VL_RAND_RESET_I(int obits, uint64_t salt) VL_MT_SAFE;
 /// Random reset a signal of given width (init time only)
-extern QData VL_RAND_RESET_Q(int obits) VL_MT_SAFE;
+extern QData VL_RAND_RESET_Q(int obits, uint64_t salt) VL_MT_SAFE;
 /// Random reset a signal of given width (init time only)
-extern WDataOutP VL_RAND_RESET_W(int obits, WDataOutP outwp) VL_MT_SAFE;
+extern WDataOutP VL_RAND_RESET_W(int obits, WDataOutP outwp, uint64_t salt) VL_MT_SAFE;
 
 /// Random reset a signal of given width (assign time only)
-extern IData VL_RAND_RESET_ASSIGN_I(int obits) VL_MT_SAFE;
+extern IData VL_RAND_RESET_ASSIGN_I(int obits, uint64_t salt) VL_MT_SAFE;
 /// Random reset a signal of given width (assign time only)
-extern QData VL_RAND_RESET_ASSIGN_Q(int obits) VL_MT_SAFE;
+extern QData VL_RAND_RESET_ASSIGN_Q(int obits, uint64_t salt) VL_MT_SAFE;
 /// Random reset a signal of given width (assign time only)
-extern WDataOutP VL_RAND_RESET_ASSIGN_W(int obits, WDataOutP outwp) VL_MT_SAFE;
+extern WDataOutP VL_RAND_RESET_ASSIGN_W(int obits, WDataOutP outwp, uint64_t salt) VL_MT_SAFE;
 
 /// Zero reset a signal (slow - else use VL_ZERO_W)
 extern WDataOutP VL_ZERO_RESET_W(int obits, WDataOutP outwp) VL_MT_SAFE;

--- a/src/V3AstNodeExpr.h
+++ b/src/V3AstNodeExpr.h
@@ -1835,8 +1835,7 @@ public:
     int instrCount() const override { return INSTR_COUNT_PLI; }
     bool sameNode(const AstNode* /*samep*/) const override { return true; }
     bool combinable(const AstRand* samep) const {
-        return !seedp() && !samep->seedp()
-               && urandom() == samep->urandom();
+        return !seedp() && !samep->seedp() && urandom() == samep->urandom();
     }
     bool urandom() const { return m_urandom; }
 };

--- a/src/V3AstNodeExpr.h
+++ b/src/V3AstNodeExpr.h
@@ -1822,11 +1822,13 @@ public:
     }
     string emitC() override {
         if (m_reset) {
+            // NOCOMMIT
+            string salt = std::to_string(0x0123456789abcdefull);
             if (v3Global.opt.xAssign() == "unique") {
-                return "VL_RAND_RESET_ASSIGN_%nq(%nw, %P)";
+                return "VL_RAND_RESET_ASSIGN_%nq(%nw, %P, " + salt + ")";
             } else {
                 // This follows xInitial randomization
-                return "VL_RAND_RESET_%nq(%nw, %P)";
+                return "VL_RAND_RESET_%nq(%nw, %P, " + salt + ")";
             }
         }
         if (seedp()) {

--- a/src/V3AstNodeExpr.h
+++ b/src/V3AstNodeExpr.h
@@ -1825,10 +1825,12 @@ public:
             // NOCOMMIT
             string salt = std::to_string(0x0123456789abcdefull);
             if (v3Global.opt.xAssign() == "unique") {
-                return "VL_RAND_RESET_ASSIGN_%nq(%nw, %P, " + salt + ")";
+                // NOCOMMIT -- scope
+                return "VL_RAND_RESET_ASSIGN_%nq(%nw, %P, 0x123, " + salt + ")";
             } else {
                 // This follows xInitial randomization
-                return "VL_RAND_RESET_%nq(%nw, %P, " + salt + ")";
+                // NOCOMMIT -- scope
+                return "VL_RAND_RESET_%nq(%nw, %P, 0x123, " + salt + ")";
             }
         }
         if (seedp()) {

--- a/src/V3AstNodeExpr.h
+++ b/src/V3AstNodeExpr.h
@@ -1805,6 +1805,7 @@ class AstRand final : public AstNodeExpr {
     const bool m_reset = false;  // Random reset, versus always random
 public:
     class Reset {};
+    // NOCOMMIT -- needed or reset always false?
     AstRand(FileLine* fl, Reset, AstNodeDType* dtp, bool reset)
         : ASTGEN_SUPER_Rand(fl)
         , m_reset{reset} {

--- a/src/V3AstNodeExpr.h
+++ b/src/V3AstNodeExpr.h
@@ -1802,15 +1802,8 @@ class AstRand final : public AstNodeExpr {
     // Return a random number, based upon width()
     // @astgen op1 := seedp : Optional[AstNode]
     const bool m_urandom = false;  // $urandom vs $random
-    const bool m_reset = false;  // Random reset, versus always random
 public:
     class Reset {};
-    // NOCOMMIT -- needed or reset always false?
-    AstRand(FileLine* fl, Reset, AstNodeDType* dtp, bool reset)
-        : ASTGEN_SUPER_Rand(fl)
-        , m_reset{reset} {
-        dtypep(dtp);
-    }
     AstRand(FileLine* fl, AstNode* seedp, bool urandom)
         : ASTGEN_SUPER_Rand(fl)
         , m_urandom{urandom} {
@@ -1822,14 +1815,6 @@ public:
                        : (m_urandom ? "%f$urandom()" : "%f$random()");
     }
     string emitC() override {
-        if (m_reset) {
-            if (v3Global.opt.xAssign() == "unique") {
-                return "VL_RAND_RESET_ASSIGN_%nq(%nw, %P)";
-            } else {
-                // This follows xInitial randomization
-                return "VL_RAND_RESET_%nq(%nw, %P)";
-            }
-        }
         if (seedp()) {
             if (urandom()) {
                 return "VL_URANDOM_SEEDED_%nq%lq(%li)";
@@ -1846,14 +1831,13 @@ public:
     bool cleanOut() const override { return false; }
     bool isGateOptimizable() const override { return false; }
     bool isPredictOptimizable() const override { return false; }
-    bool isPure() override { return !m_reset && !seedp(); }
+    bool isPure() override { return !seedp(); }
     int instrCount() const override { return INSTR_COUNT_PLI; }
     bool sameNode(const AstNode* /*samep*/) const override { return true; }
     bool combinable(const AstRand* samep) const {
-        return !seedp() && !samep->seedp() && reset() == samep->reset()
+        return !seedp() && !samep->seedp()
                && urandom() == samep->urandom();
     }
-    bool reset() const { return m_reset; }
     bool urandom() const { return m_urandom; }
 };
 class AstRandRNG final : public AstNodeExpr {

--- a/src/V3AstNodeExpr.h
+++ b/src/V3AstNodeExpr.h
@@ -1822,15 +1822,11 @@ public:
     }
     string emitC() override {
         if (m_reset) {
-            // NOCOMMIT
-            string salt = std::to_string(0x0123456789abcdefull);
             if (v3Global.opt.xAssign() == "unique") {
-                // NOCOMMIT -- scope
-                return "VL_RAND_RESET_ASSIGN_%nq(%nw, %P, 0x123, " + salt + ")";
+                return "VL_RAND_RESET_ASSIGN_%nq(%nw, %P)";
             } else {
                 // This follows xInitial randomization
-                // NOCOMMIT -- scope
-                return "VL_RAND_RESET_%nq(%nw, %P, 0x123, " + salt + ")";
+                return "VL_RAND_RESET_%nq(%nw, %P)";
             }
         }
         if (seedp()) {

--- a/src/V3EmitCFunc.cpp
+++ b/src/V3EmitCFunc.cpp
@@ -24,9 +24,6 @@
 #include <string>
 #include <vector>
 
-// NOCOMMIT
-VL_DEFINE_DEBUG_FUNCTIONS;
-
 // We use a static char array in VL_VALUE_STRING
 constexpr int VL_VALUE_STRING_MAX_WIDTH = 8192;
 
@@ -674,8 +671,6 @@ void EmitCFunc::emitVarReset(AstVar* varp, bool constructing) {
 string EmitCFunc::emitVarResetRecurse(const AstVar* varp, bool constructing,
                                       const string& varNameProtected, AstNodeDType* dtypep,
                                       int depth, const string& suffix) {
-    UINFO(1, "Var Reset -- " << varp->prettyName() << " -- " << varp->name() << " - "
-                             << varp->origName() << " -- " << varp << endl);
     dtypep = dtypep->skipRefp();
     AstBasicDType* const basicp = dtypep->basicp();
     // Returns string to do resetting, empty to do nothing (which caller should handle)
@@ -778,7 +773,6 @@ string EmitCFunc::emitVarResetRecurse(const AstVar* varp, bool constructing,
                 if (!zeroit) {
                     emitVarResetScopeHash();
                     uint64_t salt = std::hash<std::string>{}(varp->prettyName());
-                    UINFO(1, "Var Hash -- " << varp->prettyName() << " -- " << salt << endl);
                     out += ", ";
                     out += "__VscopeHash, ";
                     out += std::to_string(salt);
@@ -799,10 +793,8 @@ string EmitCFunc::emitVarResetRecurse(const AstVar* varp, bool constructing,
             } else {
                 emitVarResetScopeHash();
                 uint64_t salt = std::hash<std::string>{}(varp->prettyName());
-                UINFO(1, "Var Hash -- " << varp->prettyName() << " -- " << salt << endl);
                 out += " = VL_SCOPED_RAND_RESET_";
                 out += dtypep->charIQWN();
-                // NOCOMMIT -- 64b
                 out += "(" + cvtToStr(dtypep->widthMin()) + ", " + "__VscopeHash, "
                        + std::to_string(salt) + "ull);\n";
             }
@@ -816,7 +808,6 @@ string EmitCFunc::emitVarResetRecurse(const AstVar* varp, bool constructing,
 
 void EmitCFunc::emitVarResetScopeHash() {
     if (m_createdScopeHash) { return; }
-    // NOCOMMIT -- name?
     if (m_class) {
         puts("uint64_t __VscopeHash = " + std::to_string(std::hash<std::string>{}(m_class->name()))
              + "ULL;\n");

--- a/src/V3EmitCFunc.cpp
+++ b/src/V3EmitCFunc.cpp
@@ -21,6 +21,7 @@
 #include "V3TSP.h"
 
 #include <map>
+#include <string>
 #include <vector>
 
 // NOCOMMIT
@@ -816,6 +817,11 @@ string EmitCFunc::emitVarResetRecurse(const AstVar* varp, bool constructing,
 void EmitCFunc::emitVarResetScopeHash() {
     if (m_createdScopeHash) { return; }
     // NOCOMMIT -- name?
-    puts("uint64_t __VscopeHash = std::hash<std::string>{}(vlSelf->name());\n");
+    if (m_class) {
+        puts("uint64_t __VscopeHash = " + std::to_string(std::hash<std::string>{}(m_class->name()))
+             + "ULL;\n");
+    } else {
+        puts("uint64_t __VscopeHash = std::hash<std::string>{}(vlSelf->name());\n");
+    }
     m_createdScopeHash = true;
 }

--- a/src/V3EmitCFunc.cpp
+++ b/src/V3EmitCFunc.cpp
@@ -815,7 +815,8 @@ void EmitCFunc::emitVarResetScopeHash() {
     if (m_class) {
         m_classHash = std::to_string(std::hash<std::string>{}(m_class->name())) + "ULL";
     } else {
-        puts("uint64_t __VscopeHash = std::hash<std::string>{}(vlSelf->name());\n");
+        puts(string("uint64_t __VscopeHash = std::hash<std::string>{}(")
+             + (m_useSelfForThis ? "vlSelf" : "this") + "->name());\n");
     }
     m_createdScopeHash = true;
 }

--- a/src/V3EmitCFunc.cpp
+++ b/src/V3EmitCFunc.cpp
@@ -770,7 +770,7 @@ string EmitCFunc::emitVarResetRecurse(const AstVar* varp, bool constructing,
                     out += cvtToStr(constp->num().edataWord(w)) + "U;\n";
                 }
             } else {
-                out += zeroit ? (slow ? "VL_ZERO_RESET_W(" : "VL_ZERO_W(") : "VL_RAND_RESET_W(";
+                out += zeroit ? (slow ? "VL_ZERO_RESET_W(" : "VL_ZERO_W(") : "VL_SCOPED_RAND_RESET_W(";
                 out += cvtToStr(dtypep->widthMin());
                 out += ", " + varNameProtected + suffix;
                 if (!zeroit) {
@@ -799,7 +799,7 @@ string EmitCFunc::emitVarResetRecurse(const AstVar* varp, bool constructing,
                 emitVarResetScopeHash();
                 uint64_t salt = std::hash<std::string>{}(varp->prettyName());
                 UINFO(1, "Var Hash -- " << varp->prettyName() << " -- " << salt << endl);
-                out += " = VL_RAND_RESET_";
+                out += " = VL_SCOPED_RAND_RESET_";
                 out += dtypep->charIQWN();
                 // NOCOMMIT -- 64b
                 out += "(" + cvtToStr(dtypep->widthMin()) + ", "

--- a/src/V3EmitCFunc.cpp
+++ b/src/V3EmitCFunc.cpp
@@ -673,8 +673,8 @@ void EmitCFunc::emitVarReset(AstVar* varp, bool constructing) {
 string EmitCFunc::emitVarResetRecurse(const AstVar* varp, bool constructing,
                                       const string& varNameProtected, AstNodeDType* dtypep,
                                       int depth, const string& suffix) {
-    UINFO(1, "Var Reset -- " << varp->prettyName() << " -- " << varp->name() << " - " << varp->origName() << " -- " << varp
-                             << endl);
+    UINFO(1, "Var Reset -- " << varp->prettyName() << " -- " << varp->name() << " - "
+                             << varp->origName() << " -- " << varp << endl);
     dtypep = dtypep->skipRefp();
     AstBasicDType* const basicp = dtypep->basicp();
     // Returns string to do resetting, empty to do nothing (which caller should handle)
@@ -770,14 +770,14 @@ string EmitCFunc::emitVarResetRecurse(const AstVar* varp, bool constructing,
                     out += cvtToStr(constp->num().edataWord(w)) + "U;\n";
                 }
             } else {
-                out += zeroit ? (slow ? "VL_ZERO_RESET_W(" : "VL_ZERO_W(") : "VL_SCOPED_RAND_RESET_W(";
+                out += zeroit ? (slow ? "VL_ZERO_RESET_W(" : "VL_ZERO_W(")
+                              : "VL_SCOPED_RAND_RESET_W(";
                 out += cvtToStr(dtypep->widthMin());
                 out += ", " + varNameProtected + suffix;
                 if (!zeroit) {
                     emitVarResetScopeHash();
                     uint64_t salt = std::hash<std::string>{}(varp->prettyName());
-                    UINFO(1,
-                          "Var Hash -- " << varp->prettyName() << " -- " << salt << endl);
+                    UINFO(1, "Var Hash -- " << varp->prettyName() << " -- " << salt << endl);
                     out += ", ";
                     out += "__VscopeHash, ";
                     out += std::to_string(salt);
@@ -802,10 +802,8 @@ string EmitCFunc::emitVarResetRecurse(const AstVar* varp, bool constructing,
                 out += " = VL_SCOPED_RAND_RESET_";
                 out += dtypep->charIQWN();
                 // NOCOMMIT -- 64b
-                out += "(" + cvtToStr(dtypep->widthMin()) + ", "
-                       + "__VscopeHash, "
-                       + std::to_string(salt)
-                       + "ull);\n";
+                out += "(" + cvtToStr(dtypep->widthMin()) + ", " + "__VscopeHash, "
+                       + std::to_string(salt) + "ull);\n";
             }
             return out;
         }

--- a/src/V3EmitCFunc.cpp
+++ b/src/V3EmitCFunc.cpp
@@ -21,7 +21,6 @@
 #include "V3TSP.h"
 
 #include <map>
-#include <string>
 #include <vector>
 
 // We use a static char array in VL_VALUE_STRING
@@ -774,7 +773,7 @@ string EmitCFunc::emitVarResetRecurse(const AstVar* varp, bool constructing,
                 out += ", " + varNameProtected + suffix;
                 if (!zeroit) {
                     emitVarResetScopeHash();
-                    const uint64_t salt = VString::hash(varp->prettyName());
+                    const uint64_t salt = VString::hashMurmur(varp->prettyName());
                     out += ", ";
                     out += m_classOrPackage ? m_classOrPackageHash : "__VscopeHash";
                     out += ", ";
@@ -795,7 +794,7 @@ string EmitCFunc::emitVarResetRecurse(const AstVar* varp, bool constructing,
                 out += " = 0;\n";
             } else {
                 emitVarResetScopeHash();
-                const uint64_t salt = VString::hash(varp->prettyName());
+                const uint64_t salt = VString::hashMurmur(varp->prettyName());
                 out += " = VL_SCOPED_RAND_RESET_";
                 out += dtypep->charIQWN();
                 out += "(" + cvtToStr(dtypep->widthMin()) + ", "
@@ -813,7 +812,8 @@ string EmitCFunc::emitVarResetRecurse(const AstVar* varp, bool constructing,
 void EmitCFunc::emitVarResetScopeHash() {
     if (VL_LIKELY(m_createdScopeHash)) { return; }
     if (m_classOrPackage) {
-        m_classOrPackageHash = std::to_string(VString::hash(m_classOrPackage->name())) + "ULL";
+        m_classOrPackageHash
+            = std::to_string(VString::hashMurmur(m_classOrPackage->name())) + "ULL";
     } else {
         puts(string("const uint64_t __VscopeHash = VL_HASH(")
              + (m_useSelfForThis ? "vlSelf" : "this") + "->name());\n");

--- a/src/V3EmitCFunc.cpp
+++ b/src/V3EmitCFunc.cpp
@@ -774,9 +774,9 @@ string EmitCFunc::emitVarResetRecurse(const AstVar* varp, bool constructing,
                 out += ", " + varNameProtected + suffix;
                 if (!zeroit) {
                     emitVarResetScopeHash();
-                    uint64_t salt = std::hash<std::string>{}(varp->prettyName());
+                    const uint64_t salt = VString::hash(varp->prettyName());
                     out += ", ";
-                    out += m_class ? m_classHash : "__VscopeHash";
+                    out += m_classOrPackage ? m_classOrPackageHash : "__VscopeHash";
                     out += ", ";
                     out += std::to_string(salt);
                     out += "ull";
@@ -795,12 +795,12 @@ string EmitCFunc::emitVarResetRecurse(const AstVar* varp, bool constructing,
                 out += " = 0;\n";
             } else {
                 emitVarResetScopeHash();
-                uint64_t salt = std::hash<std::string>{}(varp->prettyName());
+                const uint64_t salt = VString::hash(varp->prettyName());
                 out += " = VL_SCOPED_RAND_RESET_";
                 out += dtypep->charIQWN();
                 out += "(" + cvtToStr(dtypep->widthMin()) + ", "
-                       + (m_class ? m_classHash : "__VscopeHash") + ", " + std::to_string(salt)
-                       + "ull);\n";
+                       + (m_classOrPackage ? m_classOrPackageHash : "__VscopeHash") + ", "
+                       + std::to_string(salt) + "ull);\n";
             }
             return out;
         }
@@ -811,11 +811,11 @@ string EmitCFunc::emitVarResetRecurse(const AstVar* varp, bool constructing,
 }
 
 void EmitCFunc::emitVarResetScopeHash() {
-    if (m_createdScopeHash) { return; }
-    if (m_class) {
-        m_classHash = std::to_string(std::hash<std::string>{}(m_class->name())) + "ULL";
+    if (VL_LIKELY(m_createdScopeHash)) { return; }
+    if (m_classOrPackage) {
+        m_classOrPackageHash = std::to_string(VString::hash(m_classOrPackage->name())) + "ULL";
     } else {
-        puts(string("uint64_t __VscopeHash = std::hash<std::string>{}(")
+        puts(string("const uint64_t __VscopeHash = VL_HASH(")
              + (m_useSelfForThis ? "vlSelf" : "this") + "->name());\n");
     }
     m_createdScopeHash = true;

--- a/src/V3EmitCFunc.h
+++ b/src/V3EmitCFunc.h
@@ -120,6 +120,7 @@ class EmitCFunc VL_NOT_FINAL : public EmitCConstInit {
     int m_labelNum = 0;  // Next label number
     bool m_inUC = false;  // Inside an AstUCStmt or AstUCExpr
     bool m_emitConstInit = false;  // Emitting constant initializer
+    bool m_createdScopeHash = false;  // Already created a scope hash
 
     // State associated with processing $display style string formatting
     struct EmitDispState final {
@@ -214,6 +215,7 @@ public:
     string emitVarResetRecurse(const AstVar* varp, bool constructing,
                                const string& varNameProtected, AstNodeDType* dtypep, int depth,
                                const string& suffix);
+    void emitVarResetScopeHash();
     void emitChangeDet();
     void emitConstInit(AstNode* initp) {
         // We should refactor emit to produce output into a provided buffer, not go through members

--- a/src/V3EmitCFunc.h
+++ b/src/V3EmitCFunc.h
@@ -151,8 +151,8 @@ protected:
     const AstNodeModule* m_modp = nullptr;  // Current module being emitted
     const AstCFunc* m_cfuncp = nullptr;  // Current function being emitted
     bool m_instantiatesOwnProcess = false;
-    const AstClassPackage* m_class = nullptr;  // Pointer to current class
-    string m_classHash;  // Hash of class name
+    const AstClassPackage* m_classOrPackage = nullptr;  // Pointer to current class or package
+    string m_classOrPackageHash;  // Hash of class or package name
 
     bool constructorNeedsProcess(const AstClass* const classp) {
         const AstNode* const newp = m_memberMap.findMember(classp, "new");

--- a/src/V3EmitCFunc.h
+++ b/src/V3EmitCFunc.h
@@ -152,6 +152,7 @@ protected:
     const AstCFunc* m_cfuncp = nullptr;  // Current function being emitted
     bool m_instantiatesOwnProcess = false;
     const AstClassPackage* m_class = nullptr;  // Pointer to current class
+    string m_classHash;  // Hash of class name
 
     bool constructorNeedsProcess(const AstClass* const classp) {
         const AstNode* const newp = m_memberMap.findMember(classp, "new");

--- a/src/V3EmitCFunc.h
+++ b/src/V3EmitCFunc.h
@@ -151,6 +151,7 @@ protected:
     const AstNodeModule* m_modp = nullptr;  // Current module being emitted
     const AstCFunc* m_cfuncp = nullptr;  // Current function being emitted
     bool m_instantiatesOwnProcess = false;
+    const AstClassPackage* m_class = nullptr;  // Pointer to current class
 
     bool constructorNeedsProcess(const AstClass* const classp) {
         const AstNode* const newp = m_memberMap.findMember(classp, "new");
@@ -287,6 +288,7 @@ public:
         VL_RESTORER(m_useSelfForThis);
         VL_RESTORER(m_cfuncp);
         VL_RESTORER(m_instantiatesOwnProcess);
+        VL_RESTORER(m_createdScopeHash);
         m_cfuncp = nodep;
         m_instantiatesOwnProcess = false;
 

--- a/src/V3EmitCImp.cpp
+++ b/src/V3EmitCImp.cpp
@@ -507,9 +507,9 @@ class EmitCImp final : EmitCFunc {
         };
 
         gather(modp);
-        VL_RESTORER(m_class);
+        VL_RESTORER(m_classOrPackage);
         if (const AstClassPackage* const packagep = VN_CAST(modp, ClassPackage)) {
-            m_class = packagep;
+            m_classOrPackage = packagep;
             gather(packagep->classp());
         }
 

--- a/src/V3EmitCImp.cpp
+++ b/src/V3EmitCImp.cpp
@@ -18,7 +18,6 @@
 
 #include "V3EmitC.h"
 #include "V3EmitCFunc.h"
-#include "V3Global.h"
 #include "V3ThreadPool.h"
 #include "V3UniqueNames.h"
 

--- a/src/V3EmitCImp.cpp
+++ b/src/V3EmitCImp.cpp
@@ -18,6 +18,7 @@
 
 #include "V3EmitC.h"
 #include "V3EmitCFunc.h"
+#include "V3Global.h"
 #include "V3ThreadPool.h"
 #include "V3UniqueNames.h"
 
@@ -506,7 +507,9 @@ class EmitCImp final : EmitCFunc {
         };
 
         gather(modp);
+        VL_RESTORER(m_class);
         if (const AstClassPackage* const packagep = VN_CAST(modp, ClassPackage)) {
+            m_class = packagep;
             gather(packagep->classp());
         }
 

--- a/src/V3Options.cpp
+++ b/src/V3Options.cpp
@@ -2097,6 +2097,7 @@ V3Options::V3Options() {
     m_makeDir = "obj_dir";
     m_unusedRegexp = "*unused*";
     m_xAssign = "fast";
+    m_xInitial = "unique";
 
     m_defaultLanguage = V3LangCode::mostRecent();
 

--- a/src/V3String.cpp
+++ b/src/V3String.cpp
@@ -22,6 +22,8 @@
 #include "V3Error.h"
 #include "V3FileLine.h"
 
+#include <cstdint>
+
 #ifndef V3ERROR_NO_GLOBAL_
 #include "V3Global.h"
 VL_DEFINE_DEBUG_FUNCTIONS;
@@ -314,6 +316,49 @@ string VString::aOrAn(const char* word) {
     case 'u': return "an";
     default: return "a";
     }
+}
+
+// MurmurHash64A
+uint64_t VString::hash(const string& str) VL_PURE {
+    const char* key = str.c_str();
+    const size_t len = str.size();
+    const uint64_t seed = 0;
+    const uint64_t m = 0xc6a4a7935bd1e995ULL;
+    const int r = 47;
+
+    uint64_t h = seed ^ (len * m);
+
+    const uint64_t* data = (const uint64_t*)key;
+    const uint64_t* end = data + (len / 8);
+
+    while (data != end) {
+        uint64_t k = *data++;
+
+        k *= m;
+        k ^= k >> r;
+        k *= m;
+
+        h ^= k;
+        h *= m;
+    }
+
+    const unsigned char* data2 = (const unsigned char*)data;
+
+    switch (len & 7) {
+    case 7: h ^= uint64_t(data2[6]) << 48;
+    case 6: h ^= uint64_t(data2[5]) << 40;
+    case 5: h ^= uint64_t(data2[4]) << 32;
+    case 4: h ^= uint64_t(data2[3]) << 24;
+    case 3: h ^= uint64_t(data2[2]) << 16;
+    case 2: h ^= uint64_t(data2[1]) << 8;
+    case 1: h ^= uint64_t(data2[0]); h *= m;
+    };
+
+    h ^= h >> r;
+    h *= m;
+    h ^= h >> r;
+
+    return h;
 }
 
 //######################################################################

--- a/src/V3String.cpp
+++ b/src/V3String.cpp
@@ -345,13 +345,13 @@ uint64_t VString::hash(const string& str) VL_PURE {
     const unsigned char* data2 = (const unsigned char*)data;
 
     switch (len & 7) {
-    case 7: h ^= uint64_t(data2[6]) << 48;
-    case 6: h ^= uint64_t(data2[5]) << 40;
-    case 5: h ^= uint64_t(data2[4]) << 32;
-    case 4: h ^= uint64_t(data2[3]) << 24;
-    case 3: h ^= uint64_t(data2[2]) << 16;
-    case 2: h ^= uint64_t(data2[1]) << 8;
-    case 1: h ^= uint64_t(data2[0]); h *= m;
+    case 7: h ^= uint64_t(data2[6]) << 48; /* fallthrough */
+    case 6: h ^= uint64_t(data2[5]) << 40; /* fallthrough */
+    case 5: h ^= uint64_t(data2[4]) << 32; /* fallthrough */
+    case 4: h ^= uint64_t(data2[3]) << 24; /* fallthrough */
+    case 3: h ^= uint64_t(data2[2]) << 16; /* fallthrough */
+    case 2: h ^= uint64_t(data2[1]) << 8; /* fallthrough */
+    case 1: h ^= uint64_t(data2[0]); h *= m; /* fallthrough */
     };
 
     h ^= h >> r;

--- a/src/V3String.cpp
+++ b/src/V3String.cpp
@@ -22,8 +22,6 @@
 #include "V3Error.h"
 #include "V3FileLine.h"
 
-#include <cstdint>
-
 #ifndef V3ERROR_NO_GLOBAL_
 #include "V3Global.h"
 VL_DEFINE_DEBUG_FUNCTIONS;
@@ -319,7 +317,7 @@ string VString::aOrAn(const char* word) {
 }
 
 // MurmurHash64A
-uint64_t VString::hash(const string& str) VL_PURE {
+uint64_t VString::hashMurmur(const string& str) VL_PURE {
     const char* key = str.c_str();
     const size_t len = str.size();
     const uint64_t seed = 0;

--- a/src/V3String.h
+++ b/src/V3String.h
@@ -139,6 +139,8 @@ public:
     // Return proper article (a/an) for a word. May be inaccurate for some special words
     static string aOrAn(const char* word);
     static string aOrAn(const string& word) { return aOrAn(word.c_str()); }
+    // Hash the string
+    static uint64_t hash(const string& str) VL_PURE;
 };
 
 //######################################################################

--- a/src/V3String.h
+++ b/src/V3String.h
@@ -140,7 +140,7 @@ public:
     static string aOrAn(const char* word);
     static string aOrAn(const string& word) { return aOrAn(word.c_str()); }
     // Hash the string
-    static uint64_t hash(const string& str) VL_PURE;
+    static uint64_t hashMurmur(const string& str) VL_PURE;
 };
 
 //######################################################################

--- a/src/V3Unknown.cpp
+++ b/src/V3Unknown.cpp
@@ -353,25 +353,13 @@ class UnknownVisitor final : public VNVisitor {
                 AstNodeVarRef* const newref1p
                     = new AstVarRef{nodep->fileline(), newvarp, VAccess::READ};
                 replaceHandle.relink(newref1p);  // Replace const with varref
-                AstInitial* const newinitp = new AstInitial{
-                    nodep->fileline(),
-                    new AstAssign{
-                        nodep->fileline(),
-                        new AstVarRef{nodep->fileline(), newvarp, VAccess::WRITE},
-                        new AstOr{nodep->fileline(), new AstConst{nodep->fileline(), numb1},
-                                  new AstAnd{nodep->fileline(),
-                                             new AstConst{nodep->fileline(), numbx},
-                                             new AstRand{nodep->fileline(), AstRand::Reset{},
-                                                         nodep->dtypep(), true}}}}};
                 // Add inits in front of other statement.
                 // In the future, we should stuff the initp into the module's constructor.
                 AstNode* const afterp = m_modp->stmtsp()->unlinkFrBackWithNext();
                 m_modp->addStmtsp(newvarp);
-                m_modp->addStmtsp(newinitp);
                 m_modp->addStmtsp(afterp);
                 if (debug() >= 9) newref1p->dumpTree("-     _new: ");
                 if (debug() >= 9) newvarp->dumpTree("-     _new: ");
-                if (debug() >= 9) newinitp->dumpTree("-     _new: ");
                 VL_DO_DANGLING(nodep->deleteTree(), nodep);
             }
         }

--- a/src/V3Unknown.cpp
+++ b/src/V3Unknown.cpp
@@ -353,13 +353,24 @@ class UnknownVisitor final : public VNVisitor {
                 AstNodeVarRef* const newref1p
                     = new AstVarRef{nodep->fileline(), newvarp, VAccess::READ};
                 replaceHandle.relink(newref1p);  // Replace const with varref
+                AstInitial* const newinitp = new AstInitial{
+                    nodep->fileline(),
+                    new AstAssign{
+                        nodep->fileline(),
+                        new AstVarRef{nodep->fileline(), newvarp, VAccess::WRITE},
+                        new AstOr{nodep->fileline(), new AstConst{nodep->fileline(), numb1},
+                                  new AstAnd{
+                                      nodep->fileline(), new AstConst{nodep->fileline(), numbx},
+                                      new AstVarRef{nodep->fileline(), newvarp, VAccess::READ}}}}};
                 // Add inits in front of other statement.
                 // In the future, we should stuff the initp into the module's constructor.
                 AstNode* const afterp = m_modp->stmtsp()->unlinkFrBackWithNext();
                 m_modp->addStmtsp(newvarp);
+                m_modp->addStmtsp(newinitp);
                 m_modp->addStmtsp(afterp);
                 if (debug() >= 9) newref1p->dumpTree("-     _new: ");
                 if (debug() >= 9) newvarp->dumpTree("-     _new: ");
+                if (debug() >= 9) newinitp->dumpTree("-     _new: ");
                 VL_DO_DANGLING(nodep->deleteTree(), nodep);
             }
         }

--- a/test_regress/t/t_debug_emitv.py
+++ b/test_regress/t/t_debug_emitv.py
@@ -25,7 +25,11 @@ if test.verbose:
     # Print if that the output Verilog is clean
     # TODO not yet round-trip clean
     test.run(
-        cmd=[os.environ["VERILATOR_ROOT"] + "/bin/verilator", "--lint-only", output_v],
+        cmd=[
+            os.environ["VERILATOR_ROOT"] + "/bin/verilator",
+            "--lint-only",
+            output_vs[0],
+        ],
         logfile=test.obj_dir + "/sim_roundtrip.log",
         fails=True,
         verilator_run=True,

--- a/test_regress/t/t_debug_emitv.py
+++ b/test_regress/t/t_debug_emitv.py
@@ -9,23 +9,26 @@
 
 import vltest_bootstrap
 
-test.scenarios('vlt')
+test.scenarios("vlt")
 
 test.lint(
     # We also have dump-tree turned on, so hit a lot of AstNode*::dump() functions
     # Likewise XML
     v_flags=["--lint-only --dumpi-tree 9 --dumpi-V3EmitV 9 --debug-emitv"])
 
-output_v = test.glob_one(test.obj_dir + "/" + test.vm_prefix + "_*_width.tree.v")
+output_vs = test.glob_some(test.obj_dir + "/" + test.vm_prefix + "_*_width.tree.v")
 
-test.files_identical(output_v, test.golden_filename)
+for output_v in output_vs:
+    test.files_identical(output_v, test.golden_filename)
 
 if test.verbose:
     # Print if that the output Verilog is clean
     # TODO not yet round-trip clean
-    test.run(cmd=[os.environ["VERILATOR_ROOT"] + "/bin/verilator", "--lint-only", output_v],
-             logfile=test.obj_dir + "/sim_roundtrip.log",
-             fails=True,
-             verilator_run=True)
+    test.run(
+        cmd=[os.environ["VERILATOR_ROOT"] + "/bin/verilator", "--lint-only", output_v],
+        logfile=test.obj_dir + "/sim_roundtrip.log",
+        fails=True,
+        verilator_run=True,
+    )
 
 test.passes()

--- a/test_regress/t/t_flag_xinitial_unique.py
+++ b/test_regress/t/t_flag_xinitial_unique.py
@@ -9,13 +9,13 @@
 
 import vltest_bootstrap
 
-test.scenarios('vlt_all')
+test.scenarios("vlt_all")
 
 test.compile(verilator_flags2=["--x-initial unique"])
 
 test.execute()
 
 files = glob.glob(test.obj_dir + "/" + test.vm_prefix + "___024root__DepSet_*__Slow.cpp")
-test.file_grep_any(files, r'VL_RAND_RESET')
+test.file_grep_any(files, r"VL_SCOPED_RAND_RESET")
 
 test.passes()

--- a/test_regress/t/t_x_assign.cpp
+++ b/test_regress/t/t_x_assign.cpp
@@ -21,12 +21,6 @@ double sc_time_stamp() { return 0; }
 # define EXPECTED 0
 #elif defined(T_X_ASSIGN_1)
 # define EXPECTED 1
-#elif defined(T_X_ASSIGN_UNIQUE_0)
-# define EXPECTED 0
-#elif defined(T_X_ASSIGN_UNIQUE_1)
-# define EXPECTED 1
-#else
-# error "Don't know expectd output for test" #TEST
 #endif
 // clang-format on
 
@@ -35,6 +29,8 @@ int main(int argc, const char** argv) {
     Verilated::randReset(0);
 #elif defined(T_X_ASSIGN_UNIQUE_1)
     Verilated::randReset(1);
+#elif defined(T_X_ASSIGN_UNIQUE_2)
+    Verilated::randReset(2);
 #endif
 
     VM_PREFIX* top = new VM_PREFIX{};
@@ -53,6 +49,11 @@ int main(int argc, const char** argv) {
 #elif defined(T_X_ASSIGN_UNIQUE_1)
     if (top->o_int != -1) {
         vl_fatal(__FILE__, __LINE__, "TOP.t", "x assign was not correct");
+        exit(1);
+    }
+#elif defined(T_X_ASSIGN_UNIQUE_2)
+    if (top->o_int == 0 || top->o_int == -1) {
+        vl_fatal(__FILE__, __LINE__, "TOP.t", "x assign was not unique");
         exit(1);
     }
 #else

--- a/test_regress/t/t_x_assign.cpp
+++ b/test_regress/t/t_x_assign.cpp
@@ -31,13 +31,13 @@ double sc_time_stamp() { return 0; }
 // clang-format on
 
 int main(int argc, const char** argv) {
-    VM_PREFIX* top = new VM_PREFIX{};
-
 #if defined(T_X_ASSIGN_UNIQUE_0)
     Verilated::randReset(0);
 #elif defined(T_X_ASSIGN_UNIQUE_1)
     Verilated::randReset(1);
 #endif
+
+    VM_PREFIX* top = new VM_PREFIX{};
 
     // Evaluate one clock posedge
     top->clk = 0;
@@ -45,9 +45,14 @@ int main(int argc, const char** argv) {
     top->clk = 1;
     top->eval();
 
-#if defined(T_X_ASSIGN_UNIQUE_0) || defined(T_X_ASSIGN_UNIQUE_1)
-    if (top->o_int == 0 || top->o_int == -1) {
-        vl_fatal(__FILE__, __LINE__, "TOP.t", "x assign was not unique");
+#if defined(T_X_ASSIGN_UNIQUE_0)
+    if (top->o_int != 0) {
+        vl_fatal(__FILE__, __LINE__, "TOP.t", "x assign was not correct");
+        exit(1);
+    }
+#elif defined(T_X_ASSIGN_UNIQUE_1)
+    if (top->o_int != -1) {
+        vl_fatal(__FILE__, __LINE__, "TOP.t", "x assign was not correct");
         exit(1);
     }
 #else

--- a/test_regress/t/t_x_assign_unique_2.py
+++ b/test_regress/t/t_x_assign_unique_2.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2024 by Wilson Snyder. This program is free software; you can
+# redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios("vlt_all")
+test.pli_filename = "t/t_x_assign.cpp"
+test.top_filename = "t/t_x_assign.v"
+
+test.compile(
+    make_top_shell=False,
+    make_main=False,
+    verilator_flags2=["--x-assign unique --exe", "--x-initial 0", test.pli_filename],
+)
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_x_rand_mt_stability.out
+++ b/test_regress/t/t_x_rand_mt_stability.out
@@ -12,6 +12,6 @@ rand = 0xf0acf3e4
 rand = 0xca0ac74c
 rand = 0x4eddfc2c
 rand = 0x1919db69
-x_assigned = 0xe3e54aaa
+x_assigned = 0xbc969e82
 Last rand = 0x2d118c9b
 *-* All Finished *-*

--- a/test_regress/t/t_x_rand_mt_stability.out
+++ b/test_regress/t/t_x_rand_mt_stability.out
@@ -1,0 +1,17 @@
+uninitialized = 0x500685e2
+x_assigned (initial) = 0x00000000
+uninitialized2 = 0x5416b56c
+big = 0xc4503b56329c5b62d25ee2d7f2b45b50c6d1c37791f35012b1782a67b194f8a0
+random_init = 0x952aaa76
+top.t.the_sub_yes_inline_1 no_init 0x5293d3db1468cfe4
+top.t.the_sub_yes_inline_2 no_init 0xe27ac165957ed737
+top.t.the_sub_no_inline_1 no_init 0x843435030e893ca5
+top.t.the_sub_no_inline_2 no_init 0x164cf3d70f336a36
+rand = 0xb3cf9302
+rand = 0xf0acf3e4
+rand = 0xca0ac74c
+rand = 0x4eddfc2c
+rand = 0x1919db69
+x_assigned = 0xe3e54aaa
+Last rand = 0x2d118c9b
+*-* All Finished *-*

--- a/test_regress/t/t_x_rand_mt_stability.out
+++ b/test_regress/t/t_x_rand_mt_stability.out
@@ -1,17 +1,17 @@
-uninitialized = 0x500685e2
+uninitialized = 0xf5bbcbc0
 x_assigned (initial) = 0x00000000
-uninitialized2 = 0x5416b56c
-big = 0xc4503b56329c5b62d25ee2d7f2b45b50c6d1c37791f35012b1782a67b194f8a0
+uninitialized2 = 0xa979eb54
+big = 0xa20c93ac50d8c57d4c80949aa68e82775da6af98ce08f75dc6ccfad97b059a33
 random_init = 0x952aaa76
-top.t.the_sub_yes_inline_1 no_init 0x5293d3db1468cfe4
-top.t.the_sub_yes_inline_2 no_init 0xe27ac165957ed737
-top.t.the_sub_no_inline_1 no_init 0x843435030e893ca5
-top.t.the_sub_no_inline_2 no_init 0x164cf3d70f336a36
+top.t.the_sub_yes_inline_1 no_init 0x4a544f7798b83fc8
+top.t.the_sub_yes_inline_2 no_init 0x19b7000ee0472c9
+top.t.the_sub_no_inline_1 no_init 0x38121a34978975dd
+top.t.the_sub_no_inline_2 no_init 0x9022c84ae0fa3cf6
 rand = 0xb3cf9302
 rand = 0xf0acf3e4
 rand = 0xca0ac74c
 rand = 0x4eddfc2c
 rand = 0x1919db69
-x_assigned = 0xbc969e82
+x_assigned = 0xc0391efd
 Last rand = 0x2d118c9b
 *-* All Finished *-*

--- a/test_regress/t/t_x_rand_mt_stability.py
+++ b/test_regress/t/t_x_rand_mt_stability.py
@@ -8,12 +8,17 @@
 # SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
 
 import vltest_bootstrap
+import glob
 
-test.scenarios("vlt")
+test.scenarios("vltmt")
 test.top_filename = "t/t_x_rand_stability.v"
 
-test.compile(verilator_flags2=["--x-initial unique", "--trace"])
+test.compile(verilator_flags2=["--x-initial unique"])
 
 test.execute(all_run_flags=["+verilator+rand+reset+2"], expect_filename=test.golden_filename)
 
 test.passes()
+
+other_logs = [x for x in glob.glob("t/t_x_rand_mt_stability_*.out") if "_zero" not in x]
+for other_log in other_logs:
+    test.files_identical(test.golden_filename, other_log)

--- a/test_regress/t/t_x_rand_mt_stability_add.out
+++ b/test_regress/t/t_x_rand_mt_stability_add.out
@@ -12,6 +12,6 @@ rand = 0xf0acf3e4
 rand = 0xca0ac74c
 rand = 0x4eddfc2c
 rand = 0x1919db69
-x_assigned = 0xe3e54aaa
+x_assigned = 0xbc969e82
 Last rand = 0x2d118c9b
 *-* All Finished *-*

--- a/test_regress/t/t_x_rand_mt_stability_add.out
+++ b/test_regress/t/t_x_rand_mt_stability_add.out
@@ -1,0 +1,17 @@
+uninitialized = 0x500685e2
+x_assigned (initial) = 0x00000000
+uninitialized2 = 0x5416b56c
+big = 0xc4503b56329c5b62d25ee2d7f2b45b50c6d1c37791f35012b1782a67b194f8a0
+random_init = 0x952aaa76
+top.t.the_sub_yes_inline_1 no_init 0x5293d3db1468cfe4
+top.t.the_sub_yes_inline_2 no_init 0xe27ac165957ed737
+top.t.the_sub_no_inline_1 no_init 0x843435030e893ca5
+top.t.the_sub_no_inline_2 no_init 0x164cf3d70f336a36
+rand = 0xb3cf9302
+rand = 0xf0acf3e4
+rand = 0xca0ac74c
+rand = 0x4eddfc2c
+rand = 0x1919db69
+x_assigned = 0xe3e54aaa
+Last rand = 0x2d118c9b
+*-* All Finished *-*

--- a/test_regress/t/t_x_rand_mt_stability_add.out
+++ b/test_regress/t/t_x_rand_mt_stability_add.out
@@ -1,17 +1,17 @@
-uninitialized = 0x500685e2
+uninitialized = 0xf5bbcbc0
 x_assigned (initial) = 0x00000000
-uninitialized2 = 0x5416b56c
-big = 0xc4503b56329c5b62d25ee2d7f2b45b50c6d1c37791f35012b1782a67b194f8a0
+uninitialized2 = 0xa979eb54
+big = 0xa20c93ac50d8c57d4c80949aa68e82775da6af98ce08f75dc6ccfad97b059a33
 random_init = 0x952aaa76
-top.t.the_sub_yes_inline_1 no_init 0x5293d3db1468cfe4
-top.t.the_sub_yes_inline_2 no_init 0xe27ac165957ed737
-top.t.the_sub_no_inline_1 no_init 0x843435030e893ca5
-top.t.the_sub_no_inline_2 no_init 0x164cf3d70f336a36
+top.t.the_sub_yes_inline_1 no_init 0x4a544f7798b83fc8
+top.t.the_sub_yes_inline_2 no_init 0x19b7000ee0472c9
+top.t.the_sub_no_inline_1 no_init 0x38121a34978975dd
+top.t.the_sub_no_inline_2 no_init 0x9022c84ae0fa3cf6
 rand = 0xb3cf9302
 rand = 0xf0acf3e4
 rand = 0xca0ac74c
 rand = 0x4eddfc2c
 rand = 0x1919db69
-x_assigned = 0xbc969e82
+x_assigned = 0xc0391efd
 Last rand = 0x2d118c9b
 *-* All Finished *-*

--- a/test_regress/t/t_x_rand_mt_stability_add.py
+++ b/test_regress/t/t_x_rand_mt_stability_add.py
@@ -9,10 +9,10 @@
 
 import vltest_bootstrap
 
-test.scenarios("vlt")
+test.scenarios("vltmt")
 test.top_filename = "t/t_x_rand_stability.v"
 
-test.compile(verilator_flags2=["--x-initial unique", "--trace"])
+test.compile(verilator_flags2=["--x-initial unique", "-DADD_SIGNAL"])
 
 test.execute(all_run_flags=["+verilator+rand+reset+2"], expect_filename=test.golden_filename)
 

--- a/test_regress/t/t_x_rand_mt_stability_add_trace.out
+++ b/test_regress/t/t_x_rand_mt_stability_add_trace.out
@@ -12,6 +12,6 @@ rand = 0xf0acf3e4
 rand = 0xca0ac74c
 rand = 0x4eddfc2c
 rand = 0x1919db69
-x_assigned = 0xe3e54aaa
+x_assigned = 0xbc969e82
 Last rand = 0x2d118c9b
 *-* All Finished *-*

--- a/test_regress/t/t_x_rand_mt_stability_add_trace.out
+++ b/test_regress/t/t_x_rand_mt_stability_add_trace.out
@@ -1,0 +1,17 @@
+uninitialized = 0x500685e2
+x_assigned (initial) = 0x00000000
+uninitialized2 = 0x5416b56c
+big = 0xc4503b56329c5b62d25ee2d7f2b45b50c6d1c37791f35012b1782a67b194f8a0
+random_init = 0x952aaa76
+top.t.the_sub_yes_inline_1 no_init 0x5293d3db1468cfe4
+top.t.the_sub_yes_inline_2 no_init 0xe27ac165957ed737
+top.t.the_sub_no_inline_1 no_init 0x843435030e893ca5
+top.t.the_sub_no_inline_2 no_init 0x164cf3d70f336a36
+rand = 0xb3cf9302
+rand = 0xf0acf3e4
+rand = 0xca0ac74c
+rand = 0x4eddfc2c
+rand = 0x1919db69
+x_assigned = 0xe3e54aaa
+Last rand = 0x2d118c9b
+*-* All Finished *-*

--- a/test_regress/t/t_x_rand_mt_stability_add_trace.out
+++ b/test_regress/t/t_x_rand_mt_stability_add_trace.out
@@ -1,17 +1,17 @@
-uninitialized = 0x500685e2
+uninitialized = 0xf5bbcbc0
 x_assigned (initial) = 0x00000000
-uninitialized2 = 0x5416b56c
-big = 0xc4503b56329c5b62d25ee2d7f2b45b50c6d1c37791f35012b1782a67b194f8a0
+uninitialized2 = 0xa979eb54
+big = 0xa20c93ac50d8c57d4c80949aa68e82775da6af98ce08f75dc6ccfad97b059a33
 random_init = 0x952aaa76
-top.t.the_sub_yes_inline_1 no_init 0x5293d3db1468cfe4
-top.t.the_sub_yes_inline_2 no_init 0xe27ac165957ed737
-top.t.the_sub_no_inline_1 no_init 0x843435030e893ca5
-top.t.the_sub_no_inline_2 no_init 0x164cf3d70f336a36
+top.t.the_sub_yes_inline_1 no_init 0x4a544f7798b83fc8
+top.t.the_sub_yes_inline_2 no_init 0x19b7000ee0472c9
+top.t.the_sub_no_inline_1 no_init 0x38121a34978975dd
+top.t.the_sub_no_inline_2 no_init 0x9022c84ae0fa3cf6
 rand = 0xb3cf9302
 rand = 0xf0acf3e4
 rand = 0xca0ac74c
 rand = 0x4eddfc2c
 rand = 0x1919db69
-x_assigned = 0xbc969e82
+x_assigned = 0xc0391efd
 Last rand = 0x2d118c9b
 *-* All Finished *-*

--- a/test_regress/t/t_x_rand_mt_stability_add_trace.py
+++ b/test_regress/t/t_x_rand_mt_stability_add_trace.py
@@ -9,10 +9,10 @@
 
 import vltest_bootstrap
 
-test.scenarios("vlt")
+test.scenarios("vltmt")
 test.top_filename = "t/t_x_rand_stability.v"
 
-test.compile(verilator_flags2=["--x-initial unique", "--trace"])
+test.compile(verilator_flags2=["--x-initial unique", "-DADD_SIGNAL", "--trace"])
 
 test.execute(all_run_flags=["+verilator+rand+reset+2"], expect_filename=test.golden_filename)
 

--- a/test_regress/t/t_x_rand_mt_stability_trace.out
+++ b/test_regress/t/t_x_rand_mt_stability_trace.out
@@ -12,6 +12,6 @@ rand = 0xf0acf3e4
 rand = 0xca0ac74c
 rand = 0x4eddfc2c
 rand = 0x1919db69
-x_assigned = 0xe3e54aaa
+x_assigned = 0xbc969e82
 Last rand = 0x2d118c9b
 *-* All Finished *-*

--- a/test_regress/t/t_x_rand_mt_stability_trace.out
+++ b/test_regress/t/t_x_rand_mt_stability_trace.out
@@ -1,0 +1,17 @@
+uninitialized = 0x500685e2
+x_assigned (initial) = 0x00000000
+uninitialized2 = 0x5416b56c
+big = 0xc4503b56329c5b62d25ee2d7f2b45b50c6d1c37791f35012b1782a67b194f8a0
+random_init = 0x952aaa76
+top.t.the_sub_yes_inline_1 no_init 0x5293d3db1468cfe4
+top.t.the_sub_yes_inline_2 no_init 0xe27ac165957ed737
+top.t.the_sub_no_inline_1 no_init 0x843435030e893ca5
+top.t.the_sub_no_inline_2 no_init 0x164cf3d70f336a36
+rand = 0xb3cf9302
+rand = 0xf0acf3e4
+rand = 0xca0ac74c
+rand = 0x4eddfc2c
+rand = 0x1919db69
+x_assigned = 0xe3e54aaa
+Last rand = 0x2d118c9b
+*-* All Finished *-*

--- a/test_regress/t/t_x_rand_mt_stability_trace.out
+++ b/test_regress/t/t_x_rand_mt_stability_trace.out
@@ -1,17 +1,17 @@
-uninitialized = 0x500685e2
+uninitialized = 0xf5bbcbc0
 x_assigned (initial) = 0x00000000
-uninitialized2 = 0x5416b56c
-big = 0xc4503b56329c5b62d25ee2d7f2b45b50c6d1c37791f35012b1782a67b194f8a0
+uninitialized2 = 0xa979eb54
+big = 0xa20c93ac50d8c57d4c80949aa68e82775da6af98ce08f75dc6ccfad97b059a33
 random_init = 0x952aaa76
-top.t.the_sub_yes_inline_1 no_init 0x5293d3db1468cfe4
-top.t.the_sub_yes_inline_2 no_init 0xe27ac165957ed737
-top.t.the_sub_no_inline_1 no_init 0x843435030e893ca5
-top.t.the_sub_no_inline_2 no_init 0x164cf3d70f336a36
+top.t.the_sub_yes_inline_1 no_init 0x4a544f7798b83fc8
+top.t.the_sub_yes_inline_2 no_init 0x19b7000ee0472c9
+top.t.the_sub_no_inline_1 no_init 0x38121a34978975dd
+top.t.the_sub_no_inline_2 no_init 0x9022c84ae0fa3cf6
 rand = 0xb3cf9302
 rand = 0xf0acf3e4
 rand = 0xca0ac74c
 rand = 0x4eddfc2c
 rand = 0x1919db69
-x_assigned = 0xbc969e82
+x_assigned = 0xc0391efd
 Last rand = 0x2d118c9b
 *-* All Finished *-*

--- a/test_regress/t/t_x_rand_mt_stability_trace.py
+++ b/test_regress/t/t_x_rand_mt_stability_trace.py
@@ -9,7 +9,7 @@
 
 import vltest_bootstrap
 
-test.scenarios("vlt")
+test.scenarios("vltmt")
 test.top_filename = "t/t_x_rand_stability.v"
 
 test.compile(verilator_flags2=["--x-initial unique", "--trace"])

--- a/test_regress/t/t_x_rand_mt_stability_zeros.out
+++ b/test_regress/t/t_x_rand_mt_stability_zeros.out
@@ -1,0 +1,17 @@
+uninitialized = 0x00000000
+x_assigned (initial) = 0x00000000
+uninitialized2 = 0x00000000
+big = 0x0000000000000000000000000000000000000000000000000000000000000000
+random_init = 0x952aaa76
+top.t.the_sub_yes_inline_1 no_init 0x0
+top.t.the_sub_yes_inline_2 no_init 0x0
+top.t.the_sub_no_inline_1 no_init 0x0
+top.t.the_sub_no_inline_2 no_init 0x0
+rand = 0xb3cf9302
+rand = 0xf0acf3e4
+rand = 0xca0ac74c
+rand = 0x4eddfc2c
+rand = 0x1919db69
+x_assigned = 0xe3e54aaa
+Last rand = 0x2d118c9b
+*-* All Finished *-*

--- a/test_regress/t/t_x_rand_mt_stability_zeros.out
+++ b/test_regress/t/t_x_rand_mt_stability_zeros.out
@@ -12,6 +12,6 @@ rand = 0xf0acf3e4
 rand = 0xca0ac74c
 rand = 0x4eddfc2c
 rand = 0x1919db69
-x_assigned = 0xe3e54aaa
+x_assigned = 0x00000000
 Last rand = 0x2d118c9b
 *-* All Finished *-*

--- a/test_regress/t/t_x_rand_mt_stability_zeros.py
+++ b/test_regress/t/t_x_rand_mt_stability_zeros.py
@@ -9,11 +9,11 @@
 
 import vltest_bootstrap
 
-test.scenarios("vlt")
+test.scenarios("vltmt")
 test.top_filename = "t/t_x_rand_stability.v"
 
-test.compile(verilator_flags2=["--x-initial unique", "--trace"])
+test.compile(verilator_flags2=["--x-initial unique", "-DNOT_RAND"])
 
-test.execute(all_run_flags=["+verilator+rand+reset+2"], expect_filename=test.golden_filename)
+test.execute(all_run_flags=["+verilator+rand+reset+0"], expect_filename=test.golden_filename)
 
 test.passes()

--- a/test_regress/t/t_x_rand_stability.out
+++ b/test_regress/t/t_x_rand_stability.out
@@ -1,0 +1,10 @@
+rand = 0x02fe107d
+rand = 0xa97523fb
+rand = 0xbe450da7
+rand = 0x5d1eb5e3
+rand = 0xd5b8d57e
+uninitialized = 0xe85acf2d
+x_assigned = 0xf0700dbf
+uninitialized2 = 0x0f7f28c0
+Last rand = 0xf0be314a
+*-* All Finished *-*

--- a/test_regress/t/t_x_rand_stability.out
+++ b/test_regress/t/t_x_rand_stability.out
@@ -7,11 +7,11 @@ top.t.the_sub_yes_inline_1 no_init 0x5293d3db1468cfe4
 top.t.the_sub_yes_inline_2 no_init 0xe27ac165957ed737
 top.t.the_sub_no_inline_1 no_init 0x843435030e893ca5
 top.t.the_sub_no_inline_2 no_init 0x164cf3d70f336a36
+rand = 0xe3e54aaa
 rand = 0xe85acf2d
 rand = 0x15e12c6a
 rand = 0x0f7f28c0
 rand = 0xe189c52a
-rand = 0xf0700dbf
-x_assigned = 0xe3e54aaa
-Last rand = 0x02fe107d
+x_assigned = 0xbc969e82
+Last rand = 0xf0700dbf
 *-* All Finished *-*

--- a/test_regress/t/t_x_rand_stability.out
+++ b/test_regress/t/t_x_rand_stability.out
@@ -1,10 +1,17 @@
-rand = 0x952aaa76
-rand = 0xe3e54aaa
+uninitialized = 0x500685e2
+x_assigned (initial) = 0x00000000
+uninitialized2 = 0x5416b56c
+big = 0xc4503b56329c5b62d25ee2d7f2b45b50c6d1c37791f35012b1782a67b194f8a0
+random_init = 0x952aaa76
+top.t.the_sub_yes_inline_1 no_init 0x5293d3db1468cfe4
+top.t.the_sub_yes_inline_2 no_init 0xe27ac165957ed737
+top.t.the_sub_no_inline_1 no_init 0x843435030e893ca5
+top.t.the_sub_no_inline_2 no_init 0x164cf3d70f336a36
 rand = 0xe85acf2d
 rand = 0x15e12c6a
 rand = 0x0f7f28c0
-uninitialized = 0x0077defe
-x_assigned = 0xb3c4d5e6
-uninitialized2 = 0x0067ee70
-Last rand = 0xe189c52a
+rand = 0xe189c52a
+rand = 0xf0700dbf
+x_assigned = 0xe3e54aaa
+Last rand = 0x02fe107d
 *-* All Finished *-*

--- a/test_regress/t/t_x_rand_stability.out
+++ b/test_regress/t/t_x_rand_stability.out
@@ -1,10 +1,10 @@
-rand = 0x02fe107d
-rand = 0xa97523fb
-rand = 0xbe450da7
-rand = 0x5d1eb5e3
-rand = 0xd5b8d57e
-uninitialized = 0xe85acf2d
-x_assigned = 0xf0700dbf
-uninitialized2 = 0x0f7f28c0
-Last rand = 0xf0be314a
+rand = 0x952aaa76
+rand = 0xe3e54aaa
+rand = 0xe85acf2d
+rand = 0x15e12c6a
+rand = 0x0f7f28c0
+uninitialized = 0x0077defe
+x_assigned = 0xb3c4d5e6
+uninitialized2 = 0x0067ee70
+Last rand = 0xe189c52a
 *-* All Finished *-*

--- a/test_regress/t/t_x_rand_stability.out
+++ b/test_regress/t/t_x_rand_stability.out
@@ -1,17 +1,17 @@
-uninitialized = 0x500685e2
+uninitialized = 0xf5bbcbc0
 x_assigned (initial) = 0x00000000
-uninitialized2 = 0x5416b56c
-big = 0xc4503b56329c5b62d25ee2d7f2b45b50c6d1c37791f35012b1782a67b194f8a0
+uninitialized2 = 0xa979eb54
+big = 0xa20c93ac50d8c57d4c80949aa68e82775da6af98ce08f75dc6ccfad97b059a33
 random_init = 0x952aaa76
-top.t.the_sub_yes_inline_1 no_init 0x5293d3db1468cfe4
-top.t.the_sub_yes_inline_2 no_init 0xe27ac165957ed737
-top.t.the_sub_no_inline_1 no_init 0x843435030e893ca5
-top.t.the_sub_no_inline_2 no_init 0x164cf3d70f336a36
+top.t.the_sub_yes_inline_1 no_init 0x4a544f7798b83fc8
+top.t.the_sub_yes_inline_2 no_init 0x19b7000ee0472c9
+top.t.the_sub_no_inline_1 no_init 0x38121a34978975dd
+top.t.the_sub_no_inline_2 no_init 0x9022c84ae0fa3cf6
 rand = 0xe3e54aaa
 rand = 0xe85acf2d
 rand = 0x15e12c6a
 rand = 0x0f7f28c0
 rand = 0xe189c52a
-x_assigned = 0xbc969e82
+x_assigned = 0xc0391efd
 Last rand = 0xf0700dbf
 *-* All Finished *-*

--- a/test_regress/t/t_x_rand_stability.py
+++ b/test_regress/t/t_x_rand_stability.py
@@ -13,7 +13,9 @@ test.scenarios("simulator")
 
 test.compile(verilator_flags2=["--x-initial unique"])
 
-test.execute(all_run_flags=["+verilator+rand+reset+2"], expect_filename=test.golden_filename)
+test.execute(
+    all_run_flags=["+verilator+rand+reset+2"], expect_filename=test.golden_filename
+)
 
 test.passes()
 

--- a/test_regress/t/t_x_rand_stability.py
+++ b/test_regress/t/t_x_rand_stability.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2024 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios("simulator")
+
+test.compile(verilator_flags2=["--x-initial unique"])
+
+test.execute(all_run_flags=["+verilator+rand+reset+2"], expect_filename=test.golden_filename)
+
+test.passes()
+
+other_logs = glob.glob("t/t_x_rand_stability_*.out")
+for other_log in other_logs:
+    test.files_identical(test.golden_filename, other_log)

--- a/test_regress/t/t_x_rand_stability.py
+++ b/test_regress/t/t_x_rand_stability.py
@@ -10,7 +10,7 @@
 import vltest_bootstrap
 import glob
 
-test.scenarios("simulator")
+test.scenarios("vlt")
 
 test.compile(verilator_flags2=["--x-initial unique"])
 

--- a/test_regress/t/t_x_rand_stability.py
+++ b/test_regress/t/t_x_rand_stability.py
@@ -14,9 +14,7 @@ test.scenarios("simulator")
 
 test.compile(verilator_flags2=["--x-initial unique"])
 
-test.execute(
-    all_run_flags=["+verilator+rand+reset+2"], expect_filename=test.golden_filename
-)
+test.execute(all_run_flags=["+verilator+rand+reset+2"], expect_filename=test.golden_filename)
 
 test.passes()
 

--- a/test_regress/t/t_x_rand_stability.v
+++ b/test_regress/t/t_x_rand_stability.v
@@ -16,7 +16,7 @@ module t (/*AUTOARG*/
     logic [31:0] uninitialized;
     logic [31:0] x_assigned = '0;
 `ifdef ADD_SIGNAL
-    logic [31:0] added /* verilator public */;
+    logic [31:0] added;
 `endif
     logic [31:0] unused;
     logic [31:0] uninitialized2;
@@ -42,9 +42,14 @@ module t (/*AUTOARG*/
         $display("rand = 0x%x", $random());
         if (cyc == 4) begin
             $display("x_assigned = 0x%x", x_assigned);
+`ifndef NOT_RAND
             if (uninitialized == uninitialized2) $stop();
             if (the_sub_yes_inline_1.no_init == the_sub_yes_inline_2.no_init) $stop();
             if (the_sub_no_inline_1.no_init == the_sub_no_inline_2.no_init) $stop();
+`endif
+`ifdef ADD_SIGNAL
+            if (added != added) $stop();
+`endif
             $display("Last rand = 0x%x", $random());
             $write("*-* All Finished *-*\n");
             $finish;

--- a/test_regress/t/t_x_rand_stability.v
+++ b/test_regress/t/t_x_rand_stability.v
@@ -17,6 +17,7 @@ module t (/*AUTOARG*/
     logic [31:0] x_assigned = '0;
 `ifdef ADD_SIGNAL
     logic [31:0] added;
+    logic [31:0] x_assigned_added = '0;
 `endif
     logic [31:0] unused;
     logic [31:0] uninitialized2;
@@ -38,6 +39,9 @@ module t (/*AUTOARG*/
 
     always @(posedge clk) begin
         x_assigned <= 'x;
+`ifdef ADD_SIGNAL
+        x_assigned_added <= 'x;
+`endif
         cyc <= cyc + 1;
         $display("rand = 0x%x", $random());
         if (cyc == 4) begin
@@ -48,7 +52,8 @@ module t (/*AUTOARG*/
             if (the_sub_no_inline_1.no_init == the_sub_no_inline_2.no_init) $stop();
 `endif
 `ifdef ADD_SIGNAL
-            if (added != added) $stop();
+            if (added == 0) $stop();
+            if (x_assigned_added == 0) $stop();
 `endif
             $display("Last rand = 0x%x", $random());
             $write("*-* All Finished *-*\n");

--- a/test_regress/t/t_x_rand_stability.v
+++ b/test_regress/t/t_x_rand_stability.v
@@ -20,6 +20,21 @@ module t (/*AUTOARG*/
 `endif
     logic [31:0] unused;
     logic [31:0] uninitialized2;
+    logic [255:0] big;
+    int random_init = $random();
+
+    sub_no_inline the_sub_no_inline_1();
+    sub_no_inline the_sub_no_inline_2();
+    sub_yes_inline the_sub_yes_inline_1();
+    sub_yes_inline the_sub_yes_inline_2();
+
+    initial begin
+        $display("uninitialized = 0x%x", uninitialized);
+        $display("x_assigned = 0x%x", x_assigned);
+        $display("uninitialized2 = 0x%x", uninitialized2);
+        $display("big = 0x%x", big);
+        $display("random_init = 0x%x", random_init);
+    end
 
     always @(posedge clk) begin
         x_assigned <= 'x;
@@ -27,13 +42,22 @@ module t (/*AUTOARG*/
         $display("rand = 0x%x", $random());
         if (cyc == 4) begin
             if (uninitialized == uninitialized2) $stop();
-            $display("uninitialized = 0x%x", uninitialized);
-            $display("x_assigned = 0x%x", x_assigned);
-            $display("uninitialized2 = 0x%x", uninitialized2);
+            if (the_sub_yes_inline_1.no_init == the_sub_yes_inline_2.no_init) $stop();
+            if (the_sub_no_inline_1.no_init == the_sub_no_inline_2.no_init) $stop();
             $display("Last rand = 0x%x", $random());
             $write("*-* All Finished *-*\n");
             $finish;
         end
     end
 
+endmodule
+
+module sub_no_inline; /* verilator no_inline_module */
+    logic [63:0] no_init;
+    initial $display("%m no_init 0x%0x", no_init);
+endmodule
+
+module sub_yes_inline; /* verilator inline_module */
+    logic [63:0] no_init;
+    initial $display("%m no_init 0x%0x", no_init);
 endmodule

--- a/test_regress/t/t_x_rand_stability.v
+++ b/test_regress/t/t_x_rand_stability.v
@@ -30,7 +30,7 @@ module t (/*AUTOARG*/
 
     initial begin
         $display("uninitialized = 0x%x", uninitialized);
-        $display("x_assigned = 0x%x", x_assigned);
+        $display("x_assigned (initial) = 0x%x", x_assigned);
         $display("uninitialized2 = 0x%x", uninitialized2);
         $display("big = 0x%x", big);
         $display("random_init = 0x%x", random_init);
@@ -41,6 +41,7 @@ module t (/*AUTOARG*/
         cyc <= cyc + 1;
         $display("rand = 0x%x", $random());
         if (cyc == 4) begin
+            $display("x_assigned = 0x%x", x_assigned);
             if (uninitialized == uninitialized2) $stop();
             if (the_sub_yes_inline_1.no_init == the_sub_yes_inline_2.no_init) $stop();
             if (the_sub_no_inline_1.no_init == the_sub_no_inline_2.no_init) $stop();

--- a/test_regress/t/t_x_rand_stability.v
+++ b/test_regress/t/t_x_rand_stability.v
@@ -1,0 +1,39 @@
+// DESCRIPTION: Verilator: Confirm x randomization stability
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2025 by Wilson Snyder.
+// SPDX-License-Identifier: CC0-1.0
+
+
+module t (/*AUTOARG*/
+    // Inputs
+    clk
+    );
+
+    input clk;
+    int cyc = 0;
+
+    logic [31:0] uninitialized;
+    logic [31:0] x_assigned = '0;
+`ifdef ADD_SIGNAL
+    logic [31:0] added /* verilator public */;
+`endif
+    logic [31:0] unused;
+    logic [31:0] uninitialized2;
+
+    always @(posedge clk) begin
+        x_assigned <= 'x;
+        cyc <= cyc + 1;
+        $display("rand = 0x%x", $random());
+        if (cyc == 4) begin
+            if (uninitialized == uninitialized2) $stop();
+            $display("uninitialized = 0x%x", uninitialized);
+            $display("x_assigned = 0x%x", x_assigned);
+            $display("uninitialized2 = 0x%x", uninitialized2);
+            $display("Last rand = 0x%x", $random());
+            $write("*-* All Finished *-*\n");
+            $finish;
+        end
+    end
+
+endmodule

--- a/test_regress/t/t_x_rand_stability_add.out
+++ b/test_regress/t/t_x_rand_stability_add.out
@@ -7,11 +7,11 @@ top.t.the_sub_yes_inline_1 no_init 0x5293d3db1468cfe4
 top.t.the_sub_yes_inline_2 no_init 0xe27ac165957ed737
 top.t.the_sub_no_inline_1 no_init 0x843435030e893ca5
 top.t.the_sub_no_inline_2 no_init 0x164cf3d70f336a36
+rand = 0xe3e54aaa
 rand = 0xe85acf2d
 rand = 0x15e12c6a
 rand = 0x0f7f28c0
 rand = 0xe189c52a
-rand = 0xf0700dbf
-x_assigned = 0xe3e54aaa
-Last rand = 0x02fe107d
+x_assigned = 0xbc969e82
+Last rand = 0xf0700dbf
 *-* All Finished *-*

--- a/test_regress/t/t_x_rand_stability_add.out
+++ b/test_regress/t/t_x_rand_stability_add.out
@@ -1,0 +1,10 @@
+rand = 0xbe450da7
+rand = 0x5d1eb5e3
+rand = 0xd5b8d57e
+rand = 0xf0be314a
+rand = 0xba24397c
+uninitialized = 0x0f7f28c0
+x_assigned = 0xa97523fb
+uninitialized2 = 0x02fe107d
+Last rand = 0xd61b440b
+*-* All Finished *-*

--- a/test_regress/t/t_x_rand_stability_add.out
+++ b/test_regress/t/t_x_rand_stability_add.out
@@ -1,10 +1,10 @@
-rand = 0xbe450da7
-rand = 0x5d1eb5e3
-rand = 0xd5b8d57e
-rand = 0xf0be314a
-rand = 0xba24397c
-uninitialized = 0x0f7f28c0
-x_assigned = 0xa97523fb
-uninitialized2 = 0x02fe107d
-Last rand = 0xd61b440b
+rand = 0x952aaa76
+rand = 0xe3e54aaa
+rand = 0xe85acf2d
+rand = 0x15e12c6a
+rand = 0x0f7f28c0
+uninitialized = 0x001f1bbe
+x_assigned = 0xb3c4d5e6
+uninitialized2 = 0x0013d7d3
+Last rand = 0xe189c52a
 *-* All Finished *-*

--- a/test_regress/t/t_x_rand_stability_add.out
+++ b/test_regress/t/t_x_rand_stability_add.out
@@ -1,10 +1,17 @@
-rand = 0x952aaa76
-rand = 0xe3e54aaa
+uninitialized = 0x500685e2
+x_assigned (initial) = 0x00000000
+uninitialized2 = 0x5416b56c
+big = 0xc4503b56329c5b62d25ee2d7f2b45b50c6d1c37791f35012b1782a67b194f8a0
+random_init = 0x952aaa76
+top.t.the_sub_yes_inline_1 no_init 0x5293d3db1468cfe4
+top.t.the_sub_yes_inline_2 no_init 0xe27ac165957ed737
+top.t.the_sub_no_inline_1 no_init 0x843435030e893ca5
+top.t.the_sub_no_inline_2 no_init 0x164cf3d70f336a36
 rand = 0xe85acf2d
 rand = 0x15e12c6a
 rand = 0x0f7f28c0
-uninitialized = 0x001f1bbe
-x_assigned = 0xb3c4d5e6
-uninitialized2 = 0x0013d7d3
-Last rand = 0xe189c52a
+rand = 0xe189c52a
+rand = 0xf0700dbf
+x_assigned = 0xe3e54aaa
+Last rand = 0x02fe107d
 *-* All Finished *-*

--- a/test_regress/t/t_x_rand_stability_add.out
+++ b/test_regress/t/t_x_rand_stability_add.out
@@ -1,17 +1,17 @@
-uninitialized = 0x500685e2
+uninitialized = 0xf5bbcbc0
 x_assigned (initial) = 0x00000000
-uninitialized2 = 0x5416b56c
-big = 0xc4503b56329c5b62d25ee2d7f2b45b50c6d1c37791f35012b1782a67b194f8a0
+uninitialized2 = 0xa979eb54
+big = 0xa20c93ac50d8c57d4c80949aa68e82775da6af98ce08f75dc6ccfad97b059a33
 random_init = 0x952aaa76
-top.t.the_sub_yes_inline_1 no_init 0x5293d3db1468cfe4
-top.t.the_sub_yes_inline_2 no_init 0xe27ac165957ed737
-top.t.the_sub_no_inline_1 no_init 0x843435030e893ca5
-top.t.the_sub_no_inline_2 no_init 0x164cf3d70f336a36
+top.t.the_sub_yes_inline_1 no_init 0x4a544f7798b83fc8
+top.t.the_sub_yes_inline_2 no_init 0x19b7000ee0472c9
+top.t.the_sub_no_inline_1 no_init 0x38121a34978975dd
+top.t.the_sub_no_inline_2 no_init 0x9022c84ae0fa3cf6
 rand = 0xe3e54aaa
 rand = 0xe85acf2d
 rand = 0x15e12c6a
 rand = 0x0f7f28c0
 rand = 0xe189c52a
-x_assigned = 0xbc969e82
+x_assigned = 0xc0391efd
 Last rand = 0xf0700dbf
 *-* All Finished *-*

--- a/test_regress/t/t_x_rand_stability_add.py
+++ b/test_regress/t/t_x_rand_stability_add.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2024 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios("simulator")
+test.top_filename = "t/t_x_rand_stability.v"
+
+test.compile(verilator_flags2=["--x-initial unique", "-DADD_SIGNAL"])
+
+test.execute(all_run_flags=["+verilator+rand+reset+2"], expect_filename=test.golden_filename)
+
+test.passes()

--- a/test_regress/t/t_x_rand_stability_add.py
+++ b/test_regress/t/t_x_rand_stability_add.py
@@ -9,7 +9,7 @@
 
 import vltest_bootstrap
 
-test.scenarios("simulator")
+test.scenarios("vlt")
 test.top_filename = "t/t_x_rand_stability.v"
 
 test.compile(verilator_flags2=["--x-initial unique", "-DADD_SIGNAL"])

--- a/test_regress/t/t_x_rand_stability_add_trace.out
+++ b/test_regress/t/t_x_rand_stability_add_trace.out
@@ -7,11 +7,11 @@ top.t.the_sub_yes_inline_1 no_init 0x5293d3db1468cfe4
 top.t.the_sub_yes_inline_2 no_init 0xe27ac165957ed737
 top.t.the_sub_no_inline_1 no_init 0x843435030e893ca5
 top.t.the_sub_no_inline_2 no_init 0x164cf3d70f336a36
+rand = 0xe3e54aaa
 rand = 0xe85acf2d
 rand = 0x15e12c6a
 rand = 0x0f7f28c0
 rand = 0xe189c52a
-rand = 0xf0700dbf
-x_assigned = 0xe3e54aaa
-Last rand = 0x02fe107d
+x_assigned = 0xbc969e82
+Last rand = 0xf0700dbf
 *-* All Finished *-*

--- a/test_regress/t/t_x_rand_stability_add_trace.out
+++ b/test_regress/t/t_x_rand_stability_add_trace.out
@@ -1,10 +1,17 @@
-rand = 0x952aaa76
-rand = 0xe3e54aaa
+uninitialized = 0x500685e2
+x_assigned (initial) = 0x00000000
+uninitialized2 = 0x5416b56c
+big = 0xc4503b56329c5b62d25ee2d7f2b45b50c6d1c37791f35012b1782a67b194f8a0
+random_init = 0x952aaa76
+top.t.the_sub_yes_inline_1 no_init 0x5293d3db1468cfe4
+top.t.the_sub_yes_inline_2 no_init 0xe27ac165957ed737
+top.t.the_sub_no_inline_1 no_init 0x843435030e893ca5
+top.t.the_sub_no_inline_2 no_init 0x164cf3d70f336a36
 rand = 0xe85acf2d
 rand = 0x15e12c6a
 rand = 0x0f7f28c0
-uninitialized = 0x001f1bbe
-x_assigned = 0xb3c4d5e6
-uninitialized2 = 0x0013d7d3
-Last rand = 0xe189c52a
+rand = 0xe189c52a
+rand = 0xf0700dbf
+x_assigned = 0xe3e54aaa
+Last rand = 0x02fe107d
 *-* All Finished *-*

--- a/test_regress/t/t_x_rand_stability_add_trace.out
+++ b/test_regress/t/t_x_rand_stability_add_trace.out
@@ -1,10 +1,10 @@
-rand = 0x5d1eb5e3
-rand = 0xd5b8d57e
-rand = 0xf0be314a
-rand = 0xba24397c
-rand = 0xd61b440b
-uninitialized = 0x0f7f28c0
-x_assigned = 0xbe450da7
-uninitialized2 = 0xa97523fb
-Last rand = 0x911c43eb
+rand = 0x952aaa76
+rand = 0xe3e54aaa
+rand = 0xe85acf2d
+rand = 0x15e12c6a
+rand = 0x0f7f28c0
+uninitialized = 0x001f1bbe
+x_assigned = 0xb3c4d5e6
+uninitialized2 = 0x0013d7d3
+Last rand = 0xe189c52a
 *-* All Finished *-*

--- a/test_regress/t/t_x_rand_stability_add_trace.out
+++ b/test_regress/t/t_x_rand_stability_add_trace.out
@@ -1,17 +1,17 @@
-uninitialized = 0x500685e2
+uninitialized = 0xf5bbcbc0
 x_assigned (initial) = 0x00000000
-uninitialized2 = 0x5416b56c
-big = 0xc4503b56329c5b62d25ee2d7f2b45b50c6d1c37791f35012b1782a67b194f8a0
+uninitialized2 = 0xa979eb54
+big = 0xa20c93ac50d8c57d4c80949aa68e82775da6af98ce08f75dc6ccfad97b059a33
 random_init = 0x952aaa76
-top.t.the_sub_yes_inline_1 no_init 0x5293d3db1468cfe4
-top.t.the_sub_yes_inline_2 no_init 0xe27ac165957ed737
-top.t.the_sub_no_inline_1 no_init 0x843435030e893ca5
-top.t.the_sub_no_inline_2 no_init 0x164cf3d70f336a36
+top.t.the_sub_yes_inline_1 no_init 0x4a544f7798b83fc8
+top.t.the_sub_yes_inline_2 no_init 0x19b7000ee0472c9
+top.t.the_sub_no_inline_1 no_init 0x38121a34978975dd
+top.t.the_sub_no_inline_2 no_init 0x9022c84ae0fa3cf6
 rand = 0xe3e54aaa
 rand = 0xe85acf2d
 rand = 0x15e12c6a
 rand = 0x0f7f28c0
 rand = 0xe189c52a
-x_assigned = 0xbc969e82
+x_assigned = 0xc0391efd
 Last rand = 0xf0700dbf
 *-* All Finished *-*

--- a/test_regress/t/t_x_rand_stability_add_trace.out
+++ b/test_regress/t/t_x_rand_stability_add_trace.out
@@ -1,0 +1,10 @@
+rand = 0x5d1eb5e3
+rand = 0xd5b8d57e
+rand = 0xf0be314a
+rand = 0xba24397c
+rand = 0xd61b440b
+uninitialized = 0x0f7f28c0
+x_assigned = 0xbe450da7
+uninitialized2 = 0xa97523fb
+Last rand = 0x911c43eb
+*-* All Finished *-*

--- a/test_regress/t/t_x_rand_stability_add_trace.py
+++ b/test_regress/t/t_x_rand_stability_add_trace.py
@@ -9,7 +9,7 @@
 
 import vltest_bootstrap
 
-test.scenarios("simulator")
+test.scenarios("vlt")
 test.top_filename = "t/t_x_rand_stability.v"
 
 test.compile(verilator_flags2=["--x-initial unique", "-DADD_SIGNAL", "--trace"])

--- a/test_regress/t/t_x_rand_stability_add_trace.py
+++ b/test_regress/t/t_x_rand_stability_add_trace.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2024 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios("simulator")
+test.top_filename = "t/t_x_rand_stability.v"
+
+test.compile(verilator_flags2=["--x-initial unique", "-DADD_SIGNAL", "--trace"])
+
+test.execute(all_run_flags=["+verilator+rand+reset+2"], expect_filename=test.golden_filename)
+
+test.passes()

--- a/test_regress/t/t_x_rand_stability_trace.out
+++ b/test_regress/t/t_x_rand_stability_trace.out
@@ -7,11 +7,11 @@ top.t.the_sub_yes_inline_1 no_init 0x5293d3db1468cfe4
 top.t.the_sub_yes_inline_2 no_init 0xe27ac165957ed737
 top.t.the_sub_no_inline_1 no_init 0x843435030e893ca5
 top.t.the_sub_no_inline_2 no_init 0x164cf3d70f336a36
+rand = 0xe3e54aaa
 rand = 0xe85acf2d
 rand = 0x15e12c6a
 rand = 0x0f7f28c0
 rand = 0xe189c52a
-rand = 0xf0700dbf
-x_assigned = 0xe3e54aaa
-Last rand = 0x02fe107d
+x_assigned = 0xbc969e82
+Last rand = 0xf0700dbf
 *-* All Finished *-*

--- a/test_regress/t/t_x_rand_stability_trace.out
+++ b/test_regress/t/t_x_rand_stability_trace.out
@@ -1,0 +1,10 @@
+rand = 0xa97523fb
+rand = 0xbe450da7
+rand = 0x5d1eb5e3
+rand = 0xd5b8d57e
+rand = 0xf0be314a
+uninitialized = 0xe85acf2d
+x_assigned = 0x02fe107d
+uninitialized2 = 0xe189c52a
+Last rand = 0xba24397c
+*-* All Finished *-*

--- a/test_regress/t/t_x_rand_stability_trace.out
+++ b/test_regress/t/t_x_rand_stability_trace.out
@@ -1,10 +1,17 @@
-rand = 0x952aaa76
-rand = 0xe3e54aaa
+uninitialized = 0x500685e2
+x_assigned (initial) = 0x00000000
+uninitialized2 = 0x5416b56c
+big = 0xc4503b56329c5b62d25ee2d7f2b45b50c6d1c37791f35012b1782a67b194f8a0
+random_init = 0x952aaa76
+top.t.the_sub_yes_inline_1 no_init 0x5293d3db1468cfe4
+top.t.the_sub_yes_inline_2 no_init 0xe27ac165957ed737
+top.t.the_sub_no_inline_1 no_init 0x843435030e893ca5
+top.t.the_sub_no_inline_2 no_init 0x164cf3d70f336a36
 rand = 0xe85acf2d
 rand = 0x15e12c6a
 rand = 0x0f7f28c0
-uninitialized = 0x0077defe
-x_assigned = 0xb3c4d5e6
-uninitialized2 = 0x0067ee70
-Last rand = 0xe189c52a
+rand = 0xe189c52a
+rand = 0xf0700dbf
+x_assigned = 0xe3e54aaa
+Last rand = 0x02fe107d
 *-* All Finished *-*

--- a/test_regress/t/t_x_rand_stability_trace.out
+++ b/test_regress/t/t_x_rand_stability_trace.out
@@ -1,10 +1,10 @@
-rand = 0xa97523fb
-rand = 0xbe450da7
-rand = 0x5d1eb5e3
-rand = 0xd5b8d57e
-rand = 0xf0be314a
-uninitialized = 0xe85acf2d
-x_assigned = 0x02fe107d
-uninitialized2 = 0xe189c52a
-Last rand = 0xba24397c
+rand = 0x952aaa76
+rand = 0xe3e54aaa
+rand = 0xe85acf2d
+rand = 0x15e12c6a
+rand = 0x0f7f28c0
+uninitialized = 0x0077defe
+x_assigned = 0xb3c4d5e6
+uninitialized2 = 0x0067ee70
+Last rand = 0xe189c52a
 *-* All Finished *-*

--- a/test_regress/t/t_x_rand_stability_trace.out
+++ b/test_regress/t/t_x_rand_stability_trace.out
@@ -1,17 +1,17 @@
-uninitialized = 0x500685e2
+uninitialized = 0xf5bbcbc0
 x_assigned (initial) = 0x00000000
-uninitialized2 = 0x5416b56c
-big = 0xc4503b56329c5b62d25ee2d7f2b45b50c6d1c37791f35012b1782a67b194f8a0
+uninitialized2 = 0xa979eb54
+big = 0xa20c93ac50d8c57d4c80949aa68e82775da6af98ce08f75dc6ccfad97b059a33
 random_init = 0x952aaa76
-top.t.the_sub_yes_inline_1 no_init 0x5293d3db1468cfe4
-top.t.the_sub_yes_inline_2 no_init 0xe27ac165957ed737
-top.t.the_sub_no_inline_1 no_init 0x843435030e893ca5
-top.t.the_sub_no_inline_2 no_init 0x164cf3d70f336a36
+top.t.the_sub_yes_inline_1 no_init 0x4a544f7798b83fc8
+top.t.the_sub_yes_inline_2 no_init 0x19b7000ee0472c9
+top.t.the_sub_no_inline_1 no_init 0x38121a34978975dd
+top.t.the_sub_no_inline_2 no_init 0x9022c84ae0fa3cf6
 rand = 0xe3e54aaa
 rand = 0xe85acf2d
 rand = 0x15e12c6a
 rand = 0x0f7f28c0
 rand = 0xe189c52a
-x_assigned = 0xbc969e82
+x_assigned = 0xc0391efd
 Last rand = 0xf0700dbf
 *-* All Finished *-*

--- a/test_regress/t/t_x_rand_stability_trace.py
+++ b/test_regress/t/t_x_rand_stability_trace.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2024 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios("simulator")
+test.top_filename = "t/t_x_rand_stability.v"
+
+test.compile(verilator_flags2=["--x-initial unique", "--trace"])
+
+test.execute(all_run_flags=["+verilator+rand+reset+2"], expect_filename=test.golden_filename)
+
+test.passes()

--- a/test_regress/t/t_x_rand_stability_zeros.out
+++ b/test_regress/t/t_x_rand_stability_zeros.out
@@ -7,11 +7,11 @@ top.t.the_sub_yes_inline_1 no_init 0x0
 top.t.the_sub_yes_inline_2 no_init 0x0
 top.t.the_sub_no_inline_1 no_init 0x0
 top.t.the_sub_no_inline_2 no_init 0x0
+rand = 0xe3e54aaa
 rand = 0xe85acf2d
 rand = 0x15e12c6a
 rand = 0x0f7f28c0
 rand = 0xe189c52a
-rand = 0xf0700dbf
-x_assigned = 0xe3e54aaa
-Last rand = 0x02fe107d
+x_assigned = 0x00000000
+Last rand = 0xf0700dbf
 *-* All Finished *-*

--- a/test_regress/t/t_x_rand_stability_zeros.out
+++ b/test_regress/t/t_x_rand_stability_zeros.out
@@ -1,0 +1,17 @@
+uninitialized = 0x00000000
+x_assigned (initial) = 0x00000000
+uninitialized2 = 0x00000000
+big = 0x0000000000000000000000000000000000000000000000000000000000000000
+random_init = 0x952aaa76
+top.t.the_sub_yes_inline_1 no_init 0x0
+top.t.the_sub_yes_inline_2 no_init 0x0
+top.t.the_sub_no_inline_1 no_init 0x0
+top.t.the_sub_no_inline_2 no_init 0x0
+rand = 0xe85acf2d
+rand = 0x15e12c6a
+rand = 0x0f7f28c0
+rand = 0xe189c52a
+rand = 0xf0700dbf
+x_assigned = 0xe3e54aaa
+Last rand = 0x02fe107d
+*-* All Finished *-*

--- a/test_regress/t/t_x_rand_stability_zeros.py
+++ b/test_regress/t/t_x_rand_stability_zeros.py
@@ -9,7 +9,7 @@
 
 import vltest_bootstrap
 
-test.scenarios("simulator")
+test.scenarios("vlt")
 test.top_filename = "t/t_x_rand_stability.v"
 
 test.compile(verilator_flags2=["--x-initial unique", "-DNOT_RAND"])

--- a/test_regress/t/t_x_rand_stability_zeros.py
+++ b/test_regress/t/t_x_rand_stability_zeros.py
@@ -14,8 +14,6 @@ test.top_filename = "t/t_x_rand_stability.v"
 
 test.compile(verilator_flags2=["--x-initial unique"])
 
-test.execute(
-    all_run_flags=["+verilator+rand+reset+0"], expect_filename=test.golden_filename
-)
+test.execute(all_run_flags=["+verilator+rand+reset+0"], expect_filename=test.golden_filename)
 
 test.passes()

--- a/test_regress/t/t_x_rand_stability_zeros.py
+++ b/test_regress/t/t_x_rand_stability_zeros.py
@@ -12,7 +12,7 @@ import vltest_bootstrap
 test.scenarios("simulator")
 test.top_filename = "t/t_x_rand_stability.v"
 
-test.compile(verilator_flags2=["--x-initial unique"])
+test.compile(verilator_flags2=["--x-initial unique", "-DNOT_RAND"])
 
 test.execute(all_run_flags=["+verilator+rand+reset+0"], expect_filename=test.golden_filename)
 

--- a/test_regress/t/t_x_rand_stability_zeros.py
+++ b/test_regress/t/t_x_rand_stability_zeros.py
@@ -8,18 +8,14 @@
 # SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
 
 import vltest_bootstrap
-import glob
 
 test.scenarios("simulator")
+test.top_filename = "t/t_x_rand_stability.v"
 
 test.compile(verilator_flags2=["--x-initial unique"])
 
 test.execute(
-    all_run_flags=["+verilator+rand+reset+2"], expect_filename=test.golden_filename
+    all_run_flags=["+verilator+rand+reset+0"], expect_filename=test.golden_filename
 )
 
 test.passes()
-
-other_logs = [x for x in glob.glob("t/t_x_rand_stability_*.out") if "_zero" not in x]
-for other_log in other_logs:
-    test.files_identical(test.golden_filename, other_log)


### PR DESCRIPTION
We recently noticed that seeds were not portable between builds w/ and w/o `--trace`.  This is because the two have different numbers of `VL_RAND_RESET_*()` calls.  This is a proof of concept which, while not fully fleshed out, does resolve the issue for us (at least in limited testing).

We can work around this by setting `--x-initial` and `--x-assign` to `0`.  However, this is obviously not ideal.

The basic idea is that since `VL_RAND_RESET_*()` call may be optimized away (or differently) between builds, we don't let these calls advance the PRNG stream.  Instead we calculate salt values during verilation (based on the AST or RTL path or something stable) and run the PRNG algorithm on that without modifying its state.

Open items:
- in `*rand64()`, if `reset` is true return the next value per the algorithm after the state has been salted, but do not update the sate (instead of the simple XOR which is there now)
- compute salts for various places which emit hard-coded salts currently (should be stable between verilations and w/ and w/o `--trace`
- tests

I recognize that this isn't foolproof since one could:
```
int value;
always_ff @(posedge clk) value = $random();
```
And if `value` isn't used then I assume Verilator can prune it when we're running w/o `--trace`.  However, this scenario feels a lot more obvious / straightforward to deal with whereas `x` randomization is very pervasive and implicit.

Anyway, I wanted to get initial thoughts on this before I went further.  Please advise.