### PR TITLE
Support simple cycle delay sequence expressions inside assertion properties

### DIFF
--- a/src/V3AssertPre.cpp
+++ b/src/V3AssertPre.cpp
@@ -56,10 +56,15 @@ private:
     AstNodeExpr* m_disablep = nullptr;  // Last disable
     // Other:
     V3UniqueNames m_cycleDlyNames{"__VcycleDly"};  // Cycle delay counter name generator
+    V3UniqueNames m_propPrecondNames{"__VpropPrecond"};  // Cycle delay temporaries name generator
     bool m_inAssign = false;  // True if in an AssignNode
     bool m_inAssignDlyLhs = false;  // True if in AssignDly's LHS
+    bool m_inSExpr = false;  // True if in AstSExpr
+    AstPExpr* m_pExpr = nullptr;  // Current AstPExpr
     bool m_inSynchDrive = false;  // True if in synchronous drive
     std::vector<AstVarXRef*> m_xrefsp;  // list of xrefs that need name fixup
+    bool m_hasSExpr = false;  // True if assert has AstSExpr inside
+    AstNode* m_hasUnsupp = nullptr;  // True if assert has unsupported construct inside
 
     // METHODS
 
@@ -335,16 +340,21 @@ private:
             VL_DO_DANGLING(valuep->deleteTree(), valuep);
             return;
         }
+        AstSenItem* sensesp = nullptr;
         if (!m_defaultClockingp) {
-            nodep->v3error("Usage of cycle delays requires default clocking"
-                           " (IEEE 1800-2023 14.11)");
-            VL_DO_DANGLING(nodep->unlinkFrBack()->deleteTree(), nodep);
-            VL_DO_DANGLING(valuep->deleteTree(), valuep);
-            return;
+            if (!m_pExpr && !m_inSExpr) {
+                nodep->v3error("Usage of cycle delays requires default clocking"
+                               " (IEEE 1800-2023 14.11)");
+                VL_DO_DANGLING(nodep->unlinkFrBack()->deleteTree(), nodep);
+                VL_DO_DANGLING(valuep->deleteTree(), valuep);
+                return;
+            }
+            sensesp = m_senip;
+        } else {
+            sensesp = m_defaultClockingp->sensesp();
         }
         AstEventControl* const controlp = new AstEventControl{
-            nodep->fileline(),
-            new AstSenTree{flp, m_defaultClockingp->sensesp()->cloneTree(false)}, nullptr};
+            nodep->fileline(), new AstSenTree{flp, sensesp->cloneTree(false)}, nullptr};
         const std::string delayName = m_cycleDlyNames.get(nodep);
         AstVar* const cntVarp = new AstVar{flp, VVarType::BLOCKTEMP, delayName + "__counter",
                                            nodep->findBasicDType(VBasicDTypeKwd::UINT32)};
@@ -403,6 +413,32 @@ private:
                 }
             }
             nodep->user1(true);
