### PR TITLE
CI: Don't skip on format

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -52,6 +52,6 @@ jobs:
       - name: Push
         run: |-
           if [ -n "$(git status --porcelain)" ]; then
-            git commit . -m "Apply 'make format' [ci skip]" &&
+            git commit . -m "Apply 'make format'" &&
             git push origin
           fi


### PR DESCRIPTION
@wsnyder not sure what was the intent with this, but it disables CI if someone raises a PR after the format was applied on their branch. Now that cached builds are <10m, probably non need?