### PR TITLE
Internals: Use /bin/sh to test gdb

### DIFF
--- a/bin/verilator
+++ b/bin/verilator
@@ -202,7 +202,7 @@ sub gdb_works {
     $! = undef;  # Cleanup -x
     system("gdb /bin/sh"
            . " --batch-silent --quiet --return-child-result"
-           . " -ex 'run -c \"echo -n\"'"  # `/bin/sh -c "echo -n"`
+           . " -ex 'run -c exit'"  # `/bin/sh -c exit
            . " -ex 'set width 0'"
            . " -ex 'bt'"
            . " -ex 'quit'");

--- a/bin/verilator
+++ b/bin/verilator
@@ -200,9 +200,9 @@ sub verilator_bin {
 
 sub gdb_works {
     $! = undef;  # Cleanup -x
-    system("gdb /bin/echo"
+    system("gdb /bin/sh"
            . " --batch-silent --quiet --return-child-result"
-           . " -ex 'run -n'"  # `echo -n`
+           . " -ex 'run -c \"echo -n\"'"  # `/bin/sh -c "echo -n"`
            . " -ex 'set width 0'"
            . " -ex 'bt'"
            . " -ex 'quit'");


### PR DESCRIPTION
`/bin/echo` is not a binary executable on all platforms, use `/bin/sh` (more likely to be a binary) to probe if gdb works properly