### PR TITLE
Transform SelExtract to PackArrayDType when a type is needed.

### DIFF
--- a/src/V3LinkParse.cpp
+++ b/src/V3LinkParse.cpp
@@ -440,12 +440,13 @@ class LinkParseVisitor final : public VNVisitor {
 
                     for (auto it = selexNodes.begin(); it != selexNodes.end(); ++it) {
                         selex = *it;
-                        FileLine *fl = selex->fileline();
+                        FileLine* fl = selex->fileline();
                         //AstParseRef *fromp = VN_CAST(selex->fromp()->unlinkFrBack(), ParseRef);
                         AstNodeExpr* leftp = selex->leftp()->unlinkFrBack();
                         AstNodeExpr* rightp = selex->rightp()->unlinkFrBack();
                         AstRange* const range = new AstRange{fl, leftp, rightp};
-                        arrayDType = new AstPackArrayDType{fl, VFlagChildDType{}, arrayDType, range};
+                        arrayDType
+                            = new AstPackArrayDType{fl, VFlagChildDType{}, arrayDType, range};
                     }
                     VL_DO_DANGLING(dtypep->deleteTree(), dtypep);
                     dtypep = arrayDType;


### PR DESCRIPTION
This is an attempt to fix #6923.
It solves the base issue, but it's definitely incorrect. At the very least, it should be combined with the code right above dealing with `DOT`, to handle things like

```
interface tb_if;
    typedef logic[3:0] tbif_t;
    ...
endinterface

module test(
    tb_if.TB inif [3:0]
);
    localparam type type_t = inif[1].tbif_t[1:0];
endmodule
```

But I'm not really sure this fix is even in the right place. Any suggestion is appreciated, as well as anyone more knowledgeable taking over the fix.