### PR TITLE
Fix Apple clang PCH compile error with -o flag (#7251)

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -60,6 +60,7 @@ Driss Hafdi
 Edgar E. Iglesias
 Eric Müller
 Eric Rippey
+Eunseo Song
 Ethan Sifferman
 Eyck Jentzsch
 Fabian Keßler-Schulz

--- a/include/verilated.mk.in
+++ b/include/verilated.mk.in
@@ -280,10 +280,10 @@ ifneq ($(VM_DEFAULT_RULES),0)
 	$(OBJCACHE) $(CXX) $(OPT_FAST) $(CXXFLAGS) $(CPPFLAGS) -c -o $@ $<
 
   $(VK_OBJS_FAST): %.o: %.cpp $(VK_PCH_H).fast.gch
-	$(OBJCACHE) $(CXX) $(OPT_FAST) $(CXXFLAGS) $(CPPFLAGS) $(VK_PCH_I_FAST) -c -o $@ $<
+	$(OBJCACHE) $(CXX) $(OPT_FAST) $(CXXFLAGS) $(CPPFLAGS) $(VK_PCH_I_FAST) -c $<
 
   $(VK_OBJS_SLOW): %.o: %.cpp $(VK_PCH_H).slow.gch
-	$(OBJCACHE) $(CXX) $(OPT_SLOW) $(CXXFLAGS) $(CPPFLAGS) $(VK_PCH_I_SLOW) -c -o $@ $<
+	$(OBJCACHE) $(CXX) $(OPT_SLOW) $(CXXFLAGS) $(CPPFLAGS) $(VK_PCH_I_SLOW) -c $<
 
   $(VK_GLOBAL_OBJS): %.o: %.cpp
 	$(OBJCACHE) $(CXX) $(OPT_GLOBAL) $(CXXFLAGS) $(CPPFLAGS) -c -o $@ $<


### PR DESCRIPTION
## Summary
- Remove `-o $@` from PCH build rules in `verilated.mk.in` to fix Apple clang error: "cannot specify -o when generating multiple output files"
- The `%.o: %.cpp` pattern rule already implies the correct output filename, so `-o $@` is unnecessary
- Non-PCH rules (lines 280, 289) are left unchanged as they are unaffected

## Test plan
- [x] Built Verilator from source on macOS with Apple clang 17
- [x] Verilated and compiled a test design with `--output-split 1` (triggers PCH usage across 40 files) — build succeeded
- [x] Ran regression tests: `t_a1_first_cc`, `t_flag_verilate`, `t_opt_table_sparse_output_split` — all PASSED

Closes #7251