### PR TITLE
Fix import of class with default params

### DIFF
--- a/src/V3AstNodeOther.h
+++ b/src/V3AstNodeOther.h
@@ -1348,6 +1348,7 @@ public:
 };
 class AstPackageImport final : public AstNode {
     // A package import declaration
+    // @astgen op1 := resolvedClassp : Optional[AstClassOrPackageRef]
     //
     // @astgen ptr := m_packagep : Optional[AstPackage]  // Package hierarchy
     string m_name;  // What imported e.g. "*"

--- a/src/V3LinkDot.cpp
+++ b/src/V3LinkDot.cpp
@@ -1694,7 +1694,12 @@ class LinkDotFindVisitor final : public VNVisitor {
             }
         } else {
             VSymEnt* const impp = srcp->findIdFlat(nodep->name());
-            if (!impp) nodep->v3error("Import object not found: " << nodep->prettyPkgNameQ());
+            if (!impp) {
+                nodep->v3error("Import object not found: " << nodep->prettyPkgNameQ());
+            } else if (AstClass* const classp = VN_CAST(impp->nodep(), Class)) {
+                nodep->resolvedClassp(
+                    new AstClassOrPackageRef{nodep->fileline(), classp->name(), classp, nullptr});
+            }
         }
         m_curSymp->importFromPackage(m_statep->symsp(), srcp, nodep->name());
         UINFO(9, "    Link Done: " << nodep);

--- a/test_regress/t/t_class_defaultparam_import.py
+++ b/test_regress/t/t_class_defaultparam_import.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2025 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('vlt')
+
+test.compile()
+
+test.passes()

--- a/test_regress/t/t_class_defaultparam_import.v
+++ b/test_regress/t/t_class_defaultparam_import.v
@@ -1,0 +1,12 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2025 by Antmicro.
+// SPDX-License-Identifier: CC0-1.0
+
+package foo;
+   class bar#(type T=int);
+   endclass
+endpackage;
+
+import foo::bar;

--- a/test_regress/t/t_dump_json.out
+++ b/test_regress/t/t_dump_json.out
@@ -542,7 +542,7 @@
   ]},
   {"type":"PACKAGE","name":"$unit","addr":"(E)","loc":"a,0:0,0:0","origName":"__024unit","level":3,"modPublic":false,"inLibrary":true,"dead":false,"recursiveClone":false,"recursive":false,"timeunit":"1ps","inlinesp": [],
    "stmtsp": [
-    {"type":"PACKAGEIMPORT","name":"*","addr":"(SI)","loc":"d,31:9,31:12","packagep":"(F)"}
+    {"type":"PACKAGEIMPORT","name":"*","addr":"(SI)","loc":"d,31:9,31:12","packagep":"(F)","resolvedClassp": []}
   ]},
   {"type":"PACKAGE","name":"std","addr":"(F)","loc":"d,31:9,31:12","origName":"std","level":4,"modPublic":false,"inLibrary":true,"dead":false,"recursiveClone":false,"recursive":false,"timeunit":"1ps","inlinesp": [],
    "stmtsp": [


### PR DESCRIPTION
If a parameterized class gets imported, store it in `AstPackageImport` so it doesn't get deleted (causing an error in `V3LinkDot`).