### PR TITLE
Tests: Add v_flags and XRUN define to xrun run flags

### DIFF
--- a/test_regress/driver.py
+++ b/test_regress/driver.py
@@ -807,8 +807,8 @@ class VlTest:
         self.xrun_flags = []  # Doesn't really have a compile step
         self.xrun_flags2 = []  # Overridden in some sim files
         self.xrun_run_flags = [
-            "-64", "-access", "+rwc", "-newsv", "-sv", "-xmlibdirname", self.obj_dir + "/work",
-            "-l", self.obj_dir + "/history", "-quiet", "-plinowarn"
+            "+define+XRUN", "-64", "-access", "+rwc", "-newsv", "-sv", "-xmlibdirname",
+            self.obj_dir + "/work", "-l", self.obj_dir + "/history", "-quiet", "-plinowarn"
         ]
         # Verilator
         self.verilator_define = 'VERILATOR'
@@ -1540,6 +1540,7 @@ class VlTest:
                 "echo q | " + run_env + VtOs.getenv_def('VERILATOR_XRUN', "xrun"),
                 ' '.join(param['xrun_run_flags']),
                 ' '.join(param['xrun_flags2']),
+                ' '.join(param['v_flags']),
                 ' '.join(param['all_run_flags']),
                 pli_opt,
                 param['top_filename'],


### PR DESCRIPTION
The addition of the XRUN define allows using `define XRUN` in Verilog testbenches, and the `v_flags` enable simple usage of flags such as `--verbose` and `--trace` when running the test to set defines like `TEST_VERBOSE`, `TEST_OBJ_DIR`, `TEST_DUMPFILE` etc. without needing to manually set those in the test's python script.