### PR TITLE
Improve covergroup handling

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -24,6 +24,7 @@ Anthony Donlon
 Anthony Moore
 Arkadiusz Kozdra
 Arthur Rosa
+Artur Bieniek
 Aylon Chaim Porat
 Bartłomiej Chmiel
 Brian Li

--- a/src/verilog.y
+++ b/src/verilog.y
@@ -6780,7 +6780,15 @@ covergroup_declaration<nodep>:  // ==IEEE: covergroup_declaration
         |       covergroup_declarationFront '(' tf_port_listE ')'
         /*cont*/    coverage_eventE ';' coverage_spec_or_optionListE
         /*cont*/    yENDGROUP endLabelE
-                        { $$ = $1;
+                        {
+                          AstFunc *constructor = new AstFunc{$<fl>1, "new", nullptr, nullptr};
+                          constructor->classMethod(true);
+                          constructor->isConstructor(true);
+                          constructor->dtypep($1->dtypep());
+                          constructor->addStmtsp($3);
+
+                          $1->addMembersp(constructor);
+                          $$ = $1;
                           GRAMMARP->endLabel($<fl>9, $1, $9); }
         //                      // IEEE 1800-2023 added:
         |       covergroup_declarationFront yEXTENDS idAny/*covergroup_identifier*/

--- a/src/verilog.y
+++ b/src/verilog.y
@@ -7529,10 +7529,9 @@ class_item<nodep>:                      // ==IEEE: class_item
         |       timeunits_declaration                   { $$ = $1; }
         |       covergroup_declaration
                         {
-                                string cgName = $1->name();
-                                $1->name("__vlAnonCG_"+cgName);
-
-                                AstVar *cgInstance = new AstVar($<fl>1, VVarType::VAR, cgName, VFlagChildDType{}, new AstRefDType($<fl>1, $1->name()));
+                                const string cgName = $1->name();
+                                $1->name("__vlAnonCG_" + cgName);
+                                AstVar const *cgInstance = new AstVar($<fl>1, VVarType::VAR, cgName, VFlagChildDType{}, new AstRefDType($<fl>1, $1->name()));
                                 $$ = addNextNull($1, cgInstance);
                          }
         //                      // local_parameter_declaration under parameter_declaration

--- a/src/verilog.y
+++ b/src/verilog.y
@@ -6790,31 +6790,31 @@ covergroup_declaration<nodep>:  // ==IEEE: covergroup_declaration
                           $1->addMembersp(newp);
                           $$ = $1;
                           GRAMMARP->endLabel($<fl>9, $1, $9); }
-        //                      // IEEE 1800-2023 added:
-        |       covergroup_declarationFront yEXTENDS idAny/*covergroup_identifier*/
-        /*cont*/    ';' coverage_spec_or_optionListE
-        /*cont*/    yENDGROUP endLabelE
-                        { $$ = $1;
-                          GRAMMARP->endLabel($<fl>7, $1, $7); }
+        ;
+
+// IEEE 1800-2023 added:
+covergroup_extendsE<fl>:
+                /* empty */     { $$ = nullptr; }
+        |       yEXTENDS        { $$ = $1; }
         ;
 
 covergroup_declarationFront<classp>:  // IEEE: part of covergroup_declaration
-                yCOVERGROUP idAny
+                yCOVERGROUP covergroup_extendsE idAny
                         {
-                        $$ = new AstClass{$<fl>2, *$2, PARSEP->libname()};
+                        $$ = new AstClass{$<fl>3, *$3, PARSEP->libname()};
 
-                        AstFunc *sample = new AstFunc{$<fl>1, "sample", nullptr, nullptr};
+                        AstFunc* const sample = new AstFunc{$<fl>1, "sample", nullptr, nullptr};
                         sample->classMethod(true);
                         sample->dtypep(sample->findVoidDType());
                         $$->addMembersp(sample);
 
-                        AstFunc *getCoverage = new AstFunc{$<fl>1, "get_coverage", nullptr, nullptr};
+                        AstFunc* const getCoverage = new AstFunc{$<fl>1, "get_coverage", nullptr, nullptr};
                         getCoverage->classMethod(true);
                         getCoverage->dtypep(getCoverage->findVoidDType());
                         $$->addMembersp(getCoverage);
 
                         BBCOVERIGN($<fl>1, "Ignoring unsupported: covergroup"); }
-        ;
+                ;
 
 cgexpr<nodeExprp>:  // IEEE-2012: covergroup_expression, before that just expression
                 expr                                    { $$ = $1; }

--- a/src/verilog.y
+++ b/src/verilog.y
@@ -6808,10 +6808,10 @@ covergroup_declarationFront<classp>:  // IEEE: part of covergroup_declaration
                         sample->dtypep(sample->findVoidDType());
                         $$->addMembersp(sample);
 
