### PR TITLE
[#84740] Set higher timeout with ASAN

### DIFF
--- a/test_regress/t/t_opt_const_big_or_tree.py
+++ b/test_regress/t/t_opt_const_big_or_tree.py
@@ -14,7 +14,7 @@ test.scenarios('vlt_all')
 if test.have_dev_gcov:
     test.skip("Too slow with code coverage")
 
-test.timeout(10)
+test.timeout(10 if not test.have_dev_asan else 30)
 
 test.compile(verilator_make_gmake=False)
 


### PR DESCRIPTION
Set a higher timeout for this test when using `--enable-dev-asan` flag. This is needed because the test fails otherwise under G++.