### PR TITLE
Tests: Fix driver.py error for missing scenario

### DIFF
--- a/test_regress/driver.py
+++ b/test_regress/driver.py
@@ -1367,7 +1367,7 @@ class VlTest:
                              ("--verbose" if self.verbose else ""),
                          ])
         else:
-            self.error("No compile step defined for '%s' scenario" % self.scenario())
+            self.error("No compile step defined for '%s' scenario" % self.scenario)
 
         if param['make_pli']:
             if self.verbose:


### PR DESCRIPTION
If all branches of the "if param[...]" condition in the compile function fail, an error is thrown. This error itself throws an error when attempting to print "self.scenario()", because self.scenario is not callable. This commit fixes this behavior by removing the parentheses.