### PR TITLE
CI: Disable ccache on coverage jobs

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -71,10 +71,12 @@ jobs:
           # behind 'verilator --version'
           fetch-depth: ${{ (inputs.install || inputs.dev-gcov) && '0' || '1' }}
 
-      # ccache is unreliable on the macOS runners; disable it there
-      - name: Disable ccache on macOS
-        if: ${{ startsWith(inputs.runs-on, 'macos') }}
-        run: echo "CCACHE_DISABLE=1" >> "$GITHUB_ENV"
+      - name: Configure ccache
+        run: |
+          # ccache is unreliable on macOS, and does nothing with 'gcc --coverage'
+          if [ "${{ startsWith(inputs.runs-on, 'macos') }}" = true ] || [ "${{ inputs.dev-gcov }}" = true ]; then
+            echo "CCACHE_DISABLE=1" >> "$GITHUB_ENV"
+          fi
 
       - name: Cache $CCACHE_DIR
         if: ${{ env.CCACHE_DISABLE != '1' }}

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -67,9 +67,17 @@ jobs:
           tar --zstd -x -f ${{ inputs.archive }}
           ls -lsha
 
+      - name: Configure ccache
+        run: |
+          # ccache is unreliable on macOS, and does nothing with 'gcc --coverage'
+          if [ "${{ startsWith(inputs.runs-on, 'macos') }}" = true ] || [ "${{ inputs.dev-gcov }}" = true ]; then
+            echo "CCACHE_DISABLE=1" >> "$GITHUB_ENV"
+          fi
+
       # Test-job ccache is stored as an artifact, not actions/cache
       - name: Restore ccache
         id: ccache
+        if: ${{ env.CCACHE_DISABLE != '1' }}
         uses: ./repo/.github/actions/artifact-cache
         with:
           mode: restore
@@ -109,7 +117,7 @@ jobs:
           name: code-coverage-${{ inputs.suite }}
 
       - name: Save ccache
-        if: ${{ !cancelled() }}
+        if: ${{ env.CCACHE_DISABLE != '1' && !cancelled() }}
         uses: ./repo/.github/actions/artifact-cache
         with:
           mode: save


### PR DESCRIPTION
gcc --coverage is unsupported by ccache and results in a bypass. Don't save unnecessary caches.
