### PR TITLE
Enable EmitV to output formatted code to std::ostream

### DIFF
--- a/src/V3File.cpp
+++ b/src/V3File.cpp
@@ -640,11 +640,10 @@ bool VInFilter::readWholefile(const string& filename, VInFilter::StrList& outl) 
 }
 
 //######################################################################
-// V3OutFormatter: A class for printing to a file, with automatic indentation of C++ code.
+// V3OutFormatter: A class for printing code with automatic indentation.
 
-V3OutFormatter::V3OutFormatter(const string& filename, V3OutFormatter::Language lang)
-    : m_filename{filename}
-    , m_lang{lang} {
+V3OutFormatter::V3OutFormatter(V3OutFormatter::Language lang)
+    : m_lang{lang} {
     m_blockIndent = v3Global.opt.decoration() ? 4 : 1;
     m_commaWidth = v3Global.opt.decoration() ? 50 : 150;
 }
@@ -962,7 +961,8 @@ void V3OutFormatter::printf(const char* fmt...) {
 // V3OutFormatter: A class for printing to a file, with automatic indentation of C++ code.
 
 V3OutFile::V3OutFile(const string& filename, V3OutFormatter::Language lang)
-    : V3OutFormatter{filename, lang}
+    : V3OutFormatter{lang}
+    , m_filename{filename}
     , m_bufferp{new std::array<char, WRITE_BUFFER_SIZE_BYTES>{}} {
     if ((m_fp = V3File::new_fopen_w(filename)) == nullptr) {
         v3fatal("Can't write file: " << filename);
@@ -991,6 +991,13 @@ void V3OutCFile::putsGuard() {
     puts("\n#ifndef " + var + "\n");
     puts("#define " + var + "  // guard\n");
 }
+
+//######################################################################
+// V3OutStream
+
+V3OutStream::V3OutStream(std::ostream& ostream, V3OutFormatter::Language lang)
+    : V3OutFormatter{lang}
+    , m_ostream{ostream} {}
 
 //######################################################################
 // VIdProtect

--- a/src/V3File.h
+++ b/src/V3File.h
@@ -102,7 +102,7 @@ public:
 };
 
 //============================================================================
-// V3OutFormatter: A class for automatic indentation of C++ or Verilog code.
+// V3OutFormatter: A class for automatic indentation of output code.
 
 class V3OutFormatter VL_NOT_FINAL {
     // TYPES
@@ -113,7 +113,6 @@ public:
 
 private:
     // MEMBERS
-    const string m_filename;
     const Language m_lang;  // Indenting Verilog code
     int m_blockIndent;  // Characters per block indent
     int m_commaWidth;  // Width after which to break at ,'s
@@ -132,10 +131,9 @@ private:
     void putcNoTracking(char chr);
 
 public:
-    V3OutFormatter(const string& filename, Language lang);
+    V3OutFormatter(Language lang);
     virtual ~V3OutFormatter() = default;
     // ACCESSORS
-    string filename() const { return m_filename; }
     int column() const { return m_column; }
     int blockIndent() const { return m_blockIndent; }
     void blockIndent(int flag) { m_blockIndent = flag; }
@@ -165,7 +163,7 @@ public:
     void indentInc() { m_indentLevel += m_blockIndent; }
     void indentDec() {
         m_indentLevel -= m_blockIndent;
-        UASSERT(m_indentLevel >= 0, ": " << m_filename << ": Underflow of indentation");
+        UASSERT(m_indentLevel >= 0, "Underflow of indentation");
     }
     void blockInc() { m_parenVec.push(m_indentLevel + m_blockIndent); }
     void blockDec() {
@@ -201,6 +199,7 @@ class V3OutFile VL_NOT_FINAL : public V3OutFormatter {
     static constexpr std::size_t WRITE_BUFFER_SIZE_BYTES = 128 * 1024;
 
     // MEMBERS
+    const std::string m_filename;
     FILE* m_fp = nullptr;
     std::size_t m_usedBytes = 0;  // Number of bytes stored in m_bufferp
     std::size_t m_writtenBytes = 0;  // Number of bytes written to output
@@ -213,6 +212,8 @@ public:
     V3OutFile(V3OutFile&&) = delete;
     V3OutFile& operator=(V3OutFile&&) = delete;
     ~V3OutFile() override;
+
+    std::string filename() const { return m_filename; }
 
     void putsForceIncs();
 
@@ -428,6 +429,24 @@ public:
     }
     ~V3OutXmlFile() override = default;
     virtual void putsHeader() { puts("<?xml version=\"1.0\" ?>\n"); }
+};
+
+//============================================================================
+// V3OutStream: A class for printing formatted code to any std::ostream
+
+class V3OutStream VL_NOT_FINAL : public V3OutFormatter {
+    // MEMBERS
+    std::ostream& m_ostream;
+
+    VL_UNCOPYABLE(V3OutStream);
+    VL_UNMOVABLE(V3OutStream);
+
+public:
+    V3OutStream(std::ostream& ostream, V3OutFormatter::Language lang);
+    ~V3OutStream() override = default;
+
+    void putcOutput(char chr) override { m_ostream << chr; };
+    void putsOutput(const char* str) override { m_ostream << str; };
 };
 
 //============================================================================


### PR DESCRIPTION
Introduce V3OutStream as a V3OutFormatter that writes to a stream instead of a file. This can be used to emit formatted code fragments e.g. in debug prints and graph dumps.

Currently unused but enables EmitV to print nicely indented code. Will need this for dumping DFGs with always blocks in future patch:
![example](https://github.com/user-attachments/assets/762d3d3d-2a6e-4163-9a82-9d392f5134f7)
