### PR TITLE
Support 1-bit params with -G and -pvalue (#6051)

### DIFF
--- a/src/V3AstNodes.cpp
+++ b/src/V3AstNodes.cpp
@@ -425,7 +425,7 @@ AstConst* AstConst::parseParamLiteral(FileLine* fl, const string& literal) {
         // the Verilog literal parser.
         char* endp;
         const int v = strtol(literal.c_str(), &endp, 0);
-        if ((v != 0) && (endp[0] == 0)) {  // C literal
+        if ((v != 0) && (v != 1) && (endp[0] == 0)) {  // C literal
             return new AstConst{fl, AstConst::Signed32{}, v};
         } else {  // Try a Verilog literal (fatals if not)
             return new AstConst{fl, AstConst::StringToParse{}, literal.c_str()};

--- a/test_regress/t/t_flag_parameter.v
+++ b/test_regress/t/t_flag_parameter.v
@@ -57,6 +57,11 @@ module t;
    parameter int71 = 1;
    parameter int72 = 1;
 
+   parameter bit bit0to0 = 0;
+   parameter bit bit1to1 = 1;
+   parameter bit bit0to1 = 0;
+   parameter bit bit1to0 = 1;
+
    initial begin
       `check(string1,"New String");
       `check(string2,"New String");
@@ -88,6 +93,10 @@ module t;
       `check(int62,32'hdeadbeef);
       `check(int71,-1000);
       `check(int72,-1000);
+      `check(bit0to0, 1'b0);
+      `check(bit1to1, 1'b1);
+      `check(bit0to1, 1'b1);
+      `check(bit1to0, 1'b0);
 
       // Check parameter assigned simple integer literal is signed
       if ((int11 << 27) >>> 31 != -1) $stop;

--- a/test_regress/t/t_flag_parameter.vc
+++ b/test_regress/t/t_flag_parameter.vc
@@ -28,3 +28,11 @@
 -pvalue+int62="32'hdead_beef"
 -Gint71=-1000
 -pvalue+int72=-1000
+-Gbit0to0=0
+-pvalue+bit0to0=0
+-Gbit1to1=1
+-pvalue+bit1to1=1
+-Gbit0to1=1
+-pvalue+bit0to1=1
+-Gbit1to0=0
+-pvalue+bit1to0=0


### PR DESCRIPTION
parseParamLiteral already checks for (v != 0) in which case it skips the Signed32(strtol(..)) and falls back to verilog literal which takes the exact required width. This PR simply adds a check for (v != 1) so that both 0 and 1 result in 1-bit AstConst rather than 0 being a 1-bit AstConst and 1 being a 32-bit AstConst. Added test coverage.

We appreciate your contributing to Verilator.  If this is your first commit, please add your name to docs/CONTRIBUTORS, and read our contributing guidelines in docs/CONTRIBUTING.rst.
