### PR TITLE
CI: Cleanup Windows build

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -101,32 +101,19 @@ jobs:
   build-windows:
     name: Build | windows-2025-vs2026 | msvc
     runs-on: windows-2025-vs2026
-    env:
-      CCACHE_COMPRESS: 1
-      CCACHE_DIR: ${{ github.workspace }}/.ccache
-      CCACHE_LIMIT_MULTIPLE: 0.95
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7
         with:
           path: repo
-      - name: Cache $CCACHE_DIR
+      - name: Cache win_flex_bison
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v5
         with:
-          path: ${{ env.CCACHE_DIR }}
-          key: msbuild-msvc-cmake
+          path: ${{ github.workspace }}/win_flex_bison
+          key: win_flex_bison
       - name: compile
-        env:
-          WIN_FLEX_BISON: ${{ github.workspace }}/.ccache
         run: ./ci/ci-win-compile.ps1
       - name: test build
         run: ./ci/ci-win-test.ps1
-      - name: Zip up repository
-        run: Compress-Archive -LiteralPath install -DestinationPath verilator.zip
-      - name: Upload zip archive
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
-        with:
-          path: ${{ github.workspace }}/repo/verilator.zip
-          name: verilator-win.zip
 
   test-2604-gcc:
     name: Test | ${{ matrix.os }} | ${{ matrix.cc }} | ${{ matrix.suite }}

--- a/ci/ci-win-compile.ps1
+++ b/ci/ci-win-compile.ps1
@@ -6,19 +6,33 @@
 
 Set-PSDebug -Trace 1
 
-if (-Not (Test-Path $PWD/../.ccache/win_bison.exe)) {
+$NPROC = $env:NUMBER_OF_PROCESSORS
+
+# Absolute path for the win_flex_bison install; CMake reads this from the environment
+$env:WIN_FLEX_BISON = "$(Resolve-Path ..)/win_flex_bison"
+
+if (-Not (Test-Path $env:WIN_FLEX_BISON/win_bison.exe)) {
     git clone --depth 1 https://github.com/lexxmark/winflexbison
     cd winflexbison
     mkdir build
     cd build
-    cmake .. --install-prefix $PWD/../../../.ccache
-    cmake --build . --config Release -j 3
-    cmake --install . --prefix $PWD/../../../.ccache
+    cmake .. --install-prefix $env:WIN_FLEX_BISON
+    cmake --build . --config Release -j $NPROC
+    cmake --install . --prefix $env:WIN_FLEX_BISON
     cd ../..
 }
 
+# Enter the MSVC developer shell so cl/link are on PATH for the Ninja generator
+$VsPath = & "${env:ProgramFiles(x86)}/Microsoft Visual Studio/Installer/vswhere.exe" -latest -products * -property installationPath
+Import-Module "$VsPath/Common7/Tools/Microsoft.VisualStudio.DevShell.dll"
+Enter-VsDevShell -VsInstallPath $VsPath -SkipAutomaticLocation -DevCmdArguments "-arch=x64 -host_arch=x64"
+
 mkdir build
 cd build
-cmake .. --install-prefix $PWD/../install
-cmake --build . --config Release -j 3
+# Ninja saturates all cores; the MSBuild generator only parallelizes across
+# projects and Verilator is a single target, so it compiles serially. /Od skips
+# optimization: this job only checks that Verilator builds and can verilate an
+# example, so an optimized binary is not needed and the codegen time dominates.
+cmake .. -G Ninja -DCMAKE_BUILD_TYPE=Release --install-prefix $PWD/../install "-DCMAKE_CXX_FLAGS_RELEASE=/Od /DNDEBUG"
+cmake --build .
 cmake --install . --prefix $PWD/../install

--- a/ci/ci-win-test.ps1
+++ b/ci/ci-win-test.ps1
@@ -7,13 +7,17 @@
 
 Set-PSDebug -Trace 1
 
+$NPROC = $env:NUMBER_OF_PROCESSORS
+
 cd install
 $Env:VERILATOR_ROOT=$PWD
 cd examples/cmake_tracing_c
 mkdir build
 cd build
-cmake ..
-cmake --build . --config Release -j 3
+# /Od skips optimization; this only checks the example verilates and builds, so
+# an optimized binary is not needed (see ci-win-compile.ps1).
+cmake .. "-DCMAKE_CXX_FLAGS_RELEASE=/Od /DNDEBUG"
+cmake --build . --config Release -j $NPROC
 
 # TODO put this back in, see issue# 5163
 # Release/example.exe


### PR DESCRIPTION
The Windows build never actually used ccache; the '.ccache' directory only ever held the win_flex_bison install, and cmake/MSVC did no compiler caching. Clean this up:

- Drop the CCACHE_* environment variables from the job (meaningless here).
- Store win_flex_bison in a dedicated 'win_flex_bison' directory instead of the misleadingly named '.ccache', and cache just that (static key, as it is a fixed third-party tool).
- Set WIN_FLEX_BISON inside ci-win-compile.ps1 as an absolute path, rather than in the workflow, making the script self-contained.
- Use the runner's processor count for build parallelism instead of a fixed '-j 3', in both ci-win-compile.ps1 and ci-win-test.ps1.
- Remove the verilator-win.zip archive and upload steps; nothing consumes that artifact.
