### PR TITLE
Fix  #5993 by considering intermediate one bit mask

### DIFF
--- a/src/V3Const.cpp
+++ b/src/V3Const.cpp
@@ -125,6 +125,9 @@ class ConstBitOpTreeVisitor final : public VNVisitorConst {
         void updateBitRange(const AstShiftR* shiftp) {
             m_lsb += VN_AS(shiftp->rhsp(), Const)->toUInt();
         }
+        void limitBitRangeToLsb() {
+            m_msb = std::min(m_msb, m_lsb);
+        }
         int wordIdx() const { return m_wordIdx; }
         void wordIdx(int i) { m_wordIdx = i; }
         bool polarity() const { return m_polarity; }
@@ -538,6 +541,7 @@ class ConstBitOpTreeVisitor final : public VNVisitorConst {
             Restorer restorer{*this};
             incrOps(nodep, __LINE__);
             iterateConst(nodep->rhsp());
+            if (m_leafp) m_leafp->limitBitRangeToLsb();
             CONST_BITOP_RETURN_IF(m_failed, nodep->rhsp());
             restorer.disableRestore();  // Now all checks passed
         } else if (nodep->type() == m_rootp->type()) {  // And, Or, Xor

--- a/src/V3Const.cpp
+++ b/src/V3Const.cpp
@@ -125,9 +125,7 @@ class ConstBitOpTreeVisitor final : public VNVisitorConst {
         void updateBitRange(const AstShiftR* shiftp) {
             m_lsb += VN_AS(shiftp->rhsp(), Const)->toUInt();
         }
-        void limitBitRangeToLsb() {
-            m_msb = std::min(m_msb, m_lsb);
-        }
+        void limitBitRangeToLsb() { m_msb = std::min(m_msb, m_lsb); }
         int wordIdx() const { return m_wordIdx; }
         void wordIdx(int i) { m_wordIdx = i; }
         bool polarity() const { return m_polarity; }

--- a/test_regress/t/t_opt_const_dfg.py
+++ b/test_regress/t/t_opt_const_dfg.py
@@ -18,7 +18,7 @@ test.compile(verilator_flags2=["-Wno-UNOPTTHREADS", "--stats", test.pli_filename
 test.execute()
 
 if test.vlt:
-    test.file_grep(test.stats, r'Optimizations, Const bit op reduction\s+(\d+)', 39)
+    test.file_grep(test.stats, r'Optimizations, Const bit op reduction\s+(\d+)', 43)
     test.file_grep(test.stats, r'SplitVar, packed variables split automatically\s+(\d+)', 1)
 
 test.passes()


### PR DESCRIPTION
Fixes #5993

Intermediate "& 1" was ignored.

The first commit reproduces the issue like [this](https://github.com/verilator/verilator/actions/runs/14942388583/job/41981369930?pr=5998#step:6:308). Thanks Wilson for the simplified test
