### PR TITLE
Fix V3SplitAs issue

### DIFF
--- a/test_regress/t/t_func_nba.py
+++ b/test_regress/t/t_func_nba.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2024 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios("simulator")
+
+test.compile(timing_loop=True, verilator_flags2=["--trace", "--timing"])
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_func_nba.v
+++ b/test_regress/t/t_func_nba.v
@@ -1,0 +1,72 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain.
+// SPDX-FileCopyrightText: 2026 Wilson Snyder
+// SPDX-License-Identifier: CC0-1.0
+
+
+interface intf
+(
+    input logic clk
+);
+    logic       blargh /*verilator isolate_assignments*/;
+    int data;
+    modport sink (
+        input   clk,
+        output  blargh,
+        input   data
+    );
+    modport source (
+        input clk, blargh,
+        output data
+    );
+endinterface
+
+module sub
+(
+    intf.sink intf_a,
+    intf.source  intf_b
+);
+    function automatic logic ident_func(logic arg);
+        return arg;
+    endfunction
+    function automatic logic other_func();
+    endfunction
+    wire bar /* verilator public */;
+    always_ff @(posedge intf_a.clk) begin
+            intf_a.blargh <= '1;
+            if (other_func()) begin
+            end
+            if (ident_func(intf_a.data[0])) begin
+                intf_b.data <= '1;
+                intf_a.blargh <= '0;
+            end
+    end
+endmodule
+
+module t();
+    logic clk;
+    intf intf_b (.*);
+    intf intf_a (.*);
+    sub the_sub (.*);
+
+    initial begin
+        clk = '0;
+        #10;
+        clk = ~clk;
+        #10;
+        if (!intf_a.blargh) $stop;
+        clk = ~clk;
+        intf_a.data = '1;
+        #10;
+        clk = ~clk;
+        #10;
+        clk = ~clk;
+        #10;
+        if (intf_a.blargh) $stop;
+        clk = ~clk;
+        #10;
+            $write("*-* All Finished *-*\n");
+            $finish;
+    end
+endmodule


