### PR TITLE
Clone typedef in captureTypedefContext.

### DIFF
--- a/src/V3LinkDotIfaceCapture.cpp
+++ b/src/V3LinkDotIfaceCapture.cpp
@@ -185,6 +185,8 @@ void V3LinkDotIfaceCapture::captureTypedefContext(
     const std::function<std::string()>& indentFn) {
     if (!enabled() || !refp) return;
 
+    refp = refp->cloneTreePure(false);
+
     UINFO(9, indentFn() << "iface capture capture request stage=" << stageLabel
                         << " typedef=" << refp << " name=" << refp->name() << " dotPos=" << dotPos
                         << " dotText='" << dotText << "' dotSym=" << dotSymp);


### PR DESCRIPTION
This attempts to fix #6920.
The idea is to just clone the typedef when capturing it, so that a specialization of the type does not affect all instances.
It seems to work on the simple example from the issue report, but I suspect this is not fully correct and needs something more, since I don't fully understand the surrounding code. In particular, I'm worried that simply cloning I'm "taking out" the nodes from successive stages that should operate on them.
I'm open to any suggestions on how to implement it properly, or if someone knows how to and wants to fix it in a separate PR I can just drop this.