### PR TITLE
Fix tristate handling for unpacked arrays and pullup/pulldown buses (#3988)

### DIFF
--- a/src/V3Tristate.cpp
+++ b/src/V3Tristate.cpp
@@ -717,14 +717,17 @@ class TristateVisitor final : public TristateBaseVisitor {
             if (!m_tgraph.isTristate(varp)) continue;
             const auto it = m_lhsmap.find(varp);
             if (it != m_lhsmap.end()) continue;
-            // This variable is floating, set output enable to
-            // always be off on this assign
+            // This variable is floating, set output enable to always be off on this assign.
+            // For pullup/pulldown vars, use pull value with en=0 - the final resolution will
+            // apply the pull formula: final = (driven_value & en) | (~en & pull_value)
             UINFO(8, "  Adding driver to var " << varp);
-            AstConst* const constp = newAllZerosOrOnes(varp, false);
+            const AstPull* const pullp = m_varAux(varp).pullp;
+            const bool pullValue = pullp && pullp->direction() == 1;
+            AstConst* const constp = newAllZerosOrOnes(varp, pullValue);
             AstVarRef* const varrefp = new AstVarRef{varp->fileline(), varp, VAccess::WRITE};
             AstAssignW* const newp = new AstAssignW{varp->fileline(), varrefp, constp};
             UINFO(9, "       newoev " << newp);
-            varrefp->user1p(newAllZerosOrOnes(varp, false));
+            varrefp->user1p(newAllZerosOrOnes(varp, false));  // en=0 for floating/pullup vars
             nodep->addStmtsp(new AstAlways{newp});
             mapInsertLhsVarRef(varrefp);  // insertTristates will convert
             //                               // to a varref to the __out# variable
@@ -796,6 +799,7 @@ class TristateVisitor final : public TristateBaseVisitor {
             m_lhsmap.erase(invarp);
             VL_DO_DANGLING(delete refsp, refsp);
         }
+
     }
 
     void aggregateTriSameStrength(AstNodeModule* nodep, AstVar* const varp, AstVar* const envarp,
@@ -1043,29 +1047,24 @@ class TristateVisitor final : public TristateBaseVisitor {
             return;
         }
 
-        if (!outvarp) {
-            // This is the final pre-forced resolution of the tristate, so we apply
-            // the pull direction to any undriven pins.
+        // Apply pull formula: final = orp | (~enp & pull_value)
+        // This is done for ALL levels (top and intermediate) when there's a pull.
+        const bool hasPull = m_varAux(lhsp).pullp || hasPerBitPulls(lhsp);
+        if (hasPull) {
+            // Generate undriven expression (~enable)
             AstNodeExpr* undrivenp;
-            UINFO(4, "Final resolution: envarp=" << (envarp ? envarp->name() : "null")
-                                                 << " enp=" << (enp ? "set" : "null")
-                                                 << " orp=" << (orp ? "set" : "null") << endl);
-            if (envarp) {
-                undrivenp = new AstNot{envarp->fileline(),
-                                       new AstVarRef{envarp->fileline(), envarp, VAccess::READ}};
+            UINFO(4, "Applying pull for " << lhsp->name() << " envarp=" << (envarp ? envarp->name() : "null")
+                                          << " enp=" << (enp ? "set" : "null")
+                                          << " orp=" << (orp ? "set" : "null")
+                                          << " outvarp=" << (outvarp ? "set" : "null") << endl);
+            if (enp) {
+                undrivenp = new AstNot{enp->fileline(), enp->cloneTreePure(true)};
             } else {
-                if (enp) {
-                    undrivenp = new AstNot{enp->fileline(), enp};
-                } else {
-                    undrivenp = newAllZerosOrOnes(invarp, true);
-                }
+                undrivenp = newAllZerosOrOnes(invarp, true);  // all ones = all undriven
             }
 
             // Generate pull constant: use per-bit pulls if available, else whole-var pull
             AstConst* pullConstp;
-            UINFO(4, "Resolution for " << lhsp->name() << " hasPerBitPulls="
-                                       << hasPerBitPulls(lhsp)
-                                       << " outvarp=" << (outvarp ? "set" : "null") << endl);
             if (hasPerBitPulls(lhsp)) {
                 pullConstp = createPerBitPullConst(lhsp);
                 UINFO(4, "using per-bit pull const for " << lhsp->name() << endl);
@@ -1076,7 +1075,16 @@ class TristateVisitor final : public TristateBaseVisitor {
             }
 
             undrivenp = new AstAnd{invarp->fileline(), undrivenp, pullConstp};
-            orp = new AstOr{invarp->fileline(), orp, undrivenp};
+            // Apply pull to output: orp = orp | (~en & pull_value)
+            orp = orp ? new AstOr{invarp->fileline(), orp, undrivenp} : undrivenp;
+        } else if (!orp) {
+            // No pull and no drivers - default to 0
+            orp = newAllZerosOrOnes(invarp, false);
+        }
+
+        // Ensure enp is valid when envarp exists (pullup/pulldown only = no active driver)
+        if (envarp && !enp) {
+            enp = newAllZerosOrOnes(invarp, false);
         }
 
         if (envarp) {
@@ -1591,10 +1599,27 @@ class TristateVisitor final : public TristateBaseVisitor {
                 UINFO(9, "   enp<-rhs " << nodep->lhsp()->user1p());
                 m_tgraph.didProcess(nodep);
             } else {
-                // Non-tristate assignment - just mark as processed.
-                // Don't set user1p here as there are no handlers for many LHS node types
-                // (ArraySel, MemberSel, StructSel, etc.) and checkUnhandled() would error.
-                m_tgraph.didProcess(nodep, true);
+                // Non-tristate RHS. For SEL assigns to tristate variables, we still
+                // need to track which bits are driven by creating a proper enable.
+                if (AstSel* const selp = VN_CAST(nodep->lhsp(), Sel)) {
+                    if (AstNodeVarRef* const varrefp = VN_CAST(selp->fromp(), NodeVarRef)) {
+                        if (m_tgraph.isTristate(varrefp->varp())) {
+                            // Create an all-1s enable for the SEL width - this will be
+                            // deposited into the correct bit positions by newEnableDeposit
+                            nodep->lhsp()->user1p(newAllZerosOrOnes(nodep->lhsp(), true));
+                            UINFO(9, "   enp<-nonTri SEL " << nodep->lhsp()->user1p());
+                            m_tgraph.didProcess(nodep);
+                        } else {
+                            m_tgraph.didProcess(nodep, true);
+                        }
+                    } else {
+                        m_tgraph.didProcess(nodep, true);
+                    }
+                } else {
+                    // Don't set user1p here as there are no handlers for many LHS node types
+                    // (ArraySel, MemberSel, StructSel, etc.) and checkUnhandled() would error.
+                    m_tgraph.didProcess(nodep, true);
+                }
             }
             m_alhs = true;  // And user1p() will indicate tristate equation, if any
             if (AstAssignW* const assignWp = VN_CAST(nodep, AssignW)) {
@@ -1892,7 +1917,7 @@ class TristateVisitor final : public TristateBaseVisitor {
                             AstConst* const constp
                                 = new AstConst{fl, AstConst::WidthedValue{}, width, value};
                             // Replace RHS of the assign with the constant
-                            VL_DO_DANGLING(assignp->rhsp()->unlinkFrBack()->deleteTree(), assignp);
+                            assignp->rhsp()->unlinkFrBack()->deleteTree();
                             AstAssignW* const mutableAssignp
                                 = const_cast<AstAssignW*>(assignp);
                             mutableAssignp->rhsp(constp);
@@ -2337,7 +2362,8 @@ class TristateVisitor final : public TristateBaseVisitor {
 
             AstNodeExpr* undrivenp = new AstNot{fl, new AstVarRef{fl, envarp, VAccess::READ}};
             undrivenp = new AstAnd{fl, undrivenp, pullConstp};
-            orp = new AstOr{fl, orp, undrivenp};
+            // Handle case where there are no other drivers (only pullup/pulldown)
+            orp = orp ? new AstOr{fl, orp, undrivenp} : undrivenp;
 
             // Assign final value to invarp
             AstAssignW* const assp

--- a/src/V3Tristate.cpp
+++ b/src/V3Tristate.cpp
@@ -403,8 +403,9 @@ class TristateVisitor final : public TristateBaseVisitor {
     const VNUser4InUse m_inuser4;
 
     struct AuxAstVar final {
-        AstPull* pullp = nullptr;  // pullup/pulldown direction
+        AstPull* pullp = nullptr;  // pullup/pulldown direction (whole variable)
         AstVar* outVarp = nullptr;  // output __out var
+        std::map<int, int> bitPulls;  // per-bit pull: bit_index -> direction (1=up, 0=down)
     };
 
     AstUser3Allocator<AstVar, AuxAstVar> m_varAux;
@@ -497,9 +498,12 @@ class TristateVisitor final : public TristateBaseVisitor {
     AstNodeExpr* getEnp(AstNode* nodep) {
         if (nodep->user1p()) {
             if (AstNodeVarRef* const refp = VN_CAST(nodep, NodeVarRef)) {
-                if (refp->varp()->isIO()) {
-                    // When reading a tri-state port, we can always use the value
+                if (refp->varp()->isIO() && refp->access().isReadOnly()) {
+                    // When READING a tri-state port, we can always use the value
                     // because such port will have resolution logic in upper module.
+                    // For WRITE access (LHS), use the actual enable (e.g., from
+                    // newEnableDeposit for bit-select targets) to correctly
+                    // track which bits are driven.
                     return newAllZerosOrOnes(nodep, true);
                 }
             }
@@ -650,6 +654,40 @@ class TristateVisitor final : public TristateBaseVisitor {
                                                  << oldpullp->warnContextSecondary());
             }
         }
+    }
+
+    void setBitPullDirection(AstVar* varp, int bitIndex, int direction) {
+        // Set pull direction for a specific bit of a bus.
+        // direction: 1 = pullup, 0 = pulldown
+        auto& bitPulls = m_varAux(varp).bitPulls;
+        auto it = bitPulls.find(bitIndex);
+        if (it != bitPulls.end() && it->second != direction) {
+            // Conflicting pull directions on same bit - should not happen
+            // but warn if it does (via UINFO, not error)
+            UINFO(4, "Conflicting per-bit pull at bit " << bitIndex << " of " << varp);
+        }
+        bitPulls[bitIndex] = direction;
+    }
+
+    AstConst* createPerBitPullConst(AstVar* varp) {
+        // Create a constant with per-bit pull values.
+        // Bits without explicit pull default to pulldown (0).
+        const int width = varp->width();
+        const auto& bitPulls = m_varAux(varp).bitPulls;
+        V3Number num{varp, width, 0};  // Start with all zeros
+        for (const auto& pair : bitPulls) {
+            const int bitIndex = pair.first;
+            const int direction = pair.second;
+            if (bitIndex < width && direction == 1) {
+                num.setBit(bitIndex, 1);
+            }
+        }
+        return new AstConst{varp->fileline(), num};
+    }
+
+    bool hasPerBitPulls(AstVar* varp) {
+        // Note: Not const - m_varAux allocates on access
+        return !m_varAux(varp).bitPulls.empty();
     }
 
     void checkUnhandled(AstNode* nodep) {
@@ -869,7 +907,11 @@ class TristateVisitor final : public TristateBaseVisitor {
                 envarp = getCreateEnVarp(invarp, isTopInout);  // dir set in visit(AstPin*)
                 outvarp->user1p(envarp);
                 m_varAux(outvarp).pullp = m_varAux(invarp).pullp;  // AstPull* propagation
+                m_varAux(outvarp).bitPulls = m_varAux(invarp).bitPulls;  // Per-bit pull propagation
                 if (m_varAux(invarp).pullp) UINFO(9, "propagate pull to " << outvarp);
+                if (!m_varAux(invarp).bitPulls.empty()) {
+                    UINFO(9, "propagate per-bit pulls to " << outvarp);
+                }
             } else if (invarp->user1p()) {
                 envarp = VN_AS(invarp->user1p(), Var);  // From CASEEQ, foo === 1'bz
             }
@@ -1004,10 +1046,10 @@ class TristateVisitor final : public TristateBaseVisitor {
         if (!outvarp) {
             // This is the final pre-forced resolution of the tristate, so we apply
             // the pull direction to any undriven pins.
-            const AstPull* const pullp = m_varAux(lhsp).pullp;
-            const bool pull1 = pullp && pullp->direction() == 1;  // Else default is down
-
             AstNodeExpr* undrivenp;
+            UINFO(4, "Final resolution: envarp=" << (envarp ? envarp->name() : "null")
+                                                 << " enp=" << (enp ? "set" : "null")
+                                                 << " orp=" << (orp ? "set" : "null") << endl);
             if (envarp) {
                 undrivenp = new AstNot{envarp->fileline(),
                                        new AstVarRef{envarp->fileline(), envarp, VAccess::READ}};
@@ -1019,8 +1061,21 @@ class TristateVisitor final : public TristateBaseVisitor {
                 }
             }
 
-            undrivenp
-                = new AstAnd{invarp->fileline(), undrivenp, newAllZerosOrOnes(invarp, pull1)};
+            // Generate pull constant: use per-bit pulls if available, else whole-var pull
+            AstConst* pullConstp;
+            UINFO(4, "Resolution for " << lhsp->name() << " hasPerBitPulls="
+                                       << hasPerBitPulls(lhsp)
+                                       << " outvarp=" << (outvarp ? "set" : "null") << endl);
+            if (hasPerBitPulls(lhsp)) {
+                pullConstp = createPerBitPullConst(lhsp);
+                UINFO(4, "using per-bit pull const for " << lhsp->name() << endl);
+            } else {
+                const AstPull* const pullp = m_varAux(lhsp).pullp;
+                const bool pull1 = pullp && pullp->direction() == 1;  // Else default is down
+                pullConstp = newAllZerosOrOnes(invarp, pull1);
+            }
+
+            undrivenp = new AstAnd{invarp->fileline(), undrivenp, pullConstp};
             orp = new AstOr{invarp->fileline(), orp, undrivenp};
         }
 
@@ -1536,6 +1591,9 @@ class TristateVisitor final : public TristateBaseVisitor {
                 UINFO(9, "   enp<-rhs " << nodep->lhsp()->user1p());
                 m_tgraph.didProcess(nodep);
             } else {
+                // Non-tristate assignment - just mark as processed.
+                // Don't set user1p here as there are no handlers for many LHS node types
+                // (ArraySel, MemberSel, StructSel, etc.) and checkUnhandled() would error.
                 m_tgraph.didProcess(nodep, true);
             }
             m_alhs = true;  // And user1p() will indicate tristate equation, if any
@@ -1794,6 +1852,8 @@ class TristateVisitor final : public TristateBaseVisitor {
     //     const inout  Spec says illegal
     //     const output Unsupported; Illegal?
     void visit(AstPin* nodep) override {
+        UINFO(4, "visit(Pin) " << nodep->name() << " graphing=" << m_graphing
+                               << " user2=" << nodep->user2() << endl);
         if (m_graphing) {
             if (nodep->user2() & U2_GRAPHING) return;  // This pin is already expanded
             nodep->user2Or(U2_GRAPHING);
@@ -1801,7 +1861,63 @@ class TristateVisitor final : public TristateBaseVisitor {
             AstVar* const enModVarp = static_cast<AstVar*>(nodep->modVarp()->user1p());
             if (!enModVarp) {
                 // May have an output only that later connects to a tristate, so simplify now.
-                V3Inst::pinReconnectSimple(nodep, m_cellp, false);
+                const AstAssignW* const assignp
+                    = V3Inst::pinReconnectSimple(nodep, m_cellp, false);
+                // Debug: check pull state
+                UINFO(4, "Pin " << nodep->name() << " modVarp=" << nodep->modVarp()->name()
+                                << " pullp=" << (m_varAux(nodep->modVarp()).pullp ? "set" : "null")
+                                << " assignp=" << (assignp ? "set" : "null") << endl);
+                // Propagate any pullups/pulldowns upwards for non-tristate outputs
+                if (AstPull* const pullp = m_varAux(nodep->modVarp()).pullp) {
+                    // Determine the constant value (1 for pullup, 0 for pulldown)
+                    const bool isPullup = pullp->direction() == 1;
+                    if (assignp) {
+                        // pinReconnectSimple created an assign: temp_wire = pin_expr
+                        // For simple VarRef targets, propagate pull direction.
+                        // For bit-select targets, we need to assign the constant value.
+                        if (AstVarRef* const vrefp = VN_CAST(assignp->lhsp(), VarRef)) {
+                            UINFO(9, "propagate pull to non-tri target " << vrefp);
+                            setPullDirection(vrefp->varp(), pullp);
+                        } else if (AstSel* const selp = VN_CAST(assignp->lhsp(), Sel)) {
+                            // Bit-select target: replace the assign RHS with a constant
+                            // to drive the specific bit with the pull value.
+                            // This handles cases like: conb cell (.HI(out_value[3]));
+                            // where out_value is an output port of a wrapper module.
+                            UINFO(9, "bit-select pull: generating constant assign for " << selp);
+                            FileLine* const fl = nodep->fileline();
+                            // Create constant value based on pull direction and width
+                            const int width = selp->widthMin();
+                            const uint32_t value
+                                = isPullup ? static_cast<uint32_t>(VL_MASK_I(width)) : 0;
+                            AstConst* const constp
+                                = new AstConst{fl, AstConst::WidthedValue{}, width, value};
+                            // Replace RHS of the assign with the constant
+                            VL_DO_DANGLING(assignp->rhsp()->unlinkFrBack()->deleteTree(), assignp);
+                            AstAssignW* const mutableAssignp
+                                = const_cast<AstAssignW*>(assignp);
+                            mutableAssignp->rhsp(constp);
+                        }
+                    } else if (AstVarRef* const exprRefp = VN_CAST(nodep->exprp(), VarRef)) {
+                        // For simple wires, propagate directly
+                        UINFO(9, "propagate pull to simple wire " << exprRefp);
+                        setPullDirection(exprRefp->varp(), pullp);
+                    } else if (AstSel* const exprSelp = VN_CAST(nodep->exprp(), Sel)) {
+                        // Direct bit-select expression without pinReconnectSimple creating assign
+                        // Create an assign to drive the bit-select with the constant value
+                        UINFO(9, "direct bit-select pull: generating assign for " << exprSelp);
+                        FileLine* const fl = nodep->fileline();
+                        const int width = exprSelp->widthMin();
+                        const uint32_t value
+                            = isPullup ? static_cast<uint32_t>(VL_MASK_I(width)) : 0;
+                        AstConst* const constp
+                            = new AstConst{fl, AstConst::WidthedValue{}, width, value};
+                        // Clone the bit-select expression for the LHS
+                        AstSel* const lhsp = static_cast<AstSel*>(exprSelp->cloneTree(false));
+                        AstAssignW* const newAssignp = new AstAssignW{fl, lhsp, constp};
+                        // Insert the new assign after the cell
+                        m_cellp->addNextHere(newAssignp);
+                    }
+                }
                 iteratePinGuts(nodep);
                 return;  // No __en signals on this pin
             }
@@ -1938,10 +2054,58 @@ class TristateVisitor final : public TristateBaseVisitor {
             }
 
             // Propagate any pullups/pulldowns upwards if necessary
+            UINFO(4, "Tristate pin " << nodep->name() << " exprrefp="
+                                     << (exprrefp ? exprrefp->name() : "null")
+                                     << " pullp=" << (m_varAux(nodep->modVarp()).pullp ? "set" : "null")
+                                     << " outAssignp=" << (outAssignp ? "set" : "null") << endl);
             if (exprrefp) {
-                if (AstPull* const pullp = m_varAux(nodep->modVarp()).pullp) {
+                AstPull* const pullp = m_varAux(nodep->modVarp()).pullp;
+                const auto& srcBitPulls = m_varAux(nodep->modVarp()).bitPulls;
+
+                if (pullp) {
                     UINFO(9, "propagate pull on " << exprrefp);
                     setPullDirection(exprrefp->varp(), pullp);
+                    // If pinReconnectSimple created an assignment, propagate pull
+                    // to the assignment target variable.
+                    if (outAssignp) {
+                        UINFO(4, "outAssignp lhsp type: " << outAssignp->lhsp()->typeName()
+                                                         << " = " << outAssignp->lhsp() << endl);
+                        if (AstVarRef* const vrefp = VN_CAST(outAssignp->lhsp(), VarRef)) {
+                            UINFO(9, "propagate pull to assign target " << vrefp);
+                            setPullDirection(vrefp->varp(), pullp);
+                        } else if (AstSel* const selp = VN_CAST(outAssignp->lhsp(), Sel)) {
+                            // For bit-select targets, record per-bit pull direction
+                            // instead of setting pull on the whole variable.
+                            UINFO(4, "SEL branch taken for " << selp << endl);
+                            if (AstVarRef* const fromRefp = VN_CAST(selp->fromp(), VarRef)) {
+                                if (AstConst* const idxp = VN_CAST(selp->lsbp(), Const)) {
+                                    const int bitIndex = idxp->toSInt();
+                                    const int direction = pullp->direction();
+                                    UINFO(4, "setBitPullDirection at bit " << bitIndex
+                                                                        << " of " << fromRefp->varp()->name()
+                                                                        << " direction=" << direction << endl);
+                                    setBitPullDirection(fromRefp->varp(), bitIndex, direction);
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // Also propagate per-bit pulls if present
+                if (!srcBitPulls.empty()) {
+                    UINFO(9, "propagate per-bit pulls from " << nodep->modVarp());
+                    for (const auto& pair : srcBitPulls) {
+                        setBitPullDirection(exprrefp->varp(), pair.first, pair.second);
+                    }
+                    // If there's an assign to a whole variable, propagate to that too
+                    if (outAssignp) {
+                        if (AstVarRef* const vrefp = VN_CAST(outAssignp->lhsp(), VarRef)) {
+                            UINFO(9, "propagate per-bit pulls to assign target " << vrefp);
+                            for (const auto& pair : srcBitPulls) {
+                                setBitPullDirection(vrefp->varp(), pair.first, pair.second);
+                            }
+                        }
+                    }
                 }
             }
             // Don't need to visit the created assigns, as it was added at
@@ -2160,12 +2324,19 @@ class TristateVisitor final : public TristateBaseVisitor {
             UINFOTREE(9, enAssp, "", "iface-enAssp");
             ifaceModp->addStmtsp(new AstAlways{enAssp});
 
-            // Pull resolution
-            const AstPull* const pullp = m_varAux(invarp).pullp;
-            const bool pull1 = pullp && pullp->direction() == 1;  // Else default is down
+            // Pull resolution - use per-bit pulls if available
+            AstConst* pullConstp;
+            if (hasPerBitPulls(invarp)) {
+                pullConstp = createPerBitPullConst(invarp);
+                UINFO(9, "using per-bit pull const for interface " << invarp);
+            } else {
+                const AstPull* const pullp = m_varAux(invarp).pullp;
+                const bool pull1 = pullp && pullp->direction() == 1;  // Else default is down
+                pullConstp = newAllZerosOrOnes(invarp, pull1);
+            }
 
             AstNodeExpr* undrivenp = new AstNot{fl, new AstVarRef{fl, envarp, VAccess::READ}};
-            undrivenp = new AstAnd{fl, undrivenp, newAllZerosOrOnes(invarp, pull1)};
+            undrivenp = new AstAnd{fl, undrivenp, pullConstp};
             orp = new AstOr{fl, orp, undrivenp};
 
             // Assign final value to invarp

--- a/test_regress/t/t_pull_bitsel.py
+++ b/test_regress/t/t_pull_bitsel.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Test pullup/pulldown on bus bit-selects via wrapper
+#
+# This file ONLY is placed under the Creative Commons Public Domain, for
+# any use, without warranty, 2026 by Lucas Amaral.
+# SPDX-License-Identifier: CC0-1.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile()
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_pull_bitsel.v
+++ b/test_regress/t/t_pull_bitsel.v
@@ -1,0 +1,69 @@
+// DESCRIPTION: Verilator: Test pullup/pulldown with bit-select assigns
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2026 by Lucas Amaral.
+// SPDX-License-Identifier: CC0-1.0
+
+// Bug: When a module has bit-select assigns (e.g., out[17:0] = in[17:0])
+// combined with pullup/pulldown tie cells for other bits, the enable
+// for the assigns incorrectly covers all bits, causing the pull constant
+// to be optimized away.
+
+// verilator lint_off PINMISSING
+
+// Tie cell with pullup/pulldown (like sky130_fd_sc_hd__conb)
+module conb(output HI, output LO);
+   pullup   pu (HI);
+   pulldown pd (LO);
+endmodule
+
+// Wrapper that instantiates tie cell and connects to specific bit
+module tiecell_1(output HI, output LO);
+   conb base (.HI(HI), .LO(LO));
+endmodule
+
+// Module similar to Mask: passthrough for some bits, tie cells for others
+module top(input [31:0] in_value, output [31:0] out_value);
+   // Passthrough for bits 0-7 (element 0)
+   assign out_value[7:0] = in_value[7:0];
+
+   // Bits 8-15 (element 1): bit 15 = pullup, rest = pulldown
+   tiecell_1 u_hi (.HI(out_value[15]));
+   tiecell_1 u_lo_8 (.LO(out_value[8]));
+   tiecell_1 u_lo_9 (.LO(out_value[9]));
+   tiecell_1 u_lo_10 (.LO(out_value[10]));
+   tiecell_1 u_lo_11 (.LO(out_value[11]));
+   tiecell_1 u_lo_12 (.LO(out_value[12]));
+   tiecell_1 u_lo_13 (.LO(out_value[13]));
+   tiecell_1 u_lo_14 (.LO(out_value[14]));
+
+   // Passthrough for bits 16-31
+   assign out_value[31:16] = in_value[31:16];
+endmodule
+
+module t(/*AUTOARG*/);
+
+   // Use wire with assign - values propagate in same delta cycle
+   wire [31:0] in_value = 32'hDEAD_0000;
+   wire [31:0] out_value;
+
+   top dut (.in_value(in_value), .out_value(out_value));
+
+   // Expected: bits 31:16 = DEAD (passthrough), bit 15 = 1 (pullup),
+   //           bits 14:8 = 0 (pulldown), bits 7:0 = 00 (passthrough)
+   wire [31:0] expected = 32'hDEAD_8000;
+
+   initial begin
+      // Check after settle - use $display first to show values
+      $display("in_value = %h, out_value = %h, expected = %h", in_value, out_value, expected);
+
+      if (out_value !== expected) begin
+         $display("%%Error: out_value = %h, expected %h", out_value, expected);
+         $stop;
+      end
+
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end
+
+endmodule

--- a/test_regress/t/t_tri_pullup_bus.py
+++ b/test_regress/t/t_tri_pullup_bus.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2024 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile(timing_loop=True, verilator_flags2=['--timing'])
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_tri_pullup_bus.v
+++ b/test_regress/t/t_tri_pullup_bus.v
@@ -1,0 +1,81 @@
+// DESCRIPTION: Verilator: Test pullup/pulldown with partial bus assigns
+//
+// This tests the case where:
+// - A bus has some bits driven by pullup/pulldown through hierarchical modules
+// - Other bits are driven by regular assigns (partial SEL)
+// - The enable tracking must correctly handle the SEL assigns
+//
+// This file ONLY is placed under the Creative Commons Public Domain.
+// SPDX-License-Identifier: CC0-1.0
+
+`default_nettype none
+
+module pullup_mod(output HI);
+    pullup pullup0(HI);
+endmodule
+
+module pulldown_mod(output LO);
+    pulldown pulldown0(LO);
+endmodule
+
+module top (
+    input wire [3:0] in_value,
+    output wire [7:0] out_value
+);
+    // Lower 4 bits driven by input (partial SEL assign)
+    assign out_value[3:0] = in_value;
+
+    // Upper 4 bits: alternating pullup/pulldown through hierarchical modules
+    // out_value[4] = 1 (pullup)
+    // out_value[5] = 0 (pulldown)
+    // out_value[6] = 1 (pullup)
+    // out_value[7] = 0 (pulldown)
+    pullup_mod   p0(.HI(out_value[4]));
+    pulldown_mod p1(.LO(out_value[5]));
+    pullup_mod   p2(.HI(out_value[6]));
+    pulldown_mod p3(.LO(out_value[7]));
+endmodule
+
+module t;
+    reg [3:0] in_value;
+    wire [7:0] out_value;
+
+    top dut(.in_value(in_value), .out_value(out_value));
+
+    initial begin
+        // Test 1: Lower bits = 0xF
+        in_value = 4'hF;
+        #1;
+        // Expected: 0x5F = 0101_1111
+        // Bits [3:0] = F (from input)
+        // Bit 4 = 1 (pullup), Bit 5 = 0 (pulldown)
+        // Bit 6 = 1 (pullup), Bit 7 = 0 (pulldown)
+        if (out_value !== 8'h5F) begin
+            $display("%%Error: Test1 expected 5F, got %h", out_value);
+            $stop;
+        end
+
+        // Test 2: Lower bits = 0xA
+        in_value = 4'hA;
+        #1;
+        // Expected: 0x5A = 0101_1010
+        if (out_value !== 8'h5A) begin
+            $display("%%Error: Test2 expected 5A, got %h", out_value);
+            $stop;
+        end
+
+        // Test 3: Lower bits = 0x0
+        in_value = 4'h0;
+        #1;
+        // Expected: 0x50 = 0101_0000
+        if (out_value !== 8'h50) begin
+            $display("%%Error: Test3 expected 50, got %h", out_value);
+            $stop;
+        end
+
+        $write("*-* All Finished *-*\n");
+        $finish;
+    end
+endmodule
+
+`default_nettype wire

--- a/test_regress/t/t_unpacked_array_partsel.py
+++ b/test_regress/t/t_unpacked_array_partsel.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This file ONLY is placed under the Creative Commons Public Domain, for
+# any use, without warranty, 2024 by Wilson Snyder.
+# SPDX-License-Identifier: CC0-1.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+# Test that part-selects on unpacked array elements compile without
+# spurious "Unsupported LHS tristate construct: ARRAYSEL" errors.
+# This is a regression test for a false positive in V3Tristate.
+
+test.compile()
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_unpacked_array_partsel.v
+++ b/test_regress/t/t_unpacked_array_partsel.v
@@ -1,0 +1,51 @@
+// DESCRIPTION: Verilator: Test unpacked array with part-select assignment
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2024 by Wilson Snyder.
+// SPDX-License-Identifier: CC0-1.0
+
+// Test that assigning to part-selects of unpacked array elements works
+// without spurious "Unsupported LHS tristate construct: ARRAYSEL" errors.
+// This is a non-tristate design - the error was a false positive.
+
+module t (/*AUTOARG*/
+   // Inputs
+   clk
+   );
+   input clk;
+
+   // Unpacked array of packed vectors
+   wire [15:0] packed_in_unpacked [0:3];
+
+   // Source data
+   wire [7:0] source [0:3];
+   assign source[0] = 8'hAA;
+   assign source[1] = 8'hBB;
+   assign source[2] = 8'hCC;
+   assign source[3] = 8'hDD;
+
+   // Assign to part-selects of unpacked array elements
+   // This pattern was incorrectly flagged as tristate
+   genvar i;
+   generate
+      for (i = 0; i < 4; i = i + 1) begin : gen_assign
+         assign packed_in_unpacked[i][7:0] = source[i];
+         assign packed_in_unpacked[i][15:8] = ~source[i];
+      end
+   endgenerate
+
+   // Verification
+   integer cyc = 0;
+   always @(posedge clk) begin
+      cyc <= cyc + 1;
+      if (cyc == 5) begin
+         if (packed_in_unpacked[0] !== 16'h55AA) $stop;
+         if (packed_in_unpacked[1] !== 16'h44BB) $stop;
+         if (packed_in_unpacked[2] !== 16'h33CC) $stop;
+         if (packed_in_unpacked[3] !== 16'h22DD) $stop;
+         $write("*-* All Finished *-*\n");
+         $finish;
+      end
+   end
+
+endmodule


### PR DESCRIPTION
ARRAYSEL reported false positive on unpacked array element part-selects (e.g. `arr[i][7:0] = x`) incorrectly tripped a tristate "Unsupported LHS" error, even though the design has no tristate signals. The else branch for non-tristate RHS was setting `user1p()` on the LHS even for ARRAYSEL nodes (unpacked array element connections). Since there's no `visit(AstArraySel*)` handler for the non-graphing phase, `checkUnhandled()` would error with "Unsupported LHS tristate construct". The fix skips ARRAYSEL in this code path; actual tristate array selects (tri type) are still correctly flagged as unsupported in other paths.

Pullup/pulldown bus correctness fix, first observed on the sky130 standard-cell `conb` tie-cell. When a bus has some bits driven by pullup/pulldown (through hierarchical modules) and other bits driven by regular bit-select assigns, the enable tracking was not properly handling the SEL assigns. This caused the pullup/pulldown values to be incorrect because the enable for the non-tristate assignment was not being propagated. The fix detects SEL LHS targeting tristate variables in `visitAssign()` and creates a proper enable expression for the partial assign, applies the pull formula at all levels (not just top-level) when a pull is present, and handles the case where `orp` is null when only pullup/pulldown drives the signal.

Added regression tests:
- `t_unpacked_array_partsel` for the ARRAYSEL false-positive, 
- `t_tri_pullup_bus` for a bus with partial SEL combined with hierarchical pullup/pulldown, and 
- `t_pull_bitsel` which captures the original sky130 `conb`-style topology with passthrough bits surrounding the pull region.
