### PR TITLE
Fix recursive default assignment for subarrays (#4589)

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -134,6 +134,7 @@ Jose Loyola
 Josep Sans
 Joseph Nwabueze
 Josh Redford
+Julian Carrier
 Julian Daube
 Julie Schwartz
 Julien Margetts

--- a/src/V3Const.cpp
+++ b/src/V3Const.cpp
@@ -2667,12 +2667,27 @@ class ConstVisitor final : public VNVisitor {
         iterateChildren(nodep);
         if (const AstInitArray* const initp = VN_CAST(nodep->lhsp(), InitArray)) {
             if (!(m_doExpensive || m_params)) return false;
-            // At present only support 1D unpacked arrays
-            const auto initOfConst = [](const AstNode* const nodep) -> bool {  //
-                return VN_IS(nodep, Const) || VN_IS(nodep, InitItem);
+            const auto isConstInit = [](const AstNode* const exprp,
+                                        const auto& isConstInitRecurse) -> bool {
+                if (VN_IS(exprp, Const)) return true;
+                if (const AstInitItem* const itemp = VN_CAST(exprp, InitItem)) {
+                    return isConstInitRecurse(itemp->valuep(), isConstInitRecurse);
+                }
+                if (const AstInitArray* const arrayp = VN_CAST(exprp, InitArray)) {
+                    const auto itemIsConstInit = [&isConstInitRecurse](const AstNode* const itemp)
+                        -> bool {
+                        return isConstInitRecurse(itemp, isConstInitRecurse);
+                    };
+                    if (arrayp->initsp() && !arrayp->initsp()->forall(itemIsConstInit)) return false;
+                    if (arrayp->defaultp()
+                        && !isConstInitRecurse(arrayp->defaultp(), isConstInitRecurse)) {
+                        return false;
+                    }
+                    return true;
+                }
+                return false;
             };
-            if (initp->initsp() && !initp->initsp()->forall(initOfConst)) return false;
-            if (initp->defaultp() && !initp->defaultp()->forall(initOfConst)) return false;
+            if (!isConstInit(initp, isConstInit)) return false;
         } else if (!VN_IS(nodep->lhsp(), Const)) {
             return false;
         }

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -5282,6 +5282,30 @@ class WidthVisitor final : public VNVisitor {
         return newp;
     }
 
+    AstPatMember* defaultPatp_patternArray(AstPatMember* defaultp, AstNodeDType* elemDTypep) {
+        AstPatMember* const newpatp = defaultp->cloneTree(false);
+        AstNodeExpr* const valuep = newpatp->lhssp();
+        AstNodeDType* const elemDTypeSkipRefp = elemDTypep->skipRefp();
+
+        if (!VN_IS(elemDTypeSkipRefp, UnpackArrayDType)) return newpatp;
+        if (VN_IS(valuep, Pattern)) return newpatp;
+        if (!valuep->dtypep()) userIterate(valuep, WidthVP{SELF, BOTH}.p());
+        if (valuep->dtypep()
+            && AstNode::computeCastable(valuep->dtypep()->skipRefp(), elemDTypeSkipRefp, nullptr)
+                   .isAssignable()) {
+            return newpatp;
+        }
+
+        AstNodeExpr* const recursiveValuep = valuep->unlinkFrBack();
+        VL_DO_DANGLING(pushDeletep(newpatp), newpatp);
+        AstPatMember* const nestedDefaultp
+            = new AstPatMember{defaultp->fileline(), recursiveValuep, nullptr, nullptr};
+        nestedDefaultp->isDefault(true);
+        AstPattern* const recursivePatternp
+            = new AstPattern{defaultp->fileline(), nestedDefaultp};
+        return new AstPatMember{defaultp->fileline(), recursivePatternp, nullptr, nullptr};
+    }
+
     void patternArray(AstPattern* nodep, AstNodeArrayDType* arrayDtp, AstPatMember* defaultp) {
         const VNumRange range = arrayDtp->declRange();
         PatVecMap patmap = patVectorMap(nodep, range);
@@ -5296,7 +5320,7 @@ class WidthVisitor final : public VNVisitor {
             const auto it = patmap.find(ent);
             if (it == patmap.end()) {
                 if (defaultp) {
-                    newpatp = defaultp->cloneTree(false);
+                    newpatp = defaultPatp_patternArray(defaultp, arrayDtp->subDTypep());
                     patp = newpatp;
                 } else if (!(VN_IS(arrayDtp, UnpackArrayDType) && !allConstant && isConcat)) {
                     // If arrayDtp is an unpacked array and item is not constant,

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -5283,21 +5283,27 @@ class WidthVisitor final : public VNVisitor {
     }
 
     AstPatMember* defaultPatp_patternArray(AstPatMember* defaultp, AstNodeDType* elemDTypep) {
-        AstNodeExpr* const valuep = defaultp->lhssp();
+        AstNodeExpr* const valuep = defaultp->lhssp()->cloneTree(false);
         AstNodeDType* const elemDTypeSkipRefp = elemDTypep->skipRefp();
 
-        if (!VN_IS(elemDTypeSkipRefp, UnpackArrayDType)) return defaultp->cloneTree(false);
-        if (VN_IS(valuep, Pattern)) return defaultp->cloneTree(false);
+        if (!VN_IS(elemDTypeSkipRefp, UnpackArrayDType)) {
+            VL_DO_DANGLING(pushDeletep(valuep), valuep);
+            return defaultp->cloneTree(false);
+        }
+        if (VN_IS(valuep, Pattern)) {
+            VL_DO_DANGLING(pushDeletep(valuep), valuep);
+            return defaultp->cloneTree(false);
+        }
         if (!valuep->dtypep()) userIterate(valuep, WidthVP{SELF, BOTH}.p());
         if (valuep->dtypep()
             && AstNode::computeCastable(valuep->dtypep()->skipRefp(), elemDTypeSkipRefp, nullptr)
                    .isAssignable()) {
+            VL_DO_DANGLING(pushDeletep(valuep), valuep);
             return defaultp->cloneTree(false);
         }
 
-        AstNodeExpr* const recursiveValuep = valuep->cloneTree(false);
         AstPatMember* const nestedDefaultp
-            = new AstPatMember{defaultp->fileline(), recursiveValuep, nullptr, nullptr};
+            = new AstPatMember{defaultp->fileline(), valuep, nullptr, nullptr};
         nestedDefaultp->isDefault(true);
         AstPattern* const recursivePatternp
             = new AstPattern{defaultp->fileline(), nestedDefaultp};

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -5283,21 +5283,19 @@ class WidthVisitor final : public VNVisitor {
     }
 
     AstPatMember* defaultPatp_patternArray(AstPatMember* defaultp, AstNodeDType* elemDTypep) {
-        AstPatMember* const newpatp = defaultp->cloneTree(false);
-        AstNodeExpr* const valuep = newpatp->lhssp();
+        AstNodeExpr* const valuep = defaultp->lhssp();
         AstNodeDType* const elemDTypeSkipRefp = elemDTypep->skipRefp();
 
-        if (!VN_IS(elemDTypeSkipRefp, UnpackArrayDType)) return newpatp;
-        if (VN_IS(valuep, Pattern)) return newpatp;
+        if (!VN_IS(elemDTypeSkipRefp, UnpackArrayDType)) return defaultp->cloneTree(false);
+        if (VN_IS(valuep, Pattern)) return defaultp->cloneTree(false);
         if (!valuep->dtypep()) userIterate(valuep, WidthVP{SELF, BOTH}.p());
         if (valuep->dtypep()
             && AstNode::computeCastable(valuep->dtypep()->skipRefp(), elemDTypeSkipRefp, nullptr)
                    .isAssignable()) {
-            return newpatp;
+            return defaultp->cloneTree(false);
         }
 
-        AstNodeExpr* const recursiveValuep = valuep->unlinkFrBack();
-        VL_DO_DANGLING(pushDeletep(newpatp), newpatp);
+        AstNodeExpr* const recursiveValuep = valuep->cloneTree(false);
         AstPatMember* const nestedDefaultp
             = new AstPatMember{defaultp->fileline(), recursiveValuep, nullptr, nullptr};
         nestedDefaultp->isDefault(true);

--- a/test_regress/t/t_array_pattern_default_recursive.py
+++ b/test_regress/t/t_array_pattern_default_recursive.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2026 by Verilator Authors
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile()
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_array_pattern_default_recursive.py
+++ b/test_regress/t/t_array_pattern_default_recursive.py
@@ -4,7 +4,7 @@
 # This program is free software; you can redistribute it and/or modify it
 # under the terms of either the GNU Lesser General Public License Version 3
 # or the Perl Artistic License Version 2.0.
-# SPDX-FileCopyrightText: 2026 by Verilator Authors
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
 # SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
 
 import vltest_bootstrap

--- a/test_regress/t/t_array_pattern_default_recursive.v
+++ b/test_regress/t/t_array_pattern_default_recursive.v
@@ -9,6 +9,7 @@ module t;
   int arr_default_scalar[4][4];
   int row[4];
   int arr_default_array[2][4];
+  int arr_mixed_default[2][3];
 
   initial begin
     arr_default_scalar = '{default: 0};
@@ -21,6 +22,14 @@ module t;
     foreach (arr_default_array[i, j]) begin
       if (arr_default_array[i][j] != row[j]) $stop;
     end
+
+    arr_mixed_default = '{0: '{0: 1, default: 3}, default: '{default: 2}};
+    if (arr_mixed_default[0][0] != 1) $stop;
+    if (arr_mixed_default[0][1] != 3) $stop;
+    if (arr_mixed_default[0][2] != 3) $stop;
+    if (arr_mixed_default[1][0] != 2) $stop;
+    if (arr_mixed_default[1][1] != 2) $stop;
+    if (arr_mixed_default[1][2] != 2) $stop;
 
     $write("*-* All Finished *-*\n");
     $finish;

--- a/test_regress/t/t_array_pattern_default_recursive.v
+++ b/test_regress/t/t_array_pattern_default_recursive.v
@@ -1,0 +1,29 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain.
+// SPDX-FileCopyrightText: 2026 by Verilator Authors
+// SPDX-License-Identifier: CC0-1.0
+
+module t;
+
+  int arr_default_scalar[4][4];
+  int row[4];
+  int arr_default_array[2][4];
+
+  initial begin
+    arr_default_scalar = '{default: 0};
+    foreach (arr_default_scalar[i, j]) begin
+      if (arr_default_scalar[i][j] != 0) $stop;
+    end
+
+    row = '{1, 2, 3, 4};
+    arr_default_array = '{default: row};
+    foreach (arr_default_array[i, j]) begin
+      if (arr_default_array[i][j] != row[j]) $stop;
+    end
+
+    $write("*-* All Finished *-*\n");
+    $finish;
+  end
+
+endmodule

--- a/test_regress/t/t_array_pattern_default_recursive.v
+++ b/test_regress/t/t_array_pattern_default_recursive.v
@@ -1,7 +1,7 @@
 // DESCRIPTION: Verilator: Verilog Test module
 //
 // This file ONLY is placed under the Creative Commons Public Domain.
-// SPDX-FileCopyrightText: 2026 by Verilator Authors
+// SPDX-FileCopyrightText: 2026 Wilson Snyder
 // SPDX-License-Identifier: CC0-1.0
 
 module t;

--- a/test_regress/t/t_assert_elab_p.out
+++ b/test_regress/t/t_assert_elab_p.out
@@ -1,4 +1,4 @@
--Info: t/t_assert_elab_p.v:14:5: %m test.sv:25: 4=4 2=2 STAGE_IDS='{'h1, 'h1, 'h1, 'h1}
+-Info: t/t_assert_elab_p.v:14:5: %m test.sv:25: 4=4 2=2 STAGE_IDS='{'{'h1, 'h1}, '{'h1, 'h1}, '{'h1, 'h1}, '{'h1, 'h1}}
                                : ... note: In instance 't.pipe'
    14 |     $info("%m %s:%0d: 4=%0d 2=%0d STAGE_IDS=%p", "test.sv", 25, 4, 2, STAGE_IDS);
       |     ^~~~~


### PR DESCRIPTION
Fixes #2491.

## Summary
Verilator was rejecting legal unpacked-array default assignment patterns like `int a[4][4] = '{default: 0};` because it tried to assign the scalar default directly to a subarray instead of applying `default` recursively. This patch is necessary to implement IEEE 1800 recursive default behavior for unpacked subarrays so standards-compliant source (including transpiled code) no longer fails elaboration/lint.

## Issue
Fixes https://github.com/verilator/verilator/issues/4589

## Root Cause
In `WidthVisitor::patternArray` (`src/V3Width.cpp`), when an element was filled from `default: ...`, Verilator cloned the default pattern member and immediately typed it as the subelement dtype. For unpacked subarray elements, scalar defaults (for example `0`) must first be interpreted as a recursive default pattern (`'{default: 0}` at the next level), but that recursion was not synthesized, leading to unpacked-array type errors.

## Changes
- `src/V3Width.cpp`
  - Added `defaultPatp_patternArray(AstPatMember* defaultp, AstNodeDType* elemDTypep)`.
  - For unpacked subarray elements:
    - Keep existing behavior if value is already a pattern.
    - Keep existing behavior if value is directly assignable to the subarray type.
    - Otherwise rewrite the element default into a recursive pattern form equivalent to `'{default: value}`.
  - `patternArray(...)` now uses `defaultPatp_patternArray(...)` instead of raw `defaultp->cloneTree(false)`.
- Added regression test:
  - `test_regress/t/t_array_pattern_default_recursive.v`
  - `test_regress/t/t_array_pattern_default_recursive.py`

## Verification Evidence (VE)
### Environment
- Command: `./bin/verilator --version`
- Result: `Verilator 5.047 devel rev v5.046-53-g4f4d48e9d (mod)`

### 1. Fixed behavior: recursive default on unpacked subarrays now accepted
- Testcase:
  ```systemverilog
  module dut;
     int a[4][4] = '{default: 0};
  endmodule
  ```
- Command: `./bin/verilator --lint-only /tmp/repro_4589_default.sv`
- Result: Pass (exit code 0)

### 2. Non-regression: direct array-typed default value still accepted
- Testcase:
  ```systemverilog
  module t;
    int row[4] = '{1,2,3,4};
    int c[2][4] = '{default: row};
  endmodule
  ```
- Command: `./bin/verilator --lint-only /tmp/repro_default_row.sv`
- Result: Pass (exit code 0)

### 3. Regression test added for this fix
- Command: `./bin/verilator --binary test_regress/t/t_array_pattern_default_recursive.v && ./obj_dir/Vt_array_pattern_default_recursive`
- Result: Pass, runtime prints `*-* All Finished *-*`