### PR TITLE
Add support for disabling a fork from outside that fork

### DIFF
--- a/include/verilated_std.sv
+++ b/include/verilated_std.sv
@@ -175,6 +175,14 @@ package std;
 `endif
       endtask
 
+      static task killQueue(ref process processQueue[$]);
+`ifdef VERILATOR_TIMING
+         while (processQueue.size() > 0) begin
+            processQueue.pop_back().kill();
+         end
+`endif
+      endtask
+
       // Two process references are equal if the different classes' containing
       // m_process are equal. Can't yet use <=> as the base class template
       // comparisons doesn't define <=> as they don't yet require --timing and C++20.

--- a/src/V3AstNodeOther.h
+++ b/src/V3AstNodeOther.h
@@ -1974,7 +1974,7 @@ class AstVar final : public AstNode {
     bool m_isConst : 1;  // Table contains constant data
     bool m_isContinuously : 1;  // Ever assigned continuously (for force/release)
     bool m_hasStrengthAssignment : 1;  // Is on LHS of assignment with strength specifier
-    bool m_isStatic : 1;  // Static C variable (for Verilog see instead isAutomatic)
+    bool m_isStatic : 1;  // Static C variable (for Verilog see instead lifetime())
     bool m_isPulldown : 1;  // Tri0
     bool m_isPullup : 1;  // Tri1
     bool m_isIfaceParent : 1;  // dtype is reference to interface present in this module

--- a/src/V3LinkJump.cpp
+++ b/src/V3LinkJump.cpp
@@ -338,14 +338,14 @@ class LinkJumpVisitor final : public VNVisitor {
         nodep->unlinkFrBack();
         VL_DO_DANGLING(pushDeletep(nodep), nodep);
     }
-    AstNode* getMemberp(AstNodeModule* nodep, const std::string& name) {
+    AstNode* getMemberp(const AstNodeModule* const nodep, const std::string& name) {
         for (AstNode* itemp = nodep->stmtsp(); itemp; itemp = itemp->nextp()) {
             if (itemp->name() == name) return itemp;
         }
         return nullptr;
     }
     bool existsBlockAbove(const std::string& name) const {
-        for (AstNodeBlock* const stackp : vlstd::reverse_view(m_blockStack)) {
+        for (const AstNodeBlock* const stackp : vlstd::reverse_view(m_blockStack)) {
             if (stackp->name() == name) return true;
         }
         return false;

--- a/src/V3LinkJump.cpp
+++ b/src/V3LinkJump.cpp
@@ -361,6 +361,9 @@ class LinkJumpVisitor final : public VNVisitor {
             if (existsBlockAbove(forkp->name())) {
                 nodep->v3warn(E_UNSUPPORTED, "Unsupported: disabling fork being inside it");
             }
+            if (m_ftaskp) {
+                nodep->v3warn(E_UNSUPPORTED, "Unsupported: disabling fork from task / function");
+            }
             AstPackage* const topPkgp = v3Global.rootp()->dollarUnitPkgAddp();
             AstClass* const processClassp
                 = VN_AS(getMemberp(v3Global.rootp()->stdPackagep(), "process"), Class);

--- a/src/V3LinkJump.cpp
+++ b/src/V3LinkJump.cpp
@@ -162,6 +162,18 @@ class LinkJumpVisitor final : public VNVisitor {
         if (AstNode* const refp = nodep->op4p()) addPrefixToBlocksRecurse(prefix, refp);
         if (AstNode* const refp = nodep->nextp()) addPrefixToBlocksRecurse(prefix, refp);
     }
+    static AstNode* getMemberp(const AstNodeModule* const nodep, const std::string& name) {
+        for (AstNode* itemp = nodep->stmtsp(); itemp; itemp = itemp->nextp()) {
+            if (itemp->name() == name) return itemp;
+        }
+        return nullptr;
+    }
+    bool existsBlockAbove(const std::string& name) const {
+        for (const AstNodeBlock* const stackp : vlstd::reverse_view(m_blockStack)) {
+            if (stackp->name() == name) return true;
+        }
+        return false;
+    }
 
     // VISITORS
     void visit(AstNodeModule* nodep) override {
@@ -337,18 +349,6 @@ class LinkJumpVisitor final : public VNVisitor {
         }
         nodep->unlinkFrBack();
         VL_DO_DANGLING(pushDeletep(nodep), nodep);
-    }
-    AstNode* getMemberp(const AstNodeModule* const nodep, const std::string& name) {
-        for (AstNode* itemp = nodep->stmtsp(); itemp; itemp = itemp->nextp()) {
-            if (itemp->name() == name) return itemp;
-        }
-        return nullptr;
-    }
-    bool existsBlockAbove(const std::string& name) const {
-        for (const AstNodeBlock* const stackp : vlstd::reverse_view(m_blockStack)) {
-            if (stackp->name() == name) return true;
-        }
-        return false;
     }
     void visit(AstDisable* nodep) override {
         UINFO(8, "   DISABLE " << nodep);

--- a/src/V3LinkJump.cpp
+++ b/src/V3LinkJump.cpp
@@ -387,7 +387,7 @@ class LinkJumpVisitor final : public VNVisitor {
             // pushed to the queue. `disable` statement is replaced with calling `kill()` method on
             // each element of the queue.
             if (existsBlockAbove(forkp->name())) {
-                nodep->v3warn(E_UNSUPPORTED, "Unsupported: disabling fork being inside it");
+                nodep->v3warn(E_UNSUPPORTED, "Unsupported: disabling fork from within it");
             }
             if (m_ftaskp) {
                 nodep->v3warn(E_UNSUPPORTED, "Unsupported: disabling fork from task / function");

--- a/src/V3LinkJump.cpp
+++ b/src/V3LinkJump.cpp
@@ -361,6 +361,16 @@ class LinkJumpVisitor final : public VNVisitor {
                                          nullptr},
                     nullptr}};
             topPkgp->addStmtsp(processQueuep);
+            for (AstNode* forkItemp = forkp->stmtsp(); forkItemp; forkItemp = forkItemp->nextp()) {
+                AstBegin* beginp = VN_CAST(forkItemp, Begin);
+                if (!beginp) {
+                    beginp = new AstBegin{fl, "", nullptr};
+                    forkItemp->replaceWith(beginp);
+                    beginp->addStmtsp(forkItemp);
+                    // In order to continue the iteration
+                    forkItemp = beginp;
+                }
+            }
         } else if (AstBegin* const beginp = VN_CAST(targetp, Begin)) {
             const std::string targetName = beginp->name();
             bool aboveBlock = false;

--- a/src/V3LinkJump.cpp
+++ b/src/V3LinkJump.cpp
@@ -359,7 +359,7 @@ class LinkJumpVisitor final : public VNVisitor {
                 fl, VVarType::VAR, m_queueNames.get(forkp->name()), VFlagChildDType{},
                 new AstQueueDType{fl, VFlagChildDType{},
                                   new AstClassRefDType{fl, processClassp, nullptr}, nullptr}};
-            processQueuep->isStatic(true);
+            processQueuep->lifetime(VLifetime::STATIC);
             topPkgp->addStmtsp(processQueuep);
             AstVarRef* const queueRefp = new AstVarRef{fl, topPkgp, processQueuep, VAccess::WRITE};
             AstFunc* const selfMethodp = VN_AS(getMemberp(processClassp, "self"), Func);

--- a/src/V3LinkJump.cpp
+++ b/src/V3LinkJump.cpp
@@ -382,6 +382,19 @@ class LinkJumpVisitor final : public VNVisitor {
                 }
                 beginp->stmtsp()->addHereThisAsNext(pushCurrentProcessp);
             }
+            AstVarRef* const queueReadRefp
+                = new AstVarRef{fl, topPkgp, processQueuep, VAccess::READ};
+            AstVar* const queueIterp
+                = new AstVar{fl, VVarType::BLOCKTEMP, "i", nodep->findSigned32DType()};
+            AstStmtExpr* const processKillp = new AstStmtExpr{
+                fl, new AstMethodCall{fl,
+                                      new AstSelBit{fl, queueReadRefp,
+                                                    new AstVarRef{fl, queueIterp, VAccess::READ}},
+                                      "kill", nullptr}};
+            AstForeach* const foreachp = new AstForeach{
+                fl, new AstSelLoopVars{fl, queueReadRefp->cloneTree(false), queueIterp},
+                processKillp};
+            nodep->addNextHere(new AstBegin{fl, "", foreachp, false, true});
         } else if (AstBegin* const beginp = VN_CAST(targetp, Begin)) {
             const std::string targetName = beginp->name();
             bool aboveBlock = false;

--- a/src/V3LinkJump.cpp
+++ b/src/V3LinkJump.cpp
@@ -387,7 +387,7 @@ class LinkJumpVisitor final : public VNVisitor {
             // pushed to the queue. `disable` statement is replaced with calling `kill()` method on
             // each element of the queue.
             if (existsBlockAbove(forkp->name())) {
-                nodep->v3warn(E_UNSUPPORTED, "Unsupported: disabling fork from within it");
+                nodep->v3warn(E_UNSUPPORTED, "Unsupported: disabling fork from within same fork");
             }
             if (m_ftaskp) {
                 nodep->v3warn(E_UNSUPPORTED, "Unsupported: disabling fork from task / function");

--- a/src/V3ParseImp.h
+++ b/src/V3ParseImp.h
@@ -293,12 +293,12 @@ public:
     void dumpInputsFile() VL_MT_DISABLED;
     void dumpTokensAhead(int line) VL_MT_DISABLED;
     static void candidatePli(VSpellCheck* spellerp) VL_MT_DISABLED;
+    void importIfInStd(FileLine* fileline, const string& id);
 
 private:
     void preprocDumps(std::ostream& os);
     void lexFile(const string& modname) VL_MT_DISABLED;
     void yylexReadTok() VL_MT_DISABLED;
-    void importIfInStd(FileLine* fileline, const string& id);
     void tokenPull() VL_MT_DISABLED;
     void tokenPipeline() VL_MT_DISABLED;  // Internal; called from tokenToBison
     int tokenPipelineId(int token) VL_MT_DISABLED;

--- a/src/verilog.y
+++ b/src/verilog.y
@@ -3754,7 +3754,9 @@ statement_item<nodep>:          // IEEE: statement_item
         //                      // IEEE: disable_statement
         |       yDISABLE yFORK ';'                      { $$ = new AstDisableFork{$1}; }
         |       yDISABLE idDottedSel ';'
-                        { $$ = new AstDisable{$1, $2}; }
+                        { $$ = new AstDisable{$1, $2};
+                          PARSEP->importIfInStd($1, "process");
+                        }
         //                      // IEEE: event_trigger
         |       yP_MINUSGT expr ';'
                         { $$ = new AstFireEvent{$1, $2, false}; }

--- a/test_regress/t/t_disable.out
+++ b/test_regress/t/t_disable.out
@@ -1,4 +1,4 @@
-%Error-UNSUPPORTED: t/t_disable.v:11:10: Unsupported: disabling fork being inside it
+%Error-UNSUPPORTED: t/t_disable.v:11:10: Unsupported: disabling fork from within it
    11 |          disable foo;
       |          ^~~~~~~
                     ... For error description see https://verilator.org/warn/UNSUPPORTED?v=latest

--- a/test_regress/t/t_disable.out
+++ b/test_regress/t/t_disable.out
@@ -1,4 +1,4 @@
-%Error-UNSUPPORTED: t/t_disable.v:11:10: Unsupported: disabling fork by name
+%Error-UNSUPPORTED: t/t_disable.v:11:10: Unsupported: disabling fork being inside it
    11 |          disable foo;
       |          ^~~~~~~
                     ... For error description see https://verilator.org/warn/UNSUPPORTED?v=latest

--- a/test_regress/t/t_disable.out
+++ b/test_regress/t/t_disable.out
@@ -1,4 +1,4 @@
-%Error-UNSUPPORTED: t/t_disable.v:11:10: Unsupported: disabling fork from within it
+%Error-UNSUPPORTED: t/t_disable.v:11:10: Unsupported: disabling fork from within same fork
    11 |          disable foo;
       |          ^~~~~~~
                     ... For error description see https://verilator.org/warn/UNSUPPORTED?v=latest

--- a/test_regress/t/t_disable_outside.py
+++ b/test_regress/t/t_disable_outside.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2024 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile(timing_loop=True, verilator_flags2=["--timing"])
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_disable_outside.v
+++ b/test_regress/t/t_disable_outside.v
@@ -1,0 +1,26 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2025 by Antmicro.
+// SPDX-License-Identifier: CC0-1.0
+
+module t (/*AUTOARG*/);
+   initial begin
+      begin : blk
+         int x = 0;
+         fork : fork_blk
+            begin
+               x = 1;
+               #2;
+               x = 2;
+            end
+         join_none
+         #1;
+         disable fork_blk;
+         #2;
+         if (x != 1) $stop;
+         $write("*-* All Finished *-*\n");
+         $finish;
+      end
+   end
+endmodule

--- a/test_regress/t/t_disable_outside2.py
+++ b/test_regress/t/t_disable_outside2.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2024 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile(timing_loop=True, verilator_flags2=["--timing"])
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_disable_outside2.v
+++ b/test_regress/t/t_disable_outside2.v
@@ -1,0 +1,29 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2025 by Antmicro.
+// SPDX-License-Identifier: CC0-1.0
+
+module t (/*AUTOARG*/);
+   initial begin
+      for (int i = 0; i < 3; i++) begin
+         begin : blk
+            int x = 0;
+            fork : fork_blk
+               begin
+                  x = 1;
+                  #2;
+                  x = 2;
+               end
+            join_none
+            #1;
+            if (i < 2) disable fork_blk;
+            #2;
+            if (i < 2 && x != 1) $stop;
+            if (i == 2 && x != 2) $stop;
+         end
+      end
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end
+endmodule

--- a/test_regress/t/t_disable_within_task_unsup.out
+++ b/test_regress/t/t_disable_within_task_unsup.out
@@ -1,0 +1,5 @@
+%Error-UNSUPPORTED: t/t_disable_within_task_unsup.v:8:4: Unsupported: disabling fork from task / function
+    8 |    disable t.init.fork_blk;
+      |    ^~~~~~~
+                    ... For error description see https://verilator.org/warn/UNSUPPORTED?v=latest
+%Error: Exiting due to

--- a/test_regress/t/t_disable_within_task_unsup.py
+++ b/test_regress/t/t_disable_within_task_unsup.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2024 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.lint(verilator_flags2=['--timing'], fails=True, expect_filename=test.golden_filename)
+
+test.passes()

--- a/test_regress/t/t_disable_within_task_unsup.v
+++ b/test_regress/t/t_disable_within_task_unsup.v
@@ -1,0 +1,31 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2025 by Antmicro.
+// SPDX-License-Identifier: CC0-1.0
+
+task disable_fork_blk;
+   disable t.init.fork_blk;
+endtask
+
+module t(/*AUTOARG*/);
+
+   initial begin : init
+      int x = 0;
+      fork : fork_blk
+         begin
+            x = 1;
+            disable_fork_blk();
+            x = 2;
+         end
+         begin
+            #1;
+            x = 3;
+         end
+      join
+      if (x != 1) $stop;
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end
+
+endmodule

--- a/test_regress/t/t_dump_json.out
+++ b/test_regress/t/t_dump_json.out
@@ -1,427 +1,427 @@
-{"type":"NETLIST","name":"$root","addr":"(B)","loc":"a,0:0,0:0","timeunit":"1ps","timeprecision":"1ps","typeTablep":"(C)","constPoolp":"(D)","dollarUnitPkgp":"UNLINKED","stdPackagep":"UNLINKED","evalp":"UNLINKED","evalNbap":"UNLINKED","dpiExportTriggerp":"UNLINKED","delaySchedulerp":"UNLINKED","nbaEventp":"UNLINKED","nbaEventTriggerp":"UNLINKED","topScopep":"UNLINKED",
+{"type":"NETLIST","name":"$root","addr":"(B)","loc":"a,0:0,0:0","timeunit":"1ps","timeprecision":"1ps","typeTablep":"(C)","constPoolp":"(D)","dollarUnitPkgp":"(E)","stdPackagep":"(F)","evalp":"UNLINKED","evalNbap":"UNLINKED","dpiExportTriggerp":"UNLINKED","delaySchedulerp":"UNLINKED","nbaEventp":"UNLINKED","nbaEventTriggerp":"UNLINKED","topScopep":"UNLINKED",
  "modulesp": [
-  {"type":"MODULE","name":"t","addr":"(E)","loc":"e,7:8,7:9","isChecker":false,"isProgram":false,"origName":"t","level":2,"modPublic":false,"inLibrary":false,"dead":false,"recursiveClone":false,"recursive":false,"timeunit":"1ps","inlinesp": [],
+  {"type":"MODULE","name":"t","addr":"(G)","loc":"e,7:8,7:9","isChecker":false,"isProgram":false,"origName":"t","level":2,"modPublic":false,"inLibrary":false,"dead":false,"recursiveClone":false,"recursive":false,"timeunit":"1ps","inlinesp": [],
    "stmtsp": [
-    {"type":"PORT","name":"clk","addr":"(F)","loc":"e,9:4,9:7","exprp": []},
-    {"type":"VAR","name":"clk","addr":"(G)","loc":"e,11:10,11:13","dtypep":"UNLINKED","origName":"clk","isSc":false,"isPrimaryIO":false,"direction":"INPUT","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"attrClocker":"UNKNOWN","lifetime":"NONE","varType":"PORT","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"ignorePostWrite":false,"ignoreSchedWrite":false,"sensIfacep":"UNLINKED",
+    {"type":"PORT","name":"clk","addr":"(H)","loc":"e,9:4,9:7","exprp": []},
+    {"type":"VAR","name":"clk","addr":"(I)","loc":"e,11:10,11:13","dtypep":"UNLINKED","origName":"clk","isSc":false,"isPrimaryIO":false,"direction":"INPUT","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"attrClocker":"UNKNOWN","lifetime":"NONE","varType":"PORT","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"ignorePostWrite":false,"ignoreSchedWrite":false,"sensIfacep":"UNLINKED",
      "childDTypep": [
-      {"type":"BASICDTYPE","name":"LOGIC_IMPLICIT","addr":"(H)","loc":"e,11:10,11:13","dtypep":"(H)","keyword":"LOGIC_IMPLICIT","generic":false,"rangep": []}
+      {"type":"BASICDTYPE","name":"LOGIC_IMPLICIT","addr":"(J)","loc":"e,11:10,11:13","dtypep":"(J)","keyword":"LOGIC_IMPLICIT","generic":false,"rangep": []}
     ],"delayp": [],"valuep": [],"attrsp": []},
-    {"type":"VAR","name":"cyc","addr":"(I)","loc":"e,13:12,13:15","dtypep":"UNLINKED","origName":"cyc","isSc":false,"isPrimaryIO":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"attrClocker":"UNKNOWN","lifetime":"NONE","varType":"VAR","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"ignorePostWrite":false,"ignoreSchedWrite":false,"sensIfacep":"UNLINKED",
+    {"type":"VAR","name":"cyc","addr":"(K)","loc":"e,13:12,13:15","dtypep":"UNLINKED","origName":"cyc","isSc":false,"isPrimaryIO":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"attrClocker":"UNKNOWN","lifetime":"NONE","varType":"VAR","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"ignorePostWrite":false,"ignoreSchedWrite":false,"sensIfacep":"UNLINKED",
      "childDTypep": [
-      {"type":"BASICDTYPE","name":"integer","addr":"(J)","loc":"e,13:4,13:11","dtypep":"(J)","keyword":"integer","range":"31:0","generic":false,"rangep": []}
+      {"type":"BASICDTYPE","name":"integer","addr":"(L)","loc":"e,13:4,13:11","dtypep":"(L)","keyword":"integer","range":"31:0","generic":false,"rangep": []}
     ],"delayp": [],
      "valuep": [
-      {"type":"CONST","name":"?32?sh0","addr":"(K)","loc":"e,13:18,13:19","dtypep":"(L)"}
+      {"type":"CONST","name":"?32?sh0","addr":"(M)","loc":"e,13:18,13:19","dtypep":"(N)"}
     ],"attrsp": []},
-    {"type":"VAR","name":"crc","addr":"(M)","loc":"e,14:15,14:18","dtypep":"UNLINKED","origName":"crc","isSc":false,"isPrimaryIO":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"attrClocker":"UNKNOWN","lifetime":"NONE","varType":"VAR","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"ignorePostWrite":false,"ignoreSchedWrite":false,"sensIfacep":"UNLINKED",
+    {"type":"VAR","name":"crc","addr":"(O)","loc":"e,14:15,14:18","dtypep":"UNLINKED","origName":"crc","isSc":false,"isPrimaryIO":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"attrClocker":"UNKNOWN","lifetime":"NONE","varType":"VAR","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"ignorePostWrite":false,"ignoreSchedWrite":false,"sensIfacep":"UNLINKED",
      "childDTypep": [
-      {"type":"BASICDTYPE","name":"logic","addr":"(N)","loc":"e,14:4,14:7","dtypep":"(N)","keyword":"logic","generic":false,
+      {"type":"BASICDTYPE","name":"logic","addr":"(P)","loc":"e,14:4,14:7","dtypep":"(P)","keyword":"logic","generic":false,
        "rangep": [
-        {"type":"RANGE","name":"","addr":"(O)","loc":"e,14:8,14:9","ascending":false,
+        {"type":"RANGE","name":"","addr":"(Q)","loc":"e,14:8,14:9","ascending":false,
          "leftp": [
-          {"type":"CONST","name":"?32?sh3f","addr":"(P)","loc":"e,14:9,14:11","dtypep":"(Q)"}
+          {"type":"CONST","name":"?32?sh3f","addr":"(R)","loc":"e,14:9,14:11","dtypep":"(S)"}
         ],
          "rightp": [
-          {"type":"CONST","name":"?32?sh0","addr":"(R)","loc":"e,14:12,14:13","dtypep":"(L)"}
+          {"type":"CONST","name":"?32?sh0","addr":"(T)","loc":"e,14:12,14:13","dtypep":"(N)"}
         ]}
       ]}
     ],"delayp": [],"valuep": [],"attrsp": []},
-    {"type":"VAR","name":"sum","addr":"(S)","loc":"e,15:15,15:18","dtypep":"UNLINKED","origName":"sum","isSc":false,"isPrimaryIO":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"attrClocker":"UNKNOWN","lifetime":"NONE","varType":"VAR","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"ignorePostWrite":false,"ignoreSchedWrite":false,"sensIfacep":"UNLINKED",
+    {"type":"VAR","name":"sum","addr":"(U)","loc":"e,15:15,15:18","dtypep":"UNLINKED","origName":"sum","isSc":false,"isPrimaryIO":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"attrClocker":"UNKNOWN","lifetime":"NONE","varType":"VAR","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"ignorePostWrite":false,"ignoreSchedWrite":false,"sensIfacep":"UNLINKED",
      "childDTypep": [
-      {"type":"BASICDTYPE","name":"logic","addr":"(T)","loc":"e,15:4,15:7","dtypep":"(T)","keyword":"logic","generic":false,
+      {"type":"BASICDTYPE","name":"logic","addr":"(V)","loc":"e,15:4,15:7","dtypep":"(V)","keyword":"logic","generic":false,
        "rangep": [
-        {"type":"RANGE","name":"","addr":"(U)","loc":"e,15:8,15:9","ascending":false,
+        {"type":"RANGE","name":"","addr":"(W)","loc":"e,15:8,15:9","ascending":false,
          "leftp": [
-          {"type":"CONST","name":"?32?sh3f","addr":"(V)","loc":"e,15:9,15:11","dtypep":"(Q)"}
+          {"type":"CONST","name":"?32?sh3f","addr":"(X)","loc":"e,15:9,15:11","dtypep":"(S)"}
         ],
          "rightp": [
-          {"type":"CONST","name":"?32?sh0","addr":"(W)","loc":"e,15:12,15:13","dtypep":"(L)"}
+          {"type":"CONST","name":"?32?sh0","addr":"(Y)","loc":"e,15:12,15:13","dtypep":"(N)"}
         ]}
       ]}
     ],"delayp": [],"valuep": [],"attrsp": []},
-    {"type":"VAR","name":"in","addr":"(X)","loc":"e,18:16,18:18","dtypep":"UNLINKED","origName":"in","isSc":false,"isPrimaryIO":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"attrClocker":"UNKNOWN","lifetime":"NONE","varType":"WIRE","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"ignorePostWrite":false,"ignoreSchedWrite":false,"sensIfacep":"UNLINKED",
+    {"type":"VAR","name":"in","addr":"(Z)","loc":"e,18:16,18:18","dtypep":"UNLINKED","origName":"in","isSc":false,"isPrimaryIO":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"attrClocker":"UNKNOWN","lifetime":"NONE","varType":"WIRE","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"ignorePostWrite":false,"ignoreSchedWrite":false,"sensIfacep":"UNLINKED",
      "childDTypep": [
-      {"type":"BASICDTYPE","name":"logic","addr":"(Y)","loc":"e,18:9,18:10","dtypep":"(Y)","keyword":"logic","generic":false,
+      {"type":"BASICDTYPE","name":"logic","addr":"(AB)","loc":"e,18:9,18:10","dtypep":"(AB)","keyword":"logic","generic":false,
        "rangep": [
-        {"type":"RANGE","name":"","addr":"(Z)","loc":"e,18:9,18:10","ascending":false,
+        {"type":"RANGE","name":"","addr":"(BB)","loc":"e,18:9,18:10","ascending":false,
          "leftp": [
-          {"type":"CONST","name":"?32?sh1f","addr":"(AB)","loc":"e,18:10,18:12","dtypep":"(BB)"}
+          {"type":"CONST","name":"?32?sh1f","addr":"(CB)","loc":"e,18:10,18:12","dtypep":"(DB)"}
         ],
          "rightp": [
-          {"type":"CONST","name":"?32?sh0","addr":"(CB)","loc":"e,18:13,18:14","dtypep":"(L)"}
+          {"type":"CONST","name":"?32?sh0","addr":"(EB)","loc":"e,18:13,18:14","dtypep":"(N)"}
         ]}
       ]}
     ],"delayp": [],"valuep": [],"attrsp": []},
-    {"type":"ASSIGNW","name":"","addr":"(DB)","loc":"e,18:19,18:20","dtypep":"UNLINKED",
+    {"type":"ASSIGNW","name":"","addr":"(FB)","loc":"e,18:19,18:20","dtypep":"UNLINKED",
      "rhsp": [
-      {"type":"SELEXTRACT","name":"","addr":"(EB)","loc":"e,18:24,18:25","dtypep":"UNLINKED",
+      {"type":"SELEXTRACT","name":"","addr":"(GB)","loc":"e,18:24,18:25","dtypep":"UNLINKED",
        "fromp": [
-        {"type":"PARSEREF","name":"crc","addr":"(FB)","loc":"e,18:21,18:24","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+        {"type":"PARSEREF","name":"crc","addr":"(HB)","loc":"e,18:21,18:24","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
       ],
        "leftp": [
-        {"type":"CONST","name":"?32?sh1f","addr":"(GB)","loc":"e,18:25,18:27","dtypep":"(BB)"}
+        {"type":"CONST","name":"?32?sh1f","addr":"(IB)","loc":"e,18:25,18:27","dtypep":"(DB)"}
       ],
        "rightp": [
-        {"type":"CONST","name":"?32?sh0","addr":"(HB)","loc":"e,18:28,18:29","dtypep":"(L)"}
+        {"type":"CONST","name":"?32?sh0","addr":"(JB)","loc":"e,18:28,18:29","dtypep":"(N)"}
       ],"attrp": []}
     ],
      "lhsp": [
-      {"type":"PARSEREF","name":"in","addr":"(IB)","loc":"e,18:16,18:18","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+      {"type":"PARSEREF","name":"in","addr":"(KB)","loc":"e,18:16,18:18","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
     ],"timingControlp": [],"strengthSpecp": []},
-    {"type":"VAR","name":"out","addr":"(JB)","loc":"e,22:25,22:28","dtypep":"UNLINKED","origName":"out","isSc":false,"isPrimaryIO":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"attrClocker":"UNKNOWN","lifetime":"NONE","varType":"WIRE","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"ignorePostWrite":false,"ignoreSchedWrite":false,"sensIfacep":"UNLINKED",
+    {"type":"VAR","name":"out","addr":"(LB)","loc":"e,22:25,22:28","dtypep":"UNLINKED","origName":"out","isSc":false,"isPrimaryIO":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"attrClocker":"UNKNOWN","lifetime":"NONE","varType":"WIRE","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"ignorePostWrite":false,"ignoreSchedWrite":false,"sensIfacep":"UNLINKED",
      "childDTypep": [
-      {"type":"BASICDTYPE","name":"logic","addr":"(KB)","loc":"e,22:9,22:10","dtypep":"(KB)","keyword":"logic","generic":false,
+      {"type":"BASICDTYPE","name":"logic","addr":"(MB)","loc":"e,22:9,22:10","dtypep":"(MB)","keyword":"logic","generic":false,
        "rangep": [
-        {"type":"RANGE","name":"","addr":"(LB)","loc":"e,22:9,22:10","ascending":false,
+        {"type":"RANGE","name":"","addr":"(NB)","loc":"e,22:9,22:10","ascending":false,
          "leftp": [
-          {"type":"CONST","name":"?32?sh1f","addr":"(MB)","loc":"e,22:10,22:12","dtypep":"(BB)"}
+          {"type":"CONST","name":"?32?sh1f","addr":"(OB)","loc":"e,22:10,22:12","dtypep":"(DB)"}
         ],
          "rightp": [
-          {"type":"CONST","name":"?32?sh0","addr":"(NB)","loc":"e,22:13,22:14","dtypep":"(L)"}
+          {"type":"CONST","name":"?32?sh0","addr":"(PB)","loc":"e,22:13,22:14","dtypep":"(N)"}
         ]}
       ]}
     ],"delayp": [],"valuep": [],"attrsp": []},
-    {"type":"CELL","name":"test","addr":"(OB)","loc":"e,25:9,25:13","origName":"test","recursive":false,"modp":"(PB)",
+    {"type":"CELL","name":"test","addr":"(QB)","loc":"e,25:9,25:13","origName":"test","recursive":false,"modp":"(RB)",
      "pinsp": [
-      {"type":"PIN","name":"out","addr":"(QB)","loc":"e,27:15,27:18","svDotName":true,"svImplicit":false,"modVarp":"UNLINKED","modPTypep":"UNLINKED",
+      {"type":"PIN","name":"out","addr":"(SB)","loc":"e,27:15,27:18","svDotName":true,"svImplicit":false,"modVarp":"UNLINKED","modPTypep":"UNLINKED",
        "exprp": [
-        {"type":"SELEXTRACT","name":"","addr":"(RB)","loc":"e,27:45,27:46","dtypep":"UNLINKED",
+        {"type":"SELEXTRACT","name":"","addr":"(TB)","loc":"e,27:45,27:46","dtypep":"UNLINKED",
          "fromp": [
-          {"type":"PARSEREF","name":"out","addr":"(SB)","loc":"e,27:42,27:45","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+          {"type":"PARSEREF","name":"out","addr":"(UB)","loc":"e,27:42,27:45","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
         ],
          "leftp": [
-          {"type":"CONST","name":"?32?sh1f","addr":"(TB)","loc":"e,27:46,27:48","dtypep":"(BB)"}
+          {"type":"CONST","name":"?32?sh1f","addr":"(VB)","loc":"e,27:46,27:48","dtypep":"(DB)"}
         ],
          "rightp": [
-          {"type":"CONST","name":"?32?sh0","addr":"(UB)","loc":"e,27:49,27:50","dtypep":"(L)"}
+          {"type":"CONST","name":"?32?sh0","addr":"(WB)","loc":"e,27:49,27:50","dtypep":"(N)"}
         ],"attrp": []}
       ]},
-      {"type":"PIN","name":"clk","addr":"(VB)","loc":"e,29:15,29:18","svDotName":true,"svImplicit":false,"modVarp":"UNLINKED","modPTypep":"UNLINKED",
+      {"type":"PIN","name":"clk","addr":"(XB)","loc":"e,29:15,29:18","svDotName":true,"svImplicit":false,"modVarp":"UNLINKED","modPTypep":"UNLINKED",
        "exprp": [
-        {"type":"PARSEREF","name":"clk","addr":"(WB)","loc":"e,29:42,29:45","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+        {"type":"PARSEREF","name":"clk","addr":"(YB)","loc":"e,29:42,29:45","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
       ]},
-      {"type":"PIN","name":"in","addr":"(XB)","loc":"e,30:15,30:17","svDotName":true,"svImplicit":false,"modVarp":"UNLINKED","modPTypep":"UNLINKED",
+      {"type":"PIN","name":"in","addr":"(ZB)","loc":"e,30:15,30:17","svDotName":true,"svImplicit":false,"modVarp":"UNLINKED","modPTypep":"UNLINKED",
        "exprp": [
-        {"type":"SELEXTRACT","name":"","addr":"(YB)","loc":"e,30:44,30:45","dtypep":"UNLINKED",
+        {"type":"SELEXTRACT","name":"","addr":"(AC)","loc":"e,30:44,30:45","dtypep":"UNLINKED",
          "fromp": [
-          {"type":"PARSEREF","name":"in","addr":"(ZB)","loc":"e,30:42,30:44","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+          {"type":"PARSEREF","name":"in","addr":"(BC)","loc":"e,30:42,30:44","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
         ],
          "leftp": [
-          {"type":"CONST","name":"?32?sh1f","addr":"(AC)","loc":"e,30:45,30:47","dtypep":"(BB)"}
+          {"type":"CONST","name":"?32?sh1f","addr":"(CC)","loc":"e,30:45,30:47","dtypep":"(DB)"}
         ],
          "rightp": [
-          {"type":"CONST","name":"?32?sh0","addr":"(BC)","loc":"e,30:48,30:49","dtypep":"(L)"}
+          {"type":"CONST","name":"?32?sh0","addr":"(DC)","loc":"e,30:48,30:49","dtypep":"(N)"}
         ],"attrp": []}
       ]}
     ],"paramsp": [],"rangep": [],"intfRefsp": []},
-    {"type":"VAR","name":"result","addr":"(CC)","loc":"e,33:16,33:22","dtypep":"UNLINKED","origName":"result","isSc":false,"isPrimaryIO":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"attrClocker":"UNKNOWN","lifetime":"NONE","varType":"WIRE","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"ignorePostWrite":false,"ignoreSchedWrite":false,"sensIfacep":"UNLINKED",
+    {"type":"VAR","name":"result","addr":"(EC)","loc":"e,33:16,33:22","dtypep":"UNLINKED","origName":"result","isSc":false,"isPrimaryIO":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"attrClocker":"UNKNOWN","lifetime":"NONE","varType":"WIRE","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"ignorePostWrite":false,"ignoreSchedWrite":false,"sensIfacep":"UNLINKED",
      "childDTypep": [
-      {"type":"BASICDTYPE","name":"logic","addr":"(DC)","loc":"e,33:9,33:10","dtypep":"(DC)","keyword":"logic","generic":false,
+      {"type":"BASICDTYPE","name":"logic","addr":"(FC)","loc":"e,33:9,33:10","dtypep":"(FC)","keyword":"logic","generic":false,
        "rangep": [
-        {"type":"RANGE","name":"","addr":"(EC)","loc":"e,33:9,33:10","ascending":false,
+        {"type":"RANGE","name":"","addr":"(GC)","loc":"e,33:9,33:10","ascending":false,
          "leftp": [
-          {"type":"CONST","name":"?32?sh3f","addr":"(FC)","loc":"e,33:10,33:12","dtypep":"(Q)"}
+          {"type":"CONST","name":"?32?sh3f","addr":"(HC)","loc":"e,33:10,33:12","dtypep":"(S)"}
         ],
          "rightp": [
-          {"type":"CONST","name":"?32?sh0","addr":"(GC)","loc":"e,33:13,33:14","dtypep":"(L)"}
+          {"type":"CONST","name":"?32?sh0","addr":"(IC)","loc":"e,33:13,33:14","dtypep":"(N)"}
         ]}
       ]}
     ],"delayp": [],"valuep": [],"attrsp": []},
-    {"type":"ASSIGNW","name":"","addr":"(HC)","loc":"e,33:23,33:24","dtypep":"UNLINKED",
+    {"type":"ASSIGNW","name":"","addr":"(JC)","loc":"e,33:23,33:24","dtypep":"UNLINKED",
      "rhsp": [
-      {"type":"REPLICATE","name":"","addr":"(IC)","loc":"e,33:25,33:26","dtypep":"(JC)",
+      {"type":"REPLICATE","name":"","addr":"(KC)","loc":"e,33:25,33:26","dtypep":"(LC)",
        "srcp": [
-        {"type":"CONCAT","name":"","addr":"(KC)","loc":"e,33:31,33:32","dtypep":"UNLINKED",
+        {"type":"CONCAT","name":"","addr":"(MC)","loc":"e,33:31,33:32","dtypep":"UNLINKED",
          "lhsp": [
-          {"type":"CONST","name":"32'h0","addr":"(LC)","loc":"e,33:26,33:31","dtypep":"(MC)"}
+          {"type":"CONST","name":"32'h0","addr":"(NC)","loc":"e,33:26,33:31","dtypep":"(OC)"}
         ],
          "rhsp": [
-          {"type":"PARSEREF","name":"out","addr":"(NC)","loc":"e,33:33,33:36","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+          {"type":"PARSEREF","name":"out","addr":"(PC)","loc":"e,33:33,33:36","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
         ]}
       ],
        "countp": [
-        {"type":"CONST","name":"32'h1","addr":"(OC)","loc":"e,33:25,33:26","dtypep":"(MC)"}
+        {"type":"CONST","name":"32'h1","addr":"(QC)","loc":"e,33:25,33:26","dtypep":"(OC)"}
       ]}
     ],
      "lhsp": [
-      {"type":"PARSEREF","name":"result","addr":"(PC)","loc":"e,33:16,33:22","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+      {"type":"PARSEREF","name":"result","addr":"(RC)","loc":"e,33:16,33:22","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
     ],"timingControlp": [],"strengthSpecp": []},
-    {"type":"ALWAYS","name":"","addr":"(QC)","loc":"e,36:4,36:10","keyword":"always","isSuspendable":false,"needProcess":false,"sensesp": [],
+    {"type":"ALWAYS","name":"","addr":"(SC)","loc":"e,36:4,36:10","keyword":"always","isSuspendable":false,"needProcess":false,"sensesp": [],
      "stmtsp": [
-      {"type":"EVENTCONTROL","name":"","addr":"(RC)","loc":"e,36:11,36:12",
+      {"type":"EVENTCONTROL","name":"","addr":"(TC)","loc":"e,36:11,36:12",
        "sensesp": [
-        {"type":"SENTREE","name":"","addr":"(SC)","loc":"e,36:11,36:12","isMulti":false,
+        {"type":"SENTREE","name":"","addr":"(UC)","loc":"e,36:11,36:12","isMulti":false,
          "sensesp": [
-          {"type":"SENITEM","name":"","addr":"(TC)","loc":"e,36:14,36:21","edgeType":"POS",
+          {"type":"SENITEM","name":"","addr":"(VC)","loc":"e,36:14,36:21","edgeType":"POS",
            "sensp": [
-            {"type":"PARSEREF","name":"clk","addr":"(UC)","loc":"e,36:22,36:25","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+            {"type":"PARSEREF","name":"clk","addr":"(WC)","loc":"e,36:22,36:25","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
           ],"condp": []}
         ]}
       ],
        "stmtsp": [
-        {"type":"BEGIN","name":"","addr":"(VC)","loc":"e,36:27,36:32","generate":false,"genfor":false,"implied":false,"needProcess":false,"unnamed":true,"genforp": [],
+        {"type":"BEGIN","name":"","addr":"(XC)","loc":"e,36:27,36:32","generate":false,"genfor":false,"implied":false,"needProcess":false,"unnamed":true,"genforp": [],
          "stmtsp": [
-          {"type":"ASSIGNDLY","name":"","addr":"(WC)","loc":"e,40:11,40:13","dtypep":"UNLINKED",
+          {"type":"ASSIGNDLY","name":"","addr":"(YC)","loc":"e,40:11,40:13","dtypep":"UNLINKED",
            "rhsp": [
-            {"type":"ADD","name":"","addr":"(XC)","loc":"e,40:18,40:19","dtypep":"UNLINKED",
+            {"type":"ADD","name":"","addr":"(ZC)","loc":"e,40:18,40:19","dtypep":"UNLINKED",
              "lhsp": [
-              {"type":"PARSEREF","name":"cyc","addr":"(YC)","loc":"e,40:14,40:17","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+              {"type":"PARSEREF","name":"cyc","addr":"(AD)","loc":"e,40:14,40:17","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
             ],
              "rhsp": [
-              {"type":"CONST","name":"?32?sh1","addr":"(ZC)","loc":"e,40:20,40:21","dtypep":"(L)"}
+              {"type":"CONST","name":"?32?sh1","addr":"(BD)","loc":"e,40:20,40:21","dtypep":"(N)"}
             ]}
           ],
            "lhsp": [
-            {"type":"PARSEREF","name":"cyc","addr":"(AD)","loc":"e,40:7,40:10","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+            {"type":"PARSEREF","name":"cyc","addr":"(CD)","loc":"e,40:7,40:10","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
           ],"timingControlp": []},
-          {"type":"ASSIGNDLY","name":"","addr":"(BD)","loc":"e,41:11,41:13","dtypep":"UNLINKED",
+          {"type":"ASSIGNDLY","name":"","addr":"(DD)","loc":"e,41:11,41:13","dtypep":"UNLINKED",
            "rhsp": [
-            {"type":"REPLICATE","name":"","addr":"(CD)","loc":"e,41:14,41:15","dtypep":"(JC)",
+            {"type":"REPLICATE","name":"","addr":"(ED)","loc":"e,41:14,41:15","dtypep":"(LC)",
              "srcp": [
-              {"type":"CONCAT","name":"","addr":"(DD)","loc":"e,41:24,41:25","dtypep":"UNLINKED",
+              {"type":"CONCAT","name":"","addr":"(FD)","loc":"e,41:24,41:25","dtypep":"UNLINKED",
                "lhsp": [
-                {"type":"SELEXTRACT","name":"","addr":"(ED)","loc":"e,41:18,41:19","dtypep":"UNLINKED",
+                {"type":"SELEXTRACT","name":"","addr":"(GD)","loc":"e,41:18,41:19","dtypep":"UNLINKED",
                  "fromp": [
-                  {"type":"PARSEREF","name":"crc","addr":"(FD)","loc":"e,41:15,41:18","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+                  {"type":"PARSEREF","name":"crc","addr":"(HD)","loc":"e,41:15,41:18","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
                 ],
                  "leftp": [
-                  {"type":"CONST","name":"?32?sh3e","addr":"(GD)","loc":"e,41:19,41:21","dtypep":"(Q)"}
+                  {"type":"CONST","name":"?32?sh3e","addr":"(ID)","loc":"e,41:19,41:21","dtypep":"(S)"}
                 ],
                  "rightp": [
-                  {"type":"CONST","name":"?32?sh0","addr":"(HD)","loc":"e,41:22,41:23","dtypep":"(L)"}
+                  {"type":"CONST","name":"?32?sh0","addr":"(JD)","loc":"e,41:22,41:23","dtypep":"(N)"}
                 ],"attrp": []}
               ],
                "rhsp": [
-                {"type":"XOR","name":"","addr":"(ID)","loc":"e,41:43,41:44","dtypep":"UNLINKED",
+                {"type":"XOR","name":"","addr":"(KD)","loc":"e,41:43,41:44","dtypep":"UNLINKED",
                  "lhsp": [
-                  {"type":"XOR","name":"","addr":"(JD)","loc":"e,41:34,41:35","dtypep":"UNLINKED",
+                  {"type":"XOR","name":"","addr":"(LD)","loc":"e,41:34,41:35","dtypep":"UNLINKED",
                    "lhsp": [
-                    {"type":"SELBIT","name":"","addr":"(KD)","loc":"e,41:29,41:30","dtypep":"UNLINKED",
+                    {"type":"SELBIT","name":"","addr":"(MD)","loc":"e,41:29,41:30","dtypep":"UNLINKED",
                      "fromp": [
-                      {"type":"PARSEREF","name":"crc","addr":"(LD)","loc":"e,41:26,41:29","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+                      {"type":"PARSEREF","name":"crc","addr":"(ND)","loc":"e,41:26,41:29","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
                     ],
                      "bitp": [
-                      {"type":"CONST","name":"?32?sh3f","addr":"(MD)","loc":"e,41:30,41:32","dtypep":"(Q)"}
+                      {"type":"CONST","name":"?32?sh3f","addr":"(OD)","loc":"e,41:30,41:32","dtypep":"(S)"}
                     ],"thsp": [],"attrp": []}
                   ],
                    "rhsp": [
-                    {"type":"SELBIT","name":"","addr":"(ND)","loc":"e,41:39,41:40","dtypep":"UNLINKED",
+                    {"type":"SELBIT","name":"","addr":"(PD)","loc":"e,41:39,41:40","dtypep":"UNLINKED",
                      "fromp": [
-                      {"type":"PARSEREF","name":"crc","addr":"(OD)","loc":"e,41:36,41:39","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+                      {"type":"PARSEREF","name":"crc","addr":"(QD)","loc":"e,41:36,41:39","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
                     ],
                      "bitp": [
-                      {"type":"CONST","name":"?32?sh2","addr":"(PD)","loc":"e,41:40,41:41","dtypep":"(QD)"}
+                      {"type":"CONST","name":"?32?sh2","addr":"(RD)","loc":"e,41:40,41:41","dtypep":"(SD)"}
                     ],"thsp": [],"attrp": []}
                   ]}
                 ],
                  "rhsp": [
-                  {"type":"SELBIT","name":"","addr":"(RD)","loc":"e,41:48,41:49","dtypep":"UNLINKED",
+                  {"type":"SELBIT","name":"","addr":"(TD)","loc":"e,41:48,41:49","dtypep":"UNLINKED",
                    "fromp": [
-                    {"type":"PARSEREF","name":"crc","addr":"(SD)","loc":"e,41:45,41:48","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+                    {"type":"PARSEREF","name":"crc","addr":"(UD)","loc":"e,41:45,41:48","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
                   ],
                    "bitp": [
-                    {"type":"CONST","name":"?32?sh0","addr":"(TD)","loc":"e,41:49,41:50","dtypep":"(L)"}
+                    {"type":"CONST","name":"?32?sh0","addr":"(VD)","loc":"e,41:49,41:50","dtypep":"(N)"}
                   ],"thsp": [],"attrp": []}
                 ]}
               ]}
             ],
              "countp": [
-              {"type":"CONST","name":"32'h1","addr":"(UD)","loc":"e,41:14,41:15","dtypep":"(MC)"}
+              {"type":"CONST","name":"32'h1","addr":"(WD)","loc":"e,41:14,41:15","dtypep":"(OC)"}
             ]}
           ],
            "lhsp": [
-            {"type":"PARSEREF","name":"crc","addr":"(VD)","loc":"e,41:7,41:10","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+            {"type":"PARSEREF","name":"crc","addr":"(XD)","loc":"e,41:7,41:10","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
           ],"timingControlp": []},
-          {"type":"ASSIGNDLY","name":"","addr":"(WD)","loc":"e,42:11,42:13","dtypep":"UNLINKED",
+          {"type":"ASSIGNDLY","name":"","addr":"(YD)","loc":"e,42:11,42:13","dtypep":"UNLINKED",
            "rhsp": [
-            {"type":"XOR","name":"","addr":"(XD)","loc":"e,42:21,42:22","dtypep":"UNLINKED",
+            {"type":"XOR","name":"","addr":"(ZD)","loc":"e,42:21,42:22","dtypep":"UNLINKED",
              "lhsp": [
-              {"type":"PARSEREF","name":"result","addr":"(YD)","loc":"e,42:14,42:20","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+              {"type":"PARSEREF","name":"result","addr":"(AE)","loc":"e,42:14,42:20","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
             ],
              "rhsp": [
-              {"type":"REPLICATE","name":"","addr":"(ZD)","loc":"e,42:23,42:24","dtypep":"(JC)",
+              {"type":"REPLICATE","name":"","addr":"(BE)","loc":"e,42:23,42:24","dtypep":"(LC)",
                "srcp": [
-                {"type":"CONCAT","name":"","addr":"(AE)","loc":"e,42:33,42:34","dtypep":"UNLINKED",
+                {"type":"CONCAT","name":"","addr":"(CE)","loc":"e,42:33,42:34","dtypep":"UNLINKED",
                  "lhsp": [
-                  {"type":"SELEXTRACT","name":"","addr":"(BE)","loc":"e,42:27,42:28","dtypep":"UNLINKED",
+                  {"type":"SELEXTRACT","name":"","addr":"(DE)","loc":"e,42:27,42:28","dtypep":"UNLINKED",
                    "fromp": [
-                    {"type":"PARSEREF","name":"sum","addr":"(CE)","loc":"e,42:24,42:27","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+                    {"type":"PARSEREF","name":"sum","addr":"(EE)","loc":"e,42:24,42:27","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
                   ],
                    "leftp": [
-                    {"type":"CONST","name":"?32?sh3e","addr":"(DE)","loc":"e,42:28,42:30","dtypep":"(Q)"}
+                    {"type":"CONST","name":"?32?sh3e","addr":"(FE)","loc":"e,42:28,42:30","dtypep":"(S)"}
                   ],
                    "rightp": [
-                    {"type":"CONST","name":"?32?sh0","addr":"(EE)","loc":"e,42:31,42:32","dtypep":"(L)"}
+                    {"type":"CONST","name":"?32?sh0","addr":"(GE)","loc":"e,42:31,42:32","dtypep":"(N)"}
                   ],"attrp": []}
                 ],
                  "rhsp": [
-                  {"type":"XOR","name":"","addr":"(FE)","loc":"e,42:52,42:53","dtypep":"UNLINKED",
+                  {"type":"XOR","name":"","addr":"(HE)","loc":"e,42:52,42:53","dtypep":"UNLINKED",
                    "lhsp": [
-                    {"type":"XOR","name":"","addr":"(GE)","loc":"e,42:43,42:44","dtypep":"UNLINKED",
+                    {"type":"XOR","name":"","addr":"(IE)","loc":"e,42:43,42:44","dtypep":"UNLINKED",
                      "lhsp": [
-                      {"type":"SELBIT","name":"","addr":"(HE)","loc":"e,42:38,42:39","dtypep":"UNLINKED",
+                      {"type":"SELBIT","name":"","addr":"(JE)","loc":"e,42:38,42:39","dtypep":"UNLINKED",
                        "fromp": [
-                        {"type":"PARSEREF","name":"sum","addr":"(IE)","loc":"e,42:35,42:38","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+                        {"type":"PARSEREF","name":"sum","addr":"(KE)","loc":"e,42:35,42:38","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
                       ],
                        "bitp": [
-                        {"type":"CONST","name":"?32?sh3f","addr":"(JE)","loc":"e,42:39,42:41","dtypep":"(Q)"}
+                        {"type":"CONST","name":"?32?sh3f","addr":"(LE)","loc":"e,42:39,42:41","dtypep":"(S)"}
                       ],"thsp": [],"attrp": []}
                     ],
                      "rhsp": [
-                      {"type":"SELBIT","name":"","addr":"(KE)","loc":"e,42:48,42:49","dtypep":"UNLINKED",
+                      {"type":"SELBIT","name":"","addr":"(ME)","loc":"e,42:48,42:49","dtypep":"UNLINKED",
                        "fromp": [
-                        {"type":"PARSEREF","name":"sum","addr":"(LE)","loc":"e,42:45,42:48","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+                        {"type":"PARSEREF","name":"sum","addr":"(NE)","loc":"e,42:45,42:48","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
                       ],
                        "bitp": [
-                        {"type":"CONST","name":"?32?sh2","addr":"(ME)","loc":"e,42:49,42:50","dtypep":"(QD)"}
+                        {"type":"CONST","name":"?32?sh2","addr":"(OE)","loc":"e,42:49,42:50","dtypep":"(SD)"}
                       ],"thsp": [],"attrp": []}
                     ]}
                   ],
                    "rhsp": [
-                    {"type":"SELBIT","name":"","addr":"(NE)","loc":"e,42:57,42:58","dtypep":"UNLINKED",
+                    {"type":"SELBIT","name":"","addr":"(PE)","loc":"e,42:57,42:58","dtypep":"UNLINKED",
                      "fromp": [
-                      {"type":"PARSEREF","name":"sum","addr":"(OE)","loc":"e,42:54,42:57","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+                      {"type":"PARSEREF","name":"sum","addr":"(QE)","loc":"e,42:54,42:57","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
                     ],
                      "bitp": [
-                      {"type":"CONST","name":"?32?sh0","addr":"(PE)","loc":"e,42:58,42:59","dtypep":"(L)"}
+                      {"type":"CONST","name":"?32?sh0","addr":"(RE)","loc":"e,42:58,42:59","dtypep":"(N)"}
                     ],"thsp": [],"attrp": []}
                   ]}
                 ]}
               ],
                "countp": [
-                {"type":"CONST","name":"32'h1","addr":"(QE)","loc":"e,42:23,42:24","dtypep":"(MC)"}
+                {"type":"CONST","name":"32'h1","addr":"(SE)","loc":"e,42:23,42:24","dtypep":"(OC)"}
               ]}
             ]}
           ],
            "lhsp": [
-            {"type":"PARSEREF","name":"sum","addr":"(RE)","loc":"e,42:7,42:10","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+            {"type":"PARSEREF","name":"sum","addr":"(TE)","loc":"e,42:7,42:10","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
           ],"timingControlp": []},
-          {"type":"IF","name":"","addr":"(SE)","loc":"e,43:7,43:9",
+          {"type":"IF","name":"","addr":"(UE)","loc":"e,43:7,43:9",
            "condp": [
-            {"type":"EQ","name":"","addr":"(TE)","loc":"e,43:15,43:17","dtypep":"(UE)",
+            {"type":"EQ","name":"","addr":"(VE)","loc":"e,43:15,43:17","dtypep":"(WE)",
              "lhsp": [
-              {"type":"PARSEREF","name":"cyc","addr":"(VE)","loc":"e,43:11,43:14","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+              {"type":"PARSEREF","name":"cyc","addr":"(XE)","loc":"e,43:11,43:14","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
             ],
              "rhsp": [
-              {"type":"CONST","name":"?32?sh0","addr":"(WE)","loc":"e,43:18,43:19","dtypep":"(L)"}
+              {"type":"CONST","name":"?32?sh0","addr":"(YE)","loc":"e,43:18,43:19","dtypep":"(N)"}
             ]}
           ],
            "thensp": [
-            {"type":"BEGIN","name":"","addr":"(XE)","loc":"e,43:21,43:26","generate":false,"genfor":false,"implied":false,"needProcess":false,"unnamed":true,"genforp": [],
+            {"type":"BEGIN","name":"","addr":"(ZE)","loc":"e,43:21,43:26","generate":false,"genfor":false,"implied":false,"needProcess":false,"unnamed":true,"genforp": [],
              "stmtsp": [
-              {"type":"ASSIGNDLY","name":"","addr":"(YE)","loc":"e,45:14,45:16","dtypep":"UNLINKED",
+              {"type":"ASSIGNDLY","name":"","addr":"(AF)","loc":"e,45:14,45:16","dtypep":"UNLINKED",
                "rhsp": [
-                {"type":"CONST","name":"64'h5aef0c8dd70a4497","addr":"(ZE)","loc":"e,45:17,45:38","dtypep":"(AF)"}
+                {"type":"CONST","name":"64'h5aef0c8dd70a4497","addr":"(BF)","loc":"e,45:17,45:38","dtypep":"(CF)"}
               ],
                "lhsp": [
-                {"type":"PARSEREF","name":"crc","addr":"(BF)","loc":"e,45:10,45:13","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+                {"type":"PARSEREF","name":"crc","addr":"(DF)","loc":"e,45:10,45:13","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
               ],"timingControlp": []},
-              {"type":"ASSIGNDLY","name":"","addr":"(CF)","loc":"e,46:14,46:16","dtypep":"UNLINKED",
+              {"type":"ASSIGNDLY","name":"","addr":"(EF)","loc":"e,46:14,46:16","dtypep":"UNLINKED",
                "rhsp": [
-                {"type":"CONST","name":"'0","addr":"(DF)","loc":"e,46:17,46:19","dtypep":"(UE)"}
+                {"type":"CONST","name":"'0","addr":"(FF)","loc":"e,46:17,46:19","dtypep":"(WE)"}
               ],
                "lhsp": [
-                {"type":"PARSEREF","name":"sum","addr":"(EF)","loc":"e,46:10,46:13","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+                {"type":"PARSEREF","name":"sum","addr":"(GF)","loc":"e,46:10,46:13","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
               ],"timingControlp": []}
             ]}
           ],
            "elsesp": [
-            {"type":"IF","name":"","addr":"(FF)","loc":"e,48:12,48:14",
+            {"type":"IF","name":"","addr":"(HF)","loc":"e,48:12,48:14",
              "condp": [
-              {"type":"LT","name":"","addr":"(GF)","loc":"e,48:20,48:21","dtypep":"(UE)",
+              {"type":"LT","name":"","addr":"(IF)","loc":"e,48:20,48:21","dtypep":"(WE)",
                "lhsp": [
-                {"type":"PARSEREF","name":"cyc","addr":"(HF)","loc":"e,48:16,48:19","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+                {"type":"PARSEREF","name":"cyc","addr":"(JF)","loc":"e,48:16,48:19","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
               ],
                "rhsp": [
-                {"type":"CONST","name":"?32?sha","addr":"(IF)","loc":"e,48:22,48:24","dtypep":"(JF)"}
+                {"type":"CONST","name":"?32?sha","addr":"(KF)","loc":"e,48:22,48:24","dtypep":"(LF)"}
               ]}
             ],
              "thensp": [
-              {"type":"BEGIN","name":"","addr":"(KF)","loc":"e,48:26,48:31","generate":false,"genfor":false,"implied":false,"needProcess":false,"unnamed":true,"genforp": [],
+              {"type":"BEGIN","name":"","addr":"(MF)","loc":"e,48:26,48:31","generate":false,"genfor":false,"implied":false,"needProcess":false,"unnamed":true,"genforp": [],
                "stmtsp": [
-                {"type":"ASSIGNDLY","name":"","addr":"(LF)","loc":"e,49:14,49:16","dtypep":"UNLINKED",
+                {"type":"ASSIGNDLY","name":"","addr":"(NF)","loc":"e,49:14,49:16","dtypep":"UNLINKED",
                  "rhsp": [
-                  {"type":"CONST","name":"'0","addr":"(MF)","loc":"e,49:17,49:19","dtypep":"(UE)"}
+                  {"type":"CONST","name":"'0","addr":"(OF)","loc":"e,49:17,49:19","dtypep":"(WE)"}
                 ],
                  "lhsp": [
-                  {"type":"PARSEREF","name":"sum","addr":"(NF)","loc":"e,49:10,49:13","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+                  {"type":"PARSEREF","name":"sum","addr":"(PF)","loc":"e,49:10,49:13","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
                 ],"timingControlp": []}
               ]}
             ],
              "elsesp": [
-              {"type":"IF","name":"","addr":"(OF)","loc":"e,51:12,51:14",
+              {"type":"IF","name":"","addr":"(QF)","loc":"e,51:12,51:14",
                "condp": [
-                {"type":"LT","name":"","addr":"(PF)","loc":"e,51:20,51:21","dtypep":"(UE)",
+                {"type":"LT","name":"","addr":"(RF)","loc":"e,51:20,51:21","dtypep":"(WE)",
                  "lhsp": [
-                  {"type":"PARSEREF","name":"cyc","addr":"(QF)","loc":"e,51:16,51:19","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+                  {"type":"PARSEREF","name":"cyc","addr":"(SF)","loc":"e,51:16,51:19","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
                 ],
                  "rhsp": [
-                  {"type":"CONST","name":"?32?sh5a","addr":"(RF)","loc":"e,51:22,51:24","dtypep":"(SF)"}
+                  {"type":"CONST","name":"?32?sh5a","addr":"(TF)","loc":"e,51:22,51:24","dtypep":"(UF)"}
                 ]}
               ],
                "thensp": [
-                {"type":"BEGIN","name":"","addr":"(TF)","loc":"e,51:26,51:31","generate":false,"genfor":false,"implied":false,"needProcess":false,"unnamed":true,"genforp": [],"stmtsp": []}
+                {"type":"BEGIN","name":"","addr":"(VF)","loc":"e,51:26,51:31","generate":false,"genfor":false,"implied":false,"needProcess":false,"unnamed":true,"genforp": [],"stmtsp": []}
               ],
                "elsesp": [
-                {"type":"IF","name":"","addr":"(UF)","loc":"e,53:12,53:14",
+                {"type":"IF","name":"","addr":"(WF)","loc":"e,53:12,53:14",
                  "condp": [
-                  {"type":"EQ","name":"","addr":"(VF)","loc":"e,53:20,53:22","dtypep":"(UE)",
+                  {"type":"EQ","name":"","addr":"(XF)","loc":"e,53:20,53:22","dtypep":"(WE)",
                    "lhsp": [
-                    {"type":"PARSEREF","name":"cyc","addr":"(WF)","loc":"e,53:16,53:19","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+                    {"type":"PARSEREF","name":"cyc","addr":"(YF)","loc":"e,53:16,53:19","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
                   ],
                    "rhsp": [
-                    {"type":"CONST","name":"?32?sh63","addr":"(XF)","loc":"e,53:23,53:25","dtypep":"(SF)"}
+                    {"type":"CONST","name":"?32?sh63","addr":"(ZF)","loc":"e,53:23,53:25","dtypep":"(UF)"}
                   ]}
                 ],
                  "thensp": [
-                  {"type":"BEGIN","name":"","addr":"(YF)","loc":"e,53:27,53:32","generate":false,"genfor":false,"implied":false,"needProcess":false,"unnamed":true,"genforp": [],
+                  {"type":"BEGIN","name":"","addr":"(AG)","loc":"e,53:27,53:32","generate":false,"genfor":false,"implied":false,"needProcess":false,"unnamed":true,"genforp": [],
                    "stmtsp": [
-                    {"type":"DISPLAY","name":"","addr":"(ZF)","loc":"e,54:10,54:16",
+                    {"type":"DISPLAY","name":"","addr":"(BG)","loc":"e,54:10,54:16",
                      "fmtp": [
-                      {"type":"SFORMATF","name":"","addr":"(AG)","loc":"e,54:10,54:16","dtypep":"(BG)",
+                      {"type":"SFORMATF","name":"","addr":"(CG)","loc":"e,54:10,54:16","dtypep":"(DG)",
                        "exprsp": [
-                        {"type":"CONST","name":"232'h5b2530745d206379633d3d253064206372633d25782073756d3d25780a","addr":"(CG)","loc":"e,54:17,54:49","dtypep":"(DG)"},
-                        {"type":"TIME","name":"","addr":"(EG)","loc":"e,54:51,54:56","dtypep":"(FG)","timeunit":"NONE"},
-                        {"type":"PARSEREF","name":"cyc","addr":"(GG)","loc":"e,54:58,54:61","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []},
-                        {"type":"PARSEREF","name":"crc","addr":"(HG)","loc":"e,54:63,54:66","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []},
-                        {"type":"PARSEREF","name":"sum","addr":"(IG)","loc":"e,54:68,54:71","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+                        {"type":"CONST","name":"232'h5b2530745d206379633d3d253064206372633d25782073756d3d25780a","addr":"(EG)","loc":"e,54:17,54:49","dtypep":"(FG)"},
+                        {"type":"TIME","name":"","addr":"(GG)","loc":"e,54:51,54:56","dtypep":"(HG)","timeunit":"NONE"},
+                        {"type":"PARSEREF","name":"cyc","addr":"(IG)","loc":"e,54:58,54:61","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []},
+                        {"type":"PARSEREF","name":"crc","addr":"(JG)","loc":"e,54:63,54:66","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []},
+                        {"type":"PARSEREF","name":"sum","addr":"(KG)","loc":"e,54:68,54:71","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
                       ],"scopeNamep": []}
                     ],"filep": []},
-                    {"type":"IF","name":"","addr":"(JG)","loc":"e,55:10,55:12",
+                    {"type":"IF","name":"","addr":"(LG)","loc":"e,55:10,55:12",
                      "condp": [
-                      {"type":"NEQCASE","name":"","addr":"(KG)","loc":"e,55:18,55:21","dtypep":"(UE)",
+                      {"type":"NEQCASE","name":"","addr":"(MG)","loc":"e,55:18,55:21","dtypep":"(WE)",
                        "lhsp": [
-                        {"type":"PARSEREF","name":"crc","addr":"(LG)","loc":"e,55:14,55:17","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+                        {"type":"PARSEREF","name":"crc","addr":"(NG)","loc":"e,55:14,55:17","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
                       ],
                        "rhsp": [
-                        {"type":"CONST","name":"64'hc77bb9b3784ea091","addr":"(MG)","loc":"e,55:22,55:42","dtypep":"(AF)"}
+                        {"type":"CONST","name":"64'hc77bb9b3784ea091","addr":"(OG)","loc":"e,55:22,55:42","dtypep":"(CF)"}
                       ]}
                     ],
                      "thensp": [
-                      {"type":"STOP","name":"","addr":"(NG)","loc":"e,55:44,55:49","isFatal":false}
+                      {"type":"STOP","name":"","addr":"(PG)","loc":"e,55:44,55:49","isFatal":false}
                     ],"elsesp": []},
-                    {"type":"IF","name":"","addr":"(OG)","loc":"e,58:10,58:12",
+                    {"type":"IF","name":"","addr":"(QG)","loc":"e,58:10,58:12",
                      "condp": [
-                      {"type":"NEQCASE","name":"","addr":"(PG)","loc":"e,58:18,58:21","dtypep":"(UE)",
+                      {"type":"NEQCASE","name":"","addr":"(RG)","loc":"e,58:18,58:21","dtypep":"(WE)",
                        "lhsp": [
-                        {"type":"PARSEREF","name":"sum","addr":"(QG)","loc":"e,58:14,58:17","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+                        {"type":"PARSEREF","name":"sum","addr":"(SG)","loc":"e,58:14,58:17","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
                       ],
                        "rhsp": [
-                        {"type":"CONST","name":"64'h4afe43fb79d7b71e","addr":"(RG)","loc":"e,58:22,58:42","dtypep":"(AF)"}
+                        {"type":"CONST","name":"64'h4afe43fb79d7b71e","addr":"(TG)","loc":"e,58:22,58:42","dtypep":"(CF)"}
                       ]}
                     ],
                      "thensp": [
-                      {"type":"STOP","name":"","addr":"(SG)","loc":"e,58:44,58:49","isFatal":false}
+                      {"type":"STOP","name":"","addr":"(UG)","loc":"e,58:44,58:49","isFatal":false}
                     ],"elsesp": []},
-                    {"type":"DISPLAY","name":"","addr":"(TG)","loc":"e,59:10,59:16",
+                    {"type":"DISPLAY","name":"","addr":"(VG)","loc":"e,59:10,59:16",
                      "fmtp": [
-                      {"type":"SFORMATF","name":"","addr":"(UG)","loc":"e,59:10,59:16","dtypep":"(BG)",
+                      {"type":"SFORMATF","name":"","addr":"(WG)","loc":"e,59:10,59:16","dtypep":"(DG)",
                        "exprsp": [
-                        {"type":"CONST","name":"168'h2a2d2a20416c6c2046696e6973686564202a2d2a0a","addr":"(VG)","loc":"e,59:17,59:41","dtypep":"(WG)"}
+                        {"type":"CONST","name":"168'h2a2d2a20416c6c2046696e6973686564202a2d2a0a","addr":"(XG)","loc":"e,59:17,59:41","dtypep":"(YG)"}
                       ],"scopeNamep": []}
                     ],"filep": []},
-                    {"type":"FINISH","name":"","addr":"(XG)","loc":"e,60:10,60:17"}
+                    {"type":"FINISH","name":"","addr":"(ZG)","loc":"e,60:10,60:17"}
                   ]}
                 ],"elsesp": []}
               ]}
@@ -431,125 +431,647 @@
       ]}
     ]}
   ]},
-  {"type":"MODULE","name":"Test","addr":"(PB)","loc":"e,66:8,66:12","isChecker":false,"isProgram":false,"origName":"Test","level":3,"modPublic":false,"inLibrary":false,"dead":false,"recursiveClone":false,"recursive":false,"timeunit":"1ps","inlinesp": [],
+  {"type":"MODULE","name":"Test","addr":"(RB)","loc":"e,66:8,66:12","isChecker":false,"isProgram":false,"origName":"Test","level":3,"modPublic":false,"inLibrary":false,"dead":false,"recursiveClone":false,"recursive":false,"timeunit":"1ps","inlinesp": [],
    "stmtsp": [
-    {"type":"PORT","name":"out","addr":"(YG)","loc":"e,68:4,68:7","exprp": []},
-    {"type":"PORT","name":"clk","addr":"(ZG)","loc":"e,70:4,70:7","exprp": []},
-    {"type":"PORT","name":"in","addr":"(AH)","loc":"e,70:9,70:11","exprp": []},
-    {"type":"VAR","name":"clk","addr":"(BH)","loc":"e,78:10,78:13","dtypep":"UNLINKED","origName":"clk","isSc":false,"isPrimaryIO":false,"direction":"INPUT","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"attrClocker":"UNKNOWN","lifetime":"NONE","varType":"PORT","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"ignorePostWrite":false,"ignoreSchedWrite":false,"sensIfacep":"UNLINKED",
+    {"type":"PORT","name":"out","addr":"(AH)","loc":"e,68:4,68:7","exprp": []},
+    {"type":"PORT","name":"clk","addr":"(BH)","loc":"e,70:4,70:7","exprp": []},
+    {"type":"PORT","name":"in","addr":"(CH)","loc":"e,70:9,70:11","exprp": []},
+    {"type":"VAR","name":"clk","addr":"(DH)","loc":"e,78:10,78:13","dtypep":"UNLINKED","origName":"clk","isSc":false,"isPrimaryIO":false,"direction":"INPUT","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"attrClocker":"UNKNOWN","lifetime":"NONE","varType":"PORT","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"ignorePostWrite":false,"ignoreSchedWrite":false,"sensIfacep":"UNLINKED",
      "childDTypep": [
-      {"type":"BASICDTYPE","name":"LOGIC_IMPLICIT","addr":"(CH)","loc":"e,78:10,78:13","dtypep":"(CH)","keyword":"LOGIC_IMPLICIT","generic":false,"rangep": []}
+      {"type":"BASICDTYPE","name":"LOGIC_IMPLICIT","addr":"(EH)","loc":"e,78:10,78:13","dtypep":"(EH)","keyword":"LOGIC_IMPLICIT","generic":false,"rangep": []}
     ],"delayp": [],"valuep": [],"attrsp": []},
-    {"type":"VAR","name":"in","addr":"(DH)","loc":"e,79:17,79:19","dtypep":"UNLINKED","origName":"in","isSc":false,"isPrimaryIO":false,"direction":"INPUT","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"attrClocker":"UNKNOWN","lifetime":"NONE","varType":"PORT","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"ignorePostWrite":false,"ignoreSchedWrite":false,"sensIfacep":"UNLINKED",
+    {"type":"VAR","name":"in","addr":"(FH)","loc":"e,79:17,79:19","dtypep":"UNLINKED","origName":"in","isSc":false,"isPrimaryIO":false,"direction":"INPUT","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"attrClocker":"UNKNOWN","lifetime":"NONE","varType":"PORT","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"ignorePostWrite":false,"ignoreSchedWrite":false,"sensIfacep":"UNLINKED",
      "childDTypep": [
-      {"type":"BASICDTYPE","name":"logic","addr":"(EH)","loc":"e,79:10,79:11","dtypep":"(EH)","keyword":"logic","generic":false,
+      {"type":"BASICDTYPE","name":"logic","addr":"(GH)","loc":"e,79:10,79:11","dtypep":"(GH)","keyword":"logic","generic":false,
        "rangep": [
-        {"type":"RANGE","name":"","addr":"(FH)","loc":"e,79:10,79:11","ascending":false,
+        {"type":"RANGE","name":"","addr":"(HH)","loc":"e,79:10,79:11","ascending":false,
          "leftp": [
-          {"type":"CONST","name":"?32?sh1f","addr":"(GH)","loc":"e,79:11,79:13","dtypep":"(BB)"}
+          {"type":"CONST","name":"?32?sh1f","addr":"(IH)","loc":"e,79:11,79:13","dtypep":"(DB)"}
         ],
          "rightp": [
-          {"type":"CONST","name":"?32?sh0","addr":"(HH)","loc":"e,79:14,79:15","dtypep":"(L)"}
+          {"type":"CONST","name":"?32?sh0","addr":"(JH)","loc":"e,79:14,79:15","dtypep":"(N)"}
         ]}
       ]}
     ],"delayp": [],"valuep": [],"attrsp": []},
-    {"type":"VAR","name":"out","addr":"(IH)","loc":"e,80:22,80:25","dtypep":"UNLINKED","origName":"out","isSc":false,"isPrimaryIO":false,"direction":"OUTPUT","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"attrClocker":"UNKNOWN","lifetime":"NONE","varType":"PORT","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"ignorePostWrite":false,"ignoreSchedWrite":false,"sensIfacep":"UNLINKED",
+    {"type":"VAR","name":"out","addr":"(KH)","loc":"e,80:22,80:25","dtypep":"UNLINKED","origName":"out","isSc":false,"isPrimaryIO":false,"direction":"OUTPUT","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"attrClocker":"UNKNOWN","lifetime":"NONE","varType":"PORT","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"ignorePostWrite":false,"ignoreSchedWrite":false,"sensIfacep":"UNLINKED",
      "childDTypep": [
-      {"type":"BASICDTYPE","name":"logic","addr":"(JH)","loc":"e,80:11,80:14","dtypep":"(JH)","keyword":"logic","generic":false,
+      {"type":"BASICDTYPE","name":"logic","addr":"(LH)","loc":"e,80:11,80:14","dtypep":"(LH)","keyword":"logic","generic":false,
        "rangep": [
-        {"type":"RANGE","name":"","addr":"(KH)","loc":"e,80:15,80:16","ascending":false,
+        {"type":"RANGE","name":"","addr":"(MH)","loc":"e,80:15,80:16","ascending":false,
          "leftp": [
-          {"type":"CONST","name":"?32?sh1f","addr":"(LH)","loc":"e,80:16,80:18","dtypep":"(BB)"}
+          {"type":"CONST","name":"?32?sh1f","addr":"(NH)","loc":"e,80:16,80:18","dtypep":"(DB)"}
         ],
          "rightp": [
-          {"type":"CONST","name":"?32?sh0","addr":"(MH)","loc":"e,80:19,80:20","dtypep":"(L)"}
+          {"type":"CONST","name":"?32?sh0","addr":"(OH)","loc":"e,80:19,80:20","dtypep":"(N)"}
         ]}
       ]}
     ],"delayp": [],"valuep": [],"attrsp": []},
-    {"type":"ALWAYS","name":"","addr":"(NH)","loc":"e,82:4,82:10","keyword":"always","isSuspendable":false,"needProcess":false,"sensesp": [],
+    {"type":"ALWAYS","name":"","addr":"(PH)","loc":"e,82:4,82:10","keyword":"always","isSuspendable":false,"needProcess":false,"sensesp": [],
      "stmtsp": [
-      {"type":"EVENTCONTROL","name":"","addr":"(OH)","loc":"e,82:11,82:12",
+      {"type":"EVENTCONTROL","name":"","addr":"(QH)","loc":"e,82:11,82:12",
        "sensesp": [
-        {"type":"SENTREE","name":"","addr":"(PH)","loc":"e,82:11,82:12","isMulti":false,
+        {"type":"SENTREE","name":"","addr":"(RH)","loc":"e,82:11,82:12","isMulti":false,
          "sensesp": [
-          {"type":"SENITEM","name":"","addr":"(QH)","loc":"e,82:13,82:20","edgeType":"POS",
+          {"type":"SENITEM","name":"","addr":"(SH)","loc":"e,82:13,82:20","edgeType":"POS",
            "sensp": [
-            {"type":"PARSEREF","name":"clk","addr":"(RH)","loc":"e,82:21,82:24","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+            {"type":"PARSEREF","name":"clk","addr":"(TH)","loc":"e,82:21,82:24","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
           ],"condp": []}
         ]}
       ],
        "stmtsp": [
-        {"type":"BEGIN","name":"","addr":"(SH)","loc":"e,82:26,82:31","generate":false,"genfor":false,"implied":false,"needProcess":false,"unnamed":true,"genforp": [],
+        {"type":"BEGIN","name":"","addr":"(UH)","loc":"e,82:26,82:31","generate":false,"genfor":false,"implied":false,"needProcess":false,"unnamed":true,"genforp": [],
          "stmtsp": [
-          {"type":"ASSIGNDLY","name":"","addr":"(TH)","loc":"e,83:11,83:13","dtypep":"UNLINKED",
+          {"type":"ASSIGNDLY","name":"","addr":"(VH)","loc":"e,83:11,83:13","dtypep":"UNLINKED",
            "rhsp": [
-            {"type":"PARSEREF","name":"in","addr":"(UH)","loc":"e,83:14,83:16","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+            {"type":"PARSEREF","name":"in","addr":"(WH)","loc":"e,83:14,83:16","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
           ],
            "lhsp": [
-            {"type":"PARSEREF","name":"out","addr":"(VH)","loc":"e,83:7,83:10","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+            {"type":"PARSEREF","name":"out","addr":"(XH)","loc":"e,83:7,83:10","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
           ],"timingControlp": []},
-          {"type":"ASSERTCTL","name":"","addr":"(WH)","loc":"e,86:7,86:17","ctlType":"$assertoff",
+          {"type":"ASSERTCTL","name":"","addr":"(YH)","loc":"e,86:7,86:17","ctlType":"$assertoff",
            "controlTypep": [
-            {"type":"CONST","name":"32'h4","addr":"(XH)","loc":"e,86:7,86:17","dtypep":"(MC)"}
+            {"type":"CONST","name":"32'h4","addr":"(ZH)","loc":"e,86:7,86:17","dtypep":"(OC)"}
           ],"assertTypesp": [],"directiveTypesp": []},
-          {"type":"ASSERTCTL","name":"","addr":"(YH)","loc":"e,87:7,87:18","ctlType":"$assertkill",
+          {"type":"ASSERTCTL","name":"","addr":"(AI)","loc":"e,87:7,87:18","ctlType":"$assertkill",
            "controlTypep": [
-            {"type":"CONST","name":"32'h5","addr":"(ZH)","loc":"e,87:7,87:18","dtypep":"(MC)"}
+            {"type":"CONST","name":"32'h5","addr":"(BI)","loc":"e,87:7,87:18","dtypep":"(OC)"}
           ],"assertTypesp": [],"directiveTypesp": []},
-          {"type":"ASSERT","name":"","addr":"(AI)","loc":"e,88:7,88:13","type":"[SIMPLE_IMMEDIATE]",
+          {"type":"ASSERT","name":"","addr":"(CI)","loc":"e,88:7,88:13","type":"[SIMPLE_IMMEDIATE]",
            "propp": [
-            {"type":"CONST","name":"?32?sh0","addr":"(BI)","loc":"e,88:14,88:15","dtypep":"(L)"}
+            {"type":"CONST","name":"?32?sh0","addr":"(DI)","loc":"e,88:14,88:15","dtypep":"(N)"}
           ],"sentreep": [],"failsp": [],"passsp": []},
-          {"type":"ASSERTCTL","name":"","addr":"(CI)","loc":"e,89:7,89:16","ctlType":"$asserton",
+          {"type":"ASSERTCTL","name":"","addr":"(EI)","loc":"e,89:7,89:16","ctlType":"$asserton",
            "controlTypep": [
-            {"type":"CONST","name":"32'h3","addr":"(DI)","loc":"e,89:7,89:16","dtypep":"(MC)"}
+            {"type":"CONST","name":"32'h3","addr":"(FI)","loc":"e,89:7,89:16","dtypep":"(OC)"}
           ],"assertTypesp": [],"directiveTypesp": []},
-          {"type":"ASSERTCTL","name":"","addr":"(EI)","loc":"e,90:7,90:21","ctlType":"",
+          {"type":"ASSERTCTL","name":"","addr":"(GI)","loc":"e,90:7,90:21","ctlType":"",
            "controlTypep": [
-            {"type":"CONST","name":"?32?sh3","addr":"(FI)","loc":"e,90:22,90:23","dtypep":"(QD)"}
+            {"type":"CONST","name":"?32?sh3","addr":"(HI)","loc":"e,90:22,90:23","dtypep":"(SD)"}
           ],
            "assertTypesp": [
-            {"type":"CONST","name":"?32?sh8","addr":"(GI)","loc":"e,90:25,90:26","dtypep":"(JF)"}
+            {"type":"CONST","name":"?32?sh8","addr":"(II)","loc":"e,90:25,90:26","dtypep":"(LF)"}
           ],"directiveTypesp": []},
-          {"type":"BEGIN","name":"blk","addr":"(HI)","loc":"e,91:15,91:18","generate":false,"genfor":false,"implied":false,"needProcess":false,"unnamed":false,"genforp": [],
+          {"type":"BEGIN","name":"blk","addr":"(JI)","loc":"e,91:15,91:18","generate":false,"genfor":false,"implied":false,"needProcess":false,"unnamed":false,"genforp": [],
            "stmtsp": [
-            {"type":"DISABLE","name":"","addr":"(II)","loc":"e,92:10,92:17",
+            {"type":"DISABLE","name":"","addr":"(KI)","loc":"e,92:10,92:17",
              "targetRefp": [
-              {"type":"PARSEREF","name":"blk","addr":"(JI)","loc":"e,92:18,92:21","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+              {"type":"PARSEREF","name":"blk","addr":"(LI)","loc":"e,92:18,92:21","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
             ]}
           ]}
         ]}
       ]}
     ]}
+  ]},
+  {"type":"PACKAGE","name":"$unit","addr":"(E)","loc":"a,0:0,0:0","origName":"__024unit","level":3,"modPublic":false,"inLibrary":true,"dead":false,"recursiveClone":false,"recursive":false,"timeunit":"1ps","inlinesp": [],
+   "stmtsp": [
+    {"type":"PACKAGEIMPORT","name":"*","addr":"(MI)","loc":"d,31:9,31:12","packagep":"(F)"}
+  ]},
+  {"type":"PACKAGE","name":"std","addr":"(F)","loc":"d,31:9,31:12","origName":"std","level":4,"modPublic":false,"inLibrary":true,"dead":false,"recursiveClone":false,"recursive":false,"timeunit":"1ps","inlinesp": [],
+   "stmtsp": [
+    {"type":"CLASS","name":"mailbox","addr":"(NI)","loc":"d,32:4,32:9","isExtended":false,"isInterfaceClass":false,"isVirtual":false,"origName":"mailbox","level":5,"modPublic":false,"inLibrary":false,"dead":false,"recursiveClone":false,"recursive":false,"timeunit":"NONE","classOrPackagep":"UNLINKED","inlinesp": [],
+     "stmtsp": [
+      {"type":"VAR","name":"T","addr":"(OI)","loc":"d,32:25,32:26","dtypep":"UNLINKED","origName":"T","isSc":false,"isPrimaryIO":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"attrClocker":"UNKNOWN","lifetime":"NONE","varType":"GPARAM","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":true,"isParam":true,"attrScBv":false,"attrSFormat":false,"ignorePostWrite":false,"ignoreSchedWrite":false,"sensIfacep":"UNLINKED",
+       "childDTypep": [
+        {"type":"PARSETYPEDTYPE","name":"","addr":"(PI)","loc":"d,32:20,32:24","dtypep":"UNLINKED","generic":false}
+      ],"delayp": [],"valuep": [],"attrsp": []},
+      {"type":"TYPEDEFFWD","name":"T","addr":"(QI)","loc":"d,32:25,32:26"},
+      {"type":"VAR","name":"m_bound","addr":"(RI)","loc":"d,33:21,33:28","dtypep":"UNLINKED","origName":"m_bound","isSc":false,"isPrimaryIO":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"attrClocker":"UNKNOWN","lifetime":"NONE","varType":"VAR","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"ignorePostWrite":false,"ignoreSchedWrite":false,"sensIfacep":"UNLINKED",
+       "childDTypep": [
+        {"type":"BASICDTYPE","name":"int","addr":"(SI)","loc":"d,33:17,33:20","dtypep":"(SI)","keyword":"int","range":"31:0","generic":false,"rangep": []}
+      ],"delayp": [],"valuep": [],"attrsp": []},
+      {"type":"VAR","name":"m_queue","addr":"(TI)","loc":"d,34:19,34:26","dtypep":"UNLINKED","origName":"m_queue","isSc":false,"isPrimaryIO":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"attrClocker":"UNKNOWN","lifetime":"NONE","varType":"VAR","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"ignorePostWrite":false,"ignoreSchedWrite":false,"sensIfacep":"UNLINKED",
+       "childDTypep": [
+        {"type":"BRACKETARRAYDTYPE","name":"","addr":"(UI)","loc":"d,34:26,34:27","dtypep":"UNLINKED","generic":false,
+         "childDTypep": [
+          {"type":"REFDTYPE","name":"T","addr":"(VI)","loc":"d,34:17,34:18","dtypep":"UNLINKED","generic":false,"typedefp":"UNLINKED","refDTypep":"UNLINKED","classOrPackagep":"UNLINKED","typeofp": [],"classOrPackageOpp": [],"paramsp": []}
+        ],
+         "elementsp": [
+          {"type":"UNBOUNDED","name":"","addr":"(WI)","loc":"d,34:27,34:28","dtypep":"(XI)"}
+        ]}
+      ],"delayp": [],"valuep": [],"attrsp": []},
+      {"type":"FUNC","name":"new","addr":"(YI)","loc":"d,36:16,36:19","dtypep":"UNLINKED","method":false,"dpiExport":false,"dpiImport":false,"dpiOpenChild":false,"dpiOpenParent":false,"isExternDef":false,"isExternProto":false,"prototype":false,"recursive":false,"taskPublic":false,"cname":"new","fvarp": [],"classOrPackagep": [],
+       "stmtsp": [
+        {"type":"VAR","name":"bound","addr":"(ZI)","loc":"d,36:24,36:29","dtypep":"UNLINKED","origName":"bound","isSc":false,"isPrimaryIO":false,"direction":"INPUT","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"attrClocker":"UNKNOWN","lifetime":"NONE","varType":"PORT","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"ignorePostWrite":false,"ignoreSchedWrite":false,"sensIfacep":"UNLINKED",
+         "childDTypep": [
+          {"type":"BASICDTYPE","name":"int","addr":"(AJ)","loc":"d,36:20,36:23","dtypep":"(AJ)","keyword":"int","range":"31:0","generic":false,"rangep": []}
+        ],"delayp": [],
+         "valuep": [
+          {"type":"CONST","name":"?32?sh0","addr":"(BJ)","loc":"d,36:32,36:33","dtypep":"(N)"}
+        ],"attrsp": []},
+        {"type":"ASSIGN","name":"","addr":"(CJ)","loc":"d,37:18,37:19","dtypep":"UNLINKED",
+         "rhsp": [
+          {"type":"PARSEREF","name":"bound","addr":"(DJ)","loc":"d,37:20,37:25","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+        ],
+         "lhsp": [
+          {"type":"PARSEREF","name":"m_bound","addr":"(EJ)","loc":"d,37:10,37:17","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+        ],"timingControlp": []}
+      ],"scopeNamep": []},
+      {"type":"FUNC","name":"num","addr":"(FJ)","loc":"d,40:20,40:23","dtypep":"UNLINKED","method":false,"dpiExport":false,"dpiImport":false,"dpiOpenChild":false,"dpiOpenParent":false,"isExternDef":false,"isExternProto":false,"prototype":false,"recursive":false,"taskPublic":false,"cname":"num",
+       "fvarp": [
+        {"type":"BASICDTYPE","name":"int","addr":"(GJ)","loc":"d,40:16,40:19","dtypep":"(GJ)","keyword":"int","range":"31:0","generic":false,"rangep": []}
+      ],"classOrPackagep": [],
+       "stmtsp": [
+        {"type":"RETURN","name":"","addr":"(HJ)","loc":"d,41:10,41:16",
+         "lhsp": [
+          {"type":"DOT","name":"","addr":"(IJ)","loc":"d,41:24,41:25","dtypep":"UNLINKED","colon":false,
+           "lhsp": [
+            {"type":"PARSEREF","name":"m_queue","addr":"(JJ)","loc":"d,41:17,41:24","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+          ],
+           "rhsp": [
+            {"type":"FUNCREF","name":"size","addr":"(KJ)","loc":"d,41:25,41:29","dtypep":"UNLINKED","dotted":"","taskp":"UNLINKED","classOrPackagep":"UNLINKED","namep": [],"pinsp": [],"scopeNamep": []}
+          ]}
+        ]}
+      ],"scopeNamep": []},
+      {"type":"TASK","name":"put","addr":"(LJ)","loc":"d,44:12,44:15","method":false,"dpiExport":false,"dpiImport":false,"dpiOpenChild":false,"dpiOpenParent":false,"isExternDef":false,"isExternProto":false,"prototype":false,"recursive":false,"taskPublic":false,"cname":"put","fvarp": [],"classOrPackagep": [],
+       "stmtsp": [
+        {"type":"VAR","name":"message","addr":"(MJ)","loc":"d,44:18,44:25","dtypep":"UNLINKED","origName":"message","isSc":false,"isPrimaryIO":false,"direction":"INPUT","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"attrClocker":"UNKNOWN","lifetime":"NONE","varType":"PORT","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"ignorePostWrite":false,"ignoreSchedWrite":false,"sensIfacep":"UNLINKED",
+         "childDTypep": [
+          {"type":"REFDTYPE","name":"T","addr":"(NJ)","loc":"d,44:16,44:17","dtypep":"UNLINKED","generic":false,"typedefp":"UNLINKED","refDTypep":"UNLINKED","classOrPackagep":"UNLINKED","typeofp": [],"classOrPackageOpp": [],"paramsp": []}
+        ],"delayp": [],"valuep": [],"attrsp": []}
+      ],"scopeNamep": []},
+      {"type":"FUNC","name":"try_put","addr":"(OJ)","loc":"d,52:20,52:27","dtypep":"UNLINKED","method":false,"dpiExport":false,"dpiImport":false,"dpiOpenChild":false,"dpiOpenParent":false,"isExternDef":false,"isExternProto":false,"prototype":false,"recursive":false,"taskPublic":false,"cname":"try_put",
+       "fvarp": [
+        {"type":"BASICDTYPE","name":"int","addr":"(PJ)","loc":"d,52:16,52:19","dtypep":"(PJ)","keyword":"int","range":"31:0","generic":false,"rangep": []}
+      ],"classOrPackagep": [],
+       "stmtsp": [
+        {"type":"VAR","name":"message","addr":"(QJ)","loc":"d,52:30,52:37","dtypep":"UNLINKED","origName":"message","isSc":false,"isPrimaryIO":false,"direction":"INPUT","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"attrClocker":"UNKNOWN","lifetime":"NONE","varType":"PORT","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"ignorePostWrite":false,"ignoreSchedWrite":false,"sensIfacep":"UNLINKED",
+         "childDTypep": [
+          {"type":"REFDTYPE","name":"T","addr":"(RJ)","loc":"d,52:28,52:29","dtypep":"UNLINKED","generic":false,"typedefp":"UNLINKED","refDTypep":"UNLINKED","classOrPackagep":"UNLINKED","typeofp": [],"classOrPackageOpp": [],"paramsp": []}
+        ],"delayp": [],"valuep": [],"attrsp": []},
+        {"type":"IF","name":"","addr":"(SJ)","loc":"d,53:10,53:12",
+         "condp": [
+          {"type":"LOGOR","name":"","addr":"(TJ)","loc":"d,53:27,53:29","dtypep":"(WE)",
+           "lhsp": [
+            {"type":"EQ","name":"","addr":"(UJ)","loc":"d,53:22,53:24","dtypep":"(WE)",
+             "lhsp": [
+              {"type":"PARSEREF","name":"m_bound","addr":"(VJ)","loc":"d,53:14,53:21","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+            ],
+             "rhsp": [
+              {"type":"CONST","name":"?32?sh0","addr":"(WJ)","loc":"d,53:25,53:26","dtypep":"(N)"}
+            ]}
+          ],
+           "rhsp": [
+            {"type":"LT","name":"","addr":"(XJ)","loc":"d,53:36,53:37","dtypep":"(WE)",
+             "lhsp": [
+              {"type":"FUNCREF","name":"num","addr":"(YJ)","loc":"d,53:30,53:33","dtypep":"UNLINKED","dotted":"","taskp":"UNLINKED","classOrPackagep":"UNLINKED","namep": [],"pinsp": [],"scopeNamep": []}
+            ],
+             "rhsp": [
+              {"type":"PARSEREF","name":"m_bound","addr":"(ZJ)","loc":"d,53:38,53:45","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+            ]}
+          ]}
+        ],
+         "thensp": [
+          {"type":"BEGIN","name":"","addr":"(AK)","loc":"d,53:47,53:52","generate":false,"genfor":false,"implied":false,"needProcess":false,"unnamed":true,"genforp": [],
+           "stmtsp": [
+            {"type":"STMTEXPR","name":"","addr":"(BK)","loc":"d,54:20,54:21",
+             "exprp": [
+              {"type":"DOT","name":"","addr":"(CK)","loc":"d,54:20,54:21","dtypep":"UNLINKED","colon":false,
+               "lhsp": [
+                {"type":"PARSEREF","name":"m_queue","addr":"(DK)","loc":"d,54:13,54:20","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+              ],
+               "rhsp": [
+                {"type":"TASKREF","name":"push_back","addr":"(EK)","loc":"d,54:21,54:30","dtypep":"(FK)","dotted":"","taskp":"UNLINKED","classOrPackagep":"UNLINKED","namep": [],
+                 "pinsp": [
+                  {"type":"ARG","name":"","addr":"(GK)","loc":"d,54:31,54:38",
+                   "exprp": [
+                    {"type":"PARSEREF","name":"message","addr":"(HK)","loc":"d,54:31,54:38","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+                  ]}
+                ],"scopeNamep": []}
+              ]}
+            ]},
+            {"type":"RETURN","name":"","addr":"(IK)","loc":"d,55:13,55:19",
+             "lhsp": [
+              {"type":"CONST","name":"?32?sh1","addr":"(JK)","loc":"d,55:20,55:21","dtypep":"(N)"}
+            ]}
+          ]}
+        ],"elsesp": []},
+        {"type":"RETURN","name":"","addr":"(KK)","loc":"d,57:10,57:16",
+         "lhsp": [
+          {"type":"CONST","name":"?32?sh0","addr":"(LK)","loc":"d,57:17,57:18","dtypep":"(N)"}
+        ]}
+      ],"scopeNamep": []},
+      {"type":"TASK","name":"get","addr":"(MK)","loc":"d,60:12,60:15","method":false,"dpiExport":false,"dpiImport":false,"dpiOpenChild":false,"dpiOpenParent":false,"isExternDef":false,"isExternProto":false,"prototype":false,"recursive":false,"taskPublic":false,"cname":"get","fvarp": [],"classOrPackagep": [],
+       "stmtsp": [
+        {"type":"VAR","name":"message","addr":"(NK)","loc":"d,60:22,60:29","dtypep":"UNLINKED","origName":"message","isSc":false,"isPrimaryIO":false,"direction":"REF","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"attrClocker":"UNKNOWN","lifetime":"NONE","varType":"PORT","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"ignorePostWrite":false,"ignoreSchedWrite":false,"sensIfacep":"UNLINKED",
+         "childDTypep": [
+          {"type":"REFDTYPE","name":"T","addr":"(OK)","loc":"d,60:20,60:21","dtypep":"UNLINKED","generic":false,"typedefp":"UNLINKED","refDTypep":"UNLINKED","classOrPackagep":"UNLINKED","typeofp": [],"classOrPackageOpp": [],"paramsp": []}
+        ],"delayp": [],"valuep": [],"attrsp": []}
+      ],"scopeNamep": []},
+      {"type":"FUNC","name":"try_get","addr":"(PK)","loc":"d,69:20,69:27","dtypep":"UNLINKED","method":false,"dpiExport":false,"dpiImport":false,"dpiOpenChild":false,"dpiOpenParent":false,"isExternDef":false,"isExternProto":false,"prototype":false,"recursive":false,"taskPublic":false,"cname":"try_get",
+       "fvarp": [
+        {"type":"BASICDTYPE","name":"int","addr":"(QK)","loc":"d,69:16,69:19","dtypep":"(QK)","keyword":"int","range":"31:0","generic":false,"rangep": []}
+      ],"classOrPackagep": [],
+       "stmtsp": [
+        {"type":"VAR","name":"message","addr":"(RK)","loc":"d,69:34,69:41","dtypep":"UNLINKED","origName":"message","isSc":false,"isPrimaryIO":false,"direction":"REF","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"attrClocker":"UNKNOWN","lifetime":"NONE","varType":"PORT","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"ignorePostWrite":false,"ignoreSchedWrite":false,"sensIfacep":"UNLINKED",
+         "childDTypep": [
+          {"type":"REFDTYPE","name":"T","addr":"(SK)","loc":"d,69:32,69:33","dtypep":"UNLINKED","generic":false,"typedefp":"UNLINKED","refDTypep":"UNLINKED","classOrPackagep":"UNLINKED","typeofp": [],"classOrPackageOpp": [],"paramsp": []}
+        ],"delayp": [],"valuep": [],"attrsp": []},
+        {"type":"IF","name":"","addr":"(TK)","loc":"d,70:10,70:12",
+         "condp": [
+          {"type":"GT","name":"","addr":"(UK)","loc":"d,70:20,70:21","dtypep":"(WE)",
+           "lhsp": [
+            {"type":"FUNCREF","name":"num","addr":"(VK)","loc":"d,70:14,70:17","dtypep":"UNLINKED","dotted":"","taskp":"UNLINKED","classOrPackagep":"UNLINKED","namep": [],"pinsp": [],"scopeNamep": []}
+          ],
+           "rhsp": [
+            {"type":"CONST","name":"?32?sh0","addr":"(WK)","loc":"d,70:22,70:23","dtypep":"(N)"}
+          ]}
+        ],
+         "thensp": [
+          {"type":"BEGIN","name":"","addr":"(XK)","loc":"d,70:25,70:30","generate":false,"genfor":false,"implied":false,"needProcess":false,"unnamed":true,"genforp": [],
+           "stmtsp": [
+            {"type":"ASSIGN","name":"","addr":"(YK)","loc":"d,71:21,71:22","dtypep":"UNLINKED",
+             "rhsp": [
+              {"type":"DOT","name":"","addr":"(ZK)","loc":"d,71:30,71:31","dtypep":"UNLINKED","colon":false,
+               "lhsp": [
+                {"type":"PARSEREF","name":"m_queue","addr":"(AL)","loc":"d,71:23,71:30","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+              ],
+               "rhsp": [
+                {"type":"FUNCREF","name":"pop_front","addr":"(BL)","loc":"d,71:31,71:40","dtypep":"UNLINKED","dotted":"","taskp":"UNLINKED","classOrPackagep":"UNLINKED","namep": [],"pinsp": [],"scopeNamep": []}
+              ]}
+            ],
+             "lhsp": [
+              {"type":"PARSEREF","name":"message","addr":"(CL)","loc":"d,71:13,71:20","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+            ],"timingControlp": []},
+            {"type":"RETURN","name":"","addr":"(DL)","loc":"d,72:13,72:19",
+             "lhsp": [
+              {"type":"CONST","name":"?32?sh1","addr":"(EL)","loc":"d,72:20,72:21","dtypep":"(N)"}
+            ]}
+          ]}
+        ],"elsesp": []},
+        {"type":"RETURN","name":"","addr":"(FL)","loc":"d,74:10,74:16",
+         "lhsp": [
+          {"type":"CONST","name":"?32?sh0","addr":"(GL)","loc":"d,74:17,74:18","dtypep":"(N)"}
+        ]}
+      ],"scopeNamep": []},
+      {"type":"TASK","name":"peek","addr":"(HL)","loc":"d,77:12,77:16","method":false,"dpiExport":false,"dpiImport":false,"dpiOpenChild":false,"dpiOpenParent":false,"isExternDef":false,"isExternProto":false,"prototype":false,"recursive":false,"taskPublic":false,"cname":"peek","fvarp": [],"classOrPackagep": [],
+       "stmtsp": [
+        {"type":"VAR","name":"message","addr":"(IL)","loc":"d,77:23,77:30","dtypep":"UNLINKED","origName":"message","isSc":false,"isPrimaryIO":false,"direction":"REF","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"attrClocker":"UNKNOWN","lifetime":"NONE","varType":"PORT","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"ignorePostWrite":false,"ignoreSchedWrite":false,"sensIfacep":"UNLINKED",
+         "childDTypep": [
+          {"type":"REFDTYPE","name":"T","addr":"(JL)","loc":"d,77:21,77:22","dtypep":"UNLINKED","generic":false,"typedefp":"UNLINKED","refDTypep":"UNLINKED","classOrPackagep":"UNLINKED","typeofp": [],"classOrPackageOpp": [],"paramsp": []}
+        ],"delayp": [],"valuep": [],"attrsp": []}
+      ],"scopeNamep": []},
+      {"type":"FUNC","name":"try_peek","addr":"(KL)","loc":"d,86:20,86:28","dtypep":"UNLINKED","method":false,"dpiExport":false,"dpiImport":false,"dpiOpenChild":false,"dpiOpenParent":false,"isExternDef":false,"isExternProto":false,"prototype":false,"recursive":false,"taskPublic":false,"cname":"try_peek",
+       "fvarp": [
+        {"type":"BASICDTYPE","name":"int","addr":"(LL)","loc":"d,86:16,86:19","dtypep":"(LL)","keyword":"int","range":"31:0","generic":false,"rangep": []}
+      ],"classOrPackagep": [],
+       "stmtsp": [
+        {"type":"VAR","name":"message","addr":"(ML)","loc":"d,86:35,86:42","dtypep":"UNLINKED","origName":"message","isSc":false,"isPrimaryIO":false,"direction":"REF","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"attrClocker":"UNKNOWN","lifetime":"NONE","varType":"PORT","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"ignorePostWrite":false,"ignoreSchedWrite":false,"sensIfacep":"UNLINKED",
+         "childDTypep": [
+          {"type":"REFDTYPE","name":"T","addr":"(NL)","loc":"d,86:33,86:34","dtypep":"UNLINKED","generic":false,"typedefp":"UNLINKED","refDTypep":"UNLINKED","classOrPackagep":"UNLINKED","typeofp": [],"classOrPackageOpp": [],"paramsp": []}
+        ],"delayp": [],"valuep": [],"attrsp": []},
+        {"type":"IF","name":"","addr":"(OL)","loc":"d,87:10,87:12",
+         "condp": [
+          {"type":"GT","name":"","addr":"(PL)","loc":"d,87:20,87:21","dtypep":"(WE)",
+           "lhsp": [
+            {"type":"FUNCREF","name":"num","addr":"(QL)","loc":"d,87:14,87:17","dtypep":"UNLINKED","dotted":"","taskp":"UNLINKED","classOrPackagep":"UNLINKED","namep": [],"pinsp": [],"scopeNamep": []}
+          ],
+           "rhsp": [
+            {"type":"CONST","name":"?32?sh0","addr":"(RL)","loc":"d,87:22,87:23","dtypep":"(N)"}
+          ]}
+        ],
+         "thensp": [
+          {"type":"BEGIN","name":"","addr":"(SL)","loc":"d,87:25,87:30","generate":false,"genfor":false,"implied":false,"needProcess":false,"unnamed":true,"genforp": [],
+           "stmtsp": [
+            {"type":"ASSIGN","name":"","addr":"(TL)","loc":"d,88:21,88:22","dtypep":"UNLINKED",
+             "rhsp": [
+              {"type":"SELBIT","name":"","addr":"(UL)","loc":"d,88:30,88:31","dtypep":"UNLINKED",
+               "fromp": [
+                {"type":"PARSEREF","name":"m_queue","addr":"(VL)","loc":"d,88:23,88:30","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+              ],
+               "bitp": [
+                {"type":"CONST","name":"?32?sh0","addr":"(WL)","loc":"d,88:31,88:32","dtypep":"(N)"}
+              ],"thsp": [],"attrp": []}
+            ],
+             "lhsp": [
+              {"type":"PARSEREF","name":"message","addr":"(XL)","loc":"d,88:13,88:20","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+            ],"timingControlp": []},
+            {"type":"RETURN","name":"","addr":"(YL)","loc":"d,89:13,89:19",
+             "lhsp": [
+              {"type":"CONST","name":"?32?sh1","addr":"(ZL)","loc":"d,89:20,89:21","dtypep":"(N)"}
+            ]}
+          ]}
+        ],"elsesp": []},
+        {"type":"RETURN","name":"","addr":"(AM)","loc":"d,91:10,91:16",
+         "lhsp": [
+          {"type":"CONST","name":"?32?sh0","addr":"(BM)","loc":"d,91:17,91:18","dtypep":"(N)"}
+        ]}
+      ],"scopeNamep": []}
+    ],"extendsp": []},
+    {"type":"CLASS","name":"semaphore","addr":"(CM)","loc":"d,95:4,95:9","isExtended":false,"isInterfaceClass":false,"isVirtual":false,"origName":"semaphore","level":5,"modPublic":false,"inLibrary":false,"dead":false,"recursiveClone":false,"recursive":false,"timeunit":"NONE","classOrPackagep":"UNLINKED","inlinesp": [],
+     "stmtsp": [
+      {"type":"VAR","name":"m_keyCount","addr":"(DM)","loc":"d,96:21,96:31","dtypep":"UNLINKED","origName":"m_keyCount","isSc":false,"isPrimaryIO":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"attrClocker":"UNKNOWN","lifetime":"NONE","varType":"VAR","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"ignorePostWrite":false,"ignoreSchedWrite":false,"sensIfacep":"UNLINKED",
+       "childDTypep": [
+        {"type":"BASICDTYPE","name":"int","addr":"(EM)","loc":"d,96:17,96:20","dtypep":"(EM)","keyword":"int","range":"31:0","generic":false,"rangep": []}
+      ],"delayp": [],"valuep": [],"attrsp": []},
+      {"type":"FUNC","name":"new","addr":"(FM)","loc":"d,98:16,98:19","dtypep":"UNLINKED","method":false,"dpiExport":false,"dpiImport":false,"dpiOpenChild":false,"dpiOpenParent":false,"isExternDef":false,"isExternProto":false,"prototype":false,"recursive":false,"taskPublic":false,"cname":"new","fvarp": [],"classOrPackagep": [],
+       "stmtsp": [
+        {"type":"VAR","name":"keyCount","addr":"(GM)","loc":"d,98:24,98:32","dtypep":"UNLINKED","origName":"keyCount","isSc":false,"isPrimaryIO":false,"direction":"INPUT","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"attrClocker":"UNKNOWN","lifetime":"NONE","varType":"PORT","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"ignorePostWrite":false,"ignoreSchedWrite":false,"sensIfacep":"UNLINKED",
+         "childDTypep": [
+          {"type":"BASICDTYPE","name":"int","addr":"(HM)","loc":"d,98:20,98:23","dtypep":"(HM)","keyword":"int","range":"31:0","generic":false,"rangep": []}
+        ],"delayp": [],
+         "valuep": [
+          {"type":"CONST","name":"?32?sh0","addr":"(IM)","loc":"d,98:35,98:36","dtypep":"(N)"}
+        ],"attrsp": []},
+        {"type":"ASSIGN","name":"","addr":"(JM)","loc":"d,99:21,99:22","dtypep":"UNLINKED",
+         "rhsp": [
+          {"type":"PARSEREF","name":"keyCount","addr":"(KM)","loc":"d,99:23,99:31","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+        ],
+         "lhsp": [
+          {"type":"PARSEREF","name":"m_keyCount","addr":"(LM)","loc":"d,99:10,99:20","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+        ],"timingControlp": []}
+      ],"scopeNamep": []},
+      {"type":"TASK","name":"put","addr":"(MM)","loc":"d,102:21,102:24","method":false,"dpiExport":false,"dpiImport":false,"dpiOpenChild":false,"dpiOpenParent":false,"isExternDef":false,"isExternProto":false,"prototype":false,"recursive":false,"taskPublic":false,"cname":"put","fvarp": [],"classOrPackagep": [],
+       "stmtsp": [
+        {"type":"VAR","name":"keyCount","addr":"(NM)","loc":"d,102:29,102:37","dtypep":"UNLINKED","origName":"keyCount","isSc":false,"isPrimaryIO":false,"direction":"INPUT","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"attrClocker":"UNKNOWN","lifetime":"NONE","varType":"PORT","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"ignorePostWrite":false,"ignoreSchedWrite":false,"sensIfacep":"UNLINKED",
+         "childDTypep": [
+          {"type":"BASICDTYPE","name":"int","addr":"(OM)","loc":"d,102:25,102:28","dtypep":"(OM)","keyword":"int","range":"31:0","generic":false,"rangep": []}
+        ],"delayp": [],
+         "valuep": [
+          {"type":"CONST","name":"?32?sh1","addr":"(PM)","loc":"d,102:40,102:41","dtypep":"(N)"}
+        ],"attrsp": []},
+        {"type":"ASSIGN","name":"","addr":"(QM)","loc":"d,103:21,103:23","dtypep":"UNLINKED",
+         "rhsp": [
+          {"type":"ADD","name":"","addr":"(RM)","loc":"d,103:21,103:23","dtypep":"UNLINKED",
+           "lhsp": [
+            {"type":"PARSEREF","name":"m_keyCount","addr":"(SM)","loc":"d,103:10,103:20","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+          ],
+           "rhsp": [
+            {"type":"PARSEREF","name":"keyCount","addr":"(TM)","loc":"d,103:24,103:32","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+          ]}
+        ],
+         "lhsp": [
+          {"type":"PARSEREF","name":"m_keyCount","addr":"(UM)","loc":"d,103:10,103:20","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+        ],"timingControlp": []}
+      ],"scopeNamep": []},
+      {"type":"TASK","name":"get","addr":"(VM)","loc":"d,106:12,106:15","method":false,"dpiExport":false,"dpiImport":false,"dpiOpenChild":false,"dpiOpenParent":false,"isExternDef":false,"isExternProto":false,"prototype":false,"recursive":false,"taskPublic":false,"cname":"get","fvarp": [],"classOrPackagep": [],
+       "stmtsp": [
+        {"type":"VAR","name":"keyCount","addr":"(WM)","loc":"d,106:20,106:28","dtypep":"UNLINKED","origName":"keyCount","isSc":false,"isPrimaryIO":false,"direction":"INPUT","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"attrClocker":"UNKNOWN","lifetime":"NONE","varType":"PORT","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"ignorePostWrite":false,"ignoreSchedWrite":false,"sensIfacep":"UNLINKED",
+         "childDTypep": [
+          {"type":"BASICDTYPE","name":"int","addr":"(XM)","loc":"d,106:16,106:19","dtypep":"(XM)","keyword":"int","range":"31:0","generic":false,"rangep": []}
+        ],"delayp": [],
+         "valuep": [
+          {"type":"CONST","name":"?32?sh1","addr":"(YM)","loc":"d,106:31,106:32","dtypep":"(N)"}
+        ],"attrsp": []}
+      ],"scopeNamep": []},
+      {"type":"FUNC","name":"try_get","addr":"(ZM)","loc":"d,115:20,115:27","dtypep":"UNLINKED","method":false,"dpiExport":false,"dpiImport":false,"dpiOpenChild":false,"dpiOpenParent":false,"isExternDef":false,"isExternProto":false,"prototype":false,"recursive":false,"taskPublic":false,"cname":"try_get",
+       "fvarp": [
+        {"type":"BASICDTYPE","name":"int","addr":"(AN)","loc":"d,115:16,115:19","dtypep":"(AN)","keyword":"int","range":"31:0","generic":false,"rangep": []}
+      ],"classOrPackagep": [],
+       "stmtsp": [
+        {"type":"VAR","name":"keyCount","addr":"(BN)","loc":"d,115:32,115:40","dtypep":"UNLINKED","origName":"keyCount","isSc":false,"isPrimaryIO":false,"direction":"INPUT","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"attrClocker":"UNKNOWN","lifetime":"NONE","varType":"PORT","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"ignorePostWrite":false,"ignoreSchedWrite":false,"sensIfacep":"UNLINKED",
+         "childDTypep": [
+          {"type":"BASICDTYPE","name":"int","addr":"(CN)","loc":"d,115:28,115:31","dtypep":"(CN)","keyword":"int","range":"31:0","generic":false,"rangep": []}
+        ],"delayp": [],
+         "valuep": [
+          {"type":"CONST","name":"?32?sh1","addr":"(DN)","loc":"d,115:43,115:44","dtypep":"(N)"}
+        ],"attrsp": []},
+        {"type":"IF","name":"","addr":"(EN)","loc":"d,116:10,116:12",
+         "condp": [
+          {"type":"GTE","name":"","addr":"(FN)","loc":"d,116:25,116:27","dtypep":"(WE)",
+           "lhsp": [
+            {"type":"PARSEREF","name":"m_keyCount","addr":"(GN)","loc":"d,116:14,116:24","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+          ],
+           "rhsp": [
+            {"type":"PARSEREF","name":"keyCount","addr":"(HN)","loc":"d,116:28,116:36","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+          ]}
+        ],
+         "thensp": [
+          {"type":"BEGIN","name":"","addr":"(IN)","loc":"d,116:38,116:43","generate":false,"genfor":false,"implied":false,"needProcess":false,"unnamed":true,"genforp": [],
+           "stmtsp": [
+            {"type":"ASSIGN","name":"","addr":"(JN)","loc":"d,117:24,117:26","dtypep":"UNLINKED",
+             "rhsp": [
+              {"type":"SUB","name":"","addr":"(KN)","loc":"d,117:24,117:26","dtypep":"UNLINKED",
+               "lhsp": [
+                {"type":"PARSEREF","name":"m_keyCount","addr":"(LN)","loc":"d,117:13,117:23","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+              ],
+               "rhsp": [
+                {"type":"PARSEREF","name":"keyCount","addr":"(MN)","loc":"d,117:27,117:35","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+              ]}
+            ],
+             "lhsp": [
+              {"type":"PARSEREF","name":"m_keyCount","addr":"(NN)","loc":"d,117:13,117:23","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+            ],"timingControlp": []},
+            {"type":"RETURN","name":"","addr":"(ON)","loc":"d,118:13,118:19",
+             "lhsp": [
+              {"type":"CONST","name":"?32?sh1","addr":"(PN)","loc":"d,118:20,118:21","dtypep":"(N)"}
+            ]}
+          ]}
+        ],"elsesp": []},
+        {"type":"RETURN","name":"","addr":"(QN)","loc":"d,120:10,120:16",
+         "lhsp": [
+          {"type":"CONST","name":"?32?sh0","addr":"(RN)","loc":"d,120:17,120:18","dtypep":"(N)"}
+        ]}
+      ],"scopeNamep": []}
+    ],"extendsp": []},
+    {"type":"CLASS","name":"process","addr":"(SN)","loc":"d,124:4,124:9","isExtended":false,"isInterfaceClass":false,"isVirtual":false,"origName":"process","level":5,"modPublic":false,"inLibrary":false,"dead":false,"recursiveClone":false,"recursive":false,"timeunit":"NONE","classOrPackagep":"UNLINKED","inlinesp": [],
+     "stmtsp": [
+      {"type":"TYPEDEF","name":"state","addr":"(TN)","loc":"d,131:9,131:14","dtypep":"UNLINKED","attrPublic":false,
+       "childDTypep": [
+        {"type":"DEFIMPLICITDTYPE","name":"__typeimpenum0","addr":"(UN)","loc":"d,125:15,125:19","dtypep":"UNLINKED","generic":false,
+         "childDTypep": [
+          {"type":"ENUMDTYPE","name":"","addr":"(VN)","loc":"d,125:15,125:19","dtypep":"UNLINKED","enum":true,"generic":false,"refDTypep":"UNLINKED",
+           "childDTypep": [
+            {"type":"BASICDTYPE","name":"int","addr":"(WN)","loc":"d,125:20,125:21","dtypep":"(WN)","keyword":"int","range":"31:0","generic":false,"rangep": []}
+          ],
+           "itemsp": [
+            {"type":"ENUMITEM","name":"FINISHED","addr":"(XN)","loc":"d,126:10,126:18","dtypep":"UNLINKED","rangep": [],
+             "valuep": [
+              {"type":"CONST","name":"?32?sh0","addr":"(YN)","loc":"d,126:22,126:23","dtypep":"(N)"}
+            ]},
+            {"type":"ENUMITEM","name":"RUNNING","addr":"(ZN)","loc":"d,127:10,127:17","dtypep":"UNLINKED","rangep": [],
+             "valuep": [
+              {"type":"CONST","name":"?32?sh1","addr":"(AO)","loc":"d,127:22,127:23","dtypep":"(N)"}
+            ]},
+            {"type":"ENUMITEM","name":"WAITING","addr":"(BO)","loc":"d,128:10,128:17","dtypep":"UNLINKED","rangep": [],
+             "valuep": [
+              {"type":"CONST","name":"?32?sh2","addr":"(CO)","loc":"d,128:22,128:23","dtypep":"(SD)"}
+            ]},
+            {"type":"ENUMITEM","name":"SUSPENDED","addr":"(DO)","loc":"d,129:10,129:19","dtypep":"UNLINKED","rangep": [],
+             "valuep": [
+              {"type":"CONST","name":"?32?sh3","addr":"(EO)","loc":"d,129:22,129:23","dtypep":"(SD)"}
+            ]},
+            {"type":"ENUMITEM","name":"KILLED","addr":"(FO)","loc":"d,130:10,130:16","dtypep":"UNLINKED","rangep": [],
+             "valuep": [
+              {"type":"CONST","name":"?32?sh4","addr":"(GO)","loc":"d,130:22,130:23","dtypep":"(HO)"}
+            ]}
+          ]}
+        ]}
+      ],"attrsp": []},
+      {"type":"FUNC","name":"self","addr":"(IO)","loc":"d,138:31,138:35","dtypep":"UNLINKED","method":false,"dpiExport":false,"dpiImport":false,"dpiOpenChild":false,"dpiOpenParent":false,"isExternDef":false,"isExternProto":false,"prototype":false,"recursive":false,"taskPublic":false,"cname":"self",
+       "fvarp": [
+        {"type":"REFDTYPE","name":"process","addr":"(JO)","loc":"d,138:23,138:30","dtypep":"UNLINKED","generic":false,"typedefp":"UNLINKED","refDTypep":"UNLINKED","classOrPackagep":"UNLINKED","typeofp": [],"classOrPackageOpp": [],"paramsp": []}
+      ],"classOrPackagep": [],
+       "stmtsp": [
+        {"type":"VAR","name":"p","addr":"(KO)","loc":"d,139:18,139:19","dtypep":"UNLINKED","origName":"p","isSc":false,"isPrimaryIO":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"attrClocker":"UNKNOWN","lifetime":"NONE","varType":"VAR","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"ignorePostWrite":false,"ignoreSchedWrite":false,"sensIfacep":"UNLINKED",
+         "childDTypep": [
+          {"type":"REFDTYPE","name":"process","addr":"(LO)","loc":"d,139:10,139:17","dtypep":"UNLINKED","generic":false,"typedefp":"UNLINKED","refDTypep":"UNLINKED","classOrPackagep":"UNLINKED","typeofp": [],"classOrPackageOpp": [],"paramsp": []}
+        ],"delayp": [],
+         "valuep": [
+          {"type":"NEW","name":"new","addr":"(MO)","loc":"d,139:22,139:25","dtypep":"UNLINKED","isImplicit":false,"isScoped":false,"dotted":"","taskp":"UNLINKED","classOrPackagep":"UNLINKED","namep": [],"pinsp": [],"scopeNamep": []}
+        ],"attrsp": []},
+        {"type":"RETURN","name":"","addr":"(NO)","loc":"d,143:10,143:16",
+         "lhsp": [
+          {"type":"PARSEREF","name":"p","addr":"(OO)","loc":"d,143:17,143:18","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+        ]}
+      ],"scopeNamep": []},
+      {"type":"TASK","name":"set_status","addr":"(PO)","loc":"d,146:31,146:41","method":false,"dpiExport":false,"dpiImport":false,"dpiOpenChild":false,"dpiOpenParent":false,"isExternDef":false,"isExternProto":false,"prototype":false,"recursive":false,"taskPublic":false,"cname":"set_status","fvarp": [],"classOrPackagep": [],
+       "stmtsp": [
+        {"type":"VAR","name":"s","addr":"(QO)","loc":"d,146:48,146:49","dtypep":"UNLINKED","origName":"s","isSc":false,"isPrimaryIO":false,"direction":"INPUT","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"attrClocker":"UNKNOWN","lifetime":"NONE","varType":"PORT","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"ignorePostWrite":false,"ignoreSchedWrite":false,"sensIfacep":"UNLINKED",
+         "childDTypep": [
+          {"type":"REFDTYPE","name":"state","addr":"(RO)","loc":"d,146:42,146:47","dtypep":"UNLINKED","generic":false,"typedefp":"UNLINKED","refDTypep":"UNLINKED","classOrPackagep":"UNLINKED","typeofp": [],"classOrPackageOpp": [],"paramsp": []}
+        ],"delayp": [],"valuep": [],"attrsp": []}
+      ],"scopeNamep": []},
+      {"type":"FUNC","name":"status","addr":"(SO)","loc":"d,152:22,152:28","dtypep":"UNLINKED","method":false,"dpiExport":false,"dpiImport":false,"dpiOpenChild":false,"dpiOpenParent":false,"isExternDef":false,"isExternProto":false,"prototype":false,"recursive":false,"taskPublic":false,"cname":"status",
+       "fvarp": [
+        {"type":"REFDTYPE","name":"state","addr":"(TO)","loc":"d,152:16,152:21","dtypep":"UNLINKED","generic":false,"typedefp":"UNLINKED","refDTypep":"UNLINKED","classOrPackagep":"UNLINKED","typeofp": [],"classOrPackageOpp": [],"paramsp": []}
+      ],"classOrPackagep": [],
+       "stmtsp": [
+        {"type":"RETURN","name":"","addr":"(UO)","loc":"d,156:10,156:16",
+         "lhsp": [
+          {"type":"PARSEREF","name":"RUNNING","addr":"(VO)","loc":"d,156:17,156:24","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+        ]}
+      ],"scopeNamep": []},
+      {"type":"TASK","name":"kill","addr":"(WO)","loc":"d,160:21,160:25","method":false,"dpiExport":false,"dpiImport":false,"dpiOpenChild":false,"dpiOpenParent":false,"isExternDef":false,"isExternProto":false,"prototype":false,"recursive":false,"taskPublic":false,"cname":"kill","fvarp": [],"classOrPackagep": [],
+       "stmtsp": [
+        {"type":"STMTEXPR","name":"","addr":"(XO)","loc":"d,161:10,161:20",
+         "exprp": [
+          {"type":"TASKREF","name":"set_status","addr":"(YO)","loc":"d,161:10,161:20","dtypep":"(FK)","dotted":"","taskp":"UNLINKED","classOrPackagep":"UNLINKED","namep": [],
+           "pinsp": [
+            {"type":"ARG","name":"","addr":"(ZO)","loc":"d,161:21,161:27",
+             "exprp": [
+              {"type":"PARSEREF","name":"KILLED","addr":"(AP)","loc":"d,161:21,161:27","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+            ]}
+          ],"scopeNamep": []}
+        ]}
+      ],"scopeNamep": []},
+      {"type":"TASK","name":"suspend","addr":"(BP)","loc":"d,164:21,164:28","method":false,"dpiExport":false,"dpiImport":false,"dpiOpenChild":false,"dpiOpenParent":false,"isExternDef":false,"isExternProto":false,"prototype":false,"recursive":false,"taskPublic":false,"cname":"suspend","fvarp": [],"classOrPackagep": [],
+       "stmtsp": [
+        {"type":"DISPLAY","name":"","addr":"(CP)","loc":"d,165:10,165:16",
+         "fmtp": [
+          {"type":"SFORMATF","name":"","addr":"(DP)","loc":"d,165:10,165:16","dtypep":"(DG)",
+           "exprsp": [
+            {"type":"CONST","name":"296'h7374643a3a70726f636573733a3a73757370656e642829206e6f7420737570706f72746564","addr":"(EP)","loc":"d,165:17,165:56","dtypep":"(FP)"}
+          ],"scopeNamep": []}
+        ],"filep": []},
+        {"type":"STOP","name":"","addr":"(GP)","loc":"d,165:10,165:16","isFatal":false}
+      ],"scopeNamep": []},
+      {"type":"TASK","name":"resume","addr":"(HP)","loc":"d,168:21,168:27","method":false,"dpiExport":false,"dpiImport":false,"dpiOpenChild":false,"dpiOpenParent":false,"isExternDef":false,"isExternProto":false,"prototype":false,"recursive":false,"taskPublic":false,"cname":"resume","fvarp": [],"classOrPackagep": [],
+       "stmtsp": [
+        {"type":"STMTEXPR","name":"","addr":"(IP)","loc":"d,169:10,169:20",
+         "exprp": [
+          {"type":"TASKREF","name":"set_status","addr":"(JP)","loc":"d,169:10,169:20","dtypep":"(FK)","dotted":"","taskp":"UNLINKED","classOrPackagep":"UNLINKED","namep": [],
+           "pinsp": [
+            {"type":"ARG","name":"","addr":"(KP)","loc":"d,169:21,169:28",
+             "exprp": [
+              {"type":"PARSEREF","name":"RUNNING","addr":"(LP)","loc":"d,169:21,169:28","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+            ]}
+          ],"scopeNamep": []}
+        ]}
+      ],"scopeNamep": []},
+      {"type":"TASK","name":"await","addr":"(MP)","loc":"d,172:12,172:17","method":false,"dpiExport":false,"dpiImport":false,"dpiOpenChild":false,"dpiOpenParent":false,"isExternDef":false,"isExternProto":false,"prototype":false,"recursive":false,"taskPublic":false,"cname":"await","fvarp": [],"classOrPackagep": [],"stmtsp": [],"scopeNamep": []},
+      {"type":"FUNC","name":"get_randstate","addr":"(NP)","loc":"d,215:23,215:36","dtypep":"UNLINKED","method":false,"dpiExport":false,"dpiImport":false,"dpiOpenChild":false,"dpiOpenParent":false,"isExternDef":false,"isExternProto":false,"prototype":false,"recursive":false,"taskPublic":false,"cname":"get_randstate",
+       "fvarp": [
+        {"type":"BASICDTYPE","name":"string","addr":"(OP)","loc":"d,215:16,215:22","dtypep":"(OP)","keyword":"string","generic":false,"rangep": []}
+      ],"classOrPackagep": [],
+       "stmtsp": [
+        {"type":"VAR","name":"s","addr":"(PP)","loc":"d,216:17,216:18","dtypep":"UNLINKED","origName":"s","isSc":false,"isPrimaryIO":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"attrClocker":"UNKNOWN","lifetime":"NONE","varType":"VAR","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"ignorePostWrite":false,"ignoreSchedWrite":false,"sensIfacep":"UNLINKED",
+         "childDTypep": [
+          {"type":"BASICDTYPE","name":"string","addr":"(QP)","loc":"d,216:10,216:16","dtypep":"(QP)","keyword":"string","generic":false,"rangep": []}
+        ],"delayp": [],"valuep": [],"attrsp": []},
+        {"type":"STMTEXPR","name":"","addr":"(RP)","loc":"d,218:11,218:12",
+         "exprp": [
+          {"type":"DOT","name":"","addr":"(SP)","loc":"d,218:11,218:12","dtypep":"UNLINKED","colon":false,
+           "lhsp": [
+            {"type":"PARSEREF","name":"s","addr":"(TP)","loc":"d,218:10,218:11","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+          ],
+           "rhsp": [
+            {"type":"TASKREF","name":"itoa","addr":"(UP)","loc":"d,218:12,218:16","dtypep":"(FK)","dotted":"","taskp":"UNLINKED","classOrPackagep":"UNLINKED","namep": [],
+             "pinsp": [
+              {"type":"ARG","name":"","addr":"(VP)","loc":"d,218:17,218:24",
+               "exprp": [
+                {"type":"RAND","name":"","addr":"(WP)","loc":"d,218:17,218:24","dtypep":"UNLINKED","seedp": []}
+              ]}
+            ],"scopeNamep": []}
+          ]}
+        ]},
+        {"type":"STMTEXPR","name":"","addr":"(XP)","loc":"d,219:10,219:23",
+         "exprp": [
+          {"type":"TASKREF","name":"set_randstate","addr":"(YP)","loc":"d,219:10,219:23","dtypep":"(FK)","dotted":"","taskp":"UNLINKED","classOrPackagep":"UNLINKED","namep": [],
+           "pinsp": [
+            {"type":"ARG","name":"","addr":"(ZP)","loc":"d,219:24,219:25",
+             "exprp": [
+              {"type":"PARSEREF","name":"s","addr":"(AQ)","loc":"d,219:24,219:25","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+            ]}
+          ],"scopeNamep": []}
+        ]},
+        {"type":"RETURN","name":"","addr":"(BQ)","loc":"d,220:10,220:16",
+         "lhsp": [
+          {"type":"PARSEREF","name":"s","addr":"(CQ)","loc":"d,220:17,220:18","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+        ]}
+      ],"scopeNamep": []},
+      {"type":"TASK","name":"set_randstate","addr":"(DQ)","loc":"d,223:21,223:34","method":false,"dpiExport":false,"dpiImport":false,"dpiOpenChild":false,"dpiOpenParent":false,"isExternDef":false,"isExternProto":false,"prototype":false,"recursive":false,"taskPublic":false,"cname":"set_randstate","fvarp": [],"classOrPackagep": [],
+       "stmtsp": [
+        {"type":"VAR","name":"s","addr":"(EQ)","loc":"d,223:42,223:43","dtypep":"UNLINKED","origName":"s","isSc":false,"isPrimaryIO":false,"direction":"INPUT","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"attrClocker":"UNKNOWN","lifetime":"NONE","varType":"PORT","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"ignorePostWrite":false,"ignoreSchedWrite":false,"sensIfacep":"UNLINKED",
+         "childDTypep": [
+          {"type":"BASICDTYPE","name":"string","addr":"(FQ)","loc":"d,223:35,223:41","dtypep":"(FQ)","keyword":"string","generic":false,"rangep": []}
+        ],"delayp": [],"valuep": [],"attrsp": []},
+        {"type":"SYSFUNCASTASK","name":"","addr":"(GQ)","loc":"d,224:10,224:18",
+         "lhsp": [
+          {"type":"RAND","name":"","addr":"(HQ)","loc":"d,224:10,224:18","dtypep":"UNLINKED",
+           "seedp": [
+            {"type":"DOT","name":"","addr":"(IQ)","loc":"d,224:20,224:21","dtypep":"UNLINKED","colon":false,
+             "lhsp": [
+              {"type":"PARSEREF","name":"s","addr":"(JQ)","loc":"d,224:19,224:20","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+            ],
+             "rhsp": [
+              {"type":"FUNCREF","name":"atoi","addr":"(KQ)","loc":"d,224:21,224:25","dtypep":"UNLINKED","dotted":"","taskp":"UNLINKED","classOrPackagep":"UNLINKED","namep": [],"pinsp": [],"scopeNamep": []}
+            ]}
+          ]}
+        ]}
+      ],"scopeNamep": []}
+    ],"extendsp": []},
+    {"type":"FUNC","name":"randomize","addr":"(LQ)","loc":"d,227:17,227:26","dtypep":"UNLINKED","method":false,"dpiExport":false,"dpiImport":false,"dpiOpenChild":false,"dpiOpenParent":false,"isExternDef":false,"isExternProto":false,"prototype":false,"recursive":false,"taskPublic":false,"cname":"randomize",
+     "fvarp": [
+      {"type":"BASICDTYPE","name":"int","addr":"(MQ)","loc":"d,227:13,227:16","dtypep":"(MQ)","keyword":"int","range":"31:0","generic":false,"rangep": []}
+    ],"classOrPackagep": [],
+     "stmtsp": [
+      {"type":"ASSIGN","name":"","addr":"(NQ)","loc":"d,228:17,228:18","dtypep":"UNLINKED",
+       "rhsp": [
+        {"type":"CONST","name":"?32?sh0","addr":"(OQ)","loc":"d,228:19,228:20","dtypep":"(N)"}
+      ],
+       "lhsp": [
+        {"type":"PARSEREF","name":"randomize","addr":"(PQ)","loc":"d,228:7,228:16","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+      ],"timingControlp": []}
+    ],"scopeNamep": []}
   ]}
 ],"filesp": [],
  "miscsp": [
-  {"type":"TYPETABLE","name":"","addr":"(C)","loc":"a,0:0,0:0","constraintRefp":"UNLINKED","emptyQueuep":"UNLINKED","queueIndexp":"UNLINKED","streamp":"UNLINKED","voidp":"(KI)",
+  {"type":"TYPETABLE","name":"","addr":"(C)","loc":"a,0:0,0:0","constraintRefp":"UNLINKED","emptyQueuep":"UNLINKED","queueIndexp":"UNLINKED","streamp":"UNLINKED","voidp":"(FK)",
    "typesp": [
-    {"type":"BASICDTYPE","name":"integer","addr":"(LI)","loc":"d,34:27,34:28","dtypep":"(LI)","keyword":"integer","range":"31:0","generic":true,"rangep": []},
-    {"type":"BASICDTYPE","name":"logic","addr":"(L)","loc":"d,36:32,36:33","dtypep":"(L)","keyword":"logic","range":"31:0","generic":true,"rangep": []},
-    {"type":"BASICDTYPE","name":"logic","addr":"(UE)","loc":"d,53:22,53:24","dtypep":"(UE)","keyword":"logic","generic":true,"rangep": []},
-    {"type":"VOIDDTYPE","name":"","addr":"(KI)","loc":"d,54:21,54:30","dtypep":"(KI)","generic":false},
-    {"type":"BASICDTYPE","name":"logic","addr":"(QD)","loc":"d,128:22,128:23","dtypep":"(QD)","keyword":"logic","range":"31:0","generic":true,"rangep": []},
-    {"type":"BASICDTYPE","name":"logic","addr":"(MI)","loc":"d,130:22,130:23","dtypep":"(MI)","keyword":"logic","range":"31:0","generic":true,"rangep": []},
-    {"type":"BASICDTYPE","name":"logic","addr":"(NI)","loc":"d,165:17,165:56","dtypep":"(NI)","keyword":"logic","range":"295:0","generic":true,"rangep": []},
-    {"type":"BASICDTYPE","name":"string","addr":"(BG)","loc":"d,165:10,165:16","dtypep":"(BG)","keyword":"string","generic":true,"rangep": []},
-    {"type":"BASICDTYPE","name":"logic","addr":"(Q)","loc":"e,14:9,14:11","dtypep":"(Q)","keyword":"logic","range":"31:0","generic":true,"rangep": []},
-    {"type":"BASICDTYPE","name":"logic","addr":"(BB)","loc":"e,18:10,18:12","dtypep":"(BB)","keyword":"logic","range":"31:0","generic":true,"rangep": []},
-    {"type":"BASICDTYPE","name":"logic","addr":"(MC)","loc":"e,33:26,33:31","dtypep":"(MC)","keyword":"logic","range":"31:0","generic":true,"rangep": []},
-    {"type":"BASICDTYPE","name":"logic","addr":"(JC)","loc":"e,33:25,33:26","dtypep":"(JC)","keyword":"logic","generic":true,"rangep": []},
-    {"type":"BASICDTYPE","name":"logic","addr":"(AF)","loc":"e,45:17,45:38","dtypep":"(AF)","keyword":"logic","range":"63:0","generic":true,"rangep": []},
-    {"type":"BASICDTYPE","name":"logic","addr":"(JF)","loc":"e,48:22,48:24","dtypep":"(JF)","keyword":"logic","range":"31:0","generic":true,"rangep": []},
-    {"type":"BASICDTYPE","name":"logic","addr":"(SF)","loc":"e,51:22,51:24","dtypep":"(SF)","keyword":"logic","range":"31:0","generic":true,"rangep": []},
-    {"type":"BASICDTYPE","name":"logic","addr":"(DG)","loc":"e,54:17,54:49","dtypep":"(DG)","keyword":"logic","range":"231:0","generic":true,"rangep": []},
-    {"type":"BASICDTYPE","name":"QData","addr":"(FG)","loc":"e,54:51,54:56","dtypep":"(FG)","keyword":"QData","range":"63:0","generic":true,"rangep": []},
-    {"type":"BASICDTYPE","name":"logic","addr":"(WG)","loc":"e,59:17,59:41","dtypep":"(WG)","keyword":"logic","range":"167:0","generic":true,"rangep": []}
+    {"type":"BASICDTYPE","name":"integer","addr":"(XI)","loc":"d,34:27,34:28","dtypep":"(XI)","keyword":"integer","range":"31:0","generic":true,"rangep": []},
+    {"type":"BASICDTYPE","name":"logic","addr":"(N)","loc":"d,36:32,36:33","dtypep":"(N)","keyword":"logic","range":"31:0","generic":true,"rangep": []},
+    {"type":"BASICDTYPE","name":"logic","addr":"(WE)","loc":"d,53:22,53:24","dtypep":"(WE)","keyword":"logic","generic":true,"rangep": []},
+    {"type":"VOIDDTYPE","name":"","addr":"(FK)","loc":"d,54:21,54:30","dtypep":"(FK)","generic":false},
+    {"type":"BASICDTYPE","name":"logic","addr":"(SD)","loc":"d,128:22,128:23","dtypep":"(SD)","keyword":"logic","range":"31:0","generic":true,"rangep": []},
+    {"type":"BASICDTYPE","name":"logic","addr":"(HO)","loc":"d,130:22,130:23","dtypep":"(HO)","keyword":"logic","range":"31:0","generic":true,"rangep": []},
+    {"type":"BASICDTYPE","name":"logic","addr":"(FP)","loc":"d,165:17,165:56","dtypep":"(FP)","keyword":"logic","range":"295:0","generic":true,"rangep": []},
+    {"type":"BASICDTYPE","name":"string","addr":"(DG)","loc":"d,165:10,165:16","dtypep":"(DG)","keyword":"string","generic":true,"rangep": []},
+    {"type":"BASICDTYPE","name":"logic","addr":"(S)","loc":"e,14:9,14:11","dtypep":"(S)","keyword":"logic","range":"31:0","generic":true,"rangep": []},
+    {"type":"BASICDTYPE","name":"logic","addr":"(DB)","loc":"e,18:10,18:12","dtypep":"(DB)","keyword":"logic","range":"31:0","generic":true,"rangep": []},
+    {"type":"BASICDTYPE","name":"logic","addr":"(OC)","loc":"e,33:26,33:31","dtypep":"(OC)","keyword":"logic","range":"31:0","generic":true,"rangep": []},
+    {"type":"BASICDTYPE","name":"logic","addr":"(LC)","loc":"e,33:25,33:26","dtypep":"(LC)","keyword":"logic","generic":true,"rangep": []},
+    {"type":"BASICDTYPE","name":"logic","addr":"(CF)","loc":"e,45:17,45:38","dtypep":"(CF)","keyword":"logic","range":"63:0","generic":true,"rangep": []},
+    {"type":"BASICDTYPE","name":"logic","addr":"(LF)","loc":"e,48:22,48:24","dtypep":"(LF)","keyword":"logic","range":"31:0","generic":true,"rangep": []},
+    {"type":"BASICDTYPE","name":"logic","addr":"(UF)","loc":"e,51:22,51:24","dtypep":"(UF)","keyword":"logic","range":"31:0","generic":true,"rangep": []},
+    {"type":"BASICDTYPE","name":"logic","addr":"(FG)","loc":"e,54:17,54:49","dtypep":"(FG)","keyword":"logic","range":"231:0","generic":true,"rangep": []},
+    {"type":"BASICDTYPE","name":"QData","addr":"(HG)","loc":"e,54:51,54:56","dtypep":"(HG)","keyword":"QData","range":"63:0","generic":true,"rangep": []},
+    {"type":"BASICDTYPE","name":"logic","addr":"(YG)","loc":"e,59:17,59:41","dtypep":"(YG)","keyword":"logic","range":"167:0","generic":true,"rangep": []}
   ]},
   {"type":"CONSTPOOL","name":"","addr":"(D)","loc":"a,0:0,0:0",
    "modulep": [
-    {"type":"MODULE","name":"@CONST-POOL@","addr":"(OI)","loc":"a,0:0,0:0","isChecker":false,"isProgram":false,"origName":"@CONST-POOL@","level":0,"modPublic":false,"inLibrary":false,"dead":false,"recursiveClone":false,"recursive":false,"timeunit":"NONE","inlinesp": [],
+    {"type":"MODULE","name":"@CONST-POOL@","addr":"(QQ)","loc":"a,0:0,0:0","isChecker":false,"isProgram":false,"origName":"@CONST-POOL@","level":0,"modPublic":false,"inLibrary":false,"dead":false,"recursiveClone":false,"recursive":false,"timeunit":"NONE","inlinesp": [],
      "stmtsp": [
-      {"type":"SCOPE","name":"@CONST-POOL@","addr":"(PI)","loc":"a,0:0,0:0","aboveScopep":"UNLINKED","aboveCellp":"UNLINKED","modp":"(OI)","varsp": [],"blocksp": [],"inlinesp": []}
+      {"type":"SCOPE","name":"@CONST-POOL@","addr":"(RQ)","loc":"a,0:0,0:0","aboveScopep":"UNLINKED","aboveCellp":"UNLINKED","modp":"(QQ)","varsp": [],"blocksp": [],"inlinesp": []}
     ]}
   ]}
 ]}

--- a/test_regress/t/t_dump_json.out
+++ b/test_regress/t/t_dump_json.out
@@ -969,78 +969,91 @@
         ]}
       ],"scopeNamep": []},
       {"type":"TASK","name":"await","addr":"(MP)","loc":"d,172:12,172:17","method":false,"dpiExport":false,"dpiImport":false,"dpiOpenChild":false,"dpiOpenParent":false,"isExternDef":false,"isExternProto":false,"prototype":false,"recursive":false,"taskPublic":false,"cname":"await","fvarp": [],"classOrPackagep": [],"stmtsp": [],"scopeNamep": []},
-      {"type":"FUNC","name":"get_randstate","addr":"(NP)","loc":"d,215:23,215:36","dtypep":"UNLINKED","method":false,"dpiExport":false,"dpiImport":false,"dpiOpenChild":false,"dpiOpenParent":false,"isExternDef":false,"isExternProto":false,"prototype":false,"recursive":false,"taskPublic":false,"cname":"get_randstate",
+      {"type":"TASK","name":"killQueue","addr":"(NP)","loc":"d,178:19,178:28","method":false,"dpiExport":false,"dpiImport":false,"dpiOpenChild":false,"dpiOpenParent":false,"isExternDef":false,"isExternProto":false,"prototype":false,"recursive":false,"taskPublic":false,"cname":"killQueue","fvarp": [],"classOrPackagep": [],
+       "stmtsp": [
+        {"type":"VAR","name":"processQueue","addr":"(OP)","loc":"d,178:41,178:53","dtypep":"UNLINKED","origName":"processQueue","isSc":false,"isPrimaryIO":false,"direction":"REF","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"attrClocker":"UNKNOWN","lifetime":"NONE","varType":"PORT","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"ignorePostWrite":false,"ignoreSchedWrite":false,"sensIfacep":"UNLINKED",
+         "childDTypep": [
+          {"type":"BRACKETARRAYDTYPE","name":"","addr":"(PP)","loc":"d,178:53,178:54","dtypep":"UNLINKED","generic":false,
+           "childDTypep": [
+            {"type":"REFDTYPE","name":"process","addr":"(QP)","loc":"d,178:33,178:40","dtypep":"UNLINKED","generic":false,"typedefp":"UNLINKED","refDTypep":"UNLINKED","classOrPackagep":"UNLINKED","typeofp": [],"classOrPackageOpp": [],"paramsp": []}
+          ],
+           "elementsp": [
+            {"type":"UNBOUNDED","name":"","addr":"(RP)","loc":"d,178:54,178:55","dtypep":"(XI)"}
+          ]}
+        ],"delayp": [],"valuep": [],"attrsp": []}
+      ],"scopeNamep": []},
+      {"type":"FUNC","name":"get_randstate","addr":"(SP)","loc":"d,223:23,223:36","dtypep":"UNLINKED","method":false,"dpiExport":false,"dpiImport":false,"dpiOpenChild":false,"dpiOpenParent":false,"isExternDef":false,"isExternProto":false,"prototype":false,"recursive":false,"taskPublic":false,"cname":"get_randstate",
        "fvarp": [
-        {"type":"BASICDTYPE","name":"string","addr":"(OP)","loc":"d,215:16,215:22","dtypep":"(OP)","keyword":"string","generic":false,"rangep": []}
+        {"type":"BASICDTYPE","name":"string","addr":"(TP)","loc":"d,223:16,223:22","dtypep":"(TP)","keyword":"string","generic":false,"rangep": []}
       ],"classOrPackagep": [],
        "stmtsp": [
-        {"type":"VAR","name":"s","addr":"(PP)","loc":"d,216:17,216:18","dtypep":"UNLINKED","origName":"s","isSc":false,"isPrimaryIO":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"attrClocker":"UNKNOWN","lifetime":"NONE","varType":"VAR","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"ignorePostWrite":false,"ignoreSchedWrite":false,"sensIfacep":"UNLINKED",
+        {"type":"VAR","name":"s","addr":"(UP)","loc":"d,224:17,224:18","dtypep":"UNLINKED","origName":"s","isSc":false,"isPrimaryIO":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"attrClocker":"UNKNOWN","lifetime":"NONE","varType":"VAR","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"ignorePostWrite":false,"ignoreSchedWrite":false,"sensIfacep":"UNLINKED",
          "childDTypep": [
-          {"type":"BASICDTYPE","name":"string","addr":"(QP)","loc":"d,216:10,216:16","dtypep":"(QP)","keyword":"string","generic":false,"rangep": []}
+          {"type":"BASICDTYPE","name":"string","addr":"(VP)","loc":"d,224:10,224:16","dtypep":"(VP)","keyword":"string","generic":false,"rangep": []}
         ],"delayp": [],"valuep": [],"attrsp": []},
-        {"type":"STMTEXPR","name":"","addr":"(RP)","loc":"d,218:11,218:12",
+        {"type":"STMTEXPR","name":"","addr":"(WP)","loc":"d,226:11,226:12",
          "exprp": [
-          {"type":"DOT","name":"","addr":"(SP)","loc":"d,218:11,218:12","dtypep":"UNLINKED","colon":false,
+          {"type":"DOT","name":"","addr":"(XP)","loc":"d,226:11,226:12","dtypep":"UNLINKED","colon":false,
            "lhsp": [
-            {"type":"PARSEREF","name":"s","addr":"(TP)","loc":"d,218:10,218:11","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+            {"type":"PARSEREF","name":"s","addr":"(YP)","loc":"d,226:10,226:11","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
           ],
            "rhsp": [
-            {"type":"TASKREF","name":"itoa","addr":"(UP)","loc":"d,218:12,218:16","dtypep":"(FK)","dotted":"","taskp":"UNLINKED","classOrPackagep":"UNLINKED","namep": [],
+            {"type":"TASKREF","name":"itoa","addr":"(ZP)","loc":"d,226:12,226:16","dtypep":"(FK)","dotted":"","taskp":"UNLINKED","classOrPackagep":"UNLINKED","namep": [],
              "pinsp": [
-              {"type":"ARG","name":"","addr":"(VP)","loc":"d,218:17,218:24",
+              {"type":"ARG","name":"","addr":"(AQ)","loc":"d,226:17,226:24",
                "exprp": [
-                {"type":"RAND","name":"","addr":"(WP)","loc":"d,218:17,218:24","dtypep":"UNLINKED","seedp": []}
+                {"type":"RAND","name":"","addr":"(BQ)","loc":"d,226:17,226:24","dtypep":"UNLINKED","seedp": []}
               ]}
             ],"scopeNamep": []}
           ]}
         ]},
-        {"type":"STMTEXPR","name":"","addr":"(XP)","loc":"d,219:10,219:23",
+        {"type":"STMTEXPR","name":"","addr":"(CQ)","loc":"d,227:10,227:23",
          "exprp": [
-          {"type":"TASKREF","name":"set_randstate","addr":"(YP)","loc":"d,219:10,219:23","dtypep":"(FK)","dotted":"","taskp":"UNLINKED","classOrPackagep":"UNLINKED","namep": [],
+          {"type":"TASKREF","name":"set_randstate","addr":"(DQ)","loc":"d,227:10,227:23","dtypep":"(FK)","dotted":"","taskp":"UNLINKED","classOrPackagep":"UNLINKED","namep": [],
            "pinsp": [
-            {"type":"ARG","name":"","addr":"(ZP)","loc":"d,219:24,219:25",
+            {"type":"ARG","name":"","addr":"(EQ)","loc":"d,227:24,227:25",
              "exprp": [
-              {"type":"PARSEREF","name":"s","addr":"(AQ)","loc":"d,219:24,219:25","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+              {"type":"PARSEREF","name":"s","addr":"(FQ)","loc":"d,227:24,227:25","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
             ]}
           ],"scopeNamep": []}
         ]},
-        {"type":"RETURN","name":"","addr":"(BQ)","loc":"d,220:10,220:16",
+        {"type":"RETURN","name":"","addr":"(GQ)","loc":"d,228:10,228:16",
          "lhsp": [
-          {"type":"PARSEREF","name":"s","addr":"(CQ)","loc":"d,220:17,220:18","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+          {"type":"PARSEREF","name":"s","addr":"(HQ)","loc":"d,228:17,228:18","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
         ]}
       ],"scopeNamep": []},
-      {"type":"TASK","name":"set_randstate","addr":"(DQ)","loc":"d,223:21,223:34","method":false,"dpiExport":false,"dpiImport":false,"dpiOpenChild":false,"dpiOpenParent":false,"isExternDef":false,"isExternProto":false,"prototype":false,"recursive":false,"taskPublic":false,"cname":"set_randstate","fvarp": [],"classOrPackagep": [],
+      {"type":"TASK","name":"set_randstate","addr":"(IQ)","loc":"d,231:21,231:34","method":false,"dpiExport":false,"dpiImport":false,"dpiOpenChild":false,"dpiOpenParent":false,"isExternDef":false,"isExternProto":false,"prototype":false,"recursive":false,"taskPublic":false,"cname":"set_randstate","fvarp": [],"classOrPackagep": [],
        "stmtsp": [
-        {"type":"VAR","name":"s","addr":"(EQ)","loc":"d,223:42,223:43","dtypep":"UNLINKED","origName":"s","isSc":false,"isPrimaryIO":false,"direction":"INPUT","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"attrClocker":"UNKNOWN","lifetime":"NONE","varType":"PORT","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"ignorePostWrite":false,"ignoreSchedWrite":false,"sensIfacep":"UNLINKED",
+        {"type":"VAR","name":"s","addr":"(JQ)","loc":"d,231:42,231:43","dtypep":"UNLINKED","origName":"s","isSc":false,"isPrimaryIO":false,"direction":"INPUT","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"attrClocker":"UNKNOWN","lifetime":"NONE","varType":"PORT","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"ignorePostWrite":false,"ignoreSchedWrite":false,"sensIfacep":"UNLINKED",
          "childDTypep": [
-          {"type":"BASICDTYPE","name":"string","addr":"(FQ)","loc":"d,223:35,223:41","dtypep":"(FQ)","keyword":"string","generic":false,"rangep": []}
+          {"type":"BASICDTYPE","name":"string","addr":"(KQ)","loc":"d,231:35,231:41","dtypep":"(KQ)","keyword":"string","generic":false,"rangep": []}
         ],"delayp": [],"valuep": [],"attrsp": []},
-        {"type":"SYSFUNCASTASK","name":"","addr":"(GQ)","loc":"d,224:10,224:18",
+        {"type":"SYSFUNCASTASK","name":"","addr":"(LQ)","loc":"d,232:10,232:18",
          "lhsp": [
-          {"type":"RAND","name":"","addr":"(HQ)","loc":"d,224:10,224:18","dtypep":"UNLINKED",
+          {"type":"RAND","name":"","addr":"(MQ)","loc":"d,232:10,232:18","dtypep":"UNLINKED",
            "seedp": [
-            {"type":"DOT","name":"","addr":"(IQ)","loc":"d,224:20,224:21","dtypep":"UNLINKED","colon":false,
+            {"type":"DOT","name":"","addr":"(NQ)","loc":"d,232:20,232:21","dtypep":"UNLINKED","colon":false,
              "lhsp": [
-              {"type":"PARSEREF","name":"s","addr":"(JQ)","loc":"d,224:19,224:20","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+              {"type":"PARSEREF","name":"s","addr":"(OQ)","loc":"d,232:19,232:20","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
             ],
              "rhsp": [
-              {"type":"FUNCREF","name":"atoi","addr":"(KQ)","loc":"d,224:21,224:25","dtypep":"UNLINKED","dotted":"","taskp":"UNLINKED","classOrPackagep":"UNLINKED","namep": [],"pinsp": [],"scopeNamep": []}
+              {"type":"FUNCREF","name":"atoi","addr":"(PQ)","loc":"d,232:21,232:25","dtypep":"UNLINKED","dotted":"","taskp":"UNLINKED","classOrPackagep":"UNLINKED","namep": [],"pinsp": [],"scopeNamep": []}
             ]}
           ]}
         ]}
       ],"scopeNamep": []}
     ],"extendsp": []},
-    {"type":"FUNC","name":"randomize","addr":"(LQ)","loc":"d,227:17,227:26","dtypep":"UNLINKED","method":false,"dpiExport":false,"dpiImport":false,"dpiOpenChild":false,"dpiOpenParent":false,"isExternDef":false,"isExternProto":false,"prototype":false,"recursive":false,"taskPublic":false,"cname":"randomize",
+    {"type":"FUNC","name":"randomize","addr":"(QQ)","loc":"d,235:17,235:26","dtypep":"UNLINKED","method":false,"dpiExport":false,"dpiImport":false,"dpiOpenChild":false,"dpiOpenParent":false,"isExternDef":false,"isExternProto":false,"prototype":false,"recursive":false,"taskPublic":false,"cname":"randomize",
      "fvarp": [
-      {"type":"BASICDTYPE","name":"int","addr":"(MQ)","loc":"d,227:13,227:16","dtypep":"(MQ)","keyword":"int","range":"31:0","generic":false,"rangep": []}
+      {"type":"BASICDTYPE","name":"int","addr":"(RQ)","loc":"d,235:13,235:16","dtypep":"(RQ)","keyword":"int","range":"31:0","generic":false,"rangep": []}
     ],"classOrPackagep": [],
      "stmtsp": [
-      {"type":"ASSIGN","name":"","addr":"(NQ)","loc":"d,228:17,228:18","dtypep":"UNLINKED",
+      {"type":"ASSIGN","name":"","addr":"(SQ)","loc":"d,236:17,236:18","dtypep":"UNLINKED",
        "rhsp": [
-        {"type":"CONST","name":"?32?sh0","addr":"(OQ)","loc":"d,228:19,228:20","dtypep":"(N)"}
+        {"type":"CONST","name":"?32?sh0","addr":"(TQ)","loc":"d,236:19,236:20","dtypep":"(N)"}
       ],
        "lhsp": [
-        {"type":"PARSEREF","name":"randomize","addr":"(PQ)","loc":"d,228:7,228:16","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
+        {"type":"PARSEREF","name":"randomize","addr":"(UQ)","loc":"d,236:7,236:16","dtypep":"UNLINKED","expect":"TEXT","lhsp": [],"ftaskrefp": []}
       ],"timingControlp": []}
     ],"scopeNamep": []}
   ]}
@@ -1069,9 +1082,9 @@
   ]},
   {"type":"CONSTPOOL","name":"","addr":"(D)","loc":"a,0:0,0:0",
    "modulep": [
-    {"type":"MODULE","name":"@CONST-POOL@","addr":"(QQ)","loc":"a,0:0,0:0","isChecker":false,"isProgram":false,"origName":"@CONST-POOL@","level":0,"modPublic":false,"inLibrary":false,"dead":false,"recursiveClone":false,"recursive":false,"timeunit":"NONE","inlinesp": [],
+    {"type":"MODULE","name":"@CONST-POOL@","addr":"(VQ)","loc":"a,0:0,0:0","isChecker":false,"isProgram":false,"origName":"@CONST-POOL@","level":0,"modPublic":false,"inLibrary":false,"dead":false,"recursiveClone":false,"recursive":false,"timeunit":"NONE","inlinesp": [],
      "stmtsp": [
-      {"type":"SCOPE","name":"@CONST-POOL@","addr":"(RQ)","loc":"a,0:0,0:0","aboveScopep":"UNLINKED","aboveCellp":"UNLINKED","modp":"(QQ)","varsp": [],"blocksp": [],"inlinesp": []}
+      {"type":"SCOPE","name":"@CONST-POOL@","addr":"(WQ)","loc":"a,0:0,0:0","aboveScopep":"UNLINKED","aboveCellp":"UNLINKED","modp":"(VQ)","varsp": [],"blocksp": [],"inlinesp": []}
     ]}
   ]}
 ]}


### PR DESCRIPTION
The support is added by converting
```systemverilog
fork : X
   begin
      // fork1 original body
   end
   begin
      // fork2 original body
   end
join_none
...
disable X;
```
to
```systemverilog
static std::process fork_X_processes[$];
fork : X
   begin
      fork_X_processes.push_back(std::process::self());
      // fork1 original body
   end
   begin
      fork_X_processes.push_back(std::process::self());
      // fork2 original body
   end
join_none
...
// disable X;
while (fork_X_processes.size() > 0) fork_X_processes.pop_back().kill();
```

I left disabling a fork from within it unsupported, because I am not sure if calling `kill` on the current process is safe and if any other changes are required to handle that case. I throw `UNSUPPORTED` when `disable` is used within a task or a function due to the same reason. In general we don't know if that task is called outside the fork or inside.

I don't like the fact that I import `std` package every time the `disable` statement is used. Do you see a better solution?