### PR TITLE
[Doc] Update the documentation of DPI example

### DIFF
--- a/docs/guide/connecting.rst
+++ b/docs/guide/connecting.rst
@@ -184,7 +184,7 @@ Verilog, put in our.v:
 
    initial begin
      $display("%x + %x = %x", 1, 2, add(1,2));
-   endtask
+   end
 
 Then after Verilating, Verilator will create a file Vour__Dpi.h with the
 prototype to call this function:


### PR DESCRIPTION
The terminator of initial block was wrongly used as `endtask`, which should be `end`. Fix #7532 .

