### PR TITLE
[#83823] Resolve dtype in V3Width on AstMethodCall, fix #6412

### DIFF
--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -3313,10 +3313,13 @@ class WidthVisitor final : public VNVisitor {
                     VL_DO_DANGLING(pushDeletep(nodep), nodep);
                     return true;
                 }
-                if (VN_IS(foundp, NodeFTask)) {
-                    nodep->replaceWith(new AstMethodCall{nodep->fileline(),
-                                                         nodep->fromp()->unlinkFrBack(),
-                                                         nodep->name(), nullptr});
+                if (AstNodeFTask* ftaskp = VN_CAST(foundp, NodeFTask)) {
+                    AstMethodCall* newp = new AstMethodCall{
+                        nodep->fileline(), nodep->fromp()->unlinkFrBack(), nodep->name(), nullptr};
+                    newp->taskp(ftaskp);
+                    newp->dtypep(ftaskp->dtypep());
+                    newp->classOrPackagep(classp);
+                    nodep->replaceWith(newp);
                     VL_DO_DANGLING(pushDeletep(nodep), nodep);
                     return true;
                 }

--- a/test_regress/t/t_func_ref_noparen.py
+++ b/test_regress/t/t_func_ref_noparen.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2025 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('vlt')
+
+test.compile()
+
+test.passes()

--- a/test_regress/t/t_func_ref_noparen.v
+++ b/test_regress/t/t_func_ref_noparen.v
@@ -1,0 +1,17 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2025 by Antmicro.
+// SPDX-License-Identifier: CC0-1.0
+
+class c;
+   function f();
+   endfunction
+endclass
+module t;
+   c cinst;
+   initial begin
+      cinst = new();
+      if(cinst.f) begin end
+   end
+endmodule


### PR DESCRIPTION
Assign `dtypep` and `taskp` of `AstMethodCall` correctly in V3Width. Added a test to ensure that works. Fixes #6412.