### PR TITLE
CI/Makefile: Auto format .rst files

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -546,6 +546,13 @@ PY_FILES = \
 # Python files, test_regress tests
 PY_TEST_FILES = test_regress/t/*.py
 
+# reStructuredText Sphinx files
+RST_FILES = \
+  *.rst \
+  */*.rst \
+  ci/docker/*/*.rst \
+  docs/guide/*.rst \
+
 # YAML files
 YAML_FILES = \
   .*.yaml \
@@ -558,7 +565,7 @@ YAML_FILES = \
 # Format
 
 format:
-	$(MAKE) -j 5 format-c format-cmake format-exec format-md format-py format-yaml
+	$(MAKE) -j 5 format-c format-cmake format-exec format-md format-py format-rst format-yaml
 
 BEAUTYSH = beautysh
 BEAUTYSH_FLAGS = --indent-size 2
@@ -608,6 +615,13 @@ YAPF_FLAGS = -i --parallel
 format-py yapf:
 	$(YAPF) --version
 	$(YAPF) $(YAPF_FLAGS) $(PY_FILES)
+
+DOCSTRFMT = docstrfmt
+DOCSTRFMT_FLAGS = --line-length 75 --indent-width 3 --keep-blanks --ordered-marker "\#" --preserve-adornments --no-center-section-titles
+
+format-rst:
+	$(DOCSTRFMT) --version
+	$(DOCSTRFMT) $(DOCSTRFMT_FLAGS) $(RST_FILES)
 
 YAMLFIX = YAMLFIX_WHITELINES=1 YAMLFIX_LINE_LENGTH=200 YAMLFIX_preserve_quotes=true yamlfix
 YAMLFIX_FLAGS =

--- a/python-dev-requirements.txt
+++ b/python-dev-requirements.txt
@@ -19,6 +19,7 @@
 breathe==4.36.0
 compiledb==0.10.7
 distro==1.9.0
+docstrfmt==2.2.0
 gersemi==0.23.1
 mbake==1.4.3
 mdformat==1.0.0


### PR DESCRIPTION
`make format` will now round-trip format all the RST text files.

Note this requires developers do a `make venv` to get docstrfmt==2.2.0
