### PR TITLE
Support cross iff

### DIFF
--- a/src/V3AstNodeOther.h
+++ b/src/V3AstNodeOther.h
@@ -2810,11 +2810,14 @@ class AstCoverCross final : public AstNodeFuncCovItem {
     // @astgen op2 := optionsp : List[AstCoverOption]     // post-LinkParse only
     // @astgen op3 := rawBodyp : List[AstNode]  // Parse: raw cross_body items;
     //                                          // post-LinkParse: empty
+    // @astgen op4 := iffp     : Optional[AstNodeExpr]  // Conditional sampling guard
 public:
-    AstCoverCross(FileLine* fl, const string& name, AstCoverpointRef* itemsp)
+    AstCoverCross(FileLine* fl, const string& name, AstCoverpointRef* itemsp,
+                  AstNodeExpr* iffp = nullptr)
         : ASTGEN_SUPER_CoverCross(fl, name) {
         UASSERT(itemsp, "AstCoverCross requires at least one coverpoint reference");
         addItemsp(itemsp);
+        this->iffp(iffp);
     }
     ASTGEN_MEMBERS_AstCoverCross;
     void dump(std::ostream& str) const override;

--- a/src/V3Covergroup.cpp
+++ b/src/V3Covergroup.cpp
@@ -410,6 +410,19 @@ class FunctionalCoverageVisitor final : public VNVisitor {
         return name;
     }
 
+    // Capture an iff guard in a function-local temporary so it is evaluated once per sample()
+    AstVarRef* captureIffToTemp(AstNodeExpr* iffp, const string& tempName) {
+        FileLine* const fl = iffp->fileline();
+        AstVar* const iffVarp
+            = new AstVar{fl, VVarType::BLOCKTEMP, tempName, iffp->findBitDType()};
+        iffVarp->funcLocal(true);
+        m_sampleFuncp->addStmtsp(iffVarp);
+        iffp->unlinkFrBack();
+        m_sampleFuncp->addStmtsp(
+            new AstAssign{fl, new AstVarRef{fl, iffVarp, VAccess::WRITE}, iffp});
+        return new AstVarRef{fl, iffVarp, VAccess::READ};
+    }
+
     AstNodeExpr* applyCoverpointIffCondition(AstCoverpoint* coverpointp, FileLine* fl,
                                              AstNodeExpr* condp) {
         if (AstNodeExpr* const iffp = coverpointp->iffp()) {
@@ -812,6 +825,11 @@ class FunctionalCoverageVisitor final : public VNVisitor {
         FileLine* const fl = coverpointp->fileline();
         UINFO(4, "  Generating VlCoverpoint member: " << coverpointp->name());
 
+        if (AstNodeExpr* const iffp = coverpointp->iffp()) {
+            coverpointp->iffp(
+                captureIffToTemp(iffp, "__VcpIff_" + sanitizeGeneratedName(coverpointp->name())));
+        }
+
         // Size the hit list to the gen-time max bin overlap (1 unless cross-fed with
         // overlapping ranges), so no cross hit is ever dropped and storage is minimal.
         const bool crossFed = m_crossedCpNames.count(coverpointp->name()) != 0;
@@ -1212,6 +1230,11 @@ class FunctionalCoverageVisitor final : public VNVisitor {
         FileLine* const fl = crossp->fileline();
         UINFO(4, "  Generating VlCoverCross member: " << crossp->name());
 
+        if (AstNodeExpr* const iffp = crossp->iffp()) {
+            crossp->iffp(
+                captureIffToTemp(iffp, "__VcrossIff_" + sanitizeGeneratedName(crossp->name())));
+        }
+
         // Resolve and unlink the coverpoint refs, in dimension order.  Every ref resolves to a
         // known coverpoint (a cross with an unresolvable item was dropped earlier).
         std::vector<AstVar*> cpVars;
@@ -1257,7 +1280,12 @@ class FunctionalCoverageVisitor final : public VNVisitor {
 
         // sample(): after all coverpoints have sampled (cross loop runs after coverpoint loop).
         UASSERT_OBJ(m_sampleFuncp, crossp, "sample() CFunc not set for cross");
-        m_sampleFuncp->addStmtsp(makeCrossCpsCall(fl, cpVars, cxVarp, ".sample(__Vcx_cps);"));
+        AstNodeStmt* const samplep = makeCrossCpsCall(fl, cpVars, cxVarp, ".sample(__Vcx_cps);");
+        if (AstNodeExpr* const iffp = crossp->iffp()) {
+            m_sampleFuncp->addStmtsp(new AstIf{fl, iffp->cloneTree(false), samplep});
+        } else {
+            m_sampleFuncp->addStmtsp(samplep);
+        }
     }
 
     void generateCrossCode(AstCoverCross* crossp) {
@@ -1784,6 +1812,7 @@ class FunctionalCoverageVisitor final : public VNVisitor {
             visitor.scan(cpp->exprp());
             visitor.scan(cpp->iffp());
         }
+        for (AstCoverCross* const crossp : m_coverCrosses) visitor.scan(crossp->iffp());
         return visitor.offenderp();
     }
 

--- a/src/V3EmitV.cpp
+++ b/src/V3EmitV.cpp
@@ -361,6 +361,11 @@ class EmitVBaseVisitorConst VL_NOT_FINAL : public VNVisitorConst {
             if (itemp != nodep->itemsp()) puts(", ");
             iterateConst(itemp);
         }
+        if (nodep->iffp()) {
+            puts(" iff (");
+            iterateConst(nodep->iffp());
+            puts(")");
+        }
         puts(";\n");
     }
     void visit(AstCoverTransSet* nodep) override {

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -2008,6 +2008,12 @@ class WidthVisitor final : public VNVisitor {
         // Delete the assignment node (we've extracted the value)
         VL_DO_DANGLING(pushDeletep(nodep->unlinkFrBack()), nodep);
     }
+    void visit(AstCoverCross* nodep) override {
+        userIterateAndNext(nodep->itemsp(), nullptr);
+        if (nodep->iffp()) iterateCheckBool(nodep, "iff condition", nodep->iffp(), BOTH);
+        userIterateAndNext(nodep->optionsp(), nullptr);
+        userIterateAndNext(nodep->rawBodyp(), nullptr);
+    }
     void visit(AstCoverpoint* nodep) override {
         // The coverpoint expression is self-determined (IEEE 1800-2023 19.5).  Width it
         // with a context so a bit/part-select (AstSel) is sized here; otherwise it would

--- a/src/verilog.y
+++ b/src/verilog.y
@@ -7321,24 +7321,16 @@ cover_cross<nodep>:  // ==IEEE: cover_cross
                 id/*cover_point_identifier*/ ':' yCROSS list_of_cross_items iffE cross_body
                         {
                           AstCoverCross* const nodep = new AstCoverCross{$<fl>3, *$1,
-                                                          VN_AS($4, CoverpointRef)};
+                                                          VN_AS($4, CoverpointRef), $5};
                           if ($6) nodep->addRawBodyp($6);
-                          if ($5) {
-                              $5->v3warn(COVERIGN, "Unsupported: 'iff' in coverage cross");
-                              VL_DO_DANGLING($5->deleteTree(), $5);
-                          }
                           $$ = nodep;
                         }
         |       yCROSS list_of_cross_items iffE cross_body
                         {
                           AstCoverCross* const nodep = new AstCoverCross{$<fl>1,
                                                           "__cross" + cvtToStr(GRAMMARP->s_typeImpNum++),
-                                                          VN_AS($2, CoverpointRef)};
+                                                          VN_AS($2, CoverpointRef), $3};
                           if ($4) nodep->addRawBodyp($4);
-                          if ($3) {
-                              $3->v3warn(COVERIGN, "Unsupported: 'iff' in coverage cross");
-                              VL_DO_DANGLING($3->deleteTree(), $3);
-                          }
                           $$ = nodep;
                         }
         ;

--- a/test_regress/t/t_covergroup_iff.out
+++ b/test_regress/t/t_covergroup_iff.out
@@ -1,3 +1,6 @@
+__vlAnonCG_cg.cp_a.one: 2
+__vlAnonCG_cg.cp_b.one: 2
+__vlAnonCG_cg.cross_ab.one_x_one [cross]: 1
 cg_and.cp_concat.b00: 0
 cg_and.cp_concat.b01: 1
 cg_and.cp_concat.b10: 0
@@ -6,6 +9,15 @@ cg_array_iff.cp.arr[0]: 1
 cg_array_iff.cp.arr[1]: 0
 cg_array_iff.cp.arr[2]: 0
 cg_bitw.cp.seven: 1
+cg_cross_coverpoint_iff.cp_a.one: 2
+cg_cross_coverpoint_iff.cp_b.one: 2
+cg_cross_coverpoint_iff.cross_ab.one_x_one [cross]: 1
+cg_cross_iff.cp_a.one: 3
+cg_cross_iff.cp_b.one: 3
+cg_cross_iff.cross_ab.one_x_one [cross]: 1
+cg_cross_iff_unnamed.__cross7.one_x_one [cross]: 1
+cg_cross_iff_unnamed.cp_a.one: 2
+cg_cross_iff_unnamed.cp_b.one: 2
 cg_default_iff.cp.def [default]: 1
 cg_default_iff.cp.known: 1
 cg_iff.cp_value.disabled_hi: 0

--- a/test_regress/t/t_covergroup_iff.v
+++ b/test_regress/t/t_covergroup_iff.v
@@ -8,6 +8,7 @@
 // Test iff (enable) guard: sampling is gated by the enable condition.
 // Covers iff on explicit value bins, default bin, array bins,
 // simple 2-step transition, and 3-step transition.
+// Also covers coverpoint iff propagation into crosses and cross-level iff guards.
 //
 // Also covers compound iff expressions (&&, ||, unary !, bit/part-select,
 // relational compare, parenthesized bitwise, and a concatenation-valued
@@ -20,6 +21,30 @@
 `define stop $stop
 `define checkr(gotv,expv) do if ((gotv) != (expv)) begin $write("%%Error: %s:%0d:  got=%f exp=%f\n", `__FILE__,`__LINE__, (gotv), (expv)); `stop; end while(0);
 // verilog_format: on
+
+class CrossIffEmbedded;
+  bit a;
+  bit b;
+  bit enabled;
+
+  // cross-level iff using an enclosing class member
+  covergroup cg;
+    cp_a: coverpoint a {bins one = {1};}
+    cp_b: coverpoint b {bins one = {1};}
+    cross_ab: cross cp_a, cp_b iff (this.enabled);
+  endgroup
+
+  function new();
+    cg = new;
+  endfunction
+
+  function void observe(bit next_a, bit next_b, bit next_enabled);
+    a = next_a;
+    b = next_b;
+    enabled = next_enabled;
+    cg.sample();
+  endfunction
+endclass
 
 module t;
   logic enable;
@@ -96,6 +121,29 @@ module t;
     cp: coverpoint count iff ((m_a & m_b) == 2'b10) {bins seven = {7};}
   endgroup
 
+  // coverpoint-level iff only; the cross has no guard
+  covergroup cg_cross_coverpoint_iff with function sample(
+      bit a, bit b, bit enable_a, bit enable_b);
+    cp_a: coverpoint a iff (enable_a) {bins one = {1};}
+    cp_b: coverpoint b iff (enable_b) {bins one = {1};}
+    cross_ab: cross cp_a, cp_b;
+  endgroup
+
+  // coverpoint-level and cross-level iff together
+  covergroup cg_cross_iff with function sample(
+      bit a, bit b, bit enable_a, bit enable_b, bit enable_cross);
+    cp_a: coverpoint a iff (enable_a) {bins one = {1};}
+    cp_b: coverpoint b iff (enable_b) {bins one = {1};}
+    cross_ab: cross cp_a, cp_b iff (enable_cross && (a == b));
+  endgroup
+
+  // cross-level iff only; also exercise an unnamed cross
+  covergroup cg_cross_iff_unnamed with function sample(bit a, bit b, bit disable_cross);
+    cp_a: coverpoint a {bins one = {1};}
+    cp_b: coverpoint b {bins one = {1};}
+    cross cp_a, cp_b iff (!disable_cross) {}
+  endgroup
+
   cg_iff cg1 = new;
   cg_default_iff cg2 = new;
   cg_array_iff cg3 = new;
@@ -106,8 +154,24 @@ module t;
   cg_part cpp = new;
   cg_rel cr = new;
   cg_bitw cb = new;
+  cg_cross_coverpoint_iff cxc = new;
+  cg_cross_iff cx = new;
+  cg_cross_iff_unnamed cxu = new;
+  CrossIffEmbedded cxe = new;
 
   initial begin
+    cxc.sample(1, 1, 0, 1);
+    cxc.sample(1, 1, 1, 0);
+    cxc.sample(1, 1, 1, 1);
+    cx.sample(1, 1, 0, 1, 1);
+    cx.sample(1, 1, 1, 0, 1);
+    cx.sample(1, 1, 1, 1, 0);
+    cx.sample(1, 1, 1, 1, 1);
+    cxu.sample(1, 1, 1);
+    cxu.sample(1, 1, 0);
+    cxe.observe(1, 1, 0);
+    cxe.observe(1, 1, 1);
+
     // Sample disabled_lo and disabled_hi with enable=0 -- must not be recorded
     enable = 0;
     value = 1;

--- a/test_regress/t/t_covergroup_unsup.out
+++ b/test_regress/t/t_covergroup_unsup.out
@@ -3,242 +3,233 @@
       |                        ^~
                    ... For warning description see https://verilator.org/warn/COVERIGN?v=latest
                    ... Use "/* verilator lint_off COVERIGN */" and lint_on around source to disable this message.
-%Warning-COVERIGN: t/t_covergroup_unsup.v:98:21: Unsupported: 'iff' in coverage cross
-   98 |     cross a, b iff (!rst);
-      |                     ^
-%Warning-COVERIGN: t/t_covergroup_unsup.v:101:21: Unsupported: 'iff' in coverage cross
-  101 |     cross a, b iff (!rst) {}
-      |                     ^
-%Warning-COVERIGN: t/t_covergroup_unsup.v:108:21: Unsupported: 'function' in coverage cross body
-  108 |       function void crossfunc; endfunction
+%Warning-COVERIGN: t/t_covergroup_unsup.v:102:21: Unsupported: 'function' in coverage cross body
+  102 |       function void crossfunc; endfunction
       |                     ^~~~~~~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:109:18: Unsupported: function call in coverage select expression
-  109 |       bins one = crossfunc();
+%Warning-COVERIGN: t/t_covergroup_unsup.v:103:18: Unsupported: function call in coverage select expression
+  103 |       bins one = crossfunc();
       |                  ^~~~~~~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:109:7: Unsupported: explicit coverage cross bins
-  109 |       bins one = crossfunc();
+%Warning-COVERIGN: t/t_covergroup_unsup.v:103:7: Unsupported: explicit coverage cross bins
+  103 |       bins one = crossfunc();
       |       ^~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:113:31: Unsupported: 'iff' in coverage cross
-  113 |     my_cg_id: cross a, b iff (!rst);
-      |                               ^
-%Warning-COVERIGN: t/t_covergroup_unsup.v:123:14: Unsupported: 'bins' explicit array size (treated as '[]')
-  123 |     { bins ba[2] = {a}; }
+%Warning-COVERIGN: t/t_covergroup_unsup.v:113:14: Unsupported: 'bins' explicit array size (treated as '[]')
+  113 |     { bins ba[2] = {a}; }
       |              ^
-%Warning-COVERIGN: t/t_covergroup_unsup.v:127:21: Unsupported: 'with' in cover bin (bin created without filter)
-  127 |     { bins ba = {a} with ( b ); }
+%Warning-COVERIGN: t/t_covergroup_unsup.v:117:21: Unsupported: 'with' in cover bin (bin created without filter)
+  117 |     { bins ba = {a} with ( b ); }
       |                     ^~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:130:32: Unsupported: 'with' in wildcard cover bin
-  130 |     { wildcard bins bwaw = {a} with ( b ); }
+%Warning-COVERIGN: t/t_covergroup_unsup.v:120:32: Unsupported: 'with' in wildcard cover bin
+  120 |     { wildcard bins bwaw = {a} with ( b ); }
       |                                ^~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:133:27: Unsupported: 'sequence' in default cover bin
-  133 |     { bins defs = default sequence; }
+%Warning-COVERIGN: t/t_covergroup_unsup.v:123:27: Unsupported: 'sequence' in default cover bin
+  123 |     { bins defs = default sequence; }
       |                           ^~~~~~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:136:7: Unsupported: 'wildcard' transition list in cover bin
-  136 |     { wildcard bins wbts = ( 1, 2 ); }
+%Warning-COVERIGN: t/t_covergroup_unsup.v:126:7: Unsupported: 'wildcard' transition list in cover bin
+  126 |     { wildcard bins wbts = ( 1, 2 ); }
       |       ^~~~~~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:137:31: Unsupported: covergroup value range '[...]'
-  137 |     { bins bts2 = ( 2, 3 ), ( [5:6] ), ( [5 +/- 2] ), ( [ 5 +%- 20.0] ) ; }
+%Warning-COVERIGN: t/t_covergroup_unsup.v:127:31: Unsupported: covergroup value range '[...]'
+  127 |     { bins bts2 = ( 2, 3 ), ( [5:6] ), ( [5 +/- 2] ), ( [ 5 +%- 20.0] ) ; }
       |                               ^
-%Warning-COVERIGN: t/t_covergroup_unsup.v:137:42: Unsupported: covergroup value range '[...]'
-  137 |     { bins bts2 = ( 2, 3 ), ( [5:6] ), ( [5 +/- 2] ), ( [ 5 +%- 20.0] ) ; }
+%Warning-COVERIGN: t/t_covergroup_unsup.v:127:42: Unsupported: covergroup value range '[...]'
+  127 |     { bins bts2 = ( 2, 3 ), ( [5:6] ), ( [5 +/- 2] ), ( [ 5 +%- 20.0] ) ; }
       |                                          ^
-%Warning-COVERIGN: t/t_covergroup_unsup.v:137:57: Unsupported: covergroup value range '[...]'
-  137 |     { bins bts2 = ( 2, 3 ), ( [5:6] ), ( [5 +/- 2] ), ( [ 5 +%- 20.0] ) ; }
+%Warning-COVERIGN: t/t_covergroup_unsup.v:127:57: Unsupported: covergroup value range '[...]'
+  127 |     { bins bts2 = ( 2, 3 ), ( [5:6] ), ( [5 +/- 2] ), ( [ 5 +%- 20.0] ) ; }
       |                                                         ^
-%Warning-COVERIGN: t/t_covergroup_unsup.v:140:23: Unsupported: '[*]' in cover transition
-  140 |     { bins bts2 = ( 3 [*5] ) ; }
+%Warning-COVERIGN: t/t_covergroup_unsup.v:130:23: Unsupported: '[*]' in cover transition
+  130 |     { bins bts2 = ( 3 [*5] ) ; }
       |                       ^~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:141:23: Unsupported: '[*]' in cover transition
-  141 |     { bins bts2 = ( 3 [*5:6] ) ; }
+%Warning-COVERIGN: t/t_covergroup_unsup.v:131:23: Unsupported: '[*]' in cover transition
+  131 |     { bins bts2 = ( 3 [*5:6] ) ; }
       |                       ^~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:142:23: Unsupported: '[->' in cover transition
-  142 |     { bins bts2 = ( 3 [->5] ) ; }
+%Warning-COVERIGN: t/t_covergroup_unsup.v:132:23: Unsupported: '[->' in cover transition
+  132 |     { bins bts2 = ( 3 [->5] ) ; }
       |                       ^~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:143:23: Unsupported: '[->' in cover transition
-  143 |     { bins bts2 = ( 3 [->5:6] ) ; }
+%Warning-COVERIGN: t/t_covergroup_unsup.v:133:23: Unsupported: '[->' in cover transition
+  133 |     { bins bts2 = ( 3 [->5:6] ) ; }
       |                       ^~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:144:23: Unsupported: '[=]' in cover transition
-  144 |     { bins bts2 = ( 3 [=5] ) ; }
+%Warning-COVERIGN: t/t_covergroup_unsup.v:134:23: Unsupported: '[=]' in cover transition
+  134 |     { bins bts2 = ( 3 [=5] ) ; }
       |                       ^~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:145:23: Unsupported: '[=]' in cover transition
-  145 |     { bins bts2 = ( 3 [=5:6] ) ; }
+%Warning-COVERIGN: t/t_covergroup_unsup.v:135:23: Unsupported: '[=]' in cover transition
+  135 |     { bins bts2 = ( 3 [=5:6] ) ; }
       |                       ^~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:151:12: Unsupported: 'bins' array (non-auto)
-  151 |     { bins nonAuto[4]; }
+%Warning-COVERIGN: t/t_covergroup_unsup.v:141:12: Unsupported: 'bins' array (non-auto)
+  141 |     { bins nonAuto[4]; }
       |            ^~~~~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:153:35: Unsupported: 'with' in cover bin (bin created without filter)
-  153 |     { ignore_bins ib_with = {1,2} with ( b ); }
+%Warning-COVERIGN: t/t_covergroup_unsup.v:143:35: Unsupported: 'with' in cover bin (bin created without filter)
+  143 |     { ignore_bins ib_with = {1,2} with ( b ); }
       |                                   ^~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:154:37: Unsupported: 'with' in cover bin (bin created without filter)
-  154 |     { illegal_bins lib_with = {1,2} with ( b ); }
+%Warning-COVERIGN: t/t_covergroup_unsup.v:144:37: Unsupported: 'with' in cover bin (bin created without filter)
+  144 |     { illegal_bins lib_with = {1,2} with ( b ); }
       |                                     ^~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:156:29: Unsupported: 'with' in cover bin
-  156 |     { ignore_bins ib_cp = a with ( b ); }
+%Warning-COVERIGN: t/t_covergroup_unsup.v:146:29: Unsupported: 'with' in cover bin
+  146 |     { ignore_bins ib_cp = a with ( b ); }
       |                             ^~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:157:31: Unsupported: 'with' in cover bin
-  157 |     { illegal_bins lib_cp = a with ( b ); }
+%Warning-COVERIGN: t/t_covergroup_unsup.v:147:31: Unsupported: 'with' in cover bin
+  147 |     { illegal_bins lib_cp = a with ( b ); }
       |                               ^~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:159:45: Unsupported: 'with' in wildcard cover bin
-  159 |     { wildcard ignore_bins wib_with = {1,2} with ( b ); }
+%Warning-COVERIGN: t/t_covergroup_unsup.v:149:45: Unsupported: 'with' in wildcard cover bin
+  149 |     { wildcard ignore_bins wib_with = {1,2} with ( b ); }
       |                                             ^~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:160:47: Unsupported: 'with' in wildcard cover bin
-  160 |     { wildcard illegal_bins wlib_with = {1,2} with ( b ); }
+%Warning-COVERIGN: t/t_covergroup_unsup.v:150:47: Unsupported: 'with' in wildcard cover bin
+  150 |     { wildcard illegal_bins wlib_with = {1,2} with ( b ); }
       |                                               ^~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:162:7: Unsupported: 'wildcard' transition list in cover bin
-  162 |     { wildcard ignore_bins wib_trans = ( 1 => 2 ); }
+%Warning-COVERIGN: t/t_covergroup_unsup.v:152:7: Unsupported: 'wildcard' transition list in cover bin
+  152 |     { wildcard ignore_bins wib_trans = ( 1 => 2 ); }
       |       ^~~~~~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:163:7: Unsupported: 'wildcard' transition list in cover bin
-  163 |     { wildcard illegal_bins wlib_trans = ( 1 => 2 ); }
+%Warning-COVERIGN: t/t_covergroup_unsup.v:153:7: Unsupported: 'wildcard' transition list in cover bin
+  153 |     { wildcard illegal_bins wlib_trans = ( 1 => 2 ); }
       |       ^~~~~~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:165:40: Unsupported: 'sequence' in default cover bin
-  165 |     { ignore_bins ib_def_seq = default sequence; }
+%Warning-COVERIGN: t/t_covergroup_unsup.v:155:40: Unsupported: 'sequence' in default cover bin
+  155 |     { ignore_bins ib_def_seq = default sequence; }
       |                                        ^~~~~~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:166:42: Unsupported: 'sequence' in default cover bin
-  166 |     { illegal_bins lib_def_seq = default sequence; }
+%Warning-COVERIGN: t/t_covergroup_unsup.v:156:42: Unsupported: 'sequence' in default cover bin
+  156 |     { illegal_bins lib_def_seq = default sequence; }
       |                                          ^~~~~~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:171:24: Unsupported: 'with' in cover bin
-  171 |      bins div_by_2 = a with (item % 2 == 0);
+%Warning-COVERIGN: t/t_covergroup_unsup.v:161:24: Unsupported: 'with' in cover bin
+  161 |      bins div_by_2 = a with (item % 2 == 0);
       |                        ^~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:172:32: Unsupported: 'with' in cover bin
-  172 |      bins div_by_2_paren[] = a with (item % 2 == 0);
+%Warning-COVERIGN: t/t_covergroup_unsup.v:162:32: Unsupported: 'with' in cover bin
+  162 |      bins div_by_2_paren[] = a with (item % 2 == 0);
       |                                ^~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:178:20: Unsupported: 'binsof' in coverage select expression
-  178 |       bins bin_a = binsof(a);
+%Warning-COVERIGN: t/t_covergroup_unsup.v:168:20: Unsupported: 'binsof' in coverage select expression
+  168 |       bins bin_a = binsof(a);
       |                    ^~~~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:178:7: Unsupported: explicit coverage cross bins
-  178 |       bins bin_a = binsof(a);
+%Warning-COVERIGN: t/t_covergroup_unsup.v:168:7: Unsupported: explicit coverage cross bins
+  168 |       bins bin_a = binsof(a);
       |       ^~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:179:21: Unsupported: 'binsof' in coverage select expression
-  179 |       bins bin_ai = binsof(a) iff (!rst);
+%Warning-COVERIGN: t/t_covergroup_unsup.v:169:21: Unsupported: 'binsof' in coverage select expression
+  169 |       bins bin_ai = binsof(a) iff (!rst);
       |                     ^~~~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:179:7: Unsupported: explicit coverage cross bins
-  179 |       bins bin_ai = binsof(a) iff (!rst);
+%Warning-COVERIGN: t/t_covergroup_unsup.v:169:7: Unsupported: explicit coverage cross bins
+  169 |       bins bin_ai = binsof(a) iff (!rst);
       |       ^~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:180:20: Unsupported: 'binsof' in coverage select expression
-  180 |       bins bin_c = binsof(cp.x);
+%Warning-COVERIGN: t/t_covergroup_unsup.v:170:20: Unsupported: 'binsof' in coverage select expression
+  170 |       bins bin_c = binsof(cp.x);
       |                    ^~~~~~
+%Warning-COVERIGN: t/t_covergroup_unsup.v:170:7: Unsupported: explicit coverage cross bins
+  170 |       bins bin_c = binsof(cp.x);
+      |       ^~~~
+%Warning-COVERIGN: t/t_covergroup_unsup.v:171:21: Unsupported: 'binsof' in coverage select expression
+  171 |       bins bin_na = ! binsof(a);
+      |                     ^
+%Warning-COVERIGN: t/t_covergroup_unsup.v:171:7: Unsupported: explicit coverage cross bins
+  171 |       bins bin_na = ! binsof(a);
+      |       ^~~~
+%Warning-COVERIGN: t/t_covergroup_unsup.v:173:30: Unsupported: 'intersect' in coverage select expression
+  173 |       bins bin_d = binsof(a) intersect { b };
+      |                              ^~~~~~~~~
+%Warning-COVERIGN: t/t_covergroup_unsup.v:173:7: Unsupported: explicit coverage cross bins
+  173 |       bins bin_d = binsof(a) intersect { b };
+      |       ^~~~
+%Warning-COVERIGN: t/t_covergroup_unsup.v:174:31: Unsupported: 'intersect' in coverage select expression
+  174 |       bins bin_nd = ! binsof(a) intersect { b };
+      |                               ^
+%Warning-COVERIGN: t/t_covergroup_unsup.v:174:7: Unsupported: explicit coverage cross bins
+  174 |       bins bin_nd = ! binsof(a) intersect { b };
+      |       ^~~~
+%Warning-COVERIGN: t/t_covergroup_unsup.v:176:20: Unsupported: 'with' in coverage select expression
+  176 |       bins bin_e = with (a);
+      |                    ^~~~
+%Warning-COVERIGN: t/t_covergroup_unsup.v:176:7: Unsupported: explicit coverage cross bins
+  176 |       bins bin_e = with (a);
+      |       ^~~~
+%Warning-COVERIGN: t/t_covergroup_unsup.v:177:24: Unsupported: 'with' in coverage select expression
+  177 |       bins bin_not_e = ! with (a);
+      |                        ^
+%Warning-COVERIGN: t/t_covergroup_unsup.v:177:7: Unsupported: explicit coverage cross bins
+  177 |       bins bin_not_e = ! with (a);
+      |       ^~~~
+%Warning-COVERIGN: t/t_covergroup_unsup.v:179:23: Unsupported: 'binsof' in coverage select expression
+  179 |       bins bin_par = (binsof(a));
+      |                       ^~~~~~
+%Warning-COVERIGN: t/t_covergroup_unsup.v:179:7: Unsupported: explicit coverage cross bins
+  179 |       bins bin_par = (binsof(a));
+      |       ^~~~
+%Warning-COVERIGN: t/t_covergroup_unsup.v:180:22: Unsupported: 'binsof' in coverage select expression
+  180 |       bins bin_and = binsof(a) && binsof(b);
+      |                      ^~~~~~
+%Warning-COVERIGN: t/t_covergroup_unsup.v:180:35: Unsupported: 'binsof' in coverage select expression
+  180 |       bins bin_and = binsof(a) && binsof(b);
+      |                                   ^~~~~~
+%Warning-COVERIGN: t/t_covergroup_unsup.v:180:32: Unsupported: '&&' in coverage select expression
+  180 |       bins bin_and = binsof(a) && binsof(b);
+      |                                ^~
 %Warning-COVERIGN: t/t_covergroup_unsup.v:180:7: Unsupported: explicit coverage cross bins
-  180 |       bins bin_c = binsof(cp.x);
+  180 |       bins bin_and = binsof(a) && binsof(b);
       |       ^~~~
 %Warning-COVERIGN: t/t_covergroup_unsup.v:181:21: Unsupported: 'binsof' in coverage select expression
-  181 |       bins bin_na = ! binsof(a);
-      |                     ^
-%Warning-COVERIGN: t/t_covergroup_unsup.v:181:7: Unsupported: explicit coverage cross bins
-  181 |       bins bin_na = ! binsof(a);
-      |       ^~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:183:30: Unsupported: 'intersect' in coverage select expression
-  183 |       bins bin_d = binsof(a) intersect { b };
-      |                              ^~~~~~~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:183:7: Unsupported: explicit coverage cross bins
-  183 |       bins bin_d = binsof(a) intersect { b };
-      |       ^~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:184:31: Unsupported: 'intersect' in coverage select expression
-  184 |       bins bin_nd = ! binsof(a) intersect { b };
-      |                               ^
-%Warning-COVERIGN: t/t_covergroup_unsup.v:184:7: Unsupported: explicit coverage cross bins
-  184 |       bins bin_nd = ! binsof(a) intersect { b };
-      |       ^~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:186:20: Unsupported: 'with' in coverage select expression
-  186 |       bins bin_e = with (a);
-      |                    ^~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:186:7: Unsupported: explicit coverage cross bins
-  186 |       bins bin_e = with (a);
-      |       ^~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:187:24: Unsupported: 'with' in coverage select expression
-  187 |       bins bin_not_e = ! with (a);
-      |                        ^
-%Warning-COVERIGN: t/t_covergroup_unsup.v:187:7: Unsupported: explicit coverage cross bins
-  187 |       bins bin_not_e = ! with (a);
-      |       ^~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:189:23: Unsupported: 'binsof' in coverage select expression
-  189 |       bins bin_par = (binsof(a));
-      |                       ^~~~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:189:7: Unsupported: explicit coverage cross bins
-  189 |       bins bin_par = (binsof(a));
-      |       ^~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:190:22: Unsupported: 'binsof' in coverage select expression
-  190 |       bins bin_and = binsof(a) && binsof(b);
-      |                      ^~~~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:190:35: Unsupported: 'binsof' in coverage select expression
-  190 |       bins bin_and = binsof(a) && binsof(b);
-      |                                   ^~~~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:190:32: Unsupported: '&&' in coverage select expression
-  190 |       bins bin_and = binsof(a) && binsof(b);
-      |                                ^~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:190:7: Unsupported: explicit coverage cross bins
-  190 |       bins bin_and = binsof(a) && binsof(b);
-      |       ^~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:191:21: Unsupported: 'binsof' in coverage select expression
-  191 |       bins bin_or = binsof(a) || binsof(b);
+  181 |       bins bin_or = binsof(a) || binsof(b);
       |                     ^~~~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:191:34: Unsupported: 'binsof' in coverage select expression
-  191 |       bins bin_or = binsof(a) || binsof(b);
+%Warning-COVERIGN: t/t_covergroup_unsup.v:181:34: Unsupported: 'binsof' in coverage select expression
+  181 |       bins bin_or = binsof(a) || binsof(b);
       |                                  ^~~~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:191:31: Unsupported: '||' in coverage select expression
-  191 |       bins bin_or = binsof(a) || binsof(b);
+%Warning-COVERIGN: t/t_covergroup_unsup.v:181:31: Unsupported: '||' in coverage select expression
+  181 |       bins bin_or = binsof(a) || binsof(b);
       |                               ^~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:191:7: Unsupported: explicit coverage cross bins
-  191 |       bins bin_or = binsof(a) || binsof(b);
+%Warning-COVERIGN: t/t_covergroup_unsup.v:181:7: Unsupported: explicit coverage cross bins
+  181 |       bins bin_or = binsof(a) || binsof(b);
       |       ^~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:192:23: Unsupported: 'binsof' in coverage select expression
-  192 |       bins bin_with = binsof(a) with (a);
+%Warning-COVERIGN: t/t_covergroup_unsup.v:182:23: Unsupported: 'binsof' in coverage select expression
+  182 |       bins bin_with = binsof(a) with (a);
       |                       ^~~~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:192:33: Unsupported: 'with' in coverage select expression
-  192 |       bins bin_with = binsof(a) with (a);
+%Warning-COVERIGN: t/t_covergroup_unsup.v:182:33: Unsupported: 'with' in coverage select expression
+  182 |       bins bin_with = binsof(a) with (a);
       |                                 ^~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:192:7: Unsupported: explicit coverage cross bins
-  192 |       bins bin_with = binsof(a) with (a);
+%Warning-COVERIGN: t/t_covergroup_unsup.v:182:7: Unsupported: explicit coverage cross bins
+  182 |       bins bin_with = binsof(a) with (a);
       |       ^~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:193:26: Unsupported: 'binsof' in coverage select expression
-  193 |       bins bin_or_with = binsof(a) || binsof(a) with (a);
+%Warning-COVERIGN: t/t_covergroup_unsup.v:183:26: Unsupported: 'binsof' in coverage select expression
+  183 |       bins bin_or_with = binsof(a) || binsof(a) with (a);
       |                          ^~~~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:193:39: Unsupported: 'binsof' in coverage select expression
-  193 |       bins bin_or_with = binsof(a) || binsof(a) with (a);
+%Warning-COVERIGN: t/t_covergroup_unsup.v:183:39: Unsupported: 'binsof' in coverage select expression
+  183 |       bins bin_or_with = binsof(a) || binsof(a) with (a);
       |                                       ^~~~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:193:49: Unsupported: 'with' in coverage select expression
-  193 |       bins bin_or_with = binsof(a) || binsof(a) with (a);
+%Warning-COVERIGN: t/t_covergroup_unsup.v:183:49: Unsupported: 'with' in coverage select expression
+  183 |       bins bin_or_with = binsof(a) || binsof(a) with (a);
       |                                                 ^~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:193:36: Unsupported: '||' in coverage select expression
-  193 |       bins bin_or_with = binsof(a) || binsof(a) with (a);
+%Warning-COVERIGN: t/t_covergroup_unsup.v:183:36: Unsupported: '||' in coverage select expression
+  183 |       bins bin_or_with = binsof(a) || binsof(a) with (a);
       |                                    ^~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:193:7: Unsupported: explicit coverage cross bins
-  193 |       bins bin_or_with = binsof(a) || binsof(a) with (a);
+%Warning-COVERIGN: t/t_covergroup_unsup.v:183:7: Unsupported: explicit coverage cross bins
+  183 |       bins bin_or_with = binsof(a) || binsof(a) with (a);
       |       ^~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:194:27: Unsupported: 'binsof' in coverage select expression
-  194 |       bins bin_and_with = binsof(a) && binsof(a) with (a);
+%Warning-COVERIGN: t/t_covergroup_unsup.v:184:27: Unsupported: 'binsof' in coverage select expression
+  184 |       bins bin_and_with = binsof(a) && binsof(a) with (a);
       |                           ^~~~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:194:40: Unsupported: 'binsof' in coverage select expression
-  194 |       bins bin_and_with = binsof(a) && binsof(a) with (a);
+%Warning-COVERIGN: t/t_covergroup_unsup.v:184:40: Unsupported: 'binsof' in coverage select expression
+  184 |       bins bin_and_with = binsof(a) && binsof(a) with (a);
       |                                        ^~~~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:194:50: Unsupported: 'with' in coverage select expression
-  194 |       bins bin_and_with = binsof(a) && binsof(a) with (a);
+%Warning-COVERIGN: t/t_covergroup_unsup.v:184:50: Unsupported: 'with' in coverage select expression
+  184 |       bins bin_and_with = binsof(a) && binsof(a) with (a);
       |                                                  ^~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:194:37: Unsupported: '&&' in coverage select expression
-  194 |       bins bin_and_with = binsof(a) && binsof(a) with (a);
+%Warning-COVERIGN: t/t_covergroup_unsup.v:184:37: Unsupported: '&&' in coverage select expression
+  184 |       bins bin_and_with = binsof(a) && binsof(a) with (a);
       |                                     ^~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:194:7: Unsupported: explicit coverage cross bins
-  194 |       bins bin_and_with = binsof(a) && binsof(a) with (a);
+%Warning-COVERIGN: t/t_covergroup_unsup.v:184:7: Unsupported: explicit coverage cross bins
+  184 |       bins bin_and_with = binsof(a) && binsof(a) with (a);
       |       ^~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:195:34: Unsupported: 'binsof' in coverage select expression
-  195 |       bins bin_multiple_fields = binsof(p.inner_packet.field);
+%Warning-COVERIGN: t/t_covergroup_unsup.v:185:34: Unsupported: 'binsof' in coverage select expression
+  185 |       bins bin_multiple_fields = binsof(p.inner_packet.field);
       |                                  ^~~~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:195:7: Unsupported: explicit coverage cross bins
-  195 |       bins bin_multiple_fields = binsof(p.inner_packet.field);
+%Warning-COVERIGN: t/t_covergroup_unsup.v:185:7: Unsupported: explicit coverage cross bins
+  185 |       bins bin_multiple_fields = binsof(p.inner_packet.field);
       |       ^~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:197:30: Unsupported: 'binsof' in coverage select expression
-  197 |       ignore_bins ib_cross = binsof(a);
+%Warning-COVERIGN: t/t_covergroup_unsup.v:187:30: Unsupported: 'binsof' in coverage select expression
+  187 |       ignore_bins ib_cross = binsof(a);
       |                              ^~~~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:197:7: Unsupported: explicit coverage cross bins
-  197 |       ignore_bins ib_cross = binsof(a);
+%Warning-COVERIGN: t/t_covergroup_unsup.v:187:7: Unsupported: explicit coverage cross bins
+  187 |       ignore_bins ib_cross = binsof(a);
       |       ^~~~~~~~~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:198:32: Unsupported: 'binsof' in coverage select expression
-  198 |       illegal_bins lib_cross = binsof(a);
+%Warning-COVERIGN: t/t_covergroup_unsup.v:188:32: Unsupported: 'binsof' in coverage select expression
+  188 |       illegal_bins lib_cross = binsof(a);
       |                                ^~~~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:198:7: Unsupported: explicit coverage cross bins
-  198 |       illegal_bins lib_cross = binsof(a);
+%Warning-COVERIGN: t/t_covergroup_unsup.v:188:7: Unsupported: explicit coverage cross bins
+  188 |       illegal_bins lib_cross = binsof(a);
       |       ^~~~~~~~~~~~
-%Error-UNSUPPORTED: t/t_covergroup_unsup.v:223:5: Unsupported: covergroup inheritance (extends)
-  223 |     covergroup extends cg_empty;
+%Error-UNSUPPORTED: t/t_covergroup_unsup.v:213:5: Unsupported: covergroup inheritance (extends)
+  213 |     covergroup extends cg_empty;
       |     ^~~~~~~~~~
                     ... For error description see https://verilator.org/warn/UNSUPPORTED?v=latest
 %Error: Exiting due to

--- a/test_regress/t/t_covergroup_unsup.v
+++ b/test_regress/t/t_covergroup_unsup.v
@@ -94,12 +94,6 @@ module t (
     signed id: coverpoint a iff (b);
   endgroup
 
-  covergroup cg_cross;
-    cross a, b iff (!rst);
-  endgroup
-  covergroup cg_cross2;
-    cross a, b iff (!rst) {}
-  endgroup
   covergroup cg_cross3;
     cross a, b { option.comment = "cross"; option.weight = 12; option.per_instance = 1; }
   endgroup
@@ -109,10 +103,6 @@ module t (
       bins one = crossfunc();
     }
   endgroup
-  covergroup cg_cross_id;
-    my_cg_id: cross a, b iff (!rst);
-  endgroup
-
   covergroup cg_binsoroptions_bk1;
     { bins ba = {a}; }
     { bins bar = {a} iff (!rst); }

--- a/test_regress/t/t_covergroup_unsup_ign2.out
+++ b/test_regress/t/t_covergroup_unsup_ign2.out
@@ -3,248 +3,239 @@
       |                        ^~
                    ... For warning description see https://verilator.org/warn/COVERIGN?v=latest
                    ... Use "/* verilator lint_off COVERIGN */" and lint_on around source to disable this message.
-%Warning-COVERIGN: t/t_covergroup_unsup.v:98:21: Unsupported: 'iff' in coverage cross
-   98 |     cross a, b iff (!rst);
-      |                     ^
-%Warning-COVERIGN: t/t_covergroup_unsup.v:101:21: Unsupported: 'iff' in coverage cross
-  101 |     cross a, b iff (!rst) {}
-      |                     ^
-%Warning-COVERIGN: t/t_covergroup_unsup.v:108:21: Unsupported: 'function' in coverage cross body
-  108 |       function void crossfunc; endfunction
+%Warning-COVERIGN: t/t_covergroup_unsup.v:102:21: Unsupported: 'function' in coverage cross body
+  102 |       function void crossfunc; endfunction
       |                     ^~~~~~~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:109:18: Unsupported: function call in coverage select expression
-  109 |       bins one = crossfunc();
+%Warning-COVERIGN: t/t_covergroup_unsup.v:103:18: Unsupported: function call in coverage select expression
+  103 |       bins one = crossfunc();
       |                  ^~~~~~~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:109:7: Unsupported: explicit coverage cross bins
-  109 |       bins one = crossfunc();
+%Warning-COVERIGN: t/t_covergroup_unsup.v:103:7: Unsupported: explicit coverage cross bins
+  103 |       bins one = crossfunc();
       |       ^~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:113:31: Unsupported: 'iff' in coverage cross
-  113 |     my_cg_id: cross a, b iff (!rst);
-      |                               ^
-%Warning-COVERIGN: t/t_covergroup_unsup.v:123:14: Unsupported: 'bins' explicit array size (treated as '[]')
-  123 |     { bins ba[2] = {a}; }
+%Warning-COVERIGN: t/t_covergroup_unsup.v:113:14: Unsupported: 'bins' explicit array size (treated as '[]')
+  113 |     { bins ba[2] = {a}; }
       |              ^
-%Warning-COVERIGN: t/t_covergroup_unsup.v:127:21: Unsupported: 'with' in cover bin (bin created without filter)
-  127 |     { bins ba = {a} with ( b ); }
+%Warning-COVERIGN: t/t_covergroup_unsup.v:117:21: Unsupported: 'with' in cover bin (bin created without filter)
+  117 |     { bins ba = {a} with ( b ); }
       |                     ^~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:130:32: Unsupported: 'with' in wildcard cover bin
-  130 |     { wildcard bins bwaw = {a} with ( b ); }
+%Warning-COVERIGN: t/t_covergroup_unsup.v:120:32: Unsupported: 'with' in wildcard cover bin
+  120 |     { wildcard bins bwaw = {a} with ( b ); }
       |                                ^~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:133:27: Unsupported: 'sequence' in default cover bin
-  133 |     { bins defs = default sequence; }
+%Warning-COVERIGN: t/t_covergroup_unsup.v:123:27: Unsupported: 'sequence' in default cover bin
+  123 |     { bins defs = default sequence; }
       |                           ^~~~~~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:136:7: Unsupported: 'wildcard' transition list in cover bin
-  136 |     { wildcard bins wbts = ( 1, 2 ); }
+%Warning-COVERIGN: t/t_covergroup_unsup.v:126:7: Unsupported: 'wildcard' transition list in cover bin
+  126 |     { wildcard bins wbts = ( 1, 2 ); }
       |       ^~~~~~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:137:31: Unsupported: covergroup value range '[...]'
-  137 |     { bins bts2 = ( 2, 3 ), ( [5:6] ), ( [5 +/- 2] ), ( [ 5 +%- 20.0] ) ; }
+%Warning-COVERIGN: t/t_covergroup_unsup.v:127:31: Unsupported: covergroup value range '[...]'
+  127 |     { bins bts2 = ( 2, 3 ), ( [5:6] ), ( [5 +/- 2] ), ( [ 5 +%- 20.0] ) ; }
       |                               ^
-%Warning-COVERIGN: t/t_covergroup_unsup.v:137:42: Unsupported: covergroup value range '[...]'
-  137 |     { bins bts2 = ( 2, 3 ), ( [5:6] ), ( [5 +/- 2] ), ( [ 5 +%- 20.0] ) ; }
+%Warning-COVERIGN: t/t_covergroup_unsup.v:127:42: Unsupported: covergroup value range '[...]'
+  127 |     { bins bts2 = ( 2, 3 ), ( [5:6] ), ( [5 +/- 2] ), ( [ 5 +%- 20.0] ) ; }
       |                                          ^
-%Warning-COVERIGN: t/t_covergroup_unsup.v:137:57: Unsupported: covergroup value range '[...]'
-  137 |     { bins bts2 = ( 2, 3 ), ( [5:6] ), ( [5 +/- 2] ), ( [ 5 +%- 20.0] ) ; }
+%Warning-COVERIGN: t/t_covergroup_unsup.v:127:57: Unsupported: covergroup value range '[...]'
+  127 |     { bins bts2 = ( 2, 3 ), ( [5:6] ), ( [5 +/- 2] ), ( [ 5 +%- 20.0] ) ; }
       |                                                         ^
-%Warning-COVERIGN: t/t_covergroup_unsup.v:140:23: Unsupported: '[*]' in cover transition
-  140 |     { bins bts2 = ( 3 [*5] ) ; }
+%Warning-COVERIGN: t/t_covergroup_unsup.v:130:23: Unsupported: '[*]' in cover transition
+  130 |     { bins bts2 = ( 3 [*5] ) ; }
       |                       ^~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:141:23: Unsupported: '[*]' in cover transition
-  141 |     { bins bts2 = ( 3 [*5:6] ) ; }
+%Warning-COVERIGN: t/t_covergroup_unsup.v:131:23: Unsupported: '[*]' in cover transition
+  131 |     { bins bts2 = ( 3 [*5:6] ) ; }
       |                       ^~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:142:23: Unsupported: '[->' in cover transition
-  142 |     { bins bts2 = ( 3 [->5] ) ; }
+%Warning-COVERIGN: t/t_covergroup_unsup.v:132:23: Unsupported: '[->' in cover transition
+  132 |     { bins bts2 = ( 3 [->5] ) ; }
       |                       ^~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:143:23: Unsupported: '[->' in cover transition
-  143 |     { bins bts2 = ( 3 [->5:6] ) ; }
+%Warning-COVERIGN: t/t_covergroup_unsup.v:133:23: Unsupported: '[->' in cover transition
+  133 |     { bins bts2 = ( 3 [->5:6] ) ; }
       |                       ^~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:144:23: Unsupported: '[=]' in cover transition
-  144 |     { bins bts2 = ( 3 [=5] ) ; }
+%Warning-COVERIGN: t/t_covergroup_unsup.v:134:23: Unsupported: '[=]' in cover transition
+  134 |     { bins bts2 = ( 3 [=5] ) ; }
       |                       ^~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:145:23: Unsupported: '[=]' in cover transition
-  145 |     { bins bts2 = ( 3 [=5:6] ) ; }
+%Warning-COVERIGN: t/t_covergroup_unsup.v:135:23: Unsupported: '[=]' in cover transition
+  135 |     { bins bts2 = ( 3 [=5:6] ) ; }
       |                       ^~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:151:12: Unsupported: 'bins' array (non-auto)
-  151 |     { bins nonAuto[4]; }
+%Warning-COVERIGN: t/t_covergroup_unsup.v:141:12: Unsupported: 'bins' array (non-auto)
+  141 |     { bins nonAuto[4]; }
       |            ^~~~~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:153:35: Unsupported: 'with' in cover bin (bin created without filter)
-  153 |     { ignore_bins ib_with = {1,2} with ( b ); }
+%Warning-COVERIGN: t/t_covergroup_unsup.v:143:35: Unsupported: 'with' in cover bin (bin created without filter)
+  143 |     { ignore_bins ib_with = {1,2} with ( b ); }
       |                                   ^~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:154:37: Unsupported: 'with' in cover bin (bin created without filter)
-  154 |     { illegal_bins lib_with = {1,2} with ( b ); }
+%Warning-COVERIGN: t/t_covergroup_unsup.v:144:37: Unsupported: 'with' in cover bin (bin created without filter)
+  144 |     { illegal_bins lib_with = {1,2} with ( b ); }
       |                                     ^~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:156:29: Unsupported: 'with' in cover bin
-  156 |     { ignore_bins ib_cp = a with ( b ); }
+%Warning-COVERIGN: t/t_covergroup_unsup.v:146:29: Unsupported: 'with' in cover bin
+  146 |     { ignore_bins ib_cp = a with ( b ); }
       |                             ^~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:157:31: Unsupported: 'with' in cover bin
-  157 |     { illegal_bins lib_cp = a with ( b ); }
+%Warning-COVERIGN: t/t_covergroup_unsup.v:147:31: Unsupported: 'with' in cover bin
+  147 |     { illegal_bins lib_cp = a with ( b ); }
       |                               ^~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:159:45: Unsupported: 'with' in wildcard cover bin
-  159 |     { wildcard ignore_bins wib_with = {1,2} with ( b ); }
+%Warning-COVERIGN: t/t_covergroup_unsup.v:149:45: Unsupported: 'with' in wildcard cover bin
+  149 |     { wildcard ignore_bins wib_with = {1,2} with ( b ); }
       |                                             ^~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:160:47: Unsupported: 'with' in wildcard cover bin
-  160 |     { wildcard illegal_bins wlib_with = {1,2} with ( b ); }
+%Warning-COVERIGN: t/t_covergroup_unsup.v:150:47: Unsupported: 'with' in wildcard cover bin
+  150 |     { wildcard illegal_bins wlib_with = {1,2} with ( b ); }
       |                                               ^~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:162:7: Unsupported: 'wildcard' transition list in cover bin
-  162 |     { wildcard ignore_bins wib_trans = ( 1 => 2 ); }
+%Warning-COVERIGN: t/t_covergroup_unsup.v:152:7: Unsupported: 'wildcard' transition list in cover bin
+  152 |     { wildcard ignore_bins wib_trans = ( 1 => 2 ); }
       |       ^~~~~~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:163:7: Unsupported: 'wildcard' transition list in cover bin
-  163 |     { wildcard illegal_bins wlib_trans = ( 1 => 2 ); }
+%Warning-COVERIGN: t/t_covergroup_unsup.v:153:7: Unsupported: 'wildcard' transition list in cover bin
+  153 |     { wildcard illegal_bins wlib_trans = ( 1 => 2 ); }
       |       ^~~~~~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:165:40: Unsupported: 'sequence' in default cover bin
-  165 |     { ignore_bins ib_def_seq = default sequence; }
+%Warning-COVERIGN: t/t_covergroup_unsup.v:155:40: Unsupported: 'sequence' in default cover bin
+  155 |     { ignore_bins ib_def_seq = default sequence; }
       |                                        ^~~~~~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:166:42: Unsupported: 'sequence' in default cover bin
-  166 |     { illegal_bins lib_def_seq = default sequence; }
+%Warning-COVERIGN: t/t_covergroup_unsup.v:156:42: Unsupported: 'sequence' in default cover bin
+  156 |     { illegal_bins lib_def_seq = default sequence; }
       |                                          ^~~~~~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:171:24: Unsupported: 'with' in cover bin
-  171 |      bins div_by_2 = a with (item % 2 == 0);
+%Warning-COVERIGN: t/t_covergroup_unsup.v:161:24: Unsupported: 'with' in cover bin
+  161 |      bins div_by_2 = a with (item % 2 == 0);
       |                        ^~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:172:32: Unsupported: 'with' in cover bin
-  172 |      bins div_by_2_paren[] = a with (item % 2 == 0);
+%Warning-COVERIGN: t/t_covergroup_unsup.v:162:32: Unsupported: 'with' in cover bin
+  162 |      bins div_by_2_paren[] = a with (item % 2 == 0);
       |                                ^~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:178:20: Unsupported: 'binsof' in coverage select expression
-  178 |       bins bin_a = binsof(a);
+%Warning-COVERIGN: t/t_covergroup_unsup.v:168:20: Unsupported: 'binsof' in coverage select expression
+  168 |       bins bin_a = binsof(a);
       |                    ^~~~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:178:7: Unsupported: explicit coverage cross bins
-  178 |       bins bin_a = binsof(a);
+%Warning-COVERIGN: t/t_covergroup_unsup.v:168:7: Unsupported: explicit coverage cross bins
+  168 |       bins bin_a = binsof(a);
       |       ^~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:179:21: Unsupported: 'binsof' in coverage select expression
-  179 |       bins bin_ai = binsof(a) iff (!rst);
+%Warning-COVERIGN: t/t_covergroup_unsup.v:169:21: Unsupported: 'binsof' in coverage select expression
+  169 |       bins bin_ai = binsof(a) iff (!rst);
       |                     ^~~~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:179:7: Unsupported: explicit coverage cross bins
-  179 |       bins bin_ai = binsof(a) iff (!rst);
+%Warning-COVERIGN: t/t_covergroup_unsup.v:169:7: Unsupported: explicit coverage cross bins
+  169 |       bins bin_ai = binsof(a) iff (!rst);
       |       ^~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:180:20: Unsupported: 'binsof' in coverage select expression
-  180 |       bins bin_c = binsof(cp.x);
+%Warning-COVERIGN: t/t_covergroup_unsup.v:170:20: Unsupported: 'binsof' in coverage select expression
+  170 |       bins bin_c = binsof(cp.x);
       |                    ^~~~~~
+%Warning-COVERIGN: t/t_covergroup_unsup.v:170:7: Unsupported: explicit coverage cross bins
+  170 |       bins bin_c = binsof(cp.x);
+      |       ^~~~
+%Warning-COVERIGN: t/t_covergroup_unsup.v:171:21: Unsupported: 'binsof' in coverage select expression
+  171 |       bins bin_na = ! binsof(a);
+      |                     ^
+%Warning-COVERIGN: t/t_covergroup_unsup.v:171:7: Unsupported: explicit coverage cross bins
+  171 |       bins bin_na = ! binsof(a);
+      |       ^~~~
+%Warning-COVERIGN: t/t_covergroup_unsup.v:173:30: Unsupported: 'intersect' in coverage select expression
+  173 |       bins bin_d = binsof(a) intersect { b };
+      |                              ^~~~~~~~~
+%Warning-COVERIGN: t/t_covergroup_unsup.v:173:7: Unsupported: explicit coverage cross bins
+  173 |       bins bin_d = binsof(a) intersect { b };
+      |       ^~~~
+%Warning-COVERIGN: t/t_covergroup_unsup.v:174:31: Unsupported: 'intersect' in coverage select expression
+  174 |       bins bin_nd = ! binsof(a) intersect { b };
+      |                               ^
+%Warning-COVERIGN: t/t_covergroup_unsup.v:174:7: Unsupported: explicit coverage cross bins
+  174 |       bins bin_nd = ! binsof(a) intersect { b };
+      |       ^~~~
+%Warning-COVERIGN: t/t_covergroup_unsup.v:176:20: Unsupported: 'with' in coverage select expression
+  176 |       bins bin_e = with (a);
+      |                    ^~~~
+%Warning-COVERIGN: t/t_covergroup_unsup.v:176:7: Unsupported: explicit coverage cross bins
+  176 |       bins bin_e = with (a);
+      |       ^~~~
+%Warning-COVERIGN: t/t_covergroup_unsup.v:177:24: Unsupported: 'with' in coverage select expression
+  177 |       bins bin_not_e = ! with (a);
+      |                        ^
+%Warning-COVERIGN: t/t_covergroup_unsup.v:177:7: Unsupported: explicit coverage cross bins
+  177 |       bins bin_not_e = ! with (a);
+      |       ^~~~
+%Warning-COVERIGN: t/t_covergroup_unsup.v:179:23: Unsupported: 'binsof' in coverage select expression
+  179 |       bins bin_par = (binsof(a));
+      |                       ^~~~~~
+%Warning-COVERIGN: t/t_covergroup_unsup.v:179:7: Unsupported: explicit coverage cross bins
+  179 |       bins bin_par = (binsof(a));
+      |       ^~~~
+%Warning-COVERIGN: t/t_covergroup_unsup.v:180:22: Unsupported: 'binsof' in coverage select expression
+  180 |       bins bin_and = binsof(a) && binsof(b);
+      |                      ^~~~~~
+%Warning-COVERIGN: t/t_covergroup_unsup.v:180:35: Unsupported: 'binsof' in coverage select expression
+  180 |       bins bin_and = binsof(a) && binsof(b);
+      |                                   ^~~~~~
+%Warning-COVERIGN: t/t_covergroup_unsup.v:180:32: Unsupported: '&&' in coverage select expression
+  180 |       bins bin_and = binsof(a) && binsof(b);
+      |                                ^~
 %Warning-COVERIGN: t/t_covergroup_unsup.v:180:7: Unsupported: explicit coverage cross bins
-  180 |       bins bin_c = binsof(cp.x);
+  180 |       bins bin_and = binsof(a) && binsof(b);
       |       ^~~~
 %Warning-COVERIGN: t/t_covergroup_unsup.v:181:21: Unsupported: 'binsof' in coverage select expression
-  181 |       bins bin_na = ! binsof(a);
-      |                     ^
-%Warning-COVERIGN: t/t_covergroup_unsup.v:181:7: Unsupported: explicit coverage cross bins
-  181 |       bins bin_na = ! binsof(a);
-      |       ^~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:183:30: Unsupported: 'intersect' in coverage select expression
-  183 |       bins bin_d = binsof(a) intersect { b };
-      |                              ^~~~~~~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:183:7: Unsupported: explicit coverage cross bins
-  183 |       bins bin_d = binsof(a) intersect { b };
-      |       ^~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:184:31: Unsupported: 'intersect' in coverage select expression
-  184 |       bins bin_nd = ! binsof(a) intersect { b };
-      |                               ^
-%Warning-COVERIGN: t/t_covergroup_unsup.v:184:7: Unsupported: explicit coverage cross bins
-  184 |       bins bin_nd = ! binsof(a) intersect { b };
-      |       ^~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:186:20: Unsupported: 'with' in coverage select expression
-  186 |       bins bin_e = with (a);
-      |                    ^~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:186:7: Unsupported: explicit coverage cross bins
-  186 |       bins bin_e = with (a);
-      |       ^~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:187:24: Unsupported: 'with' in coverage select expression
-  187 |       bins bin_not_e = ! with (a);
-      |                        ^
-%Warning-COVERIGN: t/t_covergroup_unsup.v:187:7: Unsupported: explicit coverage cross bins
-  187 |       bins bin_not_e = ! with (a);
-      |       ^~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:189:23: Unsupported: 'binsof' in coverage select expression
-  189 |       bins bin_par = (binsof(a));
-      |                       ^~~~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:189:7: Unsupported: explicit coverage cross bins
-  189 |       bins bin_par = (binsof(a));
-      |       ^~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:190:22: Unsupported: 'binsof' in coverage select expression
-  190 |       bins bin_and = binsof(a) && binsof(b);
-      |                      ^~~~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:190:35: Unsupported: 'binsof' in coverage select expression
-  190 |       bins bin_and = binsof(a) && binsof(b);
-      |                                   ^~~~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:190:32: Unsupported: '&&' in coverage select expression
-  190 |       bins bin_and = binsof(a) && binsof(b);
-      |                                ^~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:190:7: Unsupported: explicit coverage cross bins
-  190 |       bins bin_and = binsof(a) && binsof(b);
-      |       ^~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:191:21: Unsupported: 'binsof' in coverage select expression
-  191 |       bins bin_or = binsof(a) || binsof(b);
+  181 |       bins bin_or = binsof(a) || binsof(b);
       |                     ^~~~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:191:34: Unsupported: 'binsof' in coverage select expression
-  191 |       bins bin_or = binsof(a) || binsof(b);
+%Warning-COVERIGN: t/t_covergroup_unsup.v:181:34: Unsupported: 'binsof' in coverage select expression
+  181 |       bins bin_or = binsof(a) || binsof(b);
       |                                  ^~~~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:191:31: Unsupported: '||' in coverage select expression
-  191 |       bins bin_or = binsof(a) || binsof(b);
+%Warning-COVERIGN: t/t_covergroup_unsup.v:181:31: Unsupported: '||' in coverage select expression
+  181 |       bins bin_or = binsof(a) || binsof(b);
       |                               ^~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:191:7: Unsupported: explicit coverage cross bins
-  191 |       bins bin_or = binsof(a) || binsof(b);
+%Warning-COVERIGN: t/t_covergroup_unsup.v:181:7: Unsupported: explicit coverage cross bins
+  181 |       bins bin_or = binsof(a) || binsof(b);
       |       ^~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:192:23: Unsupported: 'binsof' in coverage select expression
-  192 |       bins bin_with = binsof(a) with (a);
+%Warning-COVERIGN: t/t_covergroup_unsup.v:182:23: Unsupported: 'binsof' in coverage select expression
+  182 |       bins bin_with = binsof(a) with (a);
       |                       ^~~~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:192:33: Unsupported: 'with' in coverage select expression
-  192 |       bins bin_with = binsof(a) with (a);
+%Warning-COVERIGN: t/t_covergroup_unsup.v:182:33: Unsupported: 'with' in coverage select expression
+  182 |       bins bin_with = binsof(a) with (a);
       |                                 ^~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:192:7: Unsupported: explicit coverage cross bins
-  192 |       bins bin_with = binsof(a) with (a);
+%Warning-COVERIGN: t/t_covergroup_unsup.v:182:7: Unsupported: explicit coverage cross bins
+  182 |       bins bin_with = binsof(a) with (a);
       |       ^~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:193:26: Unsupported: 'binsof' in coverage select expression
-  193 |       bins bin_or_with = binsof(a) || binsof(a) with (a);
+%Warning-COVERIGN: t/t_covergroup_unsup.v:183:26: Unsupported: 'binsof' in coverage select expression
+  183 |       bins bin_or_with = binsof(a) || binsof(a) with (a);
       |                          ^~~~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:193:39: Unsupported: 'binsof' in coverage select expression
-  193 |       bins bin_or_with = binsof(a) || binsof(a) with (a);
+%Warning-COVERIGN: t/t_covergroup_unsup.v:183:39: Unsupported: 'binsof' in coverage select expression
+  183 |       bins bin_or_with = binsof(a) || binsof(a) with (a);
       |                                       ^~~~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:193:49: Unsupported: 'with' in coverage select expression
-  193 |       bins bin_or_with = binsof(a) || binsof(a) with (a);
+%Warning-COVERIGN: t/t_covergroup_unsup.v:183:49: Unsupported: 'with' in coverage select expression
+  183 |       bins bin_or_with = binsof(a) || binsof(a) with (a);
       |                                                 ^~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:193:36: Unsupported: '||' in coverage select expression
-  193 |       bins bin_or_with = binsof(a) || binsof(a) with (a);
+%Warning-COVERIGN: t/t_covergroup_unsup.v:183:36: Unsupported: '||' in coverage select expression
+  183 |       bins bin_or_with = binsof(a) || binsof(a) with (a);
       |                                    ^~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:193:7: Unsupported: explicit coverage cross bins
-  193 |       bins bin_or_with = binsof(a) || binsof(a) with (a);
+%Warning-COVERIGN: t/t_covergroup_unsup.v:183:7: Unsupported: explicit coverage cross bins
+  183 |       bins bin_or_with = binsof(a) || binsof(a) with (a);
       |       ^~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:194:27: Unsupported: 'binsof' in coverage select expression
-  194 |       bins bin_and_with = binsof(a) && binsof(a) with (a);
+%Warning-COVERIGN: t/t_covergroup_unsup.v:184:27: Unsupported: 'binsof' in coverage select expression
+  184 |       bins bin_and_with = binsof(a) && binsof(a) with (a);
       |                           ^~~~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:194:40: Unsupported: 'binsof' in coverage select expression
-  194 |       bins bin_and_with = binsof(a) && binsof(a) with (a);
+%Warning-COVERIGN: t/t_covergroup_unsup.v:184:40: Unsupported: 'binsof' in coverage select expression
+  184 |       bins bin_and_with = binsof(a) && binsof(a) with (a);
       |                                        ^~~~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:194:50: Unsupported: 'with' in coverage select expression
-  194 |       bins bin_and_with = binsof(a) && binsof(a) with (a);
+%Warning-COVERIGN: t/t_covergroup_unsup.v:184:50: Unsupported: 'with' in coverage select expression
+  184 |       bins bin_and_with = binsof(a) && binsof(a) with (a);
       |                                                  ^~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:194:37: Unsupported: '&&' in coverage select expression
-  194 |       bins bin_and_with = binsof(a) && binsof(a) with (a);
+%Warning-COVERIGN: t/t_covergroup_unsup.v:184:37: Unsupported: '&&' in coverage select expression
+  184 |       bins bin_and_with = binsof(a) && binsof(a) with (a);
       |                                     ^~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:194:7: Unsupported: explicit coverage cross bins
-  194 |       bins bin_and_with = binsof(a) && binsof(a) with (a);
+%Warning-COVERIGN: t/t_covergroup_unsup.v:184:7: Unsupported: explicit coverage cross bins
+  184 |       bins bin_and_with = binsof(a) && binsof(a) with (a);
       |       ^~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:195:34: Unsupported: 'binsof' in coverage select expression
-  195 |       bins bin_multiple_fields = binsof(p.inner_packet.field);
+%Warning-COVERIGN: t/t_covergroup_unsup.v:185:34: Unsupported: 'binsof' in coverage select expression
+  185 |       bins bin_multiple_fields = binsof(p.inner_packet.field);
       |                                  ^~~~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:195:7: Unsupported: explicit coverage cross bins
-  195 |       bins bin_multiple_fields = binsof(p.inner_packet.field);
+%Warning-COVERIGN: t/t_covergroup_unsup.v:185:7: Unsupported: explicit coverage cross bins
+  185 |       bins bin_multiple_fields = binsof(p.inner_packet.field);
       |       ^~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:197:30: Unsupported: 'binsof' in coverage select expression
-  197 |       ignore_bins ib_cross = binsof(a);
+%Warning-COVERIGN: t/t_covergroup_unsup.v:187:30: Unsupported: 'binsof' in coverage select expression
+  187 |       ignore_bins ib_cross = binsof(a);
       |                              ^~~~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:197:7: Unsupported: explicit coverage cross bins
-  197 |       ignore_bins ib_cross = binsof(a);
+%Warning-COVERIGN: t/t_covergroup_unsup.v:187:7: Unsupported: explicit coverage cross bins
+  187 |       ignore_bins ib_cross = binsof(a);
       |       ^~~~~~~~~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:198:32: Unsupported: 'binsof' in coverage select expression
-  198 |       illegal_bins lib_cross = binsof(a);
+%Warning-COVERIGN: t/t_covergroup_unsup.v:188:32: Unsupported: 'binsof' in coverage select expression
+  188 |       illegal_bins lib_cross = binsof(a);
       |                                ^~~~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:198:7: Unsupported: explicit coverage cross bins
-  198 |       illegal_bins lib_cross = binsof(a);
+%Warning-COVERIGN: t/t_covergroup_unsup.v:188:7: Unsupported: explicit coverage cross bins
+  188 |       illegal_bins lib_cross = binsof(a);
       |       ^~~~~~~~~~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:104:18: Ignoring unsupported coverage cross option: 'comment'
-  104 |     cross a, b { option.comment = "cross"; option.weight = 12; option.per_instance = 1; }
+%Warning-COVERIGN: t/t_covergroup_unsup.v:98:18: Ignoring unsupported coverage cross option: 'comment'
+   98 |     cross a, b { option.comment = "cross"; option.weight = 12; option.per_instance = 1; }
       |                  ^~~~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:104:44: Ignoring unsupported coverage cross option: 'weight'
-  104 |     cross a, b { option.comment = "cross"; option.weight = 12; option.per_instance = 1; }
+%Warning-COVERIGN: t/t_covergroup_unsup.v:98:44: Ignoring unsupported coverage cross option: 'weight'
+   98 |     cross a, b { option.comment = "cross"; option.weight = 12; option.per_instance = 1; }
       |                                            ^~~~~~
-%Warning-COVERIGN: t/t_covergroup_unsup.v:104:64: Ignoring unsupported coverage cross option: 'per_instance'
-  104 |     cross a, b { option.comment = "cross"; option.weight = 12; option.per_instance = 1; }
+%Warning-COVERIGN: t/t_covergroup_unsup.v:98:64: Ignoring unsupported coverage cross option: 'per_instance'
+   98 |     cross a, b { option.comment = "cross"; option.weight = 12; option.per_instance = 1; }
       |                                                                ^~~~~~
 %Warning-WIDTHTRUNC: t/t_covergroup_unsup.v:76:5: Logical operator COVERPOINT 'a' expects 1 bit on the iff condition, but iff condition's VARREF 'b' generates 32 bits.
                                                 : ... note: In instance 't'
@@ -278,25 +269,13 @@
       |                ^~~~~~~~~~
 %Warning-COVERIGN: t/t_covergroup_unsup.v:98:11: Unsupported: cross of 'a' which is not a coverpoint (implicit coverpoint)
                                                : ... note: In instance 't'
-   98 |     cross a, b iff (!rst);
+   98 |     cross a, b { option.comment = "cross"; option.weight = 12; option.per_instance = 1; }
       |           ^
 %Warning-COVERIGN: t/t_covergroup_unsup.v:101:11: Unsupported: cross of 'a' which is not a coverpoint (implicit coverpoint)
                                                 : ... note: In instance 't'
-  101 |     cross a, b iff (!rst) {}
+  101 |     cross a, b {
       |           ^
-%Warning-COVERIGN: t/t_covergroup_unsup.v:104:11: Unsupported: cross of 'a' which is not a coverpoint (implicit coverpoint)
+%Warning-COVERIGN: t/t_covergroup_unsup.v:167:11: Unsupported: cross of 'a' which is not a coverpoint (implicit coverpoint)
                                                 : ... note: In instance 't'
-  104 |     cross a, b { option.comment = "cross"; option.weight = 12; option.per_instance = 1; }
-      |           ^
-%Warning-COVERIGN: t/t_covergroup_unsup.v:107:11: Unsupported: cross of 'a' which is not a coverpoint (implicit coverpoint)
-                                                : ... note: In instance 't'
-  107 |     cross a, b {
-      |           ^
-%Warning-COVERIGN: t/t_covergroup_unsup.v:113:21: Unsupported: cross of 'a' which is not a coverpoint (implicit coverpoint)
-                                                : ... note: In instance 't'
-  113 |     my_cg_id: cross a, b iff (!rst);
-      |                     ^
-%Warning-COVERIGN: t/t_covergroup_unsup.v:177:11: Unsupported: cross of 'a' which is not a coverpoint (implicit coverpoint)
-                                                : ... note: In instance 't'
-  177 |     cross a, b {
+  167 |     cross a, b {
       |           ^

--- a/test_regress/t/t_debug_emitv.out
+++ b/test_regress/t/t_debug_emitv.out
@@ -953,7 +953,7 @@ module Vt_debug_emitv_t;
             bins y0 = {'sh0};
             bins y1 = {'sh1};
         };
-      cx: cross cp_x, cp_y;
+      cx: cross cp_x, cp_y iff ((cg_sig[0] == cg_sig2[0]));
     endfunction
     int signed __Vint;
     struct {

--- a/test_regress/t/t_debug_emitv.v
+++ b/test_regress/t/t_debug_emitv.v
@@ -430,7 +430,7 @@ module t (/*AUTOARG*/
       bins y0 = {0};
       bins y1 = {1};
     }
-    cx: cross cp_x, cp_y;
+    cx: cross cp_x, cp_y iff (cg_sig[0] == cg_sig2[0]);
   endgroup
 
   cg_basic   cg_basic_inst   = new;


### PR DESCRIPTION
Add `iff` support for coverpoints used in crosses and for crosses.
Tested on Questa.

/cc @mballance 