### PR TITLE
Fix DFG synthesis non-determinism (#6557)

### DIFF
--- a/src/V3DfgSynthesize.cpp
+++ b/src/V3DfgSynthesize.cpp
@@ -532,7 +532,8 @@ class AstToDfgSynthesize final {
     // TYPES
     using Variable = std::conditional_t<T_Scoped, AstVarScope, AstVar>;
 
-    struct VariableComparator {
+    // SymTab must be ordered in order to yield stable results
+    struct VariableComparator final {
         bool operator()(const Variable* lhs, const Variable* rhs) const {
             return lhs->name() < rhs->name();
         }


### PR DESCRIPTION
Re: #6557 

I still need to do more testing on this and I haven't even run it through `test_regress` yet (we'll see what happens here) but this does appear to resolve the non-determinism in the one `.cpp` file I've been tracking.  I now get the same results in 1000/1000 runs.

The problem (as I believe to understand it) is that:

- `AstToDfgSynthesize::joinSymbolTables()` loops over a `SymTab`
- which calls `AstToDfgSynthesize::joinDrivers()`
- which calls `AstToDfgConverter::createTmp()` with (notably with a `SynthJoin` prefix)
- which calls `DfgGraph::makeNewVar()`
- which adds `AstVar`s and possibly `AstVarScope`s to a module

`SynthJoin` tracks with the AST diffs I mentioned in #6557.  And in that first AST diff only the order of vars seems to be permuted.  Fixing the ordering of that loop seems to have resolved the issue.

Of course, I have no idea what this does to performance.  I'm sure all the string compares are terrible.  So please let me know if there is a better way to accomplish this.