### PR TITLE
Fix coverage of variables of complex types

### DIFF
--- a/src/V3AstNodeExpr.h
+++ b/src/V3AstNodeExpr.h
@@ -3895,6 +3895,7 @@ public:
     AstNodeExpr* cloneType(AstNodeExpr* lhsp, AstNodeExpr* rhsp) override {
         return new AstNeq{fileline(), lhsp, rhsp};
     }
+    static AstNodeBiop* newTyped(FileLine* fl, AstNodeExpr* lhsp, AstNodeExpr* rhsp);
     void numberOperate(V3Number& out, const V3Number& lhs, const V3Number& rhs) override {
         out.opNeq(lhs, rhs);
     }

--- a/src/V3AstNodes.cpp
+++ b/src/V3AstNodes.cpp
@@ -317,6 +317,16 @@ AstNodeBiop* AstEqWild::newTyped(FileLine* fl, AstNodeExpr* lhsp, AstNodeExpr* r
     }
 }
 
+AstNodeBiop* AstNeq::newTyped(FileLine* fl, AstNodeExpr* lhsp, AstNodeExpr* rhsp) {
+    if (lhsp->isString() && rhsp->isString()) {
+        return new AstNeqN{fl, lhsp, rhsp};
+    } else if (lhsp->isDouble() && rhsp->isDouble()) {
+        return new AstNeqD{fl, lhsp, rhsp};
+    } else {
+        return new AstNeq{fl, lhsp, rhsp};
+    }
+}
+
 AstExecGraph::AstExecGraph(FileLine* fileline, const string& name) VL_MT_DISABLED
     : ASTGEN_SUPER_ExecGraph(fileline),
       m_depGraphp{new V3Graph},

--- a/src/V3Clock.cpp
+++ b/src/V3Clock.cpp
@@ -111,7 +111,7 @@ class ClockVisitor final : public VNVisitor {
             = VN_CAST(origp->dtypep()->skipRefp(), BasicDType)) {
             if (!bdtypep->isOpaque()) comparedp = new AstXor{nodep->fileline(), origp, changeRdp};
         }
-        if (!comparedp) comparedp = AstEq::newTyped(nodep->fileline(), origp, changeRdp);
+        if (!comparedp) comparedp = AstNeq::newTyped(nodep->fileline(), origp, changeRdp);
         AstIf* const newp = new AstIf{nodep->fileline(), comparedp, incp};
         // We could add another IF to detect posedges, and only increment if so.
         // It's another whole branch though versus a potential memory miss.

--- a/test_regress/t/t_cover_toggle.out
+++ b/test_regress/t/t_cover_toggle.out
@@ -225,6 +225,6 @@
            input_struct
            );
         
- 000011    input str_logic input_struct;
+ 000019    input str_logic input_struct;
         endmodule
         

--- a/test_regress/t/t_cover_toggle.out
+++ b/test_regress/t/t_cover_toggle.out
@@ -5,6 +5,8 @@
         // any use, without warranty, 2008 by Wilson Snyder.
         // SPDX-License-Identifier: CC0-1.0
         
