### PR TITLE
Improve wide Sel expansion and substitution (#6341)

### DIFF
--- a/src/V3AstNodeOther.h
+++ b/src/V3AstNodeOther.h
@@ -1863,6 +1863,7 @@ class AstVar final : public AstNode {
     bool m_isHideProtected : 1;  // Verilog protected
     bool m_noReset : 1;  // Do not do automated reset/randomization
     bool m_noSubst : 1;  // Do not substitute out references
+    bool m_substConstOnly : 1;  // Only substitute if constant
     bool m_overridenParam : 1;  // Overridden parameter by #(...) or defparam
     bool m_trace : 1;  // Trace this variable
     bool m_isLatched : 1;  // Not assigned in all control paths of combo always
@@ -1912,6 +1913,7 @@ class AstVar final : public AstNode {
         m_isHideProtected = false;
         m_noReset = false;
         m_noSubst = false;
+        m_substConstOnly = false;
         m_overridenParam = false;
         m_trace = false;
         m_isLatched = false;
@@ -2068,6 +2070,8 @@ public:
     bool noReset() const { return m_noReset; }
     void noSubst(bool flag) { m_noSubst = flag; }
     bool noSubst() const { return m_noSubst; }
+    void substConstOnly(bool flag) { m_substConstOnly = flag; }
+    bool substConstOnly() const { return m_substConstOnly; }
     void overriddenParam(bool flag) { m_overridenParam = flag; }
     bool overriddenParam() const { return m_overridenParam; }
     void trace(bool flag) { m_trace = flag; }

--- a/src/V3Expand.cpp
+++ b/src/V3Expand.cpp
@@ -152,11 +152,7 @@ class ExpandVisitor final : public VNVisitor {
     }
 
     AstVar* addLocalTmp(AstNode* placep, const char* namep, AstNodeExpr* valuep) {
-        std::string name;
-        name += "__V";
-        name += namep;
-        name += "_";
-        name += std::to_string(m_nTmps);
+        const std::string name = "__V"s + namep + "_"s + std::to_string(m_nTmps);
         FileLine* const flp = placep->fileline();
         AstVar* const tmpp = new AstVar{flp, VVarType::STMTTEMP, name, valuep->dtypep()};
         tmpp->funcLocal(true);
@@ -272,7 +268,7 @@ class ExpandVisitor final : public VNVisitor {
         // If indexp was constant, just use it
         if (!indexp) return new AstWordSel{flp, fromp, new AstConst{flp, wordOffset}};
 
-        // Otherwie compute at runtime
+        // Otherwise compute at runtime
         if (indexp->backp()) indexp = indexp->cloneTreePure(false);
         if (wordOffset) indexp = new AstAdd{flp, new AstConst{flp, wordOffset}, indexp};
         return new AstWordSel{flp, fromp, indexp};
@@ -541,7 +537,7 @@ class ExpandVisitor final : public VNVisitor {
         UASSERT_OBJ(nodep->widthMin() == rhsp->widthConst(), nodep, "Width mismatch");
         if (!doExpandWide(nodep)) return false;
 
-        // Simplify the index, incase it becomes a constant
+        // Simplify the index, in case it becomes a constant
         V3Const::constifyEditCpp(rhsp->lsbp());
 
         // If it's a constant select and aligned, we can just copy the words

--- a/src/V3Subst.cpp
+++ b/src/V3Subst.cpp
@@ -233,7 +233,7 @@ class SubstVisitor final : public VNVisitor {
     int m_ops = 0;  // Number of operators on assign rhs
     int m_assignStep = 0;  // Assignment number to determine var lifetime
     const AstCFunc* m_funcp = nullptr;  // Current function we are under
-    size_t m_nSubst;  // Number of substitutions performed
+    size_t m_nSubst = 0;  // Number of substitutions performed
 
     enum {
         SUBST_MAX_OPS_SUBST = 30,  // Maximum number of ops to substitute in

--- a/src/V3Subst.cpp
+++ b/src/V3Subst.cpp
@@ -118,15 +118,21 @@ public:
     }
     // ACCESSORS
     AstNodeExpr* substWhole(AstNode* errp) {
-        if (!m_varp->isWide() && !m_whole.m_complex && m_whole.m_assignp && !m_wordAssign) {
-            const AstNodeAssign* const assp = m_whole.m_assignp;
-            UASSERT_OBJ(assp, errp, "Reading whole that was never assigned");
-            // AstCvtPackedToArray can't be anywhere else than on the RHS of assignment
-            if (VN_IS(assp->rhsp(), CvtPackedToArray)) return nullptr;
-            return assp->rhsp();
-        } else {
-            return nullptr;
-        }
+        if (m_varp->isWide()) return nullptr;
+        if (m_whole.m_complex) return nullptr;
+        if (!m_whole.m_assignp) return nullptr;
+        if (m_wordAssign) return nullptr;
+
+        const AstNodeAssign* const assp = m_whole.m_assignp;
+        UASSERT_OBJ(assp, errp, "Reading whole that was never assigned");
+        AstNodeExpr* const rhsp = assp->rhsp();
+
+        // AstCvtPackedToArray can't be anywhere else than on the RHS of assignment
+        if (VN_IS(rhsp, CvtPackedToArray)) return nullptr;
+        // Check if only substitute if constant
+        if (m_varp->substConstOnly() && !VN_IS(rhsp, Const)) return nullptr;
+        // Substitute it
+        return rhsp;
     }
     // Return what to substitute given word number for
     AstNodeExpr* substWord(AstNode* errp, int word) {
@@ -227,7 +233,7 @@ class SubstVisitor final : public VNVisitor {
     int m_ops = 0;  // Number of operators on assign rhs
     int m_assignStep = 0;  // Assignment number to determine var lifetime
     const AstCFunc* m_funcp = nullptr;  // Current function we are under
-    VDouble0 m_statSubsts;  // Statistic tracking
+    size_t m_nSubst;  // Number of substitutions performed
 
     enum {
         SUBST_MAX_OPS_SUBST = 30,  // Maximum number of ops to substitute in
@@ -251,7 +257,10 @@ class SubstVisitor final : public VNVisitor {
         VL_RESTORER(m_ops);
         m_ops = 0;
         m_assignStep++;
+        const size_t nSubstBefore = m_nSubst;
         iterateAndNextNull(nodep->rhsp());
+        if (nSubstBefore != m_nSubst) V3Const::constifyEditCpp(nodep->rhsp());
+        if (VN_IS(nodep->rhsp(), Const)) m_ops = 0;
         bool hit = false;
         if (AstVarRef* const varrefp = VN_CAST(nodep->lhsp(), VarRef)) {
             if (isSubstVar(varrefp->varp())) {
@@ -292,11 +301,14 @@ class SubstVisitor final : public VNVisitor {
         UINFOTREE(6, newp, "", "w_new");
         nodep->replaceWith(newp);
         VL_DO_DANGLING(nodep->deleteTree(), nodep);
-        ++m_statSubsts;
+        ++m_nSubst;
     }
     void visit(AstWordSel* nodep) override {
         if (!m_funcp) return;
+        const size_t nSubstBefore = m_nSubst;
         iterate(nodep->bitp());
+        // Simplify in case it was substituted and became constant
+        if (nSubstBefore != m_nSubst) V3Const::constifyEditCpp(nodep->bitp());
         AstVarRef* const varrefp = VN_CAST(nodep->fromp(), VarRef);
         const AstConst* const constp = VN_CAST(nodep->bitp(), Const);
         if (varrefp && isSubstVar(varrefp->varp()) && varrefp->access().isReadOnly() && constp) {
@@ -380,7 +392,7 @@ public:
     // CONSTRUCTORS
     explicit SubstVisitor(AstNode* nodep) { iterate(nodep); }
     ~SubstVisitor() override {
-        V3Stats::addStat("Optimizations, Substituted temps", m_statSubsts);
+        V3Stats::addStat("Optimizations, Substituted temps", m_nSubst);
         UASSERT(m_entries.empty(), "References outside functions");
     }
 };


### PR DESCRIPTION
- Avoid repeated sub-expressions in expanded wide AstSel
- Fix OOB access to VlWide when the AstSel itself is not OOB

This also makes the output code a bit more readable and is overall neutral in performance for both verilation and simulation.

Fixes #6341
