### PR TITLE
Fix always_ff on constant edge

### DIFF
--- a/src/V3DfgOptimizer.cpp
+++ b/src/V3DfgOptimizer.cpp
@@ -266,6 +266,11 @@ class DataflowOptimize final {
                     if (hasExtWr) DfgVertexVar::setHasExtWrRefs(vscp);
                     return;
                 }
+                // TODO: remove once Actives can tolerate NEVER SenItems
+                if (AstSenItem* senItemp = VN_CAST(nodep, SenItem)) {
+                    senItemp->foreach(
+                        [](AstVarRef* refp) { DfgVertexVar::setHasExtRdRefs(refp->varScopep()); });
+                }
             } else {
                 if (AstVar* const varp = VN_CAST(nodep, Var)) {
                     const bool hasExtRd = varp->isPrimaryIO() || varp->isSigUserRdPublic()  //

--- a/test_regress/t/t_always_ff_never.py
+++ b/test_regress/t/t_always_ff_never.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2024 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator_st')
+
+test.compile()
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_always_ff_never.v
+++ b/test_regress/t/t_always_ff_never.v
@@ -1,0 +1,40 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2025 by Wilson Snyder.
+// SPDX-License-Identifier: CC0-1.0
+
+interface intf
+    (input wire clk /*verilator public*/ );
+endinterface
+
+module sub (
+    input wire clk,
+    input wire dat
+);
+    intf the_intf (.clk);
+
+    logic [63:0] last_transition = 123;
+    always_ff @(edge dat) begin
+        last_transition <= $time;
+    end
+
+    int cyc = 0;
+    always_ff @(posedge clk) begin
+        cyc <= cyc + 1;
+        if (cyc == 2) begin
+            if (last_transition != 123) $stop;
+            $write("*-* All Finished *-*\n");
+            $finish;
+        end
+    end
+endmodule
+
+module t (/*AUTOARG*/
+          // Inputs
+          clk
+          );
+   input clk;
+
+    sub the_sub (.clk, .dat ('0));
+endmodule


### PR DESCRIPTION
Added `t_always_ff_never` to show an internal error we're hitting:
```
%Error: Internal Error: t/t_always_ff_never.v:19:25: ../V3Delayed.cpp:1216: <= assignment in non-clocked block, should have been converted in V3Active
                                                   : ... note: In instance 't.the_sub'
-node: ASSIGNDLY 0x555557091a40 <e1316> {f19az} u1=0x1 @dt=0x555557095bc0@(G/w64)
   19 |         last_transition <= $time;
      |                         ^~
```
This happens because this in `V3Delayed`:
```
        UASSERT_OBJ(m_inSuspendableOrFork || m_activep->hasClocked(), nodep,
                    "<= assignment in non-clocked block, should have been converted in V3Active");
```
doesn't like that the `ACTIVE` only contains a `NEVER` `SENITEM`:
```
    1:2:2: ACTIVE 0x555557164c30 <e1583> {f18af}  sequent => SENTREE 0x555557162fd0 <e1582> {f18ap}
    1:2:2:1: SENTREE 0x555557162fd0 <e1582> {f18ap}
    1:2:2:1:1: SENITEM 0x555557163550 <e1717> {f18ar} [NEVER]
    1:2:2:2: ALWAYS 0x555557162000 <e1584> {f18af} [always_ff]
```
I naively tried to just bypass the assert when that is the case but that ended poorly in other ways.

I'm guessing that this whole active block should have been pruned before I got to this assert.  Is that a correct assumption and any suggestions on where that should happen?  I'm going to try adding such a thing to `V3Const` next.