### PR TITLE
Param dependent typedef linking fix

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -83,6 +83,7 @@ Huang Rui
 Huanghuang Zhou
 HungMingWu
 HyungKi Jeong
+Igor Zaworski
 Ilya Barkov
 Iru Cai
 Ivan Vnučec

--- a/src/V3LinkDot.cpp
+++ b/src/V3LinkDot.cpp
@@ -4419,6 +4419,12 @@ class LinkDotResolveVisitor final : public VNVisitor {
                 nodep->classOrPackagep(cpackagerefp->classOrPackageSkipp());
                 if (!VN_IS(nodep->classOrPackagep(), Class)
                     && !VN_IS(nodep->classOrPackagep(), Package)) {
+                    if (m_statep->forPrimary()) {
+                        // It may be a type that comes from parameter class that is not
+                        // instantioned yet
+                        iterate(cpackagep);
+                        return;
+                    }
                     // Likely impossible, as error thrown earlier
                     cpackagerefp->v3error(  // LCOV_EXCL_LINE
                         "'::' expected to reference a class/package but referenced '"

--- a/test_regress/t/t_typedef_param_class.py
+++ b/test_regress/t/t_typedef_param_class.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2025 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile()
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_typedef_param_class.v
+++ b/test_regress/t/t_typedef_param_class.v
@@ -12,8 +12,6 @@ class Class2;
   typedef int Some_type2;
 endclass
 
-
-
 module t;
   initial begin
     int value0 = 7;

--- a/test_regress/t/t_typedef_param_class.v
+++ b/test_regress/t/t_typedef_param_class.v
@@ -15,16 +15,11 @@ endclass
 
 
 module t;
-   initial begin
-      Class1#(Class2)::Some_type1 value1 = 7;
-      // TODO: uncomment those lines when `type` will be fixed
-      // type(value1) in this case causes an error:
-      //  %Error: Internal Error: t/t_typedef_param_class.v:19:16:
-      // ../V3Ast.h:2659: AstNode is not of expected type, but instead has type 'VARREF'
-      //     19 |       if (type(value1) != type(value2)) $stop;
-      // int value2 = 13;
-      // if (type(value1) != type(value2)) $stop;
-      $write("*-* All Finished *-*\n");
-      $finish;
-   end
+  initial begin
+    int value0 = 7;
+    Class1#(Class2)::Some_type1 value1 = value0;
+    int value2 = value1;
+    $write("*-* All Finished *-*\n");
+    $finish;
+  end
 endmodule

--- a/test_regress/t/t_typedef_param_class.v
+++ b/test_regress/t/t_typedef_param_class.v
@@ -1,0 +1,30 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2025 by Antmicro.
+// SPDX-License-Identifier: CC0-1.0
+
+class Class1 #(type T);
+  typedef T::Some_type2 Some_type1;
+endclass
+
+class Class2;
+  typedef int Some_type2;
+endclass
+
+
+
+module t;
+   initial begin
+      Class1#(Class2)::Some_type1 value1 = 7;
+      // TODO: uncomment those lines when `type` will be fixed
+      // type(value1) in this case causes an error:
+      //  %Error: Internal Error: t/t_typedef_param_class.v:19:16:
+      // ../V3Ast.h:2659: AstNode is not of expected type, but instead has type 'VARREF'
+      //     19 |       if (type(value1) != type(value2)) $stop;
+      // int value2 = 13;
+      // if (type(value1) != type(value2)) $stop;
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end
+endmodule


### PR DESCRIPTION
Typedefs that were dependent on a class parameter didn't work e.g.:
```
class Class1 #(type T);
  typedef T::Some_type2 Some_type1;
endclass
```

This solution allows above code to compile.