### PR TITLE
Fix randomization of bounded queues

### DIFF
--- a/include/verilated_random.h
+++ b/include/verilated_random.h
@@ -377,12 +377,12 @@ public:
     }
 
     // Register queue of non-struct types
-    template <typename T>
+    template <typename T, size_t N_MaxSize>
     typename std::enable_if<!VlContainsCustomStruct<T>::value, void>::type
-    write_var(VlQueue<T>& var, int width, const char* name, int dimension,
+    write_var(VlQueue<T, N_MaxSize>& var, int width, const char* name, int dimension,
               std::uint32_t randmodeIdx = std::numeric_limits<std::uint32_t>::max()) {
         if (m_vars.find(name) == m_vars.end()) {
-            m_vars[name] = std::make_shared<const VlRandomArrayVarTemplate<VlQueue<T>>>(
+            m_vars[name] = std::make_shared<const VlRandomArrayVarTemplate<VlQueue<T, N_MaxSize>>>(
                 name, width, &var, dimension, randmodeIdx);
         }
         if (dimension > 0) {
@@ -394,9 +394,9 @@ public:
     }
 
     // Register queue of structs
-    template <typename T>
+    template <typename T, size_t N_MaxSize>
     typename std::enable_if<VlContainsCustomStruct<T>::value, void>::type
-    write_var(VlQueue<T>& var, int width, const char* name, int dimension,
+    write_var(VlQueue<T, N_MaxSize>& var, int width, const char* name, int dimension,
               std::uint32_t randmodeIdx = std::numeric_limits<std::uint32_t>::max()) {
         if (dimension > 0) record_struct_arr(var, name, dimension, {}, {});
     }
@@ -488,8 +488,8 @@ public:
     }
 
     // Recursively record all elements in a queue
-    template <typename T>
-    void record_arr_table(VlQueue<T>& var, const std::string& name, int dimension,
+    template <typename T, size_t N_MaxSize>
+    void record_arr_table(VlQueue<T, N_MaxSize>& var, const std::string& name, int dimension,
                           std::vector<IData> indices, std::vector<size_t> idxWidths) {
         if ((dimension > 0) && (var.size() != 0)) {
             idxWidths.push_back(32);
@@ -562,8 +562,8 @@ public:
     }
 
     // Recursively process VlQueue of structs
-    template <typename T>
-    void record_struct_arr(VlQueue<T>& var, const std::string& name, int dimension,
+    template <typename T, size_t N_MaxSize>
+    void record_struct_arr(VlQueue<T, N_MaxSize>& var, const std::string& name, int dimension,
                            std::vector<IData> indices, std::vector<size_t> idxWidths) {
         if ((dimension > 0) && (var.size() != 0)) {
             idxWidths.push_back(32);

--- a/test_regress/t/t_randomize_queue_constraints.v
+++ b/test_regress/t/t_randomize_queue_constraints.v
@@ -24,10 +24,12 @@ end
 
 class Foo;
   rand int m_intQueue[$];
+  rand int m_intQueueSized[$:9];
   rand int m_idx;
 
   function new;
     m_intQueue = '{10{0}};
+    m_intQueueSized = '{10{0}};
   endfunction
 
   constraint int_queue_c {
@@ -35,6 +37,13 @@ class Foo;
     m_intQueue[m_idx] == m_idx + 1;
     foreach (m_intQueue[i]) {
       m_intQueue[i] inside {[0:127]};
+    }
+  }
+  constraint int_queue_sized_c {
+    m_idx inside {[0:9]};
+    m_intQueueSized[m_idx] == m_idx + 1;
+    foreach (m_intQueueSized[i]) {
+      m_intQueueSized[i] inside {[0:127]};
     }
   }
 endclass
@@ -47,6 +56,12 @@ module t_randomize_queue_constraints;
     $display("Queue: %p", foo.m_intQueue);
     `check_rand(foo, foo.m_intQueue[3], foo.m_intQueue[5] inside {[0:127]});
     $display("Queue: %p", foo.m_intQueue);
+
+    `check_rand(foo, foo.m_idx, foo.m_idx inside {[0:9]} && foo.m_intQueueSized[foo.m_idx] == foo.m_idx + 1);
+    $display("Queue: %p", foo.m_intQueueSized);
+    `check_rand(foo, foo.m_intQueueSized[3], foo.m_intQueueSized[5] inside {[0:127]});
+    $display("Queue: %p", foo.m_intQueueSized);
+
     $write("*-* All Finished *-*\n");
     $finish;
   end


### PR DESCRIPTION
Added `size_t N_MaxSize` template specialization to `VlRandomizer` methods containing `VlQueue` to allow for a bounded `VlQueue` to fall into the same template specialization as a unbounded `VlQueue`.

Previously they would fall into a general case template specialization (as `VlQueue<T, N_MaxSize>` with `N_MaxSize > 0` were treated differently than the default `N_MaxSize = 0`), which did not record the array table for the solver.

This issue later resulted in errors within verilog-SMT solver comunication. 
```
%Warning: include/verilated_random.cpp:788: Internal: Solver error: (error "line 25 column 54: select requires 1 arguments, but was provided with 2 arguments")
%Warning: include/verilated_random.cpp:788: Internal: Solver error: (error "line 26 column 70: select requires 1 arguments, but was provided with 2 arguments")
%Error: issue.sv:55: Verilog $stop
Aborting...
```