### PR TITLE
Fixes internal fault on pin to non-existent port with PINNOTFOUND suppressed (#8051)

### DIFF
--- a/src/V3LinkDot.cpp
+++ b/src/V3LinkDot.cpp
@@ -3923,6 +3923,7 @@ class LinkDotResolveVisitor final : public VNVisitor {
                                       << (suggest.empty() ? "" : nodep->warnMore() + suggest)
                                       << '\n'
                                       << nodep->warnContextPrimary() << decl);
+                    VL_DO_DANGLING(pushDeletep(nodep->unlinkFrBack()), nodep);
                     return;
                 }
             }

--- a/test_regress/t/t_lint_pinnotfound_deparam.py
+++ b/test_regress/t/t_lint_pinnotfound_deparam.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('vlt')
+
+test.lint()
+
+test.passes()

--- a/test_regress/t/t_lint_pinnotfound_deparam.v
+++ b/test_regress/t/t_lint_pinnotfound_deparam.v
@@ -1,0 +1,16 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain.
+// SPDX-FileCopyrightText: 2026 Nikolai Kumar
+// SPDX-License-Identifier: CC0-1.0
+
+/* verilator lint_off PINNOTFOUND */
+
+module child ();
+endmodule
+
+module t;
+  child u_child (
+    .missing_port (1'b0)
+  );
+endmodule


### PR DESCRIPTION
Fixes #8051.

Dropping the pin at the warning site means no subsequent pass will see the invalid pin.

Does not change any behavior when the warning is unsuppressed. 

Adds t_lint_pinnotfound_deparam, a lint test that internal faults before the change.
