### PR TITLE
Fix clocking-event wait waking on the in-progress edge after a mid-slot resume (#7934)

### DIFF
--- a/src/V3AssertPre.cpp
+++ b/src/V3AssertPre.cpp
@@ -474,6 +474,8 @@ private:
                 new AstSenTree{flp, new AstSenItem{flp, VEdgeType::ET_EVENT,
                                                    new AstVarRef{flp, evtVarp, VAccess::READ}}},
                 nullptr};
+            // ##0 may resolve on the current cycle's clocking event; do not defer to next edge.
+            waitp->syncCurrentCycle(true);
             AstIf* const ifp = new AstIf{flp, new AstNot{flp, isTriggeredp}, waitp};
             nodep->replaceWith(ifp);
             VL_DO_DANGLING(pushDeletep(nodep), nodep);

--- a/src/V3AstNodeOther.h
+++ b/src/V3AstNodeOther.h
@@ -2189,6 +2189,7 @@ class AstVar final : public AstNode {
     bool m_isReadByDpi : 1;  // This variable can be read by a DPI Export
     bool m_isWrittenByDpi : 1;  // This variable can be written by a DPI Export
     bool m_isWrittenBySuspendable : 1;  // This variable can be written by a suspendable process
+    bool m_isClockingEvent : 1;  // Event var backing a clocking block
     bool m_ignorePostRead : 1;  // Ignore reads in 'Post' blocks during ordering
     bool m_ignorePostWrite : 1;  // Ignore writes in 'Post' blocks during ordering
     bool m_ignoreSchedWrite : 1;  // Ignore writes in scheduling (for special optimizations)
@@ -2253,6 +2254,7 @@ class AstVar final : public AstNode {
         m_isReadByDpi = false;
         m_isWrittenByDpi = false;
         m_isWrittenBySuspendable = false;
+        m_isClockingEvent = false;
         m_ignorePostRead = false;
         m_ignorePostWrite = false;
         m_ignoreSchedWrite = false;
@@ -2442,6 +2444,8 @@ public:
     void setWrittenByDpi() { m_isWrittenByDpi = true; }
     bool isWrittenBySuspendable() const { return m_isWrittenBySuspendable; }
     void setWrittenBySuspendable() { m_isWrittenBySuspendable = true; }
+    bool isClockingEvent() const { return m_isClockingEvent; }
+    void setClockingEvent() { m_isClockingEvent = true; }
     bool ignorePostRead() const { return m_ignorePostRead; }
     void setIgnorePostRead() { m_ignorePostRead = true; }
     bool ignorePostWrite() const { return m_ignorePostWrite; }

--- a/src/V3AstNodeStmt.h
+++ b/src/V3AstNodeStmt.h
@@ -284,6 +284,8 @@ class AstCAwait final : public AstNodeStmt {
     // @astgen op1 := exprp : AstNodeExpr
     //
     // @astgen ptr := m_sentreep : Optional[AstSenTree]  // Sentree related to this await
+    //
+    // @astgen ptr := m_readySenTreep : Optional[AstSenTree]  // Clock edge gating @(cb) ready()
 public:
     AstCAwait(FileLine* fl, AstNodeExpr* exprp, AstSenTree* sentreep = nullptr)
         : ASTGEN_SUPER_CAwait(fl)
@@ -296,6 +298,9 @@ public:
     bool isTimingControl() const override { return true; }
     AstSenTree* sentreep() const { return m_sentreep; }
     void clearSentreep() { m_sentreep = nullptr; }
+    AstSenTree* readySenTreep() const { return m_readySenTreep; }
+    void readySenTreep(AstSenTree* nodep) { m_readySenTreep = nodep; }
+    void clearReadySenTreep() { m_readySenTreep = nullptr; }
 };
 class AstCReturn final : public AstNodeStmt {
     // C++ return from a function
@@ -673,6 +678,9 @@ class AstEventControl final : public AstNodeStmt {
     // Parents: stmtlist
     // @astgen op1 := sentreep : Optional[AstSenTree]
     // @astgen op2 := stmtsp : List[AstNode]
+    // True if a wait on a clocking event may resolve on the current cycle (procedural ##0)
+    bool m_syncCurrentCycle = false;
+
 public:
     AstEventControl(FileLine* fl, AstSenTree* sentreep, AstNode* stmtsp)
         : ASTGEN_SUPER_EventControl(fl) {
@@ -680,9 +688,16 @@ public:
         addStmtsp(stmtsp);
     }
     ASTGEN_MEMBERS_AstEventControl;
+    void dump(std::ostream& str) const override;
+    void dumpJson(std::ostream& str) const override;
     string verilogKwd() const override { return "@(%l) %r"; }
     bool isTimingControl() const override { return true; }
+    bool sameNode(const AstNode* samep) const override {
+        return syncCurrentCycle() == VN_DBG_AS(samep, EventControl)->syncCurrentCycle();
+    }
     int instrCount() const override { return 0; }
+    bool syncCurrentCycle() const { return m_syncCurrentCycle; }
+    void syncCurrentCycle(bool flag) { m_syncCurrentCycle = flag; }
 };
 class AstExecGraph final : public AstNodeStmt {
     // For parallel execution, this node contains a dependency graph. Each

--- a/src/V3AstNodes.cpp
+++ b/src/V3AstNodes.cpp
@@ -450,6 +450,7 @@ AstVar* AstClocking::ensureEventp(bool childDType) {
                          : new AstVar{fileline(), VVarType::MODULETEMP, m_name,
                                       findBasicDType(VBasicDTypeKwd::EVENT)};
         evp->lifetime(VLifetime::STATIC_EXPLICIT);
+        evp->setClockingEvent();
         eventp(evp);
         // Trigger the clocking event in Observed (IEEE 1800-2023 14.13)
         addNextHere(new AstAlwaysObserved{
@@ -3306,6 +3307,7 @@ void AstVar::dump(std::ostream& str) const {
     if (ignorePostWrite()) str << " [IGNPWR]";
     if (ignoreSchedWrite()) str << " [IGNWR]";
     if (isStdRandomizeArg()) str << " [STDRANDARG]";
+    if (isClockingEvent()) str << " [CLOCKINGEVT]";
     if (!lifetime().isNone()) str << " [" << lifetime().ascii() << "] ";
     str << " " << varType();
 }
@@ -3336,6 +3338,7 @@ void AstVar::dumpJson(std::ostream& str) const {
     dumpJsonBoolFuncIf(str, isFuncReturn);
     dumpJsonBoolFuncIf(str, isFuncLocal);
     dumpJsonBoolFuncIf(str, isStdRandomizeArg);
+    dumpJsonBoolFuncIf(str, isClockingEvent);
     dumpJsonStr(str, "lifetime", lifetime().ascii());
     dumpJsonStr(str, "varType", varType().ascii());
     if (dtypep()) dumpJsonStr(str, "dtypeName", dtypep()->name());
@@ -3724,8 +3727,23 @@ void AstCAwait::dump(std::ostream& str) const {
         str << " => ";
         sentreep()->dump(str);
     }
+    if (readySenTreep()) {
+        str << " ready=> ";
+        readySenTreep()->dump(str);
+    }
 }
-void AstCAwait::dumpJson(std::ostream& str) const { dumpJsonGen(str); }
+void AstCAwait::dumpJson(std::ostream& str) const {
+    dumpJsonBoolIf(str, "readySenTree", readySenTreep());
+    dumpJsonGen(str);
+}
+void AstEventControl::dump(std::ostream& str) const {
+    this->AstNodeStmt::dump(str);
+    if (syncCurrentCycle()) str << " [SYNCCURCYCLE]";
+}
+void AstEventControl::dumpJson(std::ostream& str) const {
+    dumpJsonBoolFuncIf(str, syncCurrentCycle);
+    dumpJsonGen(str);
+}
 int AstCMethodHard::instrCount() const {
     return 0;  // TODO
 }

--- a/src/V3Sched.cpp
+++ b/src/V3Sched.cpp
@@ -1063,6 +1063,7 @@ void schedule(AstNetlist* netlistp) {
     remapSensitivities(logicRegions.m_act, trigKit.mapVec());
     remapSensitivities(logicReplicas.m_act, trigKit.mapVec());
     remapSensitivities(timingKit.m_lbs, trigKit.mapVec());
+    timingKit.remapReadySenses(trigKit.mapVec());
     const std::map<const AstVarScope*, std::vector<AstSenTree*>> actTimingDomains
         = timingKit.remapDomains(trigKit.mapVec());
 
@@ -1172,7 +1173,10 @@ void schedule(AstNetlist* netlistp) {
     } else {
         // beforeTrigVisitor clears Sentree pointers in AstCAwaits (as these sentrees will get
         // deleted later) if there was no need to call it, SenTrees have to be cleaned manually
-        netlistp->foreach([](AstCAwait* const cAwaitp) { cAwaitp->clearSentreep(); });
+        netlistp->foreach([](AstCAwait* const cAwaitp) {
+            cAwaitp->clearSentreep();
+            cAwaitp->clearReadySenTreep();
+        });
     }
     if (AstVarScope* const trigAccp = trigKit.vscAccp()) {
         // Copy trigger vector to accumulator at the end of static initialziation so,

--- a/src/V3Sched.h
+++ b/src/V3Sched.h
@@ -374,10 +374,15 @@ class TimingKit final {
 public:
     LogicByScope m_lbs;  // Actives that resume timing schedulers
     AstNodeStmt* m_postUpdates = nullptr;  // Post updates for the trigger eval function
+    // Trigger-scheduler vscp -> clock sense that gates its ready() (clocking events)
+    std::map<const AstVarScope*, AstSenTree*> m_readySenTrees;
 
     // Remaps external domains using the specified trigger map
     std::map<const AstVarScope*, std::vector<AstSenTree*>> remapDomains(
         const std::unordered_map<const AstSenTree*, AstSenTree*>& trigMap) const VL_MT_DISABLED;
+    // Remaps the clocking-event ready senses in-place using the specified trigger map
+    void remapReadySenses(const std::unordered_map<const AstSenTree*, AstSenTree*>& trigMap)
+        VL_MT_DISABLED;
     // Get the delay scheduler variable
     AstVarScope* getDelayScheduler(AstNetlist* const netlistp) VL_MT_DISABLED;
     // Creates a timing resume call (if needed, else returns null)

--- a/src/V3SchedTiming.cpp
+++ b/src/V3SchedTiming.cpp
@@ -53,6 +53,15 @@ TimingKit::remapDomains(const std::unordered_map<const AstSenTree*, AstSenTree*>
     return remappedDomainMap;
 }
 
+void TimingKit::remapReadySenses(
+    const std::unordered_map<const AstSenTree*, AstSenTree*>& trigMap) {
+    for (auto& p : m_readySenTrees) {
+        const auto it = trigMap.find(p.second);
+        UASSERT(it != trigMap.end(), "Clocking-event ready sense missing from trigger map");
+        p.second = it->second;
+    }
+}
+
 //============================================================================
 // Creates a timing resume call (if needed, else returns null)
 
@@ -70,7 +79,7 @@ AstCCall* TimingKit::createResume(AstNetlist* const netlistp) {
 
         for (const auto& p : m_lbs) {
             AstActive* const activep = p.second;
-            activep->foreach([this](AstCMethodHard* const exprp) {
+            activep->foreach([this, activep](AstCMethodHard* const exprp) {
                 if (exprp->method() != VCMethod::SCHED_RESUME) return;
                 AstNodeExpr* const fromp = exprp->fromp();
                 if (VN_AS(fromp->dtypep(), BasicDType)->keyword()
@@ -82,7 +91,16 @@ AstCCall* TimingKit::createResume(AstNetlist* const netlistp) {
                     VCMethod::SCHED_MOVE_TO_RESUME_QUEUE,
                     exprp->pinsp() ? exprp->pinsp()->cloneTree(true) : nullptr};
                 moveToResumep->dtypeSetVoid();
-                m_resumeFuncp->addStmtsp(moveToResumep->makeStmt());
+                AstNode* stmtp = moveToResumep->makeStmt();
+                // Clocking-event schedulers: reach the resume queue only when the event fires,
+                // while ready() (on the clock edge) froze the eligible set. See createReady.
+                const auto it = m_readySenTrees.find(VN_AS(fromp, VarRef)->varScopep());
+                if (it != m_readySenTrees.end()) {
+                    AstIf* const ifp = V3Sched::util::createIfFromSenTree(activep->sentreep());
+                    ifp->addThensp(stmtp);
+                    stmtp = ifp;
+                }
+                m_resumeFuncp->addStmtsp(stmtp);
             });
         }
 
@@ -152,7 +170,11 @@ AstCCall* TimingKit::createReady(AstNetlist* const netlistp) {
                 scopeTopp->addBlocksp(m_readyFuncp);
             }
 
-            AstSenTree* const senTreep = activep->sentreep();
+            // Clocking-event waits gate ready() on the clock edge, not the event. See
+            // createResume.
+            AstSenTree* senTreep = activep->sentreep();
+            const auto readyIt = m_readySenTrees.find(schedulerp);
+            if (readyIt != m_readySenTrees.end()) senTreep = readyIt->second;
             FileLine* const flp = senTreep->fileline();
 
             // Create an 'AstIf' sensitive to the suspending triggers
@@ -190,6 +212,8 @@ class AwaitVisitor final : public VNVisitor {
     AstNodeStmt*& m_postUpdatesr;  // Post updates for the trigger eval function
     // Additional var sensitivities
     std::map<const AstVarScope*, std::set<AstSenTree*>>& m_externalDomains;
+    // Trigger-scheduler vscp -> clock sense that gates its ready() (clocking events)
+    std::map<const AstVarScope*, AstSenTree*>& m_readySenTrees;
     std::set<AstSenTree*> m_processDomains;  // Sentrees from the current process
     // Variables written by suspendable processes
     std::vector<AstVarScope*> m_writtenBySuspendable;
@@ -213,6 +237,10 @@ class AwaitVisitor final : public VNVisitor {
         auto* const methodp = VN_AS(awaitp->exprp(), CMethodHard);
         AstVarScope* const schedulerp = VN_AS(methodp->fromp(), VarRef)->varScopep();
         AstSenTree* const sentreep = awaitp->sentreep();
+        // Record the clock sense that gates ready() for a clocking-event wait (see createReady).
+        if (AstSenTree* const readySensep = awaitp->readySenTreep()) {
+            m_readySenTrees.emplace(schedulerp, readySensep);
+        }
         FileLine* const flp = sentreep->fileline();
         // Create a resume() call on the timing scheduler
         auto* const resumep = new AstCMethodHard{
@@ -282,11 +310,13 @@ class AwaitVisitor final : public VNVisitor {
 public:
     // CONSTRUCTORS
     explicit AwaitVisitor(AstNetlist* nodep, LogicByScope& lbs, AstNodeStmt*& postUpdatesr,
-                          std::map<const AstVarScope*, std::set<AstSenTree*>>& externalDomains)
+                          std::map<const AstVarScope*, std::set<AstSenTree*>>& externalDomains,
+                          std::map<const AstVarScope*, AstSenTree*>& readySenTrees)
         : m_scopeTopp{nodep->topScopep()->scopep()}
         , m_lbs{lbs}
         , m_postUpdatesr{postUpdatesr}
-        , m_externalDomains{externalDomains} {
+        , m_externalDomains{externalDomains}
+        , m_readySenTrees{readySenTrees} {
         iterate(nodep);
     }
     ~AwaitVisitor() override = default;
@@ -297,8 +327,11 @@ TimingKit prepareTiming(AstNetlist* const netlistp) {
     LogicByScope lbs;
     AstNodeStmt* postUpdates = nullptr;
     std::map<const AstVarScope*, std::set<AstSenTree*>> externalDomains;
-    { AwaitVisitor{netlistp, lbs, postUpdates, externalDomains}; }
-    return {std::move(lbs), postUpdates, std::move(externalDomains)};
+    std::map<const AstVarScope*, AstSenTree*> readySenTrees;
+    { AwaitVisitor{netlistp, lbs, postUpdates, externalDomains, readySenTrees}; }
+    TimingKit kit{std::move(lbs), postUpdates, std::move(externalDomains)};
+    kit.m_readySenTrees = std::move(readySenTrees);
+    return kit;
 }
 
 //============================================================================

--- a/src/V3SchedTrigger.cpp
+++ b/src/V3SchedTrigger.cpp
@@ -992,6 +992,7 @@ class AwaitBeforeTrigVisitor final : public VNVisitor {
             }
         }
         nodep->clearSentreep();  // Clear as these sentrees will get deleted later
+        nodep->clearReadySenTreep();  // Ditto
         iterate(nodep);
     }
 

--- a/src/V3Timing.cpp
+++ b/src/V3Timing.cpp
@@ -509,6 +509,11 @@ class TimingControlVisitor final : public VNVisitor {
     // Other
     SenTreeFinder m_finder{m_netlistp};  // Sentree finder and uniquifier
     SenExprBuilder* m_senExprBuilderp = nullptr;  // Sens expression builder for current m_scope
+    // Clocking-event var -> the clock sense that gates its @(cb) ready()
+    std::map<const AstVarScope*, AstSenTree*> m_clockingEventSenses;
+    // Ditto keyed by AstVar, for @(vif.cb) reached through a (virtual) interface handle
+    std::map<const AstVar*, AstSenTree*> m_clockingEventSensesByVar;
+    bool m_clockingEventSensesGathered = false;
 
     // Stats
     size_t m_statZeroDelays = 0;  // Number of statically known #0 delays
@@ -657,6 +662,68 @@ class TimingControlVisitor final : public VNVisitor {
             sentreep->user1p(trigSchedp);
         }
         return VN_AS(sentreep->user1p(), VarScope);
+    }
+    // Map each clocking-event var to the clock sense of the Observed active that fires it. The
+    // event fire is lowered to opaque code in V3Delayed (after this pass), so gather it here.
+    void gatherClockingEventSenses() {
+        if (m_clockingEventSensesGathered) return;
+        m_clockingEventSensesGathered = true;
+        m_netlistp->foreach([this](AstActive* const activep) {
+            if (!activep->sentreep()) return;
+            activep->foreach([&](AstFireEvent* const firep) {
+                const AstVarRef* const refp = VN_CAST(firep->operandp(), VarRef);
+                if (!refp || !refp->varp()->isClockingEvent()) return;
+                // Canonicalize so the pointer is to a stable, pointable sentree, as for
+                // m_sentreep.
+                AstSenTree* const sensep = m_finder.getSenTree(activep->sentreep());
+                m_clockingEventSenses.emplace(refp->varScopep(), sensep);
+                m_clockingEventSensesByVar.emplace(refp->varp(), sensep);
+            });
+        });
+    }
+    // The clock sense that fires the given clocking-event var, by concrete VarScope
+    AstSenTree* clockingEventSensep(const AstVarScope* const evtVscp) {
+        gatherClockingEventSenses();
+        const auto it = m_clockingEventSenses.find(evtVscp);
+        return it == m_clockingEventSenses.end() ? nullptr : it->second;
+    }
+    // Ditto by AstVar, for a clocking event reached through a (virtual) interface handle
+    AstSenTree* clockingEventSenseByVarp(const AstVar* const evtVarp) {
+        gatherClockingEventSenses();
+        const auto it = m_clockingEventSensesByVar.find(evtVarp);
+        return it == m_clockingEventSensesByVar.end() ? nullptr : it->second;
+    }
+    // Rebuild a clock edge through an interface handle: 'posedge vif.clk' from the
+    // instance-scope 'posedge clk'. Null unless the clock is a member of that interface
+    // (V3Width keeps it one), as a MemberSel on a non-member only fails at C++ compile time.
+    AstSenTree* buildHandleClockSensep(AstSenTree* const instClkSenp, AstNodeExpr* const handlep) {
+        const AstNodeDType* const hdtypep
+            = handlep->dtypep() ? handlep->dtypep()->skipRefp() : nullptr;
+        const AstIfaceRefDType* const ifrefp = VN_CAST(hdtypep, IfaceRefDType);
+        if (!ifrefp || !ifrefp->ifaceViaCellp()) return nullptr;
+        AstSenItem* const sip = instClkSenp->sensesp();
+        if (sip->nextp()) return nullptr;  // Multi-edge clocking event; not rebuildable
+        AstVarRef* const refp = VN_CAST(sip->sensp(), VarRef);
+        if (!refp || !refp->varScopep()
+            || refp->varScopep()->scopep()->modp() != ifrefp->ifaceViaCellp()) {
+            return nullptr;
+        }
+        AstMemberSel* const mselp
+            = new AstMemberSel{sip->fileline(), handlep->cloneTree(false), refp->varp()};
+        return new AstSenTree{instClkSenp->fileline(),
+                              new AstSenItem{sip->fileline(), sip->edgeType(), mselp}};
+    }
+    // The clock edge to latch for a @(vif.cb) wait, which wakes on the clock edge but resumes
+    // on the event (as for plain @(cb)) so a mid-timestep arrival defers to the next edge. The
+    // handle resolves at run time, so it is gated in the dynamic poll loop. Null otherwise.
+    AstSenTree* handleClockSensep(AstEventControl* const nodep) {
+        if (nodep->syncCurrentCycle()) return nullptr;
+        AstSenItem* const senip = nodep->sentreep()->sensesp();
+        if (!senip || senip->nextp() || senip->edgeType() != VEdgeType::ET_EVENT) return nullptr;
+        const AstMemberSel* const mselp = VN_CAST(senip->sensp(), MemberSel);
+        if (!mselp || !mselp->varp() || !mselp->varp()->isClockingEvent()) return nullptr;
+        AstSenTree* const instClkp = clockingEventSenseByVarp(mselp->varp());
+        return instClkp ? buildHandleClockSensep(instClkp, mselp->fromp()) : nullptr;
     }
     // Creates a string describing the sentree
     AstCExpr* createEventDescription(AstSenTree* const sentreep) const {
@@ -1077,10 +1144,11 @@ class TimingControlVisitor final : public VNVisitor {
         FileLine* const flp = nodep->fileline();
         // Relink child statements after the event control
         if (nodep->stmtsp()) nodep->addNextHere(nodep->stmtsp()->unlinkFrBackWithNext());
-        if (needDynamicTrigger(nodep->sentreep())) {
+        AstSenTree* const latchClkSenp = handleClockSensep(nodep);
+        if (needDynamicTrigger(nodep->sentreep()) || latchClkSenp) {
             // Create the trigger variable and init it with 0
-            AstVarScope* const trigvscp
-                = createTemp(flp, m_dynTrigNames.get(nodep), nodep->findBitDType(), nodep);
+            const std::string trigName = m_dynTrigNames.get(nodep);
+            AstVarScope* const trigvscp = createTemp(flp, trigName, nodep->findBitDType(), nodep);
             auto* const initp = new AstAssign{flp, new AstVarRef{flp, trigvscp, VAccess::WRITE},
                                               new AstConst{flp, AstConst::BitFalse{}}};
             // Await the eval step with the dynamic trigger scheduler. First, create the method
@@ -1097,10 +1165,31 @@ class TimingControlVisitor final : public VNVisitor {
                 = new AstCAwait{flp, evalMethodp, getCreateDynamicTriggerSenTree()};
             // Construct the sen expression for this sentree
             UASSERT_OBJ(m_senExprBuilderp, nodep, "No SenExprBuilder for this scope");
-            auto* const assignp = new AstAssign{flp, new AstVarRef{flp, trigvscp, VAccess::WRITE},
-                                                m_senExprBuilderp->build(sentreep).first};
+            // For @(vif.cb), trigger only once the latched edge and the event have both come
+            AstNodeStmt* readyInitp = nullptr;
+            AstNodeStmt* readyLatchp = nullptr;
+            AstNodeExpr* trigExprp;
+            if (latchClkSenp) {
+                AstNodeExpr* const edgep = m_senExprBuilderp->build(latchClkSenp).first;
+                AstNodeExpr* const eventp = m_senExprBuilderp->build(sentreep).first;
+                AstVarScope* const readyvscp
+                    = createTemp(flp, trigName + "__ready", nodep->findBitDType(), nodep);
+                readyInitp = new AstAssign{flp, new AstVarRef{flp, readyvscp, VAccess::WRITE},
+                                           new AstConst{flp, AstConst::BitFalse{}}};
+                readyLatchp = new AstAssign{
+                    flp, new AstVarRef{flp, readyvscp, VAccess::WRITE},
+                    new AstOr{flp, new AstVarRef{flp, readyvscp, VAccess::READ}, edgep}};
+                trigExprp = new AstAnd{flp, new AstVarRef{flp, readyvscp, VAccess::READ}, eventp};
+            } else {
+                trigExprp = m_senExprBuilderp->build(sentreep).first;
+            }
+            auto* const assignp
+                = new AstAssign{flp, new AstVarRef{flp, trigvscp, VAccess::WRITE}, trigExprp};
             // Get the SenExprBuilder results
             const SenExprBuilder::Results senResults = m_senExprBuilderp->getAndClearResults();
+            // Delete only after getAndClearResults(): the builder holds VNRef keys into
+            // latchClkSenp until then.
+            if (latchClkSenp) VL_DO_DANGLING(latchClkSenp->deleteTree(), latchClkSenp);
             localizeVars(m_procp, senResults.m_vars);
             // If post updates are destructive (e.g. clearFired on events), perform a
             // conservative pre-clear once before entering the wait loop so stale state from a
@@ -1115,6 +1204,8 @@ class TimingControlVisitor final : public VNVisitor {
             loopp->addStmtsp(awaitEvalp);
             // Put pre updates before the trigger check and assignment
             for (AstNodeStmt* const stmtp : senResults.m_preUpdates) loopp->addStmtsp(stmtp);
+            // Latch the clock edge before the trigger assignment reads it
+            if (readyLatchp) loopp->addStmtsp(readyLatchp);
             // Then the trigger check and assignment
             loopp->addStmtsp(assignp);
             // Let the dynamic trigger scheduler know if this trigger was set
@@ -1138,9 +1229,11 @@ class TimingControlVisitor final : public VNVisitor {
             VN_AS(awaitResumep->exprp(), CMethodHard)->method(VCMethod::SCHED_RESUMPTION);
             AstNode::addNext<AstNodeStmt, AstNodeStmt>(loopp, awaitResumep);
             // Replace the event control with one explicit stmt chain:
-            //   init -> [inits] -> [optional destructive pre-clears] -> loop -> awaitResumption
+            //   init -> [ready init] -> [inits] -> [optional destructive pre-clears] -> loop
+            //        -> awaitResumption
             AstNodeStmt* chainp = nullptr;
             chainp = AstNode::addNextNull(chainp, initp);
+            if (readyInitp) chainp = AstNode::addNextNull(chainp, readyInitp);
             for (AstNodeStmt* const stmtp : senResults.m_inits) {
                 chainp = AstNode::addNextNull(chainp, stmtp);
             }
@@ -1167,6 +1260,20 @@ class TimingControlVisitor final : public VNVisitor {
             addEventDebugInfo(triggerMethodp, sentreep);
             // Create the co_await
             AstCAwait* const awaitp = new AstCAwait{flp, triggerMethodp, sentreep};
+            // A plain @(cb) wait gates ready() on the clock edge, not the event, so a process
+            // reaching it mid-timestep blocks to the next edge. See V3SchedTiming.
+            AstSenItem* const senip = sentreep->sensesp();
+            if (!nodep->syncCurrentCycle() && senip && !senip->nextp()
+                && senip->edgeType() == VEdgeType::ET_EVENT) {
+                if (const AstVarRef* const evrefp = VN_CAST(senip->sensp(), VarRef)) {
+                    if (evrefp->varp()->isClockingEvent()) {
+                        if (AstSenTree* const clkSensep
+                            = clockingEventSensep(evrefp->varScopep())) {
+                            awaitp->readySenTreep(clkSensep);
+                        }
+                    }
+                }
+            }
             nodep->replaceWith(awaitp);
         }
         VL_DO_DANGLING(nodep->deleteTree(), nodep);

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -3870,8 +3870,17 @@ class WidthVisitor final : public VNVisitor {
             if (memberSelClass(nodep, adtypep)) return;
         } else if (AstIfaceRefDType* const adtypep = VN_CAST(fromDtp, IfaceRefDType)) {
             if (AstNode* foundp = memberSelIface(nodep, adtypep)) {
-                if (AstClocking* const clockingp = VN_CAST(foundp, Clocking))
+                if (AstClocking* const clockingp = VN_CAST(foundp, Clocking)) {
+                    // @(vif.cb) reads the clock through the handle (see V3Timing), so it
+                    // must stay a member rather than be optimized to its driver
+                    if (adtypep->isVirtual()) {
+                        AstIface* const clkIfacep = adtypep->ifaceViaCellp();
+                        clockingp->sensesp()->foreach([clkIfacep](AstVarRef* const refp) {
+                            refp->varp()->sensIfacep(clkIfacep);
+                        });
+                    }
                     foundp = clockingp->ensureEventp();
+                }
                 if (AstVar* const varp = VN_CAST(foundp, Var)) {
                     if (!varp->didWidth()) userIterate(varp, nullptr);
                     nodep->dtypep(foundp->dtypep());

--- a/test_regress/t/t_clocking_midslot.py
+++ b/test_regress/t/t_clocking_midslot.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+# --dump-tree: dev coverage of AstCAwait::dump()'s ready sentree arm, which needs a
+# clocking-event wait and so cannot be reached by the --lint-only t_debug_emitv
+test.compile(verilator_flags2=["--binary", "--debugi 1", "--dump-tree", "--dump-tree-json"])
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_clocking_midslot.v
+++ b/test_regress/t/t_clocking_midslot.v
@@ -1,0 +1,191 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain
+// SPDX-FileCopyrightText: 2026 Wilson Snyder
+// SPDX-License-Identifier: CC0-1.0
+//
+// A clocking event wait executed by a process resumed mid-timestep by something
+// other than the clocking event (here a mailbox get) must block until the NEXT
+// clocking event, not the edge already in progress in the current timestep. The
+// clocking event fires in the Observed region; a process resumed in the Active
+// region of the same edge reaches the wait, suspends, and must not be woken by
+// that same edge's Observed fire (which would collapse a one-clock pulse).
+//
+// Covers @(cb) directly, and @(vif.cb) through a (virtual) interface handle in a
+// module process (static path) and a class method (dynamic path), plus a second
+// interface instance (the clock-sense map is first-instance-wins) and clocks that
+// are not plain interface members: via a port, and aliased inside the interface.
+//
+// posedges at 5, 15, 25, ...; output skew #1.
+
+// verilog_format: off
+`define stop $stop
+`define checkd(gotv,expv) do if ((gotv) !== (expv)) begin $write("%%Error: %s:%0d:  got=%0d exp=%0d (%s !== %s)\n", `__FILE__,`__LINE__, (gotv), (expv), `"gotv`", `"expv`"); `stop; end while(0);
+// verilog_format: on
+
+interface Iface;
+  logic clk = 0;
+  logic sig;
+  clocking cb @(posedge clk);
+    default output #1;
+    output sig;
+  endclocking
+endinterface
+
+interface IfaceP (
+    input logic clk
+);
+  logic sig;
+  clocking cb @(posedge clk);
+    default output #1;
+    output sig;
+  endclocking
+endinterface
+
+interface IfaceA (
+    input logic clk_i
+);
+  logic clk;
+  logic sig;
+  assign clk = clk_i;
+  clocking cb @(posedge clk);
+    default output #1;
+    output sig;
+  endclocking
+endinterface
+
+class Drv;
+  virtual Iface vif;
+  mailbox #(int) mb;
+  time t_cb;
+  task run();
+    int n;
+    mb.get(n);  // resume mid-slot at t=15
+    @(vif.cb);  // must block to t=25
+    t_cb = $time;
+  endtask
+endclass
+
+module t;
+  timeunit 1ns; timeprecision 1ns;
+
+  logic clk = 0;
+  logic sig;
+  bit seen = 0;  // did sig ever reach 1?
+  always #5 clk = ~clk;
+
+  clocking cb @(posedge clk);
+    default output #1;
+    output sig;
+  endclocking
+
+  Iface intf ();
+  Iface intf2 ();
+  IfaceP intfp (.clk(clk));
+  IfaceA intfa (.clk_i(clk));
+
+  virtual Iface vif;
+  virtual Iface vif2;
+  virtual IfaceP vifp;
+  virtual IfaceA vifa;
+
+  always #5 intf.clk = ~intf.clk;
+  always #5 intf2.clk = ~intf2.clk;
+
+  mailbox #(int) mb_probe = new();
+  mailbox #(int) mb_pulse = new();
+  mailbox #(int) mb_mod = new();
+  mailbox #(int) mb_mod2 = new();
+  mailbox #(int) mb_port = new();
+  mailbox #(int) mb_alias = new();
+
+  time t_first_cb, t_mod_cb, t_mod2_cb, t_port_cb, t_alias_cb;
+
+  // Direct @(cb): timing after a mid-slot resume must be the next edge
+  initial begin : timing_probe
+    int n;
+    mb_probe.get(n);
+    @(cb);
+    t_first_cb = $time;
+  end
+
+  // Direct @(cb): a one-clock pulse driven across a mid-slot resume must survive
+  initial begin : pulse_driver
+    int n;
+    mb_pulse.get(n);
+    cb.sig <= 1'b1;
+    @(cb);
+    cb.sig <= 1'b0;
+  end
+  always @(posedge clk) if (sig === 1'b1) seen = 1;
+
+  // Static path: @(vif.cb) in a module process
+  initial begin : mod_driver
+    int n;
+    vif = intf;
+    mb_mod.get(n);
+    @(vif.cb);
+    t_mod_cb = $time;
+  end
+
+  // Second instance of the same interface: exercises first-instance-wins clock sense
+  initial begin : mod_driver2
+    int n;
+    vif2 = intf2;
+    mb_mod2.get(n);
+    @(vif2.cb);
+    t_mod2_cb = $time;
+  end
+
+  // Port clock: not a plain member, so the handle rebuild needs it kept interface-sensitive
+  initial begin : port_driver
+    int n;
+    vifp = intfp;
+    mb_port.get(n);
+    @(vifp.cb);
+    t_port_cb = $time;
+  end
+
+  // Clock aliased inside the interface: also not a plain member after gate optimization
+  initial begin : alias_driver
+    int n;
+    vifa = intfa;
+    mb_alias.get(n);
+    @(vifa.cb);
+    t_alias_cb = $time;
+  end
+
+  // Dynamic path: @(vif.cb) in a class method
+  Drv d = new;
+
+  initial begin : check
+    d.vif = intf;
+    d.mb = new;
+    fork
+      d.run();
+    join_none
+    repeat (2) @(posedge clk);  // t=15
+    mb_probe.put(1);
+    mb_pulse.put(1);
+    mb_mod.put(1);
+    mb_mod2.put(1);
+    mb_port.put(1);
+    mb_alias.put(1);
+    d.mb.put(1);
+    repeat (4) @(posedge clk);
+    `checkd(t_first_cb, 25);  // direct @(cb)
+    `checkd(seen, 1);  // one-clock pulse survived
+    `checkd(t_mod_cb, 25);  // module @(vif.cb)
+    `checkd(t_mod2_cb, 25);  // 2nd-instance @(vif2.cb)
+    `checkd(d.t_cb, 25);  // class @(vif.cb)
+    `checkd(t_port_cb, 25);  // port-clock @(vifp.cb)
+    `checkd(t_alias_cb, 25);  // internally-aliased clock @(vifa.cb)
+    $write("*-* All Finished *-*\n");
+    $finish;
+  end
+
+  initial begin
+    #1000;
+    `stop;
+  end
+endmodule

--- a/test_regress/t/t_debug_emitv.out
+++ b/test_regress/t/t_debug_emitv.out
@@ -1335,6 +1335,28 @@ module Vt_debug_emitv_seq_event;
             @( sq())end
     end
 endmodule
+module Vt_debug_emitv_clocking_event;
+    input logic clk;
+    logic sig;
+
+    ???? // CLOCKING 'cb'
+    posedge clk
+    ???? // CLOCKINGITEM
+    32'h0siglogic sig;
+    event cb;
+
+    ???? // ALWAYSOBSERVED
+    @(posedge clk)
+    ???? // FIREEVENT
+    cbinitial begin
+        begin
+
+            ???? // EVENTCONTROL
+            @( cb)##0;
+            sig = 1;
+        end
+    end
+endmodule
 package Vt_debug_emitv_p;
     logic pkgvar;
 endpackage

--- a/test_regress/t/t_debug_emitv.v
+++ b/test_regress/t/t_debug_emitv.v
@@ -140,6 +140,7 @@ module t (/*AUTOARG*/
 
   sub sub(.*);
   seq_event seq_event(.*);
+  clocking_event clocking_event(.*);
 
   initial begin
     int other;
@@ -452,6 +453,17 @@ module seq_event(input logic clk);
   endsequence
   initial begin
     @sq;
+  end
+endmodule
+
+module clocking_event(input logic clk);
+  logic sig;
+  default clocking cb @(posedge clk);
+    output sig;
+  endclocking
+  initial begin
+    @(cb);
+    ##0 sig = 1;
   end
 endmodule
 


### PR DESCRIPTION
Fixes #7934.

A process resumed mid-timestep by something other than the clocking event
(for example a blocking `mailbox.get()`) that then waits on a clocking event
was woken by the clocking event of the edge already in progress, instead of
blocking until the next edge. This collapsed a one-clock pulse
(`cb.sig <= 1; @(cb); cb.sig <= 0`) into a single timestep, losing the pulse.

The clocking event is fired in the Observed region. The
trigger scheduler for `@(cb)` gated both its `ready()` and its `resume()` on
that late event, so a waiter that suspended earlier in the same timestep was
swept in by the same edge. `@(posedge clk)` does not have this problem because
its `ready()` is gated on the early clock edge, so a late-suspending process
misses it and waits for the next edge.

The fix separates the two gates for clocking-event waits:

- `@(cb)` (static trigger scheduler): gate `ready()` on the clock edge (early)
  while `resume()` stays gated on the event's fired flag (Observed). A process
  arriving mid-timestep defers to the next edge; an already-waiting process
  still resumes after Observed input sampling, so sampled input clockvars stay
  correct.
- `@(vif.cb)` (clocking event through a virtual interface handle): the handle
  is only known at runtime, so the wait is routed to the dynamic trigger
  scheduler and the same split is applied inside its poll loop with a sticky
  latch (latch the clock edge, trigger only once the event has also fired). A
  plain `edge && fired` conjunction can never be true in one evaluation,
  because the edge is consumed in the Active region before the event fires in
  Observed, so the latch is required. The clock edge is rebuilt through the
  handle only when the clock is a plain member of the interface; a
  port-aliased or imported clock falls back to the previous behavior instead
  of generating an invalid member access.

Procedural `##0` keeps its current-cycle behavior via
`AstEventControl::syncCurrentCycle`.

New test `t_clocking_midslot` covers: plain `@(cb)` timing and the lost pulse
from the issue reproducer, `@(vif.cb)` in a module process (static path) and
in a class method (dynamic path), a second interface instance, and a
port-clocked interface (the rebuild bail path).