### PR TITLE
Match the compiler flags used with CMake to those in `verilated.mk`

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -238,6 +238,7 @@ Sebastien Van Cauwenberghe
 Sergey Fedorov
 Sergi Granell
 Seth Pellegrino
+Shogo Yamazaki
 Shou-Li Hsu
 Srinivasan Venkataramanan
 Stefan Wallentowitz

--- a/verilator-config.cmake.in
+++ b/verilator-config.cmake.in
@@ -743,15 +743,16 @@ function(verilate TARGET)
 
     target_link_libraries(${TARGET} PUBLIC ${VERILATOR_MT_CFLAGS})
 
-    target_compile_features(${TARGET} PRIVATE cxx_std_11)
-
     if(${VERILATE_PREFIX}_TIMING)
-        check_cxx_compiler_flag(-fcoroutines-ts COROUTINES_TS_FLAG)
-        target_compile_options(
-            ${TARGET}
-            PRIVATE
-                $<IF:$<BOOL:${COROUTINES_TS_FLAG}>,-fcoroutines-ts,-fcoroutines>
-        )
+        if("@CFG_CXXFLAGS_COROUTINES@" STREQUAL "-std=gnu++20")
+            target_compile_features(${TARGET} PRIVATE cxx_std_20)
+        else()
+            target_compile_options(
+                ${TARGET}
+                PRIVATE
+                    @CFG_CXXFLAGS_COROUTINES@
+            )
+        endif()
     endif()
 endfunction()
 


### PR DESCRIPTION
I’ve had the experience that when using `clang` as a compiler to verilate, the process works correctly with GNU Make but fails with CMake.  After doing a little research, I realized that the compiler flags used when specifying the `--timing` option differ between [`verilator-config.cmake`][verilator-config-cmake] and [`verilated.mk`][verilated-mk]; the latter is derived by [`./configure`][configure-ac] during the Verilator build. The root of the problem was that when the compiler did not support `-fcoroutines-ts`, `-fcoroutines` was passed, which is also not supported by `clang`.

This patch ensures that the same compiler options are passed when using GNU Make versus CMake with the `--timing` argument, thereby resolving build failures that occur when using `clang` with CMake.

Possibly related issue: #5404

[verilator-config-cmake]: https://github.com/verilator/verilator/blob/6595e5cf55ecac422713ca84542d499c01dd5537/verilator-config.cmake.in#L749-L754
[verilated-mk]: https://github.com/verilator/verilator/blob/6595e5cf55ecac422713ca84542d499c01dd5537/include/verilated.mk.in#L182-L186
[configure-ac]: https://github.com/verilator/verilator/blob/6595e5cf55ecac422713ca84542d499c01dd5537/configure.ac#L477-L484