### PR TITLE
Internals: Clean up V3Reorder

### DIFF
--- a/src/V3EmitV.cpp
+++ b/src/V3EmitV.cpp
@@ -1223,6 +1223,12 @@ void V3EmitV::debugVerilogForTree(const AstNode* nodep, std::ostream& os) {
     { EmitVStreamVisitor{nodep, os, /* tracking: */ true, true}; }
 }
 
+std::string V3EmitV::debugVerilogForTree(const AstNode* nodep) {
+    std::stringstream ss;
+    debugVerilogForTree(nodep, ss);
+    return ss.str();
+}
+
 void V3EmitV::emitvFiles() {
     UINFO(2, __FUNCTION__ << ":");
     for (AstNodeFile* filep = v3Global.rootp()->filesp(); filep;

--- a/src/V3EmitV.h
+++ b/src/V3EmitV.h
@@ -29,6 +29,7 @@ class V3EmitV final {
 public:
     static void verilogForTree(const AstNode* nodep, std::ostream& os = std::cout);
     static void debugVerilogForTree(const AstNode* nodep, std::ostream& os);
+    static std::string debugVerilogForTree(const AstNode* nodep);
     static void emitvFiles();
     static void debugEmitV(const string& filename);
 };


### PR DESCRIPTION
This is primarily cleanup, but there are 2 functional changes included:
- It used to accidentally reorder bodies of AstNodeIf that were outside an AstAlways. Now it will not touch anything outside an AstAlways.
- Removed one redundant cuttable edge from the graph which perturbs the result of `V3Graph::acyclic`. This should make no difference for the actual intended result of reordering NBAs to eliminate shadow variables.
