### PR TITLE
Add missing include on FreeBSD

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -276,6 +276,7 @@ Zhen Yan
 Zhou Shen
 Zhouyi Shen
 Zixi Li
+apocelipes
 dependabot[bot]
 february cozzocrea
 sumpster

--- a/include/verilatedos_c.h
+++ b/include/verilatedos_c.h
@@ -41,6 +41,9 @@
 #if defined(__APPLE__) && !defined(__arm64__) && !defined(__POWERPC__)
 # include <cpuid.h>  // For __cpuid_count()
 #endif
+#if defined(__FreeBSD__)
+# include <pthread_np.h>  // For pthread_getaffinity_np()
+#endif
 
 #if defined(__APPLE__) && defined(__MACH__)
 # include <mach/mach.h>  // For task_info()


### PR DESCRIPTION
The code fails to compile on FreeBSD due to missing necessary header files:

```console
  [111/165] /usr/bin/c++ -DYYDEBUG -I/root/.xmake/packages/f/flex/2.6.4/5fce828ad19b4d83a9b6c72065b9ae5e/include -I/root/.xmake/cache/packages/2512/v/verilator/v5.042/source/src/../include -I/root/.xmake/cache/packages/2512/v/verilator/v5.042/source/build_b9d68eb3/src -I/root/.xmake/cache/packages/2512/v/verilator/v5.042/source/build_b9d68eb3/src/../include -I/root/.xmake/cache/packages/2512/v/verilator/v5.042/source/src -O3 -DNDEBUG -std=gnu++20 -fPIE -MD -MT src/CMakeFiles/verilatorRelease.dir/V3Os.cpp.o -MF src/CMakeFiles/verilatorRelease.dir/V3Os.cpp.o.d -o src/CMakeFiles/verilatorRelease.dir/V3Os.cpp.o -c /root/.xmake/cache/packages/2512/v/verilator/v5.042/source/src/V3Os.cpp
  FAILED: [code=1] src/CMakeFiles/verilatorRelease.dir/V3Os.cpp.o 
  /usr/bin/c++ -DYYDEBUG -I/root/.xmake/packages/f/flex/2.6.4/5fce828ad19b4d83a9b6c72065b9ae5e/include -I/root/.xmake/cache/packages/2512/v/verilator/v5.042/source/src/../include -I/root/.xmake/cache/packages/2512/v/verilator/v5.042/source/build_b9d68eb3/src -I/root/.xmake/cache/packages/2512/v/verilator/v5.042/source/build_b9d68eb3/src/../include -I/root/.xmake/cache/packages/2512/v/verilator/v5.042/source/src -O3 -DNDEBUG -std=gnu++20 -fPIE -MD -MT src/CMakeFiles/verilatorRelease.dir/V3Os.cpp.o -MF src/CMakeFiles/verilatorRelease.dir/V3Os.cpp.o.d -o src/CMakeFiles/verilatorRelease.dir/V3Os.cpp.o -c /root/.xmake/cache/packages/2512/v/verilator/v5.042/source/src/V3Os.cpp
  In file included from /root/.xmake/cache/packages/2512/v/verilator/v5.042/source/src/V3Os.cpp:88:
  /root/.xmake/cache/packages/2512/v/verilator/v5.042/source/src/../include/verilatedos_c.h:114:20: error: use of undeclared identifier 'pthread_getaffinity_np'
    114 |     const int rc = pthread_getaffinity_np(pthread_self(), sizeof(cpuset), &cpuset);
        |                    ^
  1 error generated.
```

This is a follow-up for #6027 and #6028, so I didn't open a new issue.