### PR TITLE
Declare VL_TO_STRING function for array of structs

### DIFF
--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -6616,7 +6616,13 @@ class WidthVisitor final : public VNVisitor {
             } else if (dtypep->isString()) {
                 formatAttr = VFormatAttr::STRING;
             } else if (isFormatNonNumericArg(dtypep)) {
-                if (AstVarRef* const varRefp = VN_CAST(argp, VarRef)) {
+                const AstNodeExpr* formatTypeArgp = argp;
+                if (const AstCMethodHard* const cmethp = VN_CAST(formatTypeArgp, CMethodHard)) {
+                    if (cmethp->method() == VCMethod::ARRAY_AT) formatTypeArgp = cmethp->fromp();
+                } else if (const AstArraySel* const arselp = VN_CAST(formatTypeArgp, ArraySel)) {
+                    formatTypeArgp = arselp->fromp();
+                }
+                if (const AstVarRef* const varRefp = VN_CAST(formatTypeArgp, VarRef)) {
                     if (AstClassRefDType* const classRefp
                         = VN_CAST(varRefp->dtypep(), ClassRefDType)) {
                         if (classRefp->classp()) {

--- a/test_regress/t/t_sys_sformat.v
+++ b/test_regress/t/t_sys_sformat.v
@@ -43,10 +43,17 @@ module t (
   int mem[2] = '{1, 2};
   string s;
 
+  typedef struct{
+    integer dummy;
+  } test_struct_t;
+
+  test_struct_t structs[1];
+
   initial begin
     n = 4'b1100;
     q = 64'h1234_5678_abcd_0123;
     wide = "hello-there12345";
+
     $sformat(str, "n=%b q=%d w=%s", n, q, wide);
     `checks(str, "n=1100 q= 1311768467750060323 w=hello-there12345");
 
@@ -134,6 +141,11 @@ module t (
     `checks(s, "constified");
 
     $display(mem);  // Implied %p
+
+    structs[0].dummy = 0;
+
+    s = $sformatf("%p", structs[0]);
+    `checks(s, "'{dummy:'h0}");
 
     $write("*-* All Finished *-*\n");
     $finish;


### PR DESCRIPTION
Currently when parsing an array of structs in `V3Width` we're not creating designated `VL_TO_STRING` function for struct when it's only used in an array. This happens, because when we encounter non numeric argument for `$sformatf` we only check if it is a class or a struct, so we were skipping generation of `VL_TO_STRING` function if argument was a dereference of an array. To fix this I've added a code that checks if an argument is dereference of an array, if it is, create designated `VL_TO_STRING` function.