### PR TITLE
Testing: Add --enable-asan configure option to compile with AddressSanitizer

### DIFF
--- a/bin/verilator
+++ b/bin/verilator
@@ -203,10 +203,23 @@ sub aslr_off {
 
 sub ulimit_stack_unlimited {
     return "" if !$opt_unlimited_stack;
-    system("ulimit -s unlimited 2>/dev/null");
+    my $limit = "unlimited";
+    # AddressSanitizer doesn't work with 'ulimit -s unlimted'
+    if (`${\(verilator_bin())} --get-supported ASAN` eq "1\n") {
+        # Use host 'physical memory / #cores / 8' instead
+        open(my $fh, "<", "/proc/meminfo") || die "Can't read host memory for asan";
+        while (<$fh>) {
+            if (m/MemTotal:\s+(\d+)\s+kB/) {
+                $limit = int(int($1)/`nproc`/8);
+                last;
+            }
+        }
+        close($fh);
+    }
+    system("ulimit -s $limit 2>/dev/null");
     my $status = $?;
     if ($status == 0) {
-        return "ulimit -s unlimited 2>/dev/null; exec ";
+        return "ulimit -s $limit 2>/dev/null; exec ";
     } else {
         return "";
     }

--- a/configure.ac
+++ b/configure.ac
@@ -61,9 +61,10 @@ AC_MSG_RESULT($CFG_ENABLE_PARTIAL_STATIC)
 AC_MSG_CHECKING(whether to use AddressSanitizer)
 AC_ARG_ENABLE([asan],
               [AS_HELP_STRING([--enable-asan],
-                              [Enable compiling Verilator with ASAN AddressSanitizer
-                               for memory error detection. This disables tcmalloc.
-                               Does not affect Verilated models using ASAN.])],
+                              [Enable compiling Verilator with ASAN
+                               AddressSanitizer for memory error detection.
+                               This disables tcmalloc.  Does not affect
+                               Verilated models using ASAN.])],
               [case "${enableval}" in
                 yes) CFG_WITH_ASAN=yes ;;
                 no)  CFG_WITH_ASAN=no ;;

--- a/configure.ac
+++ b/configure.ac
@@ -57,6 +57,20 @@ AC_ARG_ENABLE([partial-static],
                CFG_ENABLE_PARTIAL_STATIC=yes)
 AC_MSG_RESULT($CFG_ENABLE_PARTIAL_STATIC)
 
+# Flag to enable compiling with AddressSanitizer
+AC_MSG_CHECKING(whether to use AddressSanitizer)
+AC_ARG_ENABLE([asan],
+              [AS_HELP_STRING([--enabel-asan],
+                              [Enable AddressSanitizer for run-time memory
+                               error detection. This disables tcmalloc.])],
+              [case "${enableval}" in
+                yes) CFG_WITH_ASAN=yes ;;
+                no)  CFG_WITH_ASAN=no ;;
+                *)   AC_MSG_ERROR([bad value '${enableval}' for --enable-asan]) ;;
+               esac],
+               CFG_WITH_ASAN=no)
+AC_MSG_RESULT($CFG_WITH_ASAN)
+
 # Flag to enable linking Verilator with tcmalloc if available
 AC_MSG_CHECKING(whether to use tcmalloc)
 AC_ARG_ENABLE([tcmalloc],
@@ -69,8 +83,12 @@ AC_ARG_ENABLE([tcmalloc],
                 *)   AC_MSG_ERROR([bad value '${enableval}' for --enable-tcmalloc]) ;;
                esac],
               [CFG_WITH_TCMALLOC=check;])
-AC_SUBST(CFG_WITH_TCMALLOC)
-AC_MSG_RESULT($CFG_WITH_TCMALLOC)
+if test "$CFG_WITH_ASAN" = "yes"; then
+  CFG_WITH_TCMALLOC=no
+  AC_MSG_RESULT("disabled by --enable-asan")
+else
+  AC_MSG_RESULT($CFG_WITH_TCMALLOC)
+fi
 
 # Flag to enable coverage build
 AC_MSG_CHECKING(whether to build for coverage collection)
