### PR TITLE
Fix large debug_str for emitted Syms headers

### DIFF
--- a/src/V3EmitCHeaders.cpp
+++ b/src/V3EmitCHeaders.cpp
@@ -169,8 +169,8 @@ class EmitCHeader final : public EmitCConstInit {
             putns(modp, name + "(" + ctorArgs + ");\n");
             putns(modp, "~" + name + "();\n");
         } else {
-            putns(modp, name + "() = default;\n");
-            putns(modp, "~" + name + "() = default;\n");
+            putns(modp, name + "();\n");
+            putns(modp, "~" + name + "();\n");
             putns(modp, "void ctor(" + ctorArgs + ");\n");
             putns(modp, "void dtor();\n");
         }

--- a/src/V3EmitCImp.cpp
+++ b/src/V3EmitCImp.cpp
@@ -135,6 +135,8 @@ class EmitCImp final : public EmitCFunc {
             ofp()->indentDec();
             puts(" {\n");
         } else {
+            putns(modp, modName + "::" + modName + "() = default;\n");
+            putns(modp, modName + "::~" + modName + "() = default;\n\n");
             putns(modp, "void " + modName + "::ctor(" + ctorArgs + ") {\n");
         }
 


### PR DESCRIPTION
Noticed that large sizes of simulation binaries occurs when `-CFLAGS -g` option is set during Verilation. The `.debug_str` section is at fault here.

For instance, the recent change https://github.com/verilator/verilator/commit/2fabf50801c3ef612c79347158863794ca22caea changed the way how Syms ctors are emitted. Previously default constructors were only declared in a Syms header file and defined in cpp file. The aforementioned change inlined default ctor definitions into header files. For large designs this resulted in large debug sections as each variable in a class was added to debuginfo of each translation unit using this header rather than a translation unit that only used Syms's implementation.

No functional change intended here, for debug builds should decrease binaries size.

Result for rtlmeter Vortex/huge Verilated with `-CFLAGS -g`:

(emitted `C++` + binaries) size on master: 12G
(emitted `C++` + binaries) size with this fix: 8.1G

This PR resolves the same problem as in https://github.com/verilator/verilator/pull/6796, thus marking it as obsolete.