### PR TITLE
Fix unpacked to packed parameter assignment (#6088)

### DIFF
--- a/src/V3Const.cpp
+++ b/src/V3Const.cpp
@@ -2752,11 +2752,6 @@ class ConstVisitor final : public VNVisitor {
             } else {
                 AstNode* const fromp = nodep->fromp()->unlinkFrBack();
                 nodep->replaceWithKeepDType(fromp);
-                if (VN_IS(fromp->dtypep()->skipRefp(), NodeArrayDType)) {
-                    // Strip off array to find what array references
-                    fromp->dtypeFrom(
-                        VN_AS(fromp->dtypep()->skipRefp(), NodeArrayDType)->subDTypep());
-                }
                 VL_DO_DANGLING(pushDeletep(nodep), nodep);
             }
         }

--- a/test_regress/t/t_unpacked_to_packed_param.py
+++ b/test_regress/t/t_unpacked_to_packed_param.py
@@ -8,7 +8,6 @@
 # SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
 
 import vltest_bootstrap
-import glob
 
 test.scenarios("vlt")
 

--- a/test_regress/t/t_unpacked_to_packed_param.py
+++ b/test_regress/t/t_unpacked_to_packed_param.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2024 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+import glob
+
+test.scenarios("vlt")
+
+test.compile()
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_unpacked_to_packed_param.v
+++ b/test_regress/t/t_unpacked_to_packed_param.v
@@ -1,0 +1,38 @@
+// DESCRIPTION: Verilator: Confirm x randomization stability
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2025 by Wilson Snyder.
+// SPDX-License-Identifier: CC0-1.0
+
+module t (/*AUTOARG*/
+    // Inputs
+    clk
+    );
+
+    input clk;
+
+    always @(posedge clk) begin
+        $write("*-* All Finished *-*\n");
+        $finish;
+    end
+
+    localparam logic [1:0][7:0] foo_unpacked [2:0] = '{"12", "34", "56"};
+    localparam logic [2:0][1:0][7:0] foo_packed = '{"12", "34", "56"};
+
+    sub #(
+        .foos ({foo_unpacked[0], foo_unpacked[1], foo_unpacked[2]})
+    ) the_unpacked_sub();
+
+    sub #(
+        .foos ({foo_packed[0], foo_packed[1], foo_packed[2]})
+    ) the_packed_sub();
+
+endmodule
+
+module sub #(
+    parameter logic [2:0][1:0][7:0] foos
+);
+    initial begin
+        if (foos != "563412") $stop;
+    end
+endmodule


### PR DESCRIPTION
I don't know what this bit of code I deleted was intended to do, but it was causing unpacked arrays being assigned to packed array parameters to produce incorrect results.  Also, nothing else appears to need it.

More specifically, it was causing this during V3Param:
```
CONST 0x55555718f2c0 <e1333#> {f23bh} @dt=0x555557186240@(w8)  16'h3132
```

Where the 16 bit constant was being widthed to 8 bits.

I believe `fromp` is already sufficiently de-arrayed and that we don't need to go any further.  But I could be missing something.