### PR TITLE
Apply DFG before V3Gate.

### DIFF
--- a/docs/guide/exe_verilator.rst
+++ b/docs/guide/exe_verilator.rst
@@ -597,8 +597,8 @@ Summary:
 .. option:: -fno-dfg
 
    Rarely needed. Disable all use of the DFG-based combinational logic
-   optimizer.  Alias for :vlopt:`-fno-dfg-pre-inline` and
-   :vlopt:`-fno-dfg-post-inline`.
+   optimizer.  Alias for :vlopt:`-fno-dfg-pre-inline`,
+   :vlopt:`-fno-dfg-post-inline` and :vlopt:`-fno-dfg-scoped`.
 
 .. option:: -fno-dfg-peephole
 
@@ -615,6 +615,10 @@ Summary:
 .. option:: -fno-dfg-pre-inline
 
    Rarely needed. Do not apply the DFG optimizer before inlining.
+
+.. option:: -fno-dfg-scoped
+
+   Rarely needed. Do not apply the DFG optimizer across module scopes.
 
 .. option:: -fno-expand
 

--- a/src/V3Dfg.cpp
+++ b/src/V3Dfg.cpp
@@ -26,8 +26,8 @@ VL_DEFINE_DEBUG_FUNCTIONS;
 // DfgGraph
 //------------------------------------------------------------------------------
 
