### PR TITLE
Fix dynamic array assignment to unpacked arrays (#6907)

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -110,6 +110,7 @@ Ilya Barkov
 Iru Cai
 Ivan Vnučec
 Iztok Jeras
+Jaeuk Lee
 Jake Merdich
 Jakub Michalski
 Jakub Wasilewski

--- a/include/verilated_funcs.h
+++ b/include/verilated_funcs.h
@@ -3090,13 +3090,9 @@ static inline void VL_REVCOPY_Q(VlQueue<T>& q, const VlUnpacked<T, N_Depth>& fro
 template <typename T, std::size_t N_Depth>
 static inline void VL_COPY_Q(VlUnpacked<T, N_Depth>& q, const VlQueue<T>& from, int lbits,
                              int srcElementBits, int dstElementBits) {
-    if (srcElementBits == dstElementBits) {
-        for (size_t i = 0; i < N_Depth; ++i) q[i] = from.at(static_cast<int32_t>(i));
-    } else {
-        VlQueue<T> tmpQ;
-        VL_COPY_Q(tmpQ, from, lbits, srcElementBits, dstElementBits);
-        for (size_t i = 0; i < N_Depth; ++i) q[i] = tmpQ.at(static_cast<int32_t>(i));
-    }
+    VlQueue<T> tmpQ;
+    VL_COPY_Q(tmpQ, from, lbits, srcElementBits, dstElementBits);
+    for (size_t i = 0; i < N_Depth; ++i) q[i] = tmpQ.at(static_cast<int32_t>(i));
 }
 
 template <typename T, std::size_t N_Depth>

--- a/include/verilated_funcs.h
+++ b/include/verilated_funcs.h
@@ -3086,6 +3086,27 @@ static inline void VL_REVCOPY_Q(VlQueue<T>& q, const VlUnpacked<T, N_Depth>& fro
     VL_COPY_Q(q, srcQ, lbits, srcElementBits, dstElementBits);
 }
 
+// Overloads for VlQueue source -> VlUnpacked destination
+template <typename T, std::size_t N_Depth>
+static inline void VL_COPY_Q(VlUnpacked<T, N_Depth>& q, const VlQueue<T>& from, int lbits,
+                             int srcElementBits, int dstElementBits) {
+    if (srcElementBits == dstElementBits) {
+        for (size_t i = 0; i < N_Depth; ++i) q[i] = from.at(static_cast<int32_t>(i));
+    } else {
+        VlQueue<T> tmpQ;
+        VL_COPY_Q(tmpQ, from, lbits, srcElementBits, dstElementBits);
+        for (size_t i = 0; i < N_Depth; ++i) q[i] = tmpQ.at(static_cast<int32_t>(i));
+    }
+}
+
+template <typename T, std::size_t N_Depth>
+static inline void VL_REVCOPY_Q(VlUnpacked<T, N_Depth>& q, const VlQueue<T>& from, int lbits,
+                                int srcElementBits, int dstElementBits) {
+    VlQueue<T> tmpQ;
+    VL_REVCOPY_Q(tmpQ, from, lbits, srcElementBits, dstElementBits);
+    for (size_t i = 0; i < N_Depth; ++i) q[i] = tmpQ.at(static_cast<int32_t>(i));
+}
+
 //======================================================================
 // Expressions needing insert/select
 

--- a/src/V3Slice.cpp
+++ b/src/V3Slice.cpp
@@ -247,6 +247,7 @@ class SliceVisitor final : public VNVisitor {
         const AstUnpackArrayDType* const arrayp = VN_CAST(dtp, UnpackArrayDType);
         if (!arrayp) return false;
         if (VN_IS(stp, CvtPackedToArray)) return false;
+        if (VN_IS(stp, CvtArrayToArray)) return false;
         if (VN_IS(stp, CReset)) return false;
 
         // Any isSc variables must be expanded regardless of --fno-slice

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -6439,6 +6439,7 @@ class WidthVisitor final : public VNVisitor {
             }
 
             iterateCheckAssign(nodep, "Assign RHS", nodep->rhsp(), FINAL, lhsDTypep);
+            convertArrayToUnpackedAssign(nodep);
             // UINFOTREE(1, nodep, "", "AssignOut");
         }
         if (VN_IS(nodep, AssignForce)) checkForceReleaseLhs(nodep, nodep->lhsp());
@@ -6559,6 +6560,30 @@ class WidthVisitor final : public VNVisitor {
         UASSERT_OBJ(nodep->lhsp()->dtypep(), nodep, "L-value is untyped");
         UASSERT_OBJ(nodep->lhsp()->dtypep()->widthSized(), nodep, "L-value width is unsized");
         checkForceReleaseLhs(nodep, nodep->lhsp());
+    }
+
+    static void convertArrayToUnpackedAssign(AstNodeAssign* nodep) {
+        AstNodeDType* const lhsDTypep = nodep->lhsp()->dtypep()->skipRefp();
+        if (!VN_IS(lhsDTypep, UnpackArrayDType)) return;
+
+        AstNodeExpr* const rhsp = nodep->rhsp();
+        AstNodeDType* const rhsDTypep = rhsp->dtypep()->skipRefp();
+        if (!VN_IS(rhsDTypep, DynArrayDType) && !VN_IS(rhsDTypep, QueueDType)) return;
+
+        int srcElementBits = 1;
+        if (const AstNodeDType* const elemDtp = rhsDTypep->subDTypep()->skipRefp()) {
+            srcElementBits = elemDtp->width();
+        }
+        int dstElementBits = 1;
+        if (const AstNodeDType* const elemDtp = lhsDTypep->subDTypep()->skipRefp()) {
+            dstElementBits = elemDtp->width();
+        }
+
+        rhsp->unlinkFrBack();
+        AstCvtArrayToArray* const newp = new AstCvtArrayToArray{
+            rhsp->fileline(), rhsp, lhsDTypep, false, 1, dstElementBits, srcElementBits};
+        newp->didWidth(true);
+        nodep->rhsp(newp);
     }
 
     static bool isFormatNonNumericArg(const AstNodeDType* dtypep) {

--- a/test_regress/t/t_dynarray.v
+++ b/test_regress/t/t_dynarray.v
@@ -27,6 +27,7 @@ module t (
   byte_t a[];
   byte_t b[];
   byte_t fixed[256];
+  byte_t fixed_desc[255:0];
   byte_t fixed_rev[1:256];
   byte_t q[$];
 
@@ -172,6 +173,12 @@ module t (
       fixed = q;
       `checkh(fixed[0], 8'h40);
       `checkh(fixed[255], 8'h3f);
+      fixed_desc = a;
+      `checkh(fixed_desc[255], 8'h9f);
+      `checkh(fixed_desc[0], 8'ha0);
+      fixed_desc = q;
+      `checkh(fixed_desc[255], 8'h3f);
+      `checkh(fixed_desc[0], 8'h40);
       fixed_rev = a;
       `checkh(fixed_rev[1], 8'ha0);
       `checkh(fixed_rev[256], 8'h9f);

--- a/test_regress/t/t_dynarray.v
+++ b/test_regress/t/t_dynarray.v
@@ -26,6 +26,9 @@ module t (
   typedef bit [7:0] byte_t;
   byte_t a[];
   byte_t b[];
+  byte_t fixed[256];
+  byte_t fixed_rev[1:256];
+  byte_t q[$];
 
   // wide data array
   typedef struct packed {
@@ -156,6 +159,26 @@ module t (
 
       p256.delete();
       `checkh(p256.size, 0);
+
+      // Test assignment from dynamic and queue arrays to fixed unpacked arrays.
+      a = new[256];
+      for (int j = 0; j < 256; j++) begin
+        a[j] = byte_t'(j + 32'ha0);
+        q.push_back(byte_t'(j + 32'h40));
+      end
+      fixed = a;
+      `checkh(fixed[0], 8'ha0);
+      `checkh(fixed[255], 8'h9f);
+      fixed = q;
+      `checkh(fixed[0], 8'h40);
+      `checkh(fixed[255], 8'h3f);
+      fixed_rev = a;
+      `checkh(fixed_rev[1], 8'ha0);
+      `checkh(fixed_rev[256], 8'h9f);
+      fixed_rev = q;
+      `checkh(fixed_rev[1], 8'h40);
+      `checkh(fixed_rev[256], 8'h3f);
+      q.delete();
 
     end
 


### PR DESCRIPTION
Fixes #6907.

This keeps fixed unpacked array assignments from trying to slice dynamic array and queue RHS values, and emits the existing array conversion path backed by VlQueue-to-VlUnpacked copy helpers.

Tests:
- VERILATOR_ROOT=$PWD test_regress/t/t_dynarray.py
- VERILATOR_ROOT=$PWD test_regress/t/t_queue_assignment.py
- VERILATOR_ROOT=$PWD test_regress/t/t_unpacked_to_queue.py
- VERILATOR_ROOT=$PWD test_regress/t/t_stream_queue.py
- VERILATOR_ROOT=$PWD test_regress/t/t_stream_dynamic.py
- make -j20
- make format
- make cppcheck
- make lint-py