### PR TITLE
Refactor Dfg variable flags.

### DIFF
--- a/src/V3DfgDecomposition.cpp
+++ b/src/V3DfgDecomposition.cpp
@@ -330,13 +330,10 @@ class ExtractCyclicComponents final {
                 }
             }
             UASSERT_OBJ(clonep, &vtx, "Unhandled 'DfgVertexVar' sub-type");
-            if (vtx.hasModRefs()) clonep->setHasModRefs();
-            if (vtx.hasExtRefs()) clonep->setHasExtRefs();
             VertexState& cloneStatep = allocState(*clonep);
             cloneStatep.component = component;
-            // We need to mark both the original and the clone as having references in other DFGs
+            // Mark variable as having references in other DFGs
             vtx.setHasDfgRefs();
-            clonep->setHasDfgRefs();
         }
         return *clonep;
     }

--- a/src/V3DfgDfgToAst.cpp
+++ b/src/V3DfgDfgToAst.cpp
@@ -129,8 +129,8 @@ template <bool T_Scoped>
 class DfgToAstVisitor final : DfgVisitor {
     // NODE STATE
 
-    // AstScope::user1p  // The combinational AstActive under this scope
-    const VNUser1InUse m_user1InUse;
+    // AstScope::user2p  // The combinational AstActive under this scope
+    const VNUser2InUse m_user2InUse;
 
     // TYPES
     using VariableType = std::conditional_t<T_Scoped, AstVarScope, AstVar>;
@@ -152,28 +152,28 @@ class DfgToAstVisitor final : DfgVisitor {
     }
 
     static AstActive* getCombActive(AstScope* scopep) {
-        if (!scopep->user1p()) {
+        if (!scopep->user2p()) {
             // Try to find the existing combinational AstActive
             for (AstNode* nodep = scopep->blocksp(); nodep; nodep = nodep->nextp()) {
                 AstActive* const activep = VN_CAST(nodep, Active);
                 if (!activep) continue;
                 if (activep->hasCombo()) {
-                    scopep->user1p(activep);
+                    scopep->user2p(activep);
                     break;
                 }
             }
             // If there isn't one, create a new one
-            if (!scopep->user1p()) {
+            if (!scopep->user2p()) {
                 FileLine* const flp = scopep->fileline();
                 AstSenTree* const senTreep
                     = new AstSenTree{flp, new AstSenItem{flp, AstSenItem::Combo{}}};
                 AstActive* const activep = new AstActive{flp, "", senTreep};
                 activep->sensesStorep(senTreep);
                 scopep->addBlocksp(activep);
-                scopep->user1p(activep);
+                scopep->user2p(activep);
             }
         }
-        return VN_AS(scopep->user1p(), Active);
+        return VN_AS(scopep->user2p(), Active);
     }
 
     AstNodeExpr* convertDfgVertexToAstNodeExpr(DfgVertex* vtxp) {

--- a/src/astgen
+++ b/src/astgen
@@ -1250,13 +1250,13 @@ def write_dfg_ast_to_dfg(filename):
                 continue
 
             fh.write("void visit(Ast{t}* nodep) override {{\n".format(t=node.name))
-            fh.write('    UASSERT_OBJ(!nodep->user1p(), nodep, "Already has Dfg vertex");\n\n')
+            fh.write('    UASSERT_OBJ(!nodep->user2p(), nodep, "Already has Dfg vertex");\n\n')
             fh.write("    if (unhandled(nodep)) return;\n\n")
             for i in range(node.arity):
                 fh.write("    iterate(nodep->op{j}p());\n".format(j=i + 1))
                 fh.write("    if (m_foundUnhandled) return;\n")
                 fh.write(
-                    '    UASSERT_OBJ(nodep->op{j}p()->user1p(), nodep, "Child {j} missing Dfg vertex");\n'
+                    '    UASSERT_OBJ(nodep->op{j}p()->user2p(), nodep, "Child {j} missing Dfg vertex");\n'
                     .format(j=i + 1))
             fh.write("\n")
             fh.write("    Dfg{t}* const vtxp = makeVertex<Dfg{t}>(nodep, *m_dfgp);\n".format(
@@ -1268,11 +1268,11 @@ def write_dfg_ast_to_dfg(filename):
             fh.write("    }\n\n")
             for i in range(node.arity):
                 fh.write(
-                    "    vtxp->relinkSource<{i}>(nodep->op{j}p()->user1u().to<DfgVertex*>());\n".
+                    "    vtxp->relinkSource<{i}>(nodep->op{j}p()->user2u().to<DfgVertex*>());\n".
                     format(i=i, j=i + 1))
             fh.write("\n")
             fh.write("    m_uncommittedVertices.push_back(vtxp);\n")
-            fh.write("    nodep->user1p(vtxp);\n")
+            fh.write("    nodep->user2p(vtxp);\n")
             fh.write("}\n")
 
 


### PR DESCRIPTION
Store all flags in a DfgVertexVar relating to the underlying AstVar/AstVarScope stored via AstNode::user1(). user2/user3/user4 are then usable by DFG algorithms as needed.

No functional change. Will merge when tests passing.