### PR TITLE
Internals: Optimize updates of Vtogcov signals. No functional change intended.

### DIFF
--- a/include/verilated_cov.h
+++ b/include/verilated_cov.h
@@ -75,17 +75,17 @@ class VerilatedCovImp;
         ccontextp->_insertp("hier", name, __VA_ARGS__); \
     } while (false)
 
-static inline void VL_COV_TOGGLE_CHG_S_I(const int width, unsigned int* cov, const IData var,
+static inline void VL_COV_TOGGLE_CHG_S_I(const int width, uint32_t* cov, const IData var,
                                          const IData covVar) {
     for (int i = 0; i < width; ++i) *(cov + i) += ((var ^ covVar) >> i) & 1;
 }
 
-static inline void VL_COV_TOGGLE_CHG_S_Q(const int width, unsigned int* cov, const IData var,
+static inline void VL_COV_TOGGLE_CHG_S_Q(const int width, uint32_t* cov, const IData var,
                                          const IData covVar) {
     for (int i = 0; i < width; ++i) *(cov + i) += ((var ^ covVar) >> i) & 1;
 }
 
-static inline void VL_COV_TOGGLE_CHG_S_W(const int width, unsigned int* cov, WDataInP var,
+static inline void VL_COV_TOGGLE_CHG_S_W(const int width, uint32_t* cov, WDataInP var,
                                          WDataInP covVar) {
     for (int i = 0; i < (width + 31) / 32; ++i) {
         const EData changed = var[i] ^ covVar[i];

--- a/include/verilated_cov.h
+++ b/include/verilated_cov.h
@@ -77,17 +77,17 @@ class VerilatedCovImp;
 
 static inline void VL_COV_TOGGLE_CHG_I(const int width, unsigned int* cov, const IData var,
                                        const IData covVar) {
-    for (int i = 0; i < width; i++) *(cov + i) += ((var ^ covVar) >> i) & 1;
+    for (int i = 0; i < width; ++i) *(cov + i) += ((var ^ covVar) >> i) & 1;
 }
 
 static inline void VL_COV_TOGGLE_CHG_Q(const int width, unsigned int* cov, const IData var,
                                        const IData covVar) {
-    for (int i = 0; i < width; i++) *(cov + i) += ((var ^ covVar) >> i) & 1;
+    for (int i = 0; i < width; ++i) *(cov + i) += ((var ^ covVar) >> i) & 1;
 }
 
 static inline void VL_COV_TOGGLE_CHG_W(const int width, unsigned int* cov, WDataInP var,
                                        WDataInP covVar) {
-    for (int i = 0; i < width; i++) {
+    for (int i = 0; i < width; ++i) {
         const int wdata_i = i / 32;
         const int elem_i = i % 32;
         *(cov + i) += ((var[wdata_i] ^ covVar[wdata_i]) >> elem_i) & 1;

--- a/include/verilated_cov.h
+++ b/include/verilated_cov.h
@@ -90,7 +90,7 @@ static inline void VL_COV_TOGGLE_CHG_ST_W(const int width, uint32_t* covp, WData
     for (int i = 0; i < VL_WORDS_I(width); ++i) {
         const EData changed = newData[i] ^ oldData[i];
         if (changed) {
-            for (int j = 0; j < width - i * 32; ++j) *(covp + i * 32 + j) += (changed >> j) & 1;
+            for (int j = 0; j < width - i * VL_EDATA_SIZE; ++j) *(covp + i * VL_EDATA_SIZE + j) += (changed >> j) & 1;
         }
     }
 }
@@ -118,9 +118,9 @@ static inline void VL_COV_TOGGLE_CHG_MT_W(const int width, std::atomic<uint32_t>
     for (int i = 0; i < VL_WORDS_I(width); ++i) {
         const EData changed = newData[i] ^ oldData[i];
         if (changed) {
-            for (int j = 0; j < width - i * 32; ++j) {
+            for (int j = 0; j < width - i * VL_EDATA_SIZE; ++j) {
                 if (VL_BITISSET_E(changed, j)) {
-                    (covp + i * 32 + j)->fetch_add(1, std::memory_order_relaxed);
+                    (covp + i * VL_EDATA_SIZE + j)->fetch_add(1, std::memory_order_relaxed);
                 }
             }
         }

--- a/include/verilated_cov.h
+++ b/include/verilated_cov.h
@@ -77,18 +77,18 @@ class VerilatedCovImp;
 
 static inline void VL_COV_TOGGLE_CHG_S_I(const int width, uint32_t* cov, const IData newData,
                                          const IData oldData) {
-    for (int i = 0; i < width; ++i) *(cov + i) += ((var ^ covVar) >> i) & 1;
+    for (int i = 0; i < width; ++i) *(cov + i) += ((newData ^ oldData) >> i) & 1;
 }
 
-static inline void VL_COV_TOGGLE_CHG_S_Q(const int width, uint32_t* cov, const IData var,
-                                         const IData covVar) {
-    for (int i = 0; i < width; ++i) *(cov + i) += ((var ^ covVar) >> i) & 1;
+static inline void VL_COV_TOGGLE_CHG_S_Q(const int width, uint32_t* cov, const IData newData,
+                                         const IData oldData) {
+    for (int i = 0; i < width; ++i) *(cov + i) += ((newData ^ oldData) >> i) & 1;
 }
 
-static inline void VL_COV_TOGGLE_CHG_S_W(const int width, uint32_t* cov, WDataInP var,
-                                         WDataInP covVar) {
+static inline void VL_COV_TOGGLE_CHG_S_W(const int width, uint32_t* cov, WDataInP newData,
+                                         WDataInP oldData) {
     for (int i = 0; i < VL_WORDS_I(width); ++i) {
-        const EData changed = var[i] ^ covVar[i];
+        const EData changed = newData[i] ^ oldData[i];
         if (changed) {
             for (int j = 0; j < width - i * 32; ++j) *(cov + i * 32 + j) += (changed >> j) & 1;
         }
@@ -96,26 +96,30 @@ static inline void VL_COV_TOGGLE_CHG_S_W(const int width, uint32_t* cov, WDataIn
 }
 
 static inline void VL_COV_TOGGLE_CHG_M_I(const int width, std::atomic<uint32_t>* cov,
-                                         const IData var, const IData covVar) {
+                                         const IData newData, const IData oldData) {
     for (int i = 0; i < width; ++i) {
-        if (((var ^ covVar) >> i) & 1) (cov + i)->fetch_add(1, std::memory_order_relaxed);
+        if (VL_BITISSET_I((newData ^ oldData), i)) {
+            (cov + i)->fetch_add(1, std::memory_order_relaxed);
+        }
     }
 }
 
 static inline void VL_COV_TOGGLE_CHG_M_Q(const int width, std::atomic<uint32_t>* cov,
-                                         const IData var, const IData covVar) {
+                                         const IData newData, const IData oldData) {
     for (int i = 0; i < width; ++i) {
-        if (((var ^ covVar) >> i) & 1) (cov + i)->fetch_add(1, std::memory_order_relaxed);
+        if (VL_BITISSET_Q((newData ^ oldData), i)) {
+            (cov + i)->fetch_add(1, std::memory_order_relaxed);
+        }
     }
 }
 
-static inline void VL_COV_TOGGLE_CHG_M_W(const int width, std::atomic<uint32_t>* cov, WDataInP var,
-                                         WDataInP covVar) {
-    for (int i = 0; i < (width + 31) / 32; ++i) {
-        const EData changed = var[i] ^ covVar[i];
+static inline void VL_COV_TOGGLE_CHG_M_W(const int width, std::atomic<uint32_t>* cov,
+                                         WDataInP newData, WDataInP oldData) {
+    for (int i = 0; i < VL_WORDS_I(width); ++i) {
+        const EData changed = newData[i] ^ oldData[i];
         if (changed) {
             for (int j = 0; j < width - i * 32; ++j) {
-                if ((changed >> j) & 1) {
+                if (VL_BITISSET_E(changed, j)) {
                     (cov + i * 32 + j)->fetch_add(1, std::memory_order_relaxed);
                 }
             }

--- a/include/verilated_cov.h
+++ b/include/verilated_cov.h
@@ -90,7 +90,8 @@ static inline void VL_COV_TOGGLE_CHG_ST_W(const int width, uint32_t* covp, WData
     for (int i = 0; i < VL_WORDS_I(width); ++i) {
         const EData changed = newData[i] ^ oldData[i];
         if (changed) {
-            for (int j = 0; j < width - i * VL_EDATA_SIZE; ++j) *(covp + i * VL_EDATA_SIZE + j) += (changed >> j) & 1;
+            for (int j = 0; j < width - i * VL_EDATA_SIZE; ++j)
+                *(covp + i * VL_EDATA_SIZE + j) += (changed >> j) & 1;
         }
     }
 }

--- a/include/verilated_cov.h
+++ b/include/verilated_cov.h
@@ -90,8 +90,8 @@ static inline void VL_COV_TOGGLE_CHG_ST_W(const int width, uint32_t* covp, WData
     for (int i = 0; i < VL_WORDS_I(width); ++i) {
         const EData changed = newData[i] ^ oldData[i];
         if (changed) {
-            for (int j = 0; j < width - i * VL_EDATA_SIZE; ++j) {
-                *(covp + i * VL_EDATA_SIZE + j) += (changed >> j) & 1;
+            for (int j = 0; j < width - i * VL_EDATASIZE; ++j) {
+                *(covp + i * VL_EDATASIZE + j) += (changed >> j) & 1;
             }
         }
     }
@@ -120,9 +120,9 @@ static inline void VL_COV_TOGGLE_CHG_MT_W(const int width, std::atomic<uint32_t>
     for (int i = 0; i < VL_WORDS_I(width); ++i) {
         const EData changed = newData[i] ^ oldData[i];
         if (changed) {
-            for (int j = 0; j < width - i * VL_EDATA_SIZE; ++j) {
+            for (int j = 0; j < width - i * VL_EDATASIZE; ++j) {
                 if (VL_BITISSET_E(changed, j)) {
-                    (covp + i * VL_EDATA_SIZE + j)->fetch_add(1, std::memory_order_relaxed);
+                    (covp + i * VL_EDATASIZE + j)->fetch_add(1, std::memory_order_relaxed);
                 }
             }
         }

--- a/include/verilated_cov.h
+++ b/include/verilated_cov.h
@@ -75,8 +75,8 @@ class VerilatedCovImp;
         ccontextp->_insertp("hier", name, __VA_ARGS__); \
     } while (false)
 
-static inline void VL_COV_TOGGLE_CHG_S_I(const int width, uint32_t* cov, const IData var,
-                                         const IData covVar) {
+static inline void VL_COV_TOGGLE_CHG_S_I(const int width, uint32_t* cov, const IData newData,
+                                         const IData oldData) {
     for (int i = 0; i < width; ++i) *(cov + i) += ((var ^ covVar) >> i) & 1;
 }
 
@@ -87,7 +87,7 @@ static inline void VL_COV_TOGGLE_CHG_S_Q(const int width, uint32_t* cov, const I
 
 static inline void VL_COV_TOGGLE_CHG_S_W(const int width, uint32_t* cov, WDataInP var,
                                          WDataInP covVar) {
-    for (int i = 0; i < (width + 31) / 32; ++i) {
+    for (int i = 0; i < VL_WORDS_I(width); ++i) {
         const EData changed = var[i] ^ covVar[i];
         if (changed) {
             for (int j = 0; j < width - i * 32; ++j) *(cov + i * 32 + j) += (changed >> j) & 1;

--- a/include/verilated_cov.h
+++ b/include/verilated_cov.h
@@ -96,7 +96,7 @@ static inline void VL_COV_TOGGLE_CHG_S_W(const int width, uint32_t* cov, WDataIn
 }
 
 static inline void VL_COV_TOGGLE_CHG_MT_I(const int width, std::atomic<uint32_t>* covp,
-                                         const IData newData, const IData oldData) VL_MT_SAFE {
+                                          const IData newData, const IData oldData) VL_MT_SAFE {
     for (int i = 0; i < width; ++i) {
         if (VL_BITISSET_I((newData ^ oldData), i)) {
             (cov + i)->fetch_add(1, std::memory_order_relaxed);

--- a/include/verilated_cov.h
+++ b/include/verilated_cov.h
@@ -85,6 +85,15 @@ static inline void VL_COV_TOGGLE_CHG_Q(const int width, unsigned int* cov, const
     for (int i = 0; i < width; i++) *(cov + i) += ((var ^ covVar) >> i) & 1;
 }
 
+static inline void VL_COV_TOGGLE_CHG_W(const int width, unsigned int* cov, WDataInP var,
+                                       WDataInP covVar) {
+    for (int i = 0; i < width; i++) {
+        const int wdata_i = i / 32;
+        const int elem_i = i % 32;
+        *(cov + i) += ((var[wdata_i] ^ covVar[wdata_i]) >> elem_i) & 1;
+    }
+}
+
 //=============================================================================
 //  VerilatedCov
 /// Per-VerilatedContext coverage data class.

--- a/include/verilated_cov.h
+++ b/include/verilated_cov.h
@@ -90,8 +90,9 @@ static inline void VL_COV_TOGGLE_CHG_ST_W(const int width, uint32_t* covp, WData
     for (int i = 0; i < VL_WORDS_I(width); ++i) {
         const EData changed = newData[i] ^ oldData[i];
         if (changed) {
-            for (int j = 0; j < width - i * VL_EDATA_SIZE; ++j)
+            for (int j = 0; j < width - i * VL_EDATA_SIZE; ++j ) {
                 *(covp + i * VL_EDATA_SIZE + j) += (changed >> j) & 1;
+            }
         }
     }
 }

--- a/include/verilated_cov.h
+++ b/include/verilated_cov.h
@@ -75,22 +75,22 @@ class VerilatedCovImp;
         ccontextp->_insertp("hier", name, __VA_ARGS__); \
     } while (false)
 
-static inline void VL_COV_TOGGLE_CHG_S_I(const int width, uint32_t* cov, const IData newData,
-                                         const IData oldData) {
-    for (int i = 0; i < width; ++i) *(cov + i) += ((newData ^ oldData) >> i) & 1;
+static inline void VL_COV_TOGGLE_CHG_ST_I(const int width, uint32_t* covp, const IData newData,
+                                          const IData oldData) {
+    for (int i = 0; i < width; ++i) *(covp + i) += ((newData ^ oldData) >> i) & 1;
 }
 
-static inline void VL_COV_TOGGLE_CHG_S_Q(const int width, uint32_t* cov, const IData newData,
-                                         const IData oldData) {
-    for (int i = 0; i < width; ++i) *(cov + i) += ((newData ^ oldData) >> i) & 1;
+static inline void VL_COV_TOGGLE_CHG_ST_Q(const int width, uint32_t* covp, const IData newData,
+                                          const IData oldData) {
+    for (int i = 0; i < width; ++i) *(covp + i) += ((newData ^ oldData) >> i) & 1;
 }
 
-static inline void VL_COV_TOGGLE_CHG_S_W(const int width, uint32_t* cov, WDataInP newData,
-                                         WDataInP oldData) {
+static inline void VL_COV_TOGGLE_CHG_ST_W(const int width, uint32_t* covp, WDataInP newData,
+                                          WDataInP oldData) {
     for (int i = 0; i < VL_WORDS_I(width); ++i) {
         const EData changed = newData[i] ^ oldData[i];
         if (changed) {
-            for (int j = 0; j < width - i * 32; ++j) *(cov + i * 32 + j) += (changed >> j) & 1;
+            for (int j = 0; j < width - i * 32; ++j) *(covp + i * 32 + j) += (changed >> j) & 1;
         }
     }
 }
@@ -99,28 +99,28 @@ static inline void VL_COV_TOGGLE_CHG_MT_I(const int width, std::atomic<uint32_t>
                                           const IData newData, const IData oldData) VL_MT_SAFE {
     for (int i = 0; i < width; ++i) {
         if (VL_BITISSET_I((newData ^ oldData), i)) {
-            (cov + i)->fetch_add(1, std::memory_order_relaxed);
+            (covp + i)->fetch_add(1, std::memory_order_relaxed);
         }
     }
 }
 
-static inline void VL_COV_TOGGLE_CHG_M_Q(const int width, std::atomic<uint32_t>* cov,
-                                         const IData newData, const IData oldData) {
+static inline void VL_COV_TOGGLE_CHG_MT_Q(const int width, std::atomic<uint32_t>* covp,
+                                          const IData newData, const IData oldData) VL_MT_SAFE {
     for (int i = 0; i < width; ++i) {
         if (VL_BITISSET_Q((newData ^ oldData), i)) {
-            (cov + i)->fetch_add(1, std::memory_order_relaxed);
+            (covp + i)->fetch_add(1, std::memory_order_relaxed);
         }
     }
 }
 
-static inline void VL_COV_TOGGLE_CHG_M_W(const int width, std::atomic<uint32_t>* cov,
-                                         WDataInP newData, WDataInP oldData) {
+static inline void VL_COV_TOGGLE_CHG_MT_W(const int width, std::atomic<uint32_t>* covp,
+                                          WDataInP newData, WDataInP oldData) VL_MT_SAFE {
     for (int i = 0; i < VL_WORDS_I(width); ++i) {
         const EData changed = newData[i] ^ oldData[i];
         if (changed) {
             for (int j = 0; j < width - i * 32; ++j) {
                 if (VL_BITISSET_E(changed, j)) {
-                    (cov + i * 32 + j)->fetch_add(1, std::memory_order_relaxed);
+                    (covp + i * 32 + j)->fetch_add(1, std::memory_order_relaxed);
                 }
             }
         }

--- a/include/verilated_cov.h
+++ b/include/verilated_cov.h
@@ -90,7 +90,7 @@ static inline void VL_COV_TOGGLE_CHG_ST_W(const int width, uint32_t* covp, WData
     for (int i = 0; i < VL_WORDS_I(width); ++i) {
         const EData changed = newData[i] ^ oldData[i];
         if (changed) {
-            for (int j = 0; j < width - i * VL_EDATA_SIZE; ++j ) {
+            for (int j = 0; j < width - i * VL_EDATA_SIZE; ++j) {
                 *(covp + i * VL_EDATA_SIZE + j) += (changed >> j) & 1;
             }
         }

--- a/include/verilated_cov.h
+++ b/include/verilated_cov.h
@@ -95,8 +95,8 @@ static inline void VL_COV_TOGGLE_CHG_S_W(const int width, uint32_t* cov, WDataIn
     }
 }
 
-static inline void VL_COV_TOGGLE_CHG_M_I(const int width, std::atomic<uint32_t>* cov,
-                                         const IData newData, const IData oldData) {
+static inline void VL_COV_TOGGLE_CHG_MT_I(const int width, std::atomic<uint32_t>* covp,
+                                         const IData newData, const IData oldData) VL_MT_SAFE {
     for (int i = 0; i < width; ++i) {
         if (VL_BITISSET_I((newData ^ oldData), i)) {
             (cov + i)->fetch_add(1, std::memory_order_relaxed);

--- a/include/verilated_cov.h
+++ b/include/verilated_cov.h
@@ -75,6 +75,16 @@ class VerilatedCovImp;
         ccontextp->_insertp("hier", name, __VA_ARGS__); \
     } while (false)
 
+static inline void VL_COV_TOGGLE_CHG_I(const int width, unsigned int* cov, const IData var,
+                                       const IData covVar) {
+    for (int i = 0; i < width; i++) *(cov + i) += ((var ^ covVar) >> i) & 1;
+}
+
+static inline void VL_COV_TOGGLE_CHG_Q(const int width, unsigned int* cov, const IData var,
+                                       const IData covVar) {
+    for (int i = 0; i < width; i++) *(cov + i) += ((var ^ covVar) >> i) & 1;
+}
+
 //=============================================================================
 //  VerilatedCov
 /// Per-VerilatedContext coverage data class.

--- a/include/verilated_cov.h
+++ b/include/verilated_cov.h
@@ -87,10 +87,11 @@ static inline void VL_COV_TOGGLE_CHG_Q(const int width, unsigned int* cov, const
 
 static inline void VL_COV_TOGGLE_CHG_W(const int width, unsigned int* cov, WDataInP var,
                                        WDataInP covVar) {
-    for (int i = 0; i < width; ++i) {
-        const int wdata_i = i / 32;
-        const int elem_i = i % 32;
-        *(cov + i) += ((var[wdata_i] ^ covVar[wdata_i]) >> elem_i) & 1;
+    for (int i = 0; i < (width + 31) / 32; ++i) {
+        const EData changed = var[i] ^ covVar[i];
+        if (changed) {
+            for (int j = 0; j < width - i * 32; ++j) *(cov + i * 32 + j) += (changed >> j) & 1;
+        }
     }
 }
 

--- a/src/V3AstNodeOther.h
+++ b/src/V3AstNodeOther.h
@@ -3005,16 +3005,21 @@ class AstCoverDecl final : public AstNodeStmt {
     string m_linescov;
     int m_offset;  // Offset column numbers to uniq-ify IFs
     int m_binNum = 0;  // Set by V3EmitCSyms to tell final V3Emit what to increment
-    int m_size;  // Number of points
+    int m_begin;  // If the node corresponds to packed array, m_begin is `lo()`, m_end is
+                  // `hi() + 1`. In other cases they are both 0. It allows to distinguish `bit x`
+                  // from `bit [0:0] x`.
+    int m_end;
+
 public:
     AstCoverDecl(FileLine* fl, const string& page, const string& comment, const string& linescov,
-                 int offset, int size)
+                 int offset, int begin, int end)
         : ASTGEN_SUPER_CoverDecl(fl)
         , m_page{page}
         , m_text{comment}
         , m_linescov{linescov}
         , m_offset{offset}
-        , m_size{size} {}
+        , m_begin{begin}
+        , m_end{end} {}
     ASTGEN_MEMBERS_AstCoverDecl;
     const char* broken() const override {
         if (m_dataDeclp
@@ -3030,7 +3035,9 @@ public:
     int binNum() const { return m_binNum; }
     void binNum(int flag) { m_binNum = flag; }
     int offset() const { return m_offset; }
-    int size() const { return m_size; }
+    int begin() const { return m_begin; }
+    int end() const { return m_end; }
+    int size() const { return std::max(end() - begin(), 1); }
     const string& comment() const { return m_text; }  // text to insert in code
     const string& linescov() const { return m_linescov; }
     const string& page() const { return m_page; }

--- a/src/V3AstNodeOther.h
+++ b/src/V3AstNodeOther.h
@@ -404,9 +404,9 @@ class AstNodeCoverDecl VL_NOT_FINAL : public AstNodeStmt {
     //
     // [After V3CoverageJoin] Duplicate declaration to get data from instead
     // @astgen ptr := m_dataDeclp : Optional[AstNodeCoverDecl]
-    string m_page;
-    string m_text;
-    string m_hier;
+    string m_page;  // Coverage point's page tag
+    string m_text;  // Coverage point's text
+    string m_hier;  // Coverage point's hierarchy
     int m_binNum = 0;  // Set by V3EmitCSyms to tell final V3Emit what to increment
 public:
     AstNodeCoverDecl(VNType t, FileLine* fl, const string& page, const string& comment)
@@ -3917,7 +3917,7 @@ public:
 class AstCoverToggleDecl final : public AstNodeCoverDecl {
     // Coverage analysis point declaration
     // Used for toggle coverage
-    const VNumRange m_range;  // packed array ranges
+    const VNumRange m_range;  // Packed array range covering each toggle bit
 public:
     AstCoverToggleDecl(FileLine* fl, const string& page, const string& comment,
                        const VNumRange& range)

--- a/src/V3AstNodeOther.h
+++ b/src/V3AstNodeOther.h
@@ -436,7 +436,7 @@ public:
     bool sameNode(const AstNode* samep) const override {
         const AstNodeCoverDecl* const asamep = VN_DBG_AS(samep, NodeCoverDecl);
         return (fileline() == asamep->fileline() && hier() == asamep->hier()
-                && comment() == asamep->comment());
+                && comment() == asamep->comment() && page() == asamep->page());
     }
     bool isPredictOptimizable() const override { return false; }
     void dataDeclp(AstNodeCoverDecl* nodep) { m_dataDeclp = nodep; }

--- a/src/V3AstNodeOther.h
+++ b/src/V3AstNodeOther.h
@@ -3048,6 +3048,7 @@ public:
 };
 class AstCoverInc final : public AstNodeStmt {
     // Coverage analysis point; increment coverage count
+    // @astgen op1 := toggleExprp : Optional[AstNodeExpr]
     //
     // @astgen ptr := m_declp : AstCoverDecl  // [After V3CoverageJoin] Declaration
 public:

--- a/src/V3AstNodeOther.h
+++ b/src/V3AstNodeOther.h
@@ -3005,14 +3005,16 @@ class AstCoverDecl final : public AstNodeStmt {
     string m_linescov;
     int m_offset;  // Offset column numbers to uniq-ify IFs
     int m_binNum = 0;  // Set by V3EmitCSyms to tell final V3Emit what to increment
+    int m_size;  // Number of points
 public:
     AstCoverDecl(FileLine* fl, const string& page, const string& comment, const string& linescov,
-                 int offset)
+                 int offset, int size)
         : ASTGEN_SUPER_CoverDecl(fl)
         , m_page{page}
         , m_text{comment}
         , m_linescov{linescov}
-        , m_offset{offset} {}
+        , m_offset{offset}
+        , m_size{size} {}
     ASTGEN_MEMBERS_AstCoverDecl;
     const char* broken() const override {
         if (m_dataDeclp
@@ -3028,6 +3030,7 @@ public:
     int binNum() const { return m_binNum; }
     void binNum(int flag) { m_binNum = flag; }
     int offset() const { return m_offset; }
+    int size() const { return m_size; }
     const string& comment() const { return m_text; }  // text to insert in code
     const string& linescov() const { return m_linescov; }
     const string& page() const { return m_page; }

--- a/src/V3AstNodeOther.h
+++ b/src/V3AstNodeOther.h
@@ -3048,7 +3048,9 @@ public:
 };
 class AstCoverInc final : public AstNodeStmt {
     // Coverage analysis point; increment coverage count
-    // @astgen op1 := toggleExprp : Optional[AstNodeExpr]
+    // @astgen op1 := toggleExprp : Optional[AstNodeExpr]  // [After V3Clock]
+    // @astgen op2 := toggleCovExprp : Optional[AstNodeExpr]  // [After V3Clock]
+    // These are expressions to which the node corresponds. Used only in toggle coverage
     //
     // @astgen ptr := m_declp : AstCoverDecl  // [After V3CoverageJoin] Declaration
 public:

--- a/src/V3AstNodeOther.h
+++ b/src/V3AstNodeOther.h
@@ -3924,8 +3924,8 @@ public:
         : ASTGEN_SUPER_CoverToggleDecl(fl, page, comment)
         , m_range{range} {}
     ASTGEN_MEMBERS_AstCoverToggleDecl;
-    // void dump(std::ostream& str) const override;
-    // void dumpJson(std::ostream& str) const override;
+    void dump(std::ostream& str) const override;
+    void dumpJson(std::ostream& str) const override;
     int size() const override { return m_range.elements(); }
     const VNumRange& range() const { return m_range; }
     bool sameNode(const AstNode* samep) const override {

--- a/src/V3AstNodeOther.h
+++ b/src/V3AstNodeOther.h
@@ -3917,17 +3917,20 @@ public:
 class AstCoverToggleDecl final : public AstNodeCoverDecl {
     // Coverage analysis point declaration
     // Used for toggle coverage
+    const VNumRange m_range;  // packed array ranges
 public:
-    AstCoverToggleDecl(FileLine* fl, const string& page, const string& comment)
-        : ASTGEN_SUPER_CoverToggleDecl(fl, page, comment) {}
+    AstCoverToggleDecl(FileLine* fl, const string& page, const string& comment,
+                       const VNumRange& range)
+        : ASTGEN_SUPER_CoverToggleDecl(fl, page, comment)
+        , m_range{range} {}
     ASTGEN_MEMBERS_AstCoverToggleDecl;
-    bool hasDType() const override VL_MT_SAFE { return true; }
     // void dump(std::ostream& str) const override;
     // void dumpJson(std::ostream& str) const override;
-    int size() const override { return dtypep()->width(); }
+    int size() const override { return m_range.elements(); }
+    const VNumRange& range() const { return m_range; }
     bool sameNode(const AstNode* samep) const override {
         const AstCoverToggleDecl* const asamep = VN_DBG_AS(samep, CoverToggleDecl);
-        return AstNodeCoverDecl::sameNode(samep) && dtypep() == asamep->dtypep();
+        return AstNodeCoverDecl::sameNode(samep) && range() == asamep->range();
     }
 };
 

--- a/src/V3AstNodes.cpp
+++ b/src/V3AstNodes.cpp
@@ -2922,10 +2922,9 @@ void AstBegin::dumpJson(std::ostream& str) const {
     dumpJsonBoolFunc(str, needProcess);
     dumpJsonGen(str);
 }
-void AstCoverDecl::dump(std::ostream& str) const {
+void AstNodeCoverDecl::dump(std::ostream& str) const {
     this->AstNodeStmt::dump(str);
     if (!page().empty()) str << " page=" << page();
-    if (!linescov().empty()) str << " lc=" << linescov();
     if (this->dataDeclNullp()) {
         static bool s_recursing = false;
         str << " -> ";
@@ -2940,11 +2939,18 @@ void AstCoverDecl::dump(std::ostream& str) const {
         if (binNum()) str << " bin" << std::dec << binNum();
     }
 }
-void AstCoverDecl::dumpJson(std::ostream& str) const {
+void AstNodeCoverDecl::dumpJson(std::ostream& str) const {
     dumpJsonStrFunc(str, page);
-    dumpJsonStrFunc(str, linescov);
     dumpJsonNumFunc(str, binNum);
     dumpJsonGen(str);
+}
+void AstCoverOtherDecl::dump(std::ostream& str) const {
+    this->AstNodeCoverDecl::dump(str);
+    if (!linescov().empty()) str << " lc=" << linescov();
+}
+void AstCoverOtherDecl::dumpJson(std::ostream& str) const {
+    this->AstNodeCoverDecl::dumpJson(str);
+    dumpJsonStrFunc(str, linescov);
 }
 void AstCoverInc::dump(std::ostream& str) const {
     this->AstNodeStmt::dump(str);

--- a/src/V3AstNodes.cpp
+++ b/src/V3AstNodes.cpp
@@ -2952,6 +2952,17 @@ void AstCoverOtherDecl::dumpJson(std::ostream& str) const {
     this->AstNodeCoverDecl::dumpJson(str);
     dumpJsonStrFunc(str, linescov);
 }
+void AstCoverToggleDecl::dump(std::ostream& str) const {
+    this->AstNodeCoverDecl::dump(str);
+    if (range().ranged()) str << " range=[" << range().left() << ":" << range().right() << "]";
+}
+void AstCoverToggleDecl::dumpJson(std::ostream& str) const {
+    this->AstNodeCoverDecl::dumpJson(str);
+    if (range().ranged()) {
+        dumpJsonStr(str, "range",
+                    std::to_string(range().left()) + ":" + std::to_string(range().right()));
+    }
+}
 void AstCoverInc::dump(std::ostream& str) const {
     this->AstNodeStmt::dump(str);
     str << " -> ";

--- a/src/V3Begin.cpp
+++ b/src/V3Begin.cpp
@@ -289,7 +289,7 @@ class BeginVisitor final : public VNVisitor {
         }
         iterateChildren(nodep);
     }
-    void visit(AstCoverDecl* nodep) override {
+    void visit(AstNodeCoverDecl* nodep) override {
         // Don't need to fix path in coverage statements, they're not under
         // any BEGINs, but V3Coverage adds them all under the module itself.
         iterateChildren(nodep);

--- a/src/V3CCtors.cpp
+++ b/src/V3CCtors.cpp
@@ -161,10 +161,10 @@ class CCtorsVisitor final : public VNVisitor {
         if (v3Global.opt.coverage()) {
             V3CCtorsBuilder configure_coverage{nodep, "_configure_coverage", VCtorType::COVERAGE};
             for (AstNode* np = nodep->stmtsp(); np; np = np->nextp()) {
-                if (AstCoverDecl* const coverp = VN_CAST(np, CoverDecl)) {
+                if (AstNodeCoverDecl* const coverp = VN_CAST(np, NodeCoverDecl)) {
                     // ... else we don't have a static VlSym to be able to coverage insert
                     UASSERT_OBJ(!VN_IS(nodep, Class), coverp,
-                                "CoverDecl should be in class's package, not class itself");
+                                "NodeCoverDecl should be in class's package, not class itself");
                     np = coverp->backp();
                     configure_coverage.add(coverp->unlinkFrBack());
                 }

--- a/src/V3Class.cpp
+++ b/src/V3Class.cpp
@@ -175,7 +175,7 @@ class ClassVisitor final : public VNVisitor {
         //    m_toScopeMoves.emplace_back(nodep, m_classScopep);
         //}
     }
-    void visit(AstCoverDecl* nodep) override {
+    void visit(AstNodeCoverDecl* nodep) override {
         // Need to declare coverage in package, where we have access to symbol table
         iterateChildren(nodep);
         if (m_classPackagep) m_classPackagep->addStmtsp(nodep->unlinkFrBack());

--- a/src/V3Clock.cpp
+++ b/src/V3Clock.cpp
@@ -100,11 +100,12 @@ class ClockVisitor final : public VNVisitor {
         // if (debug()) nodep->dumpTree("-  ct: ");
         // COVERTOGGLE(INC, ORIG, CHANGE) ->
         //   IF(ORIG ^ CHANGE) { INC; CHANGE = ORIG; }
-        AstNode* const incp = nodep->incp()->unlinkFrBack();
+        AstCoverInc* const incp = nodep->incp()->unlinkFrBack();
         AstNodeExpr* const origp = nodep->origp()->unlinkFrBack();
         AstNodeExpr* const changeWrp = nodep->changep()->unlinkFrBack();
         AstNodeExpr* const changeRdp = ConvertWriteRefsToRead::main(changeWrp->cloneTree(false));
         AstNodeExpr* comparedp = nullptr;
+        incp->toggleExprp(origp->cloneTree(false));
         // Xor will optimize better than Eq, when CoverToggle has bit selects,
         // but can only use Xor with non-opaque types
         if (const AstBasicDType* const bdtypep

--- a/src/V3Clock.cpp
+++ b/src/V3Clock.cpp
@@ -106,6 +106,7 @@ class ClockVisitor final : public VNVisitor {
         AstNodeExpr* const changeRdp = ConvertWriteRefsToRead::main(changeWrp->cloneTree(false));
         AstNodeExpr* comparedp = nullptr;
         incp->toggleExprp(origp->cloneTree(false));
+        incp->toggleCovExprp(changeRdp->cloneTree(false));
         // Xor will optimize better than Eq, when CoverToggle has bit selects,
         // but can only use Xor with non-opaque types
         if (const AstBasicDType* const bdtypep

--- a/src/V3Coverage.cpp
+++ b/src/V3Coverage.cpp
@@ -182,7 +182,7 @@ class CoverageVisitor final : public VNVisitor {
 
     AstCoverInc* newCoverInc(FileLine* fl, const string& hier, const string& page_prefix,
                              const string& comment, const string& linescov, int offset,
-                             const string& trace_var_name) {
+                             const string& trace_var_name, const int size) {
         // We could use the basename of the filename to the page, but seems
         // better for code from an include file to be listed under the
         // module using it rather than the include file.
@@ -191,7 +191,7 @@ class CoverageVisitor final : public VNVisitor {
         // Someday the user might be allowed to specify a different page suffix
         const string page = page_prefix + "/" + m_modp->prettyName();
 
-        AstCoverDecl* const declp = new AstCoverDecl{fl, page, comment, linescov, offset};
+        AstCoverDecl* const declp = new AstCoverDecl{fl, page, comment, linescov, offset, size};
         declp->hier(hier);
         m_modp->addStmtsp(declp);
         UINFO(9, "new " << declp);
@@ -318,7 +318,7 @@ class CoverageVisitor final : public VNVisitor {
             lineTrack(nodep);
             AstNode* const newp
                 = newCoverInc(nodep->fileline(), "", "v_line", "block", linesCov(m_state, nodep),
-                              0, traceNameForLine(nodep, "block"));
+                              0, traceNameForLine(nodep, "block"), 1);
             insertProcStatement(nodep, newp);
         }
     }
@@ -356,7 +356,7 @@ class CoverageVisitor final : public VNVisitor {
             lineTrack(nodep);
             AstNode* const newp
                 = newCoverInc(nodep->fileline(), "", "v_line", "block", linesCov(m_state, nodep),
-                              0, traceNameForLine(nodep, "block"));
+                              0, traceNameForLine(nodep, "block"), 1);
             insertProcStatement(nodep, newp);
         }
     }
@@ -408,7 +408,8 @@ class CoverageVisitor final : public VNVisitor {
         AstCoverToggle* const newp = new AstCoverToggle{
             varp->fileline(),
             newCoverInc(varp->fileline(), "", "v_toggle",
-                        hierPrefix + varp->name() + above.m_comment, "", 0, ""),
+                        hierPrefix + varp->name() + above.m_comment, "", 0, "",
+                        above.m_varRefp->width()),
             above.m_varRefp->cloneTree(false), above.m_chgRefp->cloneTree(false)};
         m_modp->addStmtsp(newp);
     }
@@ -532,7 +533,7 @@ class CoverageVisitor final : public VNVisitor {
             nodep->thenp(new AstExprStmt{thenp->fileline(),
                                          newCoverInc(nodep->fileline(), "", "v_branch",
                                                      "cond_then", linesCov(m_state, nodep), 0,
-                                                     traceNameForLine(nodep, "cond_then")),
+                                                     traceNameForLine(nodep, "cond_then"), 1),
                                          thenp});
             m_state = lastState;
             createHandle(nodep);
@@ -541,7 +542,7 @@ class CoverageVisitor final : public VNVisitor {
             nodep->elsep(new AstExprStmt{elsep->fileline(),
                                          newCoverInc(nodep->fileline(), "", "v_branch",
                                                      "cond_else", linesCov(m_state, nodep), 1,
-                                                     traceNameForLine(nodep, "cond_else")),
+                                                     traceNameForLine(nodep, "cond_else"), 1),
                                          elsep});
 
             m_state = lastState;
@@ -601,13 +602,13 @@ class CoverageVisitor final : public VNVisitor {
                 UINFO(4, "   COVER-branch: " << nodep);
                 nodep->addThensp(newCoverInc(nodep->fileline(), "", "v_branch", "if",
                                              linesCov(ifState, nodep), 0,
-                                             traceNameForLine(nodep, "if")));
+                                             traceNameForLine(nodep, "if"), 1));
                 // The else has a column offset of 1 to uniquify it relative to the if
                 // As "if" and "else" are more than one character wide, this won't overlap
                 // another token
                 nodep->addElsesp(newCoverInc(nodep->fileline(), "", "v_branch", "else",
                                              linesCov(elseState, nodep), 1,
-                                             traceNameForLine(nodep, "else")));
+                                             traceNameForLine(nodep, "else"), 1));
             }
             // If/else attributes to each block as non-branch coverage
             else if (first_elsif || cont_elsif) {
@@ -615,7 +616,7 @@ class CoverageVisitor final : public VNVisitor {
                 if (ifState.lineCoverageOn(nodep)) {
                     nodep->addThensp(newCoverInc(nodep->fileline(), "", "v_line", "elsif",
                                                  linesCov(ifState, nodep), 0,
-                                                 traceNameForLine(nodep, "elsif")));
+                                                 traceNameForLine(nodep, "elsif"), 1));
                 }
                 // and we don't insert the else as the child if-else will do so
             } else {
@@ -624,13 +625,13 @@ class CoverageVisitor final : public VNVisitor {
                     UINFO(4, "   COVER-half-if: " << nodep);
                     nodep->addThensp(newCoverInc(nodep->fileline(), "", "v_line", "if",
                                                  linesCov(ifState, nodep), 0,
-                                                 traceNameForLine(nodep, "if")));
+                                                 traceNameForLine(nodep, "if"), 1));
                 }
                 if (elseState.lineCoverageOn(nodep)) {
                     UINFO(4, "   COVER-half-el: " << nodep);
                     nodep->addElsesp(newCoverInc(nodep->fileline(), "", "v_line", "else",
                                                  linesCov(elseState, nodep), 1,
-                                                 traceNameForLine(nodep, "else")));
+                                                 traceNameForLine(nodep, "else"), 1));
                 }
             }
             m_state = lastState;
@@ -653,7 +654,7 @@ class CoverageVisitor final : public VNVisitor {
                 UINFO(4, "   COVER: " << nodep);
                 nodep->addStmtsp(newCoverInc(nodep->fileline(), "", "v_line", "case",
                                              linesCov(m_state, nodep), 0,
-                                             traceNameForLine(nodep, "case")));
+                                             traceNameForLine(nodep, "case"), 1));
             }
         }
     }
@@ -668,7 +669,7 @@ class CoverageVisitor final : public VNVisitor {
             lineTrack(nodep);
             nodep->addCoverincsp(newCoverInc(nodep->fileline(), m_beginHier, "v_user", "cover",
                                              linesCov(m_state, nodep), 0,
-                                             m_beginHier + "_vlCoverageUserTrace"));
+                                             m_beginHier + "_vlCoverageUserTrace", 1));
         }
     }
     void visit(AstStop* nodep) override {
@@ -741,7 +742,7 @@ class CoverageVisitor final : public VNVisitor {
             comment += ") => ";
             comment += (m_objective ? '1' : '0');
             AstNode* const newp
-                = newCoverInc(fl, "", "v_expr", comment, "", 0, traceNameForLine(nodep, name));
+                = newCoverInc(fl, "", "v_expr", comment, "", 0, traceNameForLine(nodep, name), 1);
             UASSERT_OBJ(condp, nodep, "No terms in expression coverage branch");
             AstIf* const ifp = new AstIf{fl, condp, newp, nullptr};
             ifp->user2(true);

--- a/src/V3Coverage.cpp
+++ b/src/V3Coverage.cpp
@@ -180,23 +180,8 @@ class CoverageVisitor final : public VNVisitor {
         return nullptr;
     }
 
-    AstCoverInc* newCoverInc(FileLine* fl, const string& hier, const string& page_prefix,
-                             const string& comment, const string& linescov, int offset,
-                             const string& trace_var_name, const int begin, const int end) {
-        // We could use the basename of the filename to the page, but seems
-        // better for code from an include file to be listed under the
-        // module using it rather than the include file.
-        // Note the module name could have parameters appended, we'll consider this
-        // a feature as it allows for each parameterized block to be counted separately.
-        // Someday the user might be allowed to specify a different page suffix
-        const string page = page_prefix + "/" + m_modp->prettyName();
-
-        AstCoverDecl* const declp
-            = new AstCoverDecl{fl, page, comment, linescov, offset, begin, end};
-        declp->hier(hier);
-        m_modp->addStmtsp(declp);
-        UINFO(9, "new " << declp);
-
+    AstCoverInc* newCoverInc(FileLine* fl, AstNodeCoverDecl* const declp,
+                             const string& trace_var_name) {
         AstCoverInc* const incp = new AstCoverInc{fl, declp};
         if (!trace_var_name.empty()
             && v3Global.opt.traceCoverage()
@@ -317,9 +302,12 @@ class CoverageVisitor final : public VNVisitor {
         iterateAndNextNull(nodep->stmtsp());
         if (m_state.lineCoverageOn(nodep)) {
             lineTrack(nodep);
+            AstCoverOtherDecl* const declp
+                = new AstCoverOtherDecl{nodep->fileline(), "v_line/" + m_modp->prettyName(),
+                                        "block", linesCov(m_state, nodep), 0};
+            m_modp->addStmtsp(declp);
             AstNode* const newp
-                = newCoverInc(nodep->fileline(), "", "v_line", "block", linesCov(m_state, nodep),
-                              0, traceNameForLine(nodep, "block"), 0, 0);
+                = newCoverInc(nodep->fileline(), declp, traceNameForLine(nodep, "block"));
             insertProcStatement(nodep, newp);
         }
     }
@@ -355,9 +343,12 @@ class CoverageVisitor final : public VNVisitor {
         iterateChildren(nodep);
         if (m_state.lineCoverageOn(nodep)) {
             lineTrack(nodep);
+            AstCoverOtherDecl* const declp
+                = new AstCoverOtherDecl{nodep->fileline(), "v_line/" + m_modp->prettyName(),
+                                        "block", linesCov(m_state, nodep), 0};
+            m_modp->addStmtsp(declp);
             AstNode* const newp
-                = newCoverInc(nodep->fileline(), "", "v_line", "block", linesCov(m_state, nodep),
-                              0, traceNameForLine(nodep, "block"), 0, 0);
+                = newCoverInc(nodep->fileline(), declp, traceNameForLine(nodep, "block"));
             insertProcStatement(nodep, newp);
         }
     }
@@ -403,26 +394,25 @@ class CoverageVisitor final : public VNVisitor {
         }
     }
 
-    void toggleVarBottom(const ToggleEnt& above, const AstVar* varp, const int begin,
-                         const int end) {
+    void toggleVarBottom(const ToggleEnt& above, const AstVar* varp,
+                         const AstNodeDType* const dtypep) {
         const std::string hierPrefix
             = (m_beginHier != "") ? AstNode::prettyName(m_beginHier) + "." : "";
+        AstCoverToggleDecl* const declp
+            = new AstCoverToggleDecl{varp->fileline(), "v_toggle/" + m_modp->prettyName(),
+                                     hierPrefix + varp->name() + above.m_comment};
+        declp->dtypeFrom(dtypep);
+        m_modp->addStmtsp(declp);
         AstCoverToggle* const newp = new AstCoverToggle{
-            varp->fileline(),
-            newCoverInc(varp->fileline(), "", "v_toggle",
-                        hierPrefix + varp->name() + above.m_comment, "", 0, "", begin, end),
+            varp->fileline(), newCoverInc(varp->fileline(), declp, ""),
             above.m_varRefp->cloneTree(false), above.m_chgRefp->cloneTree(false)};
         m_modp->addStmtsp(newp);
     }
 
     void toggleVarRecurse(const AstNodeDType* const dtypep, const int depth,  // per-iteration
                           const ToggleEnt& above, const AstVar* const varp) {  // Constant
-        if (const AstBasicDType* const bdtypep = VN_CAST(dtypep, BasicDType)) {
-            if (bdtypep->isRanged()) {
-                toggleVarBottom(above, varp, bdtypep->lo(), bdtypep->hi() + 1);
-            } else {
-                toggleVarBottom(above, varp, 0, 0);
-            }
+        if (VN_IS(dtypep, BasicDType)) {
+            toggleVarBottom(above, varp, dtypep);
         } else if (const AstUnpackArrayDType* const adtypep = VN_CAST(dtypep, UnpackArrayDType)) {
             for (int index_docs = adtypep->lo(); index_docs <= adtypep->hi(); ++index_docs) {
                 const int index_code = index_docs - adtypep->lo();
@@ -535,20 +525,26 @@ class CoverageVisitor final : public VNVisitor {
             iterate(nodep->thenp());
             lineTrack(nodep);
             AstNodeExpr* const thenp = nodep->thenp()->unlinkFrBack();
-            nodep->thenp(new AstExprStmt{thenp->fileline(),
-                                         newCoverInc(nodep->fileline(), "", "v_branch",
-                                                     "cond_then", linesCov(m_state, nodep), 0,
-                                                     traceNameForLine(nodep, "cond_then"), 0, 0),
-                                         thenp});
+            AstCoverOtherDecl* const thenDeclp
+                = new AstCoverOtherDecl{thenp->fileline(), "v_branch/" + m_modp->prettyName(),
+                                        "cond_then", linesCov(m_state, nodep), 0};
+            m_modp->addStmtsp(thenDeclp);
+            nodep->thenp(new AstExprStmt{
+                thenp->fileline(),
+                newCoverInc(nodep->fileline(), thenDeclp, traceNameForLine(nodep, "cond_then")),
+                thenp});
             m_state = lastState;
             createHandle(nodep);
             iterate(nodep->elsep());
             AstNodeExpr* const elsep = nodep->elsep()->unlinkFrBack();
-            nodep->elsep(new AstExprStmt{elsep->fileline(),
-                                         newCoverInc(nodep->fileline(), "", "v_branch",
-                                                     "cond_else", linesCov(m_state, nodep), 1,
-                                                     traceNameForLine(nodep, "cond_else"), 0, 0),
-                                         elsep});
+            AstCoverOtherDecl* const elseDeclp
+                = new AstCoverOtherDecl{thenp->fileline(), "v_branch/" + m_modp->prettyName(),
+                                        "cond_else", linesCov(m_state, nodep), 1};
+            m_modp->addStmtsp(elseDeclp);
+            nodep->elsep(new AstExprStmt{
+                elsep->fileline(),
+                newCoverInc(nodep->fileline(), elseDeclp, traceNameForLine(nodep, "cond_else")),
+                elsep});
 
             m_state = lastState;
         } else {
@@ -605,38 +601,55 @@ class CoverageVisitor final : public VNVisitor {
                 // Normal if. Linecov shows what's inside the if (not condition that is
                 // always executed)
                 UINFO(4, "   COVER-branch: " << nodep);
-                nodep->addThensp(newCoverInc(nodep->fileline(), "", "v_branch", "if",
-                                             linesCov(ifState, nodep), 0,
-                                             traceNameForLine(nodep, "if"), 0, 0));
+                AstCoverOtherDecl* const ifDeclp
+                    = new AstCoverOtherDecl{nodep->fileline(), "v_branch/" + m_modp->prettyName(),
+                                            "if", linesCov(ifState, nodep), 0};
+                m_modp->addStmtsp(ifDeclp);
+                nodep->addThensp(
+                    newCoverInc(nodep->fileline(), ifDeclp, traceNameForLine(nodep, "if")));
                 // The else has a column offset of 1 to uniquify it relative to the if
                 // As "if" and "else" are more than one character wide, this won't overlap
                 // another token
-                nodep->addElsesp(newCoverInc(nodep->fileline(), "", "v_branch", "else",
-                                             linesCov(elseState, nodep), 1,
-                                             traceNameForLine(nodep, "else"), 0, 0));
+                AstCoverOtherDecl* const elseDeclp
+                    = new AstCoverOtherDecl{nodep->fileline(), "v_branch/" + m_modp->prettyName(),
+                                            "else", linesCov(elseState, nodep), 1};
+                m_modp->addStmtsp(elseDeclp);
+                nodep->addElsesp(
+                    newCoverInc(nodep->fileline(), elseDeclp, traceNameForLine(nodep, "else")));
             }
             // If/else attributes to each block as non-branch coverage
             else if (first_elsif || cont_elsif) {
                 UINFO(4, "   COVER-elsif: " << nodep);
                 if (ifState.lineCoverageOn(nodep)) {
-                    nodep->addThensp(newCoverInc(nodep->fileline(), "", "v_line", "elsif",
-                                                 linesCov(ifState, nodep), 0,
-                                                 traceNameForLine(nodep, "elsif"), 0, 0));
+                    AstCoverOtherDecl* const elsifDeclp = new AstCoverOtherDecl{
+                        nodep->fileline(), "v_line/" + m_modp->prettyName(), "elsif",
+                        linesCov(ifState, nodep), 0};
+                    m_modp->addStmtsp(elsifDeclp);
+
+                    nodep->addThensp(newCoverInc(nodep->fileline(), elsifDeclp,
+                                                 traceNameForLine(nodep, "elsif")));
                 }
                 // and we don't insert the else as the child if-else will do so
             } else {
                 // Cover as separate blocks (not a branch as is not two-legged)
                 if (ifState.lineCoverageOn(nodep)) {
                     UINFO(4, "   COVER-half-if: " << nodep);
-                    nodep->addThensp(newCoverInc(nodep->fileline(), "", "v_line", "if",
-                                                 linesCov(ifState, nodep), 0,
-                                                 traceNameForLine(nodep, "if"), 0, 0));
+                    AstCoverOtherDecl* const ifDeclp = new AstCoverOtherDecl{
+                        nodep->fileline(), "v_line/" + m_modp->prettyName(), "if",
+                        linesCov(ifState, nodep), 0};
+                    m_modp->addStmtsp(ifDeclp);
+                    nodep->addThensp(
+                        newCoverInc(nodep->fileline(), ifDeclp, traceNameForLine(nodep, "if")));
                 }
                 if (elseState.lineCoverageOn(nodep)) {
                     UINFO(4, "   COVER-half-el: " << nodep);
-                    nodep->addElsesp(newCoverInc(nodep->fileline(), "", "v_line", "else",
-                                                 linesCov(elseState, nodep), 1,
-                                                 traceNameForLine(nodep, "else"), 0, 0));
+                    AstCoverOtherDecl* const elseDeclp = new AstCoverOtherDecl{
+                        nodep->fileline(), "v_line/" + m_modp->prettyName(), "else",
+                        linesCov(elseState, nodep), 1};
+                    m_modp->addStmtsp(elseDeclp);
+
+                    nodep->addElsesp(newCoverInc(nodep->fileline(), elseDeclp,
+                                                 traceNameForLine(nodep, "else")));
                 }
             }
             m_state = lastState;
@@ -657,9 +670,12 @@ class CoverageVisitor final : public VNVisitor {
             if (m_state.lineCoverageOn(nodep)) {  // if the case body didn't disable it
                 lineTrack(nodep);
                 UINFO(4, "   COVER: " << nodep);
-                nodep->addStmtsp(newCoverInc(nodep->fileline(), "", "v_line", "case",
-                                             linesCov(m_state, nodep), 0,
-                                             traceNameForLine(nodep, "case"), 0, 0));
+                AstCoverOtherDecl* const declp
+                    = new AstCoverOtherDecl{nodep->fileline(), "v_line/" + m_modp->prettyName(),
+                                            "case", linesCov(m_state, nodep), 0};
+                m_modp->addStmtsp(declp);
+                nodep->addStmtsp(
+                    newCoverInc(nodep->fileline(), declp, traceNameForLine(nodep, "case")));
             }
         }
     }
@@ -672,9 +688,13 @@ class CoverageVisitor final : public VNVisitor {
         if (!nodep->coverincsp() && v3Global.opt.coverageUser()) {
             // Note the name may be overridden by V3Assert processing
             lineTrack(nodep);
-            nodep->addCoverincsp(newCoverInc(nodep->fileline(), m_beginHier, "v_user", "cover",
-                                             linesCov(m_state, nodep), 0,
-                                             m_beginHier + "_vlCoverageUserTrace", 0, 0));
+            AstCoverOtherDecl* const declp
+                = new AstCoverOtherDecl{nodep->fileline(), "v_user/" + m_modp->prettyName(),
+                                        "cover", linesCov(m_state, nodep), 0};
+            declp->hier(m_beginHier);
+            m_modp->addStmtsp(declp);
+            nodep->addCoverincsp(
+                newCoverInc(nodep->fileline(), declp, m_beginHier + "_vlCoverageUserTrace"));
         }
     }
     void visit(AstStop* nodep) override {
@@ -746,8 +766,10 @@ class CoverageVisitor final : public VNVisitor {
             }
             comment += ") => ";
             comment += (m_objective ? '1' : '0');
-            AstNode* const newp = newCoverInc(fl, "", "v_expr", comment, "", 0,
-                                              traceNameForLine(nodep, name), 0, 0);
+            AstCoverOtherDecl* const declp = new AstCoverOtherDecl{
+                nodep->fileline(), "v_exp/" + m_modp->prettyName(), comment, "", 0};
+            m_modp->addStmtsp(declp);
+            AstNode* const newp = newCoverInc(fl, declp, traceNameForLine(nodep, name));
             UASSERT_OBJ(condp, nodep, "No terms in expression coverage branch");
             AstIf* const ifp = new AstIf{fl, condp, newp, nullptr};
             ifp->user2(true);

--- a/src/V3Coverage.cpp
+++ b/src/V3Coverage.cpp
@@ -394,14 +394,12 @@ class CoverageVisitor final : public VNVisitor {
         }
     }
 
-    void toggleVarBottom(const ToggleEnt& above, const AstVar* varp,
-                         const AstNodeDType* const dtypep) {
+    void toggleVarBottom(const ToggleEnt& above, const AstVar* varp, const VNumRange& range) {
         const std::string hierPrefix
             = (m_beginHier != "") ? AstNode::prettyName(m_beginHier) + "." : "";
         AstCoverToggleDecl* const declp
             = new AstCoverToggleDecl{varp->fileline(), "v_toggle/" + m_modp->prettyName(),
-                                     hierPrefix + varp->name() + above.m_comment};
-        declp->dtypeFrom(dtypep);
+                                     hierPrefix + varp->name() + above.m_comment, range};
         m_modp->addStmtsp(declp);
         AstCoverToggle* const newp = new AstCoverToggle{
             varp->fileline(), newCoverInc(varp->fileline(), declp, ""),
@@ -411,8 +409,8 @@ class CoverageVisitor final : public VNVisitor {
 
     void toggleVarRecurse(const AstNodeDType* const dtypep, const int depth,  // per-iteration
                           const ToggleEnt& above, const AstVar* const varp) {  // Constant
-        if (VN_IS(dtypep, BasicDType)) {
-            toggleVarBottom(above, varp, dtypep);
+        if (const AstBasicDType* const basicp = VN_CAST(dtypep, BasicDType)) {
+            toggleVarBottom(above, varp, basicp->nrange());
         } else if (const AstUnpackArrayDType* const adtypep = VN_CAST(dtypep, UnpackArrayDType)) {
             for (int index_docs = adtypep->lo(); index_docs <= adtypep->hi(); ++index_docs) {
                 const int index_code = index_docs - adtypep->lo();

--- a/src/V3Coverage.cpp
+++ b/src/V3Coverage.cpp
@@ -416,21 +416,7 @@ class CoverageVisitor final : public VNVisitor {
     void toggleVarRecurse(const AstNodeDType* const dtypep, const int depth,  // per-iteration
                           const ToggleEnt& above, const AstVar* const varp) {  // Constant
         if (const AstBasicDType* const bdtypep = VN_CAST(dtypep, BasicDType)) {
-            if (bdtypep->isRanged()) {
-                for (int index_docs = bdtypep->lo(); index_docs < bdtypep->hi() + 1;
-                     ++index_docs) {
-                    const int index_code = index_docs - bdtypep->lo();
-                    ToggleEnt newent{above.m_comment + "["s + cvtToStr(index_docs) + "]",
-                                     new AstSel{varp->fileline(),
-                                                above.m_varRefp->cloneTree(false), index_code, 1},
-                                     new AstSel{varp->fileline(),
-                                                above.m_chgRefp->cloneTree(false), index_code, 1}};
-                    toggleVarBottom(newent, varp);
-                    newent.cleanup();
-                }
-            } else {
-                toggleVarBottom(above, varp);
-            }
+            toggleVarBottom(above, varp);
         } else if (const AstUnpackArrayDType* const adtypep = VN_CAST(dtypep, UnpackArrayDType)) {
             for (int index_docs = adtypep->lo(); index_docs <= adtypep->hi(); ++index_docs) {
                 const int index_code = index_docs - adtypep->lo();

--- a/src/V3Coverage.cpp
+++ b/src/V3Coverage.cpp
@@ -765,7 +765,7 @@ class CoverageVisitor final : public VNVisitor {
             comment += ") => ";
             comment += (m_objective ? '1' : '0');
             AstCoverOtherDecl* const declp = new AstCoverOtherDecl{
-                nodep->fileline(), "v_exp/" + m_modp->prettyName(), comment, "", 0};
+                nodep->fileline(), "v_expr/" + m_modp->prettyName(), comment, "", 0};
             m_modp->addStmtsp(declp);
             AstNode* const newp = newCoverInc(fl, declp, traceNameForLine(nodep, name));
             UASSERT_OBJ(condp, nodep, "No terms in expression coverage branch");

--- a/src/V3CoverageJoin.cpp
+++ b/src/V3CoverageJoin.cpp
@@ -75,7 +75,7 @@ class CoverageJoinVisitor final : public VNVisitor {
                 // The CoverDecl the duplicate pointed to now needs to point to the
                 // original's data. I.e. the duplicate will get the coverage number
                 // from the non-duplicate
-                AstCoverDecl* const datadeclp = nodep->incp()->declp()->dataDeclThisp();
+                AstNodeCoverDecl* const datadeclp = nodep->incp()->declp()->dataDeclThisp();
                 removep->incp()->declp()->dataDeclp(datadeclp);
                 UINFO(8, "   new " << removep->incp()->declp());
                 // Mark the found node as a duplicate of the first node

--- a/src/V3EmitCFunc.h
+++ b/src/V3EmitCFunc.h
@@ -741,6 +741,10 @@ public:
             }
         } else {
             puts("VL_COV_TOGGLE_CHG_");
+            if (v3Global.opt.threads() > 1)
+                puts("M_");
+            else
+                puts("S_");
             emitIQW(nodep->toggleExprp());
             puts("(");
             puts(cvtToStr(nodep->declp()->size()));

--- a/src/V3EmitCFunc.h
+++ b/src/V3EmitCFunc.h
@@ -727,7 +727,7 @@ public:
     }
     void visit(AstCoverToggleDecl* nodep) override {
         for (int i = 0; i < nodep->size(); i++) {
-            putns(nodep, "vlSelf->__vlCoverInsert(");  // As Declared in emitCoverageDecl
+            putns(nodep, "vlSelf->__vlCoverToggleInsert(");  // As Declared in emitCoverageDecl
             puts("&(vlSymsp->__Vcoverage[");
             puts(cvtToStr(nodep->dataDeclThisp()->binNum() + i));
             puts("])");
@@ -752,7 +752,7 @@ public:
             const string index
                 = (nodep->range().ranged()) ? '[' + cvtToStr(nodep->range().lo() + i) + ']' : "";
             putsQuoted(protectWordsIf(nodep->comment() + index, nodep->protect()));
-            puts(", \"\");\n");
+            puts(");\n");
         }
     }
     void visit(AstCoverInc* nodep) override {

--- a/src/V3EmitCFunc.h
+++ b/src/V3EmitCFunc.h
@@ -741,10 +741,11 @@ public:
             }
         } else {
             puts("VL_COV_TOGGLE_CHG_");
-            if (v3Global.opt.threads() > 1)
+            if (v3Global.opt.threads() > 1) {
                 puts("M_");
-            else
+            } else {
                 puts("S_");
+            }
             emitIQW(nodep->toggleExprp());
             puts("(");
             puts(cvtToStr(nodep->declp()->size()));

--- a/src/V3EmitCFunc.h
+++ b/src/V3EmitCFunc.h
@@ -751,7 +751,7 @@ public:
             puts(", ");
             AstBasicDType* const basicp = VN_CAST(nodep->dtypep(), BasicDType);
             const string index
-                = (basicp && basicp->rangep()) ? '[' + cvtToStr(basicp->lo() + i) + ']' : "";
+                = (basicp && basicp->isRanged()) ? '[' + cvtToStr(basicp->lo() + i) + ']' : "";
             putsQuoted(protectWordsIf(nodep->comment() + index, nodep->protect()));
             puts(", \"\");\n");
         }

--- a/src/V3EmitCFunc.h
+++ b/src/V3EmitCFunc.h
@@ -721,7 +721,8 @@ public:
             puts(", ");
             putsQuoted(protectWordsIf(nodep->page(), nodep->protect()));
             puts(", ");
-            const string index = nodep->size() > 1 ? '[' + cvtToStr(i) + ']' : "";
+            const string index
+                = (nodep->begin() != nodep->end()) ? '[' + cvtToStr(nodep->begin() + i) + ']' : "";
             putsQuoted(protectWordsIf(nodep->comment() + index, nodep->protect()));
             puts(", ");
             putsQuoted(nodep->linescov());

--- a/src/V3EmitCFunc.h
+++ b/src/V3EmitCFunc.h
@@ -727,9 +727,9 @@ public:
     }
     void visit(AstCoverToggleDecl* nodep) override {
         putns(nodep, "vlSelf->__vlCoverToggleInsert(");  // As Declared in emitCoverageDecl
-        puts(cvtToStr(nodep->range().lo()));
+        puts(cvtToStr(nodep->range().right()));
         puts(", ");
-        puts(cvtToStr(nodep->range().hi()));
+        puts(cvtToStr(nodep->range().left()));
         puts(", ");
         puts(cvtToStr(nodep->range().ranged()));
         puts(", ");

--- a/src/V3EmitCFunc.h
+++ b/src/V3EmitCFunc.h
@@ -749,9 +749,8 @@ public:
             puts(", ");
             putsQuoted(protectWordsIf(nodep->page(), nodep->protect()));
             puts(", ");
-            AstBasicDType* const basicp = VN_CAST(nodep->dtypep(), BasicDType);
             const string index
-                = (basicp && basicp->isRanged()) ? '[' + cvtToStr(basicp->lo() + i) + ']' : "";
+                = (nodep->range().ranged()) ? '[' + cvtToStr(nodep->range().lo() + i) + ']' : "";
             putsQuoted(protectWordsIf(nodep->comment() + index, nodep->protect()));
             puts(", \"\");\n");
         }

--- a/src/V3EmitCFunc.h
+++ b/src/V3EmitCFunc.h
@@ -771,9 +771,9 @@ public:
         } else {
             puts("VL_COV_TOGGLE_CHG_");
             if (v3Global.opt.threads() > 1) {
-                puts("M_");
+                puts("MT_");
             } else {
-                puts("S_");
+                puts("ST_");
             }
             emitIQW(nodep->toggleExprp());
             puts("(");

--- a/src/V3EmitCFunc.h
+++ b/src/V3EmitCFunc.h
@@ -745,6 +745,7 @@ public:
             puts("(");
             puts(cvtToStr(nodep->declp()->size()));
             puts(", ");
+            puts("vlSymsp->__Vcoverage + ");
             puts(cvtToStr(nodep->declp()->dataDeclThisp()->binNum()));
             puts(", ");
             iterateConst(nodep->toggleExprp());

--- a/src/V3EmitCFunc.h
+++ b/src/V3EmitCFunc.h
@@ -698,32 +698,35 @@ public:
         iterateChildrenConst(nodep);
     }
     void visit(AstCoverDecl* nodep) override {
-        putns(nodep, "vlSelf->__vlCoverInsert(");  // As Declared in emitCoverageDecl
-        puts("&(vlSymsp->__Vcoverage[");
-        puts(cvtToStr(nodep->dataDeclThisp()->binNum()));
-        puts("])");
-        // If this isn't the first instantiation of this module under this
-        // design, don't really count the bucket, and rely on verilator_cov to
-        // aggregate counts.  This is because Verilator combines all
-        // hierarchies itself, and if verilator_cov also did it, you'd end up
-        // with (number-of-instant) times too many counts in this bin.
-        puts(", first");  // Enable, passed from __Vconfigure parameter
-        puts(", ");
-        putsQuoted(protect(nodep->fileline()->filename()));
-        puts(", ");
-        puts(cvtToStr(nodep->fileline()->lineno()));
-        puts(", ");
-        puts(cvtToStr(nodep->offset() + nodep->fileline()->firstColumn()));
-        puts(", ");
-        putsQuoted((!nodep->hier().empty() ? "." : "")
-                   + protectWordsIf(nodep->hier(), nodep->protect()));
-        puts(", ");
-        putsQuoted(protectWordsIf(nodep->page(), nodep->protect()));
-        puts(", ");
-        putsQuoted(protectWordsIf(nodep->comment(), nodep->protect()));
-        puts(", ");
-        putsQuoted(nodep->linescov());
-        puts(");\n");
+        for (int i = 0; i < nodep->size(); i++) {
+            putns(nodep, "vlSelf->__vlCoverInsert(");  // As Declared in emitCoverageDecl
+            puts("&(vlSymsp->__Vcoverage[");
+            puts(cvtToStr(nodep->dataDeclThisp()->binNum() + i));
+            puts("])");
+            // If this isn't the first instantiation of this module under this
+            // design, don't really count the bucket, and rely on verilator_cov to
+            // aggregate counts.  This is because Verilator combines all
+            // hierarchies itself, and if verilator_cov also did it, you'd end up
+            // with (number-of-instant) times too many counts in this bin.
+            puts(", first");  // Enable, passed from __Vconfigure parameter
+            puts(", ");
+            putsQuoted(protect(nodep->fileline()->filename()));
+            puts(", ");
+            puts(cvtToStr(nodep->fileline()->lineno()));
+            puts(", ");
+            puts(cvtToStr(nodep->offset() + nodep->fileline()->firstColumn()));
+            puts(", ");
+            putsQuoted((!nodep->hier().empty() ? "." : "")
+                       + protectWordsIf(nodep->hier(), nodep->protect()));
+            puts(", ");
+            putsQuoted(protectWordsIf(nodep->page(), nodep->protect()));
+            puts(", ");
+            const string index = nodep->size() > 1 ? '[' + cvtToStr(i) + ']' : "";
+            putsQuoted(protectWordsIf(nodep->comment() + index, nodep->protect()));
+            puts(", ");
+            putsQuoted(nodep->linescov());
+            puts(");\n");
+        }
     }
     void visit(AstCoverInc* nodep) override {
         if (nodep->declp()->size() == 1) {

--- a/src/V3EmitCFunc.h
+++ b/src/V3EmitCFunc.h
@@ -727,7 +727,11 @@ public:
     }
     void visit(AstCoverToggleDecl* nodep) override {
         putns(nodep, "vlSelf->__vlCoverToggleInsert(");  // As Declared in emitCoverageDecl
-        puts(cvtToStr(nodep->size()));
+        puts(cvtToStr(nodep->range().lo()));
+        puts(", ");
+        puts(cvtToStr(nodep->range().hi()));
+        puts(", ");
+        puts(cvtToStr(nodep->range().ranged()));
         puts(", ");
         puts("&(vlSymsp->__Vcoverage[");
         puts(cvtToStr(nodep->dataDeclThisp()->binNum()));

--- a/src/V3EmitCFunc.h
+++ b/src/V3EmitCFunc.h
@@ -726,14 +726,28 @@ public:
         puts(");\n");
     }
     void visit(AstCoverInc* nodep) override {
-        if (v3Global.opt.threads() > 1) {
-            putns(nodep, "vlSymsp->__Vcoverage[");
-            puts(cvtToStr(nodep->declp()->dataDeclThisp()->binNum()));
-            puts("].fetch_add(1, std::memory_order_relaxed);\n");
+        if (nodep->declp()->size() == 1) {
+            if (v3Global.opt.threads() > 1) {
+                putns(nodep, "vlSymsp->__Vcoverage[");
+                puts(cvtToStr(nodep->declp()->dataDeclThisp()->binNum()));
+                puts("].fetch_add(1, std::memory_order_relaxed);\n");
+            } else {
+                putns(nodep, "++(vlSymsp->__Vcoverage[");
+                puts(cvtToStr(nodep->declp()->dataDeclThisp()->binNum()));
+                puts("]);\n");
+            }
         } else {
-            putns(nodep, "++(vlSymsp->__Vcoverage[");
+            puts("VL_COV_TOGGLE_CHG_");
+            emitIQW(nodep->toggleExprp());
+            puts("(");
+            puts(cvtToStr(nodep->declp()->size()));
+            puts(", ");
             puts(cvtToStr(nodep->declp()->dataDeclThisp()->binNum()));
-            puts("]);\n");
+            puts(", ");
+            iterateConst(nodep->toggleExprp());
+            puts(", ");
+            iterateConst(nodep->toggleCovExprp());
+            puts(");\n");
         }
     }
     void visit(AstDisableFork* nodep) override { putns(nodep, "vlProcess->disableFork();\n"); }

--- a/src/V3EmitCFunc.h
+++ b/src/V3EmitCFunc.h
@@ -726,34 +726,32 @@ public:
         puts(");\n");
     }
     void visit(AstCoverToggleDecl* nodep) override {
-        for (int i = 0; i < nodep->size(); i++) {
-            putns(nodep, "vlSelf->__vlCoverToggleInsert(");  // As Declared in emitCoverageDecl
-            puts("&(vlSymsp->__Vcoverage[");
-            puts(cvtToStr(nodep->dataDeclThisp()->binNum() + i));
-            puts("])");
-            // If this isn't the first instantiation of this module under this
-            // design, don't really count the bucket, and rely on verilator_cov to
-            // aggregate counts.  This is because Verilator combines all
-            // hierarchies itself, and if verilator_cov also did it, you'd end up
-            // with (number-of-instant) times too many counts in this bin.
-            puts(", first");  // Enable, passed from __Vconfigure parameter
-            puts(", ");
-            putsQuoted(protect(nodep->fileline()->filename()));
-            puts(", ");
-            puts(cvtToStr(nodep->fileline()->lineno()));
-            puts(", ");
-            puts(cvtToStr(nodep->fileline()->firstColumn()));
-            puts(", ");
-            putsQuoted((!nodep->hier().empty() ? "." : "")
-                       + protectWordsIf(nodep->hier(), nodep->protect()));
-            puts(", ");
-            putsQuoted(protectWordsIf(nodep->page(), nodep->protect()));
-            puts(", ");
-            const string index
-                = (nodep->range().ranged()) ? '[' + cvtToStr(nodep->range().lo() + i) + ']' : "";
-            putsQuoted(protectWordsIf(nodep->comment() + index, nodep->protect()));
-            puts(");\n");
-        }
+        putns(nodep, "vlSelf->__vlCoverToggleInsert(");  // As Declared in emitCoverageDecl
+        puts(cvtToStr(nodep->size()));
+        puts(", ");
+        puts("&(vlSymsp->__Vcoverage[");
+        puts(cvtToStr(nodep->dataDeclThisp()->binNum()));
+        puts("])");
+        // If this isn't the first instantiation of this module under this
+        // design, don't really count the bucket, and rely on verilator_cov to
+        // aggregate counts.  This is because Verilator combines all
+        // hierarchies itself, and if verilator_cov also did it, you'd end up
+        // with (number-of-instant) times too many counts in this bin.
+        puts(", first");  // Enable, passed from __Vconfigure parameter
+        puts(", ");
+        putsQuoted(protect(nodep->fileline()->filename()));
+        puts(", ");
+        puts(cvtToStr(nodep->fileline()->lineno()));
+        puts(", ");
+        puts(cvtToStr(nodep->fileline()->firstColumn()));
+        puts(", ");
+        putsQuoted((!nodep->hier().empty() ? "." : "")
+                   + protectWordsIf(nodep->hier(), nodep->protect()));
+        puts(", ");
+        putsQuoted(protectWordsIf(nodep->page(), nodep->protect()));
+        puts(", ");
+        putsQuoted(protectWordsIf(nodep->comment(), nodep->protect()));
+        puts(");\n");
     }
     void visit(AstCoverInc* nodep) override {
         if (nodep->declp()->size() == 1) {

--- a/src/V3EmitCHeaders.cpp
+++ b/src/V3EmitCHeaders.cpp
@@ -183,7 +183,7 @@ class EmitCHeader final : public EmitCConstInit {
 
         if (v3Global.opt.coverageToggle() && !VN_IS(modp, Class)) {
             decorateFirst(first, section);
-            puts("void __vlCoverToggleInsert(");
+            puts("void __vlCoverToggleInsert(int size, ");
             puts(v3Global.opt.threads() > 1 ? "std::atomic<uint32_t>" : "uint32_t");
             puts("* countp, bool enable, const char* filenamep, int lineno, int column,\n");
             puts("const char* hierp, const char* pagep, const char* commentp);\n");

--- a/src/V3EmitCHeaders.cpp
+++ b/src/V3EmitCHeaders.cpp
@@ -183,7 +183,7 @@ class EmitCHeader final : public EmitCConstInit {
 
         if (v3Global.opt.coverageToggle() && !VN_IS(modp, Class)) {
             decorateFirst(first, section);
-            puts("void __vlCoverToggleInsert(int size, ");
+            puts("void __vlCoverToggleInsert(int begin, int end, bool ranged, ");
             puts(v3Global.opt.threads() > 1 ? "std::atomic<uint32_t>" : "uint32_t");
             puts("* countp, bool enable, const char* filenamep, int lineno, int column,\n");
             puts("const char* hierp, const char* pagep, const char* commentp);\n");

--- a/src/V3EmitCHeaders.cpp
+++ b/src/V3EmitCHeaders.cpp
@@ -181,6 +181,14 @@ class EmitCHeader final : public EmitCConstInit {
                  "linescovp);\n");
         }
 
+        if (v3Global.opt.coverageToggle() && !VN_IS(modp, Class)) {
+            decorateFirst(first, section);
+            puts("void __vlCoverToggleInsert(");
+            puts(v3Global.opt.threads() > 1 ? "std::atomic<uint32_t>" : "uint32_t");
+            puts("* countp, bool enable, const char* filenamep, int lineno, int column,\n");
+            puts("const char* hierp, const char* pagep, const char* commentp);\n");
+        }
+
         if (v3Global.opt.savable()) {
             decorateFirst(first, section);
             puts("void " + protect("__Vserialize") + "(VerilatedSerialize& os);\n");

--- a/src/V3EmitCImp.cpp
+++ b/src/V3EmitCImp.cpp
@@ -379,7 +379,7 @@ class EmitCImp final : EmitCFunc {
             puts("  \"comment\",commentWithIndex.c_str(),");
             puts("  \"\", \"\");\n");  //  linescov argument, but in toggle coverage it is always
                                        //  empty
-            puts("countp++;\n");
+            puts("++countp;\n");
             puts("}\n");
             puts("}\n");
             splitSizeInc(10);

--- a/src/V3EmitCImp.cpp
+++ b/src/V3EmitCImp.cpp
@@ -356,9 +356,9 @@ class EmitCImp final : EmitCFunc {
             // range is inclusive
             puts("for (int i = begin; i != end + step; i += step) {\n");
             if (v3Global.opt.threads() > 1) {
-                puts("uint32_t* count32p = reinterpret_cast<uint32_t*>(countp);\n");
+                puts("uint32_t* const count32p = reinterpret_cast<uint32_t*>(countp);\n");
             } else {
-                puts("uint32_t* count32p = countp;\n");
+                puts("uint32_t* const count32p = countp;\n");
             }
             // static doesn't need save-restore as is constant
             puts("static uint32_t fake_zero_count = 0;\n");

--- a/src/V3EmitCImp.cpp
+++ b/src/V3EmitCImp.cpp
@@ -345,14 +345,15 @@ class EmitCImp final : EmitCFunc {
         if (v3Global.opt.coverageToggle()) {
             puts("\n// Toggle Coverage\n");
             puts("void " + prefixNameProtect(m_modp) + "::__vlCoverToggleInsert(");
-            puts("int size, ");
+            puts("int begin, int end, bool ranged, ");
             puts(v3Global.opt.threads() > 1 ? "std::atomic<uint32_t>" : "uint32_t");
             puts("* countp, bool enable, const char* filenamep, int lineno, int column,\n");
             puts("const char* hierp, const char* pagep, const char* commentp) {\n");
             if (v3Global.opt.threads() > 1) {
                 puts("assert(sizeof(uint32_t) == sizeof(std::atomic<uint32_t>));\n");
             }
-            puts("for (int i = 0; i < size; i++) {\n");
+            puts("int step = (end >= begin) ? 1 : -1;\n");
+            puts("for (int i = begin; i <= end; i += step) {\n");
             if (v3Global.opt.threads() > 1) {
                 puts("uint32_t* count32p = reinterpret_cast<uint32_t*>(countp);\n");
             } else {
@@ -362,8 +363,8 @@ class EmitCImp final : EmitCFunc {
             puts("static uint32_t fake_zero_count = 0;\n");
             puts("std::string fullhier = std::string{VerilatedModule::name()} + hierp;\n");
             puts("if (!fullhier.empty() && fullhier[0] == '.') fullhier = fullhier.substr(1);\n");
-            puts("std::string commentWithIndex = std::string{commentp} + '[' + std::to_string(i) "
-                 "+ ']';\n");
+            puts("std::string commentWithIndex = commentp;\n");
+            puts("if (ranged) commentWithIndex += '[' + std::to_string(i) + ']';\n");
             // Used for second++ instantiation of identical bin
             puts("if (!enable) count32p = &fake_zero_count;\n");
             puts("*count32p = 0;\n");

--- a/src/V3EmitCImp.cpp
+++ b/src/V3EmitCImp.cpp
@@ -356,9 +356,9 @@ class EmitCImp final : EmitCFunc {
             // range is inclusive
             puts("for (int i = begin; i != end + step; i += step) {\n");
             if (v3Global.opt.threads() > 1) {
-                puts("uint32_t* const count32p = reinterpret_cast<uint32_t*>(countp);\n");
+                puts("uint32_t* count32p = reinterpret_cast<uint32_t*>(countp);\n");
             } else {
-                puts("uint32_t* const count32p = countp;\n");
+                puts("uint32_t* count32p = countp;\n");
             }
             // static doesn't need save-restore as is constant
             puts("static uint32_t fake_zero_count = 0;\n");

--- a/src/V3EmitCImp.cpp
+++ b/src/V3EmitCImp.cpp
@@ -103,7 +103,7 @@ class EmitCGatherDependencies final : VNVisitorConst {
         addSelfDependency(nodep->selfPointer(), nodep->varp());
         iterateChildrenConst(nodep);
     }
-    void visit(AstCoverDecl* nodep) override {
+    void visit(AstNodeCoverDecl* nodep) override {
         addSymsDependency();
         iterateChildrenConst(nodep);
     }

--- a/src/V3EmitCImp.cpp
+++ b/src/V3EmitCImp.cpp
@@ -353,7 +353,8 @@ class EmitCImp final : EmitCFunc {
                 puts("assert(sizeof(uint32_t) == sizeof(std::atomic<uint32_t>));\n");
             }
             puts("int step = (end >= begin) ? 1 : -1;\n");
-            puts("for (int i = begin; i <= end; i += step) {\n");
+            // range is inclusive
+            puts("for (int i = begin; i != end + step; i += step) {\n");
             if (v3Global.opt.threads() > 1) {
                 puts("uint32_t* count32p = reinterpret_cast<uint32_t*>(countp);\n");
             } else {

--- a/src/V3EmitCImp.cpp
+++ b/src/V3EmitCImp.cpp
@@ -345,11 +345,15 @@ class EmitCImp final : EmitCFunc {
         if (v3Global.opt.coverageToggle()) {
             puts("\n// Toggle Coverage\n");
             puts("void " + prefixNameProtect(m_modp) + "::__vlCoverToggleInsert(");
+            puts("int size, ");
             puts(v3Global.opt.threads() > 1 ? "std::atomic<uint32_t>" : "uint32_t");
             puts("* countp, bool enable, const char* filenamep, int lineno, int column,\n");
             puts("const char* hierp, const char* pagep, const char* commentp) {\n");
             if (v3Global.opt.threads() > 1) {
                 puts("assert(sizeof(uint32_t) == sizeof(std::atomic<uint32_t>));\n");
+            }
+            puts("for (int i = 0; i < size; i++) {\n");
+            if (v3Global.opt.threads() > 1) {
                 puts("uint32_t* count32p = reinterpret_cast<uint32_t*>(countp);\n");
             } else {
                 puts("uint32_t* count32p = countp;\n");
@@ -358,6 +362,8 @@ class EmitCImp final : EmitCFunc {
             puts("static uint32_t fake_zero_count = 0;\n");
             puts("std::string fullhier = std::string{VerilatedModule::name()} + hierp;\n");
             puts("if (!fullhier.empty() && fullhier[0] == '.') fullhier = fullhier.substr(1);\n");
+            puts("std::string commentWithIndex = std::string{commentp} + '[' + std::to_string(i) "
+                 "+ ']';\n");
             // Used for second++ instantiation of identical bin
             puts("if (!enable) count32p = &fake_zero_count;\n");
             puts("*count32p = 0;\n");
@@ -368,9 +374,11 @@ class EmitCImp final : EmitCFunc {
             puts("  \"column\",column,\n");
             puts("\"hier\",fullhier,");
             puts("  \"page\",pagep,");
-            puts("  \"comment\",commentp,");
+            puts("  \"comment\",commentWithIndex.c_str(),");
             puts("  \"\", \"\");\n");  //  linescov argument, but in toggle coverage it is always
                                        //  empty
+            puts("countp++;\n");
+            puts("}\n");
             puts("}\n");
             splitSizeInc(10);
         }

--- a/src/V3EmitCSyms.cpp
+++ b/src/V3EmitCSyms.cpp
@@ -379,7 +379,8 @@ class EmitCSyms final : EmitCBaseVisitorConst {
     void visit(AstCoverDecl* nodep) override {
         // Assign numbers to all bins, so we know how big of an array to use
         if (!nodep->dataDeclNullp()) {  // else duplicate we don't need code for
-            nodep->binNum(m_coverBins++);
+            nodep->binNum(m_coverBins);
+            m_coverBins += nodep->size();
         }
     }
     void visit(AstCFunc* nodep) override {

--- a/src/V3EmitCSyms.cpp
+++ b/src/V3EmitCSyms.cpp
@@ -376,7 +376,7 @@ class EmitCSyms final : EmitCBaseVisitorConst {
         iterateChildrenConst(nodep);
         m_statVarScopeBytes += nodep->varp()->dtypep()->widthTotalBytes();
     }
-    void visit(AstCoverDecl* nodep) override {
+    void visit(AstNodeCoverDecl* nodep) override {
         // Assign numbers to all bins, so we know how big of an array to use
         if (!nodep->dataDeclNullp()) {  // else duplicate we don't need code for
             nodep->binNum(m_coverBins);

--- a/src/V3EmitV.cpp
+++ b/src/V3EmitV.cpp
@@ -234,7 +234,7 @@ class EmitVBaseVisitorConst VL_NOT_FINAL : public VNVisitorConst {
         putbs("continue");
         if (!m_suppressSemi) puts(";\n");
     }
-    void visit(AstCoverDecl*) override {}  // N/A
+    void visit(AstNodeCoverDecl*) override {}  // N/A
     void visit(AstCoverInc*) override {}  // N/A
     void visit(AstCoverToggle*) override {}  // N/A
 

--- a/src/V3Inline.cpp
+++ b/src/V3Inline.cpp
@@ -459,7 +459,7 @@ class InlineRelinkVisitor final : public VNVisitor {
         if (afterp) nodep->addScopeEntrp(afterp);
         iterateChildren(nodep);
     }
-    void visit(AstCoverDecl* nodep) override {
+    void visit(AstNodeCoverDecl* nodep) override {
         // Fix path in coverage statements
         nodep->hier(VString::dot(m_cellp->prettyName(), ".", nodep->hier()));
         iterateChildren(nodep);

--- a/src/V3Undriven.cpp
+++ b/src/V3Undriven.cpp
@@ -545,7 +545,7 @@ class UndrivenVisitor final : public VNVisitorConst {
     void visit(AstPrimitive*) override {}
 
     // Coverage artifacts etc shouldn't count as a sink
-    void visit(AstCoverDecl*) override {}
+    void visit(AstNodeCoverDecl*) override {}
     void visit(AstCoverInc*) override {}
     void visit(AstCoverToggle*) override {}
     void visit(AstTraceDecl*) override {}

--- a/test_regress/t/t_cover_line_wide_ternary.out
+++ b/test_regress/t/t_cover_line_wide_ternary.out
@@ -41,9 +41,9 @@
 -000009  point: comment=block hier=top.t
 %000009             cyc[0] ?
 -000009  point: comment=cond_then hier=top.t
--000009  point: comment=cond_else hier=top.t
 %000009             {intfs[1].foo, intfs[1].bar, intfs[1].baz} :
 -000009  point: comment=cond_then hier=top.t
+-000009  point: comment=cond_else hier=top.t
 %000009             {intfs[0].foo, intfs[0].bar, intfs[0].baz};
 -000009  point: comment=cond_else hier=top.t
             end
@@ -54,9 +54,9 @@
 +000010  point: comment=block hier=top.t
  000010             cyc[0] ?
 +000010  point: comment=cond_then hier=top.t
-+000010  point: comment=cond_else hier=top.t
  000010             {intfs[1].foo, intfs[1].bar, intfs[1].baz} :
 +000010  point: comment=cond_then hier=top.t
++000010  point: comment=cond_else hier=top.t
  000010             {intfs[0].foo, intfs[0].bar, intfs[0].baz};
 +000010  point: comment=cond_else hier=top.t
             end
@@ -65,9 +65,9 @@
                 {intf_sel_assign.foo, intf_sel_assign.bar, intf_sel_assign.baz} =
  000010             cyc[0] ?
 +000010  point: comment=cond_then hier=top.t
-+000010  point: comment=cond_else hier=top.t
  000010             {intfs[1].foo, intfs[1].bar, intfs[1].baz} :
 +000010  point: comment=cond_then hier=top.t
++000010  point: comment=cond_else hier=top.t
  000010             {intfs[0].foo, intfs[0].bar, intfs[0].baz};
 +000010  point: comment=cond_else hier=top.t
         

--- a/test_regress/t/t_cover_toggle.out
+++ b/test_regress/t/t_cover_toggle.out
@@ -50,7 +50,9 @@
            str_queue_t str_queue;
         
            typedef struct packed {
-              bit [5:3] x;
+              // verilator lint_off ASCRANGE
+              bit [3:5] x;
+              // verilator lint_on ASCRANGE
               bit [0:0] y;
            } str_bit_t;
 %000002    str_bit_t str_bit;

--- a/test_regress/t/t_cover_toggle.out
+++ b/test_regress/t/t_cover_toggle.out
@@ -49,6 +49,13 @@
            } str_queue_t;
            str_queue_t str_queue;
         
+           typedef struct packed {
+              bit [5:3] x;
+              bit [0:0] y;
+           } str_bit_t;
+%000002    str_bit_t str_bit;
+%000002    str_bit_t [5:2] str_bit_arr;
+        
            assign strl.a = clk;
         
            alpha a1 (/*AUTOINST*/
@@ -108,10 +115,16 @@
                  if (cyc == 3) begin
                     str_queue.q.push_back(1);
                     toggle <= '1;
+                    str_bit.x <= '1;
+                    str_bit.y <= '1;
+                    str_bit_arr[4].x <= '1;
                  end
                  if (cyc == 4) begin
                     if (str_queue.q.size() != 1) $stop;
                     toggle <= '0;
+                    str_bit.x[3] <= 0;
+                    str_bit.y[0] <= 0;
+                    str_bit_arr[4].x[3] <= 0;
                  end
                  else if (cyc == 10) begin
                     $write("*-* All Finished *-*\n");

--- a/test_regress/t/t_cover_toggle.py
+++ b/test_regress/t/t_cover_toggle.py
@@ -21,7 +21,7 @@ test.inline_checks()
 test.file_grep_not(test.obj_dir + "/coverage.dat", "largeish")
 
 if test.vlt_all:
-    test.file_grep(test.stats, r'Coverage, Toggle points joined\s+(\d+)', 27)
+    test.file_grep(test.stats, r'Coverage, Toggle points joined\s+(\d+)', 13)
 
 test.run(cmd=[
     os.environ["VERILATOR_ROOT"] + "/bin/verilator_coverage",

--- a/test_regress/t/t_cover_toggle.v
+++ b/test_regress/t/t_cover_toggle.v
@@ -49,7 +49,9 @@ module t (/*AUTOARG*/
    str_queue_t str_queue;
 
    typedef struct packed {
-      bit [5:3] x;
+      // verilator lint_off ASCRANGE
+      bit [3:5] x;
+      // verilator lint_on ASCRANGE
       bit [0:0] y;
    } str_bit_t;
    str_bit_t str_bit;

--- a/test_regress/t/t_cover_toggle.v
+++ b/test_regress/t/t_cover_toggle.v
@@ -50,6 +50,7 @@ module t (/*AUTOARG*/
 
    typedef struct packed {
       bit [5:3] x;
+      bit [0:0] y;
    } str_bit_t;
    str_bit_t str_bit;
    str_bit_t [5:2] str_bit_arr;
@@ -114,12 +115,14 @@ module t (/*AUTOARG*/
             str_queue.q.push_back(1);
             toggle <= '1;
             str_bit.x <= '1;
+            str_bit.y <= '1;
             str_bit_arr[4].x <= '1;
          end
          if (cyc == 4) begin
             if (str_queue.q.size() != 1) $stop;
             toggle <= '0;
             str_bit.x[3] <= 0;
+            str_bit.y[0] <= 0;
             str_bit_arr[2].x[3] <= 0;
          end
          else if (cyc == 10) begin

--- a/test_regress/t/t_cover_toggle.v
+++ b/test_regress/t/t_cover_toggle.v
@@ -123,7 +123,7 @@ module t (/*AUTOARG*/
             toggle <= '0;
             str_bit.x[3] <= 0;
             str_bit.y[0] <= 0;
-            str_bit_arr[2].x[3] <= 0;
+            str_bit_arr[4].x[3] <= 0;
          end
          else if (cyc == 10) begin
             $write("*-* All Finished *-*\n");

--- a/test_regress/t/t_cover_toggle.v
+++ b/test_regress/t/t_cover_toggle.v
@@ -48,6 +48,12 @@ module t (/*AUTOARG*/
    } str_queue_t;
    str_queue_t str_queue;
 
+   typedef struct packed {
+      bit [5:3] x;
+   } str_bit_t;
+   str_bit_t str_bit;
+   str_bit_t [5:2] str_bit_arr;
+
    assign strl.a = clk;
 
    alpha a1 (/*AUTOINST*/
@@ -107,10 +113,14 @@ module t (/*AUTOARG*/
          if (cyc == 3) begin
             str_queue.q.push_back(1);
             toggle <= '1;
+            str_bit.x <= '1;
+            str_bit_arr[4].x <= '1;
          end
          if (cyc == 4) begin
             if (str_queue.q.size() != 1) $stop;
             toggle <= '0;
+            str_bit.x[3] <= 0;
+            str_bit_arr[2].x[3] <= 0;
          end
          else if (cyc == 10) begin
             $write("*-* All Finished *-*\n");

--- a/test_regress/t/t_cover_toggle__points.out
+++ b/test_regress/t/t_cover_toggle__points.out
@@ -67,6 +67,33 @@
            } str_queue_t;
            str_queue_t str_queue;
         
+           typedef struct packed {
+              bit [5:3] x;
+              bit [0:0] y;
+           } str_bit_t;
+%000002    str_bit_t str_bit;
+-000002  point: comment=str_bit.x[3] hier=top.t
+-000001  point: comment=str_bit.x[4] hier=top.t
+-000001  point: comment=str_bit.x[5] hier=top.t
+-000002  point: comment=str_bit.y[0] hier=top.t
+%000002    str_bit_t [5:2] str_bit_arr;
+-000000  point: comment=str_bit_arr[2].x[3] hier=top.t
+-000000  point: comment=str_bit_arr[2].x[4] hier=top.t
+-000000  point: comment=str_bit_arr[2].x[5] hier=top.t
+-000000  point: comment=str_bit_arr[2].y[0] hier=top.t
+-000000  point: comment=str_bit_arr[3].x[3] hier=top.t
+-000000  point: comment=str_bit_arr[3].x[4] hier=top.t
+-000000  point: comment=str_bit_arr[3].x[5] hier=top.t
+-000000  point: comment=str_bit_arr[3].y[0] hier=top.t
+-000002  point: comment=str_bit_arr[4].x[3] hier=top.t
+-000001  point: comment=str_bit_arr[4].x[4] hier=top.t
+-000001  point: comment=str_bit_arr[4].x[5] hier=top.t
+-000000  point: comment=str_bit_arr[4].y[0] hier=top.t
+-000000  point: comment=str_bit_arr[5].x[3] hier=top.t
+-000000  point: comment=str_bit_arr[5].x[4] hier=top.t
+-000000  point: comment=str_bit_arr[5].x[5] hier=top.t
+-000000  point: comment=str_bit_arr[5].y[0] hier=top.t
+        
            assign strl.a = clk;
         
            alpha a1 (/*AUTOINST*/
@@ -150,10 +177,16 @@
                  if (cyc == 3) begin
                     str_queue.q.push_back(1);
                     toggle <= '1;
+                    str_bit.x <= '1;
+                    str_bit.y <= '1;
+                    str_bit_arr[4].x <= '1;
                  end
                  if (cyc == 4) begin
                     if (str_queue.q.size() != 1) $stop;
                     toggle <= '0;
+                    str_bit.x[3] <= 0;
+                    str_bit.y[0] <= 0;
+                    str_bit_arr[4].x[3] <= 0;
                  end
                  else if (cyc == 10) begin
                     $write("*-* All Finished *-*\n");

--- a/test_regress/t/t_cover_toggle__points.out
+++ b/test_regress/t/t_cover_toggle__points.out
@@ -68,7 +68,9 @@
            str_queue_t str_queue;
         
            typedef struct packed {
-              bit [5:3] x;
+              // verilator lint_off ASCRANGE
+              bit [3:5] x;
+              // verilator lint_on ASCRANGE
               bit [0:0] y;
            } str_bit_t;
 %000002    str_bit_t str_bit;

--- a/test_regress/t/t_opt_const_cov.py
+++ b/test_regress/t/t_opt_const_cov.py
@@ -16,6 +16,6 @@ test.compile(verilator_flags2=["-Wno-UNOPTTHREADS", "--stats", "--coverage", "--
 test.execute()
 
 if test.vlt:
-    test.file_grep(test.stats, r'Optimizations, Const bit op reduction\s+(\d+)', 620)
+    test.file_grep(test.stats, r'Optimizations, Const bit op reduction\s+(\d+)', 478)
 
 test.passes()


### PR DESCRIPTION
It is pre-pull to https://github.com/verilator/verilator/pull/6086. It does what was discussed in the comments.

It also adds assertion that checks if the type of a variable is non-opaque. I noticed that in that case the condition of incrementattion is wrong. I wanted to fix it, but as I checked, toggle coverage is disabled for all such types.