### PR TITLE
Fix 'always' static variables (#6462)

### DIFF
--- a/src/V3Begin.cpp
+++ b/src/V3Begin.cpp
@@ -199,6 +199,17 @@ class BeginVisitor final : public VNVisitor {
             m_liftedp = nullptr;
         }
     }
+    void visit(AstNodeProcedure* nodep) override {
+        UINFO(8, "  " << nodep);
+        VL_RESTORER(m_keepBegins);
+        m_keepBegins = false;
+        iterateChildren(nodep);
+        nodep->foreach([nodep](AstInitialStatic* const initp) {
+            if (initp == nodep) return;  // As InitialStatic is a NodeProcedure itself
+            initp->unlinkFrBack();
+            nodep->addHereThisAsNext(initp);
+        });
+    }
     void visit(AstBegin* nodep) override {
         // Begin blocks were only useful in variable creation, change names and delete
         UINFO(8, "  " << nodep);

--- a/src/V3LinkParse.cpp
+++ b/src/V3LinkParse.cpp
@@ -390,7 +390,7 @@ class LinkParseVisitor final : public VNVisitor {
                 nodep->valuep()->unlinkFrBack()->deleteTree();
             }  // 2. Under modules/class, it's an initial value to be loaded at time 0 via an
                // AstInitial
-            else if (m_valueModp) {
+            else {
                 // Making an AstAssign (vs AstAssignW) to a wire is an error, suppress it
                 FileLine* const newfl = new FileLine{fl};
                 newfl->warnOff(V3ErrorCode::PROCASSWIRE, true);
@@ -401,17 +401,15 @@ class LinkParseVisitor final : public VNVisitor {
                     newfl, new AstParseRef{newfl, VParseRefExp::PX_TEXT, nodep->name()},
                     VN_AS(nodep->valuep()->unlinkFrBack(), NodeExpr)};
                 if (nodep->lifetime().isAutomatic()) {
-                    nodep->addNextHere(new AstInitialAutomatic{newfl, assp});
+                    if (m_valueModp) {
+                        // 4. Under blocks, it's an initial value to be under an assign
+                        nodep->addNextHere(new AstInitialAutomatic{newfl, assp});
+                    } else {
+                        nodep->addNextHere(assp);
+                    }
                 } else {
                     nodep->addNextHere(new AstInitialStatic{newfl, assp});
                 }
-            }  // 4. Under blocks, it's an initial value to be under an assign
-            else {
-                FileLine* const newfl = new FileLine{fl};
-                newfl->warnOff(V3ErrorCode::E_CONSTWRITTEN, true);
-                nodep->addNextHere(
-                    new AstAssign{newfl, new AstVarRef{newfl, nodep, VAccess::WRITE},
-                                  VN_AS(nodep->valuep()->unlinkFrBack(), NodeExpr)});
             }
         }
     }

--- a/test_regress/t/t_var_always_static.py
+++ b/test_regress/t/t_var_always_static.py
@@ -11,10 +11,7 @@ import vltest_bootstrap
 
 test.scenarios('simulator')
 
-test.compile(verilator_flags2=["--binary", "--stats", "t/t_wide_temp_while_cond.cpp"])
-
-if test.vlt or test.vltmt:
-    test.file_grep(test.stats, r'Optimizations, Prelim temporary variables created\s+(\d+)', 4)
+test.compile(verilator_flags2=['--binary'])
 
 test.execute()
 

--- a/test_regress/t/t_var_always_static.v
+++ b/test_regress/t/t_var_always_static.v
@@ -1,0 +1,72 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2025 by Wilson Snyder.
+// SPDX-License-Identifier: CC0-1.0
+
+// verilog_format: off
+`define stop $stop
+`define checkd(gotv,expv) do if ((gotv) !== (expv)) begin $write("%%Error: %s:%0d:  got=%0d exp=%0d\n", `__FILE__,`__LINE__, (gotv), (expv)); `stop; end while(0);
+// verilog_format: on
+
+module t;
+  logic clk;
+  int out;
+  int out2;
+  int expected;
+
+  always_ff @(posedge clk) begin
+    automatic int proc_auto = 0;
+    static int proc_static = 8;
+    proc_auto = proc_auto + 1;
+    proc_static = proc_static + proc_auto;
+    out <= proc_static;
+    out2 <= func_out2();
+  end
+
+  function int func_out2();
+    automatic int func_auto = 0;
+    static int func_static = 8;
+    func_auto = func_auto + 1;
+    func_static = func_static + func_auto;
+    return func_static;
+  endfunction
+
+  initial begin
+    `checkd(A.i1, 1);
+    `checkd(A.i2, 2);
+    `checkd(A.i3, 3);
+    `checkd(A.t, 0);
+    #1;
+    begin : A
+      static int i1 = 1;
+      static int i2 = i1 + 1;
+      static int i3 = i2 + 1;
+      static time t = $time;  // Initializes at 0, not current time (all simulators agree)
+      `checkd(i1, 1);
+      `checkd(i2, 2);
+      `checkd(i3, 3);
+      `checkd(t, 0);
+    end
+  end
+
+  initial begin
+    clk = 0;
+
+    for (int cycle = 0; cycle < 20; ++cycle) begin
+      clk = 0;
+      #5;
+      clk = 1;
+      #4;
+      // Print outputs after each positive clock edge
+      expected = (cycle == 0) ? 9 : (9 + cycle);
+      $display("[%0t] got=%0d %0d | exp=%0d", $time, out, out2, expected);
+      `checkd(out, expected);
+      `checkd(out2, expected);
+      #1;
+    end
+
+    $finish;
+  end
+
+endmodule


### PR DESCRIPTION
@gezalore the t_constraint_mode.py test fails in this due to DFG "eating" the InitialStatic assignment (which is now used more broadly to fix this issue).  Can you please take a look? Feel free to edit the branch directly or push separate standalone fix to master. Thanks.
