### PR TITLE
Optimize conditional merging across some impure statements

### DIFF
--- a/src/V3AstNodeExpr.h
+++ b/src/V3AstNodeExpr.h
@@ -620,6 +620,8 @@ public:
         init(text, setwidth);
     }
     ASTGEN_MEMBERS_AstCExpr;
+    void dump(std::ostream& str = std::cout) const override;
+    void dumpJson(std::ostream& str = std::cout) const override;
     // METHODS
     bool cleanOut() const override { return true; }
     std::string emitC() override { V3ERROR_NA_RETURN(""); }

--- a/src/V3AstNodes.cpp
+++ b/src/V3AstNodes.cpp
@@ -1849,6 +1849,14 @@ void AstCellInlineScope::dumpJson(std::ostream& str) const {
     dumpJsonStrFunc(str, origModName);
     dumpJsonGen(str);
 }
+void AstCExpr::dump(std::ostream& str) const {
+    this->AstNodeExpr::dump(str);
+    if (m_pure) str << " [PURE]";
+}
+void AstCExpr::dumpJson(std::ostream& str) const {
+    dumpJsonBoolIf(str, "pure", m_pure);
+    dumpJsonGen(str);
+}
 bool AstClass::isCacheableChild(const AstNode* nodep) {
     return VN_IS(nodep, Var) || VN_IS(nodep, Typedef)
            || (VN_IS(nodep, Constraint) && !VN_AS(nodep, Constraint)->isExternProto())

--- a/src/V3Task.cpp
+++ b/src/V3Task.cpp
@@ -765,7 +765,8 @@ class TaskVisitor final : public VNVisitor {
             // __Vscopep
             ccallp->addArgsp(snp);
             // __Vfilenamep
-            ccallp->addArgsp(new AstCExpr{flp, "\"" + flp->filenameEsc() + "\"", 64});
+            ccallp->addArgsp(
+                new AstCExpr{flp, AstCExpr::Pure{}, "\"" + flp->filenameEsc() + "\"", 64});
             // __Vlineno
             ccallp->addArgsp(new AstConst(flp, flp->lineno()));
         }

--- a/test_regress/t/t_json_only_debugcheck.out
+++ b/test_regress/t/t_json_only_debugcheck.out
@@ -109,7 +109,7 @@
         ],"filep": []},
         {"type":"STOP","name":"","addr":"(TC)","loc":"d,38:142,38:147"}
       ],"elsesp": []},
-      {"type":"IF","name":"","addr":"(UC)","loc":"d,39:10,39:12",
+      {"type":"IF","name":"","addr":"(UC)","loc":"d,39:34,39:37",
        "condp": [
         {"type":"NEQ","name":"","addr":"(VC)","loc":"d,39:34,39:37","dtypep":"(GB)",
          "lhsp": [
@@ -181,73 +181,34 @@
             ]}
           ],"scopeNamep": []}
         ],"filep": []},
