### PR TITLE
Fix inline constraint on array-indexed randomize target (#7431)

### DIFF
--- a/src/V3LinkWith.cpp
+++ b/src/V3LinkWith.cpp
@@ -107,7 +107,7 @@ class LinkWithVisitor final : public VNVisitor {
     }
 
     void visit(AstMemberSel* nodep) override {
-        if (m_inRandomizeWith && nodep->fromp()->isSame(m_currentRandomizeSelectp)) {
+        if (m_inRandomizeWith && nodep->fromp()->sameTree(m_currentRandomizeSelectp)) {
             // Replace member selects to the element
             // on which the randomize() is called with LambdaArgRef
             // This allows V3Randomize to work properly when

--- a/src/V3Randomize.cpp
+++ b/src/V3Randomize.cpp
@@ -1124,10 +1124,9 @@ class ConstraintExprVisitor final : public VNVisitor {
         // For global constraints: check shared path-level set
         // For inline constraints: check per-instance set (each __Vrandwith has own randomizer)
         // For class-level constraints: check varp->user3()
-        const bool alreadyWritten
-            = isGlobalConstrained ? m_writtenVars.count(smtName) > 0
-              : m_inlineInitTaskp ? m_inlineWrittenVars.count(smtName) > 0
-                                  : varp->user3();
+        const bool alreadyWritten = isGlobalConstrained ? m_writtenVars.count(smtName) > 0
+                                    : m_inlineInitTaskp ? m_inlineWrittenVars.count(smtName) > 0
+                                                        : varp->user3();
         const bool shouldWriteVar = !alreadyWritten;
         if (shouldWriteVar) {
             // Track this variable path as written

--- a/src/V3Randomize.cpp
+++ b/src/V3Randomize.cpp
@@ -740,6 +740,7 @@ class ConstraintExprVisitor final : public VNVisitor {
                                // (used to format "%s.%s" for struct arrays)
     std::set<std::string>& m_writtenVars;  // Track which variable paths have write_var generated
                                            // (shared across all constraints)
+    std::set<std::string> m_inlineWrittenVars;  // Per-instance tracking for inline constraints
     std::set<AstVar*>* m_sizeConstrainedArraysp = nullptr;  // Arrays with size+element constraints
 
     // Build full path for a MemberSel chain (e.g., "obj.l2.l3.l4")
@@ -1120,14 +1121,18 @@ class ConstraintExprVisitor final : public VNVisitor {
         // else: Global constraints keep nodep alive for write_var processing
         relinker.relink(exprp);
 
-        // For global constraints: check if this specific path has been written
-        // For normal constraints: only call write_var if varp->user3() is not set
+        // For global constraints: check shared path-level set
+        // For inline constraints: check per-instance set (each __Vrandwith has own randomizer)
+        // For class-level constraints: check varp->user3()
         const bool alreadyWritten
-            = isGlobalConstrained ? m_writtenVars.count(smtName) > 0 : varp->user3();
+            = isGlobalConstrained ? m_writtenVars.count(smtName) > 0
+              : m_inlineInitTaskp ? m_inlineWrittenVars.count(smtName) > 0
+                                  : varp->user3();
         const bool shouldWriteVar = !alreadyWritten;
         if (shouldWriteVar) {
             // Track this variable path as written
             if (isGlobalConstrained) m_writtenVars.insert(smtName);
+            if (m_inlineInitTaskp) m_inlineWrittenVars.insert(smtName);
             // For global constraints, delete nodep after processing
             if (isGlobalConstrained && !nodep->backp()) VL_DO_DANGLING(pushDeletep(nodep), nodep);
 

--- a/test_regress/t/t_constraint_foreach_classref.v
+++ b/test_regress/t/t_constraint_foreach_classref.v
@@ -106,14 +106,26 @@ module t;
     end
 
     // === Test 4: Array of objects with inline constraint for sub-object members ===
-    // Verifies that member resolution works when randomize() target is array-indexed
-    // (regression test for verilator/verilator#7431)
+    // Verifies member resolution AND runtime enforcement when randomize()
+    // target is array-indexed (regression test for verilator/verilator#7431)
     foreach (od_arr[i]) begin
       od_arr[i] = new(3);
       assert(od_arr[i].randomize() with {
         od_arr[i].items[0].val > 8'd10;
         od_arr[i].items[0].val < 8'd200;
+        od_arr[i].items[0].tag > 0;
       } != 0);
+
+      if (!(od_arr[i].items[0].val > 10 && od_arr[i].items[0].val < 200)) begin
+        $display("FAIL: od_arr[%0d].items[0].val=%0d out of range",
+                 i, od_arr[i].items[0].val);
+        $stop;
+      end
+      if (od_arr[i].items[0].tag == 0) begin
+        $display("FAIL: od_arr[%0d].items[0].tag=%0d should be > 0",
+                 i, od_arr[i].items[0].tag);
+        $stop;
+      end
     end
 
     $write("*-* All Finished *-*\n");

--- a/test_regress/t/t_constraint_foreach_classref.v
+++ b/test_regress/t/t_constraint_foreach_classref.v
@@ -39,6 +39,7 @@ endclass
 
 module t;
   OuterDyn od;
+  OuterDyn od_arr[5];
   OuterQueue oq;
 
   initial begin
@@ -102,6 +103,17 @@ module t;
         $display("FAIL: queue items[%0d].tag=%0d should be > 0", i, oq.items[i].tag);
         $stop;
       end
+    end
+
+    // === Test 4: Array of objects with inline constraint for sub-object members ===
+    // Verifies that member resolution works when randomize() target is array-indexed
+    // (regression test for verilator/verilator#7431)
+    foreach (od_arr[i]) begin
+      od_arr[i] = new(3);
+      assert(od_arr[i].randomize() with {
+        od_arr[i].items[0].val > 8'd10;
+        od_arr[i].items[0].val < 8'd200;
+      } != 0);
     end
 
     $write("*-* All Finished *-*\n");


### PR DESCRIPTION
## Summary

This patch fixes `randomize() with` when the randomize target is an array-indexed class object. Referencing sub-object members through the receiver (e.g., `od_arr[i].items[0].val`) inside the `with` clause incorrectly reports "Member not found in class". Additionally, when the same class has multiple inline constraint call sites, `write_var` registration is skipped for subsequent call sites, causing constraints to be silently ignored at runtime. Fixes #7431.

## Reproducer

```systemverilog
class Inner;
  rand bit [7:0] val;
  rand bit [3:0] tag;
  function new(); val = 0; tag = 0; endfunction
endclass

class Outer;
  rand Inner items[];
  function new(int n = 3);
    items = new[n];
    foreach (items[i]) items[i] = new();
  endfunction
endclass

module t;
  Outer od;
  Outer od_arr[5];
  initial begin
    od = new(3);
    assert(od.randomize() with {
      foreach (items[i]) { items[i].val > 10; }
    } != 0);
    foreach (od_arr[i]) begin
      od_arr[i] = new(3);
      assert(od_arr[i].randomize() with {
        od_arr[i].items[0].val > 8'd10;
        od_arr[i].items[0].tag > 0;
      } != 0);
    end
    $finish;
  end
endmodule
```

On master:
```
%Error: test.v:21:35: Member 'val' not found in class 'Outer'
```

## Changes

- `V3LinkWith.cpp`: Replace `isSame()` with `sameTree()` in `visit(AstMemberSel*)` to compare the full expression subtree when matching `MemberSel.fromp()` against the randomize receiver.
- `V3Randomize.cpp`: Add per-instance `m_inlineWrittenVars` set in `ConstraintExprVisitor` for `write_var` dedup in inline constraints, instead of using the global `varp->user3()` flag which is shared across all `__Vrandwith` functions.

## Test

- Extended `test_regress/t/t_constraint_foreach_classref.v` -- added Test 4: array of objects with inline constraint referencing sub-object members through array-indexed receiver, with runtime value verification.

---
Developed by PlanV GmbH, assisted with Claude Code.

Reviewed by YilouWang.