### PR TITLE
Add test coverage for stream to packed N-dim arrays

### DIFF
--- a/test_regress/t/t_stream_unpack.v
+++ b/test_regress/t/t_stream_unpack.v
@@ -31,6 +31,8 @@ module t (/*AUTOARG*/);
       logic [15:0] d;
       logic [3:0] e [2];
       logic f [8];
+      logic [1:0][7:0] g;
+      logic [1:0][1:0][3:0] h;
 
       { >> bit {arr}} = bit6;
       `checkp(arr, "'{'h1, 'h1, 'h1, 'h0, 'h0, 'h0} ");
@@ -210,6 +212,12 @@ module t (/*AUTOARG*/);
       { << 2 {e, f}} = d;
       `checkp(e, "'{'h1, 'h7} ");
       `checkp(f, "'{'h0, 'h0, 'h1, 'h0, 'h0, 'h0, 'h1, 'h1} ");
+
+      g = { << 8 {16'hABCD}};
+      `checkh(g, 16'hCDAB);
+
+      h = { << 8 {16'hABCD}};
+      `checkh(h, 16'hCDAB);
 
       $write("*-* All Finished *-*\n");
       $finish;


### PR DESCRIPTION
In Verilator 5.024 this worked, and in 5.036 it had regressed and threw the following error at Verilation:

/V3EmitCFunc.h:1457: Unknown node type reached emitter: CVTPACKEDTOARRAY

This fails on v5.036 and succeeds on master at time of PR.

Closes https://github.com/verilator/verilator/issues/6031
