### PR TITLE
Use `FlagShared` NBA scheme for unpacked struct arrays

### DIFF
--- a/src/V3Delayed.cpp
+++ b/src/V3Delayed.cpp
@@ -430,12 +430,8 @@ class DelayedVisitor final : public VNVisitor {
             }
             // In a suspendable of fork, we must use the unique flag scheme, TODO: why?
             if (vscpInfo.m_inSuspOrFork) return Scheme::FlagUnique;
-            // Otherwise if an array of packed/basic elements, use the shared flag scheme
-            if (basicp) return Scheme::FlagShared;
-            // Finally fall back on the shadow variable scheme, e.g. for
-            // arrays of unpacked structs. This will be slow.
             // TODO: generic LHS scheme as discussed in #5092
-            return Scheme::ShadowVar;
+            return Scheme::FlagShared;
         }
 
         // In a suspendable of fork, we must use the unique flag scheme, TODO: why?

--- a/test_regress/t/t_nba_unpacked_struct_array.py
+++ b/test_regress/t/t_nba_unpacked_struct_array.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2026 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile()
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_nba_unpacked_struct_array.v
+++ b/test_regress/t/t_nba_unpacked_struct_array.v
@@ -1,0 +1,33 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2026 by Antmicro.
+// SPDX-License-Identifier: CC0-1.0
+
+module t(clk);
+  input clk;
+
+  typedef struct {
+    int x;
+  } struct_t;
+
+  int cyc = 0;
+  struct_t array[1];
+  int res = 1;
+
+  always @(posedge clk) begin
+    cyc <= cyc + 1;
+    if (cyc == 1) begin
+      array[0].x <= 1;
+    end
+    if (cyc == 2) begin
+      array[0].x = 0;
+    end
+    if (cyc == 3) begin
+      if (res != 0) $stop;
+      $finish;
+    end
+  end
+
+  always @(array[0].x) res = array[0].x;
+endmodule


### PR DESCRIPTION
I admit I've not fully internalized the new NBA handling yet. But using `FlagShared` seems at least less wrong here. I could not find the motivation for using `ShadowVar` for this, may have missed something.