### PR TITLE
VlThreadPool: Improve too many threads check logic

### DIFF
--- a/include/verilated_threads.cpp
+++ b/include/verilated_threads.cpp
@@ -156,7 +156,7 @@ std::string VlThreadPool::numaAssign() {
     // Make a reasonable processor affinity selection
     const int num_threads = static_cast<int>(m_workers.size());
     if (num_threads < 2) return "too few threads";
-    if (static_cast<unsigned>(num_threads) > num_proc) return "too many threads";
+    if (static_cast<unsigned>(num_threads) >= num_proc - 1) return "too many threads";
 
     // Read CPU info.
     // Uncertain if any modern system has gaps in the processor id (Solaris

--- a/test_regress/t/t_gantt_numa.py
+++ b/test_regress/t/t_gantt_numa.py
@@ -41,7 +41,8 @@ for trial in range(0, trials):
 
     if sys.platform != "darwin":
         test.file_grep(gantt_log, r'CPU info:')
-        test.file_grep(gantt_log, r'NUMA status += (assigned|%Warning: no /proc/cpuinfo)')
+        test.file_grep(gantt_log,
+                       r'NUMA status += (assigned|too many threads|%Warning: no /proc/cpuinfo)')
         # False fails occasionally
         # test.file_grep_not(gantt_log, r'%Warning:')  # e.g. There were fewer CPUs (1) than threads (3).
 


### PR DESCRIPTION
As the thread pool is initialized for `m_threads - 1` workers, when `m_threads` equals `the number of processors`, the `num_threads` will be equal to `the number of processors - 1`, which is not needed to set affinity.

This also improves backward compatibility. As mentioned in issue #6826, when the new context API is not used, the default thread pool is created with the number of workers equal to `the number of processors - 1`. In this case, when using `--threads n` with `n` less than the number of processors, the thread pool is still created with the `number of processors - 1` workers, so we will even set wrong affinity, and let some SMTs on the same core be used for emulator model threads, which degrades performance. With this fix, the affinity will not be set in this case.
