### PR TITLE
Iternals: Remove AstAssignPre/AstAssignPost

### DIFF
--- a/docs/internals.rst
+++ b/docs/internals.rst
@@ -450,7 +450,7 @@ as defined in the standard:
 - All other logic is assigned to the 'nba' region.
 
 For completeness, note that a subset of the 'act' region logic, specifically,
-the logic related to the pre-assignments of NBA updates (i.e., AstAssignPre
+the logic related to the pre-assignments of NBA updates (i.e., AstAlwaysPre
 nodes), is handled separately, but is executed as part of the 'act' region.
 
 Also note that all logic representing the committing of an NBA (i.e., Ast*Post)

--- a/src/V3AstNodeOther.h
+++ b/src/V3AstNodeOther.h
@@ -2551,6 +2551,14 @@ public:
         : ASTGEN_SUPER_AlwaysPostponed(fl, stmtsp) {}
     ASTGEN_MEMBERS_AstAlwaysPostponed;
 };
+class AstAlwaysPre final : public AstNodeProcedure {
+    // Like always but 'pre' scheduled, e.g. for implementing NBAs
+
+public:
+    explicit AstAlwaysPre(FileLine* fl)
+        : ASTGEN_SUPER_AlwaysPre(fl, nullptr) {}
+    ASTGEN_MEMBERS_AstAlwaysPre;
+};
 class AstAlwaysReactive final : public AstNodeProcedure {
     // Like always but Reactive scheduling region
     // @astgen op1 := sentreep : Optional[AstSenTree] // Sensitivity list, removed in V3Active

--- a/src/V3AstNodeStmt.h
+++ b/src/V3AstNodeStmt.h
@@ -1162,28 +1162,6 @@ public:
     }
     bool brokeLhsMustBeLvalue() const override { return true; }
 };
