### PR TITLE
Test: lint_off waiver for missing file/module not working

### DIFF
--- a/test_regress/t/t_waive_no_module.py
+++ b/test_regress/t/t_waive_no_module.py
@@ -12,8 +12,6 @@ import vltest_bootstrap
 test.scenarios('vlt')
 test.top_filename = "t/t_waive_no_module.v"
 
-test.lint(verilator_flags2=[
-    "--lint-only -Wall t/t_waive_no_module.vlt"
-])
+test.lint(verilator_flags2=["--lint-only -Wall t/t_waive_no_module.vlt"])
 
 test.passes()

--- a/test_regress/t/t_waive_no_module.py
+++ b/test_regress/t/t_waive_no_module.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2024 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('vlt')
+test.top_filename = "t/t_waive_no_module.v"
+
+test.lint(verilator_flags2=[
+    "--lint-only -Wall t/t_waive_no_module.vlt"
+])
+
+test.passes()

--- a/test_regress/t/t_waive_no_module.v
+++ b/test_regress/t/t_waive_no_module.v
@@ -1,0 +1,22 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2012 by Wilson Snyder.
+// SPDX-License-Identifier: CC0-1.0
+
+/* verilator lint_off UNUSEDSIGNAL */
+
+module t_waive_no_module(
+   input logic clk,
+   input logic rst,
+   input logic [7:0] abc
+);
+   // This module is not defined but we have waived it in the .vlt file.
+   some_module_name #(
+      .SOME_PARAM(1)
+   ) u_some_module_name (
+      .clk(clk),
+      .rst(rst),
+      .abc(abc)
+   );
+endmodule

--- a/test_regress/t/t_waive_no_module.vlt
+++ b/test_regress/t/t_waive_no_module.vlt
@@ -1,0 +1,2 @@
+`verilator_config
+lint_off -file "*.v" -match "Cannot find file containing module: 'some_module_name'"


### PR DESCRIPTION
This worked in Verilator v5.024 to waive missing modules when linting. I check the equivalent example on 5.024 using the older .pl test regress style and the same .vlt file. I believe it broke in 5.028, based on reviewing the relevant commit history. But, I've also now tested it at mainline (2025.05.29, so that is v5.037 I think) and it is now broken and results in an error -- basically the waiver was not respected.

```text
vlt/t_waive_no_module: ==================================================
	export GCOV_PREFIX_STRIP='99'
	export GCOV_PREFIX='/Users/paul-demo/git/verilator/test_regress/obj_dist/gcov_1'
	perl /Users/paul-demo/git/verilator/bin/verilator --prefix Vt_waive_no_module -cc -Mdir obj_vlt/t_waive_no_module --fdedup --debug-check --comp-limit-members 10 --x-assign unique --lint-only -Wall t/t_waive_no_module.vlt --clk clk -f input.vc +define+TEST_OBJ_DIR=obj_vlt/t_waive_no_module +define+TEST_DUMPFILE=obj_vlt/t_waive_no_module/simx.vcd t/t_waive_no_module.v   > obj_vlt/t_waive_no_module/vlt_compile.log
%Error: t/t_waive_no_module.v:15:4: Cannot find file containing module: 'some_module_name'
   15 |    some_module_name #(
      |    ^~~~~~~~~~~~~~~~
        ... See the manual at https://verilator.org/verilator_doc.html?v=5.037 for more assistance.
        ... Looked in:
             t/some_module_name
             t/some_module_name.v
             t/some_module_name.sv
             some_module_name
             some_module_name.v
             some_module_name.sv
             obj_vlt/t_waive_no_module/some_module_name
             obj_vlt/t_waive_no_module/some_module_name.v
             obj_vlt/t_waive_no_module/some_module_name.sv
%Error: Exiting due to 1 error(s)
%Warning: vlt/t_waive_no_module: Exec of verilator failed: %Error: t/t_waive_no_module.v:15:4: Cannot find file containing module: 'some_module_name'
vlt/t_waive_no_module: %Error: Exec of verilator failed: %Error: t/t_waive_no_module.v:15:4: Cannot find file containing module: 'some_module_name'
vlt/t_waive_no_module: FAILED: Exec of verilator failed: %Error: t/t_waive_no_module.v:15:4: Cannot find file containing module: 'some_module_name'
==SUMMARY: Passed 0  Failed 1  Time 0:00

======================================================================
#vlt/t_waive_no_module: %Error: Exec of verilator failed: %Error: t/t_waive_no_module.v:15:4: Cannot find file containing module: 'some_module_name'
		make && test_regress/t/t_waive_no_module.py  --vlt
==TESTS DONE, FAILED: Passed 0  Failed 1  Time 0:00
```
