### PR TITLE
Remove cmake bad file reference

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -201,7 +201,6 @@ set(HEADERS
     V3WidthCommit.h
     V3WidthRemove.h
     VlcBucket.h
-    VlcCovergroup.h
     VlcOptions.h
     VlcPoint.h
     VlcSource.h


### PR DESCRIPTION
- VlcCovergroup.h seems to be a leftover change no longer needed
- Removing allows cmake build on macOS to run further
- `make ; make tests ; make examples` all still ok after this change as a double check

Issue: https://github.com/verilator/verilator/issues/7791