### PR TITLE
feat(lint): add UNSYNTHESIZABLE warning for non-synthesizable operators

### DIFF
--- a/docs/guide/warnings.rst
+++ b/docs/guide/warnings.rst
@@ -2388,6 +2388,25 @@ List Of Warnings
    simulate correctly.
 
 
+.. option:: UNSYNTHESIZABLE
+
+   Warns when the design uses an arithmetic operator that is commonly
+   rejected or treated specially by hardware synthesis tools: division
+   (``/``), modulo (``%``), and exponentiation (``**``), including their
+   signed variants.
+
+   Behavior across synthesis tools varies. Some tools accept these
+   operators when at least one operand is a constant (e.g., dividing by a
+   power of two reduces to a shift). Other tools reject them outright.
+   Detecting these operators in Verilator helps catch potential
+   simulation/synthesis mismatches early in flows that target less
+   permissive synthesizers.
+
+   Disabled by default. Enable with ``-Wwarn-UNSYNTHESIZABLE`` to surface
+   it. Ignoring this warning does not affect Verilator simulation; it
+   only flags a potential synthesis-flow incompatibility.
+
+
 .. option:: UNSUPPORTED
 
    An error that a construct might be legal according to IEEE but is not

--- a/src/V3Error.h
+++ b/src/V3Error.h
@@ -176,6 +176,7 @@ public:
         UNPACKED,       // Unsupported unpacked
         UNSATCONSTR,    // Unsatisfied constraint
         UNSIGNED,       // Comparison is constant due to unsigned arithmetic
+        UNSYNTHESIZABLE,// Unsynthesizable operator
         UNUSED,         // Unused genvar, parameter or signal message (Backward Compatibility)
         UNUSEDGENVAR,   // No receivers for genvar
         UNUSEDLOOP,     // Loop is unused
@@ -238,15 +239,16 @@ public:
             "REDEFMACRO", "RISEFALLDLY", "SELRANGE", "SHORTREAL", "SIDEEFFECT", "SPECIFYIGN",
             "SPLITVAR", "STATICVAR", "STMTDLY", "SUPERNFIRST", "SYMRSVDWORD", "SYNCASYNCNET",
             "TICKCOUNT", "TIMESCALEMOD", "UNDRIVEN", "UNOPT", "UNOPTFLAT", "UNOPTTHREADS",
