### PR TITLE
Fix purity of dynamic cast

### DIFF
--- a/src/V3AstNodeExpr.h
+++ b/src/V3AstNodeExpr.h
@@ -2465,7 +2465,7 @@ public:
     bool sizeMattersLhs() const override { return false; }
     bool sizeMattersRhs() const override { return false; }
     int instrCount() const override { return widthInstrs() * 20; }
-    bool isPure() override { return true; }
+    bool isPure() override { return false; }
 };
 class AstCompareNN final : public AstNodeBiop {
     // Verilog str.compare() and str.icompare()

--- a/test_regress/t/t_class_dyn_cast_empty_if.py
+++ b/test_regress/t/t_class_dyn_cast_empty_if.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2025 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile()
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_class_dyn_cast_empty_if.v
+++ b/test_regress/t/t_class_dyn_cast_empty_if.v
@@ -1,0 +1,33 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2025 by Antmicro.
+// SPDX-License-Identifier: CC0-1.0
+
+typedef class Derived;
+class Base;
+  function Derived cast();
+    if ($cast(cast,this)) begin end
+  endfunction
+endclass
+
+class Derived extends Base;
+  string x;
+  function new(string xval);
+    x = xval;
+  endfunction
+  function string get();
+    return x;
+  endfunction
+endclass
+
+module t;
+  initial begin
+    Derived d = new("Hello");
+    Base b = d;
+    Derived c = b.cast();
+    if (d.get() != c.get()) $stop;
+    $write("*-* All Finished *-*\n");
+    $finish;
+  end
+endmodule


### PR DESCRIPTION
Dynamic cast had wrong purity and because of that if it was used as a condition in an empty `if` statement whole statement was removed - even though it shouldn't.
