### PR TITLE
Tests: Add failing tests for non-uniform constrained randomize (#8024)

### DIFF
--- a/test_regress/t/t_constraint_uniform_joint.py
+++ b/test_regress/t/t_constraint_uniform_joint.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+if not test.have_solver:
+    test.skip("No constraint solver installed")
+
+test.compile()
+
+test.execute(all_run_flags=["+verilator+seed+1"])
+
+test.passes()

--- a/test_regress/t/t_constraint_uniform_joint.v
+++ b/test_regress/t/t_constraint_uniform_joint.v
@@ -1,0 +1,81 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain.
+// SPDX-FileCopyrightText: 2026 BRDR LIFE
+// SPDX-License-Identifier: CC0-1.0
+
+// IEEE 1800-2023 18.5.9 requires uniformity over legal value *combinations*,
+// not just over the values of one variable.  Here x + y == 10 with two 4-bit
+// variables has exactly 11 solutions, x = 0..10 with y = 10 - x, so each
+// value of x should come up about as often as any other.
+//
+// Unlike the single-variable ranges in t_constraint_uniform_range, the skew
+// here is spread across the bins rather than concentrated in one value, so a
+// per-value band wide enough not to be flaky does not catch it.  This test
+// uses a chi-square goodness-of-fit statistic instead.  With 11 bins there
+// are 10 degrees of freedom, where a uniform solver averages about 10 and
+// exceeds 60 with probability about 4e-9.  Verilator scores in the low
+// hundreds.  See issue #8024.
+
+// verilog_format: off
+`define stop $stop
+`define check_range(nam,gotv,minv,maxv) do if ((gotv) < (minv) || (gotv) > (maxv)) begin $write("%%Error: %s:%0d: %s: got=%0d exp=%0d..%0d\n", `__FILE__,`__LINE__, nam, (gotv), (minv), (maxv)); fails++; end while(0);
+// verilog_format: on
+
+`define N 2000
+`define SOLUTIONS 11
+`define CHI2_MAX 60
+
+class Pair;
+  rand bit [3:0] x, y;
+  constraint c {x + y == 10;}
+endclass
+
+module t;
+  int fails;
+  int hist  [0:15];
+
+  initial begin
+    automatic Pair p = new;
+    real expect_each;
+    real chi2;
+    real diff;
+    int i;
+    int r;
+
+    foreach (hist[i]) hist[i] = 0;
+
+    for (i = 0; i < `N; i++) begin
+      r = p.randomize();
+      `check_range("randomize", r, 1, 1)
+      // Every solution must satisfy the constraint and lie in x = 0..10.
+      `check_range("x + y", int'(p.x) + int'(p.y), 10, 10)
+      `check_range("x", int'(p.x), 0, 10)
+      hist[p.x]++;
+    end
+
+    expect_each = real'(`N) / real'(`SOLUTIONS);
+    chi2 = 0.0;
+    $write("x counts (expected %0.1f each):", expect_each);
+    for (i = 0; i < `SOLUTIONS; i++) begin
+      $write(" %0d", hist[i]);
+      diff = real'(hist[i]) - expect_each;
+      chi2 += (diff * diff) / expect_each;
+    end
+    $write("\n");
+    $display("chi-square %0.1f over %0d bins, tolerated up to %0d", chi2, `SOLUTIONS, `CHI2_MAX);
+
+    if (chi2 > real'(`CHI2_MAX)) begin
+      $write("%%Error: %s:%0d: x distribution is not uniform over the 11 solutions\n", `__FILE__,
+             `__LINE__);
+      fails++;
+    end
+
+    if (fails != 0) begin
+      $write("%%Error: %0d check(s) outside tolerance\n", fails);
+      `stop;
+    end
+    $write("*-* All Finished *-*\n");
+    $finish;
+  end
+endmodule

--- a/test_regress/t/t_constraint_uniform_lrm.py
+++ b/test_regress/t/t_constraint_uniform_lrm.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+if not test.have_solver:
+    test.skip("No constraint solver installed")
+
+test.compile()
+
+test.execute(all_run_flags=["+verilator+seed+1"])
+
+test.passes()

--- a/test_regress/t/t_constraint_uniform_lrm.v
+++ b/test_regress/t/t_constraint_uniform_lrm.v
@@ -1,0 +1,89 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain.
+// SPDX-FileCopyrightText: 2026 BRDR LIFE
+// SPDX-License-Identifier: CC0-1.0
+
+// IEEE 1800-2023 18.5.9 (18.5.10 in 1800-2017) requires that the solver
+// "assure that the random values are selected to give a uniform value
+// distribution over legal value combinations (that is, all combinations of
+// legal values have the same probability of being the solution)".
+//
+// This is the worked example from that clause.  There are 1 + 2**8 legal
+// {s,d} combinations and s is true in only one of them, so Table 18-1 of the
+// clause gives every combination probability 1/257, and s is set in about one
+// draw in 257.
+//
+// The runtime sets s about half the time instead, which is roughly the
+// Table 18-2 distribution that the clause reserves for "solve s before d".
+//
+// The second half of this test runs the ordered form for contrast, but only
+// prints what it sees rather than checking it.  That form does not match
+// Table 18-2 either -- it comes out near 27% rather than 50% -- but it takes
+// a different path through the runtime (the phased solve rather than the
+// per-bit pinning), so it looks like a separate matter and is left out of the
+// pass criterion here.  See issue #8024.
+
+// verilog_format: off
+`define stop $stop
+`define check_range(nam,gotv,minv,maxv) do if ((gotv) < (minv) || (gotv) > (maxv)) begin $write("%%Error: %s:%0d: %s: got=%0d exp=%0d..%0d\n", `__FILE__,`__LINE__, nam, (gotv), (minv), (maxv)); fails++; end while(0);
+// verilog_format: on
+
+`define N 2000
+
+// The class exactly as printed in IEEE 1800-2023 18.5.9.
+class B;
+  rand bit s;
+  rand bit [7:0] d;
+  constraint c {s -> d == 0;}
+endclass
+
+// The same class with the ordering the clause uses to obtain Table 18-2.
+class BOrdered;
+  rand bit s;
+  rand bit [7:0] d;
+  constraint c {s -> d == 0;}
+  constraint order {solve s before d;}
+endclass
+
+module t;
+  int fails;
+
+  initial begin
+    automatic B b = new;
+    automatic BOrdered bo = new;
+    int s_ones;
+    int s_ones_ordered;
+    int i;
+    int r;
+
+    // Table 18-1: no ordering, so every legal {s,d} pair is equally likely
+    // and s is set in 1 of 257 draws.  Binomial(`N, 1/257) has mean 7.8 and
+    // standard deviation 2.8, so the upper bound below sits about 11 sigma
+    // out and a uniform solver passes with room to spare.
+    for (i = 0; i < `N; i++) begin
+      r = b.randomize();
+      `check_range("randomize", r, 1, 1)
+      if (b.s) s_ones++;
+    end
+    $display("Table 18-1  s==1 in %0d/%0d draws (expected about %0d)", s_ones, `N, `N / 257);
+    `check_range("s==1 without solve-before", s_ones, 0, 40)
+
+    // Table 18-2: "solve s before d" picks s first, so the clause puts s at
+    // 50%.  Reported for contrast only; see the note at the top of the file.
+    for (i = 0; i < `N; i++) begin
+      r = bo.randomize();
+      `check_range("randomize ordered", r, 1, 1)
+      if (bo.s) s_ones_ordered++;
+    end
+    $display("Table 18-2  s==1 in %0d/%0d draws (expected about %0d, not checked here)",
+             s_ones_ordered, `N, `N / 2);
+
+    if (fails != 0) begin
+      $write("%%Error: %0d check(s) outside tolerance\n", fails);
+      `stop;
+    end
+    $write("*-* All Finished *-*\n");
+    $finish;
+  end
+endmodule