-            "UNPACKED", "UNSATCONSTR", "UNSIGNED", "UNUSED", "UNUSEDGENVAR", "UNUSEDLOOP",
-            "UNUSEDPARAM", "UNUSEDSIGNAL", "USERERROR", "USERFATAL", "USERINFO", "USERWARN",
-            "VARHIDDEN", "WAITCONST", "WIDTH", "WIDTHCONCAT", "WIDTHEXPAND", "WIDTHTRUNC",
-            "WIDTHXZEXPAND", "ZERODLY", "ZEROREPL", " MAX"};
+            "UNPACKED", "UNSATCONSTR", "UNSIGNED", "UNSYNTHESIZABLE", "UNUSED", "UNUSEDGENVAR",
+            "UNUSEDLOOP", "UNUSEDPARAM", "UNUSEDSIGNAL", "USERERROR", "USERFATAL", "USERINFO",
+            "USERWARN", "VARHIDDEN", "WAITCONST", "WIDTH", "WIDTHCONCAT", "WIDTHEXPAND",
+            "WIDTHTRUNC", "WIDTHXZEXPAND", "ZERODLY", "ZEROREPL", " MAX"};
         return names[m_e];
     }
     // Warnings that default to off
     bool defaultsOff() const VL_MT_SAFE {
-        return (m_e == IMPERFECTSCH || m_e == I_CELLDEFINE || styleError());
+        return (m_e == IMPERFECTSCH || m_e == I_CELLDEFINE || m_e == UNSYNTHESIZABLE
+                || styleError());
     }
     // Warnings that warn about nasty side effects
     bool dangerous() const VL_MT_SAFE { return (m_e == COMBDLY); }

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -369,13 +369,33 @@ class WidthVisitor final : public VNVisitor {
     // Signed: If both sides real
     void visit(AstAdd* nodep) override { visit_add_sub_replace(nodep, true); }
     void visit(AstSub* nodep) override { visit_add_sub_replace(nodep, true); }
-    void visit(AstDiv* nodep) override { visit_add_sub_replace(nodep, true); }
+    void visit(AstDiv* nodep) override {
+        if (!m_paramsOnly) {
+            nodep->v3warn(UNSYNTHESIZABLE, "Operator '/' is not synthesizable");
+        }
+        visit_add_sub_replace(nodep, true);
+    }
     void visit(AstMul* nodep) override { visit_add_sub_replace(nodep, true); }
     // These can't promote to real
-    void visit(AstModDiv* nodep) override { visit_add_sub_replace(nodep, false); }
-    void visit(AstModDivS* nodep) override { visit_add_sub_replace(nodep, false); }
+    void visit(AstModDiv* nodep) override {
+        if (!m_paramsOnly) {
+            nodep->v3warn(UNSYNTHESIZABLE, "Operator '%' (modulo) is not synthesizable");
+        }
+        visit_add_sub_replace(nodep, false);
+    }
+    void visit(AstModDivS* nodep) override {
+        if (!m_paramsOnly) {
+            nodep->v3warn(UNSYNTHESIZABLE, "Operator '%' (signed modulo) is not synthesizable");
+        }
+        visit_add_sub_replace(nodep, false);
+    }
     void visit(AstMulS* nodep) override { visit_add_sub_replace(nodep, false); }
-    void visit(AstDivS* nodep) override { visit_add_sub_replace(nodep, false); }
+    void visit(AstDivS* nodep) override {
+        if (!m_paramsOnly) {
+            nodep->v3warn(UNSYNTHESIZABLE, "Operator '/' (signed division) is not synthesizable");
+        }
+        visit_add_sub_replace(nodep, false);
+    }
     // Widths: out width = lhs width, but upper matters
     // Signed: Output signed iff LHS signed; unary operator
     // Unary promote to real
@@ -1895,6 +1915,9 @@ class WidthVisitor final : public VNVisitor {
         // RHS is self-determined (IEEE)
         // Real if either side is real (as with AstAdd)
         assertAtExpr(nodep);
+        if (!m_paramsOnly) {
+            nodep->v3warn(UNSYNTHESIZABLE, "Operator '**' (power) is not synthesizable");
+        }
         if (m_vup->prelim()) {
             userIterateAndNext(nodep->lhsp(), WidthVP{CONTEXT_DET, PRELIM}.p());
             userIterateAndNext(nodep->rhsp(), WidthVP{CONTEXT_DET, PRELIM}.p());

--- a/test_regress/t/t_lint_unsynthesizable_bad.out
+++ b/test_regress/t/t_lint_unsynthesizable_bad.out
@@ -1,0 +1,7 @@
+%Warning-UNSYNTHESIZABLE: t/t_lint_unsynthesizable_bad.v:7:16: Operator '/' is not synthesizable
+                                                                          : ... note: In instance 't'
+    7 |   assign q = a / b;
+      |                ^
+                          ... For warning description see https://verilator.org/warn/UNSYNTHESIZABLE?v=latest
+                          ... Use "/* verilator lint_off UNSYNTHESIZABLE */" and lint_on around source to disable this message.
+%Error: Exiting due to

--- a/test_regress/t/t_lint_unsynthesizable_bad.py
+++ b/test_regress/t/t_lint_unsynthesizable_bad.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Lint test for UNSYNTHESIZABLE warning
+#
+# SPDX-FileCopyrightText: 2026 Lucas Amaral
+# SPDX-License-Identifier: CC0-1.0
+
+import vltest_bootstrap
+
+test.scenarios('linter')
+
+test.lint(fails=True,
+          v_flags2=['-Wwarn-UNSYNTHESIZABLE'],
+          expect_filename=test.golden_filename)
+
+test.passes()

--- a/test_regress/t/t_lint_unsynthesizable_bad.v
+++ b/test_regress/t/t_lint_unsynthesizable_bad.v
@@ -1,0 +1,8 @@
+// DESCRIPTION: Verilator: Test of UNSYNTHESIZABLE warning on / % ** operators
+//
+// SPDX-FileCopyrightText: 2026 Lucas Amaral
+// SPDX-License-Identifier: CC0-1.0
+
+module t (input wire [7:0] a, b, output wire [7:0] q);
+  assign q = a / b;
+endmodule


### PR DESCRIPTION
Add UNSYNTHESIZABLE warning code (disabled by default) and emit it on division, modulo, and power operators (/ , % , **; including signed variants). These operators are generally not synthesizable by hardware synthesis tools, so warning early helps catch simulation/synthesis mismatches.