### PR TITLE
feat(lint): add UNSYNTHESIZABLE warning for /, %, ** operators

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -322,3 +322,4 @@ Yogish Sekhar
 24bit-xjkp
 Zubin Jain
 Muzaffer Kal
+Lucas Amaral

--- a/docs/guide/warnings.rst
+++ b/docs/guide/warnings.rst
@@ -2410,6 +2410,24 @@ List Of Warnings
    Disabling this error also disables :option:`COVERIGN` and
    :option:`SPECIFYIGN`.
 
+
+.. option:: UNSYNTHESIZABLE
+
+   Warns when the design uses an arithmetic operator that is commonly
+   rejected or treated specially by hardware synthesis tools: division
+   (``/``), modulo (``%``), and exponentiation (``**``), including their
+   signed variants.
+
+   Behavior across synthesis tools varies. Verilator simulates these
+   operators correctly, but synthesis tools may quietly reinterpret them,
+   producing a netlist that diverges from the simulation. Detecting these
+   operators in Verilator helps catch potential simulation/synthesis
+   mismatches early in flows that target less permissive synthesizers.
+
+   Disabled by default. Enable with ``-Wwarn-UNSYNTHESIZABLE`` to surface
+   it. Ignoring this warning does not affect Verilator simulation; it
+   only flags a potential synthesis-flow incompatibility.
+
 .. option:: UNUSED
 
    Disabling/enabling UNUSED is equivalent to disabling/enabling the

--- a/src/V3Error.h
+++ b/src/V3Error.h
@@ -176,6 +176,7 @@ public:
         UNPACKED,       // Unsupported unpacked
         UNSATCONSTR,    // Unsatisfied constraint
         UNSIGNED,       // Comparison is constant due to unsigned arithmetic
+        UNSYNTHESIZABLE,// Unsynthesizable operator
         UNUSED,         // Unused genvar, parameter or signal message (Backward Compatibility)
         UNUSEDGENVAR,   // No receivers for genvar
         UNUSEDLOOP,     // Loop is unused
@@ -238,15 +239,16 @@ public:
             "REDEFMACRO", "RISEFALLDLY", "SELRANGE", "SHORTREAL", "SIDEEFFECT", "SPECIFYIGN",
             "SPLITVAR", "STATICVAR", "STMTDLY", "SUPERNFIRST", "SYMRSVDWORD", "SYNCASYNCNET",
             "TICKCOUNT", "TIMESCALEMOD", "UNDRIVEN", "UNOPT", "UNOPTFLAT", "UNOPTTHREADS",
