### PR TITLE
Fix `--trace` flag description in docs

### DIFF
--- a/docs/guide/exe_verilator.rst
+++ b/docs/guide/exe_verilator.rst
@@ -1733,7 +1733,7 @@ Summary:
    :vlopt:`--trace-vcd` instead.
 
    Using :vlopt:`--trace` without :vlopt:`--trace-fst` nor
-   :vlopt:`--trace-fst` requests VCD traces.
+   :vlopt:`--trace-saif` requests VCD traces.
 
    Using :vlopt:`--trace` :vlopt:`--trace-fst` requests FST traces.
 


### PR DESCRIPTION
I suppose this should read `--trace-saif` here instead of a duplicate `--trace-fst`.