### PR TITLE
Optimize more wide operation temporaries with substitution

### DIFF
--- a/src/V3Subst.cpp
+++ b/src/V3Subst.cpp
@@ -64,7 +64,7 @@ class SubstVarEntry final {
     std::vector<Record> m_wordRecords{static_cast<size_t>(m_varp->widthWords()), Record{}};
 
     // METHDOS
-    void deleteAssignmentIfUnused(Record& record, size_t &nAssignDeleted) {
+    void deleteAssignmentIfUnused(Record& record, size_t& nAssignDeleted) {
         if (!record.m_assignp) return;
         if (record.m_used) return;
         ++nAssignDeleted;
@@ -118,10 +118,11 @@ public:
     // Returns substitution of whole word, or nullptr if not known/stale
     AstNodeExpr* substWord(uint32_t word) { return substRecord(m_wordRecords[word]); }
 
-    void deleteUnusedAssignments(size_t &nWordAssignDeleted, size_t &nWholeAssignDeleted) {
+    void deleteUnusedAssignments(size_t& nWordAssignDeleted, size_t& nWholeAssignDeleted) {
         // Delete assignments to temporaries if they are not used
         if (!m_varp->isStatementTemp()) return;
-        for (Record& wordRecord : m_wordRecords) deleteAssignmentIfUnused(wordRecord, nWordAssignDeleted);
+        for (Record& wordRecord : m_wordRecords)
+            deleteAssignmentIfUnused(wordRecord, nWordAssignDeleted);
         deleteAssignmentIfUnused(m_wholeRecord, nWholeAssignDeleted);
     }
 };
@@ -427,7 +428,8 @@ public:
     explicit SubstVisitor(AstNode* nodep) { iterate(nodep); }
     ~SubstVisitor() override {
         V3Stats::addStat("Optimizations, Substituted temps", m_nSubst);
-        V3Stats::addStat("Optimizations, Whole variable assignments deleted", m_nWholeAssignDeleted);
+        V3Stats::addStat("Optimizations, Whole variable assignments deleted",
+                         m_nWholeAssignDeleted);
         V3Stats::addStat("Optimizations, Whole variables substituted", m_nWholeSubstituted);
         V3Stats::addStat("Optimizations, Word assignments deleted", m_nWordAssignDeleted);
         V3Stats::addStat("Optimizations, Words substituted", m_nWordSubstituted);


### PR DESCRIPTION
A temporary introduced by V3Premit could not be eliminated in V3Subst if it was involved in an expression that did a write back to a non-temporary. To enables removing these, we need to track all variables in V3Subtst, not just the ones we would consider for elimination. Note the new implementation is marginally faster than the old one even though it does more work. It can eliminate ~5% more of wide temporaries on some designs. Algorithm is largely the same, but there will be follow up.