### PR TITLE
Optimize multiplexers in Dfg synthesis

### DIFF
--- a/src/V3Cfg.cpp
+++ b/src/V3Cfg.cpp
@@ -29,24 +29,9 @@
 VL_DEFINE_DEBUG_FUNCTIONS;
 
 //######################################################################
-// ControlFlowGraph method definitions
+// CfgBlock method definitions
 
-bool ControlFlowGraph::containsLoop() const {
-    for (const V3GraphVertex& vtx : vertices()) {
-        const BasicBlock& current = static_cast<const BasicBlock&>(vtx);
-        for (const V3GraphEdge& edge : current.outEdges()) {
-            const BasicBlock& successor = *static_cast<const BasicBlock*>(edge.top());
-            // IDs are the reverse post-order numbering, so easy to check for a back-edge
-            if (successor.id() < current.id()) return true;
-        }
-    }
-    return false;
-}
-
-//######################################################################
-// BasicBlock method definitions
-
-std::string BasicBlock::name() const {
+std::string CfgBlock::name() const {
     std::stringstream ss;
     ss << "BB " + std::to_string(id()) + ":\n";
     for (AstNode* nodep : m_stmtps) {
@@ -62,29 +47,275 @@ std::string BasicBlock::name() const {
             V3EmitV::debugVerilogForTree(nodep, ss);
         }
     }
-    std::string text = VString::replaceSubstr(ss.str(), "\n", "\\l        ");
-    if (inEmpty()) text = "**ENTER**\n" + text;
-    if (outEmpty()) text = text + "\n**EXIT**";
+    std::string text = VString::replaceSubstr(
+        VString::replaceSubstr(ss.str(), "\n", "\\l        "), "\"", "\\\"");
+    if (isEnter()) text = "**ENTER**\n" + text;
+    if (isExit()) text = text + "\n**EXIT**";
     return text;
 }
-std::string BasicBlock::dotShape() const { return "rect"; }
-std::string BasicBlock::dotRank() const {
-    if (inEmpty()) return "source";
-    if (outEmpty()) return "sink";
+std::string CfgBlock::dotShape() const { return "rect"; }
+std::string CfgBlock::dotRank() const {
+    if (isEnter()) return "source";
+    if (isExit()) return "sink";
     return "";
 }
 
 //######################################################################
-// ControlFlowEdge method definitions
+// CfgEdge method definitions
 
-std::string ControlFlowEdge::dotLabel() const {
+std::string CfgEdge::dotLabel() const {
     std::string label = "E" + std::to_string(id());
-    const BasicBlock& source = *fromp()->as<BasicBlock>();
-    const ControlFlowEdge* const untknp = source.untknEdgep();
+    const CfgEdge* const untknp = srcp()->untknEdgep();
     if (this == untknp) {
         label += " / F";
     } else if (untknp) {
         label += " / T";
     }
     return label;
+}
+
+//######################################################################
+// CfgGraph method definitions
+
+static void cfgOrderVisitBlock(std::vector<CfgBlock*>& postOrderEnumeration, CfgBlock* bbp) {
+    // Mark visited
+    bbp->user(1);
+    // Visit un-visited successors
+    if (CfgBlock* const takenp = bbp->takenp()) {
+        if (!takenp->user()) cfgOrderVisitBlock(postOrderEnumeration, takenp);
+        if (CfgBlock* const untknp = bbp->untknp()) {
+            if (!untknp->user()) cfgOrderVisitBlock(postOrderEnumeration, untknp);
+        }
+    }
+    // Add to post order enumeration
+    postOrderEnumeration.emplace_back(bbp);
+};
+
+void CfgGraph::rpoBlocks() {
+    UASSERT_OBJ(m_nEdits != m_nLastOrdered, m_enterp, "Redundant 'CfgGraph::order' call");
+    m_nLastOrdered = m_nEdits;
+
+    // Reset marks
+    for (V3GraphVertex& v : vertices()) v.user(0);
+
+    // Compute post-order enumeration. Simple recursive algorith will do.
+    std::vector<CfgBlock*> postOrderEnumeration;
+    postOrderEnumeration.reserve(m_nBlocks);
+    cfgOrderVisitBlock(postOrderEnumeration, m_enterp);
+    UASSERT_OBJ(postOrderEnumeration.size() == m_nBlocks, m_enterp, "Inconsistent block count");
+
+    // Assign block IDs equal to the reverse post-order number and sort vertices
+    for (size_t i = 0; i < postOrderEnumeration.size(); ++i) {
+        CfgBlock* const bbp = postOrderEnumeration[m_nBlocks - 1 - i];
+        bbp->m_rpoNumber = i;
+        vertices().unlink(bbp);
+        vertices().linkBack(bbp);
+    }
+
+    // Assign edge IDs
+    size_t edgeCount = 0;
+    for (V3GraphVertex& v : vertices()) {
+        for (V3GraphEdge& e : v.outEdges()) static_cast<CfgEdge&>(e).m_id = edgeCount++;
+    }
+    UASSERT_OBJ(edgeCount == m_nEdges, m_enterp, "Inconsistent edge count");
+}
+
+bool CfgGraph::containsLoop() const {
+    for (const V3GraphVertex& vtx : vertices()) {
+        const CfgBlock& current = static_cast<const CfgBlock&>(vtx);
+        for (const V3GraphEdge& edge : current.outEdges()) {
+            const CfgBlock& successor = *static_cast<const CfgBlock*>(edge.top());
+            // IDs are the reverse post-order numbering, so easy to check for a back-edge
+            if (successor.id() < current.id()) return true;
+        }
+    }
+    return false;
+}
+
+void CfgGraph::minimize() {
+    // Remove empty blocks (except enter and exit)
+    for (V3GraphVertex* const vtxp : vertices().unlinkable()) {
+        CfgBlock* const bbp = static_cast<CfgBlock*>(vtxp);
+        if (bbp->isEnter()) continue;
+        if (bbp->isExit()) continue;
+        if (!bbp->stmtps().empty()) continue;
+        UASSERT(!bbp->isBranch(), "Empty block should have a single successor");
+        CfgBlock* const succp = bbp->takenp();
+        for (V3GraphEdge* const edgep : bbp->inEdges().unlinkable()) edgep->relinkTop(succp);
+        ++m_nEdits;
+        --m_nEdges;
+        --m_nBlocks;
+        VL_DO_DANGLING(bbp->unlinkDelete(this), bbp);
+    }
+
+    // Combine sequential blocks
+    for (V3GraphVertex* const vtxp : vertices().unlinkable()) {
+        CfgBlock* const srcp = static_cast<CfgBlock*>(vtxp);
+        if (srcp->isExit()) continue;
+        if (srcp->isBranch()) continue;
+        CfgBlock* const dstp = srcp->takenp();
+        if (dstp->isJoin()) continue;
+        // Combine them
+        if (srcp->isEnter()) m_enterp = dstp;
+        std::vector<AstNodeStmt*> stmtps{std::move(srcp->m_stmtps)};
+        stmtps.reserve(stmtps.size() + dstp->m_stmtps.size());
+        stmtps.insert(stmtps.end(), dstp->m_stmtps.begin(), dstp->m_stmtps.end());
+        dstp->m_stmtps = std::move(stmtps);
+        for (V3GraphEdge* const edgep : srcp->inEdges().unlinkable()) edgep->relinkTop(dstp);
+        ++m_nEdits;
+        --m_nEdges;
+        --m_nBlocks;
+        VL_DO_DANGLING(srcp->unlinkDelete(this), srcp);
+    }
+
+    if (m_nEdits != m_nLastOrdered) rpoBlocks();
+    if (dumpGraphLevel() >= 9) dumpDotFilePrefixed("cfg-minimize");
+}
+
+void CfgGraph::breakCriticalEdges() {
+    // Gather critical edges
+    std::vector<CfgEdge*> criticalEdges;
+    criticalEdges.reserve(m_nEdges);
+    for (V3GraphVertex& vtx : vertices()) {
+        const CfgBlock& bb = static_cast<const CfgBlock&>(vtx);
+        if (!bb.isBranch()) continue;
+        for (V3GraphEdge& edge : vtx.outEdges()) {
+            const CfgBlock& succ = static_cast<const CfgBlock&>(*edge.top());
+            if (!succ.isJoin()) continue;
+            criticalEdges.emplace_back(static_cast<CfgEdge*>(&edge));
+        }
+    }
+    // Insert blocks
+    for (CfgEdge* const edgep : criticalEdges) {
+        CfgBlock* const newp = addBlock();
+        addTakenEdge(newp, edgep->dstp());
+        edgep->relinkTop(newp);
+    }
+
+    if (m_nEdits != m_nLastOrdered) rpoBlocks();
+    if (dumpGraphLevel() >= 9) dumpDotFilePrefixed("cfg-breakCriticalEdges");
+}
+
+// Given a branching basic block, if the sub-graph below this branch, up until
+// the point where all of its control flow path convertes is series-parallel,
+// then return the (potentially newly created) basic block with exactly 2
+// predecessors where the two control flow paths from this branch have joined.
+// If the relevant sub-graph is not series-parallel (there is a control flow
+// path between the branches, or to a path not dominated by the given branch),
+// then return nullptr. Cached results in the given map
+CfgBlock* CfgGraph::getOrCreateTwoWayJoinFor(CfgBlock* bbp) {
+    UASSERT_OBJ(bbp->isBranch(), bbp, "Not a branch");
+
+    // Mark visited
+    UASSERT_OBJ(!bbp->user(), bbp, "Should not visit twice");
+    bbp->user(1);
+
+    // We need the edge converting to a join block along both path. This is how we find it:
+    const auto chaseEdge = [&](CfgEdge* edgep) -> CfgEdge* {
+        while (true) {
+            CfgBlock* dstp = edgep->dstp();
+            // Stop if found the joining block along this path
+            if (dstp->isJoin()) return edgep;
+            // If the successor is a branch, recursively get it's 2-way join block
+            while (dstp->isBranch()) {
+                dstp = getOrCreateTwoWayJoinFor(dstp);
+                // If the subgarph below dstp is not series-parallel, then no solution
+                if (!dstp) return nullptr;
+            }
+            UASSERT_OBJ(!dstp->isExit(), bbp, "Non-convergent branch - multiple Exit blocks?");
+            edgep = dstp->takenEdgep();
+        }
+    };
+
+    // Walk down both paths
+    CfgEdge* const takenEdgep = chaseEdge(bbp->takenEdgep());
+    if (!takenEdgep) return nullptr;
+    CfgEdge* const untknEdgep = chaseEdge(bbp->untknEdgep());
+    if (!untknEdgep) return nullptr;
+    // If we ended up at different joining blocks, then there is a path from one
+    // of the branches into a path of another branch before 'bbp', no solution
+    if (takenEdgep->dstp() != untknEdgep->dstp()) return nullptr;
+
+    // Pick up the common successor
+    CfgBlock* const succp = takenEdgep->dstp();
+    // If the common successor is a 2-way join, we can use it directly
+    if (succp->isTwoWayJoin()) return succp;
+    // Otherwise insert a new block to join the 2 paths of the original block
+    CfgBlock* const joinp = addBlock();
+    addTakenEdge(joinp, succp);
+    takenEdgep->relinkTop(joinp);
+    untknEdgep->relinkTop(joinp);
+    return joinp;
+}
+
+bool CfgGraph::insertTwoWayJoins() {
+    // Reset marks
+    for (V3GraphVertex& v : vertices()) v.user(0);
+
+    bool isSeriesParallel = true;
+
+    // We will be adding vertices at the end. That's OK, they don't need to be visited again
+    for (V3GraphVertex& v : vertices()) {
+        CfgBlock& bb = static_cast<CfgBlock&>(v);
+        // Skip if already visited
+        if (bb.user()) continue;
+        // Skip if not a branch
+        if (!bb.isBranch()) continue;
+        // Fix it up, record if failed
+        if (!getOrCreateTwoWayJoinFor(&bb)) isSeriesParallel = false;
+    }
+
+    if (m_nEdits != m_nLastOrdered) rpoBlocks();
+    if (dumpGraphLevel() >= 9) dumpDotFilePrefixed("cfg-insertTwoWayJoins");
+
+    return isSeriesParallel;
+}
+
+//######################################################################
+// CfgDominatorTree
+
+const CfgBlock* CfgDominatorTree::intersect(const CfgBlock* ap, const CfgBlock* bp) {
+    while (ap != bp) {
+        while (*ap > *bp) ap = m_bb2Idom[*ap];
+        while (*bp > *ap) bp = m_bb2Idom[*bp];
+    }
+    return ap;
+}
+
+CfgDominatorTree::CfgDominatorTree(const CfgGraph& cfg)
+    : m_bb2Idom{cfg.makeBlockMap<const CfgBlock*>()} {
+
+    // Build the immediate dominator map, using algorithm from:
+    // "A Simple, Fast Dominance Algorithm", Keith D. Cooper et al., 2006
+    // Immediate dominator of the enter block
+
+    // Point enteer block to itself, while computing below
+    m_bb2Idom[cfg.enter()] = &cfg.enter();
+    // Iterate until settled
+    for (bool changed = true; changed;) {
+        changed = false;
+        // For each vertex except enter block
+        for (const V3GraphVertex& vtx : cfg.vertices()) {
+            const CfgBlock& curr = static_cast<const CfgBlock&>(vtx);
+            if (curr.isEnter()) continue;  // Skip entry block
+
+            // For each predecessor of current block
+            const CfgBlock* idom = nullptr;
+            for (const V3GraphEdge& edge : curr.inEdges()) {
+                const CfgBlock& pred = static_cast<const CfgBlock&>(*edge.fromp());
+                // Skip if perdecessor not yet processed
+                if (!m_bb2Idom[pred]) continue;
+                // Pick first, then use intersect
+                idom = !idom ? &pred : intersect(&pred, idom);
+            }
+
+            // If chenged, record it, else move on
+            if (idom == m_bb2Idom[curr]) continue;
+            m_bb2Idom[curr] = idom;
+            changed = true;
+        }
+    }
+
+    // The enter block is the root of the tree and does not itself have an immediate dominator
+    m_bb2Idom[cfg.enter()] = nullptr;
 }

--- a/src/V3Cfg.h
+++ b/src/V3Cfg.h
@@ -68,69 +68,103 @@
 #include <vector>
 
 //######################################################################
-// DenseMap - This can be made generic if needed
+// Control Flow Graph (CFG) and related data structures
 
-// Map from unique non-negative integers (IDs) to generic values. As opposed
-// to a std::map/std::unordered_map, in DenseMap, all entries are value
-// initialized at construction, and the map is always dense. This can be
-// improved if necessary but is sufficient for our current purposes.
-template <typename T_Key, size_t (T_Key::*Index)() const, typename T_Value>
-class DenseMap final {
-    std::vector<T_Value> m_map;  // The map, stored as a vector
+class CfgGraph;
+class CfgBlock;
+class CfgEdge;
 
-public:
-    // CONSTRUCTOR
-    explicit DenseMap(size_t size)
-        : m_map{size} {}
-
-    T_Value& operator[](const T_Key& key) { return m_map.at((key.*Index)()); }
-    const T_Value& operator[](const T_Key& key) const { return m_map.at((key.*Index)()); }
-};
+template <typename T_Key, typename T_Value>
+class CfgMap;
+template <typename T_Value>
+class CfgBlockMap;
+template <typename T_Value>
+class CfgEdgeMap;
 
 //######################################################################
-// ControlFlowGraph data structure
+// CfgBlock - A basic block (verticies of the control flow graph)
 
-class ControlFlowGraph;
-class BasicBlock;
-class ControlFlowEdge;
-
-// A basic block (verticies of the control flow graph)
-class BasicBlock final : public V3GraphVertex {
-    VL_RTTI_IMPL(BasicBlock, V3GraphVertex)
+class CfgBlock final : public V3GraphVertex {
+    friend class CfgGraph;
+    template <typename T_Key, typename T_Value>
+    friend class CfgMap;
     friend class CfgBuilder;
 
-    // STATE - Immutable after construction, set by CfgBuilder
-    // V3GraphEdge::user() is set to the unique id by CfgBuilder
-    std::vector<AstNodeStmt*> m_stmtps;  // statements in this BasicBlock
+    // STATE
+    CfgGraph* const m_cfgp;  // The control flow graph this CfgBlock is under
+    size_t m_rpoNumber;  // Reverse post-order number and unique ID of this CfgBlock
 
-    // CONSTRUCTOR - via CfgBuilder only
-    inline explicit BasicBlock(ControlFlowGraph* graphp);
-    ~BasicBlock() override = default;
+    // V3GraphEdge::user() is set to the unique id by CfgBuilder
+    std::vector<AstNodeStmt*> m_stmtps;  // statements in this CfgBlock
+
+    // PRIVATE METHODS
+    // ID (reverse post-order numpber) of this block
+    inline size_t id();
+    inline size_t id() const;
+
+    // CONSTRUCTOR/DESTRUCTOR - via CfgGraph only
+    inline explicit CfgBlock(CfgGraph* cfgp);
+    ~CfgBlock() override = default;
 
 public:
-    // METHODS - all const
+    // PUBLIC METHODS
 
-    // Statements in this BasicBlock
+    // Is this the entry block of the CFG?
+    bool isEnter() const { return inEmpty(); }
+    // Is this the exit block of the CFG?
+    bool isExit() const { return outEmpty(); }
+    // Is this a branching block (multiple successors)?
+    bool isBranch() const { return outEdges().hasMultipleElements(); }
+    // Is this a control flow convergence block (multiple predecessors)?
+    bool isJoin() const { return inEdges().hasMultipleElements(); }
+    // Is this a join of exactly 2 paths?
+    bool isTwoWayJoin() const { return inEdges().hasTwoElements(); }
+
+    // The edge going to the taken (or uncinditional) successor, or nullptr if exit block
+    inline CfgEdge* takenEdgep();
+    inline const CfgEdge* takenEdgep() const;
+    // The edge going to the untaken successor, or nullptr if not a branch, or exit block
+    inline CfgEdge* untknEdgep();
+    inline const CfgEdge* untknEdgep() const;
+    // The taken successor block, or nullptr if exit block
+    inline CfgBlock* takenp();
+    inline const CfgBlock* takenp() const;
+    // The untakens successor block, or nullptr if not a branch, or exit block
+    inline CfgBlock* untknp();
+    inline const CfgBlock* untknp() const;
+
+    // The first predecessor edge, or nullptr if enter block
+    inline CfgEdge* firstPredecessorEdgep();
+    inline const CfgEdge* firstPredecessorEdgep() const;
+    // The last predecessor edge, or nullptr if enter block
+    inline CfgEdge* lastPredecessorEdgep();
+    inline const CfgEdge* lastPredecessorEdgep() const;
+    // The first predecessor block, or nullptr if enter block
+    inline CfgBlock* firstPredecessorp();
+    inline const CfgBlock* firstPredecessorp() const;
+    // The last predecessor block, or nullptr if enter block
+    inline CfgBlock* lastPredecessorp();
+    inline const CfgBlock* lastPredecessorp() const;
+
+    // Statements in this CfgBlock
     const std::vector<AstNodeStmt*>& stmtps() const { return m_stmtps; }
-    // Unique ID of this BasicBlock - defines topological ordering
-    size_t id() const { return V3GraphVertex::user(); }
 
-    // The edge corresponding to the terminator branch being taken (including unonditoinal goto)
-    inline const ControlFlowEdge* takenEdgep() const;
-    // The edge corresponding to the terminator branch being not taken (or nullptr if goto)
-    inline const ControlFlowEdge* untknEdgep() const;
-    // Same as takenpEdgep/untknEdgep but returns the successor basic blocks
-    inline const BasicBlock* takenSuccessorp() const;
-    inline const BasicBlock* untknSuccessorp() const;
+    // Ordering is done on reverese post-order numbering. For loop-free graph
+    // this ensures that a block that compares less than another is not a
+    // successor of the other block (it is an ancestor, or sibling).
+    bool operator<(const CfgBlock& that) const { return id() < that.id(); }
+    bool operator>(const CfgBlock& that) const { return id() > that.id(); }
+    bool operator==(const CfgBlock& that) const { return this == &that; }
 
-    void forEachSuccessor(std::function<void(const BasicBlock&)> f) const {
-        for (const V3GraphEdge& edge : outEdges()) f(*edge.top()->as<BasicBlock>());
+    // Iterators
+    void forEachSuccessor(std::function<void(const CfgBlock&)> f) const {
+        for (const V3GraphEdge& edge : outEdges()) f(*static_cast<CfgBlock*>(edge.top()));
+    }
+    void forEachPredecessor(std::function<void(const CfgBlock&)> f) const {
+        for (const V3GraphEdge& edge : inEdges()) f(*static_cast<CfgBlock*>(edge.fromp()));
     }
 
-    void forEachPredecessor(std::function<void(const BasicBlock&)> f) const {
-        for (const V3GraphEdge& edge : inEdges()) f(*edge.fromp()->as<BasicBlock>());
-    }
-
+    // Source location for debugging
     FileLine* fileline() const override {
         return !m_stmtps.empty() ? m_stmtps.front()->fileline() : nullptr;
     }
@@ -141,130 +175,397 @@ public:
     std::string dotRank() const override;
 };
 
-// A control flow graph edge
-class ControlFlowEdge final : public V3GraphEdge {
-    VL_RTTI_IMPL(ControlFlowEdge, V3GraphEdge)
-    friend class CfgBuilder;
+//######################################################################
+// CfgEdge - An edges of the control flow graph
+
+class CfgEdge final : public V3GraphEdge {
+    friend class CfgGraph;
+    template <typename T_Key, typename T_Value>
+    friend class CfgMap;
 
     // STATE - Immutable after construction, set by CfgBuilder
-    // V3GraphEdge::user() is set to the unique id by CfgBuilder
+    CfgGraph* const m_cfgp;  // The control flow graph this CfgEdge is under
+    size_t m_id;  // Unique ID of this vertex
 
-    // CONSTRUCTOR - via CfgBuilder only
-    inline ControlFlowEdge(ControlFlowGraph* graphp, BasicBlock* srcp, BasicBlock* dstp);
-    ~ControlFlowEdge() override = default;
+    // PRIVATE METHODS
+    // Unique ID of this CfgEdge - no particular meaning
+    inline size_t id();
+    inline size_t id() const;
+
+    // CONSTRUCTOR/DESTRUCTOR - via CfgGraph only
+    inline CfgEdge(CfgGraph* graphp, CfgBlock* srcp, CfgBlock* dstp);
+    ~CfgEdge() override = default;
 
 public:
     // METHODS - all const
 
-    // Unique ID of this ControlFlowEdge - no particular meaning
-    size_t id() const { return user(); }
-
-    // Source/destination BasicBlock
-    const BasicBlock& src() const { return *static_cast<BasicBlock*>(fromp()); }
-    const BasicBlock& dst() const { return *static_cast<BasicBlock*>(top()); }
+    // Source/destination CfgBlock
+    const CfgBlock* srcp() const { return static_cast<const CfgBlock*>(fromp()); }
+    const CfgBlock* dstp() const { return static_cast<const CfgBlock*>(top()); }
+    CfgBlock* srcp() { return static_cast<CfgBlock*>(fromp()); }
+    CfgBlock* dstp() { return static_cast<CfgBlock*>(top()); }
 
     // For Graphviz dumps only
     std::string dotLabel() const override;
 };
 
-template <typename T_Value>
-using BasicBlockMap = DenseMap<BasicBlock, &BasicBlock::id, T_Value>;
+//######################################################################
+// CfgGraph - The control flow graph
 
-template <typename T_Value>
-using ControlFlowEdgeMap = DenseMap<ControlFlowEdge, &ControlFlowEdge::id, T_Value>;
-
-// The control flow graph
-class ControlFlowGraph final : public V3Graph {
+class CfgGraph final : public V3Graph {
+    friend class CfgBlock;
+    friend class CfgEdge;
+    template <typename T_Key, typename T_Value>
+    friend class CfgMap;
     friend class CfgBuilder;
 
-    // STATE - Immutable after construction, set by CfgBuilder
-    BasicBlock* m_enterp = nullptr;  // The singular entry vertex
-    BasicBlock* m_exitp = nullptr;  // The singular exit vertex
-    size_t m_nBasicBlocks = 0;  // Number of BasicBlocks in this ControlFlowGraph
-    size_t m_nEdges = 0;  // Number of ControlFlowEdges in this ControlFlowGraph
+    // STATE
+    size_t m_nEdits = 0;  // Edit count of this graph
+    size_t m_nLastOrdered = 0;  // Last edit count blocks were ordered
+    CfgBlock* m_enterp = nullptr;  // The singular entry vertex
+    CfgBlock* m_exitp = nullptr;  // The singular exit vertex
+    size_t m_nBlocks = 0;  // Number of CfgBlocks in this CfgGraph
+    size_t m_nEdges = 0;  // Number of CfgEdges in this CfgGraph
 
-    // CONSTRUCTOR - via CfgBuilder only
-    ControlFlowGraph() = default;
+    // PRIVATE METHODS
 
-public:
-    ~ControlFlowGraph() override = default;
+    // Compute reverse post-order enumeration of blocks, and sort them
+    // accordingly. Assign blocks, and edge IDs. Invalidates all previous IDs.
+    void rpoBlocks();
 
-    // METHODS
-    void foreach(std::function<void(const BasicBlock&)> f) const {
-        for (const V3GraphVertex& vtx : vertices()) f(*vtx.as<BasicBlock>());
+    // Add a new CfgBlock to this graph
+    CfgBlock* addBlock() {
+        ++m_nEdits;
+        ++m_nBlocks;
+        return new CfgBlock{this};
     }
 
+    // Add a new taken (or unconditional) CfgEdge to this CFG
+    void addTakenEdge(CfgBlock* srcp, CfgBlock* dstp) {
+        UASSERT_OBJ(srcp->m_cfgp == this, srcp, "'srcp' is not in this graph");
+        UASSERT_OBJ(dstp->m_cfgp == this, dstp, "'dstp' is not in this graph");
+        UASSERT_OBJ(!srcp->takenEdgep(), srcp, "Taken edge should be added first");
+        //
+        UASSERT_OBJ(dstp != m_enterp, dstp, "Enter block cannot have a predecessor");
+        UASSERT_OBJ(srcp != m_exitp, srcp, "Exit block cannot have a successor");
+        ++m_nEdits;
+        ++m_nEdges;
+        new CfgEdge{this, srcp, dstp};
+    }
+
+    // Add a new untaken CfgEdge to this CFG
+    void addUntknEdge(CfgBlock* srcp, CfgBlock* dstp) {
+        UASSERT_OBJ(srcp->m_cfgp == this, srcp, "'srcp' is not in this graph");
+        UASSERT_OBJ(dstp->m_cfgp == this, dstp, "'dstp' is not in this graph");
+        UASSERT_OBJ(srcp->takenEdgep(), srcp, "Untaken edge shold be added second");
+        UASSERT_OBJ(srcp->takenp() != dstp, srcp, "Untaken branch targets the same block");
+        //
+        UASSERT_OBJ(dstp != m_enterp, dstp, "Enter block cannot have a predecessor");
+        UASSERT_OBJ(srcp != m_exitp, srcp, "Exit block cannot have a successor");
+        ++m_nEdits;
+        ++m_nEdges;
+        new CfgEdge{this, srcp, dstp};
+    }
+
+    size_t idOf(const CfgBlock* bbp) const {
+        UASSERT_OBJ(m_nEdits == m_nLastOrdered, m_enterp, "Cfg was edited but not re-ordered");
+        return bbp->m_rpoNumber;
+    }
+
+    size_t idOf(const CfgEdge* edgep) const {
+        UASSERT_OBJ(m_nEdits == m_nLastOrdered, m_enterp, "Cfg was edited but not re-ordered");
+        return edgep->m_id;
+    }
+
+    // Implementation for insertTwoWayJoins
+    CfgBlock* getOrCreateTwoWayJoinFor(CfgBlock* bbp);
+
+    // CONSTRUCTOR - use CfgGraph::build, which might fail, so this can't be public
+    CfgGraph() = default;
+
+public:
+    ~CfgGraph() override = default;
+
+    // STATIC FUNCTIONS
+
+    // Build CFG for the given list of statements
+    static std::unique_ptr<CfgGraph> build(AstNode* stmtsp);
+
+    // PUBLIC METHODS
+
     // Accessors
-    const BasicBlock& enter() const { return *m_enterp; }
-    const BasicBlock& exit() const { return *m_exitp; }
+    const CfgBlock& enter() const { return *m_enterp; }
+    const CfgBlock& exit() const { return *m_exitp; }
 
     // Number of basic blocks in this graph
-    size_t nBasicBlocks() const { return m_nBasicBlocks; }
+    size_t nBlocks() const { return m_nBlocks; }
     // Number of control flow edges in this graph
     size_t nEdges() const { return m_nEdges; }
 
-    // Create a BasicBlock map for this graph
+    // Create a CfgBlock map for this graph
     template <typename T_Value>
-    BasicBlockMap<T_Value> makeBasicBlockMap() const {
-        return BasicBlockMap<T_Value>{nBasicBlocks()};
-    }
-    // Create a ControlFlowEdgeMap map for this graph
+    inline CfgBlockMap<T_Value> makeBlockMap() const;
+    // Create a CfgEdgeMap map for this graph
     template <typename T_Value>
-    ControlFlowEdgeMap<T_Value> makeEdgeMap() const {
-        return ControlFlowEdgeMap<T_Value>{nEdges()};
-    }
+    inline CfgEdgeMap<T_Value> makeEdgeMap() const;
 
     // Returns true iff the graph contains a loop (back-edge)
     bool containsLoop() const;
+
+    //------------------------------------------------------------------
+    // The following methods mutate this CFG and invalidate CfgBlock and
+    // CfgEdge IDs and associated CfgBlockMap, CfgEdgeMap and other
+    // query instances.
+
+    // Remove empty blocks, combine sequential blocks. Keeps the enter/exit block, even if empty.
+    void minimize();
+
+    // Insert empty blocks to fix critical edges (edges that have a source with
+    // multiple successors, and a destination with multiple predecessors)
+    void breakCriticalEdges();
+
+    bool insertTwoWayJoins();
 };
 
 //######################################################################
-// Inline method definitions
+// CfgMap - Map from CfgBlock or CfgEdge to generic values
 
-BasicBlock::BasicBlock(ControlFlowGraph* cfgp)
-    : V3GraphVertex{cfgp} {}
+template <typename T_Key, typename T_Value>
+class CfgMap VL_NOT_FINAL {
+    // As opposed to a std::map/std::unordered_map, all entries are value
+    // initialized at construction, and the map is always dense. This can
+    // be improved if necessary but is sufficient for our current purposes.
 
-const ControlFlowEdge* BasicBlock::takenEdgep() const {
-    // It's always the first edge
-    const V3GraphEdge* const frontp = outEdges().frontp();
-    return static_cast<const ControlFlowEdge*>(frontp);
-}
+    const CfgGraph* m_cfgp;  // The control flow graph this map is for
+    size_t m_created;  // Edit count of CFG this map was created at
+    std::vector<T_Value> m_map;  // The map, stored as a vector
 
-const ControlFlowEdge* BasicBlock::untknEdgep() const {
-    // It's always the second (last) edge
-    const V3GraphEdge* const frontp = outEdges().frontp();
-    const V3GraphEdge* const backp = outEdges().backp();
-    return backp != frontp ? static_cast<const ControlFlowEdge*>(backp) : nullptr;
-}
+protected:
+    // CONSTRUCTOR
+    explicit CfgMap(const CfgGraph* cfgp, size_t size)
+        : m_cfgp{cfgp}
+        , m_created{cfgp->m_nEdits}
+        , m_map{size} {}
 
-const BasicBlock* BasicBlock::takenSuccessorp() const {
-    const ControlFlowEdge* const edgep = takenEdgep();
-    return edgep ? static_cast<const BasicBlock*>(edgep->top()) : nullptr;
-}
+public:
+    // Can create an empty map
+    CfgMap()
+        : m_cfgp{nullptr}
+        , m_created{0} {}
 
-const BasicBlock* BasicBlock::untknSuccessorp() const {
-    const ControlFlowEdge* const edgep = untknEdgep();
-    return edgep ? static_cast<const BasicBlock*>(edgep->top()) : nullptr;
-}
+    // Copyable, movable
+    CfgMap(const CfgMap<T_Key, T_Value>&) = default;
+    CfgMap(CfgMap<T_Key, T_Value>&&) = default;
+    CfgMap<T_Key, T_Value>& operator=(const CfgMap<T_Key, T_Value>&) = default;
+    CfgMap<T_Key, T_Value>& operator=(CfgMap<T_Key, T_Value>&&) = default;
 
-ControlFlowEdge::ControlFlowEdge(ControlFlowGraph* graphp, BasicBlock* srcp, BasicBlock* dstp)
-    : V3GraphEdge{graphp, srcp, dstp, 1, false} {}
+    T_Value& operator[](const T_Key& key) {
+        UASSERT_OBJ(m_created == m_cfgp->m_nEdits, m_cfgp->m_enterp, "Map is stale");
+        UASSERT_OBJ(m_cfgp == key.m_cfgp, m_cfgp->m_enterp, "Key not in this CFG");
+        return m_map.at(key.id());
+    }
+    const T_Value& operator[](const T_Key& key) const {
+        UASSERT_OBJ(m_created == m_cfgp->m_nEdits, m_cfgp->m_enterp, "Map is stale");
+        UASSERT_OBJ(m_cfgp == key.m_cfgp, m_cfgp->m_enterp, "Key not in this CFG");
+        return m_map.at(key.id());
+    }
+    T_Value& operator[](const T_Key* keyp) {
+        UASSERT_OBJ(m_created == m_cfgp->m_nEdits, m_cfgp->m_enterp, "Map is stale");
+        UASSERT_OBJ(m_cfgp == keyp->m_cfgp, m_cfgp->m_enterp, "Key not in this CFG");
+        return m_map.at(keyp->id());
+    }
+    const T_Value& operator[](const T_Key* keyp) const {
+        UASSERT_OBJ(m_created == m_cfgp->m_nEdits, m_cfgp->m_enterp, "Map is stale");
+        UASSERT_OBJ(m_cfgp == keyp->m_cfgp, m_cfgp->m_enterp, "Key not in this CFG");
+        return m_map.at(keyp->id());
+    }
+};
+
+template <typename T_Value>
+class CfgBlockMap final : public CfgMap<CfgBlock, T_Value> {
+    friend class CfgGraph;
+    // CONSTRUCTOR - Create one via CfgGraph::makeBlockMap
+    explicit CfgBlockMap(const CfgGraph* cfgp)
+        : CfgMap<CfgBlock, T_Value>{cfgp, cfgp->nBlocks()} {}
+
+public:
+    // Can create an empty map
+    CfgBlockMap() = default;
+    // Copyable, movable
+    CfgBlockMap(const CfgBlockMap&) = default;
+    CfgBlockMap(CfgBlockMap&&) = default;
+    CfgBlockMap& operator=(const CfgBlockMap&) = default;
+    CfgBlockMap& operator=(CfgBlockMap&&) = default;
+};
+
+template <typename T_Value>
+class CfgEdgeMap final : public CfgMap<CfgEdge, T_Value> {
+    friend class CfgGraph;
+    // CONSTRUCTOR - Create one via CfgGraph::makeEdgeMap
+    explicit CfgEdgeMap(const CfgGraph* cfgp)
+        : CfgMap<CfgEdge, T_Value>{cfgp, cfgp->nEdges()} {}
+
+public:
+    // Can create an empty map
+    CfgEdgeMap() = default;
+    // Copyable, movable
+    CfgEdgeMap(const CfgEdgeMap&) = default;
+    CfgEdgeMap(CfgEdgeMap&&) = default;
+    CfgEdgeMap& operator=(const CfgEdgeMap&) = default;
+    CfgEdgeMap& operator=(CfgEdgeMap&&) = default;
+};
 
 //######################################################################
-// ControlFlowGraph functions
+// Innline method definitions
+
+// --- CfgBlock ---
+
+CfgBlock::CfgBlock(CfgGraph* cfgp)
+    : V3GraphVertex{cfgp}
+    , m_cfgp{cfgp} {}
+
+size_t CfgBlock::id() { return m_cfgp->idOf(this); }
+size_t CfgBlock::id() const { return m_cfgp->idOf(this); }
+
+// Successor edges
+CfgEdge* CfgBlock::takenEdgep() {  // It's always the first edge
+    return isExit() ? nullptr : static_cast<CfgEdge*>(outEdges().frontp());
+}
+const CfgEdge* CfgBlock::takenEdgep() const {  // It's always the first edge
+    return isExit() ? nullptr : static_cast<const CfgEdge*>(outEdges().frontp());
+}
+CfgEdge* CfgBlock::untknEdgep() {  // It's always the second (last) edge
+    return isBranch() ? static_cast<CfgEdge*>(outEdges().backp()) : nullptr;
+}
+const CfgEdge* CfgBlock::untknEdgep() const {  // It's always the second (last) edge
+    return isBranch() ? static_cast<const CfgEdge*>(outEdges().backp()) : nullptr;
+}
+CfgBlock* CfgBlock::takenp() {
+    return isExit() ? nullptr : static_cast<CfgBlock*>(outEdges().frontp()->top());
+}
+const CfgBlock* CfgBlock::takenp() const {
+    return isExit() ? nullptr : static_cast<CfgBlock*>(outEdges().frontp()->top());
+}
+CfgBlock* CfgBlock::untknp() {
+    return isBranch() ? static_cast<CfgBlock*>(outEdges().backp()->top()) : nullptr;
+}
+const CfgBlock* CfgBlock::untknp() const {
+    return isBranch() ? static_cast<const CfgBlock*>(outEdges().backp()->top()) : nullptr;
+}
+
+// Predecessor edges
+CfgEdge* CfgBlock::firstPredecessorEdgep() {  //
+    return static_cast<CfgEdge*>(inEdges().frontp());
+}
+const CfgEdge* CfgBlock::firstPredecessorEdgep() const {  //
+    return static_cast<const CfgEdge*>(inEdges().frontp());
+}
+CfgEdge* CfgBlock::lastPredecessorEdgep() {  //
+    return static_cast<CfgEdge*>(inEdges().backp());
+}
+const CfgEdge* CfgBlock::lastPredecessorEdgep() const {  //
+    return static_cast<const CfgEdge*>(inEdges().backp());
+}
+CfgBlock* CfgBlock::firstPredecessorp() {  //
+    return isEnter() ? nullptr : firstPredecessorEdgep()->srcp();
+}
+const CfgBlock* CfgBlock::firstPredecessorp() const {  //
+    return isEnter() ? nullptr : firstPredecessorEdgep()->srcp();
+}
+CfgBlock* CfgBlock::lastPredecessorp() {  //
+    return isEnter() ? nullptr : lastPredecessorEdgep()->srcp();
+}
+const CfgBlock* CfgBlock::lastPredecessorp() const {  //
+    return isEnter() ? nullptr : lastPredecessorEdgep()->srcp();
+}
+
+// --- CfgEdge ---
+
+CfgEdge::CfgEdge(CfgGraph* cfgp, CfgBlock* srcp, CfgBlock* dstp)
+    : V3GraphEdge{cfgp, srcp, dstp, 1, false}
+    , m_cfgp{cfgp} {}
+
+size_t CfgEdge::id() { return m_cfgp->idOf(this); }
+size_t CfgEdge::id() const { return m_cfgp->idOf(this); }
+
+// --- CfgGraph ---
+
+template <typename T_Value>
+CfgBlockMap<T_Value> CfgGraph::makeBlockMap() const {
+    return CfgBlockMap<T_Value>{this};
+}
+template <typename T_Value>
+CfgEdgeMap<T_Value> CfgGraph::makeEdgeMap() const {
+    return CfgEdgeMap<T_Value>{this};
+}
+
+//######################################################################
+// CfgDominatorTree
+
+class CfgDominatorTree final {
+    // STATE
+    CfgBlockMap<const CfgBlock*> m_bb2Idom;  // Map from CfgBlock to its immediate dominator
+
+    // PRIVATE METHODS
+
+    // Part of algorithm to compute m_bb2Idom, see consructor
+    const CfgBlock* intersect(const CfgBlock* ap, const CfgBlock* bp);
+
+public:
+    // CONSTRUCTOR
+    explicit CfgDominatorTree(const CfgGraph& cfg);
+    // Can create an empty map
+    CfgDominatorTree() = default;
+    // Copyable, movable
+    CfgDominatorTree(const CfgDominatorTree&) = default;
+    CfgDominatorTree(CfgDominatorTree&&) = default;
+    CfgDominatorTree& operator=(const CfgDominatorTree&) = default;
+    CfgDominatorTree& operator=(CfgDominatorTree&&) = default;
+
+    // PUBLIC METHODS
+
+    // Return unique CfgBlock that dominates both of the given blocks, but does
+    // not strictly dominate any other block that dominates both blocks. It
+    // will return 'ap' or 'bp' if one dominates the other (or are the same)
+    const CfgBlock* closestCommonDominator(const CfgBlock* ap, const CfgBlock* bp) const {
+        while (ap != bp) {
+            if (*ap < *bp) {
+                bp = m_bb2Idom[bp];
+            } else {
+                ap = m_bb2Idom[ap];
+            }
+        }
+        return ap;
+    }
+
+    // Returns true if 'ap' dominates 'bp'
+    bool dominates(const CfgBlock* const ap, const CfgBlock* bp) {
+        // Walk up the dominator tree from 'bp' until reaching 'ap' or the root
+        while (true) {
+            // True if 'ap' is above (or same as) 'bp'
+            if (ap == bp) return true;
+            // Step up the dominator tree
+            bp = m_bb2Idom[bp];
+            // False if reached the root
+            if (!bp) return false;
+        }
+    }
+};
+
+//######################################################################
+// V3Cfg
 
 namespace V3Cfg {
-// Build control flow graph for given node
-std::unique_ptr<const ControlFlowGraph> build(const AstNodeProcedure*);
 
 // Compute AstVars live on entry to given CFG. That is, variables that might
 // be read before wholly assigned in the CFG. Returns nullptr if the analysis
 // failed due to unhandled statements or data types involved in the CFG.
 // On success, returns a vector of AstVar or AstVarScope nodes live on entry.
-std::unique_ptr<std::vector<AstVar*>> liveVars(const ControlFlowGraph&);
+std::unique_ptr<std::vector<AstVar*>> liveVars(const CfgGraph&);
 
 // Same as liveVars, but return AstVarScopes insted
-std::unique_ptr<std::vector<AstVarScope*>> liveVarScopes(const ControlFlowGraph&);
+std::unique_ptr<std::vector<AstVarScope*>> liveVarScopes(const CfgGraph&);
+
 }  //namespace V3Cfg
 
 #endif  // VERILATOR_V3CFG_H_

--- a/src/V3DfgAstToDfg.cpp
+++ b/src/V3DfgAstToDfg.cpp
@@ -57,7 +57,7 @@ class AstToDfgVisitor final : public VNVisitor {
         }
     }
 
-    std::unique_ptr<std::vector<Variable*>> getLiveVariables(const ControlFlowGraph& cfg) {
+    std::unique_ptr<std::vector<Variable*>> getLiveVariables(const CfgGraph& cfg) {
         // TODO: remove the useless reinterpret_casts when C++17 'if constexpr' actually works
         if VL_CONSTEXPR_CXX17 (T_Scoped) {
             std::unique_ptr<std::vector<AstVarScope*>> result = V3Cfg::liveVarScopes(cfg);
@@ -139,7 +139,7 @@ class AstToDfgVisitor final : public VNVisitor {
 
     // Gather variables live in to the given CFG.
     // Return nullptr if any are not supported.
-    std::unique_ptr<std::vector<DfgVertexVar*>> gatherLive(const ControlFlowGraph& cfg) {
+    std::unique_ptr<std::vector<DfgVertexVar*>> gatherLive(const CfgGraph& cfg) {
         // Run analysis
         std::unique_ptr<std::vector<Variable*>> varps = getLiveVariables(cfg);
         if (!varps) {
@@ -206,7 +206,7 @@ class AstToDfgVisitor final : public VNVisitor {
         // Potentially convertible block
         ++m_ctx.m_inputs;
         // Attempt to build CFG of AstAlways, give up if failed
-        std::unique_ptr<const ControlFlowGraph> cfgp = V3Cfg::build(nodep);
+        std::unique_ptr<CfgGraph> cfgp = CfgGraph::build(nodep->stmtsp());
         if (!cfgp) {
             ++m_ctx.m_nonRepCfg;
             return false;

--- a/src/V3DfgContext.h
+++ b/src/V3DfgContext.h
@@ -251,7 +251,13 @@ public:
         // Reverted
         VDouble0 revertNonSyn;  // Reverted due to being driven from non-synthesizable vertex
         VDouble0 revertMultidrive;  // Reverted due to multiple drivers
-
+        // Additional stats
+        VDouble0 cfgTrivial;  // Trivial input CFGs
+        VDouble0 cfgSp;  // Series-paralel input CFGs
+        VDouble0 cfgDag;  // Generic loop free input CFGs
+        VDouble0 cfgCyclic;  // Cyclic input CFGs
+        VDouble0 joinUsingPathPredicate;  // Num control flow joins using full path predicate
+        VDouble0 joinUsingBranchCondition;  // Num Control flow joins using dominating branch cond
     } m_synt;
 
 private:
@@ -314,6 +320,14 @@ private:
         nSyntExpect -= m_synt.synthAlways;
         nSyntExpect -= m_synt.synthAssign;
         UASSERT(nSyntNonSyn == nSyntExpect, "Inconsistent statistics / synt");
+
+        addStat("synt / input CFG trivial", m_synt.cfgTrivial);
+        addStat("synt / input CFG sp", m_synt.cfgSp);
+        addStat("synt / input CFG dag", m_synt.cfgDag);
+        addStat("synt / input CFG cyclic", m_synt.cfgCyclic);
+
+        addStat("synt / joins using path predicate", m_synt.joinUsingPathPredicate);
+        addStat("synt / joins using branch condition", m_synt.joinUsingBranchCondition);
     }
 };
 

--- a/src/V3DfgVertices.h
+++ b/src/V3DfgVertices.h
@@ -346,7 +346,7 @@ public:
 class DfgLogic final : public DfgVertexVariadic {
     // Generic vertex representing a whole combinational process
     AstNode* const m_nodep;  // The Ast logic represented by this vertex
-    const std::unique_ptr<const ControlFlowGraph> m_cfgp;
+    const std::unique_ptr<CfgGraph> m_cfgp;
     // Vertices this logic was synthesized into. Excluding variables
     std::vector<DfgVertex*> m_synth;
 
@@ -356,7 +356,7 @@ public:
         , m_nodep{nodep}
         , m_cfgp{nullptr} {}
 
-    DfgLogic(DfgGraph& dfg, AstAlways* nodep, std::unique_ptr<const ControlFlowGraph> cfgp)
+    DfgLogic(DfgGraph& dfg, AstAlways* nodep, std::unique_ptr<CfgGraph> cfgp)
         : DfgVertexVariadic{dfg, dfgType(), nodep->fileline(), nullptr, 1u}
         , m_nodep{nodep}
         , m_cfgp{std::move(cfgp)} {}
@@ -366,7 +366,8 @@ public:
     void addInput(DfgVertexVar* varp) { addSource()->relinkSource(varp); }
 
     AstNode* nodep() const { return m_nodep; }
-    const ControlFlowGraph& cfg() const { return *m_cfgp; }
+    CfgGraph& cfg() { return *m_cfgp; }
+    const CfgGraph& cfg() const { return *m_cfgp; }
     std::vector<DfgVertex*>& synth() { return m_synth; }
     const std::vector<DfgVertex*>& synth() const { return m_synth; }
 

--- a/src/V3List.h
+++ b/src/V3List.h
@@ -241,6 +241,7 @@ public:
     bool empty() const { return !m_headp; }
     bool hasSingleElement() const { return m_headp && m_headp == m_lastp; }
     bool hasMultipleElements() const { return m_headp && m_headp != m_lastp; }
+    bool hasTwoElements() const { return m_headp && toLinks(m_headp).m_nextp == m_lastp; }
 
     // These return pointers, as we often want to unlink/delete them, and can also signal empty
     T_Element* frontp() { return static_cast<T_Element*>(m_headp); }

--- a/test_regress/t/t_dfg_break_cycles.py
+++ b/test_regress/t/t_dfg_break_cycles.py
@@ -44,9 +44,10 @@ with open(rdFile, 'r', encoding="utf8") as rdFh, \
      open(pdeclFile, 'w', encoding="utf8") as pdeclFh, \
      open(checkFile, 'w', encoding="utf8") as checkFh:
     for line in rdFh:
-        if "// UNOPTFLAT" in line:
+        line, _, cmt = line.partition("//")
+        cmt, _, _ = cmt.partition("//")
+        if "UNOPTFLAT" in cmt:
             nExpectedCycles += 1
-        line = line.split("//")[0]
         m = re.search(r'`signal\((\w+),', line)
         if not m:
             continue

--- a/test_regress/t/t_dfg_synthesis.py
+++ b/test_regress/t/t_dfg_synthesis.py
@@ -70,13 +70,14 @@ test.compile(verilator_flags2=[
     "--stats",
     "--build",
     "--fdfg-synthesize-all",
+    "-fno-dfg-pre-inline",
     "-fno-dfg-post-inline",
-    "-fno-dfg-scoped",
     "--exe",
     "+incdir+" + test.obj_dir,
     "-Mdir", test.obj_dir + "/obj_opt",
     "--prefix", "Vopt",
     "-fno-const-before-dfg",  # Otherwise V3Const makes testing painful
+    "-fno-split", # Dfg will take care of it
     "--debug", "--debugi", "0", "--dumpi-tree", "0",
     "-CFLAGS \"-I .. -I ../obj_ref\"",
     "../obj_ref/Vref__ALL.a",
@@ -84,14 +85,13 @@ test.compile(verilator_flags2=[
 ])  # yapf:disable
 
 test.file_grep(test.obj_dir + "/obj_opt/Vopt__stats.txt",
-               r'DFG pre inline Synthesis, synt / always blocks considered\s+(\d+)$',
+               r'DFG scoped Synthesis, synt / always blocks considered\s+(\d+)$',
                nAlwaysSynthesized + nAlwaysReverted + nAlwaysNotSynthesized)
 test.file_grep(test.obj_dir + "/obj_opt/Vopt__stats.txt",
-               r'DFG pre inline Synthesis, synt / always blocks synthesized\s+(\d+)$',
+               r'DFG scoped Synthesis, synt / always blocks synthesized\s+(\d+)$',
                nAlwaysSynthesized + nAlwaysReverted)
 test.file_grep(test.obj_dir + "/obj_opt/Vopt__stats.txt",
-               r'DFG pre inline Synthesis, synt / reverted \(multidrive\)\s+(\d)$',
-               nAlwaysReverted)
+               r'DFG scoped Synthesis, synt / reverted \(multidrive\)\s+(\d)$', nAlwaysReverted)
 
 # Execute test to check equivalence
 test.execute(executable=test.obj_dir + "/obj_opt/Vopt")

--- a/test_regress/t/t_dfg_synthesis.v
+++ b/test_regress/t/t_dfg_synthesis.v
@@ -154,6 +154,176 @@ module t (
   end
   `signal(CONDITONAL_F, condigional_f);
 
+  logic [2:0] conditional_g;
+  always_comb begin
+    if (rand_a[0]) begin
+      if (rand_a[1]) begin
+        if (rand_a[2]) begin
+          conditional_g = 3'b111;
+        end else begin
+          conditional_g = 3'b011;
+        end
+      end else begin
+        if (rand_a[2]) begin
+          conditional_g = 3'b101;
+        end else begin
+          conditional_g = 3'b001;
+        end
+      end
+    end else begin
+      if (rand_a[1]) begin
+        if (rand_a[2]) begin
+          conditional_g = 3'b110;
+        end else begin
+          conditional_g = 3'b010;
+        end
+      end else begin
+        if (rand_a[2]) begin
+          conditional_g = 3'b100;
+        end else begin
+          conditional_g = 3'b000;
+        end
+      end
+    end
+  end
+  `signal(CONDITONAL_G, conditional_g);
+
+  logic [2:0] conditional_h;
+  always_comb begin
+    if (rand_a[0]) begin
+      if (rand_a[1]) begin
+        conditional_h = 3'b011;
+        if (rand_a[2]) begin
+          conditional_h = 3'b111;
+        end
+      end else begin
+        conditional_h = 3'b001;
+        if (rand_a[2]) begin
+          conditional_h = 3'b101;
+        end
+      end
+    end else begin
+      if (rand_a[1]) begin
+        conditional_h = 3'b010;
+        if (rand_a[2]) begin
+          conditional_h = 3'b110;
+        end
+      end else begin
+        conditional_h = 3'b000;
+        if (rand_a[2]) begin
+          conditional_h = 3'b100;
+        end
+      end
+    end
+  end
+  `signal(CONDITONAL_H, conditional_h);
+
+  logic [2:0] conditional_i;
+  always_comb begin // Dumbass trailing zeroes count
+    do begin
+      conditional_i = 3'd0;
+      if (rand_a[0]) break;
+      conditional_i = 3'd1;
+      if (rand_a[1]) break;
+      conditional_i = 3'd2;
+      if (rand_a[2]) break;
+      conditional_i = 3'd3;
+      if (rand_a[3]) break;
+      conditional_i = 3'd4;
+    end while (0);
+  end
+  `signal(CONDITONAL_I, conditional_i);
+
+  logic [2:0] conditional_j;
+  always_comb begin // Even more dumbass trailing ones count
+    do begin
+      conditional_j = 3'd0;
+      if (rand_a[0]) begin
+        conditional_j = 3'd1;
+      end else begin
+        break;
+      end
+      if (rand_a[1]) begin
+        conditional_j = 3'd2;
+      end else begin
+        break;
+      end
+      if (rand_a[2]) begin
+        conditional_j = 3'd3;
+      end else begin
+        break;
+      end
+      if (rand_a[3]) begin
+        conditional_j = 3'd4;
+      end
+    end while (0);
+  end
+  `signal(CONDITONAL_J, conditional_j);
+
+  logic [2:0] conditional_k;
+  always_comb begin
+    if (rand_b[0]) begin
+      do begin
+        conditional_k = 3'd0;
+        if (rand_a[0]) break;
+        conditional_k = 3'd1;
+        if (rand_a[1]) break;
+        conditional_k = 3'd2;
+        if (rand_a[2]) break;
+        conditional_k = 3'd3;
+        if (rand_a[3]) break;
+        conditional_k = 3'd4;
+      end while (0);
+    end else begin
+      do begin
+        conditional_k = 3'd0;
+        if (rand_a[0]) begin
+          conditional_k = 3'd1;
+        end else begin
+          break;
+        end
+        if (rand_a[1]) begin
+          conditional_k = 3'd2;
+        end else begin
+          break;
+        end
+        if (rand_a[2]) begin
+          conditional_k = 3'd3;
+        end else begin
+          break;
+        end
+        if (rand_a[3]) begin
+          conditional_k = 3'd4;
+        end
+      end while (0);
+    end
+  end
+  `signal(CONDITONAL_K, conditional_k);
+
+  logic [1:0] conditional_l_a;
+  logic [1:0] conditional_l_b;
+  always_comb begin
+    do begin
+      conditional_l_a = 2'd0;
+      if (rand_a[1:0] == 2'd0) break;
+      conditional_l_a = 2'd1;
+      if (rand_a[1:0] == 2'd1) break;
+      conditional_l_a = 2'd2;
+      if (rand_a[1:0] == 2'd2) break;
+      conditional_l_a = 2'd3;
+    end while (0);
+    do begin
+      conditional_l_b = 2'd0;
+      if (rand_b[1:0] == 2'd0) break;
+      conditional_l_b = 2'd1;
+      if (rand_b[1:0] == 2'd1) break;
+      conditional_l_b = 2'd2;
+      if (rand_b[1:0] == 2'd2) break;
+      conditional_l_b = 2'd3;
+    end while (0);
+  end
+  `signal(CONDITONAL_L, {conditional_l_b, conditional_l_a});
+
   logic [7:0] partial_conditional_a;
   always_comb begin
     partial_conditional_a[1:0] = 2'd0;
@@ -225,4 +395,111 @@ module t (
     partial_temporary_a = partial_temporary_tmp;
   end
   `signal(PARTIAL_TEMPORARY, partial_temporary_a);
+
+  logic circular_0_x;
+  logic circular_0_y;
+  logic circular_0_z;
+  always_comb begin
+    circular_0_x = 1'b0;
+    circular_0_y = 1'd0;
+    if (rand_b[0]) begin
+      circular_0_x = 1'b1;
+      if (circular_0_z) begin
+        circular_0_y = 1'd1;
+      end
+    end
+  end
+  assign circular_0_z = circular_0_x & rand_a[0];
+  `signal(CIRCULAR_0, {circular_0_x, circular_0_y, circular_0_z});
+
+  logic [2:0] nsp_a; // Non series-parallel CFG
+  always_comb begin
+    do begin
+      nsp_a = 3'd0; // BB 0 -> BB 1 / BB 2
+      if (rand_a[1:0] == 2'd0) begin
+        nsp_a = 3'd1; // BB 1 -> BB 4
+      end else begin
+        nsp_a = 3'd2; // BB 2 -> BB 3 / BB 4
+        if (rand_a[1:0] == 2'd1) begin
+          nsp_a = 3'd3; // BB3 -> BB 5
+          break;
+        end
+      end
+      nsp_a = 3'd4; // BB 4 -> BB 5
+    end while (0);
+    //nsp_a = 3'd5; // BB 5
+  end
+  `signal(NSP_A, nsp_a);
+
+  logic [2:0] nsp_b; // Non series-parallel CFG
+  always_comb begin
+    do begin
+      nsp_b = 3'd0;
+      if (rand_a[1:0] == 2'd0) begin
+        nsp_b = 3'd1;
+      end else begin
+        nsp_b = 3'd2;
+        if (rand_a[1:0] == 2'd1) begin
+          nsp_b = 3'd3;
+          break;
+        end else begin
+          nsp_b = 3'd4;
+          if (rand_a[1:0] == 2'd2) begin
+            nsp_b = 3'd5;
+          end else begin
+            nsp_b = 3'd6;
+            break;
+          end
+        end
+      end
+      nsp_b = 3'd7;
+    end while (0);
+  end
+  `signal(NSP_B, nsp_b);
+
+  logic [2:0] part_sp_a; // Contains series-parallel sub-graph CFG
+  always_comb begin
+    do begin
+      part_sp_a = 3'd0;
+      if (rand_a[0]) begin
+        part_sp_a = 3'd1;
+        if (rand_a[1]) begin
+          part_sp_a = 3'd2;
+        end
+      end else begin
+        part_sp_a = 3'd3;
+        if (rand_a[2]) begin
+          part_sp_a = 3'd4;
+          if (rand_a[3]) begin
+            part_sp_a = 3'd5;
+          end
+          break;
+        end
+      end
+      part_sp_a = 3'd6;
+      if (rand_a[4]) begin
+        part_sp_a = 3'd7;
+      end
+    end while (0);
+  end
+  `signal(PART_SP_A, part_sp_a);
+
+  logic [1:0] both_break;
+  always_comb begin
+    do begin
+      if (rand_a[0]) begin
+        both_break = 2'd0;
+        break;
+      end else begin
+        both_break = 2'd1;
+        break;
+      end
+      // Unreachable
+      if (rand_a[1]) begin
+        both_break = 2'd2;
+      end
+    end while(0);
+  end
+  `signal(BOTH_BREAK, both_break);
+
 endmodule


### PR DESCRIPTION
The previous algorithm was designed to handle the general case where a full control flow path predicate is required to select which value to use when synthesizing control flow join point in an always block.

Here we add a better algorithm that tries to use the predicate of the closest dominating branch if the branch paths dominate the joining paths. This is almost universally true in synthesizable logic (RTLMeter has no exceptions), however there are cases where this is not applicable, for which we fall back on the previous generic algorithm.

Overall this significantly simplifies the synthesized Dfg graphs and enables further optimization.