### PR TITLE
Fix access flags in MemberSel randomization assignments (#6756)

### DIFF
--- a/src/V3Broken.cpp
+++ b/src/V3Broken.cpp
@@ -234,9 +234,8 @@ private:
         const size_t nWriteRefs = m_nWriteRefs;
         const size_t nCalls = m_nCalls;
         iterateConst(nodep->lhsp());
-        // TODO: Enable this when #6756 is fixed
         // Only check if there are no calls on the LHS, as calls might return an LValue
-        if (false && v3Global.assertDTypesResolved() && m_nCalls == nCalls) {
+        if (v3Global.assertDTypesResolved() && m_nCalls == nCalls) {
             UASSERT_OBJ(m_nWriteRefs > nWriteRefs, nodep, "No write refs on LHS of assignment");
         }
         processExit(nodep);

--- a/src/V3Randomize.cpp
+++ b/src/V3Randomize.cpp
@@ -2217,10 +2217,11 @@ class RandomizeVisitor final : public VNVisitor {
     AstNodeExpr* makeSiblingRefp(AstNodeExpr* const exprp, AstVar* const varp,
                                  const VAccess access) {
         if (AstMemberSel* const memberSelp = VN_CAST(exprp, MemberSel)) {
-            // TODO: this ignored 'access' and will create a read reference in
-            // t_randomize_inline_var_ctl, see issue #6756
-            return new AstMemberSel{exprp->fileline(), memberSelp->fromp()->cloneTree(false),
-                                    varp};
+            AstMemberSel* const newMemberSelp
+                = new AstMemberSel{exprp->fileline(), memberSelp->fromp()->cloneTree(false), varp};
+            // Set access on all VarRef nodes in the cloned subtree
+            newMemberSelp->foreach([access](AstVarRef* varrefp) { varrefp->access(access); });
+            return newMemberSelp;
         }
         UASSERT_OBJ(VN_IS(exprp, VarRef), exprp, "Should be a VarRef");
         return new AstVarRef{exprp->fileline(), VN_AS(varp->user2p(), Class), varp, access};


### PR DESCRIPTION
Fix the problem mentioned in #6756 and Remove the warning-ignored workaround and comments.