### PR TITLE
Add missing include

### DIFF
--- a/include/verilated_threads.cpp
+++ b/include/verilated_threads.cpp
@@ -29,6 +29,7 @@
 #include <fstream>
 #include <iostream>
 #include <memory>
+#include <pthread_np.h>
 #include <string>
 
 //=============================================================================


### PR DESCRIPTION
Since verilator 5.036, it still builds fine on FreeBSD but actually running it results in the following error(s):
```
[info] [Progress] Verilator compilation started
[info] /usr/local/share/verilator/include/verilated_threads.cpp:124:20: error: use of undeclared identifier 'pthread_getaffinity_np'
[info]   124 |     const int rc = pthread_getaffinity_np(pthread_self(), sizeof(cpu_set_t), &cpuset);
[info]       |                    ^
[info] /usr/local/share/verilator/include/verilated_threads.cpp:245:24: error: use of undeclared identifier 'pthread_setaffinity_np'; did you mean 'sched_setaffinity'?
[info]   245 |         const int rc = pthread_setaffinity_np(m_workers[thread]->m_cthread.native_handle(),
[info]       |                        ^~~~~~~~~~~~~~~~~~~~~~
[info]       |                        sched_setaffinity
[info] /usr/include/sched.h:44:5: note: 'sched_setaffinity' declared here
[info]    44 | int sched_setaffinity(pid_t pid, size_t cpusetsz, const cpuset_t *cpuset);
[info]       |     ^
[info] /usr/local/share/verilator/include/verilated_threads.cpp:245:47: error: cannot initialize a parameter of type 'pid_t' (aka 'int') with an rvalue of type 'native_handle_type' (aka 'pthread *')
[info]   245 |         const int rc = pthread_setaffinity_np(m_workers[thread]->m_cthread.native_handle(),
[info]       |                                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[info] /usr/include/sched.h:44:29: note: passing argument to parameter 'pid' here
[info]    44 | int sched_setaffinity(pid_t pid, size_t cpusetsz, const cpuset_t *cpuset);
[info]       |                             ^
[info] 3 errors generated.
[info] gmake: *** [/usr/local/share/verilator/include/verilated.mk:282: verilated_threads.o] Error 1
```
This is due to a missing include of `pthread_np.h` which this PR addresses.