### PR TITLE
issue 6124 - support more casting combinations b/t string, array, queue

### DIFF
--- a/include/verilated_funcs.h
+++ b/include/verilated_funcs.h
@@ -2957,6 +2957,29 @@ inline std::string VL_CVT_PACK_STR_NI(IData lhs) VL_PURE {
     VL_SET_WI(lw, lhs);
     return VL_CVT_PACK_STR_NW(1, lw);
 }
+inline std::string VL_CVT_PACK_STR_NI(const VlQueue<CData>& q) VL_PURE {
+    std::string result;
+    for (const auto& byte : q) result.push_back(static_cast<char>(byte));
+    return result;
+}
+template <size_t N_Depth>
+inline std::string VL_CVT_PACK_STR_NI(const VlUnpacked<CData, N_Depth>& q) VL_PURE {
+    std::string result;
+    for (size_t i = 0; i < N_Depth; ++i) result.push_back(static_cast<char>(q[i]));
+    return result;
+}
+static inline void VL_UNPACK_RI_N(int lbits, int rbits, VlQueue<CData>& q,
+                                  const std::string& from) {
+    q.clear();
+    q.resize(from.size());
+    for (size_t i = 0; i < from.size(); ++i) q.atWrite(i) = static_cast<CData>(from[i]);
+}
+template <size_t N_Depth>
+static inline void VL_UNPACK_UI_N(int lbits, int rbits, VlUnpacked<CData, N_Depth>& q,
+                                  const std::string& from) {
+    q.atDefault() = 0;
+    for (size_t i = 0; i < from.size() && i < N_Depth; ++i) q[i] = static_cast<CData>(from[i]);
+}
 inline std::string VL_CONCATN_NNN(const std::string& lhs, const std::string& rhs) VL_PURE {
     return lhs + rhs;
 }

