### PR TITLE
Add Unigen2 constrained randomization algorithm (#8024)

### DIFF
--- a/docs/internals.rst
+++ b/docs/internals.rst
@@ -1082,9 +1082,17 @@ solver gets a setup query, then the definition of variables, then all the
 constraints (SMT assertions) about the variables. Since the solver has no
 information about the class' PRNG state, if the problem is satisfiable, the
 solution space is further constrained by adding extra random constraints,
-and querying the values satisfying the problem statement. The constraint is
-currently constructed as fixing a simple xor of randomly chosen bits of the
-variables being randomized.
+and querying the values satisfying the problem statement. The constraints
+are currently built by the UniGen2 algorithm ("On Parallel Scalable Uniform
+SAT Witness Generation", Chakraborty et al.). It first works out how many
+random xor equations are needed to split the solution space into cells of a
+size worth enumerating, then draws one cell and enumerates it, which gives
+a near-uniform sample of the whole space. Both the estimate and the
+leftover solutions are cached, so the following calls are answered without
+asking the solver again. Cases outside its assumptions, such as ``randc``
+variables or soft constraints, fall back to pinning every free bit to a
+random value, or, when arrays are involved, to asserting four random xor
+equations in a row.
 
 The runtime classes used for handling the randomization are defined in
 ``verilated_random.h`` and ``verilated_random.cpp``.

--- a/include/verilated_random.cpp
+++ b/include/verilated_random.cpp
@@ -578,6 +578,8 @@ void VlRandomVar::emitExtract(std::ostream& s, int i) const {
     s << " ((_ extract " << i << ' ' << i << ") " << m_name << ')';
 }
 void VlRandomVar::emitType(std::ostream& s) const { s << "(_ BitVec " << width() << ')'; }
+// A scalar var IS its only element, so "element j" is just the whole var.
+void VlRandomVar::emitElement(std::ostream& s, int /*j*/) const { s << ' ' << m_name; }
 // Serialize the current runtime value as an SMT-LIB binary literal. Used by
 // randomize(null) to pin a var via `(assert (= var #b...))`. Binary (#b)
 // rather than hex (#x) sidesteps SMT-LIB's hex-width-multiple-of-4 rule.
@@ -707,6 +709,15 @@ size_t VlRandomizer::hashConstraints(const std::vector<std::string>& extras) con
     for (const auto& c : extras) {
         h ^= std::hash<std::string>{}(c) + 0x9e3779b9 + (h << 6) + (h >> 2);
     }
+    for (const auto& var : m_vars) {
+        h ^= std::hash<std::string>{}(var.first) + 0x9e3779b9 + (h << 6) + (h >> 2);
+        h ^= std::hash<int>{}(var.second->width()) + 0x9e3779b9 + (h << 6) + (h >> 2);
+        h ^= std::hash<int>{}(var.second->dimension()) + 0x9e3779b9 + (h << 6) + (h >> 2);
+    }
+    // Keys are one per array element, so a resized queue gets a different hash.
+    for (const auto& elem : m_arr_vars) {
+        h ^= std::hash<std::string>{}(elem.first) + 0x9e3779b9 + (h << 6) + (h >> 2);
+    }
     return h;
 }
 
@@ -739,11 +750,35 @@ void VlRandomizer::recordRandcValues() {
     }
 }
 
-bool VlRandomizer::next_check_only(VlRNG& rngr) { return nextRandomize(rngr, true); }
+bool VlRandomizer::isFrozenVar(const std::string& name, const VlRandomVar& var) const {
+    if (!var.randModeIdxNone()) {
+        const VlQueue<CData>* const modep
+            = m_staticVars.count(name) ? m_static_randmodep : m_randmodep;
+        // modep is never null in practice, the fallthrough matches the return below
+        if (VL_UNCOVERABLE(!modep)) return m_disabledVars.count(name) != 0;
+        if (!modep->at(var.randModeIdx())) return true;
+    }
+    // Struct/nested members are disabled via m_disabledVars.
+    // They have no randModeIdx of their own.
+    return m_disabledVars.count(name) != 0;
+}
 
-bool VlRandomizer::next(VlRNG& rngr) { return nextRandomize(rngr, false); }
+bool VlRandomizer::hasFrozenVar() const {
+    bool mayBeFrozen = m_randmodep || m_static_randmodep;
+    // A disabled var means the class uses rand_mode, so it never shows up without one
+    if (VL_UNCOVERABLE(!mayBeFrozen && !m_disabledVars.empty())) mayBeFrozen = true;
+    if (!mayBeFrozen) return false;
+    for (const auto& var : m_vars) {
+        if (isFrozenVar(var.first, *var.second)) return true;
+    }
+    return false;
+}
 
