### PR TITLE
Internals: Refactor AstCFunc internals (#6280)

### DIFF
--- a/src/V3AstNodeOther.h
+++ b/src/V3AstNodeOther.h
@@ -459,10 +459,9 @@ class AstCFunc final : public AstNode {
     // C++ function
     // Parents:  MODULE/SCOPE
     // If adding node accessors, see below emptyBody
-    // @astgen op1 := argsp : List[AstNode]
-    // @astgen op2 := initsp : List[AstNode]
+    // @astgen op1 := argsp : List[AstVar]  // Argument (and return value) variables
+    // @astgen op2 := varsp : List[AstVar]  // Local variables
     // @astgen op3 := stmtsp : List[AstNode]
-    // @astgen op4 := finalsp : List[AstNode]
     //
     // @astgen ptr := m_scopep : Optional[AstScope]  // Scope that function is under
     string m_name;
@@ -599,9 +598,7 @@ public:
     bool recursive() const { return m_recursive; }
     void cost(int cost) { m_cost = cost; }
     // Special methods
-    bool emptyBody() const {
-        return !keepIfEmpty() && !argsp() && !initsp() && !stmtsp() && !finalsp();
-    }
+    bool emptyBody() const { return !keepIfEmpty() && !argsp() && !varsp() && !stmtsp(); }
 };
 class AstCLocalScope final : public AstNode {
     // Pack statements into an unnamed scope when generating C++

--- a/src/V3Depth.cpp
+++ b/src/V3Depth.cpp
@@ -52,7 +52,7 @@ class DepthVisitor final : public VNVisitor {
         AstVar* const varp = new AstVar{nodep->fileline(), VVarType::STMTTEMP,
                                         m_tempNames.get(nodep), nodep->dtypep()};
         if (m_cfuncp) {
-            m_cfuncp->addInitsp(varp);
+            m_cfuncp->addVarsp(varp);
         } else if (m_mtaskbodyp) {
             m_mtaskbodyp->addStmtsFirstp(varp);
         } else {

--- a/src/V3Descope.cpp
+++ b/src/V3Descope.cpp
@@ -135,9 +135,8 @@ class DescopeVisitor final : public VNVisitor {
                 // Multiple functions under this name, need a wrapper function
                 UINFO(6, "  Wrapping " << name << " multifuncs");
                 AstCFunc* const newfuncp = topFuncp->cloneTree(false);
-                if (newfuncp->initsp()) newfuncp->initsp()->unlinkFrBackWithNext()->deleteTree();
+                if (newfuncp->varsp()) newfuncp->varsp()->unlinkFrBackWithNext()->deleteTree();
                 if (newfuncp->stmtsp()) newfuncp->stmtsp()->unlinkFrBackWithNext()->deleteTree();
-                if (newfuncp->finalsp()) newfuncp->finalsp()->unlinkFrBackWithNext()->deleteTree();
                 newfuncp->name(name);
                 newfuncp->isStatic(false);
                 topFuncp->addNextHere(newfuncp);

--- a/src/V3EmitCFunc.h
+++ b/src/V3EmitCFunc.h
@@ -473,19 +473,14 @@ public:
             puts("auto& vlSelfRef = std::ref(*vlSelf).get();\n");
         }
 
-        if (nodep->initsp()) {
-            putsDecoration(nodep, "// Init\n");
-            iterateAndNextConstNull(nodep->initsp());
+        if (nodep->varsp()) {
+            putsDecoration(nodep, "// Locals\n");
+            iterateAndNextConstNull(nodep->varsp());
         }
 
         if (nodep->stmtsp()) {
             putsDecoration(nodep, "// Body\n");
             iterateAndNextConstNull(nodep->stmtsp());
-        }
-
-        if (nodep->finalsp()) {
-            putsDecoration(nodep, "// Final\n");
-            iterateAndNextConstNull(nodep->finalsp());
         }
 
         m_usevlSelfRef = false;

--- a/src/V3Expand.cpp
+++ b/src/V3Expand.cpp
@@ -159,7 +159,7 @@ class ExpandVisitor final : public VNVisitor {
         tmpp->isInternal(true);
         tmpp->noReset(true);
         tmpp->substConstOnly(true);
-        m_funcp->addInitsp(tmpp);
+        m_funcp->addVarsp(tmpp);
         insertBefore(placep, new AstAssign{flp, new AstVarRef{flp, tmpp, VAccess::WRITE}, valuep});
         return tmpp;
     }

--- a/src/V3Localize.cpp
+++ b/src/V3Localize.cpp
@@ -119,7 +119,7 @@ class LocalizeVisitor final : public VNVisitor {
                     = new AstVar{oldVarp->fileline(), oldVarp->varType(), newName, oldVarp};
                 newVarp->funcLocal(true);
                 newVarp->noReset(oldVarp->noReset());
-                funcp->addInitsp(newVarp);
+                funcp->addVarsp(newVarp);
 
                 // Fix up all the references within this function
                 const auto er = m_references(funcp).equal_range(nodep);

--- a/src/V3Premit.cpp
+++ b/src/V3Premit.cpp
@@ -91,7 +91,7 @@ class PremitVisitor final : public VNVisitor {
             // Keep as local temporary.
             const std::string name = "__Vtemp_" + std::to_string(++m_tmpVarCnt);
             varp = new AstVar{flp, VVarType::STMTTEMP, name, nodep->dtypep()};
-            m_cfuncp->addInitsp(varp);
+            m_cfuncp->addVarsp(varp);
             ++m_temporaryVarsCreated;
 
             // Assignment to put before the referencing statement

--- a/src/V3Sched.cpp
+++ b/src/V3Sched.cpp
@@ -345,8 +345,6 @@ void splitCheck(AstCFunc* ofuncp) {
     // Unlink all statements, then add item by item to new sub-functions
     AstBegin* const tempp = new AstBegin{ofuncp->fileline(), "[EditWrapper]",
                                          ofuncp->stmtsp()->unlinkFrBackWithNext(), false};
-    // Currently we do not use finalsp in V3Sched, if we do, it needs to be handled here
-    UASSERT_OBJ(!ofuncp->finalsp(), ofuncp, "Should not have any finalps");
     while (tempp->stmtsp()) {
         AstNode* const itemp = tempp->stmtsp()->unlinkFrBack();
         const int stmts = itemp->nodeCount();

--- a/src/V3SchedTiming.cpp
+++ b/src/V3SchedTiming.cpp
@@ -389,7 +389,7 @@ void transformForks(AstNetlist* const netlistp) {
                 nodep->replaceWith(callp->makeStmt());
                 // If we're in a class, add a vlSymsp arg
                 if (m_inClass) {
-                    newfuncp->addInitsp(new AstCStmt{nodep->fileline(), "VL_KEEP_THIS;"});
+                    newfuncp->addStmtsp(new AstCStmt{flp, "VL_KEEP_THIS;"});
                     newfuncp->argTypes(EmitCUtil::symClassVar());
                     callp->argTypes("vlSymsp");
                 }
@@ -398,11 +398,11 @@ void transformForks(AstNetlist* const netlistp) {
                 if (nodep->needProcess()) {
                     newfuncp->setNeedProcess();
                     newfuncp->addStmtsp(
-                        new AstCStmt{nodep->fileline(), "vlProcess->state(VlProcess::FINISHED);"});
+                        new AstCStmt{flp, "vlProcess->state(VlProcess::FINISHED);"});
                 }
                 if (!m_beginHasAwaits) {
                     // co_return at the end (either that or a co_await is required in a coroutine
-                    newfuncp->addStmtsp(new AstCStmt{nodep->fileline(), "co_return;"});
+                    newfuncp->addStmtsp(new AstCStmt{flp, "co_return;"});
                 } else {
                     m_awaitMoved = true;
                 }

--- a/src/V3Task.cpp
+++ b/src/V3Task.cpp
@@ -372,7 +372,7 @@ class TaskVisitor final : public VNVisitor {
     AstVarScope* createFuncVar(AstCFunc* funcp, const string& name, AstVar* examplep) {
         AstVar* const newvarp = new AstVar{funcp->fileline(), VVarType::BLOCKTEMP, name, examplep};
         newvarp->funcLocal(true);
-        funcp->addInitsp(newvarp);
+        funcp->addVarsp(newvarp);
         AstVarScope* const newvscp = new AstVarScope{funcp->fileline(), m_scopep, newvarp};
         m_scopep->addVarsp(newvscp);
         return newvscp;
@@ -1256,7 +1256,7 @@ class TaskVisitor final : public VNVisitor {
             // Need symbol table
             if (cfuncp->name() == "new") {
                 const string stmt = VIdProtect::protect("_ctor_var_reset") + "(vlSymsp);";
-                cfuncp->addInitsp(new AstCStmt{nodep->fileline(), stmt});
+                cfuncp->addStmtsp(new AstCStmt{nodep->fileline(), stmt});
             }
         }
         if (nodep->dpiContext()) {
@@ -1272,7 +1272,7 @@ class TaskVisitor final : public VNVisitor {
             // The AstScopeName is really a statement(ish) for tracking, not a function
             snp->dpiExport(true);
             snp->unlinkFrBack();
-            cfuncp->addInitsp(snp);
+            cfuncp->addStmtsp(snp);
         }
 
         // Create list of arguments and move to function
@@ -1332,7 +1332,7 @@ class TaskVisitor final : public VNVisitor {
 
         // Return statement
         if (rtnvscp && nodep->taskPublic()) {
-            cfuncp->addFinalsp(new AstCReturn{
+            cfuncp->addStmtsp(new AstCReturn{
                 rtnvscp->fileline(), new AstVarRef{rtnvscp->fileline(), rtnvscp, VAccess::READ}});
         }
         // Replace variable refs

--- a/src/V3Timing.cpp
+++ b/src/V3Timing.cpp
@@ -836,7 +836,14 @@ class TimingControlVisitor final : public VNVisitor {
 
         nodep->rtnType("VlCoroutine");
         // If in a class, create a shared pointer to 'this'
-        if (m_classp) nodep->addInitsp(new AstCStmt{nodep->fileline(), "VL_KEEP_THIS;"});
+        if (m_classp) {
+            AstCStmt* const cstmtp = new AstCStmt{nodep->fileline(), "VL_KEEP_THIS;"};
+            if (AstNode* const stmtsp = nodep->stmtsp()) {
+                stmtsp->addHereThisAsNext(cstmtp);
+            } else {
+                nodep->addStmtsp(cstmtp);
+            }
+        }
         AstNode* firstCoStmtp = nullptr;  // First co_* statement in the function
         nodep->exists([&](AstCAwait* const awaitp) -> bool { return (firstCoStmtp = awaitp); });
         if (!firstCoStmtp) {

--- a/src/V3TraceDecl.cpp
+++ b/src/V3TraceDecl.cpp
@@ -229,7 +229,7 @@ class TraceDeclVisitor final : public VNVisitor {
             const string n = cvtToStr(m_subFuncps.size());
             const string name{"trace_init_sub__" + m_currScopep->nameDotless() + "__" + n};
             AstCFunc* const funcp = newCFunc(flp, name);
-            funcp->addInitsp(new AstCStmt{flp, "const int c = vlSymsp->__Vm_baseCode;"});
+            funcp->addStmtsp(new AstCStmt{flp, "const int c = vlSymsp->__Vm_baseCode;"});
             m_subFuncps.push_back(funcp);
         }
         m_subFuncps.back()->addStmtsp(stmtp);

--- a/test_regress/t/t_json_only_debugcheck.out
+++ b/test_regress/t/t_json_only_debugcheck.out
@@ -15,7 +15,7 @@
      "scopep": [
       {"type":"SCOPE","name":"TOP","addr":"(Y)","loc":"d,11:8,11:9","aboveScopep":"UNLINKED","aboveCellp":"UNLINKED","modp":"(I)","varsp": [],"blocksp": [],"inlinesp": []}
     ]},
-    {"type":"CFUNC","name":"_eval_static","addr":"(Z)","loc":"a,0:0,0:0","slow":true,"isStatic":false,"dpiExportDispatcher":false,"dpiExportImpl":false,"dpiImportPrototype":false,"dpiImportWrapper":false,"dpiContext":false,"isConstructor":false,"isDestructor":false,"isVirtual":false,"isCoroutine":false,"needProcess":false,"scopep":"(Y)","argsp": [],"initsp": [],
+    {"type":"CFUNC","name":"_eval_static","addr":"(Z)","loc":"a,0:0,0:0","slow":true,"isStatic":false,"dpiExportDispatcher":false,"dpiExportImpl":false,"dpiImportPrototype":false,"dpiImportWrapper":false,"dpiContext":false,"isConstructor":false,"isDestructor":false,"isVirtual":false,"isCoroutine":false,"needProcess":false,"scopep":"(Y)","argsp": [],"varsp": [],
      "stmtsp": [
       {"type":"STMTEXPR","name":"","addr":"(AB)","loc":"d,11:8,11:9",
        "exprp": [
@@ -28,8 +28,8 @@
        "lhsp": [
         {"type":"VARREF","name":"__Vtrigprevexpr___TOP__clk__0","addr":"(HB)","loc":"d,63:22,63:25","dtypep":"(FB)","access":"WR","varp":"(N)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []}
-    ],"finalsp": []},
-    {"type":"CFUNC","name":"_eval_static__TOP","addr":"(DB)","loc":"d,11:8,11:9","slow":true,"isStatic":false,"dpiExportDispatcher":false,"dpiExportImpl":false,"dpiImportPrototype":false,"dpiImportWrapper":false,"dpiContext":false,"isConstructor":false,"isDestructor":false,"isVirtual":false,"isCoroutine":false,"needProcess":false,"scopep":"(Y)","argsp": [],"initsp": [],
+    ]},
+    {"type":"CFUNC","name":"_eval_static__TOP","addr":"(DB)","loc":"d,11:8,11:9","slow":true,"isStatic":false,"dpiExportDispatcher":false,"dpiExportImpl":false,"dpiImportPrototype":false,"dpiImportWrapper":false,"dpiContext":false,"isConstructor":false,"isDestructor":false,"isVirtual":false,"isCoroutine":false,"needProcess":false,"scopep":"(Y)","argsp": [],"varsp": [],
      "stmtsp": [
       {"type":"ASSIGN","name":"","addr":"(IB)","loc":"d,23:23,23:24","dtypep":"(R)",
        "rhsp": [
@@ -38,16 +38,16 @@
        "lhsp": [
         {"type":"VARREF","name":"t.cyc","addr":"(LB)","loc":"d,23:23,23:24","dtypep":"(R)","access":"WR","varp":"(Q)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []}
-    ],"finalsp": []},
-    {"type":"CFUNC","name":"_eval_initial","addr":"(MB)","loc":"a,0:0,0:0","slow":true,"isStatic":false,"dpiExportDispatcher":false,"dpiExportImpl":false,"dpiImportPrototype":false,"dpiImportWrapper":false,"dpiContext":false,"isConstructor":false,"isDestructor":false,"isVirtual":false,"isCoroutine":false,"needProcess":false,"scopep":"(Y)","argsp": [],"initsp": [],
+    ]},
+    {"type":"CFUNC","name":"_eval_initial","addr":"(MB)","loc":"a,0:0,0:0","slow":true,"isStatic":false,"dpiExportDispatcher":false,"dpiExportImpl":false,"dpiImportPrototype":false,"dpiImportWrapper":false,"dpiContext":false,"isConstructor":false,"isDestructor":false,"isVirtual":false,"isCoroutine":false,"needProcess":false,"scopep":"(Y)","argsp": [],"varsp": [],
      "stmtsp": [
       {"type":"STMTEXPR","name":"","addr":"(NB)","loc":"d,11:8,11:9",
        "exprp": [
         {"type":"CCALL","name":"","addr":"(OB)","loc":"d,11:8,11:9","dtypep":"(CB)","funcName":"_eval_initial__TOP","funcp":"(PB)","argsp": []}
       ]}
-    ],"finalsp": []},
+    ]},
     {"type":"CFUNC","name":"_eval_initial__TOP","addr":"(PB)","loc":"d,11:8,11:9","slow":true,"isStatic":false,"dpiExportDispatcher":false,"dpiExportImpl":false,"dpiImportPrototype":false,"dpiImportWrapper":false,"dpiContext":false,"isConstructor":false,"isDestructor":false,"isVirtual":false,"isCoroutine":false,"needProcess":false,"scopep":"(Y)","argsp": [],
-     "initsp": [
+     "varsp": [
       {"type":"VAR","name":"__Vtemp_1","addr":"(QB)","loc":"d,49:120,49:121","dtypep":"(RB)","origName":"__Vtemp_1","isSc":false,"isPrimaryIO":false,"isPrimaryClock":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"lifetime":"NONE","varType":"STMTTEMP","dtypeName":"string","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"ignorePostWrite":false,"ignoreSchedWrite":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []}
     ],
      "stmtsp": [
@@ -862,10 +862,10 @@
        "lhsp": [
         {"type":"VARREF","name":"t.e","addr":"(BN)","loc":"d,55:7,55:8","dtypep":"(TB)","access":"WR","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []}
-    ],"finalsp": []},
-    {"type":"CFUNC","name":"_eval_final","addr":"(CN)","loc":"a,0:0,0:0","slow":true,"isStatic":false,"dpiExportDispatcher":false,"dpiExportImpl":false,"dpiImportPrototype":false,"dpiImportWrapper":false,"dpiContext":false,"isConstructor":false,"isDestructor":false,"isVirtual":false,"isCoroutine":false,"needProcess":false,"scopep":"(Y)","argsp": [],"initsp": [],"stmtsp": [],"finalsp": []},
-    {"type":"CFUNC","name":"_eval_settle","addr":"(DN)","loc":"a,0:0,0:0","slow":true,"isStatic":false,"dpiExportDispatcher":false,"dpiExportImpl":false,"dpiImportPrototype":false,"dpiImportWrapper":false,"dpiContext":false,"isConstructor":false,"isDestructor":false,"isVirtual":false,"isCoroutine":false,"needProcess":false,"scopep":"(Y)","argsp": [],"initsp": [],"stmtsp": [],"finalsp": []},
-    {"type":"CFUNC","name":"_eval_triggers__act","addr":"(EN)","loc":"a,0:0,0:0","slow":false,"isStatic":false,"dpiExportDispatcher":false,"dpiExportImpl":false,"dpiImportPrototype":false,"dpiImportWrapper":false,"dpiContext":false,"isConstructor":false,"isDestructor":false,"isVirtual":false,"isCoroutine":false,"needProcess":false,"scopep":"(Y)","argsp": [],"initsp": [],
+    ]},
+    {"type":"CFUNC","name":"_eval_final","addr":"(CN)","loc":"a,0:0,0:0","slow":true,"isStatic":false,"dpiExportDispatcher":false,"dpiExportImpl":false,"dpiImportPrototype":false,"dpiImportWrapper":false,"dpiContext":false,"isConstructor":false,"isDestructor":false,"isVirtual":false,"isCoroutine":false,"needProcess":false,"scopep":"(Y)","argsp": [],"varsp": [],"stmtsp": []},
+    {"type":"CFUNC","name":"_eval_settle","addr":"(DN)","loc":"a,0:0,0:0","slow":true,"isStatic":false,"dpiExportDispatcher":false,"dpiExportImpl":false,"dpiImportPrototype":false,"dpiImportWrapper":false,"dpiContext":false,"isConstructor":false,"isDestructor":false,"isVirtual":false,"isCoroutine":false,"needProcess":false,"scopep":"(Y)","argsp": [],"varsp": [],"stmtsp": []},
+    {"type":"CFUNC","name":"_eval_triggers__act","addr":"(EN)","loc":"a,0:0,0:0","slow":false,"isStatic":false,"dpiExportDispatcher":false,"dpiExportImpl":false,"dpiImportPrototype":false,"dpiImportWrapper":false,"dpiContext":false,"isConstructor":false,"isDestructor":false,"isVirtual":false,"isCoroutine":false,"needProcess":false,"scopep":"(Y)","argsp": [],"varsp": [],
      "stmtsp": [
       {"type":"STMTEXPR","name":"","addr":"(FN)","loc":"d,11:8,11:9",
        "exprp": [
@@ -911,8 +911,8 @@
         {"type":"TEXT","name":"","addr":"(YN)","loc":"d,11:8,11:9","text":"}\n"},
         {"type":"TEXT","name":"","addr":"(ZN)","loc":"d,11:8,11:9","text":"#endif"}
       ]}
-    ],"finalsp": []},
-    {"type":"CFUNC","name":"_dump_triggers__act","addr":"(XN)","loc":"a,0:0,0:0","slow":true,"isStatic":false,"dpiExportDispatcher":false,"dpiExportImpl":false,"dpiImportPrototype":false,"dpiImportWrapper":false,"dpiContext":false,"isConstructor":false,"isDestructor":false,"isVirtual":false,"isCoroutine":false,"needProcess":false,"scopep":"(Y)","argsp": [],"initsp": [],
+    ]},
+    {"type":"CFUNC","name":"_dump_triggers__act","addr":"(XN)","loc":"a,0:0,0:0","slow":true,"isStatic":false,"dpiExportDispatcher":false,"dpiExportImpl":false,"dpiImportPrototype":false,"dpiImportWrapper":false,"dpiContext":false,"isConstructor":false,"isDestructor":false,"isVirtual":false,"isCoroutine":false,"needProcess":false,"scopep":"(Y)","argsp": [],"varsp": [],
      "stmtsp": [
       {"type":"IF","name":"","addr":"(AO)","loc":"d,11:8,11:9",
        "condp": [
@@ -958,8 +958,8 @@
           {"type":"TEXT","name":"","addr":"(RO)","loc":"d,11:8,11:9","text":"VL_DBG_MSGF(\"         'act' region trigger index 0 is active: @(posedge clk)\\n\");"}
         ]}
       ],"elsesp": []}
-    ],"finalsp": []},
-    {"type":"CFUNC","name":"_dump_triggers__nba","addr":"(SO)","loc":"a,0:0,0:0","slow":true,"isStatic":false,"dpiExportDispatcher":false,"dpiExportImpl":false,"dpiImportPrototype":false,"dpiImportWrapper":false,"dpiContext":false,"isConstructor":false,"isDestructor":false,"isVirtual":false,"isCoroutine":false,"needProcess":false,"scopep":"(Y)","argsp": [],"initsp": [],
+    ]},
+    {"type":"CFUNC","name":"_dump_triggers__nba","addr":"(SO)","loc":"a,0:0,0:0","slow":true,"isStatic":false,"dpiExportDispatcher":false,"dpiExportImpl":false,"dpiImportPrototype":false,"dpiImportWrapper":false,"dpiContext":false,"isConstructor":false,"isDestructor":false,"isVirtual":false,"isCoroutine":false,"needProcess":false,"scopep":"(Y)","argsp": [],"varsp": [],
      "stmtsp": [
       {"type":"IF","name":"","addr":"(TO)","loc":"d,11:8,11:9",
        "condp": [
@@ -1005,9 +1005,9 @@
           {"type":"TEXT","name":"","addr":"(IP)","loc":"d,11:8,11:9","text":"VL_DBG_MSGF(\"         'nba' region trigger index 0 is active: @(posedge clk)\\n\");"}
         ]}
       ],"elsesp": []}
-    ],"finalsp": []},
-    {"type":"CFUNC","name":"_eval_act","addr":"(JP)","loc":"a,0:0,0:0","slow":false,"isStatic":false,"dpiExportDispatcher":false,"dpiExportImpl":false,"dpiImportPrototype":false,"dpiImportWrapper":false,"dpiContext":false,"isConstructor":false,"isDestructor":false,"isVirtual":false,"isCoroutine":false,"needProcess":false,"scopep":"(Y)","argsp": [],"initsp": [],"stmtsp": [],"finalsp": []},
-    {"type":"CFUNC","name":"_eval_nba","addr":"(G)","loc":"a,0:0,0:0","slow":false,"isStatic":false,"dpiExportDispatcher":false,"dpiExportImpl":false,"dpiImportPrototype":false,"dpiImportWrapper":false,"dpiContext":false,"isConstructor":false,"isDestructor":false,"isVirtual":false,"isCoroutine":false,"needProcess":false,"scopep":"(Y)","argsp": [],"initsp": [],
+    ]},
+    {"type":"CFUNC","name":"_eval_act","addr":"(JP)","loc":"a,0:0,0:0","slow":false,"isStatic":false,"dpiExportDispatcher":false,"dpiExportImpl":false,"dpiImportPrototype":false,"dpiImportWrapper":false,"dpiContext":false,"isConstructor":false,"isDestructor":false,"isVirtual":false,"isCoroutine":false,"needProcess":false,"scopep":"(Y)","argsp": [],"varsp": [],"stmtsp": []},
+    {"type":"CFUNC","name":"_eval_nba","addr":"(G)","loc":"a,0:0,0:0","slow":false,"isStatic":false,"dpiExportDispatcher":false,"dpiExportImpl":false,"dpiImportPrototype":false,"dpiImportWrapper":false,"dpiContext":false,"isConstructor":false,"isDestructor":false,"isVirtual":false,"isCoroutine":false,"needProcess":false,"scopep":"(Y)","argsp": [],"varsp": [],
      "stmtsp": [
       {"type":"IF","name":"","addr":"(KP)","loc":"d,11:8,11:9",
        "condp": [
@@ -1031,9 +1031,9 @@
           {"type":"CCALL","name":"","addr":"(RP)","loc":"d,23:17,23:20","dtypep":"(CB)","funcName":"_nba_sequent__TOP__0","funcp":"(SP)","argsp": []}
         ]}
       ],"elsesp": []}
-    ],"finalsp": []},
+    ]},
     {"type":"CFUNC","name":"_nba_sequent__TOP__0","addr":"(SP)","loc":"d,23:17,23:20","slow":false,"isStatic":false,"dpiExportDispatcher":false,"dpiExportImpl":false,"dpiImportPrototype":false,"dpiImportWrapper":false,"dpiContext":false,"isConstructor":false,"isDestructor":false,"isVirtual":false,"isCoroutine":false,"needProcess":false,"scopep":"(Y)","argsp": [],
-     "initsp": [
+     "varsp": [
       {"type":"VAR","name":"__Vdly__t.cyc","addr":"(TP)","loc":"d,23:17,23:20","dtypep":"(R)","origName":"__Vdly__t__DOT__cyc","isSc":false,"isPrimaryIO":false,"isPrimaryClock":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":true,"lifetime":"NONE","varType":"BLOCKTEMP","dtypeName":"integer","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"ignorePostWrite":false,"ignoreSchedWrite":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
       {"type":"CRESET","name":"","addr":"(UP)","loc":"d,23:17,23:20","constructing":true,
        "varrefp": [
@@ -2409,9 +2409,9 @@
        "lhsp": [
         {"type":"VARREF","name":"t.e","addr":"(VIB)","loc":"d,24:9,24:10","dtypep":"(TB)","access":"WR","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []}
-    ],"finalsp": []},
+    ]},
     {"type":"CFUNC","name":"_eval_phase__act","addr":"(WIB)","loc":"a,0:0,0:0","slow":false,"isStatic":false,"dpiExportDispatcher":false,"dpiExportImpl":false,"dpiImportPrototype":false,"dpiImportWrapper":false,"dpiContext":false,"isConstructor":false,"isDestructor":false,"isVirtual":false,"isCoroutine":false,"needProcess":false,"scopep":"(Y)","argsp": [],
-     "initsp": [
+     "varsp": [
       {"type":"VAR","name":"__VpreTriggered","addr":"(XIB)","loc":"d,11:8,11:9","dtypep":"(V)","origName":"__VpreTriggered","isSc":false,"isPrimaryIO":false,"isPrimaryClock":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":true,"lifetime":"NONE","varType":"MODULETEMP","dtypeName":"VlTriggerVec","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"ignorePostWrite":false,"ignoreSchedWrite":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
       {"type":"VAR","name":"__VactExecute","addr":"(YIB)","loc":"d,11:8,11:9","dtypep":"(P)","origName":"__VactExecute","isSc":false,"isPrimaryIO":false,"isPrimaryClock":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":true,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":true,"lifetime":"NONE","varType":"MODULETEMP","dtypeName":"bit","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"ignorePostWrite":false,"ignoreSchedWrite":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []}
     ],
@@ -2465,9 +2465,9 @@
        "lhsp": [
         {"type":"VARREF","name":"__VactExecute","addr":"(TJB)","loc":"a,0:0,0:0","dtypep":"(FB)","access":"RD","varp":"(YIB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ]}
-    ],"finalsp": []},
+    ]},
     {"type":"CFUNC","name":"_eval_phase__nba","addr":"(UJB)","loc":"a,0:0,0:0","slow":false,"isStatic":false,"dpiExportDispatcher":false,"dpiExportImpl":false,"dpiImportPrototype":false,"dpiImportWrapper":false,"dpiContext":false,"isConstructor":false,"isDestructor":false,"isVirtual":false,"isCoroutine":false,"needProcess":false,"scopep":"(Y)","argsp": [],
-     "initsp": [
+     "varsp": [
       {"type":"VAR","name":"__VnbaExecute","addr":"(VJB)","loc":"d,11:8,11:9","dtypep":"(P)","origName":"__VnbaExecute","isSc":false,"isPrimaryIO":false,"isPrimaryClock":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":true,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":true,"lifetime":"NONE","varType":"MODULETEMP","dtypeName":"bit","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"ignorePostWrite":false,"ignoreSchedWrite":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []}
     ],
      "stmtsp": [
@@ -2502,9 +2502,9 @@
        "lhsp": [
         {"type":"VARREF","name":"__VnbaExecute","addr":"(IKB)","loc":"a,0:0,0:0","dtypep":"(FB)","access":"RD","varp":"(VJB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ]}
-    ],"finalsp": []},
+    ]},
     {"type":"CFUNC","name":"_eval","addr":"(F)","loc":"a,0:0,0:0","slow":false,"isStatic":false,"dpiExportDispatcher":false,"dpiExportImpl":false,"dpiImportPrototype":false,"dpiImportWrapper":false,"dpiContext":false,"isConstructor":false,"isDestructor":false,"isVirtual":false,"isCoroutine":false,"needProcess":false,"scopep":"(Y)","argsp": [],
-     "initsp": [
+     "varsp": [
       {"type":"VAR","name":"__VnbaIterCount","addr":"(JKB)","loc":"d,11:8,11:9","dtypep":"(T)","origName":"__VnbaIterCount","isSc":false,"isPrimaryIO":false,"isPrimaryClock":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":true,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":true,"lifetime":"NONE","varType":"MODULETEMP","dtypeName":"bit","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"ignorePostWrite":false,"ignoreSchedWrite":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
       {"type":"VAR","name":"__VnbaContinue","addr":"(KKB)","loc":"d,11:8,11:9","dtypep":"(P)","origName":"__VnbaContinue","isSc":false,"isPrimaryIO":false,"isPrimaryClock":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":true,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":true,"lifetime":"NONE","varType":"MODULETEMP","dtypeName":"bit","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"ignorePostWrite":false,"ignoreSchedWrite":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []}
     ],
@@ -2667,8 +2667,8 @@
           ],"timingControlp": []}
         ],"elsesp": []}
       ],"contsp": []}
-    ],"finalsp": []},
-    {"type":"CFUNC","name":"_eval_debug_assertions","addr":"(ZMB)","loc":"d,11:8,11:9","slow":false,"isStatic":false,"dpiExportDispatcher":false,"dpiExportImpl":false,"dpiImportPrototype":false,"dpiImportWrapper":false,"dpiContext":false,"isConstructor":false,"isDestructor":false,"isVirtual":false,"isCoroutine":false,"needProcess":false,"scopep":"UNLINKED","argsp": [],"initsp": [],
+    ]},
+    {"type":"CFUNC","name":"_eval_debug_assertions","addr":"(ZMB)","loc":"d,11:8,11:9","slow":false,"isStatic":false,"dpiExportDispatcher":false,"dpiExportImpl":false,"dpiImportPrototype":false,"dpiImportWrapper":false,"dpiContext":false,"isConstructor":false,"isDestructor":false,"isVirtual":false,"isCoroutine":false,"needProcess":false,"scopep":"UNLINKED","argsp": [],"varsp": [],
      "stmtsp": [
       {"type":"IF","name":"","addr":"(ANB)","loc":"d,15:10,15:13",
        "condp": [
@@ -2686,8 +2686,8 @@
           {"type":"TEXT","name":"","addr":"(GNB)","loc":"d,15:10,15:13","text":"Verilated::overWidthError(\"clk\");"}
         ]}
       ],"elsesp": []}
-    ],"finalsp": []},
-    {"type":"CFUNC","name":"_ctor_var_reset","addr":"(HNB)","loc":"d,11:8,11:9","slow":true,"isStatic":false,"dpiExportDispatcher":false,"dpiExportImpl":false,"dpiImportPrototype":false,"dpiImportWrapper":false,"dpiContext":false,"isConstructor":false,"isDestructor":false,"isVirtual":false,"isCoroutine":false,"needProcess":false,"scopep":"UNLINKED","argsp": [],"initsp": [],
+    ]},
+    {"type":"CFUNC","name":"_ctor_var_reset","addr":"(HNB)","loc":"d,11:8,11:9","slow":true,"isStatic":false,"dpiExportDispatcher":false,"dpiExportImpl":false,"dpiImportPrototype":false,"dpiImportWrapper":false,"dpiContext":false,"isConstructor":false,"isDestructor":false,"isVirtual":false,"isCoroutine":false,"needProcess":false,"scopep":"UNLINKED","argsp": [],"varsp": [],
      "stmtsp": [
       {"type":"CRESET","name":"","addr":"(INB)","loc":"d,15:10,15:13","constructing":true,
        "varrefp": [
@@ -2705,7 +2705,7 @@
        "varrefp": [
         {"type":"VARREF","name":"__Vtrigprevexpr___TOP__clk__0","addr":"(PNB)","loc":"d,11:8,11:9","dtypep":"(K)","access":"WR","varp":"(N)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ]}
-    ],"finalsp": []},
+    ]},
     {"type":"CUSE","name":"$unit","addr":"(QNB)","loc":"a,0:0,0:0","useType":"INT_FWD"}
   ]},
   {"type":"PACKAGE","name":"$unit","addr":"(E)","loc":"a,0:0,0:0","origName":"__024unit","level":0,"modPublic":false,"inLibrary":true,"dead":false,"recursiveClone":false,"recursive":false,"timeunit":"NONE","inlinesp": [],
@@ -2774,7 +2774,7 @@
       ]}
     ],"attrsp": []},
     {"type":"SCOPE","name":"$unit","addr":"(POB)","loc":"a,0:0,0:0","aboveScopep":"(Y)","aboveCellp":"(X)","modp":"(E)","varsp": [],"blocksp": [],"inlinesp": []},
-    {"type":"CFUNC","name":"_ctor_var_reset","addr":"(QOB)","loc":"a,0:0,0:0","slow":true,"isStatic":false,"dpiExportDispatcher":false,"dpiExportImpl":false,"dpiImportPrototype":false,"dpiImportWrapper":false,"dpiContext":false,"isConstructor":false,"isDestructor":false,"isVirtual":false,"isCoroutine":false,"needProcess":false,"scopep":"UNLINKED","argsp": [],"initsp": [],
+    {"type":"CFUNC","name":"_ctor_var_reset","addr":"(QOB)","loc":"a,0:0,0:0","slow":true,"isStatic":false,"dpiExportDispatcher":false,"dpiExportImpl":false,"dpiImportPrototype":false,"dpiImportWrapper":false,"dpiContext":false,"isConstructor":false,"isDestructor":false,"isVirtual":false,"isCoroutine":false,"needProcess":false,"scopep":"UNLINKED","argsp": [],"varsp": [],
      "stmtsp": [
       {"type":"CRESET","name":"","addr":"(ROB)","loc":"d,17:12,17:16","constructing":true,
        "varrefp": [
@@ -2788,7 +2788,7 @@
        "varrefp": [
         {"type":"VARREF","name":"__Venumtab_enum_name1","addr":"(WOB)","loc":"d,17:12,17:16","dtypep":"(HM)","access":"WR","varp":"(IM)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ]}
-    ],"finalsp": []}
+    ]}
   ]}
 ],
  "filesp": [


### PR DESCRIPTION
- Delete 'finalsp'. It was used in one place, basically unnecessary and safe to remove.
- Make 'argsp' a 'List[AstVar]'. This held before. It holds the function argument and return variables.
- Replace 'intitsp' with 'varsp' and make it into 'List[AstVar]' to hold the function local variables. This was most of its use before. The few places we inserted statements here now moved into 'stmtsp' by inserting at the front of the list.
