### PR TITLE
Add --ignore-initial-multidriven

### DIFF
--- a/bin/verilator
+++ b/bin/verilator
@@ -439,6 +439,7 @@ detailed descriptions of these arguments.
     --hierarchical-threads <threads>  Number of threads for hierarchical scheduling
      -I<dir>                    Directory to search for includes
     --if-depth <value>          Tune IFDEPTH warning
+    --ignore-initial-multidriven  Disable MULTIDRIVEN for initial+always pairs
      +incdir+<dir>              Directory to search for includes
     --inline-cfuncs <value>     Inline CFuncs with <=value nodes (0=off)
     --inline-cfuncs-product <value>  Inline CFuncs if size*calls <= value

--- a/docs/guide/exe_verilator.rst
+++ b/docs/guide/exe_verilator.rst
@@ -935,6 +935,13 @@ Summary:
    Rarely needed. Set the depth at which the IFDEPTH warning will fire,
    defaults to 0, which disables this warning.
 
+.. option:: --ignore-initial-multidriven
+
+   Disables the :option:`MULTIDRIVEN` warning for variables that are
+   assigned by both an ``initial`` block and a single ``always_ff`` or
+   ``always_comb`` block. Multiple ``always`` drivers of the same variable
+   still warn.
+
 .. option:: +incdir+<dir>
 
    See :vlopt:`-y`. Unlike with :vlopt:`-y`, multiple directories may be

--- a/src/V3Options.cpp
+++ b/src/V3Options.cpp
@@ -1537,6 +1537,7 @@ void V3Options::parseOptsList(FileLine* fl, const string& optdir, int argc,
     }).notForRerun();
     DECL_OPTION("-if-depth", Set, &m_ifDepth);
     DECL_OPTION("-ignc", OnOff, &m_ignc).undocumented();
+    DECL_OPTION("-ignore-initial-multidriven", OnOff, &m_ignoreInitialMultidriven);
     DECL_OPTION("-inline-cfuncs", Set, &m_inlineCFuncs);
     DECL_OPTION("-inline-cfuncs-product", Set, &m_inlineCFuncsProduct);
     DECL_OPTION("-inline-mult", Set, &m_inlineMult);

--- a/src/V3Options.h
+++ b/src/V3Options.h
@@ -257,6 +257,7 @@ private:
     bool m_fourstate = false;       // main switch: --fourstate
     bool m_hierarchical = false;    // main switch: --hierarchical
     bool m_ignc = false;            // main switch: --ignc
+    bool m_ignoreInitialMultidriven = false;  // main switch: --ignore-initial-multidriven
     bool m_jsonOnly = false;        // main switch: --json-only
     bool m_lintOnly = false;        // main switch: --lint-only
     bool m_gmake = false;           // main switch: --make gmake
@@ -598,6 +599,7 @@ public:
     bool anyPublicFlat() const { return m_publicParams || m_publicFlatRW || m_publicDepth; }
     bool lintOnly() const VL_MT_SAFE { return m_lintOnly; }
     bool ignc() const { return m_ignc; }
+    bool ignoreInitialMultidriven() const { return m_ignoreInitialMultidriven; }
     bool quietBuild() const VL_MT_SAFE { return m_quietBuild; }
     bool quietExit() const VL_MT_SAFE { return m_quietExit; }
     bool quietStats() const VL_MT_SAFE { return m_quietStats; }

