### PR TITLE
Internals: Use type safe string format/scan

### DIFF
--- a/include/verilated.cpp
+++ b/include/verilated.cpp
@@ -4405,8 +4405,8 @@ void VlFormatString::applyDouble(double value) {
     if (!proceed()) m_fmtChar = FormatChar::f;
 
     switch (m_fmtChar) {
-    case FormatChar::e: // FALLTHRU
-    case FormatChar::f: // FALLTHRU
+    case FormatChar::e:  // FALLTHRU
+    case FormatChar::f:  // FALLTHRU
     case FormatChar::g: {  // Print with given format string
         renderDouble(m_format.substr(m_fmtBegin, m_fmtEnd - m_fmtBegin), value);
         break;
@@ -4417,10 +4417,10 @@ void VlFormatString::applyDouble(double value) {
         break;
     }
 
-    case FormatChar::d: // FALLTHRU
-    case FormatChar::b: // FALLTHRU
-    case FormatChar::o: // FALLTHRU
-    case FormatChar::h: // FALLTHRU
+    case FormatChar::d:  // FALLTHRU
+    case FormatChar::b:  // FALLTHRU
+    case FormatChar::o:  // FALLTHRU
+    case FormatChar::h:  // FALLTHRU
     case FormatChar::x: {  // Round to 64-bit integer and print as int
         VlWide<2> wide;
         VL_SET_WQ(wide, VL_RTOIROUND_Q_D(value));

--- a/include/verilated.cpp
+++ b/include/verilated.cpp
@@ -1834,105 +1834,112 @@ void VL_FCLOSE_I(IData fdi) VL_MT_SAFE {
     Verilated::threadContextp()->impp()->fdClose(fdi);
 }
 
-void VL_SFORMAT_NX(int obits, CData& destr, const std::string& format, int argc, ...) VL_MT_SAFE {
-    static thread_local std::string t_output;  // static only for speed
-    t_output = "";
-    va_list ap;
-    va_start(ap, argc);
-    _vl_vsformat(t_output, format, argc, ap);
-    va_end(ap);
+// void VL_SFORMAT_NX(int obits, CData& destr, const std::string& format, int argc, ...) VL_MT_SAFE
+// {
+//     static thread_local std::string t_output;  // static only for speed
+//     t_output = "";
+//     va_list ap;
+//     va_start(ap, argc);
+//     _vl_vsformat(t_output, format, argc, ap);
+//     va_end(ap);
 
-    _vl_string_to_vint(obits, &destr, t_output.length(), t_output.c_str());
-}
+//     _vl_string_to_vint(obits, &destr, t_output.length(), t_output.c_str());
+// }
 
-void VL_SFORMAT_NX(int obits, SData& destr, const std::string& format, int argc, ...) VL_MT_SAFE {
-    static thread_local std::string t_output;  // static only for speed
-    t_output = "";
-    va_list ap;
-    va_start(ap, argc);
-    _vl_vsformat(t_output, format, argc, ap);
-    va_end(ap);
+// void VL_SFORMAT_NX(int obits, SData& destr, const std::string& format, int argc, ...) VL_MT_SAFE
+// {
+//     static thread_local std::string t_output;  // static only for speed
+//     t_output = "";
+//     va_list ap;
+//     va_start(ap, argc);
+//     _vl_vsformat(t_output, format, argc, ap);
+//     va_end(ap);
 
-    _vl_string_to_vint(obits, &destr, t_output.length(), t_output.c_str());
-}
+//     _vl_string_to_vint(obits, &destr, t_output.length(), t_output.c_str());
+// }
 
-void VL_SFORMAT_NX(int obits, IData& destr, const std::string& format, int argc, ...) VL_MT_SAFE {
-    static thread_local std::string t_output;  // static only for speed
-    t_output = "";
-    va_list ap;
-    va_start(ap, argc);
-    _vl_vsformat(t_output, format, argc, ap);
-    va_end(ap);
+// void VL_SFORMAT_NX(int obits, IData& destr, const std::string& format, int argc, ...) VL_MT_SAFE
+// {
+//     static thread_local std::string t_output;  // static only for speed
+//     t_output = "";
+//     va_list ap;
+//     va_start(ap, argc);
+//     _vl_vsformat(t_output, format, argc, ap);
+//     va_end(ap);
 
-    _vl_string_to_vint(obits, &destr, t_output.length(), t_output.c_str());
-}
+//     _vl_string_to_vint(obits, &destr, t_output.length(), t_output.c_str());
+// }
 
-void VL_SFORMAT_NX(int obits, QData& destr, const std::string& format, int argc, ...) VL_MT_SAFE {
-    static thread_local std::string t_output;  // static only for speed
-    t_output = "";
-    va_list ap;
-    va_start(ap, argc);
-    _vl_vsformat(t_output, format, argc, ap);
-    va_end(ap);
+// void VL_SFORMAT_NX(int obits, QData& destr, const std::string& format, int argc, ...) VL_MT_SAFE
+// {
+//     static thread_local std::string t_output;  // static only for speed
+//     t_output = "";
+//     va_list ap;
+//     va_start(ap, argc);
+//     _vl_vsformat(t_output, format, argc, ap);
+//     va_end(ap);
 
-    _vl_string_to_vint(obits, &destr, t_output.length(), t_output.c_str());
-}
+//     _vl_string_to_vint(obits, &destr, t_output.length(), t_output.c_str());
+// }
 
-void VL_SFORMAT_NX(int obits, EData* destp, const std::string& format, int argc, ...) VL_MT_SAFE {
-    static thread_local std::string t_output;  // static only for speed
-    t_output = "";
-    va_list ap;
-    va_start(ap, argc);
-    _vl_vsformat(t_output, format, argc, ap);
-    va_end(ap);
+// void VL_SFORMAT_NX(int obits, EData* destp, const std::string& format, int argc, ...) VL_MT_SAFE
+// {
+//     static thread_local std::string t_output;  // static only for speed
+//     t_output = "";
+//     va_list ap;
+//     va_start(ap, argc);
+//     _vl_vsformat(t_output, format, argc, ap);
+//     va_end(ap);
 
-    _vl_string_to_vint(obits, destp, t_output.length(), t_output.c_str());
-}
+//     _vl_string_to_vint(obits, destp, t_output.length(), t_output.c_str());
+// }
 
-void VL_SFORMAT_NX(int obits_ignored, std::string& output, const std::string& format, int argc,
-                   ...) VL_MT_SAFE {
-    (void)obits_ignored;  // So VL_SFORMAT_NNX function signatures all match
-    std::string temp_output;
-    va_list ap;
-    va_start(ap, argc);
-    _vl_vsformat(temp_output, format, argc, ap);
-    va_end(ap);
-    output = temp_output;
-}
+// void VL_SFORMAT_NX(int obits_ignored, std::string& output, const std::string& format, int argc,
+//                    ...) VL_MT_SAFE {
+//     (void)obits_ignored;  // So VL_SFORMAT_NNX function signatures all match
+//     va_list ap;
+//     va_start(ap, argc);
+//     _vl_vsformat(output, format, argc, ap);
+//     va_end(ap);
+// }
 
-std::string VL_SFORMATF_N_NX(const std::string& format, int argc, ...) VL_MT_SAFE {
-    static thread_local std::string t_output;  // static only for speed
-    t_output = "";
-    va_list ap;
-    va_start(ap, argc);
-    _vl_vsformat(t_output, format, argc, ap);
-    va_end(ap);
+// std::string VL_SFORMATF_N_NX(const std::string& format, int argc, ...) VL_MT_SAFE {
+//     static thread_local std::string t_output;  // static only for speed
+//     t_output = "";
+//     va_list ap;
+//     va_start(ap, argc);
+//     _vl_vsformat(t_output, format, argc, ap);
+//     va_end(ap);
 
-    return t_output;
-}
+//     return t_output;
+// }
 
-void VL_WRITEF_NX(const std::string& format, int argc, ...) VL_MT_SAFE {
-    static thread_local std::string t_output;  // static only for speed
-    t_output = "";
-    va_list ap;
-    va_start(ap, argc);
-    _vl_vsformat(t_output, format, argc, ap);
-    va_end(ap);
+// void VL_WRITEF_NX(const std::string& format, int argc, ...) VL_MT_SAFE {
+//     static thread_local std::string t_output;  // static only for speed
+//     t_output = "";
+//     va_list ap;
+//     va_start(ap, argc);
+//     _vl_vsformat(t_output, format, argc, ap);
+//     va_end(ap);
 
-    VL_PRINTF_MT("%s", t_output.c_str());
-}
+//     VL_PRINTF_MT("%s", t_output.c_str());
+// }
 
-void VL_FWRITEF_NX(IData fpi, const std::string& format, int argc, ...) VL_MT_SAFE {
-    // While threadsafe, each thread can only access different file handles
-    static thread_local std::string t_output;  // static only for speed
-    t_output = "";
+// void VL_FWRITEF_NX(IData fpi, const std::string& format, int argc, ...) VL_MT_SAFE {
+//     // While threadsafe, each thread can only access different file handles
+//     static thread_local std::string t_output;  // static only for speed
+//     t_output = "";
 
-    va_list ap;
-    va_start(ap, argc);
-    _vl_vsformat(t_output, format, argc, ap);
-    va_end(ap);
+//     va_list ap;
+//     va_start(ap, argc);
+//     _vl_vsformat(t_output, format, argc, ap);
+//     va_end(ap);
 
-    Verilated::threadContextp()->impp()->fdWrite(fpi, t_output);
+//     Verilated::threadContextp()->impp()->fdWrite(fpi, t_output);
+// }
+
+void _vl_fputs(IData fpi, const char* str) VL_MT_SAFE {
+    Verilated::threadContextp()->impp()->fdWrite(fpi, str);
 }
 
 IData VL_FSCANF_INX(IData fpi, const std::string& format, int argc, ...) VL_MT_SAFE {
@@ -2304,7 +2311,7 @@ std::string VL_TO_STRING(QData lhs) {
     return VL_SFORMATF_N_NX("'h%0x", 1, VL_VFORMATATTR_UNSIGNED, 64, lhs);
 }
 std::string VL_TO_STRING(double lhs) {
-    return VL_SFORMATF_N_NX("%g", 1, VL_VFORMATATTR_DOUBLE, lhs);
+    return VL_SFORMATF_N_NX("%g", 1, VlFormatString::Double{}, lhs);
 }
 std::string VL_TO_STRING_W(int words, const WDataInP obj) {
     return VL_SFORMATF_N_NX("'h%0x", 1, VL_VFORMATATTR_UNSIGNED, words * VL_EDATASIZE, obj);
@@ -4052,6 +4059,442 @@ void VlDeleter::deleteAll() VL_EXCLUDES(m_mutex) VL_EXCLUDES(m_deleteMutex) VL_M
         for (VlDeletable* const objp : m_deleteNow) delete objp;
         m_deleteNow.clear();
         m_deleteMutex.unlock();
+    }
+}
+
+//===========================================================================
+// VlFormatString:: Methods
+
+thread_local std::string VlFormatString::t_tmp;
+
+bool VlFormatString::matchChar(size_t& indexr, char c) {
+    if (indexr >= m_formatLength) return false;
+    if (m_format[indexr] != c) return false;
+    ++indexr;
+    return true;
+}
+
+bool VlFormatString::matchUint(size_t& indexr, uint64_t& valuer) {
+    if (indexr >= m_formatLength) return false;
+    if (!std::isdigit(m_format[indexr])) return false;
+    valuer = 0;
+    do {
+        valuer = valuer * 10 + (m_format[indexr] - '0');
+        ++indexr;
+    } while (indexr < m_formatLength && std::isdigit(m_format[indexr]));
+    return true;
+}
+
+bool VlFormatString::matchFormatChar(size_t& indexr, FormatChar& fmtCharr) {
+    if (indexr >= m_formatLength) return false;
+    const char fmtChar = std::tolower(m_format[indexr]);
+    switch (fmtChar) {
+    case 'b':  // FALLTHRU
+    case 'c':  // FALLTHRU
+    case 'd':  // FALLTHRU
+    case 'e':  // FALLTHRU
+    case 'f':  // FALLTHRU
+    case 'g':  // FALLTHRU
+    case 'h':  // FALLTHRU
+    case 'o':  // FALLTHRU
+    case 'p':  // FALLTHRU
+    case 's':  // FALLTHRU
+    case 't':  // FALLTHRU
+    case 'u':  // FALLTHRU
+    case 'v':  // FALLTHRU
+    case 'x':  // FALLTHRU
+    case 'z':  // FALLTHRU
+        fmtCharr = static_cast<FormatChar>(fmtChar);
+        ++indexr;
+        return true;
+    }
+    return false;
+}
+
+bool VlFormatString::parseFormatSpecifier() {
+    // This function is called with m_index pointing to the character after the '%'
+    assert(m_index && m_format[m_index - 1] == '%');
+
+    if (m_index >= m_formatLength) return false;
+
+    // Save start index, use m_fmtEnd as current index
+    m_fmtBegin = m_index - 1;
+    m_fmtEnd = m_index;
+    // Accept a '-' for left justification
+    m_fmtLeftJustify = matchChar(m_fmtEnd, '-');
+    // Accept an integer for field width
+    m_fmtWidth = 0;
+    m_fmtWidthSet = matchUint(m_fmtEnd, m_fmtWidth);
+    // Accept a '.' for precision, and if given accept another integer
+    if (matchChar(m_fmtEnd, '.')) {
+        uint64_t precision;  // Unsused, will just call C sformat
+        matchUint(m_fmtEnd, precision);
+    }
+    // Accept a legal format specifier character, if found, commit the index and return true
+    if (matchFormatChar(m_fmtEnd, m_fmtChar)) {
+        m_index = m_fmtEnd;
+        return true;
+    }
+    // Not a valid format specifier, caller will emit it verbatim
+    return false;
+}
+
+bool VlFormatString::proceed() {
+    while (m_index < m_formatLength) {
+        const char c = m_format[m_index++];
+        // Emit characters until next % is found
+        if (c != '%') {
+            m_output += c;
+            continue;
+        }
+
+        // Parse format specifier - first check for simple cases
+        switch (std::tolower(m_format[m_index])) {
+        case '%':  // Literal '%'
+            ++m_index;
+            m_output += '%';
+            continue;
+        case 'm':  // Scope name
+            ++m_index;
+            m_output += m_modelNamep;
+            if (m_modelNamep[0] && m_scopeNamep[0]) m_output += '.';
+            m_output += m_scopeNamep;
+            continue;
+        case 'l':  // Library - compile-time only // LCOV_EXCL_START
+            ++m_index;
+            m_output += "----";
+            continue;  // LCOV_EXCL_STOP
+        default:  // format specifier expected
+            break;
+        }
+
+        // Parse format specifier. If invalid, just emit the characters verbatim
+        if (!parseFormatSpecifier()) {
+            m_output += '%';
+            continue;
+        }
+
+        // Format specifier parsed successfully
+        return true;
+    }
+    // No more format specifiers, reset the specifier info members
+    m_fmtChar = FormatChar::d;
+    m_fmtWidth = 0;
+    m_fmtWidthSet = false;
+    m_fmtLeftJustify = false;
+    return false;
+}
+
+void VlFormatString::renderWData(bool isSigned, int bits, int msb, WDataInP value) {
+    switch (m_fmtChar) {
+    case FormatChar::s: {  // Number-based string
+        std::string field;
+        for (; msb >= 0; --msb) {
+            msb = (msb / 8) * 8;  // Next digit
+            const IData charval = VL_BITRSHIFT_W(value, msb) & 0xff;
+            field += (charval == 0) ? ' ' : charval;
+        }
+        std::string padding;
+        if (m_fmtWidthSet && m_fmtWidth > field.size())
+            padding.append(m_fmtWidth - field.size(), ' ');
+        m_output += m_fmtLeftJustify ? (field + padding) : (padding + field);
+        break;
+    }
+
+    case FormatChar::d: {  // Signed/unsigned decimal
+        int digits = 0;
+        std::string append;
+        const QData qvalue = VL_SET_QW(value);
+        if (isSigned) {
+            if (bits <= VL_QUADSIZE) {
+                digits = _vl_snprintf_string(
+                    t_tmp, "%" PRId64, static_cast<int64_t>(VL_EXTENDS_QQ(bits, bits, qvalue)));
+                append = t_tmp;
+            } else {
+                if (VL_SIGN_E(bits, value[VL_WORDS_I(bits) - 1])) {
+                    std::vector<EData> neg(VL_WORDS_I(bits));
+                    WDataOutP negp = WDataOutP::external(neg.data());
+                    VL_NEGATE_W(VL_WORDS_I(bits), negp, value);
+                    append = "-"s + VL_DECIMAL_NW(bits, negp);
+                } else {
+                    append = VL_DECIMAL_NW(bits, value);
+                }
+                digits = static_cast<int>(append.length());
+            }
+        } else {  // Unsigned decimal
+            if (bits <= VL_QUADSIZE) {
+                digits = _vl_snprintf_string(t_tmp, "%" PRIu64, qvalue);
+                append = t_tmp;
+            } else {
+                append = VL_DECIMAL_NW(bits, value);
+                digits = static_cast<int>(append.length());
+            }
+        }
+        if (!m_fmtWidthSet) {
+            const double mantissabits = bits - (isSigned ? 1 : 0);
+            // This is log10(2**mantissabits) as log2(2**mantissabits)/log2(10),
+            // + 1.0 rounding bias.
+            double dchars = mantissabits / 3.321928094887362 + 1.0;
+            if (isSigned) ++dchars;  // space for sign
+            m_fmtWidth = static_cast<int>(dchars);
+        }
+        const int needmore = static_cast<int>(m_fmtWidth) - digits;
+        if (needmore > 0) {
+            std::string padding;
+            if (m_fmtLeftJustify) {
+                padding.append(needmore, ' ');  // Pre-pad spaces
+                m_output += append + padding;
+            } else {
+                if (m_format[m_fmtBegin + 1] == '0') {  // %0
+                    padding.append(needmore, '0');  // Pre-pad zero
+                } else {
+                    padding.append(needmore, ' ');  // Pre-pad spaces
+                }
+                m_output += padding + append;
+            }
+        } else {
+            m_output += append;
+        }
+        break;
+    }
+
+    case FormatChar::b:  // FALLTHRU
+    case FormatChar::o:  // FALLTHRU
+    case FormatChar::h:  // FALLTHRU
+    case FormatChar::x: {
+        if (m_fmtWidthSet || m_fmtLeftJustify) {
+            msb = VL_MOSTSETBITP1_W(VL_WORDS_I(bits), value);
+            msb = msb > 0 ? msb - 1 : 0;
+        }
+
+        std::string append;
+        int digits;
+        switch (m_fmtChar) {
+        case FormatChar::b: {
+            digits = msb + 1;
+            for (; msb >= 0; --msb) append += (VL_BITRSHIFT_W(value, msb) & 1) + '0';
+            break;
+        }
+        case FormatChar::o: {
+            digits = (msb + 1 + 2) / 3;
+            for (; msb >= 0; --msb) {
+                msb = (msb / 3) * 3;  // Next digit
+                // Octal numbers may span more than one wide word,
+                // so we need to grab each bit separately and check for overrun
+                // Octal is rare, so we'll do it a slow simple way
+                append
+                    += static_cast<char>('0' + ((VL_BITISSETLIMIT_W(value, bits, msb + 0)) ? 1 : 0)
+                                         + ((VL_BITISSETLIMIT_W(value, bits, msb + 1)) ? 2 : 0)
+                                         + ((VL_BITISSETLIMIT_W(value, bits, msb + 2)) ? 4 : 0));
+            }
+            break;
+        }
+        default: {  // 'h' / 'x'
+            digits = (msb + 1 + 3) / 4;
+            for (; msb >= 0; --msb) {
+                msb = (msb / 4) * 4;  // Next digit
+                const IData charval = VL_BITRSHIFT_W(value, msb) & 0xf;
+                append += "0123456789abcdef"[charval];
+            }
+            break;
+        }
+        }  // switch
+
+        const int needmore = static_cast<int>(m_fmtWidth) - digits;
+        if (needmore > 0) {
+            std::string padding;
+            if (m_fmtLeftJustify) {
+                padding.append(needmore, ' ');  // Pre-pad spaces
+                m_output += append + padding;
+            } else {
+                padding.append(needmore, '0');  // Pre-pad zero
+                m_output += padding + append;
+            }
+        } else {
+            m_output += append;
+        }
+        break;
+    }  // b / h / o / x
+
+    case FormatChar::t: {
+        if (!m_fmtWidthSet) m_fmtWidth = Verilated::threadContextp()->impp()->timeFormatWidth();
+        m_output += _vl_vsformat_time(t_tmp, VL_SET_QW(value), m_timeunit, m_fmtLeftJustify,
+                                      m_fmtWidth);
+        break;
+    }
+
+    case FormatChar::c: {
+        m_output += static_cast<char>(value[0] & 0xff);
+        break;
+    }
+
+    case FormatChar::v: {
+        // Strength; assume always strong
+        for (msb = bits - 1; msb >= 0; --msb) {
+            if (VL_BITRSHIFT_W(value, msb) & 1) {
+                m_output += "St1 ";
+            } else {
+                m_output += "St0 ";
+            }
+        }
+        break;
+    }
+
+    case FormatChar::e:
+        assert(false);  // TODO: Implement WData as "%e"
+        break;
+    case FormatChar::f:
+        assert(false);  // TODO: Implement WData as "%f"
+        break;
+    case FormatChar::g:
+        assert(false);  // TODO: Implement WData as "%g"
+        break;
+    case FormatChar::p:
+        assert(false);  // TODO: Implement WData as "%p"
+        break;
+    case FormatChar::u:
+        assert(false);  // TODO: Implement WData as "%u"
+        break;
+    case FormatChar::z:
+        assert(false);  // TODO: Implement WData as "%z"
+        break;
+    }
+}
+
+void VlFormatString::renderDouble(const std::string& format, double value) {
+    // IEEE says same as C
+    _vl_snprintf_string(t_tmp, format.c_str(), value);
+    m_output += t_tmp;
+}
+
+void VlFormatString::applyQData(const char fmtArg, const int bits, QData value) {
+    VlWide<2> valueWide;
+    VL_SET_WQ(valueWide, value);
+    applyWData(fmtArg, bits, valueWide);
+}
+
+void VlFormatString::applyWData(const char fmtArg, const int bits, WDataInP value) {
+    assert(fmtArg == VL_VFORMATATTR_SIGNED || fmtArg == VL_VFORMATATTR_UNSIGNED);
+
+    // Find next format specifier, if none, use '%d'
+    if (!proceed()) m_fmtChar = FormatChar::d;
+
+    if (m_fmtChar == FormatChar::p) {
+        if (m_fmtWidthSet && m_fmtWidth == 0) {
+            // For %0p, IEEE our choice, use 'h%0h
+            m_output += "'h";
+            m_fmtChar = FormatChar::h;
+        } else {
+            // UVM tests require %0d
+            m_fmtWidthSet = true;
+            m_fmtWidth = 0;
+            m_fmtChar = FormatChar::d;
+        }
+    }
+
+    int msb = bits - 1;
+    if (m_fmtWidthSet && m_fmtWidth == 0) {
+        while (msb && !VL_BITISSET_W(value, msb)) --msb;
+    }
+
+    renderWData(fmtArg == VL_VFORMATATTR_SIGNED, bits, msb, value);
+}
+
+void VlFormatString::applyDouble(double value) {
+    // Find next format specifier, if none, use '%f'
+    if (!proceed()) m_fmtChar = FormatChar::f;
+
+    switch (m_fmtChar) {
+    case FormatChar::e: // FALLTHRU
+    case FormatChar::f: // FALLTHRU
+    case FormatChar::g: {  // Print with given format string
+        renderDouble(m_format.substr(m_fmtBegin, m_fmtEnd - m_fmtBegin), value);
+        break;
+    }
+
+    case FormatChar::p: {  // Print as "%g"
+        renderDouble("%g", value);
+        break;
+    }
+
+    case FormatChar::d: // FALLTHRU
+    case FormatChar::b: // FALLTHRU
+    case FormatChar::o: // FALLTHRU
+    case FormatChar::h: // FALLTHRU
+    case FormatChar::x: {  // Round to 64-bit integer and print as int
+        VlWide<2> wide;
+        VL_SET_WQ(wide, VL_RTOIROUND_Q_D(value));
+        renderWData(false, 64, 63, wide);
+        break;
+    }
+
+    case FormatChar::t: {
+        if (!m_fmtWidthSet) m_fmtWidth = Verilated::threadContextp()->impp()->timeFormatWidth();
+        m_output += _vl_vsformat_time(t_tmp, value, m_timeunit, m_fmtLeftJustify, m_fmtWidth);
+        break;
+    }
+
+    case FormatChar::c:
+        assert(false);  // TODO: Implement double as "%c"
+        break;
+    case FormatChar::s:
+        assert(false);  // TODO: Implement double as "%s"
+        break;
+    case FormatChar::u:
+        assert(false);  // TODO: Implement source as "%u"
+        break;
+    case FormatChar::v:
+        assert(false);  // TODO: Implement double as "%v"
+        break;
+    case FormatChar::z:
+        assert(false);  // TODO: Implement double as "%z"
+        break;
+    }
+}
+
+void VlFormatString::applyString(const char fmtArg, const std::string& value) {
+    assert(fmtArg == VL_VFORMATATTR_STRING || fmtArg == VL_VFORMATATTR_COMPLEX);
+
+    // Find next format specifier, if none, use '%s'
+    if (!proceed()) m_fmtChar = FormatChar::s;
+
+    // Override specifier if necessary
+    if (fmtArg == VL_VFORMATATTR_COMPLEX) {
+        if (m_fmtChar != FormatChar::p) m_fmtChar = FormatChar::s;
+    } else if (fmtArg == VL_VFORMATATTR_STRING) {
+        if (m_fmtChar != FormatChar::p && m_fmtChar != FormatChar::x) {
+            m_fmtChar = FormatChar::s;
+        }
+    } else {
+        m_fmtChar = FormatChar::s;
+    }
+
+    if (m_fmtChar == FormatChar::p) {
+        if (fmtArg == VL_VFORMATATTR_STRING) {
+            m_output += '"' + value + '"';
+        } else {  // fmtArg == VL_VFORMATATTR_COMPLEX
+            m_output += value;
+        }
+    } else if (m_fmtChar == FormatChar::x) {
+        // V3Width errors on const %x of string, but V3Randomize may make a %x on a
+        // string, or may have a runtime format
+        const int chars = value.size();
+        int truncFront = m_fmtWidthSet ? (chars - (static_cast<int>(m_fmtWidth) / 2)) : 0;
+        if (truncFront < 0) truncFront = 0;
+        const int bits = chars * 8;
+        std::vector<EData> strwide;
+        strwide.resize(VL_WORDS_I(bits));
+        WDataOutP strwidep = WDataOutP::external(strwide.data());
+        VL_NTOI_W(bits, strwidep, value, truncFront);
+        renderWData(false, bits, bits - 1, strwidep);
+    } else {  // m_fmtChar == 's'
+        std::string padding;
+        if (m_fmtWidth > value.size()) padding.append(m_fmtWidth - value.size(), ' ');
+        if (m_fmtLeftJustify) {
+            m_output += value + padding;
+        } else {
+            m_output += padding + value;
+        }
     }
 }
 

--- a/include/verilated_funcs.h
+++ b/include/verilated_funcs.h
@@ -150,8 +150,21 @@ extern void VL_FCLOSE_I(IData fdi) VL_MT_SAFE;
 extern IData VL_FREAD_I(int width, int array_lsb, int array_size, void* memp, IData fpi,
                         IData start, IData count) VL_MT_SAFE;
 
-extern void VL_WRITEF_NX(const std::string& format, int argc, ...) VL_MT_SAFE;
-extern void VL_FWRITEF_NX(IData fpi, const std::string& format, int argc, ...) VL_MT_SAFE;
+template <typename... Args>
+inline void VL_WRITEF_NX(const std::string& format, int, Args&&... args) VL_MT_SAFE {
+    VlFormatString formatter{format, std::forward<Args>(args)...};
+    const std::string& output = formatter.result();
+    VL_PRINTF_MT("%s", output.c_str());
+}
+
+void _vl_fputs(IData fpi, const char* str) VL_MT_SAFE;
+
+template <typename... Args>
+inline void VL_FWRITEF_NX(IData fpi, const std::string& format, int, Args&&... args) VL_MT_SAFE {
+    VlFormatString formatter{format, std::forward<Args>(args)...};
+    const std::string& output = formatter.result();
+    _vl_fputs(fpi, output.c_str());
+}
 
 extern IData VL_FSCANF_INX(IData fpi, const std::string& format, int argc, ...) VL_MT_SAFE;
 extern IData VL_SSCANF_IINX(int lbits, IData ld, const std::string& format, int argc,
@@ -161,16 +174,54 @@ extern IData VL_SSCANF_IQNX(int lbits, QData ld, const std::string& format, int 
 extern IData VL_SSCANF_IWNX(int lbits, WDataInP const lwp, const std::string& format, int argc,
                             ...) VL_MT_SAFE;
 
-extern void VL_SFORMAT_NX(int obits, CData& destr, const std::string& format, int argc,
-                          ...) VL_MT_SAFE;
-extern void VL_SFORMAT_NX(int obits, SData& destr, const std::string& format, int argc,
-                          ...) VL_MT_SAFE;
-extern void VL_SFORMAT_NX(int obits, IData& destr, const std::string& format, int argc,
-                          ...) VL_MT_SAFE;
-extern void VL_SFORMAT_NX(int obits, QData& destr, const std::string& format, int argc,
-                          ...) VL_MT_SAFE;
-extern void VL_SFORMAT_NX(int obits, EData* destp, const std::string& format, int argc,
-                          ...) VL_MT_SAFE;
+void _vl_string_to_vint(int obits, void* destp, size_t srclen, const char* srcp) VL_MT_SAFE;
+
+template <typename... Args>
+inline void VL_SFORMAT_NX(int obits, CData& dest, const std::string& format, int,
+                          Args&&... args) VL_MT_SAFE {
+    VlFormatString formatter{format, std::forward<Args>(args)...};
+    const std::string& output = formatter.result();
+    _vl_string_to_vint(obits, &dest, output.length(), output.c_str());
+}
+template <typename... Args>
+inline void VL_SFORMAT_NX(int obits, SData& dest, const std::string& format, int,
+                          Args&&... args) VL_MT_SAFE {
+    VlFormatString formatter{format, std::forward<Args>(args)...};
+    const std::string& output = formatter.result();
+    _vl_string_to_vint(obits, &dest, output.length(), output.c_str());
+}
+template <typename... Args>
+inline void VL_SFORMAT_NX(int obits, IData& dest, const std::string& format, int,
+                          Args&&... args) VL_MT_SAFE {
+    VlFormatString formatter{format, std::forward<Args>(args)...};
+    const std::string& output = formatter.result();
+    _vl_string_to_vint(obits, &dest, output.length(), output.c_str());
+}
+template <typename... Args>
+inline void VL_SFORMAT_NX(int obits, QData& dest, const std::string& format, int,
+                          Args&&... args) VL_MT_SAFE {
+    VlFormatString formatter{format, std::forward<Args>(args)...};
+    const std::string& output = formatter.result();
+    _vl_string_to_vint(obits, &dest, output.length(), output.c_str());
+}
+template <typename... Args>
+inline void VL_SFORMAT_NX(int obits, WDataOutP dest, const std::string& format, int,
+                          Args&&... args) VL_MT_SAFE {
+    VlFormatString formatter{format, std::forward<Args>(args)...};
+    const std::string& output = formatter.result();
+    _vl_string_to_vint(obits, dest.datap(), output.length(), output.c_str());
+}
+template <typename... Args>
+inline void VL_SFORMAT_NX(int /*obits*/, std::string& dest, const std::string& format, int,
+                          Args&&... args) VL_MT_SAFE {
+    VlFormatString formatter{format, std::forward<Args>(args)...};
+    dest = formatter.result();
+}
+template <typename... Args>
+inline std::string VL_SFORMATF_N_NX(const std::string& format, int, Args&&...args) VL_MT_SAFE {
+    VlFormatString formatter{format, std::forward<Args>(args)...};
+    return formatter.result();
+}
 
 extern void VL_STACKTRACE() VL_MT_SAFE;
 extern std::string VL_STACKTRACE_N() VL_MT_SAFE;
@@ -3594,9 +3645,7 @@ extern void VL_WRITEMEM_N(bool hex, int bits, QData depth, int array_lsb,
                           QData end) VL_MT_SAFE;
 extern IData VL_SSCANF_INNX(int lbits, const std::string& ld, const std::string& format, int argc,
                             ...) VL_MT_SAFE;
-extern void VL_SFORMAT_NX(int obits_ignored, std::string& output, const std::string& format,
-                          int argc, ...) VL_MT_SAFE;
-extern std::string VL_SFORMATF_N_NX(const std::string& format, int argc, ...) VL_MT_SAFE;
+
 extern void VL_TIMEFORMAT_IINI(bool hasUnits, int units, bool hasPrecision, int precision,
                                bool hasSuffix, const std::string& suffix, bool hasWidth, int width,
                                VerilatedContext* contextp) VL_MT_SAFE;

--- a/include/verilated_funcs.h
+++ b/include/verilated_funcs.h
@@ -218,7 +218,7 @@ inline void VL_SFORMAT_NX(int /*obits*/, std::string& dest, const std::string& f
     dest = formatter.result();
 }
 template <typename... Args>
-inline std::string VL_SFORMATF_N_NX(const std::string& format, int, Args&&...args) VL_MT_SAFE {
+inline std::string VL_SFORMATF_N_NX(const std::string& format, int, Args&&... args) VL_MT_SAFE {
     VlFormatString formatter{format, std::forward<Args>(args)...};
     return formatter.result();
 }

--- a/include/verilated_types.h
+++ b/include/verilated_types.h
@@ -2078,7 +2078,7 @@ public:
     VlClassRef() = default;
     // Init with nullptr
     // cppcheck-suppress noExplicitConstructor
-    VlClassRef(VlNull){};
+    VlClassRef(VlNull) {};
     template <typename... T_Args>
     VlClassRef(VlDeleter& deleter, T_Args&&... args)
         : m_objp{new T_Class} {
@@ -2306,5 +2306,151 @@ VlQueue<T_Value, N_MaxSize>::VlQueue(VlQueue<VlClassRef<T_Subclass>>&& that)
     : m_deque{std::make_move_iterator(that.m_deque.begin()),
               std::make_move_iterator(that.m_deque.end())}
     , m_defaultValue{std::move(that.m_defaultValue)} {}
+
+//======================================================================
+
+// Format string renderer used by generated code
+class VlFormatString final {
+    // List of all valid format specifier characters - must match 'matchFormatChar' below
+    // Using an enum class to get exhaustive switch warnings from the C++ compiler.
+    enum class FormatChar : char {
+        b = 'b',
+        c = 'c',
+        d = 'd',
+        e = 'e',
+        f = 'f',
+        g = 'g',
+        h = 'h',
+        o = 'o',
+        p = 'p',
+        s = 's',
+        t = 't',
+        u = 'u',
+        v = 'v',
+        x = 'x',
+        z = 'z'
+    };
+
+    static thread_local std::string t_tmp;  // Temporary storate - static only for speed
+
+    const std::string& m_format;  // Format string
+    const size_t m_formatLength = m_format.length();  // Length of the format string
+    std::string m_output;  // Rendered output string
+    size_t m_index = 0;  // Current index pointing into the format string, for parsing
+
+    // Parsed format specifier detail - 'm_fmt*'
+    size_t m_fmtBegin = 0;  // Start of current format specifier (inclusive, points to '%')
+    size_t m_fmtEnd = 0;  // End of current format specifier (exclusive)
+    bool m_fmtLeftJustify = false;  // Left justify flag
+    bool m_fmtWidthSet = false;  // Width set flag
+    uint64_t m_fmtWidth = 0;  // Width value
+    FormatChar m_fmtChar = FormatChar::d;  // Format specifier character
+
+    // Special inputs stored for later rendering
+    const char* m_modelNamep = "";  // Name of model for "%m"
+    const char* m_scopeNamep = "";  // Name of scope for "%m"
+    int m_timeunit = 0;  // Timeunit for "%t"
+
+    // Attempt to match the given character at the given index.
+    // Iff successful, advances 'indexr' and returns true.
+    bool matchChar(size_t& indexr, char c);
+    // Attempt to match a decimal integer at the given index.
+    // Iff successful, advances 'indexr' and returns true.
+    bool matchUint(size_t& indexr, uint64_t& valuer);
+    // Attempt to match a format specifier character at the given index.
+    // Iff successful, advances 'indexr' and returns true.
+    bool matchFormatChar(size_t& indexr, FormatChar& fmtCharr);
+
+    // Called by proceed() to parse a single format specifier.
+    // Returns true if a valid format specifier is found.
+    // Updates 'm_fmt*' members even if returns false.
+    bool parseFormatSpecifier();
+
+    // Parse format string until the next format character needing input for substitution is found.
+    // Returns true if an argument is expected, or false if the end of the format string reached.
+    // If returns 'true', then the next input datum should be rendered according to 'm_fmt*'.
+    bool proceed();
+
+    // Actually render a WData and add it to the output string
+    void renderWData(bool isSigned, int bits, int msb, WDataInP value);
+    // Actually render a double and add it to the output string
+    void renderDouble(const std::string& format, double value);
+
+public:
+    // Marker types for overload resolution
+    struct TimeUnit {};
+    struct ScopeName {};
+    struct Double {};
+
+    template <typename... Args>
+    VlFormatString(const std::string& format, Args&&... args)
+        : m_format{format} {
+        m_output.reserve(m_format.length());
+        // Render all arguments
+        apply(std::forward<Args>(args)...);
+        // Emit rest of string - must scan in case there is trailing '%m' or '%%
+        while (proceed()) m_output += m_format.substr(m_fmtBegin, m_fmtEnd - m_fmtBegin);
+    }
+
+    // Return the rendered output string
+    const std::string& result() const { return m_output; }
+
+    // ---
+    // Tempalte based dispatchers so generated code can still do a variadic call
+
+    // Recursion base case
+    void apply() {}
+
+    // Scopename
+    template <typename... Args>
+    void apply(ScopeName, const char* modelNamep, const char* scopeNamep, Args&&... args) {
+        // Just save for later
+        m_scopeNamep = scopeNamep;
+        m_modelNamep = modelNamep;
+        apply(std::forward<Args>(args)...);
+    }
+
+    // Timeunit
+    template <typename... Args>
+    void apply(TimeUnit, int timeunit, Args&&... args) {
+        // Just save for later
+        m_timeunit = timeunit;
+        apply(std::forward<Args>(args)...);
+    }
+
+    // QData - Anything narrower is promoted ingenerated code
+    template <typename... Args>
+    void apply(char fmtArg, int bits, QData value, Args&&... args) {
+        applyQData(fmtArg, bits, value);
+        apply(std::forward<Args>(args)...);
+    }
+    // WData
+    template <typename... Args>
+    void apply(char fmtArg, int bits, WDataInP value, Args&&... args) {
+        applyWData(fmtArg, bits, value);
+        apply(std::forward<Args>(args)...);
+    }
+
+    // Double
+    template <typename... Args>
+    void apply(Double, double value, Args&&... args) {
+        applyDouble(value);
+        apply(std::forward<Args>(args)...);
+    }
+
+    // String
+    template <typename... Args>
+    void apply(char fmtArg, const std::string& value, Args&&... args) {
+        applyString(fmtArg, value);
+        apply(std::forward<Args>(args)...);
+    }
+
+    // ---
+    // Actual apply methods - generated code should eventually call these directly
+    void applyQData(char fmtArg, int bits, QData value);
+    void applyWData(char fmtArg, int bits, WDataInP value);
+    void applyDouble(double value);
+    void applyString(char fmtArg, const std::string& value);
+};
 
 #endif  // Guard

--- a/include/verilated_types.h
+++ b/include/verilated_types.h
@@ -2078,7 +2078,7 @@ public:
     VlClassRef() = default;
     // Init with nullptr
     // cppcheck-suppress noExplicitConstructor
-    VlClassRef(VlNull) {};
+    VlClassRef(VlNull){};
     template <typename... T_Args>
     VlClassRef(VlDeleter& deleter, T_Args&&... args)
         : m_objp{new T_Class} {

--- a/src/V3EmitCFunc.cpp
+++ b/src/V3EmitCFunc.cpp
@@ -227,7 +227,6 @@ bool EmitCFunc::displayEmitHeader(AstNode* nodep) {
         puts(cvtToStr(dispp->lhsp()->widthMin()));
         putbs(",");
         iterateConst(dispp->lhsp());
-        emitDatap(dispp->lhsp());
         putbs(",");
     } else if (VN_IS(nodep, SFormatF)) {
         isStmt = false;
@@ -286,7 +285,6 @@ void EmitCFunc::displayNode(AstNode* nodep, AstSFormatF* fmtp,  // fmtp is nullp
     if (exprFormat) {
         UASSERT_OBJ(exprsp, nodep, "Missing format expression");
         iterateConst(exprsp);
-        emitDatap(exprsp);
         exprsp = exprsp->nextp();
     } else {
         ofp()->putsQuoted(vformat);
@@ -311,8 +309,7 @@ void EmitCFunc::displayNode(AstNode* nodep, AstSFormatF* fmtp,  // fmtp is nullp
         AstScopeName* const scopenamep = fmtp ? fmtp->scopeNamep() : nullptr;
         UASSERT_OBJ(scopenamep, nodep, "Display with %m but no AstScopeName");
         const string suffix = scopenamep->scopePrettySymName();
-        ofp()->puts(", '"s + VFormatAttr{VFormatAttr::SCOPE}.ascii() + "'");
-        ofp()->puts(",vlSymsp->name(),");
+        ofp()->puts(", VlFormatString::ScopeName{},vlSymsp->name(),");
         ofp()->putsQuoted(suffix);
     }
 
@@ -330,8 +327,8 @@ void EmitCFunc::displayNode(AstNode* nodep, AstSFormatF* fmtp,  // fmtp is nullp
         UASSERT_OBJ(!timeunit.isNone(), nodep,
                     "Use of %t must be under AstDisplay, AstSFormat, or AstSFormatF, or "
                     "SScanF, and timeunit set");
-        ofp()->puts(", '"s + VFormatAttr{VFormatAttr::TIMEUNIT}.ascii() + "'");
-        ofp()->puts(","s + cvtToStr((int)timeunit.powerOfTen()));
+        ofp()->puts(", VlFormatString::TimeUnit{},");
+        ofp()->puts(cvtToStr((int)timeunit.powerOfTen()));
     }
 
     // Arguments
@@ -341,19 +338,29 @@ void EmitCFunc::displayNode(AstNode* nodep, AstSFormatF* fmtp,  // fmtp is nullp
         AstSFormatArg* const fargp = VN_CAST(argp, SFormatArg);
         AstNode* const subargp = fargp ? fargp->exprp() : argp;
         const VFormatAttr formatAttr = AstSFormatArg::formatAttrDefauled(fargp, subargp->dtypep());
-        puts(", '"s + formatAttr.ascii() + '\'');
+        if (formatAttr.isDouble()) {
+            puts(", VlFormatString::Double{}");
+        } else {
+            puts(", '"s + formatAttr.ascii() + '\'');
+        }
         if (formatAttr.isSigned() || formatAttr.isUnsigned())
             puts("," + cvtToStr(subargp->widthMin()));
-        const bool addrof = isScan || formatAttr.isString() || formatAttr.isComplex();
         puts(",");
-        if (addrof) puts("&(");
-        if (VN_IS(subargp, StreamR))
-            emitStreamR(
-                VN_CAST(subargp, StreamR),
-                nodep);  // This has to be done here because streamR doesn't know what it returns
-        else { iterateConst(subargp); }
-        if (addrof) puts(")");
-        if (!addrof) emitDatap(argp);
+        if (isScan) puts("&(");
+        if (VN_IS(subargp, StreamR)) {
+            // This has to be done here because streamR doesn't know what it returns
+            emitStreamR(VN_CAST(subargp, StreamR), nodep);
+        } else {
+            bool isInt = formatAttr.isSigned() || formatAttr.isUnsigned();
+
+            // TODO: some builtin methods return C 'int' (e.g. array.size()).
+            // These won't promote to QData (which is unsigned), so cast here.
+            const char* const castp = isScan || !isInt || subargp->isWide() ? nullptr : "(QData)(";
+            if (castp) puts(castp);
+            iterateConst(subargp);
+            if (castp) puts(")");
+        }
+        if (isScan) puts(")");
         ofp()->indentDec();
     }
 

--- a/src/V3EmitCFunc.h
+++ b/src/V3EmitCFunc.h
@@ -963,11 +963,6 @@ public:
         iterateAndNextConstNull(nodep->lhsp());
         puts(");\n");
     }
-    void visit(AstDisplay* nodep) override {
-        string text = nodep->fmtp()->text();
-        if (nodep->addNewline()) text += "\n";
-        displayNode(nodep, nodep->fmtp(), text, nodep->fmtp()->exprsp(), false);
-    }
     void visit(AstDumpCtl* nodep) override {
         switch (nodep->ctlType()) {
         case VDumpCtlType::FILE:
@@ -1015,6 +1010,11 @@ public:
             const string scope = nodep->scopeDpiName();
             putnbs(nodep, "(vlSymsp->" + protect("__Vscopep_" + scope) + ")");
         }
+    }
+    void visit(AstDisplay* nodep) override {
+        string text = nodep->fmtp()->text();
+        if (nodep->addNewline()) text += "\n";
+        displayNode(nodep, nodep->fmtp(), text, nodep->fmtp()->exprsp(), false);
     }
     void visit(AstSFormat* nodep) override {
         displayNode(nodep, nodep->fmtp(), nodep->fmtp()->text(), nodep->fmtp()->exprsp(), false);

--- a/test_regress/t/t_display_exprformat_args_bad.out
+++ b/test_regress/t/t_display_exprformat_args_bad.out
@@ -1,3 +1,3 @@
 got=42 rest b=%b c=%c d=%d e=%e f=%f g=%g h=%h o=%o p=%p s=%s t=%t u=%u v=%v z=%z
-got=42 rest B=%b C=%c D=%d E=%e F=%f G=%g H=%h O=%o P=%p S=%s T=%t U=%u V=%v Z=%z
+got=42 rest B=%B C=%C D=%D E=%E F=%F G=%G H=%H O=%O P=%P S=%S T=%T U=%U V=%V Z=%Z
 *-* All Finished *-*

--- a/test_regress/t/t_prof_timing.py
+++ b/test_regress/t/t_prof_timing.py
@@ -53,7 +53,7 @@ test.file_grep(test.obj_dir + "/profcfuncs.log", r'Overall summary by')
 #   Appears that GCC 11.4 has a bug whereby it doesn't trace function calls
 #   within coroutines; CLang seems to work correctly.
 #   test.file_grep(test.obj_dir + "/profcfuncs.log", r'VLib + VL_POWSS_QQQ')
-test.file_grep(test.obj_dir + "/profcfuncs.log", r'VLib + VL_WRITEF')
+test.file_grep(test.obj_dir + "/profcfuncs.log", r'VLib + VL_PRINTF')
 test.file_grep(test.obj_dir + "/profcfuncs.log", r'VBlock + t_prof:')
 
 test.passes()

--- a/test_regress/t/t_stream_queue.v
+++ b/test_regress/t/t_stream_queue.v
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: CC0-1.0
 
 `define stop $stop
-`define checks(gotv,expv) do if ((gotv) != (expv)) begin $write("%%Error: %s:%0d:  got='%h' exp='%h'\n", `__FILE__,`__LINE__, (gotv), (expv)); `stop; end while(0);
+`define checks(gotv,expv) do if ((gotv) != (expv)) begin $write("%%Error: %s:%0d:  got='' exp=''\n", `__FILE__,`__LINE__); `stop; end while(0);
 module t;
 
   logic [7:0] i_char;


### PR DESCRIPTION
This is a WIP patch to use a type safe format implementation I mentioned in #7643. If you are happy with this I will do 'scan' as well, and add the missing cases + tests for them.

---

Rewrite string format/scan to use a type safe C++ interface. This will later enable handling 4-state data naturally via WData-like handles. It also uncovered a couple bugs (e.g. #7663) and untested cases.

Note: eventually emit should be able to emit the calls to `apply*` without the templated dispatchers. The `apply` templates are there for now as to not change VL_SFORMAT* and related variadic signatures.
