### PR TITLE
Fix gate deduplication with function arguments

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -7,6 +7,7 @@ contribution terms including the AI policy in ``docs/CONTRIBUTING.rst``.
 
 Please see the Verilator manual for 200+ additional contributors. Thanks to all.
 
+24bit-xjkp
 404allen404
 Adam Bagley
 Adam Kostrzewski
@@ -31,13 +32,14 @@ Andrii Andrieiev
 anonkey
 Anthony Donlon
 Anthony Moore
+apocelipes
 Arkadiusz Kozdra
 Arthur Rosa
 Artur Bieniek
 AUDIY
 Aylon Chaim Porat
-Bartłomiej Chmiel
 Bartosz Skorowski
+Bartłomiej Chmiel
 Benjamin Collier
 BRDR LIFE
 Brian Li
@@ -63,24 +65,28 @@ David Ledger
 David Metz
 David Stanford
 David Turner
+dependabot[bot]
 Dercury
 Diego Roux
 Dominick Grochowina
-Dragon-Git
 Don Williamson
+Dragon-Git
 Drew Ranck
 Drew Taussig
 Driss Hafdi
 Edgar E. Iglesias
+em2machine
+emmettifelts
 Eric Mejdrich
 Eric Müller
 Eric Rippey
 Eryk Szpotański
-Eunseo Song
 Ethan Sifferman
+Eunseo Song
 Eyck Jentzsch
 Fabian Keßler-Schulz
 Fan Shupei
+february cozzocrea
 Felix Neumärker
 Felix Yan
 Frans Skarman
@@ -154,11 +160,11 @@ Jonathan Schröter
 Jordan McConnon
 Jose Drowne
 Jose Loyola
-Jose Tejada (JOTEGO)
 Josep Sans
 Joseph Nwabueze
 Josh Redford
 Joshua Leahy
+JOTEGO (Jose Tejada)
 Julian Carrier
 Julian Daube
 Julie Schwartz
@@ -220,6 +226,7 @@ Mladen Slijepcevic
 Morten Borup Petersen
 Mostafa Gamal
 Moubarak Jeje
+Muzaffer Kal
 Nandu Raj
 Natan Kreimer
 Nathan Graybeal
@@ -275,13 +282,16 @@ Sergey Chusov
 Sergey Fedorov
 Sergi Granell
 Seth Pellegrino
+Shashvat Prabhu
 Shogo Yamazaki
 Shou-Li Hsu
+spomatasmd
 Srinivasan Venkataramanan
 Stefan Wallentowitz
 Stephen Henry
 Steven Hugg
 Stuart Morris
+sumpster
 Szymon Gizler
 Sören Tempel
 Teng Huang
@@ -321,9 +331,11 @@ Wolfgang Mayerwieser
 Xi Zhang
 Yan Xu
 Yangyu Chen
+Yilin Li
 Yilou Wang
 Yinan Xu
 Yoda Lee
+Yogish Sekhar
 Yossi Nivin
 Yu-Sheng Lin
 Yuri Victorovich
@@ -334,18 +346,6 @@ Zhen Yan
 Zhou Shen
 Zhouyi Shen
 Zixi Li
-apocelipes
-dependabot[bot]
-february cozzocrea
-sumpster
-em2machine
-emmettifelts
+Zubin Jain
 Àlex Torregrosa
 Ícaro Lima
-Yogish Sekhar
-24bit-xjkp
-Zubin Jain
-Muzaffer Kal
-Yilin Li
-Shashvat Prabhu
-spomatasmd

--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -154,6 +154,7 @@ Jonathan Schröter
 Jordan McConnon
 Jose Drowne
 Jose Loyola
+Jose Tejada (JOTEGO)
 Josep Sans
 Joseph Nwabueze
 Josh Redford

