### PR TITLE
Fix randomize when size in if statement

### DIFF
--- a/src/V3Randomize.cpp
+++ b/src/V3Randomize.cpp
@@ -3264,6 +3264,19 @@ class RandomizeVisitor final : public VNVisitor {
         m_prePostWrap;  // Per-handle-type pre/post virtual wrapper presence
 
     // METHODS
+    // Check if method is inside conditional of if statment.
+    static bool isInsideIfCond(AstNodeExpr* nodep) {
+        const AstNodeExpr* exprp = nodep;
+
+        while (exprp) {
+            if (const AstConstraintIf* const constIfp = VN_CAST(exprp->backp(), ConstraintIf)) {
+                if (constIfp->condp() == exprp) return true;
+            }
+            exprp = VN_CAST(exprp->backp(), NodeExpr);
+        }
+
+        return false;
+    }
     // Check if two nodes are semantically equivalent (not pointer equality):
     static bool isSimilarNode(const AstNodeExpr* withExpr, const AstNodeExpr* argExpr) {
         // VarRef: compare variable pointers
@@ -5688,7 +5701,11 @@ class RandomizeVisitor final : public VNVisitor {
             capturedTreep->foreachAndNext([&](AstCMethodHard* methodp) {
                 if (methodp->method() == VCMethod::DYN_SIZE
                     || methodp->method() == VCMethod::ASSOC_SIZE) {
-                    sizeMethodps.push_back(methodp);
+                    if (isInsideIfCond(methodp)) {
+                        methodp->user1(false);
+                    } else {
+                        sizeMethodps.push_back(methodp);
+                    }
                 }
             });
             for (AstCMethodHard* const methodp : sizeMethodps) {

--- a/test_regress/t/t_randomize_this_inline.v
+++ b/test_regress/t/t_randomize_this_inline.v
@@ -8,6 +8,7 @@
 `define stop $stop
 `define checkd(gotv,expv) do if ((gotv) !== (expv)) begin $write("%%Error: %s:%0d:  got=%0d exp=%0d\n", `__FILE__,`__LINE__, (gotv), (expv)); `stop; end while(0);
 `define check_range(gotv,minv,maxv) do if ((gotv) < (minv) || (gotv) > (maxv)) begin $write("%%Error: %s:%0d:  got=%0d exp=%0d-%0d\n", `__FILE__,`__LINE__, (gotv), (minv), (maxv)); `stop; end while(0);
+`define check_inside(gotv,tablev) do if (!(gotv inside {tablev})) begin $write("%%Error: %s:%0d:  got=%0d exp=%0d\n", `__FILE__,`__LINE__, (gotv), (tablev)); `stop; end while(0);
 // verilog_format: on
 
 // Test: 'this' keyword inside inline randomize() with {} constraint blocks.
@@ -16,6 +17,7 @@
 class DataItem;
   rand bit [7:0] value;
   rand bit [7:0] limit;
+  rand integer int_val;
   constraint default_con {limit inside {[8'd50 : 8'd200]};}
 endclass
 
@@ -23,10 +25,33 @@ endclass
 // 'this' must bind to the randomized object, not the calling class.
 class Caller;
   rand bit [7:0] own_value;
+  rand integer values[];
+  function new();
+    values = new[5];
+    values[0] = 'hCAFEBABE;
+    values[1] = 'hDEADBEEF;
+    values[2] = 'hBAADF00D;
+    values[3] = 'hBEEFBABE;
+    values[4] = 'hFACEFEED;
+  endfunction
   function int do_rand(DataItem item);
     return item.randomize() with {
       this.value > 8'd30;
       this.value < 8'd40;
+    };
+  endfunction
+  function int randomize_int_gt(DataItem item);
+    return item.randomize() with {
+      if (values.size > 0) {
+        item.int_val inside {values};
+      }
+    };
+  endfunction
+  function int randomize_int_addition_gt(DataItem item);
+    return item.randomize() with {
+      if ((values.size + 3) - 4 > -1) {
+        item.int_val inside {values};
+      }
     };
   endfunction
 endclass
@@ -68,6 +93,18 @@ module t;
     rand_ok = caller.do_rand(item);
     `checkd(rand_ok, 1)
     `check_range(item.value, 31, 39)
+
+    // Test 5: 'this' binds to randomized object, if statement containing size
+    // with comparision inside constraint.
+    rand_ok = caller.randomize_int_gt(item);
+    `checkd(rand_ok, 1)
+    `check_inside(item.int_val, caller.values)
+
+    // Test 6: 'this' binds to randomized object, if statement containing size
+    // with comparition and addition inside constraint.
+    rand_ok = caller.randomize_int_addition_gt(item);
+    `checkd(rand_ok, 1)
+    `check_inside(item.int_val, caller.values)
 
     $write("*-* All Finished *-*\n");
     $finish;


### PR DESCRIPTION
In `V3Randomize.cpp`, when handling `arr.size` inside `if` statement inside `randomize...with` statement it was mistakenly treated as a regular `arr.size`, which resulted in generating non-compiling code.