### PR TITLE
Automatically publish scheduled RTLMeter results

### DIFF
--- a/.github/workflows/reusable-rtlmeter-run.yml
+++ b/.github/workflows/reusable-rtlmeter-run.yml
@@ -16,8 +16,15 @@ on:
         description: "Compiler to use: 'gcc' or 'clang'"
         type: string
         required: true
+      # Note: The combination of 'cases' and 'run-name' must be unique for all
+      # invocations of this workflow within a run of the parent workflow.
+      # These two are used together to generate a unique results file name.
       cases:
         description: "RTLMeter cases to run"
+        type: string
+        required: true
+      run-name:
+        description: "Run name (identifier) to add to collated results"
         type: string
         required: true
       compileArgs:
@@ -93,10 +100,10 @@ jobs:
         id: results
         working-directory: rtlmeter
         run: |
-          # 'inputs.cases' has special characters, use its md5sum as unique id
-          hash=$(md5sum <<< '${{ inputs.cases }}' | awk '{print $1}')
+          # Use 'inputs.cases' and 'inputs.run-name' to generate a unique file name
+          hash=$(md5sum <<< '${{ inputs.cases }} ${{ inputs.run-name }}' | awk '{print $1}')
           echo "hash=${hash}" >> $GITHUB_OUTPUT
-          ./rtlmeter collate > ../results-${hash}.json
+          ./rtlmeter collate --runName "${{ inputs.run-name }}"  > ../results-${hash}.json
 
       - name: Report results
         working-directory: rtlmeter
@@ -107,7 +114,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           path: results-${{ steps.results.outputs.hash }}.json
-          name: rtlmeter-results-${{ inputs.runs-on }}-${{ inputs.cc }}-${{ steps.results.outputs.hash }}
+          name: rtlmeter-results-${{ steps.results.outputs.hash }}
           overwrite: true
           retention-days: 2
 

--- a/.github/workflows/rtlmeter.yml
+++ b/.github/workflows/rtlmeter.yml
@@ -48,6 +48,7 @@ jobs:
       runs-on: ubuntu-24.04
       cc: gcc
       cases: ${{ matrix.cases }}
+      run-name: "gcc"
       compileArgs: ""
       executeArgs: ""
     strategy:
@@ -88,6 +89,7 @@ jobs:
       runs-on: ubuntu-24.04
       cc: clang
       cases: ${{ matrix.cases }}
+      run-name: "clang --threads 4"
       compileArgs: "--threads 4"
       executeArgs: ""
     strategy:
@@ -128,39 +130,24 @@ jobs:
     if: ${{ (contains(needs.*.result, 'success') || contains(needs.*.result, 'failure')) && !cancelled() }}
     runs-on: ubuntu-24.04
     steps:
-      - name: Download all GCC results
+      - name: Download all results
         uses: actions/download-artifact@v4
         with:
-          pattern: rtlmeter-results-ubuntu-24.04-gcc-*
-          path: all-results-gcc-${{ github.run_id }}
+          pattern: rtlmeter-results-*
+          path: all-results-${{ github.run_id }}
           merge-multiple: true
-      - name: Download all Clang results
-        uses: actions/download-artifact@v4
-        with:
-          pattern: rtlmeter-results-ubuntu-24.04-clang-*
-          path: all-results-clang-${{ github.run_id }}
-          merge-multiple: true
-      - name: Tar up results
+      - name: Tar up all results into single archive
         run: |
-          # Ensure combined result directories exists in case of no results
-          mkdir -p all-results-gcc-${{ github.run_id }}
-          mkdir -p all-results-clang-${{ github.run_id }}
-          ls -la all-results*
-          # Tar up each directory
-          tar --posix -c -z -f all-results-gcc-${{ github.run_id }}.tar.gz all-results-gcc-${{ github.run_id }}
-          tar --posix -c -z -f all-results-clang-${{ github.run_id }}.tar.gz all-results-clang-${{ github.run_id }}
-      - name: Upload combined GCC results
+          # Ensure combined result directory exists in case of no results
+          mkdir -p all-results-${{ github.run_id }}
+          ls -la all-results-${{ github.run_id }}
+          # Tar up the results directory
+          tar --posix -c -z -f all-results-${{ github.run_id }}.tar.gz all-results-${{ github.run_id }}
+      - name: Upload combined results
         uses: actions/upload-artifact@v4
         with:
-          path: all-results-gcc-${{ github.run_id }}.tar.gz
-          name: "all-results-gcc"
-          overwrite: true
-          retention-days: 30
-      - name: Upload combined Clang results
-        uses: actions/upload-artifact@v4
-        with:
-          path: all-results-clang-${{ github.run_id }}.tar.gz
-          name: "all-results-clang"
+          path: all-results-${{ github.run_id }}.tar.gz
+          name: all-results
           overwrite: true
           retention-days: 30
 
@@ -173,15 +160,13 @@ jobs:
       - name: Download combined results
         uses: actions/download-artifact@v4
         with:
-          pattern: all-results-*
+          name: all-results
           path: results
-          merge-multiple: true
       - name: Extract combined results
         working-directory: results
         run: |
-          for f in $(find . -name "all-results*.tar.gz");  do  \
-            tar xzfv $f; \
-          done
+            tar xzfv all-results-${{ github.run_id }}.tar.gz
+            ls -la
       # Pushing to verilator/verilator-rtlmeter-results requires elevated permissions
       - name: Generate access token
         id: generate-token