-                        AstFunc *get_coverage = new AstFunc{$<fl>1, "get_coverage", nullptr, nullptr};
-                        get_coverage->classMethod(true);
-                        get_coverage->dtypep(get_coverage->findVoidDType());
-                        $$->addMembersp(get_coverage);
+                        AstFunc *getCoverage = new AstFunc{$<fl>1, "get_coverage", nullptr, nullptr};
+                        getCoverage->classMethod(true);
+                        getCoverage->dtypep(getCoverage->findVoidDType());
+                        $$->addMembersp(getCoverage);
 
                         BBCOVERIGN($<fl>1, "Ignoring unsupported: covergroup"); }
         ;
@@ -7531,11 +7531,11 @@ class_item<nodep>:                      // ==IEEE: class_item
         |       timeunits_declaration                   { $$ = $1; }
         |       covergroup_declaration
                         {
-                                string cgname = $1->name();
-                                $1->name("__v_anon_covergroup_"+cgname);
+                                string cgName = $1->name();
+                                $1->name("__v_anon_covergroup_"+cgName);
 
-                                AstVar *cg_instance = new AstVar($<fl>1, VVarType::VAR, cgname, VFlagChildDType{}, new AstRefDType($<fl>1, $1->name()));
-                                $$ = addNextNull($1, cg_instance);
+                                AstVar *cgInstance = new AstVar($<fl>1, VVarType::VAR, cgName, VFlagChildDType{}, new AstRefDType($<fl>1, $1->name()));
+                                $$ = addNextNull($1, cgInstance);
                          }
         //                      // local_parameter_declaration under parameter_declaration
         |       parameter_declaration ';'               { $$ = $1; }

--- a/src/verilog.y
+++ b/src/verilog.y
@@ -6780,8 +6780,7 @@ covergroup_declaration<nodep>:  // ==IEEE: covergroup_declaration
         |       covergroup_declarationFront '(' tf_port_listE ')'
         /*cont*/    coverage_eventE ';' coverage_spec_or_optionListE
         /*cont*/    yENDGROUP endLabelE
