### PR TITLE
Fix memory leak in VerilatedFst::close()

### DIFF
--- a/include/verilated_fst_c.cpp
+++ b/include/verilated_fst_c.cpp
@@ -98,8 +98,10 @@ void VerilatedFst::close() VL_MT_SAFE_EXCLUDES(m_mutex) {
     const VerilatedLockGuard lock{m_mutex};
     Super::closeBase();
     emitTimeChangeMaybe();
-    if (m_fst) m_fst->close();  // LCOV_EXCL_BR_LINE
-    m_fst = nullptr;
+    if (m_fst) {
+        m_fst->close();
+        VL_DO_CLEAR(delete m_fst, m_fst = nullptr);
+    }
 }
 
 void VerilatedFst::flush() VL_MT_SAFE_EXCLUDES(m_mutex) {


### PR DESCRIPTION
`VerilatedFst::close()` assigns `nullptr` to `m_fst` without freeing it first. This leak can be reproduced on, I think, everything that uses `--trace-fst`. For example:
```
$ ./test_regress/t/t_param_x_unique.py --runtime-debug
[...]
SUMMARY: AddressSanitizer: 17587 byte(s) leaked in 6 allocation(s).
%Warning: vlt/t_param_x_unique: Exec of obj_vlt/t_param_x_unique/Vt_param_x_unique failed: ==92536==ERROR: LeakSanitizer: detected memory leaks
vlt/t_param_x_unique: %Error: Exec of obj_vlt/t_param_x_unique/Vt_param_x_unique failed: ==92536==ERROR: LeakSanitizer: detected memory leaks
vlt/t_param_x_unique: FAILED: Exec of obj_vlt/t_param_x_unique/Vt_param_x_unique failed: ==92536==ERROR: LeakSanitizer: detected memory leaks
==SUMMARY: Passed 0  Failed 1  Time 0:00

```