### PR TITLE
Internals: Hide CC make rules

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -56,7 +56,6 @@ jobs:
       CI_DEV_ASAN: ${{ inputs.dev-asan }}
       CI_DEV_GCOV: ${{ inputs.dev-gcov }}
       CI_RUNS_ON: ${{ inputs.os }}
-      CC: ${{ inputs.cc }}
       CXX: ${{ inputs.cc == 'clang' && 'clang++' || 'g++' }}
       CACHE_BASE_KEY: build-${{ inputs.os }}-${{ inputs.cc }}
       CCACHE_MAXSIZE: 1000M  # Per build matrix entry (* 5 = 5000M in total)

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -49,7 +49,6 @@ jobs:
       CI_BUILD_STAGE_NAME: test
       CI_RUNS_ON: ${{ inputs.os }}
       CI_RELOC: ${{inputs.reloc }}
-      CC: ${{ inputs.cc }}
       CXX: ${{ inputs.cc == 'clang' && 'clang++' || 'g++' }}
       CACHE_BASE_KEY: test-${{ inputs.os }}-${{ inputs.cc }}-${{inputs.reloc }}-${{ inputs.suite }}
       CCACHE_MAXSIZE: 100M  # Per build per suite (* 5 * 5 = 2500M in total)

--- a/ci/docker/buildenv/README.rst
+++ b/ci/docker/buildenv/README.rst
@@ -35,7 +35,7 @@ To change the compiler use the `-e` switch to pass environment variables:
 
 ::
 
-   docker run -ti -e CC=clang-18 -e CXX=clang++-18 verilator/verilator-buildenv test
+   docker run -ti -e CXX=clang++-18 verilator/verilator-buildenv test
 
 The tests, that involve numactl are not working due to security restrictions.
 To run those too, add the CAP_SYS_NICE capability during the start of the container:

--- a/ci/docker/buildenv/build.sh
+++ b/ci/docker/buildenv/build.sh
@@ -9,7 +9,6 @@
 
 : "${REPO:=https://github.com/verilator/verilator}"
 : "${REV:=master}"
-: "${CC:=gcc}"
 : "${CXX:=g++}"
 
 SRCS=$PWD/verilator

--- a/nodist/fuzzer/setup_user
+++ b/nodist/fuzzer/setup_user
@@ -16,7 +16,7 @@ set -e
 # Build instrumented version of verilator
 pushd ../..
 autoconf
-AFL_HARDEN=1 CC=afl-gcc CXX=afl-g++ ./configure $(cd ..; pwd)
+AFL_HARDEN=1 CXX=afl-g++ ./configure $(cd ..; pwd)
 make clean
 make -j $(ncpus)
 popd

--- a/src/Makefile_obj.in
+++ b/src/Makefile_obj.in
@@ -35,7 +35,7 @@ incdir = $(srcdir)/../include
 bldsrc = ..
 
 # Programs
-CC = @CC@
+CC = false # Everything is built as C++ via CXX
 CXX = @CXX@
 LINK = @CXX@
 LEX = @LEX@
@@ -396,8 +396,6 @@ $(TGT): $(PREDEP_H) $(OBJS)
 	$(OBJCACHE) ${CXX} ${CXXFLAGS} ${CXXFLAGSOBJ} ${CPPFLAGSWALL} ${CFG_CXXFLAGS_PCH} -c $< -o $@
 %.o: %.cpp
 	$(OBJCACHE) ${CXX} ${CXXFLAGS} ${CXXFLAGSOBJ} ${CPPFLAGSWALL} -c $< -o $@
-%.o: %.c
-	$(OBJCACHE) ${CC}  ${CFLAGS} ${CPPFLAGSWALL} -c $< -o $@
 
 V3ParseLex.o: V3ParseLex.cpp V3Lexer.yy.cpp V3ParseBison.c
 	$(OBJCACHE) ${CXX} ${CXXFLAGS} ${CXXFLAGSOBJ} ${CPPFLAGSPARSER} -c $< -o $@


### PR DESCRIPTION
All code is built as C++ via CXX, but we still have some references to CC. Trying to make sure we don't add plain C later by hiding the C compiler. (So it's always enough to override CXX=... in configure)
