### PR TITLE
Fix null pointer dereference with `.randomize()`

### DIFF
--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -4414,13 +4414,13 @@ class WidthVisitor final : public VNVisitor {
                     if (argp->exprp()) userIterate(argp->exprp(), WidthVP{SELF, BOTH}.p());
                 }
             }
-            methodCallLValueRecurse(nodep, nodep->fromp(), VAccess::WRITE);
+            methodCallLValueRecurse(nodep, nodep->fromp(), VAccess::READ);
             V3Randomize::newRandomizeFunc(m_memberMap, first_classp);
             handleRandomizeArgs(nodep, first_classp);
         } else if (nodep->name() == "srandom") {
             methodOkArguments(nodep, 1, 1);
             iterateCheckSigned32(nodep, "argument", methodArg(nodep, 0), BOTH);
-            methodCallLValueRecurse(nodep, nodep->fromp(), VAccess::WRITE);
+            methodCallLValueRecurse(nodep, nodep->fromp(), VAccess::READ);
             V3Randomize::newSRandomFunc(m_memberMap, first_classp);
         }
         UASSERT_OBJ(first_classp, nodep, "Unlinked");

--- a/test_regress/t/t_randomize_array_elem_with.py
+++ b/test_regress/t/t_randomize_array_elem_with.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+if not test.have_solver:
+    test.skip("No constraint solver installed")
+
+test.compile()
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_randomize_array_elem_with.v
+++ b/test_regress/t/t_randomize_array_elem_with.v
@@ -1,0 +1,34 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain
+// SPDX-FileCopyrightText: 2026 Antmicro
+// SPDX-License-Identifier: CC0-1.0
+
+class mbus_seq_item;
+  rand logic MREAD;
+endclass
+
+module t;
+  initial begin
+    mbus_seq_item req_c[10];
+    for (int i = 0; i < 10; i++) begin
+      req_c[i] = new;
+
+      if (req_c[i].randomize() with {MREAD == 0;} == 0) begin
+        $stop;
+      end
+      if (req_c[i].MREAD != 0) begin
+        $stop;
+      end
+
+      if (req_c[i].randomize() == 0) begin
+        $stop;
+      end
+
+      req_c[i].srandom(42);
+    end
+
+    $write("*-* All Finished *-*\n");
+    $finish;
+  end
+endmodule


### PR DESCRIPTION
Fixes a null pointer dereference when using `randomize()` method on an array-select in a loop. This is done by changing the object references passed to `randomize()` and `srandom()` to `READ` - the access mode any method called on the object would have, if the method internally modifies the object, it creates handles to its fields with `WRITE` access mode.