-                        {
-                          AstFunc* const newp = new AstFunc{$<fl>1, "new", nullptr, nullptr};
+                        { AstFunc* const newp = new AstFunc{$<fl>1, "new", nullptr, nullptr};
                           newp->classMethod(true);
                           newp->isConstructor(true);
                           newp->dtypep($1->dtypep());
@@ -6792,8 +6791,8 @@ covergroup_declaration<nodep>:  // ==IEEE: covergroup_declaration
         ;
 
 covergroup_extendsE<fl>:  // IEEE: Part of covergroup_declaration
-                /* empty */     { $$ = nullptr; }
-        |       yEXTENDS        { $$ = $1; }
+                /* empty */                             { $$ = nullptr; }
+        |       yEXTENDS                                { $$ = $1; }
         ;
 
 covergroup_declarationFront<classp>:  // IEEE: part of covergroup_declaration

--- a/src/verilog.y
+++ b/src/verilog.y
@@ -6782,12 +6782,12 @@ covergroup_declaration<nodep>:  // ==IEEE: covergroup_declaration
         /*cont*/    yENDGROUP endLabelE
                         {
                           AstFunc* const newp = new AstFunc{$<fl>1, "new", nullptr, nullptr};
-                          constructor->classMethod(true);
-                          constructor->isConstructor(true);
-                          constructor->dtypep($1->dtypep());
-                          constructor->addStmtsp($3);
+                          newp->classMethod(true);
+                          newp->isConstructor(true);
+                          newp->dtypep($1->dtypep());
+                          newp->addStmtsp($3);
 
-                          $1->addMembersp(constructor);
+                          $1->addMembersp(newp);
                           $$ = $1;
                           GRAMMARP->endLabel($<fl>9, $1, $9); }
         //                      // IEEE 1800-2023 added:
@@ -7532,7 +7532,7 @@ class_item<nodep>:                      // ==IEEE: class_item
         |       covergroup_declaration
                         {
                                 string cgName = $1->name();
-                                $1->name("__v_anon_covergroup_"+cgName);
+                                $1->name("__vlAnonCG_"+cgName);
 
                                 AstVar *cgInstance = new AstVar($<fl>1, VVarType::VAR, cgName, VFlagChildDType{}, new AstRefDType($<fl>1, $1->name()));
                                 $$ = addNextNull($1, cgInstance);

--- a/src/verilog.y
+++ b/src/verilog.y
@@ -6791,8 +6791,7 @@ covergroup_declaration<nodep>:  // ==IEEE: covergroup_declaration
                           GRAMMARP->endLabel($<fl>9, $1, $9); }
         ;
 
-// IEEE 1800-2023 added:
-covergroup_extendsE<fl>:
+covergroup_extendsE<fl>:  // IEEE: Part of covergroup_declaration
                 /* empty */     { $$ = nullptr; }
         |       yEXTENDS        { $$ = $1; }
         ;

--- a/src/verilog.y
+++ b/src/verilog.y
@@ -7531,7 +7531,7 @@ class_item<nodep>:                      // ==IEEE: class_item
                         {
                                 const string cgName = $1->name();
                                 $1->name("__vlAnonCG_" + cgName);
-                                AstVar const *cgInstance = new AstVar($<fl>1, VVarType::VAR, cgName, VFlagChildDType{}, new AstRefDType($<fl>1, $1->name()));
+                                AstVar *cgInstance = new AstVar($<fl>1, VVarType::VAR, cgName, VFlagChildDType{}, new AstRefDType($<fl>1, $1->name()));
                                 $$ = addNextNull($1, cgInstance);
                          }
         //                      // local_parameter_declaration under parameter_declaration

--- a/src/verilog.y
+++ b/src/verilog.y
@@ -6781,7 +6781,7 @@ covergroup_declaration<nodep>:  // ==IEEE: covergroup_declaration
         /*cont*/    coverage_eventE ';' coverage_spec_or_optionListE
         /*cont*/    yENDGROUP endLabelE
                         {
-                          AstFunc *constructor = new AstFunc{$<fl>1, "new", nullptr, nullptr};
+                          AstFunc* const newp = new AstFunc{$<fl>1, "new", nullptr, nullptr};
                           constructor->classMethod(true);
                           constructor->isConstructor(true);
                           constructor->dtypep($1->dtypep());

--- a/src/verilog.y
+++ b/src/verilog.y
@@ -6786,7 +6786,6 @@ covergroup_declaration<nodep>:  // ==IEEE: covergroup_declaration
                           newp->isConstructor(true);
                           newp->dtypep($1->dtypep());
                           newp->addStmtsp($3);
-
                           $1->addMembersp(newp);
                           $$ = $1;
                           GRAMMARP->endLabel($<fl>9, $1, $9); }

--- a/src/verilog.y
+++ b/src/verilog.y
@@ -7531,8 +7531,8 @@ class_item<nodep>:                      // ==IEEE: class_item
                         {
                                 const string cgName = $1->name();
                                 $1->name("__vlAnonCG_" + cgName);
-                                AstVar *cgInstance = new AstVar($<fl>1, VVarType::VAR, cgName, VFlagChildDType{}, new AstRefDType($<fl>1, $1->name()));
-                                $$ = addNextNull($1, cgInstance);
+                                AstVar* const newp = new AstVar{$<fl>1, VVarType::VAR, cgName, VFlagChildDType{}, new AstRefDType($<fl>1, $1->name())};
+                                $$ = addNextNull($1, newp);
                          }
         //                      // local_parameter_declaration under parameter_declaration
         |       parameter_declaration ';'               { $$ = $1; }

--- a/src/verilog.y
+++ b/src/verilog.y
@@ -6799,19 +6799,19 @@ covergroup_extendsE<fl>:  // IEEE: Part of covergroup_declaration
 covergroup_declarationFront<classp>:  // IEEE: part of covergroup_declaration
                 yCOVERGROUP covergroup_extendsE idAny
                         {
-                        $$ = new AstClass{$<fl>3, *$3, PARSEP->libname()};
+                         $$ = new AstClass{$<fl>3, *$3, PARSEP->libname()};
 
-                        AstFunc* const sample = new AstFunc{$<fl>1, "sample", nullptr, nullptr};
-                        sample->classMethod(true);
-                        sample->dtypep(sample->findVoidDType());
-                        $$->addMembersp(sample);
+                         AstFunc* const sample = new AstFunc{$<fl>1, "sample", nullptr, nullptr};
+                         sample->classMethod(true);
+                         sample->dtypep(sample->findVoidDType());
+                         $$->addMembersp(sample);
 
-                        AstFunc* const getCoverage = new AstFunc{$<fl>1, "get_coverage", nullptr, nullptr};
-                        getCoverage->classMethod(true);
-                        getCoverage->dtypep(getCoverage->findVoidDType());
-                        $$->addMembersp(getCoverage);
+                         AstFunc* const getCoverage = new AstFunc{$<fl>1, "get_coverage", nullptr, nullptr};
+                         getCoverage->classMethod(true);
+                         getCoverage->dtypep(getCoverage->findVoidDType());
+                         $$->addMembersp(getCoverage);
 
-                        BBCOVERIGN($<fl>1, "Ignoring unsupported: covergroup"); }
+                         BBCOVERIGN($<fl>1, "Ignoring unsupported: covergroup"); }
                 ;
 
 cgexpr<nodeExprp>:  // IEEE-2012: covergroup_expression, before that just expression

--- a/src/verilog.y
+++ b/src/verilog.y
@@ -6798,19 +6798,19 @@ covergroup_extendsE<fl>:  // IEEE: Part of covergroup_declaration
 covergroup_declarationFront<classp>:  // IEEE: part of covergroup_declaration
                 yCOVERGROUP covergroup_extendsE idAny
                         {
-                         $$ = new AstClass{$<fl>3, *$3, PARSEP->libname()};
+                          $$ = new AstClass{$<fl>3, *$3, PARSEP->libname()};
 
-                         AstFunc* const sample = new AstFunc{$<fl>1, "sample", nullptr, nullptr};
-                         sample->classMethod(true);
-                         sample->dtypep(sample->findVoidDType());
-                         $$->addMembersp(sample);
+                          AstFunc* const sample = new AstFunc{$<fl>1, "sample", nullptr, nullptr};
+                          sample->classMethod(true);
+                          sample->dtypep(sample->findVoidDType());
+                          $$->addMembersp(sample);
 
-                         AstFunc* const getCoverage = new AstFunc{$<fl>1, "get_coverage", nullptr, nullptr};
-                         getCoverage->classMethod(true);
-                         getCoverage->dtypep(getCoverage->findVoidDType());
-                         $$->addMembersp(getCoverage);
+                          AstFunc* const getCoverage = new AstFunc{$<fl>1, "get_coverage", nullptr, nullptr};
+                          getCoverage->classMethod(true);
+                          getCoverage->dtypep(getCoverage->findVoidDType());
+                          $$->addMembersp(getCoverage);
 
-                         BBCOVERIGN($<fl>1, "Ignoring unsupported: covergroup"); }
+                          BBCOVERIGN($<fl>1, "Ignoring unsupported: covergroup"); }
                 ;
 
 cgexpr<nodeExprp>:  // IEEE-2012: covergroup_expression, before that just expression