--- a/src/V3Ast.cpp
+++ b/src/V3Ast.cpp
@@ -1628,9 +1628,18 @@ static VCastable computeCastableImp(const AstNodeDType* toDtp, const AstNodeDTyp
         if (VN_IS(fromBaseDtp, EnumDType) && toDtp->sameTree(fromDtp))
             return VCastable::ENUM_IMPLICIT;
         if (fromNumericable) return VCastable::ENUM_EXPLICIT;
-    } else if (VN_IS(toDtp, QueueDType)
+    } else if ((VN_IS(toDtp, QueueDType) || VN_IS(toDtp, DynArrayDType))
                && (VN_IS(fromDtp, BasicDType) || VN_IS(fromDtp, StreamDType))) {
         return VCastable::COMPATIBLE;
+    } else if (VN_IS(toDtp, BasicDType) && toDtp->isString()
+               && (VN_IS(fromDtp, QueueDType) || VN_IS(fromDtp, DynArrayDType))) {
+        return VCastable::COMPATIBLE;
+    } else if ((VN_IS(toDtp, QueueDType) && VN_IS(fromDtp, DynArrayDType))
+               || (VN_IS(toDtp, DynArrayDType) && VN_IS(fromDtp, QueueDType))) {
+        if (fromDtp->subDTypep() && toDtp->subDTypep()
+            && fromDtp->subDTypep()->sameTree(toDtp->subDTypep())) {
+            return VCastable::COMPATIBLE;
+        }
     } else if (VN_IS(toDtp, ClassRefDType) && VN_IS(fromConstp, Const)) {
         if (fromConstp->isNull()) return VCastable::COMPATIBLE;
     } else if (VN_IS(toDtp, ClassRefDType) && VN_IS(fromDtp, ClassRefDType)) {

--- a/test_regress/t/t_queue_cast_compatible.py
+++ b/test_regress/t/t_queue_cast_compatible.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2025 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile()
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_queue_cast_compatible.v
+++ b/test_regress/t/t_queue_cast_compatible.v
@@ -1,0 +1,194 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed into the Public Domain, for any use,
+// without warranty, 2025 by Paul Swirhun.
+// SPDX-License-Identifier: CC0-1.0
+
+`define checkh(gotv,
+               expv) do if ((gotv) !== (expv)) begin $write("%%Error: %s:%0d:  got='h%x exp='h%x\n", `__FILE__,`__LINE__, (gotv), (expv)); $stop; end while(0);
+`define checks(gotv,
+               expv) do if ((gotv) != (expv)) begin $write("%%Error: %s:%0d:  got='%s' exp='%s'\n", `__FILE__,`__LINE__, (gotv), (expv)); $stop; end while(0);
+
+module t (  /*AUTOARG*/);
+
+  // Byte types for string casting
+  typedef byte unsigned byte_array_t[];
+  typedef byte unsigned byte_queue_t[$];
+
+  // Different element widths for queue <-> array casting
+  typedef logic [7:0] byte_array2_t[];
+  typedef logic [7:0] byte_queue2_t[$];
+  typedef logic [15:0] word_array_t[];
+  typedef logic [15:0] word_queue_t[$];
+  typedef logic [23:0] word_odd_array_t[];
+  typedef logic [23:0] word_odd_queue_t[$];
+  typedef logic [31:0] dword_array_t[];
+  typedef logic [31:0] dword_queue_t[$];
+  typedef logic [55:0] dword_odd_array_t[];
+  typedef logic [55:0] dword_odd_queue_t[$];
+  typedef logic [63:0] qword_array_t[];
+  typedef logic [63:0] qword_queue_t[$];
+  typedef logic [119:0] odd_array_t[];
+  typedef logic [119:0] odd_queue_t[$];
+  typedef logic [127:0] dqword_array_t[];
+  typedef logic [127:0] dqword_queue_t[$];
+
+  initial begin
+    static string str = "Hi";
+    byte_array_t  arr;
+    byte_queue_t  que;
+
+    // Test string <-> byte array/queue casting
+    $display("Testing string <-> byte array/queue casting");
+
+    // String to dynamic array
+    arr = byte_array_t'(str);
+    `checkh(arr[0], 8'h48);
+    `checkh(arr[1], 8'h69);
+
+    // Dynamic array to string
+    str = string'(arr);
+    `checks(str, "Hi");
+
+    // String to queue
+    que = byte_queue_t'(str);
+    `checkh(que[0], 8'h48);
+    `checkh(que[1], 8'h69);
+
+    // Queue to string
+    str = string'(que);
+    `checks(str, "Hi");
+
+    // Test queue <-> array casting with same element width
+    $display("Testing queue <-> array casting with same element width");
+
+    begin
+      byte_array2_t arr2;
+      byte_queue2_t que2;
+
+      // Initialize queue
+      que2 = {8'h41, 8'h42, 8'h43};  // "ABC"
+
+      // Queue to array
+      arr2 = byte_array2_t'(que2);
+      `checkh(arr2[0], 8'h41);
+      `checkh(arr2[1], 8'h42);
+      `checkh(arr2[2], 8'h43);
+
+      // Array to queue
+      que2 = byte_queue2_t'(arr2);
+      `checkh(que2[0], 8'h41);
+      `checkh(que2[1], 8'h42);
+      `checkh(que2[2], 8'h43);
+    end
+
+    // Test with 16-bit elements
+    begin
+      word_array_t warr;
+      word_queue_t wque;
+
+      wque = {16'h1234, 16'h5678};
+      warr = word_array_t'(wque);
+      `checkh(warr[0], 16'h1234);
+      `checkh(warr[1], 16'h5678);
+
+      wque = word_queue_t'(warr);
+      `checkh(wque[0], 16'h1234);
+      `checkh(wque[1], 16'h5678);
+    end
+
+    // Test with 24-bit elements (non-32-bit-aligned)
+    begin
+      word_odd_array_t woarr;
+      word_odd_queue_t woque;
+
+      woque = {24'h123456, 24'hABCDEF};
+      woarr = word_odd_array_t'(woque);
+      `checkh(woarr[0], 24'h123456);
+      `checkh(woarr[1], 24'hABCDEF);
+
+      woque = word_odd_queue_t'(woarr);
+      `checkh(woque[0], 24'h123456);
+      `checkh(woque[1], 24'hABCDEF);
+    end
+
+    // Test with 32-bit elements
+    begin
+      dword_array_t dwarr;
+      dword_queue_t dwque;
+
+      dwque = {32'h12345678, 32'hABCDEF00};
+      dwarr = dword_array_t'(dwque);
+      `checkh(dwarr[0], 32'h12345678);
+      `checkh(dwarr[1], 32'hABCDEF00);
+
+      dwque = dword_queue_t'(dwarr);
+      `checkh(dwque[0], 32'h12345678);
+      `checkh(dwque[1], 32'hABCDEF00);
+    end
+
+    // Test with 56-bit elements (non-64-bit-aligned)
+    begin
+      dword_odd_array_t dwoarr;
+      dword_odd_queue_t dwoque;
+
+      dwoque = {56'h123456789ABCDE, 56'hFEDCBA09876543};
+      dwoarr = dword_odd_array_t'(dwoque);
+      `checkh(dwoarr[0], 56'h123456789ABCDE);
+      `checkh(dwoarr[1], 56'hFEDCBA09876543);
+
+      dwoque = dword_odd_queue_t'(dwoarr);
+      `checkh(dwoque[0], 56'h123456789ABCDE);
+      `checkh(dwoque[1], 56'hFEDCBA09876543);
+    end
+
+    // Test with 64-bit elements
+    begin
+      qword_array_t qwarr;
+      qword_queue_t qwque;
+
+      qwque = {64'h123456789ABCDEF0, 64'hFEDCBA0987654321};
+      qwarr = qword_array_t'(qwque);
+      `checkh(qwarr[0], 64'h123456789ABCDEF0);
+      `checkh(qwarr[1], 64'hFEDCBA0987654321);
+
+      qwque = qword_queue_t'(qwarr);
+      `checkh(qwque[0], 64'h123456789ABCDEF0);
+      `checkh(qwque[1], 64'hFEDCBA0987654321);
+    end
+
+    // Test with 128-bit elements
+    begin
+      dqword_array_t dqwarr;
+      dqword_queue_t dqwque;
+
+      dqwque = {128'h123456789ABCDEF0FEDCBA0987654321, 128'hAABBCCDDEEFF00112233445566778899};
+      dqwarr = dqword_array_t'(dqwque);
+      `checkh(dqwarr[0], 128'h123456789ABCDEF0FEDCBA0987654321);
+      `checkh(dqwarr[1], 128'hAABBCCDDEEFF00112233445566778899);
+
+      dqwque = dqword_queue_t'(dqwarr);
+      `checkh(dqwque[0], 128'h123456789ABCDEF0FEDCBA0987654321);
+      `checkh(dqwque[1], 128'hAABBCCDDEEFF00112233445566778899);
+    end
+
+    // Test with 120-bit elements (non-word-aligned)
+    begin
+      odd_array_t oddarr;
+      odd_queue_t oddque;
+
+      oddque = {120'h123456789ABCDEF0FEDCBA098765, 120'hAABBCCDDEEFF001122334455667};
+      oddarr = odd_array_t'(oddque);
+      `checkh(oddarr[0], 120'h123456789ABCDEF0FEDCBA098765);
+      `checkh(oddarr[1], 120'hAABBCCDDEEFF001122334455667);
+
+      oddque = odd_queue_t'(oddarr);
+      `checkh(oddque[0], 120'h123456789ABCDEF0FEDCBA098765);
+      `checkh(oddque[1], 120'hAABBCCDDEEFF001122334455667);
+    end
+
+    $write("*-* All Finished *-*\n");
+    $finish;
+  end
+
+endmodule

--- a/test_regress/t/t_queue_cast_incompatible.out
+++ b/test_regress/t/t_queue_cast_incompatible.out
@@ -1,0 +1,58 @@
+%Error-UNSUPPORTED: t/t_queue_cast_incompatible.v:52:28: Unsupported: static cast to 'logic[7:0]$[]' from 'logic[15:0]$[$]'
+                                                       : ... note: In instance 't'
+   52 |     byte_arr = byte_array_t'(word_que);
+      |                            ^
+                    ... For error description see https://verilator.org/warn/UNSUPPORTED?v=latest
+%Error-UNSUPPORTED: t/t_queue_cast_incompatible.v:53:28: Unsupported: static cast to 'logic[15:0]$[$]' from 'logic[7:0]$[]'
+                                                       : ... note: In instance 't'
+   53 |     word_que = word_queue_t'(byte_arr);
+      |                            ^
+%Error-UNSUPPORTED: t/t_queue_cast_incompatible.v:56:28: Unsupported: static cast to 'logic[7:0]$[]' from 'struct{}t.struct8_t$[$]'
+                                                       : ... note: In instance 't'
+   56 |     byte_arr = byte_array_t'(struct_que);
+      |                            ^
+%Error-UNSUPPORTED: t/t_queue_cast_incompatible.v:57:32: Unsupported: static cast to 'struct{}t.struct8_t$[]' from 'logic[7:0]$[$]'
+                                                       : ... note: In instance 't'
+   57 |     struct_arr = struct_array_t'(byte_que);
+      |                                ^
+%Error-UNSUPPORTED: t/t_queue_cast_incompatible.v:74:26: Unsupported: String casting only supported to byte arrays/queues
+                                                       : ... note: In instance 't'
+   74 |     int_arr = int_array_t'(str);
+      |                          ^
+%Error-UNSUPPORTED: t/t_queue_cast_incompatible.v:75:26: Unsupported: String casting only supported to byte arrays/queues
+                                                       : ... note: In instance 't'
+   75 |     int_que = int_queue_t'(str);
+      |                          ^
+%Error-UNSUPPORTED: t/t_queue_cast_incompatible.v:76:28: Unsupported: String casting only supported to byte arrays/queues
+                                                       : ... note: In instance 't'
+   76 |     word_arr = word_array_t'(str);
+      |                            ^
+%Error-UNSUPPORTED: t/t_queue_cast_incompatible.v:77:28: Unsupported: String casting only supported to byte arrays/queues
+                                                       : ... note: In instance 't'
+   77 |     word_que = word_queue_t'(str);
+      |                            ^
+%Error-UNSUPPORTED: t/t_queue_cast_incompatible.v:80:28: Unsupported: String casting only supported to byte arrays/queues
+                                                       : ... note: In instance 't'
+   80 |     bit1_arr = bit1_array_t'(str);
+      |                            ^
+%Error-UNSUPPORTED: t/t_queue_cast_incompatible.v:81:28: Unsupported: String casting only supported to byte arrays/queues
+                                                       : ... note: In instance 't'
+   81 |     bit1_que = bit1_queue_t'(str);
+      |                            ^
+%Error-UNSUPPORTED: t/t_queue_cast_incompatible.v:82:28: Unsupported: String casting only supported to byte arrays/queues
+                                                       : ... note: In instance 't'
+   82 |     bit3_arr = bit3_array_t'(str);
+      |                            ^
+%Error-UNSUPPORTED: t/t_queue_cast_incompatible.v:83:28: Unsupported: String casting only supported to byte arrays/queues
+                                                       : ... note: In instance 't'
+   83 |     bit3_que = bit3_queue_t'(str);
+      |                            ^
+%Error-UNSUPPORTED: t/t_queue_cast_incompatible.v:84:28: Unsupported: String casting only supported to byte arrays/queues
+                                                       : ... note: In instance 't'
+   84 |     bit7_arr = bit7_array_t'(str);
+      |                            ^
+%Error-UNSUPPORTED: t/t_queue_cast_incompatible.v:85:28: Unsupported: String casting only supported to byte arrays/queues
+                                                       : ... note: In instance 't'
+   85 |     bit7_que = bit7_queue_t'(str);
+      |                            ^
+%Error: Exiting due to

--- a/test_regress/t/t_queue_cast_incompatible.py
+++ b/test_regress/t/t_queue_cast_incompatible.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2025 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile(fails=True, expect_filename=test.golden_filename)
+
+test.passes()

--- a/test_regress/t/t_queue_cast_incompatible.v
+++ b/test_regress/t/t_queue_cast_incompatible.v
@@ -1,0 +1,91 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed into the Public Domain, for any use,
+// without warranty, 2025 by Paul Swirhun.
+// SPDX-License-Identifier: CC0-1.0
+
+module t (  /*AUTOARG*/);
+
+  // Different width types that should fail casting
+  typedef logic [7:0] byte_array_t[];
+  typedef logic [7:0] byte_queue_t[$];
+  typedef logic [15:0] word_array_t[];
+  typedef logic [15:0] word_queue_t[$];
+
+  // Struct types with same width but different structure
+  typedef struct packed {logic [3:0] a, b;} struct8_t;
+  typedef struct8_t struct_array_t[];
+  typedef struct8_t struct_queue_t[$];
+
+  // Non-byte types for string casting restrictions
+  typedef int int_array_t[];
+  typedef int int_queue_t[$];
+
+  // Narrow bit widths that use CData but aren't byte-compatible
+  typedef logic [0:0] bit1_array_t[];
+  typedef logic [0:0] bit1_queue_t[$];
+  typedef logic [2:0] bit3_array_t[];
+  typedef logic [2:0] bit3_queue_t[$];
+  typedef logic [6:0] bit7_array_t[];
+  typedef logic [6:0] bit7_queue_t[$];
+
+  initial begin
+    byte_array_t   byte_arr;
+    byte_queue_t   byte_que;
+    word_array_t   word_arr;
+    word_queue_t   word_que;
+    struct_array_t struct_arr;
+    struct_queue_t struct_que;
+    int_array_t    int_arr;
+    int_queue_t    int_que;
+    bit1_array_t   bit1_arr;
+    bit1_queue_t   bit1_que;
+    bit3_array_t   bit3_arr;
+    bit3_queue_t   bit3_que;
+    bit7_array_t   bit7_arr;
+    bit7_queue_t   bit7_que;
+    string         str;
+
+    // These should all fail compilation due to width mismatch
+
+    // Different width: byte vs word
+    byte_arr = byte_array_t'(word_que);
+    word_que = word_queue_t'(byte_arr);
+
+    // Different structure: struct vs logic (same width)
+    byte_arr = byte_array_t'(struct_que);
+    struct_arr = struct_array_t'(byte_que);
+
+    // String casting to non-byte types should fail
+    str = string'(int_arr);
+    str = string'(int_que);
+    str = string'(word_arr);
+    str = string'(word_que);
+
+    // String casting to narrow bit widths should fail
+    str = string'(bit1_arr);
+    str = string'(bit1_que);
+    str = string'(bit3_arr);
+    str = string'(bit3_que);
+    str = string'(bit7_arr);
+    str = string'(bit7_que);
+
+    // String casting from non-byte types should fail
+    int_arr = int_array_t'(str);
+    int_que = int_queue_t'(str);
+    word_arr = word_array_t'(str);
+    word_que = word_queue_t'(str);
+
+    // String casting from narrow bit widths should fail
+    bit1_arr = bit1_array_t'(str);
+    bit1_que = bit1_queue_t'(str);
+    bit3_arr = bit3_array_t'(str);
+    bit3_que = bit3_queue_t'(str);
+    bit7_arr = bit7_array_t'(str);
+    bit7_que = bit7_queue_t'(str);
+
+    $write("*-* Should not reach here *-*\n");
+    $finish;
+  end
+
+endmodule


### PR DESCRIPTION
https://github.com/verilator/verilator/issues/6124

Support casting between byte [], byte [$] and string types

Cadence and Siemens simulators pass for this test; Synopsys says "Feature is not yet supported: string casting of unsupported type". But the comment in issue 6124 was that IEEE says it should be supported. It seems to be just a few extra if/else cases to add casting support; please review to make sure I didn't do something overly broad with these additions -- the intention is only to allow casting to/from strings when the type is byte-like (ie, I don't want to get into endianness concerns when casting a string to an array of integers, for example).