### PR TITLE
Internals: Replace AstMTaskBody with AstCFunc(#6280)

### DIFF
--- a/include/verilated_profiler.h
+++ b/include/verilated_profiler.h
@@ -120,7 +120,7 @@ public:
         m_type = Type::SECTION_PUSH;
     }
     void sectionPop() { m_type = Type::SECTION_POP; }
-    void mtaskBegin(uint32_t id, uint32_t predictStart, const char* hierBlock = "") {
+    void mtaskBegin(uint32_t id, uint32_t predictStart, const char* hierBlock) {
         m_payload.mtaskBegin.m_id = id;
         m_payload.mtaskBegin.m_predictStart = predictStart;
         m_payload.mtaskBegin.m_cpu = VlOs::getcpu();

--- a/src/V3AstNodeOther.h
+++ b/src/V3AstNodeOther.h
@@ -1100,32 +1100,6 @@ public:
     string name() const override VL_MT_STABLE { return m_name; }
     ASTGEN_MEMBERS_AstIntfRef;
 };
-class AstMTaskBody final : public AstNode {
-    // Hold statements for each MTask
-    // @astgen op1 := stmtsp : List[AstNode]
-    ExecMTask* m_execMTaskp = nullptr;
-
-public:
-    explicit AstMTaskBody(FileLine* fl)
-        : ASTGEN_SUPER_MTaskBody(fl) {}
-    ASTGEN_MEMBERS_AstMTaskBody;
-    void cloneRelink() override { UASSERT(!clonep(), "Not cloneable"); }
-    const char* broken() const override {
-        BROKEN_RTN(!m_execMTaskp);
-        return nullptr;
-    }
-    void addStmtsFirstp(AstNode* nodep) {
-        if (stmtsp()) {
-            stmtsp()->addHereThisAsNext(nodep);
-        } else {
-            addStmtsp(nodep);
-        }
-    }
-    ExecMTask* execMTaskp() const { return m_execMTaskp; }
-    void execMTaskp(ExecMTask* execMTaskp) { m_execMTaskp = execMTaskp; }
-    void dump(std::ostream& str = std::cout) const override;
-    void dumpJson(std::ostream& str = std::cout) const override;
-};
 class AstModport final : public AstNode {
     // A modport in an interface
     // @astgen op1 := varsp : List[AstNode]

--- a/src/V3AstNodes.cpp
+++ b/src/V3AstNodes.cpp
@@ -340,6 +340,16 @@ AstExecGraph::AstExecGraph(FileLine* fileline, const string& name) VL_MT_DISABLE
 
 AstExecGraph::~AstExecGraph() { VL_DO_DANGLING(delete m_depGraphp, m_depGraphp); }
 
+const char* AstExecGraph::broken() const {
+    BROKEN_RTN(!m_depGraphp);
+    for (const V3GraphVertex& vtx : m_depGraphp->vertices()) {
+        const ExecMTask* const mtaskp = vtx.as<ExecMTask>();
+        AstCFunc* const funcp = mtaskp->funcp();
+        BROKEN_RTN(!funcp || !funcp->brokeExists());
+    }
+    return nullptr;
+}
+
 AstNodeExpr* AstInsideRange::newAndFromInside(AstNodeExpr* exprp, AstNodeExpr* lhsp,
                                               AstNodeExpr* rhsp) {
     AstNodeExpr* const ap = new AstGte{fileline(), exprp, lhsp};
@@ -2536,17 +2546,6 @@ void AstSystemCSection::dump(std::ostream& str) const {
 }
 void AstSystemCSection::dumpJson(std::ostream& str) const {
     dumpJsonStr(str, "sectionType", sectionType().ascii());
-    dumpJsonGen(str);
-}
-void AstMTaskBody::dump(std::ostream& str) const {
-    this->AstNode::dump(str);
-    str << " ";
-    m_execMTaskp->dump(str);
-}
-void AstMTaskBody::dumpJson(std::ostream& str) const {
-    str << ',' << '"' << "execMTask" << '"' << ':' << '"';
-    m_execMTaskp->dump(str);  // TODO: Consider dumping it as json object
-    str << '"';
     dumpJsonGen(str);
 }
 void AstTypeTable::dump(std::ostream& str) const {

--- a/src/V3Depth.cpp
+++ b/src/V3Depth.cpp
@@ -38,7 +38,6 @@ class DepthVisitor final : public VNVisitor {
 
     // STATE - for current visit position (use VL_RESTORER)
     AstCFunc* m_cfuncp = nullptr;  // Current block
-    AstMTaskBody* m_mtaskbodyp = nullptr;  // Current mtaskbody
     AstNode* m_stmtp = nullptr;  // Current statement
     int m_depth = 0;  // How deep in an expression
     int m_maxdepth = 0;  // Maximum depth in an expression
@@ -53,8 +52,6 @@ class DepthVisitor final : public VNVisitor {
                                         m_tempNames.get(nodep), nodep->dtypep()};
         if (m_cfuncp) {
             m_cfuncp->addVarsp(varp);
-        } else if (m_mtaskbodyp) {
-            m_mtaskbodyp->addStmtsFirstp(varp);
         } else {
             nodep->v3fatalSrc("Deep expression not under a function");
         }
@@ -70,26 +67,12 @@ class DepthVisitor final : public VNVisitor {
     // VISITORS
     void visit(AstCFunc* nodep) override {
         VL_RESTORER(m_cfuncp);
-        VL_RESTORER(m_mtaskbodyp);
         VL_RESTORER(m_depth);
         VL_RESTORER(m_maxdepth);
         m_cfuncp = nodep;
-        m_mtaskbodyp = nullptr;
         m_depth = 0;
         m_maxdepth = 0;
         m_tempNames.reset();
-        iterateChildren(nodep);
-    }
-    void visit(AstMTaskBody* nodep) override {
-        VL_RESTORER(m_cfuncp);
-        VL_RESTORER(m_mtaskbodyp);
-        VL_RESTORER(m_depth);
-        VL_RESTORER(m_maxdepth);
-        m_cfuncp = nullptr;
-        m_mtaskbodyp = nodep;
-        m_depth = 0;
-        m_maxdepth = 0;
-        // We don't reset the names, as must share across tasks
         iterateChildren(nodep);
     }
     void visitStmt(AstNodeStmt* nodep) {

--- a/src/V3EmitCFunc.h
+++ b/src/V3EmitCFunc.h
@@ -1623,11 +1623,6 @@ public:
     }
 
     //
-    void visit(AstMTaskBody* nodep) override {
-        VL_RESTORER(m_useSelfForThis);
-        m_useSelfForThis = true;
-        iterateChildrenConst(nodep);
-    }
     void visit(AstConsAssoc* nodep) override {
         putnbs(nodep, nodep->dtypep()->cType("", false, false));
         puts("()");
@@ -1723,7 +1718,6 @@ public:
     void visit(AstExecGraph* nodep) override {
         // The location of the AstExecGraph within the containing AstCFunc is where we want to
         // invoke the graph and wait for it to complete. Emitting the children does just that.
-        UASSERT_OBJ(!nodep->mTaskBodiesp(), nodep, "These should have been lowered");
         iterateChildrenConst(nodep);
     }
 

--- a/src/V3ExecGraph.h
+++ b/src/V3ExecGraph.h
@@ -25,7 +25,10 @@
 #include <atomic>
 
 class AstNetlist;
-class AstMTaskBody;
+class AstCFunc;
+class AstExecGraph;
+class AstNodeStmt;
+class AstScope;
 
 //*************************************************************************
 // MTasks and graph structures
@@ -33,9 +36,9 @@ class AstMTaskBody;
 class ExecMTask final : public V3GraphVertex {
     VL_RTTI_IMPL(ExecMTask, V3GraphVertex)
 private:
-    AstMTaskBody* const m_bodyp;  // Task body
     const uint32_t m_id;  // Unique ID of this ExecMTask.
     static std::atomic<uint32_t> s_nextId;  // Next ID to use
+    AstCFunc* const m_funcp;  // The function that contains the task body
     const std::string m_hashName;  // Hashed name based on body for profile-driven optimization
     // Predicted critical path from the start of this mtask to the ends of the graph that are
     // reachable from this mtask. In abstract time units.
@@ -46,9 +49,12 @@ private:
     int m_threads = 1;  // Threads used by this mtask
     VL_UNCOPYABLE(ExecMTask);
 
+    static AstCFunc* createCFunc(AstExecGraph* execGraphp, AstScope* scopep, AstNodeStmt* stmtsp,
+                                 uint32_t id);
+
 public:
-    ExecMTask(V3Graph* graphp, AstMTaskBody* bodyp) VL_MT_DISABLED;
-    AstMTaskBody* bodyp() const { return m_bodyp; }
+    ExecMTask(AstExecGraph* execGraphp, AstScope* scopep, AstNodeStmt* stmtsp) VL_MT_DISABLED;
+    AstCFunc* funcp() const { return m_funcp; }
     uint32_t id() const VL_MT_SAFE { return m_id; }
     uint32_t priority() const { return m_priority; }
     void priority(uint32_t pri) { m_priority = pri; }

--- a/src/V3Hasher.cpp
+++ b/src/V3Hasher.cpp
@@ -513,9 +513,6 @@ class HasherVisitor final : public VNVisitorConst {
             iterateConstNull(nodep->ftaskp());
         });
     }
-    void visit(AstMTaskBody* nodep) override {
-        m_hash += hashNodeAndIterate(nodep, HASH_DTYPE, HASH_CHILDREN, []() {});
-    }
     void visit(AstNodeProcedure* nodep) override {
         m_hash += hashNodeAndIterate(nodep, HASH_DTYPE, HASH_CHILDREN, []() {});
     }

--- a/src/V3LifePost.cpp
+++ b/src/V3LifePost.cpp
@@ -290,7 +290,7 @@ class LifePostDlyVisitor final : public VNVisitorConst {
             const ExecMTask* const mtaskp = mtaskVtx.as<ExecMTask>();
             VL_RESTORER(m_execMTaskp);
             m_execMTaskp = mtaskp;
-            iterateConst(mtaskp->bodyp());
+            trace(mtaskp->funcp());
         }
     }
     void visit(AstCFunc* nodep) override {

--- a/src/V3OrderParallel.cpp
+++ b/src/V3OrderParallel.cpp
@@ -1763,7 +1763,7 @@ class DpiThreadsVisitor final : public VNVisitorConst {
 
 public:
     // CONSTRUCTORS
-    explicit DpiThreadsVisitor(AstMTaskBody* nodep) { iterateConst(nodep); }
+    explicit DpiThreadsVisitor(AstCFunc* nodep) { iterateConst(nodep); }
     int threads() const { return m_threads; }
     ~DpiThreadsVisitor() override = default;
 
@@ -2431,8 +2431,9 @@ AstNodeStmt* V3Order::createParallel(OrderGraph& orderGraph, OrderMoveGraph& mov
     if (dumpGraphLevel() >= 9) moveGraph.dumpDotFilePrefixed(tag + "_ordermv_pruned");
 
     // Create the AstExecGraph node which represents the execution of the MTask graph.
-    FileLine* const rootFlp = v3Global.rootp()->fileline();
-    AstExecGraph* const execGraphp = new AstExecGraph{rootFlp, tag};
+    FileLine* const flp = v3Global.rootp()->fileline();
+    AstScope* const scopep = v3Global.rootp()->topScopep()->scopep();
+    AstExecGraph* const execGraphp = new AstExecGraph{flp, tag};
     V3Graph* const depGraphp = execGraphp->depGraphp();
 
     // Translate the LogicMTask graph into the corresponding ExecMTask graph,
@@ -2468,23 +2469,22 @@ AstNodeStmt* V3Order::createParallel(OrderGraph& orderGraph, OrderMoveGraph& mov
             VL_DO_DANGLING(mVtxp->unlinkDelete(&moveGraph), mVtxp);
         }
 
-        // We have 2 objects, because AstMTaskBody is an AstNode, and ExecMTask is a GraphVertex.
-        // To combine them would involve multiple inheritance.
-
-        // Construct the actual MTaskBody
-        AstMTaskBody* const bodyp = new AstMTaskBody{rootFlp};
-        execGraphp->addMTaskBodiesp(bodyp);
-        bodyp->addStmtsp(emitter.getStmts());
-        UASSERT_OBJ(bodyp->stmtsp(), bodyp, "Should not try to create empty MTask");
-
         // Create the ExecMTask
-        ExecMTask* const execMTaskp = new ExecMTask{depGraphp, bodyp};
-        if (!v3Global.opt.hierBlocks().empty())
-            execMTaskp->threads(DpiThreadsVisitor{bodyp}.threads());
+        ExecMTask* const execMTaskp = new ExecMTask{execGraphp, scopep, emitter.getStmts()};
+        if (!v3Global.opt.hierBlocks().empty()) {
+            execMTaskp->threads(DpiThreadsVisitor{execMTaskp->funcp()}.threads());
+        }
         const bool newEntry = logicMTaskToExecMTask.emplace(mTaskp, execMTaskp).second;
         UASSERT_OBJ(newEntry, mTaskp, "LogicMTasks should be processed in dependencyorder");
         UINFO(3, "Final '" << tag << "' LogicMTask " << mTaskp->id() << " maps to ExecMTask"
                            << execMTaskp->id());
+
+        // For code analysis purposes, we can pretend the AstExecGraph runs the
+        // MTasks sequentially, in some topological order that respects edges.
+        // The order they are created here happens to be just such an order.
+        AstCCall* const callp = new AstCCall{flp, execMTaskp->funcp()};
+        callp->dtypeSetVoid();
+        execGraphp->addStmtsp(callp->makeStmt());
 
         // Add the dependency edges between ExecMTasks
         for (const V3GraphEdge& edge : mTaskp->inEdges()) {

--- a/src/V3VariableOrder.cpp
+++ b/src/V3VariableOrder.cpp
@@ -53,7 +53,7 @@ class GatherMTaskAffinity final : VNVisitorConst {
     GatherMTaskAffinity(const ExecMTask* mTaskp, MTaskAffinityMap& results)
         : m_results{results}
         , m_id{mTaskp->id()} {
-        iterateChildrenConst(mTaskp->bodyp());
+        iterateConst(mTaskp->funcp());
     }
     ~GatherMTaskAffinity() = default;
     VL_UNMOVABLE(GatherMTaskAffinity);


### PR DESCRIPTION
AstMTaskBody is somewhat redundant and is problematic for #6280. We used to wrap all MTasks in a CFunc before emit anyway. Now we create that CFunc when we create the ExecMTask in V3OrderParallel, and subsequently use the CFunc to represent the contents of the MTask. Final output and optimizations are the same, but internals are simplified to move towards #6280.

No functional change.
