### PR TITLE
Fix UNUSED / UNDRIVEN for unused functions (#6893)

### DIFF
--- a/test_regress/t/t_lint_style_bad.out
+++ b/test_regress/t/t_lint_style_bad.out
@@ -23,7 +23,7 @@
       |            ^~~
                        ... For warning description see https://verilator.org/warn/UNUSEDSIGNAL?v=latest
                        ... Use "/* verilator lint_off UNUSEDSIGNAL */" and lint_on around source to disable this message.
-%Warning-UNDRIVEN: t/t_lint_style_bad.v:12:14: Signal is not driven: 'top'
+%Warning-UNDRIVEN: t/t_lint_style_bad.v:12:14: Function variable is not driven: 'top'
                                              : ... note: In instance 't'
    12 |       output top;
       |              ^~~

--- a/test_regress/t/t_lint_unused_func_bad.out
+++ b/test_regress/t/t_lint_unused_func_bad.out
@@ -1,0 +1,29 @@
+%Warning-UNUSEDSIGNAL: t/t_lint_unused_func_bad.v:14:53: Function variable is not used: 'not_used'
+                                                       : ... note: In instance 't'
+   14 | function automatic int unused_input_unused_func(int not_used);
+      |                                                     ^~~~~~~~
+                       ... For warning description see https://verilator.org/warn/UNUSEDSIGNAL?v=latest
+                       ... Use "/* verilator lint_off UNUSEDSIGNAL */" and lint_on around source to disable this message.
+%Warning-UNDRIVEN: t/t_lint_unused_func_bad.v:20:7: Function variable is not driven: 'not_driven'
+                                                  : ... note: In instance 't'
+   20 |   int not_driven;
+      |       ^~~~~~~~~~
+                   ... For warning description see https://verilator.org/warn/UNDRIVEN?v=latest
+                   ... Use "/* verilator lint_off UNDRIVEN */" and lint_on around source to disable this message.
+%Warning-UNDRIVEN: t/t_lint_unused_func_bad.v:25:7: Function variable is not driven: 'undriven_result'
+                                                  : ... note: In instance 't'
+   25 |   int undriven_result;
+      |       ^~~~~~~~~~~~~~~
+%Warning-UNDRIVEN: t/t_lint_unused_func_bad.v:29:52: Function variable is not driven: 'undriven_out_param'
+                                                   : ... note: In instance 't'
+   29 | function automatic void undriven_output(output int undriven_out_param);
+      |                                                    ^~~~~~~~~~~~~~~~~~
+%Warning-UNUSEDSIGNAL: t/t_lint_unused_func_bad.v:32:51: Function variable is not driven, nor used: 'untouched_inout_param'
+                                                       : ... note: In instance 't'
+   32 | function automatic void untouched_inout(inout int untouched_inout_param);
+      |                                                   ^~~~~~~~~~~~~~~~~~~~~
+%Warning-UNUSEDSIGNAL: t/t_lint_unused_func_bad.v:35:63: Function variable is not driven, nor used: 'untouched_inout_unused_func_param'
+                                                       : ... note: In instance 't'
+   35 | function automatic void untouched_inout_unused_func(inout int untouched_inout_unused_func_param);
+      |                                                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+%Error: Exiting due to

--- a/test_regress/t/t_lint_unused_func_bad.py
+++ b/test_regress/t/t_lint_unused_func_bad.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2025 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios("simulator")
+
+test.compile(
+    verilator_flags2=["--lint-only -Wall -Wno-DECLFILENAME --unused-regexp blargh"],
+    fails=True,
+    expect_filename=test.golden_filename,
+)
+
+test.passes()

--- a/test_regress/t/t_lint_unused_func_bad.v
+++ b/test_regress/t/t_lint_unused_func_bad.v
@@ -1,0 +1,54 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain.
+// SPDX-FileCopyrightText: 2026 Wilson Snyder
+// SPDX-License-Identifier: CC0-1.0
+
+function automatic int ok_unused_func(real val);
+  int result = $rtoi(val);
+  bit huh = result[0];
+  return result + huh;
+endfunction
+
+// Unused parameter
+function automatic int unused_input_unused_func(int not_used);
+  return 5;
+endfunction
+
+// Undriven variable
+function automatic int undriven_var_unused_func(int some_val);
+  int not_driven;
+  return some_val + not_driven;
+endfunction
+
+function automatic int undriven_var();
+  int undriven_result;
+  return undriven_result;
+endfunction
+
+function automatic void undriven_output(output int undriven_out_param);
+endfunction
+
+function automatic void untouched_inout(inout int untouched_inout_param);
+endfunction
+
+function automatic void untouched_inout_unused_func(inout int untouched_inout_unused_func_param);
+endfunction
+
+function automatic void driven_inout_unused_func(inout int driven_inout_unused_func_param);
+    driven_inout_unused_func_param = 7;
+endfunction
+
+function automatic void used_inout_unused_func(inout int used_inout_unused_func_param);
+    $display(used_inout_unused_func_param);
+endfunction
+
+module t;
+  int result;
+  initial begin
+    result = undriven_var();
+    undriven_output(result);
+    untouched_inout(result);
+    $display(result);
+  end
+endmodule


### PR DESCRIPTION
Variables in unused functions toss very confusing warnings:
```
unc/vlt_compile.log                                                                                                                                                                                                                                                                                                                                                                                                                      %Warning-UNUSEDSIGNAL: t/t_unused_func.v:7:33: Signal is not used: 'val'                                                                                                                                                                                                                                                                                                                                                                 
                                             : ... note: In instance 't'                                                                                                                                                                                                                                                                                                                                                                     7 | function automatic int foo(real val);                                                                                                                                                                                                                                                                                                                                                                                            
      |                                 ^~~                                                                                                                                                                                                                                                                                                                                                                                              
                       ... For warning description see https://verilator.org/warn/UNUSEDSIGNAL?v=5.045                                                                                                                                                                                                                                                                                                                                                          ... Use "/* verilator lint_off UNUSEDSIGNAL */" and lint_on around source to disable this message.                                                                                                                                                                                                                                                                                                                
%Warning-UNUSEDSIGNAL: t/t_unused_func.v:8:7: Bits of signal are not driven, nor used: 'result'[31:1]                                                                                                               
                                            : ... note: In instance 't'                                                                                                                                             
    8 |   int result = $rtoi(val);                                                                                                                                                                                  
      |       ^~~~~~                                                                                                                                                                                                
%Warning-UNDRIVEN: t/t_unused_func.v:8:7: Bits of signal are not driven: 'result'[0]                                                                                                                                
                                        : ... note: In instance 't'                                                                                                                                                 
    8 |   int result = $rtoi(val);                                                                      
      |       ^~~~~~                                                                                   
                   ... For warning description see https://verilator.org/warn/UNDRIVEN?v=5.045         
                   ... Use "/* verilator lint_off UNDRIVEN */" and lint_on around source to disable this message.
%Warning-UNUSEDSIGNAL: t/t_unused_func.v:9:7: Signal is not driven, nor used: 'huh'                                                                                                                                                                                                                                                                                                                                                      
                                            : ... note: In instance 't'                              
    9 |   bit huh = result[0];                                                                                                                                                                                                                                                                                                                                                                                                           
      |       ^~~                                                                                                                                                                                                                                                                                                                                                                                                                        
```

E.g. `val` is definitely used on line 8, but because the function isn't called, V3Undriven ripples through the func and yells about everything.  I guess there's an argument that you shouldn't have un-called functions and that instead the warnings should just be changed to say that instead.  However, I don't think that's a good plan since that discourages sharing functions via packages or included files (not everyone will use all the funcs).

This PR now marks Vars as driven / used in the function declaration.  That caused spurious MULTIDRIVEN warnings as was mentioned in the comment I changed.  So now you don't get MULTIDRIVEN if you're looking at a function declaration or if the last driver was the function declaration.