### PR TITLE
Fix interface parameter access in parameter map (#6587) (#6621)

### DIFF
--- a/test_regress/t/t_interface_parameter_access.v
+++ b/test_regress/t/t_interface_parameter_access.v
@@ -70,12 +70,15 @@ endmodule
 
 
 module testmod
+  #(parameter SOME_PARAM = 789)
   (
    input clk,
    test_if.mp intf,
    test_if intf_no_mp,
    test_if.mp intf_array [1:0]
    );
+
+   test_if #(.FOO (intf.FOO)) some_other_intf ();
 
    // verilator lint_off HIERPARAM
    localparam THE_FOO = intf.FOO;
@@ -89,6 +92,10 @@ module testmod
    always @(posedge clk) begin
       if (THE_FOO != 5) begin
          $display("%%Error: THE_FOO = %0d", THE_FOO);
+         $stop;
+      end
+      if (some_other_intf.FOO != 5) begin
+         $display("%%Error: some_other_intf.FOO = %0d", some_other_intf.FOO);
          $stop;
       end
       if (THE_OTHER_FOO != 5) begin


### PR DESCRIPTION
I had to revert test runner commit per https://github.com/verilator/verilator/issues/6622 to get tests to run, so this will have to be separated out of this PR, but....

I think the second commit in this PR resolves the issue raised in https://github.com/verilator/verilator/pull/6621. I included that test addition in this PR and both these tests pass:

test_regress/t/t_interface_param_dependency.py
test_regress/t/t_interface_parameter_access.py

I beefed up some similar checking in test_regress/t/t_interface_param_dependency.v too.