### PR TITLE
Fix s_eventually in parameterised interfaces

### DIFF
--- a/src/V3Assert.cpp
+++ b/src/V3Assert.cpp
@@ -1007,10 +1007,12 @@ class AssertVisitor final : public VNVisitor {
         VL_RESTORER(m_modPastNum);
         VL_RESTORER(m_modStrobeNum);
         VL_RESTORER(m_modExpr2Sen2DelayedAlwaysp);
+        VL_RESTORER(m_finalp);
         m_modp = nodep;
         m_modPastNum = 0;
         m_modStrobeNum = 0;
         m_modExpr2Sen2DelayedAlwaysp.clear();
+        m_finalp = nullptr;
         iterateChildren(nodep);
     }
     void visit(AstNodeProcedure* nodep) override {

--- a/test_regress/t/t_property_s_eventually_iface_param.py
+++ b/test_regress/t/t_property_s_eventually_iface_param.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile(timing_loop=True, verilator_flags2=['--timing'])
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_property_s_eventually_iface_param.v
+++ b/test_regress/t/t_property_s_eventually_iface_param.v
@@ -1,0 +1,36 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain.
+// SPDX-FileCopyrightText: 2026 Wilson Snyder
+// SPDX-License-Identifier: CC0-1.0
+
+interface iface_if #(parameter int W = 8) (input bit clk);
+  logic [W-1:0] sig = 0;
+  int passed = 0;
+  assert property (@(posedge clk) s_eventually (sig == 1)) passed++;
+endinterface
+
+module t;
+  bit clk = 0;
+  initial forever #1 clk = ~clk;
+  int cyc = 0;
+
+  // Two distinct specializations: V3Param clones the interface into two
+  // modules, each with its own s_eventually tracking. The generated final
+  // block must stay per-module.
+  iface_if #(.W(4)) a(.clk(clk));
+  iface_if #(.W(8)) b(.clk(clk));
+
+  always @(posedge clk) begin
+    ++cyc;
+    if (cyc == 2) begin
+      a.sig <= 1;
+      b.sig <= 1;
+    end
+    if (cyc == 5) begin
+      if (a.passed == 0 || b.passed == 0) $stop;
+      $write("*-* All Finished *-*\n");
+      $finish;
+    end
+  end
+endmodule


### PR DESCRIPTION
m_finalp (the s_eventually end-of-sim AstFinal) wasn't reset in visit(AstNodeModule), unlike the rest of the per-module state. A parameterised interface specialised into two modules then had the second module's final logic appended to the first's, referencing a variable from the wrong module causing V3Scope to abort. Reset it per module.

PR prepared with Claude Opus 4.8