### PR TITLE
Simplify naming of Vthread schedule funcs. No functional change

### DIFF
--- a/src/V3ExecGraph.cpp
+++ b/src/V3ExecGraph.cpp
@@ -771,8 +771,8 @@ const std::vector<AstCFunc*> createThreadFunctions(const ThreadSchedule& schedul
     for (const std::vector<const ExecMTask*>& thread : schedule.threads) {
         if (thread.empty()) continue;
         const uint32_t threadId = schedule.threadId(thread.front());
-        const string name{"__Vthread__" + tag + "__t" + cvtToStr(threadId) + "__s"
-                          + cvtToStr(schedule.id())};
+        const string name{"__Vthread__" + tag + "__s" + cvtToStr(schedule.id()) + "__t"
+                          + cvtToStr(threadId)};
         AstCFunc* const funcp = new AstCFunc{fl, name, nullptr, "void"};
         modp->addStmtsp(funcp);
         funcps.push_back(funcp);


### PR DESCRIPTION
This PR makes naming convention more intuitive for hierarchical schedules changing it 
from `__t<thread id>__s<schedule id>` to `__s<schedule id>__t<thread id>`.