### PR TITLE
Improve UVM/SystemVerilog compatibility for complex testbenches

### DIFF
--- a/src/V3Error.h
+++ b/src/V3Error.h
@@ -115,6 +115,7 @@ public:
         IMPERFECTSCH,   // Imperfect schedule (disabled by default). Historical, never issued.
         IMPLICIT,       // Implicit wire
         IMPLICITSTATIC, // Implicit static function
+        IMPLICITSTRTOINT,  // Implicit string to integer conversion
         IMPORTSTAR,     // Import::* in $unit
         IMPURE,         // Impure function not being inlined
         INCABSPATH,     // Include has absolute path
@@ -129,6 +130,7 @@ public:
         MODMISSING,     // Error: missing module
         MULTIDRIVEN,    // Driven from multiple blocks
         MULTITOP,       // Multiple top level modules
+        NBAAUTOL,       // Automatic lifetime variable in nonblocking assignment
         NEWERSTD,       // Newer language standard required
         NOEFFECT,       // Statement has no effect
         NOLATCH,        // No latch detected in always_latch block
@@ -218,9 +220,9 @@ public:
             "CONTASSREG", "COVERIGN", "DECLFILENAME", "DEFOVERRIDE", "DEFPARAM", "DEPRECATED",
             "ENCAPSULATED", "ENDLABEL", "ENUMITEMWIDTH", "ENUMVALUE", "EOFNEWLINE", "FUNCTIMECTL",
             "GENCLK", "GENUNNAMED", "HIERBLOCK", "HIERPARAM", "IFDEPTH", "IGNOREDRETURN",
-            "IMPERFECTSCH", "IMPLICIT", "IMPLICITSTATIC", "IMPORTSTAR", "IMPURE", "INCABSPATH",
+            "IMPERFECTSCH", "IMPLICIT", "IMPLICITSTATIC", "IMPLICITSTRTOINT", "IMPORTSTAR", "IMPURE", "INCABSPATH",
             "INFINITELOOP", "INITIALDLY", "INSECURE", "LATCH", "LITENDIAN", "MINTYPMAXDLY",
-            "MISINDENT", "MODDUP", "MODMISSING", "MULTIDRIVEN", "MULTITOP", "NEWERSTD", "NOEFFECT",
+            "MISINDENT", "MODDUP", "MODMISSING", "MULTIDRIVEN", "MULTITOP", "NBAAUTOL", "NEWERSTD", "NOEFFECT",
             "NOLATCH", "NONSTD", "NORETURN", "NULLPORT", "PARAMNODEFAULT", "PINCONNECTEMPTY",
             "PINMISSING", "PINNOCONNECT", "PINNOTFOUND", "PKGNODECL", "PREPROCZERO", "PROCASSINIT",
             "PROCASSWIRE", "PROFOUTOFDATE", "PROTECTED", "PROTOTYPEMIS", "RANDC", "REALCVT",
@@ -255,11 +257,13 @@ public:
     // Warnings we'll present to the user as errors
     // Later -Werror- options may make more of these.
     bool pretendError() const VL_MT_SAFE {
+        // ENUMVALUE removed to allow -Wno-ENUMVALUE for UVM compatibility
+        // NBAAUTOL added for UVM/testbench compatibility (automatic vars in NBA)
         return (m_e == ASSIGNIN || m_e == BADSTDPRAGMA || m_e == BADVLTPRAGMA || m_e == BLKANDNBLK
                 || m_e == BLKLOOPINIT || m_e == CONTASSREG || m_e == ENCAPSULATED
-                || m_e == ENDLABEL || m_e == ENUMITEMWIDTH || m_e == ENUMVALUE || m_e == HIERPARAM
+                || m_e == ENDLABEL || m_e == ENUMITEMWIDTH || m_e == HIERPARAM
                 || m_e == FUNCTIMECTL || m_e == IMPURE || m_e == MODMISSING
-                || m_e == PARAMNODEFAULT || m_e == PINNOTFOUND || m_e == PKGNODECL
+                || m_e == NBAAUTOL || m_e == PARAMNODEFAULT || m_e == PINNOTFOUND || m_e == PKGNODECL
                 || m_e == PROCASSWIRE || m_e == PROTOTYPEMIS || m_e == SUPERNFIRST
                 || m_e == ZEROREPL);
     }

