### PR TITLE
Fix BSD systems to use package prefix (#7969)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -219,6 +219,25 @@ AC_ARG_WITH([solver],
 AC_SUBST(CFG_WITH_SOLVER)
 AC_MSG_RESULT($CFG_WITH_SOLVER)
 
+# On BSD systems, third-party packages (e.g. liblz4) are typically installed
+# under a non-default prefix such as /usr/local. Tell generated verilated
+# makefiles where to look for those packaged headers and libraries.
+AC_ARG_VAR([CFG_PACKAGE_PREFIX],
+           [Prefix under which packaged dependencies are installed for verilated makefiles])
+AC_MSG_CHECKING([for package prefix for verilated makefiles])
+if test "x$prefix" != "x" && test "x$prefix" != "xNONE"; then
+  if test "x$CFG_PACKAGE_PREFIX" = "x"; then
+    case "`uname -s`" in
+      FreeBSD|OpenBSD|DragonFly*)
+        CFG_PACKAGE_PREFIX="$prefix"
+        echo "using --prefix=$prefix for package prefix for verilated makefiles (CFG_PACKAGE_PREFIX)"
+        ;;
+    esac
+  fi
+fi
+AC_MSG_RESULT([$CFG_PACKAGE_PREFIX])
+AC_SUBST([CFG_PACKAGE_PREFIX])
+
 ######################################################################
 ## Compiler checks
 

--- a/include/verilated.mk.in
+++ b/include/verilated.mk.in
@@ -55,6 +55,8 @@ CFG_LDLIBS_THREADS = @CFG_LDLIBS_THREADS@
 # Linker flags/libraries for runtime VPI library loading (+verilator+vpi+<lib>)
 CFG_LDFLAGS_DYNAMIC = @CFG_LDFLAGS_DYNAMIC@
 CFG_LDLIBS_DYNAMIC = @CFG_LDLIBS_DYNAMIC@
+# Package prefix for finding third-party dependencies on BSD
+CFG_PACKAGE_PREFIX = @CFG_PACKAGE_PREFIX@
 
 ######################################################################
 # Programs
@@ -110,6 +112,14 @@ VPATH += $(VERILATOR_ROOT)/include
 VPATH += $(VERILATOR_ROOT)/include/vltstd
 
 LDFLAGS += $(CFG_LDFLAGS_VERILATED)
+
+# On BSD systems, packaged dependencies (e.g. liblz4) live under a
+# non-default prefix such as /usr/local. Point the compiler and linker there.
+ifneq ($(CFG_PACKAGE_PREFIX),)
+  CXXFLAGS += -I$(CFG_PACKAGE_PREFIX)/include
+  CPPFLAGS += -I$(CFG_PACKAGE_PREFIX)/include
+  LDFLAGS += -L$(CFG_PACKAGE_PREFIX)/lib
+endif
 
 #OPT = -ggdb -DPRINTINITSTR -DDETECTCHANGE
 #OPT = -ggdb -DPRINTINITSTR


### PR DESCRIPTION
Fixes #7969.

On FreeBSD liblz4 was not found during verilated programs compilation because the liblz4 package is installed into /usr/local

configure now initializes the CFG_PACKAGE_PREFIX variable and uses it in verilated.mk to add proper flags to CXXFLAGS/CPPFLAGS/LDFLAGS variables.

We appreciate your contributing to Verilator.  If this is your first commit, please add your name to docs/CONTRIBUTORS, and read our contributing guidelines in docs/CONTRIBUTING.rst.
