### PR TITLE
Fix unused variables

### DIFF
--- a/include/verilated_fst_c.cpp
+++ b/include/verilated_fst_c.cpp
@@ -137,6 +137,7 @@ void VerilatedFst::declDTypeEnum(int dtypenum, const char* name, uint32_t elemen
         = fstWriterCreateEnumTable(m_fst, name, elements, minValbits, itemNamesp, itemValuesp);
     const bool newEntry = m_local2fstdtype[initUserp()].emplace(dtypenum, enumNum).second;
     assert(newEntry);
+    (void)newEntry;  // Prevent unused variable warning when asserts are disabled
 }
 
 void VerilatedFst::pushPrefix(const char* namep, VerilatedTracePrefixType type, int left,

--- a/include/verilated_trace_imp.h
+++ b/include/verilated_trace_imp.h
@@ -327,7 +327,6 @@ void VerilatedTrace<VL_SUB_T, VL_BUF_T>::dump(uint64_t timeui) VL_MT_SAFE_EXCLUD
         if (!preChangeDump()) return;
     }
 
-    uint32_t* bufferp = nullptr;
     // Update time point
     emitTimeChange(timeui);
 
@@ -355,7 +354,6 @@ void VerilatedTrace<VL_SUB_T, VL_BUF_T>::addModel(VerilatedModel* modelp)
     VL_MT_SAFE_EXCLUDES(m_mutex) {
     const VerilatedLockGuard lock{m_mutex};
 
-    const bool firstModel = m_models.empty();
     const bool newModel = m_models.insert(modelp).second;
     VerilatedContext* const contextp = modelp->contextp();
 


### PR DESCRIPTION
This PR fixes a few unused variables to prevent compiler warnings/errors. Two in `verilated_trace_imp.h` that are not used at all (looks like those are leftovers after https://github.com/verilator/verilator/pull/7443) and one in `VerilatedFst::declDTypeEnum` that is unused when assertions are disabled