### PR TITLE
Internals: Remove all AstClassOrPackageRef in V3Width

### DIFF
--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -2232,10 +2232,6 @@ class WidthVisitor final : public VNVisitor {
         UINFO(4, "dtWidthed " << nodep);
         // No nodep->typedefp(nullptr) for now; V3WidthCommit needs to check accesses
         nodep->doingWidth(false);
-        // Reference resolved, delete explicit operand if remaining
-        if (AstNodeExpr* const clsOrPkgOpp = nodep->classOrPackageOpp()) {
-            VL_DO_DANGLING(clsOrPkgOpp->unlinkFrBack()->deleteTree(), clsOrPkgOpp);
-        }
     }
     void visit(AstTypedef* nodep) override {
         if (nodep->didWidthAndSet()) return;  // This node is a dtype & not both PRELIMed+FINALed

--- a/src/V3WidthCommit.cpp
+++ b/src/V3WidthCommit.cpp
@@ -531,6 +531,10 @@ private:
         }
         editDType(nodep);
     }
+    void visit(AstClassOrPackageRef* nodep) override {
+        // Reference must have been resolved, can delete these
+        VL_DO_DANGLING(pushDeletep(nodep->unlinkFrBack()), nodep);
+    }
     void visit(AstNode* nodep) override {
         iterateChildren(nodep);
         editDType(nodep);


### PR DESCRIPTION
#6834 set `hasDType()` of `AstClassOrPackageRef` to false as it was hitting the broken checks with that patch. However, there should be none of these nodes left after resolving parameters and references during V3Param/V3LinkDot. Unfortunately those are a bit messy when handling these, so safest seems to delete the remaining nodes in V3Width.