### PR TITLE
Tests: add driver.py test.priority settings

### DIFF
--- a/test_regress/t/t_a1_first_cc.py
+++ b/test_regress/t/t_a1_first_cc.py
@@ -13,6 +13,7 @@
 
 import vltest_bootstrap
 
+test.priority(100)
 test.scenarios('vlt')
 
 test.leak_check_disable()

--- a/test_regress/t/t_a2_first_sc.py
+++ b/test_regress/t/t_a2_first_sc.py
@@ -13,6 +13,7 @@
 
 import vltest_bootstrap
 
+test.priority(100)
 test.scenarios('vlt')
 test.top_filename = "t/t_a1_first_cc.v"
 

--- a/test_regress/t/t_a3_selftest.py
+++ b/test_regress/t/t_a3_selftest.py
@@ -9,6 +9,7 @@
 
 import vltest_bootstrap
 
+test.priority(100)
 test.scenarios('vlt')
 test.top_filename = "t/t_EXAMPLE.v"
 

--- a/test_regress/t/t_a3_selftest_thread.py
+++ b/test_regress/t/t_a3_selftest_thread.py
@@ -9,6 +9,7 @@
 
 import vltest_bootstrap
 
+test.priority(100)
 test.scenarios('vltmt')
 test.top_filename = "t/t_EXAMPLE.v"
 

--- a/test_regress/t/t_a6_examples.py
+++ b/test_regress/t/t_a6_examples.py
@@ -9,6 +9,7 @@
 
 import vltest_bootstrap
 
+test.priority(180)
 test.scenarios('dist')
 
 test.clean_command = '/bin/rm -rf ../examples/*/build ../examples/*/obj*'

--- a/test_regress/t/t_case_write1.py
+++ b/test_regress/t/t_case_write1.py
@@ -9,6 +9,7 @@
 
 import vltest_bootstrap
 
+test.priority(50)
 test.scenarios('simulator')
 
 test.compile(verilator_flags2=["--stats -O3 -x-assign fast"])

--- a/test_regress/t/t_case_write2.py
+++ b/test_regress/t/t_case_write2.py
@@ -9,6 +9,7 @@
 
 import vltest_bootstrap
 
+test.priority(50)
 test.scenarios('simulator')
 
 test.compile(verilator_flags2=["--stats -O3 -x-assign fast"])

--- a/test_regress/t/t_dist_attributes_include.py
+++ b/test_regress/t/t_dist_attributes_include.py
@@ -9,6 +9,7 @@
 
 import vltest_bootstrap
 
+test.priority(30)
 test.scenarios('dist')
 test.rerunnable = False
 
@@ -32,18 +33,15 @@ if not have_clang_check():
 
 # some of the files are only used in Verilation
 # and are only in "include" folder
-srcfiles = test.glob_some(test.root +
-                          "/src/*.cpp") + test.glob_some(test.root +
-                                                         "/src/obj_dbg/V3Const__gen.cpp")
-srcfiles = [f for f in srcfiles if re.search(r'\/(V3Const|Vlc\w*|\w*_test|\w*_sc|\w*.yy).cpp$', f)]
+srcfiles = test.glob_some(test.root + "/include/*.cpp")
 srcfiles_str = " ".join(srcfiles)
+clang_args = "-I" + test.root + "/include/ -I" + test.root + "/include/vltstd/ -fcoroutines-ts"
 
 test.run(logfile=test.run_log_filename,
          tee=True,
          cmd=["python3", test.root + "/nodist/clang_check_attributes",
               "--verilator-root=" + test.root,
-              "--compilation-root=" + test.root + "/src/obj_dbg",
-              "--compile-commands-dir=" + test.root + "/src/obj_dbg",
+              "--cxxflags='" + clang_args + "'",
               srcfiles_str])  # yapf:disable
 
 test.file_grep(test.run_log_filename, r'Number of functions reported unsafe: +(\d+)', 0)

--- a/test_regress/t/t_dist_attributes_src.py
+++ b/test_regress/t/t_dist_attributes_src.py
@@ -9,6 +9,7 @@
 
 import vltest_bootstrap
 
+test.priority(30)
 test.scenarios('dist')
 test.rerunnable = False
 
@@ -32,15 +33,18 @@ if not have_clang_check():
 
 # some of the files are only used in Verilation
 # and are only in "include" folder
