### PR TITLE
Fix virtual interface null assignments and comparisons (#5974)

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -155,6 +155,7 @@ Martin Schmidt
 Martin Stadler
 Mateusz Gancarz
 Matthew Ballance
+Maxim Fonarev
 Michael Bikovitsky
 Michael Killough
 Michaël Lefebvre

--- a/include/verilated_types.h
+++ b/include/verilated_types.h
@@ -1859,8 +1859,10 @@ public:
 struct VlNull final {
     operator bool() const { return false; }
     bool operator==(const void* ptr) const { return !ptr; }
+    bool operator!=(const void* ptr) const { return ptr; }
 };
 inline bool operator==(const void* ptr, VlNull) { return !ptr; }
+inline bool operator!=(const void* ptr, VlNull) { return ptr; }
 
 //===================================================================
 // Verilog class reference container

--- a/src/V3AstNodes.cpp
+++ b/src/V3AstNodes.cpp
@@ -922,7 +922,7 @@ AstNodeDType::CTypeRecursed AstNodeDType::cTypeRecurse(bool compound, bool packe
         info.m_type = "VlClassRef<" + EmitCBase::prefixNameProtect(adtypep) + ">";
     } else if (const auto* const adtypep = VN_CAST(dtypep, IfaceRefDType)) {
         UASSERT_OBJ(!packed, this, "Unsupported type for packed struct or union");
-        info.m_type = EmitCBase::prefixNameProtect(adtypep->ifaceViaCellp()) + "*";
+        info.m_type = "VlIfaceRef<" + EmitCBase::prefixNameProtect(adtypep->ifaceViaCellp()) + ">";
     } else if (const auto* const adtypep = VN_CAST(dtypep, UnpackArrayDType)) {
         UASSERT_OBJ(!packed, this, "Unsupported type for packed struct or union");
         if (adtypep->isCompound()) compound = true;

--- a/src/V3Common.cpp
+++ b/src/V3Common.cpp
@@ -66,7 +66,7 @@ static void makeVlToString(AstClass* nodep) {
 static void makeVlToString(AstIface* nodep) {
     AstCFunc* const funcp
         = new AstCFunc{nodep->fileline(), "VL_TO_STRING", nullptr, "std::string"};
-    funcp->argTypes("const " + EmitCBase::prefixNameProtect(nodep) + "* obj");
+    funcp->argTypes("const VlIfaceRef<" + EmitCBase::prefixNameProtect(nodep) + ">& obj");
     funcp->isMethod(false);
     funcp->isConst(false);
     funcp->isStatic(false);

--- a/src/V3EmitCFunc.cpp
+++ b/src/V3EmitCFunc.cpp
@@ -692,7 +692,7 @@ string EmitCFunc::emitVarResetRecurse(const AstVar* varp, bool constructing,
     } else if (VN_IS(dtypep, ClassRefDType)) {
         return "";  // Constructor does it
     } else if (VN_IS(dtypep, IfaceRefDType)) {
-        return varNameProtected + suffix + " = nullptr;\n";
+        return "";  // Constructor does it
     } else if (const AstDynArrayDType* const adtypep = VN_CAST(dtypep, DynArrayDType)) {
         // Access std::array as C array
         const string cvtarray = (adtypep->subDTypep()->isWide() ? ".data()" : "");

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -7401,30 +7401,40 @@ class WidthVisitor final : public VNVisitor {
                                 << underp->prettyNameQ() << " is an interface.");
             } else if (const AstIfaceRefDType* expIfaceRefp
                        = VN_CAST(expDTypep->skipRefp(), IfaceRefDType)) {
-                const AstIfaceRefDType* underIfaceRefp
-                    = VN_CAST(underp->dtypep()->skipRefp(), IfaceRefDType);
-                if (!underIfaceRefp) {
-                    underp->v3error(ucfirst(nodep->prettyOperatorName())
-                                    << " expected " << expIfaceRefp->ifaceViaCellp()->prettyNameQ()
-                                    << " interface on " << side << " but " << underp->prettyNameQ()
-                                    << " is not an interface.");
-                } else if (expIfaceRefp->ifaceViaCellp() != underIfaceRefp->ifaceViaCellp()) {
-                    underp->v3error(ucfirst(nodep->prettyOperatorName())
-                                    << " expected " << expIfaceRefp->ifaceViaCellp()->prettyNameQ()
-                                    << " interface on " << side << " but " << underp->prettyNameQ()
-                                    << " is a different interface ("
-                                    << underIfaceRefp->ifaceViaCellp()->prettyNameQ() << ").");
-                } else if (underIfaceRefp->modportp()
-                           && expIfaceRefp->modportp() != underIfaceRefp->modportp()) {
-                    underp->v3error(ucfirst(nodep->prettyOperatorName())
-                                    << " expected "
-                                    << (expIfaceRefp->modportp()
-                                            ? expIfaceRefp->modportp()->prettyNameQ()
-                                            : "no")
-                                    << " interface modport on " << side << " but got "
-                                    << underIfaceRefp->modportp()->prettyNameQ() << " modport.");
+                if (VN_IS(underp, Const)) {
+                    if (!VN_CAST(underp, Const)->num().isNull()) {
+                        underp->v3error(ucfirst(nodep->prettyOperatorName())
+                                        << " expected 'null' keyword"
+                                        << " on " << side << " but got " << underp->prettyNameQ());
+                    } else {
+                        underp = userIterateSubtreeReturnEdits(underp, WidthVP{expDTypep, FINAL}.p());
+                    }
                 } else {
-                    underp = userIterateSubtreeReturnEdits(underp, WidthVP{expDTypep, FINAL}.p());
+                    const AstIfaceRefDType* underIfaceRefp
+                        = VN_CAST(underp->dtypep()->skipRefp(), IfaceRefDType);
+                    if (!underIfaceRefp) {
+                        underp->v3error(ucfirst(nodep->prettyOperatorName())
+                                        << " expected " << expIfaceRefp->ifaceViaCellp()->prettyNameQ()
+                                        << " interface on " << side << " but " << underp->prettyNameQ()
+                                        << " is not an interface.");
+                    } else if (expIfaceRefp->ifaceViaCellp() != underIfaceRefp->ifaceViaCellp()) {
+                        underp->v3error(ucfirst(nodep->prettyOperatorName())
+                                        << " expected " << expIfaceRefp->ifaceViaCellp()->prettyNameQ()
+                                        << " interface on " << side << " but " << underp->prettyNameQ()
+                                        << " is a different interface ("
+                                        << underIfaceRefp->ifaceViaCellp()->prettyNameQ() << ").");
+                    } else if (underIfaceRefp->modportp()
+                               && expIfaceRefp->modportp() != underIfaceRefp->modportp()) {
+                        underp->v3error(ucfirst(nodep->prettyOperatorName())
+                                        << " expected "
+                                        << (expIfaceRefp->modportp()
+                                                ? expIfaceRefp->modportp()->prettyNameQ()
+                                                : "no")
+                                        << " interface modport on " << side << " but got "
+                                        << underIfaceRefp->modportp()->prettyNameQ() << " modport.");
+                    } else {
+                        underp = userIterateSubtreeReturnEdits(underp, WidthVP{expDTypep, FINAL}.p());
+                    }
                 }
             } else {
                 // Hope it just works out (perhaps a cast will deal with it)

--- a/test_regress/t/t_interface_virtual.v
+++ b/test_regress/t/t_interface_virtual.v
@@ -32,10 +32,17 @@ module t (/*AUTOARG*/);
    Clsgen#(virtual PBus) gen;
 
    initial begin
+      if (va != null) $stop;
+      va = null;
+      if (va != null) $stop;
       va = ia;
-      vb = ia;
-
       if (va == null) $stop;
+      va = null;
+      if (va != null) $stop;
+      va = ia;
+      if (va == null) $stop;
+
+      vb = ia;
 
       $display("va==vb? %b", va==vb);
       $display("va!=vb? %b", va!=vb);


### PR DESCRIPTION
partial fix #5974

- allowed inequality (!=) comparison between virtual interface and null
- allowed null assignment to virtual interface

but I can't figure out how to properly perform null assignment itself.

SV code like this:
```systemverilog
va = null;
``` 
emits like this:
```c++
.h
Vt_interface_virtual_PBus* t__DOT__va;

.cpp
vlSelfRef.t__DOT__va = VlNull{};
``` 
but assignment to VlNull is working only on ```VlClassRef``` (verilated_types.h)
```c++
VlClassRef& operator=(VlNull) {
    refCountDec();
    m_objp = nullptr;
    return *this;
}
```
so i should create new class like ```VlIfaceRef```?