### PR TITLE
Internals: Improve astgen type enums to be switch statement friendly

### DIFF
--- a/src/V3Ast.cpp
+++ b/src/V3Ast.cpp
@@ -52,7 +52,7 @@ int AstNodeDType::s_uniqueNum = 0;
 //######################################################################
 // VNType
 
-const VNTypeInfo VNType::typeInfoTable[] = {
+const VNTypeInfo VNType::s_typeInfoTable[VNType::NUM_TYPES()] = {
 #include "V3Ast__gen_type_info.h"  // From ./astgen
 };
 
@@ -1162,8 +1162,7 @@ bool AstNode::sameTreeIter(const AstNode* node1p, const AstNode* node2p, bool ig
 void AstNode::checkTreeIter(const AstNode* prevBackp) const VL_MT_STABLE {
     // private: Check a tree and children
     UASSERT_OBJ(prevBackp == this->backp(), this, "Back node inconsistent");
-    // cppcheck-suppress danglingTempReference
-    const VNTypeInfo& typeInfo = *type().typeInfo();
+    const VNTypeInfo& typeInfo = VNType::typeInfo(this->type());
     for (int i = 1; i <= 4; i++) {
         AstNode* nodep = nullptr;
         switch (i) {

--- a/src/V3Ast.h
+++ b/src/V3Ast.h
@@ -109,22 +109,21 @@ struct VNTypeInfo final {
 };
 
 class VNType final {
-    static const VNTypeInfo typeInfoTable[];
+    static const VNTypeInfo s_typeInfoTable[];
 
 public:
 #include "V3Ast__gen_type_enum.h"  // From ./astgen
-    // Above include has:
-    //   enum en {...};
-    //   const char* ascii() const {...};
-    const enum en m_e;
+    const en m_e;
     VNType() = delete;
+
+    // VNType is interconvetible with VNType::en
     // cppcheck-suppress noExplicitConstructor
-    constexpr VNType(en _e) VL_MT_SAFE : m_e{_e} {}
-    explicit VNType(int _e)
-        : m_e(static_cast<en>(_e)) {}  // Need () or GCC 4.8 false warning
-    // cppcheck-suppress danglingTempReference
-    const VNTypeInfo* typeInfo() const VL_MT_SAFE { return &typeInfoTable[m_e]; }
+    constexpr VNType(en _e) VL_MT_SAFE
+        : m_e{_e} {}
     constexpr operator en() const VL_MT_SAFE { return m_e; }
+
+    // Retrieve VNTypeInfo for the given type
+    static const VNTypeInfo& typeInfo(VNType t) VL_MT_SAFE { return s_typeInfoTable[t.m_e]; }
 };
 constexpr bool operator==(const VNType& lhs, const VNType& rhs) VL_PURE {
     return lhs.m_e == rhs.m_e;

--- a/src/V3Begin.cpp
+++ b/src/V3Begin.cpp
@@ -387,9 +387,9 @@ static AstNode* createForeachLoop(AstNodeForeach* nodep, AstNode* bodysp, AstVar
     AstNodeExpr* condp;
     bool inc = true;
     switch (nodeType) {
-    case VNType::atLteS: condp = new AstLteS{fl, varRefp, rightp}; break;
-    case VNType::atLt: condp = new AstLt{fl, varRefp, rightp}; break;
-    case VNType::atGteS:
+    case VNType::LteS: condp = new AstLteS{fl, varRefp, rightp}; break;
+    case VNType::Lt: condp = new AstLt{fl, varRefp, rightp}; break;
+    case VNType::GteS:
         condp = new AstGteS{fl, varRefp, rightp};
         inc = false;
         break;
@@ -419,8 +419,8 @@ static AstNode* createForeachLoopRanged(AstNodeForeach* nodep, AstNode* bodysp, 
     AstNodeExpr* const leftp = new AstConst{fl, left};
     AstNodeExpr* const rightp = new AstConst{fl, right};
     return createForeachLoop(nodep, bodysp, varp, leftp, rightp,
-                             declRange.left() <= declRange.right() ? VNType::atLteS
-                                                                   : VNType::atGteS);
+                             declRange.left() <= declRange.right() ? VNType::LteS
+                                                                   : VNType::GteS);
 }
 AstNode* V3Begin::convertToWhile(AstForeach* nodep) {
     // UINFOTREE(1, nodep, "", "foreach-old");
@@ -460,7 +460,7 @@ AstNode* V3Begin::convertToWhile(AstForeach* nodep) {
                     AstConst* const leftp = new AstConst{fl, 0};
                     AstNodeExpr* const rightp = new AstLenN{fl, fromp->cloneTreePure(false)};
                     loopp
-                        = createForeachLoop(nodep, bodyPointp, varp, leftp, rightp, VNType::atLt);
+                        = createForeachLoop(nodep, bodyPointp, varp, leftp, rightp, VNType::Lt);
                 } else {
                     UASSERT_OBJ(adtypep->isRanged(), varp, "foreach on basic " << adtypep);
                     loopp = createForeachLoopRanged(nodep, bodyPointp, varp, adtypep->declRange());
@@ -479,7 +479,7 @@ AstNode* V3Begin::convertToWhile(AstForeach* nodep) {
                 subfromp->dtypep(fromDtp);
                 rightp->dtypeSetSigned32();
                 rightp->protect(false);
-                loopp = createForeachLoop(nodep, bodyPointp, varp, leftp, rightp, VNType::atLt);
+                loopp = createForeachLoop(nodep, bodyPointp, varp, leftp, rightp, VNType::Lt);
             } else if (VN_IS(fromDtp, AssocArrayDType)) {
                 // Make this: var KEY_TYPE index;
                 //            bit index__Vfirst;

--- a/src/V3CCtors.cpp
+++ b/src/V3CCtors.cpp
@@ -177,7 +177,7 @@ class CCtorsVisitor final : public VNVisitor {
             // If can be referred to by base pointer, need virtual delete
             funcp->isVirtual(classp->isExtended());
             funcp->slow(false);
-            insertSc(funcp, classp, VNType::atScDtor);
+            insertSc(funcp, classp, VNType::ScDtor);
             classp->addStmtsp(funcp);
         }
     }
@@ -188,7 +188,7 @@ class CCtorsVisitor final : public VNVisitor {
         m_varResetp = nullptr;
         m_cfuncp = nodep;
         iterateChildren(nodep);
-        if (nodep->name() == "new") insertSc(nodep, m_modp, VNType::atScCtor);
+        if (nodep->name() == "new") insertSc(nodep, m_modp, VNType::ScCtor);
     }
     void visit(AstVar* nodep) override {
         if (nodep->needsCReset()) {

--- a/src/V3Dfg.cpp
+++ b/src/V3Dfg.cpp
@@ -81,7 +81,7 @@ std::unique_ptr<DfgGraph> DfgGraph::clone() const {
         DfgVertexVar* cp = nullptr;
 
         switch (vtx.type()) {
-        case VDfgType::atVarArray: {
+        case VDfgType::VarArray: {
             if (scoped) {
                 cp = new DfgVarArray{*clonep, vp->varScopep()};
             } else {
@@ -90,7 +90,7 @@ std::unique_ptr<DfgGraph> DfgGraph::clone() const {
             vtxp2clonep.emplace(&vtx, cp);
             break;
         }
-        case VDfgType::atVarPacked: {
+        case VDfgType::VarPacked: {
             if (scoped) {
                 cp = new DfgVarPacked{*clonep, vp->varScopep()};
             } else {
@@ -112,38 +112,38 @@ std::unique_ptr<DfgGraph> DfgGraph::clone() const {
     for (const DfgVertex& vtx : m_opVertices) {
         switch (vtx.type()) {
 #include "V3Dfg__gen_clone_cases.h"  // From ./astgen
-        case VDfgType::atSel: {
+        case VDfgType::Sel: {
             DfgSel* const cp = new DfgSel{*clonep, vtx.fileline(), vtx.dtypep()};
             cp->lsb(vtx.as<DfgSel>()->lsb());
             vtxp2clonep.emplace(&vtx, cp);
             break;
         }
-        case VDfgType::atUnitArray: {
+        case VDfgType::UnitArray: {
             DfgUnitArray* const cp = new DfgUnitArray{*clonep, vtx.fileline(), vtx.dtypep()};
             vtxp2clonep.emplace(&vtx, cp);
             break;
         }
-        case VDfgType::atMux: {
+        case VDfgType::Mux: {
             DfgMux* const cp = new DfgMux{*clonep, vtx.fileline(), vtx.dtypep()};
             vtxp2clonep.emplace(&vtx, cp);
             break;
         }
-        case VDfgType::atSpliceArray: {
+        case VDfgType::SpliceArray: {
             DfgSpliceArray* const cp = new DfgSpliceArray{*clonep, vtx.fileline(), vtx.dtypep()};
             vtxp2clonep.emplace(&vtx, cp);
             break;
         }
-        case VDfgType::atSplicePacked: {
+        case VDfgType::SplicePacked: {
             DfgSplicePacked* const cp = new DfgSplicePacked{*clonep, vtx.fileline(), vtx.dtypep()};
             vtxp2clonep.emplace(&vtx, cp);
             break;
         }
-        case VDfgType::atLogic: {
+        case VDfgType::Logic: {
             vtx.v3fatalSrc("DfgLogic cannot be cloned");
             VL_UNREACHABLE;
             break;
         }
-        case VDfgType::atUnresolved: {
+        case VDfgType::Unresolved: {
             vtx.v3fatalSrc("DfgUnresolved cannot be cloned");
             VL_UNREACHABLE;
             break;
@@ -168,8 +168,8 @@ std::unique_ptr<DfgGraph> DfgGraph::clone() const {
     for (const DfgVertex& vtx : m_opVertices) {
         if (vtx.is<DfgVertexVariadic>()) {
             switch (vtx.type()) {
-            case VDfgType::atSpliceArray:
-            case VDfgType::atSplicePacked: {
+            case VDfgType::SpliceArray:
+            case VDfgType::SplicePacked: {
                 const DfgVertexSplice* const vp = vtx.as<DfgVertexSplice>();
                 DfgVertexSplice* const cp = vtxp2clonep.at(vp)->as<DfgVertexSplice>();
                 vp->foreachDriver([&](const DfgVertex& src, uint32_t lo, FileLine* flp) {

--- a/src/V3Dfg.h
+++ b/src/V3Dfg.h
@@ -150,8 +150,10 @@ inline AstNodeDType* toDfgDType(const AstNodeDType* dtypep) {
 class VDfgType final {
 public:
 #include "V3Dfg__gen_type_enum.h"  // From ./astgen
-    const enum en m_e;
+    const en m_e;
     VDfgType() = delete;
+
+    // VDfgType is interconvetible with VDfgType::en
     // cppcheck-suppress noExplicitConstructor
     constexpr VDfgType(en _e)
         : m_e{_e} {}

--- a/src/V3EmitCHeaders.cpp
+++ b/src/V3EmitCHeaders.cpp
@@ -564,7 +564,7 @@ class EmitCHeader final : public EmitCConstInit {
         puts("\nclass " + EmitCUtil::symClassName() + ";\n");
 
         // From `systemc_header
-        emitTextSection(modp, VNType::atScHdr);
+        emitTextSection(modp, VNType::ScHdr);
 
         emitStructs(modp);
 
@@ -607,7 +607,7 @@ class EmitCHeader final : public EmitCConstInit {
         emitFuncDecls(modp, /* inClassBody: */ true);
 
         // From `systemc_interface
-        emitTextSection(modp, VNType::atScInt);
+        emitTextSection(modp, VNType::ScInt);
 
         // Close class body
         puts("};\n");
@@ -616,7 +616,7 @@ class EmitCHeader final : public EmitCConstInit {
         // Emit out of class function declarations
         puts("\n");
         emitFuncDecls(modp, /* inClassBody: */ false);
-        emitTextSection(modp, VNType::atScHdrPost);
+        emitTextSection(modp, VNType::ScHdrPost);
     }
 
     explicit EmitCHeader(const AstNodeModule* modp) {

--- a/src/V3EmitCImp.cpp
+++ b/src/V3EmitCImp.cpp
@@ -200,7 +200,7 @@ class EmitCImp final : EmitCFunc {
         puts("#include \"" + EmitCUtil::pchClassName() + ".h\"\n");
         for (const string& name : headers) puts("#include \"" + name + ".h\"\n");
 
-        emitTextSection(m_modp, VNType::atScImpHdr);
+        emitTextSection(m_modp, VNType::ScImpHdr);
     }
 
     void emitStaticVarDefns(const AstNodeModule* modp) {
@@ -286,7 +286,7 @@ class EmitCImp final : EmitCFunc {
 
         putsDecoration(modp, "// Reset structure values\n");
         puts(modName + "__" + protect("_ctor_var_reset") + "(this);\n");
-        emitTextSection(modp, VNType::atScCtor);
+        emitTextSection(modp, VNType::ScCtor);
 
         puts("}\n");
     }
@@ -393,7 +393,7 @@ class EmitCImp final : EmitCFunc {
         puts("\n");
         putns(modp, EmitCUtil::prefixNameProtect(modp) + "::~" + EmitCUtil::prefixNameProtect(modp)
                         + "() {\n");
-        emitTextSection(modp, VNType::atScDtor);
+        emitTextSection(modp, VNType::ScDtor);
         puts("}\n");
         splitSizeInc(10);
     }
@@ -507,7 +507,7 @@ class EmitCImp final : EmitCFunc {
             emitSavableImp(modp);
         } else {
             // From `systemc_implementation
-            emitTextSection(modp, VNType::atScImp);
+            emitTextSection(modp, VNType::ScImp);
         }
     }
     void emitCommonImp(const AstNodeModule* modp) {

--- a/src/V3Slice.cpp
+++ b/src/V3Slice.cpp
@@ -350,12 +350,12 @@ class SliceVisitor final : public VNVisitor {
                     logp = clonep;
                 } else {
                     switch (nodep->type()) {
-                    case VNType::atEq:  // FALLTHRU
-                    case VNType::atEqCase:
+                    case VNType::Eq:  // FALLTHRU
+                    case VNType::EqCase:
                         logp = new AstLogAnd{nodep->fileline(), logp, clonep};
                         break;
-                    case VNType::atNeq:  // FALLTHRU
-                    case VNType::atNeqCase:
+                    case VNType::Neq:  // FALLTHRU
+                    case VNType::NeqCase:
                         logp = new AstLogOr{nodep->fileline(), logp, clonep};
                         break;
                     default: nodep->v3fatalSrc("Unknown node type processing array slice"); break;

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -8015,15 +8015,15 @@ class WidthVisitor final : public VNVisitor {
         if (!nodep->dtypep()) nodep->dtypeFrom(nodep->lhsp());
         // To simplify callers, some node types don't need to change
         switch (nodep->type()) {
-        case VNType::atEq: nodep->dtypeChgSigned(signedFlavorNeeded); return nullptr;
-        case VNType::atNeq: nodep->dtypeChgSigned(signedFlavorNeeded); return nullptr;
-        case VNType::atEqCase: nodep->dtypeChgSigned(signedFlavorNeeded); return nullptr;
-        case VNType::atNeqCase: nodep->dtypeChgSigned(signedFlavorNeeded); return nullptr;
-        case VNType::atEqWild: nodep->dtypeChgSigned(signedFlavorNeeded); return nullptr;
-        case VNType::atNeqWild: nodep->dtypeChgSigned(signedFlavorNeeded); return nullptr;
-        case VNType::atAdd: nodep->dtypeChgSigned(signedFlavorNeeded); return nullptr;
-        case VNType::atSub: nodep->dtypeChgSigned(signedFlavorNeeded); return nullptr;
-        case VNType::atShiftL: nodep->dtypeChgSigned(signedFlavorNeeded); return nullptr;
+        case VNType::Eq: nodep->dtypeChgSigned(signedFlavorNeeded); return nullptr;
+        case VNType::Neq: nodep->dtypeChgSigned(signedFlavorNeeded); return nullptr;
+        case VNType::EqCase: nodep->dtypeChgSigned(signedFlavorNeeded); return nullptr;
+        case VNType::NeqCase: nodep->dtypeChgSigned(signedFlavorNeeded); return nullptr;
+        case VNType::EqWild: nodep->dtypeChgSigned(signedFlavorNeeded); return nullptr;
+        case VNType::NeqWild: nodep->dtypeChgSigned(signedFlavorNeeded); return nullptr;
+        case VNType::Add: nodep->dtypeChgSigned(signedFlavorNeeded); return nullptr;
+        case VNType::Sub: nodep->dtypeChgSigned(signedFlavorNeeded); return nullptr;
+        case VNType::ShiftL: nodep->dtypeChgSigned(signedFlavorNeeded); return nullptr;
         default: break;
         }
         FileLine* const fl = nodep->fileline();
@@ -8031,22 +8031,22 @@ class WidthVisitor final : public VNVisitor {
         AstNodeExpr* const rhsp = nodep->rhsp()->unlinkFrBack();
         AstNodeBiop* newp = nullptr;
         switch (nodep->type()) {
-        case VNType::atGt: newp = new AstGtS{fl, lhsp, rhsp}; break;
-        case VNType::atGtS: newp = new AstGt{fl, lhsp, rhsp}; break;
-        case VNType::atGte: newp = new AstGteS{fl, lhsp, rhsp}; break;
-        case VNType::atGteS: newp = new AstGte{fl, lhsp, rhsp}; break;
-        case VNType::atLt: newp = new AstLtS{fl, lhsp, rhsp}; break;
-        case VNType::atLtS: newp = new AstLt{fl, lhsp, rhsp}; break;
-        case VNType::atLte: newp = new AstLteS{fl, lhsp, rhsp}; break;
-        case VNType::atLteS: newp = new AstLte{fl, lhsp, rhsp}; break;
-        case VNType::atDiv: newp = new AstDivS{fl, lhsp, rhsp}; break;
-        case VNType::atDivS: newp = new AstDiv{fl, lhsp, rhsp}; break;
-        case VNType::atModDiv: newp = new AstModDivS{fl, lhsp, rhsp}; break;
-        case VNType::atModDivS: newp = new AstModDiv{fl, lhsp, rhsp}; break;
-        case VNType::atMul: newp = new AstMulS{fl, lhsp, rhsp}; break;
-        case VNType::atMulS: newp = new AstMul{fl, lhsp, rhsp}; break;
-        case VNType::atShiftR: newp = new AstShiftRS{fl, lhsp, rhsp}; break;
-        case VNType::atShiftRS: newp = new AstShiftR{fl, lhsp, rhsp}; break;
+        case VNType::Gt: newp = new AstGtS{fl, lhsp, rhsp}; break;
+        case VNType::GtS: newp = new AstGt{fl, lhsp, rhsp}; break;
+        case VNType::Gte: newp = new AstGteS{fl, lhsp, rhsp}; break;
+        case VNType::GteS: newp = new AstGte{fl, lhsp, rhsp}; break;
+        case VNType::Lt: newp = new AstLtS{fl, lhsp, rhsp}; break;
+        case VNType::LtS: newp = new AstLt{fl, lhsp, rhsp}; break;
+        case VNType::Lte: newp = new AstLteS{fl, lhsp, rhsp}; break;
+        case VNType::LteS: newp = new AstLte{fl, lhsp, rhsp}; break;
+        case VNType::Div: newp = new AstDivS{fl, lhsp, rhsp}; break;
+        case VNType::DivS: newp = new AstDiv{fl, lhsp, rhsp}; break;
+        case VNType::ModDiv: newp = new AstModDivS{fl, lhsp, rhsp}; break;
+        case VNType::ModDivS: newp = new AstModDiv{fl, lhsp, rhsp}; break;
+        case VNType::Mul: newp = new AstMulS{fl, lhsp, rhsp}; break;
+        case VNType::MulS: newp = new AstMul{fl, lhsp, rhsp}; break;
+        case VNType::ShiftR: newp = new AstShiftRS{fl, lhsp, rhsp}; break;
+        case VNType::ShiftRS: newp = new AstShiftR{fl, lhsp, rhsp}; break;
         default:  // LCOV_EXCL_LINE
             nodep->v3fatalSrc("Node needs sign change, but bad case: " << nodep);
             break;
@@ -8066,25 +8066,25 @@ class WidthVisitor final : public VNVisitor {
         AstNodeBiop* newp = nullptr;
         // No width change on output;...                // All below have bool or double outputs
         switch (nodep->type()) {
-        case VNType::atAdd: newp = new AstAddD{fl, lhsp, rhsp}; break;
-        case VNType::atSub: newp = new AstSubD{fl, lhsp, rhsp}; break;
-        case VNType::atPow: newp = new AstPowD{fl, lhsp, rhsp}; break;
-        case VNType::atEq:
-        case VNType::atEqCase: newp = new AstEqD{fl, lhsp, rhsp}; break;
-        case VNType::atNeq:
-        case VNType::atNeqCase: newp = new AstNeqD{fl, lhsp, rhsp}; break;
-        case VNType::atGt:
-        case VNType::atGtS: newp = new AstGtD{fl, lhsp, rhsp}; break;
-        case VNType::atGte:
-        case VNType::atGteS: newp = new AstGteD{fl, lhsp, rhsp}; break;
-        case VNType::atLt:
-        case VNType::atLtS: newp = new AstLtD{fl, lhsp, rhsp}; break;
-        case VNType::atLte:
-        case VNType::atLteS: newp = new AstLteD{fl, lhsp, rhsp}; break;
-        case VNType::atDiv:
-        case VNType::atDivS: newp = new AstDivD{fl, lhsp, rhsp}; break;
-        case VNType::atMul:
-        case VNType::atMulS: newp = new AstMulD{fl, lhsp, rhsp}; break;
+        case VNType::Add: newp = new AstAddD{fl, lhsp, rhsp}; break;
+        case VNType::Sub: newp = new AstSubD{fl, lhsp, rhsp}; break;
+        case VNType::Pow: newp = new AstPowD{fl, lhsp, rhsp}; break;
+        case VNType::Eq:
+        case VNType::EqCase: newp = new AstEqD{fl, lhsp, rhsp}; break;
+        case VNType::Neq:
+        case VNType::NeqCase: newp = new AstNeqD{fl, lhsp, rhsp}; break;
+        case VNType::Gt:
+        case VNType::GtS: newp = new AstGtD{fl, lhsp, rhsp}; break;
+        case VNType::Gte:
+        case VNType::GteS: newp = new AstGteD{fl, lhsp, rhsp}; break;
+        case VNType::Lt:
+        case VNType::LtS: newp = new AstLtD{fl, lhsp, rhsp}; break;
+        case VNType::Lte:
+        case VNType::LteS: newp = new AstLteD{fl, lhsp, rhsp}; break;
+        case VNType::Div:
+        case VNType::DivS: newp = new AstDivD{fl, lhsp, rhsp}; break;
+        case VNType::Mul:
+        case VNType::MulS: newp = new AstMulD{fl, lhsp, rhsp}; break;
         default:  // LCOV_EXCL_LINE
             nodep->v3fatalSrc("Node needs conversion to double, but bad case: " << nodep);
             break;
@@ -8105,18 +8105,18 @@ class WidthVisitor final : public VNVisitor {
         AstNodeBiop* newp = nullptr;
         // No width change on output;...                // All below have bool or double outputs
         switch (nodep->type()) {
-        case VNType::atEq:
-        case VNType::atEqCase: newp = new AstEqN{fl, lhsp, rhsp}; break;
-        case VNType::atNeq:
-        case VNType::atNeqCase: newp = new AstNeqN{fl, lhsp, rhsp}; break;
-        case VNType::atGt:
-        case VNType::atGtS: newp = new AstGtN{fl, lhsp, rhsp}; break;
-        case VNType::atGte:
-        case VNType::atGteS: newp = new AstGteN{fl, lhsp, rhsp}; break;
-        case VNType::atLt:
-        case VNType::atLtS: newp = new AstLtN{fl, lhsp, rhsp}; break;
-        case VNType::atLte:
-        case VNType::atLteS: newp = new AstLteN{fl, lhsp, rhsp}; break;
+        case VNType::Eq:
+        case VNType::EqCase: newp = new AstEqN{fl, lhsp, rhsp}; break;
+        case VNType::Neq:
+        case VNType::NeqCase: newp = new AstNeqN{fl, lhsp, rhsp}; break;
+        case VNType::Gt:
+        case VNType::GtS: newp = new AstGtN{fl, lhsp, rhsp}; break;
+        case VNType::Gte:
+        case VNType::GteS: newp = new AstGteN{fl, lhsp, rhsp}; break;
+        case VNType::Lt:
+        case VNType::LtS: newp = new AstLtN{fl, lhsp, rhsp}; break;
+        case VNType::Lte:
+        case VNType::LteS: newp = new AstLteN{fl, lhsp, rhsp}; break;
         default:  // LCOV_EXCL_LINE
             nodep->v3fatalSrc("Node needs conversion to string, but bad case: " << nodep);
             break;
@@ -8135,7 +8135,7 @@ class WidthVisitor final : public VNVisitor {
         AstNodeExpr* const lhsp = nodep->lhsp()->unlinkFrBack();
         AstNodeUniop* newp = nullptr;
         switch (nodep->type()) {
-        case VNType::atNegate: newp = new AstNegateD{fl, lhsp}; break;
+        case VNType::Negate: newp = new AstNegateD{fl, lhsp}; break;
         default:  // LCOV_EXCL_LINE
             nodep->v3fatalSrc("Node needs conversion to double, but bad case: " << nodep);
             break;

--- a/src/astgen
+++ b/src/astgen
@@ -832,22 +832,20 @@ def write_type_enum(prefix, nodeList):
 
         fh.write("    enum en : uint16_t {\n")
         for node in sorted(filter(lambda _: _.isLeaf, nodeList), key=lambda _: _.typeId):
-            fh.write("        at{t} = {n},\n".format(t=node.name, n=node.typeId))
-        fh.write("        _ENUM_END = {n}\n".format(n=root.typeIdMax + 1))
+            fh.write("        {t} = {n},\n".format(t=node.name, n=node.typeId))
         fh.write("    };\n")
+        fh.write("    static constexpr size_t NUM_TYPES() {{ return {n}; }}\n".format(n=root.typeIdMax + 1))
 
         fh.write("    enum bounds : uint16_t {\n")
         for node in sorted(filter(lambda _: not _.isLeaf, nodeList), key=lambda _: _.typeIdMin):
             fh.write("        first{t} = {n},\n".format(t=node.name, n=node.typeIdMin))
             fh.write("        last{t}  = {n},\n".format(t=node.name, n=node.typeIdMax))
-        fh.write("        _BOUNDS_END\n")
         fh.write("    };\n")
 
         fh.write("    const char* ascii() const VL_MT_SAFE {\n")
-        fh.write("        static const char* const names[_ENUM_END + 1] = {\n")
+        fh.write("        static const char* const names[] = {\n")
         for node in sorted(filter(lambda _: _.isLeaf, nodeList), key=lambda _: _.typeId):
             fh.write('            "{T}",\n'.format(T=node.name.upper()))
-        fh.write("            \"_ENUM_END\"\n")
         fh.write("        };\n")
         fh.write("        return names[m_e];\n")
         fh.write("    }\n")
@@ -879,7 +877,7 @@ def write_type_tests(prefix, nodeList):
                     "return static_cast<int>({v}->type()) >= static_cast<int>({e}::first{t}) && static_cast<int>({v}->type()) <= static_cast<int>({e}::last{t});"
                     .format(v=variable, e=enum, t=node.name))
             else:
-                fh.write("return {v}->type() == {e}::at{t};".format(v=variable,
+                fh.write("return {v}->type() == {e}::{t};".format(v=variable,
                                                                     e=enum,
                                                                     t=node.name))
             fh.write(" }\n")
@@ -1148,7 +1146,7 @@ def write_ast_macros(filename):
             # Only care about leaf classes for the rest
             if node.isLeaf:
                 fh.write(
-                    "#define ASTGEN_SUPER_{t}(...) Ast{b}(VNType::at{t}, __VA_ARGS__)\n".format(
+                    "#define ASTGEN_SUPER_{t}(...) Ast{b}(VNType::{t}, __VA_ARGS__)\n".format(
                         t=node.name, b=node.superClass.name))
             fh.write("\n")
 
@@ -1180,7 +1178,7 @@ def write_dfg_macros(filename):
 
             if node.isLeaf:
                 emitBlock('''\
-                static constexpr VDfgType dfgType() {{ return VDfgType::at{t}; }};
+                static constexpr VDfgType dfgType() {{ return VDfgType::{t}; }};
                 using Super = Dfg{s};
                 void accept(DfgVisitor& v) override {{ v.visit(this); }}
                 ''',
@@ -1249,7 +1247,7 @@ def write_dfg_clone_cases(filename):
                 continue
 
             emitBlock('''\
-                      case VDfgType::at{t}: {{
+                      case VDfgType::{t}: {{
                         Dfg{t}* const cp = new Dfg{t}{{*clonep, vtx.fileline(), vtx.dtypep()}};
                         vtxp2clonep.emplace(&vtx, cp);
                         break;


### PR DESCRIPTION
- Remove _ENUM_END, so -Wswitch does not demand it's covered. Use the new NUM_TYPES constexpr member instead.
- Remove 'at' prefix. This seems historical and is not particularly useful.
- Fix some cppcheck warts while at it
