### PR TITLE
Optimize constant folding in wide expression expansion

### DIFF
--- a/src/V3Expand.cpp
+++ b/src/V3Expand.cpp
@@ -78,9 +78,9 @@ class ExpandVisitor final : public VNVisitor {
 
     // STATE - across all visitors
     AstCFunc* m_funcp = nullptr;  // Current function
-    size_t m_statWides = 0;  // Statistic tracking
-    size_t m_statWideWords = 0;  // Statistic tracking
-    size_t m_statWideLimited = 0;  // Statistic tracking
+    VDouble0 m_statWides;  // Statistic tracking
+    VDouble0 m_statWideWords;  // Statistic tracking
+    VDouble0 m_statWideLimited;  // Statistic tracking
 
     // STATE - for current function
     size_t m_nTmps = 0;  // Sequence numbers for temopraries
@@ -390,7 +390,7 @@ class ExpandVisitor final : public VNVisitor {
         VL_RESTORER(m_nTmps);
         m_funcp = nodep;
         m_nTmps = 0;
-        const size_t statWidesBefore = m_statWides;
+        const VDouble0 statWidesBefore = m_statWides;
         iterateChildren(nodep);
 
         // Constant fold here if anything was expanded, as Ast size can likely be reduced

--- a/src/V3Expand.cpp
+++ b/src/V3Expand.cpp
@@ -78,9 +78,9 @@ class ExpandVisitor final : public VNVisitor {
 
     // STATE - across all visitors
     AstCFunc* m_funcp = nullptr;  // Current function
-    VDouble0 m_statWides;  // Statistic tracking
-    VDouble0 m_statWideWords;  // Statistic tracking
-    VDouble0 m_statWideLimited;  // Statistic tracking
+    size_t m_statWides = 0;  // Statistic tracking
+    size_t m_statWideWords = 0;  // Statistic tracking
+    size_t m_statWideLimited = 0;  // Statistic tracking
 
     // STATE - for current function
     size_t m_nTmps = 0;  // Sequence numbers for temopraries
@@ -95,8 +95,8 @@ class ExpandVisitor final : public VNVisitor {
 
     bool doExpandWide(AstNode* nodep) {
         if (isImpure(nodep)) return false;
-        ++m_statWides;
         if (nodep->widthWords() <= v3Global.opt.expandLimit()) {
+            ++m_statWides;
             m_statWideWords += nodep->widthWords();
             return true;
         } else {
@@ -390,10 +390,11 @@ class ExpandVisitor final : public VNVisitor {
         VL_RESTORER(m_nTmps);
         m_funcp = nodep;
         m_nTmps = 0;
+        const size_t statWidesBefore = m_statWides;
         iterateChildren(nodep);
 
-        // Constant fold here, as Ast size can likely be reduced
-        if (v3Global.opt.fConstEager()) {
+        // Constant fold here if anything was expanded, as Ast size can likely be reduced
+        if (v3Global.opt.fConstEager() && m_statWides != statWidesBefore) {
             AstNode* const editedp = V3Const::constifyEditCpp(nodep);
             UASSERT_OBJ(editedp == nodep, editedp, "Should not have replaced CFunc");
         }


### PR DESCRIPTION
Do not apply V3Const in V3Expand after a function if nothing was expanded in it.

Also fix statistics counter while at it.

Inspired by #6340

I'm assuming based on this showing up as "Optimizations, expand wides" m_statWides was supposed to be the number of expanded wides?