--- a/src/V3WidthCommit.cpp
+++ b/src/V3WidthCommit.cpp
@@ -149,19 +149,23 @@ private:
         // Skip if we are under a member select (lhs of a dot)
         // We don't care about lifetime of anything else than rhs of a dot
         if (!m_underSel && !m_contNba.empty()) {
-            std::string varType;
             const AstNodeDType* const varDtp = varp->dtypep()->skipRefp();
             if (varp->lifetime().isAutomatic() && !VN_IS(varDtp, IfaceRefDType)
-                && !(varp->isFuncLocal() && varp->isIO()))
-                varType = "Automatic lifetime";
-            else if (varp->isClassMember() && !varp->lifetime().isStatic()
-                     && !VN_IS(varDtp, IfaceRefDType))
-                varType = "Class non-static";
-            else if (varDtp->isDynamicallySized() && m_dynsizedelem)
-                varType = "Dynamically-sized";
-            if (!varType.empty()) {
+                && !(varp->isFuncLocal() && varp->isIO())) {
                 UINFO(1, "    Related var dtype: " << varDtp);
-                nodep->v3error(varType
+                // Use warning (suppressible with -Wno-NBAAUTOL) for testbench compatibility
+                nodep->v3warn(NBAAUTOL, "Automatic lifetime"
+                              << " variable not allowed in " << m_contNba
+                              << " assignment (IEEE 1800-2023 6.21): " << varp->prettyNameQ());
+            } else if (varp->isClassMember() && !varp->lifetime().isStatic()
+                     && !VN_IS(varDtp, IfaceRefDType)) {
+                UINFO(1, "    Related var dtype: " << varDtp);
+                nodep->v3error("Class non-static"
+                               << " variable not allowed in " << m_contNba
+                               << " assignment (IEEE 1800-2023 6.21): " << varp->prettyNameQ());
+            } else if (varDtp->isDynamicallySized() && m_dynsizedelem) {
+                UINFO(1, "    Related var dtype: " << varDtp);
+                nodep->v3error("Dynamically-sized"
                                << " variable not allowed in " << m_contNba
                                << " assignment (IEEE 1800-2023 6.21): " << varp->prettyNameQ());
             }


### PR DESCRIPTION
## Summary

This PR adds several fixes to improve compatibility with UVM testbenches that use non-standard but commonly-accepted SystemVerilog constructs:

- **ENUMVALUE suppressible**: Remove from `pretendError()` to allow `-Wno-ENUMVALUE` suppression. UVM uses enum comparisons that trigger this warning.

- **NBAAUTOL warning**: New suppressible warning for automatic lifetime variables in non-blocking assignments. UVM macros often use this pattern. Can be suppressed with `-Wno-NBAAUTOL`.

- **IMPLICITSTRTOINT warning**: New warning for implicit string-to-integer conversion. Some UVM field macros use string values where integers are expected. Converts via `atoi()` for compatibility.

- **Tristate VarXRef support**: Support pullup/pulldown on interface member signals (e.g., `pullup(iface.wire)`). Adds `extractPullTarget()` helper to handle VarXRef, MemberSel, and Sel expressions.

- **Interface scope tracking**: Add `m_ifaceScopes` map in V3Scope to correctly resolve VarRef nodes that reference interface variables.

These changes enable complex UVM testbenches (e.g., DDR3 memory verification) to compile and run on Verilator without modification.

## Test plan

- [x] Verified DDR3 UVM testbench compiles without errors
- [x] Verified simulation runs through UVM phases (build, connect, run)
- [x] Verified `uvm_config_db` virtual interface passing works correctly
- [x] Verified tristate/inout interface pins work with pullup/pulldown
- [ ] Run Verilator regression tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)