### PR TITLE
Fix out-of-bounds read value for 2-state types

### DIFF
--- a/src/V3Unknown.cpp
+++ b/src/V3Unknown.cpp
@@ -546,7 +546,11 @@ class UnknownVisitor final : public VNVisitor {
                 } else if (nodeDtp->isString()) {
                     xnum = V3Number{nodep, V3Number::String{}, ""};
                 } else {
-                    xnum.setAllBitsX();
+                    if (nodeDtp->isFourstate()) {
+                        xnum.setAllBitsX();
+                    } else {
+                        xnum.setAllBits0();
+                    }
                 }
                 AstNode* const newp = new AstCond{nodep->fileline(), condp, nodep,
                                                   new AstConst{nodep->fileline(), xnum}};

--- a/test_regress/t/t_oob_2state_array.py
+++ b/test_regress/t/t_oob_2state_array.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+# x-assign shouldn't affect 2-state oob read
+test.compile(verilator_flags2=["--binary --x-assign 1"])
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_oob_2state_array.v
+++ b/test_regress/t/t_oob_2state_array.v
@@ -1,0 +1,28 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain.
+// SPDX-FileCopyrightText: 2026 Antmicro
+// SPDX-License-Identifier: CC0-1.0
+
+`define stop $stop
+`define checkh(gotv,expv) do if ((gotv) !== (expv)) begin $write("%%Error: %s:%0d:  got=%0x exp=%0x (%s !== %s)\n", `__FILE__,`__LINE__, (gotv), (expv), `"gotv`", `"expv`"); `stop; end while(0);
+
+
+module t;
+  logic clk = 1'b0;
+  always #1 clk = ~clk;
+
+  int idx = 0;
+  bit a[0:2] = {1, 1, 1};
+
+  always @(posedge clk) begin
+    if (idx == 4) begin
+      $write("*-* All Finished *-*\n");
+      $finish;
+    end
+    else begin
+      idx <= idx + 1;
+      `checkh(a[idx], idx <= 2 ? 1 : 0);
+    end
+  end
+endmodule


### PR DESCRIPTION
According to the `Table 7-1—Value read from a nonexistent array entry` from the specification, only four state arrays should return `x` on out-of-bounds reads, but verilator was using `x`s even in case of 2-state arrays where `0` should be read. This PR fixes that by checking if the type is a 4-state in V3Unknown and using `0` instead of `x` if its not