-        {"type":"STOP","name":"","addr":"(TD)","loc":"d,39:158,39:163"}
-      ],"elsesp": []},
-      {"type":"IF","name":"","addr":"(UD)","loc":"d,40:10,40:12",
-       "condp": [
-        {"type":"NEQ","name":"","addr":"(VD)","loc":"d,40:26,40:29","dtypep":"(GB)",
-         "lhsp": [
-          {"type":"CONST","name":"4'h1","addr":"(WD)","loc":"d,40:31,40:34","dtypep":"(UB)"}
-        ],
-         "rhsp": [
-          {"type":"ARRAYSEL","name":"","addr":"(XD)","loc":"d,40:15,40:16","dtypep":"(BC)",
-           "fromp": [
-            {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(YD)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
-          ],
-           "bitp": [
-            {"type":"AND","name":"","addr":"(ZD)","loc":"d,40:15,40:16","dtypep":"(GC)",
-             "lhsp": [
-              {"type":"CONST","name":"32'h7","addr":"(AE)","loc":"d,40:15,40:16","dtypep":"(IC)"}
-            ],
-             "rhsp": [
-              {"type":"ARRAYSEL","name":"","addr":"(BE)","loc":"d,40:15,40:16","dtypep":"(GC)",
-               "fromp": [
-                {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(CE)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
-              ],
-               "bitp": [
-                {"type":"AND","name":"","addr":"(DE)","loc":"d,40:15,40:16","dtypep":"(GC)",
-                 "lhsp": [
-                  {"type":"CONST","name":"32'h7","addr":"(EE)","loc":"d,40:15,40:16","dtypep":"(IC)"}
-                ],
-                 "rhsp": [
-                  {"type":"CCAST","name":"","addr":"(FE)","loc":"d,40:15,40:16","dtypep":"(GC)","size":32,
-                   "lhsp": [
-                    {"type":"VARREF","name":"t.e","addr":"(GE)","loc":"d,40:15,40:16","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
-                  ]}
-                ]}
-              ]}
-            ]}
-          ]}
-        ]}
-      ],
-       "thensp": [
-        {"type":"DISPLAY","name":"","addr":"(HE)","loc":"d,40:43,40:49",
+        {"type":"STOP","name":"","addr":"(TD)","loc":"d,39:158,39:163"},
+        {"type":"DISPLAY","name":"","addr":"(UD)","loc":"d,40:43,40:49",
          "fmtp": [
-          {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:40:  got='h%x exp='h1\\n","addr":"(IE)","loc":"d,40:43,40:49","dtypep":"(SB)",
+          {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:40:  got='h%x exp='h1\\n","addr":"(VD)","loc":"d,40:43,40:49","dtypep":"(SB)",
            "exprsp": [
-            {"type":"ARRAYSEL","name":"","addr":"(JE)","loc":"d,40:122,40:123","dtypep":"(BC)",
+            {"type":"ARRAYSEL","name":"","addr":"(WD)","loc":"d,40:122,40:123","dtypep":"(BC)",
              "fromp": [
-              {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(KE)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+              {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(XD)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
             ],
              "bitp": [
-              {"type":"AND","name":"","addr":"(LE)","loc":"d,40:122,40:123","dtypep":"(GC)",
+              {"type":"AND","name":"","addr":"(YD)","loc":"d,40:122,40:123","dtypep":"(GC)",
                "lhsp": [
-                {"type":"CONST","name":"32'h7","addr":"(ME)","loc":"d,40:122,40:123","dtypep":"(IC)"}
+                {"type":"CONST","name":"32'h7","addr":"(ZD)","loc":"d,40:122,40:123","dtypep":"(IC)"}
               ],
                "rhsp": [
-                {"type":"ARRAYSEL","name":"","addr":"(NE)","loc":"d,40:122,40:123","dtypep":"(GC)",
+                {"type":"ARRAYSEL","name":"","addr":"(AE)","loc":"d,40:122,40:123","dtypep":"(GC)",
                  "fromp": [
-                  {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(OE)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(BE)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                 ],
                  "bitp": [
-                  {"type":"AND","name":"","addr":"(PE)","loc":"d,40:122,40:123","dtypep":"(GC)",
+                  {"type":"AND","name":"","addr":"(CE)","loc":"d,40:122,40:123","dtypep":"(GC)",
                    "lhsp": [
-                    {"type":"CONST","name":"32'h7","addr":"(QE)","loc":"d,40:122,40:123","dtypep":"(IC)"}
+                    {"type":"CONST","name":"32'h7","addr":"(DE)","loc":"d,40:122,40:123","dtypep":"(IC)"}
                   ],
                    "rhsp": [
-                    {"type":"CCAST","name":"","addr":"(RE)","loc":"d,40:122,40:123","dtypep":"(GC)","size":32,
+                    {"type":"CCAST","name":"","addr":"(EE)","loc":"d,40:122,40:123","dtypep":"(GC)","size":32,
                      "lhsp": [
-                      {"type":"VARREF","name":"t.e","addr":"(SE)","loc":"d,40:122,40:123","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"t.e","addr":"(FE)","loc":"d,40:122,40:123","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ]}
                   ]}
                 ]}
@@ -255,48 +216,48 @@
             ]}
           ],"scopeNamep": []}
         ],"filep": []},
-        {"type":"STOP","name":"","addr":"(TE)","loc":"d,40:142,40:147"}
+        {"type":"STOP","name":"","addr":"(GE)","loc":"d,40:142,40:147"}
       ],"elsesp": []},
-      {"type":"IF","name":"","addr":"(UE)","loc":"d,41:10,41:12",
+      {"type":"IF","name":"","addr":"(HE)","loc":"d,41:42,41:45",
        "condp": [
-        {"type":"NEQ","name":"","addr":"(VE)","loc":"d,41:42,41:45","dtypep":"(GB)",
+        {"type":"NEQ","name":"","addr":"(IE)","loc":"d,41:42,41:45","dtypep":"(GB)",
          "lhsp": [
-          {"type":"CONST","name":"4'h3","addr":"(WE)","loc":"d,41:47,41:50","dtypep":"(UB)"}
+          {"type":"CONST","name":"4'h3","addr":"(JE)","loc":"d,41:47,41:50","dtypep":"(UB)"}
         ],
          "rhsp": [
-          {"type":"ARRAYSEL","name":"","addr":"(XE)","loc":"d,41:15,41:16","dtypep":"(BC)",
+          {"type":"ARRAYSEL","name":"","addr":"(KE)","loc":"d,41:15,41:16","dtypep":"(BC)",
            "fromp": [
-            {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(YE)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(LE)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ],
            "bitp": [
-            {"type":"AND","name":"","addr":"(ZE)","loc":"d,41:15,41:16","dtypep":"(GC)",
+            {"type":"AND","name":"","addr":"(ME)","loc":"d,41:15,41:16","dtypep":"(GC)",
              "lhsp": [
-              {"type":"CONST","name":"32'h7","addr":"(AF)","loc":"d,41:15,41:16","dtypep":"(IC)"}
+              {"type":"CONST","name":"32'h7","addr":"(NE)","loc":"d,41:15,41:16","dtypep":"(IC)"}
             ],
              "rhsp": [
-              {"type":"ARRAYSEL","name":"","addr":"(BF)","loc":"d,41:15,41:16","dtypep":"(GC)",
+              {"type":"ARRAYSEL","name":"","addr":"(OE)","loc":"d,41:15,41:16","dtypep":"(GC)",
                "fromp": [
-                {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(CF)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(PE)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
               ],
                "bitp": [
-                {"type":"AND","name":"","addr":"(DF)","loc":"d,41:15,41:16","dtypep":"(GC)",
+                {"type":"AND","name":"","addr":"(QE)","loc":"d,41:15,41:16","dtypep":"(GC)",
                  "lhsp": [
-                  {"type":"CONST","name":"32'h7","addr":"(EF)","loc":"d,41:15,41:16","dtypep":"(IC)"}
+                  {"type":"CONST","name":"32'h7","addr":"(RE)","loc":"d,41:15,41:16","dtypep":"(IC)"}
                 ],
                  "rhsp": [
-                  {"type":"ARRAYSEL","name":"","addr":"(FF)","loc":"d,41:15,41:16","dtypep":"(GC)",
+                  {"type":"ARRAYSEL","name":"","addr":"(SE)","loc":"d,41:15,41:16","dtypep":"(GC)",
                    "fromp": [
-                    {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(GF)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(TE)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ],
                    "bitp": [
-                    {"type":"AND","name":"","addr":"(HF)","loc":"d,41:15,41:16","dtypep":"(GC)",
+                    {"type":"AND","name":"","addr":"(UE)","loc":"d,41:15,41:16","dtypep":"(GC)",
                      "lhsp": [
-                      {"type":"CONST","name":"32'h7","addr":"(IF)","loc":"d,41:15,41:16","dtypep":"(IC)"}
+                      {"type":"CONST","name":"32'h7","addr":"(VE)","loc":"d,41:15,41:16","dtypep":"(IC)"}
                     ],
                      "rhsp": [
-                      {"type":"CCAST","name":"","addr":"(JF)","loc":"d,41:15,41:16","dtypep":"(GC)","size":32,
+                      {"type":"CCAST","name":"","addr":"(WE)","loc":"d,41:15,41:16","dtypep":"(GC)","size":32,
                        "lhsp": [
-                        {"type":"VARREF","name":"t.e","addr":"(KF)","loc":"d,41:15,41:16","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                        {"type":"VARREF","name":"t.e","addr":"(XE)","loc":"d,41:15,41:16","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                       ]}
                     ]}
                   ]}
@@ -307,43 +268,43 @@
         ]}
       ],
        "thensp": [
-        {"type":"DISPLAY","name":"","addr":"(LF)","loc":"d,41:59,41:65",
+        {"type":"DISPLAY","name":"","addr":"(YE)","loc":"d,41:59,41:65",
          "fmtp": [
-          {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:41:  got='h%x exp='h3\\n","addr":"(MF)","loc":"d,41:59,41:65","dtypep":"(SB)",
+          {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:41:  got='h%x exp='h3\\n","addr":"(ZE)","loc":"d,41:59,41:65","dtypep":"(SB)",
            "exprsp": [
-            {"type":"ARRAYSEL","name":"","addr":"(NF)","loc":"d,41:138,41:139","dtypep":"(BC)",
+            {"type":"ARRAYSEL","name":"","addr":"(AF)","loc":"d,41:138,41:139","dtypep":"(BC)",
              "fromp": [
-              {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(OF)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+              {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(BF)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
             ],
              "bitp": [
-              {"type":"AND","name":"","addr":"(PF)","loc":"d,41:138,41:139","dtypep":"(GC)",
+              {"type":"AND","name":"","addr":"(CF)","loc":"d,41:138,41:139","dtypep":"(GC)",
                "lhsp": [
-                {"type":"CONST","name":"32'h7","addr":"(QF)","loc":"d,41:138,41:139","dtypep":"(IC)"}
+                {"type":"CONST","name":"32'h7","addr":"(DF)","loc":"d,41:138,41:139","dtypep":"(IC)"}
               ],
                "rhsp": [
-                {"type":"ARRAYSEL","name":"","addr":"(RF)","loc":"d,41:138,41:139","dtypep":"(GC)",
+                {"type":"ARRAYSEL","name":"","addr":"(EF)","loc":"d,41:138,41:139","dtypep":"(GC)",
                  "fromp": [
-                  {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(SF)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(FF)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                 ],
                  "bitp": [
-                  {"type":"AND","name":"","addr":"(TF)","loc":"d,41:138,41:139","dtypep":"(GC)",
+                  {"type":"AND","name":"","addr":"(GF)","loc":"d,41:138,41:139","dtypep":"(GC)",
                    "lhsp": [
-                    {"type":"CONST","name":"32'h7","addr":"(UF)","loc":"d,41:138,41:139","dtypep":"(IC)"}
+                    {"type":"CONST","name":"32'h7","addr":"(HF)","loc":"d,41:138,41:139","dtypep":"(IC)"}
                   ],
                    "rhsp": [
-                    {"type":"ARRAYSEL","name":"","addr":"(VF)","loc":"d,41:138,41:139","dtypep":"(GC)",
+                    {"type":"ARRAYSEL","name":"","addr":"(IF)","loc":"d,41:138,41:139","dtypep":"(GC)",
                      "fromp": [
-                      {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(WF)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(JF)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ],
                      "bitp": [
-                      {"type":"AND","name":"","addr":"(XF)","loc":"d,41:138,41:139","dtypep":"(GC)",
+                      {"type":"AND","name":"","addr":"(KF)","loc":"d,41:138,41:139","dtypep":"(GC)",
                        "lhsp": [
-                        {"type":"CONST","name":"32'h7","addr":"(YF)","loc":"d,41:138,41:139","dtypep":"(IC)"}
+                        {"type":"CONST","name":"32'h7","addr":"(LF)","loc":"d,41:138,41:139","dtypep":"(IC)"}
                       ],
                        "rhsp": [
-                        {"type":"CCAST","name":"","addr":"(ZF)","loc":"d,41:138,41:139","dtypep":"(GC)","size":32,
+                        {"type":"CCAST","name":"","addr":"(MF)","loc":"d,41:138,41:139","dtypep":"(GC)","size":32,
                          "lhsp": [
-                          {"type":"VARREF","name":"t.e","addr":"(AG)","loc":"d,41:138,41:139","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                          {"type":"VARREF","name":"t.e","addr":"(NF)","loc":"d,41:138,41:139","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                         ]}
                       ]}
                     ]}
@@ -353,95 +314,44 @@
             ]}
           ],"scopeNamep": []}
         ],"filep": []},
-        {"type":"STOP","name":"","addr":"(BG)","loc":"d,41:174,41:179"}
-      ],"elsesp": []},
-      {"type":"IF","name":"","addr":"(CG)","loc":"d,42:10,42:12",
-       "condp": [
-        {"type":"NEQ","name":"","addr":"(DG)","loc":"d,42:34,42:37","dtypep":"(GB)",
-         "lhsp": [
-          {"type":"CONST","name":"4'h3","addr":"(EG)","loc":"d,42:39,42:42","dtypep":"(UB)"}
-        ],
-         "rhsp": [
-          {"type":"ARRAYSEL","name":"","addr":"(FG)","loc":"d,42:15,42:16","dtypep":"(BC)",
-           "fromp": [
-            {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(GG)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
-          ],
-           "bitp": [
-            {"type":"AND","name":"","addr":"(HG)","loc":"d,42:15,42:16","dtypep":"(GC)",
-             "lhsp": [
-              {"type":"CONST","name":"32'h7","addr":"(IG)","loc":"d,42:15,42:16","dtypep":"(IC)"}
-            ],
-             "rhsp": [
-              {"type":"ARRAYSEL","name":"","addr":"(JG)","loc":"d,42:15,42:16","dtypep":"(GC)",
-               "fromp": [
-                {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(KG)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
-              ],
-               "bitp": [
-                {"type":"AND","name":"","addr":"(LG)","loc":"d,42:15,42:16","dtypep":"(GC)",
-                 "lhsp": [
-                  {"type":"CONST","name":"32'h7","addr":"(MG)","loc":"d,42:15,42:16","dtypep":"(IC)"}
-                ],
-                 "rhsp": [
-                  {"type":"ARRAYSEL","name":"","addr":"(NG)","loc":"d,42:15,42:16","dtypep":"(GC)",
-                   "fromp": [
-                    {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(OG)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
-                  ],
-                   "bitp": [
-                    {"type":"AND","name":"","addr":"(PG)","loc":"d,42:15,42:16","dtypep":"(GC)",
-                     "lhsp": [
-                      {"type":"CONST","name":"32'h7","addr":"(QG)","loc":"d,42:15,42:16","dtypep":"(IC)"}
-                    ],
-                     "rhsp": [
-                      {"type":"CCAST","name":"","addr":"(RG)","loc":"d,42:15,42:16","dtypep":"(GC)","size":32,
-                       "lhsp": [
-                        {"type":"VARREF","name":"t.e","addr":"(SG)","loc":"d,42:15,42:16","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
-                      ]}
-                    ]}
-                  ]}
-                ]}
-              ]}
-            ]}
-          ]}
-        ]}
-      ],
-       "thensp": [
-        {"type":"DISPLAY","name":"","addr":"(TG)","loc":"d,42:51,42:57",
+        {"type":"STOP","name":"","addr":"(OF)","loc":"d,41:174,41:179"},
+        {"type":"DISPLAY","name":"","addr":"(PF)","loc":"d,42:51,42:57",
          "fmtp": [
-          {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:42:  got='h%x exp='h3\\n","addr":"(UG)","loc":"d,42:51,42:57","dtypep":"(SB)",
+          {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:42:  got='h%x exp='h3\\n","addr":"(QF)","loc":"d,42:51,42:57","dtypep":"(SB)",
            "exprsp": [
-            {"type":"ARRAYSEL","name":"","addr":"(VG)","loc":"d,42:130,42:131","dtypep":"(BC)",
+            {"type":"ARRAYSEL","name":"","addr":"(RF)","loc":"d,42:130,42:131","dtypep":"(BC)",
              "fromp": [
-              {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(WG)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+              {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(SF)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
             ],
              "bitp": [
-              {"type":"AND","name":"","addr":"(XG)","loc":"d,42:130,42:131","dtypep":"(GC)",
+              {"type":"AND","name":"","addr":"(TF)","loc":"d,42:130,42:131","dtypep":"(GC)",
                "lhsp": [
-                {"type":"CONST","name":"32'h7","addr":"(YG)","loc":"d,42:130,42:131","dtypep":"(IC)"}
+                {"type":"CONST","name":"32'h7","addr":"(UF)","loc":"d,42:130,42:131","dtypep":"(IC)"}
               ],
                "rhsp": [
-                {"type":"ARRAYSEL","name":"","addr":"(ZG)","loc":"d,42:130,42:131","dtypep":"(GC)",
+                {"type":"ARRAYSEL","name":"","addr":"(VF)","loc":"d,42:130,42:131","dtypep":"(GC)",
                  "fromp": [
-                  {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(AH)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(WF)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                 ],
                  "bitp": [
-                  {"type":"AND","name":"","addr":"(BH)","loc":"d,42:130,42:131","dtypep":"(GC)",
+                  {"type":"AND","name":"","addr":"(XF)","loc":"d,42:130,42:131","dtypep":"(GC)",
                    "lhsp": [
-                    {"type":"CONST","name":"32'h7","addr":"(CH)","loc":"d,42:130,42:131","dtypep":"(IC)"}
+                    {"type":"CONST","name":"32'h7","addr":"(YF)","loc":"d,42:130,42:131","dtypep":"(IC)"}
                   ],
                    "rhsp": [
-                    {"type":"ARRAYSEL","name":"","addr":"(DH)","loc":"d,42:130,42:131","dtypep":"(GC)",
+                    {"type":"ARRAYSEL","name":"","addr":"(ZF)","loc":"d,42:130,42:131","dtypep":"(GC)",
                      "fromp": [
-                      {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(EH)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(AG)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ],
                      "bitp": [
-                      {"type":"AND","name":"","addr":"(FH)","loc":"d,42:130,42:131","dtypep":"(GC)",
+                      {"type":"AND","name":"","addr":"(BG)","loc":"d,42:130,42:131","dtypep":"(GC)",
                        "lhsp": [
-                        {"type":"CONST","name":"32'h7","addr":"(GH)","loc":"d,42:130,42:131","dtypep":"(IC)"}
+                        {"type":"CONST","name":"32'h7","addr":"(CG)","loc":"d,42:130,42:131","dtypep":"(IC)"}
                       ],
                        "rhsp": [
-                        {"type":"CCAST","name":"","addr":"(HH)","loc":"d,42:130,42:131","dtypep":"(GC)","size":32,
+                        {"type":"CCAST","name":"","addr":"(DG)","loc":"d,42:130,42:131","dtypep":"(GC)","size":32,
                          "lhsp": [
-                          {"type":"VARREF","name":"t.e","addr":"(IH)","loc":"d,42:130,42:131","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                          {"type":"VARREF","name":"t.e","addr":"(EG)","loc":"d,42:130,42:131","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                         ]}
                       ]}
                     ]}
@@ -451,95 +361,44 @@
             ]}
           ],"scopeNamep": []}
         ],"filep": []},
-        {"type":"STOP","name":"","addr":"(JH)","loc":"d,42:158,42:163"}
-      ],"elsesp": []},
-      {"type":"IF","name":"","addr":"(KH)","loc":"d,43:10,43:12",
-       "condp": [
-        {"type":"NEQ","name":"","addr":"(LH)","loc":"d,43:30,43:33","dtypep":"(GB)",
-         "lhsp": [
-          {"type":"CONST","name":"4'h3","addr":"(MH)","loc":"d,43:35,43:38","dtypep":"(UB)"}
-        ],
-         "rhsp": [
-          {"type":"ARRAYSEL","name":"","addr":"(NH)","loc":"d,43:15,43:16","dtypep":"(BC)",
-           "fromp": [
-            {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(OH)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
-          ],
-           "bitp": [
-            {"type":"AND","name":"","addr":"(PH)","loc":"d,43:15,43:16","dtypep":"(GC)",
-             "lhsp": [
-              {"type":"CONST","name":"32'h7","addr":"(QH)","loc":"d,43:15,43:16","dtypep":"(IC)"}
-            ],
-             "rhsp": [
-              {"type":"ARRAYSEL","name":"","addr":"(RH)","loc":"d,43:15,43:16","dtypep":"(GC)",
-               "fromp": [
-                {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(SH)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
-              ],
-               "bitp": [
-                {"type":"AND","name":"","addr":"(TH)","loc":"d,43:15,43:16","dtypep":"(GC)",
-                 "lhsp": [
-                  {"type":"CONST","name":"32'h7","addr":"(UH)","loc":"d,43:15,43:16","dtypep":"(IC)"}
-                ],
-                 "rhsp": [
-                  {"type":"ARRAYSEL","name":"","addr":"(VH)","loc":"d,43:15,43:16","dtypep":"(GC)",
-                   "fromp": [
-                    {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(WH)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
-                  ],
-                   "bitp": [
-                    {"type":"AND","name":"","addr":"(XH)","loc":"d,43:15,43:16","dtypep":"(GC)",
-                     "lhsp": [
-                      {"type":"CONST","name":"32'h7","addr":"(YH)","loc":"d,43:15,43:16","dtypep":"(IC)"}
-                    ],
-                     "rhsp": [
-                      {"type":"CCAST","name":"","addr":"(ZH)","loc":"d,43:15,43:16","dtypep":"(GC)","size":32,
-                       "lhsp": [
-                        {"type":"VARREF","name":"t.e","addr":"(AI)","loc":"d,43:15,43:16","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
-                      ]}
-                    ]}
-                  ]}
-                ]}
-              ]}
-            ]}
-          ]}
-        ]}
-      ],
-       "thensp": [
-        {"type":"DISPLAY","name":"","addr":"(BI)","loc":"d,43:47,43:53",
+        {"type":"STOP","name":"","addr":"(FG)","loc":"d,42:158,42:163"},
+        {"type":"DISPLAY","name":"","addr":"(GG)","loc":"d,43:47,43:53",
          "fmtp": [
-          {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:43:  got='h%x exp='h3\\n","addr":"(CI)","loc":"d,43:47,43:53","dtypep":"(SB)",
+          {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:43:  got='h%x exp='h3\\n","addr":"(HG)","loc":"d,43:47,43:53","dtypep":"(SB)",
            "exprsp": [
-            {"type":"ARRAYSEL","name":"","addr":"(DI)","loc":"d,43:126,43:127","dtypep":"(BC)",
+            {"type":"ARRAYSEL","name":"","addr":"(IG)","loc":"d,43:126,43:127","dtypep":"(BC)",
              "fromp": [
-              {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(EI)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+              {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(JG)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
             ],
              "bitp": [
-              {"type":"AND","name":"","addr":"(FI)","loc":"d,43:126,43:127","dtypep":"(GC)",
+              {"type":"AND","name":"","addr":"(KG)","loc":"d,43:126,43:127","dtypep":"(GC)",
                "lhsp": [
-                {"type":"CONST","name":"32'h7","addr":"(GI)","loc":"d,43:126,43:127","dtypep":"(IC)"}
+                {"type":"CONST","name":"32'h7","addr":"(LG)","loc":"d,43:126,43:127","dtypep":"(IC)"}
               ],
                "rhsp": [
-                {"type":"ARRAYSEL","name":"","addr":"(HI)","loc":"d,43:126,43:127","dtypep":"(GC)",
+                {"type":"ARRAYSEL","name":"","addr":"(MG)","loc":"d,43:126,43:127","dtypep":"(GC)",
                  "fromp": [
-                  {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(II)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(NG)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                 ],
                  "bitp": [
-                  {"type":"AND","name":"","addr":"(JI)","loc":"d,43:126,43:127","dtypep":"(GC)",
+                  {"type":"AND","name":"","addr":"(OG)","loc":"d,43:126,43:127","dtypep":"(GC)",
                    "lhsp": [
-                    {"type":"CONST","name":"32'h7","addr":"(KI)","loc":"d,43:126,43:127","dtypep":"(IC)"}
+                    {"type":"CONST","name":"32'h7","addr":"(PG)","loc":"d,43:126,43:127","dtypep":"(IC)"}
                   ],
                    "rhsp": [
-                    {"type":"ARRAYSEL","name":"","addr":"(LI)","loc":"d,43:126,43:127","dtypep":"(GC)",
+                    {"type":"ARRAYSEL","name":"","addr":"(QG)","loc":"d,43:126,43:127","dtypep":"(GC)",
                      "fromp": [
-                      {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(MI)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(RG)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ],
                      "bitp": [
-                      {"type":"AND","name":"","addr":"(NI)","loc":"d,43:126,43:127","dtypep":"(GC)",
+                      {"type":"AND","name":"","addr":"(SG)","loc":"d,43:126,43:127","dtypep":"(GC)",
                        "lhsp": [
-                        {"type":"CONST","name":"32'h7","addr":"(OI)","loc":"d,43:126,43:127","dtypep":"(IC)"}
+                        {"type":"CONST","name":"32'h7","addr":"(TG)","loc":"d,43:126,43:127","dtypep":"(IC)"}
                       ],
                        "rhsp": [
-                        {"type":"CCAST","name":"","addr":"(PI)","loc":"d,43:126,43:127","dtypep":"(GC)","size":32,
+                        {"type":"CCAST","name":"","addr":"(UG)","loc":"d,43:126,43:127","dtypep":"(GC)","size":32,
                          "lhsp": [
-                          {"type":"VARREF","name":"t.e","addr":"(QI)","loc":"d,43:126,43:127","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                          {"type":"VARREF","name":"t.e","addr":"(VG)","loc":"d,43:126,43:127","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                         ]}
                       ]}
                     ]}
@@ -549,138 +408,111 @@
             ]}
           ],"scopeNamep": []}
         ],"filep": []},
-        {"type":"STOP","name":"","addr":"(RI)","loc":"d,43:150,43:155"}
+        {"type":"STOP","name":"","addr":"(WG)","loc":"d,43:150,43:155"}
       ],"elsesp": []},
-      {"type":"IF","name":"","addr":"(SI)","loc":"d,44:10,44:12",
+      {"type":"IF","name":"","addr":"(XG)","loc":"d,44:23,44:26",
        "condp": [
-        {"type":"NEQ","name":"","addr":"(TI)","loc":"d,44:23,44:26","dtypep":"(GB)",
+        {"type":"NEQ","name":"","addr":"(YG)","loc":"d,44:23,44:26","dtypep":"(GB)",
          "lhsp": [
-          {"type":"CONST","name":"4'h1","addr":"(UI)","loc":"d,44:28,44:31","dtypep":"(UB)"}
+          {"type":"CONST","name":"4'h1","addr":"(ZG)","loc":"d,44:28,44:31","dtypep":"(UB)"}
         ],
          "rhsp": [
-          {"type":"ARRAYSEL","name":"","addr":"(VI)","loc":"d,44:15,44:16","dtypep":"(BC)",
+          {"type":"ARRAYSEL","name":"","addr":"(AH)","loc":"d,44:15,44:16","dtypep":"(BC)",
            "fromp": [
-            {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(WI)","loc":"d,17:12,17:16","dtypep":"(XI)","access":"RD","varp":"(YI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(BH)","loc":"d,17:12,17:16","dtypep":"(CH)","access":"RD","varp":"(DH)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ],
            "bitp": [
-            {"type":"AND","name":"","addr":"(ZI)","loc":"d,44:15,44:16","dtypep":"(GC)",
+            {"type":"AND","name":"","addr":"(EH)","loc":"d,44:15,44:16","dtypep":"(GC)",
              "lhsp": [
-              {"type":"CONST","name":"32'h7","addr":"(AJ)","loc":"d,44:15,44:16","dtypep":"(IC)"}
+              {"type":"CONST","name":"32'h7","addr":"(FH)","loc":"d,44:15,44:16","dtypep":"(IC)"}
             ],
              "rhsp": [
-              {"type":"CCAST","name":"","addr":"(BJ)","loc":"d,44:15,44:16","dtypep":"(GC)","size":32,
+              {"type":"CCAST","name":"","addr":"(GH)","loc":"d,44:15,44:16","dtypep":"(GC)","size":32,
                "lhsp": [
-                {"type":"VARREF","name":"t.e","addr":"(CJ)","loc":"d,44:15,44:16","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                {"type":"VARREF","name":"t.e","addr":"(HH)","loc":"d,44:15,44:16","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
               ]}
             ]}
           ]}
         ]}
       ],
        "thensp": [
-        {"type":"DISPLAY","name":"","addr":"(DJ)","loc":"d,44:40,44:46",
+        {"type":"DISPLAY","name":"","addr":"(IH)","loc":"d,44:40,44:46",
          "fmtp": [
-          {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:44:  got='h%x exp='h1\\n","addr":"(EJ)","loc":"d,44:40,44:46","dtypep":"(SB)",
+          {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:44:  got='h%x exp='h1\\n","addr":"(JH)","loc":"d,44:40,44:46","dtypep":"(SB)",
            "exprsp": [
-            {"type":"ARRAYSEL","name":"","addr":"(FJ)","loc":"d,44:119,44:120","dtypep":"(BC)",
+            {"type":"ARRAYSEL","name":"","addr":"(KH)","loc":"d,44:119,44:120","dtypep":"(BC)",
              "fromp": [
-              {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(GJ)","loc":"d,17:12,17:16","dtypep":"(XI)","access":"RD","varp":"(YI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+              {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(LH)","loc":"d,17:12,17:16","dtypep":"(CH)","access":"RD","varp":"(DH)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
             ],
              "bitp": [
-              {"type":"AND","name":"","addr":"(HJ)","loc":"d,44:119,44:120","dtypep":"(GC)",
+              {"type":"AND","name":"","addr":"(MH)","loc":"d,44:119,44:120","dtypep":"(GC)",
                "lhsp": [
-                {"type":"CONST","name":"32'h7","addr":"(IJ)","loc":"d,44:119,44:120","dtypep":"(IC)"}
+                {"type":"CONST","name":"32'h7","addr":"(NH)","loc":"d,44:119,44:120","dtypep":"(IC)"}
               ],
                "rhsp": [
-                {"type":"CCAST","name":"","addr":"(JJ)","loc":"d,44:119,44:120","dtypep":"(GC)","size":32,
+                {"type":"CCAST","name":"","addr":"(OH)","loc":"d,44:119,44:120","dtypep":"(GC)","size":32,
                  "lhsp": [
-                  {"type":"VARREF","name":"t.e","addr":"(KJ)","loc":"d,44:119,44:120","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"t.e","addr":"(PH)","loc":"d,44:119,44:120","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                 ]}
               ]}
             ]}
           ],"scopeNamep": []}
         ],"filep": []},
-        {"type":"STOP","name":"","addr":"(LJ)","loc":"d,44:136,44:141"}
-      ],"elsesp": []},
-      {"type":"IF","name":"","addr":"(MJ)","loc":"d,45:10,45:12",
-       "condp": [
-        {"type":"NEQ","name":"","addr":"(NJ)","loc":"d,45:26,45:29","dtypep":"(GB)",
-         "lhsp": [
-          {"type":"CONST","name":"4'h1","addr":"(OJ)","loc":"d,45:31,45:34","dtypep":"(UB)"}
-        ],
-         "rhsp": [
-          {"type":"ARRAYSEL","name":"","addr":"(PJ)","loc":"d,45:15,45:16","dtypep":"(BC)",
-           "fromp": [
-            {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(QJ)","loc":"d,17:12,17:16","dtypep":"(XI)","access":"RD","varp":"(YI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
-          ],
-           "bitp": [
-            {"type":"AND","name":"","addr":"(RJ)","loc":"d,45:15,45:16","dtypep":"(GC)",
-             "lhsp": [
-              {"type":"CONST","name":"32'h7","addr":"(SJ)","loc":"d,45:15,45:16","dtypep":"(IC)"}
-            ],
-             "rhsp": [
-              {"type":"CCAST","name":"","addr":"(TJ)","loc":"d,45:15,45:16","dtypep":"(GC)","size":32,
-               "lhsp": [
-                {"type":"VARREF","name":"t.e","addr":"(UJ)","loc":"d,45:15,45:16","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
-              ]}
-            ]}
-          ]}
-        ]}
-      ],
-       "thensp": [
-        {"type":"DISPLAY","name":"","addr":"(VJ)","loc":"d,45:43,45:49",
+        {"type":"STOP","name":"","addr":"(QH)","loc":"d,44:136,44:141"},
+        {"type":"DISPLAY","name":"","addr":"(RH)","loc":"d,45:43,45:49",
          "fmtp": [
-          {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:45:  got='h%x exp='h1\\n","addr":"(WJ)","loc":"d,45:43,45:49","dtypep":"(SB)",
+          {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:45:  got='h%x exp='h1\\n","addr":"(SH)","loc":"d,45:43,45:49","dtypep":"(SB)",
            "exprsp": [
-            {"type":"ARRAYSEL","name":"","addr":"(XJ)","loc":"d,45:122,45:123","dtypep":"(BC)",
+            {"type":"ARRAYSEL","name":"","addr":"(TH)","loc":"d,45:122,45:123","dtypep":"(BC)",
              "fromp": [
-              {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(YJ)","loc":"d,17:12,17:16","dtypep":"(XI)","access":"RD","varp":"(YI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+              {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(UH)","loc":"d,17:12,17:16","dtypep":"(CH)","access":"RD","varp":"(DH)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
             ],
              "bitp": [
-              {"type":"AND","name":"","addr":"(ZJ)","loc":"d,45:122,45:123","dtypep":"(GC)",
+              {"type":"AND","name":"","addr":"(VH)","loc":"d,45:122,45:123","dtypep":"(GC)",
                "lhsp": [
-                {"type":"CONST","name":"32'h7","addr":"(AK)","loc":"d,45:122,45:123","dtypep":"(IC)"}
+                {"type":"CONST","name":"32'h7","addr":"(WH)","loc":"d,45:122,45:123","dtypep":"(IC)"}
               ],
                "rhsp": [
-                {"type":"CCAST","name":"","addr":"(BK)","loc":"d,45:122,45:123","dtypep":"(GC)","size":32,
+                {"type":"CCAST","name":"","addr":"(XH)","loc":"d,45:122,45:123","dtypep":"(GC)","size":32,
                  "lhsp": [
-                  {"type":"VARREF","name":"t.e","addr":"(CK)","loc":"d,45:122,45:123","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"t.e","addr":"(YH)","loc":"d,45:122,45:123","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                 ]}
               ]}
             ]}
           ],"scopeNamep": []}
         ],"filep": []},
-        {"type":"STOP","name":"","addr":"(DK)","loc":"d,45:142,45:147"}
+        {"type":"STOP","name":"","addr":"(ZH)","loc":"d,45:142,45:147"}
       ],"elsesp": []},
-      {"type":"IF","name":"","addr":"(EK)","loc":"d,46:10,46:12",
+      {"type":"IF","name":"","addr":"(AI)","loc":"d,46:34,46:37",
        "condp": [
-        {"type":"NEQ","name":"","addr":"(FK)","loc":"d,46:34,46:37","dtypep":"(GB)",
+        {"type":"NEQ","name":"","addr":"(BI)","loc":"d,46:34,46:37","dtypep":"(GB)",
          "lhsp": [
-          {"type":"CONST","name":"4'h4","addr":"(GK)","loc":"d,46:39,46:42","dtypep":"(UB)"}
+          {"type":"CONST","name":"4'h4","addr":"(CI)","loc":"d,46:39,46:42","dtypep":"(UB)"}
         ],
          "rhsp": [
-          {"type":"ARRAYSEL","name":"","addr":"(HK)","loc":"d,46:15,46:16","dtypep":"(BC)",
+          {"type":"ARRAYSEL","name":"","addr":"(DI)","loc":"d,46:15,46:16","dtypep":"(BC)",
            "fromp": [
-            {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(IK)","loc":"d,17:12,17:16","dtypep":"(XI)","access":"RD","varp":"(YI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(EI)","loc":"d,17:12,17:16","dtypep":"(CH)","access":"RD","varp":"(DH)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ],
            "bitp": [
-            {"type":"AND","name":"","addr":"(JK)","loc":"d,46:15,46:16","dtypep":"(GC)",
+            {"type":"AND","name":"","addr":"(FI)","loc":"d,46:15,46:16","dtypep":"(GC)",
              "lhsp": [
-              {"type":"CONST","name":"32'h7","addr":"(KK)","loc":"d,46:15,46:16","dtypep":"(IC)"}
+              {"type":"CONST","name":"32'h7","addr":"(GI)","loc":"d,46:15,46:16","dtypep":"(IC)"}
             ],
              "rhsp": [
-              {"type":"ARRAYSEL","name":"","addr":"(LK)","loc":"d,46:15,46:16","dtypep":"(GC)",
+              {"type":"ARRAYSEL","name":"","addr":"(HI)","loc":"d,46:15,46:16","dtypep":"(GC)",
                "fromp": [
-                {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(MK)","loc":"d,17:12,17:16","dtypep":"(XI)","access":"RD","varp":"(YI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(II)","loc":"d,17:12,17:16","dtypep":"(CH)","access":"RD","varp":"(DH)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
               ],
                "bitp": [
-                {"type":"AND","name":"","addr":"(NK)","loc":"d,46:15,46:16","dtypep":"(GC)",
+                {"type":"AND","name":"","addr":"(JI)","loc":"d,46:15,46:16","dtypep":"(GC)",
                  "lhsp": [
-                  {"type":"CONST","name":"32'h7","addr":"(OK)","loc":"d,46:15,46:16","dtypep":"(IC)"}
+                  {"type":"CONST","name":"32'h7","addr":"(KI)","loc":"d,46:15,46:16","dtypep":"(IC)"}
                 ],
                  "rhsp": [
-                  {"type":"CCAST","name":"","addr":"(PK)","loc":"d,46:15,46:16","dtypep":"(GC)","size":32,
+                  {"type":"CCAST","name":"","addr":"(LI)","loc":"d,46:15,46:16","dtypep":"(GC)","size":32,
                    "lhsp": [
-                    {"type":"VARREF","name":"t.e","addr":"(QK)","loc":"d,46:15,46:16","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"t.e","addr":"(MI)","loc":"d,46:15,46:16","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ]}
                 ]}
               ]}
@@ -689,33 +521,33 @@
         ]}
       ],
        "thensp": [
-        {"type":"DISPLAY","name":"","addr":"(RK)","loc":"d,46:51,46:57",
+        {"type":"DISPLAY","name":"","addr":"(NI)","loc":"d,46:51,46:57",
          "fmtp": [
-          {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:46:  got='h%x exp='h4\\n","addr":"(SK)","loc":"d,46:51,46:57","dtypep":"(SB)",
+          {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:46:  got='h%x exp='h4\\n","addr":"(OI)","loc":"d,46:51,46:57","dtypep":"(SB)",
            "exprsp": [
-            {"type":"ARRAYSEL","name":"","addr":"(TK)","loc":"d,46:130,46:131","dtypep":"(BC)",
+            {"type":"ARRAYSEL","name":"","addr":"(PI)","loc":"d,46:130,46:131","dtypep":"(BC)",
              "fromp": [
-              {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(UK)","loc":"d,17:12,17:16","dtypep":"(XI)","access":"RD","varp":"(YI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+              {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(QI)","loc":"d,17:12,17:16","dtypep":"(CH)","access":"RD","varp":"(DH)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
             ],
              "bitp": [
-              {"type":"AND","name":"","addr":"(VK)","loc":"d,46:130,46:131","dtypep":"(GC)",
+              {"type":"AND","name":"","addr":"(RI)","loc":"d,46:130,46:131","dtypep":"(GC)",
                "lhsp": [
-                {"type":"CONST","name":"32'h7","addr":"(WK)","loc":"d,46:130,46:131","dtypep":"(IC)"}
+                {"type":"CONST","name":"32'h7","addr":"(SI)","loc":"d,46:130,46:131","dtypep":"(IC)"}
               ],
                "rhsp": [
-                {"type":"ARRAYSEL","name":"","addr":"(XK)","loc":"d,46:130,46:131","dtypep":"(GC)",
+                {"type":"ARRAYSEL","name":"","addr":"(TI)","loc":"d,46:130,46:131","dtypep":"(GC)",
                  "fromp": [
-                  {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(YK)","loc":"d,17:12,17:16","dtypep":"(XI)","access":"RD","varp":"(YI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(UI)","loc":"d,17:12,17:16","dtypep":"(CH)","access":"RD","varp":"(DH)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                 ],
                  "bitp": [
-                  {"type":"AND","name":"","addr":"(ZK)","loc":"d,46:130,46:131","dtypep":"(GC)",
+                  {"type":"AND","name":"","addr":"(VI)","loc":"d,46:130,46:131","dtypep":"(GC)",
                    "lhsp": [
-                    {"type":"CONST","name":"32'h7","addr":"(AL)","loc":"d,46:130,46:131","dtypep":"(IC)"}
+                    {"type":"CONST","name":"32'h7","addr":"(WI)","loc":"d,46:130,46:131","dtypep":"(IC)"}
                   ],
                    "rhsp": [
-                    {"type":"CCAST","name":"","addr":"(BL)","loc":"d,46:130,46:131","dtypep":"(GC)","size":32,
+                    {"type":"CCAST","name":"","addr":"(XI)","loc":"d,46:130,46:131","dtypep":"(GC)","size":32,
                      "lhsp": [
-                      {"type":"VARREF","name":"t.e","addr":"(CL)","loc":"d,46:130,46:131","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"t.e","addr":"(YI)","loc":"d,46:130,46:131","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ]}
                   ]}
                 ]}
@@ -723,73 +555,34 @@
             ]}
           ],"scopeNamep": []}
         ],"filep": []},
-        {"type":"STOP","name":"","addr":"(DL)","loc":"d,46:158,46:163"}
-      ],"elsesp": []},
-      {"type":"IF","name":"","addr":"(EL)","loc":"d,47:10,47:12",
-       "condp": [
-        {"type":"NEQ","name":"","addr":"(FL)","loc":"d,47:26,47:29","dtypep":"(GB)",
-         "lhsp": [
-          {"type":"CONST","name":"4'h4","addr":"(GL)","loc":"d,47:31,47:34","dtypep":"(UB)"}
-        ],
-         "rhsp": [
-          {"type":"ARRAYSEL","name":"","addr":"(HL)","loc":"d,47:15,47:16","dtypep":"(BC)",
-           "fromp": [
-            {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(IL)","loc":"d,17:12,17:16","dtypep":"(XI)","access":"RD","varp":"(YI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
-          ],
-           "bitp": [
-            {"type":"AND","name":"","addr":"(JL)","loc":"d,47:15,47:16","dtypep":"(GC)",
-             "lhsp": [
-              {"type":"CONST","name":"32'h7","addr":"(KL)","loc":"d,47:15,47:16","dtypep":"(IC)"}
-            ],
-             "rhsp": [
-              {"type":"ARRAYSEL","name":"","addr":"(LL)","loc":"d,47:15,47:16","dtypep":"(GC)",
-               "fromp": [
-                {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(ML)","loc":"d,17:12,17:16","dtypep":"(XI)","access":"RD","varp":"(YI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
-              ],
-               "bitp": [
-                {"type":"AND","name":"","addr":"(NL)","loc":"d,47:15,47:16","dtypep":"(GC)",
-                 "lhsp": [
-                  {"type":"CONST","name":"32'h7","addr":"(OL)","loc":"d,47:15,47:16","dtypep":"(IC)"}
-                ],
-                 "rhsp": [
-                  {"type":"CCAST","name":"","addr":"(PL)","loc":"d,47:15,47:16","dtypep":"(GC)","size":32,
-                   "lhsp": [
-                    {"type":"VARREF","name":"t.e","addr":"(QL)","loc":"d,47:15,47:16","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
-                  ]}
-                ]}
-              ]}
-            ]}
-          ]}
-        ]}
-      ],
-       "thensp": [
-        {"type":"DISPLAY","name":"","addr":"(RL)","loc":"d,47:43,47:49",
+        {"type":"STOP","name":"","addr":"(ZI)","loc":"d,46:158,46:163"},
+        {"type":"DISPLAY","name":"","addr":"(AJ)","loc":"d,47:43,47:49",
          "fmtp": [
-          {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:47:  got='h%x exp='h4\\n","addr":"(SL)","loc":"d,47:43,47:49","dtypep":"(SB)",
+          {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:47:  got='h%x exp='h4\\n","addr":"(BJ)","loc":"d,47:43,47:49","dtypep":"(SB)",
            "exprsp": [
-            {"type":"ARRAYSEL","name":"","addr":"(TL)","loc":"d,47:122,47:123","dtypep":"(BC)",
+            {"type":"ARRAYSEL","name":"","addr":"(CJ)","loc":"d,47:122,47:123","dtypep":"(BC)",
              "fromp": [
-              {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(UL)","loc":"d,17:12,17:16","dtypep":"(XI)","access":"RD","varp":"(YI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+              {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(DJ)","loc":"d,17:12,17:16","dtypep":"(CH)","access":"RD","varp":"(DH)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
             ],
              "bitp": [
-              {"type":"AND","name":"","addr":"(VL)","loc":"d,47:122,47:123","dtypep":"(GC)",
+              {"type":"AND","name":"","addr":"(EJ)","loc":"d,47:122,47:123","dtypep":"(GC)",
                "lhsp": [
-                {"type":"CONST","name":"32'h7","addr":"(WL)","loc":"d,47:122,47:123","dtypep":"(IC)"}
+                {"type":"CONST","name":"32'h7","addr":"(FJ)","loc":"d,47:122,47:123","dtypep":"(IC)"}
               ],
                "rhsp": [
-                {"type":"ARRAYSEL","name":"","addr":"(XL)","loc":"d,47:122,47:123","dtypep":"(GC)",
+                {"type":"ARRAYSEL","name":"","addr":"(GJ)","loc":"d,47:122,47:123","dtypep":"(GC)",
                  "fromp": [
-                  {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(YL)","loc":"d,17:12,17:16","dtypep":"(XI)","access":"RD","varp":"(YI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(HJ)","loc":"d,17:12,17:16","dtypep":"(CH)","access":"RD","varp":"(DH)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                 ],
                  "bitp": [
-                  {"type":"AND","name":"","addr":"(ZL)","loc":"d,47:122,47:123","dtypep":"(GC)",
+                  {"type":"AND","name":"","addr":"(IJ)","loc":"d,47:122,47:123","dtypep":"(GC)",
                    "lhsp": [
-                    {"type":"CONST","name":"32'h7","addr":"(AM)","loc":"d,47:122,47:123","dtypep":"(IC)"}
+                    {"type":"CONST","name":"32'h7","addr":"(JJ)","loc":"d,47:122,47:123","dtypep":"(IC)"}
                   ],
                    "rhsp": [
-                    {"type":"CCAST","name":"","addr":"(BM)","loc":"d,47:122,47:123","dtypep":"(GC)","size":32,
+                    {"type":"CCAST","name":"","addr":"(KJ)","loc":"d,47:122,47:123","dtypep":"(GC)","size":32,
                      "lhsp": [
-                      {"type":"VARREF","name":"t.e","addr":"(CM)","loc":"d,47:122,47:123","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"t.e","addr":"(LJ)","loc":"d,47:122,47:123","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ]}
                   ]}
                 ]}
@@ -797,96 +590,96 @@
             ]}
           ],"scopeNamep": []}
         ],"filep": []},
-        {"type":"STOP","name":"","addr":"(DM)","loc":"d,47:142,47:147"}
+        {"type":"STOP","name":"","addr":"(MJ)","loc":"d,47:142,47:147"}
       ],"elsesp": []},
-      {"type":"IF","name":"","addr":"(EM)","loc":"d,49:10,49:12",
+      {"type":"IF","name":"","addr":"(NJ)","loc":"d,49:10,49:12",
        "condp": [
-        {"type":"NEQN","name":"","addr":"(FM)","loc":"d,49:23,49:25","dtypep":"(GB)",
+        {"type":"NEQN","name":"","addr":"(OJ)","loc":"d,49:23,49:25","dtypep":"(GB)",
          "lhsp": [
-          {"type":"CONST","name":"\\\"E03\\\"","addr":"(GM)","loc":"d,49:27,49:32","dtypep":"(SB)"}
+          {"type":"CONST","name":"\\\"E03\\\"","addr":"(PJ)","loc":"d,49:27,49:32","dtypep":"(SB)"}
         ],
          "rhsp": [
-          {"type":"ARRAYSEL","name":"","addr":"(HM)","loc":"d,49:15,49:16","dtypep":"(SB)",
+          {"type":"ARRAYSEL","name":"","addr":"(QJ)","loc":"d,49:15,49:16","dtypep":"(SB)",
            "fromp": [
-            {"type":"VARREF","name":"__Venumtab_enum_name1","addr":"(IM)","loc":"d,17:12,17:16","dtypep":"(JM)","access":"RD","varp":"(KM)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"__Venumtab_enum_name1","addr":"(RJ)","loc":"d,17:12,17:16","dtypep":"(SJ)","access":"RD","varp":"(TJ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ],
            "bitp": [
-            {"type":"AND","name":"","addr":"(LM)","loc":"d,49:15,49:16","dtypep":"(GC)",
+            {"type":"AND","name":"","addr":"(UJ)","loc":"d,49:15,49:16","dtypep":"(GC)",
              "lhsp": [
-              {"type":"CONST","name":"32'h7","addr":"(MM)","loc":"d,49:15,49:16","dtypep":"(IC)"}
+              {"type":"CONST","name":"32'h7","addr":"(VJ)","loc":"d,49:15,49:16","dtypep":"(IC)"}
             ],
              "rhsp": [
-              {"type":"CCAST","name":"","addr":"(NM)","loc":"d,49:15,49:16","dtypep":"(GC)","size":32,
+              {"type":"CCAST","name":"","addr":"(WJ)","loc":"d,49:15,49:16","dtypep":"(GC)","size":32,
                "lhsp": [
-                {"type":"VARREF","name":"t.e","addr":"(OM)","loc":"d,49:15,49:16","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                {"type":"VARREF","name":"t.e","addr":"(XJ)","loc":"d,49:15,49:16","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
               ]}
             ]}
           ]}
         ]}
       ],
        "thensp": [
-        {"type":"ASSIGN","name":"","addr":"(PM)","loc":"d,49:120,49:121","dtypep":"(SB)",
+        {"type":"ASSIGN","name":"","addr":"(YJ)","loc":"d,49:120,49:121","dtypep":"(SB)",
          "rhsp": [
-          {"type":"ARRAYSEL","name":"","addr":"(QM)","loc":"d,49:120,49:121","dtypep":"(SB)",
+          {"type":"ARRAYSEL","name":"","addr":"(ZJ)","loc":"d,49:120,49:121","dtypep":"(SB)",
            "fromp": [
-            {"type":"VARREF","name":"__Venumtab_enum_name1","addr":"(RM)","loc":"d,17:12,17:16","dtypep":"(JM)","access":"RD","varp":"(KM)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"__Venumtab_enum_name1","addr":"(AK)","loc":"d,17:12,17:16","dtypep":"(SJ)","access":"RD","varp":"(TJ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ],
            "bitp": [
-            {"type":"AND","name":"","addr":"(SM)","loc":"d,49:120,49:121","dtypep":"(GC)",
+            {"type":"AND","name":"","addr":"(BK)","loc":"d,49:120,49:121","dtypep":"(GC)",
              "lhsp": [
-              {"type":"CONST","name":"32'h7","addr":"(TM)","loc":"d,49:120,49:121","dtypep":"(IC)"}
+              {"type":"CONST","name":"32'h7","addr":"(CK)","loc":"d,49:120,49:121","dtypep":"(IC)"}
             ],
              "rhsp": [
-              {"type":"CCAST","name":"","addr":"(UM)","loc":"d,49:120,49:121","dtypep":"(GC)","size":32,
+              {"type":"CCAST","name":"","addr":"(DK)","loc":"d,49:120,49:121","dtypep":"(GC)","size":32,
                "lhsp": [
-                {"type":"VARREF","name":"t.e","addr":"(VM)","loc":"d,49:120,49:121","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                {"type":"VARREF","name":"t.e","addr":"(EK)","loc":"d,49:120,49:121","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
               ]}
             ]}
           ]}
         ],
          "lhsp": [
-          {"type":"VARREF","name":"__Vtemp_1","addr":"(WM)","loc":"d,49:120,49:121","dtypep":"(SB)","access":"WR","varp":"(RB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+          {"type":"VARREF","name":"__Vtemp_1","addr":"(FK)","loc":"d,49:120,49:121","dtypep":"(SB)","access":"WR","varp":"(RB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
         ],"timingControlp": []},
-        {"type":"DISPLAY","name":"","addr":"(XM)","loc":"d,49:41,49:47",
+        {"type":"DISPLAY","name":"","addr":"(GK)","loc":"d,49:41,49:47",
          "fmtp": [
-          {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:49:  got='%@' exp='E03'\\n","addr":"(YM)","loc":"d,49:41,49:47","dtypep":"(SB)",
+          {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:49:  got='%@' exp='E03'\\n","addr":"(HK)","loc":"d,49:41,49:47","dtypep":"(SB)",
            "exprsp": [
-            {"type":"VARREF","name":"__Vtemp_1","addr":"(ZM)","loc":"d,49:120,49:121","dtypep":"(SB)","access":"RD","varp":"(RB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"__Vtemp_1","addr":"(IK)","loc":"d,49:120,49:121","dtypep":"(SB)","access":"RD","varp":"(RB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ],"scopeNamep": []}
         ],"filep": []},
-        {"type":"STOP","name":"","addr":"(AN)","loc":"d,49:139,49:144"}
+        {"type":"STOP","name":"","addr":"(JK)","loc":"d,49:139,49:144"}
       ],"elsesp": []},
-      {"type":"ASSIGN","name":"","addr":"(BN)","loc":"d,55:9,55:10","dtypep":"(UB)",
+      {"type":"ASSIGN","name":"","addr":"(KK)","loc":"d,55:9,55:10","dtypep":"(UB)",
        "rhsp": [
-        {"type":"CONST","name":"4'h4","addr":"(CN)","loc":"d,55:13,55:17","dtypep":"(UB)"}
+        {"type":"CONST","name":"4'h4","addr":"(LK)","loc":"d,55:13,55:17","dtypep":"(UB)"}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"t.e","addr":"(DN)","loc":"d,55:7,55:8","dtypep":"(UB)","access":"WR","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"t.e","addr":"(MK)","loc":"d,55:7,55:8","dtypep":"(UB)","access":"WR","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []}
     ]},
-    {"type":"CFUNC","name":"_eval_final","addr":"(EN)","loc":"a,0:0,0:0","slow":true,"scopep":"(Z)","argsp": [],"varsp": [],"stmtsp": []},
-    {"type":"CFUNC","name":"_eval_settle","addr":"(FN)","loc":"a,0:0,0:0","slow":true,"scopep":"(Z)","argsp": [],"varsp": [],"stmtsp": []},
-    {"type":"CFUNC","name":"_eval_triggers_vec__act","addr":"(GN)","loc":"a,0:0,0:0","scopep":"(Z)","argsp": [],"varsp": [],
+    {"type":"CFUNC","name":"_eval_final","addr":"(NK)","loc":"a,0:0,0:0","slow":true,"scopep":"(Z)","argsp": [],"varsp": [],"stmtsp": []},
+    {"type":"CFUNC","name":"_eval_settle","addr":"(OK)","loc":"a,0:0,0:0","slow":true,"scopep":"(Z)","argsp": [],"varsp": [],"stmtsp": []},
+    {"type":"CFUNC","name":"_eval_triggers_vec__act","addr":"(PK)","loc":"a,0:0,0:0","scopep":"(Z)","argsp": [],"varsp": [],
      "stmtsp": [
-      {"type":"ASSIGN","name":"","addr":"(HN)","loc":"d,11:8,11:9","dtypep":"(IN)",
+      {"type":"ASSIGN","name":"","addr":"(QK)","loc":"d,11:8,11:9","dtypep":"(RK)",
        "rhsp": [
-        {"type":"CCAST","name":"","addr":"(JN)","loc":"d,63:14,63:21","dtypep":"(KN)","size":64,
+        {"type":"CCAST","name":"","addr":"(SK)","loc":"d,63:14,63:21","dtypep":"(TK)","size":64,
          "lhsp": [
-          {"type":"CCAST","name":"","addr":"(LN)","loc":"d,63:14,63:21","dtypep":"(GB)","size":32,
+          {"type":"CCAST","name":"","addr":"(UK)","loc":"d,63:14,63:21","dtypep":"(GB)","size":32,
            "lhsp": [
-            {"type":"AND","name":"","addr":"(MN)","loc":"d,63:14,63:21","dtypep":"(GB)",
+            {"type":"AND","name":"","addr":"(VK)","loc":"d,63:14,63:21","dtypep":"(GB)",
              "lhsp": [
-              {"type":"CCAST","name":"","addr":"(NN)","loc":"d,63:22,63:25","dtypep":"(GB)","size":32,
+              {"type":"CCAST","name":"","addr":"(WK)","loc":"d,63:22,63:25","dtypep":"(GB)","size":32,
                "lhsp": [
-                {"type":"VARREF","name":"clk","addr":"(ON)","loc":"d,63:22,63:25","dtypep":"(GB)","access":"RD","varp":"(J)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                {"type":"VARREF","name":"clk","addr":"(XK)","loc":"d,63:22,63:25","dtypep":"(GB)","access":"RD","varp":"(J)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
               ]}
             ],
              "rhsp": [
-              {"type":"NOT","name":"","addr":"(PN)","loc":"d,63:14,63:21","dtypep":"(GB)",
+              {"type":"NOT","name":"","addr":"(YK)","loc":"d,63:14,63:21","dtypep":"(GB)",
                "lhsp": [
-                {"type":"CCAST","name":"","addr":"(QN)","loc":"d,63:14,63:21","dtypep":"(GB)","size":32,
+                {"type":"CCAST","name":"","addr":"(ZK)","loc":"d,63:14,63:21","dtypep":"(GB)","size":32,
                  "lhsp": [
-                  {"type":"VARREF","name":"__Vtrigprevexpr___TOP__clk__0","addr":"(RN)","loc":"d,63:14,63:21","dtypep":"(GB)","access":"RD","varp":"(N)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"__Vtrigprevexpr___TOP__clk__0","addr":"(AL)","loc":"d,63:14,63:21","dtypep":"(GB)","access":"RD","varp":"(N)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                 ]}
               ]}
             ]}
@@ -894,440 +687,413 @@
         ]}
       ],
        "lhsp": [
-        {"type":"ARRAYSEL","name":"","addr":"(SN)","loc":"d,11:8,11:9","dtypep":"(IN)",
+        {"type":"ARRAYSEL","name":"","addr":"(BL)","loc":"d,11:8,11:9","dtypep":"(RK)",
          "fromp": [
-          {"type":"VARREF","name":"__VactTriggered","addr":"(TN)","loc":"d,11:8,11:9","dtypep":"(W)","access":"WR","varp":"(V)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+          {"type":"VARREF","name":"__VactTriggered","addr":"(CL)","loc":"d,11:8,11:9","dtypep":"(W)","access":"WR","varp":"(V)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
         ],
          "bitp": [
-          {"type":"CONST","name":"32'h0","addr":"(UN)","loc":"d,11:8,11:9","dtypep":"(IC)"}
+          {"type":"CONST","name":"32'h0","addr":"(DL)","loc":"d,11:8,11:9","dtypep":"(IC)"}
         ]}
       ],"timingControlp": []},
-      {"type":"ASSIGN","name":"","addr":"(VN)","loc":"d,63:22,63:25","dtypep":"(GB)",
+      {"type":"ASSIGN","name":"","addr":"(EL)","loc":"d,63:22,63:25","dtypep":"(GB)",
        "rhsp": [
-        {"type":"VARREF","name":"clk","addr":"(WN)","loc":"d,63:22,63:25","dtypep":"(GB)","access":"RD","varp":"(J)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"clk","addr":"(FL)","loc":"d,63:22,63:25","dtypep":"(GB)","access":"RD","varp":"(J)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"__Vtrigprevexpr___TOP__clk__0","addr":"(XN)","loc":"d,63:22,63:25","dtypep":"(GB)","access":"WR","varp":"(N)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"__Vtrigprevexpr___TOP__clk__0","addr":"(GL)","loc":"d,63:22,63:25","dtypep":"(GB)","access":"WR","varp":"(N)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []}
     ]},
-    {"type":"CFUNC","name":"_dump_triggers__act","addr":"(YN)","loc":"a,0:0,0:0","slow":true,"isStatic":true,"scopep":"(Z)",
+    {"type":"CFUNC","name":"_dump_triggers__act","addr":"(HL)","loc":"a,0:0,0:0","slow":true,"isStatic":true,"scopep":"(Z)",
      "argsp": [
-      {"type":"VAR","name":"triggers","addr":"(ZN)","loc":"a,0:0,0:0","dtypep":"(W)","origName":"triggers","verilogName":"triggers","direction":"CONSTREF","isFuncLocal":true,"lifetime":"NONE","varType":"BLOCKTEMP","dtypeName":"","sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
-      {"type":"ASSIGN","name":"","addr":"(AO)","loc":"a,0:0,0:0","dtypep":"(W)",
+      {"type":"VAR","name":"triggers","addr":"(IL)","loc":"a,0:0,0:0","dtypep":"(W)","origName":"triggers","verilogName":"triggers","direction":"CONSTREF","isFuncLocal":true,"lifetime":"NONE","varType":"BLOCKTEMP","dtypeName":"","sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
+      {"type":"ASSIGN","name":"","addr":"(JL)","loc":"a,0:0,0:0","dtypep":"(W)",
        "rhsp": [
-        {"type":"CRESET","name":"","addr":"(BO)","loc":"a,0:0,0:0","dtypep":"(W)","constructing":true}
+        {"type":"CRESET","name":"","addr":"(KL)","loc":"a,0:0,0:0","dtypep":"(W)","constructing":true}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"triggers","addr":"(CO)","loc":"a,0:0,0:0","dtypep":"(W)","access":"WR","varp":"(ZN)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"triggers","addr":"(LL)","loc":"a,0:0,0:0","dtypep":"(W)","access":"WR","varp":"(IL)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []},
-      {"type":"VAR","name":"tag","addr":"(DO)","loc":"a,0:0,0:0","dtypep":"(SB)","origName":"tag","verilogName":"tag","direction":"CONSTREF","isFuncLocal":true,"lifetime":"NONE","varType":"BLOCKTEMP","dtypeName":"string","sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
-      {"type":"ASSIGN","name":"","addr":"(EO)","loc":"a,0:0,0:0","dtypep":"(SB)",
+      {"type":"VAR","name":"tag","addr":"(ML)","loc":"a,0:0,0:0","dtypep":"(SB)","origName":"tag","verilogName":"tag","direction":"CONSTREF","isFuncLocal":true,"lifetime":"NONE","varType":"BLOCKTEMP","dtypeName":"string","sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
+      {"type":"ASSIGN","name":"","addr":"(NL)","loc":"a,0:0,0:0","dtypep":"(SB)",
        "rhsp": [
-        {"type":"CRESET","name":"","addr":"(FO)","loc":"a,0:0,0:0","dtypep":"(SB)","constructing":true}
+        {"type":"CRESET","name":"","addr":"(OL)","loc":"a,0:0,0:0","dtypep":"(SB)","constructing":true}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"tag","addr":"(GO)","loc":"a,0:0,0:0","dtypep":"(SB)","access":"WR","varp":"(DO)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"tag","addr":"(PL)","loc":"a,0:0,0:0","dtypep":"(SB)","access":"WR","varp":"(ML)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []}
     ],"varsp": [],
      "stmtsp": [
-      {"type":"IF","name":"","addr":"(HO)","loc":"d,11:8,11:9",
+      {"type":"IF","name":"","addr":"(QL)","loc":"d,11:8,11:9",
        "condp": [
-        {"type":"AND","name":"","addr":"(IO)","loc":"d,11:8,11:9","dtypep":"(GB)",
+        {"type":"AND","name":"","addr":"(RL)","loc":"d,11:8,11:9","dtypep":"(GB)",
          "lhsp": [
-          {"type":"CONST","name":"32'h1","addr":"(JO)","loc":"d,11:8,11:9","dtypep":"(IC)"}
+          {"type":"CONST","name":"32'h1","addr":"(SL)","loc":"d,11:8,11:9","dtypep":"(IC)"}
         ],
          "rhsp": [
-          {"type":"NOT","name":"","addr":"(KO)","loc":"d,11:8,11:9","dtypep":"(GB)",
+          {"type":"NOT","name":"","addr":"(TL)","loc":"d,11:8,11:9","dtypep":"(GB)",
            "lhsp": [
-            {"type":"CCAST","name":"","addr":"(LO)","loc":"d,11:8,11:9","dtypep":"(GB)","size":32,
+            {"type":"CCAST","name":"","addr":"(UL)","loc":"d,11:8,11:9","dtypep":"(GB)","size":32,
              "lhsp": [
-              {"type":"CCALL","name":"","addr":"(MO)","loc":"d,11:8,11:9","dtypep":"(GB)","funcName":"_trigger_anySet__act","funcp":"(NO)",
+              {"type":"CCALL","name":"","addr":"(VL)","loc":"d,11:8,11:9","dtypep":"(GB)","funcName":"_trigger_anySet__act","funcp":"(WL)",
                "argsp": [
-                {"type":"VARREF","name":"triggers","addr":"(OO)","loc":"d,11:8,11:9","dtypep":"(W)","access":"WR","varp":"(ZN)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                {"type":"VARREF","name":"triggers","addr":"(XL)","loc":"d,11:8,11:9","dtypep":"(W)","access":"WR","varp":"(IL)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
               ]}
             ]}
           ]}
         ]}
       ],
        "thensp": [
-        {"type":"CSTMT","name":"","addr":"(PO)","loc":"d,11:8,11:9",
+        {"type":"CSTMT","name":"","addr":"(YL)","loc":"d,11:8,11:9",
          "nodesp": [
-          {"type":"TEXT","name":"","addr":"(QO)","loc":"d,11:8,11:9","text":"VL_DBG_MSGS(\"         No '\" + "},
-          {"type":"VARREF","name":"tag","addr":"(RO)","loc":"d,11:8,11:9","dtypep":"(SB)","access":"RD","varp":"(DO)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"},
-          {"type":"TEXT","name":"","addr":"(SO)","loc":"d,11:8,11:9","text":" + \"' region triggers active\\n\");"}
+          {"type":"TEXT","name":"","addr":"(ZL)","loc":"d,11:8,11:9","text":"VL_DBG_MSGS(\"         No '\" + "},
+          {"type":"VARREF","name":"tag","addr":"(AM)","loc":"d,11:8,11:9","dtypep":"(SB)","access":"RD","varp":"(ML)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"},
+          {"type":"TEXT","name":"","addr":"(BM)","loc":"d,11:8,11:9","text":" + \"' region triggers active\\n\");"}
         ]}
       ],"elsesp": []},
-      {"type":"IF","name":"","addr":"(TO)","loc":"d,11:8,11:9",
+      {"type":"IF","name":"","addr":"(CM)","loc":"d,11:8,11:9",
        "condp": [
-        {"type":"AND","name":"","addr":"(UO)","loc":"d,11:8,11:9","dtypep":"(GB)",
+        {"type":"AND","name":"","addr":"(DM)","loc":"d,11:8,11:9","dtypep":"(GB)",
          "lhsp": [
-          {"type":"CONST","name":"32'h1","addr":"(VO)","loc":"d,11:8,11:9","dtypep":"(IC)"}
+          {"type":"CONST","name":"32'h1","addr":"(EM)","loc":"d,11:8,11:9","dtypep":"(IC)"}
         ],
          "rhsp": [
-          {"type":"CCAST","name":"","addr":"(WO)","loc":"d,11:8,11:9","dtypep":"(GB)","size":32,
+          {"type":"CCAST","name":"","addr":"(FM)","loc":"d,11:8,11:9","dtypep":"(GB)","size":32,
            "lhsp": [
-            {"type":"ARRAYSEL","name":"","addr":"(XO)","loc":"d,11:8,11:9","dtypep":"(IN)",
+            {"type":"ARRAYSEL","name":"","addr":"(GM)","loc":"d,11:8,11:9","dtypep":"(RK)",
              "fromp": [
-              {"type":"VARREF","name":"triggers","addr":"(YO)","loc":"d,11:8,11:9","dtypep":"(W)","access":"RD","varp":"(ZN)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+              {"type":"VARREF","name":"triggers","addr":"(HM)","loc":"d,11:8,11:9","dtypep":"(W)","access":"RD","varp":"(IL)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
             ],
              "bitp": [
-              {"type":"CONST","name":"32'h0","addr":"(ZO)","loc":"d,11:8,11:9","dtypep":"(IC)"}
+              {"type":"CONST","name":"32'h0","addr":"(IM)","loc":"d,11:8,11:9","dtypep":"(IC)"}
             ]}
           ]}
         ]}
       ],
        "thensp": [
-        {"type":"CSTMT","name":"","addr":"(AP)","loc":"d,11:8,11:9",
+        {"type":"CSTMT","name":"","addr":"(JM)","loc":"d,11:8,11:9",
          "nodesp": [
-          {"type":"TEXT","name":"","addr":"(BP)","loc":"d,11:8,11:9","text":"VL_DBG_MSGS(\"         '\" + "},
-          {"type":"VARREF","name":"tag","addr":"(CP)","loc":"d,11:8,11:9","dtypep":"(SB)","access":"RD","varp":"(DO)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"},
-          {"type":"TEXT","name":"","addr":"(DP)","loc":"d,11:8,11:9","text":" + \"' region trigger index 0 is active: @(posedge clk)\\n\");"}
+          {"type":"TEXT","name":"","addr":"(KM)","loc":"d,11:8,11:9","text":"VL_DBG_MSGS(\"         '\" + "},
+          {"type":"VARREF","name":"tag","addr":"(LM)","loc":"d,11:8,11:9","dtypep":"(SB)","access":"RD","varp":"(ML)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"},
+          {"type":"TEXT","name":"","addr":"(MM)","loc":"d,11:8,11:9","text":" + \"' region trigger index 0 is active: @(posedge clk)\\n\");"}
         ]}
       ],"elsesp": []}
     ]},
-    {"type":"CFUNC","name":"_trigger_anySet__act","addr":"(NO)","loc":"a,0:0,0:0","isStatic":true,"scopep":"(Z)",
+    {"type":"CFUNC","name":"_trigger_anySet__act","addr":"(WL)","loc":"a,0:0,0:0","isStatic":true,"scopep":"(Z)",
      "argsp": [
-      {"type":"VAR","name":"in","addr":"(EP)","loc":"a,0:0,0:0","dtypep":"(W)","origName":"in","verilogName":"in","direction":"CONSTREF","isFuncLocal":true,"lifetime":"NONE","varType":"BLOCKTEMP","dtypeName":"","sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
-      {"type":"ASSIGN","name":"","addr":"(FP)","loc":"a,0:0,0:0","dtypep":"(W)",
+      {"type":"VAR","name":"in","addr":"(NM)","loc":"a,0:0,0:0","dtypep":"(W)","origName":"in","verilogName":"in","direction":"CONSTREF","isFuncLocal":true,"lifetime":"NONE","varType":"BLOCKTEMP","dtypeName":"","sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
+      {"type":"ASSIGN","name":"","addr":"(OM)","loc":"a,0:0,0:0","dtypep":"(W)",
        "rhsp": [
-        {"type":"CRESET","name":"","addr":"(GP)","loc":"a,0:0,0:0","dtypep":"(W)","constructing":true}
+        {"type":"CRESET","name":"","addr":"(PM)","loc":"a,0:0,0:0","dtypep":"(W)","constructing":true}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"in","addr":"(HP)","loc":"a,0:0,0:0","dtypep":"(W)","access":"WR","varp":"(EP)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"in","addr":"(QM)","loc":"a,0:0,0:0","dtypep":"(W)","access":"WR","varp":"(NM)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []}
     ],
      "varsp": [
-      {"type":"VAR","name":"n","addr":"(IP)","loc":"a,0:0,0:0","dtypep":"(JP)","origName":"n","verilogName":"n","direction":"NONE","noReset":true,"isFuncLocal":true,"lifetime":"NONE","varType":"BLOCKTEMP","dtypeName":"IData","sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []}
+      {"type":"VAR","name":"n","addr":"(RM)","loc":"a,0:0,0:0","dtypep":"(SM)","origName":"n","verilogName":"n","direction":"NONE","noReset":true,"isFuncLocal":true,"lifetime":"NONE","varType":"BLOCKTEMP","dtypeName":"IData","sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []}
     ],
      "stmtsp": [
-      {"type":"ASSIGN","name":"","addr":"(KP)","loc":"a,0:0,0:0","dtypep":"(JP)",
+      {"type":"ASSIGN","name":"","addr":"(TM)","loc":"a,0:0,0:0","dtypep":"(SM)",
        "rhsp": [
-        {"type":"CONST","name":"32'h0","addr":"(LP)","loc":"a,0:0,0:0","dtypep":"(IC)"}
+        {"type":"CONST","name":"32'h0","addr":"(UM)","loc":"a,0:0,0:0","dtypep":"(IC)"}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"n","addr":"(MP)","loc":"a,0:0,0:0","dtypep":"(JP)","access":"WR","varp":"(IP)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"n","addr":"(VM)","loc":"a,0:0,0:0","dtypep":"(SM)","access":"WR","varp":"(RM)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []},
-      {"type":"LOOP","name":"","addr":"(NP)","loc":"d,11:8,11:9","unroll":"default",
+      {"type":"LOOP","name":"","addr":"(WM)","loc":"d,11:8,11:9","unroll":"default",
        "stmtsp": [
-        {"type":"IF","name":"","addr":"(OP)","loc":"d,11:8,11:9",
+        {"type":"IF","name":"","addr":"(XM)","loc":"d,11:8,11:9",
          "condp": [
-          {"type":"ARRAYSEL","name":"","addr":"(PP)","loc":"d,11:8,11:9","dtypep":"(IN)",
+          {"type":"ARRAYSEL","name":"","addr":"(YM)","loc":"d,11:8,11:9","dtypep":"(RK)",
            "fromp": [
-            {"type":"VARREF","name":"in","addr":"(QP)","loc":"d,11:8,11:9","dtypep":"(W)","access":"RD","varp":"(EP)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"in","addr":"(ZM)","loc":"d,11:8,11:9","dtypep":"(W)","access":"RD","varp":"(NM)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ],
            "bitp": [
-            {"type":"VARREF","name":"n","addr":"(RP)","loc":"d,11:8,11:9","dtypep":"(JP)","access":"RD","varp":"(IP)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"n","addr":"(AN)","loc":"d,11:8,11:9","dtypep":"(SM)","access":"RD","varp":"(RM)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ]}
         ],
          "thensp": [
-          {"type":"CRETURN","name":"","addr":"(SP)","loc":"d,11:8,11:9",
+          {"type":"CRETURN","name":"","addr":"(BN)","loc":"d,11:8,11:9",
            "lhsp": [
-            {"type":"CONST","name":"1'h1","addr":"(TP)","loc":"d,11:8,11:9","dtypep":"(GB)"}
+            {"type":"CONST","name":"1'h1","addr":"(CN)","loc":"d,11:8,11:9","dtypep":"(GB)"}
           ]}
         ],"elsesp": []},
-        {"type":"ASSIGN","name":"","addr":"(UP)","loc":"a,0:0,0:0","dtypep":"(JP)",
+        {"type":"ASSIGN","name":"","addr":"(DN)","loc":"a,0:0,0:0","dtypep":"(SM)",
          "rhsp": [
-          {"type":"ADD","name":"","addr":"(VP)","loc":"a,0:0,0:0","dtypep":"(JP)",
+          {"type":"ADD","name":"","addr":"(EN)","loc":"a,0:0,0:0","dtypep":"(SM)",
            "lhsp": [
-            {"type":"CCAST","name":"","addr":"(WP)","loc":"a,0:0,0:0","dtypep":"(IC)","size":32,
+            {"type":"CCAST","name":"","addr":"(FN)","loc":"a,0:0,0:0","dtypep":"(IC)","size":32,
              "lhsp": [
-              {"type":"CONST","name":"32'h1","addr":"(XP)","loc":"a,0:0,0:0","dtypep":"(IC)"}
+              {"type":"CONST","name":"32'h1","addr":"(GN)","loc":"a,0:0,0:0","dtypep":"(IC)"}
             ]}
           ],
            "rhsp": [
-            {"type":"VARREF","name":"n","addr":"(YP)","loc":"a,0:0,0:0","dtypep":"(JP)","access":"RD","varp":"(IP)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"n","addr":"(HN)","loc":"a,0:0,0:0","dtypep":"(SM)","access":"RD","varp":"(RM)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ]}
         ],
          "lhsp": [
-          {"type":"VARREF","name":"n","addr":"(ZP)","loc":"a,0:0,0:0","dtypep":"(JP)","access":"WR","varp":"(IP)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+          {"type":"VARREF","name":"n","addr":"(IN)","loc":"a,0:0,0:0","dtypep":"(SM)","access":"WR","varp":"(RM)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
         ],"timingControlp": []},
-        {"type":"LOOPTEST","name":"","addr":"(AQ)","loc":"d,11:8,11:9",
+        {"type":"LOOPTEST","name":"","addr":"(JN)","loc":"d,11:8,11:9",
          "condp": [
-          {"type":"GT","name":"","addr":"(BQ)","loc":"d,11:8,11:9","dtypep":"(GB)",
+          {"type":"GT","name":"","addr":"(KN)","loc":"d,11:8,11:9","dtypep":"(GB)",
            "lhsp": [
-            {"type":"CONST","name":"32'h1","addr":"(CQ)","loc":"d,11:8,11:9","dtypep":"(IC)"}
+            {"type":"CONST","name":"32'h1","addr":"(LN)","loc":"d,11:8,11:9","dtypep":"(IC)"}
           ],
            "rhsp": [
-            {"type":"VARREF","name":"n","addr":"(DQ)","loc":"d,11:8,11:9","dtypep":"(JP)","access":"RD","varp":"(IP)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"n","addr":"(MN)","loc":"d,11:8,11:9","dtypep":"(SM)","access":"RD","varp":"(RM)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ]}
         ]}
       ],"contsp": []},
-      {"type":"CRETURN","name":"","addr":"(EQ)","loc":"d,11:8,11:9",
+      {"type":"CRETURN","name":"","addr":"(NN)","loc":"d,11:8,11:9",
        "lhsp": [
-        {"type":"CONST","name":"1'h0","addr":"(FQ)","loc":"d,11:8,11:9","dtypep":"(GB)"}
+        {"type":"CONST","name":"1'h0","addr":"(ON)","loc":"d,11:8,11:9","dtypep":"(GB)"}
       ]}
     ]},
-    {"type":"CFUNC","name":"_nba_sequent__TOP__0","addr":"(GQ)","loc":"d,23:17,23:20","scopep":"(Z)","argsp": [],
+    {"type":"CFUNC","name":"_nba_sequent__TOP__0","addr":"(PN)","loc":"d,23:17,23:20","scopep":"(Z)","argsp": [],
      "varsp": [
-      {"type":"VAR","name":"__Vdly__t.cyc","addr":"(HQ)","loc":"d,23:17,23:20","dtypep":"(S)","origName":"__Vdly__t__DOT__cyc","verilogName":"__Vdly__t.cyc","direction":"NONE","isFuncLocal":true,"lifetime":"NONE","varType":"BLOCKTEMP","dtypeName":"integer","sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
-      {"type":"ASSIGN","name":"","addr":"(IQ)","loc":"d,23:17,23:20","dtypep":"(S)",
+      {"type":"VAR","name":"__Vdly__t.cyc","addr":"(QN)","loc":"d,23:17,23:20","dtypep":"(S)","origName":"__Vdly__t__DOT__cyc","verilogName":"__Vdly__t.cyc","direction":"NONE","isFuncLocal":true,"lifetime":"NONE","varType":"BLOCKTEMP","dtypeName":"integer","sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
+      {"type":"ASSIGN","name":"","addr":"(RN)","loc":"d,23:17,23:20","dtypep":"(S)",
        "rhsp": [
-        {"type":"CRESET","name":"","addr":"(JQ)","loc":"d,23:17,23:20","dtypep":"(S)","constructing":true}
+        {"type":"CRESET","name":"","addr":"(SN)","loc":"d,23:17,23:20","dtypep":"(S)","constructing":true}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"__Vdly__t.cyc","addr":"(KQ)","loc":"d,23:17,23:20","dtypep":"(S)","access":"WR","varp":"(HQ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"__Vdly__t.cyc","addr":"(TN)","loc":"d,23:17,23:20","dtypep":"(S)","access":"WR","varp":"(QN)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []},
-      {"type":"VAR","name":"__Vdly__t.e","addr":"(LQ)","loc":"d,24:9,24:10","dtypep":"(M)","origName":"__Vdly__t__DOT__e","verilogName":"__Vdly__t.e","direction":"NONE","isFuncLocal":true,"lifetime":"NONE","varType":"BLOCKTEMP","dtypeName":"my_t","sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
-      {"type":"ASSIGN","name":"","addr":"(MQ)","loc":"d,24:9,24:10","dtypep":"(M)",
+      {"type":"VAR","name":"__Vdly__t.e","addr":"(UN)","loc":"d,24:9,24:10","dtypep":"(M)","origName":"__Vdly__t__DOT__e","verilogName":"__Vdly__t.e","direction":"NONE","isFuncLocal":true,"lifetime":"NONE","varType":"BLOCKTEMP","dtypeName":"my_t","sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
+      {"type":"ASSIGN","name":"","addr":"(VN)","loc":"d,24:9,24:10","dtypep":"(M)",
        "rhsp": [
-        {"type":"CRESET","name":"","addr":"(NQ)","loc":"d,24:9,24:10","dtypep":"(M)","constructing":true}
+        {"type":"CRESET","name":"","addr":"(WN)","loc":"d,24:9,24:10","dtypep":"(M)","constructing":true}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"__Vdly__t.e","addr":"(OQ)","loc":"d,24:9,24:10","dtypep":"(M)","access":"WR","varp":"(LQ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"__Vdly__t.e","addr":"(XN)","loc":"d,24:9,24:10","dtypep":"(M)","access":"WR","varp":"(UN)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []},
-      {"type":"VAR","name":"__Vtemp_1","addr":"(PQ)","loc":"d,70:123,70:124","dtypep":"(SB)","origName":"__Vtemp_1","verilogName":"__Vtemp_1","direction":"NONE","lifetime":"NONE","varType":"STMTTEMP","dtypeName":"string","sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
-      {"type":"VAR","name":"__Vtemp_2","addr":"(QQ)","loc":"d,80:123,80:124","dtypep":"(SB)","origName":"__Vtemp_2","verilogName":"__Vtemp_2","direction":"NONE","lifetime":"NONE","varType":"STMTTEMP","dtypeName":"string","sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
-      {"type":"VAR","name":"__Vtemp_3","addr":"(RQ)","loc":"d,90:123,90:124","dtypep":"(SB)","origName":"__Vtemp_3","verilogName":"__Vtemp_3","direction":"NONE","lifetime":"NONE","varType":"STMTTEMP","dtypeName":"string","sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []}
+      {"type":"VAR","name":"__Vtemp_1","addr":"(YN)","loc":"d,70:123,70:124","dtypep":"(SB)","origName":"__Vtemp_1","verilogName":"__Vtemp_1","direction":"NONE","lifetime":"NONE","varType":"STMTTEMP","dtypeName":"string","sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
+      {"type":"VAR","name":"__Vtemp_2","addr":"(ZN)","loc":"d,80:123,80:124","dtypep":"(SB)","origName":"__Vtemp_2","verilogName":"__Vtemp_2","direction":"NONE","lifetime":"NONE","varType":"STMTTEMP","dtypeName":"string","sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
+      {"type":"VAR","name":"__Vtemp_3","addr":"(AO)","loc":"d,90:123,90:124","dtypep":"(SB)","origName":"__Vtemp_3","verilogName":"__Vtemp_3","direction":"NONE","lifetime":"NONE","varType":"STMTTEMP","dtypeName":"string","sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []}
     ],
      "stmtsp": [
-      {"type":"ASSIGN","name":"","addr":"(SQ)","loc":"d,23:17,23:20","dtypep":"(S)",
+      {"type":"ASSIGN","name":"","addr":"(BO)","loc":"d,23:17,23:20","dtypep":"(S)",
        "rhsp": [
-        {"type":"VARREF","name":"t.cyc","addr":"(TQ)","loc":"d,23:17,23:20","dtypep":"(S)","access":"RD","varp":"(R)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"t.cyc","addr":"(CO)","loc":"d,23:17,23:20","dtypep":"(S)","access":"RD","varp":"(R)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"__Vdly__t.cyc","addr":"(UQ)","loc":"d,23:17,23:20","dtypep":"(S)","access":"WR","varp":"(HQ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"__Vdly__t.cyc","addr":"(DO)","loc":"d,23:17,23:20","dtypep":"(S)","access":"WR","varp":"(QN)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []},
-      {"type":"ASSIGN","name":"","addr":"(VQ)","loc":"d,24:9,24:10","dtypep":"(UB)",
+      {"type":"ASSIGN","name":"","addr":"(EO)","loc":"d,24:9,24:10","dtypep":"(UB)",
        "rhsp": [
-        {"type":"VARREF","name":"t.e","addr":"(WQ)","loc":"d,24:9,24:10","dtypep":"(UB)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"t.e","addr":"(FO)","loc":"d,24:9,24:10","dtypep":"(UB)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"__Vdly__t.e","addr":"(XQ)","loc":"d,24:9,24:10","dtypep":"(UB)","access":"WR","varp":"(LQ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"__Vdly__t.e","addr":"(GO)","loc":"d,24:9,24:10","dtypep":"(UB)","access":"WR","varp":"(UN)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []},
-      {"type":"ASSIGNDLY","name":"","addr":"(YQ)","loc":"d,64:11,64:13","dtypep":"(S)",
+      {"type":"ASSIGNDLY","name":"","addr":"(HO)","loc":"d,64:11,64:13","dtypep":"(S)",
        "rhsp": [
-        {"type":"ADD","name":"","addr":"(ZQ)","loc":"d,64:18,64:19","dtypep":"(S)",
+        {"type":"ADD","name":"","addr":"(IO)","loc":"d,64:18,64:19","dtypep":"(S)",
          "lhsp": [
-          {"type":"CCAST","name":"","addr":"(AR)","loc":"d,64:20,64:21","dtypep":"(IC)","size":32,
+          {"type":"CCAST","name":"","addr":"(JO)","loc":"d,64:20,64:21","dtypep":"(IC)","size":32,
            "lhsp": [
-            {"type":"CONST","name":"32'sh1","addr":"(BR)","loc":"d,64:20,64:21","dtypep":"(LB)"}
+            {"type":"CONST","name":"32'sh1","addr":"(KO)","loc":"d,64:20,64:21","dtypep":"(LB)"}
           ]}
         ],
          "rhsp": [
-          {"type":"VARREF","name":"t.cyc","addr":"(CR)","loc":"d,64:14,64:17","dtypep":"(S)","access":"RD","varp":"(R)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+          {"type":"VARREF","name":"t.cyc","addr":"(LO)","loc":"d,64:14,64:17","dtypep":"(S)","access":"RD","varp":"(R)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
         ]}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"__Vdly__t.cyc","addr":"(DR)","loc":"d,64:7,64:10","dtypep":"(S)","access":"WR","varp":"(HQ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"__Vdly__t.cyc","addr":"(MO)","loc":"d,64:7,64:10","dtypep":"(S)","access":"WR","varp":"(QN)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []},
-      {"type":"IF","name":"","addr":"(ER)","loc":"d,65:7,65:9",
+      {"type":"IF","name":"","addr":"(NO)","loc":"d,65:7,65:9",
        "condp": [
-        {"type":"EQ","name":"","addr":"(FR)","loc":"d,65:14,65:16","dtypep":"(GB)",
+        {"type":"EQ","name":"","addr":"(OO)","loc":"d,65:14,65:16","dtypep":"(GB)",
          "lhsp": [
-          {"type":"CONST","name":"32'sh0","addr":"(GR)","loc":"d,65:16,65:17","dtypep":"(LB)"}
+          {"type":"CONST","name":"32'sh0","addr":"(PO)","loc":"d,65:16,65:17","dtypep":"(LB)"}
         ],
          "rhsp": [
-          {"type":"VARREF","name":"t.cyc","addr":"(HR)","loc":"d,65:11,65:14","dtypep":"(S)","access":"RD","varp":"(R)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+          {"type":"VARREF","name":"t.cyc","addr":"(QO)","loc":"d,65:11,65:14","dtypep":"(S)","access":"RD","varp":"(R)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
         ]}
       ],
        "thensp": [
-        {"type":"ASSIGNDLY","name":"","addr":"(IR)","loc":"d,67:12,67:14","dtypep":"(UB)",
+        {"type":"ASSIGNDLY","name":"","addr":"(RO)","loc":"d,67:12,67:14","dtypep":"(UB)",
          "rhsp": [
-          {"type":"CONST","name":"4'h1","addr":"(JR)","loc":"d,67:15,67:18","dtypep":"(UB)"}
+          {"type":"CONST","name":"4'h1","addr":"(SO)","loc":"d,67:15,67:18","dtypep":"(UB)"}
         ],
          "lhsp": [
-          {"type":"VARREF","name":"__Vdly__t.e","addr":"(KR)","loc":"d,67:10,67:11","dtypep":"(UB)","access":"WR","varp":"(LQ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+          {"type":"VARREF","name":"__Vdly__t.e","addr":"(TO)","loc":"d,67:10,67:11","dtypep":"(UB)","access":"WR","varp":"(UN)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
         ],"timingControlp": []}
       ],
        "elsesp": [
-        {"type":"IF","name":"","addr":"(LR)","loc":"d,69:12,69:14",
+        {"type":"IF","name":"","addr":"(UO)","loc":"d,69:12,69:14",
          "condp": [
-          {"type":"EQ","name":"","addr":"(MR)","loc":"d,69:19,69:21","dtypep":"(GB)",
+          {"type":"EQ","name":"","addr":"(VO)","loc":"d,69:19,69:21","dtypep":"(GB)",
            "lhsp": [
-            {"type":"CONST","name":"32'sh1","addr":"(NR)","loc":"d,69:21,69:22","dtypep":"(LB)"}
+            {"type":"CONST","name":"32'sh1","addr":"(WO)","loc":"d,69:21,69:22","dtypep":"(LB)"}
           ],
            "rhsp": [
-            {"type":"VARREF","name":"t.cyc","addr":"(OR)","loc":"d,69:16,69:19","dtypep":"(S)","access":"RD","varp":"(R)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"t.cyc","addr":"(XO)","loc":"d,69:16,69:19","dtypep":"(S)","access":"RD","varp":"(R)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ]}
         ],
          "thensp": [
-          {"type":"IF","name":"","addr":"(PR)","loc":"d,70:13,70:15",
+          {"type":"IF","name":"","addr":"(YO)","loc":"d,70:13,70:15",
            "condp": [
-            {"type":"NEQN","name":"","addr":"(QR)","loc":"d,70:26,70:28","dtypep":"(GB)",
+            {"type":"NEQN","name":"","addr":"(ZO)","loc":"d,70:26,70:28","dtypep":"(GB)",
              "lhsp": [
-              {"type":"CONST","name":"\\\"E01\\\"","addr":"(RR)","loc":"d,70:30,70:35","dtypep":"(SB)"}
+              {"type":"CONST","name":"\\\"E01\\\"","addr":"(AP)","loc":"d,70:30,70:35","dtypep":"(SB)"}
             ],
              "rhsp": [
-              {"type":"ARRAYSEL","name":"","addr":"(SR)","loc":"d,70:18,70:19","dtypep":"(SB)",
+              {"type":"ARRAYSEL","name":"","addr":"(BP)","loc":"d,70:18,70:19","dtypep":"(SB)",
                "fromp": [
-                {"type":"VARREF","name":"__Venumtab_enum_name1","addr":"(TR)","loc":"d,17:12,17:16","dtypep":"(JM)","access":"RD","varp":"(KM)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                {"type":"VARREF","name":"__Venumtab_enum_name1","addr":"(CP)","loc":"d,17:12,17:16","dtypep":"(SJ)","access":"RD","varp":"(TJ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
               ],
                "bitp": [
-                {"type":"AND","name":"","addr":"(UR)","loc":"d,70:18,70:19","dtypep":"(GC)",
+                {"type":"AND","name":"","addr":"(DP)","loc":"d,70:18,70:19","dtypep":"(GC)",
                  "lhsp": [
-                  {"type":"CONST","name":"32'h7","addr":"(VR)","loc":"d,70:18,70:19","dtypep":"(IC)"}
+                  {"type":"CONST","name":"32'h7","addr":"(EP)","loc":"d,70:18,70:19","dtypep":"(IC)"}
                 ],
                  "rhsp": [
-                  {"type":"CCAST","name":"","addr":"(WR)","loc":"d,70:18,70:19","dtypep":"(GC)","size":32,
+                  {"type":"CCAST","name":"","addr":"(FP)","loc":"d,70:18,70:19","dtypep":"(GC)","size":32,
                    "lhsp": [
-                    {"type":"VARREF","name":"t.e","addr":"(XR)","loc":"d,70:18,70:19","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"t.e","addr":"(GP)","loc":"d,70:18,70:19","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ]}
                 ]}
               ]}
             ]}
           ],
            "thensp": [
-            {"type":"ASSIGN","name":"","addr":"(YR)","loc":"d,70:123,70:124","dtypep":"(SB)",
+            {"type":"ASSIGN","name":"","addr":"(HP)","loc":"d,70:123,70:124","dtypep":"(SB)",
              "rhsp": [
-              {"type":"ARRAYSEL","name":"","addr":"(ZR)","loc":"d,70:123,70:124","dtypep":"(SB)",
+              {"type":"ARRAYSEL","name":"","addr":"(IP)","loc":"d,70:123,70:124","dtypep":"(SB)",
                "fromp": [
-                {"type":"VARREF","name":"__Venumtab_enum_name1","addr":"(AS)","loc":"d,17:12,17:16","dtypep":"(JM)","access":"RD","varp":"(KM)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                {"type":"VARREF","name":"__Venumtab_enum_name1","addr":"(JP)","loc":"d,17:12,17:16","dtypep":"(SJ)","access":"RD","varp":"(TJ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
               ],
                "bitp": [
-                {"type":"AND","name":"","addr":"(BS)","loc":"d,70:123,70:124","dtypep":"(GC)",
+                {"type":"AND","name":"","addr":"(KP)","loc":"d,70:123,70:124","dtypep":"(GC)",
                  "lhsp": [
-                  {"type":"CONST","name":"32'h7","addr":"(CS)","loc":"d,70:123,70:124","dtypep":"(IC)"}
+                  {"type":"CONST","name":"32'h7","addr":"(LP)","loc":"d,70:123,70:124","dtypep":"(IC)"}
                 ],
                  "rhsp": [
-                  {"type":"CCAST","name":"","addr":"(DS)","loc":"d,70:123,70:124","dtypep":"(GC)","size":32,
+                  {"type":"CCAST","name":"","addr":"(MP)","loc":"d,70:123,70:124","dtypep":"(GC)","size":32,
                    "lhsp": [
-                    {"type":"VARREF","name":"t.e","addr":"(ES)","loc":"d,70:123,70:124","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"t.e","addr":"(NP)","loc":"d,70:123,70:124","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ]}
                 ]}
               ]}
             ],
              "lhsp": [
-              {"type":"VARREF","name":"__Vtemp_1","addr":"(FS)","loc":"d,70:123,70:124","dtypep":"(SB)","access":"WR","varp":"(PQ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+              {"type":"VARREF","name":"__Vtemp_1","addr":"(OP)","loc":"d,70:123,70:124","dtypep":"(SB)","access":"WR","varp":"(YN)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
             ],"timingControlp": []},
-            {"type":"DISPLAY","name":"","addr":"(GS)","loc":"d,70:44,70:50",
+            {"type":"DISPLAY","name":"","addr":"(PP)","loc":"d,70:44,70:50",
              "fmtp": [
-              {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:70:  got='%@' exp='E01'\\n","addr":"(HS)","loc":"d,70:44,70:50","dtypep":"(SB)",
+              {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:70:  got='%@' exp='E01'\\n","addr":"(QP)","loc":"d,70:44,70:50","dtypep":"(SB)",
                "exprsp": [
-                {"type":"VARREF","name":"__Vtemp_1","addr":"(IS)","loc":"d,70:123,70:124","dtypep":"(SB)","access":"RD","varp":"(PQ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                {"type":"VARREF","name":"__Vtemp_1","addr":"(RP)","loc":"d,70:123,70:124","dtypep":"(SB)","access":"RD","varp":"(YN)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
               ],"scopeNamep": []}
             ],"filep": []},
-            {"type":"STOP","name":"","addr":"(JS)","loc":"d,70:142,70:147"}
+            {"type":"STOP","name":"","addr":"(SP)","loc":"d,70:142,70:147"}
           ],"elsesp": []},
-          {"type":"IF","name":"","addr":"(KS)","loc":"d,71:13,71:15",
+          {"type":"IF","name":"","addr":"(TP)","loc":"d,71:26,71:29",
            "condp": [
-            {"type":"NEQ","name":"","addr":"(LS)","loc":"d,71:26,71:29","dtypep":"(GB)",
+            {"type":"NEQ","name":"","addr":"(UP)","loc":"d,71:26,71:29","dtypep":"(GB)",
              "lhsp": [
-              {"type":"CONST","name":"4'h3","addr":"(MS)","loc":"d,71:31,71:34","dtypep":"(UB)"}
+              {"type":"CONST","name":"4'h3","addr":"(VP)","loc":"d,71:31,71:34","dtypep":"(UB)"}
             ],
              "rhsp": [
-              {"type":"ARRAYSEL","name":"","addr":"(NS)","loc":"d,71:18,71:19","dtypep":"(BC)",
+              {"type":"ARRAYSEL","name":"","addr":"(WP)","loc":"d,71:18,71:19","dtypep":"(BC)",
                "fromp": [
-                {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(OS)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(XP)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
               ],
                "bitp": [
-                {"type":"AND","name":"","addr":"(PS)","loc":"d,71:18,71:19","dtypep":"(GC)",
+                {"type":"AND","name":"","addr":"(YP)","loc":"d,71:18,71:19","dtypep":"(GC)",
                  "lhsp": [
-                  {"type":"CONST","name":"32'h7","addr":"(QS)","loc":"d,71:18,71:19","dtypep":"(IC)"}
+                  {"type":"CONST","name":"32'h7","addr":"(ZP)","loc":"d,71:18,71:19","dtypep":"(IC)"}
                 ],
                  "rhsp": [
-                  {"type":"CCAST","name":"","addr":"(RS)","loc":"d,71:18,71:19","dtypep":"(GC)","size":32,
+                  {"type":"CCAST","name":"","addr":"(AQ)","loc":"d,71:18,71:19","dtypep":"(GC)","size":32,
                    "lhsp": [
-                    {"type":"VARREF","name":"t.e","addr":"(SS)","loc":"d,71:18,71:19","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"t.e","addr":"(BQ)","loc":"d,71:18,71:19","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ]}
                 ]}
               ]}
             ]}
           ],
            "thensp": [
-            {"type":"DISPLAY","name":"","addr":"(TS)","loc":"d,71:43,71:49",
+            {"type":"DISPLAY","name":"","addr":"(CQ)","loc":"d,71:43,71:49",
              "fmtp": [
-              {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:71:  got='h%x exp='h3\\n","addr":"(US)","loc":"d,71:43,71:49","dtypep":"(SB)",
+              {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:71:  got='h%x exp='h3\\n","addr":"(DQ)","loc":"d,71:43,71:49","dtypep":"(SB)",
                "exprsp": [
-                {"type":"ARRAYSEL","name":"","addr":"(VS)","loc":"d,71:122,71:123","dtypep":"(BC)",
+                {"type":"ARRAYSEL","name":"","addr":"(EQ)","loc":"d,71:122,71:123","dtypep":"(BC)",
                  "fromp": [
-                  {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(WS)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(FQ)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                 ],
                  "bitp": [
-                  {"type":"AND","name":"","addr":"(XS)","loc":"d,71:122,71:123","dtypep":"(GC)",
+                  {"type":"AND","name":"","addr":"(GQ)","loc":"d,71:122,71:123","dtypep":"(GC)",
                    "lhsp": [
-                    {"type":"CONST","name":"32'h7","addr":"(YS)","loc":"d,71:122,71:123","dtypep":"(IC)"}
+                    {"type":"CONST","name":"32'h7","addr":"(HQ)","loc":"d,71:122,71:123","dtypep":"(IC)"}
                   ],
                    "rhsp": [
-                    {"type":"CCAST","name":"","addr":"(ZS)","loc":"d,71:122,71:123","dtypep":"(GC)","size":32,
+                    {"type":"CCAST","name":"","addr":"(IQ)","loc":"d,71:122,71:123","dtypep":"(GC)","size":32,
                      "lhsp": [
-                      {"type":"VARREF","name":"t.e","addr":"(AT)","loc":"d,71:122,71:123","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"t.e","addr":"(JQ)","loc":"d,71:122,71:123","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ]}
                   ]}
                 ]}
               ],"scopeNamep": []}
             ],"filep": []},
-            {"type":"STOP","name":"","addr":"(BT)","loc":"d,71:139,71:144"}
-          ],"elsesp": []},
-          {"type":"IF","name":"","addr":"(CT)","loc":"d,72:13,72:15",
-           "condp": [
-            {"type":"NEQ","name":"","addr":"(DT)","loc":"d,72:29,72:32","dtypep":"(GB)",
-             "lhsp": [
-              {"type":"CONST","name":"4'h3","addr":"(ET)","loc":"d,72:34,72:37","dtypep":"(UB)"}
-            ],
-             "rhsp": [
-              {"type":"ARRAYSEL","name":"","addr":"(FT)","loc":"d,72:18,72:19","dtypep":"(BC)",
-               "fromp": [
-                {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(GT)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
-              ],
-               "bitp": [
-                {"type":"AND","name":"","addr":"(HT)","loc":"d,72:18,72:19","dtypep":"(GC)",
-                 "lhsp": [
-                  {"type":"CONST","name":"32'h7","addr":"(IT)","loc":"d,72:18,72:19","dtypep":"(IC)"}
-                ],
-                 "rhsp": [
-                  {"type":"CCAST","name":"","addr":"(JT)","loc":"d,72:18,72:19","dtypep":"(GC)","size":32,
-                   "lhsp": [
-                    {"type":"VARREF","name":"t.e","addr":"(KT)","loc":"d,72:18,72:19","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
-                  ]}
-                ]}
-              ]}
-            ]}
-          ],
-           "thensp": [
-            {"type":"DISPLAY","name":"","addr":"(LT)","loc":"d,72:46,72:52",
+            {"type":"STOP","name":"","addr":"(KQ)","loc":"d,71:139,71:144"},
+            {"type":"DISPLAY","name":"","addr":"(LQ)","loc":"d,72:46,72:52",
              "fmtp": [
-              {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:72:  got='h%x exp='h3\\n","addr":"(MT)","loc":"d,72:46,72:52","dtypep":"(SB)",
+              {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:72:  got='h%x exp='h3\\n","addr":"(MQ)","loc":"d,72:46,72:52","dtypep":"(SB)",
                "exprsp": [
-                {"type":"ARRAYSEL","name":"","addr":"(NT)","loc":"d,72:125,72:126","dtypep":"(BC)",
+                {"type":"ARRAYSEL","name":"","addr":"(NQ)","loc":"d,72:125,72:126","dtypep":"(BC)",
                  "fromp": [
-                  {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(OT)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(OQ)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                 ],
                  "bitp": [
-                  {"type":"AND","name":"","addr":"(PT)","loc":"d,72:125,72:126","dtypep":"(GC)",
+                  {"type":"AND","name":"","addr":"(PQ)","loc":"d,72:125,72:126","dtypep":"(GC)",
                    "lhsp": [
-                    {"type":"CONST","name":"32'h7","addr":"(QT)","loc":"d,72:125,72:126","dtypep":"(IC)"}
+                    {"type":"CONST","name":"32'h7","addr":"(QQ)","loc":"d,72:125,72:126","dtypep":"(IC)"}
                   ],
                    "rhsp": [
-                    {"type":"CCAST","name":"","addr":"(RT)","loc":"d,72:125,72:126","dtypep":"(GC)","size":32,
+                    {"type":"CCAST","name":"","addr":"(RQ)","loc":"d,72:125,72:126","dtypep":"(GC)","size":32,
                      "lhsp": [
-                      {"type":"VARREF","name":"t.e","addr":"(ST)","loc":"d,72:125,72:126","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"t.e","addr":"(SQ)","loc":"d,72:125,72:126","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ]}
                   ]}
                 ]}
               ],"scopeNamep": []}
             ],"filep": []},
-            {"type":"STOP","name":"","addr":"(TT)","loc":"d,72:145,72:150"}
+            {"type":"STOP","name":"","addr":"(TQ)","loc":"d,72:145,72:150"}
           ],"elsesp": []},
-          {"type":"IF","name":"","addr":"(UT)","loc":"d,73:13,73:15",
+          {"type":"IF","name":"","addr":"(UQ)","loc":"d,73:13,73:15",
            "condp": [
-            {"type":"NEQ","name":"","addr":"(VT)","loc":"d,73:29,73:32","dtypep":"(GB)",
+            {"type":"NEQ","name":"","addr":"(VQ)","loc":"d,73:29,73:32","dtypep":"(GB)",
              "lhsp": [
-              {"type":"CONST","name":"4'h4","addr":"(WT)","loc":"d,73:34,73:37","dtypep":"(UB)"}
+              {"type":"CONST","name":"4'h4","addr":"(WQ)","loc":"d,73:34,73:37","dtypep":"(UB)"}
             ],
              "rhsp": [
-              {"type":"ARRAYSEL","name":"","addr":"(XT)","loc":"d,73:18,73:19","dtypep":"(BC)",
+              {"type":"ARRAYSEL","name":"","addr":"(XQ)","loc":"d,73:18,73:19","dtypep":"(BC)",
                "fromp": [
-                {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(YT)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(YQ)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
               ],
                "bitp": [
-                {"type":"AND","name":"","addr":"(ZT)","loc":"d,73:18,73:19","dtypep":"(GC)",
+                {"type":"AND","name":"","addr":"(ZQ)","loc":"d,73:18,73:19","dtypep":"(GC)",
                  "lhsp": [
-                  {"type":"CONST","name":"32'h7","addr":"(AU)","loc":"d,73:18,73:19","dtypep":"(IC)"}
+                  {"type":"CONST","name":"32'h7","addr":"(AR)","loc":"d,73:18,73:19","dtypep":"(IC)"}
                 ],
                  "rhsp": [
-                  {"type":"ARRAYSEL","name":"","addr":"(BU)","loc":"d,73:18,73:19","dtypep":"(GC)",
+                  {"type":"ARRAYSEL","name":"","addr":"(BR)","loc":"d,73:18,73:19","dtypep":"(GC)",
                    "fromp": [
-                    {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(CU)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(CR)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ],
                    "bitp": [
-                    {"type":"AND","name":"","addr":"(DU)","loc":"d,73:18,73:19","dtypep":"(GC)",
+                    {"type":"AND","name":"","addr":"(DR)","loc":"d,73:18,73:19","dtypep":"(GC)",
                      "lhsp": [
-                      {"type":"CONST","name":"32'h7","addr":"(EU)","loc":"d,73:18,73:19","dtypep":"(IC)"}
+                      {"type":"CONST","name":"32'h7","addr":"(ER)","loc":"d,73:18,73:19","dtypep":"(IC)"}
                     ],
                      "rhsp": [
-                      {"type":"CCAST","name":"","addr":"(FU)","loc":"d,73:18,73:19","dtypep":"(GC)","size":32,
+                      {"type":"CCAST","name":"","addr":"(FR)","loc":"d,73:18,73:19","dtypep":"(GC)","size":32,
                        "lhsp": [
-                        {"type":"VARREF","name":"t.e","addr":"(GU)","loc":"d,73:18,73:19","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                        {"type":"VARREF","name":"t.e","addr":"(GR)","loc":"d,73:18,73:19","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                       ]}
                     ]}
                   ]}
@@ -1336,33 +1102,33 @@
             ]}
           ],
            "thensp": [
-            {"type":"DISPLAY","name":"","addr":"(HU)","loc":"d,73:46,73:52",
+            {"type":"DISPLAY","name":"","addr":"(HR)","loc":"d,73:46,73:52",
              "fmtp": [
-              {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:73:  got='h%x exp='h4\\n","addr":"(IU)","loc":"d,73:46,73:52","dtypep":"(SB)",
+              {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:73:  got='h%x exp='h4\\n","addr":"(IR)","loc":"d,73:46,73:52","dtypep":"(SB)",
                "exprsp": [
-                {"type":"ARRAYSEL","name":"","addr":"(JU)","loc":"d,73:125,73:126","dtypep":"(BC)",
+                {"type":"ARRAYSEL","name":"","addr":"(JR)","loc":"d,73:125,73:126","dtypep":"(BC)",
                  "fromp": [
-                  {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(KU)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(KR)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                 ],
                  "bitp": [
-                  {"type":"AND","name":"","addr":"(LU)","loc":"d,73:125,73:126","dtypep":"(GC)",
+                  {"type":"AND","name":"","addr":"(LR)","loc":"d,73:125,73:126","dtypep":"(GC)",
                    "lhsp": [
-                    {"type":"CONST","name":"32'h7","addr":"(MU)","loc":"d,73:125,73:126","dtypep":"(IC)"}
+                    {"type":"CONST","name":"32'h7","addr":"(MR)","loc":"d,73:125,73:126","dtypep":"(IC)"}
                   ],
                    "rhsp": [
-                    {"type":"ARRAYSEL","name":"","addr":"(NU)","loc":"d,73:125,73:126","dtypep":"(GC)",
+                    {"type":"ARRAYSEL","name":"","addr":"(NR)","loc":"d,73:125,73:126","dtypep":"(GC)",
                      "fromp": [
-                      {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(OU)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(OR)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ],
                      "bitp": [
-                      {"type":"AND","name":"","addr":"(PU)","loc":"d,73:125,73:126","dtypep":"(GC)",
+                      {"type":"AND","name":"","addr":"(PR)","loc":"d,73:125,73:126","dtypep":"(GC)",
                        "lhsp": [
-                        {"type":"CONST","name":"32'h7","addr":"(QU)","loc":"d,73:125,73:126","dtypep":"(IC)"}
+                        {"type":"CONST","name":"32'h7","addr":"(QR)","loc":"d,73:125,73:126","dtypep":"(IC)"}
                       ],
                        "rhsp": [
-                        {"type":"CCAST","name":"","addr":"(RU)","loc":"d,73:125,73:126","dtypep":"(GC)","size":32,
+                        {"type":"CCAST","name":"","addr":"(RR)","loc":"d,73:125,73:126","dtypep":"(GC)","size":32,
                          "lhsp": [
-                          {"type":"VARREF","name":"t.e","addr":"(SU)","loc":"d,73:125,73:126","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                          {"type":"VARREF","name":"t.e","addr":"(SR)","loc":"d,73:125,73:126","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                         ]}
                       ]}
                     ]}
@@ -1370,138 +1136,111 @@
                 ]}
               ],"scopeNamep": []}
             ],"filep": []},
-            {"type":"STOP","name":"","addr":"(TU)","loc":"d,73:145,73:150"}
+            {"type":"STOP","name":"","addr":"(TR)","loc":"d,73:145,73:150"}
           ],"elsesp": []},
-          {"type":"IF","name":"","addr":"(UU)","loc":"d,74:13,74:15",
+          {"type":"IF","name":"","addr":"(UR)","loc":"d,74:26,74:29",
            "condp": [
-            {"type":"NEQ","name":"","addr":"(VU)","loc":"d,74:26,74:29","dtypep":"(GB)",
+            {"type":"NEQ","name":"","addr":"(VR)","loc":"d,74:26,74:29","dtypep":"(GB)",
              "lhsp": [
-              {"type":"CONST","name":"4'h4","addr":"(WU)","loc":"d,74:31,74:34","dtypep":"(UB)"}
+              {"type":"CONST","name":"4'h4","addr":"(WR)","loc":"d,74:31,74:34","dtypep":"(UB)"}
             ],
              "rhsp": [
-              {"type":"ARRAYSEL","name":"","addr":"(XU)","loc":"d,74:18,74:19","dtypep":"(BC)",
+              {"type":"ARRAYSEL","name":"","addr":"(XR)","loc":"d,74:18,74:19","dtypep":"(BC)",
                "fromp": [
-                {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(YU)","loc":"d,17:12,17:16","dtypep":"(XI)","access":"RD","varp":"(YI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(YR)","loc":"d,17:12,17:16","dtypep":"(CH)","access":"RD","varp":"(DH)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
               ],
                "bitp": [
-                {"type":"AND","name":"","addr":"(ZU)","loc":"d,74:18,74:19","dtypep":"(GC)",
+                {"type":"AND","name":"","addr":"(ZR)","loc":"d,74:18,74:19","dtypep":"(GC)",
                  "lhsp": [
-                  {"type":"CONST","name":"32'h7","addr":"(AV)","loc":"d,74:18,74:19","dtypep":"(IC)"}
+                  {"type":"CONST","name":"32'h7","addr":"(AS)","loc":"d,74:18,74:19","dtypep":"(IC)"}
                 ],
                  "rhsp": [
-                  {"type":"CCAST","name":"","addr":"(BV)","loc":"d,74:18,74:19","dtypep":"(GC)","size":32,
+                  {"type":"CCAST","name":"","addr":"(BS)","loc":"d,74:18,74:19","dtypep":"(GC)","size":32,
                    "lhsp": [
-                    {"type":"VARREF","name":"t.e","addr":"(CV)","loc":"d,74:18,74:19","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"t.e","addr":"(CS)","loc":"d,74:18,74:19","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ]}
                 ]}
               ]}
             ]}
           ],
            "thensp": [
-            {"type":"DISPLAY","name":"","addr":"(DV)","loc":"d,74:43,74:49",
+            {"type":"DISPLAY","name":"","addr":"(DS)","loc":"d,74:43,74:49",
              "fmtp": [
-              {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:74:  got='h%x exp='h4\\n","addr":"(EV)","loc":"d,74:43,74:49","dtypep":"(SB)",
+              {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:74:  got='h%x exp='h4\\n","addr":"(ES)","loc":"d,74:43,74:49","dtypep":"(SB)",
                "exprsp": [
-                {"type":"ARRAYSEL","name":"","addr":"(FV)","loc":"d,74:122,74:123","dtypep":"(BC)",
+                {"type":"ARRAYSEL","name":"","addr":"(FS)","loc":"d,74:122,74:123","dtypep":"(BC)",
                  "fromp": [
-                  {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(GV)","loc":"d,17:12,17:16","dtypep":"(XI)","access":"RD","varp":"(YI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(GS)","loc":"d,17:12,17:16","dtypep":"(CH)","access":"RD","varp":"(DH)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                 ],
                  "bitp": [
-                  {"type":"AND","name":"","addr":"(HV)","loc":"d,74:122,74:123","dtypep":"(GC)",
+                  {"type":"AND","name":"","addr":"(HS)","loc":"d,74:122,74:123","dtypep":"(GC)",
                    "lhsp": [
-                    {"type":"CONST","name":"32'h7","addr":"(IV)","loc":"d,74:122,74:123","dtypep":"(IC)"}
+                    {"type":"CONST","name":"32'h7","addr":"(IS)","loc":"d,74:122,74:123","dtypep":"(IC)"}
                   ],
                    "rhsp": [
-                    {"type":"CCAST","name":"","addr":"(JV)","loc":"d,74:122,74:123","dtypep":"(GC)","size":32,
+                    {"type":"CCAST","name":"","addr":"(JS)","loc":"d,74:122,74:123","dtypep":"(GC)","size":32,
                      "lhsp": [
-                      {"type":"VARREF","name":"t.e","addr":"(KV)","loc":"d,74:122,74:123","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"t.e","addr":"(KS)","loc":"d,74:122,74:123","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ]}
                   ]}
                 ]}
               ],"scopeNamep": []}
             ],"filep": []},
-            {"type":"STOP","name":"","addr":"(LV)","loc":"d,74:139,74:144"}
-          ],"elsesp": []},
-          {"type":"IF","name":"","addr":"(MV)","loc":"d,75:13,75:15",
-           "condp": [
-            {"type":"NEQ","name":"","addr":"(NV)","loc":"d,75:29,75:32","dtypep":"(GB)",
-             "lhsp": [
-              {"type":"CONST","name":"4'h4","addr":"(OV)","loc":"d,75:34,75:37","dtypep":"(UB)"}
-            ],
-             "rhsp": [
-              {"type":"ARRAYSEL","name":"","addr":"(PV)","loc":"d,75:18,75:19","dtypep":"(BC)",
-               "fromp": [
-                {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(QV)","loc":"d,17:12,17:16","dtypep":"(XI)","access":"RD","varp":"(YI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
-              ],
-               "bitp": [
-                {"type":"AND","name":"","addr":"(RV)","loc":"d,75:18,75:19","dtypep":"(GC)",
-                 "lhsp": [
-                  {"type":"CONST","name":"32'h7","addr":"(SV)","loc":"d,75:18,75:19","dtypep":"(IC)"}
-                ],
-                 "rhsp": [
-                  {"type":"CCAST","name":"","addr":"(TV)","loc":"d,75:18,75:19","dtypep":"(GC)","size":32,
-                   "lhsp": [
-                    {"type":"VARREF","name":"t.e","addr":"(UV)","loc":"d,75:18,75:19","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
-                  ]}
-                ]}
-              ]}
-            ]}
-          ],
-           "thensp": [
-            {"type":"DISPLAY","name":"","addr":"(VV)","loc":"d,75:46,75:52",
+            {"type":"STOP","name":"","addr":"(LS)","loc":"d,74:139,74:144"},
+            {"type":"DISPLAY","name":"","addr":"(MS)","loc":"d,75:46,75:52",
              "fmtp": [
-              {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:75:  got='h%x exp='h4\\n","addr":"(WV)","loc":"d,75:46,75:52","dtypep":"(SB)",
+              {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:75:  got='h%x exp='h4\\n","addr":"(NS)","loc":"d,75:46,75:52","dtypep":"(SB)",
                "exprsp": [
-                {"type":"ARRAYSEL","name":"","addr":"(XV)","loc":"d,75:125,75:126","dtypep":"(BC)",
+                {"type":"ARRAYSEL","name":"","addr":"(OS)","loc":"d,75:125,75:126","dtypep":"(BC)",
                  "fromp": [
-                  {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(YV)","loc":"d,17:12,17:16","dtypep":"(XI)","access":"RD","varp":"(YI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(PS)","loc":"d,17:12,17:16","dtypep":"(CH)","access":"RD","varp":"(DH)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                 ],
                  "bitp": [
-                  {"type":"AND","name":"","addr":"(ZV)","loc":"d,75:125,75:126","dtypep":"(GC)",
+                  {"type":"AND","name":"","addr":"(QS)","loc":"d,75:125,75:126","dtypep":"(GC)",
                    "lhsp": [
-                    {"type":"CONST","name":"32'h7","addr":"(AW)","loc":"d,75:125,75:126","dtypep":"(IC)"}
+                    {"type":"CONST","name":"32'h7","addr":"(RS)","loc":"d,75:125,75:126","dtypep":"(IC)"}
                   ],
                    "rhsp": [
-                    {"type":"CCAST","name":"","addr":"(BW)","loc":"d,75:125,75:126","dtypep":"(GC)","size":32,
+                    {"type":"CCAST","name":"","addr":"(SS)","loc":"d,75:125,75:126","dtypep":"(GC)","size":32,
                      "lhsp": [
-                      {"type":"VARREF","name":"t.e","addr":"(CW)","loc":"d,75:125,75:126","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"t.e","addr":"(TS)","loc":"d,75:125,75:126","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ]}
                   ]}
                 ]}
               ],"scopeNamep": []}
             ],"filep": []},
-            {"type":"STOP","name":"","addr":"(DW)","loc":"d,75:145,75:150"}
+            {"type":"STOP","name":"","addr":"(US)","loc":"d,75:145,75:150"}
           ],"elsesp": []},
-          {"type":"IF","name":"","addr":"(EW)","loc":"d,76:13,76:15",
+          {"type":"IF","name":"","addr":"(VS)","loc":"d,76:13,76:15",
            "condp": [
-            {"type":"NEQ","name":"","addr":"(FW)","loc":"d,76:29,76:32","dtypep":"(GB)",
+            {"type":"NEQ","name":"","addr":"(WS)","loc":"d,76:29,76:32","dtypep":"(GB)",
              "lhsp": [
-              {"type":"CONST","name":"4'h3","addr":"(GW)","loc":"d,76:34,76:37","dtypep":"(UB)"}
+              {"type":"CONST","name":"4'h3","addr":"(XS)","loc":"d,76:34,76:37","dtypep":"(UB)"}
             ],
              "rhsp": [
-              {"type":"ARRAYSEL","name":"","addr":"(HW)","loc":"d,76:18,76:19","dtypep":"(BC)",
+              {"type":"ARRAYSEL","name":"","addr":"(YS)","loc":"d,76:18,76:19","dtypep":"(BC)",
                "fromp": [
-                {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(IW)","loc":"d,17:12,17:16","dtypep":"(XI)","access":"RD","varp":"(YI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(ZS)","loc":"d,17:12,17:16","dtypep":"(CH)","access":"RD","varp":"(DH)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
               ],
                "bitp": [
-                {"type":"AND","name":"","addr":"(JW)","loc":"d,76:18,76:19","dtypep":"(GC)",
+                {"type":"AND","name":"","addr":"(AT)","loc":"d,76:18,76:19","dtypep":"(GC)",
                  "lhsp": [
-                  {"type":"CONST","name":"32'h7","addr":"(KW)","loc":"d,76:18,76:19","dtypep":"(IC)"}
+                  {"type":"CONST","name":"32'h7","addr":"(BT)","loc":"d,76:18,76:19","dtypep":"(IC)"}
                 ],
                  "rhsp": [
-                  {"type":"ARRAYSEL","name":"","addr":"(LW)","loc":"d,76:18,76:19","dtypep":"(GC)",
+                  {"type":"ARRAYSEL","name":"","addr":"(CT)","loc":"d,76:18,76:19","dtypep":"(GC)",
                    "fromp": [
-                    {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(MW)","loc":"d,17:12,17:16","dtypep":"(XI)","access":"RD","varp":"(YI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(DT)","loc":"d,17:12,17:16","dtypep":"(CH)","access":"RD","varp":"(DH)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ],
                    "bitp": [
-                    {"type":"AND","name":"","addr":"(NW)","loc":"d,76:18,76:19","dtypep":"(GC)",
+                    {"type":"AND","name":"","addr":"(ET)","loc":"d,76:18,76:19","dtypep":"(GC)",
                      "lhsp": [
-                      {"type":"CONST","name":"32'h7","addr":"(OW)","loc":"d,76:18,76:19","dtypep":"(IC)"}
+                      {"type":"CONST","name":"32'h7","addr":"(FT)","loc":"d,76:18,76:19","dtypep":"(IC)"}
                     ],
                      "rhsp": [
-                      {"type":"CCAST","name":"","addr":"(PW)","loc":"d,76:18,76:19","dtypep":"(GC)","size":32,
+                      {"type":"CCAST","name":"","addr":"(GT)","loc":"d,76:18,76:19","dtypep":"(GC)","size":32,
                        "lhsp": [
-                        {"type":"VARREF","name":"t.e","addr":"(QW)","loc":"d,76:18,76:19","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                        {"type":"VARREF","name":"t.e","addr":"(HT)","loc":"d,76:18,76:19","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                       ]}
                     ]}
                   ]}
@@ -1510,33 +1249,33 @@
             ]}
           ],
            "thensp": [
-            {"type":"DISPLAY","name":"","addr":"(RW)","loc":"d,76:46,76:52",
+            {"type":"DISPLAY","name":"","addr":"(IT)","loc":"d,76:46,76:52",
              "fmtp": [
-              {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:76:  got='h%x exp='h3\\n","addr":"(SW)","loc":"d,76:46,76:52","dtypep":"(SB)",
+              {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:76:  got='h%x exp='h3\\n","addr":"(JT)","loc":"d,76:46,76:52","dtypep":"(SB)",
                "exprsp": [
-                {"type":"ARRAYSEL","name":"","addr":"(TW)","loc":"d,76:125,76:126","dtypep":"(BC)",
+                {"type":"ARRAYSEL","name":"","addr":"(KT)","loc":"d,76:125,76:126","dtypep":"(BC)",
                  "fromp": [
-                  {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(UW)","loc":"d,17:12,17:16","dtypep":"(XI)","access":"RD","varp":"(YI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(LT)","loc":"d,17:12,17:16","dtypep":"(CH)","access":"RD","varp":"(DH)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                 ],
                  "bitp": [
-                  {"type":"AND","name":"","addr":"(VW)","loc":"d,76:125,76:126","dtypep":"(GC)",
+                  {"type":"AND","name":"","addr":"(MT)","loc":"d,76:125,76:126","dtypep":"(GC)",
                    "lhsp": [
-                    {"type":"CONST","name":"32'h7","addr":"(WW)","loc":"d,76:125,76:126","dtypep":"(IC)"}
+                    {"type":"CONST","name":"32'h7","addr":"(NT)","loc":"d,76:125,76:126","dtypep":"(IC)"}
                   ],
                    "rhsp": [
-                    {"type":"ARRAYSEL","name":"","addr":"(XW)","loc":"d,76:125,76:126","dtypep":"(GC)",
+                    {"type":"ARRAYSEL","name":"","addr":"(OT)","loc":"d,76:125,76:126","dtypep":"(GC)",
                      "fromp": [
-                      {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(YW)","loc":"d,17:12,17:16","dtypep":"(XI)","access":"RD","varp":"(YI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(PT)","loc":"d,17:12,17:16","dtypep":"(CH)","access":"RD","varp":"(DH)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ],
                      "bitp": [
-                      {"type":"AND","name":"","addr":"(ZW)","loc":"d,76:125,76:126","dtypep":"(GC)",
+                      {"type":"AND","name":"","addr":"(QT)","loc":"d,76:125,76:126","dtypep":"(GC)",
                        "lhsp": [
-                        {"type":"CONST","name":"32'h7","addr":"(AX)","loc":"d,76:125,76:126","dtypep":"(IC)"}
+                        {"type":"CONST","name":"32'h7","addr":"(RT)","loc":"d,76:125,76:126","dtypep":"(IC)"}
                       ],
                        "rhsp": [
-                        {"type":"CCAST","name":"","addr":"(BX)","loc":"d,76:125,76:126","dtypep":"(GC)","size":32,
+                        {"type":"CCAST","name":"","addr":"(ST)","loc":"d,76:125,76:126","dtypep":"(GC)","size":32,
                          "lhsp": [
-                          {"type":"VARREF","name":"t.e","addr":"(CX)","loc":"d,76:125,76:126","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                          {"type":"VARREF","name":"t.e","addr":"(TT)","loc":"d,76:125,76:126","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                         ]}
                       ]}
                     ]}
@@ -1544,215 +1283,188 @@
                 ]}
               ],"scopeNamep": []}
             ],"filep": []},
-            {"type":"STOP","name":"","addr":"(DX)","loc":"d,76:145,76:150"}
+            {"type":"STOP","name":"","addr":"(UT)","loc":"d,76:145,76:150"}
           ],"elsesp": []},
-          {"type":"ASSIGNDLY","name":"","addr":"(EX)","loc":"d,77:12,77:14","dtypep":"(UB)",
+          {"type":"ASSIGNDLY","name":"","addr":"(VT)","loc":"d,77:12,77:14","dtypep":"(UB)",
            "rhsp": [
-            {"type":"CONST","name":"4'h3","addr":"(FX)","loc":"d,77:15,77:18","dtypep":"(UB)"}
+            {"type":"CONST","name":"4'h3","addr":"(WT)","loc":"d,77:15,77:18","dtypep":"(UB)"}
           ],
            "lhsp": [
-            {"type":"VARREF","name":"__Vdly__t.e","addr":"(GX)","loc":"d,77:10,77:11","dtypep":"(UB)","access":"WR","varp":"(LQ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"__Vdly__t.e","addr":"(XT)","loc":"d,77:10,77:11","dtypep":"(UB)","access":"WR","varp":"(UN)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ],"timingControlp": []}
         ],
          "elsesp": [
-          {"type":"IF","name":"","addr":"(HX)","loc":"d,79:12,79:14",
+          {"type":"IF","name":"","addr":"(YT)","loc":"d,79:12,79:14",
            "condp": [
-            {"type":"EQ","name":"","addr":"(IX)","loc":"d,79:19,79:21","dtypep":"(GB)",
+            {"type":"EQ","name":"","addr":"(ZT)","loc":"d,79:19,79:21","dtypep":"(GB)",
              "lhsp": [
-              {"type":"CONST","name":"32'sh2","addr":"(JX)","loc":"d,79:21,79:22","dtypep":"(LB)"}
+              {"type":"CONST","name":"32'sh2","addr":"(AU)","loc":"d,79:21,79:22","dtypep":"(LB)"}
             ],
              "rhsp": [
-              {"type":"VARREF","name":"t.cyc","addr":"(KX)","loc":"d,79:16,79:19","dtypep":"(S)","access":"RD","varp":"(R)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+              {"type":"VARREF","name":"t.cyc","addr":"(BU)","loc":"d,79:16,79:19","dtypep":"(S)","access":"RD","varp":"(R)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
             ]}
           ],
            "thensp": [
-            {"type":"IF","name":"","addr":"(LX)","loc":"d,80:13,80:15",
+            {"type":"IF","name":"","addr":"(CU)","loc":"d,80:13,80:15",
              "condp": [
-              {"type":"NEQN","name":"","addr":"(MX)","loc":"d,80:26,80:28","dtypep":"(GB)",
+              {"type":"NEQN","name":"","addr":"(DU)","loc":"d,80:26,80:28","dtypep":"(GB)",
                "lhsp": [
-                {"type":"CONST","name":"\\\"E03\\\"","addr":"(NX)","loc":"d,80:30,80:35","dtypep":"(SB)"}
+                {"type":"CONST","name":"\\\"E03\\\"","addr":"(EU)","loc":"d,80:30,80:35","dtypep":"(SB)"}
               ],
                "rhsp": [
-                {"type":"ARRAYSEL","name":"","addr":"(OX)","loc":"d,80:18,80:19","dtypep":"(SB)",
+                {"type":"ARRAYSEL","name":"","addr":"(FU)","loc":"d,80:18,80:19","dtypep":"(SB)",
                  "fromp": [
-                  {"type":"VARREF","name":"__Venumtab_enum_name1","addr":"(PX)","loc":"d,17:12,17:16","dtypep":"(JM)","access":"RD","varp":"(KM)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"__Venumtab_enum_name1","addr":"(GU)","loc":"d,17:12,17:16","dtypep":"(SJ)","access":"RD","varp":"(TJ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                 ],
                  "bitp": [
-                  {"type":"AND","name":"","addr":"(QX)","loc":"d,80:18,80:19","dtypep":"(GC)",
+                  {"type":"AND","name":"","addr":"(HU)","loc":"d,80:18,80:19","dtypep":"(GC)",
                    "lhsp": [
-                    {"type":"CONST","name":"32'h7","addr":"(RX)","loc":"d,80:18,80:19","dtypep":"(IC)"}
+                    {"type":"CONST","name":"32'h7","addr":"(IU)","loc":"d,80:18,80:19","dtypep":"(IC)"}
                   ],
                    "rhsp": [
-                    {"type":"CCAST","name":"","addr":"(SX)","loc":"d,80:18,80:19","dtypep":"(GC)","size":32,
+                    {"type":"CCAST","name":"","addr":"(JU)","loc":"d,80:18,80:19","dtypep":"(GC)","size":32,
                      "lhsp": [
-                      {"type":"VARREF","name":"t.e","addr":"(TX)","loc":"d,80:18,80:19","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"t.e","addr":"(KU)","loc":"d,80:18,80:19","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ]}
                   ]}
                 ]}
               ]}
             ],
              "thensp": [
-              {"type":"ASSIGN","name":"","addr":"(UX)","loc":"d,80:123,80:124","dtypep":"(SB)",
+              {"type":"ASSIGN","name":"","addr":"(LU)","loc":"d,80:123,80:124","dtypep":"(SB)",
                "rhsp": [
-                {"type":"ARRAYSEL","name":"","addr":"(VX)","loc":"d,80:123,80:124","dtypep":"(SB)",
+                {"type":"ARRAYSEL","name":"","addr":"(MU)","loc":"d,80:123,80:124","dtypep":"(SB)",
                  "fromp": [
-                  {"type":"VARREF","name":"__Venumtab_enum_name1","addr":"(WX)","loc":"d,17:12,17:16","dtypep":"(JM)","access":"RD","varp":"(KM)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"__Venumtab_enum_name1","addr":"(NU)","loc":"d,17:12,17:16","dtypep":"(SJ)","access":"RD","varp":"(TJ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                 ],
                  "bitp": [
-                  {"type":"AND","name":"","addr":"(XX)","loc":"d,80:123,80:124","dtypep":"(GC)",
+                  {"type":"AND","name":"","addr":"(OU)","loc":"d,80:123,80:124","dtypep":"(GC)",
                    "lhsp": [
-                    {"type":"CONST","name":"32'h7","addr":"(YX)","loc":"d,80:123,80:124","dtypep":"(IC)"}
+                    {"type":"CONST","name":"32'h7","addr":"(PU)","loc":"d,80:123,80:124","dtypep":"(IC)"}
                   ],
                    "rhsp": [
-                    {"type":"CCAST","name":"","addr":"(ZX)","loc":"d,80:123,80:124","dtypep":"(GC)","size":32,
+                    {"type":"CCAST","name":"","addr":"(QU)","loc":"d,80:123,80:124","dtypep":"(GC)","size":32,
                      "lhsp": [
-                      {"type":"VARREF","name":"t.e","addr":"(AY)","loc":"d,80:123,80:124","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"t.e","addr":"(RU)","loc":"d,80:123,80:124","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ]}
                   ]}
                 ]}
               ],
                "lhsp": [
-                {"type":"VARREF","name":"__Vtemp_2","addr":"(BY)","loc":"d,80:123,80:124","dtypep":"(SB)","access":"WR","varp":"(QQ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                {"type":"VARREF","name":"__Vtemp_2","addr":"(SU)","loc":"d,80:123,80:124","dtypep":"(SB)","access":"WR","varp":"(ZN)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
               ],"timingControlp": []},
-              {"type":"DISPLAY","name":"","addr":"(CY)","loc":"d,80:44,80:50",
+              {"type":"DISPLAY","name":"","addr":"(TU)","loc":"d,80:44,80:50",
                "fmtp": [
-                {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:80:  got='%@' exp='E03'\\n","addr":"(DY)","loc":"d,80:44,80:50","dtypep":"(SB)",
+                {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:80:  got='%@' exp='E03'\\n","addr":"(UU)","loc":"d,80:44,80:50","dtypep":"(SB)",
                  "exprsp": [
-                  {"type":"VARREF","name":"__Vtemp_2","addr":"(EY)","loc":"d,80:123,80:124","dtypep":"(SB)","access":"RD","varp":"(QQ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"__Vtemp_2","addr":"(VU)","loc":"d,80:123,80:124","dtypep":"(SB)","access":"RD","varp":"(ZN)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                 ],"scopeNamep": []}
               ],"filep": []},
-              {"type":"STOP","name":"","addr":"(FY)","loc":"d,80:142,80:147"}
+              {"type":"STOP","name":"","addr":"(WU)","loc":"d,80:142,80:147"}
             ],"elsesp": []},
-            {"type":"IF","name":"","addr":"(GY)","loc":"d,81:13,81:15",
+            {"type":"IF","name":"","addr":"(XU)","loc":"d,81:26,81:29",
              "condp": [
-              {"type":"NEQ","name":"","addr":"(HY)","loc":"d,81:26,81:29","dtypep":"(GB)",
+              {"type":"NEQ","name":"","addr":"(YU)","loc":"d,81:26,81:29","dtypep":"(GB)",
                "lhsp": [
-                {"type":"CONST","name":"4'h4","addr":"(IY)","loc":"d,81:31,81:34","dtypep":"(UB)"}
+                {"type":"CONST","name":"4'h4","addr":"(ZU)","loc":"d,81:31,81:34","dtypep":"(UB)"}
               ],
                "rhsp": [
-                {"type":"ARRAYSEL","name":"","addr":"(JY)","loc":"d,81:18,81:19","dtypep":"(BC)",
+                {"type":"ARRAYSEL","name":"","addr":"(AV)","loc":"d,81:18,81:19","dtypep":"(BC)",
                  "fromp": [
-                  {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(KY)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(BV)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                 ],
                  "bitp": [
-                  {"type":"AND","name":"","addr":"(LY)","loc":"d,81:18,81:19","dtypep":"(GC)",
+                  {"type":"AND","name":"","addr":"(CV)","loc":"d,81:18,81:19","dtypep":"(GC)",
                    "lhsp": [
-                    {"type":"CONST","name":"32'h7","addr":"(MY)","loc":"d,81:18,81:19","dtypep":"(IC)"}
+                    {"type":"CONST","name":"32'h7","addr":"(DV)","loc":"d,81:18,81:19","dtypep":"(IC)"}
                   ],
                    "rhsp": [
-                    {"type":"CCAST","name":"","addr":"(NY)","loc":"d,81:18,81:19","dtypep":"(GC)","size":32,
+                    {"type":"CCAST","name":"","addr":"(EV)","loc":"d,81:18,81:19","dtypep":"(GC)","size":32,
                      "lhsp": [
-                      {"type":"VARREF","name":"t.e","addr":"(OY)","loc":"d,81:18,81:19","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"t.e","addr":"(FV)","loc":"d,81:18,81:19","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ]}
                   ]}
                 ]}
               ]}
             ],
              "thensp": [
-              {"type":"DISPLAY","name":"","addr":"(PY)","loc":"d,81:43,81:49",
+              {"type":"DISPLAY","name":"","addr":"(GV)","loc":"d,81:43,81:49",
                "fmtp": [
-                {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:81:  got='h%x exp='h4\\n","addr":"(QY)","loc":"d,81:43,81:49","dtypep":"(SB)",
+                {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:81:  got='h%x exp='h4\\n","addr":"(HV)","loc":"d,81:43,81:49","dtypep":"(SB)",
                  "exprsp": [
-                  {"type":"ARRAYSEL","name":"","addr":"(RY)","loc":"d,81:122,81:123","dtypep":"(BC)",
+                  {"type":"ARRAYSEL","name":"","addr":"(IV)","loc":"d,81:122,81:123","dtypep":"(BC)",
                    "fromp": [
-                    {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(SY)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(JV)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ],
                    "bitp": [
-                    {"type":"AND","name":"","addr":"(TY)","loc":"d,81:122,81:123","dtypep":"(GC)",
+                    {"type":"AND","name":"","addr":"(KV)","loc":"d,81:122,81:123","dtypep":"(GC)",
                      "lhsp": [
-                      {"type":"CONST","name":"32'h7","addr":"(UY)","loc":"d,81:122,81:123","dtypep":"(IC)"}
+                      {"type":"CONST","name":"32'h7","addr":"(LV)","loc":"d,81:122,81:123","dtypep":"(IC)"}
                     ],
                      "rhsp": [
-                      {"type":"CCAST","name":"","addr":"(VY)","loc":"d,81:122,81:123","dtypep":"(GC)","size":32,
+                      {"type":"CCAST","name":"","addr":"(MV)","loc":"d,81:122,81:123","dtypep":"(GC)","size":32,
                        "lhsp": [
-                        {"type":"VARREF","name":"t.e","addr":"(WY)","loc":"d,81:122,81:123","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                        {"type":"VARREF","name":"t.e","addr":"(NV)","loc":"d,81:122,81:123","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                       ]}
                     ]}
                   ]}
                 ],"scopeNamep": []}
               ],"filep": []},
-              {"type":"STOP","name":"","addr":"(XY)","loc":"d,81:139,81:144"}
-            ],"elsesp": []},
-            {"type":"IF","name":"","addr":"(YY)","loc":"d,82:13,82:15",
-             "condp": [
-              {"type":"NEQ","name":"","addr":"(ZY)","loc":"d,82:29,82:32","dtypep":"(GB)",
-               "lhsp": [
-                {"type":"CONST","name":"4'h4","addr":"(AZ)","loc":"d,82:34,82:37","dtypep":"(UB)"}
-              ],
-               "rhsp": [
-                {"type":"ARRAYSEL","name":"","addr":"(BZ)","loc":"d,82:18,82:19","dtypep":"(BC)",
-                 "fromp": [
-                  {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(CZ)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
-                ],
-                 "bitp": [
-                  {"type":"AND","name":"","addr":"(DZ)","loc":"d,82:18,82:19","dtypep":"(GC)",
-                   "lhsp": [
-                    {"type":"CONST","name":"32'h7","addr":"(EZ)","loc":"d,82:18,82:19","dtypep":"(IC)"}
-                  ],
-                   "rhsp": [
-                    {"type":"CCAST","name":"","addr":"(FZ)","loc":"d,82:18,82:19","dtypep":"(GC)","size":32,
-                     "lhsp": [
-                      {"type":"VARREF","name":"t.e","addr":"(GZ)","loc":"d,82:18,82:19","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
-                    ]}
-                  ]}
-                ]}
-              ]}
-            ],
-             "thensp": [
-              {"type":"DISPLAY","name":"","addr":"(HZ)","loc":"d,82:46,82:52",
+              {"type":"STOP","name":"","addr":"(OV)","loc":"d,81:139,81:144"},
+              {"type":"DISPLAY","name":"","addr":"(PV)","loc":"d,82:46,82:52",
                "fmtp": [
-                {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:82:  got='h%x exp='h4\\n","addr":"(IZ)","loc":"d,82:46,82:52","dtypep":"(SB)",
+                {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:82:  got='h%x exp='h4\\n","addr":"(QV)","loc":"d,82:46,82:52","dtypep":"(SB)",
                  "exprsp": [
-                  {"type":"ARRAYSEL","name":"","addr":"(JZ)","loc":"d,82:125,82:126","dtypep":"(BC)",
+                  {"type":"ARRAYSEL","name":"","addr":"(RV)","loc":"d,82:125,82:126","dtypep":"(BC)",
                    "fromp": [
-                    {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(KZ)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(SV)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ],
                    "bitp": [
-                    {"type":"AND","name":"","addr":"(LZ)","loc":"d,82:125,82:126","dtypep":"(GC)",
+                    {"type":"AND","name":"","addr":"(TV)","loc":"d,82:125,82:126","dtypep":"(GC)",
                      "lhsp": [
-                      {"type":"CONST","name":"32'h7","addr":"(MZ)","loc":"d,82:125,82:126","dtypep":"(IC)"}
+                      {"type":"CONST","name":"32'h7","addr":"(UV)","loc":"d,82:125,82:126","dtypep":"(IC)"}
                     ],
                      "rhsp": [
-                      {"type":"CCAST","name":"","addr":"(NZ)","loc":"d,82:125,82:126","dtypep":"(GC)","size":32,
+                      {"type":"CCAST","name":"","addr":"(VV)","loc":"d,82:125,82:126","dtypep":"(GC)","size":32,
                        "lhsp": [
-                        {"type":"VARREF","name":"t.e","addr":"(OZ)","loc":"d,82:125,82:126","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                        {"type":"VARREF","name":"t.e","addr":"(WV)","loc":"d,82:125,82:126","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                       ]}
                     ]}
                   ]}
                 ],"scopeNamep": []}
               ],"filep": []},
-              {"type":"STOP","name":"","addr":"(PZ)","loc":"d,82:145,82:150"}
+              {"type":"STOP","name":"","addr":"(XV)","loc":"d,82:145,82:150"}
             ],"elsesp": []},
-            {"type":"IF","name":"","addr":"(QZ)","loc":"d,83:13,83:15",
+            {"type":"IF","name":"","addr":"(YV)","loc":"d,83:13,83:15",
              "condp": [
-              {"type":"NEQ","name":"","addr":"(RZ)","loc":"d,83:29,83:32","dtypep":"(GB)",
+              {"type":"NEQ","name":"","addr":"(ZV)","loc":"d,83:29,83:32","dtypep":"(GB)",
                "lhsp": [
-                {"type":"CONST","name":"4'h1","addr":"(SZ)","loc":"d,83:34,83:37","dtypep":"(UB)"}
+                {"type":"CONST","name":"4'h1","addr":"(AW)","loc":"d,83:34,83:37","dtypep":"(UB)"}
               ],
                "rhsp": [
-                {"type":"ARRAYSEL","name":"","addr":"(TZ)","loc":"d,83:18,83:19","dtypep":"(BC)",
+                {"type":"ARRAYSEL","name":"","addr":"(BW)","loc":"d,83:18,83:19","dtypep":"(BC)",
                  "fromp": [
-                  {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(UZ)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(CW)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                 ],
                  "bitp": [
-                  {"type":"AND","name":"","addr":"(VZ)","loc":"d,83:18,83:19","dtypep":"(GC)",
+                  {"type":"AND","name":"","addr":"(DW)","loc":"d,83:18,83:19","dtypep":"(GC)",
                    "lhsp": [
-                    {"type":"CONST","name":"32'h7","addr":"(WZ)","loc":"d,83:18,83:19","dtypep":"(IC)"}
+                    {"type":"CONST","name":"32'h7","addr":"(EW)","loc":"d,83:18,83:19","dtypep":"(IC)"}
                   ],
                    "rhsp": [
-                    {"type":"ARRAYSEL","name":"","addr":"(XZ)","loc":"d,83:18,83:19","dtypep":"(GC)",
+                    {"type":"ARRAYSEL","name":"","addr":"(FW)","loc":"d,83:18,83:19","dtypep":"(GC)",
                      "fromp": [
-                      {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(YZ)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(GW)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ],
                      "bitp": [
-                      {"type":"AND","name":"","addr":"(ZZ)","loc":"d,83:18,83:19","dtypep":"(GC)",
+                      {"type":"AND","name":"","addr":"(HW)","loc":"d,83:18,83:19","dtypep":"(GC)",
                        "lhsp": [
-                        {"type":"CONST","name":"32'h7","addr":"(AAB)","loc":"d,83:18,83:19","dtypep":"(IC)"}
+                        {"type":"CONST","name":"32'h7","addr":"(IW)","loc":"d,83:18,83:19","dtypep":"(IC)"}
                       ],
                        "rhsp": [
-                        {"type":"CCAST","name":"","addr":"(BAB)","loc":"d,83:18,83:19","dtypep":"(GC)","size":32,
+                        {"type":"CCAST","name":"","addr":"(JW)","loc":"d,83:18,83:19","dtypep":"(GC)","size":32,
                          "lhsp": [
-                          {"type":"VARREF","name":"t.e","addr":"(CAB)","loc":"d,83:18,83:19","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                          {"type":"VARREF","name":"t.e","addr":"(KW)","loc":"d,83:18,83:19","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                         ]}
                       ]}
                     ]}
@@ -1761,33 +1473,33 @@
               ]}
             ],
              "thensp": [
-              {"type":"DISPLAY","name":"","addr":"(DAB)","loc":"d,83:46,83:52",
+              {"type":"DISPLAY","name":"","addr":"(LW)","loc":"d,83:46,83:52",
                "fmtp": [
-                {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:83:  got='h%x exp='h1\\n","addr":"(EAB)","loc":"d,83:46,83:52","dtypep":"(SB)",
+                {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:83:  got='h%x exp='h1\\n","addr":"(MW)","loc":"d,83:46,83:52","dtypep":"(SB)",
                  "exprsp": [
-                  {"type":"ARRAYSEL","name":"","addr":"(FAB)","loc":"d,83:125,83:126","dtypep":"(BC)",
+                  {"type":"ARRAYSEL","name":"","addr":"(NW)","loc":"d,83:125,83:126","dtypep":"(BC)",
                    "fromp": [
-                    {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(GAB)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(OW)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ],
                    "bitp": [
-                    {"type":"AND","name":"","addr":"(HAB)","loc":"d,83:125,83:126","dtypep":"(GC)",
+                    {"type":"AND","name":"","addr":"(PW)","loc":"d,83:125,83:126","dtypep":"(GC)",
                      "lhsp": [
-                      {"type":"CONST","name":"32'h7","addr":"(IAB)","loc":"d,83:125,83:126","dtypep":"(IC)"}
+                      {"type":"CONST","name":"32'h7","addr":"(QW)","loc":"d,83:125,83:126","dtypep":"(IC)"}
                     ],
                      "rhsp": [
-                      {"type":"ARRAYSEL","name":"","addr":"(JAB)","loc":"d,83:125,83:126","dtypep":"(GC)",
+                      {"type":"ARRAYSEL","name":"","addr":"(RW)","loc":"d,83:125,83:126","dtypep":"(GC)",
                        "fromp": [
-                        {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(KAB)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                        {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(SW)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                       ],
                        "bitp": [
-                        {"type":"AND","name":"","addr":"(LAB)","loc":"d,83:125,83:126","dtypep":"(GC)",
+                        {"type":"AND","name":"","addr":"(TW)","loc":"d,83:125,83:126","dtypep":"(GC)",
                          "lhsp": [
-                          {"type":"CONST","name":"32'h7","addr":"(MAB)","loc":"d,83:125,83:126","dtypep":"(IC)"}
+                          {"type":"CONST","name":"32'h7","addr":"(UW)","loc":"d,83:125,83:126","dtypep":"(IC)"}
                         ],
                          "rhsp": [
-                          {"type":"CCAST","name":"","addr":"(NAB)","loc":"d,83:125,83:126","dtypep":"(GC)","size":32,
+                          {"type":"CCAST","name":"","addr":"(VW)","loc":"d,83:125,83:126","dtypep":"(GC)","size":32,
                            "lhsp": [
-                            {"type":"VARREF","name":"t.e","addr":"(OAB)","loc":"d,83:125,83:126","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                            {"type":"VARREF","name":"t.e","addr":"(WW)","loc":"d,83:125,83:126","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                           ]}
                         ]}
                       ]}
@@ -1795,138 +1507,111 @@
                   ]}
                 ],"scopeNamep": []}
               ],"filep": []},
-              {"type":"STOP","name":"","addr":"(PAB)","loc":"d,83:145,83:150"}
+              {"type":"STOP","name":"","addr":"(XW)","loc":"d,83:145,83:150"}
             ],"elsesp": []},
-            {"type":"IF","name":"","addr":"(QAB)","loc":"d,84:13,84:15",
+            {"type":"IF","name":"","addr":"(YW)","loc":"d,84:26,84:29",
              "condp": [
-              {"type":"NEQ","name":"","addr":"(RAB)","loc":"d,84:26,84:29","dtypep":"(GB)",
+              {"type":"NEQ","name":"","addr":"(ZW)","loc":"d,84:26,84:29","dtypep":"(GB)",
                "lhsp": [
-                {"type":"CONST","name":"4'h1","addr":"(SAB)","loc":"d,84:31,84:34","dtypep":"(UB)"}
+                {"type":"CONST","name":"4'h1","addr":"(AX)","loc":"d,84:31,84:34","dtypep":"(UB)"}
               ],
                "rhsp": [
-                {"type":"ARRAYSEL","name":"","addr":"(TAB)","loc":"d,84:18,84:19","dtypep":"(BC)",
+                {"type":"ARRAYSEL","name":"","addr":"(BX)","loc":"d,84:18,84:19","dtypep":"(BC)",
                  "fromp": [
-                  {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(UAB)","loc":"d,17:12,17:16","dtypep":"(XI)","access":"RD","varp":"(YI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(CX)","loc":"d,17:12,17:16","dtypep":"(CH)","access":"RD","varp":"(DH)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                 ],
                  "bitp": [
-                  {"type":"AND","name":"","addr":"(VAB)","loc":"d,84:18,84:19","dtypep":"(GC)",
+                  {"type":"AND","name":"","addr":"(DX)","loc":"d,84:18,84:19","dtypep":"(GC)",
                    "lhsp": [
-                    {"type":"CONST","name":"32'h7","addr":"(WAB)","loc":"d,84:18,84:19","dtypep":"(IC)"}
+                    {"type":"CONST","name":"32'h7","addr":"(EX)","loc":"d,84:18,84:19","dtypep":"(IC)"}
                   ],
                    "rhsp": [
-                    {"type":"CCAST","name":"","addr":"(XAB)","loc":"d,84:18,84:19","dtypep":"(GC)","size":32,
+                    {"type":"CCAST","name":"","addr":"(FX)","loc":"d,84:18,84:19","dtypep":"(GC)","size":32,
                      "lhsp": [
-                      {"type":"VARREF","name":"t.e","addr":"(YAB)","loc":"d,84:18,84:19","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"t.e","addr":"(GX)","loc":"d,84:18,84:19","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ]}
                   ]}
                 ]}
               ]}
             ],
              "thensp": [
-              {"type":"DISPLAY","name":"","addr":"(ZAB)","loc":"d,84:43,84:49",
+              {"type":"DISPLAY","name":"","addr":"(HX)","loc":"d,84:43,84:49",
                "fmtp": [
-                {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:84:  got='h%x exp='h1\\n","addr":"(ABB)","loc":"d,84:43,84:49","dtypep":"(SB)",
+                {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:84:  got='h%x exp='h1\\n","addr":"(IX)","loc":"d,84:43,84:49","dtypep":"(SB)",
                  "exprsp": [
-                  {"type":"ARRAYSEL","name":"","addr":"(BBB)","loc":"d,84:122,84:123","dtypep":"(BC)",
+                  {"type":"ARRAYSEL","name":"","addr":"(JX)","loc":"d,84:122,84:123","dtypep":"(BC)",
                    "fromp": [
-                    {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(CBB)","loc":"d,17:12,17:16","dtypep":"(XI)","access":"RD","varp":"(YI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(KX)","loc":"d,17:12,17:16","dtypep":"(CH)","access":"RD","varp":"(DH)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ],
                    "bitp": [
-                    {"type":"AND","name":"","addr":"(DBB)","loc":"d,84:122,84:123","dtypep":"(GC)",
+                    {"type":"AND","name":"","addr":"(LX)","loc":"d,84:122,84:123","dtypep":"(GC)",
                      "lhsp": [
-                      {"type":"CONST","name":"32'h7","addr":"(EBB)","loc":"d,84:122,84:123","dtypep":"(IC)"}
+                      {"type":"CONST","name":"32'h7","addr":"(MX)","loc":"d,84:122,84:123","dtypep":"(IC)"}
                     ],
                      "rhsp": [
-                      {"type":"CCAST","name":"","addr":"(FBB)","loc":"d,84:122,84:123","dtypep":"(GC)","size":32,
+                      {"type":"CCAST","name":"","addr":"(NX)","loc":"d,84:122,84:123","dtypep":"(GC)","size":32,
                        "lhsp": [
-                        {"type":"VARREF","name":"t.e","addr":"(GBB)","loc":"d,84:122,84:123","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                        {"type":"VARREF","name":"t.e","addr":"(OX)","loc":"d,84:122,84:123","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                       ]}
                     ]}
                   ]}
                 ],"scopeNamep": []}
               ],"filep": []},
-              {"type":"STOP","name":"","addr":"(HBB)","loc":"d,84:139,84:144"}
-            ],"elsesp": []},
-            {"type":"IF","name":"","addr":"(IBB)","loc":"d,85:13,85:15",
-             "condp": [
-              {"type":"NEQ","name":"","addr":"(JBB)","loc":"d,85:29,85:32","dtypep":"(GB)",
-               "lhsp": [
-                {"type":"CONST","name":"4'h1","addr":"(KBB)","loc":"d,85:34,85:37","dtypep":"(UB)"}
-              ],
-               "rhsp": [
-                {"type":"ARRAYSEL","name":"","addr":"(LBB)","loc":"d,85:18,85:19","dtypep":"(BC)",
-                 "fromp": [
-                  {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(MBB)","loc":"d,17:12,17:16","dtypep":"(XI)","access":"RD","varp":"(YI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
-                ],
-                 "bitp": [
-                  {"type":"AND","name":"","addr":"(NBB)","loc":"d,85:18,85:19","dtypep":"(GC)",
-                   "lhsp": [
-                    {"type":"CONST","name":"32'h7","addr":"(OBB)","loc":"d,85:18,85:19","dtypep":"(IC)"}
-                  ],
-                   "rhsp": [
-                    {"type":"CCAST","name":"","addr":"(PBB)","loc":"d,85:18,85:19","dtypep":"(GC)","size":32,
-                     "lhsp": [
-                      {"type":"VARREF","name":"t.e","addr":"(QBB)","loc":"d,85:18,85:19","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
-                    ]}
-                  ]}
-                ]}
-              ]}
-            ],
-             "thensp": [
-              {"type":"DISPLAY","name":"","addr":"(RBB)","loc":"d,85:46,85:52",
+              {"type":"STOP","name":"","addr":"(PX)","loc":"d,84:139,84:144"},
+              {"type":"DISPLAY","name":"","addr":"(QX)","loc":"d,85:46,85:52",
                "fmtp": [
-                {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:85:  got='h%x exp='h1\\n","addr":"(SBB)","loc":"d,85:46,85:52","dtypep":"(SB)",
+                {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:85:  got='h%x exp='h1\\n","addr":"(RX)","loc":"d,85:46,85:52","dtypep":"(SB)",
                  "exprsp": [
-                  {"type":"ARRAYSEL","name":"","addr":"(TBB)","loc":"d,85:125,85:126","dtypep":"(BC)",
+                  {"type":"ARRAYSEL","name":"","addr":"(SX)","loc":"d,85:125,85:126","dtypep":"(BC)",
                    "fromp": [
-                    {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(UBB)","loc":"d,17:12,17:16","dtypep":"(XI)","access":"RD","varp":"(YI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(TX)","loc":"d,17:12,17:16","dtypep":"(CH)","access":"RD","varp":"(DH)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ],
                    "bitp": [
-                    {"type":"AND","name":"","addr":"(VBB)","loc":"d,85:125,85:126","dtypep":"(GC)",
+                    {"type":"AND","name":"","addr":"(UX)","loc":"d,85:125,85:126","dtypep":"(GC)",
                      "lhsp": [
-                      {"type":"CONST","name":"32'h7","addr":"(WBB)","loc":"d,85:125,85:126","dtypep":"(IC)"}
+                      {"type":"CONST","name":"32'h7","addr":"(VX)","loc":"d,85:125,85:126","dtypep":"(IC)"}
                     ],
                      "rhsp": [
-                      {"type":"CCAST","name":"","addr":"(XBB)","loc":"d,85:125,85:126","dtypep":"(GC)","size":32,
+                      {"type":"CCAST","name":"","addr":"(WX)","loc":"d,85:125,85:126","dtypep":"(GC)","size":32,
                        "lhsp": [
-                        {"type":"VARREF","name":"t.e","addr":"(YBB)","loc":"d,85:125,85:126","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                        {"type":"VARREF","name":"t.e","addr":"(XX)","loc":"d,85:125,85:126","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                       ]}
                     ]}
                   ]}
                 ],"scopeNamep": []}
               ],"filep": []},
-              {"type":"STOP","name":"","addr":"(ZBB)","loc":"d,85:145,85:150"}
+              {"type":"STOP","name":"","addr":"(YX)","loc":"d,85:145,85:150"}
             ],"elsesp": []},
-            {"type":"IF","name":"","addr":"(ACB)","loc":"d,86:13,86:15",
+            {"type":"IF","name":"","addr":"(ZX)","loc":"d,86:13,86:15",
              "condp": [
-              {"type":"NEQ","name":"","addr":"(BCB)","loc":"d,86:29,86:32","dtypep":"(GB)",
+              {"type":"NEQ","name":"","addr":"(AY)","loc":"d,86:29,86:32","dtypep":"(GB)",
                "lhsp": [
-                {"type":"CONST","name":"4'h4","addr":"(CCB)","loc":"d,86:34,86:37","dtypep":"(UB)"}
+                {"type":"CONST","name":"4'h4","addr":"(BY)","loc":"d,86:34,86:37","dtypep":"(UB)"}
               ],
                "rhsp": [
-                {"type":"ARRAYSEL","name":"","addr":"(DCB)","loc":"d,86:18,86:19","dtypep":"(BC)",
+                {"type":"ARRAYSEL","name":"","addr":"(CY)","loc":"d,86:18,86:19","dtypep":"(BC)",
                  "fromp": [
-                  {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(ECB)","loc":"d,17:12,17:16","dtypep":"(XI)","access":"RD","varp":"(YI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(DY)","loc":"d,17:12,17:16","dtypep":"(CH)","access":"RD","varp":"(DH)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                 ],
                  "bitp": [
-                  {"type":"AND","name":"","addr":"(FCB)","loc":"d,86:18,86:19","dtypep":"(GC)",
+                  {"type":"AND","name":"","addr":"(EY)","loc":"d,86:18,86:19","dtypep":"(GC)",
                    "lhsp": [
-                    {"type":"CONST","name":"32'h7","addr":"(GCB)","loc":"d,86:18,86:19","dtypep":"(IC)"}
+                    {"type":"CONST","name":"32'h7","addr":"(FY)","loc":"d,86:18,86:19","dtypep":"(IC)"}
                   ],
                    "rhsp": [
-                    {"type":"ARRAYSEL","name":"","addr":"(HCB)","loc":"d,86:18,86:19","dtypep":"(GC)",
+                    {"type":"ARRAYSEL","name":"","addr":"(GY)","loc":"d,86:18,86:19","dtypep":"(GC)",
                      "fromp": [
-                      {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(ICB)","loc":"d,17:12,17:16","dtypep":"(XI)","access":"RD","varp":"(YI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(HY)","loc":"d,17:12,17:16","dtypep":"(CH)","access":"RD","varp":"(DH)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ],
                      "bitp": [
-                      {"type":"AND","name":"","addr":"(JCB)","loc":"d,86:18,86:19","dtypep":"(GC)",
+                      {"type":"AND","name":"","addr":"(IY)","loc":"d,86:18,86:19","dtypep":"(GC)",
                        "lhsp": [
-                        {"type":"CONST","name":"32'h7","addr":"(KCB)","loc":"d,86:18,86:19","dtypep":"(IC)"}
+                        {"type":"CONST","name":"32'h7","addr":"(JY)","loc":"d,86:18,86:19","dtypep":"(IC)"}
                       ],
                        "rhsp": [
-                        {"type":"CCAST","name":"","addr":"(LCB)","loc":"d,86:18,86:19","dtypep":"(GC)","size":32,
+                        {"type":"CCAST","name":"","addr":"(KY)","loc":"d,86:18,86:19","dtypep":"(GC)","size":32,
                          "lhsp": [
-                          {"type":"VARREF","name":"t.e","addr":"(MCB)","loc":"d,86:18,86:19","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                          {"type":"VARREF","name":"t.e","addr":"(LY)","loc":"d,86:18,86:19","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                         ]}
                       ]}
                     ]}
@@ -1935,33 +1620,33 @@
               ]}
             ],
              "thensp": [
-              {"type":"DISPLAY","name":"","addr":"(NCB)","loc":"d,86:46,86:52",
+              {"type":"DISPLAY","name":"","addr":"(MY)","loc":"d,86:46,86:52",
                "fmtp": [
-                {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:86:  got='h%x exp='h4\\n","addr":"(OCB)","loc":"d,86:46,86:52","dtypep":"(SB)",
+                {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:86:  got='h%x exp='h4\\n","addr":"(NY)","loc":"d,86:46,86:52","dtypep":"(SB)",
                  "exprsp": [
-                  {"type":"ARRAYSEL","name":"","addr":"(PCB)","loc":"d,86:125,86:126","dtypep":"(BC)",
+                  {"type":"ARRAYSEL","name":"","addr":"(OY)","loc":"d,86:125,86:126","dtypep":"(BC)",
                    "fromp": [
-                    {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(QCB)","loc":"d,17:12,17:16","dtypep":"(XI)","access":"RD","varp":"(YI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(PY)","loc":"d,17:12,17:16","dtypep":"(CH)","access":"RD","varp":"(DH)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ],
                    "bitp": [
-                    {"type":"AND","name":"","addr":"(RCB)","loc":"d,86:125,86:126","dtypep":"(GC)",
+                    {"type":"AND","name":"","addr":"(QY)","loc":"d,86:125,86:126","dtypep":"(GC)",
                      "lhsp": [
-                      {"type":"CONST","name":"32'h7","addr":"(SCB)","loc":"d,86:125,86:126","dtypep":"(IC)"}
+                      {"type":"CONST","name":"32'h7","addr":"(RY)","loc":"d,86:125,86:126","dtypep":"(IC)"}
                     ],
                      "rhsp": [
-                      {"type":"ARRAYSEL","name":"","addr":"(TCB)","loc":"d,86:125,86:126","dtypep":"(GC)",
+                      {"type":"ARRAYSEL","name":"","addr":"(SY)","loc":"d,86:125,86:126","dtypep":"(GC)",
                        "fromp": [
-                        {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(UCB)","loc":"d,17:12,17:16","dtypep":"(XI)","access":"RD","varp":"(YI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                        {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(TY)","loc":"d,17:12,17:16","dtypep":"(CH)","access":"RD","varp":"(DH)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                       ],
                        "bitp": [
-                        {"type":"AND","name":"","addr":"(VCB)","loc":"d,86:125,86:126","dtypep":"(GC)",
+                        {"type":"AND","name":"","addr":"(UY)","loc":"d,86:125,86:126","dtypep":"(GC)",
                          "lhsp": [
-                          {"type":"CONST","name":"32'h7","addr":"(WCB)","loc":"d,86:125,86:126","dtypep":"(IC)"}
+                          {"type":"CONST","name":"32'h7","addr":"(VY)","loc":"d,86:125,86:126","dtypep":"(IC)"}
                         ],
                          "rhsp": [
-                          {"type":"CCAST","name":"","addr":"(XCB)","loc":"d,86:125,86:126","dtypep":"(GC)","size":32,
+                          {"type":"CCAST","name":"","addr":"(WY)","loc":"d,86:125,86:126","dtypep":"(GC)","size":32,
                            "lhsp": [
-                            {"type":"VARREF","name":"t.e","addr":"(YCB)","loc":"d,86:125,86:126","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                            {"type":"VARREF","name":"t.e","addr":"(XY)","loc":"d,86:125,86:126","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                           ]}
                         ]}
                       ]}
@@ -1969,215 +1654,188 @@
                   ]}
                 ],"scopeNamep": []}
               ],"filep": []},
-              {"type":"STOP","name":"","addr":"(ZCB)","loc":"d,86:145,86:150"}
+              {"type":"STOP","name":"","addr":"(YY)","loc":"d,86:145,86:150"}
             ],"elsesp": []},
-            {"type":"ASSIGNDLY","name":"","addr":"(ADB)","loc":"d,87:12,87:14","dtypep":"(UB)",
+            {"type":"ASSIGNDLY","name":"","addr":"(ZY)","loc":"d,87:12,87:14","dtypep":"(UB)",
              "rhsp": [
-              {"type":"CONST","name":"4'h4","addr":"(BDB)","loc":"d,87:15,87:18","dtypep":"(UB)"}
+              {"type":"CONST","name":"4'h4","addr":"(AZ)","loc":"d,87:15,87:18","dtypep":"(UB)"}
             ],
              "lhsp": [
-              {"type":"VARREF","name":"__Vdly__t.e","addr":"(CDB)","loc":"d,87:10,87:11","dtypep":"(UB)","access":"WR","varp":"(LQ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+              {"type":"VARREF","name":"__Vdly__t.e","addr":"(BZ)","loc":"d,87:10,87:11","dtypep":"(UB)","access":"WR","varp":"(UN)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
             ],"timingControlp": []}
           ],
            "elsesp": [
-            {"type":"IF","name":"","addr":"(DDB)","loc":"d,89:12,89:14",
+            {"type":"IF","name":"","addr":"(CZ)","loc":"d,89:12,89:14",
              "condp": [
-              {"type":"EQ","name":"","addr":"(EDB)","loc":"d,89:19,89:21","dtypep":"(GB)",
+              {"type":"EQ","name":"","addr":"(DZ)","loc":"d,89:19,89:21","dtypep":"(GB)",
                "lhsp": [
-                {"type":"CONST","name":"32'sh3","addr":"(FDB)","loc":"d,89:21,89:22","dtypep":"(LB)"}
+                {"type":"CONST","name":"32'sh3","addr":"(EZ)","loc":"d,89:21,89:22","dtypep":"(LB)"}
               ],
                "rhsp": [
-                {"type":"VARREF","name":"t.cyc","addr":"(GDB)","loc":"d,89:16,89:19","dtypep":"(S)","access":"RD","varp":"(R)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                {"type":"VARREF","name":"t.cyc","addr":"(FZ)","loc":"d,89:16,89:19","dtypep":"(S)","access":"RD","varp":"(R)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
               ]}
             ],
              "thensp": [
-              {"type":"IF","name":"","addr":"(HDB)","loc":"d,90:13,90:15",
+              {"type":"IF","name":"","addr":"(GZ)","loc":"d,90:13,90:15",
                "condp": [
-                {"type":"NEQN","name":"","addr":"(IDB)","loc":"d,90:26,90:28","dtypep":"(GB)",
+                {"type":"NEQN","name":"","addr":"(HZ)","loc":"d,90:26,90:28","dtypep":"(GB)",
                  "lhsp": [
-                  {"type":"CONST","name":"\\\"E04\\\"","addr":"(JDB)","loc":"d,90:30,90:35","dtypep":"(SB)"}
+                  {"type":"CONST","name":"\\\"E04\\\"","addr":"(IZ)","loc":"d,90:30,90:35","dtypep":"(SB)"}
                 ],
                  "rhsp": [
-                  {"type":"ARRAYSEL","name":"","addr":"(KDB)","loc":"d,90:18,90:19","dtypep":"(SB)",
+                  {"type":"ARRAYSEL","name":"","addr":"(JZ)","loc":"d,90:18,90:19","dtypep":"(SB)",
                    "fromp": [
-                    {"type":"VARREF","name":"__Venumtab_enum_name1","addr":"(LDB)","loc":"d,17:12,17:16","dtypep":"(JM)","access":"RD","varp":"(KM)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"__Venumtab_enum_name1","addr":"(KZ)","loc":"d,17:12,17:16","dtypep":"(SJ)","access":"RD","varp":"(TJ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ],
                    "bitp": [
-                    {"type":"AND","name":"","addr":"(MDB)","loc":"d,90:18,90:19","dtypep":"(GC)",
+                    {"type":"AND","name":"","addr":"(LZ)","loc":"d,90:18,90:19","dtypep":"(GC)",
                      "lhsp": [
-                      {"type":"CONST","name":"32'h7","addr":"(NDB)","loc":"d,90:18,90:19","dtypep":"(IC)"}
+                      {"type":"CONST","name":"32'h7","addr":"(MZ)","loc":"d,90:18,90:19","dtypep":"(IC)"}
                     ],
                      "rhsp": [
-                      {"type":"CCAST","name":"","addr":"(ODB)","loc":"d,90:18,90:19","dtypep":"(GC)","size":32,
+                      {"type":"CCAST","name":"","addr":"(NZ)","loc":"d,90:18,90:19","dtypep":"(GC)","size":32,
                        "lhsp": [
-                        {"type":"VARREF","name":"t.e","addr":"(PDB)","loc":"d,90:18,90:19","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                        {"type":"VARREF","name":"t.e","addr":"(OZ)","loc":"d,90:18,90:19","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                       ]}
                     ]}
                   ]}
                 ]}
               ],
                "thensp": [
-                {"type":"ASSIGN","name":"","addr":"(QDB)","loc":"d,90:123,90:124","dtypep":"(SB)",
+                {"type":"ASSIGN","name":"","addr":"(PZ)","loc":"d,90:123,90:124","dtypep":"(SB)",
                  "rhsp": [
-                  {"type":"ARRAYSEL","name":"","addr":"(RDB)","loc":"d,90:123,90:124","dtypep":"(SB)",
+                  {"type":"ARRAYSEL","name":"","addr":"(QZ)","loc":"d,90:123,90:124","dtypep":"(SB)",
                    "fromp": [
-                    {"type":"VARREF","name":"__Venumtab_enum_name1","addr":"(SDB)","loc":"d,17:12,17:16","dtypep":"(JM)","access":"RD","varp":"(KM)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"__Venumtab_enum_name1","addr":"(RZ)","loc":"d,17:12,17:16","dtypep":"(SJ)","access":"RD","varp":"(TJ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ],
                    "bitp": [
-                    {"type":"AND","name":"","addr":"(TDB)","loc":"d,90:123,90:124","dtypep":"(GC)",
+                    {"type":"AND","name":"","addr":"(SZ)","loc":"d,90:123,90:124","dtypep":"(GC)",
                      "lhsp": [
-                      {"type":"CONST","name":"32'h7","addr":"(UDB)","loc":"d,90:123,90:124","dtypep":"(IC)"}
+                      {"type":"CONST","name":"32'h7","addr":"(TZ)","loc":"d,90:123,90:124","dtypep":"(IC)"}
                     ],
                      "rhsp": [
-                      {"type":"CCAST","name":"","addr":"(VDB)","loc":"d,90:123,90:124","dtypep":"(GC)","size":32,
+                      {"type":"CCAST","name":"","addr":"(UZ)","loc":"d,90:123,90:124","dtypep":"(GC)","size":32,
                        "lhsp": [
-                        {"type":"VARREF","name":"t.e","addr":"(WDB)","loc":"d,90:123,90:124","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                        {"type":"VARREF","name":"t.e","addr":"(VZ)","loc":"d,90:123,90:124","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                       ]}
                     ]}
                   ]}
                 ],
                  "lhsp": [
-                  {"type":"VARREF","name":"__Vtemp_3","addr":"(XDB)","loc":"d,90:123,90:124","dtypep":"(SB)","access":"WR","varp":"(RQ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"__Vtemp_3","addr":"(WZ)","loc":"d,90:123,90:124","dtypep":"(SB)","access":"WR","varp":"(AO)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                 ],"timingControlp": []},
-                {"type":"DISPLAY","name":"","addr":"(YDB)","loc":"d,90:44,90:50",
+                {"type":"DISPLAY","name":"","addr":"(XZ)","loc":"d,90:44,90:50",
                  "fmtp": [
-                  {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:90:  got='%@' exp='E04'\\n","addr":"(ZDB)","loc":"d,90:44,90:50","dtypep":"(SB)",
+                  {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:90:  got='%@' exp='E04'\\n","addr":"(YZ)","loc":"d,90:44,90:50","dtypep":"(SB)",
                    "exprsp": [
-                    {"type":"VARREF","name":"__Vtemp_3","addr":"(AEB)","loc":"d,90:123,90:124","dtypep":"(SB)","access":"RD","varp":"(RQ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"__Vtemp_3","addr":"(ZZ)","loc":"d,90:123,90:124","dtypep":"(SB)","access":"RD","varp":"(AO)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ],"scopeNamep": []}
                 ],"filep": []},
-                {"type":"STOP","name":"","addr":"(BEB)","loc":"d,90:142,90:147"}
+                {"type":"STOP","name":"","addr":"(AAB)","loc":"d,90:142,90:147"}
               ],"elsesp": []},
-              {"type":"IF","name":"","addr":"(CEB)","loc":"d,91:13,91:15",
+              {"type":"IF","name":"","addr":"(BAB)","loc":"d,91:26,91:29",
                "condp": [
-                {"type":"NEQ","name":"","addr":"(DEB)","loc":"d,91:26,91:29","dtypep":"(GB)",
+                {"type":"NEQ","name":"","addr":"(CAB)","loc":"d,91:26,91:29","dtypep":"(GB)",
                  "lhsp": [
-                  {"type":"CONST","name":"4'h1","addr":"(EEB)","loc":"d,91:31,91:34","dtypep":"(UB)"}
+                  {"type":"CONST","name":"4'h1","addr":"(DAB)","loc":"d,91:31,91:34","dtypep":"(UB)"}
                 ],
                  "rhsp": [
-                  {"type":"ARRAYSEL","name":"","addr":"(FEB)","loc":"d,91:18,91:19","dtypep":"(BC)",
+                  {"type":"ARRAYSEL","name":"","addr":"(EAB)","loc":"d,91:18,91:19","dtypep":"(BC)",
                    "fromp": [
-                    {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(GEB)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(FAB)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ],
                    "bitp": [
-                    {"type":"AND","name":"","addr":"(HEB)","loc":"d,91:18,91:19","dtypep":"(GC)",
+                    {"type":"AND","name":"","addr":"(GAB)","loc":"d,91:18,91:19","dtypep":"(GC)",
                      "lhsp": [
-                      {"type":"CONST","name":"32'h7","addr":"(IEB)","loc":"d,91:18,91:19","dtypep":"(IC)"}
+                      {"type":"CONST","name":"32'h7","addr":"(HAB)","loc":"d,91:18,91:19","dtypep":"(IC)"}
                     ],
                      "rhsp": [
-                      {"type":"CCAST","name":"","addr":"(JEB)","loc":"d,91:18,91:19","dtypep":"(GC)","size":32,
+                      {"type":"CCAST","name":"","addr":"(IAB)","loc":"d,91:18,91:19","dtypep":"(GC)","size":32,
                        "lhsp": [
-                        {"type":"VARREF","name":"t.e","addr":"(KEB)","loc":"d,91:18,91:19","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                        {"type":"VARREF","name":"t.e","addr":"(JAB)","loc":"d,91:18,91:19","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                       ]}
                     ]}
                   ]}
                 ]}
               ],
                "thensp": [
-                {"type":"DISPLAY","name":"","addr":"(LEB)","loc":"d,91:43,91:49",
+                {"type":"DISPLAY","name":"","addr":"(KAB)","loc":"d,91:43,91:49",
                  "fmtp": [
-                  {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:91:  got='h%x exp='h1\\n","addr":"(MEB)","loc":"d,91:43,91:49","dtypep":"(SB)",
+                  {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:91:  got='h%x exp='h1\\n","addr":"(LAB)","loc":"d,91:43,91:49","dtypep":"(SB)",
                    "exprsp": [
-                    {"type":"ARRAYSEL","name":"","addr":"(NEB)","loc":"d,91:122,91:123","dtypep":"(BC)",
+                    {"type":"ARRAYSEL","name":"","addr":"(MAB)","loc":"d,91:122,91:123","dtypep":"(BC)",
                      "fromp": [
-                      {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(OEB)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(NAB)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ],
                      "bitp": [
-                      {"type":"AND","name":"","addr":"(PEB)","loc":"d,91:122,91:123","dtypep":"(GC)",
+                      {"type":"AND","name":"","addr":"(OAB)","loc":"d,91:122,91:123","dtypep":"(GC)",
                        "lhsp": [
-                        {"type":"CONST","name":"32'h7","addr":"(QEB)","loc":"d,91:122,91:123","dtypep":"(IC)"}
+                        {"type":"CONST","name":"32'h7","addr":"(PAB)","loc":"d,91:122,91:123","dtypep":"(IC)"}
                       ],
                        "rhsp": [
-                        {"type":"CCAST","name":"","addr":"(REB)","loc":"d,91:122,91:123","dtypep":"(GC)","size":32,
+                        {"type":"CCAST","name":"","addr":"(QAB)","loc":"d,91:122,91:123","dtypep":"(GC)","size":32,
                          "lhsp": [
-                          {"type":"VARREF","name":"t.e","addr":"(SEB)","loc":"d,91:122,91:123","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                          {"type":"VARREF","name":"t.e","addr":"(RAB)","loc":"d,91:122,91:123","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                         ]}
                       ]}
                     ]}
                   ],"scopeNamep": []}
                 ],"filep": []},
-                {"type":"STOP","name":"","addr":"(TEB)","loc":"d,91:139,91:144"}
-              ],"elsesp": []},
-              {"type":"IF","name":"","addr":"(UEB)","loc":"d,92:13,92:15",
-               "condp": [
-                {"type":"NEQ","name":"","addr":"(VEB)","loc":"d,92:29,92:32","dtypep":"(GB)",
-                 "lhsp": [
-                  {"type":"CONST","name":"4'h1","addr":"(WEB)","loc":"d,92:34,92:37","dtypep":"(UB)"}
-                ],
-                 "rhsp": [
-                  {"type":"ARRAYSEL","name":"","addr":"(XEB)","loc":"d,92:18,92:19","dtypep":"(BC)",
-                   "fromp": [
-                    {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(YEB)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
-                  ],
-                   "bitp": [
-                    {"type":"AND","name":"","addr":"(ZEB)","loc":"d,92:18,92:19","dtypep":"(GC)",
-                     "lhsp": [
-                      {"type":"CONST","name":"32'h7","addr":"(AFB)","loc":"d,92:18,92:19","dtypep":"(IC)"}
-                    ],
-                     "rhsp": [
-                      {"type":"CCAST","name":"","addr":"(BFB)","loc":"d,92:18,92:19","dtypep":"(GC)","size":32,
-                       "lhsp": [
-                        {"type":"VARREF","name":"t.e","addr":"(CFB)","loc":"d,92:18,92:19","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
-                      ]}
-                    ]}
-                  ]}
-                ]}
-              ],
-               "thensp": [
-                {"type":"DISPLAY","name":"","addr":"(DFB)","loc":"d,92:46,92:52",
+                {"type":"STOP","name":"","addr":"(SAB)","loc":"d,91:139,91:144"},
+                {"type":"DISPLAY","name":"","addr":"(TAB)","loc":"d,92:46,92:52",
                  "fmtp": [
-                  {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:92:  got='h%x exp='h1\\n","addr":"(EFB)","loc":"d,92:46,92:52","dtypep":"(SB)",
+                  {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:92:  got='h%x exp='h1\\n","addr":"(UAB)","loc":"d,92:46,92:52","dtypep":"(SB)",
                    "exprsp": [
-                    {"type":"ARRAYSEL","name":"","addr":"(FFB)","loc":"d,92:125,92:126","dtypep":"(BC)",
+                    {"type":"ARRAYSEL","name":"","addr":"(VAB)","loc":"d,92:125,92:126","dtypep":"(BC)",
                      "fromp": [
-                      {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(GFB)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(WAB)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ],
                      "bitp": [
-                      {"type":"AND","name":"","addr":"(HFB)","loc":"d,92:125,92:126","dtypep":"(GC)",
+                      {"type":"AND","name":"","addr":"(XAB)","loc":"d,92:125,92:126","dtypep":"(GC)",
                        "lhsp": [
-                        {"type":"CONST","name":"32'h7","addr":"(IFB)","loc":"d,92:125,92:126","dtypep":"(IC)"}
+                        {"type":"CONST","name":"32'h7","addr":"(YAB)","loc":"d,92:125,92:126","dtypep":"(IC)"}
                       ],
                        "rhsp": [
-                        {"type":"CCAST","name":"","addr":"(JFB)","loc":"d,92:125,92:126","dtypep":"(GC)","size":32,
+                        {"type":"CCAST","name":"","addr":"(ZAB)","loc":"d,92:125,92:126","dtypep":"(GC)","size":32,
                          "lhsp": [
-                          {"type":"VARREF","name":"t.e","addr":"(KFB)","loc":"d,92:125,92:126","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                          {"type":"VARREF","name":"t.e","addr":"(ABB)","loc":"d,92:125,92:126","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                         ]}
                       ]}
                     ]}
                   ],"scopeNamep": []}
                 ],"filep": []},
-                {"type":"STOP","name":"","addr":"(LFB)","loc":"d,92:145,92:150"}
+                {"type":"STOP","name":"","addr":"(BBB)","loc":"d,92:145,92:150"}
               ],"elsesp": []},
-              {"type":"IF","name":"","addr":"(MFB)","loc":"d,93:13,93:15",
+              {"type":"IF","name":"","addr":"(CBB)","loc":"d,93:13,93:15",
                "condp": [
-                {"type":"NEQ","name":"","addr":"(NFB)","loc":"d,93:29,93:32","dtypep":"(GB)",
+                {"type":"NEQ","name":"","addr":"(DBB)","loc":"d,93:29,93:32","dtypep":"(GB)",
                  "lhsp": [
-                  {"type":"CONST","name":"4'h3","addr":"(OFB)","loc":"d,93:34,93:37","dtypep":"(UB)"}
+                  {"type":"CONST","name":"4'h3","addr":"(EBB)","loc":"d,93:34,93:37","dtypep":"(UB)"}
                 ],
                  "rhsp": [
-                  {"type":"ARRAYSEL","name":"","addr":"(PFB)","loc":"d,93:18,93:19","dtypep":"(BC)",
+                  {"type":"ARRAYSEL","name":"","addr":"(FBB)","loc":"d,93:18,93:19","dtypep":"(BC)",
                    "fromp": [
-                    {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(QFB)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(GBB)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ],
                    "bitp": [
-                    {"type":"AND","name":"","addr":"(RFB)","loc":"d,93:18,93:19","dtypep":"(GC)",
+                    {"type":"AND","name":"","addr":"(HBB)","loc":"d,93:18,93:19","dtypep":"(GC)",
                      "lhsp": [
-                      {"type":"CONST","name":"32'h7","addr":"(SFB)","loc":"d,93:18,93:19","dtypep":"(IC)"}
+                      {"type":"CONST","name":"32'h7","addr":"(IBB)","loc":"d,93:18,93:19","dtypep":"(IC)"}
                     ],
                      "rhsp": [
-                      {"type":"ARRAYSEL","name":"","addr":"(TFB)","loc":"d,93:18,93:19","dtypep":"(GC)",
+                      {"type":"ARRAYSEL","name":"","addr":"(JBB)","loc":"d,93:18,93:19","dtypep":"(GC)",
                        "fromp": [
-                        {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(UFB)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                        {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(KBB)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                       ],
                        "bitp": [
-                        {"type":"AND","name":"","addr":"(VFB)","loc":"d,93:18,93:19","dtypep":"(GC)",
+                        {"type":"AND","name":"","addr":"(LBB)","loc":"d,93:18,93:19","dtypep":"(GC)",
                          "lhsp": [
-                          {"type":"CONST","name":"32'h7","addr":"(WFB)","loc":"d,93:18,93:19","dtypep":"(IC)"}
+                          {"type":"CONST","name":"32'h7","addr":"(MBB)","loc":"d,93:18,93:19","dtypep":"(IC)"}
                         ],
                          "rhsp": [
-                          {"type":"CCAST","name":"","addr":"(XFB)","loc":"d,93:18,93:19","dtypep":"(GC)","size":32,
+                          {"type":"CCAST","name":"","addr":"(NBB)","loc":"d,93:18,93:19","dtypep":"(GC)","size":32,
                            "lhsp": [
-                            {"type":"VARREF","name":"t.e","addr":"(YFB)","loc":"d,93:18,93:19","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                            {"type":"VARREF","name":"t.e","addr":"(OBB)","loc":"d,93:18,93:19","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                           ]}
                         ]}
                       ]}
@@ -2186,33 +1844,33 @@
                 ]}
               ],
                "thensp": [
-                {"type":"DISPLAY","name":"","addr":"(ZFB)","loc":"d,93:46,93:52",
+                {"type":"DISPLAY","name":"","addr":"(PBB)","loc":"d,93:46,93:52",
                  "fmtp": [
-                  {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:93:  got='h%x exp='h3\\n","addr":"(AGB)","loc":"d,93:46,93:52","dtypep":"(SB)",
+                  {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:93:  got='h%x exp='h3\\n","addr":"(QBB)","loc":"d,93:46,93:52","dtypep":"(SB)",
                    "exprsp": [
-                    {"type":"ARRAYSEL","name":"","addr":"(BGB)","loc":"d,93:125,93:126","dtypep":"(BC)",
+                    {"type":"ARRAYSEL","name":"","addr":"(RBB)","loc":"d,93:125,93:126","dtypep":"(BC)",
                      "fromp": [
-                      {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(CGB)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(SBB)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ],
                      "bitp": [
-                      {"type":"AND","name":"","addr":"(DGB)","loc":"d,93:125,93:126","dtypep":"(GC)",
+                      {"type":"AND","name":"","addr":"(TBB)","loc":"d,93:125,93:126","dtypep":"(GC)",
                        "lhsp": [
-                        {"type":"CONST","name":"32'h7","addr":"(EGB)","loc":"d,93:125,93:126","dtypep":"(IC)"}
+                        {"type":"CONST","name":"32'h7","addr":"(UBB)","loc":"d,93:125,93:126","dtypep":"(IC)"}
                       ],
                        "rhsp": [
-                        {"type":"ARRAYSEL","name":"","addr":"(FGB)","loc":"d,93:125,93:126","dtypep":"(GC)",
+                        {"type":"ARRAYSEL","name":"","addr":"(VBB)","loc":"d,93:125,93:126","dtypep":"(GC)",
                          "fromp": [
-                          {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(GGB)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                          {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(WBB)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"RD","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                         ],
                          "bitp": [
-                          {"type":"AND","name":"","addr":"(HGB)","loc":"d,93:125,93:126","dtypep":"(GC)",
+                          {"type":"AND","name":"","addr":"(XBB)","loc":"d,93:125,93:126","dtypep":"(GC)",
                            "lhsp": [
-                            {"type":"CONST","name":"32'h7","addr":"(IGB)","loc":"d,93:125,93:126","dtypep":"(IC)"}
+                            {"type":"CONST","name":"32'h7","addr":"(YBB)","loc":"d,93:125,93:126","dtypep":"(IC)"}
                           ],
                            "rhsp": [
-                            {"type":"CCAST","name":"","addr":"(JGB)","loc":"d,93:125,93:126","dtypep":"(GC)","size":32,
+                            {"type":"CCAST","name":"","addr":"(ZBB)","loc":"d,93:125,93:126","dtypep":"(GC)","size":32,
                              "lhsp": [
-                              {"type":"VARREF","name":"t.e","addr":"(KGB)","loc":"d,93:125,93:126","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                              {"type":"VARREF","name":"t.e","addr":"(ACB)","loc":"d,93:125,93:126","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                             ]}
                           ]}
                         ]}
@@ -2220,138 +1878,111 @@
                     ]}
                   ],"scopeNamep": []}
                 ],"filep": []},
-                {"type":"STOP","name":"","addr":"(LGB)","loc":"d,93:145,93:150"}
+                {"type":"STOP","name":"","addr":"(BCB)","loc":"d,93:145,93:150"}
               ],"elsesp": []},
-              {"type":"IF","name":"","addr":"(MGB)","loc":"d,94:13,94:15",
+              {"type":"IF","name":"","addr":"(CCB)","loc":"d,94:26,94:29",
                "condp": [
-                {"type":"NEQ","name":"","addr":"(NGB)","loc":"d,94:26,94:29","dtypep":"(GB)",
+                {"type":"NEQ","name":"","addr":"(DCB)","loc":"d,94:26,94:29","dtypep":"(GB)",
                  "lhsp": [
-                  {"type":"CONST","name":"4'h3","addr":"(OGB)","loc":"d,94:31,94:34","dtypep":"(UB)"}
+                  {"type":"CONST","name":"4'h3","addr":"(ECB)","loc":"d,94:31,94:34","dtypep":"(UB)"}
                 ],
                  "rhsp": [
-                  {"type":"ARRAYSEL","name":"","addr":"(PGB)","loc":"d,94:18,94:19","dtypep":"(BC)",
+                  {"type":"ARRAYSEL","name":"","addr":"(FCB)","loc":"d,94:18,94:19","dtypep":"(BC)",
                    "fromp": [
-                    {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(QGB)","loc":"d,17:12,17:16","dtypep":"(XI)","access":"RD","varp":"(YI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(GCB)","loc":"d,17:12,17:16","dtypep":"(CH)","access":"RD","varp":"(DH)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ],
                    "bitp": [
-                    {"type":"AND","name":"","addr":"(RGB)","loc":"d,94:18,94:19","dtypep":"(GC)",
+                    {"type":"AND","name":"","addr":"(HCB)","loc":"d,94:18,94:19","dtypep":"(GC)",
                      "lhsp": [
-                      {"type":"CONST","name":"32'h7","addr":"(SGB)","loc":"d,94:18,94:19","dtypep":"(IC)"}
+                      {"type":"CONST","name":"32'h7","addr":"(ICB)","loc":"d,94:18,94:19","dtypep":"(IC)"}
                     ],
                      "rhsp": [
-                      {"type":"CCAST","name":"","addr":"(TGB)","loc":"d,94:18,94:19","dtypep":"(GC)","size":32,
+                      {"type":"CCAST","name":"","addr":"(JCB)","loc":"d,94:18,94:19","dtypep":"(GC)","size":32,
                        "lhsp": [
-                        {"type":"VARREF","name":"t.e","addr":"(UGB)","loc":"d,94:18,94:19","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                        {"type":"VARREF","name":"t.e","addr":"(KCB)","loc":"d,94:18,94:19","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                       ]}
                     ]}
                   ]}
                 ]}
               ],
                "thensp": [
-                {"type":"DISPLAY","name":"","addr":"(VGB)","loc":"d,94:43,94:49",
+                {"type":"DISPLAY","name":"","addr":"(LCB)","loc":"d,94:43,94:49",
                  "fmtp": [
-                  {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:94:  got='h%x exp='h3\\n","addr":"(WGB)","loc":"d,94:43,94:49","dtypep":"(SB)",
+                  {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:94:  got='h%x exp='h3\\n","addr":"(MCB)","loc":"d,94:43,94:49","dtypep":"(SB)",
                    "exprsp": [
-                    {"type":"ARRAYSEL","name":"","addr":"(XGB)","loc":"d,94:122,94:123","dtypep":"(BC)",
+                    {"type":"ARRAYSEL","name":"","addr":"(NCB)","loc":"d,94:122,94:123","dtypep":"(BC)",
                      "fromp": [
-                      {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(YGB)","loc":"d,17:12,17:16","dtypep":"(XI)","access":"RD","varp":"(YI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(OCB)","loc":"d,17:12,17:16","dtypep":"(CH)","access":"RD","varp":"(DH)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ],
                      "bitp": [
-                      {"type":"AND","name":"","addr":"(ZGB)","loc":"d,94:122,94:123","dtypep":"(GC)",
+                      {"type":"AND","name":"","addr":"(PCB)","loc":"d,94:122,94:123","dtypep":"(GC)",
                        "lhsp": [
-                        {"type":"CONST","name":"32'h7","addr":"(AHB)","loc":"d,94:122,94:123","dtypep":"(IC)"}
+                        {"type":"CONST","name":"32'h7","addr":"(QCB)","loc":"d,94:122,94:123","dtypep":"(IC)"}
                       ],
                        "rhsp": [
-                        {"type":"CCAST","name":"","addr":"(BHB)","loc":"d,94:122,94:123","dtypep":"(GC)","size":32,
+                        {"type":"CCAST","name":"","addr":"(RCB)","loc":"d,94:122,94:123","dtypep":"(GC)","size":32,
                          "lhsp": [
-                          {"type":"VARREF","name":"t.e","addr":"(CHB)","loc":"d,94:122,94:123","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                          {"type":"VARREF","name":"t.e","addr":"(SCB)","loc":"d,94:122,94:123","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                         ]}
                       ]}
                     ]}
                   ],"scopeNamep": []}
                 ],"filep": []},
-                {"type":"STOP","name":"","addr":"(DHB)","loc":"d,94:139,94:144"}
-              ],"elsesp": []},
-              {"type":"IF","name":"","addr":"(EHB)","loc":"d,95:13,95:15",
-               "condp": [
-                {"type":"NEQ","name":"","addr":"(FHB)","loc":"d,95:29,95:32","dtypep":"(GB)",
-                 "lhsp": [
-                  {"type":"CONST","name":"4'h3","addr":"(GHB)","loc":"d,95:34,95:37","dtypep":"(UB)"}
-                ],
-                 "rhsp": [
-                  {"type":"ARRAYSEL","name":"","addr":"(HHB)","loc":"d,95:18,95:19","dtypep":"(BC)",
-                   "fromp": [
-                    {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(IHB)","loc":"d,17:12,17:16","dtypep":"(XI)","access":"RD","varp":"(YI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
-                  ],
-                   "bitp": [
-                    {"type":"AND","name":"","addr":"(JHB)","loc":"d,95:18,95:19","dtypep":"(GC)",
-                     "lhsp": [
-                      {"type":"CONST","name":"32'h7","addr":"(KHB)","loc":"d,95:18,95:19","dtypep":"(IC)"}
-                    ],
-                     "rhsp": [
-                      {"type":"CCAST","name":"","addr":"(LHB)","loc":"d,95:18,95:19","dtypep":"(GC)","size":32,
-                       "lhsp": [
-                        {"type":"VARREF","name":"t.e","addr":"(MHB)","loc":"d,95:18,95:19","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
-                      ]}
-                    ]}
-                  ]}
-                ]}
-              ],
-               "thensp": [
-                {"type":"DISPLAY","name":"","addr":"(NHB)","loc":"d,95:46,95:52",
+                {"type":"STOP","name":"","addr":"(TCB)","loc":"d,94:139,94:144"},
+                {"type":"DISPLAY","name":"","addr":"(UCB)","loc":"d,95:46,95:52",
                  "fmtp": [
-                  {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:95:  got='h%x exp='h3\\n","addr":"(OHB)","loc":"d,95:46,95:52","dtypep":"(SB)",
+                  {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:95:  got='h%x exp='h3\\n","addr":"(VCB)","loc":"d,95:46,95:52","dtypep":"(SB)",
                    "exprsp": [
-                    {"type":"ARRAYSEL","name":"","addr":"(PHB)","loc":"d,95:125,95:126","dtypep":"(BC)",
+                    {"type":"ARRAYSEL","name":"","addr":"(WCB)","loc":"d,95:125,95:126","dtypep":"(BC)",
                      "fromp": [
-                      {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(QHB)","loc":"d,17:12,17:16","dtypep":"(XI)","access":"RD","varp":"(YI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(XCB)","loc":"d,17:12,17:16","dtypep":"(CH)","access":"RD","varp":"(DH)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ],
                      "bitp": [
-                      {"type":"AND","name":"","addr":"(RHB)","loc":"d,95:125,95:126","dtypep":"(GC)",
+                      {"type":"AND","name":"","addr":"(YCB)","loc":"d,95:125,95:126","dtypep":"(GC)",
                        "lhsp": [
-                        {"type":"CONST","name":"32'h7","addr":"(SHB)","loc":"d,95:125,95:126","dtypep":"(IC)"}
+                        {"type":"CONST","name":"32'h7","addr":"(ZCB)","loc":"d,95:125,95:126","dtypep":"(IC)"}
                       ],
                        "rhsp": [
-                        {"type":"CCAST","name":"","addr":"(THB)","loc":"d,95:125,95:126","dtypep":"(GC)","size":32,
+                        {"type":"CCAST","name":"","addr":"(ADB)","loc":"d,95:125,95:126","dtypep":"(GC)","size":32,
                          "lhsp": [
-                          {"type":"VARREF","name":"t.e","addr":"(UHB)","loc":"d,95:125,95:126","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                          {"type":"VARREF","name":"t.e","addr":"(BDB)","loc":"d,95:125,95:126","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                         ]}
                       ]}
                     ]}
                   ],"scopeNamep": []}
                 ],"filep": []},
-                {"type":"STOP","name":"","addr":"(VHB)","loc":"d,95:145,95:150"}
+                {"type":"STOP","name":"","addr":"(CDB)","loc":"d,95:145,95:150"}
               ],"elsesp": []},
-              {"type":"IF","name":"","addr":"(WHB)","loc":"d,96:13,96:15",
+              {"type":"IF","name":"","addr":"(DDB)","loc":"d,96:13,96:15",
                "condp": [
-                {"type":"NEQ","name":"","addr":"(XHB)","loc":"d,96:29,96:32","dtypep":"(GB)",
+                {"type":"NEQ","name":"","addr":"(EDB)","loc":"d,96:29,96:32","dtypep":"(GB)",
                  "lhsp": [
-                  {"type":"CONST","name":"4'h1","addr":"(YHB)","loc":"d,96:34,96:37","dtypep":"(UB)"}
+                  {"type":"CONST","name":"4'h1","addr":"(FDB)","loc":"d,96:34,96:37","dtypep":"(UB)"}
                 ],
                  "rhsp": [
-                  {"type":"ARRAYSEL","name":"","addr":"(ZHB)","loc":"d,96:18,96:19","dtypep":"(BC)",
+                  {"type":"ARRAYSEL","name":"","addr":"(GDB)","loc":"d,96:18,96:19","dtypep":"(BC)",
                    "fromp": [
-                    {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(AIB)","loc":"d,17:12,17:16","dtypep":"(XI)","access":"RD","varp":"(YI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                    {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(HDB)","loc":"d,17:12,17:16","dtypep":"(CH)","access":"RD","varp":"(DH)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                   ],
                    "bitp": [
-                    {"type":"AND","name":"","addr":"(BIB)","loc":"d,96:18,96:19","dtypep":"(GC)",
+                    {"type":"AND","name":"","addr":"(IDB)","loc":"d,96:18,96:19","dtypep":"(GC)",
                      "lhsp": [
-                      {"type":"CONST","name":"32'h7","addr":"(CIB)","loc":"d,96:18,96:19","dtypep":"(IC)"}
+                      {"type":"CONST","name":"32'h7","addr":"(JDB)","loc":"d,96:18,96:19","dtypep":"(IC)"}
                     ],
                      "rhsp": [
-                      {"type":"ARRAYSEL","name":"","addr":"(DIB)","loc":"d,96:18,96:19","dtypep":"(GC)",
+                      {"type":"ARRAYSEL","name":"","addr":"(KDB)","loc":"d,96:18,96:19","dtypep":"(GC)",
                        "fromp": [
-                        {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(EIB)","loc":"d,17:12,17:16","dtypep":"(XI)","access":"RD","varp":"(YI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                        {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(LDB)","loc":"d,17:12,17:16","dtypep":"(CH)","access":"RD","varp":"(DH)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                       ],
                        "bitp": [
-                        {"type":"AND","name":"","addr":"(FIB)","loc":"d,96:18,96:19","dtypep":"(GC)",
+                        {"type":"AND","name":"","addr":"(MDB)","loc":"d,96:18,96:19","dtypep":"(GC)",
                          "lhsp": [
-                          {"type":"CONST","name":"32'h7","addr":"(GIB)","loc":"d,96:18,96:19","dtypep":"(IC)"}
+                          {"type":"CONST","name":"32'h7","addr":"(NDB)","loc":"d,96:18,96:19","dtypep":"(IC)"}
                         ],
                          "rhsp": [
-                          {"type":"CCAST","name":"","addr":"(HIB)","loc":"d,96:18,96:19","dtypep":"(GC)","size":32,
+                          {"type":"CCAST","name":"","addr":"(ODB)","loc":"d,96:18,96:19","dtypep":"(GC)","size":32,
                            "lhsp": [
-                            {"type":"VARREF","name":"t.e","addr":"(IIB)","loc":"d,96:18,96:19","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                            {"type":"VARREF","name":"t.e","addr":"(PDB)","loc":"d,96:18,96:19","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                           ]}
                         ]}
                       ]}
@@ -2360,33 +1991,33 @@
                 ]}
               ],
                "thensp": [
-                {"type":"DISPLAY","name":"","addr":"(JIB)","loc":"d,96:46,96:52",
+                {"type":"DISPLAY","name":"","addr":"(QDB)","loc":"d,96:46,96:52",
                  "fmtp": [
-                  {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:96:  got='h%x exp='h1\\n","addr":"(KIB)","loc":"d,96:46,96:52","dtypep":"(SB)",
+                  {"type":"SFORMATF","name":"%%Error: t/t_enum_type_methods.v:96:  got='h%x exp='h1\\n","addr":"(RDB)","loc":"d,96:46,96:52","dtypep":"(SB)",
                    "exprsp": [
-                    {"type":"ARRAYSEL","name":"","addr":"(LIB)","loc":"d,96:125,96:126","dtypep":"(BC)",
+                    {"type":"ARRAYSEL","name":"","addr":"(SDB)","loc":"d,96:125,96:126","dtypep":"(BC)",
                      "fromp": [
-                      {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(MIB)","loc":"d,17:12,17:16","dtypep":"(XI)","access":"RD","varp":"(YI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                      {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(TDB)","loc":"d,17:12,17:16","dtypep":"(CH)","access":"RD","varp":"(DH)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                     ],
                      "bitp": [
-                      {"type":"AND","name":"","addr":"(NIB)","loc":"d,96:125,96:126","dtypep":"(GC)",
+                      {"type":"AND","name":"","addr":"(UDB)","loc":"d,96:125,96:126","dtypep":"(GC)",
                        "lhsp": [
-                        {"type":"CONST","name":"32'h7","addr":"(OIB)","loc":"d,96:125,96:126","dtypep":"(IC)"}
+                        {"type":"CONST","name":"32'h7","addr":"(VDB)","loc":"d,96:125,96:126","dtypep":"(IC)"}
                       ],
                        "rhsp": [
-                        {"type":"ARRAYSEL","name":"","addr":"(PIB)","loc":"d,96:125,96:126","dtypep":"(GC)",
+                        {"type":"ARRAYSEL","name":"","addr":"(WDB)","loc":"d,96:125,96:126","dtypep":"(GC)",
                          "fromp": [
-                          {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(QIB)","loc":"d,17:12,17:16","dtypep":"(XI)","access":"RD","varp":"(YI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                          {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(XDB)","loc":"d,17:12,17:16","dtypep":"(CH)","access":"RD","varp":"(DH)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                         ],
                          "bitp": [
-                          {"type":"AND","name":"","addr":"(RIB)","loc":"d,96:125,96:126","dtypep":"(GC)",
+                          {"type":"AND","name":"","addr":"(YDB)","loc":"d,96:125,96:126","dtypep":"(GC)",
                            "lhsp": [
-                            {"type":"CONST","name":"32'h7","addr":"(SIB)","loc":"d,96:125,96:126","dtypep":"(IC)"}
+                            {"type":"CONST","name":"32'h7","addr":"(ZDB)","loc":"d,96:125,96:126","dtypep":"(IC)"}
                           ],
                            "rhsp": [
-                            {"type":"CCAST","name":"","addr":"(TIB)","loc":"d,96:125,96:126","dtypep":"(GC)","size":32,
+                            {"type":"CCAST","name":"","addr":"(AEB)","loc":"d,96:125,96:126","dtypep":"(GC)","size":32,
                              "lhsp": [
-                              {"type":"VARREF","name":"t.e","addr":"(UIB)","loc":"d,96:125,96:126","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                              {"type":"VARREF","name":"t.e","addr":"(BEB)","loc":"d,96:125,96:126","dtypep":"(GC)","access":"RD","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                             ]}
                           ]}
                         ]}
@@ -2394,627 +2025,627 @@
                     ]}
                   ],"scopeNamep": []}
                 ],"filep": []},
-                {"type":"STOP","name":"","addr":"(VIB)","loc":"d,96:145,96:150"}
+                {"type":"STOP","name":"","addr":"(CEB)","loc":"d,96:145,96:150"}
               ],"elsesp": []},
-              {"type":"ASSIGNDLY","name":"","addr":"(WIB)","loc":"d,97:12,97:14","dtypep":"(UB)",
+              {"type":"ASSIGNDLY","name":"","addr":"(DEB)","loc":"d,97:12,97:14","dtypep":"(UB)",
                "rhsp": [
-                {"type":"CONST","name":"4'h1","addr":"(XIB)","loc":"d,97:15,97:18","dtypep":"(UB)"}
+                {"type":"CONST","name":"4'h1","addr":"(EEB)","loc":"d,97:15,97:18","dtypep":"(UB)"}
               ],
                "lhsp": [
-                {"type":"VARREF","name":"__Vdly__t.e","addr":"(YIB)","loc":"d,97:10,97:11","dtypep":"(UB)","access":"WR","varp":"(LQ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                {"type":"VARREF","name":"__Vdly__t.e","addr":"(FEB)","loc":"d,97:10,97:11","dtypep":"(UB)","access":"WR","varp":"(UN)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
               ],"timingControlp": []}
             ],
              "elsesp": [
-              {"type":"IF","name":"","addr":"(ZIB)","loc":"d,99:12,99:14",
+              {"type":"IF","name":"","addr":"(GEB)","loc":"d,99:12,99:14",
                "condp": [
-                {"type":"EQ","name":"","addr":"(AJB)","loc":"d,99:19,99:21","dtypep":"(GB)",
+                {"type":"EQ","name":"","addr":"(HEB)","loc":"d,99:19,99:21","dtypep":"(GB)",
                  "lhsp": [
-                  {"type":"CONST","name":"32'sh63","addr":"(BJB)","loc":"d,99:21,99:23","dtypep":"(LB)"}
+                  {"type":"CONST","name":"32'sh63","addr":"(IEB)","loc":"d,99:21,99:23","dtypep":"(LB)"}
                 ],
                  "rhsp": [
-                  {"type":"VARREF","name":"t.cyc","addr":"(CJB)","loc":"d,99:16,99:19","dtypep":"(S)","access":"RD","varp":"(R)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+                  {"type":"VARREF","name":"t.cyc","addr":"(JEB)","loc":"d,99:16,99:19","dtypep":"(S)","access":"RD","varp":"(R)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
                 ]}
               ],
                "thensp": [
-                {"type":"DISPLAY","name":"","addr":"(DJB)","loc":"d,100:10,100:16",
+                {"type":"DISPLAY","name":"","addr":"(KEB)","loc":"d,100:10,100:16",
                  "fmtp": [
-                  {"type":"SFORMATF","name":"*-* All Finished *-*\\n","addr":"(EJB)","loc":"d,100:10,100:16","dtypep":"(SB)","exprsp": [],"scopeNamep": []}
+                  {"type":"SFORMATF","name":"*-* All Finished *-*\\n","addr":"(LEB)","loc":"d,100:10,100:16","dtypep":"(SB)","exprsp": [],"scopeNamep": []}
                 ],"filep": []},
-                {"type":"FINISH","name":"","addr":"(FJB)","loc":"d,101:10,101:17"}
+                {"type":"FINISH","name":"","addr":"(MEB)","loc":"d,101:10,101:17"}
               ],"elsesp": []}
             ]}
           ]}
         ]}
       ]},
-      {"type":"ASSIGN","name":"","addr":"(GJB)","loc":"d,23:17,23:20","dtypep":"(S)",
+      {"type":"ASSIGN","name":"","addr":"(NEB)","loc":"d,23:17,23:20","dtypep":"(S)",
        "rhsp": [
-        {"type":"VARREF","name":"__Vdly__t.cyc","addr":"(HJB)","loc":"d,23:17,23:20","dtypep":"(S)","access":"RD","varp":"(HQ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"__Vdly__t.cyc","addr":"(OEB)","loc":"d,23:17,23:20","dtypep":"(S)","access":"RD","varp":"(QN)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"t.cyc","addr":"(IJB)","loc":"d,23:17,23:20","dtypep":"(S)","access":"WR","varp":"(R)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"t.cyc","addr":"(PEB)","loc":"d,23:17,23:20","dtypep":"(S)","access":"WR","varp":"(R)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []},
-      {"type":"ASSIGN","name":"","addr":"(JJB)","loc":"d,24:9,24:10","dtypep":"(UB)",
+      {"type":"ASSIGN","name":"","addr":"(QEB)","loc":"d,24:9,24:10","dtypep":"(UB)",
        "rhsp": [
-        {"type":"VARREF","name":"__Vdly__t.e","addr":"(KJB)","loc":"d,24:9,24:10","dtypep":"(UB)","access":"RD","varp":"(LQ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"__Vdly__t.e","addr":"(REB)","loc":"d,24:9,24:10","dtypep":"(UB)","access":"RD","varp":"(UN)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"t.e","addr":"(LJB)","loc":"d,24:9,24:10","dtypep":"(UB)","access":"WR","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"t.e","addr":"(SEB)","loc":"d,24:9,24:10","dtypep":"(UB)","access":"WR","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []}
     ]},
     {"type":"CFUNC","name":"_eval_nba","addr":"(G)","loc":"a,0:0,0:0","scopep":"(Z)","argsp": [],"varsp": [],
      "stmtsp": [
-      {"type":"IF","name":"","addr":"(MJB)","loc":"d,11:8,11:9",
+      {"type":"IF","name":"","addr":"(TEB)","loc":"d,11:8,11:9",
        "condp": [
-        {"type":"AND","name":"","addr":"(NJB)","loc":"d,11:8,11:9","dtypep":"(KN)",
+        {"type":"AND","name":"","addr":"(UEB)","loc":"d,11:8,11:9","dtypep":"(TK)",
          "lhsp": [
-          {"type":"CONST","name":"64'h1","addr":"(OJB)","loc":"d,11:8,11:9","dtypep":"(KN)"}
+          {"type":"CONST","name":"64'h1","addr":"(VEB)","loc":"d,11:8,11:9","dtypep":"(TK)"}
         ],
          "rhsp": [
-          {"type":"ARRAYSEL","name":"","addr":"(PJB)","loc":"d,11:8,11:9","dtypep":"(IN)",
+          {"type":"ARRAYSEL","name":"","addr":"(WEB)","loc":"d,11:8,11:9","dtypep":"(RK)",
            "fromp": [
-            {"type":"VARREF","name":"__VnbaTriggered","addr":"(QJB)","loc":"d,11:8,11:9","dtypep":"(W)","access":"RD","varp":"(X)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"__VnbaTriggered","addr":"(XEB)","loc":"d,11:8,11:9","dtypep":"(W)","access":"RD","varp":"(X)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ],
            "bitp": [
-            {"type":"CONST","name":"32'h0","addr":"(RJB)","loc":"d,11:8,11:9","dtypep":"(IC)"}
+            {"type":"CONST","name":"32'h0","addr":"(YEB)","loc":"d,11:8,11:9","dtypep":"(IC)"}
           ]}
         ]}
       ],
        "thensp": [
-        {"type":"STMTEXPR","name":"","addr":"(SJB)","loc":"d,23:17,23:20",
+        {"type":"STMTEXPR","name":"","addr":"(ZEB)","loc":"d,23:17,23:20",
          "exprp": [
-          {"type":"CCALL","name":"","addr":"(TJB)","loc":"d,23:17,23:20","dtypep":"(DB)","funcName":"_nba_sequent__TOP__0","funcp":"(GQ)","argsp": []}
+          {"type":"CCALL","name":"","addr":"(AFB)","loc":"d,23:17,23:20","dtypep":"(DB)","funcName":"_nba_sequent__TOP__0","funcp":"(PN)","argsp": []}
         ]}
       ],"elsesp": []}
     ]},
-    {"type":"CFUNC","name":"_trigger_orInto__act_vec_vec","addr":"(UJB)","loc":"a,0:0,0:0","isStatic":true,"scopep":"(Z)",
+    {"type":"CFUNC","name":"_trigger_orInto__act_vec_vec","addr":"(BFB)","loc":"a,0:0,0:0","isStatic":true,"scopep":"(Z)",
      "argsp": [
-      {"type":"VAR","name":"out","addr":"(VJB)","loc":"a,0:0,0:0","dtypep":"(W)","origName":"out","verilogName":"out","direction":"INOUT","isFuncLocal":true,"lifetime":"NONE","varType":"BLOCKTEMP","dtypeName":"","sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
-      {"type":"ASSIGN","name":"","addr":"(WJB)","loc":"a,0:0,0:0","dtypep":"(W)",
+      {"type":"VAR","name":"out","addr":"(CFB)","loc":"a,0:0,0:0","dtypep":"(W)","origName":"out","verilogName":"out","direction":"INOUT","isFuncLocal":true,"lifetime":"NONE","varType":"BLOCKTEMP","dtypeName":"","sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
+      {"type":"ASSIGN","name":"","addr":"(DFB)","loc":"a,0:0,0:0","dtypep":"(W)",
        "rhsp": [
-        {"type":"CRESET","name":"","addr":"(XJB)","loc":"a,0:0,0:0","dtypep":"(W)","constructing":true}
+        {"type":"CRESET","name":"","addr":"(EFB)","loc":"a,0:0,0:0","dtypep":"(W)","constructing":true}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"out","addr":"(YJB)","loc":"a,0:0,0:0","dtypep":"(W)","access":"WR","varp":"(VJB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"out","addr":"(FFB)","loc":"a,0:0,0:0","dtypep":"(W)","access":"WR","varp":"(CFB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []},
-      {"type":"VAR","name":"in","addr":"(ZJB)","loc":"a,0:0,0:0","dtypep":"(W)","origName":"in","verilogName":"in","direction":"CONSTREF","isFuncLocal":true,"lifetime":"NONE","varType":"BLOCKTEMP","dtypeName":"","sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
-      {"type":"ASSIGN","name":"","addr":"(AKB)","loc":"a,0:0,0:0","dtypep":"(W)",
+      {"type":"VAR","name":"in","addr":"(GFB)","loc":"a,0:0,0:0","dtypep":"(W)","origName":"in","verilogName":"in","direction":"CONSTREF","isFuncLocal":true,"lifetime":"NONE","varType":"BLOCKTEMP","dtypeName":"","sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
+      {"type":"ASSIGN","name":"","addr":"(HFB)","loc":"a,0:0,0:0","dtypep":"(W)",
        "rhsp": [
-        {"type":"CRESET","name":"","addr":"(BKB)","loc":"a,0:0,0:0","dtypep":"(W)","constructing":true}
+        {"type":"CRESET","name":"","addr":"(IFB)","loc":"a,0:0,0:0","dtypep":"(W)","constructing":true}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"in","addr":"(CKB)","loc":"a,0:0,0:0","dtypep":"(W)","access":"WR","varp":"(ZJB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"in","addr":"(JFB)","loc":"a,0:0,0:0","dtypep":"(W)","access":"WR","varp":"(GFB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []}
     ],
      "varsp": [
-      {"type":"VAR","name":"n","addr":"(DKB)","loc":"a,0:0,0:0","dtypep":"(JP)","origName":"n","verilogName":"n","direction":"NONE","noReset":true,"isFuncLocal":true,"lifetime":"NONE","varType":"BLOCKTEMP","dtypeName":"IData","sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []}
+      {"type":"VAR","name":"n","addr":"(KFB)","loc":"a,0:0,0:0","dtypep":"(SM)","origName":"n","verilogName":"n","direction":"NONE","noReset":true,"isFuncLocal":true,"lifetime":"NONE","varType":"BLOCKTEMP","dtypeName":"IData","sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []}
     ],
      "stmtsp": [
-      {"type":"ASSIGN","name":"","addr":"(EKB)","loc":"a,0:0,0:0","dtypep":"(JP)",
+      {"type":"ASSIGN","name":"","addr":"(LFB)","loc":"a,0:0,0:0","dtypep":"(SM)",
        "rhsp": [
-        {"type":"CONST","name":"32'h0","addr":"(FKB)","loc":"a,0:0,0:0","dtypep":"(IC)"}
+        {"type":"CONST","name":"32'h0","addr":"(MFB)","loc":"a,0:0,0:0","dtypep":"(IC)"}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"n","addr":"(GKB)","loc":"a,0:0,0:0","dtypep":"(JP)","access":"WR","varp":"(DKB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"n","addr":"(NFB)","loc":"a,0:0,0:0","dtypep":"(SM)","access":"WR","varp":"(KFB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []},
-      {"type":"LOOP","name":"","addr":"(HKB)","loc":"d,11:8,11:9","unroll":"default",
+      {"type":"LOOP","name":"","addr":"(OFB)","loc":"d,11:8,11:9","unroll":"default",
        "stmtsp": [
-        {"type":"ASSIGN","name":"","addr":"(IKB)","loc":"d,11:8,11:9","dtypep":"(IN)",
+        {"type":"ASSIGN","name":"","addr":"(PFB)","loc":"d,11:8,11:9","dtypep":"(RK)",
          "rhsp": [
-          {"type":"OR","name":"","addr":"(JKB)","loc":"d,11:8,11:9","dtypep":"(IN)",
+          {"type":"OR","name":"","addr":"(QFB)","loc":"d,11:8,11:9","dtypep":"(RK)",
            "lhsp": [
-            {"type":"ARRAYSEL","name":"","addr":"(KKB)","loc":"d,11:8,11:9","dtypep":"(IN)",
+            {"type":"ARRAYSEL","name":"","addr":"(RFB)","loc":"d,11:8,11:9","dtypep":"(RK)",
              "fromp": [
-              {"type":"VARREF","name":"out","addr":"(LKB)","loc":"d,11:8,11:9","dtypep":"(W)","access":"RD","varp":"(VJB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+              {"type":"VARREF","name":"out","addr":"(SFB)","loc":"d,11:8,11:9","dtypep":"(W)","access":"RD","varp":"(CFB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
             ],
              "bitp": [
-              {"type":"VARREF","name":"n","addr":"(MKB)","loc":"d,11:8,11:9","dtypep":"(JP)","access":"RD","varp":"(DKB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+              {"type":"VARREF","name":"n","addr":"(TFB)","loc":"d,11:8,11:9","dtypep":"(SM)","access":"RD","varp":"(KFB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
             ]}
           ],
            "rhsp": [
-            {"type":"ARRAYSEL","name":"","addr":"(NKB)","loc":"d,11:8,11:9","dtypep":"(IN)",
+            {"type":"ARRAYSEL","name":"","addr":"(UFB)","loc":"d,11:8,11:9","dtypep":"(RK)",
              "fromp": [
-              {"type":"VARREF","name":"in","addr":"(OKB)","loc":"d,11:8,11:9","dtypep":"(W)","access":"RD","varp":"(ZJB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+              {"type":"VARREF","name":"in","addr":"(VFB)","loc":"d,11:8,11:9","dtypep":"(W)","access":"RD","varp":"(GFB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
             ],
              "bitp": [
-              {"type":"VARREF","name":"n","addr":"(PKB)","loc":"d,11:8,11:9","dtypep":"(JP)","access":"RD","varp":"(DKB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+              {"type":"VARREF","name":"n","addr":"(WFB)","loc":"d,11:8,11:9","dtypep":"(SM)","access":"RD","varp":"(KFB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
             ]}
           ]}
         ],
          "lhsp": [
-          {"type":"ARRAYSEL","name":"","addr":"(QKB)","loc":"d,11:8,11:9","dtypep":"(IN)",
+          {"type":"ARRAYSEL","name":"","addr":"(XFB)","loc":"d,11:8,11:9","dtypep":"(RK)",
            "fromp": [
-            {"type":"VARREF","name":"out","addr":"(RKB)","loc":"d,11:8,11:9","dtypep":"(W)","access":"WR","varp":"(VJB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"out","addr":"(YFB)","loc":"d,11:8,11:9","dtypep":"(W)","access":"WR","varp":"(CFB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ],
            "bitp": [
-            {"type":"VARREF","name":"n","addr":"(SKB)","loc":"d,11:8,11:9","dtypep":"(JP)","access":"RD","varp":"(DKB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"n","addr":"(ZFB)","loc":"d,11:8,11:9","dtypep":"(SM)","access":"RD","varp":"(KFB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ]}
         ],"timingControlp": []},
-        {"type":"ASSIGN","name":"","addr":"(TKB)","loc":"a,0:0,0:0","dtypep":"(JP)",
+        {"type":"ASSIGN","name":"","addr":"(AGB)","loc":"a,0:0,0:0","dtypep":"(SM)",
          "rhsp": [
-          {"type":"ADD","name":"","addr":"(UKB)","loc":"a,0:0,0:0","dtypep":"(JP)",
+          {"type":"ADD","name":"","addr":"(BGB)","loc":"a,0:0,0:0","dtypep":"(SM)",
            "lhsp": [
-            {"type":"CCAST","name":"","addr":"(VKB)","loc":"a,0:0,0:0","dtypep":"(IC)","size":32,
+            {"type":"CCAST","name":"","addr":"(CGB)","loc":"a,0:0,0:0","dtypep":"(IC)","size":32,
              "lhsp": [
-              {"type":"CONST","name":"32'h1","addr":"(WKB)","loc":"a,0:0,0:0","dtypep":"(IC)"}
+              {"type":"CONST","name":"32'h1","addr":"(DGB)","loc":"a,0:0,0:0","dtypep":"(IC)"}
             ]}
           ],
            "rhsp": [
-            {"type":"VARREF","name":"n","addr":"(XKB)","loc":"a,0:0,0:0","dtypep":"(JP)","access":"RD","varp":"(DKB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"n","addr":"(EGB)","loc":"a,0:0,0:0","dtypep":"(SM)","access":"RD","varp":"(KFB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ]}
         ],
          "lhsp": [
-          {"type":"VARREF","name":"n","addr":"(YKB)","loc":"a,0:0,0:0","dtypep":"(JP)","access":"WR","varp":"(DKB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+          {"type":"VARREF","name":"n","addr":"(FGB)","loc":"a,0:0,0:0","dtypep":"(SM)","access":"WR","varp":"(KFB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
         ],"timingControlp": []},
-        {"type":"LOOPTEST","name":"","addr":"(ZKB)","loc":"d,11:8,11:9",
+        {"type":"LOOPTEST","name":"","addr":"(GGB)","loc":"d,11:8,11:9",
          "condp": [
-          {"type":"GTE","name":"","addr":"(ALB)","loc":"d,11:8,11:9","dtypep":"(GB)",
+          {"type":"GTE","name":"","addr":"(HGB)","loc":"d,11:8,11:9","dtypep":"(GB)",
            "lhsp": [
-            {"type":"CONST","name":"32'h0","addr":"(BLB)","loc":"d,11:8,11:9","dtypep":"(IC)"}
+            {"type":"CONST","name":"32'h0","addr":"(IGB)","loc":"d,11:8,11:9","dtypep":"(IC)"}
           ],
            "rhsp": [
-            {"type":"VARREF","name":"n","addr":"(CLB)","loc":"d,11:8,11:9","dtypep":"(JP)","access":"RD","varp":"(DKB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"n","addr":"(JGB)","loc":"d,11:8,11:9","dtypep":"(SM)","access":"RD","varp":"(KFB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ]}
         ]}
       ],"contsp": []}
     ]},
-    {"type":"CFUNC","name":"_eval_phase__act","addr":"(DLB)","loc":"a,0:0,0:0","scopep":"(Z)","argsp": [],"varsp": [],
+    {"type":"CFUNC","name":"_eval_phase__act","addr":"(KGB)","loc":"a,0:0,0:0","scopep":"(Z)","argsp": [],"varsp": [],
      "stmtsp": [
-      {"type":"STMTEXPR","name":"","addr":"(ELB)","loc":"d,11:8,11:9",
+      {"type":"STMTEXPR","name":"","addr":"(LGB)","loc":"d,11:8,11:9",
        "exprp": [
-        {"type":"CCALL","name":"","addr":"(FLB)","loc":"d,11:8,11:9","dtypep":"(DB)","funcName":"_eval_triggers_vec__act","funcp":"(GN)","argsp": []}
+        {"type":"CCALL","name":"","addr":"(MGB)","loc":"d,11:8,11:9","dtypep":"(DB)","funcName":"_eval_triggers_vec__act","funcp":"(PK)","argsp": []}
       ]},
-      {"type":"CSTMT","name":"","addr":"(GLB)","loc":"d,11:8,11:9",
+      {"type":"CSTMT","name":"","addr":"(NGB)","loc":"d,11:8,11:9",
        "nodesp": [
-        {"type":"TEXT","name":"","addr":"(HLB)","loc":"d,11:8,11:9","text":"#ifdef VL_DEBUG\n"},
-        {"type":"TEXT","name":"","addr":"(ILB)","loc":"d,11:8,11:9","text":"if (VL_UNLIKELY(vlSymsp->_vm_contextp__->debug())) {\n"},
-        {"type":"STMTEXPR","name":"","addr":"(JLB)","loc":"d,11:8,11:9",
+        {"type":"TEXT","name":"","addr":"(OGB)","loc":"d,11:8,11:9","text":"#ifdef VL_DEBUG\n"},
+        {"type":"TEXT","name":"","addr":"(PGB)","loc":"d,11:8,11:9","text":"if (VL_UNLIKELY(vlSymsp->_vm_contextp__->debug())) {\n"},
+        {"type":"STMTEXPR","name":"","addr":"(QGB)","loc":"d,11:8,11:9",
          "exprp": [
-          {"type":"CCALL","name":"","addr":"(KLB)","loc":"d,11:8,11:9","dtypep":"(DB)","funcName":"_dump_triggers__act","funcp":"(YN)",
+          {"type":"CCALL","name":"","addr":"(RGB)","loc":"d,11:8,11:9","dtypep":"(DB)","funcName":"_dump_triggers__act","funcp":"(HL)",
            "argsp": [
-            {"type":"VARREF","name":"__VactTriggered","addr":"(LLB)","loc":"d,11:8,11:9","dtypep":"(W)","access":"RD","varp":"(V)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"},
-            {"type":"CONST","name":"\\\"act\\\"","addr":"(MLB)","loc":"d,11:8,11:9","dtypep":"(SB)"}
+            {"type":"VARREF","name":"__VactTriggered","addr":"(SGB)","loc":"d,11:8,11:9","dtypep":"(W)","access":"RD","varp":"(V)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"},
+            {"type":"CONST","name":"\\\"act\\\"","addr":"(TGB)","loc":"d,11:8,11:9","dtypep":"(SB)"}
           ]}
         ]},
-        {"type":"TEXT","name":"","addr":"(NLB)","loc":"d,11:8,11:9","text":"}\n"},
-        {"type":"TEXT","name":"","addr":"(OLB)","loc":"d,11:8,11:9","text":"#endif"}
+        {"type":"TEXT","name":"","addr":"(UGB)","loc":"d,11:8,11:9","text":"}\n"},
+        {"type":"TEXT","name":"","addr":"(VGB)","loc":"d,11:8,11:9","text":"#endif"}
       ]},
-      {"type":"STMTEXPR","name":"","addr":"(PLB)","loc":"d,11:8,11:9",
+      {"type":"STMTEXPR","name":"","addr":"(WGB)","loc":"d,11:8,11:9",
        "exprp": [
-        {"type":"CCALL","name":"","addr":"(QLB)","loc":"d,11:8,11:9","dtypep":"(DB)","funcName":"_trigger_orInto__act_vec_vec","funcp":"(UJB)",
+        {"type":"CCALL","name":"","addr":"(XGB)","loc":"d,11:8,11:9","dtypep":"(DB)","funcName":"_trigger_orInto__act_vec_vec","funcp":"(BFB)",
          "argsp": [
-          {"type":"VARREF","name":"__VnbaTriggered","addr":"(RLB)","loc":"d,11:8,11:9","dtypep":"(W)","access":"WR","varp":"(X)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"},
-          {"type":"VARREF","name":"__VactTriggered","addr":"(SLB)","loc":"d,11:8,11:9","dtypep":"(W)","access":"RD","varp":"(V)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+          {"type":"VARREF","name":"__VnbaTriggered","addr":"(YGB)","loc":"d,11:8,11:9","dtypep":"(W)","access":"WR","varp":"(X)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"},
+          {"type":"VARREF","name":"__VactTriggered","addr":"(ZGB)","loc":"d,11:8,11:9","dtypep":"(W)","access":"RD","varp":"(V)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
         ]}
       ]},
-      {"type":"CRETURN","name":"","addr":"(TLB)","loc":"a,0:0,0:0",
+      {"type":"CRETURN","name":"","addr":"(AHB)","loc":"a,0:0,0:0",
        "lhsp": [
-        {"type":"CONST","name":"1'h0","addr":"(ULB)","loc":"a,0:0,0:0","dtypep":"(GB)"}
+        {"type":"CONST","name":"1'h0","addr":"(BHB)","loc":"a,0:0,0:0","dtypep":"(GB)"}
       ]}
     ]},
-    {"type":"CFUNC","name":"_trigger_clear__act","addr":"(VLB)","loc":"a,0:0,0:0","isStatic":true,"scopep":"(Z)",
+    {"type":"CFUNC","name":"_trigger_clear__act","addr":"(CHB)","loc":"a,0:0,0:0","isStatic":true,"scopep":"(Z)",
      "argsp": [
-      {"type":"VAR","name":"out","addr":"(WLB)","loc":"a,0:0,0:0","dtypep":"(W)","origName":"out","verilogName":"out","direction":"OUTPUT","isFuncLocal":true,"lifetime":"NONE","varType":"BLOCKTEMP","dtypeName":"","sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
-      {"type":"ASSIGN","name":"","addr":"(XLB)","loc":"a,0:0,0:0","dtypep":"(W)",
+      {"type":"VAR","name":"out","addr":"(DHB)","loc":"a,0:0,0:0","dtypep":"(W)","origName":"out","verilogName":"out","direction":"OUTPUT","isFuncLocal":true,"lifetime":"NONE","varType":"BLOCKTEMP","dtypeName":"","sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
+      {"type":"ASSIGN","name":"","addr":"(EHB)","loc":"a,0:0,0:0","dtypep":"(W)",
        "rhsp": [
-        {"type":"CRESET","name":"","addr":"(YLB)","loc":"a,0:0,0:0","dtypep":"(W)","constructing":true}
+        {"type":"CRESET","name":"","addr":"(FHB)","loc":"a,0:0,0:0","dtypep":"(W)","constructing":true}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"out","addr":"(ZLB)","loc":"a,0:0,0:0","dtypep":"(W)","access":"WR","varp":"(WLB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"out","addr":"(GHB)","loc":"a,0:0,0:0","dtypep":"(W)","access":"WR","varp":"(DHB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []}
     ],
      "varsp": [
-      {"type":"VAR","name":"n","addr":"(AMB)","loc":"a,0:0,0:0","dtypep":"(JP)","origName":"n","verilogName":"n","direction":"NONE","noReset":true,"isFuncLocal":true,"lifetime":"NONE","varType":"BLOCKTEMP","dtypeName":"IData","sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []}
+      {"type":"VAR","name":"n","addr":"(HHB)","loc":"a,0:0,0:0","dtypep":"(SM)","origName":"n","verilogName":"n","direction":"NONE","noReset":true,"isFuncLocal":true,"lifetime":"NONE","varType":"BLOCKTEMP","dtypeName":"IData","sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []}
     ],
      "stmtsp": [
-      {"type":"ASSIGN","name":"","addr":"(BMB)","loc":"a,0:0,0:0","dtypep":"(JP)",
+      {"type":"ASSIGN","name":"","addr":"(IHB)","loc":"a,0:0,0:0","dtypep":"(SM)",
        "rhsp": [
-        {"type":"CONST","name":"32'h0","addr":"(CMB)","loc":"a,0:0,0:0","dtypep":"(IC)"}
+        {"type":"CONST","name":"32'h0","addr":"(JHB)","loc":"a,0:0,0:0","dtypep":"(IC)"}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"n","addr":"(DMB)","loc":"a,0:0,0:0","dtypep":"(JP)","access":"WR","varp":"(AMB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"n","addr":"(KHB)","loc":"a,0:0,0:0","dtypep":"(SM)","access":"WR","varp":"(HHB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []},
-      {"type":"LOOP","name":"","addr":"(EMB)","loc":"d,11:8,11:9","unroll":"default",
+      {"type":"LOOP","name":"","addr":"(LHB)","loc":"d,11:8,11:9","unroll":"default",
        "stmtsp": [
-        {"type":"ASSIGN","name":"","addr":"(FMB)","loc":"d,11:8,11:9","dtypep":"(IN)",
+        {"type":"ASSIGN","name":"","addr":"(MHB)","loc":"d,11:8,11:9","dtypep":"(RK)",
          "rhsp": [
-          {"type":"CONST","name":"64'h0","addr":"(GMB)","loc":"d,11:8,11:9","dtypep":"(KN)"}
+          {"type":"CONST","name":"64'h0","addr":"(NHB)","loc":"d,11:8,11:9","dtypep":"(TK)"}
         ],
          "lhsp": [
-          {"type":"ARRAYSEL","name":"","addr":"(HMB)","loc":"d,11:8,11:9","dtypep":"(IN)",
+          {"type":"ARRAYSEL","name":"","addr":"(OHB)","loc":"d,11:8,11:9","dtypep":"(RK)",
            "fromp": [
-            {"type":"VARREF","name":"out","addr":"(IMB)","loc":"d,11:8,11:9","dtypep":"(W)","access":"WR","varp":"(WLB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"out","addr":"(PHB)","loc":"d,11:8,11:9","dtypep":"(W)","access":"WR","varp":"(DHB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ],
            "bitp": [
-            {"type":"VARREF","name":"n","addr":"(JMB)","loc":"d,11:8,11:9","dtypep":"(JP)","access":"RD","varp":"(AMB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"n","addr":"(QHB)","loc":"d,11:8,11:9","dtypep":"(SM)","access":"RD","varp":"(HHB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ]}
         ],"timingControlp": []},
-        {"type":"ASSIGN","name":"","addr":"(KMB)","loc":"a,0:0,0:0","dtypep":"(JP)",
+        {"type":"ASSIGN","name":"","addr":"(RHB)","loc":"a,0:0,0:0","dtypep":"(SM)",
          "rhsp": [
-          {"type":"ADD","name":"","addr":"(LMB)","loc":"a,0:0,0:0","dtypep":"(JP)",
+          {"type":"ADD","name":"","addr":"(SHB)","loc":"a,0:0,0:0","dtypep":"(SM)",
            "lhsp": [
-            {"type":"CCAST","name":"","addr":"(MMB)","loc":"a,0:0,0:0","dtypep":"(IC)","size":32,
+            {"type":"CCAST","name":"","addr":"(THB)","loc":"a,0:0,0:0","dtypep":"(IC)","size":32,
              "lhsp": [
-              {"type":"CONST","name":"32'h1","addr":"(NMB)","loc":"a,0:0,0:0","dtypep":"(IC)"}
+              {"type":"CONST","name":"32'h1","addr":"(UHB)","loc":"a,0:0,0:0","dtypep":"(IC)"}
             ]}
           ],
            "rhsp": [
-            {"type":"VARREF","name":"n","addr":"(OMB)","loc":"a,0:0,0:0","dtypep":"(JP)","access":"RD","varp":"(AMB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"n","addr":"(VHB)","loc":"a,0:0,0:0","dtypep":"(SM)","access":"RD","varp":"(HHB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ]}
         ],
          "lhsp": [
-          {"type":"VARREF","name":"n","addr":"(PMB)","loc":"a,0:0,0:0","dtypep":"(JP)","access":"WR","varp":"(AMB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+          {"type":"VARREF","name":"n","addr":"(WHB)","loc":"a,0:0,0:0","dtypep":"(SM)","access":"WR","varp":"(HHB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
         ],"timingControlp": []},
-        {"type":"LOOPTEST","name":"","addr":"(QMB)","loc":"d,11:8,11:9",
+        {"type":"LOOPTEST","name":"","addr":"(XHB)","loc":"d,11:8,11:9",
          "condp": [
-          {"type":"GT","name":"","addr":"(RMB)","loc":"d,11:8,11:9","dtypep":"(GB)",
+          {"type":"GT","name":"","addr":"(YHB)","loc":"d,11:8,11:9","dtypep":"(GB)",
            "lhsp": [
-            {"type":"CONST","name":"32'h1","addr":"(SMB)","loc":"d,11:8,11:9","dtypep":"(IC)"}
+            {"type":"CONST","name":"32'h1","addr":"(ZHB)","loc":"d,11:8,11:9","dtypep":"(IC)"}
           ],
            "rhsp": [
-            {"type":"VARREF","name":"n","addr":"(TMB)","loc":"d,11:8,11:9","dtypep":"(JP)","access":"RD","varp":"(AMB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"n","addr":"(AIB)","loc":"d,11:8,11:9","dtypep":"(SM)","access":"RD","varp":"(HHB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ]}
         ]}
       ],"contsp": []}
     ]},
-    {"type":"CFUNC","name":"_eval_phase__nba","addr":"(UMB)","loc":"a,0:0,0:0","scopep":"(Z)","argsp": [],
+    {"type":"CFUNC","name":"_eval_phase__nba","addr":"(BIB)","loc":"a,0:0,0:0","scopep":"(Z)","argsp": [],
      "varsp": [
-      {"type":"VAR","name":"__VnbaExecute","addr":"(VMB)","loc":"d,11:8,11:9","dtypep":"(P)","origName":"__VnbaExecute","verilogName":"__VnbaExecute","direction":"NONE","noReset":true,"isFuncLocal":true,"lifetime":"NONE","varType":"MODULETEMP","dtypeName":"bit","sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []}
+      {"type":"VAR","name":"__VnbaExecute","addr":"(CIB)","loc":"d,11:8,11:9","dtypep":"(P)","origName":"__VnbaExecute","verilogName":"__VnbaExecute","direction":"NONE","noReset":true,"isFuncLocal":true,"lifetime":"NONE","varType":"MODULETEMP","dtypeName":"bit","sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []}
     ],
      "stmtsp": [
-      {"type":"ASSIGN","name":"","addr":"(WMB)","loc":"a,0:0,0:0","dtypep":"(GB)",
+      {"type":"ASSIGN","name":"","addr":"(DIB)","loc":"a,0:0,0:0","dtypep":"(GB)",
        "rhsp": [
-        {"type":"CCALL","name":"","addr":"(XMB)","loc":"d,11:8,11:9","dtypep":"(GB)","funcName":"_trigger_anySet__act","funcp":"(NO)",
+        {"type":"CCALL","name":"","addr":"(EIB)","loc":"d,11:8,11:9","dtypep":"(GB)","funcName":"_trigger_anySet__act","funcp":"(WL)",
          "argsp": [
-          {"type":"VARREF","name":"__VnbaTriggered","addr":"(YMB)","loc":"d,11:8,11:9","dtypep":"(W)","access":"WR","varp":"(X)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+          {"type":"VARREF","name":"__VnbaTriggered","addr":"(FIB)","loc":"d,11:8,11:9","dtypep":"(W)","access":"WR","varp":"(X)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
         ]}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"__VnbaExecute","addr":"(ZMB)","loc":"a,0:0,0:0","dtypep":"(GB)","access":"WR","varp":"(VMB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"__VnbaExecute","addr":"(GIB)","loc":"a,0:0,0:0","dtypep":"(GB)","access":"WR","varp":"(CIB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []},
-      {"type":"IF","name":"","addr":"(ANB)","loc":"a,0:0,0:0",
+      {"type":"IF","name":"","addr":"(HIB)","loc":"a,0:0,0:0",
        "condp": [
-        {"type":"VARREF","name":"__VnbaExecute","addr":"(BNB)","loc":"a,0:0,0:0","dtypep":"(GB)","access":"RD","varp":"(VMB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"__VnbaExecute","addr":"(IIB)","loc":"a,0:0,0:0","dtypep":"(GB)","access":"RD","varp":"(CIB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],
        "thensp": [
-        {"type":"STMTEXPR","name":"","addr":"(CNB)","loc":"a,0:0,0:0",
+        {"type":"STMTEXPR","name":"","addr":"(JIB)","loc":"a,0:0,0:0",
          "exprp": [
-          {"type":"CCALL","name":"","addr":"(DNB)","loc":"a,0:0,0:0","dtypep":"(DB)","funcName":"_eval_nba","funcp":"(G)","argsp": []}
+          {"type":"CCALL","name":"","addr":"(KIB)","loc":"a,0:0,0:0","dtypep":"(DB)","funcName":"_eval_nba","funcp":"(G)","argsp": []}
         ]},
-        {"type":"STMTEXPR","name":"","addr":"(ENB)","loc":"d,11:8,11:9",
+        {"type":"STMTEXPR","name":"","addr":"(LIB)","loc":"d,11:8,11:9",
          "exprp": [
-          {"type":"CCALL","name":"","addr":"(FNB)","loc":"d,11:8,11:9","dtypep":"(DB)","funcName":"_trigger_clear__act","funcp":"(VLB)",
+          {"type":"CCALL","name":"","addr":"(MIB)","loc":"d,11:8,11:9","dtypep":"(DB)","funcName":"_trigger_clear__act","funcp":"(CHB)",
            "argsp": [
-            {"type":"VARREF","name":"__VnbaTriggered","addr":"(GNB)","loc":"d,11:8,11:9","dtypep":"(W)","access":"WR","varp":"(X)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"__VnbaTriggered","addr":"(NIB)","loc":"d,11:8,11:9","dtypep":"(W)","access":"WR","varp":"(X)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ]}
         ]}
       ],"elsesp": []},
-      {"type":"CRETURN","name":"","addr":"(HNB)","loc":"a,0:0,0:0",
+      {"type":"CRETURN","name":"","addr":"(OIB)","loc":"a,0:0,0:0",
        "lhsp": [
-        {"type":"VARREF","name":"__VnbaExecute","addr":"(INB)","loc":"a,0:0,0:0","dtypep":"(GB)","access":"RD","varp":"(VMB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"__VnbaExecute","addr":"(PIB)","loc":"a,0:0,0:0","dtypep":"(GB)","access":"RD","varp":"(CIB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ]}
     ]},
     {"type":"CFUNC","name":"_eval","addr":"(F)","loc":"a,0:0,0:0","scopep":"(Z)","argsp": [],
      "varsp": [
-      {"type":"VAR","name":"__VnbaIterCount","addr":"(JNB)","loc":"d,11:8,11:9","dtypep":"(U)","origName":"__VnbaIterCount","verilogName":"__VnbaIterCount","direction":"NONE","noReset":true,"isFuncLocal":true,"lifetime":"NONE","varType":"MODULETEMP","dtypeName":"bit","sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []}
+      {"type":"VAR","name":"__VnbaIterCount","addr":"(QIB)","loc":"d,11:8,11:9","dtypep":"(U)","origName":"__VnbaIterCount","verilogName":"__VnbaIterCount","direction":"NONE","noReset":true,"isFuncLocal":true,"lifetime":"NONE","varType":"MODULETEMP","dtypeName":"bit","sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []}
     ],
      "stmtsp": [
-      {"type":"ASSIGN","name":"","addr":"(KNB)","loc":"d,11:8,11:9","dtypep":"(U)",
+      {"type":"ASSIGN","name":"","addr":"(RIB)","loc":"d,11:8,11:9","dtypep":"(U)",
        "rhsp": [
-        {"type":"CONST","name":"32'h0","addr":"(LNB)","loc":"d,11:8,11:9","dtypep":"(IC)"}
+        {"type":"CONST","name":"32'h0","addr":"(SIB)","loc":"d,11:8,11:9","dtypep":"(IC)"}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"__VnbaIterCount","addr":"(MNB)","loc":"d,11:8,11:9","dtypep":"(U)","access":"WR","varp":"(JNB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"__VnbaIterCount","addr":"(TIB)","loc":"d,11:8,11:9","dtypep":"(U)","access":"WR","varp":"(QIB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []},
-      {"type":"LOOP","name":"","addr":"(NNB)","loc":"a,0:0,0:0","unroll":"default",
+      {"type":"LOOP","name":"","addr":"(UIB)","loc":"a,0:0,0:0","unroll":"default",
        "stmtsp": [
-        {"type":"IF","name":"","addr":"(ONB)","loc":"a,0:0,0:0",
+        {"type":"IF","name":"","addr":"(VIB)","loc":"a,0:0,0:0",
          "condp": [
-          {"type":"LT","name":"","addr":"(PNB)","loc":"a,0:0,0:0","dtypep":"(GB)",
+          {"type":"LT","name":"","addr":"(WIB)","loc":"a,0:0,0:0","dtypep":"(GB)",
            "lhsp": [
-            {"type":"CONST","name":"32'h64","addr":"(QNB)","loc":"a,0:0,0:0","dtypep":"(IC)"}
+            {"type":"CONST","name":"32'h64","addr":"(XIB)","loc":"a,0:0,0:0","dtypep":"(IC)"}
           ],
            "rhsp": [
-            {"type":"VARREF","name":"__VnbaIterCount","addr":"(RNB)","loc":"a,0:0,0:0","dtypep":"(U)","access":"RD","varp":"(JNB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"__VnbaIterCount","addr":"(YIB)","loc":"a,0:0,0:0","dtypep":"(U)","access":"RD","varp":"(QIB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ]}
         ],
          "thensp": [
-          {"type":"CSTMT","name":"","addr":"(SNB)","loc":"d,11:8,11:9",
+          {"type":"CSTMT","name":"","addr":"(ZIB)","loc":"d,11:8,11:9",
            "nodesp": [
-            {"type":"TEXT","name":"","addr":"(TNB)","loc":"d,11:8,11:9","text":"#ifdef VL_DEBUG\n"},
-            {"type":"STMTEXPR","name":"","addr":"(UNB)","loc":"d,11:8,11:9",
+            {"type":"TEXT","name":"","addr":"(AJB)","loc":"d,11:8,11:9","text":"#ifdef VL_DEBUG\n"},
+            {"type":"STMTEXPR","name":"","addr":"(BJB)","loc":"d,11:8,11:9",
              "exprp": [
-              {"type":"CCALL","name":"","addr":"(VNB)","loc":"d,11:8,11:9","dtypep":"(DB)","funcName":"_dump_triggers__act","funcp":"(YN)",
+              {"type":"CCALL","name":"","addr":"(CJB)","loc":"d,11:8,11:9","dtypep":"(DB)","funcName":"_dump_triggers__act","funcp":"(HL)",
                "argsp": [
-                {"type":"VARREF","name":"__VnbaTriggered","addr":"(WNB)","loc":"d,11:8,11:9","dtypep":"(W)","access":"RD","varp":"(X)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"},
-                {"type":"CONST","name":"\\\"nba\\\"","addr":"(XNB)","loc":"d,11:8,11:9","dtypep":"(SB)"}
+                {"type":"VARREF","name":"__VnbaTriggered","addr":"(DJB)","loc":"d,11:8,11:9","dtypep":"(W)","access":"RD","varp":"(X)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"},
+                {"type":"CONST","name":"\\\"nba\\\"","addr":"(EJB)","loc":"d,11:8,11:9","dtypep":"(SB)"}
               ]}
             ]},
-            {"type":"TEXT","name":"","addr":"(YNB)","loc":"d,11:8,11:9","text":"#endif"}
+            {"type":"TEXT","name":"","addr":"(FJB)","loc":"d,11:8,11:9","text":"#endif"}
           ]},
-          {"type":"CSTMT","name":"","addr":"(ZNB)","loc":"a,0:0,0:0",
+          {"type":"CSTMT","name":"","addr":"(GJB)","loc":"a,0:0,0:0",
            "nodesp": [
-            {"type":"TEXT","name":"","addr":"(AOB)","loc":"a,0:0,0:0","text":"VL_FATAL_MT(\"t/t_enum_type_methods.v\", 11, \"\", \"DIDNOTCONVERGE: NBA region did not converge after '--converge-limit' of 100 tries\");"}
+            {"type":"TEXT","name":"","addr":"(HJB)","loc":"a,0:0,0:0","text":"VL_FATAL_MT(\"t/t_enum_type_methods.v\", 11, \"\", \"DIDNOTCONVERGE: NBA region did not converge after '--converge-limit' of 100 tries\");"}
           ]}
         ],"elsesp": []},
-        {"type":"ASSIGN","name":"","addr":"(BOB)","loc":"d,11:8,11:9","dtypep":"(U)",
+        {"type":"ASSIGN","name":"","addr":"(IJB)","loc":"d,11:8,11:9","dtypep":"(U)",
          "rhsp": [
-          {"type":"ADD","name":"","addr":"(COB)","loc":"d,11:8,11:9","dtypep":"(U)",
+          {"type":"ADD","name":"","addr":"(JJB)","loc":"d,11:8,11:9","dtypep":"(U)",
            "lhsp": [
-            {"type":"CCAST","name":"","addr":"(DOB)","loc":"d,11:8,11:9","dtypep":"(IC)","size":32,
+            {"type":"CCAST","name":"","addr":"(KJB)","loc":"d,11:8,11:9","dtypep":"(IC)","size":32,
              "lhsp": [
-              {"type":"CONST","name":"32'h1","addr":"(EOB)","loc":"d,11:8,11:9","dtypep":"(IC)"}
+              {"type":"CONST","name":"32'h1","addr":"(LJB)","loc":"d,11:8,11:9","dtypep":"(IC)"}
             ]}
           ],
            "rhsp": [
-            {"type":"VARREF","name":"__VnbaIterCount","addr":"(FOB)","loc":"d,11:8,11:9","dtypep":"(U)","access":"RD","varp":"(JNB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"__VnbaIterCount","addr":"(MJB)","loc":"d,11:8,11:9","dtypep":"(U)","access":"RD","varp":"(QIB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ]}
         ],
          "lhsp": [
-          {"type":"VARREF","name":"__VnbaIterCount","addr":"(GOB)","loc":"d,11:8,11:9","dtypep":"(U)","access":"WR","varp":"(JNB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+          {"type":"VARREF","name":"__VnbaIterCount","addr":"(NJB)","loc":"d,11:8,11:9","dtypep":"(U)","access":"WR","varp":"(QIB)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
         ],"timingControlp": []},
-        {"type":"ASSIGN","name":"","addr":"(HOB)","loc":"d,11:8,11:9","dtypep":"(U)",
+        {"type":"ASSIGN","name":"","addr":"(OJB)","loc":"d,11:8,11:9","dtypep":"(U)",
          "rhsp": [
-          {"type":"CONST","name":"32'h0","addr":"(IOB)","loc":"d,11:8,11:9","dtypep":"(IC)"}
+          {"type":"CONST","name":"32'h0","addr":"(PJB)","loc":"d,11:8,11:9","dtypep":"(IC)"}
         ],
          "lhsp": [
-          {"type":"VARREF","name":"__VactIterCount","addr":"(JOB)","loc":"d,11:8,11:9","dtypep":"(U)","access":"WR","varp":"(T)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+          {"type":"VARREF","name":"__VactIterCount","addr":"(QJB)","loc":"d,11:8,11:9","dtypep":"(U)","access":"WR","varp":"(T)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
         ],"timingControlp": []},
-        {"type":"LOOP","name":"","addr":"(KOB)","loc":"a,0:0,0:0","unroll":"default",
+        {"type":"LOOP","name":"","addr":"(RJB)","loc":"a,0:0,0:0","unroll":"default",
          "stmtsp": [
-          {"type":"IF","name":"","addr":"(LOB)","loc":"a,0:0,0:0",
+          {"type":"IF","name":"","addr":"(SJB)","loc":"a,0:0,0:0",
            "condp": [
-            {"type":"LT","name":"","addr":"(MOB)","loc":"a,0:0,0:0","dtypep":"(GB)",
+            {"type":"LT","name":"","addr":"(TJB)","loc":"a,0:0,0:0","dtypep":"(GB)",
              "lhsp": [
-              {"type":"CONST","name":"32'h64","addr":"(NOB)","loc":"a,0:0,0:0","dtypep":"(IC)"}
+              {"type":"CONST","name":"32'h64","addr":"(UJB)","loc":"a,0:0,0:0","dtypep":"(IC)"}
             ],
              "rhsp": [
-              {"type":"VARREF","name":"__VactIterCount","addr":"(OOB)","loc":"a,0:0,0:0","dtypep":"(U)","access":"RD","varp":"(T)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+              {"type":"VARREF","name":"__VactIterCount","addr":"(VJB)","loc":"a,0:0,0:0","dtypep":"(U)","access":"RD","varp":"(T)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
             ]}
           ],
            "thensp": [
-            {"type":"CSTMT","name":"","addr":"(POB)","loc":"d,11:8,11:9",
+            {"type":"CSTMT","name":"","addr":"(WJB)","loc":"d,11:8,11:9",
              "nodesp": [
-              {"type":"TEXT","name":"","addr":"(QOB)","loc":"d,11:8,11:9","text":"#ifdef VL_DEBUG\n"},
-              {"type":"STMTEXPR","name":"","addr":"(ROB)","loc":"d,11:8,11:9",
+              {"type":"TEXT","name":"","addr":"(XJB)","loc":"d,11:8,11:9","text":"#ifdef VL_DEBUG\n"},
+              {"type":"STMTEXPR","name":"","addr":"(YJB)","loc":"d,11:8,11:9",
                "exprp": [
-                {"type":"CCALL","name":"","addr":"(SOB)","loc":"d,11:8,11:9","dtypep":"(DB)","funcName":"_dump_triggers__act","funcp":"(YN)",
+                {"type":"CCALL","name":"","addr":"(ZJB)","loc":"d,11:8,11:9","dtypep":"(DB)","funcName":"_dump_triggers__act","funcp":"(HL)",
                  "argsp": [
-                  {"type":"VARREF","name":"__VactTriggered","addr":"(TOB)","loc":"d,11:8,11:9","dtypep":"(W)","access":"RD","varp":"(V)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"},
-                  {"type":"CONST","name":"\\\"act\\\"","addr":"(UOB)","loc":"d,11:8,11:9","dtypep":"(SB)"}
+                  {"type":"VARREF","name":"__VactTriggered","addr":"(AKB)","loc":"d,11:8,11:9","dtypep":"(W)","access":"RD","varp":"(V)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"},
+                  {"type":"CONST","name":"\\\"act\\\"","addr":"(BKB)","loc":"d,11:8,11:9","dtypep":"(SB)"}
                 ]}
               ]},
-              {"type":"TEXT","name":"","addr":"(VOB)","loc":"d,11:8,11:9","text":"#endif"}
+              {"type":"TEXT","name":"","addr":"(CKB)","loc":"d,11:8,11:9","text":"#endif"}
             ]},
-            {"type":"CSTMT","name":"","addr":"(WOB)","loc":"a,0:0,0:0",
+            {"type":"CSTMT","name":"","addr":"(DKB)","loc":"a,0:0,0:0",
              "nodesp": [
-              {"type":"TEXT","name":"","addr":"(XOB)","loc":"a,0:0,0:0","text":"VL_FATAL_MT(\"t/t_enum_type_methods.v\", 11, \"\", \"DIDNOTCONVERGE: Active region did not converge after '--converge-limit' of 100 tries\");"}
+              {"type":"TEXT","name":"","addr":"(EKB)","loc":"a,0:0,0:0","text":"VL_FATAL_MT(\"t/t_enum_type_methods.v\", 11, \"\", \"DIDNOTCONVERGE: Active region did not converge after '--converge-limit' of 100 tries\");"}
             ]}
           ],"elsesp": []},
-          {"type":"ASSIGN","name":"","addr":"(YOB)","loc":"d,11:8,11:9","dtypep":"(U)",
+          {"type":"ASSIGN","name":"","addr":"(FKB)","loc":"d,11:8,11:9","dtypep":"(U)",
            "rhsp": [
-            {"type":"ADD","name":"","addr":"(ZOB)","loc":"d,11:8,11:9","dtypep":"(U)",
+            {"type":"ADD","name":"","addr":"(GKB)","loc":"d,11:8,11:9","dtypep":"(U)",
              "lhsp": [
-              {"type":"CCAST","name":"","addr":"(APB)","loc":"d,11:8,11:9","dtypep":"(IC)","size":32,
+              {"type":"CCAST","name":"","addr":"(HKB)","loc":"d,11:8,11:9","dtypep":"(IC)","size":32,
                "lhsp": [
-                {"type":"CONST","name":"32'h1","addr":"(BPB)","loc":"d,11:8,11:9","dtypep":"(IC)"}
+                {"type":"CONST","name":"32'h1","addr":"(IKB)","loc":"d,11:8,11:9","dtypep":"(IC)"}
               ]}
             ],
              "rhsp": [
-              {"type":"VARREF","name":"__VactIterCount","addr":"(CPB)","loc":"d,11:8,11:9","dtypep":"(U)","access":"RD","varp":"(T)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+              {"type":"VARREF","name":"__VactIterCount","addr":"(JKB)","loc":"d,11:8,11:9","dtypep":"(U)","access":"RD","varp":"(T)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
             ]}
           ],
            "lhsp": [
-            {"type":"VARREF","name":"__VactIterCount","addr":"(DPB)","loc":"d,11:8,11:9","dtypep":"(U)","access":"WR","varp":"(T)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"__VactIterCount","addr":"(KKB)","loc":"d,11:8,11:9","dtypep":"(U)","access":"WR","varp":"(T)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ],"timingControlp": []},
-          {"type":"ASSIGN","name":"","addr":"(EPB)","loc":"a,0:0,0:0","dtypep":"(GB)",
+          {"type":"ASSIGN","name":"","addr":"(LKB)","loc":"a,0:0,0:0","dtypep":"(GB)",
            "rhsp": [
-            {"type":"CCALL","name":"","addr":"(FPB)","loc":"a,0:0,0:0","dtypep":"(GB)","funcName":"_eval_phase__act","funcp":"(DLB)","argsp": []}
+            {"type":"CCALL","name":"","addr":"(MKB)","loc":"a,0:0,0:0","dtypep":"(GB)","funcName":"_eval_phase__act","funcp":"(KGB)","argsp": []}
           ],
            "lhsp": [
-            {"type":"VARREF","name":"__VactPhaseResult","addr":"(GPB)","loc":"a,0:0,0:0","dtypep":"(GB)","access":"WR","varp":"(O)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"__VactPhaseResult","addr":"(NKB)","loc":"a,0:0,0:0","dtypep":"(GB)","access":"WR","varp":"(O)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ],"timingControlp": []},
-          {"type":"LOOPTEST","name":"","addr":"(HPB)","loc":"a,0:0,0:0",
+          {"type":"LOOPTEST","name":"","addr":"(OKB)","loc":"a,0:0,0:0",
            "condp": [
-            {"type":"VARREF","name":"__VactPhaseResult","addr":"(IPB)","loc":"a,0:0,0:0","dtypep":"(GB)","access":"RD","varp":"(O)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+            {"type":"VARREF","name":"__VactPhaseResult","addr":"(PKB)","loc":"a,0:0,0:0","dtypep":"(GB)","access":"RD","varp":"(O)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
           ]}
         ],"contsp": []},
-        {"type":"ASSIGN","name":"","addr":"(JPB)","loc":"a,0:0,0:0","dtypep":"(GB)",
+        {"type":"ASSIGN","name":"","addr":"(QKB)","loc":"a,0:0,0:0","dtypep":"(GB)",
          "rhsp": [
-          {"type":"CCALL","name":"","addr":"(KPB)","loc":"a,0:0,0:0","dtypep":"(GB)","funcName":"_eval_phase__nba","funcp":"(UMB)","argsp": []}
+          {"type":"CCALL","name":"","addr":"(RKB)","loc":"a,0:0,0:0","dtypep":"(GB)","funcName":"_eval_phase__nba","funcp":"(BIB)","argsp": []}
         ],
          "lhsp": [
-          {"type":"VARREF","name":"__VnbaPhaseResult","addr":"(LPB)","loc":"a,0:0,0:0","dtypep":"(GB)","access":"WR","varp":"(Q)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+          {"type":"VARREF","name":"__VnbaPhaseResult","addr":"(SKB)","loc":"a,0:0,0:0","dtypep":"(GB)","access":"WR","varp":"(Q)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
         ],"timingControlp": []},
-        {"type":"LOOPTEST","name":"","addr":"(MPB)","loc":"a,0:0,0:0",
+        {"type":"LOOPTEST","name":"","addr":"(TKB)","loc":"a,0:0,0:0",
          "condp": [
-          {"type":"VARREF","name":"__VnbaPhaseResult","addr":"(NPB)","loc":"a,0:0,0:0","dtypep":"(GB)","access":"RD","varp":"(Q)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+          {"type":"VARREF","name":"__VnbaPhaseResult","addr":"(UKB)","loc":"a,0:0,0:0","dtypep":"(GB)","access":"RD","varp":"(Q)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
         ]}
       ],"contsp": []}
     ]},
-    {"type":"CFUNC","name":"_eval_debug_assertions","addr":"(OPB)","loc":"d,11:8,11:9","scopep":"UNLINKED","argsp": [],"varsp": [],
+    {"type":"CFUNC","name":"_eval_debug_assertions","addr":"(VKB)","loc":"d,11:8,11:9","scopep":"UNLINKED","argsp": [],"varsp": [],
      "stmtsp": [
-      {"type":"IF","name":"","addr":"(PPB)","loc":"d,15:10,15:13",
+      {"type":"IF","name":"","addr":"(WKB)","loc":"d,15:10,15:13",
        "condp": [
-        {"type":"AND","name":"","addr":"(QPB)","loc":"d,15:10,15:13","dtypep":"(K)",
+        {"type":"AND","name":"","addr":"(XKB)","loc":"d,15:10,15:13","dtypep":"(K)",
          "lhsp": [
-          {"type":"VARREF","name":"clk","addr":"(RPB)","loc":"d,15:10,15:13","dtypep":"(K)","access":"RD","varp":"(J)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+          {"type":"VARREF","name":"clk","addr":"(YKB)","loc":"d,15:10,15:13","dtypep":"(K)","access":"RD","varp":"(J)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
         ],
          "rhsp": [
-          {"type":"CONST","name":"8'hfe","addr":"(SPB)","loc":"d,15:10,15:13","dtypep":"(TPB)"}
+          {"type":"CONST","name":"8'hfe","addr":"(ZKB)","loc":"d,15:10,15:13","dtypep":"(ALB)"}
         ]}
       ],
        "thensp": [
-        {"type":"CSTMT","name":"","addr":"(UPB)","loc":"d,15:10,15:13",
+        {"type":"CSTMT","name":"","addr":"(BLB)","loc":"d,15:10,15:13",
          "nodesp": [
-          {"type":"TEXT","name":"","addr":"(VPB)","loc":"d,15:10,15:13","text":"Verilated::overWidthError(\"clk\");"}
+          {"type":"TEXT","name":"","addr":"(CLB)","loc":"d,15:10,15:13","text":"Verilated::overWidthError(\"clk\");"}
         ]}
       ],"elsesp": []}
     ]},
-    {"type":"CFUNC","name":"_ctor_var_reset","addr":"(WPB)","loc":"d,11:8,11:9","slow":true,"scopep":"UNLINKED","argsp": [],"varsp": [],
+    {"type":"CFUNC","name":"_ctor_var_reset","addr":"(DLB)","loc":"d,11:8,11:9","slow":true,"scopep":"UNLINKED","argsp": [],"varsp": [],
      "stmtsp": [
-      {"type":"ASSIGN","name":"","addr":"(XPB)","loc":"d,15:10,15:13","dtypep":"(K)",
+      {"type":"ASSIGN","name":"","addr":"(ELB)","loc":"d,15:10,15:13","dtypep":"(K)",
        "rhsp": [
-        {"type":"CRESET","name":"","addr":"(YPB)","loc":"d,15:10,15:13","dtypep":"(K)","constructing":true}
+        {"type":"CRESET","name":"","addr":"(FLB)","loc":"d,15:10,15:13","dtypep":"(K)","constructing":true}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"clk","addr":"(ZPB)","loc":"d,15:10,15:13","dtypep":"(K)","access":"WR","varp":"(J)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"clk","addr":"(GLB)","loc":"d,15:10,15:13","dtypep":"(K)","access":"WR","varp":"(J)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []},
-      {"type":"ASSIGN","name":"","addr":"(AQB)","loc":"d,24:9,24:10","dtypep":"(M)",
+      {"type":"ASSIGN","name":"","addr":"(HLB)","loc":"d,24:9,24:10","dtypep":"(M)",
        "rhsp": [
-        {"type":"CRESET","name":"","addr":"(BQB)","loc":"d,24:9,24:10","dtypep":"(M)","constructing":true}
+        {"type":"CRESET","name":"","addr":"(ILB)","loc":"d,24:9,24:10","dtypep":"(M)","constructing":true}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"t.e","addr":"(CQB)","loc":"d,24:9,24:10","dtypep":"(M)","access":"WR","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"t.e","addr":"(JLB)","loc":"d,24:9,24:10","dtypep":"(M)","access":"WR","varp":"(L)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []},
-      {"type":"ASSIGN","name":"","addr":"(DQB)","loc":"d,11:8,11:9","dtypep":"(W)",
+      {"type":"ASSIGN","name":"","addr":"(KLB)","loc":"d,11:8,11:9","dtypep":"(W)",
        "rhsp": [
-        {"type":"CRESET","name":"","addr":"(EQB)","loc":"d,11:8,11:9","dtypep":"(W)","constructing":true}
+        {"type":"CRESET","name":"","addr":"(LLB)","loc":"d,11:8,11:9","dtypep":"(W)","constructing":true}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"__VactTriggered","addr":"(FQB)","loc":"d,11:8,11:9","dtypep":"(W)","access":"WR","varp":"(V)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"__VactTriggered","addr":"(MLB)","loc":"d,11:8,11:9","dtypep":"(W)","access":"WR","varp":"(V)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []},
-      {"type":"ASSIGN","name":"","addr":"(GQB)","loc":"d,11:8,11:9","dtypep":"(K)",
+      {"type":"ASSIGN","name":"","addr":"(NLB)","loc":"d,11:8,11:9","dtypep":"(K)",
        "rhsp": [
-        {"type":"CRESET","name":"","addr":"(HQB)","loc":"d,11:8,11:9","dtypep":"(K)","constructing":true}
+        {"type":"CRESET","name":"","addr":"(OLB)","loc":"d,11:8,11:9","dtypep":"(K)","constructing":true}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"__Vtrigprevexpr___TOP__clk__0","addr":"(IQB)","loc":"d,11:8,11:9","dtypep":"(K)","access":"WR","varp":"(N)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"__Vtrigprevexpr___TOP__clk__0","addr":"(PLB)","loc":"d,11:8,11:9","dtypep":"(K)","access":"WR","varp":"(N)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []},
-      {"type":"ASSIGN","name":"","addr":"(JQB)","loc":"d,11:8,11:9","dtypep":"(W)",
+      {"type":"ASSIGN","name":"","addr":"(QLB)","loc":"d,11:8,11:9","dtypep":"(W)",
        "rhsp": [
-        {"type":"CRESET","name":"","addr":"(KQB)","loc":"d,11:8,11:9","dtypep":"(W)","constructing":true}
+        {"type":"CRESET","name":"","addr":"(RLB)","loc":"d,11:8,11:9","dtypep":"(W)","constructing":true}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"__VnbaTriggered","addr":"(LQB)","loc":"d,11:8,11:9","dtypep":"(W)","access":"WR","varp":"(X)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"__VnbaTriggered","addr":"(SLB)","loc":"d,11:8,11:9","dtypep":"(W)","access":"WR","varp":"(X)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []}
     ]},
-    {"type":"CUSE","name":"$unit","addr":"(MQB)","loc":"a,0:0,0:0","useType":"INT_FWD"}
+    {"type":"CUSE","name":"$unit","addr":"(TLB)","loc":"a,0:0,0:0","useType":"INT_FWD"}
   ]},
   {"type":"PACKAGE","name":"$unit","addr":"(E)","loc":"a,0:0,0:0","origName":"__024unit","verilogName":"\\$unit ","level":2,"inLibrary":true,"timeunit":"NONE","inlinesp": [],
    "stmtsp": [
     {"type":"VAR","name":"__Venumtab_enum_next1","addr":"(EC)","loc":"d,17:12,17:16","dtypep":"(DC)","origName":"__Venumtab_enum_next1","verilogName":"__Venumtab_enum_next1","direction":"NONE","isConst":true,"lifetime":"VSTATIC","varType":"MODULETEMP","dtypeName":"","sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],
      "valuep": [
-      {"type":"INITARRAY","name":"","addr":"(NQB)","loc":"d,17:12,17:16","dtypep":"(DC)","initList":" [1]=(OQB) [3]=(PQB) [4]=(QQB)",
+      {"type":"INITARRAY","name":"","addr":"(ULB)","loc":"d,17:12,17:16","dtypep":"(DC)","initList":" [1]=(VLB) [3]=(WLB) [4]=(XLB)",
        "defaultp": [
-        {"type":"CONST","name":"4'h0","addr":"(RQB)","loc":"d,17:12,17:16","dtypep":"(UB)"}
+        {"type":"CONST","name":"4'h0","addr":"(YLB)","loc":"d,17:12,17:16","dtypep":"(UB)"}
       ],
        "initsp": [
-        {"type":"INITITEM","name":"","addr":"(OQB)","loc":"d,17:12,17:16",
+        {"type":"INITITEM","name":"","addr":"(VLB)","loc":"d,17:12,17:16",
          "valuep": [
-          {"type":"CONST","name":"4'h3","addr":"(SQB)","loc":"d,19:30,19:31","dtypep":"(UB)"}
+          {"type":"CONST","name":"4'h3","addr":"(ZLB)","loc":"d,19:30,19:31","dtypep":"(UB)"}
         ]},
-        {"type":"INITITEM","name":"","addr":"(PQB)","loc":"d,17:12,17:16",
+        {"type":"INITITEM","name":"","addr":"(WLB)","loc":"d,17:12,17:16",
          "valuep": [
-          {"type":"CONST","name":"4'h4","addr":"(TQB)","loc":"d,20:30,20:31","dtypep":"(UB)"}
+          {"type":"CONST","name":"4'h4","addr":"(AMB)","loc":"d,20:30,20:31","dtypep":"(UB)"}
         ]},
-        {"type":"INITITEM","name":"","addr":"(QQB)","loc":"d,17:12,17:16",
+        {"type":"INITITEM","name":"","addr":"(XLB)","loc":"d,17:12,17:16",
          "valuep": [
-          {"type":"CONST","name":"4'h1","addr":"(UQB)","loc":"d,18:30,18:31","dtypep":"(UB)"}
+          {"type":"CONST","name":"4'h1","addr":"(BMB)","loc":"d,18:30,18:31","dtypep":"(UB)"}
         ]}
       ]}
     ],"attrsp": []},
-    {"type":"VAR","name":"__Venumtab_enum_prev1","addr":"(YI)","loc":"d,17:12,17:16","dtypep":"(XI)","origName":"__Venumtab_enum_prev1","verilogName":"__Venumtab_enum_prev1","direction":"NONE","isConst":true,"lifetime":"VSTATIC","varType":"MODULETEMP","dtypeName":"","sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],
+    {"type":"VAR","name":"__Venumtab_enum_prev1","addr":"(DH)","loc":"d,17:12,17:16","dtypep":"(CH)","origName":"__Venumtab_enum_prev1","verilogName":"__Venumtab_enum_prev1","direction":"NONE","isConst":true,"lifetime":"VSTATIC","varType":"MODULETEMP","dtypeName":"","sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],
      "valuep": [
-      {"type":"INITARRAY","name":"","addr":"(VQB)","loc":"d,17:12,17:16","dtypep":"(XI)","initList":" [1]=(WQB) [3]=(XQB) [4]=(YQB)",
+      {"type":"INITARRAY","name":"","addr":"(CMB)","loc":"d,17:12,17:16","dtypep":"(CH)","initList":" [1]=(DMB) [3]=(EMB) [4]=(FMB)",
        "defaultp": [
-        {"type":"CONST","name":"4'h0","addr":"(ZQB)","loc":"d,17:12,17:16","dtypep":"(UB)"}
+        {"type":"CONST","name":"4'h0","addr":"(GMB)","loc":"d,17:12,17:16","dtypep":"(UB)"}
       ],
        "initsp": [
-        {"type":"INITITEM","name":"","addr":"(WQB)","loc":"d,17:12,17:16",
+        {"type":"INITITEM","name":"","addr":"(DMB)","loc":"d,17:12,17:16",
          "valuep": [
-          {"type":"CONST","name":"4'h4","addr":"(ARB)","loc":"d,20:30,20:31","dtypep":"(UB)"}
+          {"type":"CONST","name":"4'h4","addr":"(HMB)","loc":"d,20:30,20:31","dtypep":"(UB)"}
         ]},
-        {"type":"INITITEM","name":"","addr":"(XQB)","loc":"d,17:12,17:16",
+        {"type":"INITITEM","name":"","addr":"(EMB)","loc":"d,17:12,17:16",
          "valuep": [
-          {"type":"CONST","name":"4'h1","addr":"(BRB)","loc":"d,18:30,18:31","dtypep":"(UB)"}
+          {"type":"CONST","name":"4'h1","addr":"(IMB)","loc":"d,18:30,18:31","dtypep":"(UB)"}
         ]},
-        {"type":"INITITEM","name":"","addr":"(YQB)","loc":"d,17:12,17:16",
+        {"type":"INITITEM","name":"","addr":"(FMB)","loc":"d,17:12,17:16",
          "valuep": [
-          {"type":"CONST","name":"4'h3","addr":"(CRB)","loc":"d,19:30,19:31","dtypep":"(UB)"}
+          {"type":"CONST","name":"4'h3","addr":"(JMB)","loc":"d,19:30,19:31","dtypep":"(UB)"}
         ]}
       ]}
     ],"attrsp": []},
-    {"type":"VAR","name":"__Venumtab_enum_name1","addr":"(KM)","loc":"d,17:12,17:16","dtypep":"(JM)","origName":"__Venumtab_enum_name1","verilogName":"__Venumtab_enum_name1","direction":"NONE","isConst":true,"lifetime":"VSTATIC","varType":"MODULETEMP","dtypeName":"","sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],
+    {"type":"VAR","name":"__Venumtab_enum_name1","addr":"(TJ)","loc":"d,17:12,17:16","dtypep":"(SJ)","origName":"__Venumtab_enum_name1","verilogName":"__Venumtab_enum_name1","direction":"NONE","isConst":true,"lifetime":"VSTATIC","varType":"MODULETEMP","dtypeName":"","sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],
      "valuep": [
-      {"type":"INITARRAY","name":"","addr":"(DRB)","loc":"d,17:12,17:16","dtypep":"(JM)","initList":" [1]=(ERB) [3]=(FRB) [4]=(GRB)",
+      {"type":"INITARRAY","name":"","addr":"(KMB)","loc":"d,17:12,17:16","dtypep":"(SJ)","initList":" [1]=(LMB) [3]=(MMB) [4]=(NMB)",
        "defaultp": [
-        {"type":"CONST","name":"\\\"\\\"","addr":"(HRB)","loc":"d,17:12,17:16","dtypep":"(SB)"}
+        {"type":"CONST","name":"\\\"\\\"","addr":"(OMB)","loc":"d,17:12,17:16","dtypep":"(SB)"}
       ],
        "initsp": [
-        {"type":"INITITEM","name":"","addr":"(ERB)","loc":"d,17:12,17:16",
+        {"type":"INITITEM","name":"","addr":"(LMB)","loc":"d,17:12,17:16",
          "valuep": [
-          {"type":"CONST","name":"\\\"E01\\\"","addr":"(IRB)","loc":"d,17:12,17:16","dtypep":"(SB)"}
+          {"type":"CONST","name":"\\\"E01\\\"","addr":"(PMB)","loc":"d,17:12,17:16","dtypep":"(SB)"}
         ]},
-        {"type":"INITITEM","name":"","addr":"(FRB)","loc":"d,17:12,17:16",
+        {"type":"INITITEM","name":"","addr":"(MMB)","loc":"d,17:12,17:16",
          "valuep": [
-          {"type":"CONST","name":"\\\"E03\\\"","addr":"(JRB)","loc":"d,17:12,17:16","dtypep":"(SB)"}
+          {"type":"CONST","name":"\\\"E03\\\"","addr":"(QMB)","loc":"d,17:12,17:16","dtypep":"(SB)"}
         ]},
-        {"type":"INITITEM","name":"","addr":"(GRB)","loc":"d,17:12,17:16",
+        {"type":"INITITEM","name":"","addr":"(NMB)","loc":"d,17:12,17:16",
          "valuep": [
-          {"type":"CONST","name":"\\\"E04\\\"","addr":"(KRB)","loc":"d,17:12,17:16","dtypep":"(SB)"}
+          {"type":"CONST","name":"\\\"E04\\\"","addr":"(RMB)","loc":"d,17:12,17:16","dtypep":"(SB)"}
         ]}
       ]}
     ],"attrsp": []},
-    {"type":"SCOPE","name":"$unit","addr":"(LRB)","loc":"a,0:0,0:0","aboveScopep":"(Z)","aboveCellp":"(Y)","modp":"(E)","varsp": [],"blocksp": [],"inlinesp": []},
-    {"type":"CFUNC","name":"_ctor_var_reset","addr":"(MRB)","loc":"a,0:0,0:0","slow":true,"scopep":"UNLINKED","argsp": [],"varsp": [],
+    {"type":"SCOPE","name":"$unit","addr":"(SMB)","loc":"a,0:0,0:0","aboveScopep":"(Z)","aboveCellp":"(Y)","modp":"(E)","varsp": [],"blocksp": [],"inlinesp": []},
+    {"type":"CFUNC","name":"_ctor_var_reset","addr":"(TMB)","loc":"a,0:0,0:0","slow":true,"scopep":"UNLINKED","argsp": [],"varsp": [],
      "stmtsp": [
-      {"type":"ASSIGN","name":"","addr":"(NRB)","loc":"d,17:12,17:16","dtypep":"(DC)",
+      {"type":"ASSIGN","name":"","addr":"(UMB)","loc":"d,17:12,17:16","dtypep":"(DC)",
        "rhsp": [
-        {"type":"CRESET","name":"","addr":"(ORB)","loc":"d,17:12,17:16","dtypep":"(DC)","constructing":true}
+        {"type":"CRESET","name":"","addr":"(VMB)","loc":"d,17:12,17:16","dtypep":"(DC)","constructing":true}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(PRB)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"WR","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"__Venumtab_enum_next1","addr":"(WMB)","loc":"d,17:12,17:16","dtypep":"(DC)","access":"WR","varp":"(EC)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []},
-      {"type":"ASSIGN","name":"","addr":"(QRB)","loc":"d,17:12,17:16","dtypep":"(XI)",
+      {"type":"ASSIGN","name":"","addr":"(XMB)","loc":"d,17:12,17:16","dtypep":"(CH)",
        "rhsp": [
-        {"type":"CRESET","name":"","addr":"(RRB)","loc":"d,17:12,17:16","dtypep":"(XI)","constructing":true}
+        {"type":"CRESET","name":"","addr":"(YMB)","loc":"d,17:12,17:16","dtypep":"(CH)","constructing":true}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(SRB)","loc":"d,17:12,17:16","dtypep":"(XI)","access":"WR","varp":"(YI)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"__Venumtab_enum_prev1","addr":"(ZMB)","loc":"d,17:12,17:16","dtypep":"(CH)","access":"WR","varp":"(DH)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []},
-      {"type":"ASSIGN","name":"","addr":"(TRB)","loc":"d,17:12,17:16","dtypep":"(JM)",
+      {"type":"ASSIGN","name":"","addr":"(ANB)","loc":"d,17:12,17:16","dtypep":"(SJ)",
        "rhsp": [
-        {"type":"CRESET","name":"","addr":"(URB)","loc":"d,17:12,17:16","dtypep":"(JM)","constructing":true}
+        {"type":"CRESET","name":"","addr":"(BNB)","loc":"d,17:12,17:16","dtypep":"(SJ)","constructing":true}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"__Venumtab_enum_name1","addr":"(VRB)","loc":"d,17:12,17:16","dtypep":"(JM)","access":"WR","varp":"(KM)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
+        {"type":"VARREF","name":"__Venumtab_enum_name1","addr":"(CNB)","loc":"d,17:12,17:16","dtypep":"(SJ)","access":"WR","varp":"(TJ)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []}
     ]}
   ]}
 ],
  "filesp": [
-  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck__Syms__Slow.cpp","addr":"(WRB)","loc":"a,0:0,0:0","source":true,"slow":true,"tblockp": []},
-  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck__Syms.h","addr":"(XRB)","loc":"a,0:0,0:0","tblockp": []},
-  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck.h","addr":"(YRB)","loc":"a,0:0,0:0","tblockp": []},
-  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck.cpp","addr":"(ZRB)","loc":"a,0:0,0:0","source":true,"tblockp": []},
-  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck__pch.h","addr":"(ASB)","loc":"a,0:0,0:0","tblockp": []},
-  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck_$root.h","addr":"(BSB)","loc":"a,0:0,0:0","tblockp": []},
-  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck_$unit.h","addr":"(CSB)","loc":"a,0:0,0:0","tblockp": []},
-  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck_$root__Slow.cpp","addr":"(DSB)","loc":"a,0:0,0:0","source":true,"slow":true,"tblockp": []},
-  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck_$root__0__Slow.cpp","addr":"(ESB)","loc":"a,0:0,0:0","source":true,"slow":true,"tblockp": []},
-  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck_$root__0.cpp","addr":"(FSB)","loc":"a,0:0,0:0","source":true,"tblockp": []},
-  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck_$unit__Slow.cpp","addr":"(GSB)","loc":"a,0:0,0:0","source":true,"slow":true,"tblockp": []},
-  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck_$unit__0__Slow.cpp","addr":"(HSB)","loc":"a,0:0,0:0","source":true,"slow":true,"tblockp": []}
+  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck__Syms__Slow.cpp","addr":"(DNB)","loc":"a,0:0,0:0","source":true,"slow":true,"tblockp": []},
+  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck__Syms.h","addr":"(ENB)","loc":"a,0:0,0:0","tblockp": []},
+  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck.h","addr":"(FNB)","loc":"a,0:0,0:0","tblockp": []},
+  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck.cpp","addr":"(GNB)","loc":"a,0:0,0:0","source":true,"tblockp": []},
+  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck__pch.h","addr":"(HNB)","loc":"a,0:0,0:0","tblockp": []},
+  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck_$root.h","addr":"(INB)","loc":"a,0:0,0:0","tblockp": []},
+  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck_$unit.h","addr":"(JNB)","loc":"a,0:0,0:0","tblockp": []},
+  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck_$root__Slow.cpp","addr":"(KNB)","loc":"a,0:0,0:0","source":true,"slow":true,"tblockp": []},
+  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck_$root__0__Slow.cpp","addr":"(LNB)","loc":"a,0:0,0:0","source":true,"slow":true,"tblockp": []},
+  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck_$root__0.cpp","addr":"(MNB)","loc":"a,0:0,0:0","source":true,"tblockp": []},
+  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck_$unit__Slow.cpp","addr":"(NNB)","loc":"a,0:0,0:0","source":true,"slow":true,"tblockp": []},
+  {"type":"CFILE","name":"obj_vlt/t_json_only_debugcheck/Vt_json_only_debugcheck_$unit__0__Slow.cpp","addr":"(ONB)","loc":"a,0:0,0:0","source":true,"slow":true,"tblockp": []}
 ],
  "miscsp": [
   {"type":"TYPETABLE","name":"","addr":"(C)","loc":"a,0:0,0:0","constraintRefp":"UNLINKED","emptyQueuep":"UNLINKED","queueIndexp":"UNLINKED","streamp":"UNLINKED","voidp":"(DB)",
    "typesp": [
     {"type":"BASICDTYPE","name":"logic","addr":"(K)","loc":"d,33:24,33:27","dtypep":"(K)","keyword":"logic","generic":true,"rangep": []},
     {"type":"BASICDTYPE","name":"logic","addr":"(IC)","loc":"d,53:16,53:17","dtypep":"(IC)","keyword":"logic","range":"31:0","generic":true,"rangep": []},
-    {"type":"BASICDTYPE","name":"logic","addr":"(ISB)","loc":"d,17:17,17:18","dtypep":"(ISB)","keyword":"logic","range":"3:0","generic":true,"rangep": []},
-    {"type":"ENUMDTYPE","name":"t.my_t","addr":"(BC)","loc":"d,17:12,17:16","dtypep":"(BC)","enum":true,"refDTypep":"(ISB)","childDTypep": [],
+    {"type":"BASICDTYPE","name":"logic","addr":"(PNB)","loc":"d,17:17,17:18","dtypep":"(PNB)","keyword":"logic","range":"3:0","generic":true,"rangep": []},
+    {"type":"ENUMDTYPE","name":"t.my_t","addr":"(BC)","loc":"d,17:12,17:16","dtypep":"(BC)","enum":true,"refDTypep":"(PNB)","childDTypep": [],
      "itemsp": [
-      {"type":"ENUMITEM","name":"E01","addr":"(JSB)","loc":"d,18:24,18:27","dtypep":"(UB)","rangep": [],
+      {"type":"ENUMITEM","name":"E01","addr":"(QNB)","loc":"d,18:24,18:27","dtypep":"(UB)","rangep": [],
        "valuep": [
-        {"type":"CONST","name":"4'h1","addr":"(KSB)","loc":"d,18:30,18:31","dtypep":"(UB)"}
+        {"type":"CONST","name":"4'h1","addr":"(RNB)","loc":"d,18:30,18:31","dtypep":"(UB)"}
       ]},
-      {"type":"ENUMITEM","name":"E03","addr":"(LSB)","loc":"d,19:24,19:27","dtypep":"(UB)","rangep": [],
+      {"type":"ENUMITEM","name":"E03","addr":"(SNB)","loc":"d,19:24,19:27","dtypep":"(UB)","rangep": [],
        "valuep": [
-        {"type":"CONST","name":"4'h3","addr":"(MSB)","loc":"d,19:30,19:31","dtypep":"(UB)"}
+        {"type":"CONST","name":"4'h3","addr":"(TNB)","loc":"d,19:30,19:31","dtypep":"(UB)"}
       ]},
-      {"type":"ENUMITEM","name":"E04","addr":"(NSB)","loc":"d,20:24,20:27","dtypep":"(UB)","rangep": [],
+      {"type":"ENUMITEM","name":"E04","addr":"(UNB)","loc":"d,20:24,20:27","dtypep":"(UB)","rangep": [],
        "valuep": [
-        {"type":"CONST","name":"4'h4","addr":"(OSB)","loc":"d,20:30,20:31","dtypep":"(UB)"}
+        {"type":"CONST","name":"4'h4","addr":"(VNB)","loc":"d,20:30,20:31","dtypep":"(UB)"}
       ]}
     ]},
     {"type":"BASICDTYPE","name":"integer","addr":"(S)","loc":"d,23:4,23:11","dtypep":"(S)","keyword":"integer","range":"31:0","generic":true,"signed":true,"rangep": []},
@@ -3022,61 +2653,61 @@
     {"type":"BASICDTYPE","name":"string","addr":"(SB)","loc":"d,28:4,28:10","dtypep":"(SB)","keyword":"string","generic":true,"rangep": []},
     {"type":"UNPACKARRAYDTYPE","name":"","addr":"(DC)","loc":"d,17:12,17:16","dtypep":"(DC)","declRange":"[7:0]","refDTypep":"(BC)","childDTypep": [],
      "rangep": [
-      {"type":"RANGE","name":"","addr":"(PSB)","loc":"d,17:12,17:16",
+      {"type":"RANGE","name":"","addr":"(WNB)","loc":"d,17:12,17:16",
        "leftp": [
-        {"type":"CONST","name":"32'h7","addr":"(QSB)","loc":"d,17:12,17:16","dtypep":"(IC)"}
+        {"type":"CONST","name":"32'h7","addr":"(XNB)","loc":"d,17:12,17:16","dtypep":"(IC)"}
       ],
        "rightp": [
-        {"type":"CONST","name":"32'h0","addr":"(RSB)","loc":"d,17:12,17:16","dtypep":"(IC)"}
+        {"type":"CONST","name":"32'h0","addr":"(YNB)","loc":"d,17:12,17:16","dtypep":"(IC)"}
       ]}
     ]},
-    {"type":"UNPACKARRAYDTYPE","name":"","addr":"(XI)","loc":"d,17:12,17:16","dtypep":"(XI)","declRange":"[7:0]","refDTypep":"(BC)","childDTypep": [],
+    {"type":"UNPACKARRAYDTYPE","name":"","addr":"(CH)","loc":"d,17:12,17:16","dtypep":"(CH)","declRange":"[7:0]","refDTypep":"(BC)","childDTypep": [],
      "rangep": [
-      {"type":"RANGE","name":"","addr":"(SSB)","loc":"d,17:12,17:16",
+      {"type":"RANGE","name":"","addr":"(ZNB)","loc":"d,17:12,17:16",
        "leftp": [
-        {"type":"CONST","name":"32'h7","addr":"(TSB)","loc":"d,17:12,17:16","dtypep":"(IC)"}
+        {"type":"CONST","name":"32'h7","addr":"(AOB)","loc":"d,17:12,17:16","dtypep":"(IC)"}
       ],
        "rightp": [
-        {"type":"CONST","name":"32'h0","addr":"(USB)","loc":"d,17:12,17:16","dtypep":"(IC)"}
+        {"type":"CONST","name":"32'h0","addr":"(BOB)","loc":"d,17:12,17:16","dtypep":"(IC)"}
       ]}
     ]},
-    {"type":"UNPACKARRAYDTYPE","name":"","addr":"(JM)","loc":"d,17:12,17:16","dtypep":"(JM)","isCompound":true,"declRange":"[7:0]","refDTypep":"(SB)","childDTypep": [],
+    {"type":"UNPACKARRAYDTYPE","name":"","addr":"(SJ)","loc":"d,17:12,17:16","dtypep":"(SJ)","isCompound":true,"declRange":"[7:0]","refDTypep":"(SB)","childDTypep": [],
      "rangep": [
-      {"type":"RANGE","name":"","addr":"(VSB)","loc":"d,17:12,17:16",
+      {"type":"RANGE","name":"","addr":"(COB)","loc":"d,17:12,17:16",
        "leftp": [
-        {"type":"CONST","name":"32'h7","addr":"(WSB)","loc":"d,17:12,17:16","dtypep":"(IC)"}
+        {"type":"CONST","name":"32'h7","addr":"(DOB)","loc":"d,17:12,17:16","dtypep":"(IC)"}
       ],
        "rightp": [
-        {"type":"CONST","name":"32'h0","addr":"(XSB)","loc":"d,17:12,17:16","dtypep":"(IC)"}
+        {"type":"CONST","name":"32'h0","addr":"(EOB)","loc":"d,17:12,17:16","dtypep":"(IC)"}
       ]}
     ]},
     {"type":"BASICDTYPE","name":"logic","addr":"(LB)","loc":"d,23:23,23:24","dtypep":"(LB)","keyword":"logic","range":"31:0","generic":true,"signed":true,"rangep": []},
     {"type":"VOIDDTYPE","name":"","addr":"(DB)","loc":"a,0:0,0:0","dtypep":"(DB)"},
-    {"type":"BASICDTYPE","name":"bit","addr":"(IN)","loc":"a,0:0,0:0","dtypep":"(IN)","keyword":"bit","range":"63:0","generic":true,"rangep": []},
-    {"type":"UNPACKARRAYDTYPE","name":"","addr":"(W)","loc":"d,11:8,11:9","dtypep":"(W)","declRange":"[0:0]","refDTypep":"(IN)","childDTypep": [],
+    {"type":"BASICDTYPE","name":"bit","addr":"(RK)","loc":"a,0:0,0:0","dtypep":"(RK)","keyword":"bit","range":"63:0","generic":true,"rangep": []},
+    {"type":"UNPACKARRAYDTYPE","name":"","addr":"(W)","loc":"d,11:8,11:9","dtypep":"(W)","declRange":"[0:0]","refDTypep":"(RK)","childDTypep": [],
      "rangep": [
-      {"type":"RANGE","name":"","addr":"(YSB)","loc":"d,11:8,11:9",
+      {"type":"RANGE","name":"","addr":"(FOB)","loc":"d,11:8,11:9",
        "leftp": [
-        {"type":"CONST","name":"32'h0","addr":"(ZSB)","loc":"d,11:8,11:9","dtypep":"(IC)"}
+        {"type":"CONST","name":"32'h0","addr":"(GOB)","loc":"d,11:8,11:9","dtypep":"(IC)"}
       ],
        "rightp": [
-        {"type":"CONST","name":"32'h0","addr":"(ATB)","loc":"d,11:8,11:9","dtypep":"(IC)"}
+        {"type":"CONST","name":"32'h0","addr":"(HOB)","loc":"d,11:8,11:9","dtypep":"(IC)"}
       ]}
     ]},
-    {"type":"BASICDTYPE","name":"IData","addr":"(JP)","loc":"a,0:0,0:0","dtypep":"(JP)","keyword":"IData","range":"31:0","generic":true,"rangep": []},
-    {"type":"BASICDTYPE","name":"logic","addr":"(KN)","loc":"d,63:14,63:21","dtypep":"(KN)","keyword":"logic","range":"63:0","generic":true,"rangep": []},
+    {"type":"BASICDTYPE","name":"IData","addr":"(SM)","loc":"a,0:0,0:0","dtypep":"(SM)","keyword":"IData","range":"31:0","generic":true,"rangep": []},
+    {"type":"BASICDTYPE","name":"logic","addr":"(TK)","loc":"d,63:14,63:21","dtypep":"(TK)","keyword":"logic","range":"63:0","generic":true,"rangep": []},
     {"type":"BASICDTYPE","name":"bit","addr":"(P)","loc":"d,11:8,11:9","dtypep":"(P)","keyword":"bit","generic":true,"rangep": []},
     {"type":"BASICDTYPE","name":"bit","addr":"(U)","loc":"d,11:8,11:9","dtypep":"(U)","keyword":"bit","range":"31:0","generic":true,"rangep": []},
     {"type":"BASICDTYPE","name":"logic","addr":"(GB)","loc":"d,63:22,63:25","dtypep":"(GB)","keyword":"logic","range":"31:0","generic":true,"rangep": []},
     {"type":"BASICDTYPE","name":"logic","addr":"(UB)","loc":"d,32:11,32:14","dtypep":"(UB)","keyword":"logic","range":"31:0","generic":true,"rangep": []},
     {"type":"BASICDTYPE","name":"logic","addr":"(GC)","loc":"d,38:15,38:16","dtypep":"(GC)","keyword":"logic","range":"31:0","generic":true,"rangep": []},
-    {"type":"BASICDTYPE","name":"logic","addr":"(TPB)","loc":"d,15:10,15:13","dtypep":"(TPB)","keyword":"logic","range":"7:0","generic":true,"rangep": []}
+    {"type":"BASICDTYPE","name":"logic","addr":"(ALB)","loc":"d,15:10,15:13","dtypep":"(ALB)","keyword":"logic","range":"7:0","generic":true,"rangep": []}
   ]},
   {"type":"CONSTPOOL","name":"","addr":"(D)","loc":"a,0:0,0:0",
    "modulep": [
-    {"type":"MODULE","name":"@CONST-POOL@","addr":"(BTB)","loc":"a,0:0,0:0","origName":"@CONST-POOL@","verilogName":"@CONST-POOL@","level":0,"timeunit":"NONE","inlinesp": [],
+    {"type":"MODULE","name":"@CONST-POOL@","addr":"(IOB)","loc":"a,0:0,0:0","origName":"@CONST-POOL@","verilogName":"@CONST-POOL@","level":0,"timeunit":"NONE","inlinesp": [],
      "stmtsp": [
-      {"type":"SCOPE","name":"TOP","addr":"(CTB)","loc":"a,0:0,0:0","aboveScopep":"UNLINKED","aboveCellp":"UNLINKED","modp":"(BTB)","varsp": [],"blocksp": [],"inlinesp": []}
+      {"type":"SCOPE","name":"TOP","addr":"(JOB)","loc":"a,0:0,0:0","aboveScopep":"UNLINKED","aboveCellp":"UNLINKED","modp":"(IOB)","varsp": [],"blocksp": [],"inlinesp": []}
     ]}
   ]}
 ]}

--- a/test_regress/t/t_opt_merge_cond.py
+++ b/test_regress/t/t_opt_merge_cond.py
@@ -17,8 +17,8 @@ test.execute()
 
 if test.vlt:
     # Note, with vltmt this might be split differently, so only checking vlt
-    test.file_grep(test.stats, r'Optimizations, MergeCond merges\s+(\d+)', 9)
-    test.file_grep(test.stats, r'Optimizations, MergeCond merged items\s+(\d+)', 580)
-    test.file_grep(test.stats, r'Optimizations, MergeCond longest merge\s+(\d+)', 128)
+    test.file_grep(test.stats, r'Optimizations, MergeCond merges\s+(\d+)', 11)
+    test.file_grep(test.stats, r'Optimizations, MergeCond merged items\s+(\d+)', 585)
+    test.file_grep(test.stats, r'Optimizations, MergeCond longest merge\s+(\d+)', 129)
 
 test.passes()

--- a/test_regress/t/t_opt_merge_cond_relaxed.cpp
+++ b/test_regress/t/t_opt_merge_cond_relaxed.cpp
@@ -1,0 +1,29 @@
+// -*- mode: C++; c-file-style: "cc-mode" -*-
+//*************************************************************************
+//
+// This program is free software; you can redistribute it and/or modify it
+// under the terms of either the GNU Lesser General Public License Version 3
+// or the Perl Artistic License Version 2.0.
+// SPDX-FileCopyrightText: 2026-2026 Wilson Snyder
+// SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+//
+//*************************************************************************
+
+#include "svdpi.h"
+
+#include <iostream>
+
+extern "C" void setDpi(int value);
+
+extern "C" void setViaDpi(int value) {
+    std::cout << "setViaDpi " << value << std::endl;
+    setDpi(value);
+}
+
+extern "C" int getDpi();
+
+extern "C" int getViaDpi() {
+    const int value = getDpi();
+    std::cout << "getViaDpi " << value << std::endl;
+    return value;
+}

--- a/test_regress/t/t_opt_merge_cond_relaxed.out
+++ b/test_regress/t/t_opt_merge_cond_relaxed.out
@@ -1,0 +1,173 @@
+setViaDpi 3
+setViaDpi 6
+setViaDpi 4
+getViaDpi 2
+cnt=  4 pub=  1
+getViaDpi 24
+getViaDpi 24
+getViaDpi 100
+cnt=  8 pub=  2
+cyc[1] is 1 once
+cyc[1] is 1 twice
+setViaDpi 18
+setViaDpi 34
+setViaDpi 32
+setViaDpi 6
+setViaDpi 4
+getViaDpi 2
+cnt= 12 pub=  3
+cyc[1] is 1 once
+cyc[1] is 1 twice
+setViaDpi 35
+setViaDpi 67
+setViaDpi 3
+getViaDpi 2
+cnt= 16 pub=  4
+setViaDpi 6
+getViaDpi 2
+cnt= 20 pub=  5
+getViaDpi 24
+getViaDpi 24
+getViaDpi 100
+cnt= 24 pub=  6
+cyc[1] is 1 once
+cyc[1] is 1 twice
+setViaDpi 22
+setViaDpi 38
+setViaDpi 36
+setViaDpi 3
+setViaDpi 6
+getViaDpi 2
+cnt= 28 pub=  7
+cyc[1] is 1 once
+cyc[1] is 1 twice
+setViaDpi 39
+setViaDpi 71
+getViaDpi 2
+cnt= 32 pub=  8
+setViaDpi 6
+setViaDpi 4
+getViaDpi 2
+cnt= 36 pub=  9
+getViaDpi 24
+getViaDpi 24
+setViaDpi 3
+getViaDpi 100
+cnt= 40 pub= 10
+cyc[1] is 1 once
+cyc[1] is 1 twice
+setViaDpi 26
+setViaDpi 42
+setViaDpi 40
+setViaDpi 6
+setViaDpi 4
+getViaDpi 2
+cnt= 44 pub= 11
+cyc[1] is 1 once
+cyc[1] is 1 twice
+setViaDpi 43
+setViaDpi 75
+getViaDpi 2
+cnt= 48 pub= 12
+setViaDpi 3
+setViaDpi 6
+getViaDpi 2
+cnt= 52 pub= 13
+getViaDpi 24
+getViaDpi 24
+getViaDpi 100
+cnt= 56 pub= 14
+cyc[1] is 1 once
+cyc[1] is 1 twice
+setViaDpi 30
+setViaDpi 46
+setViaDpi 44
+setViaDpi 6
+getViaDpi 2
+cnt= 60 pub= 15
+cyc[1] is 1 once
+cyc[1] is 1 twice
+setViaDpi 47
+setViaDpi 79
+setViaDpi 3
+getViaDpi 2
+cnt= 64 pub= 16
+setViaDpi 6
+setViaDpi 4
+getViaDpi 2
+cnt= 68 pub= 17
+getViaDpi 24
+getViaDpi 24
+getViaDpi 100
+cnt= 72 pub= 18
+cyc[1] is 1 once
+cyc[1] is 1 twice
+setViaDpi 34
+setViaDpi 50
+setViaDpi 48
+setViaDpi 3
+setViaDpi 6
+setViaDpi 4
+getViaDpi 2
+cnt= 76 pub= 19
+cyc[1] is 1 once
+cyc[1] is 1 twice
+setViaDpi 51
+setViaDpi 83
+getViaDpi 2
+cnt= 80 pub= 20
+setViaDpi 6
+getViaDpi 2
+cnt= 84 pub= 21
+getViaDpi 24
+getViaDpi 24
+setViaDpi 3
+getViaDpi 100
+cnt= 88 pub= 22
+cyc[1] is 1 once
+cyc[1] is 1 twice
+setViaDpi 38
+setViaDpi 54
+setViaDpi 52
+setViaDpi 6
+getViaDpi 2
+cnt= 92 pub= 23
+cyc[1] is 1 once
+cyc[1] is 1 twice
+setViaDpi 55
+setViaDpi 87
+getViaDpi 2
+cnt= 96 pub= 24
+setViaDpi 3
+setViaDpi 6
+setViaDpi 4
+getViaDpi 2
+cnt=100 pub= 25
+getViaDpi 24
+getViaDpi 24
+getViaDpi 100
+cnt=104 pub= 26
+cyc[1] is 1 once
+cyc[1] is 1 twice
+setViaDpi 42
+setViaDpi 58
+setViaDpi 56
+setViaDpi 6
+setViaDpi 4
+getViaDpi 2
+cnt=108 pub= 27
+cyc[1] is 1 once
+cyc[1] is 1 twice
+setViaDpi 59
+setViaDpi 91
+setViaDpi 3
+getViaDpi 2
+cnt=112 pub= 28
+setViaDpi 6
+getViaDpi 2
+cnt=116 pub= 29
+getViaDpi 24
+getViaDpi 24
+getViaDpi 100
+cnt=120 pub= 30
+*-* All Finished *-*

--- a/test_regress/t/t_opt_merge_cond_relaxed.py
+++ b/test_regress/t/t_opt_merge_cond_relaxed.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('vlt_all')
+
+test.compile(verilator_flags2=["--binary", "--stats", test.top_filename.replace(".v", ".cpp")])
+
+test.file_grep(test.stats, r'Optimizations, MergeCond merges\s+(\d+)', 4)
+
+test.execute(expect_filename=test.golden_filename)
+
+test.passes()

--- a/test_regress/t/t_opt_merge_cond_relaxed.v
+++ b/test_regress/t/t_opt_merge_cond_relaxed.v
@@ -1,0 +1,133 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain.
+// SPDX-FileCopyrightText: 2026 Wilson Snyder
+// SPDX-License-Identifier: CC0-1.0
+
+`define stop $stop
+`define check(got ,exp) do if ((got) !== (exp)) begin $write("%%Error: %s:%0d: cyc=%0d got='h%x exp='h%x\n", `__FILE__,`__LINE__, cyc, (got), (exp)); `stop; end while(0)
+
+module t;
+
+  logic clk = 0;
+  always #5 clk = ~clk;
+
+  initial begin
+    #300;
+    $write("*-* All Finished *-*\n");
+    $finish;
+  end
+
+  int cyc = 0;
+  always @(posedge clk) cyc <= cyc + 1;
+
+  int dpiWr = 0;
+  function automatic void setDpi(int value);
+    dpiWr = value;
+  endfunction
+  export "DPI-C" function setDpi;
+  import "DPI-C" context function void setViaDpi(int value); // calls setDpi(value)
+
+  int dpiRd = 0;
+  function automatic int getDpi();
+    return dpiRd;
+  endfunction
+  export "DPI-C" function getDpi;
+  import "DPI-C" context function int getViaDpi(); // calls getDpi()
+
+  int tmp;
+  int cnt = 0;
+
+  int pub /* verilator public_flat_rd */ = 0;
+
+  always @(posedge clk) begin
+
+    //---------------------------
+    // Mergeable
+
+    // Side effect but no implicit state access.
+    if (cyc[1]) $display("cyc[1] is 1 once");
+    ++cnt;
+    if (cyc[1]) $display("cyc[1] is 1 twice");
+
+    // Side effect but no implicit state access.
+    if (cyc > 100000) $error("cyc > 100000 once");
+    ++cnt;
+    if (cyc > 100000) $error("cyc > 100000 once");
+
+    // DPI call, but no public state involved.
+    dpiWr = 13;
+    if (cyc[1:0] == 2'd2) setViaDpi(cyc + 16);
+    ++cnt;
+    if (cyc[1:0] == 2'd2) setViaDpi(cyc + 32);
+    `check(dpiWr, cyc % 4 == 2 ? cyc + 32 : 13);
+
+    // DPI call, but no public state involved.
+    dpiRd = 24;
+    tmp = 10;
+    if (cyc[1:0] == 2'd1) begin
+      tmp = getViaDpi();
+      tmp += 10;
+    end
+    ++cnt;
+    if (cyc[1:0] == 2'd1) begin
+      tmp = getViaDpi();
+      tmp += 20;
+    end
+    `check(tmp, cyc % 4 == 1 ? 44 : 10);
+
+    //---------------------------
+    // NOT Mergeable
+
+    // DPI call, possible implicit state chagne.
+    tmp = dpiWr;
+    if (dpiWr[1:0] == 2'd2) setViaDpi(dpiWr & ~32'b11);
+    if (dpiWr[1:0] == 2'd2) setViaDpi(dpiWr + 10); // Won't execute
+    `check(dpiWr, cyc % 4 == 2 ? (tmp & ~32'b11) : 13);
+
+    // DPI call, possible implicit state acces.
+    dpiWr = 14;
+    if (cyc[1:0] == 2'd3) setViaDpi(cyc + 32);
+    ++pub;
+    if (cyc[1:0] == 2'd3) setViaDpi(cyc + 64);
+    `check(dpiWr, cyc % 4 == 3 ? cyc + 64 : 14);
+
+    // DPI call, possible implicit state change.
+    dpiWr = 11;
+    tmp = cyc + $c(0); // Prevent repalcing with 'cyc'
+    if (tmp % 3 == 0) begin
+        setViaDpi(3);
+        tmp = dpiWr + 2;
+    end
+    if (tmp % 3 == 0) setViaDpi(4); // Won't execute
+    `check(dpiWr, cyc % 3 == 0 ? 3 : 11);
+    dpiWr = 3;
+
+    // DPI call, possible implicit state change.
+    tmp = cyc + $c(0); // Prevent repalcing with 'cyc'
+    if (tmp % 2 == 0) begin
+        setViaDpi(6);
+        if (cyc[2]) tmp = dpiWr + 1;
+    end
+    if (tmp % 2 == 0) setViaDpi(4); // Sometime executes
+    `check(tmp, cyc % 2 == 0 ? (cyc[2] ? 7 : cyc) : cyc);
+    `check(dpiWr, cyc % 2 == 0 ? (cyc[2] ? 6 : 4) : 3);
+
+    // DPI call, possible implicit state read.
+    dpiRd = 2;
+    if (cyc[1:0] == 2'd1) begin
+      dpiRd = 100;
+    end
+    tmp = getViaDpi();
+    if (cyc[1:0] == 2'd1) begin
+      dpiRd = 3;
+    end
+    `check(tmp, cyc % 4 == 1 ? 100 : 2);
+    `check(dpiRd, cyc % 4 == 1 ? 3 : 2);
+
+    //---------------------------
+    // Dispaly so not eliminated
+    $display("cnt=%3d pub=%3d", cnt, pub);
+  end
+
+endmodule


### PR DESCRIPTION
- Allow reordering pure statements with DPI import calls iff no public variables (including those read via a DPI export) are involved. This ensures the DPI import can't observe the reordering
- Allow reordering of pure statements with AstDisplay and AstStop. This requires an assumption that AstDisplay and AstStop will not read or write model state other than via a VarRef explicitly present int the Ast. This seems reasonable.

Overall this allows eliminating a lot of conditionals around assertions, which were previously not possible.

---

I will test this a bit more, but conceptually ready.