### PR TITLE
Fix FSM detection of coverage-only branches (#7941)

### DIFF
--- a/src/V3FsmDetect.cpp
+++ b/src/V3FsmDetect.cpp
@@ -1106,9 +1106,8 @@ class FsmDetectVisitor final : public VNVisitor {
         AstVarScope* thenVscp = nullptr;
         AstVarScope* elseVscp = nullptr;
         AstNode* const thenNodep = singleMeaningfulBranch(skipLeadingIgnorableStmt(ifp->thensp()));
-        UASSERT_OBJ(thenNodep, ifp, "Empty then-branch unexpectedly survived to FSM detection");
         AstNode* const elseNodep = singleMeaningfulBranch(skipLeadingIgnorableStmt(ifp->elsesp()));
-        if (!elseNodep) return false;
+        if (!thenNodep || !elseNodep) return false;
         if (!directConstStateAssignNode(thenNodep, thenVscp, thenValue)) return false;
         if (!directConstStateAssignNode(elseNodep, elseVscp, elseValue)) return false;
         if (thenVscp == stateVscp && elseVscp == stateVscp) return true;

--- a/test_regress/t/t_cover_fsm_two_proc_multi.out
+++ b/test_regress/t/t_cover_fsm_two_proc_multi.out
@@ -45,6 +45,38 @@
           end
         endmodule
         
+        module fsm_negated_guard (
+%000009     input logic clk,
+%000001     input logic rst,
+%000001     input logic hold
+        );
+          typedef enum logic {
+            S0,
+            S1
+          } state_t;
+        
+%000004   state_t state_q;
+%000004   state_t state_d;
+        
+ 000010   always_comb begin
+ 000010     state_d = state_q;
+~000010     case (state_q)
+        // [FSM coverage]
+%000001        // [fsm_arc t.negated_guard_u.state_q::ANY->S0[reset]] [reset arc, excluded from %]
+%000003        // [fsm_arc t.negated_guard_u.state_q::S1->S0]
+%000003        // [fsm_state t.negated_guard_u.state_q::S0]
+%000004        // [fsm_state t.negated_guard_u.state_q::S1]
+%000009       S0: if (!hold) state_d = S1;
+%000004       S1: state_d = S0;
+            endcase
+          end
+        
+%000009   always_ff @(posedge clk) begin
+%000007     if (rst) state_q <= S0;
+%000007     else state_q <= state_d;
+          end
+        endmodule
+        
         module fsm_three_block (
 %000009     input logic clk,
 %000001     input logic rst,
@@ -425,6 +457,11 @@
               .clk(clk),
               .rst(rst),
               .start(start)
+          );
+          fsm_negated_guard negated_guard_u (
+              .clk(clk),
+              .rst(rst),
+              .hold(start)
           );
           fsm_three_block three_block_u (
               .clk(clk),

--- a/test_regress/t/t_cover_fsm_two_proc_multi.v
+++ b/test_regress/t/t_cover_fsm_two_proc_multi.v
@@ -37,6 +37,33 @@ module fsm_basic (
   end
 endmodule
 
+module fsm_negated_guard (
+    input logic clk,
+    input logic rst,
+    input logic hold
+);
+  typedef enum logic {
+    S0,
+    S1
+  } state_t;
+
+  state_t state_q;
+  state_t state_d;
+
+  always_comb begin
+    state_d = state_q;
+    case (state_q)
+      S0: if (!hold) state_d = S1;
+      S1: state_d = S0;
+    endcase
+  end
+
+  always_ff @(posedge clk) begin
+    if (rst) state_q <= S0;
+    else state_q <= state_d;
+  end
+endmodule
+
 module fsm_three_block (
     input logic clk,
     input logic rst,
@@ -368,6 +395,11 @@ module t (
       .clk(clk),
       .rst(rst),
       .start(start)
+  );
+  fsm_negated_guard negated_guard_u (
+      .clk(clk),
+      .rst(rst),
+      .hold(start)
   );
   fsm_three_block three_block_u (
       .clk(clk),


### PR DESCRIPTION
Treat branches containing only prior coverage instrumentation as unsupported FSM transition shapes instead of asserting after condition canonicalization. Add a combined line/FSM coverage regression for a negated one-sided guard.

- Fixes #7941 