+        } else if (m_inSExpr && !nodep->user1()) {
+            AstVar* const preVarp
+                = new AstVar{nodep->varp()->fileline(), VVarType::BLOCKTEMP,
+                             m_propPrecondNames.get(nodep->varp()) + nodep->varp()->name(),
+                             nodep->varp()->dtypep()};
+            preVarp->lifetime(VLifetime::STATIC_EXPLICIT);
+            m_modp->addStmtsp(preVarp);
+            AstVarRef* const origp
+                = new AstVarRef{nodep->fileline(), nodep->varp(), VAccess::READ};
+            origp->user1(true);
+            AstVarRef* const precondp
+                = new AstVarRef{preVarp->fileline(), preVarp, VAccess::WRITE};
+            precondp->user1(true);
+
+            // Pack assignments in sampled as in concurrent assertions they are needed.
+            // Then, in assert's propp, sample only non-precondition variables.
+            AstSampled* sampledp = new AstSampled{origp->fileline(), origp};
+            sampledp->dtypeFrom(origp);
+            AstAssign* const assignp = new AstAssign{m_pExpr->fileline(), precondp, sampledp};
+            m_pExpr->addPrecondp(assignp);
+
+            AstVarRef* const precondReadp
+                = new AstVarRef{preVarp->fileline(), preVarp, VAccess::READ};
+            precondReadp->user1(true);
+            nodep->replaceWith(precondReadp);
+            VL_DO_DANGLING(pushDeletep(nodep), nodep);
         }
     }
     void visit(AstMemberSel* nodep) override {
@@ -456,10 +492,28 @@ private:
 
     void visit(AstNodeCoverOrAssert* nodep) override {
         if (nodep->sentreep()) return;  // Already processed
+
+        VL_RESTORER(m_hasSExpr);
+        VL_RESTORER(m_hasUnsupp);
+
         clearAssertInfo();
+        AstPExpr* const pexprp = new AstPExpr{nodep->propp()->fileline()};
+        pexprp->dtypeFrom(nodep->propp());
+        m_pExpr = pexprp;
+
         // Find Clocking's buried under nodep->exprsp
         iterateChildren(nodep);
         if (!nodep->immediate()) nodep->sentreep(newSenTree(nodep));
+        if (m_hasSExpr && m_hasUnsupp) {
+            m_hasUnsupp->v3warn(E_UNSUPPORTED, "Implication with sequence expression");
+            if (m_pExpr) VL_DO_DANGLING(pushDeletep(m_pExpr), m_pExpr);
+        } else if (m_pExpr && m_pExpr->precondp()) {
+            m_pExpr->condp(VN_AS(nodep->propp()->unlinkFrBackWithNext(), NodeExpr));
+            nodep->propp(m_pExpr);
+            iterateAndNextNull(m_pExpr->precondp());
+        } else if (m_pExpr) {
+            VL_DO_DANGLING(pushDeletep(m_pExpr), m_pExpr);
+        }
         clearAssertInfo();
     }
     void visit(AstFalling* nodep) override {
@@ -483,12 +537,12 @@ private:
         if (exprp->width() > 1) exprp = new AstSel{fl, exprp, 0, 1};
         AstSenTree* sentreep = nodep->sentreep();
         if (sentreep) sentreep->unlinkFrBack();
-        AstNodeExpr* const pastp = new AstPast{fl, exprp};
+        AstPast* const pastp = new AstPast{fl, exprp};
         pastp->dtypeFrom(exprp);
+        pastp->sentreep(newSenTree(nodep, sentreep));
         exprp = new AstAnd{fl, pastp, new AstNot{fl, exprp->cloneTreePure(false)}};
         exprp->dtypeSetBit();
         nodep->replaceWith(exprp);
-        nodep->sentreep(newSenTree(nodep, sentreep));
         VL_DO_DANGLING(pushDeletep(nodep), nodep);
     }
     void visit(AstFuture* nodep) override {
@@ -497,6 +551,10 @@ private:
         AstSenTree* const sentreep = nodep->sentreep();
         if (sentreep) VL_DO_DANGLING(pushDeletep(sentreep->unlinkFrBack()), sentreep);
         nodep->sentreep(newSenTree(nodep));
+    }
+    void visit(AstLogNot* nodep) override {
+        if (m_inSExpr) nodep->v3error("Syntax error: unexpected 'not' in sequence expression");
+        iterateChildren(nodep);
     }
     void visit(AstPast* nodep) override {
         if (nodep->sentreep()) return;  // Already processed
@@ -524,12 +582,12 @@ private:
         if (exprp->width() > 1) exprp = new AstSel{fl, exprp, 0, 1};
         AstSenTree* sentreep = nodep->sentreep();
         if (sentreep) sentreep->unlinkFrBack();
-        AstNodeExpr* const pastp = new AstPast{fl, exprp};
+        AstPast* const pastp = new AstPast{fl, exprp};
         pastp->dtypeFrom(exprp);
+        pastp->sentreep(newSenTree(nodep, sentreep));
         exprp = new AstAnd{fl, new AstNot{fl, pastp}, exprp->cloneTreePure(false)};
         exprp->dtypeSetBit();
         nodep->replaceWith(exprp);
-        nodep->sentreep(newSenTree(nodep, sentreep));
         VL_DO_DANGLING(pushDeletep(nodep), nodep);
     }
     void visit(AstStable* nodep) override {
@@ -539,12 +597,12 @@ private:
         AstNodeExpr* exprp = nodep->exprp()->unlinkFrBack();
         AstSenTree* sentreep = nodep->sentreep();
         if (sentreep) sentreep->unlinkFrBack();
-        AstNodeExpr* const pastp = new AstPast{fl, exprp};
+        AstPast* const pastp = new AstPast{fl, exprp};
         pastp->dtypeFrom(exprp);
+        pastp->sentreep(newSenTree(nodep, sentreep));
         exprp = new AstEq{fl, pastp, exprp->cloneTreePure(false)};
         exprp->dtypeSetBit();
         nodep->replaceWith(exprp);
-        nodep->sentreep(newSenTree(nodep, sentreep));
         VL_DO_DANGLING(pushDeletep(nodep), nodep);
     }
     void visit(AstSteady* nodep) override {
@@ -563,21 +621,27 @@ private:
 
     void visit(AstImplication* nodep) override {
         if (nodep->sentreep()) return;  // Already processed
+        m_hasUnsupp = nodep;
 
-        FileLine* const fl = nodep->fileline();
+        iterateChildren(nodep);
+
+        FileLine* const flp = nodep->fileline();
         AstNodeExpr* const rhsp = nodep->rhsp()->unlinkFrBack();
         AstNodeExpr* lhsp = nodep->lhsp()->unlinkFrBack();
+        if (nodep->isOverlapped()) {
+            nodep->replaceWith(new AstLogOr{flp, new AstLogNot{flp, lhsp}, rhsp});
+        } else {
+            if (m_disablep) {
+                lhsp = new AstAnd{flp, new AstNot{flp, m_disablep->cloneTreePure(false)}, lhsp};
+            }
 
-        if (m_disablep) {
-            lhsp = new AstAnd{fl, new AstNot{fl, m_disablep->cloneTreePure(false)}, lhsp};
+            AstPast* const pastp = new AstPast{flp, lhsp};
+            pastp->dtypeFrom(lhsp);
+            pastp->sentreep(newSenTree(nodep));
+            AstNodeExpr* const exprp = new AstOr{flp, new AstNot{flp, pastp}, rhsp};
+            exprp->dtypeSetBit();
+            nodep->replaceWith(exprp);
         }
-
-        AstNodeExpr* const pastp = new AstPast{fl, lhsp};
-        pastp->dtypeFrom(lhsp);
-        AstNodeExpr* const exprp = new AstOr{fl, new AstNot{fl, pastp}, rhsp};
-        exprp->dtypeSetBit();
-        nodep->replaceWith(exprp);
-        nodep->sentreep(newSenTree(nodep));
         VL_DO_DANGLING(pushDeletep(nodep), nodep);
     }
 
@@ -620,6 +684,19 @@ private:
         // Unlink and just keep a pointer to it, convert to sentree as needed
         m_senip = nodep->sensesp();
         nodep->replaceWith(blockp);
+        VL_DO_DANGLING(pushDeletep(nodep), nodep);
+    }
+    void visit(AstSExpr* nodep) override {
+        VL_RESTORER(m_inSExpr);
+        m_inSExpr = true;
+        m_hasSExpr = true;
+
+        UASSERT_OBJ(m_pExpr, nodep, "Should be created for each assert");
+        if (AstDelay* const delayp = VN_CAST(nodep->delayp(), Delay))
+            m_pExpr->addPrecondp(delayp->unlinkFrBack());
+
+        iterateChildren(nodep);
+        nodep->replaceWith(nodep->exprp()->unlinkFrBack());
         VL_DO_DANGLING(pushDeletep(nodep), nodep);
     }
     void visit(AstNodeModule* nodep) override {

--- a/src/V3AstNodeExpr.h
+++ b/src/V3AstNodeExpr.h
@@ -1561,14 +1561,22 @@ public:
 };
 class AstImplication final : public AstNodeExpr {
     // Verilog Implication Operator
-    // Nonoverlapping "|=>"
-    // Overlapping "|->" (doesn't currently use this - might make new Ast type)
+    // Nonoverlapped "|=>"
+    // Overlapped "|->"
     // @astgen op1 := lhsp : AstNodeExpr
     // @astgen op2 := rhsp : AstNodeExpr
     // @astgen op3 := sentreep : Optional[AstSenTree]
+
 public:
-    AstImplication(FileLine* fl, AstNodeExpr* lhsp, AstNodeExpr* rhsp)
-        : ASTGEN_SUPER_Implication(fl) {
+    enum class Type : uint8_t { OVERLAPPED, NONOVERLAPPED };
+
+private:
+    const Type m_type;  // Implication type
+
+public:
+    AstImplication(FileLine* fl, AstNodeExpr* lhsp, AstNodeExpr* rhsp, Type type)
+        : ASTGEN_SUPER_Implication(fl)
+        , m_type{type} {
         this->lhsp(lhsp);
         this->rhsp(rhsp);
     }
@@ -1579,6 +1587,7 @@ public:
     bool cleanOut() const override { V3ERROR_NA_RETURN(""); }
     int instrCount() const override { return widthInstrs(); }
     bool sameNode(const AstNode* /*samep*/) const override { return true; }
+    bool isOverlapped() const { return m_type == Type::OVERLAPPED; }
 };
 class AstInitArray final : public AstNodeExpr {
     // This is also used as an array value in V3Simulate/const prop.
@@ -1743,6 +1752,21 @@ public:
     bool cleanOut() const override { return true; }
     bool sameNode(const AstNode* /*samep*/) const override { return true; }
     int instrCount() const override { return widthInstrs(); }
+};
+class AstPExpr final : public AstNodeExpr {
+    // Property expression
+    // @astgen op1 := precondp : List[AstNode]
+    // @astgen op2 := condp : Optional[AstNodeExpr]
+public:
+    explicit AstPExpr(FileLine* fl)
+        : ASTGEN_SUPER_PExpr(fl) {}
+    ASTGEN_MEMBERS_AstPExpr;
+    string emitVerilog() override { V3ERROR_NA_RETURN(""); }
+    string emitC() override { V3ERROR_NA_RETURN(""); }
+    string emitSimpleOperator() override { V3ERROR_NA_RETURN(""); }
+    bool cleanOut() const override { V3ERROR_NA_RETURN(""); }
+    int instrCount() const override { return widthInstrs(); }
+    bool sameNode(const AstNode* /*samep*/) const override { return true; }
 };
 class AstParseHolder final : public AstNodeExpr {
     // A reference to something soon to replace, used in a select at parse time
@@ -1953,6 +1977,24 @@ public:
     }
     ASTGEN_MEMBERS_AstRose;
     string emitVerilog() override { return "$rose(%l)"; }
+    string emitC() override { V3ERROR_NA_RETURN(""); }
+    string emitSimpleOperator() override { V3ERROR_NA_RETURN(""); }
+    bool cleanOut() const override { V3ERROR_NA_RETURN(""); }
+    int instrCount() const override { return widthInstrs(); }
+    bool sameNode(const AstNode* /*samep*/) const override { return true; }
+};
+class AstSExpr final : public AstNodeExpr {
+    // Sequence expression
+    // @astgen op1 := delayp : AstNode
+    // @astgen op2 := exprp : AstNodeExpr
+public:
+    explicit AstSExpr(FileLine* fl, AstNode* delayp, AstNodeExpr* exprp)
+        : ASTGEN_SUPER_SExpr(fl) {
+        this->delayp(delayp);
+        this->exprp(exprp);
+    }
+    ASTGEN_MEMBERS_AstSExpr;
+    string emitVerilog() override { V3ERROR_NA_RETURN(""); }
     string emitC() override { V3ERROR_NA_RETURN(""); }
     string emitSimpleOperator() override { V3ERROR_NA_RETURN(""); }
     bool cleanOut() const override { V3ERROR_NA_RETURN(""); }

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -1548,6 +1548,13 @@ class WidthVisitor final : public VNVisitor {
             if (nodep->seedp()) iterateCheckSigned32(nodep, "seed", nodep->seedp(), BOTH);
         }
     }
+    void visit(AstSExpr* nodep) override {
+        if (m_vup->prelim()) {
+            iterateCheckBool(nodep, "exprp", nodep->exprp(), BOTH);
+            iterate(nodep->delayp());
+            nodep->dtypeSetBit();
+        }
+    }
     void visit(AstURandomRange* nodep) override {
         if (m_vup->prelim()) {
             nodep->dtypeSetUInt32();  // Says the spec

--- a/src/verilog.y
+++ b/src/verilog.y
@@ -6526,8 +6526,8 @@ pexpr<nodeExprp>:  // IEEE: property_expr  (The name pexpr is important as regex
         //
         //                      // IEEE: "sequence_expr yP_ORMINUSGT pexpr"
         //                      // Instead we use pexpr to prevent conflicts
-        |       ~o~pexpr yP_ORMINUSGT pexpr             { $$ = new AstLogOr{$2, new AstLogNot{$2, $1}, $3}; }
-        |       ~o~pexpr yP_OREQGT pexpr                { $$ = new AstImplication{$2, $1, $3}; }
+        |       ~o~pexpr yP_ORMINUSGT pexpr             { $$ = new AstImplication{$2, $1, $3, AstImplication::Type::OVERLAPPED}; }
+        |       ~o~pexpr yP_OREQGT pexpr                { $$ = new AstImplication{$2, $1, $3, AstImplication::Type::NONOVERLAPPED}; }
         //
         //                      // IEEE-2009: property_statement
         //                      // IEEE-2012: yIF and yCASE
@@ -6605,7 +6605,7 @@ sexpr<nodeExprp>:  // ==IEEE: sequence_expr  (The name sexpr is important as reg
         //                      // IEEE: "sequence_expr cycle_delay_range sequence_expr { cycle_delay_range sequence_expr }"
         //                      // Both rules basically mean we can repeat sequences, so make it simpler:
                 cycle_delay_range ~p~sexpr  %prec yP_POUNDPOUND
-                        { $$ = $2; BBUNSUP($2->fileline(), "Unsupported: ## (in sequence expression)"); }
+                        { $$ = new AstSExpr{$<fl>1, $1, $2}; }
         |       ~p~sexpr cycle_delay_range sexpr %prec prPOUNDPOUND_MULTI
                         { $$ = $1; BBUNSUP($2->fileline(), "Unsupported: ## (in sequence expression)"); }
         //
@@ -6660,8 +6660,7 @@ sexpr<nodeExprp>:  // ==IEEE: sequence_expr  (The name sexpr is important as reg
 cycle_delay_range<nodep>:  // IEEE: ==cycle_delay_range
         //                      // These three terms in 1800-2005 ONLY
                 yP_POUNDPOUND intnumAsConst
-                        { $$ = $2;
-                          BBUNSUP($<fl>1, "Unsupported: ## () cycle delay range expression"); }
+                        { $$ = new AstDelay{$<fl>1, $2, true}; }
         |       yP_POUNDPOUND idAny
                         { $$ = new AstConst{$1, AstConst::BitFalse{}};
                           BBUNSUP($<fl>1, "Unsupported: ## id cycle delay range expression"); }

--- a/test_regress/t/t_expect.out
+++ b/test_regress/t/t_expect.out
@@ -1,28 +1,19 @@
-%Error-UNSUPPORTED: t/t_expect.v:19:32: Unsupported: ## () cycle delay range expression
+%Error-UNSUPPORTED: t/t_expect.v:19:32: Unsupported: ## (in sequence expression)
    19 |       expect (@(posedge clk) a ##1 b) a = 110;
       |                                ^~
                     ... For error description see https://verilator.org/warn/UNSUPPORTED?v=latest
-%Error-UNSUPPORTED: t/t_expect.v:19:34: Unsupported: ## (in sequence expression)
-   19 |       expect (@(posedge clk) a ##1 b) a = 110;
-      |                                  ^
 %Error-UNSUPPORTED: t/t_expect.v:19:7: Unsupported: expect
    19 |       expect (@(posedge clk) a ##1 b) a = 110;
       |       ^~~~~~
-%Error-UNSUPPORTED: t/t_expect.v:21:32: Unsupported: ## () cycle delay range expression
+%Error-UNSUPPORTED: t/t_expect.v:21:32: Unsupported: ## (in sequence expression)
    21 |       expect (@(posedge clk) a ##1 b) else a = 299;
       |                                ^~
-%Error-UNSUPPORTED: t/t_expect.v:21:34: Unsupported: ## (in sequence expression)
-   21 |       expect (@(posedge clk) a ##1 b) else a = 299;
-      |                                  ^
 %Error-UNSUPPORTED: t/t_expect.v:21:7: Unsupported: expect
    21 |       expect (@(posedge clk) a ##1 b) else a = 299;
       |       ^~~~~~
-%Error-UNSUPPORTED: t/t_expect.v:23:32: Unsupported: ## () cycle delay range expression
+%Error-UNSUPPORTED: t/t_expect.v:23:32: Unsupported: ## (in sequence expression)
    23 |       expect (@(posedge clk) a ##1 b) a = 300; else a = 399;
       |                                ^~
-%Error-UNSUPPORTED: t/t_expect.v:23:34: Unsupported: ## (in sequence expression)
-   23 |       expect (@(posedge clk) a ##1 b) a = 300; else a = 399;
-      |                                  ^
 %Error-UNSUPPORTED: t/t_expect.v:23:7: Unsupported: expect
    23 |       expect (@(posedge clk) a ##1 b) a = 300; else a = 399;
       |       ^~~~~~

--- a/test_regress/t/t_property_sexpr.out
+++ b/test_regress/t/t_property_sexpr.out
@@ -1,0 +1,36 @@
+[4] single delay with const stmt, fileline:        108
+[6] single delay with const stmt, fileline:        108
+[8] single delay with const stmt, fileline:        108
+[12] single delay with var stmt, fileline:        111
+[14] single delay with var else, fileline:        112
+[16] single delay with var stmt, fileline:        111
+[18] single delay with var else, fileline:        112
+[20] single delay with var stmt, fileline:        111
+[26] single multi-cycle delay with var else, fileline:        116
+[28] single multi-cycle delay with var stmt, fileline:        115
+[30] single multi-cycle delay with var else, fileline:        116
+[34] single delay with var brackets 1 else, fileline:        120
+[36] single delay with var brackets 1 stmt, fileline:        119
+[38] single delay with var brackets 1 else, fileline:        120
+[40] single delay with var brackets 1 stmt, fileline:        119
+[44] single delay with var brackets 2 stmt, fileline:        123
+[46] single delay with var brackets 2 else, fileline:        124
+[48] single delay with var brackets 2 stmt, fileline:        123
+[50] single delay with var brackets 2 else, fileline:        124
+[54] single delay with negated var else, fileline:        128
+[56] single delay with negated var stmt, fileline:        127
+[58] single delay with negated var else, fileline:        128
+[60] single delay with negated var else, fileline:        128
+[64] single delay with negated var else, fileline:        132
+[66] single delay with negated var stmt, fileline:        131
+[68] single delay with negated var else, fileline:        132
+[70] single delay with negated var stmt, fileline:        131
+[74] single delay with negated var brackets stmt, fileline:        135
+[76] single delay with negated var brackets else, fileline:        136
+[78] single delay with negated var brackets stmt, fileline:        135
+[80] single delay with negated var brackets else, fileline:        136
+[84] single delay with negated var brackets else, fileline:        139
+[88] single delay with negated var brackets else, fileline:        139
+[106] cover property, fileline:        143
+[108] cover property, fileline:        143
+*-* All Finished *-*

--- a/test_regress/t/t_property_sexpr.py
+++ b/test_regress/t/t_property_sexpr.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2025 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile(timing_loop=True, verilator_flags2=['--assert', '--timing', '--coverage-user'])
+
+test.execute(expect_filename=test.golden_filename)
+
+test.passes()

--- a/test_regress/t/t_property_sexpr.v
+++ b/test_regress/t/t_property_sexpr.v
@@ -1,0 +1,148 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed into the Public Domain, for any use,
+// without warranty, 2025 by Antmicro.
+// SPDX-License-Identifier: CC0-1.0
+
+module t (  /*AUTOARG*/
+    // Inputs
+    clk
+);
+
+  input clk;
+
+  bit [3:0] val = 0;
+  event e1;
+  event e2;
+  event e3;
+  event e4;
+  event e5;
+  event e6;
+  event e7;
+  event e8;
+  event e9;
+  event e10;
+  event e11;
+  integer cyc = 1;
+
+  always @(negedge clk) begin
+    val <= 4'(cyc % 4);
+
+    if (cyc >= 0 && cyc <= 4) begin
+      ->e1;
+`ifdef TEST_VERBOSE
+      $display("[%0t] triggered e1", $time);
+`endif
+    end
+    if (cyc >= 5 && cyc <= 10) begin
+      ->e2;
+`ifdef TEST_VERBOSE
+      $display("[%0t] triggered e2", $time);
+`endif
+    end
+    if (cyc >= 11 && cyc <= 15) begin
+      ->e3;
+`ifdef TEST_VERBOSE
+      $display("[%0t] triggered e3", $time);
+`endif
+    end
+    if (cyc >= 16 && cyc <= 20) begin
+      ->e4;
+`ifdef TEST_VERBOSE
+      $display("[%0t] triggered e4", $time);
+`endif
+    end
+    if (cyc >= 21 && cyc <= 25) begin
+      ->e5;
+`ifdef TEST_VERBOSE
+      $display("[%0t] triggered e5", $time);
+`endif
+    end
+    if (cyc >= 26 && cyc <= 30) begin
+      ->e6;
+`ifdef TEST_VERBOSE
+      $display("[%0t] triggered e6", $time);
+`endif
+    end
+    if (cyc >= 31 && cyc <= 35) begin
+      ->e7;
+`ifdef TEST_VERBOSE
+      $display("[%0t] triggered e7", $time);
+`endif
+    end
+    if (cyc >= 36 && cyc <= 40) begin
+      ->e8;
+`ifdef TEST_VERBOSE
+      $display("[%0t] triggered e8", $time);
+`endif
+    end
+    if (cyc >= 41 && cyc <= 45) begin
+      ->e9;
+`ifdef TEST_VERBOSE
+      $display("[%0t] triggered e8", $time);
+`endif
+    end
+    if (cyc >= 46 && cyc <= 50) begin
+      ->e10;
+`ifdef TEST_VERBOSE
+      $display("[%0t] triggered e8", $time);
+`endif
+    end
+    if (cyc >= 51 && cyc <= 55) begin
+      ->e11;
+`ifdef TEST_VERBOSE
+      $display("[%0t] triggered e8", $time);
+`endif
+    end
+`ifdef TEST_VERBOSE
+    $display("cyc=%0d val=%0d", cyc, val);
+`endif
+    cyc <= cyc + 1;
+    if (cyc == 100) begin
+      $write("*-* All Finished *-*\n");
+      $finish;
+    end
+  end
+
+  assert property (@(e1) ##1 1)
+    $display("[%0t] single delay with const stmt, fileline:%d", $time, `__LINE__);
+
+  assert property (@(e2) ##1 val[0])
+    $display("[%0t] single delay with var stmt, fileline:%d", $time, `__LINE__);
+  else $display("[%0t] single delay with var else, fileline:%d", $time, `__LINE__);
+
+  assert property (@(e3) ##2 val[0])
+    $display("[%0t] single multi-cycle delay with var stmt, fileline:%d", $time, `__LINE__);
+  else $display("[%0t] single multi-cycle delay with var else, fileline:%d", $time, `__LINE__);
+
+  assert property (@(e4) ##1 (val[0]))
+    $display("[%0t] single delay with var brackets 1 stmt, fileline:%d", $time, `__LINE__);
+  else $display("[%0t] single delay with var brackets 1 else, fileline:%d", $time, `__LINE__);
+
+  assert property (@(e5) (##1 (val[0])))
+    $display("[%0t] single delay with var brackets 2 stmt, fileline:%d", $time, `__LINE__);
+  else $display("[%0t] single delay with var brackets 2 else, fileline:%d", $time, `__LINE__);
+
+  assert property (@(e6) (##1 val[0] && val[1]))
+    $display("[%0t] single delay with negated var stmt, fileline:%d", $time, `__LINE__);
+  else $display("[%0t] single delay with negated var else, fileline:%d", $time, `__LINE__);
+
+  assert property (@(e7) not ##1 val[0])
+    $display("[%0t] single delay with negated var stmt, fileline:%d", $time, `__LINE__);
+  else $display("[%0t] single delay with negated var else, fileline:%d", $time, `__LINE__);
+
+  assume property (@(e8) not (##1 val[0]))
+    $display("[%0t] single delay with negated var brackets stmt, fileline:%d", $time, `__LINE__);
+  else $display("[%0t] single delay with negated var brackets else, fileline:%d", $time, `__LINE__);
+
+  assume property (@(e9) not (##1 val[0]))
+  else $display("[%0t] single delay with negated var brackets else, fileline:%d", $time, `__LINE__);
+
+  cover property (@(e10) ##1 val[0]);
+
+  cover property (@(e11) not ##1 val[1]) $display("[%0t] cover property, fileline:%d", $time, `__LINE__);
+
+  restrict property (@(e11) ##1 val[0]);
+
+  restrict property (@(e11) not ##1 val[0]);
+endmodule

--- a/test_regress/t/t_property_sexpr_bad.out
+++ b/test_regress/t/t_property_sexpr_bad.out
@@ -1,0 +1,6 @@
+%Error: t/t_property_sexpr_bad.v:20:39: Syntax error: unexpected 'not' in sequence expression
+                                      : ... note: In instance 't'
+   20 |   assert property (@(posedge clk) ##1 not val) $display("[%0t] single delay with negated var stmt, fileline:%d", $time, 20);
+      |                                       ^~~
+        ... See the manual at https://verilator.org/verilator_doc.html?v=latest for more assistance.
+%Error: Exiting due to

--- a/test_regress/t/t_property_sexpr_bad.py
+++ b/test_regress/t/t_property_sexpr_bad.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2025 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('vlt')
+
+test.lint(fails=True,
+          verilator_flags2=['--assert', '--timing'],
+          expect_filename=test.golden_filename)
+
+test.passes()

--- a/test_regress/t/t_property_sexpr_bad.v
+++ b/test_regress/t/t_property_sexpr_bad.v
@@ -1,0 +1,21 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed into the Public Domain, for any use,
+// without warranty, 2025 by Antmicro.
+// SPDX-License-Identifier: CC0-1.0
+
+module t (  /*AUTOARG*/
+    // Inputs
+    clk
+);
+
+  input clk;
+  bit val;
+
+  always @(negedge clk) begin
+    $write("*-* All Finished *-*\n");
+    $finish;
+  end
+
+  assert property (@(posedge clk) ##1 not val) $display("[%0t] single delay with negated var stmt, fileline:%d", $time, `__LINE__);
+endmodule

--- a/test_regress/t/t_property_sexpr_parse_unsup.out
+++ b/test_regress/t/t_property_sexpr_parse_unsup.out
@@ -1,0 +1,35 @@
+%Error-UNSUPPORTED: t/t_property_sexpr_unsup.v:29:39: Unsupported: ## (in sequence expression)
+   29 |   assert property (@(posedge clk) val ##1 val) $display("[%0t] var with single delay stmt, fileline:%d", $time, 29);
+      |                                       ^~
+                    ... For error description see https://verilator.org/warn/UNSUPPORTED?v=latest
+%Error-UNSUPPORTED: t/t_property_sexpr_unsup.v:30:43: Unsupported: ## (in sequence expression)
+   30 |   assert property (@(posedge clk) ##1 val ##2 val) $display("[%0t] sequence stmt, fileline:%d", $time, 30);
+      |                                           ^~
+%Error-UNSUPPORTED: t/t_property_sexpr_unsup.v:65:14: Unsupported sequence match items
+   65 |     ($rose(a), l_b = b) |-> ##[3:10] q[l_b];
+      |              ^
+%Error-UNSUPPORTED: t/t_property_sexpr_unsup.v:65:29: Unsupported: ## range cycle delay range expression
+   65 |     ($rose(a), l_b = b) |-> ##[3:10] q[l_b];
+      |                             ^~
+%Error-UNSUPPORTED: t/t_property_sexpr_unsup.v:64:13: Unsupported: property variable declaration
+   64 |     integer l_b;
+      |             ^~~
+%Error-UNSUPPORTED: t/t_property_sexpr_unsup.v:82:16: Unsupported sequence match items
+   82 |     (count == 0, l_t = $realtime) ##1 (count == 7)[->1] |-> $realtime - l_t < 50.5;
+      |                ^
+%Error-UNSUPPORTED: t/t_property_sexpr_unsup.v:82:51: Unsupported: [-> boolean abbrev expression
+   82 |     (count == 0, l_t = $realtime) ##1 (count == 7)[->1] |-> $realtime - l_t < 50.5;
+      |                                                   ^~~
+%Error-UNSUPPORTED: t/t_property_sexpr_unsup.v:82:54: Unsupported: boolean abbrev (in sequence expression)
+   82 |     (count == 0, l_t = $realtime) ##1 (count == 7)[->1] |-> $realtime - l_t < 50.5;
+      |                                                      ^
+%Error-UNSUPPORTED: t/t_property_sexpr_unsup.v:82:35: Unsupported: ## (in sequence expression)
+   82 |     (count == 0, l_t = $realtime) ##1 (count == 7)[->1] |-> $realtime - l_t < 50.5;
+      |                                   ^~
+%Error-UNSUPPORTED: t/t_property_sexpr_unsup.v:80:14: Unsupported: property variable declaration
+   80 |     realtime l_t;
+      |              ^~~
+%Error-UNSUPPORTED: t/t_property_sexpr_unsup.v:86:31: Unsupported: ## (in sequence expression)
+   86 |   assert property (@clk not a ##1 b);
+      |                               ^~
+%Error: Exiting due to

--- a/test_regress/t/t_property_sexpr_parse_unsup.py
+++ b/test_regress/t/t_property_sexpr_parse_unsup.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2025 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('vlt')
+
+test.top_filename = "t/t_property_sexpr_unsup.v"
+
+test.lint(expect_filename=test.golden_filename,
+          verilator_flags2=['-DPARSING_TIME', '--assert', '--timing', '--error-limit 1000'],
+          fails=True)
+
+test.passes()

--- a/test_regress/t/t_property_sexpr_unsup.out
+++ b/test_regress/t/t_property_sexpr_unsup.out
@@ -1,122 +1,23 @@
-%Error-UNSUPPORTED: t/t_property_sexpr_unsup.v:46:35: Unsupported: ## () cycle delay range expression
-   46 |   assert property (@(posedge clk) ##2 val)
-      |                                   ^~
+%Error-UNSUPPORTED: t/t_property_sexpr_unsup.v:32:41: Implication with sequence expression
+   32 |   assert property (@(posedge clk) ##1 1 |-> 1) $display("[%0t] single delay with const implication stmt, fileline:%d", $time, 32);
+      |                                         ^~~
                     ... For error description see https://verilator.org/warn/UNSUPPORTED?v=latest
-%Error-UNSUPPORTED: t/t_property_sexpr_unsup.v:46:39: Unsupported: ## (in sequence expression)
-   46 |   assert property (@(posedge clk) ##2 val)
-      |                                       ^~~
-%Error-UNSUPPORTED: t/t_property_sexpr_unsup.v:49:35: Unsupported: ## () cycle delay range expression
-   49 |   assert property (@(posedge clk) ##1 1 |=> 0)
-      |                                   ^~
-%Error-UNSUPPORTED: t/t_property_sexpr_unsup.v:49:39: Unsupported: ## (in sequence expression)
-   49 |   assert property (@(posedge clk) ##1 1 |=> 0)
-      |                                       ^
-%Error-UNSUPPORTED: t/t_property_sexpr_unsup.v:52:35: Unsupported: ## () cycle delay range expression
-   52 |   assert property (@(posedge clk) ##1 1 |=> not (val))
-      |                                   ^~
-%Error-UNSUPPORTED: t/t_property_sexpr_unsup.v:52:39: Unsupported: ## (in sequence expression)
-   52 |   assert property (@(posedge clk) ##1 1 |=> not (val))
-      |                                       ^
-%Error-UNSUPPORTED: t/t_property_sexpr_unsup.v:55:35: Unsupported: ## () cycle delay range expression
-   55 |   assert property (@(posedge clk) ##1 val)
-      |                                   ^~
-%Error-UNSUPPORTED: t/t_property_sexpr_unsup.v:55:39: Unsupported: ## (in sequence expression)
-   55 |   assert property (@(posedge clk) ##1 val)
-      |                                       ^~~
-%Error-UNSUPPORTED: t/t_property_sexpr_unsup.v:58:35: Unsupported: ## () cycle delay range expression
-   58 |   assert property (@(posedge clk) ##1 (val))
-      |                                   ^~
-%Error-UNSUPPORTED: t/t_property_sexpr_unsup.v:58:40: Unsupported: ## (in sequence expression)
-   58 |   assert property (@(posedge clk) ##1 (val))
-      |                                        ^~~
-%Error-UNSUPPORTED: t/t_property_sexpr_unsup.v:61:36: Unsupported: ## () cycle delay range expression
-   61 |   assert property (@(posedge clk) (##1 (val)))
-      |                                    ^~
-%Error-UNSUPPORTED: t/t_property_sexpr_unsup.v:61:41: Unsupported: ## (in sequence expression)
-   61 |   assert property (@(posedge clk) (##1 (val)))
+%Error-UNSUPPORTED: t/t_property_sexpr_unsup.v:34:41: Implication with sequence expression
+   34 |   assert property (@(posedge clk) ##1 1 |-> not (val)) $display("[%0t] single delay implication with negated var stmt, fileline:%d", $time, 34);
       |                                         ^~~
-%Error-UNSUPPORTED: t/t_property_sexpr_unsup.v:64:36: Unsupported: ## () cycle delay range expression
-   64 |   assert property (@(posedge clk) (##1 (val)))
-      |                                    ^~
-%Error-UNSUPPORTED: t/t_property_sexpr_unsup.v:64:41: Unsupported: ## (in sequence expression)
-   64 |   assert property (@(posedge clk) (##1 (val)))
+%Error-UNSUPPORTED: t/t_property_sexpr_unsup.v:36:37: Implication with sequence expression
+   36 |   assert property (@(posedge clk) 1 |-> ##1 val) $display("[%0t] single delay implication with negated var stmt, fileline:%d", $time, 36);
+      |                                     ^~~
+%Error-UNSUPPORTED: t/t_property_sexpr_unsup.v:38:45: Implication with sequence expression
+   38 |   assert property (@(posedge clk) (##1 val) |-> (not val)) $display("[%0t] single delay with negated implication stmt, fileline:%d", $time, 38);
+      |                                             ^~~
+%Error-UNSUPPORTED: t/t_property_sexpr_unsup.v:40:45: Implication with sequence expression
+   40 |   assert property (@(posedge clk) ##1 (val) |-> not (val)) $display("[%0t] single delay with negated implication brackets stmt, fileline:%d", $time, 40);
+      |                                             ^~~
+%Error-UNSUPPORTED: t/t_property_sexpr_unsup.v:44:41: Implication with sequence expression
+   44 |   assert property (@(posedge clk) ##1 1 |-> 0) $display("[%0t] disable iff with cond implication stmt, fileline:%d", $time, 44);
       |                                         ^~~
-%Error-UNSUPPORTED: t/t_property_sexpr_unsup.v:67:40: Unsupported: ## () cycle delay range expression
-   67 |   assert property (@(posedge clk) not (##1 val))
-      |                                        ^~
-%Error-UNSUPPORTED: t/t_property_sexpr_unsup.v:67:44: Unsupported: ## (in sequence expression)
-   67 |   assert property (@(posedge clk) not (##1 val))
-      |                                            ^~~
-%Error-UNSUPPORTED: t/t_property_sexpr_unsup.v:70:35: Unsupported: ## () cycle delay range expression
-   70 |   assert property (@(posedge clk) ##1 1 |=> 1)
-      |                                   ^~
-%Error-UNSUPPORTED: t/t_property_sexpr_unsup.v:70:39: Unsupported: ## (in sequence expression)
-   70 |   assert property (@(posedge clk) ##1 1 |=> 1)
-      |                                       ^
-%Error-UNSUPPORTED: t/t_property_sexpr_unsup.v:73:35: Unsupported: ## () cycle delay range expression
-   73 |   assert property (@(posedge clk) ##1 val |=> not val)
-      |                                   ^~
-%Error-UNSUPPORTED: t/t_property_sexpr_unsup.v:73:39: Unsupported: ## (in sequence expression)
-   73 |   assert property (@(posedge clk) ##1 val |=> not val)
-      |                                       ^~~
-%Error-UNSUPPORTED: t/t_property_sexpr_unsup.v:76:35: Unsupported: ## () cycle delay range expression
-   76 |   assert property (@(posedge clk) ##1 (val) |=> not (val))
-      |                                   ^~
-%Error-UNSUPPORTED: t/t_property_sexpr_unsup.v:76:40: Unsupported: ## (in sequence expression)
-   76 |   assert property (@(posedge clk) ##1 (val) |=> not (val))
-      |                                        ^~~
-%Error-UNSUPPORTED: t/t_property_sexpr_unsup.v:82:57: Unsupported: ## () cycle delay range expression
-   82 |   assert property (@(posedge clk) disable iff (cyc < 3) ##1 1 |=> cyc > 3)
-      |                                                         ^~
-%Error-UNSUPPORTED: t/t_property_sexpr_unsup.v:82:61: Unsupported: ## (in sequence expression)
-   82 |   assert property (@(posedge clk) disable iff (cyc < 3) ##1 1 |=> cyc > 3)
-      |                                                             ^
-%Error-UNSUPPORTED: t/t_property_sexpr_unsup.v:85:36: Unsupported: ## () cycle delay range expression
-   85 |   assert property (@(posedge clk) (##1 val) |=> (##1 val))
-      |                                    ^~
-%Error-UNSUPPORTED: t/t_property_sexpr_unsup.v:85:40: Unsupported: ## (in sequence expression)
-   85 |   assert property (@(posedge clk) (##1 val) |=> (##1 val))
-      |                                        ^~~
-%Error-UNSUPPORTED: t/t_property_sexpr_unsup.v:85:50: Unsupported: ## () cycle delay range expression
-   85 |   assert property (@(posedge clk) (##1 val) |=> (##1 val))
-      |                                                  ^~
-%Error-UNSUPPORTED: t/t_property_sexpr_unsup.v:85:54: Unsupported: ## (in sequence expression)
-   85 |   assert property (@(posedge clk) (##1 val) |=> (##1 val))
-      |                                                      ^~~
-%Error-UNSUPPORTED: t/t_property_sexpr_unsup.v:103:14: Unsupported sequence match items
-  103 |     ($rose(a), l_b = b) |-> ##[3:10] q[l_b];
-      |              ^
-%Error-UNSUPPORTED: t/t_property_sexpr_unsup.v:103:29: Unsupported: ## range cycle delay range expression
-  103 |     ($rose(a), l_b = b) |-> ##[3:10] q[l_b];
-      |                             ^~
-%Error-UNSUPPORTED: t/t_property_sexpr_unsup.v:103:39: Unsupported: ## (in sequence expression)
-  103 |     ($rose(a), l_b = b) |-> ##[3:10] q[l_b];
-      |                                       ^
-%Error-UNSUPPORTED: t/t_property_sexpr_unsup.v:102:13: Unsupported: property variable declaration
-  102 |     integer l_b;
-      |             ^~~
-%Error-UNSUPPORTED: t/t_property_sexpr_unsup.v:120:16: Unsupported sequence match items
-  120 |     (count == 0, l_t = $realtime) ##1 (count == 7)[->1] |-> $realtime - l_t < 50.5;
-      |                ^
-%Error-UNSUPPORTED: t/t_property_sexpr_unsup.v:120:35: Unsupported: ## () cycle delay range expression
-  120 |     (count == 0, l_t = $realtime) ##1 (count == 7)[->1] |-> $realtime - l_t < 50.5;
-      |                                   ^~
-%Error-UNSUPPORTED: t/t_property_sexpr_unsup.v:120:51: Unsupported: [-> boolean abbrev expression
-  120 |     (count == 0, l_t = $realtime) ##1 (count == 7)[->1] |-> $realtime - l_t < 50.5;
-      |                                                   ^~~
-%Error-UNSUPPORTED: t/t_property_sexpr_unsup.v:120:54: Unsupported: boolean abbrev (in sequence expression)
-  120 |     (count == 0, l_t = $realtime) ##1 (count == 7)[->1] |-> $realtime - l_t < 50.5;
-      |                                                      ^
-%Error-UNSUPPORTED: t/t_property_sexpr_unsup.v:120:37: Unsupported: ## (in sequence expression)
-  120 |     (count == 0, l_t = $realtime) ##1 (count == 7)[->1] |-> $realtime - l_t < 50.5;
-      |                                     ^
-%Error-UNSUPPORTED: t/t_property_sexpr_unsup.v:118:14: Unsupported: property variable declaration
-  118 |     realtime l_t;
-      |              ^~~
-%Error-UNSUPPORTED: t/t_property_sexpr_unsup.v:124:31: Unsupported: ## () cycle delay range expression
-  124 |   assert property (@clk not a ##1 b);
-      |                               ^~
-%Error-UNSUPPORTED: t/t_property_sexpr_unsup.v:124:33: Unsupported: ## (in sequence expression)
-  124 |   assert property (@clk not a ##1 b);
-      |                                 ^
+%Error-UNSUPPORTED: t/t_property_sexpr_unsup.v:46:45: Implication with sequence expression
+   46 |   assert property (@(posedge clk) (##1 val) |-> (##1 val)) $display("[%0t] two delays implication stmt, fileline:%d", $time, 46);
+      |                                             ^~~
 %Error: Exiting due to

--- a/test_regress/t/t_sequence_sexpr_unsup.out
+++ b/test_regress/t/t_sequence_sexpr_unsup.out
@@ -36,209 +36,182 @@
    52 |       a intersect b;
       |         ^~~~~~~~~
 %Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:55:4: Unsupported: sequence
-   55 |    sequence s_uni_cycdelay_int;
+   55 |    sequence s_uni_cycdelay_id;
       |    ^~~~~~~~
-%Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:56:7: Unsupported: ## () cycle delay range expression
-   56 |       ## 1 b;
+%Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:56:7: Unsupported: ## id cycle delay range expression
+   56 |       ## DELAY b;
       |       ^~
-%Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:56:12: Unsupported: ## (in sequence expression)
-   56 |       ## 1 b;
-      |            ^
 %Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:58:4: Unsupported: sequence
-   58 |    sequence s_uni_cycdelay_id;
+   58 |    sequence s_uni_cycdelay_pid;
       |    ^~~~~~~~
-%Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:59:7: Unsupported: ## id cycle delay range expression
-   59 |       ## DELAY b;
+%Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:59:7: Unsupported: ## () cycle delay range expression
+   59 |       ## ( DELAY ) b;
       |       ^~
-%Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:59:16: Unsupported: ## (in sequence expression)
-   59 |       ## DELAY b;
-      |                ^
 %Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:61:4: Unsupported: sequence
-   61 |    sequence s_uni_cycdelay_pid;
+   61 |    sequence s_uni_cycdelay_range;
       |    ^~~~~~~~
-%Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:62:7: Unsupported: ## () cycle delay range expression
-   62 |       ## ( DELAY ) b;
+%Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:62:7: Unsupported: ## range cycle delay range expression
+   62 |       ## [1:2] b;
       |       ^~
-%Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:62:20: Unsupported: ## (in sequence expression)
-   62 |       ## ( DELAY ) b;
-      |                    ^
 %Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:64:4: Unsupported: sequence
-   64 |    sequence s_uni_cycdelay_range;
+   64 |    sequence s_uni_cycdelay_star;
       |    ^~~~~~~~
-%Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:65:7: Unsupported: ## range cycle delay range expression
-   65 |       ## [1:2] b;
+%Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:65:7: Unsupported: ## [*] cycle delay range expression
+   65 |       ## [*] b;
       |       ^~
-%Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:65:16: Unsupported: ## (in sequence expression)
-   65 |       ## [1:2] b;
-      |                ^
 %Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:67:4: Unsupported: sequence
-   67 |    sequence s_uni_cycdelay_star;
+   67 |    sequence s_uni_cycdelay_plus;
       |    ^~~~~~~~
-%Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:68:7: Unsupported: ## [*] cycle delay range expression
-   68 |       ## [*] b;
+%Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:68:7: Unsupported: ## [+] cycle delay range expression
+   68 |       ## [+] b;
       |       ^~
-%Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:68:14: Unsupported: ## (in sequence expression)
-   68 |       ## [*] b;
-      |              ^
-%Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:70:4: Unsupported: sequence
-   70 |    sequence s_uni_cycdelay_plus;
+%Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:71:4: Unsupported: sequence
+   71 |    sequence s_cycdelay_int;
       |    ^~~~~~~~
-%Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:71:7: Unsupported: ## [+] cycle delay range expression
-   71 |       ## [+] b;
-      |       ^~
-%Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:71:14: Unsupported: ## (in sequence expression)
-   71 |       ## [+] b;
-      |              ^
+%Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:72:9: Unsupported: ## (in sequence expression)
+   72 |       a ## 1 b;
+      |         ^~
 %Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:74:4: Unsupported: sequence
-   74 |    sequence s_cycdelay_int;
+   74 |    sequence s_cycdelay_id;
       |    ^~~~~~~~
-%Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:75:9: Unsupported: ## () cycle delay range expression
-   75 |       a ## 1 b;
+%Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:75:9: Unsupported: ## id cycle delay range expression
+   75 |       a ## DELAY b;
       |         ^~
-%Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:75:12: Unsupported: ## (in sequence expression)
-   75 |       a ## 1 b;
-      |            ^
+%Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:75:9: Unsupported: ## (in sequence expression)
+   75 |       a ## DELAY b;
+      |         ^~
 %Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:77:4: Unsupported: sequence
-   77 |    sequence s_cycdelay_id;
+   77 |    sequence s_cycdelay_pid;
       |    ^~~~~~~~
-%Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:78:9: Unsupported: ## id cycle delay range expression
-   78 |       a ## DELAY b;
+%Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:78:9: Unsupported: ## () cycle delay range expression
+   78 |       a ## ( DELAY ) b;
       |         ^~
-%Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:78:9: Unsupported: ## (in sequence expression)
-   78 |       a ## DELAY b;
-      |         ^~
-%Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:80:4: Unsupported: sequence
-   80 |    sequence s_cycdelay_pid;
-      |    ^~~~~~~~
-%Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:81:9: Unsupported: ## () cycle delay range expression
-   81 |       a ## ( DELAY ) b;
-      |         ^~
-%Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:81:14: Unsupported: ## (in sequence expression)
-   81 |       a ## ( DELAY ) b;
+%Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:78:14: Unsupported: ## (in sequence expression)
+   78 |       a ## ( DELAY ) b;
       |              ^~~~~
-%Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:83:4: Unsupported: sequence
-   83 |    sequence s_cycdelay_range;
+%Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:80:4: Unsupported: sequence
+   80 |    sequence s_cycdelay_range;
       |    ^~~~~~~~
-%Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:84:9: Unsupported: ## range cycle delay range expression
-   84 |       a ## [1:2] b;
+%Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:81:9: Unsupported: ## range cycle delay range expression
+   81 |       a ## [1:2] b;
+      |         ^~
+%Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:81:9: Unsupported: ## (in sequence expression)
+   81 |       a ## [1:2] b;
+      |         ^~
+%Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:83:4: Unsupported: sequence
+   83 |    sequence s_cycdelay_star;
+      |    ^~~~~~~~
+%Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:84:9: Unsupported: ## [*] cycle delay range expression
+   84 |       a ## [*] b;
       |         ^~
 %Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:84:9: Unsupported: ## (in sequence expression)
-   84 |       a ## [1:2] b;
+   84 |       a ## [*] b;
       |         ^~
 %Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:86:4: Unsupported: sequence
-   86 |    sequence s_cycdelay_star;
+   86 |    sequence s_cycdelay_plus;
       |    ^~~~~~~~
-%Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:87:9: Unsupported: ## [*] cycle delay range expression
-   87 |       a ## [*] b;
+%Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:87:9: Unsupported: ## [+] cycle delay range expression
+   87 |       a ## [+] b;
       |         ^~
 %Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:87:9: Unsupported: ## (in sequence expression)
-   87 |       a ## [*] b;
+   87 |       a ## [+] b;
       |         ^~
-%Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:89:4: Unsupported: sequence
-   89 |    sequence s_cycdelay_plus;
+%Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:90:4: Unsupported: sequence
+   90 |    sequence s_booleanabbrev_brastar_int;
       |    ^~~~~~~~
-%Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:90:9: Unsupported: ## [+] cycle delay range expression
-   90 |       a ## [+] b;
+%Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:91:9: Unsupported: [*] boolean abbrev expression
+   91 |       a [* 1 ];
       |         ^~
-%Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:90:9: Unsupported: ## (in sequence expression)
-   90 |       a ## [+] b;
-      |         ^~
+%Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:91:12: Unsupported: boolean abbrev (in sequence expression)
+   91 |       a [* 1 ];
+      |            ^
 %Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:93:4: Unsupported: sequence
-   93 |    sequence s_booleanabbrev_brastar_int;
+   93 |    sequence s_booleanabbrev_brastar;
       |    ^~~~~~~~
 %Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:94:9: Unsupported: [*] boolean abbrev expression
-   94 |       a [* 1 ];
+   94 |       a [*];
       |         ^~
-%Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:94:12: Unsupported: boolean abbrev (in sequence expression)
-   94 |       a [* 1 ];
-      |            ^
+%Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:94:9: Unsupported: boolean abbrev (in sequence expression)
+   94 |       a [*];
+      |         ^~
 %Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:96:4: Unsupported: sequence
-   96 |    sequence s_booleanabbrev_brastar;
+   96 |    sequence s_booleanabbrev_plus;
       |    ^~~~~~~~
-%Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:97:9: Unsupported: [*] boolean abbrev expression
-   97 |       a [*];
-      |         ^~
+%Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:97:9: Unsupported: [+] boolean abbrev expression
+   97 |       a [+];
+      |         ^~~
 %Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:97:9: Unsupported: boolean abbrev (in sequence expression)
-   97 |       a [*];
-      |         ^~
+   97 |       a [+];
+      |         ^~~
 %Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:99:4: Unsupported: sequence
-   99 |    sequence s_booleanabbrev_plus;
+   99 |    sequence s_booleanabbrev_eq;
       |    ^~~~~~~~
-%Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:100:9: Unsupported: [+] boolean abbrev expression
-  100 |       a [+];
-      |         ^~~
-%Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:100:9: Unsupported: boolean abbrev (in sequence expression)
-  100 |       a [+];
-      |         ^~~
+%Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:100:9: Unsupported: [= boolean abbrev expression
+  100 |       a [= 1];
+      |         ^~
+%Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:100:12: Unsupported: boolean abbrev (in sequence expression)
+  100 |       a [= 1];
+      |            ^
 %Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:102:4: Unsupported: sequence
-  102 |    sequence s_booleanabbrev_eq;
+  102 |    sequence s_booleanabbrev_eq_range;
       |    ^~~~~~~~
 %Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:103:9: Unsupported: [= boolean abbrev expression
-  103 |       a [= 1];
+  103 |       a [= 1:2];
       |         ^~
 %Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:103:12: Unsupported: boolean abbrev (in sequence expression)
-  103 |       a [= 1];
+  103 |       a [= 1:2];
       |            ^
 %Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:105:4: Unsupported: sequence
-  105 |    sequence s_booleanabbrev_eq_range;
+  105 |    sequence s_booleanabbrev_minusgt;
       |    ^~~~~~~~
-%Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:106:9: Unsupported: [= boolean abbrev expression
-  106 |       a [= 1:2];
-      |         ^~
-%Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:106:12: Unsupported: boolean abbrev (in sequence expression)
-  106 |       a [= 1:2];
-      |            ^
+%Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:106:9: Unsupported: [-> boolean abbrev expression
+  106 |       a [-> 1];
+      |         ^~~
+%Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:106:13: Unsupported: boolean abbrev (in sequence expression)
+  106 |       a [-> 1];
+      |             ^
 %Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:108:4: Unsupported: sequence
-  108 |    sequence s_booleanabbrev_minusgt;
+  108 |    sequence s_booleanabbrev_minusgt_range;
       |    ^~~~~~~~
 %Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:109:9: Unsupported: [-> boolean abbrev expression
-  109 |       a [-> 1];
+  109 |       a [-> 1:2];
       |         ^~~
 %Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:109:13: Unsupported: boolean abbrev (in sequence expression)
-  109 |       a [-> 1];
+  109 |       a [-> 1:2];
       |             ^
-%Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:111:4: Unsupported: sequence
-  111 |    sequence s_booleanabbrev_minusgt_range;
+%Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:112:4: Unsupported: sequence
+  112 |    sequence p_arg_seqence(sequence inseq);
       |    ^~~~~~~~
-%Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:112:9: Unsupported: [-> boolean abbrev expression
-  112 |       a [-> 1:2];
-      |         ^~~
-%Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:112:13: Unsupported: boolean abbrev (in sequence expression)
-  112 |       a [-> 1:2];
-      |             ^
-%Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:115:4: Unsupported: sequence
-  115 |    sequence p_arg_seqence(sequence inseq);
-      |    ^~~~~~~~
-%Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:115:27: Unsupported: sequence argument data type
-  115 |    sequence p_arg_seqence(sequence inseq);
+%Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:112:27: Unsupported: sequence argument data type
+  112 |    sequence p_arg_seqence(sequence inseq);
       |                           ^~~~~~~~
+%Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:116:4: Unsupported: sequence
+  116 |    sequence s_firstmatch_a;
+      |    ^~~~~~~~
+%Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:117:7: Unsupported: first_match (in sequence expression)
+  117 |       first_match (a);
+      |       ^~~~~~~~~~~
 %Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:119:4: Unsupported: sequence
-  119 |    sequence s_firstmatch_a;
+  119 |    sequence s_firstmatch_ab;
       |    ^~~~~~~~
 %Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:120:7: Unsupported: first_match (in sequence expression)
-  120 |       first_match (a);
+  120 |       first_match (a, res0 = 1);
       |       ^~~~~~~~~~~
 %Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:122:4: Unsupported: sequence
-  122 |    sequence s_firstmatch_ab;
+  122 |    sequence s_firstmatch_abc;
       |    ^~~~~~~~
 %Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:123:7: Unsupported: first_match (in sequence expression)
-  123 |       first_match (a, res0 = 1);
+  123 |       first_match (a, res0 = 1, res1 = 2);
       |       ^~~~~~~~~~~
-%Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:125:4: Unsupported: sequence
-  125 |    sequence s_firstmatch_abc;
-      |    ^~~~~~~~
-%Error-UNSUPPORTED: t/t_sequence_sexpr_unsup.v:126:7: Unsupported: first_match (in sequence expression)
-  126 |       first_match (a, res0 = 1, res1 = 2);
-      |       ^~~~~~~~~~~
-%Warning-COVERIGN: t/t_sequence_sexpr_unsup.v:129:10: Ignoring unsupported: cover sequence
-  129 |    cover sequence (s_a) $display("");
+%Warning-COVERIGN: t/t_sequence_sexpr_unsup.v:126:10: Ignoring unsupported: cover sequence
+  126 |    cover sequence (s_a) $display("");
       |          ^~~~~~~~
                    ... For warning description see https://verilator.org/warn/COVERIGN?v=latest
                    ... Use "/* verilator lint_off COVERIGN */" and lint_on around source to disable this message.
-%Warning-COVERIGN: t/t_sequence_sexpr_unsup.v:130:10: Ignoring unsupported: cover sequence
-  130 |    cover sequence (@(posedge a) disable iff (b) s_a) $display("");
+%Warning-COVERIGN: t/t_sequence_sexpr_unsup.v:127:10: Ignoring unsupported: cover sequence
+  127 |    cover sequence (@(posedge a) disable iff (b) s_a) $display("");
       |          ^~~~~~~~
-%Warning-COVERIGN: t/t_sequence_sexpr_unsup.v:131:10: Ignoring unsupported: cover sequence
-  131 |    cover sequence (disable iff (b) s_a) $display("");
+%Warning-COVERIGN: t/t_sequence_sexpr_unsup.v:128:10: Ignoring unsupported: cover sequence
+  128 |    cover sequence (disable iff (b) s_a) $display("");
       |          ^~~~~~~~
 %Error: Exiting due to

--- a/test_regress/t/t_sequence_sexpr_unsup.v
+++ b/test_regress/t/t_sequence_sexpr_unsup.v
@@ -52,9 +52,6 @@ module t (/*AUTOARG*/
       a intersect b;
    endsequence
 
-   sequence s_uni_cycdelay_int;
-      ## 1 b;
-   endsequence
    sequence s_uni_cycdelay_id;
       ## DELAY b;
    endsequence


### PR DESCRIPTION
Adds support for simple sequence expressions such as:
1. Single element cycle delay sequence with an expression (ex. bit signal)
2. sexpr `not` operation.