@@ -201,15 +186,9 @@ jobs:
         id: import-results
         working-directory: verilator-rtlmeter-results
         run: |
-          # Import 'gcc' results
-          for f in $(find ../results -wholename "*all-results-gcc-*/*.json"); do \
+          for f in $(find ../results -name "*.json"); do \
             echo "Importing $f"; \
-            ./bin/add-rtlmeter-result --descr "gcc" $f; \
-          done
-          # Import 'clang --threads 4' results
-          for f in $(find ../results -wholename "*all-results-clang-*/*.json"); do \
-            echo "Importing $f"; \
-            ./bin/add-rtlmeter-result --descr "clang --threads 4" $f; \
+            ./bin/add-rtlmeter-result $f; \
           done
           test -z "$(git status --porcelain)" || echo "valid=1" >> "$GITHUB_OUTPUT"
       - name: Push to verilator-rtlmeter-results

--- a/.github/workflows/rtlmeter.yml
+++ b/.github/workflows/rtlmeter.yml
@@ -197,7 +197,6 @@ jobs:
           repository: "verilator/verilator-rtlmeter-results"
           token: ${{ steps.generate-token.outputs.token }}
           path: verilator-rtlmeter-results
-          fetch-depth: 20
       - name: Import results
         id: import-results
         working-directory: verilator-rtlmeter-results
@@ -221,6 +220,4 @@ jobs:
           git config --global user.name "github action"
           git add .
           git commit -m "Verilator CI: Results of 'RTLMeter' workflow run #${{ github.run_number }}"
-          git log --oneline | head -10
-          git show --quiet | cat
           git push origin

--- a/.github/workflows/rtlmeter.yml
+++ b/.github/workflows/rtlmeter.yml
@@ -154,6 +154,11 @@ jobs:
   publish-results:
     name: Publish results to verilator/verilator-rtlmeter-results
     needs: combine-results
+    # Only run on scheduled builds on the main repository. We also restrict
+    # the publishing to run only on the first run_attempt. This is required
+    # to prevent multiple uploads the same day (if rerunning), as the
+    # dashboard UI currently assumes there is only one data point per
+    # calendar day. Results from reruns can be imported manually if needed.
     if: ${{ github.event_name == 'schedule' && github.repository == 'verilator/verilator' && github.run_attempt == 1 && contains(needs.*.result, 'success') && !cancelled() }}
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/rtlmeter.yml
+++ b/.github/workflows/rtlmeter.yml
@@ -163,3 +163,64 @@ jobs:
           name: "all-results-clang"
           overwrite: true
           retention-days: 30
+
+  publish-results:
+    name: Publish results to verilator/verilator-rtlmeter-results
+    needs: combine-results
+    if: ${{ github.event_name == 'schedule' && github.repository == 'verilator/verilator' && github.run_attempt == 1 && contains(needs.*.result, 'success') && !cancelled() }}
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Download combined results
+        uses: actions/download-artifact@v4
+        with:
+          pattern: all-results-*
+          path: results
+          merge-multiple: true
+      - name: Extract combined results
+        working-directory: results
+        run: |
+          for f in $(find . -name "all-results*.tar.gz");  do  \
+            tar xzfv $f; \
+          done
+      # Pushing to verilator/verilator-rtlmeter-results requires elevated permissions
+      - name: Generate access token
+        id: generate-token
+        uses: actions/create-github-app-token@v2.0.6
+        with:
+          app-id: ${{ vars.RTLMETER_RESULTS_CI_APP_ID }}
+          private-key: ${{ secrets.RTLMETER_RESULTS_CI_APP_PRIVATE_KEY }}
+          owner: verilator
+          repositories: verilator-rtlmeter-results
+      - name: Checkout verilator-rtlmeter-results
+        uses: actions/checkout@v4
+        with:
+          repository: "verilator/verilator-rtlmeter-results"
+          token: ${{ steps.generate-token.outputs.token }}
+          path: verilator-rtlmeter-results
+          fetch-depth: 20
+      - name: Import results
+        id: import-results
+        working-directory: verilator-rtlmeter-results
+        run: |
+          # Import 'gcc' results
+          for f in $(find ../results -wholename "*all-results-gcc-*/*.json"); do \
+            echo "Importing $f"; \
+            ./bin/add-rtlmeter-result --descr "gcc" $f; \
+          done
+          # Import 'clang --threads 4' results
+          for f in $(find ../results -wholename "*all-results-clang-*/*.json"); do \
+            echo "Importing $f"; \
+            ./bin/add-rtlmeter-result --descr "clang --threads 4" $f; \
+          done
+          test -z "$(git status --porcelain)" || echo "valid=1" >> "$GITHUB_OUTPUT"
+      - name: Push to verilator-rtlmeter-results
+        if: ${{ steps.import-results.outputs.valid }}
+        working-directory: verilator-rtlmeter-results
+        run: |
+          git config --global user.email "action@example.com"
+          git config --global user.name "github action"
+          git add .
+          git commit -m "Verilator CI: Results of 'RTLMeter' workflow run #${{ github.run_number }}"
+          git log --oneline | head -10
+          git show --quiet | cat
+          git push origin


### PR DESCRIPTION
Update RTLMeter workflow to automatically push the performance numbers from scheduled (nightly) runs to verilator/verilator-rtlmeter-results

I tested this out on my fork and on verilator/verilator using manual runs.

Access control to verilator/verilator-rtlmeter-results is managed via https://github.com/actions/create-github-app-token, as described in the README there, which I have set up.

(Only runs on verilator/verilator)