### PR TITLE
Use CReturn for exiting loops on `$finish`

### DIFF
--- a/src/V3AstNodeStmt.h
+++ b/src/V3AstNodeStmt.h
@@ -619,6 +619,20 @@ public:
     int instrCount() const override { return 0; }  // Rarely executes
     bool sameNode(const AstNode* samep) const override { return fileline() == samep->fileline(); }
 };
+class AstFinishFork final : public AstNodeStmt {
+    // $finish in fork
+public:
+    explicit AstFinishFork(FileLine* fl)
+        : ASTGEN_SUPER_FinishFork(fl) {}
+    ASTGEN_MEMBERS_AstFinishFork;
+    bool isGateOptimizable() const override { return false; }
+    bool isPredictOptimizable() const override { return false; }
+    bool isPure() override { return false; }  // SPECIAL: $display has 'visual' ordering
+    bool isOutputter() override { return true; }  // SPECIAL: $display makes output
+    bool isUnlikely() const override { return true; }
+    int instrCount() const override { return 0; }  // Rarely executes
+    bool sameNode(const AstNode* samep) const override { return fileline() == samep->fileline(); }
+};
 class AstFireEvent final : public AstNodeStmt {
     // '-> _' and '->> _' event trigger statements
     // @astgen op1 := operandp : AstNodeExpr

--- a/src/V3CfgBuilder.cpp
+++ b/src/V3CfgBuilder.cpp
@@ -89,6 +89,7 @@ class CfgBuilder final : public VNVisitorConst {
     void visit(AstComment*) override {}  // ignore entirely
     void visit(AstDisplay* nodep) override { simpleStatement(nodep); }
     void visit(AstFinish* nodep) override { simpleStatement(nodep); }
+    void visit(AstFinishFork* nodep) override { simpleStatement(nodep); }
     void visit(AstStmtExpr* nodep) override { simpleStatement(nodep); }
     void visit(AstStop* nodep) override { simpleStatement(nodep); }
 

--- a/src/V3CfgLiveVariables.cpp
+++ b/src/V3CfgLiveVariables.cpp
@@ -164,6 +164,7 @@ class CfgLiveVariables final : VNVisitorConst {
     void visit(AstAssign* nodep) override { single(nodep); }
     void visit(AstDisplay* nodep) override { single(nodep); }
     void visit(AstFinish* nodep) override { single(nodep); }
+    void visit(AstFinishFork* nodep) override { single(nodep); }
     void visit(AstStmtExpr* nodep) override { single(nodep); }
     void visit(AstStop* nodep) override { single(nodep); }
 

--- a/src/V3EmitCFunc.h
+++ b/src/V3EmitCFunc.h
@@ -1248,6 +1248,18 @@ public:
         puts(cvtToStr(nodep->fileline()->lineno()));
         puts(", \"\");\n");
     }
+    void visit(AstFinishFork* nodep) override {
+        putns(nodep, "VL_FINISH_MT(");
+        putsQuoted(protect(nodep->fileline()->filename()));
+        puts(", ");
+        puts(cvtToStr(nodep->fileline()->lineno()));
+        puts(", \"\");\n");
+        if (m_cfuncp->isCoroutine()) {
+            putns(nodep, "co_return;\n");
+        } else {
+            putns(nodep, "return;\n");
+        }
+    }
     void visit(AstPrintTimeScale* nodep) override {
         putns(nodep, "VL_PRINTTIMESCALE(");
         putsQuoted(protect(nodep->prettyName()));

--- a/src/V3EmitV.cpp
+++ b/src/V3EmitV.cpp
@@ -542,6 +542,7 @@ class EmitVBaseVisitorConst VL_NOT_FINAL : public VNVisitorConst {
         puts(";\n");
     }
     void visit(AstFinish* nodep) override { putfs(nodep, "$finish;\n"); }
+    void visit(AstFinishFork* nodep) override { putfs(nodep, "$finish;\n"); }
     void visit(AstStmtExpr* nodep) override {
         iterateConst(nodep->exprp());
         puts(";\n");

--- a/src/V3LinkJump.cpp
+++ b/src/V3LinkJump.cpp
@@ -441,7 +441,10 @@ class LinkJumpVisitor final : public VNVisitor {
     void visit(AstFinish* nodep) override {
         if (nodep->user1SetOnce()) return;  // Process once
         iterateChildren(nodep);
-        if (m_loopp) {
+        if (m_inFork) {
+            nodep->replaceWith(new AstFinishFork{nodep->fileline()});
+            VL_DO_DANGLING(nodep->deleteTree(), nodep);
+        } else if (m_loopp) {
             // Jump to the end of the loop (post-finish)
             AstJumpBlock* const blockp = getJumpBlock(m_loopp, false);
             nodep->addNextHere(new AstJumpGo{nodep->fileline(), blockp});

--- a/test_regress/t/t_fork_finish.py
+++ b/test_regress/t/t_fork_finish.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2025 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile(verilator_flags2=["--timing"])
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_fork_finish.v
+++ b/test_regress/t/t_fork_finish.v
@@ -1,0 +1,21 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2025 by Antmicro.
+// SPDX-License-Identifier: CC0-1.0
+
+module t;
+  initial begin
+    forever begin
+      fork
+        begin
+          assert ($c(1)) begin
+            $write("*-* All Finished *-*\n");
+            $finish;
+          end
+          wait ($c(1));
+        end
+      join_any
+    end
+  end
+endmodule


### PR DESCRIPTION
Changes introduced in https://github.com/verilator/verilator/commit/717667034be28c3c689d2ff6fd4debb4f3ebec95 added support for terminating loops on `$finish` with jumps. However, when loops are nested or `$finish` is present inside a fork, jump labels are defined in a different scope leading to broken links in V3Order stage.

```
%Error: Internal Error: t/t_fork_finish.v:14:13: ../V3Broken.cpp:178: Broken link in node (or something without may
bePointedTo): '!blockp()->brokeExistsAbove()' @ ../V3AstNodes.cpp:2045
-node: JUMPGO 0x55555708b810 <e1291> {f14an} -> JUMPBLOCK 0x55555708b3f0 <e1681#> {f9af}
   14 |             $finish;
      |             ^~~~~~~
                        ... See the manual at https://verilator.org/verilator_doc.html?v=5.041 for more assistance.
- V3Ast.cpp:1397:     Dumping obj_vlt/t_fork_finish/Vt_fork_finish_990_final.tree
```
This implementation uses `AstCReturn` to terminate such loops immediately regardless of nesting level or coroutine presence.

To simplify cases for both `return;` and `co_return;`, I'd changed AstCReturn to handle void return as well as emission-time selection between C++ keywords (to avoid `return`s in AstCStmt in a code).