### PR TITLE
Internals: Annotate AstNode classes to generate matching DfgVertex

### DIFF
--- a/src/V3AstNodeExpr.h
+++ b/src/V3AstNodeExpr.h
@@ -2889,6 +2889,7 @@ public:
 };
 class AstConcat final : public AstNodeBiop {
     // If you're looking for {#{}}, see AstReplicate
+    // @astgen makeDfgVertex
 public:
     AstConcat(FileLine* fl, AstNodeExpr* lhsp, AstNodeExpr* rhsp)
         : ASTGEN_SUPER_Concat(fl, lhsp, rhsp) {
@@ -2938,6 +2939,7 @@ public:
     bool stringFlavor() const override { return true; }
 };
 class AstDiv final : public AstNodeBiop {
+    // @astgen makeDfgVertex
 public:
     AstDiv(FileLine* fl, AstNodeExpr* lhsp, AstNodeExpr* rhsp)
         : ASTGEN_SUPER_Div(fl, lhsp, rhsp) {
@@ -2980,6 +2982,7 @@ public:
     bool doubleFlavor() const override { return true; }
 };
 class AstDivS final : public AstNodeBiop {
+    // @astgen makeDfgVertex
 public:
     AstDivS(FileLine* fl, AstNodeExpr* lhsp, AstNodeExpr* rhsp)
         : ASTGEN_SUPER_DivS(fl, lhsp, rhsp) {
@@ -3003,6 +3006,7 @@ public:
 };
 class AstEqWild final : public AstNodeBiop {
     // Note wildcard operator rhs differs from lhs
+    // @astgen makeDfgVertex
 public:
     AstEqWild(FileLine* fl, AstNodeExpr* lhsp, AstNodeExpr* rhsp)
         : ASTGEN_SUPER_EqWild(fl, lhsp, rhsp) {
@@ -3109,6 +3113,7 @@ public:
     bool sizeMattersRhs() const override { return false; }
 };
 class AstGt final : public AstNodeBiop {
+    // @astgen makeDfgVertex
 public:
     AstGt(FileLine* fl, AstNodeExpr* lhsp, AstNodeExpr* rhsp)
         : ASTGEN_SUPER_Gt(fl, lhsp, rhsp) {
@@ -3171,6 +3176,7 @@ public:
     bool stringFlavor() const override { return true; }
 };
 class AstGtS final : public AstNodeBiop {
+    // @astgen makeDfgVertex
 public:
     AstGtS(FileLine* fl, AstNodeExpr* lhsp, AstNodeExpr* rhsp)
         : ASTGEN_SUPER_GtS(fl, lhsp, rhsp) {
@@ -3192,6 +3198,7 @@ public:
     bool signedFlavor() const override { return true; }
 };
 class AstGte final : public AstNodeBiop {
+    // @astgen makeDfgVertex
 public:
     AstGte(FileLine* fl, AstNodeExpr* lhsp, AstNodeExpr* rhsp)
         : ASTGEN_SUPER_Gte(fl, lhsp, rhsp) {
@@ -3254,6 +3261,7 @@ public:
     bool stringFlavor() const override { return true; }
 };
 class AstGteS final : public AstNodeBiop {
+    // @astgen makeDfgVertex
 public:
     AstGteS(FileLine* fl, AstNodeExpr* lhsp, AstNodeExpr* rhsp)
         : ASTGEN_SUPER_GteS(fl, lhsp, rhsp) {
@@ -3275,6 +3283,7 @@ public:
     bool signedFlavor() const override { return true; }
 };
 class AstLogAnd final : public AstNodeBiop {
+    // @astgen makeDfgVertex
 public:
     AstLogAnd(FileLine* fl, AstNodeExpr* lhsp, AstNodeExpr* rhsp)
         : ASTGEN_SUPER_LogAnd(fl, lhsp, rhsp) {
@@ -3296,6 +3305,7 @@ public:
     int instrCount() const override { return widthInstrs() + INSTR_COUNT_BRANCH; }
 };
 class AstLogIf final : public AstNodeBiop {
+    // @astgen makeDfgVertex
 public:
     AstLogIf(FileLine* fl, AstNodeExpr* lhsp, AstNodeExpr* rhsp)
         : ASTGEN_SUPER_LogIf(fl, lhsp, rhsp) {
@@ -3317,6 +3327,7 @@ public:
     int instrCount() const override { return widthInstrs() + INSTR_COUNT_BRANCH; }
 };
 class AstLogOr final : public AstNodeBiop {
+    // @astgen makeDfgVertex
 public:
     AstLogOr(FileLine* fl, AstNodeExpr* lhsp, AstNodeExpr* rhsp)
         : ASTGEN_SUPER_LogOr(fl, lhsp, rhsp) {
@@ -3338,6 +3349,7 @@ public:
     int instrCount() const override { return widthInstrs() + INSTR_COUNT_BRANCH; }
 };
 class AstLt final : public AstNodeBiop {
+    // @astgen makeDfgVertex
 public:
     AstLt(FileLine* fl, AstNodeExpr* lhsp, AstNodeExpr* rhsp)
         : ASTGEN_SUPER_Lt(fl, lhsp, rhsp) {
@@ -3400,6 +3412,7 @@ public:
     bool stringFlavor() const override { return true; }
 };
 class AstLtS final : public AstNodeBiop {
+    // @astgen makeDfgVertex
 public:
     AstLtS(FileLine* fl, AstNodeExpr* lhsp, AstNodeExpr* rhsp)
         : ASTGEN_SUPER_LtS(fl, lhsp, rhsp) {
@@ -3421,6 +3434,7 @@ public:
     bool signedFlavor() const override { return true; }
 };
 class AstLte final : public AstNodeBiop {
+    // @astgen makeDfgVertex
 public:
     AstLte(FileLine* fl, AstNodeExpr* lhsp, AstNodeExpr* rhsp)
         : ASTGEN_SUPER_Lte(fl, lhsp, rhsp) {
@@ -3483,6 +3497,7 @@ public:
     bool stringFlavor() const override { return true; }
 };
 class AstLteS final : public AstNodeBiop {
+    // @astgen makeDfgVertex
 public:
     AstLteS(FileLine* fl, AstNodeExpr* lhsp, AstNodeExpr* rhsp)
         : ASTGEN_SUPER_LteS(fl, lhsp, rhsp) {
@@ -3504,6 +3519,7 @@ public:
     bool signedFlavor() const override { return true; }
 };
 class AstModDiv final : public AstNodeBiop {
+    // @astgen makeDfgVertex
 public:
     AstModDiv(FileLine* fl, AstNodeExpr* lhsp, AstNodeExpr* rhsp)
         : ASTGEN_SUPER_ModDiv(fl, lhsp, rhsp) {
@@ -3525,6 +3541,7 @@ public:
     int instrCount() const override { return widthInstrs() * INSTR_COUNT_INT_DIV; }
 };
 class AstModDivS final : public AstNodeBiop {
+    // @astgen makeDfgVertex
 public:
     AstModDivS(FileLine* fl, AstNodeExpr* lhsp, AstNodeExpr* rhsp)
         : ASTGEN_SUPER_ModDivS(fl, lhsp, rhsp) {
@@ -3547,6 +3564,7 @@ public:
     bool signedFlavor() const override { return true; }
 };
 class AstNeqWild final : public AstNodeBiop {
+    // @astgen makeDfgVertex
 public:
     AstNeqWild(FileLine* fl, AstNodeExpr* lhsp, AstNodeExpr* rhsp)
         : ASTGEN_SUPER_NeqWild(fl, lhsp, rhsp) {
@@ -3566,6 +3584,7 @@ public:
     bool sizeMattersRhs() const override { return false; }
 };
 class AstPow final : public AstNodeBiop {
+    // @astgen makeDfgVertex
 public:
     AstPow(FileLine* fl, AstNodeExpr* lhsp, AstNodeExpr* rhsp)
         : ASTGEN_SUPER_Pow(fl, lhsp, rhsp) {
@@ -3606,6 +3625,7 @@ public:
     bool doubleFlavor() const override { return true; }
 };
 class AstPowSS final : public AstNodeBiop {
+    // @astgen makeDfgVertex
 public:
     AstPowSS(FileLine* fl, AstNodeExpr* lhsp, AstNodeExpr* rhsp)
         : ASTGEN_SUPER_PowSS(fl, lhsp, rhsp) {
@@ -3627,6 +3647,7 @@ public:
     bool signedFlavor() const override { return true; }
 };
 class AstPowSU final : public AstNodeBiop {
+    // @astgen makeDfgVertex
 public:
     AstPowSU(FileLine* fl, AstNodeExpr* lhsp, AstNodeExpr* rhsp)
         : ASTGEN_SUPER_PowSU(fl, lhsp, rhsp) {
@@ -3648,6 +3669,7 @@ public:
     bool signedFlavor() const override { return true; }
 };
 class AstPowUS final : public AstNodeBiop {
+    // @astgen makeDfgVertex
 public:
     AstPowUS(FileLine* fl, AstNodeExpr* lhsp, AstNodeExpr* rhsp)
         : ASTGEN_SUPER_PowUS(fl, lhsp, rhsp) {
@@ -3673,6 +3695,7 @@ class AstReplicate final : public AstNodeBiop {
     // Verilog {rhs{lhs}} - Note rhsp() is the replicate value, not the lhsp()
     // @astgen alias op1 := srcp
     // @astgen alias op2 := countp
+    // @astgen makeDfgVertex
 public:
     AstReplicate(FileLine* fl, AstNodeExpr* lhsp, AstNodeExpr* rhsp)
         : ASTGEN_SUPER_Replicate(fl, lhsp, rhsp) {
@@ -3877,6 +3900,7 @@ public:
     void declElWidth(int flag) { m_declElWidth = flag; }
 };
 class AstShiftL final : public AstNodeBiop {
+    // @astgen makeDfgVertex
 public:
     AstShiftL(FileLine* fl, AstNodeExpr* lhsp, AstNodeExpr* rhsp, int setwidth = 0)
         : ASTGEN_SUPER_ShiftL(fl, lhsp, rhsp) {
@@ -3920,6 +3944,7 @@ public:
     bool sizeMattersRhs() const override { return false; }
 };
 class AstShiftR final : public AstNodeBiop {
+    // @astgen makeDfgVertex
 public:
     AstShiftR(FileLine* fl, AstNodeExpr* lhsp, AstNodeExpr* rhsp, int setwidth = 0)
         : ASTGEN_SUPER_ShiftR(fl, lhsp, rhsp) {
@@ -3967,6 +3992,7 @@ public:
 class AstShiftRS final : public AstNodeBiop {
     // Shift right with sign extension, >>> operator
     // Output data type's width determines which bit is used for sign extension
+    // @astgen makeDfgVertex
 public:
     AstShiftRS(FileLine* fl, AstNodeExpr* lhsp, AstNodeExpr* rhsp, int setwidth = 0)
         : ASTGEN_SUPER_ShiftRS(fl, lhsp, rhsp) {
@@ -4013,6 +4039,7 @@ public:
     bool signedFlavor() const override { return true; }
 };
 class AstSub final : public AstNodeBiop {
+    // @astgen makeDfgVertex
 public:
     AstSub(FileLine* fl, AstNodeExpr* lhsp, AstNodeExpr* rhsp)
         : ASTGEN_SUPER_Sub(fl, lhsp, rhsp) {
@@ -4078,6 +4105,7 @@ public:
 
 // === AstNodeBiCom ===
 class AstEq final : public AstNodeBiCom {
+    // @astgen makeDfgVertex
 public:
     AstEq(FileLine* fl, AstNodeExpr* lhsp, AstNodeExpr* rhsp)
         : ASTGEN_SUPER_Eq(fl, lhsp, rhsp) {
@@ -4100,6 +4128,7 @@ public:
     bool sizeMattersRhs() const override { return false; }
 };
 class AstEqCase final : public AstNodeBiCom {
+    // @astgen makeDfgVertex
 public:
     AstEqCase(FileLine* fl, AstNodeExpr* lhsp, AstNodeExpr* rhsp)
         : ASTGEN_SUPER_EqCase(fl, lhsp, rhsp) {
@@ -4180,6 +4209,7 @@ public:
     int instrCount() const override { return INSTR_COUNT_STR; }
 };
 class AstLogEq final : public AstNodeBiCom {
+    // @astgen makeDfgVertex
 public:
     AstLogEq(FileLine* fl, AstNodeExpr* lhsp, AstNodeExpr* rhsp)
         : ASTGEN_SUPER_LogEq(fl, lhsp, rhsp) {
@@ -4201,6 +4231,7 @@ public:
     int instrCount() const override { return widthInstrs() + INSTR_COUNT_BRANCH; }
 };
 class AstNeq final : public AstNodeBiCom {
+    // @astgen makeDfgVertex
 public:
     AstNeq(FileLine* fl, AstNodeExpr* lhsp, AstNodeExpr* rhsp)
         : ASTGEN_SUPER_Neq(fl, lhsp, rhsp) {
@@ -4222,6 +4253,7 @@ public:
     bool sizeMattersRhs() const override { return false; }
 };
 class AstNeqCase final : public AstNodeBiCom {
+    // @astgen makeDfgVertex
 public:
     AstNeqCase(FileLine* fl, AstNodeExpr* lhsp, AstNodeExpr* rhsp)
         : ASTGEN_SUPER_NeqCase(fl, lhsp, rhsp) {
@@ -4304,6 +4336,7 @@ public:
 
 // === AstNodeBiComAsv ===
 class AstAdd final : public AstNodeBiComAsv {
+    // @astgen makeDfgVertex
 public:
     AstAdd(FileLine* fl, AstNodeExpr* lhsp, AstNodeExpr* rhsp)
         : ASTGEN_SUPER_Add(fl, lhsp, rhsp) {
@@ -4345,6 +4378,7 @@ public:
     bool doubleFlavor() const override { return true; }
 };
 class AstAnd final : public AstNodeBiComAsv {
+    // @astgen makeDfgVertex
 public:
     AstAnd(FileLine* fl, AstNodeExpr* lhsp, AstNodeExpr* rhsp)
         : ASTGEN_SUPER_And(fl, lhsp, rhsp) {
@@ -4366,6 +4400,7 @@ public:
     const char* widthMismatch() const override VL_MT_STABLE;
 };
 class AstMul final : public AstNodeBiComAsv {
+    // @astgen makeDfgVertex
 public:
     AstMul(FileLine* fl, AstNodeExpr* lhsp, AstNodeExpr* rhsp)
         : ASTGEN_SUPER_Mul(fl, lhsp, rhsp) {
@@ -4408,6 +4443,7 @@ public:
     bool doubleFlavor() const override { return true; }
 };
 class AstMulS final : public AstNodeBiComAsv {
+    // @astgen makeDfgVertex
 public:
     AstMulS(FileLine* fl, AstNodeExpr* lhsp, AstNodeExpr* rhsp)
         : ASTGEN_SUPER_MulS(fl, lhsp, rhsp) {
@@ -4431,6 +4467,7 @@ public:
     bool signedFlavor() const override { return true; }
 };
 class AstOr final : public AstNodeBiComAsv {
+    // @astgen makeDfgVertex
 public:
     AstOr(FileLine* fl, AstNodeExpr* lhsp, AstNodeExpr* rhsp)
         : ASTGEN_SUPER_Or(fl, lhsp, rhsp) {
@@ -4452,6 +4489,7 @@ public:
     const char* widthMismatch() const override VL_MT_STABLE;
 };
 class AstXor final : public AstNodeBiComAsv {
+    // @astgen makeDfgVertex
 public:
     AstXor(FileLine* fl, AstNodeExpr* lhsp, AstNodeExpr* rhsp)
         : ASTGEN_SUPER_Xor(fl, lhsp, rhsp) {
@@ -4509,6 +4547,7 @@ public:
 
 // === AstNodeSel ===
 class AstArraySel final : public AstNodeSel {
+    // @astgen makeDfgVertex
     void init(const AstNode* fromp) {
         if (fromp && VN_IS(fromp->dtypep()->skipRefp(), NodeArrayDType)) {
             // Strip off array to find what array references
@@ -4621,6 +4660,7 @@ public:
 // === AstNodeStream ===
 class AstStreamL final : public AstNodeStream {
     // Verilog {rhs{lhs}} - Note rhsp() is the slice size, not the lhsp()
+    // @astgen makeDfgVertex
 public:
     AstStreamL(FileLine* fl, AstNodeExpr* lhsp, AstNodeExpr* rhsp)
         : ASTGEN_SUPER_StreamL(fl, lhsp, rhsp) {}
@@ -4639,6 +4679,7 @@ public:
 };
 class AstStreamR final : public AstNodeStream {
     // Verilog {rhs{lhs}} - Note rhsp() is the slice size, not the lhsp()
+    // @astgen makeDfgVertex
 public:
     AstStreamR(FileLine* fl, AstNodeExpr* lhsp, AstNodeExpr* rhsp)
         : ASTGEN_SUPER_StreamR(fl, lhsp, rhsp) {}
@@ -4927,6 +4968,7 @@ class AstCond final : public AstNodeTriop {
     // @astgen alias op1 := condp
     // @astgen alias op2 := thenp
     // @astgen alias op3 := elsep
+    // @astgen makeDfgVertex
 public:
     AstCond(FileLine* fl, AstNodeExpr* condp, AstNodeExpr* thenp, AstNodeExpr* elsep);
     ASTGEN_MEMBERS_AstCond;
@@ -5275,6 +5317,7 @@ public:
 };
 class AstCountOnes final : public AstNodeUniop {
     // Number of bits set in vector
+    // @astgen makeDfgVertex
 public:
     AstCountOnes(FileLine* fl, AstNodeExpr* lhsp)
         : ASTGEN_SUPER_CountOnes(fl, lhsp) {}
@@ -5306,6 +5349,7 @@ public:
 };
 class AstExtend final : public AstNodeUniop {
     // Expand a value into a wider entity by 0 extension.  Width is implied from nodep->width()
+    // @astgen makeDfgVertex
 public:
     AstExtend(FileLine* fl, AstNodeExpr* lhsp)
         : ASTGEN_SUPER_Extend(fl, lhsp) {}
@@ -5329,6 +5373,7 @@ public:
 };
 class AstExtendS final : public AstNodeUniop {
     // Expand a value into a wider entity by sign extension.  Width is implied from nodep->width()
+    // @astgen makeDfgVertex
 public:
     AstExtendS(FileLine* fl, AstNodeExpr* lhsp)
         : ASTGEN_SUPER_ExtendS(fl, lhsp) {}
@@ -5475,6 +5520,7 @@ public:
     bool sizeMattersLhs() const override { return false; }
 };
 class AstLogNot final : public AstNodeUniop {
+    // @astgen makeDfgVertex
 public:
     AstLogNot(FileLine* fl, AstNodeExpr* lhsp)
         : ASTGEN_SUPER_LogNot(fl, lhsp) {
@@ -5506,6 +5552,7 @@ public:
     bool sizeMattersLhs() const override { return false; }
 };
 class AstNegate final : public AstNodeUniop {
+    // @astgen makeDfgVertex
 public:
     AstNegate(FileLine* fl, AstNodeExpr* lhsp)
         : ASTGEN_SUPER_Negate(fl, lhsp) {
@@ -5539,6 +5586,7 @@ public:
     bool doubleFlavor() const override { return true; }
 };
 class AstNot final : public AstNodeUniop {
+    // @astgen makeDfgVertex
 public:
     AstNot(FileLine* fl, AstNodeExpr* lhsp)
         : ASTGEN_SUPER_Not(fl, lhsp) {
@@ -5660,6 +5708,7 @@ public:
     bool isSystemFunc() const override { return true; }
 };
 class AstRedAnd final : public AstNodeUniop {
+    // @astgen makeDfgVertex
 public:
     AstRedAnd(FileLine* fl, AstNodeExpr* lhsp)
         : ASTGEN_SUPER_RedAnd(fl, lhsp) {
@@ -5674,6 +5723,7 @@ public:
     bool sizeMattersLhs() const override { return false; }
 };
 class AstRedOr final : public AstNodeUniop {
+    // @astgen makeDfgVertex
 public:
     AstRedOr(FileLine* fl, AstNodeExpr* lhsp)
         : ASTGEN_SUPER_RedOr(fl, lhsp) {
@@ -5688,6 +5738,7 @@ public:
     bool sizeMattersLhs() const override { return false; }
 };
 class AstRedXor final : public AstNodeUniop {
+    // @astgen makeDfgVertex
 public:
     AstRedXor(FileLine* fl, AstNodeExpr* lhsp)
         : ASTGEN_SUPER_RedXor(fl, lhsp) {

--- a/src/V3Dfg.cpp
+++ b/src/V3Dfg.cpp
@@ -672,7 +672,6 @@ void DfgVertex::typeCheck(const DfgGraph& dfg) const {
 
     case VDfgType::Add:
     case VDfgType::And:
-    case VDfgType::BufIf1:
     case VDfgType::Div:
     case VDfgType::DivS:
     case VDfgType::ModDiv:
@@ -757,16 +756,6 @@ void DfgVertex::typeCheck(const DfgGraph& dfg) const {
         CHECK(inputp(0)->isPacked(), "Operand should be same type");
         CHECK(inputp(0)->size() < size(), "Operand should be narrower");
         return;
-    }
-
-    case VDfgType::SAnd:
-    case VDfgType::SIntersect:
-    case VDfgType::SOr:
-    case VDfgType::SThroughout: {
-        // LCOV_EXCL_START  // Lowered before DFG
-        UASSERT_OBJ(false, this, "SAnd/SIntersect/SOr/SThroughout should be removed before DFG");
-        return;
-        // LCOV_EXCL_STOP
     }
 
     case VDfgType::LogAnd:

--- a/src/V3DfgCse.cpp
+++ b/src/V3DfgCse.cpp
@@ -78,7 +78,6 @@ class V3DfgCse final {
         case VDfgType::Add:
         case VDfgType::And:
         case VDfgType::ArraySel:
-        case VDfgType::BufIf1:
         case VDfgType::Concat:
         case VDfgType::Cond:
         case VDfgType::CountOnes:
@@ -125,10 +124,6 @@ class V3DfgCse final {
         case VDfgType::ShiftRS:
         case VDfgType::StreamL:
         case VDfgType::StreamR:
-        case VDfgType::SAnd:
-        case VDfgType::SIntersect:
-        case VDfgType::SOr:
-        case VDfgType::SThroughout:
         case VDfgType::Sub:
         case VDfgType::Xor: return V3Hash{};
         }
@@ -205,7 +200,6 @@ class V3DfgCse final {
         case VDfgType::Add:
         case VDfgType::And:
         case VDfgType::ArraySel:
-        case VDfgType::BufIf1:
         case VDfgType::Concat:
         case VDfgType::Cond:
         case VDfgType::CountOnes:
@@ -251,10 +245,6 @@ class V3DfgCse final {
         case VDfgType::ShiftR:
         case VDfgType::ShiftRS:
         case VDfgType::StreamL:
-        case VDfgType::SAnd:
-        case VDfgType::SIntersect:
-        case VDfgType::SOr:
-        case VDfgType::SThroughout:
         case VDfgType::StreamR:
         case VDfgType::Sub:
         case VDfgType::Xor: return true;

--- a/src/astgen
+++ b/src/astgen
@@ -31,6 +31,7 @@ class Node:
         self._arity = -1  # Arity of node
         self._ops = {}  # Operands of node
         self._ptrs = []  # Pointer members of node (name, types)
+        self._makeDfgVertex = False  # Create a corresponding DfgVertex sub-class
 
     @property
     def name(self):
@@ -68,6 +69,10 @@ class Node:
         assert self.isCompleted
         return self._ptrs
 
+    @property
+    def makeDfgVertex(self):
+        return self._makeDfgVertex
+
     # Pre completion methods
     def addSubClass(self, subClass):
         assert not self.isCompleted
@@ -90,6 +95,9 @@ class Node:
     def addPtr(self, name, monad, kind, legals):
         name = re.sub(r'^m_', '', name)
         self._ptrs.append({'name': name, 'monad': monad, 'kind': kind, 'legals': legals})
+
+    def setMakeDfgVertex(self):
+        self._makeDfgVertex = True
 
     # Computes derived properties over entire class hierarchy.
     # No more changes to the hierarchy are allowed once this was called
@@ -609,9 +617,12 @@ def read_types(filename, Nodes, prefix):
             if prefix != "Ast":
                 continue
 
-            match = re.match(r'^\s*//\s*@astgen\s+(.*)$', line)
-            if match:
+            if match := re.match(r'^\s*//\s*@astgen\s+(.*)$', line):
                 decl = re.sub(r'//.*$', '', match.group(1))
+                if decl == "makeDfgVertex":
+                    node.setMakeDfgVertex()
+                    continue
+
                 what, sep, rest = partitionAndStrip(decl, ":=")
                 what = re.sub(r'\s+', ' ', what)
                 if not sep:
@@ -668,10 +679,12 @@ def read_types(filename, Nodes, prefix):
                     error(
                         lineno, "Malformed @astgen what (expecting 'op1'..'op4'," +
                         " 'alias op1'.., 'ptr'): " + what)
-            else:
-                line = re.sub(r'//.*$', '', line)
-                if re.match(r'.*[Oo]p[1-9].*', line):
-                    error(lineno, "Use generated accessors to access op<N> operands")
+                continue
+
+            line = re.sub(r'//.*$', '', line)
+
+            if re.match(r'.*[Oo]p[1-9].*', line):
+                error(lineno, "Use generated accessors to access op<N> operands")
 
             if re.match(r'^\s*Ast[A-Z][A-Za-z0-9_]+\s*\*(\s*const)?\s+m_[A-Za-z0-9_]+\s*;', line):
                 error(lineno, "Use '@astgen ptr' for Ast pointer members: " + line)
@@ -1407,116 +1420,6 @@ check_types(AstNodeList, "Ast", "Node")
 # These are standalone so we don't need to parse the sources for this.
 DfgVertices["Vertex"] = Node("Vertex", None)
 
-# AstNodeExpr that are not representable in Dfg
-DfgIgnored = (
-    # Floating point operations
-    "AcosD",
-    "AcoshD",
-    "AddD",
-    "AsinD",
-    "AsinhD",
-    "Atan2D",
-    "AtanD",
-    "AtanhD",
-    "BitsToRealD",
-    "CeilD",
-    "CosD",
-    "CoshD",
-    "DivD",
-    "EqD",
-    "ExpD",
-    "FloorD",
-    "GtD",
-    "GteD",
-    "HypotD",
-    "ISToRD",
-    "IToRD",
-    "Log10D",
-    "LogD",
-    "LtD",
-    "LteD",
-    "MulD",
-    "NegateD",
-    "NeqD",
-    "PowD",
-    "RealToBits",
-    "RToIRoundS",
-    "RToIS",
-    "SinD",
-    "SinhD",
-    "SqrtD",
-    "SubD",
-    "TanD",
-    "TanhD",
-    # String operations
-    "AtoN",
-    "CompareNN",
-    "ConcatN",
-    "CvtPackString",
-    "EqN",
-    "GetcN",
-    "GetcRefN",
-    "GteN",
-    "GtN",
-    "LenN",
-    "LteN",
-    "LtN",
-    "NeqN",
-    "NToI",
-    "PutcN",
-    "ReplicateN",
-    "SubstrN",
-    "ToLowerN",
-    "ToStringN",
-    "ToUpperN",
-    # Effectful
-    "PostAdd",
-    "PostSub",
-    "PreAdd",
-    "PreSub",
-    # Only used after DFG
-    "ShiftLOvr",
-    "ShiftROvr",
-    "ShiftRSOvr",
-    "WordSel",
-    # File operations
-    "FEof",
-    "FGetC",
-    "FGetS",
-    "FUngetC",
-    # Dynamic array operations
-    "AssocSel",
-    "IsUnbounded",
-    "WildcardSel",
-    # Type comparison
-    "EqT",
-    "NeqT",
-    # Distributions
-    "DistChiSquare",
-    "DistErlang",
-    "DistExponential",
-    "DistNormal",
-    "DistPoisson",
-    "DistT",
-    "DistUniform",
-    # Specials
-    "CastDynamic",
-    "CastWrap",
-    "CAwait",
-    "CCast",
-    "CLog2",
-    "IsUnknown",
-    "NullCheck",
-    "OneHot",
-    "OneHot0",
-    "ResizeLValue",
-    "Signed",
-    "SliceSel",
-    "TimeImport",
-    "Unsigned",
-    "URandomRange",
-)
-
 # Read DfgVertex definitions
 for filename in Args.dfgdef:
     read_types(os.path.join(Args.I, filename), DfgVertices, "Dfg")
@@ -1527,12 +1430,8 @@ for node in AstNodeList:
     if not node.isLeaf:
         continue
 
-    # Ignore any explicitly defined vertex
-    if node.name in DfgVertices:
-        continue
-
-    # Ignore expressions types that DFG cannot handle
-    if node.name in DfgIgnored:
+    # Only create vertices for explcitly marked AstNode sub-types
+    if not node.makeDfgVertex:
         continue
 
     if node.isSubClassOf(AstNodes["NodeUniop"]):
@@ -1542,7 +1441,9 @@ for node in AstNodeList:
     elif node.isSubClassOf(AstNodes["NodeTriop"]):
         base = DfgVertices["VertexTernary"]
     else:
-        continue
+        sys.exit(
+            "%Error: cannot create DfgVertex for node not derived from AstNodeUnary, AstNodeBinary, or AstNodeTernary: "
+            + node.name)
 
     vertex = Node(node.name, base)
     DfgVertices[node.name] = vertex


### PR DESCRIPTION
Explicitly annotate those AstNodeExpr subclasses that should have a corresponding DfgVertex subclass generated by astgen. This avoids having to tweak things in Dfg when adding new AstNode subclasses, which can then be handled separately.
