### PR TITLE
Fix dereferencing stale iterator in DfgVertex::scopep()

### DIFF
--- a/test_regress/t/t_enum_int.py
+++ b/test_regress/t/t_enum_int.py
@@ -11,7 +11,7 @@ import vltest_bootstrap
 
 test.scenarios('simulator')
 
-test.compile()
+test.compile(verilator_flags2=["--debug", "--debugi", "0", "--dumpi-tree", "0"])
 
 test.execute()
 


### PR DESCRIPTION
Fixes part of #6225