-DfgGraph::DfgGraph(AstModule& module, const string& name)
-    : m_modulep{&module}
+DfgGraph::DfgGraph(AstModule* modulep, const string& name)
+    : m_modulep{modulep}
     , m_name{name} {}
 
 DfgGraph::~DfgGraph() {
@@ -69,14 +69,31 @@ std::string DfgGraph::makeUniqueName(const std::string& prefix, size_t n) {
     return "__Vdfg" + prefix + m_tmpNameStub + std::to_string(n);
 }
 
-DfgVertexVar* DfgGraph::makeNewVar(FileLine* flp, const std::string& name, AstNodeDType* dtypep) {
-    // Add AstVar to containing module
-    AstVar* const varp = new AstVar{flp, VVarType::MODULETEMP, name, dtypep};
-    modulep()->addStmtsp(varp);
+DfgVertexVar* DfgGraph::makeNewVar(FileLine* flp, const std::string& name, AstNodeDType* dtypep,
+                                   AstScope* scopep) {
+    UASSERT_OBJ(!!scopep != !!modulep(), flp,
+                "makeNewVar scopep should only be provided for a scoped DfgGraph");
 
-    // Create and return the corresponding variable vertex
-    if (VN_IS(varp->dtypeSkipRefp(), UnpackArrayDType)) return new DfgVarArray{*this, varp};
-    return new DfgVarPacked{*this, varp};
+    // Create AstVar
+    AstVar* const varp = new AstVar{flp, VVarType::MODULETEMP, name, dtypep};
+
+    if (scopep) {
+        // Add AstVar to the scope's module
+        scopep->modp()->addStmtsp(varp);
+        // Create AstVarScope
+        AstVarScope* const vscp = new AstVarScope{flp, scopep, varp};
+        // Add to scope
+        scopep->addVarsp(vscp);
+        // Create and return the corresponding variable vertex
+        if (VN_IS(varp->dtypeSkipRefp(), UnpackArrayDType)) return new DfgVarArray{*this, vscp};
+        return new DfgVarPacked{*this, vscp};
+    } else {
+        // Add AstVar to containing module
+        modulep()->addStmtsp(varp);
+        // Create and return the corresponding variable vertex
+        if (VN_IS(varp->dtypeSkipRefp(), UnpackArrayDType)) return new DfgVarArray{*this, varp};
+        return new DfgVarPacked{*this, varp};
+    }
 }
 
 static const string toDotId(const DfgVertex& vtx) { return '"' + cvtToHex(&vtx) + '"'; }
@@ -85,9 +102,10 @@ static const string toDotId(const DfgVertex& vtx) { return '"' + cvtToHex(&vtx) 
 static void dumpDotVertex(std::ostream& os, const DfgVertex& vtx) {
 
     if (const DfgVarPacked* const varVtxp = vtx.cast<DfgVarPacked>()) {
+        AstNode* const nodep = varVtxp->nodep();
         AstVar* const varp = varVtxp->varp();
         os << toDotId(vtx);
-        os << " [label=\"" << varp->name() << "\nW" << varVtxp->width() << " / F"
+        os << " [label=\"" << nodep->name() << "\nW" << varVtxp->width() << " / F"
            << varVtxp->fanout() << '"';
 
         if (varp->direction() == VDirection::INPUT) {
@@ -112,10 +130,11 @@ static void dumpDotVertex(std::ostream& os, const DfgVertex& vtx) {
     }
 
     if (const DfgVarArray* const arrVtxp = vtx.cast<DfgVarArray>()) {
+        AstNode* const nodep = arrVtxp->nodep();
         AstVar* const varp = arrVtxp->varp();
         const int elements = VN_AS(arrVtxp->dtypep(), UnpackArrayDType)->elementsConst();
         os << toDotId(vtx);
-        os << " [label=\"" << varp->name() << "[" << elements << "]\"";
+        os << " [label=\"" << nodep->name() << "[" << elements << "]\"";
         if (varp->direction() == VDirection::INPUT) {
             os << ", shape=box3d, style=filled, fillcolor=chartreuse2";  // Green
         } else if (varp->direction() == VDirection::OUTPUT) {
@@ -299,7 +318,7 @@ void DfgGraph::dumpDotAllVarConesPrefixed(const string& label) const {
         if (!sinkp) return;
 
         // Open output file
-        const string coneName{prefix + sinkp->varp()->name()};
+        const string coneName{prefix + sinkp->nodep()->name()};
         const string fileName{v3Global.debugFilename(coneName) + ".dot"};
         const std::unique_ptr<std::ofstream> os{V3File::new_ofstream(fileName)};
         if (os->fail()) v3fatal("Can't write file: " << fileName);
@@ -476,13 +495,45 @@ DfgVarPacked* DfgVertex::getResultVar() {
             return;
         }
         // Prefer the one with the lexically smaller name
-        if (const int cmp = resp->varp()->name().compare(varp->varp()->name())) {
+        if (const int cmp = resp->nodep()->name().compare(varp->nodep()->name())) {
             if (cmp > 0) resp = varp;
             return;
         }
         // 'resp' and 'varp' are all the same, keep using the existing 'resp'
     });
     return resp;
+}
+
+AstScope* DfgVertex::scopep(ScopeCache& cache, bool tryResultVar) VL_MT_DISABLED {
+    // If this is a variable, we are done
+    if (DfgVertexVar* const varp = this->cast<DfgVertexVar>()) return varp->varScopep()->scopep();
+
+    // Try the result var first if instructed (usully only in the recursive case)
+    if (tryResultVar) {
+        if (DfgVertexVar* const varp = this->getResultVar()) return varp->varScopep()->scopep();
+    }
+
+    // Look up cache
+    const auto pair = cache.emplace(this, nullptr);
+    if (pair.second) {
+        // Find scope based on sources, falling back on the root scope
+        AstScope* const rootp = v3Global.rootp()->topScopep()->scopep();
+        AstScope* foundp = rootp;
+        const auto edges = sourceEdges();
+        for (size_t i = 0; i < edges.second; ++i) {
+            DfgEdge& edge = edges.first[i];
+            foundp = edge.sourcep()->scopep(cache, true);
+            if (foundp != rootp) break;
+        }
+        pair.first->second = foundp;
+    }
+
+    // If the cache entry exists, but have not set the mapping yet, then we have a circualr graph
+    UASSERT_OBJ(pair.first->second, this,
+                "DfgVertex::scopep called on graph with circular operations");
+
+    // Done
+    return pair.first->second;
 }
 
 void DfgVertex::unlinkDelete(DfgGraph& dfg) {
@@ -521,15 +572,17 @@ V3Hash DfgSel::selfHash() const { return V3Hash{lsb()}; }
 // DfgVertexVar ----------
 
 bool DfgVertexVar::selfEquals(const DfgVertex& that) const {
-    UASSERT_OBJ(varp() != that.as<DfgVertexVar>()->varp(), this,
-                "There should only be one DfgVertexVar for a given AstVar");
+    UASSERT_OBJ(nodep()->type() == that.as<DfgVertexVar>()->nodep()->type(), this,
+                "Both DfgVertexVar should be scoped or unscoped");
+    UASSERT_OBJ(nodep() != that.as<DfgVertexVar>()->nodep(), this,
+                "There should only be one DfgVertexVar for a given AstVar or AstVarScope");
     return false;
 }
 
 V3Hash DfgVertexVar::selfHash() const {
     V3Hash hash;
-    hash += m_varp->name();
-    hash += m_varp->varType();
+    hash += nodep()->name();
+    hash += varp()->varType();
     return hash;
 }
 

--- a/src/V3Dfg.h
+++ b/src/V3Dfg.h
@@ -203,16 +203,17 @@ public:
 
     // Return data type used to represent the type of 'nodep' when converted to a DfgVertex
     static AstNodeDType* dtypeFor(const AstNode* nodep) {
-        UDEBUGONLY(UASSERT_OBJ(isSupportedDType(nodep->dtypep()), nodep, "Unsupported dtype"););
+        const AstNodeDType* const dtypep = nodep->dtypep()->skipRefp();
+        UDEBUGONLY(UASSERT_OBJ(isSupportedDType(dtypep), nodep, "Unsupported dtype"););
         // For simplicity, all packed types are represented with a fixed type
-        if (AstUnpackArrayDType* const typep = VN_CAST(nodep->dtypep(), UnpackArrayDType)) {
+        if (const AstUnpackArrayDType* const typep = VN_CAST(dtypep, UnpackArrayDType)) {
             AstNodeDType* const adtypep = new AstUnpackArrayDType{
                 typep->fileline(), dtypeForWidth(typep->subDTypep()->width()),
                 typep->rangep()->cloneTree(false)};
             v3Global.rootp()->typeTablep()->addTypesp(adtypep);
             return adtypep;
         }
-        return dtypeForWidth(nodep->width());
+        return dtypeForWidth(dtypep->width());
     }
 
     // Source location
@@ -283,6 +284,18 @@ public:
     // Return a canonical variable vertex that holds the value of this vertex,
     // or nullptr if no such variable exists in the graph. This is O(fanout).
     DfgVarPacked* getResultVar() VL_MT_DISABLED;
+
+    // Cache type for 'scopep' below
+    using ScopeCache = std::unordered_map<const DfgVertex*, AstScope*>;
+
+    // Retrieve the prefred AstScope this vertex belongs to. For variable
+    // vertices this is defined. For operation vertices, we try to find a
+    // scope based on variables in the upstream logic cone (inputs). If
+    // there isn't one, (beceuse the whole upstream cone is constant...),
+    // then the root scope is returned. If 'tryResultVar' is true, we will
+    // condier the scope of 'getResultVar' first, if it exists.
+    // Only call this with a scoped DfgGraph
+    AstScope* scopep(ScopeCache& cache, bool tryResultVar = false) VL_MT_DISABLED;
 
     // If the node has a single sink, return it, otherwise return nullptr
     DfgVertex* singleSink() const {
@@ -643,14 +656,15 @@ class DfgGraph final {
     size_t m_size = 0;  // Number of vertices in the graph
     uint32_t m_userCurrent = 0;  // Vertex user data generation number currently in use
     uint32_t m_userCnt = 0;  // Vertex user data generation counter
-    // Parent of the graph (i.e.: the module containing the logic represented by this graph).
+    // Parent of the graph (i.e.: the module containing the logic represented by this graph),
+    // or nullptr when run after V3Scope
     AstModule* const m_modulep;
     const std::string m_name;  // Name of graph - need not be unique
     std::string m_tmpNameStub{""};  // Name stub for temporary variables - computed lazy
 
 public:
     // CONSTRUCTOR
-    explicit DfgGraph(AstModule& module, const string& name = "") VL_MT_DISABLED;
+    explicit DfgGraph(AstModule* modulep, const string& name = "") VL_MT_DISABLED;
     ~DfgGraph() VL_MT_DISABLED;
     VL_UNCOPYABLE(DfgGraph);
 
@@ -662,7 +676,7 @@ public:
     inline void removeVertex(DfgVertex& vtx);
     // Number of vertices in this graph
     size_t size() const { return m_size; }
-    // Parent module
+    // Parent module - or nullptr when run after V3Scope
     AstModule* modulep() const { return m_modulep; }
     // Name of this graph
     const string& name() const { return m_name; }
@@ -699,8 +713,11 @@ public:
     // must be unique (as a pair) in each invocation for this graph.
     std::string makeUniqueName(const std::string& prefix, size_t n) VL_MT_DISABLED;
 
-    // Create a new variable with the given name and data type
-    DfgVertexVar* makeNewVar(FileLine*, const std::string& name, AstNodeDType*) VL_MT_DISABLED;
+    // Create a new variable with the given name and data type. For a Scoped
+    // Dfg, the AstScope where the corresponding AstVarScope will be inserted
+    // must be provided
+    DfgVertexVar* makeNewVar(FileLine*, const std::string& name, AstNodeDType*,
+                             AstScope*) VL_MT_DISABLED;
 
     // Split this graph into individual components (unique sub-graphs with no edges between them).
     // Also removes any vertices that are not weakly connected to any variable.
@@ -888,6 +905,24 @@ bool DfgVertex::isZero() const {
 bool DfgVertex::isOnes() const {
     if (const DfgConst* const constp = cast<DfgConst>()) return constp->isOnes();
     return false;
+}
+
+//------------------------------------------------------------------------------
+// Inline method definitions - for DfgVertexVar
+//------------------------------------------------------------------------------
+
+DfgVertexVar::DfgVertexVar(DfgGraph& dfg, VDfgType type, AstVar* varp, uint32_t initialCapacity)
+    : DfgVertexVariadic{dfg, type, varp->fileline(), dtypeFor(varp), initialCapacity}
+    , m_varp{varp}
+    , m_varScopep{nullptr} {
+    UASSERT_OBJ(dfg.modulep(), varp, "Un-scoped DfgVertexVar created in scoped DfgGraph");
+}
+DfgVertexVar::DfgVertexVar(DfgGraph& dfg, VDfgType type, AstVarScope* vscp,
+                           uint32_t initialCapacity)
+    : DfgVertexVariadic{dfg, type, vscp->fileline(), dtypeFor(vscp), initialCapacity}
+    , m_varp{vscp->varp()}
+    , m_varScopep{vscp} {
+    UASSERT_OBJ(!dfg.modulep(), vscp, "Scoped DfgVertexVar created in un-scoped DfgGraph");
 }
 
 //------------------------------------------------------------------------------

--- a/src/V3DfgOptimizer.cpp
+++ b/src/V3DfgOptimizer.cpp
@@ -236,75 +236,101 @@ void V3DfgOptimizer::extract(AstNetlist* netlistp) {
     V3Global::dumpCheckGlobalTree("dfg-extract", 0, dumpTreeEitherLevel() >= 3);
 }
 
+static void process(DfgGraph& dfg, V3DfgOptimizationContext& ctx) {
+    // Extract the cyclic sub-graphs. We do this because a lot of the optimizations assume a
+    // DAG, and large, mostly acyclic graphs could not be optimized due to the presence of
+    // small cycles.
+    const std::vector<std::unique_ptr<DfgGraph>>& cyclicComponents
+        = dfg.extractCyclicComponents("cyclic");
+
+    // Split the remaining acyclic DFG into [weakly] connected components
+    const std::vector<std::unique_ptr<DfgGraph>>& acyclicComponents
+        = dfg.splitIntoComponents("acyclic");
+
+    // Quick sanity check
+    UASSERT_OBJ(dfg.size() == 0, dfg.modulep(), "DfgGraph should have become empty");
+
+    // For each acyclic component
+    for (auto& component : acyclicComponents) {
+        if (dumpDfgLevel() >= 7) component->dumpDotFilePrefixed(ctx.prefix() + "source");
+        // Optimize the component
+        V3DfgPasses::optimize(*component, ctx);
+        // Add back under the main DFG (we will convert everything back in one go)
+        dfg.addGraph(*component);
+    }
+
+    // Eliminate redundant variables. Run this on the whole acyclic DFG. It needs to traverse
+    // the module/netlist to perform variable substitutions. Doing this by component would do
+    // redundant traversals and can be extremely slow when we have many components.
+    V3DfgPasses::eliminateVars(dfg, ctx.m_eliminateVarsContext);
+
+    // For each cyclic component
+    for (auto& component : cyclicComponents) {
+        if (dumpDfgLevel() >= 7) component->dumpDotFilePrefixed(ctx.prefix() + "source");
+        // Converting back to Ast assumes the 'regularize' pass was run, so we must run it
+        V3DfgPasses::regularize(*component, ctx.m_regularizeContext);
+        // Add back under the main DFG (we will convert everything back in one go)
+        dfg.addGraph(*component);
+    }
+}
+
 void V3DfgOptimizer::optimize(AstNetlist* netlistp, const string& label) {
     UINFO(2, __FUNCTION__ << ":");
 
     // NODE STATE
-    // AstVar::user1 -> Used by V3DfgPasses::astToDfg, V3DfgPasses::eliminateVars
+    // AstVar::user1 -> Used by:
+    //                    - V3DfgPasses::astToDfg,
+    //                    - V3DfgPasses::eliminateVars,
+    //                    - V3DfgPasses::dfgToAst,
     // AstVar::user2 -> bool: Flag indicating referenced by AstVarXRef (set just below)
-    // AstVar::user3 -> bool: Flag indicating written by logic not representable as DFG
+    // AstVar::user3, AstVarScope::user3
+    //               -> bool: Flag indicating written by logic not representable as DFG
     //                        (set by V3DfgPasses::astToDfg)
     const VNUser2InUse user2InUse;
     const VNUser3InUse user3InUse;
 
-    // Mark cross-referenced variables
-    netlistp->foreach([](const AstVarXRef* xrefp) { xrefp->varp()->user2(true); });
-
     V3DfgOptimizationContext ctx{label};
 
-    // Run the optimization phase
-    for (AstNode* nodep = netlistp->modulesp(); nodep; nodep = nodep->nextp()) {
-        // Only optimize proper modules
-        AstModule* const modp = VN_CAST(nodep, Module);
-        if (!modp) continue;
+    if (!netlistp->topScopep()) {
+        // Pre V3Scope application. Run on each module separately.
 
-        UINFO(4, "Applying DFG optimization to module '" << modp->name() << "'");
-        ++ctx.m_modules;
+        // Mark cross-referenced variables
+        netlistp->foreach([](const AstVarXRef* xrefp) { xrefp->varp()->user2(true); });
 
-        // Build the DFG of this module
-        const std::unique_ptr<DfgGraph> dfg{V3DfgPasses::astToDfg(*modp, ctx)};
+        // Run the optimization phase
+        for (AstNode* nodep = netlistp->modulesp(); nodep; nodep = nodep->nextp()) {
+            // Only optimize proper modules
+            AstModule* const modp = VN_CAST(nodep, Module);
+            if (!modp) continue;
+
+            UINFO(4, "Applying DFG optimization to module '" << modp->name() << "'");
+            ++ctx.m_modules;
+
+            // Build the DFG of this module
+            const std::unique_ptr<DfgGraph> dfg{V3DfgPasses::astToDfg(*modp, ctx)};
+            if (dumpDfgLevel() >= 8) dfg->dumpDotFilePrefixed(ctx.prefix() + "whole-input");
+
+            // Actually process the graph
+            process(*dfg, ctx);
+
+            // Convert back to Ast
+            if (dumpDfgLevel() >= 8) dfg->dumpDotFilePrefixed(ctx.prefix() + "whole-optimized");
+            V3DfgPasses::dfgToAst(*dfg, ctx);
+        }
+    } else {
+        // Post V3Scope application. Run on whole netlist.
+        UINFO(4, "Applying DFG optimization to entire netlist");
+
+        // Build the DFG of the whole design
+        const std::unique_ptr<DfgGraph> dfg{V3DfgPasses::astToDfg(*netlistp, ctx)};
         if (dumpDfgLevel() >= 8) dfg->dumpDotFilePrefixed(ctx.prefix() + "whole-input");
 
-        // Extract the cyclic sub-graphs. We do this because a lot of the optimizations assume a
-        // DAG, and large, mostly acyclic graphs could not be optimized due to the presence of
-        // small cycles.
-        const std::vector<std::unique_ptr<DfgGraph>>& cyclicComponents
-            = dfg->extractCyclicComponents("cyclic");
-
-        // Split the remaining acyclic DFG into [weakly] connected components
-        const std::vector<std::unique_ptr<DfgGraph>>& acyclicComponents
-            = dfg->splitIntoComponents("acyclic");
-
-        // Quick sanity check
-        UASSERT_OBJ(dfg->size() == 0, nodep, "DfgGraph should have become empty");
-
-        // For each acyclic component
-        for (auto& component : acyclicComponents) {
-            if (dumpDfgLevel() >= 7) component->dumpDotFilePrefixed(ctx.prefix() + "source");
-            // Optimize the component
-            V3DfgPasses::optimize(*component, ctx);
-            // Add back under the main DFG (we will convert everything back in one go)
-            dfg->addGraph(*component);
-        }
-
-        // Eliminate redundant variables. Run this on the whole acyclic DFG. It needs to traverse
-        // the module to perform variable substitutions. Doing this by component would do
-        // redundant traversals and can be extremely slow in large modules with many components.
-        V3DfgPasses::eliminateVars(*dfg, ctx.m_eliminateVarsContext);
-
-        // For each cyclic component
-        for (auto& component : cyclicComponents) {
-            if (dumpDfgLevel() >= 7) component->dumpDotFilePrefixed(ctx.prefix() + "source");
-            // Converting back to Ast assumes the 'regularize' pass was run, so we must run it
-            V3DfgPasses::regularize(*component, ctx.m_regularizeContext);
-            // Add back under the main DFG (we will convert everything back in one go)
-            dfg->addGraph(*component);
-        }
+        // Actually process the graph
+        process(*dfg, ctx);
 
         // Convert back to Ast
         if (dumpDfgLevel() >= 8) dfg->dumpDotFilePrefixed(ctx.prefix() + "whole-optimized");
-        AstModule* const resultModp = V3DfgPasses::dfgToAst(*dfg, ctx);
-        UASSERT_OBJ(resultModp == modp, modp, "Should be the same module");
+        V3DfgPasses::dfgToAst(*dfg, ctx);
     }
 
     V3Global::dumpCheckGlobalTree("dfg-optimize", 0, dumpTreeEitherLevel() >= 3);

--- a/src/V3DfgPasses.h
+++ b/src/V3DfgPasses.h
@@ -117,12 +117,14 @@ namespace V3DfgPasses {
 // constructed DfgGraph.
 DfgGraph* astToDfg(AstModule&, V3DfgOptimizationContext&) VL_MT_DISABLED;
 
+// Same as above, but for the entire netlist, after V3Scope
+DfgGraph* astToDfg(AstNetlist&, V3DfgOptimizationContext&) VL_MT_DISABLED;
+
 // Optimize the given DfgGraph
 void optimize(DfgGraph&, V3DfgOptimizationContext&) VL_MT_DISABLED;
 
-// Convert DfgGraph back into Ast, and insert converted graph back into its parent module.
-// Returns the parent module.
-AstModule* dfgToAst(DfgGraph&, V3DfgOptimizationContext&) VL_MT_DISABLED;
+// Convert DfgGraph back into Ast, and insert converted graph back into the Ast.
+void dfgToAst(DfgGraph&, V3DfgOptimizationContext&) VL_MT_DISABLED;
 
 //===========================================================================
 // Intermediate/internal operations

--- a/src/V3DfgPatternStats.h
+++ b/src/V3DfgPatternStats.h
@@ -28,7 +28,7 @@ class V3DfgPatternStats final {
     static constexpr uint32_t MAX_PATTERN_DEPTH = 4;
 
     std::map<std::string, std::string> m_internedConsts;  // Interned constants
-    std::map<const AstVar*, std::string> m_internedVars;  // Interned variables
+    std::map<const AstNode*, std::string> m_internedVars;  // Interned variables
     std::map<uint32_t, std::string> m_internedSelLsbs;  // Interned lsb value for selects
     std::map<uint32_t, std::string> m_internedWordWidths;  // Interned widths
     std::map<uint32_t, std::string> m_internedWideWidths;  // Interned widths
@@ -51,7 +51,7 @@ class V3DfgPatternStats final {
     }
 
     const std::string& internVar(const DfgVertexVar& vtx) {
-        const auto pair = m_internedVars.emplace(vtx.varp(), "v");
+        const auto pair = m_internedVars.emplace(vtx.nodep(), "v");
         if (pair.second) pair.first->second += toLetters(m_internedVars.size() - 1);
         return pair.first->second;
     }

--- a/src/V3DfgPeephole.cpp
+++ b/src/V3DfgPeephole.cpp
@@ -403,8 +403,8 @@ class V3DfgPeephole final : public DfgVisitor {
         // If both sides are variable references, order the side in some defined way. This
         // allows CSE to later merge 'a op b' with 'b op a'.
         if (lhsp->is<DfgVertexVar>() && rhsp->is<DfgVertexVar>()) {
-            AstVar* const lVarp = lhsp->as<DfgVertexVar>()->varp();
-            AstVar* const rVarp = rhsp->as<DfgVertexVar>()->varp();
+            AstNode* const lVarp = lhsp->as<DfgVertexVar>()->nodep();
+            AstNode* const rVarp = rhsp->as<DfgVertexVar>()->nodep();
             if (lVarp->name() > rVarp->name()) {
                 APPLYING(SWAP_VAR_IN_COMMUTATIVE_BINARY) {
                     Vertex* const replacementp = make<Vertex>(vtxp, rhsp, lhsp);

--- a/src/V3DfgRegularize.cpp
+++ b/src/V3DfgRegularize.cpp
@@ -38,6 +38,10 @@ class DfgRegularize final {
         : m_dfg{dfg}
         , m_ctx{ctx} {
 
+        // Scope cache for below
+        const bool scoped = !dfg.modulep();
+        DfgVertex::ScopeCache scopeCache;
+
         // Ensure intermediate values used multiple times are written to variables
         for (DfgVertex& vtx : m_dfg.opVertices()) {
             const bool needsIntermediateVariable = [&]() {
@@ -71,8 +75,9 @@ class DfgRegularize final {
                 // Need to create an intermediate variable
                 const std::string name = m_dfg.makeUniqueName("Regularize", m_nTmps);
                 FileLine* const flp = vtx.fileline();
+                AstScope* const scopep = scoped ? vtx.scopep(scopeCache) : nullptr;
                 DfgVarPacked* const newp
-                    = m_dfg.makeNewVar(flp, name, vtx.dtypep())->as<DfgVarPacked>();
+                    = m_dfg.makeNewVar(flp, name, vtx.dtypep(), scopep)->as<DfgVarPacked>();
                 ++m_nTmps;
                 ++m_ctx.m_temporariesIntroduced;
                 // Replace vertex with the variable and add back driver

--- a/src/V3DfgVertices.h
+++ b/src/V3DfgVertices.h
@@ -40,6 +40,7 @@
 
 class DfgVertexVar VL_NOT_FINAL : public DfgVertexVariadic {
     AstVar* const m_varp;  // The AstVar associated with this vertex (not owned by this vertex)
+    AstVarScope* const m_varScopep;  // The AstVarScope associated with this vertex (not owned)
     bool m_hasDfgRefs = false;  // This AstVar is referenced in a different DFG of the module
     bool m_hasModRefs = false;  // This AstVar is referenced outside the DFG, but in the module
     bool m_hasExtRefs = false;  // This AstVar is referenced from outside the module
@@ -48,14 +49,17 @@ class DfgVertexVar VL_NOT_FINAL : public DfgVertexVariadic {
     V3Hash selfHash() const final VL_MT_DISABLED;
 
 public:
-    DfgVertexVar(DfgGraph& dfg, VDfgType type, AstVar* varp, uint32_t initialCapacity)
-        : DfgVertexVariadic{dfg, type, varp->fileline(), dtypeFor(varp), initialCapacity}
-        , m_varp{varp} {}
+    inline DfgVertexVar(DfgGraph& dfg, VDfgType type, AstVar* varp, uint32_t initialCapacity);
+    inline DfgVertexVar(DfgGraph& dfg, VDfgType type, AstVarScope* vscp, uint32_t initialCapacity);
     ASTGEN_MEMBERS_DfgVertexVar;
 
     bool isDrivenByDfg() const { return arity() > 0; }
 
     AstVar* varp() const { return m_varp; }
+    AstVarScope* varScopep() const { return m_varScopep; }
+    AstNode* nodep() const {
+        return m_varScopep ? static_cast<AstNode*>(m_varScopep) : static_cast<AstNode*>(m_varp);
+    }
     bool hasDfgRefs() const { return m_hasDfgRefs; }
     void setHasDfgRefs() { m_hasDfgRefs = true; }
     bool hasModRefs() const { return m_hasModRefs; }
@@ -73,7 +77,7 @@ public:
         // Keep if public
         if (varp()->isSigPublic()) return true;
         // Keep if written in non-DFG code
-        if (varp()->user3()) return true;
+        if (nodep()->user3()) return true;
         // Otherwise it can be removed
         return false;
     }
@@ -181,7 +185,11 @@ class DfgVarArray final : public DfgVertexVar {
 public:
     DfgVarArray(DfgGraph& dfg, AstVar* varp)
         : DfgVertexVar{dfg, dfgType(), varp, 4u} {
-        UASSERT_OBJ(VN_IS(varp->dtypeSkipRefp(), UnpackArrayDType), varp, "Non array DfgVarArray");
+        UASSERT_OBJ(VN_IS(dtypep(), UnpackArrayDType), varp, "Non array DfgVarArray");
+    }
+    DfgVarArray(DfgGraph& dfg, AstVarScope* vscp)
+        : DfgVertexVar{dfg, dfgType(), vscp, 4u} {
+        UASSERT_OBJ(VN_IS(dtypep(), UnpackArrayDType), vscp, "Non array DfgVarArray");
     }
     ASTGEN_MEMBERS_DfgVarArray;
 
@@ -239,6 +247,8 @@ class DfgVarPacked final : public DfgVertexVar {
 public:
     DfgVarPacked(DfgGraph& dfg, AstVar* varp)
         : DfgVertexVar{dfg, dfgType(), varp, 1u} {}
+    DfgVarPacked(DfgGraph& dfg, AstVarScope* vscp)
+        : DfgVertexVar{dfg, dfgType(), vscp, 1u} {}
     ASTGEN_MEMBERS_DfgVarPacked;
 
     bool isDrivenFullyByDfg() const {

--- a/src/V3Options.cpp
+++ b/src/V3Options.cpp
@@ -1331,6 +1331,7 @@ void V3Options::parseOptsList(FileLine* fl, const string& optdir, int argc,
     DECL_OPTION("-fdfg", CbFOnOff, [this](bool flag) {
         m_fDfgPreInline = flag;
         m_fDfgPostInline = flag;
+        m_fDfgScoped = flag;
     });
     DECL_OPTION("-fdfg-peephole", FOnOff, &m_fDfgPeephole);
     DECL_OPTION("-fdfg-peephole-", CbPartialMatch, [this](const char* optp) {  //
@@ -1341,6 +1342,7 @@ void V3Options::parseOptsList(FileLine* fl, const string& optdir, int argc,
     });
     DECL_OPTION("-fdfg-pre-inline", FOnOff, &m_fDfgPreInline);
     DECL_OPTION("-fdfg-post-inline", FOnOff, &m_fDfgPostInline);
+    DECL_OPTION("-fdfg-scoped", FOnOff, &m_fDfgScoped);
     DECL_OPTION("-fexpand", FOnOff, &m_fExpand);
     DECL_OPTION("-ffunc-opt", CbFOnOff, [this](bool flag) {  //
         m_fFuncSplitCat = flag;
@@ -2182,6 +2184,7 @@ void V3Options::optimize(int level) {
     m_fDedupe = flag;
     m_fDfgPreInline = flag;
     m_fDfgPostInline = flag;
+    m_fDfgScoped = flag;
     m_fDeadAssigns = flag;
     m_fDeadCells = flag;
     m_fExpand = flag;

--- a/src/V3Options.h
+++ b/src/V3Options.h
@@ -423,6 +423,7 @@ private:
     bool m_fDfgPeephole = true; // main switch: -fno-dfg-peephole
     bool m_fDfgPreInline;    // main switch: -fno-dfg-pre-inline and -fno-dfg
     bool m_fDfgPostInline;   // main switch: -fno-dfg-post-inline and -fno-dfg
+    bool m_fDfgScoped;       // main switch: -fno-dfg-scoped and -fno-dfg
     bool m_fDeadAssigns;     // main switch: -fno-dead-assigns: remove dead assigns
     bool m_fDeadCells;   // main switch: -fno-dead-cells: remove dead cells
     bool m_fExpand;      // main switch: -fno-expand: expansion of C macros
@@ -737,6 +738,7 @@ public:
     bool fDfgPeephole() const { return m_fDfgPeephole; }
     bool fDfgPreInline() const { return m_fDfgPreInline; }
     bool fDfgPostInline() const { return m_fDfgPostInline; }
+    bool fDfgScoped() const { return m_fDfgScoped; }
     bool fDfgPeepholeEnabled(const std::string& name) const {
         return !m_fDfgPeepholeDisabled.count(name);
     }

--- a/src/Verilator.cpp
+++ b/src/Verilator.cpp
@@ -405,6 +405,11 @@ static void process() {
             // forcing.
             V3Force::forceAll(v3Global.rootp());
 
+            if (v3Global.opt.fDfgScoped()) {
+                // Scoped DFG optimization
+                V3DfgOptimizer::optimize(v3Global.rootp(), "scoped");
+            }
+
             // Gate-based logic elimination; eliminate signals and push constant across cell
             // boundaries Instant propagation makes lots-o-constant reduction possibilities.
             if (v3Global.opt.fGate()) {

--- a/test_regress/t/t_dfg_peephole.py
+++ b/test_regress/t/t_dfg_peephole.py
@@ -96,7 +96,7 @@ def check(name):
     name = name.lower()
     name = re.sub(r'_', ' ', name)
     test.file_grep(test.obj_dir + "/obj_opt/Vopt__stats.txt",
-                   r'DFG\s+(pre|post) inline Peephole, ' + name + r'\s+([1-9]\d*)')
+                   r'DFG\s+(pre inline|post inline|scoped) Peephole, ' + name + r'\s+([1-9]\d*)')
 
 
 # Check all optimizations defined in

--- a/test_regress/t/t_dfg_stats_patterns_pre_inline.py
+++ b/test_regress/t/t_dfg_stats_patterns_pre_inline.py
@@ -12,7 +12,7 @@ import vltest_bootstrap
 test.scenarios('vlt')
 test.top_filename = "t/t_dfg_stats_patterns.v"
 
-test.compile(verilator_flags2=["--stats --no-skip-identical -fno-dfg-post-inline"])
+test.compile(verilator_flags2=["--stats --no-skip-identical -fno-dfg-post-inline -fno-dfg-scoped"])
 
 fn = test.glob_one(test.obj_dir + "/" + test.vm_prefix + "__stats_dfg_patterns*")
 test.files_identical(fn, test.golden_filename)

--- a/test_regress/t/t_dfg_stats_patterns_scoped.out
+++ b/test_regress/t/t_dfg_stats_patterns_scoped.out
@@ -1,0 +1,50 @@
+DFG 'scoped' patterns with depth 1
+            3 (NOT vA:a)*:a
+            2 (AND _A:a _B:a):a
+            2 (REPLICATE _A:a cA:a)*:b
+            1 (AND _A:a _B:a)*:a
+            1 (CONCAT '0:a _A:b):A
+            1 (NOT _A:a):a
+            1 (REPLICATE _A:1 cA:a)*:b
+            1 (REPLICATE _A:a cA:b)*:b
+            1 (REPLICATE _A:a cA:b)*:c
+            1 (SEL@0 _A:a):1
+            1 (SEL@0 _A:a):b
+            1 (SEL@A _A:a):1
+
+DFG 'scoped' patterns with depth 2
+            2 (AND (NOT vA:a)*:a (NOT vB:a)*:a):a
+            1 (AND (NOT vA:a)*:a (NOT vB:a)*:a)*:a
+            1 (CONCAT '0:a (REPLICATE _A:a cA:a)*:b):A
+            1 (NOT (REPLICATE _A:a cA:b)*:b):b
+            1 (REPLICATE (NOT _A:a):a cA:a)*:b
+            1 (REPLICATE (REPLICATE _A:1 cA:a)*:b cB:a)*:c
+            1 (REPLICATE (REPLICATE _A:a cA:b)*:b cA:b)*:c
+            1 (REPLICATE (REPLICATE _A:a cA:b)*:c cA:b)*:b
+            1 (REPLICATE (SEL@A _A:a):1 cA:b)*:c
+            1 (SEL@0 (AND _A:a _B:a)*:a):1
+            1 (SEL@0 (REPLICATE _A:a cA:a)*:b):c
+            1 (SEL@A (AND _A:a _B:a)*:a):1
+
+DFG 'scoped' patterns with depth 3
+            1 (CONCAT '0:a (REPLICATE (REPLICATE _A:b cA:a)*:a cA:a)*:c):A
+            1 (NOT (REPLICATE (REPLICATE _A:a cA:b)*:c cA:b)*:b):b
+            1 (REPLICATE (NOT (REPLICATE _A:a cA:b)*:b):b cA:b)*:c
+            1 (REPLICATE (REPLICATE (REPLICATE _A:1 cA:a)*:b cB:a)*:c cB:a)*:a
+            1 (REPLICATE (REPLICATE (REPLICATE _A:a cA:b)*:c cA:b)*:b cA:b)*:d
+            1 (REPLICATE (REPLICATE (SEL@A _A:a):1 cA:b)*:c cB:b)*:d
+            1 (REPLICATE (SEL@A (AND _A:a _B:a)*:a):1 cA:b)*:c
+            1 (SEL@0 (AND (NOT vA:a)*:a (NOT vB:a)*:a)*:a):1
+            1 (SEL@0 (REPLICATE (NOT _A:a):a cA:a)*:b):c
+            1 (SEL@A (AND (NOT vA:a)*:a (NOT vB:a)*:a)*:a):1
+
+DFG 'scoped' patterns with depth 4
+            1 (CONCAT '0:a (REPLICATE (REPLICATE (REPLICATE _A:b cA:a)*:c cA:a)*:a cA:a)*:d):A
+            1 (NOT (REPLICATE (REPLICATE (REPLICATE _A:1 cA:a)*:b cB:a)*:c cB:a)*:a):a
+            1 (REPLICATE (NOT (REPLICATE (REPLICATE _A:a cA:b)*:c cA:b)*:b):b cA:b)*:d
+            1 (REPLICATE (REPLICATE (REPLICATE (REPLICATE _A:1 cA:a)*:b cB:a)*:c cB:a)*:a cB:a)*:d
+            1 (REPLICATE (REPLICATE (REPLICATE (SEL@A _A:a):1 cA:b)*:c cB:b)*:d cB:b)*:b
+            1 (REPLICATE (REPLICATE (SEL@A (AND _A:a _B:a)*:a):1 cA:b)*:c cB:b)*:d
+            1 (REPLICATE (SEL@A (AND (NOT vA:a)*:a (NOT vB:a)*:a)*:a):1 cA:b)*:c
+            1 (SEL@0 (REPLICATE (NOT (REPLICATE _A:a cA:b)*:b):b cA:b)*:c):d
+

--- a/test_regress/t/t_dfg_stats_patterns_scoped.py
+++ b/test_regress/t/t_dfg_stats_patterns_scoped.py
@@ -12,7 +12,8 @@ import vltest_bootstrap
 test.scenarios('vlt')
 test.top_filename = "t/t_dfg_stats_patterns.v"
 
-test.compile(verilator_flags2=["--stats --no-skip-identical -fno-dfg-pre-inline -fno-dfg-scoped"])
+test.compile(
+    verilator_flags2=["--stats --no-skip-identical -fno-dfg-pre-inline -fno-dfg-post-inline"])
 
 fn = test.glob_one(test.obj_dir + "/" + test.vm_prefix + "__stats_dfg_patterns*")
 test.files_identical(fn, test.golden_filename)

--- a/test_regress/t/t_hier_block_chained.py
+++ b/test_regress/t/t_hier_block_chained.py
@@ -33,9 +33,9 @@ test.compile(
 
 if test.vltmt:
     test.file_grep(test.obj_dir + "/V" + test.name + "__hier.dir/V" + test.name + "__stats.txt",
-                   r'Optimizations, Thread schedule count\s+(\d+)', 1)
+                   r'Optimizations, Thread schedule count\s+(\d+)', 2)
     test.file_grep(test.obj_dir + "/V" + test.name + "__hier.dir/V" + test.name + "__stats.txt",
-                   r'Optimizations, Thread schedule total tasks\s+(\d+)', 2)
+                   r'Optimizations, Thread schedule total tasks\s+(\d+)', 3)
 
 test.execute()
 

--- a/test_regress/t/t_inst_tree_inl0_pub1.py
+++ b/test_regress/t/t_inst_tree_inl0_pub1.py
@@ -42,7 +42,7 @@ if test.vlt_all:
     # We expect to combine sequent functions across multiple instances of
     # l2, l3, l4, l5. If this number drops, please confirm this has not broken.
     test.file_grep(test.stats, r'Optimizations, Combined CFuncs\s+(\d+)',
-                   (85 if test.vltmt else 67))
+                   (91 if test.vltmt else 87))
 
     # Everything should use relative references
     check_relative_refs("t", True)

--- a/test_regress/t/t_inst_tree_inl1_pub0.py
+++ b/test_regress/t/t_inst_tree_inl1_pub0.py
@@ -15,7 +15,8 @@ test.top_filename = "t/t_inst_tree.v"
 out_filename = test.obj_dir + "/V" + test.name + ".tree.json"
 
 test.compile(v_flags2=[
-    "--no-json-edit-nums", "-fno-dfg-post-inline", test.t_dir + "/t_inst_tree_inl1_pub0.vlt"
+    "--no-json-edit-nums", "-fno-dfg-post-inline", "-fno-dfg-scoped", test.t_dir +
+    "/t_inst_tree_inl1_pub0.vlt"
 ])
 
 if test.vlt_all:

--- a/test_regress/t/t_opt_const_dfg.py
+++ b/test_regress/t/t_opt_const_dfg.py
@@ -18,7 +18,7 @@ test.compile(verilator_flags2=["-Wno-UNOPTTHREADS", "--stats", test.pli_filename
 test.execute()
 
 if test.vlt:
-    test.file_grep(test.stats, r'Optimizations, Const bit op reduction\s+(\d+)', 43)
+    test.file_grep(test.stats, r'Optimizations, Const bit op reduction\s+(\d+)', 38)
     test.file_grep(test.stats, r'SplitVar, packed variables split automatically\s+(\d+)', 1)
 
 test.passes()

--- a/test_regress/t/t_unopt_combo_bad.out
+++ b/test_regress/t/t_unopt_combo_bad.out
@@ -4,7 +4,7 @@
                     ... For warning description see https://verilator.org/warn/UNOPTFLAT?v=latest
                     ... Use "/* verilator lint_off UNOPTFLAT */" and lint_on around source to disable this message.
                     t/t_unopt_combo.v:23:25:      Example path: t.b
-                    t/t_unopt_combo.v:124:4:      Example path: ALWAYS
+                    t/t_unopt_combo.v:137:14:      Example path: ASSIGNW
                     t/t_unopt_combo.v:24:25:      Example path: t.c
                     t/t_unopt_combo.v:81:4:      Example path: ALWAYS
                     t/t_unopt_combo.v:23:25:      Example path: t.b


### PR DESCRIPTION
This patch enables DFG to run after V3Scope (but before V3ActiveTop), and applies it just before V3Gate.

This is beneficial because a lot of lowering and optimization has been performed at that point (V3Task, V3Unroll, V3SplitAs), which enables more code to convert to DFG form.

While this yields +/- a few % on most RTLMeter designs, one case gains 17% simulation speed.

More importantly I'm working on some patches to split up combinational cycles, and the most problematic ones happen through module boundaries, so this enables handling those.

There is a slight risk of reducing the efficiency of V3Combine, as where some logic must be inserted when converting back to Ast is not entirely clear in scoped mode. In this patch, we put the logic into the scope that contains the AstVarScope that it drives.

The binToOneHot pass cannot yet handle a scoped DfgGraph, so is not applied in the post scope run.

---

This patch passes everything in RTLMeter, but I expect it might cause some fallout so if you are planning a release in the near future, we can punt this until after.