### PR TITLE
Update docker base image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -29,7 +29,7 @@ jobs:
 
   build:
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     strategy:
       matrix:

--- a/Changes
+++ b/Changes
@@ -36,7 +36,7 @@ Verilator 5.037 devel
 * Improve hierarchical scheduling visualization in V3ExecGraph (#6009). [Bartłomiej Chmiel, Antmicro Ltd.]
 * Improve DPI temporary 'for' loop performance (#6079). [Bartłomiej Chmiel, Antmicro Ltd.]
 * Improve memory usage for SenTrees in V3OrderProcessDomains (#6112). [Geza Lore]
-* Improve docker image size (#6139). [Tobias Rosenkranz, bitaggregat GmbH.]
+* Improve docker image size (#6139). [Tobias Rosenkranz, bitaggregat GmbH]
 * Optimize DFG De Morgan patterns (#6090). [Geza Lore]
 * Optimize DFG variable elimination (#6091). [Geza Lore]
 * Optimize DFG PUSH_SEL_THROUGH_CONCAT pattern (#6092). [Geza Lore]
@@ -86,6 +86,7 @@ Verilator 5.037 devel
 * Fix method calls without parenthesis (#6127). [Alex Solomatnikov]
 * Fix `pre_randomize`/`post_randomize` when no randomize (#6128). [Alex Solomatnikov]
 * Fix interface array connections with non-zero low declaration index.
+* Update docker base image (#6147). [Tobias Rosenkranz, bitaggregat GmbH]
 
 
 Verilator 5.036 2025-04-27

--- a/ci/docker/buildenv/Dockerfile
+++ b/ci/docker/buildenv/Dockerfile
@@ -6,7 +6,7 @@
 # Version 2.0.
 # SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
 
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 # Create the user
 RUN groupadd verilator \
@@ -36,12 +36,14 @@ RUN apt-get update \
                         help2man \
                         libfl2 \
                         libfl-dev \
+                        libclang-rt-18-dev \
                         libgoogle-perftools-dev \
                         libsystemc \
                         libsystemc-dev \
                         numactl \
                         perl \
                         python3 \
+                        python3-distro \
                         wget \
                         z3 \
                         zlib1g \

--- a/ci/docker/buildenv/README.rst
+++ b/ci/docker/buildenv/README.rst
@@ -13,7 +13,7 @@ Verilator build. It uses the following parameters:
 
 -  Source revision (default: master)
 
--  Compiler (GCC 10.3.0, clang 10.0.0, default: 10.3.0)
+-  Compiler (GCC 13.3.0, clang 18.1.3, default: 13.3.0)
 
 The container is published as ``verilator/verilator-buildenv`` on `docker
 hub
@@ -31,18 +31,18 @@ To also run tests:
 
    docker run -ti verilator/verilator-buildenv test
 
-To change the compiler:
+To change the compiler use the `-e` switch to pass environment variables:
 
 ::
 
-   docker run -ti -e CC=clang-10 -e CXX=clang++-10 verilator/verilator-buildenv test
+   docker run -ti -e CC=clang-18 -e CXX=clang++-18 verilator/verilator-buildenv test
 
-The tests that involve gdb are not working due to security restrictions.
-To run those too:
+The tests, that involve numactl are not working due to security restrictions.
+To run those too, add the CAP_SYS_NICE capability during the start of the container:
 
 ::
 
-   docker run -ti -e CC=clang-10 -e CXX=clang++-10 --cap-add=SYS_PTRACE --security-opt seccomp=unconfined verilator/verilator-buildenv test
+   docker run -ti --cap-add=CAP_SYS_NICE verilator/verilator-buildenv test
 
 Rather then building using a remote git repository you may prefer to use a
 working copy on the local filesystem. Mount the local working copy path as
@@ -52,7 +52,7 @@ top of a repository:
 
 ::
 
-   docker run -ti -v ${PWD}:/tmp/repo -e REPO=/tmp/repo -e REV=`git rev-parse --short HEAD` --cap-add=SYS_PTRACE --security-opt seccomp=unconfined verilator/verilator-buildenv test
+   docker run -ti -v ${PWD}:/tmp/repo -e REPO=/tmp/repo -e REV=`git rev-parse --short HEAD` verilator/verilator-buildenv test
 
 
 Rebuilding

--- a/ci/docker/run/Dockerfile
+++ b/ci/docker/run/Dockerfile
@@ -6,7 +6,7 @@
 # Version 2.0.
 # SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
 
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive \


### PR DESCRIPTION
The docker container builds without problems. 

It parses and generates `*.cpp`-files from `*.v`-files. 

With a small modifications to `test_regress/t/t_a1_first_cc.py` (path-change to the `verilator-docker`-script) and the modification of that script to use the local build docker image, I was able to run the `smoke-test` successfully.

I was not able to run other test from the `test_regress`-directory. I assume that is due to the fact, that the `driver.py` isn't prepared for that.