### PR TITLE
Wrap forked processes in `begin`s early

### DIFF
--- a/src/V3AstNodes.cpp
+++ b/src/V3AstNodes.cpp
@@ -3232,7 +3232,8 @@ AstAlways* AstAssignW::convertToAlways() {
     if (hasTimingControl) {
         // If there's a timing control, put the assignment in a fork..join_none. This process won't
         // get marked as suspendable and thus will be scheduled normally
-        AstFork* forkp = new AstFork{flp, "", bodysp};
+        AstBegin* const beginp = new AstBegin{flp, "", bodysp};
+        AstFork* const forkp = new AstFork{flp, "", beginp};
         forkp->joinType(VJoinType::JOIN_NONE);
         bodysp = forkp;
     }

--- a/src/V3Fork.cpp
+++ b/src/V3Fork.cpp
@@ -459,10 +459,11 @@ class DynScopeVisitor final : public VNVisitor {
                 })) {
             nodep->user2(true);
             // Put it in a fork to prevent lifetime issues with the local
-            AstFork* const forkp = new AstFork{nodep->fileline(), "", nullptr};
+            AstBegin* const beginp = new AstBegin{nodep->fileline(), "", nullptr};
+            AstFork* const forkp = new AstFork{nodep->fileline(), "", beginp};
             forkp->joinType(VJoinType::JOIN_NONE);
             nodep->replaceWith(forkp);
-            forkp->addStmtsp(nodep);
+            beginp->addStmtsp(nodep);
             UINFO(9, "assign new fork " << forkp);
         } else {
             visit(static_cast<AstNodeStmt*>(nodep));

--- a/test_regress/t/t_timing_intra_assign_func.py
+++ b/test_regress/t/t_timing_intra_assign_func.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2025 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile(verilator_flags2=["--binary"])
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_timing_intra_assign_func.v
+++ b/test_regress/t/t_timing_intra_assign_func.v
@@ -1,0 +1,26 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2025 by Wilson Snyder.
+// SPDX-License-Identifier: CC0-1.0
+
+module t;
+  reg [3:0] ia = 4'd1;
+  wire signed [3:0] iufunc;
+
+  // verilator lint_off WIDTH
+  assign #1 iufunc = int_func(ia);
+  // verilator lint_on WIDTH
+
+  function [31:0] int_func;
+    input [31:0] in;
+    int_func = in * 2;
+  endfunction
+
+  initial begin
+      #1
+      if (iufunc != 4'd2) $stop;
+      $write("*-* All Finished *-*\n");
+      $finish;
+  end
+endmodule


### PR DESCRIPTION
Fixes #6343.

In that test case (as in the one included in this patch), the continuous assignment is converted into an `always` with a fork. The forked process was not wrapped in a `begin`, so the `always` got marked as a suspendable, so it got converted to an `initial forever` (basically). The timing control was in a fork, so it never suspended the loop, leading to a hang. This patch requires the pre-`Timing` stages to wrap statements under forks in `begin`s.