### PR TITLE
Tests: TEST_OBJ_DIR, TEST_DUMPFILE to abspath

### DIFF
--- a/test_regress/driver.py
+++ b/test_regress/driver.py
@@ -1162,7 +1162,9 @@ class VlTest:
         self.compile_vlt_cmd(**param)
 
         if not re.search(r'TEST_DUMPFILE', ' '.join(self.v_flags)):
-            self.v_flags += [self._define_opt_calc() + "TEST_DUMPFILE=" + os.path.abspath(self.trace_filename)]
+            self.v_flags += [
+                self._define_opt_calc() + "TEST_DUMPFILE=" + os.path.abspath(self.trace_filename)
+            ]
 
         if not param['make_top_shell']:
             self.top_shell_filename = ""


### PR DESCRIPTION
Previously, `TEST_OBJ_DIR` and `TEST_DUMPFILE` were relative to the location of `driver.py`. However, this meant that these relative paths were baked into the Verilated executable, so for successful trace dumping, the executable had to be executed from the `test_regress` directory. Executing the verilated executable from elsewhere would cause trace dumping to silently fail (or in the case of Icarus, fail fatally) because the relative path `test_regress/obj_vlt/<test_name>` cannot be found.
This commit fixes this by making `TEST_OBJ_DIR` and `TEST_DUMPFILE` absolute paths.
