### PR TITLE
Improve docker image size

### DIFF
--- a/ci/docker/run/Dockerfile
+++ b/ci/docker/run/Dockerfile
@@ -48,7 +48,8 @@ RUN git clone "${REPO}" verilator && \
     make && \
     make install && \
     cd .. && \
-    rm -r verilator
+    rm -r verilator && \
+    ccache -C
 
 COPY verilator-wrap.sh /usr/local/bin/verilator-wrap.sh
 


### PR DESCRIPTION
Clear ccache during docker image build to save ~240MiB.

These files are not necessary for users, because they don't rebuild verilator within the docker container.
