### PR TITLE
Fix gcov dump discarding coverage counts after warnings

### DIFF
--- a/include/verilated.cpp
+++ b/include/verilated.cpp
@@ -3887,7 +3887,7 @@ void Verilated::runFlushCallbacks() VL_MT_SAFE {
     // When running internal code coverage (gcc --coverage, as opposed to
     // verilator --coverage), dump coverage data to properly cover failing
     // tests.
-    VL_GCOV_DUMP();
+    VL_GCOV_DUMP_RESET();
 }
 
 void Verilated::addExitCb(VoidPCb cb, void* datap) VL_MT_SAFE { addCbExit(cb, datap); }

--- a/include/verilatedos.h
+++ b/include/verilatedos.h
@@ -332,10 +332,19 @@
 
 #ifdef VL_GCOV
 extern "C" void __gcov_dump();
+extern "C" void __gcov_reset();
 // Dump internal code coverage data before e.g. std::abort()
 # define VL_GCOV_DUMP() __gcov_dump()
+// Dump, then re-arm dumping; dumping is one-shot, so without the reset a dump
+// on a nonfatal path would silently discard everything counted after it
+# define VL_GCOV_DUMP_RESET() \
+        do { \
+            __gcov_dump(); \
+            __gcov_reset(); \
+        } while (false)
 #else
 # define VL_GCOV_DUMP()
+# define VL_GCOV_DUMP_RESET()
 #endif
 
 //=========================================================================


### PR DESCRIPTION
Internal code coverage (--coverage builds) dumps profile data from runFlushCallbacks() on every warning, but gcov dumping is one-shot: after the first __gcov_dump(), all later dumps -- including the normal at-exit one -- are silently ignored, so any test that emits a warning loses all coverage counted after its first warning. Re-arm dumping with __gcov_reset() after each nonfatal dump (VL_GCOV_DUMP_RESET). Fatal paths keep the plain one-shot VL_GCOV_DUMP. On a warning-emitting test the flush-path counter now reads 6 (one per warning) instead of freezing after the first.