### PR TITLE
Don't pick initial random values for verilator-created variables

### DIFF
--- a/src/V3EmitCFunc.cpp
+++ b/src/V3EmitCFunc.cpp
@@ -670,6 +670,7 @@ string EmitCFunc::emitVarResetRecurse(const AstVar* varp, bool constructing,
                || varp->isFuncLocal()  // Randomization too slow
                || (basicp && basicp->isZeroInit())
                || (v3Global.opt.underlineZero() && !varp->name().empty() && varp->name()[0] == '_')
+               || (varp->varType().isTemp() && !varp->isXTemp())
                || (varp->isXTemp()
                        ? (v3Global.opt.xAssign() != "unique")
                        : (v3Global.opt.xInitial() == "fast" || v3Global.opt.xInitial() == "0")));

--- a/test_regress/t/t_split_var_issue.py
+++ b/test_regress/t/t_split_var_issue.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2025 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios("simulator_st")
+
+test.compile(verilator_flags2=["--assert", "-fno-localize"])
+
+test.execute(all_run_flags=["+verilator+rand+reset+2"])
+
+test.passes()

--- a/test_regress/t/t_split_var_issue.v
+++ b/test_regress/t/t_split_var_issue.v
@@ -1,0 +1,50 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2025 by Wilson Snyder.
+// SPDX-License-Identifier: CC0-1.0
+
+module other_sub (
+    input wire clk,
+    input wire      foo,
+    output logic     [5:0] bar
+);
+    always_comb bar[0] = foo;
+`ifndef NO_ASSERT
+    assert property (@(posedge clk) (foo == bar[0]));
+`endif
+    always_ff @(posedge clk) bar[5:1] <= bar[4:0];
+endmodule
+
+interface intf
+    (input wire clk);
+endinterface
+
+module sub (
+    input logic clk
+);
+    for (genvar k = 0; k < 4; k++) begin
+        logic     [5:0] bar;
+        other_sub
+        the_other_sub (
+            .clk,
+            .foo ('1),
+            .bar
+        );
+    end
+endmodule
+
+module t (/*AUTOARG*/
+    clk
+    );
+    input clk;
+    int cyc = 0;
+    always @ (posedge clk) begin
+        cyc <= cyc + 1;
+        if (cyc == 9) begin
+            $write("*-* All Finished *-*\n");
+            $finish;
+        end
+    end
+    sub the_sub (.*);
+endmodule


### PR DESCRIPTION
I'm struggling to create a reproducer for this one but wanted to first discuss my current solution.  The problem we ran into involves code that looks something like:
```verilog
logic [N:0] foo;
always_comb foo[0] = bar;
for (k = 1; k < N+1; k++) begin : gen_loop
    always_ff @(posedge clk) foo[k] <= foo[k-1];
```
where `bar` is an input port which is connected to `'1`.

Our tests were failing in unexpected ways and we tracked it down to the fact that `foo[0]` was low, which was unexpected since `bar` was high.  The problem only presents with `--x-initial unique`.  Also, we have a number of instances of this logic but only some are affected.

Verilator is creating `VdlyMask` variables for `foo` because it is assigned via both blocking and non-blocking assignments.  And (I believe) due to output cfuncs splitting some of these `VdlyMask` variables are local to `Vtop_Foo___nba_sequent__*_0()` and some belong to `vlSelf` (again, I believe) because they are used across `Vtop_Foo___nba_sequent__*_[01]()`.  The ones that belong to `vlSelf` are initialized in `*___ctor_var_reset()` using `VL_SCOPED_RAND_RESET_I()` whereas the ones which are local to the one NBA function are initialized to `0`.

I think the rest of the story here is that the low bit of the `VdlyMask` variable should always be zero allowing the sequential assignment of that bit to be unperturbed during NBA.  However, because `VdlyMask` is randomized it can cause the mask to be wrong and then the initial assignment is incorrect and things fall apart from there.

Questions:
Is it intended that block, module and stmt temp vars should be randomized with `--x-initial`?

My problem with creating a reproducer is that I can observe the problem when verilating our many source files, but when I squash the source via `verilator -E` (in preparation for sv-bugpoint) the issue does not present on the squashed file (I'm running `-E` with all the same flag as when I observe the issue).  Does anyone know if code that has already been preprocessed with output split differently than code which has not?