### PR TITLE
Fix access to static variable inside function (#7474)

### DIFF
--- a/src/V3LinkDot.cpp
+++ b/src/V3LinkDot.cpp
@@ -4323,6 +4323,13 @@ class LinkDotResolveVisitor final : public VNVisitor {
                                                           << cellp->modp()->prettyNameQ());
                     }
                 }
+            } else if (allowScope && VN_IS(foundp->nodep(), NodeFTask)) {
+                // Function/task used as scope for static variable access (IEEE std 1800-2017 6.21)
+                // Don't set m_dotText so the static variable resolves as a VarRef rather than VarXRef.
+                // This is so that V3Begin won't move it out of the function/task's scope.
+                ok = true;
+                m_ds.m_dotSymp = foundp;
+                m_ds.m_dotPos = DP_SCOPE;
             } else if (allowFTask && VN_IS(foundp->nodep(), NodeFTask)) {
                 AstNodeFTaskRef* taskrefp;
                 if (VN_IS(foundp->nodep(), Task)) {

--- a/src/V3LinkDot.cpp
+++ b/src/V3LinkDot.cpp
@@ -4323,7 +4323,7 @@ class LinkDotResolveVisitor final : public VNVisitor {
                                                           << cellp->modp()->prettyNameQ());
                     }
                 }
