### PR TITLE
Optimize VL_SFORMAT when result is string

### DIFF
--- a/include/verilated.cpp
+++ b/include/verilated.cpp
@@ -1888,9 +1888,7 @@ void VL_SFORMAT_NX(int obits, EData* destp, const std::string& format, int argc,
     _vl_string_to_vint(obits, destp, t_output.length(), t_output.c_str());
 }
 
-void VL_SFORMAT_NX(int obits_ignored, std::string& output, const std::string& format, int argc,
-                   ...) VL_MT_SAFE {
-    (void)obits_ignored;  // So VL_SFORMAT_NNX function signatures all match
+void VL_SFORMAT_NX(std::string& output, const std::string& format, int argc, ...) VL_MT_SAFE {
     std::string temp_output;
     va_list ap;
     va_start(ap, argc);

--- a/include/verilated_funcs.h
+++ b/include/verilated_funcs.h
@@ -3668,7 +3668,7 @@ extern void VL_WRITEMEM_N(bool hex, int bits, QData depth, int array_lsb,
                           QData end) VL_MT_SAFE;
 extern IData VL_SSCANF_INNX(int lbits, const std::string& ld, const std::string& format, int argc,
                             ...) VL_MT_SAFE;
-extern void VL_SFORMAT_NX(int obits_ignored, std::string& output, const std::string& format,
+extern void VL_SFORMAT_NX(std::string& output, const std::string& format,
                           int argc, ...) VL_MT_SAFE;
 extern std::string VL_SFORMATF_N_NX(const std::string& format, int argc, ...) VL_MT_SAFE;
 extern void VL_TIMEFORMAT_IINI(bool hasUnits, int units, bool hasPrecision, int precision,

--- a/include/verilated_funcs.h
+++ b/include/verilated_funcs.h
@@ -3668,8 +3668,8 @@ extern void VL_WRITEMEM_N(bool hex, int bits, QData depth, int array_lsb,
                           QData end) VL_MT_SAFE;
 extern IData VL_SSCANF_INNX(int lbits, const std::string& ld, const std::string& format, int argc,
                             ...) VL_MT_SAFE;
-extern void VL_SFORMAT_NX(std::string& output, const std::string& format,
-                          int argc, ...) VL_MT_SAFE;
+extern void VL_SFORMAT_NX(std::string& output, const std::string& format, int argc,
+                          ...) VL_MT_SAFE;
 extern std::string VL_SFORMATF_N_NX(const std::string& format, int argc, ...) VL_MT_SAFE;
 extern void VL_TIMEFORMAT_IINI(bool hasUnits, int units, bool hasPrecision, int precision,
                                bool hasSuffix, const std::string& suffix, bool hasWidth, int width,

--- a/src/V3EmitCFunc.cpp
+++ b/src/V3EmitCFunc.cpp
@@ -224,8 +224,10 @@ bool EmitCFunc::displayEmitHeader(AstNode* nodep) {
     } else if (const AstSFormat* const dispp = VN_CAST(nodep, SFormat)) {
         isStmt = true;
         puts("VL_SFORMAT_NX(");
-        puts(cvtToStr(dispp->lhsp()->widthMin()));
-        putbs(",");
+        if (!dispp->lhsp()->dtypep()->isString()) {
+            puts(cvtToStr(dispp->lhsp()->widthMin()));
+            putbs(",");
+        }
         iterateConst(dispp->lhsp());
         emitDatap(dispp->lhsp());
         putbs(",");


### PR DESCRIPTION
Omit unused bit width parameter. Emit rule is simple enough to change and the unused parameter just bloats code size.
