### PR TITLE
VlThreadPool: Provide NUMA strategy environment variable

### DIFF
--- a/docs/guide/environment.rst
+++ b/docs/guide/environment.rst
@@ -1,6 +1,8 @@
 .. Copyright 2003-2025 by Wilson Snyder.
 .. SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
 
+.. _Environment:
+
 Environment
 ===========
 
@@ -88,6 +90,20 @@ associated programs.
 
    If set, the command to run when using the :vlopt:`--gdb` option, such as
    "ddd". If not specified, it will use "gdb".
+
+.. option:: VERILATOR_NUMA_STRATEGY
+
+   If set, controls NUMA assignment strategy for Verilator's thread pool
+   for Verilated simulations at runtime.
+   Possible values are:
+
+   * Empty(``""``) or ``"default"``: Enables NUMA assignment that prioritizes
+     assigning Verilator threads to physical cores.
+
+   * ``"none"``: Disables NUMA assignment. Let the operating system handle
+     thread scheduling.
+
+   Other values may be supported in future releases.
 
 .. option:: VERILATOR_ROOT
 

--- a/docs/guide/simulating.rst
+++ b/docs/guide/simulating.rst
@@ -85,8 +85,11 @@ above documentation for these options.
 
 If using Verilated multithreaded, consider overriding Verilator's default
 thread-to-processor assignment by using ``numactl``; see
-:ref:`Multithreading`. Also, consider using profile-guided optimization;
-see :ref:`Thread PGO`.
+:ref:`Multithreading`. If your OS can handle thread assignment for your
+design and hardware well, consider disabling Verilator's NUMA assignment by
+setting the :vlopt:`VERILATOR_NUMA_STRATEGY` environment variable to
+``none``; see :ref:`Environment`. Also, consider using profile-guided
+optimization; see :ref:`Thread PGO`.
 
 Minor Verilog code changes can also give big wins. You should not have any
 :option:`UNOPTFLAT` warnings from Verilator. Fixing these warnings can

--- a/docs/guide/verilating.rst
+++ b/docs/guide/verilating.rst
@@ -285,6 +285,13 @@ schedules threads using multiple hyperthreads within the same physical
 core. If there is no affinity already set, on Linux only, Verilator
 attempts to set thread-to-processor affinity in a reasonable way.
 
+Some newer Linux kernels handle thread assignment well. If running
+Verilator on such a system, automatic thread affinity may not be
+beneficial and may even reduce performance. In this case, environment
+variable :vlopt:`VERILATOR_NUMA_STRATEGY` may be set to ``none`` to
+disable automatic thread affinity. For more information, refer to
+:ref:`Environment`.
+
 For best performance, use the :command:`numactl` program to (when the
 threading count fits) select unique physical cores on the same socket. The
 same applies for :vlopt:`--trace-threads` as well.
@@ -311,6 +318,15 @@ adjusted if you want another simulator to use, e.g., socket 1, or if you
 Verilated with a different number of threads. To see what CPUs are actually
 used, use :vlopt:`--prof-exec`.
 
+On Systems with multiple L3 clusters per socket (e.g., AMD EPYC or Ryzen),
+consider using :command:`lstopo` to determine the L3 cluster topology of
+the current system and :command:`numactl` to bind CPUs within a single L3
+cluster. This can improve performance for minimal communication latency
+between threads. Sometimes, for model's thread counts that are more than
+the core count per L3 cluster, using SMTs (hyperthreads) within a single L3
+cluster can have better performance than spreading across multiple L3
+clusters using physical cores only. Experimentation is recommended to find
+the best settings for underlying hardware and model characteristics.
 
 Multithreaded Verilog and Library Support
 -----------------------------------------

--- a/include/verilated_threads.cpp
+++ b/include/verilated_threads.cpp
@@ -147,6 +147,12 @@ VlThreadPool::~VlThreadPool() {
 
 std::string VlThreadPool::numaAssign() {
 #if defined(__linux) || defined(CPU_ZERO) || defined(VL_CPPCHECK)  // Linux-like pthreads
+    std::string numa_strategy = VlOs::getenvStr("VERILATOR_NUMA_STRATEGY", "default");
+    if (numa_strategy == "none") {
+        return "no NUMA assignment requested";
+    } else if (numa_strategy != "default" && numa_strategy != "") {
+        return "%Warning: unknown VERILATOR_NUMA_STRATEGY value '" + numa_strategy + "'";
+    }
     // Get number of processor available to the current process
     const unsigned num_proc = VlOs::getProcessAvailableParallelism();
     if (!num_proc) return "Can't determine number of available threads";


### PR DESCRIPTION
As discussed in issue #6826 and PR #6839. The current NUMA assignment strategy may lead to suboptimal performance on some systems with certain designs, even without using numactl. This commit introduces an environment variable `VERILATOR_NUMA_STRATEGY` to allow users to disable NUMA assignment if they find it degrades performance on their systems.

Although the current code will not do numaAssign when it runs with `numactl`. But [Linux Kernel with Cache Aware Scheduling](https://lore.kernel.org/lkml/cover.1764801860.git.tim.c.chen@linux.intel.com/) can make the best choice for thread scheduling, especially on a shared machine that doesn't want to bind all threads to specific cores statically. So it is still useful to provide an option to disable numaAssign.

I also want to add some new options in the future. I found that sometimes assign verilated threads to SMTs within the same CPU Cluster (Like 8 Cores per Cluster on AMD Zen 4 and Zen 5) may provide better performance for some designs than using physical cores across different Clusters. But the current implementation does not consider this possibility. And this does not happen on AMD Zen 3, even though it also has 8 Cores per Cluster as Zen 4. So I want to investigate more before adding more options.