### PR TITLE
Fix property argument retaining type of the previous variable

### DIFF
--- a/src/verilog.y
+++ b/src/verilog.y
@@ -6564,9 +6564,11 @@ property_port_itemFront:  // IEEE: part of property_port_item/sequence_port_item
 
 property_port_itemAssignment<nodep>:  // IEEE: part of property_port_item/sequence_port_item
                 id variable_dimensionListE
-                        { $$ = VARDONEA($<fl>1, *$1, $2, nullptr); }
+                        { VARDECL(VAR);
+                          $$ = VARDONEA($<fl>1, *$1, $2, nullptr); }
         |       id variable_dimensionListE '=' property_actual_arg
-                        { $$ = VARDONEA($<fl>1, *$1, $2, $4);
+                        { VARDECL(VAR);
+                          $$ = VARDONEA($<fl>1, *$1, $2, $4);
                           BBUNSUP($3, "Unsupported: property variable default value"); }
         ;
 

--- a/test_regress/t/t_property_arg_type.py
+++ b/test_regress/t/t_property_arg_type.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile()
+
+test.passes()

--- a/test_regress/t/t_property_arg_type.v
+++ b/test_regress/t/t_property_arg_type.v
@@ -1,0 +1,27 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain.
+// SPDX-FileCopyrightText: 2026 Antmicro
+// SPDX-License-Identifier: CC0-1.0
+
+// Test to assert that property argument type is not retained from
+// the previous variable and is not causing errors
+
+module t(input clk);
+  genvar i;
+  property prop(prop_arg);
+    @(posedge clk)
+    (prop_arg |-> prop_arg);
+  endproperty
+
+  wire w;
+  property prop2(prop_arg);
+    @(posedge clk)
+    (prop_arg |-> prop_arg);
+  endproperty
+
+  initial begin
+    $write("*-* All Finished *-*\n");
+    $finish;
+  end
+endmodule


### PR DESCRIPTION
The property argument type was never set and `GRAMMARP->m_varDecl` in `V3ParseGrammar::createVariable()` (https://github.com/verilator/verilator/blob/9588e67ca9a65fcd2ffb69d123233c8028286293/src/V3ParseGrammar.cpp#L229) was containing whatever the last used type was, resulting in incorrect property argument type in some cases.  

For example the following code:
```
module t(input clk);
  genvar i;
  property prop(prop_arg);
    @(posedge clk)
    (prop_arg |-> prop_arg);
  endproperty
endmodule
```
was resulting in:
```
%Error: t/t_property_arg_type.v:14:6: Genvar 'prop_arg' used outside generate for loop (IEEE 1800-2023 27.4)
   14 |     (prop_arg |-> prop_arg);
      |      ^~~~~~~~
        ... See the manual at https://verilator.org/verilator_doc.html?v=5.049 for more assistance.
%Error: t/t_property_arg_type.v:14:19: Genvar 'prop_arg' used outside generate for loop (IEEE 1800-2023 27.4)
   14 |     (prop_arg |-> prop_arg);
      |                   ^~~~~~~~
```
because the type of property argument `prop_arg` was retaining the type from the genvar `i` used just before it.  

This PR fixes this issue by setting property argument variable type before calling `V3ParseGrammar::createVariable()`