### PR TITLE
Fix std::randomize internal error on static member of different class

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -88,6 +88,7 @@ Gökçe Aydos
 Han Qi
 Harald Heckmann
 Hennadii Chernyshchyk
+hjsanjana
 Howard Su
 Huang Rui
 Huanghuang Zhou

--- a/src/V3Randomize.cpp
+++ b/src/V3Randomize.cpp
@@ -2824,6 +2824,11 @@ class CaptureVisitor final : public VNVisitor {
             && varRefp->varp()->lifetime().isStatic())
             return CaptureMode::CAP_NO;
         if (callerIsClass && varIsFieldOfCaller) return CaptureMode::CAP_THIS;
+        // Static member of a different class: V3Width replaces AstMemberSel with a bare
+        // AstVarRef (classOrPackagep set). Capture current value as a function argument.
+        if (callerIsClass && varClassp && !varIsFieldOfCaller
+            && varRefp->varp()->lifetime().isStatic())
+            return CaptureMode::CAP_VALUE;
         UASSERT_OBJ(!callerIsClass, varRefp, "Invalid reference?");
         return CaptureMode::CAP_VALUE;
     }

--- a/test_regress/t/t_std_randomize_static_member.py
+++ b/test_regress/t/t_std_randomize_static_member.py
@@ -4,7 +4,7 @@
 # This program is free software; you can redistribute it and/or modify it
 # under the terms of either the GNU Lesser General Public License Version 3
 # or the Perl Artistic License Version 2.0.
-# SPDX-FileCopyrightText: 2026 Antmicro
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
 # SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
 
 import vltest_bootstrap

--- a/test_regress/t/t_std_randomize_static_member.py
+++ b/test_regress/t/t_std_randomize_static_member.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2026 Antmicro
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+if not test.have_solver:
+    test.skip("No constraint solver installed")
+
+test.compile()
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_std_randomize_static_member.v
+++ b/test_regress/t/t_std_randomize_static_member.v
@@ -11,70 +11,70 @@
 
 package tlogy_m_pkg;
 class v_cfg;
-   static int num_of_ds = 0;
+  static int num_of_ds = 0;
 endclass
 
 class tlogy_m;
-   v_cfg v[$];
+  v_cfg v[$];
 endclass
 endpackage
 
 package s_pkg;
 import tlogy_m_pkg::*;
 class s_cfg;
-   tlogy_m t_m;
-   bit     t_mode;
-   int     a_d_idx;
+  tlogy_m t_m;
+  bit t_mode;
+  int a_d_idx;
 
-   function void setup_h_iw_cfg();
-      if (t_mode) begin
-         foreach (t_m.v[i]) begin
-            if (std::randomize(a_d_idx) with {
-                   if (t_m.v[i].num_of_ds > 1) {
-                      a_d_idx inside {[0:(t_m.v[i].num_of_ds - 1)]};
-                      a_d_idx != 0;
-                   }
-                } == 0)
-              $stop;
-         end
+  function void setup_h_iw_cfg();
+    if (t_mode) begin
+      foreach (t_m.v[i]) begin
+        if (std::randomize(a_d_idx) with {
+               if (t_m.v[i].num_of_ds > 1) {
+                 a_d_idx inside {[0:(t_m.v[i].num_of_ds - 1)]};
+                 a_d_idx != 0;
+               }
+             } == 0)
+          $stop;
       end
-   endfunction
+    end
+  endfunction
 endclass
 endpackage
 
 module t;
-   import tlogy_m_pkg::*;
-   import s_pkg::*;
+  import tlogy_m_pkg::*;
+  import s_pkg::*;
 
-   initial begin
-      automatic s_cfg cfg = new;
-      automatic tlogy_m tm = new;
-      automatic v_cfg vc0 = new;
-      automatic v_cfg vc1 = new;
+  initial begin
+    automatic s_cfg cfg = new;
+    automatic tlogy_m tm = new;
+    automatic v_cfg vc0 = new;
+    automatic v_cfg vc1 = new;
 
-      // Set up: push two entries in the queue and set num_of_ds = 3
-      // so the constraint branch (num_of_ds > 1) is exercised.
-      tm.v.push_back(vc0);
-      tm.v.push_back(vc1);
-      v_cfg::num_of_ds = 3;
+    // Set up: push two entries in the queue and set num_of_ds = 3
+    // so the constraint branch (num_of_ds > 1) is exercised.
+    tm.v.push_back(vc0);
+    tm.v.push_back(vc1);
+    v_cfg::num_of_ds = 3;
 
-      cfg.t_m = tm;
-      cfg.t_mode = 1'b1;
+    cfg.t_m = tm;
+    cfg.t_mode = 1'b1;
 
