### PR TITLE
Internals: Add --four-state option (Issue #3645 partial)

### DIFF
--- a/src/V3Options.cpp
+++ b/src/V3Options.cpp
@@ -1435,6 +1435,7 @@ void V3Options::parseOptsList(FileLine* fl, const string& optdir, int argc,
         parseOptsFile(fl, parseFileArg(optdir, valp), false);
     }).notForRerun();
     DECL_OPTION("-flatten", OnOff, &m_flatten);
+    DECL_OPTION("-four-state", OnOff, &m_fourState);
     DECL_OPTION("-future0", CbVal, [this](const char* valp) { addFuture0(valp); });
     DECL_OPTION("-future1", CbVal, [this](const char* valp) { addFuture1(valp); });
 

--- a/src/V3Options.h
+++ b/src/V3Options.h
@@ -254,6 +254,7 @@ private:
     bool m_emitAccessors = false;   // main switch: --emit-accessors
     bool m_exe = false;             // main switch: --exe
     bool m_flatten = false;         // main switch: --flatten
+    bool m_fourState = false;       // main switch: --four-state
     bool m_hierarchical = false;    // main switch: --hierarchical
     bool m_ignc = false;            // main switch: --ignc
     bool m_jsonOnly = false;        // main switch: --json-only
@@ -537,6 +538,7 @@ public:
     bool emitAccessors() const { return m_emitAccessors; }
     bool exe() const { return m_exe; }
     bool flatten() const { return m_flatten; }
+    bool fourState() const { return m_fourState; }
     bool gmake() const { return m_gmake; }
     bool makeJson() const { return m_makeJson; }
     bool threadsDpiPure() const { return m_threadsDpiPure; }

--- a/test_regress/t/t_dist_docs_options.py
+++ b/test_regress/t/t_dist_docs_options.py
@@ -16,6 +16,7 @@ Doc_Waivers = [
     '+verilator+prof+threads+start+',  # Deprecated
     '+verilator+prof+threads+window+',  # Deprecated
     '-clk',  # Deprecated
+    '-four-state',
     '-lineno',  # Deprecated
     '-order-clock-delay',  # Deprecated
     '-pp-comments',  # Deprecated
@@ -33,6 +34,7 @@ Test_Waivers = [
     '-rr',  # Not testing; not requiring rr installation
     # Need testing:
     '-fconst',  # TODO breaks due to some needed V3Const steps
+    '-four-state',
 ]
 
 Sums = {}


### PR DESCRIPTION
## Summary
- Add `--four-state` command-line option to V3Options. No behavior yet.
- Added to doc/test waivers until we have reasonable support for the future functionality.

## Context
- Phase 1 of Issue #3645.
- See Issue #3645 for full discussion on 4-state (X/Z) simulation support.

## Testing
- [x] CI passes in fork https://github.com/10U-Labs-LLC/verilator/actions/runs/20766890647

## Request
Requesting feedback before converting to non-draft.