### PR TITLE
Fix dpi export pointers (#7742)

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -325,3 +325,4 @@ Yogish Sekhar
 24bit-xjkp
 Zubin Jain
 Muzaffer Kal
+Yilin Li

--- a/src/V3EmitCFunc.cpp
+++ b/src/V3EmitCFunc.cpp
@@ -463,9 +463,9 @@ void EmitCFunc::emitVarReset(const string& prefix, AstVar* varp, bool constructi
     // 'constructing' indicates that the object was just constructed, so if it is a string or
     // something that starts off clear already, no need to clear it again
     AstNodeDType* const dtypep = varp->dtypep()->skipRefp();
-    const string vlSelf = m_cfuncp && m_cfuncp->isStatic() ? 
-                          "vlSymsp->TOP__" + m_modp->name() + "." :
-                          VSelfPointerText::replaceThis(m_useSelfForThis, "this->");
+    const string vlSelf = m_cfuncp && m_cfuncp->isStatic()
+                              ? "vlSymsp->TOP__" + m_modp->name() + "."
+                              : VSelfPointerText::replaceThis(m_useSelfForThis, "this->");
     const string varNameProtected
         = ((VN_IS(m_modp, Class) || varp->isFuncLocal()) || !prefix.empty())
               ? varp->nameProtect()

--- a/src/V3EmitCFunc.cpp
+++ b/src/V3EmitCFunc.cpp
@@ -463,7 +463,9 @@ void EmitCFunc::emitVarReset(const string& prefix, AstVar* varp, bool constructi
     // 'constructing' indicates that the object was just constructed, so if it is a string or
     // something that starts off clear already, no need to clear it again
     AstNodeDType* const dtypep = varp->dtypep()->skipRefp();
-    const string vlSelf = VSelfPointerText::replaceThis(m_useSelfForThis, "this->");
+    const string vlSelf = m_cfuncp && m_cfuncp->isStatic() ? 
+                          "vlSymsp->TOP__" + m_modp->name() + "." :
+                          VSelfPointerText::replaceThis(m_useSelfForThis, "this->");
     const string varNameProtected
         = ((VN_IS(m_modp, Class) || varp->isFuncLocal()) || !prefix.empty())
               ? varp->nameProtect()

--- a/src/V3EmitCFunc.cpp
+++ b/src/V3EmitCFunc.cpp
@@ -463,9 +463,7 @@ void EmitCFunc::emitVarReset(const string& prefix, AstVar* varp, bool constructi
     // 'constructing' indicates that the object was just constructed, so if it is a string or
     // something that starts off clear already, no need to clear it again
     AstNodeDType* const dtypep = varp->dtypep()->skipRefp();
-    const string vlSelf = m_cfuncp && m_cfuncp->isStatic()
-                              ? "vlSymsp->TOP__" + m_modp->name() + "."
-                              : VSelfPointerText::replaceThis(m_useSelfForThis, "this->");
+    const string vlSelf = VSelfPointerText::replaceThis(m_useSelfForThis, "this->");
     const string varNameProtected
         = ((VN_IS(m_modp, Class) || varp->isFuncLocal()) || !prefix.empty())
               ? varp->nameProtect()

--- a/src/V3EmitCFunc.h
+++ b/src/V3EmitCFunc.h
@@ -573,8 +573,14 @@ public:
                      + "\", " + std::to_string(nodep->fileline()->lineno()) + ")->"),
                     memberVarp, resetp->constructing());
             } else {
-                AstVar* const varp = VN_AS(fromp, NodeVarRef)->varp();
-                emitVarReset("", varp, resetp->constructing());
+                AstNodeVarRef* const fromVarRefp = VN_AS(fromp, NodeVarRef);
+                AstVar* const varp = fromVarRefp->varp();
+                const string prefix
+                    = fromVarRefp->selfPointer().isEmpty()
+                          ? ""
+                          : dereferenceString(
+                                VN_AS(fromp, NodeVarRef)->selfPointerProtect(m_useSelfForThis));
+                emitVarReset(prefix, varp, resetp->constructing());
             }
             return;
         }

--- a/test_regress/t/t_dpi_export_unpack.py
+++ b/test_regress/t/t_dpi_export_unpack.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test for dpi unpack array
+#
+# author: Yilin Li
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile(verilator_flags2=["--binary"])
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_dpi_export_unpack.py
+++ b/test_regress/t/t_dpi_export_unpack.py
@@ -1,7 +1,13 @@
 #!/usr/bin/env python3
-# DESCRIPTION: Verilator: Verilog Test for dpi unpack array
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
 #
-# author: Yilin Li
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2024 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+# 9-Jun-2026: Modifications for this test contributed by Yilin Li.
 
 import vltest_bootstrap
 

--- a/test_regress/t/t_dpi_export_unpack.v
+++ b/test_regress/t/t_dpi_export_unpack.v
@@ -23,7 +23,7 @@ task loadHEX;
   readHEX(file, stimuli);
 endtask
 
-module tb();
+module tb ();
 
   logic [7:0] result[32'h00010000];
   initial begin

--- a/test_regress/t/t_dpi_export_unpack.v
+++ b/test_regress/t/t_dpi_export_unpack.v
@@ -1,0 +1,23 @@
+export "DPI-C" task readHEX;
+export "DPI-C" task loadHEX;
+
+task readHEX;
+  input string file;
+  output logic [7:0] stimuli[32'h00010000];
+  $readmemh(file, stimuli);
+endtask
+
+task loadHEX;
+  input string file;
+  logic [7:0] stimuli[32'h00010000];
+  readHEX(file, stimuli);
+endtask
+
+module tb();
+
+  logic [7:0] result[32'h00010000];
+  initial begin
+    loadHEX("dummy");
+  end
+
+endmodule

--- a/test_regress/t/t_dpi_export_unpack.v
+++ b/test_regress/t/t_dpi_export_unpack.v
@@ -1,3 +1,13 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This program is free software; you can redistribute it and/or modify it
+// under the terms of either the GNU Lesser General Public License Version 3
+// or the Perl Artistic License Version 2.0.
+// SPDX-FileCopyrightText: 2020 Wilson Snyder
+// SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+// 9-Jun-2026: Modifications for this test contributed by Yilin Li.
+
 export "DPI-C" task readHEX;
 export "DPI-C" task loadHEX;
 


### PR DESCRIPTION
This PR fixes bug #7742, which causes the verilator to generate incorrect pointers ("this->" rather than "vlSymsp->TOP__${m_modp->name}"). 

As far as I know, this bug does not exist in version v5.040. It is a newly introduced bug after that.

The patch was made by modifying a tiny little bit of code. 