### PR TITLE
Deadify functions without references, check virtual class instantiations later

### DIFF
--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -4582,11 +4582,6 @@ class WidthVisitor final : public VNVisitor {
                 // Either made explicitly or V3LinkDot made implicitly
                 classp->v3fatalSrc("Can't find class's new");
             }
-            if (classp->isVirtual() || classp->isInterfaceClass()) {
-                nodep->v3error("Illegal to call 'new' using an abstract virtual class "
-                               + AstNode::prettyNameQ(classp->origName())
-                               + " (IEEE 1800-2023 8.21)");
-            }
         } else {  // super.new case
             // in this case class and taskp() should be properly linked in V3LinkDot.cpp during
             // "super" reference resolution

--- a/test_regress/t/t_class_param_virtual_bad.out
+++ b/test_regress/t/t_class_param_virtual_bad.out
@@ -1,10 +1,10 @@
-%Error: t/t_class_param_virtual_bad.v:13:11: Illegal to call 'new' using an abstract virtual class 'VBase' (IEEE 1800-2023 8.21)
-                                           : ... note: In instance 't'
-   13 |       t = new;
-      |           ^~~
-        ... See the manual at https://verilator.org/verilator_doc.html?v=latest for more assistance.
 %Error: t/t_class_param_virtual_bad.v:23:28: Illegal to call 'new' using an abstract virtual class 'ClsVirt' (IEEE 1800-2023 8.21)
                                            : ... note: In instance 't'
    23 |       ClsVirt#(VBase) cv = new;   
       |                            ^~~
+        ... See the manual at https://verilator.org/verilator_doc.html?v=latest for more assistance.
+%Error: t/t_class_param_virtual_bad.v:13:11: Illegal to call 'new' using an abstract virtual class 'VBase' (IEEE 1800-2023 8.21)
+                                           : ... note: In instance 't'
+   13 |       t = new;
+      |           ^~~
 %Error: Exiting due to

--- a/test_regress/t/t_func_virt_new.py
+++ b/test_regress/t/t_func_virt_new.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2025 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('vlt')
+
+test.lint()
+
+test.compile()
+
+test.passes()

--- a/test_regress/t/t_func_virt_new.v
+++ b/test_regress/t/t_func_virt_new.v
@@ -1,0 +1,19 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2025 by Antmicro.
+// SPDX-License-Identifier: CC0-1.0
+
+class cl #(type T= int);
+  function void f();
+    T obj = new;
+  endfunction
+endclass
+virtual class vcl;
+endclass;
+module t;
+  cl #(vcl) c = new;
+  initial begin
+
+  end
+endmodule

--- a/test_regress/t/t_func_virt_new_bad.out
+++ b/test_regress/t/t_func_virt_new_bad.out
@@ -1,0 +1,6 @@
+%Error: t/t_func_virt_new_bad.v:9:13: Illegal to call 'new' using an abstract virtual class 'vcl' (IEEE 1800-2023 8.21)
+                                    : ... note: In instance 't'
+    9 |     T obj = new;
+      |             ^~~
+        ... See the manual at https://verilator.org/verilator_doc.html?v=latest for more assistance.
+%Error: Exiting due to

--- a/test_regress/t/t_func_virt_new_bad.py
+++ b/test_regress/t/t_func_virt_new_bad.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2025 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('vlt')
+
+test.lint(fails=True, expect_filename=test.golden_filename)
+
+test.passes()

--- a/test_regress/t/t_func_virt_new_bad.v
+++ b/test_regress/t/t_func_virt_new_bad.v
@@ -1,0 +1,19 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2025 by Antmicro.
+// SPDX-License-Identifier: CC0-1.0
+
+class cl #(type T= int);
+  function void f();
+    T obj = new;
+  endfunction
+endclass
+virtual class vcl;
+endclass;
+module t;
+  cl #(vcl) c = new;
+  initial begin
+    c.f();
+  end
+endmodule

--- a/test_regress/t/t_opt_dead_task.py
+++ b/test_regress/t/t_opt_dead_task.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2025 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile(verilator_flags2=["--stats"])
+
+if test.vlt_all:
+    test.file_grep(test.stats, r'Optimizations, deadified FTasks\s+(\d+)', 2)
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_opt_dead_task.v
+++ b/test_regress/t/t_opt_dead_task.v
@@ -1,0 +1,28 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2025 by Antmicro.
+// SPDX-License-Identifier: CC0-1.0
+
+module t (input clk);
+   // AstLet and AstProperty are also NodeFTasks, but lets are substituted earlier and properties should be "used" by their asserts so also not deadified
+   let nclk = ~clk;
+   assert property(@(posedge clk)1);
+
+   function void livefunc();
+   endfunction
+   task livetask;
+   endtask
+   // Tasks/functions that are called somewhere will not be deadified
+   initial begin
+      livefunc();
+      livetask();
+      $finish;
+   end
+
+   // These should be deadified
+   function deadfunc();
+   endfunction
+   task deadtask;
+   endtask
+endmodule


### PR DESCRIPTION
Deadify functions that are not class methods and have no references.
Track virtual class instantiations in another way - if it is in a function that is never called, allow it.