### PR TITLE
Support parameter resolution of 1D unpacked array slices (#6257)

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -161,6 +161,7 @@ Martin Stadler
 Mateusz Gancarz
 Matthew Ballance
 Max Wipfli
+Michael Bedford Taylor
 Michael Bikovitsky
 Michael Killough
 Michal Czyz

--- a/src/V3Const.cpp
+++ b/src/V3Const.cpp
@@ -2787,6 +2787,18 @@ class ConstVisitor final : public VNVisitor {
         }
         m_selp = nullptr;
     }
+
+    // Evaluate a slice of an unpacked array.  If constantification is
+    // required (m_required=true), call replaceWithSimulation() to compute
+    // the slice via simulation.  Otherwise just iterate the children.
+    void visit(AstSliceSel* nodep) override {
+       // First constify or width any child nodes
+       iterateChildren(nodep);
+       if (!m_required) return;  // Do nothing unless we are in parameter mode
+       // Fallback to simulation: this will invoke SimulateVisitor::visit(AstSliceSel*)
+       replaceWithSimulation(nodep);
+    }
+
     void visit(AstCAwait* nodep) override {
         m_hasJumpDelay = true;
         iterateChildren(nodep);

--- a/src/V3Param.cpp
+++ b/src/V3Param.cpp
@@ -732,6 +732,14 @@ class ParamProcessor final {
                 AstNode* const exprp = pinp->exprp();
                 longnamer += "_" + paramSmallName(srcModp, modvarp) + paramValueNumber(exprp);
                 any_overridesr = true;
+            } else if (VN_IS(pinp->exprp(), InitArray)) {
+                // Array assigned to scalar parameter.  Treat the InitArray as a constant
+                // integer array and include it in the module name.  Constantify nested
+                // expressions before mangling the value number.
+                V3Const::constifyParamsEdit(pinp->exprp());
+                longnamer += "_" + paramSmallName(srcModp, modvarp)
+                    + paramValueNumber(pinp->exprp());
+                any_overridesr = true;
             } else {
                 V3Const::constifyParamsEdit(pinp->exprp());
                 // String constants are parsed as logic arrays and converted to strings in V3Const.

--- a/src/V3Simulate.h
+++ b/src/V3Simulate.h
@@ -908,9 +908,9 @@ private:
             const VNumRange& sliceRange = nodep->declRange();
             const uint32_t sliceElements = sliceRange.elements();
             const int sliceLo = sliceRange.lo();
-            // Use this node's dtype for the slice array                                                                                                                                                     
+            // Use this node's dtype for the slice array
             AstNodeDType* dtypep = nodep->dtypep()->skipRefp();
-            // Clone the default value from the base array, if present                                                                                                                                       
+            // Clone the default value from the base array, if present
             AstNodeExpr* defaultp = nullptr;
             if (initp->defaultp()) defaultp = initp->defaultp()->cloneTree(false);
             AstInitArray* newInitp = new AstInitArray{nodep->fileline(), dtypep, defaultp};

--- a/src/V3Simulate.h
+++ b/src/V3Simulate.h
@@ -922,7 +922,7 @@ private:
                 if (itemp) clonep = itemp->cloneTree(false);
                 newInitp->addIndexValuep(idx, clonep);
             }
-            // Assign the new constant array and track it for later deletion                                                                                                                                 
+            // Assign the new constant array and track it for later deletion
             setValue(nodep, newInitp);
             m_reclaimValuesp.push_back(newInitp);
         } else {

--- a/src/V3Simulate.h
+++ b/src/V3Simulate.h
@@ -918,9 +918,7 @@ private:
             for (uint32_t idx = 0; idx < sliceElements; ++idx) {
                 const uint32_t baseIdx = sliceLo + idx;
                 AstNodeExpr* const itemp = initp->getIndexDefaultedValuep(baseIdx);
-                AstNodeExpr* clonep = nullptr;
-                if (itemp) clonep = itemp->cloneTree(false);
-                newInitp->addIndexValuep(idx, clonep);
+                if (itemp) newInitp->addIndexValuep(idx, itemp->cloneTree(false));
             }
             // Assign the new constant array and track it for later deletion
             setValue(nodep, newInitp);

--- a/src/V3Simulate.h
+++ b/src/V3Simulate.h
@@ -895,15 +895,15 @@ private:
         }
     }
 
