### PR TITLE
Fix local interface parameter hierarchical access (#6661)

### DIFF
--- a/test_regress/t/t_interface_param_local_access.py
+++ b/test_regress/t/t_interface_param_local_access.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2024 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios("simulator_st")
+
+test.compile()
+
+test.passes()

--- a/test_regress/t/t_interface_param_local_access.v
+++ b/test_regress/t/t_interface_param_local_access.v
@@ -1,0 +1,51 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2025 by Wilson Snyder.
+// SPDX-License-Identifier: CC0-1.0
+
+interface intf #(
+    parameter int FOO = 32
+) ();
+endinterface
+
+module sub (
+    intf intf_a,
+    intf intf_b
+);
+  localparam int INTF_A_FOO = intf_a.FOO;
+  localparam int INTF_B_FOO = intf_b.FOO;
+  if (INTF_A_FOO != INTF_B_FOO)
+    $error("INTF_A_FOO != INTF_B_FOO: %0d != %0d", INTF_A_FOO, INTF_B_FOO);
+endmodule
+
+module t;
+  intf #(.FOO(21)) local_intf ();
+
+  intf #(.FOO(21)) intf_a_1 ();
+  intf #(.FOO(21)) intf_b_1 ();
+  sub sub_1 (
+      .intf_a(intf_a_1),
+      .intf_b(intf_b_1)
+  );
+
+  /* verilator lint_off HIERPARAM */
+  localparam int LOCAL_INTF_FOO = local_intf.FOO;
+  /* verilator lint_on HIERPARAM */
+  intf #(.FOO(LOCAL_INTF_FOO)) intf_a_2 ();
+  intf #(.FOO(21)) intf_b_2 ();
+  sub sub_2 (
+      .intf_a(intf_a_2),
+      .intf_b(intf_b_2)
+  );
+
+  /* verilator lint_off HIERPARAM */
+  intf #(.FOO(local_intf.FOO)) intf_a_3 ();
+  /* verilator lint_on HIERPARAM */
+  intf #(.FOO(21)) intf_b_3 ();
+  sub sub_3 (
+      .intf_a(intf_a_3),
+      .intf_b(intf_b_3)
+  );
+
+endmodule


### PR DESCRIPTION
…cal access

Build cache of locally-declared interfaces as well as those that appear in port list, and check both caches when attempting to resolve

We appreciate your contributing to Verilator.  If this is your first commit, please add your name to docs/CONTRIBUTORS, and read our contributing guidelines in docs/CONTRIBUTING.rst.
