### PR TITLE
Fix splitting of assignments to SC variables (#6329)

### DIFF
--- a/src/V3FuncOpt.cpp
+++ b/src/V3FuncOpt.cpp
@@ -228,6 +228,8 @@ class FuncOptVisitor final : public VNVisitor {
         UASSERT_OBJ(lhsp->width() == rhsp->width(), nodep, "Inconsistent assignment");
         // Only consider pure assignments. Nodes inserted below are safe.
         if (!nodep->user1() && (!lhsp->isPure() || !rhsp->isPure())) return false;
+        // Do not split assignments to SC variables, they cannot be assiged in parts
+        if (lhsp->exists([](AstVarRef* refp) { return refp->varp()->isSc(); })) return false;
         // Check for a Sel on the LHS if present, and skip over it
         uint32_t lsb = 0;
         if (AstSel* const selp = VN_CAST(lhsp, Sel)) {

--- a/test_regress/t/t_balance_cats_sc.py
+++ b/test_regress/t/t_balance_cats_sc.py
@@ -11,10 +11,13 @@ import vltest_bootstrap
 
 test.scenarios('vlt')
 
-test.compile(
-    verilator_flags2=["--stats", "--build", "--gate-stmts", "10000", "--expand-limit", "128"])
+test.top_filename = "t/t_balance_cats.v"
+
+test.compile(verilator_flags2=[
+    "--stats", "--build", "--gate-stmts", "10000", "--expand-limit", "128", "--sc"
+])
 
 test.file_grep(test.stats, r'Optimizations, FuncOpt concat trees balanced\s+(\d+)', 1)
-test.file_grep(test.stats, r'Optimizations, FuncOpt concat splits\s+(\d+)', 62)
+test.file_grep(test.stats, r'Optimizations, FuncOpt concat splits\s+(\d+)', 0)
 
 test.passes()


### PR DESCRIPTION
SC variables can only be assigned whole, so do not split up concatenation assignments in V3FuncOpt.

Fixes #6329