### PR TITLE
Dump function to which AstAddrOfCFunc points

### DIFF
--- a/src/V3AstNodeExpr.h
+++ b/src/V3AstNodeExpr.h
@@ -561,6 +561,7 @@ public:
 
 public:
     ASTGEN_MEMBERS_AstAddrOfCFunc;
+    void dump(std::ostream& str) const override;
     string emitVerilog() override { V3ERROR_NA_RETURN(""); }
     string emitC() override { V3ERROR_NA_RETURN(""); }
     bool cleanOut() const override { return true; }

--- a/src/V3AstNodes.cpp
+++ b/src/V3AstNodes.cpp
@@ -189,6 +189,12 @@ void AstNodeCond::numberOperate(V3Number& out, const V3Number& lhs, const V3Numb
     }
 }
 
+void AstAddrOfCFunc::dump(std::ostream& str) const {
+    this->AstNodeExpr::dump(str);
+    str << " -> ";
+    funcp()->dump(str);
+}
+
 void AstBasicDType::init(VBasicDTypeKwd kwd, VSigning numer, int wantwidth, int wantwidthmin,
                          AstRange* rangep) {
     // wantwidth=0 means figure it out, but if a widthmin is >=0


### PR DESCRIPTION
Without this change, all nodes of the `AstAddrOfCFunc` type are dumped as
```
ADDROFCFUNC 0x555556e91ad0 <e2141#> {e1ai} @dt=0x555556e54fc0@(G/w64)
```
This PR adds also functions to which they point to.