### PR TITLE
Limit scope of local lambda variables to the lambda they are used in

### DIFF
--- a/src/V3EmitCFunc.h
+++ b/src/V3EmitCFunc.h
@@ -122,6 +122,8 @@ class EmitCFunc VL_NOT_FINAL : public EmitCConstInit {
     bool m_inUC = false;  // Inside an AstUCStmt or AstUCExpr
     bool m_emitConstInit = false;  // Emitting constant initializer
     bool m_createdScopeHash = false;  // Already created a scope hash
+    std::unordered_set<const AstVar*> localLambdaVars;  // Which vars are only local inside
+                                                        // lambdas, should not be used from classes
 
     // State associated with processing $display style string formatting
     struct EmitDispState final {
@@ -1169,6 +1171,30 @@ public:
         // GCC allows compound statements in expressions, but this is not standard.
         // So we use an immediate-evaluation lambda and comma operator
         putnbs(nodep, "([&]() {\n");
+
+        if (AstVarRef* varrefp = VN_CAST(nodep->resultp(), VarRef)) {
+            AstVar* varp = varrefp->varp();
+            bool exists = false;
+            for (AstNode* nextp = nodep->stmtsp(); nextp; nextp = nextp->nextp()) {
+                if (nextp->exists([varp](AstVarRef* refp2) { return varp == refp2->varp(); })) {
+                    exists = true;
+                    break;
+                }
+            }
+
+            if (exists && !varrefp->selfPointer().isEmpty() && !m_usevlSelfRef) {
+                // If this->localLambdaVar would be emitted here, construct it as a local variable
+                // instead
+                localLambdaVars.insert(varp);
+                nodep->stmtsp()->addHereThisAsNext(varp->unlinkFrBack());
+                AstCExpr* const exprp = new AstCExpr{nodep->fileline(), varp->name(), 0};
+                exprp->dtypeSetString();
+                nodep->addStmtsp(new AstCReturn{nodep->fileline(), exprp});
+                iterateAndNextConstNull(nodep->stmtsp());
+                puts("}())");
+                return;
+            }
+        }
         iterateAndNextConstNull(nodep->stmtsp());
         puts("}(), ");
         iterateAndNextConstNull(nodep->resultp());
@@ -1509,7 +1535,9 @@ public:
             putns(nodep, nodep->selfPointerProtect(m_useSelfForThis));
             return;
         } else if (!nodep->selfPointer().isEmpty()) {
-            emitDereference(nodep, nodep->selfPointerProtect(m_useSelfForThis));
+            if (localLambdaVars.find(varp) == localLambdaVars.end()) {
+                emitDereference(nodep, nodep->selfPointerProtect(m_useSelfForThis));
+            }
         }
         putns(nodep, nodep->varp()->nameProtect());
     }

--- a/test_regress/t/t_func_call_super_arg.py
+++ b/test_regress/t/t_func_call_super_arg.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2025 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile()
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_func_call_super_arg.v
+++ b/test_regress/t/t_func_call_super_arg.v
@@ -1,0 +1,27 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2025 by Antmicro.
+// SPDX-License-Identifier: CC0-1.0
+
+class base_reg_block;
+  function new(string name);
+  endfunction
+
+  function string build_coverage();
+    return "";
+  endfunction
+endclass
+
+class spi_reg_block extends base_reg_block;
+  function new();
+    super.new(build_coverage());
+  endfunction
+endclass
+
+module hvl_top;
+  initial begin
+    spi_reg_block test = new;
+    $finish;
+  end
+endmodule


### PR DESCRIPTION
If there is a variable used only inside a lambda, create it explicitly there and return it afterwards. Don't use the variable inside the class - this results in segfaults on super constructor calls, especially for uninitialized strings.