### PR TITLE
Set lifetime of expr coverage variable

### DIFF
--- a/src/V3Coverage.cpp
+++ b/src/V3Coverage.cpp
@@ -824,6 +824,7 @@ class CoverageVisitor final : public VNVisitor {
                     if (pair.second) {
                         varp = new AstVar{fl, VVarType::MODULETEMP, m_exprTempNames.get(frefp),
                                           dtypep};
+                        varp->lifetime(VLifetime::AUTOMATIC_EXPLICIT);
                         pair.first->second = varp;
                         if (m_ftaskp) {
                             varp->funcLocal(true);

--- a/test_regress/t/t_cover_expr_fork.v
+++ b/test_regress/t/t_cover_expr_fork.v
@@ -13,6 +13,9 @@ module t;
         if (!x) begin
           cnt++;
         end
+        if (!$onehot(x)) begin
+          cnt++;
+        end
       end
     join_none
   endtask
@@ -20,7 +23,7 @@ module t;
   initial begin
     myTask();
     #1;
-    if (cnt != 1) $stop;
+    if (cnt != 2) $stop;
 
     $write("*-* All Finished *-*\n");
     $finish;


### PR DESCRIPTION
It sets the lifetime of a variable created for expression coverage. Without that, we get the error about missing lifetime:
```
%Error: Internal Error: t/t_cover_expr_fork.v:16:13: ../V3Fork.cpp:687: Variable's lifetime is unknown                                      
                                                   : ... note: In instance 't'                                                              
   16 |         if (!$onehot(x)) begin                                                                                                      
      |             ^                                                  
```