### PR TITLE
Fix hierarchical class scope resolution

### DIFF
--- a/src/V3LinkDot.cpp
+++ b/src/V3LinkDot.cpp
@@ -4635,9 +4635,15 @@ class LinkDotResolveVisitor final : public VNVisitor {
                 m_ds.m_dotText = "";
             } else if (AstClass* const defp = VN_CAST(foundp->nodep(), Class)) {
                 if (allowVar) {
-                    AstRefDType* const newp = new AstRefDType{nodep->fileline(), nodep->name()};
-                    replaceWithCheckBreak(nodep, newp);
-                    VL_DO_DANGLING(pushDeletep(nodep), nodep);
+                    if (m_ds.m_dotPos == DP_SCOPE && !staticAccess) {
+                        // Continue hierarchical lookup in the class scope.
+                        m_ds.m_dotSymp = foundp;
+                    } else {
+                        AstRefDType* const newp
+                            = new AstRefDType{nodep->fileline(), nodep->name()};
+                        replaceWithCheckBreak(nodep, newp);
+                        VL_DO_DANGLING(pushDeletep(nodep), nodep);
+                    }
                     ok = true;
                     m_ds.m_dotText = "";
                 } else {

--- a/test_regress/t/t_class_modscope.v
+++ b/test_regress/t/t_class_modscope.v
@@ -9,6 +9,25 @@
 `define checkh(gotv,expv) do if ((gotv) !== (expv)) begin $write("%%Error: %s:%0d:  got='h%x exp='h%x\n", `__FILE__,`__LINE__, (gotv), (expv)); `stop; end while(0);
 // verilog_format: on
 
+interface class_if;
+  class scoped_class;
+    static function int fstatic();
+      return 42;
+    endfunction
+    function int fnonstatic();
+      return 43;
+    endfunction
+  endclass
+
+  scoped_class class_inst;
+
+  initial begin
+    `checkh(scoped_class::fstatic(), 42);
+    class_inst = new();
+    `checkh(class_inst.fnonstatic(), 43);
+  end
+endinterface
+
 module m ();
   class c;
     static function void fstatic();
@@ -22,6 +41,7 @@ module m ();
   endclass
 
   c classinst;
+  class_if class_if_inst();
   int v;
 
   initial begin
@@ -31,6 +51,7 @@ module m ();
     classinst = new();
     classinst.fnonstatic();
     `checkh(v, 44);
+    `checkh(class_if_inst.scoped_class.fstatic(), 42);
     $finish;
   end
 endmodule


### PR DESCRIPTION
Hierarchical references to classes were incorrectly converted into datatype references. Subsequent lookup then expected a package scope and failed with "Bad package link" internal error.
`!staticAccess` exclusion is used to identify `::` syntax which was lowered to from `DP_PACKAGE` to `DP_SCOPE`.
Keep class declarations as the active lookup scope when they appear as an intermediate component of a hierarchical reference. This also fixes the same issue with covergroups, which are internally represented as classes.