### PR TITLE
Fix data race on V3TSP edge IDs between parallel sorts (#7194)

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -325,3 +325,4 @@ Yogish Sekhar
 24bit-xjkp
 Zubin Jain
 Muzaffer Kal
+Shashvat Prabhu

--- a/src/V3TSP.cpp
+++ b/src/V3TSP.cpp
@@ -41,8 +41,6 @@ VL_DEFINE_DEBUG_FUNCTIONS;
 // Support classes
 
 namespace V3TSP {
-static uint32_t s_edgeIdNext = 0;
-
 static void selfTestStates();
 static void selfTestString();
 }  // namespace V3TSP
@@ -77,6 +75,7 @@ public:
 
     // MEMBERS
     std::unordered_map<T_Key, Vertex*> m_vertices;  // T_Key to Vertex lookup map
+    uint32_t m_edgeIdNext = 0;  // Next edge ID; IDs need only be unique within this graph
 
     // CONSTRUCTORS
     TspGraphTmpl()
@@ -105,7 +104,7 @@ public:
         // The only time we may create duplicate edges is when
         // combining the MST with the perfect-matched pairs,
         // and in that case, we want to permit duplicate edges.
-        const uint32_t edgeId = ++V3TSP::s_edgeIdNext;
+        const uint32_t edgeId = ++m_edgeIdNext;
 
         // We want to be able to compare edges quickly for a total
         // ordering, so pre-compute a sorting key and store it in


### PR DESCRIPTION
Fixes #7194

`TspGraphTmpl::addEdge()` incremented the file-scope `static uint32_t s_edgeIdNext` non-atomically. When multiple `V3TSP::tspSort()` calls ran concurrently on the verilation thread pool (--threads > 1 with -j > 1, via the old V3VariableOrder path), the racy increment could produce duplicate edge IDs within a single graph. The Euler tour marks edges by ID, so a duplicate makes two edges appear as one and the tour gets stuck: "Internal Error: V3TSP.cpp: No unmarked edges found in tour".

This makes the edge ID counter a per-graph member instead. Edge IDs are only ever compared within a single graph (Euler tour marked set, combineGraph dedup, edge sort tie-break), so per-graph uniqueness is sufficient. Relative ID order within a graph is unchanged (insertion order), so results are identical. This removes the shared mutable state entirely, making tspSort match its VL_MT_SAFE annotation.

Note: the original crash path was already removed by 57fa98e52 (#7610), which dropped the TSP sort from V3VariableOrder, so the crash is no longer reachable from the command line on master. This fixes the remaining latent race in V3TSP itself for any future concurrent caller.

Verified by temporarily adding a concurrent stress block to V3TSP::selfTest() (8 threads x 500 tspSort iterations): unfixed code hit the exact "No unmarked edges found in tour" fatal on every run; with this change, all runs complete with results identical to the single-threaded output. The stress code is not part of this PR. t_a3_selftest, t_a3_selftest_thread (vltmt) and t_variable_order_mtask pass.