### PR TITLE
Change public_flat* and other to support long names

### DIFF
--- a/src/V3Ast.h
+++ b/src/V3Ast.h
@@ -585,8 +585,8 @@ public:
     // ACCESSORS
     virtual string name() const VL_MT_STABLE { return ""; }
     virtual string origName() const { return ""; }
-    string prettyOrigOrName() const {
-        return prettyName(origName().empty() ? name() : origName());
+    string prettyDehashOrigOrName() const {
+        return prettyName(VName::dehash(origName().empty() ? name() : origName()));
     }
     virtual void name(const string& name) {
         this->v3fatalSrc("name() called on object without name() method");

--- a/src/V3Control.cpp
+++ b/src/V3Control.cpp
@@ -263,7 +263,7 @@ public:
         const VPragmaType pragma = VPragmaType::COVERAGE_BLOCK_OFF;
         if (!nodep->unnamed()) {
             for (const string& i : m_coverageOffBlocks) {
-                if (VString::wildmatch(nodep->prettyOrigOrName(), i)) {
+                if (VString::wildmatch(nodep->prettyDehashOrigOrName(), i)) {
                     nodep->addItemsp(new AstPragma{nodep->fileline(), pragma});
                 }
             }
@@ -274,7 +274,7 @@ public:
         const VPragmaType pragma = VPragmaType::COVERAGE_BLOCK_OFF;
         if (!nodep->unnamed()) {
             for (const string& i : m_coverageOffBlocks) {
-                if (VString::wildmatch(nodep->prettyOrigOrName(), i)) {
+                if (VString::wildmatch(nodep->prettyDehashOrigOrName(), i)) {
                     nodep->addStmtsp(new AstPragma{nodep->fileline(), pragma});
                 }
             }
@@ -754,7 +754,7 @@ void V3Control::applyCoverageBlock(AstNodeModule* modulep, AstBegin* nodep) {
     const string& filename = nodep->fileline()->filename();
     V3ControlFile* const filep = V3ControlResolver::s().files().resolve(filename);
     if (filep) filep->applyBlock(nodep);
-    const string& modname = modulep->prettyOrigOrName();
+    const string& modname = modulep->prettyDehashOrigOrName();
     V3ControlModule* const modp = V3ControlResolver::s().modules().resolve(modname);
     if (modp) modp->applyBlock(nodep);
 }
@@ -763,7 +763,7 @@ void V3Control::applyCoverageBlock(AstNodeModule* modulep, AstGenBlock* nodep) {
     const string& filename = nodep->fileline()->filename();
     V3ControlFile* const filep = V3ControlResolver::s().files().resolve(filename);
     if (filep) filep->applyBlock(nodep);
-    const string& modname = modulep->prettyOrigOrName();
+    const string& modname = modulep->prettyDehashOrigOrName();
     V3ControlModule* const modp = V3ControlResolver::s().modules().resolve(modname);
     if (modp) modp->applyBlock(nodep);
 }
@@ -775,16 +775,16 @@ void V3Control::applyIgnores(FileLine* filelinep) {
 }
 
 void V3Control::applyModule(AstNodeModule* modulep) {
-    const string& modname = modulep->prettyOrigOrName();
+    const string& modname = modulep->prettyDehashOrigOrName();
     V3ControlModule* const modp = V3ControlResolver::s().modules().resolve(modname);
     if (modp) modp->apply(modulep);
 }
 
 void V3Control::applyFTask(AstNodeModule* modulep, AstNodeFTask* ftaskp) {
-    const string& modname = modulep->prettyOrigOrName();
+    const string& modname = modulep->prettyDehashOrigOrName();
     V3ControlModule* const modp = V3ControlResolver::s().modules().resolve(modname);
     if (!modp) return;
-    const V3ControlFTask* const ftp = modp->ftasks().resolve(ftaskp->prettyOrigOrName());
+    const V3ControlFTask* const ftp = modp->ftasks().resolve(ftaskp->prettyDehashOrigOrName());
     if (ftp) ftp->apply(ftaskp);
 }
 
@@ -792,14 +792,14 @@ void V3Control::applyVarAttr(const AstNodeModule* modulep, const AstNodeFTask* f
                              AstVar* varp) {
     V3ControlVar* vp;
     V3ControlModule* const modp
-        = V3ControlResolver::s().modules().resolve(modulep->prettyOrigOrName());
+        = V3ControlResolver::s().modules().resolve(modulep->prettyDehashOrigOrName());
     if (!modp) return;
     if (ftaskp) {
-        V3ControlFTask* const ftp = modp->ftasks().resolve(ftaskp->prettyOrigOrName());
+        V3ControlFTask* const ftp = modp->ftasks().resolve(ftaskp->prettyDehashOrigOrName());
         if (!ftp) return;
-        vp = ftp->vars().resolve(varp->prettyOrigOrName());
+        vp = ftp->vars().resolve(varp->prettyDehashOrigOrName());
     } else {
-        vp = modp->vars().resolve(varp->prettyOrigOrName());
+        vp = modp->vars().resolve(varp->prettyDehashOrigOrName());
     }
     if (vp) vp->apply(varp);
 }

--- a/test_regress/t/t_vpi_escape.cpp
+++ b/test_regress/t/t_vpi_escape.cpp
@@ -156,7 +156,7 @@ int _mon_check_iter() {
     TEST_CHECK_CSTR(p, "\\mod.with_dot ");
     if (TestSimulator::is_verilator()) {
         p = vpi_get_str(vpiDefName, vh2);
-        TEST_CHECK_CSTR(p, "sub");
+        TEST_CHECK_CSTR(p, "sub_with_very___05Fvery_____VhshsmH6BYHIAHq4mnPF8T3lXnhhONMT1I4ouBvkJk58");
     }
 
     TestVpiHandle vh_null_name = my_vpi_handle("___0_");

--- a/test_regress/t/t_vpi_escape.cpp
+++ b/test_regress/t/t_vpi_escape.cpp
@@ -156,7 +156,8 @@ int _mon_check_iter() {
     TEST_CHECK_CSTR(p, "\\mod.with_dot ");
     if (TestSimulator::is_verilator()) {
         p = vpi_get_str(vpiDefName, vh2);
-        TEST_CHECK_CSTR(p, "sub_with_very___05Fvery_____VhshsmH6BYHIAHq4mnPF8T3lXnhhONMT1I4ouBvkJk58");
+        TEST_CHECK_CSTR(
+            p, "sub_with_very___05Fvery_____VhshsmH6BYHIAHq4mnPF8T3lXnhhONMT1I4ouBvkJk58");
     }
 
     TestVpiHandle vh_null_name = my_vpi_handle("___0_");

--- a/test_regress/t/t_vpi_escape.v
+++ b/test_regress/t/t_vpi_escape.v
@@ -62,13 +62,13 @@ extern "C" int mon_check();
 
    integer        status;
 
-   sub a0 (.cyc(cyc));
+   sub_with_very__very__very__very__very__very__very__very__very__very__very__very__very__very__very__very__very__very__very__very__very__very__very__very__very__very_long_name a0 (.cyc(cyc));
 
-   sub \mod.with_dot (.cyc(cyc));
+   sub_with_very__very__very__very__very__very__very__very__very__very__very__very__very__very__very__very__very__very__very__very__very__very__very__very__very__very_long_name \mod.with_dot (.cyc(cyc));
 
    // Check if scope names are not decoded twice
-   sub ___0F_ (.cyc(cyc));
-   sub ___0_ (.cyc(cyc));
+   sub_with_very__very__very__very__very__very__very__very__very__very__very__very__very__very__very__very__very__very__very__very__very__very__very__very__very__very_long_name ___0F_ (.cyc(cyc));
+   sub_with_very__very__very__very__very__very__very__very__very__very__very__very__very__very__very__very__very__very__very__very__very__very__very__very__very__very_long_name ___0_ (.cyc(cyc));
 
    initial begin
 
@@ -112,12 +112,12 @@ extern "C" int mon_check();
 
 endmodule
 
-module sub (
+module sub_with_very__very__very__very__very__very__very__very__very__very__very__very__very__very__very__very__very__very__very__very__very__very__very__very__very__very_long_name (
             input [31:0] cyc /*verilator public_flat_rd*/
             );
    reg \b.c /*verilator public_flat_rw*/;
    reg subsig1 /*verilator public_flat_rd*/;
-   reg subsig2 /*verilator public_flat_rd*/;
+   reg subsig2; // public in .vlt
 `ifdef IVERILOG
    // stop icarus optimizing signals away
    wire redundant = subsig1 | subsig2 | \b.c ;

--- a/test_regress/t/t_vpi_escape.vlt
+++ b/test_regress/t/t_vpi_escape.vlt
@@ -7,3 +7,4 @@
 `verilator_config
 
 public_flat_rd -module "*" -var "double__underscore__vlt"
+public_flat_rd -module "sub_with_very__very__very__very__very__very__very__very__very__very__very__very__very__very__very__very__very__very__very__very__very__very__very__very__very__very_long_name" -var "subsig2"


### PR DESCRIPTION
Fix `public_flat*` command for modules with very long names (that are
hashed by Verilator)

Follow up to d89df33fcd6de49b30a4d42a469e1f9de2da8aba.