### PR TITLE
Unify the two DFG cycle finding algorithms.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -230,6 +230,7 @@ set(COMMON_SOURCES
     V3DfgAstToDfg.cpp
     V3DfgBreakCycles.cpp
     V3DfgCache.cpp
+    V3DfgColorSCCs.cpp
     V3DfgDecomposition.cpp
     V3DfgDfgToAst.cpp
     V3DfgOptimizer.cpp

--- a/src/Makefile_obj.in
+++ b/src/Makefile_obj.in
@@ -242,6 +242,7 @@ RAW_OBJS_PCH_ASTNOMT = \
   V3DfgAstToDfg.o \
   V3DfgBreakCycles.o \
   V3DfgCache.o \
+  V3DfgColorSCCs.o \
   V3DfgDecomposition.o \
   V3DfgDfgToAst.o \
   V3DfgOptimizer.o \

--- a/src/V3DfgColorSCCs.cpp
+++ b/src/V3DfgColorSCCs.cpp
@@ -1,0 +1,156 @@
+// -*- mode: C++; c-file-style: "cc-mode" -*-
+//*************************************************************************
+// DESCRIPTION: Verilator: Cycle finding algorithm for DfgGraph
+//
+// Code available from: https://verilator.org
+//
+//*************************************************************************
+//
+// Copyright 2003-2025 by Wilson Snyder. This program is free software; you
+// can redistribute it and/or modify it under the terms of either the GNU
+// Lesser General Public License Version 3 or the Perl Artistic License
+// Version 2.0.
+// SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+//
+//*************************************************************************
+//
+// Implements Pearce's algorithm to color the strongly connected components. For reference
+// see "An Improved Algorithm for Finding the Strongly Connected Components of a Directed
+// Graph", David J.Pearce, 2005.
+//
+//*************************************************************************
+
+#include "V3Dfg.h"
+#include "V3DfgPasses.h"
+
+#include <limits>
+#include <vector>
+
+// Similar algorithm used in ExtractCyclicComponents.
+// This one sets DfgVertex::user(). See the static 'apply' method below.
+class ColorStronglyConnectedComponents final {
+    static constexpr uint32_t UNASSIGNED = std::numeric_limits<uint32_t>::max();
+
+    // TYPES
+    struct VertexState final {
+        uint32_t component = UNASSIGNED;  // Result component number (0 means not in SCC)
+        uint32_t index = UNASSIGNED;  // Used by Pearce's algorithm for detecting SCCs
+        VertexState() = default;
+        VertexState(uint32_t i, uint32_t n)
+            : component{n}
+            , index{i} {}
+    };
+
+    // STATE
+    DfgGraph& m_dfg;  // The input graph
+    uint32_t m_nonTrivialSCCs = 0;  // Number of non-trivial SCCs in the graph
+    uint32_t m_index = 0;  // Visitation index counter
+    std::vector<DfgVertex*> m_stack;  // The stack used by the algorithm
+
+    // METHODS
+    void visitColorSCCs(DfgVertex& vtx, VertexState& vtxState) {
+        UDEBUGONLY(UASSERT_OBJ(vtxState.index == UNASSIGNED, &vtx, "Already visited vertex"););
+
+        // Visiting vertex
+        const size_t rootIndex = vtxState.index = ++m_index;
+
+        // Visit children
+        vtx.forEachSink([&](DfgVertex& child) {
+            VertexState& childSatate = child.user<VertexState>();
+            // If the child has not yet been visited, then continue traversal
+            if (childSatate.index == UNASSIGNED) visitColorSCCs(child, childSatate);
+            // If the child is not in an SCC
+            if (childSatate.component == UNASSIGNED) {
+                if (vtxState.index > childSatate.index) vtxState.index = childSatate.index;
+            }
+        });
+
+        if (vtxState.index == rootIndex) {
+            // This is the 'root' of an SCC
+
+            // A trivial SCC contains only a single vertex
+            const bool isTrivial = m_stack.empty()  //
+                                   || m_stack.back()->getUser<VertexState>().index < rootIndex;
+            // We also need a separate component for vertices that drive themselves (which can
+            // happen for input like 'assign a = a'), as we want to extract them (they are cyclic).
+            const bool drivesSelf = vtx.findSink<DfgVertex>([&vtx](const DfgVertex& sink) {  //
+                return &vtx == &sink;
+            });
+
+            if (!isTrivial || drivesSelf) {
+                // Allocate new component
+                ++m_nonTrivialSCCs;
+                vtxState.component = m_nonTrivialSCCs;
+                while (!m_stack.empty()) {
+                    VertexState& topState = m_stack.back()->getUser<VertexState>();
+                    // Only higher nodes belong to the same SCC
+                    if (topState.index < rootIndex) break;
+                    m_stack.pop_back();
+                    topState.component = m_nonTrivialSCCs;
+                }
+            } else {
+                // Trivial SCC (and does not drive itself), so acyclic. Keep it in original graph.
+                vtxState.component = 0;
+            }
+        } else {
+            // Not the root of an SCC
+            m_stack.push_back(&vtx);
+        }
+    }
+
+    void colorSCCs() {
+        // We know constant nodes have no input edges, so they cannot be part
+        // of a non-trivial SCC. Mark them as such without any real traversals.
+        for (DfgConst& vtx : m_dfg.constVertices()) vtx.setUser(VertexState{0, 0});
+
+        // Start traversals through variables
+        for (DfgVertexVar& vtx : m_dfg.varVertices()) {
+            VertexState& vtxState = vtx.user<VertexState>();
+            // If it has no input or no outputs, it cannot be part of a non-trivial SCC.
+            if (vtx.arity() == 0 || !vtx.hasSinks()) {
+                UDEBUGONLY(UASSERT_OBJ(vtxState.index == UNASSIGNED || vtxState.component == 0,
+                                       &vtx, "Non circular variable must be in a trivial SCC"););
+                vtxState.index = 0;
+                vtxState.component = 0;
+                continue;
+            }
+            // If not yet visited, start a traversal
+            if (vtxState.index == UNASSIGNED) visitColorSCCs(vtx, vtxState);
+        }
+
+        // Start traversals through operations
+        for (DfgVertex& vtx : m_dfg.opVertices()) {
+            VertexState& vtxState = vtx.user<VertexState>();
+            // If not yet visited, start a traversal
+            if (vtxState.index == UNASSIGNED) visitColorSCCs(vtx, vtxState);
+        }
+    }
+
+    ColorStronglyConnectedComponents(DfgGraph& dfg)
+        : m_dfg{dfg} {
+        UASSERT(dfg.size() < UNASSIGNED, "Graph too big " << dfg.name());
+        // Yet another implementation of Pearce's algorithm.
+        colorSCCs();
+        // Re-assign user values
+        m_dfg.forEachVertex([](DfgVertex& vtx) {
+            const uint64_t component = vtx.getUser<VertexState>().component;
+            vtx.setUser<uint64_t>(component);
+        });
+    }
+
+public:
+    // Sets DfgVertex::user<uint64_t>() for all vertext to:
+    // - 0, if the vertex is not part of a non-trivial strongly connected component
+    //   and is not part of a self-loop. That is: the Vertex is not part of any cycle.
+    // - N, if the vertex is part of a non-trivial strongly conneced component or self-loop N.
+    //   That is: each set of vertices that are reachable from each other will have the same
+    //   non-zero value assigned.
+    // Returns the number of non-trivial SCCs (~distinct cycles)
+    static uint32_t apply(DfgGraph& dfg) {
+        return ColorStronglyConnectedComponents{dfg}.m_nonTrivialSCCs;
+    }
+};
+
+uint32_t V3DfgPasses::colorStronglyConnectedComponents(DfgGraph& dfg) {
+    return ColorStronglyConnectedComponents::apply(dfg);
+}

--- a/src/V3DfgDecomposition.cpp
+++ b/src/V3DfgDecomposition.cpp
@@ -21,6 +21,7 @@
 #include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
 #include "V3Dfg.h"
+#include "V3DfgPasses.h"
 #include "V3File.h"
 
 #include <deque>
@@ -117,173 +118,42 @@ std::vector<std::unique_ptr<DfgGraph>> DfgGraph::splitIntoComponents(std::string
 }
 
 class ExtractCyclicComponents final {
-    static constexpr size_t UNASSIGNED = std::numeric_limits<size_t>::max();
-
     // TYPES
-    struct VertexState final {
-        size_t index = UNASSIGNED;  // Used by Pearce's algorithm for detecting SCCs
-        size_t component = UNASSIGNED;  // Result component number (0 stays in input graph)
-        bool merged = false;  // Visited in the merging pass
-        VertexState(){};
+    // We reuse the DfgVertex::user state set by V3DfgPasses::colorStronglyConnectedComponents.
+    // We sneak an extra flag into the MSB to indicate the vertex was merged already.
+    class VertexState final {
+        uint64_t& m_userr;
+
+    public:
+        VertexState(DfgVertex& vtx)
+            : m_userr{vtx.getUser<uint64_t>()} {}
+        bool merged() const { return m_userr >> 63; }
+        void setMerged() { m_userr |= 1ULL << 63; }
+        uint64_t component() const { return m_userr & ~(1ULL << 63); }
+        void component(uint64_t value) { m_userr = (m_userr & (1ULL << 63)) | value; }
     };
 
     // STATE
-
-    //==========================================================================
-    // Shared state
-
     DfgGraph& m_dfg;  // The input graph
-    std::deque<VertexState> m_stateStorage;  // Container for VertexState instances
     const std::string m_prefix;  // Component name prefix
-    size_t m_nonTrivialSCCs = 0;  // Number of non-trivial SCCs in the graph
     const bool m_doExpensiveChecks = v3Global.opt.debugCheck();
-
-    //==========================================================================
-    // State for Pearce's algorithm for detecting SCCs
-
-    size_t m_index = 0;  // Visitation index counter
-    std::vector<DfgVertex*> m_stack;  // The stack used by the algorithm
-
-    //==========================================================================
-    // State for extraction
-
     // The extracted cyclic components
     std::vector<std::unique_ptr<DfgGraph>> m_components;
     // Map from 'variable vertex' -> 'component index' -> 'clone in that component'
-    std::unordered_map<const DfgVertexVar*, std::unordered_map<size_t, DfgVertexVar*>> m_clones;
+    std::unordered_map<const DfgVertexVar*, std::unordered_map<uint64_t, DfgVertexVar*>> m_clones;
 
     // METHODS
-
-    //==========================================================================
-    // Shared methods
-
-    VertexState& state(DfgVertex& vtx) const { return *vtx.getUser<VertexState*>(); }
-
-    VertexState& allocState(DfgVertex& vtx) {
-        VertexState*& statep = vtx.user<VertexState*>();
-        UASSERT_OBJ(!statep, &vtx, "Vertex state already allocated " << cvtToHex(statep));
-        m_stateStorage.emplace_back();
-        statep = &m_stateStorage.back();
-        return *statep;
-    }
-
-    VertexState& getOrAllocState(DfgVertex& vtx) {
-        VertexState*& statep = vtx.user<VertexState*>();
-        if (!statep) {
-            m_stateStorage.emplace_back();
-            statep = &m_stateStorage.back();
-        }
-        return *statep;
-    }
-
-    //==========================================================================
-    // Methods for Pearce's algorithm to detect strongly connected components
-
-    void visitColorSCCs(DfgVertex& vtx, VertexState& vtxState) {
-        UDEBUGONLY(UASSERT_OBJ(vtxState.index == UNASSIGNED, &vtx, "Already visited vertex"););
-
-        // Visiting vertex
-        const size_t rootIndex = vtxState.index = ++m_index;
-
-        // Visit children
-        vtx.forEachSink([&](DfgVertex& child) {
-            VertexState& childSatate = getOrAllocState(child);
-            // If the child has not yet been visited, then continue traversal
-            if (childSatate.index == UNASSIGNED) visitColorSCCs(child, childSatate);
-            // If the child is not in an SCC
-            if (childSatate.component == UNASSIGNED) {
-                if (vtxState.index > childSatate.index) vtxState.index = childSatate.index;
-            }
-        });
-
-        if (vtxState.index == rootIndex) {
-            // This is the 'root' of an SCC
-
-            // A trivial SCC contains only a single vertex
-            const bool isTrivial = m_stack.empty() || state(*m_stack.back()).index < rootIndex;
-            // We also need a separate component for vertices that drive themselves (which can
-            // happen for input like 'assign a = a'), as we want to extract them (they are cyclic).
-            const bool drivesSelf = vtx.findSink<DfgVertex>([&vtx](const DfgVertex& sink) {  //
-                return &vtx == &sink;
-            });
-
-            if (!isTrivial || drivesSelf) {
-                // Allocate new component
-                ++m_nonTrivialSCCs;
-                vtxState.component = m_nonTrivialSCCs;
-                while (!m_stack.empty()) {
-                    VertexState& topState = state(*m_stack.back());
-                    // Only higher nodes belong to the same SCC
-                    if (topState.index < rootIndex) break;
-                    m_stack.pop_back();
-                    topState.component = m_nonTrivialSCCs;
-                }
-            } else {
-                // Trivial SCC (and does not drive itself), so acyclic. Keep it in original graph.
-                vtxState.component = 0;
-            }
-        } else {
-            // Not the root of an SCC
-            m_stack.push_back(&vtx);
-        }
-    }
-
-    void colorSCCs() {
-        // Implements Pearce's algorithm to color the strongly connected components. For reference
-        // see "An Improved Algorithm for Finding the Strongly Connected Components of a Directed
-        // Graph", David J.Pearce, 2005.
-
-        // We can leverage some properties of the input graph to gain a bit of speed. Firstly, we
-        // know constant nodes have no in edges, so they cannot be part of a non-trivial SCC. Mark
-        // them as such without starting a whole traversal.
-        for (DfgConst& vtx : m_dfg.constVertices()) {
-            VertexState& vtxState = allocState(vtx);
-            vtxState.index = 0;
-            vtxState.component = 0;
-        }
-
-        // Next, we know that all SCCs must include a variable (as the input graph was converted
-        // from an AST, we can only have a cycle by going through a variable), so we only start
-        // traversals through them, and only if we know they have both in and out edges.
-        for (DfgVertexVar& vtx : m_dfg.varVertices()) {
-            if (vtx.arity() > 0 && vtx.hasSinks()) {
-                VertexState& vtxState = getOrAllocState(vtx);
-                // If not yet visited, start a traversal
-                if (vtxState.index == UNASSIGNED) visitColorSCCs(vtx, vtxState);
-            } else {
-                VertexState& vtxState = getOrAllocState(vtx);
-                UDEBUGONLY(UASSERT_OBJ(vtxState.index == UNASSIGNED || vtxState.component == 0,
-                                       &vtx, "Non circular variable must be in a trivial SCC"););
-                vtxState.index = 0;
-                vtxState.component = 0;
-            }
-        }
-
-        // Finally, everything we did not visit through the traversal of a variable cannot be in an
-        // SCC, (otherwise we would have found it from a variable).
-        for (DfgVertex& vtx : m_dfg.opVertices()) {
-            VertexState& vtxState = getOrAllocState(vtx);
-            if (vtxState.index == UNASSIGNED) {
-                vtxState.index = 0;
-                vtxState.component = 0;
-            }
-        }
-    }
-
-    //==========================================================================
-    // Methods for merging
-
-    void visitMergeSCCs(DfgVertex& vtx, size_t targetComponent) {
-        VertexState& vtxState = state(vtx);
+    void visitMergeSCCs(DfgVertex& vtx, uint64_t targetComponent) {
+        VertexState vtxState{vtx};
 
         // Move on if already visited
-        if (vtxState.merged) return;
+        if (vtxState.merged()) return;
 
         // Visiting vertex
-        vtxState.merged = true;
+        vtxState.setMerged();
 
         // Assign vertex to the target component
-        vtxState.component = targetComponent;
+        vtxState.component(targetComponent);
 
         // Visit all neighbors. We stop at variable boundaries,
         // which is where we will split the graphs
@@ -304,16 +174,14 @@ class ExtractCyclicComponents final {
         for (DfgVertex& vtx : m_dfg.opVertices()) {
             // Start DFS from each vertex that is in a non-trivial SCC, and merge everything
             // that is reachable from it into this component.
-            if (const size_t target = state(vtx).component) visitMergeSCCs(vtx, target);
+            if (const uint64_t target = VertexState{vtx}.component()) visitMergeSCCs(vtx, target);
         }
     }
 
-    //==========================================================================
-    // Methods for extraction
-
     // Retrieve clone of vertex in the given component
-    DfgVertexVar& getClone(DfgVertexVar& vtx, size_t component) {
-        UASSERT_OBJ(state(vtx).component != component, &vtx, "Vertex is in that component");
+    DfgVertexVar& getClone(DfgVertexVar& vtx, uint64_t component) {
+        UASSERT_OBJ(VertexState{vtx}.component() != component, &vtx,
+                    "Vertex is in that component");
         DfgVertexVar*& clonep = m_clones[&vtx][component];
         if (!clonep) {
             if (DfgVarPacked* const pVtxp = vtx.cast<DfgVarPacked>()) {
@@ -330,21 +198,20 @@ class ExtractCyclicComponents final {
                 }
             }
             UASSERT_OBJ(clonep, &vtx, "Unhandled 'DfgVertexVar' sub-type");
-            VertexState& cloneStatep = allocState(*clonep);
-            cloneStatep.component = component;
+            clonep->setUser<uint64_t>(component);
         }
         return *clonep;
     }
 
     // Fix edges that cross components
     void fixEdges(DfgVertexVar& vtx) {
-        const size_t component = state(vtx).component;
+        const uint64_t component = VertexState{vtx}.component();
 
         // Fix up sources in a different component
         vtx.forEachSourceEdge([&](DfgEdge& edge, size_t) {
             DfgVertex* const srcp = edge.sourcep();
             if (!srcp) return;
-            const size_t sourceComponent = state(*srcp).component;
+            const uint64_t sourceComponent = VertexState{*srcp}.component();
             // Same component is OK
             if (sourceComponent == component) return;
             // Relink the source to write the clone
@@ -354,7 +221,7 @@ class ExtractCyclicComponents final {
 
         // Fix up sinks in a different component
         vtx.forEachSinkEdge([&](DfgEdge& edge) {
-            const size_t sinkComponent = state(*edge.sinkp()).component;
+            const uint64_t sinkComponent = VertexState{*edge.sinkp()}.component();
             // Same component is OK
             if (sinkComponent == component) return;
             // Relink the sink to read the clone
@@ -366,7 +233,7 @@ class ExtractCyclicComponents final {
     void moveVertices(DfgVertex::List<Vertex>& list) {
         for (DfgVertex* const vtxp : list.unlinkable()) {
             DfgVertex& vtx = *vtxp;
-            if (const size_t component = state(vtx).component) {
+            if (const uint64_t component = VertexState{vtx}.component()) {
                 m_dfg.removeVertex(vtx);
                 m_components[component - 1]->addVertex(vtx);
             }
@@ -378,15 +245,15 @@ class ExtractCyclicComponents final {
         // - Edges only cross components at variable boundaries
         // - Variable vertex sources are all connected.
         dfg.forEachVertex([&](DfgVertex& vtx) {
-            const size_t component = state(vtx).component;
+            const uint64_t component = VertexState{vtx}.component();
             vtx.forEachSource([&](DfgVertex& src) {
                 if (src.is<DfgVertexVar>()) return;  // OK to cross at variables
-                UASSERT_OBJ(component == state(src).component, &vtx,
+                UASSERT_OBJ(component == VertexState{src}.component(), &vtx,
                             "Edge crossing components without variable involvement");
             });
             vtx.forEachSink([&](DfgVertex& snk) {
                 if (snk.is<DfgVertexVar>()) return;  // OK to cross at variables
-                UASSERT_OBJ(component == state(snk).component, &vtx,
+                UASSERT_OBJ(component == VertexState{snk}.component(), &vtx,
                             "Edge crossing components without variable involvement");
             });
         });
@@ -408,10 +275,10 @@ class ExtractCyclicComponents final {
         });
     }
 
-    void extractComponents() {
+    void extractComponents(uint32_t numNonTrivialSCCs) {
         // Allocate result graphs
-        m_components.resize(m_nonTrivialSCCs);
-        for (size_t i = 0; i < m_nonTrivialSCCs; ++i) {
+        m_components.resize(numNonTrivialSCCs);
+        for (uint32_t i = 0; i < numNonTrivialSCCs; ++i) {
             m_components[i].reset(new DfgGraph{m_dfg.modulep(), m_prefix + cvtToStr(i)});
         }
 
@@ -450,17 +317,17 @@ class ExtractCyclicComponents final {
     explicit ExtractCyclicComponents(DfgGraph& dfg, const std::string& label)
         : m_dfg{dfg}
         , m_prefix{dfg.name() + (label.empty() ? "" : "-") + label + "-component-"} {
-        // VertexState is stored as user data
+        // DfgVertex::user<uint64_t> is set to the SCC number by colorStronglyConnectedComponents,
+        // Then we use VertexState to handle the MSB as an extra flag.
         const auto userDataInUse = dfg.userDataInUse();
         // Find all the non-trivial SCCs (and trivial cycles) in the graph
-        colorSCCs();
-        // If the graph was acyclic (which should be the common case),
-        // there will be no non-trivial SCCs, so we are done.
-        if (!m_nonTrivialSCCs) return;
+        const uint32_t numNonTrivialSCCs = V3DfgPasses::colorStronglyConnectedComponents(dfg);
+        // If the graph was acyclic (which should be the common case), then we are done.
+        if (!numNonTrivialSCCs) return;
         // Ensure that component boundaries are always at variables, by merging SCCs
         mergeSCCs();
         // Extract the components
-        extractComponents();
+        extractComponents(numNonTrivialSCCs);
     }
 
 public:

--- a/src/V3DfgPasses.h
+++ b/src/V3DfgPasses.h
@@ -60,6 +60,14 @@ void dfgToAst(DfgGraph&, V3DfgContext&) VL_MT_DISABLED;
 
 // Construct binary to oneHot decoders
 void binToOneHot(DfgGraph&, V3DfgBinToOneHotContext&) VL_MT_DISABLED;
+// Sets DfgVertex::user<uint64_t>() for all vertext to:
+// - 0, if the vertex is not part of a non-trivial strongly connected component
+//   and is not part of a self-loop. That is: the Vertex is not part of any cycle.
+// - N, if the vertex is part of a non-trivial strongly conneced component or self-loop N.
+//   That is: each set of vertices that are reachable from each other will have the same
+//   non-zero value assigned.
+// Returns the number of non-trivial SCCs (distinct cycles)
+uint32_t colorStronglyConnectedComponents(DfgGraph&) VL_MT_DISABLED;
 // Common subexpression elimination
 void cse(DfgGraph&, V3DfgCseContext&) VL_MT_DISABLED;
 // Inline fully driven variables


### PR DESCRIPTION
Both V3DfgBreakCycles.cpp and V3DfgDecomposition.cpp used to contain an implementation of the same algorithm to color strongly connected components. Now there is only one, and it lives in V3DfgColorSCCs.cpp.