### PR TITLE
Fix covergroups without --coverage (#7848)

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -146,6 +146,7 @@ Jose Loyola
 Josep Sans
 Joseph Nwabueze
 Josh Redford
+Joshua Leahy
 Julian Carrier
 Julian Daube
 Julie Schwartz

--- a/include/verilated_covergroup.cpp
+++ b/include/verilated_covergroup.cpp
@@ -14,7 +14,8 @@
 /// \file
 /// \brief Verilated functional-coverage collection runtime implementation
 ///
-/// Compiled and linked when "verilator --coverage" is used with covergroups.
+/// Linked when covergroups are present.  The coverage-database registration
+/// is compiled only with "verilator --coverage".
 ///
 //=============================================================================
 
@@ -22,7 +23,9 @@
 
 #include "verilated_covergroup.h"
 
-#include "verilated_cov.h"
+#if VM_COVERAGE
+# include "verilated_cov.h"
+#endif
 
 void VlCoverpoint::init(const char* hier, uint32_t atLeast, int nBins) {
     m_hier = hier;
@@ -54,6 +57,7 @@ std::string VlCoverpoint::binName(int i) const {
     return name;
 }
 
+#if VM_COVERAGE
 void VlCoverpoint::registerBins(VerilatedCovContext* covcontextp, const char* page) {
     for (int i = 0; i < binCount(); ++i) {
         const VlCovNamer& nm = namerFor(i);
@@ -76,3 +80,4 @@ void VlCoverpoint::registerBins(VerilatedCovContext* covcontextp, const char* pa
         }
     }
 }
+#endif  // VM_COVERAGE

--- a/src/V3EmitCHeaders.cpp
+++ b/src/V3EmitCHeaders.cpp
@@ -683,7 +683,8 @@ class EmitCHeader final : public EmitCConstInit {
         if (v3Global.opt.mtasks()) puts("#include \"verilated_threads.h\"\n");
         if (v3Global.opt.savable()) puts("#include \"verilated_save.h\"\n");
         if (v3Global.opt.coverage()) puts("#include \"verilated_cov.h\"\n");
-        if (v3Global.opt.coverage()) puts("#include \"verilated_covergroup.h\"\n");
+        if (v3Global.opt.coverage() || v3Global.useCovergroup())
+            puts("#include \"verilated_covergroup.h\"\n");
         if (v3Global.usesTiming()) puts("#include \"verilated_timing.h\"\n");
         if (v3Global.useRandomizeMethods()) puts("#include \"verilated_random.h\"\n");
         if (v3Global.usesForce()) puts("#include \"verilated_force.h\"\n");

--- a/src/V3EmitCModel.cpp
+++ b/src/V3EmitCModel.cpp
@@ -70,7 +70,8 @@ class EmitCModel final : public EmitCFunc {
         if (v3Global.opt.mtasks()) puts("#include \"verilated_threads.h\"\n");
         if (v3Global.opt.savable()) puts("#include \"verilated_save.h\"\n");
         if (v3Global.opt.coverage()) puts("#include \"verilated_cov.h\"\n");
-        if (v3Global.opt.coverage()) puts("#include \"verilated_covergroup.h\"\n");
+        if (v3Global.opt.coverage() || v3Global.useCovergroup())
+            puts("#include \"verilated_covergroup.h\"\n");
         if (v3Global.dpi()) puts("#include \"svdpi.h\"\n");
 
         // Declare foreign instances up front to make C++ happy

--- a/src/V3Global.cpp
+++ b/src/V3Global.cpp
@@ -245,7 +245,8 @@ std::vector<std::string> V3Global::verilatedCppFiles() {
     if (v3Global.opt.vpi()) result.emplace_back("verilated_vpi.cpp");
     if (v3Global.opt.savable()) result.emplace_back("verilated_save.cpp");
     if (v3Global.opt.coverage()) result.emplace_back("verilated_cov.cpp");
-    if (v3Global.opt.coverage()) result.emplace_back("verilated_covergroup.cpp");
+    if (v3Global.opt.coverage() || v3Global.useCovergroup())
+        result.emplace_back("verilated_covergroup.cpp");
     for (const string& base : v3Global.opt.traceSourceBases())
         result.emplace_back(base + "_c.cpp");
     if (v3Global.usesProbDist()) result.emplace_back("verilated_probdist.cpp");

--- a/test_regress/t/t_covergroup_cross_no_coverage.py
+++ b/test_regress/t/t_covergroup_cross_no_coverage.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('vlt_all')
+test.top_filename = 't/t_covergroup_cross.v'
+
+# runs without --coverage
+test.compile(verilator_flags2=['--Wno-COVERIGN'])
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_covergroup_option_no_coverage.py
+++ b/test_regress/t/t_covergroup_option_no_coverage.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('vlt')
+test.top_filename = 't/t_covergroup_option.v'
+
+# runs without --coverage
+test.compile(verilator_flags2=['--Wno-COVERIGN'])
+
+test.execute()
+
+test.passes()


### PR DESCRIPTION
First of all, amazing work on adding covergroups to verilator.

Now that covergroups aren't silently discarded they emit code on every build, that works just fine with --coverage, but it seems to introduce a regression if --coverage isn't passed; the covergroups code ends up referencing the coverage system that isn't linked in. One way of solving this would be to just not emit the covergroup code at all, but I think that'll break other systemverilog features like 'get_coverage', so I though the better think to do is to link in the local coverage stuff but not the central databasey thing.

This change fixes the issue, and the regression test I added goes from failing to passing, however feel free to discard my PR and it fix it in a better way. I haven't contributed to verilator before so it's quite possible I've fixed it in the wrong way. However it probably needs to be fixed before 5.049 is cut.