### PR TITLE
Fix rand_mode()/constraint_mode() crash when used as function arguments (#7051)

### DIFF
--- a/src/V3Randomize.cpp
+++ b/src/V3Randomize.cpp
@@ -2835,7 +2835,12 @@ class RandomizeVisitor final : public VNVisitor {
             return;
         }
 
-        if (nodep->name() != "randomize") return;
+        if (nodep->name() != "randomize") {
+            // Iterate children so nested rand_mode/constraint_mode/randomize calls
+            // inside function arguments are still visited and transformed
+            iterateChildren(nodep);
+            return;
+        }
 
         if (nodep->classOrPackagep() && nodep->classOrPackagep()->name() == "std") {
             // Handle std::randomize; create wrapper function that calls basicStdRandomization on

--- a/test_regress/t/t_randomize_rand_mode_funcarg.py
+++ b/test_regress/t/t_randomize_rand_mode_funcarg.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile()
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_randomize_rand_mode_funcarg.v
+++ b/test_regress/t/t_randomize_rand_mode_funcarg.v
@@ -1,0 +1,48 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain.
+// SPDX-FileCopyrightText: 2026 PlanV GmbH
+// SPDX-License-Identifier: CC0-1.0
+
+// Test: rand_mode() used as a function argument (not standalone expression)
+// Ensures nested rand_mode() calls inside function arguments are properly
+// transformed and do not cause Internal Error in V3SplitVar.
+
+class RandModeClass;
+  rand int x;
+  rand int y;
+
+  constraint c { x inside {[1:255]}; y inside {[1:255]}; }
+
+  task check_mode(string name, int actual, int expected);
+    if (actual !== expected) begin
+      $display("Error: %s.rand_mode() = %0d, expected %0d", name, actual, expected);
+      $stop;
+    end
+  endtask
+
+  // Task that calls check_mode with rand_mode() as argument
+  task test_funcarg;
+    check_mode("x", x.rand_mode(), 1);
+    check_mode("y", y.rand_mode(), 1);
+
+    x.rand_mode(0);
+    check_mode("x", x.rand_mode(), 0);
+    check_mode("y", y.rand_mode(), 1);
+
+    x.rand_mode(1);
+    check_mode("x", x.rand_mode(), 1);
+
+    // Also test using rand_mode() in $display arguments
+    $display("x.rand_mode=%0d y.rand_mode=%0d", x.rand_mode(), y.rand_mode());
+  endtask
+endclass
+
+module t;
+  initial begin
+    automatic RandModeClass obj = new;
+    obj.test_funcarg();
+    $write("*-* All Finished *-*\n");
+    $finish;
+  end
+endmodule


### PR DESCRIPTION

## Summary

Fix internal error (`unlinked`) when `rand_mode()` or `constraint_mode()` is passed as a function argument. Per IEEE 1800-2017 §18.8/§18.9, these methods return int values and should be usable in any expression context.

## Issue

Fix #7051 

## Changes

- Added `iterateChildren(nodep)` before the early return in `RandomizeVisitor::visit(AstNodeFTaskRef*)` for non-randomize function calls, so nested `rand_mode`/`constraint_mode`/`randomize` method calls in function arguments are visited and transformed

## Test

- Added `test_regress/t/t_randomize_rand_mode_funcarg.{v,py}` — passes `rand_mode()` return value as function argument, verifies query and set operations

---

Written by Claude Code and PlanV GmbH.

Reviewed by YilouWang.
