### PR TITLE
Fix incorrect assumption in V3DfgDecomposition (#6211)

### DIFF
--- a/test_regress/t/t_dfg_circular_merged_scc.py
+++ b/test_regress/t/t_dfg_circular_merged_scc.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2025 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('vlt')
+
+test.compile()
+
+test.passes()

--- a/test_regress/t/t_dfg_circular_merged_scc.v
+++ b/test_regress/t/t_dfg_circular_merged_scc.v
@@ -1,0 +1,27 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2025 by Geza Lore.
+// SPDX-License-Identifier: CC0-1.0
+
+module mul (input [8:0] A, input [16:0] B, output [25:0] Y);
+  assign Y = $signed(A) * $signed(B);
+endmodule
+
+module A;
+  wire [26:0] C;
+  wire [26:0] D;
+  wire [8:0]  E;
+
+  // This yields a circular DFG with a fairly special form that used to trip
+  // decomposition.
+  mul mul (
+    .A(9'd10),
+    .B(17'h0cccd),
+    .Y({ C[26], C[9:0], D[15:1] })
+  );
+
+  assign E = { C[8:0] };
+  assign C[25:10] = {16{C[26]}};
+
+endmodule


### PR DESCRIPTION
Due to SCC merging the deleted assumption/assertion can be violated. Fixes #6211.