-class AstAssignPost final : public AstNodeAssign {
-    // Like Assign, but predelayed assignment requiring special order handling
-public:
-    AstAssignPost(FileLine* fl, AstNodeExpr* lhsp, AstNodeExpr* rhsp)
-        : ASTGEN_SUPER_AssignPost(fl, lhsp, rhsp) {}
-    ASTGEN_MEMBERS_AstAssignPost;
-    AstNodeAssign* cloneType(AstNodeExpr* lhsp, AstNodeExpr* rhsp) override {
-        return new AstAssignPost{fileline(), lhsp, rhsp};
-    }
-    bool brokeLhsMustBeLvalue() const override { return true; }
-};
-class AstAssignPre final : public AstNodeAssign {
-    // Like Assign, but predelayed assignment requiring special order handling
-public:
-    AstAssignPre(FileLine* fl, AstNodeExpr* lhsp, AstNodeExpr* rhsp)
-        : ASTGEN_SUPER_AssignPre(fl, lhsp, rhsp) {}
-    ASTGEN_MEMBERS_AstAssignPre;
-    AstNodeAssign* cloneType(AstNodeExpr* lhsp, AstNodeExpr* rhsp) override {
-        return new AstAssignPre{fileline(), lhsp, rhsp};
-    }
-    bool brokeLhsMustBeLvalue() const override { return true; }
-};
 class AstAssignVarScope final : public AstNodeAssign {
     // Assign two VarScopes to each other
 public:

--- a/src/V3EmitV.cpp
+++ b/src/V3EmitV.cpp
@@ -132,6 +132,16 @@ class EmitVBaseVisitorConst VL_NOT_FINAL : public VNVisitorConst {
         iterateAndNextConstNull(nodep->stmtsp());
         putqs(nodep, "end\n");
     }
+    void visit(AstAlwaysPre* nodep) override {
+        putfs(nodep, "always /* PRE */ begin\n");
+        iterateAndNextConstNull(nodep->stmtsp());
+        putqs(nodep, "end\n");
+    }
+    void visit(AstAlwaysPost* nodep) override {
+        putfs(nodep, "always /* POST */ begin\n");
+        iterateAndNextConstNull(nodep->stmtsp());
+        putqs(nodep, "end\n");
+    }
     void visit(AstAlwaysPublic* nodep) override {
         putfs(nodep, "/*verilator public_flat_rw ");
         if (m_sentreep) {

--- a/src/V3GraphTest.cpp
+++ b/src/V3GraphTest.cpp
@@ -188,7 +188,7 @@ public:
         V3GraphTestVertex* const posedge = n = new V3GraphTestVertex{gp, "*posedge clk*"};
         { new V3GraphEdge{gp, clk, n, 2}; }
 
-        // AssignPre's     VarRefs on LHS:  generate special BLK
+        // AlwaysPre's     VarRefs on LHS:  generate special BLK
         //    normal:      VarRefs on LHS:  generate normal
         //    underSBlock: VarRefs on RHS:  consume 'pre' (required to save cutable tests)
         n = new V3GraphTestVertex{gp, "a_dly<PRE=a"};
@@ -227,7 +227,7 @@ public:
             new V3GraphEdge{gp, posedge, n, 2};
         }
 
-        // AssignPost's
+        // AlwaysPost's
         //    normal:      VarRefs on LHS:  generate normal
         //    underSBlock: VarRefs on RHS:  consume normal
         n = new V3GraphTestVertex{gp, "a=POST=a_dly"};

--- a/src/V3Order.cpp
+++ b/src/V3Order.cpp
@@ -21,7 +21,7 @@
 //      For seq logic
 //          Add logic_sensitive_vertex for this list of SenItems
 //              Add edge for each sensitive_var->logic_sensitive_vertex
-//          For AssignPre's
+//          For AlwaysPre's
 //              Add vertex for this logic
 //                  Add edge logic_sensitive_vertex->logic_vertex
 //                  Add edge logic_consumed_var_PREVAR->logic_vertex
@@ -38,11 +38,11 @@
 //              Add vertex for this logic
 //                  Add edge logic_sensitive_vertex->logic_vertex
 //                  Add edge logic_generated_var_PREORDER->logic_vertex
-//                      This ensures the AssignPre gets scheduled before this logic
+//                      This ensures the AlwaysPre gets scheduled before this logic
 //                  Add edge logic_vertex->consumed_var_PREVAR
 //                  Add edge logic_vertex->consumed_var_POSTVAR
 //                  Add edge logic_vertex->logic_generated_var (same as if comb)
-//          For AssignPost's
+//          For AlwaysPost's
 //              Add vertex for this logic
 //                  Add edge logic_sensitive_vertex->logic_vertex
 //                  Add edge logic_consumed_var->logic_vertex (same as if comb)

--- a/src/V3OrderGraph.h
+++ b/src/V3OrderGraph.h
@@ -34,13 +34,13 @@
 // roles are:
 //
 // OrderVarStdVertex:   Data dependencies for combinational logic and delayed assignment
-//                      updates (AssignPost).
+//                      updates (AlwaysPost).
 // OrderVarPostVertex:  Ensures all sequential logic blocks reading a signal do so before any
 //                      combinational or delayed assignments update that signal.
-// OrderVarPordVertex:  Ensures a _d = _q AssignPre used to implement delayed (non-blocking)
+// OrderVarPordVertex:  Ensures a _d = _q AlwaysPre used to implement delayed (non-blocking)
 //                      assignments is the first write of a _d, before any sequential blocks
 //                      write to that _d.
-// OrderVarPreVertex:   This is an optimization. Try to ensure that a _d = _q AssignPre is the
+// OrderVarPreVertex:   This is an optimization. Try to ensure that a _d = _q AlwaysPre is the
 //                      last read of a _q, after all reads of that _q by sequential logic. The
 //                      model is still correct if we cannot satisfy this due to other interfering
 //                      constraints. If respecting this constraint is possible, then combined

--- a/src/V3Sched.cpp
+++ b/src/V3Sched.cpp
@@ -107,12 +107,13 @@ void invertAndMergeSenTreeMap(
 AstSenTree* findTriggeredIface(const AstVarScope* vscp,
                                const VirtIfaceTriggers::IfaceSensMap& vifTrigged,
                                const VirtIfaceTriggers::IfaceMemberSensMap& vifMemberTriggered) {
+    UASSERT_OBJ(vscp->varp()->sensIfacep(), vscp, "Not an virtual interface trigger");
     const auto ifaceIt = vifTrigged.find(vscp->varp()->sensIfacep());
     if (ifaceIt != vifTrigged.end()) return ifaceIt->second;
     for (const auto& memberIt : vifMemberTriggered) {
         if (memberIt.first.m_ifacep == vscp->varp()->sensIfacep()) { return memberIt.second; }
     }
-    return nullptr;
+    vscp->v3fatalSrc("Did not find virtual interface trigger");
 }
 
 //============================================================================

--- a/src/V3Sched.h
+++ b/src/V3Sched.h
@@ -94,7 +94,7 @@ struct LogicClasses final {
 // Combinational (including hybrid) logic, and clocked logic in partitioned to compute all clock
 // signals in the 'act' region. For details see the internals documentation.
 struct LogicRegions final {
-    LogicByScope m_pre;  // AstAssignPre logic in 'act' region
+    LogicByScope m_pre;  // AstAlwaysPre logic in 'act' region
     LogicByScope m_act;  // 'act' region logic
     LogicByScope m_nba;  // 'nba' region logic
     LogicByScope m_obs;  // AstAlwaysObserved logic in 'obs' region

--- a/src/V3SchedPartition.cpp
+++ b/src/V3SchedPartition.cpp
@@ -26,7 +26,7 @@
 // is then assigned to the 'act' region, and all other logic is assigned to
 // the 'nba' region.
 //
-// For later practical purposes, AstAssignPre logic that would be assigned to
+// For later practical purposes, AstAlwaysPre logic that would be assigned to
 // the 'act' region is returned separately. Nevertheless, this logic is part of
 // the 'act' region.
 //
@@ -241,8 +241,7 @@ class SchedGraphBuilder final : public VNVisitor {
     void visit(AstAlwaysPublic* nodep) override { visitLogic(nodep); }
 
     // Pre and Post logic are handled separately
-    void visit(AstAssignPre* nodep) override {}
-    void visit(AstAssignPost* nodep) override {}
+    void visit(AstAlwaysPre* nodep) override {}
     void visit(AstAlwaysPost* nodep) override {}
 
     // LCOV_EXCL_START
@@ -375,14 +374,14 @@ LogicRegions partition(LogicByScope& clockedLogic, LogicByScope& combinationalLo
             markVars(activep);
         }
 
-        // AstAssignPre, AstAssignPost and AstAlwaysPost should only appear under a clocked
+        // AstAlwaysPre and AstAlwaysPost should only appear under a clocked
         // AstActive, and should be the only thing left at this point.
         for (const auto& pair : clockedLogic) {
             AstScope* const scopep = pair.first;
             AstActive* const activep = pair.second;
             for (AstNode *nodep = activep->stmtsp(), *nextp; nodep; nodep = nextp) {
                 nextp = nodep->nextp();
-                if (AstAssignPre* const logicp = VN_CAST(nodep, AssignPre)) {
+                if (AstAlwaysPre* const logicp = VN_CAST(nodep, AlwaysPre)) {
                     bool toActiveRegion = false;
                     logicp->foreach([&](const AstNodeVarRef* vrefp) {
                         AstVarScope* const vscp = vrefp->varScopep();
@@ -398,7 +397,7 @@ LogicRegions partition(LogicByScope& clockedLogic, LogicByScope& combinationalLo
                     logicp->unlinkFrBack();
                     lbs.add(scopep, activep->sentreep(), logicp);
                 } else {
-                    UASSERT_OBJ(VN_IS(nodep, AssignPost) || VN_IS(nodep, AlwaysPost), nodep,
+                    UASSERT_OBJ(VN_IS(nodep, AlwaysPost), nodep,
                                 "Unexpected node type " << nodep->typeName());
                     nodep->unlinkFrBack();
                     result.m_nba.add(scopep, activep->sentreep(), nodep);

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -5374,7 +5374,6 @@ class WidthVisitor final : public VNVisitor {
         //       handled in each visitor.
         //    Then LHS sign-extends only if *RHS* is signed
         assertAtStatement(nodep);
-        // UINFOTREE(1, nodep, "", "AssignPre");
         {
             // UINFOTREE(1, nodep, "", "assin:");
             userIterateAndNext(nodep->lhsp(), WidthVP{SELF, BOTH}.p());

--- a/test_regress/t/t_json_only_debugcheck.out
+++ b/test_regress/t/t_json_only_debugcheck.out
@@ -1161,14 +1161,14 @@
       {"type":"VAR","name":"__Vtemp_3","addr":"(UR)","loc":"d,90:123,90:124","dtypep":"(RB)","origName":"__Vtemp_3","isSc":false,"isPrimaryIO":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isUsedClock":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"attrClocker":"UNKNOWN","lifetime":"NONE","varType":"STMTTEMP","dtypeName":"string","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"ignorePostWrite":false,"ignoreSchedWrite":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []}
     ],
      "stmtsp": [
-      {"type":"ASSIGNPRE","name":"","addr":"(VR)","loc":"d,23:17,23:20","dtypep":"(R)",
+      {"type":"ASSIGN","name":"","addr":"(VR)","loc":"d,23:17,23:20","dtypep":"(R)",
        "rhsp": [
         {"type":"VARREF","name":"t.cyc","addr":"(WR)","loc":"d,23:17,23:20","dtypep":"(R)","access":"RD","varp":"(Q)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],
        "lhsp": [
         {"type":"VARREF","name":"__Vdly__t.cyc","addr":"(XR)","loc":"d,23:17,23:20","dtypep":"(R)","access":"WR","varp":"(MR)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []},
-      {"type":"ASSIGNPRE","name":"","addr":"(YR)","loc":"d,24:9,24:10","dtypep":"(AC)",
+      {"type":"ASSIGN","name":"","addr":"(YR)","loc":"d,24:9,24:10","dtypep":"(AC)",
        "rhsp": [
         {"type":"VARREF","name":"t.e","addr":"(ZR)","loc":"d,24:9,24:10","dtypep":"(AC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],
@@ -2507,14 +2507,14 @@
           ]}
         ]}
       ]},
-      {"type":"ASSIGNPOST","name":"","addr":"(JKB)","loc":"d,23:17,23:20","dtypep":"(R)",
+      {"type":"ASSIGN","name":"","addr":"(JKB)","loc":"d,23:17,23:20","dtypep":"(R)",
        "rhsp": [
         {"type":"VARREF","name":"__Vdly__t.cyc","addr":"(KKB)","loc":"d,23:17,23:20","dtypep":"(R)","access":"RD","varp":"(MR)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],
        "lhsp": [
         {"type":"VARREF","name":"t.cyc","addr":"(LKB)","loc":"d,23:17,23:20","dtypep":"(R)","access":"WR","varp":"(Q)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []},
-      {"type":"ASSIGNPOST","name":"","addr":"(MKB)","loc":"d,24:9,24:10","dtypep":"(AC)",
+      {"type":"ASSIGN","name":"","addr":"(MKB)","loc":"d,24:9,24:10","dtypep":"(AC)",
        "rhsp": [
         {"type":"VARREF","name":"__Vdly__t.e","addr":"(NKB)","loc":"d,24:9,24:10","dtypep":"(AC)","access":"RD","varp":"(PR)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],

--- a/test_regress/t/t_xml_debugcheck.out
+++ b/test_regress/t/t_xml_debugcheck.out
@@ -711,14 +711,14 @@
         <var loc="d,70,123,70,124" name="__Vtemp_1" dtype_id="10" vartype="string" origName="__Vtemp_1"/>
         <var loc="d,80,123,80,124" name="__Vtemp_2" dtype_id="10" vartype="string" origName="__Vtemp_2"/>
         <var loc="d,90,123,90,124" name="__Vtemp_3" dtype_id="10" vartype="string" origName="__Vtemp_3"/>
-        <assignpre loc="d,23,17,23,20" dtype_id="4">
+        <assign loc="d,23,17,23,20" dtype_id="4">
           <varref loc="d,23,17,23,20" name="t.cyc" dtype_id="4"/>
           <varref loc="d,23,17,23,20" name="__Vdly__t.cyc" dtype_id="4"/>
-        </assignpre>
-        <assignpre loc="d,24,9,24,10" dtype_id="11">
+        </assign>
+        <assign loc="d,24,9,24,10" dtype_id="11">
           <varref loc="d,24,9,24,10" name="t.e" dtype_id="11"/>
           <varref loc="d,24,9,24,10" name="__Vdly__t.e" dtype_id="11"/>
-        </assignpre>
+        </assign>
         <assigndly loc="d,64,11,64,13" dtype_id="4">
           <add loc="d,64,18,64,19" dtype_id="4">
             <ccast loc="d,64,20,64,21" dtype_id="14">
@@ -1510,14 +1510,14 @@
             </if>
           </begin>
         </if>
-        <assignpost loc="d,23,17,23,20" dtype_id="4">
+        <assign loc="d,23,17,23,20" dtype_id="4">
           <varref loc="d,23,17,23,20" name="__Vdly__t.cyc" dtype_id="4"/>
           <varref loc="d,23,17,23,20" name="t.cyc" dtype_id="4"/>
-        </assignpost>
-        <assignpost loc="d,24,9,24,10" dtype_id="11">
+        </assign>
+        <assign loc="d,24,9,24,10" dtype_id="11">
           <varref loc="d,24,9,24,10" name="__Vdly__t.e" dtype_id="11"/>
           <varref loc="d,24,9,24,10" name="t.e" dtype_id="11"/>
-        </assignpost>
+        </assign>
       </cfunc>
       <cfunc loc="a,0,0,0,0" name="_eval_phase__act">
         <var loc="d,11,8,11,9" name="__VpreTriggered" dtype_id="6" vartype="VlTriggerVec" origName="__VpreTriggered"/>


### PR DESCRIPTION
Replace with AstAlwaysPre/AstAlwaysPost with AstAssign under them.

Step towards #6280

---

Assuming you are happy without the flags for Pre/Post after discussion but let me know otherwise. There is also the new flag on the VarScope plus it's pretty easy to see them, the LHS or RHS contains "__Vdly*" signals.