### PR TITLE
Internals: Mark Premit temporaries funcLocal, noReset

### DIFF
--- a/src/V3Premit.cpp
+++ b/src/V3Premit.cpp
@@ -91,6 +91,8 @@ class PremitVisitor final : public VNVisitor {
             // Keep as local temporary.
             const std::string name = "__Vtemp_" + std::to_string(++m_tmpVarCnt);
             varp = new AstVar{flp, VVarType::STMTTEMP, name, nodep->dtypep()};
+            varp->funcLocal(true);
+            varp->noReset(true);
             m_cfuncp->addVarsp(varp);
             ++m_temporaryVarsCreated;
 

--- a/test_regress/t/t_json_only_debugcheck.out
+++ b/test_regress/t/t_json_only_debugcheck.out
@@ -49,7 +49,7 @@
     ]},
     {"type":"CFUNC","name":"_eval_initial__TOP","addr":"(QB)","loc":"d,11:8,11:9","slow":true,"scopep":"(Z)","argsp": [],
      "varsp": [
-      {"type":"VAR","name":"__Vtemp_1","addr":"(RB)","loc":"d,49:120,49:121","dtypep":"(SB)","origName":"__Vtemp_1","verilogName":"__Vtemp_1","direction":"NONE","lifetime":"NONE","varType":"STMTTEMP","dtypeName":"string","sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []}
+      {"type":"VAR","name":"__Vtemp_1","addr":"(RB)","loc":"d,49:120,49:121","dtypep":"(SB)","origName":"__Vtemp_1","verilogName":"__Vtemp_1","direction":"NONE","noReset":true,"isFuncLocal":true,"lifetime":"NONE","varType":"STMTTEMP","dtypeName":"string","sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []}
     ],
      "stmtsp": [
       {"type":"ASSIGN","name":"","addr":"(TB)","loc":"d,32:9,32:10","dtypep":"(UB)",
@@ -868,9 +868,9 @@
        "lhsp": [
         {"type":"VARREF","name":"__Vdly__t.e","addr":"(XN)","loc":"d,24:9,24:10","dtypep":"(M)","access":"WR","varp":"(UN)","varScopep":"UNLINKED","classOrPackagep":"UNLINKED"}
       ],"timingControlp": []},
-      {"type":"VAR","name":"__Vtemp_1","addr":"(YN)","loc":"d,70:123,70:124","dtypep":"(SB)","origName":"__Vtemp_1","verilogName":"__Vtemp_1","direction":"NONE","lifetime":"NONE","varType":"STMTTEMP","dtypeName":"string","sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
-      {"type":"VAR","name":"__Vtemp_2","addr":"(ZN)","loc":"d,80:123,80:124","dtypep":"(SB)","origName":"__Vtemp_2","verilogName":"__Vtemp_2","direction":"NONE","lifetime":"NONE","varType":"STMTTEMP","dtypeName":"string","sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
-      {"type":"VAR","name":"__Vtemp_3","addr":"(AO)","loc":"d,90:123,90:124","dtypep":"(SB)","origName":"__Vtemp_3","verilogName":"__Vtemp_3","direction":"NONE","lifetime":"NONE","varType":"STMTTEMP","dtypeName":"string","sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []}
+      {"type":"VAR","name":"__Vtemp_1","addr":"(YN)","loc":"d,70:123,70:124","dtypep":"(SB)","origName":"__Vtemp_1","verilogName":"__Vtemp_1","direction":"NONE","noReset":true,"isFuncLocal":true,"lifetime":"NONE","varType":"STMTTEMP","dtypeName":"string","sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
+      {"type":"VAR","name":"__Vtemp_2","addr":"(ZN)","loc":"d,80:123,80:124","dtypep":"(SB)","origName":"__Vtemp_2","verilogName":"__Vtemp_2","direction":"NONE","noReset":true,"isFuncLocal":true,"lifetime":"NONE","varType":"STMTTEMP","dtypeName":"string","sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []},
+      {"type":"VAR","name":"__Vtemp_3","addr":"(AO)","loc":"d,90:123,90:124","dtypep":"(SB)","origName":"__Vtemp_3","verilogName":"__Vtemp_3","direction":"NONE","noReset":true,"isFuncLocal":true,"lifetime":"NONE","varType":"STMTTEMP","dtypeName":"string","sensIfacep":"UNLINKED","childDTypep": [],"delayp": [],"valuep": [],"attrsp": []}
     ],
      "stmtsp": [
       {"type":"ASSIGN","name":"","addr":"(BO)","loc":"d,23:17,23:20","dtypep":"(S)",


### PR DESCRIPTION
This currently has no effect but is more correct for the future.