### PR TITLE
Fix range delays with parameter bounds

### DIFF
--- a/src/V3AssertNfa.cpp
+++ b/src/V3AssertNfa.cpp
@@ -461,8 +461,8 @@ class SvaNfaBuilder final {
     AstVar* tryHoistSampled(AstNodeExpr* exprp, FileLine* flp, int cloneCount) {
         constexpr int kHoistThreshold = 2;
         if (cloneCount < kHoistThreshold) return nullptr;
-        AstVar* const tempVarp = new AstVar{flp, VVarType::MODULETEMP, m_propTempNames.get(exprp),
-                                            m_modp->findBitDType()};
+        AstVar* const tempVarp
+            = new AstVar{flp, VVarType::MODULETEMP, m_propTempNames.get(exprp), exprp->dtypep()};
         m_modp->addStmtsp(tempVarp);
         AstAssign* const assignp = new AstAssign{flp, new AstVarRef{flp, tempVarp, VAccess::WRITE},
                                                  sampled(exprp->cloneTreePure(false))};

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -731,6 +731,17 @@ class WidthVisitor final : public VNVisitor {
         iterateCheckBool(nodep, "default disable iff condition", nodep->condp(), BOTH);
     }
     void visit(AstDelay* nodep) override {
+        if (nodep->isCycleDelay() && m_underSExpr) {
+            // Fold parameterized SVA cycle-delay bounds
+            userIterateAndNext(nodep->lhsp(), WidthVP{SELF, BOTH}.p());
+            V3Const::constifyParamsNoWarnEdit(nodep->lhsp());
+            if (nodep->rhsp() && !nodep->isUnbounded()) {
+                // Fold parametrized SVA cycle-delay max bound
+                userIterateAndNext(nodep->rhsp(), WidthVP{SELF, BOTH}.p());
+                V3Const::constifyParamsNoWarnEdit(nodep->rhsp());
+            }
+            return;
+        }
         if (AstNodeExpr* const fallDelayp = nodep->fallDelay()) {
             iterateCheckDelay(nodep, "delay", nodep->lhsp(), BOTH);
             iterateCheckDelay(nodep, "delay", fallDelayp, BOTH);

--- a/test_regress/t/t_property_sexpr_range_delay.v
+++ b/test_regress/t/t_property_sexpr_range_delay.v
@@ -13,6 +13,8 @@
 module t (
     input clk
 );
+  parameter P = 1;
+
   integer cyc = 0;
   reg [63:0] crc = '0;
   reg [63:0] sum = '0;
@@ -63,6 +65,11 @@ module t (
   // Basic ##[1:3] range delay
   assert property (@(posedge clk) disable iff (cyc < 2)
       a |-> ##[1:3] (a | b | c | d | e));
+
+  // Parameterized range bound
+  assert property (@(posedge clk) disable iff (cyc < 2)
+      a |-> ##[P:P+3] (a | b | c | d | e));
+  assert property (@(posedge clk) ##[P:P+3] 1);
 
   // ##[2:4] range delay
   assert property (@(posedge clk) disable iff (cyc < 2)


### PR DESCRIPTION
Fixes an error in the following snippet:
```verilog
module m #(
    parameter P = 1
);
  assert property (@(posedge 1) ##[P:P+3] 1);
endmodule
```
`getConstInt()` used by V3AssertNfa for reading SVA delay bounds only ran plain constant folding. For parametrized bounds such as `##[P:P+3]`, the parameter reference was not substituted, so the NFA builder treated it as non-constant and reported a bogus range error: `Range delay maximum must be >= minimum (IEEE 1800-2023 16.7)`.

Constify parameter expressions for `AstDelay` cycle-delay bounds in V3Width.

Also preserve the dtype of `$sampled` expressions - this repro uses an unsized constant `1`, which triggered DFG width checks due to incorrect width.