### PR TITLE
Fix scheduling of variables written in non-inlined functions in suspendable processes - optimized

### DIFF
--- a/src/V3SchedTiming.cpp
+++ b/src/V3SchedTiming.cpp
@@ -26,10 +26,12 @@
 
 #include "V3PchAstNoMT.h"  // VL_MT_DISABLED_CODE_UNIT
 
+#include "V3AstUserAllocator.h"
 #include "V3EmitCBase.h"
 #include "V3Sched.h"
 
 #include <unordered_map>
+#include <unordered_set>
 
 VL_DEFINE_DEBUG_FUNCTIONS;
 
@@ -179,7 +181,8 @@ AstCCall* TimingKit::createReady(AstNetlist* const netlistp) {
 
 class AwaitVisitor final : public VNVisitor {
     // NODE STATE
-    //  AstSenTree::user1()  -> bool.  Set true if the sentree has been visited.
+    //  AstSenTree::user1()  -> bool.               Set true if the sentree has been visited.
+    //  AstCFunc::user1()    -> AstUser1Allocator.  See alocator below
     const VNUser1InUse m_inuser1;
 
     // STATE
@@ -192,7 +195,34 @@ class AwaitVisitor final : public VNVisitor {
     std::map<const AstVarScope*, std::set<AstSenTree*>>& m_externalDomains;
     std::set<AstSenTree*> m_processDomains;  // Sentrees from the current process
     // Variables written by suspendable processes
-    std::vector<AstVarScope*> m_writtenBySuspendable;
+    std::set<AstVarScope*> m_writtenBySuspendable;
+    struct CFuncCache final {
+        std::set<AstSenTree*> m_processDomains;  // What shall be added to m_processDomains
+        std::set<AstVarScope*>
+            m_writtenBySuspendable;  // What shall be added to m_writtenBySuspendable
+        std::set<AstCFunc*> m_includes;  // CFuncs whose CFuncCache shall be included into this
+        // m_includes does not need to keep bool with m_gatherVars to know which cache shall be
+        // used since:
+        //  Only possible transition in a graph is from `!m_gatherVars` to `m_gatherVars`
+        //  (in visit(AstFork*) there is a only possible transition, visit(AstNodeProcedure*) is
+        //  not considered since it does not occur during a graph traversal)
+        //  therefore, if change of state occurs it is certain that the first node after transition
+        //  won't be in visiting state
+        //  therefore, every node in a m_includes shall take value of m_gatherVars under which
+        //  current CFuncCache is
+        enum State : uint8_t {
+            UNINITIALIZED = 0,  // Not initialized members are empty
+            VISITING,  // Visiting - needed for breaking recursion
+            INITIALIZED,  // Members contains correct values
+        } m_state  // Current state of Cache
+            = UNINITIALIZED;
+    };
+    std::vector<const AstCFunc*> m_callStack;  // Current callstack of AstCFuncs
+    // Caches how visiting the function with given value of m_gatherVars changes
+    // m_processDomains and m_writtenBySuspendable - only accessed from visit(AstCFunc* nodep)
+    AstUser1Allocator<AstCFunc, std::array<CFuncCache, 2>> m_cfuncsCache;
+    // Count uses of not inlined writes to signals in suspendables
+    VDouble0 m_notInlinedWritesInSuspendableUsage;
 
     // METHODS
     // Add arguments to a resume() call based on arguments in the suspending call
@@ -206,6 +236,19 @@ class AwaitVisitor final : public VNVisitor {
             }
         } else {
             resumep->addPinsp(pinsp->cloneTree(false));
+        }
+    }
+    void addCFuncCachedValues(const AstCFunc* const cfuncp,
+                              std::unordered_set<const AstCFunc*>& visited) {
+        if (!visited.insert(cfuncp).second) return;
+        CFuncCache& value = m_cfuncsCache(cfuncp)[static_cast<size_t>(m_gatherVars)];
+        const size_t initialSize = m_writtenBySuspendable.size();
+        m_writtenBySuspendable.insert(value.m_writtenBySuspendable.begin(),
+                                      value.m_writtenBySuspendable.end());
+        m_notInlinedWritesInSuspendableUsage += m_writtenBySuspendable.size() - initialSize;
+        m_processDomains.insert(value.m_processDomains.begin(), value.m_processDomains.end());
+        for (const AstCFunc* const includedp : value.m_includes) {
+            addCFuncCachedValues(includedp, visited);
         }
     }
     // Create an active with a timing scheduler resume() call
@@ -236,6 +279,40 @@ class AwaitVisitor final : public VNVisitor {
         activep->addStmtsp(resumep->makeStmt());
         m_lbs.emplace_back(m_scopeTopp, activep);
     }
+    // Visit AstCFunc from a AstNodeCCall - this function is rather expensive to call therefore, it
+    // only shall be called when necessary
+    void visitCalledCFunc(AstCFunc* const nodep) {
+        if (!m_inProcess) return;  // Skip if not in process - nothing would be added to any set
+        const size_t cacheKey = static_cast<size_t>(m_gatherVars);
+        CFuncCache& value = m_cfuncsCache(nodep)[cacheKey];
+        switch (value.m_state) {
+        case CFuncCache::UNINITIALIZED: {
+            // Save current state
+            VL_RESTORER_CLEAR(m_processDomains);
+            VL_RESTORER_CLEAR(m_writtenBySuspendable);
+
+            // Visit
+            value.m_state = CFuncCache::VISITING;
+            m_callStack.push_back(nodep);
+            iterateChildren(nodep);
+            m_callStack.pop_back();
+            value.m_state = CFuncCache::INITIALIZED;
+
+            // Save a cache
+            std::swap(m_processDomains, value.m_processDomains);
+            std::swap(m_writtenBySuspendable, value.m_writtenBySuspendable);
+        } break;
+        case CFuncCache::VISITING: {
+            for (size_t i = m_callStack.size() - 1; m_callStack.at(i) != nodep; --i) {
+                m_cfuncsCache(m_callStack[i])[cacheKey].m_includes.insert(nodep);
+            }
+            return;  // Break recursion
+        }
+        case CFuncCache::INITIALIZED: break;
+        }
+        std::unordered_set<const AstCFunc*> visited;
+        addCFuncCachedValues(nodep, visited);
+    }
 
     // VISITORS
     void visit(AstNodeProcedure* const nodep) override {
@@ -244,8 +321,6 @@ class AwaitVisitor final : public VNVisitor {
                     nodep, "Process in process?");
         m_inProcess = true;
         m_gatherVars = nodep->isSuspendable();  // Only gather vars in a suspendable
-        const VNUser2InUse user2InUse;  // AstVarScope -> bool: Set true if var has been added
-                                        // to m_writtenBySuspendable
         iterateChildren(nodep);
         for (AstVarScope* const vscp : m_writtenBySuspendable) {
             m_externalDomains[vscp].insert(m_processDomains.begin(), m_processDomains.end());
@@ -267,12 +342,26 @@ class AwaitVisitor final : public VNVisitor {
             if (!sentreep->user1SetOnce()) createResumeActive(nodep);
             if (m_inProcess) m_processDomains.insert(sentreep);
         }
+        iterateChildren(nodep);
     }
     void visit(AstNodeVarRef* nodep) override {
-        if (m_gatherVars && nodep->access().isWriteOrRW() && !nodep->varp()->ignoreSchedWrite()
-            && !nodep->varScopep()->user2SetOnce()) {
-            m_writtenBySuspendable.push_back(nodep->varScopep());
+        if (m_gatherVars && nodep->access().isWriteOrRW() && !nodep->varp()->ignoreSchedWrite()) {
+            m_writtenBySuspendable.insert(nodep->varScopep());
         }
+    }
+    void visit(AstNodeCCall* const nodep) override {
+        iterateChildren(nodep);
+        // We need to visit bodies of non-inlined functions
+        visitCalledCFunc(nodep->funcp());
+    }
+    void visit(AstCFunc* const nodep) override {
+        const auto& value = m_cfuncsCache(nodep);
+        // Check whether it was already visited by visitCalledCFunc()
+        if (value[0].m_state != CFuncCache::UNINITIALIZED
+            || value[1].m_state != CFuncCache::UNINITIALIZED) {
+            return;
+        }
+        iterateChildren(nodep);
     }
     void visit(AstExprStmt* nodep) override { iterateChildren(nodep); }
 
@@ -289,7 +378,10 @@ public:
         , m_externalDomains{externalDomains} {
         iterate(nodep);
     }
-    ~AwaitVisitor() override = default;
+    ~AwaitVisitor() override {
+        V3Stats::addStat("Scheduling, count of non-inlined signal writes in suspendables",
+                         m_notInlinedWritesInSuspendableUsage);
+    }
 };
 
 TimingKit prepareTiming(AstNetlist* const netlistp) {

--- a/test_regress/t/t_sched_noninlined_func_suspendable.py
+++ b/test_regress/t/t_sched_noninlined_func_suspendable.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile(verilator_flags2=['--binary', '--stats', '-fno-dfg'])
+
+test.execute()
+
+test.file_grep(test.stats,
+               r'Scheduling, count of non-inlined signal writes in suspendables\s+(\d+)', 5)
+
+test.passes()

--- a/test_regress/t/t_sched_noninlined_func_suspendable.v
+++ b/test_regress/t/t_sched_noninlined_func_suspendable.v
@@ -1,0 +1,93 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain
+// SPDX-FileCopyrightText: 2026 Antmicro
+// SPDX-License-Identifier: CC0-1.0
+
+// verilog_format: off
+`define stop $stop
+`define checkh(gotv,expv) do if ((gotv) !== (expv)) begin $write("%%Error: %s:%0d:  got='h%x exp='h%x\n", `__FILE__,`__LINE__, (gotv), (expv)); `stop; end while(0)
+// verilog_format: off
+
+package pkg;
+  bit [2:0] y3;
+endpackage
+
+module t;
+  bit [2:0] y;
+  bit [2:0] z;
+  assign z[0] = 1'b1;
+  assign z[1] = !(y[0]);
+  assign z[2] = !(|y[1:0]);
+
+  bit [2:0] y2;
+  bit [2:0] z2;
+  assign z2[0] = 1'b1;
+  assign z2[1] = !(y2[0]);
+  assign z2[2] = !(|y2[1:0]);
+
+  import pkg::y3;
+  bit [2:0] z3;
+  assign z3[0] = 1'b1;
+  assign z3[1] = !(y3[0]);
+  assign z3[2] = !(|y3[1:0]);
+
+  bit [2:0] y4;
+  bit [2:0] z4;
+  assign z4[0] = 1'b1;
+  assign z4[1] = !(y4[0]);
+  assign z4[2] = !(|y4[1:0]);
+  class Foo;
+    function automatic int bar();
+      // verilator no_inline_task
+      y2 = 3'b111;
+      y3 = 3'b111;
+      return 1;
+    endfunction
+    task run();
+      y = 3'b111;
+      #1;
+      `checkh(z, 3'b001);
+      `checkh(z2, 3'b001);
+      `checkh(z3, 3'b001);
+      `checkh(z4, 3'b111);
+    endtask
+    task a(bit x = 0);
+      // verilator no_inline_task
+      y4 = ~y4;
+      #1;
+      if (!x) b(!x);
+    endtask
+    task b(bit x = 0);
+      // verilator no_inline_task
+      if (!x) a(!x);
+    endtask
+  endclass
+  initial begin
+    static Foo foo = new;
+    #1;
+    `checkh(z, 3'b111);
+    `checkh(z2, 3'b111);
+    `checkh(z3, 3'b111);
+    `checkh(z4, 3'b111);
+    void'(foo.bar());
+    #1;
+    `checkh(z, 3'b111);
+    `checkh(z2, 3'b001);
+    `checkh(z3, 3'b001);
+    `checkh(z4, 3'b111);
+    foo.run();
+    foo.a();
+    `checkh(z, 3'b001);
+    `checkh(z2, 3'b001);
+    `checkh(z3, 3'b001);
+    `checkh(z4, 3'b001);
+    foo.b();
+    `checkh(z, 3'b001);
+    `checkh(z2, 3'b001);
+    `checkh(z3, 3'b001);
+    `checkh(z4, 3'b111);
+    $write("*-* All Finished *-*\n");
+    $finish;
+  end
+endmodule

--- a/test_regress/t/t_timing_debug2.out
+++ b/test_regress/t/t_timing_debug2.out
@@ -78,7 +78,7 @@
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_orInto__act_vec_vec
 -V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_anySet__act
--V{t#,#}         'act' region trigger index 1 is active: @([true] __VdlySched.awaitingCurrentTime())
+-V{t#,#}         'act' region trigger index 2 is active: @([true] __VdlySched.awaitingCurrentTime())
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_orInto__act_vec_vec
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_anySet__act
 -V{t#,#}+    Vt_timing_debug2___024root___timing_resume
@@ -110,7 +110,7 @@
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_orInto__act_vec_vec
 -V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_anySet__act
--V{t#,#}         'act' region trigger index 2 is active: @([true] __VdynSched.evaluate())
+-V{t#,#}         'act' region trigger index 1 is active: @([true] __VdynSched.evaluate())
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_orInto__act_vec_vec
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_anySet__act
 -V{t#,#}+    Vt_timing_debug2___024root___timing_resume
@@ -171,7 +171,7 @@
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_orInto__act_vec_vec
 -V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_anySet__act
--V{t#,#}         'act' region trigger index 1 is active: @([true] __VdlySched.awaitingCurrentTime())
+-V{t#,#}         'act' region trigger index 2 is active: @([true] __VdlySched.awaitingCurrentTime())
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_orInto__act_vec_vec
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_anySet__act
 -V{t#,#}+    Vt_timing_debug2___024root___timing_resume
@@ -247,7 +247,7 @@
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_orInto__act_vec_vec
 -V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_anySet__act
--V{t#,#}         'act' region trigger index 1 is active: @([true] __VdlySched.awaitingCurrentTime())
+-V{t#,#}         'act' region trigger index 2 is active: @([true] __VdlySched.awaitingCurrentTime())
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_orInto__act_vec_vec
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_anySet__act
 -V{t#,#}+    Vt_timing_debug2___024root___timing_resume
@@ -278,7 +278,7 @@
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_orInto__act_vec_vec
 -V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_anySet__act
--V{t#,#}         'act' region trigger index 2 is active: @([true] __VdynSched.evaluate())
+-V{t#,#}         'act' region trigger index 1 is active: @([true] __VdynSched.evaluate())
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_orInto__act_vec_vec
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_anySet__act
 -V{t#,#}+    Vt_timing_debug2___024root___timing_resume
@@ -339,7 +339,7 @@
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_orInto__act_vec_vec
 -V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_anySet__act
--V{t#,#}         'act' region trigger index 1 is active: @([true] __VdlySched.awaitingCurrentTime())
+-V{t#,#}         'act' region trigger index 2 is active: @([true] __VdlySched.awaitingCurrentTime())
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_orInto__act_vec_vec
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_anySet__act
 -V{t#,#}+    Vt_timing_debug2___024root___timing_resume
@@ -463,7 +463,7 @@
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_orInto__act_vec_vec
 -V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_anySet__act
--V{t#,#}         'act' region trigger index 1 is active: @([true] __VdlySched.awaitingCurrentTime())
+-V{t#,#}         'act' region trigger index 2 is active: @([true] __VdlySched.awaitingCurrentTime())
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_orInto__act_vec_vec
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_anySet__act
 -V{t#,#}+    Vt_timing_debug2___024root___timing_resume
@@ -498,7 +498,7 @@
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_orInto__act_vec_vec
 -V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_anySet__act
--V{t#,#}         'act' region trigger index 2 is active: @([true] __VdynSched.evaluate())
+-V{t#,#}         'act' region trigger index 1 is active: @([true] __VdynSched.evaluate())
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_orInto__act_vec_vec
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_anySet__act
 -V{t#,#}+    Vt_timing_debug2___024root___timing_resume
@@ -581,7 +581,7 @@
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_orInto__act_vec_vec
 -V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_anySet__act
--V{t#,#}         'act' region trigger index 1 is active: @([true] __VdlySched.awaitingCurrentTime())
+-V{t#,#}         'act' region trigger index 2 is active: @([true] __VdlySched.awaitingCurrentTime())
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_orInto__act_vec_vec
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_anySet__act
 -V{t#,#}+    Vt_timing_debug2___024root___timing_resume
@@ -676,7 +676,7 @@
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_orInto__act_vec_vec
 -V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_anySet__act
--V{t#,#}         'act' region trigger index 1 is active: @([true] __VdlySched.awaitingCurrentTime())
+-V{t#,#}         'act' region trigger index 2 is active: @([true] __VdlySched.awaitingCurrentTime())
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_orInto__act_vec_vec
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_anySet__act
 -V{t#,#}+    Vt_timing_debug2___024root___timing_resume
@@ -711,7 +711,7 @@
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_orInto__act_vec_vec
 -V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_anySet__act
--V{t#,#}         'act' region trigger index 2 is active: @([true] __VdynSched.evaluate())
+-V{t#,#}         'act' region trigger index 1 is active: @([true] __VdynSched.evaluate())
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_orInto__act_vec_vec
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_anySet__act
 -V{t#,#}+    Vt_timing_debug2___024root___timing_resume
@@ -794,7 +794,7 @@
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_orInto__act_vec_vec
 -V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_anySet__act
--V{t#,#}         'act' region trigger index 1 is active: @([true] __VdlySched.awaitingCurrentTime())
+-V{t#,#}         'act' region trigger index 2 is active: @([true] __VdlySched.awaitingCurrentTime())
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_orInto__act_vec_vec
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_anySet__act
 -V{t#,#}+    Vt_timing_debug2___024root___timing_resume
@@ -831,7 +831,7 @@
 -V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_anySet__act
 -V{t#,#}         'act' region trigger index 0 is active: @([event] t.ec.e)
--V{t#,#}         'act' region trigger index 2 is active: @([true] __VdynSched.evaluate())
+-V{t#,#}         'act' region trigger index 1 is active: @([true] __VdynSched.evaluate())
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_orInto__act_vec_vec
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_anySet__act
 -V{t#,#}+    Vt_timing_debug2___024root___timing_resume
@@ -906,7 +906,7 @@
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_orInto__act_vec_vec
 -V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_anySet__act
--V{t#,#}         'act' region trigger index 1 is active: @([true] __VdlySched.awaitingCurrentTime())
+-V{t#,#}         'act' region trigger index 2 is active: @([true] __VdlySched.awaitingCurrentTime())
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_orInto__act_vec_vec
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_anySet__act
 -V{t#,#}+    Vt_timing_debug2___024root___timing_resume
@@ -936,7 +936,7 @@
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_orInto__act_vec_vec
 -V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_anySet__act
--V{t#,#}         'act' region trigger index 2 is active: @([true] __VdynSched.evaluate())
+-V{t#,#}         'act' region trigger index 1 is active: @([true] __VdynSched.evaluate())
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_orInto__act_vec_vec
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_anySet__act
 -V{t#,#}+    Vt_timing_debug2___024root___timing_resume
@@ -994,7 +994,7 @@
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_orInto__act_vec_vec
 -V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_anySet__act
--V{t#,#}         'act' region trigger index 1 is active: @([true] __VdlySched.awaitingCurrentTime())
+-V{t#,#}         'act' region trigger index 2 is active: @([true] __VdlySched.awaitingCurrentTime())
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_orInto__act_vec_vec
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_anySet__act
 -V{t#,#}+    Vt_timing_debug2___024root___timing_resume
@@ -1060,7 +1060,7 @@
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_orInto__act_vec_vec
 -V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_anySet__act
--V{t#,#}         'act' region trigger index 1 is active: @([true] __VdlySched.awaitingCurrentTime())
+-V{t#,#}         'act' region trigger index 2 is active: @([true] __VdlySched.awaitingCurrentTime())
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_orInto__act_vec_vec
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_anySet__act
 -V{t#,#}+    Vt_timing_debug2___024root___timing_resume
@@ -1125,7 +1125,7 @@
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_orInto__act_vec_vec
 -V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_anySet__act
--V{t#,#}         'act' region trigger index 1 is active: @([true] __VdlySched.awaitingCurrentTime())
+-V{t#,#}         'act' region trigger index 2 is active: @([true] __VdlySched.awaitingCurrentTime())
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_orInto__act_vec_vec
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_anySet__act
 -V{t#,#}+    Vt_timing_debug2___024root___timing_resume
@@ -1152,7 +1152,7 @@
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_orInto__act_vec_vec
 -V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_anySet__act
--V{t#,#}         'act' region trigger index 2 is active: @([true] __VdynSched.evaluate())
+-V{t#,#}         'act' region trigger index 1 is active: @([true] __VdynSched.evaluate())
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_orInto__act_vec_vec
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_anySet__act
 -V{t#,#}+    Vt_timing_debug2___024root___timing_resume
@@ -1215,7 +1215,7 @@
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_orInto__act_vec_vec
 -V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_anySet__act
--V{t#,#}         'act' region trigger index 1 is active: @([true] __VdlySched.awaitingCurrentTime())
+-V{t#,#}         'act' region trigger index 2 is active: @([true] __VdlySched.awaitingCurrentTime())
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_orInto__act_vec_vec
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_anySet__act
 -V{t#,#}+    Vt_timing_debug2___024root___timing_resume
@@ -1280,7 +1280,7 @@
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_orInto__act_vec_vec
 -V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_anySet__act
--V{t#,#}         'act' region trigger index 1 is active: @([true] __VdlySched.awaitingCurrentTime())
+-V{t#,#}         'act' region trigger index 2 is active: @([true] __VdlySched.awaitingCurrentTime())
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_orInto__act_vec_vec
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_anySet__act
 -V{t#,#}+    Vt_timing_debug2___024root___timing_resume
@@ -1320,7 +1320,7 @@
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_orInto__act_vec_vec
 -V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_anySet__act
--V{t#,#}         'act' region trigger index 2 is active: @([true] __VdynSched.evaluate())
+-V{t#,#}         'act' region trigger index 1 is active: @([true] __VdynSched.evaluate())
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_orInto__act_vec_vec
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_anySet__act
 -V{t#,#}+    Vt_timing_debug2___024root___timing_resume
@@ -1371,7 +1371,7 @@
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_orInto__act_vec_vec
 -V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_anySet__act
--V{t#,#}         'act' region trigger index 1 is active: @([true] __VdlySched.awaitingCurrentTime())
+-V{t#,#}         'act' region trigger index 2 is active: @([true] __VdlySched.awaitingCurrentTime())
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_orInto__act_vec_vec
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_anySet__act
 -V{t#,#}+    Vt_timing_debug2___024root___timing_resume
@@ -1427,7 +1427,7 @@
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_orInto__act_vec_vec
 -V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_anySet__act
--V{t#,#}         'act' region trigger index 1 is active: @([true] __VdlySched.awaitingCurrentTime())
+-V{t#,#}         'act' region trigger index 2 is active: @([true] __VdlySched.awaitingCurrentTime())
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_orInto__act_vec_vec
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_anySet__act
 -V{t#,#}+    Vt_timing_debug2___024root___timing_resume
@@ -1486,7 +1486,7 @@
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_orInto__act_vec_vec
 -V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_anySet__act
--V{t#,#}         'act' region trigger index 1 is active: @([true] __VdlySched.awaitingCurrentTime())
+-V{t#,#}         'act' region trigger index 2 is active: @([true] __VdlySched.awaitingCurrentTime())
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_orInto__act_vec_vec
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_anySet__act
 -V{t#,#}+    Vt_timing_debug2___024root___timing_resume
@@ -1541,7 +1541,7 @@
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_orInto__act_vec_vec
 -V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_anySet__act
--V{t#,#}         'act' region trigger index 1 is active: @([true] __VdlySched.awaitingCurrentTime())
+-V{t#,#}         'act' region trigger index 2 is active: @([true] __VdlySched.awaitingCurrentTime())
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_orInto__act_vec_vec
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_anySet__act
 -V{t#,#}+    Vt_timing_debug2___024root___timing_resume
@@ -1596,7 +1596,7 @@
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_orInto__act_vec_vec
 -V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_anySet__act
--V{t#,#}         'act' region trigger index 1 is active: @([true] __VdlySched.awaitingCurrentTime())
+-V{t#,#}         'act' region trigger index 2 is active: @([true] __VdlySched.awaitingCurrentTime())
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_orInto__act_vec_vec
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_anySet__act
 -V{t#,#}+    Vt_timing_debug2___024root___timing_resume
@@ -1649,7 +1649,7 @@
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_orInto__act_vec_vec
 -V{t#,#}+    Vt_timing_debug2___024root___dump_triggers__act
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_anySet__act
--V{t#,#}         'act' region trigger index 1 is active: @([true] __VdlySched.awaitingCurrentTime())
+-V{t#,#}         'act' region trigger index 2 is active: @([true] __VdlySched.awaitingCurrentTime())
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_orInto__act_vec_vec
 -V{t#,#}+    Vt_timing_debug2___024root___trigger_anySet__act
 -V{t#,#}+    Vt_timing_debug2___024root___timing_resume


### PR DESCRIPTION
Fixes #4542.

This is the same change that was introduced here: https://github.com/verilator/verilator/pull/7836 but optimized.

This is split of https://github.com/verilator/verilator/pull/7909 as mentioned here: https://github.com/verilator/verilator/pull/7909#issuecomment-4925233467

Additionally, I've caught a small error - not emitting a proper error when static method was virtual as well.

If this change will still lead to an out of memory error (in test mentioned here https://github.com/verilator/verilator/pull/7836#issuecomment-4918183185 by @wsnyder), I can introduce some upper limit of amount of functions with cached results and some LRU or second chance algorithm to manage it.