### PR TITLE
[#86646] Fix large array initialization

### DIFF
--- a/src/V3Slice.cpp
+++ b/src/V3Slice.cpp
@@ -254,6 +254,7 @@ class SliceVisitor final : public VNVisitor {
         const int elementLimit = v3Global.opt.fSliceElementLimit();
         if (elements > elementLimit && elementLimit > 0) {
             ++m_statSliceElementSkips;
+            m_okInitArray = true;  // VL_RESTORER in visit(AstNodeAssign)
             return false;
         }
 

--- a/test_regress/t/t_mem.v
+++ b/test_regress/t/t_mem.v
@@ -12,6 +12,9 @@ module t (/*AUTOARG*/
    input clk;
    integer cyc; initial cyc=1;
 
+   logic hugemem [257];
+   initial hugemem = '{default:1'b0};
+
    // [16] is SV syntax for [0:15]
    reg [7:0] memory8_16 [16];
 
@@ -41,6 +44,7 @@ module t (/*AUTOARG*/
       if (cyc!=0) begin
          cyc <= cyc + 1;
          if (cyc==1) begin
+            $display(hugemem);
             m_we <= 1'b1;
             m_addr <= 3'd2;
             m_data <= 16'h55_44;


### PR DESCRIPTION
This fixes a regression from e2f5854088ffcccb63a5438b9de0b93531e75774 causing the init of an array larger than 256 elements to fail with `Array initialization should have been removed earlier`.