### PR TITLE
Fix: look for variable scope up in hierarchy

### DIFF
--- a/src/V3Scope.cpp
+++ b/src/V3Scope.cpp
@@ -68,9 +68,18 @@ class ScopeVisitor final : public VNVisitor {
                 UASSERT_OBJ(it2 != m_packageScopes.end(), nodep, "Can't locate package scope");
                 scopep = it2->second;
             }
-            const auto it3 = m_varScopes.find(std::make_pair(nodep->varp(), scopep));
-            UASSERT_OBJ(it3 != m_varScopes.end(), nodep, "Can't locate varref scope");
-            AstVarScope* const varscp = it3->second;
+            // Search up the scope hierarchy for the variable
+            AstVarScope* varscp = nullptr;
+            AstScope* searchScopep = scopep;
+            while (searchScopep) {
+                const auto it3 = m_varScopes.find(std::make_pair(nodep->varp(), searchScopep));
+                if (it3 != m_varScopes.end()) {
+                    varscp = it3->second;
+                    break;
+                }
+                searchScopep = searchScopep->aboveScopep();
+            }
+            UASSERT_OBJ(varscp, nodep, "Can't locate varref scope");
             nodep->varScopep(varscp);
         }
     }

--- a/test_regress/t/t_class_modscope.py
+++ b/test_regress/t/t_class_modscope.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2025 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile()
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_class_modscope.v
+++ b/test_regress/t/t_class_modscope.v
@@ -1,0 +1,34 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2025 by Antmicro.
+// SPDX-License-Identifier: CC0-1.0
+
+`define stop $stop
+`define checkh(gotv,expv) do if ((gotv) !== (expv)) begin $write("%%Error: %s:%0d:  got='h%x exp='h%x\n", `__FILE__,`__LINE__, (gotv), (expv)); `stop; end while(0);
+
+module m();
+  class c;
+    static function void fstatic();
+      `checkh(v, 42);
+      v++;
+    endfunction
+    function void fnonstatic();
+      `checkh(v, 43);
+      v++;
+    endfunction
+  endclass
+
+  c classinst;
+  int v;
+
+  initial begin
+    v=42;
+    `checkh(v, 42);
+    c::fstatic();
+    classinst = new();
+    classinst.fnonstatic();
+    `checkh(v, 44);
+    $finish;
+  end
+endmodule


### PR DESCRIPTION
When a variable defined above a class was referenced in the class, Verilator could not find its scope, because it was only looking inside the scope of the class. This change fixes that - enables looking for scopes up in the hierarchy until it is found.