### PR TITLE
Removal of breaking if

### DIFF
--- a/src/V3Randomize.cpp
+++ b/src/V3Randomize.cpp
@@ -913,12 +913,6 @@ class ConstraintExprVisitor final : public VNVisitor {
         if (nodep->user1()) {
             nodep->v3warn(CONSTRAINTIGN, "Global constraints ignored (unsupported)");
         }
-        if (VN_IS(nodep->fromp(), NodeVarRef) && nodep->varp()->isRand() && m_inlineInitTaskp) {
-            iterateChildren(nodep);
-            nodep->replaceWith(nodep->fromp()->unlinkFrBack());
-            VL_DO_DANGLING(nodep->deleteTree(), nodep);
-            return;
-        }
         editFormat(nodep);
     }
     void visit(AstSFormatF* nodep) override {}

--- a/test_regress/t/t_randomize_from_randomized_class.py
+++ b/test_regress/t/t_randomize_from_randomized_class.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2025 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+if not test.have_solver:
+    test.skip("No constraint solver installed")
+
+test.compile()
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_randomize_from_randomized_class.v
+++ b/test_regress/t/t_randomize_from_randomized_class.v
@@ -25,6 +25,7 @@ module t;
     B b = new;
     b.r();
     if (b.a.j != 7) $stop;
+    $write("*-* All Finished *-*\n");
     $finish;
   end
 endmodule

--- a/test_regress/t/t_randomize_from_randomized_class.v
+++ b/test_regress/t/t_randomize_from_randomized_class.v
@@ -1,0 +1,30 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2025 by Antmicro.
+// SPDX-License-Identifier: CC0-1.0
+
+class A;
+  rand int j;
+endclass
+
+class B;
+  A a;
+  rand int i;
+  function new();
+    a = new;
+    i = 7;
+  endfunction
+  task r();
+    if (a.randomize() with { j == i; } == 0) $stop;
+  endtask
+endclass
+
+module t;
+  initial begin
+    B b = new;
+    b.r();
+    if (b.a.j != 7) $stop;
+    $finish;
+  end
+endmodule


### PR DESCRIPTION
I found a case where removed block of code was an issue and its removal allowed for expected Verilator behavior. It happened when using `rand` variable inside inline constraint e.g.:
```systemverilog
class A;
  rand int j;
endclass

class B;
  A a;
  rand int i;
  function new();
    a = new;
    i = 7;
  endfunction
  task r();
    if (a.randomize() with { j == i; } == 0) $stop;
  endtask
endclass
```

Removed block of code has been introduced a few weeks ago in [this](https://github.com/verilator/verilator/pull/6185) PR. Actually, I don't know why it has been introduced - from my static code analysis, I concluded that: when we are dealing with `std::randomize` (which was introduced in the mentioned PR) this code is unreachable and when we are not, everything had been working just fine.
