### PR TITLE
Exclude SystemC variables from DFG

### DIFF
--- a/src/V3Dfg.cpp
+++ b/src/V3Dfg.cpp
@@ -639,9 +639,6 @@ DfgVertexVar* DfgVertex::getResultVar() {
     this->forEachSink([&resp](DfgVertex& sink) {
         DfgVertexVar* const varp = sink.cast<DfgVertexVar>();
         if (!varp) return;
-        // Ignore SystemC variables, they cannot participate in expressions or
-        // be assigned rvalue expressions.
-        if (varp->varp()->isSc()) return;
         // First variable found
         if (!resp) {
             resp = varp;

--- a/src/V3Dfg.h
+++ b/src/V3Dfg.h
@@ -918,12 +918,14 @@ DfgVertexVar::DfgVertexVar(DfgGraph& dfg, VDfgType type, AstVar* varp)
     , m_varp{varp}
     , m_varScopep{nullptr} {
     UASSERT_OBJ(dfg.modulep(), varp, "Un-scoped DfgVertexVar created in scoped DfgGraph");
+    UASSERT_OBJ(!m_varp->isSc(), varp, "SystemC variable is not representable by DfgVertexVar");
 }
 DfgVertexVar::DfgVertexVar(DfgGraph& dfg, VDfgType type, AstVarScope* vscp)
     : DfgVertexUnary{dfg, type, vscp->fileline(), dtypeFor(vscp)}
     , m_varp{vscp->varp()}
     , m_varScopep{vscp} {
     UASSERT_OBJ(!dfg.modulep(), vscp, "Scoped DfgVertexVar created in un-scoped DfgGraph");
+    UASSERT_OBJ(!m_varp->isSc(), vscp, "SystemC variable is not representable by DfgVertexVar");
 }
 
 //------------------------------------------------------------------------------

--- a/src/V3DfgAstToDfg.cpp
+++ b/src/V3DfgAstToDfg.cpp
@@ -125,8 +125,9 @@ class AstToDfgVisitor final : public VNVisitor {
 
     void markReferenced(AstNode* nodep) {
         nodep->foreach([this](const AstVarRef* refp) {
-            // No need to (and in fact cannot) mark variables with unsupported dtypes
-            if (!DfgVertex::isSupportedDType(refp->varp()->dtypep())) return;
+            // No need to (and in fact cannot) mark variables if:
+            if (!DfgVertex::isSupportedDType(refp->varp()->dtypep())) return;  //  unsupported type
+            if (refp->varp()->isSc()) return;  // SystemC
             VariableType* const tgtp = getTarget(refp);
             // Mark vertex as having a module reference outside current DFG
             getNet(tgtp)->setHasModRefs();
@@ -809,6 +810,7 @@ class AstToDfgVisitor final : public VNVisitor {
             || nodep->varp()->isIfaceRef()  // Cannot handle interface references
             || nodep->varp()->delayp()  // Cannot handle delayed variables
             || nodep->classOrPackagep()  // Cannot represent cross module references
+            || nodep->varp()->isSc()  // SystemC variables are special and rare, we can ignore
         ) {
             markReferenced(nodep);
             m_foundUnhandled = true;

--- a/src/V3DfgPeephole.cpp
+++ b/src/V3DfgPeephole.cpp
@@ -1202,7 +1202,7 @@ class V3DfgPeephole final : public DfgVisitor {
     void visit(DfgArraySel* vtxp) override {
         if (DfgConst* const idxp = vtxp->bitp()->cast<DfgConst>()) {
             if (DfgVarArray* const varp = vtxp->fromp()->cast<DfgVarArray>()) {
-                if (varp->srcp() && !varp->varp()->isForced() && !varp->varp()->isSc()) {
+                if (varp->srcp() && !varp->varp()->isForced()) {
                     if (DfgSpliceArray* const splicep = varp->srcp()->cast<DfgSpliceArray>()) {
                         if (DfgVertex* const driverp = splicep->driverAt(idxp->toSizeT())) {
                             if (!driverp->is<DfgVertexSplice>()) {

--- a/src/V3DfgRegularize.cpp
+++ b/src/V3DfgRegularize.cpp
@@ -54,14 +54,6 @@ class DfgRegularize final {
                           });
                     return hasNonVarSink;
                 }
-                // Anything that drives an SC variable needs an intermediate,
-                // as we can only assign simple variables to SC variables at runtime.
-                const bool hasScSink = vtx.findSink<DfgVertexVar>([](const DfgVertexVar& var) {  //
-                    return var.varp()->isSc();
-                });
-                if (hasScSink) return true;
-                // // Splice vertices always need a variable as they represent partial updates
-                // if (vtx.is<DfgVertexSplice>()) return true;
                 // Operations without multiple sinks need no variables
                 if (!vtx.hasMultipleSinks()) return false;
                 // Array selects need no variables, they are just memory references


### PR DESCRIPTION
SystemC variables are fairly special (they can only be assigned to/from, but not otherwise participate in expressions), which complicates some DFG code. These variables only ever appear as port on the top level wrapper, so excluding them from DFG does not make us loose any optimizations, but simplifies internals.