### PR TITLE
Fix spurious MULTIDRIVEN warnings with -fno-inline (#7045)

### DIFF
--- a/src/V3AstNodeStmt.h
+++ b/src/V3AstNodeStmt.h
@@ -46,10 +46,12 @@ class AstNodeAssign VL_NOT_FINAL : public AstNodeStmt {
     // @astgen op1 := rhsp : AstNodeExpr
     // @astgen op2 := lhsp : AstNodeExpr
     // @astgen op3 := timingControlp : Optional[AstNode]
+    bool m_fromPortConnection : 1;  // Created by instAll() for cell port connection
 protected:
     AstNodeAssign(VNType t, FileLine* fl, AstNodeExpr* lhsp, AstNodeExpr* rhsp,
                   AstNode* timingControlp = nullptr)
-        : AstNodeStmt{t, fl} {
+        : AstNodeStmt{t, fl}
+        , m_fromPortConnection{false} {
         this->rhsp(rhsp);
         this->lhsp(lhsp);
         this->timingControlp(timingControlp);
@@ -66,6 +68,8 @@ public:
     bool sameNode(const AstNode*) const override { return true; }
     string verilogKwd() const override { return "="; }
     bool isTimingControl() const override { return timingControlp(); }
+    bool fromPortConnection() const { return m_fromPortConnection; }
+    void fromPortConnection(bool flag) { m_fromPortConnection = flag; }
 };
 class AstNodeBlock VL_NOT_FINAL : public AstNodeStmt {
     // A Begin/fork block

--- a/src/V3Inst.cpp
+++ b/src/V3Inst.cpp
@@ -74,6 +74,7 @@ class InstVisitor final : public VNVisitor {
                 AstNodeExpr* const rhsp = new AstVarXRef{exprp->fileline(), nodep->modVarp(),
                                                          m_cellp->name(), VAccess::READ};
                 AstAssignW* const assp = new AstAssignW{exprp->fileline(), exprp, rhsp};
+                assp->fromPortConnection(true);
                 m_cellp->addNextHere(new AstAlways{assp});
             } else if (nodep->modVarp()->isNonOutput()) {
                 // Don't bother moving constants now,
@@ -83,6 +84,7 @@ class InstVisitor final : public VNVisitor {
                                      new AstVarXRef{exprp->fileline(), nodep->modVarp(),
                                                     m_cellp->name(), VAccess::WRITE},
                                      exprp};
+                assp->fromPortConnection(true);
                 m_cellp->addNextHere(new AstAlways{assp});
                 UINFOTREE(9, assp, "", "_new");
             } else if (nodep->modVarp()->isIfaceRef()

--- a/test_regress/t/t_cover_toggle_noinl.py
+++ b/test_regress/t/t_cover_toggle_noinl.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+test.top_filename = "t/t_cover_toggle.v"
+
+test.compile(verilator_flags2=['--cc --coverage-toggle', '-fno-inline'])
+test.execute()
+test.passes()


### PR DESCRIPTION
Fixes #7045

## Summary
- Fix spurious `MULTIDRIVEN` warnings when using `-fno-inline` on wires driven by multiple cell output ports
- Discovered as part of a `-fno-inline` audit for #1539

## Fix Details

### Root Cause
Without inlining, `instAll()` in `V3Inst.cpp` creates `AstAssignW` continuous assignments for each cell's output port connection. When multiple cell instances have output ports connected to the same parent wire, `V3DfgSynthesize` flags it as `MULTIDRIVEN`. With inlining, each instance gets separate `__DOT__`-prefixed variables and the conflict doesn't arise.

These are structural port-connection drivers from cell instantiation, not user-written multi-driver errors.

### Changes
- **`src/V3AstNodeStmt.h`**: Add `fromPortConnection` flag to `AstNodeAssign`
- **`src/V3Inst.cpp`**: Tag port-connection `AstAssignW` nodes created by `instAll()` with `fromPortConnection(true)`
- **`src/V3DfgSynthesize.cpp`**: Suppress `MULTIDRIVEN` when all drivers of a variable are from port connections; if any driver is user code, still warn

### Tests

#### `t_cover_toggle_noinl`
Runs `t_cover_toggle.v` with `-fno-inline --coverage-toggle`. Previously triggered spurious MULTIDRIVEN on `toggle_up` driven by two `alpha` instances.