--- a/src/verilog.y
+++ b/src/verilog.y
@@ -7528,11 +7528,11 @@ class_item<nodep>:                      // ==IEEE: class_item
         |       timeunits_declaration                   { $$ = $1; }
         |       covergroup_declaration
                         {
-                                const string cgName = $1->name();
-                                $1->name("__vlAnonCG_" + cgName);
-                                AstVar* const newp = new AstVar{$<fl>1, VVarType::VAR, cgName, VFlagChildDType{}, new AstRefDType($<fl>1, $1->name())};
-                                $$ = addNextNull($1, newp);
-                         }
+                          const string cgName = $1->name();
+                          $1->name("__vlAnonCG_" + cgName);
+                          AstVar* const newp = new AstVar{$<fl>1, VVarType::VAR, cgName, VFlagChildDType{}, new AstRefDType($<fl>1, $1->name())};
+                          $$ = addNextNull($1, newp);
+                        }
         //                      // local_parameter_declaration under parameter_declaration
         |       parameter_declaration ';'               { $$ = $1; }
         |       ';'                                     { $$ = nullptr; }

--- a/src/verilog.y
+++ b/src/verilog.y
@@ -6981,7 +6981,7 @@ cross_itemList<nodep>:  // IEEE: part of list_of_cross_items
         ;
 
 cross_item<nodep>:  // ==IEEE: cross_item
-                idAny/*cover_point_identifier or variable_identifier*/  { $$ = nullptr; /*UNSUP*/ }
+                idDotted/*cover_point_identifier or variable_identifier*/  { $1->deleteTree(); $$ = nullptr; /*UNSUP*/ }
         ;
 
 cross_body<nodep>:  // ==IEEE: cross_body

--- a/test_regress/t/t_covergroup_args.py
+++ b/test_regress/t/t_covergroup_args.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2025 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('vlt')
+
+test.compile()
+
+test.passes()

--- a/test_regress/t/t_covergroup_args.v
+++ b/test_regress/t/t_covergroup_args.v
@@ -6,12 +6,12 @@
 
 /* verilator lint_off COVERIGN */
 module t;
-    covergroup cg_args(int var1, int var2=42);
+    covergroup cgArgs(int var1, int var2=42);
 
     endgroup
 
-    cg_args cov1 = new(69, 77);
-    cg_args cov2 = new(69);
+    cgArgs cov1 = new(69, 77);
+    cgArgs cov2 = new(69);
     function x();
         cov1.sample();
         cov2.get_coverage();