--- a/test_regress/t/t_constraint_uniform_range.py
+++ b/test_regress/t/t_constraint_uniform_range.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+if not test.have_solver:
+    test.skip("No constraint solver installed")
+
+test.compile()
+
+test.execute(all_run_flags=["+verilator+seed+1"])
+
+test.passes()

--- a/test_regress/t/t_constraint_uniform_range.v
+++ b/test_regress/t/t_constraint_uniform_range.v
@@ -1,0 +1,187 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain.
+// SPDX-FileCopyrightText: 2026 BRDR LIFE
+// SPDX-License-Identifier: CC0-1.0
+
+// IEEE 1800-2023 18.5.9 requires every legal value combination to be equally
+// probable.  For a single variable constrained to a range that means every
+// value in the range comes up equally often.
+//
+// A range that is a power-of-2 bit-aligned block does come out uniform.  Any
+// other range does not: the runtime pins each free bit to a random target, so
+// bit k is set half the time whatever fraction of the legal values actually
+// have it set.  Over [0:16] only one of the seventeen legal values has bit 4
+// set, so that one value takes about half of all draws.
+//
+// The $urandom_range case is a control that involves no solver, and the
+// [0:15] and [0:31] cases are controls that the current mechanism handles
+// correctly.  All three pass; they are here so that a failure elsewhere is
+// clearly not the harness.  See issue #8024.
+
+// verilog_format: off
+`define stop $stop
+`define check_range(nam,gotv,minv,maxv) do if ((gotv) < (minv) || (gotv) > (maxv)) begin $write("%%Error: %s:%0d: %s: got=%0d exp=%0d..%0d\n", `__FILE__,`__LINE__, nam, (gotv), (minv), (maxv)); fails++; end while(0);
+// verilog_format: on
+
+`define N 2000
+
+// Every legal value must be drawn between a third and twice the uniform
+// share.  The tightest range here has 16 legal values, where Binomial(`N,
+// 1/16) has mean 125 and standard deviation 10.8, so the band is over 7 sigma
+// either way and a uniform solver passes on any seed.
+//
+// The low bound is a third rather than a half because the two are not
+// independent: if one value takes half of all draws, the rest necessarily
+// average half the uniform share, which would make the low bound fire
+// marginally on every one of them.  A third keeps the reported failure on the
+// value that is actually over-represented.
+`define LO_NUM 1
+`define LO_DEN 3
+`define HI_NUM 2
+`define HI_DEN 1
+
+class InsideAligned16;
+  rand int value;
+  constraint c {value inside {[0 : 15]};}
+endclass
+
+class InsideAligned32;
+  rand int value;
+  constraint c {value inside {[0 : 31]};}
+endclass
+
+// Seventeen legal values.  Only value 16 has bit 4 set.
+class InsideOffByOne;
+  rand int value;
+  constraint c {value inside {[0 : 16]};}
+endclass
+
+class InsideRange;
+  rand int value;
+  constraint c {value inside {[1 : 20]};}
+endclass
+
+// The same legal set written without 'inside'.
+class CompareRange;
+  rand int value;
+  constraint c {
+    value >= 1;
+    value <= 20;
+  }
+endclass
+
+// The same legal set asked for as a soft constraint inside a wider hard one.
+class SoftRange;
+  rand int value;
+  constraint c {value inside {[0 : 100]};}
+endclass
+
+module t;
+  int fails;
+  int hist  [0:127];
+
+  function automatic void reset_hist();
+    foreach (hist[i]) hist[i] = 0;
+  endfunction
+
+  function automatic void tally(input int value, input int lo, input int hi);
+    if (value < lo || value > hi) begin
+      $write("%%Error: value %0d outside [%0d:%0d]\n", value, lo, hi);
+      fails++;
+      return;
+    end
+    hist[value]++;
+  endfunction
+
+  // Report every legal value, then flag the ones outside the band.
+  function automatic void check_uniform(input string name, input int lo, input int hi);
+    automatic int nvals = hi - lo + 1;
+    automatic int expect_each = `N / nvals;
+    automatic int minv = hist[lo];
+    automatic int maxv = hist[lo];
+    for (int v = lo; v <= hi; v++) begin
+      if (hist[v] < minv) minv = hist[v];
+      if (hist[v] > maxv) maxv = hist[v];
+    end
+    $display("%-28s [%0d:%0d] %0d values, expected %0d each, got min=%0d max=%0d", name, lo, hi,
+             nvals, expect_each, minv, maxv);
+    for (int v = lo; v <= hi; v++)
+      `check_range(name, hist[v], expect_each * `LO_NUM / `LO_DEN, expect_each * `HI_NUM / `HI_DEN)
+  endfunction
+
+  initial begin
+    automatic InsideAligned16 a16 = new;
+    automatic InsideAligned32 a32 = new;
+    automatic InsideOffByOne o17 = new;
+    automatic InsideRange ir = new;
+    automatic CompareRange cr = new;
+    automatic SoftRange sr = new;
+    int i;
+    int r;
+
+    // Control: no solver involved.
+    reset_hist();
+    for (i = 0; i < `N; i++) tally($urandom_range(16, 0), 0, 16);
+    check_uniform("$urandom_range 0..16", 0, 16);
+
+    // Control: power-of-2 bit-aligned blocks are handled correctly.
+    reset_hist();
+    for (i = 0; i < `N; i++) begin
+      r = a16.randomize();
+      `check_range("randomize [0:15]", r, 1, 1)
+      tally(a16.value, 0, 15);
+    end
+    check_uniform("inside [0:15]", 0, 15);
+
+    reset_hist();
+    for (i = 0; i < `N; i++) begin
+      r = a32.randomize();
+      `check_range("randomize [0:31]", r, 1, 1)
+      tally(a32.value, 0, 31);
+    end
+    check_uniform("inside [0:31]", 0, 31);
+
+    // One value wider than a power-of-2 block, which is the worst case.
+    reset_hist();
+    for (i = 0; i < `N; i++) begin
+      r = o17.randomize();
+      `check_range("randomize [0:16]", r, 1, 1)
+      tally(o17.value, 0, 16);
+    end
+    check_uniform("inside [0:16]", 0, 16);
+
+    reset_hist();
+    for (i = 0; i < `N; i++) begin
+      r = ir.randomize();
+      `check_range("randomize [1:20]", r, 1, 1)
+      tally(ir.value, 1, 20);
+    end
+    check_uniform("inside [1:20]", 1, 20);
+
+    // Not specific to 'inside'; both lower to the same comparisons.
+    reset_hist();
+    for (i = 0; i < `N; i++) begin
+      r = cr.randomize();
+      `check_range("randomize >=1 <=20", r, 1, 1)
+      tally(cr.value, 1, 20);
+    end
+    check_uniform("value >= 1; value <= 20", 1, 20);
+
+    // Soft constraints take the same path.
+    reset_hist();
+    for (i = 0; i < `N; i++) begin
+      r = sr.randomize() with {soft value inside {[1 : 20]};};
+      `check_range("randomize soft [1:20]", r, 1, 1)
+      tally(sr.value, 1, 20);
+    end
+    check_uniform("soft inside [1:20]", 1, 20);
+
+    if (fails != 0) begin
+      $write("%%Error: %0d check(s) outside tolerance\n", fails);
+      `stop;
+    end
+    $write("*-* All Finished *-*\n");
+    $finish;
+  end
+endmodule


