### PR TITLE
Fix Replicate with unsigned count but MSB set

### DIFF
--- a/src/V3AstNodeExpr.h
+++ b/src/V3AstNodeExpr.h
@@ -3367,8 +3367,9 @@ public:
         : ASTGEN_SUPER_Replicate(fl, lhsp, rhsp) {
         if (lhsp) {
             if (const AstConst* const constp = VN_CAST(rhsp, Const)) {
-                if (constp->num().isFourState() || constp->num().isNegative()) {  // V3Width warns
-                    dtypeSetLogicSized(lhsp->width(), VSigning::UNSIGNED);
+                if (constp->num().isFourState()
+                    || (constp->dtypep()->isSigned() && constp->num().isNegative())) {
+                    dtypeSetLogicSized(lhsp->width(), VSigning::UNSIGNED);  // V3Width warns
                 } else {
                     dtypeSetLogicSized(lhsp->width() * constp->toSInt(), VSigning::UNSIGNED);
                 }

--- a/test_regress/t/t_dfg_peephole.v
+++ b/test_regress/t/t_dfg_peephole.v
@@ -243,6 +243,10 @@ module t (
    assign ascending_assign[4:7] = arand_b[0:3];
    `signal(ASCENDING_ASSIGN, ascending_assign);
 
+   // Special cases to be covered
+   `signal(REPLICATE_WIDTH, {4'd8{rand_a[0]}});  // Replicate count unsigned, but MSB set
+   if ($bits(REPLICATE_WIDTH) != 8) $fatal("%0d != 8", $bits(REPLICATE_WIDTH));
+
    // Sel from not requires the operand to have a sinle sink, so can't use
    // the chekc due to the raw expression referencing the operand
    wire [63:0] sel_from_not_tmp = ~(rand_a >> rand_b[2:0] << rand_a[3:0]);


### PR DESCRIPTION
Correctly compute witdh of AstReplicate in its constructor when the count is unsigned but its MSB is set.

Fixes #6231

---

It's a bit suspect that `V3Number::isNegative()` returns true if the MSB is set even if `V3Number::isSigned()` is false, however there are a couple places where we check `isNegative()` without `isSigned()`, so instead of changing that I made the AstReplicate constructor do the same a V3Width. Might be worth revisiting though to make sure there are no similar bugs elsewhere.