### PR TITLE
Internals: Remove 'VlWide::operator bool()'

### DIFF
--- a/include/verilated_types.h
+++ b/include/verilated_types.h
@@ -95,12 +95,6 @@ struct VlWide final {
         return std::memcmp(m_storage, that.m_storage, N_Words * sizeof(EData)) == 0;
     }
     bool operator!=(const VlWide<N_Words>& that) const VL_PURE { return !(*this == that); }
-    operator bool() const VL_PURE {
-        for (size_t i = 0; i < N_Words; ++i) {
-            if (m_storage[i]) return true;
-        }
-        return false;
-    }
     EData& operator[](size_t index) VL_MT_SAFE { return m_storage[index]; }
     const EData& operator[](size_t index) const VL_MT_SAFE { return m_storage[index]; }
 

--- a/src/V3Clock.cpp
+++ b/src/V3Clock.cpp
@@ -77,18 +77,22 @@ class ClockVisitor final : public VNVisitor {
         AstNodeExpr* comparedp = nullptr;
         incp->toggleExprp(origp->cloneTree(false));
         incp->toggleCovExprp(changeRdp->cloneTree(false));
+        FileLine* const flp = nodep->fileline();
         // Xor will optimize better than Eq, when CoverToggle has bit selects,
         // but can only use Xor with non-opaque types
         if (const AstBasicDType* const bdtypep
             = VN_CAST(origp->dtypep()->skipRefp(), BasicDType)) {
-            if (!bdtypep->isOpaque()) comparedp = new AstXor{nodep->fileline(), origp, changeRdp};
+            if (!bdtypep->isOpaque()) {
+                AstNodeExpr* const zp = new AstConst{flp, AstConst::DTyped{}, origp->dtypep()};
+                comparedp = new AstNeq{flp, zp, new AstXor{flp, origp, changeRdp}};
+            }
         }
-        if (!comparedp) comparedp = AstNeq::newTyped(nodep->fileline(), origp, changeRdp);
-        AstIf* const newp = new AstIf{nodep->fileline(), comparedp, incp};
+        if (!comparedp) comparedp = AstNeq::newTyped(flp, origp, changeRdp);
+        AstIf* const newp = new AstIf{flp, comparedp, incp};
         // We could add another IF to detect posedges, and only increment if so.
         // It's another whole branch though versus a potential memory miss.
         // We'll go with the miss.
-        newp->addThensp(new AstAssign{nodep->fileline(), changeWrp, origp->cloneTree(false)});
+        newp->addThensp(new AstAssign{flp, changeWrp, origp->cloneTree(false)});
         nodep->replaceWith(newp);
         VL_DO_DANGLING(nodep->deleteTree(), nodep);
     }

--- a/test_regress/t/t_dfg_peephole.py
+++ b/test_regress/t/t_dfg_peephole.py
@@ -58,10 +58,10 @@ with open(rdFile, 'r', encoding="utf8") as rdFh, \
         pdeclFh.write("output " + sig + ";\n")
         checkFh.write("if (ref." + sig + " != opt." + sig + ") {\n")
         checkFh.write("    std::cout << \"Mismatched " + sig + "\" << std::endl;\n")
-        checkFh.write("    std::cout << \"Ref: 0x\" << std::hex << (ref." + sig +
-                      " + 0) << std::endl;\n")
-        checkFh.write("    std::cout << \"Opt: 0x\" << std::hex << (opt." + sig +
-                      " + 0) << std::endl;\n")
+        checkFh.write("    std::cout << \"Ref: \" << VL_TO_STRING(ref." + sig +
+                      ") << std::endl;\n")
+        checkFh.write("    std::cout << \"Opt: \" << VL_TO_STRING(opt." + sig +
+                      ") << std::endl;\n")
         checkFh.write("    std::exit(1);\n")
         checkFh.write("}\n")
 


### PR DESCRIPTION
This was a fudge to work around using VlWide in `if` conditions without a `_ != 0` check. That check is actually inserted by V3Width (or an equivalent reduction), so the offending code was only generated internally. Hopefully fixed the single instance where this really happened. (If not, C++ will fail to compile with "cannot convert VlWide to bool in 'if (__HERE__)'" errors, still better than the old version which used to silently not do the right test due to incorrect implicit conversions.)
