### PR TITLE
mark undefined weak symbol as -U for APPLE

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -35,6 +35,7 @@ Chris Randall
 Christopher Taylor
 Chuxuan Wang
 Chykon
+Congcong Cai
 Conor McCullough
 Dan Petrisko
 Danny Oler

--- a/verilator-config.cmake.in
+++ b/verilator-config.cmake.in
@@ -119,7 +119,7 @@ if(NOT CMAKE_CXX_COMPILER_ID MATCHES MSVC)
     endif()
 endif()
 
-if(${CMAKE_CXX_COMPILER_ID} STREQUAL "AppleClang")
+if(Apple)
     add_link_options(-Wl,-U,__Z15vl_time_stamp64v,-U,__Z13sc_time_stampv)
 endif()
 


### PR DESCRIPTION
undefined weak link is a common problem in macos even use normal clang.
this patch wants to relax the restrictions on adding the link option, from Apple Clang to all Apple devices

previous PR: #3823
