### PR TITLE
fix arrays of user defined types for parameter types

### DIFF
--- a/test_regress/t/t_type_param.v
+++ b/test_regress/t/t_type_param.v
@@ -40,6 +40,20 @@ module t();
    foo #(.bar (logic [ $bits(qux3) - 1 : 0]))
    foo_inst3 (.bar_size (bar_size3));
 
+   typedef struct packed {
+       logic foo;
+       logic bar;
+   } some_struct_t;
+   int bar_size4;
+
+   foo #(.bar (some_struct_t [7:0]))
+   foo_inst4 (.bar_size (bar_size4));
+
+   int bar_size5;
+
+   foo #(.bar (some_struct_t [2:0] [5:0]))
+   foo_inst5 (.bar_size (bar_size5));
+
    localparam bar_bits = 13;
    int bar_size_wrapper;
 
@@ -80,6 +94,16 @@ module t();
       if (bar_size3 != $bits(qux3)) begin
          $display("%m: bar_size3 != bits of qux3 (%0d, %0d)",
                  bar_size3, $bits(qux3));
+         $stop();
+      end
+      if (bar_size4 != $bits(some_struct_t)*8) begin
+         $display("%m: bar_size4 != bits of some_struct_t * 8 (%0d, %0d)",
+                 bar_size4, $bits(some_struct_t) * 8);
+         $stop();
+      end
+      if (bar_size5 != $bits(some_struct_t)*3*6) begin
+         $display("%m: bar_size5 != bits of some_struct_t * 3 * 6 (%0d, %0d)",
+                 bar_size5, $bits(some_struct_t) * 3 * 6);
          $stop();
       end
       if (bar_size_wrapper != bar_bits) begin


### PR DESCRIPTION
These feel like they may be related, but I can break them apart if not.

Something has changed wrt arrays of user defined types.  With my changes `t_cast`  says:
```
%Error-UNSUPPORTED: t/t_cast.v:104:19: Unsupported: static cast to 'enum{}t.enum_t[3:0]' from 'logic[63:0]'
                                     : ... note: In instance 't'
  104 |       es = enums_t'(64'h0001_0001_0001_0001);
      |                   ^
```

and `t_type_param` says:
```
%Error: t/t_type_param.v:49:16: Data type used where a non-data type is expected: 'some_struct_t'
   49 |    foo #(.bar (some_struct_t [7:0]))
      |                ^~~~~~~~~~~~~
        ... See the manual at https://verilator.org/verilator_doc.html?v=5.037 for more assistance.
%Error: Internal Error: t/t_type_param.v:49:30: ../V3Broken.cpp:168: Broken link in node (or something without maybePointedTo): 'fromp() && !(privateTypeTest<AstNodeExpr>(fromp()))' @ ./V3Ast__gen_impl.h:5839
   49 |    foo #(.bar (some_struct_t [7:0]))
      |                              ^
```

The former is because `WidthVisitor::visit(AstCast*)` runs `computeCastable()` on the to and from types and finds `UNSUPPORTED`, but I'm not immediately spotting what's changed in this visitor or in the castable code.  Perhaps it's something with the datatypes themselves?

Anyway, just digging in.  But posting now in case what's going on is obvious to others.