### PR TITLE
Fileline for nested hier_blocks' workers error

### DIFF
--- a/src/V3Config.h
+++ b/src/V3Config.h
@@ -54,7 +54,7 @@ public:
     static void applyVarAttr(AstNodeModule* modulep, AstNodeFTask* ftaskp, AstVar* varp);
 
     static int getHierWorkers(const string& model);
-    static FileLine* getHierWorkersFileLine();
+    static FileLine* getHierWorkersFileLine(const string& model);
     static uint64_t getProfileData(const string& hierDpi);
     static uint64_t getProfileData(const string& model, const string& key);
     static FileLine* getProfileDataFileLine();

--- a/src/V3HierBlock.cpp
+++ b/src/V3HierBlock.cpp
@@ -192,8 +192,8 @@ V3StringList V3HierBlock::commandArgs(bool forCMake) const {
     const int blockThreads = V3Config::getHierWorkers(m_modp->origName());
     if (blockThreads > 1) {
         if (hasParent()) {
-            V3Config::getHierWorkersFileLine()->v3warn(
-                E_UNSUPPORTED, "Specifying workers for nested hierarchical blocks");
+            V3Config::getHierWorkersFileLine(m_modp->origName())
+                ->v3warn(E_UNSUPPORTED, "Specifying workers for nested hierarchical blocks");
         } else {
             if (v3Global.opt.threads() < blockThreads) {
                 m_modp->v3error("Hierarchical blocks cannot be scheduled on more threads than in "

--- a/test_regress/t/t_hier_block_threads_bad.out
+++ b/test_regress/t/t_hier_block_threads_bad.out
@@ -3,8 +3,8 @@
    23 | module Core(input clk); /*verilator hier_block*/ 
       |        ^~~~
         ... See the manual at https://verilator.org/verilator_doc.html?v=latest for more assistance.
-%Error-UNSUPPORTED: t/t_hier_block_threads_bad.vlt:8:1: Specifying workers for nested hierarchical blocks
-    8 | hier_workers -module "Core" -workers 8
+%Error-UNSUPPORTED: t/t_hier_block_threads_bad.vlt:9:1: Specifying workers for nested hierarchical blocks
+    9 | hier_workers -module "SubCore" -workers 8
       | ^~~~~~~~~~~~
                     ... For error description see https://verilator.org/warn/UNSUPPORTED?v=latest
 %Error: Exiting due to


### PR DESCRIPTION
Adds Fileline pointing to the offending line in VLT config for `Specifying workers for nested hierarchical blocks` error.
This improves error message and makes it easier to find nested blocks for which specifying `hier_workers` is not supported.