### PR TITLE
Optimization: deadify functions in more cases.

### DIFF
--- a/test_regress/t/t_opt_dead_task.py
+++ b/test_regress/t/t_opt_dead_task.py
@@ -14,7 +14,7 @@ test.scenarios('simulator')
 test.compile(verilator_flags2=["--stats"])
 
 if test.vlt_all:
-    test.file_grep(test.stats, r'Optimizations, deadified FTasks\s+(\d+)', 2)
+    test.file_grep(test.stats, r'Optimizations, deadified FTasks\s+(\d+)', 6)
 
 test.execute()
 

--- a/test_regress/t/t_opt_dead_task.v
+++ b/test_regress/t/t_opt_dead_task.v
@@ -22,7 +22,21 @@ module t (input clk);
 
    // These should be deadified
    function deadfunc();
+      deeptask2();
    endfunction
    task deadtask;
+      deeptask1();
+   endtask
+   // A chain of dead tasks calling each other to ensure V3Dead can remove chained dead tasks
+   task deeptask1;
+      deeptask2();
+   endtask
+   task deeptask2;
+      deeptask3();
+   endtask
+   task deeptask3;
+      deeptask4();
+   endtask
+   task deeptask4;
    endtask
 endmodule


### PR DESCRIPTION
Follow up to [#6380](https://github.com/verilator/verilator/pull/6380). Deadify functions in more cases, this allows deadifying functions up to 3 levels deep (function called in a dead function called in a dead function), since the stage is executed 3 times instead of just 1 time.