### PR TITLE
Add cast in gdbinit.py

### DIFF
--- a/src/.gdbinit.py
+++ b/src/.gdbinit.py
@@ -16,7 +16,7 @@ import gdb  # pylint: disable=import-error
 def _vltgdb_get_dump(node):
     gdb.execute(f'set $_gdb_dump_json_str = AstNode::dumpTreeJsonGdb({node})')
     dump = gdb.execute('printf "%s", $_gdb_dump_json_str', to_string=True)
-    gdb.execute('call free($_gdb_dump_json_str)')
+    gdb.execute('call (void)free($_gdb_dump_json_str)')
     return dump
 
 


### PR DESCRIPTION
Add a cast in `src/.gdbinit.py` necessary for GDB to work properly without an error. This is required for `t_gdb_jtree` from [verilator_ext_tests](https://github.com/verilator/verilator_ext_tests).