### PR TITLE
Fix local interface param in param map

### DIFF
--- a/test_regress/t/t_interface_parameter_local_access.py
+++ b/test_regress/t/t_interface_parameter_local_access.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2024 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios("simulator_st")
+
+test.compile()
+
+test.passes()

--- a/test_regress/t/t_interface_parameter_local_access.v
+++ b/test_regress/t/t_interface_parameter_local_access.v
@@ -1,0 +1,43 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2025 by Wilson Snyder.
+// SPDX-License-Identifier: CC0-1.0
+
+interface intf
+#(
+  parameter int FOO = 32
+)
+();
+endinterface
+
+module sub (
+  intf intf_a,
+  intf intf_b
+);
+  localparam int INTF_A_FOO = intf_a.FOO;
+  localparam int INTF_B_FOO = intf_b.FOO;
+  if (INTF_A_FOO != INTF_B_FOO)
+    $error("INTF_A_FOO != INTF_B_FOO: %0d != %0d", INTF_A_FOO, INTF_B_FOO);
+endmodule
+
+module t;
+  intf #(.FOO (21)) local_intf ();
+  /* verilator lint_off HIERPARAM */
+`ifdef CONST_LITERAL
+  intf #(.FOO(21)) the_intf_a ();
+`else
+`ifdef INTERMEDIATE_LPARAM
+  localparam int LOCAL_INTF_FOO = local_intf.FOO;
+  intf #(.FOO(LOCAL_INTF_FOO)) the_intf_a ();
+`else
+  intf #(.FOO(local_intf.FOO)) the_intf_a ();
+`endif
+`endif
+  /* verilator lint_on HIERPARAM */
+  intf #(.FOO(21)) the_intf_b ();
+
+  sub the_sub (
+    .intf_a (the_intf_a),
+    .intf_b (the_intf_b));
+endmodule


### PR DESCRIPTION
Re: #6621 here is an example where `lint_off`ing `HIERPARAM` will result in an incorrect elaboration result.  Using a literal instead of the interface parameter obviously works.  But so does an intermediate localparam.  The only thing that doesn't work correctly is using the dotted reference to the interface parameter directly in the subsequent interface's parameter map.

@paul-demo you asked for an example so if you have time to look at this please feel free to lift the test and I can abandon this PR.

I see that V3Param yields the default value of `FOO` for `the_intf_a` instead of the value it should have gotten from `local_intf`.  But I haven't looked farther than that.