### PR TITLE
CI: Restore testing of installation relocation

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -263,14 +263,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Ubuntu 24.04 clang
-          - {os: ubuntu-24.04, cc: clang, reloc: 0, suite: dist-vlt-0}
-          - {os: ubuntu-24.04, cc: clang, reloc: 0, suite: dist-vlt-1}
-          - {os: ubuntu-24.04, cc: clang, reloc: 0, suite: dist-vlt-2}
-          - {os: ubuntu-24.04, cc: clang, reloc: 0, suite: dist-vlt-3}
-          - {os: ubuntu-24.04, cc: clang, reloc: 0, suite: vltmt-0}
-          - {os: ubuntu-24.04, cc: clang, reloc: 0, suite: vltmt-1}
-          - {os: ubuntu-24.04, cc: clang, reloc: 0, suite: vltmt-2}
+          # Ubuntu 24.04 clang, also test relocation
+          - {os: ubuntu-24.04, cc: clang, reloc: 1, suite: dist-vlt-0}
+          - {os: ubuntu-24.04, cc: clang, reloc: 1, suite: dist-vlt-1}
+          - {os: ubuntu-24.04, cc: clang, reloc: 1, suite: dist-vlt-2}
+          - {os: ubuntu-24.04, cc: clang, reloc: 1, suite: dist-vlt-3}
+          - {os: ubuntu-24.04, cc: clang, reloc: 1, suite: vltmt-0}
+          - {os: ubuntu-24.04, cc: clang, reloc: 1, suite: vltmt-1}
+          - {os: ubuntu-24.04, cc: clang, reloc: 1, suite: vltmt-2}
 
   test-2204-gcc:
     name: Test | ${{ matrix.os }} | ${{ matrix.cc }} | ${{ matrix.reloc && 'reloc | ' || '' }} ${{ matrix.suite }}


### PR DESCRIPTION
PR #7776 removed Ubuntu 22.04 clang from the test matrix, which was the only one testing the relocation of an installation. Add back under Ubuntu 24.04 clang.
