### PR TITLE
Fix missing logic normalization when using -fno-gate (#6952)

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -30,6 +30,7 @@ Bartłomiej Chmiel
 Brian Li
 Cameron Kirk
 Cameron Waite
+Charitha Jeewanka
 Chih-Mao Chen
 Chris Bachhuber
 Chris Randall

--- a/src/V3Gate.cpp
+++ b/src/V3Gate.cpp
@@ -1291,7 +1291,7 @@ void V3Gate::gateAll(AstNetlist* netlistp) {
         // --- NON-CRITICAL OPTIMIZATIONS ---
         // Only run these aggressive logic reducers if gate optimization is enabled
         if (v3Global.opt.fGate()) {
-            
+
             // Remove redundant logic
             if (v3Global.opt.fDedupe()) {
                 GateDedupe::apply(*graphp);
@@ -1307,7 +1307,7 @@ void V3Gate::gateAll(AstNetlist* netlistp) {
             // Remove unused logic
             GateUnused::apply(*graphp);
             if (dumpGraphLevel() >= 3) graphp->dumpDotFilePrefixed("gate_final");
-            
+
         } // End of fGate() check
     }
 

--- a/src/V3Gate.cpp
+++ b/src/V3Gate.cpp
@@ -1284,26 +1284,33 @@ void V3Gate::gateAll(AstNetlist* netlistp) {
         graphp->removeRedundantEdgesSum(&V3GraphEdge::followAlwaysTrue);
         if (dumpGraphLevel() >= 6) graphp->dumpDotFilePrefixed("gate_simp");
 
-        // Inline variables
+        // Inline variables (CRITICAL for downstream scheduling)
         GateInline::apply(*graphp);
         if (dumpGraphLevel() >= 6) graphp->dumpDotFilePrefixed("gate_inline");
 
-        // Remove redundant logic
-        if (v3Global.opt.fDedupe()) {
-            GateDedupe::apply(*graphp);
-            if (dumpGraphLevel() >= 6) graphp->dumpDotFilePrefixed("gate_dedup");
-        }
+        // --- NON-CRITICAL OPTIMIZATIONS ---
+        // Only run these aggressive logic reducers if gate optimization is enabled
+        if (v3Global.opt.fGate()) {
+            
+            // Remove redundant logic
+            if (v3Global.opt.fDedupe()) {
+                GateDedupe::apply(*graphp);
+                if (dumpGraphLevel() >= 6) graphp->dumpDotFilePrefixed("gate_dedup");
+            }
 
-        // Merge assignments
-        if (v3Global.opt.fAssemble()) {
-            GateMergeAssignments::apply(*graphp);
-            if (dumpGraphLevel() >= 6) graphp->dumpDotFilePrefixed("gate_merge");
-        }
+            // Merge assignments
+            if (v3Global.opt.fAssemble()) {
+                GateMergeAssignments::apply(*graphp);
+                if (dumpGraphLevel() >= 6) graphp->dumpDotFilePrefixed("gate_merge");
+            }
 
-        // Remove unused logic
-        GateUnused::apply(*graphp);
-        if (dumpGraphLevel() >= 3) graphp->dumpDotFilePrefixed("gate_final");
+            // Remove unused logic
+            GateUnused::apply(*graphp);
+            if (dumpGraphLevel() >= 3) graphp->dumpDotFilePrefixed("gate_final");
+            
+        } // End of fGate() check
     }
 
     V3Global::dumpCheckGlobalTree("gate", 0, dumpTreeEitherLevel() >= 3);
 }
+

--- a/src/Verilator.cpp
+++ b/src/Verilator.cpp
@@ -420,12 +420,13 @@ static void process() {
 
             // Gate-based logic elimination; eliminate signals and push constant across cell
             // boundaries Instant propagation makes lots-o-constant reduction possibilities.
-            if (v3Global.opt.fGate()) {
-                V3Gate::gateAll(v3Global.rootp());
-                // V3Gate calls constant propagation itself.
-            } else {
-                v3info("Command Line disabled gate optimization with -fno-gate.  "
-                       "This may cause ordering problems.");
+            // Always run gateAll to perform critical downstream normalizations
+            // (like GateInline) even if fGate is false.
+            V3Gate::gateAll(v3Global.rootp());
+            
+            if (!v3Global.opt.fGate()) {
+                v3info("Command Line disabled gate optimization with -fno-gate. "
+                       "Only critical normalizations will be performed.");
             }
 
             // Combine COVERINCs with duplicate terms

--- a/src/Verilator.cpp
+++ b/src/Verilator.cpp
@@ -423,7 +423,7 @@ static void process() {
             // Always run gateAll to perform critical downstream normalizations
             // (like GateInline) even if fGate is false.
             V3Gate::gateAll(v3Global.rootp());
-            
+
             if (!v3Global.opt.fGate()) {
                 v3info("Command Line disabled gate optimization with -fno-gate. "
                        "Only critical normalizations will be performed.");


### PR DESCRIPTION
**The Issue:**
When compiling with `-O0` or `-fno-gate`, module-level var initializations evaluated via ternary operators were evaluating incorrectly as time-zero static initializations rather than continuous assignments.

**Root Cause:**
As noted by @wsnyder in #6952, downstream scheduling relies on V3Gate to normalize these variables. However, src/Verilator.cpp was unconditionally bypassing V3Gate::gateAll() when `-fno-gate` was set. Because `GateInline::apply()` never ran, the AST retained AstInitialStatic nodes for these variables, causing the scheduler to incorrectly place them in the `__Slow` path.

**The Fix:**
Modified the pipeline to ensure critical downstream normalizations run regardless of the gate optimization flag, while preserving `-O0` compile speed by bypassing heavy optimizations:

`src/Verilator.cpp`: Removed the `if (v3Global.opt.fGate()`) block around `V3Gate::gateAll()`, ensuring the pass is always entered.

`src/V3Gate.cpp`: Left` GateInline::apply(*graphp)` exposed so it always runs. Wrapped the subsequent, non-critical optimizations (GateDedupe, GateMergeAssignments, GateUnused) in an `if (v3Global.opt.fGate())` block.