### PR TITLE
Omit -v farg with --dump-inputs

### DIFF
--- a/src/V3Options.cpp
+++ b/src/V3Options.cpp
@@ -1833,7 +1833,7 @@ void V3Options::parseOptsList(FileLine* fl, const string& optdir, int argc,
     });
     DECL_OPTION("-v", CbVal, [this, &optdir](const char* valp) {
         V3Options::addLibraryFile(parseFileArg(optdir, valp), work());
-    });
+    }).notForRerun();
     DECL_OPTION("-valgrind", CbCall, []() {});  // Processed only in bin/verilator shell
     DECL_OPTION("-verilate", OnOff, &m_verilate);
     DECL_OPTION("-verilate-jobs", CbVal, [this, fl](const char* valp) {


### PR DESCRIPTION
Missed this one.