--- a/src/V3Undriven.cpp
+++ b/src/V3Undriven.cpp
@@ -527,10 +527,12 @@ class UndrivenVisitor final : public VNVisitorConst {
                                                        : entryp->callNodep();
                 const bool sameFileLine
                     = otherVarRefp && nodep->fileline() == otherVarRefp->fileline();
+                const bool ignoreInitialMD = v3Global.opt.ignoreInitialMultidriven()
+                                             && (m_inInitial || m_inInitialStatic);
                 if (entryp->isDrivenWhole() && !m_inBBox && !VN_IS(nodep, VarXRef)
                     && !VN_IS(nodep->dtypep()->skipRefp(), UnpackArrayDType) && !sameFileLine
                     && !entryp->isUnderGen() && otherWritep && !entryp->isFtaskDriven()
-                    && !ftaskDef
+                    && !ftaskDef && !ignoreInitialMD
                     && !nodep->varp()->fileline()->warnIsOff(V3ErrorCode::MULTIDRIVEN)) {
                     const bool otherWriteIsStaticInit
                         = nodep->varp()->hasUserInit() && otherWritep == entryp->initStaticp();
@@ -585,7 +587,11 @@ class UndrivenVisitor final : public VNVisitorConst {
                 }
                 if (!m_inInitialSetup || nodep->varp()->hasUserInit()) {
                     // Else don't count default initialization as a driver to a net/variable
-                    entryp->drivenWhole(nodep, ftaskDef);
+                    if (ignoreInitialMD) {
+                        entryp->drivenWhole(static_cast<const AstNode*>(nodep));
+                    } else {
+                        entryp->drivenWhole(nodep, ftaskDef);
+                    }
                 }
                 if (m_alwaysCombp && entryp->isDrivenAlwaysCombWhole()
                     && m_alwaysCombp != entryp->getAlwCombp()

--- a/test_regress/t/t_lint_always_ff_multidriven_bad.v
+++ b/test_regress/t/t_lint_always_ff_multidriven_bad.v
@@ -11,7 +11,7 @@ module t(input wire clk);
   initial a = 1'b0;
 
   always_ff @(posedge a) begin
-    a <= 1'b1;  // <--- Warning
+    a <= 1'b1;  // <--- Warning (suppressed with --ignore-initial-multidriven)
   end
 
   logic b;
@@ -20,7 +20,7 @@ module t(input wire clk);
     b <= 1'b1;
   end
 
-  initial b = 1'b0;  // <--- Warning
+  initial b = 1'b0;  // <--- Warning (suppressed with --ignore-initial-multidriven)
 
   reg [1:0][1:0] q;
 

--- a/test_regress/t/t_lint_always_ff_multidriven_ignore_initial_bad.out
+++ b/test_regress/t/t_lint_always_ff_multidriven_ignore_initial_bad.out
@@ -1,0 +1,11 @@
+%Warning-MULTIDRIVEN: t/t_lint_always_ff_multidriven_bad.v:34:7: Variable written to in always_ff also written by other process (IEEE 1800-2023 9.2.2.4): 'q'
+                                                               : ... note: In instance 't'
+                      t/t_lint_always_ff_multidriven_bad.v:34:7: 
+   34 |       q[i][1] <= a;  
+      |       ^
+                      t/t_lint_always_ff_multidriven_bad.v:29:7: ... Location of other write
+   29 |       q[i][0] <= a;  
+      |       ^
+                      ... For warning description see https://verilator.org/warn/MULTIDRIVEN?v=latest
+                      ... Use "/* verilator lint_off MULTIDRIVEN */" and lint_on around source to disable this message.
+%Error: Exiting due to

--- a/test_regress/t/t_lint_always_ff_multidriven_ignore_initial_bad.py
+++ b/test_regress/t/t_lint_always_ff_multidriven_ignore_initial_bad.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('linter')
+test.top_filename = "t/t_lint_always_ff_multidriven_bad.v"
+
+test.lint(fails=True,
+          verilator_flags2=["--ignore-initial-multidriven"],
+          expect_filename=test.golden_filename)
+
+test.passes()


### PR DESCRIPTION
Re: #7621 agreed that **9.2.2.2 Combinational logic always_comb procedure** does say:
`The variables assigned on the left-hand side of assignments shall not be assigned by any other process.`

But the LRM says a lot of things.  I have no idea what the point of this prohibition is when applied to initial procedures.  There is no simulator (read: scheduler) ambiguity since `initial` has to run before `always*`.  And there is no synthesizer ambiguity because (at the risk of painting with too broad a brush) ASIC designs don't want initial procedures *or* variable initializers and FPGA designs use either as `INIT` / bitstream load time initial values (distinct from functional resets).

I'm curious @MrCookieeeee what motivated the PR since (again maybe this is a failure of imagination) I'd think one would either want to completely prohibit `initial` blocks or one would be fine with `initial` plus `always_ff`.

In any case, #7621 does seem to do what the LRM says, but I'd like to add a switch to be able to go back to the old way.  Xcelium already has such a flag (no clue about other simulators).  And yes, all the `initial` code can be refactored to variable inializers.  But to do so one would need to create a bunch of initializer functions, and those are also procedural blocks.  I'm not sure what 9.2.2.2 thinks about those.