### PR TITLE
issue_6622 - sched_getaffinity is linux-only; use fallback for MacOS

### DIFF
--- a/nodist/clang_check_attributes
+++ b/nodist/clang_check_attributes
@@ -1073,6 +1073,13 @@ class TopDownSummaryPrinter():
         print(f"Number of functions reported unsafe: {len(self._unsafe_in_safe)}")
 
 
+def get_cpu_count():
+    try:
+        return len(os.sched_getaffinity(0))
+    except AttributeError:
+        return multiprocessing.cpu_count()
+
+
 def main():
     default_verilator_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 
@@ -1115,7 +1122,7 @@ def main():
     cmdline = parser.parse_args()
 
     if cmdline.jobs == 0:
-        cmdline.jobs = max(1, len(os.sched_getaffinity(0)))
+        cmdline.jobs = max(1, get_cpu_count())
 
     if not cmdline.compilation_root:
         cmdline.compilation_root = cmdline.verilator_root

--- a/nodist/install_test
+++ b/nodist/install_test
@@ -3,6 +3,7 @@
 ######################################################################
 
 import argparse
+import multiprocessing
 import os
 import shutil
 import subprocess
@@ -91,8 +92,15 @@ def cleanenv():
             del os.environ[var]
 
 
+def get_cpu_count():
+    try:
+        return len(os.sched_getaffinity(0))
+    except AttributeError:
+        return multiprocessing.cpu_count()
+
+
 def calc_jobs():
-    return len(os.sched_getaffinity(0)) + 1
+    return get_cpu_count() + 1
 
 
 def run(command):

--- a/test_regress/driver.py
+++ b/test_regress/driver.py
@@ -2764,9 +2764,16 @@ def _calc_hashset() -> list:
 # Verilator utilities
 
 
+def get_cpu_count():
+    try:
+        return len(os.sched_getaffinity(0))
+    except AttributeError:
+        return multiprocessing.cpu_count()
+
+
 @lru_cache(maxsize=1)
 def max_procs() -> int:
-    procs = len(os.sched_getaffinity(0))
+    procs = get_cpu_count()
     if procs < 2:
         print("driver.py: Python didn't find at least two CPUs")
     return procs

--- a/test_regress/t/t_a7_hier_block_cmake.py
+++ b/test_regress/t/t_a7_hier_block_cmake.py
@@ -8,7 +8,16 @@
 # SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
 
 import vltest_bootstrap
+import multiprocessing
 import os
+
+
+def get_cpu_count():
+    try:
+        return len(os.sched_getaffinity(0))
+    except AttributeError:
+        return multiprocessing.cpu_count()
+
 
 # If a test fails, broken .cmake may disturb the next run
 test.clean_objs()
@@ -30,7 +39,7 @@ test.run(logfile=test.obj_dir + "/cmake.log",
 test.run(logfile=test.obj_dir + "/build.log",
          cmd=[
              'cd "' + test.obj_dir + '" && cmake --build', '.', ('-v' if test.verbose else ''),
-             '-j ' + str(len(os.sched_getaffinity(0))), '--', "CXX_FLAGS=" + str(threads)
+             '-j ' + str(get_cpu_count()), '--', "CXX_FLAGS=" + str(threads)
          ])
 
 test.run(logfile=test.obj_dir + "/run.log",


### PR DESCRIPTION
We appreciate your contributing to Verilator.  If this is your first commit, please add your name to docs/CONTRIBUTORS, and read our contributing guidelines in docs/CONTRIBUTING.rst.
