### PR TITLE
Patch developer build on MacOS/Flex2.6.4

### DIFF
--- a/src/V3LinkDot.cpp
+++ b/src/V3LinkDot.cpp
@@ -3365,6 +3365,8 @@ class LinkDotResolveVisitor final : public VNVisitor {
                     VL_DO_DANGLING(pushDeletep(nodep), nodep);
                     ok = true;
                     m_ds.m_dotText = "";
+                } else {
+                    (void)defp;  // Prevent unused variable warning
                 }
             } else if (AstEnumItem* const valuep = VN_CAST(foundp->nodep(), EnumItem)) {
                 if (allowVar) {

--- a/src/flexfix
+++ b/src/flexfix
@@ -18,13 +18,17 @@ for line in sys.stdin:
     # Fix flex 2.6.1 warning
     line = re.sub(r'for \( i = 0; i < _yybytes_len; \+\+i \)',
                   r'for ( i = 0; (yy_size_t)(i) < (yy_size_t)(_yybytes_len); ++i )', line)
-    # Fix flex 2.6.0 warning
+    # Fix flex 2.6.0+ sign comparison warnings
     line = re.sub(
         r'\(\(int\) \(\(yy_n_chars\) \+ number_to_move\) > YY_CURRENT_BUFFER_LVALUE->yy_buf_size\)',
         r'((int) ((yy_n_chars) + number_to_move) > (int) YY_CURRENT_BUFFER_LVALUE->yy_buf_size)',
         line)
     line = re.sub(r' number_to_move == YY_MORE_ADJ ', r' (int)number_to_move == (int)YY_MORE_ADJ ',
                   line)
+    line = re.sub(
+        r'\(\(\(yy_n_chars\) \+ number_to_move\) > YY_CURRENT_BUFFER_LVALUE->yy_buf_size\)',
+        r'(((int)(yy_n_chars) + (int)number_to_move) > (int)YY_CURRENT_BUFFER_LVALUE->yy_buf_size)',
+        line)
     # Fix flex 2.5.4 namespace omission
     line = re.sub(r'^class istream;', '#include <iostream>\nusing namespace std;\n', line)
     # Fix flex 2.5.31 redefinition


### PR DESCRIPTION
- With export VERILATOR_AUTHOR_SITE=1 and ./configure --enable-longtests, verilator didn't build on M1 Mac 15.5 / Flex 2.6.4 without these changes. It does build with them.
- "Regular user build" has been fine regardless so it must just be some signed-comparison warnings become errors when doing things in "developer mode"

We appreciate your contributing to Verilator.  If this is your first commit, please add your name to docs/CONTRIBUTORS, and read our contributing guidelines in docs/CONTRIBUTING.rst.
