### PR TITLE
Fix dropped iff guard on clocking inside task (#7658)

### DIFF
--- a/src/V3SenExprBuilder.h
+++ b/src/V3SenExprBuilder.h
@@ -318,7 +318,7 @@ public:
         bool firedAtInitialization = false;
         for (AstSenItem* senItemp = senTreep->sensesp(); senItemp;
              senItemp = VN_AS(senItemp->nextp(), SenItem)) {
-            const auto& pair = createTerm(senItemp);
+            const auto& pair = build(senItemp);
             if (AstNodeExpr* termp = pair.first) {
                 resultp = resultp ? new AstOr{flp, resultp, termp} : termp;
                 firedAtInitialization |= pair.second;

--- a/test_regress/t/t_clocking_iff_class.py
+++ b/test_regress/t/t_clocking_iff_class.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile(verilator_flags2=["--binary", "--timing"])
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_clocking_iff_class.v
+++ b/test_regress/t/t_clocking_iff_class.v
@@ -1,0 +1,29 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain
+// SPDX-FileCopyrightText: 2026 Nikolai Kumar
+// SPDX-License-Identifier: CC0-1.0
+
+class monitor;
+  bit clk, enable, fired;
+  task run();
+    forever @(posedge clk iff enable) fired = 1;
+  endtask
+endclass
+
+module t;
+  monitor mon = new;
+  always #5 mon.clk = ~mon.clk;
+  initial begin
+    fork mon.run(); join_none
+
+    repeat(4) @(posedge mon.clk);
+    if (mon.fired !== 0) begin $display("FAIL: fired before iff guard satisfied"); $stop; end
+
+    mon.enable = 1;
+    repeat (2) @(posedge mon.clk);
+    if (mon.fired !== 1) begin $display("FAIL: did not fire when guard true"); $stop; end
+    $write("*-* All Finished *-*\n");
+    $finish;
+  end
+endmodule


### PR DESCRIPTION
Changing `SenExprBuilder::build(AstSenTree*)` from `createTerm(senItemp)` to `build(senItemp)`. This fix prevents the iff guard from being dropped in `@(posedge clk iff condition)`.
