### PR TITLE
Internals: Refactor V3Error, and handle UNDRIVEN/UNSUPPORTED/WIDTH consistently

### DIFF
--- a/docs/guide/warnings.rst
+++ b/docs/guide/warnings.rst
@@ -2301,6 +2301,8 @@ List Of Warnings
    make the design simulate incorrectly and is only intended for lint
    usage; see the details under :vlopt:`--bbox-unsup`.
 
+   Disabling this error also disables :option:`COVERIGN` and
+   :option:`SPECIFYIGN`.
 
 .. option:: UNUSED
 

--- a/src/V3Error.cpp
+++ b/src/V3Error.cpp
@@ -166,9 +166,9 @@ void V3ErrorGuarded::v3errorEndGuts(const std::ostringstream& sstr, const string
     if (m_errorSuppressed) {
         // On debug, show only non default-off warning to prevent pages of warnings
         if (m_message.code().defaultsOff()) return;
-        if (!debug() || debug() < 3 || (debug() < 9 && m_showedSuppressed[m_message.code()]))
+        if (!debug() || debug() < 3 || (debug() < 9 && m_showedSuppressed.test(m_message.code())))
             return;
-        m_showedSuppressed[m_message.code()] = true;
+        m_showedSuppressed.set(m_message.code(), true);
     }
     string msg
         = V3Error::warnContextBegin() + msgPrefix() + V3Error::warnContextEnd() + sstr.str();
@@ -223,8 +223,8 @@ void V3ErrorGuarded::v3errorEndGuts(const std::ostringstream& sstr, const string
         const bool anError = isError(m_message.code(), m_errorSuppressed);
         if (m_message.code()
                 != V3ErrorCode::EC_FATALMANY  // Not verbose on final too-many-errors error
-            && !m_describedEachWarn[m_message.code()]) {
-            m_describedEachWarn[m_message.code()] = true;
+            && !m_describedEachWarn.test(m_message.code())) {
+            m_describedEachWarn.set(m_message.code(), true);
             if (m_message.code() >= V3ErrorCode::EC_FIRST_NAMED) {
                 text += warnMoreSpaces() + "... For " + (anError ? "error" : "warning")
                         + " description see " + m_message.code().url() + '\n';
@@ -238,7 +238,7 @@ void V3ErrorGuarded::v3errorEndGuts(const std::ostringstream& sstr, const string
                 text += warnMoreSpaces() + "... See the manual at " + m_message.code().url()
                         + " for more assistance.\n";
             }
-            if (!m_pretendError[m_message.code()] && !m_message.code().hardError()) {
+            if (!m_pretendError.test(m_message.code()) && !m_message.code().hardError()) {
                 text += warnMoreSpaces() + "... Use \"/* verilator lint_off "
                         + m_message.code().ascii()
                         + " */\" and lint_on around source to disable this message.\n";

--- a/src/V3Options.cpp
+++ b/src/V3Options.cpp
@@ -1863,12 +1863,6 @@ void V3Options::parseOptsList(FileLine* fl, const string& optdir, int argc,
         FileLine::globalWarnLintOff(false);
         FileLine::globalWarnStyleOff(false);
     });
-    DECL_OPTION("-Werror-UNUSED", CbCall, []() {
-        V3Error::pretendError(V3ErrorCode::UNUSEDGENVAR, true);
-        V3Error::pretendError(V3ErrorCode::UNUSEDLOOP, true);
-        V3Error::pretendError(V3ErrorCode::UNUSEDPARAM, true);
-        V3Error::pretendError(V3ErrorCode::UNUSEDSIGNAL, true);
-    });
     DECL_OPTION("-Werror-", CbPartialMatch, [this, fl](const char* optp) {
         const V3ErrorCode code{optp};
         if (code == V3ErrorCode::EC_ERROR) {
@@ -1901,8 +1895,6 @@ void V3Options::parseOptsList(FileLine* fl, const string& optdir, int argc,
         FileLine::globalWarnStyleOff(true);
     });
     DECL_OPTION("-Wno-style", CbCall, []() { FileLine::globalWarnStyleOff(true); });
-    DECL_OPTION("-Wno-UNUSED", CbCall, []() { FileLine::globalWarnUnusedOff(true); });
-    DECL_OPTION("-Wno-WIDTH", CbCall, []() { FileLine::globalWarnOff(V3ErrorCode::WIDTH, true); });
     DECL_OPTION("-work", Set, &m_work);
     DECL_OPTION("-Wpedantic", CbCall, [this]() {
         m_pedantic = true;
@@ -1923,25 +1915,6 @@ void V3Options::parseOptsList(FileLine* fl, const string& optdir, int argc,
     });
     DECL_OPTION("-Wwarn-lint", CbCall, []() { FileLine::globalWarnLintOff(false); });
     DECL_OPTION("-Wwarn-style", CbCall, []() { FileLine::globalWarnStyleOff(false); });
-    DECL_OPTION("-Wwarn-UNUSED", CbCall, []() {
-        FileLine::globalWarnUnusedOff(false);
-        V3Error::pretendError(V3ErrorCode::UNUSEDGENVAR, false);
-        V3Error::pretendError(V3ErrorCode::UNUSEDLOOP, false);
-        V3Error::pretendError(V3ErrorCode::UNUSEDSIGNAL, false);
-        V3Error::pretendError(V3ErrorCode::UNUSEDPARAM, false);
-    });
-    DECL_OPTION("-Wwarn-UNSUPPORTED", CbCall, []() {
-        FileLine::globalWarnOff(V3ErrorCode::E_UNSUPPORTED, false);
-        FileLine::globalWarnOff(V3ErrorCode::COVERIGN, false);
-        FileLine::globalWarnOff(V3ErrorCode::SPECIFYIGN, false);
-        V3Error::pretendError(V3ErrorCode::E_UNSUPPORTED, false);
-        V3Error::pretendError(V3ErrorCode::COVERIGN, false);
-        V3Error::pretendError(V3ErrorCode::SPECIFYIGN, false);
-    });
-    DECL_OPTION("-Wwarn-WIDTH", CbCall, []() {
-        FileLine::globalWarnOff(V3ErrorCode::WIDTH, false);
-        V3Error::pretendError(V3ErrorCode::WIDTH, false);
-    });
     DECL_OPTION("-waiver-multiline", OnOff, &m_waiverMultiline);
     DECL_OPTION("-waiver-output", Set, &m_waiverOutput);
 

--- a/src/verilog.y
+++ b/src/verilog.y
@@ -8129,10 +8129,8 @@ vltOffFront<errcodeen>:
         |       yVLT_TRACING_OFF                        { $$ = V3ErrorCode::I_TRACING; }
         |       yVLT_LINT_OFF                           { $$ = V3ErrorCode::I_LINT; }
         |       yVLT_LINT_OFF yVLT_D_RULE idAny
-                        { const char *codemsg = (*$3).c_str();
-                          if (V3ErrorCode::unusedMsg(codemsg)) $$ = V3ErrorCode::I_UNUSED;
-                          else {$$ = V3ErrorCode{codemsg}; }
-                          if ($$ == V3ErrorCode::EC_ERROR) { $1->v3error("Unknown error code: '" << *$3 << "'"); } }
+                        { $$ = V3ErrorCode{*$3};
+                          if ($$ == V3ErrorCode::EC_ERROR) $1->v3error("Unknown error code: '" << *$3 << "'"); }
         ;
 
 vltOnFront<errcodeen>:
@@ -8141,10 +8139,8 @@ vltOnFront<errcodeen>:
         |       yVLT_TRACING_ON                         { $$ = V3ErrorCode::I_TRACING; }
         |       yVLT_LINT_ON                            { $$ = V3ErrorCode::I_LINT; }
         |       yVLT_LINT_ON yVLT_D_RULE idAny
-                        { const char *codemsg = (*$3).c_str();
-                          if (V3ErrorCode::unusedMsg(codemsg)) $$ = V3ErrorCode::I_UNUSED;
-                          else {$$ = V3ErrorCode{codemsg}; }
-                          if ($$ == V3ErrorCode::EC_ERROR) { $1->v3error("Unknown error code: '" << *$3 << "'"); } }
+                        { $$ = V3ErrorCode{*$3};
+                          if ($$ == V3ErrorCode::EC_ERROR) $1->v3error("Unknown error code: '" << *$3 << "'"); }
         ;
 
 vltDBlock<strp>:  // --block <arg>

--- a/test_regress/t/t_lint_lint_bad.py
+++ b/test_regress/t/t_lint_lint_bad.py
@@ -11,6 +11,8 @@ import vltest_bootstrap
 
 test.scenarios('linter')
 
-test.lint(verilator_flags2=["-Wwarn-lint"], fails=True, expect_filename=test.golden_filename)
+test.lint(verilator_flags2=["-Wwarn-lint -Wno-style"],
+          fails=True,
+          expect_filename=test.golden_filename)
 
 test.passes()

--- a/test_regress/t/t_vlt_warn.v
+++ b/test_regress/t/t_vlt_warn.v
@@ -14,7 +14,6 @@
 
 
 
-
 module t;
    reg width_warn_var_line18 = 2'b11;  // Width warning - must be line 18
    reg width_warn2_var_line19 = 2'b11;  // Width warning - must be line 19

--- a/test_regress/t/t_vlt_warn.vlt
+++ b/test_regress/t/t_vlt_warn.vlt
@@ -8,12 +8,12 @@
 
 lint_off -rule DEPRECATED     -file "t/t_vlt_warn.vlt" -lines 14
 lint_off -rule CASEINCOMPLETE -file "t/t_vlt_warn.v"
-lint_off -rule WIDTH          -file "t/t_vlt_warn.v" -lines 19
+lint_off -rule WIDTH          -file "t/t_vlt_warn.v" -lines 18
 lint_off -rule DECLFILENAME   -file "*/t_vlt_warn.v"
-// Test wildcard filenames
-lint_off -rule WIDTH          -file "*/t_vlt_warn.v" -lines 20-20
+// Test wildcard filenames, and WIDTH delegating to WIDTHTRUNC
+lint_off -rule WIDTH          -file "*/t_vlt_warn.v" -lines 19-19
 // Test global disables
-lint_off                      -file "*/t_vlt_warn.v" -lines 21-21
+lint_off                      -file "*/t_vlt_warn.v" -lines 20-20
 // Test match
 lint_off -rule UNUSED         -file "*/t_vlt_warn.v" -match "Signal is not used: 'width_warn*'"
 

--- a/test_regress/t/t_vlt_warn_bad.out
+++ b/test_regress/t/t_vlt_warn_bad.out
@@ -1,6 +1,6 @@
-%Warning-WIDTHTRUNC: t/t_vlt_warn.v:21:33: Operator ASSIGN expects 1 bits on the Assign RHS, but Assign RHS's CONST '2'h3' generates 2 bits.
+%Warning-WIDTHTRUNC: t/t_vlt_warn.v:20:33: Operator ASSIGN expects 1 bits on the Assign RHS, but Assign RHS's CONST '2'h3' generates 2 bits.
                                          : ... note: In instance 't'
-   21 |    reg width_warn3_var_line20 = 2'b11;   
+   20 |    reg width_warn3_var_line20 = 2'b11;   
       |                                 ^~~~~
                      ... For warning description see https://verilator.org/warn/WIDTHTRUNC?v=latest
                      ... Use "/* verilator lint_off WIDTHTRUNC */" and lint_on around source to disable this message.

--- a/test_regress/t/t_vlt_warn_bad.vlt
+++ b/test_regress/t/t_vlt_warn_bad.vlt
@@ -10,8 +10,6 @@ lint_off -rule CASEINCOMPLETE -file "t/t_vlt_warn.v"
 lint_off -rule WIDTH          -file "t/t_vlt_warn.v" -lines 18
 // Test wildcard filenames
 lint_off -rule WIDTH          -file "*/t_vlt_warn.v" -lines 19-19
-// Test global disables
-lint_off                      -file "*/t_vlt_warn.v" -lines 20-20
 
 coverage_off -file "t/t_vlt_warn.v"
 // Test --flag is also accepted


### PR DESCRIPTION
Load of V3Error internal cleanups towards some future cleanups.

Handle UNDRIVEN/UNSUPPORTED/WIDTH the same way; likely some -Wwarn-x/-Wno-x/-Werror-x behavior for these may change in some small ways, but at least now all consistent.

No change to I_LINT or I_STYLE to make likewise consistent, as is more user disruptive, but may come soon.

