### PR TITLE
Fix `free` collision

### DIFF
--- a/src/V3EmitCImp.cpp
+++ b/src/V3EmitCImp.cpp
@@ -253,7 +253,7 @@ class EmitCImp final : public EmitCFunc {
         } else {
             putns(modp, "void " + modName + "::dtor() {\n");
         }
-        putns(modp, "VL_DO_DANGLING(free(const_cast<char*>(vlNamep)), vlNamep);\n");
+        putns(modp, "VL_DO_DANGLING(std::free(const_cast<char*>(vlNamep)), vlNamep);\n");
         emitSystemCSection(modp, VSystemCSectionType::DTOR);
         puts("}\n");
     }

--- a/test_regress/t/t_var_rsvd_port.v
+++ b/test_regress/t/t_var_rsvd_port.v
@@ -13,6 +13,7 @@ module t (/*AUTOARG*/
 
    reg  vector; // OK, as not public
    reg  switch /*verilator public*/;    // Bad
+   reg  free /*verilator public*/;    // OK, not actually a keyword
 
    initial begin
       $write("*-* All Finished *-*\n");


### PR DESCRIPTION
#6660 introduced `free()` into the verilated C++.  This causes problems if the design has a public `free` signal.  Without the fix `t_var_rsvd_port` will now throw:
```
Vt_var_rsvd_port_t__Slow.cpp: In member function âvoid Vt_var_rsvd_port_t::dtor()â:                       
Vt_var_rsvd_port_t__Slow.cpp:21:51: error: expression cannot be used as a function                        
   21 |     VL_DO_DANGLING(free(const_cast<char*>(vlNamep)), vlNamep);                                    
      |                                                   ^                                               
/usr/scratch/work/devs/verilator/test_regress/../include/verilatedos.h:259:13: note: in definition of macro âVL_DO_DANGLINGâ
  259 |             stmt; \                                  
      |             ^~~~                                                                                  
```