### PR TITLE
Support 2**n expressions in constraint randomization

### DIFF
--- a/src/V3Randomize.cpp
+++ b/src/V3Randomize.cpp
@@ -1629,38 +1629,44 @@ class ConstraintExprVisitor final : public VNVisitor {
             nodep->replaceWith(powerp);
             VL_DO_DANGLING(nodep->deleteTree(), nodep);
             iterate(powerp);
-        } else if (const AstConst* const basep = VN_CAST(nodep->lhsp(), Const);
-                   basep && basep->num().toUInt() == 2) {
-            // Non-constant exponent, base == 2: transform to shift-based SMT expression.
-            // AstPow/AstPowSU (unsigned exponent): 2**n -> 1<<n
-            // AstPowSS/AstPowUS (signed exponent): 2**n -> n>=0 ? 1<<n : 0
-            //   IEEE 1800-2023 ss11.4.3: integer base with negative exponent gives 0,
-            //   which ShiftL cannot represent; use SMT ite (AstCond -> bvsge + bvshl).
-            FileLine* const fl = nodep->fileline();
-            AstNodeExpr* const rhsp = nodep->rhsp()->unlinkFrBack();
-            const int width = nodep->width();
-            const bool rhsDependent = rhsp->user1();
-            AstConst* const onep = new AstConst{fl, AstConst::WidthedValue{}, width, 1};
-            AstShiftL* const shiftp = new AstShiftL{fl, onep, rhsp, width};
-            shiftp->dtypeFrom(nodep);
-            shiftp->user1(rhsDependent);
-            AstNodeExpr* resultp = shiftp;
-            if (VN_IS(nodep, PowSS) || VN_IS(nodep, PowUS)) {
-                // Signed exponent: guard 1<<n with n>=0 check
-                AstNodeExpr* const nClonep = rhsp->cloneTreePure(false);
-                nClonep->user1(rhsDependent);
-                AstConst* const zeroNp
-                    = new AstConst{fl, AstConst::WidthedValue{}, rhsp->width(), 0};
-                AstGteS* const condp = new AstGteS{fl, nClonep, zeroNp};
-                condp->user1(rhsDependent);
-                AstConst* const zeroRp = new AstConst{fl, AstConst::WidthedValue{}, width, 0};
-                resultp = new AstCond{fl, condp, shiftp, zeroRp};
-                resultp->dtypeFrom(nodep);
-                resultp->user1(nodep->user1());
+        } else if (const AstConst* const basep = VN_CAST(nodep->lhsp(), Const)) {
+            if (basep->num().toUInt() == 2) {
+                // Non-constant exponent, base == 2: transform to shift-based SMT expression.
+                // AstPow/AstPowSU (unsigned exponent): 2**n -> 1<<n
+                // AstPowSS/AstPowUS (signed exponent): 2**n -> n>=0 ? 1<<n : 0
+                //   IEEE 1800-2023 ss11.4.3: integer base with negative exponent gives 0,
+                //   which ShiftL cannot represent; use SMT ite (AstCond -> bvsge + bvshl).
+                FileLine* const fl = nodep->fileline();
+                AstNodeExpr* const rhsp = nodep->rhsp()->unlinkFrBack();
+                const int width = nodep->width();
+                const bool rhsDependent = rhsp->user1();
+                AstConst* const onep = new AstConst{fl, AstConst::WidthedValue{}, width, 1};
+                AstShiftL* const shiftp = new AstShiftL{fl, onep, rhsp, width};
+                shiftp->dtypeFrom(nodep);
+                shiftp->user1(rhsDependent);
+                AstNodeExpr* resultp = shiftp;
+                if (VN_IS(nodep, PowSS) || VN_IS(nodep, PowUS)) {
+                    // Signed exponent: guard 1<<n with n>=0 check
+                    AstNodeExpr* const nClonep = rhsp->cloneTreePure(false);
+                    nClonep->user1(rhsDependent);
+                    AstConst* const zeroNp
+                        = new AstConst{fl, AstConst::WidthedValue{}, rhsp->width(), 0};
+                    AstGteS* const condp = new AstGteS{fl, nClonep, zeroNp};
+                    condp->user1(rhsDependent);
+                    AstConst* const zeroRp
+                        = new AstConst{fl, AstConst::WidthedValue{}, width, 0};
+                    resultp = new AstCond{fl, condp, shiftp, zeroRp};
+                    resultp->dtypeFrom(nodep);
+                    resultp->user1(nodep->user1());
+                }
+                nodep->replaceWith(resultp);
+                VL_DO_DANGLING(nodep->deleteTree(), nodep);
+                iterate(resultp);
+            } else {
+                nodep->v3warn(
+                    CONSTRAINTIGN,
+                    "Unsupported: Power (**) expression with non-constant exponent in constraint");
             }
-            nodep->replaceWith(resultp);
-            VL_DO_DANGLING(nodep->deleteTree(), nodep);
-            iterate(resultp);
         } else {
             nodep->v3warn(
                 CONSTRAINTIGN,

--- a/src/V3Randomize.cpp
+++ b/src/V3Randomize.cpp
@@ -1653,8 +1653,7 @@ class ConstraintExprVisitor final : public VNVisitor {
                         = new AstConst{fl, AstConst::WidthedValue{}, rhsp->width(), 0};
                     AstGteS* const condp = new AstGteS{fl, nClonep, zeroNp};
                     condp->user1(rhsDependent);
-                    AstConst* const zeroRp
-                        = new AstConst{fl, AstConst::WidthedValue{}, width, 0};
+                    AstConst* const zeroRp = new AstConst{fl, AstConst::WidthedValue{}, width, 0};
                     resultp = new AstCond{fl, condp, shiftp, zeroRp};
                     resultp->dtypeFrom(nodep);
                     resultp->user1(nodep->user1());

--- a/src/V3Randomize.cpp
+++ b/src/V3Randomize.cpp
@@ -1629,29 +1629,39 @@ class ConstraintExprVisitor final : public VNVisitor {
             nodep->replaceWith(powerp);
             VL_DO_DANGLING(nodep->deleteTree(), nodep);
             iterate(powerp);
-        } else {
-            // Non-constant exponent: special-case 2**n -> 1<<n for unsigned exponent.
-            // AstShiftL is unsigned, so only safe when the exponent is non-negative:
-            //   AstPow   (unsigned**unsigned) and AstPowSU (signed_base**unsigned_exp).
-            // AstPowSS/PowUS have a signed exponent; n<0 requires result=0 per
-            // IEEE 1800-2023 ss11.4.3, which ShiftL cannot provide.
-            if (VN_IS(nodep, Pow) || VN_IS(nodep, PowSU)) {
-                if (const AstConst* const basep = VN_CAST(nodep->lhsp(), Const);
-                    basep && basep->num().toUInt() == 2) {
-                    // 2**n -> 1<<n; handleShift will emit as SMT bvshl with width fixup
-                    FileLine* const fl = nodep->fileline();
-                    AstNodeExpr* const rhsp = nodep->rhsp()->unlinkFrBack();
-                    AstConst* const onep
-                        = new AstConst{fl, AstConst::WidthedValue{}, nodep->width(), 1};
-                    AstShiftL* const shiftp = new AstShiftL{fl, onep, rhsp, nodep->width()};
-                    shiftp->dtypeFrom(nodep);
-                    shiftp->user1(nodep->user1());
-                    nodep->replaceWith(shiftp);
-                    VL_DO_DANGLING(nodep->deleteTree(), nodep);
-                    iterate(shiftp);
-                    return;
-                }
+        } else if (const AstConst* const basep = VN_CAST(nodep->lhsp(), Const);
+                   basep && basep->num().toUInt() == 2) {
+            // Non-constant exponent, base == 2: transform to shift-based SMT expression.
+            // AstPow/AstPowSU (unsigned exponent): 2**n -> 1<<n
+            // AstPowSS/AstPowUS (signed exponent): 2**n -> n>=0 ? 1<<n : 0
+            //   IEEE 1800-2023 ss11.4.3: integer base with negative exponent gives 0,
+            //   which ShiftL cannot represent; use SMT ite (AstCond -> bvsge + bvshl).
+            FileLine* const fl = nodep->fileline();
+            AstNodeExpr* const rhsp = nodep->rhsp()->unlinkFrBack();
+            const int width = nodep->width();
+            const bool rhsDependent = rhsp->user1();
+            AstConst* const onep = new AstConst{fl, AstConst::WidthedValue{}, width, 1};
+            AstShiftL* const shiftp = new AstShiftL{fl, onep, rhsp, width};
+            shiftp->dtypeFrom(nodep);
+            shiftp->user1(rhsDependent);
+            AstNodeExpr* resultp = shiftp;
+            if (VN_IS(nodep, PowSS) || VN_IS(nodep, PowUS)) {
+                // Signed exponent: guard 1<<n with n>=0 check
+                AstNodeExpr* const nClonep = rhsp->cloneTreePure(false);
+                nClonep->user1(rhsDependent);
+                AstConst* const zeroNp
+                    = new AstConst{fl, AstConst::WidthedValue{}, rhsp->width(), 0};
+                AstGteS* const condp = new AstGteS{fl, nClonep, zeroNp};
+                condp->user1(rhsDependent);
+                AstConst* const zeroRp = new AstConst{fl, AstConst::WidthedValue{}, width, 0};
+                resultp = new AstCond{fl, condp, shiftp, zeroRp};
+                resultp->dtypeFrom(nodep);
+                resultp->user1(nodep->user1());
             }
+            nodep->replaceWith(resultp);
+            VL_DO_DANGLING(nodep->deleteTree(), nodep);
+            iterate(resultp);
+        } else {
             nodep->v3warn(
                 CONSTRAINTIGN,
                 "Unsupported: Power (**) expression with non-constant exponent in constraint");

--- a/src/V3Randomize.cpp
+++ b/src/V3Randomize.cpp
@@ -1634,8 +1634,8 @@ class ConstraintExprVisitor final : public VNVisitor {
                 // Non-constant exponent, base == 2: transform to shift-based SMT expression.
                 // AstPow/AstPowSU (unsigned exponent): 2**n -> 1<<n
                 // AstPowSS/AstPowUS (signed exponent): 2**n -> n>=0 ? 1<<n : 0
-                //   IEEE 1800-2023 ss11.4.3: integer base with negative exponent gives 0,
-                //   which ShiftL cannot represent; use SMT ite (AstCond -> bvsge + bvshl).
+                // IEEE 1800-2023 ss11.4.3: integer base with negative exponent gives 0,
+                // which ShiftL cannot represent; use SMT ite (AstCond -> bvsge + bvshl).
                 FileLine* const fl = nodep->fileline();
                 AstNodeExpr* const rhsp = nodep->rhsp()->unlinkFrBack();
                 const int width = nodep->width();
@@ -1664,7 +1664,7 @@ class ConstraintExprVisitor final : public VNVisitor {
             } else {
                 nodep->v3warn(
                     CONSTRAINTIGN,
-                    "Unsupported: Power (**) expression with non-constant exponent in constraint");
+                    "Unsupported: Power (**) expression with non-2 base in constraint");
             }
         } else {
             nodep->v3warn(

--- a/src/V3Randomize.cpp
+++ b/src/V3Randomize.cpp
@@ -1662,9 +1662,8 @@ class ConstraintExprVisitor final : public VNVisitor {
                 VL_DO_DANGLING(nodep->deleteTree(), nodep);
                 iterate(resultp);
             } else {
-                nodep->v3warn(
-                    CONSTRAINTIGN,
-                    "Unsupported: Power (**) expression with non-2 base in constraint");
+                nodep->v3warn(CONSTRAINTIGN,
+                              "Unsupported: Power (**) expression with non-2 base in constraint");
             }
         } else {
             nodep->v3warn(

--- a/src/V3Randomize.cpp
+++ b/src/V3Randomize.cpp
@@ -1630,6 +1630,28 @@ class ConstraintExprVisitor final : public VNVisitor {
             VL_DO_DANGLING(nodep->deleteTree(), nodep);
             iterate(powerp);
         } else {
+            // Non-constant exponent: special-case 2**n -> 1<<n for unsigned exponent.
+            // AstShiftL is unsigned, so only safe when the exponent is non-negative:
+            //   AstPow   (unsigned**unsigned) and AstPowSU (signed_base**unsigned_exp).
+            // AstPowSS/PowUS have a signed exponent; n<0 requires result=0 per
+            // IEEE 1800-2023 ss11.4.3, which ShiftL cannot provide.
+            if (VN_IS(nodep, Pow) || VN_IS(nodep, PowSU)) {
+                if (const AstConst* const basep = VN_CAST(nodep->lhsp(), Const);
+                    basep && basep->num().toUInt() == 2) {
+                    // 2**n -> 1<<n; handleShift will emit as SMT bvshl with width fixup
+                    FileLine* const fl = nodep->fileline();
+                    AstNodeExpr* const rhsp = nodep->rhsp()->unlinkFrBack();
+                    AstConst* const onep
+                        = new AstConst{fl, AstConst::WidthedValue{}, nodep->width(), 1};
+                    AstShiftL* const shiftp = new AstShiftL{fl, onep, rhsp, nodep->width()};
+                    shiftp->dtypeFrom(nodep);
+                    shiftp->user1(nodep->user1());
+                    nodep->replaceWith(shiftp);
+                    VL_DO_DANGLING(nodep->deleteTree(), nodep);
+                    iterate(shiftp);
+                    return;
+                }
+            }
             nodep->v3warn(
                 CONSTRAINTIGN,
                 "Unsupported: Power (**) expression with non-constant exponent in constraint");

--- a/test_regress/t/t_constraint_non_base2_pow_unsup.out
+++ b/test_regress/t/t_constraint_non_base2_pow_unsup.out
@@ -1,4 +1,4 @@
-%Warning-CONSTRAINTIGN: t/t_constraint_non_base2_pow_unsup.v:12:25: Unsupported: Power (**) expression with non-constant exponent in constraint
+%Warning-CONSTRAINTIGN: t/t_constraint_non_base2_pow_unsup.v:12:25: Unsupported: Power (**) expression with non-2 base in constraint
    12 |   constraint c { x == 3 ** n; }
       |                         ^~
                         ... For warning description see https://verilator.org/warn/CONSTRAINTIGN?v=latest

--- a/test_regress/t/t_constraint_non_base2_pow_unsup.out
+++ b/test_regress/t/t_constraint_non_base2_pow_unsup.out
@@ -1,0 +1,6 @@
+%Warning-CONSTRAINTIGN: t/t_constraint_non_base2_pow_unsup.v:12:25: Unsupported: Power (**) expression with non-constant exponent in constraint
+   12 |   constraint c { x == 3 ** n; }
+      |                         ^~
+                        ... For warning description see https://verilator.org/warn/CONSTRAINTIGN?v=latest
+                        ... Use "/* verilator lint_off CONSTRAINTIGN */" and lint_on around source to disable this message.
+%Error: Exiting due to

--- a/test_regress/t/t_constraint_non_base2_pow_unsup.py
+++ b/test_regress/t/t_constraint_non_base2_pow_unsup.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('vlt')
+
+test.lint(fails=True, expect_filename=test.golden_filename)
+
+test.passes()

--- a/test_regress/t/t_constraint_non_base2_pow_unsup.v
+++ b/test_regress/t/t_constraint_non_base2_pow_unsup.v
@@ -1,0 +1,22 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain.
+// SPDX-FileCopyrightText: 2026 PlanV GmbH
+// SPDX-License-Identifier: CC0-1.0
+
+// Power (**) with constant non-2 base and non-constant exponent is unsupported.
+// Only base 2 can be lowered to SMT via left-shift; other bases have no SMT encoding.
+class C;
+  rand int unsigned n;
+  rand int unsigned x;
+  constraint c { x == 3 ** n; }
+endclass
+
+module t;
+  C obj;
+  initial begin
+    obj = new;
+    void'(obj.randomize());
+    $finish;
+  end
+endmodule

--- a/test_regress/t/t_randomize_pow2.py
+++ b/test_regress/t/t_randomize_pow2.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+if not test.have_solver:
+    test.skip("No constraint solver installed")
+
+test.compile()
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_randomize_pow2.v
+++ b/test_regress/t/t_randomize_pow2.v
@@ -4,40 +4,57 @@
 // SPDX-FileCopyrightText: 2026 PlanV GmbH
 // SPDX-License-Identifier: CC0-1.0
 
-// Test 2**n in constraints: ConstraintExprVisitor transforms 2**n -> 1<<n for SMT.
-// Only unsigned exponent variants (AstPow, AstPowSU) are supported.
-// Signed exponent variants (AstPowSS, AstPowUS) retain the CONSTRAINTIGN warning.
-
-class Pow2Test;
+// AstPow (unsigned**unsigned): 2**n -> 1<<n directly
+class UnsignedPow2;
   rand bit [3:0] n;
   rand bit [15:0] result;
-
-  // AstPow (unsigned**unsigned): 2**n -> 1<<n
-  constraint c_pow2 {
-    n inside {[0:7]};
-    result == 16'(2**n);
-  }
-
+  constraint c { n inside {[0:7]}; result == 16'(2**n); }
   function void check();
     if (result !== (16'h1 << n)) begin
-      $display("FAIL: result=%0d expected 2**%0d=%0d", result, n, 16'h1 << n);
+      $display("FAIL UnsignedPow2: result=%0d expected 2**%0d=%0d", result, n, 16'h1 << n);
+      $stop;
+    end
+  endfunction
+endclass
+
+// AstPowUS (unsigned**signed): 2**n -> n>=0 ? 1<<n : 0
+class SignedExpPow2;
+  rand int signed n;
+  rand bit [15:0] result;
+  constraint c { n inside {[-2:7]}; result == 16'(2**n); }
+  function void check();
+    bit [15:0] expected;
+    expected = (n >= 0) ? (16'h1 << n) : 16'h0;
+    if (result !== expected) begin
+      $display("FAIL SignedExpPow2: n=%0d result=%0d expected=%0d", n, result, expected);
       $stop;
     end
   endfunction
 endclass
 
 module t;
-  Pow2Test obj;
+  UnsignedPow2 u;
+  SignedExpPow2 s;
 
   initial begin
-    obj = new;
+    u = new;
     repeat (20) begin
-      if (obj.randomize() == 0) begin
-        $display("FAIL: randomize() returned 0");
+      if (u.randomize() == 0) begin
+        $display("FAIL: UnsignedPow2.randomize() returned 0");
         $stop;
       end
-      obj.check();
+      u.check();
     end
+
+    s = new;
+    repeat (30) begin
+      if (s.randomize() == 0) begin
+        $display("FAIL: SignedExpPow2.randomize() returned 0");
+        $stop;
+      end
+      s.check();
+    end
+
     $write("*-* All Finished *-*\n");
     $finish;
   end

--- a/test_regress/t/t_randomize_pow2.v
+++ b/test_regress/t/t_randomize_pow2.v
@@ -1,0 +1,44 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain.
+// SPDX-FileCopyrightText: 2026 PlanV GmbH
+// SPDX-License-Identifier: CC0-1.0
+
+// Test 2**n in constraints: ConstraintExprVisitor transforms 2**n -> 1<<n for SMT.
+// Only unsigned exponent variants (AstPow, AstPowSU) are supported.
+// Signed exponent variants (AstPowSS, AstPowUS) retain the CONSTRAINTIGN warning.
+
+class Pow2Test;
+  rand bit [3:0] n;
+  rand bit [15:0] result;
+
+  // AstPow (unsigned**unsigned): 2**n -> 1<<n
+  constraint c_pow2 {
+    n inside {[0:7]};
+    result == 16'(2**n);
+  }
+
+  function void check();
+    if (result !== (16'h1 << n)) begin
+      $display("FAIL: result=%0d expected 2**%0d=%0d", result, n, 16'h1 << n);
+      $stop;
+    end
+  endfunction
+endclass
+
+module t;
+  Pow2Test obj;
+
+  initial begin
+    obj = new;
+    repeat (20) begin
+      if (obj.randomize() == 0) begin
+        $display("FAIL: randomize() returned 0");
+        $stop;
+      end
+      obj.check();
+    end
+    $write("*-* All Finished *-*\n");
+    $finish;
+  end
+endmodule


### PR DESCRIPTION
## Summary

This patch adds support for `2**n` expressions in constraints where `n` is a
randomized variable. SMT-LIB2 has no power operator, but `2**n` is equivalent
to `1<<n` for non-negative exponents (SMT-LIB2 `bvshl`), and to `n>=0 ? 1<<n : 0`
for signed exponents per IEEE 1800-2023 ss11.4.3 (negative integer exponent gives 0).

This is a cleaner re-implementation of PR #6806, extended to cover all four
signedness variants (`**`, `**SS`, `**SU`, `**US`) and correcting the signed-exponent
semantics that the original PR missed.

**Now supported in constraints:**
- `2**n` (unsigned base, unsigned exponent) → `1<<n`
- `2**n` (signed base, unsigned exponent) → `1<<n`
- `2**n` (signed base, signed exponent) → `n>=0 ? 1<<n : 0`
- `2**n` (unsigned base, signed exponent) → `n>=0 ? 1<<n : 0`

**Still unsupported:**
- `k**n` where k≠2 constant base with non-constant exponent (new distinct warning)
- `x**n` where x itself is a rand variable (non-constant base)
- Real-typed power (`2.0**n`)

## Reproducer

```systemverilog
class C;
  rand bit [3:0] n;
  rand bit [15:0] x;
  constraint c { n inside {[0:7]}; x == 2**n; }
endclass
module t;
  C obj;
  initial begin obj = new; void'(obj.randomize()); $finish; end
endmodule
```
On master:

```
%Warning-CONSTRAINTIGN: t.sv:4:42: Unsupported: Power (**) expression with non-constant exponent in constraint
```
## Changes

- ConstraintExprVisitor::handlePow (src/V3Randomize.cpp): adds a branch for constant base 2 with non-constant exponent, lowering to left-shift for unsigned exponents and to a guarded left-shift for signed exponents.
- handlePow: emits a distinct CONSTRAINTIGN message for constant non-2 base, separate from the non-constant-base case.

## Test

- Added test_regress/t/t_randomize_pow2.{v,py} — verifies both unsigned-exponent `(2**n with n: bit[3:0]`) and signed-exponent (`2**n with n: int signed, n inside {[-2:7]}`) cases produce correct values after randomize().
- Added test_regress/t/t_constraint_non_base2_pow_unsup.{v,py,out} — verifies that `3**n` (constant non-2 base) still emits `CONSTRAINTIGN`.

-----
Developed by PlanV GmbH, assisted with Claude Code.

Reviewed by YilouWang.