### PR TITLE
Fix randomization of dynamic arrays of objects

### DIFF
--- a/src/V3Randomize.cpp
+++ b/src/V3Randomize.cpp
@@ -4569,6 +4569,16 @@ class RandomizeVisitor final : public VNVisitor {
         }
     }
 
+    static bool isDynArrOfClassTypeRecurse(const AstNodeDType* const dtypep) {
+        const AstNodeDType* const refp = dtypep->skipRefp();
+        if (VN_IS(refp, DynArrayDType) || VN_IS(refp, QueueDType)) {
+            return isDynArrOfClassTypeRecurse(refp->subDTypep());
+        } else if (VN_IS(refp, ClassRefDType)) {
+            return true;
+        }
+        return false;
+    }
+
     // VISITORS
     void visit(AstNodeModule* nodep) override {
         VL_RESTORER(m_modp);
@@ -4801,6 +4811,18 @@ class RandomizeVisitor final : public VNVisitor {
 
                 // Refresh array element tables after resize
                 for (AstVar* const arrVarp : sizeArraysIt->second) {
+                    // Array elements of class data type are passed to the solver as separate
+                    // variables, so passing the original array variable is redundant, because it
+                    // won't be referenced
+                    if (isDynArrOfClassTypeRecurse(arrVarp->dtypep())) {
+                        const uint32_t unpackedDims = arrVarp->dtypep()->dimensions(false).second;
+                        if (unpackedDims > 1) {
+                            arrVarp->v3warn(
+                                E_UNSUPPORTED,
+                                "Unsupported: Nested array element access in global constraint");
+                        }
+                        continue;
+                    }
                     AstCMethodHard* const methodp = new AstCMethodHard{
                         fl, new AstVarRef{fl, genModp, genp, VAccess::READWRITE},
                         VCMethod::RANDOMIZER_WRITE_VAR};

--- a/test_regress/t/t_constraint_global_cls_arr.py
+++ b/test_regress/t/t_constraint_global_cls_arr.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2025 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+if not test.have_solver:
+    test.skip("No constraint solver installed")
+
+test.compile()
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_constraint_global_cls_arr.v
+++ b/test_regress/t/t_constraint_global_cls_arr.v
@@ -1,0 +1,37 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain.
+// SPDX-FileCopyrightText: 2026 Antmicro
+// SPDX-License-Identifier: CC0-1.0
+
+class Foo;
+  rand int abcd;
+endclass
+
+class Bar;
+  rand Foo foo_arr[];
+
+  function new();
+    foo_arr = new[12];
+    foreach(foo_arr[i]) foo_arr[i] = new;
+  endfunction
+
+  constraint c {
+    foo_arr.size() == 10;
+    foreach (foo_arr[i]) foo_arr[i].abcd < 8;
+  }
+endclass
+
+module t;
+  Bar bar;
+  initial begin
+    bar = new();
+    bar.randomize();
+    if (bar.foo_arr.size() != 10) $stop;
+    foreach (bar.foo_arr[i]) begin
+      if (bar.foo_arr[i] >= 8) $stop;
+    end
+    $write("*-* All Finished *-*\n");
+    $finish;
+  end
+endmodule

--- a/test_regress/t/t_constraint_global_cls_arr_2d_unsup.out
+++ b/test_regress/t/t_constraint_global_cls_arr_2d_unsup.out
@@ -1,0 +1,6 @@
+%Error-UNSUPPORTED: t/t_constraint_global_cls_arr_2d_unsup.v:13:12: Unsupported: Nested array element access in global constraint
+                                                                  : ... note: In instance 't'
+   13 |   rand Foo foo_arr[$][];
+      |            ^~~~~~~
+                    ... For error description see https://verilator.org/warn/UNSUPPORTED?v=latest
+%Error: Exiting due to

--- a/test_regress/t/t_constraint_global_cls_arr_2d_unsup.py
+++ b/test_regress/t/t_constraint_global_cls_arr_2d_unsup.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2025 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('vlt')
+
+test.lint(fails=test.vlt_all, expect_filename=test.golden_filename)
+
+test.passes()

--- a/test_regress/t/t_constraint_global_cls_arr_2d_unsup.v
+++ b/test_regress/t/t_constraint_global_cls_arr_2d_unsup.v
@@ -1,0 +1,41 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain.
+// SPDX-FileCopyrightText: 2026 Antmicro
+// SPDX-License-Identifier: CC0-1.0
+
+class Foo;
+  rand int abcd;
+   constraint c { abcd >= 2; }
+endclass
+
+class Bar;
+  rand Foo foo_arr[$][];
+
+  function new();
+    for (int i = 0; i < 3; i++) foo_arr[i] = new[5];
+    foreach(foo_arr[i, j]) foo_arr[i][j] = new;
+  endfunction
+
+  constraint c {
+    foo_arr.size() == 10;
+    foreach (foo_arr[i, j]) foo_arr[i][j].abcd < 8;
+  }
+endclass
+
+module t;
+  Bar bar;
+  initial begin
+    bar = new();
+    void'(bar.randomize());
+    if (bar.foo_arr.size() != 10) $stop;
+    foreach (bar.foo_arr[i, j]) begin
+      if (bar.foo_arr[i][j].abcd < 2 || bar.foo_arr[i][j].abcd >= 8) $stop;
+    end
+    for (int i = 3; i < 10; i++) begin
+      if (bar.foo_arr[i].size() != 0) $stop;
+    end
+    $write("*-* All Finished *-*\n");
+    $finish;
+  end
+endmodule


### PR DESCRIPTION
It fixes randomization of 1D dynamic arrays of class objects.
Currently on master, cpp compilation errors are thrown on tests from this PR, e.g.:
```
/home/rrozak/verilator/test_regress/../include/verilated_random.h: In instantiation of â VlRandomizer::record_arr_table(VlQueue<T_Key>&, const std::string&, int, std::vector<unsigned int>, std::vecto    
r<long unsigned int>) [with T = VlClassRef<Vt_constraint_global_cls_arr___024unit__03a__03aFoo>; std::string = std::__cxx11::basic_string<char>]â:                                                         
/home/rrozak/verilator/test_regress/../include/verilated_random.h:391:29:   required from â std::enable_if<(! VlContainsCustomStruct<T>::value), void>::type VlRandomizer::write_var(VlQueue<T_Key>        
&, int, const char*, int, uint32_t) [with T = VlClassRef<Vt_constraint_global_cls_arr___024unit__03a__03aFoo>; typename std::enable_if<(! VlContainsCustomStruct<T>::value), void>::type = void; uint32_t =
 unsigned int]â                                                                                      
  391 |             record_arr_table(var, name, dimension, {}, {});                                  
      |             ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                   
Vt_constraint_global_cls_arr___024unit__03a__03aBar__Vclpkg__0.cpp:58:38:   required from here                                                                                                             
   58 |     this->__PVT__constraint.write_var(this->__PVT__foo_arr, 0ULL,                                                                                                                                  
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~                                                                                                                                  
   59 |                                       "foo_arr", 1ULL);                                                                                                                                            
      |                                       ~~~~~~~~~~~~~~~~                                       
/home/rrozak/verilator/test_regress/../include/verilated_random.h:499:33: error: no matching function for call to â                                                                                        
3aFoo>&, const std::string&, int, std::vector<unsigned int>&, std::vector<long unsigned int>&)â                                                                                                            
  499 |                 record_arr_table(var.atWrite(i), indexed_name, dimension - 1, indices, idxWidths);                                                                                          
      |                 ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                  
```

My changes prevent from creating a call to that function, because it is not needed anyway. Elements of dynamic array of class type are passed to the solver as separate variables and the original array is not referenced in the constraints passed to the solver.

Arrays of more dimensions don't work too, but on other types of arrays UNSUPPORTED is thrown, so I added the same error in the case of multidimensional dynamic arrays.