### PR TITLE
Fix upcasting class type parameters

### DIFF
--- a/src/V3EmitCFunc.h
+++ b/src/V3EmitCFunc.h
@@ -1339,7 +1339,8 @@ public:
     }
     void visit(AstCCast* nodep) override {
         // Extending a value of the same word width is just a NOP.
-        if (const AstClassRefDType* const classDtypep = VN_CAST(nodep->dtypep(), ClassRefDType)) {
+        if (const AstClassRefDType* const classDtypep
+            = VN_CAST(nodep->dtypep()->skipRefp(), ClassRefDType)) {
             putns(nodep, "(" + classDtypep->cType("", false, false) + ")(");
         } else if (nodep->size() <= VL_BYTESIZE) {
             putns(nodep, "(CData)(");

--- a/test_regress/t/t_class_param_upcast.py
+++ b/test_regress/t/t_class_param_upcast.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2025 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile()
+
+test.passes()

--- a/test_regress/t/t_class_param_upcast.v
+++ b/test_regress/t/t_class_param_upcast.v
@@ -1,0 +1,33 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2025 by Antmicro.
+// SPDX-License-Identifier: CC0-1.0
+
+class factory #(type T);
+  static function T create;
+    T obj = new;
+    return obj;
+  endfunction
+endclass
+
+class foo;
+endclass
+
+class bar extends foo;
+  static function bar create;
+    bar b = new;
+    return b;
+  endfunction
+endclass
+
+module t;
+  initial begin
+    foo f;
+    if (bit'($random))
+      f = bar::create;
+    else
+      f = factory#(foo)::create();
+    $finish;
+  end
+endmodule;


### PR DESCRIPTION
The test case included in this patch currently produces a C++ compile error:

```
./Vt_class_param_upcast___024root__DepSet_hc21173b8__0__Slow.cpp:18:33: error: no viable overloaded '='
   18 |     t__DOT__unnamedblk1__DOT__f = ((1U & VL_RANDOM_I())
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^ ~~~~~~~~~~~~~~~~~~~~~
   19 |                                     ? (CData)(([&]() {
      |                                     ~~~~~~~~~~~~~~~~~~
   20 |                     vlSymsp->TOP____024unit__03a__03abar__Vclpkg.__VnoInFunc_create(vlSymsp, __Vfunc_create__0__Vfuncout);
      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   21 |                 }(), __Vfunc_create__0__Vfuncout)) :
      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   22 |                                    ([&]() {
      |                                    ~~~~~~~~
   23 |                 vlSymsp->TOP____024unit__03a__03afactory__Tz1__Vclpkg.__VnoInFunc_create(vlSymsp, __Vfunc_create__1__Vfuncout);
      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   24 |             }(), __Vfunc_create__1__Vfuncout));
      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

The issue is the cast is emitted incorrectly (it's `CData` instead of the base class type).