### PR TITLE
Fix side effects for improved FTask purity

### DIFF
--- a/src/V3AstNodes.cpp
+++ b/src/V3AstNodes.cpp
@@ -2912,7 +2912,6 @@ void AstNodeFTask::dump(std::ostream& str) const {
     if (isStatic()) str << " [STATIC]";
     if (verilogTask()) str << " [VTASK]";
     if (verilogFunction()) str << " [VFUNC]";
-    // str << (getPurityRecurse() ? " [PURE]" : " [IMPURE]");
     if ((dpiImport() || dpiExport()) && cname() != name()) str << " [c=" << cname() << "]";
 }
 bool AstNodeFTask::isPure() {
@@ -2932,13 +2931,9 @@ bool AstNodeFTask::getPurityRecurse() const {
             if (varp->isInoutOrRef()) return false;
         }
         if (!stmtp->isPure()) return false;
-        if (stmtp->exists([](AstNode* const nodep) {
-                if (AstNodeVarRef* const varrefp = VN_CAST(nodep, VarRef)) {
-                    return (!varrefp->varp()->isFuncLocal()
-                            || varrefp->varp()->lifetime().isStatic())
-                           && varrefp->access().isWriteOrRW();
-                }
-                return !nodep->isPure();
+        if (stmtp->exists([](const AstNodeVarRef* const varrefp) {
+                return (!varrefp->varp()->isFuncLocal() || varrefp->varp()->lifetime().isStatic())
+                       && varrefp->access().isWriteOrRW();
             }))
             return false;
     }

--- a/src/V3Const.cpp
+++ b/src/V3Const.cpp
@@ -3371,6 +3371,10 @@ class ConstVisitor final : public VNVisitor {
                     nodep->unlinkFrBack();
                 }
                 VL_DO_DANGLING(pushDeletep(nodep), nodep);
+
+                // Removed branch could contain only impurity within a function and the
+                // function could be purified
+                VIsCached::clearCacheTree();
             } else if (!AstNode::afterCommentp(nodep->thensp())
                        && !AstNode::afterCommentp(nodep->elsesp())) {
                 if (!nodep->condp()->isPure()) {

--- a/test_regress/t/t_func_purification.py
+++ b/test_regress/t/t_func_purification.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2025 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile()
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_func_purification.v
+++ b/test_regress/t/t_func_purification.v
@@ -1,0 +1,23 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2025 by Antmicro.
+// SPDX-License-Identifier: CC0-1.0
+
+module t;
+  initial begin
+    if (0 & func(1)) $stop;
+    $write("*-* All Finished *-*\n");
+    $finish;
+  end
+  function bit func(bit x);
+    if (x) begin
+      if (x) begin
+        return 1;
+      end else begin
+        $c("");
+      end
+      return 0;
+    end
+  endfunction
+endmodule


### PR DESCRIPTION
This PR initially was supposed to add purity for statements to solve issue that will be solved by [this PR](https://github.com/verilator/verilator/pull/6483). So, right now this PR contains everything that can be influenced by change in mentioned PR.

This fixes side-effect issues that can arise when impure functions that previously were marked incorrectly as `pure` will be marked correctly (in `case` and `inside` expressions were called multiple times and because of that the warnings `SIDEEFFECT` were issued) so, to fix this I compute value of `case_expression` and lhs of `inside` before its usage.

The another issue was:
```
%Warning-SIDEEFFECT: t/uvm/uvm_pkg_todo.svh:18913:97: Expression side effect may be mishandled
                                                    : ... note: In instance 't'
                                                    : ... Suggest use a temporary variable in place of this expression
18913 |        zombies = arb_sequence_q.find(item) with (item.request==SEQ_TYPE_LOCK && item.process_id.status inside {process::KILLED,process::FINISHED});
      |                                                                                                 ^~~~~~
```

This is caused by the fact that function `status` uses `$c` in order to get status and because of that it is marked as impure - even though it is pure.
To fix this we need to have some way to mark `$c` or whole function as pure.

**Why this worked before?** Verilator just ignored `$c` (in this particular case) and didn't check it's purity when it was in assign statement - and in this case it was (in assign statement) because returning a value is assigning it to a proper variable.

I've fixed this by introducing `$pc` which is exactly the same as `$c` except from the fact it is pure - it is user responsibility to use it properly.

Moreover, change of `case` behavior shall allow us to be compliant with the standard: `The case_expression shall be evaluated exactly once and before any of the case_item_expressions.` ~ `IEEE 1800-2023 12.5`

Also, there is one thing to consider. Currently, purity cache is cleared after `V3Const` it is done because optimization introduced in [this commit](https://github.com/verilator/verilator/commit/bdae48f6ae16235266edaefe016ddf6b2aeeee60#diff-878b3596a5f51938b52d1ef0a3100351cadc51634c2fd065cbdc29708f8f9186R1124) may remove one of the `if` branches and it may happen that the branch contained only impure statement in thole `FTask` - if this is a case the function `purified` itself and cache is invalid. Moreover, every `FTask` that calls this `FTask` may also become pure. So, cache shall be cleared after every such optimization. However, since `V3Const` is called multiple times we can just clear it after whole visitor - this way we only lose some potential optimization in current `V3Const` call by considering now pure `FTasks` as impure but those optimizations shall be applied in next `V3Const` run.
The thing to consider is if it shall stay this way or maybe cache should be clear more often.