--- a/test_regress/t/t_covergroup_args.v
+++ b/test_regress/t/t_covergroup_args.v
@@ -1,0 +1,19 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2025 by Antmicro.
+// SPDX-License-Identifier: CC0-1.0
+
+/* verilator lint_off COVERIGN */
+module t;
+    covergroup cg_args(int var1, int var2=42);
+
+    endgroup
+
+    cg_args cov1 = new(69, 77);
+    cg_args cov2 = new(69);
+    function x();
+        cov1.sample();
+        cov2.get_coverage();
+    endfunction;
+endmodule

--- a/test_regress/t/t_covergroup_extends.out
+++ b/test_regress/t/t_covergroup_extends.out
@@ -1,0 +1,5 @@
+%Error: t/t_covergroup_extends.v:25:20: syntax error, unexpected extends
+   25 |         covergroup extends g1;
+      |                    ^~~~~~~
+        ... See the manual at https://verilator.org/verilator_doc.html?v=latest for more assistance.
+%Error: Exiting due to

--- a/test_regress/t/t_covergroup_extends.out
+++ b/test_regress/t/t_covergroup_extends.out
@@ -1,5 +1,0 @@
-%Error: t/t_covergroup_extends.v:25:20: syntax error, unexpected extends
-   25 |         covergroup extends g1;
-      |                    ^~~~~~~
-        ... See the manual at https://verilator.org/verilator_doc.html?v=latest for more assistance.
-%Error: Exiting due to

--- a/test_regress/t/t_covergroup_extends.py
+++ b/test_regress/t/t_covergroup_extends.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2025 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+if test.vlt_all:
+    test.lint(fails=True, expect_filename=test.golden_filename)
+else:
+    test.compile(nc_flags2=["-coverage", "functional"])
+    test.execute()
+
+test.passes()

--- a/test_regress/t/t_covergroup_extends.py
+++ b/test_regress/t/t_covergroup_extends.py
@@ -9,12 +9,8 @@
 
 import vltest_bootstrap
 
-test.scenarios('simulator')
+test.scenarios('vlt')
 
-if test.vlt_all:
-    test.lint(fails=True, expect_filename=test.golden_filename)
-else:
-    test.compile(nc_flags2=["-coverage", "functional"])
-    test.execute()
+test.compile()
 
 test.passes()

--- a/test_regress/t/t_covergroup_extends.v
+++ b/test_regress/t/t_covergroup_extends.v
@@ -1,0 +1,40 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2025 by Antmicro.
+// SPDX-License-Identifier: CC0-1.0
+
+/* verilator lint_off COVERIGN */
+module t;
+    class base;
+        enum {red, green, blue} color;
+        covergroup g1 (bit [3:0] a) with function sample(bit b);
+            option.weight       = 10;
+            option.per_instance = 1;
+            coverpoint a;
+            coverpoint b;
+            c: coverpoint color;
+        endgroup
+        function new();
+            g1 = new;
+        endfunction
+    endclass
+
+    class derived extends base;
+        bit d;
+        covergroup extends g1;
+        //TODO: Support embedded covergroups inheritance
+            option.weight = 1;  // overrides the weight from base g1
+                                // uses per_instance = 1 from base g1
+            c: coverpoint color // overrides the c coverpoint in base g1
+            {
+                ignore_bins ignore = {blue};
+            }
+            coverpoint d;       // adds new coverpoint
+            cross a, d;         // crosses new coverpoint with inherited one
+        endgroup :g1
+        function new();
+            super.new();
+        endfunction
+    endclass
+endmodule

--- a/test_regress/t/t_covergroup_extends.v
+++ b/test_regress/t/t_covergroup_extends.v
@@ -16,14 +16,13 @@ module t;
             c: coverpoint color;
         endgroup
         function new();
-            g1 = new;
+            g1 = new(0);
         endfunction
     endclass
 
     class derived extends base;
         bit d;
         covergroup extends g1;
-        //TODO: Support embedded covergroups inheritance
             option.weight = 1;  // overrides the weight from base g1
                                 // uses per_instance = 1 from base g1
             c: coverpoint color // overrides the c coverpoint in base g1

--- a/test_regress/t/t_covergroup_extends_newfirst.py
+++ b/test_regress/t/t_covergroup_extends_newfirst.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2025 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('vlt')
+
+test.compile()
+
+test.passes()

