### PR TITLE
Fix cross-hierarchy tristate drivers of interface nets

### DIFF
--- a/src/V3Tristate.cpp
+++ b/src/V3Tristate.cpp
@@ -762,6 +762,9 @@ class TristateVisitor final : public TristateBaseVisitor {
                         }
                     }
                 } else if (isIfaceTri) {
+                    // Mark here too, so a net made tristate only by an external 'z driver
+                    // still captures a plain cross-hierarchy driver processed later.
+                    m_varAux(invarp).ifaceTristate = true;
                     // Interface tristate vars: drivers from different interface instances
                     // (different VarXRef dotted paths) must be processed separately.
                     // E.g. io_ifc.d and io_ifc_local.d both target the same AstVar d in

--- a/src/V3Tristate.cpp
+++ b/src/V3Tristate.cpp
@@ -446,6 +446,7 @@ class TristateVisitor final : public TristateBaseVisitor {
     int m_unique = 0;
     bool m_alhs = false;  // On LHS of assignment
     bool m_inAlias = false;  // Inside alias statement
+    bool m_processedIfaces = false;  // Interface modules already processed (interfaces-first pass)
     VStrength m_currentStrength = VStrength::STRONG;  // Current strength of assignment,
                                                       // Used only on LHS of assignment
     const AstNode* m_logicp = nullptr;  // Current logic being built
@@ -2094,10 +2095,11 @@ class TristateVisitor final : public TristateBaseVisitor {
         if (m_graphing) {
             if (nodep->access().isWriteOrRW()) associateLogic(nodep, nodep->varp());
             if (nodep->access().isReadOrRW()) associateLogic(nodep->varp(), nodep);
-            // A plain (non-Z) cross-hierarchy driver of an interface net that is tristate
-            // must be treated as tristate here too, so it is collected as a contribution
-            // and combined with the interface's own drivers (otherwise it is silently
-            // dropped and the net resolves using only the interface-internal Z driver).
+            // Only interface tristate nets need this: a plain (non-Z) cross-hierarchy
+            // driver has no Z in its own module's graph, so mark the net tristate here to
+            // collect the driver as a contribution. The ifaceTristate flag is only set for
+            // interface nets; a non-interface cross-module tri driver does nothing here and
+            // is instead rejected (E_UNSUPPORTED) later in insertTristates.
             if (nodep->access().isWriteOrRW() && VN_IS(nodep, VarXRef)
                 && m_varAux(nodep->varp()).ifaceTristate) {
                 m_tgraph.setTristate(nodep->varp());
@@ -2182,6 +2184,9 @@ class TristateVisitor final : public TristateBaseVisitor {
     }
 
     void visit(AstNodeModule* nodep) override {
+        // Interfaces are processed first in the constructor; skip the duplicate visit
+        // during the later iterateChildrenBackwardsConst() pass over all modules.
+        if (m_processedIfaces && VN_IS(nodep, Iface)) return;
         UINFO(8, dbgState() << nodep);
         VL_RESTORER(m_modp);
         VL_RESTORER(m_graphing);
@@ -2318,24 +2323,19 @@ public:
     // CONSTRUCTORS
     explicit TristateVisitor(AstNetlist* netlistp) {
         m_tgraph.clearAndCheck();
-        // Process interface modules before any other module, so that interface tristate
-        // nets are recorded (AuxAstVar::ifaceTristate) before the modules that drive them
-        // across hierarchy are processed. A module driving an interface tristate net with a
-        // plain (non-Z) assign has no Z in its own graph to mark the net tristate, so without
-        // this ordering its driver would be silently dropped. Only modulesp() carries tristate
-        // logic (filesp/miscsp do not), so restricting the walk to it drops nothing versus the
-        // historical iterateChildrenBackwardsConst(); iterate each group in reverse declaration
-        // order to match that order.
-        std::vector<AstNodeModule*> modps;
+        // Process interface modules first, so an interface tristate net is recorded
+        // (AuxAstVar::ifaceTristate) before any module that drives it across hierarchy is
+        // graphed. A module driving such a net with a plain (non-Z) assign has no Z in its
+        // own graph to mark the net tristate, so without this its driver would be dropped.
+        // Collect only the interfaces (reverse declaration order to match the pass below).
+        std::vector<AstNodeModule*> ifacesp;
         for (AstNode* modp = netlistp->modulesp(); modp; modp = modp->nextp()) {
-            modps.push_back(VN_AS(modp, NodeModule));
+            if (VN_IS(modp, Iface)) ifacesp.push_back(VN_AS(modp, NodeModule));
         }
-        for (auto it = modps.rbegin(); it != modps.rend(); ++it) {
-            if (VN_IS(*it, Iface)) iterate(*it);
-        }
-        for (auto it = modps.rbegin(); it != modps.rend(); ++it) {
-            if (!VN_IS(*it, Iface)) iterate(*it);
-        }
+        for (auto it = ifacesp.rbegin(); it != ifacesp.rend(); ++it) iterate(*it);
+        m_processedIfaces = true;
+        // Then the rest in the historical order; interfaces are skipped (already done).
+        iterateChildrenBackwardsConst(netlistp);
 
         // Combine interface tristate contributions after all modules processed
         combineIfaceContribs();

--- a/src/V3Tristate.cpp
+++ b/src/V3Tristate.cpp
@@ -352,7 +352,9 @@ class TristatePinVisitor final : public TristateBaseVisitor {
     TristateGraph& m_tgraph;
     const bool m_lvalue;  // Flip to be an LVALUE
     // VISITORS
-    void visit(AstVarRef* nodep) override {
+    // AstNodeVarRef, not just AstVarRef: a cross-hierarchy pin expression into an
+    // interface (.pin(iface.net)) is an AstVarXRef and needs the same access flip.
+    void visit(AstNodeVarRef* nodep) override {
         UASSERT_OBJ(!nodep->access().isRW(), nodep, "Tristate unexpected on R/W access flip");
         if (m_lvalue && !nodep->access().isWriteOrRW()) {
             UINFO(9, "  Flip-to-LValue " << nodep);
@@ -405,6 +407,11 @@ class TristateVisitor final : public TristateBaseVisitor {
     struct AuxAstVar final {
         AstPull* pullp = nullptr;  // pullup/pulldown direction (whole variable)
         AstVar* outVarp = nullptr;  // output __out var
+        bool ifaceTristate = false;  // Interface var known to be tristate (set when the
+                                     // interface module is processed). Lets a module that
+                                     // drives this var across hierarchy with a plain (non-Z)
+                                     // assign be recognised as a tristate contributor even
+                                     // though that module's own graph has no Z on the net.
         std::unordered_map<int, int>
             bitPulls;  // Per-bit pull: bit_index -> direction (1=up, 0=down)
     };
@@ -780,7 +787,11 @@ class TristateVisitor final : public TristateBaseVisitor {
                     }
                 } else if (VN_IS(nodep, Iface) && !invarp->isIO()) {
                     // Local driver in an interface module - use contribution mechanism
-                    // so it can be combined with any external drivers later
+                    // so it can be combined with any external drivers later. Record that
+                    // this interface net is tristate, so a module that drives it across
+                    // hierarchy with a plain (non-Z) assign is also routed through the
+                    // contribution mechanism (its own graph has no Z to mark it tristate).
+                    m_varAux(invarp).ifaceTristate = true;
                     insertTristatesSignal(nodep, invarp, refsp, true, "", "", nullptr);
                 } else {
                     insertTristatesSignal(nodep, invarp, refsp, false, "", "", nullptr);
@@ -2080,6 +2091,14 @@ class TristateVisitor final : public TristateBaseVisitor {
         if (m_graphing) {
             if (nodep->access().isWriteOrRW()) associateLogic(nodep, nodep->varp());
             if (nodep->access().isReadOrRW()) associateLogic(nodep->varp(), nodep);
+            // A plain (non-Z) cross-hierarchy driver of an interface net that is tristate
+            // must be treated as tristate here too, so it is collected as a contribution
+            // and combined with the interface's own drivers (otherwise it is silently
+            // dropped and the net resolves using only the interface-internal Z driver).
+            if (nodep->access().isWriteOrRW() && VN_IS(nodep, VarXRef)
+                && m_varAux(nodep->varp()).ifaceTristate) {
+                m_tgraph.setTristate(nodep->varp());
+            }
         } else {
             if (nodep->user2() & U2_NONGRAPH) return;  // Processed
             nodep->user2Or(U2_NONGRAPH);
@@ -2296,7 +2315,24 @@ public:
     // CONSTRUCTORS
     explicit TristateVisitor(AstNetlist* netlistp) {
         m_tgraph.clearAndCheck();
-        iterateChildrenBackwardsConst(netlistp);
+        // Process interface modules before any other module, so that interface tristate
+        // nets are recorded (AuxAstVar::ifaceTristate) before the modules that drive them
+        // across hierarchy are processed. A module driving an interface tristate net with a
+        // plain (non-Z) assign has no Z in its own graph to mark the net tristate, so without
+        // this ordering its driver would be silently dropped. Only modulesp() carries tristate
+        // logic (filesp/miscsp do not), so restricting the walk to it drops nothing versus the
+        // historical iterateChildrenBackwardsConst(); iterate each group in reverse declaration
+        // order to match that order.
+        std::vector<AstNodeModule*> modps;
+        for (AstNode* modp = netlistp->modulesp(); modp; modp = modp->nextp()) {
+            modps.push_back(VN_AS(modp, NodeModule));
+        }
+        for (auto it = modps.rbegin(); it != modps.rend(); ++it) {
+            if (VN_IS(*it, Iface)) iterate(*it);
+        }
+        for (auto it = modps.rbegin(); it != modps.rend(); ++it) {
+            if (!VN_IS(*it, Iface)) iterate(*it);
+        }
 
         // Combine interface tristate contributions after all modules processed
         combineIfaceContribs();

--- a/test_regress/t/t_interface_inout_tristate.py
+++ b/test_regress/t/t_interface_inout_tristate.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile(timing_loop=True, verilator_flags2=['--timing'])
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_interface_inout_tristate.v
+++ b/test_regress/t/t_interface_inout_tristate.v
@@ -1,0 +1,62 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain.
+// SPDX-FileCopyrightText: 2026 PlanV GmbH
+// SPDX-License-Identifier: CC0-1.0
+
+// verilog_format: off
+`define stop $stop
+`define checkh(gotv,expv) do if ((gotv) !== (expv)) begin $write("%%Error: %s:%0d:  got='h%x exp='h%x\n", `__FILE__,`__LINE__, (gotv), (expv)); `stop; end while(0);
+// verilog_format: on
+
+// verilator lint_off MULTIDRIVEN
+
+interface ifc;
+  // Tristate net resolved across an inout port connected hierarchically to
+  // this interface signal (iface.data <-> dut inout port).
+  wire [7:0] data;
+endinterface
+
+module dut (
+    inout wire [7:0] data,
+    input bit oe,
+    input logic [7:0] val
+);
+  // The inout port drives the interface net when enabled, releases it (Z) otherwise.
+  assign data = oe ? val : 8'hzz;
+endmodule
+
+module t;
+  ifc ifc0 ();
+  bit oe, top_oe;
+  logic [7:0] val, topval;
+
+  // A second driver from the top, so resolution is observable from both sides.
+  assign ifc0.data = top_oe ? topval : 8'hzz;
+
+  dut u (
+      .data(ifc0.data),
+      .oe(oe),
+      .val(val)
+  );
+
+  initial begin
+    // dut drives the interface net through the inout port.
+    oe = 1;
+    val = 8'hA5;
+    top_oe = 0;
+    topval = 8'h00;
+    #1 `checkh(ifc0.data, 8'hA5);
+    // top drives, dut releases.
+    oe = 0;
+    top_oe = 1;
+    topval = 8'h3C;
+    #1 `checkh(ifc0.data, 8'h3C);
+    // Neither drives: net floats to Z.
+    oe = 0;
+    top_oe = 0;
+    #1 `checkh(ifc0.data, 8'hzz);
+    $write("*-* All Finished *-*\n");
+    $finish;
+  end
+endmodule

--- a/test_regress/t/t_interface_inout_tristate.v
+++ b/test_regress/t/t_interface_inout_tristate.v
@@ -7,6 +7,11 @@
 // verilog_format: off
 `define stop $stop
 `define checkh(gotv,expv) do if ((gotv) !== (expv)) begin $write("%%Error: %s:%0d:  got='h%x exp='h%x\n", `__FILE__,`__LINE__, (gotv), (expv)); `stop; end while(0);
+`ifdef verilator
+ `define no_optimize(v) $c(v)
+`else
+ `define no_optimize(v) (v)
+`endif
 // verilog_format: on
 
 // verilator lint_off MULTIDRIVEN
@@ -42,20 +47,23 @@ module t;
 
   initial begin
     // dut drives the interface net through the inout port.
-    oe = 1;
-    val = 8'hA5;
-    top_oe = 0;
-    topval = 8'h00;
-    #1 `checkh(ifc0.data, 8'hA5);
+    oe = `no_optimize(1'b1);
+    val = `no_optimize(8'hA5);
+    top_oe = `no_optimize(1'b0);
+    topval = `no_optimize(8'h00);
+    #1;
+    `checkh(ifc0.data, 8'hA5);
     // top drives, dut releases.
-    oe = 0;
-    top_oe = 1;
-    topval = 8'h3C;
-    #1 `checkh(ifc0.data, 8'h3C);
+    oe = `no_optimize(1'b0);
+    top_oe = `no_optimize(1'b1);
+    topval = `no_optimize(8'h3C);
+    #1;
+    `checkh(ifc0.data, 8'h3C);
     // Neither drives: net floats to Z.
-    oe = 0;
-    top_oe = 0;
-    #1 `checkh(ifc0.data, 8'hzz);
+    oe = `no_optimize(1'b0);
+    top_oe = `no_optimize(1'b0);
+    #1;
+    `checkh(ifc0.data, 8'hzz);
     $write("*-* All Finished *-*\n");
     $finish;
   end

--- a/test_regress/t/t_interface_tristate_plain_xhier.py
+++ b/test_regress/t/t_interface_tristate_plain_xhier.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile(timing_loop=True, verilator_flags2=['--timing'])
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_interface_tristate_plain_xhier.v
+++ b/test_regress/t/t_interface_tristate_plain_xhier.v
@@ -1,0 +1,68 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain.
+// SPDX-FileCopyrightText: 2026 PlanV GmbH
+// SPDX-License-Identifier: CC0-1.0
+
+// verilog_format: off
+`define stop $stop
+`define checkh(gotv,expv) do if ((gotv) !== (expv)) begin $write("%%Error: %s:%0d:  got='h%x exp='h%x\n", `__FILE__,`__LINE__, (gotv), (expv)); `stop; end while(0);
+// verilog_format: on
+
+// verilator lint_off MULTIDRIVEN
+
+interface ifc;
+  wire [1:0] w;
+  // Self-contained interface-internal tristate driver: 'z while en==0, so any
+  // external driver must win the net resolution.
+  bit en = 0;
+  logic [1:0] wint;
+  assign wint = 2'b11;
+  assign w = en ? wint : 2'bzz;
+  // Read the resolved net from inside the interface (a consumer's view), so the
+  // check sees the true resolution, not the driving module's own local copy.
+  function automatic logic [1:0] get_w();
+    return w;
+  endfunction
+endinterface
+
+module driver (
+    ifc io,
+    input logic [1:0] din
+);
+  // Plain (non-Z) cross-hierarchy driver of an interface tristate net.
+  // This module's own tristate graph has no 'z on io.w, so before the fix this
+  // contribution was silently dropped and io.w resolved to the interface-internal
+  // 'z (== 0) only.
+  assign io.w = din;
+endmodule
+
+module t;
+  // u_a, u_b: interface nets driven plainly from the top module (depth-0 xref).
+  // u_c:      interface net driven plainly from a child module (depth-1 xref).
+  ifc u_a ();
+  ifc u_b ();
+  ifc u_c ();
+
+  logic [1:0] va, vb, vc;
+  assign va = 2'b01;
+  assign vb = 2'b10;
+  assign vc = 2'b11;
+
+  assign u_a.w = va;  // plain top-level driver
+  assign u_b.w = vb;  // plain top-level driver
+  driver u_drv (
+      .io(u_c),
+      .din(vc)
+  );  // plain driver in a child module
+
+  initial begin
+    #1;
+    // The plain external driver must win over the interface-internal 'z.
+    `checkh(u_a.get_w(), 2'b01);
+    `checkh(u_b.get_w(), 2'b10);
+    `checkh(u_c.get_w(), 2'b11);
+    $write("*-* All Finished *-*\n");
+    $finish;
+  end
+endmodule

--- a/test_regress/t/t_interface_tristate_plain_xhier.v
+++ b/test_regress/t/t_interface_tristate_plain_xhier.v
@@ -7,6 +7,11 @@
 // verilog_format: off
 `define stop $stop
 `define checkh(gotv,expv) do if ((gotv) !== (expv)) begin $write("%%Error: %s:%0d:  got='h%x exp='h%x\n", `__FILE__,`__LINE__, (gotv), (expv)); `stop; end while(0);
+`ifdef verilator
+ `define no_optimize(v) $c(v)
+`else
+ `define no_optimize(v) (v)
+`endif
 // verilog_format: on
 
 // verilator lint_off MULTIDRIVEN
@@ -14,10 +19,12 @@
 interface ifc;
   wire [1:0] w;
   // Self-contained interface-internal tristate driver: 'z while en==0, so any
-  // external driver must win the net resolution.
-  bit en = 0;
+  // external driver must win the net resolution. no_optimize keeps the driver
+  // values from being constant-folded, so the resolution runs at run time.
+  logic en;
   logic [1:0] wint;
-  assign wint = 2'b11;
+  assign en = `no_optimize(1'b0);
+  assign wint = `no_optimize(2'b11);
   assign w = en ? wint : 2'bzz;
   // Read the resolved net from inside the interface (a consumer's view), so the
   // check sees the true resolution, not the driving module's own local copy.
@@ -66,10 +73,10 @@ module t;
   ifc_tri u_e ();
 
   logic [1:0] va, vb, vc, ve;
-  assign va = 2'b01;
-  assign vb = 2'b10;
-  assign vc = 2'b11;
-  assign ve = 2'b01;
+  assign va = `no_optimize(2'b01);
+  assign vb = `no_optimize(2'b10);
+  assign vc = `no_optimize(2'b11);
+  assign ve = `no_optimize(2'b01);
 
   assign u_a.w = va;  // plain top-level driver
   assign u_b.w = vb;  // plain top-level driver

--- a/test_regress/t/t_interface_tristate_plain_xhier.v
+++ b/test_regress/t/t_interface_tristate_plain_xhier.v
@@ -26,6 +26,11 @@ interface ifc;
   endfunction
 endinterface
 
+// Interface net made tristate only by an external 'z driver (no internal driver).
+interface ifc_tri;
+  tri [1:0] w;
+endinterface
+
 module driver (
     ifc io,
     input logic [1:0] din
@@ -37,17 +42,34 @@ module driver (
   assign io.w = din;
 endmodule
 
+module driver_tri (
+    ifc_tri io,
+    input logic [1:0] din
+);
+  assign io.w = din;
+endmodule
+
+module zdriver (
+    ifc_tri io
+);
+  assign io.w = 2'bzz;
+endmodule
+
 module t;
   // u_a, u_b: interface nets driven plainly from the top module (depth-0 xref).
   // u_c:      interface net driven plainly from a child module (depth-1 xref).
   ifc u_a ();
   ifc u_b ();
   ifc u_c ();
+  // u_e: net is tristate only via zdriver's external 'z; the plain driver must
+  // still win (the interface itself has no internal driver).
+  ifc_tri u_e ();
 
-  logic [1:0] va, vb, vc;
+  logic [1:0] va, vb, vc, ve;
   assign va = 2'b01;
   assign vb = 2'b10;
   assign vc = 2'b11;
+  assign ve = 2'b01;
 
   assign u_a.w = va;  // plain top-level driver
   assign u_b.w = vb;  // plain top-level driver
@@ -55,6 +77,11 @@ module t;
       .io(u_c),
       .din(vc)
   );  // plain driver in a child module
+  driver_tri u_pdrv (
+      .io(u_e),
+      .din(ve)
+  );  // plain driver of an externally-tristated net
+  zdriver u_zdrv (.io(u_e));  // external 'z driver
 
   initial begin
     #1;
@@ -62,6 +89,8 @@ module t;
     `checkh(u_a.get_w(), 2'b01);
     `checkh(u_b.get_w(), 2'b10);
     `checkh(u_c.get_w(), 2'b11);
+    // The plain driver must win over an external-only 'z (no internal driver).
+    `checkh(u_e.w, 2'b01);
     $write("*-* All Finished *-*\n");
     $finish;
   end

--- a/test_regress/t/t_interface_tristate_plain_xhier_noinl.py
+++ b/test_regress/t/t_interface_tristate_plain_xhier_noinl.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+test.top_filename = "t_interface_tristate_plain_xhier.v"
+
+test.compile(timing_loop=True, verilator_flags2=['--timing', '-fno-inline'])
+
+test.execute()
+
+test.passes()


### PR DESCRIPTION
## Summary

This patch fixes two related problems with a tristate net that lives inside an interface and is driven across a hierarchy boundary: a plain (non-`Z`) cross-hierarchy driver was silently dropped (the net resolved to its interface-internal `'z`), and connecting an `inout` port to such a net aborted with `Internal Error: V3DfgSynthesize: Non-ReadOnly reference`. Per IEEE 1800-2023 6.6.1 a `'z` driver loses to any driven value. 

We hit both while bringing up the OpenTitan pattgen IP UVM environment on Verilator. 

PR #7339 previously tackled the cross-interface driver case but has been stalled (last update three months ago) on exactly the `inout` internal error the accellera UVM (xbus) test triggers; this patch takes a different approach that resolves both at once and covers #7339's cases. Thanks to #7339 for the implementation that inspired and informed this work.

## Reproducer

Plain cross-hierarchy driver dropped:
```systemverilog
interface ifc; wire [1:0] w; assign w = 1'b0 ? 2'b11 : 2'bzz; endinterface
module t;
  ifc u (); logic [1:0] v; assign v = 2'b01;
  assign u.w = v;  // plain (non-Z) cross-hierarchy driver
  initial begin #1; if (u.w !== 2'b01) $stop; $finish; end
endmodule
```
On master: `u.w` reads `'h0` (external driver lost); Questa gives `01`.

`inout` port connected to an interface tristate net:
```systemverilog
interface ifc; wire [7:0] data; endinterface
module dut (inout wire [7:0] data, input bit oe, input logic [7:0] val);
  assign data = oe ? val : 8'hzz;
endmodule
module t; ifc i0 (); dut u (.data(i0.data), .oe(1'b1), .val(8'hA5));
  initial begin #1; if (i0.data !== 8'hA5) $stop; $finish; end
endmodule
```
On master: `%Error: Internal Error: V3DfgSynthesize.cpp: Non-ReadOnly reference`.

## Changes
- src/V3Tristate.cpp (TristateVisitor ctor + handleNodeVarRef): mark an interface tristate net driven across hierarchy as tristate in the driving module so its plain (non-Z) driver is collected as a contribution -- whether the net's `'z` originates inside the interface or in another module; process interface modules before their drivers.
- src/V3Tristate.cpp (TristatePinVisitor): match AstVarXRef as well as AstVarRef so a cross-hierarchy inout pin expression (`iface.net`) gets its access flipped; it previously kept WRITE access on the input-side reconnect, leaving a write reference on an RHS that tripped V3DfgSynthesize.

## Test
- t_interface_tristate_plain_xhier.{v,py} + _noinl.py -- plain cross-hierarchy driver from top and from a child module, covering an interface tristate net whose `'z` comes from inside the interface and (separately) only from another module; validated against Questa.
- t_interface_inout_tristate.{v,py} -- bidirectional tristate across an inout port connected to an interface net; validated against Questa.

---
Developed by PlanV GmbH, assisted with Claude Code.

Reviewed by YilouWang.