### PR TITLE
Fix spurious VPI value change callbacks

### DIFF
--- a/include/verilated_vpi.cpp
+++ b/include/verilated_vpi.cpp
@@ -429,7 +429,7 @@ public:
     void createPrevDatap() {
         if (VL_UNLIKELY(!m_prevDatap)) {
             m_prevDatap = new uint8_t[entSize()];
-            std::memcpy(prevDatap(), varp()->datap(), entSize());
+            std::memcpy(prevDatap(), m_varDatap, entSize());
         }
     }
 };

--- a/test_regress/t/t_vpi_var.cpp
+++ b/test_regress/t/t_vpi_var.cpp
@@ -156,6 +156,12 @@ int _value_callback_quad(p_cb_data cb_data) {
     return 0;
 }
 
+int _value_callback_never(p_cb_data cb_data) {
+    printf("%%Error: callback should never be called\n");
+    exit(-1);
+    return 0;
+}
+
 int _mon_check_value_callbacks() {
     s_vpi_value v;
     v.format = vpiIntVal;
@@ -206,6 +212,18 @@ int _mon_check_value_callbacks() {
 
         cb_data.obj = vh2;
         cb_data.cb_rtn = _value_callback_quad;
+
+        TestVpiHandle callback_h = vpi_register_cb(&cb_data);
+        CHECK_RESULT_NZ(callback_h);
+    }
+    {
+        TestVpiHandle vh1 = VPI_HANDLE("some_mem");
+        CHECK_RESULT_NZ(vh1);
+        TestVpiHandle vh2 = vpi_handle_by_index(vh1, 3);
+        CHECK_RESULT_NZ(vh2);
+
+        cb_data.obj = vh2;
+        cb_data.cb_rtn = _value_callback_never;
 
         TestVpiHandle callback_h = vpi_register_cb(&cb_data);
         CHECK_RESULT_NZ(callback_h);

--- a/test_regress/t/t_vpi_var.v
+++ b/test_regress/t/t_vpi_var.v
@@ -59,6 +59,8 @@ extern "C" int mon_check();
    // keyword collision
    localparam int nullptr        /*verilator public */ = 123;
 
+   logic [31:0] some_mem [4] /* verilator public_flat_rd */ = {0, 0, 0, 432};
+
    sub sub();
 
    // Test loop

--- a/test_regress/t/t_vpi_var2.v
+++ b/test_regress/t/t_vpi_var2.v
@@ -75,6 +75,7 @@ extern "C" int mon_check();
    real           real1;
    string         str1;
    localparam int nullptr = 123;
+   logic [31:0] some_mem [4] = {0, 0, 0, 432};
 /*verilator public_off*/
 
    sub sub();

--- a/test_regress/t/t_vpi_var3.v
+++ b/test_regress/t/t_vpi_var3.v
@@ -56,6 +56,7 @@ extern "C" int mon_check();
    real           real1;
    string         str1;
    localparam int nullptr = 123;
+   logic [31:0] some_mem [4] = {0, 0, 0, 432};
 
    sub sub();
 


### PR DESCRIPTION
Previous data was being captured incorrectly for non-zero indices into arrays for VPI value change callbacks.  This caused spurious callbacks because prev != new despite the signal's value not actually changing.