### PR TITLE
Support `assign` expression coverage (#7542)

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -263,6 +263,7 @@ Szymon Gizler
 Sören Tempel
 Teng Huang
 Thomas Aldrian
+Thomas Brown
 Thomas Dybdahl Ahle
 Tim Hutt
 Tim Snyder

--- a/src/V3Coverage.cpp
+++ b/src/V3Coverage.cpp
@@ -290,8 +290,15 @@ class CoverageVisitor final : public VNVisitor {
     }
     void visit(AstAlways* nodep) override {
         if (nodep->keyword() == VAlwaysKwd::CONT_ASSIGN) {
-            // Don't want line coverage for it, iterate for expression/toggle coverage only
+            // Handle continuous assigns for expression coverage (but not line coverage)
+            VL_RESTORER(m_state);
+            VL_RESTORER(m_exprStmtsp);
+            VL_RESTORER(m_inToggleOff);
+            m_exprStmtsp = nodep;
+            m_inToggleOff = true;
+            createHandle(nodep);
             iterateChildren(nodep);
+            // Note: No line coverage for continuous assigns
             return;
         }
         iterateProcedure(nodep);

--- a/test_regress/t/t_cover_expr.out
+++ b/test_regress/t/t_cover_expr.out
@@ -22,6 +22,7 @@
           integer some_int;
           integer other_int;
           logic some_bool;
+          logic [1:0] assign_lhs;
         
           wire t1 = cyc[0];
           wire t2 = cyc[1];
@@ -282,6 +283,18 @@
 -000002  point: type=expr comment=(t1==1 && t2==1) => 1 hier=top.t
 -000005  point: type=expr comment=(t2==0) => 0 hier=top.t
           end
+        
+%000005   assign assign_lhs[0] = t1 && t2;
+-000005  point: type=expr comment=(t1==0) => 0 hier=top.t
+-000002  point: type=expr comment=(t1==1 && t2==1) => 1 hier=top.t
+-000005  point: type=expr comment=(t2==0) => 0 hier=top.t
+%000003   assign assign_lhs[1] = (t1 && t2) || (t3 && t4);
+-000003  point: type=expr comment=(t1==0 && t3==0) => 0 hier=top.t
+-000003  point: type=expr comment=(t1==0 && t4==0) => 0 hier=top.t
+-000002  point: type=expr comment=(t1==1 && t2==1) => 1 hier=top.t
+-000003  point: type=expr comment=(t2==0 && t3==0) => 0 hier=top.t
+-000003  point: type=expr comment=(t2==0 && t4==0) => 0 hier=top.t
+-000000  point: type=expr comment=(t3==1 && t4==1) => 1 hier=top.t
         
           logic ta, tb, tc;
           initial begin

--- a/test_regress/t/t_cover_expr.v
+++ b/test_regress/t/t_cover_expr.v
@@ -21,6 +21,7 @@ module t (
   integer some_int;
   integer other_int;
   logic some_bool;
+  logic [1:0] assign_lhs;
 
   wire t1 = cyc[0];
   wire t2 = cyc[1];
@@ -119,6 +120,9 @@ module t (
   always_comb begin
     if (t1 && t2) $write("");
   end
+
+  assign assign_lhs[0] = t1 && t2;
+  assign assign_lhs[1] = (t1 && t2) || (t3 && t4);
 
   logic ta, tb, tc;
   initial begin

--- a/test_regress/t/t_cover_expr_max.out
+++ b/test_regress/t/t_cover_expr_max.out
@@ -22,6 +22,7 @@
           integer some_int;
           integer other_int;
           logic some_bool;
+          logic [1:0] assign_lhs;
         
           wire t1 = cyc[0];
           wire t2 = cyc[1];
@@ -410,6 +411,18 @@
 -000002  point: type=expr comment=(t1==1 && t2==1) => 1 hier=top.t
 -000005  point: type=expr comment=(t2==0) => 0 hier=top.t
           end
+        
+%000005   assign assign_lhs[0] = t1 && t2;
+-000005  point: type=expr comment=(t1==0) => 0 hier=top.t
+-000002  point: type=expr comment=(t1==1 && t2==1) => 1 hier=top.t
+-000005  point: type=expr comment=(t2==0) => 0 hier=top.t
+%000003   assign assign_lhs[1] = (t1 && t2) || (t3 && t4);
+-000003  point: type=expr comment=(t1==0 && t3==0) => 0 hier=top.t
+-000003  point: type=expr comment=(t1==0 && t4==0) => 0 hier=top.t
+-000002  point: type=expr comment=(t1==1 && t2==1) => 1 hier=top.t
+-000003  point: type=expr comment=(t2==0 && t3==0) => 0 hier=top.t
+-000003  point: type=expr comment=(t2==0 && t4==0) => 0 hier=top.t
+-000000  point: type=expr comment=(t3==1 && t4==1) => 1 hier=top.t
         
           logic ta, tb, tc;
           initial begin

--- a/test_regress/t/t_cover_expr_trace.out
+++ b/test_regress/t/t_cover_expr_trace.out
@@ -22,6 +22,7 @@
           integer some_int;
           integer other_int;
           logic some_bool;
+          logic [1:0] assign_lhs;
         
           wire t1 = cyc[0];
           wire t2 = cyc[1];
@@ -282,6 +283,18 @@
 -000002  point: type=expr comment=(t1==1 && t2==1) => 1 hier=top.t
 -000005  point: type=expr comment=(t2==0) => 0 hier=top.t
           end
+        
+%000005   assign assign_lhs[0] = t1 && t2;
+-000005  point: type=expr comment=(t1==0) => 0 hier=top.t
+-000002  point: type=expr comment=(t1==1 && t2==1) => 1 hier=top.t
+-000005  point: type=expr comment=(t2==0) => 0 hier=top.t
+%000003   assign assign_lhs[1] = (t1 && t2) || (t3 && t4);
+-000003  point: type=expr comment=(t1==0 && t3==0) => 0 hier=top.t
+-000003  point: type=expr comment=(t1==0 && t4==0) => 0 hier=top.t
+-000002  point: type=expr comment=(t1==1 && t2==1) => 1 hier=top.t
+-000003  point: type=expr comment=(t2==0 && t3==0) => 0 hier=top.t
+-000003  point: type=expr comment=(t2==0 && t4==0) => 0 hier=top.t
+-000000  point: type=expr comment=(t3==1 && t4==1) => 1 hier=top.t
         
           logic ta, tb, tc;
           initial begin

--- a/test_regress/t/t_cover_line_expr.out
+++ b/test_regress/t/t_cover_line_expr.out
@@ -25,6 +25,7 @@
           integer some_int;
           integer other_int;
           logic some_bool;
+          logic [1:0] assign_lhs;
         
           wire t1 = cyc[0];
           wire t2 = cyc[1];
@@ -392,6 +393,18 @@
 -000002  point: type=branch comment=if hier=top.t
 -000008  point: type=branch comment=else hier=top.t
           end
+        
+%000005   assign assign_lhs[0] = t1 && t2;
+-000005  point: type=expr comment=(t1==0) => 0 hier=top.t
+-000002  point: type=expr comment=(t1==1 && t2==1) => 1 hier=top.t
+-000005  point: type=expr comment=(t2==0) => 0 hier=top.t
+%000003   assign assign_lhs[1] = (t1 && t2) || (t3 && t4);
+-000003  point: type=expr comment=(t1==0 && t3==0) => 0 hier=top.t
+-000003  point: type=expr comment=(t1==0 && t4==0) => 0 hier=top.t
+-000002  point: type=expr comment=(t1==1 && t2==1) => 1 hier=top.t
+-000003  point: type=expr comment=(t2==0 && t3==0) => 0 hier=top.t
+-000003  point: type=expr comment=(t2==0 && t4==0) => 0 hier=top.t
+-000000  point: type=expr comment=(t3==1 && t4==1) => 1 hier=top.t
         
           logic ta, tb, tc;
 %000001   initial begin


### PR DESCRIPTION
Resolves issue https://github.com/verilator/verilator/issues/7542

I noticed that assign statements don't generate expression coverage. This PR fixes that and also adds a unit test.

It's my first time contributing to verilator so please guide me if I am missing anything.