### PR TITLE
feat(lint): add UNPACKED warning for unpacked array ports

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -318,3 +318,4 @@ emmettifelts
 Ícaro Lima
 Yogish Sekhar
 24bit-xjkp
+Lucas Amaral

--- a/src/V3Error.h
+++ b/src/V3Error.h
@@ -246,7 +246,7 @@ public:
     }
     // Warnings that default to off
     bool defaultsOff() const VL_MT_SAFE {
-        return (m_e == IMPERFECTSCH || m_e == I_CELLDEFINE || styleError());
+        return (m_e == IMPERFECTSCH || m_e == I_CELLDEFINE || m_e == UNPACKED || styleError());
     }
     // Warnings that warn about nasty side effects
     bool dangerous() const VL_MT_SAFE { return (m_e == COMBDLY); }
@@ -286,8 +286,8 @@ public:
                 || m_e == CASEWITHX || m_e == CASEX || m_e == CASTCONST || m_e == CMPCONST
                 || m_e == COLONPLUS || m_e == IMPLICIT || m_e == IMPLICITSTATIC || m_e == LATCH
                 || m_e == MISINDENT || m_e == NEWERSTD || m_e == PREPROCZERO || m_e == PINMISSING
-                || m_e == REALCVT || m_e == STATICVAR || m_e == UNSIGNED || m_e == WIDTH
-                || m_e == WIDTHTRUNC || m_e == WIDTHEXPAND || m_e == WIDTHXZEXPAND);
+                || m_e == REALCVT || m_e == STATICVAR || m_e == UNSIGNED
+                || m_e == WIDTH || m_e == WIDTHTRUNC || m_e == WIDTHEXPAND || m_e == WIDTHXZEXPAND);
     }
     // Warnings that are style only
     bool styleError() const VL_MT_SAFE {

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -2982,6 +2982,15 @@ class WidthVisitor final : public VNVisitor {
         userIterateAndNext(nodep->delayp(), WidthVP{nodep->dtypep(), PRELIM}.p());
         UINFO(4, "varWidthed " << nodep);
         // UINFOTREE(1, nodep, "", "InitOut");
+        // Check for unsupported unpacked array on interface ports only
+        // (synthesis tools pack these, causing GLS mismatches)
+        if (nodep->isIO() && !nodep->isIfaceRef()) {
+            if (VN_IS(nodep->dtypep()->skipRefp(), UnpackArrayDType)) {
+                nodep->v3warn(UNPACKED, "Unsupported: Unpacked array on port "
+                                            << nodep->prettyNameQ()
+                                            << "; synthesis may pack this");
+            }
+        }
         nodep->didWidth(true);
         nodep->doingWidth(false);
     }


### PR DESCRIPTION
- Add UNPACKED to defaultsOff() so it's disabled by default
- Emit warning in V3Width::visit(AstVar*) for IO ports with UnpackArrayDType
- Only warns on interface ports, not internal signals
- Rationale: synthesis tools pack unpacked arrays, causing GLS mismatches
