### PR TITLE
V3Scope: Check upper scopes when searching for scope in VarRef 

### DIFF
--- a/src/V3Scope.cpp
+++ b/src/V3Scope.cpp
@@ -68,7 +68,12 @@ class ScopeVisitor final : public VNVisitor {
                 UASSERT_OBJ(it2 != m_packageScopes.end(), nodep, "Can't locate package scope");
                 scopep = it2->second;
             }
-            const auto it3 = m_varScopes.find(std::make_pair(nodep->varp(), scopep));
+            VarScopeMap::const_iterator it3 = m_varScopes.end();
+            while ((it3 = m_varScopes.find(std::make_pair(nodep->varp(), scopep)))
+                       == m_varScopes.end()
+                   && scopep != nullptr) {
+                scopep = scopep->aboveScopep();
+            }
             UASSERT_OBJ(it3 != m_varScopes.end(), nodep, "Can't locate varref scope");
             AstVarScope* const varscp = it3->second;
             nodep->varScopep(varscp);

--- a/test_regress/t/t_varref_scope.py
+++ b/test_regress/t/t_varref_scope.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2025 by Wilson Snyder. This program is free software; you can
+# redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile()
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_varref_scope.v
+++ b/test_regress/t/t_varref_scope.v
@@ -23,4 +23,3 @@ module t;
     $finish;
   end
 endmodule
-

--- a/test_regress/t/t_varref_scope.v
+++ b/test_regress/t/t_varref_scope.v
@@ -1,0 +1,26 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2025 by Antmicro.
+// SPDX-License-Identifier: CC0-1.0
+
+module t;
+  logic read_data = 1;
+  class seq_item;
+    logic read_data;
+  endclass
+  class monitor_concrete;
+    task monitor(seq_item item);
+      item.read_data = read_data;
+    endtask
+  endclass
+  initial begin
+    monitor_concrete mon = new();
+    seq_item item = new();
+    mon.monitor(item);
+    if (!item.read_data) $stop;
+    $write("*-* All Finished *-*\n");
+    $finish;
+  end
+endmodule
+


### PR DESCRIPTION
As described in `23.9 Scope rules` of IEEE, if identifier isn't declared in local scope, we should search scopes upward until we find valid identifier.