### PR TITLE
FSM state coverage in .info files

### DIFF
--- a/src/VlcTop.cpp
+++ b/src/VlcTop.cpp
@@ -264,7 +264,7 @@ void VlcTop::writeInfo(const string& filename) {
             for (const auto& point : sc.points()) {
                 if (point->isFsmArc()) continue;
                 daCount = std::max(daCount, point->count());
-                if (!point->isFsmState()) infoPoints.push_back(point);
+                infoPoints.push_back(point);
             }
             os << "DA:" << sc.lineno() << "," << daCount << "\n";
             if (infoPoints.size() <= 1) continue;

--- a/test_regress/t/t_vlcov_data_g.dat
+++ b/test_regress/t/t_vlcov_data_g.dat
@@ -1,0 +1,10 @@
+# SystemC::Coverage-3
+C 'ft/t_cover_fsm_basic.vl45n7tfsm_arcpagev_fsm_arc/$rootot.state::ANY->S_IDLE[reset_include]Fvt.stateFfANYFtS_IDLEFgreset_includehtop.TOP' 1
+C 'ft/t_cover_fsm_basic.vl45n7tfsm_arcpagev_fsm_arc/$rootot.state::S_DONE->S_DONEFvt.stateFfS_DONEFtS_DONEhtop.TOP' 4
+C 'ft/t_cover_fsm_basic.vl45n7tfsm_arcpagev_fsm_arc/$rootot.state::S_IDLE->S_IDLEFvt.stateFfS_IDLEFtS_IDLEhtop.TOP' 3
+C 'ft/t_cover_fsm_basic.vl45n7tfsm_arcpagev_fsm_arc/$rootot.state::S_IDLE->S_RUNFvt.stateFfS_IDLEFtS_RUNhtop.TOP' 1
+C 'ft/t_cover_fsm_basic.vl45n7tfsm_arcpagev_fsm_arc/$rootot.state::S_RUN->S_DONEFvt.stateFfS_RUNFtS_DONEhtop.TOP' 1
+C 'ft/t_cover_fsm_basic.vl45n7tfsm_statepagev_fsm_state/$rootot.state::S_DONEFvt.stateFtS_DONEhtop.TOP' 1
+C 'ft/t_cover_fsm_basic.vl45n7tfsm_statepagev_fsm_state/$rootot.state::S_ERRFvt.stateFtS_ERRhtop.TOP' 0
+C 'ft/t_cover_fsm_basic.vl45n7tfsm_statepagev_fsm_state/$rootot.state::S_IDLEFvt.stateFtS_IDLEhtop.TOP' 0
+C 'ft/t_cover_fsm_basic.vl45n7tfsm_statepagev_fsm_state/$rootot.state::S_RUNFvt.stateFtS_RUNhtop.TOP' 1

--- a/test_regress/t/t_vlcov_opt_fsm_state.info.out
+++ b/test_regress/t/t_vlcov_opt_fsm_state.info.out
@@ -1,0 +1,10 @@
+TN:verilator_coverage
+SF:t/t_cover_fsm_basic.v
+DA:45,1
+BRDA:45,0,t.state::S_DONE,1
+BRDA:45,0,t.state::S_ERR,0
+BRDA:45,0,t.state::S_IDLE,0
+BRDA:45,0,t.state::S_RUN,1
+BRF:4
+BRH:0
+end_of_record

--- a/test_regress/t/t_vlcov_opt_fsm_state.py
+++ b/test_regress/t/t_vlcov_opt_fsm_state.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('dist')
+
+test.run(cmd=[
+    os.environ["VERILATOR_ROOT"] + "/bin/verilator_coverage", "--write-info",
+    test.obj_dir + "/coverage.info", "--filter-type fsm_state", "t/t_vlcov_data_g.dat"
+],
+         verilator_run=True)
+
+test.files_identical(test.obj_dir + "/coverage.info", "t/" + test.name + ".info.out")
+
+test.passes()


### PR DESCRIPTION
This PR introduces `fsm_state` coverage in `.info` files generated by `verilator_coverage`.

It is always enabled but if you think that it should be behind some flag (like `--fsm-coverage`), I may introduce some which will be required to get `fsm_state` coverage in `.info` files outputted by `verilator_coverage`.
