### PR TITLE
Internals: Assign trace codes starting from zero

### DIFF
--- a/include/verilated_trace_imp.h
+++ b/include/verilated_trace_imp.h
@@ -352,8 +352,8 @@ void VerilatedTrace<VL_SUB_T, VL_BUF_T>::traceInit() VL_MT_UNSAFE {
         // each signal, which is 'nextCode()' entries after the init callbacks
         // above have been run, plus up to 2 more words of metadata per signal,
         // plus fixed overhead of 1 for a termination flag and 3 for a time stamp
-        // update.
-        m_offloadBufferSize = nextCode() + numSignals() * 2 + 4;
+        // update and 2 for the buffer address.
+        m_offloadBufferSize = nextCode() + numSignals() * 2 + 6;
 
         // Start the worker thread
         m_workerThread.reset(

--- a/src/V3AstNodeStmt.h
+++ b/src/V3AstNodeStmt.h
@@ -1180,7 +1180,7 @@ class AstTraceDecl final : public AstNodeStmt {
     // Parents:  {statement list}
     // Expression being traced - Moved to AstTraceInc by V3Trace
     // @astgen op1 := valuep : Optional[AstNodeExpr]
-    uint32_t m_code{0};  // Trace identifier code
+    uint32_t m_code{std::numeric_limits<uint32_t>::max()};  // Trace identifier code
     uint32_t m_fidx{0};  // Trace function index
     const string m_showname;  // Name of variable
     const VNumRange m_bitRange;  // Property of var the trace details
@@ -1212,6 +1212,7 @@ public:
     // Details on what we're tracing
     uint32_t code() const { return m_code; }
     void code(uint32_t code) { m_code = code; }
+    bool codeAssigned() const { return m_code != std::numeric_limits<uint32_t>::max(); }
     uint32_t fidx() const { return m_fidx; }
     void fidx(uint32_t fidx) { m_fidx = fidx; }
     uint32_t codeInc() const {

--- a/src/V3Trace.cpp
+++ b/src/V3Trace.cpp
@@ -190,7 +190,6 @@ class TraceVisitor final : public VNVisitor {
 
     VDouble0 m_statSetters;  // Statistic tracking
     VDouble0 m_statSettersSlow;  // Statistic tracking
-    VDouble0 m_statUniqCodes;  // Statistic tracking
     VDouble0 m_statUniqSigs;  // Statistic tracking
 
     // All activity numbers applying to a given trace
@@ -595,19 +594,18 @@ class TraceVisitor final : public VNVisitor {
                 // no need to create a TraceInc node.
                 const AstTraceDecl* const canonDeclp = canonVtxp->nodep();
                 UASSERT_OBJ(!canonVtxp->duplicatep(), canonDeclp, "Canonical node is a duplicate");
-                UASSERT_OBJ(canonDeclp->code() != 0, canonDeclp,
+                UASSERT_OBJ(canonDeclp->codeAssigned(), canonDeclp,
                             "Canonical node should have code assigned already");
                 declp->code(canonDeclp->code());
                 continue;
             }
 
             // This is a canonical trace node. Assign trace code (signal number).
-            UASSERT_OBJ(declp->code() == 0, declp,
+            UASSERT_OBJ(!declp->codeAssigned(), declp,
                         "Canonical node should not have code assigned yet");
             declp->code(m_code);
             const uint32_t codeInc = declp->codeInc();
             m_code += codeInc;
-            m_statUniqCodes += codeInc;
             ++m_statUniqSigs;
 
             // If this is a const signal, add the AstTraceInc
@@ -839,9 +837,6 @@ class TraceVisitor final : public VNVisitor {
 
     // VISITORS
     void visit(AstNetlist* nodep) override {
-        m_code = 1;  // Multiple TopScopes will require fixing how code#s
-        // are assigned as duplicate varscopes must result in the same tracing code#.
-
         // Add vertexes for all TraceDecl, and edges from VARs each trace looks at
         m_finding = false;
         iterateChildren(nodep);
@@ -945,7 +940,7 @@ public:
     ~TraceVisitor() override {
         V3Stats::addStat("Tracing, Activity setters", m_statSetters);
         V3Stats::addStat("Tracing, Activity slow blocks", m_statSettersSlow);
-        V3Stats::addStat("Tracing, Unique trace codes", m_statUniqCodes);
+        V3Stats::addStat("Tracing, Unique trace codes", m_code);
         V3Stats::addStat("Tracing, Unique traced signals", m_statUniqSigs);
     }
 };


### PR DESCRIPTION
Use uint32_t max value instead of zero as sentinel value for a trace code being unassigned. Prep for follow on patch.

Note the actual trace file will still start codes from one, the codes in the model are just an offset from the base code.
