### PR TITLE
Fix errant integer promotion

### DIFF
--- a/src/V3Clean.cpp
+++ b/src/V3Clean.cpp
@@ -18,7 +18,7 @@
 // Each module:
 //      For each expression, if it requires a clean operand,
 //      and the operand is dirty, insert a CLEAN node.
-//      Resize operands to C++ 32/64/wide types.
+//      Resize operands (but not variables or variable selects) to C++ 32/64/wide types.
 //      Copy all width() values to widthMin() so RANGE, etc can still see orig widths
 //
 //*************************************************************************
@@ -83,6 +83,7 @@ class CleanVisitor final : public VNVisitor {
             if (VN_IS(nodep, Var)  //
                 || VN_IS(nodep, ConsPackMember)  //
                 || VN_IS(nodep, NodeDType)  // Don't want to change variable widths!
+                || VN_IS(nodep, NodeSel)  // Array selects should reflect variable widths
                 || VN_IS(nodep->dtypep()->skipRefp(), AssocArrayDType)  // Or arrays
                 || VN_IS(nodep->dtypep()->skipRefp(), WildcardArrayDType)
                 || VN_IS(nodep->dtypep()->skipRefp(), DynArrayDType)

--- a/src/Verilator.cpp
+++ b/src/Verilator.cpp
@@ -527,7 +527,8 @@ static void process() {
             // Bits between widthMin() and width() are irrelevant, but may be non zero.
             v3Global.widthMinUsage(VWidthMinUsage::VERILOG_WIDTH);
 
-            // Make all expressions either 8, 16, 32 or 64 bits
+            // Make all expressions 32, 64, or 32*N bits
+            // Variables and selects-of-variables remain verilog-width
             V3Clean::cleanAll(v3Global.rootp());
 
             // Move wide constants to BLOCK temps / ConstPool.

--- a/test_regress/t/t_array_sel_short.py
+++ b/test_regress/t/t_array_sel_short.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2024 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios("simulator")
+
+test.compile(verilator_flags2=["--dump-tree"])
+
+if test.vlt_all:
+    # Test for correct array select width, see: #7012
+    clean_tree = test.glob_one(test.obj_dir + "/V*_clean.tree")
+    test.file_grep_count(clean_tree, r"ARRAYSEL.*G\/w16", 2)
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_array_sel_short.v
+++ b/test_regress/t/t_array_sel_short.v
@@ -1,0 +1,17 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain.
+// SPDX-FileCopyrightText: 2026 Wilson Snyder
+// SPDX-License-Identifier: CC0-1.0
+
+module t;
+
+   logic [15:0] foo [8];
+
+   initial begin
+      if (foo[1] != foo[1]) $stop;
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end
+
+endmodule

--- a/test_regress/t/t_json_only_debugcheck.out
+++ b/test_regress/t/t_json_only_debugcheck.out
@@ -66,79 +66,79 @@
           {"type":"CONST","name":"4'h4","addr":"(ZB)","loc":"d,38:31,38:34","dtypep":"(UB)"}
         ],
          "rhsp": [
-          {"type":"ARRAYSEL","name":"","addr":"(AC)","loc":"d,38:15,38:16","dtypep":"(UB)",
+          {"type":"ARRAYSEL","name":"","addr":"(AC)","loc":"d,38:15,38:16","dtypep":"(BC)",
            "fromp": [
-            {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(BC)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(CC)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ],
            "bitp": [
-            {"type":"AND","name":"","addr":"(EC)","loc":"d,38:15,38:16","dtypep":"(FC)",
+            {"type":"AND","name":"","addr":"(FC)","loc":"d,38:15,38:16","dtypep":"(GC)",
              "lhsp": [
-              {"type":"CONST","name":"32'h7","addr":"(GC)","loc":"d,38:15,38:16","dtypep":"(HC)"}
+              {"type":"CONST","name":"32'h7","addr":"(HC)","loc":"d,38:15,38:16","dtypep":"(IC)"}
             ],
              "rhsp": [
-              {"type":"CCAST","name":"","addr":"(IC)","loc":"d,38:15,38:16","dtypep":"(FC)","size":32,
+              {"type":"CCAST","name":"","addr":"(JC)","loc":"d,38:15,38:16","dtypep":"(GC)","size":32,
                "lhsp": [
-                {"type":"VARREF","name":"t.e","addr":"(JC)","loc":"d,38:15,38:16","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                {"type":"VARREF","name":"t.e","addr":"(KC)","loc":"d,38:15,38:16","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
               ]}
             ]}
           ]}
         ]}
       ],
        "thensp": [
-        {"type":"DISPLAY","name":"","addr":"(KC)","loc":"d,38:43,38:49",
+        {"type":"DISPLAY","name":"","addr":"(LC)","loc":"d,38:43,38:49",
          "fmtp": [
-          {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:38:  got='h%x exp='h4\\n","addr":"(LC)","loc":"d,38:43,38:49","dtypep":"(SB)",
+          {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:38:  got='h%x exp='h4\\n","addr":"(MC)","loc":"d,38:43,38:49","dtypep":"(SB)",
            "exprsp": [
-            {"type":"ARRAYSEL","name":"","addr":"(MC)","loc":"d,38:122,38:123","dtypep":"(UB)",
+            {"type":"ARRAYSEL","name":"","addr":"(NC)","loc":"d,38:122,38:123","dtypep":"(BC)",
              "fromp": [
-              {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(NC)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+              {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(OC)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
             ],
              "bitp": [
-              {"type":"AND","name":"","addr":"(OC)","loc":"d,38:122,38:123","dtypep":"(FC)",
+              {"type":"AND","name":"","addr":"(PC)","loc":"d,38:122,38:123","dtypep":"(GC)",
                "lhsp": [
-                {"type":"CONST","name":"32'h7","addr":"(PC)","loc":"d,38:122,38:123","dtypep":"(HC)"}
+                {"type":"CONST","name":"32'h7","addr":"(QC)","loc":"d,38:122,38:123","dtypep":"(IC)"}
               ],
                "rhsp": [
-                {"type":"CCAST","name":"","addr":"(QC)","loc":"d,38:122,38:123","dtypep":"(FC)","size":32,
+                {"type":"CCAST","name":"","addr":"(RC)","loc":"d,38:122,38:123","dtypep":"(GC)","size":32,
                  "lhsp": [
-                  {"type":"VARREF","name":"t.e","addr":"(RC)","loc":"d,38:122,38:123","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"t.e","addr":"(SC)","loc":"d,38:122,38:123","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                 ]}
               ]}
             ]}
           ],"scopeNamep": []}
         ],"filep": []},
-        {"type":"STOP","name":"","addr":"(SC)","loc":"d,38:142,38:147"}
+        {"type":"STOP","name":"","addr":"(TC)","loc":"d,38:142,38:147"}
       ],"elsesp": []},
-      {"type":"IF","name":"","addr":"(TC)","loc":"d,39:10,39:12",
+      {"type":"IF","name":"","addr":"(UC)","loc":"d,39:10,39:12",
        "condp": [
-        {"type":"NEQ","name":"","addr":"(UC)","loc":"d,39:34,39:37","dtypep":"(GB)",
+        {"type":"NEQ","name":"","addr":"(VC)","loc":"d,39:34,39:37","dtypep":"(GB)",
          "lhsp": [
-          {"type":"CONST","name":"4'h1","addr":"(VC)","loc":"d,39:39,39:42","dtypep":"(UB)"}
+          {"type":"CONST","name":"4'h1","addr":"(WC)","loc":"d,39:39,39:42","dtypep":"(UB)"}
         ],
          "rhsp": [
-          {"type":"ARRAYSEL","name":"","addr":"(WC)","loc":"d,39:15,39:16","dtypep":"(UB)",
+          {"type":"ARRAYSEL","name":"","addr":"(XC)","loc":"d,39:15,39:16","dtypep":"(BC)",
            "fromp": [
-            {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(XC)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(YC)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ],
            "bitp": [
-            {"type":"AND","name":"","addr":"(YC)","loc":"d,39:15,39:16","dtypep":"(FC)",
+            {"type":"AND","name":"","addr":"(ZC)","loc":"d,39:15,39:16","dtypep":"(GC)",
              "lhsp": [
-              {"type":"CONST","name":"32'h7","addr":"(ZC)","loc":"d,39:15,39:16","dtypep":"(HC)"}
+              {"type":"CONST","name":"32'h7","addr":"(AD)","loc":"d,39:15,39:16","dtypep":"(IC)"}
             ],
              "rhsp": [
-              {"type":"ARRAYSEL","name":"","addr":"(AD)","loc":"d,39:15,39:16","dtypep":"(FC)",
+              {"type":"ARRAYSEL","name":"","addr":"(BD)","loc":"d,39:15,39:16","dtypep":"(GC)",
                "fromp": [
-                {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(BD)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(CD)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
               ],
                "bitp": [
-                {"type":"AND","name":"","addr":"(CD)","loc":"d,39:15,39:16","dtypep":"(FC)",
+                {"type":"AND","name":"","addr":"(DD)","loc":"d,39:15,39:16","dtypep":"(GC)",
                  "lhsp": [
-                  {"type":"CONST","name":"32'h7","addr":"(DD)","loc":"d,39:15,39:16","dtypep":"(HC)"}
+                  {"type":"CONST","name":"32'h7","addr":"(ED)","loc":"d,39:15,39:16","dtypep":"(IC)"}
                 ],
                  "rhsp": [
-                  {"type":"CCAST","name":"","addr":"(ED)","loc":"d,39:15,39:16","dtypep":"(FC)","size":32,
+                  {"type":"CCAST","name":"","addr":"(FD)","loc":"d,39:15,39:16","dtypep":"(GC)","size":32,
                    "lhsp": [
-                    {"type":"VARREF","name":"t.e","addr":"(FD)","loc":"d,39:15,39:16","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"t.e","addr":"(GD)","loc":"d,39:15,39:16","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ]}
                 ]}
               ]}
@@ -147,33 +147,33 @@
         ]}
       ],
        "thensp": [
-        {"type":"DISPLAY","name":"","addr":"(GD)","loc":"d,39:51,39:57",
+        {"type":"DISPLAY","name":"","addr":"(HD)","loc":"d,39:51,39:57",
          "fmtp": [
-          {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:39:  got='h%x exp='h1\\n","addr":"(HD)","loc":"d,39:51,39:57","dtypep":"(SB)",
+          {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:39:  got='h%x exp='h1\\n","addr":"(ID)","loc":"d,39:51,39:57","dtypep":"(SB)",
            "exprsp": [
-            {"type":"ARRAYSEL","name":"","addr":"(ID)","loc":"d,39:130,39:131","dtypep":"(UB)",
+            {"type":"ARRAYSEL","name":"","addr":"(JD)","loc":"d,39:130,39:131","dtypep":"(BC)",
              "fromp": [
-              {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(JD)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+              {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(KD)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
             ],
              "bitp": [
-              {"type":"AND","name":"","addr":"(KD)","loc":"d,39:130,39:131","dtypep":"(FC)",
+              {"type":"AND","name":"","addr":"(LD)","loc":"d,39:130,39:131","dtypep":"(GC)",
                "lhsp": [
-                {"type":"CONST","name":"32'h7","addr":"(LD)","loc":"d,39:130,39:131","dtypep":"(HC)"}
+                {"type":"CONST","name":"32'h7","addr":"(MD)","loc":"d,39:130,39:131","dtypep":"(IC)"}
               ],
                "rhsp": [
-                {"type":"ARRAYSEL","name":"","addr":"(MD)","loc":"d,39:130,39:131","dtypep":"(FC)",
+                {"type":"ARRAYSEL","name":"","addr":"(ND)","loc":"d,39:130,39:131","dtypep":"(GC)",
                  "fromp": [
-                  {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(ND)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(OD)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                 ],
                  "bitp": [
-                  {"type":"AND","name":"","addr":"(OD)","loc":"d,39:130,39:131","dtypep":"(FC)",
+                  {"type":"AND","name":"","addr":"(PD)","loc":"d,39:130,39:131","dtypep":"(GC)",
                    "lhsp": [
-                    {"type":"CONST","name":"32'h7","addr":"(PD)","loc":"d,39:130,39:131","dtypep":"(HC)"}
+                    {"type":"CONST","name":"32'h7","addr":"(QD)","loc":"d,39:130,39:131","dtypep":"(IC)"}
                   ],
                    "rhsp": [
-                    {"type":"CCAST","name":"","addr":"(QD)","loc":"d,39:130,39:131","dtypep":"(FC)","size":32,
+                    {"type":"CCAST","name":"","addr":"(RD)","loc":"d,39:130,39:131","dtypep":"(GC)","size":32,
                      "lhsp": [
-                      {"type":"VARREF","name":"t.e","addr":"(RD)","loc":"d,39:130,39:131","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"t.e","addr":"(SD)","loc":"d,39:130,39:131","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ]}
                   ]}
                 ]}
@@ -181,38 +181,38 @@
             ]}
           ],"scopeNamep": []}
         ],"filep": []},
-        {"type":"STOP","name":"","addr":"(SD)","loc":"d,39:158,39:163"}
+        {"type":"STOP","name":"","addr":"(TD)","loc":"d,39:158,39:163"}
       ],"elsesp": []},
-      {"type":"IF","name":"","addr":"(TD)","loc":"d,40:10,40:12",
+      {"type":"IF","name":"","addr":"(UD)","loc":"d,40:10,40:12",
        "condp": [
-        {"type":"NEQ","name":"","addr":"(UD)","loc":"d,40:26,40:29","dtypep":"(GB)",
+        {"type":"NEQ","name":"","addr":"(VD)","loc":"d,40:26,40:29","dtypep":"(GB)",
          "lhsp": [
-          {"type":"CONST","name":"4'h1","addr":"(VD)","loc":"d,40:31,40:34","dtypep":"(UB)"}
+          {"type":"CONST","name":"4'h1","addr":"(WD)","loc":"d,40:31,40:34","dtypep":"(UB)"}
         ],
          "rhsp": [
-          {"type":"ARRAYSEL","name":"","addr":"(WD)","loc":"d,40:15,40:16","dtypep":"(UB)",
+          {"type":"ARRAYSEL","name":"","addr":"(XD)","loc":"d,40:15,40:16","dtypep":"(BC)",
            "fromp": [
-            {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(XD)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(YD)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ],
            "bitp": [
-            {"type":"AND","name":"","addr":"(YD)","loc":"d,40:15,40:16","dtypep":"(FC)",
+            {"type":"AND","name":"","addr":"(ZD)","loc":"d,40:15,40:16","dtypep":"(GC)",
              "lhsp": [
-              {"type":"CONST","name":"32'h7","addr":"(ZD)","loc":"d,40:15,40:16","dtypep":"(HC)"}
+              {"type":"CONST","name":"32'h7","addr":"(AE)","loc":"d,40:15,40:16","dtypep":"(IC)"}
             ],
              "rhsp": [
-              {"type":"ARRAYSEL","name":"","addr":"(AE)","loc":"d,40:15,40:16","dtypep":"(FC)",
+              {"type":"ARRAYSEL","name":"","addr":"(BE)","loc":"d,40:15,40:16","dtypep":"(GC)",
                "fromp": [
-                {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(BE)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(CE)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
               ],
                "bitp": [
-                {"type":"AND","name":"","addr":"(CE)","loc":"d,40:15,40:16","dtypep":"(FC)",
+                {"type":"AND","name":"","addr":"(DE)","loc":"d,40:15,40:16","dtypep":"(GC)",
                  "lhsp": [
-                  {"type":"CONST","name":"32'h7","addr":"(DE)","loc":"d,40:15,40:16","dtypep":"(HC)"}
+                  {"type":"CONST","name":"32'h7","addr":"(EE)","loc":"d,40:15,40:16","dtypep":"(IC)"}
                 ],
                  "rhsp": [
-                  {"type":"CCAST","name":"","addr":"(EE)","loc":"d,40:15,40:16","dtypep":"(FC)","size":32,
+                  {"type":"CCAST","name":"","addr":"(FE)","loc":"d,40:15,40:16","dtypep":"(GC)","size":32,
                    "lhsp": [
-                    {"type":"VARREF","name":"t.e","addr":"(FE)","loc":"d,40:15,40:16","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"t.e","addr":"(GE)","loc":"d,40:15,40:16","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ]}
                 ]}
               ]}
@@ -221,33 +221,33 @@
         ]}
       ],
        "thensp": [
-        {"type":"DISPLAY","name":"","addr":"(GE)","loc":"d,40:43,40:49",
+        {"type":"DISPLAY","name":"","addr":"(HE)","loc":"d,40:43,40:49",
          "fmtp": [
-          {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:40:  got='h%x exp='h1\\n","addr":"(HE)","loc":"d,40:43,40:49","dtypep":"(SB)",
+          {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:40:  got='h%x exp='h1\\n","addr":"(IE)","loc":"d,40:43,40:49","dtypep":"(SB)",
            "exprsp": [
-            {"type":"ARRAYSEL","name":"","addr":"(IE)","loc":"d,40:122,40:123","dtypep":"(UB)",
+            {"type":"ARRAYSEL","name":"","addr":"(JE)","loc":"d,40:122,40:123","dtypep":"(BC)",
              "fromp": [
-              {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(JE)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+              {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(KE)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
             ],
              "bitp": [
-              {"type":"AND","name":"","addr":"(KE)","loc":"d,40:122,40:123","dtypep":"(FC)",
+              {"type":"AND","name":"","addr":"(LE)","loc":"d,40:122,40:123","dtypep":"(GC)",
                "lhsp": [
-                {"type":"CONST","name":"32'h7","addr":"(LE)","loc":"d,40:122,40:123","dtypep":"(HC)"}
+                {"type":"CONST","name":"32'h7","addr":"(ME)","loc":"d,40:122,40:123","dtypep":"(IC)"}
               ],
                "rhsp": [
-                {"type":"ARRAYSEL","name":"","addr":"(ME)","loc":"d,40:122,40:123","dtypep":"(FC)",
+                {"type":"ARRAYSEL","name":"","addr":"(NE)","loc":"d,40:122,40:123","dtypep":"(GC)",
                  "fromp": [
-                  {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(NE)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(OE)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                 ],
                  "bitp": [
-                  {"type":"AND","name":"","addr":"(OE)","loc":"d,40:122,40:123","dtypep":"(FC)",
+                  {"type":"AND","name":"","addr":"(PE)","loc":"d,40:122,40:123","dtypep":"(GC)",
                    "lhsp": [
-                    {"type":"CONST","name":"32'h7","addr":"(PE)","loc":"d,40:122,40:123","dtypep":"(HC)"}
+                    {"type":"CONST","name":"32'h7","addr":"(QE)","loc":"d,40:122,40:123","dtypep":"(IC)"}
                   ],
                    "rhsp": [
-                    {"type":"CCAST","name":"","addr":"(QE)","loc":"d,40:122,40:123","dtypep":"(FC)","size":32,
+                    {"type":"CCAST","name":"","addr":"(RE)","loc":"d,40:122,40:123","dtypep":"(GC)","size":32,
                      "lhsp": [
-                      {"type":"VARREF","name":"t.e","addr":"(RE)","loc":"d,40:122,40:123","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"t.e","addr":"(SE)","loc":"d,40:122,40:123","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ]}
                   ]}
                 ]}
@@ -255,48 +255,48 @@
             ]}
           ],"scopeNamep": []}
         ],"filep": []},
-        {"type":"STOP","name":"","addr":"(SE)","loc":"d,40:142,40:147"}
+        {"type":"STOP","name":"","addr":"(TE)","loc":"d,40:142,40:147"}
       ],"elsesp": []},
-      {"type":"IF","name":"","addr":"(TE)","loc":"d,41:10,41:12",
+      {"type":"IF","name":"","addr":"(UE)","loc":"d,41:10,41:12",
        "condp": [
-        {"type":"NEQ","name":"","addr":"(UE)","loc":"d,41:42,41:45","dtypep":"(GB)",
+        {"type":"NEQ","name":"","addr":"(VE)","loc":"d,41:42,41:45","dtypep":"(GB)",
          "lhsp": [
-          {"type":"CONST","name":"4'h3","addr":"(VE)","loc":"d,41:47,41:50","dtypep":"(UB)"}
+          {"type":"CONST","name":"4'h3","addr":"(WE)","loc":"d,41:47,41:50","dtypep":"(UB)"}
         ],
          "rhsp": [
-          {"type":"ARRAYSEL","name":"","addr":"(WE)","loc":"d,41:15,41:16","dtypep":"(UB)",
+          {"type":"ARRAYSEL","name":"","addr":"(XE)","loc":"d,41:15,41:16","dtypep":"(BC)",
            "fromp": [
-            {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(XE)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(YE)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ],
            "bitp": [
-            {"type":"AND","name":"","addr":"(YE)","loc":"d,41:15,41:16","dtypep":"(FC)",
+            {"type":"AND","name":"","addr":"(ZE)","loc":"d,41:15,41:16","dtypep":"(GC)",
              "lhsp": [
-              {"type":"CONST","name":"32'h7","addr":"(ZE)","loc":"d,41:15,41:16","dtypep":"(HC)"}
+              {"type":"CONST","name":"32'h7","addr":"(AF)","loc":"d,41:15,41:16","dtypep":"(IC)"}
             ],
              "rhsp": [
-              {"type":"ARRAYSEL","name":"","addr":"(AF)","loc":"d,41:15,41:16","dtypep":"(FC)",
+              {"type":"ARRAYSEL","name":"","addr":"(BF)","loc":"d,41:15,41:16","dtypep":"(GC)",
                "fromp": [
-                {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(BF)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(CF)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
               ],
                "bitp": [
-                {"type":"AND","name":"","addr":"(CF)","loc":"d,41:15,41:16","dtypep":"(FC)",
+                {"type":"AND","name":"","addr":"(DF)","loc":"d,41:15,41:16","dtypep":"(GC)",
                  "lhsp": [
-                  {"type":"CONST","name":"32'h7","addr":"(DF)","loc":"d,41:15,41:16","dtypep":"(HC)"}
+                  {"type":"CONST","name":"32'h7","addr":"(EF)","loc":"d,41:15,41:16","dtypep":"(IC)"}
                 ],
                  "rhsp": [
-                  {"type":"ARRAYSEL","name":"","addr":"(EF)","loc":"d,41:15,41:16","dtypep":"(FC)",
+                  {"type":"ARRAYSEL","name":"","addr":"(FF)","loc":"d,41:15,41:16","dtypep":"(GC)",
                    "fromp": [
-                    {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(FF)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(GF)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ],
                    "bitp": [
-                    {"type":"AND","name":"","addr":"(GF)","loc":"d,41:15,41:16","dtypep":"(FC)",
+                    {"type":"AND","name":"","addr":"(HF)","loc":"d,41:15,41:16","dtypep":"(GC)",
                      "lhsp": [
-                      {"type":"CONST","name":"32'h7","addr":"(HF)","loc":"d,41:15,41:16","dtypep":"(HC)"}
+                      {"type":"CONST","name":"32'h7","addr":"(IF)","loc":"d,41:15,41:16","dtypep":"(IC)"}
                     ],
                      "rhsp": [
-                      {"type":"CCAST","name":"","addr":"(IF)","loc":"d,41:15,41:16","dtypep":"(FC)","size":32,
+                      {"type":"CCAST","name":"","addr":"(JF)","loc":"d,41:15,41:16","dtypep":"(GC)","size":32,
                        "lhsp": [
-                        {"type":"VARREF","name":"t.e","addr":"(JF)","loc":"d,41:15,41:16","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                        {"type":"VARREF","name":"t.e","addr":"(KF)","loc":"d,41:15,41:16","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                       ]}
                     ]}
                   ]}
@@ -307,43 +307,43 @@
         ]}
       ],
        "thensp": [
-        {"type":"DISPLAY","name":"","addr":"(KF)","loc":"d,41:59,41:65",
+        {"type":"DISPLAY","name":"","addr":"(LF)","loc":"d,41:59,41:65",
          "fmtp": [
-          {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:41:  got='h%x exp='h3\\n","addr":"(LF)","loc":"d,41:59,41:65","dtypep":"(SB)",
+          {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:41:  got='h%x exp='h3\\n","addr":"(MF)","loc":"d,41:59,41:65","dtypep":"(SB)",
            "exprsp": [
-            {"type":"ARRAYSEL","name":"","addr":"(MF)","loc":"d,41:138,41:139","dtypep":"(UB)",
+            {"type":"ARRAYSEL","name":"","addr":"(NF)","loc":"d,41:138,41:139","dtypep":"(BC)",
              "fromp": [
-              {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(NF)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+              {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(OF)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
             ],
              "bitp": [
-              {"type":"AND","name":"","addr":"(OF)","loc":"d,41:138,41:139","dtypep":"(FC)",
+              {"type":"AND","name":"","addr":"(PF)","loc":"d,41:138,41:139","dtypep":"(GC)",
                "lhsp": [
-                {"type":"CONST","name":"32'h7","addr":"(PF)","loc":"d,41:138,41:139","dtypep":"(HC)"}
+                {"type":"CONST","name":"32'h7","addr":"(QF)","loc":"d,41:138,41:139","dtypep":"(IC)"}
               ],
                "rhsp": [
-                {"type":"ARRAYSEL","name":"","addr":"(QF)","loc":"d,41:138,41:139","dtypep":"(FC)",
+                {"type":"ARRAYSEL","name":"","addr":"(RF)","loc":"d,41:138,41:139","dtypep":"(GC)",
                  "fromp": [
-                  {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(RF)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(SF)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                 ],
                  "bitp": [
-                  {"type":"AND","name":"","addr":"(SF)","loc":"d,41:138,41:139","dtypep":"(FC)",
+                  {"type":"AND","name":"","addr":"(TF)","loc":"d,41:138,41:139","dtypep":"(GC)",
                    "lhsp": [
-                    {"type":"CONST","name":"32'h7","addr":"(TF)","loc":"d,41:138,41:139","dtypep":"(HC)"}
+                    {"type":"CONST","name":"32'h7","addr":"(UF)","loc":"d,41:138,41:139","dtypep":"(IC)"}
                   ],
                    "rhsp": [
-                    {"type":"ARRAYSEL","name":"","addr":"(UF)","loc":"d,41:138,41:139","dtypep":"(FC)",
+                    {"type":"ARRAYSEL","name":"","addr":"(VF)","loc":"d,41:138,41:139","dtypep":"(GC)",
                      "fromp": [
-                      {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(VF)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(WF)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ],
                      "bitp": [
-                      {"type":"AND","name":"","addr":"(WF)","loc":"d,41:138,41:139","dtypep":"(FC)",
+                      {"type":"AND","name":"","addr":"(XF)","loc":"d,41:138,41:139","dtypep":"(GC)",
                        "lhsp": [
-                        {"type":"CONST","name":"32'h7","addr":"(XF)","loc":"d,41:138,41:139","dtypep":"(HC)"}
+                        {"type":"CONST","name":"32'h7","addr":"(YF)","loc":"d,41:138,41:139","dtypep":"(IC)"}
                       ],
                        "rhsp": [
-                        {"type":"CCAST","name":"","addr":"(YF)","loc":"d,41:138,41:139","dtypep":"(FC)","size":32,
+                        {"type":"CCAST","name":"","addr":"(ZF)","loc":"d,41:138,41:139","dtypep":"(GC)","size":32,
                          "lhsp": [
-                          {"type":"VARREF","name":"t.e","addr":"(ZF)","loc":"d,41:138,41:139","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                          {"type":"VARREF","name":"t.e","addr":"(AG)","loc":"d,41:138,41:139","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                         ]}
                       ]}
                     ]}
@@ -353,48 +353,48 @@
             ]}
           ],"scopeNamep": []}
         ],"filep": []},
-        {"type":"STOP","name":"","addr":"(AG)","loc":"d,41:174,41:179"}
+        {"type":"STOP","name":"","addr":"(BG)","loc":"d,41:174,41:179"}
       ],"elsesp": []},
-      {"type":"IF","name":"","addr":"(BG)","loc":"d,42:10,42:12",
+      {"type":"IF","name":"","addr":"(CG)","loc":"d,42:10,42:12",
        "condp": [
-        {"type":"NEQ","name":"","addr":"(CG)","loc":"d,42:34,42:37","dtypep":"(GB)",
+        {"type":"NEQ","name":"","addr":"(DG)","loc":"d,42:34,42:37","dtypep":"(GB)",
          "lhsp": [
-          {"type":"CONST","name":"4'h3","addr":"(DG)","loc":"d,42:39,42:42","dtypep":"(UB)"}
+          {"type":"CONST","name":"4'h3","addr":"(EG)","loc":"d,42:39,42:42","dtypep":"(UB)"}
         ],
          "rhsp": [
-          {"type":"ARRAYSEL","name":"","addr":"(EG)","loc":"d,42:15,42:16","dtypep":"(UB)",
+          {"type":"ARRAYSEL","name":"","addr":"(FG)","loc":"d,42:15,42:16","dtypep":"(BC)",
            "fromp": [
-            {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(FG)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(GG)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ],
            "bitp": [
-            {"type":"AND","name":"","addr":"(GG)","loc":"d,42:15,42:16","dtypep":"(FC)",
+            {"type":"AND","name":"","addr":"(HG)","loc":"d,42:15,42:16","dtypep":"(GC)",
              "lhsp": [
-              {"type":"CONST","name":"32'h7","addr":"(HG)","loc":"d,42:15,42:16","dtypep":"(HC)"}
+              {"type":"CONST","name":"32'h7","addr":"(IG)","loc":"d,42:15,42:16","dtypep":"(IC)"}
             ],
              "rhsp": [
-              {"type":"ARRAYSEL","name":"","addr":"(IG)","loc":"d,42:15,42:16","dtypep":"(FC)",
+              {"type":"ARRAYSEL","name":"","addr":"(JG)","loc":"d,42:15,42:16","dtypep":"(GC)",
                "fromp": [
-                {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(JG)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(KG)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
               ],
                "bitp": [
-                {"type":"AND","name":"","addr":"(KG)","loc":"d,42:15,42:16","dtypep":"(FC)",
+                {"type":"AND","name":"","addr":"(LG)","loc":"d,42:15,42:16","dtypep":"(GC)",
                  "lhsp": [
-                  {"type":"CONST","name":"32'h7","addr":"(LG)","loc":"d,42:15,42:16","dtypep":"(HC)"}
+                  {"type":"CONST","name":"32'h7","addr":"(MG)","loc":"d,42:15,42:16","dtypep":"(IC)"}
                 ],
                  "rhsp": [
-                  {"type":"ARRAYSEL","name":"","addr":"(MG)","loc":"d,42:15,42:16","dtypep":"(FC)",
+                  {"type":"ARRAYSEL","name":"","addr":"(NG)","loc":"d,42:15,42:16","dtypep":"(GC)",
                    "fromp": [
-                    {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(NG)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(OG)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ],
                    "bitp": [
-                    {"type":"AND","name":"","addr":"(OG)","loc":"d,42:15,42:16","dtypep":"(FC)",
+                    {"type":"AND","name":"","addr":"(PG)","loc":"d,42:15,42:16","dtypep":"(GC)",
                      "lhsp": [
-                      {"type":"CONST","name":"32'h7","addr":"(PG)","loc":"d,42:15,42:16","dtypep":"(HC)"}
+                      {"type":"CONST","name":"32'h7","addr":"(QG)","loc":"d,42:15,42:16","dtypep":"(IC)"}
                     ],
                      "rhsp": [
-                      {"type":"CCAST","name":"","addr":"(QG)","loc":"d,42:15,42:16","dtypep":"(FC)","size":32,
+                      {"type":"CCAST","name":"","addr":"(RG)","loc":"d,42:15,42:16","dtypep":"(GC)","size":32,
                        "lhsp": [
-                        {"type":"VARREF","name":"t.e","addr":"(RG)","loc":"d,42:15,42:16","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                        {"type":"VARREF","name":"t.e","addr":"(SG)","loc":"d,42:15,42:16","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                       ]}
                     ]}
                   ]}
@@ -405,43 +405,43 @@
         ]}
       ],
        "thensp": [
-        {"type":"DISPLAY","name":"","addr":"(SG)","loc":"d,42:51,42:57",
+        {"type":"DISPLAY","name":"","addr":"(TG)","loc":"d,42:51,42:57",
          "fmtp": [
-          {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:42:  got='h%x exp='h3\\n","addr":"(TG)","loc":"d,42:51,42:57","dtypep":"(SB)",
+          {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:42:  got='h%x exp='h3\\n","addr":"(UG)","loc":"d,42:51,42:57","dtypep":"(SB)",
            "exprsp": [
-            {"type":"ARRAYSEL","name":"","addr":"(UG)","loc":"d,42:130,42:131","dtypep":"(UB)",
+            {"type":"ARRAYSEL","name":"","addr":"(VG)","loc":"d,42:130,42:131","dtypep":"(BC)",
              "fromp": [
-              {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(VG)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+              {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(WG)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
             ],
              "bitp": [
-              {"type":"AND","name":"","addr":"(WG)","loc":"d,42:130,42:131","dtypep":"(FC)",
+              {"type":"AND","name":"","addr":"(XG)","loc":"d,42:130,42:131","dtypep":"(GC)",
                "lhsp": [
-                {"type":"CONST","name":"32'h7","addr":"(XG)","loc":"d,42:130,42:131","dtypep":"(HC)"}
+                {"type":"CONST","name":"32'h7","addr":"(YG)","loc":"d,42:130,42:131","dtypep":"(IC)"}
               ],
                "rhsp": [
-                {"type":"ARRAYSEL","name":"","addr":"(YG)","loc":"d,42:130,42:131","dtypep":"(FC)",
+                {"type":"ARRAYSEL","name":"","addr":"(ZG)","loc":"d,42:130,42:131","dtypep":"(GC)",
                  "fromp": [
-                  {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(ZG)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(AH)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                 ],
                  "bitp": [
-                  {"type":"AND","name":"","addr":"(AH)","loc":"d,42:130,42:131","dtypep":"(FC)",
+                  {"type":"AND","name":"","addr":"(BH)","loc":"d,42:130,42:131","dtypep":"(GC)",
                    "lhsp": [
-                    {"type":"CONST","name":"32'h7","addr":"(BH)","loc":"d,42:130,42:131","dtypep":"(HC)"}
+                    {"type":"CONST","name":"32'h7","addr":"(CH)","loc":"d,42:130,42:131","dtypep":"(IC)"}
                   ],
                    "rhsp": [
-                    {"type":"ARRAYSEL","name":"","addr":"(CH)","loc":"d,42:130,42:131","dtypep":"(FC)",
+                    {"type":"ARRAYSEL","name":"","addr":"(DH)","loc":"d,42:130,42:131","dtypep":"(GC)",
                      "fromp": [
-                      {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(DH)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(EH)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ],
                      "bitp": [
-                      {"type":"AND","name":"","addr":"(EH)","loc":"d,42:130,42:131","dtypep":"(FC)",
+                      {"type":"AND","name":"","addr":"(FH)","loc":"d,42:130,42:131","dtypep":"(GC)",
                        "lhsp": [
-                        {"type":"CONST","name":"32'h7","addr":"(FH)","loc":"d,42:130,42:131","dtypep":"(HC)"}
+                        {"type":"CONST","name":"32'h7","addr":"(GH)","loc":"d,42:130,42:131","dtypep":"(IC)"}
                       ],
                        "rhsp": [
-                        {"type":"CCAST","name":"","addr":"(GH)","loc":"d,42:130,42:131","dtypep":"(FC)","size":32,
+                        {"type":"CCAST","name":"","addr":"(HH)","loc":"d,42:130,42:131","dtypep":"(GC)","size":32,
                          "lhsp": [
-                          {"type":"VARREF","name":"t.e","addr":"(HH)","loc":"d,42:130,42:131","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                          {"type":"VARREF","name":"t.e","addr":"(IH)","loc":"d,42:130,42:131","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                         ]}
                       ]}
                     ]}
@@ -451,48 +451,48 @@
             ]}
           ],"scopeNamep": []}
         ],"filep": []},
-        {"type":"STOP","name":"","addr":"(IH)","loc":"d,42:158,42:163"}
+        {"type":"STOP","name":"","addr":"(JH)","loc":"d,42:158,42:163"}
       ],"elsesp": []},
-      {"type":"IF","name":"","addr":"(JH)","loc":"d,43:10,43:12",
+      {"type":"IF","name":"","addr":"(KH)","loc":"d,43:10,43:12",
        "condp": [
-        {"type":"NEQ","name":"","addr":"(KH)","loc":"d,43:30,43:33","dtypep":"(GB)",
+        {"type":"NEQ","name":"","addr":"(LH)","loc":"d,43:30,43:33","dtypep":"(GB)",
          "lhsp": [
-          {"type":"CONST","name":"4'h3","addr":"(LH)","loc":"d,43:35,43:38","dtypep":"(UB)"}
+          {"type":"CONST","name":"4'h3","addr":"(MH)","loc":"d,43:35,43:38","dtypep":"(UB)"}
         ],
          "rhsp": [
-          {"type":"ARRAYSEL","name":"","addr":"(MH)","loc":"d,43:15,43:16","dtypep":"(UB)",
+          {"type":"ARRAYSEL","name":"","addr":"(NH)","loc":"d,43:15,43:16","dtypep":"(BC)",
            "fromp": [
-            {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(NH)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(OH)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ],
            "bitp": [
-            {"type":"AND","name":"","addr":"(OH)","loc":"d,43:15,43:16","dtypep":"(FC)",
+            {"type":"AND","name":"","addr":"(PH)","loc":"d,43:15,43:16","dtypep":"(GC)",
              "lhsp": [
-              {"type":"CONST","name":"32'h7","addr":"(PH)","loc":"d,43:15,43:16","dtypep":"(HC)"}
+              {"type":"CONST","name":"32'h7","addr":"(QH)","loc":"d,43:15,43:16","dtypep":"(IC)"}
             ],
              "rhsp": [
-              {"type":"ARRAYSEL","name":"","addr":"(QH)","loc":"d,43:15,43:16","dtypep":"(FC)",
+              {"type":"ARRAYSEL","name":"","addr":"(RH)","loc":"d,43:15,43:16","dtypep":"(GC)",
                "fromp": [
-                {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(RH)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(SH)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
               ],
                "bitp": [
-                {"type":"AND","name":"","addr":"(SH)","loc":"d,43:15,43:16","dtypep":"(FC)",
+                {"type":"AND","name":"","addr":"(TH)","loc":"d,43:15,43:16","dtypep":"(GC)",
                  "lhsp": [
-                  {"type":"CONST","name":"32'h7","addr":"(TH)","loc":"d,43:15,43:16","dtypep":"(HC)"}
+                  {"type":"CONST","name":"32'h7","addr":"(UH)","loc":"d,43:15,43:16","dtypep":"(IC)"}
                 ],
                  "rhsp": [
-                  {"type":"ARRAYSEL","name":"","addr":"(UH)","loc":"d,43:15,43:16","dtypep":"(FC)",
+                  {"type":"ARRAYSEL","name":"","addr":"(VH)","loc":"d,43:15,43:16","dtypep":"(GC)",
                    "fromp": [
-                    {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(VH)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(WH)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ],
                    "bitp": [
-                    {"type":"AND","name":"","addr":"(WH)","loc":"d,43:15,43:16","dtypep":"(FC)",
+                    {"type":"AND","name":"","addr":"(XH)","loc":"d,43:15,43:16","dtypep":"(GC)",
                      "lhsp": [
-                      {"type":"CONST","name":"32'h7","addr":"(XH)","loc":"d,43:15,43:16","dtypep":"(HC)"}
+                      {"type":"CONST","name":"32'h7","addr":"(YH)","loc":"d,43:15,43:16","dtypep":"(IC)"}
                     ],
                      "rhsp": [
-                      {"type":"CCAST","name":"","addr":"(YH)","loc":"d,43:15,43:16","dtypep":"(FC)","size":32,
+                      {"type":"CCAST","name":"","addr":"(ZH)","loc":"d,43:15,43:16","dtypep":"(GC)","size":32,
                        "lhsp": [
-                        {"type":"VARREF","name":"t.e","addr":"(ZH)","loc":"d,43:15,43:16","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                        {"type":"VARREF","name":"t.e","addr":"(AI)","loc":"d,43:15,43:16","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                       ]}
                     ]}
                   ]}
@@ -503,43 +503,43 @@
         ]}
       ],
        "thensp": [
-        {"type":"DISPLAY","name":"","addr":"(AI)","loc":"d,43:47,43:53",
+        {"type":"DISPLAY","name":"","addr":"(BI)","loc":"d,43:47,43:53",
          "fmtp": [
-          {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:43:  got='h%x exp='h3\\n","addr":"(BI)","loc":"d,43:47,43:53","dtypep":"(SB)",
+          {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:43:  got='h%x exp='h3\\n","addr":"(CI)","loc":"d,43:47,43:53","dtypep":"(SB)",
            "exprsp": [
-            {"type":"ARRAYSEL","name":"","addr":"(CI)","loc":"d,43:126,43:127","dtypep":"(UB)",
+            {"type":"ARRAYSEL","name":"","addr":"(DI)","loc":"d,43:126,43:127","dtypep":"(BC)",
              "fromp": [
-              {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(DI)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+              {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(EI)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
             ],
              "bitp": [
-              {"type":"AND","name":"","addr":"(EI)","loc":"d,43:126,43:127","dtypep":"(FC)",
+              {"type":"AND","name":"","addr":"(FI)","loc":"d,43:126,43:127","dtypep":"(GC)",
                "lhsp": [
-                {"type":"CONST","name":"32'h7","addr":"(FI)","loc":"d,43:126,43:127","dtypep":"(HC)"}
+                {"type":"CONST","name":"32'h7","addr":"(GI)","loc":"d,43:126,43:127","dtypep":"(IC)"}
               ],
                "rhsp": [
-                {"type":"ARRAYSEL","name":"","addr":"(GI)","loc":"d,43:126,43:127","dtypep":"(FC)",
+                {"type":"ARRAYSEL","name":"","addr":"(HI)","loc":"d,43:126,43:127","dtypep":"(GC)",
                  "fromp": [
-                  {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(HI)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(II)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                 ],
                  "bitp": [
-                  {"type":"AND","name":"","addr":"(II)","loc":"d,43:126,43:127","dtypep":"(FC)",
+                  {"type":"AND","name":"","addr":"(JI)","loc":"d,43:126,43:127","dtypep":"(GC)",
                    "lhsp": [
-                    {"type":"CONST","name":"32'h7","addr":"(JI)","loc":"d,43:126,43:127","dtypep":"(HC)"}
+                    {"type":"CONST","name":"32'h7","addr":"(KI)","loc":"d,43:126,43:127","dtypep":"(IC)"}
                   ],
                    "rhsp": [
-                    {"type":"ARRAYSEL","name":"","addr":"(KI)","loc":"d,43:126,43:127","dtypep":"(FC)",
+                    {"type":"ARRAYSEL","name":"","addr":"(LI)","loc":"d,43:126,43:127","dtypep":"(GC)",
                      "fromp": [
-                      {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(LI)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(MI)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ],
                      "bitp": [
-                      {"type":"AND","name":"","addr":"(MI)","loc":"d,43:126,43:127","dtypep":"(FC)",
+                      {"type":"AND","name":"","addr":"(NI)","loc":"d,43:126,43:127","dtypep":"(GC)",
                        "lhsp": [
-                        {"type":"CONST","name":"32'h7","addr":"(NI)","loc":"d,43:126,43:127","dtypep":"(HC)"}
+                        {"type":"CONST","name":"32'h7","addr":"(OI)","loc":"d,43:126,43:127","dtypep":"(IC)"}
                       ],
                        "rhsp": [
-                        {"type":"CCAST","name":"","addr":"(OI)","loc":"d,43:126,43:127","dtypep":"(FC)","size":32,
+                        {"type":"CCAST","name":"","addr":"(PI)","loc":"d,43:126,43:127","dtypep":"(GC)","size":32,
                          "lhsp": [
-                          {"type":"VARREF","name":"t.e","addr":"(PI)","loc":"d,43:126,43:127","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                          {"type":"VARREF","name":"t.e","addr":"(QI)","loc":"d,43:126,43:127","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                         ]}
                       ]}
                     ]}
@@ -549,138 +549,138 @@
             ]}
           ],"scopeNamep": []}
         ],"filep": []},
-        {"type":"STOP","name":"","addr":"(QI)","loc":"d,43:150,43:155"}
+        {"type":"STOP","name":"","addr":"(RI)","loc":"d,43:150,43:155"}
       ],"elsesp": []},
-      {"type":"IF","name":"","addr":"(RI)","loc":"d,44:10,44:12",
+      {"type":"IF","name":"","addr":"(SI)","loc":"d,44:10,44:12",
        "condp": [
-        {"type":"NEQ","name":"","addr":"(SI)","loc":"d,44:23,44:26","dtypep":"(GB)",
+        {"type":"NEQ","name":"","addr":"(TI)","loc":"d,44:23,44:26","dtypep":"(GB)",
          "lhsp": [
-          {"type":"CONST","name":"4'h1","addr":"(TI)","loc":"d,44:28,44:31","dtypep":"(UB)"}
+          {"type":"CONST","name":"4'h1","addr":"(UI)","loc":"d,44:28,44:31","dtypep":"(UB)"}
         ],
          "rhsp": [
-          {"type":"ARRAYSEL","name":"","addr":"(UI)","loc":"d,44:15,44:16","dtypep":"(UB)",
+          {"type":"ARRAYSEL","name":"","addr":"(VI)","loc":"d,44:15,44:16","dtypep":"(BC)",
            "fromp": [
-            {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(VI)","loc":"d,17:12,17:16","dtypep":"(WI)","access":"RD","varp":"(XI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(WI)","loc":"d,17:12,17:16","dtypep":"(XI)","access":"RD","varp":"(YI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ],
            "bitp": [
-            {"type":"AND","name":"","addr":"(YI)","loc":"d,44:15,44:16","dtypep":"(FC)",
+            {"type":"AND","name":"","addr":"(ZI)","loc":"d,44:15,44:16","dtypep":"(GC)",
              "lhsp": [
-              {"type":"CONST","name":"32'h7","addr":"(ZI)","loc":"d,44:15,44:16","dtypep":"(HC)"}
+              {"type":"CONST","name":"32'h7","addr":"(AJ)","loc":"d,44:15,44:16","dtypep":"(IC)"}
             ],
              "rhsp": [
-              {"type":"CCAST","name":"","addr":"(AJ)","loc":"d,44:15,44:16","dtypep":"(FC)","size":32,
+              {"type":"CCAST","name":"","addr":"(BJ)","loc":"d,44:15,44:16","dtypep":"(GC)","size":32,
                "lhsp": [
-                {"type":"VARREF","name":"t.e","addr":"(BJ)","loc":"d,44:15,44:16","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                {"type":"VARREF","name":"t.e","addr":"(CJ)","loc":"d,44:15,44:16","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
               ]}
             ]}
           ]}
         ]}
       ],
        "thensp": [
-        {"type":"DISPLAY","name":"","addr":"(CJ)","loc":"d,44:40,44:46",
+        {"type":"DISPLAY","name":"","addr":"(DJ)","loc":"d,44:40,44:46",
          "fmtp": [
-          {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:44:  got='h%x exp='h1\\n","addr":"(DJ)","loc":"d,44:40,44:46","dtypep":"(SB)",
+          {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:44:  got='h%x exp='h1\\n","addr":"(EJ)","loc":"d,44:40,44:46","dtypep":"(SB)",
            "exprsp": [
-            {"type":"ARRAYSEL","name":"","addr":"(EJ)","loc":"d,44:119,44:120","dtypep":"(UB)",
+            {"type":"ARRAYSEL","name":"","addr":"(FJ)","loc":"d,44:119,44:120","dtypep":"(BC)",
              "fromp": [
-              {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(FJ)","loc":"d,17:12,17:16","dtypep":"(WI)","access":"RD","varp":"(XI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+              {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(GJ)","loc":"d,17:12,17:16","dtypep":"(XI)","access":"RD","varp":"(YI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
             ],
              "bitp": [
-              {"type":"AND","name":"","addr":"(GJ)","loc":"d,44:119,44:120","dtypep":"(FC)",
+              {"type":"AND","name":"","addr":"(HJ)","loc":"d,44:119,44:120","dtypep":"(GC)",
                "lhsp": [
-                {"type":"CONST","name":"32'h7","addr":"(HJ)","loc":"d,44:119,44:120","dtypep":"(HC)"}
+                {"type":"CONST","name":"32'h7","addr":"(IJ)","loc":"d,44:119,44:120","dtypep":"(IC)"}
               ],
                "rhsp": [
-                {"type":"CCAST","name":"","addr":"(IJ)","loc":"d,44:119,44:120","dtypep":"(FC)","size":32,
+                {"type":"CCAST","name":"","addr":"(JJ)","loc":"d,44:119,44:120","dtypep":"(GC)","size":32,
                  "lhsp": [
-                  {"type":"VARREF","name":"t.e","addr":"(JJ)","loc":"d,44:119,44:120","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"t.e","addr":"(KJ)","loc":"d,44:119,44:120","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                 ]}
               ]}
             ]}
           ],"scopeNamep": []}
         ],"filep": []},
-        {"type":"STOP","name":"","addr":"(KJ)","loc":"d,44:136,44:141"}
+        {"type":"STOP","name":"","addr":"(LJ)","loc":"d,44:136,44:141"}
       ],"elsesp": []},
-      {"type":"IF","name":"","addr":"(LJ)","loc":"d,45:10,45:12",
+      {"type":"IF","name":"","addr":"(MJ)","loc":"d,45:10,45:12",
        "condp": [
-        {"type":"NEQ","name":"","addr":"(MJ)","loc":"d,45:26,45:29","dtypep":"(GB)",
+        {"type":"NEQ","name":"","addr":"(NJ)","loc":"d,45:26,45:29","dtypep":"(GB)",
          "lhsp": [
-          {"type":"CONST","name":"4'h1","addr":"(NJ)","loc":"d,45:31,45:34","dtypep":"(UB)"}
+          {"type":"CONST","name":"4'h1","addr":"(OJ)","loc":"d,45:31,45:34","dtypep":"(UB)"}
         ],
          "rhsp": [
-          {"type":"ARRAYSEL","name":"","addr":"(OJ)","loc":"d,45:15,45:16","dtypep":"(UB)",
+          {"type":"ARRAYSEL","name":"","addr":"(PJ)","loc":"d,45:15,45:16","dtypep":"(BC)",
            "fromp": [
-            {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(PJ)","loc":"d,17:12,17:16","dtypep":"(WI)","access":"RD","varp":"(XI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(QJ)","loc":"d,17:12,17:16","dtypep":"(XI)","access":"RD","varp":"(YI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ],
            "bitp": [
-            {"type":"AND","name":"","addr":"(QJ)","loc":"d,45:15,45:16","dtypep":"(FC)",
+            {"type":"AND","name":"","addr":"(RJ)","loc":"d,45:15,45:16","dtypep":"(GC)",
              "lhsp": [
-              {"type":"CONST","name":"32'h7","addr":"(RJ)","loc":"d,45:15,45:16","dtypep":"(HC)"}
+              {"type":"CONST","name":"32'h7","addr":"(SJ)","loc":"d,45:15,45:16","dtypep":"(IC)"}
             ],
              "rhsp": [
-              {"type":"CCAST","name":"","addr":"(SJ)","loc":"d,45:15,45:16","dtypep":"(FC)","size":32,
+              {"type":"CCAST","name":"","addr":"(TJ)","loc":"d,45:15,45:16","dtypep":"(GC)","size":32,
                "lhsp": [
-                {"type":"VARREF","name":"t.e","addr":"(TJ)","loc":"d,45:15,45:16","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                {"type":"VARREF","name":"t.e","addr":"(UJ)","loc":"d,45:15,45:16","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
               ]}
             ]}
           ]}
         ]}
       ],
        "thensp": [
-        {"type":"DISPLAY","name":"","addr":"(UJ)","loc":"d,45:43,45:49",
+        {"type":"DISPLAY","name":"","addr":"(VJ)","loc":"d,45:43,45:49",
          "fmtp": [
-          {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:45:  got='h%x exp='h1\\n","addr":"(VJ)","loc":"d,45:43,45:49","dtypep":"(SB)",
+          {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:45:  got='h%x exp='h1\\n","addr":"(WJ)","loc":"d,45:43,45:49","dtypep":"(SB)",
            "exprsp": [
-            {"type":"ARRAYSEL","name":"","addr":"(WJ)","loc":"d,45:122,45:123","dtypep":"(UB)",
+            {"type":"ARRAYSEL","name":"","addr":"(XJ)","loc":"d,45:122,45:123","dtypep":"(BC)",
              "fromp": [
-              {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(XJ)","loc":"d,17:12,17:16","dtypep":"(WI)","access":"RD","varp":"(XI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+              {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(YJ)","loc":"d,17:12,17:16","dtypep":"(XI)","access":"RD","varp":"(YI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
             ],
              "bitp": [
-              {"type":"AND","name":"","addr":"(YJ)","loc":"d,45:122,45:123","dtypep":"(FC)",
+              {"type":"AND","name":"","addr":"(ZJ)","loc":"d,45:122,45:123","dtypep":"(GC)",
                "lhsp": [
-                {"type":"CONST","name":"32'h7","addr":"(ZJ)","loc":"d,45:122,45:123","dtypep":"(HC)"}
+                {"type":"CONST","name":"32'h7","addr":"(AK)","loc":"d,45:122,45:123","dtypep":"(IC)"}
               ],
                "rhsp": [
-                {"type":"CCAST","name":"","addr":"(AK)","loc":"d,45:122,45:123","dtypep":"(FC)","size":32,
+                {"type":"CCAST","name":"","addr":"(BK)","loc":"d,45:122,45:123","dtypep":"(GC)","size":32,
                  "lhsp": [
-                  {"type":"VARREF","name":"t.e","addr":"(BK)","loc":"d,45:122,45:123","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"t.e","addr":"(CK)","loc":"d,45:122,45:123","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                 ]}
               ]}
             ]}
           ],"scopeNamep": []}
         ],"filep": []},
-        {"type":"STOP","name":"","addr":"(CK)","loc":"d,45:142,45:147"}
+        {"type":"STOP","name":"","addr":"(DK)","loc":"d,45:142,45:147"}
       ],"elsesp": []},
-      {"type":"IF","name":"","addr":"(DK)","loc":"d,46:10,46:12",
+      {"type":"IF","name":"","addr":"(EK)","loc":"d,46:10,46:12",
        "condp": [
-        {"type":"NEQ","name":"","addr":"(EK)","loc":"d,46:34,46:37","dtypep":"(GB)",
+        {"type":"NEQ","name":"","addr":"(FK)","loc":"d,46:34,46:37","dtypep":"(GB)",
          "lhsp": [
-          {"type":"CONST","name":"4'h4","addr":"(FK)","loc":"d,46:39,46:42","dtypep":"(UB)"}
+          {"type":"CONST","name":"4'h4","addr":"(GK)","loc":"d,46:39,46:42","dtypep":"(UB)"}
         ],
          "rhsp": [
-          {"type":"ARRAYSEL","name":"","addr":"(GK)","loc":"d,46:15,46:16","dtypep":"(UB)",
+          {"type":"ARRAYSEL","name":"","addr":"(HK)","loc":"d,46:15,46:16","dtypep":"(BC)",
            "fromp": [
-            {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(HK)","loc":"d,17:12,17:16","dtypep":"(WI)","access":"RD","varp":"(XI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(IK)","loc":"d,17:12,17:16","dtypep":"(XI)","access":"RD","varp":"(YI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ],
            "bitp": [
-            {"type":"AND","name":"","addr":"(IK)","loc":"d,46:15,46:16","dtypep":"(FC)",
+            {"type":"AND","name":"","addr":"(JK)","loc":"d,46:15,46:16","dtypep":"(GC)",
              "lhsp": [
-              {"type":"CONST","name":"32'h7","addr":"(JK)","loc":"d,46:15,46:16","dtypep":"(HC)"}
+              {"type":"CONST","name":"32'h7","addr":"(KK)","loc":"d,46:15,46:16","dtypep":"(IC)"}
             ],
              "rhsp": [
-              {"type":"ARRAYSEL","name":"","addr":"(KK)","loc":"d,46:15,46:16","dtypep":"(FC)",
+              {"type":"ARRAYSEL","name":"","addr":"(LK)","loc":"d,46:15,46:16","dtypep":"(GC)",
                "fromp": [
-                {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(LK)","loc":"d,17:12,17:16","dtypep":"(WI)","access":"RD","varp":"(XI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(MK)","loc":"d,17:12,17:16","dtypep":"(XI)","access":"RD","varp":"(YI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
               ],
                "bitp": [
-                {"type":"AND","name":"","addr":"(MK)","loc":"d,46:15,46:16","dtypep":"(FC)",
+                {"type":"AND","name":"","addr":"(NK)","loc":"d,46:15,46:16","dtypep":"(GC)",
                  "lhsp": [
-                  {"type":"CONST","name":"32'h7","addr":"(NK)","loc":"d,46:15,46:16","dtypep":"(HC)"}
+                  {"type":"CONST","name":"32'h7","addr":"(OK)","loc":"d,46:15,46:16","dtypep":"(IC)"}
                 ],
                  "rhsp": [
-                  {"type":"CCAST","name":"","addr":"(OK)","loc":"d,46:15,46:16","dtypep":"(FC)","size":32,
+                  {"type":"CCAST","name":"","addr":"(PK)","loc":"d,46:15,46:16","dtypep":"(GC)","size":32,
                    "lhsp": [
-                    {"type":"VARREF","name":"t.e","addr":"(PK)","loc":"d,46:15,46:16","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"t.e","addr":"(QK)","loc":"d,46:15,46:16","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ]}
                 ]}
               ]}
@@ -689,33 +689,33 @@
         ]}
       ],
        "thensp": [
-        {"type":"DISPLAY","name":"","addr":"(QK)","loc":"d,46:51,46:57",
+        {"type":"DISPLAY","name":"","addr":"(RK)","loc":"d,46:51,46:57",
          "fmtp": [
-          {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:46:  got='h%x exp='h4\\n","addr":"(RK)","loc":"d,46:51,46:57","dtypep":"(SB)",
+          {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:46:  got='h%x exp='h4\\n","addr":"(SK)","loc":"d,46:51,46:57","dtypep":"(SB)",
            "exprsp": [
-            {"type":"ARRAYSEL","name":"","addr":"(SK)","loc":"d,46:130,46:131","dtypep":"(UB)",
+            {"type":"ARRAYSEL","name":"","addr":"(TK)","loc":"d,46:130,46:131","dtypep":"(BC)",
              "fromp": [
-              {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(TK)","loc":"d,17:12,17:16","dtypep":"(WI)","access":"RD","varp":"(XI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+              {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(UK)","loc":"d,17:12,17:16","dtypep":"(XI)","access":"RD","varp":"(YI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
             ],
              "bitp": [
-              {"type":"AND","name":"","addr":"(UK)","loc":"d,46:130,46:131","dtypep":"(FC)",
+              {"type":"AND","name":"","addr":"(VK)","loc":"d,46:130,46:131","dtypep":"(GC)",
                "lhsp": [
-                {"type":"CONST","name":"32'h7","addr":"(VK)","loc":"d,46:130,46:131","dtypep":"(HC)"}
+                {"type":"CONST","name":"32'h7","addr":"(WK)","loc":"d,46:130,46:131","dtypep":"(IC)"}
               ],
                "rhsp": [
-                {"type":"ARRAYSEL","name":"","addr":"(WK)","loc":"d,46:130,46:131","dtypep":"(FC)",
+                {"type":"ARRAYSEL","name":"","addr":"(XK)","loc":"d,46:130,46:131","dtypep":"(GC)",
                  "fromp": [
-                  {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(XK)","loc":"d,17:12,17:16","dtypep":"(WI)","access":"RD","varp":"(XI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(YK)","loc":"d,17:12,17:16","dtypep":"(XI)","access":"RD","varp":"(YI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                 ],
                  "bitp": [
-                  {"type":"AND","name":"","addr":"(YK)","loc":"d,46:130,46:131","dtypep":"(FC)",
+                  {"type":"AND","name":"","addr":"(ZK)","loc":"d,46:130,46:131","dtypep":"(GC)",
                    "lhsp": [
-                    {"type":"CONST","name":"32'h7","addr":"(ZK)","loc":"d,46:130,46:131","dtypep":"(HC)"}
+                    {"type":"CONST","name":"32'h7","addr":"(AL)","loc":"d,46:130,46:131","dtypep":"(IC)"}
                   ],
                    "rhsp": [
-                    {"type":"CCAST","name":"","addr":"(AL)","loc":"d,46:130,46:131","dtypep":"(FC)","size":32,
+                    {"type":"CCAST","name":"","addr":"(BL)","loc":"d,46:130,46:131","dtypep":"(GC)","size":32,
                      "lhsp": [
-                      {"type":"VARREF","name":"t.e","addr":"(BL)","loc":"d,46:130,46:131","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"t.e","addr":"(CL)","loc":"d,46:130,46:131","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ]}
                   ]}
                 ]}
@@ -723,38 +723,38 @@
             ]}
           ],"scopeNamep": []}
         ],"filep": []},
-        {"type":"STOP","name":"","addr":"(CL)","loc":"d,46:158,46:163"}
+        {"type":"STOP","name":"","addr":"(DL)","loc":"d,46:158,46:163"}
       ],"elsesp": []},
-      {"type":"IF","name":"","addr":"(DL)","loc":"d,47:10,47:12",
+      {"type":"IF","name":"","addr":"(EL)","loc":"d,47:10,47:12",
        "condp": [
-        {"type":"NEQ","name":"","addr":"(EL)","loc":"d,47:26,47:29","dtypep":"(GB)",
+        {"type":"NEQ","name":"","addr":"(FL)","loc":"d,47:26,47:29","dtypep":"(GB)",
          "lhsp": [
-          {"type":"CONST","name":"4'h4","addr":"(FL)","loc":"d,47:31,47:34","dtypep":"(UB)"}
+          {"type":"CONST","name":"4'h4","addr":"(GL)","loc":"d,47:31,47:34","dtypep":"(UB)"}
         ],
          "rhsp": [
-          {"type":"ARRAYSEL","name":"","addr":"(GL)","loc":"d,47:15,47:16","dtypep":"(UB)",
+          {"type":"ARRAYSEL","name":"","addr":"(HL)","loc":"d,47:15,47:16","dtypep":"(BC)",
            "fromp": [
-            {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(HL)","loc":"d,17:12,17:16","dtypep":"(WI)","access":"RD","varp":"(XI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(IL)","loc":"d,17:12,17:16","dtypep":"(XI)","access":"RD","varp":"(YI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ],
            "bitp": [
-            {"type":"AND","name":"","addr":"(IL)","loc":"d,47:15,47:16","dtypep":"(FC)",
+            {"type":"AND","name":"","addr":"(JL)","loc":"d,47:15,47:16","dtypep":"(GC)",
              "lhsp": [
-              {"type":"CONST","name":"32'h7","addr":"(JL)","loc":"d,47:15,47:16","dtypep":"(HC)"}
+              {"type":"CONST","name":"32'h7","addr":"(KL)","loc":"d,47:15,47:16","dtypep":"(IC)"}
             ],
              "rhsp": [
-              {"type":"ARRAYSEL","name":"","addr":"(KL)","loc":"d,47:15,47:16","dtypep":"(FC)",
+              {"type":"ARRAYSEL","name":"","addr":"(LL)","loc":"d,47:15,47:16","dtypep":"(GC)",
                "fromp": [
-                {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(LL)","loc":"d,17:12,17:16","dtypep":"(WI)","access":"RD","varp":"(XI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(ML)","loc":"d,17:12,17:16","dtypep":"(XI)","access":"RD","varp":"(YI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
               ],
                "bitp": [
-                {"type":"AND","name":"","addr":"(ML)","loc":"d,47:15,47:16","dtypep":"(FC)",
+                {"type":"AND","name":"","addr":"(NL)","loc":"d,47:15,47:16","dtypep":"(GC)",
                  "lhsp": [
-                  {"type":"CONST","name":"32'h7","addr":"(NL)","loc":"d,47:15,47:16","dtypep":"(HC)"}
+                  {"type":"CONST","name":"32'h7","addr":"(OL)","loc":"d,47:15,47:16","dtypep":"(IC)"}
                 ],
                  "rhsp": [
-                  {"type":"CCAST","name":"","addr":"(OL)","loc":"d,47:15,47:16","dtypep":"(FC)","size":32,
+                  {"type":"CCAST","name":"","addr":"(PL)","loc":"d,47:15,47:16","dtypep":"(GC)","size":32,
                    "lhsp": [
-                    {"type":"VARREF","name":"t.e","addr":"(PL)","loc":"d,47:15,47:16","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"t.e","addr":"(QL)","loc":"d,47:15,47:16","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ]}
                 ]}
               ]}
@@ -763,33 +763,33 @@
         ]}
       ],
        "thensp": [
-        {"type":"DISPLAY","name":"","addr":"(QL)","loc":"d,47:43,47:49",
+        {"type":"DISPLAY","name":"","addr":"(RL)","loc":"d,47:43,47:49",
          "fmtp": [
-          {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:47:  got='h%x exp='h4\\n","addr":"(RL)","loc":"d,47:43,47:49","dtypep":"(SB)",
+          {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:47:  got='h%x exp='h4\\n","addr":"(SL)","loc":"d,47:43,47:49","dtypep":"(SB)",
            "exprsp": [
-            {"type":"ARRAYSEL","name":"","addr":"(SL)","loc":"d,47:122,47:123","dtypep":"(UB)",
+            {"type":"ARRAYSEL","name":"","addr":"(TL)","loc":"d,47:122,47:123","dtypep":"(BC)",
              "fromp": [
-              {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(TL)","loc":"d,17:12,17:16","dtypep":"(WI)","access":"RD","varp":"(XI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+              {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(UL)","loc":"d,17:12,17:16","dtypep":"(XI)","access":"RD","varp":"(YI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
             ],
              "bitp": [
-              {"type":"AND","name":"","addr":"(UL)","loc":"d,47:122,47:123","dtypep":"(FC)",
+              {"type":"AND","name":"","addr":"(VL)","loc":"d,47:122,47:123","dtypep":"(GC)",
                "lhsp": [
-                {"type":"CONST","name":"32'h7","addr":"(VL)","loc":"d,47:122,47:123","dtypep":"(HC)"}
+                {"type":"CONST","name":"32'h7","addr":"(WL)","loc":"d,47:122,47:123","dtypep":"(IC)"}
               ],
                "rhsp": [
-                {"type":"ARRAYSEL","name":"","addr":"(WL)","loc":"d,47:122,47:123","dtypep":"(FC)",
+                {"type":"ARRAYSEL","name":"","addr":"(XL)","loc":"d,47:122,47:123","dtypep":"(GC)",
                  "fromp": [
-                  {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(XL)","loc":"d,17:12,17:16","dtypep":"(WI)","access":"RD","varp":"(XI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(YL)","loc":"d,17:12,17:16","dtypep":"(XI)","access":"RD","varp":"(YI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                 ],
                  "bitp": [
-                  {"type":"AND","name":"","addr":"(YL)","loc":"d,47:122,47:123","dtypep":"(FC)",
+                  {"type":"AND","name":"","addr":"(ZL)","loc":"d,47:122,47:123","dtypep":"(GC)",
                    "lhsp": [
-                    {"type":"CONST","name":"32'h7","addr":"(ZL)","loc":"d,47:122,47:123","dtypep":"(HC)"}
+                    {"type":"CONST","name":"32'h7","addr":"(AM)","loc":"d,47:122,47:123","dtypep":"(IC)"}
                   ],
                    "rhsp": [
-                    {"type":"CCAST","name":"","addr":"(AM)","loc":"d,47:122,47:123","dtypep":"(FC)","size":32,
+                    {"type":"CCAST","name":"","addr":"(BM)","loc":"d,47:122,47:123","dtypep":"(GC)","size":32,
                      "lhsp": [
-                      {"type":"VARREF","name":"t.e","addr":"(BM)","loc":"d,47:122,47:123","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"t.e","addr":"(CM)","loc":"d,47:122,47:123","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ]}
                   ]}
                 ]}
@@ -797,96 +797,96 @@
             ]}
           ],"scopeNamep": []}
         ],"filep": []},
-        {"type":"STOP","name":"","addr":"(CM)","loc":"d,47:142,47:147"}
+        {"type":"STOP","name":"","addr":"(DM)","loc":"d,47:142,47:147"}
       ],"elsesp": []},
-      {"type":"IF","name":"","addr":"(DM)","loc":"d,49:10,49:12",
+      {"type":"IF","name":"","addr":"(EM)","loc":"d,49:10,49:12",
        "condp": [
-        {"type":"NEQN","name":"","addr":"(EM)","loc":"d,49:23,49:25","dtypep":"(GB)",
+        {"type":"NEQN","name":"","addr":"(FM)","loc":"d,49:23,49:25","dtypep":"(GB)",
          "lhsp": [
-          {"type":"CONST","name":"\\\"E03\\\"","addr":"(FM)","loc":"d,49:27,49:32","dtypep":"(SB)"}
+          {"type":"CONST","name":"\\\"E03\\\"","addr":"(GM)","loc":"d,49:27,49:32","dtypep":"(SB)"}
         ],
          "rhsp": [
-          {"type":"ARRAYSEL","name":"","addr":"(GM)","loc":"d,49:15,49:16","dtypep":"(SB)",
+          {"type":"ARRAYSEL","name":"","addr":"(HM)","loc":"d,49:15,49:16","dtypep":"(SB)",
            "fromp": [
-            {"type":"VARREF","name":"__Venumtab_enum_name1","addr":"(HM)","loc":"d,17:12,17:16","dtypep":"(IM)","access":"RD","varp":"(JM)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"__Venumtab_enum_name1","addr":"(IM)","loc":"d,17:12,17:16","dtypep":"(JM)","access":"RD","varp":"(KM)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ],
            "bitp": [
-            {"type":"AND","name":"","addr":"(KM)","loc":"d,49:15,49:16","dtypep":"(FC)",
+            {"type":"AND","name":"","addr":"(LM)","loc":"d,49:15,49:16","dtypep":"(GC)",
              "lhsp": [
-              {"type":"CONST","name":"32'h7","addr":"(LM)","loc":"d,49:15,49:16","dtypep":"(HC)"}
+              {"type":"CONST","name":"32'h7","addr":"(MM)","loc":"d,49:15,49:16","dtypep":"(IC)"}
             ],
              "rhsp": [
-              {"type":"CCAST","name":"","addr":"(MM)","loc":"d,49:15,49:16","dtypep":"(FC)","size":32,
+              {"type":"CCAST","name":"","addr":"(NM)","loc":"d,49:15,49:16","dtypep":"(GC)","size":32,
                "lhsp": [
-                {"type":"VARREF","name":"t.e","addr":"(NM)","loc":"d,49:15,49:16","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                {"type":"VARREF","name":"t.e","addr":"(OM)","loc":"d,49:15,49:16","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
               ]}
             ]}
           ]}
         ]}
       ],
        "thensp": [
-        {"type":"ASSIGN","name":"","addr":"(OM)","loc":"d,49:120,49:121","dtypep":"(SB)",
+        {"type":"ASSIGN","name":"","addr":"(PM)","loc":"d,49:120,49:121","dtypep":"(SB)",
          "rhsp": [
-          {"type":"ARRAYSEL","name":"","addr":"(PM)","loc":"d,49:120,49:121","dtypep":"(SB)",
+          {"type":"ARRAYSEL","name":"","addr":"(QM)","loc":"d,49:120,49:121","dtypep":"(SB)",
            "fromp": [
-            {"type":"VARREF","name":"__Venumtab_enum_name1","addr":"(QM)","loc":"d,17:12,17:16","dtypep":"(IM)","access":"RD","varp":"(JM)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"__Venumtab_enum_name1","addr":"(RM)","loc":"d,17:12,17:16","dtypep":"(JM)","access":"RD","varp":"(KM)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ],
            "bitp": [
-            {"type":"AND","name":"","addr":"(RM)","loc":"d,49:120,49:121","dtypep":"(FC)",
+            {"type":"AND","name":"","addr":"(SM)","loc":"d,49:120,49:121","dtypep":"(GC)",
              "lhsp": [
-              {"type":"CONST","name":"32'h7","addr":"(SM)","loc":"d,49:120,49:121","dtypep":"(HC)"}
+              {"type":"CONST","name":"32'h7","addr":"(TM)","loc":"d,49:120,49:121","dtypep":"(IC)"}
             ],
              "rhsp": [
-              {"type":"CCAST","name":"","addr":"(TM)","loc":"d,49:120,49:121","dtypep":"(FC)","size":32,
+              {"type":"CCAST","name":"","addr":"(UM)","loc":"d,49:120,49:121","dtypep":"(GC)","size":32,
                "lhsp": [
-                {"type":"VARREF","name":"t.e","addr":"(UM)","loc":"d,49:120,49:121","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                {"type":"VARREF","name":"t.e","addr":"(VM)","loc":"d,49:120,49:121","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
               ]}
             ]}
           ]}
         ],
          "lhsp": [
-          {"type":"VARREF","name":"__Vtemp_1","addr":"(VM)","loc":"d,49:120,49:121","dtypep":"(SB)","access":"WR","varp":"(RB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+          {"type":"VARREF","name":"__Vtemp_1","addr":"(WM)","loc":"d,49:120,49:121","dtypep":"(SB)","access":"WR","varp":"(RB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
         ],"timingControlp": []},
-        {"type":"DISPLAY","name":"","addr":"(WM)","loc":"d,49:41,49:47",
+        {"type":"DISPLAY","name":"","addr":"(XM)","loc":"d,49:41,49:47",
          "fmtp": [
-          {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:49:  got='%@' exp='E03'\\n","addr":"(XM)","loc":"d,49:41,49:47","dtypep":"(SB)",
+          {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:49:  got='%@' exp='E03'\\n","addr":"(YM)","loc":"d,49:41,49:47","dtypep":"(SB)",
            "exprsp": [
-            {"type":"VARREF","name":"__Vtemp_1","addr":"(YM)","loc":"d,49:120,49:121","dtypep":"(SB)","access":"RD","varp":"(RB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"__Vtemp_1","addr":"(ZM)","loc":"d,49:120,49:121","dtypep":"(SB)","access":"RD","varp":"(RB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ],"scopeNamep": []}
         ],"filep": []},
-        {"type":"STOP","name":"","addr":"(ZM)","loc":"d,49:139,49:144"}
+        {"type":"STOP","name":"","addr":"(AN)","loc":"d,49:139,49:144"}
       ],"elsesp": []},
-      {"type":"ASSIGN","name":"","addr":"(AN)","loc":"d,55:9,55:10","dtypep":"(UB)",
+      {"type":"ASSIGN","name":"","addr":"(BN)","loc":"d,55:9,55:10","dtypep":"(UB)",
        "rhsp": [
-        {"type":"CONST","name":"4'h4","addr":"(BN)","loc":"d,55:13,55:17","dtypep":"(UB)"}
+        {"type":"CONST","name":"4'h4","addr":"(CN)","loc":"d,55:13,55:17","dtypep":"(UB)"}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"t.e","addr":"(CN)","loc":"d,55:7,55:8","dtypep":"(UB)","access":"WR","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"t.e","addr":"(DN)","loc":"d,55:7,55:8","dtypep":"(UB)","access":"WR","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []}
     ]},
-    {"type":"CFUNC","name":"_eval_final","addr":"(DN)","loc":"a,0:0,0:0","slow":true,"scopep":"(Z)","argsp": [],"varsp": [],"stmtsp": []},
-    {"type":"CFUNC","name":"_eval_settle","addr":"(EN)","loc":"a,0:0,0:0","slow":true,"scopep":"(Z)","argsp": [],"varsp": [],"stmtsp": []},
-    {"type":"CFUNC","name":"_eval_triggers_vec__act","addr":"(FN)","loc":"a,0:0,0:0","scopep":"(Z)","argsp": [],"varsp": [],
+    {"type":"CFUNC","name":"_eval_final","addr":"(EN)","loc":"a,0:0,0:0","slow":true,"scopep":"(Z)","argsp": [],"varsp": [],"stmtsp": []},
+    {"type":"CFUNC","name":"_eval_settle","addr":"(FN)","loc":"a,0:0,0:0","slow":true,"scopep":"(Z)","argsp": [],"varsp": [],"stmtsp": []},
+    {"type":"CFUNC","name":"_eval_triggers_vec__act","addr":"(GN)","loc":"a,0:0,0:0","scopep":"(Z)","argsp": [],"varsp": [],
      "stmtsp": [
-      {"type":"ASSIGN","name":"","addr":"(GN)","loc":"d,11:8,11:9","dtypep":"(HN)",
+      {"type":"ASSIGN","name":"","addr":"(HN)","loc":"d,11:8,11:9","dtypep":"(IN)",
        "rhsp": [
-        {"type":"CCAST","name":"","addr":"(IN)","loc":"d,63:14,63:21","dtypep":"(JN)","size":64,
+        {"type":"CCAST","name":"","addr":"(JN)","loc":"d,63:14,63:21","dtypep":"(KN)","size":64,
          "lhsp": [
-          {"type":"CCAST","name":"","addr":"(KN)","loc":"d,63:14,63:21","dtypep":"(GB)","size":32,
+          {"type":"CCAST","name":"","addr":"(LN)","loc":"d,63:14,63:21","dtypep":"(GB)","size":32,
            "lhsp": [
-            {"type":"AND","name":"","addr":"(LN)","loc":"d,63:14,63:21","dtypep":"(GB)",
+            {"type":"AND","name":"","addr":"(MN)","loc":"d,63:14,63:21","dtypep":"(GB)",
              "lhsp": [
-              {"type":"CCAST","name":"","addr":"(MN)","loc":"d,63:22,63:25","dtypep":"(GB)","size":32,
+              {"type":"CCAST","name":"","addr":"(NN)","loc":"d,63:22,63:25","dtypep":"(GB)","size":32,
                "lhsp": [
-                {"type":"VARREF","name":"clk","addr":"(NN)","loc":"d,63:22,63:25","dtypep":"(GB)","access":"RD","varp":"(J)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                {"type":"VARREF","name":"clk","addr":"(ON)","loc":"d,63:22,63:25","dtypep":"(GB)","access":"RD","varp":"(J)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
               ]}
             ],
              "rhsp": [
-              {"type":"NOT","name":"","addr":"(ON)","loc":"d,63:14,63:21","dtypep":"(GB)",
+              {"type":"NOT","name":"","addr":"(PN)","loc":"d,63:14,63:21","dtypep":"(GB)",
                "lhsp": [
-                {"type":"CCAST","name":"","addr":"(PN)","loc":"d,63:14,63:21","dtypep":"(GB)","size":32,
+                {"type":"CCAST","name":"","addr":"(QN)","loc":"d,63:14,63:21","dtypep":"(GB)","size":32,
                  "lhsp": [
-                  {"type":"VARREF","name":"__Vtrigprevexpr___TOP__clk__0","addr":"(QN)","loc":"d,63:14,63:21","dtypep":"(GB)","access":"RD","varp":"(N)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"__Vtrigprevexpr___TOP__clk__0","addr":"(RN)","loc":"d,63:14,63:21","dtypep":"(GB)","access":"RD","varp":"(N)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                 ]}
               ]}
             ]}
@@ -894,440 +894,440 @@
         ]}
       ],
        "lhsp": [
-        {"type":"ARRAYSEL","name":"","addr":"(RN)","loc":"d,11:8,11:9","dtypep":"(HN)",
+        {"type":"ARRAYSEL","name":"","addr":"(SN)","loc":"d,11:8,11:9","dtypep":"(IN)",
          "fromp": [
-          {"type":"VARREF","name":"__VactTriggered","addr":"(SN)","loc":"d,11:8,11:9","dtypep":"(W)","access":"WR","varp":"(V)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+          {"type":"VARREF","name":"__VactTriggered","addr":"(TN)","loc":"d,11:8,11:9","dtypep":"(W)","access":"WR","varp":"(V)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
         ],
          "bitp": [
-          {"type":"CONST","name":"32'h0","addr":"(TN)","loc":"d,11:8,11:9","dtypep":"(HC)"}
+          {"type":"CONST","name":"32'h0","addr":"(UN)","loc":"d,11:8,11:9","dtypep":"(IC)"}
         ]}
       ],"timingControlp": []},
-      {"type":"ASSIGN","name":"","addr":"(UN)","loc":"d,63:22,63:25","dtypep":"(GB)",
+      {"type":"ASSIGN","name":"","addr":"(VN)","loc":"d,63:22,63:25","dtypep":"(GB)",
        "rhsp": [
-        {"type":"VARREF","name":"clk","addr":"(VN)","loc":"d,63:22,63:25","dtypep":"(GB)","access":"RD","varp":"(J)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"clk","addr":"(WN)","loc":"d,63:22,63:25","dtypep":"(GB)","access":"RD","varp":"(J)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"__Vtrigprevexpr___TOP__clk__0","addr":"(WN)","loc":"d,63:22,63:25","dtypep":"(GB)","access":"WR","varp":"(N)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"__Vtrigprevexpr___TOP__clk__0","addr":"(XN)","loc":"d,63:22,63:25","dtypep":"(GB)","access":"WR","varp":"(N)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []}
     ]},
-    {"type":"CFUNC","name":"_dump_triggers__act","addr":"(XN)","loc":"a,0:0,0:0","slow":true,"isStatic":true,"scopep":"(Z)",
+    {"type":"CFUNC","name":"_dump_triggers__act","addr":"(YN)","loc":"a,0:0,0:0","slow":true,"isStatic":true,"scopep":"(Z)",
      "argsp": [
-      {"type":"VAR","name":"triggers","addr":"(YN)","loc":"a,0:0,0:0","dtypep":"(W)","origName":"triggers","verilogName":"triggers","direction":"CONSTREF","isFuncLocal":true,"lifetime":"NONE","varType":"BLOCKTEMP","dtypeName":"","sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
-      {"type":"ASSIGN","name":"","addr":"(ZN)","loc":"a,0:0,0:0","dtypep":"(W)",
+      {"type":"VAR","name":"triggers","addr":"(ZN)","loc":"a,0:0,0:0","dtypep":"(W)","origName":"triggers","verilogName":"triggers","direction":"CONSTREF","isFuncLocal":true,"lifetime":"NONE","varType":"BLOCKTEMP","dtypeName":"","sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
+      {"type":"ASSIGN","name":"","addr":"(AO)","loc":"a,0:0,0:0","dtypep":"(W)",
        "rhsp": [
-        {"type":"CRESET","name":"","addr":"(AO)","loc":"a,0:0,0:0","dtypep":"(W)","constructing":true}
+        {"type":"CRESET","name":"","addr":"(BO)","loc":"a,0:0,0:0","dtypep":"(W)","constructing":true}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"triggers","addr":"(BO)","loc":"a,0:0,0:0","dtypep":"(W)","access":"WR","varp":"(YN)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"triggers","addr":"(CO)","loc":"a,0:0,0:0","dtypep":"(W)","access":"WR","varp":"(ZN)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []},
-      {"type":"VAR","name":"tag","addr":"(CO)","loc":"a,0:0,0:0","dtypep":"(SB)","origName":"tag","verilogName":"tag","direction":"CONSTREF","isFuncLocal":true,"lifetime":"NONE","varType":"BLOCKTEMP","dtypeName":"string","sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
-      {"type":"ASSIGN","name":"","addr":"(DO)","loc":"a,0:0,0:0","dtypep":"(SB)",
+      {"type":"VAR","name":"tag","addr":"(DO)","loc":"a,0:0,0:0","dtypep":"(SB)","origName":"tag","verilogName":"tag","direction":"CONSTREF","isFuncLocal":true,"lifetime":"NONE","varType":"BLOCKTEMP","dtypeName":"string","sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
+      {"type":"ASSIGN","name":"","addr":"(EO)","loc":"a,0:0,0:0","dtypep":"(SB)",
        "rhsp": [
-        {"type":"CRESET","name":"","addr":"(EO)","loc":"a,0:0,0:0","dtypep":"(SB)","constructing":true}
+        {"type":"CRESET","name":"","addr":"(FO)","loc":"a,0:0,0:0","dtypep":"(SB)","constructing":true}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"tag","addr":"(FO)","loc":"a,0:0,0:0","dtypep":"(SB)","access":"WR","varp":"(CO)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"tag","addr":"(GO)","loc":"a,0:0,0:0","dtypep":"(SB)","access":"WR","varp":"(DO)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []}
     ],"varsp": [],
      "stmtsp": [
-      {"type":"IF","name":"","addr":"(GO)","loc":"d,11:8,11:9",
+      {"type":"IF","name":"","addr":"(HO)","loc":"d,11:8,11:9",
        "condp": [
-        {"type":"AND","name":"","addr":"(HO)","loc":"d,11:8,11:9","dtypep":"(GB)",
+        {"type":"AND","name":"","addr":"(IO)","loc":"d,11:8,11:9","dtypep":"(GB)",
          "lhsp": [
-          {"type":"CONST","name":"32'h1","addr":"(IO)","loc":"d,11:8,11:9","dtypep":"(HC)"}
+          {"type":"CONST","name":"32'h1","addr":"(JO)","loc":"d,11:8,11:9","dtypep":"(IC)"}
         ],
          "rhsp": [
-          {"type":"NOT","name":"","addr":"(JO)","loc":"d,11:8,11:9","dtypep":"(GB)",
+          {"type":"NOT","name":"","addr":"(KO)","loc":"d,11:8,11:9","dtypep":"(GB)",
            "lhsp": [
-            {"type":"CCAST","name":"","addr":"(KO)","loc":"d,11:8,11:9","dtypep":"(GB)","size":32,
+            {"type":"CCAST","name":"","addr":"(LO)","loc":"d,11:8,11:9","dtypep":"(GB)","size":32,
              "lhsp": [
-              {"type":"CCALL","name":"","addr":"(LO)","loc":"d,11:8,11:9","dtypep":"(GB)","funcName":"_trigger_anySet__act","funcp":"(MO)",
+              {"type":"CCALL","name":"","addr":"(MO)","loc":"d,11:8,11:9","dtypep":"(GB)","funcName":"_trigger_anySet__act","funcp":"(NO)",
                "argsp": [
-                {"type":"VARREF","name":"triggers","addr":"(NO)","loc":"d,11:8,11:9","dtypep":"(W)","access":"WR","varp":"(YN)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                {"type":"VARREF","name":"triggers","addr":"(OO)","loc":"d,11:8,11:9","dtypep":"(W)","access":"WR","varp":"(ZN)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
               ]}
             ]}
           ]}
         ]}
       ],
        "thensp": [
-        {"type":"CSTMT","name":"","addr":"(OO)","loc":"d,11:8,11:9",
+        {"type":"CSTMT","name":"","addr":"(PO)","loc":"d,11:8,11:9",
          "nodesp": [
-          {"type":"TEXT","name":"","addr":"(PO)","loc":"d,11:8,11:9","text":"VL_DBG_MSGS(\"         No '\" + "},
-          {"type":"VARREF","name":"tag","addr":"(QO)","loc":"d,11:8,11:9","dtypep":"(SB)","access":"RD","varp":"(CO)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"},
-          {"type":"TEXT","name":"","addr":"(RO)","loc":"d,11:8,11:9","text":" + \"' region triggers active\\n\");"}
+          {"type":"TEXT","name":"","addr":"(QO)","loc":"d,11:8,11:9","text":"VL_DBG_MSGS(\"         No '\" + "},
+          {"type":"VARREF","name":"tag","addr":"(RO)","loc":"d,11:8,11:9","dtypep":"(SB)","access":"RD","varp":"(DO)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"},
+          {"type":"TEXT","name":"","addr":"(SO)","loc":"d,11:8,11:9","text":" + \"' region triggers active\\n\");"}
         ]}
       ],"elsesp": []},
-      {"type":"IF","name":"","addr":"(SO)","loc":"d,11:8,11:9",
+      {"type":"IF","name":"","addr":"(TO)","loc":"d,11:8,11:9",
        "condp": [
-        {"type":"AND","name":"","addr":"(TO)","loc":"d,11:8,11:9","dtypep":"(GB)",
+        {"type":"AND","name":"","addr":"(UO)","loc":"d,11:8,11:9","dtypep":"(GB)",
          "lhsp": [
-          {"type":"CONST","name":"32'h1","addr":"(UO)","loc":"d,11:8,11:9","dtypep":"(HC)"}
+          {"type":"CONST","name":"32'h1","addr":"(VO)","loc":"d,11:8,11:9","dtypep":"(IC)"}
         ],
          "rhsp": [
-          {"type":"CCAST","name":"","addr":"(VO)","loc":"d,11:8,11:9","dtypep":"(GB)","size":32,
+          {"type":"CCAST","name":"","addr":"(WO)","loc":"d,11:8,11:9","dtypep":"(GB)","size":32,
            "lhsp": [
-            {"type":"ARRAYSEL","name":"","addr":"(WO)","loc":"d,11:8,11:9","dtypep":"(HN)",
+            {"type":"ARRAYSEL","name":"","addr":"(XO)","loc":"d,11:8,11:9","dtypep":"(IN)",
              "fromp": [
-              {"type":"VARREF","name":"triggers","addr":"(XO)","loc":"d,11:8,11:9","dtypep":"(W)","access":"RD","varp":"(YN)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+              {"type":"VARREF","name":"triggers","addr":"(YO)","loc":"d,11:8,11:9","dtypep":"(W)","access":"RD","varp":"(ZN)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
             ],
              "bitp": [
-              {"type":"CONST","name":"32'h0","addr":"(YO)","loc":"d,11:8,11:9","dtypep":"(HC)"}
+              {"type":"CONST","name":"32'h0","addr":"(ZO)","loc":"d,11:8,11:9","dtypep":"(IC)"}
             ]}
           ]}
         ]}
       ],
        "thensp": [
-        {"type":"CSTMT","name":"","addr":"(ZO)","loc":"d,11:8,11:9",
+        {"type":"CSTMT","name":"","addr":"(AP)","loc":"d,11:8,11:9",
          "nodesp": [
-          {"type":"TEXT","name":"","addr":"(AP)","loc":"d,11:8,11:9","text":"VL_DBG_MSGS(\"         '\" + "},
-          {"type":"VARREF","name":"tag","addr":"(BP)","loc":"d,11:8,11:9","dtypep":"(SB)","access":"RD","varp":"(CO)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"},
-          {"type":"TEXT","name":"","addr":"(CP)","loc":"d,11:8,11:9","text":" + \"' region trigger index 0 is active: @(posedge clk)\\n\");"}
+          {"type":"TEXT","name":"","addr":"(BP)","loc":"d,11:8,11:9","text":"VL_DBG_MSGS(\"         '\" + "},
+          {"type":"VARREF","name":"tag","addr":"(CP)","loc":"d,11:8,11:9","dtypep":"(SB)","access":"RD","varp":"(DO)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"},
+          {"type":"TEXT","name":"","addr":"(DP)","loc":"d,11:8,11:9","text":" + \"' region trigger index 0 is active: @(posedge clk)\\n\");"}
         ]}
       ],"elsesp": []}
     ]},
-    {"type":"CFUNC","name":"_trigger_anySet__act","addr":"(MO)","loc":"a,0:0,0:0","isStatic":true,"scopep":"(Z)",
+    {"type":"CFUNC","name":"_trigger_anySet__act","addr":"(NO)","loc":"a,0:0,0:0","isStatic":true,"scopep":"(Z)",
      "argsp": [
-      {"type":"VAR","name":"in","addr":"(DP)","loc":"a,0:0,0:0","dtypep":"(W)","origName":"in","verilogName":"in","direction":"CONSTREF","isFuncLocal":true,"lifetime":"NONE","varType":"BLOCKTEMP","dtypeName":"","sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
-      {"type":"ASSIGN","name":"","addr":"(EP)","loc":"a,0:0,0:0","dtypep":"(W)",
+      {"type":"VAR","name":"in","addr":"(EP)","loc":"a,0:0,0:0","dtypep":"(W)","origName":"in","verilogName":"in","direction":"CONSTREF","isFuncLocal":true,"lifetime":"NONE","varType":"BLOCKTEMP","dtypeName":"","sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
+      {"type":"ASSIGN","name":"","addr":"(FP)","loc":"a,0:0,0:0","dtypep":"(W)",
        "rhsp": [
-        {"type":"CRESET","name":"","addr":"(FP)","loc":"a,0:0,0:0","dtypep":"(W)","constructing":true}
+        {"type":"CRESET","name":"","addr":"(GP)","loc":"a,0:0,0:0","dtypep":"(W)","constructing":true}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"in","addr":"(GP)","loc":"a,0:0,0:0","dtypep":"(W)","access":"WR","varp":"(DP)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"in","addr":"(HP)","loc":"a,0:0,0:0","dtypep":"(W)","access":"WR","varp":"(EP)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []}
     ],
      "varsp": [
-      {"type":"VAR","name":"n","addr":"(HP)","loc":"a,0:0,0:0","dtypep":"(IP)","origName":"n","verilogName":"n","direction":"NONE","noReset":true,"isFuncLocal":true,"lifetime":"NONE","varType":"BLOCKTEMP","dtypeName":"IData","sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []}
+      {"type":"VAR","name":"n","addr":"(IP)","loc":"a,0:0,0:0","dtypep":"(JP)","origName":"n","verilogName":"n","direction":"NONE","noReset":true,"isFuncLocal":true,"lifetime":"NONE","varType":"BLOCKTEMP","dtypeName":"IData","sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []}
     ],
      "stmtsp": [
-      {"type":"ASSIGN","name":"","addr":"(JP)","loc":"a,0:0,0:0","dtypep":"(IP)",
+      {"type":"ASSIGN","name":"","addr":"(KP)","loc":"a,0:0,0:0","dtypep":"(JP)",
        "rhsp": [
-        {"type":"CONST","name":"32'h0","addr":"(KP)","loc":"a,0:0,0:0","dtypep":"(HC)"}
+        {"type":"CONST","name":"32'h0","addr":"(LP)","loc":"a,0:0,0:0","dtypep":"(IC)"}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"n","addr":"(LP)","loc":"a,0:0,0:0","dtypep":"(IP)","access":"WR","varp":"(HP)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"n","addr":"(MP)","loc":"a,0:0,0:0","dtypep":"(JP)","access":"WR","varp":"(IP)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []},
-      {"type":"LOOP","name":"","addr":"(MP)","loc":"d,11:8,11:9","unroll":"default",
+      {"type":"LOOP","name":"","addr":"(NP)","loc":"d,11:8,11:9","unroll":"default",
        "stmtsp": [
-        {"type":"IF","name":"","addr":"(NP)","loc":"d,11:8,11:9",
+        {"type":"IF","name":"","addr":"(OP)","loc":"d,11:8,11:9",
          "condp": [
-          {"type":"ARRAYSEL","name":"","addr":"(OP)","loc":"d,11:8,11:9","dtypep":"(HN)",
+          {"type":"ARRAYSEL","name":"","addr":"(PP)","loc":"d,11:8,11:9","dtypep":"(IN)",
            "fromp": [
-            {"type":"VARREF","name":"in","addr":"(PP)","loc":"d,11:8,11:9","dtypep":"(W)","access":"RD","varp":"(DP)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"in","addr":"(QP)","loc":"d,11:8,11:9","dtypep":"(W)","access":"RD","varp":"(EP)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ],
            "bitp": [
-            {"type":"VARREF","name":"n","addr":"(QP)","loc":"d,11:8,11:9","dtypep":"(IP)","access":"RD","varp":"(HP)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"n","addr":"(RP)","loc":"d,11:8,11:9","dtypep":"(JP)","access":"RD","varp":"(IP)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ]}
         ],
          "thensp": [
-          {"type":"CRETURN","name":"","addr":"(RP)","loc":"d,11:8,11:9",
+          {"type":"CRETURN","name":"","addr":"(SP)","loc":"d,11:8,11:9",
            "lhsp": [
-            {"type":"CONST","name":"1'h1","addr":"(SP)","loc":"d,11:8,11:9","dtypep":"(GB)"}
+            {"type":"CONST","name":"1'h1","addr":"(TP)","loc":"d,11:8,11:9","dtypep":"(GB)"}
           ]}
         ],"elsesp": []},
-        {"type":"ASSIGN","name":"","addr":"(TP)","loc":"a,0:0,0:0","dtypep":"(IP)",
+        {"type":"ASSIGN","name":"","addr":"(UP)","loc":"a,0:0,0:0","dtypep":"(JP)",
          "rhsp": [
-          {"type":"ADD","name":"","addr":"(UP)","loc":"a,0:0,0:0","dtypep":"(IP)",
+          {"type":"ADD","name":"","addr":"(VP)","loc":"a,0:0,0:0","dtypep":"(JP)",
            "lhsp": [
-            {"type":"CCAST","name":"","addr":"(VP)","loc":"a,0:0,0:0","dtypep":"(HC)","size":32,
+            {"type":"CCAST","name":"","addr":"(WP)","loc":"a,0:0,0:0","dtypep":"(IC)","size":32,
              "lhsp": [
-              {"type":"CONST","name":"32'h1","addr":"(WP)","loc":"a,0:0,0:0","dtypep":"(HC)"}
+              {"type":"CONST","name":"32'h1","addr":"(XP)","loc":"a,0:0,0:0","dtypep":"(IC)"}
             ]}
           ],
            "rhsp": [
-            {"type":"VARREF","name":"n","addr":"(XP)","loc":"a,0:0,0:0","dtypep":"(IP)","access":"RD","varp":"(HP)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"n","addr":"(YP)","loc":"a,0:0,0:0","dtypep":"(JP)","access":"RD","varp":"(IP)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ]}
         ],
          "lhsp": [
-          {"type":"VARREF","name":"n","addr":"(YP)","loc":"a,0:0,0:0","dtypep":"(IP)","access":"WR","varp":"(HP)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+          {"type":"VARREF","name":"n","addr":"(ZP)","loc":"a,0:0,0:0","dtypep":"(JP)","access":"WR","varp":"(IP)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
         ],"timingControlp": []},
-        {"type":"LOOPTEST","name":"","addr":"(ZP)","loc":"d,11:8,11:9",
+        {"type":"LOOPTEST","name":"","addr":"(AQ)","loc":"d,11:8,11:9",
          "condp": [
-          {"type":"GT","name":"","addr":"(AQ)","loc":"d,11:8,11:9","dtypep":"(GB)",
+          {"type":"GT","name":"","addr":"(BQ)","loc":"d,11:8,11:9","dtypep":"(GB)",
            "lhsp": [
-            {"type":"CONST","name":"32'h1","addr":"(BQ)","loc":"d,11:8,11:9","dtypep":"(HC)"}
+            {"type":"CONST","name":"32'h1","addr":"(CQ)","loc":"d,11:8,11:9","dtypep":"(IC)"}
           ],
            "rhsp": [
-            {"type":"VARREF","name":"n","addr":"(CQ)","loc":"d,11:8,11:9","dtypep":"(IP)","access":"RD","varp":"(HP)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"n","addr":"(DQ)","loc":"d,11:8,11:9","dtypep":"(JP)","access":"RD","varp":"(IP)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ]}
         ]}
       ],"contsp": []},
-      {"type":"CRETURN","name":"","addr":"(DQ)","loc":"d,11:8,11:9",
+      {"type":"CRETURN","name":"","addr":"(EQ)","loc":"d,11:8,11:9",
        "lhsp": [
-        {"type":"CONST","name":"1'h0","addr":"(EQ)","loc":"d,11:8,11:9","dtypep":"(GB)"}
+        {"type":"CONST","name":"1'h0","addr":"(FQ)","loc":"d,11:8,11:9","dtypep":"(GB)"}
       ]}
     ]},
-    {"type":"CFUNC","name":"_nba_sequent__TOP__0","addr":"(FQ)","loc":"d,23:17,23:20","scopep":"(Z)","argsp": [],
+    {"type":"CFUNC","name":"_nba_sequent__TOP__0","addr":"(GQ)","loc":"d,23:17,23:20","scopep":"(Z)","argsp": [],
      "varsp": [
-      {"type":"VAR","name":"__Vdly__t.cyc","addr":"(GQ)","loc":"d,23:17,23:20","dtypep":"(S)","origName":"__Vdly__t__DOT__cyc","verilogName":"__Vdly__t.cyc","direction":"NONE","isFuncLocal":true,"lifetime":"NONE","varType":"BLOCKTEMP","dtypeName":"integer","sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
-      {"type":"ASSIGN","name":"","addr":"(HQ)","loc":"d,23:17,23:20","dtypep":"(S)",
+      {"type":"VAR","name":"__Vdly__t.cyc","addr":"(HQ)","loc":"d,23:17,23:20","dtypep":"(S)","origName":"__Vdly__t__DOT__cyc","verilogName":"__Vdly__t.cyc","direction":"NONE","isFuncLocal":true,"lifetime":"NONE","varType":"BLOCKTEMP","dtypeName":"integer","sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
+      {"type":"ASSIGN","name":"","addr":"(IQ)","loc":"d,23:17,23:20","dtypep":"(S)",
        "rhsp": [
-        {"type":"CRESET","name":"","addr":"(IQ)","loc":"d,23:17,23:20","dtypep":"(S)","constructing":true}
+        {"type":"CRESET","name":"","addr":"(JQ)","loc":"d,23:17,23:20","dtypep":"(S)","constructing":true}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"__Vdly__t.cyc","addr":"(JQ)","loc":"d,23:17,23:20","dtypep":"(S)","access":"WR","varp":"(GQ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"__Vdly__t.cyc","addr":"(KQ)","loc":"d,23:17,23:20","dtypep":"(S)","access":"WR","varp":"(HQ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []},
-      {"type":"VAR","name":"__Vdly__t.e","addr":"(KQ)","loc":"d,24:9,24:10","dtypep":"(M)","origName":"__Vdly__t__DOT__e","verilogName":"__Vdly__t.e","direction":"NONE","isFuncLocal":true,"lifetime":"NONE","varType":"BLOCKTEMP","dtypeName":"my_t","sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
-      {"type":"ASSIGN","name":"","addr":"(LQ)","loc":"d,24:9,24:10","dtypep":"(M)",
+      {"type":"VAR","name":"__Vdly__t.e","addr":"(LQ)","loc":"d,24:9,24:10","dtypep":"(M)","origName":"__Vdly__t__DOT__e","verilogName":"__Vdly__t.e","direction":"NONE","isFuncLocal":true,"lifetime":"NONE","varType":"BLOCKTEMP","dtypeName":"my_t","sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
+      {"type":"ASSIGN","name":"","addr":"(MQ)","loc":"d,24:9,24:10","dtypep":"(M)",
        "rhsp": [
-        {"type":"CRESET","name":"","addr":"(MQ)","loc":"d,24:9,24:10","dtypep":"(M)","constructing":true}
+        {"type":"CRESET","name":"","addr":"(NQ)","loc":"d,24:9,24:10","dtypep":"(M)","constructing":true}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"__Vdly__t.e","addr":"(NQ)","loc":"d,24:9,24:10","dtypep":"(M)","access":"WR","varp":"(KQ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"__Vdly__t.e","addr":"(OQ)","loc":"d,24:9,24:10","dtypep":"(M)","access":"WR","varp":"(LQ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []},
-      {"type":"VAR","name":"__Vtemp_1","addr":"(OQ)","loc":"d,70:123,70:124","dtypep":"(SB)","origName":"__Vtemp_1","verilogName":"__Vtemp_1","direction":"NONE","lifetime":"NONE","varType":"STMTTEMP","dtypeName":"string","sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
-      {"type":"VAR","name":"__Vtemp_2","addr":"(PQ)","loc":"d,80:123,80:124","dtypep":"(SB)","origName":"__Vtemp_2","verilogName":"__Vtemp_2","direction":"NONE","lifetime":"NONE","varType":"STMTTEMP","dtypeName":"string","sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
-      {"type":"VAR","name":"__Vtemp_3","addr":"(QQ)","loc":"d,90:123,90:124","dtypep":"(SB)","origName":"__Vtemp_3","verilogName":"__Vtemp_3","direction":"NONE","lifetime":"NONE","varType":"STMTTEMP","dtypeName":"string","sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []}
+      {"type":"VAR","name":"__Vtemp_1","addr":"(PQ)","loc":"d,70:123,70:124","dtypep":"(SB)","origName":"__Vtemp_1","verilogName":"__Vtemp_1","direction":"NONE","lifetime":"NONE","varType":"STMTTEMP","dtypeName":"string","sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
+      {"type":"VAR","name":"__Vtemp_2","addr":"(QQ)","loc":"d,80:123,80:124","dtypep":"(SB)","origName":"__Vtemp_2","verilogName":"__Vtemp_2","direction":"NONE","lifetime":"NONE","varType":"STMTTEMP","dtypeName":"string","sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
+      {"type":"VAR","name":"__Vtemp_3","addr":"(RQ)","loc":"d,90:123,90:124","dtypep":"(SB)","origName":"__Vtemp_3","verilogName":"__Vtemp_3","direction":"NONE","lifetime":"NONE","varType":"STMTTEMP","dtypeName":"string","sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []}
     ],
      "stmtsp": [
-      {"type":"ASSIGN","name":"","addr":"(RQ)","loc":"d,23:17,23:20","dtypep":"(S)",
+      {"type":"ASSIGN","name":"","addr":"(SQ)","loc":"d,23:17,23:20","dtypep":"(S)",
        "rhsp": [
-        {"type":"VARREF","name":"t.cyc","addr":"(SQ)","loc":"d,23:17,23:20","dtypep":"(S)","access":"RD","varp":"(R)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"t.cyc","addr":"(TQ)","loc":"d,23:17,23:20","dtypep":"(S)","access":"RD","varp":"(R)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"__Vdly__t.cyc","addr":"(TQ)","loc":"d,23:17,23:20","dtypep":"(S)","access":"WR","varp":"(GQ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"__Vdly__t.cyc","addr":"(UQ)","loc":"d,23:17,23:20","dtypep":"(S)","access":"WR","varp":"(HQ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []},
-      {"type":"ASSIGN","name":"","addr":"(UQ)","loc":"d,24:9,24:10","dtypep":"(UB)",
+      {"type":"ASSIGN","name":"","addr":"(VQ)","loc":"d,24:9,24:10","dtypep":"(UB)",
        "rhsp": [
-        {"type":"VARREF","name":"t.e","addr":"(VQ)","loc":"d,24:9,24:10","dtypep":"(UB)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"t.e","addr":"(WQ)","loc":"d,24:9,24:10","dtypep":"(UB)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"__Vdly__t.e","addr":"(WQ)","loc":"d,24:9,24:10","dtypep":"(UB)","access":"WR","varp":"(KQ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"__Vdly__t.e","addr":"(XQ)","loc":"d,24:9,24:10","dtypep":"(UB)","access":"WR","varp":"(LQ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []},
-      {"type":"ASSIGNDLY","name":"","addr":"(XQ)","loc":"d,64:11,64:13","dtypep":"(S)",
+      {"type":"ASSIGNDLY","name":"","addr":"(YQ)","loc":"d,64:11,64:13","dtypep":"(S)",
        "rhsp": [
-        {"type":"ADD","name":"","addr":"(YQ)","loc":"d,64:18,64:19","dtypep":"(S)",
+        {"type":"ADD","name":"","addr":"(ZQ)","loc":"d,64:18,64:19","dtypep":"(S)",
          "lhsp": [
-          {"type":"CCAST","name":"","addr":"(ZQ)","loc":"d,64:20,64:21","dtypep":"(HC)","size":32,
+          {"type":"CCAST","name":"","addr":"(AR)","loc":"d,64:20,64:21","dtypep":"(IC)","size":32,
            "lhsp": [
-            {"type":"CONST","name":"32'sh1","addr":"(AR)","loc":"d,64:20,64:21","dtypep":"(LB)"}
+            {"type":"CONST","name":"32'sh1","addr":"(BR)","loc":"d,64:20,64:21","dtypep":"(LB)"}
           ]}
         ],
          "rhsp": [
-          {"type":"VARREF","name":"t.cyc","addr":"(BR)","loc":"d,64:14,64:17","dtypep":"(S)","access":"RD","varp":"(R)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+          {"type":"VARREF","name":"t.cyc","addr":"(CR)","loc":"d,64:14,64:17","dtypep":"(S)","access":"RD","varp":"(R)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
         ]}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"__Vdly__t.cyc","addr":"(CR)","loc":"d,64:7,64:10","dtypep":"(S)","access":"WR","varp":"(GQ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"__Vdly__t.cyc","addr":"(DR)","loc":"d,64:7,64:10","dtypep":"(S)","access":"WR","varp":"(HQ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []},
-      {"type":"IF","name":"","addr":"(DR)","loc":"d,65:7,65:9",
+      {"type":"IF","name":"","addr":"(ER)","loc":"d,65:7,65:9",
        "condp": [
-        {"type":"EQ","name":"","addr":"(ER)","loc":"d,65:14,65:16","dtypep":"(GB)",
+        {"type":"EQ","name":"","addr":"(FR)","loc":"d,65:14,65:16","dtypep":"(GB)",
          "lhsp": [
-          {"type":"CONST","name":"32'sh0","addr":"(FR)","loc":"d,65:16,65:17","dtypep":"(LB)"}
+          {"type":"CONST","name":"32'sh0","addr":"(GR)","loc":"d,65:16,65:17","dtypep":"(LB)"}
         ],
          "rhsp": [
-          {"type":"VARREF","name":"t.cyc","addr":"(GR)","loc":"d,65:11,65:14","dtypep":"(S)","access":"RD","varp":"(R)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+          {"type":"VARREF","name":"t.cyc","addr":"(HR)","loc":"d,65:11,65:14","dtypep":"(S)","access":"RD","varp":"(R)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
         ]}
       ],
        "thensp": [
-        {"type":"ASSIGNDLY","name":"","addr":"(HR)","loc":"d,67:12,67:14","dtypep":"(UB)",
+        {"type":"ASSIGNDLY","name":"","addr":"(IR)","loc":"d,67:12,67:14","dtypep":"(UB)",
          "rhsp": [
-          {"type":"CONST","name":"4'h1","addr":"(IR)","loc":"d,67:15,67:18","dtypep":"(UB)"}
+          {"type":"CONST","name":"4'h1","addr":"(JR)","loc":"d,67:15,67:18","dtypep":"(UB)"}
         ],
          "lhsp": [
-          {"type":"VARREF","name":"__Vdly__t.e","addr":"(JR)","loc":"d,67:10,67:11","dtypep":"(UB)","access":"WR","varp":"(KQ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+          {"type":"VARREF","name":"__Vdly__t.e","addr":"(KR)","loc":"d,67:10,67:11","dtypep":"(UB)","access":"WR","varp":"(LQ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
         ],"timingControlp": []}
       ],
        "elsesp": [
-        {"type":"IF","name":"","addr":"(KR)","loc":"d,69:12,69:14",
+        {"type":"IF","name":"","addr":"(LR)","loc":"d,69:12,69:14",
          "condp": [
-          {"type":"EQ","name":"","addr":"(LR)","loc":"d,69:19,69:21","dtypep":"(GB)",
+          {"type":"EQ","name":"","addr":"(MR)","loc":"d,69:19,69:21","dtypep":"(GB)",
            "lhsp": [
-            {"type":"CONST","name":"32'sh1","addr":"(MR)","loc":"d,69:21,69:22","dtypep":"(LB)"}
+            {"type":"CONST","name":"32'sh1","addr":"(NR)","loc":"d,69:21,69:22","dtypep":"(LB)"}
           ],
            "rhsp": [
-            {"type":"VARREF","name":"t.cyc","addr":"(NR)","loc":"d,69:16,69:19","dtypep":"(S)","access":"RD","varp":"(R)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"t.cyc","addr":"(OR)","loc":"d,69:16,69:19","dtypep":"(S)","access":"RD","varp":"(R)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ]}
         ],
          "thensp": [
-          {"type":"IF","name":"","addr":"(OR)","loc":"d,70:13,70:15",
+          {"type":"IF","name":"","addr":"(PR)","loc":"d,70:13,70:15",
            "condp": [
-            {"type":"NEQN","name":"","addr":"(PR)","loc":"d,70:26,70:28","dtypep":"(GB)",
+            {"type":"NEQN","name":"","addr":"(QR)","loc":"d,70:26,70:28","dtypep":"(GB)",
              "lhsp": [
-              {"type":"CONST","name":"\\\"E01\\\"","addr":"(QR)","loc":"d,70:30,70:35","dtypep":"(SB)"}
+              {"type":"CONST","name":"\\\"E01\\\"","addr":"(RR)","loc":"d,70:30,70:35","dtypep":"(SB)"}
             ],
              "rhsp": [
-              {"type":"ARRAYSEL","name":"","addr":"(RR)","loc":"d,70:18,70:19","dtypep":"(SB)",
+              {"type":"ARRAYSEL","name":"","addr":"(SR)","loc":"d,70:18,70:19","dtypep":"(SB)",
                "fromp": [
-                {"type":"VARREF","name":"__Venumtab_enum_name1","addr":"(SR)","loc":"d,17:12,17:16","dtypep":"(IM)","access":"RD","varp":"(JM)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                {"type":"VARREF","name":"__Venumtab_enum_name1","addr":"(TR)","loc":"d,17:12,17:16","dtypep":"(JM)","access":"RD","varp":"(KM)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
               ],
                "bitp": [
-                {"type":"AND","name":"","addr":"(TR)","loc":"d,70:18,70:19","dtypep":"(FC)",
+                {"type":"AND","name":"","addr":"(UR)","loc":"d,70:18,70:19","dtypep":"(GC)",
                  "lhsp": [
-                  {"type":"CONST","name":"32'h7","addr":"(UR)","loc":"d,70:18,70:19","dtypep":"(HC)"}
+                  {"type":"CONST","name":"32'h7","addr":"(VR)","loc":"d,70:18,70:19","dtypep":"(IC)"}
                 ],
                  "rhsp": [
-                  {"type":"CCAST","name":"","addr":"(VR)","loc":"d,70:18,70:19","dtypep":"(FC)","size":32,
+                  {"type":"CCAST","name":"","addr":"(WR)","loc":"d,70:18,70:19","dtypep":"(GC)","size":32,
                    "lhsp": [
-                    {"type":"VARREF","name":"t.e","addr":"(WR)","loc":"d,70:18,70:19","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"t.e","addr":"(XR)","loc":"d,70:18,70:19","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ]}
                 ]}
               ]}
             ]}
           ],
            "thensp": [
-            {"type":"ASSIGN","name":"","addr":"(XR)","loc":"d,70:123,70:124","dtypep":"(SB)",
+            {"type":"ASSIGN","name":"","addr":"(YR)","loc":"d,70:123,70:124","dtypep":"(SB)",
              "rhsp": [
-              {"type":"ARRAYSEL","name":"","addr":"(YR)","loc":"d,70:123,70:124","dtypep":"(SB)",
+              {"type":"ARRAYSEL","name":"","addr":"(ZR)","loc":"d,70:123,70:124","dtypep":"(SB)",
                "fromp": [
-                {"type":"VARREF","name":"__Venumtab_enum_name1","addr":"(ZR)","loc":"d,17:12,17:16","dtypep":"(IM)","access":"RD","varp":"(JM)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                {"type":"VARREF","name":"__Venumtab_enum_name1","addr":"(AS)","loc":"d,17:12,17:16","dtypep":"(JM)","access":"RD","varp":"(KM)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
               ],
                "bitp": [
-                {"type":"AND","name":"","addr":"(AS)","loc":"d,70:123,70:124","dtypep":"(FC)",
+                {"type":"AND","name":"","addr":"(BS)","loc":"d,70:123,70:124","dtypep":"(GC)",
                  "lhsp": [
-                  {"type":"CONST","name":"32'h7","addr":"(BS)","loc":"d,70:123,70:124","dtypep":"(HC)"}
+                  {"type":"CONST","name":"32'h7","addr":"(CS)","loc":"d,70:123,70:124","dtypep":"(IC)"}
                 ],
                  "rhsp": [
-                  {"type":"CCAST","name":"","addr":"(CS)","loc":"d,70:123,70:124","dtypep":"(FC)","size":32,
+                  {"type":"CCAST","name":"","addr":"(DS)","loc":"d,70:123,70:124","dtypep":"(GC)","size":32,
                    "lhsp": [
-                    {"type":"VARREF","name":"t.e","addr":"(DS)","loc":"d,70:123,70:124","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"t.e","addr":"(ES)","loc":"d,70:123,70:124","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ]}
                 ]}
               ]}
             ],
              "lhsp": [
-              {"type":"VARREF","name":"__Vtemp_1","addr":"(ES)","loc":"d,70:123,70:124","dtypep":"(SB)","access":"WR","varp":"(OQ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+              {"type":"VARREF","name":"__Vtemp_1","addr":"(FS)","loc":"d,70:123,70:124","dtypep":"(SB)","access":"WR","varp":"(PQ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
             ],"timingControlp": []},
-            {"type":"DISPLAY","name":"","addr":"(FS)","loc":"d,70:44,70:50",
+            {"type":"DISPLAY","name":"","addr":"(GS)","loc":"d,70:44,70:50",
              "fmtp": [
-              {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:70:  got='%@' exp='E01'\\n","addr":"(GS)","loc":"d,70:44,70:50","dtypep":"(SB)",
+              {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:70:  got='%@' exp='E01'\\n","addr":"(HS)","loc":"d,70:44,70:50","dtypep":"(SB)",
                "exprsp": [
-                {"type":"VARREF","name":"__Vtemp_1","addr":"(HS)","loc":"d,70:123,70:124","dtypep":"(SB)","access":"RD","varp":"(OQ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                {"type":"VARREF","name":"__Vtemp_1","addr":"(IS)","loc":"d,70:123,70:124","dtypep":"(SB)","access":"RD","varp":"(PQ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
               ],"scopeNamep": []}
             ],"filep": []},
-            {"type":"STOP","name":"","addr":"(IS)","loc":"d,70:142,70:147"}
+            {"type":"STOP","name":"","addr":"(JS)","loc":"d,70:142,70:147"}
           ],"elsesp": []},
-          {"type":"IF","name":"","addr":"(JS)","loc":"d,71:13,71:15",
+          {"type":"IF","name":"","addr":"(KS)","loc":"d,71:13,71:15",
            "condp": [
-            {"type":"NEQ","name":"","addr":"(KS)","loc":"d,71:26,71:29","dtypep":"(GB)",
+            {"type":"NEQ","name":"","addr":"(LS)","loc":"d,71:26,71:29","dtypep":"(GB)",
              "lhsp": [
-              {"type":"CONST","name":"4'h3","addr":"(LS)","loc":"d,71:31,71:34","dtypep":"(UB)"}
+              {"type":"CONST","name":"4'h3","addr":"(MS)","loc":"d,71:31,71:34","dtypep":"(UB)"}
             ],
              "rhsp": [
-              {"type":"ARRAYSEL","name":"","addr":"(MS)","loc":"d,71:18,71:19","dtypep":"(UB)",
+              {"type":"ARRAYSEL","name":"","addr":"(NS)","loc":"d,71:18,71:19","dtypep":"(BC)",
                "fromp": [
-                {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(NS)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(OS)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
               ],
                "bitp": [
-                {"type":"AND","name":"","addr":"(OS)","loc":"d,71:18,71:19","dtypep":"(FC)",
+                {"type":"AND","name":"","addr":"(PS)","loc":"d,71:18,71:19","dtypep":"(GC)",
                  "lhsp": [
-                  {"type":"CONST","name":"32'h7","addr":"(PS)","loc":"d,71:18,71:19","dtypep":"(HC)"}
+                  {"type":"CONST","name":"32'h7","addr":"(QS)","loc":"d,71:18,71:19","dtypep":"(IC)"}
                 ],
                  "rhsp": [
-                  {"type":"CCAST","name":"","addr":"(QS)","loc":"d,71:18,71:19","dtypep":"(FC)","size":32,
+                  {"type":"CCAST","name":"","addr":"(RS)","loc":"d,71:18,71:19","dtypep":"(GC)","size":32,
                    "lhsp": [
-                    {"type":"VARREF","name":"t.e","addr":"(RS)","loc":"d,71:18,71:19","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"t.e","addr":"(SS)","loc":"d,71:18,71:19","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ]}
                 ]}
               ]}
             ]}
           ],
            "thensp": [
-            {"type":"DISPLAY","name":"","addr":"(SS)","loc":"d,71:43,71:49",
+            {"type":"DISPLAY","name":"","addr":"(TS)","loc":"d,71:43,71:49",
              "fmtp": [
-              {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:71:  got='h%x exp='h3\\n","addr":"(TS)","loc":"d,71:43,71:49","dtypep":"(SB)",
+              {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:71:  got='h%x exp='h3\\n","addr":"(US)","loc":"d,71:43,71:49","dtypep":"(SB)",
                "exprsp": [
-                {"type":"ARRAYSEL","name":"","addr":"(US)","loc":"d,71:122,71:123","dtypep":"(UB)",
+                {"type":"ARRAYSEL","name":"","addr":"(VS)","loc":"d,71:122,71:123","dtypep":"(BC)",
                  "fromp": [
-                  {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(VS)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(WS)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                 ],
                  "bitp": [
-                  {"type":"AND","name":"","addr":"(WS)","loc":"d,71:122,71:123","dtypep":"(FC)",
+                  {"type":"AND","name":"","addr":"(XS)","loc":"d,71:122,71:123","dtypep":"(GC)",
                    "lhsp": [
-                    {"type":"CONST","name":"32'h7","addr":"(XS)","loc":"d,71:122,71:123","dtypep":"(HC)"}
+                    {"type":"CONST","name":"32'h7","addr":"(YS)","loc":"d,71:122,71:123","dtypep":"(IC)"}
                   ],
                    "rhsp": [
-                    {"type":"CCAST","name":"","addr":"(YS)","loc":"d,71:122,71:123","dtypep":"(FC)","size":32,
+                    {"type":"CCAST","name":"","addr":"(ZS)","loc":"d,71:122,71:123","dtypep":"(GC)","size":32,
                      "lhsp": [
-                      {"type":"VARREF","name":"t.e","addr":"(ZS)","loc":"d,71:122,71:123","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"t.e","addr":"(AT)","loc":"d,71:122,71:123","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ]}
                   ]}
                 ]}
               ],"scopeNamep": []}
             ],"filep": []},
-            {"type":"STOP","name":"","addr":"(AT)","loc":"d,71:139,71:144"}
+            {"type":"STOP","name":"","addr":"(BT)","loc":"d,71:139,71:144"}
           ],"elsesp": []},
-          {"type":"IF","name":"","addr":"(BT)","loc":"d,72:13,72:15",
+          {"type":"IF","name":"","addr":"(CT)","loc":"d,72:13,72:15",
            "condp": [
-            {"type":"NEQ","name":"","addr":"(CT)","loc":"d,72:29,72:32","dtypep":"(GB)",
+            {"type":"NEQ","name":"","addr":"(DT)","loc":"d,72:29,72:32","dtypep":"(GB)",
              "lhsp": [
-              {"type":"CONST","name":"4'h3","addr":"(DT)","loc":"d,72:34,72:37","dtypep":"(UB)"}
+              {"type":"CONST","name":"4'h3","addr":"(ET)","loc":"d,72:34,72:37","dtypep":"(UB)"}
             ],
              "rhsp": [
-              {"type":"ARRAYSEL","name":"","addr":"(ET)","loc":"d,72:18,72:19","dtypep":"(UB)",
+              {"type":"ARRAYSEL","name":"","addr":"(FT)","loc":"d,72:18,72:19","dtypep":"(BC)",
                "fromp": [
-                {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(FT)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(GT)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
               ],
                "bitp": [
-                {"type":"AND","name":"","addr":"(GT)","loc":"d,72:18,72:19","dtypep":"(FC)",
+                {"type":"AND","name":"","addr":"(HT)","loc":"d,72:18,72:19","dtypep":"(GC)",
                  "lhsp": [
-                  {"type":"CONST","name":"32'h7","addr":"(HT)","loc":"d,72:18,72:19","dtypep":"(HC)"}
+                  {"type":"CONST","name":"32'h7","addr":"(IT)","loc":"d,72:18,72:19","dtypep":"(IC)"}
                 ],
                  "rhsp": [
-                  {"type":"CCAST","name":"","addr":"(IT)","loc":"d,72:18,72:19","dtypep":"(FC)","size":32,
+                  {"type":"CCAST","name":"","addr":"(JT)","loc":"d,72:18,72:19","dtypep":"(GC)","size":32,
                    "lhsp": [
-                    {"type":"VARREF","name":"t.e","addr":"(JT)","loc":"d,72:18,72:19","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"t.e","addr":"(KT)","loc":"d,72:18,72:19","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ]}
                 ]}
               ]}
             ]}
           ],
            "thensp": [
-            {"type":"DISPLAY","name":"","addr":"(KT)","loc":"d,72:46,72:52",
+            {"type":"DISPLAY","name":"","addr":"(LT)","loc":"d,72:46,72:52",
              "fmtp": [
-              {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:72:  got='h%x exp='h3\\n","addr":"(LT)","loc":"d,72:46,72:52","dtypep":"(SB)",
+              {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:72:  got='h%x exp='h3\\n","addr":"(MT)","loc":"d,72:46,72:52","dtypep":"(SB)",
                "exprsp": [
-                {"type":"ARRAYSEL","name":"","addr":"(MT)","loc":"d,72:125,72:126","dtypep":"(UB)",
+                {"type":"ARRAYSEL","name":"","addr":"(NT)","loc":"d,72:125,72:126","dtypep":"(BC)",
                  "fromp": [
-                  {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(NT)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(OT)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                 ],
                  "bitp": [
-                  {"type":"AND","name":"","addr":"(OT)","loc":"d,72:125,72:126","dtypep":"(FC)",
+                  {"type":"AND","name":"","addr":"(PT)","loc":"d,72:125,72:126","dtypep":"(GC)",
                    "lhsp": [
-                    {"type":"CONST","name":"32'h7","addr":"(PT)","loc":"d,72:125,72:126","dtypep":"(HC)"}
+                    {"type":"CONST","name":"32'h7","addr":"(QT)","loc":"d,72:125,72:126","dtypep":"(IC)"}
                   ],
                    "rhsp": [
-                    {"type":"CCAST","name":"","addr":"(QT)","loc":"d,72:125,72:126","dtypep":"(FC)","size":32,
+                    {"type":"CCAST","name":"","addr":"(RT)","loc":"d,72:125,72:126","dtypep":"(GC)","size":32,
                      "lhsp": [
-                      {"type":"VARREF","name":"t.e","addr":"(RT)","loc":"d,72:125,72:126","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"t.e","addr":"(ST)","loc":"d,72:125,72:126","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ]}
                   ]}
                 ]}
               ],"scopeNamep": []}
             ],"filep": []},
-            {"type":"STOP","name":"","addr":"(ST)","loc":"d,72:145,72:150"}
+            {"type":"STOP","name":"","addr":"(TT)","loc":"d,72:145,72:150"}
           ],"elsesp": []},
-          {"type":"IF","name":"","addr":"(TT)","loc":"d,73:13,73:15",
+          {"type":"IF","name":"","addr":"(UT)","loc":"d,73:13,73:15",
            "condp": [
-            {"type":"NEQ","name":"","addr":"(UT)","loc":"d,73:29,73:32","dtypep":"(GB)",
+            {"type":"NEQ","name":"","addr":"(VT)","loc":"d,73:29,73:32","dtypep":"(GB)",
              "lhsp": [
-              {"type":"CONST","name":"4'h4","addr":"(VT)","loc":"d,73:34,73:37","dtypep":"(UB)"}
+              {"type":"CONST","name":"4'h4","addr":"(WT)","loc":"d,73:34,73:37","dtypep":"(UB)"}
             ],
              "rhsp": [
-              {"type":"ARRAYSEL","name":"","addr":"(WT)","loc":"d,73:18,73:19","dtypep":"(UB)",
+              {"type":"ARRAYSEL","name":"","addr":"(XT)","loc":"d,73:18,73:19","dtypep":"(BC)",
                "fromp": [
-                {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(XT)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(YT)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
               ],
                "bitp": [
-                {"type":"AND","name":"","addr":"(YT)","loc":"d,73:18,73:19","dtypep":"(FC)",
+                {"type":"AND","name":"","addr":"(ZT)","loc":"d,73:18,73:19","dtypep":"(GC)",
                  "lhsp": [
-                  {"type":"CONST","name":"32'h7","addr":"(ZT)","loc":"d,73:18,73:19","dtypep":"(HC)"}
+                  {"type":"CONST","name":"32'h7","addr":"(AU)","loc":"d,73:18,73:19","dtypep":"(IC)"}
                 ],
                  "rhsp": [
-                  {"type":"ARRAYSEL","name":"","addr":"(AU)","loc":"d,73:18,73:19","dtypep":"(FC)",
+                  {"type":"ARRAYSEL","name":"","addr":"(BU)","loc":"d,73:18,73:19","dtypep":"(GC)",
                    "fromp": [
-                    {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(BU)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(CU)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ],
                    "bitp": [
-                    {"type":"AND","name":"","addr":"(CU)","loc":"d,73:18,73:19","dtypep":"(FC)",
+                    {"type":"AND","name":"","addr":"(DU)","loc":"d,73:18,73:19","dtypep":"(GC)",
                      "lhsp": [
-                      {"type":"CONST","name":"32'h7","addr":"(DU)","loc":"d,73:18,73:19","dtypep":"(HC)"}
+                      {"type":"CONST","name":"32'h7","addr":"(EU)","loc":"d,73:18,73:19","dtypep":"(IC)"}
                     ],
                      "rhsp": [
-                      {"type":"CCAST","name":"","addr":"(EU)","loc":"d,73:18,73:19","dtypep":"(FC)","size":32,
+                      {"type":"CCAST","name":"","addr":"(FU)","loc":"d,73:18,73:19","dtypep":"(GC)","size":32,
                        "lhsp": [
-                        {"type":"VARREF","name":"t.e","addr":"(FU)","loc":"d,73:18,73:19","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                        {"type":"VARREF","name":"t.e","addr":"(GU)","loc":"d,73:18,73:19","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                       ]}
                     ]}
                   ]}
@@ -1336,33 +1336,33 @@
             ]}
           ],
            "thensp": [
-            {"type":"DISPLAY","name":"","addr":"(GU)","loc":"d,73:46,73:52",
+            {"type":"DISPLAY","name":"","addr":"(HU)","loc":"d,73:46,73:52",
              "fmtp": [
-              {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:73:  got='h%x exp='h4\\n","addr":"(HU)","loc":"d,73:46,73:52","dtypep":"(SB)",
+              {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:73:  got='h%x exp='h4\\n","addr":"(IU)","loc":"d,73:46,73:52","dtypep":"(SB)",
                "exprsp": [
-                {"type":"ARRAYSEL","name":"","addr":"(IU)","loc":"d,73:125,73:126","dtypep":"(UB)",
+                {"type":"ARRAYSEL","name":"","addr":"(JU)","loc":"d,73:125,73:126","dtypep":"(BC)",
                  "fromp": [
-                  {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(JU)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(KU)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                 ],
                  "bitp": [
-                  {"type":"AND","name":"","addr":"(KU)","loc":"d,73:125,73:126","dtypep":"(FC)",
+                  {"type":"AND","name":"","addr":"(LU)","loc":"d,73:125,73:126","dtypep":"(GC)",
                    "lhsp": [
-                    {"type":"CONST","name":"32'h7","addr":"(LU)","loc":"d,73:125,73:126","dtypep":"(HC)"}
+                    {"type":"CONST","name":"32'h7","addr":"(MU)","loc":"d,73:125,73:126","dtypep":"(IC)"}
                   ],
                    "rhsp": [
-                    {"type":"ARRAYSEL","name":"","addr":"(MU)","loc":"d,73:125,73:126","dtypep":"(FC)",
+                    {"type":"ARRAYSEL","name":"","addr":"(NU)","loc":"d,73:125,73:126","dtypep":"(GC)",
                      "fromp": [
-                      {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(NU)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(OU)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ],
                      "bitp": [
-                      {"type":"AND","name":"","addr":"(OU)","loc":"d,73:125,73:126","dtypep":"(FC)",
+                      {"type":"AND","name":"","addr":"(PU)","loc":"d,73:125,73:126","dtypep":"(GC)",
                        "lhsp": [
-                        {"type":"CONST","name":"32'h7","addr":"(PU)","loc":"d,73:125,73:126","dtypep":"(HC)"}
+                        {"type":"CONST","name":"32'h7","addr":"(QU)","loc":"d,73:125,73:126","dtypep":"(IC)"}
                       ],
                        "rhsp": [
-                        {"type":"CCAST","name":"","addr":"(QU)","loc":"d,73:125,73:126","dtypep":"(FC)","size":32,
+                        {"type":"CCAST","name":"","addr":"(RU)","loc":"d,73:125,73:126","dtypep":"(GC)","size":32,
                          "lhsp": [
-                          {"type":"VARREF","name":"t.e","addr":"(RU)","loc":"d,73:125,73:126","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                          {"type":"VARREF","name":"t.e","addr":"(SU)","loc":"d,73:125,73:126","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                         ]}
                       ]}
                     ]}
@@ -1370,138 +1370,138 @@
                 ]}
               ],"scopeNamep": []}
             ],"filep": []},
-            {"type":"STOP","name":"","addr":"(SU)","loc":"d,73:145,73:150"}
+            {"type":"STOP","name":"","addr":"(TU)","loc":"d,73:145,73:150"}
           ],"elsesp": []},
-          {"type":"IF","name":"","addr":"(TU)","loc":"d,74:13,74:15",
+          {"type":"IF","name":"","addr":"(UU)","loc":"d,74:13,74:15",
            "condp": [
-            {"type":"NEQ","name":"","addr":"(UU)","loc":"d,74:26,74:29","dtypep":"(GB)",
+            {"type":"NEQ","name":"","addr":"(VU)","loc":"d,74:26,74:29","dtypep":"(GB)",
              "lhsp": [
-              {"type":"CONST","name":"4'h4","addr":"(VU)","loc":"d,74:31,74:34","dtypep":"(UB)"}
+              {"type":"CONST","name":"4'h4","addr":"(WU)","loc":"d,74:31,74:34","dtypep":"(UB)"}
             ],
              "rhsp": [
-              {"type":"ARRAYSEL","name":"","addr":"(WU)","loc":"d,74:18,74:19","dtypep":"(UB)",
+              {"type":"ARRAYSEL","name":"","addr":"(XU)","loc":"d,74:18,74:19","dtypep":"(BC)",
                "fromp": [
-                {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(XU)","loc":"d,17:12,17:16","dtypep":"(WI)","access":"RD","varp":"(XI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(YU)","loc":"d,17:12,17:16","dtypep":"(XI)","access":"RD","varp":"(YI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
               ],
                "bitp": [
-                {"type":"AND","name":"","addr":"(YU)","loc":"d,74:18,74:19","dtypep":"(FC)",
+                {"type":"AND","name":"","addr":"(ZU)","loc":"d,74:18,74:19","dtypep":"(GC)",
                  "lhsp": [
-                  {"type":"CONST","name":"32'h7","addr":"(ZU)","loc":"d,74:18,74:19","dtypep":"(HC)"}
+                  {"type":"CONST","name":"32'h7","addr":"(AV)","loc":"d,74:18,74:19","dtypep":"(IC)"}
                 ],
                  "rhsp": [
-                  {"type":"CCAST","name":"","addr":"(AV)","loc":"d,74:18,74:19","dtypep":"(FC)","size":32,
+                  {"type":"CCAST","name":"","addr":"(BV)","loc":"d,74:18,74:19","dtypep":"(GC)","size":32,
                    "lhsp": [
-                    {"type":"VARREF","name":"t.e","addr":"(BV)","loc":"d,74:18,74:19","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"t.e","addr":"(CV)","loc":"d,74:18,74:19","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ]}
                 ]}
               ]}
             ]}
           ],
            "thensp": [
-            {"type":"DISPLAY","name":"","addr":"(CV)","loc":"d,74:43,74:49",
+            {"type":"DISPLAY","name":"","addr":"(DV)","loc":"d,74:43,74:49",
              "fmtp": [
-              {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:74:  got='h%x exp='h4\\n","addr":"(DV)","loc":"d,74:43,74:49","dtypep":"(SB)",
+              {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:74:  got='h%x exp='h4\\n","addr":"(EV)","loc":"d,74:43,74:49","dtypep":"(SB)",
                "exprsp": [
-                {"type":"ARRAYSEL","name":"","addr":"(EV)","loc":"d,74:122,74:123","dtypep":"(UB)",
+                {"type":"ARRAYSEL","name":"","addr":"(FV)","loc":"d,74:122,74:123","dtypep":"(BC)",
                  "fromp": [
-                  {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(FV)","loc":"d,17:12,17:16","dtypep":"(WI)","access":"RD","varp":"(XI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(GV)","loc":"d,17:12,17:16","dtypep":"(XI)","access":"RD","varp":"(YI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                 ],
                  "bitp": [
-                  {"type":"AND","name":"","addr":"(GV)","loc":"d,74:122,74:123","dtypep":"(FC)",
+                  {"type":"AND","name":"","addr":"(HV)","loc":"d,74:122,74:123","dtypep":"(GC)",
                    "lhsp": [
-                    {"type":"CONST","name":"32'h7","addr":"(HV)","loc":"d,74:122,74:123","dtypep":"(HC)"}
+                    {"type":"CONST","name":"32'h7","addr":"(IV)","loc":"d,74:122,74:123","dtypep":"(IC)"}
                   ],
                    "rhsp": [
-                    {"type":"CCAST","name":"","addr":"(IV)","loc":"d,74:122,74:123","dtypep":"(FC)","size":32,
+                    {"type":"CCAST","name":"","addr":"(JV)","loc":"d,74:122,74:123","dtypep":"(GC)","size":32,
                      "lhsp": [
-                      {"type":"VARREF","name":"t.e","addr":"(JV)","loc":"d,74:122,74:123","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"t.e","addr":"(KV)","loc":"d,74:122,74:123","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ]}
                   ]}
                 ]}
               ],"scopeNamep": []}
             ],"filep": []},
-            {"type":"STOP","name":"","addr":"(KV)","loc":"d,74:139,74:144"}
+            {"type":"STOP","name":"","addr":"(LV)","loc":"d,74:139,74:144"}
           ],"elsesp": []},
-          {"type":"IF","name":"","addr":"(LV)","loc":"d,75:13,75:15",
+          {"type":"IF","name":"","addr":"(MV)","loc":"d,75:13,75:15",
            "condp": [
-            {"type":"NEQ","name":"","addr":"(MV)","loc":"d,75:29,75:32","dtypep":"(GB)",
+            {"type":"NEQ","name":"","addr":"(NV)","loc":"d,75:29,75:32","dtypep":"(GB)",
              "lhsp": [
-              {"type":"CONST","name":"4'h4","addr":"(NV)","loc":"d,75:34,75:37","dtypep":"(UB)"}
+              {"type":"CONST","name":"4'h4","addr":"(OV)","loc":"d,75:34,75:37","dtypep":"(UB)"}
             ],
              "rhsp": [
-              {"type":"ARRAYSEL","name":"","addr":"(OV)","loc":"d,75:18,75:19","dtypep":"(UB)",
+              {"type":"ARRAYSEL","name":"","addr":"(PV)","loc":"d,75:18,75:19","dtypep":"(BC)",
                "fromp": [
-                {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(PV)","loc":"d,17:12,17:16","dtypep":"(WI)","access":"RD","varp":"(XI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(QV)","loc":"d,17:12,17:16","dtypep":"(XI)","access":"RD","varp":"(YI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
               ],
                "bitp": [
-                {"type":"AND","name":"","addr":"(QV)","loc":"d,75:18,75:19","dtypep":"(FC)",
+                {"type":"AND","name":"","addr":"(RV)","loc":"d,75:18,75:19","dtypep":"(GC)",
                  "lhsp": [
-                  {"type":"CONST","name":"32'h7","addr":"(RV)","loc":"d,75:18,75:19","dtypep":"(HC)"}
+                  {"type":"CONST","name":"32'h7","addr":"(SV)","loc":"d,75:18,75:19","dtypep":"(IC)"}
                 ],
                  "rhsp": [
-                  {"type":"CCAST","name":"","addr":"(SV)","loc":"d,75:18,75:19","dtypep":"(FC)","size":32,
+                  {"type":"CCAST","name":"","addr":"(TV)","loc":"d,75:18,75:19","dtypep":"(GC)","size":32,
                    "lhsp": [
-                    {"type":"VARREF","name":"t.e","addr":"(TV)","loc":"d,75:18,75:19","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"t.e","addr":"(UV)","loc":"d,75:18,75:19","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ]}
                 ]}
               ]}
             ]}
           ],
            "thensp": [
-            {"type":"DISPLAY","name":"","addr":"(UV)","loc":"d,75:46,75:52",
+            {"type":"DISPLAY","name":"","addr":"(VV)","loc":"d,75:46,75:52",
              "fmtp": [
-              {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:75:  got='h%x exp='h4\\n","addr":"(VV)","loc":"d,75:46,75:52","dtypep":"(SB)",
+              {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:75:  got='h%x exp='h4\\n","addr":"(WV)","loc":"d,75:46,75:52","dtypep":"(SB)",
                "exprsp": [
-                {"type":"ARRAYSEL","name":"","addr":"(WV)","loc":"d,75:125,75:126","dtypep":"(UB)",
+                {"type":"ARRAYSEL","name":"","addr":"(XV)","loc":"d,75:125,75:126","dtypep":"(BC)",
                  "fromp": [
-                  {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(XV)","loc":"d,17:12,17:16","dtypep":"(WI)","access":"RD","varp":"(XI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(YV)","loc":"d,17:12,17:16","dtypep":"(XI)","access":"RD","varp":"(YI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                 ],
                  "bitp": [
-                  {"type":"AND","name":"","addr":"(YV)","loc":"d,75:125,75:126","dtypep":"(FC)",
+                  {"type":"AND","name":"","addr":"(ZV)","loc":"d,75:125,75:126","dtypep":"(GC)",
                    "lhsp": [
-                    {"type":"CONST","name":"32'h7","addr":"(ZV)","loc":"d,75:125,75:126","dtypep":"(HC)"}
+                    {"type":"CONST","name":"32'h7","addr":"(AW)","loc":"d,75:125,75:126","dtypep":"(IC)"}
                   ],
                    "rhsp": [
-                    {"type":"CCAST","name":"","addr":"(AW)","loc":"d,75:125,75:126","dtypep":"(FC)","size":32,
+                    {"type":"CCAST","name":"","addr":"(BW)","loc":"d,75:125,75:126","dtypep":"(GC)","size":32,
                      "lhsp": [
-                      {"type":"VARREF","name":"t.e","addr":"(BW)","loc":"d,75:125,75:126","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"t.e","addr":"(CW)","loc":"d,75:125,75:126","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ]}
                   ]}
                 ]}
               ],"scopeNamep": []}
             ],"filep": []},
-            {"type":"STOP","name":"","addr":"(CW)","loc":"d,75:145,75:150"}
+            {"type":"STOP","name":"","addr":"(DW)","loc":"d,75:145,75:150"}
           ],"elsesp": []},
-          {"type":"IF","name":"","addr":"(DW)","loc":"d,76:13,76:15",
+          {"type":"IF","name":"","addr":"(EW)","loc":"d,76:13,76:15",
            "condp": [
-            {"type":"NEQ","name":"","addr":"(EW)","loc":"d,76:29,76:32","dtypep":"(GB)",
+            {"type":"NEQ","name":"","addr":"(FW)","loc":"d,76:29,76:32","dtypep":"(GB)",
              "lhsp": [
-              {"type":"CONST","name":"4'h3","addr":"(FW)","loc":"d,76:34,76:37","dtypep":"(UB)"}
+              {"type":"CONST","name":"4'h3","addr":"(GW)","loc":"d,76:34,76:37","dtypep":"(UB)"}
             ],
              "rhsp": [
-              {"type":"ARRAYSEL","name":"","addr":"(GW)","loc":"d,76:18,76:19","dtypep":"(UB)",
+              {"type":"ARRAYSEL","name":"","addr":"(HW)","loc":"d,76:18,76:19","dtypep":"(BC)",
                "fromp": [
-                {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(HW)","loc":"d,17:12,17:16","dtypep":"(WI)","access":"RD","varp":"(XI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(IW)","loc":"d,17:12,17:16","dtypep":"(XI)","access":"RD","varp":"(YI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
               ],
                "bitp": [
-                {"type":"AND","name":"","addr":"(IW)","loc":"d,76:18,76:19","dtypep":"(FC)",
+                {"type":"AND","name":"","addr":"(JW)","loc":"d,76:18,76:19","dtypep":"(GC)",
                  "lhsp": [
-                  {"type":"CONST","name":"32'h7","addr":"(JW)","loc":"d,76:18,76:19","dtypep":"(HC)"}
+                  {"type":"CONST","name":"32'h7","addr":"(KW)","loc":"d,76:18,76:19","dtypep":"(IC)"}
                 ],
                  "rhsp": [
-                  {"type":"ARRAYSEL","name":"","addr":"(KW)","loc":"d,76:18,76:19","dtypep":"(FC)",
+                  {"type":"ARRAYSEL","name":"","addr":"(LW)","loc":"d,76:18,76:19","dtypep":"(GC)",
                    "fromp": [
-                    {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(LW)","loc":"d,17:12,17:16","dtypep":"(WI)","access":"RD","varp":"(XI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(MW)","loc":"d,17:12,17:16","dtypep":"(XI)","access":"RD","varp":"(YI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ],
                    "bitp": [
-                    {"type":"AND","name":"","addr":"(MW)","loc":"d,76:18,76:19","dtypep":"(FC)",
+                    {"type":"AND","name":"","addr":"(NW)","loc":"d,76:18,76:19","dtypep":"(GC)",
                      "lhsp": [
-                      {"type":"CONST","name":"32'h7","addr":"(NW)","loc":"d,76:18,76:19","dtypep":"(HC)"}
+                      {"type":"CONST","name":"32'h7","addr":"(OW)","loc":"d,76:18,76:19","dtypep":"(IC)"}
                     ],
                      "rhsp": [
-                      {"type":"CCAST","name":"","addr":"(OW)","loc":"d,76:18,76:19","dtypep":"(FC)","size":32,
+                      {"type":"CCAST","name":"","addr":"(PW)","loc":"d,76:18,76:19","dtypep":"(GC)","size":32,
                        "lhsp": [
-                        {"type":"VARREF","name":"t.e","addr":"(PW)","loc":"d,76:18,76:19","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                        {"type":"VARREF","name":"t.e","addr":"(QW)","loc":"d,76:18,76:19","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                       ]}
                     ]}
                   ]}
@@ -1510,33 +1510,33 @@
             ]}
           ],
            "thensp": [
-            {"type":"DISPLAY","name":"","addr":"(QW)","loc":"d,76:46,76:52",
+            {"type":"DISPLAY","name":"","addr":"(RW)","loc":"d,76:46,76:52",
              "fmtp": [
-              {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:76:  got='h%x exp='h3\\n","addr":"(RW)","loc":"d,76:46,76:52","dtypep":"(SB)",
+              {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:76:  got='h%x exp='h3\\n","addr":"(SW)","loc":"d,76:46,76:52","dtypep":"(SB)",
                "exprsp": [
-                {"type":"ARRAYSEL","name":"","addr":"(SW)","loc":"d,76:125,76:126","dtypep":"(UB)",
+                {"type":"ARRAYSEL","name":"","addr":"(TW)","loc":"d,76:125,76:126","dtypep":"(BC)",
                  "fromp": [
-                  {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(TW)","loc":"d,17:12,17:16","dtypep":"(WI)","access":"RD","varp":"(XI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(UW)","loc":"d,17:12,17:16","dtypep":"(XI)","access":"RD","varp":"(YI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                 ],
                  "bitp": [
-                  {"type":"AND","name":"","addr":"(UW)","loc":"d,76:125,76:126","dtypep":"(FC)",
+                  {"type":"AND","name":"","addr":"(VW)","loc":"d,76:125,76:126","dtypep":"(GC)",
                    "lhsp": [
-                    {"type":"CONST","name":"32'h7","addr":"(VW)","loc":"d,76:125,76:126","dtypep":"(HC)"}
+                    {"type":"CONST","name":"32'h7","addr":"(WW)","loc":"d,76:125,76:126","dtypep":"(IC)"}
                   ],
                    "rhsp": [
-                    {"type":"ARRAYSEL","name":"","addr":"(WW)","loc":"d,76:125,76:126","dtypep":"(FC)",
+                    {"type":"ARRAYSEL","name":"","addr":"(XW)","loc":"d,76:125,76:126","dtypep":"(GC)",
                      "fromp": [
-                      {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(XW)","loc":"d,17:12,17:16","dtypep":"(WI)","access":"RD","varp":"(XI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(YW)","loc":"d,17:12,17:16","dtypep":"(XI)","access":"RD","varp":"(YI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ],
                      "bitp": [
-                      {"type":"AND","name":"","addr":"(YW)","loc":"d,76:125,76:126","dtypep":"(FC)",
+                      {"type":"AND","name":"","addr":"(ZW)","loc":"d,76:125,76:126","dtypep":"(GC)",
                        "lhsp": [
-                        {"type":"CONST","name":"32'h7","addr":"(ZW)","loc":"d,76:125,76:126","dtypep":"(HC)"}
+                        {"type":"CONST","name":"32'h7","addr":"(AX)","loc":"d,76:125,76:126","dtypep":"(IC)"}
                       ],
                        "rhsp": [
-                        {"type":"CCAST","name":"","addr":"(AX)","loc":"d,76:125,76:126","dtypep":"(FC)","size":32,
+                        {"type":"CCAST","name":"","addr":"(BX)","loc":"d,76:125,76:126","dtypep":"(GC)","size":32,
                          "lhsp": [
-                          {"type":"VARREF","name":"t.e","addr":"(BX)","loc":"d,76:125,76:126","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                          {"type":"VARREF","name":"t.e","addr":"(CX)","loc":"d,76:125,76:126","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                         ]}
                       ]}
                     ]}
@@ -1544,215 +1544,215 @@
                 ]}
               ],"scopeNamep": []}
             ],"filep": []},
-            {"type":"STOP","name":"","addr":"(CX)","loc":"d,76:145,76:150"}
+            {"type":"STOP","name":"","addr":"(DX)","loc":"d,76:145,76:150"}
           ],"elsesp": []},
-          {"type":"ASSIGNDLY","name":"","addr":"(DX)","loc":"d,77:12,77:14","dtypep":"(UB)",
+          {"type":"ASSIGNDLY","name":"","addr":"(EX)","loc":"d,77:12,77:14","dtypep":"(UB)",
            "rhsp": [
-            {"type":"CONST","name":"4'h3","addr":"(EX)","loc":"d,77:15,77:18","dtypep":"(UB)"}
+            {"type":"CONST","name":"4'h3","addr":"(FX)","loc":"d,77:15,77:18","dtypep":"(UB)"}
           ],
            "lhsp": [
-            {"type":"VARREF","name":"__Vdly__t.e","addr":"(FX)","loc":"d,77:10,77:11","dtypep":"(UB)","access":"WR","varp":"(KQ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"__Vdly__t.e","addr":"(GX)","loc":"d,77:10,77:11","dtypep":"(UB)","access":"WR","varp":"(LQ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ],"timingControlp": []}
         ],
          "elsesp": [
-          {"type":"IF","name":"","addr":"(GX)","loc":"d,79:12,79:14",
+          {"type":"IF","name":"","addr":"(HX)","loc":"d,79:12,79:14",
            "condp": [
-            {"type":"EQ","name":"","addr":"(HX)","loc":"d,79:19,79:21","dtypep":"(GB)",
+            {"type":"EQ","name":"","addr":"(IX)","loc":"d,79:19,79:21","dtypep":"(GB)",
              "lhsp": [
-              {"type":"CONST","name":"32'sh2","addr":"(IX)","loc":"d,79:21,79:22","dtypep":"(LB)"}
+              {"type":"CONST","name":"32'sh2","addr":"(JX)","loc":"d,79:21,79:22","dtypep":"(LB)"}
             ],
              "rhsp": [
-              {"type":"VARREF","name":"t.cyc","addr":"(JX)","loc":"d,79:16,79:19","dtypep":"(S)","access":"RD","varp":"(R)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+              {"type":"VARREF","name":"t.cyc","addr":"(KX)","loc":"d,79:16,79:19","dtypep":"(S)","access":"RD","varp":"(R)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
             ]}
           ],
            "thensp": [
-            {"type":"IF","name":"","addr":"(KX)","loc":"d,80:13,80:15",
+            {"type":"IF","name":"","addr":"(LX)","loc":"d,80:13,80:15",
              "condp": [
-              {"type":"NEQN","name":"","addr":"(LX)","loc":"d,80:26,80:28","dtypep":"(GB)",
+              {"type":"NEQN","name":"","addr":"(MX)","loc":"d,80:26,80:28","dtypep":"(GB)",
                "lhsp": [
-                {"type":"CONST","name":"\\\"E03\\\"","addr":"(MX)","loc":"d,80:30,80:35","dtypep":"(SB)"}
+                {"type":"CONST","name":"\\\"E03\\\"","addr":"(NX)","loc":"d,80:30,80:35","dtypep":"(SB)"}
               ],
                "rhsp": [
-                {"type":"ARRAYSEL","name":"","addr":"(NX)","loc":"d,80:18,80:19","dtypep":"(SB)",
+                {"type":"ARRAYSEL","name":"","addr":"(OX)","loc":"d,80:18,80:19","dtypep":"(SB)",
                  "fromp": [
-                  {"type":"VARREF","name":"__Venumtab_enum_name1","addr":"(OX)","loc":"d,17:12,17:16","dtypep":"(IM)","access":"RD","varp":"(JM)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"__Venumtab_enum_name1","addr":"(PX)","loc":"d,17:12,17:16","dtypep":"(JM)","access":"RD","varp":"(KM)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                 ],
                  "bitp": [
-                  {"type":"AND","name":"","addr":"(PX)","loc":"d,80:18,80:19","dtypep":"(FC)",
+                  {"type":"AND","name":"","addr":"(QX)","loc":"d,80:18,80:19","dtypep":"(GC)",
                    "lhsp": [
-                    {"type":"CONST","name":"32'h7","addr":"(QX)","loc":"d,80:18,80:19","dtypep":"(HC)"}
+                    {"type":"CONST","name":"32'h7","addr":"(RX)","loc":"d,80:18,80:19","dtypep":"(IC)"}
                   ],
                    "rhsp": [
-                    {"type":"CCAST","name":"","addr":"(RX)","loc":"d,80:18,80:19","dtypep":"(FC)","size":32,
+                    {"type":"CCAST","name":"","addr":"(SX)","loc":"d,80:18,80:19","dtypep":"(GC)","size":32,
                      "lhsp": [
-                      {"type":"VARREF","name":"t.e","addr":"(SX)","loc":"d,80:18,80:19","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"t.e","addr":"(TX)","loc":"d,80:18,80:19","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ]}
                   ]}
                 ]}
               ]}
             ],
              "thensp": [
-              {"type":"ASSIGN","name":"","addr":"(TX)","loc":"d,80:123,80:124","dtypep":"(SB)",
+              {"type":"ASSIGN","name":"","addr":"(UX)","loc":"d,80:123,80:124","dtypep":"(SB)",
                "rhsp": [
-                {"type":"ARRAYSEL","name":"","addr":"(UX)","loc":"d,80:123,80:124","dtypep":"(SB)",
+                {"type":"ARRAYSEL","name":"","addr":"(VX)","loc":"d,80:123,80:124","dtypep":"(SB)",
                  "fromp": [
-                  {"type":"VARREF","name":"__Venumtab_enum_name1","addr":"(VX)","loc":"d,17:12,17:16","dtypep":"(IM)","access":"RD","varp":"(JM)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"__Venumtab_enum_name1","addr":"(WX)","loc":"d,17:12,17:16","dtypep":"(JM)","access":"RD","varp":"(KM)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                 ],
                  "bitp": [
-                  {"type":"AND","name":"","addr":"(WX)","loc":"d,80:123,80:124","dtypep":"(FC)",
+                  {"type":"AND","name":"","addr":"(XX)","loc":"d,80:123,80:124","dtypep":"(GC)",
                    "lhsp": [
-                    {"type":"CONST","name":"32'h7","addr":"(XX)","loc":"d,80:123,80:124","dtypep":"(HC)"}
+                    {"type":"CONST","name":"32'h7","addr":"(YX)","loc":"d,80:123,80:124","dtypep":"(IC)"}
                   ],
                    "rhsp": [
-                    {"type":"CCAST","name":"","addr":"(YX)","loc":"d,80:123,80:124","dtypep":"(FC)","size":32,
+                    {"type":"CCAST","name":"","addr":"(ZX)","loc":"d,80:123,80:124","dtypep":"(GC)","size":32,
                      "lhsp": [
-                      {"type":"VARREF","name":"t.e","addr":"(ZX)","loc":"d,80:123,80:124","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"t.e","addr":"(AY)","loc":"d,80:123,80:124","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ]}
                   ]}
                 ]}
               ],
                "lhsp": [
-                {"type":"VARREF","name":"__Vtemp_2","addr":"(AY)","loc":"d,80:123,80:124","dtypep":"(SB)","access":"WR","varp":"(PQ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                {"type":"VARREF","name":"__Vtemp_2","addr":"(BY)","loc":"d,80:123,80:124","dtypep":"(SB)","access":"WR","varp":"(QQ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
               ],"timingControlp": []},
-              {"type":"DISPLAY","name":"","addr":"(BY)","loc":"d,80:44,80:50",
+              {"type":"DISPLAY","name":"","addr":"(CY)","loc":"d,80:44,80:50",
                "fmtp": [
-                {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:80:  got='%@' exp='E03'\\n","addr":"(CY)","loc":"d,80:44,80:50","dtypep":"(SB)",
+                {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:80:  got='%@' exp='E03'\\n","addr":"(DY)","loc":"d,80:44,80:50","dtypep":"(SB)",
                  "exprsp": [
-                  {"type":"VARREF","name":"__Vtemp_2","addr":"(DY)","loc":"d,80:123,80:124","dtypep":"(SB)","access":"RD","varp":"(PQ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"__Vtemp_2","addr":"(EY)","loc":"d,80:123,80:124","dtypep":"(SB)","access":"RD","varp":"(QQ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                 ],"scopeNamep": []}
               ],"filep": []},
-              {"type":"STOP","name":"","addr":"(EY)","loc":"d,80:142,80:147"}
+              {"type":"STOP","name":"","addr":"(FY)","loc":"d,80:142,80:147"}
             ],"elsesp": []},
-            {"type":"IF","name":"","addr":"(FY)","loc":"d,81:13,81:15",
+            {"type":"IF","name":"","addr":"(GY)","loc":"d,81:13,81:15",
              "condp": [
-              {"type":"NEQ","name":"","addr":"(GY)","loc":"d,81:26,81:29","dtypep":"(GB)",
+              {"type":"NEQ","name":"","addr":"(HY)","loc":"d,81:26,81:29","dtypep":"(GB)",
                "lhsp": [
-                {"type":"CONST","name":"4'h4","addr":"(HY)","loc":"d,81:31,81:34","dtypep":"(UB)"}
+                {"type":"CONST","name":"4'h4","addr":"(IY)","loc":"d,81:31,81:34","dtypep":"(UB)"}
               ],
                "rhsp": [
-                {"type":"ARRAYSEL","name":"","addr":"(IY)","loc":"d,81:18,81:19","dtypep":"(UB)",
+                {"type":"ARRAYSEL","name":"","addr":"(JY)","loc":"d,81:18,81:19","dtypep":"(BC)",
                  "fromp": [
-                  {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(JY)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(KY)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                 ],
                  "bitp": [
-                  {"type":"AND","name":"","addr":"(KY)","loc":"d,81:18,81:19","dtypep":"(FC)",
+                  {"type":"AND","name":"","addr":"(LY)","loc":"d,81:18,81:19","dtypep":"(GC)",
                    "lhsp": [
-                    {"type":"CONST","name":"32'h7","addr":"(LY)","loc":"d,81:18,81:19","dtypep":"(HC)"}
+                    {"type":"CONST","name":"32'h7","addr":"(MY)","loc":"d,81:18,81:19","dtypep":"(IC)"}
                   ],
                    "rhsp": [
-                    {"type":"CCAST","name":"","addr":"(MY)","loc":"d,81:18,81:19","dtypep":"(FC)","size":32,
+                    {"type":"CCAST","name":"","addr":"(NY)","loc":"d,81:18,81:19","dtypep":"(GC)","size":32,
                      "lhsp": [
-                      {"type":"VARREF","name":"t.e","addr":"(NY)","loc":"d,81:18,81:19","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"t.e","addr":"(OY)","loc":"d,81:18,81:19","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ]}
                   ]}
                 ]}
               ]}
             ],
              "thensp": [
-              {"type":"DISPLAY","name":"","addr":"(OY)","loc":"d,81:43,81:49",
+              {"type":"DISPLAY","name":"","addr":"(PY)","loc":"d,81:43,81:49",
                "fmtp": [
-                {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:81:  got='h%x exp='h4\\n","addr":"(PY)","loc":"d,81:43,81:49","dtypep":"(SB)",
+                {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:81:  got='h%x exp='h4\\n","addr":"(QY)","loc":"d,81:43,81:49","dtypep":"(SB)",
                  "exprsp": [
-                  {"type":"ARRAYSEL","name":"","addr":"(QY)","loc":"d,81:122,81:123","dtypep":"(UB)",
+                  {"type":"ARRAYSEL","name":"","addr":"(RY)","loc":"d,81:122,81:123","dtypep":"(BC)",
                    "fromp": [
-                    {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(RY)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(SY)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ],
                    "bitp": [
-                    {"type":"AND","name":"","addr":"(SY)","loc":"d,81:122,81:123","dtypep":"(FC)",
+                    {"type":"AND","name":"","addr":"(TY)","loc":"d,81:122,81:123","dtypep":"(GC)",
                      "lhsp": [
-                      {"type":"CONST","name":"32'h7","addr":"(TY)","loc":"d,81:122,81:123","dtypep":"(HC)"}
+                      {"type":"CONST","name":"32'h7","addr":"(UY)","loc":"d,81:122,81:123","dtypep":"(IC)"}
                     ],
                      "rhsp": [
-                      {"type":"CCAST","name":"","addr":"(UY)","loc":"d,81:122,81:123","dtypep":"(FC)","size":32,
+                      {"type":"CCAST","name":"","addr":"(VY)","loc":"d,81:122,81:123","dtypep":"(GC)","size":32,
                        "lhsp": [
-                        {"type":"VARREF","name":"t.e","addr":"(VY)","loc":"d,81:122,81:123","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                        {"type":"VARREF","name":"t.e","addr":"(WY)","loc":"d,81:122,81:123","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                       ]}
                     ]}
                   ]}
                 ],"scopeNamep": []}
               ],"filep": []},
-              {"type":"STOP","name":"","addr":"(WY)","loc":"d,81:139,81:144"}
+              {"type":"STOP","name":"","addr":"(XY)","loc":"d,81:139,81:144"}
             ],"elsesp": []},
-            {"type":"IF","name":"","addr":"(XY)","loc":"d,82:13,82:15",
+            {"type":"IF","name":"","addr":"(YY)","loc":"d,82:13,82:15",
              "condp": [
-              {"type":"NEQ","name":"","addr":"(YY)","loc":"d,82:29,82:32","dtypep":"(GB)",
+              {"type":"NEQ","name":"","addr":"(ZY)","loc":"d,82:29,82:32","dtypep":"(GB)",
                "lhsp": [
-                {"type":"CONST","name":"4'h4","addr":"(ZY)","loc":"d,82:34,82:37","dtypep":"(UB)"}
+                {"type":"CONST","name":"4'h4","addr":"(AZ)","loc":"d,82:34,82:37","dtypep":"(UB)"}
               ],
                "rhsp": [
-                {"type":"ARRAYSEL","name":"","addr":"(AZ)","loc":"d,82:18,82:19","dtypep":"(UB)",
+                {"type":"ARRAYSEL","name":"","addr":"(BZ)","loc":"d,82:18,82:19","dtypep":"(BC)",
                  "fromp": [
-                  {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(BZ)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(CZ)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                 ],
                  "bitp": [
-                  {"type":"AND","name":"","addr":"(CZ)","loc":"d,82:18,82:19","dtypep":"(FC)",
+                  {"type":"AND","name":"","addr":"(DZ)","loc":"d,82:18,82:19","dtypep":"(GC)",
                    "lhsp": [
-                    {"type":"CONST","name":"32'h7","addr":"(DZ)","loc":"d,82:18,82:19","dtypep":"(HC)"}
+                    {"type":"CONST","name":"32'h7","addr":"(EZ)","loc":"d,82:18,82:19","dtypep":"(IC)"}
                   ],
                    "rhsp": [
-                    {"type":"CCAST","name":"","addr":"(EZ)","loc":"d,82:18,82:19","dtypep":"(FC)","size":32,
+                    {"type":"CCAST","name":"","addr":"(FZ)","loc":"d,82:18,82:19","dtypep":"(GC)","size":32,
                      "lhsp": [
-                      {"type":"VARREF","name":"t.e","addr":"(FZ)","loc":"d,82:18,82:19","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"t.e","addr":"(GZ)","loc":"d,82:18,82:19","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ]}
                   ]}
                 ]}
               ]}
             ],
              "thensp": [
-              {"type":"DISPLAY","name":"","addr":"(GZ)","loc":"d,82:46,82:52",
+              {"type":"DISPLAY","name":"","addr":"(HZ)","loc":"d,82:46,82:52",
                "fmtp": [
-                {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:82:  got='h%x exp='h4\\n","addr":"(HZ)","loc":"d,82:46,82:52","dtypep":"(SB)",
+                {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:82:  got='h%x exp='h4\\n","addr":"(IZ)","loc":"d,82:46,82:52","dtypep":"(SB)",
                  "exprsp": [
-                  {"type":"ARRAYSEL","name":"","addr":"(IZ)","loc":"d,82:125,82:126","dtypep":"(UB)",
+                  {"type":"ARRAYSEL","name":"","addr":"(JZ)","loc":"d,82:125,82:126","dtypep":"(BC)",
                    "fromp": [
-                    {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(JZ)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(KZ)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ],
                    "bitp": [
-                    {"type":"AND","name":"","addr":"(KZ)","loc":"d,82:125,82:126","dtypep":"(FC)",
+                    {"type":"AND","name":"","addr":"(LZ)","loc":"d,82:125,82:126","dtypep":"(GC)",
                      "lhsp": [
-                      {"type":"CONST","name":"32'h7","addr":"(LZ)","loc":"d,82:125,82:126","dtypep":"(HC)"}
+                      {"type":"CONST","name":"32'h7","addr":"(MZ)","loc":"d,82:125,82:126","dtypep":"(IC)"}
                     ],
                      "rhsp": [
-                      {"type":"CCAST","name":"","addr":"(MZ)","loc":"d,82:125,82:126","dtypep":"(FC)","size":32,
+                      {"type":"CCAST","name":"","addr":"(NZ)","loc":"d,82:125,82:126","dtypep":"(GC)","size":32,
                        "lhsp": [
-                        {"type":"VARREF","name":"t.e","addr":"(NZ)","loc":"d,82:125,82:126","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                        {"type":"VARREF","name":"t.e","addr":"(OZ)","loc":"d,82:125,82:126","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                       ]}
                     ]}
                   ]}
                 ],"scopeNamep": []}
               ],"filep": []},
-              {"type":"STOP","name":"","addr":"(OZ)","loc":"d,82:145,82:150"}
+              {"type":"STOP","name":"","addr":"(PZ)","loc":"d,82:145,82:150"}
             ],"elsesp": []},
-            {"type":"IF","name":"","addr":"(PZ)","loc":"d,83:13,83:15",
+            {"type":"IF","name":"","addr":"(QZ)","loc":"d,83:13,83:15",
              "condp": [
-              {"type":"NEQ","name":"","addr":"(QZ)","loc":"d,83:29,83:32","dtypep":"(GB)",
+              {"type":"NEQ","name":"","addr":"(RZ)","loc":"d,83:29,83:32","dtypep":"(GB)",
                "lhsp": [
-                {"type":"CONST","name":"4'h1","addr":"(RZ)","loc":"d,83:34,83:37","dtypep":"(UB)"}
+                {"type":"CONST","name":"4'h1","addr":"(SZ)","loc":"d,83:34,83:37","dtypep":"(UB)"}
               ],
                "rhsp": [
-                {"type":"ARRAYSEL","name":"","addr":"(SZ)","loc":"d,83:18,83:19","dtypep":"(UB)",
+                {"type":"ARRAYSEL","name":"","addr":"(TZ)","loc":"d,83:18,83:19","dtypep":"(BC)",
                  "fromp": [
-                  {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(TZ)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(UZ)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                 ],
                  "bitp": [
-                  {"type":"AND","name":"","addr":"(UZ)","loc":"d,83:18,83:19","dtypep":"(FC)",
+                  {"type":"AND","name":"","addr":"(VZ)","loc":"d,83:18,83:19","dtypep":"(GC)",
                    "lhsp": [
-                    {"type":"CONST","name":"32'h7","addr":"(VZ)","loc":"d,83:18,83:19","dtypep":"(HC)"}
+                    {"type":"CONST","name":"32'h7","addr":"(WZ)","loc":"d,83:18,83:19","dtypep":"(IC)"}
                   ],
                    "rhsp": [
-                    {"type":"ARRAYSEL","name":"","addr":"(WZ)","loc":"d,83:18,83:19","dtypep":"(FC)",
+                    {"type":"ARRAYSEL","name":"","addr":"(XZ)","loc":"d,83:18,83:19","dtypep":"(GC)",
                      "fromp": [
-                      {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(XZ)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(YZ)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ],
                      "bitp": [
-                      {"type":"AND","name":"","addr":"(YZ)","loc":"d,83:18,83:19","dtypep":"(FC)",
+                      {"type":"AND","name":"","addr":"(ZZ)","loc":"d,83:18,83:19","dtypep":"(GC)",
                        "lhsp": [
-                        {"type":"CONST","name":"32'h7","addr":"(ZZ)","loc":"d,83:18,83:19","dtypep":"(HC)"}
+                        {"type":"CONST","name":"32'h7","addr":"(AAB)","loc":"d,83:18,83:19","dtypep":"(IC)"}
                       ],
                        "rhsp": [
-                        {"type":"CCAST","name":"","addr":"(AAB)","loc":"d,83:18,83:19","dtypep":"(FC)","size":32,
+                        {"type":"CCAST","name":"","addr":"(BAB)","loc":"d,83:18,83:19","dtypep":"(GC)","size":32,
                          "lhsp": [
-                          {"type":"VARREF","name":"t.e","addr":"(BAB)","loc":"d,83:18,83:19","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                          {"type":"VARREF","name":"t.e","addr":"(CAB)","loc":"d,83:18,83:19","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                         ]}
                       ]}
                     ]}
@@ -1761,33 +1761,33 @@
               ]}
             ],
              "thensp": [
-              {"type":"DISPLAY","name":"","addr":"(CAB)","loc":"d,83:46,83:52",
+              {"type":"DISPLAY","name":"","addr":"(DAB)","loc":"d,83:46,83:52",
                "fmtp": [
-                {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:83:  got='h%x exp='h1\\n","addr":"(DAB)","loc":"d,83:46,83:52","dtypep":"(SB)",
+                {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:83:  got='h%x exp='h1\\n","addr":"(EAB)","loc":"d,83:46,83:52","dtypep":"(SB)",
                  "exprsp": [
-                  {"type":"ARRAYSEL","name":"","addr":"(EAB)","loc":"d,83:125,83:126","dtypep":"(UB)",
+                  {"type":"ARRAYSEL","name":"","addr":"(FAB)","loc":"d,83:125,83:126","dtypep":"(BC)",
                    "fromp": [
-                    {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(FAB)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(GAB)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ],
                    "bitp": [
-                    {"type":"AND","name":"","addr":"(GAB)","loc":"d,83:125,83:126","dtypep":"(FC)",
+                    {"type":"AND","name":"","addr":"(HAB)","loc":"d,83:125,83:126","dtypep":"(GC)",
                      "lhsp": [
-                      {"type":"CONST","name":"32'h7","addr":"(HAB)","loc":"d,83:125,83:126","dtypep":"(HC)"}
+                      {"type":"CONST","name":"32'h7","addr":"(IAB)","loc":"d,83:125,83:126","dtypep":"(IC)"}
                     ],
                      "rhsp": [
-                      {"type":"ARRAYSEL","name":"","addr":"(IAB)","loc":"d,83:125,83:126","dtypep":"(FC)",
+                      {"type":"ARRAYSEL","name":"","addr":"(JAB)","loc":"d,83:125,83:126","dtypep":"(GC)",
                        "fromp": [
-                        {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(JAB)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                        {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(KAB)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                       ],
                        "bitp": [
-                        {"type":"AND","name":"","addr":"(KAB)","loc":"d,83:125,83:126","dtypep":"(FC)",
+                        {"type":"AND","name":"","addr":"(LAB)","loc":"d,83:125,83:126","dtypep":"(GC)",
                          "lhsp": [
-                          {"type":"CONST","name":"32'h7","addr":"(LAB)","loc":"d,83:125,83:126","dtypep":"(HC)"}
+                          {"type":"CONST","name":"32'h7","addr":"(MAB)","loc":"d,83:125,83:126","dtypep":"(IC)"}
                         ],
                          "rhsp": [
-                          {"type":"CCAST","name":"","addr":"(MAB)","loc":"d,83:125,83:126","dtypep":"(FC)","size":32,
+                          {"type":"CCAST","name":"","addr":"(NAB)","loc":"d,83:125,83:126","dtypep":"(GC)","size":32,
                            "lhsp": [
-                            {"type":"VARREF","name":"t.e","addr":"(NAB)","loc":"d,83:125,83:126","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                            {"type":"VARREF","name":"t.e","addr":"(OAB)","loc":"d,83:125,83:126","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                           ]}
                         ]}
                       ]}
@@ -1795,138 +1795,138 @@
                   ]}
                 ],"scopeNamep": []}
               ],"filep": []},
-              {"type":"STOP","name":"","addr":"(OAB)","loc":"d,83:145,83:150"}
+              {"type":"STOP","name":"","addr":"(PAB)","loc":"d,83:145,83:150"}
             ],"elsesp": []},
-            {"type":"IF","name":"","addr":"(PAB)","loc":"d,84:13,84:15",
+            {"type":"IF","name":"","addr":"(QAB)","loc":"d,84:13,84:15",
              "condp": [
-              {"type":"NEQ","name":"","addr":"(QAB)","loc":"d,84:26,84:29","dtypep":"(GB)",
+              {"type":"NEQ","name":"","addr":"(RAB)","loc":"d,84:26,84:29","dtypep":"(GB)",
                "lhsp": [
-                {"type":"CONST","name":"4'h1","addr":"(RAB)","loc":"d,84:31,84:34","dtypep":"(UB)"}
+                {"type":"CONST","name":"4'h1","addr":"(SAB)","loc":"d,84:31,84:34","dtypep":"(UB)"}
               ],
                "rhsp": [
-                {"type":"ARRAYSEL","name":"","addr":"(SAB)","loc":"d,84:18,84:19","dtypep":"(UB)",
+                {"type":"ARRAYSEL","name":"","addr":"(TAB)","loc":"d,84:18,84:19","dtypep":"(BC)",
                  "fromp": [
-                  {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(TAB)","loc":"d,17:12,17:16","dtypep":"(WI)","access":"RD","varp":"(XI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(UAB)","loc":"d,17:12,17:16","dtypep":"(XI)","access":"RD","varp":"(YI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                 ],
                  "bitp": [
-                  {"type":"AND","name":"","addr":"(UAB)","loc":"d,84:18,84:19","dtypep":"(FC)",
+                  {"type":"AND","name":"","addr":"(VAB)","loc":"d,84:18,84:19","dtypep":"(GC)",
                    "lhsp": [
-                    {"type":"CONST","name":"32'h7","addr":"(VAB)","loc":"d,84:18,84:19","dtypep":"(HC)"}
+                    {"type":"CONST","name":"32'h7","addr":"(WAB)","loc":"d,84:18,84:19","dtypep":"(IC)"}
                   ],
                    "rhsp": [
-                    {"type":"CCAST","name":"","addr":"(WAB)","loc":"d,84:18,84:19","dtypep":"(FC)","size":32,
+                    {"type":"CCAST","name":"","addr":"(XAB)","loc":"d,84:18,84:19","dtypep":"(GC)","size":32,
                      "lhsp": [
-                      {"type":"VARREF","name":"t.e","addr":"(XAB)","loc":"d,84:18,84:19","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"t.e","addr":"(YAB)","loc":"d,84:18,84:19","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ]}
                   ]}
                 ]}
               ]}
             ],
              "thensp": [
-              {"type":"DISPLAY","name":"","addr":"(YAB)","loc":"d,84:43,84:49",
+              {"type":"DISPLAY","name":"","addr":"(ZAB)","loc":"d,84:43,84:49",
                "fmtp": [
-                {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:84:  got='h%x exp='h1\\n","addr":"(ZAB)","loc":"d,84:43,84:49","dtypep":"(SB)",
+                {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:84:  got='h%x exp='h1\\n","addr":"(ABB)","loc":"d,84:43,84:49","dtypep":"(SB)",
                  "exprsp": [
-                  {"type":"ARRAYSEL","name":"","addr":"(ABB)","loc":"d,84:122,84:123","dtypep":"(UB)",
+                  {"type":"ARRAYSEL","name":"","addr":"(BBB)","loc":"d,84:122,84:123","dtypep":"(BC)",
                    "fromp": [
-                    {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(BBB)","loc":"d,17:12,17:16","dtypep":"(WI)","access":"RD","varp":"(XI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(CBB)","loc":"d,17:12,17:16","dtypep":"(XI)","access":"RD","varp":"(YI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ],
                    "bitp": [
-                    {"type":"AND","name":"","addr":"(CBB)","loc":"d,84:122,84:123","dtypep":"(FC)",
+                    {"type":"AND","name":"","addr":"(DBB)","loc":"d,84:122,84:123","dtypep":"(GC)",
                      "lhsp": [
-                      {"type":"CONST","name":"32'h7","addr":"(DBB)","loc":"d,84:122,84:123","dtypep":"(HC)"}
+                      {"type":"CONST","name":"32'h7","addr":"(EBB)","loc":"d,84:122,84:123","dtypep":"(IC)"}
                     ],
                      "rhsp": [
-                      {"type":"CCAST","name":"","addr":"(EBB)","loc":"d,84:122,84:123","dtypep":"(FC)","size":32,
+                      {"type":"CCAST","name":"","addr":"(FBB)","loc":"d,84:122,84:123","dtypep":"(GC)","size":32,
                        "lhsp": [
-                        {"type":"VARREF","name":"t.e","addr":"(FBB)","loc":"d,84:122,84:123","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                        {"type":"VARREF","name":"t.e","addr":"(GBB)","loc":"d,84:122,84:123","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                       ]}
                     ]}
                   ]}
                 ],"scopeNamep": []}
               ],"filep": []},
-              {"type":"STOP","name":"","addr":"(GBB)","loc":"d,84:139,84:144"}
+              {"type":"STOP","name":"","addr":"(HBB)","loc":"d,84:139,84:144"}
             ],"elsesp": []},
-            {"type":"IF","name":"","addr":"(HBB)","loc":"d,85:13,85:15",
+            {"type":"IF","name":"","addr":"(IBB)","loc":"d,85:13,85:15",
              "condp": [
-              {"type":"NEQ","name":"","addr":"(IBB)","loc":"d,85:29,85:32","dtypep":"(GB)",
+              {"type":"NEQ","name":"","addr":"(JBB)","loc":"d,85:29,85:32","dtypep":"(GB)",
                "lhsp": [
-                {"type":"CONST","name":"4'h1","addr":"(JBB)","loc":"d,85:34,85:37","dtypep":"(UB)"}
+                {"type":"CONST","name":"4'h1","addr":"(KBB)","loc":"d,85:34,85:37","dtypep":"(UB)"}
               ],
                "rhsp": [
-                {"type":"ARRAYSEL","name":"","addr":"(KBB)","loc":"d,85:18,85:19","dtypep":"(UB)",
+                {"type":"ARRAYSEL","name":"","addr":"(LBB)","loc":"d,85:18,85:19","dtypep":"(BC)",
                  "fromp": [
-                  {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(LBB)","loc":"d,17:12,17:16","dtypep":"(WI)","access":"RD","varp":"(XI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(MBB)","loc":"d,17:12,17:16","dtypep":"(XI)","access":"RD","varp":"(YI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                 ],
                  "bitp": [
-                  {"type":"AND","name":"","addr":"(MBB)","loc":"d,85:18,85:19","dtypep":"(FC)",
+                  {"type":"AND","name":"","addr":"(NBB)","loc":"d,85:18,85:19","dtypep":"(GC)",
                    "lhsp": [
-                    {"type":"CONST","name":"32'h7","addr":"(NBB)","loc":"d,85:18,85:19","dtypep":"(HC)"}
+                    {"type":"CONST","name":"32'h7","addr":"(OBB)","loc":"d,85:18,85:19","dtypep":"(IC)"}
                   ],
                    "rhsp": [
-                    {"type":"CCAST","name":"","addr":"(OBB)","loc":"d,85:18,85:19","dtypep":"(FC)","size":32,
+                    {"type":"CCAST","name":"","addr":"(PBB)","loc":"d,85:18,85:19","dtypep":"(GC)","size":32,
                      "lhsp": [
-                      {"type":"VARREF","name":"t.e","addr":"(PBB)","loc":"d,85:18,85:19","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"t.e","addr":"(QBB)","loc":"d,85:18,85:19","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ]}
                   ]}
                 ]}
               ]}
             ],
              "thensp": [
-              {"type":"DISPLAY","name":"","addr":"(QBB)","loc":"d,85:46,85:52",
+              {"type":"DISPLAY","name":"","addr":"(RBB)","loc":"d,85:46,85:52",
                "fmtp": [
-                {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:85:  got='h%x exp='h1\\n","addr":"(RBB)","loc":"d,85:46,85:52","dtypep":"(SB)",
+                {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:85:  got='h%x exp='h1\\n","addr":"(SBB)","loc":"d,85:46,85:52","dtypep":"(SB)",
                  "exprsp": [
-                  {"type":"ARRAYSEL","name":"","addr":"(SBB)","loc":"d,85:125,85:126","dtypep":"(UB)",
+                  {"type":"ARRAYSEL","name":"","addr":"(TBB)","loc":"d,85:125,85:126","dtypep":"(BC)",
                    "fromp": [
-                    {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(TBB)","loc":"d,17:12,17:16","dtypep":"(WI)","access":"RD","varp":"(XI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(UBB)","loc":"d,17:12,17:16","dtypep":"(XI)","access":"RD","varp":"(YI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ],
                    "bitp": [
-                    {"type":"AND","name":"","addr":"(UBB)","loc":"d,85:125,85:126","dtypep":"(FC)",
+                    {"type":"AND","name":"","addr":"(VBB)","loc":"d,85:125,85:126","dtypep":"(GC)",
                      "lhsp": [
-                      {"type":"CONST","name":"32'h7","addr":"(VBB)","loc":"d,85:125,85:126","dtypep":"(HC)"}
+                      {"type":"CONST","name":"32'h7","addr":"(WBB)","loc":"d,85:125,85:126","dtypep":"(IC)"}
                     ],
                      "rhsp": [
-                      {"type":"CCAST","name":"","addr":"(WBB)","loc":"d,85:125,85:126","dtypep":"(FC)","size":32,
+                      {"type":"CCAST","name":"","addr":"(XBB)","loc":"d,85:125,85:126","dtypep":"(GC)","size":32,
                        "lhsp": [
-                        {"type":"VARREF","name":"t.e","addr":"(XBB)","loc":"d,85:125,85:126","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                        {"type":"VARREF","name":"t.e","addr":"(YBB)","loc":"d,85:125,85:126","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                       ]}
                     ]}
                   ]}
                 ],"scopeNamep": []}
               ],"filep": []},
-              {"type":"STOP","name":"","addr":"(YBB)","loc":"d,85:145,85:150"}
+              {"type":"STOP","name":"","addr":"(ZBB)","loc":"d,85:145,85:150"}
             ],"elsesp": []},
-            {"type":"IF","name":"","addr":"(ZBB)","loc":"d,86:13,86:15",
+            {"type":"IF","name":"","addr":"(ACB)","loc":"d,86:13,86:15",
              "condp": [
-              {"type":"NEQ","name":"","addr":"(ACB)","loc":"d,86:29,86:32","dtypep":"(GB)",
+              {"type":"NEQ","name":"","addr":"(BCB)","loc":"d,86:29,86:32","dtypep":"(GB)",
                "lhsp": [
-                {"type":"CONST","name":"4'h4","addr":"(BCB)","loc":"d,86:34,86:37","dtypep":"(UB)"}
+                {"type":"CONST","name":"4'h4","addr":"(CCB)","loc":"d,86:34,86:37","dtypep":"(UB)"}
               ],
                "rhsp": [
-                {"type":"ARRAYSEL","name":"","addr":"(CCB)","loc":"d,86:18,86:19","dtypep":"(UB)",
+                {"type":"ARRAYSEL","name":"","addr":"(DCB)","loc":"d,86:18,86:19","dtypep":"(BC)",
                  "fromp": [
-                  {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(DCB)","loc":"d,17:12,17:16","dtypep":"(WI)","access":"RD","varp":"(XI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(ECB)","loc":"d,17:12,17:16","dtypep":"(XI)","access":"RD","varp":"(YI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                 ],
                  "bitp": [
-                  {"type":"AND","name":"","addr":"(ECB)","loc":"d,86:18,86:19","dtypep":"(FC)",
+                  {"type":"AND","name":"","addr":"(FCB)","loc":"d,86:18,86:19","dtypep":"(GC)",
                    "lhsp": [
-                    {"type":"CONST","name":"32'h7","addr":"(FCB)","loc":"d,86:18,86:19","dtypep":"(HC)"}
+                    {"type":"CONST","name":"32'h7","addr":"(GCB)","loc":"d,86:18,86:19","dtypep":"(IC)"}
                   ],
                    "rhsp": [
-                    {"type":"ARRAYSEL","name":"","addr":"(GCB)","loc":"d,86:18,86:19","dtypep":"(FC)",
+                    {"type":"ARRAYSEL","name":"","addr":"(HCB)","loc":"d,86:18,86:19","dtypep":"(GC)",
                      "fromp": [
-                      {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(HCB)","loc":"d,17:12,17:16","dtypep":"(WI)","access":"RD","varp":"(XI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(ICB)","loc":"d,17:12,17:16","dtypep":"(XI)","access":"RD","varp":"(YI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ],
                      "bitp": [
-                      {"type":"AND","name":"","addr":"(ICB)","loc":"d,86:18,86:19","dtypep":"(FC)",
+                      {"type":"AND","name":"","addr":"(JCB)","loc":"d,86:18,86:19","dtypep":"(GC)",
                        "lhsp": [
-                        {"type":"CONST","name":"32'h7","addr":"(JCB)","loc":"d,86:18,86:19","dtypep":"(HC)"}
+                        {"type":"CONST","name":"32'h7","addr":"(KCB)","loc":"d,86:18,86:19","dtypep":"(IC)"}
                       ],
                        "rhsp": [
-                        {"type":"CCAST","name":"","addr":"(KCB)","loc":"d,86:18,86:19","dtypep":"(FC)","size":32,
+                        {"type":"CCAST","name":"","addr":"(LCB)","loc":"d,86:18,86:19","dtypep":"(GC)","size":32,
                          "lhsp": [
-                          {"type":"VARREF","name":"t.e","addr":"(LCB)","loc":"d,86:18,86:19","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                          {"type":"VARREF","name":"t.e","addr":"(MCB)","loc":"d,86:18,86:19","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                         ]}
                       ]}
                     ]}
@@ -1935,33 +1935,33 @@
               ]}
             ],
              "thensp": [
-              {"type":"DISPLAY","name":"","addr":"(MCB)","loc":"d,86:46,86:52",
+              {"type":"DISPLAY","name":"","addr":"(NCB)","loc":"d,86:46,86:52",
                "fmtp": [
-                {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:86:  got='h%x exp='h4\\n","addr":"(NCB)","loc":"d,86:46,86:52","dtypep":"(SB)",
+                {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:86:  got='h%x exp='h4\\n","addr":"(OCB)","loc":"d,86:46,86:52","dtypep":"(SB)",
                  "exprsp": [
-                  {"type":"ARRAYSEL","name":"","addr":"(OCB)","loc":"d,86:125,86:126","dtypep":"(UB)",
+                  {"type":"ARRAYSEL","name":"","addr":"(PCB)","loc":"d,86:125,86:126","dtypep":"(BC)",
                    "fromp": [
-                    {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(PCB)","loc":"d,17:12,17:16","dtypep":"(WI)","access":"RD","varp":"(XI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(QCB)","loc":"d,17:12,17:16","dtypep":"(XI)","access":"RD","varp":"(YI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ],
                    "bitp": [
-                    {"type":"AND","name":"","addr":"(QCB)","loc":"d,86:125,86:126","dtypep":"(FC)",
+                    {"type":"AND","name":"","addr":"(RCB)","loc":"d,86:125,86:126","dtypep":"(GC)",
                      "lhsp": [
-                      {"type":"CONST","name":"32'h7","addr":"(RCB)","loc":"d,86:125,86:126","dtypep":"(HC)"}
+                      {"type":"CONST","name":"32'h7","addr":"(SCB)","loc":"d,86:125,86:126","dtypep":"(IC)"}
                     ],
                      "rhsp": [
-                      {"type":"ARRAYSEL","name":"","addr":"(SCB)","loc":"d,86:125,86:126","dtypep":"(FC)",
+                      {"type":"ARRAYSEL","name":"","addr":"(TCB)","loc":"d,86:125,86:126","dtypep":"(GC)",
                        "fromp": [
-                        {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(TCB)","loc":"d,17:12,17:16","dtypep":"(WI)","access":"RD","varp":"(XI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                        {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(UCB)","loc":"d,17:12,17:16","dtypep":"(XI)","access":"RD","varp":"(YI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                       ],
                        "bitp": [
-                        {"type":"AND","name":"","addr":"(UCB)","loc":"d,86:125,86:126","dtypep":"(FC)",
+                        {"type":"AND","name":"","addr":"(VCB)","loc":"d,86:125,86:126","dtypep":"(GC)",
                          "lhsp": [
-                          {"type":"CONST","name":"32'h7","addr":"(VCB)","loc":"d,86:125,86:126","dtypep":"(HC)"}
+                          {"type":"CONST","name":"32'h7","addr":"(WCB)","loc":"d,86:125,86:126","dtypep":"(IC)"}
                         ],
                          "rhsp": [
-                          {"type":"CCAST","name":"","addr":"(WCB)","loc":"d,86:125,86:126","dtypep":"(FC)","size":32,
+                          {"type":"CCAST","name":"","addr":"(XCB)","loc":"d,86:125,86:126","dtypep":"(GC)","size":32,
                            "lhsp": [
-                            {"type":"VARREF","name":"t.e","addr":"(XCB)","loc":"d,86:125,86:126","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                            {"type":"VARREF","name":"t.e","addr":"(YCB)","loc":"d,86:125,86:126","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                           ]}
                         ]}
                       ]}
@@ -1969,215 +1969,215 @@
                   ]}
                 ],"scopeNamep": []}
               ],"filep": []},
-              {"type":"STOP","name":"","addr":"(YCB)","loc":"d,86:145,86:150"}
+              {"type":"STOP","name":"","addr":"(ZCB)","loc":"d,86:145,86:150"}
             ],"elsesp": []},
-            {"type":"ASSIGNDLY","name":"","addr":"(ZCB)","loc":"d,87:12,87:14","dtypep":"(UB)",
+            {"type":"ASSIGNDLY","name":"","addr":"(ADB)","loc":"d,87:12,87:14","dtypep":"(UB)",
              "rhsp": [
-              {"type":"CONST","name":"4'h4","addr":"(ADB)","loc":"d,87:15,87:18","dtypep":"(UB)"}
+              {"type":"CONST","name":"4'h4","addr":"(BDB)","loc":"d,87:15,87:18","dtypep":"(UB)"}
             ],
              "lhsp": [
-              {"type":"VARREF","name":"__Vdly__t.e","addr":"(BDB)","loc":"d,87:10,87:11","dtypep":"(UB)","access":"WR","varp":"(KQ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+              {"type":"VARREF","name":"__Vdly__t.e","addr":"(CDB)","loc":"d,87:10,87:11","dtypep":"(UB)","access":"WR","varp":"(LQ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
             ],"timingControlp": []}
           ],
            "elsesp": [
-            {"type":"IF","name":"","addr":"(CDB)","loc":"d,89:12,89:14",
+            {"type":"IF","name":"","addr":"(DDB)","loc":"d,89:12,89:14",
              "condp": [
-              {"type":"EQ","name":"","addr":"(DDB)","loc":"d,89:19,89:21","dtypep":"(GB)",
+              {"type":"EQ","name":"","addr":"(EDB)","loc":"d,89:19,89:21","dtypep":"(GB)",
                "lhsp": [
-                {"type":"CONST","name":"32'sh3","addr":"(EDB)","loc":"d,89:21,89:22","dtypep":"(LB)"}
+                {"type":"CONST","name":"32'sh3","addr":"(FDB)","loc":"d,89:21,89:22","dtypep":"(LB)"}
               ],
                "rhsp": [
-                {"type":"VARREF","name":"t.cyc","addr":"(FDB)","loc":"d,89:16,89:19","dtypep":"(S)","access":"RD","varp":"(R)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                {"type":"VARREF","name":"t.cyc","addr":"(GDB)","loc":"d,89:16,89:19","dtypep":"(S)","access":"RD","varp":"(R)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
               ]}
             ],
              "thensp": [
-              {"type":"IF","name":"","addr":"(GDB)","loc":"d,90:13,90:15",
+              {"type":"IF","name":"","addr":"(HDB)","loc":"d,90:13,90:15",
                "condp": [
-                {"type":"NEQN","name":"","addr":"(HDB)","loc":"d,90:26,90:28","dtypep":"(GB)",
+                {"type":"NEQN","name":"","addr":"(IDB)","loc":"d,90:26,90:28","dtypep":"(GB)",
                  "lhsp": [
-                  {"type":"CONST","name":"\\\"E04\\\"","addr":"(IDB)","loc":"d,90:30,90:35","dtypep":"(SB)"}
+                  {"type":"CONST","name":"\\\"E04\\\"","addr":"(JDB)","loc":"d,90:30,90:35","dtypep":"(SB)"}
                 ],
                  "rhsp": [
-                  {"type":"ARRAYSEL","name":"","addr":"(JDB)","loc":"d,90:18,90:19","dtypep":"(SB)",
+                  {"type":"ARRAYSEL","name":"","addr":"(KDB)","loc":"d,90:18,90:19","dtypep":"(SB)",
                    "fromp": [
-                    {"type":"VARREF","name":"__Venumtab_enum_name1","addr":"(KDB)","loc":"d,17:12,17:16","dtypep":"(IM)","access":"RD","varp":"(JM)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"__Venumtab_enum_name1","addr":"(LDB)","loc":"d,17:12,17:16","dtypep":"(JM)","access":"RD","varp":"(KM)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ],
                    "bitp": [
-                    {"type":"AND","name":"","addr":"(LDB)","loc":"d,90:18,90:19","dtypep":"(FC)",
+                    {"type":"AND","name":"","addr":"(MDB)","loc":"d,90:18,90:19","dtypep":"(GC)",
                      "lhsp": [
-                      {"type":"CONST","name":"32'h7","addr":"(MDB)","loc":"d,90:18,90:19","dtypep":"(HC)"}
+                      {"type":"CONST","name":"32'h7","addr":"(NDB)","loc":"d,90:18,90:19","dtypep":"(IC)"}
                     ],
                      "rhsp": [
-                      {"type":"CCAST","name":"","addr":"(NDB)","loc":"d,90:18,90:19","dtypep":"(FC)","size":32,
+                      {"type":"CCAST","name":"","addr":"(ODB)","loc":"d,90:18,90:19","dtypep":"(GC)","size":32,
                        "lhsp": [
-                        {"type":"VARREF","name":"t.e","addr":"(ODB)","loc":"d,90:18,90:19","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                        {"type":"VARREF","name":"t.e","addr":"(PDB)","loc":"d,90:18,90:19","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                       ]}
                     ]}
                   ]}
                 ]}
               ],
                "thensp": [
-                {"type":"ASSIGN","name":"","addr":"(PDB)","loc":"d,90:123,90:124","dtypep":"(SB)",
+                {"type":"ASSIGN","name":"","addr":"(QDB)","loc":"d,90:123,90:124","dtypep":"(SB)",
                  "rhsp": [
-                  {"type":"ARRAYSEL","name":"","addr":"(QDB)","loc":"d,90:123,90:124","dtypep":"(SB)",
+                  {"type":"ARRAYSEL","name":"","addr":"(RDB)","loc":"d,90:123,90:124","dtypep":"(SB)",
                    "fromp": [
-                    {"type":"VARREF","name":"__Venumtab_enum_name1","addr":"(RDB)","loc":"d,17:12,17:16","dtypep":"(IM)","access":"RD","varp":"(JM)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"__Venumtab_enum_name1","addr":"(SDB)","loc":"d,17:12,17:16","dtypep":"(JM)","access":"RD","varp":"(KM)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ],
                    "bitp": [
-                    {"type":"AND","name":"","addr":"(SDB)","loc":"d,90:123,90:124","dtypep":"(FC)",
+                    {"type":"AND","name":"","addr":"(TDB)","loc":"d,90:123,90:124","dtypep":"(GC)",
                      "lhsp": [
-                      {"type":"CONST","name":"32'h7","addr":"(TDB)","loc":"d,90:123,90:124","dtypep":"(HC)"}
+                      {"type":"CONST","name":"32'h7","addr":"(UDB)","loc":"d,90:123,90:124","dtypep":"(IC)"}
                     ],
                      "rhsp": [
-                      {"type":"CCAST","name":"","addr":"(UDB)","loc":"d,90:123,90:124","dtypep":"(FC)","size":32,
+                      {"type":"CCAST","name":"","addr":"(VDB)","loc":"d,90:123,90:124","dtypep":"(GC)","size":32,
                        "lhsp": [
-                        {"type":"VARREF","name":"t.e","addr":"(VDB)","loc":"d,90:123,90:124","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                        {"type":"VARREF","name":"t.e","addr":"(WDB)","loc":"d,90:123,90:124","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                       ]}
                     ]}
                   ]}
                 ],
                  "lhsp": [
-                  {"type":"VARREF","name":"__Vtemp_3","addr":"(WDB)","loc":"d,90:123,90:124","dtypep":"(SB)","access":"WR","varp":"(QQ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"__Vtemp_3","addr":"(XDB)","loc":"d,90:123,90:124","dtypep":"(SB)","access":"WR","varp":"(RQ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                 ],"timingControlp": []},
-                {"type":"DISPLAY","name":"","addr":"(XDB)","loc":"d,90:44,90:50",
+                {"type":"DISPLAY","name":"","addr":"(YDB)","loc":"d,90:44,90:50",
                  "fmtp": [
-                  {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:90:  got='%@' exp='E04'\\n","addr":"(YDB)","loc":"d,90:44,90:50","dtypep":"(SB)",
+                  {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:90:  got='%@' exp='E04'\\n","addr":"(ZDB)","loc":"d,90:44,90:50","dtypep":"(SB)",
                    "exprsp": [
-                    {"type":"VARREF","name":"__Vtemp_3","addr":"(ZDB)","loc":"d,90:123,90:124","dtypep":"(SB)","access":"RD","varp":"(QQ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"__Vtemp_3","addr":"(AEB)","loc":"d,90:123,90:124","dtypep":"(SB)","access":"RD","varp":"(RQ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ],"scopeNamep": []}
                 ],"filep": []},
-                {"type":"STOP","name":"","addr":"(AEB)","loc":"d,90:142,90:147"}
+                {"type":"STOP","name":"","addr":"(BEB)","loc":"d,90:142,90:147"}
               ],"elsesp": []},
-              {"type":"IF","name":"","addr":"(BEB)","loc":"d,91:13,91:15",
+              {"type":"IF","name":"","addr":"(CEB)","loc":"d,91:13,91:15",
                "condp": [
-                {"type":"NEQ","name":"","addr":"(CEB)","loc":"d,91:26,91:29","dtypep":"(GB)",
+                {"type":"NEQ","name":"","addr":"(DEB)","loc":"d,91:26,91:29","dtypep":"(GB)",
                  "lhsp": [
-                  {"type":"CONST","name":"4'h1","addr":"(DEB)","loc":"d,91:31,91:34","dtypep":"(UB)"}
+                  {"type":"CONST","name":"4'h1","addr":"(EEB)","loc":"d,91:31,91:34","dtypep":"(UB)"}
                 ],
                  "rhsp": [
-                  {"type":"ARRAYSEL","name":"","addr":"(EEB)","loc":"d,91:18,91:19","dtypep":"(UB)",
+                  {"type":"ARRAYSEL","name":"","addr":"(FEB)","loc":"d,91:18,91:19","dtypep":"(BC)",
                    "fromp": [
-                    {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(FEB)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(GEB)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ],
                    "bitp": [
-                    {"type":"AND","name":"","addr":"(GEB)","loc":"d,91:18,91:19","dtypep":"(FC)",
+                    {"type":"AND","name":"","addr":"(HEB)","loc":"d,91:18,91:19","dtypep":"(GC)",
                      "lhsp": [
-                      {"type":"CONST","name":"32'h7","addr":"(HEB)","loc":"d,91:18,91:19","dtypep":"(HC)"}
+                      {"type":"CONST","name":"32'h7","addr":"(IEB)","loc":"d,91:18,91:19","dtypep":"(IC)"}
                     ],
                      "rhsp": [
-                      {"type":"CCAST","name":"","addr":"(IEB)","loc":"d,91:18,91:19","dtypep":"(FC)","size":32,
+                      {"type":"CCAST","name":"","addr":"(JEB)","loc":"d,91:18,91:19","dtypep":"(GC)","size":32,
                        "lhsp": [
-                        {"type":"VARREF","name":"t.e","addr":"(JEB)","loc":"d,91:18,91:19","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                        {"type":"VARREF","name":"t.e","addr":"(KEB)","loc":"d,91:18,91:19","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                       ]}
                     ]}
                   ]}
                 ]}
               ],
                "thensp": [
-                {"type":"DISPLAY","name":"","addr":"(KEB)","loc":"d,91:43,91:49",
+                {"type":"DISPLAY","name":"","addr":"(LEB)","loc":"d,91:43,91:49",
                  "fmtp": [
-                  {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:91:  got='h%x exp='h1\\n","addr":"(LEB)","loc":"d,91:43,91:49","dtypep":"(SB)",
+                  {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:91:  got='h%x exp='h1\\n","addr":"(MEB)","loc":"d,91:43,91:49","dtypep":"(SB)",
                    "exprsp": [
-                    {"type":"ARRAYSEL","name":"","addr":"(MEB)","loc":"d,91:122,91:123","dtypep":"(UB)",
+                    {"type":"ARRAYSEL","name":"","addr":"(NEB)","loc":"d,91:122,91:123","dtypep":"(BC)",
                      "fromp": [
-                      {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(NEB)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(OEB)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ],
                      "bitp": [
-                      {"type":"AND","name":"","addr":"(OEB)","loc":"d,91:122,91:123","dtypep":"(FC)",
+                      {"type":"AND","name":"","addr":"(PEB)","loc":"d,91:122,91:123","dtypep":"(GC)",
                        "lhsp": [
-                        {"type":"CONST","name":"32'h7","addr":"(PEB)","loc":"d,91:122,91:123","dtypep":"(HC)"}
+                        {"type":"CONST","name":"32'h7","addr":"(QEB)","loc":"d,91:122,91:123","dtypep":"(IC)"}
                       ],
                        "rhsp": [
-                        {"type":"CCAST","name":"","addr":"(QEB)","loc":"d,91:122,91:123","dtypep":"(FC)","size":32,
+                        {"type":"CCAST","name":"","addr":"(REB)","loc":"d,91:122,91:123","dtypep":"(GC)","size":32,
                          "lhsp": [
-                          {"type":"VARREF","name":"t.e","addr":"(REB)","loc":"d,91:122,91:123","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                          {"type":"VARREF","name":"t.e","addr":"(SEB)","loc":"d,91:122,91:123","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                         ]}
                       ]}
                     ]}
                   ],"scopeNamep": []}
                 ],"filep": []},
-                {"type":"STOP","name":"","addr":"(SEB)","loc":"d,91:139,91:144"}
+                {"type":"STOP","name":"","addr":"(TEB)","loc":"d,91:139,91:144"}
               ],"elsesp": []},
-              {"type":"IF","name":"","addr":"(TEB)","loc":"d,92:13,92:15",
+              {"type":"IF","name":"","addr":"(UEB)","loc":"d,92:13,92:15",
                "condp": [
-                {"type":"NEQ","name":"","addr":"(UEB)","loc":"d,92:29,92:32","dtypep":"(GB)",
+                {"type":"NEQ","name":"","addr":"(VEB)","loc":"d,92:29,92:32","dtypep":"(GB)",
                  "lhsp": [
-                  {"type":"CONST","name":"4'h1","addr":"(VEB)","loc":"d,92:34,92:37","dtypep":"(UB)"}
+                  {"type":"CONST","name":"4'h1","addr":"(WEB)","loc":"d,92:34,92:37","dtypep":"(UB)"}
                 ],
                  "rhsp": [
-                  {"type":"ARRAYSEL","name":"","addr":"(WEB)","loc":"d,92:18,92:19","dtypep":"(UB)",
+                  {"type":"ARRAYSEL","name":"","addr":"(XEB)","loc":"d,92:18,92:19","dtypep":"(BC)",
                    "fromp": [
-                    {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(XEB)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(YEB)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ],
                    "bitp": [
-                    {"type":"AND","name":"","addr":"(YEB)","loc":"d,92:18,92:19","dtypep":"(FC)",
+                    {"type":"AND","name":"","addr":"(ZEB)","loc":"d,92:18,92:19","dtypep":"(GC)",
                      "lhsp": [
-                      {"type":"CONST","name":"32'h7","addr":"(ZEB)","loc":"d,92:18,92:19","dtypep":"(HC)"}
+                      {"type":"CONST","name":"32'h7","addr":"(AFB)","loc":"d,92:18,92:19","dtypep":"(IC)"}
                     ],
                      "rhsp": [
-                      {"type":"CCAST","name":"","addr":"(AFB)","loc":"d,92:18,92:19","dtypep":"(FC)","size":32,
+                      {"type":"CCAST","name":"","addr":"(BFB)","loc":"d,92:18,92:19","dtypep":"(GC)","size":32,
                        "lhsp": [
-                        {"type":"VARREF","name":"t.e","addr":"(BFB)","loc":"d,92:18,92:19","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                        {"type":"VARREF","name":"t.e","addr":"(CFB)","loc":"d,92:18,92:19","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                       ]}
                     ]}
                   ]}
                 ]}
               ],
                "thensp": [
-                {"type":"DISPLAY","name":"","addr":"(CFB)","loc":"d,92:46,92:52",
+                {"type":"DISPLAY","name":"","addr":"(DFB)","loc":"d,92:46,92:52",
                  "fmtp": [
-                  {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:92:  got='h%x exp='h1\\n","addr":"(DFB)","loc":"d,92:46,92:52","dtypep":"(SB)",
+                  {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:92:  got='h%x exp='h1\\n","addr":"(EFB)","loc":"d,92:46,92:52","dtypep":"(SB)",
                    "exprsp": [
-                    {"type":"ARRAYSEL","name":"","addr":"(EFB)","loc":"d,92:125,92:126","dtypep":"(UB)",
+                    {"type":"ARRAYSEL","name":"","addr":"(FFB)","loc":"d,92:125,92:126","dtypep":"(BC)",
                      "fromp": [
-                      {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(FFB)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(GFB)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ],
                      "bitp": [
-                      {"type":"AND","name":"","addr":"(GFB)","loc":"d,92:125,92:126","dtypep":"(FC)",
+                      {"type":"AND","name":"","addr":"(HFB)","loc":"d,92:125,92:126","dtypep":"(GC)",
                        "lhsp": [
-                        {"type":"CONST","name":"32'h7","addr":"(HFB)","loc":"d,92:125,92:126","dtypep":"(HC)"}
+                        {"type":"CONST","name":"32'h7","addr":"(IFB)","loc":"d,92:125,92:126","dtypep":"(IC)"}
                       ],
                        "rhsp": [
-                        {"type":"CCAST","name":"","addr":"(IFB)","loc":"d,92:125,92:126","dtypep":"(FC)","size":32,
+                        {"type":"CCAST","name":"","addr":"(JFB)","loc":"d,92:125,92:126","dtypep":"(GC)","size":32,
                          "lhsp": [
-                          {"type":"VARREF","name":"t.e","addr":"(JFB)","loc":"d,92:125,92:126","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                          {"type":"VARREF","name":"t.e","addr":"(KFB)","loc":"d,92:125,92:126","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                         ]}
                       ]}
                     ]}
                   ],"scopeNamep": []}
                 ],"filep": []},
-                {"type":"STOP","name":"","addr":"(KFB)","loc":"d,92:145,92:150"}
+                {"type":"STOP","name":"","addr":"(LFB)","loc":"d,92:145,92:150"}
               ],"elsesp": []},
-              {"type":"IF","name":"","addr":"(LFB)","loc":"d,93:13,93:15",
+              {"type":"IF","name":"","addr":"(MFB)","loc":"d,93:13,93:15",
                "condp": [
-                {"type":"NEQ","name":"","addr":"(MFB)","loc":"d,93:29,93:32","dtypep":"(GB)",
+                {"type":"NEQ","name":"","addr":"(NFB)","loc":"d,93:29,93:32","dtypep":"(GB)",
                  "lhsp": [
-                  {"type":"CONST","name":"4'h3","addr":"(NFB)","loc":"d,93:34,93:37","dtypep":"(UB)"}
+                  {"type":"CONST","name":"4'h3","addr":"(OFB)","loc":"d,93:34,93:37","dtypep":"(UB)"}
                 ],
                  "rhsp": [
-                  {"type":"ARRAYSEL","name":"","addr":"(OFB)","loc":"d,93:18,93:19","dtypep":"(UB)",
+                  {"type":"ARRAYSEL","name":"","addr":"(PFB)","loc":"d,93:18,93:19","dtypep":"(BC)",
                    "fromp": [
-                    {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(PFB)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(QFB)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ],
                    "bitp": [
-                    {"type":"AND","name":"","addr":"(QFB)","loc":"d,93:18,93:19","dtypep":"(FC)",
+                    {"type":"AND","name":"","addr":"(RFB)","loc":"d,93:18,93:19","dtypep":"(GC)",
                      "lhsp": [
-                      {"type":"CONST","name":"32'h7","addr":"(RFB)","loc":"d,93:18,93:19","dtypep":"(HC)"}
+                      {"type":"CONST","name":"32'h7","addr":"(SFB)","loc":"d,93:18,93:19","dtypep":"(IC)"}
                     ],
                      "rhsp": [
-                      {"type":"ARRAYSEL","name":"","addr":"(SFB)","loc":"d,93:18,93:19","dtypep":"(FC)",
+                      {"type":"ARRAYSEL","name":"","addr":"(TFB)","loc":"d,93:18,93:19","dtypep":"(GC)",
                        "fromp": [
-                        {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(TFB)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                        {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(UFB)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                       ],
                        "bitp": [
-                        {"type":"AND","name":"","addr":"(UFB)","loc":"d,93:18,93:19","dtypep":"(FC)",
+                        {"type":"AND","name":"","addr":"(VFB)","loc":"d,93:18,93:19","dtypep":"(GC)",
                          "lhsp": [
-                          {"type":"CONST","name":"32'h7","addr":"(VFB)","loc":"d,93:18,93:19","dtypep":"(HC)"}
+                          {"type":"CONST","name":"32'h7","addr":"(WFB)","loc":"d,93:18,93:19","dtypep":"(IC)"}
                         ],
                          "rhsp": [
-                          {"type":"CCAST","name":"","addr":"(WFB)","loc":"d,93:18,93:19","dtypep":"(FC)","size":32,
+                          {"type":"CCAST","name":"","addr":"(XFB)","loc":"d,93:18,93:19","dtypep":"(GC)","size":32,
                            "lhsp": [
-                            {"type":"VARREF","name":"t.e","addr":"(XFB)","loc":"d,93:18,93:19","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                            {"type":"VARREF","name":"t.e","addr":"(YFB)","loc":"d,93:18,93:19","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                           ]}
                         ]}
                       ]}
@@ -2186,33 +2186,33 @@
                 ]}
               ],
                "thensp": [
-                {"type":"DISPLAY","name":"","addr":"(YFB)","loc":"d,93:46,93:52",
+                {"type":"DISPLAY","name":"","addr":"(ZFB)","loc":"d,93:46,93:52",
                  "fmtp": [
-                  {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:93:  got='h%x exp='h3\\n","addr":"(ZFB)","loc":"d,93:46,93:52","dtypep":"(SB)",
+                  {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:93:  got='h%x exp='h3\\n","addr":"(AGB)","loc":"d,93:46,93:52","dtypep":"(SB)",
                    "exprsp": [
-                    {"type":"ARRAYSEL","name":"","addr":"(AGB)","loc":"d,93:125,93:126","dtypep":"(UB)",
+                    {"type":"ARRAYSEL","name":"","addr":"(BGB)","loc":"d,93:125,93:126","dtypep":"(BC)",
                      "fromp": [
-                      {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(BGB)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(CGB)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ],
                      "bitp": [
-                      {"type":"AND","name":"","addr":"(CGB)","loc":"d,93:125,93:126","dtypep":"(FC)",
+                      {"type":"AND","name":"","addr":"(DGB)","loc":"d,93:125,93:126","dtypep":"(GC)",
                        "lhsp": [
-                        {"type":"CONST","name":"32'h7","addr":"(DGB)","loc":"d,93:125,93:126","dtypep":"(HC)"}
+                        {"type":"CONST","name":"32'h7","addr":"(EGB)","loc":"d,93:125,93:126","dtypep":"(IC)"}
                       ],
                        "rhsp": [
-                        {"type":"ARRAYSEL","name":"","addr":"(EGB)","loc":"d,93:125,93:126","dtypep":"(FC)",
+                        {"type":"ARRAYSEL","name":"","addr":"(FGB)","loc":"d,93:125,93:126","dtypep":"(GC)",
                          "fromp": [
-                          {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(FGB)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"RD","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                          {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(GGB)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                         ],
                          "bitp": [
-                          {"type":"AND","name":"","addr":"(GGB)","loc":"d,93:125,93:126","dtypep":"(FC)",
+                          {"type":"AND","name":"","addr":"(HGB)","loc":"d,93:125,93:126","dtypep":"(GC)",
                            "lhsp": [
-                            {"type":"CONST","name":"32'h7","addr":"(HGB)","loc":"d,93:125,93:126","dtypep":"(HC)"}
+                            {"type":"CONST","name":"32'h7","addr":"(IGB)","loc":"d,93:125,93:126","dtypep":"(IC)"}
                           ],
                            "rhsp": [
-                            {"type":"CCAST","name":"","addr":"(IGB)","loc":"d,93:125,93:126","dtypep":"(FC)","size":32,
+                            {"type":"CCAST","name":"","addr":"(JGB)","loc":"d,93:125,93:126","dtypep":"(GC)","size":32,
                              "lhsp": [
-                              {"type":"VARREF","name":"t.e","addr":"(JGB)","loc":"d,93:125,93:126","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                              {"type":"VARREF","name":"t.e","addr":"(KGB)","loc":"d,93:125,93:126","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                             ]}
                           ]}
                         ]}
@@ -2220,138 +2220,138 @@
                     ]}
                   ],"scopeNamep": []}
                 ],"filep": []},
-                {"type":"STOP","name":"","addr":"(KGB)","loc":"d,93:145,93:150"}
+                {"type":"STOP","name":"","addr":"(LGB)","loc":"d,93:145,93:150"}
               ],"elsesp": []},
-              {"type":"IF","name":"","addr":"(LGB)","loc":"d,94:13,94:15",
+              {"type":"IF","name":"","addr":"(MGB)","loc":"d,94:13,94:15",
                "condp": [
-                {"type":"NEQ","name":"","addr":"(MGB)","loc":"d,94:26,94:29","dtypep":"(GB)",
+                {"type":"NEQ","name":"","addr":"(NGB)","loc":"d,94:26,94:29","dtypep":"(GB)",
                  "lhsp": [
-                  {"type":"CONST","name":"4'h3","addr":"(NGB)","loc":"d,94:31,94:34","dtypep":"(UB)"}
+                  {"type":"CONST","name":"4'h3","addr":"(OGB)","loc":"d,94:31,94:34","dtypep":"(UB)"}
                 ],
                  "rhsp": [
-                  {"type":"ARRAYSEL","name":"","addr":"(OGB)","loc":"d,94:18,94:19","dtypep":"(UB)",
+                  {"type":"ARRAYSEL","name":"","addr":"(PGB)","loc":"d,94:18,94:19","dtypep":"(BC)",
                    "fromp": [
-                    {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(PGB)","loc":"d,17:12,17:16","dtypep":"(WI)","access":"RD","varp":"(XI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(QGB)","loc":"d,17:12,17:16","dtypep":"(XI)","access":"RD","varp":"(YI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ],
                    "bitp": [
-                    {"type":"AND","name":"","addr":"(QGB)","loc":"d,94:18,94:19","dtypep":"(FC)",
+                    {"type":"AND","name":"","addr":"(RGB)","loc":"d,94:18,94:19","dtypep":"(GC)",
                      "lhsp": [
-                      {"type":"CONST","name":"32'h7","addr":"(RGB)","loc":"d,94:18,94:19","dtypep":"(HC)"}
+                      {"type":"CONST","name":"32'h7","addr":"(SGB)","loc":"d,94:18,94:19","dtypep":"(IC)"}
                     ],
                      "rhsp": [
-                      {"type":"CCAST","name":"","addr":"(SGB)","loc":"d,94:18,94:19","dtypep":"(FC)","size":32,
+                      {"type":"CCAST","name":"","addr":"(TGB)","loc":"d,94:18,94:19","dtypep":"(GC)","size":32,
                        "lhsp": [
-                        {"type":"VARREF","name":"t.e","addr":"(TGB)","loc":"d,94:18,94:19","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                        {"type":"VARREF","name":"t.e","addr":"(UGB)","loc":"d,94:18,94:19","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                       ]}
                     ]}
                   ]}
                 ]}
               ],
                "thensp": [
-                {"type":"DISPLAY","name":"","addr":"(UGB)","loc":"d,94:43,94:49",
+                {"type":"DISPLAY","name":"","addr":"(VGB)","loc":"d,94:43,94:49",
                  "fmtp": [
-                  {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:94:  got='h%x exp='h3\\n","addr":"(VGB)","loc":"d,94:43,94:49","dtypep":"(SB)",
+                  {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:94:  got='h%x exp='h3\\n","addr":"(WGB)","loc":"d,94:43,94:49","dtypep":"(SB)",
                    "exprsp": [
-                    {"type":"ARRAYSEL","name":"","addr":"(WGB)","loc":"d,94:122,94:123","dtypep":"(UB)",
+                    {"type":"ARRAYSEL","name":"","addr":"(XGB)","loc":"d,94:122,94:123","dtypep":"(BC)",
                      "fromp": [
-                      {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(XGB)","loc":"d,17:12,17:16","dtypep":"(WI)","access":"RD","varp":"(XI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(YGB)","loc":"d,17:12,17:16","dtypep":"(XI)","access":"RD","varp":"(YI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ],
                      "bitp": [
-                      {"type":"AND","name":"","addr":"(YGB)","loc":"d,94:122,94:123","dtypep":"(FC)",
+                      {"type":"AND","name":"","addr":"(ZGB)","loc":"d,94:122,94:123","dtypep":"(GC)",
                        "lhsp": [
-                        {"type":"CONST","name":"32'h7","addr":"(ZGB)","loc":"d,94:122,94:123","dtypep":"(HC)"}
+                        {"type":"CONST","name":"32'h7","addr":"(AHB)","loc":"d,94:122,94:123","dtypep":"(IC)"}
                       ],
                        "rhsp": [
-                        {"type":"CCAST","name":"","addr":"(AHB)","loc":"d,94:122,94:123","dtypep":"(FC)","size":32,
+                        {"type":"CCAST","name":"","addr":"(BHB)","loc":"d,94:122,94:123","dtypep":"(GC)","size":32,
                          "lhsp": [
-                          {"type":"VARREF","name":"t.e","addr":"(BHB)","loc":"d,94:122,94:123","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                          {"type":"VARREF","name":"t.e","addr":"(CHB)","loc":"d,94:122,94:123","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                         ]}
                       ]}
                     ]}
                   ],"scopeNamep": []}
                 ],"filep": []},
-                {"type":"STOP","name":"","addr":"(CHB)","loc":"d,94:139,94:144"}
+                {"type":"STOP","name":"","addr":"(DHB)","loc":"d,94:139,94:144"}
               ],"elsesp": []},
-              {"type":"IF","name":"","addr":"(DHB)","loc":"d,95:13,95:15",
+              {"type":"IF","name":"","addr":"(EHB)","loc":"d,95:13,95:15",
                "condp": [
-                {"type":"NEQ","name":"","addr":"(EHB)","loc":"d,95:29,95:32","dtypep":"(GB)",
+                {"type":"NEQ","name":"","addr":"(FHB)","loc":"d,95:29,95:32","dtypep":"(GB)",
                  "lhsp": [
-                  {"type":"CONST","name":"4'h3","addr":"(FHB)","loc":"d,95:34,95:37","dtypep":"(UB)"}
+                  {"type":"CONST","name":"4'h3","addr":"(GHB)","loc":"d,95:34,95:37","dtypep":"(UB)"}
                 ],
                  "rhsp": [
-                  {"type":"ARRAYSEL","name":"","addr":"(GHB)","loc":"d,95:18,95:19","dtypep":"(UB)",
+                  {"type":"ARRAYSEL","name":"","addr":"(HHB)","loc":"d,95:18,95:19","dtypep":"(BC)",
                    "fromp": [
-                    {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(HHB)","loc":"d,17:12,17:16","dtypep":"(WI)","access":"RD","varp":"(XI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(IHB)","loc":"d,17:12,17:16","dtypep":"(XI)","access":"RD","varp":"(YI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ],
                    "bitp": [
-                    {"type":"AND","name":"","addr":"(IHB)","loc":"d,95:18,95:19","dtypep":"(FC)",
+                    {"type":"AND","name":"","addr":"(JHB)","loc":"d,95:18,95:19","dtypep":"(GC)",
                      "lhsp": [
-                      {"type":"CONST","name":"32'h7","addr":"(JHB)","loc":"d,95:18,95:19","dtypep":"(HC)"}
+                      {"type":"CONST","name":"32'h7","addr":"(KHB)","loc":"d,95:18,95:19","dtypep":"(IC)"}
                     ],
                      "rhsp": [
-                      {"type":"CCAST","name":"","addr":"(KHB)","loc":"d,95:18,95:19","dtypep":"(FC)","size":32,
+                      {"type":"CCAST","name":"","addr":"(LHB)","loc":"d,95:18,95:19","dtypep":"(GC)","size":32,
                        "lhsp": [
-                        {"type":"VARREF","name":"t.e","addr":"(LHB)","loc":"d,95:18,95:19","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                        {"type":"VARREF","name":"t.e","addr":"(MHB)","loc":"d,95:18,95:19","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                       ]}
                     ]}
                   ]}
                 ]}
               ],
                "thensp": [
-                {"type":"DISPLAY","name":"","addr":"(MHB)","loc":"d,95:46,95:52",
+                {"type":"DISPLAY","name":"","addr":"(NHB)","loc":"d,95:46,95:52",
                  "fmtp": [
-                  {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:95:  got='h%x exp='h3\\n","addr":"(NHB)","loc":"d,95:46,95:52","dtypep":"(SB)",
+                  {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:95:  got='h%x exp='h3\\n","addr":"(OHB)","loc":"d,95:46,95:52","dtypep":"(SB)",
                    "exprsp": [
-                    {"type":"ARRAYSEL","name":"","addr":"(OHB)","loc":"d,95:125,95:126","dtypep":"(UB)",
+                    {"type":"ARRAYSEL","name":"","addr":"(PHB)","loc":"d,95:125,95:126","dtypep":"(BC)",
                      "fromp": [
-                      {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(PHB)","loc":"d,17:12,17:16","dtypep":"(WI)","access":"RD","varp":"(XI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(QHB)","loc":"d,17:12,17:16","dtypep":"(XI)","access":"RD","varp":"(YI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ],
                      "bitp": [
-                      {"type":"AND","name":"","addr":"(QHB)","loc":"d,95:125,95:126","dtypep":"(FC)",
+                      {"type":"AND","name":"","addr":"(RHB)","loc":"d,95:125,95:126","dtypep":"(GC)",
                        "lhsp": [
-                        {"type":"CONST","name":"32'h7","addr":"(RHB)","loc":"d,95:125,95:126","dtypep":"(HC)"}
+                        {"type":"CONST","name":"32'h7","addr":"(SHB)","loc":"d,95:125,95:126","dtypep":"(IC)"}
                       ],
                        "rhsp": [
-                        {"type":"CCAST","name":"","addr":"(SHB)","loc":"d,95:125,95:126","dtypep":"(FC)","size":32,
+                        {"type":"CCAST","name":"","addr":"(THB)","loc":"d,95:125,95:126","dtypep":"(GC)","size":32,
                          "lhsp": [
-                          {"type":"VARREF","name":"t.e","addr":"(THB)","loc":"d,95:125,95:126","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                          {"type":"VARREF","name":"t.e","addr":"(UHB)","loc":"d,95:125,95:126","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                         ]}
                       ]}
                     ]}
                   ],"scopeNamep": []}
                 ],"filep": []},
-                {"type":"STOP","name":"","addr":"(UHB)","loc":"d,95:145,95:150"}
+                {"type":"STOP","name":"","addr":"(VHB)","loc":"d,95:145,95:150"}
               ],"elsesp": []},
-              {"type":"IF","name":"","addr":"(VHB)","loc":"d,96:13,96:15",
+              {"type":"IF","name":"","addr":"(WHB)","loc":"d,96:13,96:15",
                "condp": [
-                {"type":"NEQ","name":"","addr":"(WHB)","loc":"d,96:29,96:32","dtypep":"(GB)",
+                {"type":"NEQ","name":"","addr":"(XHB)","loc":"d,96:29,96:32","dtypep":"(GB)",
                  "lhsp": [
-                  {"type":"CONST","name":"4'h1","addr":"(XHB)","loc":"d,96:34,96:37","dtypep":"(UB)"}
+                  {"type":"CONST","name":"4'h1","addr":"(YHB)","loc":"d,96:34,96:37","dtypep":"(UB)"}
                 ],
                  "rhsp": [
-                  {"type":"ARRAYSEL","name":"","addr":"(YHB)","loc":"d,96:18,96:19","dtypep":"(UB)",
+                  {"type":"ARRAYSEL","name":"","addr":"(ZHB)","loc":"d,96:18,96:19","dtypep":"(BC)",
                    "fromp": [
-                    {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(ZHB)","loc":"d,17:12,17:16","dtypep":"(WI)","access":"RD","varp":"(XI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(AIB)","loc":"d,17:12,17:16","dtypep":"(XI)","access":"RD","varp":"(YI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ],
                    "bitp": [
-                    {"type":"AND","name":"","addr":"(AIB)","loc":"d,96:18,96:19","dtypep":"(FC)",
+                    {"type":"AND","name":"","addr":"(BIB)","loc":"d,96:18,96:19","dtypep":"(GC)",
                      "lhsp": [
-                      {"type":"CONST","name":"32'h7","addr":"(BIB)","loc":"d,96:18,96:19","dtypep":"(HC)"}
+                      {"type":"CONST","name":"32'h7","addr":"(CIB)","loc":"d,96:18,96:19","dtypep":"(IC)"}
                     ],
                      "rhsp": [
-                      {"type":"ARRAYSEL","name":"","addr":"(CIB)","loc":"d,96:18,96:19","dtypep":"(FC)",
+                      {"type":"ARRAYSEL","name":"","addr":"(DIB)","loc":"d,96:18,96:19","dtypep":"(GC)",
                        "fromp": [
-                        {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(DIB)","loc":"d,17:12,17:16","dtypep":"(WI)","access":"RD","varp":"(XI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                        {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(EIB)","loc":"d,17:12,17:16","dtypep":"(XI)","access":"RD","varp":"(YI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                       ],
                        "bitp": [
-                        {"type":"AND","name":"","addr":"(EIB)","loc":"d,96:18,96:19","dtypep":"(FC)",
+                        {"type":"AND","name":"","addr":"(FIB)","loc":"d,96:18,96:19","dtypep":"(GC)",
                          "lhsp": [
-                          {"type":"CONST","name":"32'h7","addr":"(FIB)","loc":"d,96:18,96:19","dtypep":"(HC)"}
+                          {"type":"CONST","name":"32'h7","addr":"(GIB)","loc":"d,96:18,96:19","dtypep":"(IC)"}
                         ],
                          "rhsp": [
-                          {"type":"CCAST","name":"","addr":"(GIB)","loc":"d,96:18,96:19","dtypep":"(FC)","size":32,
+                          {"type":"CCAST","name":"","addr":"(HIB)","loc":"d,96:18,96:19","dtypep":"(GC)","size":32,
                            "lhsp": [
-                            {"type":"VARREF","name":"t.e","addr":"(HIB)","loc":"d,96:18,96:19","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                            {"type":"VARREF","name":"t.e","addr":"(IIB)","loc":"d,96:18,96:19","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                           ]}
                         ]}
                       ]}
@@ -2360,33 +2360,33 @@
                 ]}
               ],
                "thensp": [
-                {"type":"DISPLAY","name":"","addr":"(IIB)","loc":"d,96:46,96:52",
+                {"type":"DISPLAY","name":"","addr":"(JIB)","loc":"d,96:46,96:52",
                  "fmtp": [
-                  {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:96:  got='h%x exp='h1\\n","addr":"(JIB)","loc":"d,96:46,96:52","dtypep":"(SB)",
+                  {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:96:  got='h%x exp='h1\\n","addr":"(KIB)","loc":"d,96:46,96:52","dtypep":"(SB)",
                    "exprsp": [
-                    {"type":"ARRAYSEL","name":"","addr":"(KIB)","loc":"d,96:125,96:126","dtypep":"(UB)",
+                    {"type":"ARRAYSEL","name":"","addr":"(LIB)","loc":"d,96:125,96:126","dtypep":"(BC)",
                      "fromp": [
-                      {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(LIB)","loc":"d,17:12,17:16","dtypep":"(WI)","access":"RD","varp":"(XI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(MIB)","loc":"d,17:12,17:16","dtypep":"(XI)","access":"RD","varp":"(YI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ],
                      "bitp": [
-                      {"type":"AND","name":"","addr":"(MIB)","loc":"d,96:125,96:126","dtypep":"(FC)",
+                      {"type":"AND","name":"","addr":"(NIB)","loc":"d,96:125,96:126","dtypep":"(GC)",
                        "lhsp": [
-                        {"type":"CONST","name":"32'h7","addr":"(NIB)","loc":"d,96:125,96:126","dtypep":"(HC)"}
+                        {"type":"CONST","name":"32'h7","addr":"(OIB)","loc":"d,96:125,96:126","dtypep":"(IC)"}
                       ],
                        "rhsp": [
-                        {"type":"ARRAYSEL","name":"","addr":"(OIB)","loc":"d,96:125,96:126","dtypep":"(FC)",
+                        {"type":"ARRAYSEL","name":"","addr":"(PIB)","loc":"d,96:125,96:126","dtypep":"(GC)",
                          "fromp": [
-                          {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(PIB)","loc":"d,17:12,17:16","dtypep":"(WI)","access":"RD","varp":"(XI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                          {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(QIB)","loc":"d,17:12,17:16","dtypep":"(XI)","access":"RD","varp":"(YI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                         ],
                          "bitp": [
-                          {"type":"AND","name":"","addr":"(QIB)","loc":"d,96:125,96:126","dtypep":"(FC)",
+                          {"type":"AND","name":"","addr":"(RIB)","loc":"d,96:125,96:126","dtypep":"(GC)",
                            "lhsp": [
-                            {"type":"CONST","name":"32'h7","addr":"(RIB)","loc":"d,96:125,96:126","dtypep":"(HC)"}
+                            {"type":"CONST","name":"32'h7","addr":"(SIB)","loc":"d,96:125,96:126","dtypep":"(IC)"}
                           ],
                            "rhsp": [
-                            {"type":"CCAST","name":"","addr":"(SIB)","loc":"d,96:125,96:126","dtypep":"(FC)","size":32,
+                            {"type":"CCAST","name":"","addr":"(TIB)","loc":"d,96:125,96:126","dtypep":"(GC)","size":32,
                              "lhsp": [
-                              {"type":"VARREF","name":"t.e","addr":"(TIB)","loc":"d,96:125,96:126","dtypep":"(FC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                              {"type":"VARREF","name":"t.e","addr":"(UIB)","loc":"d,96:125,96:126","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                             ]}
                           ]}
                         ]}
@@ -2394,615 +2394,615 @@
                     ]}
                   ],"scopeNamep": []}
                 ],"filep": []},
-                {"type":"STOP","name":"","addr":"(UIB)","loc":"d,96:145,96:150"}
+                {"type":"STOP","name":"","addr":"(VIB)","loc":"d,96:145,96:150"}
               ],"elsesp": []},
-              {"type":"ASSIGNDLY","name":"","addr":"(VIB)","loc":"d,97:12,97:14","dtypep":"(UB)",
+              {"type":"ASSIGNDLY","name":"","addr":"(WIB)","loc":"d,97:12,97:14","dtypep":"(UB)",
                "rhsp": [
-                {"type":"CONST","name":"4'h1","addr":"(WIB)","loc":"d,97:15,97:18","dtypep":"(UB)"}
+                {"type":"CONST","name":"4'h1","addr":"(XIB)","loc":"d,97:15,97:18","dtypep":"(UB)"}
               ],
                "lhsp": [
-                {"type":"VARREF","name":"__Vdly__t.e","addr":"(XIB)","loc":"d,97:10,97:11","dtypep":"(UB)","access":"WR","varp":"(KQ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                {"type":"VARREF","name":"__Vdly__t.e","addr":"(YIB)","loc":"d,97:10,97:11","dtypep":"(UB)","access":"WR","varp":"(LQ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
               ],"timingControlp": []}
             ],
              "elsesp": [
-              {"type":"IF","name":"","addr":"(YIB)","loc":"d,99:12,99:14",
+              {"type":"IF","name":"","addr":"(ZIB)","loc":"d,99:12,99:14",
                "condp": [
-                {"type":"EQ","name":"","addr":"(ZIB)","loc":"d,99:19,99:21","dtypep":"(GB)",
+                {"type":"EQ","name":"","addr":"(AJB)","loc":"d,99:19,99:21","dtypep":"(GB)",
                  "lhsp": [
-                  {"type":"CONST","name":"32'sh63","addr":"(AJB)","loc":"d,99:21,99:23","dtypep":"(LB)"}
+                  {"type":"CONST","name":"32'sh63","addr":"(BJB)","loc":"d,99:21,99:23","dtypep":"(LB)"}
                 ],
                  "rhsp": [
-                  {"type":"VARREF","name":"t.cyc","addr":"(BJB)","loc":"d,99:16,99:19","dtypep":"(S)","access":"RD","varp":"(R)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"t.cyc","addr":"(CJB)","loc":"d,99:16,99:19","dtypep":"(S)","access":"RD","varp":"(R)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                 ]}
               ],
                "thensp": [
-                {"type":"DISPLAY","name":"","addr":"(CJB)","loc":"d,100:10,100:16",
+                {"type":"DISPLAY","name":"","addr":"(DJB)","loc":"d,100:10,100:16",
                  "fmtp": [
-                  {"type":"SFORMATF","name":"*-* All Finished *-*\\n","addr":"(DJB)","loc":"d,100:10,100:16","dtypep":"(SB)","exprsp": [],"scopeNamep": []}
+                  {"type":"SFORMATF","name":"*-* All Finished *-*\\n","addr":"(EJB)","loc":"d,100:10,100:16","dtypep":"(SB)","exprsp": [],"scopeNamep": []}
                 ],"filep": []},
-                {"type":"FINISH","name":"","addr":"(EJB)","loc":"d,101:10,101:17"}
+                {"type":"FINISH","name":"","addr":"(FJB)","loc":"d,101:10,101:17"}
               ],"elsesp": []}
             ]}
           ]}
         ]}
       ]},
-      {"type":"ASSIGN","name":"","addr":"(FJB)","loc":"d,23:17,23:20","dtypep":"(S)",
+      {"type":"ASSIGN","name":"","addr":"(GJB)","loc":"d,23:17,23:20","dtypep":"(S)",
        "rhsp": [
-        {"type":"VARREF","name":"__Vdly__t.cyc","addr":"(GJB)","loc":"d,23:17,23:20","dtypep":"(S)","access":"RD","varp":"(GQ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"__Vdly__t.cyc","addr":"(HJB)","loc":"d,23:17,23:20","dtypep":"(S)","access":"RD","varp":"(HQ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"t.cyc","addr":"(HJB)","loc":"d,23:17,23:20","dtypep":"(S)","access":"WR","varp":"(R)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"t.cyc","addr":"(IJB)","loc":"d,23:17,23:20","dtypep":"(S)","access":"WR","varp":"(R)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []},
-      {"type":"ASSIGN","name":"","addr":"(IJB)","loc":"d,24:9,24:10","dtypep":"(UB)",
+      {"type":"ASSIGN","name":"","addr":"(JJB)","loc":"d,24:9,24:10","dtypep":"(UB)",
        "rhsp": [
-        {"type":"VARREF","name":"__Vdly__t.e","addr":"(JJB)","loc":"d,24:9,24:10","dtypep":"(UB)","access":"RD","varp":"(KQ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"__Vdly__t.e","addr":"(KJB)","loc":"d,24:9,24:10","dtypep":"(UB)","access":"RD","varp":"(LQ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"t.e","addr":"(KJB)","loc":"d,24:9,24:10","dtypep":"(UB)","access":"WR","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"t.e","addr":"(LJB)","loc":"d,24:9,24:10","dtypep":"(UB)","access":"WR","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []}
     ]},
     {"type":"CFUNC","name":"_eval_nba","addr":"(G)","loc":"a,0:0,0:0","scopep":"(Z)","argsp": [],"varsp": [],
      "stmtsp": [
-      {"type":"IF","name":"","addr":"(LJB)","loc":"d,11:8,11:9",
+      {"type":"IF","name":"","addr":"(MJB)","loc":"d,11:8,11:9",
        "condp": [
-        {"type":"AND","name":"","addr":"(MJB)","loc":"d,11:8,11:9","dtypep":"(JN)",
+        {"type":"AND","name":"","addr":"(NJB)","loc":"d,11:8,11:9","dtypep":"(KN)",
          "lhsp": [
-          {"type":"CONST","name":"64'h1","addr":"(NJB)","loc":"d,11:8,11:9","dtypep":"(JN)"}
+          {"type":"CONST","name":"64'h1","addr":"(OJB)","loc":"d,11:8,11:9","dtypep":"(KN)"}
         ],
          "rhsp": [
-          {"type":"ARRAYSEL","name":"","addr":"(OJB)","loc":"d,11:8,11:9","dtypep":"(HN)",
+          {"type":"ARRAYSEL","name":"","addr":"(PJB)","loc":"d,11:8,11:9","dtypep":"(IN)",
            "fromp": [
-            {"type":"VARREF","name":"__VnbaTriggered","addr":"(PJB)","loc":"d,11:8,11:9","dtypep":"(W)","access":"RD","varp":"(X)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"__VnbaTriggered","addr":"(QJB)","loc":"d,11:8,11:9","dtypep":"(W)","access":"RD","varp":"(X)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ],
            "bitp": [
-            {"type":"CONST","name":"32'h0","addr":"(QJB)","loc":"d,11:8,11:9","dtypep":"(HC)"}
+            {"type":"CONST","name":"32'h0","addr":"(RJB)","loc":"d,11:8,11:9","dtypep":"(IC)"}
           ]}
         ]}
       ],
        "thensp": [
-        {"type":"STMTEXPR","name":"","addr":"(RJB)","loc":"d,23:17,23:20",
+        {"type":"STMTEXPR","name":"","addr":"(SJB)","loc":"d,23:17,23:20",
          "exprp": [
-          {"type":"CCALL","name":"","addr":"(SJB)","loc":"d,23:17,23:20","dtypep":"(DB)","funcName":"_nba_sequent__TOP__0","funcp":"(FQ)","argsp": []}
+          {"type":"CCALL","name":"","addr":"(TJB)","loc":"d,23:17,23:20","dtypep":"(DB)","funcName":"_nba_sequent__TOP__0","funcp":"(GQ)","argsp": []}
         ]}
       ],"elsesp": []}
     ]},
-    {"type":"CFUNC","name":"_trigger_orInto__act_vec_vec","addr":"(TJB)","loc":"a,0:0,0:0","isStatic":true,"scopep":"(Z)",
+    {"type":"CFUNC","name":"_trigger_orInto__act_vec_vec","addr":"(UJB)","loc":"a,0:0,0:0","isStatic":true,"scopep":"(Z)",
      "argsp": [
-      {"type":"VAR","name":"out","addr":"(UJB)","loc":"a,0:0,0:0","dtypep":"(W)","origName":"out","verilogName":"out","direction":"INOUT","isFuncLocal":true,"lifetime":"NONE","varType":"BLOCKTEMP","dtypeName":"","sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
-      {"type":"ASSIGN","name":"","addr":"(VJB)","loc":"a,0:0,0:0","dtypep":"(W)",
+      {"type":"VAR","name":"out","addr":"(VJB)","loc":"a,0:0,0:0","dtypep":"(W)","origName":"out","verilogName":"out","direction":"INOUT","isFuncLocal":true,"lifetime":"NONE","varType":"BLOCKTEMP","dtypeName":"","sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
+      {"type":"ASSIGN","name":"","addr":"(WJB)","loc":"a,0:0,0:0","dtypep":"(W)",
        "rhsp": [
-        {"type":"CRESET","name":"","addr":"(WJB)","loc":"a,0:0,0:0","dtypep":"(W)","constructing":true}
+        {"type":"CRESET","name":"","addr":"(XJB)","loc":"a,0:0,0:0","dtypep":"(W)","constructing":true}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"out","addr":"(XJB)","loc":"a,0:0,0:0","dtypep":"(W)","access":"WR","varp":"(UJB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"out","addr":"(YJB)","loc":"a,0:0,0:0","dtypep":"(W)","access":"WR","varp":"(VJB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []},
-      {"type":"VAR","name":"in","addr":"(YJB)","loc":"a,0:0,0:0","dtypep":"(W)","origName":"in","verilogName":"in","direction":"CONSTREF","isFuncLocal":true,"lifetime":"NONE","varType":"BLOCKTEMP","dtypeName":"","sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
-      {"type":"ASSIGN","name":"","addr":"(ZJB)","loc":"a,0:0,0:0","dtypep":"(W)",
+      {"type":"VAR","name":"in","addr":"(ZJB)","loc":"a,0:0,0:0","dtypep":"(W)","origName":"in","verilogName":"in","direction":"CONSTREF","isFuncLocal":true,"lifetime":"NONE","varType":"BLOCKTEMP","dtypeName":"","sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
+      {"type":"ASSIGN","name":"","addr":"(AKB)","loc":"a,0:0,0:0","dtypep":"(W)",
        "rhsp": [
-        {"type":"CRESET","name":"","addr":"(AKB)","loc":"a,0:0,0:0","dtypep":"(W)","constructing":true}
+        {"type":"CRESET","name":"","addr":"(BKB)","loc":"a,0:0,0:0","dtypep":"(W)","constructing":true}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"in","addr":"(BKB)","loc":"a,0:0,0:0","dtypep":"(W)","access":"WR","varp":"(YJB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"in","addr":"(CKB)","loc":"a,0:0,0:0","dtypep":"(W)","access":"WR","varp":"(ZJB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []}
     ],
      "varsp": [
-      {"type":"VAR","name":"n","addr":"(CKB)","loc":"a,0:0,0:0","dtypep":"(IP)","origName":"n","verilogName":"n","direction":"NONE","noReset":true,"isFuncLocal":true,"lifetime":"NONE","varType":"BLOCKTEMP","dtypeName":"IData","sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []}
+      {"type":"VAR","name":"n","addr":"(DKB)","loc":"a,0:0,0:0","dtypep":"(JP)","origName":"n","verilogName":"n","direction":"NONE","noReset":true,"isFuncLocal":true,"lifetime":"NONE","varType":"BLOCKTEMP","dtypeName":"IData","sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []}
     ],
      "stmtsp": [
-      {"type":"ASSIGN","name":"","addr":"(DKB)","loc":"a,0:0,0:0","dtypep":"(IP)",
+      {"type":"ASSIGN","name":"","addr":"(EKB)","loc":"a,0:0,0:0","dtypep":"(JP)",
        "rhsp": [
-        {"type":"CONST","name":"32'h0","addr":"(EKB)","loc":"a,0:0,0:0","dtypep":"(HC)"}
+        {"type":"CONST","name":"32'h0","addr":"(FKB)","loc":"a,0:0,0:0","dtypep":"(IC)"}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"n","addr":"(FKB)","loc":"a,0:0,0:0","dtypep":"(IP)","access":"WR","varp":"(CKB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"n","addr":"(GKB)","loc":"a,0:0,0:0","dtypep":"(JP)","access":"WR","varp":"(DKB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []},
-      {"type":"LOOP","name":"","addr":"(GKB)","loc":"d,11:8,11:9","unroll":"default",
+      {"type":"LOOP","name":"","addr":"(HKB)","loc":"d,11:8,11:9","unroll":"default",
        "stmtsp": [
-        {"type":"ASSIGN","name":"","addr":"(HKB)","loc":"d,11:8,11:9","dtypep":"(HN)",
+        {"type":"ASSIGN","name":"","addr":"(IKB)","loc":"d,11:8,11:9","dtypep":"(IN)",
          "rhsp": [
-          {"type":"OR","name":"","addr":"(IKB)","loc":"d,11:8,11:9","dtypep":"(HN)",
+          {"type":"OR","name":"","addr":"(JKB)","loc":"d,11:8,11:9","dtypep":"(IN)",
            "lhsp": [
-            {"type":"ARRAYSEL","name":"","addr":"(JKB)","loc":"d,11:8,11:9","dtypep":"(HN)",
+            {"type":"ARRAYSEL","name":"","addr":"(KKB)","loc":"d,11:8,11:9","dtypep":"(IN)",
              "fromp": [
-              {"type":"VARREF","name":"out","addr":"(KKB)","loc":"d,11:8,11:9","dtypep":"(W)","access":"RD","varp":"(UJB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+              {"type":"VARREF","name":"out","addr":"(LKB)","loc":"d,11:8,11:9","dtypep":"(W)","access":"RD","varp":"(VJB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
             ],
              "bitp": [
-              {"type":"VARREF","name":"n","addr":"(LKB)","loc":"d,11:8,11:9","dtypep":"(IP)","access":"RD","varp":"(CKB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+              {"type":"VARREF","name":"n","addr":"(MKB)","loc":"d,11:8,11:9","dtypep":"(JP)","access":"RD","varp":"(DKB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
             ]}
           ],
            "rhsp": [
-            {"type":"ARRAYSEL","name":"","addr":"(MKB)","loc":"d,11:8,11:9","dtypep":"(HN)",
+            {"type":"ARRAYSEL","name":"","addr":"(NKB)","loc":"d,11:8,11:9","dtypep":"(IN)",
              "fromp": [
-              {"type":"VARREF","name":"in","addr":"(NKB)","loc":"d,11:8,11:9","dtypep":"(W)","access":"RD","varp":"(YJB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+              {"type":"VARREF","name":"in","addr":"(OKB)","loc":"d,11:8,11:9","dtypep":"(W)","access":"RD","varp":"(ZJB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
             ],
              "bitp": [
-              {"type":"VARREF","name":"n","addr":"(OKB)","loc":"d,11:8,11:9","dtypep":"(IP)","access":"RD","varp":"(CKB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+              {"type":"VARREF","name":"n","addr":"(PKB)","loc":"d,11:8,11:9","dtypep":"(JP)","access":"RD","varp":"(DKB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
             ]}
           ]}
         ],
          "lhsp": [
-          {"type":"ARRAYSEL","name":"","addr":"(PKB)","loc":"d,11:8,11:9","dtypep":"(HN)",
+          {"type":"ARRAYSEL","name":"","addr":"(QKB)","loc":"d,11:8,11:9","dtypep":"(IN)",
            "fromp": [
-            {"type":"VARREF","name":"out","addr":"(QKB)","loc":"d,11:8,11:9","dtypep":"(W)","access":"WR","varp":"(UJB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"out","addr":"(RKB)","loc":"d,11:8,11:9","dtypep":"(W)","access":"WR","varp":"(VJB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ],
            "bitp": [
-            {"type":"VARREF","name":"n","addr":"(RKB)","loc":"d,11:8,11:9","dtypep":"(IP)","access":"RD","varp":"(CKB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"n","addr":"(SKB)","loc":"d,11:8,11:9","dtypep":"(JP)","access":"RD","varp":"(DKB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ]}
         ],"timingControlp": []},
-        {"type":"ASSIGN","name":"","addr":"(SKB)","loc":"a,0:0,0:0","dtypep":"(IP)",
+        {"type":"ASSIGN","name":"","addr":"(TKB)","loc":"a,0:0,0:0","dtypep":"(JP)",
          "rhsp": [
-          {"type":"ADD","name":"","addr":"(TKB)","loc":"a,0:0,0:0","dtypep":"(IP)",
+          {"type":"ADD","name":"","addr":"(UKB)","loc":"a,0:0,0:0","dtypep":"(JP)",
            "lhsp": [
-            {"type":"CCAST","name":"","addr":"(UKB)","loc":"a,0:0,0:0","dtypep":"(HC)","size":32,
+            {"type":"CCAST","name":"","addr":"(VKB)","loc":"a,0:0,0:0","dtypep":"(IC)","size":32,
              "lhsp": [
-              {"type":"CONST","name":"32'h1","addr":"(VKB)","loc":"a,0:0,0:0","dtypep":"(HC)"}
+              {"type":"CONST","name":"32'h1","addr":"(WKB)","loc":"a,0:0,0:0","dtypep":"(IC)"}
             ]}
           ],
            "rhsp": [
-            {"type":"VARREF","name":"n","addr":"(WKB)","loc":"a,0:0,0:0","dtypep":"(IP)","access":"RD","varp":"(CKB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"n","addr":"(XKB)","loc":"a,0:0,0:0","dtypep":"(JP)","access":"RD","varp":"(DKB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ]}
         ],
          "lhsp": [
-          {"type":"VARREF","name":"n","addr":"(XKB)","loc":"a,0:0,0:0","dtypep":"(IP)","access":"WR","varp":"(CKB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+          {"type":"VARREF","name":"n","addr":"(YKB)","loc":"a,0:0,0:0","dtypep":"(JP)","access":"WR","varp":"(DKB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
         ],"timingControlp": []},
-        {"type":"LOOPTEST","name":"","addr":"(YKB)","loc":"d,11:8,11:9",
+        {"type":"LOOPTEST","name":"","addr":"(ZKB)","loc":"d,11:8,11:9",
          "condp": [
-          {"type":"GTE","name":"","addr":"(ZKB)","loc":"d,11:8,11:9","dtypep":"(GB)",
+          {"type":"GTE","name":"","addr":"(ALB)","loc":"d,11:8,11:9","dtypep":"(GB)",
            "lhsp": [
-            {"type":"CONST","name":"32'h0","addr":"(ALB)","loc":"d,11:8,11:9","dtypep":"(HC)"}
+            {"type":"CONST","name":"32'h0","addr":"(BLB)","loc":"d,11:8,11:9","dtypep":"(IC)"}
           ],
            "rhsp": [
-            {"type":"VARREF","name":"n","addr":"(BLB)","loc":"d,11:8,11:9","dtypep":"(IP)","access":"RD","varp":"(CKB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"n","addr":"(CLB)","loc":"d,11:8,11:9","dtypep":"(JP)","access":"RD","varp":"(DKB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ]}
         ]}
       ],"contsp": []}
     ]},
-    {"type":"CFUNC","name":"_eval_phase__act","addr":"(CLB)","loc":"a,0:0,0:0","scopep":"(Z)","argsp": [],"varsp": [],
+    {"type":"CFUNC","name":"_eval_phase__act","addr":"(DLB)","loc":"a,0:0,0:0","scopep":"(Z)","argsp": [],"varsp": [],
      "stmtsp": [
-      {"type":"STMTEXPR","name":"","addr":"(DLB)","loc":"d,11:8,11:9",
+      {"type":"STMTEXPR","name":"","addr":"(ELB)","loc":"d,11:8,11:9",
        "exprp": [
-        {"type":"CCALL","name":"","addr":"(ELB)","loc":"d,11:8,11:9","dtypep":"(DB)","funcName":"_eval_triggers_vec__act","funcp":"(FN)","argsp": []}
+        {"type":"CCALL","name":"","addr":"(FLB)","loc":"d,11:8,11:9","dtypep":"(DB)","funcName":"_eval_triggers_vec__act","funcp":"(GN)","argsp": []}
       ]},
-      {"type":"CSTMT","name":"","addr":"(FLB)","loc":"d,11:8,11:9",
+      {"type":"CSTMT","name":"","addr":"(GLB)","loc":"d,11:8,11:9",
        "nodesp": [
-        {"type":"TEXT","name":"","addr":"(GLB)","loc":"d,11:8,11:9","text":"#ifdef VL_DEBUG\n"},
-        {"type":"TEXT","name":"","addr":"(HLB)","loc":"d,11:8,11:9","text":"if (VL_UNLIKELY(vlSymsp->_vm_contextp__->debug())) {\n"},
-        {"type":"STMTEXPR","name":"","addr":"(ILB)","loc":"d,11:8,11:9",
+        {"type":"TEXT","name":"","addr":"(HLB)","loc":"d,11:8,11:9","text":"#ifdef VL_DEBUG\n"},
+        {"type":"TEXT","name":"","addr":"(ILB)","loc":"d,11:8,11:9","text":"if (VL_UNLIKELY(vlSymsp->_vm_contextp__->debug())) {\n"},
+        {"type":"STMTEXPR","name":"","addr":"(JLB)","loc":"d,11:8,11:9",
          "exprp": [
-          {"type":"CCALL","name":"","addr":"(JLB)","loc":"d,11:8,11:9","dtypep":"(DB)","funcName":"_dump_triggers__act","funcp":"(XN)",
+          {"type":"CCALL","name":"","addr":"(KLB)","loc":"d,11:8,11:9","dtypep":"(DB)","funcName":"_dump_triggers__act","funcp":"(YN)",
            "argsp": [
-            {"type":"VARREF","name":"__VactTriggered","addr":"(KLB)","loc":"d,11:8,11:9","dtypep":"(W)","access":"RD","varp":"(V)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"},
-            {"type":"CONST","name":"\\\"act\\\"","addr":"(LLB)","loc":"d,11:8,11:9","dtypep":"(SB)"}
+            {"type":"VARREF","name":"__VactTriggered","addr":"(LLB)","loc":"d,11:8,11:9","dtypep":"(W)","access":"RD","varp":"(V)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"},
+            {"type":"CONST","name":"\\\"act\\\"","addr":"(MLB)","loc":"d,11:8,11:9","dtypep":"(SB)"}
           ]}
         ]},
-        {"type":"TEXT","name":"","addr":"(MLB)","loc":"d,11:8,11:9","text":"}\n"},
-        {"type":"TEXT","name":"","addr":"(NLB)","loc":"d,11:8,11:9","text":"#endif"}
+        {"type":"TEXT","name":"","addr":"(NLB)","loc":"d,11:8,11:9","text":"}\n"},
+        {"type":"TEXT","name":"","addr":"(OLB)","loc":"d,11:8,11:9","text":"#endif"}
       ]},
-      {"type":"STMTEXPR","name":"","addr":"(OLB)","loc":"d,11:8,11:9",
+      {"type":"STMTEXPR","name":"","addr":"(PLB)","loc":"d,11:8,11:9",
        "exprp": [
-        {"type":"CCALL","name":"","addr":"(PLB)","loc":"d,11:8,11:9","dtypep":"(DB)","funcName":"_trigger_orInto__act_vec_vec","funcp":"(TJB)",
+        {"type":"CCALL","name":"","addr":"(QLB)","loc":"d,11:8,11:9","dtypep":"(DB)","funcName":"_trigger_orInto__act_vec_vec","funcp":"(UJB)",
          "argsp": [
-          {"type":"VARREF","name":"__VnbaTriggered","addr":"(QLB)","loc":"d,11:8,11:9","dtypep":"(W)","access":"WR","varp":"(X)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"},
-          {"type":"VARREF","name":"__VactTriggered","addr":"(RLB)","loc":"d,11:8,11:9","dtypep":"(W)","access":"RD","varp":"(V)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+          {"type":"VARREF","name":"__VnbaTriggered","addr":"(RLB)","loc":"d,11:8,11:9","dtypep":"(W)","access":"WR","varp":"(X)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"},
+          {"type":"VARREF","name":"__VactTriggered","addr":"(SLB)","loc":"d,11:8,11:9","dtypep":"(W)","access":"RD","varp":"(V)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
         ]}
       ]},
-      {"type":"CRETURN","name":"","addr":"(SLB)","loc":"a,0:0,0:0",
+      {"type":"CRETURN","name":"","addr":"(TLB)","loc":"a,0:0,0:0",
        "lhsp": [
-        {"type":"CONST","name":"1'h0","addr":"(TLB)","loc":"a,0:0,0:0","dtypep":"(GB)"}
+        {"type":"CONST","name":"1'h0","addr":"(ULB)","loc":"a,0:0,0:0","dtypep":"(GB)"}
       ]}
     ]},
-    {"type":"CFUNC","name":"_trigger_clear__act","addr":"(ULB)","loc":"a,0:0,0:0","isStatic":true,"scopep":"(Z)",
+    {"type":"CFUNC","name":"_trigger_clear__act","addr":"(VLB)","loc":"a,0:0,0:0","isStatic":true,"scopep":"(Z)",
      "argsp": [
-      {"type":"VAR","name":"out","addr":"(VLB)","loc":"a,0:0,0:0","dtypep":"(W)","origName":"out","verilogName":"out","direction":"OUTPUT","isFuncLocal":true,"lifetime":"NONE","varType":"BLOCKTEMP","dtypeName":"","sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
-      {"type":"ASSIGN","name":"","addr":"(WLB)","loc":"a,0:0,0:0","dtypep":"(W)",
+      {"type":"VAR","name":"out","addr":"(WLB)","loc":"a,0:0,0:0","dtypep":"(W)","origName":"out","verilogName":"out","direction":"OUTPUT","isFuncLocal":true,"lifetime":"NONE","varType":"BLOCKTEMP","dtypeName":"","sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
+      {"type":"ASSIGN","name":"","addr":"(XLB)","loc":"a,0:0,0:0","dtypep":"(W)",
        "rhsp": [
-        {"type":"CRESET","name":"","addr":"(XLB)","loc":"a,0:0,0:0","dtypep":"(W)","constructing":true}
+        {"type":"CRESET","name":"","addr":"(YLB)","loc":"a,0:0,0:0","dtypep":"(W)","constructing":true}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"out","addr":"(YLB)","loc":"a,0:0,0:0","dtypep":"(W)","access":"WR","varp":"(VLB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"out","addr":"(ZLB)","loc":"a,0:0,0:0","dtypep":"(W)","access":"WR","varp":"(WLB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []}
     ],
      "varsp": [
-      {"type":"VAR","name":"n","addr":"(ZLB)","loc":"a,0:0,0:0","dtypep":"(IP)","origName":"n","verilogName":"n","direction":"NONE","noReset":true,"isFuncLocal":true,"lifetime":"NONE","varType":"BLOCKTEMP","dtypeName":"IData","sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []}
+      {"type":"VAR","name":"n","addr":"(AMB)","loc":"a,0:0,0:0","dtypep":"(JP)","origName":"n","verilogName":"n","direction":"NONE","noReset":true,"isFuncLocal":true,"lifetime":"NONE","varType":"BLOCKTEMP","dtypeName":"IData","sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []}
     ],
      "stmtsp": [
-      {"type":"ASSIGN","name":"","addr":"(AMB)","loc":"a,0:0,0:0","dtypep":"(IP)",
+      {"type":"ASSIGN","name":"","addr":"(BMB)","loc":"a,0:0,0:0","dtypep":"(JP)",
        "rhsp": [
-        {"type":"CONST","name":"32'h0","addr":"(BMB)","loc":"a,0:0,0:0","dtypep":"(HC)"}
+        {"type":"CONST","name":"32'h0","addr":"(CMB)","loc":"a,0:0,0:0","dtypep":"(IC)"}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"n","addr":"(CMB)","loc":"a,0:0,0:0","dtypep":"(IP)","access":"WR","varp":"(ZLB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"n","addr":"(DMB)","loc":"a,0:0,0:0","dtypep":"(JP)","access":"WR","varp":"(AMB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []},
-      {"type":"LOOP","name":"","addr":"(DMB)","loc":"d,11:8,11:9","unroll":"default",
+      {"type":"LOOP","name":"","addr":"(EMB)","loc":"d,11:8,11:9","unroll":"default",
        "stmtsp": [
-        {"type":"ASSIGN","name":"","addr":"(EMB)","loc":"d,11:8,11:9","dtypep":"(HN)",
+        {"type":"ASSIGN","name":"","addr":"(FMB)","loc":"d,11:8,11:9","dtypep":"(IN)",
          "rhsp": [
-          {"type":"CONST","name":"64'h0","addr":"(FMB)","loc":"d,11:8,11:9","dtypep":"(JN)"}
+          {"type":"CONST","name":"64'h0","addr":"(GMB)","loc":"d,11:8,11:9","dtypep":"(KN)"}
         ],
          "lhsp": [
-          {"type":"ARRAYSEL","name":"","addr":"(GMB)","loc":"d,11:8,11:9","dtypep":"(HN)",
+          {"type":"ARRAYSEL","name":"","addr":"(HMB)","loc":"d,11:8,11:9","dtypep":"(IN)",
            "fromp": [
-            {"type":"VARREF","name":"out","addr":"(HMB)","loc":"d,11:8,11:9","dtypep":"(W)","access":"WR","varp":"(VLB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"out","addr":"(IMB)","loc":"d,11:8,11:9","dtypep":"(W)","access":"WR","varp":"(WLB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ],
            "bitp": [
-            {"type":"VARREF","name":"n","addr":"(IMB)","loc":"d,11:8,11:9","dtypep":"(IP)","access":"RD","varp":"(ZLB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"n","addr":"(JMB)","loc":"d,11:8,11:9","dtypep":"(JP)","access":"RD","varp":"(AMB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ]}
         ],"timingControlp": []},
-        {"type":"ASSIGN","name":"","addr":"(JMB)","loc":"a,0:0,0:0","dtypep":"(IP)",
+        {"type":"ASSIGN","name":"","addr":"(KMB)","loc":"a,0:0,0:0","dtypep":"(JP)",
          "rhsp": [
-          {"type":"ADD","name":"","addr":"(KMB)","loc":"a,0:0,0:0","dtypep":"(IP)",
+          {"type":"ADD","name":"","addr":"(LMB)","loc":"a,0:0,0:0","dtypep":"(JP)",
            "lhsp": [
-            {"type":"CCAST","name":"","addr":"(LMB)","loc":"a,0:0,0:0","dtypep":"(HC)","size":32,
+            {"type":"CCAST","name":"","addr":"(MMB)","loc":"a,0:0,0:0","dtypep":"(IC)","size":32,
              "lhsp": [
-              {"type":"CONST","name":"32'h1","addr":"(MMB)","loc":"a,0:0,0:0","dtypep":"(HC)"}
+              {"type":"CONST","name":"32'h1","addr":"(NMB)","loc":"a,0:0,0:0","dtypep":"(IC)"}
             ]}
           ],
            "rhsp": [
-            {"type":"VARREF","name":"n","addr":"(NMB)","loc":"a,0:0,0:0","dtypep":"(IP)","access":"RD","varp":"(ZLB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"n","addr":"(OMB)","loc":"a,0:0,0:0","dtypep":"(JP)","access":"RD","varp":"(AMB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ]}
         ],
          "lhsp": [
-          {"type":"VARREF","name":"n","addr":"(OMB)","loc":"a,0:0,0:0","dtypep":"(IP)","access":"WR","varp":"(ZLB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+          {"type":"VARREF","name":"n","addr":"(PMB)","loc":"a,0:0,0:0","dtypep":"(JP)","access":"WR","varp":"(AMB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
         ],"timingControlp": []},
-        {"type":"LOOPTEST","name":"","addr":"(PMB)","loc":"d,11:8,11:9",
+        {"type":"LOOPTEST","name":"","addr":"(QMB)","loc":"d,11:8,11:9",
          "condp": [
-          {"type":"GT","name":"","addr":"(QMB)","loc":"d,11:8,11:9","dtypep":"(GB)",
+          {"type":"GT","name":"","addr":"(RMB)","loc":"d,11:8,11:9","dtypep":"(GB)",
            "lhsp": [
-            {"type":"CONST","name":"32'h1","addr":"(RMB)","loc":"d,11:8,11:9","dtypep":"(HC)"}
+            {"type":"CONST","name":"32'h1","addr":"(SMB)","loc":"d,11:8,11:9","dtypep":"(IC)"}
           ],
            "rhsp": [
-            {"type":"VARREF","name":"n","addr":"(SMB)","loc":"d,11:8,11:9","dtypep":"(IP)","access":"RD","varp":"(ZLB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"n","addr":"(TMB)","loc":"d,11:8,11:9","dtypep":"(JP)","access":"RD","varp":"(AMB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ]}
         ]}
       ],"contsp": []}
     ]},
-    {"type":"CFUNC","name":"_eval_phase__nba","addr":"(TMB)","loc":"a,0:0,0:0","scopep":"(Z)","argsp": [],
+    {"type":"CFUNC","name":"_eval_phase__nba","addr":"(UMB)","loc":"a,0:0,0:0","scopep":"(Z)","argsp": [],
      "varsp": [
-      {"type":"VAR","name":"__VnbaExecute","addr":"(UMB)","loc":"d,11:8,11:9","dtypep":"(P)","origName":"__VnbaExecute","verilogName":"__VnbaExecute","direction":"NONE","noReset":true,"isFuncLocal":true,"lifetime":"NONE","varType":"MODULETEMP","dtypeName":"bit","sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []}
+      {"type":"VAR","name":"__VnbaExecute","addr":"(VMB)","loc":"d,11:8,11:9","dtypep":"(P)","origName":"__VnbaExecute","verilogName":"__VnbaExecute","direction":"NONE","noReset":true,"isFuncLocal":true,"lifetime":"NONE","varType":"MODULETEMP","dtypeName":"bit","sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []}
     ],
      "stmtsp": [
-      {"type":"ASSIGN","name":"","addr":"(VMB)","loc":"a,0:0,0:0","dtypep":"(GB)",
+      {"type":"ASSIGN","name":"","addr":"(WMB)","loc":"a,0:0,0:0","dtypep":"(GB)",
        "rhsp": [
-        {"type":"CCALL","name":"","addr":"(WMB)","loc":"d,11:8,11:9","dtypep":"(GB)","funcName":"_trigger_anySet__act","funcp":"(MO)",
+        {"type":"CCALL","name":"","addr":"(XMB)","loc":"d,11:8,11:9","dtypep":"(GB)","funcName":"_trigger_anySet__act","funcp":"(NO)",
          "argsp": [
-          {"type":"VARREF","name":"__VnbaTriggered","addr":"(XMB)","loc":"d,11:8,11:9","dtypep":"(W)","access":"WR","varp":"(X)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+          {"type":"VARREF","name":"__VnbaTriggered","addr":"(YMB)","loc":"d,11:8,11:9","dtypep":"(W)","access":"WR","varp":"(X)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
         ]}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"__VnbaExecute","addr":"(YMB)","loc":"a,0:0,0:0","dtypep":"(GB)","access":"WR","varp":"(UMB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"__VnbaExecute","addr":"(ZMB)","loc":"a,0:0,0:0","dtypep":"(GB)","access":"WR","varp":"(VMB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []},
-      {"type":"IF","name":"","addr":"(ZMB)","loc":"a,0:0,0:0",
+      {"type":"IF","name":"","addr":"(ANB)","loc":"a,0:0,0:0",
        "condp": [
-        {"type":"VARREF","name":"__VnbaExecute","addr":"(ANB)","loc":"a,0:0,0:0","dtypep":"(GB)","access":"RD","varp":"(UMB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"__VnbaExecute","addr":"(BNB)","loc":"a,0:0,0:0","dtypep":"(GB)","access":"RD","varp":"(VMB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],
        "thensp": [
-        {"type":"STMTEXPR","name":"","addr":"(BNB)","loc":"a,0:0,0:0",
+        {"type":"STMTEXPR","name":"","addr":"(CNB)","loc":"a,0:0,0:0",
          "exprp": [
-          {"type":"CCALL","name":"","addr":"(CNB)","loc":"a,0:0,0:0","dtypep":"(DB)","funcName":"_eval_nba","funcp":"(G)","argsp": []}
+          {"type":"CCALL","name":"","addr":"(DNB)","loc":"a,0:0,0:0","dtypep":"(DB)","funcName":"_eval_nba","funcp":"(G)","argsp": []}
         ]},
-        {"type":"STMTEXPR","name":"","addr":"(DNB)","loc":"d,11:8,11:9",
+        {"type":"STMTEXPR","name":"","addr":"(ENB)","loc":"d,11:8,11:9",
          "exprp": [
-          {"type":"CCALL","name":"","addr":"(ENB)","loc":"d,11:8,11:9","dtypep":"(DB)","funcName":"_trigger_clear__act","funcp":"(ULB)",
+          {"type":"CCALL","name":"","addr":"(FNB)","loc":"d,11:8,11:9","dtypep":"(DB)","funcName":"_trigger_clear__act","funcp":"(VLB)",
            "argsp": [
-            {"type":"VARREF","name":"__VnbaTriggered","addr":"(FNB)","loc":"d,11:8,11:9","dtypep":"(W)","access":"WR","varp":"(X)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"__VnbaTriggered","addr":"(GNB)","loc":"d,11:8,11:9","dtypep":"(W)","access":"WR","varp":"(X)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ]}
         ]}
       ],"elsesp": []},
-      {"type":"CRETURN","name":"","addr":"(GNB)","loc":"a,0:0,0:0",
+      {"type":"CRETURN","name":"","addr":"(HNB)","loc":"a,0:0,0:0",
        "lhsp": [
-        {"type":"VARREF","name":"__VnbaExecute","addr":"(HNB)","loc":"a,0:0,0:0","dtypep":"(GB)","access":"RD","varp":"(UMB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"__VnbaExecute","addr":"(INB)","loc":"a,0:0,0:0","dtypep":"(GB)","access":"RD","varp":"(VMB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ]}
     ]},
     {"type":"CFUNC","name":"_eval","addr":"(F)","loc":"a,0:0,0:0","scopep":"(Z)","argsp": [],
      "varsp": [
-      {"type":"VAR","name":"__VnbaIterCount","addr":"(INB)","loc":"d,11:8,11:9","dtypep":"(U)","origName":"__VnbaIterCount","verilogName":"__VnbaIterCount","direction":"NONE","noReset":true,"isFuncLocal":true,"lifetime":"NONE","varType":"MODULETEMP","dtypeName":"bit","sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []}
+      {"type":"VAR","name":"__VnbaIterCount","addr":"(JNB)","loc":"d,11:8,11:9","dtypep":"(U)","origName":"__VnbaIterCount","verilogName":"__VnbaIterCount","direction":"NONE","noReset":true,"isFuncLocal":true,"lifetime":"NONE","varType":"MODULETEMP","dtypeName":"bit","sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []}
     ],
      "stmtsp": [
-      {"type":"ASSIGN","name":"","addr":"(JNB)","loc":"d,11:8,11:9","dtypep":"(U)",
+      {"type":"ASSIGN","name":"","addr":"(KNB)","loc":"d,11:8,11:9","dtypep":"(U)",
        "rhsp": [
-        {"type":"CONST","name":"32'h0","addr":"(KNB)","loc":"d,11:8,11:9","dtypep":"(HC)"}
+        {"type":"CONST","name":"32'h0","addr":"(LNB)","loc":"d,11:8,11:9","dtypep":"(IC)"}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"__VnbaIterCount","addr":"(LNB)","loc":"d,11:8,11:9","dtypep":"(U)","access":"WR","varp":"(INB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"__VnbaIterCount","addr":"(MNB)","loc":"d,11:8,11:9","dtypep":"(U)","access":"WR","varp":"(JNB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []},
-      {"type":"LOOP","name":"","addr":"(MNB)","loc":"a,0:0,0:0","unroll":"default",
+      {"type":"LOOP","name":"","addr":"(NNB)","loc":"a,0:0,0:0","unroll":"default",
        "stmtsp": [
-        {"type":"IF","name":"","addr":"(NNB)","loc":"a,0:0,0:0",
+        {"type":"IF","name":"","addr":"(ONB)","loc":"a,0:0,0:0",
          "condp": [
-          {"type":"LT","name":"","addr":"(ONB)","loc":"a,0:0,0:0","dtypep":"(GB)",
+          {"type":"LT","name":"","addr":"(PNB)","loc":"a,0:0,0:0","dtypep":"(GB)",
            "lhsp": [
-            {"type":"CONST","name":"32'h64","addr":"(PNB)","loc":"a,0:0,0:0","dtypep":"(HC)"}
+            {"type":"CONST","name":"32'h64","addr":"(QNB)","loc":"a,0:0,0:0","dtypep":"(IC)"}
           ],
            "rhsp": [
-            {"type":"VARREF","name":"__VnbaIterCount","addr":"(QNB)","loc":"a,0:0,0:0","dtypep":"(U)","access":"RD","varp":"(INB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"__VnbaIterCount","addr":"(RNB)","loc":"a,0:0,0:0","dtypep":"(U)","access":"RD","varp":"(JNB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ]}
         ],
          "thensp": [
-          {"type":"CSTMT","name":"","addr":"(RNB)","loc":"d,11:8,11:9",
+          {"type":"CSTMT","name":"","addr":"(SNB)","loc":"d,11:8,11:9",
            "nodesp": [
-            {"type":"TEXT","name":"","addr":"(SNB)","loc":"d,11:8,11:9","text":"#ifdef VL_DEBUG\n"},
-            {"type":"STMTEXPR","name":"","addr":"(TNB)","loc":"d,11:8,11:9",
+            {"type":"TEXT","name":"","addr":"(TNB)","loc":"d,11:8,11:9","text":"#ifdef VL_DEBUG\n"},
+            {"type":"STMTEXPR","name":"","addr":"(UNB)","loc":"d,11:8,11:9",
              "exprp": [
-              {"type":"CCALL","name":"","addr":"(UNB)","loc":"d,11:8,11:9","dtypep":"(DB)","funcName":"_dump_triggers__act","funcp":"(XN)",
+              {"type":"CCALL","name":"","addr":"(VNB)","loc":"d,11:8,11:9","dtypep":"(DB)","funcName":"_dump_triggers__act","funcp":"(YN)",
                "argsp": [
-                {"type":"VARREF","name":"__VnbaTriggered","addr":"(VNB)","loc":"d,11:8,11:9","dtypep":"(W)","access":"RD","varp":"(X)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"},
-                {"type":"CONST","name":"\\\"nba\\\"","addr":"(WNB)","loc":"d,11:8,11:9","dtypep":"(SB)"}
+                {"type":"VARREF","name":"__VnbaTriggered","addr":"(WNB)","loc":"d,11:8,11:9","dtypep":"(W)","access":"RD","varp":"(X)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"},
+                {"type":"CONST","name":"\\\"nba\\\"","addr":"(XNB)","loc":"d,11:8,11:9","dtypep":"(SB)"}
               ]}
             ]},
-            {"type":"TEXT","name":"","addr":"(XNB)","loc":"d,11:8,11:9","text":"#endif"}
+            {"type":"TEXT","name":"","addr":"(YNB)","loc":"d,11:8,11:9","text":"#endif"}
           ]},
-          {"type":"CSTMT","name":"","addr":"(YNB)","loc":"a,0:0,0:0",
+          {"type":"CSTMT","name":"","addr":"(ZNB)","loc":"a,0:0,0:0",
            "nodesp": [
-            {"type":"TEXT","name":"","addr":"(ZNB)","loc":"a,0:0,0:0","text":"VL_FATAL_MT(\"t/t_enum_type_methods.v\", 11, \"\", \"DIDNOTCONVERGE: NBA region did not converge after '--converge-limit' of 100 tries\");"}
+            {"type":"TEXT","name":"","addr":"(AOB)","loc":"a,0:0,0:0","text":"VL_FATAL_MT(\"t/t_enum_type_methods.v\", 11, \"\", \"DIDNOTCONVERGE: NBA region did not converge after '--converge-limit' of 100 tries\");"}
           ]}
         ],"elsesp": []},
-        {"type":"ASSIGN","name":"","addr":"(AOB)","loc":"d,11:8,11:9","dtypep":"(U)",
+        {"type":"ASSIGN","name":"","addr":"(BOB)","loc":"d,11:8,11:9","dtypep":"(U)",
          "rhsp": [
-          {"type":"ADD","name":"","addr":"(BOB)","loc":"d,11:8,11:9","dtypep":"(U)",
+          {"type":"ADD","name":"","addr":"(COB)","loc":"d,11:8,11:9","dtypep":"(U)",
            "lhsp": [
-            {"type":"CCAST","name":"","addr":"(COB)","loc":"d,11:8,11:9","dtypep":"(HC)","size":32,
+            {"type":"CCAST","name":"","addr":"(DOB)","loc":"d,11:8,11:9","dtypep":"(IC)","size":32,
              "lhsp": [
-              {"type":"CONST","name":"32'h1","addr":"(DOB)","loc":"d,11:8,11:9","dtypep":"(HC)"}
+              {"type":"CONST","name":"32'h1","addr":"(EOB)","loc":"d,11:8,11:9","dtypep":"(IC)"}
             ]}
           ],
            "rhsp": [
-            {"type":"VARREF","name":"__VnbaIterCount","addr":"(EOB)","loc":"d,11:8,11:9","dtypep":"(U)","access":"RD","varp":"(INB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"__VnbaIterCount","addr":"(FOB)","loc":"d,11:8,11:9","dtypep":"(U)","access":"RD","varp":"(JNB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ]}
         ],
          "lhsp": [
-          {"type":"VARREF","name":"__VnbaIterCount","addr":"(FOB)","loc":"d,11:8,11:9","dtypep":"(U)","access":"WR","varp":"(INB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+          {"type":"VARREF","name":"__VnbaIterCount","addr":"(GOB)","loc":"d,11:8,11:9","dtypep":"(U)","access":"WR","varp":"(JNB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
         ],"timingControlp": []},
-        {"type":"ASSIGN","name":"","addr":"(GOB)","loc":"d,11:8,11:9","dtypep":"(U)",
+        {"type":"ASSIGN","name":"","addr":"(HOB)","loc":"d,11:8,11:9","dtypep":"(U)",
          "rhsp": [
-          {"type":"CONST","name":"32'h0","addr":"(HOB)","loc":"d,11:8,11:9","dtypep":"(HC)"}
+          {"type":"CONST","name":"32'h0","addr":"(IOB)","loc":"d,11:8,11:9","dtypep":"(IC)"}
         ],
          "lhsp": [
-          {"type":"VARREF","name":"__VactIterCount","addr":"(IOB)","loc":"d,11:8,11:9","dtypep":"(U)","access":"WR","varp":"(T)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+          {"type":"VARREF","name":"__VactIterCount","addr":"(JOB)","loc":"d,11:8,11:9","dtypep":"(U)","access":"WR","varp":"(T)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
         ],"timingControlp": []},
-        {"type":"LOOP","name":"","addr":"(JOB)","loc":"a,0:0,0:0","unroll":"default",
+        {"type":"LOOP","name":"","addr":"(KOB)","loc":"a,0:0,0:0","unroll":"default",
          "stmtsp": [
-          {"type":"IF","name":"","addr":"(KOB)","loc":"a,0:0,0:0",
+          {"type":"IF","name":"","addr":"(LOB)","loc":"a,0:0,0:0",
            "condp": [
-            {"type":"LT","name":"","addr":"(LOB)","loc":"a,0:0,0:0","dtypep":"(GB)",
+            {"type":"LT","name":"","addr":"(MOB)","loc":"a,0:0,0:0","dtypep":"(GB)",
              "lhsp": [
-              {"type":"CONST","name":"32'h64","addr":"(MOB)","loc":"a,0:0,0:0","dtypep":"(HC)"}
+              {"type":"CONST","name":"32'h64","addr":"(NOB)","loc":"a,0:0,0:0","dtypep":"(IC)"}
             ],
              "rhsp": [
-              {"type":"VARREF","name":"__VactIterCount","addr":"(NOB)","loc":"a,0:0,0:0","dtypep":"(U)","access":"RD","varp":"(T)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+              {"type":"VARREF","name":"__VactIterCount","addr":"(OOB)","loc":"a,0:0,0:0","dtypep":"(U)","access":"RD","varp":"(T)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
             ]}
           ],
            "thensp": [
-            {"type":"CSTMT","name":"","addr":"(OOB)","loc":"d,11:8,11:9",
+            {"type":"CSTMT","name":"","addr":"(POB)","loc":"d,11:8,11:9",
              "nodesp": [
-              {"type":"TEXT","name":"","addr":"(POB)","loc":"d,11:8,11:9","text":"#ifdef VL_DEBUG\n"},
-              {"type":"STMTEXPR","name":"","addr":"(QOB)","loc":"d,11:8,11:9",
+              {"type":"TEXT","name":"","addr":"(QOB)","loc":"d,11:8,11:9","text":"#ifdef VL_DEBUG\n"},
+              {"type":"STMTEXPR","name":"","addr":"(ROB)","loc":"d,11:8,11:9",
                "exprp": [
-                {"type":"CCALL","name":"","addr":"(ROB)","loc":"d,11:8,11:9","dtypep":"(DB)","funcName":"_dump_triggers__act","funcp":"(XN)",
+                {"type":"CCALL","name":"","addr":"(SOB)","loc":"d,11:8,11:9","dtypep":"(DB)","funcName":"_dump_triggers__act","funcp":"(YN)",
                  "argsp": [
-                  {"type":"VARREF","name":"__VactTriggered","addr":"(SOB)","loc":"d,11:8,11:9","dtypep":"(W)","access":"RD","varp":"(V)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"},
-                  {"type":"CONST","name":"\\\"act\\\"","addr":"(TOB)","loc":"d,11:8,11:9","dtypep":"(SB)"}
+                  {"type":"VARREF","name":"__VactTriggered","addr":"(TOB)","loc":"d,11:8,11:9","dtypep":"(W)","access":"RD","varp":"(V)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"},
+                  {"type":"CONST","name":"\\\"act\\\"","addr":"(UOB)","loc":"d,11:8,11:9","dtypep":"(SB)"}
                 ]}
               ]},
-              {"type":"TEXT","name":"","addr":"(UOB)","loc":"d,11:8,11:9","text":"#endif"}
+              {"type":"TEXT","name":"","addr":"(VOB)","loc":"d,11:8,11:9","text":"#endif"}
             ]},
-            {"type":"CSTMT","name":"","addr":"(VOB)","loc":"a,0:0,0:0",
+            {"type":"CSTMT","name":"","addr":"(WOB)","loc":"a,0:0,0:0",
              "nodesp": [
-              {"type":"TEXT","name":"","addr":"(WOB)","loc":"a,0:0,0:0","text":"VL_FATAL_MT(\"t/t_enum_type_methods.v\", 11, \"\", \"DIDNOTCONVERGE: Active region did not converge after '--converge-limit' of 100 tries\");"}
+              {"type":"TEXT","name":"","addr":"(XOB)","loc":"a,0:0,0:0","text":"VL_FATAL_MT(\"t/t_enum_type_methods.v\", 11, \"\", \"DIDNOTCONVERGE: Active region did not converge after '--converge-limit' of 100 tries\");"}
             ]}
           ],"elsesp": []},
-          {"type":"ASSIGN","name":"","addr":"(XOB)","loc":"d,11:8,11:9","dtypep":"(U)",
+          {"type":"ASSIGN","name":"","addr":"(YOB)","loc":"d,11:8,11:9","dtypep":"(U)",
            "rhsp": [
-            {"type":"ADD","name":"","addr":"(YOB)","loc":"d,11:8,11:9","dtypep":"(U)",
+            {"type":"ADD","name":"","addr":"(ZOB)","loc":"d,11:8,11:9","dtypep":"(U)",
              "lhsp": [
-              {"type":"CCAST","name":"","addr":"(ZOB)","loc":"d,11:8,11:9","dtypep":"(HC)","size":32,
+              {"type":"CCAST","name":"","addr":"(APB)","loc":"d,11:8,11:9","dtypep":"(IC)","size":32,
                "lhsp": [
-                {"type":"CONST","name":"32'h1","addr":"(APB)","loc":"d,11:8,11:9","dtypep":"(HC)"}
+                {"type":"CONST","name":"32'h1","addr":"(BPB)","loc":"d,11:8,11:9","dtypep":"(IC)"}
               ]}
             ],
              "rhsp": [
-              {"type":"VARREF","name":"__VactIterCount","addr":"(BPB)","loc":"d,11:8,11:9","dtypep":"(U)","access":"RD","varp":"(T)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+              {"type":"VARREF","name":"__VactIterCount","addr":"(CPB)","loc":"d,11:8,11:9","dtypep":"(U)","access":"RD","varp":"(T)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
             ]}
           ],
            "lhsp": [
-            {"type":"VARREF","name":"__VactIterCount","addr":"(CPB)","loc":"d,11:8,11:9","dtypep":"(U)","access":"WR","varp":"(T)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"__VactIterCount","addr":"(DPB)","loc":"d,11:8,11:9","dtypep":"(U)","access":"WR","varp":"(T)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ],"timingControlp": []},
-          {"type":"ASSIGN","name":"","addr":"(DPB)","loc":"a,0:0,0:0","dtypep":"(GB)",
+          {"type":"ASSIGN","name":"","addr":"(EPB)","loc":"a,0:0,0:0","dtypep":"(GB)",
            "rhsp": [
-            {"type":"CCALL","name":"","addr":"(EPB)","loc":"a,0:0,0:0","dtypep":"(GB)","funcName":"_eval_phase__act","funcp":"(CLB)","argsp": []}
+            {"type":"CCALL","name":"","addr":"(FPB)","loc":"a,0:0,0:0","dtypep":"(GB)","funcName":"_eval_phase__act","funcp":"(DLB)","argsp": []}
           ],
            "lhsp": [
-            {"type":"VARREF","name":"__VactPhaseResult","addr":"(FPB)","loc":"a,0:0,0:0","dtypep":"(GB)","access":"WR","varp":"(O)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"__VactPhaseResult","addr":"(GPB)","loc":"a,0:0,0:0","dtypep":"(GB)","access":"WR","varp":"(O)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ],"timingControlp": []},
-          {"type":"LOOPTEST","name":"","addr":"(GPB)","loc":"a,0:0,0:0",
+          {"type":"LOOPTEST","name":"","addr":"(HPB)","loc":"a,0:0,0:0",
            "condp": [
-            {"type":"VARREF","name":"__VactPhaseResult","addr":"(HPB)","loc":"a,0:0,0:0","dtypep":"(GB)","access":"RD","varp":"(O)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"__VactPhaseResult","addr":"(IPB)","loc":"a,0:0,0:0","dtypep":"(GB)","access":"RD","varp":"(O)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ]}
         ],"contsp": []},
-        {"type":"ASSIGN","name":"","addr":"(IPB)","loc":"a,0:0,0:0","dtypep":"(GB)",
+        {"type":"ASSIGN","name":"","addr":"(JPB)","loc":"a,0:0,0:0","dtypep":"(GB)",
          "rhsp": [
-          {"type":"CCALL","name":"","addr":"(JPB)","loc":"a,0:0,0:0","dtypep":"(GB)","funcName":"_eval_phase__nba","funcp":"(TMB)","argsp": []}
+          {"type":"CCALL","name":"","addr":"(KPB)","loc":"a,0:0,0:0","dtypep":"(GB)","funcName":"_eval_phase__nba","funcp":"(UMB)","argsp": []}
         ],
          "lhsp": [
-          {"type":"VARREF","name":"__VnbaPhaseResult","addr":"(KPB)","loc":"a,0:0,0:0","dtypep":"(GB)","access":"WR","varp":"(Q)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+          {"type":"VARREF","name":"__VnbaPhaseResult","addr":"(LPB)","loc":"a,0:0,0:0","dtypep":"(GB)","access":"WR","varp":"(Q)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
         ],"timingControlp": []},
-        {"type":"LOOPTEST","name":"","addr":"(LPB)","loc":"a,0:0,0:0",
+        {"type":"LOOPTEST","name":"","addr":"(MPB)","loc":"a,0:0,0:0",
          "condp": [
-          {"type":"VARREF","name":"__VnbaPhaseResult","addr":"(MPB)","loc":"a,0:0,0:0","dtypep":"(GB)","access":"RD","varp":"(Q)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+          {"type":"VARREF","name":"__VnbaPhaseResult","addr":"(NPB)","loc":"a,0:0,0:0","dtypep":"(GB)","access":"RD","varp":"(Q)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
         ]}
       ],"contsp": []}
     ]},
-    {"type":"CFUNC","name":"_eval_debug_assertions","addr":"(NPB)","loc":"d,11:8,11:9","scopep":"UNLINKED","argsp": [],"varsp": [],
+    {"type":"CFUNC","name":"_eval_debug_assertions","addr":"(OPB)","loc":"d,11:8,11:9","scopep":"UNLINKED","argsp": [],"varsp": [],
      "stmtsp": [
-      {"type":"IF","name":"","addr":"(OPB)","loc":"d,15:10,15:13",
+      {"type":"IF","name":"","addr":"(PPB)","loc":"d,15:10,15:13",
        "condp": [
-        {"type":"AND","name":"","addr":"(PPB)","loc":"d,15:10,15:13","dtypep":"(K)",
+        {"type":"AND","name":"","addr":"(QPB)","loc":"d,15:10,15:13","dtypep":"(K)",
          "lhsp": [
-          {"type":"VARREF","name":"clk","addr":"(QPB)","loc":"d,15:10,15:13","dtypep":"(K)","access":"RD","varp":"(J)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+          {"type":"VARREF","name":"clk","addr":"(RPB)","loc":"d,15:10,15:13","dtypep":"(K)","access":"RD","varp":"(J)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
         ],
          "rhsp": [
-          {"type":"CONST","name":"8'hfe","addr":"(RPB)","loc":"d,15:10,15:13","dtypep":"(SPB)"}
+          {"type":"CONST","name":"8'hfe","addr":"(SPB)","loc":"d,15:10,15:13","dtypep":"(TPB)"}
         ]}
       ],
        "thensp": [
-        {"type":"CSTMT","name":"","addr":"(TPB)","loc":"d,15:10,15:13",
+        {"type":"CSTMT","name":"","addr":"(UPB)","loc":"d,15:10,15:13",
          "nodesp": [
-          {"type":"TEXT","name":"","addr":"(UPB)","loc":"d,15:10,15:13","text":"Verilated::overWidthError(\"clk\");"}
+          {"type":"TEXT","name":"","addr":"(VPB)","loc":"d,15:10,15:13","text":"Verilated::overWidthError(\"clk\");"}
         ]}
       ],"elsesp": []}
     ]},
-    {"type":"CFUNC","name":"_ctor_var_reset","addr":"(VPB)","loc":"d,11:8,11:9","slow":true,"scopep":"UNLINKED","argsp": [],"varsp": [],
+    {"type":"CFUNC","name":"_ctor_var_reset","addr":"(WPB)","loc":"d,11:8,11:9","slow":true,"scopep":"UNLINKED","argsp": [],"varsp": [],
      "stmtsp": [
-      {"type":"ASSIGN","name":"","addr":"(WPB)","loc":"d,15:10,15:13","dtypep":"(K)",
+      {"type":"ASSIGN","name":"","addr":"(XPB)","loc":"d,15:10,15:13","dtypep":"(K)",
        "rhsp": [
-        {"type":"CRESET","name":"","addr":"(XPB)","loc":"d,15:10,15:13","dtypep":"(K)","constructing":true}
+        {"type":"CRESET","name":"","addr":"(YPB)","loc":"d,15:10,15:13","dtypep":"(K)","constructing":true}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"clk","addr":"(YPB)","loc":"d,15:10,15:13","dtypep":"(K)","access":"WR","varp":"(J)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"clk","addr":"(ZPB)","loc":"d,15:10,15:13","dtypep":"(K)","access":"WR","varp":"(J)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []},
-      {"type":"ASSIGN","name":"","addr":"(ZPB)","loc":"d,24:9,24:10","dtypep":"(M)",
+      {"type":"ASSIGN","name":"","addr":"(AQB)","loc":"d,24:9,24:10","dtypep":"(M)",
        "rhsp": [
-        {"type":"CRESET","name":"","addr":"(AQB)","loc":"d,24:9,24:10","dtypep":"(M)","constructing":true}
+        {"type":"CRESET","name":"","addr":"(BQB)","loc":"d,24:9,24:10","dtypep":"(M)","constructing":true}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"t.e","addr":"(BQB)","loc":"d,24:9,24:10","dtypep":"(M)","access":"WR","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"t.e","addr":"(CQB)","loc":"d,24:9,24:10","dtypep":"(M)","access":"WR","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []},
-      {"type":"ASSIGN","name":"","addr":"(CQB)","loc":"d,11:8,11:9","dtypep":"(W)",
+      {"type":"ASSIGN","name":"","addr":"(DQB)","loc":"d,11:8,11:9","dtypep":"(W)",
        "rhsp": [
-        {"type":"CRESET","name":"","addr":"(DQB)","loc":"d,11:8,11:9","dtypep":"(W)","constructing":true}
+        {"type":"CRESET","name":"","addr":"(EQB)","loc":"d,11:8,11:9","dtypep":"(W)","constructing":true}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"__VactTriggered","addr":"(EQB)","loc":"d,11:8,11:9","dtypep":"(W)","access":"WR","varp":"(V)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"__VactTriggered","addr":"(FQB)","loc":"d,11:8,11:9","dtypep":"(W)","access":"WR","varp":"(V)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []},
-      {"type":"ASSIGN","name":"","addr":"(FQB)","loc":"d,11:8,11:9","dtypep":"(K)",
+      {"type":"ASSIGN","name":"","addr":"(GQB)","loc":"d,11:8,11:9","dtypep":"(K)",
        "rhsp": [
-        {"type":"CRESET","name":"","addr":"(GQB)","loc":"d,11:8,11:9","dtypep":"(K)","constructing":true}
+        {"type":"CRESET","name":"","addr":"(HQB)","loc":"d,11:8,11:9","dtypep":"(K)","constructing":true}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"__Vtrigprevexpr___TOP__clk__0","addr":"(HQB)","loc":"d,11:8,11:9","dtypep":"(K)","access":"WR","varp":"(N)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"__Vtrigprevexpr___TOP__clk__0","addr":"(IQB)","loc":"d,11:8,11:9","dtypep":"(K)","access":"WR","varp":"(N)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []},
-      {"type":"ASSIGN","name":"","addr":"(IQB)","loc":"d,11:8,11:9","dtypep":"(W)",
+      {"type":"ASSIGN","name":"","addr":"(JQB)","loc":"d,11:8,11:9","dtypep":"(W)",
        "rhsp": [
-        {"type":"CRESET","name":"","addr":"(JQB)","loc":"d,11:8,11:9","dtypep":"(W)","constructing":true}
+        {"type":"CRESET","name":"","addr":"(KQB)","loc":"d,11:8,11:9","dtypep":"(W)","constructing":true}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"__VnbaTriggered","addr":"(KQB)","loc":"d,11:8,11:9","dtypep":"(W)","access":"WR","varp":"(X)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"__VnbaTriggered","addr":"(LQB)","loc":"d,11:8,11:9","dtypep":"(W)","access":"WR","varp":"(X)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []}
     ]},
-    {"type":"CUSE","name":"$unit","addr":"(LQB)","loc":"a,0:0,0:0","useType":"INT_FWD"}
+    {"type":"CUSE","name":"$unit","addr":"(MQB)","loc":"a,0:0,0:0","useType":"INT_FWD"}
   ]},
   {"type":"PACKAGE","name":"$unit","addr":"(E)","loc":"a,0:0,0:0","origName":"__024unit","verilogName":"\\$unit ","level":2,"inLibrary":true,"timeunit":"NONE","inlinesp": [],
    "stmtsp": [
-    {"type":"VAR","name":"__Venumtab_enum_next1","addr":"(DC)","loc":"d,17:12,17:16","dtypep":"(CC)","origName":"__Venumtab_enum_next1","verilogName":"__Venumtab_enum_next1","direction":"NONE","isConst":true,"lifetime":"VSTATIC","varType":"MODULETEMP","dtypeName":"","sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],
+    {"type":"VAR","name":"__Venumtab_enum_next1","addr":"(EC)","loc":"d,17:12,17:16","dtypep":"(DC)","origName":"__Venumtab_enum_next1","verilogName":"__Venumtab_enum_next1","direction":"NONE","isConst":true,"lifetime":"VSTATIC","varType":"MODULETEMP","dtypeName":"","sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],
      "valuep": [
-      {"type":"INITARRAY","name":"","addr":"(MQB)","loc":"d,17:12,17:16","dtypep":"(CC)","initList":" [1]=(NQB) [3]=(OQB) [4]=(PQB)",
+      {"type":"INITARRAY","name":"","addr":"(NQB)","loc":"d,17:12,17:16","dtypep":"(DC)","initList":" [1]=(OQB) [3]=(PQB) [4]=(QQB)",
        "defaultp": [
-        {"type":"CONST","name":"4'h0","addr":"(QQB)","loc":"d,17:12,17:16","dtypep":"(UB)"}
+        {"type":"CONST","name":"4'h0","addr":"(RQB)","loc":"d,17:12,17:16","dtypep":"(UB)"}
       ],
        "initsp": [
-        {"type":"INITITEM","name":"","addr":"(NQB)","loc":"d,17:12,17:16",
-         "valuep": [
-          {"type":"CONST","name":"4'h3","addr":"(RQB)","loc":"d,19:30,19:31","dtypep":"(UB)"}
-        ]},
         {"type":"INITITEM","name":"","addr":"(OQB)","loc":"d,17:12,17:16",
          "valuep": [
-          {"type":"CONST","name":"4'h4","addr":"(SQB)","loc":"d,20:30,20:31","dtypep":"(UB)"}
+          {"type":"CONST","name":"4'h3","addr":"(SQB)","loc":"d,19:30,19:31","dtypep":"(UB)"}
         ]},
         {"type":"INITITEM","name":"","addr":"(PQB)","loc":"d,17:12,17:16",
          "valuep": [
-          {"type":"CONST","name":"4'h1","addr":"(TQB)","loc":"d,18:30,18:31","dtypep":"(UB)"}
+          {"type":"CONST","name":"4'h4","addr":"(TQB)","loc":"d,20:30,20:31","dtypep":"(UB)"}
+        ]},
+        {"type":"INITITEM","name":"","addr":"(QQB)","loc":"d,17:12,17:16",
+         "valuep": [
+          {"type":"CONST","name":"4'h1","addr":"(UQB)","loc":"d,18:30,18:31","dtypep":"(UB)"}
         ]}
       ]}
     ],"attrsp": []},
-    {"type":"VAR","name":"__Venumtab_enum_prev1","addr":"(XI)","loc":"d,17:12,17:16","dtypep":"(WI)","origName":"__Venumtab_enum_prev1","verilogName":"__Venumtab_enum_prev1","direction":"NONE","isConst":true,"lifetime":"VSTATIC","varType":"MODULETEMP","dtypeName":"","sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],
+    {"type":"VAR","name":"__Venumtab_enum_prev1","addr":"(YI)","loc":"d,17:12,17:16","dtypep":"(XI)","origName":"__Venumtab_enum_prev1","verilogName":"__Venumtab_enum_prev1","direction":"NONE","isConst":true,"lifetime":"VSTATIC","varType":"MODULETEMP","dtypeName":"","sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],
      "valuep": [
-      {"type":"INITARRAY","name":"","addr":"(UQB)","loc":"d,17:12,17:16","dtypep":"(WI)","initList":" [1]=(VQB) [3]=(WQB) [4]=(XQB)",
+      {"type":"INITARRAY","name":"","addr":"(VQB)","loc":"d,17:12,17:16","dtypep":"(XI)","initList":" [1]=(WQB) [3]=(XQB) [4]=(YQB)",
        "defaultp": [
-        {"type":"CONST","name":"4'h0","addr":"(YQB)","loc":"d,17:12,17:16","dtypep":"(UB)"}
+        {"type":"CONST","name":"4'h0","addr":"(ZQB)","loc":"d,17:12,17:16","dtypep":"(UB)"}
       ],
        "initsp": [
-        {"type":"INITITEM","name":"","addr":"(VQB)","loc":"d,17:12,17:16",
-         "valuep": [
-          {"type":"CONST","name":"4'h4","addr":"(ZQB)","loc":"d,20:30,20:31","dtypep":"(UB)"}
-        ]},
         {"type":"INITITEM","name":"","addr":"(WQB)","loc":"d,17:12,17:16",
          "valuep": [
-          {"type":"CONST","name":"4'h1","addr":"(ARB)","loc":"d,18:30,18:31","dtypep":"(UB)"}
+          {"type":"CONST","name":"4'h4","addr":"(ARB)","loc":"d,20:30,20:31","dtypep":"(UB)"}
         ]},
         {"type":"INITITEM","name":"","addr":"(XQB)","loc":"d,17:12,17:16",
          "valuep": [
-          {"type":"CONST","name":"4'h3","addr":"(BRB)","loc":"d,19:30,19:31","dtypep":"(UB)"}
+          {"type":"CONST","name":"4'h1","addr":"(BRB)","loc":"d,18:30,18:31","dtypep":"(UB)"}
+        ]},
+        {"type":"INITITEM","name":"","addr":"(YQB)","loc":"d,17:12,17:16",
+         "valuep": [
+          {"type":"CONST","name":"4'h3","addr":"(CRB)","loc":"d,19:30,19:31","dtypep":"(UB)"}
         ]}
       ]}
     ],"attrsp": []},
-    {"type":"VAR","name":"__Venumtab_enum_name1","addr":"(JM)","loc":"d,17:12,17:16","dtypep":"(IM)","origName":"__Venumtab_enum_name1","verilogName":"__Venumtab_enum_name1","direction":"NONE","isConst":true,"lifetime":"VSTATIC","varType":"MODULETEMP","dtypeName":"","sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],
+    {"type":"VAR","name":"__Venumtab_enum_name1","addr":"(KM)","loc":"d,17:12,17:16","dtypep":"(JM)","origName":"__Venumtab_enum_name1","verilogName":"__Venumtab_enum_name1","direction":"NONE","isConst":true,"lifetime":"VSTATIC","varType":"MODULETEMP","dtypeName":"","sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],
      "valuep": [
-      {"type":"INITARRAY","name":"","addr":"(CRB)","loc":"d,17:12,17:16","dtypep":"(IM)","initList":" [1]=(DRB) [3]=(ERB) [4]=(FRB)",
+      {"type":"INITARRAY","name":"","addr":"(DRB)","loc":"d,17:12,17:16","dtypep":"(JM)","initList":" [1]=(ERB) [3]=(FRB) [4]=(GRB)",
        "defaultp": [
-        {"type":"CONST","name":"\\\"\\\"","addr":"(GRB)","loc":"d,17:12,17:16","dtypep":"(SB)"}
+        {"type":"CONST","name":"\\\"\\\"","addr":"(HRB)","loc":"d,17:12,17:16","dtypep":"(SB)"}
       ],
        "initsp": [
-        {"type":"INITITEM","name":"","addr":"(DRB)","loc":"d,17:12,17:16",
-         "valuep": [
-          {"type":"CONST","name":"\\\"E01\\\"","addr":"(HRB)","loc":"d,17:12,17:16","dtypep":"(SB)"}
-        ]},
         {"type":"INITITEM","name":"","addr":"(ERB)","loc":"d,17:12,17:16",
          "valuep": [
-          {"type":"CONST","name":"\\\"E03\\\"","addr":"(IRB)","loc":"d,17:12,17:16","dtypep":"(SB)"}
+          {"type":"CONST","name":"\\\"E01\\\"","addr":"(IRB)","loc":"d,17:12,17:16","dtypep":"(SB)"}
         ]},
         {"type":"INITITEM","name":"","addr":"(FRB)","loc":"d,17:12,17:16",
          "valuep": [
-          {"type":"CONST","name":"\\\"E04\\\"","addr":"(JRB)","loc":"d,17:12,17:16","dtypep":"(SB)"}
+          {"type":"CONST","name":"\\\"E03\\\"","addr":"(JRB)","loc":"d,17:12,17:16","dtypep":"(SB)"}
+        ]},
+        {"type":"INITITEM","name":"","addr":"(GRB)","loc":"d,17:12,17:16",
+         "valuep": [
+          {"type":"CONST","name":"\\\"E04\\\"","addr":"(KRB)","loc":"d,17:12,17:16","dtypep":"(SB)"}
         ]}
       ]}
     ],"attrsp": []},
-    {"type":"SCOPE","name":"$unit","addr":"(KRB)","loc":"a,0:0,0:0","aboveScopep":"(Z)","aboveCellp":"(Y)","modp":"(E)","varsp": [],"blocksp": [],"inlinesp": []},
-    {"type":"CFUNC","name":"_ctor_var_reset","addr":"(LRB)","loc":"a,0:0,0:0","slow":true,"scopep":"UNLINKED","argsp": [],"varsp": [],
+    {"type":"SCOPE","name":"$unit","addr":"(LRB)","loc":"a,0:0,0:0","aboveScopep":"(Z)","aboveCellp":"(Y)","modp":"(E)","varsp": [],"blocksp": [],"inlinesp": []},
+    {"type":"CFUNC","name":"_ctor_var_reset","addr":"(MRB)","loc":"a,0:0,0:0","slow":true,"scopep":"UNLINKED","argsp": [],"varsp": [],
      "stmtsp": [
-      {"type":"ASSIGN","name":"","addr":"(MRB)","loc":"d,17:12,17:16","dtypep":"(CC)",
+      {"type":"ASSIGN","name":"","addr":"(NRB)","loc":"d,17:12,17:16","dtypep":"(DC)",
        "rhsp": [
-        {"type":"CRESET","name":"","addr":"(NRB)","loc":"d,17:12,17:16","dtypep":"(CC)","constructing":true}
+        {"type":"CRESET","name":"","addr":"(ORB)","loc":"d,17:12,17:16","dtypep":"(DC)","constructing":true}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(ORB)","loc":"d,17:12,17:16","dtypep":"(CC)","access":"WR","varp":"(DC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(PRB)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"WR","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []},
-      {"type":"ASSIGN","name":"","addr":"(PRB)","loc":"d,17:12,17:16","dtypep":"(WI)",
+      {"type":"ASSIGN","name":"","addr":"(QRB)","loc":"d,17:12,17:16","dtypep":"(XI)",
        "rhsp": [
-        {"type":"CRESET","name":"","addr":"(QRB)","loc":"d,17:12,17:16","dtypep":"(WI)","constructing":true}
+        {"type":"CRESET","name":"","addr":"(RRB)","loc":"d,17:12,17:16","dtypep":"(XI)","constructing":true}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(RRB)","loc":"d,17:12,17:16","dtypep":"(WI)","access":"WR","varp":"(XI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(SRB)","loc":"d,17:12,17:16","dtypep":"(XI)","access":"WR","varp":"(YI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []},
-      {"type":"ASSIGN","name":"","addr":"(SRB)","loc":"d,17:12,17:16","dtypep":"(IM)",
+      {"type":"ASSIGN","name":"","addr":"(TRB)","loc":"d,17:12,17:16","dtypep":"(JM)",
        "rhsp": [
-        {"type":"CRESET","name":"","addr":"(TRB)","loc":"d,17:12,17:16","dtypep":"(IM)","constructing":true}
+        {"type":"CRESET","name":"","addr":"(URB)","loc":"d,17:12,17:16","dtypep":"(JM)","constructing":true}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"__Venumtab_enum_name1","addr":"(URB)","loc":"d,17:12,17:16","dtypep":"(IM)","access":"WR","varp":"(JM)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"__Venumtab_enum_name1","addr":"(VRB)","loc":"d,17:12,17:16","dtypep":"(JM)","access":"WR","varp":"(KM)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []}
     ]}
   ]}
 ],
  "filesp": [
-  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck__Syms__Slow.cpp","addr":"(VRB)","loc":"a,0:0,0:0","source":true,"slow":true,"tblockp": []},
-  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck__Syms.h","addr":"(WRB)","loc":"a,0:0,0:0","tblockp": []},
-  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck.h","addr":"(XRB)","loc":"a,0:0,0:0","tblockp": []},
-  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck.cpp","addr":"(YRB)","loc":"a,0:0,0:0","source":true,"tblockp": []},
-  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck__pch.h","addr":"(ZRB)","loc":"a,0:0,0:0","tblockp": []},
-  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck_$root.h","addr":"(ASB)","loc":"a,0:0,0:0","tblockp": []},
-  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck_$unit.h","addr":"(BSB)","loc":"a,0:0,0:0","tblockp": []},
-  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck_$root__Slow.cpp","addr":"(CSB)","loc":"a,0:0,0:0","source":true,"slow":true,"tblockp": []},
-  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck_$root__0__Slow.cpp","addr":"(DSB)","loc":"a,0:0,0:0","source":true,"slow":true,"tblockp": []},
-  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck_$root__0.cpp","addr":"(ESB)","loc":"a,0:0,0:0","source":true,"tblockp": []},
-  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck_$unit__Slow.cpp","addr":"(FSB)","loc":"a,0:0,0:0","source":true,"slow":true,"tblockp": []},
-  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck_$unit__0__Slow.cpp","addr":"(GSB)","loc":"a,0:0,0:0","source":true,"slow":true,"tblockp": []}
+  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck__Syms__Slow.cpp","addr":"(WRB)","loc":"a,0:0,0:0","source":true,"slow":true,"tblockp": []},
+  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck__Syms.h","addr":"(XRB)","loc":"a,0:0,0:0","tblockp": []},
+  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck.h","addr":"(YRB)","loc":"a,0:0,0:0","tblockp": []},
+  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck.cpp","addr":"(ZRB)","loc":"a,0:0,0:0","source":true,"tblockp": []},
+  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck__pch.h","addr":"(ASB)","loc":"a,0:0,0:0","tblockp": []},
+  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck_$root.h","addr":"(BSB)","loc":"a,0:0,0:0","tblockp": []},
+  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck_$unit.h","addr":"(CSB)","loc":"a,0:0,0:0","tblockp": []},
+  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck_$root__Slow.cpp","addr":"(DSB)","loc":"a,0:0,0:0","source":true,"slow":true,"tblockp": []},
+  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck_$root__0__Slow.cpp","addr":"(ESB)","loc":"a,0:0,0:0","source":true,"slow":true,"tblockp": []},
+  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck_$root__0.cpp","addr":"(FSB)","loc":"a,0:0,0:0","source":true,"tblockp": []},
+  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck_$unit__Slow.cpp","addr":"(GSB)","loc":"a,0:0,0:0","source":true,"slow":true,"tblockp": []},
+  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck_$unit__0__Slow.cpp","addr":"(HSB)","loc":"a,0:0,0:0","source":true,"slow":true,"tblockp": []}
 ],
  "miscsp": [
   {"type":"TYPETABLE","name":"","addr":"(C)","loc":"a,0:0,0:0","constraintRefp":"UNLINKED","emptyQueuep":"UNLINKED","queueIndexp":"UNLINKED","streamp":"UNLINKED","voidp":"(DB)",
    "typesp": [
     {"type":"BASICDTYPE","name":"logic","addr":"(K)","loc":"d,33:24,33:27","dtypep":"(K)","keyword":"logic","generic":true,"rangep": []},
-    {"type":"BASICDTYPE","name":"logic","addr":"(HC)","loc":"d,53:16,53:17","dtypep":"(HC)","keyword":"logic","range":"31:0","generic":true,"rangep": []},
-    {"type":"BASICDTYPE","name":"logic","addr":"(HSB)","loc":"d,17:17,17:18","dtypep":"(HSB)","keyword":"logic","range":"3:0","generic":true,"rangep": []},
-    {"type":"ENUMDTYPE","name":"t.my_t","addr":"(ISB)","loc":"d,17:12,17:16","dtypep":"(ISB)","enum":true,"refDTypep":"(HSB)","childDTypep": [],
+    {"type":"BASICDTYPE","name":"logic","addr":"(IC)","loc":"d,53:16,53:17","dtypep":"(IC)","keyword":"logic","range":"31:0","generic":true,"rangep": []},
+    {"type":"BASICDTYPE","name":"logic","addr":"(ISB)","loc":"d,17:17,17:18","dtypep":"(ISB)","keyword":"logic","range":"3:0","generic":true,"rangep": []},
+    {"type":"ENUMDTYPE","name":"t.my_t","addr":"(BC)","loc":"d,17:12,17:16","dtypep":"(BC)","enum":true,"refDTypep":"(ISB)","childDTypep": [],
      "itemsp": [
       {"type":"ENUMITEM","name":"E01","addr":"(JSB)","loc":"d,18:24,18:27","dtypep":"(UB)","rangep": [],
        "valuep": [
@@ -3018,59 +3018,59 @@
       ]}
     ]},
     {"type":"BASICDTYPE","name":"integer","addr":"(S)","loc":"d,23:4,23:11","dtypep":"(S)","keyword":"integer","range":"31:0","generic":true,"signed":true,"rangep": []},
-    {"type":"REFDTYPE","name":"my_t","addr":"(M)","loc":"d,24:4,24:8","dtypep":"(ISB)","typedefp":"UNLINKED","refDTypep":"(ISB)","classOrPackagep":"UNLINKED","typeofp": [],"classOrPackageOpp": [],"paramsp": []},
+    {"type":"REFDTYPE","name":"my_t","addr":"(M)","loc":"d,24:4,24:8","dtypep":"(BC)","typedefp":"UNLINKED","refDTypep":"(BC)","classOrPackagep":"UNLINKED","typeofp": [],"classOrPackageOpp": [],"paramsp": []},
     {"type":"BASICDTYPE","name":"string","addr":"(SB)","loc":"d,28:4,28:10","dtypep":"(SB)","keyword":"string","generic":true,"rangep": []},
-    {"type":"UNPACKARRAYDTYPE","name":"","addr":"(CC)","loc":"d,17:12,17:16","dtypep":"(CC)","declRange":"[7:0]","refDTypep":"(ISB)","childDTypep": [],
+    {"type":"UNPACKARRAYDTYPE","name":"","addr":"(DC)","loc":"d,17:12,17:16","dtypep":"(DC)","declRange":"[7:0]","refDTypep":"(BC)","childDTypep": [],
      "rangep": [
       {"type":"RANGE","name":"","addr":"(PSB)","loc":"d,17:12,17:16",
        "leftp": [
-        {"type":"CONST","name":"32'h7","addr":"(QSB)","loc":"d,17:12,17:16","dtypep":"(HC)"}
+        {"type":"CONST","name":"32'h7","addr":"(QSB)","loc":"d,17:12,17:16","dtypep":"(IC)"}
       ],
        "rightp": [
-        {"type":"CONST","name":"32'h0","addr":"(RSB)","loc":"d,17:12,17:16","dtypep":"(HC)"}
+        {"type":"CONST","name":"32'h0","addr":"(RSB)","loc":"d,17:12,17:16","dtypep":"(IC)"}
       ]}
     ]},
-    {"type":"UNPACKARRAYDTYPE","name":"","addr":"(WI)","loc":"d,17:12,17:16","dtypep":"(WI)","declRange":"[7:0]","refDTypep":"(ISB)","childDTypep": [],
+    {"type":"UNPACKARRAYDTYPE","name":"","addr":"(XI)","loc":"d,17:12,17:16","dtypep":"(XI)","declRange":"[7:0]","refDTypep":"(BC)","childDTypep": [],
      "rangep": [
       {"type":"RANGE","name":"","addr":"(SSB)","loc":"d,17:12,17:16",
        "leftp": [
-        {"type":"CONST","name":"32'h7","addr":"(TSB)","loc":"d,17:12,17:16","dtypep":"(HC)"}
+        {"type":"CONST","name":"32'h7","addr":"(TSB)","loc":"d,17:12,17:16","dtypep":"(IC)"}
       ],
        "rightp": [
-        {"type":"CONST","name":"32'h0","addr":"(USB)","loc":"d,17:12,17:16","dtypep":"(HC)"}
+        {"type":"CONST","name":"32'h0","addr":"(USB)","loc":"d,17:12,17:16","dtypep":"(IC)"}
       ]}
     ]},
-    {"type":"UNPACKARRAYDTYPE","name":"","addr":"(IM)","loc":"d,17:12,17:16","dtypep":"(IM)","isCompound":true,"declRange":"[7:0]","refDTypep":"(SB)","childDTypep": [],
+    {"type":"UNPACKARRAYDTYPE","name":"","addr":"(JM)","loc":"d,17:12,17:16","dtypep":"(JM)","isCompound":true,"declRange":"[7:0]","refDTypep":"(SB)","childDTypep": [],
      "rangep": [
       {"type":"RANGE","name":"","addr":"(VSB)","loc":"d,17:12,17:16",
        "leftp": [
-        {"type":"CONST","name":"32'h7","addr":"(WSB)","loc":"d,17:12,17:16","dtypep":"(HC)"}
+        {"type":"CONST","name":"32'h7","addr":"(WSB)","loc":"d,17:12,17:16","dtypep":"(IC)"}
       ],
        "rightp": [
-        {"type":"CONST","name":"32'h0","addr":"(XSB)","loc":"d,17:12,17:16","dtypep":"(HC)"}
+        {"type":"CONST","name":"32'h0","addr":"(XSB)","loc":"d,17:12,17:16","dtypep":"(IC)"}
       ]}
     ]},
     {"type":"BASICDTYPE","name":"logic","addr":"(LB)","loc":"d,23:23,23:24","dtypep":"(LB)","keyword":"logic","range":"31:0","generic":true,"signed":true,"rangep": []},
     {"type":"VOIDDTYPE","name":"","addr":"(DB)","loc":"a,0:0,0:0","dtypep":"(DB)"},
-    {"type":"BASICDTYPE","name":"bit","addr":"(HN)","loc":"a,0:0,0:0","dtypep":"(HN)","keyword":"bit","range":"63:0","generic":true,"rangep": []},
-    {"type":"UNPACKARRAYDTYPE","name":"","addr":"(W)","loc":"d,11:8,11:9","dtypep":"(W)","declRange":"[0:0]","refDTypep":"(HN)","childDTypep": [],
+    {"type":"BASICDTYPE","name":"bit","addr":"(IN)","loc":"a,0:0,0:0","dtypep":"(IN)","keyword":"bit","range":"63:0","generic":true,"rangep": []},
+    {"type":"UNPACKARRAYDTYPE","name":"","addr":"(W)","loc":"d,11:8,11:9","dtypep":"(W)","declRange":"[0:0]","refDTypep":"(IN)","childDTypep": [],
      "rangep": [
       {"type":"RANGE","name":"","addr":"(YSB)","loc":"d,11:8,11:9",
        "leftp": [
-        {"type":"CONST","name":"32'h0","addr":"(ZSB)","loc":"d,11:8,11:9","dtypep":"(HC)"}
+        {"type":"CONST","name":"32'h0","addr":"(ZSB)","loc":"d,11:8,11:9","dtypep":"(IC)"}
       ],
        "rightp": [
-        {"type":"CONST","name":"32'h0","addr":"(ATB)","loc":"d,11:8,11:9","dtypep":"(HC)"}
+        {"type":"CONST","name":"32'h0","addr":"(ATB)","loc":"d,11:8,11:9","dtypep":"(IC)"}
       ]}
     ]},
-    {"type":"BASICDTYPE","name":"IData","addr":"(IP)","loc":"a,0:0,0:0","dtypep":"(IP)","keyword":"IData","range":"31:0","generic":true,"rangep": []},
-    {"type":"BASICDTYPE","name":"logic","addr":"(JN)","loc":"d,63:14,63:21","dtypep":"(JN)","keyword":"logic","range":"63:0","generic":true,"rangep": []},
+    {"type":"BASICDTYPE","name":"IData","addr":"(JP)","loc":"a,0:0,0:0","dtypep":"(JP)","keyword":"IData","range":"31:0","generic":true,"rangep": []},
+    {"type":"BASICDTYPE","name":"logic","addr":"(KN)","loc":"d,63:14,63:21","dtypep":"(KN)","keyword":"logic","range":"63:0","generic":true,"rangep": []},
     {"type":"BASICDTYPE","name":"bit","addr":"(P)","loc":"d,11:8,11:9","dtypep":"(P)","keyword":"bit","generic":true,"rangep": []},
     {"type":"BASICDTYPE","name":"bit","addr":"(U)","loc":"d,11:8,11:9","dtypep":"(U)","keyword":"bit","range":"31:0","generic":true,"rangep": []},
     {"type":"BASICDTYPE","name":"logic","addr":"(GB)","loc":"d,63:22,63:25","dtypep":"(GB)","keyword":"logic","range":"31:0","generic":true,"rangep": []},
     {"type":"BASICDTYPE","name":"logic","addr":"(UB)","loc":"d,32:11,32:14","dtypep":"(UB)","keyword":"logic","range":"31:0","generic":true,"rangep": []},
-    {"type":"BASICDTYPE","name":"logic","addr":"(FC)","loc":"d,38:15,38:16","dtypep":"(FC)","keyword":"logic","range":"31:0","generic":true,"rangep": []},
-    {"type":"BASICDTYPE","name":"logic","addr":"(SPB)","loc":"d,15:10,15:13","dtypep":"(SPB)","keyword":"logic","range":"7:0","generic":true,"rangep": []}
+    {"type":"BASICDTYPE","name":"logic","addr":"(GC)","loc":"d,38:15,38:16","dtypep":"(GC)","keyword":"logic","range":"31:0","generic":true,"rangep": []},
+    {"type":"BASICDTYPE","name":"logic","addr":"(TPB)","loc":"d,15:10,15:13","dtypep":"(TPB)","keyword":"logic","range":"7:0","generic":true,"rangep": []}
   ]},
   {"type":"CONSTPOOL","name":"","addr":"(D)","loc":"a,0:0,0:0",
    "modulep": [


### PR DESCRIPTION
I'm running into incorrect simulation results in a large design.  The incorrect results only appear when I'm verilating without trace support.  I tracked the problem down to this line:

```cpp
        vlSelfRef.__PVT__foo[0x00000031U] 
            = (((((vlSymsp->TOP__tb__dut__sub.__PVT__gen_loop__BRA__1__KET____DOT__other_sub__DOT__qux
                   [8U] << 0x00000012U) | (vlSymsp->TOP__tb__dut__sub.__PVT__gen_loop__BRA__0__KET____DOT__other_sub__DOT__qux
                                           [8U] << 2U)) 
                 | vlSymsp->TOP__tb__dut__sub.__PVT__baz
                 [8U]) >> 0x0000001aU) | ((((3U & (
                                                   vlSymsp->TOP__tb__dut__sub.__PVT__gen_loop__BRA__1__KET____DOT__other_sub__DOT__qux
                                                   [8U] 
                                                   >> 0x0000000eU)) 
                                            | (vlSymsp->TOP__tb__dut__sub.__PVT__gen_loop__BRA__0__KET____DOT__other_sub__DOT__qux
                                               [8U] 
                                               >> 0x0000001eU)) 
                                           | ((vlSymsp->TOP__tb__dut__sub.__PVT__gen_loop__BRA__3__KET____DOT__other_sub__DOT__qux
                                               [8U] 
                                               << 0x00000012U) 
                                              | (vlSymsp->TOP__tb__dut__sub.__PVT__gen_loop__BRA__2__KET____DOT__other_sub__DOT__qux
                                                 [8U] 
                                                 << 2U))) 
                                          << 6U));
```
(obfuscated by hand, so hopefully I didn't screw anything up)

I noticed that `foo[0]` - `foo[0x1f]` is being assigned from a `__VdfgRegularize` variable.  So I tried re-building with `--fno-dfg` and the problem went away.

However, the underlying problem comes from shifting promoted integers.  `foo` is `VL_INW(__PVT__foo,2055,0,65)`, `baz` is `VlUnpacked<CData/*1:0*/, 9>` and `qux` is `VlUnpacked<SData/*15:0*/, 9>`.  The problem is that some of these shifts take a `uint16_t` and push a `1` into the MSB of an `int` and then things go south from there.

If I plug this assignment's RHS into the debugger I can see it produce the incorrect result (0xffffffff as opposed to not that since it's sign extending when it's clearly not desired).  However, if I plug the same expression into the debugger with a few `(unsigned)` casts sprinkled in, then I get the expected value.

While breaking some of the test suite, this change fixes my original problem.  I'm working on getting all the tests to pass, but would also like to confirm I'm going in the right direction here.

Also I just noticed `EmitCFunc::visit(AstCCast*)`, so I'm wondering if I should be adding that to the AST instead of doing what I'm doing here.  Do I need to throw a `CCast` into the tree every time there's a shift?  Or should I put this in the Biop visit() like I have here?  Also, I think (?) this isn't a problem for non-simple shifts which use `VL_SHIFT*` since those functions already have unsigned return types.

Boiling down what we've got into a `test_regress/` test may be tricky because I can only tickle the bug via our cocotb test.  I'm looking into options there.

cc @gezalore re: DFG (not sure if it's directly related)
