### PR TITLE
Fix UB in bitshift causing events to be lost

### DIFF
--- a/src/V3SchedTrigger.cpp
+++ b/src/V3SchedTrigger.cpp
@@ -920,7 +920,7 @@ class AwaitBeforeTrigVisitor final : public VNVisitor {
                 const size_t idx = m_trigKit.senItem2TrigIdx(senItemp);
                 if (usedTriggers.find(idx) != usedTriggers.end()) {
                     usedTrigsToUsingTrees[idx / TriggerKit::WORD_SIZE]
-                                         [1 << (idx % TriggerKit::WORD_SIZE)]
+                                         [size_t{1} << (idx % TriggerKit::WORD_SIZE)]
                                              .push_back(shedp);
                 }
             }

--- a/test_regress/t/t_fork_join_none_wait_ev.py
+++ b/test_regress/t/t_fork_join_none_wait_ev.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile(verilator_flags2=['--timing'])
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_fork_join_none_wait_ev.v
+++ b/test_regress/t/t_fork_join_none_wait_ev.v
@@ -1,0 +1,40 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// SPDX-FileCopyrightText: 2026 Antmicro
+// SPDX-License-Identifier: CC0-1.0
+
+// verilog_format: off
+`define stop $stop
+`define checkd(gotv,expv) do if ((gotv) !== (expv)) begin $write("%%Error: %s:%0d:  got=%0d exp=%0d\n", `__FILE__,`__LINE__, (gotv), (expv)); `stop; end while(0);
+// verilog_format: on
+
+module t(
+  input clk
+);
+  int cyc = 0;
+  int cnt = 0;
+  event ev[128];
+
+  always @(posedge clk) begin
+    ++cyc;
+    if (cyc >= 3) begin
+      `checkd(cnt, 128);
+      $finish;
+    end
+  end
+
+  for (genvar i = 0; i < 128; ++i) begin : gen_ev_wait
+    always @(posedge clk) begin
+      if (cyc < 3) begin
+        fork
+          begin
+            ->ev[i];
+            @(ev[i]);
+            cnt++;
+          end
+        join_none
+      end
+    end
+  end
+endmodule


### PR DESCRIPTION
Fix UB when bitshifting, which caused events which modulo 64 was from 30 to 60 to get lost and not fire properly.