### PR TITLE
Fix bug #6431, relink super functions to default instances of parametrized classes.

### DIFF
--- a/src/V3AstNodes.cpp
+++ b/src/V3AstNodes.cpp
@@ -463,7 +463,7 @@ void AstNetlist::timeprecisionMerge(FileLine*, const VTimescale& value) {
 }
 
 void AstNew::dump(std::ostream& str) const {
-    this->AstNode::dump(str);
+    this->AstNodeFTaskRef::dump(str);
     if (isImplicit()) str << " [IMPLICIT]";
     if (isScoped()) str << " [SCOPED]";
 }

--- a/test_regress/t/t_class_param_super.py
+++ b/test_regress/t/t_class_param_super.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2025 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('vlt')
+
+test.compile()
+
+test.passes()

--- a/test_regress/t/t_class_param_super.v
+++ b/test_regress/t/t_class_param_super.v
@@ -1,0 +1,18 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2025 by Antmicro.
+// SPDX-License-Identifier: CC0-1.0
+
+class base #(
+   type T = int
+);
+   function void fbase();
+   endfunction
+endclass
+
+class ext extends base;
+   function fext();
+      super.fbase();
+   endfunction
+endclass


### PR DESCRIPTION
This fixes a regression from [PR#6388](https://github.com/verilator/verilator/pull/6388), it failed when a class with default parameters was extended by another class, which called `super.new()`. In fact, calling any super function from a class that extends a parametrized class would fail. I fixed that and added a regression test in this PR.