### PR TITLE
Fix resolving parameters (#6388) (#6418) (#6421) (#6438)

### DIFF
--- a/test_regress/t/t_bug6421.py
+++ b/test_regress/t/t_bug6421.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2025 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('vlt')
+
+test.compile(verilator_flags=["--binary"])
+
+test.passes()

--- a/test_regress/t/t_bug6421.v
+++ b/test_regress/t/t_bug6421.v
@@ -1,0 +1,38 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2025 by Antmicro.
+// SPDX-License-Identifier: CC0-1.0
+
+package uvm_pkg;
+class uvm_queue #(type T=int);
+endclass
+class m_uvm_waiter;
+endclass
+class uvm_config_db#(type T=int);
+  static local uvm_queue#(m_uvm_waiter) m_waiters[string];
+  static function void set(int a, string b, string c, int d);
+  endfunction
+endclass
+endpackage
+package sfr_agent_pkg;
+class sfr_monitor_abstract;
+endclass
+endpackage: sfr_agent_pkg
+module sfr_monitor_bfm  #(ADDR_WIDTH = 8,
+                          DATA_WIDTH = 8)
+                        (
+                         input [ADDR_WIDTH-1:0] address);
+  import uvm_pkg::*;
+  import sfr_agent_pkg::*; int SFR_MONITOR;
+initial begin
+  uvm_config_db #(sfr_monitor_abstract)::set(null, "uvm_test_top", "SFR_MONITOR", SFR_MONITOR);
+end
+endmodule: sfr_monitor_bfm
+module hdl_top;
+parameter DATA_WIDTH = 32;
+parameter ADDR_WIDTH = 32;
+sfr_monitor_bfm #(.ADDR_WIDTH(ADDR_WIDTH),
+                  .DATA_WIDTH(DATA_WIDTH)) SFR_MONITOR(
+                                                        .address(42));
+endmodule


### PR DESCRIPTION
My latest [PR](https://github.com/verilator/verilator/pull/6421) unfortunately introduced another regression, the test I am adding here was failing due to:
```
%Error: Internal Error: test.sv:7:16: ../V3LinkDot.cpp:2997: class reference parameter not removed by V3Param
                                    : ... note: In instance 'hdl_top.SFR_MONITOR'
    7 |   static local uvm_queue#(m_uvm_waiter) m_waiters[string];
```
This PR fixes that issue. Hopefully there will be no more uncaught regressions here.