### PR TITLE
Do not emit 'get-value' for empty constrained arrays

### DIFF
--- a/include/verilated_random.cpp
+++ b/include/verilated_random.cpp
@@ -808,15 +808,20 @@ bool VlRandomizer::parseSolution(std::iostream& os) {
         return false;
     }
 
-    os << "(get-value (";
+    std::stringstream getValueStr;
     for (const auto& var : m_vars) {
         if (var.second->dimension() > 0) {
             auto arrVarsp = std::make_shared<const ArrayInfoMap>(m_arr_vars);
             var.second->setArrayInfo(arrVarsp);
         }
-        var.second->emitGetValue(os);
+        var.second->emitGetValue(getValueStr);
     }
-    os << "))\n";
+    if (getValueStr.str() == "") {
+        // Mark as m_checkOnly to skip generation of any subsequent solver calls
+        m_checkOnly = true;
+        return true;
+    }
+    os << "(get-value (" << getValueStr.str() << "))\n";
     // Quasi-parse S-expression of the form ((x #xVALUE) (y #bVALUE) (z #xVALUE))
     char c;
     if (!(os >> c) || c != '(') {

--- a/test_regress/t/t_constraint_array_index.v
+++ b/test_regress/t/t_constraint_array_index.v
@@ -142,6 +142,41 @@ class Test13_VeryLargeArray;
   }
 endclass
 
+// Test 14: Foreach on empty array
+class Test14_EmptyArray;
+  rand int empty[];
+
+  function new;
+    empty = new[0];
+  endfunction
+
+  constraint c {
+    foreach (empty[i]) {
+      empty[i] == 0;
+    }
+  }
+endclass
+
+// Test 15: Foreach on empty and not empty array
+class Test15_EmptyAndNotEmptyArray;
+  rand int empty[];
+  rand int notEmpty[];
+
+  function new;
+    empty = new[0];
+    notEmpty = new[10];
+  endfunction
+
+  constraint c {
+    foreach (empty[i]) {
+      empty[i] == 0;
+    }
+    foreach (notEmpty[i]) {
+      notEmpty[i] == 'hDEADBEEF;
+    }
+  }
+endclass
+
 module t;
   initial begin
     Test1_BasicIndex t1;
@@ -157,6 +192,8 @@ module t;
     Test11_LargerArray t11;
     Test12_LargeComplex t12;
     Test13_VeryLargeArray t13;
+    Test14_EmptyArray t14;
+    Test15_EmptyAndNotEmptyArray t15;
     int i;
 
     // Test 1: Basic index
@@ -223,6 +260,19 @@ module t;
     t13 = new;
     i = t13.randomize();
     `checkd(i, 1)
+
+    // Test 14: Foreach on empty array
+    t14 = new;
+    i = t14.randomize();
+    `checkd(i, 1)
+
+    // Test 15: Foreach on empty and not empty array
+    t15 = new;
+    i = t15.randomize();
+    `checkd(i, 1)
+    foreach (t15.notEmpty[i]) begin
+        `checkd(t15.notEmpty[i], 'hDEADBEEF);
+    end
 
     $write("*-* All Finished *-*\n");
     $finish;


### PR DESCRIPTION
When we try to constraint empty array we generate empty `get-value` solver call, which makes solver throw an error and thus randomization fails. This commit aims to get rid of empty `get-value` calls if there is an empty array constrained.