### PR TITLE
Fix wait fork trigger temporary split across generated functions (#7985)

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -201,6 +201,7 @@ Maarten De Braekeleer
 Maciej Sobkowski
 Marcel Chang
 Marco Bartoli
+Marco Brambilla
 Marco Widmer
 Mariusz Glebocki
 Markus Krause

--- a/src/V3SchedUtil.cpp
+++ b/src/V3SchedUtil.cpp
@@ -157,12 +157,49 @@ void splitCheckFinishSubFunc(AstCFunc* ofuncp, AstCFunc* subFuncp,
     }
 }
 
+// Compute, for each top level statement of 'ofuncp', whether a new sub-function may begin there.
+// Sub-functions are emitted as separate C++ functions, so they cannot see each other's automatic
+// storage. A function-local AstVar declared among the top level statements must therefore end up
+// in the same sub-function as every reference to it, otherwise the emitted C++ refers to an
+// undeclared identifier (and the AstVar can be deleted from under the still-live references).
+static std::vector<bool> splitCheckBreakable(const AstCFunc* ofuncp) {
+    // Gather the top level statements, and where each locally declared variable is declared
+    std::vector<const AstNode*> stmtps;
+    std::unordered_map<const AstVar*, size_t> declIdx;  // Local var -> index it is declared at
+    for (const AstNode* nodep = ofuncp->stmtsp(); nodep; nodep = nodep->nextp()) {
+        if (const AstVar* const varp = VN_CAST(nodep, Var)) declIdx.emplace(varp, stmtps.size());
+        stmtps.push_back(nodep);
+    }
+
+    // Find the last statement referencing each locally declared variable
+    std::vector<size_t> lastUse(stmtps.size());
+    for (size_t i = 0; i < stmtps.size(); ++i) {
+        lastUse[i] = i;  // A declaration is live at least where it is declared
+        stmtps[i]->foreach([&](const AstNodeVarRef* refp) {
+            const auto it = declIdx.find(refp->varp());  // 'end()' if not one of our locals
+            if (it != declIdx.end()) lastUse[it->second] = std::max(lastUse[it->second], i);
+        });
+    }
+
+    // A break before statement 'i' is allowed only if no local declared before 'i' is still live
+    std::vector<bool> breakable(stmtps.size(), true);
+    size_t liveEnd = 0;  // Last index any so far declared local is referenced at
+    for (size_t i = 0; i < stmtps.size(); ++i) {
+        breakable[i] = liveEnd < i;
+        if (VN_IS(stmtps[i], Var)) liveEnd = std::max(liveEnd, lastUse[i]);
+    }
+    return breakable;
+}
+
 // Split large function according to --output-split-cfuncs
 void splitCheck(AstCFunc* const ofuncp) {
     if (!ofuncp) return;
     UASSERT_OBJ(!ofuncp->varsp(), ofuncp, "Can't split function with local variables");
     if (!v3Global.opt.outputSplitCFuncs() || !ofuncp->stmtsp()) return;
     if (ofuncp->nodeCount() < v3Global.opt.outputSplitCFuncs()) return;
+
+    // Statement boundaries that would separate a local declaration from a reference to it
+    const std::vector<bool> breakable = splitCheckBreakable(ofuncp);
 
     // Need to find the AstVarScopes for the function arguments. They should be in the same Scope.
     std::unordered_map<const AstVar*, AstVarScope*> argVscps;
@@ -187,13 +224,13 @@ void splitCheck(AstCFunc* const ofuncp) {
 
     // Move statements one by one to the new sub-functions
     AstNode* stmtsp = ofuncp->stmtsp()->unlinkFrBackWithNext();
-    while (AstNode* const itemp = stmtsp) {
+    for (size_t index = 0; AstNode* const itemp = stmtsp; ++index) {
         stmtsp = stmtsp->nextp();
         if (stmtsp) stmtsp->unlinkFrBackWithNext();
         const size_t itemSize = static_cast<size_t>(itemp->nodeCount());
         size += itemSize;
 
-        if (size > static_cast<size_t>(v3Global.opt.outputSplitCFuncs())) {
+        if (size > static_cast<size_t>(v3Global.opt.outputSplitCFuncs()) && breakable[index]) {
             if (subFuncp) splitCheckFinishSubFunc(ofuncp, subFuncp, argVscps);
             subFuncp = nullptr;
             size = itemSize;

--- a/test_regress/t/t_timing_wait_fork_split.py
+++ b/test_regress/t/t_timing_wait_fork_split.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+# --output-split-cfuncs forces the process to be split into sub-functions
+test.compile(verilator_flags2=["--binary", "--output-split-cfuncs", "20"])
+
+# Confirm the split actually happened: the 'initial' timing process is emitted
+# as function sub-parts (__Vtiming__0__0 / __Vtiming__0__1). Without the split
+# this test would not exercise the bug it guards against -- a dynamic 'wait
+# fork' trigger temporary separated from its uses across a sub-function boundary.
+if test.vlt_all:
+    test.file_grep(test.obj_dir + "/V" + test.name + "_t__0.cpp", r'__Vtiming__0__1\b')
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_timing_wait_fork_split.v
+++ b/test_regress/t/t_timing_wait_fork_split.v
@@ -1,0 +1,40 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// A 'wait fork' needs a dynamic trigger temporary, which is function-local to
+// the process it appears in. Splitting the process into sub-functions must not
+// separate that declaration from its uses, as sub-functions are emitted as
+// separate C++ functions.
+//
+// This file ONLY is placed under the Creative Commons Public Domain.
+// SPDX-FileCopyrightText: 2026 Wilson Snyder
+// SPDX-License-Identifier: CC0-1.0
+
+module t;
+  logic clk = 1'b0;
+  int   cnt = 0;
+
+  always #5 clk = ~clk;
+
+  task automatic phase(int n);
+    fork begin @(posedge clk); cnt += n; end join_none
+    wait fork;
+  endtask
+
+  initial begin
+    fork @(posedge clk); join_none
+    wait fork;
+    phase(1);
+    fork @(negedge clk); join_none
+    wait fork;
+    phase(2);
+    fork @(posedge clk); join_none
+    wait fork;
+    phase(4);
+    if (cnt != 7) begin
+      $write("%%Error: cnt=%0d exp=7\n", cnt);
+      $stop;
+    end
+    $write("*-* All Finished *-*\n");
+    $finish;
+  end
+endmodule


### PR DESCRIPTION
Fixes #7985.

`V3Sched::util::splitCheck()` cuts a function's top level statement list on node count alone,
ignoring `AstVar` declarations sitting in that list. `V3Timing::localizeVars()` puts the dynamic
trigger temporaries there, which a `wait fork` reaches, so the declaration could land in one
sub-function and its references in another. Sub-functions are emitted as separate C++ functions, so
the output failed to compile. `V3InlineCFuncs` could also inline the sub-function holding the
declaration and free the `AstVar` while other sub-functions still referenced it, which `--debug`
reports as a broken link and which segfaults an `-O3` build.

`splitCheck()`'s own `UASSERT_OBJ(!ofuncp->varsp(), ..., "Can't split function with local
variables")` shows the intent was already there, but it only checks `AstCFunc::varsp()`, not
declarations among the statements.

### Why not just remove the locals again

This is the same failure as #5987, fixed in #5822 by removing function locals from `SenExprBuilder`
outright ("function locals are not safe here because we might need to split up the generated
function"). #6926 reintroduced them for the dynamic-trigger path, because #6859 needs the temporary
to be per-process so concurrent copies do not share one.

The two requirements conflict directly. Reverting #6926 would regress #6859, so this instead moves
the constraint into the splitter: a sub-function boundary is only permitted where it does not
separate a local declaration from a reference to it. Both requirements then hold.

### Implementation

A helper computes each top level local's live range (declaration index to last referencing
statement) and marks boundaries inside any still-open range as unavailable; the split loop consults
it. Linear: one `foreach` per statement plus two O(n) sweeps. No behaviour change for functions
below the split threshold or with no locals among their statements.

One consequence worth flagging: because `localizeVars()` declares these temporaries at the front of
the process, the protected range reaches to the last use, so that region stops being split. On the
4096-statement stock-flags case in #7985 the process still splits, into 2 sub-functions instead of
3. Narrowing that would mean declaring the temporaries next to their uses in `V3Timing`, which
seemed orthogonal and is not attempted here.

### Testing

- New `test_regress/t/t_timing_wait_fork_split.{v,py}`: three `wait fork` sites plus a task under
  `--output-split-cfuncs 20`, self-checking. Fails before, passes after.
- `t/t_scheduling_7.py`, which guards #6859, still passes.
- Full `test_regress` suite on f8fb1d6: 4008 passed, 1 failed. The one failure is `t_dist_lint_py`,
  entirely on pre-existing findings in files this PR does not touch, from linters newer than CI
  pins (ruff 0.16, mypy 2.3, pylint 4.0).
- Swept 5 shapes (inline `wait fork`; a task called from 3 sites; `wait fork` in a loop;
  `@(expression)` dynamic triggers mixed with `wait fork`; the `t_scheduling_7` class-method shape)
  across 19 values of `--output-split-cfuncs` from 1 to 1000, so the boundary lands in every
  position: 95/95 clean with this patch, 58/95 failing without it.
- `src/V3SchedUtil.cpp` is `clang-format --dry-run --Werror` clean.

---

Disclosure per `docs/CONTRIBUTING.rst`: generative AI (Claude) assisted with the root cause
investigation and drafting this patch. I have reviewed, verified and tested the result myself, and
submit it as my own work product under the DCO.
