### PR TITLE
Testing: Relax expected file count in t_flag_csplit_groups

### DIFF
--- a/test_regress/driver.py
+++ b/test_regress/driver.py
@@ -2685,7 +2685,7 @@ class VlTest:
             self.error("File_grep: " + filename + ": Got='" + match.group(1) + "' Expected='" +
                        str(expvalue) + "' in regexp: '" + regexp + "'")
             return None
-        return [match.groups()]
+        return match.groups()
 
     def file_grep_count(self, filename: str, regexp, expcount: int) -> None:
         contents = self.file_contents(filename)

--- a/test_regress/t/t_flag_csplit_groups.py
+++ b/test_regress/t/t_flag_csplit_groups.py
@@ -125,7 +125,9 @@ test.file_grep_not(test.obj_dir + "/" + test.vm_prefix + "_classes.mk", "vm_clas
 test.file_grep_not(test.obj_dir + "/" + test.vm_prefix + "_classes.mk", "vm_classes_2")
 
 # Check combine count
-test.file_grep(test.stats, r'Node count, CFILE + (\d+)', (276 if test.vltmt else 259))
+nFiles = int(test.file_grep(test.stats, r'Node count, CFILE + (\d+)')[0])
+if nFiles < 200:
+    test.error("Expecting >= 200 files, but got " + str(nFiles))
 test.file_grep(test.stats, r'Makefile targets, VM_CLASSES_FAST + (\d+)', 2)
 test.file_grep(test.stats, r'Makefile targets, VM_CLASSES_SLOW + (\d+)', 2)
 

--- a/test_regress/t/t_func_dotted_inl2.py
+++ b/test_regress/t/t_func_dotted_inl2.py
@@ -20,7 +20,7 @@ if test.vlt_all:
     modps = test.file_grep(
         out_filename,
         r'{"type":"MODULE","name":"mb","addr":"([^"]*)","loc":"\w,99:[^"]*",.*"origName":"mb"')
-    modp = modps[0][0]
+    modp = modps[0]
     test.file_grep(
         out_filename,
         r'{"type":"CELL","name":"t.ma0.mb0","addr":"[^"]*","loc":"\w,87:[^"]*",.*"origName":"mb0",.*"modp":"([^"]*)"',

--- a/test_regress/t/t_func_dotted_inl2_vlt.py
+++ b/test_regress/t/t_func_dotted_inl2_vlt.py
@@ -19,7 +19,7 @@ if test.vlt_all:
     modps = test.file_grep(
         out_filename,
         r'{"type":"MODULE","name":"mb","addr":"([^"]*)","loc":"\w,99:[^"]*",.*"origName":"mb"')
-    modp = modps[0][0]
+    modp = modps[0]
     test.file_grep(
         out_filename,
         r'{"type":"CELL","name":"t.ma0.mb0","addr":"[^"]*","loc":"\w,87:[^"]*",.*"origName":"mb0",.*"modp":"([^"]*)"',


### PR DESCRIPTION
I have a couple patches I need keep resolving merge conflicts on this on rebase. Don't think there is much point in looking for an exact number.