### PR TITLE
Fix basicp segfault in EmitCSyms::getSymCtorStmts (#7142)

### DIFF
--- a/src/V3EmitCSyms.cpp
+++ b/src/V3EmitCSyms.cpp
@@ -829,8 +829,7 @@ std::vector<std::string> EmitCSyms::getSymCtorStmts() {
             stmt += varp->vlEnumDir();  // VLVD_IN etc
             if (varp->dtypep()->skipRefp()->isSigned()) stmt += "|VLVF_SIGNED";
             if (AstBasicDType* const basicp = varp->dtypep()->skipRefp()->basicp()) {
-                if (basicp->keyword() == VBasicDTypeKwd::BIT)
-                    stmt += "|VLVF_BITVAR";
+                if (basicp->keyword() == VBasicDTypeKwd::BIT) stmt += "|VLVF_BITVAR";
             }
             stmt += ", ";
             stmt += std::to_string(udim);


### PR DESCRIPTION
This fixes #7142 for me. I'm not sure of the correctness though. Specifically, this prevents the segfault from happening, but if basicp() should never be NULL then the problem is elsewhere. Let me know and I can try to create a minimized replicator that I can share.