### PR TITLE
Fix modification of members of object with const handle

### DIFF
--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -218,6 +218,7 @@ class WidthVisitor final : public VNVisitor {
     bool m_underFork = false;  // Visiting under a fork
     bool m_underSExpr = false;  // Visiting under a sequence expression
     bool m_underPackedArray = false;  // Visiting under a AstPackArrayDType
+    bool m_underMemberSel = false; // Viting under a MemberSel
     bool m_hasNamedType = false;  // Packed array is defined using named type
     AstNode* m_seqUnsupp = nullptr;  // Property has unsupported node
     bool m_hasSExpr = false;  // Property has a sequence expression
@@ -2908,7 +2909,7 @@ class WidthVisitor final : public VNVisitor {
         } else if (nodep->access().isWriteOrRW() && nodep->varp()->isConst() && !m_paramsOnly
                    && (!m_ftaskp || !m_ftaskp->isConstructor())
                    && !VN_IS(m_procedurep, InitialAutomatic) && !VN_IS(m_procedurep, InitialStatic)
-                   && !nodep->isClassHandleValue()) {
+                   && !m_underMemberSel) {
             // Too loose, but need to allow our generated first assignment
             // Move this to a property of the AstInitial block
             nodep->v3warn(E_CONSTWRITTEN, "Writing to 'const' data-typed variable "
@@ -3544,6 +3545,8 @@ class WidthVisitor final : public VNVisitor {
     void visit(AstMemberSel* nodep) override {
         UINFO(5, "   MEMBERSEL " << nodep);
         if (nodep->didWidth()) return;
+        VL_RESTORER(m_underMemberSel);
+        m_underMemberSel = true;
         UINFOTREE(9, nodep, "", "mbs-in");
         userIterateChildren(nodep, WidthVP{SELF, BOTH}.p());
         UINFOTREE(9, nodep, "", "mbs-ic");

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -2908,7 +2908,8 @@ class WidthVisitor final : public VNVisitor {
         } else if (nodep->access().isWriteOrRW() && nodep->varp()->isConst() && !m_paramsOnly
                    && (!m_ftaskp || !m_ftaskp->isConstructor())
                    && !VN_IS(m_procedurep, InitialAutomatic)
-                   && !VN_IS(m_procedurep, InitialStatic)) {
+                   && !VN_IS(m_procedurep, InitialStatic)
+                   && !nodep->isClassHandleValue()) {
             // Too loose, but need to allow our generated first assignment
             // Move this to a property of the AstInitial block
             nodep->v3warn(E_CONSTWRITTEN, "Writing to 'const' data-typed variable "
@@ -3691,6 +3692,11 @@ class WidthVisitor final : public VNVisitor {
                         nodep->replaceWith(varRefp);
                         VL_DO_DANGLING(pushDeletep(nodep), nodep);
                         return true;
+                    }
+                    if (nodep->access().isWriteOrRW() && varp->isConst()) {
+                        nodep->v3warn(E_CONSTWRITTEN, "Writing to 'const' data-typed variable "
+                                                          << nodep->prettyNameQ()
+                                                          << " (IEEE 1800-2023 6.20.6)");
                     }
                     nodep->dtypep(foundp->dtypep());
                     nodep->varp(varp);

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -2907,8 +2907,7 @@ class WidthVisitor final : public VNVisitor {
             }
         } else if (nodep->access().isWriteOrRW() && nodep->varp()->isConst() && !m_paramsOnly
                    && (!m_ftaskp || !m_ftaskp->isConstructor())
-                   && !VN_IS(m_procedurep, InitialAutomatic)
-                   && !VN_IS(m_procedurep, InitialStatic)
+                   && !VN_IS(m_procedurep, InitialAutomatic) && !VN_IS(m_procedurep, InitialStatic)
                    && !nodep->isClassHandleValue()) {
             // Too loose, but need to allow our generated first assignment
             // Move this to a property of the AstInitial block

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -218,7 +218,7 @@ class WidthVisitor final : public VNVisitor {
     bool m_underFork = false;  // Visiting under a fork
     bool m_underSExpr = false;  // Visiting under a sequence expression
     bool m_underPackedArray = false;  // Visiting under a AstPackArrayDType
-    bool m_underMemberSel = false; // Viting under a MemberSel
+    bool m_underMemberSel = false;  // Viting under a MemberSel
     bool m_hasNamedType = false;  // Packed array is defined using named type
     AstNode* m_seqUnsupp = nullptr;  // Property has unsupported node
     bool m_hasSExpr = false;  // Property has a sequence expression

--- a/test_regress/t/t_const_handle.py
+++ b/test_regress/t/t_const_handle.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile()
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_const_handle.v
+++ b/test_regress/t/t_const_handle.v
@@ -1,0 +1,25 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain.
+// SPDX-FileCopyrightText: 2026 Antmicro
+// SPDX-License-Identifier: CC0-1.0
+
+// verilog_format: off
+`define stop $stop
+`define checkd(gotv,expv) do if ((gotv) !== (expv)) begin $write("%%Error: %s:%0d:  got=%0d exp=%0d\n", `__FILE__,`__LINE__, (gotv), (expv)); `stop; end while(0);
+// verilog_format: on
+
+class Cls;
+  int x;
+endclass
+
+module t;
+  initial begin
+    const automatic Cls cls = new;
+    cls.x = 1;
+    `checkd(cls.x, 1);
+
+    $write("*-* All Finished *-*\n");
+    $finish;
+  end
+endmodule

--- a/test_regress/t/t_const_handle_bad.out
+++ b/test_regress/t/t_const_handle_bad.out
@@ -1,0 +1,14 @@
+%Error-CONSTWRITTEN: t/t_const_handle_bad.v:15:9: Writing to 'const' data-typed variable 'x' (IEEE 1800-2023 6.20.6)
+                                                : ... note: In instance 't'
+   15 |     cls.x = 1;
+      |         ^
+                     ... For error description see https://verilator.org/warn/CONSTWRITTEN?v=latest
+%Error-CONSTWRITTEN: t/t_const_handle_bad.v:16:10: Writing to 'const' data-typed variable 'x' (IEEE 1800-2023 6.20.6)
+                                                 : ... note: In instance 't'
+   16 |     cls2.x = 1;
+      |          ^
+%Error-CONSTWRITTEN: t/t_const_handle_bad.v:18:5: Writing to 'const' data-typed variable 'cls' (IEEE 1800-2023 6.20.6)
+                                                : ... note: In instance 't'
+   18 |     cls = cls2;
+      |     ^~~
+%Error: Exiting due to

--- a/test_regress/t/t_const_handle_bad.py
+++ b/test_regress/t/t_const_handle_bad.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('vlt')
+
+test.lint(fails=True, expect_filename=test.golden_filename)
+
+test.passes()

--- a/test_regress/t/t_const_handle_bad.v
+++ b/test_regress/t/t_const_handle_bad.v
@@ -1,0 +1,21 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain.
+// SPDX-FileCopyrightText: 2026 Antmicro
+// SPDX-License-Identifier: CC0-1.0
+
+class Cls;
+  const int x;
+endclass
+
+module t;
+  initial begin
+    const automatic Cls cls = new;
+    automatic Cls cls2 = new;
+    cls.x = 1;
+    cls2.x = 1;
+
+    cls = cls2;
+    cls2 = cls;
+  end
+endmodule


### PR DESCRIPTION
This PR fixes modification of members of an object if the object handle is declared as const. According to standard it should be possible if the member is not declared const.

Example:

~~~systemverilog
class Cls;
  int x;
endclass

module t;
  initial begin
    const automatic Cls cls = new;
    cls.x = 1;
  end
endmodule
~~~

Before this resulted in error.

~~~
%Error-CONSTWRITTEN: ex/const_handle.sv:8:5: Writing to 'const' data-typed variable 'cls' (IEEE 1800-2023 6.20.6)
                                           : ... note: In instance 't'
    8 |     cls.x = 1;
      |     ^~~
                     ... For error description see https://verilator.org/warn/CONSTWRITTEN?v=5.047
%Error: Exiting due to 1 error(s)
~~~

Now it works properly because `x` is not declared const.
