### PR TITLE
Fix interface internal type reference (#6920)

### DIFF
--- a/src/V3LinkDotIfaceCapture.cpp
+++ b/src/V3LinkDotIfaceCapture.cpp
@@ -56,7 +56,8 @@ string V3LinkDotIfaceCapture::extractIfacePortName(const string& dotText) {
 void V3LinkDotIfaceCapture::add(AstRefDType* refp, AstCell* cellp, AstNodeModule* ownerModp,
                                 AstTypedef* typedefp, AstNodeModule* typedefOwnerModp,
                                 AstVar* ifacePortVarp) {
-    if (!refp) return;
+    // TODO -- probably classes too
+    if (!refp || cellp->modp() == ownerModp) return;
     if (!typedefp) typedefp = refp->typedefp();
     if (!typedefOwnerModp && typedefp) typedefOwnerModp = findOwnerModule(typedefp);
     s_map[refp] = CapturedIfaceTypedef{

--- a/test_regress/t/t_interface_type_ref_internal.py
+++ b/test_regress/t/t_interface_type_ref_internal.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2025 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile()
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_interface_type_ref_internal.v
+++ b/test_regress/t/t_interface_type_ref_internal.v
@@ -1,0 +1,23 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain.
+// SPDX-FileCopyrightText: 2026 Wilson Snyder
+// SPDX-License-Identifier: CC0-1.0
+
+interface ifc #(parameter int width)(input logic [width-1:0] b);
+  logic [width-1:0] a;
+  typedef logic[width-1:0] type_t;
+  always_comb a = type_t'(b);
+endinterface
+
+module t;
+  logic [15:0] x;
+  ifc #(.width(16)) x_ifc(x);
+  logic [7:0] y;
+  ifc #(.width(8)) y_ifc(y);
+
+  initial begin
+    $write("*-* All Finished *-*\n");
+    $finish;
+  end
+endmodule


### PR DESCRIPTION
Possible solution for #6920 

If I understand correctly, `V3LinkDotIfaceCapture` tracks type references from interfaces so that they can be fixed up throughout the linkdot / param process.  This mechanism is changing a type reference which lives inside of an interface from pointing to the correct type to an incorrect one.  I don't believe we need `V3LinknDotIfaceCapture` for type references within an interface, so I'm just bailing out if `cellp` is an `ownerModp`.

Currently I'm trying to get #6832 into a land-able state.  I want to run HEAD vs HEAD + #6832 on our codebase to check for any kind of regression or divergence.  So while it's not completely necessary to get a fix in for this issue before landing #6832, it would certainly make my life easier.  @em2machine mentioned working on an IfaceCapture replacement in #6965, so this would probably just be a stop gap measure, but I believe it to be strictly better than what we currently have.

Also, I tried to expand this test to look into the analogous code path for `addClass()` but ran into more / different problems.  So I'm just going to leave that and defer to @em2machine 's forthcoming work there.