### PR TITLE
Support modports referencing clocking blocks (#4555)

### DIFF
--- a/src/V3AssertPre.cpp
+++ b/src/V3AssertPre.cpp
@@ -167,7 +167,7 @@ private:
                 AstModportVarRef* const modVarp
                     = new AstModportVarRef{nodep->fileline(), varp->name(), itemp->direction()};
                 modVarp->varp(varp);
-                AstNode::addNext(static_cast<AstNode*>(nodep), modVarp);
+                nodep->addNextHere(modVarp);
             }
         }
         VL_DO_DANGLING(pushDeletep(nodep->unlinkFrBack()), nodep);

--- a/src/V3AssertPre.cpp
+++ b/src/V3AssertPre.cpp
@@ -38,6 +38,7 @@ class AssertPreVisitor final : public VNVisitor {
     // We're not parsing the tree, or anything more complicated.
 private:
     // NODE STATE
+    // AstClockingItem::user1p()         // AstVar*.      varp() of ClockingItem after unlink
     const VNUser1InUse m_inuser1;
     // STATE
     // Current context:
@@ -157,8 +158,8 @@ private:
         VL_DO_DANGLING(pushDeletep(nodep->unlinkFrBack()), nodep);
     }
     void visit(AstModportClockingRef* const nodep) override {
-        // They have to be removed, because contain references to clocking blocks,
-        // which are removed too. They aren't needed anyway.
+        // It has to be converted to a list of ModportClockingVarRefs,
+        // because clocking blocks are removed in this pass
         for (AstClockingItem* itemp = nodep->clockingp()->itemsp(); itemp;
              itemp = VN_AS(itemp->nextp(), ClockingItem)) {
             AstVar* const varp = itemp->varp() ? itemp->varp() : VN_AS(itemp->user1p(), Var);

--- a/src/V3AssertPre.cpp
+++ b/src/V3AssertPre.cpp
@@ -156,6 +156,11 @@ private:
         if (nodep->eventp()) nodep->addNextHere(nodep->eventp()->unlinkFrBack());
         VL_DO_DANGLING(pushDeletep(nodep->unlinkFrBack()), nodep);
     }
+    void visit(AstModportClockingRef* const nodep) override {
+        // They have to be removed, because contain references to clocking blocks,
+        // which are removed too. They aren't needed anyway.
+        VL_DO_DANGLING(pushDeletep(nodep->unlinkFrBack()), nodep);
+    }
     void visit(AstClockingItem* const nodep) override {
         // Get a ref to the sampled/driven variable
         AstVar* const varp = nodep->varp();

--- a/src/V3AstNodeOther.h
+++ b/src/V3AstNodeOther.h
@@ -1212,7 +1212,9 @@ public:
     ASTGEN_MEMBERS_AstModportClockingRef;
     void dump(std::ostream& str) const override;
     string name() const override VL_MT_STABLE { return m_name; }
-    AstClocking* clockingp() const VL_MT_STABLE { return m_clockingp; }  // [After Link] Pointer to clocking block
+    AstClocking* clockingp() const VL_MT_STABLE {
+        return m_clockingp;
+    }  // [After Link] Pointer to clocking block
     void clockingp(AstClocking* clockingp) { m_clockingp = clockingp; }
 };
 class AstModportFTaskRef final : public AstNode {

--- a/src/V3AstNodeOther.h
+++ b/src/V3AstNodeOther.h
@@ -1198,6 +1198,23 @@ public:
     bool maybePointedTo() const override VL_MT_SAFE { return true; }
     ASTGEN_MEMBERS_AstModport;
 };
+class AstModportClockingRef final : public AstNode {
+    // A clocking block referenced under a modport
+    // The storage for the variable itself is inside the interface, thus this is a reference
+    // PARENT: AstModport
+    //
+    // @astgen ptr := m_clockingp : Optional[AstClocking]  // Link to the actual clocking block
+    string m_name;  // Name of the clocking block referenced
+public:
+    AstModportClockingRef(FileLine* fl, const string& name)
+        : ASTGEN_SUPER_ModportClockingRef(fl)
+        , m_name{name} {}
+    ASTGEN_MEMBERS_AstModportClockingRef;
+    void dump(std::ostream& str) const override;
+    string name() const override VL_MT_STABLE { return m_name; }
+    AstClocking* clockingp() const VL_MT_STABLE { return m_clockingp; }  // [After Link] Pointer to clocking block
+    void clockingp(AstClocking* clockingp) { m_clockingp = clockingp; }
+};
 class AstModportFTaskRef final : public AstNode {
     // An import/export referenced under a modport
     // The storage for the function itself is inside the

--- a/src/V3AstNodeOther.h
+++ b/src/V3AstNodeOther.h
@@ -1201,7 +1201,7 @@ public:
 };
 class AstModportClockingRef final : public AstNode {
     // A clocking block referenced under a modport
-    // The storage for the variable itself is inside the interface, thus this is a reference
+    // The storage for the clocking block itself is inside the interface, thus this is a reference
     // PARENT: AstModport
     //
     // @astgen ptr := m_clockingp : Optional[AstClocking]  // Link to the actual clocking block

--- a/src/V3AstNodeOther.h
+++ b/src/V3AstNodeOther.h
@@ -826,6 +826,7 @@ public:
         addItemsp(itemsp);
     }
     ASTGEN_MEMBERS_AstClocking;
+    bool maybePointedTo() const override VL_MT_SAFE { return true; }
     void dump(std::ostream& str) const override;
     void dumpJson(std::ostream& str) const override;
     std::string name() const override VL_MT_STABLE { return m_name; }

--- a/src/V3AstNodes.cpp
+++ b/src/V3AstNodes.cpp
@@ -2082,6 +2082,15 @@ void AstMemberSel::dump(std::ostream& str) const {
     }
 }
 void AstMemberSel::dumpJson(std::ostream& str) const { dumpJsonGen(str); }
