### PR TITLE
Reduce memory use of statistic collection

### DIFF
--- a/src/V3StatsReport.cpp
+++ b/src/V3StatsReport.cpp
@@ -160,7 +160,12 @@ class StatsReport final {
 
 public:
     // METHODS
-    static void addStat(const V3Statistic& stat) { s_allStats.push_back(stat); }
+    static void addStat(const V3Statistic& stat) {
+        // Avoid memory blow-up when called frequently with zero adds,
+        // e.g. from V3Const invoked on individual expressions.
+        if (stat.sumit() && stat.value() == 0.0) return;
+        s_allStats.push_back(stat);
+    }
 
     static double getStatSum(const string& name) {
         // O(n^2) if called a lot; present assumption is only a small call count


### PR DESCRIPTION
PR #6495 added some new stats to V3Const using V3Stats::addStatSum, which allocates a new statistics record on each call. V3Const is often invoked on small pieces of Ast, e.g. just an expression, but even those calls add a new record with a zero value. This caused #6495 to increase peak memory consumption by ~15% on average in RTLMeter.

Quick fix by not adding a statistics record when the addend is zero.