### PR TITLE
Fix reference counting for modport task refs

### DIFF
--- a/src/V3Dead.cpp
+++ b/src/V3Dead.cpp
@@ -187,7 +187,7 @@ class DeadVisitor final : public VNVisitor {
     void visit(AstModportFTaskRef* nodep) override {
         iterateChildren(nodep);
         checkAll(nodep);
-        if (nodep->ftaskp()) nodep->ftaskp()->user1(1);
+        if (nodep->ftaskp()) nodep->ftaskp()->user1Inc();
     }
     void visit(AstRefDType* nodep) override {
         iterateChildren(nodep);

--- a/test_regress/t/t_interface_modport_import.v
+++ b/test_regress/t/t_interface_modport_import.v
@@ -23,6 +23,21 @@ interface test_if;
 endinterface  // test_if
 
 
+interface dead_caller_if;
+  task automatic imported_task;
+  endtask
+  modport mp(import imported_task);
+endinterface
+
+module dead_caller_test;
+  dead_caller_if di ();
+
+  task automatic uncalled_caller;
+    di.imported_task;
+  endtask
+endmodule
+
+
 module t (  /*AUTOARG*/
     // Inputs
     clk
@@ -35,6 +50,8 @@ module t (  /*AUTOARG*/
       .clk(clk),
       .i(i.mp)
   );
+
+  dead_caller_test dead_caller_test_i ();
 
 endmodule
 

--- a/test_regress/t/t_interface_modport_import.v
+++ b/test_regress/t/t_interface_modport_import.v
@@ -23,21 +23,6 @@ interface test_if;
 endinterface  // test_if
 
 
-interface dead_caller_if;
-  task automatic imported_task;
-  endtask
-  modport mp(import imported_task);
-endinterface
-
-module dead_caller_test;
-  dead_caller_if di ();
-
-  task automatic uncalled_caller;
-    di.imported_task;
-  endtask
-endmodule
-
-
 module t (  /*AUTOARG*/
     // Inputs
     clk
@@ -50,8 +35,6 @@ module t (  /*AUTOARG*/
       .clk(clk),
       .i(i.mp)
   );
-
-  dead_caller_test dead_caller_test_i ();
 
 endmodule
 

--- a/test_regress/t/t_opt_dead.v
+++ b/test_regress/t/t_opt_dead.v
@@ -44,6 +44,20 @@ interface If_Dead;
   modport modport_Dead(import if_func_Dead);
 endinterface
 
+interface Dead_caller_if;
+  task automatic imported_task_Dead;
+  endtask
+  modport mp_Dead(import imported_task_Dead);
+endinterface
+
+module Dead_caller_test;
+  Dead_caller_if di ();
+
+  task automatic uncalled_caller_Dead;
+    di.imported_task_Dead;
+  endtask
+endmodule
+
 package Pkg_public_kpt;
   parameter int public_int_Keep  /*verilator public_flat_rd*/ = 5;
 endpackage
@@ -76,6 +90,7 @@ module t (  /*AUTOARG*/);
 
   Mod_Empty_Dead cell_empty_Dead ();
   Mod_Parent_Empty_Dead cell_parent_empty_Dead ();
+  Dead_caller_test dead_caller_test_i ();
 
   typedef_Dead1_t assigned_to_Dead1;
   typedef_Dead2_t assigned_to_Dead2;


### PR DESCRIPTION
The DeadVisitor visitor for AstModportFTaskRef forces the target task's refcount to 1, if referenced by a task which itself is found to be dead then the target task can be dead-code eliminated. Resolve this by incrementing user1 rather than forcing. This behaviour seems to have been introduced as part of #6380 but had been fine before.

Found & patch prep'ed with claude code.