### PR TITLE
Fix expression type comparison

### DIFF
--- a/src/V3AstNodeExpr.h
+++ b/src/V3AstNodeExpr.h
@@ -587,10 +587,6 @@ public:
     string emitVerilog() override { V3ERROR_NA_RETURN(""); }
     string emitC() override { V3ERROR_NA_RETURN(""); }
     bool cleanOut() const override { V3ERROR_NA_RETURN(true); }
-    AstNodeDType* fromDTypep() const {
-        if (AstNodeDType* dtypep = VN_CAST(fromp(), NodeDType)) return dtypep;
-        return VN_AS(fromp(), NodeExpr)->dtypep();
-    }
 };
 class AstCExpr final : public AstNodeExpr {
     // @astgen op1 := exprsp : List[AstNode] // Expressions to print

--- a/src/V3AstNodeExpr.h
+++ b/src/V3AstNodeExpr.h
@@ -588,14 +588,8 @@ public:
     string emitC() override { V3ERROR_NA_RETURN(""); }
     bool cleanOut() const override { V3ERROR_NA_RETURN(true); }
     AstNodeDType* fromDTypep() const {
-        if (m_attrType == VAttrType::TYPEID) {
-            if (AstNodeDType* dtypep = VN_CAST(fromp(), NodeDType)) {
-                return dtypep;
-            } else if (AstNodeExpr* exprp = VN_CAST(fromp(), NodeExpr)) {
-                return exprp->dtypep();
-            }
-        }
-        return nullptr;
+        if (AstNodeDType* dtypep = VN_CAST(fromp(), NodeDType)) return dtypep;
+        return VN_AS(fromp(), NodeExpr)->dtypep();
     }
 };
 class AstCExpr final : public AstNodeExpr {

--- a/src/V3AstNodeExpr.h
+++ b/src/V3AstNodeExpr.h
@@ -587,6 +587,16 @@ public:
     string emitVerilog() override { V3ERROR_NA_RETURN(""); }
     string emitC() override { V3ERROR_NA_RETURN(""); }
     bool cleanOut() const override { V3ERROR_NA_RETURN(true); }
+    AstNodeDType* fromDTypep() const {
+        if (m_attrType == VAttrType::TYPEID) {
+            if (AstNodeDType* dtypep = VN_CAST(fromp(), NodeDType)) {
+                return dtypep;
+            } else if (AstNodeExpr* exprp = VN_CAST(fromp(), NodeExpr)) {
+                return exprp->dtypep();
+            }
+        }
+        return nullptr;
+    }
 };
 class AstCExpr final : public AstNodeExpr {
     // @astgen op1 := exprsp : List[AstNode] // Expressions to print

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -7010,18 +7010,8 @@ class WidthVisitor final : public VNVisitor {
                         "Type compare expects type reference");
             UASSERT_OBJ(rhsap->attrType() == VAttrType::TYPEID, rhsap,
                         "Type compare expects type reference");
-            AstNodeDType* lhsDtp = nullptr;
-            AstNodeDType* rhsDtp = nullptr;
-            if (!(lhsDtp = VN_CAST(lhsap->fromp(), NodeDType))) {
-                if (AstNodeExpr* const exprp = VN_CAST(lhsap->fromp(), NodeExpr)) {
-                    lhsDtp = exprp->dtypep();
-                }
-            }
-            if (!(rhsDtp = VN_CAST(rhsap->fromp(), NodeDType))) {
-                if (AstNodeExpr* const exprp = VN_CAST(rhsap->fromp(), NodeExpr)) {
-                    rhsDtp = exprp->dtypep();
-                }
-            }
+            const AstNodeDType* const lhsDtp = lhsap->fromDTypep();
+            const AstNodeDType* const rhsDtp = rhsap->fromDTypep();
             UASSERT_OBJ(lhsDtp, lhsap, "LHS has no data type");
             UASSERT_OBJ(rhsDtp, rhsap, "RHS has no data type");
             UINFO(9, "==type lhsDtp " << lhsDtp);

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -1832,8 +1832,11 @@ class WidthVisitor final : public VNVisitor {
             break;
         }
         case VAttrType::TYPEID:
-            // Soon to be handled in AstEqT
-            nodep->dtypeSetSigned32();
+            if (AstNodeDType* dtypep = VN_CAST(nodep->fromp(), NodeDType)) {
+                nodep->dtypep(dtypep);
+            } else {
+                nodep->dtypep(VN_AS(nodep->fromp(), NodeExpr)->dtypep());
+            }
             break;
         case VAttrType::VAR_BASE:
             // Soon to be handled in V3LinkWidth SEL generation, under attrp() and newSubLsbOf
@@ -2395,7 +2398,7 @@ class WidthVisitor final : public VNVisitor {
             nodep->attrsp()->foreach([this, nodep](AstAttrOf* attrp) {
                 if (attrp->attrType() == VAttrType::VAR_PORT_DTYPE) {
                     V3Const::constifyParamsEdit(attrp->fromp());  // fromp may change
-                    if (!similarDTypeRecurse(nodep->dtypep(), attrp->fromDTypep())) {
+                    if (!similarDTypeRecurse(nodep->dtypep(), attrp->dtypep())) {
                         nodep->dtypep()->v3error("Non-ANSI I/O declaration of signal "
                                                  "conflicts with type declaration: "
                                                  << nodep->prettyNameQ() << '\n'
@@ -5186,7 +5189,7 @@ class WidthVisitor final : public VNVisitor {
         // Deal with case(type(data_type))
         if (AstAttrOf* const exprap = VN_CAST(nodep->exprp(), AttrOf)) {
             if (exprap->attrType() == VAttrType::TYPEID) {
-                const AstNodeDType* const exprDtp = exprap->fromDTypep();
+                const AstNodeDType* const exprDtp = exprap->dtypep();
                 UINFO(9, "case type exprDtp " << exprDtp);
                 // V3Param may have a pointer to this case statement, and we need
                 // dotted references to remain properly named, so rather than
@@ -5205,7 +5208,7 @@ class WidthVisitor final : public VNVisitor {
                                 condp->v3error(
                                     "Case(type) statement requires items that have type() items");
                             } else {
-                                AstNodeDType* const condDtp = condAttrp->fromDTypep();
+                                AstNodeDType* const condDtp = condAttrp->dtypep();
                                 if (AstNode::computeCastable(exprDtp, condDtp, nodep)
                                     == VCastable::SAMEISH) {
                                     hit = true;
@@ -7010,8 +7013,8 @@ class WidthVisitor final : public VNVisitor {
                         "Type compare expects type reference");
             UASSERT_OBJ(rhsap->attrType() == VAttrType::TYPEID, rhsap,
                         "Type compare expects type reference");
-            const AstNodeDType* const lhsDtp = lhsap->fromDTypep();
-            const AstNodeDType* const rhsDtp = rhsap->fromDTypep();
+            const AstNodeDType* const lhsDtp = lhsap->dtypep();
+            const AstNodeDType* const rhsDtp = rhsap->dtypep();
             UINFO(9, "==type lhsDtp " << lhsDtp);
             UINFO(9, "==type rhsDtp " << lhsDtp);
             const bool invert = VN_IS(nodep, NeqT);

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -2395,7 +2395,7 @@ class WidthVisitor final : public VNVisitor {
             nodep->attrsp()->foreach([this, nodep](AstAttrOf* attrp) {
                 if (attrp->attrType() == VAttrType::VAR_PORT_DTYPE) {
                     V3Const::constifyParamsEdit(attrp->fromp());  // fromp may change
-                    if (!similarDTypeRecurse(nodep->dtypep(), VN_AS(attrp->fromp(), NodeDType))) {
+                    if (!similarDTypeRecurse(nodep->dtypep(), attrp->fromDTypep())) {
                         nodep->dtypep()->v3error("Non-ANSI I/O declaration of signal "
                                                  "conflicts with type declaration: "
                                                  << nodep->prettyNameQ() << '\n'
@@ -5186,7 +5186,7 @@ class WidthVisitor final : public VNVisitor {
         // Deal with case(type(data_type))
         if (AstAttrOf* const exprap = VN_CAST(nodep->exprp(), AttrOf)) {
             if (exprap->attrType() == VAttrType::TYPEID) {
-                AstNodeDType* const exprDtp = VN_AS(exprap->fromp(), NodeDType);
+                const AstNodeDType* const exprDtp = exprap->fromDTypep();
                 UINFO(9, "case type exprDtp " << exprDtp);
                 // V3Param may have a pointer to this case statement, and we need
                 // dotted references to remain properly named, so rather than
@@ -5205,7 +5205,7 @@ class WidthVisitor final : public VNVisitor {
                                 condp->v3error(
                                     "Case(type) statement requires items that have type() items");
                             } else {
-                                AstNodeDType* const condDtp = VN_AS(condAttrp->fromp(), NodeDType);
+                                AstNodeDType* const condDtp = condAttrp->fromDTypep();
                                 if (AstNode::computeCastable(exprDtp, condDtp, nodep)
                                     == VCastable::SAMEISH) {
                                     hit = true;
@@ -7012,8 +7012,6 @@ class WidthVisitor final : public VNVisitor {
                         "Type compare expects type reference");
             const AstNodeDType* const lhsDtp = lhsap->fromDTypep();
             const AstNodeDType* const rhsDtp = rhsap->fromDTypep();
-            UASSERT_OBJ(lhsDtp, lhsap, "LHS has no data type");
-            UASSERT_OBJ(rhsDtp, rhsap, "RHS has no data type");
             UINFO(9, "==type lhsDtp " << lhsDtp);
             UINFO(9, "==type rhsDtp " << lhsDtp);
             const bool invert = VN_IS(nodep, NeqT);

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -2398,7 +2398,7 @@ class WidthVisitor final : public VNVisitor {
             nodep->attrsp()->foreach([this, nodep](AstAttrOf* attrp) {
                 if (attrp->attrType() == VAttrType::VAR_PORT_DTYPE) {
                     V3Const::constifyParamsEdit(attrp->fromp());  // fromp may change
-                    if (!similarDTypeRecurse(nodep->dtypep(), attrp->dtypep())) {
+                    if (!similarDTypeRecurse(nodep->dtypep(), VN_AS(attrp->fromp(), NodeDType))) {
                         nodep->dtypep()->v3error("Non-ANSI I/O declaration of signal "
                                                  "conflicts with type declaration: "
                                                  << nodep->prettyNameQ() << '\n'

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -7010,8 +7010,20 @@ class WidthVisitor final : public VNVisitor {
                         "Type compare expects type reference");
             UASSERT_OBJ(rhsap->attrType() == VAttrType::TYPEID, rhsap,
                         "Type compare expects type reference");
-            AstNodeDType* const lhsDtp = VN_AS(lhsap->fromp(), NodeDType);
-            AstNodeDType* const rhsDtp = VN_AS(rhsap->fromp(), NodeDType);
+            AstNodeDType* lhsDtp = nullptr;
+            AstNodeDType* rhsDtp = nullptr;
+            if (!(lhsDtp = VN_CAST(lhsap->fromp(), NodeDType))) {
+                if (AstNodeExpr* const exprp = VN_CAST(lhsap->fromp(), NodeExpr)) {
+                    lhsDtp = exprp->dtypep();
+                }
+            }
+            if (!(rhsDtp = VN_CAST(rhsap->fromp(), NodeDType))) {
+                if (AstNodeExpr* const exprp = VN_CAST(rhsap->fromp(), NodeExpr)) {
+                    rhsDtp = exprp->dtypep();
+                }
+            }
+            UASSERT_OBJ(lhsDtp, lhsap, "LHS has no data type");
+            UASSERT_OBJ(rhsDtp, rhsap, "RHS has no data type");
             UINFO(9, "==type lhsDtp " << lhsDtp);
             UINFO(9, "==type rhsDtp " << lhsDtp);
             const bool invert = VN_IS(nodep, NeqT);

--- a/test_regress/t/t_type_expression_compare.py
+++ b/test_regress/t/t_type_expression_compare.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2025 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile()
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_type_expression_compare.v
+++ b/test_regress/t/t_type_expression_compare.v
@@ -12,7 +12,11 @@ module t;
       int value2 = 13;
       if (type(value1) != type(value2)) $stop;
       if (type(value1 + value2) != type(value2 + 18)) $stop;
-      $write("*-* All Finished *-*\n");
-      $finish;
+      if (type(value1) == type(value2) && type(value1 + value2) == type(value2 + 18)) begin
+        $write("*-* All Finished *-*\n");
+        $finish;
+      end else begin
+        $stop;
+      end
    end
 endmodule

--- a/test_regress/t/t_type_expression_compare.v
+++ b/test_regress/t/t_type_expression_compare.v
@@ -10,8 +10,22 @@ module t;
    initial begin
       Int_T value1 = 7;
       int value2 = 13;
+      real r;
       if (type(value1) != type(value2)) $stop;
       if (type(value1 + value2) != type(value2 + 18)) $stop;
+      case (type(value1))
+        type(value2): ;
+        type(r): $stop;
+        type(chandle): $stop;
+        type(logic): $stop;
+        default: $stop;
+      endcase
+      case (type(value1 + value2 + 13))
+        type(type(value2 + 18 - 40)): ;
+        type(r): $stop;
+        type(chandle): $stop;
+        default: $stop;
+      endcase
       if (type(value1) == type(value2) && type(value1 + value2) == type(value2 + 18)) begin
         $write("*-* All Finished *-*\n");
         $finish;

--- a/test_regress/t/t_type_expression_compare.v
+++ b/test_regress/t/t_type_expression_compare.v
@@ -1,0 +1,18 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2025 by Antmicro.
+// SPDX-License-Identifier: CC0-1.0
+
+typedef int Int_T;
+
+module t;
+   initial begin
+      Int_T value1 = 7;
+      int value2 = 13;
+      if (type(value1) != type(value2)) $stop;
+      if (type(value1 + value2) != type(value2 + 18)) $stop;
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end
+endmodule

--- a/test_regress/t/t_type_expression_compare.v
+++ b/test_regress/t/t_type_expression_compare.v
@@ -7,30 +7,30 @@
 typedef int Int_T;
 
 module t;
-   initial begin
-      Int_T value1 = 7;
-      int value2 = 13;
-      real r;
-      if (type(value1) != type(value2)) $stop;
-      if (type(value1 + value2) != type(value2 + 18)) $stop;
-      case (type(value1))
-        type(value2): ;
-        type(r): $stop;
-        type(chandle): $stop;
-        type(logic): $stop;
-        default: $stop;
-      endcase
-      case (type(value1 + value2 + 13))
-        type(type(value2 + 18 - 40)): ;
-        type(r): $stop;
-        type(chandle): $stop;
-        default: $stop;
-      endcase
-      if (type(value1) == type(value2) && type(value1 + value2) == type(value2 + 18)) begin
-        $write("*-* All Finished *-*\n");
-        $finish;
-      end else begin
-        $stop;
-      end
-   end
+  initial begin
+    Int_T value1 = 7;
+    int value2 = 13;
+    real r;
+    if (type(value1) != type(value2)) $stop;
+    if (type(value1 + value2) != type(value2 + 18)) $stop;
+    case (type(value1))
+      type(value2): ;
+      type(r): $stop;
+      type(chandle): $stop;
+      type(logic): $stop;
+      default: $stop;
+    endcase
+    case (type(value1 + value2 + 13))
+      type(type(value2 + 18 - 40)): ;
+      type(r): $stop;
+      type(chandle): $stop;
+      default: $stop;
+    endcase
+    if (type(value1) == type(value2) && type(value1 + value2) == type(value2 + 18)) begin
+      $write("*-* All Finished *-*\n");
+      $finish;
+    end else begin
+      $stop;
+    end
+  end
 endmodule


### PR DESCRIPTION
When trying to compare types of expressions using `type(expr) !=/== type(expr)` verilator did throw an internal error.

This fixes the above issue and allows to compare types of expressions.