### PR TITLE
Deprecate '--make cmake' option

### DIFF
--- a/docs/guide/deprecations.rst
+++ b/docs/guide/deprecations.rst
@@ -20,3 +20,9 @@ C++14 compiler support
 XML output
   Verilator currently supports XML parser output (enabled with `--xml-only`).
   Support for `--xml-*` options will be deprecated no sooner than January 2026.
+
+--make cmake
+  The `--make cmake` options is deprecated and will be removed no sooner than
+  January 2026. Use `--make json` instead. Note that the CMake integration
+  shipping with verialtor (verilator-config.mk) alerady uses `--make json` so
+  no changes are necessary if using taht

--- a/docs/guide/files.rst
+++ b/docs/guide/files.rst
@@ -42,8 +42,8 @@ For --cc/--sc, it creates:
 
 .. list-table::
 
-   * - *{prefix}*\ .cmake
-     - CMake include script for compiling (from --make cmake)
+   * - *{prefix}*\ .json
+     - JSON build definition compiling (from --make json)
    * - *{prefix}*\ .mk
      - Make include file for compiling (from --make gmake)
    * - *{prefix}*\ _classes.mk
@@ -99,8 +99,8 @@ For --hierarchical mode, it creates:
      - Make dependencies of the top module (from --hierarchical)
    * - *{prefix}*\ _hier.mk
      - Make file for hierarchical blocks (from --make gmake)
-   * - *{prefix}*\ __hierCMakeArgs.f
-     - Arguments for hierarchical Verilation (from --make cmake)
+   * - *{prefix}*\ __hierMkJsonArgs.f
+     - Arguments for hierarchical Verilation (from --make json)
    * - *{prefix}*\ __hierMkArgs.f
      - Arguments for hierarchical Verilation (from --make gmake)
    * - *{prefix}*\ __hierParameters.v

--- a/docs/guide/verilating.rst
+++ b/docs/guide/verilating.rst
@@ -59,7 +59,7 @@ When using these options:
    makefiles to generate an archive (.a) containing the objects.
 
 #. If :vlopt:`--binary` or :vlopt:`--build` is used, it calls :ref:`GNU
-   Make` or :ref:`CMake` to build the model.
+   Make` to build the model.
 
 Once a model is built, the next step is typically for the user to run it,
 see :ref:`Simulating`.

--- a/docs/spelling.txt
+++ b/docs/spelling.txt
@@ -768,7 +768,7 @@ hdr
 hdzhangdoc
 hh
 hier
-hierCMakeArgs
+hierMkJsonArgs
 hierMkArgs
 hierParameters
 hierVer

--- a/src/V3HierBlock.h
+++ b/src/V3HierBlock.h
@@ -99,8 +99,8 @@ public:
     const V3HierBlockParams& params() const { return m_params; }
     const AstNodeModule* modp() const { return m_modp; }
 
-    // For emitting Makefile and CMakeLists.txt
-    VStringList commandArgs(bool forCMake) const VL_MT_DISABLED;
+    // For emitting Makefile and build definition JSON
+    VStringList commandArgs(bool forMkJson) const VL_MT_DISABLED;
     VStringList hierBlockArgs() const VL_MT_DISABLED;
     string hierPrefix() const VL_MT_DISABLED;
     string hierSomeFilename(bool withDir, const char* prefix,
@@ -112,9 +112,9 @@ public:
     // Returns the original HDL file if it is not included in v3Global.opt.vFiles().
     string vFileIfNecessary() const VL_MT_DISABLED;
     // Write command line arguments to .f file for this hierarchical block
-    void writeCommandArgsFile(bool forCMake) const VL_MT_DISABLED;
+    void writeCommandArgsFile(bool forMkJson) const VL_MT_DISABLED;
     void writeParametersFile() const VL_MT_DISABLED;
-    string commandArgsFilename(bool forCMake) const VL_MT_DISABLED;
+    string commandArgsFilename(bool forMkJson) const VL_MT_DISABLED;
     string typeParametersFilename() const VL_MT_DISABLED;
 };
 
@@ -146,9 +146,9 @@ public:
     HierVector hierBlocksSorted() const VL_MT_DISABLED;
 
     // Write command line arguments to .f files for child Verilation run
-    void writeCommandArgsFiles(bool forCMake) const VL_MT_DISABLED;
+    void writeCommandArgsFiles(bool forMkJson) const VL_MT_DISABLED;
     void writeParametersFiles() const VL_MT_DISABLED;
-    static string topCommandArgsFilename(bool forCMake) VL_MT_DISABLED;
+    static string topCommandArgsFilename(bool forMkJson) VL_MT_DISABLED;
 
     static void createPlan(AstNetlist* nodep) VL_MT_DISABLED;
 };

