### PR TITLE
Allow stream concatenation in init array patterns

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -126,6 +126,8 @@ Jamie Iles
 Jan Van Winkel
 Jean Berniolles
 Jean-Nicolas Strauss
+Jeffrey Song
+jeffrey.song
 Jens Yuechao Liu
 Jeremy Bennett
 Jesse Taube

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -3453,7 +3453,8 @@ class WidthVisitor final : public VNVisitor {
             }
             const AstNodeDType* const arrayp = nodep->dtypep()->skipRefp();
             if (VN_IS(arrayp, NodeArrayDType) || VN_IS(arrayp, AssocArrayDType)) {
-                userIterateChildren(nodep, WidthVP{arrayp->subDTypep(), BOTH}.p());
+                userIterateChildren(nodep,
+                                    WidthVP{arrayp->subDTypep(), BOTH, STREAM_USE_ASSIGN}.p());
             } else {
                 UINFO(1, "on " << nodep);
                 UINFO(1, "dtype object " << arrayp);

--- a/test_regress/t/t_array_pattern_concat.v
+++ b/test_regress/t/t_array_pattern_concat.v
@@ -14,6 +14,12 @@ endpackage
 
 module t (  /*AUTOARG*/);
 
+  typedef logic [31:0] word_t;
+  typedef word_t word_pair_t[2];
+
+  word_t stream_src = 32'h1234_5678;
+  word_pair_t stream_words;
+
   // Test: array concatenation in pattern initialization
   // An array localparam used as a value in another array's pattern
   // should have its elements "flattened" into the target array.
@@ -78,6 +84,11 @@ module t (  /*AUTOARG*/);
   localparam logic [31:0] PKG_SLICE[4] = '{arr_pkg::PKG_ADDRS[0:1], 32'hAA, 32'hBB};
 
   initial begin
+    // Streaming concatenation as a positional assignment-pattern member
+    stream_words = '{{<<8{stream_src}}, 32'h0};
+    `checkh(stream_words[0], 32'h7856_3412);
+    `checkh(stream_words[1], 32'h0000_0000);
+
     `checkh(ALL_ADDRS[0], 32'h80001000);
     `checkh(ALL_ADDRS[1], 32'h80002000);
     `checkh(ALL_ADDRS[2], 32'h80003000);


### PR DESCRIPTION
## Summary

Propagate assignment-like streaming context while width-checking `AstInitArray` values. Extend the existing array-pattern concatenation regression with a runtime streaming member.

## Root cause

`AstInitArray` values are assignment-pattern members, but width checking did not pass `STREAM_USE_ASSIGN` to those elements. Legal streaming concatenations were rejected as implicit casts under IEEE 1800-2023 11.4.17.

## Validation

- consolidated `t_array_pattern_concat` regression fails on `origin/master` and passes with this change
- 12 adjacent stream and array-pattern regressions
- changed-file formatting and distribution checks
- accepted-candidate aggregate regression: 6501 passed, 0 failed, 145 skipped

## Contribution certification

Significant AI assistance was used during development and review. The human submitter must review the change and complete Verilator's DCO certification before this draft is marked ready for review.