### PR TITLE
Make driver.py exit on MacOS when child process finishes

### DIFF
--- a/test_regress/driver.py
+++ b/test_regress/driver.py
@@ -1734,6 +1734,9 @@ class VlTest:
                     try:
                         data = os.read(fd, 1)
                         self._run_output(data, logfh, tee)
+                        # Parent detects child termination by checking for b''
+                        if not data:
+                            break
                     except OSError:
                         break
 


### PR DESCRIPTION
Apparently os.read(fd, 1) returns b'' on MacOS when the child process exits, whereas it must be throwing an OSError on the platforms that Verilator developers typically use.

Tested by running t_x_assign_0.py with and without a breaking change of "--x-assign 0" to "--x-assign 1" and observed the expected test output and pass/fail summaries get printed in both cases. Without this change, the test runner never exits.

Fixes https://github.com/verilator/verilator/issues/6032
