### PR TITLE
Fix reserved keywords reaching emitter

### DIFF
--- a/src/V3Name.cpp
+++ b/src/V3Name.cpp
@@ -83,6 +83,7 @@ class NameVisitor final : public VNVisitorConst {
         VL_RESTORER(m_modp);
         m_modp = nodep;
         iterateChildrenConst(nodep);
+        rename(nodep, false);
     }
     // Add __PVT__ to names of local signals
     void visit(AstVar* nodep) override {

--- a/test_regress/t/t_module_reserved_keyword.out
+++ b/test_regress/t/t_module_reserved_keyword.out
@@ -1,0 +1,6 @@
+%Warning-SYMRSVDWORD: t/t_module_reserved_keyword.v:7:8: Symbol matches C++ common word: 'interrupt'
+                                                       : ... note: In instance 'interrupt'
+    7 | module interrupt (
+      |        ^~~~~~~~~
+                      ... For warning description see https://verilator.org/warn/SYMRSVDWORD?v=latest
+                      ... Use "/* verilator lint_off SYMRSVDWORD */" and lint_on around source to disable this message.

--- a/test_regress/t/t_module_reserved_keyword.out
+++ b/test_regress/t/t_module_reserved_keyword.out
@@ -4,3 +4,4 @@
       |        ^~~~~~~~~
                       ... For warning description see https://verilator.org/warn/SYMRSVDWORD?v=latest
                       ... Use "/* verilator lint_off SYMRSVDWORD */" and lint_on around source to disable this message.
+%Error: Exiting due to

--- a/test_regress/t/t_module_reserved_keyword.py
+++ b/test_regress/t/t_module_reserved_keyword.py
@@ -9,10 +9,15 @@
 
 import vltest_bootstrap
 
-test.scenarios('simulator')
+test.scenarios("simulator")
 
-test.compile(verilator_flags2=["--cc -Wno-fatal -fno-inline --coverage --top-module interrupt --no-skip-identical"],
-          fails=False,
-          expect_filename=test.golden_filename)
+test.compile(
+    verilator_flags2=[
+        "-fno-inline",
+        "--coverage",
+    ],
+    fails=True,
+    expect_filename=test.golden_filename,
+)
 
 test.passes()

--- a/test_regress/t/t_module_reserved_keyword.py
+++ b/test_regress/t/t_module_reserved_keyword.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2024 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile(verilator_flags2=["--cc -Wno-fatal -fno-inline --coverage --top-module interrupt --no-skip-identical"],
+          fails=False,
+          expect_filename=test.golden_filename)
+
+test.passes()

--- a/test_regress/t/t_module_reserved_keyword.v
+++ b/test_regress/t/t_module_reserved_keyword.v
@@ -1,0 +1,11 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain.
+// SPDX-FileCopyrightText: 2026 Antmicro
+// SPDX-License-Identifier: CC0-1.0
+
+module interrupt (
+    input  logic clk_i = 1,
+    input  logic rst_ni = 1
+);
+endmodule


### PR DESCRIPTION
This PR fixes an issue where modules with reserved names could end up in emitter.

Before that, following error was thrown:
```
%Error: t/t_module_reserved_keyword.v:7:8: Symbol matching C++ common word reserved word reached emitter, should have hit SYMRSVDWORD: 'interrupt'
                                         : ... note: In instance 'interrupt'
    7 | module interrupt (
      |        ^~~~~~~~~
        ... See the manual at https://verilator.org/verilator_doc.html?v=5.049 for more assistance.
%Error: Exiting due to 1 error(s)
```