-            "UNPACKED", "UNSATCONSTR", "UNSIGNED", "UNUSED", "UNUSEDGENVAR", "UNUSEDLOOP",
-            "UNUSEDPARAM", "UNUSEDSIGNAL", "USERERROR", "USERFATAL", "USERINFO", "USERWARN",
-            "VARHIDDEN", "WAITCONST", "WIDTH", "WIDTHCONCAT", "WIDTHEXPAND", "WIDTHTRUNC",
-            "WIDTHXZEXPAND", "ZERODLY", "ZEROREPL", " MAX"};
+            "UNPACKED", "UNSATCONSTR", "UNSIGNED", "UNSYNTHESIZABLE", "UNUSED", "UNUSEDGENVAR",
+            "UNUSEDLOOP", "UNUSEDPARAM", "UNUSEDSIGNAL", "USERERROR", "USERFATAL", "USERINFO",
+            "USERWARN", "VARHIDDEN", "WAITCONST", "WIDTH", "WIDTHCONCAT", "WIDTHEXPAND",
+            "WIDTHTRUNC", "WIDTHXZEXPAND", "ZERODLY", "ZEROREPL", " MAX"};
         return names[m_e];
     }
     // Warnings that default to off
     bool defaultsOff() const VL_MT_SAFE {
-        return (m_e == IMPERFECTSCH || m_e == I_CELLDEFINE || styleError());
+        return (m_e == IMPERFECTSCH || m_e == I_CELLDEFINE || m_e == UNSYNTHESIZABLE
+                || styleError());
     }
     // Warnings that warn about nasty side effects
     bool dangerous() const VL_MT_SAFE { return (m_e == COMBDLY); }

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -369,10 +369,22 @@ class WidthVisitor final : public VNVisitor {
     // Signed: If both sides real
     void visit(AstAdd* nodep) override { visit_add_sub_replace(nodep, true); }
     void visit(AstSub* nodep) override { visit_add_sub_replace(nodep, true); }
-    void visit(AstDiv* nodep) override { visit_add_sub_replace(nodep, true); }
+    void visit(AstDiv* nodep) override {
+        if (!m_paramsOnly) {
+            nodep->v3warn(UNSYNTHESIZABLE,
+                          "Operator '/' is not always synthesizable; behavior varies by tool");
+        }
+        visit_add_sub_replace(nodep, true);
+    }
     void visit(AstMul* nodep) override { visit_add_sub_replace(nodep, true); }
     // These can't promote to real
-    void visit(AstModDiv* nodep) override { visit_add_sub_replace(nodep, false); }
+    void visit(AstModDiv* nodep) override {
+        if (!m_paramsOnly) {
+            nodep->v3warn(UNSYNTHESIZABLE,
+                          "Operator '%' is not always synthesizable; behavior varies by tool");
+        }
+        visit_add_sub_replace(nodep, false);
+    }
     void visit(AstModDivS* nodep) override { visit_add_sub_replace(nodep, false); }
     void visit(AstMulS* nodep) override { visit_add_sub_replace(nodep, false); }
     void visit(AstDivS* nodep) override { visit_add_sub_replace(nodep, false); }
@@ -1896,6 +1908,10 @@ class WidthVisitor final : public VNVisitor {
         // RHS is self-determined (IEEE)
         // Real if either side is real (as with AstAdd)
         assertAtExpr(nodep);
+        if (!m_paramsOnly) {
+            nodep->v3warn(UNSYNTHESIZABLE, "Operator '**' (power) is not always synthesizable;"
+                                           " behavior varies by tool");
+        }
         if (m_vup->prelim()) {
             userIterateAndNext(nodep->lhsp(), WidthVP{CONTEXT_DET, PRELIM}.p());
             userIterateAndNext(nodep->rhsp(), WidthVP{CONTEXT_DET, PRELIM}.p());

--- a/test_regress/t/t_lint_unsynthesizable_bad.out
+++ b/test_regress/t/t_lint_unsynthesizable_bad.out
@@ -1,0 +1,29 @@
+%Warning-UNSYNTHESIZABLE: t/t_lint_unsynthesizable_bad.v:15:21: Operator '/' is not always synthesizable; behavior varies by tool
+                                                              : ... note: In instance 't'
+   15 |   assign q_div  = a / b;
+      |                     ^
+                          ... For warning description see https://verilator.org/warn/UNSYNTHESIZABLE?v=latest
+                          ... Use "/* verilator lint_off UNSYNTHESIZABLE */" and lint_on around source to disable this message.
+%Warning-UNSYNTHESIZABLE: t/t_lint_unsynthesizable_bad.v:16:21: Operator '%' is not always synthesizable; behavior varies by tool
+                                                              : ... note: In instance 't'
+   16 |   assign q_mod  = a % b;
+      |                     ^
+%Warning-UNSYNTHESIZABLE: t/t_lint_unsynthesizable_bad.v:17:22: Operator '/' is not always synthesizable; behavior varies by tool
+                                                              : ... note: In instance 't'
+   17 |   assign q_divs = sa / sb;
+      |                      ^
+%Warning-UNSYNTHESIZABLE: t/t_lint_unsynthesizable_bad.v:18:22: Operator '%' is not always synthesizable; behavior varies by tool
+                                                              : ... note: In instance 't'
+   18 |   assign q_mods = sa % sb;
+      |                      ^
+%Warning-UNSYNTHESIZABLE: t/t_lint_unsynthesizable_bad.v:19:21: Operator '**' (power) is not always synthesizable; behavior varies by tool
+                                                              : ... note: In instance 't'
+   19 |   assign q_pow  = a ** b;
+      |                     ^~
+%Warning-WIDTHEXPAND: t/t_lint_unsynthesizable_bad.v:19:21: Operator POW expects 16 bits on the LHS, but LHS's VARREF 'a' generates 8 bits.
+                                                          : ... note: In instance 't'
+   19 |   assign q_pow  = a ** b;
+      |                     ^~
+                      ... For warning description see https://verilator.org/warn/WIDTHEXPAND?v=latest
+                      ... Use "/* verilator lint_off WIDTHEXPAND */" and lint_on around source to disable this message.
+%Error: Exiting due to

--- a/test_regress/t/t_lint_unsynthesizable_bad.py
+++ b/test_regress/t/t_lint_unsynthesizable_bad.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Lint test for UNSYNTHESIZABLE warning
+#
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
+# SPDX-License-Identifier: CC0-1.0
+
+import vltest_bootstrap
+
+test.scenarios('linter')
+
+test.lint(fails=True, v_flags2=['-Wwarn-UNSYNTHESIZABLE'], expect_filename=test.golden_filename)
+
+test.passes()

--- a/test_regress/t/t_lint_unsynthesizable_bad.v
+++ b/test_regress/t/t_lint_unsynthesizable_bad.v
@@ -1,0 +1,20 @@
+// DESCRIPTION: Verilator: Test of UNSYNTHESIZABLE warning on / % ** operators
+//
+// SPDX-FileCopyrightText: 2026 Lucas Amaral
+// SPDX-License-Identifier: CC0-1.0
+
+module t (
+  input wire [7:0] a, b,
+  input wire signed [7:0] sa, sb,
+  output wire [7:0] q_div,
+  output wire [7:0] q_mod,
+  output wire signed [7:0] q_divs,
+  output wire signed [7:0] q_mods,
+  output wire [15:0] q_pow
+);
+  assign q_div  = a / b;
+  assign q_mod  = a % b;
+  assign q_divs = sa / sb;
+  assign q_mods = sa % sb;
+  assign q_pow  = a ** b;
+endmodule


### PR DESCRIPTION
## Summary

Adds an opt-in `UNSYNTHESIZABLE` lint warning for the `/`, `%`, and `**` operators (including their signed variants).

## Motivation

These operators are syntactically valid in SystemVerilog and Verilator simulates them correctly, but their treatment by synthesis tools varies widely:

- Some tools (Yosys' default backend, smaller open-source flows targeting fabric-only FPGAs, restrictive ASIC nodes) reject them outright.
- Others infer a divider / multiplier only when an operand is constant or a power of two, and silently produce a different result otherwise.
- A handful pass them through but emit large, costly hardware that the designer didn't intend.

The hazard is **silent**: the same RTL passes Verilator, passes the testbench, and only diverges once it reaches synthesis or the netlist. Surfacing the construct in Verilator helps catch potential simulation/synthesis mismatches early.

## What this PR does

- Adds `UNSYNTHESIZABLE` to `V3ErrorCode` (alphabetical) and to `defaultsOff()` — disabled by default
- Emits the warning in `V3Width::visit(AstDiv*)`, `visit(AstModDiv*)`, and `visit(AstPow*)` when not in `m_paramsOnly` mode
- Documents the warning in `docs/guide/warnings.rst`
- Adds regression test `t_lint_unsynthesizable_bad` that exercises all 3 unique messages (`/`, `%`, `**`)

## Notes

- Off by default; enable with `-Wwarn-UNSYNTHESIZABLE`
- The warning message uses the accurate phrasing `"Operator 'X' is not always synthesizable; behavior varies by tool"` to reflect that these operators *can* be synthesized, just not portably
- Signed variants (`AstDivS`, `AstModDivS`, `AstMulS`) are handled because Verilator promotes them to the unsigned visitors first via `visit_add_sub_replace`
- The contributor entry in `docs/CONTRIBUTORS` is in a separate commit so it can be dropped on conflict

## Test plan

- [x] `make test_regress` passes locally (`vlt/t_lint_unsynthesizable_bad: Self PASSED`)
- [x] Fork CI green on `lucaaamaral/verilator#2` before opening this PR
- [ ] Upstream CI green
