### PR TITLE
fix: cmake variable APPLE can't be written as Apple

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -38,8 +38,8 @@ Chykon
 Congcong Cai
 Conor McCullough
 Dan Petrisko
-Danny Oler
 Daniel Bates
+Danny Oler
 Dave Sargeant
 David Horton
 David Ledger
@@ -144,6 +144,7 @@ Krzysztof Obłonczek
 Krzysztof Starecki
 Krzysztof Sychla
 Kuba Ober
+Lan Zongwei
 Larry Doolittle
 Liam Braun
 Luca Colagrande

--- a/verilator-config.cmake.in
+++ b/verilator-config.cmake.in
@@ -119,7 +119,7 @@ if(NOT CMAKE_CXX_COMPILER_ID MATCHES MSVC)
     endif()
 endif()
 
-if(Apple)
+if(APPLE)
     add_link_options(-Wl,-U,__Z15vl_time_stamp64v,-U,__Z13sc_time_stampv)
 endif()
 


### PR DESCRIPTION
cmake variable APPLE can't be written as Apple.

fix cmake issue in the pr: https://github.com/verilator/verilator/pull/6348