### PR TITLE
Fix arithmetic left-shift by constants over 32 bits (#6007)

### DIFF
--- a/src/V3Number.cpp
+++ b/src/V3Number.cpp
@@ -1877,8 +1877,8 @@ V3Number& V3Number::opShiftL(const V3Number& lhs, const V3Number& rhs) {
         if (rhs.bitIs1(bit)) return *this;  // shift of over 2^32 must be zero
     }
     const uint32_t rhsval = rhs.toUInt();
-    for (int bit = 0; bit < width(); ++bit) {
-        if (bit >= static_cast<int>(rhsval)) setBit(bit, lhs.bitIs(bit - rhsval));
+    for (uint32_t bit = 0; bit < static_cast<uint32_t>(width()); ++bit) {
+        if (bit >= rhsval) setBit(bit, lhs.bitIs(bit - rhsval));
     }
     return *this;
 }

--- a/test_regress/t/t_math_shiftls.py
+++ b/test_regress/t/t_math_shiftls.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2025 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile(verilator_flags2=['--binary'])
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_math_shiftls.v
+++ b/test_regress/t/t_math_shiftls.v
@@ -17,7 +17,7 @@ output wire [6:0] out33;
       #10;
       `checkd(out33, '0);
       $write("*-* All Finished *-*\n");
-      $finish; 
+      $finish;
     end
 
 endmodule

--- a/test_regress/t/t_math_shiftls.v
+++ b/test_regress/t/t_math_shiftls.v
@@ -1,0 +1,23 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2025 by Zhen Yan.
+// SPDX-License-Identifier: CC0-1.0
+
+`define stop $stop
+`define checkd(gotv, expv) do if ((gotv) !== (expv)) begin $write("%%Error: %s:%0d:  got=%0d exp=%0d\n", `__FILE__, `__LINE__, (gotv), (expv)); `stop; end while(0);
+
+module top (out33);
+
+output wire [6:0] out33;
+
+    assign out33 = (7'o66 <<< 32'hFFFF_FFFF);
+
+    initial begin
+      #10;
+      `checkd(out33, '0);
+      $write("*-* All Finished *-*\n");
+      $finish; 
+    end
+
+endmodule


### PR DESCRIPTION
Fix https://github.com/verilator/verilator/issues/6007 . Although @yTakatsukasa suggested using `uint64_t` instead of `int`, it seems that `uint32_t` should be sufficient? since the bit width will not exceed the range representable by `uint32_t`.
