### PR TITLE
Internals: Move DPI export AstScopeName out of statement list (#6280)

### DIFF
--- a/src/V3AstNodeOther.h
+++ b/src/V3AstNodeOther.h
@@ -508,6 +508,7 @@ class AstCFunc final : public AstNode {
     // @astgen op1 := argsp : List[AstVar]  // Argument (and return value) variables
     // @astgen op2 := varsp : List[AstVar]  // Local variables
     // @astgen op3 := stmtsp : List[AstNode]
+    // @astgen op4 := scopeNamep : Optional[AstScopeName]  // Scoping context for DPI export
     //
     // @astgen ptr := m_scopep : Optional[AstScope]  // Scope that function is under
     string m_name;
@@ -658,7 +659,7 @@ public:
     void cost(int cost) { m_cost = cost; }
     // Special methods
     bool emptyBody() const {
-        return !keepIfEmpty() && !argsp() && !varsp() && !stmtsp() && !isVirtual()
+        return !keepIfEmpty() && !argsp() && !varsp() && !stmtsp() && !scopeNamep() && !isVirtual()
                && !dpiImportPrototype();
     }
 };

--- a/src/V3Task.cpp
+++ b/src/V3Task.cpp
@@ -1388,10 +1388,9 @@ class TaskVisitor final : public VNVisitor {
         if (nodep->dpiExport()) {
             AstScopeName* const snp = nodep->scopeNamep();
             UASSERT_OBJ(snp, nodep, "Missing scoping context");
-            // The AstScopeName is really a statement(ish) for tracking, not a function
             snp->dpiExport(true);
             snp->unlinkFrBack();
-            cfuncp->addStmtsp(snp);
+            cfuncp->scopeNamep(snp);
         }
 
         // Create list of arguments and move to function


### PR DESCRIPTION
AstScopeName is an AstNodeExpr, but V3Task stashed the DPI export scoping marker into the enclosing AstCFunc's statement list (addStmtsp), placing an expression in a statement position.

Give AstCFunc a dedicated 'scopeNamep' operand to hold the marker instead. Part of #6280