@@ -433,6 +451,14 @@ AC_SUBST(CFG_CXXFLAGS_COROUTINES)
 AC_SUBST(HAVE_COROUTINES)
 
 # Flags for compiling Verilator internals including parser always
+if test "$CFG_WITH_ASAN" = "yes"; then
+  _MY_CXX_CHECK_IFELSE(-fsanitize=address -DVL_ASAN,
+    [CFG_CXXFLAGS_SRC="$CFG_CXXFLAGS_SRC -fsanitize=address -DVL_ASAN"
+     CFG_LDFLAGS_SRC="$CFG_LDFLAGS_SRC -fsanitize=address"
+     AC_DEFINE([HAVE_ASAN],[1],[Defined if built with AddresSanitizer])]
+  )
+fi
+AC_SUBST(HAVE_ASAN)
 _MY_CXX_CHECK_OPT(CFG_CXXFLAGS_SRC,-Qunused-arguments)
 _MY_CXX_CHECK_OPT(CFG_CXXFLAGS_SRC,-Wno-shadow)
 _MY_CXX_CHECK_OPT(CFG_CXXFLAGS_SRC,-Wno-unused-parameter)

--- a/configure.ac
+++ b/configure.ac
@@ -60,9 +60,10 @@ AC_MSG_RESULT($CFG_ENABLE_PARTIAL_STATIC)
 # Flag to enable compiling with AddressSanitizer
 AC_MSG_CHECKING(whether to use AddressSanitizer)
 AC_ARG_ENABLE([asan],
-              [AS_HELP_STRING([--enabel-asan],
-                              [Enable AddressSanitizer for run-time memory
-                               error detection. This disables tcmalloc.])],
+              [AS_HELP_STRING([--enable-asan],
+                              [Enable compiling Verilator with ASAN AddressSanitizer
+                               for memory error detection. This disables tcmalloc.
+                               Does not affect Verilated models using ASAN.])],
               [case "${enableval}" in
                 yes) CFG_WITH_ASAN=yes ;;
                 no)  CFG_WITH_ASAN=no ;;

--- a/docs/guide/exe_verilator.rst
+++ b/docs/guide/exe_verilator.rst
@@ -772,7 +772,7 @@ Summary:
    be useful in makefiles. See also :vlopt:`-V`, and the various
    :file:`*.mk` files.
 
-   Feature may be one of the following: COROUTINES, SYSTEMC.
+   Feature may be one of the following: COROUTINES, SYSTEMC, ASAN.
 
 .. option:: --getenv <variable>
 

