### PR TITLE
Adding t_tristate_infer test

### DIFF
--- a/test_regress/t/t_tristate_infer.py
+++ b/test_regress/t/t_tristate_infer.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2025 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile()
+
+test.passes()

--- a/test_regress/t/t_tristate_infer.v
+++ b/test_regress/t/t_tristate_infer.v
@@ -1,0 +1,17 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// **If you do not wish for your code to be released to the public
+// please note it here, otherwise:**
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2025 by Wilson Snyder.
+// SPDX-License-Identifier: CC0-1.0
+
+module top (input a);
+   mod m (.*);
+endmodule
+
+module mod (input a);
+   initial assert (a !== 'z);
+endmodule 
+


### PR DESCRIPTION
This PR adds (failing) test t_tristate_infer.v

```
%Error-UNSUPPORTED: t/t_tristate_infer.v:11:8: Unsupported: tristate in top-level IO: 'a'
                                             : ... note: In instance 'top'
   11 |    mod m (.*);
      |        ^
                    ... For error description see https://verilator.org/warn/UNSUPPORTED?v=5.039
%Error: Exiting due to 1 error(s)
```

Basically, my understanding is that the comparison causes a forced type inference that propagates to the toplevel. From the verilog spec, I believe that the type should be wire regardless of any downstream comparison. This case was minimized using https://github.com/antmicro/sv-bugpoint so it's a little silly, but this is originally from BaseJump STL modules that are used in several projects.

Aside: is there a flag to disable tristate support so that this compilation doesn't fail? My current workaround is just to remove that assertion from the file (which works fine).

Thanks!