### PR TITLE
fix read-only linker error

### DIFF
--- a/src/V3ExecGraph.cpp
+++ b/src/V3ExecGraph.cpp
@@ -312,6 +312,7 @@ public:
 
 uint32_t ThreadSchedule::s_nextId = 0;
 std::unordered_map<const ExecMTask*, ThreadSchedule::MTaskState> ThreadSchedule::mtaskState{};
+constexpr double V3ExecGraph::ThreadSchedule::s_threadBoxWidth;
 
 //######################################################################
 // PackThreads


### PR DESCRIPTION
I'm running into a linker error when trying to build from `master` now:
```
/usr/bin/ld: V3ExecGraph.o: warning: relocation against `_ZN11V3ExecGraph14ThreadSchedule16s_threadBoxWidthE' in read-only section `.text._ZN11V3ExecGraph14ThreadSchedule20dumpDotFileEmitMTaskERKSt10unique_ptrISt14basic_ofstreamIcSt11char_traitsIcEESt14default_deleteIS5_EEPK9ExecMTaskRKS0_jRNSt7__debug6vectorIdSaIdEEE[_ZN11V3ExecGraph14ThreadSchedule20dumpDotFileEmitMTaskERKSt10unique_ptrISt14basic_ofstreamIcSt11char_trai
tsIcEESt14default_deleteIS5_EEPK9ExecMTaskRKS0_jRNSt7__debug6vectorIdSaIdEEE]'                                                                                                                                                                                                                                                                                                                                                           
/usr/bin/ld: V3ExecGraph.o: in function `double const& std::max<double>(double const&, double const&)':                                                                                                                                                                                                                                                                                                                                  
/usr/include/c++/10/bits/stl_algobase.h:261: undefined reference to `V3ExecGraph::ThreadSchedule::s_threadBoxWidth'                                                                                                                                                                                                                                                                                                                      
/usr/bin/ld: warning: creating DT_TEXTREL in a PIE
```

This PR resolves the issue for me.  I'm not certain, but I believe this stems from a behavioral change in gcc on version 11.  I'm on version 10 and the GitHub CI appears to be on version 11.

Do we have an official minimum version for the C++ compilers?  I see gcc version 10 mentioned here:
https://verilator.org/guide/latest/install.html?highlight=requirements
but I don't see a specific section on what compiler versions are supported.

Also, if we do want to support gcc 10 (if in fact this is a gcc version issue) I'm not sure how to make gcc 11 flag this.
