### PR TITLE
V3Coverage cleanup. No functional change.

### DIFF
--- a/src/V3Coverage.cpp
+++ b/src/V3Coverage.cpp
@@ -403,8 +403,8 @@ class CoverageVisitor final : public VNVisitor {
         m_modp->addStmtsp(newp);
     }
 
-    void toggleVarRecurse(AstNodeDType* dtypep, int depth,  // per-iteration
-                          const ToggleEnt& above, AstVar* varp) {  // Constant
+    void toggleVarRecurse(const AstNodeDType* const dtypep, const int depth,  // per-iteration
+                          const ToggleEnt& above, const AstVar* const varp) {  // Constant
         if (const AstBasicDType* const bdtypep = VN_CAST(dtypep, BasicDType)) {
             if (bdtypep->isRanged()) {
                 for (int index_docs = bdtypep->lo(); index_docs < bdtypep->hi() + 1;

--- a/src/V3Coverage.cpp
+++ b/src/V3Coverage.cpp
@@ -399,7 +399,7 @@ class CoverageVisitor final : public VNVisitor {
             varp->fileline(),
             newCoverInc(varp->fileline(), "", "v_toggle",
                         hierPrefix + varp->name() + above.m_comment, "", 0, ""),
-            above.m_varRefp->cloneTree(true), above.m_chgRefp->cloneTree(true)};
+            above.m_varRefp->cloneTree(false), above.m_chgRefp->cloneTree(false)};
         m_modp->addStmtsp(newp);
     }
 
@@ -411,10 +411,10 @@ class CoverageVisitor final : public VNVisitor {
                      ++index_docs) {
                     const int index_code = index_docs - bdtypep->lo();
                     ToggleEnt newent{above.m_comment + "["s + cvtToStr(index_docs) + "]",
-                                     new AstSel{varp->fileline(), above.m_varRefp->cloneTree(true),
-                                                index_code, 1},
-                                     new AstSel{varp->fileline(), above.m_chgRefp->cloneTree(true),
-                                                index_code, 1}};
+                                     new AstSel{varp->fileline(),
+                                                above.m_varRefp->cloneTree(false), index_code, 1},
+                                     new AstSel{varp->fileline(),
+                                                above.m_chgRefp->cloneTree(false), index_code, 1}};
                     toggleVarBottom(newent, varp);
                     newent.cleanup();
                 }
@@ -426,9 +426,9 @@ class CoverageVisitor final : public VNVisitor {
                 const int index_code = index_docs - adtypep->lo();
                 ToggleEnt newent{above.m_comment + "["s + cvtToStr(index_docs) + "]",
                                  new AstArraySel{varp->fileline(),
-                                                 above.m_varRefp->cloneTree(true), index_code},
+                                                 above.m_varRefp->cloneTree(false), index_code},
                                  new AstArraySel{varp->fileline(),
-                                                 above.m_chgRefp->cloneTree(true), index_code}};
+                                                 above.m_chgRefp->cloneTree(false), index_code}};
                 toggleVarRecurse(adtypep->subDTypep()->skipRefp(), depth + 1, newent, varp,
                                  chgVarp);
                 newent.cleanup();
