### PR TITLE
CI: Disable ccache on macOS

### DIFF
--- a/ci/ci-script.bash
+++ b/ci/ci-script.bash
@@ -27,6 +27,8 @@ if [ "$CI_OS_NAME" = "linux" ]; then
 elif [ "$CI_OS_NAME" = "osx" ]; then
   export MAKE=make
   NPROC=$(sysctl -n hw.logicalcpu)
+  # Disable ccache, doesn't always work in GitHub Actions
+  export OBJCACHE=
 elif [ "$CI_OS_NAME" = "freebsd" ]; then
   export MAKE=gmake
   NPROC=$(sysctl -n hw.ncpu)


### PR DESCRIPTION
ccache seems bust on macOS, not sure if temporary, but we don't actually run tests on macOS, just build Verilator itself, so disabling should be fine for now.