### PR TITLE
Fix segfault on unsupported PLI calls

### DIFF
--- a/src/verilog.l
+++ b/src/verilog.l
@@ -50,7 +50,7 @@
 
 #define STR \
     do { \
-        const string str (yytext, yyleng); \
+        const string str(yytext, yyleng); \
         yylval.strp = PARSEP->newString(AstNode::encodeName(str)); \
     } while (false)
 

--- a/src/verilog.l
+++ b/src/verilog.l
@@ -48,6 +48,12 @@
         yylval.fl = CRELINE(); \
     } while (false)
 
+#define STR \
+    do { \
+        const string str (yytext, yyleng); \
+        yylval.strp = PARSEP->newString(AstNode::encodeName(str)); \
+    } while (false)
+
 #define ERROR_RSVD_WORD(language) \
     do { \
         yylval.fl->v3warn(E_UNSUPPORTED, "Unsupported: " << language \
@@ -257,11 +263,11 @@ vnum    {vnum1}|{vnum2}|{vnum3}|{vnum4}|{vnum5}
   "$psprintf"           { FL; yylval.fl->v3warn(NONSTD, "Non-standard system function '" << yytext << "';"
                                                 " suggest use standard '$sformatf' (IEEE 1800-2023 21.3.3)");
                           return yD_SFORMATF; }
-  "$q_add"              { FL; ERROR_RSVD_WORD("IEEE 1364-1995"); return yaD_PLI; }
-  "$q_exam"             { FL; ERROR_RSVD_WORD("IEEE 1364-1995"); return yaD_PLI; }
-  "$q_full"             { FL; ERROR_RSVD_WORD("IEEE 1364-1995"); return yaD_PLI; }
-  "$q_initialize"       { FL; ERROR_RSVD_WORD("IEEE 1364-1995"); return yaD_PLI; }
-  "$q_remove"           { FL; ERROR_RSVD_WORD("IEEE 1364-1995"); return yaD_PLI; }
+  "$q_add"              { FL; STR; ERROR_RSVD_WORD("IEEE 1364-1995"); return yaD_PLI; }
+  "$q_exam"             { FL; STR; ERROR_RSVD_WORD("IEEE 1364-1995"); return yaD_PLI; }
+  "$q_full"             { FL; STR; ERROR_RSVD_WORD("IEEE 1364-1995"); return yaD_PLI; }
+  "$q_initialize"       { FL; STR; ERROR_RSVD_WORD("IEEE 1364-1995"); return yaD_PLI; }
+  "$q_remove"           { FL; STR; ERROR_RSVD_WORD("IEEE 1364-1995"); return yaD_PLI; }
   "$random"             { FL; return yD_RANDOM; }
   "$readmemb"           { FL; return yD_READMEMB; }
   "$readmemh"           { FL; return yD_READMEMH; }
@@ -478,11 +484,11 @@ vnum    {vnum1}|{vnum2}|{vnum3}|{vnum4}|{vnum5}
   "$changing_gclk"      { FL; return yD_CHANGING_GCLK; }
   "$countbits"          { FL; return yD_COUNTBITS; }
   "$countones"          { FL; return yD_COUNTONES; }
-  "$coverage_control"   { FL; ERROR_RSVD_WORD("IEEE 1800-2005"); return yaD_PLI; }
-  "$coverage_get"       { FL; ERROR_RSVD_WORD("IEEE 1800-2005"); return yaD_PLI; }
-  "$coverage_get_max"   { FL; ERROR_RSVD_WORD("IEEE 1800-2005"); return yaD_PLI; }
-  "$coverage_merge"     { FL; ERROR_RSVD_WORD("IEEE 1800-2005"); return yaD_PLI; }
-  "$coverage_save"      { FL; ERROR_RSVD_WORD("IEEE 1800-2005"); return yaD_PLI; }
+  "$coverage_control"   { FL; STR; ERROR_RSVD_WORD("IEEE 1800-2005"); return yaD_PLI; }
+  "$coverage_get"       { FL; STR; ERROR_RSVD_WORD("IEEE 1800-2005"); return yaD_PLI; }
+  "$coverage_get_max"   { FL; STR; ERROR_RSVD_WORD("IEEE 1800-2005"); return yaD_PLI; }
+  "$coverage_merge"     { FL; STR; ERROR_RSVD_WORD("IEEE 1800-2005"); return yaD_PLI; }
+  "$coverage_save"      { FL; STR; ERROR_RSVD_WORD("IEEE 1800-2005"); return yaD_PLI; }
   "$dimensions"         { FL; return yD_DIMENSIONS; }
   "$error"              { FL; return yD_ERROR; }
   "$falling_gclk"       { FL; return yD_FALLING_GCLK; }
@@ -490,16 +496,16 @@ vnum    {vnum1}|{vnum2}|{vnum3}|{vnum4}|{vnum5}
   "$fell"               { FL; return yD_FELL; }
   "$fell_gclk"          { FL; return yD_FELL_GCLK; }
   "$future_gclk"        { FL; return yD_FUTURE_GCLK; }
-  "$get_coverage"       { FL; ERROR_RSVD_WORD("IEEE 1800-2005"); return yaD_PLI; }
+  "$get_coverage"       { FL; STR; ERROR_RSVD_WORD("IEEE 1800-2005"); return yaD_PLI; }
   "$high"               { FL; return yD_HIGH; }
   "$increment"          { FL; return yD_INCREMENT; }
-  "$inferred_clock"     { FL; ERROR_RSVD_WORD("IEEE 1800-2005"); return yaD_PLI; }
+  "$inferred_clock"     { FL; STR; ERROR_RSVD_WORD("IEEE 1800-2005"); return yaD_PLI; }
   "$inferred_disable"   { FL; return yD_INFERRED_DISABLE; }
   "$info"               { FL; return yD_INFO; }
   "$isunbounded"        { FL; return yD_ISUNBOUNDED; }
   "$isunknown"          { FL; return yD_ISUNKNOWN; }
   "$left"               { FL; return yD_LEFT; }
-  "$load_coverage_db"   { FL; ERROR_RSVD_WORD("IEEE 1800-2005"); return yaD_PLI; }
+  "$load_coverage_db"   { FL; STR; ERROR_RSVD_WORD("IEEE 1800-2005"); return yaD_PLI; }
   "$low"                { FL; return yD_LOW; }
   "$onehot"             { FL; return yD_ONEHOT; }
   "$onehot0"            { FL; return yD_ONEHOT0; }
@@ -510,7 +516,7 @@ vnum    {vnum1}|{vnum2}|{vnum3}|{vnum4}|{vnum5}
   "$root"               { FL; return yD_ROOT; }
   "$rose"               { FL; return yD_ROSE; }
   "$rose_gclk"          { FL; return yD_ROSE_GCLK; }
-  "$set_coverage_db_name" { FL; ERROR_RSVD_WORD("IEEE 1800-2005"); return yaD_PLI; }
+  "$set_coverage_db_name" { FL; STR; ERROR_RSVD_WORD("IEEE 1800-2005"); return yaD_PLI; }
   "$size"               { FL; return yD_SIZE; }
   "$stable"             { FL; return yD_STABLE; }
   "$stable_gclk"        { FL; return yD_STABLE_GCLK; }
@@ -673,10 +679,7 @@ vnum    {vnum1}|{vnum2}|{vnum3}|{vnum4}|{vnum5}
 
   /* Default PLI rule */
 <V95,V01NC,V01C,V05,VA5,S05,S09,S12,S17,S23,SAX>{
-  "$"[a-zA-Z0-9_$]+     { const string str (yytext, yyleng);
-                          yylval.strp = PARSEP->newString(AstNode::encodeName(str));
-                          FL; return yaD_PLI;
-                        }
+  "$"[a-zA-Z0-9_$]+     { FL; STR; return yaD_PLI; }
 }
 
   /************************************************************************/


### PR DESCRIPTION
Fixes segfaults on some systems:

```
#0  std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_S_copy (__d=0x5555567e1b40 "status) !== (0)) begin $write(\"%%Error: %s:%0d:  got=%0d exp=%0d (%s !== %s)\\n\", \"t/t_sys_queue_unsup.v\"\341\004", __s=0x1 <error: Cannot access memory at address 0x1>, __n=1) at /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/15.1.1/../../../../include/c++/15.1.1/bits/basic_string.h:451
#1  std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_construct<true> (this=0x5555567e1b30, __str=0x1 <error: Cannot access memory at address 0x1>, __n=0) at /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/15.1.1/../../../../include/c++/15.1.1/bits/basic_string.tcc:298
#2  std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::basic_string (this=0x5555567e1b30, __str=...) at /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/15.1.1/../../../../include/c++/15.1.1/bits/basic_string.h:617
#3  AstNodeFTaskRef::AstNodeFTaskRef (this=this@entry=0x5555567e1a80, t=t@entry=..., fl=<optimized out>, name=..., pinsp=0x5555567e1700) at ../V3AstNodeExpr.h:250
#4  0x0000555555d40e1a in AstTaskRef::AstTaskRef (this=0x5555567e1b40, this@entry=0x5555567e1a80, fl=0x5555567e0370, name=..., pinsp=0x5555567e1700) at ../V3AstNodeExpr.h:4610
#5  0x0000555555d2baa0 in yyparse () at ../verilog.y:4072
#6  0x0000555555d4f47b in V3ParseImp::lexFile (this=this@entry=0x5555566d5db0, modname=...) at ../V3ParseImp.cpp:401
#7  0x0000555555d4e4f9 in V3ParseImp::parseFile (this=0x5555566d5db0, fileline=<optimized out>, modfilename=..., inLibrary=<optimized out>, libname=..., errmsg=...) at ../V3ParseImp.cpp:352
#8  0x0000555555f11d55 in V3Global::readFiles (this=<optimized out>) at ../V3Global.cpp:105
#9  0x0000555555daea2b in verilate (argString=...) at ../Verilator.cpp:716
#10 0x0000555555dac9ae in main (argc=<optimized out>, argv=<optimized out>) at ../Verilator.cpp:878
```