-            } else if (allowScope && VN_IS(foundp->nodep(), NodeFTask)) {
+            } else if (allowScope && !allowFTask && VN_IS(foundp->nodep(), NodeFTask)) {
                 // Function/task used as scope for static variable access (IEEE std 1800-2017 6.21)
                 // Don't set m_dotText so the static variable resolves as a VarRef rather than
                 // VarXRef. This is so that V3Begin won't move it out of the function/task's scope.

--- a/src/V3LinkDot.cpp
+++ b/src/V3LinkDot.cpp
@@ -4325,8 +4325,8 @@ class LinkDotResolveVisitor final : public VNVisitor {
                 }
             } else if (allowScope && VN_IS(foundp->nodep(), NodeFTask)) {
                 // Function/task used as scope for static variable access (IEEE std 1800-2017 6.21)
-                // Don't set m_dotText so the static variable resolves as a VarRef rather than VarXRef.
-                // This is so that V3Begin won't move it out of the function/task's scope.
+                // Don't set m_dotText so the static variable resolves as a VarRef rather than
+                // VarXRef. This is so that V3Begin won't move it out of the function/task's scope.
                 ok = true;
                 m_ds.m_dotSymp = foundp;
                 m_ds.m_dotPos = DP_SCOPE;

--- a/test_regress/t/t_static_var_xref.py
+++ b/test_regress/t/t_static_var_xref.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2024 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile()
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_static_var_xref.py
+++ b/test_regress/t/t_static_var_xref.py
@@ -16,4 +16,3 @@ test.compile()
 test.execute()
 
 test.passes()
-

--- a/test_regress/t/t_static_var_xref.py
+++ b/test_regress/t/t_static_var_xref.py
@@ -16,3 +16,4 @@ test.compile()
 test.execute()
 
 test.passes()
+

--- a/test_regress/t/t_static_var_xref.v
+++ b/test_regress/t/t_static_var_xref.v
@@ -1,0 +1,26 @@
+// DESCRIPTION: Verilator: Dotted reference that uses another dotted reference
+// as the select expression
+//
+// This file ONLY is placed under the Creative Commons Public Domain.
+// SPDX-FileCopyrightText: 2020 Wilson Snyder
+// SPDX-License-Identifier: CC0-1.0
+
+package test_pkg;
+  class foo;
+    virtual function void visit();
+      static int compiled_regex;
+      compiled_regex = 1;
+      endfunction
+
+      function void end_v();
+        visit.compiled_regex = 0;
+      endfunction
+    endclass
+endpackage
+
+module t;
+  initial begin
+    $write("*-* All Coverage Tests Passed *-*\n");
+    $finish;
+  end
+endmodule

--- a/test_regress/t/t_static_var_xref.v
+++ b/test_regress/t/t_static_var_xref.v
@@ -10,12 +10,12 @@ package test_pkg;
     virtual function void visit();
       static int compiled_regex;
       compiled_regex = 1;
-      endfunction
+    endfunction
 
-      function void end_v();
-        visit.compiled_regex = 0;
-      endfunction
-    endclass
+    function void end_v();
+      visit.compiled_regex = 0;
+    endfunction
+  endclass
 endpackage
 
 module t;
@@ -24,4 +24,3 @@ module t;
     $finish;
   end
 endmodule
-

--- a/test_regress/t/t_static_var_xref.v
+++ b/test_regress/t/t_static_var_xref.v
@@ -24,3 +24,4 @@ module t;
     $finish;
   end
 endmodule
+

--- a/test_regress/t/t_static_var_xref.v
+++ b/test_regress/t/t_static_var_xref.v
@@ -20,7 +20,7 @@ endpackage
 
 module t;
   initial begin
-    $write("*-* All Coverage Tests Passed *-*\n");
+    $write("*-* All Finished *-*\n");
     $finish;
   end
 endmodule

--- a/test_regress/t/t_var_xref_bad.out
+++ b/test_regress/t/t_var_xref_bad.out
@@ -1,5 +1,5 @@
-%Error: t/t_var_xref_bad.v:11:11: Found definition of 'tsk' as a TASK but expected a scope/variable
+%Error: t/t_var_xref_bad.v:11:15: Can't find definition of variable/method: 'bad_missing_ref'
    11 |   initial tsk.bad_missing_ref = 0;
-      |           ^~~
+      |               ^~~~~~~~~~~~~~~
         ... See the manual at https://verilator.org/verilator_doc.html?v=latest for more assistance.
 %Error: Exiting due to


### PR DESCRIPTION
This fix addresses #7474 

Including the MRE as a reference:
```verilog
package test_pkg;
  class foo;
    virtual function void visit();
      static int compiled_regex;
      compiled_regex = 1;
    endfunction

    function void end_v();
      visit.compiled_regex = 0;  // legal as per IEEE std 1800-2017 section 6.21
    endfunction
  endclass
endpackage

module t;
endmodule
```

In `V3LinkDot.cpp` 's `visit(AstParseRef*) method,

What I noticed (and tried to work with) first is:
When resolving `visit.compiled_regex`, the LHS `visit` is looked up at `DP_FIRST` position with `allowScope = true`. 
We then check what type of node was found:
```cpp
} else if (VN_IS(foundp->nodep(), Cell) || VN_IS(foundp->nodep(), NodeBlock)
           || VN_IS(foundp->nodep(), GenBlock)
           || VN_IS(foundp->nodep(), Netlist)
           || VN_IS(foundp->nodep(), Module)) {
    if (allowScope) {
        ok = true;
        m_ds.m_dotText = VString::dot(m_ds.m_dotText, ".", nodep->name());
        m_ds.m_dotSymp = foundp;
        m_ds.m_dotPos = DP_SCOPE;
    }
```
Since `NodeFTask` isn't checked here, the function falls through to a later handler which doesn't handle the situation where funcs and tasks are used as scopes. And since none of the conditions set `ok = true`, the error is first produced.

But then, even after adding `NodeFTask` to the scope check, the scope handler sets `m_ds.m_dotText = "visit"`, which causes the resolved variable to become a `VarXRef` (cross-reference with `dotted()="visit"`) instead of just a `VarRef`.

Later on, `V3Begin::debeginAll()` plucks the static function variables out of the function scope, which produces the following mesage when we eventually try to revisit `visit.compiled_regex` through `V3LinkDot::linkDotScope()`:

```
Can't find definition of 'compiled_regex' in dotted signal: 'visit.compiled_regex'
```

**To fix this:**

A new handler for `NodeFTask` as a scope can be added before the existing `allowFTask` function call handler, as seen in the diff.

**This also causes the following side effect:**

The error message for `t_var_xref_bad` changes from:

```
Found definition of 'tsk' as a TASK but expected a scope/variable
```

to:

```
Can't find definition of variable/method: 'bad_missing_ref'
```