-      repeat (20) begin
-         cfg.setup_h_iw_cfg();
-         // When num_of_ds = 3 the constraint is:
-         //   a_d_idx inside {[0:2]} && a_d_idx != 0
-         // so a_d_idx must be 1 or 2.
-         if (cfg.a_d_idx < 1 || cfg.a_d_idx > 2) $stop;
-      end
-
-      // Also verify that the "no constraint" branch (num_of_ds <= 1)
-      // compiles and runs without crashing.
-      v_cfg::num_of_ds = 0;
+    repeat (20) begin
       cfg.setup_h_iw_cfg();
+      // When num_of_ds = 3 the constraint is:
+      //   a_d_idx inside {[0:2]} && a_d_idx != 0
+      // so a_d_idx must be 1 or 2.
+      if (cfg.a_d_idx < 1 || cfg.a_d_idx > 2) $stop;
+    end
 
-      $write("*-* All Finished *-*\n");
-      $finish;
-   end
+    // Also verify that the "no constraint" branch (num_of_ds <= 1)
+    // compiles and runs without crashing.
+    v_cfg::num_of_ds = 0;
+    cfg.setup_h_iw_cfg();
+
+    $write("*-* All Finished *-*\n");
+    $finish;
+  end
 endmodule

--- a/test_regress/t/t_std_randomize_static_member.v
+++ b/test_regress/t/t_std_randomize_static_member.v
@@ -1,0 +1,80 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain
+// SPDX-FileCopyrightText: 2026 Antmicro
+// SPDX-License-Identifier: CC0-1.0
+
+// Regression test for GitHub issue #7498:
+// std::randomize() constraint referencing a static class member of a
+// *different* class (accessed via a foreach loop) caused an internal error
+// in V3Randomize ("Invalid reference?").
+
+package tlogy_m_pkg;
+class v_cfg;
+   static int num_of_ds = 0;
+endclass
+
+class tlogy_m;
+   v_cfg v[$];
+endclass
+endpackage
+
+package s_pkg;
+import tlogy_m_pkg::*;
+class s_cfg;
+   tlogy_m t_m;
+   bit     t_mode;
+   int     a_d_idx;
+
+   function void setup_h_iw_cfg();
+      if (t_mode) begin
+         foreach (t_m.v[i]) begin
+            if (std::randomize(a_d_idx) with {
+                   if (t_m.v[i].num_of_ds > 1) {
+                      a_d_idx inside {[0:(t_m.v[i].num_of_ds - 1)]};
+                      a_d_idx != 0;
+                   }
+                } == 0)
+              $stop;
+         end
+      end
+   endfunction
+endclass
+endpackage
+
+module t;
+   import tlogy_m_pkg::*;
+   import s_pkg::*;
+
+   initial begin
+      automatic s_cfg cfg = new;
+      automatic tlogy_m tm = new;
+      automatic v_cfg vc0 = new;
+      automatic v_cfg vc1 = new;
+
+      // Set up: push two entries in the queue and set num_of_ds = 3
+      // so the constraint branch (num_of_ds > 1) is exercised.
+      tm.v.push_back(vc0);
+      tm.v.push_back(vc1);
+      v_cfg::num_of_ds = 3;
+
+      cfg.t_m = tm;
+      cfg.t_mode = 1'b1;
+
+      repeat (20) begin
+         cfg.setup_h_iw_cfg();
+         // When num_of_ds = 3 the constraint is:
+         //   a_d_idx inside {[0:2]} && a_d_idx != 0
+         // so a_d_idx must be 1 or 2.
+         if (cfg.a_d_idx < 1 || cfg.a_d_idx > 2) $stop;
+      end
+
+      // Also verify that the "no constraint" branch (num_of_ds <= 1)
+      // compiles and runs without crashing.
+      v_cfg::num_of_ds = 0;
+      cfg.setup_h_iw_cfg();
+
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end
+endmodule


### PR DESCRIPTION
Fixes #7498.

## Problem

When a `std::randomize() with {}` constraint references a static member
of a *different* class (e.g. `t_m.v[i].num_of_ds` where `num_of_ds` is
`static`), Verilator crashes with:

    Internal Error: V3Randomize.cpp:2827: Invalid reference?

## Root cause

Two passes interact to produce the crash:

1. **V3Width** detects that `t_m.v[i].num_of_ds` accesses a static
   member and collapses the entire member-select chain into a bare
   `AstVarRef(num_of_ds, classOrPackagep=v_cfg)`, because static
   members are class-level and don't depend on the instance.

2. **CaptureVisitor** (V3Randomize) visits this bare `AstVarRef` while
   building the inline constraint function. Its `getVarRefCaptureMode`
   had no case for "static member of a *different* class", so it fell
   through to the `UASSERT`.

## Fix

Add the missing case in `getVarRefCaptureMode`: when the referenced
variable is a static member of a class other than the caller's class,
return `CAP_VALUE` — capture the current value as a function argument.
This is correct because statics are globally shared and don't require
a `this` pointer.

## Test

Added `test_regress/t/t_std_randomize_static_member.v` which reproduces
the exact class structure from the issue report, sets `num_of_ds = 3`,
runs the constrained randomization 20 times, and verifies the result
satisfies the constraint.