--- a/test_regress/t/t_covergroup_extends_newfirst.v
+++ b/test_regress/t/t_covergroup_extends_newfirst.v
@@ -1,0 +1,39 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2025 by Antmicro.
+// SPDX-License-Identifier: CC0-1.0
+
+/* verilator lint_off COVERIGN */
+module t;
+    class base;
+        function new();
+            g1 = new(0);
+        endfunction
+        enum {red, green, blue} color;
+        covergroup g1 (bit [3:0] a) with function sample(bit b);
+            option.weight       = 10;
+            option.per_instance = 1;
+            coverpoint a;
+            coverpoint b;
+            c: coverpoint color;
+        endgroup
+    endclass
+
+    class derived extends base;
+        bit d;
+        function new();
+            super.new();
+        endfunction
+        covergroup extends g1;
+            option.weight = 1;  // overrides the weight from base g1
+                                // uses per_instance = 1 from base g1
+            c: coverpoint color // overrides the c coverpoint in base g1
+            {
+                ignore_bins ignore = {blue};
+            }
+            coverpoint d;       // adds new coverpoint
+            cross a, d;         // crosses new coverpoint with inherited one
+        endgroup :g1
+    endclass
+endmodule

--- a/test_regress/t/t_covergroup_func_override_bad.out
+++ b/test_regress/t/t_covergroup_func_override_bad.out
@@ -1,0 +1,5 @@
+%Error: t/t_covergroup_func_override_bad.v:10:5: syntax error, unexpected function
+   10 |     function sample();
+      |     ^~~~~~~~
+        ... See the manual at https://verilator.org/verilator_doc.html?v=latest for more assistance.
+%Error: Exiting due to

--- a/test_regress/t/t_covergroup_func_override_bad.py
+++ b/test_regress/t/t_covergroup_func_override_bad.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2025 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+if test.vlt_all:
+    test.lint(fails=True, expect_filename=test.golden_filename)
+else:
+    test.compile(nc_flags2=["-coverage", "functional"])
+    test.execute()
+
+test.passes()

--- a/test_regress/t/t_covergroup_func_override_bad.v
+++ b/test_regress/t/t_covergroup_func_override_bad.v
@@ -1,0 +1,17 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2025 by Antmicro.
+// SPDX-License-Identifier: CC0-1.0
+
+/* verilator lint_off COVERIGN */
+module t();
+    covergroup cg;
+    function sample();
+
+    endfunction
+    function get_coverage();
+
+    endfunction
+    endgroup
+endmodule

--- a/test_regress/t/t_covergroup_in_class.py
+++ b/test_regress/t/t_covergroup_in_class.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2025 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('vlt')
+
+test.compile()
+
+test.passes()

--- a/test_regress/t/t_covergroup_in_class.v
+++ b/test_regress/t/t_covergroup_in_class.v
@@ -6,13 +6,13 @@
 
 /* verilator lint_off COVERIGN */
 class myClass;
-    covergroup embedded_cg;
+    covergroup embeddedCg;
 
     endgroup
-    
+
     function new();
-        embedded_cg = new();
-        embedded_cg.sample();
-        embedded_cg.get_coverage();
+        embeddedCg = new();
+        embeddedCg.sample();
+        embeddedCg.get_coverage();
     endfunction
 endclass

--- a/test_regress/t/t_covergroup_in_class.v
+++ b/test_regress/t/t_covergroup_in_class.v
@@ -1,0 +1,18 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2025 by Antmicro.
+// SPDX-License-Identifier: CC0-1.0
+
+/* verilator lint_off COVERIGN */
+class myClass;
+    covergroup embedded_cg;
+
+    endgroup
+    
+    function new();
+        embedded_cg = new();
+        embedded_cg.sample();
+        embedded_cg.get_coverage();
+    endfunction
+endclass

--- a/test_regress/t/t_covergroup_in_class_colliding.py
+++ b/test_regress/t/t_covergroup_in_class_colliding.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2025 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('vlt')
+
+test.compile()
+
+test.passes()

--- a/test_regress/t/t_covergroup_in_class_colliding.v
+++ b/test_regress/t/t_covergroup_in_class_colliding.v
@@ -1,0 +1,30 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2025 by Antmicro.
+// SPDX-License-Identifier: CC0-1.0
+
+/* verilator lint_off COVERIGN */
+class myClass;
+    covergroup embeddedCg;
+
+    endgroup
+
+    function new();
+        embeddedCg = new();
+        embeddedCg.sample();
+        embeddedCg.get_coverage();
+    endfunction
+endclass
+
+class secondClass;
+    covergroup embeddedCg;
+
+    endgroup
+
+    function new();
+        embeddedCg = new();
+        embeddedCg.sample();
+        embeddedCg.get_coverage();
+    endfunction
+endclass

