### PR TITLE
Extend ALWCOMBORDER warning for VarXRefs.

### DIFF
--- a/test_regress/t/t_lint_always_comb_iface.v
+++ b/test_regress/t/t_lint_always_comb_iface.v
@@ -31,6 +31,8 @@ module t
    my_if out1_i ();
    my_if out2_i ();
    my_if out3_i ();
+   my_if out4a_i ();
+   my_if out4b_i ();
 
    assign in_i.valid   = in_valid;
    assign in_i.data    = in_data ;
@@ -50,6 +52,12 @@ module t
                             .out_i  (out3_i)
                             );
 
+   my_module4 my_module4_i (
+                            .in_i   (in_i  ),
+                            .outa_i  (out4a_i),
+                            .outb_i  (out4b_i)
+                            );
+
 endmodule
 
 module my_module1 (
@@ -57,7 +65,6 @@ module my_module1 (
                    my_if.master_mp out_i
                    );
 
-   // Gives ALWCOMBORDER warning
    always_comb
      begin
         out_i.valid = in_i.valid;
@@ -92,3 +99,21 @@ module my_module3 (
    assign out_i.data   = in_i.data ;
 
 endmodule
+
+module my_module4 (
+                   my_if.slave_mp  in_i,
+                   my_if.master_mp outa_i,
+                   my_if.master_mp outb_i
+                   );
+
+   // Works with two separate instances
+   always_comb
+     begin
+        outa_i.valid = in_i.valid;
+        outa_i.data  = in_i.data;
+        outb_i.valid = in_i.valid;
+        outb_i.data  = in_i.data;
+     end
+
+endmodule
+

--- a/test_regress/t/t_lint_always_comb_iface_order_bad.out
+++ b/test_regress/t/t_lint_always_comb_iface_order_bad.out
@@ -1,0 +1,7 @@
+%Warning-ALWCOMBORDER: t/t_lint_always_comb_iface_order_bad.v:55:15: Always_comb variable driven after use: 'valid'
+                                                                   : ... note: In instance 't.my_module_i'
+   55 |         out_i.valid = in_i.valid;
+      |               ^~~~~
+                       ... For warning description see https://verilator.org/warn/ALWCOMBORDER?v=latest
+                       ... Use "/* verilator lint_off ALWCOMBORDER */" and lint_on around source to disable this message.
+%Error: Exiting due to

--- a/test_regress/t/t_lint_always_comb_iface_order_bad.py
+++ b/test_regress/t/t_lint_always_comb_iface_order_bad.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2024 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('linter')
+
+test.lint(fails=True, expect_filename=test.golden_filename)
+
+test.passes()

--- a/test_regress/t/t_lint_always_comb_iface_order_bad.v
+++ b/test_regress/t/t_lint_always_comb_iface_order_bad.v
@@ -1,0 +1,58 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain.
+// SPDX-FileCopyrightText: 2017 Josh Redford
+// SPDX-License-Identifier: CC0-1.0
+
+interface my_if;
+
+   logic            valid;
+   logic [7:0]      data ;
+
+   modport slave_mp (
+                     input valid,
+                     input data
+                     );
+
+   modport master_mp (
+                      output valid,
+                      output data
+                      );
+
+endinterface
+
+module t
+  (
+   input wire       in_valid,
+   input wire [7:0] in_data
+   );
+
+   my_if in_i  ();
+   my_if out_i ();
+
+   assign in_i.valid   = in_valid;
+   assign in_i.data    = in_data ;
+
+   my_module my_module_i (
+                          .in_i   (in_i  ),
+                          .out_i  (out_i)
+                          );
+
+endmodule
+
+module my_module (
+                   my_if.slave_mp  in_i,
+                   my_if.master_mp out_i
+                   );
+
+   // Gives ALWCOMBORDER warning
+   always_comb
+     begin
+        if (out_i.valid)
+          out_i.data  = in_i.data;
+        else
+          out_i.data  = out_i.data;
+        out_i.valid = in_i.valid;
+     end
+
+endmodule


### PR DESCRIPTION
Currently VarXRefs are excluded from ALWCOMBORDER checks because they can point to different instances of a struct/interface. Use a map with a unique key per instance and always_comb block to be able to check ordering.