### PR TITLE
Fix timing control under fork under function

### DIFF
--- a/src/V3Fork.cpp
+++ b/src/V3Fork.cpp
@@ -286,6 +286,7 @@ class DynScopeVisitor final : public VNVisitor {
     const VNUser2InUse m_inuser2;
 
     // STATE
+    bool m_inFunc = false;  // True if in a function
     AstNodeModule* m_modp = nullptr;  // Module we are currently under
     AstNode* m_procp = nullptr;  // Function/task/block we are currently under
     std::deque<AstNode*> m_frameOrder;  // Ordered list of frames (for determinism)
@@ -367,6 +368,8 @@ class DynScopeVisitor final : public VNVisitor {
     void visit(AstNodeFTask* nodep) override {
         VL_RESTORER(m_procp);
         m_procp = nodep;
+        VL_RESTORER(m_inFunc);
+        m_inFunc = VN_IS(nodep, Func);
         if (hasAsyncFork(nodep)) pushDynScopeFrame(m_procp);
         iterateChildren(nodep);
     }
@@ -433,12 +436,20 @@ class DynScopeVisitor final : public VNVisitor {
             if (!isEvent && m_afterTimingControl && nodep->varp()->isWritable()
                 && nodep->access().isWriteOrRW()) {
                 // The output variable may not exist after a delay, so we can't just write to it
-                nodep->v3warn(
-                    E_UNSUPPORTED,
-                    "Unsupported: Writing to a captured "
-                        << (nodep->varp()->isInout() ? "inout" : "output") << " variable in a "
-                        << (VN_IS(nodep->backp(), AssignDly) ? "non-blocking assignment" : "fork")
-                        << " after a timing control");
+                if (m_inFunc) {
+                    nodep->v3error(
+                        "Writing to an "
+                        << (nodep->varp()->isInout() ? "inout" : "output")
+                        << " variable of a function after a timing control is not allowed");
+                } else {
+                    nodep->v3warn(
+                        E_UNSUPPORTED,
+                        "Unsupported: Writing to a captured "
+                            << (nodep->varp()->isInout() ? "inout" : "output") << " variable in a "
+                            << (VN_IS(nodep->backp(), AssignDly) ? "non-blocking assignment"
+                                                                 : "fork")
+                            << " after a timing control");
+                }
             }
             if (!framep->instance().initialized()) framep->createInstancePrototype();
             framep->captureVarInsert(nodep->varp());

--- a/test_regress/t/t_timing_func_fork.py
+++ b/test_regress/t/t_timing_func_fork.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2025 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile(verilator_flags2=["--binary -Wno-UNOPTFLAT"])
+
+test.passes()

--- a/test_regress/t/t_timing_func_fork.v
+++ b/test_regress/t/t_timing_func_fork.v
@@ -1,0 +1,61 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2025 by Antmicro.
+// SPDX-License-Identifier: CC0-1.0
+
+module t(/*AUTOARG*/);
+
+  function int f1;
+    fork begin
+      #1 $stop;
+    end join_none
+    f1 = 0;
+  endfunction
+
+  function int f2;
+    fork begin
+      int x;
+      x = #5 0; $stop;
+    end join_none
+    f2 = 0;
+  endfunction
+
+  event e;
+  function int f3;
+    fork begin
+      int x;
+      @e $stop;
+      x = 0;
+    end join_none
+    f3 = 0;
+  endfunction
+
+  function int f4;
+    fork begin
+      int x;
+      x = @e 0; $stop;
+    end join_none
+    f4 = 0;
+  endfunction
+
+  int i;
+
+  function int f5;
+    fork begin
+      int x;
+      wait(i == 0) $stop;
+      x = 0;
+    end join_none
+    f5 = 0;
+  endfunction
+
+  initial begin
+    fork begin
+      i = f1();
+      $write("*-* All Finished *-*\n");
+      $finish;
+    end join_none
+  end
+
+endmodule

--- a/test_regress/t/t_timing_func_fork_bad.out
+++ b/test_regress/t/t_timing_func_fork_bad.out
@@ -1,0 +1,42 @@
+%Error: t/t_timing_func_fork_bad.v:12:7: Writing to an output variable of a function after a timing control is not allowed
+                                       : ... note: In instance 't'
+   12 |       f1 = 0;
+      |       ^~
+        ... See the manual at https://verilator.org/verilator_doc.html?v=latest for more assistance.
+%Error: t/t_timing_func_fork_bad.v:13:7: Writing to an output variable of a function after a timing control is not allowed
+                                       : ... note: In instance 't'
+   13 |       o1 = 0;
+      |       ^~
+%Error: t/t_timing_func_fork_bad.v:19:7: Writing to an output variable of a function after a timing control is not allowed
+                                       : ... note: In instance 't'
+   19 |       f2 = #5 0; $stop;
+      |       ^~
+%Error: t/t_timing_func_fork_bad.v:20:7: Writing to an inout variable of a function after a timing control is not allowed
+                                       : ... note: In instance 't'
+   20 |       io2 = 0;
+      |       ^~~
+%Error: t/t_timing_func_fork_bad.v:28:7: Writing to an output variable of a function after a timing control is not allowed
+                                       : ... note: In instance 't'
+   28 |       f3 = 0;
+      |       ^~
+%Error: t/t_timing_func_fork_bad.v:29:7: Writing to an output variable of a function after a timing control is not allowed
+                                       : ... note: In instance 't'
+   29 |       o3 = 0;
+      |       ^~
+%Error: t/t_timing_func_fork_bad.v:35:7: Writing to an output variable of a function after a timing control is not allowed
+                                       : ... note: In instance 't'
+   35 |       f4 = @e 0; $stop;
+      |       ^~
+%Error: t/t_timing_func_fork_bad.v:36:7: Writing to an inout variable of a function after a timing control is not allowed
+                                       : ... note: In instance 't'
+   36 |       io4 = 0;
+      |       ^~~
+%Error: t/t_timing_func_fork_bad.v:45:7: Writing to an output variable of a function after a timing control is not allowed
+                                       : ... note: In instance 't'
+   45 |       f5 = 0;
+      |       ^~
+%Error: t/t_timing_func_fork_bad.v:46:7: Writing to an output variable of a function after a timing control is not allowed
+                                       : ... note: In instance 't'
+   46 |       o5 = 0;
+      |       ^~
+%Error: Exiting due to

--- a/test_regress/t/t_timing_func_fork_bad.py
+++ b/test_regress/t/t_timing_func_fork_bad.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2025 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile(fails=True,
+             verilator_flags2=["--binary -Wno-UNOPTFLAT"],
+             expect_filename=test.golden_filename)
+
+test.passes()

--- a/test_regress/t/t_timing_func_fork_bad.v
+++ b/test_regress/t/t_timing_func_fork_bad.v
@@ -1,0 +1,50 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2025 by Antmicro.
+// SPDX-License-Identifier: CC0-1.0
+
+module t(/*AUTOARG*/);
+
+  function int f1(output int o1);
+    fork begin
+      #1 $stop;
+      f1 = 0;
+      o1 = 0;
+    end join_none
+  endfunction
+
+  function int f2(inout io2);
+    fork begin
+      f2 = #5 0; $stop;
+      io2 = 0;
+    end join_none
+  endfunction
+
+  event e;
+  function int f3(output int o3);
+    fork begin
+      @e $stop;
+      f3 = 0;
+      o3 = 0;
+    end join_none
+  endfunction
+
+  function int f4(inout int io4);
+    fork begin
+      f4 = @e 0; $stop;
+      io4 = 0;
+    end join_none
+  endfunction
+
+  int i;
+
+  function int f5(output int o5);
+    fork begin
+      wait(i == 0) $stop;
+      f5 = 0;
+      o5 = 0;
+    end join_none
+  endfunction
+
+endmodule


### PR DESCRIPTION
Fixes spurious errors when using timing controls under a `fork..join_none` in a function.
Adds a better error message when writing to an output var after such a timing control.