--- a/test_regress/t/t_covergroup_in_class_duplicate_bad.out
+++ b/test_regress/t/t_covergroup_in_class_duplicate_bad.out
@@ -1,0 +1,8 @@
+%Error: t/t_covergroup_in_class_duplicate_bad.v:13:16: Duplicate declaration of CLASS '__vlAnonCG_embeddedCg': '__vlAnonCG_embeddedCg'
+   13 |     covergroup embeddedCg;
+      |                ^~~~~~~~~~
+        t/t_covergroup_in_class_duplicate_bad.v:9:16: ... Location of original declaration
+    9 |     covergroup embeddedCg;
+      |                ^~~~~~~~~~
+        ... See the manual at https://verilator.org/verilator_doc.html?v=latest for more assistance.
+%Error: Exiting due to

--- a/test_regress/t/t_covergroup_in_class_duplicate_bad.py
+++ b/test_regress/t/t_covergroup_in_class_duplicate_bad.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2025 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile(fails=True, expect_filename=test.golden_filename)
+
+test.passes()

--- a/test_regress/t/t_covergroup_in_class_duplicate_bad.v
+++ b/test_regress/t/t_covergroup_in_class_duplicate_bad.v
@@ -1,0 +1,16 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2025 by Antmicro.
+// SPDX-License-Identifier: CC0-1.0
+
+/* verilator lint_off COVERIGN */
+class myClass;
+    covergroup embeddedCg;
+
+    endgroup
+
+    covergroup embeddedCg;
+
+    endgroup
+endclass

--- a/test_regress/t/t_covergroup_new_override_bad.out
+++ b/test_regress/t/t_covergroup_new_override_bad.out
@@ -1,0 +1,5 @@
+%Error: t/t_covergroup_new_override_bad.v:10:5: syntax error, unexpected function
+   10 |     function new();
+      |     ^~~~~~~~
+        ... See the manual at https://verilator.org/verilator_doc.html?v=latest for more assistance.
+%Error: Exiting due to

--- a/test_regress/t/t_covergroup_new_override_bad.py
+++ b/test_regress/t/t_covergroup_new_override_bad.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2025 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+if test.vlt_all:
+    test.lint(fails=True, expect_filename=test.golden_filename)
+else:
+    test.compile(nc_flags2=["-coverage", "functional"])
+    test.execute()
+
+test.passes()

--- a/test_regress/t/t_covergroup_new_override_bad.v
+++ b/test_regress/t/t_covergroup_new_override_bad.v
@@ -1,0 +1,14 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2025 by Antmicro.
+// SPDX-License-Identifier: CC0-1.0
+
+/* verilator lint_off COVERIGN */
+module t();
+    covergroup cg;
+    function new();
+
+    endfunction
+    endgroup
+endmodule

--- a/test_regress/t/t_covergroup_unsup.out
+++ b/test_regress/t/t_covergroup_unsup.out
@@ -388,7 +388,7 @@
   154 |    covergroup cg_more extends cg_empty;
       |    ^~~~~~~~~~
 %Warning-COVERIGN: t/t_covergroup_unsup.v:157:4: Ignoring unsupported: covergroup
-  157 |    covergroup cg_args(int cg_lim);
+  157 |    covergroup cgArgs(int cg_lim);
       |    ^~~~~~~~~~
 %Warning-COVERIGN: t/t_covergroup_unsup.v:164:7: Ignoring unsupported: covergroup
   164 |       covergroup cov1 @m_z;

--- a/test_regress/t/t_covergroup_unsup.out
+++ b/test_regress/t/t_covergroup_unsup.out
@@ -402,11 +402,9 @@
 %Warning-COVERIGN: t/t_covergroup_unsup.v:166:10: Ignoring unsupported: coverpoint
   166 |          coverpoint m_y;
       |          ^~~~~~~~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:164:18: Ignoring unsupported: covergroup within class
-  164 |       covergroup cov1 @m_z;
-      |                  ^~~~
-%Error: t/t_covergroup_unsup.v:169:23: Can't find definition of variable: 'cov1'
-  169 |       function new(); cov1 = new; endfunction
-      |                       ^~~~
+%Error: t/t_covergroup_unsup.v:176:26: Too many arguments in function call to FUNC 'new'
+                                     : ... note: In instance 't'
+  176 |       cg_args cov2 = new(2);
+      |                          ^
         ... See the manual at https://verilator.org/verilator_doc.html?v=latest for more assistance.
 %Error: Exiting due to

--- a/test_regress/t/t_covergroup_unsup.out
+++ b/test_regress/t/t_covergroup_unsup.out
@@ -402,9 +402,4 @@
 %Warning-COVERIGN: t/t_covergroup_unsup.v:166:10: Ignoring unsupported: coverpoint
   166 |          coverpoint m_y;
       |          ^~~~~~~~~~
