### PR TITLE
Tests: Use top shell w/ xrun

### DIFF
--- a/test_regress/driver.py
+++ b/test_regress/driver.py
@@ -1621,6 +1621,7 @@ class VlTest:
                 '-input',
                 '@exit',
                 param['top_filename'],
+                param['top_shell_filename'],
             ]
             self.run(cmd=cmd,
                      check_finished=param['check_finished'],


### PR DESCRIPTION
Found one more.  `--xrun` wasn't building with the top shell, so `clk` was never being advanced.