### PR TITLE
Internals: Make AstCLocalScope an AstNodeStmt (#6280)

### DIFF
--- a/src/V3AstNodeOther.h
+++ b/src/V3AstNodeOther.h
@@ -662,16 +662,6 @@ public:
                && !dpiImportPrototype();
     }
 };
-class AstCLocalScope final : public AstNode {
-    // Pack statements into an unnamed scope when generating C++
-    // @astgen op1 := stmtsp : List[AstNode]
-public:
-    AstCLocalScope(FileLine* fl, AstNode* stmtsp)
-        : ASTGEN_SUPER_CLocalScope(fl) {
-        addStmtsp(stmtsp);
-    }
-    ASTGEN_MEMBERS_AstCLocalScope;
-};
 class AstCUse final : public AstNode {
     // C++ use of a class or #include; indicates need of forward declaration
     // Parents:  NODEMODULE

--- a/src/V3AstNodeStmt.h
+++ b/src/V3AstNodeStmt.h
@@ -297,6 +297,16 @@ public:
     AstSenTree* sentreep() const { return m_sentreep; }
     void clearSentreep() { m_sentreep = nullptr; }
 };
+class AstCLocalScope final : public AstNodeStmt {
+    // Pack statements into an unnamed scope when generating C++
+    // @astgen op1 := stmtsp : List[AstNode]
+public:
+    AstCLocalScope(FileLine* fl, AstNode* stmtsp)
+        : ASTGEN_SUPER_CLocalScope(fl) {
+        addStmtsp(stmtsp);
+    }
+    ASTGEN_MEMBERS_AstCLocalScope;
+};
 class AstCReturn final : public AstNodeStmt {
     // C++ return from a function
     // @astgen op1 := lhsp : AstNodeExpr


### PR DESCRIPTION
AstCLocalScope wraps statements in an unnamed C++ scope ('{ ... }') and is only ever placed in statement position. Part of #6280.
