### PR TITLE
Support NBAs in initial blocks with delay/event controls (#7566)

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -320,3 +320,4 @@ emmettifelts
 Yogish Sekhar
 24bit-xjkp
 Zubin Jain
+Muzaffer Kal

--- a/docs/guide/warnings.rst
+++ b/docs/guide/warnings.rst
@@ -1179,7 +1179,9 @@ List Of Warnings
 
    Warns that the code has a delayed assignment inside of an ``initial`` or
    ``final`` block. If this message is suppressed, Verilator will convert
-   this to a non-delayed assignment. See also :option:`COMBDLY`.
+   this to a non-delayed assignment. With :vlopt:`--timing`, delayed
+   assignments in timed ``initial`` blocks are scheduled as non-blocking
+   assignments. See also :option:`COMBDLY`.
 
    Ignoring this warning may make Verilator simulations differ from other
    simulators.

--- a/docs/guide/warnings.rst
+++ b/docs/guide/warnings.rst
@@ -1180,8 +1180,9 @@ List Of Warnings
    Warns that the code has a delayed assignment inside of an ``initial`` or
    ``final`` block. If this message is suppressed, Verilator will convert
    this to a non-delayed assignment. With :vlopt:`--timing`, delayed
-   assignments in timed ``initial`` blocks are scheduled as non-blocking
-   assignments. See also :option:`COMBDLY`.
+   assignments in ``initial`` blocks that also contain a `#` delay
+   control, or `@` even control statement are scheduled as
+   non-blocking assignments. See also :option:`COMBDLY`.
 
    Ignoring this warning may make Verilator simulations differ from other
    simulators.

--- a/src/V3Active.cpp
+++ b/src/V3Active.cpp
@@ -509,7 +509,13 @@ class ActiveVisitor final : public VNVisitor {
 
     void visit(AstInitialStatic* nodep) override { moveUnderSpecial<AstSenItem::Static>(nodep); }
     void visit(AstInitial* nodep) override {
-        const ActiveDlyVisitor dlyvisitor{nodep, ActiveDlyVisitor::CT_INITIAL};
+        const bool timedInitial
+            = v3Global.opt.timing().isSetTrue()
+              && nodep->exists([](const AstNode* const subp) {
+                     return VN_IS(subp, Delay) || VN_IS(subp, EventControl);
+                 });
+        const ActiveDlyVisitor dlyvisitor{nodep, timedInitial ? ActiveDlyVisitor::CT_SUSPENDABLE
+                                                              : ActiveDlyVisitor::CT_INITIAL};
         visitSenItems(nodep);
         moveUnderSpecial<AstSenItem::Initial>(nodep);
     }

--- a/test_regress/t/t_assert_preponed_nba.py
+++ b/test_regress/t/t_assert_preponed_nba.py
@@ -11,7 +11,7 @@ import vltest_bootstrap
 
 test.scenarios('simulator')
 
-test.compile(verilator_flags2=['--binary --timing --assert'])
+test.compile(verilator_flags2=['--binary'])
 
 test.execute()
 

--- a/test_regress/t/t_assert_preponed_nba.py
+++ b/test_regress/t/t_assert_preponed_nba.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile(verilator_flags2=['--binary --timing --assert'])
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_assert_preponed_nba.v
+++ b/test_regress/t/t_assert_preponed_nba.v
@@ -1,0 +1,35 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain.
+// SPDX-FileCopyrightText: 2026 Wilson Snyder
+// SPDX-License-Identifier: CC0-1.0
+
+module t;
+  bit clk = 0;
+  int cnt = 0;
+  bit fire = 0;
+
+  always #1 clk = ~clk;
+
+  always_ff @(posedge clk) begin
+    if (fire) cnt <= cnt + 1;
+  end
+
+  assert property (@(posedge clk) fire |-> (cnt == 0))
+  else begin
+    $write("%%Error: sampled fire=1 cnt=%0d, expected preponed cnt 0\n", cnt);
+    $stop;
+  end
+
+  initial begin
+    @(posedge clk);
+    // verilator lint_off INITIALDLY
+    fire <= 1;
+    @(posedge clk);
+    fire <= 0;
+    // verilator lint_on INITIALDLY
+    repeat (2) @(posedge clk);
+    $write("*-* All Finished *-*\n");
+    $finish;
+  end
+endmodule

--- a/test_regress/t/t_assert_preponed_nba.v
+++ b/test_regress/t/t_assert_preponed_nba.v
@@ -16,6 +16,7 @@ module t;
   end
 
   assert property (@(posedge clk) fire |-> (cnt == 0))
+    $write("Assertion fired and passed: cnt=%0d\n", cnt);
   else begin
     $write("%%Error: sampled fire=1 cnt=%0d, expected preponed cnt 0\n", cnt);
     $stop;
@@ -23,11 +24,9 @@ module t;
 
   initial begin
     @(posedge clk);
-    // verilator lint_off INITIALDLY
     fire <= 1;
     @(posedge clk);
     fire <= 0;
-    // verilator lint_on INITIALDLY
     repeat (2) @(posedge clk);
     $write("*-* All Finished *-*\n");
     $finish;


### PR DESCRIPTION
this is a fix for #7566. The assert is gone.