### PR TITLE
Fix conditional expression with parameterized classes

### DIFF
--- a/src/V3Ast.cpp
+++ b/src/V3Ast.cpp
@@ -1735,12 +1735,15 @@ AstNodeDType* AstNode::getCommonClassTypep(AstNode* node1p, AstNode* node2p) {
         if (castable == VCastable::DYNAMIC_CLASS) return node2p->dtypep();
     }
 
-    AstClassRefDType* classDtypep1 = VN_CAST(node1p->dtypep(), ClassRefDType);
+    AstClassRefDType* classDtypep1 = VN_CAST(node1p->dtypep()->skipRefp(), ClassRefDType);
     while (classDtypep1) {
         const VCastable castable = computeCastable(classDtypep1, node2p->dtypep(), node2p);
         if (castable == VCastable::COMPATIBLE) return classDtypep1;
-        const AstClassExtends* const extendsp = classDtypep1->classp()->extendsp();
-        classDtypep1 = extendsp ? VN_AS(extendsp->dtypep(), ClassRefDType) : nullptr;
+        AstClassExtends* const extendsp = classDtypep1->classp()->extendsp();
+        if (!extendsp) break;
+        AstNodeDType* const edtp
+            = extendsp->dtypep() ? extendsp->dtypep() : extendsp->childDTypep();
+        classDtypep1 = VN_AS(edtp->skipRefp(), ClassRefDType);
     }
     return nullptr;
 }

--- a/test_regress/t/t_param_class_cond.py
+++ b/test_regress/t/t_param_class_cond.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile()
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_param_class_cond.v
+++ b/test_regress/t/t_param_class_cond.v
@@ -1,0 +1,49 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain.
+// SPDX-FileCopyrightText: 2026 Antmicro
+// SPDX-License-Identifier: CC0-1.0
+
+class Base;
+  int value;
+endclass
+
+typedef Base Base_t;
+
+class SubA #(type T = int) extends Base_t;
+endclass
+
+class SubB #(type T = int) extends Base_t;
+endclass
+
+typedef SubA #(int) SubAInt_t;
+typedef SubB #(int) SubBInt_t;
+
+class Container;
+  local SubAInt_t a;
+  local SubBInt_t b;
+  function new();
+    a = new;
+    a.value = 1;
+    b = new;
+    b.value = 2;
+  endfunction
+  function Base test(int sel);
+    test = sel[0] ? a : b;
+  endfunction
+endclass
+
+module t;
+  Container c;
+  int cyc;
+  Base result;
+  initial begin
+    c = new;
+    for (cyc = 0; cyc < 100; ++cyc) begin
+      result = c.test(cyc);
+      if (result.value != (cyc[0] ? 1 : 2)) $stop;
+    end
+    $write("*-* All Finished *-*\n");
+    $finish;
+  end
+endmodule


### PR DESCRIPTION
This code:

```verilog
class Base;
endclass

class SubA #(type T = int) extends Base;
endclass

class SubB #(type T = int) extends Base;
endclass

class Container;
  local SubA #(int) a;
  local SubB #(int) b;
  function void test();
    Base result = (1) ? a : b;
  endfunction
endclass

module t;
  Container c;
  initial begin
    c = new;
    c.test;
    $write("*-* All Finished *-*\n");
    $finish;
  end
endmodule
```

Results in error:
```
%Error: t/t_cond_expression_parametrized_classes.v:20:23: Incompatible types of operands of condition operator: CLASSREFDTYPE 'SubA_' and CLASSREFDTYPE 'SubB_'
                                                        : ... note: In instance 't'
   20 |     Base result = (1) ? a : b;
      |                       ^
        ... See the manual at https://verilator.org/verilator_doc.html?v=5.051 for more assistance.
%Error: Exiting due to 1 error(s)
```



It's because `getCommonClassTypep` finds a common base by walking the extends chain of the first operand, each step reading the next base type from `extendsp->dtypep()`. For parameterized classes this `dtypep` is null, the `AstClassExtends` node's dtype was never resolved for the class ref (only childDTypep is set), so `VN_AS(edtp, ClassRefDType)` yields nullptr and the walk terminates before reaching the common base. For non-parameterized the same loop walks the full chain.