### PR TITLE
CI: Add 60 minute timeout to RTLMeter compile and run steps

### DIFF
--- a/.github/workflows/reusable-rtlmeter-run.yml
+++ b/.github/workflows/reusable-rtlmeter-run.yml
@@ -92,15 +92,13 @@ jobs:
       - name: Compile cases
         working-directory: rtlmeter
         run: |
-          ./rtlmeter run --verbose --cases='${{ inputs.cases }}' --compileArgs='${{ inputs.compileArgs }}' --executeArgs='${{ inputs.executeArgs }}' --nExecute=0
-          # My YAML highlighter sucks, so I put this comment here wiht a phony closing quote mark to make it work: '
+          ./rtlmeter run --timeout 60 --verbose --cases='${{inputs.cases}}' --compileArgs='${{inputs.compileArgs}}' --executeArgs='${{inputs.executeArgs}}' --nExecute=0
 
       - name: Execute cases
         working-directory: rtlmeter
-        continue-on-error: true  # Do not fail on error, so we can at leat save the successful results
+        continue-on-error: true  # Do not fail on error, so we can at least save the successful results
         run: |
-          ./rtlmeter run --verbose --cases='${{ inputs.cases }}' --compileArgs='${{ inputs.compileArgs }}' --executeArgs='${{ inputs.executeArgs }}'
-          # My YAML highlighter sucks, so I put this comment here wiht a phony closing quote mark to make it work: '
+          ./rtlmeter run --timeout 60 --verbose --cases='${{inputs.cases}}' --compileArgs='${{inputs.compileArgs}}' --executeArgs='${{inputs.executeArgs}}'
 
       - name: Collate results
         id: results
@@ -127,5 +125,4 @@ jobs:
       - name: Report status
         working-directory: rtlmeter
         run: | # This will fail the job if any of the runs failed
-          ./rtlmeter run --verbose --cases='${{ inputs.cases }}' --compileArgs='${{ inputs.compileArgs }}' --executeArgs='${{ inputs.executeArgs }}'
-          # My YAML highlighter sucks, so I put this comment here wiht a phony closing quote mark to make it work: '
+          ./rtlmeter run --verbose --cases='${{inputs.cases}}' --compileArgs='${{inputs.compileArgs}}' --executeArgs='${{inputs.executeArgs}}'


### PR DESCRIPTION
The default timeout for a job in GitHub Actions is 6 hours, which is both too long, but more importantly, when reached the job is 'cancelled' instead of 'failed'. Use the new `--timeout` option on `rtlmeter run` instead to add a 60 minute timeout to compile and execute steps. (This is ~3x longer than recent worst runs in the CI)