### PR TITLE
Support constant parameter ranges

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -163,6 +163,7 @@ Matthew Ballance
 Max Wipfli
 Michael Bikovitsky
 Michael Killough
+Michael Bedford Taylor
 Michal Czyz
 Michaël Lefebvre
 Mike Popoloski


### PR DESCRIPTION
Code for addressing issue #6257 (supporting 1D parameter constant ranges).

This passes the test specified in that issue.

Please review this code extra carefully for feedback on correctness, as my knowledge of the Verilator source base is very limited.