### PR TITLE
Fix variables declared in fork after taskify

### DIFF
--- a/src/V3Fork.cpp
+++ b/src/V3Fork.cpp
@@ -605,6 +605,10 @@ class ForkVisitor final : public VNVisitor {
         m_modp->addStmtsp(taskp);
         UINFO(9, "new " << taskp);
 
+        // We created a task from fork, so make sure that all
+        // local (to this new task) variables are marked as funcLocal
+        for (AstVar* const localp : m_forkLocalsp) localp->funcLocal(true);
+
         AstTaskRef* const taskrefp = new AstTaskRef{nodep->fileline(), taskp, m_capturedVarRefsp};
         AstStmtExpr* const taskcallp = taskrefp->makeStmt();
         // Replaced nodes will be revisited, so we don't need to "lift" the arguments

--- a/test_regress/t/t_var_in_fork.v
+++ b/test_regress/t/t_var_in_fork.v
@@ -47,6 +47,14 @@ module t();
     $display("Static variable: %d", static_var);
     if (static_var != 1)
       $stop;
+    fork
+      begin
+          automatic int my_auto_var = 0;
+          my_auto_var++;
+          $display("Automatic variable in fork: %d", my_auto_var);
+          if (my_auto_var != 1) $stop;
+      end
+    join_none
     $write("*-* All Finished *-*\n");
     $finish;
   end


### PR DESCRIPTION
This fixes usage of variables that are declared inside `fork` that are tasfied and in result made local to this new task.

Currently verilator gives:
``` 
%Error: Internal Error: t/t_var_in_fork.v:52:25: ../V3Task.cpp:126: No scope for var
                                               : ... note: In instance 't'
   52 |           automatic int my_auto_var = 0;
      |                         ^~~~~~~~~~~
```