### PR TITLE
Fix regression rejecting boolean `!x` inside sequence expressions (#7549)

### DIFF
--- a/src/V3AstNodeExpr.h
+++ b/src/V3AstNodeExpr.h
@@ -5543,9 +5543,13 @@ public:
 };
 class AstLogNot final : public AstNodeUniop {
     // @astgen makeDfgVertex
+private:
+    const bool m_fromProperty;  // True if from property 'not' keyword (IEEE 1800-2023 16.12.2),
+                                // false for boolean '!' (IEEE 1800-2023 11.4.7)
 public:
-    AstLogNot(FileLine* fl, AstNodeExpr* lhsp)
-        : ASTGEN_SUPER_LogNot(fl, lhsp) {
+    AstLogNot(FileLine* fl, AstNodeExpr* lhsp, bool fromProperty = false)
+        : ASTGEN_SUPER_LogNot(fl, lhsp)
+        , m_fromProperty{fromProperty} {
         dtypeSetBit();
     }
     ASTGEN_MEMBERS_AstLogNot;
@@ -5557,6 +5561,7 @@ public:
     bool cleanOut() const override { return true; }
     bool cleanLhs() const override { return true; }
     bool sizeMattersLhs() const override { return false; }
+    bool fromProperty() const { return m_fromProperty; }
 };
 class AstNToI final : public AstNodeUniop {
     // String to any-size integral

--- a/src/V3AstNodeExpr.h
+++ b/src/V3AstNodeExpr.h
@@ -5544,7 +5544,7 @@ public:
 class AstLogNot final : public AstNodeUniop {
     // @astgen makeDfgVertex
 private:
-    const bool m_fromProperty;  // True if from property 'not' keyword (IEEE 1800-2023 16.12.2),
+    const bool m_fromProperty;  // True if from property 'not' keyword (IEEE 1800-2023 16.12.3),
                                 // false for boolean '!' (IEEE 1800-2023 11.4.7)
 public:
     AstLogNot(FileLine* fl, AstNodeExpr* lhsp, bool fromProperty = false)

--- a/src/V3AstNodeExpr.h
+++ b/src/V3AstNodeExpr.h
@@ -5562,6 +5562,8 @@ public:
     bool cleanLhs() const override { return true; }
     bool sizeMattersLhs() const override { return false; }
     bool fromProperty() const { return m_fromProperty; }
+    void dump(std::ostream& str) const override;
+    void dumpJson(std::ostream& str) const override;
 };
 class AstNToI final : public AstNodeUniop {
     // String to any-size integral

--- a/src/V3AstNodes.cpp
+++ b/src/V3AstNodes.cpp
@@ -1841,6 +1841,14 @@ void AstCCast::dumpJson(std::ostream& str) const {
     dumpJsonNumFunc(str, size);
     dumpJsonGen(str);
 }
+void AstLogNot::dump(std::ostream& str) const {
+    this->AstNodeUniop::dump(str);
+    if (fromProperty()) str << " [fromProperty]";
+}
+void AstLogNot::dumpJson(std::ostream& str) const {
+    dumpJsonBoolFuncIf(str, fromProperty);
+    dumpJsonGen(str);
+}
 void AstCvtArrayToArray::dump(std::ostream& str) const {
     this->AstNodeExpr::dump(str);
     str << " reverse=" << reverse();

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -7586,7 +7586,7 @@ class WidthVisitor final : public VNVisitor {
         }
     }
 
-    void visit_log_not(AstNode* nodep) {
+    void visit_log_not(AstLogNot* nodep) {
         // CALLER: LogNot
         // Width-check: lhs 1 bit
         // Real: Allowed; implicitly compares with zero
@@ -7602,7 +7602,10 @@ class WidthVisitor final : public VNVisitor {
         if (m_vup->prelim()) {
             iterateCheckBool(nodep, "LHS", nodep->op1p(), BOTH);
             nodep->dtypeSetBit();
-            if (m_underSExpr) {
+            // IEEE 1800-2023 16.12.2: property 'not' is not a sequence operator.
+            // Boolean '!' is allowed in sequences (16.9.1 expression_or_dist).
+            // The parser distinguishes the two via AstLogNot::fromProperty().
+            if (m_underSExpr && nodep->fromProperty()) {
                 nodep->v3error("Unexpected 'not' in sequence expression context");
                 AstConst* const newp = new AstConst{nodep->fileline(), 0};
                 newp->dtypeFrom(nodep);

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -7602,8 +7602,8 @@ class WidthVisitor final : public VNVisitor {
         if (m_vup->prelim()) {
             iterateCheckBool(nodep, "LHS", nodep->op1p(), BOTH);
             nodep->dtypeSetBit();
-            // IEEE 1800-2023 16.12.2: property 'not' is not a sequence operator.
-            // Boolean '!' is allowed in sequences (16.9.1 expression_or_dist).
+            // IEEE 1800-2023 16.12.3: property 'not' is not a sequence operator.
+            // Boolean '!' is allowed in sequences (16.7 expression_or_dist).
             // The parser distinguishes the two via AstLogNot::fromProperty().
             if (m_underSExpr && nodep->fromProperty()) {
                 nodep->v3error("Unexpected 'not' in sequence expression context");

--- a/src/verilog.y
+++ b/src/verilog.y
@@ -6722,7 +6722,7 @@ pexpr<nodeExprp>:  // IEEE: property_expr  (The name pexpr is important as regex
         //                      // Expanded below
         //
                 yNOT pexpr
-                        { $$ = new AstLogNot{$1, $2}; }
+                        { $$ = new AstLogNot{$1, $2, /*fromProperty=*/true}; }
         |       ySTRONG '(' sexpr ')'
                         { $$ = $3; BBUNSUP($2, "Unsupported: strong (in property expression)"); }
         |       yWEAK '(' sexpr ')'

--- a/test_regress/t/t_assert_bang_in_seq.py
+++ b/test_regress/t/t_assert_bang_in_seq.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile(timing_loop=True, verilator_flags2=['--assert', '--timing'])
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_assert_bang_in_seq.py
+++ b/test_regress/t/t_assert_bang_in_seq.py
@@ -11,7 +11,7 @@ import vltest_bootstrap
 
 test.scenarios('simulator')
 
-test.compile(timing_loop=True, verilator_flags2=['--assert', '--timing'])
+test.compile(verilator_flags2=['--assert', '--timing'])
 
 test.execute()
 

--- a/test_regress/t/t_assert_bang_in_seq.v
+++ b/test_regress/t/t_assert_bang_in_seq.v
@@ -1,0 +1,52 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain.
+// SPDX-FileCopyrightText: 2026 PlanV GmbH
+// SPDX-License-Identifier: CC0-1.0
+
+module t;
+  bit clk = 0;
+  always #1 clk = ~clk;
+
+  bit c_true  = 1'b1;
+  bit c_false = 1'b0;
+  bit b       = 1'b0;
+  bit c       = 1'b0;
+  bit [3:0] vec = 4'b1110;
+
+  initial begin
+    #20 $write("*-* All Finished *-*\n");
+    $finish;
+  end
+
+  // Simple boolean `!` as the rhs of ##1.
+  property p_bang_simple;
+    @(posedge clk) c_true ##1 !c_false;
+  endproperty
+  ap_bang_simple: assert property(p_bang_simple);
+
+  // Conjunction of two bangs inside the sequence.
+  property p_bang_and;
+    @(posedge clk) c_true ##1 (!b && !c);
+  endproperty
+  ap_bang_and: assert property(p_bang_and);
+
+  // Bit-select negation.
+  property p_bang_bit;
+    @(posedge clk) c_true ##1 !vec[0];
+  endproperty
+  ap_bang_bit: assert property(p_bang_bit);
+
+  // Sampled value function inside a negation.
+  property p_bang_past;
+    @(posedge clk) c_true ##1 !$past(c_false);
+  endproperty
+  ap_bang_past: assert property(p_bang_past);
+
+  // Bang interleaved with multiple cycle delays.
+  property p_bang_interleaved;
+    @(posedge clk) c_true ##0 !c_false ##1 c_true;
+  endproperty
+  ap_bang_interleaved: assert property(p_bang_interleaved);
+
+endmodule

--- a/test_regress/t/t_assert_bang_in_seq.v
+++ b/test_regress/t/t_assert_bang_in_seq.v
@@ -8,10 +8,10 @@ module t;
   bit clk = 0;
   always #1 clk = ~clk;
 
-  bit c_true  = 1'b1;
+  bit c_true = 1'b1;
   bit c_false = 1'b0;
-  bit b       = 1'b0;
-  bit c       = 1'b0;
+  bit b = 1'b0;
+  bit c = 1'b0;
   bit [3:0] vec = 4'b1110;
 
   initial begin
@@ -23,30 +23,45 @@ module t;
   property p_bang_simple;
     @(posedge clk) c_true ##1 !c_false;
   endproperty
-  ap_bang_simple: assert property(p_bang_simple);
+  ap_bang_simple :
+  assert property (p_bang_simple);
 
   // Conjunction of two bangs inside the sequence.
   property p_bang_and;
     @(posedge clk) c_true ##1 (!b && !c);
   endproperty
-  ap_bang_and: assert property(p_bang_and);
+  ap_bang_and :
+  assert property (p_bang_and);
 
   // Bit-select negation.
   property p_bang_bit;
     @(posedge clk) c_true ##1 !vec[0];
   endproperty
-  ap_bang_bit: assert property(p_bang_bit);
+  ap_bang_bit :
+  assert property (p_bang_bit);
 
   // Sampled value function inside a negation.
   property p_bang_past;
-    @(posedge clk) c_true ##1 !$past(c_false);
+    @(posedge clk) c_true ##1 !$past(
+        c_false
+    );
   endproperty
-  ap_bang_past: assert property(p_bang_past);
+  ap_bang_past :
+  assert property (p_bang_past);
 
   // Bang interleaved with multiple cycle delays.
   property p_bang_interleaved;
     @(posedge clk) c_true ##0 !c_false ##1 c_true;
   endproperty
-  ap_bang_interleaved: assert property(p_bang_interleaved);
+  ap_bang_interleaved :
+  assert property (p_bang_interleaved);
+
+  // CVV-style: bang on the consequent of an implication, mirroring
+  // core-v-verif's `|-> ##1 !irq_enabled` pattern that motivated this fix.
+  property p_bang_cvv_style;
+    @(posedge clk) c_true |-> ##1 !c_false;
+  endproperty
+  ap_bang_cvv_style :
+  assert property (p_bang_cvv_style);
 
 endmodule

--- a/test_regress/t/t_assert_bang_in_seq.v
+++ b/test_regress/t/t_assert_bang_in_seq.v
@@ -4,64 +4,76 @@
 // SPDX-FileCopyrightText: 2026 PlanV GmbH
 // SPDX-License-Identifier: CC0-1.0
 
-module t;
-  bit clk = 0;
-  always #1 clk = ~clk;
+// verilog_format: off
+`define stop $stop
+`define checkh(gotv,expv) do if ((gotv) !== (expv)) begin $write("%%Error: %s:%0d:  got=%0x exp=%0x (%s !== %s)\n", `__FILE__,`__LINE__, (gotv), (expv), `"gotv`", `"expv`"); `stop; end while(0);
+`define checkd(gotv,expv) do if ((gotv) !== (expv)) begin $write("%%Error: %s:%0d:  got=%0d exp=%0d\n", `__FILE__,`__LINE__, (gotv), (expv)); `stop; end while(0);
+// verilog_format: on
 
-  bit c_true = 1'b1;
-  bit c_false = 1'b0;
-  bit b = 1'b0;
-  bit c = 1'b0;
-  bit [3:0] vec = 4'b1110;
+module t (
+    input clk
+);
 
-  initial begin
-    #20 $write("*-* All Finished *-*\n");
-    $finish;
+  int cyc;
+  reg [63:0] crc;
+
+  // Non-adjacent CRC bits avoid LFSR shift correlation.
+  wire a = crc[0];
+  wire b = crc[4];
+  wire c = crc[8];
+  wire d = crc[12];
+
+  int count_fail1 = 0;
+  int count_fail2 = 0;
+  int count_fail3 = 0;
+  int count_fail4 = 0;
+  int count_fail5 = 0;
+  int count_fail6 = 0;
+
+  // Test 1: a ##1 !b -- boolean ! as consequent of cycle delay.
+  assert property (@(posedge clk) a ##1 !b)
+  else count_fail1 <= count_fail1 + 1;
+
+  // Test 2: a ##1 (!b && !c) -- conjunction of two bangs in seq.
+  assert property (@(posedge clk) a ##1 (!b && !c))
+  else count_fail2 <= count_fail2 + 1;
+
+  // Test 3: a |-> ##1 !b -- bang on consequent of overlapping implication
+  // (mirrors core-v-verif `|-> ##1 !irq_enabled`).
+  assert property (@(posedge clk) a |-> ##1 !b)
+  else count_fail3 <= count_fail3 + 1;
+
+  // Test 4: a ##1 !$past(b) -- bang applied to sampled value function.
+  assert property (@(posedge clk) a ##1 !$past(b))
+  else count_fail4 <= count_fail4 + 1;
+
+  // Test 5: a ##0 !b ##1 c -- bang interleaved between cycle delays.
+  assert property (@(posedge clk) a ##0 !b ##1 c)
+  else count_fail5 <= count_fail5 + 1;
+
+  // Test 6: a |=> !d -- bang on consequent of non-overlapping implication.
+  assert property (@(posedge clk) a |=> !d)
+  else count_fail6 <= count_fail6 + 1;
+
+  always @(posedge clk) begin
+`ifdef TEST_VERBOSE
+    $write("[%0t] cyc==%0d crc=%x a=%b b=%b c=%b d=%b\n", $time, cyc, crc, a, b, c, d);
+`endif
+    cyc <= cyc + 1;
+    crc <= {crc[62:0], crc[63] ^ crc[2] ^ crc[0]};
+    if (cyc == 0) begin
+      crc <= 64'h5aef0c8d_d70a4497;
+    end
+    else if (cyc == 99) begin
+      `checkh(crc, 64'hc77bb9b3784ea091);
+      `checkd(count_fail1, 66);  // Questa: 66
+      `checkd(count_fail2, 69);  // Questa: 69
+      `checkd(count_fail3, 26);  // Questa: 26
+      `checkd(count_fail4, 66);  // Questa: 66
+      `checkd(count_fail5, 80);  // Questa: 80
+      `checkd(count_fail6, 27);  // Questa: 27
+      $write("*-* All Finished *-*\n");
+      $finish;
+    end
   end
-
-  // Simple boolean `!` as the rhs of ##1.
-  property p_bang_simple;
-    @(posedge clk) c_true ##1 !c_false;
-  endproperty
-  ap_bang_simple :
-  assert property (p_bang_simple);
-
-  // Conjunction of two bangs inside the sequence.
-  property p_bang_and;
-    @(posedge clk) c_true ##1 (!b && !c);
-  endproperty
-  ap_bang_and :
-  assert property (p_bang_and);
-
-  // Bit-select negation.
-  property p_bang_bit;
-    @(posedge clk) c_true ##1 !vec[0];
-  endproperty
-  ap_bang_bit :
-  assert property (p_bang_bit);
-
-  // Sampled value function inside a negation.
-  property p_bang_past;
-    @(posedge clk) c_true ##1 !$past(
-        c_false
-    );
-  endproperty
-  ap_bang_past :
-  assert property (p_bang_past);
-
-  // Bang interleaved with multiple cycle delays.
-  property p_bang_interleaved;
-    @(posedge clk) c_true ##0 !c_false ##1 c_true;
-  endproperty
-  ap_bang_interleaved :
-  assert property (p_bang_interleaved);
-
-  // CVV-style: bang on the consequent of an implication, mirroring
-  // core-v-verif's `|-> ##1 !irq_enabled` pattern that motivated this fix.
-  property p_bang_cvv_style;
-    @(posedge clk) c_true |-> ##1 !c_false;
-  endproperty
-  ap_bang_cvv_style :
-  assert property (p_bang_cvv_style);
-
 endmodule


### PR DESCRIPTION
## Summary

Fixes a regression that rejects boolean `!x` inside SVA sequence expressions
(`a ##1 !b`) with "Unexpected 'not' in sequence expression context". IEEE
1800-2023 16.7 allows any boolean expression inside a sequence (including
`!`); 16.12.3 defines `not` as a property operator only. 

Discovered while running a UVM testbench on cv32e40p, from https://github.com/openhwgroup/core-v-verif/pull/2724

## Reproducer

```systemverilog
module t;
  bit clk, a, b;
  property p;
    @(posedge clk) a ##1 !b;
  endproperty
  a_p: assert property(p);
endmodule
```

On master:
```
%Error: ...: Unexpected 'not' in sequence expression context
   |   assert property(@(posedge clk) a ##1 !b);
   |                                          ^~
```

## Changes

- `src/V3AstNodeExpr.h` (`AstLogNot`): add `const bool m_fromProperty` and a
  default-false constructor parameter, mirroring the
  `AstImplication::m_isOverlapped` pattern.
- `src/verilog.y` (`pexpr: yNOT pexpr`): construct with `fromProperty=true`;
  every other `AstLogNot` call site (`'!' expr`, reduction NAND/NOR/XNOR,
  `$changed`/`$stable`/`$steady`, `implies` desugar, post-V3Width synthesis
  in V3Const/V3AssertPre/V3Coverage/etc.) keeps the default and remains
  boolean.
- `src/V3Width.cpp` (`visit_log_not`): tighten the guard to
  `m_underSExpr && nodep->fromProperty()`, and narrow the parameter type
  from `AstNode*` to `AstLogNot*` (single caller).

## Test

- Added `test_regress/t/t_assert_bang_in_seq.{v,py}` -- CRC + counter
  pattern (`module t(input clk)`, 64-bit LFSR, signals from non-adjacent
  CRC bits). Six properties cover every boolean-`!` position in a
  sequence: `a ##1 !b`, `a ##1 (!b && !c)`, `a |-> ##1 !b` (CVV motivation,
  mirrors `uvmt_cv32e40p_interrupt_assert.sv`'s `|-> ##1 !irq_enabled`),
  `a ##1 !$past(b)`, `a ##0 !b ##1 c`, `a |=> !d`. Per-property fail
  counts are pinned against Questa 2022.3 (66/69/26/66/80/27).
- Three-way matrix: Questa PASS (counts as listed); master FAIL (6
  `Unexpected 'not'`, compile aborts); fixed worktree PASS (counts match
  Questa exactly).
- Pivot tests still correct: `t_property_sexpr_bad` still rejects
  `##1 not val` (property-level `not` under sequence), and
  `t_property_negated` still accepts `not (&val)` at the property root.

---
Developed by PlanV GmbH, assisted with Claude Code.

Reviewed by YilouWang.