--- a/src/V3Global.cpp
+++ b/src/V3Global.cpp
@@ -35,7 +35,7 @@ VL_DEFINE_DEBUG_FUNCTIONS;
 #ifdef VL_ASAN
 extern "C" const char* __asan_default_options() {
     // See https://github.com/google/sanitizers/wiki/SanitizerCommonFlags
-    // or 'env ASAN_OPTIONS=help=1 ./verialtor_bin'
+    // or 'env ASAN_OPTIONS=help=1 ./verilator_bin'
     return ""
 #ifndef VL_LEAK_CHECKS
            ":detect_leaks=0"

--- a/src/V3Global.cpp
+++ b/src/V3Global.cpp
@@ -30,6 +30,21 @@
 VL_DEFINE_DEBUG_FUNCTIONS;
 
 //######################################################################
+// AddressSanitizer default options
+
+#ifdef VL_ASAN
+extern "C" const char* __asan_default_options() {
+    // See https://github.com/google/sanitizers/wiki/SanitizerCommonFlags
+    // or 'env ASAN_OPTIONS=help=1 ./verialtor_bin'
+    return ""
+#ifndef VL_LEAK_CHECKS
+           ":detect_leaks=0"
+#endif
+        ;
+}
+#endif
+
+//######################################################################
 // V3Global
 
 void V3Global::boot() {

--- a/src/V3Options.cpp
+++ b/src/V3Options.cpp
@@ -817,6 +817,8 @@ string V3Options::getSupported(const string& var) {
         // cppcheck-suppress knownConditionTrueFalse
     } else if (var == "SYSTEMC" && systemCFound()) {
         return "1";
+    } else if (var == "ASAN" && builtWithAsan()) {
+        return "1";
     } else {
         return "";
     }
@@ -837,6 +839,14 @@ bool V3Options::systemCFound() {
 
 bool V3Options::coroutineSupport() {
 #ifdef HAVE_COROUTINES
+    return true;
+#else
+    return false;
+#endif
+}
+
+bool V3Options::builtWithAsan() {
+#ifdef HAVE_ASAN
     return true;
 #else
     return false;

--- a/src/V3Options.h
+++ b/src/V3Options.h
@@ -821,6 +821,7 @@ public:
     static bool systemCSystemWide();
     static bool systemCFound();  // SystemC installed, or environment points to it
     static bool coroutineSupport();  // Compiler supports coroutines
+    static bool builtWithAsan();  // Compiler built with AddressSanitizer
 
     // METHODS (file utilities using these options)
     string fileExists(const string& filename);

--- a/src/config_package.h.in
+++ b/src/config_package.h.in
@@ -44,6 +44,9 @@ PACKAGE_VERSION_STRING_CHAR
 // Define if compiled with tcmalloc
 #undef HAVE_TCMALLOC
 
+// Define if compiled with AddressSanitizer
+#undef HAVE_ASAN
+
 //**********************************************************************
 //**** This file sometimes gets truncated, so check in consumers
 #define HAVE_CONFIG_PACKAGE

--- a/test_regress/driver.py
+++ b/test_regress/driver.py
@@ -1807,6 +1807,8 @@ class VlTest:
 
         if not fails and status:
             firstline = self._error_log_summary(logfile)
+            # Strip ANSI escape sequences
+            firstline = re.sub(r'\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])', '', firstline)
             self.error("Exec of " + self._error_cmd_simplify(cmd) + " failed: " + firstline)
         if fails and status:
             print("(Exec expected to fail, and did.)")

--- a/test_regress/t/t_debug_sigsegv_bad.py
+++ b/test_regress/t/t_debug_sigsegv_bad.py
@@ -11,6 +11,8 @@ import vltest_bootstrap
 
 test.scenarios('vlt')
 
+os.environ["ASAN_OPTIONS"] = "handle_segv=0"
+
 test.lint(v_flags=["--debug-sigsegv"], fails=True, sanitize=0)
 
 test.file_grep(test.compile_log_filename,


### PR DESCRIPTION
Note this requires changing the unlimited stack setup in the perl wrapper as `ulimit -s unlimited` doesn't work with ASan.

---

With this, there are 33 errors in `make test` that I will fix up afterwards:

```
#vlt/t_dpi_argtype_bad: %Error: Line 5 miscompares; obj_vlt/t_dpi_argtype_bad/vlt_compile.log != t/t_dpi_argtype_bad.out
                make && test_regress/t/t_dpi_argtype_bad.py  --vlt
#vlt/t_gate_strength: %Error: Exec of verilator failed: ==428613==ERROR: AddressSanitizer: heap-use-after-free on address 0x503000065210 at pc 0x56a181fa0c69 bp 0x7ffe504ebcf0 sp 0x7ffe504ebce8
                make && test_regress/t/t_gate_strength.py  --vlt
#vlt/t_hier_block_prot_lib_shared: %Error: Exec of DYLD_FALLBACK_LIBRARY_PATH=/home/gl/work/verilator/repo/test_regress/obj_vlt/t_hier_block_prot_lib_shared/secret obj_vlt/t_hier_block_prot_lib_shared/Vt_hier_block_prot_lib_shared failed: ==431317==ERROR: AddressSanitizer: odr-violation (0x5dfb5925cc40):
                make && test_regress/t/t_hier_block_prot_lib_shared.py  --vlt
#vlt/t_lib_prot_shared: %Error: Exec of DYLD_FALLBACK_LIBRARY_PATH=/home/gl/work/verilator/repo/test_regress/obj_vlt/t_lib_prot_shared/secret obj_vlt/t_lib_prot_shared/Vt_lib_prot_shared failed: ==429631==ERROR: AddressSanitizer: odr-violation (0x651d2734fd80):
                make && test_regress/t/t_lib_prot_shared.py  --vlt
#vlt/t_lint_unused_bad: %Error: Line 0 miscompares; obj_vlt/t_lint_unused_bad/vlt_compile.log != t/t_lint_unused_bad.out
                make && test_regress/t/t_lint_unused_bad.py  --vlt
#vlt/t_strength_highz: %Error: Line 4 miscompares; obj_vlt/t_strength_highz/vlt_compile.log != t/t_strength_highz.out
                make && test_regress/t/t_strength_highz.py  --vlt
#vlt/t_vlt_match_contents: %Error: Line 0 miscompares; obj_vlt/t_vlt_match_contents/vlt_compile.log != t/t_vlt_match_contents.out
                make && test_regress/t/t_vlt_match_contents.py  --vlt
#vlt/t_vpi_dump: %Error: Exec of obj_vlt/t_vpi_dump/Vt_vpi_dump failed: t (vpiModule) t  vpiDefName=t
                make && test_regress/t/t_vpi_dump.py  --vlt
#vlt/t_vpi_dump_no_inline: %Error: Exec of obj_vlt/t_vpi_dump_no_inline/Vt_vpi_dump_no_inline failed: t (vpiModule) t  vpiDefName=t
                make && test_regress/t/t_vpi_dump_no_inline.py  --vlt
#vlt/t_vpi_get: %Error: Exec of obj_vlt/t_vpi_get/Vt_vpi_get failed: ==429230==ERROR: LeakSanitizer: detected memory leaks
                make && test_regress/t/t_vpi_get.py  --vlt
#vlt/t_vpi_get_public_rw_switch: %Error: Exec of obj_vlt/t_vpi_get_public_rw_switch/Vt_vpi_get failed: ==429341==ERROR: LeakSanitizer: detected memory leaks
                make && test_regress/t/t_vpi_get_public_rw_switch.py  --vlt
#vlt/t_vpi_memory: %Error: Exec of obj_vlt/t_vpi_memory/Vt_vpi_memory failed: ==430114==ERROR: LeakSanitizer: detected memory leaks
                make && test_regress/t/t_vpi_memory.py  --vlt
#vlt/t_vpi_multidim: %Error: Exec of obj_vlt/t_vpi_multidim/Vt_vpi_multidim failed: ==430530==ERROR: LeakSanitizer: detected memory leaks
                make && test_regress/t/t_vpi_multidim.py  --vlt
#vlt/t_vpi_onetime_cbs: %Error: Exec of obj_vlt/t_vpi_onetime_cbs/Vt_vpi_onetime_cbs failed: ==430325==ERROR: LeakSanitizer: detected memory leaks
                make && test_regress/t/t_vpi_onetime_cbs.py  --vlt
#vlt/t_vpi_time_cb: %Error: Exec of obj_vlt/t_vpi_time_cb/Vt_vpi_time_cb failed: ==430072==ERROR: LeakSanitizer: detected memory leaks
                make && test_regress/t/t_vpi_time_cb.py  --vlt
#vlt/t_vpi_var2: %Error: Exec of obj_vlt/t_vpi_var2/Vt_vpi_var2 failed: ==430773==ERROR: LeakSanitizer: detected memory leaks
                make && test_regress/t/t_vpi_var2.py  --vlt
#vlt/t_vpi_var3: %Error: Exec of obj_vlt/t_vpi_var3/Vt_vpi_var3 failed: ==430868==ERROR: LeakSanitizer: detected memory leaks
                make && test_regress/t/t_vpi_var3.py  --vlt
#vlt/t_vpi_var: %Error: Exec of obj_vlt/t_vpi_var/Vt_vpi_var failed: ==430756==ERROR: LeakSanitizer: detected memory leaks
                make && test_regress/t/t_vpi_var.py  --vlt
#vltmt/t_dotfiles: %Error: Exec of verilator failed: ==428617==ERROR: AddressSanitizer: heap-use-after-free on address 0x50e00002f9c0 at pc 0x5dec3f81fa77 bp 0x7ffe576f59b0 sp 0x7ffe576f59a8
                make && test_regress/t/t_dotfiles.py  --vltmt
#vltmt/t_gate_strength: %Error: Exec of verilator failed: ==428601==ERROR: AddressSanitizer: heap-use-after-free on address 0x5030000653c0 at pc 0x561902d97c69 bp 0x7ffee66a7c70 sp 0x7ffee66a7c68
                make && test_regress/t/t_gate_strength.py  --vltmt
#vltmt/t_hier_block_prot_lib_shared: %Error: Exec of DYLD_FALLBACK_LIBRARY_PATH=/home/gl/work/verilator/repo/test_regress/obj_vltmt/t_hier_block_prot_lib_shared/secret obj_vltmt/t_hier_block_prot_lib_shared/Vt_hier_block_prot_lib_shared failed: ==431341==ERROR: AddressSanitizer: odr-violation (0x5f7ea079a340):
                make && test_regress/t/t_hier_block_prot_lib_shared.py  --vltmt
#vltmt/t_lib_prot_shared: %Error: Exec of DYLD_FALLBACK_LIBRARY_PATH=/home/gl/work/verilator/repo/test_regress/obj_vltmt/t_lib_prot_shared/secret obj_vltmt/t_lib_prot_shared/Vt_lib_prot_shared failed: ==429634==ERROR: AddressSanitizer: odr-violation (0x58b309e8edc0):
                make && test_regress/t/t_lib_prot_shared.py  --vltmt
#vltmt/t_vpi_dump: %Error: Exec of obj_vltmt/t_vpi_dump/Vt_vpi_dump failed: t (vpiModule) t  vpiDefName=t
                make && test_regress/t/t_vpi_dump.py  --vltmt
#vltmt/t_vpi_dump_no_inline: %Error: Exec of obj_vltmt/t_vpi_dump_no_inline/Vt_vpi_dump_no_inline failed: t (vpiModule) t  vpiDefName=t
                make && test_regress/t/t_vpi_dump_no_inline.py  --vltmt
#vltmt/t_vpi_get: %Error: Exec of obj_vltmt/t_vpi_get/Vt_vpi_get failed: ==429337==ERROR: LeakSanitizer: detected memory leaks
                make && test_regress/t/t_vpi_get.py  --vltmt
#vltmt/t_vpi_get_public_rw_switch: %Error: Exec of obj_vltmt/t_vpi_get_public_rw_switch/Vt_vpi_get failed: ==429360==ERROR: LeakSanitizer: detected memory leaks
                make && test_regress/t/t_vpi_get_public_rw_switch.py  --vltmt
#vltmt/t_vpi_memory: %Error: Exec of obj_vltmt/t_vpi_memory/Vt_vpi_memory failed: ==430243==ERROR: LeakSanitizer: detected memory leaks
                make && test_regress/t/t_vpi_memory.py  --vltmt
#vltmt/t_vpi_multidim: %Error: Exec of obj_vltmt/t_vpi_multidim/Vt_vpi_multidim failed: ==430536==ERROR: LeakSanitizer: detected memory leaks
                make && test_regress/t/t_vpi_multidim.py  --vltmt
#vltmt/t_vpi_onetime_cbs: %Error: Exec of obj_vltmt/t_vpi_onetime_cbs/Vt_vpi_onetime_cbs failed: ==430356==ERROR: LeakSanitizer: detected memory leaks
                make && test_regress/t/t_vpi_onetime_cbs.py  --vltmt
#vltmt/t_vpi_time_cb: %Error: Exec of obj_vltmt/t_vpi_time_cb/Vt_vpi_time_cb failed: ==430070==ERROR: LeakSanitizer: detected memory leaks
                make && test_regress/t/t_vpi_time_cb.py  --vltmt
#vltmt/t_vpi_var2: %Error: Exec of obj_vltmt/t_vpi_var2/Vt_vpi_var2 failed: ==430923==ERROR: LeakSanitizer: detected memory leaks
                make && test_regress/t/t_vpi_var2.py  --vltmt
#vltmt/t_vpi_var3: %Error: Exec of obj_vltmt/t_vpi_var3/Vt_vpi_var3 failed: ==430988==ERROR: LeakSanitizer: detected memory leaks
                make && test_regress/t/t_vpi_var3.py  --vltmt
#vltmt/t_vpi_var: %Error: Exec of obj_vltmt/t_vpi_var/Vt_vpi_var failed: ==430858==ERROR: LeakSanitizer: detected memory leaks
                make && test_regress/t/t_vpi_var.py  --vltmt
```