### PR TITLE
Add variable to explicitly enable some GitHub workflows

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -26,6 +26,8 @@ defaults:
 jobs:
 
   Build:
+    # Only run scheduled jobs if explicitly enabled for that repo (e.g.: not on forks)
+    if: ${{ github.event_name != 'schedule' || vars.ENABLE_SCHEDULED_JOBS == 'true' }}
     runs-on: ubuntu-24.04
     env:
       CI_BUILD_STAGE_NAME: build

--- a/.github/workflows/rtlmeter.yml
+++ b/.github/workflows/rtlmeter.yml
@@ -24,6 +24,8 @@ concurrency:
 jobs:
   build-gcc:
     name: Build GCC
+    # Only run scheduled jobs if explicitly enabled for that repo (e.g.: not on forks)
+    if: ${{ github.event_name != 'schedule' || vars.ENABLE_SCHEDULED_JOBS == 'true' }}
     uses: ./.github/workflows/reusable-rtlmeter-build.yml
     with:
       runs-on: ubuntu-24.04
@@ -31,6 +33,8 @@ jobs:
 
   build-clang:
     name: Build Clang
+    # Only run scheduled jobs if explicitly enabled for that repo (e.g.: not on forks)
+    if: ${{ github.event_name != 'schedule' || vars.ENABLE_SCHEDULED_JOBS == 'true' }}
     uses: ./.github/workflows/reusable-rtlmeter-build.yml
     with:
       runs-on: ubuntu-24.04
@@ -119,7 +123,9 @@ jobs:
   combine-results:
     name: Combine results
     needs: [run-gcc, run-clang]
-    if: ${{ always() }}  # Run even if dependencies failed
+    # Run if any of the dependencies have run, even if failed.
+    # That is: do not run if all skipped, or the workflow was cancelled.
+    if: ${{ (contains(needs.*.result, 'success') || contains(needs.*.result, 'failure')) && !cancelled() }}
     runs-on: ubuntu-24.04
     steps:
       - name: Download all GCC results


### PR DESCRIPTION
To run scheduled instances of the RTLMeter or coverage workflows, the ENABLE_SCHEDULED_JOBS variable must explicitly be set to 'true' in the repository settings. This enables each fork to decide whether to run the scheduled instances or not.

---

I have set the variable for verilator/verilator, you can leave it unset in forks you don't want to run scheduled jobs in (which is the default).