### PR TITLE
Fix No-scope internal error on virtual interface method calls

### DIFF
--- a/src/V3Task.cpp
+++ b/src/V3Task.cpp
@@ -1624,6 +1624,7 @@ class TaskVisitor final : public VNVisitor {
         // Create cloned statements
         AstNode* beginp;
         AstCNew* cnewp = nullptr;
+        // getScope() is safe here: TaskStateVisitor stamped all FTask scopes before this pass.
         const bool virtualIfaceCall
             = TaskStateVisitor::isVirtualIfaceMethodCall(nodep)
               && TaskStateVisitor::isIfaceFTaskScope(m_statep->getScope(nodep->taskp()));

--- a/src/V3Task.cpp
+++ b/src/V3Task.cpp
@@ -246,9 +246,9 @@ private:
         UASSERT_OBJ(nodep->taskp(), nodep, "Unlinked task");
         TaskFTaskVertex* const taskVtxp = getFTaskVertex(nodep->taskp());
         new TaskEdge{&m_callGraph, m_curVxp, taskVtxp};
-        if (isVirtualIfaceMethodCall(nodep) && isIfaceFTaskScope(getScope(nodep->taskp()))) {
-            taskVtxp->needsNonInlineCFunc(true);
-        }
+        // Virtual-interface method calls dispatch through a runtime handle and
+        // must not be inlined.
+        if (isVirtualIfaceMethodCall(nodep)) taskVtxp->needsNonInlineCFunc(true);
         // Do we have to disable inlining the function?
         const V3TaskConnects tconnects = V3Task::taskConnects(nodep, nodep->taskp()->stmtsp());
         if (!taskVtxp->noInline()) {  // Else short-circuit below

--- a/test_regress/t/t_interface_virtual_func_module_call.py
+++ b/test_regress/t/t_interface_virtual_func_module_call.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile(verilator_flags2=["--binary"])
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_interface_virtual_func_module_call.v
+++ b/test_regress/t/t_interface_virtual_func_module_call.v
@@ -1,0 +1,24 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain.
+// SPDX-FileCopyrightText: 2026 PlanV GmbH
+// SPDX-License-Identifier: CC0-1.0
+
+interface iface;
+  int cnt = 0;
+  function void bump();
+    cnt++;
+  endfunction
+endinterface
+
+module t;
+  iface theIf ();
+  virtual iface vif;
+  initial begin
+    vif = theIf;
+    vif.bump();
+    if (theIf.cnt !== 1) $stop;
+    $write("*-* All Finished *-*\n");
+    $finish;
+  end
+endmodule


### PR DESCRIPTION
## Summary

This patch fixes an internal error (`No scope for function`) emitted when a virtual interface handle method is called from a context that V3Task processes before the target interface's scope is visited. 

## Reproducer

```systemverilog
interface iface;
  int cnt = 0;
  function void bump();
    cnt++;
  endfunction
endinterface

module t;
  iface theIf ();
  virtual iface vif;
  initial begin
    vif = theIf;
    vif.bump();
    if (theIf.cnt !== 1) $stop;
  end
endmodule
```

On master:

```
%Error: Internal Error: ...:V3Task.cpp:138: No scope for function
```

## Changes

- `TaskStateVisitor::visit(AstNodeFTaskRef)` (call-graph build): drop the `isIfaceFTaskScope(getScope(nodep->taskp()))` guard and request a non-inlined CFunc on `isVirtualIfaceMethodCall(nodep)` alone. That helper already requires the call to dispatch through a virtual `AstIfaceRefDType`, so the resolved task is necessarily an interface method and the removed scope check was always true. It was also crash-prone here: this pass stamps each FTask's scope (`user3p`) as scopes are iterated, so `getScope()` could run before the callee's scope was visited and hit the `No scope for function` assertion.

## Test

- Added `test_regress/t/t_interface_virtual_func_module_call.{v,py}` — virtual interface method call from a module initial; triggers the internal error on master, passes after the fix.

---
Developed by PlanV GmbH, assisted with Claude Code.

Reviewed by YilouWang.
