### PR TITLE
Fix types of queue methods

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -36,6 +36,7 @@ Artur Bieniek
 AUDIY
 Aylon Chaim Porat
 Bartłomiej Chmiel
+Bartosz Skorowski
 Benjamin Collier
 Brian Li
 Cameron Kirk

--- a/include/verilated_types.h
+++ b/include/verilated_types.h
@@ -932,7 +932,7 @@ public:
     VlQueue min(T_Func with_func) const {
         if (m_deque.empty()) return VlQueue{};
         const auto it = std::min_element(m_deque.cbegin(), m_deque.cend(),
-                                         [&with_func](const IData& a, const IData& b) {
+                                         [&with_func](const T_Value& a, const T_Value& b) {
                                              return with_func(0, a) < with_func(0, b);
                                          });
         return VlQueue::consV(*it);
@@ -946,7 +946,7 @@ public:
     VlQueue max(T_Func with_func) const {
         if (m_deque.empty()) return VlQueue{};
         const auto it = std::max_element(m_deque.cbegin(), m_deque.cend(),
-                                         [&with_func](const IData& a, const IData& b) {
+                                         [&with_func](const T_Value& a, const T_Value& b) {
                                              return with_func(0, a) < with_func(0, b);
                                          });
         return VlQueue::consV(*it);

--- a/test_regress/t/t_queue_method.v
+++ b/test_regress/t/t_queue_method.v
@@ -35,6 +35,7 @@ module t;
     bit b;
     string string_q[$];
     string string_qv[$];
+    string string_qe[$];
     point_3d points_q[$];  // Same as q and qv, but complex value type
     point_3d points_qv[$];
     Cls cls;
@@ -179,6 +180,19 @@ module t;
     `checkp(qv, "'{}");
     qv = qe.max;
     `checkp(qv, "'{}");
+
+    string_qv = string_q.min;
+    `checks(string_qv[0], "A");
+    string_qv = string_q.min(x) with (int'(x[0]) + 10);
+    `checks(string_qv[0],"A");
+    string_qv = string_q.max;
+    `checks(string_qv[0], "b");
+    string_qv = string_q.max(x) with (int'(x[0]) + 10);
+    `checks(string_qv[0],"b");
+    string_qv = string_qe.min;
+    `checkp(string_qv,"'{}");
+    string_qv = string_qe.max;
+    `checkp(string_qv,"'{}");
 
     // Reduction methods
     i = q.sum;


### PR DESCRIPTION
It fixes compilation error related to the instantiation of the VlQueue with a string template parameter.

`VlQueue::min` and `VlQueue::max` methods had lambdas with incorrect parameter types.