### PR DESCRIPTION
Tests only, no fix. These reproduce #8024 and **fail on master**, so CI on this branch is expected to be red. Opening as a draft to make the behaviour easy to poke at.

IEEE 1800-2023 18.5.9 (18.5.10 in 1800-2017) requires the solver to "assure that the random values are selected to give a uniform value distribution over legal value combinations". Constrained `randomize()` does not. Each test isolates one facet, so whichever facets a fix addresses should be visible from which tests go green.

### t_constraint_uniform_lrm

The worked example from the clause itself. `s` should be set in about 1 draw in 257; it is set in about half.

```
Table 18-1  s==1 in 1020/2000 draws (expected about 7)
%Error: t/t_constraint_uniform_lrm.v:70: s==1 without solve-before: got=1020 exp=0..40
Table 18-2  s==1 in 538/2000 draws (expected about 1000, not checked here)
```

The `solve s before d` form is run for contrast but deliberately not part of the pass criterion. It does not match Table 18-2 either, coming out near 27% rather than 50%, but it goes through the phased solve rather than the per-bit pinning, so it looks like a separate matter and I did not want to conflate the two. Happy to split it out if you would rather it were tracked.

### t_constraint_uniform_range

Single variable constrained to a range. The first three cases are controls that pass, so a failure below is clearly not the harness.

