### PR TITLE
Optimize repeated function call during symbol table init

### DIFF
--- a/include/verilated.cpp
+++ b/include/verilated.cpp
@@ -3454,12 +3454,12 @@ void* VerilatedVarProps::datapAdjustIndex(void* datap, int dim, int indx) const 
 //======================================================================
 // VerilatedScope:: Methods
 
-VerilatedScope::VerilatedScope(VerilatedSyms* symsp, const char* prefixp, const char* suffixp,
-                               const char* identifier, const char* defnamep, int8_t timeunit,
-                               Type type)
+VerilatedScope::VerilatedScope(VerilatedSyms* symsp, const char* suffixp, const char* identifier,
+                               const char* defnamep, int8_t timeunit, Type type)
     : m_symsp{symsp}
-    , m_namep{[prefixp, suffixp]() {
+    , m_namep{[symsp, suffixp]() {
         // We don't want the space and reference-count access overhead of strings.
+        const char* prefixp = symsp->name();
         char* const namep = new char[std::strlen(prefixp) + std::strlen(suffixp) + 2];
         char* dp = namep;
         for (const char* sp = prefixp; *sp;) *dp++ = *sp++;

--- a/include/verilated.h
+++ b/include/verilated.h
@@ -680,6 +680,8 @@ public:  // But for internal use only
     explicit VerilatedSyms(VerilatedContext* contextp);  // Pass null for default context
     ~VerilatedSyms();
     VL_UNCOPYABLE(VerilatedSyms);
+
+    virtual const char* name() const = 0;
 };
 
 //===========================================================================
@@ -707,8 +709,8 @@ private:
     const Type m_type;  // Type of the scope
 
 public:  // But internals only - called from verilated modules, VerilatedSyms
-    VerilatedScope(VerilatedSyms* symsp, const char* prefixp, const char* suffixp,
-                   const char* identifier, const char* defnamep, int8_t timeunit, Type type);
+    VerilatedScope(VerilatedSyms* symsp, const char* suffixp, const char* identifier,
+                   const char* defnamep, int8_t timeunit, Type type);
     ~VerilatedScope();
 
     void exportInsert(int finalize, const char* namep, void* cb) VL_MT_UNSAFE;

--- a/src/V3EmitCSyms.cpp
+++ b/src/V3EmitCSyms.cpp
@@ -552,7 +552,7 @@ void EmitCSyms::emitSymHdr() {
     for (const std::string& funcName : m_splitFuncNames) { puts("void " + funcName + "();\n"); }
 
     puts("\n// METHODS\n");
-    puts("const char* name() { return TOP.vlNamep; }\n");
+    puts("const char* name() const { return TOP.vlNamep; }\n");
 
     if (v3Global.hasEvents()) {
         if (v3Global.assignsEvents()) {
@@ -736,7 +736,7 @@ std::vector<std::string> EmitCSyms::getSymCtorStmts() {
     for (const auto& itpair : m_scopeNames) {
         const ScopeData& sd = itpair.second;
         std::string stmt;
-        stmt += protect("__Vscopep_" + sd.m_symName) + " = new VerilatedScope{this, name(), \"";
+        stmt += protect("__Vscopep_" + sd.m_symName) + " = new VerilatedScope{this, \"";
         stmt += V3OutFormatter::quoteNameControls(
             VIdProtect::protectWordsIf(sd.m_prettyName, true));
         stmt += "\", \"";


### PR DESCRIPTION
Avoiding the many repeated calls to Syms::name() in the generated code again helps a little with compile times. It's probably ok to have `VerilatedSyms::name()` a virtual method to achieve that.
