### PR TITLE
Fix t_assert_iff_clk unstable with --vltmt (#7781)

### DIFF
--- a/test_regress/t/t_assert_iff_clk.py
+++ b/test_regress/t/t_assert_iff_clk.py
@@ -9,8 +9,7 @@
 
 import vltest_bootstrap
 
-# Issue #7781 unstable with --vltmt
-test.scenarios('simulator_st')
+test.scenarios('simulator')
 
 test.compile(timing_loop=True, verilator_flags2=['--assert', '--timing'])
 

--- a/test_regress/t/t_assert_iff_clk.v
+++ b/test_regress/t/t_assert_iff_clk.v
@@ -32,7 +32,7 @@ module t (
   assert property (@(posedge clk) disable iff (cyc < 5) 1 ##1 0)
     else post_temporal_fail++;
 
-  always @(posedge clk) begin
+  always @(negedge clk) begin
     cyc <= cyc + 1;
     rst <= cyc < 4;
     x <= cyc < 4;


### PR DESCRIPTION
Addresses https://github.com/verilator/verilator/issues/7781. Fixes flakiness of test `t_assert_iff_clk` which is due to race conditions on write-read of counters by moving the counter check to negative edge of the clock.