-%Error: t/t_covergroup_unsup.v:176:26: Too many arguments in function call to FUNC 'new'
-                                     : ... note: In instance 't'
-  176 |       cg_args cov2 = new(2);
-      |                          ^
-        ... See the manual at https://verilator.org/verilator_doc.html?v=latest for more assistance.
 %Error: Exiting due to

--- a/test_regress/t/t_covergroup_unsup.out
+++ b/test_regress/t/t_covergroup_unsup.out
@@ -385,21 +385,21 @@
   136 |       cross a, b {
       |       ^~~~~
 %Warning-COVERIGN: t/t_covergroup_unsup.v:154:4: Ignoring unsupported: covergroup
-  154 |    covergroup cg_more extends cg_empty;
+  154 |    covergroup cgArgs(int cg_lim);
       |    ^~~~~~~~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:157:4: Ignoring unsupported: covergroup
-  157 |    covergroup cgArgs(int cg_lim);
-      |    ^~~~~~~~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:164:7: Ignoring unsupported: covergroup
-  164 |       covergroup cov1 @m_z;
+%Warning-COVERIGN: t/t_covergroup_unsup.v:161:7: Ignoring unsupported: covergroup
+  161 |       covergroup cov1 @m_z;
       |       ^~~~~~~~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:164:23: Ignoring unsupported: coverage clocking event
-  164 |       covergroup cov1 @m_z;
+%Warning-COVERIGN: t/t_covergroup_unsup.v:161:23: Ignoring unsupported: coverage clocking event
+  161 |       covergroup cov1 @m_z;
       |                       ^
-%Warning-COVERIGN: t/t_covergroup_unsup.v:165:10: Ignoring unsupported: coverpoint
-  165 |          coverpoint m_x;
+%Warning-COVERIGN: t/t_covergroup_unsup.v:162:10: Ignoring unsupported: coverpoint
+  162 |          coverpoint m_x;
       |          ^~~~~~~~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:166:10: Ignoring unsupported: coverpoint
-  166 |          coverpoint m_y;
+%Warning-COVERIGN: t/t_covergroup_unsup.v:163:10: Ignoring unsupported: coverpoint
+  163 |          coverpoint m_y;
       |          ^~~~~~~~~~
+%Warning-COVERIGN: t/t_covergroup_unsup.v:171:7: Ignoring unsupported: covergroup
+  171 |       covergroup extends cg_empty;
+      |       ^~~~~~~~~~
 %Error: Exiting due to

--- a/test_regress/t/t_covergroup_unsup.v
+++ b/test_regress/t/t_covergroup_unsup.v
@@ -151,9 +151,6 @@ module t (/*AUTOARG*/
       }
    endgroup
 
-   covergroup cg_more extends cg_empty;
-   endgroup
-
    covergroup cgArgs(int cg_lim);
    endgroup
 
@@ -170,8 +167,13 @@ module t (/*AUTOARG*/
 `endif
    endclass
 
+   class CgEmb;
+      covergroup extends cg_empty;
+      endgroup
+   endclass;
+
    always @(posedge clk) begin
-      cg_more cov1 = new;
+      cg_empty cov1 = new;
 `ifndef T_COVERGROUP_UNSUP_IGN
       cgArgs cov2 = new(2);
 `endif

--- a/test_regress/t/t_covergroup_unsup.v
+++ b/test_regress/t/t_covergroup_unsup.v
@@ -154,7 +154,7 @@ module t (/*AUTOARG*/
    covergroup cg_more extends cg_empty;
    endgroup
 
-   covergroup cg_args(int cg_lim);
+   covergroup cgArgs(int cg_lim);
    endgroup
 
    class CgCls;
@@ -173,7 +173,7 @@ module t (/*AUTOARG*/
    always @(posedge clk) begin
       cg_more cov1 = new;
 `ifndef T_COVERGROUP_UNSUP_IGN
-      cg_args cov2 = new(2);
+      cgArgs cov2 = new(2);
 `endif
       if (cyc == 10) begin
          $write("*-* All Finished *-*\n");

--- a/test_regress/t/t_covergroup_unsup.v
+++ b/test_regress/t/t_covergroup_unsup.v
@@ -170,7 +170,7 @@ module t (/*AUTOARG*/
    class CgEmb;
       covergroup extends cg_empty;
       endgroup
-   endclass;
+   endclass
 
    always @(posedge clk) begin
       cg_empty cov1 = new;


### PR DESCRIPTION
This MR improves handling of covergroups (ignores more cases).

In classes - as per IEEE 1800-2023 19.4:
 > A covergroup declaration within a class is an embedded covergroup declaration. An embedded
covergroup declaration declares an anonymous covergroup type and an instance variable of the
anonymous type. The covergroup_identifier defines the name of the instance variable.

Also, `get_coverage` and `sample` methods were added, so that code using covergroups can call them and not fail.