### PR TITLE
Fix optimizations of unpacked values 

### DIFF
--- a/src/V3Const.cpp
+++ b/src/V3Const.cpp
@@ -438,6 +438,7 @@ class ConstBitOpTreeVisitor final : public VNVisitorConst {
 
     // Traverse down to see AstConst or AstVarRef
     LeafInfo findLeaf(AstNode* nodep, bool expectConst) {
+        if (!nodep->dtypep()->skipRefp()->isIntegralOrPacked()) return LeafInfo{};
         LeafInfo info{m_lsb};
         {
             VL_RESTORER(m_leafp);

--- a/test_regress/t/t_opt_unpacked.py
+++ b/test_regress/t/t_opt_unpacked.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile()
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_opt_unpacked.v
+++ b/test_regress/t/t_opt_unpacked.v
@@ -1,0 +1,33 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain.
+// SPDX-FileCopyrightText: 2026 Antmicro
+// SPDX-License-Identifier: CC0-1.0
+
+// This test purpose is to make sure we do not drop if conditional
+// expression when trying to optimise bit operations.
+module t;
+  class Cls;
+  endclass;
+
+  class subCls;
+    bit val = 1'b1;
+    Cls c;
+
+    function void check_valid();
+      // "c == null" shall be preserved
+      if (val && c == null) begin
+        $stop();
+      end
+    endfunction
+  endclass;
+
+  subCls sc;
+
+  initial begin
+    sc = new;
+    sc.c = new;
+    sc.check_valid();
+    $finish;
+  end
+endmodule


### PR DESCRIPTION
When optimising bit operations, we're iterating through bits of this variable, we shouldn't do that in case of `unpacked` variables. They could have `width` equal to 0, which would result in skipping these variables entirely in new `AstNode` tree. This may lead to logically incorrect optimizations. e.g:

~~~systemverilog
if (enable && model == null)
~~~ 

Above expression in current state of `Verilator` is converted in the end to:

~~~systemverilog
if (enable)
~~~