### PR TITLE
Fix side effect internal error (#7519) (#7540)

### DIFF
--- a/src/V3LinkInc.cpp
+++ b/src/V3LinkInc.cpp
@@ -268,7 +268,6 @@ class LinkIncVisitor final : public VNVisitor {
     void prepost_stmt_sel_visit(AstAssignCompound* const nodep) {
         // Special case array[something] += expr, see comments at file top
         // UINFOTREE(9, nodep, "", "pp-stmt-sel-in");
-        iterateChildren(nodep);
         AstNodeExpr* const exprp = nodep->rhsp()->unlinkFrBack();
 
         prepost_stmt_sel_visit(nodep, nodep->lhsp(), exprp);
@@ -323,7 +322,6 @@ class LinkIncVisitor final : public VNVisitor {
         prepost_stmt_visit(nodep, exprp, storeTop, valuep);
     }
     void prepost_stmt_visit(AstAssignCompound* const nodep) {
-        iterateChildren(nodep);
         AstNodeExpr* const exprp = nodep->rhsp()->unlinkFrBack();
         AstNodeExpr* const storeTop = nodep->lhsp()->cloneTreePure(true);
         AstNodeExpr* const valuep = nodep->lhsp()->unlinkFrBack();
@@ -394,6 +392,7 @@ class LinkIncVisitor final : public VNVisitor {
     void visit(AstPreDec* nodep) override { prepost_visit(nodep); }
     void visit(AstPostDec* nodep) override { prepost_visit(nodep); }
     void visit(AstAssignCompound* nodep) override {
+        visit(static_cast<AstNodeStmt*>(nodep));
         AstSelBit* const selbitp = VN_CAST(nodep->lhsp(), SelBit);
         if (!m_insStmtp && selbitp && VN_IS(selbitp->fromp(), NodeVarRef)
             && !selbitp->bitp()->isPure()) {

--- a/test_regress/t/t_assign_expr.v
+++ b/test_regress/t/t_assign_expr.v
@@ -115,6 +115,12 @@ module t;
     `checkd(arr[2], 1);
     `checkd(x, 4);
 
+    i = 0;
+    arr[i++] -= 2;
+    `checkd(arr[0], 5);
+    arr[++i] += 5;
+    `checkd(arr[2], 6);
+
     $write("*-* All Finished *-*\n");
     $finish;
   end


### PR DESCRIPTION
It fixes #7540 

`m_insStmtp` was not updated when under `AstAssignCompound` because it has a separate visitor which did not call `AstNodeStmt`'s visitor. This caused the ++ expression to be treated as statement.