### PR TITLE
Fix of #6034: Associative arrays with enum keys lead to "Node has no type" verilation error

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -183,6 +183,7 @@ Pengcheng Xu
 Peter Debacker
 Peter Horvath
 Peter Monsson
+Petr Nohavica
 Philip Axer
 Philipp Wagner
 Pierre-Henri Horrein

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -4802,7 +4802,12 @@ class WidthVisitor final : public VNVisitor {
              patp = VN_AS(patp->nextp(), PatMember)) {
             patp->dtypep(arrayDtp->subDTypep());
             AstNodeExpr* const valuep = patternMemberValueIterate(patp);
-            AstNode* keyp = patp->keyp();
+            AstNode* keyp;
+            if (patp->varrefp()) {
+                keyp = patp->varrefp();
+            } else {
+                keyp = patp->keyp();
+            }
             if (!keyp) {
                 patp->v3error("Missing pattern key (need an expression then a ':')");
                 keyp = new AstConst{nodep->fileline(), AstConst::Signed32{}, 0};

--- a/test_regress/t/t_assoc_enum.py
+++ b/test_regress/t/t_assoc_enum.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2025 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile()
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_assoc_enum.v
+++ b/test_regress/t/t_assoc_enum.v
@@ -1,0 +1,44 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2025 by Wilson Snyder.
+// SPDX-License-Identifier: CC0-1.0
+
+`define stop $stop
+`define checkh(gotv,expv) do if ((gotv) !== (expv)) begin $write("%%Error: %s:%0d:  got=%0x exp=%0x (%s !== %s)\n", `__FILE__,`__LINE__, (gotv), (expv), `"gotv`", `"expv`"); `stop; end while(0);
+`define checks(gotv,expv) do if ((gotv) != (expv)) begin $write("%%Error: %s:%0d:  got='%s' exp='%s'\n", `__FILE__,`__LINE__, (gotv), (expv)); `stop; end while(0);
+
+class X;
+   typedef enum int {
+        INITIAL, RUNNING, SUSPENDED, COMPLETING, DONE
+   } state_t;
+
+   static string state_names[state_t] = '{
+        INITIAL:    "INITIAL",
+        RUNNING:    "RUNNING",
+        SUSPENDED:  "SUSPENDED",
+        COMPLETING: "COMPLETING",
+        DONE:       "DONE"
+   };
+   protected state_t state;
+
+   function new();
+      this.state = INITIAL;
+      `checks(state_names[this.state], "INITIAL");
+      this.state = RUNNING;
+      `checks(state_names[this.state], "RUNNING");
+   endfunction
+
+endclass
+
+module t;/*AUTOARG*/
+
+
+initial begin
+   X x = new;
+   $finish;
+end
+
+
+
+endmodule


### PR DESCRIPTION
Fix of #6034: the `keyp`  has to be set to `varrefp()` previously assigned in `V3LinkDot.cpp` in  `void visit(AstPatMember* nodep)` for the enum item case. 