### PR TITLE
Use snprintf for random unique indexes

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -126,6 +126,8 @@ Jamie Iles
 Jan Van Winkel
 Jean Berniolles
 Jean-Nicolas Strauss
+Jeffrey Song
+jeffrey.song
 Jens Yuechao Liu
 Jeremy Bennett
 Jesse Taube

--- a/include/verilated_random.cpp
+++ b/include/verilated_random.cpp
@@ -496,7 +496,7 @@ bool VlRandomizer::next(VlRNG& rngr) {
             std::string distinctExpr = "(__Vbv (distinct";
             for (uint32_t i = 0; i < size; ++i) {
                 char hexIdx[12];
-                sprintf(hexIdx, "#x%08x", i);
+                (void)VL_SNPRINTF(hexIdx, sizeof(hexIdx), "#x%08x", i);
                 distinctExpr += " (select " + it->first + " " + hexIdx + ")";
             }
             distinctExpr += "))";


### PR DESCRIPTION
## Summary

Replace `sprintf` with `VL_SNPRINTF` when formatting unique-array SMT select indexes.

## Why

Apple Clang marks `sprintf` deprecated under the current SDK. With `--enable-ccwarn`, that warning becomes an error while compiling `verilated_random.cpp`, including in process and randomization regressions.

This uses Verilator's existing bounded formatting wrapper without changing the generated index text.

## Validation

- `t_process`
- `t_randomize_unique_elem`
- aggregate build with `--enable-ccwarn --enable-longtests`
- accepted-candidate aggregate regression: 6501 passed, 0 failed, 145 skipped

The aggregate run also contained five non-overlapping candidate changes; focused tests above validate this change independently.

## Contribution certification

Significant AI assistance was used during development and review. The human submitter must review the change and complete Verilator's DCO certification before this draft is marked ready for review.