### PR TITLE
Fix: throw an error when scalar is passed to array task argument instead of generating invalid C++ 

### DIFF
--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -7507,6 +7507,14 @@ class WidthVisitor final : public VNVisitor {
                     relinkHandle.relink(newp);
                 }
                 if (portp->isWritable()) V3LinkLValue::linkLValueSet(pinp);
+                if (VN_IS(pinDTypep, BasicDType) && portp->direction() != VDirection::REF
+                    && (VN_IS(portDTypep, UnpackArrayDType) || VN_IS(portDTypep, DynArrayDType)
+                        || VN_IS(portDTypep, QueueDType) || VN_IS(portDTypep, AssocArrayDType))) {
+                    pinp->v3error("Function Argument expects " << portDTypep->prettyDTypeNameQ()
+                                                               << ", got "
+                                                               << pinDTypep->prettyDTypeNameQ());
+                    continue;
+                }
                 if (!portp->basicp() || portp->basicp()->isOpaque()) {
                     // Output args: at return caller = callee, reverse direction.
                     checkClassAssign(nodep, "Function Argument", pinp, portDTypep,

--- a/test_regress/t/t_dpi_unpack_bad.out
+++ b/test_regress/t/t_dpi_unpack_bad.out
@@ -25,8 +25,9 @@
                                               : ... note: In instance 't'
    29 |     import_func0(sig0[1]);
       |                      ^
-%Warning-WIDTHEXPAND: t/t_dpi_unpack_bad.v:29:5: Operator TASKREF 'import_func0' expects 4 bits on the Function Argument, but Function Argument's ARRAYSEL generates 3 bits.
-                                               : ... note: In instance 't'
+%Error: t/t_dpi_unpack_bad.v:29:22: Function Argument expects 'logic[3:0]$[0:2]', got 'logic[2:0]'
+                                  : ... note: In instance 't'
    29 |     import_func0(sig0[1]);
-      |     ^~~~~~~~~~~~
+      |                      ^
+        ... See the manual at https://verilator.org/verilator_doc.html?v=latest for more assistance.
 %Error: Exiting due to

--- a/test_regress/t/t_invalid_task_arguments_bad.out
+++ b/test_regress/t/t_invalid_task_arguments_bad.out
@@ -1,0 +1,18 @@
+%Error: t/t_invalid_task_arguments_bad.v:25:20: Function Argument expects 'logic[30:0]$[]', got 'IData'
+                                              : ... note: In instance 't'
+   25 |     dyn_task(.data($urandom));
+      |                    ^~~~~~~~
+        ... See the manual at https://verilator.org/verilator_doc.html?v=latest for more assistance.
+%Error: t/t_invalid_task_arguments_bad.v:26:25: Function Argument expects 'logic[30:0]$[3:0]', got 'IData'
+                                              : ... note: In instance 't'
+   26 |     unpacked_task(.data($urandom));
+      |                         ^~~~~~~~
+%Error: t/t_invalid_task_arguments_bad.v:27:22: Function Argument expects 'logic[30:0]$[$]', got 'IData'
+                                              : ... note: In instance 't'
+   27 |     queue_task(.data($urandom));
+      |                      ^~~~~~~~
+%Error: t/t_invalid_task_arguments_bad.v:28:22: Function Argument expects 'logic[30:0]$[int]', got 'IData'
+                                              : ... note: In instance 't'
+   28 |     assoc_task(.data($urandom));
+      |                      ^~~~~~~~
+%Error: Exiting due to

--- a/test_regress/t/t_invalid_task_arguments_bad.py
+++ b/test_regress/t/t_invalid_task_arguments_bad.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios("vlt")
+
+test.lint(fails=True, expect_filename=test.golden_filename)
+
+test.passes()

--- a/test_regress/t/t_invalid_task_arguments_bad.v
+++ b/test_regress/t/t_invalid_task_arguments_bad.v
@@ -1,0 +1,32 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain.
+// SPDX-FileCopyrightText: 2026 Antmicro
+// SPDX-License-Identifier: CC0-1.0
+
+task dyn_task(input logic [30:0] data []);
+  $display("%p", data);
+endtask
+
+task unpacked_task(input logic [30:0] data [3:0]);
+  $display("%p", data);
+endtask
+
+task queue_task(input logic [30:0] data [$]);
+  $display("%p", data);
+endtask
+
+task assoc_task(input logic [30:0] data [int]);
+  $display("%p", data);
+endtask
+
+module t;
+  initial begin
+    dyn_task(.data($urandom));
+    unpacked_task(.data($urandom));
+    queue_task(.data($urandom));
+    assoc_task(.data($urandom));
+    $write("*-* All Finished *-*\n");
+    $finish;
+  end
+endmodule


### PR DESCRIPTION
Passing a scalar to a task argument declared as an array type passes the linter and generated invalid C++. No existing check caught it. I've added a check in `processFTaskRefArgs` Stage 4 that fires when a `BasicDType` pin is passed to an array-typed port.


Example:
```verilog
task logic_task(input  logic [30:0]   data []);
  $display("%p", data);
endtask

module t;
  initial begin
    logic_task(.data($urandom)); // $urandom is `unsigned int` - should throw error
  end
endmodule
```


Generates invalid C++:
```
In file included from Vt_invalid_task_arguments__ALL.cpp:7:
Vt_invalid_task_arguments___024root__0__Slow.cpp: In function ‘void Vt_invalid_task_arguments___024root___eval_initial(Vt_invalid_task_arguments___024root*)’:
Vt_invalid_task_arguments___024root__0__Slow.cpp:24:27: error: no match for ‘operator=’ (operand types are ‘VlQueue<unsigned int>’ and ‘IData’ {aka ‘unsigned int’})
   24 |             = VL_RANDOM_I();
      |   
```

Now it throws an error instead:
```
%Error: test_regress/t/t_invalid_task_arguments.v:19:22: Function Argument expects 'logic[30:0]$[]', got 'IData'
                                                       : ... note: In instance 't'
   19 |     logic_task(.data($urandom));  
      |                      ^~~~~~~~
        ... See the manual at https://verilator.org/verilator_doc.html?v=5.051 for more assistance.
```