### PR TITLE
Fix unsound assertion in V3Delayed

### DIFF
--- a/src/V3Delayed.cpp
+++ b/src/V3Delayed.cpp
@@ -469,7 +469,11 @@ class DelayedVisitor final : public VNVisitor {
             varp = new AstVar{flp, VVarType::BLOCKTEMP, name, dtypep};
             modp->addStmtsp(varp);
         }
-        UASSERT_OBJ(varp->dtypep()->isSame(dtypep), flp, "Invalid type for temporary AstVar");
+
+        // We should be able to assert this here, but unfortuantely
+        // 'isAssignmentCompatible' does not exist as of right now.
+        // UASSERT_OBJ(isAssignmentCompatible(varp->dtypep(), dtypep), flp, "Invalid temporary");
+
         // Create the AstVarScope
         AstVarScope* const varscp = new AstVarScope{flp, scopep, varp};
         scopep->addVarsp(varscp);


### PR DESCRIPTION
I added this assert in #6300, however it is tripped with #6298 after the new DFG rewrites. Some things change from `BasicDType(7, logic)` to `PackedArray(BasicDType(1, logic), 6, 0)`, which really are the same thing, but I can't seem to find an existing "bool isAssignmentCompatible(aType, bType)" function. I don't want to assert `a->width() == b->width()` as some types might not be packed here at all. Unless you have a way I suggest we just remove the assertion for now.