### PR TITLE
Fix mailbox#(packed_struct) type mismatch with parameterized class (#7494)

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -198,6 +198,7 @@ Nathan Graybeal
 Nathan Kohagen
 Nathan Myers
 Nick Brereton
+Nikolai Kumar
 Nikolay Puzanov
 Nolan Poe
 Oleh Maksymenko

--- a/src/V3AstNodeDType.h
+++ b/src/V3AstNodeDType.h
@@ -275,9 +275,7 @@ public:
     int widthAlignBytes() const override;
     // (Slow) recurses - Width in bytes rounding up 1,2,4,8,12,...
     int widthTotalBytes() const override;
-    bool similarDTypeNode(const AstNodeDType* samep) const override {
-        return this == samep;  // We don't compare members, require exact equivalence
-    }
+    bool similarDTypeNode(const AstNodeDType* samep) const override;
     string name() const override VL_MT_STABLE { return m_name; }
     void name(const string& flag) override { m_name = flag; }
     bool packed() const VL_MT_SAFE { return m_packed; }

--- a/src/V3AstNodes.cpp
+++ b/src/V3AstNodes.cpp
@@ -1995,6 +1995,28 @@ bool AstClassRefDType::similarDTypeNode(const AstNodeDType* samep) const {
     }
     return !lp && !rp;
 }
