### PR TITLE
Testing: Bump vcddiff to latest

### DIFF
--- a/ci/ci-install.bash
+++ b/ci/ci-install.bash
@@ -43,7 +43,7 @@ fi
 install-vcddiff() {
   TMP_DIR="$(mktemp -d)"
   git clone https://github.com/veripool/vcddiff "$TMP_DIR"
-  git -C "${TMP_DIR}" checkout dca845020668887fd13498c772939814d9264fd5
+  git -C "${TMP_DIR}" checkout 4db0d84a27e8f148b127e916fc71d650837955c5
   "$MAKE" -C "${TMP_DIR}"
   sudo cp "${TMP_DIR}/vcddiff" /usr/local/bin
 }


### PR DESCRIPTION
Not sure why we have this pinned as we control it, bumping as new version has some fixes.