### PR TITLE
Tests: Add constraint randomization distribution conformance tests (failing, documents a solver defect)

### DIFF
--- a/test_regress/t/t_constraint_array_uniform.py
+++ b/test_regress/t/t_constraint_array_uniform.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+if not test.have_solver:
+    test.skip("No constraint solver installed")
+
+test.compile()
+
+# THIS TEST FAILS ON MASTER, BY DESIGN. A rand array solved through the
+# constraint solver takes grossly non-uniform values even under a constraint
+# that excludes nothing. See the header of t_constraint_array_uniform.v.
+#
+# Fixed seed so the bands are deterministic run to run.
+test.execute(all_run_flags=["+verilator+seed+1"])
+
+test.passes()

--- a/test_regress/t/t_constraint_array_uniform.v
+++ b/test_regress/t/t_constraint_array_uniform.v
@@ -1,0 +1,198 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain.
+// SPDX-FileCopyrightText: 2026 BRDR LIFE
+// SPDX-License-Identifier: CC0-1.0
+
+// A `rand` ARRAY solved through the constraint solver takes grossly non-uniform
+// values, even when the only constraint on it is vacuous.
+//
+//   class C;
+//     rand bit [2:0] a[8];
+//     constraint c { foreach (a[i]) a[i] <= 3'd7; }
+//   endclass
+//
+// `a` is `bit [2:0]`, so its largest possible value IS 7 and `a[i] <= 3'd7` is
+// true for every value the type can hold. The constraint excludes nothing, so
+// the eight values 0..7 must be equally likely. Over 800 solves x 8 elements =
+// 6400 samples, uniform is 800 per value. Master produces roughly:
+//
+//   value  0     1     2    3    4     5    6    7
+//   count  2133  1591  187  129  1647  529  143  41
+//
+// a 52x spread between the most and least likely value, and stable to within a
+// few percent across seeds - a systematic bias, not sampling noise.
+//
+// IEEE 1800-2023 18.5.10 requires the solver to "assure that the random values
+// are selected to give a uniform value distribution over legal value
+// combinations". No reading of that sentence permits value 7 to be 20x rarer
+// than value 0 under a constraint that excludes nothing.
+//
+// Two controls localise it to the solver's ARRAY path:
+//
+//   CtlArrNoConstraint  the same array with NO constraint at all. It never
+//                       enters the solver and is uniform (752-838 per bucket).
+//   CtlScalarVacuous    the same vacuous constraint on a SCALAR. It takes the
+//                       bit-pinning path (verilated_random.cpp
+//                       solveDiversityPins) and is uniform (85-112 of 800).
+//
+// The failing rows take solveDiversityXor instead, which verilated_random.cpp
+// selects per-OBJECT whenever any solver variable has dimension > 0 (see
+// verilated_random.cpp:633-646). Note the selector is per-object, not
+// per-variable: one array member drags every other variable in the same
+// randomize() onto the XOR path.
+//
+// ArrRestricted shows this is not limited to vacuous constraints. Under
+// `a[i] < 3'd6` the excluded values 6 and 7 are correctly absent - the hard
+// constraint is honoured - but the six legal values spread 143..2094 where each
+// should be about 1067.
+//
+// This is the root defect. The guard-condition skew documented in
+// t_constraint_rand_cond_skew is a downstream symptom of it.
+
+// verilog_format: off
+`define stop $stop
+`define checkd(gotv,expv) do if ((gotv) !== (expv)) begin $write("%%Error: %s:%0d:  got=%0d exp=%0d\n", `__FILE__,`__LINE__, (gotv), (expv)); `stop; end while(0);
+// verilog_format: on
+
+// Vacuous constraint over 8 elements. FAILING on master.
+class ArrVacuous;
+  rand bit [2:0] a[8];
+  constraint c {
+    foreach (a[i]) a[i] <= 3'd7;
+  }
+endclass
+
+// Genuinely restrictive, but still six legal values per element.
+// The exclusion is honoured; the distribution over what remains is not.
+class ArrRestricted;
+  rand bit [2:0] a[8];
+  constraint c {
+    foreach (a[i]) a[i] < 3'd6;
+  }
+endclass
+
+// Control: no constraint at all, so the array bypasses the solver. Uniform.
+class CtlArrNoConstraint;
+  rand bit [2:0] a[8];
+endclass
+
+// Control: same vacuous constraint on a scalar. Bit-pinning path. Uniform.
+class CtlScalarVacuous;
+  rand bit [2:0] a;
+  constraint c {a <= 3'd7;}
+endclass
+
+module t;
+  // 800 solves. For the 8-element arrays that is 6400 samples over 8 values,
+  // so uniform is 800 per value with sigma = sqrt(6400*(1/8)*(7/8)) = 26.5.
+  // The +/-25% band [600,1000] is +/-7.5 sigma: a uniform mechanism escapes it
+  // with probability far below 1e-12, while master misses it on six of the
+  // eight buckets.
+  localparam int SOLVES = 800;
+  localparam int NELEM = 8;
+  localparam int NVAL = 8;
+  localparam int ARR_SAMPLES = SOLVES * NELEM;
+  localparam int ARR_EXP = ARR_SAMPLES / NVAL;  // 800
+  localparam int ARR_LO = (ARR_EXP * 3) / 4;  // 600
+  localparam int ARR_HI = (ARR_EXP * 5) / 4;  // 1000
+
+  // Restricted case: 6400 samples over 6 legal values, expected 1066.
+  localparam int RES_NVAL = 6;
+  localparam int RES_EXP = ARR_SAMPLES / RES_NVAL;
+  localparam int RES_LO = (RES_EXP * 3) / 4;
+  localparam int RES_HI = (RES_EXP * 5) / 4;
+
+  // Scalar control: 800 samples over 8 values, expected 100, sigma 9.35.
+  // [60,140] is +/-4.3 sigma.
+  localparam int SCL_LO = 60;
+  localparam int SCL_HI = 140;
+
+  ArrVacuous arr_vac;
+  ArrRestricted arr_res;
+  CtlArrNoConstraint ctl_none;
+  CtlScalarVacuous ctl_scl;
+
+  int h[8];
+  int i;
+  int j;
+  int ok;
+  int bad;
+  int viol;
+
+  // Print a histogram and count how many buckets fall outside [lo,hi]
+  function automatic int band_check(string label, int hh[8], int lo, int hi, int nval);
+    int outside = 0;
+    $write("  %-22s", label);
+    for (int k = 0; k < 8; k++) $write(" %5d", hh[k]);
+    for (int k = 0; k < nval; k++) if (hh[k] < lo || hh[k] > hi) outside++;
+    $write("   band [%0d:%0d] outside=%0d %s\n", lo, hi, outside,
+           (outside != 0) ? "OUT-OF-BAND" : "ok");
+    return outside;
+  endfunction
+
+  initial begin
+    bad = 0;
+    arr_vac = new;
+    arr_res = new;
+    ctl_none = new;
+    ctl_scl = new;
+
+    $write("value histograms over %0d solves (uniform = equal buckets):\n", SOLVES);
+    $write("  %-22s %5s %5s %5s %5s %5s %5s %5s %5s\n", "shape", "0", "1", "2", "3", "4", "5",
+           "6", "7");
+
+    // Vacuous constraint over an array. Every value 0..7 is legal.
+    for (j = 0; j < 8; j++) h[j] = 0;
+    for (i = 0; i < SOLVES; i++) begin
+      ok = arr_vac.randomize();
+      `checkd(ok, 1)
+      foreach (arr_vac.a[k]) h[arr_vac.a[k]]++;
+    end
+    bad += band_check("ArrVacuous", h, ARR_LO, ARR_HI, NVAL);
+
+    // Restricted: 6 and 7 must never appear, 0..5 must be near-equal.
+    for (j = 0; j < 8; j++) h[j] = 0;
+    viol = 0;
+    for (i = 0; i < SOLVES; i++) begin
+      ok = arr_res.randomize();
+      `checkd(ok, 1)
+      foreach (arr_res.a[k]) begin
+        h[arr_res.a[k]]++;
+        if (arr_res.a[k] >= 3'd6) viol++;
+      end
+    end
+    // The hard constraint itself must hold; only the distribution is at issue.
+    `checkd(viol, 0)
+    bad += band_check("ArrRestricted (<6)", h, RES_LO, RES_HI, RES_NVAL);
+
+    // Control: unconstrained array bypasses the solver.
+    for (j = 0; j < 8; j++) h[j] = 0;
+    for (i = 0; i < SOLVES; i++) begin
+      ok = ctl_none.randomize();
+      `checkd(ok, 1)
+      foreach (ctl_none.a[k]) h[ctl_none.a[k]]++;
+    end
+    bad += band_check("CtlArrNoConstraint", h, ARR_LO, ARR_HI, NVAL);
+
+    // Control: same vacuous constraint on a scalar, bit-pinning path.
+    for (j = 0; j < 8; j++) h[j] = 0;
+    for (i = 0; i < SOLVES; i++) begin
+      ok = ctl_scl.randomize();
+      `checkd(ok, 1)
+      h[ctl_scl.a]++;
+    end
+    bad += band_check("CtlScalarVacuous", h, SCL_LO, SCL_HI, NVAL);
+
+    if (bad != 0) begin
+      $write("%%Error: %s:%0d: %0d value bucket(s) outside band\n", `__FILE__, `__LINE__, bad);
+      $write("%%Error: IEEE 1800-2023 18.5.10: the solver shall give a uniform value\n");
+      $write("%%Error: distribution over legal value combinations. A constraint that\n");
+      $write("%%Error: excludes no value must leave every value equally likely.\n");
+      `stop;
+    end
+
+    $write("*-* All Finished *-*\n");
+    $finish;
+  end
+endmodule

--- a/test_regress/t/t_constraint_rand_cond_equiv.py
+++ b/test_regress/t/t_constraint_rand_cond_equiv.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+if not test.have_solver:
+    test.skip("No constraint solver installed")
+
+test.compile()
+
+# THIS TEST FAILS ON MASTER, BY DESIGN. Constraints denoting the same solution
+# set randomize differently depending on how they are spelled, and arms of equal
+# measure are not equiprobable.
+# See the header of t_constraint_rand_cond_equiv.v.
+test.execute(all_run_flags=["+verilator+seed+1"])
+
+test.passes()

--- a/test_regress/t/t_constraint_rand_cond_equiv.v
+++ b/test_regress/t/t_constraint_rand_cond_equiv.v
@@ -1,0 +1,313 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain.
+// SPDX-FileCopyrightText: 2026 BRDR LIFE
+// SPDX-License-Identifier: CC0-1.0
+
+// Constraints with the same solution set must produce the same distribution.
+// A constraint denotes a set of legal value combinations; nothing in IEEE 1800
+// makes the distribution depend on which syntax was used to write that set
+// down. Every assertion here is RELATIONAL - it compares two spellings of one
+// solution space - so none of it depends on settling what the absolute rate
+// ought to be.
+//
+// All six SameSpace* classes below describe exactly the same problem: a free
+// `rand bit` guarding a pin of four 3-bit values, so one arm holds a single
+// solution and the other holds 2**12. They differ only in spelling: explicit
+// index, foreach, implication instead of if, queue, dynamic array, and four
+// standalone scalars instead of four array elements.
+//
+// Five of the six agree closely on master, all sitting near 0/200 - which is
+// what 18.5.10 uniformity requires, since the guarded arm is 1 of 4097
+// solutions. The scalar spelling is the outlier at 97-108/200:
+//
+//   SameSpaceArrIdx    1-4      SameSpaceQueue     1-4
+//   SameSpaceForeach   0-4      SameSpaceDyn       0-4
+//   SameSpaceImpl      0-6      SameSpaceScalars  97-108   <-- disagrees
+//
+// So `foreach` is not the trigger and neither is the choice of `if` versus
+// `->`; rewriting four array elements as four scalars of the same width moves
+// the condition by a factor of thirty. Note which side is the anomaly: the
+// array rows match the LRM and the scalar row does not. A fix must bring them
+// into agreement, and 18.5.10 says it must do so by moving the SCALAR row down,
+// not the array rows up. t_constraint_rand_cond_ok pins the array rows in place
+// so that cannot silently happen the wrong way round.
+//
+// MultiBit is the same claim in a form that needs no cross-class comparison. A
+// 2-bit condition with only mode 1 guarded leaves modes 0, 2 and 3 describing
+// three arms of identical measure, so they must be equiprobable. Over 600
+// solves master gives roughly 0:113  1:1  2:207  3:280 where the three
+// unguarded modes should each be ~200. Mode 1 near zero is correct. The 2.5x
+// spread among its three equal-measure siblings is not, and an absolute band
+// would not catch it: 113 and 280 both sit inside a +/-5 sigma band around 200.
+// That is the case for asserting relationally throughout this file.
+//
+// Nested versus conjoined guards are also compared. They agree on master; the
+// row is kept so a fix cannot break the equivalence while repairing the rest.
+
+// verilog_format: off
+`define stop $stop
+`define checkd(gotv,expv) do if ((gotv) !== (expv)) begin $write("%%Error: %s:%0d:  got=%0d exp=%0d\n", `__FILE__,`__LINE__, (gotv), (expv)); `stop; end while(0);
+`define check_rel(label,ga,gb,tol) do begin $write("  %-46s %3d vs %3d  diff %3d (max %0d)  %s\n", label, (ga), (gb), ((ga)>(gb)?(ga)-(gb):(gb)-(ga)), (tol), ((((ga)>(gb)?(ga)-(gb):(gb)-(ga))) > (tol) ? "OUT-OF-BAND" : "ok")); if ((((ga)>(gb)?(ga)-(gb):(gb)-(ga))) > (tol)) bad++; end while(0);
+// verilog_format: on
+
+// Four pinned array elements, explicit index
+class SameSpaceArrIdx;
+  rand bit [2:0] a[4];
+  rand bit sel;
+  constraint c {
+    if (sel) {
+      a[0] == 3'd0;
+      a[1] == 3'd0;
+      a[2] == 3'd0;
+      a[3] == 3'd0;
+    }
+  }
+endclass
+
+// Same set, foreach spelling
+class SameSpaceForeach;
+  rand bit [2:0] a[4];
+  rand bit sel;
+  constraint c {
+    if (sel) {
+      foreach (a[i]) a[i] == 3'd0;
+    }
+  }
+endclass
+
+// Same set, implication instead of if
+class SameSpaceImpl;
+  rand bit [2:0] a[4];
+  rand bit sel;
+  constraint c {
+    sel -> {
+      foreach (a[i]) a[i] == 3'd0;
+    }
+  }
+endclass
+
+// Same set, queue
+class SameSpaceQueue;
+  rand bit [2:0] q[$];
+  rand bit sel;
+  constraint c {
+    q.size() == 4;
+    if (sel) {foreach (q[i]) q[i] == 3'd0;}
+  }
+endclass
+
+// Same set, dynamic array
+class SameSpaceDyn;
+  rand bit [2:0] d[];
+  rand bit sel;
+  constraint c {
+    d.size() == 4;
+    if (sel) {foreach (d[i]) d[i] == 3'd0;}
+  }
+endclass
+
+// Same set, four standalone scalars instead of four array elements
+class SameSpaceScalars;
+  rand bit [2:0] s0, s1, s2, s3;
+  rand bit sel;
+  constraint c {
+    if (sel) {
+      s0 == 3'd0;
+      s1 == 3'd0;
+      s2 == 3'd0;
+      s3 == 3'd0;
+    }
+  }
+endclass
+
+// Nested guards
+class NestedGuard;
+  rand bit [2:0] a[4];
+  rand bit s1, s2;
+  constraint c {
+    if (s1)
+    if (s2) {
+      foreach (a[i]) a[i] == 3'd0;
+    }
+  }
+endclass
+
+// Conjoined guard: extensionally identical to NestedGuard
+class ConjoinedGuard;
+  rand bit [2:0] a[4];
+  rand bit s1, s2;
+  constraint c {
+    if (s1 && s2) {
+      foreach (a[i]) a[i] == 3'd0;
+    }
+  }
+endclass
+
+// Multi-bit condition: modes 0, 2 and 3 are three arms of identical measure
+class MultiBit;
+  rand bit [2:0] a[8];
+  rand bit [1:0] mode;
+  constraint c {
+    if (mode == 2'd1) {
+      foreach (a[i]) a[i] == 3'd0;
+    }
+  }
+endclass
+
+module t;
+  localparam int TRIALS = 200;
+  // Two independent rows of a fair coin differ with sigma = sqrt(2)*7.07 = 10,
+  // so 50 is 5 sigma. Rows that genuinely describe the same space cannot drift
+  // past it, and the array-versus-scalar disagreement is about 100.
+  localparam int REL_TOL = 50;
+
+  // MultiBit needs more solves: the three equal-measure arms differ with
+  // sigma = sqrt(600*2/3) = 20 at 600 trials. The assertion is on the SPREAD
+  // across all three, max minus min, which is the natural statement and avoids
+  // three separate pairwise checks sitting near their band edges. A tolerance
+  // of 100 is 5 sigma; master's spread is about 185. At 200 trials the same
+  // effect is only ~2.9 sigma, too close to the edge to assert safely.
+  localparam int MTRIALS = 600;
+  localparam int MODE_TOL = 100;
+
+  SameSpaceArrIdx idx;
+  SameSpaceForeach fe;
+  SameSpaceImpl impl;
+  SameSpaceQueue que;
+  SameSpaceDyn dyn;
+  SameSpaceScalars scl;
+  NestedGuard nest;
+  ConjoinedGuard conj;
+  MultiBit mb;
+
+  int n_idx, n_fe, n_impl, n_que, n_dyn, n_scl;
+  int n_nest, n_conj;
+  int mode_hist[4];
+  int mode_lo;
+  int mode_hi;
+  int ok;
+  int i;
+  int bad;
+  int viol;
+
+  initial begin
+    bad = 0;
+    idx = new;
+    fe = new;
+    impl = new;
+    que = new;
+    dyn = new;
+    scl = new;
+    nest = new;
+    conj = new;
+    mb = new;
+
+    n_idx = 0;
+    viol = 0;
+    for (i = 0; i < TRIALS; i++) begin
+      ok = idx.randomize();
+      `checkd(ok, 1)
+      if (idx.sel) begin
+        n_idx++;
+        foreach (idx.a[j]) if (idx.a[j] != 3'd0) viol++;
+      end
+    end
+    `checkd(viol, 0)
+
+    n_fe = 0;
+    for (i = 0; i < TRIALS; i++) begin
+      ok = fe.randomize();
+      `checkd(ok, 1)
+      if (fe.sel) n_fe++;
+    end
+
+    n_impl = 0;
+    for (i = 0; i < TRIALS; i++) begin
+      ok = impl.randomize();
+      `checkd(ok, 1)
+      if (impl.sel) n_impl++;
+    end
+
+    n_que = 0;
+    for (i = 0; i < TRIALS; i++) begin
+      ok = que.randomize();
+      `checkd(ok, 1)
+      if (que.sel) n_que++;
+    end
+
+    n_dyn = 0;
+    for (i = 0; i < TRIALS; i++) begin
+      ok = dyn.randomize();
+      `checkd(ok, 1)
+      if (dyn.sel) n_dyn++;
+    end
+
+    n_scl = 0;
+    viol = 0;
+    for (i = 0; i < TRIALS; i++) begin
+      ok = scl.randomize();
+      `checkd(ok, 1)
+      if (scl.sel) begin
+        n_scl++;
+        if (scl.s0 != 0 || scl.s1 != 0 || scl.s2 != 0 || scl.s3 != 0) viol++;
+      end
+    end
+    `checkd(viol, 0)
+
+    $write("one solution space, six spellings, %0d solves each:\n", TRIALS);
+    $write("  ArrIdx %0d  Foreach %0d  Impl %0d  Queue %0d  Dyn %0d  Scalars %0d\n", n_idx, n_fe,
+           n_impl, n_que, n_dyn, n_scl);
+    `check_rel("ArrIdx vs Foreach  (foreach is not the trigger)", n_idx, n_fe, REL_TOL)
+    `check_rel("ArrIdx vs Impl  (if vs ->)", n_idx, n_impl, REL_TOL)
+    `check_rel("ArrIdx vs Queue", n_idx, n_que, REL_TOL)
+    `check_rel("ArrIdx vs Dyn", n_idx, n_dyn, REL_TOL)
+    `check_rel("ArrIdx vs Scalars  (array elems vs scalars)", n_idx, n_scl, REL_TOL)
+
+    // Nested vs conjoined guards
+    n_nest = 0;
+    for (i = 0; i < TRIALS; i++) begin
+      ok = nest.randomize();
+      `checkd(ok, 1)
+      if (nest.s1 && nest.s2) n_nest++;
+    end
+    n_conj = 0;
+    for (i = 0; i < TRIALS; i++) begin
+      ok = conj.randomize();
+      `checkd(ok, 1)
+      if (conj.s1 && conj.s2) n_conj++;
+    end
+    `check_rel("Nested vs Conjoined  (if(a) if(b) vs if(a&&b))", n_nest, n_conj, REL_TOL)
+
+    // Multi-bit condition: modes 0, 2, 3 are equal-measure arms
+    for (i = 0; i < 4; i++) mode_hist[i] = 0;
+    for (i = 0; i < MTRIALS; i++) begin
+      ok = mb.randomize();
+      `checkd(ok, 1)
+      mode_hist[mb.mode]++;
+    end
+    $write("multi-bit condition over %0d solves: 0:%0d 1:%0d 2:%0d 3:%0d\n", MTRIALS,
+           mode_hist[0], mode_hist[1], mode_hist[2], mode_hist[3]);
+    $write("  (mode 1 is the guarded arm and is correctly rare; 0, 2 and 3 have\n");
+    $write("   identical measure and must be equiprobable)\n");
+    mode_lo = mode_hist[0];
+    mode_hi = mode_hist[0];
+    if (mode_hist[2] < mode_lo) mode_lo = mode_hist[2];
+    if (mode_hist[3] < mode_lo) mode_lo = mode_hist[3];
+    if (mode_hist[2] > mode_hi) mode_hi = mode_hist[2];
+    if (mode_hist[3] > mode_hi) mode_hi = mode_hist[3];
+    `check_rel("MultiBit spread over equal-measure modes", mode_hi, mode_lo, MODE_TOL)
+
+    if (bad != 0) begin
+      $write("%%Error: %s:%0d: %0d relational check(s) failed\n", `__FILE__, `__LINE__, bad);
+      $write("%%Error: A constraint denotes a set of legal value combinations. Two\n");
+      $write("%%Error: constraints denoting the SAME set must randomize the same way,\n");
+      $write("%%Error: whichever syntax spells them, and arms of equal measure must be\n");
+      $write("%%Error: equiprobable.\n");
+      `stop;
+    end
+
+    $write("*-* All Finished *-*\n");
+    $finish;
+  end
+endmodule

--- a/test_regress/t/t_constraint_rand_cond_ok.py
+++ b/test_regress/t/t_constraint_rand_cond_ok.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+if not test.have_solver:
+    test.skip("No constraint solver installed")
+
+test.compile()
+
+# This one PASSES on master. It pins the behaviour in this area that is already
+# correct, in particular that a guarded arm holding one solution of 2**24 stays
+# rare, so that a fix for the companion tests cannot "fix" them by making every
+# rand condition a 50/50 coin - which IEEE 1800-2023 18.5.10 rules out.
+test.execute(all_run_flags=["+verilator+seed+1"])
+
+test.passes()

--- a/test_regress/t/t_constraint_rand_cond_ok.v
+++ b/test_regress/t/t_constraint_rand_cond_ok.v
@@ -1,0 +1,319 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain.
+// SPDX-FileCopyrightText: 2026 BRDR LIFE
+// SPDX-License-Identifier: CC0-1.0
+
+// Behaviour in this area that is already CORRECT on master, pinned so it stays
+// that way. This file passes today. Its companions - t_constraint_array_uniform,
+// t_constraint_solve_before_lrm, t_constraint_rand_cond_skew and
+// t_constraint_rand_cond_equiv - document what is broken.
+//
+// Two groups.
+//
+// GROUP 1: LRM-DIRECTION ROWS. IEEE 1800-2023 18.5.10 requires a uniform value
+// distribution over legal value COMBINATIONS, not per-variable fairness. When a
+// guarded arm holds one solution out of 2**24, the condition must be true
+// almost never - the LRM's own worked example turns on exactly this point, and
+// makes `solve ... before ...` the opt-in for anything else.
+//
+// These rows therefore assert that a rare arm STAYS rare. They are the guard
+// against a well-meaning fix that makes every `rand` condition a 50/50 coin:
+// that would look like fairness, would satisfy the skew tests, and would be
+// wrong - it is the behaviour 18.5.10 explicitly describes as not happening,
+// and no commercial simulator provides it.
+//
+// ScalarPin is the calibration row. One 3-bit variable pinned under the guard
+// gives 9 solutions, one of which has the condition true, so 18.5.10 predicts
+// 1/9 = 22/200. Master gives 17-30/200.
+//
+// GROUP 2: HARD SEMANTICS. Distribution heuristics must never override the
+// language's guarantees. These are deterministic or near-deterministic and hold
+// on master:
+//
+//   Randc      a `randc bit` condition cycles, so exactly 100 of 200 solves,
+//              with no statistical width at all
+//   Soft       a satisfiable `soft sel == 1` holds in all 200 solves even
+//              though the guarded body is a hard pin over an array
+//   Dist       `sel dist {0:=1, 1:=1}` asks for per-variable shaping explicitly
+//              and gets it: 93-113/200, where the same class without the dist
+//              sits at 1-4/200
+//   ConstraintMode  constraint_mode(0) really disables the constraint - the
+//              guarded pin stops being enforced
+//   StateCond  a non-rand state variable as the condition still enforces the
+//              guarded body when it is set
+//
+// The Dist row is worth keeping in view during any fix: it shows the solver can
+// already deliver a shaped per-variable distribution when the user asks for one,
+// which is the LRM-sanctioned way to get what the skew tests are asking for by
+// accident.
+
+// verilog_format: off
+`define stop $stop
+`define checkd(gotv,expv) do if ((gotv) !== (expv)) begin $write("%%Error: %s:%0d:  got=%0d exp=%0d\n", `__FILE__,`__LINE__, (gotv), (expv)); `stop; end while(0);
+`define check_band(label,gotv,lov,hiv) do begin $write("  %-40s %3d/%0d  exp [%0d:%0d]  %s\n", label, (gotv), TRIALS, (lov), (hiv), (((gotv) < (lov) || (gotv) > (hiv)) ? "OUT-OF-BAND" : "ok")); if ((gotv) < (lov) || (gotv) > (hiv)) bad++; end while(0);
+// verilog_format: on
+
+// Guarded arm is 1 solution of 2**24 + 1
+class ArrPin;
+  rand bit [2:0] a[8];
+  rand bit sel;
+  constraint c {
+    if (sel) {
+      foreach (a[i]) a[i] == 3'd0;
+    }
+  }
+endclass
+
+// Both arms constrained, so neither is the trivial one
+class ElseArm;
+  rand bit [2:0] a[8];
+  rand bit sel;
+  constraint c {
+    if (sel) {
+      foreach (a[i]) a[i] == 3'd0;
+    } else {
+      foreach (a[i]) a[i] <= 3'd7;
+    }
+  }
+endclass
+
+// Two-dimensional array, same 24 bits
+class Arr2D;
+  rand bit [2:0] m[4][2];
+  rand bit sel;
+  constraint c {
+    if (sel) {
+      foreach (m[i]) foreach (m[i][j]) m[i][j] == 3'd0;
+    }
+  }
+endclass
+
+// Calibration: 9 solutions, 18.5.10 predicts 1/9
+class ScalarPin;
+  rand bit [2:0] a;
+  rand bit sel;
+  constraint c {
+    if (sel) {
+      a == 3'd0;
+    }
+  }
+endclass
+
+// randc condition must cycle regardless of any distribution heuristic
+class RandcCond;
+  rand bit [2:0] a[8];
+  randc bit sel;
+  constraint c {
+    if (sel) {
+      foreach (a[i]) a[i] == 3'd0;
+    }
+  }
+endclass
+
+// A satisfiable soft constraint must hold every time
+class SoftCond;
+  rand bit [2:0] a[8];
+  rand bit sel;
+  constraint c {
+    if (sel) {
+      foreach (a[i]) a[i] == 3'd0;
+    }
+    soft sel == 1;
+  }
+endclass
+
+// dist asks for per-variable shaping explicitly
+class DistCond;
+  rand bit [2:0] a[8];
+  rand bit sel;
+  constraint c {
+    if (sel) {
+      foreach (a[i]) a[i] == 3'd0;
+    }
+    sel dist {
+      0 := 1,
+      1 := 1
+    };
+  }
+endclass
+
+// constraint_mode(0) must actually disable the constraint
+class CmodeCond;
+  rand bit [2:0] a[8];
+  rand bit sel;
+  constraint c {
+    if (sel) {
+      foreach (a[i]) a[i] == 3'd0;
+    }
+  }
+endclass
+
+// Non-rand state variable as the condition
+class StateCond;
+  rand bit [2:0] a[8];
+  bit cfg;
+  constraint c {
+    if (cfg) {
+      foreach (a[i]) a[i] == 3'd0;
+    }
+  }
+endclass
+
+module t;
+  localparam int TRIALS = 200;
+  // A rare arm must stay rare. A true rate of 2% clears 20/200 at about
+  // 5 sigma, so this bound is not tight against master's 0-6.
+  localparam int RARE_HI = 20;
+  // ScalarPin: 18.5.10 predicts 22.2/200, sigma 4.44. [5,45] is +/-5 sigma.
+  localparam int SCL_LO = 5;
+  localparam int SCL_HI = 45;
+  // Explicitly shaped by dist, so fair: [60,140] is +/-5.7 sigma.
+  localparam int FAIR_LO = 60;
+  localparam int FAIR_HI = 140;
+
+  ArrPin arr_pin;
+  ElseArm else_arm;
+  Arr2D arr_2d;
+  ScalarPin scalar_pin;
+  RandcCond randc_cond;
+  SoftCond soft_cond;
+  DistCond dist_cond;
+  CmodeCond cmode_cond;
+  StateCond state_cond;
+
+  int n;
+  int ok;
+  int i;
+  int bad;
+  int viol;
+
+  initial begin
+    bad = 0;
+    $write("rows that are already correct, %0d solves each:\n", TRIALS);
+
+    // ---- Group 1: LRM direction
+    arr_pin = new;
+    n = 0;
+    viol = 0;
+    for (i = 0; i < TRIALS; i++) begin
+      ok = arr_pin.randomize();
+      `checkd(ok, 1)
+      if (arr_pin.sel) begin
+        n++;
+        foreach (arr_pin.a[j]) if (arr_pin.a[j] != 3'd0) viol++;
+      end
+    end
+    `checkd(viol, 0)
+    `check_band("ArrPin  (1 of 2**24+1 solutions)", n, 0, RARE_HI)
+
+    else_arm = new;
+    n = 0;
+    for (i = 0; i < TRIALS; i++) begin
+      ok = else_arm.randomize();
+      `checkd(ok, 1)
+      if (else_arm.sel) n++;
+    end
+    `check_band("ElseArm  (both arms constrained)", n, 0, RARE_HI)
+
+    arr_2d = new;
+    n = 0;
+    for (i = 0; i < TRIALS; i++) begin
+      ok = arr_2d.randomize();
+      `checkd(ok, 1)
+      if (arr_2d.sel) n++;
+    end
+    `check_band("Arr2D  (2-D array, same 24 bits)", n, 0, RARE_HI)
+
+    scalar_pin = new;
+    n = 0;
+    viol = 0;
+    for (i = 0; i < TRIALS; i++) begin
+      ok = scalar_pin.randomize();
+      `checkd(ok, 1)
+      if (scalar_pin.sel) begin
+        n++;
+        if (scalar_pin.a != 3'd0) viol++;
+      end
+    end
+    `checkd(viol, 0)
+    `check_band("ScalarPin  (18.5.10 predicts 1/9 = 22)", n, SCL_LO, SCL_HI)
+
+    // ---- Group 2: hard semantics
+    randc_cond = new;
+    n = 0;
+    for (i = 0; i < TRIALS; i++) begin
+      ok = randc_cond.randomize();
+      `checkd(ok, 1)
+      if (randc_cond.sel) n++;
+    end
+    // randc over a 1-bit variable cycles: exactly half, no statistical width
+    `check_band("RandcCond  (randc cycles, exact)", n, TRIALS / 2, TRIALS / 2)
+
+    soft_cond = new;
+    n = 0;
+    for (i = 0; i < TRIALS; i++) begin
+      ok = soft_cond.randomize();
+      `checkd(ok, 1)
+      if (soft_cond.sel) n++;
+    end
+    // The soft is satisfiable in every solve, so it must hold in every solve
+    `check_band("SoftCond  (satisfiable soft, exact)", n, TRIALS, TRIALS)
+
+    dist_cond = new;
+    n = 0;
+    for (i = 0; i < TRIALS; i++) begin
+      ok = dist_cond.randomize();
+      `checkd(ok, 1)
+      if (dist_cond.sel) n++;
+    end
+    `check_band("DistCond  (sel dist {0:=1,1:=1})", n, FAIR_LO, FAIR_HI)
+
+    // constraint_mode(0) must really disable the constraint: with it off the
+    // guarded pin has to stop being enforced.
+    cmode_cond = new;
+    cmode_cond.c.constraint_mode(0);
+    n = 0;
+    viol = 0;
+    for (i = 0; i < TRIALS; i++) begin
+      ok = cmode_cond.randomize();
+      `checkd(ok, 1)
+      if (cmode_cond.sel) begin
+        n++;
+        foreach (cmode_cond.a[j]) if (cmode_cond.a[j] != 3'd0) viol++;
+      end
+    end
+    $write("  %-40s sel==1 %3d/%0d, pin violated %0d times\n", "CmodeCond  (constraint_mode(0))",
+           n, TRIALS, viol);
+    if (n > 0 && viol == 0) begin
+      $write("%%Error: %s:%0d: constraint_mode(0) did not disable the constraint\n", `__FILE__,
+             `__LINE__);
+      bad++;
+    end
+
+    // Non-rand state variable as the condition: the body must be enforced
+    state_cond = new;
+    state_cond.cfg = 1'b1;
+    viol = 0;
+    for (i = 0; i < TRIALS; i++) begin
+      ok = state_cond.randomize();
+      `checkd(ok, 1)
+      foreach (state_cond.a[j]) if (state_cond.a[j] != 3'd0) viol++;
+    end
+    `checkd(viol, 0)
+    $write("  %-40s guarded body enforced\n", "StateCond  (non-rand condition)");
+
+    if (bad != 0) begin
+      $write("%%Error: %s:%0d: %0d row(s) regressed\n", `__FILE__, `__LINE__, bad);
+      $write("%%Error: These rows are correct on master. A rare arm must stay rare:\n");
+      $write("%%Error: IEEE 1800-2023 18.5.10 requires uniformity over legal value\n");
+      $write("%%Error: COMBINATIONS, not per-variable fairness, and makes solve..before\n");
+      $write("%%Error: the opt-in for anything else. Hard semantics - randc, soft, dist,\n");
+      $write("%%Error: constraint_mode - must outrank any distribution heuristic.\n");
+      `stop;
+    end
+
+    $write("*-* All Finished *-*\n");
+    $finish;
+  end
+endmodule

--- a/test_regress/t/t_constraint_rand_cond_skew.py
+++ b/test_regress/t/t_constraint_rand_cond_skew.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+if not test.have_solver:
+    test.skip("No constraint solver installed")
+
+test.compile()
+
+# THIS TEST FAILS ON MASTER, BY DESIGN. A rand condition is badly skewed once a
+# rand array enters the same randomize(), even when the guarded body excludes
+# nothing and even when the array is disjoint from the condition.
+# See the header of t_constraint_rand_cond_skew.v.
+test.execute(all_run_flags=["+verilator+seed+1"])
+
+test.passes()

--- a/test_regress/t/t_constraint_rand_cond_skew.v
+++ b/test_regress/t/t_constraint_rand_cond_skew.v
@@ -1,0 +1,282 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain.
+// SPDX-FileCopyrightText: 2026 BRDR LIFE
+// SPDX-License-Identifier: CC0-1.0
+
+// A `rand` variable used as a constraint condition is driven to a badly skewed
+// value once a rand ARRAY is present in the same randomize(). This is the
+// guard-visible symptom of the value-distribution defect documented in
+// t_constraint_array_uniform; that file is the root cause and the better place
+// to start.
+//
+// Three independent shapes, all failing on master over 8 seeds x 200 solves.
+//
+// 1. VACUOUS GUARD BODY. `a` is bit [2:0], so `a[i] <= 3'd7` is true for every
+//    value it can hold. Both arms of the `if` mean exactly the same thing and
+//    `sel` is a free coin flip under any model whatsoever. Master: 159-182/200.
+//    The literal, runtime-bound and `inside` spellings all behave alike, which
+//    rules out constant folding as the explanation.
+//
+// 2. CONTAMINATION BY AN UNRELATED ARRAY. VacBase pins four scalars under the
+//    guard and contains no array at all; it is fair at 85-108/200. Adding
+//    `foreach (pad[i]) pad[i] <= 3'd7` - a constraint that excludes nothing and
+//    never mentions `sel` - drops the same guard to 21-33/200. The constraint
+//    system factorizes into independent components, so sel's marginal cannot
+//    legally depend on a vacuous constraint over a disjoint variable.
+//
+//    CtlUnusedArr is the discriminating control: it has the same array member
+//    but leaves it UNCONSTRAINED, so the array never enters the solver, and the
+//    guard stays fair. What matters is not that the class declares an array,
+//    but that an array is pulled into the solver problem - which switches the
+//    whole object onto solveDiversityXor (verilated_random.cpp:633-646).
+//
+// 3. OVER-SELECTION OF A RESTRICTIVE ARM. `a[i] inside {[0:4]}` admits 5**8 of
+//    8**8 combinations, so 18.5.10 uniformity puts the guard true about 2.3% of
+//    the time, i.e. ~5/200. Master gives 146-167/200. Note this runs OPPOSITE
+//    to the pinned-guard rows in t_constraint_rand_cond_ok, which sit near 0
+//    exactly as the LRM requires. The skew has no consistent direction, so a
+//    fix may not simply push conditions one way.
+//
+// CtlScalarVacuous is the positive control throughout: the same vacuous guard
+// over a scalar takes the bit-pinning path and is fair at 89-110/200. It must
+// stay fair after any fix.
+
+// verilog_format: off
+`define stop $stop
+`define checkd(gotv,expv) do if ((gotv) !== (expv)) begin $write("%%Error: %s:%0d:  got=%0d exp=%0d\n", `__FILE__,`__LINE__, (gotv), (expv)); `stop; end while(0);
+`define check_band(label,gotv,lov,hiv) do begin $write("  %-40s sel==1 %3d/%0d  exp [%0d:%0d]  %s\n", label, (gotv), TRIALS, (lov), (hiv), (((gotv) < (lov) || (gotv) > (hiv)) ? "OUT-OF-BAND" : "ok")); if ((gotv) < (lov) || (gotv) > (hiv)) bad++; end while(0);
+`define check_rel(label,ga,gb,tol) do begin $write("  %-40s %3d vs %3d  diff %3d (max %0d)  %s\n", label, (ga), (gb), ((ga)>(gb)?(ga)-(gb):(gb)-(ga)), (tol), ((((ga)>(gb)?(ga)-(gb):(gb)-(ga))) > (tol) ? "OUT-OF-BAND" : "ok")); if ((((ga)>(gb)?(ga)-(gb):(gb)-(ga))) > (tol)) bad++; end while(0);
+// verilog_format: on
+
+// 1. Vacuous guarded body, literal bound
+class VacLiteral;
+  rand bit [2:0] a[8];
+  rand bit sel;
+  constraint c {
+    if (sel) {
+      foreach (a[i]) a[i] <= 3'd7;
+    }
+  }
+endclass
+
+// 1. Vacuous guarded body, runtime bound so it cannot be folded away
+class VacRuntime;
+  rand bit [2:0] a[8];
+  rand bit sel;
+  bit [2:0] lim;
+  constraint c {
+    if (sel) {
+      foreach (a[i]) a[i] <= lim;
+    }
+  }
+endclass
+
+// 1. Vacuous guarded body, `inside` covering the whole type range
+class VacInside;
+  rand bit [2:0] a[8];
+  rand bit sel;
+  constraint c {
+    if (sel) {
+      foreach (a[i]) a[i] inside {[3'd0 : 3'd7]};
+    }
+  }
+endclass
+
+// 2. Baseline: four pinned scalars under the guard, no array anywhere
+class VacBase;
+  rand bit [2:0] s0, s1, s2, s3;
+  rand bit sel;
+  constraint c {
+    if (sel) {
+      s0 == 3'd0;
+      s1 == 3'd0;
+      s2 == 3'd0;
+      s3 == 3'd0;
+    }
+  }
+endclass
+
+// 2. Identical, plus a vacuous constraint on an array disjoint from the guard
+class VacBasePlusArr;
+  rand bit [2:0] s0, s1, s2, s3;
+  rand bit sel;
+  rand bit [2:0] pad[4];
+  constraint c {
+    if (sel) {
+      s0 == 3'd0;
+      s1 == 3'd0;
+      s2 == 3'd0;
+      s3 == 3'd0;
+    }
+    foreach (pad[i]) pad[i] <= 3'd7;
+  }
+endclass
+
+// 2. Control: same array member, but UNCONSTRAINED so it never enters the
+// solver. Fair, and must stay fair.
+class CtlUnusedArr;
+  rand bit [2:0] s0, s1, s2, s3;
+  rand bit sel;
+  rand bit [2:0] pad[4];
+  constraint c {
+    if (sel) {
+      s0 == 3'd0;
+      s1 == 3'd0;
+      s2 == 3'd0;
+      s3 == 3'd0;
+    }
+  }
+endclass
+
+// 3. Restrictive arm, admitting 5**8 of 8**8 combinations
+class RestrictedArm;
+  rand bit [2:0] a[8];
+  rand bit sel;
+  constraint c {
+    if (sel) {
+      foreach (a[i]) a[i] inside {[3'd0 : 3'd4]};
+    }
+  }
+endclass
+
+// Control: vacuous guard over a scalar. Bit-pinning path. Fair.
+class CtlScalarVacuous;
+  rand bit [2:0] a;
+  rand bit sel;
+  constraint c {
+    if (sel) {
+      a <= 3'd7;
+    }
+  }
+endclass
+
+module t;
+  // Binomial(200, 0.5): mean 100, sigma 7.07, so [60,140] is +/-5.7 sigma.
+  localparam int TRIALS = 200;
+  localparam int FAIR_LO = 60;
+  localparam int FAIR_HI = 140;
+  // Two independent fair rows differ with sigma = sqrt(2)*7.07 = 10, so a
+  // tolerance of 40 on the difference is 4 sigma - wide enough that two rows
+  // which really are fair cannot trip it, and master's 67 clears it by 27.
+  localparam int REL_TOL = 40;
+  // 18.5.10 puts RestrictedArm near 5/200; 40 is a deliberately generous
+  // one-sided bound that master still misses by a factor of four.
+  localparam int RESTRICT_HI = 40;
+
+  VacLiteral vac_lit;
+  VacRuntime vac_rt;
+  VacInside vac_ins;
+  VacBase vac_base;
+  VacBasePlusArr vac_arr;
+  CtlUnusedArr ctl_unused;
+  RestrictedArm restricted;
+  CtlScalarVacuous ctl_scl;
+
+  int n_base;
+  int n_arr;
+  int n_unused;
+  int n;
+  int ok;
+  int i;
+  int bad;
+
+  initial begin
+    bad = 0;
+    $write("condition-true rate per shape, %0d solves each:\n", TRIALS);
+
+    // ---- 1. vacuous guarded body over an array
+    vac_lit = new;
+    n = 0;
+    for (i = 0; i < TRIALS; i++) begin
+      ok = vac_lit.randomize();
+      `checkd(ok, 1)
+      if (vac_lit.sel) n++;
+    end
+    `check_band("VacLiteral  (a[i] <= 3'd7)", n, FAIR_LO, FAIR_HI)
+
+    vac_rt = new;
+    vac_rt.lim = 3'd7;
+    n = 0;
+    for (i = 0; i < TRIALS; i++) begin
+      ok = vac_rt.randomize();
+      `checkd(ok, 1)
+      if (vac_rt.sel) n++;
+    end
+    `check_band("VacRuntime  (a[i] <= lim, lim==7)", n, FAIR_LO, FAIR_HI)
+
+    vac_ins = new;
+    n = 0;
+    for (i = 0; i < TRIALS; i++) begin
+      ok = vac_ins.randomize();
+      `checkd(ok, 1)
+      if (vac_ins.sel) n++;
+    end
+    `check_band("VacInside  (a[i] inside [0:7])", n, FAIR_LO, FAIR_HI)
+
+    // ---- 2. contamination by an unrelated, vacuously constrained array
+    vac_base = new;
+    n_base = 0;
+    for (i = 0; i < TRIALS; i++) begin
+      ok = vac_base.randomize();
+      `checkd(ok, 1)
+      if (vac_base.sel) n_base++;
+    end
+    `check_band("VacBase  (4 pinned scalars, no array)", n_base, FAIR_LO, FAIR_HI)
+
+    vac_arr = new;
+    n_arr = 0;
+    for (i = 0; i < TRIALS; i++) begin
+      ok = vac_arr.randomize();
+      `checkd(ok, 1)
+      if (vac_arr.sel) n_arr++;
+    end
+    $write("  %-40s sel==1 %3d/%0d\n", "VacBasePlusArr  (+ vacuous array)", n_arr, TRIALS);
+
+    ctl_unused = new;
+    n_unused = 0;
+    for (i = 0; i < TRIALS; i++) begin
+      ok = ctl_unused.randomize();
+      `checkd(ok, 1)
+      if (ctl_unused.sel) n_unused++;
+    end
+    $write("  %-40s sel==1 %3d/%0d\n", "CtlUnusedArr  (array unconstrained)", n_unused, TRIALS);
+
+    // Adding a vacuous constraint over a disjoint array must not move the guard
+    `check_rel("VacBase vs VacBasePlusArr", n_base, n_arr, REL_TOL)
+    // Control: the same array left unconstrained must not move it either
+    `check_rel("VacBase vs CtlUnusedArr", n_base, n_unused, REL_TOL)
+
+    // ---- 3. restrictive arm over-selected
+    restricted = new;
+    n = 0;
+    for (i = 0; i < TRIALS; i++) begin
+      ok = restricted.randomize();
+      `checkd(ok, 1)
+      if (restricted.sel) n++;
+    end
+    `check_band("RestrictedArm  (a[i] inside [0:4])", n, 0, RESTRICT_HI)
+
+    // ---- control
+    ctl_scl = new;
+    n = 0;
+    for (i = 0; i < TRIALS; i++) begin
+      ok = ctl_scl.randomize();
+      `checkd(ok, 1)
+      if (ctl_scl.sel) n++;
+    end
+    `check_band("CtlScalarVacuous  (control, scalar)", n, FAIR_LO, FAIR_HI)
+
+    if (bad != 0) begin
+      $write("%%Error: %s:%0d: %0d row(s) outside band\n", `__FILE__, `__LINE__, bad);
+      $write("%%Error: A guarded body that excludes no value leaves both arms of the\n");
+      $write("%%Error: `if` semantically identical, so the condition must be a fair\n");
+      $write("%%Error: coin; and a vacuous constraint over a variable disjoint from\n");
+      $write("%%Error: the condition cannot legally change the condition's marginal.\n");
+      `stop;
+    end
+
+    $write("*-* All Finished *-*\n");
+    $finish;
+  end
+endmodule

--- a/test_regress/t/t_constraint_solve_before_lrm.py
+++ b/test_regress/t/t_constraint_solve_before_lrm.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+if not test.have_solver:
+    test.skip("No constraint solver installed")
+
+test.compile()
+
+# THIS TEST FAILS ON MASTER, BY DESIGN. `solve ... before ...` inverts IEEE
+# 1800-2023 18.5.10 on the worked example the standard uses to define the
+# construct. See the header of t_constraint_solve_before_lrm.v.
+test.execute(all_run_flags=["+verilator+seed+1"])
+
+test.passes()

--- a/test_regress/t/t_constraint_solve_before_lrm.v
+++ b/test_regress/t/t_constraint_solve_before_lrm.v
@@ -1,0 +1,207 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain.
+// SPDX-FileCopyrightText: 2026 BRDR LIFE
+// SPDX-License-Identifier: CC0-1.0
+
+// `solve ... before ...` does the OPPOSITE of what IEEE 1800-2023 18.5.10
+// specifies, on the worked example the standard itself uses to define the
+// construct.
+//
+// The LRM's example, reproduced verbatim in class LrmPlain below:
+//
+//   class B;
+//     rand bit s;
+//     rand bit [31:0] d;
+//     constraint c { s -> d == 0; }
+//   endclass
+//
+// There are 2**32 + 1 solutions: 2**32 with s == 0 and any d, and exactly one
+// with s == 1 and d == 0. Under 18.5.10's uniformity requirement s must
+// therefore be 0 with probability 2**32/(2**32 + 1), i.e. s == 1 essentially
+// never. The LRM presents this skew as the CORRECT result, and presents
+// `solve s before d` as the user's opt-in to make s a fair coin:
+// "the same 2**32+1 solutions can be produced, but with different probability".
+//
+// Both halves come out backwards on master, over 8 seeds x 200 solves:
+//
+//                                  LRM     master
+//   LrmPlain    (no ordering)      ~0      90-112     far too HIGH
+//   LrmSolved   (solve s before d) ~100    0          far too LOW
+//
+// The construct is not merely weak here, it is inverted: without it the rare
+// arm is taken half the time, and adding it removes the rare arm completely.
+// `randomize()` returns 1 on every one of those solves, so this is not a
+// silent solver failure - the values really are being chosen this way.
+//
+// SolveCondFirst is the same claim on the array shape that motivated this
+// suite: `solve sel before a` is specified to make sel's distribution
+// independent of the constraint it guards, so sel should be ~100/200. Master
+// gives 41-57/200. It is printed but NOT asserted - master lands just under any
+// band wide enough to survive an RNG-stream reshuffle, and the LrmPlain /
+// LrmSolved pair already makes the point decisively.
+//
+// Mechanism, for whoever fixes this: in the phased path the per-phase diversity
+// constraint (verilated_random.cpp solvePhaseValues) calls randomConstraint,
+// which XORs bits drawn from ALL of m_vars - including the variables in later
+// solve layers - into the check that decides the current layer's values. The
+// ordering machinery re-couples the condition to the very variables it was
+// asked to be solved before.
+//
+// SolveArrFirst is deliberately asserted loosely. `solve a before sel` picks
+// the 24-bit array first, after which all-elements-zero is essentially
+// impossible, so sel should be ~0. Master gives 12-26/200, which is also too
+// high, but the LRM text supports projection-uniformity for the first-solved
+// variable less quotably than it supports the two rows above, so this row is
+// held to a one-sided sanity bound rather than made the point of the test.
+
+// verilog_format: off
+`define stop $stop
+`define checkd(gotv,expv) do if ((gotv) !== (expv)) begin $write("%%Error: %s:%0d:  got=%0d exp=%0d\n", `__FILE__,`__LINE__, (gotv), (expv)); `stop; end while(0);
+`define check_band(label,gotv,lov,hiv) do begin $write("  %-38s cond true %3d/%0d  exp [%0d:%0d]  %s\n", label, (gotv), TRIALS, (lov), (hiv), (((gotv) < (lov) || (gotv) > (hiv)) ? "OUT-OF-BAND" : "ok")); if ((gotv) < (lov) || (gotv) > (hiv)) bad++; end while(0);
+// verilog_format: on
+
+// IEEE 1800-2023 18.5.10, verbatim. s == 1 should be vanishingly rare.
+class LrmPlain;
+  rand bit s;
+  rand bit [31:0] d;
+  constraint c {s -> d == 0;}
+endclass
+
+// The same, with the ordering the LRM says makes s a fair coin.
+class LrmSolved;
+  rand bit s;
+  rand bit [31:0] d;
+  constraint c {s -> d == 0;}
+  constraint o {solve s before d;}
+endclass
+
+// Same claim, array shape: ordering must decouple sel from what it guards.
+class SolveCondFirst;
+  rand bit [2:0] a[8];
+  rand bit sel;
+  constraint c {
+    if (sel) {
+      foreach (a[i]) a[i] == 3'd0;
+    }
+  }
+  constraint o {solve sel before a;}
+endclass
+
+// Opposite ordering: array first, so the condition should almost never hold.
+class SolveArrFirst;
+  rand bit [2:0] a[8];
+  rand bit sel;
+  constraint c {
+    if (sel) {
+      foreach (a[i]) a[i] == 3'd0;
+    }
+  }
+  constraint o {solve a before sel;}
+endclass
+
+module t;
+  // Binomial(200, 0.5): mean 100, sigma 7.07, so [60,140] is +/-5.7 sigma.
+  // A one-sided <=20 bound corresponds to a true rate of 2% at about 5 sigma.
+  localparam int TRIALS = 200;
+  localparam int FAIR_LO = 60;
+  localparam int FAIR_HI = 140;
+  localparam int RARE_HI = 20;
+  // SolveArrFirst: loose one-sided sanity bound, see header.
+  localparam int LOOSE_HI = 40;
+
+  LrmPlain lrm_plain;
+  LrmSolved lrm_solved;
+  SolveCondFirst cond_first;
+  SolveArrFirst arr_first;
+
+  int n;
+  int ok;
+  int i;
+  int bad;
+  int viol;
+
+  initial begin
+    bad = 0;
+    $write("IEEE 1800-2023 18.5.10 solve..before, %0d solves per row:\n", TRIALS);
+
+    // No ordering: 2**32+1 solutions, only one of which has s == 1.
+    lrm_plain = new;
+    n = 0;
+    viol = 0;
+    for (i = 0; i < TRIALS; i++) begin
+      ok = lrm_plain.randomize();
+      `checkd(ok, 1)
+      if (lrm_plain.s) begin
+        n++;
+        if (lrm_plain.d != 32'd0) viol++;
+      end
+    end
+    // The implication itself must hold whenever s was chosen true.
+    `checkd(viol, 0)
+    `check_band("LrmPlain  (s -> d==0, no ordering)", n, 0, RARE_HI)
+
+    // With `solve s before d` the LRM says s becomes a fair coin.
+    lrm_solved = new;
+    n = 0;
+    viol = 0;
+    for (i = 0; i < TRIALS; i++) begin
+      ok = lrm_solved.randomize();
+      `checkd(ok, 1)
+      if (lrm_solved.s) begin
+        n++;
+        if (lrm_solved.d != 32'd0) viol++;
+      end
+    end
+    `checkd(viol, 0)
+    `check_band("LrmSolved  (solve s before d)", n, FAIR_LO, FAIR_HI)
+
+    // Array shape: ordering must decouple the condition from what it guards.
+    cond_first = new;
+    n = 0;
+    viol = 0;
+    for (i = 0; i < TRIALS; i++) begin
+      ok = cond_first.randomize();
+      `checkd(ok, 1)
+      if (cond_first.sel) begin
+        n++;
+        foreach (cond_first.a[j]) if (cond_first.a[j] != 3'd0) viol++;
+      end
+    end
+    `checkd(viol, 0)
+    // Informational, not asserted. `solve sel before a` should decouple sel and
+    // put this at ~100/200; master gives 41-57. The claim is sound but master
+    // lands just under any band wide enough to be safe against an RNG-stream
+    // reshuffle, so asserting it would buy a flaky test for a point the
+    // LrmPlain/LrmSolved pair above already makes decisively.
+    $write("  %-38s cond true %3d/%0d  (should be ~%0d, informational)\n",
+           "SolveCondFirst  (solve sel before a)", n, TRIALS, TRIALS / 2);
+
+    // Opposite ordering: loose one-sided bound only, see header.
+    arr_first = new;
+    n = 0;
+    viol = 0;
+    for (i = 0; i < TRIALS; i++) begin
+      ok = arr_first.randomize();
+      `checkd(ok, 1)
+      if (arr_first.sel) begin
+        n++;
+        foreach (arr_first.a[j]) if (arr_first.a[j] != 3'd0) viol++;
+      end
+    end
+    `checkd(viol, 0)
+    `check_band("SolveArrFirst  (solve a before sel)", n, 0, LOOSE_HI)
+
+    if (bad != 0) begin
+      $write("%%Error: %s:%0d: %0d row(s) outside band\n", `__FILE__, `__LINE__, bad);
+      $write("%%Error: IEEE 1800-2023 18.5.10 defines solve..before on exactly the\n");
+      $write("%%Error: LrmPlain/LrmSolved pair: without ordering the one-solution arm\n");
+      $write("%%Error: is essentially never taken, and `solve s before d` makes the\n");
+      $write("%%Error: condition a fair coin. Master inverts both halves.\n");
+      `stop;
+    end
+
+    $write("*-* All Finished *-*\n");
+    $finish;
+  end
+endmodule


### PR DESCRIPTION
**Draft: these tests fail on master by design.** They are offered as a precise, reproducible statement of an unfixed defect in the runtime constraint solver, not as a change that is ready to merge. Four of the five tests are red; the fifth passes and is there to constrain what a fix may do. I'm happy to rework the framing, the bands, or the file split — and if the maintainers would rather this be an issue than a PR, say so and I'll move it.

## The requirement being tested

IEEE 1800-2023 18.5.10 requires the solver to "assure that the random values are selected to give a uniform value distribution over legal value combinations". That is uniformity over the *solution space*, not per-variable fairness — the same clause's worked example depends on the distinction. Everything below is measured against that reading.

## 1. Array values are not uniform

`rand bit [2:0] a[8]` under `foreach (a[i]) a[i] <= 3'd7`. The array is 3 bits wide, so the constraint excludes no value the type can hold. Over 800 solves x 8 elements = 6400 samples, uniform is 800 per value:

| value | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 |
|---|---|---|---|---|---|---|---|---|
| count | 2133 | 1591 | 187 | 129 | 1647 | 529 | 143 | 41 |

A 52x spread between most and least likely, stable to within a few percent across seeds. Two controls localise it:

- the **same array with no constraint** never enters the solver and is uniform (752-838 per bucket);
- the **same vacuous constraint on a scalar** takes the bit-pinning path and is uniform (85-112 of 800).

The failing rows take `solveDiversityXor`, which `verilated_random.cpp` selects per-*object* whenever any solver variable has `dimension() > 0` (`verilated_random.cpp:633-646`). Note the selector is per-object, so one array member moves every other variable in the same `randomize()` onto that path.

It is not confined to vacuous constraints. Under `a[i] < 3'd6` the excluded values 6 and 7 are correctly absent — the hard constraint is honoured — but the six legal values spread 143..2094 where each should be about 1067.

## 2. `solve ... before ...` is inverted

On the example 18.5.10 itself uses to define the construct:

```systemverilog
rand bit s;  rand bit [31:0] d;
constraint c { s -> d == 0; }
```

There are 2\*\*32+1 solutions, so `s == 1` should be vanishingly rare, and `solve s before d` is documented to make `s` a fair coin. Master, over 200 solves:

| | LRM | master |
|---|---|---|
| no ordering | ~0 | 94/200 |
| `solve s before d` | ~100 | **0/200** |

Both halves come out backwards. `randomize()` returns 1 on every one of those solves, so this is not a silent solver failure.

## 3. A rand condition is skewed by what it guards

- A guarded body that excludes nothing (`if (sel) foreach (a[i]) a[i] <= 3'd7`) leaves both arms semantically identical, yet `sel` is 159-182/200. Literal, runtime-bound and `inside` spellings behave alike, so this is not constant folding.
- Adding a vacuous constraint on an array **disjoint from the condition** moves the condition from 100/200 to 33/200. The constraint system factorizes, so the condition's marginal cannot legally depend on it. Leaving the same array unconstrained keeps it fair, which is the discriminating control.
- Constraints denoting one solution set randomize differently by spelling: four pinned array elements give 1/200 where four pinned scalars of the same width give 101/200. `foreach` is not the trigger and neither is `if` versus `->`.

## What passes, and why it is here

`t_constraint_rand_cond_ok` is green on master. It asserts that an arm holding one solution of 2\*\*24 **stays rare**, which is what 18.5.10 requires and what the standard's own example turns on. Its purpose is to stop a fix from satisfying the other four tests by making every rand condition a 50/50 coin — that would look like fairness and would be wrong. It also pins `randc` (cycles exactly), `soft` (satisfiable softs always hold), `dist` (explicit per-variable shaping works), and `constraint_mode(0)`, all of which are correct today.

## Test design notes

- Assertions are **relational** wherever the invariant is relational. This matters: master's multi-bit mode spread of 185 *passes* a +/-5 sigma absolute band around the mean but fails a spread check, so absolute banding would hide the very effect the row exists to catch.
- Seeds are fixed so bands are deterministic run to run, and bands are sized to survive an RNG-stream reshuffle rather than sitting tight against today's numbers. Two rows whose margins were too thin to assert safely are printed as informational instead, with the reason in the source.
- Every row also functionally checks that the guarded constraint holds whenever it was selected, so a distribution fix cannot trade correctness for uniformity.

## Open question for maintainers

Whether Verilator wants to keep the per-variable diversity heuristic added for #7563. It is what makes the scalar path behave differently from the array path, and it is not what 18.5.10 describes. My reading is that the array rows match the standard and the scalar rows are the deviation, so the paths should be unified by moving the scalar behaviour toward the LRM rather than the reverse — but that is a call for the maintainers, and the tests are written so it can go either way without rewriting them.

---

*Disclosure: these tests, the measurements behind them and this description were produced with AI assistance (Claude). All numbers quoted are from actual runs on this branch against z3, across 8 seeds.*