### PR TITLE
Restore Antmicro copyright on test files accidentally overwritten

### DIFF
--- a/test_regress/t/t_constraint_unsup.v
+++ b/test_regress/t/t_constraint_unsup.v
@@ -1,7 +1,7 @@
 // DESCRIPTION: Verilator: Verilog Test module
 //
 // This file ONLY is placed under the Creative Commons Public Domain.
-// SPDX-FileCopyrightText: 2026 PlanV GmbH
+// SPDX-FileCopyrightText: 2025 Antmicro
 // SPDX-License-Identifier: CC0-1.0
 
 class Packet;

--- a/test_regress/t/t_property_sexpr_multi.v
+++ b/test_regress/t/t_property_sexpr_multi.v
@@ -1,7 +1,7 @@
 // DESCRIPTION: Verilator: Verilog Test module
 //
 // This file ONLY is placed under the Creative Commons Public Domain.
-// SPDX-FileCopyrightText: 2026 PlanV GmbH
+// SPDX-FileCopyrightText: 2025 Antmicro
 // SPDX-License-Identifier: CC0-1.0
 
 // verilog_format: off


### PR DESCRIPTION
Two pre-existing tests originally authored by Antmicro had their SPDX-FileCopyrightText header replaced with ours. This was accidental — apologies to the Antmicro team @RRozak @b-chmiel — and is corrected here:

```
test_regress/t/t_property_sexpr_multi.v — restored to 2025 Antmicro
test_regress/t/t_constraint_unsup.v — restored to 2025 Antmicro
```

Root cause: my AI_Verilator_developer workflow enforces a standard test-header template via a script. When my AI-assisted tooling edited these existing files, it applied the template to the entire header and overwrote the original copyright line. The containing commits were large, so it slipped through my human review. That's a bug in my workflow, not intentional — but fully my responsibility.

Audit: I went through my full commit history for the same failure mode across all paths. These two files are the only cases where an existing third-party copyright was replaced and still lives on master. (Separately, three obsolete Antmicro *_unsup.v lint tests were removed when the corresponding features were implemented; those were deletions of now-redundant tests, not re-attribution.)

I've also fixed the workflow so it can no longer overwrite an existing third-party copyright header. Lesson learned and I will also mention this in https://github.com/verilator/verilator/pull/7765 's AGENT.md. 

Sorry for the inconvenience and the noise.