### PR TITLE
Fix missing verilator_coverage in cmake (#8008)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,11 +155,12 @@ install(
 foreach(
     program
     verilator
-    verilator_gantt
     verilator_ccache_report
+    verilator_coverage
     verilator_difftree
-    verilator_profcfunc
+    verilator_gantt
     verilator_includer
+    verilator_profcfunc
 )
     install(PROGRAMS bin/${program} TYPE BIN)
 endforeach()


### PR DESCRIPTION
Fix #8008 