### PR TITLE
Internals: Remove redundant AstNode methods

### DIFF
--- a/src/V3Ast.h
+++ b/src/V3Ast.h
@@ -2158,16 +2158,6 @@ public:
     AstNode* firstAbovep() const {  // Returns nullptr when second or later in list
         return ((backp() && backp()->nextp() != this) ? backp() : nullptr);
     }
-    // isFirstInMyListOfStatements(n) -- implemented by child classes:
-    // AstNodeBlock, AstCaseItem, AstNodeIf, AstNodeFTask, and possibly others.
-    virtual bool isFirstInMyListOfStatements(AstNode* n) const { return false; }
-    // isStandaloneBodyStmt == Do we need a ; on generated cpp for this node?
-    bool isStandaloneBodyStmt() {
-        return (!firstAbovep()  // we're 2nd or later in the list, so yes need ;
-
-                // If we're first in the list, check what backp() thinks of us:
-                || (backp() && backp()->isFirstInMyListOfStatements(this)));
-    }
     uint8_t brokenState() const VL_MT_SAFE { return m_brokenState; }
     void brokenState(uint8_t value) { m_brokenState = value; }
 

--- a/src/V3AstNodeOther.h
+++ b/src/V3AstNodeOther.h
@@ -52,7 +52,6 @@ public:
     string name() const override VL_MT_STABLE { return m_name; }  // * = Block name
     void name(const string& name) override { m_name = name; }
     bool unnamed() const { return m_unnamed; }
-    bool isFirstInMyListOfStatements(AstNode* nodep) const override { return nodep == stmtsp(); }
 };
 class AstNodeCoverDecl VL_NOT_FINAL : public AstNode {
     // Coverage analysis point declaration
@@ -235,7 +234,6 @@ public:
     VBaseOverride baseOverride() const { return m_baseOverride; }
     void lifetime(const VLifetime& flag) { m_lifetime = flag; }
     VLifetime lifetime() const { return m_lifetime; }
-    bool isFirstInMyListOfStatements(AstNode* n) const override { return n == stmtsp(); }
     bool isPure() override;
     const char* broken() const override;
     void propagateAttrFrom(const AstNodeFTask* fromp) {

--- a/src/V3AstNodeStmt.h
+++ b/src/V3AstNodeStmt.h
@@ -119,7 +119,6 @@ public:
     bool isGateOptimizable() const override { return false; }
     int instrCount() const override { return INSTR_COUNT_BRANCH; }
     bool sameNode(const AstNode* /*samep*/) const override { return true; }
-    bool isFirstInMyListOfStatements(AstNode* n) const override { return n == stmtsp(); }
 };
 class AstNodeIf VL_NOT_FINAL : public AstNodeStmt {
     // @astgen op1 := condp : AstNodeExpr
@@ -146,9 +145,6 @@ public:
     VBranchPred branchPred() const { return m_branchPred; }
     void isBoundsCheck(bool flag) { m_isBoundsCheck = flag; }
     bool isBoundsCheck() const { return m_isBoundsCheck; }
-    bool isFirstInMyListOfStatements(AstNode* n) const override {
-        return n == thensp() || n == elsesp();
-    }
 };
 class AstNodeReadWriteMem VL_NOT_FINAL : public AstNodeStmt {
     // @astgen op1 := filenamep : AstNodeExpr
@@ -196,7 +192,6 @@ public:
     ASTGEN_MEMBERS_AstCaseItem;
     int instrCount() const override { return widthInstrs() + INSTR_COUNT_BRANCH; }
     bool isDefault() const { return condsp() == nullptr; }
-    bool isFirstInMyListOfStatements(AstNode* n) const override { return n == stmtsp(); }
 };
 
 // === AstNodeStmt ===
@@ -538,8 +533,6 @@ public:
     bool isGateOptimizable() const override { return false; }
     int instrCount() const override { return INSTR_COUNT_BRANCH; }
     bool sameNode(const AstNode* /*samep*/) const override { return true; }
-    // Stop statement searchback here
-    bool isFirstInMyListOfStatements(AstNode* n) const override { return n == stmtsp(); }
 };
 class AstDumpCtl final : public AstNodeStmt {
     // $dumpon etc
@@ -757,7 +750,6 @@ public:
     bool isGateOptimizable() const override { return false; }  // Not relevant - converted to FOR
     int instrCount() const override { return INSTR_COUNT_BRANCH; }
     bool sameNode(const AstNode* /*samep*/) const override { return true; }
-    bool isFirstInMyListOfStatements(AstNode* n) const override { return n == stmtsp(); }
 };
 class AstReturn final : public AstNodeStmt {
     // @astgen op1 := lhsp : Optional[AstNodeExpr]
@@ -1042,7 +1034,6 @@ public:
         addStmtsp(stmtsp);
     }
     ASTGEN_MEMBERS_AstWait;
-    bool isFirstInMyListOfStatements(AstNode* n) const override { return n == stmtsp(); }
     bool isTimingControl() const override { return true; }
 };
 class AstWaitFork final : public AstNodeStmt {
@@ -1072,7 +1063,6 @@ public:
     bool sameNode(const AstNode* /*samep*/) const override { return true; }
     // Stop statement searchback here
     void addNextStmt(AstNode* newp, AstNode* belowp) override;
-    bool isFirstInMyListOfStatements(AstNode* n) const override { return n == stmtsp(); }
     VOptionBool unrollFull() const { return m_unrollFull; }
     void unrollFull(const VOptionBool flag) { m_unrollFull = flag; }
 };

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -4068,7 +4068,6 @@ class WidthVisitor final : public VNVisitor {
             newp = new AstCMethodHard{nodep->fileline(), nodep->fromp()->unlinkFrBack(),
                                       nodep->name()};
             newp->dtypeFrom(adtypep->subDTypep());
-            if (VN_IS(nodep->firstAbovep(), StmtExpr)) newp->dtypeSetVoid();
         } else if (nodep->name() == "push_back" || nodep->name() == "push_front") {
             methodOkArguments(nodep, 1, 1);
             iterateCheckTyped(nodep, "argument", methodArg(nodep, 0), adtypep->subDTypep(), BOTH);

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -4068,7 +4068,7 @@ class WidthVisitor final : public VNVisitor {
             newp = new AstCMethodHard{nodep->fileline(), nodep->fromp()->unlinkFrBack(),
                                       nodep->name()};
             newp->dtypeFrom(adtypep->subDTypep());
-            if (nodep->isStandaloneBodyStmt()) newp->dtypeSetVoid();
+            if (VN_IS(nodep->firstAbovep(), StmtExpr)) newp->dtypeSetVoid();
         } else if (nodep->name() == "push_back" || nodep->name() == "push_front") {
             methodOkArguments(nodep, 1, 1);
             iterateCheckTyped(nodep, "argument", methodArg(nodep, 0), adtypep->subDTypep(), BOTH);


### PR DESCRIPTION
AstNode::isFirstInMyListOfStatements
AstNode::isStandaloneBodyStmt
