### PR TITLE
Throw unsupported in case of reduction constraints on dynamic subarray 

### DIFF
--- a/src/V3Randomize.cpp
+++ b/src/V3Randomize.cpp
@@ -2740,6 +2740,12 @@ class ConstraintExprVisitor final : public VNVisitor {
                 nodep->v3fatalSrc("Method not handled in constraints? " << nodep);
                 return;
             }
+            if (!VN_IS(nodep->fromp(), VarRef)) {
+                // Non-dynamic subarrays and member arrays are handled in other parts of code
+                nodep->v3warn(CONSTRAINTIGN, "Unsupported: Array reduction constraint on dynamic "
+                                             "array inside array or struct");
+                return;
+            }
 
             // Create loop variable and header
             AstVar* const loopVarp

--- a/test_regress/t/t_constraint_red_arr_unsup.out
+++ b/test_regress/t/t_constraint_red_arr_unsup.out
@@ -1,0 +1,33 @@
+%Warning-CONSTRAINTIGN: t/t_constraint_red_arr_unsup.v:25:16: Unsupported: Array reduction constraint on dynamic array inside array or struct
+   25 |     a + arr[0].sum() == 10;
+      |                ^~~
+                        ... For warning description see https://verilator.org/warn/CONSTRAINTIGN?v=latest
+                        ... Use "/* verilator lint_off CONSTRAINTIGN */" and lint_on around source to disable this message.
+%Warning-CONSTRAINTIGN: t/t_constraint_red_arr_unsup.v:26:16: Unsupported: Array reduction constraint on dynamic array inside array or struct
+   26 |     a + arr[1].product() == 10;
+      |                ^~~~~~~
+%Warning-CONSTRAINTIGN: t/t_constraint_red_arr_unsup.v:27:16: Unsupported: Array reduction constraint on dynamic array inside array or struct
+   27 |     a + arr[2].xor() == 10;
+      |                ^~~
+%Warning-CONSTRAINTIGN: t/t_constraint_red_arr_unsup.v:28:16: Unsupported: Array reduction constraint on dynamic array inside array or struct
+   28 |     a + arr[3].or() == 10;
+      |                ^~
+%Warning-CONSTRAINTIGN: t/t_constraint_red_arr_unsup.v:29:16: Unsupported: Array reduction constraint on dynamic array inside array or struct
+   29 |     a + arr[4].and() == 10;
+      |                ^~~
+%Warning-CONSTRAINTIGN: t/t_constraint_red_arr_unsup.v:33:16: Unsupported: Array reduction constraint on dynamic array inside array or struct
+   33 |     a + sc.arr.sum() == 10;
+      |                ^~~
+%Warning-CONSTRAINTIGN: t/t_constraint_red_arr_unsup.v:34:16: Unsupported: Array reduction constraint on dynamic array inside array or struct
+   34 |     a + sc.arr.product() == 10;
+      |                ^~~~~~~
+%Warning-CONSTRAINTIGN: t/t_constraint_red_arr_unsup.v:35:16: Unsupported: Array reduction constraint on dynamic array inside array or struct
+   35 |     a + sc.arr.xor() == 10;
+      |                ^~~
+%Warning-CONSTRAINTIGN: t/t_constraint_red_arr_unsup.v:36:16: Unsupported: Array reduction constraint on dynamic array inside array or struct
+   36 |     a + sc.arr.or() == 10;
+      |                ^~
+%Warning-CONSTRAINTIGN: t/t_constraint_red_arr_unsup.v:37:16: Unsupported: Array reduction constraint on dynamic array inside array or struct
+   37 |     a + sc.arr.and() == 10;
+      |                ^~~
+%Error: Exiting due to

--- a/test_regress/t/t_constraint_red_arr_unsup.py
+++ b/test_regress/t/t_constraint_red_arr_unsup.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('linter')
+
+test.lint(fails=test.vlt_all, expect_filename=test.golden_filename)
+
+test.passes()

--- a/test_regress/t/t_constraint_red_arr_unsup.v
+++ b/test_regress/t/t_constraint_red_arr_unsup.v
@@ -1,0 +1,46 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain
+// SPDX-FileCopyrightText: 2026 Antmicro
+// SPDX-License-Identifier: CC0-1.0
+
+class ReductionDynSubArr;
+  rand int arr[5][];
+  rand int a;
+
+  typedef struct {
+    rand int arr[];
+  } Subcls;
+
+  rand Subcls sc;
+
+  function new();
+    sc.arr = new[5];
+    foreach (arr[i]) begin
+      arr[i] = new [5];
+    end
+  endfunction
+
+  constraint red_a {
+    a + arr[0].sum() == 10;
+    a + arr[1].product() == 10;
+    a + arr[2].xor() == 10;
+    a + arr[3].or() == 10;
+    a + arr[4].and() == 10;
+  }
+
+  constraint red_b {
+    a + sc.arr.sum() == 10;
+    a + sc.arr.product() == 10;
+    a + sc.arr.xor() == 10;
+    a + sc.arr.or() == 10;
+    a + sc.arr.and() == 10;
+  }
+endclass : ReductionDynSubArr
+
+module t;
+  initial begin
+    automatic ReductionDynSubArr sub = new();
+    void'(sub.randomize());
+  end
+endmodule : t


### PR DESCRIPTION
Currently when we encounter dynamic array inside array or struct constrained with reduction constraint we throw

```
%Error: Internal Error: test_regress/t/t_constraint_foreach.v:203:17: ../V3Randomize.cpp:2791: Array reduction in constraint has non-VarRef source
```
Throw `CONSTRAINTIGN` in this case.