### PR TITLE
Skip non-constrained enum constraining when inside object of other class

### DIFF
--- a/src/V3Randomize.cpp
+++ b/src/V3Randomize.cpp
@@ -5463,6 +5463,8 @@ class RandomizeVisitor final : public VNVisitor {
                               AstEnumDType* const enumDtp
                                   = VN_CAST(subVarp->dtypep()->skipRefToEnump(), EnumDType);
                               if (enumDtp) {
+                                  // Do not emit when enum isn't constrained
+                                  if (!subVarp->user3()) return;
                                   emitEnumConstraint(smtName, enumDtp);
                                   return;
                               }

--- a/test_regress/t/t_subclass_nonconstrained_enum.py
+++ b/test_regress/t/t_subclass_nonconstrained_enum.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+if not test.have_solver:
+    test.skip("No constraint solver installed")
+
+test.compile()
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_subclass_nonconstrained_enum.v
+++ b/test_regress/t/t_subclass_nonconstrained_enum.v
@@ -1,0 +1,47 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain
+// SPDX-FileCopyrightText: 2026 Antmicro
+// SPDX-License-Identifier: CC0-1.0
+
+// verilog_format: off
+`define stop $stop
+`define checkd(gotv,expv) do if ((gotv) !== (expv)) begin $write("%%Error: %s:%0d:  got=%0d exp=%0d\n", `__FILE__,`__LINE__, (gotv), (expv)); `stop; end while(0);
+// verilog_format: on
+
+class Sub;
+  typedef enum bit [1:0] {
+    one,
+    two,
+    three,
+    four
+  } enum_t;
+
+  rand bit num;
+  rand enum_t en;
+
+  constraint c {
+    num == 0;
+  };
+endclass
+
+class Top;
+  rand Sub s;
+
+  function new();
+    s = new;
+  endfunction
+endclass
+
+module t;
+  Top top;
+  initial begin
+    top = new;
+
+    `checkd(top.randomize(), 1);
+    `checkd(top.s.num, 0);
+
+    $write("*-* All Finished *-*\n");
+    $finish();
+  end
+endmodule


### PR DESCRIPTION
When we encounter a `enum` typed `rand` variable inside a field of a class that is an object of class, we're creating an additional constraint `(__Vbv (or (= enum (_ bv0 enum_width))))))` to make sure that `enum` values are inside the desired range. This constraint is created in a different part of the code than the potential `write_var` call, so we don't know if `write_var` has been generated for this `enum` or not.

If `enum` isn't constrained, `write_var` call isn't generated, and solver call will result in `unknown constant` error. This solver constraint is not necessary when we don't constrain this variable because we'll handle randomization inside verilator-generated code.

This commit entirely skips the emitting of this constraint if `enum` isn't constrained in the first place.