### PR TITLE
Fix insertion of expr coverage statement

### DIFF
--- a/src/V3Coverage.cpp
+++ b/src/V3Coverage.cpp
@@ -375,6 +375,8 @@ class CoverageVisitor final : public VNVisitor {
             } else {
                 itemp->addElsesp(stmtp);
             }
+        } else if (AstBegin* const itemp = VN_CAST(nodep, Begin)) {
+            itemp->addStmtsp(stmtp);
         } else {
             nodep->v3fatalSrc("Bad node type");
         }
@@ -776,6 +778,8 @@ class CoverageVisitor final : public VNVisitor {
         // covers the code in that line.)
         VL_RESTORER(m_beginHier);
         VL_RESTORER(m_inToggleOff);
+        VL_RESTORER(m_exprStmtsp);
+        m_exprStmtsp = nodep;
         m_inToggleOff = true;
         if (nodep->name() != "") {
             m_beginHier = m_beginHier + (m_beginHier != "" ? "__DOT__" : "") + nodep->name();

--- a/test_regress/t/t_cover_expr_fork.py
+++ b/test_regress/t/t_cover_expr_fork.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2025 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile(verilator_flags2=['--coverage-expr --binary'])
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_cover_expr_fork.v
+++ b/test_regress/t/t_cover_expr_fork.v
@@ -1,0 +1,28 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain
+// SPDX-FileCopyrightText: 2026 Antmicro
+// SPDX-License-Identifier: CC0-1.0
+
+module t;
+  int cnt = 0;
+  task automatic myTask;
+    fork
+      begin
+        bit x;
+        if (!x) begin
+          cnt++;
+        end
+      end
+    join_none
+  endtask
+
+  initial begin
+    myTask();
+    #1;
+    if (cnt != 1) $stop;
+
+    $write("*-* All Finished *-*\n");
+    $finish;
+  end
+endmodule


### PR DESCRIPTION
Without this fix, the example I've committed as a test was throwing `Can't locate varref scope` internal error, because statements introduced for expression coverage handling were added at the end of the function. They referenced `x` variable, which is defined in an inner scope. This PR fixes such cases by allowing for insertion of these statements also to `begin..end` blocks.