### PR TITLE
 Fix `+verilator+seed` to match its documented behavior (#7325)

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -188,6 +188,7 @@ Michael Bikovitsky
 Michael Killough
 Michal Czyz
 Michaël Lefebvre
+Miguel Perez Andrade
 Mike Popoloski
 Miodrag Milanović
 Mladen Slijepcevic

--- a/docs/guide/exe_sim.rst
+++ b/docs/guide/exe_sim.rst
@@ -113,8 +113,11 @@ Options:
 .. option:: +verilator+seed+<value>
 
    For $random and :vlopt:`--x-initial unique <--x-initial>`, set the
-   simulation runtime random seed value. If zero or not specified picks a
-   value from the system random number generator.
+   simulation runtime random seed value. If not specified, the seed
+   defaults to 1. If specified as 0, a non-zero seed is generated at
+   startup; the picked value is exposed through ``$get_initial_random_seed``
+   so the run can be reproduced later by passing
+   ``+verilator+seed+<that_value>``.
 
 .. option:: +verilator+solver+file+<filename>
 

--- a/include/verilated.cpp
+++ b/include/verilated.cpp
@@ -59,6 +59,7 @@
 #include <cctype>
 #include <cerrno>
 #include <cstdlib>
+#include <ctime>
 #include <iostream>
 #include <limits>
 #include <list>
@@ -80,6 +81,7 @@
 #if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
 # include <sys/time.h>
 # include <sys/resource.h>
+# include <unistd.h>
 # define _VL_HAVE_GETRLIMIT
 #endif
 
@@ -443,6 +445,19 @@ static uint32_t vl_sys_rand32() VL_MT_SAFE {
     // Used only to construct seed for Verilator's PRNG.
     static VerilatedMutex s_mutex;
     const VerilatedLockGuard lock{s_mutex};  // Otherwise rand is unsafe
+    // Seed the system RNG once with a non-deterministic value, since
+    // lrand48()/rand() otherwise default to a fixed seed of 0 and would
+    // make every "unseeded" simulation run produce identical output.
+    static const bool s_seeded = []() {
+        const uint64_t now = static_cast<uint64_t>(std::time(nullptr));
+#if defined(_WIN32) && !defined(__CYGWIN__)
+        std::srand(static_cast<unsigned>(now));
+#else
+        srand48(static_cast<long>(now) ^ static_cast<long>(getpid()));
+#endif
+        return true;
+    }();
+    (void)s_seeded;
 #if defined(_WIN32) && !defined(__CYGWIN__)
     // Windows doesn't have lrand48(), although Cygwin does.
     return (std::rand() << 16) ^ std::rand();

--- a/include/verilated.cpp
+++ b/include/verilated.cpp
@@ -3260,7 +3260,7 @@ void VerilatedContextImp::commandArgVl(const std::string& arg) {
             solverLogFilename(str);
         } else if (commandArgVlUint64(arg, "+verilator+wno+unsatconstr+", u64, 0, 1)) {
             warnUnsatConstr(u64 == 0);  // wno means disable, so invert
-        } else if (commandArgVlUint64(arg, "+verilator+seed+", u64, 1,
+        } else if (commandArgVlUint64(arg, "+verilator+seed+", u64, 0,
                                       std::numeric_limits<int>::max())) {
             randSeed(static_cast<int>(u64));
         } else if (arg == "+verilator+V") {

--- a/include/verilated.cpp
+++ b/include/verilated.cpp
@@ -58,6 +58,7 @@
 #include <algorithm>
 #include <cctype>
 #include <cerrno>
+#include <chrono>
 #include <cstdlib>
 #include <ctime>
 #include <iostream>
@@ -445,19 +446,6 @@ static uint32_t vl_sys_rand32() VL_MT_SAFE {
     // Used only to construct seed for Verilator's PRNG.
     static VerilatedMutex s_mutex;
     const VerilatedLockGuard lock{s_mutex};  // Otherwise rand is unsafe
-    // Seed the system RNG once with a non-deterministic value, since
-    // lrand48()/rand() otherwise default to a fixed seed of 0 and would
-    // make every "unseeded" simulation run produce identical output.
-    static const bool s_seeded = []() {
-        const uint64_t now = static_cast<uint64_t>(std::time(nullptr));
-#if defined(_WIN32) && !defined(__CYGWIN__)
-        std::srand(static_cast<unsigned>(now));
-#else
-        srand48(static_cast<long>(now) ^ static_cast<long>(getpid()));
-#endif
-        return true;
-    }();
-    (void)s_seeded;
 #if defined(_WIN32) && !defined(__CYGWIN__)
     // Windows doesn't have lrand48(), although Cygwin does.
     return (std::rand() << 16) ^ std::rand();
@@ -3238,6 +3226,35 @@ std::pair<int, char**> VerilatedContextImp::argc_argv() VL_MT_SAFE_EXCLUDES(m_ar
     return std::make_pair(s_argc, s_argvp);
 }
 
+// MurmurHash3 finalizer (32-bit). Avalanches the input bits so a
+// monotonically-incrementing source like a clock counter produces seeds
+// that look unrelated across closely-spaced invocations.
+static uint32_t murmurmix32(uint32_t h) {
+    h ^= h >> 16;
+    h *= 0x85ebca6b;
+    h ^= h >> 13;
+    h *= 0xc2b2ae35;
+    h ^= h >> 16;
+    return h;
+}
+
+// Derive a non-deterministic non-zero positive seed value from the
+// high-resolution clock. Used to implement +verilator+seed+0, which means
+// "pick a random seed". Returning the actual picked value lets
+// $get_initial_random_seed() expose it so the user can reproduce the run
+// later by passing +verilator+seed+<that_value>.
+static uint64_t pickRandomSeed() VL_MT_SAFE {
+    using namespace std::chrono;
+    const uint64_t t = static_cast<uint64_t>(
+        high_resolution_clock::now().time_since_epoch().count());
+    const uint32_t folded = static_cast<uint32_t>(t >> 32) ^ static_cast<uint32_t>(t);
+    const uint32_t mixed = murmurmix32(folded);
+    // Keep within [1, INT_MAX] so it round-trips through the int seed field.
+    uint64_t seed = static_cast<uint64_t>(mixed) & 0x7fffffffULL;
+    if (seed == 0) seed = 1;
+    return seed;
+}
+
 void VerilatedContextImp::commandArgVl(const std::string& arg) {
     if (0 == std::strncmp(arg.c_str(), "+verilator+", std::strlen("+verilator+"))) {
         std::string str;
@@ -3277,6 +3294,12 @@ void VerilatedContextImp::commandArgVl(const std::string& arg) {
             warnUnsatConstr(u64 == 0);  // wno means disable, so invert
         } else if (commandArgVlUint64(arg, "+verilator+seed+", u64, 0,
                                       std::numeric_limits<int>::max())) {
+            // +verilator+seed+0 means "pick a random seed". Replace the
+            // user-supplied 0 with a non-deterministic non-zero value derived
+            // from the high-resolution clock and store that as the actual
+            // seed, so $get_initial_random_seed() returns the picked value
+            // and the run can be reproduced by passing +verilator+seed+<that_value>.
+            if (u64 == 0) u64 = pickRandomSeed();
             randSeed(static_cast<int>(u64));
         } else if (arg == "+verilator+V") {
             VerilatedImp::versionDump();  // Someday more info too

--- a/include/verilated.cpp
+++ b/include/verilated.cpp
@@ -3229,7 +3229,7 @@ std::pair<int, char**> VerilatedContextImp::argc_argv() VL_MT_SAFE_EXCLUDES(m_ar
 // MurmurHash3 finalizer (32-bit). Avalanches the input bits so a
 // monotonically-incrementing source like a clock counter produces seeds
 // that look unrelated across closely-spaced invocations.
-static uint32_t murmurmix32(uint32_t h) {
+static uint32_t murmurmix32(uint32_t h) VL_MT_SAFE {
     h ^= h >> 16;
     h *= 0x85ebca6b;
     h ^= h >> 13;

--- a/include/verilated.cpp
+++ b/include/verilated.cpp
@@ -3226,31 +3226,23 @@ std::pair<int, char**> VerilatedContextImp::argc_argv() VL_MT_SAFE_EXCLUDES(m_ar
     return std::make_pair(s_argc, s_argvp);
 }
 
-// MurmurHash3 finalizer (32-bit). Avalanches the input bits so a
-// monotonically-incrementing source like a clock counter produces seeds
-// that look unrelated across closely-spaced invocations.
-static uint32_t murmurmix32(uint32_t h) VL_MT_SAFE {
-    h ^= h >> 16;
-    h *= 0x85ebca6b;
-    h ^= h >> 13;
-    h *= 0xc2b2ae35;
-    h ^= h >> 16;
-    return h;
-}
-
-// Derive a non-deterministic non-zero positive seed value from the
-// high-resolution clock. Used to implement +verilator+seed+0, which means
-// "pick a random seed". Returning the actual picked value lets
-// $get_initial_random_seed() expose it so the user can reproduce the run
-// later by passing +verilator+seed+<that_value>.
+// Derive a non-deterministic non-zero positive seed value from the system
+// clocks. Used to implement +verilator+seed+0, which means "pick a random
+// seed". Returning the actual picked value lets $get_initial_random_seed()
+// expose it so the user can reproduce the run later by passing
+// +verilator+seed+<that_value>.
 static uint64_t pickRandomSeed() VL_MT_SAFE {
     using namespace std::chrono;
-    const uint64_t t = static_cast<uint64_t>(
-        high_resolution_clock::now().time_since_epoch().count());
-    const uint32_t folded = static_cast<uint32_t>(t >> 32) ^ static_cast<uint32_t>(t);
-    const uint32_t mixed = murmurmix32(folded);
+    // Combine steady_clock and system_clock to get entropy even when one has
+    // low resolution (e.g. high_resolution_clock aliases system_clock on MSVC).
+    const uint64_t t1 = static_cast<uint64_t>(
+        duration_cast<microseconds>(steady_clock::now().time_since_epoch()).count());
+    const uint64_t t2 = static_cast<uint64_t>(
+        duration_cast<microseconds>(system_clock::now().time_since_epoch()).count());
+    // vl_splitmix64 avalanches bits so closely-spaced timestamps look unrelated.
+    uint64_t seed = vl_splitmix64(t1 ^ t2).second;
     // Keep within [1, INT_MAX] so it round-trips through the int seed field.
-    uint64_t seed = static_cast<uint64_t>(mixed) & 0x7fffffffULL;
+    seed &= 0x7fffffffULL;
     if (seed == 0) seed = 1;
     return seed;
 }

--- a/include/verilated.h
+++ b/include/verilated.h
@@ -391,7 +391,7 @@ protected:
         int m_errorCount = 0;  // Number of errors
         int m_errorLimit = 1;  // Stop on error number
         int m_randReset = 0;  // Random reset: 0=all 0s, 1=all 1s, 2=random
-        int m_randSeed = 0;  // Random seed: 0=random
+        int m_randSeed = 1;  // Random seed (default 1; +verilator+seed+0 picks at parse time)
         static constexpr int UNITS_NONE = 99;  // Default based on precision
         int m_timeFormatUnits = UNITS_NONE;  // $timeformat units
         int m_timeFormatPrecision = 0;  // $timeformat number of decimal places

--- a/test_regress/t/t_runflag_seed_zero.py
+++ b/test_regress/t/t_runflag_seed_zero.py
@@ -4,7 +4,7 @@
 # This program is free software; you can redistribute it and/or modify it
 # under the terms of either the GNU Lesser General Public License Version 3
 # or the Perl Artistic License Version 2.0.
-# SPDX-FileCopyrightText: 2026 Miguel Perez Andrade
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
 # SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
 
 import time

--- a/test_regress/t/t_runflag_seed_zero.py
+++ b/test_regress/t/t_runflag_seed_zero.py
@@ -7,8 +7,6 @@
 # SPDX-FileCopyrightText: 2026 Wilson Snyder
 # SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
 
-import time
-
 import vltest_bootstrap
 
 # +verilator+seed+0 should pick a non-zero random seed at startup, expose it
@@ -27,9 +25,6 @@ for i in range(3):
     if match is None:
         test.error("Could not parse 'seed=NNN' from " + logfile)
     seeds.append(int(match[0]))
-    # Sleep enough to make sure time() advances at least once between runs,
-    # so we don't depend solely on getpid() for entropy.
-    time.sleep(1.1)
 
 if any(s == 0 for s in seeds):
     test.error("+verilator+seed+0 produced a zero seed: " + repr(seeds))

--- a/test_regress/t/t_runflag_seed_zero.py
+++ b/test_regress/t/t_runflag_seed_zero.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2026 Miguel Perez Andrade
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import time
+
+import vltest_bootstrap
+
+# +verilator+seed+0 should pick a non-zero random seed at startup, expose it
+# through $get_initial_random_seed(), and pick a different value across runs
+# so independent invocations are not deterministic.
+
+test.scenarios('vlt')
+
+test.compile(verilator_flags2=['--binary'])
+
+seeds = []
+for i in range(3):
+    logfile = test.obj_dir + "/seed_zero_run" + str(i) + ".log"
+    test.execute(all_run_flags=['+verilator+seed+0'], logfile=logfile)
+    match = test.file_grep(logfile, r'seed=([0-9]+)')
+    if match is None:
+        test.error("Could not parse 'seed=NNN' from " + logfile)
+    seeds.append(int(match[0]))
+    # Sleep enough to make sure time() advances at least once between runs,
+    # so we don't depend solely on getpid() for entropy.
+    time.sleep(1.1)
+
+if any(s == 0 for s in seeds):
+    test.error("+verilator+seed+0 produced a zero seed: " + repr(seeds))
+
+if len(set(seeds)) < 2:
+    test.error("+verilator+seed+0 must vary across runs, got: " + repr(seeds))
+
+test.passes()

--- a/test_regress/t/t_runflag_seed_zero.v
+++ b/test_regress/t/t_runflag_seed_zero.v
@@ -5,12 +5,12 @@
 // SPDX-License-Identifier: CC0-1.0
 
 module t;
-   int seed;
-   initial begin
-      seed = $get_initial_random_seed();
-      $display("seed=%0d", seed);
-      if (seed == 0) $stop;  // +verilator+seed+0 must be replaced by a non-zero picked seed
-      $write("*-* All Finished *-*\n");
-      $finish(2);
-   end
+  int seed;
+  initial begin
+    seed = $get_initial_random_seed();
+    $display("seed=%0d", seed);
+    if (seed == 0) $stop;  // +verilator+seed+0 must be replaced by a non-zero picked seed
+    $write("*-* All Finished *-*\n");
+    $finish(2);
+  end
 endmodule

--- a/test_regress/t/t_runflag_seed_zero.v
+++ b/test_regress/t/t_runflag_seed_zero.v
@@ -1,7 +1,7 @@
 // DESCRIPTION: Verilator: Verilog Test module
 //
 // This file ONLY is placed under the Creative Commons Public Domain.
-// SPDX-FileCopyrightText: 2026 Miguel Perez Andrade
+// SPDX-FileCopyrightText: 2026 Wilson Snyder
 // SPDX-License-Identifier: CC0-1.0
 
 module t;

--- a/test_regress/t/t_runflag_seed_zero.v
+++ b/test_regress/t/t_runflag_seed_zero.v
@@ -1,0 +1,16 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain.
+// SPDX-FileCopyrightText: 2026 Miguel Perez Andrade
+// SPDX-License-Identifier: CC0-1.0
+
+module t;
+   int seed;
+   initial begin
+      seed = $get_initial_random_seed();
+      $display("seed=%0d", seed);
+      if (seed == 0) $stop;  // +verilator+seed+0 must be replaced by a non-zero picked seed
+      $write("*-* All Finished *-*\n");
+      $finish(2);
+   end
+endmodule

--- a/test_regress/t/t_x_rand_mt_stability.out
+++ b/test_regress/t/t_x_rand_mt_stability.out
@@ -1,17 +1,17 @@
-uninitialized = 0xb108d062
+uninitialized = 0x0bb690d6
 x_assigned (initial) = 0x00000000
-uninitialized2 = 0xca249856
-big = 0x0d97b7afc0a2ac6784d0eaa74cd8feaf468cf05328c319f1a26fc1b219605edd
-random_init = 0x65d066c8
-top.t.the_sub_yes_inline_1 no_init 0x6f6ddbaeadd8dba4
-top.t.the_sub_yes_inline_2 no_init 0xfdf89c0b44e7f5d8
-top.t.the_sub_no_inline_1 no_init 0x76dc510f643e939
-top.t.the_sub_no_inline_2 no_init 0x61a6ab3d0369cf60
-rand = 0xc31fbc3d
-rand = 0xcbb440c9
-rand = 0x030234c6
-rand = 0xf53bab60
-rand = 0xcf071500
-x_assigned = 0x80742d9b
-Last rand = 0xddacca56
+uninitialized2 = 0xdf5768de
+big = 0x355d75711c3bf0ca3e65805db585c43beae34b336b9dbe44a2d040cbe101a665
+random_init = 0x5fa24450
+top.t.the_sub_yes_inline_1 no_init 0x842cd8b1033a58
+top.t.the_sub_yes_inline_2 no_init 0xa36c65459f4b9f46
+top.t.the_sub_no_inline_1 no_init 0x42d55205d10c58f8
+top.t.the_sub_no_inline_2 no_init 0xac98037e5042d96d
+rand = 0x5fa24450
+rand = 0x24800459
+rand = 0xfd8d9d77
+rand = 0xb722072d
+rand = 0x244113f3
+x_assigned = 0x08507ff6
+Last rand = 0x776efb08
 *-* All Finished *-*

--- a/test_regress/t/t_x_rand_mt_stability_add.out
+++ b/test_regress/t/t_x_rand_mt_stability_add.out
@@ -1,17 +1,17 @@
-uninitialized = 0xb108d062
+uninitialized = 0x0bb690d6
 x_assigned (initial) = 0x00000000
-uninitialized2 = 0xca249856
-big = 0x0d97b7afc0a2ac6784d0eaa74cd8feaf468cf05328c319f1a26fc1b219605edd
-random_init = 0x65d066c8
-top.t.the_sub_yes_inline_1 no_init 0x6f6ddbaeadd8dba4
-top.t.the_sub_yes_inline_2 no_init 0xfdf89c0b44e7f5d8
-top.t.the_sub_no_inline_1 no_init 0x76dc510f643e939
-top.t.the_sub_no_inline_2 no_init 0x61a6ab3d0369cf60
-rand = 0xc31fbc3d
-rand = 0xcbb440c9
-rand = 0x030234c6
-rand = 0xf53bab60
-rand = 0xcf071500
-x_assigned = 0x80742d9b
-Last rand = 0xddacca56
+uninitialized2 = 0xdf5768de
+big = 0x355d75711c3bf0ca3e65805db585c43beae34b336b9dbe44a2d040cbe101a665
+random_init = 0x5fa24450
+top.t.the_sub_yes_inline_1 no_init 0x842cd8b1033a58
+top.t.the_sub_yes_inline_2 no_init 0xa36c65459f4b9f46
+top.t.the_sub_no_inline_1 no_init 0x42d55205d10c58f8
+top.t.the_sub_no_inline_2 no_init 0xac98037e5042d96d
+rand = 0x5fa24450
+rand = 0x24800459
+rand = 0xfd8d9d77
+rand = 0xb722072d
+rand = 0x244113f3
+x_assigned = 0x08507ff6
+Last rand = 0x776efb08
 *-* All Finished *-*

--- a/test_regress/t/t_x_rand_mt_stability_add_trace.out
+++ b/test_regress/t/t_x_rand_mt_stability_add_trace.out
@@ -1,17 +1,17 @@
-uninitialized = 0xb108d062
+uninitialized = 0x0bb690d6
 x_assigned (initial) = 0x00000000
-uninitialized2 = 0xca249856
-big = 0x0d97b7afc0a2ac6784d0eaa74cd8feaf468cf05328c319f1a26fc1b219605edd
-random_init = 0x65d066c8
-top.t.the_sub_yes_inline_1 no_init 0x6f6ddbaeadd8dba4
-top.t.the_sub_yes_inline_2 no_init 0xfdf89c0b44e7f5d8
-top.t.the_sub_no_inline_1 no_init 0x76dc510f643e939
-top.t.the_sub_no_inline_2 no_init 0x61a6ab3d0369cf60
-rand = 0xc31fbc3d
-rand = 0xcbb440c9
-rand = 0x030234c6
-rand = 0xf53bab60
-rand = 0xcf071500
-x_assigned = 0x80742d9b
-Last rand = 0xddacca56
+uninitialized2 = 0xdf5768de
+big = 0x355d75711c3bf0ca3e65805db585c43beae34b336b9dbe44a2d040cbe101a665
+random_init = 0x5fa24450
+top.t.the_sub_yes_inline_1 no_init 0x842cd8b1033a58
+top.t.the_sub_yes_inline_2 no_init 0xa36c65459f4b9f46
+top.t.the_sub_no_inline_1 no_init 0x42d55205d10c58f8
+top.t.the_sub_no_inline_2 no_init 0xac98037e5042d96d
+rand = 0x5fa24450
+rand = 0x24800459
+rand = 0xfd8d9d77
+rand = 0xb722072d
+rand = 0x244113f3
+x_assigned = 0x08507ff6
+Last rand = 0x776efb08
 *-* All Finished *-*

--- a/test_regress/t/t_x_rand_mt_stability_trace.out
+++ b/test_regress/t/t_x_rand_mt_stability_trace.out
@@ -1,17 +1,17 @@
-uninitialized = 0xb108d062
+uninitialized = 0x0bb690d6
 x_assigned (initial) = 0x00000000
-uninitialized2 = 0xca249856
-big = 0x0d97b7afc0a2ac6784d0eaa74cd8feaf468cf05328c319f1a26fc1b219605edd
-random_init = 0x65d066c8
-top.t.the_sub_yes_inline_1 no_init 0x6f6ddbaeadd8dba4
-top.t.the_sub_yes_inline_2 no_init 0xfdf89c0b44e7f5d8
-top.t.the_sub_no_inline_1 no_init 0x76dc510f643e939
-top.t.the_sub_no_inline_2 no_init 0x61a6ab3d0369cf60
-rand = 0xc31fbc3d
-rand = 0xcbb440c9
-rand = 0x030234c6
-rand = 0xf53bab60
-rand = 0xcf071500
-x_assigned = 0x80742d9b
-Last rand = 0xddacca56
+uninitialized2 = 0xdf5768de
+big = 0x355d75711c3bf0ca3e65805db585c43beae34b336b9dbe44a2d040cbe101a665
+random_init = 0x5fa24450
+top.t.the_sub_yes_inline_1 no_init 0x842cd8b1033a58
+top.t.the_sub_yes_inline_2 no_init 0xa36c65459f4b9f46
+top.t.the_sub_no_inline_1 no_init 0x42d55205d10c58f8
+top.t.the_sub_no_inline_2 no_init 0xac98037e5042d96d
+rand = 0x5fa24450
+rand = 0x24800459
+rand = 0xfd8d9d77
+rand = 0xb722072d
+rand = 0x244113f3
+x_assigned = 0x08507ff6
+Last rand = 0x776efb08
 *-* All Finished *-*

--- a/test_regress/t/t_x_rand_mt_stability_zeros.out
+++ b/test_regress/t/t_x_rand_mt_stability_zeros.out
@@ -2,16 +2,16 @@ uninitialized = 0x00000000
 x_assigned (initial) = 0x00000000
 uninitialized2 = 0x00000000
 big = 0x0000000000000000000000000000000000000000000000000000000000000000
-random_init = 0x65d066c8
+random_init = 0x5fa24450
 top.t.the_sub_yes_inline_1 no_init 0x0
 top.t.the_sub_yes_inline_2 no_init 0x0
 top.t.the_sub_no_inline_1 no_init 0x0
 top.t.the_sub_no_inline_2 no_init 0x0
-rand = 0xc31fbc3d
-rand = 0xcbb440c9
-rand = 0x030234c6
-rand = 0xf53bab60
-rand = 0xcf071500
-x_assigned = 0x80742d9b
-Last rand = 0xddacca56
+rand = 0x5fa24450
+rand = 0x24800459
+rand = 0xfd8d9d77
+rand = 0xb722072d
+rand = 0x244113f3
+x_assigned = 0x08507ff6
+Last rand = 0x776efb08
 *-* All Finished *-*

--- a/test_regress/t/t_x_rand_stability.out
+++ b/test_regress/t/t_x_rand_stability.out
@@ -1,17 +1,17 @@
-uninitialized = 0xb108d062
+uninitialized = 0x0bb690d6
 x_assigned (initial) = 0x00000000
-uninitialized2 = 0xca249856
-big = 0x0d97b7afc0a2ac6784d0eaa74cd8feaf468cf05328c319f1a26fc1b219605edd
-random_init = 0x65d066c8
-top.t.the_sub_yes_inline_1 no_init 0x6f6ddbaeadd8dba4
-top.t.the_sub_yes_inline_2 no_init 0xfdf89c0b44e7f5d8
-top.t.the_sub_no_inline_1 no_init 0x76dc510f643e939
-top.t.the_sub_no_inline_2 no_init 0x61a6ab3d0369cf60
-rand = 0xf89a1fb9
-rand = 0x0577f875
-rand = 0x7bc34037
-rand = 0x2027e5c6
-rand = 0xc57ff769
-x_assigned = 0x80742d9b
-Last rand = 0x37a9fa91
+uninitialized2 = 0xdf5768de
+big = 0x355d75711c3bf0ca3e65805db585c43beae34b336b9dbe44a2d040cbe101a665
+random_init = 0x5fa24450
+top.t.the_sub_yes_inline_1 no_init 0x842cd8b1033a58
+top.t.the_sub_yes_inline_2 no_init 0xa36c65459f4b9f46
+top.t.the_sub_no_inline_1 no_init 0x42d55205d10c58f8
+top.t.the_sub_no_inline_2 no_init 0xac98037e5042d96d
+rand = 0x24800459
+rand = 0xfd8d9d77
+rand = 0xb722072d
+rand = 0x244113f3
+rand = 0x776efb08
+x_assigned = 0x08507ff6
+Last rand = 0x8b3a9df4
 *-* All Finished *-*

--- a/test_regress/t/t_x_rand_stability_add.out
+++ b/test_regress/t/t_x_rand_stability_add.out
@@ -1,17 +1,17 @@
-uninitialized = 0xb108d062
+uninitialized = 0x0bb690d6
 x_assigned (initial) = 0x00000000
-uninitialized2 = 0xca249856
-big = 0x0d97b7afc0a2ac6784d0eaa74cd8feaf468cf05328c319f1a26fc1b219605edd
-random_init = 0x65d066c8
-top.t.the_sub_yes_inline_1 no_init 0x6f6ddbaeadd8dba4
-top.t.the_sub_yes_inline_2 no_init 0xfdf89c0b44e7f5d8
-top.t.the_sub_no_inline_1 no_init 0x76dc510f643e939
-top.t.the_sub_no_inline_2 no_init 0x61a6ab3d0369cf60
-rand = 0xf89a1fb9
-rand = 0x0577f875
-rand = 0x7bc34037
-rand = 0x2027e5c6
-rand = 0xc57ff769
-x_assigned = 0x80742d9b
-Last rand = 0x37a9fa91
+uninitialized2 = 0xdf5768de
+big = 0x355d75711c3bf0ca3e65805db585c43beae34b336b9dbe44a2d040cbe101a665
+random_init = 0x5fa24450
+top.t.the_sub_yes_inline_1 no_init 0x842cd8b1033a58
+top.t.the_sub_yes_inline_2 no_init 0xa36c65459f4b9f46
+top.t.the_sub_no_inline_1 no_init 0x42d55205d10c58f8
+top.t.the_sub_no_inline_2 no_init 0xac98037e5042d96d
+rand = 0x24800459
+rand = 0xfd8d9d77
+rand = 0xb722072d
+rand = 0x244113f3
+rand = 0x776efb08
+x_assigned = 0x08507ff6
+Last rand = 0x8b3a9df4
 *-* All Finished *-*

--- a/test_regress/t/t_x_rand_stability_add_trace.out
+++ b/test_regress/t/t_x_rand_stability_add_trace.out
@@ -1,17 +1,17 @@
-uninitialized = 0xb108d062
+uninitialized = 0x0bb690d6
 x_assigned (initial) = 0x00000000
-uninitialized2 = 0xca249856
-big = 0x0d97b7afc0a2ac6784d0eaa74cd8feaf468cf05328c319f1a26fc1b219605edd
-random_init = 0x65d066c8
-top.t.the_sub_yes_inline_1 no_init 0x6f6ddbaeadd8dba4
-top.t.the_sub_yes_inline_2 no_init 0xfdf89c0b44e7f5d8
-top.t.the_sub_no_inline_1 no_init 0x76dc510f643e939
-top.t.the_sub_no_inline_2 no_init 0x61a6ab3d0369cf60
-rand = 0xf89a1fb9
-rand = 0x0577f875
-rand = 0x7bc34037
-rand = 0x2027e5c6
-rand = 0xc57ff769
-x_assigned = 0x80742d9b
-Last rand = 0x37a9fa91
+uninitialized2 = 0xdf5768de
+big = 0x355d75711c3bf0ca3e65805db585c43beae34b336b9dbe44a2d040cbe101a665
+random_init = 0x5fa24450
+top.t.the_sub_yes_inline_1 no_init 0x842cd8b1033a58
+top.t.the_sub_yes_inline_2 no_init 0xa36c65459f4b9f46
+top.t.the_sub_no_inline_1 no_init 0x42d55205d10c58f8
+top.t.the_sub_no_inline_2 no_init 0xac98037e5042d96d
+rand = 0x24800459
+rand = 0xfd8d9d77
+rand = 0xb722072d
+rand = 0x244113f3
+rand = 0x776efb08
+x_assigned = 0x08507ff6
+Last rand = 0x8b3a9df4
 *-* All Finished *-*

--- a/test_regress/t/t_x_rand_stability_trace.out
+++ b/test_regress/t/t_x_rand_stability_trace.out
@@ -1,17 +1,17 @@
-uninitialized = 0xb108d062
+uninitialized = 0x0bb690d6
 x_assigned (initial) = 0x00000000
-uninitialized2 = 0xca249856
-big = 0x0d97b7afc0a2ac6784d0eaa74cd8feaf468cf05328c319f1a26fc1b219605edd
-random_init = 0x65d066c8
-top.t.the_sub_yes_inline_1 no_init 0x6f6ddbaeadd8dba4
-top.t.the_sub_yes_inline_2 no_init 0xfdf89c0b44e7f5d8
-top.t.the_sub_no_inline_1 no_init 0x76dc510f643e939
-top.t.the_sub_no_inline_2 no_init 0x61a6ab3d0369cf60
-rand = 0xf89a1fb9
-rand = 0x0577f875
-rand = 0x7bc34037
-rand = 0x2027e5c6
-rand = 0xc57ff769
-x_assigned = 0x80742d9b
-Last rand = 0x37a9fa91
+uninitialized2 = 0xdf5768de
+big = 0x355d75711c3bf0ca3e65805db585c43beae34b336b9dbe44a2d040cbe101a665
+random_init = 0x5fa24450
+top.t.the_sub_yes_inline_1 no_init 0x842cd8b1033a58
+top.t.the_sub_yes_inline_2 no_init 0xa36c65459f4b9f46
+top.t.the_sub_no_inline_1 no_init 0x42d55205d10c58f8
+top.t.the_sub_no_inline_2 no_init 0xac98037e5042d96d
+rand = 0x24800459
+rand = 0xfd8d9d77
+rand = 0xb722072d
+rand = 0x244113f3
+rand = 0x776efb08
+x_assigned = 0x08507ff6
+Last rand = 0x8b3a9df4
 *-* All Finished *-*

--- a/test_regress/t/t_x_rand_stability_zeros.out
+++ b/test_regress/t/t_x_rand_stability_zeros.out
@@ -2,16 +2,16 @@ uninitialized = 0x00000000
 x_assigned (initial) = 0x00000000
 uninitialized2 = 0x00000000
 big = 0x0000000000000000000000000000000000000000000000000000000000000000
-random_init = 0x65d066c8
+random_init = 0x5fa24450
 top.t.the_sub_yes_inline_1 no_init 0x0
 top.t.the_sub_yes_inline_2 no_init 0x0
 top.t.the_sub_no_inline_1 no_init 0x0
 top.t.the_sub_no_inline_2 no_init 0x0
-rand = 0xf89a1fb9
-rand = 0x0577f875
-rand = 0x7bc34037
-rand = 0x2027e5c6
-rand = 0xc57ff769
-x_assigned = 0x80742d9b
-Last rand = 0x37a9fa91
+rand = 0x24800459
+rand = 0xfd8d9d77
+rand = 0xb722072d
+rand = 0x244113f3
+rand = 0x776efb08
+x_assigned = 0x08507ff6
+Last rand = 0x8b3a9df4
 *-* All Finished *-*


### PR DESCRIPTION
Closes #7325.

## Summary

The runtime documentation for `+verilator+seed+<value>` (`docs/guide/exe_sim.rst`) says:

> For `$random` and `--x-initial unique`, set the simulation runtime random seed value. If zero or not specified picks a value from the system random number generator.

Two issues prevented this from working:

1. **`+verilator+seed+0` was rejected** as an invalid argument, even though `0` is documented to mean "pick a value from the system RNG". The command-line parser enforced a minimum of `1`.
2. **The "system RNG" path was deterministic.** When the seed defaulted to `0` (or was omitted), `vl_sys_rand32()` called `lrand48()` without ever calling `srand48()`. Per POSIX, `lrand48()` falls back to a fixed seed of `0`, so unseeded simulations produced identical output on every invocation — silently defeating users who relied on the documented randomization.

This PR fixes both, so the runtime behavior matches the docs.

## Changes

All changes are in `include/verilated.cpp`.

### 1. Accept `+verilator+seed+0`

Lower the minimum value of the `+verilator+seed+` argument from `1` to `0`:

```diff
-} else if (commandArgVlUint64(arg, "+verilator+seed+", u64, 1,
+} else if (commandArgVlUint64(arg, "+verilator+seed+", u64, 0,
                                std::numeric_limits<int>::max())) {
     randSeed(static_cast<int>(u64));
```

The downstream code in `VerilatedContextImp::randSeedDefault64()` already treats `0` as "use the system RNG", so no further changes are needed for this leg.

### 2. Seed the system RNG once on first use

Inside `vl_sys_rand32()`, seed `lrand48()` (POSIX) or `std::rand()` (Windows) exactly once with a non-deterministic value derived from `time()` and `getpid()`. This is done with a function-local static initializer so it runs lazily on first use and only once for the lifetime of the process. The existing mutex covers concurrent first-callers, and C++11's thread-safe local-static initialization covers any path where the mutex is removed in the future.

```diff
 static uint32_t vl_sys_rand32() VL_MT_SAFE {
     // Return random 32-bits using system library.
     // Used only to construct seed for Verilator's PRNG.
     static VerilatedMutex s_mutex;
     const VerilatedLockGuard lock{s_mutex};  // Otherwise rand is unsafe
+    // Seed the system RNG once with a non-deterministic value, since
+    // lrand48()/rand() otherwise default to a fixed seed of 0 and would
+    // make every "unseeded" simulation run produce identical output.
+    static const bool s_seeded = []() {
+        const uint64_t now = static_cast<uint64_t>(std::time(nullptr));
+#if defined(_WIN32) && !defined(__CYGWIN__)
+        std::srand(static_cast<unsigned>(now));
+#else
+        srand48(static_cast<long>(now) ^ static_cast<long>(getpid()));
+#endif
+        return true;
+    }();
+    (void)s_seeded;
 #if defined(_WIN32) && !defined(__CYGWIN__)
     // Windows doesn't have lrand48(), although Cygwin does.
     return (std::rand() << 16) ^ std::rand();
 #else
     return (lrand48() << 16) ^ lrand48();
 #endif
 }
```

Required headers (`<ctime>` for `std::time`, `<unistd.h>` for `getpid` on POSIX) are added alongside the existing includes.

## Behavior matrix

| Invocation | Stock (before) | Fixed (this PR) |
|---|---|---|
| `+verilator+seed+0` | fatal error: *"must be ... greater than 0"* | runs, picks from system RNG |
| no `+verilator+seed` | runs, **same** result every invocation | runs, **different** result each invocation |
| `+verilator+seed+N` (N > 0) | deterministic | deterministic (unchanged) |

## How to verify

A small reproducer:

```sv
// top.sv
module top;
  initial begin
    $display("rand=%0d", $urandom());
    $finish;
  end
endmodule
```

Build with the patched verilator:

```bash
verilator --binary -j 0 top.sv
```

Then:

```bash
# Bug 1 — used to error out, now exits 0 with a value
./obj_dir/Vtop +verilator+seed+0

# Bug 2 — three different values; was three identical values
./obj_dir/Vtop ; ./obj_dir/Vtop ; ./obj_dir/Vtop

# Sanity — explicit non-zero seed remains reproducible
./obj_dir/Vtop +verilator+seed+42
./obj_dir/Vtop +verilator+seed+42

# Combined — seed=0 now behaves like no seed (varies run-to-run)
./obj_dir/Vtop +verilator+seed+0
./obj_dir/Vtop +verilator+seed+0
./obj_dir/Vtop +verilator+seed+0
```

A side-by-side regression script comparing the stock binary against the patched build is included as `test_seed_fix.sh` [test_seed_fix.sh](https://github.com/user-attachments/files/27218346/test_seed_fix.sh)

Result from running it:

<img width="996" height="1090" alt="image" src="https://github.com/user-attachments/assets/37b48fe6-141f-437d-a569-2ba5b50d83eb" />
