### PR TITLE
Fix $display accepting streaming concat arguments

### DIFF
--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -8567,6 +8567,10 @@ class WidthVisitor final : public VNVisitor {
                 ch = std::tolower(ch);
                 switch (ch) {
                 case '?':  // Unspecified by user, guess
+                    if (VN_IS(subargp, StreamL) || VN_IS(subargp, StreamR)) {
+                        subargp->v3error("Streaming concatenation cannot be used as an implicit "
+                                         "$display-like argument.");
+                    }
                     if (dtypep->isDouble()) {
                         ch = 'g';
                     } else if (dtypep->isString()) {

--- a/test_regress/t/t_display_stream_bad.out
+++ b/test_regress/t/t_display_stream_bad.out
@@ -1,0 +1,6 @@
+%Error: t/t_display_stream_bad.v:11:15: Streaming concatenation cannot be used as an implicit $display-like argument.
+                                      : ... note: In instance 't'
+   11 |     $display({<<{value}});
+      |               ^~
+        ... See the manual at https://verilator.org/verilator_doc.html?v=latest for more assistance.
+%Error: Exiting due to

--- a/test_regress/t/t_display_stream_bad.py
+++ b/test_regress/t/t_display_stream_bad.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('linter')
+
+test.lint(fails=True, expect_filename=test.golden_filename)
+
+test.passes()

--- a/test_regress/t/t_display_stream_bad.v
+++ b/test_regress/t/t_display_stream_bad.v
@@ -1,0 +1,13 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain.
+// SPDX-FileCopyrightText: 2026 Wilson Snyder
+// SPDX-License-Identifier: CC0-1.0
+
+module t;
+  int value = 1;
+
+  initial begin
+    $display({<<{value}});
+  end
+endmodule


### PR DESCRIPTION
Fixes #7663.

This rejects streaming concatenations when they are passed as implicit `$display`-like arguments, while leaving explicit formatted uses such as `%x` unchanged.

A new lint regression covers the rejected implicit argument path.

Verification:
- `make -j20`
- `make format`
- `make lint-py`
- `make cppcheck`
- `test_regress/t/t_display_stream_bad.py`
- `test_regress/t/t_stream_queue.py`
- `test_regress/t/t_stream.py`
- `test_regress/t/t_display_string.py`

Before the fix, the new regression failed because Verilator accepted the invalid `$display({<<{value}})` call.
