### PR TITLE
Tests: Fix UVM dpi tests on macOS (#6795 partial)

### DIFF
--- a/test_regress/t/uvm/v2017_1_0/dpi/uvm_dpi.h
+++ b/test_regress/t/uvm/v2017_1_0/dpi/uvm_dpi.h
@@ -32,7 +32,7 @@
 #include "vpi_user.h"
 #include "veriuser.h"
 #include "svdpi.h"
-#include <malloc.h>
+//#include <malloc.h>
 #include <string.h>
 #include <stdio.h>
 #include <regex.h>

--- a/test_regress/t/uvm/v2017_1_0/dpi/uvm_hdl_verilator.c
+++ b/test_regress/t/uvm/v2017_1_0/dpi/uvm_hdl_verilator.c
@@ -32,7 +32,7 @@
 #include "svdpi.h"
 #include "vpi_user.h"
 
-#include <malloc.h>
+#include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
 

--- a/test_regress/t/uvm/v2020_3_1/dpi/uvm_dpi.h
+++ b/test_regress/t/uvm/v2020_3_1/dpi/uvm_dpi.h
@@ -42,7 +42,7 @@
 #include "vpi_user.h"
 #include "veriuser.h"
 #include "svdpi.h"
-#include <malloc.h>
+//#include <malloc.h>
 #include <string.h>
 #include <stdio.h>
 #include <regex.h>

--- a/test_regress/t/uvm/v2020_3_1/dpi/uvm_hdl_verilator.c
+++ b/test_regress/t/uvm/v2020_3_1/dpi/uvm_hdl_verilator.c
@@ -32,7 +32,7 @@
 #include "svdpi.h"
 #include "vpi_user.h"
 
-#include <malloc.h>
+#include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
 


### PR DESCRIPTION
malloc.h is deprecated and not available on macOS. I assume you don't want to change the originals to unconditionally use stdlib.h, but we can do that if preferred.