### PR TITLE
Switch to measuring CPU time instead of real time in test timeouts

### DIFF
--- a/test_regress/t/t_concat_string.py
+++ b/test_regress/t/t_concat_string.py
@@ -7,12 +7,11 @@
 # Version 2.0.
 # SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
 
-import signal
 import vltest_bootstrap
 
 test.scenarios('simulator')
 
-signal.alarm(15)  # 15s timeout
+test.timeout(15)
 
 test.compile()
 

--- a/test_regress/t/t_const_number_unsized_parse.py
+++ b/test_regress/t/t_const_number_unsized_parse.py
@@ -7,7 +7,6 @@
 # Version 2.0.
 # SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
 
-import signal
 import vltest_bootstrap
 
 test.scenarios('vlt')
@@ -20,7 +19,7 @@ with open(test.top_filename, "w", encoding="utf8") as f:
         f.write(f"  int x{i} = 'd{i};\n")
     f.write("endmodule\n")
 
-signal.alarm(30)  # 30s timeout
+test.timeout(30)
 
 test.lint(verilator_flags2=[f"--max-num-width {2**29}"])
 

--- a/test_regress/t/t_timeout.py
+++ b/test_regress/t/t_timeout.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2025 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('dist')
+
+test.passes()
+
+test.timeout(1)
+
+# Check whether the soft limit is set to 1s
+test.run(cmd=["bash", "-c", "\"[ '$(ulimit -St)' -eq 1 ] || exit 1\""])
+
+# Set the hard limit to 2s (in case soft limit fails) and run a command which spins until signalled
+test.run(cmd=["bash", "-c", "\"trap 'exit 0' SIGXCPU; ulimit -Ht 2; while :; do :; done\""])
+
+test.passes()


### PR DESCRIPTION
Measuring real time can cause a failure irrelevant to the test, here is how to quite reliably reproduce:
* run `stress --cpu $(nproc)` in the background
* run `make -C test_regress/ clean && ccache --clear && nice -n19 test_regress/t/t_concat_string.py`

This MR switches to measuring CPU time for test timeouts instead of real time.
This is done by using `resource.setrlimit()` - it sets the limit of this process. Because resource limits are inherited by child processes, this will do its job properly when executing Verilator from the test.