### PR TITLE
Fix virtual class inheritance (#7403)

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -197,6 +197,7 @@ Nathan Graybeal
 Nathan Kohagen
 Nathan Myers
 Nick Brereton
+Nikolay Puzanov
 Nolan Poe
 Oleh Maksymenko
 Patrick Stewart

--- a/src/V3LinkDot.cpp
+++ b/src/V3LinkDot.cpp
@@ -3406,7 +3406,7 @@ class LinkDotResolveVisitor final : public VNVisitor {
                     if (!baseFuncp || !baseFuncp->pureVirtual()) continue;
                     const bool existsInDerived = foundp && !foundp->imported();
                     if (m_statep->forPrimary() && !existsInDerived
-                        && !derivedClassp->isInterfaceClass()) {
+                        && !derivedClassp->isInterfaceClass() && !derivedClassp->isVirtual()) {
                         derivedClassp->v3error(
                             "Class " << derivedClassp->prettyNameQ() << impOrExtends
                                      << baseClassp->prettyNameQ()

--- a/test_regress/t/t_class_virtual_extends_pure.py
+++ b/test_regress/t/t_class_virtual_extends_pure.py
@@ -4,7 +4,7 @@
 # This program is free software; you can redistribute it and/or modify it
 # under the terms of either the GNU Lesser General Public License Version 3
 # or the Perl Artistic License Version 2.0.
-# SPDX-FileCopyrightText: 2026 Nikolay Puzanov
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
 # SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
 
 import vltest_bootstrap

--- a/test_regress/t/t_class_virtual_extends_pure.py
+++ b/test_regress/t/t_class_virtual_extends_pure.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2026 Nikolay Puzanov
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('vlt')
+
+test.lint()
+
+test.passes()

--- a/test_regress/t/t_class_virtual_extends_pure.v
+++ b/test_regress/t/t_class_virtual_extends_pure.v
@@ -1,0 +1,23 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain.
+// SPDX-FileCopyrightText: 2026 Nikolay Puzanov
+// SPDX-License-Identifier: CC0-1.0
+
+virtual class Base;
+  pure virtual function void f0();
+endclass
+
+virtual class Child extends Base;
+  pure virtual function void f1();
+endclass
+
+class Impl extends Child;
+  virtual function void f0();
+  endfunction
+  virtual function void f1();
+  endfunction
+endclass
+
+module t;
+endmodule

--- a/test_regress/t/t_class_virtual_extends_pure.v
+++ b/test_regress/t/t_class_virtual_extends_pure.v
@@ -1,7 +1,7 @@
 // DESCRIPTION: Verilator: Verilog Test module
 //
 // This file ONLY is placed under the Creative Commons Public Domain.
-// SPDX-FileCopyrightText: 2026 Nikolay Puzanov
+// SPDX-FileCopyrightText: 2026 Wilson Snyder
 // SPDX-License-Identifier: CC0-1.0
 
 virtual class Base;


### PR DESCRIPTION
Verilator incorrectly required virtual classes to implement pure virtual methods inherited from virtual classes. According to standard, virtual classes should be allowed to inherit pure virtual methods without implementation.

Fix: Add `!derivedClassp->isVirtual()` check in `V3LinkDot.cpp` to skip the error for virtual classes extending interface classes.

Added regression test t_class_virtual_inherit_pure to verify the fix.
