### PR TITLE
Optimize 2 ** X to 1 << X even if base is signed (#6198)

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -158,6 +158,7 @@ Martin Schmidt
 Martin Stadler
 Mateusz Gancarz
 Matthew Ballance
+Max Wipfli
 Michael Bikovitsky
 Michael Killough
 Michal Czyz

--- a/test_regress/t/t_math_pow.v
+++ b/test_regress/t/t_math_pow.v
@@ -37,7 +37,8 @@ module t (/*AUTOARG*/
    wire signed [66:0] bsw = b[66:0];
 
    // verilator lint_off WIDTH
-   wire [66:0]         shifted = 2 ** b[20:0];
+   wire [66:0] shifted        = 32'd2  ** b[20:0];
+   wire [66:0] shifted_signed = 32'sd2 ** b[20:0];
 
    wire [15:0] uiii = aui ** bui;
    wire [15:0] uiiq = aui ** buq;
@@ -358,5 +359,6 @@ module t (/*AUTOARG*/
         32'd09: `checkh(shifted, 67'h0000000000000000);
         default: ;
       endcase
+      `checkh(shifted_signed, shifted);
    end
 endmodule


### PR DESCRIPTION
This optimizes `2 ** X` into `1 << X` when `X` is unsigned. This optimization was previously only present if the base is signed (e.g., given as `32'd2` instead of `2`).

I think it is not possible to apply this same optimization in the two other cases (unsigned/signed base, *signed* exponent) due to the required behavior if the exponent is negative.