### PR TITLE
Fix V3Tristate __en pin VAccess for input port processing (#7016)

### DIFF
--- a/src/V3Tristate.cpp
+++ b/src/V3Tristate.cpp
@@ -1645,7 +1645,8 @@ class TristateVisitor final : public TristateBaseVisitor {
             AstPin* const enpinp
                 = new AstPin{nodep->fileline(), nodep->pinNum(),
                              enModVarp->name(),  // should be {var}"__en"
-                             new AstVarRef{nodep->fileline(), enVarp, VAccess::WRITE}};
+                             new AstVarRef{nodep->fileline(), enVarp,
+                                           inDeclProcessing ? VAccess::READ : VAccess::WRITE}};
             enpinp->modVarp(enModVarp);
             UINFO(9, "       newpin " << enpinp);
             enpinp->user2Or(U2_BOTH);  // don't iterate the pin later

--- a/test_regress/t/t_altera_lpm_bustri_noinl.py
+++ b/test_regress/t/t_altera_lpm_bustri_noinl.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('vlt_all')
+test.top_filename = "t/t_altera_lpm.v"
+module = re.sub(r'.*t_altera_', '', test.name)
+module = re.sub(r'_noinl', '', module)
+
+test.compile(verilator_flags2=["--top-module", module, "-fno-inline"])
+
+test.passes()


### PR DESCRIPTION
Fixes #7016

## Summary
- Fix assertion failure in `GateDedupeVarVisitor::findDupe()` when using `-fno-inline` on modules with tristate ports
- Discovered as part of a `-fno-inline` audit for #1539

## Fix Details

### Root Cause
In `V3Tristate`, when creating `__en` (enable) pins for tristate signal decomposition, the pin expression `VarRef` always used `VAccess::WRITE`. For input ports (`inDeclProcessing == true`), the `__en` pin is an INPUT — the parent reads its value to send to the child — so the `VarRef` should use `VAccess::READ`. The incorrect write access caused `V3Inst` to generate `AstAssignW` nodes with `[LV]` on the RHS, creating wrong graph edges in `V3Gate` that triggered the dedup assertion.

With inlining enabled, cross-module pins are flattened before `V3Gate` runs, hiding the bug. With `-fno-inline`, the distinct `VarScope`s remain and the mismatch triggers:
```
%Error: Internal Error: V3Gate.cpp:961: Consumer doesn't match lhs of assign
```

### Changes
- **`src/V3Tristate.cpp`**: Use `inDeclProcessing ? VAccess::READ : VAccess::WRITE` for the `__en` pin expression, matching the correct data-flow direction based on port directionality.

### Tests

#### `t_altera_lpm_bustri_noinl`
Compiles `lpm_bustri` (tristate bus) with `-fno-inline`, which previously triggered the assertion.