### PR TITLE
Emit DPI temporary 'for' loops only when needed

### DIFF
--- a/src/V3Task.cpp
+++ b/src/V3Task.cpp
@@ -1944,6 +1944,7 @@ string V3Task::assignInternalToDpi(AstVar* portp, bool isPtr, const string& frSu
     // But for now, we'll just text-bash it.
     const string frName = frPrefix + portp->name() + frSuffix;
     const string toName = portp->name() + toSuffix;
+    const string idx = portp->name() + "__Vidx";
     size_t unpackSize = 1;  // non-unpacked array is treated as size 1
     int unpackDim = 0;
     if (AstUnpackArrayDType* const unpackp
@@ -1954,17 +1955,23 @@ string V3Task::assignInternalToDpi(AstVar* portp, bool isPtr, const string& frSu
     }
     if (portp->basicp()->isDpiBitVec() || portp->basicp()->isDpiLogicVec()) {
         const bool isBit = portp->basicp()->isDpiBitVec();
-        const string idx = portp->name() + "__Vidx";
-        stmt = "for (size_t " + idx + " = 0; " + idx + " < " + cvtToStr(unpackSize) + "; ++" + idx
-               + ") ";
+        const bool needsFor = unpackSize > 1;
+        if (needsFor) {
+            stmt = "for (size_t " + idx + " = 0; " + idx + " < " + cvtToStr(unpackSize) + "; ++"
+                   + idx + ") ";
+        }
+
         stmt += (isBit ? "VL_SET_SVBV_"s : "VL_SET_SVLV_"s)
                 + portp->dtypep()->skipRefp()->charIQWN() + "(" + cvtToStr(portp->width()) + ", ";
-        stmt += toName + " + " + cvtToStr(portp->dtypep()->skipRefp()->widthWords()) + " * " + idx
-                + ", ";
+        stmt += toName;
+        if (needsFor) {
+            stmt += " + " + cvtToStr(portp->dtypep()->skipRefp()->widthWords()) + " * " + idx;
+        }
+        stmt += ", ";
         if (unpackDim > 0) {  // Access multi-dimensional array as a 1D array
             stmt += "(&" + frName;
             for (int i = 0; i < unpackDim; ++i) stmt += "[0]";
-            stmt += ")[" + idx + "])";
+            stmt += ")[" + (needsFor ? idx : "0") + "])";
         } else {
             stmt += frName + ")";
         }
@@ -1973,11 +1980,13 @@ string V3Task::assignInternalToDpi(AstVar* portp, bool isPtr, const string& frSu
             = portp->basicp() && portp->basicp()->keyword() == VBasicDTypeKwd::CHANDLE;
         const bool isString
             = portp->basicp() && portp->basicp()->keyword() == VBasicDTypeKwd::STRING;
-        const string idx = portp->name() + "__Vidx";
-        stmt = "for (size_t " + idx + " = 0; " + idx + " < " + cvtToStr(unpackSize) + "; ++" + idx
-               + ") ";
+        const string unpackAt = unpackSize > 1 ? "[" + idx + "]" : "[0]";
         if (unpackDim > 0) {
-            stmt += toName + "[" + idx + "]";
+            const string forStmt = unpackSize > 1
+                                       ? "for (size_t " + idx + " = 0; " + idx + " < "
+                                             + cvtToStr(unpackSize) + "; ++" + idx + ") "
+                                       : "";
+            stmt += forStmt + toName + unpackAt;
         } else {
             if (isPtr) stmt += "*";  // DPI outputs are pointers
             stmt += toName;
@@ -1990,7 +1999,7 @@ string V3Task::assignInternalToDpi(AstVar* portp, bool isPtr, const string& frSu
         if (unpackDim > 0) {
             stmt += "(&" + frName;
             for (int i = 0; i < unpackDim; ++i) stmt += "[0]";
-            stmt += ")[" + idx + "]";
+            stmt += ")" + unpackAt;
         } else {
             stmt += frName;
         }


### PR DESCRIPTION
This PR reduces size of emitted code with DPIs. It decreased C++ bytes written on `t_hier_block_perf` test by about 1%.

Emitted code for `t_hier_block_perf` test

old:
```cpp
VL_INLINE_OPT void Vt_hier_block_perf___024root____Vdpiimwrap_t__DOT__genblk1__BRA__0__KET____DOT__core__DOT__test__DOT__Test_protectlib_combo_update_TOP(QData/*63:0*/ handle___05FV, IData/*31:0*/ &rdata, IData/*31:0*/ &rdata2, CData/*0:0*/ we, SData/*15:0*/ sel, IData/*31:0*/ wdata, QData/*63:0*/ &Test_protectlib_combo_update__Vfuncrtn) {
    VL_DEBUG_IF(VL_DBG_MSGF("+    Vt_hier_block_perf___024root____Vdpiimwrap_t__DOT__genblk1__BRA__0__KET____DOT__core__DOT__test__DOT__Test_protectlib_combo_update_TOP\n"); );
    // Body
    void* handle___05FV__Vcvt;
    for (size_t handle___05FV__Vidx = 0; handle___05FV__Vidx < 1; ++handle___05FV__Vidx) handle___05FV__Vcvt = VL_CVT_Q_VP(handle___05FV);
    svLogicVecVal rdata__Vcvt[1];
    svLogicVecVal rdata2__Vcvt[1];
    svLogic we__Vcvt;
    for (size_t we__Vidx = 0; we__Vidx < 1; ++we__Vidx) we__Vcvt = we;
    svLogicVecVal sel__Vcvt[1];
    for (size_t sel__Vidx = 0; sel__Vidx < 1; ++sel__Vidx) VL_SET_SVLV_I(16, sel__Vcvt + 1 * sel__Vidx, sel);
    svLogicVecVal wdata__Vcvt[1];
    for (size_t wdata__Vidx = 0; wdata__Vidx < 1; ++wdata__Vidx) VL_SET_SVLV_I(32, wdata__Vcvt + 1 * wdata__Vidx, wdata);
    long long Test_protectlib_combo_update__Vfuncrtn__Vcvt;
    Test_protectlib_combo_update__Vfuncrtn__Vcvt = Test_protectlib_combo_update(handle___05FV__Vcvt, rdata__Vcvt, rdata2__Vcvt, we__Vcvt, sel__Vcvt, wdata__Vcvt);
    rdata = VL_SET_I_SVLV(rdata__Vcvt);
    rdata2 = VL_SET_I_SVLV(rdata2__Vcvt);
    Test_protectlib_combo_update__Vfuncrtn = Test_protectlib_combo_update__Vfuncrtn__Vcvt;
}

```

new:
```cpp
VL_INLINE_OPT void Vt_hier_block_perf___024root____Vdpiimwrap_t__DOT__genblk1__BRA__0__KET____DOT__core__DOT__test__DOT__Test_protectlib_combo_update_TOP(QData/*63:0*/ handle___05FV, IData/*31:0*/ &rdata, IData/*31:0*/ &rdata2, CData/*0:0*/ we, SData/*15:0*/ sel, IData/*31:0*/ wdata, QData/*63:0*/ &Test_protectlib_combo_update__Vfuncrtn) {
    VL_DEBUG_IF(VL_DBG_MSGF("+    Vt_hier_block_perf___024root____Vdpiimwrap_t__DOT__genblk1__BRA__0__KET____DOT__core__DOT__test__DOT__Test_protectlib_combo_update_TOP\n"); );
    // Body
    void* handle___05FV__Vcvt;
    handle___05FV__Vcvt = VL_CVT_Q_VP(handle___05FV);
    svLogicVecVal rdata__Vcvt[1];
    svLogicVecVal rdata2__Vcvt[1];
    svLogic we__Vcvt;
    we__Vcvt = we;
    svLogicVecVal sel__Vcvt[1];
    VL_SET_SVLV_I(16, sel__Vcvt, sel);
    svLogicVecVal wdata__Vcvt[1];
    VL_SET_SVLV_I(32, wdata__Vcvt, wdata);
    long long Test_protectlib_combo_update__Vfuncrtn__Vcvt;
    Test_protectlib_combo_update__Vfuncrtn__Vcvt = Test_protectlib_combo_update(handle___05FV__Vcvt, rdata__Vcvt, rdata2__Vcvt, we__Vcvt, sel__Vcvt, wdata__Vcvt);
    rdata = VL_SET_I_SVLV(rdata__Vcvt);
    rdata2 = VL_SET_I_SVLV(rdata2__Vcvt);
    Test_protectlib_combo_update__Vfuncrtn = Test_protectlib_combo_update__Vfuncrtn__Vcvt;
}
```