### PR TITLE
Fix write access to dynamic arrays

### DIFF
--- a/src/V3AstNodes.cpp
+++ b/src/V3AstNodes.cpp
@@ -1417,6 +1417,9 @@ AstNode* AstArraySel::baseFromp(AstNode* nodep, bool overMembers) {
         } else if (VN_IS(nodep, WildcardSel)) {
             nodep = VN_AS(nodep, WildcardSel)->fromp();
             continue;
+        } else if (VN_IS(nodep, CMethodHard)) {
+            nodep = VN_AS(nodep, CMethodHard)->fromp();
+            continue;
         } else if (overMembers && VN_IS(nodep, MemberSel)) {
             nodep = VN_AS(nodep, MemberSel)->fromp();
             continue;

--- a/test_regress/t/t_dynarray_select.py
+++ b/test_regress/t/t_dynarray_select.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile()
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_dynarray_select.v
+++ b/test_regress/t/t_dynarray_select.v
@@ -1,0 +1,30 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This program is free software; you can redistribute it and/or modify it
+// under the terms of either the GNU Lesser General Public License Version 3
+// or the Perl Artistic License Version 2.0.
+// SPDX-FileCopyrightText: 2026 Antmicro
+// SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+// verilog_format: off
+`define stop $stop
+`define checkh(gotv,expv) do if ((gotv) !== (expv)) begin $write("%%Error: %s:%0d:  got='h%x exp='h%x\n", `__FILE__,`__LINE__, (gotv), (expv)); `stop; end while(0)
+// verilog_format: on
+
+class num_gen;
+  function int get_num(int x);
+    return x;
+  endfunction
+endclass
+
+module t;
+  num_gen gen;
+  bit [4:0] arr[];
+  initial begin
+    gen = new;
+    arr = new[1];
+    arr[0][gen.get_num(3)] = 1'b1;
+    `checkh(arr[0][3],1'b1);
+    $finish;
+  end
+endmodule


### PR DESCRIPTION
It fixes C++ compilation error related to `AstArraySel::baseFromp()` not being able to extract base node from `AstCMethodHard`. This later led to the base expression being classified as a non-lvalue in `V3Unknown::visit(AstSel*)` and C++ compilation error `error: lvalue required as left operand of assignment`