### PR TITLE
Fix VarRef lookup for module-level variables (#6741)

### DIFF
--- a/test_regress/t/t_randomize_module_var.py
+++ b/test_regress/t/t_randomize_module_var.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2026 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+if not test.have_solver:
+    test.skip("No constraint solver installed")
+
+test.compile()
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_randomize_module_var.v
+++ b/test_regress/t/t_randomize_module_var.v
@@ -1,0 +1,43 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2026 by PlanV GmbH.
+// SPDX-License-Identifier: CC0-1.0
+
+
+module t_randomize_module_var;
+   int golden_queue[$];
+
+   class Cls;
+      rand bit deq;
+      constraint valid_enq {
+         if (golden_queue.size() == 0) {deq == 0;}
+      }
+   endclass
+
+   Cls tr;
+
+   initial begin
+      tr = new;
+
+      // Test 1: Empty queue - deq must be 0
+      if (tr.randomize() == 0) begin
+         $stop;
+      end
+      if (tr.deq != 0) begin
+         $display("Error: Expected deq=0 when queue is empty, got %0d", tr.deq);
+         $stop;
+      end
+
+      // Test 2: Non-empty queue - deq can be 0 or 1
+      golden_queue.push_back(42);
+      if (tr.randomize() == 0) begin
+         $stop;
+      end
+      // deq can be 0 or 1, both are valid
+
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end
+
+endmodule


### PR DESCRIPTION
This patch fixes #6741 by skipping the m_packageScopes lookup when a VarRef’s classOrPackagep points to a module.

Thanks to @udayaa-init .
