### PR TITLE
Fix bounds checking in non-inlined function

### DIFF
--- a/test_regress/t/t_opt_inline_funcs.py
+++ b/test_regress/t/t_opt_inline_funcs.py
@@ -13,6 +13,6 @@ test.scenarios('vlt')
 
 test.compile(verilator_flags2=['--stats'], verilator_make_gmake=False)
 
-test.file_grep(test.stats, r'Optimizations, Functions inlined\s+(\d+)', 2)
+test.file_grep(test.stats, r'Optimizations, Functions inlined\s+(\d+)', 3)
 
 test.passes()

--- a/test_regress/t/t_opt_inline_funcs.v
+++ b/test_regress/t/t_opt_inline_funcs.v
@@ -4,7 +4,11 @@
 // any use, without warranty, 2024 by Wilson Snyder.
 // SPDX-License-Identifier: CC0-1.0
 
-module t;
+module t(
+  input  logic [16:0] clearBit_i,
+  input  int          clearBit_idx,
+  output logic [16:0] clearBit_o
+);
 
    function void allfin;
       $write("*-* All Finished *-*\n");
@@ -18,4 +22,11 @@ module t;
       allfin();
       done();
    end
+
+   function automatic logic [16:0] clearBit(logic [16:0] i, int idx);
+     i[idx] = 1'b0;
+     return i;
+   endfunction
+   assign clearBit_o = clearBit(clearBit_i, clearBit_idx);
+
 endmodule


### PR DESCRIPTION
This used to throw an "Unsupported: non-inlined impure function" error with `-fno-inline-funcs` due to the temporary inserted in V3Unkown being put in the module rather than the function.
