### PR TITLE
Internals: Make AstCExpr always cleanOut (#6280)

### DIFF
--- a/include/verilated_dpi.h
+++ b/include/verilated_dpi.h
@@ -42,10 +42,18 @@ static inline void VL_SET_W_SVBV(int obits, WDataOutP owp, const svBitVecVal* lw
     for (int i = 0; i < words - 1; ++i) owp[i] = lwp[i];
     owp[words - 1] = lwp[words - 1] & VL_MASK_I(obits);
 }
-static inline QData VL_SET_Q_SVBV(const svBitVecVal* lwp) VL_MT_SAFE {
-    return VL_SET_QII(lwp[1], lwp[0]);
+static inline void VL_SET_Q_SVBV(int obits, QData& out, const svBitVecVal* lwp) VL_MT_SAFE {
+    out = VL_MASK_Q(obits) & VL_SET_QII(lwp[1], lwp[0]);
 }
-static inline IData VL_SET_I_SVBV(const svBitVecVal* lwp) VL_MT_SAFE { return lwp[0]; }
+static inline void VL_SET_I_SVBV(int obits, IData& out, const svBitVecVal* lwp) VL_MT_SAFE {
+    out = VL_MASK_I(obits) & lwp[0];
+}
+static inline void VL_SET_S_SVBV(int obits, SData& out, const svBitVecVal* lwp) VL_MT_SAFE {
+    out = VL_MASK_I(obits) & lwp[0];
+}
+static inline void VL_SET_C_SVBV(int obits, CData& out, const svBitVecVal* lwp) VL_MT_SAFE {
+    out = VL_MASK_I(obits) & lwp[0];
+}
 
 // Convert Verilator internal data to svBitVecVal
 static inline void VL_SET_SVBV_W(int obits, svBitVecVal* owp, const WDataInP lwp) VL_MT_SAFE {
@@ -65,10 +73,18 @@ static inline void VL_SET_W_SVLV(int obits, WDataOutP owp, const svLogicVecVal* 
     for (int i = 0; i < words - 1; ++i) owp[i] = lwp[i].aval;
     owp[words - 1] = lwp[words - 1].aval & VL_MASK_I(obits);
 }
-static inline QData VL_SET_Q_SVLV(const svLogicVecVal* lwp) VL_MT_SAFE {
-    return VL_SET_QII(lwp[1].aval, lwp[0].aval);
+static inline void VL_SET_Q_SVLV(int obits, QData& out, const svLogicVecVal* lwp) VL_MT_SAFE {
+    out = VL_MASK_Q(obits) & VL_SET_QII(lwp[1].aval, lwp[0].aval);
 }
-static inline IData VL_SET_I_SVLV(const svLogicVecVal* lwp) VL_MT_SAFE { return lwp[0].aval; }
+static inline void VL_SET_I_SVLV(int obits, IData& out, const svLogicVecVal* lwp) VL_MT_SAFE {
+    out = VL_MASK_I(obits) & lwp[0].aval;
+}
+static inline void VL_SET_S_SVLV(int obits, SData& out, const svLogicVecVal* lwp) VL_MT_SAFE {
+    out = VL_MASK_I(obits) & lwp[0].aval;
+}
+static inline void VL_SET_C_SVLV(int obits, CData& out, const svLogicVecVal* lwp) VL_MT_SAFE {
+    out = VL_MASK_I(obits) & lwp[0].aval;
+}
 
 // Convert Verilator internal data to svLogicVecVal
 // Note these functions never create X/Z in svLogicVecVal

--- a/src/V3AstInlines.h
+++ b/src/V3AstInlines.h
@@ -159,9 +159,8 @@ AstCStmt::AstCStmt(FileLine* fl, const string& textStmt)
     addExprsp(new AstText{fl, textStmt, true});
 }
 
-AstCExpr::AstCExpr(FileLine* fl, const string& textStmt, int setwidth, bool cleanOut)
+AstCExpr::AstCExpr(FileLine* fl, const string& textStmt, int setwidth)
     : ASTGEN_SUPER_CExpr(fl)
-    , m_cleanOut{cleanOut}
     , m_pure{true} {
     addExprsp(new AstText{fl, textStmt, true});
     if (setwidth) dtypeSetLogicSized(setwidth, VSigning::UNSIGNED);

--- a/src/V3AstNodeExpr.h
+++ b/src/V3AstNodeExpr.h
@@ -564,22 +564,20 @@ public:
 };
 class AstCExpr final : public AstNodeExpr {
     // @astgen op1 := exprsp : List[AstNode] // Expressions to print
-    const bool m_cleanOut;
     bool m_pure;  // Pure optimizable
 public:
     // Emit C textual expr function (like AstUCFunc)
     AstCExpr(FileLine* fl, AstNode* exprsp)
         : ASTGEN_SUPER_CExpr(fl)
-        , m_cleanOut{true}
         , m_pure{false} {
         addExprsp(exprsp);
         dtypeFrom(exprsp);
     }
-    inline AstCExpr(FileLine* fl, const string& textStmt, int setwidth, bool cleanOut = true);
+    inline AstCExpr(FileLine* fl, const string& textStmt, int setwidth);
     ASTGEN_MEMBERS_AstCExpr;
     bool isGateOptimizable() const override { return m_pure; }
     bool isPredictOptimizable() const override { return m_pure; }
-    bool cleanOut() const override { return m_cleanOut; }
+    bool cleanOut() const override { return true; }
     string emitVerilog() override { V3ERROR_NA_RETURN(""); }
     string emitC() override { V3ERROR_NA_RETURN(""); }
     bool sameNode(const AstNode* /*samep*/) const override { return true; }

--- a/src/V3Sched.cpp
+++ b/src/V3Sched.cpp
@@ -453,7 +453,7 @@ void orderSequentially(AstCFunc* funcp, const LogicByScope& lbs) {
                             subFuncp->slow(false);
                             FileLine* const flp = procp->fileline();
                             AstNodeExpr* const condp = new AstCExpr{
-                                flp, "VL_LIKELY(!vlSymsp->_vm_contextp__->gotFinish())", 1, true};
+                                flp, "VL_LIKELY(!vlSymsp->_vm_contextp__->gotFinish())", 1};
                             AstLoop* const loopp = new AstLoop{flp};
                             loopp->addStmtsp(new AstLoopTest{flp, loopp, condp});
                             loopp->addStmtsp(bodyp);

--- a/src/V3Timing.cpp
+++ b/src/V3Timing.cpp
@@ -1186,7 +1186,7 @@ class TimingControlVisitor final : public VNVisitor {
             if (constp->isZero()) {
                 // We have to await forever instead of simply returning in case we're deep in a
                 // callstack
-                AstCExpr* const foreverp = new AstCExpr{flp, "VlForever{}", 0, true};
+                AstCExpr* const foreverp = new AstCExpr{flp, "VlForever{}", 0};
                 foreverp->dtypeSetVoid();  // TODO: this is sloppy but harmless
                 AstCAwait* const awaitp = new AstCAwait{flp, foreverp};
                 awaitp->dtypeSetVoid();

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -6708,7 +6708,7 @@ class WidthVisitor final : public VNVisitor {
                 classp->baseMostClassp()->needRNG(true);
                 v3Global.useRandomizeMethods(true);
                 AstCExpr* const newp
-                    = new AstCExpr{nodep->fileline(), "__Vm_rng.get_randstate()", 1, true};
+                    = new AstCExpr{nodep->fileline(), "__Vm_rng.get_randstate()", 1};
                 newp->dtypeSetString();
                 nodep->replaceWith(newp);
                 VL_DO_DANGLING(pushDeletep(nodep), nodep);
@@ -6721,7 +6721,7 @@ class WidthVisitor final : public VNVisitor {
                 classp->baseMostClassp()->needRNG(true);
                 v3Global.useRandomizeMethods(true);
                 AstCExpr* const newp
-                    = new AstCExpr{nodep->fileline(), "__Vm_rng.set_randstate(", 1, true};
+                    = new AstCExpr{nodep->fileline(), "__Vm_rng.set_randstate(", 1};
                 newp->addExprsp(exprp->unlinkFrBack());
                 newp->addExprsp(new AstText{nodep->fileline(), ")", true});
                 newp->dtypeSetString();


### PR DESCRIPTION
Roundabout patch, but the cleanOut flag in AstCExpr is a bit in the way for cleanups necessary for #6280.

There was exactly one place in V3Task, handling DPI arguments when we relied on cleanOut of AstCExpr being false for masking. Made that code do the relevant masking via a few new run-time functions, which also eliminates some special cases in the relevant V3Task functions.
