### PR TITLE
Tests: Fix Icarus vvp execution with use_libvpi

### DIFF
--- a/test_regress/driver.py
+++ b/test_regress/driver.py
@@ -1476,14 +1476,13 @@ class VlTest:
                      tee=param['tee'])
         elif param['iv']:
             cmd = [
-                run_env + 'vvp' ,' '.join(param['iv_run_flags']),
-                ' '.join(param['all_run_flags'])
+                run_env + 'vvp', ' '.join(param['iv_run_flags']), ' '.join(param['all_run_flags'])
             ]
             if param['use_libvpi']:
                 # Don't enter command line on $stop
                 cmd += ["-n"]
                 # include vpi
-                cmd += ["-m" , self.obj_dir + "/libvpi.so"]
+                cmd += ["-m", self.obj_dir + "/libvpi.so"]
             cmd += [self.obj_dir + "/simiv"]
             self.run(cmd=cmd,
                      check_finished=param['check_finished'],


### PR DESCRIPTION
Previously, `obj_iv/<testname>/simiv` was executed directly and run
flags were appended to it. However, when `use_libvpi = True`, the `vvp`
command was appended to it together with `libvpi.so`. This is not the
correct syntax for calling the `vvp` runtime, according to the [Icarus
documentation about using VPI](https://steveicarus.github.io/iverilog/usage/vpi.html), and it did not execute correctly.
This commit fixes this behavior by prepending the `vvp` runtime, then
inserting the run flags and, if `use_libvpi = True`, also the path to
the `libvpi.so`, and finally the `simiv` at the end.