```
$urandom_range 0..16         [0:16] 17 values, expected 117 each, got min=100 max=130
inside [0:15]                [0:15] 16 values, expected 125 each, got min=103 max=150
inside [0:31]                [0:31] 32 values, expected 62 each, got min=44 max=74
inside [0:16]                [0:16] 17 values, expected 117 each, got min=48 max=1024
%Error: t/t_constraint_uniform_range.v:110: inside [0:16]: got=1024 exp=39..234
inside [1:20]                [1:20] 20 values, expected 100 each, got min=45 max=537
%Error: t/t_constraint_uniform_range.v:110: inside [1:20]: got=537 exp=33..200
value >= 1; value <= 20      [1:20] 20 values, expected 100 each, got min=41 max=491
%Error: t/t_constraint_uniform_range.v:110: value >= 1; value <= 20: got=491 exp=33..200
soft inside [1:20]           [1:20] 20 values, expected 100 each, got min=51 max=513
%Error: t/t_constraint_uniform_range.v:110: soft inside [1:20]: got=513 exp=33..200
```

A power-of-2 bit-aligned block is uniform, anything else is not. Over `[0:16]` the single value 16 takes about half of all draws, which is what per-bit pinning gives when only one of the seventeen legal values has bit 4 set. The relational and soft forms behave the same as `inside`.

