### PR TITLE
Fix write variable placement for global constraints (#6740) (#6750)

### DIFF
--- a/test_regress/t/t_constraint_global_nested_member.py
+++ b/test_regress/t/t_constraint_global_nested_member.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2025 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+if not test.have_solver:
+    test.skip("No constraint solver installed")
+
+test.compile()
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_constraint_global_nested_member.v
+++ b/test_regress/t/t_constraint_global_nested_member.v
@@ -1,0 +1,87 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2025 by PlanV GmbH.
+// SPDX-License-Identifier: CC0-1.0
+
+
+// Test case 1
+class uvm_reg_field;
+  rand int m_value;
+endclass
+
+class reg_class;
+  rand int m_value;
+  rand uvm_reg_field _dummy;
+  constraint _dummy_is_reg {_dummy.m_value == m_value;}
+  function new();
+    _dummy = new;
+  endfunction
+endclass
+
+class block_class;
+  rand reg_class m_r;
+  function new();
+    m_r = new;
+  endfunction
+endclass
+
+class tb_test;
+  virtual task run_phase(int phase);
+    block_class regmodel;
+    regmodel = new;
+    // verilator lint_off IGNOREDRETURN
+    void'(regmodel.randomize() with {m_r.m_value == 32'hA5;});
+    // verilator lint_on IGNOREDRETURN
+    if (regmodel.m_r.m_value != 32'hA5) $stop;
+  endtask
+endclass
+
+
+// Test case 2
+class axi_agent_config;
+   rand bit r_ready_delays;
+   constraint r_ready_delays_c {
+      r_ready_delays == 0;
+   }
+endclass
+
+class axi_env_config;
+   rand axi_agent_config   axim_agt_cfg;
+   function new();
+      axim_agt_cfg = new;
+   endfunction
+endclass
+
+class axi_base_test;
+  axi_env_config axi_env_cfg;
+  virtual function void build_phase();
+    configure_axi_env();
+  endfunction
+  function void configure_axi_env();
+    axi_env_cfg = new;
+  endfunction
+endclass
+
+class axi_wrap_test extends axi_base_test;
+  function void configure_axi_env();
+    void'(axi_env_cfg.randomize());
+  endfunction
+endclass
+
+
+module t_constraint_global_nested_member;
+  initial begin
+    tb_test tb;
+    axi_wrap_test axi_t;
+
+    tb = new;
+    tb.run_phase(0);
+
+    axi_t = new();
+    axi_t.build_phase();
+
+    $write("*-* All Finished *-*\n");
+    $finish;
+  end
+endmodule


### PR DESCRIPTION
This patch addresses two issues that occur with global constraints in complex scenarios especially in UVM testbenches.

1. write_var placement optimization
Moved write_var for path-connected variables under global constraints from new() to randomize(). This fixes the issue where the class was not yet initialized when randomize() was called.
2. classp bug fix
Fixed an issue where write_var was placed in the wrong class when accessing nested membersel in global constraints.

This patch resolves the issues mentioned in #6740 and #6750 . Combined the two test cases into a single test and added it to CI tests.

A minor fix: Optimized several lines of non-triggered code identified by coverage report from the previous PR.