--- a/src/V3Options.cpp
+++ b/src/V3Options.cpp
@@ -1520,6 +1520,8 @@ void V3Options::parseOptsList(FileLine* fl, const string& optdir, int argc,
     DECL_OPTION("-make", CbVal, [this, fl](const char* valp) {
         if (!std::strcmp(valp, "cmake")) {
             m_cmake = true;
+            fl->v3warn(DEPRECATED,
+                       "Option '--make cmake' is deprecated, use '--make json' instead");
         } else if (!std::strcmp(valp, "gmake")) {
             m_gmake = true;
         } else if (!std::strcmp(valp, "json")) {

--- a/src/Verilator.cpp
+++ b/src/Verilator.cpp
@@ -819,6 +819,7 @@ static void execBuildJob() {
     UASSERT(v3Global.opt.build(), "--build is not specified.");
     UASSERT(v3Global.opt.gmake(), "--build requires GNU Make.");
     UASSERT(!v3Global.opt.cmake(), "--build cannot use CMake.");
+    UASSERT(!v3Global.opt.makeJson(), "--build cannot use json build.");
     VlOs::DeltaWallTime buildWallTime{true};
     UINFO(1, "Start Build");
 

--- a/test_regress/driver.py
+++ b/test_regress/driver.py
@@ -1077,10 +1077,6 @@ class VlTest:
             verilator_flags += ["--threads", str(param['threads'])]
         if param['vltmt'] and re.search(r'-trace-fst ', checkflags):
             verilator_flags += ["--trace-threads 2"]
-        if param['verilator_make_cmake']:
-            verilator_flags += ["--make cmake"]
-        if param['verilator_make_gmake']:
-            verilator_flags += ["--make gmake"]
         if param['make_main'] and param['verilator_make_gmake']:
             verilator_flags += ["--exe"]
         if param['make_main'] and param['verilator_make_gmake']:

--- a/test_regress/t/t_flag_build_bad.py
+++ b/test_regress/t/t_flag_build_bad.py
@@ -15,7 +15,11 @@ test.compile(verilator_flags2=["--build --make gmake"],
              fails=True,
              expect_filename=test.golden_filename)
 
-test.compile(verilator_flags2=["--build --make cmake"],
+test.compile(verilator_flags2=["--build --make cmake -Wno-fatal"],
+             fails=True,
+             expect_filename="t/t_flag_build_bad_cmake.out")
+
+test.compile(verilator_flags2=["--build --make json"],
              fails=True,
              expect_filename=test.golden_filename)
 

--- a/test_regress/t/t_flag_build_bad_cmake.out
+++ b/test_regress/t/t_flag_build_bad_cmake.out
@@ -1,0 +1,6 @@
+%Warning-DEPRECATED: Option '--make cmake' is deprecated, use '--make json' instead
+                     ... For warning description see https://verilator.org/warn/DEPRECATED?v=latest
+                     ... Use "/* verilator lint_off DEPRECATED */" and lint_on around source to disable this message.
+%Error: --make cannot be used together with --build. Suggest see manual
+        ... See the manual at https://verilator.org/verilator_doc.html?v=latest for more assistance.
+%Error: Exiting due to

--- a/test_regress/t/t_flag_make_cmake.py
+++ b/test_regress/t/t_flag_make_cmake.py
@@ -13,9 +13,6 @@ test.scenarios('simulator')
 
 test.compile(verilator_make_gmake=False, verilator_make_cmake=True)
 
-if not test.have_cmake:
-    test.skip("cmake is not installed")
-
 cmakecache = test.obj_dir + "/CMakeCache.txt"
 if not os.path.exists(cmakecache):
     test.error(cmakecache + " does not exist")

--- a/test_regress/t/t_probdist_cmake.py
+++ b/test_regress/t/t_probdist_cmake.py
@@ -12,7 +12,7 @@ import vltest_bootstrap
 test.scenarios('simulator')
 test.top_filename = "t/t_probdist.v"
 
-test.compile(verilator_make_gmake=False, verilator_make_cmake=1)
+test.compile(verilator_make_gmake=False, verilator_make_cmake=True)
 
 test.execute()
 

--- a/test_regress/t/t_timing_cmake.py
+++ b/test_regress/t/t_timing_cmake.py
@@ -14,8 +14,6 @@ test.top_filename = "t/t_timing_events.v"
 
 if not test.have_coroutines:
     test.skip("No coroutine support")
-if not test.have_cmake:
-    test.skip("cmake is not installed")
 
 if re.search(r'clang', test.cxx_version):
     test.skip("Known clang bug on ubuntu-24.04")

--- a/test_regress/t/t_trace_fst_cmake.py
+++ b/test_regress/t/t_trace_fst_cmake.py
@@ -11,7 +11,7 @@ import vltest_bootstrap
 
 test.scenarios('vlt_all')
 
-test.compile(v_flags2=["--trace-fst"], verilator_make_gmake=False, verilator_make_cmake=1)
+test.compile(v_flags2=["--trace-fst"], verilator_make_gmake=False, verilator_make_cmake=True)
 
 test.execute()
 

--- a/test_regress/t/t_trace_fst_sc_cmake.py
+++ b/test_regress/t/t_trace_fst_sc_cmake.py
@@ -16,7 +16,7 @@ if not test.have_sc:
 
 test.compile(verilator_flags2=["--trace-fst --sc"],
              verilator_make_gmake=False,
-             verilator_make_cmake=1)
+             verilator_make_cmake=True)
 
 test.execute()
 


### PR DESCRIPTION
V3EmitCMake have been unused, and `--make cmake` untested since #5799. verilator-config.cmake uses `--make json` instead, so removing. I am assuming nobody uses `--make cmake` directly but uses `verilate` from verilator-config.cmake, in which case this should be fine, and in either case, we stopped testing `--make cmake` since #5799 and nobody have complained since.

Follow up from #6538.
