### PR TITLE
Support delays in emitted Verilog

### DIFF
--- a/src/V3EmitV.cpp
+++ b/src/V3EmitV.cpp
@@ -927,6 +927,7 @@ class EmitVBaseVisitorConst VL_NOT_FINAL : public EmitCBaseVisitorConst {
         puts("#");
         iterateConst(nodep->lhsp());
         puts(";\n");
+        iterateAndNextConstNull(nodep->stmtsp());
     }
     void visit(AstCAwait* nodep) override {
         AstCMethodHard* methodp = VN_CAST(nodep->exprp(), CMethodHard);

--- a/src/V3EmitV.cpp
+++ b/src/V3EmitV.cpp
@@ -922,6 +922,19 @@ class EmitVBaseVisitorConst VL_NOT_FINAL : public EmitCBaseVisitorConst {
         m_sensesp = nodep->sensesp();
         iterateAndNextConstNull(nodep->stmtsp());
     }
+    void visit(AstDelay* nodep) override {
+        puts(""); // this is for proper alignment
+        puts("#");
+        iterateConst(nodep->lhsp());
+        puts(";\n");
+    }
+    void visit(AstCAwait* nodep) override {
+        AstCMethodHard* methodp = VN_CAST(nodep->exprp(), CMethodHard);
+        UASSERT_OBJ(methodp, nodep, "AstCAwait expression must be an AstCMethodHard");
+        puts(""); // this is for proper alignment
+        puts("#");
+        iterateConst(methodp->pinsp());
+    }
     void visit(AstParseRef* nodep) override { puts(nodep->prettyName()); }
     void visit(AstNodeText*) override {}
     void visit(AstVarScope*) override {}

--- a/src/V3EmitV.cpp
+++ b/src/V3EmitV.cpp
@@ -923,7 +923,7 @@ class EmitVBaseVisitorConst VL_NOT_FINAL : public EmitCBaseVisitorConst {
         iterateAndNextConstNull(nodep->stmtsp());
     }
     void visit(AstDelay* nodep) override {
-        puts(""); // this is for proper alignment
+        puts("");  // this is for proper alignment
         puts("#");
         iterateConst(nodep->lhsp());
         puts(";\n");
@@ -931,7 +931,7 @@ class EmitVBaseVisitorConst VL_NOT_FINAL : public EmitCBaseVisitorConst {
     void visit(AstCAwait* nodep) override {
         AstCMethodHard* methodp = VN_CAST(nodep->exprp(), CMethodHard);
         UASSERT_OBJ(methodp, nodep, "AstCAwait expression must be an AstCMethodHard");
-        puts(""); // this is for proper alignment
+        puts("");  // this is for proper alignment
         puts("#");
         iterateConst(methodp->pinsp());
     }

--- a/test_regress/t/t_debug_emitv.out
+++ b/test_regress/t/t_debug_emitv.out
@@ -75,6 +75,7 @@ module Vt_debug_emitv_t;
                 $write("");
             end
             #64'h1;
+            $write("After #1 delay");
         end
     end
     bit [6:5] [4:3] [2:1]  arraymanyd[10:11][12:13][14:15];

--- a/test_regress/t/t_debug_emitv.out
+++ b/test_regress/t/t_debug_emitv.out
@@ -74,6 +74,7 @@ module Vt_debug_emitv_t;
             if (the_ifaces[2].ifsig) begin
                 $write("");
             end
+            #64'h1;
         end
     end
     bit [6:5] [4:3] [2:1]  arraymanyd[10:11][12:13][14:15];

--- a/test_regress/t/t_debug_emitv.py
+++ b/test_regress/t/t_debug_emitv.py
@@ -14,7 +14,7 @@ test.scenarios("vlt")
 test.lint(
     # We also have dump-tree turned on, so hit a lot of AstNode*::dump() functions
     # Likewise XML
-    v_flags=["--lint-only --dumpi-tree 9 --dumpi-V3EmitV 9 --debug-emitv"])
+    v_flags=["--lint-only --dumpi-tree 9 --dumpi-V3EmitV 9 --debug-emitv --timing"])
 
 output_vs = test.glob_some(test.obj_dir + "/" + test.vm_prefix + "_*_width.tree.v")
 

--- a/test_regress/t/t_debug_emitv.v
+++ b/test_regress/t/t_debug_emitv.v
@@ -86,6 +86,7 @@ module t (/*AUTOARG*/
       if (|downto_32[55+:3]) $write("");
       if (|downto_32[60-:7]) $write("");
       if (the_ifaces[2].ifsig) $write("");
+      #1 $write("After #1 delay");
    end
 
    bit [6:5][4:3][2:1] arraymanyd[10:11][12:13][14:15];

--- a/test_regress/t/t_debug_emitv_addrids.py
+++ b/test_regress/t/t_debug_emitv_addrids.py
@@ -15,6 +15,6 @@ test.top_filename = "t/t_debug_emitv.v"
 test.lint(
     # We also have dump-tree turned on, so hit a lot of AstNode*::dump() functions
     # Likewise XML
-    v_flags=["--lint-only --dumpi-tree 9 --dump-tree-addrids"])
+    v_flags=["--lint-only --dumpi-tree 9 --dump-tree-addrids --timing"])
 
 test.passes()


### PR DESCRIPTION
This MR adds support for delays in emitted verilog when using the `--debug-emitv` flag. It no longer throws an error and adds a delay statement in the emitted code. The test `t_debug_emitv` was changed to test that behaviour.