### PR TITLE
 Fix unique_index of assoc array

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -218,6 +218,7 @@ Paul Bowen-Huggett
 Paul Swirhun
 Paul Wright
 Pawel Jewstafjew
+Pawel Klopotek
 Pawel Kojma
 Pawel Sagan
 Pengcheng Xu

--- a/include/verilated_types.h
+++ b/include/verilated_types.h
@@ -1090,7 +1090,7 @@ public:
     }
     VlQueue<T_Key> unique_index() const {
         VlQueue<T_Key> out;
-        std::set<T_Key> saw;
+        std::set<T_Value> saw;
         for (const auto& i : m_map) {
             auto it = saw.find(i.second);
             if (it == saw.end()) {

--- a/test_regress/t/t_assoc_method.v
+++ b/test_regress/t/t_assoc_method.v
@@ -23,6 +23,7 @@ module t;
     int qv[$];  // Value returns
     int qi[$];  // Index returns
     point points_q[int];
+    point points_qe[int]; // Empty points
     point points_qv[$];
     int i;
     bit b;
@@ -57,6 +58,12 @@ module t;
     qi = points_q.unique_index (p) with (p.x + p.y);
     qi.sort;
     `checkp(qi, "'{'h0, 'h1, 'h5}");
+
+    qi = points_qe.unique_index();
+    `checkp(qi, "'{}");
+
+    qi = points_q.unique_index();
+    `checkh(qi.size, 3);
 
     qi = points_q.find_first_index with (item.x == 1);
     `checkp(qi, "'{'h0}");


### PR DESCRIPTION
This makes unique_index method work on assoc arrays with values with types differing from the keys type. Previously it only worked with differing types in cases where they could be implicitly converted to each other.