### PR TITLE
Internals: Move CReset under Assign

### DIFF
--- a/src/V3AstNodeExpr.h
+++ b/src/V3AstNodeExpr.h
@@ -673,6 +673,32 @@ public:
 private:
     void setPurity();
 };
+class AstCReset final : public AstNodeExpr {
+    // Reset variable at startup
+    const bool m_constructing;  // Previously cleared by constructor
+public:
+    AstCReset(FileLine* fl, AstVar* varp, bool constructing)
+        : ASTGEN_SUPER_CReset(fl)
+        , m_constructing{constructing} {
+        dtypeFrom(varp);
+    }
+    ASTGEN_MEMBERS_AstCReset;
+    void dump(std::ostream& str) const override;
+    void dumpJson(std::ostream& str) const override;
+    bool isPure() override { return true; }
+    int instrCount() const override { return widthInstrs(); }
+    string emitVerilog() override { V3ERROR_NA_RETURN(""); }
+    string emitC() override { V3ERROR_NA_RETURN(""); }
+    bool cleanOut() const override { return true; }
+    const char* broken() const override {
+        BROKEN_RTN(!VN_IS(backp(), NodeAssign));  // V3Emit* assumption
+        return nullptr;
+    }
+    bool sameNode(const AstNode* samep) const override {
+        return constructing() == VN_DBG_AS(samep, CReset)->constructing();
+    }
+    bool constructing() const { return m_constructing; }
+};
 class AstCast final : public AstNodeExpr {
     // Cast to appropriate data type
     // @astgen op1 := fromp : AstNodeExpr

--- a/src/V3AstNodeStmt.h
+++ b/src/V3AstNodeStmt.h
@@ -253,26 +253,6 @@ public:
     string verilogKwd() const override { return "break"; }
     bool isBrancher() const override { V3ERROR_NA_RETURN(true); }  // Node removed early
 };
