### PR TITLE
Fix partial DFG conversion of concat assignments (#4231)

### DIFF
--- a/test_regress/t/t_hier_block_chained.v
+++ b/test_regress/t/t_hier_block_chained.v
@@ -20,7 +20,9 @@ module t (clk);
    reg [255:0] v1_5;
    reg [255:0] v1_6;
    reg [255:0] v1_7;
+   // verilator lint_off MULTIDRIVEN
    reg [255:0] dummy;
+   // verilator lint_on MULTIDRIVEN
 
    Calculate calc0(.clk(clk), .reset(reset), .v1_0(v1_0), .v1_1(dummy), .v1_2(dummy), .v1_3(dummy), .v1_4(dummy), .v1_5(dummy), .v1_6(dummy), .v1_7(dummy));
    Calculate calc1(.clk(clk), .reset(reset), .v1_0(dummy), .v1_1(v1_1), .v1_2(dummy), .v1_3(dummy), .v1_4(dummy), .v1_5(dummy), .v1_6(dummy), .v1_7(dummy));


### PR DESCRIPTION
When we had a `{a, b} = ...`, and the DFG conversion of `a = ...` succeeded, but `b = ...` failed, we still used to include `a = ...` in the DFG, which then caused a spurious multi-driver error for `a` on a subsequent DFG pass, as the original `{a, b} = ...` was still present in the Ast, but we also had the extra `a = ...` from converting out of DFG on the previous pass.

In this patch we only convert assignments with a concatenation on the LHS, if all target LValues can be converted into DFG.

This is the proper fix for #4231