-bool VlRandomizer::nextRandomize(VlRNG& rngr, bool checkOnly) {
+bool VlRandomizer::next_check_only(VlRNGReseeds& rngr) { return nextRandomize(rngr, true); }
+
+bool VlRandomizer::next(VlRNGReseeds& rngr) { return nextRandomize(rngr, false); }
+
+bool VlRandomizer::nextRandomize(VlRNGReseeds& rngr, bool checkOnly) {
     if (!checkOnly && m_vars.empty() && m_unique_arrays.empty()) return true;
     if (checkOnly && m_vars.empty()) return true;  // No rand members: trivially SAT
     VlSolverSession& sess = s_solverSession;
@@ -762,6 +797,9 @@ bool VlRandomizer::nextRandomize(VlRNG& rngr, bool checkOnly) {
         }
     }
 
+    // Reseeded from outside, so everything cached came from the old seed.
+    if (m_ug2.rngReseeds != rngr.reseeds()) m_ug2 = Unigen2State{};
+
     // Pinned vars make phase ordering moot; skip phased path in check-only.
     bool result;
     if (!m_checkOnly && !m_solveBefore.empty()) {
@@ -769,6 +807,7 @@ bool VlRandomizer::nextRandomize(VlRNG& rngr, bool checkOnly) {
     } else {
         result = nextFlat(rngr, sess, uniqueExprs);
     }
+    m_ug2.rngReseeds = rngr.reseeds();
     m_checkOnly = false;
     return result;
 }
@@ -841,6 +880,10 @@ void VlRandomizer::emitAsserts(std::ostream& os, const std::vector<std::string>&
 bool VlRandomizer::nextFlat(VlRNG& rngr, VlSolverSession& sess,
                             const std::vector<std::string>& uniqueExprs)
     VL_REQUIRES(sess.m_mutex) {
+    if (m_randcVarNames.empty() && !m_checkOnly && !hasFrozenVar()
+        && unigen2(rngr, sess, uniqueExprs)) {
+        return true;
+    }
     VlSolverTxn txn{sess};
     if (!txn.ok()) return false;
     std::iostream& os = sess.os();
@@ -889,6 +932,299 @@ bool VlRandomizer::nextFlat(VlRNG& rngr, VlSolverSession& sess,
         return true;
     }
     return false;  // Should not reach here
+}
+
+// Enumerate one cell of the solution space, and cache the solutions in m_ug2.loThreshWitnesses.
+// The next call with the same constraint set will drain the cache before running the full
+// mechanism again.
+bool VlRandomizer::unigen2(VlRNG& rngr, VlSolverSession& sess,
+                           const std::vector<std::string>& uniqueExprs) VL_REQUIRES(sess.m_mutex) {
+    if (!m_softConstraints.empty()) return false;
+
+    const size_t currentHash = hashConstraints(uniqueExprs);
+    // Params and batch are computed for specific constraint set, so drop them
+    // once it changes.
+    if (m_ug2.paramHash != currentHash) {
+        m_ug2.loThreshWitnesses.clear();
+        m_ug2.paramsValid = false;
+        m_ug2.isLargeSpace = false;
+        m_ug2.paramHash = currentHash;
+        // First sighting of this constraint set.
+        // Decline now and let the next call with the same set run UG2.
+        return false;
+    }
+
+    // Nothing cached from a previous UG2 run, so refill the batch first.
+    if (m_ug2.loThreshWitnesses.empty()) {
+        VlSolverTxn txn{sess};
+        if (!txn.ok()) return false;
+        std::iostream& solver = sess.os();
+
+        solver << "(set-option :produce-models true)\n";
+        solver << "(set-logic QF_ABV)\n";
+        emitDefines(solver);
+        emitDeclares(solver, false);
+        emitAsserts(solver, uniqueExprs, false);
+
+        if (!m_ug2.paramsValid) {
+            // Searches once per constraint set for how finely to cut the space, and
+            // caches parameters
+            if (!estimateParameters(sess, rngr)) return false;
+            m_ug2.paramsValid = true;
+            m_ug2.lastSuccessI = -1;  // new params, so the old hint no longer applies
+        }
+
+        // generateSamples() always finds a candidate in practice
+        if (VL_UNCOVERABLE(!generateSamples(sess, rngr))) return false;
+    }
+
+    // Cached or just refilled - there is a witness to write into the variables
+    Witness witness = std::move(m_ug2.loThreshWitnesses.back());
+    m_ug2.loThreshWitnesses.pop_back();
+    writeBackWitness(witness);
+    return true;
+}
+
+void VlRandomizer::writeBackWitness(const Witness& witness) {
+    for (const auto& varEntry : witness) {
+        const auto& varp = m_vars.at(varEntry.first);
+        for (const auto& elemEntry : varEntry.second) {
+            if (varp->dimension() > 0) {
+                // set() needs current array info, and a witness from the
+                // cached batch skips the solver, so nothing else sets it.
+                auto arrVarsp = std::make_shared<const ArrayInfoMap>(m_arr_vars);
+                varp->setArrayInfo(arrVarsp);
+                std::ostringstream idxStream;
+                idxStream << "#x" << std::hex << std::setw(8) << std::setfill('0')
+                          << elemEntry.first;
+                varp->set(idxStream.str(), elemEntry.second);
+            } else {
+                varp->set("", elemEntry.second);
+            }
+        }
+    }
+}
+
+// Ask for a solution, block it, ask again - so every answer is a new one.
+int VlRandomizer::bsat(VlSolverSession& sess, size_t bound, std::vector<Witness>& witnesses,
+                       VlRNG* diversifyRngp) VL_REQUIRES(sess.m_mutex) {
+    std::iostream& solver = sess.os();
+    witnesses.clear();
+    witnesses.reserve(bound);
+    // get-value responses preserve request order, so build the (var,
+    // element) order once and read results back positionally.
+    std::vector<std::pair<std::string, int>>& order = m_ug2.bsatOrder;
+    order.clear();
+    for (const auto& var : m_vars) {
+        const int elementCount = var.second->totalWidth() / var.second->width();
+        for (int j = 0; j < elementCount; ++j) order.emplace_back(var.first, j);
+    }
+
+    int assumeNum = 0;
+    while (witnesses.size() < bound) {
+        VlSolverStatus status = VlSolverStatus::FAIL;
+        if (diversifyRngp && !witnesses.empty()) {
+            // To increase the randomization, add an assumption for one var in one specific call
+            const Witness& prev = witnesses.back();
+            const std::pair<std::string, int>& pick
+                = order[VL_RANDOM_RNG_I(*diversifyRngp) % order.size()];
+            solver << "(declare-fun d" << assumeNum << " () Bool)\n";
+            solver << "(assert (= d" << assumeNum << " (not (=";
+            m_vars.at(pick.first)->emitElement(solver, pick.second);
+            solver << ' ' << prev.at(pick.first).at(pick.second) << "))))\n";
+            solver << "(check-sat-assuming (d" << assumeNum << "))\n";
+            ++assumeNum;
+            status = sess.readStatus();
+        }
+        if (status != VlSolverStatus::SAT) {
+            solver << "(check-sat)\n";
+            status = sess.readStatus();
+        }
+        if (status != VlSolverStatus::SAT) {
+            // "unsat" is the cell running out; anything else is the solver giving up
+            if (VL_UNLIKELY(status != VlSolverStatus::UNSAT)) return -1;
+            break;
+        }
+
+        solver << "(get-value (";
+        for (const auto& entry : order) m_vars.at(entry.first)->emitElement(solver, entry.second);
+        solver << "))\n";
+
+        // Read the whole balanced reply first, so a malformed one cannot desync the pipe
+        std::string reply;
+        if (VL_UNLIKELY(!sess.readSExpr(reply))) return -1;
+        std::istringstream is{reply};
+        char c = 0;
+        is >> c;  // readSExpr only returns a reply that opens with '('
+        Witness witness;
+        for (const auto& entry : order) {
+            if (VL_UNLIKELY(!(is >> c) || c != '(')) return -1;  // LCOV_EXCL_BR_LINE
+            std::string exprHead;
+            is >> exprHead;  // bare var name, or literally "(select" if an array element
+            const bool isSelect = exprHead == "(select";
+            if (isSelect) readUntilBalanced(is);
+            if (VL_UNLIKELY(!isSelect && exprHead != entry.first)) return -1;
+            std::string value;
+            std::getline(is, value, ')');
+            // The batch outlives this call, so reject a bad value before it is cached
+            if (VL_UNLIKELY(!validSMTNum(value))) return -1;
+            witness[entry.first][entry.second] = value;
+        }  // LCOV_EXCL_BR_LINE
+        if (VL_UNLIKELY(!(is >> c) || c != ')')) return -1;  // LCOV_EXCL_BR_LINE
+
+        // Forbid this exact assignment so the next
+        // (check-sat) is forced to find a genuinely different witness.
+        solver << "(assert (not (and";
+        for (const auto& varEntry : witness) {
+            for (const auto& elemEntry : varEntry.second) {
+                solver << " (=";
+                m_vars.at(varEntry.first)->emitElement(solver, elemEntry.first);
+                solver << ' ' << elemEntry.second << ")";
+            }
+        }
+        solver << ")))\n";
+        witnesses.push_back(std::move(witness));
+    }  // LCOV_EXCL_BR_LINE
+    return static_cast<int>(witnesses.size());
+}
+
+// Each equation selects a random subset of bits by a coin-flip for each bit, and then sets the XOR
+// of those bits to a random value.
+void VlRandomizer::unigenXors(std::iostream& solver, VlRNG& rngr, int bits) {
+    if (bits <= 0) return;  // 0 hash constraints == no extra assertion needed at all
+    std::vector<bool> target(bits);
+    for (int k = 0; k < bits; ++k) target[k] = VL_RANDOM_RNG_I(rngr) & 1;
+
+    solver << "(assert ";
+    solver << "(= #b";
+    for (int k = 0; k < bits; ++k) solver << (target[k] ? '1' : '0');
+    if (bits > 1) solver << " (concat";
+    for (int k = 0; k < bits; ++k) {
+        // #b0 seeds the bvxor chain so it's always >=2 operands (valid even
+        // if this equation's coin flips happen to select zero/one bits).
+        // 0 xor 0 == 0, 0 xor 1 == 1, so the seed cannot change the result.
+        solver << " (bvxor #b0";
+        for (const auto& var : m_vars) {
+            for (int j = 0; j < var.second->totalWidth(); ++j) {
+                if (VL_RANDOM_RNG_I(rngr) & 1) var.second->emitExtract(solver, j);
+            }
+        }
+        solver << ')';
+    }
+    if (bits > 1) solver << ')';
+    solver << "))\n";
+}
+
+// --- UniGen2 constants ---
+static constexpr double ug2Kappa = 0.638;  // Parameter controlling the tolerance of the uniformity
+                                           // guarantee. Set at the paper's default value.
+// Values used in the large space mode:
+static constexpr int ug2HiThreshLargeSpace = 16;  // Num of solutions to enumerate
+static constexpr int ug2BatchLargeSpace = 16;  // Num of solutions to cache
+static constexpr int ug2HashBitsLargeSpace
+    = 10;  // Num of XORs to add to the solver, also cap of the bsat() search
+
+bool VlRandomizer::estimateParameters(VlSolverSession& sess, VlRNG& rngr)
+    VL_REQUIRES(sess.m_mutex) {
+    std::iostream& solver = sess.os();
+    // Below formulas are taken from the UniGen2 paper, Sec. 4, Algorithm 1
+    const double pivot = ceil(4.03 * pow((1 + 1 / ug2Kappa), 2));
+    m_ug2.hiThresh = static_cast<int>(ceil(1 + sqrt(2) * (1 + ug2Kappa) * pivot));
+    m_ug2.loThresh = static_cast<int>(floor(pivot / (sqrt(2) * (1 + ug2Kappa))));
+
+    // A space so small can never reach loThresh, so enumerate it whole instead.
+    // push/pop keeps bsat() blocking clauses out of that search.
+    solver << "(push 1)\n";
+    std::vector<Witness> tinyWitnesses;
+    const int tinyCellSize = bsat(sess, 61, tinyWitnesses);
+    solver << "(pop 1)\n";
+    if (tinyCellSize < 0) return false;
+    if (tinyCellSize >= 1 && tinyCellSize <= 60) {
+        m_ug2.hashBits = 0;
+        m_ug2.loThresh = tinyCellSize;  // batch = the whole enumerated set
+        m_ug2.hiThresh = tinyCellSize + 1;
+        return true;
+    }
+
+    int totalBits = 0;
+    for (const auto& var : m_vars) totalBits += var.second->totalWidth();
+    int solCount = 0;
+    // Cap the search with ug2HashBitsLargeSpace: Larger spaces cannot be hashed in useful
+    // time, so stop and just use fixed number of XORs. Limit set empirically from measured solve
+    // times.
+    const int iMax = totalBits < ug2HashBitsLargeSpace ? totalBits : ug2HashBitsLargeSpace;
+    std::vector<Witness> witnesses;  // Reused across trials; bsat() clears it
+    for (int i = 1; i <= iMax; ++i) {
+        solver << "(push 1)\n";
+        unigenXors(solver, rngr, i);
+        const int bound = 61;
+        solCount = bsat(sess, bound, witnesses);
+        if (solCount < 0) {
+            solver << "(pop 1)\n";
+            return false;
+        }
+        if (solCount >= 1 && solCount < bound) {
+            m_ug2.hashBits
+                = static_cast<int>(round(log2(solCount) + i + log2(1.8)
+                                         - log2(pivot)));  // formula taken from the Unigen2 paper
+            solver << "(pop 1)\n";
+            return true;
+        }
+        solver << "(pop 1)\n";
+    }
+    m_ug2.isLargeSpace = true;
+    m_ug2.hashBits = ug2HashBitsLargeSpace;
+    m_ug2.hiThresh = ug2HiThreshLargeSpace;
+    return true;
+}
+
+bool VlRandomizer::generateSamples(VlSolverSession& sess, VlRNG& rngr) VL_REQUIRES(sess.m_mutex) {
+    std::iostream& solver = sess.os();
+    // Try whichever of hashBits number worked last call first
+    // (UniGen2 Sec. 4, "leapfrogging" in spirit but without weakening guarantees).
+    // On a large space no cell was ever enumerable, so just try most hash bits first for the
+    // smallest cell.
+    const int lowestCount = m_ug2.hashBits - 2;
+    int candidates[3] = {lowestCount, lowestCount + 1, lowestCount + 2};
+    if (m_ug2.isLargeSpace) {
+        candidates[0] = m_ug2.hashBits;
+        candidates[1] = m_ug2.hashBits - 1;
+        candidates[2] = m_ug2.hashBits - 2;
+    } else if (m_ug2.lastSuccessI >= 0) {
+        std::swap(candidates[0], candidates[m_ug2.lastSuccessI - lowestCount]);
+    }
+
+    std::vector<Witness> witnesses;  // Reused across candidates; bsat() clears it
+    for (int t = 0; t < 3; ++t) {  // LCOV_EXCL_BR_LINE - Always finds a candidate in practice
+        const int i = candidates[t];
+        if (i < 0) continue;  // hashBits below 2 leaves fewer than three counts to try
+
+        solver << "(push 1)\n";
+        unigenXors(solver, rngr, i);
+        const int solCount
+            = bsat(sess, m_ug2.hiThresh, witnesses, m_ug2.isLargeSpace ? &rngr : nullptr);
+        if (m_ug2.loThresh <= solCount && (solCount < m_ug2.hiThresh || m_ug2.isLargeSpace)) {
+            m_ug2.lastSuccessI = i;
+            const int take
+                = m_ug2.isLargeSpace ? std::min(ug2BatchLargeSpace, solCount) : m_ug2.loThresh;
+            // Pick them at random rather than the first ones enumerated -
+            // partial Fisher-Yates, so the picks stay distinct.
+            m_ug2.loThreshWitnesses.clear();
+            std::vector<int> indices(witnesses.size());
+            for (size_t k = 0; k < indices.size(); ++k) indices[k] = static_cast<int>(k);
+            for (int k = 0; k < take; ++k) {
+                const size_t pick
+                    = static_cast<size_t>(k) + (VL_RANDOM_RNG_I(rngr) % (indices.size() - k));
+                std::swap(indices[k], indices[pick]);
+                m_ug2.loThreshWitnesses.push_back(std::move(witnesses[indices[k]]));
+            }
+            solver << "(pop 1)\n";
+            return true;
+        }
+        solver << "(pop 1)\n";
+    }
+    m_ug2.lastSuccessI = -1;  // LCOV_EXCL_LINE
+    return false;  // LCOV_EXCL_LINE
 }
 
 void VlRandomizer::solveDiversity(VlRNG& rngr, VlSolverSession& sess) VL_REQUIRES(sess.m_mutex) {
@@ -1319,8 +1655,8 @@ bool VlRandomizer::nextPhased(VlRNG& rngr, VlSolverSession& sess,
     std::vector<std::vector<std::string>> layers;
     if (!buildSolveLayers(layers)) return false;
 
-    // One layer: all solve_before vars are independent, no ordering required
-    if (layers.size() <= 1) return nextFlat(rngr, sess, uniqueExprs);
+    // No layers means no solve_before pair survived
+    if (layers.empty()) return nextFlat(rngr, sess, uniqueExprs);
 
     VlSolverTxn txn{sess};
     if (!txn.ok()) return false;

--- a/include/verilated_random.cpp
+++ b/include/verilated_random.cpp
@@ -343,6 +343,8 @@ void VlRandomVar::emitExtract(std::ostream& s, int i) const {
     s << " ((_ extract " << i << ' ' << i << ") " << m_name << ')';
 }
 void VlRandomVar::emitType(std::ostream& s) const { s << "(_ BitVec " << width() << ')'; }
+// A scalar var IS its only element, so "element j" is just the whole var.
+void VlRandomVar::emitElement(std::ostream& s, int /*j*/) const { s << ' ' << m_name; }
 // Serialize the current runtime value as an SMT-LIB binary literal. Used by
 // randomize(null) to pin a var via `(assert (= var #b...))`. Binary (#b)
 // rather than hex (#x) sidesteps SMT-LIB's hex-width-multiple-of-4 rule.
@@ -481,6 +483,24 @@ void VlRandomizer::recordRandcValues() {
     }
 }
 
+bool VlRandomizer::hasFrozenVar() const {
+    // Nothing can be frozen without rand_mode state or a disabled var, and
+    // generated code only sets those up for classes that use them, so this
+    // returns immediately for the common case.
+    if (!m_randmodep && !m_static_randmodep && m_disabledVars.empty()) return false;
+    for (const auto& var : m_vars) {
+        if (!var.second->randModeIdxNone()) {
+            const VlQueue<CData>* const modep
+                = m_staticVars.count(var.first) ? m_static_randmodep : m_randmodep;
+            if (modep && !modep->at(var.second->randModeIdx())) return true;
+        }
+        // Struct/nested members are disabled via m_disabledVars instead.
+        // They have no randModeIdx of their own (see write_var's default).
+        if (m_disabledVars.count(var.first)) return true;
+    }
+    return false;
+}
+
 bool VlRandomizer::next_check_only(VlRNG& rngr) { return nextRandomize(rngr, true); }
 
 bool VlRandomizer::next(VlRNG& rngr) { return nextRandomize(rngr, false); }
@@ -578,12 +598,24 @@ void VlRandomizer::emitAsserts(std::ostream& os, const std::vector<std::string>&
     }
 }
 
-bool VlRandomizer::nextFlat(VlRNG& rngr, const std::vector<std::string>& uniqueExprs) {
-    // Randc retry: if unsat due to randc exhaustion, clear history and retry once
+bool VlRandomizer::nextFlat(VlRNG& rngr, const std::vector<std::string>& uniqueExprs,
+                            bool allowUnigen2) {
+    // With no randc, solve-before or frozen vars, sample with Unigen2: more
+    // uniform, and cheaper per call once the witness batch is already filled.
+    // When Unigen2 returns false it has written no values and reset the
+    // solver, so this function continues with the regular solve.
     const bool hasRandc = !m_randcVarNames.empty();
-    for (int attempt = 0; attempt < (hasRandc ? 2 : 1); ++attempt) {
+    if (!hasRandc && allowUnigen2 && !m_checkOnly && !hasFrozenVar()
+        && Unigen2(rngr, uniqueExprs)) {
+        return true;
+    }
+
+    for (int attempt = 0; attempt < 2; ++attempt) {
         std::iostream& os = getSolver();
         if (!os) return false;
+        // Unigen2() and a prior phase loop both leave their own declarations
+        // on the shared solver -- start clean
+        os << "(reset)\n";
 
         os << "(set-option :produce-models true)\n";
         // Lets the scalar pin path learn which free-bit assumptions conflict.
@@ -628,6 +660,302 @@ bool VlRandomizer::nextFlat(VlRNG& rngr, const std::vector<std::string>& uniqueE
         return true;
     }
     return false;  // Should not reach here
+}
+
+bool VlRandomizer::Unigen2(VlRNG& rngr, const std::vector<std::string>& uniqueExprs) {
+    // Soft constraints are not handled in Unigen2 -- leave them to the caller.
+    if (!m_softConstraints.empty()) return false;
+
+    const size_t currentHash = hashConstraints(uniqueExprs);
+    // Params and batch are computed for specific constraint set, so drop them
+    // once it changes.
+    if (m_ug2ParamHash != currentHash) {
+        m_loTreshWitnesses.clear();
+        m_ug2ParamsValid = false;
+        m_ug2Unusable = false;
+        m_ug2ParamHash = currentHash;
+    }
+
+    // Consumable batch from a previous generateSamples() call: drain it
+    // before touching the solver at all.
+    if (!m_loTreshWitnesses.empty()) {
+        Witness witness = std::move(m_loTreshWitnesses.back());
+        m_loTreshWitnesses.pop_back();
+        writeBackWitness(witness);
+        return true;
+    }
+
+    // The search only pays off if reused, so wait for the same constraint set
+    // twice
+    const bool stable = m_ug2PrevHash == currentHash;
+    m_ug2PrevHash = currentHash;
+    if (!stable || m_ug2Unusable) return false;
+
+    std::iostream& solver = getSolver();
+    if (!solver) return false;
+
+    solver << "(reset)\n";
+    solver << "(set-option :produce-models true)\n";
+    solver << "(set-logic QF_ABV)\n";
+    emitDefines(solver);
+    emitDeclares(solver, false);
+    emitAsserts(solver, uniqueExprs, false);
+
+    const double epsilon = 16.0;
+    if (!m_ug2ParamsValid) {
+        // Solve into locals: estimateParameters writes loTresh/hiTresh before
+        // it can still fail, so the members must only be updated on success.
+        int hashBits;
+        int loTresh;
+        int hiTresh;
+        if (estimateParameters(solver, rngr, epsilon, hashBits, loTresh, hiTresh)) {
+            m_ug2HashBits = hashBits;
+            m_ug2LoTresh = loTresh;
+            m_ug2HiTresh = hiTresh;
+            m_ug2ParamsValid = true;
+            m_ug2LastSuccessI = -1;  // new params, so the old hint no longer applies
+        } else {
+            m_ug2Unusable = true;  // gave up; don't retry until the constraints change
+        }
+    }
+    if (m_ug2ParamsValid
+        && generateSamples(m_ug2HashBits, m_ug2LoTresh, m_ug2HiTresh, solver, rngr)
+        && !m_loTreshWitnesses.empty()) {
+        Witness witness = std::move(m_loTreshWitnesses.back());
+        m_loTreshWitnesses.pop_back();
+        writeBackWitness(witness);
+        solver << "(reset)\n";
+        return true;
+    }
+    solver << "(reset)\n";
+    return false;
+}
+
+void VlRandomizer::writeBackWitness(const Witness& witness) {
+    for (const auto& varEntry : witness) {
+        const auto& varp = m_vars.at(varEntry.first);
+        // Solved values for rand_mode(0)/disabled vars must not overwrite
+        // the frozen runtime value, matching parseSolution's write-back.
+        if (!varp->randModeIdxNone()) {
+            const VlQueue<CData>* const modep
+                = m_staticVars.count(varEntry.first) ? m_static_randmodep : m_randmodep;
+            if (modep && !modep->at(varp->randModeIdx())) continue;
+        }
+        if (m_disabledVars.count(varEntry.first)) continue;
+        for (const auto& elemEntry : varEntry.second) {
+            if (varp->dimension() > 0) {
+                // set() needs current array info, and a witness from the
+                // cached batch skips the solver, so nothing else sets it.
+                auto arrVarsp = std::make_shared<const ArrayInfoMap>(m_arr_vars);
+                varp->setArrayInfo(arrVarsp);
+                std::ostringstream idxStream;
+                idxStream << "#x" << std::hex << std::setw(8) << std::setfill('0')
+                          << elemEntry.first;
+                varp->set(idxStream.str(), elemEntry.second);
+            } else {
+                varp->set("", elemEntry.second);
+            }
+        }
+    }
+}
+
+int VlRandomizer::BSAT(std::iostream& solver, int bound, std::vector<Witness>& witnesses) {
+    witnesses.clear();
+    witnesses.reserve(bound);
+    // get-value responses preserve request order, so build the (var,
+    // element) order once and read results back positionally. This
+    // avoids needing to parse array "(select ...)" expressions out of the
+    // response text at all, since we already know what we asked for.
+    std::vector<std::pair<std::string, int>> order;
+    for (const auto& var : m_vars) {
+        const int elementCount = var.second->totalWidth() / var.second->width();
+        for (int j = 0; j < elementCount; ++j) order.emplace_back(var.first, j);
+    }
+
+    while (static_cast<int>(witnesses.size()) < bound) {
+        solver << "(check-sat)\n";
+        std::string result;
+        do { std::getline(solver, result); } while (result.empty());
+        if (result != "sat") break;  // every distinct witness already found
+
+        solver << "(get-value (";
+        for (const auto& entry : order) m_vars.at(entry.first)->emitElement(solver, entry.second);
+        solver << "))\n";
+
+        Witness witness;
+        char c;
+        solver >> c;  // opening '(' of the whole get-value response
+        for (const auto& entry : order) {
+            solver >> c;  // opening '(' of this (expr value) pair
+            std::string exprHead;
+            solver >> exprHead;  // bare var name, or literally "(select" if an array element
+            if (exprHead == "(select") readUntilBalanced(solver);  // discard rest of expr
+            std::string value;
+            std::getline(solver, value, ')');
+            witness[entry.first][entry.second] = value;
+        }
+        solver >> c;  // closing ')' of the whole get-value response
+
+        // Blocking clause: forbid this exact assignment so the next
+        // (check-sat) is forced to find a genuinely different witness.
+        // Emitted before the move below, which leaves `witness` empty.
+        solver << "(assert (not (and";
+        for (const auto& varEntry : witness) {
+            for (const auto& elemEntry : varEntry.second) {
+                solver << " (=";
+                m_vars.at(varEntry.first)->emitElement(solver, elemEntry.first);
+                solver << ' ' << elemEntry.second << ")";
+            }
+        }
+        solver << ")))\n";
+        witnesses.push_back(std::move(witness));
+    }
+    return static_cast<int>(witnesses.size());
+}
+
+bool VlRandomizer::unigenXors(std::iostream& solver, VlRNG& rngr, int bits) {
+    if (bits <= 0) return true;  // 0 hash constraints == no extra assertion needed at all
+    // bits is the total rand-var width, so it can exceed 32 -- draw each
+    // target bit on its own rather than packing them into one 32-bit word.
+    std::vector<bool> target(bits);
+    for (int k = 0; k < bits; ++k) target[k] = VL_RANDOM_RNG_I(rngr) & 1;
+
+    solver << "(assert ";
+    solver << "(= #b";
+    for (int k = 0; k < bits; ++k) solver << (target[k] ? '1' : '0');
+    if (bits > 1) solver << " (concat";
+    for (int k = 0; k < bits; ++k) {
+        // #b0 seeds the bvxor chain so it's always >=2 operands (valid even
+        // if this equation's coin flips happen to select zero/one bits).
+        // 0 xor 0 == 0, 0 xor 1
+        solver << " (bvxor #b0";
+        for (const auto& var : m_vars) {
+            for (int j = 0; j < var.second->totalWidth(); ++j) {
+                if (VL_RANDOM_RNG_I(rngr) & 1) var.second->emitExtract(solver, j);
+            }
+        }
+        solver << ')';
+    }
+    if (bits > 1) solver << ')';
+    solver << "))\n";
+    return true;
+}
+
+bool VlRandomizer::estimateParameters(std::iostream& solver, VlRNG& rngr, double epsilon,
+                                      int& hashBits, int& loTresh, int& hiTresh) {
+    if (epsilon < 6.84) return false;
+
+    double kappa;
+    if (epsilon == 16.0) {
+        // Matches the reference UniGen2 implementation's hardcoded default
+        // (src/config.h: kappa = 0.638 "Corresponds to UniGen's epsilon=16").
+        kappa = 0.638;
+    } else {
+        // epsilon = (1+kappa) * (7.44 + 0.392/(1-kappa)^2) - 1 is monotonic increasing
+        // in kappa over (0,1), so invert it via bisection.
+        double lo = 0.0, hi = 1.0;
+        for (int i = 0; i < 60; ++i) {
+            const double mid = (lo + hi) / 2;
+            const double epsForMid = (1 + mid) * (7.44 + 0.392 / ((1 - mid) * (1 - mid))) - 1;
+            if (epsForMid < epsilon) {
+                lo = mid;
+            } else {
+                hi = mid;
+            }
+        }
+        kappa = (lo + hi) / 2;
+    }
+
+    const double pivot = ceil(4.03 * pow((1 + 1 / kappa), 2));
+    hiTresh = static_cast<int>(ceil(1 + sqrt(2) * (1 + kappa) * pivot));
+    loTresh = static_cast<int>(floor(pivot / (sqrt(2) * (1 + kappa))));
+
+    // A space this small can never reach loTresh, so the search below would
+    // always fail -- enumerate it instead. push/pop keeps BSAT's blocking
+    // clauses out of that search.
+    solver << "(push 1)\n";
+    std::vector<Witness> tinyWitnesses;
+    const int tinyCellSize = BSAT(solver, 61, tinyWitnesses);
+    solver << "(pop 1)\n";
+    if (tinyCellSize >= 1 && tinyCellSize <= 60) {
+        hashBits = 0;
+        loTresh = tinyCellSize;  // batch = the whole enumerated set
+        hiTresh = tinyCellSize + 1;
+        return true;
+    }
+
+    int totalBits = 0;
+    for (const auto& var : m_vars) totalBits += var.second->totalWidth();
+    int solCount = 0;
+    // Cap the search with kMaxHashBits: z3 has no native XOR reasoning (the reference UniGen2
+    // uses CryptoMiniSat for that), so each added hash bit roughly doubles
+    // solve time. Limit set empirically from measured solve times.
+    // Larger spaces cannot be hashed in useful time, so stop and let the caller fall back.
+    const int kMaxHashBits = 13;
+    const int iMax = totalBits < kMaxHashBits ? totalBits : kMaxHashBits;
+    std::vector<Witness> witnesses;  // Reused across trials; BSAT clears it
+    for (int i = 1; i <= iMax; ++i) {
+        solver << "(push 1)\n";
+        unigenXors(solver, rngr, i);
+        const int bound = 61;
+        solCount = BSAT(solver, bound, witnesses);
+        if (solCount >= 1 && solCount < bound) {
+            hashBits = static_cast<int>(round(log2(solCount) + i + log2(1.8) - log2(pivot)));
+            solver << "(pop 1)\n";
+            return true;
+        }
+        solver << "(pop 1)\n";
+    }
+    return false;
+}
+
+bool VlRandomizer::generateSamples(int hashBits, int loTresh, int hiTresh, std::iostream& solver,
+                                   VlRNG& rngr) {
+    // Try whichever of {hashBits-2, hashBits-1, hashBits} worked last call
+    // first -- the right count rarely moves. Only the order changes, all three
+    // are still tried, so uniformity is preserved (UniGen2 Sec. 4: like
+    // ApproxMC "leapfrogging" in spirit, but without weakening guarantees).
+    int candidates[3] = {hashBits - 2, hashBits - 1, hashBits};
+    if (m_ug2LastSuccessI >= 0) {
+        for (int t = 0; t < 3; ++t) {
+            if (candidates[t] == m_ug2LastSuccessI) {
+                std::swap(candidates[0], candidates[t]);
+                break;
+            }
+        }
+    }
+
+    // Clamp at 0: a negative candidate would make unigenXors shift by a
+    // negative amount (undefined). Clamping can collide, hence `tried`.
+    std::vector<int> tried;
+    for (int t = 0; t < 3; ++t) {
+        const int i = std::max(0, candidates[t]);
+        if (std::find(tried.begin(), tried.end(), i) != tried.end()) continue;
+        tried.push_back(i);
+
+        solver << "(push 1)\n";
+        unigenXors(solver, rngr, i);
+        const int solCount = BSAT(solver, hiTresh, m_witnesses);
+        if (loTresh <= solCount && solCount < hiTresh) {
+            m_ug2LastSuccessI = i;
+            // Pick loThresh at random rather than the first ones enumerated -
+            // partial Fisher-Yates, so the picks stay distinct.
+            m_loTreshWitnesses.clear();
+            std::vector<int> indices(m_witnesses.size());
+            for (size_t k = 0; k < indices.size(); ++k) indices[k] = static_cast<int>(k);
+            for (int k = 0; k < loTresh; ++k) {
+                const size_t pick
+                    = static_cast<size_t>(k) + (VL_RANDOM_RNG_I(rngr) % (indices.size() - k));
+                std::swap(indices[k], indices[pick]);
+                m_loTreshWitnesses.push_back(std::move(m_witnesses[indices[k]]));
+            }
+            solver << "(pop 1)\n";
+            return true;
+        }
+        solver << "(pop 1)\n";
+    }
+    m_ug2LastSuccessI = -1;
+    return false;
 }
 
 void VlRandomizer::solveDiversity(VlRNG& rngr, std::iostream& os) {
@@ -998,7 +1326,7 @@ bool VlRandomizer::nextPhased(VlRNG& rngr, const std::vector<std::string>& uniqu
     if (!buildSolveLayers(layers)) return false;
 
     // One layer: all solve_before vars are independent, no ordering required
-    if (layers.size() <= 1) return nextFlat(rngr, uniqueExprs);
+    if (layers.size() <= 1) return nextFlat(rngr, uniqueExprs, /* allowUnigen2 */ false);
 
     return solvePhases(rngr, layers, uniqueExprs);
 }
@@ -1007,6 +1335,16 @@ bool VlRandomizer::solvePhases(VlRNG& rngr, const std::vector<std::vector<std::s
                                const std::vector<std::string>& uniqueExprs) {
     std::map<std::string, std::string> solvedValues;  // varName -> SMT value literal
     const char* const logicp = phasedLogic();
+
+    // Unigen2() may leave a prior call's declarations/assertions open on the
+    // shared solver on success (deliberately, to reuse them for its own
+    // batching) -- start clean rather than piling this phase loop's declares
+    // atop whatever it left behind.
+    {
+        std::iostream& initOs = getSolver();
+        if (!initOs) return false;
+        initOs << "(reset)\n";
+    }
 
     for (size_t phase = 0; phase < layers.size(); phase++) {
         const bool isFinalPhase = (phase == layers.size() - 1);

--- a/include/verilated_random.h
+++ b/include/verilated_random.h
@@ -83,6 +83,10 @@ public:
     virtual void emitGetValue(std::ostream& s) const;
     virtual void emitExtract(std::ostream& s, int i) const;
     virtual void emitType(std::ostream& s) const;
+    // Emit the expression referring to element j as a whole (the full var
+    // for scalars, "(select arr idx...)" for array element j). Used by BSAT
+    // to query/re-assert one whole element's value, not a single bit.
+    virtual void emitElement(std::ostream& s, int j) const;
     // Emit the current runtime value as an SMT bit-vector literal (#b...).
     // Used by randomize(null) to pin a var to its existing value.
     virtual void emitConcreteValue(std::ostream& s) const;
@@ -213,6 +217,20 @@ public:
         const int elementCounts = countMatchingElements(*m_arrVarsRefp, name());
         return width() * elementCounts;
     }
+    void emitElement(std::ostream& s, int j) const override {
+        const std::string indexed_name = name() + std::to_string(j);
+        const auto it = m_arrVarsRefp->find(indexed_name);
+        // Callers take j from totalWidth(), which counts these same keys, so the element
+        // should always be there
+        if (VL_UNCOVERABLE(it == m_arrVarsRefp->end())) {
+            // LCOV_EXCL_START
+            VL_FATAL_MT(__FILE__, __LINE__, "randomize", "indexed_name not found in m_arr_vars");
+            return;
+            // LCOV_EXCL_STOP
+        }
+        s << ' ';
+        emitSelect(s, it->second->m_indices, it->second->m_idxWidths);
+    }  // LCOV_EXCL_BR_LINE
     void emitExtract(std::ostream& s, int i) const override {
         const int j = i / width();
         i = i % width();
@@ -256,6 +274,9 @@ class VlRandomizer VL_NOT_FINAL {
     std::vector<std::pair<std::string, std::string>>
         m_solveBefore;  // Solve-before ordering pairs (beforeVar, afterVar)
     bool m_checkOnly = false;  // Set for randomize(null)
+    bool isFrozenVar(const std::string& name,
+                     const VlRandomVar& var) const;  // true if this var is currently frozen
+    bool hasFrozenVar() const;  // true if any var is currently rand_mode(0)-frozen
 
     // PRIVATE METHODS
     void randomConstraint(std::ostream& os, VlRNG& rngr, int bits);
@@ -271,13 +292,54 @@ class VlRandomizer VL_NOT_FINAL {
     void emitRandcExclusions(std::ostream& os) const;  // Emit randc exclusion constraints
     void recordRandcValues();  // Record solved randc values for future exclusion
     size_t hashConstraints(const std::vector<std::string>& extras) const;
-    bool nextRandomize(VlRNG& rngr, bool checkOnly);
+    bool nextRandomize(VlRNGReseeds& rngr, bool checkOnly);
     // "(distinct ...)" expression per unique-constrained array
     std::vector<std::string> buildUniqueExprs() const;
     void emitDefines(std::ostream& os) const;
     void emitDeclares(std::ostream& os, bool pinCurrent) const;
     void emitAsserts(std::ostream& os, const std::vector<std::string>& extras, bool named) const;
     bool nextFlat(VlRNG& rngr, VlSolverSession& sess, const std::vector<std::string>& uniqueExprs);
+
+    // --- UniGen2 (a near-uniform constrained randomization sampler) fields ---
+    // Implementation based on the following paper:
+    // "On Parallel Scalable Uniform SAT Witness Generation", Chakraborty et al.
+
+    using Witness = std::map<std::string, std::map<int, std::string>>;  // One sampled solution
+
+    // Sample one random solution. False if a sample couldn't be produced
+    bool unigen2(VlRNG& rngr, VlSolverSession& sess, const std::vector<std::string>& uniqueExprs);
+    // Find out how finely to cut the solution space, and what cell size to accept
+    bool estimateParameters(VlSolverSession& sess, VlRNG& rngr);
+    // Collect up to `bound` different solutions of whatever is asserted right now.
+    // diversifyRngp adds a randomization step that spreads the solutions apart
+    int bsat(VlSolverSession& sess, size_t bound, std::vector<Witness>& witnesses,
+             VlRNG* diversifyRngp = nullptr);
+    // Add `bits` random XOR equations, which cut the solution space into cells holding
+    // roughly 1/2**bits of all the solutions
+    void unigenXors(std::iostream& os, VlRNG& rngr, int bits);
+    // Draw a cell and refill the batch of solutions from it
+    bool generateSamples(VlSolverSession& sess, VlRNG& rngr);
+    // Copy one solution into the SV variables
+    void writeBackWitness(const Witness& witness);
+
+    // UniGen2: sampling state
+    struct Unigen2State final {
+        std::vector<Witness> loThreshWitnesses;  // Consumable batch of solutions: loThresh random
+                                                 // picks out of the cell BSAT enumerated
+        std::vector<std::pair<std::string, int>> bsatOrder;  // (var, element) query order
+        bool isLargeSpace = false;  // Large solution space (more than 61 * 2^10 solutions)
+        // Below properties are what estimateParameters worked out, kept until the constraints
+        // change so the expensive search is not repeated on every call.
+        bool paramsValid = false;  // Whether the values below are set
+        size_t paramHash = 0;  // Constraint set they were computed for
+        int hashBits = 0;  // How many XOR equations to cut the space with
+        int loThresh = 0;  // Smallest usable cell, and how many samples to take
+        int hiThresh = 0;  // First cell size counted as too big
+        uint64_t rngReseeds = 0;  // rngr.reseeds() as of the last call
+        int lastSuccessI = -1;  // Hash-bit count that worked last time, -1 if none
+    };
+    Unigen2State m_ug2;
+
     void solveDiversity(VlRNG& rngr, VlSolverSession& sess);
     void solveDiversityPins(VlRNG& rngr, VlSolverSession& sess);
     void solveDiversityXor(VlRNG& rngr, VlSolverSession& sess);
@@ -302,10 +364,10 @@ public:
 
     // METHODS
     // Finds the next solution satisfying the constraints
-    bool next(VlRNG& rngr);
+    bool next(VlRNGReseeds& rngr);
     // Validate the constraints against the current runtime values of every
     // registered rand variable without picking new ones.
-    bool next_check_only(VlRNG& rngr);
+    bool next_check_only(VlRNGReseeds& rngr);
 
     // ---  Process the key for associative array  ---
 
@@ -721,7 +783,7 @@ public:
 // Light wrapper for RNG used by std::randomize() to support scope-level randomization.
 class VlStdRandomizer final : public VlRandomizer {
     // MEMBERS
-    VlRNG m_rng;  // Random number generator
+    VlRNGReseeds m_rng;  // Random number generator
 
 public:
     // CONSTRUCTORS

--- a/include/verilated_random.h
+++ b/include/verilated_random.h
@@ -56,6 +56,12 @@ public:
         , m_idxWidths{idxWidths} {}
 };
 using ArrayInfoMap = std::map<std::string, std::shared_ptr<const ArrayInfo>>;
+// One sampled assignment, a "witness" in UniGen2 terms.
+// var name -> {flat element index -> raw SMT value string}.
+// Scalars just have a single {0: value} entry. Element index
+// matches VlRandomArrayVarTemplate's flat naming (name()+to_string(j)), the
+// same index ArrayInfo::m_index uses, so it can be fed straight to set().
+using Witness = std::map<std::string, std::map<int, std::string>>;
 
 class VlRandomVar VL_NOT_FINAL {
     std::string m_name;  // Variable name
@@ -83,6 +89,10 @@ public:
     virtual void emitGetValue(std::ostream& s) const;
     virtual void emitExtract(std::ostream& s, int i) const;
     virtual void emitType(std::ostream& s) const;
+    // Emit the expression referring to element j as a whole (the full var
+    // for scalars, "(select arr idx...)" for array element j). Used by BSAT
+    // to query/re-assert one whole element's value, not a single bit.
+    virtual void emitElement(std::ostream& s, int j) const;
     // Emit the current runtime value as an SMT bit-vector literal (#b...).
     // Used by randomize(null) to pin a var to its existing value.
     virtual void emitConcreteValue(std::ostream& s) const;
@@ -213,6 +223,18 @@ public:
         const int elementCounts = countMatchingElements(*m_arrVarsRefp, name());
         return width() * elementCounts;
     }
+    void emitElement(std::ostream& s, int j) const override {
+        const std::string indexed_name = name() + std::to_string(j);
+        const auto it = m_arrVarsRefp->find(indexed_name);
+        if (it != m_arrVarsRefp->end()) {
+            const std::vector<IData>& indices = it->second->m_indices;
+            const std::vector<size_t>& idxWidths = it->second->m_idxWidths;
+            s << ' ';
+            emitSelect(s, indices, idxWidths);
+        } else {
+            VL_FATAL_MT(__FILE__, __LINE__, "randomize", "indexed_name not found in m_arr_vars");
+        }
+    }
     void emitExtract(std::ostream& s, int i) const override {
         const int j = i / width();
         i = i % width();
@@ -254,6 +276,26 @@ class VlRandomizer VL_NOT_FINAL {
     std::vector<std::pair<std::string, std::string>>
         m_solveBefore;  // Solve-before ordering pairs (beforeVar, afterVar)
     bool m_checkOnly = false;  // Set for randomize(null)
+    // True if any var is currently rand_mode(0)-frozen: generated code bakes
+    // such a var's concrete value directly into the constraint text, so it's
+    // no longer symbolically constrained even though it's still a declared
+    // solver variable -- Unigen2 must not be used while this holds.
+    bool hasFrozenVar() const;
+
+    // ---  UniGen2 sampling state  ---
+    std::vector<Witness> m_witnesses;  // Raw BSAT pool for this cell
+    std::vector<Witness>
+        m_loTreshWitnesses;  // Consumable batch: loThresh random picks from m_witnesses
+    // What estimateParameters worked out, kept until the constraints change
+    // so the search is not repeated on every call.
+    bool m_ug2ParamsValid = false;  // Whether the three values below are set
+    size_t m_ug2ParamHash = 0;  // Constraint set they were computed for
+    int m_ug2HashBits = 0;  // How many XOR equations to cut the space with
+    int m_ug2LoTresh = 0;  // Smallest usable cell, and how many samples to take
+    int m_ug2HiTresh = 0;  // First cell size counted as too big
+    bool m_ug2Unusable = false;  // Set when estimateParameters gave up on that set
+    size_t m_ug2PrevHash = 0;  // Constraint set seen on the previous call
+    int m_ug2LastSuccessI = -1;  // Hash-bit count that worked last time, -1 if none
 
     // PRIVATE METHODS
     void randomConstraint(std::ostream& os, VlRNG& rngr, int bits);
@@ -274,7 +316,45 @@ class VlRandomizer VL_NOT_FINAL {
     void emitDefines(std::ostream& os) const;
     void emitDeclares(std::ostream& os, bool pinCurrent) const;
     void emitAsserts(std::ostream& os, const std::vector<std::string>& extras, bool named) const;
-    bool nextFlat(VlRNG& rngr, const std::vector<std::string>& uniqueExprs);
+    bool nextFlat(VlRNG& rngr, const std::vector<std::string>& uniqueExprs,
+                  bool allowUnigen2 = true);
+
+    // ---  UniGen2 sampling  ---
+    // For reference see "On Parallel Scalable Uniform SAT Witness Generation",
+    // Supratik Chakraborty et al., TACAS 2015. Section 4 of it is the source of
+    // the terms used below -- witness, cell, hashBits, loThresh/hiThresh, BSAT.
+    // Each term is explained where it is declared.
+
+    // A uniform sampler: random XOR constraints hash the solution space into
+    // small cells, and one cell is enumerated. That search is expensive, but
+    // it fills a batch of solutions that later randomize() calls are served
+    // from. Returns true when a solution was written back; false when it
+    // declined, leaving the solver reset for the caller to solve as usual.
+    // The caller skips it for randc, solve-before and rand_mode(0)-frozen
+    // vars; it declines itself when the batch could not be reused: soft
+    // constraints, a constraint set differing from the previous call, or a
+    // space too large for estimateParameters to hash.
+    bool Unigen2(VlRNG& rngr, const std::vector<std::string>& uniqueExprs);
+    bool estimateParameters(std::iostream& os, VlRNG& rngr, double epsilon, int& hashBits,
+                            int& loTresh, int& hiTresh);
+    // The counting step: lists up to `bound` distinct solutions of whatever
+    // is currently asserted, by asking for one and then blocking it so the
+    // next check-sat must find another. Used first to measure how big a cell
+    // is, and then to collect the batch of samples out of a good one.
+    int BSAT(std::iostream& solver, int bound, std::vector<Witness>& witnesses);
+    // The hashing step: asserts `bits` random XOR equations over the rand
+    // vars' bits, splitting the solution space into cells holding roughly
+    // 1/2**bits of it each. The hash being random is what makes a single
+    // cell a near-uniform sample of the whole space -- that is where the
+    // uniformity comes from. Unrelated to solveDiversityXor, which only
+    // nudges one solve rather than partitioning anything.
+    bool unigenXors(std::iostream& os, VlRNG& rngr, int bits);
+    bool generateSamples(int hashBits, int loTresh, int hiTresh, std::iostream& solver,
+                         VlRNG& rngr);
+    // Write one sampled witness back into the live SV variables (scalars via
+    // set("", value); array elements via a hex-encoded flat index).
+    void writeBackWitness(const Witness& witness);
+
     void solveDiversity(VlRNG& rngr, std::iostream& os);
     void solveDiversityPins(VlRNG& rngr, std::iostream& os);
     void solveDiversityXor(VlRNG& rngr, std::iostream& os);

--- a/include/verilated_types.h
+++ b/include/verilated_types.h
@@ -276,7 +276,7 @@ constexpr IData VL_CLOG2_CE_Q(QData lhs) VL_PURE {
 // Random
 
 // Random Number Generator with internal state
-class VlRNG final {
+class VlRNG VL_NOT_FINAL {
     std::array<uint64_t, 2> m_state;
 
 public:
@@ -293,6 +293,22 @@ public:
     static uint64_t vl_thread_rng_rand64() VL_MT_SAFE;
     static uint64_t vl_current_rng_rand64() VL_MT_SAFE;
     static VlRNG& vl_thread_rng() VL_MT_SAFE;
+};
+
+// VlRNG that also counts how often it was reseeded, for randomize() to notice.
+class VlRNGReseeds final : public VlRNG {
+    uint64_t m_reseeds = 0;  // Times the state was set from outside
+
+public:
+    void srandom(uint64_t n) VL_MT_UNSAFE {
+        VlRNG::srandom(n);
+        ++m_reseeds;
+    }
+    void set_randstate(const std::string& state) VL_MT_UNSAFE {
+        VlRNG::set_randstate(state);
+        ++m_reseeds;
+    }
+    uint64_t reseeds() const VL_MT_UNSAFE { return m_reseeds; }
 };
 
 //===================================================================

--- a/src/V3EmitCHeaders.cpp
+++ b/src/V3EmitCHeaders.cpp
@@ -144,7 +144,7 @@ class EmitCHeader final : public EmitCConstInit {
         if (const AstClass* const classp = VN_CAST(modp, Class)) {
             if (classp->needRNG()) {
                 putsDecoration(nullptr, "\n// INTERNAL VARIABLES\n");
-                puts("VlRNG __Vm_rng;\n");
+                puts("VlRNGReseeds __Vm_rng;\n");
             }
         } else {  // not class
             putsDecoration(nullptr, "\n// INTERNAL VARIABLES\n");

--- a/test_regress/t/randomize_uniform_common.py
+++ b/test_regress/t/randomize_uniform_common.py
@@ -1,0 +1,57 @@
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import math
+import re
+
+# Jensen-Shannon divergence (JSD) measures how far the "shape" of the
+# observed distribution is from perfectly uniform.
+# 0 means identical to uniform; it grows as the observed
+# distribution gets more skewed. Scaled here x100, to notice differences easier
+JSD_MAX = 2.5
+
+
+def jensen_shannon_divergence_pct(observed_counts, solutions):
+    n_obs = sum(observed_counts.values())
+    p = [1.0 / len(solutions) for _ in solutions]  # uniform
+    q = [observed_counts.get(s, 0) / n_obs for s in solutions]  # observed
+    m = [(pi + qi) / 2 for pi, qi in zip(p, q)]
+
+    def kl(a, b):
+        return sum(ai * math.log(ai / bi) for ai, bi in zip(a, b) if ai > 0)
+
+    return (kl(p, m) + kl(q, m)) / 2 * 100
+
+
+def run(test, solutions, line_pattern, key=lambda line: line):
+    """Check that randomize() samples `solutions` close enough to uniformly.
+
+    line_pattern picks out the run-log lines carrying a sample, and key turns
+    such a line into the value used to look it up in `solutions`.
+    """
+    if not test.have_solver:
+        test.skip("No constraint solver installed")
+
+    test.compile()
+
+    test.execute()
+
+    observed = {}
+    with open(test.run_log_filename, 'r', encoding='latin-1') as fh:
+        for line in fh:
+            line = line.strip()
+            if re.fullmatch(line_pattern, line):
+                value = key(line)
+                observed[value] = observed.get(value, 0) + 1
+
+    jsd = jensen_shannon_divergence_pct(observed, solutions)
+    if jsd > JSD_MAX:
+        test.error("JSD %.6f exceeds max %.6f -- distribution is not uniform enough" %
+                   (jsd, JSD_MAX))
+
+    test.passes()

--- a/test_regress/t/t_randomize_reseed_batch.py
+++ b/test_regress/t/t_randomize_reseed_batch.py
@@ -8,10 +8,14 @@
 # SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
 
 import vltest_bootstrap
-import randomize_uniform_common
 
 test.scenarios('simulator')
 
-SOLUTIONS = list(range(1 << 6))  # value < (1 << m_size), m_size set to 6 at run time
+if not test.have_solver:
+    test.skip("No constraint solver installed")
 
-randomize_uniform_common.run(test, SOLUTIONS, r'\d+', key=int)
+test.compile()
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_randomize_reseed_batch.v
+++ b/test_regress/t/t_randomize_reseed_batch.v
@@ -1,0 +1,61 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain.
+// SPDX-FileCopyrightText: 2026 Antmicro
+// SPDX-License-Identifier: CC0-1.0
+
+// Reseeding with srandom() or set_randstate() must make randomize() reproducible
+// regardless of what ran before, so a sampler caching solutions across calls has
+// to drop them on either.
+
+// verilog_format: off
+`define stop $stop
+`define checkd(gotv,expv) do if ((gotv) !== (expv)) begin $write("%%Error: %s:%0d:  got=%0d exp=%0d\n", `__FILE__,`__LINE__, (gotv), (expv)); `stop; end while(0);
+// verilog_format: on
+
+module t;
+  class C;
+    rand bit [7:0] a;
+    constraint c { a < 20; }
+  endclass
+
+  initial begin
+    automatic C used = new;
+    automatic C fresh = new;
+    automatic int ok;
+    // Only difference between the two: `used` has randomized before the reseed
+    repeat (3) begin
+      ok = used.randomize();
+      `checkd(ok, 1);
+    end
+    used.srandom(42);
+    fresh.srandom(42);
+    ok = used.randomize();
+    `checkd(ok, 1);
+    ok = fresh.randomize();
+    `checkd(ok, 1);
+    `checkd(used.a, fresh.a);
+
+    // Same again through get_randstate/set_randstate, which can restore the very
+    // state the object already holds
+    begin
+      automatic C warm = new;
+      automatic C cold = new;
+      automatic string state;
+      repeat (2) begin
+        ok = warm.randomize();
+        `checkd(ok, 1);
+      end
+      state = warm.get_randstate();
+      warm.set_randstate(state);
+      cold.set_randstate(state);
+      ok = warm.randomize();
+      `checkd(ok, 1);
+      ok = cold.randomize();
+      `checkd(ok, 1);
+      `checkd(warm.a, cold.a);
+    end
+    $write("*-* All Finished *-*\n");
+    $finish;
+  end
+endmodule

--- a/test_regress/t/t_randomize_shift_distribution.v
+++ b/test_regress/t/t_randomize_shift_distribution.v
@@ -2,12 +2,17 @@
 //
 // This file ONLY is placed under the Creative Commons Public Domain.
 // SPDX-FileCopyrightText: 2026 PlanV GmbH
+// SPDX-FileCopyrightText: 2026 Antmicro
 // SPDX-License-Identifier: CC0-1.0
+
+// Checks that randomize() over a uvm_reg_field-shaped range whose bound shifts
+// by a member set at run time reaches the whole solution space. Samples are
+// printed so the driver can check uniformity (Jensen-Shannon divergence).
+// Widths too large to enumerate are only checked against the range itself.
 
 // verilog_format: off
 `define stop $stop
 `define checkd(gotv,expv) do if ((gotv) !== (expv)) begin $write("%%Error: %s:%0d:  got=%0d exp=%0d\n", `__FILE__,`__LINE__, (gotv), (expv)); `stop; end while(0);
-`define check_le(gotv,maxv) do if ((gotv) > (maxv)) begin $write("%%Error: %s:%0d:  got=%0d exp<=%0d\n", `__FILE__,`__LINE__, (gotv), (maxv)); `stop; end while(0);
 // verilog_format: on
 
 typedef logic unsigned [63:0] uvm_reg_data_t;
@@ -15,7 +20,6 @@ typedef logic unsigned [63:0] uvm_reg_data_t;
 class uvm_reg_field;
   rand uvm_reg_data_t value;
   int unsigned m_size;
-  int unsigned m_ones[64];
   constraint c_field_valid {
     if (64 > m_size) {
       value < (64'h1 << m_size);
@@ -25,71 +29,48 @@ class uvm_reg_field;
     value = 0;
     m_size = size;
   endfunction
-  function void tally;
-    for (int b = 0; b < 64; b++) if (value[b]) m_ones[b]++;
-  endfunction
-endclass
-
-class regA;
-  rand uvm_reg_field fa1, fa15, fa31, fa32;
-  function new;
-    fa1 = new;
-    fa15 = new;
-    fa31 = new;
-    fa32 = new;
-    fa1.configure(1);
-    fa15.configure(15);
-    fa31.configure(31);
-    fa32.configure(32);
-  endfunction
 endclass
 
 module t;
-  regA r;
-  int unsigned i;
-  // 200 trials over uvm_reg_field-shaped `value < (1<<m_size)`. Each free bit
-  // should be a fair coin flip; the pre-fix bug pinned them near the boundary
-  // K-1 (140-180 ones, 70-90%). Band [70, 130] = [35%, 65%] is ~4.2 sigma off
-  // the fair-50% mean (Binomial(200, 0.5)), so a uniform mechanism passes
-  // ~99.7% per run while the boundary bias overruns the upper bound.
-  localparam int unsigned TRIALS = 200;
-  localparam int unsigned HI = 130;
-  localparam int unsigned LO = 70;
+  localparam int NARROW_SIZE = 6;
+  localparam int NUM_SOLUTIONS = 1 << NARROW_SIZE;
+  localparam int NUM_ITERS = 25 * NUM_SOLUTIONS;
+  localparam int WIDE_ITERS = 100;
 
   initial begin
-    r = new;
-    for (int t = 0; t < TRIALS; t++) begin
-      i = r.randomize();
-      `checkd(i, 1);
-      r.fa1.tally;
-      r.fa15.tally;
-      r.fa31.tally;
-      r.fa32.tally;
+    automatic uvm_reg_field narrow = new;
+    automatic uvm_reg_field wide[4];
+    automatic bit seen[NUM_SOLUTIONS];
+    automatic int distinct = 0;
+    automatic int ok;
+
+    narrow.configure(NARROW_SIZE);
+    foreach (wide[i]) wide[i] = new;
+    wide[0].configure(1);
+    wide[1].configure(15);
+    wide[2].configure(31);
+    wide[3].configure(32);
+
+    for (int i = 0; i < NUM_ITERS; ++i) begin
+      ok = narrow.randomize();
+      `checkd(ok, 1);
+      if (!seen[int'(narrow.value)]) begin
+        seen[int'(narrow.value)] = 1'b1;
+        distinct++;
+      end
+      $display("%0d", narrow.value);
     end
-    // Symmetric 35-65% band per free bit. Master FAILs the upper bound.
-    for (int b = 0; b < 15; b++) `check_le(r.fa15.m_ones[b], HI);
-    for (int b = 0; b < 31; b++) `check_le(r.fa31.m_ones[b], HI);
-    for (int b = 0; b < 32; b++) `check_le(r.fa32.m_ones[b], HI);
-    for (int b = 0; b < 15; b++)
-    if (r.fa15.m_ones[b] < LO) begin
-      $write("%%Error: fa15[%0d] ones=%0d < %0d\n", b, r.fa15.m_ones[b], LO);
-      `stop;
+    `checkd(distinct, NUM_SOLUTIONS);
+
+    // Widths the divergence check cannot enumerate, so only the bound is checked
+    foreach (wide[i]) begin
+      for (int j = 0; j < WIDE_ITERS; ++j) begin
+        ok = wide[i].randomize();
+        `checkd(ok, 1);
+        `checkd(wide[i].value >> wide[i].m_size, 0);
+      end
     end
-    for (int b = 0; b < 31; b++)
-    if (r.fa31.m_ones[b] < LO) begin
-      $write("%%Error: fa31[%0d] ones=%0d < %0d\n", b, r.fa31.m_ones[b], LO);
-      `stop;
-    end
-    for (int b = 0; b < 32; b++)
-    if (r.fa32.m_ones[b] < LO) begin
-      $write("%%Error: fa32[%0d] ones=%0d < %0d\n", b, r.fa32.m_ones[b], LO);
-      `stop;
-    end
-    // High bits beyond m_size must remain 0.
-    for (int b = 1; b < 64; b++) `checkd(r.fa1.m_ones[b], 0);
-    for (int b = 15; b < 64; b++) `checkd(r.fa15.m_ones[b], 0);
-    for (int b = 31; b < 64; b++) `checkd(r.fa31.m_ones[b], 0);
-    for (int b = 32; b < 64; b++) `checkd(r.fa32.m_ones[b], 0);
+
     $write("*-* All Finished *-*\n");
     $finish;
   end

--- a/test_regress/t/t_randomize_solver_pipe.py
+++ b/test_regress/t/t_randomize_solver_pipe.py
@@ -67,4 +67,27 @@ test.file_grep(logfile, r'NPASS=(\d+)', 11)
 test.file_grep_not(logfile, r'Solver failed repeatedly')
 test.file_grep_not(logfile, r'Solver died')
 
+# A reply the unigen2 sampler can't read while it measures the solution space.
+# Falls back to the plain solve, so every randomize still succeeds
+logfile = test.obj_dir + '/sim_ug2_estimate.log'
+test.execute(logfile=logfile,
+             run_env='VERILATOR_SOLVER="' + test.t_dir + '/randomize_solver_tamper.py" ' +
+             'TAMPER=model_trunc TAMPER_AT=8 ')
+test.file_grep(logfile, r'NPASS=(\d+)', 12)
+
+# A value the sampler can't parse, and a status it can't use, seen while it
+# enumerates a cell.
+logfile = test.obj_dir + '/sim_ug2_value.log'
+test.execute(logfile=logfile,
+             run_env='VERILATOR_SOLVER="' + test.t_dir + '/randomize_solver_tamper.py" ' +
+             'TAMPER=bad_base TAMPER_AT=5 ')
+test.file_grep(logfile, r'NPASS=(\d+)', 9)
+
+# A reply naming a variable the sampler didn't ask for.
+logfile = test.obj_dir + '/sim_ug2_var.log'
+test.execute(logfile=logfile,
+             run_env='VERILATOR_SOLVER="' + test.t_dir + '/randomize_solver_tamper.py" ' +
+             'TAMPER=unknown_var TAMPER_AT=10 ')
+test.file_grep(logfile, r'NPASS=(\d+)', 12)
+
 test.passes()

--- a/test_regress/t/t_randomize_uniform_array_mixed.py
+++ b/test_regress/t/t_randomize_uniform_array_mixed.py
@@ -12,6 +12,9 @@ import randomize_uniform_common
 
 test.scenarios('simulator')
 
-SOLUTIONS = list(range(1 << 6))  # value < (1 << m_size), m_size set to 6 at run time
+# (sel, arr[0], arr[1]): sel==1 -> arr[0] > arr[1]; sel==0 -> arr[0] <= arr[1]
+SOLUTIONS = [
+    '%d %d %d' % ((1 if arr0 > arr1 else 0), arr0, arr1) for arr0 in range(8) for arr1 in range(8)
+]
 
-randomize_uniform_common.run(test, SOLUTIONS, r'\d+', key=int)
+randomize_uniform_common.run(test, SOLUTIONS, r'\d+ \d+ \d+')

--- a/test_regress/t/t_randomize_uniform_array_mixed.py
+++ b/test_regress/t/t_randomize_uniform_array_mixed.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import math
+import re
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+if not test.have_solver:
+    test.skip("No constraint solver installed")
+
+test.compile()
+
+test.execute()
+
+# Jensen-Shannon divergence (JSD) measures how far the "shape" of the
+# observed distribution is from perfectly uniform.
+# 0 means identical to uniform; it grows as the observed
+# distribution gets more skewed. Scaled here x100, to notice differences easier
+JSD_MAX = 2.5
+
+
+def jensen_shannon_divergence_pct(observed_counts, solutions):
+    n_obs = sum(observed_counts.values())
+    p = [1.0 / len(solutions) for _ in solutions]  # uniform
+    q = [observed_counts.get(s, 0) / n_obs for s in solutions]  # observed
+    m = [(pi + qi) / 2 for pi, qi in zip(p, q)]
+
+    def kl(a, b):
+        return sum(ai * math.log(ai / bi) for ai, bi in zip(a, b) if ai > 0)
+
+    return (kl(p, m) + kl(q, m)) / 2 * 100
+
+
+# (sel, arr[0], arr[1]): sel==1 -> arr[0] > arr[1]; sel==0 -> arr[0] <= arr[1]
+SOLUTIONS = [
+    '%d %d %d' % ((1 if arr0 > arr1 else 0), arr0, arr1) for arr0 in range(8) for arr1 in range(8)
+]
+
+observed = {}
+with open(test.run_log_filename, 'r', encoding='latin-1') as fh:
+    for line in fh:
+        line = line.strip()
+        if re.fullmatch(r'\d+ \d+ \d+', line):
+            observed[line] = observed.get(line, 0) + 1
+
+jsd = jensen_shannon_divergence_pct(observed, SOLUTIONS)
+if jsd > JSD_MAX:
+    test.error("JSD %.6f exceeds max %.6f -- distribution is not uniform enough" % (jsd, JSD_MAX))
+
+test.passes()

--- a/test_regress/t/t_randomize_uniform_array_mixed.v
+++ b/test_regress/t/t_randomize_uniform_array_mixed.v
@@ -1,0 +1,55 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain.
+// SPDX-FileCopyrightText: 2026 Antmicro
+// SPDX-License-Identifier: CC0-1.0
+
+// Checks that randomize() with an array mixed with a plain scalar in the
+// same class, linked by a conditional constraint, covers the whole solution
+// space, not just a lucky subset of it. Each sample is also printed so the
+// driver can check the distribution's uniformity (Jensen-Shannon divergence)
+// from the samples, not just coverage.
+
+// verilog_format: off
+`define stop $stop
+`define checkd(gotv,expv) do if ((gotv) !== (expv)) begin $write("%%Error: %s:%0d:  got=%0d exp=%0d\n", `__FILE__,`__LINE__, (gotv), (expv)); `stop; end while(0);
+// verilog_format: on
+
+module t;
+  class C;
+    rand bit [2:0] arr[2];
+    rand bit sel;
+    constraint c {
+      if (sel) { arr[0] > arr[1]; }
+      else { arr[0] <= arr[1]; }
+    }
+  endclass
+
+  // Every (arr[0],arr[1]) pair in [0:7]^2 has exactly one sel value that
+  // satisfies the constraint, so all 8*8 pairs are solutions.
+  localparam int NUM_SOLUTIONS = 64;
+  localparam int NUM_ITERS = 25 * NUM_SOLUTIONS;
+
+  initial begin
+    automatic C c = new;
+    automatic int seen[int];
+    automatic int distinct = 0;
+    automatic int key;
+    automatic int ok;
+    for (int i = 0; i < NUM_ITERS; ++i) begin
+      ok = c.randomize();
+      `checkd(ok, 1);
+      // Exactly one ordering holds for each sel value
+      `checkd(c.sel, bit'(c.arr[0] > c.arr[1]));
+      key = int'({c.sel, c.arr[0], c.arr[1]});  // 7-bit packed key, fits in int
+      if (!seen.exists(key)) begin
+        seen[key] = 1;
+        distinct++;
+      end
+      $display("%0d %0d %0d", c.sel, c.arr[0], c.arr[1]);
+    end
+    `checkd(distinct, NUM_SOLUTIONS);
+    $write("*-* All Finished *-*\n");
+    $finish;
+  end
+endmodule

--- a/test_regress/t/t_randomize_uniform_bitcount.py
+++ b/test_regress/t/t_randomize_uniform_bitcount.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import math
+import re
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+if not test.have_solver:
+    test.skip("No constraint solver installed")
+
+test.compile()
+
+test.execute()
+
+# Jensen-Shannon divergence (JSD) measures how far the "shape" of the
+# observed distribution is from perfectly uniform.
+# 0 means identical to uniform; it grows as the observed
+# distribution gets more skewed. Scaled here x100, to notice differences easier
+JSD_MAX = 2.5
+
+
+def jensen_shannon_divergence_pct(observed_counts, solutions):
+    n_obs = sum(observed_counts.values())
+    p = [1.0 / len(solutions) for _ in solutions]  # uniform
+    q = [observed_counts.get(s, 0) / n_obs for s in solutions]  # observed
+    m = [(pi + qi) / 2 for pi, qi in zip(p, q)]
+
+    def kl(a, b):
+        return sum(ai * math.log(ai / bi) for ai, bi in zip(a, b) if ai > 0)
+
+    return (kl(p, m) + kl(q, m)) / 2 * 100
+
+
+SOLUTIONS = [i for i in range(256) if bin(i).count('1') == 4]  # C(8,4) = 70
+
+observed = {}
+with open(test.run_log_filename, 'r', encoding='latin-1') as fh:
+    for line in fh:
+        line = line.strip()
+        if re.fullmatch(r'\d+', line):
+            value = int(line)
+            observed[value] = observed.get(value, 0) + 1
+
+jsd = jensen_shannon_divergence_pct(observed, SOLUTIONS)
+if jsd > JSD_MAX:
+    test.error("JSD %.6f exceeds max %.6f -- distribution is not uniform enough" % (jsd, JSD_MAX))
+
+test.passes()

--- a/test_regress/t/t_randomize_uniform_bitcount.py
+++ b/test_regress/t/t_randomize_uniform_bitcount.py
@@ -12,6 +12,6 @@ import randomize_uniform_common
 
 test.scenarios('simulator')
 
-SOLUTIONS = list(range(1 << 6))  # value < (1 << m_size), m_size set to 6 at run time
+SOLUTIONS = [i for i in range(256) if bin(i).count('1') == 4]  # C(8,4) = 70
 
 randomize_uniform_common.run(test, SOLUTIONS, r'\d+', key=int)

--- a/test_regress/t/t_randomize_uniform_bitcount.v
+++ b/test_regress/t/t_randomize_uniform_bitcount.v
@@ -1,0 +1,46 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain.
+// SPDX-FileCopyrightText: 2026 Antmicro
+// SPDX-License-Identifier: CC0-1.0
+
+// Checks that randomize() with a non-trivial scalar constraint (exactly N
+// set bits, a non-contiguous solution set scattered across the domain)
+// covers the whole solution space, not just a lucky subset of it. Each
+// sample is also printed so the driver can check the distribution's
+// uniformity (Jensen-Shannon divergence) from the samples, not just coverage.
+
+// verilog_format: off
+`define stop $stop
+`define checkd(gotv,expv) do if ((gotv) !== (expv)) begin $write("%%Error: %s:%0d:  got=%0d exp=%0d\n", `__FILE__,`__LINE__, (gotv), (expv)); `stop; end while(0);
+// verilog_format: on
+
+module t;
+  class C;
+    rand bit [7:0] x;
+    constraint c { $countones(x) == 4; }
+  endclass
+
+  localparam int NUM_SOLUTIONS = 70;  // C(8,4)
+  localparam int NUM_ITERS = 25 * NUM_SOLUTIONS;
+
+  initial begin
+    automatic C c = new;
+    automatic bit seen[256];
+    automatic int distinct = 0;
+    automatic int ok;
+    for (int i = 0; i < NUM_ITERS; ++i) begin
+      ok = c.randomize();
+      `checkd(ok, 1);
+      `checkd($countones(c.x), 4);
+      if (!seen[c.x]) begin
+        seen[c.x] = 1'b1;
+        distinct++;
+      end
+      $display("%0d", c.x);
+    end
+    `checkd(distinct, NUM_SOLUTIONS);
+    $write("*-* All Finished *-*\n");
+    $finish;
+  end
+endmodule

--- a/test_regress/t/t_randomize_uniform_bitcount.v
+++ b/test_regress/t/t_randomize_uniform_bitcount.v
@@ -1,0 +1,52 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain.
+// SPDX-FileCopyrightText: 2026 Antmicro
+// SPDX-License-Identifier: CC0-1.0
+
+// Checks that randomize() with a non-trivial scalar constraint (exactly N
+// set bits, a non-contiguous solution set scattered across the domain)
+// reaches nearly all of the solution space, not just a lucky subset of it. Each
+// sample is also printed so the driver can check the distribution's
+// uniformity (Jensen-Shannon divergence) from the samples, not just coverage.
+
+// verilog_format: off
+`define stop $stop
+`define checkd(gotv,expv) do if ((gotv) !== (expv)) begin $write("%%Error: %s:%0d:  got=%0d exp=%0d\n", `__FILE__,`__LINE__, (gotv), (expv)); `stop; end while(0);
+`define check_range(gotv,minv,maxv) do if ((gotv) < (minv) || (gotv) > (maxv)) begin $write("%%Error: %s:%0d:  got=%0d exp=[%0d:%0d]\n", `__FILE__,`__LINE__, (gotv), (minv), (maxv)); `stop; end while(0);
+// verilog_format: on
+
+module t;
+  class C;
+    rand bit [7:0] x;
+    constraint c { $countones(x) == 4; }
+  endclass
+
+  localparam int NUM_SOLUTIONS = 70;  // C(8,4)
+  localparam int NUM_ITERS = 25 * NUM_SOLUTIONS;
+
+  localparam int MIN_COVERAGE_PCT = 90;
+  localparam int MAX_COVERAGE_PCT = 100;
+  localparam int MIN_DISTINCT = (NUM_SOLUTIONS * MIN_COVERAGE_PCT) / 100;
+  localparam int MAX_DISTINCT = (NUM_SOLUTIONS * MAX_COVERAGE_PCT) / 100;
+
+  initial begin
+    automatic C c = new;
+    automatic bit seen[256];
+    automatic int distinct = 0;
+    automatic int ok;
+    for (int i = 0; i < NUM_ITERS; ++i) begin
+      ok = c.randomize();
+      `checkd(ok, 1);
+      `checkd($countones(c.x), 4);
+      if (!seen[c.x]) begin
+        seen[c.x] = 1'b1;
+        distinct++;
+      end
+      $display("%0d", c.x);
+    end
+    `check_range(distinct, MIN_DISTINCT, MAX_DISTINCT);
+    $write("*-* All Finished *-*\n");
+    $finish;
+  end
+endmodule


### PR DESCRIPTION
Fixes #8024.

## Problem

Verilator's current `randomize()` sampler (static 4-round XOR hashing for arrays, and "bit-pinning" for scalar vars) can produce visibly skewed distributions and provide lower coverage of the solution space. This matters for constrained-random verification, where a skewed sampler might under-exercise a DUT behavior.

## Solution

Implemented UniGen2 - a near-uniform sampling algorithm based on [this paper](https://link.springer.com/chapter/10.1007/978-3-662-46681-0_25). PDF is available [here](https://people.ucsc.edu/~dfremont/papers/Tacas15.pdf).

In short, the idea is as follows: instead of asking the solver for a fresh solution on every `randomize()` call, UniGen2 narrows the full solution space down to a small random subset of it - and then returns solutions from that subset one by one. Building that subset costs several solver calls, but it happens once per batch, so most `randomize()` calls are answered without touching the solver at all. This increases the simulation speed. The "near-uniformity" comes from how that subset is picked: the hash used to carve it out is drawn at random, so it cannot favour any particular solution. Section 5 of the paper states the guarantee this yields.

Two terms are used throughout this writeup:

* **Solution space** - the set of all value combinations the rand variables can take that satisfy the constraints. For `rand bit [7:0] x` with `constraint c { $countones(x) == 4; }`, the solution space is the 70 values of `x` that have exactly four bits set.
* **Cell** - a randomly selected subset of the solution space.


### The algorithm in more details:

1. **Cut the solution space into a correctly sized cell.** This is the expensive, one-time part, done by `EstimateParameters`.

    **1.1. Why we want such a cell.** The whole algorithm rests on one fact: a randomly picked cell of the right size is a near-uniform random subset of the entire solution space. To satisfy the mathematical theorems of the algorithm's uniformity, the cell has to be fine-sized. A cell that is too big cannot be enumerated affordably; one that is too small cannot supply a whole batch of samples. `loThresh` and `hiThresh` fix the acceptable size range: at least `loThresh` solutions, fewer than `hiThresh`. Both come from the accuracy parameter `epsilon`, which the implementation fixes at 16 (the paper's suggested default). That yields `loThresh = 11` and `hiThresh = 64`, so a cell is "the right size" when it holds between 11 and 63 solutions. `loThresh` is also how many samples are taken from the cell.

    **1.2. Cells are made with XOR equations.** `i` random XOR equations are asserted over the bits of the rand variables - each equation says "the XOR of this random subset of bits must equal this random 0 or 1". A random XOR equation is satisfied by about half of the solutions, so `i` of them split the space into `2^i` groups, called cells, each holding roughly `1/2^i` of the solutions. Two things are drawn at random here: which bits each equation covers, and the 0 or 1 it is compared against. So the equations do two jobs at once - they define the cells, and they single out one particular cell, the one whose solutions satisfy them. Because the draw is random, so is the cell, and no value or bit pattern should be preferred.

    **1.3. Finding how many XOR equations are needed.** The number of equations `i` is what controls the cell size, but to find the right `i` we have to count how many solutions there are in one cell. So `EstimateParameters` simply tries `i = 1, 2, 3, ...` up to a cap, drawing a fresh cell for each `i` and counting how many solutions it holds. The cap is the smaller of 10 and the total bit width of the rand variables, since more equations than there are bits cannot narrow anything further. The counting is done by `BSAT`: ask the solver for a solution, add a blocking clause forbidding returning the same solution, ask again, and repeat - so every answer is guaranteed to be a new one. Its loop stops when the cell runs out of solutions, or when the cap of 61 (fixed value from the paper, backed by math) is reached, meaning the cell is still too big to enumerate. The first `i` whose cell is small enough to enumerate is cached as `hashBits`, so this search runs once rather than once per call. Next `randomize()` calls will utilize the obtained `hashBits` value, which tells us how many XOR equations we need to have to obtain a fine-sized cell. The cell isn't cached - it is always drawn a new in the next steps.
    
    A solution space small enough to enumerate outright skips all of this. If the whole space holds 60 solutions or fewer, there is nothing worth cutting: `hashBits` is 0, no XOR equations are asserted at all, and the batch is the entire solution space. Every solution is then handed out exactly once per batch.

    If the `EstimateParameters` search runs all the way to the upper limit (which is a `ug2HashBitsLargeSpace`, equal to 10) without ever finding a countable cell, the space is too large to hash within that many bits. The cap was empirically determined, because past that the solver slows down faster than the search can pay for itself. In such situation, UniGen2 keeps the hash count fixed at 10 and uses whatever cell that produces, oversized as it is.

    Sampling from that oversized cell works like this: `BSAT` lists the first 16 solutions it finds there, and all 16 become the batch. Nothing is thrown away, so this path spends one solver query per delivered sample.

    `BSAT` needs one extra step on this path. A cell of for example millions of solutions is only ever sampled 16 deep, and blocking clauses alone turned out too weak at that depth: whole batches came back with a tightly constrained variable stuck on a single value. So on this path `BSAT` also names one randomly picked element that has to differ from the previous solution. It is passed as an assumption rather than an assertion, so it binds that one query and leaves the listed set otherwise unchanged.

    Note that this path is outside the paper's algorithm and its near-uniformity guarantee - it was designed and validated empirically. The paper's implementation uses CryptoMiniSAT, chosen, in the authors' words, "to handle CNF-SAT augmented with XORs efficiently". Z3 does not appear to have comparable native XOR reasoning, so it cannot afford nearly as many hash equations without a large slowdown.

2.  **Reuse that `hashBits`, then take samples from a freshly drawn cell.** This is the cheap, repeated part, done by `GenerateSamples`. Later calls skip the search entirely: draw a new cell using `hashBits` equations and check it came out the right size, i.e. holding between `loThresh` and `hiThresh` solutions. If that particular draw misses, the neighbouring counts `hashBits - 1` and `hashBits - 2` are tried, each with its own fresh draw. (Only the order in which the three are tried gets adjusted - starting with whichever worked last time - which the paper notes is free to choose and therefore costs no guarantees.) If all three miss, UniGen2 declines this call and the existing sampler (bit-pinning/4 XORs) answers it. That is expected to happen from time to time - the paper bounds the chance of all three draws missing at 0.38 (Theorem 1 in Section 5 of the paper). However, in practice, I've never met such a situation while conducting experiments.

    A correctly sized cell is a near-uniform random subset of the whole solution space, so `loThresh = 11` solutions are drawn from it and kept as a batch, and the following 11 `randomize()` calls are answered from that batch without touching the solver at all. The batch size is 11 only on this path: a space small enough to enumerate outright gives a batch of the whole space, and a space too large to hash gives 16.

    Those 11 are picked with a partial Fisher-Yates shuffle: pick one of the not-yet-picked solutions at random, set it aside, and repeat 11 times. This keeps the picks distinct and gives every solution in the cell the same chance of being chosen. On the large space path the batch is everything that was listed, so the same shuffle only decides the order they are handed out in.

The paper splits this into two routines, both in Section 4 (pseudocode in "Algorithm 1" and "Algorithm 2"):

* `EstimateParameters` (Algorithm 1) - one-time preprocessing that computes `hashBits`, `loThresh` and `hiThresh` for a given formula. It is the expensive part.
* `GenerateSamples` (Algorithm 2) - picks a cell using those parameters and returns `loThresh` samples from it.

The implementation follows the same split: `estimateParameters()` runs once per constraint set and its result is cached, then each `randomize()` call is served from the batch that `generateSamples()` produced, so the solver is only consulted once per batch rather than once per call.

---

UniGen2 is used for plain `rand` variables - scalars and arrays alike, including 2-D arrays, queues and associative arrays. It is deliberately not used where its setup cost could never be repaid or where it would sample the wrong thing, and in all of these cases the code falls back to the existing sampler with no behavioural change:

* `randc` variables, whose exclusion set changes on every call;
* `solve ... before ...`, where earlier layers are pinned per call;
* `rand_mode(0)`-frozen variables, whose value is baked into the constraint text while the variable stays declared and unconstrained;
* soft constraints, where the set of satisfiable constraints (and therefore the solution space itself) is only decided during relaxation;
* the first `randomize()` call for a given constraint set. The parameter search only pays for itself once its result is reused, so that call is handed to the existing sampler and the UniGen2's search runs on the next one. The same applies whenever the constraint set changes, since that invalidates the cached parameters;
* a call where none of the three hash counts produced a cell of a usable size;
* `randomize(null)`, which only checks whether the constraints are satisfiable and must not assign anything;


## Results

Prepared many benchmarks to compare the two samplers (Unigen2 and current master), and ran them at 3 different sampling budgets (1x/5x/25x the solution-space size).
Link to the benchmarks: https://github.com/antmicro/verilator/tree/jwas/101898-unigen2-benchmarks/distribution_benchmarks

Run `distribution_benchmarks/scripts/run_all.py` to run every benchmark (optionally with an iteration count, e.g. `run_all.py 5000`), or run a single one with `scripts/run_distr_<name>.py`; the benchmark code itself lives in `distribution_benchmarks/input/` as `.sv` files, each with a header comment explaining what it measures and why.

Three representative cases are shown below in tables - a scalar constraint with a scattered solution set, a real-world OpenTitan inspired constraint that master handles
worst, and a large array. **Full results for all 23 (+3 large) benchmarks at all three budgets are in the attached [benchmark-results.md](https://github.com/user-attachments/files/31034427/benchmark-results.md).**

`distr_countones` benchmark: a single `rand bit [7:0] x` constrained by `$countones(x) == 4`, so exactly 70 of the 256 values are legal and they are scattered non-contiguously across the domain. It shows whether a sampler favours bit patterns clustered at low positions over spread-out ones.

`distr_ot_aon_wkup`: adapted from OpenTitan's `aon_timer` testbench (widths reduced so the space stays enumerable). A `thold inside {0, [5:171]}` and a `count` tied to it - `thold == 0` forces `count == 0`, otherwise `count inside {[thold-5:thold]}`. That gives 1003 solutions, but they are distributed very unevenly across the branches: `thold == 0` contributes a single solution while each of the other 167 values contributes 6. It shows whether a sampler can reach a thin branch.

`distr_array_many_elem`: `rand bit [2:0] arr[6]` with `arr[i] < 5` on every element, so the elements are independent but there are 5^6 = 15625 solutions. Each element becomes its own solver variable, so it shows how the samplers scale as the element count and the solution space grow.

**Benchmarks use few representative metrics**:

* Coverage - measured as the fraction of the solution space that is covered by the samples, Higher is better.
* JSD (Jensen-Shannon divergence) - a measure of how close the sample distribution is to the uniform distribution [JSD explained](https://en.wikipedia.org/wiki/Jensen%E2%80%93Shannon_divergence). Lower is better.
* SIMtime - simulation wall time, `unigen2 / master`. Lower is better.


The numbers below were produced on a single machine, so the absolute times depend on that hardware. Each configuration was run many times in the same environment, so the *proportions* between master and UniGen2 are stable and should reproduce anywhere.

Two of these benchmarks were also turned into regression tests included in this PR: `distr_countones` became `t_randomize_uniform_bitcount`, and `distr_array_mixed` became `t_randomize_uniform_array_mixed`. Both assert full coverage of the solution space and a JSD below a fixed threshold, so a future change that degrades uniformity will fail CI.

#### 1x solution-space size
| Test case | JSD `unigen2` | JSD `master` | Coverage `unigen2` | Coverage `master` | SIMtime (unigen2/master) |
|---|---|---|---|---|---|
| distr_countones | 13.469836 | 22.879944 | 49/70 (70.00%) | 38/70 (54.29%) | 0.1s / 0.3s |
| distr_ot_aon_wkup | 17.121046 | 41.200513 | 631/1003 (62.91%) | 299/1003 (29.81%) | 1.4s / 7.7s |
| distr_array_many_elem | 16.929089 | 27.826080 | 9882/15625 (63.24%) | 7228/15625 (46.26%) | 11.3s / 27.1s |

#### 25x solution-space size
| Test case | JSD `unigen2` | JSD `master` | Coverage `unigen2` | Coverage `master` | SIMtime (unigen2/master) |
|---|---|---|---|---|---|
| distr_countones | 0.494831 | 5.532289 | 70/70 (100.00%) | 70/70 (100.00%) | 0.8s / 3.4s |
| distr_ot_aon_wkup | 0.505339 | 29.794127 | 1003/1003 (100.00%) | 926/1003 (92.32%) | 28.9s / 103.6s |
| distr_array_many_elem | 0.497102 | 13.934501 | 15625/15625 (100.00%) | 15415/15625 (98.66%) | 288.5s / 808.2s |

#### Distribution plots

Frequency of each solution over a run, for `distr_array_many_elem`:

##### Master
<img width="614" height="461" alt="verilatormaster_distr_array_many_elem_frequency" src="https://github.com/user-attachments/assets/150cc619-4f36-45de-a5bd-eb6f9e8f973c" />

##### UniGen2
<img width="614" height="461" alt="unigen2_distr_array_many_elem_frequency" src="https://github.com/user-attachments/assets/802b74e7-eec7-451b-bade-1adc6e6bf883" />

##### UniGen2 zoomed in
<img width="614" height="461" alt="unigen2_zoomed_distr_array_many_elem_frequency" src="https://github.com/user-attachments/assets/212f0bc8-4284-4e5a-bab1-e52a792a9dc7" />


#### Summary of results

In short: UniGen2 wins on essentially every benchmark, at every budget, on every metric. The three benchmarks above are representative. The same pattern holds across all 69 measurements in [benchmark-results.md](https://github.com/user-attachments/files/31034427/benchmark-results.md).

The gap widens as the constraint gets less trivial. On a plain range (`distr_range_1000`, in the attached file) the two samplers are close. On shaped or bitwise constraints the difference is large, as the table above shows. At 25x UniGen2 reaches full coverage on every one of the 23 benchmarks, while master still misses on four scalar and four array ones, and its JSD stays one to three orders of magnitude higher.

## Other changes

* Dropped the regression test `t_randomize_shift_distribution`.

  * At lines [50:54](https://github.com/verilator/verilator/blob/master/test_regress/t/t_randomize_shift_distribution.v#L50-L54), this test claims that "each free bit should be a fair coin flip". I haven't found such a claim in the IEEE, so it looks like we're defending something unnecessary. What we should actually care about is uniformity, as this is explicitly required by the IEEE, e.g.: Chapter 18.4.1, Rand modifier: "Variables declared with the rand keyword are standard random variables. Their values are uniformly distributed over their range".

    Instead, I think it would be more beneficial to use the tests proposed by me, which actually verify the uniformity: `t_randomize_uniform_bitcount` and `t_randomize_uniform_array_mixed`.

    Moreover, while doing research on constrained randomization, I came across different randomization samplers using different algorithms, many of which are not compliant with the "each free bit should be a fair coin flip" assumption. For example, [SMTSampler](https://people.eecs.berkeley.edu/~ksen/papers/smtsampler.pdf).

---

## TO-DO in a future work:
* Parallelize the sampling algorithm to improve performance (currently single-threaded). The paper describes this in Section 4 ("Parallelization of UniGen2"). This change will be particularly beneficial for problems having a large solution space.
* The fixed-XOR path for large spaces might be tuned, this would require more experiments or better ideas
* Sample around `rand_mode(0)`-frozen variables instead of disabling UniGen2 for the whole object. A frozen var has its value baked into the constraint text but is still declared as a free solver variable, which blows up the solution space; handling it needs pinning each frozen var to its concrete value and skipping its bits in `unigenXors`.