### PR TITLE
Fix MULTIDRIVEN/PROC warning suppression (#7999)

### DIFF
--- a/src/V3Ast.cpp
+++ b/src/V3Ast.cpp
@@ -1542,14 +1542,14 @@ string AstNode::instanceStr() const {
     return "";
 }
 void AstNode::v3errorEnd(const std::ostringstream& str) const VL_RELEASE(V3Error::s().m_mutex) {
-    // Don't look for instance name when warning is disabled.
-    // In case of large number of warnings, this can
-    // take significant amount of time
-    const string instanceStrExtra
-        = m_fileline->warnIsOff(V3Error::s().errorCode()) ? "" : instanceStr();
     if (!m_fileline) {
-        V3Error::v3errorEnd(str, instanceStrExtra, nullptr);
+        V3Error::v3errorEnd(str, "", nullptr);
     } else {
+        // Don't look for instance name when warning is disabled.
+        // In case of large number of warnings, this can
+        // take significant amount of time
+        const string instanceStrExtra
+            = m_fileline->warnIsOff(V3Error::s().errorCode()) ? "" : instanceStr();
         std::ostringstream nsstr;
         nsstr << str.str();
         if (debug()) {

--- a/src/V3Undriven.cpp
+++ b/src/V3Undriven.cpp
@@ -541,15 +541,20 @@ class UndrivenVisitor final : public VNVisitorConst {
                                                        : entryp->callNodep();
                 const bool sameFileLine
                     = otherVarRefp && nodep->fileline() == otherVarRefp->fileline();
-                if (entryp->isDrivenWhole() && !m_inBBox && !VN_IS(nodep, VarXRef)
-                    && !VN_IS(nodep->dtypep()->skipRefp(), UnpackArrayDType) && !sameFileLine
-                    && !entryp->isUnderGen() && otherWritep && !entryp->isFtaskDriven()
-                    && !ftaskDef && !m_inSelLhs
-                    && (!nodep->varp()->fileline()->warnIsOff(V3ErrorCode::MULTIDRIVEN)
-                        || !nodep->varp()->fileline()->warnIsOff(V3ErrorCode::MULTIDRIVENPROC))) {
+                // Preconditions shared by MULTIDRIVEN and MULTIDRIVENPROC.
+                const bool multidrivenCommon
+                    = entryp->isDrivenWhole() && !m_inBBox && !VN_IS(nodep, VarXRef)
+                      && !VN_IS(nodep->dtypep()->skipRefp(), UnpackArrayDType) && !sameFileLine
+                      && !entryp->isUnderGen() && otherWritep && !entryp->isFtaskDriven()
+                      && !ftaskDef && !m_inSelLhs;
+                // The two warnings are gated independently on the variable
+                // declaration's fileline, as v3warn suppression will check
+                // the driving fileline and still warn even if the warning
+                // was suppressed with lint_off at the declaration.
+                if (multidrivenCommon
+                    && !nodep->varp()->fileline()->warnIsOff(V3ErrorCode::MULTIDRIVEN)) {
                     const bool otherWriteIsStaticInit
                         = nodep->varp()->hasUserInit() && otherWritep == entryp->initStaticp();
-
                     if (m_alwaysCombp
                         && (!entryp->isDrivenAlwaysCombWhole()
                             || (m_alwaysCombp != entryp->getAlwCombp()
@@ -597,6 +602,9 @@ class UndrivenVisitor final : public VNVisitorConst {
                                                        << "... Location of always_ff write\n"
                                                        << otherWritep->warnContextSecondary());
                     }
+                }
+                if (multidrivenCommon
+                    && !nodep->varp()->fileline()->warnIsOff(V3ErrorCode::MULTIDRIVENPROC)) {
                     // Two plain always blocks driving the whole signal: legal
                     // SystemVerilog, but a driver conflict for synthesis. The
                     // always_ff/always_comb cases above already cover mixes with


### PR DESCRIPTION
This fixes #7999.
The issue is that `MULTIDRIVENPROC` was introduced in a way that when either it or `MULTIDRIVEN` is enabled (or both), both are processed and the code relies on `v3warn` to suppress the warning we possibly don't want. However, these warnings seem to be a bit special: they could be disabled via `lint_off` for a particular signal at the declaration, instead of being required in all the individual places where the signal is driven, and `v3warn`'s suppression is based on the latter. This restores the original behavior pre-#7968.

While looking into the cause of the bug, I found what seems to be a potential pointer dereference before checking for validity in `AstNode::v3ErrorEnd`. This seems to never happen, so maybe any node with will have warnings/errors also is guaranteed to have a fileline, and we can just assert it being non-null?

I'm not sure if this warrants a test for it. I can add one if so.