### PR TITLE
Build Verilator itself with -fno-exceptions

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -475,6 +475,7 @@ _MY_CXX_CHECK_OPT(CFG_CXXFLAGS_SRC,-Wno-shadow)
 _MY_CXX_CHECK_OPT(CFG_CXXFLAGS_SRC,-Wno-unused-parameter)
 _MY_CXX_CHECK_OPT(CFG_CXXFLAGS_SRC,-Xclang -fno-pch-timestamp)
 _MY_CXX_CHECK_OPT(CFG_CXXFLAGS_SRC,-faligned-new)
+_MY_CXX_CHECK_OPT(CFG_CXXFLAGS_SRC,-fno-exceptions)
 AC_SUBST(CFG_CXXFLAGS_SRC)
 
 # Flags for compiling Verilator parser always (in addition to above CFG_CXXFLAGS_SRC)


### PR DESCRIPTION
Note there are 2 try-catch blocks in V3Os.cpp/V3Options.cpp, both only use with MSVC, which uses the cmake base build, so this should be ok.

Saves about 10% .text size, but I would expect no real performance difference.