+void AstModportClockingRef::dump(std::ostream& str) const {
+    this->AstNode::dump(str);
+    if (clockingp()) {
+        str << " -> ";
+        clockingp()->dump(str);
+    } else {
+        str << " -> UNLINKED";
+    }
+}
 void AstModportFTaskRef::dump(std::ostream& str) const {
     this->AstNode::dump(str);
     if (isExport()) str << " EXPORT";

--- a/src/V3LinkDot.cpp
+++ b/src/V3LinkDot.cpp
@@ -3974,7 +3974,11 @@ class LinkDotResolveVisitor final : public VNVisitor {
                         dotSymp = m_statep->getNodeSym(ifaceRefp->ifacep());
                     }
                 }
+            } else if (const AstModportClockingRef* const clockingRefp
+                       = VN_CAST(dotSymp->nodep(), ModportClockingRef)) {
+                dotSymp = m_statep->getNodeSym(clockingRefp->clockingp());
             }
+
             if (!m_statep->forScopeCreation()) {
                 VSymEnt* foundp = nullptr;
                 if (modport) {

--- a/src/V3LinkDot.cpp
+++ b/src/V3LinkDot.cpp
@@ -2404,6 +2404,19 @@ class LinkDotIfaceVisitor final : public VNVisitor {
             VL_DO_DANGLING(pushDeletep(nodep), nodep);
         }
     }
+    void visit(AstModportClockingRef* nodep) override {  // IfaceVisitor::
+        UINFO(5, "   fic: " << nodep);
+        iterateChildren(nodep);
+        VSymEnt* const symp = m_curSymp->findIdFallback(nodep->name());
+        if (!symp) {
+            nodep->v3error("Modport item not found: " << nodep->prettyNameQ());
+        } else if (AstClocking* const clockingp = VN_CAST(symp->nodep(), Clocking)) {
+            nodep->clockingp(clockingp);
+        } else {
+            nodep->v3error(
+                "Modport item doesn't reference a clocking block: " << nodep->prettyNameQ());
+        }
+    }
     void visit(AstNode* nodep) override { iterateChildren(nodep); }  // IfaceVisitor::
 
 public:

--- a/src/V3LinkDot.cpp
+++ b/src/V3LinkDot.cpp
@@ -2412,6 +2412,7 @@ class LinkDotIfaceVisitor final : public VNVisitor {
             nodep->v3error("Modport item not found: " << nodep->prettyNameQ());
         } else if (AstClocking* const clockingp = VN_CAST(symp->nodep(), Clocking)) {
             nodep->clockingp(clockingp);
+            m_statep->insertSym(m_curSymp, nodep->name(), nodep, nullptr /*package*/);
         } else {
             nodep->v3error("Modport item is not a clocking block: " << nodep->prettyNameQ());
         }

--- a/src/V3LinkDot.cpp
+++ b/src/V3LinkDot.cpp
@@ -2413,8 +2413,7 @@ class LinkDotIfaceVisitor final : public VNVisitor {
         } else if (AstClocking* const clockingp = VN_CAST(symp->nodep(), Clocking)) {
             nodep->clockingp(clockingp);
         } else {
-            nodep->v3error(
-                "Modport item doesn't reference a clocking block: " << nodep->prettyNameQ());
+            nodep->v3error("Modport item is not a clocking block: " << nodep->prettyNameQ());
         }
     }
     void visit(AstNode* nodep) override { iterateChildren(nodep); }  // IfaceVisitor::

