### PR TITLE
docs (warnings): fix typo

### DIFF
--- a/docs/guide/warnings.rst
+++ b/docs/guide/warnings.rst
@@ -2603,7 +2603,7 @@ List Of Warnings
    Issued if neither :vlopt:`--sched-zero-delay`, nor
    :vlopt:`--sched-zero-delay` is used on the command line, and the input does
    not contain a compile time known ``#0`` delay, but does contain a
-   ``#(expressin)`` where the delay value cannot be determined at compile time.
+   ``#(expression)`` where the delay value cannot be determined at compile time.
    Passing :vlopt:`--no-sched-zero-delay` can improve runtime performance if
    variable delays are all known to be non-zero at runtime.
 


### PR DESCRIPTION
Fix a typo in the description for zero-delay warning.
