### PR TITLE
execute t_interface_typedef*

### DIFF
--- a/test_regress/t/t_interface_typedef.py
+++ b/test_regress/t/t_interface_typedef.py
@@ -13,7 +13,6 @@ test.scenarios('simulator_st')
 
 test.compile(verilator_flags2=['--binary'])
 
-if not test.vlt_all:
-    test.execute()
+test.execute()
 
 test.passes()

--- a/test_regress/t/t_interface_typedef.v
+++ b/test_regress/t/t_interface_typedef.v
@@ -6,7 +6,7 @@
 
 // verilog_format: off
 `define stop $stop
-`define checkh(gotv, expv) do if ((gotv) !== (expv)) begin $write("%%Error: %s:%0d:  got='h%x exp='h%x\n", `__FILE__,`__LINE__, (gotv), (expv)); `stop; end while(0)
+`define checkh(gotv, expv) do if ((gotv) !== (expv)) begin $write("%%Error: (%m) %s:%0d:  got='h%x exp='h%x\n", `__FILE__,`__LINE__, (gotv), (expv)); `stop; end while(0)
 // verilog_format: on
 
 interface ifc #(
@@ -46,15 +46,15 @@ module sub #(
     input logic clk,
     ifc ifc_if
 );
-  typedef ifc_if.struct_t struct_t;
+  typedef ifc_if.struct_t my_struct_t;
 
   wire [EXP_WIDTH-1:0] expval = '1;
 
   initial begin
-    struct_t substruct;
+    my_struct_t substruct;
     #10;
     substruct.data = '1;
-    `checkh($bits(struct_t), EXP_WIDTH);
+    `checkh($bits(my_struct_t), EXP_WIDTH);
     `checkh(substruct.data, expval);
   end
 

--- a/test_regress/t/t_interface_typedef2.py
+++ b/test_regress/t/t_interface_typedef2.py
@@ -13,7 +13,6 @@ test.scenarios('simulator_st')
 
 test.compile(verilator_flags2=['--binary'])
 
-if not test.vlt_all:
-    test.execute()
+test.execute()
 
 test.passes()


### PR DESCRIPTION
Two tests from #6732 have runtime checks but are not being run against Verilator.  Enabling the tests show one works, but the other doesn't:
```
%Error: (t.u_sub10.unnamedblk1) t/t_interface_typedef.v:57:  got='h00000001 exp='h0000000a
%Error: t/t_interface_typedef.v:57: Verilog $stop
```

I tweaked the test slightly for clarity, but it was failing before I did so.  I'll see what I can find, but @em2machine do you have any cycles to investigate or do you see what's going on here?

Got here by looking into #6920 