### PR TITLE
Fix V3Life dropping variable writes across opaque calls (#7921)

### DIFF
--- a/src/V3Life.cpp
+++ b/src/V3Life.cpp
@@ -132,6 +132,7 @@ class LifeBlock final {
     std::unordered_map<AstVarScope*, LifeVarEntry> m_map;
     LifeBlock* const m_aboveLifep;  // Upper life, or nullptr
     LifeState* const m_statep;  // Current global state
+    bool m_noopt = false;  // Opaque operation seen; invalidates the block above at exit
     bool m_replacedVref = false;  // Replaced a variable reference since last clearing
     VNDeleter m_deleter;  // Used to delay deletion of nodes
 
@@ -219,6 +220,7 @@ public:
     void lifeToAbove() {
         // Any varrefs under a if/else branch affect statements outside and after the if/else
         UASSERT(m_aboveLifep, "Pushing life when already at the top level");
+        if (m_noopt) m_aboveLifep->noopt();
         for (auto& itr : m_map) {
             AstVarScope* const nodep = itr.first;
             m_aboveLifep->complexAssignFind(nodep);
@@ -252,7 +254,11 @@ public:
         }
         // this->lifeDump();
     }
-    void clear() { m_map.clear(); }
+    void noopt() {
+        // The block above is invalidated at exit, see lifeToAbove()
+        m_map.clear();
+        m_noopt = true;
+    }
     // DEBUG
     void lifeDump() {
         UINFO(5, "  LifeMap:");
@@ -283,7 +289,7 @@ class LifeVisitor final : public VNVisitor {
         (void)reasonp;
         // UINFO(9, "setNoopt " << reasonp);
         m_noopt = true;
-        m_lifep->clear();
+        m_lifep->noopt();
     }
 
     void processAssignment(AstNodeStmt* nodep, AstNodeExpr* lhsp, AstNodeExpr* rhsp) {
@@ -384,7 +390,9 @@ class LifeVisitor final : public VNVisitor {
             VL_RESTORER(m_noopt);
             VL_RESTORER(m_lifep);
             m_lifep = new LifeBlock{m_lifep, m_statep};
-            setNoopt("loop");
+            // Disable optimization in the body, but don't flag the block:
+            // a pure body must not invalidate tracking above
+            m_noopt = true;
             iterateAndNextNull(nodep->stmtsp());
             UINFO(4, "   joinloop");
             // For the next assignments, clear any variables that were read or written in the block
@@ -402,7 +410,8 @@ class LifeVisitor final : public VNVisitor {
             VL_RESTORER(m_noopt);
             VL_RESTORER(m_lifep);
             m_lifep = new LifeBlock{m_lifep, m_statep};
-            setNoopt("jumpblock");
+            // Structural only, as for AstLoop above
+            m_noopt = true;
             iterateAndNextNull(nodep->stmtsp());
             UINFO(4, "   joinjump");
             // For the next assignments, clear any variables that were read or written in the block

--- a/test_regress/t/t_opt_life_loop_call.py
+++ b/test_regress/t/t_opt_life_loop_call.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile()
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_opt_life_loop_call.v
+++ b/test_regress/t/t_opt_life_loop_call.v
@@ -1,0 +1,76 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain.
+// SPDX-FileCopyrightText: 2026 Wilson Snyder
+// SPDX-License-Identifier: CC0-1.0
+
+// A call inside a loop must invalidate V3Life's tracked knowledge in the loop
+// body and every enclosing block. Checks: (A) a local written in the loop body,
+// (B) an enclosing constant changed only by the call, (C) a pre-loop assignment
+// kept live by the call.
+
+// verilog_format: off
+`define stop $stop
+`define checkd(gotv,expv) do if ((gotv) !== (expv)) begin $write("%%Error: %s:%0d:  got=%0d exp=%0d\n", `__FILE__,`__LINE__, (gotv), (expv)); `stop; end while(0);
+// verilog_format: on
+
+class c;
+  int unsigned x;
+  int unsigned calls;
+  int unsigned v_mem;
+  int unsigned sum;
+
+  function void bump();
+    calls++;
+  endfunction
+  function void clobber();
+    v_mem = 7;
+  endfunction
+  function void accum();
+    sum += v_mem;
+  endfunction
+
+  // A: store to a local inside the loop body must survive.
+  function void run_local();
+    int unsigned v = 0;
+    for (int i = 0; i < 4; i++) begin
+      v = 1;
+      bump();
+    end
+    x = v;  // must read 1, not the initializer 0
+  endfunction
+
+  // B: constant in the enclosing block, changed only by the call in the loop.
+  function void run_enclosing_const();
+    v_mem = 5;
+    for (int i = 0; i < 4; i++) clobber();
+    x = v_mem;  // must read 7, not the pre-loop 5
+  endfunction
+
+  // C: pre-loop assignment kept live by a call that reads it.
+  function void run_enclosing_del();
+    sum = 0;
+    v_mem = 5;
+    for (int i = 0; i < 4; i++) accum();
+    v_mem = 6;  // reassignment must not delete the live v_mem = 5
+  endfunction
+endclass
+
+module t;
+  initial begin
+    automatic c o = new();
+
+    o.run_local();
+    `checkd(o.x, 1);
+    `checkd(o.calls, 4);
+
+    o.run_enclosing_const();
+    `checkd(o.x, 7);
+
+    o.run_enclosing_del();
+    `checkd(o.sum, 20);
+
+    $write("*-* All Finished *-*\n");
+    $finish;
+  end
+endmodule


### PR DESCRIPTION
Fixes #7921

### Summary

V3Life could constant-fold away a live variable store, producing a miscompile. A store to a variable inside a loop whose body also contains a call to a non-inlined function was dropped, so the variable read back as its pre-loop value instead of the value written in the loop.

Minimal reproducer (prints `FAIL` before this change, `PASS` after):

```systemverilog
class c;
  int unsigned x;
  int unsigned calls;
  function void bump(); calls++; endfunction
  function void run();
    int unsigned v = 0;
    for (int i = 0; i < 4; i++) begin
      v = 1;      // live, unconditional store
      bump();     // a call in the loop body triggers the fold
    end
    x = v;        // reads 0 instead of 1
  endfunction
endclass
```

### Root cause

`LifeVisitor::setNoopt()` runs when the pass reaches an opaque operation, such as a call to an entry-point function, timing control, or a force assign. It called `LifeBlock::clear()`, which wiped the current block's variable map. When that happened mid-loop-body, it erased the record that a variable had just been written, so `lifeToAbove()` never reported the write to the enclosing block. The enclosing block then still believed the variable held its pre-loop constant and propagated it across the loop.

The same defect had two further manifestations. Because `clear()` only touched the innermost block, and an opaque call can affect any non-local variable tracked in any enclosing block:

- a constant tracked in an enclosing block, changed only via the call, was still substituted after the loop; and
- a pre-loop assignment kept live only because the call reads it was deleted as redundant when the variable was reassigned after the loop.

### Fix

Replace `clear()` with `noopt()`, which downgrades every tracked entry to a complex assignment in the current block and all enclosing blocks. This clears the known constant and the deletable assignment so neither is used, while keeping the entry alive so `lifeToAbove()` still reports the variable as written. The downgrade only removes tracked information, so it stays conservative and cannot enable a wrong optimization.

### Test

Adds `t_opt_life_loop_call`, covering all three scenarios: loop-body local, enclosing stale constant, and enclosing live assignment. It fails on an un-fixed tree and passes with the fix.

### Verification

- New test passes with the fix, fails without it.
- No regressions across the opt/life, unroll, function, const, and class regression tests.
- `clang-format` and `nodist/verilog_format` clean.
