### PR TITLE
Fix of linking error with conflicting function/class names

### DIFF
--- a/src/V3LinkDot.cpp
+++ b/src/V3LinkDot.cpp
@@ -784,9 +784,9 @@ public:
         if (nodep->classOrPackageSkipp()) return getNodeSym(nodep->classOrPackageSkipp());
         VSymEnt* foundp;
         if (fallback) {
-            foundp = lookSymp->findIdFallback(nodep->name());
+            foundp = lookSymp->findIdFallback(nodep->name(), true);
         } else {
-            foundp = lookSymp->findIdFlat(nodep->name());
+            foundp = lookSymp->findIdFlat(nodep->name(), true);
         }
         if (!foundp && v3Global.rootp()->stdPackagep()) {  // Look under implied std::
             foundp = getNodeSym(v3Global.rootp()->stdPackagep())->findIdFlat(nodep->name());

--- a/src/V3SymTable.h
+++ b/src/V3SymTable.h
@@ -166,13 +166,6 @@ public:
                 if (VN_IS(typedefp->childDTypep(), ClassRefDType)) { return it->second; }
                 if (const AstRefDType* const refp = VN_CAST(typedefp->childDTypep(), RefDType)) {
                     refDTypep = refp;
-                } else if (!typedefp->childDTypep()) {
-                    // When still unknown - return because it may be a class **
-                    // ** - findIdFlat is often called during stages when types
-                    // are not fully resolved and by not returning types that
-                    // may be a classes (but it is still unknown) we are risking
-                    // not compiling a valid code
-                    return it->second;
                 }
             } else if (const AstParamTypeDType* const paramTypep
                        = VN_CAST(it->second->nodep(), ParamTypeDType)) {
@@ -191,7 +184,11 @@ public:
             // referenced by AstRefDType (refDTypep->typeofp() is not null
             // or refDTypep->classOrPackageOpp() is not null)
             if (refDTypep && !refDTypep->typeofp() && !refDTypep->classOrPackageOpp()) {
-                // When still unknown - return because it may be a class **
+                // When still unknown - return because it may be a class
+                // findIdFlat is often called during stages when types
+                // are not fully resolved and by not returning types that
+                // may be a classes (but it is still unknown) we are risking
+                // not compiling a valid code
                 return it->second;
             }
         }

--- a/src/V3SymTable.h
+++ b/src/V3SymTable.h
@@ -181,14 +181,11 @@ public:
                 }
             }
             // TODO: this should be handled properly - case when it is known what type is
-            // referenced by AstRefDType (refDTypep->typeofp() is not null
-            // or refDTypep->classOrPackageOpp() is not null)
+            // referenced by AstRefDType (refDTypep->typeofp() is null or
+            // refDTypep->classOrPackageOpp() is null)
             if (refDTypep && !refDTypep->typeofp() && !refDTypep->classOrPackageOpp()) {
-                // When still unknown - return because it may be a class
-                // findIdFlat is often called during stages when types
-                // are not fully resolved and by not returning types that
-                // may be a classes (but it is still unknown) we are risking
-                // not compiling a valid code
+                // When still unknown - return because it may be a class, classes may not be
+                // linked at this point. Return in case it gets resolved to a class in the future
                 return it->second;
             }
         }

--- a/src/V3SymTable.h
+++ b/src/V3SymTable.h
@@ -164,10 +164,13 @@ public:
             if (const AstTypedef* const typedefp = VN_CAST(it->second->nodep(), Typedef)) {
                 if (const AstClassRefDType* const classRefp
                     = VN_CAST(typedefp->childDTypep(), ClassRefDType)) {
-                    if (classRefp->classp()) return it->second;
+                    return it->second;
                 }
                 if (const AstRefDType* const refp = VN_CAST(typedefp->childDTypep(), RefDType)) {
                     refDTypep = refp;
+                } else if (!typedefp->childDTypep()) {
+                    // When still unknown - returned because it may be a class
+                    return it->second;
                 }
             } else if (const AstParamTypeDType* const paramTypep
                        = VN_CAST(it->second->nodep(), ParamTypeDType)) {
@@ -183,11 +186,9 @@ public:
             // TODO: this should be handled properly - case when it is known what type is
             // referenced by AstRefDType. Right now it is unnecessary since everything works as
             // intended
-            if (refDTypep && !refDTypep->typeofp() && !refDTypep->classOrPackageOpp()
-                && !refDTypep->paramsp()) {
+            if (refDTypep && !refDTypep->typeofp() && !refDTypep->classOrPackageOpp()) {
                 return it->second;
             }
-            std::cout << "Rejected: " << typeid(*it->second->nodep()).name() << '\n';
         }
         return nullptr;
     }

--- a/test_regress/t/t_class_reference_name_colision.py
+++ b/test_regress/t/t_class_reference_name_colision.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2024 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile()
+
+test.passes()

--- a/test_regress/t/t_class_reference_name_colision.py
+++ b/test_regress/t/t_class_reference_name_colision.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # DESCRIPTION: Verilator: Verilog Test driver/expect definition
 #
-# Copyright 2024 by Wilson Snyder. This program is free software; you
+# Copyright 2025 by Wilson Snyder. This program is free software; you
 # can redistribute it and/or modify it under the terms of either the GNU
 # Lesser General Public License Version 3 or the Perl Artistic License
 # Version 2.0.

--- a/test_regress/t/t_class_reference_name_colision.v
+++ b/test_regress/t/t_class_reference_name_colision.v
@@ -1,0 +1,17 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2024 by Antmicro.
+// SPDX-License-Identifier: CC0-1.0
+
+class setup_coefficients;
+    static function int create();
+        return 1;
+    endfunction
+endclass
+
+class biquad_vseq;
+    int c_setup = setup_coefficients::create();
+    function void setup_coefficients();
+    endfunction
+endclass: biquad_vseq

--- a/test_regress/t/t_class_reference_name_colision.v
+++ b/test_regress/t/t_class_reference_name_colision.v
@@ -1,7 +1,7 @@
 // DESCRIPTION: Verilator: Verilog Test module
 //
 // This file ONLY is placed under the Creative Commons Public Domain, for
-// any use, without warranty, 2024 by Antmicro.
+// any use, without warranty, 2025 by Antmicro.
 // SPDX-License-Identifier: CC0-1.0
 
 class setup_coefficients;


### PR DESCRIPTION
Having a reference to a static member function of some class ``B`` within some class ``A`` and having member function within class ``A`` with same name as class ``B``, caused a linking error.

Example:
```
class setup_coefficients;
    static function int create();
        return 1;
    endfunction
endclass

class biquad_vseq;
    int c_setup = setup_coefficients::create();
    function void setup_coefficients();
    endfunction
endclass: biquad_vseq
```

This solves this issue by requiring left-hand side of ``::`` operator to be class or package.