### PR TITLE
Fix large array initialization for I/O ports (#6904)

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -185,6 +185,7 @@ Natan Kreimer
 Nathan Graybeal
 Nathan Kohagen
 Nathan Myers
+Neeru Uppalapati
 Nick Brereton
 Nolan Poe
 Oleh Maksymenko

--- a/src/V3EmitCFunc.h
+++ b/src/V3EmitCFunc.h
@@ -622,7 +622,8 @@ public:
                    && !VN_IS(nodep->rhsp(), MemberSel)  //
                    && !VN_IS(nodep->rhsp(), StructSel)  //
                    && !VN_IS(nodep->rhsp(), ArraySel)  //
-                   && !VN_IS(nodep->rhsp(), ExprStmt)) {
+                   && !VN_IS(nodep->rhsp(), ExprStmt)  //
+                   && !VN_IS(nodep->rhsp(), InitArray)) {
             // Wide functions assign into the array directly, don't need separate assign statement
             m_wideTempRefp = VN_AS(nodep->lhsp(), VarRef);
             paren = false;

--- a/test_regress/t/t_array_init_wide_io.cpp
+++ b/test_regress/t/t_array_init_wide_io.cpp
@@ -1,0 +1,25 @@
+// -*- mode: C++; c-file-style: "cc-mode" -*-
+// DESCRIPTION: Verilator: Verilog Test driver
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2024 by Wilson Snyder.
+// SPDX-License-Identifier: CC0-1.0
+
+#include "verilated.h"
+#include "Vt_array_init_wide_io.h"
+
+int main(int argc, char** argv) {
+    Verilated::debug(0);
+    Verilated::commandArgs(argc, argv);
+
+    std::unique_ptr<Vt_array_init_wide_io> top{new Vt_array_init_wide_io{"top"}};
+
+    top->clk = 0;
+    while (!Verilated::gotFinish()) {
+        top->clk = !top->clk;
+        top->eval();
+    }
+
+    top->final();
+    return 0;
+}

--- a/test_regress/t/t_array_init_wide_io.py
+++ b/test_regress/t/t_array_init_wide_io.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2024 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile()
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_array_init_wide_io.v
+++ b/test_regress/t/t_array_init_wide_io.v
@@ -1,0 +1,48 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2024 by Wilson Snyder.
+// SPDX-License-Identifier: CC0-1.0
+
+// Test for issue #6904: Large array initialization with wide elements
+// for I/O ports generates invalid C++ code.
+
+module t (/*AUTOARG*/
+   // Outputs
+   output_wide, output_nonwide,
+   // Inputs
+   clk
+   );
+
+   input clk;
+
+   // Wide (>64 bits) output port with >256 elements - the original bug
+   output logic [64:0] output_wide [257];
+   assign output_wide = '{default: '0};
+
+   // Non-wide output port with >256 elements - should still use optimization
+   output logic output_nonwide [257];
+   assign output_nonwide = '{default: '0};
+
+   // Wide internal variable with >256 elements - uses VlUnpacked
+   logic [64:0] internal_wide [257];
+   initial internal_wide = '{default: '0};
+
+   integer cyc = 0;
+
+   always @ (posedge clk) begin
+      cyc <= cyc + 1;
+      if (cyc == 1) begin
+         // Verify initialization worked
+         if (output_wide[0] !== 65'b0) $stop;
+         if (output_wide[256] !== 65'b0) $stop;
+         if (output_nonwide[0] !== 1'b0) $stop;
+         if (output_nonwide[256] !== 1'b0) $stop;
+         if (internal_wide[0] !== 65'b0) $stop;
+         if (internal_wide[256] !== 65'b0) $stop;
+         $write("*-* All Coverage Met *-*\n");
+         $finish;
+      end
+   end
+
+endmodule


### PR DESCRIPTION
 When you have a large array (>256 elements) with wide elements (>64 bits) on an output port like this:

  
```
  output logic [64:0] my_array [257];
  assign my_array = '{default: '0};
```
  
 Verilator generated broken C++ code that wouldn't compile. The generated code was missing the left-hand side of the assignment, producing something like {{0, 0, ...}}; instead of my_array = {{0, 0, ...}};. I believe this was introduced in commit e2f5854 as mentioned in the GH issue. The problem seems to be that output ports are declared as raw C arrays and the assignment is broken, whilst VLUnpacked does support this. I made the below changes, let me know if this is short sighted, there are bigger things to do, I also added some tests.

  1. V3Slice.cpp: Don't use this optimization for I/O ports - expand them element-by-element instead
  2. V3EmitCFunc.h: Make sure array initializers always emit the left-hand side of the assignment

  ---