### PR TITLE
Simplify release handling. No functional change

### DIFF
--- a/src/V3Force.cpp
+++ b/src/V3Force.cpp
@@ -308,6 +308,7 @@ class ForceConvertVisitor final : public VNVisitor {
             if (refp->access() != VAccess::WRITE) return;
             AstVarScope* const vscp = refp->varScopep();
             if (vscp->varp()->isContinuously()) {
+                refp->access(VAccess::READ);
                 ForceState::markNonReplaceable(refp);
             } else {
                 refp->replaceWith(m_state.getForceComponents(vscp).forcedUpdate(vscp));


### PR DESCRIPTION
It simplifies the handling of `AstRelease` and removes unnecessary changes done to the AST.