### PR TITLE
Fix: Only return new queue index if push_back succeeded

### DIFF
--- a/include/verilated_types.h
+++ b/include/verilated_types.h
@@ -621,11 +621,8 @@ public:
     T_Value& atWriteAppend(int32_t index) {
         // cppcheck-suppress variableScope
         static thread_local T_Value t_throwAway;
+        if (index == m_deque.size()) push_back(atDefault());
         if (VL_UNLIKELY(index < 0 || index >= m_deque.size())) {
-            if (index == m_deque.size()) {
-                push_back(atDefault());
-                return m_deque[index];
-            }
             t_throwAway = atDefault();
             return t_throwAway;
         }


### PR DESCRIPTION
Bounded queues can grow by `push_{front,back}` up to a certain size, this was not handled when the queue grew instead by a write to `q[q.size]`.

This would cause `t_queue_bounded` fail when run on FreeBSD 14.3-RELEASE with clang 19.1.7 (amd64).
