### PR TITLE
Add support for unpacked array concatenation in function arguments 

### DIFF
--- a/src/V3Task.cpp
+++ b/src/V3Task.cpp
@@ -1501,12 +1501,12 @@ class TaskVisitor final : public VNVisitor {
         if (m_statep->ftaskNoInline(nodep->taskp())) {
             // Create a fresh variable for each concat array present in pins list
             if (nodep->pinsp()) {
-                nodep->pinsp()->foreachAndNext([this](AstArg* arg) {
-                    AstInitArray* const arrayp = VN_CAST(arg->exprp(), InitArray);
+                nodep->pinsp()->foreachAndNext([this](AstArg* const argp) {
+                    AstInitArray* const arrayp = VN_CAST(argp->exprp(), InitArray);
                     if (!arrayp) return;
 
                     FileLine* const flp = arrayp->fileline();
-                    std::string tempName = m_initArrayTmpNames.get(arg);
+                    const std::string tempName = m_initArrayTmpNames.get(argp);
                     AstVar* const substp = new AstVar{flp, VVarType::VAR, tempName, arrayp->dtypep()};
                     substp->funcLocal(true);
                     AstVarScope* const substvscp = createVarScope(substp, tempName);
@@ -1515,7 +1515,7 @@ class TaskVisitor final : public VNVisitor {
                         flp, new AstVarRef{arrayp->fileline(), substvscp, VAccess::WRITE},
                         arrayp->unlinkFrBack()};
 
-                    AstExprStmt* exprstmtp = new AstExprStmt{
+                    AstExprStmt* const exprstmtp = new AstExprStmt{
                         flp, substp, new AstVarRef{arrayp->fileline(), substvscp, VAccess::READ}};
                     exprstmtp->stmtsp()->addNext(assignp);
                     exprstmtp->hasResult(false);
@@ -1523,7 +1523,7 @@ class TaskVisitor final : public VNVisitor {
                     AstCExpr* const exprp = new AstCExpr{flp, substp->name()};
                     exprp->dtypeSetString();
                     exprstmtp->addStmtsp(new AstCReturn{flp, exprp});
-                    arg->exprp(exprstmtp);
+                    argp->exprp(exprstmtp);
                 });
             }
             // This may share VarScope's with a public task, if any.  Yuk.

--- a/src/V3Task.cpp
+++ b/src/V3Task.cpp
@@ -1502,7 +1502,7 @@ class TaskVisitor final : public VNVisitor {
         if (m_statep->ftaskNoInline(nodep->taskp())) {
             // Create a fresh variable for each concat array present in pins list
             if (nodep->pinsp()) {
-                nodep->pinsp()->foreach([this](AstArg* arg) {
+                nodep->pinsp()->foreachAndNext([this](AstArg* arg) {
                     AstInitArray* array;
                     array = VN_CAST(arg->exprp(), InitArray);
                     if (!array) return;

--- a/src/V3Task.cpp
+++ b/src/V3Task.cpp
@@ -27,7 +27,6 @@
 
 #include "V3Task.h"
 
-#include "V3Ast.h"
 #include "V3Const.h"
 #include "V3Control.h"
 #include "V3EmitCBase.h"

--- a/src/V3Task.cpp
+++ b/src/V3Task.cpp
@@ -1447,8 +1447,7 @@ class TaskVisitor final : public VNVisitor {
     void processPins(AstNodeFTaskRef* nodep) {
         // Create a fresh variable for each concat array present in pins list
         for (AstNode* pinp = nodep->pinsp(); pinp; pinp = pinp->nextp()) {
-            AstArg* const argp = VN_CAST(pinp, Arg);
-            UASSERT_OBJ(argp, nodep, "Pin is not an AstArg");
+            AstArg* const argp = VN_AS(pinp, Arg);
             AstInitArray* const arrayp = VN_CAST(argp->exprp(), InitArray);
             if (!arrayp) continue;
 

--- a/src/V3Task.cpp
+++ b/src/V3Task.cpp
@@ -1615,8 +1615,7 @@ class TaskVisitor final : public VNVisitor {
             if (nodep->classMethod()) modes++;
             if (v3Global.opt.protectIds() && nodep->taskPublic()) {
                 // We always call protect() on names, we don't check if public or not
-                // Hence any external references wouldn't be able to find the refed public
-                // object.
+                // Hence any external references wouldn't be able to find the refed public object.
                 nodep->v3warn(E_UNSUPPORTED,
                               "Unsupported: Using --protect-ids with public function");
             }
@@ -1632,14 +1631,14 @@ class TaskVisitor final : public VNVisitor {
             // TODO: Why not if recursive? It will not work ...
             if (noInline && !nodep->classMethod() && !nodep->recursive()) {
                 if (AstNode* const impurep = m_statep->checkImpure(nodep)) {
-                    nodep->v3warn(IMPURE, "Unsupported: External variable referenced by "
-                                          "non-inlined function/task: "
-                                              << nodep->prettyNameQ() << '\n'
-                                              << nodep->warnContextPrimary() << '\n'
-                                              << impurep->warnOther()
-                                              << "... Location of the external reference: "
-                                              << impurep->prettyNameQ() << '\n'
-                                              << impurep->warnContextSecondary());
+                    nodep->v3warn(
+                        IMPURE,
+                        "Unsupported: External variable referenced by non-inlined function/task: "
+                            << nodep->prettyNameQ() << '\n'
+                            << nodep->warnContextPrimary() << '\n'
+                            << impurep->warnOther() << "... Location of the external reference: "
+                            << impurep->prettyNameQ() << '\n'
+                            << impurep->warnContextSecondary());
                 }
             }
 
@@ -1679,8 +1678,8 @@ class TaskVisitor final : public VNVisitor {
         }
     }
     void visit(AstNodeForeach* nodep) override {  // LCOV_EXCL_LINE
-        nodep->v3fatalSrc("Foreach statements should have been converted to while statements "
-                          "in V3Begin.cpp");
+        nodep->v3fatalSrc(
+            "Foreach statements should have been converted to while statements in V3Begin.cpp");
     }
     void visit(AstNodeStmt* nodep) override {
         VL_RESTORER(m_insStmtp);
@@ -1767,8 +1766,7 @@ V3TaskConnects V3Task::taskConnects(AstNodeFTaskRef* nodep, AstNode* taskStmtsp,
                     pinp->v3error("No such argument " << argp->prettyNameQ()
                                                       << " in function call to "
                                                       << nodep->taskp()->prettyTypeName());
-                    // We'll just delete it; seems less error prone than making a false
-                    // argument
+                    // We'll just delete it; seems less error prone than making a false argument
                     VL_DO_DANGLING(pinp->unlinkFrBack()->deleteTree(), pinp);
                 }
             } else {
@@ -1792,8 +1790,7 @@ V3TaskConnects V3Task::taskConnects(AstNodeFTaskRef* nodep, AstNode* taskStmtsp,
                 } else if (makeChanges) {
                     pinp->v3error("Too many arguments in function call to "
                                   << nodep->taskp()->prettyTypeName());
-                    // We'll just delete it; seems less error prone than making a false
-                    // argument
+                    // We'll just delete it; seems less error prone than making a false argument
                     VL_DO_DANGLING(pinp->unlinkFrBack()->deleteTree(), pinp);
                 }
             } else {

--- a/src/V3Task.cpp
+++ b/src/V3Task.cpp
@@ -1506,10 +1506,10 @@ class TaskVisitor final : public VNVisitor {
                     if (!arrayp) return;
 
                     FileLine* const flp = arrayp->fileline();
-                    std::string temp_name = m_tempUnpackedArrayNames.get(arg);
-                    AstVar* substp = new AstVar{flp, VVarType::VAR, temp_name, arrayp->dtypep()};
+                    std::string tempName = m_tempUnpackedArrayNames.get(arg);
+                    AstVar* substp = new AstVar{flp, VVarType::VAR, tempName, arrayp->dtypep()};
                     substp->funcLocal(true);
-                    AstVarScope* const substvscp = createVarScope(substp, temp_name);
+                    AstVarScope* const substvscp = createVarScope(substp, tempName);
 
                     AstAssign* const assignp = new AstAssign{
                         flp, new AstVarRef{arrayp->fileline(), substvscp, VAccess::WRITE},

--- a/src/V3Task.cpp
+++ b/src/V3Task.cpp
@@ -1507,13 +1507,10 @@ class TaskVisitor final : public VNVisitor {
                     if (!array) return;
 
                     FileLine* const flp = array->fileline();
-
-                    AstVar* substp
-                        = new AstVar{flp, VVarType::VAR, m_tempNames.get(arg), array->dtypep()};
+                    auto temp_name = m_tempNames.get(arg);
+                    AstVar* substp = new AstVar{flp, VVarType::VAR, temp_name, array->dtypep()};
                     substp->funcLocal(true);
-                    AstVarScope* const substvscp
-                        = new AstVarScope{substp->fileline(), m_scopep, substp};
-                    m_scopep->addVarsp(substvscp);
+                    AstVarScope* const substvscp = createVarScope(substp, temp_name);
 
                     AstAssign* assignp = new AstAssign{
                         flp, new AstVarRef{array->fileline(), substvscp, VAccess::WRITE},

--- a/src/V3Task.cpp
+++ b/src/V3Task.cpp
@@ -394,7 +394,7 @@ class TaskVisitor final : public VNVisitor {
 
     // STATE
     TaskStateVisitor* const m_statep;  // Common state between visitors
-    V3UniqueNames m_tempUnpackedArrayNames;  // For generating unique temporary variable for array arguments
+    V3UniqueNames m_initArrayTmpNames;  // For generating unique temporary variable names for arguments being AstInitArray
     AstNodeModule* m_modp = nullptr;  // Current module
     AstTopScope* const m_topScopep = v3Global.rootp()->topScopep();  // The AstTopScope
     AstScope* m_scopep = nullptr;  // Current scope
@@ -1506,8 +1506,8 @@ class TaskVisitor final : public VNVisitor {
                     if (!arrayp) return;
 
                     FileLine* const flp = arrayp->fileline();
-                    std::string tempName = m_tempUnpackedArrayNames.get(arg);
-                    AstVar* substp = new AstVar{flp, VVarType::VAR, tempName, arrayp->dtypep()};
+                    std::string tempName = m_initArrayTmpNames.get(arg);
+                    AstVar* const substp = new AstVar{flp, VVarType::VAR, tempName, arrayp->dtypep()};
                     substp->funcLocal(true);
                     AstVarScope* const substvscp = createVarScope(substp, tempName);
 
@@ -1702,7 +1702,7 @@ public:
     // CONSTRUCTORS
     TaskVisitor(AstNetlist* nodep, TaskStateVisitor* statep)
         : m_statep{statep}
-        , m_tempUnpackedArrayNames{"__Vtasktemp"} {
+        , m_initArrayTmpNames{"__VInitArrayTemp"} {
         iterate(nodep);
     }
     ~TaskVisitor() {

--- a/src/V3Task.cpp
+++ b/src/V3Task.cpp
@@ -1464,11 +1464,6 @@ class TaskVisitor final : public VNVisitor {
             AstExprStmt* const exprstmtp = new AstExprStmt{
                 flp, substp, new AstVarRef{arrayp->fileline(), substvscp, VAccess::READ}};
             exprstmtp->stmtsp()->addNext(assignp);
-            exprstmtp->hasResult(false);
-
-            AstCExpr* const exprp = new AstCExpr{flp, substp->name()};
-            exprp->dtypeSetString();
-            exprstmtp->addStmtsp(new AstCReturn{flp, exprp});
             argp->exprp(exprstmtp);
         }
     }

--- a/test_regress/t/t_concat_init_array_functions.py
+++ b/test_regress/t/t_concat_init_array_functions.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2024 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile()
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_concat_init_array_functions.v
+++ b/test_regress/t/t_concat_init_array_functions.v
@@ -14,18 +14,18 @@ endclass
 
 class B;
   virtual function int B_virt_func(int r[3], p[4]);
-    return r[0] + r[1] + r[2] + p[0] + p[1] + p[2] + p[3]; 
+    return r[0] + r[1] + r[2] + p[0] + p[1] + p[2] + p[3];
   endfunction
 endclass
 
 function int func_1_concat(int r[4]);
 // verilator no_inline_task
-  return r[0] + r[1] + r[2] + r[3]; 
+  return r[0] + r[1] + r[2] + r[3];
 endfunction
 
 function int func_2_concat(int r[3], int p[4]);
 // verilator no_inline_task
-  return r[0] + r[1] + r[2] + p[0] + p[1] + p[2] + p[3]; 
+  return r[0] + r[1] + r[2] + p[0] + p[1] + p[2] + p[3];
 endfunction
 
 module t;
@@ -34,7 +34,7 @@ module t;
   B b = new;
   initial begin
     a.r1 = {1,2};
-    a.r2 = 5; 
+    a.r2 = 5;
     s = func_1_concat({a.r1, a.r1});
     if (s != 6) $stop;
 

--- a/test_regress/t/t_concat_init_array_functions.v
+++ b/test_regress/t/t_concat_init_array_functions.v
@@ -1,4 +1,4 @@
-// DESCRIPTION: Verilator: Verilog Test module for SystemVerilog 'alias'
+// DESCRIPTION: Verilator: Verilog Test module
 //
 // Simple test for unpacked concatenation arrays used as function arguments.
 //

--- a/test_regress/t/t_concat_init_array_functions.v
+++ b/test_regress/t/t_concat_init_array_functions.v
@@ -1,9 +1,9 @@
 // DESCRIPTION: Verilator: Verilog Test module for SystemVerilog 'alias'
 //
-// Simple bi-directional transitive alias test.
+// Simple test for unpacked concatenation arrays used as function arguments.
 //
 // This file ONLY is placed under the Creative Commons Public Domain, for
-// any use, without warranty, 2025 by Antmicro.
+// any use, without warranty, 2026 by Antmicro.
 // SPDX-License-Identifier: CC0-1.0
 //
 
@@ -43,6 +43,7 @@ module t;
 
     s = b.B_virt_func({a.r1, a.r2}, {a.r1, a.r1});
     if (s != 14) $stop;
+
     $write("*-* All finished *-*\n");
     $finish;
   end

--- a/test_regress/t/t_concat_init_array_functions.v
+++ b/test_regress/t/t_concat_init_array_functions.v
@@ -1,0 +1,49 @@
+// DESCRIPTION: Verilator: Verilog Test module for SystemVerilog 'alias'
+//
+// Simple bi-directional transitive alias test.
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2025 by Antmicro.
+// SPDX-License-Identifier: CC0-1.0
+//
+
+class A;
+  int r1[2];
+  int r2;
+endclass
+
+class B;
+  virtual function int B_virt_func(int r[3], p[4]);
+    return r[0] + r[1] + r[2] + p[0] + p[1] + p[2] + p[3]; 
+  endfunction
+endclass
+
+function int func_1_concat(int r[4]);
+// verilator no_inline_task
+  return r[0] + r[1] + r[2] + r[3]; 
+endfunction
+
+function int func_2_concat(int r[3], int p[4]);
+// verilator no_inline_task
+  return r[0] + r[1] + r[2] + p[0] + p[1] + p[2] + p[3]; 
+endfunction
+
+module t;
+  int s;
+  A a = new;
+  B b = new;
+  initial begin
+    a.r1 = {1,2};
+    a.r2 = 5; 
+    s = func_1_concat({a.r1, a.r1});
+    if (s != 6) $stop;
+
+    s = func_2_concat({a.r1, a.r2}, {a.r1, a.r1});
+    if (s != 14) $stop;
+
+    s = b.B_virt_func({a.r1, a.r2}, {a.r1, a.r1});
+    if (s != 14) $stop;
+    $write("*-* All finished *-*\n");
+    $finish;
+  end
+endmodule


### PR DESCRIPTION
Fixes #5385

Verilation of designs using concat arrays as function arguments caused internal error.

Array concatenation was supported in case when it was assigned to a variable. This is why it worked for functions that were inlined. This solution uses that and converts these init arrays so that they are assigned to a variable inside `AstExprStmt`.

```
%Error: Internal Error: test_regress/t/t_concat_init_array_functions.v:38:28: ../V3EmitCConstInit.h:82: Missing array init element
   38 |     s = func_1_concat({a.r1, a.r1});
      |                            ^
                        ... See the manual at https://verilator.org/verilator_doc.html?v=5.045 for more assistance.
```