### PR TITLE
Fsm coverage - new print summary

### DIFF
--- a/src/VlcTop.cpp
+++ b/src/VlcTop.cpp
@@ -372,7 +372,8 @@ void VlcTop::annotate(const string& dirname) {
 }
 
 void VlcTop::printTypeSummary() {
-    static const std::vector<std::string> orderedTypes = {"line", "toggle", "branch", "expr"};
+    static const std::vector<std::string> orderedTypes = {"line", "toggle", "branch", "expr",
+                                                          "fsm_state", "fsm_arc"};
     std::map<std::string, std::pair<uint64_t, uint64_t>> tally;
     for (const auto& i : m_points) {
         const VlcPoint& pt = m_points.pointNumber(i.second);
@@ -385,6 +386,8 @@ void VlcTop::printTypeSummary() {
     std::set<std::string> printed;
     size_t typeWidth = 0;
     size_t countWidth = 0;
+    for (const string& type : orderedTypes) typeWidth = std::max(typeWidth, type.size());
+    countWidth = std::max(countWidth, cvtToStr(0).size());
     for (const auto& it : tally) {
         typeWidth = std::max(typeWidth, it.first.size());
         countWidth = std::max(countWidth, cvtToStr(it.second.first).size());
@@ -393,10 +396,9 @@ void VlcTop::printTypeSummary() {
     std::cout << "Coverage Summary:\n";
     for (const string& type : orderedTypes) {
         const auto it = tally.find(type);
-        if (it == tally.end()) continue;
         printed.insert(type);
-        const uint64_t hit = it->second.first;
-        const uint64_t total = it->second.second;
+        const uint64_t hit = (it == tally.end()) ? 0 : it->second.first;
+        const uint64_t total = (it == tally.end()) ? 0 : it->second.second;
         const double pct
             = total ? (100.0 * static_cast<double>(hit) / static_cast<double>(total)) : 0.0;
         std::cout << "  " << std::left << std::setw(typeWidth) << type << " : " << std::right

--- a/test_regress/t/t_cover_fsm_basic.py
+++ b/test_regress/t/t_cover_fsm_basic.py
@@ -19,6 +19,22 @@ test.execute()
 
 test.run(cmd=[
     os.environ["VERILATOR_ROOT"] + "/bin/verilator_coverage",
+    test.obj_dir + "/coverage.dat",
+],
+         logfile=test.obj_dir + "/summary.log",
+         tee=False,
+         verilator_run=True)
+
+test.file_grep(test.obj_dir + "/summary.log", r"Coverage Summary:")
+test.file_grep(test.obj_dir + "/summary.log", r"line")
+test.file_grep(test.obj_dir + "/summary.log", r"toggle")
+test.file_grep(test.obj_dir + "/summary.log", r"branch")
+test.file_grep(test.obj_dir + "/summary.log", r"expr")
+test.file_grep(test.obj_dir + "/summary.log", r"fsm_state")
+test.file_grep(test.obj_dir + "/summary.log", r"fsm_arc")
+
+test.run(cmd=[
+    os.environ["VERILATOR_ROOT"] + "/bin/verilator_coverage",
     "--annotate",
     test.obj_dir + "/annotated",
     test.obj_dir + "/coverage.dat",

--- a/test_regress/t/t_cover_fsm_basic.py
+++ b/test_regress/t/t_cover_fsm_basic.py
@@ -25,13 +25,7 @@ test.run(cmd=[
          tee=False,
          verilator_run=True)
 
-test.file_grep(test.obj_dir + "/summary.log", r"Coverage Summary:")
-test.file_grep(test.obj_dir + "/summary.log", r"line")
-test.file_grep(test.obj_dir + "/summary.log", r"toggle")
-test.file_grep(test.obj_dir + "/summary.log", r"branch")
-test.file_grep(test.obj_dir + "/summary.log", r"expr")
-test.file_grep(test.obj_dir + "/summary.log", r"fsm_state")
-test.file_grep(test.obj_dir + "/summary.log", r"fsm_arc")
+test.files_identical(test.obj_dir + "/summary.log", "t/" + test.name + "_summary.out")
 
 test.run(cmd=[
     os.environ["VERILATOR_ROOT"] + "/bin/verilator_coverage",

--- a/test_regress/t/t_cover_fsm_basic_summary.out
+++ b/test_regress/t/t_cover_fsm_basic_summary.out
@@ -1,0 +1,7 @@
+Coverage Summary:
+  line      : 0.0% (0/0)
+  toggle    : 0.0% (0/0)
+  branch    : 0.0% (0/0)
+  expr      : 0.0% (0/0)
+  fsm_state : 50.0% (2/4)
+  fsm_arc   : 100.0% (5/5)

--- a/test_regress/t/t_cover_fsm_reset.py
+++ b/test_regress/t/t_cover_fsm_reset.py
@@ -22,7 +22,17 @@ test.run(cmd=[
     "--include-reset-arcs",
     test.obj_dir + "/coverage.dat",
 ],
+         logfile=test.obj_dir + "/summary.log",
+         tee=False,
          verilator_run=True)
+
+test.file_grep(test.obj_dir + "/summary.log", r"Coverage Summary:")
+test.file_grep(test.obj_dir + "/summary.log", r"line")
+test.file_grep(test.obj_dir + "/summary.log", r"toggle")
+test.file_grep(test.obj_dir + "/summary.log", r"branch")
+test.file_grep(test.obj_dir + "/summary.log", r"expr")
+test.file_grep(test.obj_dir + "/summary.log", r"fsm_state")
+test.file_grep(test.obj_dir + "/summary.log", r"fsm_arc")
 
 test.run(cmd=[
     os.environ["VERILATOR_ROOT"] + "/bin/verilator_coverage",

--- a/test_regress/t/t_cover_fsm_reset.py
+++ b/test_regress/t/t_cover_fsm_reset.py
@@ -26,13 +26,7 @@ test.run(cmd=[
          tee=False,
          verilator_run=True)
 
-test.file_grep(test.obj_dir + "/summary.log", r"Coverage Summary:")
-test.file_grep(test.obj_dir + "/summary.log", r"line")
-test.file_grep(test.obj_dir + "/summary.log", r"toggle")
-test.file_grep(test.obj_dir + "/summary.log", r"branch")
-test.file_grep(test.obj_dir + "/summary.log", r"expr")
-test.file_grep(test.obj_dir + "/summary.log", r"fsm_state")
-test.file_grep(test.obj_dir + "/summary.log", r"fsm_arc")
+test.files_identical(test.obj_dir + "/summary.log", "t/" + test.name + "_summary.out")
 
 test.run(cmd=[
     os.environ["VERILATOR_ROOT"] + "/bin/verilator_coverage",

--- a/test_regress/t/t_cover_fsm_reset_summary.out
+++ b/test_regress/t/t_cover_fsm_reset_summary.out
@@ -1,0 +1,7 @@
+Coverage Summary:
+  line      : 100.0% (8/8)
+  toggle    : 75.0% (6/8)
+  branch    : 100.0% (8/8)
+  expr      : 0.0% (0/0)
+  fsm_state : 50.0% (2/4)
+  fsm_arc   : 100.0% (4/4)

--- a/test_regress/t/t_vlcov_summary_typed.out
+++ b/test_regress/t/t_vlcov_summary_typed.out
@@ -3,3 +3,5 @@ Coverage Summary:
   toggle : 33.3% ( 35/105)
   branch : 78.1% ( 50/ 64)
   expr   : 66.7% (  8/ 12)
+  fsm_state : 0.0% (  0/  0)
+  fsm_arc   : 0.0% (  0/  0)

--- a/test_regress/t/t_vlcov_summary_typed.out
+++ b/test_regress/t/t_vlcov_summary_typed.out
@@ -1,7 +1,7 @@
 Coverage Summary:
-  line   : 88.6% ( 39/ 44)
-  toggle : 33.3% ( 35/105)
-  branch : 78.1% ( 50/ 64)
-  expr   : 66.7% (  8/ 12)
+  line      : 88.6% ( 39/ 44)
+  toggle    : 33.3% ( 35/105)
+  branch    : 78.1% ( 50/ 64)
+  expr      : 66.7% (  8/ 12)
   fsm_state : 0.0% (  0/  0)
   fsm_arc   : 0.0% (  0/  0)


### PR DESCRIPTION
This is a follow on PR to #7412. Needs 7412 merged
Updates print summary added in #7438 to now display `fsm_state` and `fsm_arc` coverage data. 
