### PR TITLE
Tests: Fix make_main traceEverOn after eval

### DIFF
--- a/test_regress/driver.py
+++ b/test_regress/driver.py
@@ -2039,6 +2039,13 @@ class VlTest:
 
             fh.write(
                 "    const std::unique_ptr<VerilatedContext> contextp{new VerilatedContext};\n")
+
+            if self.trace:
+                fh.write("\n")
+                fh.write("#if VM_TRACE\n")
+                fh.write("    contextp->traceEverOn(true);\n")
+                fh.write("#endif\n")
+
             fh.write("    contextp->threads(" + str(self.context_threads) + ");\n")
             fh.write("    contextp->commandArgs(argc, argv);\n")
             fh.write("    contextp->debug(" + ('1' if self.verilated_debug else '0') + ");\n")
@@ -2067,7 +2074,6 @@ class VlTest:
             if self.trace:
                 fh.write("\n")
                 fh.write("#if VM_TRACE\n")
-                fh.write("    contextp->traceEverOn(true);\n")
                 if self.trace_format == 'fst-c':
                     fh.write("    std::unique_ptr<VerilatedFstC> tfp{new VerilatedFstC};\n")
                 if self.trace_format == 'fst-sc':


### PR DESCRIPTION
When dumping traces using `$dumpvars` from the Verilog code, this requires that `Verilated::traceEverOn(true)` has been called before the first eval. Otherwise, the test fails with
```
Turning on wave traces requires Verilated::traceEverOn(true) call before time 0
```
The `main` function generated by `make_main=1` does not respect this, and has the `traceEverOn` call _after_ the first eval. This causes any test using it with a `$dumpvars` statement at the start to fail. The existing test `t_gen_intdot2` also fails for this reason if run with `--trace`.

This commit fixes this behavior and moves `traceEverOn` before the first `eval`.
