### PR TITLE
Include a hint of the signed rhsval in oversized replication error

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -180,6 +180,7 @@ Paul Wright
 Pawel Jewstafjew
 Pawel Sagan
 Pengcheng Xu
+Peter Birch
 Peter Debacker
 Peter Horvath
 Peter Monsson

--- a/src/V3Number.cpp
+++ b/src/V3Number.cpp
@@ -1474,7 +1474,7 @@ V3Number& V3Number::opRepl(const V3Number& lhs,
     if (rhsval > (1UL << 24)) {
         v3error("More than a 16 Mbit replication, perhaps the replication factor"
                 " was two's-complement negative: "
-                << rhsval << " (" << (int32_t)rhsval << ")");
+                << rhsval << " (" << static_cast<int32_t>(rhsval) << ")");
     } else if (rhsval > 8192) {
         v3warn(WIDTHCONCAT, "More than a 8k bit replication is probably wrong: " << rhsval);
     }

--- a/src/V3Number.cpp
+++ b/src/V3Number.cpp
@@ -1474,7 +1474,7 @@ V3Number& V3Number::opRepl(const V3Number& lhs,
     if (rhsval > (1UL << 24)) {
         v3error("More than a 16 Mbit replication, perhaps the replication factor"
                 " was two's-complement negative: "
-                << rhsval);
+                << rhsval << " (" << (int32_t)rhsval << ")");
     } else if (rhsval > 8192) {
         v3warn(WIDTHCONCAT, "More than a 8k bit replication is probably wrong: " << rhsval);
     }

--- a/test_regress/t/t_math_repl2_bad.out
+++ b/test_regress/t/t_math_repl2_bad.out
@@ -1,4 +1,4 @@
-%Error: t/t_math_repl2_bad.v:28:30: More than a 16 Mbit replication, perhaps the replication factor was two's-complement negative: 4294967291
+%Error: t/t_math_repl2_bad.v:28:30: More than a 16 Mbit replication, perhaps the replication factor was two's-complement negative: 4294967291 (-5)
                                   : ... note: In instance 't'
    28 |          out <= {{(P24 - P29){1'b0}}, in};
       |                              ^


### PR DESCRIPTION
When a replication value becomes too large, an error message is raised suggesting that perhaps it is actually a negative value - however this leaves the reader with the responsibility to compute the two's-complement value. This change puts the hint on the line in brackets.

```
%Error: test.sv:5:35: More than a 16 Mbit replication, perhaps the replication factor was two's-complement negative: 4294967278 (-18)
                    : ... note: In instance 'mymod'
    5 | assign myval = { 4'b1001, {(31-49){1'b0}} };
      |                                   ^
        ... See the manual at https://verilator.org/verilator_doc.html?v=5.037 for more assistance.
```