### PR TITLE
Tests: Reduce peak memory use of UVM tests

### DIFF
--- a/test_regress/driver.py
+++ b/test_regress/driver.py
@@ -1687,8 +1687,9 @@ class VlTest:
         return VlTest._cached_aslr_off
 
     @property
-    def build_jobs(self) -> str:
-        return "--build-jobs " + str(Args.driver_build_jobs_n)
+    def build_jobs_groups(self) -> str:
+        return "--build-jobs " + str(Args.driver_build_jobs_n) + " --output-groups " + str(
+            max(6, Args.driver_build_jobs_n))
 
     @property
     def driver_verilator_flags(self) -> list:

--- a/test_regress/t/t_uvm_dpi_v2017_1_0.py
+++ b/test_regress/t/t_uvm_dpi_v2017_1_0.py
@@ -17,7 +17,11 @@ if re.search(r'clang', test.cxx_version):
     test.skip("uvm_regex.cc from upstream has clang warnings")
 
 test.compile(verilator_flags2=[
-    "--binary", test.build_jobs, "--vpi", "+define+T_V2017_1_0", "+incdir+t/uvm/v2017_1_0",
+    "--binary",
+    test.build_jobs_groups,
+    "--vpi",
+    "+define+T_V2017_1_0",
+    "+incdir+t/uvm/v2017_1_0",  #
     test.pli_filename
 ])
 

--- a/test_regress/t/t_uvm_dpi_v2020_3_1.py
+++ b/test_regress/t/t_uvm_dpi_v2020_3_1.py
@@ -17,7 +17,11 @@ if re.search(r'clang', test.cxx_version):
     test.skip("uvm_regex.cc from upstream has clang warnings")
 
 test.compile(verilator_flags2=[
-    "--binary", test.build_jobs, "--vpi", "+define+T_V2020_3_1", "+incdir+t/uvm/v2020_3_1",
+    "--binary",
+    test.build_jobs_groups,
+    "--vpi",
+    "+define+T_V2020_3_1",
+    "+incdir+t/uvm/v2020_3_1",  #
     test.pli_filename
 ])
 

--- a/test_regress/t/t_uvm_hello_all_v2017_1_0_dpi.py
+++ b/test_regress/t/t_uvm_hello_all_v2017_1_0_dpi.py
@@ -19,7 +19,7 @@ if test.have_dev_gcov:
 
 test.compile(v_flags2=[
     "--binary",
-    test.build_jobs,
+    test.build_jobs_groups,
     "--vpi",
     "--CFLAGS -O0",
     "-Wall",

--- a/test_regress/t/t_uvm_hello_all_v2017_1_0_nodpi.py
+++ b/test_regress/t/t_uvm_hello_all_v2017_1_0_nodpi.py
@@ -18,7 +18,7 @@ if test.have_dev_gcov:
 
 test.compile(v_flags2=[
     "--binary",
-    test.build_jobs,
+    test.build_jobs_groups,
     "--CFLAGS -O0",
     "-Wall",
     "+incdir+t/uvm",  #

--- a/test_regress/t/t_uvm_hello_all_v2020_3_1_dpi.py
+++ b/test_regress/t/t_uvm_hello_all_v2020_3_1_dpi.py
@@ -19,7 +19,7 @@ if test.have_dev_gcov:
 
 test.compile(v_flags2=[
     "--binary",
-    test.build_jobs,
+    test.build_jobs_groups,
     "--vpi",
     "--CFLAGS -O0",
     "-Wall",

--- a/test_regress/t/t_uvm_hello_all_v2020_3_1_nodpi.py
+++ b/test_regress/t/t_uvm_hello_all_v2020_3_1_nodpi.py
@@ -18,7 +18,7 @@ if test.have_dev_gcov:
 
 test.compile(v_flags2=[
     "--binary",
-    test.build_jobs,
+    test.build_jobs_groups,
     "--CFLAGS -O0",
     "-Wall",
     "+incdir+t/uvm",  #

--- a/test_regress/t/t_vpi_force.py
+++ b/test_regress/t/t_vpi_force.py
@@ -11,14 +11,19 @@ import vltest_bootstrap
 
 test.scenarios('simulator')
 
-test.compile(make_top_shell=False,
-             make_main=False,
-             make_pli=True,
-             verilator_flags2=[
-                 "+define+VERILATOR_COMMENTS --binary --vpi", test.build_jobs, "--CFLAGS -O0",
-                 test.pli_filename
-             ],
-             v_flags2=["+define+USE_VPI_NOT_DPI"])
+test.compile(
+    make_top_shell=False,
+    make_main=False,
+    make_pli=True,
+    verilator_flags2=[
+        "+define+VERILATOR_COMMENTS",  #
+        "--binary",
+        "--vpi",
+        test.build_jobs_groups,
+        "--CFLAGS -O0",
+        test.pli_filename
+    ],
+    v_flags2=["+define+USE_VPI_NOT_DPI"])
 
 test.execute(xrun_flags2=["+define+USE_VPI_NOT_DPI"], use_libvpi=True, check_finished=True)
 


### PR DESCRIPTION
GCC 14 takes ~3GB to compile the single concatenated classes file produced for UVM tests. We have several of these, all starting early due to high priority, so 16GB memory is a bit tight to run the test suite. Add --output-groups to ensure we end up with a few smaller files. This takes ~10% longer in total to compile (44s vs 40s), but uses only ~1GB memory peak.
