### PR TITLE
Fix O(n*2) analysis in const-bit-op-tree

### DIFF
--- a/test_regress/t/t_opt_const.py
+++ b/test_regress/t/t_opt_const.py
@@ -16,7 +16,7 @@ test.compile(verilator_flags2=["-Wno-UNOPTTHREADS", "-fno-dfg", "--stats", test.
 test.execute()
 
 if test.vlt:
-    test.file_grep(test.stats, r'Optimizations, Const bit op reduction\s+(\d+)', 44)
+    test.file_grep(test.stats, r'Optimizations, Const bit op reduction\s+(\d+)', 49)
     test.file_grep(test.stats, r'SplitVar, packed variables split automatically\s+(\d+)', 1)
 
 test.passes()

--- a/test_regress/t/t_opt_const_cov.py
+++ b/test_regress/t/t_opt_const_cov.py
@@ -16,6 +16,6 @@ test.compile(verilator_flags2=["-Wno-UNOPTTHREADS", "--stats", "--coverage", "--
 test.execute()
 
 if test.vlt:
-    test.file_grep(test.stats, r'Optimizations, Const bit op reduction\s+(\d+)', 478)
+    test.file_grep(test.stats, r'Optimizations, Const bit op reduction\s+(\d+)', 550)
 
 test.passes()

--- a/test_regress/t/t_opt_const_dfg.py
+++ b/test_regress/t/t_opt_const_dfg.py
@@ -18,7 +18,7 @@ test.compile(verilator_flags2=["-Wno-UNOPTTHREADS", "--stats", test.pli_filename
 test.execute()
 
 if test.vlt:
-    test.file_grep(test.stats, r'Optimizations, Const bit op reduction\s+(\d+)', 37)
+    test.file_grep(test.stats, r'Optimizations, Const bit op reduction\s+(\d+)', 43)
     test.file_grep(test.stats, r'SplitVar, packed variables split automatically\s+(\d+)', 1)
 
 test.passes()

--- a/test_regress/t/t_opt_const_no_expand.py
+++ b/test_regress/t/t_opt_const_no_expand.py
@@ -19,6 +19,6 @@ test.compile(verilator_flags2=[
 test.execute()
 
 if test.vlt:
-    test.file_grep(test.stats, r'Optimizations, Const bit op reduction\s+(\d+)', 1)
+    test.file_grep(test.stats, r'Optimizations, Const bit op reduction\s+(\d+)', 4)
 
 test.passes()

--- a/test_regress/t/t_opt_const_red.py
+++ b/test_regress/t/t_opt_const_red.py
@@ -16,6 +16,6 @@ test.compile(verilator_flags2=["-Wno-UNOPTTHREADS", "--stats"])
 test.execute()
 
 if test.vlt:
-    test.file_grep(test.stats, r'Optimizations, Const bit op reduction\s+(\d+)', 158)
+    test.file_grep(test.stats, r'Optimizations, Const bit op reduction\s+(\d+)', 160)
 
 test.passes()


### PR DESCRIPTION
Note this might miss some cases where a sub-tree within an And/Or/Xor tree is optimizeable, but not the whole tree, but in practice this seems to work better than the alternative of keeping a set of failed nodes and bail early.
