### PR TITLE
Fix memory leaks in vpi_put_value and vpi_get_value

### DIFF
--- a/test_regress/t/t_vpi_force.py
+++ b/test_regress/t/t_vpi_force.py
@@ -14,8 +14,8 @@ test.scenarios('simulator')
 test.compile(make_top_shell=False,
              make_main=False,
              make_pli=True,
-             verilator_flags2=["--binary --vpi", test.pli_filename],
-             v_flags2=["+define+USE_VPI_NOT_DPI +define+VERILATOR_COMMENTS"])
+             verilator_flags2=["+define+VERILATOR_COMMENTS --binary --vpi", test.pli_filename],
+             v_flags2=["+define+USE_VPI_NOT_DPI"])
 
 test.execute(xrun_flags2=["+define+USE_VPI_NOT_DPI"], use_libvpi=True, check_finished=True)
 


### PR DESCRIPTION
#6704 introduced the `getForceControlSignals` function to `verilated_vpi.cpp`. It returns a pair of `vpiHandles`. These handles were not released, causing a memory leak. This commit fixes this, in addition to other minor changes for speed and readability that did not make it into #6704.
No functional change intended.