### PR TITLE
Fix Inconsistent assignment error by split_var

### DIFF
--- a/src/V3SplitVar.cpp
+++ b/src/V3SplitVar.cpp
@@ -919,14 +919,8 @@ public:
             points.emplace_back(ref.lsb(), false);  // Start of a region
             points.emplace_back(ref.msb() + 1, true);  // End of a region
         }
-        int bit_hi, bit_lo;
-        if (basicp() == dtypep) {
-            bit_hi = basicp()->hi();
-            bit_lo = basicp()->lo();
-        } else {  // packed struct, packed array. lo is 0
-            bit_hi = dtypep->width() - 1;
-            bit_lo = 0;
-        }
+        const int bit_lo = basicp()->lo();
+        const int bit_hi = bit_lo + dtypep->width() - 1;
         if (skipUnused && !m_rhs.empty()) {  // Range to be read must be kept, so add points here
             int lsb = bit_hi + 1;
             int msb = bit_lo - 1;

--- a/test_regress/t/t_split_var_types.v
+++ b/test_regress/t/t_split_var_types.v
@@ -10,13 +10,20 @@ module t(/*AUTOARG*/
     );
     input clk;
 
+    logic [7:0] data = 0;
     // Test loop
     always @ (posedge clk) begin
-        $write("*-* All Finished *-*\n");
-        $finish;
+       if (data != 15) begin
+          data <= data + 8'd1;
+       end else begin
+          $write("*-* All Finished *-*\n");
+          $finish;
+       end
     end
 
+
     bug5782 u_bug5782(.data_out());
+    bug5984 u_bug5984(.in(data));
 
 endmodule
 
@@ -28,4 +35,26 @@ module bug5782 (
     always begin
         data_out = data[7];
     end
+endmodule
+
+// #5984 inconsistent assignment due to wrong bit range calculation.
+module bug5984 (
+   input logic [1:0][3:0] in
+   );
+
+   logic [1:0][5:2] internal;
+
+   for (genvar dim1 = 0; dim1 < 2; dim1++) begin
+      for (genvar dim2 = 0; dim2 < 4; dim2++) begin
+         assign internal[dim1][dim2+2] = in[dim1][dim2];
+      end
+   end
+
+   for (genvar dim1 = 0; dim1 < 2; dim1++) begin
+      for (genvar dim2 = 0; dim2 < 4; dim2++) begin
+         always_ff @(negedge internal[dim1][dim2+2]) begin
+            $display("%0b", internal[dim1][dim2+2]);
+         end
+      end
+   end
 endmodule


### PR DESCRIPTION
Fixes #5984

I suspect #5785 caused this issue.

As usual, run a test to reproduce the issue, then push the fix.