### PR TITLE
Fix: link shared library with its dependencies

### DIFF
--- a/src/V3EmitMk.cpp
+++ b/src/V3EmitMk.cpp
@@ -770,10 +770,11 @@ public:
                 // So add dynamic_lookup
                 of.puts("ifeq ($(shell uname -s),Darwin)\n");
                 of.puts("\t$(OBJCACHE) $(CXX) $(CXXFLAGS) $(CPPFLAGS) $(OPT_FAST) -undefined "
-                        "dynamic_lookup -shared $(LDFLAGS) -flat_namespace -o $@ $^ $(LIBS)\n");
+                        "dynamic_lookup -shared $(LDFLAGS) -flat_namespace -o $@ $^ $(LDLIBS) "
+                        "$(LIBS)\n");
                 of.puts("else\n");
                 of.puts("\t$(OBJCACHE) $(CXX) $(CXXFLAGS) $(CPPFLAGS) $(OPT_FAST) -shared "
-                        "$(LDFLAGS) -o $@ $^ $(LIBS)\n");
+                        "$(LDFLAGS) -o $@ $^ $(LDLIBS) $(LIBS)\n");
                 of.puts("endif\n");
                 of.puts("\n");
                 of.puts("lib" + v3Global.opt.libCreate() + ": " + v3Global.opt.libCreateName(false)


### PR DESCRIPTION
Pre-pull to #7299
Currently, shared objects created using the `--lib-create` flag don't have their dependencies linked, which results in errors like these under clang: `./obj_vlt/t_trace_lib_as_top/libsimulator.so: undefined symbol: __atomic_is_lock_free`.
This fix just adds linking to those dependencies.