### PR TITLE
Optimize string temporaries - do not localize

### DIFF
--- a/src/V3Localize.cpp
+++ b/src/V3Localize.cpp
@@ -69,6 +69,10 @@ class LocalizeVisitor final : public VNVisitor {
     bool isOptimizable(AstVarScope* nodep) {
         // Don't want to malloc/free the backing store all the time
         if (VN_IS(nodep->dtypep(), NBACommitQueueDType)) return false;
+        // Do not localize strings. They result in unnecessary initialization
+        // and bloated code size due to destructor calls when unused.
+        // TODO: Local variables should be pushed into the narrowest scope rather
+        // than emitted at the top of the function. See discussion in #6969.
         if (nodep->dtypep()->skipRefp()->isString()) return false;
         // Variables used in super constructor call can't be localized, because
         // in C++ there is no way to declare them before base class constructor call


### PR DESCRIPTION
Minor performance improvement, especially for assertions heavy code. Strings are often used as temporaries in unlikely branches. Do not localize them to avoid an unnecessary initialization on function entry.