-    // Evaluate a slice of an unpacked array.  If the base value is a constant                                                                                                                               
-    // AstInitArray, build a new AstInitArray representing the slice and assign                                                                                                                              
-    // it as this node's value.  New index 0 corresponds to the lowest index of                                                                                                                              
-    // the slice.  Otherwise, mark this node as unoptimizable.                                                                                                                                               
+    // Evaluate a slice of an unpacked array.  If the base value is a constant
+    // AstInitArray, build a new AstInitArray representing the slice and assign
+    // it as this node's value.  New index 0 corresponds to the lowest index of
+    // the slice.  Otherwise, mark this node as unoptimizable.
     void visit(AstSliceSel* nodep) override {
         checkNodeInfo(nodep);
         iterateChildrenConst(nodep);
         if (m_checkOnly || !optimizable()) return;
-        // Fetch the base constant array                                                                                                                                                                     
+        // Fetch the base constant array
         if (AstInitArray* const initp = VN_CAST(fetchValueNull(nodep->fromp()), InitArray)) {
             const VNumRange& sliceRange = nodep->declRange();
             const uint32_t sliceElements = sliceRange.elements();
@@ -914,7 +914,7 @@ private:
             AstNodeExpr* defaultp = nullptr;
             if (initp->defaultp()) defaultp = initp->defaultp()->cloneTree(false);
             AstInitArray* newInitp = new AstInitArray{nodep->fileline(), dtypep, defaultp};
-            // Copy slice elements in ascending order                                                                                                                                                        
+            // Copy slice elements in ascending order
             for (uint32_t idx = 0; idx < sliceElements; ++idx) {
                 const uint32_t baseIdx = sliceLo + idx;
                 AstNodeExpr* const itemp = initp->getIndexDefaultedValuep(baseIdx);

--- a/src/V3Simulate.h
+++ b/src/V3Simulate.h
@@ -909,7 +909,7 @@ private:
             const uint32_t sliceElements = sliceRange.elements();
             const int sliceLo = sliceRange.lo();
             // Use this node's dtype for the slice array
-            AstNodeDType* dtypep = nodep->dtypep()->skipRefp();
+            AstNodeDType* const dtypep = nodep->dtypep()->skipRefp();
             // Clone the default value from the base array, if present
             AstNodeExpr* defaultp = nullptr;
             if (initp->defaultp()) defaultp = initp->defaultp()->cloneTree(false);

--- a/src/V3Simulate.h
+++ b/src/V3Simulate.h
@@ -913,7 +913,7 @@ private:
             // Clone the default value from the base array, if present
             AstNodeExpr* defaultp = nullptr;
             if (initp->defaultp()) defaultp = initp->defaultp()->cloneTree(false);
-            AstInitArray* newInitp = new AstInitArray{nodep->fileline(), dtypep, defaultp};
+            AstInitArray* const newInitp = new AstInitArray{nodep->fileline(), dtypep, defaultp};
             // Copy slice elements in ascending order
             for (uint32_t idx = 0; idx < sliceElements; ++idx) {
                 const uint32_t baseIdx = sliceLo + idx;

--- a/test_regress/t/t_param_slice.py
+++ b/test_regress/t/t_param_slice.py
@@ -8,15 +8,10 @@
 # SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
 import vltest_bootstrap
 
-# Use the Verilator scenario.  Other scenarios such as 'sc' (SystemC) are not needed here.
 test.scenarios('vlt')
 
-# Compile the Verilog source (t_param_slice.v is detected automatically)
 test.compile(verilator_flags2=['--exe','--main','--timing'])
 
-# Run the compiled simulation
 test.execute()
 
-# Mark the test as passed if no errors occurred and the "*-* All Finished *-*"
-# marker is printed by the Verilog code.
 test.passes()

--- a/test_regress/t/t_param_slice.py
+++ b/test_regress/t/t_param_slice.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Test constant parameter slicing of unpacked arrays (issue #6257)
+
+import vltest_bootstrap
+
+# Use the Verilator scenario.  Other scenarios such as 'sc' (SystemC) are not needed here.
+test.scenarios('vlt')
+
+# Compile the Verilog source (t_param_slice.v is detected automatically)
+test.compile(verilator_flags2=['--exe','--main','--timing'])
+
+# Run the compiled simulation
+test.execute()
+
+# Mark the test as passed if no errors occurred and the "*-* All Finished *-*"
+# marker is printed by the Verilog code.
+test.passes()

--- a/test_regress/t/t_param_slice.py
+++ b/test_regress/t/t_param_slice.py
@@ -1,6 +1,11 @@
 #!/usr/bin/env python3
 # DESCRIPTION: Verilator: Test constant parameter slicing of unpacked arrays (issue #6257)
-
+#
+# Copyright 2025 by Michael Taylor. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
 import vltest_bootstrap
 
 # Use the Verilator scenario.  Other scenarios such as 'sc' (SystemC) are not needed here.

--- a/test_regress/t/t_param_slice.py
+++ b/test_regress/t/t_param_slice.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # DESCRIPTION: Verilator: Test constant parameter slicing of unpacked arrays (issue #6257)
 #
-# Copyright 2025 by Michael Taylor. This program is free software; you
+# Copyright 2025 by Wilson Snyder. This program is free software; you
 # can redistribute it and/or modify it under the terms of either the GNU
 # Lesser General Public License Version 3 or the Perl Artistic License
 # Version 2.0.

--- a/test_regress/t/t_param_slice.v
+++ b/test_regress/t/t_param_slice.v
@@ -1,3 +1,9 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed into the Public Domain, for any use,
+// without warranty, 2025 by Michael Taylor.
+// SPDX-License-Identifier: CC0-1.0
+
 module issue #(
     parameter int els_p = 1,
     // Parameter array of length els_p

--- a/test_regress/t/t_param_slice.v
+++ b/test_regress/t/t_param_slice.v
@@ -1,0 +1,51 @@
+module issue #(
+    parameter int els_p = 1,
+    // Parameter array of length els_p
+    parameter int val_p [els_p-1:0],
+    // The original number of elements in the top-level array.  This is
+    // used to compute the expected value in each instance for self-checking.
+    parameter int orig_els = 1
+) ();
+    // Recursive instantiation: create a smaller issue if there are
+    // more than one element.  Select all but the lowest element of val_p.
+    if (els_p > 1) begin : r
+        issue #(
+            .els_p(els_p-1),
+            .val_p(val_p[els_p-1:1]),
+            .orig_els(orig_els)
+        ) x ();
+    end
+    // Self-check: compute the expected value based on the original array size
+    // (orig_els) and the current size (els_p).  The lowest element of the
+    // parameter array should equal orig_els - els_p + 1.  If not, print an
+    // error.  Regardless, display the value and the instance name for
+    // debugging.  Use an 8-digit hex for consistency.
+    initial begin
+        int expected;
+        expected = orig_els - els_p + 1;
+        if (val_p[0] !== expected) begin
+           $error("Wrong value %0d expected %0d in %m", val_p[0], expected);
+           $finish;
+        end
+        $display("%08x (%m)", val_p[0]);
+    end
+endmodule
+
+module t ();
+    // Define a parameter array of integers.  The unpacked array range is
+    // 5-1:0 (4 downto 0), giving 5 elements with values 5,4,3,2,1.  Each
+    // nested instance of issue will
+    // slice off one element from the high end, so the printed values will
+    // be 1,2,3,4,5 in that order.
+    parameter int val_p [5-1:0] = '{5,4,3,2,1};
+    issue #(
+        .els_p(5),
+        .val_p(val_p),
+        .orig_els(5)
+    ) iss ();
+    initial begin
+       #1;
+        $write("*-* All Finished *-*\n");
+        $finish;
+    end
+endmodule

--- a/test_regress/t/t_param_slice.v
+++ b/test_regress/t/t_param_slice.v
@@ -96,4 +96,3 @@ module t;
     $finish;
   end
 endmodule
-

--- a/test_regress/t/t_param_slice.v
+++ b/test_regress/t/t_param_slice.v
@@ -1,7 +1,7 @@
 // DESCRIPTION: Verilator: Verilog Test module
 //
 // This file ONLY is placed into the Public Domain, for any use,
-// without warranty, 2025 by Michael Taylor.
+// without warranty, 2025 by Wilson Snyder.
 // SPDX-License-Identifier: CC0-1.0
 
 `timescale 1ns/1ps

--- a/test_regress/t/t_param_slice.v
+++ b/test_regress/t/t_param_slice.v
@@ -5,53 +5,53 @@
 // SPDX-License-Identifier: CC0-1.0
 
 module issue #(
-    parameter int els_p = 1,
-    // Parameter array of length els_p
-    parameter int val_p [els_p-1:0],
-    // The original number of elements in the top-level array.  This is
-    // used to compute the expected value in each instance for self-checking.
-    parameter int orig_els = 1
+  parameter int els_p = 1,
+  // Parameter array of length els_p
+  parameter int val_p [els_p-1:0],
+  // The original number of elements in the top-level array.  This is
+  // used to compute the expected value in each instance for self-checking.
+  parameter int orig_els = 1
 ) ();
-    // Recursive instantiation: create a smaller issue if there are
-    // more than one element.  Select all but the lowest element of val_p.
-    if (els_p > 1) begin : r
-        issue #(
-            .els_p(els_p-1),
-            .val_p(val_p[els_p-1:1]),
-            .orig_els(orig_els)
-        ) x ();
+  // Recursive instantiation: create a smaller issue if there are
+  // more than one element.  Select all but the lowest element of val_p.
+  if (els_p > 1) begin : r
+    issue #(
+      .els_p(els_p-1),
+      .val_p(val_p[els_p-1:1]),
+      .orig_els(orig_els)
+    ) x ();
+  end
+  // Self-check: compute the expected value based on the original array size
+  // (orig_els) and the current size (els_p).  The lowest element of the
+  // parameter array should equal orig_els - els_p + 1.  If not, print an
+  // error.  Regardless, display the value and the instance name for
+  // debugging.  Use an 8-digit hex for consistency.
+  initial begin
+    int expected;
+    expected = orig_els - els_p + 1;
+    if (val_p[0] !== expected) begin
+       $error("Wrong value %0d expected %0d in %m", val_p[0], expected);
+       $finish;
     end
-    // Self-check: compute the expected value based on the original array size
-    // (orig_els) and the current size (els_p).  The lowest element of the
-    // parameter array should equal orig_els - els_p + 1.  If not, print an
-    // error.  Regardless, display the value and the instance name for
-    // debugging.  Use an 8-digit hex for consistency.
-    initial begin
-        int expected;
-        expected = orig_els - els_p + 1;
-        if (val_p[0] !== expected) begin
-           $error("Wrong value %0d expected %0d in %m", val_p[0], expected);
-           $finish;
-        end
-        $display("%08x (%m)", val_p[0]);
-    end
+    $display("%08x (%m)", val_p[0]);
+  end
 endmodule
 
 module t ();
-    // Define a parameter array of integers.  The unpacked array range is
-    // 5-1:0 (4 downto 0), giving 5 elements with values 5,4,3,2,1.  Each
-    // nested instance of issue will
-    // slice off one element from the high end, so the printed values will
-    // be 1,2,3,4,5 in that order.
-    parameter int val_p [5-1:0] = '{5,4,3,2,1};
-    issue #(
-        .els_p(5),
-        .val_p(val_p),
-        .orig_els(5)
-    ) iss ();
-    initial begin
-       #1;
-        $write("*-* All Finished *-*\n");
-        $finish;
-    end
+  // Define a parameter array of integers.  The unpacked array range is
+  // 5-1:0 (4 downto 0), giving 5 elements with values 5,4,3,2,1.  Each
+  // nested instance of issue will
+  // slice off one element from the high end, so the printed values will
+  // be 1,2,3,4,5 in that order.
+  parameter int val_p [5-1:0] = '{5,4,3,2,1};
+  issue #(
+    .els_p(5),
+    .val_p(val_p),
+    .orig_els(5)
+  ) iss ();
+  initial begin
+    #1;
+    $write("*-* All Finished *-*\n");
+    $finish;
+  end
 endmodule


### PR DESCRIPTION
Resubmit for #6266.

Code for addressing issue https://github.com/verilator/verilator/issues/6257 (supporting 1D parameter constant ranges).

This passes the test specified in that issue.

Please review this code extra carefully for feedback on correctness, as my knowledge of the Verilator source base is very limited.