### PR TITLE
CI: option to create failed tests artifacts

### DIFF
--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -26,6 +26,10 @@ on:
       dev-gcov:
         required: true
         type: number
+      fail-archive:  # 0 or 1
+        required: false
+        type: number
+        default: 0
 
 env:
   CI_OS_NAME: linux
@@ -51,6 +55,7 @@ jobs:
       CI_RELOC: ${{inputs.reloc }}
       CXX: ${{ inputs.cc == 'clang' && 'clang++' || 'g++' }}
       CACHE_BASE_KEY: test-${{ inputs.os }}-${{ inputs.cc }}-${{inputs.reloc }}-${{ inputs.suite }}
+      CI_FAIL_ARCHIVE: ${{ inputs.fail-archive }}
       CCACHE_MAXSIZE: 100M  # Per build per suite (* 5 * 5 = 2500M in total)
     steps:
 
@@ -89,6 +94,15 @@ jobs:
         run: |
           source .venv/bin/activate
           ./ci/ci-script.bash
+
+      - name: Upload failing test artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          path: |
+            repo/test_regress/obj_dist/test-failures.tar.gz
+            ${{ env.RELOC_DIR }}/test_regress/obj_dist/test-failures.tar.gz
+          name: test-failures-${{ inputs.os }}-${{ inputs.cc }}-${{ inputs.reloc }}-${{ inputs.suite }}
+          if-no-files-found: ignore
 
       - name: Combine code coverage data
         if: ${{ inputs.dev-gcov }}

--- a/ci/ci-script.bash
+++ b/ci/ci-script.bash
@@ -106,6 +106,9 @@ elif [ "$CI_BUILD_STAGE_NAME" = "test" ]; then
 
   # Run the specified test
   ccache -z
+  if [ "$CI_FAIL_ARCHIVE" == 1 ]; then
+    export DRIVER_CI_FLAGS=--fail-archive
+  fi
   case $TESTS in
     dist-vlt-0)
       "$MAKE" -C "$TEST_REGRESS" SCENARIOS="--dist --vlt --driver-clean" DRIVER_HASHSET=--hashset=0/4

--- a/test_regress/Makefile
+++ b/test_regress/Makefile
@@ -45,10 +45,11 @@ endif
 
 SCENARIOS ?= --vlt --vltmt --dist
 DRIVER_HASHSET ?=
+DRIVER_CI_FLAGS ?=
 
 .PHONY: test
 test:
-	$(PYTHON3) driver.py $(DRIVER_FLAGS) $(SCENARIOS) $(DRIVER_HASHSET)
+	$(PYTHON3) driver.py $(DRIVER_FLAGS) $(SCENARIOS) $(DRIVER_HASHSET) $(DRIVER_CI_FLAGS)
 
 ######################################################################
 

--- a/test_regress/driver.py
+++ b/test_regress/driver.py
@@ -21,6 +21,7 @@ import shutil
 import signal
 import subprocess
 import sys
+import tarfile
 import time
 
 from functools import lru_cache  # Eventually use python 3.9's cache
@@ -2995,6 +2996,19 @@ def run_them() -> None:
         runner.wait_and_report()
 
     if runner.fail_cnt:
+        if Args.fail_archive:
+            # Create tarball of failed test obj_dirs for CI artifact collection
+            fail_dirs = []
+            for ftest in runner.fail_tests:
+                if os.path.isdir(ftest.obj_dir):
+                    fail_dirs.append(ftest.obj_dir)
+                fail1_dir = ftest.obj_dir + "__fail1"
+                if os.path.isdir(fail1_dir):
+                    fail_dirs.append(fail1_dir)
+            if fail_dirs:
+                with tarfile.open("obj_dist/test-failures.tar.gz", "w:gz") as tar:
+                    for d in fail_dirs:
+                        tar.add(d)
         sys.exit(10)
 
 
@@ -3054,6 +3068,9 @@ if __name__ == '__main__':
     parser.add_argument('--debug', action='store_const', const=9, help='enable debug')
     # --debugi: see _parameter()
     parser.add_argument('--driver-clean', action='store_true', help='clean after test passes')
+    parser.add_argument('--fail-archive',
+                        action='store_true',
+                        help='create obj_dist/test-failures.tar.gz on failure')
     parser.add_argument('--fail-max',
                         action='store',
                         default=None,


### PR DESCRIPTION
CI option (off by default) to capture obj dirs for failed tests as GitHub artifacts which can then be downloaded and examined.  I put the tarball under `obj_dist/` because that seems to always be created and I figured it was best to put test artifacts under `obj_*/`.

Was helpful in debugging #6832 