### PR TITLE
Fix class scope '::' reference through an inherited type parameter

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -256,6 +256,7 @@ Samuel Riedel
 Sean Cross
 Sebastien Van Cauwenberghe
 Secturion
+Sergey Chusov
 Sergey Fedorov
 Sergi Granell
 Seth Pellegrino

--- a/src/V3LinkDot.cpp
+++ b/src/V3LinkDot.cpp
@@ -1013,18 +1013,23 @@ public:
             if (checkUnresolvedRef(VN_CAST(dtypep, RefDType))) return true;
         } else if (const AstParamTypeDType* const paramTypep
                    = VN_CAST(symp->nodep(), ParamTypeDType)) {
-            // ParamTypeDType child may be wrapped in RequireDType or unwrapped
+            // Before V3Param the declared default is in childDTypep (possibly
+            // wrapped in a RequireDType); after V3Param it is consumed and the
+            // bound type is the resolved data type, e.g. a type parameter
+            // inherited from a specialized base class (REQ #(Item) -> class Item).
             AstNode* childp = paramTypep->childDTypep();
             if (const AstRequireDType* const reqp = VN_CAST(childp, RequireDType)) {
                 childp = reqp->lhsp();
             }
-            if (isValidTypeNode(childp)) return true;
-            if (checkUnresolvedRef(VN_CAST(childp, RefDType))) return true;
+            const AstNode* const checkp = childp ? childp : paramTypep->skipRefp();
+            if (isValidTypeNode(checkp)) return true;
+            if (checkUnresolvedRef(VN_CAST(checkp, RefDType))) return true;
         }
         return false;
     }
     VSymEnt* resolveClassOrPackage(VSymEnt* lookSymp, AstClassOrPackageRef* nodep, bool fallback,
-                                   bool classOnly, const string& forWhat) {
+                                   bool classOnly, const string& forWhat,
+                                   bool deferIfUnresolved = false) {
         if (nodep->classOrPackageSkipp()) return getNodeSym(nodep->classOrPackageSkipp());
         VSymEnt* foundp;
         VSymEnt* searchSymp = lookSymp;
@@ -1049,6 +1054,14 @@ public:
         if (foundp) {
             nodep->classOrPackageNodep(foundp->nodep());
             return foundp;
+        }
+        if (deferIfUnresolved) {
+            // Inside a class that extends a parameterized base, the name may be a
+            // type parameter (or other member) inherited from that base, which is
+            // only resolvable once the base is deparameterized by V3Param. Leave the
+            // reference unresolved so the caller defers it; a genuine bad name will
+            // still error in the post-V3Param link pass.
+            return nullptr;
         }
         const string suggest
             = suggestSymFallback(lookSymp, nodep->name(), LinkNodeMatcherClassOrPackage{});
@@ -4752,8 +4765,12 @@ class LinkDotResolveVisitor final : public VNVisitor {
             VL_RESTORER(m_pinSymp);
 
             if (!nodep->classOrPackageSkipp() && nodep->name() != "local::") {
+                // When inside a class that extends a parameterized base, an
+                // unresolved name may be a base-class type parameter that only
+                // becomes available after V3Param; defer rather than error.
+                const bool deferIfUnresolved = m_statep->forPrimary() && m_insideClassExtParam;
                 m_statep->resolveClassOrPackage(m_ds.m_dotSymp, nodep, m_ds.m_dotPos != DP_PACKAGE,
-                                                false, ":: reference");
+                                                false, ":: reference", deferIfUnresolved);
             }
 
             // ClassRef's have pins, so track

--- a/src/V3LinkDot.cpp
+++ b/src/V3LinkDot.cpp
@@ -1055,14 +1055,7 @@ public:
             nodep->classOrPackageNodep(foundp->nodep());
             return foundp;
         }
