### PR TITLE
Restrict Dfg PUSH_SEL_THROUGH_CONCAT pattern

### DIFF
--- a/src/V3DfgPeephole.cpp
+++ b/src/V3DfgPeephole.cpp
@@ -774,12 +774,9 @@ class V3DfgPeephole final : public DfgVisitor {
                     DfgSel* const replacementp = make<DfgSel>(vtxp, lhsp, lsb - rhsp->width());
                     replace(vtxp, replacementp);
                 }
-            } else if (lsb == 0 || msb == concatp->width() - 1  //
-                       || lhsp->is<DfgConst>() || rhsp->is<DfgConst>()  //
-                       || !concatp->hasMultipleSinks()) {
-                // If the select straddles both sides, but at least one of the sides is wholly
-                // selected, or at least one of the sides is a Const, or this concat has no other
-                // use, then push the Sel past the Concat
+            } else if (!concatp->hasMultipleSinks()) {
+                // If the select straddles both sides, the Concat has no other use,
+                // then push the Sel past the Concat
                 APPLYING(PUSH_SEL_THROUGH_CONCAT) {
                     const uint32_t rSelWidth = rhsp->width() - lsb;
                     const uint32_t lSelWidth = width - rSelWidth;


### PR DESCRIPTION
This pattern is bit dubious and can blow up the size of the logic. Restrict it to only apply if it strictly does not increase DFG size.

This is performance neutral to ~1% better, but most importantly:

```
verilate - Elapsed time [s] - lower is better
╒════════════════════════╤════╤════╤══════════════════╤═════════════════╤════════════╤═════════╕
│ Case                   │ #A │ #B │           Mean A │          Mean B │ Gain (A/B) │ p-value │
╞════════════════════════╪════╪════╪══════════════════╪═════════════════╪════════════╪═════════╡
│ XiangShan:mini-chisel3 │  2 │  1 │ 109.85 (± 0.12%) │ 44.63           │      2.46x │         │
╞════════════════════════╪════╪════╪══════════════════╪═════════════════╪════════════╪═════════╡
│ Geometric mean         │    │    │                  │                 │      2.46x │         │
╘════════════════════════╧════╧════╧══════════════════╧═════════════════╧════════════╧═════════╛

cppbuild - Peak memory [MB] - lower is better
╒════════════════════════╤════╤════╤═══════════════════╤══════════════════╤════════════╤═════════╕
│ Case                   │ #A │ #B │            Mean A │           Mean B │ Gain (A/B) │ p-value │
╞════════════════════════╪════╪════╪═══════════════════╪══════════════════╪════════════╪═════════╡
│ XiangShan:mini-chisel3 │  2 │  1 │ 7328.37 (± 0.00%) │ 586.69           │     12.49x │         │
╞════════════════════════╪════╪════╪═══════════════════╪══════════════════╪════════════╪═════════╡
│ Geometric mean         │    │    │                   │                  │     12.49x │         │
╘════════════════════════╧════╧════╧═══════════════════╧══════════════════╧════════════╧═════════╛
```