--- a/src/verilog.y
+++ b/src/verilog.y
@@ -1655,8 +1655,7 @@ modportPortsDecl<nodep>:
                 port_direction modportSimplePortOrTFPort { $$ = new AstModportVarRef{$<fl>2, *$2, GRAMMARP->m_varIO};
                                                            GRAMMARP->m_modportImpExpActive = false;}
         //                      // IEEE: modport_clocking_declaration
-        |       yCLOCKING idAny/*clocking_identifier*/
-                        { $$ = nullptr; BBUNSUP($<fl>1, "Unsupported: Modport clocking"); }
+        |       yCLOCKING idAny/*clocking_identifier*/ { $$ = new AstModportClockingRef{$1, *$2}; }
         //                      // IEEE: yIMPORT modport_tf_port
         //                      // IEEE: yEXPORT modport_tf_port
         //                      // modport_tf_port expanded here

--- a/test_regress/t/t_dist_warn_coverage.py
+++ b/test_regress/t/t_dist_warn_coverage.py
@@ -51,8 +51,6 @@ for s in [
         'Interface port declaration ',
         'Modport item is not a function/task: ',
         'Modport item is not a variable: ',
-        'Modport item is not a clocking block: ',
-        'Modport item not found: ',
         'Modport not referenced as <interface>.',
         'Modport not referenced from underneath an interface: ',
         'Non-interface used as an interface: ',
@@ -78,7 +76,6 @@ for s in [
         'Unsupported: 4-state numbers in this context',
         'Unsupported: Bind with instance list',
         'Unsupported: Concatenation to form ',
-        'Unsupported: Modport clocking',
         'Unsupported: Modport dotted port name',
         'Unsupported: Modport export with prototype',
         'Unsupported: Modport import with prototype',
@@ -106,7 +103,6 @@ for s in [
         'Unsupported: repeat event control',
         'Unsupported: static cast to ',
         'Unsupported: super',
-        'Unsupported: this.super',
         'Unsupported: with[] stream expression',
 ]:
     Suppressed[s] = True

--- a/test_regress/t/t_dist_warn_coverage.py
+++ b/test_regress/t/t_dist_warn_coverage.py
@@ -51,6 +51,7 @@ for s in [
         'Interface port declaration ',
         'Modport item is not a function/task: ',
         'Modport item is not a variable: ',
+        'Modport item is not a clocking block: ',
         'Modport item not found: ',
         'Modport not referenced as <interface>.',
         'Modport not referenced from underneath an interface: ',

--- a/test_regress/t/t_mod_interface_clocking.py
+++ b/test_regress/t/t_mod_interface_clocking.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2024 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile(verilator_flags2=["--binary"])
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_mod_interface_clocking.v
+++ b/test_regress/t/t_mod_interface_clocking.v
@@ -1,0 +1,48 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2025 by Antmicro.
+// SPDX-License-Identifier: CC0-1.0
+
+interface axi_if;
+  logic clk;
+  wire  rlast;
+  wire  rvalid;
+  clocking cb @(posedge clk);
+    inout rlast, rvalid;
+  endclocking
+  modport mcb(clocking cb, inout clk, rlast, rvalid);
+endinterface
+
+module sub (
+    axi_if.mcb axi_vi
+);
+  initial begin
+    axi_vi.clk = 1'b0;
+    #1 axi_vi.clk = 1'b1;  // triggers line 26
+    #1 axi_vi.clk = 1'b0;  // triggers line 29 (shouldn't happen)
+    #1 axi_vi.clk = 1'b1;  // triggers line 18 (shouldn't happen)
+  end
+  initial begin
+    @(negedge axi_vi.rvalid);
+    $display("[%0t] rvalid==%b", $time, axi_vi.rvalid);
+    $display("[%0t] rlast is 1: ", $time, axi_vi.rlast === 1);
+    if (axi_vi.rlast === 1) $stop;
+    $write("*-* All Finished *-*\n");
+    $finish;
+  end
+  initial begin
+    $display("[%0t] rvalid <= 1", $time);
+    axi_vi.cb.rvalid <= 1'b1;  // assigned on first clk posedge (line 13)
+    @(posedge axi_vi.rvalid);
+    $display("[%0t] rvalid <= 0", $time);
+    axi_vi.cb.rvalid <= 1'b0;  // assigned on second clk posedge (line 15), but should be on first
+    @(negedge axi_vi.clk);
+    $display("[%0t] rlast <= 1", $time);
+    axi_vi.cb.rlast <= 1'b1;  // assigned on second clk posedge (line 15), shouldn't happen
+  end
+endmodule
+module t;
+  axi_if axi_vi ();
+  sub i_sub (axi_vi);
+endmodule

--- a/test_regress/t/t_mod_interface_clocking.v
+++ b/test_regress/t/t_mod_interface_clocking.v
@@ -11,39 +11,41 @@ interface axi_if;
   clocking cb @(posedge clk);
     inout rlast, rvalid;
   endclocking
-  modport mcb(clocking cb, inout clk, rlast, rvalid);
+  modport md1(clocking cb, inout clk, rlast, rvalid);
+  modport md2(clocking cb);
 endinterface
 
 module sub (
-    axi_if.mcb axi_vi
+    axi_if.md1 axi1,
+    axi_if.md2 axi2
 );
   initial begin
-    axi_vi.clk = 1'b0;
-    #1 axi_vi.clk = 1'b1;
-    #1 axi_vi.clk = 1'b0;
-    #1 axi_vi.clk = 1'b1;
+    axi1.clk = 1'b0;
+    #1 axi1.clk = 1'b1;
+    #1 axi1.clk = 1'b0;
+    #1 axi1.clk = 1'b1;
   end
   initial begin
-    @(negedge axi_vi.rvalid);
-    $display("[%0t] rvalid==%b", $time, axi_vi.rvalid);
-    $display("[%0t] rlast is 1: ", $time, axi_vi.rlast === 1);
-    if (axi_vi.rlast === 1) $stop;
+    @(negedge axi1.rvalid);
+    $display("[%0t] rvalid==%b", $time, axi1.rvalid);
+    $display("[%0t] rlast is 1: ", $time, axi1.rlast === 1);
+    if (axi1.rlast === 1) $stop;
     $write("*-* All Finished *-*\n");
     $finish;
   end
   initial begin
     $display("[%0t] rvalid <= 1", $time);
-    axi_vi.cb.rvalid <= 1'b1;
-    @(posedge axi_vi.rvalid);
+    axi1.cb.rvalid <= 1'b1;
+    @(posedge axi1.rvalid);
     $display("[%0t] rvalid <= 0", $time);
-    axi_vi.cb.rvalid <= 1'b0;
-    @(negedge axi_vi.clk);
+    axi1.cb.rvalid <= 1'b0;
+    @(negedge axi1.clk);
     $display("[%0t] rlast <= 1", $time);
-    axi_vi.cb.rlast <= 1'b1;
+    axi2.cb.rlast <= 1'b1;
   end
 endmodule
 
 module t;
   axi_if axi_vi ();
-  sub i_sub (axi_vi);
+  sub i_sub (.axi1(axi_vi), .axi2(axi_vi));
 endmodule

--- a/test_regress/t/t_mod_interface_clocking.v
+++ b/test_regress/t/t_mod_interface_clocking.v
@@ -19,9 +19,9 @@ module sub (
 );
   initial begin
     axi_vi.clk = 1'b0;
-    #1 axi_vi.clk = 1'b1;  // triggers line 26
-    #1 axi_vi.clk = 1'b0;  // triggers line 29 (shouldn't happen)
-    #1 axi_vi.clk = 1'b1;  // triggers line 18 (shouldn't happen)
+    #1 axi_vi.clk = 1'b1;
+    #1 axi_vi.clk = 1'b0;
+    #1 axi_vi.clk = 1'b1;
   end
   initial begin
     @(negedge axi_vi.rvalid);
@@ -33,15 +33,16 @@ module sub (
   end
   initial begin
     $display("[%0t] rvalid <= 1", $time);
-    axi_vi.cb.rvalid <= 1'b1;  // assigned on first clk posedge (line 13)
+    axi_vi.cb.rvalid <= 1'b1;
     @(posedge axi_vi.rvalid);
     $display("[%0t] rvalid <= 0", $time);
-    axi_vi.cb.rvalid <= 1'b0;  // assigned on second clk posedge (line 15), but should be on first
+    axi_vi.cb.rvalid <= 1'b0;
     @(negedge axi_vi.clk);
     $display("[%0t] rlast <= 1", $time);
-    axi_vi.cb.rlast <= 1'b1;  // assigned on second clk posedge (line 15), shouldn't happen
+    axi_vi.cb.rlast <= 1'b1;
   end
 endmodule
+
 module t;
   axi_if axi_vi ();
   sub i_sub (axi_vi);

--- a/test_regress/t/t_mod_interface_clocking_bad.out
+++ b/test_regress/t/t_mod_interface_clocking_bad.out
@@ -1,5 +1,11 @@
+%Error: t/t_mod_interface_clocking_bad.v:16:25: Modport item is not a clocking block: 'reset'
+   16 |   modport mp(input clk, clocking reset, clocking cx);
+      |                         ^~~~~~~~
+        ... See the manual at https://verilator.org/verilator_doc.html?v=latest for more assistance.
+%Error: t/t_mod_interface_clocking_bad.v:16:41: Modport item not found: 'cx'
+   16 |   modport mp(input clk, clocking reset, clocking cx);
+      |                                         ^~~~~~~~
 %Error: t/t_mod_interface_clocking_bad.v:25:10: Can't find definition of 'cb'
    25 |     x.cb.reset <= 1;
       |          ^~~~~
-        ... See the manual at https://verilator.org/verilator_doc.html?v=latest for more assistance.
 %Error: Exiting due to

--- a/test_regress/t/t_mod_interface_clocking_bad.v
+++ b/test_regress/t/t_mod_interface_clocking_bad.v
@@ -13,7 +13,7 @@ interface mem_if (
     output reset;
   endclocking
 
-  modport mp(input clk);
+  modport mp(input clk, clocking reset, clocking cx);
 
 endinterface
 


### PR DESCRIPTION
It fixes #4555.
First it links clocking block references similar to how variables in modports are linked. Then it replaces them with lists of variables in V3AssertPre, when clocking blocks are replaced with variables and other constructs.
