### PR TITLE
Improve trace initialization code size

### DIFF
--- a/include/verilated_fst_c.cpp
+++ b/include/verilated_fst_c.cpp
@@ -149,8 +149,9 @@ static std::pair<bool, fstScopeType> toFstScopeType(VerilatedTracePrefixType typ
     }
 }
 
-void VerilatedFst::pushPrefix(const std::string& name, VerilatedTracePrefixType type) {
+void VerilatedFst::pushPrefix(const char* namep, VerilatedTracePrefixType type) {
     assert(!m_prefixStack.empty());  // Constructor makes an empty entry
+    const std::string name{namep};
     // An empty name means this is the root of a model created with
     // name()=="".  The tools get upset if we try to pass this as empty, so
     // we put the signals under a new $rootio scope, but the signals

--- a/include/verilated_fst_c.h
+++ b/include/verilated_fst_c.h
@@ -110,7 +110,7 @@ public:
     //=========================================================================
     // Internal interface to Verilator generated code
 
-    void pushPrefix(const std::string&, VerilatedTracePrefixType);
+    void pushPrefix(const char*, VerilatedTracePrefixType);
     void popPrefix();
 
     void declEvent(uint32_t code, uint32_t fidx, const char* name, int dtypenum,

--- a/include/verilated_saif_c.cpp
+++ b/include/verilated_saif_c.cpp
@@ -474,8 +474,9 @@ void VerilatedSaif::printIndent() {
     printStr(std::string(m_indent, ' '));  // Must use () constructor
 }
 
-void VerilatedSaif::pushPrefix(const std::string& name, VerilatedTracePrefixType type) {
+void VerilatedSaif::pushPrefix(const char* namep, VerilatedTracePrefixType type) {
     assert(!m_prefixStack.empty());  // Constructor makes an empty entry
+    const std::string name{namep};
     // An empty name means this is the root of a model created with
     // name()=="".  The tools get upset if we try to pass this as empty, so
     // we put the signals under a new $rootio scope, but the signals

--- a/include/verilated_saif_c.h
+++ b/include/verilated_saif_c.h
@@ -143,7 +143,7 @@ public:
     //=========================================================================
     // Internal interface to Verilator generated code
 
-    void pushPrefix(const std::string&, VerilatedTracePrefixType);
+    void pushPrefix(const char*, VerilatedTracePrefixType);
     void popPrefix();
 
     void declEvent(uint32_t code, uint32_t fidx, const char* name, int dtypenum,

--- a/include/verilated_vcd_c.cpp
+++ b/include/verilated_vcd_c.cpp
@@ -321,8 +321,9 @@ void VerilatedVcd::printIndent(int level_change) {
     if (level_change > 0) m_indent += level_change;
 }
 
-void VerilatedVcd::pushPrefix(const std::string& name, VerilatedTracePrefixType type) {
+void VerilatedVcd::pushPrefix(const char* namep, VerilatedTracePrefixType type) {
     assert(!m_prefixStack.empty());  // Constructor makes an empty entry
+    const std::string name{namep};
     // An empty name means this is the root of a model created with
     // name()=="".  The tools get upset if we try to pass this as empty, so
     // we put the signals under a new $rootio scope, but the signals

--- a/include/verilated_vcd_c.h
+++ b/include/verilated_vcd_c.h
@@ -134,7 +134,7 @@ public:
     //=========================================================================
     // Internal interface to Verilator generated code
 
-    void pushPrefix(const std::string&, VerilatedTracePrefixType);
+    void pushPrefix(const char*, VerilatedTracePrefixType);
     void popPrefix();
 
     void declEvent(uint32_t code, uint32_t fidx, const char* name, int dtypenum,

--- a/src/V3EmitCModel.cpp
+++ b/src/V3EmitCModel.cpp
@@ -549,8 +549,7 @@ class EmitCModel final : public EmitCFunc {
              "0.\");\n");
         puts("}\n");
         puts("vlSymsp->__Vm_baseCode = code;\n");
-        puts("tracep->pushPrefix(std::string{vlSymsp->name()}, "
-             "VerilatedTracePrefixType::SCOPE_MODULE);\n");
+        puts("tracep->pushPrefix(vlSymsp->name(), VerilatedTracePrefixType::SCOPE_MODULE);\n");
         puts(topModNameProtected + "__" + protect("trace_decl_types") + "(tracep);\n");
         puts(topModNameProtected + "__" + protect("trace_init_top") + "(vlSelf, tracep);\n");
         puts("tracep->popPrefix();\n");


### PR DESCRIPTION
Pass const char* to trace `pushPrefix`. This might seem a bit silly, but this saves 10% on the total code size in RTLMeter as it eliminates string constructor/destructor calls in the trace initializations. We always call this with either string literals or a C string. Helpful when you are in the -mcmodel=large domain.