### PR TITLE
Fix dist weights ignored in an inline randomize() with

### DIFF
--- a/src/V3Randomize.cpp
+++ b/src/V3Randomize.cpp
@@ -2278,9 +2278,112 @@ class ConstraintExprVisitor final : public VNVisitor {
         // Hoisted runtime-conditional disable_soft statements parked in the
         // constraint-items list by the pre-pass; already fully lowered.
     }
+    // Tally whether an item list holds soft constraints, non-soft ones, or
+    // both.  A nested ConstraintIf contributes whatever its own arms hold.
+    static void scanSoftness(const AstNode* const itemsp, bool& anySoftr, bool& anyHardr) {
+        for (const AstNode* itemp = itemsp; itemp; itemp = itemp->nextp()) {
+            if (const AstConstraintExpr* const constrExprp = VN_CAST(itemp, ConstraintExpr)) {
+                if (constrExprp->isSoft()) {
+                    anySoftr = true;
+                } else {
+                    anyHardr = true;
+                }
+            } else if (const AstConstraintIf* const cifp = VN_CAST(itemp, ConstraintIf)) {
+                scanSoftness(cifp->thensp(), anySoftr, anyHardr);
+                scanSoftness(cifp->elsesp(), anySoftr, anyHardr);
+            } else {
+                anyHardr = true;
+            }
+        }
+    }
+
+    static AstConstraintExpr* newTrueConstraint(FileLine* const fl, const bool isSoft) {
+        AstConstraintExpr* const truep
+            = new AstConstraintExpr{fl, new AstConst{fl, AstConst::BitTrue{}}};
+        truep->isSoft(isSoft);
+        return truep;
+    }
+
+    // Pruning can empty an arm that the original had.  Put a vacuous 'true'
+    // back, so the collapse below still builds an AstCond and visit(AstCond)
+    // can keep folding a condition the solver never sees into one C++ ternary.
+    // Dropping to a one-armed LogIf instead would push that condition into the
+    // SMT text, where a plain runtime value has no meaning.
+    static void refillArms(AstConstraintIf* const cifp, const bool hadElse, const bool isSoft) {
+        if (!cifp->thensp() && !cifp->elsesp()) return;  // Vacuous, dropped below
+        FileLine* const fl = cifp->fileline();
+        // A then arm always existed: constraint_set has no empty production, so
+        // only the else arm needs asking about.
+        if (!cifp->thensp()) cifp->addThensp(newTrueConstraint(fl, isSoft));
+        if (hadElse && !cifp->elsesp()) cifp->addElsesp(newTrueConstraint(fl, isSoft));
+    }
+
+    // Drop every item that is not of the wanted softness, and any ConstraintIf
+    // left with nothing in either arm.  Nested ConstraintIfs are refilled as
+    // they are pruned, not just the one being split, or a gated 'dist' nested
+    // under a user's if/else would lose its own arm shape.
+    void pruneToSoftness(AstNode* const itemsp, const bool keepSoft) {
+        for (AstNode* itemp = itemsp; itemp;) {
+            AstNode* const nextp = itemp->nextp();
+            bool drop;
+            if (const AstConstraintExpr* const constrExprp = VN_CAST(itemp, ConstraintExpr)) {
+                drop = constrExprp->isSoft() != keepSoft;
+            } else if (AstConstraintIf* const cifp = VN_CAST(itemp, ConstraintIf)) {
+                const bool hadElse = cifp->elsesp() != nullptr;
+                pruneToSoftness(cifp->thensp(), keepSoft);
+                pruneToSoftness(cifp->elsesp(), keepSoft);
+                refillArms(cifp, hadElse, keepSoft);
+                drop = !cifp->thensp() && !cifp->elsesp();
+            } else {
+                drop = keepSoft;  // Anything else counts as hard
+            }
+            if (drop) {
+                itemp->unlinkFrBack();
+                VL_DO_DANGLING(pushDeletep(itemp), itemp);
+            }
+            itemp = nextp;
+        }
+    }
+
     void visit(AstConstraintIf* nodep) override {
         AstNodeExpr* newp = nullptr;
         FileLine* const fl = nodep->fileline();
+        // The arms collapse into one expression below, which can carry only one
+        // softness.  The arms are alternatives, so the result is no harder than
+        // what it came from and must stay soft when they are: a 'dist' bucket
+        // choice is a chain of soft ConstraintIfs precisely so the solver may
+        // retract it and fall back on the membership constraint.
+        bool anySoft = false;
+        bool anyHard = false;
+        scanSoftness(nodep->thensp(), anySoft, anyHard);
+        scanSoftness(nodep->elsesp(), anySoft, anyHard);
+        // A 'dist' lowers to a hard membership constraint beside that soft
+        // chain, so an if/else the user wrapped around one holds both kinds in
+        // the same arm.  Split it into a hard copy and a soft copy, so neither
+        // has to be demoted to the other.  Under editSingle() the subtree was
+        // already split by the outermost ConstraintIf, which recurses.
+        if (anySoft && anyHard && !m_wantSingle) {
+            const bool hadElse = nodep->elsesp() != nullptr;
+            // The copy duplicates the condition, so an impure one would be
+            // evaluated twice.  Clone it pure to say so here; V3Width already
+            // rejects such a condition with SIDEEFFECT before this runs.  The
+            // arms are cloned plainly, as pruning discards one copy of each
+            // item rather than leaving both to be evaluated.
+            AstConstraintIf* const softCopyp = new AstConstraintIf{
+                fl, nodep->condp()->cloneTreePure(false), nodep->thensp()->cloneTree(true),
+                nodep->elsesp() ? nodep->elsesp()->cloneTree(true) : nullptr};
+            pruneToSoftness(nodep->thensp(), false);
+            pruneToSoftness(nodep->elsesp(), false);
+            pruneToSoftness(softCopyp->thensp(), true);
+            pruneToSoftness(softCopyp->elsesp(), true);
+            refillArms(nodep, hadElse, false);
+            refillArms(softCopyp, hadElse, true);
+            // iterateAndNext() re-reads nextp after this visit, so it reaches
+            // the copy without it having to be iterated here.
+            nodep->addNextHere(softCopyp);
+            anySoft = false;  // This node keeps only the hard items
+        }
+        const bool isSoft = anySoft && !anyHard;
         AstNodeExpr* const thenp = editSingle(fl, nodep->thensp());
         AstNodeExpr* const elsep = editSingle(fl, nodep->elsesp());
         if (thenp && elsep) {
@@ -2288,12 +2391,21 @@ class ConstraintExprVisitor final : public VNVisitor {
         } else if (thenp) {
             newp = new AstLogIf{fl, nodep->condp()->unlinkFrBack(), thenp};
         } else if (elsep) {
-            newp = new AstLogIf{fl, new AstNot{fl, nodep->condp()->unlinkFrBack()}, elsep};
+            // Only an else arm survives, so invert the condition.  AstLogNot
+            // rather than AstNot, with an explicit bit dtype: the condition may
+            // be wider than a bit and the result feeds a LogIf.
+            AstNodeExpr* const condp = nodep->condp()->unlinkFrBack();
+            AstNodeExpr* const notp = new AstLogNot{fl, condp};
+            notp->dtypeSetBit();
+            notp->user1(condp->user1());  // Solver-dependent exactly when the condition is
+            newp = new AstLogIf{fl, notp, elsep};
         }
         if (newp) {
             newp->dtypeSetBit();  // Result is boolean (prevents bare-var != 0 wrapping)
             newp->user1(true);  // Assume result-dependent
-            nodep->replaceWith(new AstConstraintExpr{fl, newp});
+            AstConstraintExpr* const newConstraintp = new AstConstraintExpr{fl, newp};
+            newConstraintp->isSoft(isSoft);
+            nodep->replaceWith(newConstraintp);
         } else {
             nodep->unlinkFrBack();
         }
@@ -4900,6 +5012,10 @@ class RandomizeVisitor final : public VNVisitor {
     // A non-rand value can never be re-drawn; a non-rand owner level is skipped.
     AstNodeExpr* newVarGate(AstVar* varp, const AstMemberSel* mselp, bool ownerLevel,
                             AstVar* randModeVarp, FileLine* fl) {
+        // A std::randomize() argument is drawn every call even though it carries
+        // no 'rand' lifetime of its own, so it is never frozen.  Reporting it as
+        // such would drop the weighted bucket chain for an inline dist on it.
+        if (varp->isStdRandomizeArg()) return new AstConst{fl, AstConst::BitTrue{}};
         if (!varp->rand().isRandomizable()) {
             return new AstConst{fl, AstConst::BitTrue{}, ownerLevel};
         }
@@ -5086,7 +5202,9 @@ class RandomizeVisitor final : public VNVisitor {
 
     // Replace AstDist with weighted bucket selection via AstConstraintIf chain.
     // Supports both constant and variable weight expressions.
-    void lowerDistConstraints(AstTask* taskp, AstNode* constrItemsp, AstVar* randModeVarp,
+    // taskp is the setup task for a class-scope constraint, or the generated
+    // __Vrandwith function for an inline randomize() with {} clause.
+    void lowerDistConstraints(AstNodeFTask* taskp, AstNode* constrItemsp, AstVar* randModeVarp,
                               AstConstraintForeach* foreachp = nullptr) {
         // When inside a foreach, bucket preamble stmts are stored in foreachp->user3p()
         // (as a linked list) so visit(AstConstraintForeach*) can inject them into the
@@ -5842,6 +5960,11 @@ class RandomizeVisitor final : public VNVisitor {
                     randomizeFuncp->addStmtsp(
                         implementConstraintsClearAll(randomizeFuncp->fileline(), stdrand));
                 }
+                // Lower any 'dist' while the clause is still under withp, so the
+                // bucket preamble lands in the function ahead of the constraint
+                // items that read it, exactly as for a class-scope constraint.
+                // std::randomize() has no class rand_mode variable.
+                lowerDistConstraints(randomizeFuncp, withp->exprp(), nullptr);
                 AstNode* const capturedTreep = withp->exprp()->unlinkFrBackWithNext();
                 randomizeFuncp->addStmtsp(capturedTreep);
                 {
@@ -5990,9 +6113,12 @@ class RandomizeVisitor final : public VNVisitor {
             }
         }
 
-        // Generate constraint setup code and a hardcoded call to the solver
-        AstNode* const capturedTreep = withp->exprp()->unlinkFrBackWithNext();
-        randomizeFuncp->addStmtsp(capturedTreep);
+        // Generate constraint setup code and a hardcoded call to the solver.
+        // The clause stays under withp through the passes below: lowering a
+        // 'dist' has to put its bucket preamble in the function ahead of the
+        // constraint items that read it, which is only possible while those
+        // items are not in the function yet.
+        AstNode* const withItemsp = withp->exprp();
 
         // Pre-scan captured tree for .size on dynamic/assoc arrays and replace
         // with size variables, using shared createOrGetSizeVar helper.
@@ -6002,7 +6128,7 @@ class RandomizeVisitor final : public VNVisitor {
         AstNode* inlineResizeStmtsp = nullptr;
         {
             std::vector<AstCMethodHard*> sizeMethodps;
-            capturedTreep->foreachAndNext([&](AstCMethodHard* methodp) {
+            withItemsp->foreachAndNext([&](AstCMethodHard* methodp) {
                 if (methodp->method() == VCMethod::DYN_SIZE
                     || methodp->method() == VCMethod::ASSOC_SIZE) {
                     sizeMethodps.push_back(methodp);
@@ -6041,7 +6167,7 @@ class RandomizeVisitor final : public VNVisitor {
                     }
 
                     // Append size >= 0 constraint so ConstraintExprVisitor processes it
-                    capturedTreep->addNext(createSizeGteZeroConstraint(fl, sizeVarp));
+                    withItemsp->addNext(createSizeGteZeroConstraint(fl, sizeVarp));
                 }
                 AstVarRef* const sizeVarRefp
                     = new AstVarRef{fl, sizeClassp, sizeVarp, VAccess::READ};
@@ -6050,6 +6176,16 @@ class RandomizeVisitor final : public VNVisitor {
                 VL_DO_DANGLING(methodp->deleteTree(), methodp);
             }
         }
+
+        // Lower any 'dist' to its weighted bucket chain, then move the clause
+        // into the function, so the preamble the lowering just added comes
+        // first.  Adding it afterwards would leave the bucket variable read
+        // before it is assigned, and ConstraintExprVisitor, which follows
+        // nextp(), would walk the preamble as though it were constraint items.
+        lowerDistConstraints(randomizeFuncp, withp->exprp(), randModeVarp);
+
+        AstNode* const capturedTreep = withp->exprp()->unlinkFrBackWithNext();
+        randomizeFuncp->addStmtsp(capturedTreep);
 
         {
             expandUniqueElementList(capturedTreep);

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -239,6 +239,7 @@ class WidthVisitor final : public VNVisitor {
     AstClass* m_cgClassp = nullptr;  // Current covergroup class
     AstNodeModule* m_modep = nullptr;  // Current module
     const AstConstraint* m_constraintp = nullptr;  // Current constraint
+    const AstConstraintExpr* m_constraintExprp = nullptr;  // Current constraint expression
     AstNodeProcedure* m_procedurep = nullptr;  // Current final/always
     const AstWith* m_withp = nullptr;  // Current 'with' statement
     const AstFunc* m_funcp = nullptr;  // Current function
@@ -2935,6 +2936,8 @@ class WidthVisitor final : public VNVisitor {
         userIterateAndNext(nodep->rhssp(), WidthVP{SELF, BOTH}.p());
     }
     void visit(AstConstraintExpr* nodep) override {
+        VL_RESTORER(m_constraintExprp);
+        m_constraintExprp = nodep;
         userIterateAndNext(nodep->exprp(), WidthVP{SELF, BOTH}.p());
     }
     void visit(AstConstraintUnique* nodep) override {
@@ -3517,7 +3520,9 @@ class WidthVisitor final : public VNVisitor {
         // Inside a constraint, V3Randomize handles dist lowering with proper weights,
         // but only for simple scalar/range items. Container-type items (queues, arrays)
         // must be lowered here via insideItem() which knows how to expand them.
-        if (m_constraintp) {
+        // V3Width runs before V3Randomize, so every AstConstraintExpr here came
+        // from the grammar: a constraint block, or an inline randomize() with {}.
+        if (m_constraintExprp) {
             bool canLower = true;
             for (AstDistItem* ditemp = nodep->itemsp(); ditemp;
                  ditemp = VN_AS(ditemp->nextp(), DistItem)) {

--- a/test_regress/t/t_constraint_dist_implication.py
+++ b/test_regress/t/t_constraint_dist_implication.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+if not test.have_solver:
+    test.skip("No constraint solver installed")
+
+test.compile()
+
+test.execute(all_run_flags=["+verilator+seed+1"])
+
+test.passes()

--- a/test_regress/t/t_constraint_dist_implication.v
+++ b/test_regress/t/t_constraint_dist_implication.v
@@ -1,0 +1,89 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain.
+// SPDX-FileCopyrightText: 2026 Marco Bartoli
+// SPDX-License-Identifier: CC0-1.0
+
+// A 'dist' weights the choice among its items but does not require any one of
+// them (IEEE 1800-2023 18.5.4).  The weighted pick must therefore yield to a
+// hard constraint, including one that only relates two variables indirectly.
+//
+// Here operand_a and operand_b each carry their own distribution, and a hard
+// implication ties them together when force_equal is set.  The two buckets are
+// drawn independently, so on the roughly one draw in five where force_equal is
+// 1 they usually disagree.  If the picks were hard, that disagreement would
+// have no solution and randomize() would return 0; the implication must win
+// instead.
+//
+// t_constraint_dist_inline group J covers a hard constraint excluding a bucket
+// of a single variable.  This is the cross-variable form, from issue #8026.
+
+// verilog_format: off
+`define stop $stop
+`define checkd(gotv,expv) do if ((gotv) !== (expv)) begin $write("%%Error: %s:%0d:  got=%0d exp=%0d\n", `__FILE__,`__LINE__, (gotv), (expv)); `stop; end while(0);
+// verilog_format: on
+
+`define N 200
+
+class GcdRequest;
+  localparam int GCD_RAND_MAX = 31;
+  localparam int GCD_INTERIOR_LO = 1;
+  localparam int GCD_INTERIOR_HI = 30;
+
+  rand int operand_a;
+  rand int operand_b;
+  rand bit force_equal;
+  rand bit rsp_ready_before_valid;
+
+  constraint c_edge_bias {
+    operand_a dist {
+      0                                   := 1,
+      GCD_RAND_MAX                        := 1,
+      [GCD_INTERIOR_LO : GCD_INTERIOR_HI] :/ 10
+    };
+    operand_b dist {
+      0                                   := 1,
+      GCD_RAND_MAX                        := 1,
+      [GCD_INTERIOR_LO : GCD_INTERIOR_HI] :/ 10
+    };
+    force_equal dist {
+      0 := 4,
+      1 := 1
+    };
+    (force_equal == 1) -> (operand_a == operand_b);
+    rsp_ready_before_valid dist {
+      0 := 3,
+      1 := 1
+    };
+  }
+endclass
+
+module t;
+  initial begin
+    automatic GcdRequest request = new;
+    int result;
+    int equal_trials;
+
+    for (int i = 0; i < `N; i++) begin
+      // Must stay satisfiable even when the independently drawn operand
+      // preferences disagree; the hard implication takes priority.
+      result = request.randomize();
+      `checkd(result, 1);
+      if (request.force_equal) begin
+        equal_trials++;
+        `checkd(request.operand_a, request.operand_b);
+      end
+      `checkd(request.operand_a >= 0, 1);
+      `checkd(request.operand_a <= request.GCD_RAND_MAX, 1);
+      `checkd(request.operand_b >= 0, 1);
+      `checkd(request.operand_b <= request.GCD_RAND_MAX, 1);
+    end
+
+    // Without this the run above proves nothing, as the implication would
+    // never have been exercised.
+    `checkd(equal_trials > 0, 1);
+
+    $write("*-* All Finished *-*\n");
+    $finish;
+  end
+endmodule

--- a/test_regress/t/t_constraint_dist_inline.py
+++ b/test_regress/t/t_constraint_dist_inline.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+if not test.have_solver:
+    test.skip("No constraint solver installed")
+
+test.compile()
+
+test.execute(all_run_flags=["+verilator+seed+1"])
+
+test.passes()

--- a/test_regress/t/t_constraint_dist_inline.v
+++ b/test_regress/t/t_constraint_dist_inline.v
@@ -1,0 +1,738 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain.
+// SPDX-FileCopyrightText: 2026 BRDR LIFE
+// SPDX-License-Identifier: CC0-1.0
+
+// A 'dist' constrains a value to the union of its items and weights the choice
+// among them (IEEE 1800-2023 18.5.4), identically whether written at class
+// scope or in an inline randomize() with {} clause (18.7).
+//
+// Groups: A weight operators, B weight expressions, C items and bounds,
+// D call forms, E structural contexts, F class-scope interaction, G enums and
+// array bounds and rand_mode, H methods and inheritance, I every bucket of one
+// distribution, J the bucket choice yielding to a hard constraint.
+//
+// Each check reports on its own and the run stops at the end, so one run
+// prints every failure rather than the first.
+
+// verilog_format: off
+`define stop $stop
+`define chk(NAME, CALL, PRED, LO, HI) \
+  cnt = 0; nok = 0; \
+  for (int i = 0; i < `N; i++) begin \
+    ok = CALL; \
+    if (ok != 0) begin nok++; if (PRED) cnt++; end \
+  end \
+  report(NAME, cnt, LO, HI, nok, `N);
+// verilog_format: on
+
+`define N 200
+
+class Holder;
+  rand bit [1:0] v;
+endclass
+
+class Holder3;
+  rand bit [2:0] v;
+endclass
+
+class HolderInt;
+  rand int x;
+endclass
+
+class HolderWide;
+  rand bit [39:0] x;
+endclass
+
+class MemberWeight;
+  rand bit [1:0] v;
+  int wa, wb;
+endclass
+
+class QHolder;
+  rand bit [3:0] v;
+  bit [3:0] que[$];
+endclass
+
+class ArrHolder;
+  rand bit [2:0] a[4];
+endclass
+
+class Inner;
+  rand bit [1:0] v;
+endclass
+
+class Outer;
+  rand Inner inn;
+  function new();
+    inn = new;
+  endfunction
+endclass
+
+class TwoVar;
+  rand bit [1:0] v;
+  rand bit [1:0] w;
+endclass
+
+// Class-scope constraint on a *different* variable than the inline dist.
+class SideConstraint;
+  rand bit [1:0] v;
+  rand bit [3:0] w;
+  constraint cw {w > 4'd9;}
+endclass
+
+// Class-scope non-dist constraint on the *same* variable as the inline dist.
+class NarrowConstraint;
+  rand bit [1:0] v;
+  constraint cv {v <= 2'd1;}
+endclass
+
+// Non-zero-based, descending unpacked array bounds.
+class NegIdxArr;
+  rand bit [2:0] a[5:-2];
+endclass
+
+typedef enum bit [1:0] {
+  OP_RD,
+  OP_WR,
+  OP_NOP,
+  OP_RSV
+} op_e;
+
+class OpHolder;
+  rand op_e op;
+endclass
+
+// A variable frozen with rand_mode(0) keeps its value across randomize().
+class ModeHolder;
+  rand bit [1:0] v;
+  rand bit [1:0] w;
+endclass
+
+// A randomize() with clause written inside a class method, the shape a UVM
+// sequence body() uses, resolving a weight from a member and from a local.
+class Seq;
+  rand bit [1:0] v;
+  int mw = 90;
+  function int go_member();
+    return this.randomize() with {
+      v dist {
+        0 :/ mw,
+        1 :/ 10
+      };
+    };
+  endfunction
+  function int go_local();
+    automatic int q = 90;
+    return this.randomize() with {
+      v dist {
+        0 :/ q,
+        1 :/ 10
+      };
+    };
+  endfunction
+endclass
+
+// An inline dist on a member declared in a base class.
+class DistBase;
+  rand bit [1:0] v;
+endclass
+
+class DistDerived extends DistBase;
+  rand bit [1:0] w;
+endclass
+
+// The same four-bucket distribution at class scope, as a control for the
+// inline histogram below.
+class HistClassScope;
+  rand bit [1:0] v;
+  constraint c {
+    v dist {
+      0 :/ 70,
+      1 :/ 10,
+      2 :/ 10,
+      3 :/ 10
+    };
+  }
+endclass
+
+// Heavy bucket is a single value the other constraint rules out.
+class DistConflictScalar;
+  rand bit [3:0] x;
+  constraint d {
+    x dist {
+      0 :/ 90,
+      5 :/ 10
+    };
+  }
+  constraint c {x != 0;}
+endclass
+// Heavy bucket is a range the other constraint rules out.
+class DistConflictRange;
+  rand bit [3:0] x;
+  constraint d {
+    x dist {
+      [0 : 3] :/ 90,
+      [12 : 15] :/ 10
+    };
+  }
+  constraint c {x > 10;}
+endclass
+// Same, with the dist nested inside an if/else constraint.
+class DistConflictIf;
+  rand bit [3:0] x;
+  rand bit sel;
+  constraint s {sel == 1;}
+  constraint d {
+    if (sel) {
+      x dist {
+        [0 : 3] :/ 90,
+        [12 : 15] :/ 10
+      };
+    } else {
+      x dist {7 :/ 1};
+    }
+  }
+  constraint c {x > 10;}
+endclass
+// Only the then arm holds a dist; the else arm holds a hard constraint.
+class DistMixedArm;
+  rand bit [3:0] x;
+  rand bit sel;
+  constraint s {sel == 1;}
+  constraint d {
+    if (sel) {
+      x dist {
+        [0 : 3] :/ 90,
+        [12 : 15] :/ 10
+      };
+    } else {
+      x == 7;
+    }
+  }
+  constraint c {x > 10;}
+endclass
+// A dist in a one-armed constraint if is still only a preference.
+class DistElseless;
+  rand bit [3:0] x;
+  rand bit sel;
+  constraint s {sel == 1;}
+  constraint d {
+    if (sel)
+    x dist {
+      [0 : 3] :/ 90,
+      [12 : 15] :/ 10
+    };
+  }
+  constraint c {x > 10;}
+endclass
+// A hard and a soft constraint sharing an arm keep their own priorities, so
+// the hard one holds and x is 2 every time.
+class HardStaysHard;
+  rand bit [3:0] x;
+  rand bit sel;
+  constraint s {sel == 1;}
+  constraint d {
+    if (sel) {
+      x == 2;
+      soft x == 1;
+    }
+  }
+endclass
+// Control: with nothing to conflict with, the weights still apply.
+class DistNoConflict;
+  rand bit [3:0] x;
+  constraint d {
+    x dist {
+      [0 : 3] :/ 90,
+      [12 : 15] :/ 10
+    };
+  }
+endclass
+// The membership constraint is hard, so this one has no solution at all.
+class DistImpossible;
+  rand bit [3:0] x;
+  constraint d {
+    x dist {
+      0 :/ 90,
+      5 :/ 10
+    };
+  }
+  constraint c {x > 10;}
+endclass
+// The then arm holds only a dropped 'unique', so the collapse sees an else arm
+// alone.  sel is solved to 1, so the else arm's constraint must not apply and x
+// stays free.  Assigning sel a differing value beforehand catches a condition
+// folded from that stale value rather than given to the solver.
+// A dist shares an arm with a 'unique' on a dynamically sized array, which is
+// unsupported inside a conditional constraint and is dropped.  The arm still
+// holds both a hard and a soft constraint, so the weights must survive.
+class DistBesideUnique;
+  rand bit [3:0] v;
+  rand bit [3:0] q[$];
+  rand bit sel;
+  constraint sz {q.size() == 3;}
+  constraint s {sel == 1;}
+  /* verilator lint_off CONSTRAINTIGN */
+  constraint c {
+    if (sel) {
+      v dist {
+        [0 : 3] :/ 90,
+        [12 : 15] :/ 10
+      };
+      unique {q};
+    } else {
+      v == 7;
+    }
+  }
+  /* verilator lint_on CONSTRAINTIGN */
+endclass
+
+class UniqueThenArm;
+  rand bit [3:0] q[$];
+  rand bit [3:0] x;
+  rand bit sel;
+  constraint sz {q.size() == 3;}
+  constraint s {sel == 1;}
+  // A 'unique' on a dynamically sized array inside a conditional constraint is
+  // not supported and is dropped with a CONSTRAINTIGN warning, which leaves the
+  // if with only its else arm.
+  /* verilator lint_off CONSTRAINTIGN */
+  constraint c {
+    if (sel) {
+      unique {q};
+    } else {
+      x == 3;
+    }
+  }
+  /* verilator lint_on CONSTRAINTIGN */
+endclass
+
+module t;
+  int nfail = 0;
+  int hist[4];
+  int ndistinct;
+  bit [15:0] seen;
+  int cnt, nok, ok;
+  bit [1:0] sv, sv2;
+  int svi;
+
+  // Report one case.  `cnt` is the number of draws that landed in the
+  // bucket of interest; [lo:hi] is the accepted band for it.
+  task automatic report(string nm, int got, int lo, int hi, int okcnt, int draws);
+    if (okcnt != draws) begin
+      $write("%%Error: %-34s randomize() failed %0d/%0d\n", nm, draws - okcnt, draws);
+      nfail++;
+    end
+    if (got < lo || got > hi) begin
+      $write("%%Error: %-34s got=%0d exp=%0d..%0d\n", nm, got, lo, hi);
+      nfail++;
+    end
+    else begin
+      $write("   ok   %-34s got=%0d exp=%0d..%0d\n", nm, got, lo, hi);
+    end
+  endtask
+
+  initial begin
+    automatic Holder h = new;
+    automatic Holder3 h3 = new;
+    automatic HolderInt hi = new;
+    automatic HolderWide hw = new;
+    automatic MemberWeight mw = new;
+    automatic QHolder qh = new;
+    automatic ArrHolder ah = new;
+    automatic Outer o = new;
+    automatic TwoVar tv = new;
+    automatic SideConstraint sc = new;
+    automatic NarrowConstraint nc = new;
+    automatic NegIdxArr na = new;
+    automatic OpHolder oh = new;
+    automatic ModeHolder mh = new;
+    automatic Seq sq = new;
+    automatic DistDerived dd = new;
+    automatic DistBase db;
+    automatic HistClassScope hcs = new;
+    automatic DistConflictScalar cs = new;
+    automatic DistConflictRange cr = new;
+    automatic DistConflictIf ci = new;
+    automatic DistMixedArm ma = new;
+    automatic DistElseless el = new;
+    automatic HardStaysHard hh = new;
+    automatic DistNoConflict nc2 = new;
+    automatic DistImpossible im = new;
+    automatic UniqueThenArm ut = new;
+    automatic DistBesideUnique bu = new;
+    automatic int loc_wa, loc_wb;
+    automatic bit [2:0] loc_lo, loc_hi;
+
+    // verilog_format: off
+    //==========================================================
+    // A. Weight operator forms
+    //==========================================================
+
+    // A1  ':/' on scalar items.  0 gets 90/100.
+    `chk("A1 :/ scalar", h.randomize() with { v dist { 0 :/ 90, 1 :/ 10 }; }, h.v == 0, 150, 200)
+
+    // A2  ':=' on scalar items.  Identical meaning for single values.
+    `chk("A2 := scalar", h.randomize() with { v dist { 0 := 9, 1 := 1 }; }, h.v == 0, 150, 200)
+
+    // A3  An omitted weight means ':= 1', so each item is equally likely.
+    //     Equal weights are still applied rather than left to the solver,
+    //     which returns a satisfying assignment and not a uniform one.
+    `chk("A3 omitted weight (uniform)", h.randomize() with { v dist { 0, 1 }; }, h.v == 0, 70, 130)
+
+    // A4  Mixed ':=' and ':/' in one dist.  0 gets 27, [1:3] shares 3.
+    `chk("A4 mixed := and :/", h.randomize() with { v dist { 0 := 27, [1 : 3] :/ 3 }; }, h.v == 0, 150, 200)
+
+    // A5a ':=' on a range gives that weight to EACH value in the range.
+    //     0 := 90 against [1:4] := 10 -> total 90+4*10 = 130, 0 is 69%.
+    `chk("A5a := on range (per value)", h3.randomize() with { v dist { 0 := 90, [1 : 4] := 10 }; }, h3.v == 0, 110, 175)
+
+    // A5b ':/' on a range divides the weight across the range.
+    //     0 :/ 90 against [1:4] :/ 10 -> total 100, 0 is 90%.
+    //     A5a and A5b together prove ':=' and ':/' are distinguished: an
+    //     implementation that confused them would land outside one band.
+    `chk("A5b :/ on range (divided)", h3.randomize() with { v dist { 0 :/ 90, [1 : 4] :/ 10 }; }, h3.v == 0, 150, 200)
+
+    // A6  A zero weight removes the item from the set entirely.
+    `chk("A6 zero weight excluded", h.randomize() with { v dist { 0 :/ 0, 1 :/ 5, 2 :/ 5 }; }, h.v == 0 || h.v == 3, 0, 0)
+
+    // A7  All weights zero: the dist is vacuous, randomize still succeeds.
+    cnt = 0;
+    nok = 0;
+    for (int i = 0; i < `N; i++) begin
+      ok = h.randomize() with {
+        v dist {
+          0 :/ 0,
+          1 :/ 0
+        };
+      };
+      if (ok != 0) begin
+        nok++;
+        cnt++;
+      end
+    end
+    report("A7 all-zero weights succeed", cnt, `N, `N, nok, `N);
+
+    // A8  A single item is a hard equality: the value is fully determined.
+    `chk("A8 single item", h.randomize() with { v dist { 1 :/ 5 }; }, h.v == 1, `N, `N)
+
+    //==========================================================
+    // B. Weight expression forms
+    //==========================================================
+
+    // B1  Weights read from class members.
+    mw.wa = 90;
+    mw.wb = 10;
+    `chk("B1 weight from class member", mw.randomize() with { v dist { 0 :/ wa, 1 :/ wb }; }, mw.v == 0, 150, 200)
+
+    // B2  Weights read from a local captured into the with-clause.  This form
+    //     has no class-scope equivalent, it only exists inline.
+    loc_wa = 90;
+    loc_wb = 10;
+    `chk("B2 weight from captured local", h.randomize() with { v dist { 0 :/ loc_wa, 1 :/ loc_wb }; }, h.v == 0, 150, 200)
+
+    // B3  Weight as an arithmetic expression.
+    loc_wa = 10;
+    `chk("B3 weight expression", h.randomize() with { v dist { 0 :/ loc_wa * 9, 1 :/ loc_wa }; }, h.v == 0, 150, 200)
+
+    //==========================================================
+    // C. Item and bound forms
+    //==========================================================
+
+    // C1  Constant range items.
+    `chk("C1 constant range", h3.randomize() with { v dist { [0 : 3] :/ 90, [4 : 7] :/ 10 }; }, h3.v <= 3, 150, 200)
+
+    // C2  Range bounds taken from captured locals.
+    loc_lo = 0;
+    loc_hi = 3;
+    `chk("C2 captured range bounds", h3.randomize() with { v dist { [loc_lo : loc_hi] :/ 90, [4 : 7] :/ 10 }; }, h3.v <= 3, 150, 200)
+
+    // C3  Signed negative range on a rand int.
+    `chk("C3 signed negative range", hi.randomize() with { x dist { [-9 : -5] :/ 90, [-4 : 0] :/ 10 }; }, hi.x <= -5, 150, 200)
+
+    // C4  Signed negative scalar items, spelled as literal expressions rather
+    //     than as the equivalent single-value ranges C3 uses.
+    `chk("C4 negative scalars", hi.randomize() with { x dist { -5 :/ 90, 5 :/ 10 }; }, hi.x == -5, 150, 200)
+
+    // C5  Wide (>32 bit) values.
+    `chk("C5 wide values", hw.randomize() with { x dist { 40'd0 :/ 90, 40'hff_ffff_ffff :/ 10 }; }, hw.x == 40'd0, 150, 200)
+
+    // C6  Whole-container item 'dist {que}'.  Weights are all 1 here, so this
+    //     checks membership only: every draw must be one of the queue values.
+    qh.que = '{3, 5, 7};
+    `chk("C6 whole-container membership", qh.randomize() with { v dist { que }; }, qh.v != 3 && qh.v != 5 && qh.v != 7, 0, 0)
+
+    //==========================================================
+    // D. Inline call forms
+    //==========================================================
+
+    // D1  randomize(args) with {} -- the form a UVM sequence writes.
+    `chk("D1 randomize(v) with {}", h.randomize( v ) with { v dist { 0 :/ 90, 1 :/ 10 }; }, h.v == 0, 150, 200)
+
+    // D2  std::randomize(v) with {} -- what DV_CHECK_STD_RANDOMIZE_WITH_FATAL
+    //     expands to.
+    `chk("D2 std::randomize(v) with {}", std::randomize( sv ) with { sv dist { 0 :/ 90, 1 :/ 10 }; }, sv == 0, 150, 200)
+
+    // D3  std::randomize over two variables, dist on one of them.
+    `chk("D3 std::randomize two vars", std::randomize( sv, sv2 ) with { sv dist { 0 :/ 90, 1 :/ 10 }; sv2 < 2; }, sv == 0, 150, 200)
+
+    // D4  std::randomize with a dist on each of two variables.
+    `chk("D4 std::randomize two dists", std::randomize( sv, sv2 ) with { sv dist { 0 :/ 90, 1 :/ 10 }; sv2 dist { 2 :/ 90, 3 :/ 10 }; }, sv == 0 && sv2 == 2, 130, 200)
+
+    // D5  std::randomize on a signed int, with negative scalar items.
+    `chk("D5 std::randomize signed", std::randomize( svi ) with { svi dist { -5 :/ 90, 5 :/ 10 }; }, svi == -5, 150, 200)
+
+    // D6  The restricted 'with (ids) {}' form (IEEE 1800-2023 18.7), which
+    //     names the variables the clause is allowed to constrain.
+    `chk("D6 with (ids) {} form", h.randomize() with ( v) { v dist { 0 :/ 90, 1 :/ 10 }; }, h.v == 0, 150, 200)
+
+    //==========================================================
+    // E. Structural contexts inside the with-clause
+    //==========================================================
+
+    // E1  dist inside an if/else constraint.
+    `chk("E1 dist inside if/else", tv.randomize() with { w == 1; if (w == 1) { v dist { 0 :/ 90, 1 :/ 10 }; } else { v dist { 2 :/ 90, 3 :/ 10 }; } }, tv.v == 0, 150, 200)
+
+    // E2  dist inside a foreach constraint.  4 elements per draw.
+    cnt = 0;
+    nok = 0;
+    for (int i = 0; i < `N; i++) begin
+      ok = ah.randomize() with {
+        foreach (a[j])
+        a[j] dist {
+          [0 : 1] :/ 90,
+          [2 : 7] :/ 10
+        };
+      };
+      if (ok != 0) begin
+        nok++;
+        for (int j = 0; j < 4; j++) if (ah.a[j] <= 1) cnt++;
+      end
+    end
+    report("E2 dist inside foreach", cnt, 620, 800, nok, `N);
+
+    // E3  dist as the consequent of an implication.
+    `chk("E3 dist under implication", tv.randomize() with { w == 1; (w == 1) -> v dist { 0 :/ 90, 1 :/ 10 }; }, tv.v == 0, 150, 200)
+
+    // E4  soft dist.
+    `chk("E4 soft dist", h.randomize() with { soft v dist { 0 :/ 90, 1 :/ 10 }; }, h.v == 0, 150, 200)
+
+    // E5  dist on a member-select through a rand sub-object.
+    `chk("E5 dist on member-select", o.randomize() with { inn.v dist { 0 :/ 90, 1 :/ 10 }; }, o.inn.v == 0, 150, 200)
+
+    // E6  dist on one element of a rand array.
+    `chk("E6 dist on array element", ah.randomize() with { a[1] dist { [0 : 1] :/ 90, [2 : 7] :/ 10 }; }, ah.a[1] <= 1, 150, 200)
+
+    // E7  dist alongside a constraint on a different variable.
+    `chk("E7 dist plus sibling constraint", tv.randomize() with { v dist { 0 :/ 90, 1 :/ 10 }; w == 3; }, tv.v == 0 && tv.w == 3, 150, 200)
+
+    // E8  dist alongside a *compatible* constraint on the same variable.
+    //     The extra constraint does not exclude either dist bucket.
+    `chk("E8 dist plus compatible bound", h.randomize() with { v dist { 0 :/ 90, 1 :/ 10 }; v <= 1; }, h.v == 0, 150, 200)
+
+    // E9  dist alongside a constraint that excludes the heaviest bucket.  The
+    //     set and the constraint still intersect, at [12:15], so randomize()
+    //     succeeds every time and lands there.
+    `chk("E9 dist plus excluding bound", qh.randomize() with { v dist { [0 : 3] :/ 90, [12 : 15] :/ 10 }; v > 10; }, qh.v >= 12, `N, `N)
+
+    //==========================================================
+    // F. Interaction with class-scope constraints
+    //==========================================================
+
+    // F1  Class constrains another variable; inline dist must still weight.
+    `chk("F1 class constr, other var", sc.randomize() with { v dist { 0 :/ 90, 1 :/ 10 }; }, sc.v == 0 && sc.w > 9, 150, 200)
+
+    // F2  Class constrains the same variable, compatibly with the dist.
+    `chk("F2 class constr, same var", nc.randomize() with { v dist { 0 :/ 90, 1 :/ 10 }; }, nc.v == 0, 150, 200)
+
+    // F3  Two successive inline dists on the same object must not leak state
+    //     into one another.
+    cnt = 0;
+    nok = 0;
+    for (int i = 0; i < `N; i++) begin
+      ok = h.randomize() with {
+        v dist {
+          0 :/ 90,
+          1 :/ 10
+        };
+      };
+      if (ok != 0) begin
+        ok = h.randomize() with {
+          v dist {
+            3 :/ 90,
+            2 :/ 10
+          };
+        };
+        if (ok != 0) begin
+          nok++;
+          if (h.v == 3) cnt++;
+        end
+      end
+    end
+    report("F3 successive inline dists", cnt, 165, 200, nok, `N);
+
+    //==========================================================
+    // G. Data shapes a testbench commonly writes
+    //==========================================================
+
+    // G1  An enum-typed rand variable, weighted by enumeration name.
+    `chk("G1 enum-typed items", oh.randomize() with { op dist { OP_RD :/ 90, OP_WR :/ 10 }; }, oh.op == OP_RD, 150, 200)
+
+    // G2  foreach over an unpacked array whose bounds are neither zero-based
+    //     nor ascending.  8 elements per draw, 90% of them in [0:1].
+    cnt = 0;
+    nok = 0;
+    for (int i = 0; i < `N; i++) begin
+      ok = na.randomize() with {
+        foreach (a[j])
+        a[j] dist {
+          [0 : 1] :/ 90,
+          [2 : 7] :/ 10
+        };
+      };
+      if (ok != 0) begin
+        nok++;
+        for (int j = -2; j <= 5; j++) if (na.a[j] <= 1) cnt++;
+      end
+    end
+    report("G2 descending array bounds", cnt, 1240, 1600, nok, `N);
+
+    // G3  A variable frozen with rand_mode(0) holds its value, and an inline
+    //     dist naming it is satisfied by that value while it is in the set.
+    mh.v = 0;
+    mh.v.rand_mode(0);
+    `chk("G3 rand_mode(0) frozen in set", mh.randomize() with { v dist { 0 :/ 90, 3 :/ 10 }; }, mh.v == 0, `N, `N)
+    mh.v.rand_mode(1);
+
+    //==========================================================
+    // H. Call and inheritance contexts
+    //==========================================================
+
+    // H1  The clause is written inside a class method and takes its weight
+    //     from a member of the same object.
+    `chk("H1 in a method, member weight", sq.go_member(), sq.v == 0, 150, 200)
+
+    // H2  The same, with the weight in a variable local to the method.
+    `chk("H2 in a method, local weight", sq.go_local(), sq.v == 0, 150, 200)
+
+    // H3  A member declared in a base class, randomized through a handle of
+    //     the derived type.
+    `chk("H3 base member, derived handle", dd.randomize() with { v dist { 0 :/ 90, 1 :/ 10 }; }, dd.v == 0, 150, 200)
+
+    // H4  The same object through a handle of the base type.
+    db = dd;
+    `chk("H4 base member, base handle", db.randomize() with { v dist { 0 :/ 90, 1 :/ 10 }; }, db.v == 0, 150, 200)
+
+    //==========================================================
+    // I. Every bucket of one distribution, inline and at class scope
+    //==========================================================
+
+    // I1  All four buckets of an inline dist, not just the heaviest, so a
+    //     weight applied to the wrong item is caught as well as one dropped.
+    foreach (hist[i]) hist[i] = 0;
+    nok = 0;
+    for (int i = 0; i < `N; i++) begin
+      ok = h.randomize() with {
+        v dist {
+          0 :/ 70,
+          1 :/ 10,
+          2 :/ 10,
+          3 :/ 10
+        };
+      };
+      if (ok != 0) begin
+        nok++;
+        hist[h.v]++;
+      end
+    end
+    report("I1 inline histogram bucket 0", hist[0], 110, 170, nok, `N);
+    report("I1 inline histogram bucket 1", hist[1], 6, 38, nok, `N);
+    report("I1 inline histogram bucket 2", hist[2], 6, 38, nok, `N);
+    report("I1 inline histogram bucket 3", hist[3], 6, 38, nok, `N);
+
+    // I2  Control: the same distribution written at class scope.
+    foreach (hist[i]) hist[i] = 0;
+    nok = 0;
+    for (int i = 0; i < `N; i++) begin
+      ok = hcs.randomize();
+      if (ok != 0) begin
+        nok++;
+        hist[hcs.v]++;
+      end
+    end
+    report("I2 class-scope bucket 0", hist[0], 110, 170, nok, `N);
+    report("I2 class-scope bucket 1", hist[1], 6, 38, nok, `N);
+    report("I2 class-scope bucket 2", hist[2], 6, 38, nok, `N);
+    report("I2 class-scope bucket 3", hist[3], 6, 38, nok, `N);
+
+    //==========================================================
+    // J. The bucket choice is a preference, not a requirement
+    //==========================================================
+
+    // J1  A hard constraint excluding the heavy bucket leaves the other one,
+    //     so randomize() succeeds and uses it.
+    `chk("J1 scalar bucket excluded", cs.randomize(), cs.x == 5, `N, `N)
+
+    // J2  The same with the heavy bucket a range.
+    `chk("J2 range bucket excluded", cr.randomize(), cr.x >= 12, `N, `N)
+
+    // J3  The dist nested in a constraint if.
+    `chk("J3 dist in a constraint if", ci.randomize(), ci.x >= 12, `N, `N)
+
+    // J4  One arm holds the dist, the other only a hard constraint.
+    `chk("J4 dist in one arm only", ma.randomize(), ma.x >= 12, `N, `N)
+
+    // J5  An if with no else arm.
+    `chk("J5 one-armed constraint if", el.randomize(), el.x >= 12, `N, `N)
+
+    // J6  A hard constraint sharing an arm with a soft one keeps priority.
+    `chk("J6 hard beside soft in an arm", hh.randomize(), hh.x == 2, `N, `N)
+
+    // J7  Unopposed, the weights still apply.
+    `chk("J7 unopposed weights", nc2.randomize(), nc2.x <= 3, 140, 200)
+
+    // J8  An empty intersection of the set and the constraint has no solution.
+    cnt = 0;
+    nok = 0;
+    for (int i = 0; i < `N; i++) begin
+      ok = im.randomize();
+      nok++;
+      if (ok == 0) cnt++;
+    end
+    report("J8 empty intersection fails", cnt, `N, `N, nok, `N);
+
+    // J10 A dist sharing an arm with a dropped 'unique' keeps its weights.
+    `chk("J10 dist beside a dropped unique", bu.randomize(), bu.v <= 3, 150, 200)
+
+    // J9  A 'unique' empties the other arm, leaving an else-only collapse.
+    //     x is unconstrained, so it must range rather than take the else
+    //     arm's value.
+    seen = 0;
+    nok = 0;
+    for (int i = 0; i < `N; i++) begin
+      ut.sel = 0;
+      ok = ut.randomize();
+      if (ok != 0) begin
+        nok++;
+        seen[ut.x] = 1'b1;
+      end
+    end
+    ndistinct = 0;
+    for (int v = 0; v < 16; v++) if (seen[v]) ndistinct++;
+    report("J9 else-only collapse", ndistinct, 8, 16, nok, `N);
+
+
+    //==========================================================
+
+    // verilog_format: on
+
+    if (nfail != 0) begin
+      $write("%%Error: %0d check(s) failed\n", nfail);
+      `stop;
+    end
+    $write("*-* All Finished *-*\n");
+    $finish;
+  end
+endmodule

--- a/test_regress/t/t_constraint_dist_nonconst.v
+++ b/test_regress/t/t_constraint_dist_nonconst.v
@@ -9,12 +9,9 @@
 // variables for the call and hold a fixed value while it runs, so
 // 'x dist {lo :/ 10, ...}' is as well defined as 'x dist {3 :/ 10, ...}'.
 //
-// Before the accompanying fix the weights were dropped for such a 'dist' and
-// the draw came out uniform over the set.
-//
-// Only the single-value items are affected.  The controls below are the same
-// 'dist' written with literal items, and a 'dist' whose only non-constant
-// parts are range bounds; both were already weighted correctly.
+// The controls are the same 'dist' written with literal items, and a 'dist'
+// whose only non-constant parts are range bounds.  All three carry the same
+// expected weighted bands.
 
 // verilog_format: off
 `define stop $stop
@@ -24,10 +21,10 @@
 `define check_hist `check_tol(nlo, `N * `W_LO / `W_TOT) `check_tol(nmid, `N * `W_MID / `W_TOT) `check_tol(nhi, `N * `W_HI / `W_TOT)
 // verilog_format: on
 
-// The bands only have to separate the weighted draw from the uniform one the
-// bug produces, so they are deliberately loose: every check below sits at four
-// sigma or more, while the buggy value is far outside.  A tighter band would
-// turn any future change to solver call order into a spurious failure.
+// The bands are deliberately loose, so a failure means wrong weighting rather
+// than sampling noise: every check below sits at four sigma or more.  A tighter
+// band would turn any future change to solver call order into a spurious
+// failure.
 `define N 1000
 `define TOL_PCT 40
 `define W_LO 10
@@ -61,7 +58,7 @@ class VarBounds;
   }
 endclass
 
-// The single-value items are non-constant.  This is the defect.
+// The single-value items are non-constant.
 class VarItems;
   rand bit [3:0] x;
   bit [3:0] lo = 3;
@@ -103,6 +100,20 @@ class ColonEqItems;
   }
 endclass
 
+// A negative literal is an expression, a negation over a constant, rather than
+// a constant, so it is covered separately from the literal controls above.
+// Same three weights and bands.
+class NegLiteralItems;
+  rand int x;
+  constraint c {
+    x dist {
+      -3 :/ `W_LO,
+      [-2 : 2] :/ `W_MID,
+      3 :/ `W_HI
+    };
+  }
+endclass
+
 module t;
   int nlo, nmid, nhi;
   int neqy, nnine;
@@ -122,6 +133,7 @@ module t;
     automatic VarItems vi = new;
     automatic RandItems ri = new;
     automatic ColonEqItems ce = new;
+    automatic NegLiteralItems nli = new;
 
     nlo = 0;
     nmid = 0;
@@ -169,6 +181,20 @@ module t;
       if (ce.x == 10) nten++;
     end
     `check_tol(nten, `N / 11)
+
+    // Negative literal items.  Signed, so tally() with its bit [3:0] argument
+    // does not apply.
+    nlo = 0;
+    nmid = 0;
+    nhi = 0;
+    for (int i = 0; i < `N; i++) begin
+      `checkd(nli.randomize(), 1)
+      `check_range(nli.x, -3, 3)
+      if (nli.x == -3) nlo++;
+      else if (nli.x == 3) nhi++;
+      else nmid++;
+    end
+    `check_hist
 
     $write("*-* All Finished *-*\n");
     $finish;


### PR DESCRIPTION
A `dist` written inside an inline `randomize() with {}` clause kept its set but ignored its weights, silently. The same `dist` at class scope weighted correctly, so the two paths disagreed:

```systemverilog
pl.randomize() with { v dist {0 :/ 70, 1 :/ 10, 2 :/ 10, 3 :/ 10}; };
```

came out roughly uniform. `std::randomize(v) with {...}` lost its weights the same way, which is the form `DV_CHECK_STD_RANDOMIZE_WITH_FATAL` expands to.

`V3Width::visit(AstDist)` leaves a `dist` for `V3Randomize`, which builds the weighted bucket chain, only while `m_constraintp` is set, and that is only set while iterating an `AstConstraint`. An inline clause is an `AstWith`, so the test failed there and `V3Width` took its own lowering instead, the one its comment marks as ignoring weights. This tests for the enclosing `AstConstraintExpr` instead: the grammar builds one for every `constraint_expression`, whether it came from a constraint block or a with clause, and for nothing else.

Fixing that exposed a second defect, which is the first commit here. `V3Randomize` builds the weighted bucket choice as a chain of soft `AstConstraintIf` precisely so the solver can retract it, but `ConstraintExprVisitor::visit(AstConstraintIf)` folded that chain into a fresh `AstConstraintExpr` which defaulted to hard. A `dist` whose weighted bucket another constraint excluded then reported UNSAT rather than falling back on its membership constraint. That is a pre-existing class-scope bug, but routing inline `dist` through the same lowering would have extended it to inline code, so it is fixed first.

Measured on `x dist {[0:3] :/ 90, [12:15] :/ 10}` alongside `x > 10`, over 500 draws:

| | before | after |
|---|---|---|
| randomize() succeeded | 54 / 500 | 500 / 500 |

Weighting itself is unchanged: the same 17-case class-scope matrix produces identical counts before and after.

## Performance

RTLMeter, `VeeR-EL2:default:dhry` and `Servant:serv:phil`, comparing this branch against its base: every generated `.cpp` and `.h` is byte-identical, code size 1.00x, peak memory 1.00x. Execute speed measured 1.000x on best-of-run; the mean was noisy because the machine was shared, but identical generated code means simulation speed cannot change.

RTLMeter designs contain no `randomize()`, so solver throughput was measured separately, 3000 calls, best-of-N:

| benchmark | before | after |
|---|---|---|
| class-scope dist | 4.51s | 4.25s |
| dist inside a constraint if | 39.80s | 5.16s |
| constraints with no dist | 39.65s | 39.67s |

The `dist`-in-`if` case is faster because the split emits a hard membership constraint plus a retractable soft choice, in place of one hard `ite` the solver had to satisfy exactly.

## Tests

`t_constraint_dist_inline` is the single new test. It covers both weight operators, an omitted weight, zero and all-zero weights, a single item, weights from a member and a local and an expression, constant and captured bounds, signed ranges, negative scalars, wide values, a whole-container item, the `randomize()`, `randomize(args)`, `std::randomize()` and `with (ids) {}` call forms, a `dist` in a constraint if, a foreach, an implication, a soft constraint, a member-select, an array element, beside sibling constraints, enum items, a descending non-zero-based array, `rand_mode(0)`, a class method, base-class members through derived and base handles, every bucket of a four-way distribution against a class-scope control, and the bucket choice yielding to a hard constraint in several arm shapes including the else-only collapse.

48 of its 60 checks fail without this change. Bands are sized so a failure means wrong weighting rather than sampling noise; the tightest sits at 4.2 sigma, and it passes across 15 seeds. Both commits build and pass the `t_constraint*`, `t_randomize*` and `t_rand*` suites on their own.

## Known limitation, not addressed here

A `foreach` containing a `dist` nested inside a constraint `if` hits an internal error in `V3Scope`, and `unique` inside a constraint `if` has its own problems: on a queue every `randomize()` reports unsatisfiable, and on scalars the optimized binary crashes where the debug one does not. All of these reproduce on master without this change and are independent of it. They are recorded here so the gap is visible; none is addressed.

Generative AI was used significantly in preparing this change.
