### PR TITLE
Fix the verilator_coverage -filter-type documentation

### DIFF
--- a/docs/guide/exe_verilator_coverage.rst
+++ b/docs/guide/exe_verilator_coverage.rst
@@ -133,7 +133,7 @@ verilator_coverage Arguments
 
 .. option:: --filter-type <regex>
 
-   Skips records of coverage types that matches with <regex>
+   Keeps records of coverage types that matches with <regex>
    Possible values are `toggle`, `line`, `branch`, `expr`, `covergroup`,
    `user`, `fsm_state`, `fsm_arc` and a wildcard with `\*` or `?`. The
    default value is `\*`.


### PR DESCRIPTION
Adjusts the documentation of `-filter-type` option to match with `verilator_coverage -help` and its behavior.

`verilator_coverage` skips a coverage record if its type does not match with `-filter-type`: https://github.com/verilator/verilator/blob/master/src/VlcTop.cpp#L191

Moreover, `verilator_coverage -help` says that it keeps only records of a given type: https://github.com/verilator/verilator/blob/master/bin/verilator_coverage#L180