### PR TITLE
Fix more wide ternary + coverage cases

### DIFF
--- a/src/V3Const.cpp
+++ b/src/V3Const.cpp
@@ -2107,9 +2107,12 @@ class ConstVisitor final : public VNVisitor {
                 AstVar* const tempPurep = new AstVar{rhsp->fileline(), VVarType::BLOCKTEMP,
                                                      m_concswapNames.get(rhsp), rhsp->dtypep()};
                 m_modp->addStmtsp(tempPurep);
-                AstAssign* const asnp = new AstAssign(
-                    nodep->fileline(), new AstVarRef{rhsp->fileline(), tempPurep, VAccess::WRITE},
-                    rhsp);
+                AstVarRef* const tempPureRefp
+                    = new AstVarRef{rhsp->fileline(), tempPurep, VAccess::WRITE};
+                AstNodeAssign* const asnp
+                    = VN_IS(nodep, AssignDly)
+                          ? new AstAssign(nodep->fileline(), tempPureRefp, rhsp)
+                          : nodep->cloneType(tempPureRefp, rhsp);
                 nodep->addHereThisAsNext(asnp);
                 nodep->rhsp(new AstVarRef{rhsp->fileline(), tempPurep, VAccess::READ});
             } else if (need_temp) {

--- a/test_regress/t/t_cover_line_wide_ternary.out
+++ b/test_regress/t/t_cover_line_wide_ternary.out
@@ -23,7 +23,9 @@
 -000001  point: comment=block hier=top.t
         
             intf intfs [2] ();
-            intf intf_sel();
+            intf intf_sel_ff();
+            intf intf_sel_comb();
+            intf intf_sel_assign();
         
 %000001     always_comb begin
 -000001  point: comment=block hier=top.t
@@ -33,9 +35,9 @@
 -000001  point: comment=block hier=top.t
             end
         
-%000009     always @ (posedge clk) begin
+%000009     always_ff @ (posedge clk) begin
 -000009  point: comment=block hier=top.t
-%000009         {intf_sel.foo, intf_sel.bar, intf_sel.baz} <=
+%000009         {intf_sel_ff.foo, intf_sel_ff.bar, intf_sel_ff.baz} <=
 -000009  point: comment=block hier=top.t
 %000009             cyc[0] ?
 -000009  point: comment=cond_then hier=top.t
@@ -46,6 +48,29 @@
 -000009  point: comment=cond_else hier=top.t
             end
         
+ 000010     always_comb begin
++000010  point: comment=block hier=top.t
+ 000010         {intf_sel_comb.foo, intf_sel_comb.bar, intf_sel_comb.baz} =
++000010  point: comment=block hier=top.t
+ 000010             cyc[0] ?
++000010  point: comment=cond_then hier=top.t
++000010  point: comment=cond_else hier=top.t
+ 000010             {intfs[1].foo, intfs[1].bar, intfs[1].baz} :
++000010  point: comment=cond_then hier=top.t
+ 000010             {intfs[0].foo, intfs[0].bar, intfs[0].baz};
++000010  point: comment=cond_else hier=top.t
+            end
+        
+            assign
+                {intf_sel_assign.foo, intf_sel_assign.bar, intf_sel_assign.baz} =
+ 000010             cyc[0] ?
++000010  point: comment=cond_then hier=top.t
++000010  point: comment=cond_else hier=top.t
+ 000010             {intfs[1].foo, intfs[1].bar, intfs[1].baz} :
++000010  point: comment=cond_then hier=top.t
+ 000010             {intfs[0].foo, intfs[0].bar, intfs[0].baz};
++000010  point: comment=cond_else hier=top.t
+        
 %000009     always @ (posedge clk) begin
 -000009  point: comment=block hier=top.t
 %000009         cyc <= cyc + 1;
@@ -53,9 +78,11 @@
 %000008         if (cyc==9) begin
 -000008  point: comment=else hier=top.t
 -000001  point: comment=if hier=top.t
-%000001             $display("bar = %0d", intf_sel.bar);
--000001  point: comment=if hier=top.t
-%000001             if (intf_sel.bar != 123) $stop();
+%000001             if (intf_sel_ff.bar != 123) $stop();
+-000001  point: comment=else hier=top.t
+%000001             if (intf_sel_comb.bar != 456) $stop();
+-000001  point: comment=else hier=top.t
+%000001             if (intf_sel_assign.bar != 456) $stop();
 -000001  point: comment=else hier=top.t
 %000001             $write("*-* All Finished *-*\n");
 -000001  point: comment=if hier=top.t

--- a/test_regress/t/t_cover_line_wide_ternary.v
+++ b/test_regress/t/t_cover_line_wide_ternary.v
@@ -21,25 +21,41 @@ module t (/*AUTOARG*/
     initial cyc=1;
 
     intf intfs [2] ();
-    intf intf_sel();
+    intf intf_sel_ff();
+    intf intf_sel_comb();
+    intf intf_sel_assign();
 
     always_comb begin
         intfs[0].bar = 123;
         intfs[1].bar = 456;
     end
 
-    always @ (posedge clk) begin
-        {intf_sel.foo, intf_sel.bar, intf_sel.baz} <=
+    always_ff @ (posedge clk) begin
+        {intf_sel_ff.foo, intf_sel_ff.bar, intf_sel_ff.baz} <=
             cyc[0] ?
             {intfs[1].foo, intfs[1].bar, intfs[1].baz} :
             {intfs[0].foo, intfs[0].bar, intfs[0].baz};
     end
 
+    always_comb begin
+        {intf_sel_comb.foo, intf_sel_comb.bar, intf_sel_comb.baz} =
+            cyc[0] ?
+            {intfs[1].foo, intfs[1].bar, intfs[1].baz} :
+            {intfs[0].foo, intfs[0].bar, intfs[0].baz};
+    end
+
+    assign
+        {intf_sel_assign.foo, intf_sel_assign.bar, intf_sel_assign.baz} =
+            cyc[0] ?
+            {intfs[1].foo, intfs[1].bar, intfs[1].baz} :
+            {intfs[0].foo, intfs[0].bar, intfs[0].baz};
+
     always @ (posedge clk) begin
         cyc <= cyc + 1;
         if (cyc==9) begin
-            $display("bar = %0d", intf_sel.bar);
-            if (intf_sel.bar != 123) $stop();
+            if (intf_sel_ff.bar != 123) $stop();
+            if (intf_sel_comb.bar != 456) $stop();
+            if (intf_sel_assign.bar != 456) $stop();
             $write("*-* All Finished *-*\n");
             $finish;
         end


### PR DESCRIPTION
Follow up to #6152

My previous fix didn't work for `assign` statements because it would leave the intermediate variables outside of any function and then we'd get this from `Localize`:
```
        UASSERT_OBJ(m_cfuncp, nodep, "AstVarRef not under function");
```

Added some more test cases and handled the `assign` scenario.
