### PR TITLE
Fix std::randomize inside {typedef array} internal error (#7476)

### DIFF
--- a/src/V3Randomize.cpp
+++ b/src/V3Randomize.cpp
@@ -964,7 +964,9 @@ class ConstraintExprVisitor final : public VNVisitor {
 
     AstNodeExpr* newSel(FileLine* fl, AstNodeExpr* arrayp, AstNodeExpr* idxp) {
         // similar to V3WidthSel.cpp
-        AstNodeDType* const arrDtp = arrayp->unlinkFrBack()->dtypep();
+        // skipRefp() unwraps typedef wrappers (AstRefDType) so the dtype kind
+        // checks below recognize types spelled as `typedef <scalar> <name>[$]`.
+        AstNodeDType* const arrDtp = arrayp->unlinkFrBack()->dtypep()->skipRefp();
         AstNodeExpr* selp = nullptr;
         if (VN_IS(arrDtp, QueueDType) || VN_IS(arrDtp, DynArrayDType))
             selp = new AstCMethodHard{fl, arrayp, VCMethod::ARRAY_AT, idxp};

--- a/test_regress/t/t_constraint_inside_typedef_array.py
+++ b/test_regress/t/t_constraint_inside_typedef_array.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+if not test.have_solver:
+    test.skip("No constraint solver installed")
+
+test.compile()
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_constraint_inside_typedef_array.v
+++ b/test_regress/t/t_constraint_inside_typedef_array.v
@@ -1,0 +1,72 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain.
+// SPDX-FileCopyrightText: 2026 PlanV GmbH
+// SPDX-License-Identifier: CC0-1.0
+
+// verilog_format: off
+`define stop $stop
+`define checkd(gotv,expv) do if ((gotv) !== (expv)) begin $write("%%Error: %s:%0d:  got=%0d exp=%0d\n", `__FILE__,`__LINE__, (gotv), (expv)); `stop; end while(0);
+// verilog_format: on
+
+package pkg;
+  typedef int int_q[$];
+  typedef int int_da[];
+  typedef int int_up[4];
+  typedef int_q alias_q;
+
+  class Bundle;
+    int_q  q;
+    int_da d;
+    int_up u;
+  endclass
+endpackage
+
+module t(/*AUTOARG*/);
+  import pkg::*;
+
+  initial begin
+    automatic Bundle b = new();
+    automatic int    t_l = 0;
+    automatic int    rv;
+    automatic alias_q a = '{32'd1, 32'd2, 32'd3};
+
+    b.q = '{32'd10, 32'd20, 32'd30};
+    b.d = new[3];
+    b.d = '{32'd40, 32'd50, 32'd60};
+    b.u = '{32'd70, 32'd80, 32'd90, 32'd100};
+
+    // Original reported shape: typedef queue member of a class,
+    // used as the array in `inside {...}` of a with-constraint.
+    repeat (20) begin
+      rv = std::randomize(t_l) with { t_l inside {b.q}; };
+      `checkd(rv, 1);
+      `checkd((t_l == 10 || t_l == 20 || t_l == 30), 1'b1);
+    end
+
+    // Typedef dynamic array.
+    repeat (20) begin
+      rv = std::randomize(t_l) with { t_l inside {b.d}; };
+      `checkd(rv, 1);
+      `checkd((t_l == 40 || t_l == 50 || t_l == 60), 1'b1);
+    end
+
+    // Typedef unpacked (fixed-size) array.
+    repeat (20) begin
+      rv = std::randomize(t_l) with { t_l inside {b.u}; };
+      `checkd(rv, 1);
+      `checkd((t_l == 70 || t_l == 80 || t_l == 90 || t_l == 100), 1'b1);
+    end
+
+    // Chained typedef (AstRefDType -> AstRefDType -> QueueDType) must
+    // also be unwrapped by skipRefp().
+    repeat (20) begin
+      rv = std::randomize(t_l) with { t_l inside {a}; };
+      `checkd(rv, 1);
+      `checkd((t_l == 1 || t_l == 2 || t_l == 3), 1'b1);
+    end
+
+    $write("*-* All Finished *-*\n");
+    $finish;
+  end
+endmodule


### PR DESCRIPTION
## Summary

This patch fixes an internal `V3Randomize.cpp:975: Selecting from non-array?` assertion triggered when the item of an `inside {...}` constraint has a typedef'd array dtype. Fixes #7476.

## Reproducer

```systemverilog
module t;
  typedef int int_q[$];
  initial begin
    int_q q = '{1, 2, 3};
    int t_l;
    int rv;
    rv = std::randomize(t_l) with { t_l inside {q}; };
    $display("t_l=%0d", t_l);
    $finish;
  end
endmodule
```

On master:

```
%Error: Internal Error: test.sv:...: ../V3Randomize.cpp:975: Selecting from non-array?
```

The same failure mode reproduces for typedef dynamic arrays, typedef unpacked arrays, and chained typedefs (`typedef base_q alias_q;`).

## Changes

- `src/V3Randomize.cpp` (`ConstraintExprVisitor::newSel`): unwrap typedef wrappers with `skipRefp()` before dispatching on the array dtype kind, matching the idiom used at the other 20+ dtype-inspection sites in this file. The two call-sites (`ARRAY_INSIDE` lowering and `ARRAY_R_*` reduction with-clause) both benefit transparently.

## Test

- `test_regress/t/t_constraint_inside_typedef_array.{v,py}` — positive simulator test covering typedef queue, typedef dynamic array, typedef unpacked array, and chained typedef used as `inside` items; 20 randomize iterations per case, each result range-checked against the array contents; validated against Questa.

---
Developed by PlanV GmbH, assisted with Claude Code.

Reviewed by YilouWang.