### PR TITLE
Support for `process::self().srandom()`

### DIFF
--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -4459,7 +4459,7 @@ class WidthVisitor final : public VNVisitor {
             methodCallLValueRecurse(nodep, ichildp->fromp(), access);
         } else if (const AstNodeSel* const ichildp = VN_CAST(childp, NodeSel)) {
             methodCallLValueRecurse(nodep, ichildp->fromp(), access);
-        } else if (VN_IS(childp, LambdaArgRef)) {
+        } else if (VN_IS(childp, LambdaArgRef) || VN_IS(childp, FuncRef)) {
             // NOP
         } else {
             UINFO(1, "    Related node: " << childp);

--- a/test_regress/t/t_process_self_srand.py
+++ b/test_regress/t/t_process_self_srand.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile(v_flags2=["--binary"])
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_process_self_srand.v
+++ b/test_regress/t/t_process_self_srand.v
@@ -1,0 +1,34 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain.
+// SPDX-FileCopyrightText: 2026 Antmicro
+// SPDX-License-Identifier: CC0-1.0
+
+// verilog_format: off
+`ifdef verilator
+ `define optimize_barrier $c("/*IMPURITY*/")
+`else
+ `define optimize_barrier
+`endif
+// verilog_format: on
+
+module t;
+  function process p();
+    `optimize_barrier;
+    return process::self();
+  endfunction
+
+  initial begin
+    int x;
+    int y;
+    process::self().srandom(7);
+    x = $urandom();
+    y = $urandom();
+    if (x == y) $stop;
+    p().srandom(7);
+    y = $urandom();
+    if (x != y) $stop;
+    $write("*-* All Finished *-*\n");
+    $finish;
+  end
+endmodule


### PR DESCRIPTION
Support for calling `func_returning_process().srandom()` this is achieved by just not emitting an error - this is enough to make new test case pass, provide null safety and not introduce any regression.
