### PR TITLE
Fix clang++ ambiguous overload of '==' operator

### DIFF
--- a/include/verilated_types.h
+++ b/include/verilated_types.h
@@ -24,7 +24,6 @@
 #ifndef VERILATOR_VERILATED_TYPES_H_
 #define VERILATOR_VERILATED_TYPES_H_
 
-#include "verilatedos.h"
 #ifndef VERILATOR_VERILATED_H_INTERNAL_
 #error "verilated_types.h should only be included by verilated.h"
 #endif
@@ -2071,14 +2070,23 @@ struct VlNull final {
         return nullptr;
     }
     template <class T>
-    VL_CONSTEXPR_CXX17 bool operator==(T* ptr) const {
-        return !ptr;
+    bool operator==(T* rhs) const {
+        return !rhs;
     }
     template <class T>
-    VL_CONSTEXPR_CXX17 bool operator==(const T* ptr) const {
-        return !ptr;
+    bool operator==(const T* rhs) const {
+        return !rhs;
     }
 };
+
+template <class T>
+inline bool operator==(T* lhs, VlNull) {
+    return !lhs;
+}
+template <class T>
+inline bool operator==(const T* lhs, VlNull) {
+    return !lhs;
+}
 
 //===================================================================
 // Verilog class reference container

--- a/include/verilated_types.h
+++ b/include/verilated_types.h
@@ -24,6 +24,7 @@
 #ifndef VERILATOR_VERILATED_TYPES_H_
 #define VERILATOR_VERILATED_TYPES_H_
 
+#include "verilatedos.h"
 #ifndef VERILATOR_VERILATED_H_INTERNAL_
 #error "verilated_types.h should only be included by verilated.h"
 #endif
@@ -2069,8 +2070,15 @@ struct VlNull final {
     operator T*() const {
         return nullptr;
     }
+    template <class T>
+    VL_CONSTEXPR_CXX17 bool operator==(T* ptr) const {
+        return !ptr;
+    }
+    template <class T>
+    VL_CONSTEXPR_CXX17 bool operator==(const T* ptr) const {
+        return !ptr;
+    }
 };
-inline bool operator==(const void* ptr, VlNull) { return !ptr; }
 
 //===================================================================
 // Verilog class reference container

--- a/test_regress/t/t_clang_overload.py
+++ b/test_regress/t/t_clang_overload.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2024 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('vlt')
+
+test.compile(verilator_flags2=['--binary', '--timing', '--compiler', 'clang', '-Wno-fatal'])
+
+test.passes()

--- a/test_regress/t/t_clang_overload.py
+++ b/test_regress/t/t_clang_overload.py
@@ -4,13 +4,13 @@
 # This program is free software; you can redistribute it and/or modify it
 # under the terms of either the GNU Lesser General Public License Version 3
 # or the Perl Artistic License Version 2.0.
-# SPDX-FileCopyrightText: 2024 Wilson Snyder
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
 # SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
 
 import vltest_bootstrap
 
 test.scenarios('vlt')
 
-test.compile(verilator_flags2=['--binary', '--timing', '--compiler', 'clang', '-Wno-fatal'])
+test.compile(verilator_flags2=['--binary', '-Wno-WIDTHTRUNC'])
 
 test.passes()

--- a/test_regress/t/t_clang_overload.v
+++ b/test_regress/t/t_clang_overload.v
@@ -1,0 +1,39 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain.
+// SPDX-FileCopyrightText: 2026 Antmicro
+// SPDX-License-Identifier: CC0-1.0
+
+interface irq_if (
+    input logic clk,
+    input logic resetn
+);
+  logic irq;
+  logic te;
+  logic halted;
+  logic fault;
+  logic wfi;
+  clocking cb @(posedge clk);
+    default input #1step output #2ns;
+    output irq;
+    output te;
+    input halted;
+    input fault;
+    input wfi;
+  endclocking
+  modport DUT_IRQ_PORT(input clk, resetn, output halted, fault, wfi);
+endinterface
+class base_test_class;
+  function int foo();
+  endfunction
+  virtual irq_if.DUT_IRQ_PORT irq_vif;
+  function new(string name);
+  endfunction
+  virtual function void build_phase();
+    if (irq_vif == null) begin
+      if (foo()) $display();
+    end
+  endfunction
+endclass
+module tb_top;
+endmodule


### PR DESCRIPTION
This PR fixes an error where clang++ errors due to ambiguous overload of '==' operator.
The error is visible on the minimized testcase.
Reproducible on clang 21.1.7

```cpp
./Vt_clang_overload___024unit__03a__03abase_test_class__Vclpkg__0.cpp:23:19: error: use of overloaded operator '==' is ambiguous (with operand types 'VlNull' and 'Vt_clang_overload_irq_if *')
   23 |     if ((VlNull{} == this->__PVT__irq_vif)) {
      |          ~~~~~~~~ ^  ~~~~~~~~~~~~~~~~~~~~
include/verilated_types.h:2074:13: note: candidate function (with reversed parameter order)
 2074 | inline bool operator==(const void* ptr, VlNull) { return !ptr; }
      |             ^
./Vt_clang_overload___024unit__03a__03abase_test_class__Vclpkg__0.cpp:23:19: note: built-in candidate operator==(class Vt_clang_overload_irq_if *, class Vt_clang_overload_irq_if *)
   23 |     if ((VlNull{} == this->__PVT__irq_vif)) {
      |
```