-class AstCReset final : public AstNodeStmt {
-    // Reset variable at startup
-    // @astgen op1 := varrefp : AstVarRef
-    const bool m_constructing;  // Previously cleared by constructor
-public:
-    AstCReset(FileLine* fl, AstVarRef* varrefp, bool constructing)
-        : ASTGEN_SUPER_CReset(fl)
-        , m_constructing{constructing} {
-        this->varrefp(varrefp);
-    }
-    ASTGEN_MEMBERS_AstCReset;
-    void dump(std::ostream& str) const override;
-    void dumpJson(std::ostream& str) const override;
-    bool isGateOptimizable() const override { return false; }
-    bool isPredictOptimizable() const override { return false; }
-    bool sameNode(const AstNode* samep) const override {
-        return constructing() == VN_DBG_AS(samep, CReset)->constructing();
-    }
-    bool constructing() const { return m_constructing; }
-};
 class AstCReturn final : public AstNodeStmt {
     // C++ return from a function
     // @astgen op1 := lhsp : AstNodeExpr

--- a/src/V3CCtors.cpp
+++ b/src/V3CCtors.cpp
@@ -192,12 +192,13 @@ class CCtorsVisitor final : public VNVisitor {
     }
     void visit(AstVar* nodep) override {
         if (nodep->needsCReset()) {
+            AstNode* const crstp = new AstAssign{
+                nodep->fileline(), new AstVarRef{nodep->fileline(), nodep, VAccess::WRITE},
+                new AstCReset{nodep->fileline(), nodep, true}};
             if (m_varResetp) {
-                AstVarRef* const vrefp = new AstVarRef{nodep->fileline(), nodep, VAccess::WRITE};
-                m_varResetp->add(new AstCReset{nodep->fileline(), vrefp, true});
+                m_varResetp->add(crstp);
             } else if (m_cfuncp) {
-                AstVarRef* const vrefp = new AstVarRef{nodep->fileline(), nodep, VAccess::WRITE};
-                nodep->addNextHere(new AstCReset{nodep->fileline(), vrefp, true});
+                nodep->addNextHere(crstp);
             }
         }
     }

--- a/src/V3CfgBuilder.cpp
+++ b/src/V3CfgBuilder.cpp
@@ -81,7 +81,6 @@ class CfgBuilder final : public VNVisitorConst {
     // Non-representable statements
     void visit(AstAssignDly* nodep) override { nonRepresentable(nodep); }
     void visit(AstCase* nodep) override { nonRepresentable(nodep); }  // V3Case will eliminate
-    void visit(AstCReset* nodep) override { nonRepresentable(nodep); }
     void visit(AstDelay* nodep) override { nonRepresentable(nodep); }
 
     // Representable non control-flow statements

--- a/src/V3EmitCFunc.h
+++ b/src/V3EmitCFunc.h
@@ -523,6 +523,11 @@ public:
     }
 
     void visit(AstNodeAssign* nodep) override {
+        if (AstCReset* const resetp = VN_CAST(nodep->rhsp(), CReset)) {
+            AstVar* const varp = VN_AS(nodep->lhsp(), NodeVarRef)->varp();
+            emitVarReset(varp, resetp->constructing());
+            return;
+        }
         bool paren = true;
         bool decind = false;
         bool rhs = true;
@@ -1735,10 +1740,6 @@ public:
             iterateAndNextConstNull(nodep->rhsp());
             puts(")");
         }
-    }
-    void visit(AstCReset* nodep) override {
-        AstVar* const varp = nodep->varrefp()->varp();
-        emitVarReset(varp, nodep->constructing());
     }
     void visit(AstExecGraph* nodep) override {
         // The location of the AstExecGraph within the containing AstCFunc is where we want to

--- a/src/V3Life.cpp
+++ b/src/V3Life.cpp
@@ -46,13 +46,11 @@ class LifeState final {
 public:
     VDouble0 m_statAssnDel;  // Statistic tracking
     VDouble0 m_statAssnCon;  // Statistic tracking
-    VDouble0 m_statCResetDel;  // Statistic tracking
 
     // CONSTRUCTORS
     LifeState() = default;
     ~LifeState() {
         V3Stats::addStatSum("Optimizations, Lifetime assign deletions", m_statAssnDel);
-        V3Stats::addStatSum("Optimizations, Lifetime creset deletions", m_statCResetDel);
         V3Stats::addStatSum("Optimizations, Lifetime constant prop", m_statAssnCon);
     }
 };
@@ -86,12 +84,6 @@ public:
         m_constp = nullptr;
         m_everSet = true;
         if (VN_IS(nodep->rhsp(), Const)) m_constp = VN_AS(nodep->rhsp(), Const);
-    }
-    void resetStatement(AstCReset* nodep) {  // New CReset(A) assignment
-        UASSERT_OBJ(!m_isNew, nodep, "Uninitialized new entry");
-        m_assignp = nodep;
-        m_constp = nullptr;
-        m_everSet = true;
     }
     void complexAssign() {  // A[x]=... or some complicated assignment
         UASSERT(!m_isNew, "Uninitialized new entry");
@@ -148,25 +140,8 @@ public:
         UINFOTREE(7, oldassp, "", "REMOVE/SAMEBLK");
         entr.complexAssign();
         oldassp->unlinkFrBack();
-        if (VN_IS(oldassp, CReset)) {
-            ++m_statep->m_statCResetDel;
-        } else {
-            ++m_statep->m_statAssnDel;
-        }
+        ++m_statep->m_statAssnDel;
         VL_DO_DANGLING(m_deleter.pushDeletep(oldassp), oldassp);
-    }
-    void resetStatement(AstVarScope* nodep, AstCReset* rstp) {
-        // Do we have a old assignment we can nuke?
-        UINFO(4, "     CRESETof: " << nodep);
-        UINFO(7, "       new: " << rstp);
-        LifeVarEntry& entr = m_map[nodep];
-        if (entr.isNew()) {
-            entr.init(true);
-        } else {
-            checkRemoveAssign(nodep, entr);
-        }
-        entr.resetStatement(rstp);
-        // lifeDump();
     }
     void simpleAssign(AstVarScope* nodep, AstNodeAssign* assp) {
         // Do we have a old assignment we can nuke?
@@ -331,15 +306,6 @@ class LifeVisitor final : public VNVisitor {
             m_lifep->simpleAssign(vscp, nodep);
         } else {
             iterateAndNextNull(nodep->lhsp());
-        }
-    }
-    void visit(AstCReset* nodep) override {
-        if (!m_noopt) {
-            AstVarScope* const vscp = nodep->varrefp()->varScopep();
-            UASSERT_OBJ(vscp, nodep, "Scope lost on variable");
-            m_lifep->resetStatement(vscp, nodep);
-        } else {
-            iterateAndNextNull(nodep->varrefp());
         }
     }
     void visit(AstAssignDly* nodep) override {

--- a/src/V3Slice.cpp
+++ b/src/V3Slice.cpp
@@ -241,6 +241,7 @@ class SliceVisitor final : public VNVisitor {
         const AstUnpackArrayDType* const arrayp = VN_CAST(dtp, UnpackArrayDType);
         if (!arrayp) return false;
         if (VN_IS(stp, CvtPackedToArray)) return false;
+        if (VN_IS(stp, CReset)) return false;
 
         // Any isSc variables must be expanded regardless of --fno-slice
         const bool hasSc

--- a/src/V3Task.cpp
+++ b/src/V3Task.cpp
@@ -649,9 +649,11 @@ class TaskVisitor final : public VNVisitor {
                         if (portp->needsCReset() && portp->lifetime().isAutomatic()
                             && !portp->valuep()) {
                             // Reset automatic var to its default, on each invocation of function
-                            AstVarRef* const vrefp
-                                = new AstVarRef{portp->fileline(), portp, VAccess::WRITE};
-                            portp->replaceWith(new AstCReset{portp->fileline(), vrefp, false});
+                            AstNode* const crstp = new AstAssign{
+                                portp->fileline(),
+                                new AstVarRef{portp->fileline(), portp, VAccess::WRITE},
+                                new AstCReset{portp->fileline(), portp, false}};
+                            portp->replaceWith(crstp);
                         } else {
                             portp->unlinkFrBack();
                         }

--- a/test_regress/t/t_json_only_debugcheck.out
+++ b/test_regress/t/t_json_only_debugcheck.out
@@ -928,406 +928,421 @@
     {"type":"CFUNC","name":"_dump_triggers__act","addr":"(CO)","loc":"a,0:0,0:0","slow":true,"isStatic":true,"dpiExportDispatcher":false,"dpiExportImpl":false,"dpiImportPrototype":false,"dpiImportWrapper":false,"dpiContext":false,"isConstructor":false,"isDestructor":false,"isVirtual":false,"isCoroutine":false,"needProcess":false,"scopep":"(Z)",
      "argsp": [
       {"type":"VAR","name":"triggers","addr":"(HO)","loc":"a,0:0,0:0","dtypep":"(W)","origName":"triggers","isSc":false,"isPrimaryIO":false,"isPrimaryClock":false,"direction":"CONSTREF","isConst":false,"isPullup":false,"isPulldown":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":true,"isStdRandomizeArg":false,"lifetime":"NONE","varType":"BLOCKTEMP","dtypeName":"","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"ignorePostWrite":false,"ignoreSchedWrite":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
-      {"type":"CRESET","name":"","addr":"(IO)","loc":"a,0:0,0:0","constructing":true,
-       "varrefp": [
-        {"type":"VARREF","name":"triggers","addr":"(JO)","loc":"a,0:0,0:0","dtypep":"(W)","access":"WR","varp":"(HO)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
-      ]},
-      {"type":"VAR","name":"tag","addr":"(KO)","loc":"a,0:0,0:0","dtypep":"(SB)","origName":"tag","isSc":false,"isPrimaryIO":false,"isPrimaryClock":false,"direction":"CONSTREF","isConst":false,"isPullup":false,"isPulldown":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":true,"isStdRandomizeArg":false,"lifetime":"NONE","varType":"BLOCKTEMP","dtypeName":"string","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"ignorePostWrite":false,"ignoreSchedWrite":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
-      {"type":"CRESET","name":"","addr":"(LO)","loc":"a,0:0,0:0","constructing":true,
-       "varrefp": [
-        {"type":"VARREF","name":"tag","addr":"(MO)","loc":"a,0:0,0:0","dtypep":"(SB)","access":"WR","varp":"(KO)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
-      ]}
+      {"type":"ASSIGN","name":"","addr":"(IO)","loc":"a,0:0,0:0","dtypep":"(W)",
+       "rhsp": [
+        {"type":"CRESET","name":"","addr":"(JO)","loc":"a,0:0,0:0","dtypep":"(W)","constructing":true}
+      ],
+       "lhsp": [
+        {"type":"VARREF","name":"triggers","addr":"(KO)","loc":"a,0:0,0:0","dtypep":"(W)","access":"WR","varp":"(HO)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+      ],"timingControlp": []},
+      {"type":"VAR","name":"tag","addr":"(LO)","loc":"a,0:0,0:0","dtypep":"(SB)","origName":"tag","isSc":false,"isPrimaryIO":false,"isPrimaryClock":false,"direction":"CONSTREF","isConst":false,"isPullup":false,"isPulldown":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":true,"isStdRandomizeArg":false,"lifetime":"NONE","varType":"BLOCKTEMP","dtypeName":"string","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"ignorePostWrite":false,"ignoreSchedWrite":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
+      {"type":"ASSIGN","name":"","addr":"(MO)","loc":"a,0:0,0:0","dtypep":"(SB)",
+       "rhsp": [
+        {"type":"CRESET","name":"","addr":"(NO)","loc":"a,0:0,0:0","dtypep":"(SB)","constructing":true}
+      ],
+       "lhsp": [
+        {"type":"VARREF","name":"tag","addr":"(OO)","loc":"a,0:0,0:0","dtypep":"(SB)","access":"WR","varp":"(LO)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+      ],"timingControlp": []}
     ],"varsp": [],
      "stmtsp": [
-      {"type":"IF","name":"","addr":"(NO)","loc":"d,11:8,11:9",
+      {"type":"IF","name":"","addr":"(PO)","loc":"d,11:8,11:9",
        "condp": [
-        {"type":"AND","name":"","addr":"(OO)","loc":"d,11:8,11:9","dtypep":"(GB)",
+        {"type":"AND","name":"","addr":"(QO)","loc":"d,11:8,11:9","dtypep":"(GB)",
          "lhsp": [
-          {"type":"CONST","name":"32'h1","addr":"(PO)","loc":"d,11:8,11:9","dtypep":"(HC)"}
+          {"type":"CONST","name":"32'h1","addr":"(RO)","loc":"d,11:8,11:9","dtypep":"(HC)"}
         ],
          "rhsp": [
-          {"type":"NOT","name":"","addr":"(QO)","loc":"d,11:8,11:9","dtypep":"(GB)",
+          {"type":"NOT","name":"","addr":"(SO)","loc":"d,11:8,11:9","dtypep":"(GB)",
            "lhsp": [
-            {"type":"CCAST","name":"","addr":"(RO)","loc":"d,11:8,11:9","dtypep":"(GB)","size":32,
+            {"type":"CCAST","name":"","addr":"(TO)","loc":"d,11:8,11:9","dtypep":"(GB)","size":32,
              "lhsp": [
-              {"type":"CCALL","name":"","addr":"(SO)","loc":"d,11:8,11:9","dtypep":"(GB)","funcName":"_trigger_anySet__act","funcp":"(TO)",
+              {"type":"CCALL","name":"","addr":"(UO)","loc":"d,11:8,11:9","dtypep":"(GB)","funcName":"_trigger_anySet__act","funcp":"(VO)",
                "argsp": [
-                {"type":"VARREF","name":"triggers","addr":"(UO)","loc":"d,11:8,11:9","dtypep":"(W)","access":"WR","varp":"(HO)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                {"type":"VARREF","name":"triggers","addr":"(WO)","loc":"d,11:8,11:9","dtypep":"(W)","access":"WR","varp":"(HO)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
               ]}
             ]}
           ]}
         ]}
       ],
        "thensp": [
-        {"type":"CSTMT","name":"","addr":"(VO)","loc":"d,11:8,11:9",
+        {"type":"CSTMT","name":"","addr":"(XO)","loc":"d,11:8,11:9",
          "nodesp": [
-          {"type":"TEXT","name":"","addr":"(WO)","loc":"d,11:8,11:9","text":"VL_DBG_MSGS(\"         No '\" + "},
-          {"type":"VARREF","name":"tag","addr":"(XO)","loc":"d,11:8,11:9","dtypep":"(SB)","access":"RD","varp":"(KO)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"},
-          {"type":"TEXT","name":"","addr":"(YO)","loc":"d,11:8,11:9","text":" + \"' region triggers active\\n\");"}
+          {"type":"TEXT","name":"","addr":"(YO)","loc":"d,11:8,11:9","text":"VL_DBG_MSGS(\"         No '\" + "},
+          {"type":"VARREF","name":"tag","addr":"(ZO)","loc":"d,11:8,11:9","dtypep":"(SB)","access":"RD","varp":"(LO)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"},
+          {"type":"TEXT","name":"","addr":"(AP)","loc":"d,11:8,11:9","text":" + \"' region triggers active\\n\");"}
         ]}
       ],"elsesp": []},
-      {"type":"IF","name":"","addr":"(ZO)","loc":"d,11:8,11:9",
+      {"type":"IF","name":"","addr":"(BP)","loc":"d,11:8,11:9",
        "condp": [
-        {"type":"AND","name":"","addr":"(AP)","loc":"d,11:8,11:9","dtypep":"(GB)",
+        {"type":"AND","name":"","addr":"(CP)","loc":"d,11:8,11:9","dtypep":"(GB)",
          "lhsp": [
-          {"type":"CONST","name":"32'h1","addr":"(BP)","loc":"d,11:8,11:9","dtypep":"(HC)"}
+          {"type":"CONST","name":"32'h1","addr":"(DP)","loc":"d,11:8,11:9","dtypep":"(HC)"}
         ],
          "rhsp": [
-          {"type":"CCAST","name":"","addr":"(CP)","loc":"d,11:8,11:9","dtypep":"(GB)","size":32,
+          {"type":"CCAST","name":"","addr":"(EP)","loc":"d,11:8,11:9","dtypep":"(GB)","size":32,
            "lhsp": [
-            {"type":"ARRAYSEL","name":"","addr":"(DP)","loc":"d,11:8,11:9","dtypep":"(HN)",
+            {"type":"ARRAYSEL","name":"","addr":"(FP)","loc":"d,11:8,11:9","dtypep":"(HN)",
              "fromp": [
-              {"type":"VARREF","name":"triggers","addr":"(EP)","loc":"d,11:8,11:9","dtypep":"(W)","access":"RD","varp":"(HO)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+              {"type":"VARREF","name":"triggers","addr":"(GP)","loc":"d,11:8,11:9","dtypep":"(W)","access":"RD","varp":"(HO)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
             ],
              "bitp": [
-              {"type":"CONST","name":"32'h0","addr":"(FP)","loc":"d,11:8,11:9","dtypep":"(HC)"}
+              {"type":"CONST","name":"32'h0","addr":"(HP)","loc":"d,11:8,11:9","dtypep":"(HC)"}
             ]}
           ]}
         ]}
       ],
        "thensp": [
-        {"type":"CSTMT","name":"","addr":"(GP)","loc":"d,11:8,11:9",
+        {"type":"CSTMT","name":"","addr":"(IP)","loc":"d,11:8,11:9",
          "nodesp": [
-          {"type":"TEXT","name":"","addr":"(HP)","loc":"d,11:8,11:9","text":"VL_DBG_MSGS(\"         '\" + "},
-          {"type":"VARREF","name":"tag","addr":"(IP)","loc":"d,11:8,11:9","dtypep":"(SB)","access":"RD","varp":"(KO)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"},
-          {"type":"TEXT","name":"","addr":"(JP)","loc":"d,11:8,11:9","text":" + \"' region trigger index 0 is active: @(posedge clk)\\n\");"}
+          {"type":"TEXT","name":"","addr":"(JP)","loc":"d,11:8,11:9","text":"VL_DBG_MSGS(\"         '\" + "},
+          {"type":"VARREF","name":"tag","addr":"(KP)","loc":"d,11:8,11:9","dtypep":"(SB)","access":"RD","varp":"(LO)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"},
+          {"type":"TEXT","name":"","addr":"(LP)","loc":"d,11:8,11:9","text":" + \"' region trigger index 0 is active: @(posedge clk)\\n\");"}
         ]}
       ],"elsesp": []}
     ]},
-    {"type":"CFUNC","name":"_trigger_anySet__act","addr":"(TO)","loc":"a,0:0,0:0","slow":false,"isStatic":true,"dpiExportDispatcher":false,"dpiExportImpl":false,"dpiImportPrototype":false,"dpiImportWrapper":false,"dpiContext":false,"isConstructor":false,"isDestructor":false,"isVirtual":false,"isCoroutine":false,"needProcess":false,"scopep":"(Z)",
+    {"type":"CFUNC","name":"_trigger_anySet__act","addr":"(VO)","loc":"a,0:0,0:0","slow":false,"isStatic":true,"dpiExportDispatcher":false,"dpiExportImpl":false,"dpiImportPrototype":false,"dpiImportWrapper":false,"dpiContext":false,"isConstructor":false,"isDestructor":false,"isVirtual":false,"isCoroutine":false,"needProcess":false,"scopep":"(Z)",
      "argsp": [
-      {"type":"VAR","name":"in","addr":"(KP)","loc":"a,0:0,0:0","dtypep":"(W)","origName":"in","isSc":false,"isPrimaryIO":false,"isPrimaryClock":false,"direction":"CONSTREF","isConst":false,"isPullup":false,"isPulldown":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":true,"isStdRandomizeArg":false,"lifetime":"NONE","varType":"BLOCKTEMP","dtypeName":"","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"ignorePostWrite":false,"ignoreSchedWrite":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
-      {"type":"CRESET","name":"","addr":"(LP)","loc":"a,0:0,0:0","constructing":true,
-       "varrefp": [
-        {"type":"VARREF","name":"in","addr":"(MP)","loc":"a,0:0,0:0","dtypep":"(W)","access":"WR","varp":"(KP)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
-      ]}
-    ],
-     "varsp": [
-      {"type":"VAR","name":"n","addr":"(NP)","loc":"a,0:0,0:0","dtypep":"(OP)","origName":"n","isSc":false,"isPrimaryIO":false,"isPrimaryClock":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":true,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":true,"isStdRandomizeArg":false,"lifetime":"NONE","varType":"BLOCKTEMP","dtypeName":"IData","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"ignorePostWrite":false,"ignoreSchedWrite":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []}
-    ],
-     "stmtsp": [
-      {"type":"ASSIGN","name":"","addr":"(PP)","loc":"a,0:0,0:0","dtypep":"(OP)",
+      {"type":"VAR","name":"in","addr":"(MP)","loc":"a,0:0,0:0","dtypep":"(W)","origName":"in","isSc":false,"isPrimaryIO":false,"isPrimaryClock":false,"direction":"CONSTREF","isConst":false,"isPullup":false,"isPulldown":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":true,"isStdRandomizeArg":false,"lifetime":"NONE","varType":"BLOCKTEMP","dtypeName":"","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"ignorePostWrite":false,"ignoreSchedWrite":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
+      {"type":"ASSIGN","name":"","addr":"(NP)","loc":"a,0:0,0:0","dtypep":"(W)",
        "rhsp": [
-        {"type":"CONST","name":"32'h0","addr":"(QP)","loc":"a,0:0,0:0","dtypep":"(HC)"}
+        {"type":"CRESET","name":"","addr":"(OP)","loc":"a,0:0,0:0","dtypep":"(W)","constructing":true}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"n","addr":"(RP)","loc":"a,0:0,0:0","dtypep":"(OP)","access":"WR","varp":"(NP)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"in","addr":"(PP)","loc":"a,0:0,0:0","dtypep":"(W)","access":"WR","varp":"(MP)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+      ],"timingControlp": []}
+    ],
+     "varsp": [
+      {"type":"VAR","name":"n","addr":"(QP)","loc":"a,0:0,0:0","dtypep":"(RP)","origName":"n","isSc":false,"isPrimaryIO":false,"isPrimaryClock":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":true,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":true,"isStdRandomizeArg":false,"lifetime":"NONE","varType":"BLOCKTEMP","dtypeName":"IData","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"ignorePostWrite":false,"ignoreSchedWrite":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []}
+    ],
+     "stmtsp": [
+      {"type":"ASSIGN","name":"","addr":"(SP)","loc":"a,0:0,0:0","dtypep":"(RP)",
+       "rhsp": [
+        {"type":"CONST","name":"32'h0","addr":"(TP)","loc":"a,0:0,0:0","dtypep":"(HC)"}
+      ],
+       "lhsp": [
+        {"type":"VARREF","name":"n","addr":"(UP)","loc":"a,0:0,0:0","dtypep":"(RP)","access":"WR","varp":"(QP)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []},
-      {"type":"LOOP","name":"","addr":"(SP)","loc":"d,11:8,11:9","unroll":"default",
+      {"type":"LOOP","name":"","addr":"(VP)","loc":"d,11:8,11:9","unroll":"default",
        "stmtsp": [
-        {"type":"IF","name":"","addr":"(TP)","loc":"d,11:8,11:9",
+        {"type":"IF","name":"","addr":"(WP)","loc":"d,11:8,11:9",
          "condp": [
-          {"type":"ARRAYSEL","name":"","addr":"(UP)","loc":"d,11:8,11:9","dtypep":"(HN)",
+          {"type":"ARRAYSEL","name":"","addr":"(XP)","loc":"d,11:8,11:9","dtypep":"(HN)",
            "fromp": [
-            {"type":"VARREF","name":"in","addr":"(VP)","loc":"d,11:8,11:9","dtypep":"(W)","access":"RD","varp":"(KP)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"in","addr":"(YP)","loc":"d,11:8,11:9","dtypep":"(W)","access":"RD","varp":"(MP)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ],
            "bitp": [
-            {"type":"VARREF","name":"n","addr":"(WP)","loc":"d,11:8,11:9","dtypep":"(OP)","access":"RD","varp":"(NP)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"n","addr":"(ZP)","loc":"d,11:8,11:9","dtypep":"(RP)","access":"RD","varp":"(QP)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ]}
         ],
          "thensp": [
-          {"type":"CRETURN","name":"","addr":"(XP)","loc":"d,11:8,11:9",
+          {"type":"CRETURN","name":"","addr":"(AQ)","loc":"d,11:8,11:9",
            "lhsp": [
-            {"type":"CONST","name":"1'h1","addr":"(YP)","loc":"d,11:8,11:9","dtypep":"(GB)"}
+            {"type":"CONST","name":"1'h1","addr":"(BQ)","loc":"d,11:8,11:9","dtypep":"(GB)"}
           ]}
         ],"elsesp": []},
-        {"type":"ASSIGN","name":"","addr":"(ZP)","loc":"a,0:0,0:0","dtypep":"(OP)",
+        {"type":"ASSIGN","name":"","addr":"(CQ)","loc":"a,0:0,0:0","dtypep":"(RP)",
          "rhsp": [
-          {"type":"ADD","name":"","addr":"(AQ)","loc":"a,0:0,0:0","dtypep":"(OP)",
+          {"type":"ADD","name":"","addr":"(DQ)","loc":"a,0:0,0:0","dtypep":"(RP)",
            "lhsp": [
-            {"type":"CCAST","name":"","addr":"(BQ)","loc":"a,0:0,0:0","dtypep":"(HC)","size":32,
+            {"type":"CCAST","name":"","addr":"(EQ)","loc":"a,0:0,0:0","dtypep":"(HC)","size":32,
              "lhsp": [
-              {"type":"CONST","name":"32'h1","addr":"(CQ)","loc":"a,0:0,0:0","dtypep":"(HC)"}
+              {"type":"CONST","name":"32'h1","addr":"(FQ)","loc":"a,0:0,0:0","dtypep":"(HC)"}
             ]}
           ],
            "rhsp": [
-            {"type":"VARREF","name":"n","addr":"(DQ)","loc":"a,0:0,0:0","dtypep":"(OP)","access":"RD","varp":"(NP)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"n","addr":"(GQ)","loc":"a,0:0,0:0","dtypep":"(RP)","access":"RD","varp":"(QP)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ]}
         ],
          "lhsp": [
-          {"type":"VARREF","name":"n","addr":"(EQ)","loc":"a,0:0,0:0","dtypep":"(OP)","access":"WR","varp":"(NP)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+          {"type":"VARREF","name":"n","addr":"(HQ)","loc":"a,0:0,0:0","dtypep":"(RP)","access":"WR","varp":"(QP)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
         ],"timingControlp": []},
-        {"type":"LOOPTEST","name":"","addr":"(FQ)","loc":"d,11:8,11:9",
+        {"type":"LOOPTEST","name":"","addr":"(IQ)","loc":"d,11:8,11:9",
          "condp": [
-          {"type":"GT","name":"","addr":"(GQ)","loc":"d,11:8,11:9","dtypep":"(GB)",
+          {"type":"GT","name":"","addr":"(JQ)","loc":"d,11:8,11:9","dtypep":"(GB)",
            "lhsp": [
-            {"type":"CONST","name":"32'h1","addr":"(HQ)","loc":"d,11:8,11:9","dtypep":"(HC)"}
+            {"type":"CONST","name":"32'h1","addr":"(KQ)","loc":"d,11:8,11:9","dtypep":"(HC)"}
           ],
            "rhsp": [
-            {"type":"VARREF","name":"n","addr":"(IQ)","loc":"d,11:8,11:9","dtypep":"(OP)","access":"RD","varp":"(NP)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"n","addr":"(LQ)","loc":"d,11:8,11:9","dtypep":"(RP)","access":"RD","varp":"(QP)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ]}
         ]}
       ],"contsp": []},
-      {"type":"CRETURN","name":"","addr":"(JQ)","loc":"d,11:8,11:9",
+      {"type":"CRETURN","name":"","addr":"(MQ)","loc":"d,11:8,11:9",
        "lhsp": [
-        {"type":"CONST","name":"1'h0","addr":"(KQ)","loc":"d,11:8,11:9","dtypep":"(GB)"}
+        {"type":"CONST","name":"1'h0","addr":"(NQ)","loc":"d,11:8,11:9","dtypep":"(GB)"}
       ]}
     ]},
-    {"type":"CFUNC","name":"_nba_sequent__TOP__0","addr":"(LQ)","loc":"d,23:17,23:20","slow":false,"isStatic":false,"dpiExportDispatcher":false,"dpiExportImpl":false,"dpiImportPrototype":false,"dpiImportWrapper":false,"dpiContext":false,"isConstructor":false,"isDestructor":false,"isVirtual":false,"isCoroutine":false,"needProcess":false,"scopep":"(Z)","argsp": [],
+    {"type":"CFUNC","name":"_nba_sequent__TOP__0","addr":"(OQ)","loc":"d,23:17,23:20","slow":false,"isStatic":false,"dpiExportDispatcher":false,"dpiExportImpl":false,"dpiImportPrototype":false,"dpiImportWrapper":false,"dpiContext":false,"isConstructor":false,"isDestructor":false,"isVirtual":false,"isCoroutine":false,"needProcess":false,"scopep":"(Z)","argsp": [],
      "varsp": [
-      {"type":"VAR","name":"__Vdly__t.cyc","addr":"(MQ)","loc":"d,23:17,23:20","dtypep":"(S)","origName":"__Vdly__t__DOT__cyc","isSc":false,"isPrimaryIO":false,"isPrimaryClock":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":true,"isStdRandomizeArg":false,"lifetime":"NONE","varType":"BLOCKTEMP","dtypeName":"integer","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"ignorePostWrite":false,"ignoreSchedWrite":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
-      {"type":"CRESET","name":"","addr":"(NQ)","loc":"d,23:17,23:20","constructing":true,
-       "varrefp": [
-        {"type":"VARREF","name":"__Vdly__t.cyc","addr":"(OQ)","loc":"d,23:17,23:20","dtypep":"(S)","access":"WR","varp":"(MQ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
-      ]},
-      {"type":"VAR","name":"__Vdly__t.e","addr":"(PQ)","loc":"d,24:9,24:10","dtypep":"(M)","origName":"__Vdly__t__DOT__e","isSc":false,"isPrimaryIO":false,"isPrimaryClock":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":true,"isStdRandomizeArg":false,"lifetime":"NONE","varType":"BLOCKTEMP","dtypeName":"my_t","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"ignorePostWrite":false,"ignoreSchedWrite":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
-      {"type":"CRESET","name":"","addr":"(QQ)","loc":"d,24:9,24:10","constructing":true,
-       "varrefp": [
-        {"type":"VARREF","name":"__Vdly__t.e","addr":"(RQ)","loc":"d,24:9,24:10","dtypep":"(M)","access":"WR","varp":"(PQ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
-      ]},
-      {"type":"VAR","name":"__Vtemp_1","addr":"(SQ)","loc":"d,70:123,70:124","dtypep":"(SB)","origName":"__Vtemp_1","isSc":false,"isPrimaryIO":false,"isPrimaryClock":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"isStdRandomizeArg":false,"lifetime":"NONE","varType":"STMTTEMP","dtypeName":"string","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"ignorePostWrite":false,"ignoreSchedWrite":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
-      {"type":"VAR","name":"__Vtemp_2","addr":"(TQ)","loc":"d,80:123,80:124","dtypep":"(SB)","origName":"__Vtemp_2","isSc":false,"isPrimaryIO":false,"isPrimaryClock":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"isStdRandomizeArg":false,"lifetime":"NONE","varType":"STMTTEMP","dtypeName":"string","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"ignorePostWrite":false,"ignoreSchedWrite":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
-      {"type":"VAR","name":"__Vtemp_3","addr":"(UQ)","loc":"d,90:123,90:124","dtypep":"(SB)","origName":"__Vtemp_3","isSc":false,"isPrimaryIO":false,"isPrimaryClock":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"isStdRandomizeArg":false,"lifetime":"NONE","varType":"STMTTEMP","dtypeName":"string","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"ignorePostWrite":false,"ignoreSchedWrite":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []}
+      {"type":"VAR","name":"__Vdly__t.cyc","addr":"(PQ)","loc":"d,23:17,23:20","dtypep":"(S)","origName":"__Vdly__t__DOT__cyc","isSc":false,"isPrimaryIO":false,"isPrimaryClock":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":true,"isStdRandomizeArg":false,"lifetime":"NONE","varType":"BLOCKTEMP","dtypeName":"integer","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"ignorePostWrite":false,"ignoreSchedWrite":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
+      {"type":"ASSIGN","name":"","addr":"(QQ)","loc":"d,23:17,23:20","dtypep":"(S)",
+       "rhsp": [
+        {"type":"CRESET","name":"","addr":"(RQ)","loc":"d,23:17,23:20","dtypep":"(S)","constructing":true}
+      ],
+       "lhsp": [
+        {"type":"VARREF","name":"__Vdly__t.cyc","addr":"(SQ)","loc":"d,23:17,23:20","dtypep":"(S)","access":"WR","varp":"(PQ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+      ],"timingControlp": []},
+      {"type":"VAR","name":"__Vdly__t.e","addr":"(TQ)","loc":"d,24:9,24:10","dtypep":"(M)","origName":"__Vdly__t__DOT__e","isSc":false,"isPrimaryIO":false,"isPrimaryClock":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":true,"isStdRandomizeArg":false,"lifetime":"NONE","varType":"BLOCKTEMP","dtypeName":"my_t","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"ignorePostWrite":false,"ignoreSchedWrite":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
+      {"type":"ASSIGN","name":"","addr":"(UQ)","loc":"d,24:9,24:10","dtypep":"(M)",
+       "rhsp": [
+        {"type":"CRESET","name":"","addr":"(VQ)","loc":"d,24:9,24:10","dtypep":"(M)","constructing":true}
+      ],
+       "lhsp": [
+        {"type":"VARREF","name":"__Vdly__t.e","addr":"(WQ)","loc":"d,24:9,24:10","dtypep":"(M)","access":"WR","varp":"(TQ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+      ],"timingControlp": []},
+      {"type":"VAR","name":"__Vtemp_1","addr":"(XQ)","loc":"d,70:123,70:124","dtypep":"(SB)","origName":"__Vtemp_1","isSc":false,"isPrimaryIO":false,"isPrimaryClock":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"isStdRandomizeArg":false,"lifetime":"NONE","varType":"STMTTEMP","dtypeName":"string","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"ignorePostWrite":false,"ignoreSchedWrite":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
+      {"type":"VAR","name":"__Vtemp_2","addr":"(YQ)","loc":"d,80:123,80:124","dtypep":"(SB)","origName":"__Vtemp_2","isSc":false,"isPrimaryIO":false,"isPrimaryClock":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"isStdRandomizeArg":false,"lifetime":"NONE","varType":"STMTTEMP","dtypeName":"string","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"ignorePostWrite":false,"ignoreSchedWrite":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
+      {"type":"VAR","name":"__Vtemp_3","addr":"(ZQ)","loc":"d,90:123,90:124","dtypep":"(SB)","origName":"__Vtemp_3","isSc":false,"isPrimaryIO":false,"isPrimaryClock":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"isStdRandomizeArg":false,"lifetime":"NONE","varType":"STMTTEMP","dtypeName":"string","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"ignorePostWrite":false,"ignoreSchedWrite":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []}
     ],
      "stmtsp": [
-      {"type":"ASSIGN","name":"","addr":"(VQ)","loc":"d,23:17,23:20","dtypep":"(S)",
+      {"type":"ASSIGN","name":"","addr":"(AR)","loc":"d,23:17,23:20","dtypep":"(S)",
        "rhsp": [
-        {"type":"VARREF","name":"t.cyc","addr":"(WQ)","loc":"d,23:17,23:20","dtypep":"(S)","access":"RD","varp":"(R)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"t.cyc","addr":"(BR)","loc":"d,23:17,23:20","dtypep":"(S)","access":"RD","varp":"(R)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"__Vdly__t.cyc","addr":"(XQ)","loc":"d,23:17,23:20","dtypep":"(S)","access":"WR","varp":"(MQ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"__Vdly__t.cyc","addr":"(CR)","loc":"d,23:17,23:20","dtypep":"(S)","access":"WR","varp":"(PQ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []},
-      {"type":"ASSIGN","name":"","addr":"(YQ)","loc":"d,24:9,24:10","dtypep":"(UB)",
+      {"type":"ASSIGN","name":"","addr":"(DR)","loc":"d,24:9,24:10","dtypep":"(UB)",
        "rhsp": [
-        {"type":"VARREF","name":"t.e","addr":"(ZQ)","loc":"d,24:9,24:10","dtypep":"(UB)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"t.e","addr":"(ER)","loc":"d,24:9,24:10","dtypep":"(UB)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"__Vdly__t.e","addr":"(AR)","loc":"d,24:9,24:10","dtypep":"(UB)","access":"WR","varp":"(PQ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"__Vdly__t.e","addr":"(FR)","loc":"d,24:9,24:10","dtypep":"(UB)","access":"WR","varp":"(TQ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []},
-      {"type":"ASSIGNDLY","name":"","addr":"(BR)","loc":"d,64:11,64:13","dtypep":"(S)",
+      {"type":"ASSIGNDLY","name":"","addr":"(GR)","loc":"d,64:11,64:13","dtypep":"(S)",
        "rhsp": [
-        {"type":"ADD","name":"","addr":"(CR)","loc":"d,64:18,64:19","dtypep":"(S)",
+        {"type":"ADD","name":"","addr":"(HR)","loc":"d,64:18,64:19","dtypep":"(S)",
          "lhsp": [
-          {"type":"CCAST","name":"","addr":"(DR)","loc":"d,64:20,64:21","dtypep":"(HC)","size":32,
+          {"type":"CCAST","name":"","addr":"(IR)","loc":"d,64:20,64:21","dtypep":"(HC)","size":32,
            "lhsp": [
-            {"type":"CONST","name":"32'sh1","addr":"(ER)","loc":"d,64:20,64:21","dtypep":"(LB)"}
+            {"type":"CONST","name":"32'sh1","addr":"(JR)","loc":"d,64:20,64:21","dtypep":"(LB)"}
           ]}
         ],
          "rhsp": [
-          {"type":"VARREF","name":"t.cyc","addr":"(FR)","loc":"d,64:14,64:17","dtypep":"(S)","access":"RD","varp":"(R)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+          {"type":"VARREF","name":"t.cyc","addr":"(KR)","loc":"d,64:14,64:17","dtypep":"(S)","access":"RD","varp":"(R)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
         ]}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"__Vdly__t.cyc","addr":"(GR)","loc":"d,64:7,64:10","dtypep":"(S)","access":"WR","varp":"(MQ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"__Vdly__t.cyc","addr":"(LR)","loc":"d,64:7,64:10","dtypep":"(S)","access":"WR","varp":"(PQ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []},
-      {"type":"IF","name":"","addr":"(HR)","loc":"d,65:7,65:9",
+      {"type":"IF","name":"","addr":"(MR)","loc":"d,65:7,65:9",
        "condp": [
-        {"type":"EQ","name":"","addr":"(IR)","loc":"d,65:14,65:16","dtypep":"(GB)",
+        {"type":"EQ","name":"","addr":"(NR)","loc":"d,65:14,65:16","dtypep":"(GB)",
          "lhsp": [
-          {"type":"CONST","name":"32'sh0","addr":"(JR)","loc":"d,65:16,65:17","dtypep":"(LB)"}
+          {"type":"CONST","name":"32'sh0","addr":"(OR)","loc":"d,65:16,65:17","dtypep":"(LB)"}
         ],
          "rhsp": [
-          {"type":"VARREF","name":"t.cyc","addr":"(KR)","loc":"d,65:11,65:14","dtypep":"(S)","access":"RD","varp":"(R)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+          {"type":"VARREF","name":"t.cyc","addr":"(PR)","loc":"d,65:11,65:14","dtypep":"(S)","access":"RD","varp":"(R)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
         ]}
       ],
        "thensp": [
-        {"type":"ASSIGNDLY","name":"","addr":"(LR)","loc":"d,67:12,67:14","dtypep":"(UB)",
+        {"type":"ASSIGNDLY","name":"","addr":"(QR)","loc":"d,67:12,67:14","dtypep":"(UB)",
          "rhsp": [
-          {"type":"CONST","name":"4'h1","addr":"(MR)","loc":"d,67:15,67:18","dtypep":"(UB)"}
+          {"type":"CONST","name":"4'h1","addr":"(RR)","loc":"d,67:15,67:18","dtypep":"(UB)"}
         ],
          "lhsp": [
-          {"type":"VARREF","name":"__Vdly__t.e","addr":"(NR)","loc":"d,67:10,67:11","dtypep":"(UB)","access":"WR","varp":"(PQ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+          {"type":"VARREF","name":"__Vdly__t.e","addr":"(SR)","loc":"d,67:10,67:11","dtypep":"(UB)","access":"WR","varp":"(TQ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
         ],"timingControlp": []}
       ],
        "elsesp": [
-        {"type":"IF","name":"","addr":"(OR)","loc":"d,69:12,69:14",
+        {"type":"IF","name":"","addr":"(TR)","loc":"d,69:12,69:14",
          "condp": [
-          {"type":"EQ","name":"","addr":"(PR)","loc":"d,69:19,69:21","dtypep":"(GB)",
+          {"type":"EQ","name":"","addr":"(UR)","loc":"d,69:19,69:21","dtypep":"(GB)",
            "lhsp": [
-            {"type":"CONST","name":"32'sh1","addr":"(QR)","loc":"d,69:21,69:22","dtypep":"(LB)"}
+            {"type":"CONST","name":"32'sh1","addr":"(VR)","loc":"d,69:21,69:22","dtypep":"(LB)"}
           ],
            "rhsp": [
-            {"type":"VARREF","name":"t.cyc","addr":"(RR)","loc":"d,69:16,69:19","dtypep":"(S)","access":"RD","varp":"(R)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"t.cyc","addr":"(WR)","loc":"d,69:16,69:19","dtypep":"(S)","access":"RD","varp":"(R)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ]}
         ],
          "thensp": [
-          {"type":"IF","name":"","addr":"(SR)","loc":"d,70:13,70:15",
+          {"type":"IF","name":"","addr":"(XR)","loc":"d,70:13,70:15",
            "condp": [
-            {"type":"NEQN","name":"","addr":"(TR)","loc":"d,70:26,70:28","dtypep":"(GB)",
+            {"type":"NEQN","name":"","addr":"(YR)","loc":"d,70:26,70:28","dtypep":"(GB)",
              "lhsp": [
-              {"type":"CONST","name":"\\\"E01\\\"","addr":"(UR)","loc":"d,70:30,70:35","dtypep":"(SB)"}
+              {"type":"CONST","name":"\\\"E01\\\"","addr":"(ZR)","loc":"d,70:30,70:35","dtypep":"(SB)"}
             ],
              "rhsp": [
-              {"type":"ARRAYSEL","name":"","addr":"(VR)","loc":"d,70:18,70:19","dtypep":"(SB)",
+              {"type":"ARRAYSEL","name":"","addr":"(AS)","loc":"d,70:18,70:19","dtypep":"(SB)",
                "fromp": [
-                {"type":"VARREF","name":"__Venumtab_enum_name1","addr":"(WR)","loc":"d,17:12,17:16","dtypep":"(IM)","access":"RD","varp":"(JM)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                {"type":"VARREF","name":"__Venumtab_enum_name1","addr":"(BS)","loc":"d,17:12,17:16","dtypep":"(IM)","access":"RD","varp":"(JM)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
               ],
                "bitp": [
-                {"type":"AND","name":"","addr":"(XR)","loc":"d,70:18,70:19","dtypep":"(FC)",
+                {"type":"AND","name":"","addr":"(CS)","loc":"d,70:18,70:19","dtypep":"(FC)",
                  "lhsp": [
-                  {"type":"CONST","name":"32'h7","addr":"(YR)","loc":"d,70:18,70:19","dtypep":"(HC)"}
+                  {"type":"CONST","name":"32'h7","addr":"(DS)","loc":"d,70:18,70:19","dtypep":"(HC)"}
                 ],
                  "rhsp": [
-                  {"type":"CCAST","name":"","addr":"(ZR)","loc":"d,70:18,70:19","dtypep":"(FC)","size":32,
+                  {"type":"CCAST","name":"","addr":"(ES)","loc":"d,70:18,70:19","dtypep":"(FC)","size":32,
                    "lhsp": [
-                    {"type":"VARREF","name":"t.e","addr":"(AS)","loc":"d,70:18,70:19","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"t.e","addr":"(FS)","loc":"d,70:18,70:19","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ]}
                 ]}
               ]}
             ]}
           ],
            "thensp": [
-            {"type":"ASSIGN","name":"","addr":"(BS)","loc":"d,70:123,70:124","dtypep":"(SB)",
+            {"type":"ASSIGN","name":"","addr":"(GS)","loc":"d,70:123,70:124","dtypep":"(SB)",
              "rhsp": [
-              {"type":"ARRAYSEL","name":"","addr":"(CS)","loc":"d,70:123,70:124","dtypep":"(SB)",
+              {"type":"ARRAYSEL","name":"","addr":"(HS)","loc":"d,70:123,70:124","dtypep":"(SB)",
                "fromp": [
-                {"type":"VARREF","name":"__Venumtab_enum_name1","addr":"(DS)","loc":"d,17:12,17:16","dtypep":"(IM)","access":"RD","varp":"(JM)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                {"type":"VARREF","name":"__Venumtab_enum_name1","addr":"(IS)","loc":"d,17:12,17:16","dtypep":"(IM)","access":"RD","varp":"(JM)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
               ],
                "bitp": [
-                {"type":"AND","name":"","addr":"(ES)","loc":"d,70:123,70:124","dtypep":"(FC)",
+                {"type":"AND","name":"","addr":"(JS)","loc":"d,70:123,70:124","dtypep":"(FC)",
                  "lhsp": [
-                  {"type":"CONST","name":"32'h7","addr":"(FS)","loc":"d,70:123,70:124","dtypep":"(HC)"}
+                  {"type":"CONST","name":"32'h7","addr":"(KS)","loc":"d,70:123,70:124","dtypep":"(HC)"}
                 ],
                  "rhsp": [
-                  {"type":"CCAST","name":"","addr":"(GS)","loc":"d,70:123,70:124","dtypep":"(FC)","size":32,
+                  {"type":"CCAST","name":"","addr":"(LS)","loc":"d,70:123,70:124","dtypep":"(FC)","size":32,
                    "lhsp": [
-                    {"type":"VARREF","name":"t.e","addr":"(HS)","loc":"d,70:123,70:124","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"t.e","addr":"(MS)","loc":"d,70:123,70:124","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ]}
                 ]}
               ]}
             ],
              "lhsp": [
-              {"type":"VARREF","name":"__Vtemp_1","addr":"(IS)","loc":"d,70:123,70:124","dtypep":"(SB)","access":"WR","varp":"(SQ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+              {"type":"VARREF","name":"__Vtemp_1","addr":"(NS)","loc":"d,70:123,70:124","dtypep":"(SB)","access":"WR","varp":"(XQ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
             ],"timingControlp": []},
-            {"type":"DISPLAY","name":"","addr":"(JS)","loc":"d,70:44,70:50",
+            {"type":"DISPLAY","name":"","addr":"(OS)","loc":"d,70:44,70:50",
              "fmtp": [
-              {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:70:  got='%@' exp='E01'\\n","addr":"(KS)","loc":"d,70:44,70:50","dtypep":"(SB)",
+              {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:70:  got='%@' exp='E01'\\n","addr":"(PS)","loc":"d,70:44,70:50","dtypep":"(SB)",
                "exprsp": [
-                {"type":"VARREF","name":"__Vtemp_1","addr":"(LS)","loc":"d,70:123,70:124","dtypep":"(SB)","access":"RD","varp":"(SQ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                {"type":"VARREF","name":"__Vtemp_1","addr":"(QS)","loc":"d,70:123,70:124","dtypep":"(SB)","access":"RD","varp":"(XQ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
               ],"scopeNamep": []}
             ],"filep": []},
-            {"type":"STOP","name":"","addr":"(MS)","loc":"d,70:142,70:147","isFatal":false}
+            {"type":"STOP","name":"","addr":"(RS)","loc":"d,70:142,70:147","isFatal":false}
           ],"elsesp": []},
-          {"type":"IF","name":"","addr":"(NS)","loc":"d,71:13,71:15",
+          {"type":"IF","name":"","addr":"(SS)","loc":"d,71:13,71:15",
            "condp": [
-            {"type":"NEQ","name":"","addr":"(OS)","loc":"d,71:26,71:29","dtypep":"(GB)",
+            {"type":"NEQ","name":"","addr":"(TS)","loc":"d,71:26,71:29","dtypep":"(GB)",
              "lhsp": [
-              {"type":"CONST","name":"4'h3","addr":"(PS)","loc":"d,71:31,71:34","dtypep":"(UB)"}
+              {"type":"CONST","name":"4'h3","addr":"(US)","loc":"d,71:31,71:34","dtypep":"(UB)"}
             ],
              "rhsp": [
-              {"type":"ARRAYSEL","name":"","addr":"(QS)","loc":"d,71:18,71:19","dtypep":"(UB)",
+              {"type":"ARRAYSEL","name":"","addr":"(VS)","loc":"d,71:18,71:19","dtypep":"(UB)",
                "fromp": [
-                {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(RS)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(WS)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
               ],
                "bitp": [
-                {"type":"AND","name":"","addr":"(SS)","loc":"d,71:18,71:19","dtypep":"(FC)",
+                {"type":"AND","name":"","addr":"(XS)","loc":"d,71:18,71:19","dtypep":"(FC)",
                  "lhsp": [
-                  {"type":"CONST","name":"32'h7","addr":"(TS)","loc":"d,71:18,71:19","dtypep":"(HC)"}
+                  {"type":"CONST","name":"32'h7","addr":"(YS)","loc":"d,71:18,71:19","dtypep":"(HC)"}
                 ],
                  "rhsp": [
-                  {"type":"CCAST","name":"","addr":"(US)","loc":"d,71:18,71:19","dtypep":"(FC)","size":32,
+                  {"type":"CCAST","name":"","addr":"(ZS)","loc":"d,71:18,71:19","dtypep":"(FC)","size":32,
                    "lhsp": [
-                    {"type":"VARREF","name":"t.e","addr":"(VS)","loc":"d,71:18,71:19","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"t.e","addr":"(AT)","loc":"d,71:18,71:19","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ]}
                 ]}
               ]}
             ]}
           ],
            "thensp": [
-            {"type":"DISPLAY","name":"","addr":"(WS)","loc":"d,71:43,71:49",
+            {"type":"DISPLAY","name":"","addr":"(BT)","loc":"d,71:43,71:49",
              "fmtp": [
-              {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:71:  got='h%x exp='h3\\n","addr":"(XS)","loc":"d,71:43,71:49","dtypep":"(SB)",
+              {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:71:  got='h%x exp='h3\\n","addr":"(CT)","loc":"d,71:43,71:49","dtypep":"(SB)",
                "exprsp": [
-                {"type":"ARRAYSEL","name":"","addr":"(YS)","loc":"d,71:122,71:123","dtypep":"(UB)",
+                {"type":"ARRAYSEL","name":"","addr":"(DT)","loc":"d,71:122,71:123","dtypep":"(UB)",
                  "fromp": [
-                  {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(ZS)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(ET)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                 ],
                  "bitp": [
-                  {"type":"AND","name":"","addr":"(AT)","loc":"d,71:122,71:123","dtypep":"(FC)",
+                  {"type":"AND","name":"","addr":"(FT)","loc":"d,71:122,71:123","dtypep":"(FC)",
                    "lhsp": [
-                    {"type":"CONST","name":"32'h7","addr":"(BT)","loc":"d,71:122,71:123","dtypep":"(HC)"}
+                    {"type":"CONST","name":"32'h7","addr":"(GT)","loc":"d,71:122,71:123","dtypep":"(HC)"}
                   ],
                    "rhsp": [
-                    {"type":"CCAST","name":"","addr":"(CT)","loc":"d,71:122,71:123","dtypep":"(FC)","size":32,
+                    {"type":"CCAST","name":"","addr":"(HT)","loc":"d,71:122,71:123","dtypep":"(FC)","size":32,
                      "lhsp": [
-                      {"type":"VARREF","name":"t.e","addr":"(DT)","loc":"d,71:122,71:123","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"t.e","addr":"(IT)","loc":"d,71:122,71:123","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ]}
                   ]}
                 ]}
               ],"scopeNamep": []}
             ],"filep": []},
-            {"type":"STOP","name":"","addr":"(ET)","loc":"d,71:139,71:144","isFatal":false}
+            {"type":"STOP","name":"","addr":"(JT)","loc":"d,71:139,71:144","isFatal":false}
           ],"elsesp": []},
-          {"type":"IF","name":"","addr":"(FT)","loc":"d,72:13,72:15",
+          {"type":"IF","name":"","addr":"(KT)","loc":"d,72:13,72:15",
            "condp": [
-            {"type":"NEQ","name":"","addr":"(GT)","loc":"d,72:29,72:32","dtypep":"(GB)",
+            {"type":"NEQ","name":"","addr":"(LT)","loc":"d,72:29,72:32","dtypep":"(GB)",
              "lhsp": [
-              {"type":"CONST","name":"4'h3","addr":"(HT)","loc":"d,72:34,72:37","dtypep":"(UB)"}
+              {"type":"CONST","name":"4'h3","addr":"(MT)","loc":"d,72:34,72:37","dtypep":"(UB)"}
             ],
              "rhsp": [
-              {"type":"ARRAYSEL","name":"","addr":"(IT)","loc":"d,72:18,72:19","dtypep":"(UB)",
+              {"type":"ARRAYSEL","name":"","addr":"(NT)","loc":"d,72:18,72:19","dtypep":"(UB)",
                "fromp": [
-                {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(JT)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(OT)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
               ],
                "bitp": [
-                {"type":"AND","name":"","addr":"(KT)","loc":"d,72:18,72:19","dtypep":"(FC)",
+                {"type":"AND","name":"","addr":"(PT)","loc":"d,72:18,72:19","dtypep":"(FC)",
                  "lhsp": [
-                  {"type":"CONST","name":"32'h7","addr":"(LT)","loc":"d,72:18,72:19","dtypep":"(HC)"}
+                  {"type":"CONST","name":"32'h7","addr":"(QT)","loc":"d,72:18,72:19","dtypep":"(HC)"}
                 ],
                  "rhsp": [
-                  {"type":"CCAST","name":"","addr":"(MT)","loc":"d,72:18,72:19","dtypep":"(FC)","size":32,
+                  {"type":"CCAST","name":"","addr":"(RT)","loc":"d,72:18,72:19","dtypep":"(FC)","size":32,
                    "lhsp": [
-                    {"type":"VARREF","name":"t.e","addr":"(NT)","loc":"d,72:18,72:19","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"t.e","addr":"(ST)","loc":"d,72:18,72:19","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ]}
                 ]}
               ]}
             ]}
           ],
            "thensp": [
-            {"type":"DISPLAY","name":"","addr":"(OT)","loc":"d,72:46,72:52",
+            {"type":"DISPLAY","name":"","addr":"(TT)","loc":"d,72:46,72:52",
              "fmtp": [
-              {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:72:  got='h%x exp='h3\\n","addr":"(PT)","loc":"d,72:46,72:52","dtypep":"(SB)",
+              {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:72:  got='h%x exp='h3\\n","addr":"(UT)","loc":"d,72:46,72:52","dtypep":"(SB)",
                "exprsp": [
-                {"type":"ARRAYSEL","name":"","addr":"(QT)","loc":"d,72:125,72:126","dtypep":"(UB)",
+                {"type":"ARRAYSEL","name":"","addr":"(VT)","loc":"d,72:125,72:126","dtypep":"(UB)",
                  "fromp": [
-                  {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(RT)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(WT)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                 ],
                  "bitp": [
-                  {"type":"AND","name":"","addr":"(ST)","loc":"d,72:125,72:126","dtypep":"(FC)",
+                  {"type":"AND","name":"","addr":"(XT)","loc":"d,72:125,72:126","dtypep":"(FC)",
                    "lhsp": [
-                    {"type":"CONST","name":"32'h7","addr":"(TT)","loc":"d,72:125,72:126","dtypep":"(HC)"}
+                    {"type":"CONST","name":"32'h7","addr":"(YT)","loc":"d,72:125,72:126","dtypep":"(HC)"}
                   ],
                    "rhsp": [
-                    {"type":"CCAST","name":"","addr":"(UT)","loc":"d,72:125,72:126","dtypep":"(FC)","size":32,
+                    {"type":"CCAST","name":"","addr":"(ZT)","loc":"d,72:125,72:126","dtypep":"(FC)","size":32,
                      "lhsp": [
-                      {"type":"VARREF","name":"t.e","addr":"(VT)","loc":"d,72:125,72:126","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"t.e","addr":"(AU)","loc":"d,72:125,72:126","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ]}
                   ]}
                 ]}
               ],"scopeNamep": []}
             ],"filep": []},
-            {"type":"STOP","name":"","addr":"(WT)","loc":"d,72:145,72:150","isFatal":false}
+            {"type":"STOP","name":"","addr":"(BU)","loc":"d,72:145,72:150","isFatal":false}
           ],"elsesp": []},
-          {"type":"IF","name":"","addr":"(XT)","loc":"d,73:13,73:15",
+          {"type":"IF","name":"","addr":"(CU)","loc":"d,73:13,73:15",
            "condp": [
-            {"type":"NEQ","name":"","addr":"(YT)","loc":"d,73:29,73:32","dtypep":"(GB)",
+            {"type":"NEQ","name":"","addr":"(DU)","loc":"d,73:29,73:32","dtypep":"(GB)",
              "lhsp": [
-              {"type":"CONST","name":"4'h4","addr":"(ZT)","loc":"d,73:34,73:37","dtypep":"(UB)"}
+              {"type":"CONST","name":"4'h4","addr":"(EU)","loc":"d,73:34,73:37","dtypep":"(UB)"}
             ],
              "rhsp": [
-              {"type":"ARRAYSEL","name":"","addr":"(AU)","loc":"d,73:18,73:19","dtypep":"(UB)",
+              {"type":"ARRAYSEL","name":"","addr":"(FU)","loc":"d,73:18,73:19","dtypep":"(UB)",
                "fromp": [
-                {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(BU)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(GU)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
               ],
                "bitp": [
-                {"type":"AND","name":"","addr":"(CU)","loc":"d,73:18,73:19","dtypep":"(FC)",
+                {"type":"AND","name":"","addr":"(HU)","loc":"d,73:18,73:19","dtypep":"(FC)",
                  "lhsp": [
-                  {"type":"CONST","name":"32'h7","addr":"(DU)","loc":"d,73:18,73:19","dtypep":"(HC)"}
+                  {"type":"CONST","name":"32'h7","addr":"(IU)","loc":"d,73:18,73:19","dtypep":"(HC)"}
                 ],
                  "rhsp": [
-                  {"type":"ARRAYSEL","name":"","addr":"(EU)","loc":"d,73:18,73:19","dtypep":"(FC)",
+                  {"type":"ARRAYSEL","name":"","addr":"(JU)","loc":"d,73:18,73:19","dtypep":"(FC)",
                    "fromp": [
-                    {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(FU)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(KU)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ],
                    "bitp": [
-                    {"type":"AND","name":"","addr":"(GU)","loc":"d,73:18,73:19","dtypep":"(FC)",
+                    {"type":"AND","name":"","addr":"(LU)","loc":"d,73:18,73:19","dtypep":"(FC)",
                      "lhsp": [
-                      {"type":"CONST","name":"32'h7","addr":"(HU)","loc":"d,73:18,73:19","dtypep":"(HC)"}
+                      {"type":"CONST","name":"32'h7","addr":"(MU)","loc":"d,73:18,73:19","dtypep":"(HC)"}
                     ],
                      "rhsp": [
-                      {"type":"CCAST","name":"","addr":"(IU)","loc":"d,73:18,73:19","dtypep":"(FC)","size":32,
+                      {"type":"CCAST","name":"","addr":"(NU)","loc":"d,73:18,73:19","dtypep":"(FC)","size":32,
                        "lhsp": [
-                        {"type":"VARREF","name":"t.e","addr":"(JU)","loc":"d,73:18,73:19","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                        {"type":"VARREF","name":"t.e","addr":"(OU)","loc":"d,73:18,73:19","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                       ]}
                     ]}
                   ]}
@@ -1336,33 +1351,33 @@
             ]}
           ],
            "thensp": [
-            {"type":"DISPLAY","name":"","addr":"(KU)","loc":"d,73:46,73:52",
+            {"type":"DISPLAY","name":"","addr":"(PU)","loc":"d,73:46,73:52",
              "fmtp": [
-              {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:73:  got='h%x exp='h4\\n","addr":"(LU)","loc":"d,73:46,73:52","dtypep":"(SB)",
+              {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:73:  got='h%x exp='h4\\n","addr":"(QU)","loc":"d,73:46,73:52","dtypep":"(SB)",
                "exprsp": [
-                {"type":"ARRAYSEL","name":"","addr":"(MU)","loc":"d,73:125,73:126","dtypep":"(UB)",
+                {"type":"ARRAYSEL","name":"","addr":"(RU)","loc":"d,73:125,73:126","dtypep":"(UB)",
                  "fromp": [
-                  {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(NU)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(SU)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                 ],
                  "bitp": [
-                  {"type":"AND","name":"","addr":"(OU)","loc":"d,73:125,73:126","dtypep":"(FC)",
+                  {"type":"AND","name":"","addr":"(TU)","loc":"d,73:125,73:126","dtypep":"(FC)",
                    "lhsp": [
-                    {"type":"CONST","name":"32'h7","addr":"(PU)","loc":"d,73:125,73:126","dtypep":"(HC)"}
+                    {"type":"CONST","name":"32'h7","addr":"(UU)","loc":"d,73:125,73:126","dtypep":"(HC)"}
                   ],
                    "rhsp": [
-                    {"type":"ARRAYSEL","name":"","addr":"(QU)","loc":"d,73:125,73:126","dtypep":"(FC)",
+                    {"type":"ARRAYSEL","name":"","addr":"(VU)","loc":"d,73:125,73:126","dtypep":"(FC)",
                      "fromp": [
-                      {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(RU)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(WU)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ],
                      "bitp": [
-                      {"type":"AND","name":"","addr":"(SU)","loc":"d,73:125,73:126","dtypep":"(FC)",
+                      {"type":"AND","name":"","addr":"(XU)","loc":"d,73:125,73:126","dtypep":"(FC)",
                        "lhsp": [
-                        {"type":"CONST","name":"32'h7","addr":"(TU)","loc":"d,73:125,73:126","dtypep":"(HC)"}
+                        {"type":"CONST","name":"32'h7","addr":"(YU)","loc":"d,73:125,73:126","dtypep":"(HC)"}
                       ],
                        "rhsp": [
-                        {"type":"CCAST","name":"","addr":"(UU)","loc":"d,73:125,73:126","dtypep":"(FC)","size":32,
+                        {"type":"CCAST","name":"","addr":"(ZU)","loc":"d,73:125,73:126","dtypep":"(FC)","size":32,
                          "lhsp": [
-                          {"type":"VARREF","name":"t.e","addr":"(VU)","loc":"d,73:125,73:126","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                          {"type":"VARREF","name":"t.e","addr":"(AV)","loc":"d,73:125,73:126","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                         ]}
                       ]}
                     ]}
@@ -1370,138 +1385,138 @@
                 ]}
               ],"scopeNamep": []}
             ],"filep": []},
-            {"type":"STOP","name":"","addr":"(WU)","loc":"d,73:145,73:150","isFatal":false}
+            {"type":"STOP","name":"","addr":"(BV)","loc":"d,73:145,73:150","isFatal":false}
           ],"elsesp": []},
-          {"type":"IF","name":"","addr":"(XU)","loc":"d,74:13,74:15",
+          {"type":"IF","name":"","addr":"(CV)","loc":"d,74:13,74:15",
            "condp": [
-            {"type":"NEQ","name":"","addr":"(YU)","loc":"d,74:26,74:29","dtypep":"(GB)",
+            {"type":"NEQ","name":"","addr":"(DV)","loc":"d,74:26,74:29","dtypep":"(GB)",
              "lhsp": [
-              {"type":"CONST","name":"4'h4","addr":"(ZU)","loc":"d,74:31,74:34","dtypep":"(UB)"}
+              {"type":"CONST","name":"4'h4","addr":"(EV)","loc":"d,74:31,74:34","dtypep":"(UB)"}
             ],
              "rhsp": [
-              {"type":"ARRAYSEL","name":"","addr":"(AV)","loc":"d,74:18,74:19","dtypep":"(UB)",
+              {"type":"ARRAYSEL","name":"","addr":"(FV)","loc":"d,74:18,74:19","dtypep":"(UB)",
                "fromp": [
-                {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(BV)","loc":"d,17:12,17:16","dtypep":"(WI)","access":"RD","varp":"(XI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(GV)","loc":"d,17:12,17:16","dtypep":"(WI)","access":"RD","varp":"(XI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
               ],
                "bitp": [
-                {"type":"AND","name":"","addr":"(CV)","loc":"d,74:18,74:19","dtypep":"(FC)",
+                {"type":"AND","name":"","addr":"(HV)","loc":"d,74:18,74:19","dtypep":"(FC)",
                  "lhsp": [
-                  {"type":"CONST","name":"32'h7","addr":"(DV)","loc":"d,74:18,74:19","dtypep":"(HC)"}
+                  {"type":"CONST","name":"32'h7","addr":"(IV)","loc":"d,74:18,74:19","dtypep":"(HC)"}
                 ],
                  "rhsp": [
-                  {"type":"CCAST","name":"","addr":"(EV)","loc":"d,74:18,74:19","dtypep":"(FC)","size":32,
+                  {"type":"CCAST","name":"","addr":"(JV)","loc":"d,74:18,74:19","dtypep":"(FC)","size":32,
                    "lhsp": [
-                    {"type":"VARREF","name":"t.e","addr":"(FV)","loc":"d,74:18,74:19","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"t.e","addr":"(KV)","loc":"d,74:18,74:19","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ]}
                 ]}
               ]}
             ]}
           ],
            "thensp": [
-            {"type":"DISPLAY","name":"","addr":"(GV)","loc":"d,74:43,74:49",
+            {"type":"DISPLAY","name":"","addr":"(LV)","loc":"d,74:43,74:49",
              "fmtp": [
-              {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:74:  got='h%x exp='h4\\n","addr":"(HV)","loc":"d,74:43,74:49","dtypep":"(SB)",
+              {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:74:  got='h%x exp='h4\\n","addr":"(MV)","loc":"d,74:43,74:49","dtypep":"(SB)",
                "exprsp": [
-                {"type":"ARRAYSEL","name":"","addr":"(IV)","loc":"d,74:122,74:123","dtypep":"(UB)",
+                {"type":"ARRAYSEL","name":"","addr":"(NV)","loc":"d,74:122,74:123","dtypep":"(UB)",
                  "fromp": [
-                  {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(JV)","loc":"d,17:12,17:16","dtypep":"(WI)","access":"RD","varp":"(XI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(OV)","loc":"d,17:12,17:16","dtypep":"(WI)","access":"RD","varp":"(XI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                 ],
                  "bitp": [
-                  {"type":"AND","name":"","addr":"(KV)","loc":"d,74:122,74:123","dtypep":"(FC)",
+                  {"type":"AND","name":"","addr":"(PV)","loc":"d,74:122,74:123","dtypep":"(FC)",
                    "lhsp": [
-                    {"type":"CONST","name":"32'h7","addr":"(LV)","loc":"d,74:122,74:123","dtypep":"(HC)"}
+                    {"type":"CONST","name":"32'h7","addr":"(QV)","loc":"d,74:122,74:123","dtypep":"(HC)"}
                   ],
                    "rhsp": [
-                    {"type":"CCAST","name":"","addr":"(MV)","loc":"d,74:122,74:123","dtypep":"(FC)","size":32,
+                    {"type":"CCAST","name":"","addr":"(RV)","loc":"d,74:122,74:123","dtypep":"(FC)","size":32,
                      "lhsp": [
-                      {"type":"VARREF","name":"t.e","addr":"(NV)","loc":"d,74:122,74:123","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"t.e","addr":"(SV)","loc":"d,74:122,74:123","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ]}
                   ]}
                 ]}
               ],"scopeNamep": []}
             ],"filep": []},
-            {"type":"STOP","name":"","addr":"(OV)","loc":"d,74:139,74:144","isFatal":false}
+            {"type":"STOP","name":"","addr":"(TV)","loc":"d,74:139,74:144","isFatal":false}
           ],"elsesp": []},
-          {"type":"IF","name":"","addr":"(PV)","loc":"d,75:13,75:15",
+          {"type":"IF","name":"","addr":"(UV)","loc":"d,75:13,75:15",
            "condp": [
-            {"type":"NEQ","name":"","addr":"(QV)","loc":"d,75:29,75:32","dtypep":"(GB)",
+            {"type":"NEQ","name":"","addr":"(VV)","loc":"d,75:29,75:32","dtypep":"(GB)",
              "lhsp": [
-              {"type":"CONST","name":"4'h4","addr":"(RV)","loc":"d,75:34,75:37","dtypep":"(UB)"}
+              {"type":"CONST","name":"4'h4","addr":"(WV)","loc":"d,75:34,75:37","dtypep":"(UB)"}
             ],
              "rhsp": [
-              {"type":"ARRAYSEL","name":"","addr":"(SV)","loc":"d,75:18,75:19","dtypep":"(UB)",
+              {"type":"ARRAYSEL","name":"","addr":"(XV)","loc":"d,75:18,75:19","dtypep":"(UB)",
                "fromp": [
-                {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(TV)","loc":"d,17:12,17:16","dtypep":"(WI)","access":"RD","varp":"(XI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(YV)","loc":"d,17:12,17:16","dtypep":"(WI)","access":"RD","varp":"(XI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
               ],
                "bitp": [
-                {"type":"AND","name":"","addr":"(UV)","loc":"d,75:18,75:19","dtypep":"(FC)",
+                {"type":"AND","name":"","addr":"(ZV)","loc":"d,75:18,75:19","dtypep":"(FC)",
                  "lhsp": [
-                  {"type":"CONST","name":"32'h7","addr":"(VV)","loc":"d,75:18,75:19","dtypep":"(HC)"}
+                  {"type":"CONST","name":"32'h7","addr":"(AW)","loc":"d,75:18,75:19","dtypep":"(HC)"}
                 ],
                  "rhsp": [
-                  {"type":"CCAST","name":"","addr":"(WV)","loc":"d,75:18,75:19","dtypep":"(FC)","size":32,
+                  {"type":"CCAST","name":"","addr":"(BW)","loc":"d,75:18,75:19","dtypep":"(FC)","size":32,
                    "lhsp": [
-                    {"type":"VARREF","name":"t.e","addr":"(XV)","loc":"d,75:18,75:19","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"t.e","addr":"(CW)","loc":"d,75:18,75:19","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ]}
                 ]}
               ]}
             ]}
           ],
            "thensp": [
-            {"type":"DISPLAY","name":"","addr":"(YV)","loc":"d,75:46,75:52",
+            {"type":"DISPLAY","name":"","addr":"(DW)","loc":"d,75:46,75:52",
              "fmtp": [
-              {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:75:  got='h%x exp='h4\\n","addr":"(ZV)","loc":"d,75:46,75:52","dtypep":"(SB)",
+              {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:75:  got='h%x exp='h4\\n","addr":"(EW)","loc":"d,75:46,75:52","dtypep":"(SB)",
                "exprsp": [
-                {"type":"ARRAYSEL","name":"","addr":"(AW)","loc":"d,75:125,75:126","dtypep":"(UB)",
+                {"type":"ARRAYSEL","name":"","addr":"(FW)","loc":"d,75:125,75:126","dtypep":"(UB)",
                  "fromp": [
-                  {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(BW)","loc":"d,17:12,17:16","dtypep":"(WI)","access":"RD","varp":"(XI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(GW)","loc":"d,17:12,17:16","dtypep":"(WI)","access":"RD","varp":"(XI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                 ],
                  "bitp": [
-                  {"type":"AND","name":"","addr":"(CW)","loc":"d,75:125,75:126","dtypep":"(FC)",
+                  {"type":"AND","name":"","addr":"(HW)","loc":"d,75:125,75:126","dtypep":"(FC)",
                    "lhsp": [
-                    {"type":"CONST","name":"32'h7","addr":"(DW)","loc":"d,75:125,75:126","dtypep":"(HC)"}
+                    {"type":"CONST","name":"32'h7","addr":"(IW)","loc":"d,75:125,75:126","dtypep":"(HC)"}
                   ],
                    "rhsp": [
-                    {"type":"CCAST","name":"","addr":"(EW)","loc":"d,75:125,75:126","dtypep":"(FC)","size":32,
+                    {"type":"CCAST","name":"","addr":"(JW)","loc":"d,75:125,75:126","dtypep":"(FC)","size":32,
                      "lhsp": [
-                      {"type":"VARREF","name":"t.e","addr":"(FW)","loc":"d,75:125,75:126","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"t.e","addr":"(KW)","loc":"d,75:125,75:126","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ]}
                   ]}
                 ]}
               ],"scopeNamep": []}
             ],"filep": []},
-            {"type":"STOP","name":"","addr":"(GW)","loc":"d,75:145,75:150","isFatal":false}
+            {"type":"STOP","name":"","addr":"(LW)","loc":"d,75:145,75:150","isFatal":false}
           ],"elsesp": []},
-          {"type":"IF","name":"","addr":"(HW)","loc":"d,76:13,76:15",
+          {"type":"IF","name":"","addr":"(MW)","loc":"d,76:13,76:15",
            "condp": [
-            {"type":"NEQ","name":"","addr":"(IW)","loc":"d,76:29,76:32","dtypep":"(GB)",
+            {"type":"NEQ","name":"","addr":"(NW)","loc":"d,76:29,76:32","dtypep":"(GB)",
              "lhsp": [
-              {"type":"CONST","name":"4'h3","addr":"(JW)","loc":"d,76:34,76:37","dtypep":"(UB)"}
+              {"type":"CONST","name":"4'h3","addr":"(OW)","loc":"d,76:34,76:37","dtypep":"(UB)"}
             ],
              "rhsp": [
-              {"type":"ARRAYSEL","name":"","addr":"(KW)","loc":"d,76:18,76:19","dtypep":"(UB)",
+              {"type":"ARRAYSEL","name":"","addr":"(PW)","loc":"d,76:18,76:19","dtypep":"(UB)",
                "fromp": [
-                {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(LW)","loc":"d,17:12,17:16","dtypep":"(WI)","access":"RD","varp":"(XI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(QW)","loc":"d,17:12,17:16","dtypep":"(WI)","access":"RD","varp":"(XI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
               ],
                "bitp": [
-                {"type":"AND","name":"","addr":"(MW)","loc":"d,76:18,76:19","dtypep":"(FC)",
+                {"type":"AND","name":"","addr":"(RW)","loc":"d,76:18,76:19","dtypep":"(FC)",
                  "lhsp": [
-                  {"type":"CONST","name":"32'h7","addr":"(NW)","loc":"d,76:18,76:19","dtypep":"(HC)"}
+                  {"type":"CONST","name":"32'h7","addr":"(SW)","loc":"d,76:18,76:19","dtypep":"(HC)"}
                 ],
                  "rhsp": [
-                  {"type":"ARRAYSEL","name":"","addr":"(OW)","loc":"d,76:18,76:19","dtypep":"(FC)",
+                  {"type":"ARRAYSEL","name":"","addr":"(TW)","loc":"d,76:18,76:19","dtypep":"(FC)",
                    "fromp": [
-                    {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(PW)","loc":"d,17:12,17:16","dtypep":"(WI)","access":"RD","varp":"(XI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(UW)","loc":"d,17:12,17:16","dtypep":"(WI)","access":"RD","varp":"(XI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ],
                    "bitp": [
-                    {"type":"AND","name":"","addr":"(QW)","loc":"d,76:18,76:19","dtypep":"(FC)",
+                    {"type":"AND","name":"","addr":"(VW)","loc":"d,76:18,76:19","dtypep":"(FC)",
                      "lhsp": [
-                      {"type":"CONST","name":"32'h7","addr":"(RW)","loc":"d,76:18,76:19","dtypep":"(HC)"}
+                      {"type":"CONST","name":"32'h7","addr":"(WW)","loc":"d,76:18,76:19","dtypep":"(HC)"}
                     ],
                      "rhsp": [
-                      {"type":"CCAST","name":"","addr":"(SW)","loc":"d,76:18,76:19","dtypep":"(FC)","size":32,
+                      {"type":"CCAST","name":"","addr":"(XW)","loc":"d,76:18,76:19","dtypep":"(FC)","size":32,
                        "lhsp": [
-                        {"type":"VARREF","name":"t.e","addr":"(TW)","loc":"d,76:18,76:19","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                        {"type":"VARREF","name":"t.e","addr":"(YW)","loc":"d,76:18,76:19","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                       ]}
                     ]}
                   ]}
@@ -1510,33 +1525,33 @@
             ]}
           ],
            "thensp": [
-            {"type":"DISPLAY","name":"","addr":"(UW)","loc":"d,76:46,76:52",
+            {"type":"DISPLAY","name":"","addr":"(ZW)","loc":"d,76:46,76:52",
              "fmtp": [
-              {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:76:  got='h%x exp='h3\\n","addr":"(VW)","loc":"d,76:46,76:52","dtypep":"(SB)",
+              {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:76:  got='h%x exp='h3\\n","addr":"(AX)","loc":"d,76:46,76:52","dtypep":"(SB)",
                "exprsp": [
-                {"type":"ARRAYSEL","name":"","addr":"(WW)","loc":"d,76:125,76:126","dtypep":"(UB)",
+                {"type":"ARRAYSEL","name":"","addr":"(BX)","loc":"d,76:125,76:126","dtypep":"(UB)",
                  "fromp": [
-                  {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(XW)","loc":"d,17:12,17:16","dtypep":"(WI)","access":"RD","varp":"(XI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(CX)","loc":"d,17:12,17:16","dtypep":"(WI)","access":"RD","varp":"(XI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                 ],
                  "bitp": [
-                  {"type":"AND","name":"","addr":"(YW)","loc":"d,76:125,76:126","dtypep":"(FC)",
+                  {"type":"AND","name":"","addr":"(DX)","loc":"d,76:125,76:126","dtypep":"(FC)",
                    "lhsp": [
-                    {"type":"CONST","name":"32'h7","addr":"(ZW)","loc":"d,76:125,76:126","dtypep":"(HC)"}
+                    {"type":"CONST","name":"32'h7","addr":"(EX)","loc":"d,76:125,76:126","dtypep":"(HC)"}
                   ],
                    "rhsp": [
-                    {"type":"ARRAYSEL","name":"","addr":"(AX)","loc":"d,76:125,76:126","dtypep":"(FC)",
+                    {"type":"ARRAYSEL","name":"","addr":"(FX)","loc":"d,76:125,76:126","dtypep":"(FC)",
                      "fromp": [
-                      {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(BX)","loc":"d,17:12,17:16","dtypep":"(WI)","access":"RD","varp":"(XI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(GX)","loc":"d,17:12,17:16","dtypep":"(WI)","access":"RD","varp":"(XI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ],
                      "bitp": [
-                      {"type":"AND","name":"","addr":"(CX)","loc":"d,76:125,76:126","dtypep":"(FC)",
+                      {"type":"AND","name":"","addr":"(HX)","loc":"d,76:125,76:126","dtypep":"(FC)",
                        "lhsp": [
-                        {"type":"CONST","name":"32'h7","addr":"(DX)","loc":"d,76:125,76:126","dtypep":"(HC)"}
+                        {"type":"CONST","name":"32'h7","addr":"(IX)","loc":"d,76:125,76:126","dtypep":"(HC)"}
                       ],
                        "rhsp": [
-                        {"type":"CCAST","name":"","addr":"(EX)","loc":"d,76:125,76:126","dtypep":"(FC)","size":32,
+                        {"type":"CCAST","name":"","addr":"(JX)","loc":"d,76:125,76:126","dtypep":"(FC)","size":32,
                          "lhsp": [
-                          {"type":"VARREF","name":"t.e","addr":"(FX)","loc":"d,76:125,76:126","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                          {"type":"VARREF","name":"t.e","addr":"(KX)","loc":"d,76:125,76:126","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                         ]}
                       ]}
                     ]}
@@ -1544,215 +1559,215 @@
                 ]}
               ],"scopeNamep": []}
             ],"filep": []},
-            {"type":"STOP","name":"","addr":"(GX)","loc":"d,76:145,76:150","isFatal":false}
+            {"type":"STOP","name":"","addr":"(LX)","loc":"d,76:145,76:150","isFatal":false}
           ],"elsesp": []},
-          {"type":"ASSIGNDLY","name":"","addr":"(HX)","loc":"d,77:12,77:14","dtypep":"(UB)",
+          {"type":"ASSIGNDLY","name":"","addr":"(MX)","loc":"d,77:12,77:14","dtypep":"(UB)",
            "rhsp": [
-            {"type":"CONST","name":"4'h3","addr":"(IX)","loc":"d,77:15,77:18","dtypep":"(UB)"}
+            {"type":"CONST","name":"4'h3","addr":"(NX)","loc":"d,77:15,77:18","dtypep":"(UB)"}
           ],
            "lhsp": [
-            {"type":"VARREF","name":"__Vdly__t.e","addr":"(JX)","loc":"d,77:10,77:11","dtypep":"(UB)","access":"WR","varp":"(PQ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"__Vdly__t.e","addr":"(OX)","loc":"d,77:10,77:11","dtypep":"(UB)","access":"WR","varp":"(TQ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ],"timingControlp": []}
         ],
          "elsesp": [
-          {"type":"IF","name":"","addr":"(KX)","loc":"d,79:12,79:14",
+          {"type":"IF","name":"","addr":"(PX)","loc":"d,79:12,79:14",
            "condp": [
-            {"type":"EQ","name":"","addr":"(LX)","loc":"d,79:19,79:21","dtypep":"(GB)",
+            {"type":"EQ","name":"","addr":"(QX)","loc":"d,79:19,79:21","dtypep":"(GB)",
              "lhsp": [
-              {"type":"CONST","name":"32'sh2","addr":"(MX)","loc":"d,79:21,79:22","dtypep":"(LB)"}
+              {"type":"CONST","name":"32'sh2","addr":"(RX)","loc":"d,79:21,79:22","dtypep":"(LB)"}
             ],
              "rhsp": [
-              {"type":"VARREF","name":"t.cyc","addr":"(NX)","loc":"d,79:16,79:19","dtypep":"(S)","access":"RD","varp":"(R)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+              {"type":"VARREF","name":"t.cyc","addr":"(SX)","loc":"d,79:16,79:19","dtypep":"(S)","access":"RD","varp":"(R)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
             ]}
           ],
            "thensp": [
-            {"type":"IF","name":"","addr":"(OX)","loc":"d,80:13,80:15",
+            {"type":"IF","name":"","addr":"(TX)","loc":"d,80:13,80:15",
              "condp": [
-              {"type":"NEQN","name":"","addr":"(PX)","loc":"d,80:26,80:28","dtypep":"(GB)",
+              {"type":"NEQN","name":"","addr":"(UX)","loc":"d,80:26,80:28","dtypep":"(GB)",
                "lhsp": [
-                {"type":"CONST","name":"\\\"E03\\\"","addr":"(QX)","loc":"d,80:30,80:35","dtypep":"(SB)"}
+                {"type":"CONST","name":"\\\"E03\\\"","addr":"(VX)","loc":"d,80:30,80:35","dtypep":"(SB)"}
               ],
                "rhsp": [
-                {"type":"ARRAYSEL","name":"","addr":"(RX)","loc":"d,80:18,80:19","dtypep":"(SB)",
+                {"type":"ARRAYSEL","name":"","addr":"(WX)","loc":"d,80:18,80:19","dtypep":"(SB)",
                  "fromp": [
-                  {"type":"VARREF","name":"__Venumtab_enum_name1","addr":"(SX)","loc":"d,17:12,17:16","dtypep":"(IM)","access":"RD","varp":"(JM)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"__Venumtab_enum_name1","addr":"(XX)","loc":"d,17:12,17:16","dtypep":"(IM)","access":"RD","varp":"(JM)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                 ],
                  "bitp": [
-                  {"type":"AND","name":"","addr":"(TX)","loc":"d,80:18,80:19","dtypep":"(FC)",
+                  {"type":"AND","name":"","addr":"(YX)","loc":"d,80:18,80:19","dtypep":"(FC)",
                    "lhsp": [
-                    {"type":"CONST","name":"32'h7","addr":"(UX)","loc":"d,80:18,80:19","dtypep":"(HC)"}
+                    {"type":"CONST","name":"32'h7","addr":"(ZX)","loc":"d,80:18,80:19","dtypep":"(HC)"}
                   ],
                    "rhsp": [
-                    {"type":"CCAST","name":"","addr":"(VX)","loc":"d,80:18,80:19","dtypep":"(FC)","size":32,
+                    {"type":"CCAST","name":"","addr":"(AY)","loc":"d,80:18,80:19","dtypep":"(FC)","size":32,
                      "lhsp": [
-                      {"type":"VARREF","name":"t.e","addr":"(WX)","loc":"d,80:18,80:19","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"t.e","addr":"(BY)","loc":"d,80:18,80:19","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ]}
                   ]}
                 ]}
               ]}
             ],
              "thensp": [
-              {"type":"ASSIGN","name":"","addr":"(XX)","loc":"d,80:123,80:124","dtypep":"(SB)",
+              {"type":"ASSIGN","name":"","addr":"(CY)","loc":"d,80:123,80:124","dtypep":"(SB)",
                "rhsp": [
-                {"type":"ARRAYSEL","name":"","addr":"(YX)","loc":"d,80:123,80:124","dtypep":"(SB)",
+                {"type":"ARRAYSEL","name":"","addr":"(DY)","loc":"d,80:123,80:124","dtypep":"(SB)",
                  "fromp": [
-                  {"type":"VARREF","name":"__Venumtab_enum_name1","addr":"(ZX)","loc":"d,17:12,17:16","dtypep":"(IM)","access":"RD","varp":"(JM)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"__Venumtab_enum_name1","addr":"(EY)","loc":"d,17:12,17:16","dtypep":"(IM)","access":"RD","varp":"(JM)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                 ],
                  "bitp": [
-                  {"type":"AND","name":"","addr":"(AY)","loc":"d,80:123,80:124","dtypep":"(FC)",
+                  {"type":"AND","name":"","addr":"(FY)","loc":"d,80:123,80:124","dtypep":"(FC)",
                    "lhsp": [
-                    {"type":"CONST","name":"32'h7","addr":"(BY)","loc":"d,80:123,80:124","dtypep":"(HC)"}
+                    {"type":"CONST","name":"32'h7","addr":"(GY)","loc":"d,80:123,80:124","dtypep":"(HC)"}
                   ],
                    "rhsp": [
-                    {"type":"CCAST","name":"","addr":"(CY)","loc":"d,80:123,80:124","dtypep":"(FC)","size":32,
+                    {"type":"CCAST","name":"","addr":"(HY)","loc":"d,80:123,80:124","dtypep":"(FC)","size":32,
                      "lhsp": [
-                      {"type":"VARREF","name":"t.e","addr":"(DY)","loc":"d,80:123,80:124","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"t.e","addr":"(IY)","loc":"d,80:123,80:124","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ]}
                   ]}
                 ]}
               ],
                "lhsp": [
-                {"type":"VARREF","name":"__Vtemp_2","addr":"(EY)","loc":"d,80:123,80:124","dtypep":"(SB)","access":"WR","varp":"(TQ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                {"type":"VARREF","name":"__Vtemp_2","addr":"(JY)","loc":"d,80:123,80:124","dtypep":"(SB)","access":"WR","varp":"(YQ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
               ],"timingControlp": []},
-              {"type":"DISPLAY","name":"","addr":"(FY)","loc":"d,80:44,80:50",
+              {"type":"DISPLAY","name":"","addr":"(KY)","loc":"d,80:44,80:50",
                "fmtp": [
-                {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:80:  got='%@' exp='E03'\\n","addr":"(GY)","loc":"d,80:44,80:50","dtypep":"(SB)",
+                {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:80:  got='%@' exp='E03'\\n","addr":"(LY)","loc":"d,80:44,80:50","dtypep":"(SB)",
                  "exprsp": [
-                  {"type":"VARREF","name":"__Vtemp_2","addr":"(HY)","loc":"d,80:123,80:124","dtypep":"(SB)","access":"RD","varp":"(TQ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"__Vtemp_2","addr":"(MY)","loc":"d,80:123,80:124","dtypep":"(SB)","access":"RD","varp":"(YQ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                 ],"scopeNamep": []}
               ],"filep": []},
-              {"type":"STOP","name":"","addr":"(IY)","loc":"d,80:142,80:147","isFatal":false}
+              {"type":"STOP","name":"","addr":"(NY)","loc":"d,80:142,80:147","isFatal":false}
             ],"elsesp": []},
-            {"type":"IF","name":"","addr":"(JY)","loc":"d,81:13,81:15",
+            {"type":"IF","name":"","addr":"(OY)","loc":"d,81:13,81:15",
              "condp": [
-              {"type":"NEQ","name":"","addr":"(KY)","loc":"d,81:26,81:29","dtypep":"(GB)",
+              {"type":"NEQ","name":"","addr":"(PY)","loc":"d,81:26,81:29","dtypep":"(GB)",
                "lhsp": [
-                {"type":"CONST","name":"4'h4","addr":"(LY)","loc":"d,81:31,81:34","dtypep":"(UB)"}
+                {"type":"CONST","name":"4'h4","addr":"(QY)","loc":"d,81:31,81:34","dtypep":"(UB)"}
               ],
                "rhsp": [
-                {"type":"ARRAYSEL","name":"","addr":"(MY)","loc":"d,81:18,81:19","dtypep":"(UB)",
+                {"type":"ARRAYSEL","name":"","addr":"(RY)","loc":"d,81:18,81:19","dtypep":"(UB)",
                  "fromp": [
-                  {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(NY)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(SY)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                 ],
                  "bitp": [
-                  {"type":"AND","name":"","addr":"(OY)","loc":"d,81:18,81:19","dtypep":"(FC)",
+                  {"type":"AND","name":"","addr":"(TY)","loc":"d,81:18,81:19","dtypep":"(FC)",
                    "lhsp": [
-                    {"type":"CONST","name":"32'h7","addr":"(PY)","loc":"d,81:18,81:19","dtypep":"(HC)"}
+                    {"type":"CONST","name":"32'h7","addr":"(UY)","loc":"d,81:18,81:19","dtypep":"(HC)"}
                   ],
                    "rhsp": [
-                    {"type":"CCAST","name":"","addr":"(QY)","loc":"d,81:18,81:19","dtypep":"(FC)","size":32,
+                    {"type":"CCAST","name":"","addr":"(VY)","loc":"d,81:18,81:19","dtypep":"(FC)","size":32,
                      "lhsp": [
-                      {"type":"VARREF","name":"t.e","addr":"(RY)","loc":"d,81:18,81:19","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"t.e","addr":"(WY)","loc":"d,81:18,81:19","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ]}
                   ]}
                 ]}
               ]}
             ],
              "thensp": [
-              {"type":"DISPLAY","name":"","addr":"(SY)","loc":"d,81:43,81:49",
+              {"type":"DISPLAY","name":"","addr":"(XY)","loc":"d,81:43,81:49",
                "fmtp": [
-                {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:81:  got='h%x exp='h4\\n","addr":"(TY)","loc":"d,81:43,81:49","dtypep":"(SB)",
+                {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:81:  got='h%x exp='h4\\n","addr":"(YY)","loc":"d,81:43,81:49","dtypep":"(SB)",
                  "exprsp": [
-                  {"type":"ARRAYSEL","name":"","addr":"(UY)","loc":"d,81:122,81:123","dtypep":"(UB)",
+                  {"type":"ARRAYSEL","name":"","addr":"(ZY)","loc":"d,81:122,81:123","dtypep":"(UB)",
                    "fromp": [
-                    {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(VY)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(AZ)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ],
                    "bitp": [
-                    {"type":"AND","name":"","addr":"(WY)","loc":"d,81:122,81:123","dtypep":"(FC)",
+                    {"type":"AND","name":"","addr":"(BZ)","loc":"d,81:122,81:123","dtypep":"(FC)",
                      "lhsp": [
-                      {"type":"CONST","name":"32'h7","addr":"(XY)","loc":"d,81:122,81:123","dtypep":"(HC)"}
+                      {"type":"CONST","name":"32'h7","addr":"(CZ)","loc":"d,81:122,81:123","dtypep":"(HC)"}
                     ],
                      "rhsp": [
-                      {"type":"CCAST","name":"","addr":"(YY)","loc":"d,81:122,81:123","dtypep":"(FC)","size":32,
+                      {"type":"CCAST","name":"","addr":"(DZ)","loc":"d,81:122,81:123","dtypep":"(FC)","size":32,
                        "lhsp": [
-                        {"type":"VARREF","name":"t.e","addr":"(ZY)","loc":"d,81:122,81:123","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                        {"type":"VARREF","name":"t.e","addr":"(EZ)","loc":"d,81:122,81:123","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                       ]}
                     ]}
                   ]}
                 ],"scopeNamep": []}
               ],"filep": []},
-              {"type":"STOP","name":"","addr":"(AZ)","loc":"d,81:139,81:144","isFatal":false}
+              {"type":"STOP","name":"","addr":"(FZ)","loc":"d,81:139,81:144","isFatal":false}
             ],"elsesp": []},
-            {"type":"IF","name":"","addr":"(BZ)","loc":"d,82:13,82:15",
+            {"type":"IF","name":"","addr":"(GZ)","loc":"d,82:13,82:15",
              "condp": [
-              {"type":"NEQ","name":"","addr":"(CZ)","loc":"d,82:29,82:32","dtypep":"(GB)",
+              {"type":"NEQ","name":"","addr":"(HZ)","loc":"d,82:29,82:32","dtypep":"(GB)",
                "lhsp": [
-                {"type":"CONST","name":"4'h4","addr":"(DZ)","loc":"d,82:34,82:37","dtypep":"(UB)"}
+                {"type":"CONST","name":"4'h4","addr":"(IZ)","loc":"d,82:34,82:37","dtypep":"(UB)"}
               ],
                "rhsp": [
-                {"type":"ARRAYSEL","name":"","addr":"(EZ)","loc":"d,82:18,82:19","dtypep":"(UB)",
+                {"type":"ARRAYSEL","name":"","addr":"(JZ)","loc":"d,82:18,82:19","dtypep":"(UB)",
                  "fromp": [
-                  {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(FZ)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(KZ)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                 ],
                  "bitp": [
-                  {"type":"AND","name":"","addr":"(GZ)","loc":"d,82:18,82:19","dtypep":"(FC)",
+                  {"type":"AND","name":"","addr":"(LZ)","loc":"d,82:18,82:19","dtypep":"(FC)",
                    "lhsp": [
-                    {"type":"CONST","name":"32'h7","addr":"(HZ)","loc":"d,82:18,82:19","dtypep":"(HC)"}
+                    {"type":"CONST","name":"32'h7","addr":"(MZ)","loc":"d,82:18,82:19","dtypep":"(HC)"}
                   ],
                    "rhsp": [
-                    {"type":"CCAST","name":"","addr":"(IZ)","loc":"d,82:18,82:19","dtypep":"(FC)","size":32,
+                    {"type":"CCAST","name":"","addr":"(NZ)","loc":"d,82:18,82:19","dtypep":"(FC)","size":32,
                      "lhsp": [
-                      {"type":"VARREF","name":"t.e","addr":"(JZ)","loc":"d,82:18,82:19","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"t.e","addr":"(OZ)","loc":"d,82:18,82:19","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ]}
                   ]}
                 ]}
               ]}
             ],
              "thensp": [
-              {"type":"DISPLAY","name":"","addr":"(KZ)","loc":"d,82:46,82:52",
+              {"type":"DISPLAY","name":"","addr":"(PZ)","loc":"d,82:46,82:52",
                "fmtp": [
-                {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:82:  got='h%x exp='h4\\n","addr":"(LZ)","loc":"d,82:46,82:52","dtypep":"(SB)",
+                {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:82:  got='h%x exp='h4\\n","addr":"(QZ)","loc":"d,82:46,82:52","dtypep":"(SB)",
                  "exprsp": [
-                  {"type":"ARRAYSEL","name":"","addr":"(MZ)","loc":"d,82:125,82:126","dtypep":"(UB)",
+                  {"type":"ARRAYSEL","name":"","addr":"(RZ)","loc":"d,82:125,82:126","dtypep":"(UB)",
                    "fromp": [
-                    {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(NZ)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(SZ)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ],
                    "bitp": [
-                    {"type":"AND","name":"","addr":"(OZ)","loc":"d,82:125,82:126","dtypep":"(FC)",
+                    {"type":"AND","name":"","addr":"(TZ)","loc":"d,82:125,82:126","dtypep":"(FC)",
                      "lhsp": [
-                      {"type":"CONST","name":"32'h7","addr":"(PZ)","loc":"d,82:125,82:126","dtypep":"(HC)"}
+                      {"type":"CONST","name":"32'h7","addr":"(UZ)","loc":"d,82:125,82:126","dtypep":"(HC)"}
                     ],
                      "rhsp": [
-                      {"type":"CCAST","name":"","addr":"(QZ)","loc":"d,82:125,82:126","dtypep":"(FC)","size":32,
+                      {"type":"CCAST","name":"","addr":"(VZ)","loc":"d,82:125,82:126","dtypep":"(FC)","size":32,
                        "lhsp": [
-                        {"type":"VARREF","name":"t.e","addr":"(RZ)","loc":"d,82:125,82:126","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                        {"type":"VARREF","name":"t.e","addr":"(WZ)","loc":"d,82:125,82:126","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                       ]}
                     ]}
                   ]}
                 ],"scopeNamep": []}
               ],"filep": []},
-              {"type":"STOP","name":"","addr":"(SZ)","loc":"d,82:145,82:150","isFatal":false}
+              {"type":"STOP","name":"","addr":"(XZ)","loc":"d,82:145,82:150","isFatal":false}
             ],"elsesp": []},
-            {"type":"IF","name":"","addr":"(TZ)","loc":"d,83:13,83:15",
+            {"type":"IF","name":"","addr":"(YZ)","loc":"d,83:13,83:15",
              "condp": [
-              {"type":"NEQ","name":"","addr":"(UZ)","loc":"d,83:29,83:32","dtypep":"(GB)",
+              {"type":"NEQ","name":"","addr":"(ZZ)","loc":"d,83:29,83:32","dtypep":"(GB)",
                "lhsp": [
-                {"type":"CONST","name":"4'h1","addr":"(VZ)","loc":"d,83:34,83:37","dtypep":"(UB)"}
+                {"type":"CONST","name":"4'h1","addr":"(AAB)","loc":"d,83:34,83:37","dtypep":"(UB)"}
               ],
                "rhsp": [
-                {"type":"ARRAYSEL","name":"","addr":"(WZ)","loc":"d,83:18,83:19","dtypep":"(UB)",
+                {"type":"ARRAYSEL","name":"","addr":"(BAB)","loc":"d,83:18,83:19","dtypep":"(UB)",
                  "fromp": [
-                  {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(XZ)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(CAB)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                 ],
                  "bitp": [
-                  {"type":"AND","name":"","addr":"(YZ)","loc":"d,83:18,83:19","dtypep":"(FC)",
+                  {"type":"AND","name":"","addr":"(DAB)","loc":"d,83:18,83:19","dtypep":"(FC)",
                    "lhsp": [
-                    {"type":"CONST","name":"32'h7","addr":"(ZZ)","loc":"d,83:18,83:19","dtypep":"(HC)"}
+                    {"type":"CONST","name":"32'h7","addr":"(EAB)","loc":"d,83:18,83:19","dtypep":"(HC)"}
                   ],
                    "rhsp": [
-                    {"type":"ARRAYSEL","name":"","addr":"(AAB)","loc":"d,83:18,83:19","dtypep":"(FC)",
+                    {"type":"ARRAYSEL","name":"","addr":"(FAB)","loc":"d,83:18,83:19","dtypep":"(FC)",
                      "fromp": [
-                      {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(BAB)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(GAB)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ],
                      "bitp": [
-                      {"type":"AND","name":"","addr":"(CAB)","loc":"d,83:18,83:19","dtypep":"(FC)",
+                      {"type":"AND","name":"","addr":"(HAB)","loc":"d,83:18,83:19","dtypep":"(FC)",
                        "lhsp": [
-                        {"type":"CONST","name":"32'h7","addr":"(DAB)","loc":"d,83:18,83:19","dtypep":"(HC)"}
+                        {"type":"CONST","name":"32'h7","addr":"(IAB)","loc":"d,83:18,83:19","dtypep":"(HC)"}
                       ],
                        "rhsp": [
-                        {"type":"CCAST","name":"","addr":"(EAB)","loc":"d,83:18,83:19","dtypep":"(FC)","size":32,
+                        {"type":"CCAST","name":"","addr":"(JAB)","loc":"d,83:18,83:19","dtypep":"(FC)","size":32,
                          "lhsp": [
-                          {"type":"VARREF","name":"t.e","addr":"(FAB)","loc":"d,83:18,83:19","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                          {"type":"VARREF","name":"t.e","addr":"(KAB)","loc":"d,83:18,83:19","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                         ]}
                       ]}
                     ]}
@@ -1761,33 +1776,33 @@
               ]}
             ],
              "thensp": [
-              {"type":"DISPLAY","name":"","addr":"(GAB)","loc":"d,83:46,83:52",
+              {"type":"DISPLAY","name":"","addr":"(LAB)","loc":"d,83:46,83:52",
                "fmtp": [
-                {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:83:  got='h%x exp='h1\\n","addr":"(HAB)","loc":"d,83:46,83:52","dtypep":"(SB)",
+                {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:83:  got='h%x exp='h1\\n","addr":"(MAB)","loc":"d,83:46,83:52","dtypep":"(SB)",
                  "exprsp": [
-                  {"type":"ARRAYSEL","name":"","addr":"(IAB)","loc":"d,83:125,83:126","dtypep":"(UB)",
+                  {"type":"ARRAYSEL","name":"","addr":"(NAB)","loc":"d,83:125,83:126","dtypep":"(UB)",
                    "fromp": [
-                    {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(JAB)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(OAB)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ],
                    "bitp": [
-                    {"type":"AND","name":"","addr":"(KAB)","loc":"d,83:125,83:126","dtypep":"(FC)",
+                    {"type":"AND","name":"","addr":"(PAB)","loc":"d,83:125,83:126","dtypep":"(FC)",
                      "lhsp": [
-                      {"type":"CONST","name":"32'h7","addr":"(LAB)","loc":"d,83:125,83:126","dtypep":"(HC)"}
+                      {"type":"CONST","name":"32'h7","addr":"(QAB)","loc":"d,83:125,83:126","dtypep":"(HC)"}
                     ],
                      "rhsp": [
-                      {"type":"ARRAYSEL","name":"","addr":"(MAB)","loc":"d,83:125,83:126","dtypep":"(FC)",
+                      {"type":"ARRAYSEL","name":"","addr":"(RAB)","loc":"d,83:125,83:126","dtypep":"(FC)",
                        "fromp": [
-                        {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(NAB)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                        {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(SAB)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                       ],
                        "bitp": [
-                        {"type":"AND","name":"","addr":"(OAB)","loc":"d,83:125,83:126","dtypep":"(FC)",
+                        {"type":"AND","name":"","addr":"(TAB)","loc":"d,83:125,83:126","dtypep":"(FC)",
                          "lhsp": [
-                          {"type":"CONST","name":"32'h7","addr":"(PAB)","loc":"d,83:125,83:126","dtypep":"(HC)"}
+                          {"type":"CONST","name":"32'h7","addr":"(UAB)","loc":"d,83:125,83:126","dtypep":"(HC)"}
                         ],
                          "rhsp": [
-                          {"type":"CCAST","name":"","addr":"(QAB)","loc":"d,83:125,83:126","dtypep":"(FC)","size":32,
+                          {"type":"CCAST","name":"","addr":"(VAB)","loc":"d,83:125,83:126","dtypep":"(FC)","size":32,
                            "lhsp": [
-                            {"type":"VARREF","name":"t.e","addr":"(RAB)","loc":"d,83:125,83:126","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                            {"type":"VARREF","name":"t.e","addr":"(WAB)","loc":"d,83:125,83:126","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                           ]}
                         ]}
                       ]}
@@ -1795,138 +1810,138 @@
                   ]}
                 ],"scopeNamep": []}
               ],"filep": []},
-              {"type":"STOP","name":"","addr":"(SAB)","loc":"d,83:145,83:150","isFatal":false}
+              {"type":"STOP","name":"","addr":"(XAB)","loc":"d,83:145,83:150","isFatal":false}
             ],"elsesp": []},
-            {"type":"IF","name":"","addr":"(TAB)","loc":"d,84:13,84:15",
+            {"type":"IF","name":"","addr":"(YAB)","loc":"d,84:13,84:15",
              "condp": [
-              {"type":"NEQ","name":"","addr":"(UAB)","loc":"d,84:26,84:29","dtypep":"(GB)",
+              {"type":"NEQ","name":"","addr":"(ZAB)","loc":"d,84:26,84:29","dtypep":"(GB)",
                "lhsp": [
-                {"type":"CONST","name":"4'h1","addr":"(VAB)","loc":"d,84:31,84:34","dtypep":"(UB)"}
+                {"type":"CONST","name":"4'h1","addr":"(ABB)","loc":"d,84:31,84:34","dtypep":"(UB)"}
               ],
                "rhsp": [
-                {"type":"ARRAYSEL","name":"","addr":"(WAB)","loc":"d,84:18,84:19","dtypep":"(UB)",
+                {"type":"ARRAYSEL","name":"","addr":"(BBB)","loc":"d,84:18,84:19","dtypep":"(UB)",
                  "fromp": [
-                  {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(XAB)","loc":"d,17:12,17:16","dtypep":"(WI)","access":"RD","varp":"(XI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(CBB)","loc":"d,17:12,17:16","dtypep":"(WI)","access":"RD","varp":"(XI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                 ],
                  "bitp": [
-                  {"type":"AND","name":"","addr":"(YAB)","loc":"d,84:18,84:19","dtypep":"(FC)",
+                  {"type":"AND","name":"","addr":"(DBB)","loc":"d,84:18,84:19","dtypep":"(FC)",
                    "lhsp": [
-                    {"type":"CONST","name":"32'h7","addr":"(ZAB)","loc":"d,84:18,84:19","dtypep":"(HC)"}
+                    {"type":"CONST","name":"32'h7","addr":"(EBB)","loc":"d,84:18,84:19","dtypep":"(HC)"}
                   ],
                    "rhsp": [
-                    {"type":"CCAST","name":"","addr":"(ABB)","loc":"d,84:18,84:19","dtypep":"(FC)","size":32,
+                    {"type":"CCAST","name":"","addr":"(FBB)","loc":"d,84:18,84:19","dtypep":"(FC)","size":32,
                      "lhsp": [
-                      {"type":"VARREF","name":"t.e","addr":"(BBB)","loc":"d,84:18,84:19","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"t.e","addr":"(GBB)","loc":"d,84:18,84:19","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ]}
                   ]}
                 ]}
               ]}
             ],
              "thensp": [
-              {"type":"DISPLAY","name":"","addr":"(CBB)","loc":"d,84:43,84:49",
+              {"type":"DISPLAY","name":"","addr":"(HBB)","loc":"d,84:43,84:49",
                "fmtp": [
-                {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:84:  got='h%x exp='h1\\n","addr":"(DBB)","loc":"d,84:43,84:49","dtypep":"(SB)",
+                {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:84:  got='h%x exp='h1\\n","addr":"(IBB)","loc":"d,84:43,84:49","dtypep":"(SB)",
                  "exprsp": [
-                  {"type":"ARRAYSEL","name":"","addr":"(EBB)","loc":"d,84:122,84:123","dtypep":"(UB)",
+                  {"type":"ARRAYSEL","name":"","addr":"(JBB)","loc":"d,84:122,84:123","dtypep":"(UB)",
                    "fromp": [
-                    {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(FBB)","loc":"d,17:12,17:16","dtypep":"(WI)","access":"RD","varp":"(XI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(KBB)","loc":"d,17:12,17:16","dtypep":"(WI)","access":"RD","varp":"(XI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ],
                    "bitp": [
-                    {"type":"AND","name":"","addr":"(GBB)","loc":"d,84:122,84:123","dtypep":"(FC)",
+                    {"type":"AND","name":"","addr":"(LBB)","loc":"d,84:122,84:123","dtypep":"(FC)",
                      "lhsp": [
-                      {"type":"CONST","name":"32'h7","addr":"(HBB)","loc":"d,84:122,84:123","dtypep":"(HC)"}
+                      {"type":"CONST","name":"32'h7","addr":"(MBB)","loc":"d,84:122,84:123","dtypep":"(HC)"}
                     ],
                      "rhsp": [
-                      {"type":"CCAST","name":"","addr":"(IBB)","loc":"d,84:122,84:123","dtypep":"(FC)","size":32,
+                      {"type":"CCAST","name":"","addr":"(NBB)","loc":"d,84:122,84:123","dtypep":"(FC)","size":32,
                        "lhsp": [
-                        {"type":"VARREF","name":"t.e","addr":"(JBB)","loc":"d,84:122,84:123","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                        {"type":"VARREF","name":"t.e","addr":"(OBB)","loc":"d,84:122,84:123","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                       ]}
                     ]}
                   ]}
                 ],"scopeNamep": []}
               ],"filep": []},
-              {"type":"STOP","name":"","addr":"(KBB)","loc":"d,84:139,84:144","isFatal":false}
+              {"type":"STOP","name":"","addr":"(PBB)","loc":"d,84:139,84:144","isFatal":false}
             ],"elsesp": []},
-            {"type":"IF","name":"","addr":"(LBB)","loc":"d,85:13,85:15",
+            {"type":"IF","name":"","addr":"(QBB)","loc":"d,85:13,85:15",
              "condp": [
-              {"type":"NEQ","name":"","addr":"(MBB)","loc":"d,85:29,85:32","dtypep":"(GB)",
+              {"type":"NEQ","name":"","addr":"(RBB)","loc":"d,85:29,85:32","dtypep":"(GB)",
                "lhsp": [
-                {"type":"CONST","name":"4'h1","addr":"(NBB)","loc":"d,85:34,85:37","dtypep":"(UB)"}
+                {"type":"CONST","name":"4'h1","addr":"(SBB)","loc":"d,85:34,85:37","dtypep":"(UB)"}
               ],
                "rhsp": [
-                {"type":"ARRAYSEL","name":"","addr":"(OBB)","loc":"d,85:18,85:19","dtypep":"(UB)",
+                {"type":"ARRAYSEL","name":"","addr":"(TBB)","loc":"d,85:18,85:19","dtypep":"(UB)",
                  "fromp": [
-                  {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(PBB)","loc":"d,17:12,17:16","dtypep":"(WI)","access":"RD","varp":"(XI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(UBB)","loc":"d,17:12,17:16","dtypep":"(WI)","access":"RD","varp":"(XI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                 ],
                  "bitp": [
-                  {"type":"AND","name":"","addr":"(QBB)","loc":"d,85:18,85:19","dtypep":"(FC)",
+                  {"type":"AND","name":"","addr":"(VBB)","loc":"d,85:18,85:19","dtypep":"(FC)",
                    "lhsp": [
-                    {"type":"CONST","name":"32'h7","addr":"(RBB)","loc":"d,85:18,85:19","dtypep":"(HC)"}
+                    {"type":"CONST","name":"32'h7","addr":"(WBB)","loc":"d,85:18,85:19","dtypep":"(HC)"}
                   ],
                    "rhsp": [
-                    {"type":"CCAST","name":"","addr":"(SBB)","loc":"d,85:18,85:19","dtypep":"(FC)","size":32,
+                    {"type":"CCAST","name":"","addr":"(XBB)","loc":"d,85:18,85:19","dtypep":"(FC)","size":32,
                      "lhsp": [
-                      {"type":"VARREF","name":"t.e","addr":"(TBB)","loc":"d,85:18,85:19","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"t.e","addr":"(YBB)","loc":"d,85:18,85:19","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ]}
                   ]}
                 ]}
               ]}
             ],
              "thensp": [
-              {"type":"DISPLAY","name":"","addr":"(UBB)","loc":"d,85:46,85:52",
+              {"type":"DISPLAY","name":"","addr":"(ZBB)","loc":"d,85:46,85:52",
                "fmtp": [
-                {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:85:  got='h%x exp='h1\\n","addr":"(VBB)","loc":"d,85:46,85:52","dtypep":"(SB)",
+                {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:85:  got='h%x exp='h1\\n","addr":"(ACB)","loc":"d,85:46,85:52","dtypep":"(SB)",
                  "exprsp": [
-                  {"type":"ARRAYSEL","name":"","addr":"(WBB)","loc":"d,85:125,85:126","dtypep":"(UB)",
+                  {"type":"ARRAYSEL","name":"","addr":"(BCB)","loc":"d,85:125,85:126","dtypep":"(UB)",
                    "fromp": [
-                    {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(XBB)","loc":"d,17:12,17:16","dtypep":"(WI)","access":"RD","varp":"(XI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(CCB)","loc":"d,17:12,17:16","dtypep":"(WI)","access":"RD","varp":"(XI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ],
                    "bitp": [
-                    {"type":"AND","name":"","addr":"(YBB)","loc":"d,85:125,85:126","dtypep":"(FC)",
+                    {"type":"AND","name":"","addr":"(DCB)","loc":"d,85:125,85:126","dtypep":"(FC)",
                      "lhsp": [
-                      {"type":"CONST","name":"32'h7","addr":"(ZBB)","loc":"d,85:125,85:126","dtypep":"(HC)"}
+                      {"type":"CONST","name":"32'h7","addr":"(ECB)","loc":"d,85:125,85:126","dtypep":"(HC)"}
                     ],
                      "rhsp": [
-                      {"type":"CCAST","name":"","addr":"(ACB)","loc":"d,85:125,85:126","dtypep":"(FC)","size":32,
+                      {"type":"CCAST","name":"","addr":"(FCB)","loc":"d,85:125,85:126","dtypep":"(FC)","size":32,
                        "lhsp": [
-                        {"type":"VARREF","name":"t.e","addr":"(BCB)","loc":"d,85:125,85:126","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                        {"type":"VARREF","name":"t.e","addr":"(GCB)","loc":"d,85:125,85:126","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                       ]}
                     ]}
                   ]}
                 ],"scopeNamep": []}
               ],"filep": []},
-              {"type":"STOP","name":"","addr":"(CCB)","loc":"d,85:145,85:150","isFatal":false}
+              {"type":"STOP","name":"","addr":"(HCB)","loc":"d,85:145,85:150","isFatal":false}
             ],"elsesp": []},
-            {"type":"IF","name":"","addr":"(DCB)","loc":"d,86:13,86:15",
+            {"type":"IF","name":"","addr":"(ICB)","loc":"d,86:13,86:15",
              "condp": [
-              {"type":"NEQ","name":"","addr":"(ECB)","loc":"d,86:29,86:32","dtypep":"(GB)",
+              {"type":"NEQ","name":"","addr":"(JCB)","loc":"d,86:29,86:32","dtypep":"(GB)",
                "lhsp": [
-                {"type":"CONST","name":"4'h4","addr":"(FCB)","loc":"d,86:34,86:37","dtypep":"(UB)"}
+                {"type":"CONST","name":"4'h4","addr":"(KCB)","loc":"d,86:34,86:37","dtypep":"(UB)"}
               ],
                "rhsp": [
-                {"type":"ARRAYSEL","name":"","addr":"(GCB)","loc":"d,86:18,86:19","dtypep":"(UB)",
+                {"type":"ARRAYSEL","name":"","addr":"(LCB)","loc":"d,86:18,86:19","dtypep":"(UB)",
                  "fromp": [
-                  {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(HCB)","loc":"d,17:12,17:16","dtypep":"(WI)","access":"RD","varp":"(XI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(MCB)","loc":"d,17:12,17:16","dtypep":"(WI)","access":"RD","varp":"(XI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                 ],
                  "bitp": [
-                  {"type":"AND","name":"","addr":"(ICB)","loc":"d,86:18,86:19","dtypep":"(FC)",
+                  {"type":"AND","name":"","addr":"(NCB)","loc":"d,86:18,86:19","dtypep":"(FC)",
                    "lhsp": [
-                    {"type":"CONST","name":"32'h7","addr":"(JCB)","loc":"d,86:18,86:19","dtypep":"(HC)"}
+                    {"type":"CONST","name":"32'h7","addr":"(OCB)","loc":"d,86:18,86:19","dtypep":"(HC)"}
                   ],
                    "rhsp": [
-                    {"type":"ARRAYSEL","name":"","addr":"(KCB)","loc":"d,86:18,86:19","dtypep":"(FC)",
+                    {"type":"ARRAYSEL","name":"","addr":"(PCB)","loc":"d,86:18,86:19","dtypep":"(FC)",
                      "fromp": [
-                      {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(LCB)","loc":"d,17:12,17:16","dtypep":"(WI)","access":"RD","varp":"(XI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(QCB)","loc":"d,17:12,17:16","dtypep":"(WI)","access":"RD","varp":"(XI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ],
                      "bitp": [
-                      {"type":"AND","name":"","addr":"(MCB)","loc":"d,86:18,86:19","dtypep":"(FC)",
+                      {"type":"AND","name":"","addr":"(RCB)","loc":"d,86:18,86:19","dtypep":"(FC)",
                        "lhsp": [
-                        {"type":"CONST","name":"32'h7","addr":"(NCB)","loc":"d,86:18,86:19","dtypep":"(HC)"}
+                        {"type":"CONST","name":"32'h7","addr":"(SCB)","loc":"d,86:18,86:19","dtypep":"(HC)"}
                       ],
                        "rhsp": [
-                        {"type":"CCAST","name":"","addr":"(OCB)","loc":"d,86:18,86:19","dtypep":"(FC)","size":32,
+                        {"type":"CCAST","name":"","addr":"(TCB)","loc":"d,86:18,86:19","dtypep":"(FC)","size":32,
                          "lhsp": [
-                          {"type":"VARREF","name":"t.e","addr":"(PCB)","loc":"d,86:18,86:19","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                          {"type":"VARREF","name":"t.e","addr":"(UCB)","loc":"d,86:18,86:19","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                         ]}
                       ]}
                     ]}
@@ -1935,33 +1950,33 @@
               ]}
             ],
              "thensp": [
-              {"type":"DISPLAY","name":"","addr":"(QCB)","loc":"d,86:46,86:52",
+              {"type":"DISPLAY","name":"","addr":"(VCB)","loc":"d,86:46,86:52",
                "fmtp": [
-                {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:86:  got='h%x exp='h4\\n","addr":"(RCB)","loc":"d,86:46,86:52","dtypep":"(SB)",
+                {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:86:  got='h%x exp='h4\\n","addr":"(WCB)","loc":"d,86:46,86:52","dtypep":"(SB)",
                  "exprsp": [
-                  {"type":"ARRAYSEL","name":"","addr":"(SCB)","loc":"d,86:125,86:126","dtypep":"(UB)",
+                  {"type":"ARRAYSEL","name":"","addr":"(XCB)","loc":"d,86:125,86:126","dtypep":"(UB)",
                    "fromp": [
-                    {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(TCB)","loc":"d,17:12,17:16","dtypep":"(WI)","access":"RD","varp":"(XI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(YCB)","loc":"d,17:12,17:16","dtypep":"(WI)","access":"RD","varp":"(XI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ],
                    "bitp": [
-                    {"type":"AND","name":"","addr":"(UCB)","loc":"d,86:125,86:126","dtypep":"(FC)",
+                    {"type":"AND","name":"","addr":"(ZCB)","loc":"d,86:125,86:126","dtypep":"(FC)",
                      "lhsp": [
-                      {"type":"CONST","name":"32'h7","addr":"(VCB)","loc":"d,86:125,86:126","dtypep":"(HC)"}
+                      {"type":"CONST","name":"32'h7","addr":"(ADB)","loc":"d,86:125,86:126","dtypep":"(HC)"}
                     ],
                      "rhsp": [
-                      {"type":"ARRAYSEL","name":"","addr":"(WCB)","loc":"d,86:125,86:126","dtypep":"(FC)",
+                      {"type":"ARRAYSEL","name":"","addr":"(BDB)","loc":"d,86:125,86:126","dtypep":"(FC)",
                        "fromp": [
-                        {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(XCB)","loc":"d,17:12,17:16","dtypep":"(WI)","access":"RD","varp":"(XI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                        {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(CDB)","loc":"d,17:12,17:16","dtypep":"(WI)","access":"RD","varp":"(XI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                       ],
                        "bitp": [
-                        {"type":"AND","name":"","addr":"(YCB)","loc":"d,86:125,86:126","dtypep":"(FC)",
+                        {"type":"AND","name":"","addr":"(DDB)","loc":"d,86:125,86:126","dtypep":"(FC)",
                          "lhsp": [
-                          {"type":"CONST","name":"32'h7","addr":"(ZCB)","loc":"d,86:125,86:126","dtypep":"(HC)"}
+                          {"type":"CONST","name":"32'h7","addr":"(EDB)","loc":"d,86:125,86:126","dtypep":"(HC)"}
                         ],
                          "rhsp": [
-                          {"type":"CCAST","name":"","addr":"(ADB)","loc":"d,86:125,86:126","dtypep":"(FC)","size":32,
+                          {"type":"CCAST","name":"","addr":"(FDB)","loc":"d,86:125,86:126","dtypep":"(FC)","size":32,
                            "lhsp": [
-                            {"type":"VARREF","name":"t.e","addr":"(BDB)","loc":"d,86:125,86:126","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                            {"type":"VARREF","name":"t.e","addr":"(GDB)","loc":"d,86:125,86:126","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                           ]}
                         ]}
                       ]}
@@ -1969,215 +1984,215 @@
                   ]}
                 ],"scopeNamep": []}
               ],"filep": []},
-              {"type":"STOP","name":"","addr":"(CDB)","loc":"d,86:145,86:150","isFatal":false}
+              {"type":"STOP","name":"","addr":"(HDB)","loc":"d,86:145,86:150","isFatal":false}
             ],"elsesp": []},
-            {"type":"ASSIGNDLY","name":"","addr":"(DDB)","loc":"d,87:12,87:14","dtypep":"(UB)",
+            {"type":"ASSIGNDLY","name":"","addr":"(IDB)","loc":"d,87:12,87:14","dtypep":"(UB)",
              "rhsp": [
-              {"type":"CONST","name":"4'h4","addr":"(EDB)","loc":"d,87:15,87:18","dtypep":"(UB)"}
+              {"type":"CONST","name":"4'h4","addr":"(JDB)","loc":"d,87:15,87:18","dtypep":"(UB)"}
             ],
              "lhsp": [
-              {"type":"VARREF","name":"__Vdly__t.e","addr":"(FDB)","loc":"d,87:10,87:11","dtypep":"(UB)","access":"WR","varp":"(PQ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+              {"type":"VARREF","name":"__Vdly__t.e","addr":"(KDB)","loc":"d,87:10,87:11","dtypep":"(UB)","access":"WR","varp":"(TQ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
             ],"timingControlp": []}
           ],
            "elsesp": [
-            {"type":"IF","name":"","addr":"(GDB)","loc":"d,89:12,89:14",
+            {"type":"IF","name":"","addr":"(LDB)","loc":"d,89:12,89:14",
              "condp": [
-              {"type":"EQ","name":"","addr":"(HDB)","loc":"d,89:19,89:21","dtypep":"(GB)",
+              {"type":"EQ","name":"","addr":"(MDB)","loc":"d,89:19,89:21","dtypep":"(GB)",
                "lhsp": [
-                {"type":"CONST","name":"32'sh3","addr":"(IDB)","loc":"d,89:21,89:22","dtypep":"(LB)"}
+                {"type":"CONST","name":"32'sh3","addr":"(NDB)","loc":"d,89:21,89:22","dtypep":"(LB)"}
               ],
                "rhsp": [
-                {"type":"VARREF","name":"t.cyc","addr":"(JDB)","loc":"d,89:16,89:19","dtypep":"(S)","access":"RD","varp":"(R)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                {"type":"VARREF","name":"t.cyc","addr":"(ODB)","loc":"d,89:16,89:19","dtypep":"(S)","access":"RD","varp":"(R)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
               ]}
             ],
              "thensp": [
-              {"type":"IF","name":"","addr":"(KDB)","loc":"d,90:13,90:15",
+              {"type":"IF","name":"","addr":"(PDB)","loc":"d,90:13,90:15",
                "condp": [
-                {"type":"NEQN","name":"","addr":"(LDB)","loc":"d,90:26,90:28","dtypep":"(GB)",
+                {"type":"NEQN","name":"","addr":"(QDB)","loc":"d,90:26,90:28","dtypep":"(GB)",
                  "lhsp": [
-                  {"type":"CONST","name":"\\\"E04\\\"","addr":"(MDB)","loc":"d,90:30,90:35","dtypep":"(SB)"}
+                  {"type":"CONST","name":"\\\"E04\\\"","addr":"(RDB)","loc":"d,90:30,90:35","dtypep":"(SB)"}
                 ],
                  "rhsp": [
-                  {"type":"ARRAYSEL","name":"","addr":"(NDB)","loc":"d,90:18,90:19","dtypep":"(SB)",
+                  {"type":"ARRAYSEL","name":"","addr":"(SDB)","loc":"d,90:18,90:19","dtypep":"(SB)",
                    "fromp": [
-                    {"type":"VARREF","name":"__Venumtab_enum_name1","addr":"(ODB)","loc":"d,17:12,17:16","dtypep":"(IM)","access":"RD","varp":"(JM)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"__Venumtab_enum_name1","addr":"(TDB)","loc":"d,17:12,17:16","dtypep":"(IM)","access":"RD","varp":"(JM)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ],
                    "bitp": [
-                    {"type":"AND","name":"","addr":"(PDB)","loc":"d,90:18,90:19","dtypep":"(FC)",
+                    {"type":"AND","name":"","addr":"(UDB)","loc":"d,90:18,90:19","dtypep":"(FC)",
                      "lhsp": [
-                      {"type":"CONST","name":"32'h7","addr":"(QDB)","loc":"d,90:18,90:19","dtypep":"(HC)"}
+                      {"type":"CONST","name":"32'h7","addr":"(VDB)","loc":"d,90:18,90:19","dtypep":"(HC)"}
                     ],
                      "rhsp": [
-                      {"type":"CCAST","name":"","addr":"(RDB)","loc":"d,90:18,90:19","dtypep":"(FC)","size":32,
+                      {"type":"CCAST","name":"","addr":"(WDB)","loc":"d,90:18,90:19","dtypep":"(FC)","size":32,
                        "lhsp": [
-                        {"type":"VARREF","name":"t.e","addr":"(SDB)","loc":"d,90:18,90:19","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                        {"type":"VARREF","name":"t.e","addr":"(XDB)","loc":"d,90:18,90:19","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                       ]}
                     ]}
                   ]}
                 ]}
               ],
                "thensp": [
-                {"type":"ASSIGN","name":"","addr":"(TDB)","loc":"d,90:123,90:124","dtypep":"(SB)",
+                {"type":"ASSIGN","name":"","addr":"(YDB)","loc":"d,90:123,90:124","dtypep":"(SB)",
                  "rhsp": [
-                  {"type":"ARRAYSEL","name":"","addr":"(UDB)","loc":"d,90:123,90:124","dtypep":"(SB)",
+                  {"type":"ARRAYSEL","name":"","addr":"(ZDB)","loc":"d,90:123,90:124","dtypep":"(SB)",
                    "fromp": [
-                    {"type":"VARREF","name":"__Venumtab_enum_name1","addr":"(VDB)","loc":"d,17:12,17:16","dtypep":"(IM)","access":"RD","varp":"(JM)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"__Venumtab_enum_name1","addr":"(AEB)","loc":"d,17:12,17:16","dtypep":"(IM)","access":"RD","varp":"(JM)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ],
                    "bitp": [
-                    {"type":"AND","name":"","addr":"(WDB)","loc":"d,90:123,90:124","dtypep":"(FC)",
+                    {"type":"AND","name":"","addr":"(BEB)","loc":"d,90:123,90:124","dtypep":"(FC)",
                      "lhsp": [
-                      {"type":"CONST","name":"32'h7","addr":"(XDB)","loc":"d,90:123,90:124","dtypep":"(HC)"}
+                      {"type":"CONST","name":"32'h7","addr":"(CEB)","loc":"d,90:123,90:124","dtypep":"(HC)"}
                     ],
                      "rhsp": [
-                      {"type":"CCAST","name":"","addr":"(YDB)","loc":"d,90:123,90:124","dtypep":"(FC)","size":32,
+                      {"type":"CCAST","name":"","addr":"(DEB)","loc":"d,90:123,90:124","dtypep":"(FC)","size":32,
                        "lhsp": [
-                        {"type":"VARREF","name":"t.e","addr":"(ZDB)","loc":"d,90:123,90:124","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                        {"type":"VARREF","name":"t.e","addr":"(EEB)","loc":"d,90:123,90:124","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                       ]}
                     ]}
                   ]}
                 ],
                  "lhsp": [
-                  {"type":"VARREF","name":"__Vtemp_3","addr":"(AEB)","loc":"d,90:123,90:124","dtypep":"(SB)","access":"WR","varp":"(UQ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"__Vtemp_3","addr":"(FEB)","loc":"d,90:123,90:124","dtypep":"(SB)","access":"WR","varp":"(ZQ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                 ],"timingControlp": []},
-                {"type":"DISPLAY","name":"","addr":"(BEB)","loc":"d,90:44,90:50",
+                {"type":"DISPLAY","name":"","addr":"(GEB)","loc":"d,90:44,90:50",
                  "fmtp": [
-                  {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:90:  got='%@' exp='E04'\\n","addr":"(CEB)","loc":"d,90:44,90:50","dtypep":"(SB)",
+                  {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:90:  got='%@' exp='E04'\\n","addr":"(HEB)","loc":"d,90:44,90:50","dtypep":"(SB)",
                    "exprsp": [
-                    {"type":"VARREF","name":"__Vtemp_3","addr":"(DEB)","loc":"d,90:123,90:124","dtypep":"(SB)","access":"RD","varp":"(UQ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"__Vtemp_3","addr":"(IEB)","loc":"d,90:123,90:124","dtypep":"(SB)","access":"RD","varp":"(ZQ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ],"scopeNamep": []}
                 ],"filep": []},
-                {"type":"STOP","name":"","addr":"(EEB)","loc":"d,90:142,90:147","isFatal":false}
+                {"type":"STOP","name":"","addr":"(JEB)","loc":"d,90:142,90:147","isFatal":false}
               ],"elsesp": []},
-              {"type":"IF","name":"","addr":"(FEB)","loc":"d,91:13,91:15",
+              {"type":"IF","name":"","addr":"(KEB)","loc":"d,91:13,91:15",
                "condp": [
-                {"type":"NEQ","name":"","addr":"(GEB)","loc":"d,91:26,91:29","dtypep":"(GB)",
+                {"type":"NEQ","name":"","addr":"(LEB)","loc":"d,91:26,91:29","dtypep":"(GB)",
                  "lhsp": [
-                  {"type":"CONST","name":"4'h1","addr":"(HEB)","loc":"d,91:31,91:34","dtypep":"(UB)"}
+                  {"type":"CONST","name":"4'h1","addr":"(MEB)","loc":"d,91:31,91:34","dtypep":"(UB)"}
                 ],
                  "rhsp": [
-                  {"type":"ARRAYSEL","name":"","addr":"(IEB)","loc":"d,91:18,91:19","dtypep":"(UB)",
+                  {"type":"ARRAYSEL","name":"","addr":"(NEB)","loc":"d,91:18,91:19","dtypep":"(UB)",
                    "fromp": [
-                    {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(JEB)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(OEB)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ],
                    "bitp": [
-                    {"type":"AND","name":"","addr":"(KEB)","loc":"d,91:18,91:19","dtypep":"(FC)",
+                    {"type":"AND","name":"","addr":"(PEB)","loc":"d,91:18,91:19","dtypep":"(FC)",
                      "lhsp": [
-                      {"type":"CONST","name":"32'h7","addr":"(LEB)","loc":"d,91:18,91:19","dtypep":"(HC)"}
+                      {"type":"CONST","name":"32'h7","addr":"(QEB)","loc":"d,91:18,91:19","dtypep":"(HC)"}
                     ],
                      "rhsp": [
-                      {"type":"CCAST","name":"","addr":"(MEB)","loc":"d,91:18,91:19","dtypep":"(FC)","size":32,
+                      {"type":"CCAST","name":"","addr":"(REB)","loc":"d,91:18,91:19","dtypep":"(FC)","size":32,
                        "lhsp": [
-                        {"type":"VARREF","name":"t.e","addr":"(NEB)","loc":"d,91:18,91:19","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                        {"type":"VARREF","name":"t.e","addr":"(SEB)","loc":"d,91:18,91:19","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                       ]}
                     ]}
                   ]}
                 ]}
               ],
                "thensp": [
-                {"type":"DISPLAY","name":"","addr":"(OEB)","loc":"d,91:43,91:49",
+                {"type":"DISPLAY","name":"","addr":"(TEB)","loc":"d,91:43,91:49",
                  "fmtp": [
-                  {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:91:  got='h%x exp='h1\\n","addr":"(PEB)","loc":"d,91:43,91:49","dtypep":"(SB)",
+                  {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:91:  got='h%x exp='h1\\n","addr":"(UEB)","loc":"d,91:43,91:49","dtypep":"(SB)",
                    "exprsp": [
-                    {"type":"ARRAYSEL","name":"","addr":"(QEB)","loc":"d,91:122,91:123","dtypep":"(UB)",
+                    {"type":"ARRAYSEL","name":"","addr":"(VEB)","loc":"d,91:122,91:123","dtypep":"(UB)",
                      "fromp": [
-                      {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(REB)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(WEB)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ],
                      "bitp": [
-                      {"type":"AND","name":"","addr":"(SEB)","loc":"d,91:122,91:123","dtypep":"(FC)",
+                      {"type":"AND","name":"","addr":"(XEB)","loc":"d,91:122,91:123","dtypep":"(FC)",
                        "lhsp": [
-                        {"type":"CONST","name":"32'h7","addr":"(TEB)","loc":"d,91:122,91:123","dtypep":"(HC)"}
+                        {"type":"CONST","name":"32'h7","addr":"(YEB)","loc":"d,91:122,91:123","dtypep":"(HC)"}
                       ],
                        "rhsp": [
-                        {"type":"CCAST","name":"","addr":"(UEB)","loc":"d,91:122,91:123","dtypep":"(FC)","size":32,
+                        {"type":"CCAST","name":"","addr":"(ZEB)","loc":"d,91:122,91:123","dtypep":"(FC)","size":32,
                          "lhsp": [
-                          {"type":"VARREF","name":"t.e","addr":"(VEB)","loc":"d,91:122,91:123","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                          {"type":"VARREF","name":"t.e","addr":"(AFB)","loc":"d,91:122,91:123","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                         ]}
                       ]}
                     ]}
                   ],"scopeNamep": []}
                 ],"filep": []},
-                {"type":"STOP","name":"","addr":"(WEB)","loc":"d,91:139,91:144","isFatal":false}
+                {"type":"STOP","name":"","addr":"(BFB)","loc":"d,91:139,91:144","isFatal":false}
               ],"elsesp": []},
-              {"type":"IF","name":"","addr":"(XEB)","loc":"d,92:13,92:15",
+              {"type":"IF","name":"","addr":"(CFB)","loc":"d,92:13,92:15",
                "condp": [
-                {"type":"NEQ","name":"","addr":"(YEB)","loc":"d,92:29,92:32","dtypep":"(GB)",
+                {"type":"NEQ","name":"","addr":"(DFB)","loc":"d,92:29,92:32","dtypep":"(GB)",
                  "lhsp": [
-                  {"type":"CONST","name":"4'h1","addr":"(ZEB)","loc":"d,92:34,92:37","dtypep":"(UB)"}
+                  {"type":"CONST","name":"4'h1","addr":"(EFB)","loc":"d,92:34,92:37","dtypep":"(UB)"}
                 ],
                  "rhsp": [
-                  {"type":"ARRAYSEL","name":"","addr":"(AFB)","loc":"d,92:18,92:19","dtypep":"(UB)",
+                  {"type":"ARRAYSEL","name":"","addr":"(FFB)","loc":"d,92:18,92:19","dtypep":"(UB)",
                    "fromp": [
-                    {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(BFB)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(GFB)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ],
                    "bitp": [
-                    {"type":"AND","name":"","addr":"(CFB)","loc":"d,92:18,92:19","dtypep":"(FC)",
+                    {"type":"AND","name":"","addr":"(HFB)","loc":"d,92:18,92:19","dtypep":"(FC)",
                      "lhsp": [
-                      {"type":"CONST","name":"32'h7","addr":"(DFB)","loc":"d,92:18,92:19","dtypep":"(HC)"}
+                      {"type":"CONST","name":"32'h7","addr":"(IFB)","loc":"d,92:18,92:19","dtypep":"(HC)"}
                     ],
                      "rhsp": [
-                      {"type":"CCAST","name":"","addr":"(EFB)","loc":"d,92:18,92:19","dtypep":"(FC)","size":32,
+                      {"type":"CCAST","name":"","addr":"(JFB)","loc":"d,92:18,92:19","dtypep":"(FC)","size":32,
                        "lhsp": [
-                        {"type":"VARREF","name":"t.e","addr":"(FFB)","loc":"d,92:18,92:19","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                        {"type":"VARREF","name":"t.e","addr":"(KFB)","loc":"d,92:18,92:19","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                       ]}
                     ]}
                   ]}
                 ]}
               ],
                "thensp": [
-                {"type":"DISPLAY","name":"","addr":"(GFB)","loc":"d,92:46,92:52",
+                {"type":"DISPLAY","name":"","addr":"(LFB)","loc":"d,92:46,92:52",
                  "fmtp": [
-                  {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:92:  got='h%x exp='h1\\n","addr":"(HFB)","loc":"d,92:46,92:52","dtypep":"(SB)",
+                  {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:92:  got='h%x exp='h1\\n","addr":"(MFB)","loc":"d,92:46,92:52","dtypep":"(SB)",
                    "exprsp": [
-                    {"type":"ARRAYSEL","name":"","addr":"(IFB)","loc":"d,92:125,92:126","dtypep":"(UB)",
+                    {"type":"ARRAYSEL","name":"","addr":"(NFB)","loc":"d,92:125,92:126","dtypep":"(UB)",
                      "fromp": [
-                      {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(JFB)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(OFB)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ],
                      "bitp": [
-                      {"type":"AND","name":"","addr":"(KFB)","loc":"d,92:125,92:126","dtypep":"(FC)",
+                      {"type":"AND","name":"","addr":"(PFB)","loc":"d,92:125,92:126","dtypep":"(FC)",
                        "lhsp": [
-                        {"type":"CONST","name":"32'h7","addr":"(LFB)","loc":"d,92:125,92:126","dtypep":"(HC)"}
+                        {"type":"CONST","name":"32'h7","addr":"(QFB)","loc":"d,92:125,92:126","dtypep":"(HC)"}
                       ],
                        "rhsp": [
-                        {"type":"CCAST","name":"","addr":"(MFB)","loc":"d,92:125,92:126","dtypep":"(FC)","size":32,
+                        {"type":"CCAST","name":"","addr":"(RFB)","loc":"d,92:125,92:126","dtypep":"(FC)","size":32,
                          "lhsp": [
-                          {"type":"VARREF","name":"t.e","addr":"(NFB)","loc":"d,92:125,92:126","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                          {"type":"VARREF","name":"t.e","addr":"(SFB)","loc":"d,92:125,92:126","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                         ]}
                       ]}
                     ]}
                   ],"scopeNamep": []}
                 ],"filep": []},
-                {"type":"STOP","name":"","addr":"(OFB)","loc":"d,92:145,92:150","isFatal":false}
+                {"type":"STOP","name":"","addr":"(TFB)","loc":"d,92:145,92:150","isFatal":false}
               ],"elsesp": []},
-              {"type":"IF","name":"","addr":"(PFB)","loc":"d,93:13,93:15",
+              {"type":"IF","name":"","addr":"(UFB)","loc":"d,93:13,93:15",
                "condp": [
-                {"type":"NEQ","name":"","addr":"(QFB)","loc":"d,93:29,93:32","dtypep":"(GB)",
+                {"type":"NEQ","name":"","addr":"(VFB)","loc":"d,93:29,93:32","dtypep":"(GB)",
                  "lhsp": [
-                  {"type":"CONST","name":"4'h3","addr":"(RFB)","loc":"d,93:34,93:37","dtypep":"(UB)"}
+                  {"type":"CONST","name":"4'h3","addr":"(WFB)","loc":"d,93:34,93:37","dtypep":"(UB)"}
                 ],
                  "rhsp": [
-                  {"type":"ARRAYSEL","name":"","addr":"(SFB)","loc":"d,93:18,93:19","dtypep":"(UB)",
+                  {"type":"ARRAYSEL","name":"","addr":"(XFB)","loc":"d,93:18,93:19","dtypep":"(UB)",
                    "fromp": [
-                    {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(TFB)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(YFB)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ],
                    "bitp": [
-                    {"type":"AND","name":"","addr":"(UFB)","loc":"d,93:18,93:19","dtypep":"(FC)",
+                    {"type":"AND","name":"","addr":"(ZFB)","loc":"d,93:18,93:19","dtypep":"(FC)",
                      "lhsp": [
-                      {"type":"CONST","name":"32'h7","addr":"(VFB)","loc":"d,93:18,93:19","dtypep":"(HC)"}
+                      {"type":"CONST","name":"32'h7","addr":"(AGB)","loc":"d,93:18,93:19","dtypep":"(HC)"}
                     ],
                      "rhsp": [
-                      {"type":"ARRAYSEL","name":"","addr":"(WFB)","loc":"d,93:18,93:19","dtypep":"(FC)",
+                      {"type":"ARRAYSEL","name":"","addr":"(BGB)","loc":"d,93:18,93:19","dtypep":"(FC)",
                        "fromp": [
-                        {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(XFB)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                        {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(CGB)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                       ],
                        "bitp": [
-                        {"type":"AND","name":"","addr":"(YFB)","loc":"d,93:18,93:19","dtypep":"(FC)",
+                        {"type":"AND","name":"","addr":"(DGB)","loc":"d,93:18,93:19","dtypep":"(FC)",
                          "lhsp": [
-                          {"type":"CONST","name":"32'h7","addr":"(ZFB)","loc":"d,93:18,93:19","dtypep":"(HC)"}
+                          {"type":"CONST","name":"32'h7","addr":"(EGB)","loc":"d,93:18,93:19","dtypep":"(HC)"}
                         ],
                          "rhsp": [
-                          {"type":"CCAST","name":"","addr":"(AGB)","loc":"d,93:18,93:19","dtypep":"(FC)","size":32,
+                          {"type":"CCAST","name":"","addr":"(FGB)","loc":"d,93:18,93:19","dtypep":"(FC)","size":32,
                            "lhsp": [
-                            {"type":"VARREF","name":"t.e","addr":"(BGB)","loc":"d,93:18,93:19","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                            {"type":"VARREF","name":"t.e","addr":"(GGB)","loc":"d,93:18,93:19","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                           ]}
                         ]}
                       ]}
@@ -2186,33 +2201,33 @@
                 ]}
               ],
                "thensp": [
-                {"type":"DISPLAY","name":"","addr":"(CGB)","loc":"d,93:46,93:52",
+                {"type":"DISPLAY","name":"","addr":"(HGB)","loc":"d,93:46,93:52",
                  "fmtp": [
-                  {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:93:  got='h%x exp='h3\\n","addr":"(DGB)","loc":"d,93:46,93:52","dtypep":"(SB)",
+                  {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:93:  got='h%x exp='h3\\n","addr":"(IGB)","loc":"d,93:46,93:52","dtypep":"(SB)",
                    "exprsp": [
-                    {"type":"ARRAYSEL","name":"","addr":"(EGB)","loc":"d,93:125,93:126","dtypep":"(UB)",
+                    {"type":"ARRAYSEL","name":"","addr":"(JGB)","loc":"d,93:125,93:126","dtypep":"(UB)",
                      "fromp": [
-                      {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(FGB)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(KGB)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ],
                      "bitp": [
-                      {"type":"AND","name":"","addr":"(GGB)","loc":"d,93:125,93:126","dtypep":"(FC)",
+                      {"type":"AND","name":"","addr":"(LGB)","loc":"d,93:125,93:126","dtypep":"(FC)",
                        "lhsp": [
-                        {"type":"CONST","name":"32'h7","addr":"(HGB)","loc":"d,93:125,93:126","dtypep":"(HC)"}
+                        {"type":"CONST","name":"32'h7","addr":"(MGB)","loc":"d,93:125,93:126","dtypep":"(HC)"}
                       ],
                        "rhsp": [
-                        {"type":"ARRAYSEL","name":"","addr":"(IGB)","loc":"d,93:125,93:126","dtypep":"(FC)",
+                        {"type":"ARRAYSEL","name":"","addr":"(NGB)","loc":"d,93:125,93:126","dtypep":"(FC)",
                          "fromp": [
-                          {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(JGB)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                          {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(OGB)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                         ],
                          "bitp": [
-                          {"type":"AND","name":"","addr":"(KGB)","loc":"d,93:125,93:126","dtypep":"(FC)",
+                          {"type":"AND","name":"","addr":"(PGB)","loc":"d,93:125,93:126","dtypep":"(FC)",
                            "lhsp": [
-                            {"type":"CONST","name":"32'h7","addr":"(LGB)","loc":"d,93:125,93:126","dtypep":"(HC)"}
+                            {"type":"CONST","name":"32'h7","addr":"(QGB)","loc":"d,93:125,93:126","dtypep":"(HC)"}
                           ],
                            "rhsp": [
-                            {"type":"CCAST","name":"","addr":"(MGB)","loc":"d,93:125,93:126","dtypep":"(FC)","size":32,
+                            {"type":"CCAST","name":"","addr":"(RGB)","loc":"d,93:125,93:126","dtypep":"(FC)","size":32,
                              "lhsp": [
-                              {"type":"VARREF","name":"t.e","addr":"(NGB)","loc":"d,93:125,93:126","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                              {"type":"VARREF","name":"t.e","addr":"(SGB)","loc":"d,93:125,93:126","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                             ]}
                           ]}
                         ]}
@@ -2220,138 +2235,138 @@
                     ]}
                   ],"scopeNamep": []}
                 ],"filep": []},
-                {"type":"STOP","name":"","addr":"(OGB)","loc":"d,93:145,93:150","isFatal":false}
+                {"type":"STOP","name":"","addr":"(TGB)","loc":"d,93:145,93:150","isFatal":false}
               ],"elsesp": []},
-              {"type":"IF","name":"","addr":"(PGB)","loc":"d,94:13,94:15",
+              {"type":"IF","name":"","addr":"(UGB)","loc":"d,94:13,94:15",
                "condp": [
-                {"type":"NEQ","name":"","addr":"(QGB)","loc":"d,94:26,94:29","dtypep":"(GB)",
+                {"type":"NEQ","name":"","addr":"(VGB)","loc":"d,94:26,94:29","dtypep":"(GB)",
                  "lhsp": [
-                  {"type":"CONST","name":"4'h3","addr":"(RGB)","loc":"d,94:31,94:34","dtypep":"(UB)"}
+                  {"type":"CONST","name":"4'h3","addr":"(WGB)","loc":"d,94:31,94:34","dtypep":"(UB)"}
                 ],
                  "rhsp": [
-                  {"type":"ARRAYSEL","name":"","addr":"(SGB)","loc":"d,94:18,94:19","dtypep":"(UB)",
+                  {"type":"ARRAYSEL","name":"","addr":"(XGB)","loc":"d,94:18,94:19","dtypep":"(UB)",
                    "fromp": [
-                    {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(TGB)","loc":"d,17:12,17:16","dtypep":"(WI)","access":"RD","varp":"(XI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(YGB)","loc":"d,17:12,17:16","dtypep":"(WI)","access":"RD","varp":"(XI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ],
                    "bitp": [
-                    {"type":"AND","name":"","addr":"(UGB)","loc":"d,94:18,94:19","dtypep":"(FC)",
+                    {"type":"AND","name":"","addr":"(ZGB)","loc":"d,94:18,94:19","dtypep":"(FC)",
                      "lhsp": [
-                      {"type":"CONST","name":"32'h7","addr":"(VGB)","loc":"d,94:18,94:19","dtypep":"(HC)"}
+                      {"type":"CONST","name":"32'h7","addr":"(AHB)","loc":"d,94:18,94:19","dtypep":"(HC)"}
                     ],
                      "rhsp": [
-                      {"type":"CCAST","name":"","addr":"(WGB)","loc":"d,94:18,94:19","dtypep":"(FC)","size":32,
+                      {"type":"CCAST","name":"","addr":"(BHB)","loc":"d,94:18,94:19","dtypep":"(FC)","size":32,
                        "lhsp": [
-                        {"type":"VARREF","name":"t.e","addr":"(XGB)","loc":"d,94:18,94:19","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                        {"type":"VARREF","name":"t.e","addr":"(CHB)","loc":"d,94:18,94:19","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                       ]}
                     ]}
                   ]}
                 ]}
               ],
                "thensp": [
-                {"type":"DISPLAY","name":"","addr":"(YGB)","loc":"d,94:43,94:49",
+                {"type":"DISPLAY","name":"","addr":"(DHB)","loc":"d,94:43,94:49",
                  "fmtp": [
-                  {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:94:  got='h%x exp='h3\\n","addr":"(ZGB)","loc":"d,94:43,94:49","dtypep":"(SB)",
+                  {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:94:  got='h%x exp='h3\\n","addr":"(EHB)","loc":"d,94:43,94:49","dtypep":"(SB)",
                    "exprsp": [
-                    {"type":"ARRAYSEL","name":"","addr":"(AHB)","loc":"d,94:122,94:123","dtypep":"(UB)",
+                    {"type":"ARRAYSEL","name":"","addr":"(FHB)","loc":"d,94:122,94:123","dtypep":"(UB)",
                      "fromp": [
-                      {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(BHB)","loc":"d,17:12,17:16","dtypep":"(WI)","access":"RD","varp":"(XI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(GHB)","loc":"d,17:12,17:16","dtypep":"(WI)","access":"RD","varp":"(XI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ],
                      "bitp": [
-                      {"type":"AND","name":"","addr":"(CHB)","loc":"d,94:122,94:123","dtypep":"(FC)",
+                      {"type":"AND","name":"","addr":"(HHB)","loc":"d,94:122,94:123","dtypep":"(FC)",
                        "lhsp": [
-                        {"type":"CONST","name":"32'h7","addr":"(DHB)","loc":"d,94:122,94:123","dtypep":"(HC)"}
+                        {"type":"CONST","name":"32'h7","addr":"(IHB)","loc":"d,94:122,94:123","dtypep":"(HC)"}
                       ],
                        "rhsp": [
-                        {"type":"CCAST","name":"","addr":"(EHB)","loc":"d,94:122,94:123","dtypep":"(FC)","size":32,
+                        {"type":"CCAST","name":"","addr":"(JHB)","loc":"d,94:122,94:123","dtypep":"(FC)","size":32,
                          "lhsp": [
-                          {"type":"VARREF","name":"t.e","addr":"(FHB)","loc":"d,94:122,94:123","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                          {"type":"VARREF","name":"t.e","addr":"(KHB)","loc":"d,94:122,94:123","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                         ]}
                       ]}
                     ]}
                   ],"scopeNamep": []}
                 ],"filep": []},
-                {"type":"STOP","name":"","addr":"(GHB)","loc":"d,94:139,94:144","isFatal":false}
+                {"type":"STOP","name":"","addr":"(LHB)","loc":"d,94:139,94:144","isFatal":false}
               ],"elsesp": []},
-              {"type":"IF","name":"","addr":"(HHB)","loc":"d,95:13,95:15",
+              {"type":"IF","name":"","addr":"(MHB)","loc":"d,95:13,95:15",
                "condp": [
-                {"type":"NEQ","name":"","addr":"(IHB)","loc":"d,95:29,95:32","dtypep":"(GB)",
+                {"type":"NEQ","name":"","addr":"(NHB)","loc":"d,95:29,95:32","dtypep":"(GB)",
                  "lhsp": [
-                  {"type":"CONST","name":"4'h3","addr":"(JHB)","loc":"d,95:34,95:37","dtypep":"(UB)"}
+                  {"type":"CONST","name":"4'h3","addr":"(OHB)","loc":"d,95:34,95:37","dtypep":"(UB)"}
                 ],
                  "rhsp": [
-                  {"type":"ARRAYSEL","name":"","addr":"(KHB)","loc":"d,95:18,95:19","dtypep":"(UB)",
+                  {"type":"ARRAYSEL","name":"","addr":"(PHB)","loc":"d,95:18,95:19","dtypep":"(UB)",
                    "fromp": [
-                    {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(LHB)","loc":"d,17:12,17:16","dtypep":"(WI)","access":"RD","varp":"(XI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(QHB)","loc":"d,17:12,17:16","dtypep":"(WI)","access":"RD","varp":"(XI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ],
                    "bitp": [
-                    {"type":"AND","name":"","addr":"(MHB)","loc":"d,95:18,95:19","dtypep":"(FC)",
+                    {"type":"AND","name":"","addr":"(RHB)","loc":"d,95:18,95:19","dtypep":"(FC)",
                      "lhsp": [
-                      {"type":"CONST","name":"32'h7","addr":"(NHB)","loc":"d,95:18,95:19","dtypep":"(HC)"}
+                      {"type":"CONST","name":"32'h7","addr":"(SHB)","loc":"d,95:18,95:19","dtypep":"(HC)"}
                     ],
                      "rhsp": [
-                      {"type":"CCAST","name":"","addr":"(OHB)","loc":"d,95:18,95:19","dtypep":"(FC)","size":32,
+                      {"type":"CCAST","name":"","addr":"(THB)","loc":"d,95:18,95:19","dtypep":"(FC)","size":32,
                        "lhsp": [
-                        {"type":"VARREF","name":"t.e","addr":"(PHB)","loc":"d,95:18,95:19","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                        {"type":"VARREF","name":"t.e","addr":"(UHB)","loc":"d,95:18,95:19","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                       ]}
                     ]}
                   ]}
                 ]}
               ],
                "thensp": [
-                {"type":"DISPLAY","name":"","addr":"(QHB)","loc":"d,95:46,95:52",
+                {"type":"DISPLAY","name":"","addr":"(VHB)","loc":"d,95:46,95:52",
                  "fmtp": [
-                  {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:95:  got='h%x exp='h3\\n","addr":"(RHB)","loc":"d,95:46,95:52","dtypep":"(SB)",
+                  {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:95:  got='h%x exp='h3\\n","addr":"(WHB)","loc":"d,95:46,95:52","dtypep":"(SB)",
                    "exprsp": [
-                    {"type":"ARRAYSEL","name":"","addr":"(SHB)","loc":"d,95:125,95:126","dtypep":"(UB)",
+                    {"type":"ARRAYSEL","name":"","addr":"(XHB)","loc":"d,95:125,95:126","dtypep":"(UB)",
                      "fromp": [
-                      {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(THB)","loc":"d,17:12,17:16","dtypep":"(WI)","access":"RD","varp":"(XI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(YHB)","loc":"d,17:12,17:16","dtypep":"(WI)","access":"RD","varp":"(XI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ],
                      "bitp": [
-                      {"type":"AND","name":"","addr":"(UHB)","loc":"d,95:125,95:126","dtypep":"(FC)",
+                      {"type":"AND","name":"","addr":"(ZHB)","loc":"d,95:125,95:126","dtypep":"(FC)",
                        "lhsp": [
-                        {"type":"CONST","name":"32'h7","addr":"(VHB)","loc":"d,95:125,95:126","dtypep":"(HC)"}
+                        {"type":"CONST","name":"32'h7","addr":"(AIB)","loc":"d,95:125,95:126","dtypep":"(HC)"}
                       ],
                        "rhsp": [
-                        {"type":"CCAST","name":"","addr":"(WHB)","loc":"d,95:125,95:126","dtypep":"(FC)","size":32,
+                        {"type":"CCAST","name":"","addr":"(BIB)","loc":"d,95:125,95:126","dtypep":"(FC)","size":32,
                          "lhsp": [
-                          {"type":"VARREF","name":"t.e","addr":"(XHB)","loc":"d,95:125,95:126","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                          {"type":"VARREF","name":"t.e","addr":"(CIB)","loc":"d,95:125,95:126","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                         ]}
                       ]}
                     ]}
                   ],"scopeNamep": []}
                 ],"filep": []},
-                {"type":"STOP","name":"","addr":"(YHB)","loc":"d,95:145,95:150","isFatal":false}
+                {"type":"STOP","name":"","addr":"(DIB)","loc":"d,95:145,95:150","isFatal":false}
               ],"elsesp": []},
-              {"type":"IF","name":"","addr":"(ZHB)","loc":"d,96:13,96:15",
+              {"type":"IF","name":"","addr":"(EIB)","loc":"d,96:13,96:15",
                "condp": [
-                {"type":"NEQ","name":"","addr":"(AIB)","loc":"d,96:29,96:32","dtypep":"(GB)",
+                {"type":"NEQ","name":"","addr":"(FIB)","loc":"d,96:29,96:32","dtypep":"(GB)",
                  "lhsp": [
-                  {"type":"CONST","name":"4'h1","addr":"(BIB)","loc":"d,96:34,96:37","dtypep":"(UB)"}
+                  {"type":"CONST","name":"4'h1","addr":"(GIB)","loc":"d,96:34,96:37","dtypep":"(UB)"}
                 ],
                  "rhsp": [
-                  {"type":"ARRAYSEL","name":"","addr":"(CIB)","loc":"d,96:18,96:19","dtypep":"(UB)",
+                  {"type":"ARRAYSEL","name":"","addr":"(HIB)","loc":"d,96:18,96:19","dtypep":"(UB)",
                    "fromp": [
-                    {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(DIB)","loc":"d,17:12,17:16","dtypep":"(WI)","access":"RD","varp":"(XI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(IIB)","loc":"d,17:12,17:16","dtypep":"(WI)","access":"RD","varp":"(XI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ],
                    "bitp": [
-                    {"type":"AND","name":"","addr":"(EIB)","loc":"d,96:18,96:19","dtypep":"(FC)",
+                    {"type":"AND","name":"","addr":"(JIB)","loc":"d,96:18,96:19","dtypep":"(FC)",
                      "lhsp": [
-                      {"type":"CONST","name":"32'h7","addr":"(FIB)","loc":"d,96:18,96:19","dtypep":"(HC)"}
+                      {"type":"CONST","name":"32'h7","addr":"(KIB)","loc":"d,96:18,96:19","dtypep":"(HC)"}
                     ],
                      "rhsp": [
-                      {"type":"ARRAYSEL","name":"","addr":"(GIB)","loc":"d,96:18,96:19","dtypep":"(FC)",
+                      {"type":"ARRAYSEL","name":"","addr":"(LIB)","loc":"d,96:18,96:19","dtypep":"(FC)",
                        "fromp": [
-                        {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(HIB)","loc":"d,17:12,17:16","dtypep":"(WI)","access":"RD","varp":"(XI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                        {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(MIB)","loc":"d,17:12,17:16","dtypep":"(WI)","access":"RD","varp":"(XI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                       ],
                        "bitp": [
-                        {"type":"AND","name":"","addr":"(IIB)","loc":"d,96:18,96:19","dtypep":"(FC)",
+                        {"type":"AND","name":"","addr":"(NIB)","loc":"d,96:18,96:19","dtypep":"(FC)",
                          "lhsp": [
-                          {"type":"CONST","name":"32'h7","addr":"(JIB)","loc":"d,96:18,96:19","dtypep":"(HC)"}
+                          {"type":"CONST","name":"32'h7","addr":"(OIB)","loc":"d,96:18,96:19","dtypep":"(HC)"}
                         ],
                          "rhsp": [
-                          {"type":"CCAST","name":"","addr":"(KIB)","loc":"d,96:18,96:19","dtypep":"(FC)","size":32,
+                          {"type":"CCAST","name":"","addr":"(PIB)","loc":"d,96:18,96:19","dtypep":"(FC)","size":32,
                            "lhsp": [
-                            {"type":"VARREF","name":"t.e","addr":"(LIB)","loc":"d,96:18,96:19","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                            {"type":"VARREF","name":"t.e","addr":"(QIB)","loc":"d,96:18,96:19","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                           ]}
                         ]}
                       ]}
@@ -2360,33 +2375,33 @@
                 ]}
               ],
                "thensp": [
-                {"type":"DISPLAY","name":"","addr":"(MIB)","loc":"d,96:46,96:52",
+                {"type":"DISPLAY","name":"","addr":"(RIB)","loc":"d,96:46,96:52",
                  "fmtp": [
-                  {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:96:  got='h%x exp='h1\\n","addr":"(NIB)","loc":"d,96:46,96:52","dtypep":"(SB)",
+                  {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:96:  got='h%x exp='h1\\n","addr":"(SIB)","loc":"d,96:46,96:52","dtypep":"(SB)",
                    "exprsp": [
-                    {"type":"ARRAYSEL","name":"","addr":"(OIB)","loc":"d,96:125,96:126","dtypep":"(UB)",
+                    {"type":"ARRAYSEL","name":"","addr":"(TIB)","loc":"d,96:125,96:126","dtypep":"(UB)",
                      "fromp": [
-                      {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(PIB)","loc":"d,17:12,17:16","dtypep":"(WI)","access":"RD","varp":"(XI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(UIB)","loc":"d,17:12,17:16","dtypep":"(WI)","access":"RD","varp":"(XI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ],
                      "bitp": [
-                      {"type":"AND","name":"","addr":"(QIB)","loc":"d,96:125,96:126","dtypep":"(FC)",
+                      {"type":"AND","name":"","addr":"(VIB)","loc":"d,96:125,96:126","dtypep":"(FC)",
                        "lhsp": [
-                        {"type":"CONST","name":"32'h7","addr":"(RIB)","loc":"d,96:125,96:126","dtypep":"(HC)"}
+                        {"type":"CONST","name":"32'h7","addr":"(WIB)","loc":"d,96:125,96:126","dtypep":"(HC)"}
                       ],
                        "rhsp": [
-                        {"type":"ARRAYSEL","name":"","addr":"(SIB)","loc":"d,96:125,96:126","dtypep":"(FC)",
+                        {"type":"ARRAYSEL","name":"","addr":"(XIB)","loc":"d,96:125,96:126","dtypep":"(FC)",
                          "fromp": [
-                          {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(TIB)","loc":"d,17:12,17:16","dtypep":"(WI)","access":"RD","varp":"(XI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                          {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(YIB)","loc":"d,17:12,17:16","dtypep":"(WI)","access":"RD","varp":"(XI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                         ],
                          "bitp": [
-                          {"type":"AND","name":"","addr":"(UIB)","loc":"d,96:125,96:126","dtypep":"(FC)",
+                          {"type":"AND","name":"","addr":"(ZIB)","loc":"d,96:125,96:126","dtypep":"(FC)",
                            "lhsp": [
-                            {"type":"CONST","name":"32'h7","addr":"(VIB)","loc":"d,96:125,96:126","dtypep":"(HC)"}
+                            {"type":"CONST","name":"32'h7","addr":"(AJB)","loc":"d,96:125,96:126","dtypep":"(HC)"}
                           ],
                            "rhsp": [
-                            {"type":"CCAST","name":"","addr":"(WIB)","loc":"d,96:125,96:126","dtypep":"(FC)","size":32,
+                            {"type":"CCAST","name":"","addr":"(BJB)","loc":"d,96:125,96:126","dtypep":"(FC)","size":32,
                              "lhsp": [
-                              {"type":"VARREF","name":"t.e","addr":"(XIB)","loc":"d,96:125,96:126","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                              {"type":"VARREF","name":"t.e","addr":"(CJB)","loc":"d,96:125,96:126","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                             ]}
                           ]}
                         ]}
@@ -2394,616 +2409,652 @@
                     ]}
                   ],"scopeNamep": []}
                 ],"filep": []},
-                {"type":"STOP","name":"","addr":"(YIB)","loc":"d,96:145,96:150","isFatal":false}
+                {"type":"STOP","name":"","addr":"(DJB)","loc":"d,96:145,96:150","isFatal":false}
               ],"elsesp": []},
-              {"type":"ASSIGNDLY","name":"","addr":"(ZIB)","loc":"d,97:12,97:14","dtypep":"(UB)",
+              {"type":"ASSIGNDLY","name":"","addr":"(EJB)","loc":"d,97:12,97:14","dtypep":"(UB)",
                "rhsp": [
-                {"type":"CONST","name":"4'h1","addr":"(AJB)","loc":"d,97:15,97:18","dtypep":"(UB)"}
+                {"type":"CONST","name":"4'h1","addr":"(FJB)","loc":"d,97:15,97:18","dtypep":"(UB)"}
               ],
                "lhsp": [
-                {"type":"VARREF","name":"__Vdly__t.e","addr":"(BJB)","loc":"d,97:10,97:11","dtypep":"(UB)","access":"WR","varp":"(PQ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                {"type":"VARREF","name":"__Vdly__t.e","addr":"(GJB)","loc":"d,97:10,97:11","dtypep":"(UB)","access":"WR","varp":"(TQ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
               ],"timingControlp": []}
             ],
              "elsesp": [
-              {"type":"IF","name":"","addr":"(CJB)","loc":"d,99:12,99:14",
+              {"type":"IF","name":"","addr":"(HJB)","loc":"d,99:12,99:14",
                "condp": [
-                {"type":"EQ","name":"","addr":"(DJB)","loc":"d,99:19,99:21","dtypep":"(GB)",
+                {"type":"EQ","name":"","addr":"(IJB)","loc":"d,99:19,99:21","dtypep":"(GB)",
                  "lhsp": [
-                  {"type":"CONST","name":"32'sh63","addr":"(EJB)","loc":"d,99:21,99:23","dtypep":"(LB)"}
+                  {"type":"CONST","name":"32'sh63","addr":"(JJB)","loc":"d,99:21,99:23","dtypep":"(LB)"}
                 ],
                  "rhsp": [
-                  {"type":"VARREF","name":"t.cyc","addr":"(FJB)","loc":"d,99:16,99:19","dtypep":"(S)","access":"RD","varp":"(R)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"t.cyc","addr":"(KJB)","loc":"d,99:16,99:19","dtypep":"(S)","access":"RD","varp":"(R)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                 ]}
               ],
                "thensp": [
-                {"type":"DISPLAY","name":"","addr":"(GJB)","loc":"d,100:10,100:16",
+                {"type":"DISPLAY","name":"","addr":"(LJB)","loc":"d,100:10,100:16",
                  "fmtp": [
-                  {"type":"SFORMATF","name":"*-* All Finished *-*\\n","addr":"(HJB)","loc":"d,100:10,100:16","dtypep":"(SB)","exprsp": [],"scopeNamep": []}
+                  {"type":"SFORMATF","name":"*-* All Finished *-*\\n","addr":"(MJB)","loc":"d,100:10,100:16","dtypep":"(SB)","exprsp": [],"scopeNamep": []}
                 ],"filep": []},
-                {"type":"FINISH","name":"","addr":"(IJB)","loc":"d,101:10,101:17"}
+                {"type":"FINISH","name":"","addr":"(NJB)","loc":"d,101:10,101:17"}
               ],"elsesp": []}
             ]}
           ]}
         ]}
       ]},
-      {"type":"ASSIGN","name":"","addr":"(JJB)","loc":"d,23:17,23:20","dtypep":"(S)",
+      {"type":"ASSIGN","name":"","addr":"(OJB)","loc":"d,23:17,23:20","dtypep":"(S)",
        "rhsp": [
-        {"type":"VARREF","name":"__Vdly__t.cyc","addr":"(KJB)","loc":"d,23:17,23:20","dtypep":"(S)","access":"RD","varp":"(MQ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"__Vdly__t.cyc","addr":"(PJB)","loc":"d,23:17,23:20","dtypep":"(S)","access":"RD","varp":"(PQ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"t.cyc","addr":"(LJB)","loc":"d,23:17,23:20","dtypep":"(S)","access":"WR","varp":"(R)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"t.cyc","addr":"(QJB)","loc":"d,23:17,23:20","dtypep":"(S)","access":"WR","varp":"(R)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []},
-      {"type":"ASSIGN","name":"","addr":"(MJB)","loc":"d,24:9,24:10","dtypep":"(UB)",
+      {"type":"ASSIGN","name":"","addr":"(RJB)","loc":"d,24:9,24:10","dtypep":"(UB)",
        "rhsp": [
-        {"type":"VARREF","name":"__Vdly__t.e","addr":"(NJB)","loc":"d,24:9,24:10","dtypep":"(UB)","access":"RD","varp":"(PQ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"__Vdly__t.e","addr":"(SJB)","loc":"d,24:9,24:10","dtypep":"(UB)","access":"RD","varp":"(TQ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"t.e","addr":"(OJB)","loc":"d,24:9,24:10","dtypep":"(UB)","access":"WR","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"t.e","addr":"(TJB)","loc":"d,24:9,24:10","dtypep":"(UB)","access":"WR","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []}
     ]},
     {"type":"CFUNC","name":"_eval_nba","addr":"(G)","loc":"a,0:0,0:0","slow":false,"isStatic":false,"dpiExportDispatcher":false,"dpiExportImpl":false,"dpiImportPrototype":false,"dpiImportWrapper":false,"dpiContext":false,"isConstructor":false,"isDestructor":false,"isVirtual":false,"isCoroutine":false,"needProcess":false,"scopep":"(Z)","argsp": [],"varsp": [],
      "stmtsp": [
-      {"type":"IF","name":"","addr":"(PJB)","loc":"d,11:8,11:9",
+      {"type":"IF","name":"","addr":"(UJB)","loc":"d,11:8,11:9",
        "condp": [
-        {"type":"AND","name":"","addr":"(QJB)","loc":"d,11:8,11:9","dtypep":"(JN)",
+        {"type":"AND","name":"","addr":"(VJB)","loc":"d,11:8,11:9","dtypep":"(JN)",
          "lhsp": [
-          {"type":"CONST","name":"64'h1","addr":"(RJB)","loc":"d,11:8,11:9","dtypep":"(JN)"}
+          {"type":"CONST","name":"64'h1","addr":"(WJB)","loc":"d,11:8,11:9","dtypep":"(JN)"}
         ],
          "rhsp": [
-          {"type":"ARRAYSEL","name":"","addr":"(SJB)","loc":"d,11:8,11:9","dtypep":"(HN)",
+          {"type":"ARRAYSEL","name":"","addr":"(XJB)","loc":"d,11:8,11:9","dtypep":"(HN)",
            "fromp": [
-            {"type":"VARREF","name":"__VnbaTriggered","addr":"(TJB)","loc":"d,11:8,11:9","dtypep":"(W)","access":"RD","varp":"(X)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"__VnbaTriggered","addr":"(YJB)","loc":"d,11:8,11:9","dtypep":"(W)","access":"RD","varp":"(X)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ],
            "bitp": [
-            {"type":"CONST","name":"32'h0","addr":"(UJB)","loc":"d,11:8,11:9","dtypep":"(HC)"}
+            {"type":"CONST","name":"32'h0","addr":"(ZJB)","loc":"d,11:8,11:9","dtypep":"(HC)"}
           ]}
         ]}
       ],
        "thensp": [
-        {"type":"STMTEXPR","name":"","addr":"(VJB)","loc":"d,23:17,23:20",
+        {"type":"STMTEXPR","name":"","addr":"(AKB)","loc":"d,23:17,23:20",
          "exprp": [
-          {"type":"CCALL","name":"","addr":"(WJB)","loc":"d,23:17,23:20","dtypep":"(DB)","funcName":"_nba_sequent__TOP__0","funcp":"(LQ)","argsp": []}
+          {"type":"CCALL","name":"","addr":"(BKB)","loc":"d,23:17,23:20","dtypep":"(DB)","funcName":"_nba_sequent__TOP__0","funcp":"(OQ)","argsp": []}
         ]}
       ],"elsesp": []}
     ]},
-    {"type":"CFUNC","name":"_trigger_orInto__act","addr":"(XJB)","loc":"a,0:0,0:0","slow":false,"isStatic":true,"dpiExportDispatcher":false,"dpiExportImpl":false,"dpiImportPrototype":false,"dpiImportWrapper":false,"dpiContext":false,"isConstructor":false,"isDestructor":false,"isVirtual":false,"isCoroutine":false,"needProcess":false,"scopep":"(Z)",
+    {"type":"CFUNC","name":"_trigger_orInto__act","addr":"(CKB)","loc":"a,0:0,0:0","slow":false,"isStatic":true,"dpiExportDispatcher":false,"dpiExportImpl":false,"dpiImportPrototype":false,"dpiImportWrapper":false,"dpiContext":false,"isConstructor":false,"isDestructor":false,"isVirtual":false,"isCoroutine":false,"needProcess":false,"scopep":"(Z)",
      "argsp": [
-      {"type":"VAR","name":"out","addr":"(YJB)","loc":"a,0:0,0:0","dtypep":"(W)","origName":"out","isSc":false,"isPrimaryIO":false,"isPrimaryClock":false,"direction":"INOUT","isConst":false,"isPullup":false,"isPulldown":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":true,"isStdRandomizeArg":false,"lifetime":"NONE","varType":"BLOCKTEMP","dtypeName":"","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"ignorePostWrite":false,"ignoreSchedWrite":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
-      {"type":"CRESET","name":"","addr":"(ZJB)","loc":"a,0:0,0:0","constructing":true,
-       "varrefp": [
-        {"type":"VARREF","name":"out","addr":"(AKB)","loc":"a,0:0,0:0","dtypep":"(W)","access":"WR","varp":"(YJB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
-      ]},
-      {"type":"VAR","name":"in","addr":"(BKB)","loc":"a,0:0,0:0","dtypep":"(W)","origName":"in","isSc":false,"isPrimaryIO":false,"isPrimaryClock":false,"direction":"CONSTREF","isConst":false,"isPullup":false,"isPulldown":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":true,"isStdRandomizeArg":false,"lifetime":"NONE","varType":"BLOCKTEMP","dtypeName":"","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"ignorePostWrite":false,"ignoreSchedWrite":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
-      {"type":"CRESET","name":"","addr":"(CKB)","loc":"a,0:0,0:0","constructing":true,
-       "varrefp": [
-        {"type":"VARREF","name":"in","addr":"(DKB)","loc":"a,0:0,0:0","dtypep":"(W)","access":"WR","varp":"(BKB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
-      ]}
-    ],
-     "varsp": [
-      {"type":"VAR","name":"n","addr":"(EKB)","loc":"a,0:0,0:0","dtypep":"(OP)","origName":"n","isSc":false,"isPrimaryIO":false,"isPrimaryClock":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":true,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":true,"isStdRandomizeArg":false,"lifetime":"NONE","varType":"BLOCKTEMP","dtypeName":"IData","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"ignorePostWrite":false,"ignoreSchedWrite":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []}
-    ],
-     "stmtsp": [
-      {"type":"ASSIGN","name":"","addr":"(FKB)","loc":"a,0:0,0:0","dtypep":"(OP)",
+      {"type":"VAR","name":"out","addr":"(DKB)","loc":"a,0:0,0:0","dtypep":"(W)","origName":"out","isSc":false,"isPrimaryIO":false,"isPrimaryClock":false,"direction":"INOUT","isConst":false,"isPullup":false,"isPulldown":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":true,"isStdRandomizeArg":false,"lifetime":"NONE","varType":"BLOCKTEMP","dtypeName":"","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"ignorePostWrite":false,"ignoreSchedWrite":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
+      {"type":"ASSIGN","name":"","addr":"(EKB)","loc":"a,0:0,0:0","dtypep":"(W)",
        "rhsp": [
-        {"type":"CONST","name":"32'h0","addr":"(GKB)","loc":"a,0:0,0:0","dtypep":"(HC)"}
+        {"type":"CRESET","name":"","addr":"(FKB)","loc":"a,0:0,0:0","dtypep":"(W)","constructing":true}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"n","addr":"(HKB)","loc":"a,0:0,0:0","dtypep":"(OP)","access":"WR","varp":"(EKB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"out","addr":"(GKB)","loc":"a,0:0,0:0","dtypep":"(W)","access":"WR","varp":"(DKB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []},
-      {"type":"LOOP","name":"","addr":"(IKB)","loc":"d,11:8,11:9","unroll":"default",
+      {"type":"VAR","name":"in","addr":"(HKB)","loc":"a,0:0,0:0","dtypep":"(W)","origName":"in","isSc":false,"isPrimaryIO":false,"isPrimaryClock":false,"direction":"CONSTREF","isConst":false,"isPullup":false,"isPulldown":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":true,"isStdRandomizeArg":false,"lifetime":"NONE","varType":"BLOCKTEMP","dtypeName":"","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"ignorePostWrite":false,"ignoreSchedWrite":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
+      {"type":"ASSIGN","name":"","addr":"(IKB)","loc":"a,0:0,0:0","dtypep":"(W)",
+       "rhsp": [
+        {"type":"CRESET","name":"","addr":"(JKB)","loc":"a,0:0,0:0","dtypep":"(W)","constructing":true}
+      ],
+       "lhsp": [
+        {"type":"VARREF","name":"in","addr":"(KKB)","loc":"a,0:0,0:0","dtypep":"(W)","access":"WR","varp":"(HKB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+      ],"timingControlp": []}
+    ],
+     "varsp": [
+      {"type":"VAR","name":"n","addr":"(LKB)","loc":"a,0:0,0:0","dtypep":"(RP)","origName":"n","isSc":false,"isPrimaryIO":false,"isPrimaryClock":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":true,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":true,"isStdRandomizeArg":false,"lifetime":"NONE","varType":"BLOCKTEMP","dtypeName":"IData","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"ignorePostWrite":false,"ignoreSchedWrite":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []}
+    ],
+     "stmtsp": [
+      {"type":"ASSIGN","name":"","addr":"(MKB)","loc":"a,0:0,0:0","dtypep":"(RP)",
+       "rhsp": [
+        {"type":"CONST","name":"32'h0","addr":"(NKB)","loc":"a,0:0,0:0","dtypep":"(HC)"}
+      ],
+       "lhsp": [
+        {"type":"VARREF","name":"n","addr":"(OKB)","loc":"a,0:0,0:0","dtypep":"(RP)","access":"WR","varp":"(LKB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+      ],"timingControlp": []},
+      {"type":"LOOP","name":"","addr":"(PKB)","loc":"d,11:8,11:9","unroll":"default",
        "stmtsp": [
-        {"type":"ASSIGN","name":"","addr":"(JKB)","loc":"d,11:8,11:9","dtypep":"(HN)",
+        {"type":"ASSIGN","name":"","addr":"(QKB)","loc":"d,11:8,11:9","dtypep":"(HN)",
          "rhsp": [
-          {"type":"OR","name":"","addr":"(KKB)","loc":"d,11:8,11:9","dtypep":"(HN)",
+          {"type":"OR","name":"","addr":"(RKB)","loc":"d,11:8,11:9","dtypep":"(HN)",
            "lhsp": [
-            {"type":"ARRAYSEL","name":"","addr":"(LKB)","loc":"d,11:8,11:9","dtypep":"(HN)",
+            {"type":"ARRAYSEL","name":"","addr":"(SKB)","loc":"d,11:8,11:9","dtypep":"(HN)",
              "fromp": [
-              {"type":"VARREF","name":"out","addr":"(MKB)","loc":"d,11:8,11:9","dtypep":"(W)","access":"RD","varp":"(YJB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+              {"type":"VARREF","name":"out","addr":"(TKB)","loc":"d,11:8,11:9","dtypep":"(W)","access":"RD","varp":"(DKB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
             ],
              "bitp": [
-              {"type":"VARREF","name":"n","addr":"(NKB)","loc":"d,11:8,11:9","dtypep":"(OP)","access":"RD","varp":"(EKB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+              {"type":"VARREF","name":"n","addr":"(UKB)","loc":"d,11:8,11:9","dtypep":"(RP)","access":"RD","varp":"(LKB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
             ]}
           ],
            "rhsp": [
-            {"type":"ARRAYSEL","name":"","addr":"(OKB)","loc":"d,11:8,11:9","dtypep":"(HN)",
+            {"type":"ARRAYSEL","name":"","addr":"(VKB)","loc":"d,11:8,11:9","dtypep":"(HN)",
              "fromp": [
-              {"type":"VARREF","name":"in","addr":"(PKB)","loc":"d,11:8,11:9","dtypep":"(W)","access":"RD","varp":"(BKB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+              {"type":"VARREF","name":"in","addr":"(WKB)","loc":"d,11:8,11:9","dtypep":"(W)","access":"RD","varp":"(HKB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
             ],
              "bitp": [
-              {"type":"VARREF","name":"n","addr":"(QKB)","loc":"d,11:8,11:9","dtypep":"(OP)","access":"RD","varp":"(EKB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+              {"type":"VARREF","name":"n","addr":"(XKB)","loc":"d,11:8,11:9","dtypep":"(RP)","access":"RD","varp":"(LKB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
             ]}
           ]}
         ],
          "lhsp": [
-          {"type":"ARRAYSEL","name":"","addr":"(RKB)","loc":"d,11:8,11:9","dtypep":"(HN)",
+          {"type":"ARRAYSEL","name":"","addr":"(YKB)","loc":"d,11:8,11:9","dtypep":"(HN)",
            "fromp": [
-            {"type":"VARREF","name":"out","addr":"(SKB)","loc":"d,11:8,11:9","dtypep":"(W)","access":"WR","varp":"(YJB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"out","addr":"(ZKB)","loc":"d,11:8,11:9","dtypep":"(W)","access":"WR","varp":"(DKB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ],
            "bitp": [
-            {"type":"VARREF","name":"n","addr":"(TKB)","loc":"d,11:8,11:9","dtypep":"(OP)","access":"RD","varp":"(EKB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"n","addr":"(ALB)","loc":"d,11:8,11:9","dtypep":"(RP)","access":"RD","varp":"(LKB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ]}
         ],"timingControlp": []},
-        {"type":"ASSIGN","name":"","addr":"(UKB)","loc":"a,0:0,0:0","dtypep":"(OP)",
+        {"type":"ASSIGN","name":"","addr":"(BLB)","loc":"a,0:0,0:0","dtypep":"(RP)",
          "rhsp": [
-          {"type":"ADD","name":"","addr":"(VKB)","loc":"a,0:0,0:0","dtypep":"(OP)",
+          {"type":"ADD","name":"","addr":"(CLB)","loc":"a,0:0,0:0","dtypep":"(RP)",
            "lhsp": [
-            {"type":"CCAST","name":"","addr":"(WKB)","loc":"a,0:0,0:0","dtypep":"(HC)","size":32,
+            {"type":"CCAST","name":"","addr":"(DLB)","loc":"a,0:0,0:0","dtypep":"(HC)","size":32,
              "lhsp": [
-              {"type":"CONST","name":"32'h1","addr":"(XKB)","loc":"a,0:0,0:0","dtypep":"(HC)"}
+              {"type":"CONST","name":"32'h1","addr":"(ELB)","loc":"a,0:0,0:0","dtypep":"(HC)"}
             ]}
           ],
            "rhsp": [
-            {"type":"VARREF","name":"n","addr":"(YKB)","loc":"a,0:0,0:0","dtypep":"(OP)","access":"RD","varp":"(EKB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"n","addr":"(FLB)","loc":"a,0:0,0:0","dtypep":"(RP)","access":"RD","varp":"(LKB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ]}
         ],
          "lhsp": [
-          {"type":"VARREF","name":"n","addr":"(ZKB)","loc":"a,0:0,0:0","dtypep":"(OP)","access":"WR","varp":"(EKB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+          {"type":"VARREF","name":"n","addr":"(GLB)","loc":"a,0:0,0:0","dtypep":"(RP)","access":"WR","varp":"(LKB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
         ],"timingControlp": []},
-        {"type":"LOOPTEST","name":"","addr":"(ALB)","loc":"d,11:8,11:9",
+        {"type":"LOOPTEST","name":"","addr":"(HLB)","loc":"d,11:8,11:9",
          "condp": [
-          {"type":"GT","name":"","addr":"(BLB)","loc":"d,11:8,11:9","dtypep":"(GB)",
+          {"type":"GT","name":"","addr":"(ILB)","loc":"d,11:8,11:9","dtypep":"(GB)",
            "lhsp": [
-            {"type":"CONST","name":"32'h1","addr":"(CLB)","loc":"d,11:8,11:9","dtypep":"(HC)"}
+            {"type":"CONST","name":"32'h1","addr":"(JLB)","loc":"d,11:8,11:9","dtypep":"(HC)"}
           ],
            "rhsp": [
-            {"type":"VARREF","name":"n","addr":"(DLB)","loc":"d,11:8,11:9","dtypep":"(OP)","access":"RD","varp":"(EKB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"n","addr":"(KLB)","loc":"d,11:8,11:9","dtypep":"(RP)","access":"RD","varp":"(LKB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ]}
         ]}
       ],"contsp": []}
     ]},
-    {"type":"CFUNC","name":"_eval_phase__act","addr":"(ELB)","loc":"a,0:0,0:0","slow":false,"isStatic":false,"dpiExportDispatcher":false,"dpiExportImpl":false,"dpiImportPrototype":false,"dpiImportWrapper":false,"dpiContext":false,"isConstructor":false,"isDestructor":false,"isVirtual":false,"isCoroutine":false,"needProcess":false,"scopep":"(Z)","argsp": [],"varsp": [],
+    {"type":"CFUNC","name":"_eval_phase__act","addr":"(LLB)","loc":"a,0:0,0:0","slow":false,"isStatic":false,"dpiExportDispatcher":false,"dpiExportImpl":false,"dpiImportPrototype":false,"dpiImportWrapper":false,"dpiContext":false,"isConstructor":false,"isDestructor":false,"isVirtual":false,"isCoroutine":false,"needProcess":false,"scopep":"(Z)","argsp": [],"varsp": [],
      "stmtsp": [
-      {"type":"STMTEXPR","name":"","addr":"(FLB)","loc":"d,11:8,11:9",
+      {"type":"STMTEXPR","name":"","addr":"(MLB)","loc":"d,11:8,11:9",
        "exprp": [
-        {"type":"CCALL","name":"","addr":"(GLB)","loc":"d,11:8,11:9","dtypep":"(DB)","funcName":"_eval_triggers__act","funcp":"(FN)","argsp": []}
+        {"type":"CCALL","name":"","addr":"(NLB)","loc":"d,11:8,11:9","dtypep":"(DB)","funcName":"_eval_triggers__act","funcp":"(FN)","argsp": []}
       ]},
-      {"type":"STMTEXPR","name":"","addr":"(HLB)","loc":"d,11:8,11:9",
+      {"type":"STMTEXPR","name":"","addr":"(OLB)","loc":"d,11:8,11:9",
        "exprp": [
-        {"type":"CCALL","name":"","addr":"(ILB)","loc":"d,11:8,11:9","dtypep":"(DB)","funcName":"_trigger_orInto__act","funcp":"(XJB)",
+        {"type":"CCALL","name":"","addr":"(PLB)","loc":"d,11:8,11:9","dtypep":"(DB)","funcName":"_trigger_orInto__act","funcp":"(CKB)",
          "argsp": [
-          {"type":"VARREF","name":"__VnbaTriggered","addr":"(JLB)","loc":"d,11:8,11:9","dtypep":"(W)","access":"WR","varp":"(X)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"},
-          {"type":"VARREF","name":"__VactTriggered","addr":"(KLB)","loc":"d,11:8,11:9","dtypep":"(W)","access":"RD","varp":"(V)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+          {"type":"VARREF","name":"__VnbaTriggered","addr":"(QLB)","loc":"d,11:8,11:9","dtypep":"(W)","access":"WR","varp":"(X)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"},
+          {"type":"VARREF","name":"__VactTriggered","addr":"(RLB)","loc":"d,11:8,11:9","dtypep":"(W)","access":"RD","varp":"(V)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
         ]}
       ]},
-      {"type":"CRETURN","name":"","addr":"(LLB)","loc":"a,0:0,0:0",
+      {"type":"CRETURN","name":"","addr":"(SLB)","loc":"a,0:0,0:0",
        "lhsp": [
-        {"type":"CONST","name":"1'h0","addr":"(MLB)","loc":"a,0:0,0:0","dtypep":"(GB)"}
+        {"type":"CONST","name":"1'h0","addr":"(TLB)","loc":"a,0:0,0:0","dtypep":"(GB)"}
       ]}
     ]},
-    {"type":"CFUNC","name":"_trigger_clear__act","addr":"(NLB)","loc":"a,0:0,0:0","slow":false,"isStatic":true,"dpiExportDispatcher":false,"dpiExportImpl":false,"dpiImportPrototype":false,"dpiImportWrapper":false,"dpiContext":false,"isConstructor":false,"isDestructor":false,"isVirtual":false,"isCoroutine":false,"needProcess":false,"scopep":"(Z)",
+    {"type":"CFUNC","name":"_trigger_clear__act","addr":"(ULB)","loc":"a,0:0,0:0","slow":false,"isStatic":true,"dpiExportDispatcher":false,"dpiExportImpl":false,"dpiImportPrototype":false,"dpiImportWrapper":false,"dpiContext":false,"isConstructor":false,"isDestructor":false,"isVirtual":false,"isCoroutine":false,"needProcess":false,"scopep":"(Z)",
      "argsp": [
-      {"type":"VAR","name":"out","addr":"(OLB)","loc":"a,0:0,0:0","dtypep":"(W)","origName":"out","isSc":false,"isPrimaryIO":false,"isPrimaryClock":false,"direction":"OUTPUT","isConst":false,"isPullup":false,"isPulldown":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":true,"isStdRandomizeArg":false,"lifetime":"NONE","varType":"BLOCKTEMP","dtypeName":"","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"ignorePostWrite":false,"ignoreSchedWrite":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
-      {"type":"CRESET","name":"","addr":"(PLB)","loc":"a,0:0,0:0","constructing":true,
-       "varrefp": [
-        {"type":"VARREF","name":"out","addr":"(QLB)","loc":"a,0:0,0:0","dtypep":"(W)","access":"WR","varp":"(OLB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
-      ]}
-    ],
-     "varsp": [
-      {"type":"VAR","name":"n","addr":"(RLB)","loc":"a,0:0,0:0","dtypep":"(OP)","origName":"n","isSc":false,"isPrimaryIO":false,"isPrimaryClock":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":true,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":true,"isStdRandomizeArg":false,"lifetime":"NONE","varType":"BLOCKTEMP","dtypeName":"IData","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"ignorePostWrite":false,"ignoreSchedWrite":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []}
-    ],
-     "stmtsp": [
-      {"type":"ASSIGN","name":"","addr":"(SLB)","loc":"a,0:0,0:0","dtypep":"(OP)",
+      {"type":"VAR","name":"out","addr":"(VLB)","loc":"a,0:0,0:0","dtypep":"(W)","origName":"out","isSc":false,"isPrimaryIO":false,"isPrimaryClock":false,"direction":"OUTPUT","isConst":false,"isPullup":false,"isPulldown":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":true,"isStdRandomizeArg":false,"lifetime":"NONE","varType":"BLOCKTEMP","dtypeName":"","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"ignorePostWrite":false,"ignoreSchedWrite":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
+      {"type":"ASSIGN","name":"","addr":"(WLB)","loc":"a,0:0,0:0","dtypep":"(W)",
        "rhsp": [
-        {"type":"CONST","name":"32'h0","addr":"(TLB)","loc":"a,0:0,0:0","dtypep":"(HC)"}
+        {"type":"CRESET","name":"","addr":"(XLB)","loc":"a,0:0,0:0","dtypep":"(W)","constructing":true}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"n","addr":"(ULB)","loc":"a,0:0,0:0","dtypep":"(OP)","access":"WR","varp":"(RLB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"out","addr":"(YLB)","loc":"a,0:0,0:0","dtypep":"(W)","access":"WR","varp":"(VLB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+      ],"timingControlp": []}
+    ],
+     "varsp": [
+      {"type":"VAR","name":"n","addr":"(ZLB)","loc":"a,0:0,0:0","dtypep":"(RP)","origName":"n","isSc":false,"isPrimaryIO":false,"isPrimaryClock":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":true,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":true,"isStdRandomizeArg":false,"lifetime":"NONE","varType":"BLOCKTEMP","dtypeName":"IData","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"ignorePostWrite":false,"ignoreSchedWrite":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []}
+    ],
+     "stmtsp": [
+      {"type":"ASSIGN","name":"","addr":"(AMB)","loc":"a,0:0,0:0","dtypep":"(RP)",
+       "rhsp": [
+        {"type":"CONST","name":"32'h0","addr":"(BMB)","loc":"a,0:0,0:0","dtypep":"(HC)"}
+      ],
+       "lhsp": [
+        {"type":"VARREF","name":"n","addr":"(CMB)","loc":"a,0:0,0:0","dtypep":"(RP)","access":"WR","varp":"(ZLB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []},
-      {"type":"LOOP","name":"","addr":"(VLB)","loc":"d,11:8,11:9","unroll":"default",
+      {"type":"LOOP","name":"","addr":"(DMB)","loc":"d,11:8,11:9","unroll":"default",
        "stmtsp": [
-        {"type":"ASSIGN","name":"","addr":"(WLB)","loc":"d,11:8,11:9","dtypep":"(HN)",
+        {"type":"ASSIGN","name":"","addr":"(EMB)","loc":"d,11:8,11:9","dtypep":"(HN)",
          "rhsp": [
-          {"type":"CONST","name":"64'h0","addr":"(XLB)","loc":"d,11:8,11:9","dtypep":"(JN)"}
+          {"type":"CONST","name":"64'h0","addr":"(FMB)","loc":"d,11:8,11:9","dtypep":"(JN)"}
         ],
          "lhsp": [
-          {"type":"ARRAYSEL","name":"","addr":"(YLB)","loc":"d,11:8,11:9","dtypep":"(HN)",
+          {"type":"ARRAYSEL","name":"","addr":"(GMB)","loc":"d,11:8,11:9","dtypep":"(HN)",
            "fromp": [
-            {"type":"VARREF","name":"out","addr":"(ZLB)","loc":"d,11:8,11:9","dtypep":"(W)","access":"WR","varp":"(OLB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"out","addr":"(HMB)","loc":"d,11:8,11:9","dtypep":"(W)","access":"WR","varp":"(VLB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ],
            "bitp": [
-            {"type":"VARREF","name":"n","addr":"(AMB)","loc":"d,11:8,11:9","dtypep":"(OP)","access":"RD","varp":"(RLB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"n","addr":"(IMB)","loc":"d,11:8,11:9","dtypep":"(RP)","access":"RD","varp":"(ZLB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ]}
         ],"timingControlp": []},
-        {"type":"ASSIGN","name":"","addr":"(BMB)","loc":"a,0:0,0:0","dtypep":"(OP)",
+        {"type":"ASSIGN","name":"","addr":"(JMB)","loc":"a,0:0,0:0","dtypep":"(RP)",
          "rhsp": [
-          {"type":"ADD","name":"","addr":"(CMB)","loc":"a,0:0,0:0","dtypep":"(OP)",
+          {"type":"ADD","name":"","addr":"(KMB)","loc":"a,0:0,0:0","dtypep":"(RP)",
            "lhsp": [
-            {"type":"CCAST","name":"","addr":"(DMB)","loc":"a,0:0,0:0","dtypep":"(HC)","size":32,
+            {"type":"CCAST","name":"","addr":"(LMB)","loc":"a,0:0,0:0","dtypep":"(HC)","size":32,
              "lhsp": [
-              {"type":"CONST","name":"32'h1","addr":"(EMB)","loc":"a,0:0,0:0","dtypep":"(HC)"}
+              {"type":"CONST","name":"32'h1","addr":"(MMB)","loc":"a,0:0,0:0","dtypep":"(HC)"}
             ]}
           ],
            "rhsp": [
-            {"type":"VARREF","name":"n","addr":"(FMB)","loc":"a,0:0,0:0","dtypep":"(OP)","access":"RD","varp":"(RLB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"n","addr":"(NMB)","loc":"a,0:0,0:0","dtypep":"(RP)","access":"RD","varp":"(ZLB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ]}
         ],
          "lhsp": [
-          {"type":"VARREF","name":"n","addr":"(GMB)","loc":"a,0:0,0:0","dtypep":"(OP)","access":"WR","varp":"(RLB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+          {"type":"VARREF","name":"n","addr":"(OMB)","loc":"a,0:0,0:0","dtypep":"(RP)","access":"WR","varp":"(ZLB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
         ],"timingControlp": []},
-        {"type":"LOOPTEST","name":"","addr":"(HMB)","loc":"d,11:8,11:9",
+        {"type":"LOOPTEST","name":"","addr":"(PMB)","loc":"d,11:8,11:9",
          "condp": [
-          {"type":"GT","name":"","addr":"(IMB)","loc":"d,11:8,11:9","dtypep":"(GB)",
+          {"type":"GT","name":"","addr":"(QMB)","loc":"d,11:8,11:9","dtypep":"(GB)",
            "lhsp": [
-            {"type":"CONST","name":"32'h1","addr":"(JMB)","loc":"d,11:8,11:9","dtypep":"(HC)"}
+            {"type":"CONST","name":"32'h1","addr":"(RMB)","loc":"d,11:8,11:9","dtypep":"(HC)"}
           ],
            "rhsp": [
-            {"type":"VARREF","name":"n","addr":"(KMB)","loc":"d,11:8,11:9","dtypep":"(OP)","access":"RD","varp":"(RLB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"n","addr":"(SMB)","loc":"d,11:8,11:9","dtypep":"(RP)","access":"RD","varp":"(ZLB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ]}
         ]}
       ],"contsp": []}
     ]},
-    {"type":"CFUNC","name":"_eval_phase__nba","addr":"(LMB)","loc":"a,0:0,0:0","slow":false,"isStatic":false,"dpiExportDispatcher":false,"dpiExportImpl":false,"dpiImportPrototype":false,"dpiImportWrapper":false,"dpiContext":false,"isConstructor":false,"isDestructor":false,"isVirtual":false,"isCoroutine":false,"needProcess":false,"scopep":"(Z)","argsp": [],
+    {"type":"CFUNC","name":"_eval_phase__nba","addr":"(TMB)","loc":"a,0:0,0:0","slow":false,"isStatic":false,"dpiExportDispatcher":false,"dpiExportImpl":false,"dpiImportPrototype":false,"dpiImportWrapper":false,"dpiContext":false,"isConstructor":false,"isDestructor":false,"isVirtual":false,"isCoroutine":false,"needProcess":false,"scopep":"(Z)","argsp": [],
      "varsp": [
-      {"type":"VAR","name":"__VnbaExecute","addr":"(MMB)","loc":"d,11:8,11:9","dtypep":"(P)","origName":"__VnbaExecute","isSc":false,"isPrimaryIO":false,"isPrimaryClock":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":true,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":true,"isStdRandomizeArg":false,"lifetime":"NONE","varType":"MODULETEMP","dtypeName":"bit","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"ignorePostWrite":false,"ignoreSchedWrite":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []}
+      {"type":"VAR","name":"__VnbaExecute","addr":"(UMB)","loc":"d,11:8,11:9","dtypep":"(P)","origName":"__VnbaExecute","isSc":false,"isPrimaryIO":false,"isPrimaryClock":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":true,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":true,"isStdRandomizeArg":false,"lifetime":"NONE","varType":"MODULETEMP","dtypeName":"bit","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"ignorePostWrite":false,"ignoreSchedWrite":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []}
     ],
      "stmtsp": [
-      {"type":"ASSIGN","name":"","addr":"(NMB)","loc":"a,0:0,0:0","dtypep":"(GB)",
+      {"type":"ASSIGN","name":"","addr":"(VMB)","loc":"a,0:0,0:0","dtypep":"(GB)",
        "rhsp": [
-        {"type":"CCALL","name":"","addr":"(OMB)","loc":"d,11:8,11:9","dtypep":"(GB)","funcName":"_trigger_anySet__act","funcp":"(TO)",
+        {"type":"CCALL","name":"","addr":"(WMB)","loc":"d,11:8,11:9","dtypep":"(GB)","funcName":"_trigger_anySet__act","funcp":"(VO)",
          "argsp": [
-          {"type":"VARREF","name":"__VnbaTriggered","addr":"(PMB)","loc":"d,11:8,11:9","dtypep":"(W)","access":"WR","varp":"(X)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+          {"type":"VARREF","name":"__VnbaTriggered","addr":"(XMB)","loc":"d,11:8,11:9","dtypep":"(W)","access":"WR","varp":"(X)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
         ]}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"__VnbaExecute","addr":"(QMB)","loc":"a,0:0,0:0","dtypep":"(GB)","access":"WR","varp":"(MMB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"__VnbaExecute","addr":"(YMB)","loc":"a,0:0,0:0","dtypep":"(GB)","access":"WR","varp":"(UMB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []},
-      {"type":"IF","name":"","addr":"(RMB)","loc":"a,0:0,0:0",
+      {"type":"IF","name":"","addr":"(ZMB)","loc":"a,0:0,0:0",
        "condp": [
-        {"type":"VARREF","name":"__VnbaExecute","addr":"(SMB)","loc":"a,0:0,0:0","dtypep":"(GB)","access":"RD","varp":"(MMB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"__VnbaExecute","addr":"(ANB)","loc":"a,0:0,0:0","dtypep":"(GB)","access":"RD","varp":"(UMB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],
        "thensp": [
-        {"type":"STMTEXPR","name":"","addr":"(TMB)","loc":"a,0:0,0:0",
+        {"type":"STMTEXPR","name":"","addr":"(BNB)","loc":"a,0:0,0:0",
          "exprp": [
-          {"type":"CCALL","name":"","addr":"(UMB)","loc":"a,0:0,0:0","dtypep":"(DB)","funcName":"_eval_nba","funcp":"(G)","argsp": []}
+          {"type":"CCALL","name":"","addr":"(CNB)","loc":"a,0:0,0:0","dtypep":"(DB)","funcName":"_eval_nba","funcp":"(G)","argsp": []}
         ]},
-        {"type":"STMTEXPR","name":"","addr":"(VMB)","loc":"d,11:8,11:9",
+        {"type":"STMTEXPR","name":"","addr":"(DNB)","loc":"d,11:8,11:9",
          "exprp": [
-          {"type":"CCALL","name":"","addr":"(WMB)","loc":"d,11:8,11:9","dtypep":"(DB)","funcName":"_trigger_clear__act","funcp":"(NLB)",
+          {"type":"CCALL","name":"","addr":"(ENB)","loc":"d,11:8,11:9","dtypep":"(DB)","funcName":"_trigger_clear__act","funcp":"(ULB)",
            "argsp": [
-            {"type":"VARREF","name":"__VnbaTriggered","addr":"(XMB)","loc":"d,11:8,11:9","dtypep":"(W)","access":"WR","varp":"(X)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"__VnbaTriggered","addr":"(FNB)","loc":"d,11:8,11:9","dtypep":"(W)","access":"WR","varp":"(X)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ]}
         ]}
       ],"elsesp": []},
-      {"type":"CRETURN","name":"","addr":"(YMB)","loc":"a,0:0,0:0",
+      {"type":"CRETURN","name":"","addr":"(GNB)","loc":"a,0:0,0:0",
        "lhsp": [
-        {"type":"VARREF","name":"__VnbaExecute","addr":"(ZMB)","loc":"a,0:0,0:0","dtypep":"(GB)","access":"RD","varp":"(MMB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"__VnbaExecute","addr":"(HNB)","loc":"a,0:0,0:0","dtypep":"(GB)","access":"RD","varp":"(UMB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ]}
     ]},
     {"type":"CFUNC","name":"_eval","addr":"(F)","loc":"a,0:0,0:0","slow":false,"isStatic":false,"dpiExportDispatcher":false,"dpiExportImpl":false,"dpiImportPrototype":false,"dpiImportWrapper":false,"dpiContext":false,"isConstructor":false,"isDestructor":false,"isVirtual":false,"isCoroutine":false,"needProcess":false,"scopep":"(Z)","argsp": [],
      "varsp": [
-      {"type":"VAR","name":"__VnbaIterCount","addr":"(ANB)","loc":"d,11:8,11:9","dtypep":"(U)","origName":"__VnbaIterCount","isSc":false,"isPrimaryIO":false,"isPrimaryClock":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":true,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":true,"isStdRandomizeArg":false,"lifetime":"NONE","varType":"MODULETEMP","dtypeName":"bit","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"ignorePostWrite":false,"ignoreSchedWrite":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []}
+      {"type":"VAR","name":"__VnbaIterCount","addr":"(INB)","loc":"d,11:8,11:9","dtypep":"(U)","origName":"__VnbaIterCount","isSc":false,"isPrimaryIO":false,"isPrimaryClock":false,"direction":"NONE","isConst":false,"isPullup":false,"isPulldown":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":true,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":true,"isStdRandomizeArg":false,"lifetime":"NONE","varType":"MODULETEMP","dtypeName":"bit","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"ignorePostWrite":false,"ignoreSchedWrite":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []}
     ],
      "stmtsp": [
-      {"type":"ASSIGN","name":"","addr":"(BNB)","loc":"d,11:8,11:9","dtypep":"(U)",
+      {"type":"ASSIGN","name":"","addr":"(JNB)","loc":"d,11:8,11:9","dtypep":"(U)",
        "rhsp": [
-        {"type":"CONST","name":"32'h0","addr":"(CNB)","loc":"d,11:8,11:9","dtypep":"(HC)"}
+        {"type":"CONST","name":"32'h0","addr":"(KNB)","loc":"d,11:8,11:9","dtypep":"(HC)"}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"__VnbaIterCount","addr":"(DNB)","loc":"d,11:8,11:9","dtypep":"(U)","access":"WR","varp":"(ANB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"__VnbaIterCount","addr":"(LNB)","loc":"d,11:8,11:9","dtypep":"(U)","access":"WR","varp":"(INB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []},
-      {"type":"LOOP","name":"","addr":"(ENB)","loc":"a,0:0,0:0","unroll":"default",
+      {"type":"LOOP","name":"","addr":"(MNB)","loc":"a,0:0,0:0","unroll":"default",
        "stmtsp": [
-        {"type":"IF","name":"","addr":"(FNB)","loc":"a,0:0,0:0",
+        {"type":"IF","name":"","addr":"(NNB)","loc":"a,0:0,0:0",
          "condp": [
-          {"type":"LT","name":"","addr":"(GNB)","loc":"a,0:0,0:0","dtypep":"(GB)",
+          {"type":"LT","name":"","addr":"(ONB)","loc":"a,0:0,0:0","dtypep":"(GB)",
            "lhsp": [
-            {"type":"CONST","name":"32'h64","addr":"(HNB)","loc":"a,0:0,0:0","dtypep":"(HC)"}
+            {"type":"CONST","name":"32'h64","addr":"(PNB)","loc":"a,0:0,0:0","dtypep":"(HC)"}
           ],
            "rhsp": [
-            {"type":"VARREF","name":"__VnbaIterCount","addr":"(INB)","loc":"a,0:0,0:0","dtypep":"(U)","access":"RD","varp":"(ANB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"__VnbaIterCount","addr":"(QNB)","loc":"a,0:0,0:0","dtypep":"(U)","access":"RD","varp":"(INB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ]}
         ],
          "thensp": [
-          {"type":"CSTMT","name":"","addr":"(JNB)","loc":"d,11:8,11:9",
+          {"type":"CSTMT","name":"","addr":"(RNB)","loc":"d,11:8,11:9",
            "nodesp": [
-            {"type":"TEXT","name":"","addr":"(KNB)","loc":"d,11:8,11:9","text":"#ifdef VL_DEBUG\n"},
-            {"type":"STMTEXPR","name":"","addr":"(LNB)","loc":"d,11:8,11:9",
+            {"type":"TEXT","name":"","addr":"(SNB)","loc":"d,11:8,11:9","text":"#ifdef VL_DEBUG\n"},
+            {"type":"STMTEXPR","name":"","addr":"(TNB)","loc":"d,11:8,11:9",
              "exprp": [
-              {"type":"CCALL","name":"","addr":"(MNB)","loc":"d,11:8,11:9","dtypep":"(DB)","funcName":"_dump_triggers__act","funcp":"(CO)",
+              {"type":"CCALL","name":"","addr":"(UNB)","loc":"d,11:8,11:9","dtypep":"(DB)","funcName":"_dump_triggers__act","funcp":"(CO)",
                "argsp": [
-                {"type":"VARREF","name":"__VnbaTriggered","addr":"(NNB)","loc":"d,11:8,11:9","dtypep":"(W)","access":"RD","varp":"(X)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"},
-                {"type":"CONST","name":"\\\"nba\\\"","addr":"(ONB)","loc":"d,11:8,11:9","dtypep":"(SB)"}
+                {"type":"VARREF","name":"__VnbaTriggered","addr":"(VNB)","loc":"d,11:8,11:9","dtypep":"(W)","access":"RD","varp":"(X)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"},
+                {"type":"CONST","name":"\\\"nba\\\"","addr":"(WNB)","loc":"d,11:8,11:9","dtypep":"(SB)"}
               ]}
             ]},
-            {"type":"TEXT","name":"","addr":"(PNB)","loc":"d,11:8,11:9","text":"#endif"}
+            {"type":"TEXT","name":"","addr":"(XNB)","loc":"d,11:8,11:9","text":"#endif"}
           ]},
-          {"type":"CSTMT","name":"","addr":"(QNB)","loc":"a,0:0,0:0",
+          {"type":"CSTMT","name":"","addr":"(YNB)","loc":"a,0:0,0:0",
            "nodesp": [
-            {"type":"TEXT","name":"","addr":"(RNB)","loc":"a,0:0,0:0","text":"VL_FATAL_MT(\"t/t_enum_type_methods.v\", 11, \"\", \"DIDNOTCONVERGE: NBA region did not converge after '--converge-limit' of 100 tries\");"}
+            {"type":"TEXT","name":"","addr":"(ZNB)","loc":"a,0:0,0:0","text":"VL_FATAL_MT(\"t/t_enum_type_methods.v\", 11, \"\", \"DIDNOTCONVERGE: NBA region did not converge after '--converge-limit' of 100 tries\");"}
           ]}
         ],"elsesp": []},
-        {"type":"ASSIGN","name":"","addr":"(SNB)","loc":"d,11:8,11:9","dtypep":"(U)",
+        {"type":"ASSIGN","name":"","addr":"(AOB)","loc":"d,11:8,11:9","dtypep":"(U)",
          "rhsp": [
-          {"type":"ADD","name":"","addr":"(TNB)","loc":"d,11:8,11:9","dtypep":"(U)",
+          {"type":"ADD","name":"","addr":"(BOB)","loc":"d,11:8,11:9","dtypep":"(U)",
            "lhsp": [
-            {"type":"CCAST","name":"","addr":"(UNB)","loc":"d,11:8,11:9","dtypep":"(HC)","size":32,
+            {"type":"CCAST","name":"","addr":"(COB)","loc":"d,11:8,11:9","dtypep":"(HC)","size":32,
              "lhsp": [
-              {"type":"CONST","name":"32'h1","addr":"(VNB)","loc":"d,11:8,11:9","dtypep":"(HC)"}
+              {"type":"CONST","name":"32'h1","addr":"(DOB)","loc":"d,11:8,11:9","dtypep":"(HC)"}
             ]}
           ],
            "rhsp": [
-            {"type":"VARREF","name":"__VnbaIterCount","addr":"(WNB)","loc":"d,11:8,11:9","dtypep":"(U)","access":"RD","varp":"(ANB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"__VnbaIterCount","addr":"(EOB)","loc":"d,11:8,11:9","dtypep":"(U)","access":"RD","varp":"(INB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ]}
         ],
          "lhsp": [
-          {"type":"VARREF","name":"__VnbaIterCount","addr":"(XNB)","loc":"d,11:8,11:9","dtypep":"(U)","access":"WR","varp":"(ANB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+          {"type":"VARREF","name":"__VnbaIterCount","addr":"(FOB)","loc":"d,11:8,11:9","dtypep":"(U)","access":"WR","varp":"(INB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
         ],"timingControlp": []},
-        {"type":"ASSIGN","name":"","addr":"(YNB)","loc":"d,11:8,11:9","dtypep":"(U)",
+        {"type":"ASSIGN","name":"","addr":"(GOB)","loc":"d,11:8,11:9","dtypep":"(U)",
          "rhsp": [
-          {"type":"CONST","name":"32'h0","addr":"(ZNB)","loc":"d,11:8,11:9","dtypep":"(HC)"}
+          {"type":"CONST","name":"32'h0","addr":"(HOB)","loc":"d,11:8,11:9","dtypep":"(HC)"}
         ],
          "lhsp": [
-          {"type":"VARREF","name":"__VactIterCount","addr":"(AOB)","loc":"d,11:8,11:9","dtypep":"(U)","access":"WR","varp":"(T)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+          {"type":"VARREF","name":"__VactIterCount","addr":"(IOB)","loc":"d,11:8,11:9","dtypep":"(U)","access":"WR","varp":"(T)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
         ],"timingControlp": []},
-        {"type":"LOOP","name":"","addr":"(BOB)","loc":"a,0:0,0:0","unroll":"default",
+        {"type":"LOOP","name":"","addr":"(JOB)","loc":"a,0:0,0:0","unroll":"default",
          "stmtsp": [
-          {"type":"IF","name":"","addr":"(COB)","loc":"a,0:0,0:0",
+          {"type":"IF","name":"","addr":"(KOB)","loc":"a,0:0,0:0",
            "condp": [
-            {"type":"LT","name":"","addr":"(DOB)","loc":"a,0:0,0:0","dtypep":"(GB)",
+            {"type":"LT","name":"","addr":"(LOB)","loc":"a,0:0,0:0","dtypep":"(GB)",
              "lhsp": [
-              {"type":"CONST","name":"32'h64","addr":"(EOB)","loc":"a,0:0,0:0","dtypep":"(HC)"}
+              {"type":"CONST","name":"32'h64","addr":"(MOB)","loc":"a,0:0,0:0","dtypep":"(HC)"}
             ],
              "rhsp": [
-              {"type":"VARREF","name":"__VactIterCount","addr":"(FOB)","loc":"a,0:0,0:0","dtypep":"(U)","access":"RD","varp":"(T)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+              {"type":"VARREF","name":"__VactIterCount","addr":"(NOB)","loc":"a,0:0,0:0","dtypep":"(U)","access":"RD","varp":"(T)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
             ]}
           ],
            "thensp": [
-            {"type":"CSTMT","name":"","addr":"(GOB)","loc":"d,11:8,11:9",
+            {"type":"CSTMT","name":"","addr":"(OOB)","loc":"d,11:8,11:9",
              "nodesp": [
-              {"type":"TEXT","name":"","addr":"(HOB)","loc":"d,11:8,11:9","text":"#ifdef VL_DEBUG\n"},
-              {"type":"STMTEXPR","name":"","addr":"(IOB)","loc":"d,11:8,11:9",
+              {"type":"TEXT","name":"","addr":"(POB)","loc":"d,11:8,11:9","text":"#ifdef VL_DEBUG\n"},
+              {"type":"STMTEXPR","name":"","addr":"(QOB)","loc":"d,11:8,11:9",
                "exprp": [
-                {"type":"CCALL","name":"","addr":"(JOB)","loc":"d,11:8,11:9","dtypep":"(DB)","funcName":"_dump_triggers__act","funcp":"(CO)",
+                {"type":"CCALL","name":"","addr":"(ROB)","loc":"d,11:8,11:9","dtypep":"(DB)","funcName":"_dump_triggers__act","funcp":"(CO)",
                  "argsp": [
-                  {"type":"VARREF","name":"__VactTriggered","addr":"(KOB)","loc":"d,11:8,11:9","dtypep":"(W)","access":"RD","varp":"(V)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"},
-                  {"type":"CONST","name":"\\\"act\\\"","addr":"(LOB)","loc":"d,11:8,11:9","dtypep":"(SB)"}
+                  {"type":"VARREF","name":"__VactTriggered","addr":"(SOB)","loc":"d,11:8,11:9","dtypep":"(W)","access":"RD","varp":"(V)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"},
+                  {"type":"CONST","name":"\\\"act\\\"","addr":"(TOB)","loc":"d,11:8,11:9","dtypep":"(SB)"}
                 ]}
               ]},
-              {"type":"TEXT","name":"","addr":"(MOB)","loc":"d,11:8,11:9","text":"#endif"}
+              {"type":"TEXT","name":"","addr":"(UOB)","loc":"d,11:8,11:9","text":"#endif"}
             ]},
-            {"type":"CSTMT","name":"","addr":"(NOB)","loc":"a,0:0,0:0",
+            {"type":"CSTMT","name":"","addr":"(VOB)","loc":"a,0:0,0:0",
              "nodesp": [
-              {"type":"TEXT","name":"","addr":"(OOB)","loc":"a,0:0,0:0","text":"VL_FATAL_MT(\"t/t_enum_type_methods.v\", 11, \"\", \"DIDNOTCONVERGE: Active region did not converge after '--converge-limit' of 100 tries\");"}
+              {"type":"TEXT","name":"","addr":"(WOB)","loc":"a,0:0,0:0","text":"VL_FATAL_MT(\"t/t_enum_type_methods.v\", 11, \"\", \"DIDNOTCONVERGE: Active region did not converge after '--converge-limit' of 100 tries\");"}
             ]}
           ],"elsesp": []},
-          {"type":"ASSIGN","name":"","addr":"(POB)","loc":"d,11:8,11:9","dtypep":"(U)",
+          {"type":"ASSIGN","name":"","addr":"(XOB)","loc":"d,11:8,11:9","dtypep":"(U)",
            "rhsp": [
-            {"type":"ADD","name":"","addr":"(QOB)","loc":"d,11:8,11:9","dtypep":"(U)",
+            {"type":"ADD","name":"","addr":"(YOB)","loc":"d,11:8,11:9","dtypep":"(U)",
              "lhsp": [
-              {"type":"CCAST","name":"","addr":"(ROB)","loc":"d,11:8,11:9","dtypep":"(HC)","size":32,
+              {"type":"CCAST","name":"","addr":"(ZOB)","loc":"d,11:8,11:9","dtypep":"(HC)","size":32,
                "lhsp": [
-                {"type":"CONST","name":"32'h1","addr":"(SOB)","loc":"d,11:8,11:9","dtypep":"(HC)"}
+                {"type":"CONST","name":"32'h1","addr":"(APB)","loc":"d,11:8,11:9","dtypep":"(HC)"}
               ]}
             ],
              "rhsp": [
-              {"type":"VARREF","name":"__VactIterCount","addr":"(TOB)","loc":"d,11:8,11:9","dtypep":"(U)","access":"RD","varp":"(T)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+              {"type":"VARREF","name":"__VactIterCount","addr":"(BPB)","loc":"d,11:8,11:9","dtypep":"(U)","access":"RD","varp":"(T)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
             ]}
           ],
            "lhsp": [
-            {"type":"VARREF","name":"__VactIterCount","addr":"(UOB)","loc":"d,11:8,11:9","dtypep":"(U)","access":"WR","varp":"(T)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"__VactIterCount","addr":"(CPB)","loc":"d,11:8,11:9","dtypep":"(U)","access":"WR","varp":"(T)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ],"timingControlp": []},
-          {"type":"ASSIGN","name":"","addr":"(VOB)","loc":"a,0:0,0:0","dtypep":"(GB)",
+          {"type":"ASSIGN","name":"","addr":"(DPB)","loc":"a,0:0,0:0","dtypep":"(GB)",
            "rhsp": [
-            {"type":"CCALL","name":"","addr":"(WOB)","loc":"a,0:0,0:0","dtypep":"(GB)","funcName":"_eval_phase__act","funcp":"(ELB)","argsp": []}
+            {"type":"CCALL","name":"","addr":"(EPB)","loc":"a,0:0,0:0","dtypep":"(GB)","funcName":"_eval_phase__act","funcp":"(LLB)","argsp": []}
           ],
            "lhsp": [
-            {"type":"VARREF","name":"__VactPhaseResult","addr":"(XOB)","loc":"a,0:0,0:0","dtypep":"(GB)","access":"WR","varp":"(O)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"__VactPhaseResult","addr":"(FPB)","loc":"a,0:0,0:0","dtypep":"(GB)","access":"WR","varp":"(O)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ],"timingControlp": []},
-          {"type":"LOOPTEST","name":"","addr":"(YOB)","loc":"a,0:0,0:0",
+          {"type":"LOOPTEST","name":"","addr":"(GPB)","loc":"a,0:0,0:0",
            "condp": [
-            {"type":"VARREF","name":"__VactPhaseResult","addr":"(ZOB)","loc":"a,0:0,0:0","dtypep":"(GB)","access":"RD","varp":"(O)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"__VactPhaseResult","addr":"(HPB)","loc":"a,0:0,0:0","dtypep":"(GB)","access":"RD","varp":"(O)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ]}
         ],"contsp": []},
-        {"type":"ASSIGN","name":"","addr":"(APB)","loc":"a,0:0,0:0","dtypep":"(GB)",
+        {"type":"ASSIGN","name":"","addr":"(IPB)","loc":"a,0:0,0:0","dtypep":"(GB)",
          "rhsp": [
-          {"type":"CCALL","name":"","addr":"(BPB)","loc":"a,0:0,0:0","dtypep":"(GB)","funcName":"_eval_phase__nba","funcp":"(LMB)","argsp": []}
+          {"type":"CCALL","name":"","addr":"(JPB)","loc":"a,0:0,0:0","dtypep":"(GB)","funcName":"_eval_phase__nba","funcp":"(TMB)","argsp": []}
         ],
          "lhsp": [
-          {"type":"VARREF","name":"__VnbaPhaseResult","addr":"(CPB)","loc":"a,0:0,0:0","dtypep":"(GB)","access":"WR","varp":"(Q)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+          {"type":"VARREF","name":"__VnbaPhaseResult","addr":"(KPB)","loc":"a,0:0,0:0","dtypep":"(GB)","access":"WR","varp":"(Q)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
         ],"timingControlp": []},
-        {"type":"LOOPTEST","name":"","addr":"(DPB)","loc":"a,0:0,0:0",
+        {"type":"LOOPTEST","name":"","addr":"(LPB)","loc":"a,0:0,0:0",
          "condp": [
-          {"type":"VARREF","name":"__VnbaPhaseResult","addr":"(EPB)","loc":"a,0:0,0:0","dtypep":"(GB)","access":"RD","varp":"(Q)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+          {"type":"VARREF","name":"__VnbaPhaseResult","addr":"(MPB)","loc":"a,0:0,0:0","dtypep":"(GB)","access":"RD","varp":"(Q)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
         ]}
       ],"contsp": []}
     ]},
-    {"type":"CFUNC","name":"_eval_debug_assertions","addr":"(FPB)","loc":"d,11:8,11:9","slow":false,"isStatic":false,"dpiExportDispatcher":false,"dpiExportImpl":false,"dpiImportPrototype":false,"dpiImportWrapper":false,"dpiContext":false,"isConstructor":false,"isDestructor":false,"isVirtual":false,"isCoroutine":false,"needProcess":false,"scopep":"UNLINKED","argsp": [],"varsp": [],
+    {"type":"CFUNC","name":"_eval_debug_assertions","addr":"(NPB)","loc":"d,11:8,11:9","slow":false,"isStatic":false,"dpiExportDispatcher":false,"dpiExportImpl":false,"dpiImportPrototype":false,"dpiImportWrapper":false,"dpiContext":false,"isConstructor":false,"isDestructor":false,"isVirtual":false,"isCoroutine":false,"needProcess":false,"scopep":"UNLINKED","argsp": [],"varsp": [],
      "stmtsp": [
-      {"type":"IF","name":"","addr":"(GPB)","loc":"d,15:10,15:13",
+      {"type":"IF","name":"","addr":"(OPB)","loc":"d,15:10,15:13",
        "condp": [
-        {"type":"AND","name":"","addr":"(HPB)","loc":"d,15:10,15:13","dtypep":"(K)",
+        {"type":"AND","name":"","addr":"(PPB)","loc":"d,15:10,15:13","dtypep":"(K)",
          "lhsp": [
-          {"type":"VARREF","name":"clk","addr":"(IPB)","loc":"d,15:10,15:13","dtypep":"(K)","access":"RD","varp":"(J)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+          {"type":"VARREF","name":"clk","addr":"(QPB)","loc":"d,15:10,15:13","dtypep":"(K)","access":"RD","varp":"(J)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
         ],
          "rhsp": [
-          {"type":"CONST","name":"8'hfe","addr":"(JPB)","loc":"d,15:10,15:13","dtypep":"(KPB)"}
+          {"type":"CONST","name":"8'hfe","addr":"(RPB)","loc":"d,15:10,15:13","dtypep":"(SPB)"}
         ]}
       ],
        "thensp": [
-        {"type":"CSTMT","name":"","addr":"(LPB)","loc":"d,15:10,15:13",
+        {"type":"CSTMT","name":"","addr":"(TPB)","loc":"d,15:10,15:13",
          "nodesp": [
-          {"type":"TEXT","name":"","addr":"(MPB)","loc":"d,15:10,15:13","text":"Verilated::overWidthError(\"clk\");"}
+          {"type":"TEXT","name":"","addr":"(UPB)","loc":"d,15:10,15:13","text":"Verilated::overWidthError(\"clk\");"}
         ]}
       ],"elsesp": []}
     ]},
-    {"type":"CFUNC","name":"_ctor_var_reset","addr":"(NPB)","loc":"d,11:8,11:9","slow":true,"isStatic":false,"dpiExportDispatcher":false,"dpiExportImpl":false,"dpiImportPrototype":false,"dpiImportWrapper":false,"dpiContext":false,"isConstructor":false,"isDestructor":false,"isVirtual":false,"isCoroutine":false,"needProcess":false,"scopep":"UNLINKED","argsp": [],"varsp": [],
+    {"type":"CFUNC","name":"_ctor_var_reset","addr":"(VPB)","loc":"d,11:8,11:9","slow":true,"isStatic":false,"dpiExportDispatcher":false,"dpiExportImpl":false,"dpiImportPrototype":false,"dpiImportWrapper":false,"dpiContext":false,"isConstructor":false,"isDestructor":false,"isVirtual":false,"isCoroutine":false,"needProcess":false,"scopep":"UNLINKED","argsp": [],"varsp": [],
      "stmtsp": [
-      {"type":"CRESET","name":"","addr":"(OPB)","loc":"d,15:10,15:13","constructing":true,
-       "varrefp": [
-        {"type":"VARREF","name":"clk","addr":"(PPB)","loc":"d,15:10,15:13","dtypep":"(K)","access":"WR","varp":"(J)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
-      ]},
-      {"type":"CRESET","name":"","addr":"(QPB)","loc":"d,23:17,23:20","constructing":true,
-       "varrefp": [
-        {"type":"VARREF","name":"t.cyc","addr":"(RPB)","loc":"d,23:17,23:20","dtypep":"(S)","access":"WR","varp":"(R)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
-      ]},
-      {"type":"CRESET","name":"","addr":"(SPB)","loc":"d,24:9,24:10","constructing":true,
-       "varrefp": [
-        {"type":"VARREF","name":"t.e","addr":"(TPB)","loc":"d,24:9,24:10","dtypep":"(M)","access":"WR","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
-      ]},
-      {"type":"CRESET","name":"","addr":"(UPB)","loc":"d,11:8,11:9","constructing":true,
-       "varrefp": [
-        {"type":"VARREF","name":"__VactTriggered","addr":"(VPB)","loc":"d,11:8,11:9","dtypep":"(W)","access":"WR","varp":"(V)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
-      ]},
-      {"type":"CRESET","name":"","addr":"(WPB)","loc":"d,11:8,11:9","constructing":true,
-       "varrefp": [
-        {"type":"VARREF","name":"__Vtrigprevexpr___TOP__clk__0","addr":"(XPB)","loc":"d,11:8,11:9","dtypep":"(K)","access":"WR","varp":"(N)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
-      ]},
-      {"type":"CRESET","name":"","addr":"(YPB)","loc":"d,11:8,11:9","constructing":true,
-       "varrefp": [
-        {"type":"VARREF","name":"__VnbaTriggered","addr":"(ZPB)","loc":"d,11:8,11:9","dtypep":"(W)","access":"WR","varp":"(X)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
-      ]}
+      {"type":"ASSIGN","name":"","addr":"(WPB)","loc":"d,15:10,15:13","dtypep":"(K)",
+       "rhsp": [
+        {"type":"CRESET","name":"","addr":"(XPB)","loc":"d,15:10,15:13","dtypep":"(K)","constructing":true}
+      ],
+       "lhsp": [
+        {"type":"VARREF","name":"clk","addr":"(YPB)","loc":"d,15:10,15:13","dtypep":"(K)","access":"WR","varp":"(J)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+      ],"timingControlp": []},
+      {"type":"ASSIGN","name":"","addr":"(ZPB)","loc":"d,23:17,23:20","dtypep":"(S)",
+       "rhsp": [
+        {"type":"CRESET","name":"","addr":"(AQB)","loc":"d,23:17,23:20","dtypep":"(S)","constructing":true}
+      ],
+       "lhsp": [
+        {"type":"VARREF","name":"t.cyc","addr":"(BQB)","loc":"d,23:17,23:20","dtypep":"(S)","access":"WR","varp":"(R)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+      ],"timingControlp": []},
+      {"type":"ASSIGN","name":"","addr":"(CQB)","loc":"d,24:9,24:10","dtypep":"(M)",
+       "rhsp": [
+        {"type":"CRESET","name":"","addr":"(DQB)","loc":"d,24:9,24:10","dtypep":"(M)","constructing":true}
+      ],
+       "lhsp": [
+        {"type":"VARREF","name":"t.e","addr":"(EQB)","loc":"d,24:9,24:10","dtypep":"(M)","access":"WR","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+      ],"timingControlp": []},
+      {"type":"ASSIGN","name":"","addr":"(FQB)","loc":"d,11:8,11:9","dtypep":"(W)",
+       "rhsp": [
+        {"type":"CRESET","name":"","addr":"(GQB)","loc":"d,11:8,11:9","dtypep":"(W)","constructing":true}
+      ],
+       "lhsp": [
+        {"type":"VARREF","name":"__VactTriggered","addr":"(HQB)","loc":"d,11:8,11:9","dtypep":"(W)","access":"WR","varp":"(V)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+      ],"timingControlp": []},
+      {"type":"ASSIGN","name":"","addr":"(IQB)","loc":"d,11:8,11:9","dtypep":"(K)",
+       "rhsp": [
+        {"type":"CRESET","name":"","addr":"(JQB)","loc":"d,11:8,11:9","dtypep":"(K)","constructing":true}
+      ],
+       "lhsp": [
+        {"type":"VARREF","name":"__Vtrigprevexpr___TOP__clk__0","addr":"(KQB)","loc":"d,11:8,11:9","dtypep":"(K)","access":"WR","varp":"(N)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+      ],"timingControlp": []},
+      {"type":"ASSIGN","name":"","addr":"(LQB)","loc":"d,11:8,11:9","dtypep":"(W)",
+       "rhsp": [
+        {"type":"CRESET","name":"","addr":"(MQB)","loc":"d,11:8,11:9","dtypep":"(W)","constructing":true}
+      ],
+       "lhsp": [
+        {"type":"VARREF","name":"__VnbaTriggered","addr":"(NQB)","loc":"d,11:8,11:9","dtypep":"(W)","access":"WR","varp":"(X)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+      ],"timingControlp": []}
     ]},
-    {"type":"CUSE","name":"$unit","addr":"(AQB)","loc":"a,0:0,0:0","useType":"INT_FWD"}
+    {"type":"CUSE","name":"$unit","addr":"(OQB)","loc":"a,0:0,0:0","useType":"INT_FWD"}
   ]},
   {"type":"PACKAGE","name":"$unit","addr":"(E)","loc":"a,0:0,0:0","origName":"__024unit","level":2,"modPublic":false,"inLibrary":true,"dead":false,"recursiveClone":false,"recursive":false,"timeunit":"NONE","inlinesp": [],
    "stmtsp": [
     {"type":"VAR","name":"__Venumtab_enum_next1","addr":"(DC)","loc":"d,17:12,17:16","dtypep":"(CC)","origName":"__Venumtab_enum_next1","isSc":false,"isPrimaryIO":false,"isPrimaryClock":false,"direction":"NONE","isConst":true,"isPullup":false,"isPulldown":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"isStdRandomizeArg":false,"lifetime":"VSTATIC","varType":"MODULETEMP","dtypeName":"","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"ignorePostWrite":false,"ignoreSchedWrite":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],
      "valuep": [
-      {"type":"INITARRAY","name":"","addr":"(BQB)","loc":"d,17:12,17:16","dtypep":"(CC)","initList":" [1]=(CQB) [3]=(DQB) [4]=(EQB)",
+      {"type":"INITARRAY","name":"","addr":"(PQB)","loc":"d,17:12,17:16","dtypep":"(CC)","initList":" [1]=(QQB) [3]=(RQB) [4]=(SQB)",
        "defaultp": [
-        {"type":"CONST","name":"4'h0","addr":"(FQB)","loc":"d,17:12,17:16","dtypep":"(UB)"}
+        {"type":"CONST","name":"4'h0","addr":"(TQB)","loc":"d,17:12,17:16","dtypep":"(UB)"}
       ],
        "initsp": [
-        {"type":"INITITEM","name":"","addr":"(CQB)","loc":"d,17:12,17:16",
+        {"type":"INITITEM","name":"","addr":"(QQB)","loc":"d,17:12,17:16",
          "valuep": [
-          {"type":"CONST","name":"4'h3","addr":"(GQB)","loc":"d,19:30,19:31","dtypep":"(UB)"}
+          {"type":"CONST","name":"4'h3","addr":"(UQB)","loc":"d,19:30,19:31","dtypep":"(UB)"}
         ]},
-        {"type":"INITITEM","name":"","addr":"(DQB)","loc":"d,17:12,17:16",
+        {"type":"INITITEM","name":"","addr":"(RQB)","loc":"d,17:12,17:16",
          "valuep": [
-          {"type":"CONST","name":"4'h4","addr":"(HQB)","loc":"d,20:30,20:31","dtypep":"(UB)"}
+          {"type":"CONST","name":"4'h4","addr":"(VQB)","loc":"d,20:30,20:31","dtypep":"(UB)"}
         ]},
-        {"type":"INITITEM","name":"","addr":"(EQB)","loc":"d,17:12,17:16",
+        {"type":"INITITEM","name":"","addr":"(SQB)","loc":"d,17:12,17:16",
          "valuep": [
-          {"type":"CONST","name":"4'h1","addr":"(IQB)","loc":"d,18:30,18:31","dtypep":"(UB)"}
+          {"type":"CONST","name":"4'h1","addr":"(WQB)","loc":"d,18:30,18:31","dtypep":"(UB)"}
         ]}
       ]}
     ],"attrsp": []},
     {"type":"VAR","name":"__Venumtab_enum_prev1","addr":"(XI)","loc":"d,17:12,17:16","dtypep":"(WI)","origName":"__Venumtab_enum_prev1","isSc":false,"isPrimaryIO":false,"isPrimaryClock":false,"direction":"NONE","isConst":true,"isPullup":false,"isPulldown":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"isStdRandomizeArg":false,"lifetime":"VSTATIC","varType":"MODULETEMP","dtypeName":"","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"ignorePostWrite":false,"ignoreSchedWrite":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],
      "valuep": [
-      {"type":"INITARRAY","name":"","addr":"(JQB)","loc":"d,17:12,17:16","dtypep":"(WI)","initList":" [1]=(KQB) [3]=(LQB) [4]=(MQB)",
+      {"type":"INITARRAY","name":"","addr":"(XQB)","loc":"d,17:12,17:16","dtypep":"(WI)","initList":" [1]=(YQB) [3]=(ZQB) [4]=(ARB)",
        "defaultp": [
-        {"type":"CONST","name":"4'h0","addr":"(NQB)","loc":"d,17:12,17:16","dtypep":"(UB)"}
+        {"type":"CONST","name":"4'h0","addr":"(BRB)","loc":"d,17:12,17:16","dtypep":"(UB)"}
       ],
        "initsp": [
-        {"type":"INITITEM","name":"","addr":"(KQB)","loc":"d,17:12,17:16",
+        {"type":"INITITEM","name":"","addr":"(YQB)","loc":"d,17:12,17:16",
          "valuep": [
-          {"type":"CONST","name":"4'h4","addr":"(OQB)","loc":"d,20:30,20:31","dtypep":"(UB)"}
+          {"type":"CONST","name":"4'h4","addr":"(CRB)","loc":"d,20:30,20:31","dtypep":"(UB)"}
         ]},
-        {"type":"INITITEM","name":"","addr":"(LQB)","loc":"d,17:12,17:16",
+        {"type":"INITITEM","name":"","addr":"(ZQB)","loc":"d,17:12,17:16",
          "valuep": [
-          {"type":"CONST","name":"4'h1","addr":"(PQB)","loc":"d,18:30,18:31","dtypep":"(UB)"}
+          {"type":"CONST","name":"4'h1","addr":"(DRB)","loc":"d,18:30,18:31","dtypep":"(UB)"}
         ]},
-        {"type":"INITITEM","name":"","addr":"(MQB)","loc":"d,17:12,17:16",
+        {"type":"INITITEM","name":"","addr":"(ARB)","loc":"d,17:12,17:16",
          "valuep": [
-          {"type":"CONST","name":"4'h3","addr":"(QQB)","loc":"d,19:30,19:31","dtypep":"(UB)"}
+          {"type":"CONST","name":"4'h3","addr":"(ERB)","loc":"d,19:30,19:31","dtypep":"(UB)"}
         ]}
       ]}
     ],"attrsp": []},
     {"type":"VAR","name":"__Venumtab_enum_name1","addr":"(JM)","loc":"d,17:12,17:16","dtypep":"(IM)","origName":"__Venumtab_enum_name1","isSc":false,"isPrimaryIO":false,"isPrimaryClock":false,"direction":"NONE","isConst":true,"isPullup":false,"isPulldown":false,"isSigPublic":false,"isLatched":false,"isUsedLoopIdx":false,"noReset":false,"attrIsolateAssign":false,"attrFileDescr":false,"isDpiOpenArray":false,"isFuncReturn":false,"isFuncLocal":false,"isStdRandomizeArg":false,"lifetime":"VSTATIC","varType":"MODULETEMP","dtypeName":"","isSigUserRdPublic":false,"isSigUserRWPublic":false,"isGParam":false,"isParam":false,"attrScBv":false,"attrSFormat":false,"ignorePostWrite":false,"ignoreSchedWrite":false,"sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],
      "valuep": [
-      {"type":"INITARRAY","name":"","addr":"(RQB)","loc":"d,17:12,17:16","dtypep":"(IM)","initList":" [1]=(SQB) [3]=(TQB) [4]=(UQB)",
+      {"type":"INITARRAY","name":"","addr":"(FRB)","loc":"d,17:12,17:16","dtypep":"(IM)","initList":" [1]=(GRB) [3]=(HRB) [4]=(IRB)",
        "defaultp": [
-        {"type":"CONST","name":"\\\"\\\"","addr":"(VQB)","loc":"d,17:12,17:16","dtypep":"(SB)"}
+        {"type":"CONST","name":"\\\"\\\"","addr":"(JRB)","loc":"d,17:12,17:16","dtypep":"(SB)"}
       ],
        "initsp": [
-        {"type":"INITITEM","name":"","addr":"(SQB)","loc":"d,17:12,17:16",
+        {"type":"INITITEM","name":"","addr":"(GRB)","loc":"d,17:12,17:16",
          "valuep": [
-          {"type":"CONST","name":"\\\"E01\\\"","addr":"(WQB)","loc":"d,17:12,17:16","dtypep":"(SB)"}
+          {"type":"CONST","name":"\\\"E01\\\"","addr":"(KRB)","loc":"d,17:12,17:16","dtypep":"(SB)"}
         ]},
-        {"type":"INITITEM","name":"","addr":"(TQB)","loc":"d,17:12,17:16",
+        {"type":"INITITEM","name":"","addr":"(HRB)","loc":"d,17:12,17:16",
          "valuep": [
-          {"type":"CONST","name":"\\\"E03\\\"","addr":"(XQB)","loc":"d,17:12,17:16","dtypep":"(SB)"}
+          {"type":"CONST","name":"\\\"E03\\\"","addr":"(LRB)","loc":"d,17:12,17:16","dtypep":"(SB)"}
         ]},
-        {"type":"INITITEM","name":"","addr":"(UQB)","loc":"d,17:12,17:16",
+        {"type":"INITITEM","name":"","addr":"(IRB)","loc":"d,17:12,17:16",
          "valuep": [
-          {"type":"CONST","name":"\\\"E04\\\"","addr":"(YQB)","loc":"d,17:12,17:16","dtypep":"(SB)"}
+          {"type":"CONST","name":"\\\"E04\\\"","addr":"(MRB)","loc":"d,17:12,17:16","dtypep":"(SB)"}
         ]}
       ]}
     ],"attrsp": []},
-    {"type":"SCOPE","name":"$unit","addr":"(ZQB)","loc":"a,0:0,0:0","aboveScopep":"(Z)","aboveCellp":"(Y)","modp":"(E)","varsp": [],"blocksp": [],"inlinesp": []},
-    {"type":"CFUNC","name":"_ctor_var_reset","addr":"(ARB)","loc":"a,0:0,0:0","slow":true,"isStatic":false,"dpiExportDispatcher":false,"dpiExportImpl":false,"dpiImportPrototype":false,"dpiImportWrapper":false,"dpiContext":false,"isConstructor":false,"isDestructor":false,"isVirtual":false,"isCoroutine":false,"needProcess":false,"scopep":"UNLINKED","argsp": [],"varsp": [],
+    {"type":"SCOPE","name":"$unit","addr":"(NRB)","loc":"a,0:0,0:0","aboveScopep":"(Z)","aboveCellp":"(Y)","modp":"(E)","varsp": [],"blocksp": [],"inlinesp": []},
+    {"type":"CFUNC","name":"_ctor_var_reset","addr":"(ORB)","loc":"a,0:0,0:0","slow":true,"isStatic":false,"dpiExportDispatcher":false,"dpiExportImpl":false,"dpiImportPrototype":false,"dpiImportWrapper":false,"dpiContext":false,"isConstructor":false,"isDestructor":false,"isVirtual":false,"isCoroutine":false,"needProcess":false,"scopep":"UNLINKED","argsp": [],"varsp": [],
      "stmtsp": [
-      {"type":"CRESET","name":"","addr":"(BRB)","loc":"d,17:12,17:16","constructing":true,
-       "varrefp": [
-        {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(CRB)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"WR","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
-      ]},
-      {"type":"CRESET","name":"","addr":"(DRB)","loc":"d,17:12,17:16","constructing":true,
-       "varrefp": [
-        {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(ERB)","loc":"d,17:12,17:16","dtypep":"(WI)","access":"WR","varp":"(XI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
-      ]},
-      {"type":"CRESET","name":"","addr":"(FRB)","loc":"d,17:12,17:16","constructing":true,
-       "varrefp": [
-        {"type":"VARREF","name":"__Venumtab_enum_name1","addr":"(GRB)","loc":"d,17:12,17:16","dtypep":"(IM)","access":"WR","varp":"(JM)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
-      ]}
+      {"type":"ASSIGN","name":"","addr":"(PRB)","loc":"d,17:12,17:16","dtypep":"(CC)",
+       "rhsp": [
+        {"type":"CRESET","name":"","addr":"(QRB)","loc":"d,17:12,17:16","dtypep":"(CC)","constructing":true}
+      ],
+       "lhsp": [
+        {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(RRB)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"WR","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+      ],"timingControlp": []},
+      {"type":"ASSIGN","name":"","addr":"(SRB)","loc":"d,17:12,17:16","dtypep":"(WI)",
+       "rhsp": [
+        {"type":"CRESET","name":"","addr":"(TRB)","loc":"d,17:12,17:16","dtypep":"(WI)","constructing":true}
+      ],
+       "lhsp": [
+        {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(URB)","loc":"d,17:12,17:16","dtypep":"(WI)","access":"WR","varp":"(XI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+      ],"timingControlp": []},
+      {"type":"ASSIGN","name":"","addr":"(VRB)","loc":"d,17:12,17:16","dtypep":"(IM)",
+       "rhsp": [
+        {"type":"CRESET","name":"","addr":"(WRB)","loc":"d,17:12,17:16","dtypep":"(IM)","constructing":true}
+      ],
+       "lhsp": [
+        {"type":"VARREF","name":"__Venumtab_enum_name1","addr":"(XRB)","loc":"d,17:12,17:16","dtypep":"(IM)","access":"WR","varp":"(JM)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+      ],"timingControlp": []}
     ]}
   ]}
 ],
  "filesp": [
-  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck__Syms__Slow.cpp","addr":"(HRB)","loc":"a,0:0,0:0","source":true,"slow":true,"tblockp": []},
-  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck__Syms.h","addr":"(IRB)","loc":"a,0:0,0:0","source":false,"slow":false,"tblockp": []},
-  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck.h","addr":"(JRB)","loc":"a,0:0,0:0","source":false,"slow":false,"tblockp": []},
-  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck.cpp","addr":"(KRB)","loc":"a,0:0,0:0","source":true,"slow":false,"tblockp": []},
-  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck__pch.h","addr":"(LRB)","loc":"a,0:0,0:0","source":false,"slow":false,"tblockp": []},
-  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck_$root.h","addr":"(MRB)","loc":"a,0:0,0:0","source":false,"slow":false,"tblockp": []},
-  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck_$unit.h","addr":"(NRB)","loc":"a,0:0,0:0","source":false,"slow":false,"tblockp": []},
-  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck_$root__Slow.cpp","addr":"(ORB)","loc":"a,0:0,0:0","source":true,"slow":true,"tblockp": []},
-  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck_$root__0__Slow.cpp","addr":"(PRB)","loc":"a,0:0,0:0","source":true,"slow":true,"tblockp": []},
-  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck_$root__0.cpp","addr":"(QRB)","loc":"a,0:0,0:0","source":true,"slow":false,"tblockp": []},
-  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck_$unit__Slow.cpp","addr":"(RRB)","loc":"a,0:0,0:0","source":true,"slow":true,"tblockp": []},
-  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck_$unit__0__Slow.cpp","addr":"(SRB)","loc":"a,0:0,0:0","source":true,"slow":true,"tblockp": []}
+  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck__Syms__Slow.cpp","addr":"(YRB)","loc":"a,0:0,0:0","source":true,"slow":true,"tblockp": []},
+  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck__Syms.h","addr":"(ZRB)","loc":"a,0:0,0:0","source":false,"slow":false,"tblockp": []},
+  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck.h","addr":"(ASB)","loc":"a,0:0,0:0","source":false,"slow":false,"tblockp": []},
+  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck.cpp","addr":"(BSB)","loc":"a,0:0,0:0","source":true,"slow":false,"tblockp": []},
+  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck__pch.h","addr":"(CSB)","loc":"a,0:0,0:0","source":false,"slow":false,"tblockp": []},
+  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck_$root.h","addr":"(DSB)","loc":"a,0:0,0:0","source":false,"slow":false,"tblockp": []},
+  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck_$unit.h","addr":"(ESB)","loc":"a,0:0,0:0","source":false,"slow":false,"tblockp": []},
+  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck_$root__Slow.cpp","addr":"(FSB)","loc":"a,0:0,0:0","source":true,"slow":true,"tblockp": []},
+  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck_$root__0__Slow.cpp","addr":"(GSB)","loc":"a,0:0,0:0","source":true,"slow":true,"tblockp": []},
+  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck_$root__0.cpp","addr":"(HSB)","loc":"a,0:0,0:0","source":true,"slow":false,"tblockp": []},
+  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck_$unit__Slow.cpp","addr":"(ISB)","loc":"a,0:0,0:0","source":true,"slow":true,"tblockp": []},
+  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck_$unit__0__Slow.cpp","addr":"(JSB)","loc":"a,0:0,0:0","source":true,"slow":true,"tblockp": []}
 ],
  "miscsp": [
   {"type":"TYPETABLE","name":"","addr":"(C)","loc":"a,0:0,0:0","constraintRefp":"UNLINKED","emptyQueuep":"UNLINKED","queueIndexp":"UNLINKED","streamp":"UNLINKED","voidp":"(DB)",
    "typesp": [
     {"type":"BASICDTYPE","name":"logic","addr":"(K)","loc":"d,33:24,33:27","dtypep":"(K)","keyword":"logic","generic":true,"rangep": []},
     {"type":"BASICDTYPE","name":"logic","addr":"(HC)","loc":"d,53:16,53:17","dtypep":"(HC)","keyword":"logic","range":"31:0","generic":true,"rangep": []},
-    {"type":"BASICDTYPE","name":"logic","addr":"(TRB)","loc":"d,17:17,17:18","dtypep":"(TRB)","keyword":"logic","range":"3:0","generic":true,"rangep": []},
-    {"type":"ENUMDTYPE","name":"t.my_t","addr":"(URB)","loc":"d,17:12,17:16","dtypep":"(URB)","enum":true,"generic":false,"refDTypep":"(TRB)","childDTypep": [],
+    {"type":"BASICDTYPE","name":"logic","addr":"(KSB)","loc":"d,17:17,17:18","dtypep":"(KSB)","keyword":"logic","range":"3:0","generic":true,"rangep": []},
+    {"type":"ENUMDTYPE","name":"t.my_t","addr":"(LSB)","loc":"d,17:12,17:16","dtypep":"(LSB)","enum":true,"generic":false,"refDTypep":"(KSB)","childDTypep": [],
      "itemsp": [
-      {"type":"ENUMITEM","name":"E01","addr":"(VRB)","loc":"d,18:24,18:27","dtypep":"(UB)","rangep": [],
+      {"type":"ENUMITEM","name":"E01","addr":"(MSB)","loc":"d,18:24,18:27","dtypep":"(UB)","rangep": [],
        "valuep": [
-        {"type":"CONST","name":"4'h1","addr":"(WRB)","loc":"d,18:30,18:31","dtypep":"(UB)"}
+        {"type":"CONST","name":"4'h1","addr":"(NSB)","loc":"d,18:30,18:31","dtypep":"(UB)"}
       ]},
-      {"type":"ENUMITEM","name":"E03","addr":"(XRB)","loc":"d,19:24,19:27","dtypep":"(UB)","rangep": [],
+      {"type":"ENUMITEM","name":"E03","addr":"(OSB)","loc":"d,19:24,19:27","dtypep":"(UB)","rangep": [],
        "valuep": [
-        {"type":"CONST","name":"4'h3","addr":"(YRB)","loc":"d,19:30,19:31","dtypep":"(UB)"}
+        {"type":"CONST","name":"4'h3","addr":"(PSB)","loc":"d,19:30,19:31","dtypep":"(UB)"}
       ]},
-      {"type":"ENUMITEM","name":"E04","addr":"(ZRB)","loc":"d,20:24,20:27","dtypep":"(UB)","rangep": [],
+      {"type":"ENUMITEM","name":"E04","addr":"(QSB)","loc":"d,20:24,20:27","dtypep":"(UB)","rangep": [],
        "valuep": [
-        {"type":"CONST","name":"4'h4","addr":"(ASB)","loc":"d,20:30,20:31","dtypep":"(UB)"}
+        {"type":"CONST","name":"4'h4","addr":"(RSB)","loc":"d,20:30,20:31","dtypep":"(UB)"}
       ]}
     ]},
     {"type":"BASICDTYPE","name":"integer","addr":"(S)","loc":"d,23:4,23:11","dtypep":"(S)","keyword":"integer","range":"31:0","generic":true,"signed":true,"rangep": []},
-    {"type":"REFDTYPE","name":"my_t","addr":"(M)","loc":"d,24:4,24:8","dtypep":"(URB)","generic":false,"typedefp":"UNLINKED","refDTypep":"(URB)","classOrPackagep":"UNLINKED","typeofp": [],"classOrPackageOpp": [],"paramsp": []},
+    {"type":"REFDTYPE","name":"my_t","addr":"(M)","loc":"d,24:4,24:8","dtypep":"(LSB)","generic":false,"typedefp":"UNLINKED","refDTypep":"(LSB)","classOrPackagep":"UNLINKED","typeofp": [],"classOrPackageOpp": [],"paramsp": []},
     {"type":"BASICDTYPE","name":"string","addr":"(SB)","loc":"d,28:4,28:10","dtypep":"(SB)","keyword":"string","generic":true,"rangep": []},
-    {"type":"UNPACKARRAYDTYPE","name":"","addr":"(CC)","loc":"d,17:12,17:16","dtypep":"(CC)","isCompound":false,"declRange":"[7:0]","generic":false,"refDTypep":"(URB)","childDTypep": [],
+    {"type":"UNPACKARRAYDTYPE","name":"","addr":"(CC)","loc":"d,17:12,17:16","dtypep":"(CC)","isCompound":false,"declRange":"[7:0]","generic":false,"refDTypep":"(LSB)","childDTypep": [],
      "rangep": [
-      {"type":"RANGE","name":"","addr":"(BSB)","loc":"d,17:12,17:16","ascending":false,"fromBracket":false,
+      {"type":"RANGE","name":"","addr":"(SSB)","loc":"d,17:12,17:16","ascending":false,"fromBracket":false,
        "leftp": [
-        {"type":"CONST","name":"32'h7","addr":"(CSB)","loc":"d,17:12,17:16","dtypep":"(HC)"}
+        {"type":"CONST","name":"32'h7","addr":"(TSB)","loc":"d,17:12,17:16","dtypep":"(HC)"}
       ],
        "rightp": [
-        {"type":"CONST","name":"32'h0","addr":"(DSB)","loc":"d,17:12,17:16","dtypep":"(HC)"}
+        {"type":"CONST","name":"32'h0","addr":"(USB)","loc":"d,17:12,17:16","dtypep":"(HC)"}
       ]}
     ]},
-    {"type":"UNPACKARRAYDTYPE","name":"","addr":"(WI)","loc":"d,17:12,17:16","dtypep":"(WI)","isCompound":false,"declRange":"[7:0]","generic":false,"refDTypep":"(URB)","childDTypep": [],
+    {"type":"UNPACKARRAYDTYPE","name":"","addr":"(WI)","loc":"d,17:12,17:16","dtypep":"(WI)","isCompound":false,"declRange":"[7:0]","generic":false,"refDTypep":"(LSB)","childDTypep": [],
      "rangep": [
-      {"type":"RANGE","name":"","addr":"(ESB)","loc":"d,17:12,17:16","ascending":false,"fromBracket":false,
+      {"type":"RANGE","name":"","addr":"(VSB)","loc":"d,17:12,17:16","ascending":false,"fromBracket":false,
        "leftp": [
-        {"type":"CONST","name":"32'h7","addr":"(FSB)","loc":"d,17:12,17:16","dtypep":"(HC)"}
+        {"type":"CONST","name":"32'h7","addr":"(WSB)","loc":"d,17:12,17:16","dtypep":"(HC)"}
       ],
        "rightp": [
-        {"type":"CONST","name":"32'h0","addr":"(GSB)","loc":"d,17:12,17:16","dtypep":"(HC)"}
+        {"type":"CONST","name":"32'h0","addr":"(XSB)","loc":"d,17:12,17:16","dtypep":"(HC)"}
       ]}
     ]},
     {"type":"UNPACKARRAYDTYPE","name":"","addr":"(IM)","loc":"d,17:12,17:16","dtypep":"(IM)","isCompound":true,"declRange":"[7:0]","generic":false,"refDTypep":"(SB)","childDTypep": [],
      "rangep": [
-      {"type":"RANGE","name":"","addr":"(HSB)","loc":"d,17:12,17:16","ascending":false,"fromBracket":false,
+      {"type":"RANGE","name":"","addr":"(YSB)","loc":"d,17:12,17:16","ascending":false,"fromBracket":false,
        "leftp": [
-        {"type":"CONST","name":"32'h7","addr":"(ISB)","loc":"d,17:12,17:16","dtypep":"(HC)"}
+        {"type":"CONST","name":"32'h7","addr":"(ZSB)","loc":"d,17:12,17:16","dtypep":"(HC)"}
       ],
        "rightp": [
-        {"type":"CONST","name":"32'h0","addr":"(JSB)","loc":"d,17:12,17:16","dtypep":"(HC)"}
+        {"type":"CONST","name":"32'h0","addr":"(ATB)","loc":"d,17:12,17:16","dtypep":"(HC)"}
       ]}
     ]},
     {"type":"BASICDTYPE","name":"logic","addr":"(LB)","loc":"d,23:23,23:24","dtypep":"(LB)","keyword":"logic","range":"31:0","generic":true,"signed":true,"rangep": []},
@@ -3011,28 +3062,28 @@
     {"type":"BASICDTYPE","name":"bit","addr":"(HN)","loc":"a,0:0,0:0","dtypep":"(HN)","keyword":"bit","range":"63:0","generic":true,"rangep": []},
     {"type":"UNPACKARRAYDTYPE","name":"","addr":"(W)","loc":"d,11:8,11:9","dtypep":"(W)","isCompound":false,"declRange":"[0:0]","generic":false,"refDTypep":"(HN)","childDTypep": [],
      "rangep": [
-      {"type":"RANGE","name":"","addr":"(KSB)","loc":"d,11:8,11:9","ascending":false,"fromBracket":false,
+      {"type":"RANGE","name":"","addr":"(BTB)","loc":"d,11:8,11:9","ascending":false,"fromBracket":false,
        "leftp": [
-        {"type":"CONST","name":"32'h0","addr":"(LSB)","loc":"d,11:8,11:9","dtypep":"(HC)"}
+        {"type":"CONST","name":"32'h0","addr":"(CTB)","loc":"d,11:8,11:9","dtypep":"(HC)"}
       ],
        "rightp": [
-        {"type":"CONST","name":"32'h0","addr":"(MSB)","loc":"d,11:8,11:9","dtypep":"(HC)"}
+        {"type":"CONST","name":"32'h0","addr":"(DTB)","loc":"d,11:8,11:9","dtypep":"(HC)"}
       ]}
     ]},
-    {"type":"BASICDTYPE","name":"IData","addr":"(OP)","loc":"a,0:0,0:0","dtypep":"(OP)","keyword":"IData","range":"31:0","generic":true,"rangep": []},
+    {"type":"BASICDTYPE","name":"IData","addr":"(RP)","loc":"a,0:0,0:0","dtypep":"(RP)","keyword":"IData","range":"31:0","generic":true,"rangep": []},
     {"type":"BASICDTYPE","name":"logic","addr":"(JN)","loc":"d,63:14,63:21","dtypep":"(JN)","keyword":"logic","range":"63:0","generic":true,"rangep": []},
     {"type":"BASICDTYPE","name":"bit","addr":"(P)","loc":"d,11:8,11:9","dtypep":"(P)","keyword":"bit","generic":true,"rangep": []},
     {"type":"BASICDTYPE","name":"bit","addr":"(U)","loc":"d,11:8,11:9","dtypep":"(U)","keyword":"bit","range":"31:0","generic":true,"rangep": []},
     {"type":"BASICDTYPE","name":"logic","addr":"(GB)","loc":"d,63:22,63:25","dtypep":"(GB)","keyword":"logic","range":"31:0","generic":true,"rangep": []},
     {"type":"BASICDTYPE","name":"logic","addr":"(UB)","loc":"d,32:11,32:14","dtypep":"(UB)","keyword":"logic","range":"31:0","generic":true,"rangep": []},
     {"type":"BASICDTYPE","name":"logic","addr":"(FC)","loc":"d,38:15,38:16","dtypep":"(FC)","keyword":"logic","range":"31:0","generic":true,"rangep": []},
-    {"type":"BASICDTYPE","name":"logic","addr":"(KPB)","loc":"d,15:10,15:13","dtypep":"(KPB)","keyword":"logic","range":"7:0","generic":true,"rangep": []}
+    {"type":"BASICDTYPE","name":"logic","addr":"(SPB)","loc":"d,15:10,15:13","dtypep":"(SPB)","keyword":"logic","range":"7:0","generic":true,"rangep": []}
   ]},
   {"type":"CONSTPOOL","name":"","addr":"(D)","loc":"a,0:0,0:0",
    "modulep": [
-    {"type":"MODULE","name":"@CONST-POOL@","addr":"(NSB)","loc":"a,0:0,0:0","isChecker":false,"isProgram":false,"hasGenericIface":false,"origName":"@CONST-POOL@","level":0,"modPublic":false,"inLibrary":false,"dead":false,"recursiveClone":false,"recursive":false,"timeunit":"NONE","inlinesp": [],
+    {"type":"MODULE","name":"@CONST-POOL@","addr":"(ETB)","loc":"a,0:0,0:0","isChecker":false,"isProgram":false,"hasGenericIface":false,"origName":"@CONST-POOL@","level":0,"modPublic":false,"inLibrary":false,"dead":false,"recursiveClone":false,"recursive":false,"timeunit":"NONE","inlinesp": [],
      "stmtsp": [
-      {"type":"SCOPE","name":"TOP","addr":"(OSB)","loc":"a,0:0,0:0","aboveScopep":"UNLINKED","aboveCellp":"UNLINKED","modp":"(NSB)","varsp": [],"blocksp": [],"inlinesp": []}
+      {"type":"SCOPE","name":"TOP","addr":"(FTB)","loc":"a,0:0,0:0","aboveScopep":"UNLINKED","aboveCellp":"UNLINKED","modp":"(ETB)","varsp": [],"blocksp": [],"inlinesp": []}
     ]}
   ]}
 ]}

--- a/test_regress/t/t_json_only_flat_vlvbound.out
+++ b/test_regress/t/t_json_only_flat_vlvbound.out
@@ -82,212 +82,224 @@
            "lhsp": [
             {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__0__val","addr":"(KC)","loc":"d,15:57,15:60","dtypep":"(H)","access":"WR","varp":"(SB)","varScopep":"(RB)","classOrPackagep":"UNLINKED"}
           ],"timingControlp": []},
-          {"type":"CRESET","name":"","addr":"(LC)","loc":"d,16:17,16:20","constructing":false,
-           "varrefp": [
-            {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__0__ret","addr":"(MC)","loc":"d,16:17,16:20","dtypep":"(K)","access":"WR","varp":"(UB)","varScopep":"(TB)","classOrPackagep":"UNLINKED"}
-          ]},
-          {"type":"CRESET","name":"","addr":"(NC)","loc":"d,17:13,17:14","constructing":false,
-           "varrefp": [
-            {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__0__i","addr":"(OC)","loc":"d,17:13,17:14","dtypep":"(WB)","access":"WR","varp":"(XB)","varScopep":"(VB)","classOrPackagep":"UNLINKED"}
-          ]},
-          {"type":"ASSIGN","name":"","addr":"(PC)","loc":"d,18:11,18:12","dtypep":"(WB)",
+          {"type":"ASSIGN","name":"","addr":"(LC)","loc":"d,16:17,16:20","dtypep":"(K)",
            "rhsp": [
-            {"type":"CONST","name":"32'sh0","addr":"(QC)","loc":"d,18:12,18:13","dtypep":"(RC)"}
+            {"type":"CRESET","name":"","addr":"(MC)","loc":"d,16:17,16:20","dtypep":"(K)","constructing":false}
           ],
            "lhsp": [
-            {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__0__i","addr":"(SC)","loc":"d,18:10,18:11","dtypep":"(WB)","access":"WR","varp":"(XB)","varScopep":"(VB)","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__0__ret","addr":"(NC)","loc":"d,16:17,16:20","dtypep":"(K)","access":"WR","varp":"(UB)","varScopep":"(TB)","classOrPackagep":"UNLINKED"}
           ],"timingControlp": []},
-          {"type":"LOOP","name":"","addr":"(TC)","loc":"d,18:5,18:8","unroll":"default",
+          {"type":"ASSIGN","name":"","addr":"(OC)","loc":"d,17:13,17:14","dtypep":"(WB)",
+           "rhsp": [
+            {"type":"CRESET","name":"","addr":"(PC)","loc":"d,17:13,17:14","dtypep":"(WB)","constructing":false}
+          ],
+           "lhsp": [
+            {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__0__i","addr":"(QC)","loc":"d,17:13,17:14","dtypep":"(WB)","access":"WR","varp":"(XB)","varScopep":"(VB)","classOrPackagep":"UNLINKED"}
+          ],"timingControlp": []},
+          {"type":"ASSIGN","name":"","addr":"(RC)","loc":"d,18:11,18:12","dtypep":"(WB)",
+           "rhsp": [
+            {"type":"CONST","name":"32'sh0","addr":"(SC)","loc":"d,18:12,18:13","dtypep":"(TC)"}
+          ],
+           "lhsp": [
+            {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__0__i","addr":"(UC)","loc":"d,18:10,18:11","dtypep":"(WB)","access":"WR","varp":"(XB)","varScopep":"(VB)","classOrPackagep":"UNLINKED"}
+          ],"timingControlp": []},
+          {"type":"LOOP","name":"","addr":"(VC)","loc":"d,18:5,18:8","unroll":"default",
            "stmtsp": [
-            {"type":"LOOPTEST","name":"","addr":"(UC)","loc":"d,18:16,18:17",
+            {"type":"LOOPTEST","name":"","addr":"(WC)","loc":"d,18:16,18:17",
              "condp": [
-              {"type":"GTS","name":"","addr":"(VC)","loc":"d,18:18,18:19","dtypep":"(WC)",
+              {"type":"GTS","name":"","addr":"(XC)","loc":"d,18:18,18:19","dtypep":"(YC)",
                "lhsp": [
-                {"type":"CONST","name":"32'sh7","addr":"(XC)","loc":"d,18:20,18:21","dtypep":"(RC)"}
+                {"type":"CONST","name":"32'sh7","addr":"(ZC)","loc":"d,18:20,18:21","dtypep":"(TC)"}
               ],
                "rhsp": [
-                {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__0__i","addr":"(YC)","loc":"d,18:16,18:17","dtypep":"(WB)","access":"RD","varp":"(XB)","varScopep":"(VB)","classOrPackagep":"UNLINKED"}
+                {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__0__i","addr":"(AD)","loc":"d,18:16,18:17","dtypep":"(WB)","access":"RD","varp":"(XB)","varScopep":"(VB)","classOrPackagep":"UNLINKED"}
               ]}
             ]},
-            {"type":"ASSIGN","name":"","addr":"(ZC)","loc":"d,19:14,19:15","dtypep":"(WC)",
+            {"type":"ASSIGN","name":"","addr":"(BD)","loc":"d,19:14,19:15","dtypep":"(YC)",
              "rhsp": [
-              {"type":"EQ","name":"","addr":"(AD)","loc":"d,19:31,19:33","dtypep":"(WC)",
+              {"type":"EQ","name":"","addr":"(CD)","loc":"d,19:31,19:33","dtypep":"(YC)",
                "lhsp": [
-                {"type":"CONST","name":"2'h0","addr":"(BD)","loc":"d,19:34,19:39","dtypep":"(CD)"}
+                {"type":"CONST","name":"2'h0","addr":"(DD)","loc":"d,19:34,19:39","dtypep":"(ED)"}
               ],
                "rhsp": [
-                {"type":"SEL","name":"","addr":"(DD)","loc":"d,19:20,19:21","dtypep":"(CD)","widthConst":2,"declRange":"[15:0]","declElWidth":1,
+                {"type":"SEL","name":"","addr":"(FD)","loc":"d,19:20,19:21","dtypep":"(ED)","widthConst":2,"declRange":"[15:0]","declElWidth":1,
                  "fromp": [
-                  {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__0__val","addr":"(ED)","loc":"d,19:17,19:20","dtypep":"(H)","access":"RD","varp":"(SB)","varScopep":"(RB)","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__0__val","addr":"(GD)","loc":"d,19:17,19:20","dtypep":"(H)","access":"RD","varp":"(SB)","varScopep":"(RB)","classOrPackagep":"UNLINKED"}
                 ],
                  "lsbp": [
-                  {"type":"SEL","name":"","addr":"(FD)","loc":"d,19:22,19:23","dtypep":"(GD)","widthConst":4,
+                  {"type":"SEL","name":"","addr":"(HD)","loc":"d,19:22,19:23","dtypep":"(ID)","widthConst":4,
                    "fromp": [
-                    {"type":"MULS","name":"","addr":"(HD)","loc":"d,19:22,19:23","dtypep":"(RC)",
+                    {"type":"MULS","name":"","addr":"(JD)","loc":"d,19:22,19:23","dtypep":"(TC)",
                      "lhsp": [
-                      {"type":"CONST","name":"32'sh2","addr":"(ID)","loc":"d,19:23,19:24","dtypep":"(RC)"}
+                      {"type":"CONST","name":"32'sh2","addr":"(KD)","loc":"d,19:23,19:24","dtypep":"(TC)"}
                     ],
                      "rhsp": [
-                      {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__0__i","addr":"(JD)","loc":"d,19:21,19:22","dtypep":"(WB)","access":"RD","varp":"(XB)","varScopep":"(VB)","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__0__i","addr":"(LD)","loc":"d,19:21,19:22","dtypep":"(WB)","access":"RD","varp":"(XB)","varScopep":"(VB)","classOrPackagep":"UNLINKED"}
                     ]}
                   ],
                    "lsbp": [
-                    {"type":"CONST","name":"32'h0","addr":"(KD)","loc":"d,19:22,19:23","dtypep":"(LD)"}
+                    {"type":"CONST","name":"32'h0","addr":"(MD)","loc":"d,19:22,19:23","dtypep":"(ND)"}
                   ]}
                 ]}
               ]}
             ],
              "lhsp": [
-              {"type":"SEL","name":"","addr":"(MD)","loc":"d,19:10,19:11","dtypep":"(WC)","widthConst":1,"declRange":"[6:0]","declElWidth":1,
+              {"type":"SEL","name":"","addr":"(OD)","loc":"d,19:10,19:11","dtypep":"(YC)","widthConst":1,"declRange":"[6:0]","declElWidth":1,
                "fromp": [
-                {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__0__ret","addr":"(ND)","loc":"d,19:7,19:10","dtypep":"(K)","access":"WR","varp":"(UB)","varScopep":"(TB)","classOrPackagep":"UNLINKED"}
+                {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__0__ret","addr":"(PD)","loc":"d,19:7,19:10","dtypep":"(K)","access":"WR","varp":"(UB)","varScopep":"(TB)","classOrPackagep":"UNLINKED"}
               ],
                "lsbp": [
-                {"type":"SEL","name":"","addr":"(OD)","loc":"d,19:11,19:12","dtypep":"(PD)","widthConst":3,
+                {"type":"SEL","name":"","addr":"(QD)","loc":"d,19:11,19:12","dtypep":"(RD)","widthConst":3,
                  "fromp": [
-                  {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__0__i","addr":"(QD)","loc":"d,19:11,19:12","dtypep":"(WB)","access":"RD","varp":"(XB)","varScopep":"(VB)","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__0__i","addr":"(SD)","loc":"d,19:11,19:12","dtypep":"(WB)","access":"RD","varp":"(XB)","varScopep":"(VB)","classOrPackagep":"UNLINKED"}
                 ],
                  "lsbp": [
-                  {"type":"CONST","name":"32'h0","addr":"(RD)","loc":"d,19:11,19:12","dtypep":"(LD)"}
+                  {"type":"CONST","name":"32'h0","addr":"(TD)","loc":"d,19:11,19:12","dtypep":"(ND)"}
                 ]}
               ]}
             ],"timingControlp": []},
-            {"type":"ASSIGN","name":"","addr":"(SD)","loc":"d,18:24,18:26","dtypep":"(WB)",
+            {"type":"ASSIGN","name":"","addr":"(UD)","loc":"d,18:24,18:26","dtypep":"(WB)",
              "rhsp": [
-              {"type":"ADD","name":"","addr":"(TD)","loc":"d,18:24,18:26","dtypep":"(LD)",
+              {"type":"ADD","name":"","addr":"(VD)","loc":"d,18:24,18:26","dtypep":"(ND)",
                "lhsp": [
-                {"type":"CONST","name":"32'h1","addr":"(UD)","loc":"d,18:24,18:26","dtypep":"(LD)"}
+                {"type":"CONST","name":"32'h1","addr":"(WD)","loc":"d,18:24,18:26","dtypep":"(ND)"}
               ],
                "rhsp": [
-                {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__0__i","addr":"(VD)","loc":"d,18:23,18:24","dtypep":"(WB)","access":"RD","varp":"(XB)","varScopep":"(VB)","classOrPackagep":"UNLINKED"}
+                {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__0__i","addr":"(XD)","loc":"d,18:23,18:24","dtypep":"(WB)","access":"RD","varp":"(XB)","varScopep":"(VB)","classOrPackagep":"UNLINKED"}
               ]}
             ],
              "lhsp": [
-              {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__0__i","addr":"(WD)","loc":"d,18:23,18:24","dtypep":"(WB)","access":"WR","varp":"(XB)","varScopep":"(VB)","classOrPackagep":"UNLINKED"}
+              {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__0__i","addr":"(YD)","loc":"d,18:23,18:24","dtypep":"(WB)","access":"WR","varp":"(XB)","varScopep":"(VB)","classOrPackagep":"UNLINKED"}
             ],"timingControlp": []}
           ],"contsp": []},
-          {"type":"ASSIGN","name":"","addr":"(XD)","loc":"d,21:5,21:11","dtypep":"(K)",
+          {"type":"ASSIGN","name":"","addr":"(ZD)","loc":"d,21:5,21:11","dtypep":"(K)",
            "rhsp": [
-            {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__0__ret","addr":"(YD)","loc":"d,21:12,21:15","dtypep":"(K)","access":"RD","varp":"(UB)","varScopep":"(TB)","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__0__ret","addr":"(AE)","loc":"d,21:12,21:15","dtypep":"(K)","access":"RD","varp":"(UB)","varScopep":"(TB)","classOrPackagep":"UNLINKED"}
           ],
            "lhsp": [
-            {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__0__Vfuncout","addr":"(ZD)","loc":"d,21:5,21:11","dtypep":"(K)","access":"WR","varp":"(QB)","varScopep":"(PB)","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__0__Vfuncout","addr":"(BE)","loc":"d,21:5,21:11","dtypep":"(K)","access":"WR","varp":"(QB)","varScopep":"(PB)","classOrPackagep":"UNLINKED"}
           ],"timingControlp": []},
-          {"type":"ASSIGNW","name":"","addr":"(AE)","loc":"d,24:14,24:15","dtypep":"(K)",
+          {"type":"ASSIGNW","name":"","addr":"(CE)","loc":"d,24:14,24:15","dtypep":"(K)",
            "rhsp": [
-            {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__0__Vfuncout","addr":"(BE)","loc":"d,24:16,24:19","dtypep":"(K)","access":"RD","varp":"(QB)","varScopep":"(PB)","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__0__Vfuncout","addr":"(DE)","loc":"d,24:16,24:19","dtypep":"(K)","access":"RD","varp":"(QB)","varScopep":"(PB)","classOrPackagep":"UNLINKED"}
           ],
            "lhsp": [
-            {"type":"VARREF","name":"o_a","addr":"(CE)","loc":"d,24:10,24:13","dtypep":"(K)","access":"WR","varp":"(J)","varScopep":"(T)","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"o_a","addr":"(EE)","loc":"d,24:10,24:13","dtypep":"(K)","access":"WR","varp":"(J)","varScopep":"(T)","classOrPackagep":"UNLINKED"}
           ],"timingControlp": [],"strengthSpecp": []}
         ]},
-        {"type":"ALWAYS","name":"","addr":"(DE)","loc":"d,25:14,25:15","keyword":"cont_assign","isSuspendable":false,"needProcess":false,"sentreep": [],
+        {"type":"ALWAYS","name":"","addr":"(FE)","loc":"d,25:14,25:15","keyword":"cont_assign","isSuspendable":false,"needProcess":false,"sentreep": [],
          "stmtsp": [
-          {"type":"COMMENT","name":"Function: foo","addr":"(EE)","loc":"d,25:16,25:19"},
-          {"type":"ASSIGN","name":"","addr":"(FE)","loc":"d,25:20,25:23","dtypep":"(H)",
+          {"type":"COMMENT","name":"Function: foo","addr":"(GE)","loc":"d,25:16,25:19"},
+          {"type":"ASSIGN","name":"","addr":"(HE)","loc":"d,25:20,25:23","dtypep":"(H)",
            "rhsp": [
-            {"type":"VARREF","name":"i_b","addr":"(GE)","loc":"d,25:20,25:23","dtypep":"(H)","access":"RD","varp":"(I)","varScopep":"(S)","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"i_b","addr":"(IE)","loc":"d,25:20,25:23","dtypep":"(H)","access":"RD","varp":"(I)","varScopep":"(S)","classOrPackagep":"UNLINKED"}
           ],
            "lhsp": [
-            {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__1__val","addr":"(HE)","loc":"d,15:57,15:60","dtypep":"(H)","access":"WR","varp":"(BC)","varScopep":"(AC)","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__1__val","addr":"(JE)","loc":"d,15:57,15:60","dtypep":"(H)","access":"WR","varp":"(BC)","varScopep":"(AC)","classOrPackagep":"UNLINKED"}
           ],"timingControlp": []},
-          {"type":"CRESET","name":"","addr":"(IE)","loc":"d,16:17,16:20","constructing":false,
-           "varrefp": [
-            {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__1__ret","addr":"(JE)","loc":"d,16:17,16:20","dtypep":"(K)","access":"WR","varp":"(DC)","varScopep":"(CC)","classOrPackagep":"UNLINKED"}
-          ]},
-          {"type":"CRESET","name":"","addr":"(KE)","loc":"d,17:13,17:14","constructing":false,
-           "varrefp": [
-            {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__1__i","addr":"(LE)","loc":"d,17:13,17:14","dtypep":"(WB)","access":"WR","varp":"(FC)","varScopep":"(EC)","classOrPackagep":"UNLINKED"}
-          ]},
-          {"type":"ASSIGN","name":"","addr":"(ME)","loc":"d,18:11,18:12","dtypep":"(WB)",
+          {"type":"ASSIGN","name":"","addr":"(KE)","loc":"d,16:17,16:20","dtypep":"(K)",
            "rhsp": [
-            {"type":"CONST","name":"32'sh0","addr":"(NE)","loc":"d,18:12,18:13","dtypep":"(RC)"}
+            {"type":"CRESET","name":"","addr":"(LE)","loc":"d,16:17,16:20","dtypep":"(K)","constructing":false}
           ],
            "lhsp": [
-            {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__1__i","addr":"(OE)","loc":"d,18:10,18:11","dtypep":"(WB)","access":"WR","varp":"(FC)","varScopep":"(EC)","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__1__ret","addr":"(ME)","loc":"d,16:17,16:20","dtypep":"(K)","access":"WR","varp":"(DC)","varScopep":"(CC)","classOrPackagep":"UNLINKED"}
           ],"timingControlp": []},
-          {"type":"LOOP","name":"","addr":"(PE)","loc":"d,18:5,18:8","unroll":"default",
+          {"type":"ASSIGN","name":"","addr":"(NE)","loc":"d,17:13,17:14","dtypep":"(WB)",
+           "rhsp": [
+            {"type":"CRESET","name":"","addr":"(OE)","loc":"d,17:13,17:14","dtypep":"(WB)","constructing":false}
+          ],
+           "lhsp": [
+            {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__1__i","addr":"(PE)","loc":"d,17:13,17:14","dtypep":"(WB)","access":"WR","varp":"(FC)","varScopep":"(EC)","classOrPackagep":"UNLINKED"}
+          ],"timingControlp": []},
+          {"type":"ASSIGN","name":"","addr":"(QE)","loc":"d,18:11,18:12","dtypep":"(WB)",
+           "rhsp": [
+            {"type":"CONST","name":"32'sh0","addr":"(RE)","loc":"d,18:12,18:13","dtypep":"(TC)"}
+          ],
+           "lhsp": [
+            {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__1__i","addr":"(SE)","loc":"d,18:10,18:11","dtypep":"(WB)","access":"WR","varp":"(FC)","varScopep":"(EC)","classOrPackagep":"UNLINKED"}
+          ],"timingControlp": []},
+          {"type":"LOOP","name":"","addr":"(TE)","loc":"d,18:5,18:8","unroll":"default",
            "stmtsp": [
-            {"type":"LOOPTEST","name":"","addr":"(QE)","loc":"d,18:16,18:17",
+            {"type":"LOOPTEST","name":"","addr":"(UE)","loc":"d,18:16,18:17",
              "condp": [
-              {"type":"GTS","name":"","addr":"(RE)","loc":"d,18:18,18:19","dtypep":"(WC)",
+              {"type":"GTS","name":"","addr":"(VE)","loc":"d,18:18,18:19","dtypep":"(YC)",
                "lhsp": [
-                {"type":"CONST","name":"32'sh7","addr":"(SE)","loc":"d,18:20,18:21","dtypep":"(RC)"}
+                {"type":"CONST","name":"32'sh7","addr":"(WE)","loc":"d,18:20,18:21","dtypep":"(TC)"}
               ],
                "rhsp": [
-                {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__1__i","addr":"(TE)","loc":"d,18:16,18:17","dtypep":"(WB)","access":"RD","varp":"(FC)","varScopep":"(EC)","classOrPackagep":"UNLINKED"}
+                {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__1__i","addr":"(XE)","loc":"d,18:16,18:17","dtypep":"(WB)","access":"RD","varp":"(FC)","varScopep":"(EC)","classOrPackagep":"UNLINKED"}
               ]}
             ]},
-            {"type":"ASSIGN","name":"","addr":"(UE)","loc":"d,19:14,19:15","dtypep":"(WC)",
+            {"type":"ASSIGN","name":"","addr":"(YE)","loc":"d,19:14,19:15","dtypep":"(YC)",
              "rhsp": [
-              {"type":"EQ","name":"","addr":"(VE)","loc":"d,19:31,19:33","dtypep":"(WC)",
+              {"type":"EQ","name":"","addr":"(ZE)","loc":"d,19:31,19:33","dtypep":"(YC)",
                "lhsp": [
-                {"type":"CONST","name":"2'h0","addr":"(WE)","loc":"d,19:34,19:39","dtypep":"(CD)"}
+                {"type":"CONST","name":"2'h0","addr":"(AF)","loc":"d,19:34,19:39","dtypep":"(ED)"}
               ],
                "rhsp": [
-                {"type":"SEL","name":"","addr":"(XE)","loc":"d,19:20,19:21","dtypep":"(CD)","widthConst":2,"declRange":"[15:0]","declElWidth":1,
+                {"type":"SEL","name":"","addr":"(BF)","loc":"d,19:20,19:21","dtypep":"(ED)","widthConst":2,"declRange":"[15:0]","declElWidth":1,
                  "fromp": [
-                  {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__1__val","addr":"(YE)","loc":"d,19:17,19:20","dtypep":"(H)","access":"RD","varp":"(BC)","varScopep":"(AC)","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__1__val","addr":"(CF)","loc":"d,19:17,19:20","dtypep":"(H)","access":"RD","varp":"(BC)","varScopep":"(AC)","classOrPackagep":"UNLINKED"}
                 ],
                  "lsbp": [
-                  {"type":"SEL","name":"","addr":"(ZE)","loc":"d,19:22,19:23","dtypep":"(GD)","widthConst":4,
+                  {"type":"SEL","name":"","addr":"(DF)","loc":"d,19:22,19:23","dtypep":"(ID)","widthConst":4,
                    "fromp": [
-                    {"type":"MULS","name":"","addr":"(AF)","loc":"d,19:22,19:23","dtypep":"(RC)",
+                    {"type":"MULS","name":"","addr":"(EF)","loc":"d,19:22,19:23","dtypep":"(TC)",
                      "lhsp": [
-                      {"type":"CONST","name":"32'sh2","addr":"(BF)","loc":"d,19:23,19:24","dtypep":"(RC)"}
+                      {"type":"CONST","name":"32'sh2","addr":"(FF)","loc":"d,19:23,19:24","dtypep":"(TC)"}
                     ],
                      "rhsp": [
-                      {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__1__i","addr":"(CF)","loc":"d,19:21,19:22","dtypep":"(WB)","access":"RD","varp":"(FC)","varScopep":"(EC)","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__1__i","addr":"(GF)","loc":"d,19:21,19:22","dtypep":"(WB)","access":"RD","varp":"(FC)","varScopep":"(EC)","classOrPackagep":"UNLINKED"}
                     ]}
                   ],
                    "lsbp": [
-                    {"type":"CONST","name":"32'h0","addr":"(DF)","loc":"d,19:22,19:23","dtypep":"(LD)"}
+                    {"type":"CONST","name":"32'h0","addr":"(HF)","loc":"d,19:22,19:23","dtypep":"(ND)"}
                   ]}
                 ]}
               ]}
             ],
              "lhsp": [
-              {"type":"SEL","name":"","addr":"(EF)","loc":"d,19:10,19:11","dtypep":"(WC)","widthConst":1,"declRange":"[6:0]","declElWidth":1,
+              {"type":"SEL","name":"","addr":"(IF)","loc":"d,19:10,19:11","dtypep":"(YC)","widthConst":1,"declRange":"[6:0]","declElWidth":1,
                "fromp": [
-                {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__1__ret","addr":"(FF)","loc":"d,19:7,19:10","dtypep":"(K)","access":"WR","varp":"(DC)","varScopep":"(CC)","classOrPackagep":"UNLINKED"}
+                {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__1__ret","addr":"(JF)","loc":"d,19:7,19:10","dtypep":"(K)","access":"WR","varp":"(DC)","varScopep":"(CC)","classOrPackagep":"UNLINKED"}
               ],
                "lsbp": [
-                {"type":"SEL","name":"","addr":"(GF)","loc":"d,19:11,19:12","dtypep":"(PD)","widthConst":3,
+                {"type":"SEL","name":"","addr":"(KF)","loc":"d,19:11,19:12","dtypep":"(RD)","widthConst":3,
                  "fromp": [
-                  {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__1__i","addr":"(HF)","loc":"d,19:11,19:12","dtypep":"(WB)","access":"RD","varp":"(FC)","varScopep":"(EC)","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__1__i","addr":"(LF)","loc":"d,19:11,19:12","dtypep":"(WB)","access":"RD","varp":"(FC)","varScopep":"(EC)","classOrPackagep":"UNLINKED"}
                 ],
                  "lsbp": [
-                  {"type":"CONST","name":"32'h0","addr":"(IF)","loc":"d,19:11,19:12","dtypep":"(LD)"}
+                  {"type":"CONST","name":"32'h0","addr":"(MF)","loc":"d,19:11,19:12","dtypep":"(ND)"}
                 ]}
               ]}
             ],"timingControlp": []},
-            {"type":"ASSIGN","name":"","addr":"(JF)","loc":"d,18:24,18:26","dtypep":"(WB)",
+            {"type":"ASSIGN","name":"","addr":"(NF)","loc":"d,18:24,18:26","dtypep":"(WB)",
              "rhsp": [
-              {"type":"ADD","name":"","addr":"(KF)","loc":"d,18:24,18:26","dtypep":"(LD)",
+              {"type":"ADD","name":"","addr":"(OF)","loc":"d,18:24,18:26","dtypep":"(ND)",
                "lhsp": [
-                {"type":"CONST","name":"32'h1","addr":"(LF)","loc":"d,18:24,18:26","dtypep":"(LD)"}
+                {"type":"CONST","name":"32'h1","addr":"(PF)","loc":"d,18:24,18:26","dtypep":"(ND)"}
               ],
                "rhsp": [
-                {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__1__i","addr":"(MF)","loc":"d,18:23,18:24","dtypep":"(WB)","access":"RD","varp":"(FC)","varScopep":"(EC)","classOrPackagep":"UNLINKED"}
+                {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__1__i","addr":"(QF)","loc":"d,18:23,18:24","dtypep":"(WB)","access":"RD","varp":"(FC)","varScopep":"(EC)","classOrPackagep":"UNLINKED"}
               ]}
             ],
              "lhsp": [
-              {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__1__i","addr":"(NF)","loc":"d,18:23,18:24","dtypep":"(WB)","access":"WR","varp":"(FC)","varScopep":"(EC)","classOrPackagep":"UNLINKED"}
+              {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__1__i","addr":"(RF)","loc":"d,18:23,18:24","dtypep":"(WB)","access":"WR","varp":"(FC)","varScopep":"(EC)","classOrPackagep":"UNLINKED"}
             ],"timingControlp": []}
           ],"contsp": []},
-          {"type":"ASSIGN","name":"","addr":"(OF)","loc":"d,21:5,21:11","dtypep":"(K)",
+          {"type":"ASSIGN","name":"","addr":"(SF)","loc":"d,21:5,21:11","dtypep":"(K)",
            "rhsp": [
-            {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__1__ret","addr":"(PF)","loc":"d,21:12,21:15","dtypep":"(K)","access":"RD","varp":"(DC)","varScopep":"(CC)","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__1__ret","addr":"(TF)","loc":"d,21:12,21:15","dtypep":"(K)","access":"RD","varp":"(DC)","varScopep":"(CC)","classOrPackagep":"UNLINKED"}
           ],
            "lhsp": [
-            {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__1__Vfuncout","addr":"(QF)","loc":"d,21:5,21:11","dtypep":"(K)","access":"WR","varp":"(ZB)","varScopep":"(YB)","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__1__Vfuncout","addr":"(UF)","loc":"d,21:5,21:11","dtypep":"(K)","access":"WR","varp":"(ZB)","varScopep":"(YB)","classOrPackagep":"UNLINKED"}
           ],"timingControlp": []},
-          {"type":"ASSIGNW","name":"","addr":"(RF)","loc":"d,25:14,25:15","dtypep":"(K)",
+          {"type":"ASSIGNW","name":"","addr":"(VF)","loc":"d,25:14,25:15","dtypep":"(K)",
            "rhsp": [
-            {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__1__Vfuncout","addr":"(SF)","loc":"d,25:16,25:19","dtypep":"(K)","access":"RD","varp":"(ZB)","varScopep":"(YB)","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__1__Vfuncout","addr":"(WF)","loc":"d,25:16,25:19","dtypep":"(K)","access":"RD","varp":"(ZB)","varScopep":"(YB)","classOrPackagep":"UNLINKED"}
           ],
            "lhsp": [
-            {"type":"VARREF","name":"o_b","addr":"(TF)","loc":"d,25:10,25:13","dtypep":"(K)","access":"WR","varp":"(L)","varScopep":"(U)","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"o_b","addr":"(XF)","loc":"d,25:10,25:13","dtypep":"(K)","access":"WR","varp":"(L)","varScopep":"(U)","classOrPackagep":"UNLINKED"}
           ],"timingControlp": [],"strengthSpecp": []}
         ]}
       ],"inlinesp": []}
@@ -303,24 +315,24 @@
   ]}
 ],"filesp": [],
  "miscsp": [
-  {"type":"TYPETABLE","name":"","addr":"(C)","loc":"a,0:0,0:0","constraintRefp":"UNLINKED","emptyQueuep":"UNLINKED","queueIndexp":"UNLINKED","streamp":"UNLINKED","voidp":"(UF)",
+  {"type":"TYPETABLE","name":"","addr":"(C)","loc":"a,0:0,0:0","constraintRefp":"UNLINKED","emptyQueuep":"UNLINKED","queueIndexp":"UNLINKED","streamp":"UNLINKED","voidp":"(YF)",
    "typesp": [
-    {"type":"BASICDTYPE","name":"logic","addr":"(WC)","loc":"d,18:18,18:19","dtypep":"(WC)","keyword":"logic","generic":true,"rangep": []},
-    {"type":"BASICDTYPE","name":"logic","addr":"(CD)","loc":"d,19:34,19:39","dtypep":"(CD)","keyword":"logic","range":"1:0","generic":true,"rangep": []},
+    {"type":"BASICDTYPE","name":"logic","addr":"(YC)","loc":"d,18:18,18:19","dtypep":"(YC)","keyword":"logic","generic":true,"rangep": []},
+    {"type":"BASICDTYPE","name":"logic","addr":"(ED)","loc":"d,19:34,19:39","dtypep":"(ED)","keyword":"logic","range":"1:0","generic":true,"rangep": []},
     {"type":"BASICDTYPE","name":"logic","addr":"(H)","loc":"d,9:11,9:16","dtypep":"(H)","keyword":"logic","range":"15:0","generic":true,"rangep": []},
     {"type":"BASICDTYPE","name":"logic","addr":"(K)","loc":"d,11:12,11:17","dtypep":"(K)","keyword":"logic","range":"6:0","generic":true,"rangep": []},
     {"type":"BASICDTYPE","name":"integer","addr":"(WB)","loc":"d,17:5,17:12","dtypep":"(WB)","keyword":"integer","range":"31:0","generic":true,"signed":true,"rangep": []},
-    {"type":"BASICDTYPE","name":"logic","addr":"(PD)","loc":"d,19:10,19:11","dtypep":"(PD)","keyword":"logic","range":"2:0","generic":true,"signed":true,"rangep": []},
-    {"type":"BASICDTYPE","name":"logic","addr":"(LD)","loc":"d,19:11,19:12","dtypep":"(LD)","keyword":"logic","range":"31:0","generic":true,"rangep": []},
-    {"type":"BASICDTYPE","name":"logic","addr":"(GD)","loc":"d,19:20,19:21","dtypep":"(GD)","keyword":"logic","range":"3:0","generic":true,"signed":true,"rangep": []},
-    {"type":"BASICDTYPE","name":"logic","addr":"(RC)","loc":"d,18:12,18:13","dtypep":"(RC)","keyword":"logic","range":"31:0","generic":true,"signed":true,"rangep": []},
-    {"type":"VOIDDTYPE","name":"","addr":"(UF)","loc":"a,0:0,0:0","dtypep":"(UF)","generic":false}
+    {"type":"BASICDTYPE","name":"logic","addr":"(RD)","loc":"d,19:10,19:11","dtypep":"(RD)","keyword":"logic","range":"2:0","generic":true,"signed":true,"rangep": []},
+    {"type":"BASICDTYPE","name":"logic","addr":"(ND)","loc":"d,19:11,19:12","dtypep":"(ND)","keyword":"logic","range":"31:0","generic":true,"rangep": []},
+    {"type":"BASICDTYPE","name":"logic","addr":"(ID)","loc":"d,19:20,19:21","dtypep":"(ID)","keyword":"logic","range":"3:0","generic":true,"signed":true,"rangep": []},
+    {"type":"BASICDTYPE","name":"logic","addr":"(TC)","loc":"d,18:12,18:13","dtypep":"(TC)","keyword":"logic","range":"31:0","generic":true,"signed":true,"rangep": []},
+    {"type":"VOIDDTYPE","name":"","addr":"(YF)","loc":"a,0:0,0:0","dtypep":"(YF)","generic":false}
   ]},
   {"type":"CONSTPOOL","name":"","addr":"(D)","loc":"a,0:0,0:0",
    "modulep": [
-    {"type":"MODULE","name":"@CONST-POOL@","addr":"(VF)","loc":"a,0:0,0:0","isChecker":false,"isProgram":false,"hasGenericIface":false,"origName":"@CONST-POOL@","level":0,"modPublic":false,"inLibrary":false,"dead":false,"recursiveClone":false,"recursive":false,"timeunit":"NONE","inlinesp": [],
+    {"type":"MODULE","name":"@CONST-POOL@","addr":"(ZF)","loc":"a,0:0,0:0","isChecker":false,"isProgram":false,"hasGenericIface":false,"origName":"@CONST-POOL@","level":0,"modPublic":false,"inLibrary":false,"dead":false,"recursiveClone":false,"recursive":false,"timeunit":"NONE","inlinesp": [],
      "stmtsp": [
-      {"type":"SCOPE","name":"@CONST-POOL@","addr":"(WF)","loc":"a,0:0,0:0","aboveScopep":"UNLINKED","aboveCellp":"UNLINKED","modp":"(VF)","varsp": [],"blocksp": [],"inlinesp": []}
+      {"type":"SCOPE","name":"@CONST-POOL@","addr":"(AG)","loc":"a,0:0,0:0","aboveScopep":"UNLINKED","aboveCellp":"UNLINKED","modp":"(ZF)","varsp": [],"blocksp": [],"inlinesp": []}
     ]}
   ]}
 ]}

--- a/test_regress/t/t_opt_life.py
+++ b/test_regress/t/t_opt_life.py
@@ -14,8 +14,7 @@ test.scenarios('simulator')
 test.compile(verilator_flags2=["--stats"])
 
 if test.vlt_all:
-    test.file_grep(test.stats, r'Optimizations, Lifetime assign deletions\s+(\d+)', 4)
-    test.file_grep(test.stats, r'Optimizations, Lifetime creset deletions\s+(\d+)', 1)
+    test.file_grep(test.stats, r'Optimizations, Lifetime assign deletions\s+(\d+)', 5)
     test.file_grep(test.stats, r'Optimizations, Lifetime constant prop\s+(\d+)', 5)
     test.file_grep(test.stats, r'Optimizations, Lifetime postassign deletions\s+(\d+)', 1)
 


### PR DESCRIPTION
Previously CReset was a statement, but I found debugging some initialization bugs that some optimizations were not properly happening due to it underneath having a VarRef lvalue.

This changes CReset to be an expression, and puts it under an Assign, which it basically is since it sets the value of a variable.

@gezalore for awareness; I'm pretty sure you'll see this as a move in the direction you like.

rtlmeter just in case some strange fallout.
