### PR TITLE
Internals: modernize VL_RESTORER

### DIFF
--- a/src/V3Global.h
+++ b/src/V3Global.h
@@ -46,8 +46,7 @@ class V3ThreadPool;
 /// Save a given variable's value on the stack, restoring it at end-of-scope.
 // Object must be named, or it will not persist until end-of-scope.
 // Constructor needs () or GCC 4.8 false warning.
-#define VL_RESTORER(var) \
-    const VRestorer<typename std::decay<decltype(var)>::type> restorer_##var(var);
+#define VL_RESTORER(var) const VRestorer<typename std::decay_t<decltype(var)>> restorer_##var(var);
 /// Get the copy of the variable previously saved by VL_RESTORER()
 #define VL_RESTORER_PREV(var) restorer_##var.saved()
 


### PR DESCRIPTION
Gets rid of a clang-tidy warning: `Use c++14 style type templates [modernize-type-traits]` by using `std::decay_t<>` instead of `std::decay<>::type`
