### PR TITLE
Internals: Avoid duplicate graph edges in V3Reorder and V3Split

### DIFF
--- a/src/V3Reorder.cpp
+++ b/src/V3Reorder.cpp
@@ -452,8 +452,6 @@ class ReorderVisitor final : public VNVisitor {
         // Reads of constants can be ignored - TODO: This should be "constexpr", not run-time const
         if (nodep->varp()->isConst()) return;
 
-        // SPEEDUP: We add duplicate edges, that should be fixed
-
         AstVarScope* const vscp = nodep->varScopep();
 
         // Create vertexes for variable
@@ -463,7 +461,8 @@ class ReorderVisitor final : public VNVisitor {
         // Variable is read
         if (nodep->access().isReadOnly()) {
             for (ReorderLogicVertex* const vtxp : m_stmtStackps) {
-                new ReorderRVEdge{m_graphp, vtxp, vstdp};
+                if (!vtxp->findConnectingEdgep<GraphWay::FORWARD>(vstdp))
+                    new ReorderRVEdge{m_graphp, vtxp, vstdp};
             }
             return;
         }
@@ -471,7 +470,8 @@ class ReorderVisitor final : public VNVisitor {
         // Variable is written, not NBA
         if (!m_inDly) {
             for (ReorderLogicVertex* const vtxp : m_stmtStackps) {
-                new ReorderLVEdge{m_graphp, vstdp, vtxp};
+                if (!vstdp->findConnectingEdgep<GraphWay::FORWARD>(vtxp))
+                    new ReorderLVEdge{m_graphp, vstdp, vtxp};
             }
             return;
         }
@@ -484,7 +484,8 @@ class ReorderVisitor final : public VNVisitor {
         }
         ReorderVarPostVertex* const vpostp = vscp->user2u().to<ReorderVarPostVertex*>();
         for (ReorderLogicVertex* const vtxp : m_stmtStackps) {
-            new ReorderLVEdge{m_graphp, vpostp, vtxp};
+            if (!vpostp->findConnectingEdgep<GraphWay::FORWARD>(vtxp))
+                new ReorderLVEdge{m_graphp, vpostp, vtxp};
         }
     }
 

--- a/src/V3Split.cpp
+++ b/src/V3Split.cpp
@@ -361,7 +361,6 @@ protected:
                 SplitVarStdVertex* const vstdp
                     = reinterpret_cast<SplitVarStdVertex*>(vscp->user1p());
 
-                // SPEEDUP: We add duplicate edges, that should be fixed
                 if (m_inDly && nodep->access().isWriteOrRW()) {
                     UINFO(4, "     VARREFDLY: " << nodep);
                     // Delayed variable is different from non-delayed variable
@@ -374,7 +373,8 @@ protected:
                         = reinterpret_cast<SplitVarPostVertex*>(vscp->user2p());
                     // Add edges
                     for (SplitLogicVertex* vxp : m_stmtStackps) {
-                        new SplitLVEdge{&m_graph, vpostp, vxp};
+                        if (!vpostp->findConnectingEdgep<GraphWay::FORWARD>(vxp))
+                            new SplitLVEdge{&m_graph, vpostp, vxp};
                     }
                 } else {  // Nondelayed assignment
                     if (nodep->access().isWriteOrRW()) {
@@ -382,7 +382,8 @@ protected:
                         // with all consumers of the signal
                         UINFO(4, "     VARREFLV: " << nodep);
                         for (SplitLogicVertex* ivxp : m_stmtStackps) {
-                            new SplitLVEdge{&m_graph, vstdp, ivxp};
+                            if (!vstdp->findConnectingEdgep<GraphWay::FORWARD>(ivxp))
+                                new SplitLVEdge{&m_graph, vstdp, ivxp};
                         }
                     } else {
                         UINFO(4, "     VARREF:   " << nodep);
@@ -687,7 +688,8 @@ protected:
         for (auto it = m_stmtStackps.cbegin(); it != m_stmtStackps.cend(); ++it) {
             const AstNodeIf* const ifNodep = VN_CAST((*it)->nodep(), NodeIf);
             if (ifNodep && (m_curIfConditional != ifNodep)) continue;
-            new SplitRVEdge{&m_graph, *it, vstdp};
+            if (!(*it)->findConnectingEdgep<GraphWay::FORWARD>(vstdp))
+                new SplitRVEdge{&m_graph, *it, vstdp};
         }
     }
 


### PR DESCRIPTION
## Summary
- Check for existing edges with `findConnectingEdgep` before creating new ones in `V3Reorder` and `V3Split`, removing the `// SPEEDUP` TODOs that noted duplicate edge creation
- Same dedup pattern already used in `V3OrderParallel`

No functional change.

## Test plan
- [x] `make` builds cleanly
- [x] All split tests passed: `t_always_split`, `t_always_split_cond`, `t_always_split_rst`, `t_always_splitord`, `t_always_nosplit`
- [x] All reorder tests passed: `t_always_reorder`, `t_always_noreorder`, `t_always_reorder_inlined_func`, `t_always_reorder_no_acycsimp`
- [x] General regression: `t_a1_first_cc`, `t_flag_verilate` passed