### PR TITLE
Fix "value of type 'VlWide<N>' is not contextually convertible to 'bool'" caused by V3Table

### DIFF
--- a/src/V3Table.cpp
+++ b/src/V3Table.cpp
@@ -370,8 +370,11 @@ private:
                 V3Number outputChgMask{nodep, static_cast<int>(m_outVarps.size()), 0};
                 outputChgMask.setBit(tov.ord(), 1);
                 AstNodeExpr* const condp
-                    = new AstAnd{fl, select(fl, outputAssignedTableVscp, indexVscp),
-                                 new AstConst{fl, outputChgMask}};
+                    = new AstNeq{fl,
+                                 new AstAnd{fl, select(fl, outputAssignedTableVscp, indexVscp),
+                                            new AstConst{fl, outputChgMask}},
+                                 new AstConst{fl, AstConst::WidthedValue{},
+                                              static_cast<int>(m_outVarps.size()), 0}};
                 outsetp = new AstIf{fl, condp, outsetp};
             }
 

--- a/test_regress/t/t_table_wide.py
+++ b/test_regress/t/t_table_wide.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile()
+
+test.passes()

--- a/test_regress/t/t_table_wide.v
+++ b/test_regress/t/t_table_wide.v
@@ -1,0 +1,146 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain.
+// SPDX-FileCopyrightText: 2026 Antmicro
+// SPDX-License-Identifier: CC0-1.0
+
+module m(input in);
+  // at least 65 variables are required
+  reg id42;
+  reg id43;
+  reg id44;
+  reg id45;
+  reg id46;
+  reg id47;
+  reg id48;
+  reg id49;
+  reg id50;
+  reg id51;
+  reg id52;
+  reg id53;
+  reg id54;
+  reg id55;
+  reg id56;
+  reg id57;
+  reg id58;
+  reg id59;
+  reg id60;
+  reg id61;
+  reg id62;
+  reg id63;
+  reg id64;
+  reg id65;
+  reg id66;
+  reg id67;
+  reg id68;
+  reg id69;
+  reg id70;
+  reg id71;
+  reg id72;
+  reg id73;
+  reg id74;
+  reg id75;
+  reg id76;
+  reg id77;
+  reg id78;
+  reg id79;
+  reg id80;
+  reg id81;
+  reg id82;
+  reg id83;
+  reg id84;
+  reg id85;
+  reg id86;
+  reg id87;
+  reg id88;
+  reg id89;
+  reg id90;
+  reg id91;
+  reg id92;
+  reg id93;
+  reg id94;
+  reg id95;
+  reg id96;
+  reg id97;
+  reg id98;
+  reg id99;
+  reg id100;
+  reg id101;
+  reg id102;
+  reg id103;
+  reg id104;
+  reg id105;
+  reg id106;
+  always @(posedge in) begin
+    if (in) begin
+      id42 <= 1'h0;
+      id43 <= 1'h0;
+      id44 <= 1'h0;
+      id45 <= 1'h0;
+      id46 <= 1'h0;
+      id47 <= 1'h0;
+      id48 <= 1'h0;
+      id49 <= 1'h0;
+      id50 <= 1'h0;
+      id51 <= 1'h0;
+      id52 <= 1'h0;
+      id53 <= 1'h0;
+      id54 <= 1'h0;
+      id55 <= 1'h0;
+      id56 <= 1'h0;
+      id57 <= 1'h0;
+      id58 <= 1'h0;
+      id59 <= 1'h0;
+      id60 <= 1'h0;
+      id61 <= 1'h0;
+      id62 <= 1'h0;
+      id63 <= 1'h0;
+      id64 <= 1'h0;
+      id65 <= 1'h0;
+      id66 <= 1'h0;
+      id67 <= 1'h0;
+      id68 <= 1'h0;
+      id69 <= 1'h0;
+      id70 <= 1'h0;
+      id71 <= 1'h0;
+      id72 <= 1'h0;
+      id73 <= 1'h0;
+      id74 <= 1'h0;
+      id75 <= 1'h0;
+      id76 <= 1'h0;
+      id77 <= 1'h0;
+      id78 <= 1'h0;
+      id79 <= 1'h0;
+      id80 <= 1'h0;
+      id81 <= 1'h0;
+      id82 <= 1'h0;
+      id83 <= 1'h0;
+      id84 <= 1'h0;
+      id85 <= 1'h0;
+      id86 <= 1'h0;
+      id87 <= 1'h0;
+      id88 <= 1'h0;
+      id89 <= 1'h0;
+      id90 <= 1'h0;
+      id91 <= 1'h0;
+      id92 <= 1'h0;
+      id93 <= 1'h0;
+      id94 <= 1'h0;
+      id95 <= 1'h0;
+      id96 <= 1'h0;
+      id97 <= 1'h0;
+      id98 <= 1'h0;
+      id99 <= 1'h0;
+      id100 <= 1'h0;
+      id101 <= 1'h0;
+      id102 <= 1'h0;
+      id103 <= 1'h0;
+      id104 <= 1'h0;
+      id105 <= 1'h0;
+      id106 <= 1'h0;
+    end
+  end
+  always @(posedge id106) begin
+    $display("abc");
+  end
+endmodule


### PR DESCRIPTION
`V3Table` might create `AstIf` that will ultimately result in emitted `if(VlWide)` if `condp` is wide enough, and since `VlWide` is not convertible to `bool` (and I assume re-adding `operator bool()` it is not a preferred solution, see https://github.com/verilator/verilator/pull/7652) it fails with:
```
In file included from Vt_table_wide__ALL.cpp:4:
./Vt_table_wide___024root__0.cpp:109:25: error: value of type 'VlWide<3>' is not contextually convertible to 'bool'
  109 |                     if (__Vinline_0__eval_nba___Vinline_0__nba_sequent__TOP__1___Vtemp_2) {
      |                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.

```
This PR fixes that by using `cond != 0` as a condition in `V3Table`