### PR TITLE
Tests: Add regression test for PCH with output-split (#7251)

### DIFF
--- a/test_regress/t/t_flag_csplit_pch.py
+++ b/test_regress/t/t_flag_csplit_pch.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+# --output-split triggers PCH generation (.gch files) for parallel builds
+test.compile(verilator_flags2=["--output-split 1", "--output-split-cfuncs 1"])
+
+# Verify PCH header was generated
+test.glob_some(test.obj_dir + "/*__pch.h")
+
+# Verify split files were produced
+test.glob_some(test.obj_dir + "/*__1.cpp")
+
+# Verify parallel builds enabled
+test.file_grep(test.obj_dir + "/" + test.vm_prefix + "_classes.mk",
+               r'VM_PARALLEL_BUILDS\s*=\s*1')
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_flag_csplit_pch.v
+++ b/test_regress/t/t_flag_csplit_pch.v
@@ -1,0 +1,20 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain.
+// SPDX-FileCopyrightText: 2026 Eunseo Song
+// SPDX-License-Identifier: CC0-1.0
+
+module top(input clk, input rst, output reg [7:0] count);
+   always @(posedge clk) begin
+      if (rst)
+        count <= 0;
+      else
+        count <= count + 1;
+   end
+
+   initial begin
+      $display("Hello from t_flag_csplit_pch");
+      $write("*-* All Coverage-Coverage = 1\n");
+      $finish;
+   end
+endmodule


### PR DESCRIPTION
## Summary
- Add `t_pch_output_split` test that exercises precompiled header generation via `--output-split` and `--output-split-cfuncs`
- Verifies PCH header, split `.cpp` files, and `VM_PARALLEL_BUILDS=1` are all produced correctly
- There was no existing test covering PCH behavior in the regression suite

## Test plan
- [x] `t_pch_output_split` passes on macOS with Apple clang 17
- [x] Existing tests unaffected

Relates to #7251