### PR TITLE
Fix invalid C++ on real task output argument

### DIFF
--- a/src/V3Task.cpp
+++ b/src/V3Task.cpp
@@ -534,6 +534,11 @@ class TaskVisitor final : public VNVisitor {
             }
             postRhsp->dtypeFrom(outPinp);
         }
+        if (VN_IS(outPinp, IToRD) || VN_IS(outPinp, ISToRD)) {
+            outPinp = VN_AS(outPinp, NodeUniop)->lhsp();
+            postRhsp = new AstRToIRoundS{pinp->fileline(), postRhsp};
+            postRhsp->dtypeFrom(outPinp);
+        }
         // Put output assignment AFTER function call
         AstNodeExpr* const outPinClonep
             = pureCheck ? outPinp->cloneTreePure(true) : outPinp->cloneTree(true);

--- a/test_regress/t/t_func_real_output.py
+++ b/test_regress/t/t_func_real_output.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile()
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_func_real_output.v
+++ b/test_regress/t/t_func_real_output.v
@@ -1,0 +1,37 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain.
+// SPDX-FileCopyrightText: 2026 Antmicro
+// SPDX-License-Identifier: CC0-1.0
+
+// verilog_format: off
+`define stop $stop
+`define checkh(gotv,expv) do if ((gotv) !== (expv)) begin $write("%%Error: %s:%0d:  got='h%x exp='h%x\n", `__FILE__,`__LINE__, (gotv), (expv)); `stop; end while(0);
+// verilog_format: on
+
+module t;
+  bit unsigned [3:0] dst_u2s;
+  bit signed [3:0] dst_s2s;
+  bit unsigned [11:0] dst_u2l;
+  bit signed [11:0] dst_s2l;
+
+  real src_r;
+
+  task cp_r(output real dst, input real src);
+    dst = src;
+  endtask
+
+  initial begin
+    src_r = -7.0;
+    cp_r(dst_u2s, src_r);
+    `checkh(dst_u2s, 4'h9);
+    cp_r(dst_s2s, src_r);
+    `checkh(dst_s2s, -7);
+    cp_r(dst_u2l, src_r);
+    `checkh(dst_u2l, 12'hff9);
+    cp_r(dst_s2l, src_r);
+    `checkh(dst_s2l, -7);
+    $write("*-* All Finished *-*\n");
+    $finish;
+  end
+endmodule


### PR DESCRIPTION
When task output argument is real and pin is integer, it results in invalid C++ being generated.

```verilog
module t;
  bit unsigned [3:0] dst_u2s;
  bit  signed [3:0] dst_s2s;
  bit unsigned [11:0] dst_u2l;
  bit  signed [11:0] dst_s2l;

  real src_r;

  task cp_r(output real dst, input real src);
    dst = src;
  endtask

  initial begin
    src_r = -7.0;
    cp_r(dst_u2s, src_r);
    if (dst_u2s !== 4'h9) $stop;
    cp_r(dst_s2s, src_r);
    if (dst_s2s !== -7) $stop;
    cp_r(dst_u2l, src_r);
    if (dst_u2l !== 12'hff9) $stop;
    cp_r(dst_s2l, src_r);
    if (dst_s2l !== -7) $stop;
    $write("*-* All Finished *-*\n");
    $finish;
  end
endmodule
```

Results in:
```
In file included from Vt_func_real_output__ALL.cpp:6:
Vt_func_real_output___024root__0__Slow.cpp: In function âvoid Vt_func_real_output___024root___eval_initial(Vt_func_real_output___024root*)â:
Vt_func_real_output___024root__0__Slow.cpp:20:20: error: lvalue required as left operand of assignment
   20 |         VL_ITOR_D_I(4, vlSelfRef.t__DOT__dst_u2s) = -7.0;
      |         ~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Vt_func_real_output___024root__0__Slow.cpp:24:21: error: lvalue required as left operand of assignment
   24 |         VL_ISTOR_D_I(4, vlSelfRef.t__DOT__dst_s2s) = -7.0;
      |         ~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Vt_func_real_output___024root__0__Slow.cpp:28:20: error: lvalue required as left operand of assignment
   28 |         VL_ITOR_D_I(12, vlSelfRef.t__DOT__dst_u2l) = -7.0;
      |         ~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Vt_func_real_output___024root__0__Slow.cpp:32:21: error: lvalue required as left operand of assignment
   32 |         VL_ISTOR_D_I(12, vlSelfRef.t__DOT__dst_s2l) = -7.0;
      |         ~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```