### PR TITLE
Add support for disabling begin just under fork from outside that begin (#5432 partial)

### DIFF
--- a/src/V3LinkJump.cpp
+++ b/src/V3LinkJump.cpp
@@ -212,12 +212,14 @@ class LinkJumpVisitor final : public VNVisitor {
 
         AstVarRef* const queueWriteRefp
             = new AstVarRef{fl, topPkgp, processQueuep, VAccess::WRITE};
-        AstStmtExpr* const pushCurrentProcessp = getQueuePushProcessSelfp(queueWriteRefp);
+        AstStmtExpr* pushCurrentProcessp = getQueuePushProcessSelfp(queueWriteRefp);
 
         for (AstBegin* const beginp : forks) {
             if (pushCurrentProcessp->backp()) {
-                beginp->stmtsp()->addHereThisAsNext(pushCurrentProcessp->cloneTree(false));
-            } else {
+                pushCurrentProcessp = pushCurrentProcessp->cloneTree(false);
+            }
+            if (beginp->stmtsp()) {
+                // There is no need to add it to empty block
                 beginp->stmtsp()->addHereThisAsNext(pushCurrentProcessp);
             }
         }

--- a/test_regress/t/t_disable_empty_outside.py
+++ b/test_regress/t/t_disable_empty_outside.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2024 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile(timing_loop=True, verilator_flags2=["--timing"])
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_disable_empty_outside.v
+++ b/test_regress/t/t_disable_empty_outside.v
@@ -1,0 +1,28 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2025 by Antmicro.
+// SPDX-License-Identifier: CC0-1.0
+
+module t (/*AUTOARG*/);
+   initial begin
+      begin : blk
+         int x = 0;
+         fork : fork_blk
+            begin
+            end
+            begin
+               x = 1;
+               #2;
+               x = 2;
+            end
+         join_none
+         #1;
+         disable fork_blk;
+         #2;
+         if (x != 1) $stop;
+         $write("*-* All Finished *-*\n");
+         $finish;
+      end
+   end
+endmodule

--- a/test_regress/t/t_disable_outside3.py
+++ b/test_regress/t/t_disable_outside3.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2024 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile(timing_loop=True, verilator_flags2=["--timing"])
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_disable_outside3.v
+++ b/test_regress/t/t_disable_outside3.v
@@ -1,0 +1,32 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2025 by Antmicro.
+// SPDX-License-Identifier: CC0-1.0
+
+module t (/*AUTOARG*/);
+   initial begin
+      begin : blk
+         int x = 0;
+         fork : fork_blk
+            begin
+               #4;
+               x = 3;
+            end
+            begin : begin_blk
+               x = 1;
+               #2;
+               x = 2;
+            end
+         join_none
+         #1;
+         disable fork_blk.begin_blk;
+         #2;
+         if (x != 1) $stop;
+         #2;
+         if (x != 3) $stop;
+         $write("*-* All Finished *-*\n");
+         $finish;
+      end
+   end
+endmodule

--- a/test_regress/t/t_disable_outside4.py
+++ b/test_regress/t/t_disable_outside4.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2024 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile(timing_loop=True, verilator_flags2=["--timing"])
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_disable_outside4.v
+++ b/test_regress/t/t_disable_outside4.v
@@ -1,0 +1,28 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2025 by Antmicro.
+// SPDX-License-Identifier: CC0-1.0
+
+module t (/*AUTOARG*/);
+   initial begin
+      begin : blk
+         int x = 0;
+         fork
+            begin
+               #1;
+               disable begin_blk;
+            end
+            begin : begin_blk
+               x = 1;
+               #2;
+               x = 2;
+            end
+         join_none
+         #3;
+         if (x != 1) $stop;
+         $write("*-* All Finished *-*\n");
+         $finish;
+      end
+   end
+endmodule


### PR DESCRIPTION
It adds support for disabling `begin` blocks that are directly under `fork` blocks. It does the same conversion as in https://github.com/verilator/verilator/pull/6174 but here it is done only for one block.

It also fixes disabling empty blocks. Without it, the test `t_disable_empty_outside.v` throws seg fault.

The test https://github.com/chipsalliance/sv-tests/blob/master/tests/chapter-9/9.6.2--disable_other.sv passes with my changes.