### PR TITLE
Fix the clang compilation pch issue

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -67,6 +67,7 @@ David Stanford
 David Turner
 dependabot[bot]
 Dercury
+Demin Han
 Diego Roux
 Dominick Grochowina
 Don Williamson

--- a/include/verilated.mk.in
+++ b/include/verilated.mk.in
@@ -43,7 +43,7 @@ CFG_CXXFLAGS_WEXTRA = @CFG_CXXFLAGS_WEXTRA@
 # Compiler flags that enable coroutine support
 CFG_CXXFLAGS_COROUTINES = @CFG_CXXFLAGS_COROUTINES@
 # Compiler flags when creating a precompiled header
-CFG_CXXFLAGS_PCH = -x c++-header
+CFG_CXXFLAGS_PCH = -c -x c++-header
 # Compiler option to put in front of filename to read precompiled header
 CFG_CXXFLAGS_PCH_I = @CFG_CXXFLAGS_PCH_I@
 # Compiler's filename prefix for precompiled headers, .gch if clang, empty if GCC


### PR DESCRIPTION
Without ccache, clang reports error when compiling pch in conda env: clang++: error: cannot specify -o when generating multiple output files

This is because the clang cfg file introduces some link options.

We appreciate your contributing to Verilator.  If this is your first commit, please add your name to docs/CONTRIBUTORS, and read our contributing guidelines in docs/CONTRIBUTING.rst.
