### PR TITLE
Fix broken support of unassigned virtual interfaces

### DIFF
--- a/test_regress/t/t_interface_virtual_missing_bad.out
+++ b/test_regress/t/t_interface_virtual_missing_bad.out
@@ -1,0 +1,5 @@
+%Error: t/t_interface_virtual_missing_bad.v:9:12: Cannot find file containing interface: 'foo'
+    9 |    virtual foo vif;
+      |            ^~~
+        ... See the manual at https://verilator.org/verilator_doc.html?v=latest for more assistance.
+%Error: Exiting due to

--- a/test_regress/t/t_interface_virtual_missing_bad.py
+++ b/test_regress/t/t_interface_virtual_missing_bad.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2025 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('linter')
+
+test.lint(fails=True, expect_filename=test.golden_filename)
+
+test.passes()

--- a/test_regress/t/t_interface_virtual_missing_bad.v
+++ b/test_regress/t/t_interface_virtual_missing_bad.v
@@ -1,17 +1,12 @@
 // DESCRIPTION: Verilator: Verilog Test module
 //
 // This file ONLY is placed under the Creative Commons Public Domain, for
-// any use, without warranty, 2022 by Arkadiusz Kozdra.
+// any use, without warranty, 2025 by Antmicro.
 // SPDX-License-Identifier: CC0-1.0
-
-// See also t_interface_virtual.v
-
-interface QBus();
-endinterface
 
 module t (/*AUTOARG*/);
 
-   virtual QBus q8;
+   virtual foo vif;
 
    initial begin
       $write("*-* All Finished *-*\n");

--- a/test_regress/t/t_interface_virtual_unused2.py
+++ b/test_regress/t/t_interface_virtual_unused2.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2025 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile()
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_interface_virtual_unused2.v
+++ b/test_regress/t/t_interface_virtual_unused2.v
@@ -1,17 +1,24 @@
 // DESCRIPTION: Verilator: Verilog Test module
 //
 // This file ONLY is placed under the Creative Commons Public Domain, for
-// any use, without warranty, 2022 by Arkadiusz Kozdra.
+// any use, without warranty, 2025 by Antmicro.
 // SPDX-License-Identifier: CC0-1.0
 
-// See also t_interface_virtual.v
-
-interface QBus();
+interface QBus(input logic k);
+   logic data;
 endinterface
+
+class cls;
+    virtual QBus vif1;
+
+    function foo(virtual QBus vif2);
+        vif2.data = 1;
+    endfunction
+endclass
 
 module t (/*AUTOARG*/);
 
-   virtual QBus q8;
+   cls bar;
 
    initial begin
       $write("*-* All Finished *-*\n");


### PR DESCRIPTION
Unassigned virtual interface support added by #6245 is broken - PR marks dead module as alive - we can't do that as once a module is dead it needs to remain dead because earlier steps (e.g. port resolution) have already been skipped.

This commit handles unassigned virtual interfaces at the beginning of first pass of LinkDot (so it is never marked as dead, and no linking steps are getting skipped).

Fixes #6253.