+        typedef struct packed {logic a;} str_logic;
+        
         module t (/*AUTOARG*/
            // Inputs
            clk, check_real, check_array_real, check_string
@@ -27,6 +29,8 @@
         
 %000002    str_t stoggle; initial stoggle='0;
         
+ 000019    str_logic strl; initial strl='0;
+        
            union {
               real val1;  // TODO use bit [7:0] here
               real val2;  // TODO use bit [3:0] here
@@ -44,6 +48,8 @@
               int q[$];
            } str_queue_t;
            str_queue_t str_queue;
+        
+           assign strl.a = clk;
         
            alpha a1 (/*AUTOINST*/
                      // Outputs
@@ -79,6 +85,11 @@
                         // Inputs
                         .clk                    (clk),
                         .toggle                 (toggle));
+        
+           mod_struct i_mod_struct (/*AUTOINST*/
+                                    // Inputs
+                                    .input_struct   (strl));
+        
         
 %000001    reg [1:0]  memory[121:110];
         
@@ -207,5 +218,13 @@
            if (P > 1) begin : gen_1
               assign z = 1;
            end
+        endmodule
+        
+        module mod_struct(/*AUTOARG*/
+           // Inputs
+           input_struct
+           );
+        
+ 000011    input str_logic input_struct;
         endmodule
         

--- a/test_regress/t/t_cover_toggle.v
+++ b/test_regress/t/t_cover_toggle.v
@@ -4,6 +4,8 @@
 // any use, without warranty, 2008 by Wilson Snyder.
 // SPDX-License-Identifier: CC0-1.0
 
+typedef struct packed {logic a;} str_logic;
+
 module t (/*AUTOARG*/
    // Inputs
    clk, check_real, check_array_real, check_string
@@ -26,6 +28,8 @@ module t (/*AUTOARG*/
 
    str_t stoggle; initial stoggle='0;
 
+   str_logic strl; initial strl='0;
+
    union {
       real val1;  // TODO use bit [7:0] here
       real val2;  // TODO use bit [3:0] here
@@ -43,6 +47,8 @@ module t (/*AUTOARG*/
       int q[$];
    } str_queue_t;
    str_queue_t str_queue;
+
+   assign strl.a = clk;
 
    alpha a1 (/*AUTOINST*/
              // Outputs
@@ -78,6 +84,11 @@ module t (/*AUTOARG*/
                 // Inputs
                 .clk                    (clk),
                 .toggle                 (toggle));
+
+   mod_struct i_mod_struct (/*AUTOINST*/
+                            // Inputs
+                            .input_struct   (strl));
+
 
    reg [1:0]  memory[121:110];
 
@@ -206,4 +217,12 @@ module param #(parameter P = 2) (/*AUTOARG*/
    if (P > 1) begin : gen_1
       assign z = 1;
    end
+endmodule
+
+module mod_struct(/*AUTOARG*/
+   // Inputs
+   input_struct
+   );
+
+   input str_logic input_struct;
 endmodule

--- a/test_regress/t/t_cover_toggle__points.out
+++ b/test_regress/t/t_cover_toggle__points.out
@@ -318,7 +318,7 @@
            input_struct
            );
         
- 000011    input str_logic input_struct;
-+000011  point: comment=input_struct.a hier=top.t.i_mod_struct
+ 000019    input str_logic input_struct;
++000019  point: comment=input_struct.a hier=top.t.i_mod_struct
         endmodule
         

--- a/test_regress/t/t_cover_toggle__points.out
+++ b/test_regress/t/t_cover_toggle__points.out
@@ -5,6 +5,8 @@
         // any use, without warranty, 2008 by Wilson Snyder.
         // SPDX-License-Identifier: CC0-1.0
         
+        typedef struct packed {logic a;} str_logic;
+        
         module t (/*AUTOARG*/
            // Inputs
            clk, check_real, check_array_real, check_string
@@ -30,6 +32,9 @@
 %000002    str_t stoggle; initial stoggle='0;
 -000002  point: comment=stoggle.b hier=top.t
 -000002  point: comment=stoggle.u.ua hier=top.t
+        
+ 000019    str_logic strl; initial strl='0;
++000019  point: comment=strl.a hier=top.t
         
            union {
               real val1;  // TODO use bit [7:0] here
@@ -61,6 +66,8 @@
               int q[$];
            } str_queue_t;
            str_queue_t str_queue;
+        
+           assign strl.a = clk;
         
            alpha a1 (/*AUTOINST*/
                      // Outputs
@@ -96,6 +103,11 @@
                         // Inputs
                         .clk                    (clk),
                         .toggle                 (toggle));
+        
+           mod_struct i_mod_struct (/*AUTOINST*/
+                                    // Inputs
+                                    .input_struct   (strl));
+        
         
 %000001    reg [1:0]  memory[121:110];
 -000001  point: comment=memory[110][0] hier=top.t
@@ -299,5 +311,14 @@
            if (P > 1) begin : gen_1
               assign z = 1;
            end
+        endmodule
+        
+        module mod_struct(/*AUTOARG*/
+           // Inputs
+           input_struct
+           );
+        
+ 000011    input str_logic input_struct;
++000011  point: comment=input_struct.a hier=top.t.i_mod_struct
         endmodule
         


### PR DESCRIPTION
It is a pre-pull to https://github.com/verilator/verilator/pull/6110.

During the work on that issue I noticed that the case with complex types is handled wrong, but I thought it is unreachable, so I replaced it with an assert, which failed on VeeR. I was able to reproduce it on master on an example with 1-bit struct. The problem doesn't occur on wider structs, because only 1-bit expressions may be children of `AstCoverToggle`.