### PR TITLE
V3EmitCMain: set threads in VerilatedContext

### DIFF
--- a/src/V3EmitCMain.cpp
+++ b/src/V3EmitCMain.cpp
@@ -64,6 +64,7 @@ private:
         puts("Verilated::debug(0);\n");
         puts("const std::unique_ptr<VerilatedContext> contextp{new VerilatedContext};\n");
         if (v3Global.opt.trace()) puts("contextp->traceEverOn(true);\n");
+        puts("contextp->threads(" + std::to_string(v3Global.opt.threads()) + ");\n");
         puts("contextp->commandArgs(argc, argv);\n");
         puts("\n");
 


### PR DESCRIPTION
After #5911 and before #6839, the number of threads in VerilatedContext will affect numa assignments. So we need to set it in the generated C++ main function.