### PR TITLE
Only add VAR_PORT_DTYPE prior to V3Width

### DIFF
--- a/src/V3LinkDot.cpp
+++ b/src/V3LinkDot.cpp
@@ -1912,7 +1912,7 @@ class LinkDotFindVisitor final : public VNVisitor {
                             // dtype comes from the other side.
                             VL_DO_DANGLING(varDtp->unlinkFrBack()->deleteTree(), varDtp);
                             findvarp->childDTypep(otherDtp->unlinkFrBack());
-                        } else if (otherDtp && varDtp
+                        } else if (m_statep->forPrearray() && otherDtp && varDtp
                                    && !(VN_IS(otherDtp, BasicDType)
                                         && VN_AS(otherDtp, BasicDType)->implicit())) {
                             // otherDtp and varDtp both non-nullptr and neither are implicit


### PR DESCRIPTION
Not sure if there is a deeper issue, but this is introducing the VAR_PORT_DTYPE attribute in the Arrayed/Scoped link steps which run after Width (e.g. in t_array_rev), which then linger and blow up with some other changes I have pending.

Restrict to only add the attribute in pre-Width steps (it's deleted in Width)