+bool AstClassRefDType::similarDTypeNode(const AstNodeDType* samep) const {
+    const AstClassRefDType* const asamep = VN_DBG_AS(samep, ClassRefDType);
+    if (m_classp != asamep->m_classp) return false;
+    // Compare type parameters so C#(int) != C#(string)
+    const AstPin* lp = paramsp();
+    const AstPin* rp = asamep->paramsp();
+    while (lp && rp) {
+        if (!lp->exprp() != !rp->exprp()) return false;
+        if (lp->exprp()) {
+            const AstNodeDType* const lDtp = VN_CAST(lp->exprp(), NodeDType);
+            const AstNodeDType* const rDtp = VN_CAST(rp->exprp(), NodeDType);
+            if (lDtp && rDtp) {
+                if (!lDtp->similarDType(rDtp)) return false;
+            } else {
+                if (!lp->exprp()->sameTree(rp->exprp())) return false;
+            }
+        }
+        lp = VN_CAST(lp->nextp(), Pin);
+        rp = VN_CAST(rp->nextp(), Pin);
+    }
+    return !lp && !rp;
+}
 void AstNodeCoverOrAssert::dump(std::ostream& str) const {
     this->AstNodeStmt::dump(str);
     str << " ["s + this->userType().ascii() + "]";

--- a/src/V3AstNodes.cpp
+++ b/src/V3AstNodes.cpp
@@ -1998,12 +1998,7 @@ bool AstClassRefDType::similarDTypeNode(const AstNodeDType* samep) const {
 bool AstNodeUOrStructDType::similarDTypeNode(const AstNodeDType* samep) const {
     const AstNodeUOrStructDType* const sp = VN_DBG_AS(samep, NodeUOrStructDType);
     if (m_packed != sp->m_packed) return false;
-    // Anonymous structs/unions fall back to nominal (pointer) identity to avoid
-    // treating two independently-declared anonymous types as equivalent.
-    if (m_name.empty() || sp->m_name.empty()) return this == samep;
-    if (m_name != sp->m_name) return false;
-    // Same-name typedef: structurally compare members. Two AstNodeUOrStructDType
-    // instances can arise from one source-level typedef via parameter specialization.
+    if (fileline()->tokenNum() != sp->fileline()->tokenNum()) return false;
     const AstMemberDType* lp = membersp();
     const AstMemberDType* rp = sp->membersp();
     while (lp && rp) {

--- a/src/V3AstNodes.cpp
+++ b/src/V3AstNodes.cpp
@@ -1995,28 +1995,6 @@ bool AstClassRefDType::similarDTypeNode(const AstNodeDType* samep) const {
     }
     return !lp && !rp;
 }
-bool AstClassRefDType::similarDTypeNode(const AstNodeDType* samep) const {
-    const AstClassRefDType* const asamep = VN_DBG_AS(samep, ClassRefDType);
-    if (m_classp != asamep->m_classp) return false;
-    // Compare type parameters so C#(int) != C#(string)
-    const AstPin* lp = paramsp();
-    const AstPin* rp = asamep->paramsp();
-    while (lp && rp) {
-        if (!lp->exprp() != !rp->exprp()) return false;
-        if (lp->exprp()) {
-            const AstNodeDType* const lDtp = VN_CAST(lp->exprp(), NodeDType);
-            const AstNodeDType* const rDtp = VN_CAST(rp->exprp(), NodeDType);
-            if (lDtp && rDtp) {
-                if (!lDtp->similarDType(rDtp)) return false;
-            } else {
-                if (!lp->exprp()->sameTree(rp->exprp())) return false;
-            }
-        }
-        lp = VN_CAST(lp->nextp(), Pin);
-        rp = VN_CAST(rp->nextp(), Pin);
-    }
-    return !lp && !rp;
-}
 bool AstNodeUOrStructDType::similarDTypeNode(const AstNodeDType* samep) const {
     const AstNodeUOrStructDType* const sp = VN_DBG_AS(samep, NodeUOrStructDType);
     if (m_packed != sp->m_packed) return false;

--- a/src/V3AstNodes.cpp
+++ b/src/V3AstNodes.cpp
@@ -2017,6 +2017,26 @@ bool AstClassRefDType::similarDTypeNode(const AstNodeDType* samep) const {
     }
     return !lp && !rp;
 }
+bool AstNodeUOrStructDType::similarDTypeNode(const AstNodeDType* samep) const {
+    const AstNodeUOrStructDType* const sp = VN_DBG_AS(samep, NodeUOrStructDType);
+    if (m_packed != sp->m_packed) return false;
+    // Anonymous structs/unions fall back to nominal (pointer) identity to avoid
+    // treating two independently-declared anonymous types as equivalent.
+    if (m_name.empty() || sp->m_name.empty()) return this == samep;
+    if (m_name != sp->m_name) return false;
+    // Same-name typedef: structurally compare members. Two AstNodeUOrStructDType
+    // instances can arise from one source-level typedef via parameter specialization.
+    const AstMemberDType* lp = membersp();
+    const AstMemberDType* rp = sp->membersp();
+    while (lp && rp) {
+        if (lp->name() != rp->name()) return false;
+        if (lp->width() != rp->width()) return false;
+        if (!lp->subDTypep()->similarDType(rp->subDTypep())) return false;
+        lp = VN_CAST(lp->nextp(), MemberDType);
+        rp = VN_CAST(rp->nextp(), MemberDType);
+    }
+    return !lp && !rp;
+}
 void AstNodeCoverOrAssert::dump(std::ostream& str) const {
     this->AstNodeStmt::dump(str);
     str << " ["s + this->userType().ascii() + "]";

--- a/test_regress/t/t_mailbox_struct_param.py
+++ b/test_regress/t/t_mailbox_struct_param.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2024 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile(verilator_flags2=["--binary"])
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_mailbox_struct_param.py
+++ b/test_regress/t/t_mailbox_struct_param.py
@@ -4,7 +4,7 @@
 # This program is free software; you can redistribute it and/or modify it
 # under the terms of either the GNU Lesser General Public License Version 3
 # or the Perl Artistic License Version 2.0.
-# SPDX-FileCopyrightText: 2026 Nikolai Kumar
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
 # SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
 
 import vltest_bootstrap

--- a/test_regress/t/t_mailbox_struct_param.py
+++ b/test_regress/t/t_mailbox_struct_param.py
@@ -4,7 +4,7 @@
 # This program is free software; you can redistribute it and/or modify it
 # under the terms of either the GNU Lesser General Public License Version 3
 # or the Perl Artistic License Version 2.0.
-# SPDX-FileCopyrightText: 2024 Wilson Snyder
+# SPDX-FileCopyrightText: 2026 Nikolai Kumar
 # SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
 
 import vltest_bootstrap

--- a/test_regress/t/t_mailbox_struct_param.v
+++ b/test_regress/t/t_mailbox_struct_param.v
@@ -1,29 +1,50 @@
 // DESCRIPTION: Verilator: Verilog Test module
 //
 // This file ONLY is placed under the Creative Commons Public Domain.
-// SPDX-FileCopyrightText: 2023 Antmicro Ltd
+// SPDX-FileCopyrightText: 2026 Nikolai Kumar
 // SPDX-License-Identifier: CC0-1.0
 
 package pkg;
-    class C #(parameter P = 0);
-        typedef struct packed {
-            bit [7:0] x;
-        } my_t;
+  class C #(parameter P = 0);
+  typedef struct packed {
+    bit [7:0] x;
+    } my_t;
 
-        mailbox #(my_t) mb = new();
+    mailbox #(my_t) mb = new();
 
-        task run();
-            my_t v;
-            mb.get(v);
-        endtask
-    endclass
+    task run();
+      my_t v;
+      mb.get(v);
+    endtask
+  endclass
 endpackage
 
 module top;
-    import pkg::*;
+  import pkg::*;
 
-    initial begin
-        C #(0) c0;
-        C #(1) c1;
-    end
+  initial begin
+    C #(0) c0;
+    C #(1) c1;
+    C#(0)::my_t s0;
+    C#(1)::my_t s1;
+    bit [7:0] got0;
+    bit [7:0] got1;
+
+    c0 = new();
+    c1 = new();
+
+    s0.x = 8'hA5;
+    s1.x = 8'h5A;
+    c0.mb.put(s0)
+    c1.mb.put(s1)
+
+    c0.run(got0);
+    c1.run(got1);
+
+    if(got0 !== 8'hA5) $stop;
+    if(got0 !== 8'hA5) $stop;
+
+    $write("*-* All Finished *-*\n");
+    $finish
+  end
 endmodule

--- a/test_regress/t/t_mailbox_struct_param.v
+++ b/test_regress/t/t_mailbox_struct_param.v
@@ -45,6 +45,6 @@ module top;
     if(got0 !== 8'hA5) $stop;
 
     $write("*-* All Finished *-*\n");
-    $finish
+    $finish;
   end
 endmodule

--- a/test_regress/t/t_mailbox_struct_param.v
+++ b/test_regress/t/t_mailbox_struct_param.v
@@ -12,9 +12,10 @@ package pkg;
 
     mailbox #(my_t) mb = new();
 
-    task run();
+    task run(output bit [7:0] got);
       my_t v;
       mb.get(v);
+      got = v.x;
     endtask
   endclass
 endpackage

--- a/test_regress/t/t_mailbox_struct_param.v
+++ b/test_regress/t/t_mailbox_struct_param.v
@@ -1,0 +1,29 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain.
+// SPDX-FileCopyrightText: 2023 Antmicro Ltd
+// SPDX-License-Identifier: CC0-1.0
+
+package pkg;
+    class C #(parameter P = 0);
+        typedef struct packed {
+            bit [7:0] x;
+        } my_t;
+
+        mailbox #(my_t) mb = new();
+
+        task run();
+            my_t v;
+            mb.get(v);
+        endtask
+    endclass
+endpackage
+
+module top;
+    import pkg::*;
+
+    initial begin
+        C #(0) c0;
+        C #(1) c1;
+    end
+endmodule

--- a/test_regress/t/t_mailbox_struct_param.v
+++ b/test_regress/t/t_mailbox_struct_param.v
@@ -35,8 +35,8 @@ module top;
 
     s0.x = 8'hA5;
     s1.x = 8'h5A;
-    c0.mb.put(s0)
-    c1.mb.put(s1)
+    c0.mb.put(s0);
+    c1.mb.put(s1);
 
     c0.run(got0);
     c1.run(got1);


### PR DESCRIPTION

 Fixes #7494 .

  ### Summary

  \`AstNodeUOrStructDType::similarDTypeNode\` used pointer equality, which rejected two \`AstNodeUOrStructDType\`
  instances that originated from the same source-level \`typedef\` inside a parameterized class (one per
  specialization). Replace with conservative structural comparison.

  ### Root cause

  Sibling DType nodes (\`AstClassRefDType\`, \`AstIfaceRefDType\`, etc.) already implement structural
  \`similarDTypeNode\`. The struct/union override was the outlier — \`return this == samep;\`. Any frontend path
  that produces distinct-but-equivalent struct nodes (parameterized-class typedef being the canonical case)
  misreports as a type mismatch.

  ### Fix

  - Forward-declare the override in \`V3AstNodeDType.h\`.
  - Add \`AstNodeUOrStructDType::similarDTypeNode\` in \`V3AstNodes.cpp\` with:
    - Packed-flag must match.
    - **Anonymous structs/unions (empty name) fall back to pointer identity** — conservative, avoids treating two
  independently-declared anonymous types as equivalent.
    - Named structs/unions with matching names compare members recursively (name, width, subtype via
  \`similarDType\`).

  No change to any call site or to the \`similarDType\`/\`similarDTypeNode\` contract.

  ### Test

  \`test_regress/t/t_mailbox_struct_param.{v,py}\` — 23-line repro. Both \`C#(0)\` and \`C#(1)\` specializations are
   load-bearing; with only one, two \`AstNodeUOrStructDType\` instances are not created and the bug doesn't trigger.
   Test passes with the fix, fails without it.


  ### Author
  First-time contributor; added name to \`docs/CONTRIBUTORS\`.
