### PR TITLE
Change metacomments to not enable warnings disabled in control file (#6836)

### DIFF
--- a/docs/guide/exe_verilator.rst
+++ b/docs/guide/exe_verilator.rst
@@ -2382,8 +2382,10 @@ The grammar of control commands is as follows:
    (or wildcard with '\*' or '?', or all files if omitted) and range of
    line numbers (or all lines if omitted).
 
-   With lint_off using "\*" will override any lint_on directives in the
-   source, i.e. the warning will still not be printed.
+   If a warning is disabled with lint_off, it will not be printed, even if the
+   source contains a lint_on metacomment. The control file directives and
+   metacomments are interpreted separately and do not interact. A warning is
+   emitted only if not disabled either in a control file or via metacomments.
 
    If the ``-rule`` is omitted, all lint warnings (see list in
    :vlopt:`-Wno-lint`) are enabled/disabled. This will override all later
@@ -2492,9 +2494,10 @@ The grammar of control commands is as follows:
    :option:`--no-timing`, and code:`fork`/``join*`` blocks are
    converted into ``begin``/``end`` blocks.
 
-   Same as :option:`/*verilator&32;timing_on*/`,
-   :option:`/*verilator&32;timing_off*/` metacomments.
-
+   Similar to :option:`/*verilator&32;timing_on*/`,
+   :option:`/*verilator&32;timing_off*/` metacomments, but interpreted
+   independtly. If either a control file, or metacommets disable timing
+   constructs, they will be disabled.
 
    .. t_dist_docs_style ignore tracing_on
 

--- a/docs/guide/warnings.rst
+++ b/docs/guide/warnings.rst
@@ -45,6 +45,9 @@ Warnings may be disabled in multiple ways:
 
       lint_off -rule UNSIGNED -file "*/example.v" -lines 1
 
+Metacomments and control file directives do not interact. If a warning is
+disabled by either metacomments, or a directive in a control file, it will not
+be emitted.
 
 Error And Warning Format
 ========================

--- a/src/V3Control.cpp
+++ b/src/V3Control.cpp
@@ -432,7 +432,7 @@ public:
             for (; m_lastIgnore.it != m_ignLines.end(); ++m_lastIgnore.it) {
                 if (m_lastIgnore.it->m_lineno > curlineno) break;
                 // UINFO(9, "     Hit " << *m_lastIgnore.it);
-                filelinep->warnOn(m_lastIgnore.it->m_code, m_lastIgnore.it->m_on);
+                filelinep->warnOnCtrl(m_lastIgnore.it->m_code, m_lastIgnore.it->m_on);
             }
             if (false && debug() >= 9) {
                 for (IgnLines::const_iterator it = m_lastIgnore.it; it != m_ignLines.end(); ++it) {

--- a/test_regress/t/t_vlt_timing.py
+++ b/test_regress/t/t_vlt_timing.py
@@ -10,7 +10,6 @@
 import vltest_bootstrap
 
 test.scenarios('simulator')
-test.top_filename = "t/t_timing_off.v"
 
 test.compile(verilator_flags2=["--binary t/t_vlt_timing.vlt"])
 

--- a/test_regress/t/t_vlt_timing.v
+++ b/test_regress/t/t_vlt_timing.v
@@ -1,0 +1,39 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2022 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+module t;
+  event e1;
+  event e2;
+
+  initial begin
+    int x;
+    // verilator timing_off
+    #1
+    fork @e1; @e2; join;
+    @e1
+    wait(x == 4)
+    x = #1 8;
+    // verilator timing_on
+    if (x != 8) $stop;
+    if ($time != 0) $stop;
+
+    @e2;
+
+    @e1;
+    if ((e1.triggered && e2.triggered)
+      || (!e1.triggered && !e2.triggered)) $stop;
+    if ($time != 2) $stop;
+    $write("*-* All Finished *-*\n");
+    $finish;
+  end
+
+  initial #2 ->e1;
+
+  initial #2 ->e2;
+
+  initial #3 $stop; // timeout
+  initial #1 @(e1, e2) #1 $stop; // timeout
+endmodule

--- a/test_regress/t/t_vlt_timing.vlt
+++ b/test_regress/t/t_vlt_timing.vlt
@@ -6,6 +6,10 @@
 
 `verilator_config
 
-timing_on --file "t/t_timing_off.v" --lines 23
-timing_off -file "t/t_timing_off.v" -lines 26-34
-timing_on -file "t/t_timing_off.v" -lines 35-38
+timing_off --file "t/t_vlt_timing.v"
+timing_on -file "t/t_vlt_timing.v" --lines 23
+// Bug here. This line should make no difference.
+//timing_off --file "t/t_vlt_timing.v" --lines 22-24
+timing_on --file "t/t_vlt_timing.v" --lines 23
+timing_off -file "t/t_vlt_timing.v" -lines 26-34
+timing_on -file "t/t_vlt_timing.v" -lines 35-38

--- a/test_regress/t/t_vlt_warn.v
+++ b/test_regress/t/t_vlt_warn.v
@@ -20,6 +20,10 @@ module t;
    reg width_warn2_var_line19 = 2'b11;  // Width warning - must be line 19
    reg width_warn3_var_line20 = 2'b11;  // Width warning - must be line 20
 
+   // Must not turn back on warning disabled via control file
+   // verilator lint_on CASEINCOMPLETE
+   // verilator lint_on CASEX
+
    initial begin
       casex (1'b1)
         1'b0: $stop;


### PR DESCRIPTION
Track the location based message/feature enable bits separately for code and control file directives. A message/feature is disabled if disabled either in the control file, or in code directives/metacomments. That is, enabled only if both agree should be enabled.

Fixes #6836