-srcfiles = test.glob_some(test.root + "/include/*.cpp")
+srcfiles = test.glob_some(test.root +
+                          "/src/*.cpp") + test.glob_some(test.root +
+                                                         "/src/obj_dbg/V3Const__gen.cpp")
+srcfiles = [f for f in srcfiles if re.search(r'\/(V3Const|Vlc\w*|\w*_test|\w*_sc|\w*.yy).cpp$', f)]
 srcfiles_str = " ".join(srcfiles)
-clang_args = "-I" + test.root + "/include/ -I" + test.root + "/include/vltstd/ -fcoroutines-ts"
 
 test.run(logfile=test.run_log_filename,
          tee=True,
          cmd=["python3", test.root + "/nodist/clang_check_attributes",
               "--verilator-root=" + test.root,
-              "--cxxflags='" + clang_args + "'",
+              "--compilation-root=" + test.root + "/src/obj_dbg",
+              "--compile-commands-dir=" + test.root + "/src/obj_dbg",
               srcfiles_str])  # yapf:disable
 
 test.file_grep(test.run_log_filename, r'Number of functions reported unsafe: +(\d+)', 0)

--- a/test_regress/t/t_gantt.py
+++ b/test_regress/t/t_gantt.py
@@ -11,6 +11,7 @@
 
 import vltest_bootstrap
 
+test.priority(30)
 test.scenarios('vlt_all')
 test.top_filename = "t/t_gantt.v"
 test.pli_filename = "t/t_gantt_c.cpp"

--- a/test_regress/t/t_gantt_hier.py
+++ b/test_regress/t/t_gantt_hier.py
@@ -11,6 +11,7 @@
 
 import vltest_bootstrap
 
+test.priority(30)
 test.scenarios('vlt_all')
 test.top_filename = "t/t_gantt.v"
 test.pli_filename = "t/t_gantt_c.cpp"

--- a/test_regress/t/t_gantt_two.py
+++ b/test_regress/t/t_gantt_two.py
@@ -11,6 +11,7 @@
 
 import vltest_bootstrap
 
+test.priority(50)
 test.scenarios('vlt_all')
 test.top_filename = "t/t_gantt.v"
 test.pli_filename = "t/t_gantt_c.cpp"

--- a/test_regress/t/t_hier_block.py
+++ b/test_regress/t/t_hier_block.py
@@ -9,6 +9,7 @@
 
 import vltest_bootstrap
 
+test.priority(30)
 test.scenarios('vlt_all')
 
 # stats will be deleted but generation will be skipped if libs of hierarchical blocks exist.

--- a/test_regress/t/t_hier_block_binary.py
+++ b/test_regress/t/t_hier_block_binary.py
@@ -9,6 +9,7 @@
 
 import vltest_bootstrap
 
+test.priority(30)
 test.scenarios('vlt_all')
 test.top_filename = "t/t_hier_block.v"
 

--- a/test_regress/t/t_hier_block_chained.py
+++ b/test_regress/t/t_hier_block_chained.py
@@ -9,7 +9,9 @@
 
 import vltest_bootstrap
 
+test.priority(30)
 test.scenarios('vlt_all')
+
 test.init_benchmarksim()
 test.cycles = (int(test.benchmark) if test.benchmark else 100000)
 test.sim_time = test.cycles * 10 + 1000

--- a/test_regress/t/t_hier_block_cmake.py
+++ b/test_regress/t/t_hier_block_cmake.py
@@ -13,6 +13,7 @@ import os
 # If a test fails, broken .cmake may disturb the next run
 test.clean_objs()
 
+test.priority(30)
 test.scenarios('simulator')
 test.top_filename = "t/t_hier_block.v"
 

--- a/test_regress/t/t_hier_block_import.py
+++ b/test_regress/t/t_hier_block_import.py
@@ -9,6 +9,7 @@
 
 import vltest_bootstrap
 
+test.priority(30)
 test.scenarios('vlt_all')
 
 # stats will be deleted but generation will be skipped if libs of hierarchical blocks exist.

--- a/test_regress/t/t_hier_block_import_cmake.py
+++ b/test_regress/t/t_hier_block_import_cmake.py
@@ -9,7 +9,9 @@
 
 import vltest_bootstrap
 
+test.priority(30)
 test.scenarios('vlt_all')
+
 # CMake build executes from a different directory than the Make one.
 test.top_filename = os.path.abspath("t/t_hier_block_import.v")
 

--- a/test_regress/t/t_hier_block_perf.py
+++ b/test_regress/t/t_hier_block_perf.py
@@ -9,7 +9,9 @@
 
 import vltest_bootstrap
 
+test.priority(30)
 test.scenarios('vlt_all')
