### PR TITLE
Fix expression coverage with `this` (#5849)

### DIFF
--- a/src/V3Broken.cpp
+++ b/src/V3Broken.cpp
@@ -166,7 +166,8 @@ private:
         nodep->brokenState(m_brokenCntCurrentUnder);
         const char* const whyp = nodep->brokenGen();
         UASSERT_OBJ(!whyp, nodep,
-                    "Broken link in node (or something without maybePointedTo): " << whyp << " -- " << nodep);
+                    "Broken link in node (or something without maybePointedTo): " << whyp << " -- "
+                                                                                  << nodep);
         if (!s_brokenAllowMidvisitorCheck) nodep->checkIter();
         if (nodep->dtypep()) {
             UASSERT_OBJ(nodep->dtypep()->brokeExists(), nodep,

--- a/src/V3Broken.cpp
+++ b/src/V3Broken.cpp
@@ -166,7 +166,7 @@ private:
         nodep->brokenState(m_brokenCntCurrentUnder);
         const char* const whyp = nodep->brokenGen();
         UASSERT_OBJ(!whyp, nodep,
-                    "Broken link in node (or something without maybePointedTo): " << whyp);
+                    "Broken link in node (or something without maybePointedTo): " << whyp << " -- " << nodep);
         if (!s_brokenAllowMidvisitorCheck) nodep->checkIter();
         if (nodep->dtypep()) {
             UASSERT_OBJ(nodep->dtypep()->brokeExists(), nodep,

--- a/src/V3Coverage.cpp
+++ b/src/V3Coverage.cpp
@@ -54,7 +54,7 @@ class ExprCoverageEligibleVisitor final : public VNVisitor {
     }
 
     void visit(AstNode* nodep) override {
-        if (!nodep->isExprCoverageEligible()) {
+        if (!nodep->isExprCoverageEligible() || !nodep->isPure()) {
             m_eligible = false;
         } else {
             iterateChildren(nodep);
@@ -63,7 +63,7 @@ class ExprCoverageEligibleVisitor final : public VNVisitor {
 
 public:
     // CONSTRUCTORS
-    explicit ExprCoverageEligibleVisitor(AstNode* nodep) { iterateChildren(nodep); }
+    explicit ExprCoverageEligibleVisitor(AstNode* nodep) { iterate(nodep); }
     ~ExprCoverageEligibleVisitor() override = default;
 
     bool eligible() { return m_eligible; }


### PR DESCRIPTION
I believe this should close out #5849 .  This fixes the last couple test failures that show up with `--coverage-expr` that don't also show up when running with `--coverage-line --coverage-toggle --coverage-user` instead.  The latter actually has a much larger list and both have some common failures including internal errors.  So there's still work that could be done along these lines, but I'm willing to propose that at this point that I haven't made things worse.

This PR just makes file IO ineligible for expression coverage since the cloned coverage logic would otherwise try to make the system calls a second time.  One could stash the results of the system calls instead, but this is consistent with some of the previous cleanup and I think file IO is sufficiently left field to not worry about in this context for the time being.

The only other new "failure" I see is of this form:
```
%Warning: vlt/t_opt_const_no_expand: File_grep: obj_vlt/t_opt_const_no_expand/Vt_opt_const_no_expand__stats.txt: Got='3' Expected='1' in regexp: 'Optimizations, Const bit op reduction\s+(\d+)'
```
which makes sense since expression coverage clones expressions so we're bound to see more of these optimizations.