### PR TITLE
Fix force/release test, make it as in spec and enable $stop

### DIFF
--- a/test_regress/t/t_force_release.py
+++ b/test_regress/t/t_force_release.py
@@ -11,7 +11,7 @@ import vltest_bootstrap
 
 test.scenarios('simulator')
 
-test.compile(verilator_flags2=["--binary"])
+test.compile(verilator_flags2=["--binary", "-Wno-IEEEMAYDEPRECATE"])
 
 test.execute()
 

--- a/test_regress/t/t_force_release.v
+++ b/test_regress/t/t_force_release.v
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: CC0-1.0
 
 // verilog_format: off
-`define stop  // TODO
+`define stop $stop
 `define checkh(gotv,expv) do if ((gotv) !== (expv)) begin $write("%%Error: %s:%0d:  got='h%x exp='h%x\n", `__FILE__,`__LINE__, (gotv), (expv)); `stop; end while(0)
 // verilog_format: on
 
@@ -14,11 +14,12 @@
 module t;
   logic a, b, c, d;
   wire e;
+
   and and1 (e, a, b, c);
 
   initial begin
     $monitor("%d d=%b,e=%b", $stime, d, e);
-    d = a & b & c;
+    assign d = a & b & c;
     a = 1;
     b = 0;
     c = 1;


### PR DESCRIPTION
This test was not as in spec (procedural assignment instead of `assign` procedural continuous, also missing newline) and not asserting success, whereas it actually passes since merging the full support for force/release.