### PR TITLE
Fix Linux peak memory stat to use VmHWM (#8022)

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -316,6 +316,7 @@ Tracy Narine
 Trung Nguyen
 Tudor Timi
 Tymoteusz Blazejczyk
+Tyrone Marhguy
 Udaya Raj Subedi
 Udi Finkelstein
 Unai Martinez-Corral

--- a/docs/guide/simulating.rst
+++ b/docs/guide/simulating.rst
@@ -66,7 +66,7 @@ The information in this report is:
 
 .. describe:: "allocated 123 MB"
 
-   Total memory used during simulation in megabytes.
+   Peak resident memory used during simulation in megabytes.
 
 
 .. _benchmarking & optimization:

--- a/docs/guide/verilating.rst
+++ b/docs/guide/verilating.rst
@@ -623,5 +623,5 @@ The information in this report is:
 
 .. describe:: "allocated 123 MB"
 
-   Total memory used during build by Verilator executable (excludes
-   :vlopt:`--build` compiler's usage) in megabytes.
+   Peak resident memory used by the Verilator executable during build
+   (excludes :vlopt:`--build` compiler's usage) in megabytes.

--- a/include/verilatedos_c.h
+++ b/include/verilatedos_c.h
@@ -169,17 +169,19 @@ void memUsageBytes(uint64_t& peakr, uint64_t& currentr) VL_MT_SAFE {
     }
 #else
     // Highly unportable. Sorry
+    // Use VmHWM (peak resident), matching Windows PeakWorkingSetSize and macOS resident_size_max.
+    // VmHWM excludes pages swapped out before the peak; /proc has no peak-(RSS+Swap) counter.
     std::ifstream is{"/proc/self/status"};
     if (!is) return;
     std::string line;
-    uint64_t vmPeak = 0;
+    uint64_t vmHwm = 0;
     uint64_t vmRss = 0;
     uint64_t vmSwap = 0;
     std::string field;
     while (std::getline(is, line)) {
-        if (line.rfind("VmPeak:", 0) == 0) {
+        if (line.rfind("VmHWM:", 0) == 0) {
             std::stringstream ss{line};
-            ss >> field >> vmPeak;
+            ss >> field >> vmHwm;
         } else if (line.rfind("VmRSS:", 0) == 0) {
             std::stringstream ss{line};
             ss >> field >> vmRss;
@@ -188,7 +190,7 @@ void memUsageBytes(uint64_t& peakr, uint64_t& currentr) VL_MT_SAFE {
             ss >> field >> vmSwap;
         }
     }
-    peakr = vmPeak * 1024;
+    peakr = vmHwm * 1024;
     currentr = (vmRss + vmSwap) * 1024;
 #endif
 }

--- a/test_regress/t/t_opt_gate_blow_up.py
+++ b/test_regress/t/t_opt_gate_blow_up.py
@@ -11,11 +11,13 @@ import vltest_bootstrap
 
 test.scenarios('vlt')
 
-test.compile(verilator_flags2=["--stats"])
+test.compile(verilator_flags2=["--stats --verilate-jobs 2"])
 
 memUsageMB = int(test.file_grep(test.stats, r'Peak Memory Usage \(MB\) +(\d+)')[0])
 
 if memUsageMB > 128 and not test.have_dev_asan:
     test.error("Consumed over 128MB memory")
+
+test.file_grep(test.stats, r'Verilate jobs: 2')
 
 test.passes()


### PR DESCRIPTION
Fixes #8022

## Summary
- On Linux, report peak resident memory (`VmHWM`) instead of peak virtual (`VmPeak`) in `VlOs::memUsageBytes()`, matching Windows/macOS behavior
- With `--verilate-jobs`, this stops `--stats` and the summary `allocated N MB` line from being inflated ~10× by glibc malloc arenas
- Clarify in docs that the stat is peak resident memory
- Run `t_opt_gate_blow_up` with `--verilate-jobs 2` so Linux catches this regression

## Test plan
- [x] CI passed (44 checks)
- [x] `t_opt_gate_blow_up` / contributors test covered by CI

## Notes
- First contribution: added `Tyrone Marhguy` to `docs/CONTRIBUTORS` (DCO)
- Portions of this patch were developed with AI assistance and reviewed by the human contributor