### PR TITLE
Fix t_class_param type invalid array access

### DIFF
--- a/src/V3Param.cpp
+++ b/src/V3Param.cpp
@@ -1924,7 +1924,6 @@ class ParamProcessor final {
                     classRefDType->addParamsp(newPinp);
                 }
                 // Update local tracking so future dependent defaults can find it
-                pinsByIndex.resize(paramIdx + 1, nullptr);
                 pinsByIndex[paramIdx] = newPinp;
                 if (!paramsp) paramsp = newPinp;
             }

--- a/test_regress/t/t_class_defaultparams_debug.py
+++ b/test_regress/t/t_class_defaultparams_debug.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2025 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('vlt')
+
+test.top_filename = "t/t_class_defaultparams.v"
+test.compile(verilator_flags2=["--debug"])
+
+test.passes()


### PR DESCRIPTION
Fixes #7653. There was an array resize inside the loop which caused the problem. Removing it fixes the regression.