### PR TITLE
CI: Run 24.04 clang build/test with --enable-asan

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -33,11 +33,12 @@ jobs:
     with:
       os: ${{ matrix.os }}
       cc: ${{ matrix.cc }}
+      asan: ${{ matrix.asan }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          - {os: ubuntu-24.04, cc: gcc}
+          - {os: ubuntu-24.04, cc: gcc, asan: 0}
 
   build-2404-clang:
     name: Build-Ubuntu
@@ -45,11 +46,12 @@ jobs:
     with:
       os: ${{ matrix.os }}
       cc: ${{ matrix.cc }}
+      asan: ${{ matrix.asan }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          - {os: ubuntu-24.04, cc: clang}
+          - {os: ubuntu-24.04, cc: clang, asan: 1}
 
   build-2204-gcc:
     name: Build-Ubuntu
@@ -57,11 +59,12 @@ jobs:
     with:
       os: ${{ matrix.os }}
       cc: ${{ matrix.cc }}
+      asan: ${{ matrix.asan }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          - {os: ubuntu-22.04, cc: gcc}
+          - {os: ubuntu-22.04, cc: gcc, asan: 0}
 
   build-2204-clang:
     name: Build-Ubuntu
@@ -69,11 +72,12 @@ jobs:
     with:
       os: ${{ matrix.os }}
       cc: ${{ matrix.cc }}
+      asan: ${{ matrix.asan }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          - {os: ubuntu-22.04, cc: clang}
+          - {os: ubuntu-22.04, cc: clang, asan: 0}
 
   build-osx-gcc:
     name: Build-OSX
@@ -82,11 +86,12 @@ jobs:
       os: ${{ matrix.os }}
       os-name: osx
       cc: ${{ matrix.cc }}
+      asan: ${{ matrix.asan }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          - {os: macos-15, cc: gcc}
+          - {os: macos-15, cc: gcc, asan: 0}
 
   build-osx-clang:
     name: Build-OSX
@@ -95,11 +100,12 @@ jobs:
       os: ${{ matrix.os }}
       os-name: osx
       cc: ${{ matrix.cc }}
+      asan: ${{ matrix.asan }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          - {os: macos-15, cc: clang}
+          - {os: macos-15, cc: clang, asan: 0}
 
   build-windows:
     name: Build-Windows

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -17,6 +17,9 @@ on:
         required: false
         type: string
         default: linux
+      asan:
+        required: true
+        type: number
 
 env:
   CI_OS_NAME: ${{ inputs.os-name }}
@@ -38,6 +41,7 @@ jobs:
     runs-on: ${{ inputs.os }}
     name: Sub-build | ${{ inputs.os }} | ${{ inputs.cc }}
     env:
+      CI_ASAN: ${{ inputs.asan }}
       CI_BUILD_STAGE_NAME: build
       CI_RUNS_ON: ${{ inputs.os }}
       CC: ${{ inputs.cc }}

--- a/ci/ci-script.bash
+++ b/ci/ci-script.bash
@@ -41,7 +41,11 @@ if [ "$CI_BUILD_STAGE_NAME" = "build" ]; then
 
   if [ "$COVERAGE" != 1 ]; then
     autoconf
-    ./configure --enable-longtests --enable-ccwarn --prefix="$INSTALL_DIR"
+    CONFIGURE_ARGS="--enable-longtests --enable-ccwarn"
+    if [ "$CI_ASAN" = 1 ]; then
+      CONFIGURE_ARGS="$CONFIGURE_ARGS --enable-asan"
+    fi
+    ./configure $CONFIGURE_ARGS --prefix="$INSTALL_DIR"
     ccache -z
     "$MAKE" -j "$NPROC" -k
     # 22.04: ccache -s -v


### PR DESCRIPTION
Draft as depends on #6406

The overall job latency in the CI seems to be similar as before. Building verilator is ~3 minutes extra (thought that might just be a cache effect). Running the tests is roughly the same overall. Seems to me this is well worth having.