### PR TITLE
[Nondeterminism] Resolved verilator nondeterminism causing generated C++ files to vary

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -294,6 +294,7 @@ Stuart Morris
 sumpster
 Szymon Gizler
 Sören Tempel
+Sumanth Kadiyala
 Teng Huang
 Thomas Aldrian
 Thomas Brown

--- a/src/V3Trace.cpp
+++ b/src/V3Trace.cpp
@@ -1146,8 +1146,8 @@ class TraceVisitor final : public VNVisitor {
     }
 
     TraceCFuncVertex* getCFuncVertexp(AstCFunc* nodep) {
-        TraceCFuncVertex* vertexp
-            = nodep->user1() ? nodep->user1u().toGraphVertex()->cast<TraceCFuncVertex>() : nullptr;
+        V3GraphVertex* const vtxp = nodep->user1u().toGraphVertex();
+        TraceCFuncVertex* vertexp = vtxp ? vtxp->cast<TraceCFuncVertex>() : nullptr;
         if (!vertexp) {
             vertexp = new TraceCFuncVertex{&m_graph, nodep};
             nodep->user1p(vertexp);
@@ -1155,9 +1155,8 @@ class TraceVisitor final : public VNVisitor {
         return vertexp;
     }
     TraceActivityVertex* getActivityVertexp(AstNode* nodep, bool slow) {
-        TraceActivityVertex* vertexp
-            = nodep->user3() ? nodep->user3u().toGraphVertex()->cast<TraceActivityVertex>()
-                             : nullptr;
+        V3GraphVertex* const vtxp = nodep->user3u().toGraphVertex();
+        TraceActivityVertex* vertexp = vtxp ? vtxp->cast<TraceActivityVertex>() : nullptr;
         if (!vertexp) {
             vertexp = new TraceActivityVertex{&m_graph, nodep, slow};
             nodep->user3p(vertexp);


### PR DESCRIPTION
There was an issue causing nondeterminism in the generated C++ files. It was caused by the `getCFuncVertexp` in `V3Trace.cpp`. The function utilized `nodep->user1()` to guard memoized `TraceCFuncVertex*` pointers created for `AstCFunc*` objects. If the `TraceCFuncVertex*` pointer was pointing at an address location that was 4 GiB aligned, `nodep->user1()` would return 0 even though a valid pointer exists. This would cause a trace signal and/or activitiy signal to get dropped during graph construction and thus alter the files. 

This change removes the reliance of `V3Trace.cpp` on `nodep->user1()` in `getCFuncVertexp`. It similarly removes the `nodep->user3()` dependency in `getActivityVertexp`, which is in the same file. While this does resolve the issues in `V3Trace.cpp`, the `user1()`, `user2()`, `user3()`, and `user4()` functions are used throughout the codebase, which could potentially cause similar issues elsewhere. 

Fixes #8045 