### PR TITLE
Add error when trying to assign class object to variable of non-class types

### DIFF
--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -7514,6 +7514,10 @@ class WidthVisitor final : public VNVisitor {
                             lhsStream ? EXTEND_OFF : EXTEND_LHS);
         // if (debug()) nodep->dumpTree("-  checkout: ");
         (void)rhsp;  // cppcheck
+        if (VN_IS(lhsDTypep, BasicDType) && VN_IS(rhsp->dtypep(), ClassRefDType)) {
+            rhsp->v3error(side << rhsp->dtypep()->prettyDTypeNameQ() << " cannot be assigned to "
+                               << lhsDTypep->prettyDTypeNameQ());
+        }
     }
 
     void iterateCheckBool(AstNode* nodep, const char* side, AstNode* underp, Stage stage) {

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -7345,7 +7345,7 @@ class WidthVisitor final : public VNVisitor {
                                 << rhsRawDTypep->prettyTypeName());
         } else if (VN_IS(rhsRawDTypep, ClassRefDType)) {
             nodep->v3error(side << " " << rhsRawDTypep->prettyDTypeNameQ()
-                                << " cannot be assigned to " << lhsDTypep->prettyDTypeNameQ());
+                                << " cannot be assigned to non-class " << lhsDTypep->prettyDTypeNameQ());
         }
         if (VN_IS(lhsRawDTypep, DynArrayDType) && VN_IS(rhsRawDTypep, UnpackArrayDType)) {
             VNRelinker relinker;

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -7343,9 +7343,8 @@ class WidthVisitor final : public VNVisitor {
             }
             nodep->v3error(side << " expects a " << lhsClassRefp->prettyTypeName() << ", got "
                                 << rhsRawDTypep->prettyTypeName());
-        }
-        if (VN_IS(lhsRawDTypep, BasicDType) && VN_IS(rhsRawDTypep, ClassRefDType)) {
-            nodep->v3error(side << " " << rhsp->dtypep()->prettyDTypeNameQ()
+        } else if (VN_IS(rhsRawDTypep, ClassRefDType)) {
+            nodep->v3error(side << " " << rhsRawDTypep->prettyDTypeNameQ()
                                 << " cannot be assigned to " << lhsDTypep->prettyDTypeNameQ());
         }
         if (VN_IS(lhsRawDTypep, DynArrayDType) && VN_IS(rhsRawDTypep, UnpackArrayDType)) {

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -7345,7 +7345,8 @@ class WidthVisitor final : public VNVisitor {
                                 << rhsRawDTypep->prettyTypeName());
         } else if (VN_IS(rhsRawDTypep, ClassRefDType)) {
             nodep->v3error(side << " " << rhsRawDTypep->prettyDTypeNameQ()
-                                << " cannot be assigned to non-class " << lhsDTypep->prettyDTypeNameQ());
+                                << " cannot be assigned to non-class "
+                                << lhsDTypep->prettyDTypeNameQ());
         }
         if (VN_IS(lhsRawDTypep, DynArrayDType) && VN_IS(rhsRawDTypep, UnpackArrayDType)) {
             VNRelinker relinker;

--- a/test_regress/t/t_class_to_basic_assignment_bad.out
+++ b/test_regress/t/t_class_to_basic_assignment_bad.out
@@ -1,5 +1,5 @@
-%Error: t/t_class_to_basic_assignment_bad.v:22:31: Assign RHS'class{}Foo' cannot be assigned to 'int'
+%Error: t/t_class_to_basic_assignment_bad.v:22:29: Assign RHS 'class{}Foo' cannot be assigned to 'int'
    22 |         new_node.phase_done = get();
-      |                               ^~~
+      |                             ^
         ... See the manual at https://verilator.org/verilator_doc.html?v=latest for more assistance.
 %Error: Exiting due to

--- a/test_regress/t/t_class_to_basic_assignment_bad.out
+++ b/test_regress/t/t_class_to_basic_assignment_bad.out
@@ -1,0 +1,5 @@
+%Error: t/t_class_to_basic_assignment_bad.v:22:31: Assign RHS'class{}Foo' cannot be assigned to 'int'
+   22 |         new_node.phase_done = get();
+      |                               ^~~
+        ... See the manual at https://verilator.org/verilator_doc.html?v=latest for more assistance.
+%Error: Exiting due to

--- a/test_regress/t/t_class_to_basic_assignment_bad.out
+++ b/test_regress/t/t_class_to_basic_assignment_bad.out
@@ -1,4 +1,4 @@
-%Error: t/t_class_to_basic_assignment_bad.v:26:29: Assign RHS 'class{}Foo' cannot be assigned to 'int'
+%Error: t/t_class_to_basic_assignment_bad.v:26:29: Assign RHS 'class{}Foo' cannot be assigned to non-class 'int'
    26 |         new_node.phase_done = get();
       |                             ^
         ... See the manual at https://verilator.org/verilator_doc.html?v=latest for more assistance.

--- a/test_regress/t/t_class_to_basic_assignment_bad.out
+++ b/test_regress/t/t_class_to_basic_assignment_bad.out
@@ -1,5 +1,5 @@
-%Error: t/t_class_to_basic_assignment_bad.v:22:29: Assign RHS 'class{}Foo' cannot be assigned to 'int'
-   22 |         new_node.phase_done = get();
+%Error: t/t_class_to_basic_assignment_bad.v:26:29: Assign RHS 'class{}Foo' cannot be assigned to 'int'
+   26 |         new_node.phase_done = get();
       |                             ^
         ... See the manual at https://verilator.org/verilator_doc.html?v=latest for more assistance.
 %Error: Exiting due to

--- a/test_regress/t/t_class_to_basic_assignment_bad.py
+++ b/test_regress/t/t_class_to_basic_assignment_bad.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2025 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('linter')
+
+test.lint(fails=True, expect_filename=test.golden_filename)
+
+test.passes()

--- a/test_regress/t/t_class_to_basic_assignment_bad.v
+++ b/test_regress/t/t_class_to_basic_assignment_bad.v
@@ -8,12 +8,16 @@ class Foo;
   int phase_done;
 
   static function Foo get();
+    Foo ans = new;
+    return ans;
   endfunction
 
   static function int create ();
+    return 3;
   endfunction
 
   function string get_name ();
+    return "bar";
   endfunction
 
   function void add(Foo phase);

--- a/test_regress/t/t_class_to_basic_assignment_bad.v
+++ b/test_regress/t/t_class_to_basic_assignment_bad.v
@@ -1,0 +1,28 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2025 by Antmicro.
+// SPDX-License-Identifier: CC0-1.0
+
+class Foo;
+  int phase_done;
+
+  static function Foo get();
+  endfunction
+
+  static function int create ();
+  endfunction
+
+  function string get_name ();
+  endfunction
+
+  function void add(Foo phase);
+    Foo new_node;
+    if (new_node.get_name() == "run") begin
+        new_node.phase_done = get();
+    end
+    else begin
+        new_node.phase_done = create();
+    end
+  endfunction
+endclass

--- a/test_regress/t/t_process_copy_constr.v
+++ b/test_regress/t/t_process_copy_constr.v
@@ -7,7 +7,7 @@
 class Cls;
    int x = 1;
    function new();
-      int p = process::self();
+      process p = process::self();
    endfunction
 endclass
 


### PR DESCRIPTION
Objects could be assigned to non-class types e.g.: int. Right now it throws an error.
Also, I've adjusted existing test case not to assign object to a basic type.