### PR TITLE
V3Param: follow typedef nodes when checking for nodes to relink

### DIFF
--- a/src/V3Param.cpp
+++ b/src/V3Param.cpp
@@ -1167,7 +1167,7 @@ class ParamVisitor final : public VNVisitor {
     void relinkDots() {
         for (AstDot* const dotp : m_dots) {
             const AstClassOrPackageRef* const classRefp = VN_AS(dotp->lhsp(), ClassOrPackageRef);
-            const AstClass* const lhsClassp = VN_AS(classRefp->classOrPackageNodep(), Class);
+            const AstClass* const lhsClassp = VN_AS(classRefp->classOrPackageSkipp(), Class);
             AstClassOrPackageRef* const rhsp = VN_AS(dotp->rhsp(), ClassOrPackageRef);
             for (auto* itemp = lhsClassp->membersp(); itemp; itemp = itemp->nextp()) {
                 if (itemp->name() == rhsp->name()) {
@@ -1323,7 +1323,7 @@ class ParamVisitor final : public VNVisitor {
         // by a class with actual parameter values.
         const AstClass* lhsClassp = nullptr;
         const AstClassOrPackageRef* const classRefp = VN_CAST(nodep->lhsp(), ClassOrPackageRef);
-        if (classRefp) lhsClassp = VN_CAST(classRefp->classOrPackageNodep(), Class);
+        if (classRefp) lhsClassp = VN_CAST(classRefp->classOrPackageSkipp(), Class);
         AstNode* rhsDefp = nullptr;
         AstClassOrPackageRef* const rhsp = VN_CAST(nodep->rhsp(), ClassOrPackageRef);
         if (rhsp) rhsDefp = rhsp->classOrPackageNodep();

--- a/test_regress/t/t_forward_nested_typedef.v
+++ b/test_regress/t/t_forward_nested_typedef.v
@@ -6,12 +6,18 @@
 
 typedef class Bar;
 typedef Bar Baz;
+typedef Quux #(16, 32) Quux_t;
+typedef Quux_t Quuux_t;
 
 module t;
     initial begin
         Bar::Qux::boo(1);
         Baz::Qux::boo(1);
+        Quux_t::Qux::boo(1);
+        Quuux_t::Qux::boo(1);
         if (!Bar::Qux::finish) $stop;
+        if (!Quux_t::Qux::finish) $stop;
+        if (!Quuux_t::Qux::finish) $stop;
         $write("*-* All Finished *-*\n");
         $finish;
     end
@@ -33,4 +39,9 @@ endclass
 
 class Bar;
     typedef Foo#(Bar) Qux;
+endclass
+
+class Quux #(PARA_A = 1, PARA_B = 2);
+    typedef Quux #(PARA_A, PARA_B) this_t;
+    typedef Foo#(this_t) Qux;
 endclass


### PR DESCRIPTION
This PR fixes usage of typedef types that contains parameters.