### PR TITLE
Remove AstCondBound and AstNodeCond

### DIFF
--- a/src/V3AstNodes.cpp
+++ b/src/V3AstNodes.cpp
@@ -166,9 +166,8 @@ const char* AstNodeQuadop::broken() const {
     return nullptr;
 }
 
-AstNodeCond::AstNodeCond(VNType t, FileLine* fl, AstNodeExpr* condp, AstNodeExpr* thenp,
-                         AstNodeExpr* elsep)
-    : AstNodeTriop{t, fl, condp, thenp, elsep} {
+AstCond::AstCond(FileLine* fl, AstNodeExpr* condp, AstNodeExpr* thenp, AstNodeExpr* elsep)
+    : ASTGEN_SUPER_Cond(fl, condp, thenp, elsep) {
     UASSERT_OBJ(thenp, this, "No thenp expression");
     UASSERT_OBJ(elsep, this, "No elsep expression");
     if (thenp->isClassHandleValue() && elsep->isClassHandleValue()) {
@@ -178,14 +177,6 @@ AstNodeCond::AstNodeCond(VNType t, FileLine* fl, AstNodeExpr* condp, AstNodeExpr
         dtypep(commonClassTypep);
     } else {
         dtypeFrom(thenp);
-    }
-}
-void AstNodeCond::numberOperate(V3Number& out, const V3Number& lhs, const V3Number& rhs,
-                                const V3Number& ths) {
-    if (lhs.isNeqZero()) {
-        out.opAssign(rhs);
-    } else {
-        out.opAssign(ths);
     }
 }
 

--- a/src/V3Cast.cpp
+++ b/src/V3Cast.cpp
@@ -115,7 +115,7 @@ class CastVisitor final : public VNVisitor {
         if (nodep->sizeMattersLhs()) ensureCast(nodep->lhsp());
         if (nodep->sizeMattersRhs()) ensureCast(nodep->rhsp());
     }
-    void visit(AstNodeCond* nodep) override {
+    void visit(AstCond* nodep) override {
         // All class types are castable to each other. If they are of different types,
         // a compilation error will be thrown, so an explicit cast is required. Types were
         // already checked by V3Width and dtypep of a condition operator is a type of their

--- a/src/V3Clean.cpp
+++ b/src/V3Clean.cpp
@@ -261,7 +261,7 @@ class CleanVisitor final : public VNVisitor {
     }
 
     // Control flow operators
-    void visit(AstNodeCond* nodep) override {
+    void visit(AstCond* nodep) override {
         iterateChildren(nodep);
         ensureClean(nodep->condp());
         setClean(nodep, isClean(nodep->thenp()) && isClean(nodep->elsep()));

--- a/src/V3EmitCFunc.h
+++ b/src/V3EmitCFunc.h
@@ -1349,7 +1349,7 @@ public:
         iterateAndNextConstNull(nodep->lhsp());
         puts(")");
     }
-    void visit(AstNodeCond* nodep) override {
+    void visit(AstCond* nodep) override {
         // Widths match up already, so we'll just use C++'s operator w/o any temps.
         if (nodep->thenp()->isWide()) {
             emitOpName(nodep, nodep->emitC(), nodep->condp(), nodep->thenp(), nodep->elsep());

--- a/src/V3EmitV.cpp
+++ b/src/V3EmitV.cpp
@@ -616,7 +616,7 @@ class EmitVBaseVisitorConst VL_NOT_FINAL : public VNVisitorConst {
         }
         puts("}");
     }
-    void visit(AstNodeCond* nodep) override {
+    void visit(AstCond* nodep) override {
         putbs("(");
         iterateAndNextConstNull(nodep->condp());
         putfs(nodep, " ? ");

--- a/src/V3InstrCount.cpp
+++ b/src/V3InstrCount.cpp
@@ -188,7 +188,7 @@ private:
             if (nodep->thensp()) nodep->thensp()->user2(0);  // Don't dump it
         }
     }
-    void visit(AstNodeCond* nodep) override {
+    void visit(AstCond* nodep) override {
         if (m_ignoreRemaining) return;
         // Just like if/else above, the ternary operator only evaluates
         // one of the two expressions, so only count the max.

--- a/src/V3LinkInc.cpp
+++ b/src/V3LinkInc.cpp
@@ -189,7 +189,7 @@ class LinkIncVisitor final : public VNVisitor {
     void visit(AstLogOr* nodep) override { unsupported_visit(nodep); }
     void visit(AstLogEq* nodep) override { unsupported_visit(nodep); }
     void visit(AstLogIf* nodep) override { unsupported_visit(nodep); }
-    void visit(AstNodeCond* nodep) override { unsupported_visit(nodep); }
+    void visit(AstCond* nodep) override { unsupported_visit(nodep); }
     void visit(AstPropSpec* nodep) override { unsupported_visit(nodep); }
     void prepost_visit(AstNodeTriop* nodep) {
         // Check if we are underneath a statement

--- a/src/V3MergeCond.cpp
+++ b/src/V3MergeCond.cpp
@@ -95,11 +95,11 @@ namespace {
 // if there is one and it is in a supported position, which are:
 // - RHS is the Cond
 // - RHS is And(Const, Cond). This And is inserted often by V3Clean.
-AstNodeCond* extractCondFromRhs(AstNode* rhsp) {
-    if (AstNodeCond* const condp = VN_CAST(rhsp, NodeCond)) {
+AstCond* extractCondFromRhs(AstNode* rhsp) {
+    if (AstCond* const condp = VN_CAST(rhsp, Cond)) {
         return condp;
     } else if (const AstAnd* const andp = VN_CAST(rhsp, And)) {
-        if (AstNodeCond* const condp = VN_CAST(andp->rhsp(), NodeCond)) {
+        if (AstCond* const condp = VN_CAST(andp->rhsp(), Cond)) {
             if (VN_IS(andp->lhsp(), Const)) return condp;
         }
     }
@@ -177,7 +177,7 @@ class CodeMotionAnalysisVisitor final : public VNVisitorConst {
     static AstNodeExpr* extractCondition(const AstNodeStmt* nodep) {
         AstNodeExpr* conditionp = nullptr;
         if (const AstNodeAssign* const assignp = VN_CAST(nodep, NodeAssign)) {
-            if (AstNodeCond* const conditionalp = extractCondFromRhs(assignp->rhsp())) {
+            if (AstCond* const conditionalp = extractCondFromRhs(assignp->rhsp())) {
                 conditionp = conditionalp->condp();
             }
         } else if (const AstNodeIf* const ifp = VN_CAST(nodep, NodeIf)) {
@@ -564,7 +564,7 @@ class MergeCondVisitor final : public VNVisitor {
                 return yieldsOneOrZero(biopp->lhsp()) && yieldsOneOrZero(biopp->rhsp());
             return false;
         }
-        if (const AstNodeCond* const condp = VN_CAST(nodep, NodeCond)) {
+        if (const AstCond* const condp = VN_CAST(nodep, Cond)) {
             return yieldsOneOrZero(condp->thenp()) && yieldsOneOrZero(condp->elsep());
         }
         if (const AstCCast* const castp = VN_CAST(nodep, CCast)) {
@@ -591,7 +591,7 @@ class MergeCondVisitor final : public VNVisitor {
     AstNodeExpr* foldAndUnlink(AstNodeExpr* rhsp, bool condTrue) {
         if (rhsp->sameTree(m_mgCondp)) {
             return new AstConst{rhsp->fileline(), AstConst::BitTrue{}, condTrue};
-        } else if (const AstNodeCond* const condp = extractCondFromRhs(rhsp)) {
+        } else if (const AstCond* const condp = extractCondFromRhs(rhsp)) {
             AstNodeExpr* const resp
                 = condTrue ? condp->thenp()->unlinkFrBack() : condp->elsep()->unlinkFrBack();
             if (condp == rhsp) return resp;

--- a/src/V3Premit.cpp
+++ b/src/V3Premit.cpp
@@ -321,7 +321,7 @@ class PremitVisitor final : public VNVisitor {
         }
         checkNode(nodep);
     }
-    void visit(AstNodeCond* nodep) override {
+    void visit(AstCond* nodep) override {
         iterateChildren(nodep);
         if (nodep->thenp()->isWide() && !VN_IS(nodep->condp(), Const)
             && !VN_IS(nodep->condp(), VarRef)) {

--- a/src/V3Randomize.cpp
+++ b/src/V3Randomize.cpp
@@ -766,7 +766,7 @@ class ConstraintExprVisitor final : public VNVisitor {
         if (editFormat(nodep)) return;
         editSMT(nodep, nodep->lhsp(), nodep->rhsp(), nodep->thsp());
     }
-    void visit(AstNodeCond* nodep) override {
+    void visit(AstCond* nodep) override {
         if (editFormat(nodep)) return;
         if (!nodep->condp()->user1()) {
             // Do not burden the solver if cond computable: (cond ? "then" : "else")

--- a/src/V3Simulate.h
+++ b/src/V3Simulate.h
@@ -672,7 +672,7 @@ private:
             }
         }
     }
-    void visit(AstNodeCond* nodep) override {
+    void visit(AstCond* nodep) override {
         // We could use above visit(AstNodeTriop), but need to do short circuiting.
         // It's also slower even O(n^2) to evaluate both sides when we
         // really only need to evaluate one side.

--- a/src/V3Slice.cpp
+++ b/src/V3Slice.cpp
@@ -190,11 +190,11 @@ class SliceVisitor final : public VNVisitor {
                 }
             }
             if (!newp) newp = new AstConst{nodep->fileline(), 0};
-        } else if (AstNodeCond* const snodep = VN_CAST(nodep, NodeCond)) {
+        } else if (AstCond* const snodep = VN_CAST(nodep, Cond)) {
             UINFO(9, "  cloneCond(" << elements << "," << elemIdx << ") " << nodep);
-            return snodep->cloneType(snodep->condp()->cloneTree(false, needPure),
-                                     cloneAndSel(snodep->thenp(), elements, elemIdx, needPure),
-                                     cloneAndSel(snodep->elsep(), elements, elemIdx, needPure));
+            return new AstCond{snodep->fileline(), snodep->condp()->cloneTree(false, needPure),
+                               cloneAndSel(snodep->thenp(), elements, elemIdx, needPure),
+                               cloneAndSel(snodep->elsep(), elements, elemIdx, needPure)};
         } else if (const AstSliceSel* const snodep = VN_CAST(nodep, SliceSel)) {
             UINFO(9, "  cloneSliceSel(" << elements << "," << elemIdx << ") " << nodep);
             const int leOffset = (snodep->declRange().lo()

--- a/src/V3StackCount.cpp
+++ b/src/V3StackCount.cpp
@@ -112,7 +112,7 @@ private:
             if (nodep->thensp()) nodep->thensp()->user2(0);  // Don't dump it
         }
     }
-    void visit(AstNodeCond* nodep) override {
+    void visit(AstCond* nodep) override {
         if (m_ignoreRemaining) return;
         // Just like if/else above, the ternary operator only evaluates
         // one of the two expressions, so only count the max.

--- a/src/V3Unknown.cpp
+++ b/src/V3Unknown.cpp
@@ -411,7 +411,7 @@ class UnknownVisitor final : public VNVisitor {
                 AstNodeExpr* const xexprp = new AstConst{nodep->fileline(), xnum};
                 AstNodeExpr* const newp
                     = condp->isZero() ? xexprp
-                                      : new AstCondBound{nodep->fileline(), condp, nodep, xexprp};
+                                      : new AstCond{nodep->fileline(), condp, nodep, xexprp};
                 UINFOTREE(9, newp, "", "_new");
                 // Link in conditional
                 replaceHandle.relink(newp);
@@ -485,8 +485,8 @@ class UnknownVisitor final : public VNVisitor {
                 } else {
                     xnum.setAllBitsX();
                 }
-                AstNode* const newp = new AstCondBound{nodep->fileline(), condp, nodep,
-                                                       new AstConst{nodep->fileline(), xnum}};
+                AstNode* const newp = new AstCond{nodep->fileline(), condp, nodep,
+                                                  new AstConst{nodep->fileline(), xnum}};
                 UINFOTREE(9, newp, "", "_new");
                 // Link in conditional, can blow away temp xor
                 replaceHandle.relink(newp);
@@ -496,7 +496,7 @@ class UnknownVisitor final : public VNVisitor {
                 // ARRAYSEL(...) -> ARRAYSEL(COND(LT(bit<maxbit), bit, 0))
                 VNRelinker replaceHandle;
                 AstNodeExpr* const bitp = nodep->bitp()->unlinkFrBack(&replaceHandle);
-                AstNodeExpr* const newp = new AstCondBound{
+                AstNodeExpr* const newp = new AstCond{
                     bitp->fileline(), condp, bitp,
                     new AstConst{bitp->fileline(), AstConst::WidthedValue{}, bitp->width(), 0}};
                 // Added X's, tristate them too

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -492,7 +492,7 @@ class WidthVisitor final : public VNVisitor {
         nodep->dtypeSetUInt64();  // A pointer, but not that it matters
     }
 
-    void visit(AstNodeCond* nodep) override {
+    void visit(AstCond* nodep) override {
         // op = cond ? expr1 : expr2
         // See IEEE-2012 11.4.11 and Table 11-21.
         //   LHS is self-determined


### PR DESCRIPTION
Fixes #6293

---

Was curious. Output looks identical (bar hashes which always changes when adding/removing AstNode types). Let me know if there is a reason to keep these.