### PR TITLE
Consider functions reading external parameters as pure

### DIFF
--- a/src/V3Task.cpp
+++ b/src/V3Task.cpp
@@ -271,8 +271,9 @@ private:
     }
     void visit(AstVarRef* nodep) override {
         iterateChildren(nodep);
-        if (nodep->varp()->user4u().toGraphVertex() != m_curVxp) {
-            if (m_curVxp->pure() && !nodep->varp()->isXTemp()) m_curVxp->impure(nodep);
+        AstVar* const varp = nodep->varp();
+        if (varp->user4u().toGraphVertex() != m_curVxp) {
+            if (m_curVxp->pure() && !varp->isXTemp() && !varp->isParam()) m_curVxp->impure(nodep);
         }
     }
     void visit(AstClass* nodep) override {

--- a/test_regress/t/t_opt_inline_funcs.py
+++ b/test_regress/t/t_opt_inline_funcs.py
@@ -11,8 +11,10 @@ import vltest_bootstrap
 
 test.scenarios('vlt')
 
-test.compile(verilator_flags2=['--stats'], verilator_make_gmake=False)
+test.compile(verilator_flags2=['--binary', '--stats'])
 
-test.file_grep(test.stats, r'Optimizations, Functions inlined\s+(\d+)', 3)
+test.file_grep(test.stats, r'Optimizations, Functions inlined\s+(\d+)', 4)
+
+test.execute()
 
 test.passes()

--- a/test_regress/t/t_opt_inline_funcs.v
+++ b/test_regress/t/t_opt_inline_funcs.v
@@ -4,29 +4,60 @@
 // any use, without warranty, 2024 by Wilson Snyder.
 // SPDX-License-Identifier: CC0-1.0
 
-module t(
-  input  logic [16:0] clearBit_i,
-  input  int          clearBit_idx,
-  output logic [16:0] clearBit_o
-);
 
-   function void allfin;
-      $write("*-* All Finished *-*\n");
-   endfunction
+`define stop $stop
+`define check(got ,exp) do if ((got) !== (exp)) begin $write("%%Error: %s:%0d: $time=%0t got='h%x exp='h%x\n", `__FILE__,`__LINE__, $time, (got), (exp)); `stop; end while(0)
 
-   task done;
-      $finish;
-   endtask
+module t;
 
-   initial begin
-      allfin();
-      done();
-   end
+  function void allfin;
+    $write("*-* All Finished *-*\n");
+  endfunction
 
-   function automatic logic [16:0] clearBit(logic [16:0] i, int idx);
-     i[idx] = 1'b0;
-     return i;
-   endfunction
-   assign clearBit_o = clearBit(clearBit_i, clearBit_idx);
+  task done;
+    $finish;
+  endtask
+
+  logic [16:0] clearBit_i;
+  int          clearBit_idx;
+  logic [16:0] clearBit_o;
+  function automatic logic [16:0] clearBit(logic [16:0] i, int idx);
+    i[idx] = 1'b0;
+    return i;
+  endfunction
+  always_comb begin
+    clearBit_o = clearBit(clearBit_i, clearBit_idx);
+    `check(clearBit_o, (clearBit_i & ~(17'd1 << clearBit_idx)));
+  end
+
+  logic [2:0]  lut_idx;
+  logic [4:0]  lut_o;
+  localparam logic [4:0] LUT [7:0] = '{5'd0, 5'd1, 5'd2, 5'd3, 5'd4, 5'd5, 5'd6, 5'd7};
+  function automatic logic [4:0] lut(logic [2:0] idx);
+    return LUT[idx];
+  endfunction
+  always_comb begin
+    lut_o = lut(lut_idx);
+    `check(lut_o, 5'd7 - 5'(lut_idx));
+  end
+
+  initial begin
+    #1;
+    clearBit_i = 17'h1ff;
+    for (int i = 0; i <= 16; ++i) begin
+      clearBit_idx = i;
+      #1;
+    end
+
+    #1;
+    for (int i = 0; i < 16; ++i) begin
+      lut_idx = 3'(i);
+      #1;
+    end
+
+    #1;
+    allfin();
+    done();
+  end
 
 endmodule

--- a/test_regress/t/t_opt_inline_funcs_no.py
+++ b/test_regress/t/t_opt_inline_funcs_no.py
@@ -12,8 +12,10 @@ import vltest_bootstrap
 test.scenarios('vlt')
 test.top_filename = "t/t_opt_inline_funcs.v"
 
-test.compile(verilator_flags2=['--fno-inline-funcs', '--stats'], verilator_make_gmake=False)
+test.compile(verilator_flags2=['--binary', '--fno-inline-funcs', '--stats'])
 
 test.file_grep(test.stats, r'Optimizations, Functions inlined\s+(\d+)', 0)
+
+test.execute()
 
 test.passes()

--- a/test_regress/t/t_opt_inline_funcs_no_eager.py
+++ b/test_regress/t/t_opt_inline_funcs_no_eager.py
@@ -12,8 +12,10 @@ import vltest_bootstrap
 test.scenarios('vlt')
 test.top_filename = "t/t_opt_inline_funcs.v"
 
-test.compile(verilator_flags2=['--fno-inline-funcs-eager', '--stats'], verilator_make_gmake=False)
+test.compile(verilator_flags2=['--binary', '--fno-inline-funcs-eager', '--stats'])
 
 test.file_grep(test.stats, r'Optimizations, Functions inlined\s+(\d+)', 1)
+
+test.execute()
 
 test.passes()


### PR DESCRIPTION
Parameters are constants and hence a function is still pure if it reads one. These work fine at runtime as the emitted function has access to the symbol table/module pointer. (Note packed parameters were already working like this due to them being simply inlined. This changes allows any other parameters, including unpacked types.)
