### PR TITLE
Fix parameter array sized by another parameter (#5890)

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -351,3 +351,4 @@ Zixi Li
 Zubin Jain
 Àlex Torregrosa
 Ícaro Lima
+Øyvind Janbu

--- a/src/V3Param.cpp
+++ b/src/V3Param.cpp
@@ -1467,9 +1467,8 @@ class ParamProcessor final {
                         break;
                     }
                 }
-                AstNodeDType* const substp = overridePinp
-                                                 ? VN_CAST(overridePinp->exprp(), NodeDType)
-                                                 : ptdp->subDTypep();
+                AstNodeDType* const substp
+                    = overridePinp ? VN_CAST(overridePinp->exprp(), NodeDType) : ptdp->subDTypep();
                 if (substp) toReplace.emplace_back(refp, substp);
             });
             for (auto rit = toReplace.rbegin(); rit != toReplace.rend(); ++rit) {

--- a/src/V3Param.cpp
+++ b/src/V3Param.cpp
@@ -1415,6 +1415,121 @@ class ParamProcessor final {
         }
     }
 
+    // Substitute references to this instantiation's parameters inside a detached
+    // clone, so widthing the clone does not reach into the not-yet-specialized
+    // template (#7411).  A reference is replaced by this cell's pin override, or
+    // by the parameter's own default when the pin list doesn't override it.
+    // With constPinsOnly, an override that isn't a constant yet is ignored (the
+    // default is used); otherwise the pin's expression is inlined as-is, to be
+    // constified by the caller's widthing.
+    // The root itself may be a reference to substitute (e.g. a port whose whole
+    // type is a type parameter), so follow it as it is replaced.  The caller
+    // must re-read the root from its parent, as rootp may be stale on return.
+    void substituteParamRefs(AstNode* rootp, AstPin* paramsp, bool constPinsOnly) {
+        constexpr int maxSubstIters = 1000;
+        for (int it = 0; it < maxSubstIters; ++it) {
+            bool any = false;
+            rootp->foreach([&](AstVarRef* varrefp) {
+                AstVar* const targetp = varrefp->varp();
+                AstNode* replacep = nullptr;
+                for (AstPin* pp = paramsp; pp; pp = VN_AS(pp->nextp(), Pin)) {
+                    if (pp->modVarp() == targetp) {
+                        if (AstConst* const constp = VN_CAST(pp->exprp(), Const)) {
+                            replacep = constp->cloneTree(false);
+                        } else if (!constPinsOnly && VN_IS(pp->exprp(), NodeExpr)) {
+                            replacep = pp->exprp()->cloneTree(false);
+                        }
+                        break;
+                    }
+                }
+                if (!replacep && targetp->valuep()) {
+                    replacep = targetp->valuep()->cloneTree(false);
+                }
+                if (replacep) {
+                    if (varrefp == rootp) rootp = replacep;
+                    varrefp->replaceWith(replacep);
+                    VL_DO_DANGLING(varrefp->deleteTree(), varrefp);
+                    any = true;
+                }
+            });
+            // Replace RefDType to a ParamTypeDType with pin override
+            // or the paramtype's default so constify below does not
+            // reach into the template.  Collect then replace in
+            // reverse so descendants aren't freed early.
+            std::vector<std::pair<AstRefDType*, AstNodeDType*>> toReplace;
+            rootp->foreach([&](AstRefDType* refp) {
+                AstParamTypeDType* const ptdp = VN_CAST(refp->refDTypep(), ParamTypeDType);
+                if (!ptdp) return;
+                AstPin* overridePinp = nullptr;
+                for (AstPin* pp = paramsp; pp; pp = VN_AS(pp->nextp(), Pin)) {
+                    if (pp->modPTypep() == ptdp) {
+                        overridePinp = pp;
+                        break;
+                    }
+                }
+                AstNodeDType* const substp = overridePinp
+                                                 ? VN_CAST(overridePinp->exprp(), NodeDType)
+                                                 : ptdp->subDTypep();
+                if (substp) toReplace.emplace_back(refp, substp);
+            });
+            for (auto rit = toReplace.rbegin(); rit != toReplace.rend(); ++rit) {
+                AstRefDType* const refp = rit->first;
+                AstNodeDType* const newp = rit->second->cloneTree(false);
+                if (refp == rootp) rootp = newp;
+                refp->replaceWith(newp);
+                VL_DO_DANGLING(refp->deleteTree(), refp);
+                any = true;
+            }
+            if (!any) break;
+        }
+    }
+
+    // An assignment pattern passed as a parameter pin value gets widthed against
+    // the port's declared type while the module is still the unspecialized
+    // template (constifyParamsEdit on the cell reaches V3Width's AstPin visitor).
+    // When that type depends on other parameters of the same instantiation, e.g.
+    //     module M #(parameter int N = 1, parameter int V[N]);
+    //     M #(.N(2), .V('{1, 2})) u ();
+    // the template's defaults would size the pattern (N=1 here), so the pattern
+    // is rejected as having too many elements.  Give the pattern its own copy of
+    // the port type with this instantiation's overrides substituted in; V3Width's
+    // AstPattern visitor prefers that over the port's type.
+    void resolvePatternPinDTypes(AstPin* paramsp) {
+        for (AstPin* pinp = paramsp; pinp; pinp = VN_AS(pinp->nextp(), Pin)) {
+            AstPattern* const patternp = VN_CAST(pinp->exprp(), Pattern);
+            if (!patternp || patternp->childDTypep()) continue;  // No pattern, or data_type '{}
+            AstVar* const modvarp = pinp->modVarp();
+            if (!modvarp || !modvarp->isGParam()) continue;
+            AstNodeDType* const portDTypep = modvarp->childDTypep();
+            if (!portDTypep) continue;
+            // Types that don't depend on parameters width correctly against the
+            // port itself, so leave those to the pre-existing path.  Both value
+            // parameters (int V[N]) and type parameters (T V[$bits(T)]) can size
+            // the port, so look for either kind of reference.
+            bool paramDependent = false;
+            portDTypep->foreach([&](AstVarRef*) { paramDependent = true; });
+            portDTypep->foreach([&](AstRefDType* refp) {
+                if (VN_IS(refp->refDTypep(), ParamTypeDType)) paramDependent = true;
+            });
+            if (!paramDependent) continue;
+            // Attach before substituting so the substitution root has a back pointer
+            patternp->childDTypep(portDTypep->cloneTree(false));
+            substituteParamRefs(patternp->childDTypep(), paramsp, false);
+            bool resolved = true;
+            patternp->childDTypep()->foreach([&](AstVarRef*) { resolved = false; });
+            patternp->childDTypep()->foreach([&](AstRefDType* refp) {
+                if (VN_IS(refp->refDTypep(), ParamTypeDType)) resolved = false;
+            });
+            if (!resolved) {
+                UINFO(5, "  resolvePatternPinDTypes: unresolved port type, pin="
+                             << pinp->prettyNameQ());
+                AstNodeDType* const unresolvedp = patternp->childDTypep();
+                unresolvedp->unlinkFrBack();
+                VL_DO_DANGLING(unresolvedp->deleteTree(), unresolvedp);
+            }
+        }
+    }
+
     void cellPinCleanup(AstNode* nodep, AstPin* pinp, AstPin* paramsp, AstNodeModule* srcModp,
                         string& longnamer, bool& any_overridesr) {
         if (!pinp->exprp()) return;  // No-connect
@@ -1474,58 +1589,7 @@ class ParamProcessor final {
                         cloneVarp->childDTypep(origDTypep->cloneTree(false));
                         cloneVarp->dtypep(nullptr);
                         // Inline param refs so widthing doesn't touch the template (#7411).
-                        constexpr int maxSubstIters = 1000;
-                        for (int it = 0; it < maxSubstIters; ++it) {
-                            bool any = false;
-                            cloneVarp->foreach([&](AstVarRef* varrefp) {
-                                AstVar* const targetp = varrefp->varp();
-                                AstNode* replacep = nullptr;
-                                for (AstPin* pp = paramsp; pp; pp = VN_AS(pp->nextp(), Pin)) {
-                                    if (pp->modVarp() == targetp) {
-                                        if (AstConst* const constp = VN_CAST(pp->exprp(), Const)) {
-                                            replacep = constp->cloneTree(false);
-                                        }
-                                        break;
-                                    }
-                                }
-                                if (!replacep && targetp->valuep()) {
-                                    replacep = targetp->valuep()->cloneTree(false);
-                                }
-                                if (replacep) {
-                                    varrefp->replaceWith(replacep);
-                                    VL_DO_DANGLING(varrefp->deleteTree(), varrefp);
-                                    any = true;
-                                }
-                            });
-                            // Replace RefDType to a ParamTypeDType with pin override
-                            // or the paramtype's default so constify below does not
-                            // reach into the template.  Collect then replace in
-                            // reverse so descendants aren't freed early.
-                            std::vector<std::pair<AstRefDType*, AstNodeDType*>> toReplace;
-                            cloneVarp->foreach([&](AstRefDType* refp) {
-                                AstParamTypeDType* const ptdp
-                                    = VN_CAST(refp->refDTypep(), ParamTypeDType);
-                                if (!ptdp) return;
-                                AstPin* overridePinp = nullptr;
-                                for (AstPin* pp = paramsp; pp; pp = VN_AS(pp->nextp(), Pin)) {
-                                    if (pp->modPTypep() == ptdp) {
-                                        overridePinp = pp;
-                                        break;
-                                    }
-                                }
-                                AstNodeDType* const substp
-                                    = overridePinp ? VN_CAST(overridePinp->exprp(), NodeDType)
-                                                   : ptdp->subDTypep();
-                                if (substp) toReplace.emplace_back(refp, substp);
-                            });
-                            for (auto it = toReplace.rbegin(); it != toReplace.rend(); ++it) {
-                                AstRefDType* const refp = it->first;
-                                refp->replaceWith(it->second->cloneTree(false));
-                                VL_DO_DANGLING(refp->deleteTree(), refp);
-                                any = true;
-                            }
-                            if (!any) break;
-                        }
+                        substituteParamRefs(cloneVarp, paramsp, true);
                         // Bail if anything still points at the template.
                         cloneVarp->foreach([&](AstVarRef* varrefp) {
                             varrefp->v3fatalSrc(
@@ -2202,6 +2266,19 @@ public:
             if (VN_IS(dotp->lhsp(), ClassOrPackageRef)) dotps.push_back(dotp);
         });
         for (auto it = dotps.rbegin(); it != dotps.rend(); ++it) resolveDotToTypedef(*it);
+        // Resolve the target type of assignment-pattern pin values before the
+        // constify below widths them against the unspecialized template
+        {
+            AstPin* paramsp = nullptr;
+            if (AstCell* const cellp = VN_CAST(nodep, Cell)) {
+                paramsp = cellp->paramsp();
+            } else if (AstIfaceRefDType* const ifaceRefp = VN_CAST(nodep, IfaceRefDType)) {
+                paramsp = ifaceRefp->paramsp();
+            } else if (AstClassRefDType* const classRefp = VN_CAST(nodep, ClassRefDType)) {
+                paramsp = classRefp->paramsp();
+            }
+            if (paramsp) resolvePatternPinDTypes(paramsp);
+        }
         // Evaluate all module constants
         V3Const::constifyParamsEdit(nodep);
         // Set name for warnings for when we param propagate the module

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -6935,14 +6935,22 @@ class WidthVisitor final : public VNVisitor {
             // Widthing handled as special init() case
             bool didWidth = false;
             if (AstPattern* const patternp = VN_CAST(nodep->exprp(), Pattern)) {
-                const AstVar* const modVarp = nodep->modVarp();
-                // Convert BracketArrayDType
-                userIterate(modVarp->childDTypep(),
-                            WidthVP{SELF, BOTH}.p());  // May relink pointed to node
-                AstNodeDType* const setDtp = modVarp->childDTypep();
-                if (!patternp->childDTypep()) patternp->childDTypep(setDtp->cloneTree(false));
-                userIterateChildren(nodep, WidthVP{setDtp, BOTH}.p());
-                didWidth = true;
+                // A pattern that already carries its own type, either from
+                // data_type '{...} or resolved by V3Param when the port's type
+                // depends on other parameters of this instantiation, is left to
+                // the self-determined widthing below.  Widthing the port's type
+                // here would resolve its parameter-dependent ranges against the
+                // unspecialized template's defaults.
+                if (!patternp->childDTypep()) {
+                    const AstVar* const modVarp = nodep->modVarp();
+                    // Convert BracketArrayDType
+                    userIterate(modVarp->childDTypep(),
+                                WidthVP{SELF, BOTH}.p());  // May relink pointed to node
+                    AstNodeDType* const setDtp = modVarp->childDTypep();
+                    patternp->childDTypep(setDtp->cloneTree(false));
+                    userIterateChildren(nodep, WidthVP{setDtp, BOTH}.p());
+                    didWidth = true;
+                }
             }
             if (!didWidth) userIterateChildren(nodep, WidthVP{SELF, BOTH}.p());
         } else if (!m_paramsOnly) {

--- a/test_regress/t/t_param_array10.py
+++ b/test_regress/t/t_param_array10.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile()
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_param_array10.v
+++ b/test_regress/t/t_param_array10.v
@@ -11,6 +11,12 @@
 // SPDX-FileCopyrightText: 2026 Oyvind Janbu
 // SPDX-License-Identifier: CC0-1.0
 
+// verilog_format: off
+`define stop $stop
+`define checkd(gotv,expv) do if ((gotv) !== (expv)) begin $write("%%Error: %s:%0d:  got=%0d exp=%0d\n", `__FILE__,`__LINE__, (gotv), (expv)); `stop; end while(0);
+`define checkh(gotv,expv) do if ((gotv) !== (expv)) begin $write("%%Error: %s:%0d:  got='h%x exp='h%x\n", `__FILE__,`__LINE__, (gotv), (expv)); `stop; end while(0);
+// verilog_format: on
+
 module m #(
     parameter int N = 1,
     parameter int V[N] = '{0}
@@ -127,70 +133,83 @@ module t;
 
   initial begin
     // Overridden size
-    if (i_m2.N != 2) $stop;
-    if ($size(i_m2.V) != 2) $stop;
-    if ($bits(i_m2.V) != 2 * 32) $stop;
-    if (i_m2.V[0] != 1 || i_m2.V[1] != 2) $stop;
+    `checkd(i_m2.N, 2);
+    `checkd($size(i_m2.V), 2);
+    `checkd($bits(i_m2.V), 2 * 32);
+    `checkd(i_m2.V[0], 1);
+    `checkd(i_m2.V[1], 2);
 
-    if ($size(i_m3.V) != 3) $stop;
-    if (i_m3.V[0] != 1 || i_m3.V[1] != 2 || i_m3.V[2] != 3) $stop;
+    `checkd($size(i_m3.V), 3);
+    `checkd(i_m3.V[0], 1);
+    `checkd(i_m3.V[1], 2);
+    `checkd(i_m3.V[2], 3);
 
     // Size override that is not a folded constant
-    if ($size(i_m3e.V) != 3) $stop;
-    if (i_m3e.V[2] != 3) $stop;
+    `checkd($size(i_m3e.V), 3);
+    `checkd(i_m3e.V[2], 3);
 
     // Size left at its default
-    if ($size(i_m1.V) != 1) $stop;
-    if (i_m1.V[0] != 1) $stop;
+    `checkd($size(i_m1.V), 1);
+    `checkd(i_m1.V[0], 1);
 
     // Patterns that don't name every element individually
-    if ($size(i_m4d.V) != 4) $stop;
-    if (i_m4d.V[0] != 1 || i_m4d.V[3] != 1) $stop;
-    if ($size(i_m3r.V) != 3) $stop;
-    if (i_m3r.V[0] != 1 || i_m3r.V[2] != 1) $stop;
+    `checkd($size(i_m4d.V), 4);
+    `checkd(i_m4d.V[0], 1);
+    `checkd(i_m4d.V[3], 1);
+    `checkd($size(i_m3r.V), 3);
+    `checkd(i_m3r.V[0], 1);
+    `checkd(i_m3r.V[2], 1);
 
     // Parameter-dependent element width
-    if ($size(i_p.B) != 2) $stop;
-    if ($bits(i_p.B) != 2 * 8) $stop;
-    if (i_p.B[0] != 8'ha || i_p.B[1] != 8'hb) $stop;
+    `checkd($size(i_p.B), 2);
+    `checkd($bits(i_p.B), 2 * 8);
+    `checkh(i_p.B[0], 8'ha);
+    `checkh(i_p.B[1], 8'hb);
 
     // Both dimensions parameter dependent
-    if ($size(i_d2.V) != 2) $stop;
-    if ($size(i_d2.V[0]) != 3) $stop;
-    if (i_d2.V[0][0] != 1 || i_d2.V[1][2] != 6) $stop;
+    `checkd($size(i_d2.V), 2);
+    `checkd($size(i_d2.V[0]), 3);
+    `checkd(i_d2.V[0][0], 1);
+    `checkd(i_d2.V[1][2], 6);
 
     // Interface parameters
-    if ($size(i_iface.V) != 3) $stop;
-    if (i_iface.V[0] != 1 || i_iface.V[2] != 3) $stop;
+    `checkd($size(i_iface.V), 3);
+    `checkd(i_iface.V[0], 1);
+    `checkd(i_iface.V[2], 3);
 
     // Concatenation value against a parameter-dependent width
-    if ($bits(i_c.P) != 16) $stop;
-    if (i_c.P != 16'h0a0b) $stop;
+    `checkd($bits(i_c.P), 16);
+    `checkh(i_c.P, 16'h0a0b);
 
     // Size parameter declared after the array parameter
-    if ($size(i_q2.V) != 2) $stop;
-    if (i_q2.V[0] != 1 || i_q2.V[1] != 2) $stop;
+    `checkd($size(i_q2.V), 2);
+    `checkd(i_q2.V[0], 1);
+    `checkd(i_q2.V[1], 2);
 
     // Size from a type parameter
-    if ($size(i_r.V) != 16) $stop;
-    if ($bits(i_r.V) != 16 * 16) $stop;
-    if (i_r.V[0] != 1 || i_r.V[15] != 1) $stop;
+    `checkd($size(i_r.V), 16);
+    `checkd($bits(i_r.V), 16 * 16);
+    `checkd(i_r.V[0], 1);
+    `checkd(i_r.V[15], 1);
 
     // Whole port type from a type parameter
-    if ($bits(i_sn.V) != 16) $stop;
-    if (i_sn.V.a != 8'h1 || i_sn.V.b != 8'h2) $stop;
-    if ($bits(i_sw.V) != 64) $stop;
-    if (i_sw.V.a != 32'h3 || i_sw.V.b != 32'h4) $stop;
+    `checkd($bits(i_sn.V), 16);
+    `checkh(i_sn.V.a, 8'h1);
+    `checkh(i_sn.V.b, 8'h2);
+    `checkd($bits(i_sw.V), 64);
+    `checkh(i_sw.V.a, 32'h3);
+    `checkh(i_sw.V.b, 32'h4);
 
     // Untyped parameter, parameter-dependent default value
-    if ($size(i_u.LST) != 8) $stop;
-    if ($size(i_ud.LST) != 8) $stop;
+    `checkd($size(i_u.LST), 8);
+    `checkd($size(i_ud.LST), 8);
 
     // Size from the enclosing module's parameter
-    if ($size(i_mid.i_pass.V) != 3) $stop;
-    if (i_mid.i_pass.V[0] != 1 || i_mid.i_pass.V[2] != 3) $stop;
-    if ($size(i_mid.i_expr.V) != 4) $stop;
-    if (i_mid.i_expr.V[3] != 4) $stop;
+    `checkd($size(i_mid.i_pass.V), 3);
+    `checkd(i_mid.i_pass.V[0], 1);
+    `checkd(i_mid.i_pass.V[2], 3);
+    `checkd($size(i_mid.i_expr.V), 4);
+    `checkd(i_mid.i_expr.V[3], 4);
 
     $write("*-* All Finished *-*\n");
     $finish;

--- a/test_regress/t/t_param_array10.v
+++ b/test_regress/t/t_param_array10.v
@@ -1,0 +1,198 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// An unpacked array parameter whose size comes from another parameter of the
+// same instantiation.  The size must come from the overridden parameter, not
+// from the module's own default.  See issue #5890.
+//
+// Checks are all in t's single initial block, ahead of the $finish, as an
+// initial block inside an instance may be ordered after it.
+//
+// This file ONLY is placed under the Creative Commons Public Domain.
+// SPDX-FileCopyrightText: 2026 Oyvind Janbu
+// SPDX-License-Identifier: CC0-1.0
+
+module m #(
+    parameter int N = 1,
+    parameter int V[N] = '{0}
+) ();
+endmodule
+
+// Element width also parameter dependent
+module p #(
+    parameter int W = 1,
+    parameter logic [W-1:0] B[2] = '{0, 0}
+) ();
+endmodule
+
+// Concatenation as the value of a parameter with a parameter-dependent width.
+// A concat is self-determined, so it does not go through the port's type, but
+// check it here as it is the closest relative of an assignment pattern.
+module c #(
+    parameter int W = 1,
+    parameter logic [W-1:0] P = '0
+) ();
+endmodule
+
+// Both dimensions parameter dependent
+module d2 #(
+    parameter int N = 1,
+    parameter int M = 1,
+    parameter int V[N][M] = '{'{0}}
+) ();
+endmodule
+
+// Interfaces are deparameterized separately from cells
+interface iface #(
+    parameter int N = 1,
+    parameter int V[N] = '{0}
+) ();
+endinterface
+
+// Size from a parameter declared after the array's own parameter
+module q #(
+    parameter int V[N] = '{0},
+    parameter int N = 1
+) ();
+endmodule
+
+// Size from a type parameter
+module r #(
+    parameter type T = byte,
+    parameter T V[$bits(T)] = '{default: 0}
+) ();
+endmodule
+
+// Whole port type is a type parameter, so the substituted type replaces the
+// root of the port's type rather than a range inside it
+typedef struct packed {
+  int a;
+  int b;
+} wide_t;
+typedef struct packed {
+  byte a;
+  byte b;
+} narrow_t;
+
+module s #(
+    parameter type T = wide_t,
+    parameter T V = '{default: 0}
+) ();
+endmodule
+
+// Untyped parameter with a parameter-dependent default value (issue #5890)
+module u #(
+    parameter LEN = 4,
+    parameter LST[LEN] = '{LEN{0}}
+) ();
+endmodule
+
+// Size overridden from the enclosing module's own parameter
+module mid #(
+    parameter int M = 1,
+    parameter int W[M] = '{0}
+) ();
+  m #(.N(M), .V(W)) i_pass ();  // Pass the array down
+  m #(.N(M + 1), .V('{1, 2, 3, 4})) i_expr ();  // Size from an expression, M == 3
+endmodule
+
+module t;
+  localparam int TWO = 2;
+
+  m #(.N(2), .V('{1, 2})) i_m2 ();
+  m #(.N(3), .V('{1, 2, 3})) i_m3 ();
+  m #(.N(TWO + 1), .V('{1, 2, 3})) i_m3e ();  // Non-folded size override
+  m #(.V('{1})) i_m1 ();  // Size left at its default
+  m #(.N(4), .V('{default: 1})) i_m4d ();  // Default in the pattern
+  m #(.N(3), .V('{3{1}})) i_m3r ();  // Replication in the pattern
+
+  p #(.W(8), .B('{8'ha, 8'hb})) i_p ();
+
+  d2 #(.N(2), .M(3), .V('{'{1, 2, 3}, '{4, 5, 6}})) i_d2 ();
+
+  iface #(.N(3), .V('{1, 2, 3})) i_iface ();
+
+  c #(.W(16), .P({8'ha, 8'hb})) i_c ();
+
+  q #(.N(2), .V('{1, 2})) i_q2 ();
+
+  r #(.T(shortint), .V('{16{1}})) i_r ();
+
+  s #(.T(narrow_t), .V('{a: 8'h1, b: 8'h2})) i_sn ();
+  s #(.V('{a: 32'h3, b: 32'h4})) i_sw ();  // Type left at its default
+
+  u #(.LEN(8), .LST('{8{0}})) i_u ();
+  u #(.LEN(8)) i_ud ();  // Default value must resize with LEN
+
+  mid #(.M(3), .W('{1, 2, 3})) i_mid ();
+
+  initial begin
+    // Overridden size
+    if (i_m2.N != 2) $stop;
+    if ($size(i_m2.V) != 2) $stop;
+    if ($bits(i_m2.V) != 2 * 32) $stop;
+    if (i_m2.V[0] != 1 || i_m2.V[1] != 2) $stop;
+
+    if ($size(i_m3.V) != 3) $stop;
+    if (i_m3.V[0] != 1 || i_m3.V[1] != 2 || i_m3.V[2] != 3) $stop;
+
+    // Size override that is not a folded constant
+    if ($size(i_m3e.V) != 3) $stop;
+    if (i_m3e.V[2] != 3) $stop;
+
+    // Size left at its default
+    if ($size(i_m1.V) != 1) $stop;
+    if (i_m1.V[0] != 1) $stop;
+
+    // Patterns that don't name every element individually
+    if ($size(i_m4d.V) != 4) $stop;
+    if (i_m4d.V[0] != 1 || i_m4d.V[3] != 1) $stop;
+    if ($size(i_m3r.V) != 3) $stop;
+    if (i_m3r.V[0] != 1 || i_m3r.V[2] != 1) $stop;
+
+    // Parameter-dependent element width
+    if ($size(i_p.B) != 2) $stop;
+    if ($bits(i_p.B) != 2 * 8) $stop;
+    if (i_p.B[0] != 8'ha || i_p.B[1] != 8'hb) $stop;
+
+    // Both dimensions parameter dependent
+    if ($size(i_d2.V) != 2) $stop;
+    if ($size(i_d2.V[0]) != 3) $stop;
+    if (i_d2.V[0][0] != 1 || i_d2.V[1][2] != 6) $stop;
+
+    // Interface parameters
+    if ($size(i_iface.V) != 3) $stop;
+    if (i_iface.V[0] != 1 || i_iface.V[2] != 3) $stop;
+
+    // Concatenation value against a parameter-dependent width
+    if ($bits(i_c.P) != 16) $stop;
+    if (i_c.P != 16'h0a0b) $stop;
+
+    // Size parameter declared after the array parameter
+    if ($size(i_q2.V) != 2) $stop;
+    if (i_q2.V[0] != 1 || i_q2.V[1] != 2) $stop;
+
+    // Size from a type parameter
+    if ($size(i_r.V) != 16) $stop;
+    if ($bits(i_r.V) != 16 * 16) $stop;
+    if (i_r.V[0] != 1 || i_r.V[15] != 1) $stop;
+
+    // Whole port type from a type parameter
+    if ($bits(i_sn.V) != 16) $stop;
+    if (i_sn.V.a != 8'h1 || i_sn.V.b != 8'h2) $stop;
+    if ($bits(i_sw.V) != 64) $stop;
+    if (i_sw.V.a != 32'h3 || i_sw.V.b != 32'h4) $stop;
+
+    // Untyped parameter, parameter-dependent default value
+    if ($size(i_u.LST) != 8) $stop;
+    if ($size(i_ud.LST) != 8) $stop;
+
+    // Size from the enclosing module's parameter
+    if ($size(i_mid.i_pass.V) != 3) $stop;
+    if (i_mid.i_pass.V[0] != 1 || i_mid.i_pass.V[2] != 3) $stop;
+    if ($size(i_mid.i_expr.V) != 4) $stop;
+    if (i_mid.i_expr.V[3] != 4) $stop;
+
+    $write("*-* All Finished *-*\n");
+    $finish;
+  end
+endmodule


### PR DESCRIPTION
Fixes #5890.

An assignment pattern given as a parameter pin value is widthed while the instantiated module is still the unspecialized template, as V3Param constifies the cell before cloning it. V3Width's AstPin visitor resolved the port's declared type there and used it as the pattern's target type, so the array was sized by the template's default rather than by this instantiation's override:

    module M #(parameter int N = 1, parameter int V[N]) ();
    M #(.N(2), .V('{1, 2})) u ();

    %Error: Assignment pattern with too many elements

Widthing the port's type there is also destructive, as it evaluates and removes the range expressions, so later clones of the same template would be sized from the defaults as well.

Give the pattern its own copy of the port's type with this instantiation's overrides substituted in, for both value and type parameters, and skip widthing the port's type when the pattern already carries one. The substitution loop is now shared with the existing one in cellPinCleanup.

Developed with assistance from Claude Code.
