### PR TITLE
Do not constifyParams for modvar clone in cellPinCleanup (V3Param)

### DIFF
--- a/src/V3Param.cpp
+++ b/src/V3Param.cpp
@@ -1470,7 +1470,6 @@ class ParamProcessor final {
                                 << pinp->prettyNameQ() << " of " << nodep->prettyNameQ());
                         });
                     }
-                    V3Const::constifyParamsEdit(cloneVarp);
                     if (AstConst* const widthedp = VN_CAST(cloneVarp->valuep(), Const)) {
                         // Stamp the port's type on the const so equal values hash the same.
                         if (cloneVarp->dtypep()) widthedp->dtypep(cloneVarp->dtypep());


### PR DESCRIPTION
This change seems to fix #7463 for me. The AST modifications to the base module occur during that call. With this, the base module (for the example in the issue) still has the full expressions:
```
    1: MODULE (E) {e1ai}  test  L2 D3 [PAR-TEMPL] [1ps]
    1:2: VAR (L) {e2at} @dt=0@  width [CONST] [UINIT] [VSTATICI]  GPARAM
    1:2:1: BASICDTYPE (N) {e2ap} @dt=this@(sw32)  int kwd=int range=[31:0]
    1:2:3: CONST (O) {e2bb} @dt=(H)@(G/swu32/5)  ?32?sh10
    1:2: VAR (P) {e3at} @dt=0@  width2 [CONST] [UINIT] [VSTATICI]  GPARAM
    1:2:1: BASICDTYPE (Q) {e3ap} @dt=this@(sw32)  int kwd=int range=[31:0]
    1:2:3: ADD (R) {e3bh} @dt=0@
    1:2:3:1: VARREF (VB) {e3bc} @dt=0@  width [RV] <- VAR (L) {e2at} @dt=0@  width [CONST] [UINIT] [VSTATICI]  GPARAM
    1:2:3:2: CONST (T) {e3bi} @dt=(U)@(G/swu32/4)  ?32?sh8
    1:2: PARAMTYPEDTYPE (WB) {e4au} @dt=0@  data_t -> REQUIREDTYPE (XB) {e4au} @dt=0@
    1:2:1: REQUIREDTYPE (XB) {e4au} @dt=0@
    1:2:1:1: BASICDTYPE (X) {e4bd} @dt=this@(w1)  logic kwd=logic
    1:2:1:1:1: RANGE (Y) {e4bi}
    1:2:1:1:1:1: SUB (Z) {e4bp} @dt=0@
    1:2:1:1:1:1:1: VARREF (YB) {e4bj} @dt=0@  width2 [RV] <- VAR (P) {e3at} @dt=0@  width2 [CONST] [UINIT] [VSTATICI]  GPARAM
    1:2:1:1:1:1:2: CONST (BB) {e4bq} @dt=(CB)@(G/swu32/1)  ?32?sh1
    1:2:1:1:1:2: CONST (DB) {e4bs} @dt=(CB)@(G/swu32/1)  ?32?sh0
...
```
And the parametrized module is fully constified:
```
    1: MODULE (AC) {e1ai}  test__W18_D0  L2 D2 [1ps]
    1:2: VAR (V) {e2at} @dt=(JB)@(sw32)  width [CONST] [UINIT] [VSTATICI]  GPARAM
    1:2:3: CONST (BC) {e12ap} @dt=(H)@(G/swu32/5)  ?32?sh18
    1:2: VAR (CC) {e3at} @dt=(AB)@(sw32)  width2 [CONST] [UINIT] [VSTATICI]  GPARAM
    1:2:3: CONST (G) {e3bh} @dt=(AB)@(sw32)  32'h20
    1:2: PARAMTYPEDTYPE (DC) {e4au} @dt=(S)@(w32)  data_t -> BASICDTYPE (S) {e4bd} @dt=this@(w32)  logic kwd=logic range=[31:0]
    1:2: VAR (EC) {e5aw} @dt=(FC)@(w32)ref  data [CONST] [UINIT] [VSTATICI]  GPARAM
    1:2:3: CONST (GC) {e12ba} @dt=(K)@(G/w32)  32'h0
```

However, I'm not sure if this has the unintended consequence and undoes some of the stated goals of #7387 or subsequent PRs/commits. The parametrized module name is different.