--- a/src/V3Gate.cpp
+++ b/src/V3Gate.cpp
@@ -985,9 +985,9 @@ public:
         if (m_dedupable && m_assignp) {
             const AstNode* const lhsp = m_assignp->lhsp();
             // Possible todo, handle more complex lhs expressions
-            if (const AstNodeVarRef* const lRefp = VN_CAST(lhsp, NodeVarRef)) {
-                UASSERT_OBJ(lRefp->varScopep() == consumerVscp, consumerVscp,
-                            "Consumer doesn't match lhs of assign");
+            // A logic vertex may also contain a function argument assignment.
+            if (const AstNodeVarRef* const lRefp = VN_CAST(lhsp, NodeVarRef);
+                lRefp && lRefp->varScopep() == consumerVscp) {
                 if (const AstNodeAssign* const dup
                     = m_ghash.hashAndFindDupe(m_assignp, activep, m_ifCondp)) {
                     return static_cast<AstNodeVarRef*>(dup->lhsp());

--- a/src/V3Gate.cpp
+++ b/src/V3Gate.cpp
@@ -986,8 +986,8 @@ public:
             const AstNode* const lhsp = m_assignp->lhsp();
             // Possible todo, handle more complex lhs expressions
             // A logic vertex may also contain a function argument assignment.
-            if (const AstNodeVarRef* const lRefp = VN_CAST(lhsp, NodeVarRef);
-                lRefp && lRefp->varScopep() == consumerVscp) {
+            const AstNodeVarRef* const lRefp = VN_CAST(lhsp, NodeVarRef);
+            if (lRefp && lRefp->varScopep() == consumerVscp) {
                 if (const AstNodeAssign* const dup
                     = m_ghash.hashAndFindDupe(m_assignp, activep, m_ifCondp)) {
                     return static_cast<AstNodeVarRef*>(dup->lhsp());

--- a/test_regress/t/t_gate_dedupe_func.py
+++ b/test_regress/t/t_gate_dedupe_func.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Gate deduplication with function captures
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2026 Jose Tejada
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile(verilator_flags2=[
+    '--top-module', 'game_test', '-Wno-fatal', '-Wno-IMPLICIT',
+    '-Wno-WIDTHEXPAND', '-Wno-WIDTHTRUNC',
+])
+
+test.passes()

--- a/test_regress/t/t_gate_dedupe_func.py
+++ b/test_regress/t/t_gate_dedupe_func.py
@@ -4,7 +4,7 @@
 # This program is free software; you can redistribute it and/or modify it
 # under the terms of either the GNU Lesser General Public License Version 3
 # or the Perl Artistic License Version 2.0.
-# SPDX-FileCopyrightText: 2026 Jose Tejada
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
 # SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
 
 import vltest_bootstrap

--- a/test_regress/t/t_gate_dedupe_func.py
+++ b/test_regress/t/t_gate_dedupe_func.py
@@ -12,7 +12,7 @@ import vltest_bootstrap
 test.scenarios('simulator')
 
 test.compile(verilator_flags2=[
-    '--top-module', 'game_test', '-Wno-fatal', '-Wno-IMPLICIT',
+    '--top-module', 'jtcop_game', '-Wno-fatal', '-Wno-IMPLICIT',
     '-Wno-WIDTHEXPAND', '-Wno-WIDTHTRUNC',
 ])
 

--- a/test_regress/t/t_gate_dedupe_func.v
+++ b/test_regress/t/t_gate_dedupe_func.v
@@ -5,9 +5,11 @@
 // SPDX-License-Identifier: CC0-1.0
 
 module game_test(output [7:0] st_dout);
-  jtcop_game_sdram u_game(
-    .snd_vu(),
-    .snd_peak(),
+  jtcop_game u_game(
+    .clk(clk),
+    .ba2mcu_addr(ba2mcu_addr),
+    .main_addr(main_addr),
+    .st_addr(st_addr),
     .st_dout(st_dout)
   );
 endmodule
@@ -65,24 +67,9 @@ module jtcop_game(
     output [13:1] ba2mcu_addr,
     output [18:1] main_addr
 );
-  wire [7:0] st_snd;
-  reg [7:0] st_mux;
-  assign st_dout = st_mux;
+  assign st_dout = std_video;
+  assign main_addr = '0;
 
-  always @(posedge clk) begin
-    case (st_addr[7:6])
-      0: st_mux <= st_main;
-      1: st_mux <= st_snd;
-      2: st_mux <= snd_latch;
-      3: st_mux <= std_video;
-    endcase
-  end
-
-  jtcop_main u_main(
-    .snd_latch(snd_latch),
-    .cpu_addr(main_addr),
-    .st_dout(st_main)
-  );
   jtcop_video u_video(
     .game_id(game_id),
     .cpu_addr(main_addr[12:1]),
@@ -92,34 +79,6 @@ module jtcop_game(
     .st_dout(std_video)
   );
   jtcop_sdram u_sdram(.game_id(game_id));
-endmodule
-
-module jtcop_main(
-    output [18:1] cpu_addr,
-    output reg [7:0] snd_latch,
-    output reg [7:0] st_dout
-);
-  assign cpu_dout = 0,
-         cpu_addr = 0,
-         UDSWn = 1,
-         LDSWn = 1,
-         RnW = 0,
-         sec = 0,
-         pal_cs = 0,
-         fmode_cs = 0,
-         fsft_cs = 0,
-         fmap_cs = 0,
-         bmode_cs = 0,
-         bsft_cs = 0,
-         bmap_cs = 0,
-         cmode_cs = 0,
-         csft_cs = 0,
-         cmap_cs = 0,
-         huc_cs = 0,
-         obj_cs = 0,
-         obj_copy = 0,
-         ram_cs = 0,
-         rom_cs = 0;
 endmodule
 
 module jtcop_sdram(output reg [1:0] game_id = 0);
@@ -154,19 +113,5 @@ module jtcop_video(
     .cpu_dsn(ba2_dsn),
     .st_addr(st_addr),
     .st_dout(st_dout2)
-  );
-endmodule
-
-module jtcop_game_sdram(
-    output [7:0] st_dout,
-    output [5:0] snd_vu,
-    output snd_peak
-);
-  jtcop_game u_game(
-    .clk(clk),
-    .ba2mcu_addr(ba2mcu_addr),
-    .main_addr(main_addr),
-    .st_addr(st_addr),
-    .st_dout(st_dout)
   );
 endmodule

--- a/test_regress/t/t_gate_dedupe_func.v
+++ b/test_regress/t/t_gate_dedupe_func.v
@@ -46,11 +46,10 @@ module jtcop_bac06(
   end
 endmodule
 
-module jtcop_game(input clk, input [7:0] st_addr, output [7:0] st_dout);
+module jtcop_game(input clk, output [7:0] st_dout);
   wire [12:1] cpu_addr;
   jtcop_main u_main(.cpu_addr(cpu_addr));
-  jtcop_video u_video(.cpu_addr(cpu_addr), .prisel(prisel), .st_addr(st_addr),
-                      .st_dout(st_dout));
+  jtcop_video u_video(.cpu_addr(cpu_addr), .st_dout(st_dout));
 endmodule
 
 module jtcop_main(output [12:1] cpu_addr);
@@ -59,22 +58,9 @@ endmodule
 
 module jtcop_video(
     input [12:1] cpu_addr,
-    input [7:0] prisel,
-    input [7:0] st_addr,
     output reg [7:0] st_dout
 );
-  wire [7:0] st_dout0, st_dout1, st_dout2;
-
-  always @(posedge clk) begin
-    case (st_addr[5:4])
-      0: st_dout <= st_dout0;
-      1: st_dout <= st_dout1;
-      2: st_dout <= st_dout2;
-      3: st_dout <= prisel;
-    endcase
-  end
-
   jtcop_bac06 u_ba2(.rst(rst), .clk(clk), .cpu_dout(ba2_din),
                     .cpu_addr(cpu_addr), .cpu_dsn(ba2_dsn), .st_addr(st_addr),
-                    .st_dout(st_dout2));
+                    .st_dout(st_dout));
 endmodule

--- a/test_regress/t/t_gate_dedupe_func.v
+++ b/test_regress/t/t_gate_dedupe_func.v
@@ -1,0 +1,172 @@
+// DESCRIPTION: Verilator: Gate deduplication through function argument
+//
+// This file ONLY is placed under the Creative Commons Public Domain.
+// SPDX-FileCopyrightText: 2026 Jose Tejada
+// SPDX-License-Identifier: CC0-1.0
+
+module game_test(output [7:0] st_dout);
+  jtcop_game_sdram u_game(
+    .snd_vu(),
+    .snd_peak(),
+    .st_dout(st_dout)
+  );
+endmodule
+
+module jtcop_bac06(
+    input rst,
+    input clk,
+    input [15:0] cpu_dout,
+    input [12:1] cpu_addr,
+    input [1:0] cpu_dsn,
+    input [7:0] st_addr,
+    output reg [7:0] st_dout
+);
+  reg [7:0] mode[0:3];
+  reg [15:0] hscr;
+  reg [15:0] vscr;
+  reg [3:0] colscr_sh, rowscr_sh;
+  reg [7:0] def_cfg[0:15];
+
+  always @(posedge clk) begin
+    case (st_addr[3:0])
+      0, 1, 2, 3: st_dout <= mode[st_addr[1:0]];
+      4: st_dout <= hscr[7:0];
+      5: st_dout <= hscr[15:8];
+      6: st_dout <= vscr[7:0];
+      7: st_dout <= vscr[15:8];
+      8: st_dout <= {colscr_sh, rowscr_sh};
+      default: st_dout <= '0;
+    endcase
+  end
+
+  function [15:0] combine(input [15:0] din);
+    combine = {cpu_dsn[1] ? din[15:8] : cpu_dout[15:8],
+               cpu_dsn[0] ? din[7:0] : cpu_dout[7:0]};
+  endfunction
+
+  always @(posedge clk) begin
+    if (rst) begin
+      vscr <= {def_cfg[7], def_cfg[6]};
+    end else begin
+      case (cpu_addr[2:1])
+        0: hscr <= combine(hscr);
+        1: vscr <= combine(vscr);
+        2: colscr_sh <= cpu_dout[3:0];
+        3: rowscr_sh <= cpu_dout[3:0];
+      endcase
+    end
+  end
+endmodule
+
+module jtcop_game(
+    input clk,
+    input [7:0] st_addr,
+    output [7:0] st_dout,
+    output [13:1] ba2mcu_addr,
+    output [18:1] main_addr
+);
+  wire [7:0] st_snd;
+  reg [7:0] st_mux;
+  assign st_dout = st_mux;
+
+  always @(posedge clk) begin
+    case (st_addr[7:6])
+      0: st_mux <= st_main;
+      1: st_mux <= st_snd;
+      2: st_mux <= snd_latch;
+      3: st_mux <= std_video;
+    endcase
+  end
+
+  jtcop_main u_main(
+    .snd_latch(snd_latch),
+    .cpu_addr(main_addr),
+    .st_dout(st_main)
+  );
+  jtcop_video u_video(
+    .game_id(game_id),
+    .cpu_addr(main_addr[12:1]),
+    .mcu_addr(ba2mcu_addr[10:1]),
+    .prisel(prisel),
+    .st_addr(sta_video),
+    .st_dout(std_video)
+  );
+  jtcop_sdram u_sdram(.game_id(game_id));
+endmodule
+
+module jtcop_main(
+    output [18:1] cpu_addr,
+    output reg [7:0] snd_latch,
+    output reg [7:0] st_dout
+);
+  assign cpu_dout = 0,
+         cpu_addr = 0,
+         UDSWn = 1,
+         LDSWn = 1,
+         RnW = 0,
+         sec = 0,
+         pal_cs = 0,
+         fmode_cs = 0,
+         fsft_cs = 0,
+         fmap_cs = 0,
+         bmode_cs = 0,
+         bsft_cs = 0,
+         bmap_cs = 0,
+         cmode_cs = 0,
+         csft_cs = 0,
+         cmap_cs = 0,
+         huc_cs = 0,
+         obj_cs = 0,
+         obj_copy = 0,
+         ram_cs = 0,
+         rom_cs = 0;
+endmodule
+
+module jtcop_sdram(output reg [1:0] game_id = 0);
+endmodule
+
+module jtcop_video(
+    input [1:0] game_id,
+    input [12:1] cpu_addr,
+    input [9:0] mcu_addr,
+    input [7:0] prisel,
+    input [7:0] st_addr,
+    output reg [7:0] st_dout
+);
+  localparam [1:0] HIPPODROME = 2'd1;
+  wire [7:0] st_dout0, st_dout1;
+
+  always @(posedge clk) begin
+    case (st_addr[5:4])
+      0: st_dout <= st_dout0;
+      1: st_dout <= st_dout1;
+      2: st_dout <= st_dout2;
+      3: st_dout <= prisel;
+    endcase
+  end
+
+  assign ba2_addr = game_id == HIPPODROME ? {2'd0, mcu_addr} : cpu_addr;
+  jtcop_bac06 u_ba2(
+    .rst(rst),
+    .clk(clk),
+    .cpu_dout(ba2_din),
+    .cpu_addr(ba2_addr),
+    .cpu_dsn(ba2_dsn),
+    .st_addr(st_addr),
+    .st_dout(st_dout2)
+  );
+endmodule
+
+module jtcop_game_sdram(
+    output [7:0] st_dout,
+    output [5:0] snd_vu,
+    output snd_peak
+);
+  jtcop_game u_game(
+    .clk(clk),
+    .ba2mcu_addr(ba2mcu_addr),
+    .main_addr(main_addr),
+    .st_addr(st_addr),
+    .st_dout(st_dout)
+  );
+endmodule

--- a/test_regress/t/t_gate_dedupe_func.v
+++ b/test_regress/t/t_gate_dedupe_func.v
@@ -49,18 +49,11 @@ endmodule
 module jtcop_game(input clk, output [7:0] st_dout);
   wire [12:1] cpu_addr;
   jtcop_main u_main(.cpu_addr(cpu_addr));
-  jtcop_video u_video(.cpu_addr(cpu_addr), .st_dout(st_dout));
+  jtcop_bac06 u_ba2(.rst(rst), .clk(clk), .cpu_dout(ba2_din),
+                    .cpu_addr(cpu_addr), .cpu_dsn(ba2_dsn), .st_addr(st_addr),
+                    .st_dout(st_dout));
 endmodule
 
 module jtcop_main(output [12:1] cpu_addr);
   assign cpu_addr = '0;
-endmodule
-
-module jtcop_video(
-    input [12:1] cpu_addr,
-    output reg [7:0] st_dout
-);
-  jtcop_bac06 u_ba2(.rst(rst), .clk(clk), .cpu_dout(ba2_din),
-                    .cpu_addr(cpu_addr), .cpu_dsn(ba2_dsn), .st_addr(st_addr),
-                    .st_dout(st_dout));
 endmodule

--- a/test_regress/t/t_gate_dedupe_func.v
+++ b/test_regress/t/t_gate_dedupe_func.v
@@ -5,13 +5,7 @@
 // SPDX-License-Identifier: CC0-1.0
 
 module game_test(output [7:0] st_dout);
-  jtcop_game u_game(
-    .clk(clk),
-    .ba2mcu_addr(ba2mcu_addr),
-    .main_addr(main_addr),
-    .st_addr(st_addr),
-    .st_dout(st_dout)
-  );
+  jtcop_game u_game(.clk(clk), .st_addr(st_addr), .st_dout(st_dout));
 endmodule
 
 module jtcop_bac06(
@@ -24,8 +18,7 @@ module jtcop_bac06(
     output reg [7:0] st_dout
 );
   reg [7:0] mode[0:3];
-  reg [15:0] hscr;
-  reg [15:0] vscr;
+  reg [15:0] hscr, vscr;
   reg [3:0] colscr_sh, rowscr_sh;
   reg [7:0] def_cfg[0:15];
 
@@ -47,53 +40,34 @@ module jtcop_bac06(
   endfunction
 
   always @(posedge clk) begin
-    if (rst) begin
-      vscr <= {def_cfg[7], def_cfg[6]};
-    end else begin
-      case (cpu_addr[2:1])
-        0: hscr <= combine(hscr);
-        1: vscr <= combine(vscr);
-        2: colscr_sh <= cpu_dout[3:0];
-        3: rowscr_sh <= cpu_dout[3:0];
-      endcase
-    end
+    if (rst) vscr <= {def_cfg[7], def_cfg[6]};
+    else case (cpu_addr[2:1])
+      0: hscr <= combine(hscr);
+      1: vscr <= combine(vscr);
+      2: colscr_sh <= cpu_dout[3:0];
+      3: rowscr_sh <= cpu_dout[3:0];
+    endcase
   end
 endmodule
 
-module jtcop_game(
-    input clk,
-    input [7:0] st_addr,
-    output [7:0] st_dout,
-    output [13:1] ba2mcu_addr,
-    output [18:1] main_addr
-);
-  assign st_dout = std_video;
-  assign main_addr = '0;
-
-  jtcop_video u_video(
-    .game_id(game_id),
-    .cpu_addr(main_addr[12:1]),
-    .mcu_addr(ba2mcu_addr[10:1]),
-    .prisel(prisel),
-    .st_addr(sta_video),
-    .st_dout(std_video)
-  );
-  jtcop_sdram u_sdram(.game_id(game_id));
+module jtcop_game(input clk, input [7:0] st_addr, output [7:0] st_dout);
+  wire [12:1] cpu_addr;
+  jtcop_main u_main(.cpu_addr(cpu_addr));
+  jtcop_video u_video(.cpu_addr(cpu_addr), .prisel(prisel), .st_addr(st_addr),
+                      .st_dout(st_dout));
 endmodule
 
-module jtcop_sdram(output reg [1:0] game_id = 0);
+module jtcop_main(output [12:1] cpu_addr);
+  assign cpu_addr = '0;
 endmodule
 
 module jtcop_video(
-    input [1:0] game_id,
     input [12:1] cpu_addr,
-    input [9:0] mcu_addr,
     input [7:0] prisel,
     input [7:0] st_addr,
     output reg [7:0] st_dout
 );
-  localparam [1:0] HIPPODROME = 2'd1;
-  wire [7:0] st_dout0, st_dout1;
+  wire [7:0] st_dout0, st_dout1, st_dout2;
 
   always @(posedge clk) begin
     case (st_addr[5:4])
@@ -104,14 +78,7 @@ module jtcop_video(
     endcase
   end
 
-  assign ba2_addr = game_id == HIPPODROME ? {2'd0, mcu_addr} : cpu_addr;
-  jtcop_bac06 u_ba2(
-    .rst(rst),
-    .clk(clk),
-    .cpu_dout(ba2_din),
-    .cpu_addr(ba2_addr),
-    .cpu_dsn(ba2_dsn),
-    .st_addr(st_addr),
-    .st_dout(st_dout2)
-  );
+  jtcop_bac06 u_ba2(.rst(rst), .clk(clk), .cpu_dout(ba2_din),
+                    .cpu_addr(cpu_addr), .cpu_dsn(ba2_dsn), .st_addr(st_addr),
+                    .st_dout(st_dout2));
 endmodule

--- a/test_regress/t/t_gate_dedupe_func.v
+++ b/test_regress/t/t_gate_dedupe_func.v
@@ -4,10 +4,6 @@
 // SPDX-FileCopyrightText: 2026 Jose Tejada
 // SPDX-License-Identifier: CC0-1.0
 
-module game_test(output [7:0] st_dout);
-  jtcop_game u_game(.clk(clk), .st_addr(st_addr), .st_dout(st_dout));
-endmodule
-
 module jtcop_bac06(
     input rst,
     input clk,


### PR DESCRIPTION
Gate deduplication may encounter an assignment to a function argument while processing a logic vertex. That argument is function-scoped, so its `VarScope` does not match the vertex consumer scope. The existing assertion incorrectly assumed that they always matched.

Skip deduplication for assignments whose left-hand variable scope differs from the consumer scope.

Add a regression based on a function that captures enclosing signals and is called from sequential logic.

- [x] `test_regress/t/t_gate_dedupe_func.py`
