### PR TITLE
Improve Dfg variable removal and temporary insertion (#6394)

### DIFF
--- a/src/V3DfgContext.h
+++ b/src/V3DfgContext.h
@@ -158,27 +158,6 @@ private:
         addStat("result equations", m_resultEquations);
     }
 };
-class V3DfgEliminateVarsContext final : public V3DfgSubContext {
-    // Only V3DfgContext can create an instance
-    friend class V3DfgContext;
-
-public:
-    // STATE
-    std::vector<AstNode*> m_deleteps;  // AstVar/AstVarScope that can be deleted at the end
-    VDouble0 m_varsReplaced;  // Number of variables replaced
-    VDouble0 m_varsRemoved;  // Number of variables removed
-
-private:
-    V3DfgEliminateVarsContext(V3DfgContext& ctx, const std::string& label)
-        : V3DfgSubContext{ctx, label, "EliminateVars"} {}
-    ~V3DfgEliminateVarsContext() {
-        for (AstNode* const nodep : m_deleteps) {
-            VL_DO_DANGLING(nodep->unlinkFrBack()->deleteTree(), nodep);
-        }
-        addStat("variables replaced", m_varsReplaced);
-        addStat("variables removed", m_varsRemoved);
-    }
-};
 class V3DfgPeepholeContext final : public V3DfgSubContext {
     // Only V3DfgContext can create an instance
     friend class V3DfgContext;
@@ -200,12 +179,28 @@ class V3DfgRegularizeContext final : public V3DfgSubContext {
 
 public:
     // STATE
+    VDouble0 m_temporariesOmitted;  // Number of temporaries omitted as cheaper to re-compute
     VDouble0 m_temporariesIntroduced;  // Number of temporaries introduced
+
+    std::vector<AstNode*> m_deleteps;  // AstVar/AstVarScope that can be deleted at the end
+    VDouble0 m_usedVarsReplaced;  // Number of used variables replaced with equivalent ones
+    VDouble0 m_usedVarsInlined;  // Number of used variables inlined
+    VDouble0 m_unusedRemoved;  // Number of unused vertices remoevd
 
 private:
     V3DfgRegularizeContext(V3DfgContext& ctx, const std::string& label)
         : V3DfgSubContext{ctx, label, "Regularize"} {}
-    ~V3DfgRegularizeContext() { addStat("temporaries introduced", m_temporariesIntroduced); }
+    ~V3DfgRegularizeContext() {
+        for (AstNode* const nodep : m_deleteps) {
+            VL_DO_DANGLING(nodep->unlinkFrBack()->deleteTree(), nodep);
+        }
+        addStat("used variables replaced", m_usedVarsReplaced);
+        addStat("used variables inlined", m_usedVarsInlined);
+        addStat("unused vertices removed", m_unusedRemoved);
+
+        addStat("temporaries omitted", m_temporariesOmitted);
+        addStat("temporaries introduced", m_temporariesIntroduced);
+    }
 };
 class V3DfgSynthesisContext final : public V3DfgSubContext {
     // Only V3DfgContext can create an instance
@@ -355,7 +350,6 @@ public:
     V3DfgCseContext m_cseContext0{*this, m_label + " 1st"};
     V3DfgCseContext m_cseContext1{*this, m_label + " 2nd"};
     V3DfgDfgToAstContext m_dfg2AstContext{*this, m_label};
-    V3DfgEliminateVarsContext m_eliminateVarsContext{*this, m_label};
     V3DfgPeepholeContext m_peepholeContext{*this, m_label};
     V3DfgRegularizeContext m_regularizeContext{*this, m_label};
     V3DfgSynthesisContext m_synthContext{*this, m_label};

--- a/src/V3DfgDfgToAst.cpp
+++ b/src/V3DfgDfgToAst.cpp
@@ -139,8 +139,8 @@ class DfgToAstVisitor final : DfgVisitor {
 
     AstNodeExpr* convertDfgVertexToAstNodeExpr(DfgVertex* vtxp) {
         UASSERT_OBJ(!m_resultp, vtxp, "Result already computed");
-        UASSERT_OBJ(!vtxp->hasMultipleSinks() || vtxp->is<DfgVertexVar>()
-                        || vtxp->is<DfgArraySel>() || vtxp->is<DfgConst>(),
+        UASSERT_OBJ(vtxp->is<DfgVertexVar>() || vtxp->is<DfgConst>()  //
+                        || !vtxp->hasMultipleSinks() || vtxp->isCheaperThanLoad(),  //
                     vtxp, "Intermediate DFG value with multiple uses");
         iterate(vtxp);
         UASSERT_OBJ(m_resultp, vtxp, "Missing result");

--- a/src/V3DfgPasses.h
+++ b/src/V3DfgPasses.h
@@ -82,8 +82,6 @@ void peephole(DfgGraph&, V3DfgPeepholeContext&) VL_MT_DISABLED;
 void regularize(DfgGraph&, V3DfgRegularizeContext&) VL_MT_DISABLED;
 // Remove unused nodes
 void removeUnused(DfgGraph&) VL_MT_DISABLED;
-// Eliminate (remove or replace) redundant variables. Also removes resulting unused logic.
-void eliminateVars(DfgGraph&, V3DfgEliminateVarsContext&) VL_MT_DISABLED;
 // Check all types are consistent. This will not return if there is a type error.
 void typeCheck(const DfgGraph&) VL_MT_DISABLED;
 

--- a/src/V3DfgPeephole.cpp
+++ b/src/V3DfgPeephole.cpp
@@ -1714,5 +1714,6 @@ public:
 };
 
 void V3DfgPasses::peephole(DfgGraph& dfg, V3DfgPeepholeContext& ctx) {
+    if (!v3Global.opt.fDfgPeephole()) return;
     V3DfgPeephole::apply(dfg, ctx);
 }

--- a/src/V3DfgRegularize.cpp
+++ b/src/V3DfgRegularize.cpp
@@ -27,58 +27,279 @@
 VL_DEFINE_DEBUG_FUNCTIONS;
 
 class DfgRegularize final {
+    // STATE
     DfgGraph& m_dfg;  // The graph being processed
     V3DfgRegularizeContext& m_ctx;  // The optimization context for stats
-
-    // Prefix of temporary variable names
     size_t m_nTmps = 0;  // Number of temporaries added to this graph - for variable names only
+    VNDeleter m_deleter;  // Deletes replacement nodes at the end
+
+    // METHODS
+
+    // For all operation vetices, if they drive multiple variables, pick
+    // a "canonical" one and uninline the logic through that variable.
+    void uninlineVariables() {
+        // Const vertices we can just emit as drivers to multiple sinks
+        // directly. Variable vertices, would have been inlined if equivalent,
+        // so no need to process them here, they are where they must be.
+        for (DfgVertex& vtx : m_dfg.opVertices()) {
+            // Don't process LValue operations
+            if (vtx.is<DfgVertexSplice>()) continue;
+            if (vtx.is<DfgUnitArray>()) continue;
+
+            // The prefered result variable is the canonical one if exists
+            DfgVertexVar* const varp = vtx.getResultVar();
+            if (!varp) continue;
+
+            // Relink all other sinks reading this vertex to read 'varp'
+            varp->srcp(nullptr);
+            vtx.replaceWith(varp);
+            varp->srcp(&vtx);
+        }
+    }
+
+    std::unordered_set<const DfgVertexVar*> gatherCyclicVariables() {
+        DfgUserMap<uint64_t> vtx2Scc = m_dfg.makeUserMap<uint64_t>();
+        V3DfgPasses::colorStronglyConnectedComponents(m_dfg, vtx2Scc);
+        std::unordered_set<const DfgVertexVar*> circularVariables;
+        for (const DfgVertexVar& vtx : m_dfg.varVertices()) {
+            if (vtx2Scc[vtx]) circularVariables.emplace(&vtx);
+        }
+        return circularVariables;
+    }
+
+    bool isUnused(const DfgVertex& vtx) {
+        if (vtx.hasSinks()) return false;
+        if (const DfgVertexVar* const varp = vtx.cast<DfgVertexVar>()) {
+            // There is only one Dfg when running this pass
+            UASSERT_OBJ(!varp->hasDfgRefs(), varp, "Should not have refs in other DfgGraph");
+            if (varp->hasModRefs()) return false;
+            if (varp->hasExtRefs()) return false;
+        }
+        return true;
+    }
+
+    // Given a variable and its driver, return true iff the variable can be
+    // repalced with its driver. Record replacement to be applied in the Ast
+    // in user2p of the replaced variable.
+    bool replaceable(DfgVertexVar* varp, DfgVertex* srcp) {
+        // The given variable has no external references, and is read in the module
+
+        // Make sure we are not trying to double replace something
+        AstNode* const nodep = varp->nodep();
+        UASSERT_OBJ(!nodep->user2p(), nodep, "Replacement already exists");
+
+        // If it is driven from another variable, it can be replaced by that variable.
+        if (const DfgVarPacked* const drvp = srcp->cast<DfgVarPacked>()) {
+            // Record replacement
+            nodep->user2p(drvp->nodep());
+            // The repalcement will be read in the module, mark as such so it doesn't get removed.
+            drvp->setHasModRdRefs();
+            return true;
+        }
+
+        // Expressions can only be inlined after V3Scope, as some passes assume variables.
+        if (m_dfg.modulep()) return false;
+
+        // If it is driven from a constant, it can be replaced by that constant.
+        if (const DfgConst* const constp = srcp->cast<DfgConst>()) {
+            // Need to create the AstConst
+            AstConst* const newp = new AstConst{constp->fileline(), constp->num()};
+            m_deleter.pushDeletep(newp);
+            // Record replacement
+            nodep->user2p(newp);
+            return true;
+        }
+
+        // Don't replace
+        return false;
+    }
+
+    template <bool T_Scoped>
+    static void applyReplacement(AstVarRef* refp) {
+        AstNode* const tgtp = T_Scoped ? static_cast<AstNode*>(refp->varScopep())
+                                       : static_cast<AstNode*>(refp->varp());
+        AstNode* replacementp = tgtp;
+        while (AstNode* const altp = replacementp->user2p()) replacementp = altp;
+        if (replacementp == tgtp) return;
+        UASSERT_OBJ(refp->access().isReadOnly(), refp, "Replacing write AstVarRef");
+        // If it's an inlined expression, repalce the VarRef entirely
+        if (AstNodeExpr* const newp = VN_CAST(replacementp, NodeExpr)) {
+            refp->replaceWith(newp->cloneTreePure(false));
+            return;
+        }
+        // Otherwise just re-point the VarRef to the new variable
+        if VL_CONSTEXPR_CXX17 (T_Scoped) {
+            AstVarScope* const newp = VN_AS(replacementp, VarScope);
+            refp->varScopep(newp);
+            refp->varp(newp->varp());
+        } else {
+            AstVar* const newp = VN_AS(replacementp, Var);
+            refp->varp(newp);
+        }
+    }
+
+    void eliminateVars() {
+        // Although we could eliminate some circular variables, doing so would
+        // make UNOPTFLAT traces fairly usesless, so we will not do so.
+        const std::unordered_set<const DfgVertexVar*> circularVariables = gatherCyclicVariables();
+
+        // Worklist based algoritm
+        DfgWorklist workList{m_dfg};
+
+        // Add all variables and all vertices with no sinks to the worklist
+        m_dfg.forEachVertex([&](DfgVertex& vtx) {
+            if (vtx.is<DfgVertexVar>() || !vtx.hasSinks()) workList.push_front(vtx);
+        });
+
+        // AstVar::user2p() : AstVar*/AstNodeExpr* -> The replacement variable/expression
+        // AstVarScope::user2p() : AstVarScope*/AstNodeExpr* -> The replacement variable/expression
+        const VNUser2InUse user2InUse;
+
+        // Remove vertex, enqueue it's sources
+        const auto removeVertex = [&](DfgVertex& vtx) {
+            // Add sources of removed vertex to work list
+            vtx.foreachSource([&](DfgVertex& src) {
+                workList.push_front(src);
+                return false;
+            });
+            // Delete corresponsing Ast variable at the end
+            if (const DfgVertexVar* const varp = vtx.cast<DfgVertexVar>()) {
+                m_ctx.m_deleteps.push_back(varp->nodep());
+            }
+            // Remove the unused vertex
+            vtx.unlinkDelete(m_dfg);
+        };
+
+        // Used to check if we need to apply variable replacements
+        const VDouble0 usedVarsReplacedBefore = m_ctx.m_usedVarsReplaced;
+
+        // Process the work list
+        workList.foreach([&](DfgVertex& vtx) {
+            // Remove unused vertices
+            if (isUnused(vtx)) {
+                ++m_ctx.m_unusedRemoved;
+                removeVertex(vtx);
+                return;
+            }
+
+            // Consider eliminating variables
+            DfgVertexVar* const varp = vtx.cast<DfgVertexVar>();
+            if (!varp) return;
+
+            // If it has no driver (in this Dfg), there is nothing further we can optimize
+            DfgVertex* const srcp = varp->srcp();
+            if (!srcp) return;
+
+            // If it has multiple sinks, it can't be eliminated - would increase logic size
+            if (varp->hasMultipleSinks()) return;
+            // Can't eliminate if referenced external to the module - can't replace those refs
+            if (varp->hasExtRefs()) return;
+            // Can't eliminate if written in the module - the write needs to go somewhere, and
+            // we need to observe the write in this graph if the variable has sinks
+            if (varp->hasModWrRefs()) return;
+            // There is only one Dfg when running this pass
+            UASSERT_OBJ(!varp->hasDfgRefs(), varp, "Should not have refs in other DfgGraph");
+
+            // At this point, the variable is used, driven only in this Dfg,
+            // it has exactly 0 or 1 sinks in this Dfg, and might be read in
+            // the host module, but no other references exist.
+
+            // Do not eliminate circular variables - need to preserve UNOPTFLAT traces
+            if (circularVariables.count(varp)) return;
+
+            // If it is not read in the module, it can be inlined into the
+            // Dfg unless partially driven (the partial driver network
+            // can't be fed into arbitrary logic. TODO: we should peeophole
+            // these away entirely).
+            if (!varp->hasModRdRefs()) {
+                UASSERT_OBJ(varp->hasSinks(), varp, "Shouldn't have made it here without sinks");
+                // Don't inline if partially driven
+                if (varp->defaultp()) return;
+                if (srcp->is<DfgVertexSplice>()) return;
+                if (srcp->is<DfgUnitArray>()) return;
+                // Inline this variable into its single sink
+                ++m_ctx.m_usedVarsInlined;
+                varp->replaceWith(varp->srcp());
+                removeVertex(*varp);
+                return;
+            }
+
+            // The varable is read in the module. We might still be able to replace it.
+            if (replaceable(varp, srcp)) {
+                // Replace this variable with its driver
+                ++m_ctx.m_usedVarsReplaced;
+                // Inline it if it has a sink
+                if (varp->hasSinks()) varp->replaceWith(srcp);
+                // Delete the repalced variabel
+                removeVertex(*varp);
+            }
+        });
+
+        // Job done if no replacements need to be applied
+        if (m_ctx.m_usedVarsReplaced == usedVarsReplacedBefore) return;
+
+        // Apply variable replacements
+        if (AstModule* const modp = m_dfg.modulep()) {
+            modp->foreach([](AstVarRef* refp) { applyReplacement<false>(refp); });
+        } else {
+            v3Global.rootp()->foreach([](AstVarRef* refp) { applyReplacement<true>(refp); });
+        }
+    }
+
+    void insertTemporaries() {
+        // Insert a temporary variable for all vertices that have multiple non-variable sinks
+
+        // Scope cache for below
+        const bool scoped = !m_dfg.modulep();
+        DfgVertex::ScopeCache scopeCache;
+
+        // Ensure intermediate values used multiple times are written to variables
+        for (DfgVertex& vtx : m_dfg.opVertices()) {
+            // LValue vertices feed into variables eventually and need not temporaries
+            if (vtx.is<DfgVertexSplice>()) continue;
+            if (vtx.is<DfgUnitArray>()) continue;
+
+            // If this Vertex was driving a variable, 'unlinline' would have
+            // made that the single sink, so if there are multiple sinks
+            // remaining, they must be non-variables. So nothing to do if:
+            if (!vtx.hasMultipleSinks()) continue;
+
+            // 'uninline' would have made the result var cannonical, so there shouldn't be one
+            UASSERT_OBJ(!vtx.getResultVar(), &vtx, "Failed to uninline variable");
+
+            // Do not add a temporary if it's cheaper to re-compute than to
+            // load it from memory. This also increases available parallelism.
+            if (vtx.isCheaperThanLoad()) {
+                ++m_ctx.m_temporariesOmitted;
+                continue;
+            }
+
+            // Need to create an intermediate variable
+            const std::string name = m_dfg.makeUniqueName("Regularize", m_nTmps);
+            FileLine* const flp = vtx.fileline();
+            AstScope* const scopep = scoped ? vtx.scopep(scopeCache) : nullptr;
+            DfgVertexVar* const newp = m_dfg.makeNewVar(flp, name, vtx.dtype(), scopep);
+            ++m_nTmps;
+            ++m_ctx.m_temporariesIntroduced;
+            // Replace vertex with the variable, make it drive the variable
+            vtx.replaceWith(newp);
+            newp->srcp(&vtx);
+        }
+    }
 
     // Insert intermediate variables for vertices with multiple sinks (or use an existing one)
     DfgRegularize(DfgGraph& dfg, V3DfgRegularizeContext& ctx)
         : m_dfg{dfg}
         , m_ctx{ctx} {
 
-        // Scope cache for below
-        const bool scoped = !dfg.modulep();
-        DfgVertex::ScopeCache scopeCache;
+        uninlineVariables();
+        if (dumpDfgLevel() >= 9) dfg.dumpDotFilePrefixed(ctx.prefix() + "regularize-uninlined");
 
-        // Ensure intermediate values used multiple times are written to variables
-        for (DfgVertex& vtx : m_dfg.opVertices()) {
-            const bool needsIntermediateVariable = [&]() {
-                // Splice vertices represent partial assignments. The must flow
-                // into variables, so they should never need a temporary.
-                if (vtx.is<DfgVertexSplice>()) return false;
-                // Smilarly to splice, UnitArray should never need one eitehr
-                if (vtx.is<DfgUnitArray>()) return false;
-                // Operations without multiple sinks need no variables
-                if (!vtx.hasMultipleSinks()) return false;
-                // Array selects need no variables, they are just memory references
-                if (vtx.is<DfgArraySel>()) return false;
-                // Otherwise needs an intermediate variable
-                return true;
-            }();
+        eliminateVars();
+        if (dumpDfgLevel() >= 9) dfg.dumpDotFilePrefixed(ctx.prefix() + "regularize-eliminate");
 
-            if (!needsIntermediateVariable) continue;
-
-            // This is an op that requires a result variable. Ensure it is
-            // assigned to one, and redirect other sinks read that variable.
-            if (DfgVertexVar* const varp = vtx.getResultVar()) {
-                varp->srcp(nullptr);
-                vtx.replaceWith(varp);
-                varp->srcp(&vtx);
-            } else {
-                // Need to create an intermediate variable
-                const std::string name = m_dfg.makeUniqueName("Regularize", m_nTmps);
-                FileLine* const flp = vtx.fileline();
-                AstScope* const scopep = scoped ? vtx.scopep(scopeCache) : nullptr;
-                DfgVertexVar* const newp = m_dfg.makeNewVar(flp, name, vtx.dtype(), scopep);
-                ++m_nTmps;
-                ++m_ctx.m_temporariesIntroduced;
-                // Replace vertex with the variable and add back driver
-                vtx.replaceWith(newp);
-                newp->srcp(&vtx);
-            }
-        }
+        insertTemporaries();
+        if (dumpDfgLevel() >= 9) dfg.dumpDotFilePrefixed(ctx.prefix() + "regularize-inserttmp");
     }
 
 public:

--- a/test_regress/t/t_cover_toggle.py
+++ b/test_regress/t/t_cover_toggle.py
@@ -21,7 +21,7 @@ test.inline_checks()
 test.file_grep_not(test.obj_dir + "/coverage.dat", "largeish")
 
 if test.vlt_all:
-    test.file_grep(test.stats, r'Coverage, Toggle points joined\s+(\d+)', 14)
+    test.file_grep(test.stats, r'Coverage, Toggle points joined\s+(\d+)', 13)
 
 test.run(cmd=[
     os.environ["VERILATOR_ROOT"] + "/bin/verilator_coverage",

--- a/test_regress/t/t_dfg_stats_patterns.v
+++ b/test_regress/t/t_dfg_stats_patterns.v
@@ -4,34 +4,23 @@
 // any use, without warranty, 2024 by Wilson Snyder.
 // SPDX-License-Identifier: CC0-1.0
 
-
 module t (
-    input wire [3:0] a,
-    input wire [3:0] b,
-    input wire [3:0] c,
-    output wire [3:0] x,
-    output wire [3:0] y,
-    output wire [3:0] z,
-    output wire [ 0:0] w1,
-    output wire [ 7:0] w8,
-    output wire [15:0] w16,
-    output wire [31:0] w32,
-    output wire [63:0] w64a,
-    output wire [63:0] w64b,
-    output wire [62:0] w63,
-    output wire [95:0] w96
+  input wire [3:0] a,
+  input wire [3:0] b,
+  input wire [3:0] c,
+  output wire [10:0] o
 );
+  wire [ 3:0]  x = ~a & ~b;
+  wire [ 3:0]  y = ~b & ~c;
+  wire [ 3:0]  z = ~c & ~a;
+  wire [ 0:0] w1 = x[0];
+  wire [ 7:0] w8 = {8{x[1]}};
+  wire [15:0] w16 = {2{w8}};
+  wire [31:0] w32 = {2{w16}};
+  wire [63:0] w64a = {2{w32}};
+  wire [63:0] w64b = {2{~w32}};
+  wire [62:0] w63 = 63'({2{~w32}});
+  wire [95:0] w96 = 96'(w64a);
 
-    assign x = ~a & ~b;
-    assign y = ~b & ~c;
-    assign z = ~c & ~a;
-    assign w1 = x[0];
-    assign w8 = {8{x[1]}};
-    assign w16 = {2{w8}};
-    assign w32 = {2{w16}};
-    assign w64a = {2{w32}};
-    assign w64b = {2{~w32}};
-    assign w63 = 63'({2{~w32}});
-    assign w96 = 96'(w64a);
-
+  assign o = {^x, ^y, ^z, ^w1, ^w8, ^w16, ^w32, ^w64a, ^w64b, ^w63, ^w96};
 endmodule

--- a/test_regress/t/t_dfg_stats_patterns_post_inline.out
+++ b/test_regress/t/t_dfg_stats_patterns_post_inline.out
@@ -1,50 +1,96 @@
 DFG 'post inline' patterns with depth 1
+            9 (CONCAT _A:1 _B:a):b
+            8 (REDXOR _A:a):1
+            3 (AND _A:a _B:a)*:a
             3 (NOT vA:a)*:a
-            2 (AND _A:a _B:a):a
             2 (REPLICATE _A:a cA:a)*:b
-            1 (AND _A:a _B:a)*:a
             1 (CONCAT '0:a _A:b):A
+            1 (CONCAT _A:1 _B:1):a
             1 (NOT _A:a):a
+            1 (REDXOR _A:a)*:1
             1 (REPLICATE _A:1 cA:a)*:b
             1 (REPLICATE _A:a cA:b)*:b
             1 (REPLICATE _A:a cA:b)*:c
-            1 (SEL@0 _A:a):1
-            1 (SEL@0 _A:a):b
+            1 (SEL@0 _A:a)*:1
+            1 (SEL@0 _A:a)*:b
             1 (SEL@A _A:a):1
 
 DFG 'post inline' patterns with depth 2
-            2 (AND (NOT vA:a)*:a (NOT vB:a)*:a):a
-            1 (AND (NOT vA:a)*:a (NOT vB:a)*:a)*:a
+            6 (CONCAT (REDXOR _A:a):1 (CONCAT _B:1 _C:b):c):d
+            3 (AND (NOT vA:a)*:a (NOT vB:a)*:a)*:a
+            3 (REDXOR (AND _A:a _B:a)*:a):1
             1 (CONCAT '0:a (REPLICATE _A:a cA:a)*:b):A
+            1 (CONCAT (REDXOR _A:a)*:1 (CONCAT _B:1 _C:b):c):d
+            1 (CONCAT (REDXOR _A:a):1 (CONCAT _B:1 _C:1):b):c
+            1 (CONCAT (REDXOR _A:a):1 (REDXOR _B:b)*:1):c
+            1 (CONCAT (SEL@0 _A:a)*:1 (CONCAT _B:1 _C:b):c):d
             1 (NOT (REPLICATE _A:a cA:b)*:b):b
+            1 (REDXOR (REPLICATE _A:1 cA:a)*:b):1
+            1 (REDXOR (REPLICATE _A:a cA:a)*:b)*:1
+            1 (REDXOR (REPLICATE _A:a cA:a)*:b):1
+            1 (REDXOR (REPLICATE _A:a cA:b)*:b):1
+            1 (REDXOR (REPLICATE _A:a cA:b)*:c):1
+            1 (REDXOR (SEL@0 _A:a)*:b):1
             1 (REPLICATE (NOT _A:a):a cA:a)*:b
             1 (REPLICATE (REPLICATE _A:1 cA:a)*:b cB:a)*:c
             1 (REPLICATE (REPLICATE _A:a cA:b)*:b cA:b)*:c
             1 (REPLICATE (REPLICATE _A:a cA:b)*:c cA:b)*:b
             1 (REPLICATE (SEL@A _A:a):1 cA:b)*:c
-            1 (SEL@0 (AND _A:a _B:a)*:a):1
-            1 (SEL@0 (REPLICATE _A:a cA:a)*:b):c
+            1 (SEL@0 (AND _A:a _B:a)*:a)*:1
+            1 (SEL@0 (REPLICATE _A:a cA:a)*:b)*:c
             1 (SEL@A (AND _A:a _B:a)*:a):1
 
 DFG 'post inline' patterns with depth 3
+            3 (REDXOR (AND (NOT vA:a)*:a (NOT vB:a)*:a)*:a):1
+            2 (CONCAT (REDXOR (AND _A:a _B:a)*:a):1 (CONCAT (REDXOR _C:a):1 (CONCAT _D:1 _E:b):c):d):e
             1 (CONCAT '0:a (REPLICATE (REPLICATE _A:b cA:a)*:a cA:a)*:c):A
+            1 (CONCAT (REDXOR (AND _A:a _B:a)*:a):1 (CONCAT (SEL@0 _C:a)*:1 (CONCAT _D:1 _E:b):c):d):e
+            1 (CONCAT (REDXOR (REPLICATE _A:1 cA:a)*:b):1 (CONCAT (REDXOR _B:c):1 (CONCAT _C:1 _D:d):e):f):g
+            1 (CONCAT (REDXOR (REPLICATE _A:a cA:a)*:b)*:1 (CONCAT (REDXOR _B:b):1 (CONCAT _C:1 _D:1):c):d):e
+            1 (CONCAT (REDXOR (REPLICATE _A:a cA:a)*:b):1 (CONCAT (REDXOR _B:c):1 (REDXOR _C:b)*:1):d):e
+            1 (CONCAT (REDXOR (REPLICATE _A:a cA:b)*:b):1 (CONCAT (REDXOR _B:c)*:1 (CONCAT _C:1 _D:d):e):f):g
+            1 (CONCAT (REDXOR (REPLICATE _A:a cA:b)*:c):1 (CONCAT (REDXOR _B:b):1 (CONCAT _C:1 _D:d):e):f):g
+            1 (CONCAT (REDXOR (SEL@0 _A:a)*:b):1 (REDXOR (REPLICATE _B:c cA:c)*:a)*:1):d
+            1 (CONCAT (SEL@0 (AND _A:a _B:a)*:a)*:1 (CONCAT (REDXOR _C:b):1 (CONCAT _D:1 _E:c):d):e):b
             1 (NOT (REPLICATE (REPLICATE _A:a cA:b)*:c cA:b)*:b):b
+            1 (REDXOR (REPLICATE (NOT _A:a):a cA:a)*:b):1
+            1 (REDXOR (REPLICATE (REPLICATE _A:1 cA:a)*:b cB:a)*:c):1
+            1 (REDXOR (REPLICATE (REPLICATE _A:a cA:b)*:b cA:b)*:c)*:1
+            1 (REDXOR (REPLICATE (REPLICATE _A:a cA:b)*:c cA:b)*:b):1
+            1 (REDXOR (REPLICATE (SEL@A _A:a):1 cA:b)*:c):1
+            1 (REDXOR (SEL@0 (REPLICATE _A:a cA:a)*:b)*:c):1
             1 (REPLICATE (NOT (REPLICATE _A:a cA:b)*:b):b cA:b)*:c
             1 (REPLICATE (REPLICATE (REPLICATE _A:1 cA:a)*:b cB:a)*:c cB:a)*:a
             1 (REPLICATE (REPLICATE (REPLICATE _A:a cA:b)*:c cA:b)*:b cA:b)*:d
             1 (REPLICATE (REPLICATE (SEL@A _A:a):1 cA:b)*:c cB:b)*:d
             1 (REPLICATE (SEL@A (AND _A:a _B:a)*:a):1 cA:b)*:c
-            1 (SEL@0 (AND (NOT vA:a)*:a (NOT vB:a)*:a)*:a):1
-            1 (SEL@0 (REPLICATE (NOT _A:a):a cA:a)*:b):c
+            1 (SEL@0 (AND (NOT vA:a)*:a (NOT vB:a)*:a)*:a)*:1
+            1 (SEL@0 (REPLICATE (NOT _A:a):a cA:a)*:b)*:c
             1 (SEL@A (AND (NOT vA:a)*:a (NOT vB:a)*:a)*:a):1
 
 DFG 'post inline' patterns with depth 4
             1 (CONCAT '0:a (REPLICATE (REPLICATE (REPLICATE _A:b cA:a)*:c cA:a)*:a cA:a)*:d):A
+            1 (CONCAT (REDXOR (AND (NOT vA:a)*:a (NOT vB:a)*:a)*:a):1 (CONCAT (REDXOR (AND _A:a _B:a)*:a):1 (CONCAT (REDXOR _C:a):1 (CONCAT _D:1 _E:b):c):d):e):f
+            1 (CONCAT (REDXOR (AND (NOT vA:a)*:a (NOT vB:a)*:a)*:a):1 (CONCAT (REDXOR (AND _A:a _B:a)*:a):1 (CONCAT (SEL@0 _C:a)*:1 (CONCAT _D:1 _E:b):c):d):e):f
+            1 (CONCAT (REDXOR (AND (NOT vA:a)*:a (NOT vB:a)*:a)*:a):1 (CONCAT (SEL@0 (AND _A:a _B:a)*:a)*:1 (CONCAT (REDXOR _C:b):1 (CONCAT _D:1 _E:c):d):e):b):f
+            1 (CONCAT (REDXOR (REPLICATE (NOT _A:a):a cA:a)*:b):1 (CONCAT (REDXOR (SEL@0 _B:b)*:c):1 (REDXOR (REPLICATE _A:a cA:a)*:b)*:1):d):e
+            1 (CONCAT (REDXOR (REPLICATE (REPLICATE _A:1 cA:a)*:b cB:a)*:c):1 (CONCAT (REDXOR (REPLICATE _B:c cB:a)*:a):1 (CONCAT (REDXOR _C:d)*:1 (CONCAT _D:1 _E:e):f):g):h):i
+            1 (CONCAT (REDXOR (REPLICATE (REPLICATE _A:a cA:b)*:b cA:b)*:c)*:1 (CONCAT (REDXOR (REPLICATE _B:b cA:b)*:c):1 (CONCAT (REDXOR _C:d):1 (REDXOR _D:c)*:1):e):f):g
+            1 (CONCAT (REDXOR (REPLICATE (REPLICATE _A:a cA:b)*:c cA:b)*:b):1 (CONCAT (REDXOR (REPLICATE _B:b cA:b)*:d)*:1 (CONCAT (REDXOR _C:d):1 (CONCAT _D:1 _E:1):e):f):g):h
+            1 (CONCAT (REDXOR (REPLICATE (SEL@A _A:a):1 cA:b)*:c):1 (CONCAT (REDXOR (REPLICATE _B:c cB:b)*:d):1 (CONCAT (REDXOR _C:b):1 (CONCAT _D:1 _E:e):a):f):g):h
+            1 (CONCAT (REDXOR (SEL@0 (REPLICATE _A:a cA:a)*:b)*:c):1 (REDXOR (REPLICATE (REPLICATE _B:d cA:a)*:a cA:a)*:b)*:1):e
+            1 (CONCAT (SEL@0 (AND (NOT vA:a)*:a (NOT vB:a)*:a)*:a)*:1 (CONCAT (REDXOR (REPLICATE _A:1 cA:b)*:c):1 (CONCAT (REDXOR _B:d):1 (CONCAT _C:1 _D:a):e):f):g):c
             1 (NOT (REPLICATE (REPLICATE (REPLICATE _A:1 cA:a)*:b cB:a)*:c cB:a)*:a):a
+            1 (REDXOR (REPLICATE (NOT (REPLICATE _A:a cA:b)*:b):b cA:b)*:c):1
+            1 (REDXOR (REPLICATE (REPLICATE (REPLICATE _A:1 cA:a)*:b cB:a)*:c cB:a)*:a):1
+            1 (REDXOR (REPLICATE (REPLICATE (REPLICATE _A:a cA:b)*:c cA:b)*:b cA:b)*:d)*:1
+            1 (REDXOR (REPLICATE (REPLICATE (SEL@A _A:a):1 cA:b)*:c cB:b)*:d):1
+            1 (REDXOR (REPLICATE (SEL@A (AND _A:a _B:a)*:a):1 cA:b)*:c):1
+            1 (REDXOR (SEL@0 (REPLICATE (NOT _A:a):a cA:a)*:b)*:c):1
             1 (REPLICATE (NOT (REPLICATE (REPLICATE _A:a cA:b)*:c cA:b)*:b):b cA:b)*:d
             1 (REPLICATE (REPLICATE (REPLICATE (REPLICATE _A:1 cA:a)*:b cB:a)*:c cB:a)*:a cB:a)*:d
             1 (REPLICATE (REPLICATE (REPLICATE (SEL@A _A:a):1 cA:b)*:c cB:b)*:d cB:b)*:b
             1 (REPLICATE (REPLICATE (SEL@A (AND _A:a _B:a)*:a):1 cA:b)*:c cB:b)*:d
             1 (REPLICATE (SEL@A (AND (NOT vA:a)*:a (NOT vB:a)*:a)*:a):1 cA:b)*:c
-            1 (SEL@0 (REPLICATE (NOT (REPLICATE _A:a cA:b)*:b):b cA:b)*:c):d
+            1 (SEL@0 (REPLICATE (NOT (REPLICATE _A:a cA:b)*:b):b cA:b)*:c)*:d
 

--- a/test_regress/t/t_dfg_stats_patterns_pre_inline.out
+++ b/test_regress/t/t_dfg_stats_patterns_pre_inline.out
@@ -1,50 +1,96 @@
 DFG 'pre inline' patterns with depth 1
+            9 (CONCAT _A:1 _B:a):b
+            8 (REDXOR _A:a):1
+            3 (AND _A:a _B:a)*:a
             3 (NOT vA:a)*:a
-            2 (AND _A:a _B:a):a
             2 (REPLICATE _A:a cA:a)*:b
-            1 (AND _A:a _B:a)*:a
             1 (CONCAT '0:a _A:b):A
+            1 (CONCAT _A:1 _B:1):a
             1 (NOT _A:a):a
+            1 (REDXOR _A:a)*:1
             1 (REPLICATE _A:1 cA:a)*:b
             1 (REPLICATE _A:a cA:b)*:b
             1 (REPLICATE _A:a cA:b)*:c
-            1 (SEL@0 _A:a):1
-            1 (SEL@0 _A:a):b
+            1 (SEL@0 _A:a)*:1
+            1 (SEL@0 _A:a)*:b
             1 (SEL@A _A:a):1
 
 DFG 'pre inline' patterns with depth 2
-            2 (AND (NOT vA:a)*:a (NOT vB:a)*:a):a
-            1 (AND (NOT vA:a)*:a (NOT vB:a)*:a)*:a
+            6 (CONCAT (REDXOR _A:a):1 (CONCAT _B:1 _C:b):c):d
+            3 (AND (NOT vA:a)*:a (NOT vB:a)*:a)*:a
+            3 (REDXOR (AND _A:a _B:a)*:a):1
             1 (CONCAT '0:a (REPLICATE _A:a cA:a)*:b):A
+            1 (CONCAT (REDXOR _A:a)*:1 (CONCAT _B:1 _C:b):c):d
+            1 (CONCAT (REDXOR _A:a):1 (CONCAT _B:1 _C:1):b):c
+            1 (CONCAT (REDXOR _A:a):1 (REDXOR _B:b)*:1):c
+            1 (CONCAT (SEL@0 _A:a)*:1 (CONCAT _B:1 _C:b):c):d
             1 (NOT (REPLICATE _A:a cA:b)*:b):b
+            1 (REDXOR (REPLICATE _A:1 cA:a)*:b):1
+            1 (REDXOR (REPLICATE _A:a cA:a)*:b)*:1
+            1 (REDXOR (REPLICATE _A:a cA:a)*:b):1
+            1 (REDXOR (REPLICATE _A:a cA:b)*:b):1
+            1 (REDXOR (REPLICATE _A:a cA:b)*:c):1
+            1 (REDXOR (SEL@0 _A:a)*:b):1
             1 (REPLICATE (NOT _A:a):a cA:a)*:b
             1 (REPLICATE (REPLICATE _A:1 cA:a)*:b cB:a)*:c
             1 (REPLICATE (REPLICATE _A:a cA:b)*:b cA:b)*:c
             1 (REPLICATE (REPLICATE _A:a cA:b)*:c cA:b)*:b
             1 (REPLICATE (SEL@A _A:a):1 cA:b)*:c
-            1 (SEL@0 (AND _A:a _B:a)*:a):1
-            1 (SEL@0 (REPLICATE _A:a cA:a)*:b):c
+            1 (SEL@0 (AND _A:a _B:a)*:a)*:1
+            1 (SEL@0 (REPLICATE _A:a cA:a)*:b)*:c
             1 (SEL@A (AND _A:a _B:a)*:a):1
 
 DFG 'pre inline' patterns with depth 3
+            3 (REDXOR (AND (NOT vA:a)*:a (NOT vB:a)*:a)*:a):1
+            2 (CONCAT (REDXOR (AND _A:a _B:a)*:a):1 (CONCAT (REDXOR _C:a):1 (CONCAT _D:1 _E:b):c):d):e
             1 (CONCAT '0:a (REPLICATE (REPLICATE _A:b cA:a)*:a cA:a)*:c):A
+            1 (CONCAT (REDXOR (AND _A:a _B:a)*:a):1 (CONCAT (SEL@0 _C:a)*:1 (CONCAT _D:1 _E:b):c):d):e
+            1 (CONCAT (REDXOR (REPLICATE _A:1 cA:a)*:b):1 (CONCAT (REDXOR _B:c):1 (CONCAT _C:1 _D:d):e):f):g
+            1 (CONCAT (REDXOR (REPLICATE _A:a cA:a)*:b)*:1 (CONCAT (REDXOR _B:b):1 (CONCAT _C:1 _D:1):c):d):e
+            1 (CONCAT (REDXOR (REPLICATE _A:a cA:a)*:b):1 (CONCAT (REDXOR _B:c):1 (REDXOR _C:b)*:1):d):e
+            1 (CONCAT (REDXOR (REPLICATE _A:a cA:b)*:b):1 (CONCAT (REDXOR _B:c)*:1 (CONCAT _C:1 _D:d):e):f):g
+            1 (CONCAT (REDXOR (REPLICATE _A:a cA:b)*:c):1 (CONCAT (REDXOR _B:b):1 (CONCAT _C:1 _D:d):e):f):g
+            1 (CONCAT (REDXOR (SEL@0 _A:a)*:b):1 (REDXOR (REPLICATE _B:c cA:c)*:a)*:1):d
+            1 (CONCAT (SEL@0 (AND _A:a _B:a)*:a)*:1 (CONCAT (REDXOR _C:b):1 (CONCAT _D:1 _E:c):d):e):b
             1 (NOT (REPLICATE (REPLICATE _A:a cA:b)*:c cA:b)*:b):b
+            1 (REDXOR (REPLICATE (NOT _A:a):a cA:a)*:b):1
+            1 (REDXOR (REPLICATE (REPLICATE _A:1 cA:a)*:b cB:a)*:c):1
+            1 (REDXOR (REPLICATE (REPLICATE _A:a cA:b)*:b cA:b)*:c)*:1
+            1 (REDXOR (REPLICATE (REPLICATE _A:a cA:b)*:c cA:b)*:b):1
+            1 (REDXOR (REPLICATE (SEL@A _A:a):1 cA:b)*:c):1
+            1 (REDXOR (SEL@0 (REPLICATE _A:a cA:a)*:b)*:c):1
             1 (REPLICATE (NOT (REPLICATE _A:a cA:b)*:b):b cA:b)*:c
             1 (REPLICATE (REPLICATE (REPLICATE _A:1 cA:a)*:b cB:a)*:c cB:a)*:a
             1 (REPLICATE (REPLICATE (REPLICATE _A:a cA:b)*:c cA:b)*:b cA:b)*:d
             1 (REPLICATE (REPLICATE (SEL@A _A:a):1 cA:b)*:c cB:b)*:d
             1 (REPLICATE (SEL@A (AND _A:a _B:a)*:a):1 cA:b)*:c
-            1 (SEL@0 (AND (NOT vA:a)*:a (NOT vB:a)*:a)*:a):1
-            1 (SEL@0 (REPLICATE (NOT _A:a):a cA:a)*:b):c
+            1 (SEL@0 (AND (NOT vA:a)*:a (NOT vB:a)*:a)*:a)*:1
+            1 (SEL@0 (REPLICATE (NOT _A:a):a cA:a)*:b)*:c
             1 (SEL@A (AND (NOT vA:a)*:a (NOT vB:a)*:a)*:a):1
 
 DFG 'pre inline' patterns with depth 4
             1 (CONCAT '0:a (REPLICATE (REPLICATE (REPLICATE _A:b cA:a)*:c cA:a)*:a cA:a)*:d):A
+            1 (CONCAT (REDXOR (AND (NOT vA:a)*:a (NOT vB:a)*:a)*:a):1 (CONCAT (REDXOR (AND _A:a _B:a)*:a):1 (CONCAT (REDXOR _C:a):1 (CONCAT _D:1 _E:b):c):d):e):f
+            1 (CONCAT (REDXOR (AND (NOT vA:a)*:a (NOT vB:a)*:a)*:a):1 (CONCAT (REDXOR (AND _A:a _B:a)*:a):1 (CONCAT (SEL@0 _C:a)*:1 (CONCAT _D:1 _E:b):c):d):e):f
+            1 (CONCAT (REDXOR (AND (NOT vA:a)*:a (NOT vB:a)*:a)*:a):1 (CONCAT (SEL@0 (AND _A:a _B:a)*:a)*:1 (CONCAT (REDXOR _C:b):1 (CONCAT _D:1 _E:c):d):e):b):f
+            1 (CONCAT (REDXOR (REPLICATE (NOT _A:a):a cA:a)*:b):1 (CONCAT (REDXOR (SEL@0 _B:b)*:c):1 (REDXOR (REPLICATE _A:a cA:a)*:b)*:1):d):e
+            1 (CONCAT (REDXOR (REPLICATE (REPLICATE _A:1 cA:a)*:b cB:a)*:c):1 (CONCAT (REDXOR (REPLICATE _B:c cB:a)*:a):1 (CONCAT (REDXOR _C:d)*:1 (CONCAT _D:1 _E:e):f):g):h):i
+            1 (CONCAT (REDXOR (REPLICATE (REPLICATE _A:a cA:b)*:b cA:b)*:c)*:1 (CONCAT (REDXOR (REPLICATE _B:b cA:b)*:c):1 (CONCAT (REDXOR _C:d):1 (REDXOR _D:c)*:1):e):f):g
+            1 (CONCAT (REDXOR (REPLICATE (REPLICATE _A:a cA:b)*:c cA:b)*:b):1 (CONCAT (REDXOR (REPLICATE _B:b cA:b)*:d)*:1 (CONCAT (REDXOR _C:d):1 (CONCAT _D:1 _E:1):e):f):g):h
+            1 (CONCAT (REDXOR (REPLICATE (SEL@A _A:a):1 cA:b)*:c):1 (CONCAT (REDXOR (REPLICATE _B:c cB:b)*:d):1 (CONCAT (REDXOR _C:b):1 (CONCAT _D:1 _E:e):a):f):g):h
+            1 (CONCAT (REDXOR (SEL@0 (REPLICATE _A:a cA:a)*:b)*:c):1 (REDXOR (REPLICATE (REPLICATE _B:d cA:a)*:a cA:a)*:b)*:1):e
+            1 (CONCAT (SEL@0 (AND (NOT vA:a)*:a (NOT vB:a)*:a)*:a)*:1 (CONCAT (REDXOR (REPLICATE _A:1 cA:b)*:c):1 (CONCAT (REDXOR _B:d):1 (CONCAT _C:1 _D:a):e):f):g):c
             1 (NOT (REPLICATE (REPLICATE (REPLICATE _A:1 cA:a)*:b cB:a)*:c cB:a)*:a):a
+            1 (REDXOR (REPLICATE (NOT (REPLICATE _A:a cA:b)*:b):b cA:b)*:c):1
+            1 (REDXOR (REPLICATE (REPLICATE (REPLICATE _A:1 cA:a)*:b cB:a)*:c cB:a)*:a):1
+            1 (REDXOR (REPLICATE (REPLICATE (REPLICATE _A:a cA:b)*:c cA:b)*:b cA:b)*:d)*:1
+            1 (REDXOR (REPLICATE (REPLICATE (SEL@A _A:a):1 cA:b)*:c cB:b)*:d):1
+            1 (REDXOR (REPLICATE (SEL@A (AND _A:a _B:a)*:a):1 cA:b)*:c):1
+            1 (REDXOR (SEL@0 (REPLICATE (NOT _A:a):a cA:a)*:b)*:c):1
             1 (REPLICATE (NOT (REPLICATE (REPLICATE _A:a cA:b)*:c cA:b)*:b):b cA:b)*:d
             1 (REPLICATE (REPLICATE (REPLICATE (REPLICATE _A:1 cA:a)*:b cB:a)*:c cB:a)*:a cB:a)*:d
             1 (REPLICATE (REPLICATE (REPLICATE (SEL@A _A:a):1 cA:b)*:c cB:b)*:d cB:b)*:b
             1 (REPLICATE (REPLICATE (SEL@A (AND _A:a _B:a)*:a):1 cA:b)*:c cB:b)*:d
             1 (REPLICATE (SEL@A (AND (NOT vA:a)*:a (NOT vB:a)*:a)*:a):1 cA:b)*:c
-            1 (SEL@0 (REPLICATE (NOT (REPLICATE _A:a cA:b)*:b):b cA:b)*:c):d
+            1 (SEL@0 (REPLICATE (NOT (REPLICATE _A:a cA:b)*:b):b cA:b)*:c)*:d
 

--- a/test_regress/t/t_dfg_stats_patterns_scoped.out
+++ b/test_regress/t/t_dfg_stats_patterns_scoped.out
@@ -1,50 +1,96 @@
 DFG 'scoped' patterns with depth 1
+            9 (CONCAT _A:1 _B:a):b
+            8 (REDXOR _A:a):1
+            3 (AND _A:a _B:a)*:a
             3 (NOT vA:a)*:a
-            2 (AND _A:a _B:a):a
             2 (REPLICATE _A:a cA:a)*:b
-            1 (AND _A:a _B:a)*:a
             1 (CONCAT '0:a _A:b):A
+            1 (CONCAT _A:1 _B:1):a
             1 (NOT _A:a):a
+            1 (REDXOR _A:a)*:1
             1 (REPLICATE _A:1 cA:a)*:b
             1 (REPLICATE _A:a cA:b)*:b
             1 (REPLICATE _A:a cA:b)*:c
-            1 (SEL@0 _A:a):1
-            1 (SEL@0 _A:a):b
+            1 (SEL@0 _A:a)*:1
+            1 (SEL@0 _A:a)*:b
             1 (SEL@A _A:a):1
 
 DFG 'scoped' patterns with depth 2
-            2 (AND (NOT vA:a)*:a (NOT vB:a)*:a):a
-            1 (AND (NOT vA:a)*:a (NOT vB:a)*:a)*:a
+            6 (CONCAT (REDXOR _A:a):1 (CONCAT _B:1 _C:b):c):d
+            3 (AND (NOT vA:a)*:a (NOT vB:a)*:a)*:a
+            3 (REDXOR (AND _A:a _B:a)*:a):1
             1 (CONCAT '0:a (REPLICATE _A:a cA:a)*:b):A
+            1 (CONCAT (REDXOR _A:a)*:1 (CONCAT _B:1 _C:b):c):d
+            1 (CONCAT (REDXOR _A:a):1 (CONCAT _B:1 _C:1):b):c
+            1 (CONCAT (REDXOR _A:a):1 (REDXOR _B:b)*:1):c
+            1 (CONCAT (SEL@0 _A:a)*:1 (CONCAT _B:1 _C:b):c):d
             1 (NOT (REPLICATE _A:a cA:b)*:b):b
+            1 (REDXOR (REPLICATE _A:1 cA:a)*:b):1
+            1 (REDXOR (REPLICATE _A:a cA:a)*:b)*:1
+            1 (REDXOR (REPLICATE _A:a cA:a)*:b):1
+            1 (REDXOR (REPLICATE _A:a cA:b)*:b):1
+            1 (REDXOR (REPLICATE _A:a cA:b)*:c):1
+            1 (REDXOR (SEL@0 _A:a)*:b):1
             1 (REPLICATE (NOT _A:a):a cA:a)*:b
             1 (REPLICATE (REPLICATE _A:1 cA:a)*:b cB:a)*:c
             1 (REPLICATE (REPLICATE _A:a cA:b)*:b cA:b)*:c
             1 (REPLICATE (REPLICATE _A:a cA:b)*:c cA:b)*:b
             1 (REPLICATE (SEL@A _A:a):1 cA:b)*:c
-            1 (SEL@0 (AND _A:a _B:a)*:a):1
-            1 (SEL@0 (REPLICATE _A:a cA:a)*:b):c
+            1 (SEL@0 (AND _A:a _B:a)*:a)*:1
+            1 (SEL@0 (REPLICATE _A:a cA:a)*:b)*:c
             1 (SEL@A (AND _A:a _B:a)*:a):1
 
 DFG 'scoped' patterns with depth 3
+            3 (REDXOR (AND (NOT vA:a)*:a (NOT vB:a)*:a)*:a):1
+            2 (CONCAT (REDXOR (AND _A:a _B:a)*:a):1 (CONCAT (REDXOR _C:a):1 (CONCAT _D:1 _E:b):c):d):e
             1 (CONCAT '0:a (REPLICATE (REPLICATE _A:b cA:a)*:a cA:a)*:c):A
+            1 (CONCAT (REDXOR (AND _A:a _B:a)*:a):1 (CONCAT (SEL@0 _C:a)*:1 (CONCAT _D:1 _E:b):c):d):e
+            1 (CONCAT (REDXOR (REPLICATE _A:1 cA:a)*:b):1 (CONCAT (REDXOR _B:c):1 (CONCAT _C:1 _D:d):e):f):g
+            1 (CONCAT (REDXOR (REPLICATE _A:a cA:a)*:b)*:1 (CONCAT (REDXOR _B:b):1 (CONCAT _C:1 _D:1):c):d):e
+            1 (CONCAT (REDXOR (REPLICATE _A:a cA:a)*:b):1 (CONCAT (REDXOR _B:c):1 (REDXOR _C:b)*:1):d):e
+            1 (CONCAT (REDXOR (REPLICATE _A:a cA:b)*:b):1 (CONCAT (REDXOR _B:c)*:1 (CONCAT _C:1 _D:d):e):f):g
+            1 (CONCAT (REDXOR (REPLICATE _A:a cA:b)*:c):1 (CONCAT (REDXOR _B:b):1 (CONCAT _C:1 _D:d):e):f):g
+            1 (CONCAT (REDXOR (SEL@0 _A:a)*:b):1 (REDXOR (REPLICATE _B:c cA:c)*:a)*:1):d
+            1 (CONCAT (SEL@0 (AND _A:a _B:a)*:a)*:1 (CONCAT (REDXOR _C:b):1 (CONCAT _D:1 _E:c):d):e):b
             1 (NOT (REPLICATE (REPLICATE _A:a cA:b)*:c cA:b)*:b):b
+            1 (REDXOR (REPLICATE (NOT _A:a):a cA:a)*:b):1
+            1 (REDXOR (REPLICATE (REPLICATE _A:1 cA:a)*:b cB:a)*:c):1
+            1 (REDXOR (REPLICATE (REPLICATE _A:a cA:b)*:b cA:b)*:c)*:1
+            1 (REDXOR (REPLICATE (REPLICATE _A:a cA:b)*:c cA:b)*:b):1
+            1 (REDXOR (REPLICATE (SEL@A _A:a):1 cA:b)*:c):1
+            1 (REDXOR (SEL@0 (REPLICATE _A:a cA:a)*:b)*:c):1
             1 (REPLICATE (NOT (REPLICATE _A:a cA:b)*:b):b cA:b)*:c
             1 (REPLICATE (REPLICATE (REPLICATE _A:1 cA:a)*:b cB:a)*:c cB:a)*:a
             1 (REPLICATE (REPLICATE (REPLICATE _A:a cA:b)*:c cA:b)*:b cA:b)*:d
             1 (REPLICATE (REPLICATE (SEL@A _A:a):1 cA:b)*:c cB:b)*:d
             1 (REPLICATE (SEL@A (AND _A:a _B:a)*:a):1 cA:b)*:c
-            1 (SEL@0 (AND (NOT vA:a)*:a (NOT vB:a)*:a)*:a):1
-            1 (SEL@0 (REPLICATE (NOT _A:a):a cA:a)*:b):c
+            1 (SEL@0 (AND (NOT vA:a)*:a (NOT vB:a)*:a)*:a)*:1
+            1 (SEL@0 (REPLICATE (NOT _A:a):a cA:a)*:b)*:c
             1 (SEL@A (AND (NOT vA:a)*:a (NOT vB:a)*:a)*:a):1
 
 DFG 'scoped' patterns with depth 4
             1 (CONCAT '0:a (REPLICATE (REPLICATE (REPLICATE _A:b cA:a)*:c cA:a)*:a cA:a)*:d):A
+            1 (CONCAT (REDXOR (AND (NOT vA:a)*:a (NOT vB:a)*:a)*:a):1 (CONCAT (REDXOR (AND _A:a _B:a)*:a):1 (CONCAT (REDXOR _C:a):1 (CONCAT _D:1 _E:b):c):d):e):f
+            1 (CONCAT (REDXOR (AND (NOT vA:a)*:a (NOT vB:a)*:a)*:a):1 (CONCAT (REDXOR (AND _A:a _B:a)*:a):1 (CONCAT (SEL@0 _C:a)*:1 (CONCAT _D:1 _E:b):c):d):e):f
+            1 (CONCAT (REDXOR (AND (NOT vA:a)*:a (NOT vB:a)*:a)*:a):1 (CONCAT (SEL@0 (AND _A:a _B:a)*:a)*:1 (CONCAT (REDXOR _C:b):1 (CONCAT _D:1 _E:c):d):e):b):f
+            1 (CONCAT (REDXOR (REPLICATE (NOT _A:a):a cA:a)*:b):1 (CONCAT (REDXOR (SEL@0 _B:b)*:c):1 (REDXOR (REPLICATE _A:a cA:a)*:b)*:1):d):e
+            1 (CONCAT (REDXOR (REPLICATE (REPLICATE _A:1 cA:a)*:b cB:a)*:c):1 (CONCAT (REDXOR (REPLICATE _B:c cB:a)*:a):1 (CONCAT (REDXOR _C:d)*:1 (CONCAT _D:1 _E:e):f):g):h):i
+            1 (CONCAT (REDXOR (REPLICATE (REPLICATE _A:a cA:b)*:b cA:b)*:c)*:1 (CONCAT (REDXOR (REPLICATE _B:b cA:b)*:c):1 (CONCAT (REDXOR _C:d):1 (REDXOR _D:c)*:1):e):f):g
+            1 (CONCAT (REDXOR (REPLICATE (REPLICATE _A:a cA:b)*:c cA:b)*:b):1 (CONCAT (REDXOR (REPLICATE _B:b cA:b)*:d)*:1 (CONCAT (REDXOR _C:d):1 (CONCAT _D:1 _E:1):e):f):g):h
+            1 (CONCAT (REDXOR (REPLICATE (SEL@A _A:a):1 cA:b)*:c):1 (CONCAT (REDXOR (REPLICATE _B:c cB:b)*:d):1 (CONCAT (REDXOR _C:b):1 (CONCAT _D:1 _E:e):a):f):g):h
+            1 (CONCAT (REDXOR (SEL@0 (REPLICATE _A:a cA:a)*:b)*:c):1 (REDXOR (REPLICATE (REPLICATE _B:d cA:a)*:a cA:a)*:b)*:1):e
+            1 (CONCAT (SEL@0 (AND (NOT vA:a)*:a (NOT vB:a)*:a)*:a)*:1 (CONCAT (REDXOR (REPLICATE _A:1 cA:b)*:c):1 (CONCAT (REDXOR _B:d):1 (CONCAT _C:1 _D:a):e):f):g):c
             1 (NOT (REPLICATE (REPLICATE (REPLICATE _A:1 cA:a)*:b cB:a)*:c cB:a)*:a):a
+            1 (REDXOR (REPLICATE (NOT (REPLICATE _A:a cA:b)*:b):b cA:b)*:c):1
+            1 (REDXOR (REPLICATE (REPLICATE (REPLICATE _A:1 cA:a)*:b cB:a)*:c cB:a)*:a):1
+            1 (REDXOR (REPLICATE (REPLICATE (REPLICATE _A:a cA:b)*:c cA:b)*:b cA:b)*:d)*:1
+            1 (REDXOR (REPLICATE (REPLICATE (SEL@A _A:a):1 cA:b)*:c cB:b)*:d):1
+            1 (REDXOR (REPLICATE (SEL@A (AND _A:a _B:a)*:a):1 cA:b)*:c):1
+            1 (REDXOR (SEL@0 (REPLICATE (NOT _A:a):a cA:a)*:b)*:c):1
             1 (REPLICATE (NOT (REPLICATE (REPLICATE _A:a cA:b)*:c cA:b)*:b):b cA:b)*:d
             1 (REPLICATE (REPLICATE (REPLICATE (REPLICATE _A:1 cA:a)*:b cB:a)*:c cB:a)*:a cB:a)*:d
             1 (REPLICATE (REPLICATE (REPLICATE (SEL@A _A:a):1 cA:b)*:c cB:b)*:d cB:b)*:b
             1 (REPLICATE (REPLICATE (SEL@A (AND _A:a _B:a)*:a):1 cA:b)*:c cB:b)*:d
             1 (REPLICATE (SEL@A (AND (NOT vA:a)*:a (NOT vB:a)*:a)*:a):1 cA:b)*:c
-            1 (SEL@0 (REPLICATE (NOT (REPLICATE _A:a cA:b)*:b):b cA:b)*:c):d
+            1 (SEL@0 (REPLICATE (NOT (REPLICATE _A:a cA:b)*:b):b cA:b)*:c)*:d
 

--- a/test_regress/t/t_lint_always_comb_multidriven_compile_public_flat_bad.out
+++ b/test_regress/t/t_lint_always_comb_multidriven_compile_public_flat_bad.out
@@ -48,4 +48,36 @@
                       t/t_lint_always_comb_multidriven_bad.v:40:16: ... Location of other write
    40 |    always_comb out6 = d;
       |                ^~~~
+%Warning-MULTIDRIVEN: t/t_lint_always_comb_multidriven_bad.v:17:15: Bit [0] of signal 'out2' have multiple combinational drivers. This can cause performance degradation.
+                                                                  : ... note: In instance 't'
+                      t/t_lint_always_comb_multidriven_bad.v:28:16: ... Location of offending driver
+   28 |    assign out2 = d;
+      |                ^
+                      t/t_lint_always_comb_multidriven_bad.v:29:21: ... Location of offending driver
+   29 |    always_comb out2 = 1'b0;   
+      |                     ^
+%Warning-MULTIDRIVEN: t/t_lint_always_comb_multidriven_bad.v:19:15: Bit [0] of signal 'out4' have multiple combinational drivers. This can cause performance degradation.
+                                                                  : ... note: In instance 't'
+                      t/t_lint_always_comb_multidriven_bad.v:34:21: ... Location of offending driver
+   34 |    always_comb out4 = 1'b0;
+      |                     ^
+                      t/t_lint_always_comb_multidriven_bad.v:35:16: ... Location of offending driver
+   35 |    assign out4 = d;   
+      |                ^
+%Warning-MULTIDRIVEN: t/t_lint_always_comb_multidriven_bad.v:20:15: Bit [0] of signal 'out5' have multiple combinational drivers. This can cause performance degradation.
+                                                                  : ... note: In instance 't'
+                      t/t_lint_always_comb_multidriven_bad.v:37:21: ... Location of offending driver
+   37 |    always_comb out5 = 1'b0;
+      |                     ^
+                      t/t_lint_always_comb_multidriven_bad.v:38:21: ... Location of offending driver
+   38 |    always_comb out5 = d;   
+      |                     ^
+%Warning-MULTIDRIVEN: t/t_lint_always_comb_multidriven_bad.v:21:15: Bit [0] of signal 'out6' have multiple combinational drivers. This can cause performance degradation.
+                                                                  : ... note: In instance 't'
+                      t/t_lint_always_comb_multidriven_bad.v:40:21: ... Location of offending driver
+   40 |    always_comb out6 = d;
+      |                     ^
+                      t/t_lint_always_comb_multidriven_bad.v:41:21: ... Location of offending driver
+   41 |    always_comb out6 = 1'b0;   
+      |                     ^
 %Error: Exiting due to


### PR DESCRIPTION
Combined Dfg variable elimination into the regularization pass that runs
before converting back to Ast. This avoids introducing some unnecessary
temporaries.

Added replacing of variables with constants in the Ast if after the
Dfg passes they are known to be constants. This is only done in final
scoped Dfg application.

Avoid introducing temporaries for common sub-expressions that are
cheaper to re-compute than store in a temporary variable.

Enable removal of redundant unpacked array variables.

Also fixes #6394 as this patch involved changes to that code.

---

Draft as it depends on #6390
