### PR TITLE
Param dependent type linking fix

### DIFF
--- a/src/V3LinkDot.cpp
+++ b/src/V3LinkDot.cpp
@@ -3552,9 +3552,6 @@ class LinkDotResolveVisitor final : public VNVisitor {
         UINFO(9, indent() << m_ds.ascii());
         VL_RESTORER(m_usedPins);
         m_usedPins.clear();
-        UASSERT_OBJ(m_statep->forPrimary() || VN_IS(nodep->classOrPackageNodep(), ParamTypeDType)
-                        || nodep->classOrPackageSkipp(),
-                    nodep, "ClassRef has unlinked class");
         UASSERT_OBJ(m_statep->forPrimary() || !nodep->paramsp(), nodep,
                     "class reference parameter not removed by V3Param");
         {
@@ -3565,6 +3562,10 @@ class LinkDotResolveVisitor final : public VNVisitor {
                 m_statep->resolveClassOrPackage(m_ds.m_dotSymp, nodep, m_ds.m_dotPos != DP_PACKAGE,
                                                 false, ":: reference");
             }
+            UASSERT_OBJ(m_statep->forPrimary()
+                            || VN_IS(nodep->classOrPackageNodep(), ParamTypeDType)
+                            || nodep->classOrPackageSkipp(),
+                        nodep, "ClassRef has unlinked class");
 
             // ClassRef's have pins, so track
             if (nodep->classOrPackageSkipp()) {

--- a/src/V3Param.cpp
+++ b/src/V3Param.cpp
@@ -1116,7 +1116,7 @@ class ParamVisitor final : public VNVisitor {
                 } else {
                     cellp->v3fatalSrc("Expected module parameterization");
                 }
-                UASSERT_OBJ(srcModp, cellp, "Unlinked class ref");
+                if (!srcModp) continue;
 
                 // Update path
                 string someInstanceName = modp->someInstanceName();

--- a/test_regress/t/t_class_param_subtype2.py
+++ b/test_regress/t/t_class_param_subtype2.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2025 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile()
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_class_param_subtype2.v
+++ b/test_regress/t/t_class_param_subtype2.v
@@ -1,0 +1,26 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2025 by Antmicro.
+// SPDX-License-Identifier: CC0-1.0
+
+class Class1 #(type T);
+   static function int get();
+      return T::Helper::getter();
+   endfunction
+endclass
+
+class Class2;
+   typedef Class2 Helper;
+   static function int getter();
+      return 13;
+   endfunction
+endclass
+
+module t;
+   initial begin
+      if (Class1#(Class2)::get() != 13) $stop;
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end
+endmodule


### PR DESCRIPTION
Fix for param dependent types e.g.:
```
class Class1 #(type T);
   static function int get();
      return T::Helper::getter();
   endfunction
endclass
```

Right now in above case we get an error:
```
%Error: Internal Error: test.v:3:17: ../V3Param.cpp:1119: Unlinked class ref
                                   : ... note: In instance 't'
    3 |       return T::Helper::getter();
      |                 ^~~~~~
```

However, this solution does not solve issue with:
```
class Class1 #(type T);
   static function int get();
      return T::Helper::Helper::getter();
   endfunction
endclass
```