### PR TITLE
Fix typo in docs

### DIFF
--- a/docs/guide/connecting.rst
+++ b/docs/guide/connecting.rst
@@ -179,7 +179,7 @@ DPI Example
 In the SYSTEMC example above, if you wanted to import C++ functions into
 Verilog, put in our.v:
 
-.. code-block::
+.. code-block:: sv
 
    import "DPI-C" function int add (input int a, input int b);
 
@@ -213,7 +213,7 @@ function name for the import, but note it must be escaped.
 
 .. code-block:: sv
 
-   export "DPI-C" function integer \$myRand;
+   import "DPI-C" function integer \$myRand;
 
    initial $display("myRand=%d", $myRand());
 


### PR DESCRIPTION
Change `export` to `import` in the relevant docs codeblock as that matches behavior described in the docs.

Also add systemverilog syntax highlighting in one place where it was omitted.
