### PR TITLE
property region tests

### DIFF
--- a/src/V3Assert.cpp
+++ b/src/V3Assert.cpp
@@ -495,7 +495,34 @@ class AssertVisitor final : public VNVisitor {
                 = new AstIf{nodep->fileline(), new AstLogNot{nodep->fileline(), disablep}, bodysp};
         }
         if (sentreep) {
-            bodysp = new AstAlways{nodep->fileline(), VAlwaysKwd::ALWAYS, sentreep, bodysp};
+            bool useObserved = true;
+            for (const AstSenItem* senip = sentreep->sensesp(); senip;
+                 senip = VN_CAST(senip->nextp(), SenItem)) {
+                if (senip->edgeType() == VEdgeType::ET_EVENT) {
+                    useObserved = false;
+                    break;
+                }
+                if (const AstNodeExpr* const senExprp = senip->sensp()) {
+                    if (const AstBasicDType* const bdtypep
+                        = VN_CAST(senExprp->dtypep()->skipRefp(), BasicDType)) {
+                        if (bdtypep->isEvent()) {
+                            useObserved = false;
+                            break;
+                        }
+                    }
+                }
+            }
+            if (useObserved && bodysp->exists([](const AstAssignDly*) { return true; })) {
+                useObserved = false;
+            }
+            if (useObserved && bodysp->exists([](const AstFork*) { return true; })) {
+                useObserved = false;
+            }
+            if (useObserved) {
+                bodysp = new AstAlwaysObserved{nodep->fileline(), sentreep, bodysp};
+            } else {
+                bodysp = new AstAlways{nodep->fileline(), VAlwaysKwd::ALWAYS, sentreep, bodysp};
+            }
         }
 
         if (passsp && !passsp->backp()) VL_DO_DANGLING(pushDeletep(passsp), passsp);

--- a/test_regress/t/t_assert_disable_iff.v
+++ b/test_regress/t/t_assert_disable_iff.v
@@ -49,6 +49,23 @@ module Test (
   // Pass 1st cycle
   assert property (@(cyc) disable iff (cyc != $sampled(cyc)) cyc == 0);
 
+  // disable happens in Observed, sample is Preopen
+  assert property (@(posedge clk) disable iff (cyc == 4) (cyc != 3));
+
+  // action block happens in Reactive
+  int pass_cyc;
+  assert property (@(posedge clk) 1)
+    pass_cyc = cyc;
+
+  always @(posedge clk) begin
+    if (cyc > 1) begin
+      if (pass_cyc != cyc) begin
+        $display("FAIL: pass_cyc=%0d cyc=%0d", pass_cyc, cyc);
+        $stop;
+      end
+    end
+  end
+
   //
   // Cover properties behave differently
   //

--- a/test_regress/t/t_assert_disable_iff_timing.py
+++ b/test_regress/t/t_assert_disable_iff_timing.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile(verilator_flags2=['--assert --cc --coverage-user --timing'])
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_assert_disable_iff_timing.v
+++ b/test_regress/t/t_assert_disable_iff_timing.v
@@ -1,0 +1,81 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain
+// SPDX-FileCopyrightText: 2026 Wilson Snyder
+// SPDX-License-Identifier: CC0-1.0
+
+module t (  /*AUTOARG*/
+    // Inputs
+    clk
+);
+
+  input clk;
+  int cyc;
+
+  Test test (  /*AUTOINST*/
+      // Inputs
+      .clk(clk),
+      .cyc(cyc)
+  );
+
+  always @(posedge clk) begin
+    cyc <= cyc + 1;
+    if (cyc == 12) begin
+      $write("*-* All Finished *-*\n");
+      $finish;
+    end
+  end
+
+endmodule
+
+module Test (
+    input clk,
+    input int cyc
+);
+
+  int fallback_fail_count = 0;
+
+  // --- Scenario A: event-triggered assertion (@(evtA)) ---
+  event evtA;
+  logic disA = 0;
+  always @(posedge clk) begin
+    if (cyc == 5) -> evtA;
+    disA <= (cyc == 5);
+  end
+  assert property (@(evtA) disable iff (disA) 0)
+    else begin
+      $display("FAIL scenario A (event sens): cyc=%0d disA=%0d (expected disabled)",
+               cyc, disA);
+      fallback_fail_count = fallback_fail_count + 1;
+    end
+
+  // --- Scenario B: NBA assignment in action block ---
+  int sB_dummy = 0;
+  assert property (@(posedge clk) disable iff (cyc == 4) (cyc != 3))
+    sB_dummy <= cyc;
+  else begin
+    $display("%t: FAIL scenario B (NBA action): disable iff sees Active value; cyc=%0d",
+             $time, cyc);
+    fallback_fail_count = fallback_fail_count + 1;
+  end
+
+  // --- Scenario C: property with ##N delay (AstFork) ---
+  logic disC = 0;
+  always @(posedge clk) begin
+    disC <= (cyc == 9);
+  end
+  assert property (@(posedge clk) disable iff (disC) (cyc == 7) |=> ##1 0)
+    else begin
+      $display("FAIL scenario C (##N delay): cyc=%0d disC=%0d (expected disabled)",
+               cyc, disC);
+      fallback_fail_count = fallback_fail_count + 1;
+    end
+
+  final begin
+    if (fallback_fail_count != 0) begin
+      $display("FAIL: %0d disable iff fallback scenarios incorrect", fallback_fail_count);
+      $stop;
+    end
+  end
+
+endmodule


### PR DESCRIPTION
In trying to get #7364 to work I discovered that concurrent assertions aren't being sampled in the Observed region.  I believe we need something like this change in `V3Assert`, however none of the `useObserved = false` exceptions should exist.  They are all just currently necessary to make tests pass.

Parking this here as a draft for now for comments as I look at resolving the exceptions in `V3Assert`.

cc #7278 #4848