### PR TITLE
Do not emit temporaries for atomic assignments.

### DIFF
--- a/test_regress/t/t_wide_temp_while_cond.cpp
+++ b/test_regress/t/t_wide_temp_while_cond.cpp
@@ -1,0 +1,12 @@
+// -*- mode: C++; c-file-style: "cc-mode" -*-
+//
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// Copyright 2025 by Geza Lore. This program is free software; you can
+// redistribute it and/or modify it under the terms of either the GNU
+// Lesser General Public License Version 3 or the Perl Artistic License
+// Version 2.0.
+// SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+//*************************************************************************
+
+extern "C" int identity(int x) { return x; }

--- a/test_regress/t/t_wide_temp_while_cond.py
+++ b/test_regress/t/t_wide_temp_while_cond.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2025 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile(
+    verilator_flags2=["--exe", "--main", "--timing", "--stats", "t/t_wide_temp_while_cond.cpp"])
+
+if test.vlt or test.vltmt:
+    test.file_grep(test.stats, r'Optimizations, Prelim temporary variables created\s+(\d+)', 3)
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_wide_temp_while_cond.v
+++ b/test_regress/t/t_wide_temp_while_cond.v
@@ -1,0 +1,26 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2025 by Geza Lore.
+// SPDX-License-Identifier: CC0-1.0
+
+import "DPI-C" pure function int identity(input int value);
+
+module t;
+   initial begin
+      int n = 0;
+      logic [127:0] val = 128'b1;
+      logic [15:0] one = 16'b1;
+
+      // This condition involves multiple wide temporaries, and an over-width
+      // shift, all of which requires V3Premit to fix up.
+      while (|((val[ 7'(one >> identity(32)) +: 96] << n) >> n)) begin
+        ++n;
+      end
+
+      $display("n=%0d", n);
+      if (n != 96) $stop;
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end
+endmodule


### PR DESCRIPTION
Added test for a particularly convoluted case requiring fixup in V3Premit. To help with statistics stability, also prevent V3Premit from introducing temporaries for assignment where the RHS reads the LHS, but the assignment is known to be atomic (by emitted C++ semantics).

Also rename `createWideTemp` to `createTemp`, as it is used for non-wide expressions as well.

Prep for #6216