-        if (deferIfUnresolved) {
-            // Inside a class that extends a parameterized base, the name may be a
-            // type parameter (or other member) inherited from that base, which is
-            // only resolvable once the base is deparameterized by V3Param. Leave the
-            // reference unresolved so the caller defers it; a genuine bad name will
-            // still error in the post-V3Param link pass.
-            return nullptr;
-        }
+        if (deferIfUnresolved) return nullptr;
         const string suggest
             = suggestSymFallback(lookSymp, nodep->name(), LinkNodeMatcherClassOrPackage{});
         nodep->v3error((classOnly ? "Class" : "Package/class")
@@ -4765,9 +4758,6 @@ class LinkDotResolveVisitor final : public VNVisitor {
             VL_RESTORER(m_pinSymp);
 
             if (!nodep->classOrPackageSkipp() && nodep->name() != "local::") {
-                // When inside a class that extends a parameterized base, an
-                // unresolved name may be a base-class type parameter that only
-                // becomes available after V3Param; defer rather than error.
                 const bool deferIfUnresolved = m_statep->forPrimary() && m_insideClassExtParam;
                 m_statep->resolveClassOrPackage(m_ds.m_dotSymp, nodep, m_ds.m_dotPos != DP_PACKAGE,
                                                 false, ":: reference", deferIfUnresolved);

--- a/test_regress/t/t_class_extends_param_scope.py
+++ b/test_regress/t/t_class_extends_param_scope.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2024 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile()
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_class_extends_param_scope.v
+++ b/test_regress/t/t_class_extends_param_scope.v
@@ -1,0 +1,47 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain.
+// SPDX-FileCopyrightText: 2026 Sergey Chusov
+// SPDX-License-Identifier: CC0-1.0
+
+// A factory-like static method, as used by UVM's type_id::create().
+class registry #(type T = int);
+  static function T create();
+    T r = new;
+    return r;
+  endfunction
+endclass
+
+class item;
+  int val;
+  typedef registry#(item) type_id;
+  function new();
+    val = 42;
+  endfunction
+endclass
+
+class seq_base #(type REQ = int, type RSP = REQ);
+  REQ req;
+endclass
+
+// Non-parameterized class extending a parameterized base.
+// REQ is a type parameter inherited from the (specialized) base class and is
+// here used as a '::' class scope: REQ::type_id::create().  Resolving REQ in
+// this position requires deferring until after V3Param has bound REQ to item.
+class seq extends seq_base #(item);
+  function int make();
+    REQ r;
+    r = REQ::type_id::create();
+    return r.val;
+  endfunction
+endclass
+
+module t;
+  seq s;
+  initial begin
+    s = new;
+    if (s.make() != 42) $stop;
+    $write("*-* All Finished *-*\n");
+    $finish;
+  end
+endmodule


### PR DESCRIPTION
Resolving a `::` class-scope reference whose left-hand side is a type parameter inherited from a parameterized base class failed with "Package/class for `:: reference` not found".

A typical example is a non-parameterized sequence class extending `uvm_sequence #(item)` and using `REQ::type_id::create()`.

## Root cause

Two separate issues in `V3LinkDot.cpp`:

**1. `checkIfClassOrPackage()` — post-V3Param node state**

`AstParamTypeDType` holds the declared default in `childDTypep()` before V3Param runs. After V3Param binds the inherited type parameter, `childDTypep()` is consumed (returns `nullptr`) and the resolved type is only accessible via `skipRefp()`. The old code checked only `childDTypep()`, so after deparameterization the check incorrectly returned false ("not a class"), causing a spurious error.

**Fix:** when `childDTypep()` is null, fall back to `paramTypep->skipRefp()` to find the resolved bound type.

**2. `resolveClassOrPackage()` — premature error in primary link pass**

A `::` reference to an inherited type parameter cannot be resolved during the primary link pass, because V3Param has not yet bound the parameter to a concrete type. The old code emitted a hard error immediately on lookup failure.

**Fix:** add an optional `deferIfUnresolved` flag. When the lookup is inside a class that extends a parameterized base (`m_insideClassExtParam`) *and* we are in the primary pass (`forPrimary()`), return `nullptr` instead of erroring. The reference is left unresolved and retried after V3Param. A genuinely unknown name still errors in the post-V3Param link pass.

## Test

`t_class_extends_param_scope`: a minimal `registry #(T)` / `item` / `seq_base #(REQ, RSP)` hierarchy where a non-parameterized
`seq extends seq_base #(item)` calls `REQ::type_id::create()`. Verifies the object is constructed correctly and returns the expected value (42).

Disclosure: developed with the assistance of an AI agent; reviewed, verified, and tested by the human contributor.