### PR TITLE
Fix LinkDotResolveVisitor for AstClassExtends in primary run

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -83,6 +83,7 @@ Huang Rui
 Huanghuang Zhou
 HungMingWu
 HyungKi Jeong
+Igor Zaworski
 Ilya Barkov
 Iru Cai
 Ivan Vnučec

--- a/src/V3LinkDot.cpp
+++ b/src/V3LinkDot.cpp
@@ -4213,6 +4213,7 @@ class LinkDotResolveVisitor final : public VNVisitor {
         if (nodep->classOrNullp()) return;
         LINKDOT_VISIT_START();
         if (m_statep->forPrimary()) {
+            if (nodep->childDTypep()) return;
             AstNode* cprp = nodep->classOrPkgsp();
             VSymEnt* lookSymp = m_curSymp;
             if (AstDot* const dotp = VN_CAST(cprp, Dot)) {

--- a/test_regress/t/t_class_param_extends_static_member_function_access.py
+++ b/test_regress/t/t_class_param_extends_static_member_function_access.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2025 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile()
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_class_param_extends_static_member_function_access.v
+++ b/test_regress/t/t_class_param_extends_static_member_function_access.v
@@ -1,0 +1,26 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2025 by Antmicro.
+// SPDX-License-Identifier: CC0-1.0
+
+class Class1 #(type T);
+  static function int get_p();
+    return 7;
+  endfunction
+endclass
+
+class Class2 #(type T) extends Class1 #(T);
+   static function int get_p2;
+     return T::get_p();
+   endfunction
+endclass
+
+module t;
+  initial begin
+    typedef Class2#(Class1#(int)) Class;
+    if (Class::get_p2() != Class1#(int)::get_p()) $stop;
+    $write("*-* All Finished *-*\n");
+    $finish;
+  end
+endmodule


### PR DESCRIPTION
``LinkDotResolveVisitor`` for ``AstClassExtends`` wasn't prepared for being called for the second time in primary run. However, ``revisitLater`` used in ``visit(AstDot*)`` method could cause second call.

Example:
```
class Class1 #(type T);
endclass

class Class2 #(type T) extends Class1 #(T);
   static function int get_p2;
     return T::get_p();
   endfunction
endclass
```

In order to fix this issue, I added next if-guard statement in the ``visit`` function for a ``AstClassExtends`` in ``LinkDotResolveVisitor``.