### PR TITLE
Hierarchical scheduling visualization in V3ExecGraph

### DIFF
--- a/src/V3OrderParallel.cpp
+++ b/src/V3OrderParallel.cpp
@@ -1749,10 +1749,7 @@ class DpiThreadsVisitor final : public VNVisitorConst {
         m_threads = std::max(m_threads, V3Config::getHierWorkers(nodep->cname()));
         iterateChildrenConst(nodep);
     }
-    void visit(AstNodeCCall* nodep) override {
-        iterateChildrenConst(nodep);
-        iterateConst(nodep->funcp());
-    }
+    void visit(AstNodeCCall* nodep) override { iterateConst(nodep->funcp()); }
     void visit(AstNode* nodep) override { iterateChildrenConst(nodep); }
 
 public:


### PR DESCRIPTION
This PR improves V3ExecGraph `schedule` graph dumping. 
Old hierarchical version:
![Vt_hier_block_perf_086_schedule dot](https://github.com/user-attachments/assets/8f823fbd-8c6a-4e41-8681-8e8fc8fd56e8)

New hierarchical version:
![Vt_hier_block_perf_086_schedule dot](https://github.com/user-attachments/assets/aede807a-5159-40ba-9942-47c0b65c2fdb)

Hierarchical schedules are separated with black `forks`, thread allocations from multi-thread hierarchical tasks are shown as green tasks without dependencies.

I'd normalized lengths of tasks for readability. This however may cause task length misinterpretation, for instance `mt23` takes longer than `mt26/mt27` but it is shown on the left to indicate when it started. @wsnyder I can restrict this kind of graph only for hierarchical verilation if you want.

Dependencies were also simplified, so that they are shown from simulation execution perspective rather than scheduling. This means that tasks with dependencies on the same thread were simplified to only depend on their neighbour and there are no inter-schedule dependencies.

Normal multi-threaded verilation schedules are still a nightmare to watch but I don't think we would like to make those diagrams interactive for dependency tracking, especially considering that `pack` graph shows them all in a more digestible manner.
Old version:
![Vt_hier_block_perf_086_schedule dot](https://github.com/user-attachments/assets/09e226e5-919d-45ce-90f8-b9e3368d2872)

New version:
![Vt_hier_block_perf_086_schedule dot](https://github.com/user-attachments/assets/3473f72f-89e9-4d95-973e-030fc31d0f02)