### PR DESCRIPTION
@gezalore here's a reproducer for #7185.  I haven't investigated a fix yet but can do so tomorrow.  However, the issue does appear to be between V3Task and the end.  More specifically, after V3Task `intf_a.blargh` gets conditionally assigned based on `__VlemCall_1__ident_func` which is assigned before it is used (which is the correct behavior):
```
    1:2:2:2: ASSIGN 0x55555730b360 <e868> {d31aj} @dt=0x5555573046c0@(G/w1)
    1:2:2:2:1: VARREF 0x5555572fd0e0 <e866> {d31aq} @dt=0x5555573046c0@(G/w1)  __Vfunc_ident_func__0__arg [RV] <- VARSCOPE 0x555557304fc0 <e1373#> {d30bv} @dt=0x5555573046c0@(G/w1)  TOP.t.the_sub->__Vfunc_ident_func__0__arg [T] [scopep=0x5555572048c0] -> VAR 0x5555571ffd40 <e1370#> {d30bv} @dt=0x5555573046c0@(G/w1)  __Vfunc_ident_func__0__arg [INTERNAL] BLOCKTEMP
    1:2:2:2:2: VARREF 0x5555572fcc30 <e867> {d31aj} @dt=0x5555573046c0@(G/w1)  __VlemCall_1__ident_func [LV] => VARSCOPE 0x5555573052c0 <e1099> {d40ar} @dt=0x5555573046c0@(G/w1)  TOP.t.the_sub->__VlemCall_1__ident_func [T] [scopep=0x5555572048c0] -> VAR 0x5555571ff320 <e962> {d40ar} @dt=0x5555573046c0@(G/w1)  __VlemCall_1__ident_func [INTERNAL] [!RST] [VAUTOM]  MODULETEMP
    1:2:2:2: ASSIGN 0x55555730afa0 <e1383#> {d40ar} @dt=0x5555573046c0@(G/w1)
    1:2:2:2:1: VARREF 0x5555573380f0 <e1387#> {d40ar} @dt=0x5555573046c0@(G/w1)  __VlemCall_1__ident_func [RV] <- VARSCOPE 0x5555573052c0 <e1099> {d40ar} @dt=0x5555573046c0@(G/w1)  TOP.t.the_sub->__VlemCall_1__ident_func [T] [scopep=0x5555572048c0] -> VAR 0x5555571ff320 <e962> {d40ar} @dt=0x5555573046c0@(G/w1)  __VlemCall_1__ident_func [INTERNAL] [!RST] [VAUTOM]  MODULETEMP
    1:2:2:2:2: VARREF 0x5555572fc870 <e972> {d40ar} @dt=0x5555573046c0@(G/w1)  __VlemCall_1__ident_func [LV] => VARSCOPE 0x5555573052c0 <e1099> {d40ar} @dt=0x5555573046c0@(G/w1)  TOP.t.the_sub->__VlemCall_1__ident_func [T] [scopep=0x5555572048c0] -> VAR 0x5555571ff320 <e962> {d40ar} @dt=0x5555573046c0@(G/w1)  __VlemCall_1__ident_func [INTERNAL] [!RST] [VAUTOM]  MODULETEMP
    1:2:2:2: IF 0x555557206580 <e974> {d40an}
    1:2:2:2:1: VARREF 0x5555572fc960 <e967> {d40ar} @dt=0x5555573046c0@(G/w1)  __VlemCall_1__ident_func [RV] <- VARSCOPE 0x5555573052c0 <e1099> {d40ar} @dt=0x5555573046c0@(G/w1)  TOP.t.the_sub->__VlemCall_1__ident_func [T] [scopep=0x5555572048c0] -> VAR 0x5555571ff320 <e962> {d40ar} @dt=0x5555573046c0@(G/w1)  __VlemCall_1__ident_func [INTERNAL] [!RST] [VAUTOM]  MODULETEMP
    1:2:2:2:2: ASSIGNDLY 0x55555730b040 <e935> {d41bd} @dt=0x555557304000@(G/sw32)
    1:2:2:2:2:1: CONST 0x555557338870 <e704> {d41bg} @dt=0x555557305b00@(G/w32)  32'hffffffff
    1:2:2:2:2:2: VARREF 0x5555572fcf00 <e1300> {d41ay} @dt=0x555557304000@(G/sw32)  data [LV] => VARSCOPE 0x5555573058c0 <e1085> {d13aj} @dt=0x555557304000@(G/sw32)  TOP.t.intf_b->data [T] [scopep=0x5555572041c0] -> VAR 0x5555571fe480 <e658> {d13aj} @dt=0x555557304000@(G/sw32)  data [VSTATICI]  VAR
    1:2:2:2:2: ASSIGNDLY 0x55555730b0e0 <e899> {d42bf} @dt=0x5555573046c0@(G/w1)
    1:2:2:2:2:1: CONST 0x555557338960 <e897> {d42bi} @dt=0x5555573046c0@(G/w1)  1'h0
    1:2:2:2:2:2: VARREF 0x5555572fc3c0 <e1304> {d42ay} @dt=0x5555573046c0@(G/w1)  blargh [LV] => VARSCOPE 0x555557304b40 <e1092> {d12ar} @dt=0x5555573046c0@(G/w1)  TOP.t.intf_a->blargh [T] [scopep=0x5555572047e0] -> VAR 0x5555571fe360 <e901> {d12ar} @dt=0x5555573046c0@(G/w1)  blargh [aISO] [VSTATICI]  VAR
```
but then by the end these two things get swizzled and we evaluate the condition before updating the `__VlemCall` var:
```
    1:2:3: IF 0x555557206580 <e5749> {d40an}
    1:2:3:1: VARREF 0x5555572fc0f0 <e5567> {d40ar} @dt=0x555557304b40@(G/wu32/1)  __VlemCall_1__ident_func [RV] <- VAR 0x5555571ff320 <e6083> {d40ar} @dt=0x5555573046c0@(G/w1)  __VlemCall_1__ident_func [INTERNAL] [!RST] [VAUTOM]  MODULETEMP
    1:2:3:2: ASSIGNDLY 0x55555730a140 <e5570> {d42bf} @dt=0x555557304b40@(G/wu32/1)
    1:2:3:2:1: CONST 0x555557338c30 <e5568> {d42bi} @dt=0x555557304b40@(G/wu32/1)  1'h0
    1:2:3:2:2: VARREF 0x5555572fc4b0 <e5569> {d42ay} @dt=0x555557304b40@(G/wu32/1)  __PVT__blargh [LV] => VAR 0x5555571fe360 <e6090> {d12ar} @dt=0x5555573046c0@(G/w1)  __PVT__blargh [aISO] [VSTATICI]  VAR
    1:2:3: ASSIGN 0x55555730ac80 <e5750> {d31aj} @dt=0x555557304b40@(G/wu32/1)
    1:2:3:1: VARREF 0x5555572fc000 <e5589> {d31aq} @dt=0x555557304b40@(G/wu32/1)  __Vfunc_ident_func__0__arg [RV] <- VAR 0x5555573299e0 <e5148> {d30bv} @dt=0x5555573046c0@(G/w1)  __Vfunc_ident_func__0__arg [FUNC] BLOCKTEMP
    1:2:3:2: VARREF 0x5555573383c0 <e5590> {d31aj} @dt=0x555557304b40@(G/wu32/1)  __VlemCall_1__ident_func [LV] => VAR 0x5555571ff320 <e6083> {d40ar} @dt=0x5555573046c0@(G/w1)  __VlemCall_1__ident_func [INTERNAL] [!RST] [VAUTOM]  MODULETEMP
```

This test passes with `-fno-lift-expr`.