### PR TITLE
Fix Dfg eliminateVar pass to remove more variables

### DIFF
--- a/src/V3DfgPasses.cpp
+++ b/src/V3DfgPasses.cpp
@@ -263,6 +263,8 @@ void V3DfgPasses::eliminateVars(DfgGraph& dfg, V3DfgEliminateVarsContext& ctx) {
         DfgVertex* const vtxp = workListp;
         // Detach the head
         workListp = vtxp->getUser<DfgVertex*>();
+        // Reset user pointer so it can be added back to the work list later
+        vtxp->setUser<DfgVertex*>(nullptr);
         // Prefetch next item
         VL_PREFETCH_RW(workListp);
 


### PR DESCRIPTION
Failing to reset the work list pointer in vertices leads to not removing some redundant variables if they become redundant after having been considered once already.