+
 test.init_benchmarksim()
 test.cycles = (int(test.benchmark) if test.benchmark else 100000)
 test.sim_time = test.cycles * 10 + 1000

--- a/test_regress/t/t_hier_block_prot_lib.py
+++ b/test_regress/t/t_hier_block_prot_lib.py
@@ -9,6 +9,7 @@
 
 import vltest_bootstrap
 
+test.priority(30)
 test.scenarios('vlt_all', 'xsim')
 test.top_filename = "t/t_hier_block.v"
 

--- a/test_regress/t/t_hier_block_prot_lib_shared.py
+++ b/test_regress/t/t_hier_block_prot_lib_shared.py
@@ -9,6 +9,7 @@
 
 import vltest_bootstrap
 
+test.priority(30)
 test.scenarios('vlt_all', 'xsim')
 test.top_filename = "t/t_hier_block.v"
 

--- a/test_regress/t/t_hier_block_sc.py
+++ b/test_regress/t/t_hier_block_sc.py
@@ -9,6 +9,7 @@
 
 import vltest_bootstrap
 
+test.priority(30)
 test.scenarios('vlt_all')
 test.top_filename = "t/t_hier_block.v"
 

--- a/test_regress/t/t_hier_block_sc_trace_fst.py
+++ b/test_regress/t/t_hier_block_sc_trace_fst.py
@@ -9,6 +9,7 @@
 
 import vltest_bootstrap
 
+test.priority(30)
 test.scenarios('vlt_all')
 test.top_filename = "t/t_hier_block.v"
 

--- a/test_regress/t/t_hier_block_sc_trace_vcd.py
+++ b/test_regress/t/t_hier_block_sc_trace_vcd.py
@@ -9,6 +9,7 @@
 
 import vltest_bootstrap
 
+test.priority(30)
 test.scenarios('vlt_all')
 test.top_filename = "t/t_hier_block.v"
 

--- a/test_regress/t/t_hier_block_trace_fst.py
+++ b/test_regress/t/t_hier_block_trace_fst.py
@@ -9,6 +9,7 @@
 
 import vltest_bootstrap
 
+test.priority(30)
 test.scenarios('vlt_all')
 test.top_filename = "t/t_hier_block.v"
 

--- a/test_regress/t/t_hier_block_trace_saif.py
+++ b/test_regress/t/t_hier_block_trace_saif.py
@@ -9,6 +9,7 @@
 
 import vltest_bootstrap
 
+test.priority(30)
 test.scenarios('vlt_all')
 test.top_filename = "t/t_hier_block.v"
 test.golden_filename = "t/t_hier_block_trace_saif.out"

--- a/test_regress/t/t_hier_block_trace_vcd.py
+++ b/test_regress/t/t_hier_block_trace_vcd.py
@@ -9,6 +9,7 @@
 
 import vltest_bootstrap
 
+test.priority(30)
 test.scenarios('vlt_all')
 test.top_filename = "t/t_hier_block.v"
 

--- a/test_regress/t/t_unopt_array_csplit.py
+++ b/test_regress/t/t_unopt_array_csplit.py
@@ -9,6 +9,7 @@
 
 import vltest_bootstrap
 
+test.priority(30)
 test.scenarios('vlt_all')
 test.top_filename = "t/t_unopt_array.v"
 

--- a/test_regress/t/t_uvm_hello_all_v2017_1_0_nodpi.py
+++ b/test_regress/t/t_uvm_hello_all_v2017_1_0_nodpi.py
@@ -9,6 +9,7 @@
 
 import vltest_bootstrap
 
+test.priority(50)
 test.scenarios('vlt')
 test.top_filename = 't/t_uvm_hello.v'
 

--- a/test_regress/t/t_uvm_hello_all_v2020_3_1_nodpi.py
+++ b/test_regress/t/t_uvm_hello_all_v2020_3_1_nodpi.py
@@ -9,6 +9,7 @@
 
 import vltest_bootstrap
 
+test.priority(50)
 test.scenarios('vlt')
 test.top_filename = 't/t_uvm_hello.v'
 


### PR DESCRIPTION
This allows the tests to set a test.priority, where a higher number will cause a test to be run before other tests with lower priority numbers.

This should help the current runners finish faster, as the t_uvm_* tests were always finishing last and running as a single job, asthey started late due to their late-in-sorted-order names.

The obj_dist/*.log files will add an informational message if a test is in the worst 6 runtimes and has a non-default priority. This is harmless but I'll watch it over time to see if other tests need higher priorities.