### t_constraint_uniform_joint

Uniformity over combinations rather than over one variable. `x + y == 10` on two 4-bit variables has 11 solutions.

```
x counts (expected 181.8 each): 262 269 232 234 106 143 124 249 137 120 124
chi-square 239.6 over 11 bins, tolerated up to 60
```

This one uses chi-square because the skew is spread across the bins rather than concentrated in one value, so a per-value band wide enough not to be flaky does not catch it.

### Tolerances

Bands are set well wide of binomial noise so a uniform solver passes on any seed, and the file comments give the sigma for each. The tests are pinned to `+verilator+seed+1` like the other distribution tests, but I checked seeds 1, 2, 3, 7 and 42: every control passes on all five, and every failing case fails on all five. `s==1` lands in 981..1038 of 2000 against a band of 0..40, and chi-square in 209..308 against 60.

The one place I loosened a band deliberately is the low end in the range test, which is a third of the uniform share rather than a half. If one value takes half of all draws then the rest necessarily average half the share, so a half-share low bound fires marginally on every other value and buries the signal. A third keeps the reported failure on the value that is actually over-represented.

### Not included

No `Changes` entry, since nothing user-visible is fixed yet. Tests pass `t_dist_contributors`, `t_dist_copyright`, `t_dist_lint_py`, `t_dist_untracked`, `t_dist_fixme` and `t_dist_whitespace`, and are `verible-verilog-format` clean.

Fixes #8024 once something is behind them. I sketched a few directions in the issue and would rather agree on one before writing any of it.
