### PR TITLE
Internals: Add separate cppcheck targets for whole components

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -392,16 +392,11 @@ install-msg:
 ######################################################################
 # Format/Lint
 
-CPPCHECK1_CPP = $(wildcard $(srcdir)/include/*.cpp)
-CPPCHECK2_CPP = $(wildcard $(srcdir)/examples/*/*.cpp)
-CPPCHECK3_CPP = $(wildcard $(srcdir)/src/Vlc*.cpp)
-CPPCHECK4_CPP = $(wildcard $(srcdir)/src/V3[A-D]*.cpp $(srcdir)/src/Verilator*.cpp)
-CPPCHECK5_CPP = $(wildcard $(srcdir)/src/V3[E-I]*.cpp)
-CPPCHECK6_CPP = $(wildcard $(srcdir)/src/V3[P-Z]*.cpp)
-CPPCHECK7_CPP = $(wildcard $(srcdir)/src/V3[L-R]*.cpp)
-CPPCHECK8_CPP = $(wildcard $(srcdir)/src/V3[S-Z]*.cpp)
-CHECK_CPP = $(CPPCHECK1_CPP) $(CPPCHECK2_CPP) $(CPPCHECK3_CPP) $(CPPCHECK4_CPP) \
-  $(CPPCHECK5_CPP) $(CPPCHECK6_CPP) $(CPPCHECK7_CPP) $(CPPCHECK8_CPP)
+CPPCHECK_VERILATOR_CPP = $(wildcard $(srcdir)/src/V3*.cpp $(srcdir)/src/Verilator*.cpp)
+CPPCHECK_RUNTIME_CPP = $(wildcard $(srcdir)/include/*.cpp)
+CPPCHECK_VLC_CPP = $(wildcard $(srcdir)/src/Vlc*.cpp)
+CPPCHECK_EXAMPLES_CPP = $(wildcard $(srcdir)/examples/*/*.cpp)
+CHECK_CPP = $(CPPCHECK_VERILATOR_CPP) $(CPPCHECK_RUNTIME_CPP) $(CPPCHECK_VLC_CPP) $(CPPCHECK_EXAMPLES_CPP)
 CHECK_H = $(wildcard \
   $(srcdir)/include/*.h \
   $(srcdir)/src/*.h )
@@ -409,12 +404,14 @@ CHECK_YL = $(wildcard \
   $(srcdir)/src/*.y \
   $(srcdir)/src/*.l )
 CPPCHECK = cppcheck
+CPPCHECK_JOBS = $(shell nproc)
 CPPCHECK_CACHE = $(srcdir)/src/obj_dbg/cppcheck-cache
 CPPCHECK_FLAGS = --enable=all
 CPPCHECK_FLAGS += --inline-suppr
 CPPCHECK_FLAGS += --suppressions-list=$(srcdir)/src/cppcheck-suppressions.txt
 CPPCHECK_FLAGS += --cppcheck-build-dir=$(CPPCHECK_CACHE)
 CPPCHECK_FLAGS += -DVL_DEBUG=1 -DVL_CPPCHECK=1 -D__GNUC__=1
+CPPCHECK_FLAGS += -j$(CPPCHECK_JOBS)
 CPPCHECK_INC = -I$(srcdir)/include
 CPPCHECK_INC += -I$(srcdir)/include/gtkwave
 CPPCHECK_INC += -I$(srcdir)/include/vltstd
@@ -425,23 +422,20 @@ $(CPPCHECK_CACHE): $(CHECK_CPP) $(CHECK_H) $(CHECK_YL)
 	/bin/rm -rf $@
 	/bin/mkdir -p $@
 
-cppcheck: cppcheck-1 cppcheck-2 cppcheck-3 cppcheck-4 cppcheck-5 cppcheck-6 cppcheck-7 cppcheck-8
-cppcheck-1: | $(CPPCHECK_CACHE)
-	$(CPPCHECK) $(CPPCHECK_FLAGS) $(CPPCHECK_INC) $(CPPCHECK1_CPP)
-cppcheck-2: | $(CPPCHECK_CACHE)
-	$(CPPCHECK) $(CPPCHECK_FLAGS) $(CPPCHECK_INC) $(CPPCHECK2_CPP)
-cppcheck-3: | $(CPPCHECK_CACHE)
-	$(CPPCHECK) $(CPPCHECK_FLAGS) $(CPPCHECK_INC) $(CPPCHECK3_CPP)
-cppcheck-4: | $(CPPCHECK_CACHE)
-	$(CPPCHECK) $(CPPCHECK_FLAGS) $(CPPCHECK_INC) $(CPPCHECK4_CPP)
-cppcheck-5: | $(CPPCHECK_CACHE)
-	$(CPPCHECK) $(CPPCHECK_FLAGS) $(CPPCHECK_INC) $(CPPCHECK5_CPP)
-cppcheck-6: | $(CPPCHECK_CACHE)
-	$(CPPCHECK) $(CPPCHECK_FLAGS) $(CPPCHECK_INC) $(CPPCHECK6_CPP)
-cppcheck-7: | $(CPPCHECK_CACHE)
-	$(CPPCHECK) $(CPPCHECK_FLAGS) $(CPPCHECK_INC) $(CPPCHECK7_CPP)
-cppcheck-8: | $(CPPCHECK_CACHE)
-	$(CPPCHECK) $(CPPCHECK_FLAGS) $(CPPCHECK_INC) $(CPPCHECK8_CPP)
+cppcheck-verilator: | $(CPPCHECK_CACHE)
+	$(CPPCHECK) $(CPPCHECK_FLAGS) $(CPPCHECK_INC) $(CPPCHECK_VERILATOR_CPP)
+cppcheck-runtime: | $(CPPCHECK_CACHE)
+	$(CPPCHECK) $(CPPCHECK_FLAGS) $(CPPCHECK_INC) $(CPPCHECK_RUNTIME_CPP)
+cppcheck-vlc: | $(CPPCHECK_CACHE)
+	$(CPPCHECK) $(CPPCHECK_FLAGS) $(CPPCHECK_INC) $(CPPCHECK_VLC_CPP)
+cppcheck-examples: | $(CPPCHECK_CACHE)
+	$(CPPCHECK) $(CPPCHECK_FLAGS) $(CPPCHECK_INC) $(CPPCHECK_EXAMPLES_CPP)
+
+cppcheck:
+	$(MAKE) cppcheck-vlc
+	$(MAKE) cppcheck-examples
+	$(MAKE) cppcheck-runtime
+	$(MAKE) cppcheck-verilator
 
 CLANGTIDY = clang-tidy
 CLANGTIDY_FLAGS = -config='' \


### PR DESCRIPTION
cppcheck provides best results when analysing the whole program. It also has a builtin `-j` option to run on multiple threads.

Replace existing cppcheck-* targets with cppcheck-verilator, cppcheck-runtime, cppcheck-example and cppcheck-vlc that checks each of those components as a whole. Each of these runs on the maximum available logical processors on the host by default, as reported by `nproc`, but can be manually overridden with `make CPPCHECK_JOBS=<number>` instead.

The `make cppcheck` target runs the 4 cppcheck-* targets listed above sequentially (but each of them uses the specified CPPCHECK_JOBS threads)
