### PR TITLE
[DRAFT] TDD sv-tests 12.6.1 case_pattern

### DIFF
--- a/src/V3AstAttr.h
+++ b/src/V3AstAttr.h
@@ -940,7 +940,14 @@ inline std::ostream& operator<<(std::ostream& os, const VCMethod& rhs) {
 
 class VCaseType final {
 public:
-    enum en : uint8_t { CT_CASE, CT_CASEX, CT_CASEZ, CT_CASEINSIDE, CT_RANDSEQUENCE };
+    enum en : uint8_t {
+        CT_CASE,
+        CT_CASEX,
+        CT_CASEZ,
+        CT_CASEINSIDE,
+        CT_CASEMATCHES,
+        CT_RANDSEQUENCE
+    };
     enum en m_e;
     VCaseType()
         : m_e{CT_CASE} {}

--- a/src/V3AstNodeDType.h
+++ b/src/V3AstNodeDType.h
@@ -1471,19 +1471,21 @@ public:
 };
 class AstUnionDType final : public AstNodeUOrStructDType {
     bool m_isSoft;  // Is a "union soft"
+    bool m_isTagged;  // Is a "union tagged"
 
 public:
-    // UNSUP: bool isTagged;
     // VSigning below is mispurposed to indicate if packed or not
     // isSoft implies packed
-    AstUnionDType(FileLine* fl, bool isSoft, VSigning numericUnpack)
+    AstUnionDType(FileLine* fl, bool isSoft, bool isTagged, VSigning numericUnpack)
         : ASTGEN_SUPER_UnionDType(fl, numericUnpack)
-        , m_isSoft{isSoft} {
+        , m_isSoft{isSoft}
+        , m_isTagged{isTagged} {
         packed(packed() | m_isSoft);
     }
     ASTGEN_MEMBERS_AstUnionDType;
-    string verilogKwd() const override { return "union"; }
+    string verilogKwd() const override { return m_isTagged ? "union tagged" : "union"; }
     bool isSoft() const { return m_isSoft; }
+    bool isTagged() const { return m_isTagged; }
 };
 
 #endif  // Guard

--- a/src/V3AstNodeExpr.h
+++ b/src/V3AstNodeExpr.h
@@ -1878,7 +1878,7 @@ public:
     string emitVerilog() override { return lhssp() ? "%f{%r{%k%l}}" : "%l"; }
     string emitC() override { V3ERROR_NA_RETURN(""); }
     string emitSimpleOperator() override { V3ERROR_NA_RETURN(""); }
-    bool cleanOut() const override { V3ERROR_NA_RETURN(""); }
+    bool cleanOut() const override { return true; }
     int instrCount() const override { return widthInstrs() * 2; }
     void dump(std::ostream& str = std::cout) const override;
     void dumpJson(std::ostream& str = std::cout) const override;
@@ -1886,6 +1886,61 @@ public:
     void isConcat(bool flag) { m_isConcat = flag; }
     bool isDefault() const { return m_isDefault; }
     void isDefault(bool flag) { m_isDefault = flag; }
+};
+class AstPatTagged final : public AstNodeExpr {
+    // Tagged pattern: tagged member_id [pattern]
+    // For pattern matching in case statements
+    // @astgen op1 := patternp : Optional[AstNodeExpr]  // Optional nested pattern
+    const string m_member;  // Tagged union member name
+
+public:
+    AstPatTagged(FileLine* fl, const string& member, AstNodeExpr* patternp)
+        : ASTGEN_SUPER_PatTagged(fl)
+        , m_member{member} {
+        this->patternp(patternp);
+    }
+    ASTGEN_MEMBERS_AstPatTagged;
+    string emitVerilog() override { return "tagged " + m_member; }
+    string emitC() override { V3ERROR_NA_RETURN(""); }
+    string emitSimpleOperator() override { V3ERROR_NA_RETURN(""); }
+    bool cleanOut() const override { return true; }
+    int instrCount() const override { return 0; }
+    const string& member() const { return m_member; }
+    void dump(std::ostream& str = std::cout) const override;
+    void dumpJson(std::ostream& str = std::cout) const override;
+};
+class AstPatVarBind final : public AstNodeExpr {
+    // Pattern variable binding: .identifier in pattern matching
+    // Binds matched value to a local variable
+    const string m_name;  // Variable name to bind
+
+public:
+    AstPatVarBind(FileLine* fl, const string& name)
+        : ASTGEN_SUPER_PatVarBind(fl)
+        , m_name{name} {}
+    ASTGEN_MEMBERS_AstPatVarBind;
+    string emitVerilog() override { return "." + m_name; }
+    string emitC() override { V3ERROR_NA_RETURN(""); }
+    string emitSimpleOperator() override { V3ERROR_NA_RETURN(""); }
+    bool cleanOut() const override { return true; }
+    int instrCount() const override { return 0; }
+    string name() const override VL_MT_STABLE { return m_name; }
+    void dump(std::ostream& str = std::cout) const override;
+    void dumpJson(std::ostream& str = std::cout) const override;
+};
+class AstPatWild final : public AstNodeExpr {
+    // Pattern wildcard: .* in pattern matching
+    // Matches any value
+
+public:
+    explicit AstPatWild(FileLine* fl)
+        : ASTGEN_SUPER_PatWild(fl) {}
+    ASTGEN_MEMBERS_AstPatWild;
+    string emitVerilog() override { return ".*"; }
+    string emitC() override { V3ERROR_NA_RETURN(""); }
+    string emitSimpleOperator() override { V3ERROR_NA_RETURN(""); }
+    bool cleanOut() const override { return true; }
+    int instrCount() const override { return 0; }
 };
 class AstPattern final : public AstNodeExpr {
     // Verilog '{a,b,c,d...}
@@ -1902,7 +1957,7 @@ public:
     string emitVerilog() override { V3ERROR_NA_RETURN(""); }
     string emitC() override { V3ERROR_NA_RETURN(""); }
     string emitSimpleOperator() override { V3ERROR_NA_RETURN(""); }
-    bool cleanOut() const override { V3ERROR_NA_RETURN(""); }
+    bool cleanOut() const override { return true; }
     int instrCount() const override { return widthInstrs(); }
     AstNodeDType* getChildDTypep() const override { return childDTypep(); }
     AstNodeDType* subDTypep() const VL_MT_STABLE { return dtypep() ? dtypep() : childDTypep(); }

--- a/src/V3AstNodeStmt.h
+++ b/src/V3AstNodeStmt.h
@@ -391,8 +391,10 @@ public:
     bool casex() const { return m_casex == VCaseType::CT_CASEX; }
     bool casez() const { return m_casex == VCaseType::CT_CASEZ; }
     bool caseInside() const { return m_casex == VCaseType::CT_CASEINSIDE; }
+    bool caseMatches() const { return m_casex == VCaseType::CT_CASEMATCHES; }
     bool caseSimple() const { return m_casex == VCaseType::CT_CASE; }
     void caseInsideSet() { m_casex = VCaseType::CT_CASEINSIDE; }
+    void caseMatchesSet() { m_casex = VCaseType::CT_CASEMATCHES; }
     bool fullPragma() const { return m_fullPragma; }
     void fullPragma(bool flag) { m_fullPragma = flag; }
     bool parallelPragma() const { return m_parallelPragma; }

--- a/src/V3AstNodes.cpp
+++ b/src/V3AstNodes.cpp
@@ -2561,6 +2561,16 @@ void AstPatMember::dumpJson(std::ostream& str) const {
     dumpJsonBoolFuncIf(str, isDefault);
     dumpJsonGen(str);
 }
+void AstPatVarBind::dump(std::ostream& str) const {
+    this->AstNodeExpr::dump(str);
+    str << " ." << name();
+}
+void AstPatVarBind::dumpJson(std::ostream& str) const { dumpJsonGen(str); }
+void AstPatTagged::dump(std::ostream& str) const {
+    this->AstNodeExpr::dump(str);
+    str << " tagged " << member();
+}
+void AstPatTagged::dumpJson(std::ostream& str) const { dumpJsonGen(str); }
 void AstNodeTriop::dump(std::ostream& str) const { this->AstNodeExpr::dump(str); }
 void AstNodeTriop::dumpJson(std::ostream& str) const { dumpJsonGen(str); }
 void AstSel::dump(std::ostream& str) const {

--- a/test_regress/t/t_tagged.out
+++ b/test_regress/t/t_tagged.out
@@ -1,41 +1,23 @@
-%Error-UNSUPPORTED: t/t_tagged.v:9:18: Unsupported: tagged union
-    9 |    typedef union tagged {
-      |                  ^~~~~~
-                    ... For error description see https://verilator.org/warn/UNSUPPORTED?v=latest
 %Error-UNSUPPORTED: t/t_tagged.v:10:6: Unsupported: void (for tagged unions)
    10 |      void m_invalid;
       |      ^~~~
+                    ... For error description see https://verilator.org/warn/UNSUPPORTED?v=latest
 %Error: t/t_tagged.v:19:14: syntax error, unexpected tagged, expecting IDENTIFIER-for-type
    19 |          u = tagged m_invalid;
       |              ^~~~~~
         ... See the manual at https://verilator.org/verilator_doc.html?v=latest for more assistance.
-%Error-UNSUPPORTED: t/t_tagged.v:24:16: Unsupported: matches (for tagged union)
-   24 |       case (u) matches
-      |                ^~~~~~~
-%Error: t/t_tagged.v:29:9: syntax error, unexpected tagged, expecting IDENTIFIER-for-type
-   29 |         tagged m_invalid: ;
-      |         ^~~~~~
-%Error-UNSUPPORTED: t/t_tagged.v:34:34: Unsupported: '{} tagged patterns
-   34 |       if (u matches tagged m_int .n) $stop;
-      |                                  ^
-%Error-UNSUPPORTED: t/t_tagged.v:34:21: Unsupported: '{} tagged patterns
-   34 |       if (u matches tagged m_int .n) $stop;
-      |                     ^~~~~~
+%Error-UNSUPPORTED: t/t_tagged.v:33:13: Unsupported: matches operator
+   33 |       if (u matches tagged m_invalid) ;
+      |             ^~~~~~~
 %Error-UNSUPPORTED: t/t_tagged.v:34:13: Unsupported: matches operator
    34 |       if (u matches tagged m_int .n) $stop;
       |             ^~~~~~~
 %Error: t/t_tagged.v:36:11: syntax error, unexpected tagged, expecting IDENTIFIER-for-type
    36 |       u = tagged m_int (123);
       |           ^~~~~~
-%Error: t/t_tagged.v:40:9: syntax error, unexpected tagged, expecting IDENTIFIER-for-type
-   40 |         tagged m_invalid: $stop;
-      |         ^~~~~~
-%Error-UNSUPPORTED: t/t_tagged.v:45:34: Unsupported: '{} tagged patterns
-   45 |       if (u matches tagged m_int .n) if (n != 123) $stop;
-      |                                  ^
-%Error-UNSUPPORTED: t/t_tagged.v:45:21: Unsupported: '{} tagged patterns
-   45 |       if (u matches tagged m_int .n) if (n != 123) $stop;
-      |                     ^~~~~~
+%Error: t/t_tagged.v:41:22: syntax error, unexpected '.', expecting ':' or :-then-begin or :-then-fork
+   41 |         tagged m_int .n: if (n !== 123) $stop;
+      |                      ^
 %Error-UNSUPPORTED: t/t_tagged.v:45:13: Unsupported: matches operator
    45 |       if (u matches tagged m_int .n) if (n != 123) $stop;
       |             ^~~~~~~


### PR DESCRIPTION
## Summary
- Implement parsing support for SystemVerilog tagged unions and pattern matching in case statements (IEEE 1800-2023 section 12.6.1)
- Scope focuses on [`case_pattern` sv-test](https://chipsalliance.github.io/sv-tests-results/?v=verilator+12.6.1+case_pattern) only
- Add `m_isTagged` flag to `AstUnionDType` for `union tagged` declarations
- Add new AST nodes: `AstPatTagged`, `AstPatVarBind`, `AstPatWild` for patterns
- Extend grammar with `case (expr) matches` and tagged pattern syntax

## Test plan
- [x] Passes sv-tests `12.6.1--case_pattern` test
- [x] Updated `t_tagged.out` expected output for partial tagged union support
- [x] CI build-test workflow passes: https://github.com/10U-Labs-LLC/verilator/actions/runs/20555397098

## Request
Seeking feedback before converting to PR with local CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)