### PR TITLE
Fix DFG misoptimizing bound checks

### DIFF
--- a/src/V3Dfg.cpp
+++ b/src/V3Dfg.cpp
@@ -620,6 +620,12 @@ DfgVertex::DfgVertex(DfgGraph& dfg, VDfgType type, FileLine* flp, const DfgDataT
     dfg.addVertex(*this);
 }
 
+bool DfgVertex::unsafe() const {
+    if (is<DfgMux>()) return true;
+    if (is<DfgArraySel>()) return !as<DfgArraySel>()->bitp()->is<DfgConst>();
+    return false;
+}
+
 void DfgVertex::typeCheck(const DfgGraph& dfg) const {
 
 #define CHECK(cond, msg) \

--- a/src/V3Dfg.h
+++ b/src/V3Dfg.h
@@ -195,6 +195,8 @@ public:
         UASSERT_OBJ(m_dtype.isPacked(), this, "Non packed vertex has no 'width'");
         return m_dtype.size();
     }
+    // Has terminating side-effect
+    bool unsafe() const;
 
     // Type check vertex (for debugging)
     void typeCheck(const DfgGraph& dfg) const;

--- a/src/V3DfgPeephole.cpp
+++ b/src/V3DfgPeephole.cpp
@@ -2269,7 +2269,7 @@ class V3DfgPeephole final : public DfgVisitor {
     }
 
     void visit(DfgLogAnd* const vtxp) override {
-        if (binary(vtxp)) return;
+        if (binary(vtxp) || vtxp->rhsp()->unsafe()) return;
 
         DfgVertex* const lhsp = vtxp->lhsp();
         DfgVertex* const rhsp = vtxp->rhsp();
@@ -2287,11 +2287,11 @@ class V3DfgPeephole final : public DfgVisitor {
     }
 
     void visit(DfgLogIf* const vtxp) override {
-        if (binary(vtxp)) return;
+        if (binary(vtxp) || vtxp->rhsp()->unsafe()) return;
     }
 
     void visit(DfgLogOr* const vtxp) override {
-        if (binary(vtxp)) return;
+        if (binary(vtxp) || vtxp->rhsp()->unsafe()) return;
 
         DfgVertex* const lhsp = vtxp->lhsp();
         DfgVertex* const rhsp = vtxp->rhsp();
@@ -2890,13 +2890,13 @@ class V3DfgPeephole final : public DfgVisitor {
         }
 
         if (vtxp->dtype() == m_bitDType) {
-            if (isSame(condp, thenp)) {  // a ? a : b becomes a | b
+            if (isSame(condp, thenp) && !elsep->unsafe()) {  // a ? a : b becomes a | b
                 APPLYING(REPLACE_COND_WITH_THEN_BRANCH_COND) {
                     replace(make<DfgOr>(vtxp, condp, elsep));
                     return;
                 }
             }
-            if (isSame(condp, elsep)) {  // a ? b : a becomes a & b
+            if (isSame(condp, elsep) && !thenp->unsafe()) {  // a ? b : a becomes a & b
                 APPLYING(REPLACE_COND_WITH_ELSE_BRANCH_COND) {
                     replace(make<DfgAnd>(vtxp, condp, thenp));
                     return;
@@ -2905,28 +2905,28 @@ class V3DfgPeephole final : public DfgVisitor {
         }
 
         if (vtxp->width() <= VL_QUADSIZE) {
-            if (isZero(thenp)) {  // a ? 0 : b becomes ~a & b
+            if (isZero(thenp) && !elsep->unsafe()) {  // a ? 0 : b becomes ~a & b
                 APPLYING(REPLACE_COND_WITH_THEN_BRANCH_ZERO) {
                     DfgVertex* const maskp = replicate(vtxp, make<DfgNot>(condp, condp));
                     replace(make<DfgAnd>(vtxp, maskp, elsep));
                     return;
                 }
             }
-            if (isOnes(thenp)) {  // a ? 1 : b becomes a | b
+            if (isOnes(thenp) && !elsep->unsafe()) {  // a ? 1 : b becomes a | b
                 APPLYING(REPLACE_COND_WITH_THEN_BRANCH_ONES) {
                     DfgVertex* const maskp = replicate(vtxp, condp);
                     replace(make<DfgOr>(vtxp, maskp, elsep));
                     return;
                 }
             }
-            if (isZero(elsep)) {  // a ? b : 0 becomes a & b
+            if (isZero(elsep) && !thenp->unsafe()) {  // a ? b : 0 becomes a & b
                 APPLYING(REPLACE_COND_WITH_ELSE_BRANCH_ZERO) {
                     DfgVertex* const maskp = replicate(vtxp, condp);
                     replace(make<DfgAnd>(vtxp, maskp, thenp));
                     return;
                 }
             }
-            if (isOnes(elsep)) {  // a ? b : 1 becomes ~a | b
+            if (isOnes(elsep) && !thenp->unsafe()) {  // a ? b : 1 becomes ~a | b
                 APPLYING(REPLACE_COND_WITH_ELSE_BRANCH_ONES) {
                     DfgVertex* const maskp = replicate(vtxp, make<DfgNot>(condp, condp));
                     replace(make<DfgOr>(vtxp, maskp, thenp));
@@ -2935,7 +2935,8 @@ class V3DfgPeephole final : public DfgVisitor {
             }
 
             if (DfgOr* const tOrp = thenp->cast<DfgOr>()) {
-                if (isSame(tOrp->lhsp(), elsep)) {  // a ? b | c : b becomes b | (a & c)
+                if (isSame(tOrp->lhsp(), elsep)
+                    && !tOrp->rhsp()->unsafe()) {  // a ? b | c : b becomes b | (a & c)
                     APPLYING(REPLACE_COND_THEN_OR_LHS) {
                         DfgVertex* const maskp = replicate(vtxp, condp);
                         DfgAnd* const andp = make<DfgAnd>(vtxp, maskp, tOrp->rhsp());
@@ -2943,7 +2944,8 @@ class V3DfgPeephole final : public DfgVisitor {
                         return;
                     }
                 }
-                if (isSame(tOrp->rhsp(), elsep)) {  // a ? b | c : c becomes c | (a & b)
+                if (isSame(tOrp->rhsp(), elsep)
+                    && !tOrp->lhsp()->unsafe()) {  // a ? b | c : c becomes c | (a & b)
                     APPLYING(REPLACE_COND_THEN_OR_RHS) {
                         DfgVertex* const maskp = replicate(vtxp, condp);
                         DfgAnd* const andp = make<DfgAnd>(vtxp, maskp, tOrp->lhsp());

--- a/test_regress/t/t_dfg_oob_array_access.py
+++ b/test_regress/t/t_dfg_oob_array_access.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile(verilator_flags2=["-runtime-debug"])
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_dfg_oob_array_access.v
+++ b/test_regress/t/t_dfg_oob_array_access.v
@@ -1,0 +1,27 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain.
+// SPDX-FileCopyrightText: 2026 Antmicro
+// SPDX-License-Identifier: CC0-1.0
+
+
+module t (
+    input clk
+);
+  wire mem_wire;
+  bit [15:0] idx = 65535;
+  bit mem_reg[0:34000];
+  assign mem_wire = mem_reg[idx];
+
+  always @(posedge clk) begin
+    if (idx < 65533) begin
+      $display("oob_val %d", mem_wire);
+      $write("*-* All Finished *-*\n");
+      $finish;
+    end
+    else begin
+      idx <= idx - 1;
+      mem_reg[idx] <= 0;
+    end
+  end
+endmodule


### PR DESCRIPTION
This PR fixes DFG misoptimizing array bound checks resulting in out-of-bound accesses in generated c++ code. There are at least two optimization paths that lead to this kind of misoptimization in `V3DfgPeephole` (replacing `COND` inserted by `V3Unknown` with unconditional memory access):
- Normal verilation: `V3Unknown` inserts `COND` around `AstArraySel` -> `V3Const` replaces `COND` with `LOGAND` -> `V3DfgPeephole` (`REPLACE_LOGAND_WITH_AND`) replaces `LOGAND` with `AND`
- Verilation with `-fno-const-before-dfg`: `V3Unknown` inserts `COND` around `AstArraySel` -> `V3DfgPeephole` (`REPLACE_COND_WITH_ELSE_BRANCH_ZERO`) replaces `COND` with `AND`

This issue can be reproduced with the code reported in https://github.com/verilator/verilator/issues/2984#issuecomment-4562855561

This PR fixes this by marking `AstArraySel`s that are placed inside bound checks in `V3Unknown` with `setRuntimeBoundChecked(true)` and later skipping transformation of those nodes to DFG in `V3DfgSynthesize`, thus preventing invalid optimizations on those nodes by DFG. I intially thought about marking `AstArraySel`s as impure when they are bound checked instead, but this approach has some issues:
- impure gives us more guarantees than we need here, possibly restricting other optimizations. We only care about keeping the array access conditional, not about the amount of times its done or its order (e.g we are fine with optimizing a single access away or changing it into N same accesses or reordering it)
- marking `AstArraySel` as impure was causing verilation errors in `t_queue_unknown_sel` test inside impure branches in `V3Case`. Even after fixing this test I was still able to find other failing cases not covered by existing tests. It's possible that other cases may also fail on other stages with `isPure()` checks with this approach, but are just not covered by the tests. I suppose that nothing really expects that `AstArraySel` might be impure.

Currently I don't have a good idea for a reliable regression test. Making test that is expected to segfault on invalid memory access might fail if e.g. given platform will allocate bigger address space or change its layout for verilated binary's process. Using sanitizer instead will limit amount of platforms this test can be run on. Because the invalid memory access happens on an array in `VlUnpacked` and this is the last field in it the compiler/sanitizer treats it as a flexible array and skips bound checks on it unless `-fstrict-flex-arrays` is used (as noted in https://github.com/verilator/verilator/issues/2984#issuecomment-4562855561). This flag is relatively new and e.g. the most recent g++ available in debian 12 repositiories doesn't support it.

@gezalore  I had to change `m_foundUnhandled` condition in `AstToDfgConverter::unhandled()`. I believe it was inverted, but could you please confirm that this is a valid change?