@@ -438,9 +438,9 @@ class CoverageVisitor final : public VNVisitor {
                 const AstNodeDType* const subtypep = adtypep->subDTypep()->skipRefp();
                 const int index_code = index_docs - adtypep->lo();
                 ToggleEnt newent{above.m_comment + "["s + cvtToStr(index_docs) + "]",
-                                 new AstSel{varp->fileline(), above.m_varRefp->cloneTree(true),
+                                 new AstSel{varp->fileline(), above.m_varRefp->cloneTree(false),
                                             index_code * subtypep->width(), subtypep->width()},
-                                 new AstSel{varp->fileline(), above.m_chgRefp->cloneTree(true),
+                                 new AstSel{varp->fileline(), above.m_chgRefp->cloneTree(false),
                                             index_code * subtypep->width(), subtypep->width()}};
                 toggleVarRecurse(adtypep->subDTypep()->skipRefp(), depth + 1, newent, varp,
                                  chgVarp);
@@ -452,11 +452,12 @@ class CoverageVisitor final : public VNVisitor {
                      itemp = VN_AS(itemp->nextp(), MemberDType)) {
                     AstNodeDType* const subtypep = itemp->subDTypep()->skipRefp();
                     const int index_code = itemp->lsb();
-                    ToggleEnt newent{above.m_comment + "."s + itemp->name(),
-                                     new AstSel{varp->fileline(), above.m_varRefp->cloneTree(true),
-                                                index_code, subtypep->width()},
-                                     new AstSel{varp->fileline(), above.m_chgRefp->cloneTree(true),
-                                                index_code, subtypep->width()}};
+                    ToggleEnt newent{
+                        above.m_comment + "."s + itemp->name(),
+                        new AstSel{varp->fileline(), above.m_varRefp->cloneTree(false), index_code,
+                                   subtypep->width()},
+                        new AstSel{varp->fileline(), above.m_chgRefp->cloneTree(false), index_code,
+                                   subtypep->width()}};
                     toggleVarRecurse(subtypep, depth + 1, newent, varp, chgVarp);
                     newent.cleanup();
                 }
@@ -465,9 +466,9 @@ class CoverageVisitor final : public VNVisitor {
                      itemp = VN_AS(itemp->nextp(), MemberDType)) {
                     AstNodeDType* const subtypep = itemp->subDTypep()->skipRefp();
                     AstNodeExpr* const varRefp = new AstStructSel{
-                        varp->fileline(), above.m_varRefp->cloneTree(true), itemp->name()};
+                        varp->fileline(), above.m_varRefp->cloneTree(false), itemp->name()};
                     AstNodeExpr* const chgRefp = new AstStructSel{
-                        varp->fileline(), above.m_chgRefp->cloneTree(true), itemp->name()};
+                        varp->fileline(), above.m_chgRefp->cloneTree(false), itemp->name()};
                     varRefp->dtypep(subtypep);
                     chgRefp->dtypep(subtypep);
                     ToggleEnt newent{above.m_comment + "."s + itemp->name(), varRefp, chgRefp};
@@ -481,15 +482,15 @@ class CoverageVisitor final : public VNVisitor {
                 AstNodeDType* const subtypep = itemp->subDTypep()->skipRefp();
                 if (adtypep->packed()) {
                     ToggleEnt newent{above.m_comment + "."s + itemp->name(),
-                                     above.m_varRefp->cloneTree(true),
-                                     above.m_chgRefp->cloneTree(true)};
+                                     above.m_varRefp->cloneTree(false),
+                                     above.m_chgRefp->cloneTree(false)};
                     toggleVarRecurse(subtypep, depth + 1, newent, varp, chgVarp);
                     newent.cleanup();
                 } else {
                     AstNodeExpr* const varRefp = new AstStructSel{
-                        varp->fileline(), above.m_varRefp->cloneTree(true), itemp->name()};
+                        varp->fileline(), above.m_varRefp->cloneTree(false), itemp->name()};
                     AstNodeExpr* const chgRefp = new AstStructSel{
-                        varp->fileline(), above.m_chgRefp->cloneTree(true), itemp->name()};
+                        varp->fileline(), above.m_chgRefp->cloneTree(false), itemp->name()};
                     varRefp->dtypep(subtypep);
                     chgRefp->dtypep(subtypep);
                     ToggleEnt newent{above.m_comment + "."s + itemp->name(), varRefp, chgRefp};
@@ -734,7 +735,7 @@ class CoverageVisitor final : public VNVisitor {
             for (CoverTerm& term : expr) {
                 comment += (first ? "" : " && ") + term.m_emitV
                            + "==" + (term.m_objective ? "1" : "0");
-                AstNodeExpr* const clonep = term.m_exprp->cloneTree(true);
+                AstNodeExpr* const clonep = term.m_exprp->cloneTree(false);
                 AstNodeExpr* const termp = term.m_objective ? clonep : new AstLogNot{fl, clonep};
                 if (condp) {
                     condp = new AstLogAnd{fl, condp, termp};
@@ -932,11 +933,11 @@ class CoverageVisitor final : public VNVisitor {
             const int width = lhsp->dtypep()->width();
             const size_t expected = std::is_same<T_Oper, AstXor>::value ? 0x1 << width : width + 1;
             if (checkMaxExprs(expected)) return;
-            AstNodeExpr* unrolledp = new AstSel{fl, lhsp->cloneTree(true),
+            AstNodeExpr* unrolledp = new AstSel{fl, lhsp->cloneTree(false),
                                                 new AstConst{fl, static_cast<uint32_t>(width - 1)},
                                                 new AstConst{fl, 1}};
             for (int bit = width - 2; bit >= 0; bit--) {
-                AstSel* const selp = new AstSel{fl, lhsp->cloneTree(true),
+                AstSel* const selp = new AstSel{fl, lhsp->cloneTree(false),
                                                 new AstConst{fl, static_cast<uint32_t>(bit)},
                                                 new AstConst{fl, 1}};
                 unrolledp = new T_Oper{fl, selp, unrolledp};

--- a/src/V3Coverage.cpp
+++ b/src/V3Coverage.cpp
@@ -386,7 +386,7 @@ class CoverageVisitor final : public VNVisitor {
 
                 ToggleEnt newvec{""s, new AstVarRef{fl_nowarn, nodep, VAccess::READ},
                                  new AstVarRef{fl_nowarn, chgVarp, VAccess::WRITE}};
-                toggleVarRecurse(nodep->dtypeSkipRefp(), 0, newvec, nodep, chgVarp);
+                toggleVarRecurse(nodep->dtypeSkipRefp(), 0, newvec, nodep);
                 newvec.cleanup();
             }
         }
@@ -404,7 +404,7 @@ class CoverageVisitor final : public VNVisitor {
     }
 
     void toggleVarRecurse(AstNodeDType* dtypep, int depth,  // per-iteration
-                          const ToggleEnt& above, AstVar* varp, AstVar* chgVarp) {  // Constant
+                          const ToggleEnt& above, AstVar* varp) {  // Constant
         if (const AstBasicDType* const bdtypep = VN_CAST(dtypep, BasicDType)) {
             if (bdtypep->isRanged()) {
                 for (int index_docs = bdtypep->lo(); index_docs < bdtypep->hi() + 1;
@@ -429,8 +429,7 @@ class CoverageVisitor final : public VNVisitor {
                                                  above.m_varRefp->cloneTree(false), index_code},
                                  new AstArraySel{varp->fileline(),
                                                  above.m_chgRefp->cloneTree(false), index_code}};
-                toggleVarRecurse(adtypep->subDTypep()->skipRefp(), depth + 1, newent, varp,
-                                 chgVarp);
+                toggleVarRecurse(adtypep->subDTypep()->skipRefp(), depth + 1, newent, varp);
                 newent.cleanup();
             }
         } else if (const AstPackArrayDType* const adtypep = VN_CAST(dtypep, PackArrayDType)) {
@@ -442,8 +441,7 @@ class CoverageVisitor final : public VNVisitor {
                                             index_code * subtypep->width(), subtypep->width()},
                                  new AstSel{varp->fileline(), above.m_chgRefp->cloneTree(false),
                                             index_code * subtypep->width(), subtypep->width()}};
-                toggleVarRecurse(adtypep->subDTypep()->skipRefp(), depth + 1, newent, varp,
-                                 chgVarp);
+                toggleVarRecurse(adtypep->subDTypep()->skipRefp(), depth + 1, newent, varp);
                 newent.cleanup();
             }
         } else if (const AstStructDType* const adtypep = VN_CAST(dtypep, StructDType)) {
@@ -458,7 +456,7 @@ class CoverageVisitor final : public VNVisitor {
                                    subtypep->width()},
                         new AstSel{varp->fileline(), above.m_chgRefp->cloneTree(false), index_code,
                                    subtypep->width()}};
-                    toggleVarRecurse(subtypep, depth + 1, newent, varp, chgVarp);
+                    toggleVarRecurse(subtypep, depth + 1, newent, varp);
                     newent.cleanup();
                 }
             } else {
@@ -472,7 +470,7 @@ class CoverageVisitor final : public VNVisitor {
                     varRefp->dtypep(subtypep);
                     chgRefp->dtypep(subtypep);
                     ToggleEnt newent{above.m_comment + "."s + itemp->name(), varRefp, chgRefp};
-                    toggleVarRecurse(subtypep, depth + 1, newent, varp, chgVarp);
+                    toggleVarRecurse(subtypep, depth + 1, newent, varp);
                     newent.cleanup();
                 }
             }
@@ -484,7 +482,7 @@ class CoverageVisitor final : public VNVisitor {
                     ToggleEnt newent{above.m_comment + "."s + itemp->name(),
                                      above.m_varRefp->cloneTree(false),
                                      above.m_chgRefp->cloneTree(false)};
-                    toggleVarRecurse(subtypep, depth + 1, newent, varp, chgVarp);
+                    toggleVarRecurse(subtypep, depth + 1, newent, varp);
                     newent.cleanup();
                 } else {
                     AstNodeExpr* const varRefp = new AstStructSel{
@@ -494,7 +492,7 @@ class CoverageVisitor final : public VNVisitor {
                     varRefp->dtypep(subtypep);
                     chgRefp->dtypep(subtypep);
                     ToggleEnt newent{above.m_comment + "."s + itemp->name(), varRefp, chgRefp};
-                    toggleVarRecurse(subtypep, depth + 1, newent, varp, chgVarp);
+                    toggleVarRecurse(subtypep, depth + 1, newent, varp);
                     newent.cleanup();
                 }
             }


### PR DESCRIPTION
It removes unused argument of `toggleVarRecurse` and adds `const` to others. It also changes `cloneTree(true)` to `cloneTree(false)`, because we call it on expressions, which should never have `nextp()` set.