### PR TITLE
Add support for randomize..with on objects of aliased types

### DIFF
--- a/src/V3Randomize.cpp
+++ b/src/V3Randomize.cpp
@@ -2198,12 +2198,14 @@ class RandomizeVisitor final : public VNVisitor {
 
         AstClass* classp = nullptr;
         if (AstMethodCall* const callp = VN_CAST(nodep, MethodCall)) {
-            UASSERT_OBJ(callp->fromp()->dtypep(), callp->fromp(), "Object dtype is not linked");
-            AstClassRefDType* const classrefdtypep
-                = VN_CAST(callp->fromp()->dtypep()->skipRefp(), ClassRefDType);
+            const AstNodeDType* const fromDTypep = callp->fromp()->dtypep();
+            UASSERT_OBJ(fromDTypep, callp->fromp(), "Object dtype is not linked");
+            const AstClassRefDType* const classrefdtypep
+                = VN_CAST(fromDTypep->skipRefp(), ClassRefDType);
             if (!classrefdtypep) {
                 nodep->v3warn(E_UNSUPPORTED,
-                              "Inline constraints are not supported for this node type");
+                              "Inline constraints are not supported for the node type "
+                                  << fromDTypep->prettyTypeName());
                 return;
             }
             classp = classrefdtypep->classp();

--- a/src/V3Randomize.cpp
+++ b/src/V3Randomize.cpp
@@ -2202,12 +2202,9 @@ class RandomizeVisitor final : public VNVisitor {
             UASSERT_OBJ(fromDTypep, callp->fromp(), "Object dtype is not linked");
             const AstClassRefDType* const classrefdtypep
                 = VN_CAST(fromDTypep->skipRefp(), ClassRefDType);
-            if (!classrefdtypep) {
-                nodep->v3warn(E_UNSUPPORTED,
-                              "Inline constraints are not supported for the node type "
-                                  << fromDTypep->prettyTypeName());
-                return;
-            }
+            UASSERT_OBJ(classrefdtypep, callp->fromp(),
+                        "Inline constraints are not supported for the node type "
+                            << fromDTypep->prettyTypeName());
             classp = classrefdtypep->classp();
             UASSERT_OBJ(classp, classrefdtypep, "Class type is unlinked to its ref type");
         } else {

--- a/src/V3Randomize.cpp
+++ b/src/V3Randomize.cpp
@@ -2203,8 +2203,9 @@ class RandomizeVisitor final : public VNVisitor {
             const AstClassRefDType* const classrefdtypep
                 = VN_CAST(fromDTypep->skipRefp(), ClassRefDType);
             UASSERT_OBJ(classrefdtypep, callp->fromp(),
-                        "Inline constraints are not supported for the node type "
-                            << fromDTypep->prettyTypeName());
+                        "Randomize called on expression of non-class type "
+                            << fromDTypep->skipRefp()->prettyDTypeNameQ()
+                            << " (it should be detected earlier)");
             classp = classrefdtypep->classp();
             UASSERT_OBJ(classp, classrefdtypep, "Class type is unlinked to its ref type");
         } else {

--- a/src/V3Randomize.cpp
+++ b/src/V3Randomize.cpp
@@ -2200,7 +2200,7 @@ class RandomizeVisitor final : public VNVisitor {
         if (AstMethodCall* const callp = VN_CAST(nodep, MethodCall)) {
             UASSERT_OBJ(callp->fromp()->dtypep(), callp->fromp(), "Object dtype is not linked");
             AstClassRefDType* const classrefdtypep
-                = VN_CAST(callp->fromp()->dtypep(), ClassRefDType);
+                = VN_CAST(callp->fromp()->dtypep()->skipRefp(), ClassRefDType);
             if (!classrefdtypep) {
                 nodep->v3warn(E_UNSUPPORTED,
                               "Inline constraints are not supported for this node type");

--- a/test_regress/t/t_randomize_method_with.v
+++ b/test_regress/t/t_randomize_method_with.v
@@ -109,6 +109,8 @@ module mwith();
     int c = 30;
     Foo foo = new(c);
     Baz baz = new;
+    typedef Baz baz_t;
+    baz_t baz1 = new;
     Baz2 baz2 = new;
     Bar bar = new;
     Cls2 cls2 = new;
@@ -149,6 +151,7 @@ module mwith();
     if (foo.randomize() with { a > return_2(); } != 1) $stop;
     // Check randomization of class with no constraints
     if (baz.randomize() with { v inside {[2:10]}; } != 1) $stop;
+    if (baz1.randomize() with { v inside {[2:10]}; } != 1) $stop;
     // Check randomization with captured non-static variable from different AstNodeModule
     if (!bar.test_capture_of_callers_derived_var(foo)) $stop;
     // Check randomization with non-captured non-static variable from different AstNodeModule


### PR DESCRIPTION
I fixed it by adding missing call to `skipRefp`. I also added the type information to the error message and changed that error to an assert, because I think this case is now impossible to enter.