### PR TITLE
Fix VlWide equality comparion in unpacked structs

### DIFF
--- a/include/verilated_types.h
+++ b/include/verilated_types.h
@@ -425,12 +425,13 @@ struct VlWide final {
     // Default copy assignment operators are used.
     operator WDataOutP() VL_PURE { return &m_storage[0]; }  // This also allows []
     operator WDataInP() const VL_PURE { return &m_storage[0]; }  // This also allows []
-    bool operator!=(const VlWide<N_Words>& that) const VL_PURE {
+    bool operator==(const VlWide<N_Words>& that) const VL_PURE {
         for (size_t i = 0; i < N_Words; ++i) {
-            if (m_storage[i] != that.m_storage[i]) return true;
+            if (m_storage[i] != that.m_storage[i]) return false;
         }
-        return false;
+        return true;
     }
+    bool operator!=(const VlWide<N_Words>& that) const VL_PURE { return !(*this == that); }
 
     // METHODS
     const EData& at(size_t index) const { return m_storage[index]; }

--- a/test_regress/t/t_unpacked_struct_eq.v
+++ b/test_regress/t/t_unpacked_struct_eq.v
@@ -14,6 +14,7 @@ module t;
       bit [7:0] arr[2][3];
       arr_str_t str[5];
     } sub;
+    bit [511:0] wide;
   } struct_t;
   struct_t s1;
   struct_t s2;
@@ -23,6 +24,8 @@ module t;
   assign {s2.sub.m0, s2.sub.m1} = {1'b0, 4'h5};
   assign s1.txt = "text";
   assign s2.txt = "text";
+  assign s1.wide = {16{32'hfeed0ca7}};
+  assign s2.wide = {16{32'hfeed0ca7}};
 
   assign {s1.sub.arr[0][0], s2.sub.arr[0][0]} = {8'h01, 8'h01};
   assign {s1.sub.arr[0][1], s2.sub.arr[0][1]} = {8'h02, 8'h02};
@@ -33,6 +36,7 @@ module t;
 
   assign {s3.sub.m0, s3.sub.m1} = {1'b0, 4'h5};
   assign s3.txt = "text";
+  assign s3.wide = {16{32'hfeed0ca7}};
 
   assign s3.sub.arr[0][0] = 8'h01;
   assign s3.sub.arr[0][1] = 8'h02;
@@ -44,6 +48,7 @@ module t;
   initial begin
     #1;
     if (s3 == s1) $stop;
+    if (s1 != s2) $stop;
     if (s1 == s2 && s3 != s1) begin
       $write("*-* All Finished *-*\n");
       $finish;


### PR DESCRIPTION
Having an implicit conversion to `WDataInP`/`WDataOutP` in `VlWide` has the unintended consequence that `==` on two VlWides compares the storage pointers. Fix by overloading `operator==`. There will be follow up.