### PR TITLE
Fix `--timing` with `--x-initial-edge`

### DIFF
--- a/include/verilated_timing.cpp
+++ b/include/verilated_timing.cpp
@@ -80,6 +80,11 @@ void VlDelayScheduler::resume() {
     }
 
     if (!resumed) {
+        if (m_context.time() == 0) {
+            // Nothing was scheduled at time 0, but resume() got called due to --x-initial-edge
+            return;
+        }
+
         VL_FATAL_MT(__FILE__, __LINE__, "",
                     "%Error: Encountered process that should've been resumed at an "
                     "earlier simulation time. Missed a time slot?\n");

--- a/test_regress/t/t_timing_initial_edge.py
+++ b/test_regress/t/t_timing_initial_edge.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2025 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile(verilator_flags2=["--binary", "--x-initial-edge"])
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_timing_initial_edge.v
+++ b/test_regress/t/t_timing_initial_edge.v
@@ -1,0 +1,13 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2025 by Antmicro.
+// SPDX-License-Identifier: CC0-1.0
+
+module t;
+  initial begin
+    #10;
+    $write("*-* All Finished *-*\n");
+    $finish;
+  end
+endmodule


### PR DESCRIPTION
Fixes #6603. Issue was that `--x-initial-edge` fires all triggers on initialization which causes `VlDelayScheduler::resume()` to be called without anything scheduled at time 0.