### PR TITLE
Support nested array and associative array element member access in constraint

### DIFF
--- a/include/verilated_random.cpp
+++ b/include/verilated_random.cpp
@@ -1255,6 +1255,7 @@ void VlRandomizer::clearAll() {
 }
 
 void VlRandomizer::markRandc(const char* name) { m_randcVarNames.insert(name); }
+void VlRandomizer::markRandc(const std::string& name) { m_randcVarNames.insert(name); }
 
 void VlRandomizer::solveBefore(const std::string& beforeName, const std::string& afterName) {
     m_solveBefore.emplace_back(beforeName, afterName);

--- a/include/verilated_random.h
+++ b/include/verilated_random.h
@@ -405,8 +405,10 @@ public:
     // Mark a variable as rand_mode-disabled: solver keeps it in m_vars
     // (so constraints still reference it) but skips write-back after solving.
     void set_var_disabled(const char* name) { m_disabledVars.insert(name); }
+    void set_var_disabled(const std::string& name) { m_disabledVars.insert(name); }
     // Clear disabled state for a variable
     void clear_var_disabled(const char* name) { m_disabledVars.erase(name); }
+    void clear_var_disabled(const std::string& name) { m_disabledVars.erase(name); }
 
     // ---  write_var to register variables  ---
     // Register scalar variable (non-struct, basic type)
@@ -414,6 +416,17 @@ public:
     typename std::enable_if<!VlContainsCustomStruct<T>::value && !IsVlUnpacked<T>::value,
                             void>::type
     write_var(T& var, int width, const char* name, int dimension,
+              std::uint32_t randmodeIdx = std::numeric_limits<std::uint32_t>::max()) {
+        if (m_vars.find(name) != m_vars.end()) return;
+        // TODO: make_unique once VlRandomizer is per-instance not per-ref
+        m_vars[name]
+            = std::make_shared<const VlRandomVar>(name, width, &var, dimension, randmodeIdx);
+    }
+
+    template <typename T>
+    typename std::enable_if<!VlContainsCustomStruct<T>::value && !IsVlUnpacked<T>::value,
+                            void>::type
+    write_var(T& var, int width, const std::string& name, int dimension,
               std::uint32_t randmodeIdx = std::numeric_limits<std::uint32_t>::max()) {
         if (m_vars.find(name) != m_vars.end()) return;
         // TODO: make_unique once VlRandomizer is per-instance not per-ref
@@ -704,6 +717,7 @@ public:
     void clearConstraints();
     void clearAll();  // Clear both constraints and variables
     void markRandc(const char* name);  // Mark variable as randc for cyclic tracking
+    void markRandc(const std::string& name);  // Mark variable as randc for cyclic tracking
     void solveBefore(const std::string& beforeName,
                      const std::string& afterName);  // Register solve-before ordering
     void set_randmode(const VlQueue<CData>& randmode) { m_randmodep = &randmode; }

--- a/src/V3Randomize.cpp
+++ b/src/V3Randomize.cpp
@@ -1329,6 +1329,63 @@ class ConstraintExprVisitor final : public VNVisitor {
         return formatp;
     }
 
+    void setRandMode(AstVar* varp, AstMemberSel* memberselp, std::string& smtName, const RandomizeMode& randMode,AstNodeFTask* initTaskp) {
+        AstNodeModule* const varClassp = VN_AS(varp->user2p(), NodeModule);
+        AstVar* const subRandModeVarp = getRandModeVarFromClass(varClassp);
+        if (subRandModeVarp) {
+            AstNodeExpr* const parentAccess = memberselp->fromp()->cloneTree(false);
+            AstMemberSel* const randModeSel
+                = new AstMemberSel{varp->fileline(), parentAccess, subRandModeVarp};
+            randModeSel->dtypep(subRandModeVarp->dtypep());
+            AstCMethodHard* const atp
+                = new AstCMethodHard{varp->fileline(), randModeSel, VCMethod::ARRAY_AT,
+                                     new AstConst{varp->fileline(), randMode.index}};
+            atp->dtypeSetUInt32();
+            // rand_mode ON: clear disabled state
+            AstCMethodHard* const enablep = new AstCMethodHard{
+                varp->fileline(),
+                new AstVarRef{varp->fileline(), VN_AS(m_genp->user2p(), NodeModule),
+                              m_genp, VAccess::READWRITE},
+                VCMethod::RANDOMIZER_CLEAR_VAR_DISABLED};
+            enablep->dtypeSetVoid();
+            AstNodeExpr* const nameExprp
+                = m_nestedAccess
+                      ? m_nestedAccess->cloneName()
+                      : new AstSFormatF{varp->fileline(), smtName, false, nullptr};
+            AstNodeExpr* const ennp = nameExprp;
+            ennp->dtypep(varp->dtypep());
+            enablep->addPinsp(ennp);
+            // rand_mode OFF: set disabled state
+            AstCMethodHard* const disablep = new AstCMethodHard{
+                varp->fileline(),
+                new AstVarRef{varp->fileline(), VN_AS(m_genp->user2p(), NodeModule),
+                              m_genp, VAccess::READWRITE},
+                VCMethod::RANDOMIZER_SET_VAR_DISABLED};
+            disablep->dtypeSetVoid();
+            AstNodeExpr* const disnp = nameExprp->cloneTree(false);
+            disnp->dtypep(varp->dtypep());
+            disablep->addPinsp(disnp);
+            AstIf* const ifp = new AstIf{varp->fileline(), atp, enablep->makeStmt(),
+                                         disablep->makeStmt()};
+            initTaskp->addStmtsp(ifp);
+        }
+    }
+
+    void markRandc(AstVar* varp, std::string& smtName, AstNodeFTask* initTaskp) {
+        AstCMethodHard* const markp = new AstCMethodHard{
+            varp->fileline(),
+            new AstVarRef{varp->fileline(), VN_AS(m_genp->user2p(), NodeModule), m_genp,
+                          VAccess::READWRITE},
+            VCMethod::RANDOMIZER_MARK_RANDC};
+        markp->dtypeSetVoid();
+        AstNodeExpr* const nameExprp
+            = m_nestedAccess ? m_nestedAccess->cloneName()
+                             : new AstSFormatF{varp->fileline(), smtName, false, nullptr};
+        nameExprp->dtypep(varp->dtypep());
+        markp->addPinsp(nameExprp);
+        initTaskp->addStmtsp(markp->makeStmt());
+    }
+
     // VISITORS
     void visit(AstNodeVarRef* nodep) override {
         AstVar* varp = nodep->varp();
@@ -1710,60 +1767,11 @@ class ConstraintExprVisitor final : public VNVisitor {
                 }
             }
             if (isGlobalConstrained && memberselp && randMode.usesMode) {
-                AstNodeModule* const varClassp = VN_AS(varp->user2p(), NodeModule);
-                AstVar* const subRandModeVarp = getRandModeVarFromClass(varClassp);
-                if (subRandModeVarp) {
-                    AstNodeExpr* const parentAccess = memberselp->fromp()->cloneTree(false);
-                    AstMemberSel* const randModeSel
-                        = new AstMemberSel{varp->fileline(), parentAccess, subRandModeVarp};
-                    randModeSel->dtypep(subRandModeVarp->dtypep());
-                    AstCMethodHard* const atp
-                        = new AstCMethodHard{varp->fileline(), randModeSel, VCMethod::ARRAY_AT,
-                                             new AstConst{varp->fileline(), randMode.index}};
-                    atp->dtypeSetUInt32();
-                    // rand_mode ON: clear disabled state
-                    AstCMethodHard* const enablep = new AstCMethodHard{
-                        varp->fileline(),
-                        new AstVarRef{varp->fileline(), VN_AS(m_genp->user2p(), NodeModule),
-                                      m_genp, VAccess::READWRITE},
-                        VCMethod::RANDOMIZER_CLEAR_VAR_DISABLED};
-                    enablep->dtypeSetVoid();
-                    AstNodeExpr* const nameExprp
-                        = m_nestedAccess
-                              ? m_nestedAccess->cloneName()
-                              : new AstSFormatF{varp->fileline(), smtName, false, nullptr};
-                    AstNodeExpr* const ennp = nameExprp;
-                    ennp->dtypep(varp->dtypep());
-                    enablep->addPinsp(ennp);
-                    // rand_mode OFF: set disabled state
-                    AstCMethodHard* const disablep = new AstCMethodHard{
-                        varp->fileline(),
-                        new AstVarRef{varp->fileline(), VN_AS(m_genp->user2p(), NodeModule),
-                                      m_genp, VAccess::READWRITE},
-                        VCMethod::RANDOMIZER_SET_VAR_DISABLED};
-                    disablep->dtypeSetVoid();
-                    AstNodeExpr* const disnp = nameExprp->cloneTree(false);
-                    disnp->dtypep(varp->dtypep());
-                    disablep->addPinsp(disnp);
-                    AstIf* const ifp = new AstIf{varp->fileline(), atp, enablep->makeStmt(),
-                                                 disablep->makeStmt()};
-                    initTaskp->addStmtsp(ifp);
-                }
+                setRandMode(varp, memberselp, smtName, randMode, initTaskp);
             }
             // If randc, also emit markRandc() for cyclic tracking
             if (varp->isRandC()) {
-                AstCMethodHard* const markp = new AstCMethodHard{
-                    varp->fileline(),
-                    new AstVarRef{varp->fileline(), VN_AS(m_genp->user2p(), NodeModule), m_genp,
-                                  VAccess::READWRITE},
-                    VCMethod::RANDOMIZER_MARK_RANDC};
-                markp->dtypeSetVoid();
-                AstNodeExpr* const nameExprp
-                    = m_nestedAccess ? m_nestedAccess->cloneName()
-                                     : new AstSFormatF{varp->fileline(), smtName, false, nullptr};
-                nameExprp->dtypep(varp->dtypep());
-                markp->addPinsp(nameExprp);
-                initTaskp->addStmtsp(markp->makeStmt());
+                markRandc(varp, smtName, initTaskp);
             }
         } else {
             // Variable already written, clean up cloned memberselp if any

--- a/src/V3Randomize.cpp
+++ b/src/V3Randomize.cpp
@@ -1329,7 +1329,8 @@ class ConstraintExprVisitor final : public VNVisitor {
         return formatp;
     }
 
-    void setRandMode(AstVar* varp, AstMemberSel* memberselp, std::string& smtName, const RandomizeMode& randMode,AstNodeFTask* initTaskp) {
+    void setRandMode(AstVar* varp, AstMemberSel* memberselp, std::string& smtName,
+                     const RandomizeMode& randMode, AstNodeFTask* initTaskp) {
         AstNodeModule* const varClassp = VN_AS(varp->user2p(), NodeModule);
         AstVar* const subRandModeVarp = getRandModeVarFromClass(varClassp);
         if (subRandModeVarp) {
@@ -1344,29 +1345,28 @@ class ConstraintExprVisitor final : public VNVisitor {
             // rand_mode ON: clear disabled state
             AstCMethodHard* const enablep = new AstCMethodHard{
                 varp->fileline(),
-                new AstVarRef{varp->fileline(), VN_AS(m_genp->user2p(), NodeModule),
-                              m_genp, VAccess::READWRITE},
+                new AstVarRef{varp->fileline(), VN_AS(m_genp->user2p(), NodeModule), m_genp,
+                              VAccess::READWRITE},
                 VCMethod::RANDOMIZER_CLEAR_VAR_DISABLED};
             enablep->dtypeSetVoid();
             AstNodeExpr* const nameExprp
-                = m_nestedAccess
-                      ? m_nestedAccess->cloneName()
-                      : new AstSFormatF{varp->fileline(), smtName, false, nullptr};
+                = m_nestedAccess ? m_nestedAccess->cloneName()
+                                 : new AstSFormatF{varp->fileline(), smtName, false, nullptr};
             AstNodeExpr* const ennp = nameExprp;
             ennp->dtypep(varp->dtypep());
             enablep->addPinsp(ennp);
             // rand_mode OFF: set disabled state
             AstCMethodHard* const disablep = new AstCMethodHard{
                 varp->fileline(),
-                new AstVarRef{varp->fileline(), VN_AS(m_genp->user2p(), NodeModule),
-                              m_genp, VAccess::READWRITE},
+                new AstVarRef{varp->fileline(), VN_AS(m_genp->user2p(), NodeModule), m_genp,
+                              VAccess::READWRITE},
                 VCMethod::RANDOMIZER_SET_VAR_DISABLED};
             disablep->dtypeSetVoid();
             AstNodeExpr* const disnp = nameExprp->cloneTree(false);
             disnp->dtypep(varp->dtypep());
             disablep->addPinsp(disnp);
-            AstIf* const ifp = new AstIf{varp->fileline(), atp, enablep->makeStmt(),
-                                         disablep->makeStmt()};
+            AstIf* const ifp
+                = new AstIf{varp->fileline(), atp, enablep->makeStmt(), disablep->makeStmt()};
             initTaskp->addStmtsp(ifp);
         }
     }
@@ -1770,9 +1770,7 @@ class ConstraintExprVisitor final : public VNVisitor {
                 setRandMode(varp, memberselp, smtName, randMode, initTaskp);
             }
             // If randc, also emit markRandc() for cyclic tracking
-            if (varp->isRandC()) {
-                markRandc(varp, smtName, initTaskp);
-            }
+            if (varp->isRandC()) { markRandc(varp, smtName, initTaskp); }
         } else {
             // Variable already written, clean up cloned memberselp if any
             if (memberselp) VL_DO_DANGLING(memberselp->deleteTree(), memberselp);

--- a/src/V3Randomize.cpp
+++ b/src/V3Randomize.cpp
@@ -779,6 +779,111 @@ class ConstraintExprVisitor final : public VNVisitor {
     std::set<AstVar*>* m_sizeConstrainedArraysp = nullptr;  // Arrays with size+element constraints
     AstNodeExpr* m_conditionp = nullptr;  // Condition under which current expression is defined
                                           // (nullptr == always defined)
+    std::map<AstVar*, AstVar*>
+        m_varMap;  // Variable map to relink AstNodeVarRefs under foreach in nested array access
+    AstNode* m_firstExpressionInsideIndexp = nullptr;
+
+    class NestedAccessPath final {
+        AstMemberSel* m_topNestedArrayMemberSelp
+            = nullptr;  // Top node of nested array/member access
+        AstSFormatF* m_nestedNameFormatTopp = nullptr;  // Top node of variable's name format
+        AstSFormatF* m_nestedNameFormatp = nullptr;  // Last node of variable's name format
+        AstNode** m_firstExpressionInsideIndexPointerp
+            = nullptr;  // First expression with no name, used for "Multiple expressions inside
+                        // indices of complex expression in constraint" error
+
+        std::string m_smtName;  // string name for shouldWriteVar checking
+
+    public:
+        void addVarNamePart(AstSFormatF* const nodep, std::string&& name) {
+            if (!m_nestedNameFormatp) {
+                m_nestedNameFormatTopp = nodep;
+                m_nestedNameFormatp = m_nestedNameFormatTopp;
+            } else {
+                m_nestedNameFormatp->exprsp()->addHereThisAsNext(nodep);
+            }
+            m_nestedNameFormatp = nodep;
+
+            m_smtName.insert(0, "." + name);
+            // Some expressions have empty name which can cause some variables to have the same
+            // name and only first one will be written
+            if (name == "") {
+                if (*m_firstExpressionInsideIndexPointerp) {
+                    (*m_firstExpressionInsideIndexPointerp)
+                        ->v3warn(
+                            E_UNSUPPORTED,
+                            "Unsupported: Multiple expressions inside indices of complex "
+                            "expression in constraint\n"
+                                << (*m_firstExpressionInsideIndexPointerp)->warnContextPrimary()
+                                << nodep->warnOther() << "... Location of second expression\n"
+                                << nodep->warnContextSecondary());
+                }
+                *m_firstExpressionInsideIndexPointerp = nodep;
+            }
+        }
+
+        AstMemberSel* accessTree() { return m_topNestedArrayMemberSelp; }
+        const std::string& smtName() { return m_smtName; }
+
+        void write_var(AstNodeFTask* initTaskp, AstVar* varp, AstVar* genp,
+                       AstNode* nestedArrayForeach, std::map<AstVar*, AstVar*>& m_varMap) {
+            m_topNestedArrayMemberSelp->foreach([&](AstNodeVarRef* nodep) {
+                const auto newVarp = m_varMap.find(nodep->varp());
+                if (newVarp != m_varMap.end()) { nodep->varp(newVarp->second); }
+            });
+            AstCMethodHard* const methodp = new AstCMethodHard{
+                varp->fileline(),
+                new AstVarRef{varp->fileline(), VN_AS(genp->user2p(), NodeModule), genp,
+                              VAccess::READWRITE},
+                VCMethod::RANDOMIZER_WRITE_VAR};
+            methodp->dtypeSetVoid();
+
+            // variable
+            methodp->addPinsp(m_topNestedArrayMemberSelp);
+
+            // width
+            const AstNodeDType* const dtypep = varp->dtypep();
+            const size_t width = m_topNestedArrayMemberSelp->varp()->dtypep()->width();
+            methodp->addPinsp(new AstConst{dtypep->fileline(), AstConst::Unsized64{}, width});
+
+            // solver name
+            methodp->addPinsp(m_nestedNameFormatTopp);
+            m_nestedNameFormatp = nullptr;
+
+            // dimension
+            methodp->addPinsp(new AstConst{dtypep->fileline(), AstConst::Unsized64{}, 0});
+
+            m_topNestedArrayMemberSelp = nullptr;
+            if (nestedArrayForeach) {
+                AstNode* lastp = nestedArrayForeach;
+                while (VN_IS(lastp->op2p(), Begin) || VN_IS(lastp->op2p(), Foreach)) {
+                    lastp = lastp->op2p();
+                }
+                VN_AS(lastp, Foreach)->addBodyp(methodp->makeStmt());
+                if (!nestedArrayForeach->backp()) initTaskp->addStmtsp(nestedArrayForeach);
+            } else {
+                initTaskp->addStmtsp(methodp->makeStmt());
+            }
+        }
+
+        AstNodeExpr* cloneName() { return m_nestedNameFormatTopp->cloneTree(false); }
+
+        void error() {
+            VL_DO_DANGLING(m_topNestedArrayMemberSelp->deleteTree(), m_topNestedArrayMemberSelp);
+        }
+
+        NestedAccessPath(AstMemberSel* topMemberSelp, AstNode** pointerToFirstExprp)
+            : m_topNestedArrayMemberSelp{topMemberSelp}
+            , m_firstExpressionInsideIndexPointerp{pointerToFirstExprp} {}
+        ~NestedAccessPath() {
+            if (m_nestedNameFormatp) {
+                m_nestedNameFormatTopp->deleteTree();
+                m_nestedNameFormatp = nullptr;
+            }
+        }
+    };
+    NestedAccessPath* m_nestedAccess = nullptr;  // Indicates state of nested access
+    AstNode* m_nestedArrayForeachp = nullptr;  // Foreach loops before nested access
 
     // Routes nested sub-objects with static rand vars when the outer class has none.
     AstVar* findStaticRandModeVarMember(AstClass* classp) const {
@@ -1085,10 +1190,7 @@ class ConstraintExprVisitor final : public VNVisitor {
         UASSERT_OBJ(!rhsp, nodep, "Missing emitSMT %r for " << rhsp);
         UASSERT_OBJ(!thsp, nodep, "Missing emitSMT %t for " << thsp);
         AstSFormatF* const newp = new AstSFormatF{nodep->fileline(), smtExpr, false, argsp};
-        if (m_structSel && newp->name() == "(select %s %s)") {
-            newp->name("%s.%s");
-            if (!VN_IS(nodep, AssocSel)) newp->exprsp()->nextp()->name("%x");
-        }
+
         nodep->replaceWith(newp);
         VL_DO_DANGLING(pushDeletep(nodep), nodep);
         return newp;
@@ -1247,7 +1349,12 @@ class ConstraintExprVisitor final : public VNVisitor {
         AstMemberSel* memberselp = nullptr;
         bool structSelOrCMeth = false;
         std::string smtName;
-        if (VN_IS(nodep->backp(), MemberSel)) {
+        if (m_nestedAccess) {
+            m_nestedAccess->addVarNamePart(
+                new AstSFormatF{varp->fileline(), nodep->name(), false, nullptr}, nodep->name());
+            smtName = m_nestedAccess->smtName();
+            memberselp = m_nestedAccess->accessTree();
+        } else if (VN_IS(nodep->backp(), MemberSel)) {
             // Build complete path from topmost MemberSel
             AstNode* topMemberSel = nodep->backp();
             while (VN_IS(topMemberSel->backp(), MemberSel)) {
@@ -1288,7 +1395,8 @@ class ConstraintExprVisitor final : public VNVisitor {
         if (randMode.usesMode) {
             // Use AstSFormatF (not AstConst{String}) to prevent editFormat/V3Const
             // from reformatting the SMT variable name into a hex literal
-            exprp = new AstSFormatF{nodep->fileline(), smtName, false, nullptr};
+            exprp = new AstSFormatF{nodep->fileline(), m_nestedAccess ? nodep->name() : smtName,
+                                    false, nullptr};
 
             // Get const format, using memberselp if available for correct width/value
             AstNodeExpr* constFormatp = memberselp ? getConstFormat(memberselp->cloneTree(false))
@@ -1337,7 +1445,8 @@ class ConstraintExprVisitor final : public VNVisitor {
             exprp = new AstCond{varp->fileline(), atp, exprp, constFormatp};
             exprp->user1(true);  // Mark as formatted
         } else {
-            exprp = new AstSFormatF{nodep->fileline(), smtName, false, nullptr};
+            exprp = new AstSFormatF{nodep->fileline(), m_nestedAccess ? nodep->name() : smtName,
+                                    false, nullptr};
             if (!isGlobalConstrained) VL_DO_DANGLING(pushDeletep(nodep), nodep);
         }
         // else: Global constraints keep nodep alive for write_var processing
@@ -1352,6 +1461,36 @@ class ConstraintExprVisitor final : public VNVisitor {
                                                         : varp->user3();
         const bool shouldWriteVar = !alreadyWritten;
         if (shouldWriteVar) {
+            AstNodeModule* classp;
+            if (memberselp) {
+                // For memberselp, find the root varref to get the class
+                AstNode* rootNode = memberselp->fromp();
+                while (AstMemberSel* nestedMemberSel = VN_CAST(rootNode, MemberSel)) {
+                    rootNode = nestedMemberSel->fromp();
+                }
+                if (AstNodeVarRef* rootVarRef = VN_CAST(rootNode, NodeVarRef)) {
+                    classp = VN_AS(rootVarRef->varp()->user2p(), NodeModule);
+                } else {
+                    classp = VN_AS(memberselp->user2p(), NodeModule);
+                }
+            } else {
+                classp = VN_AS(varp->user2p(), NodeModule);
+            }
+            AstNodeFTask* initTaskp = m_inlineInitTaskp;
+            if (!initTaskp) {
+                varp->user3(true);
+                if (memberselp || structSelOrCMeth) {
+                    initTaskp = VN_AS(m_memberMap.findMember(classp, "randomize"), NodeFTask);
+                    // Inherited rand members may belong to a base class
+                    // that has no randomize(); use the caller's function
+                    if (!initTaskp) initTaskp = m_memberselInitTaskp;
+                    UASSERT_OBJ(initTaskp, classp, "No randomize() in class");
+                } else {
+                    initTaskp = VN_AS(m_memberMap.findMember(classp, "new"), NodeFTask);
+                    UASSERT_OBJ(initTaskp, classp, "No new() in class");
+                }
+            }
+
             // Track this variable path as written
             if (isGlobalConstrained || (memberselp && !m_inlineInitTaskp))
                 m_writtenVars.insert(smtName);
@@ -1374,7 +1513,10 @@ class ConstraintExprVisitor final : public VNVisitor {
                 }
             }
 
-            if (isClassRefArray && !memberselp) {
+            if (m_nestedAccess) {
+                m_nestedAccess->write_var(initTaskp, varp, m_genp, m_nestedArrayForeachp,
+                                          m_varMap);
+            } else if (isClassRefArray && !memberselp) {
                 FileLine* const fl = varp->fileline();
                 AstClass* const elemClassp = elemClassRefDtp->classp();
                 AstNodeModule* const varClassp = VN_AS(varp->user2p(), NodeModule);
@@ -1462,7 +1604,7 @@ class ConstraintExprVisitor final : public VNVisitor {
                                                        new AstVarRef{fl, iterVarp, VAccess::READ}};
                         } else {
                             atWritep
-                                = new AstCMethodHard{fl, arrayWrRef, VCMethod::ARRAY_AT_WRITE,
+                                = new AstCMethodHard{fl, arrayWrRef, VCMethod::ARRAY_AT,
                                                      new AstVarRef{fl, iterVarp, VAccess::READ}};
                         }
                         atWritep->dtypep(elemClassRefDtp);
@@ -1548,20 +1690,6 @@ class ConstraintExprVisitor final : public VNVisitor {
                     methodp->addPinsp(
                         new AstConst{varp->fileline(), AstConst::Unsized64{}, randMode.index});
                 }
-                AstNodeFTask* initTaskp = m_inlineInitTaskp;
-                if (!initTaskp) {
-                    varp->user3(true);
-                    if (memberselp || structSelOrCMeth) {
-                        initTaskp = VN_AS(m_memberMap.findMember(classp, "randomize"), NodeFTask);
-                        // Inherited rand members may belong to a base class
-                        // that has no randomize(); use the caller's function
-                        if (!initTaskp) initTaskp = m_memberselInitTaskp;
-                        UASSERT_OBJ(initTaskp, classp, "No randomize() in class");
-                    } else {
-                        initTaskp = VN_AS(m_memberMap.findMember(classp, "new"), NodeFTask);
-                        UASSERT_OBJ(initTaskp, classp, "No new() in class");
-                    }
-                }
                 // For globalConstrained sub-object members with rand_mode:
                 // Always call write_var (keeps variable in solver for constraint
                 // evaluation), but toggle disabled state so the solver skips
@@ -1580,61 +1708,62 @@ class ConstraintExprVisitor final : public VNVisitor {
                     markp->dtypeSetVoid();
                     initTaskp->addStmtsp(markp->makeStmt());
                 }
-                if (isGlobalConstrained && memberselp && randMode.usesMode) {
-                    AstNodeModule* const varClassp = VN_AS(varp->user2p(), NodeModule);
-                    AstVar* const subRandModeVarp = getRandModeVarFromClass(varClassp);
-                    if (subRandModeVarp) {
-                        AstNodeExpr* const parentAccess = memberselp->fromp()->cloneTree(false);
-                        AstMemberSel* const randModeSel
-                            = new AstMemberSel{varp->fileline(), parentAccess, subRandModeVarp};
-                        randModeSel->dtypep(subRandModeVarp->dtypep());
-                        AstCMethodHard* const atp
-                            = new AstCMethodHard{varp->fileline(), randModeSel, VCMethod::ARRAY_AT,
-                                                 new AstConst{varp->fileline(), randMode.index}};
-                        atp->dtypeSetUInt32();
-                        // rand_mode ON: clear disabled state
-                        AstCMethodHard* const enablep = new AstCMethodHard{
-                            varp->fileline(),
-                            new AstVarRef{varp->fileline(), VN_AS(m_genp->user2p(), NodeModule),
-                                          m_genp, VAccess::READWRITE},
-                            VCMethod::RANDOMIZER_CLEAR_VAR_DISABLED};
-                        enablep->dtypeSetVoid();
-                        AstNodeExpr* const ennp
-                            = new AstCExpr{varp->fileline(), AstCExpr::Pure{},
-                                           "\"" + smtName + "\"", varp->width()};
-                        ennp->dtypep(varp->dtypep());
-                        enablep->addPinsp(ennp);
-                        // rand_mode OFF: set disabled state
-                        AstCMethodHard* const disablep = new AstCMethodHard{
-                            varp->fileline(),
-                            new AstVarRef{varp->fileline(), VN_AS(m_genp->user2p(), NodeModule),
-                                          m_genp, VAccess::READWRITE},
-                            VCMethod::RANDOMIZER_SET_VAR_DISABLED};
-                        disablep->dtypeSetVoid();
-                        AstNodeExpr* const disnp
-                            = new AstCExpr{varp->fileline(), AstCExpr::Pure{},
-                                           "\"" + smtName + "\"", varp->width()};
-                        disnp->dtypep(varp->dtypep());
-                        disablep->addPinsp(disnp);
-                        AstIf* const ifp = new AstIf{varp->fileline(), atp, enablep->makeStmt(),
-                                                     disablep->makeStmt()};
-                        initTaskp->addStmtsp(ifp);
-                    }
-                }
-                // If randc, also emit markRandc() for cyclic tracking
-                if (varp->isRandC()) {
-                    AstCMethodHard* const markp = new AstCMethodHard{
+            }
+            if (isGlobalConstrained && memberselp && randMode.usesMode) {
+                AstNodeModule* const varClassp = VN_AS(varp->user2p(), NodeModule);
+                AstVar* const subRandModeVarp = getRandModeVarFromClass(varClassp);
+                if (subRandModeVarp) {
+                    AstNodeExpr* const parentAccess = memberselp->fromp()->cloneTree(false);
+                    AstMemberSel* const randModeSel
+                        = new AstMemberSel{varp->fileline(), parentAccess, subRandModeVarp};
+                    randModeSel->dtypep(subRandModeVarp->dtypep());
+                    AstCMethodHard* const atp
+                        = new AstCMethodHard{varp->fileline(), randModeSel, VCMethod::ARRAY_AT,
+                                             new AstConst{varp->fileline(), randMode.index}};
+                    atp->dtypeSetUInt32();
+                    // rand_mode ON: clear disabled state
+                    AstCMethodHard* const enablep = new AstCMethodHard{
                         varp->fileline(),
                         new AstVarRef{varp->fileline(), VN_AS(m_genp->user2p(), NodeModule),
                                       m_genp, VAccess::READWRITE},
-                        VCMethod::RANDOMIZER_MARK_RANDC};
-                    markp->dtypeSetVoid();
-                    AstNodeExpr* const nameExprp = new AstCExpr{
-                        varp->fileline(), AstCExpr::Pure{}, "\"" + smtName + "\"", varp->width()};
-                    nameExprp->dtypep(varp->dtypep());
-                    markp->addPinsp(nameExprp);
-                    initTaskp->addStmtsp(markp->makeStmt());
+                        VCMethod::RANDOMIZER_CLEAR_VAR_DISABLED};
+                    enablep->dtypeSetVoid();
+                    AstNodeExpr* const nameExprp
+                        = m_nestedAccess
+                              ? m_nestedAccess->cloneName()
+                              : new AstSFormatF{varp->fileline(), smtName, false, nullptr};
+                    AstNodeExpr* const ennp = nameExprp;
+                    ennp->dtypep(varp->dtypep());
+                    enablep->addPinsp(ennp);
+                    // rand_mode OFF: set disabled state
+                    AstCMethodHard* const disablep = new AstCMethodHard{
+                        varp->fileline(),
+                        new AstVarRef{varp->fileline(), VN_AS(m_genp->user2p(), NodeModule),
+                                      m_genp, VAccess::READWRITE},
+                        VCMethod::RANDOMIZER_SET_VAR_DISABLED};
+                    disablep->dtypeSetVoid();
+                    AstNodeExpr* const disnp = nameExprp->cloneTree(false);
+                    disnp->dtypep(varp->dtypep());
+                    disablep->addPinsp(disnp);
+                    AstIf* const ifp = new AstIf{varp->fileline(), atp, enablep->makeStmt(),
+                                                 disablep->makeStmt()};
+                    initTaskp->addStmtsp(ifp);
                 }
+            }
+            // If randc, also emit markRandc() for cyclic tracking
+            if (varp->isRandC()) {
+                AstCMethodHard* const markp = new AstCMethodHard{
+                    varp->fileline(),
+                    new AstVarRef{varp->fileline(), VN_AS(m_genp->user2p(), NodeModule), m_genp,
+                                  VAccess::READWRITE},
+                    VCMethod::RANDOMIZER_MARK_RANDC};
+                markp->dtypeSetVoid();
+                AstNodeExpr* const nameExprp
+                    = m_nestedAccess ? m_nestedAccess->cloneName()
+                                     : new AstSFormatF{varp->fileline(), smtName, false, nullptr};
+                nameExprp->dtypep(varp->dtypep());
+                markp->addPinsp(nameExprp);
+                initTaskp->addStmtsp(markp->makeStmt());
             }
         } else {
             // Variable already written, clean up cloned memberselp if any
@@ -1642,6 +1771,7 @@ class ConstraintExprVisitor final : public VNVisitor {
             // Delete nodep if it's a global constraint (not deleted yet)
             if (isGlobalConstrained && !nodep->backp()) VL_DO_DANGLING(pushDeletep(nodep), nodep);
         }
+        if (m_nestedAccess) { VL_DO_DANGLING(delete m_nestedAccess, m_nestedAccess); }
     }
     // Build popcount expansion: (x & 1) + ((x & 2) >> 1) + ...
     // argp is consumed; caller must clone if reusing.
@@ -2054,6 +2184,15 @@ class ConstraintExprVisitor final : public VNVisitor {
         nodep->replaceWith(newp);
         VL_DO_DANGLING(pushDeletep(nodep), nodep);
     }
+    void addStringNamePart(AstNodeSel* nodep) {
+        if (m_nestedAccess) {
+            AstNodeExpr* const bitp = nodep->bitp()->cloneTreePure(false);
+            AstNodeExpr* const bitFormatp = new AstSFormatF{bitp->fileline(), "%32x", false, bitp};
+            AstSFormatF* const herep
+                = new AstSFormatF{nodep->fileline(), "%s.%s", false, bitFormatp};
+            m_nestedAccess->addVarNamePart(herep, nodep->bitp()->name());
+        }
+    }
     void visit(AstAssocSel* nodep) override {
         if (editFormat(nodep)) return;
         FileLine* const fl = nodep->fileline();
@@ -2061,6 +2200,7 @@ class ConstraintExprVisitor final : public VNVisitor {
         AstNodeExpr* const origp = nodep->cloneTree(false);
         AstSFormatF* newp = nullptr;
         if (VN_IS(nodep->bitp(), VarRef) && VN_AS(nodep->bitp(), VarRef)->isString()) {
+            addStringNamePart(nodep);
             VNRelinker handle;
             AstNodeExpr* const idxp = new AstSFormatF{fl, (m_structSel ? "%32x" : "#x%32x"), false,
                                                       nodep->bitp()->unlinkFrBack(&handle)};
@@ -2076,6 +2216,7 @@ class ConstraintExprVisitor final : public VNVisitor {
                     "Unsupported: Constrained randomization of associative array keys of "
                         << stringSize << "bits, limit is 128 bits");
             }
+            addStringNamePart(nodep);
             VNRelinker handle;
             AstNodeExpr* const idxp = new AstSFormatF{fl, (m_structSel ? "%32x" : "#x%32x"), false,
                                                       stringp->lhsp()->unlinkFrBack(&handle)};
@@ -2087,7 +2228,6 @@ class ConstraintExprVisitor final : public VNVisitor {
                     && VN_AS(nodep->bitp()->dtypep(), StructDType)->packed())
                 || VN_IS(nodep->bitp()->dtypep(), EnumDType)
                 || VN_IS(nodep->bitp()->dtypep(), PackArrayDType)) {
-                VNRelinker handle;
                 const int actual_width = nodep->bitp()->width();
                 std::string fmt;
                 // Normalize to standard bit width
@@ -2099,6 +2239,15 @@ class ConstraintExprVisitor final : public VNVisitor {
                     fmt = (m_structSel ? "%" : "#x%")
                           + std::to_string(VL_WORDS_I(actual_width) * 8) + "x";
                 }
+                if (m_nestedAccess) {
+                    AstNodeExpr* const bitp = nodep->bitp()->cloneTreePure(false);
+                    AstNodeExpr* const bitFormatp
+                        = new AstSFormatF{bitp->fileline(), fmt, false, bitp};
+                    AstSFormatF* const herep
+                        = new AstSFormatF{nodep->fileline(), "%s.%s", false, bitFormatp};
+                    m_nestedAccess->addVarNamePart(herep, bitp->name());
+                }
+                VNRelinker handle;
                 AstNodeExpr* const idxp
                     = new AstSFormatF{fl, fmt, false, nodep->bitp()->unlinkFrBack(&handle)};
                 handle.relink(idxp);
@@ -2107,9 +2256,11 @@ class ConstraintExprVisitor final : public VNVisitor {
                 nodep->bitp()->v3error(
                     "Illegal non-integral expression or subexpression in random constraint."
                     " (IEEE 1800-2023 18.3)");
+                if (m_nestedAccess) m_nestedAccess->error();
             }
         }
-        if (!newp || !hoistRandModeOverSelect(newp, origp)) {
+        if (newp && m_structSel && newp->name() == "(select %s %s)") { newp->name("%s.%s"); }
+        if (!newp || !hoistRandModeOverSelectAndMember(newp, origp)) {
             VL_DO_DANGLING(origp->deleteTree(), origp);
         }
     }
@@ -2123,6 +2274,32 @@ class ConstraintExprVisitor final : public VNVisitor {
         nodep->bitp()->foreach([&](const AstNodeVarRef* vrefp) {
             if (vrefp->varp()->rand().isRandomizable()) indexIsRand = true;
         });
+        if (m_nestedAccess) {
+            AstNodeExpr* const bitp = nodep->bitp()->cloneTreePure(false);
+            if (m_varMap.size()) {
+                bitp->foreach([&](AstNodeVarRef* nodep) {
+                    const auto it = m_varMap.find(nodep->varp());
+                    if (it != m_varMap.end()) { nodep->varp(it->second); }
+                });
+            }
+            AstNodeExpr* const bitFormatp
+                = indexIsRand ? new AstSFormatF{bitp->fileline(), bitp->name(), false, nullptr}
+                              : new AstSFormatF{bitp->fileline(), "%x", false, bitp};
+            AstSFormatF* const herep
+                = new AstSFormatF{nodep->fileline(), "%s.%s", false, bitFormatp};
+            if (AstSel* selp = VN_CAST(bitp, Sel)) {
+                m_nestedAccess->addVarNamePart(herep, selp->fromp()->name());
+            } else {
+                m_nestedAccess->addVarNamePart(herep, bitp->name());
+            }
+            if (indexIsRand) {
+                nodep->v3warn(E_UNSUPPORTED,
+                              "Unsupported: Randomized index in complex expression");
+                m_nestedAccess->error();
+                VL_DO_DANGLING(bitp->deleteTree(), bitp);
+                return;
+            }
+        }
         if (indexIsRand) {
             // Index depends on rand variable -- keep as SMT symbol.
             // Array index sort is 32-bit, so zero-extend narrower indices.
@@ -2143,7 +2320,11 @@ class ConstraintExprVisitor final : public VNVisitor {
                 = new AstSFormatF{fl, "#x%8x", false, nodep->bitp()->unlinkFrBack(&handle)};
             handle.relink(indexp);
             AstSFormatF* const newp = editSMT(nodep, nodep->fromp(), indexp);
-            if (!newp || !hoistRandModeOverSelect(newp, origp)) {
+            if (m_structSel) {
+                newp->name("%s.%s");
+                newp->exprsp()->nextp()->name("%x");
+            }
+            if (!hoistRandModeOverSelectAndMember(newp, origp)) {
                 VL_DO_DANGLING(origp->deleteTree(), origp);
             }
         }
@@ -2163,13 +2344,16 @@ class ConstraintExprVisitor final : public VNVisitor {
         return classp && classp->user2p() == varp;
     }
     // Lift a rand_mode Cond above the (select ...) chain of a frozen array element.
-    bool hoistRandModeOverSelect(AstSFormatF* newp, AstNodeExpr* origp) {
+    bool hoistRandModeOverSelectAndMember(AstSFormatF* newp, AstNodeExpr* origp) {
         // Only for selects yielding a non-array element (full chains)
         if (VN_IS(origp->dtypep()->skipRefp(), UnpackArrayDType)) return false;
         // Walk nested "(select %s %s)" frames down to a mode-gating AstCond
         std::vector<AstSFormatF*> frames;
         AstCond* modeCondp = nullptr;
-        for (AstSFormatF* curp = newp; curp && curp->name() == "(select %s %s)";) {
+        for (AstSFormatF* curp = newp;
+             curp
+             && (curp->name() == "(select %s %s)" || curp->name() == "%s.%s"
+                 || curp->name().rfind("%s.", 0) == 0);) {
             AstNodeExpr* const firstp = curp->exprsp();
             frames.push_back(curp);
             if (AstCond* const condp = VN_CAST(firstp, Cond)) {
@@ -2185,9 +2369,9 @@ class ConstraintExprVisitor final : public VNVisitor {
         // Rebuild the select chain text around the SMT name, innermost first
         for (auto it = frames.rbegin(); it != frames.rend(); ++it) {
             AstNodeExpr* const idxFmtp = VN_AS((*it)->exprsp()->nextp(), NodeExpr);
-            idxFmtp->unlinkFrBack();
+            if (idxFmtp) idxFmtp->unlinkFrBack();
             activep
-                = new AstSFormatF{fl, "(select %s %s)", false, AstNode::addNext(activep, idxFmtp)};
+                = new AstSFormatF{fl, (*it)->name(), false, AstNode::addNext(activep, idxFmtp)};
         }
         AstCond* const hoistp = new AstCond{fl, modep, activep, getConstFormat(origp)};
         hoistp->user1(true);  // Mark as formatted
@@ -2198,57 +2382,64 @@ class ConstraintExprVisitor final : public VNVisitor {
     void visit(AstMemberSel* nodep) override {
         // Check if rootVar is globalConstrained
         if (nodep->varp()->rand().isRandomizable() && nodep->fromp()) {
+            FileLine* const fl = nodep->fileline();
+            if (m_nestedAccess) {
+                AstSFormatF* formatp = new AstSFormatF{fl, nodep->name(), false, nullptr};
+                m_nestedAccess->addVarNamePart(new AstSFormatF{fl, "%s.%s", false, formatp},
+                                               nodep->name());
+            }
             AstNode* rootNode = nodep->fromp();
-            while (const AstMemberSel* const selp = VN_CAST(rootNode, MemberSel))
+            while (const AstMemberSel* const selp = VN_CAST(rootNode, MemberSel)) {
                 rootNode = selp->fromp();
-            if (AstArraySel* const arraySelp = VN_CAST(rootNode, ArraySel)) {
+            }
+
+            AstNodeSel* arraySelp = VN_CAST(rootNode, ArraySel);
+            if (!arraySelp) arraySelp = VN_CAST(rootNode, AssocSel);
+
+            if (arraySelp) {
                 AstNodeDType* const arrayDtp = arraySelp->fromp()->dtypep()->skipRefp();
                 AstNodeDType* const elemDtp
                     = arrayDtp->subDTypep() ? arrayDtp->subDTypep()->skipRefp() : nullptr;
                 if (elemDtp && VN_IS(elemDtp, ClassRefDType)) {
-                    // Nested class ref arrays not yet supported
                     const bool isSimple
                         = nodep->fromp() == rootNode && VN_IS(arraySelp->fromp(), VarRef);
-                    if (!isSimple) {
-                        nodep->v3warn(
-                            E_UNSUPPORTED,
-                            "Unsupported: Nested array element access in global constraint");
-                        return;
+                    if (!isSimple && !m_nestedAccess) {
+                        m_nestedAccess = new NestedAccessPath(nodep->cloneTree(false),
+                                                              &m_firstExpressionInsideIndexp);
+                        AstSFormatF* const formatp
+                            = new AstSFormatF{fl, nodep->name(), false, nullptr};
+                        m_nestedAccess->addVarNamePart(
+                            new AstSFormatF{fl, "%s.%s", false, formatp}, nodep->name());
                     }
                     VL_RESTORER(m_structSel);
                     m_structSel = true;
                     nodep->user1(true);
                     arraySelp->user1(true);
+                    AstNodeExpr* origp = nodep->cloneTree(false);
                     iterateChildren(nodep);
-                    FileLine* const fl = nodep->fileline();
-                    AstSFormatF* newp = nullptr;
-                    if (AstSFormatF* const fromp = VN_CAST(nodep->fromp(), SFormatF)) {
-                        if (fromp->name() == "%s.%s") {
-                            newp = new AstSFormatF{fl, "%s.%s." + nodep->name(), false,
-                                                   fromp->exprsp()->cloneTreePure(true)};
-                        } else {
-                            newp = new AstSFormatF{fl, fromp->name() + "." + nodep->name(), false,
-                                                   nullptr};
-                        }
-                    } else {
-                        newp = new AstSFormatF{fl, nodep->name(), false, nullptr};
-                    }
+                    AstSFormatF* const newp = new AstSFormatF{fl, "%s." + nodep->name(), false,
+                                                              nodep->fromp()->unlinkFrBack()};
                     nodep->replaceWith(newp);
+                    if (!hoistRandModeOverSelectAndMember(newp, origp))
+                        VL_DO_DANGLING(origp->deleteTree(), origp);
                     VL_DO_DANGLING(pushDeletep(nodep), nodep);
+                    VL_DO_DANGLING(delete m_nestedAccess, m_nestedAccess);
                     return;
                 }
-            }
-            if (VN_IS(rootNode, AssocSel) || VN_IS(rootNode, ArraySel)) {
-                nodep->v3warn(E_UNSUPPORTED,
-                              "Unsupported: Array element access in global constraint");
             }
             // Check if the root variable participates in global constraints
             if (const AstVarRef* const varRefp = VN_CAST(rootNode, VarRef)) {
                 AstVar* const constrainedVar = varRefp->varp();
                 if (constrainedVar->globalConstrained()) {
+                    bool const beforeIterate = m_nestedAccess;
                     // Global constraint - unwrap the MemberSel
                     iterateChildren(nodep);
-                    nodep->replaceWith(nodep->fromp()->unlinkFrBack());
+                    if (beforeIterate) {
+                        nodep->replaceWith(new AstSFormatF{fl, "%s." + nodep->name(), false,
+                                                           nodep->fromp()->unlinkFrBack()});
+                    } else {
+                        nodep->replaceWith(nodep->fromp()->unlinkFrBack());
+                    }
                     VL_DO_DANGLING(nodep->deleteTree(), nodep);
                     return;
                 }
@@ -2342,9 +2533,35 @@ class ConstraintExprVisitor final : public VNVisitor {
     }
     void visit(AstBegin* nodep) override {}
     void visit(AstConstraintForeach* nodep) override {
-        // Convert to plain foreach
+        VL_RESTORER_COPY(m_varMap);
         FileLine* const fl = nodep->fileline();
 
+        AstForeach* const foreachp
+            = new AstForeach{fl, nodep->headerp()->cloneTree(false), nullptr};
+        AstNode* clonedElementp = foreachp->headerp()->elementsp();
+        for (AstNode* elementp = nodep->headerp()->elementsp(); elementp;
+             elementp = elementp->nextp()) {
+            // Because we clone the header we only need to check one
+            if (VN_IS(elementp, Var)) {
+                AstVar* oldVarp = VN_AS(elementp, Var);
+                AstVar* newVarp = VN_AS(clonedElementp, Var);
+                m_varMap[oldVarp] = newVarp;
+            }
+            clonedElementp = clonedElementp->nextp();
+        }
+        VL_RESTORER(m_nestedArrayForeachp);
+
+        bool shouldClear = false;
+        if (!m_nestedArrayForeachp) {
+            m_nestedArrayForeachp = new AstBegin{fl, "", foreachp, false};
+            shouldClear = true;
+        } else {
+            AstNode* lastp = m_nestedArrayForeachp;
+            while (lastp->op2p()) { lastp = lastp->op2p(); }
+            VN_AS(lastp, Foreach)->addBodyp(new AstBegin{fl, "", foreachp, false});
+        }
+
+        // Convert to plain foreach
         if (!nodep->bodyp()) {
             nodep->unlinkFrBack();
         } else if (m_wantSingle) {
@@ -2371,6 +2588,8 @@ class ConstraintExprVisitor final : public VNVisitor {
         }
         UASSERT_OBJ(!nodep->user3p(), nodep, "Dist bucket preamble not injected into foreach");
         VL_DO_DANGLING(nodep->deleteTree(), nodep);
+        if (shouldClear && !m_nestedArrayForeachp->backp())
+            VL_DO_DANGLING(m_nestedArrayForeachp->deleteTree(), m_nestedArrayForeachp);
     }
     void visit(AstConstraintBefore* nodep) override {
         // Generate solveBefore() calls for each (lhs, rhs) variable pair.
@@ -2673,7 +2892,7 @@ class ConstraintExprVisitor final : public VNVisitor {
             }
             nodep->replaceWith(newp);
             VL_DO_DANGLING(nodep->deleteTree(), nodep);
-            if (origp && !hoistRandModeOverSelect(newp, origp)) {
+            if (origp && !hoistRandModeOverSelectAndMember(newp, origp)) {
                 VL_DO_DANGLING(origp->deleteTree(), origp);
             }
             return;

--- a/test_regress/t/t_constraint_global_arr_nested.py
+++ b/test_regress/t/t_constraint_global_arr_nested.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2025 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+if not test.have_solver:
+    test.skip("No constraint solver installed")
+
+test.compile()
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_constraint_global_arr_nested.v
+++ b/test_regress/t/t_constraint_global_arr_nested.v
@@ -1,0 +1,223 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain.
+// SPDX-FileCopyrightText: 2026 Antmicro
+// SPDX-License-Identifier: CC0-1.0
+
+`define stop $stop
+`define checkd(gotv,expv) do if ((gotv) !== (expv)) begin $write("%%Error: %s:%0d:  got=%0d exp=%0d\n", `__FILE__,`__LINE__, (gotv), (expv)); `stop; end while(0);
+
+/* verilator lint_off WIDTHTRUNC */
+class Inner;
+  rand int m_x;
+  rand int m_y;
+endclass
+
+class Middle;
+  rand Inner m_obj;
+  rand Inner m_arr[3];
+endclass
+
+class Item;
+  rand int x;
+  rand int y;
+  randc bit [1:0] cycle;
+endclass
+
+class Holder;
+  rand Item cyclic[1];
+  rand Item mode[1];
+  rand Item items[2];
+  rand Inner m_string_assoc[string];
+  function new;
+    mode[0] = new;
+    cyclic[0] = new;
+    m_string_assoc["abc"] = new;
+    foreach (items[i])
+      items[i] = new;
+  endfunction
+endclass
+
+class Outer;
+  int m_idx;
+  rand Middle m_mid;
+  rand Middle m_mid_arr[2];
+  rand Middle m_mid_arr2[3][2];
+  rand Middle m_mid_arr3[3][2];
+  rand Middle m_mid_arr4[3][2];
+  rand Inner m_assoc[int];
+  string m_key;
+  rand Inner m_assoc_nested[int][bit];
+  rand Holder m_holder;
+
+  function new();
+    m_idx = 1;
+    m_key = "abc";
+    m_mid = new;
+    m_mid.m_obj = new;
+    foreach (m_mid.m_arr[i]) m_mid.m_arr[i] = new;
+    foreach (m_mid_arr[i]) begin
+      m_mid_arr[i] = new;
+      m_mid_arr[i].m_obj = new;
+      foreach (m_mid_arr[i].m_arr[j]) m_mid_arr[i].m_arr[j] = new;
+    end
+    foreach (m_mid_arr2[i])
+      foreach (m_mid_arr2[i][j]) begin
+        m_mid_arr2[i][j] = new;
+        m_mid_arr2[i][j].m_obj = new;
+        foreach (m_mid_arr2[i][j].m_arr[k]) m_mid_arr2[i][j].m_arr[k] = new;
+      end
+    foreach (m_mid_arr3[i])
+      foreach (m_mid_arr3[i][j]) begin
+        m_mid_arr3[i][j] = new;
+        m_mid_arr3[i][j].m_obj = new;
+        foreach (m_mid_arr3[i][j].m_arr[k]) m_mid_arr3[i][j].m_arr[k] = new;
+      end
+    foreach (m_mid_arr4[i])
+      foreach (m_mid_arr4[i][j]) begin
+        m_mid_arr4[i][j] = new;
+        m_mid_arr4[i][j].m_obj = new;
+        foreach (m_mid_arr4[i][j].m_arr[k]) m_mid_arr4[i][j].m_arr[k] = new;
+      end
+
+    m_assoc[0] = new;
+    m_assoc[1] = new;
+    m_assoc_nested[123][1] = new;
+    m_holder = new;
+  endfunction
+
+  // Case 1: Simple nested member access
+  constraint c_simple {
+    m_mid.m_obj.m_x == 100;
+    m_mid.m_obj.m_y == 101;
+  }
+
+  // Case 2: Array indexing in the path
+  constraint c_array_index {
+    m_mid.m_arr[0].m_x == 200;
+    m_mid.m_arr[0].m_y == 201;
+  }
+
+  constraint c_array_index_idx {
+    m_mid.m_arr[m_idx].m_x == 202;
+    m_mid.m_arr[m_idx].m_y == 203;
+  }
+
+  // Case 3: Nested array indexing
+  constraint c_nested_array {
+    m_mid_arr[0].m_obj.m_x == 300;
+    m_mid_arr[0].m_obj.m_y == 301;
+  }
+
+  // Case 4: Multiple array indices
+  constraint c_multi_array {
+    m_mid_arr[1].m_arr[2].m_y == 400;
+  }
+
+  // Case 5: Associative array element member access
+  constraint c_assoc {
+    m_assoc[0].m_x == 500;
+    m_assoc[m_idx].m_x == 502;
+  }
+
+  constraint c_string_assoc {
+    m_holder.m_string_assoc[m_key].m_x == 43;
+  }
+
+  constraint c_assoc_nested {
+    m_assoc_nested[123][1].m_x == 501;
+  }
+
+  // Case 6: foreach
+  constraint c_foreach {
+    foreach (m_mid_arr2[i, j])
+      m_mid_arr2[i][j].m_obj.m_x == i + j;
+  }
+  constraint c_foreach2 {
+    foreach (m_mid_arr3[i])
+      foreach (m_mid_arr3[i][j])
+        m_mid_arr3[i][j].m_obj.m_x == i - j;
+  }
+
+  constraint c_foreach3 {
+    foreach (m_mid_arr4[i])
+        m_mid_arr4[i][m_idx].m_obj.m_x == i;
+  }
+
+  constraint c_foreach_multiple {
+    foreach(m_holder.items[i]) {
+      m_holder.items[i].x == i;
+      m_holder.items[i].y == i + 10;
+    }
+  }
+
+  // Case 7: randmode
+  constraint c_mode {
+    m_holder.mode[0].x == 42;
+  }
+
+  // Case 8: randc
+  constraint c_randc {
+    m_holder.cyclic[0].cycle inside {[0:3]};
+  }
+endclass
+
+
+module t_constraint_global_arr_nested;
+  initial begin
+    automatic Outer o = new;
+    automatic Outer randc_o = new;
+    automatic Outer randmode_off_o = new;
+    automatic bit [3:0] seen = 0;
+
+    if (randmode_off_o.randomize() != 1) $stop;
+    `checkd(randmode_off_o.m_holder.mode[0].x, 42);
+
+    o.m_holder.mode[0].x = 42;
+    o.m_holder.mode[0].x.rand_mode(0);
+
+    repeat (2) begin
+      if (o.randomize() != 1) $stop;
+
+      foreach (o.m_mid_arr2[i])
+        foreach (o.m_mid_arr2[i][j])
+          if (o.m_mid_arr2[i][j].m_obj.m_x != i + j) $stop;
+      foreach (o.m_mid_arr3[i])
+        foreach (o.m_mid_arr3[i][j])
+          if (o.m_mid_arr3[i][j].m_obj.m_x != i - j) $stop;
+      foreach (o.m_mid_arr4[i])
+        if (o.m_mid_arr4[i][1].m_obj.m_x != i) $stop;
+      `checkd(o.m_mid.m_obj.m_x, 100);
+      `checkd(o.m_mid.m_obj.m_y, 101);
+      `checkd(o.m_mid.m_arr[0].m_x, 200);
+      `checkd(o.m_mid.m_arr[0].m_y, 201);
+      `checkd(o.m_mid.m_arr[1].m_x, 202);
+      `checkd(o.m_mid.m_arr[1].m_y, 203);
+      `checkd(o.m_mid_arr[0].m_obj.m_x, 300);
+      `checkd(o.m_mid_arr[0].m_obj.m_y, 301);
+      `checkd(o.m_mid_arr[1].m_arr[2].m_y, 400);
+      `checkd(o.m_assoc[0].m_x, 500);
+      `checkd(o.m_assoc[1].m_x, 502);
+      `checkd(o.m_holder.m_string_assoc["abc"].m_x, 43);
+      `checkd(o.m_assoc_nested[123][1].m_x, 501);
+      `checkd(o.m_holder.mode[0].x, 42);
+      foreach (o.m_holder.items[i]) begin
+        `checkd(o.m_holder.items[i].x, i);
+        `checkd(o.m_holder.items[i].y, i + 10);
+      end
+    end
+    repeat (4) begin
+     if (randc_o.randomize() != 1)
+       $fatal(1, "randc randomize failed");
+     if (seen[randc_o.m_holder.cyclic[0].cycle])
+       $fatal(1, "randc repeated early: %0d",
+              randc_o.m_holder.cyclic[0].cycle);
+     seen[randc_o.m_holder.cyclic[0].cycle] = 1;
+    end
+    if (seen != 4'b1111)
+      $fatal(1, "randc did not complete the cycle");
+
+    $display("*-* All Finished *-*");
+    $finish;
+  end
+endmodule

--- a/test_regress/t/t_constraint_global_arr_nested.v
+++ b/test_regress/t/t_constraint_global_arr_nested.v
@@ -6,6 +6,23 @@
 
 `define stop $stop
 `define checkd(gotv,expv) do if ((gotv) !== (expv)) begin $write("%%Error: %s:%0d:  got=%0d exp=%0d\n", `__FILE__,`__LINE__, (gotv), (expv)); `stop; end while(0);
+`define check_rand(cl, field, cond) \
+begin \
+   automatic longint prev_result; \
+   automatic int ok; \
+   if (!bit'(cl.randomize())) $stop; \
+   prev_result = longint'(field); \
+   if (!(cond)) $stop; \
+   repeat(9) begin \
+      longint result; \
+      if (!bit'(cl.randomize())) $stop; \
+      result = longint'(field); \
+      if (!(cond)) $stop; \
+      if (result != prev_result) ok = 1; \
+      prev_result = result; \
+   end \
+   if (ok != 1) $stop; \
+end
 
 /* verilator lint_off WIDTHTRUNC */
 class Inner;
@@ -41,7 +58,8 @@ endclass
 class Outer;
   int m_idx;
   rand Middle m_mid;
-  rand Middle m_mid_arr[2];
+  rand Middle m_mid2;
+  rand Middle m_mid_arr[3];
   rand Middle m_mid_arr2[3][2];
   rand Middle m_mid_arr3[3][2];
   rand Middle m_mid_arr4[3][2];
@@ -56,6 +74,8 @@ class Outer;
     m_mid = new;
     m_mid.m_obj = new;
     foreach (m_mid.m_arr[i]) m_mid.m_arr[i] = new;
+    m_mid2 = new;
+    foreach (m_mid2.m_arr[i]) m_mid2.m_arr[i] = new;
     foreach (m_mid_arr[i]) begin
       m_mid_arr[i] = new;
       m_mid_arr[i].m_obj = new;
@@ -96,11 +116,17 @@ class Outer;
   constraint c_array_index {
     m_mid.m_arr[0].m_x == 200;
     m_mid.m_arr[0].m_y == 201;
+
+    m_mid2.m_arr[0].m_x < 200;
+    m_mid2.m_arr[0].m_y < 201;
   }
 
   constraint c_array_index_idx {
     m_mid.m_arr[m_idx].m_x == 202;
     m_mid.m_arr[m_idx].m_y == 203;
+
+    m_mid2.m_arr[m_idx].m_x < 202;
+    m_mid2.m_arr[m_idx].m_y < 203;
   }
 
   // Case 3: Nested array indexing
@@ -112,6 +138,8 @@ class Outer;
   // Case 4: Multiple array indices
   constraint c_multi_array {
     m_mid_arr[1].m_arr[2].m_y == 400;
+
+    m_mid_arr[2].m_arr[2].m_y < 400;
   }
 
   // Case 5: Associative array element member access
@@ -122,6 +150,7 @@ class Outer;
 
   constraint c_string_assoc {
     m_holder.m_string_assoc[m_key].m_x == 43;
+    m_holder.m_string_assoc[m_key].m_y < 43;
   }
 
   constraint c_assoc_nested {
@@ -176,36 +205,44 @@ module t_constraint_global_arr_nested;
     o.m_holder.mode[0].x = 42;
     o.m_holder.mode[0].x.rand_mode(0);
 
-    repeat (2) begin
-      if (o.randomize() != 1) $stop;
+    if (o.randomize() != 1) $stop;
 
-      foreach (o.m_mid_arr2[i])
-        foreach (o.m_mid_arr2[i][j])
-          if (o.m_mid_arr2[i][j].m_obj.m_x != i + j) $stop;
-      foreach (o.m_mid_arr3[i])
-        foreach (o.m_mid_arr3[i][j])
-          if (o.m_mid_arr3[i][j].m_obj.m_x != i - j) $stop;
-      foreach (o.m_mid_arr4[i])
-        if (o.m_mid_arr4[i][1].m_obj.m_x != i) $stop;
-      `checkd(o.m_mid.m_obj.m_x, 100);
-      `checkd(o.m_mid.m_obj.m_y, 101);
-      `checkd(o.m_mid.m_arr[0].m_x, 200);
-      `checkd(o.m_mid.m_arr[0].m_y, 201);
-      `checkd(o.m_mid.m_arr[1].m_x, 202);
-      `checkd(o.m_mid.m_arr[1].m_y, 203);
-      `checkd(o.m_mid_arr[0].m_obj.m_x, 300);
-      `checkd(o.m_mid_arr[0].m_obj.m_y, 301);
-      `checkd(o.m_mid_arr[1].m_arr[2].m_y, 400);
-      `checkd(o.m_assoc[0].m_x, 500);
-      `checkd(o.m_assoc[1].m_x, 502);
-      `checkd(o.m_holder.m_string_assoc["abc"].m_x, 43);
-      `checkd(o.m_assoc_nested[123][1].m_x, 501);
-      `checkd(o.m_holder.mode[0].x, 42);
-      foreach (o.m_holder.items[i]) begin
-        `checkd(o.m_holder.items[i].x, i);
-        `checkd(o.m_holder.items[i].y, i + 10);
-      end
+    foreach (o.m_mid_arr2[i])
+      foreach (o.m_mid_arr2[i][j])
+        if (o.m_mid_arr2[i][j].m_obj.m_x != i + j) $stop;
+    foreach (o.m_mid_arr3[i])
+      foreach (o.m_mid_arr3[i][j])
+        if (o.m_mid_arr3[i][j].m_obj.m_x != i - j) $stop;
+    foreach (o.m_mid_arr4[i])
+      if (o.m_mid_arr4[i][1].m_obj.m_x != i) $stop;
+    `checkd(o.m_mid.m_obj.m_x, 100);
+    `checkd(o.m_mid.m_obj.m_y, 101);
+    `checkd(o.m_mid.m_arr[0].m_x, 200);
+    `checkd(o.m_mid.m_arr[0].m_y, 201);
+    `checkd(o.m_mid.m_arr[1].m_x, 202);
+    `checkd(o.m_mid.m_arr[1].m_y, 203);
+    `checkd(o.m_mid_arr[0].m_obj.m_x, 300);
+    `checkd(o.m_mid_arr[0].m_obj.m_y, 301);
+    `checkd(o.m_mid_arr[1].m_arr[2].m_y, 400);
+    `checkd(o.m_assoc[0].m_x, 500);
+    `checkd(o.m_assoc[1].m_x, 502);
+    `checkd(o.m_holder.m_string_assoc["abc"].m_x, 43);
+    `checkd(o.m_assoc_nested[123][1].m_x, 501);
+    `checkd(o.m_holder.mode[0].x, 42);
+    foreach (o.m_holder.items[i]) begin
+      `checkd(o.m_holder.items[i].x, i);
+      `checkd(o.m_holder.items[i].y, i + 10);
     end
+    `check_rand(o, o.m_mid2.m_arr[0].m_x, o.m_mid2.m_arr[0].m_x < 200);
+    `check_rand(o, o.m_mid2.m_arr[0].m_y, o.m_mid2.m_arr[0].m_y < 201);
+
+    `check_rand(o, o.m_mid2.m_arr[1].m_x, o.m_mid2.m_arr[1].m_x < 202);
+    `check_rand(o, o.m_mid2.m_arr[1].m_y, o.m_mid2.m_arr[1].m_y < 203);
+
+    `check_rand(o, o.m_mid_arr[2].m_arr[2].m_y, o.m_mid_arr[2].m_arr[2].m_y < 400);
+
+    `check_rand(o, o.m_holder.m_string_assoc["abc"].m_y, o.m_holder.m_string_assoc["abc"].m_y < 43);
+
     repeat (4) begin
      if (randc_o.randomize() != 1)
        $fatal(1, "randc randomize failed");

--- a/test_regress/t/t_constraint_global_arr_unsup.out
+++ b/test_regress/t/t_constraint_global_arr_unsup.out
@@ -1,34 +1,31 @@
-%Error-UNSUPPORTED: t/t_constraint_global_arr_unsup.v:41:20: Unsupported: Nested array element access in global constraint
-   41 |     m_mid.m_arr[0].m_x == 200;
-      |                    ^~~
-                    ... For error description see https://verilator.org/warn/UNSUPPORTED?v=latest
-%Error-UNSUPPORTED: t/t_constraint_global_arr_unsup.v:42:20: Unsupported: Nested array element access in global constraint
-   42 |     m_mid.m_arr[0].m_y == 201;
-      |                    ^~~
-%Error-UNSUPPORTED: t/t_constraint_global_arr_unsup.v:47:24: Unsupported: Nested array element access in global constraint
-   47 |     m_mid_arr[0].m_obj.m_x == 300;
-      |                        ^~~
-%Error-UNSUPPORTED: t/t_constraint_global_arr_unsup.v:48:24: Unsupported: Nested array element access in global constraint
-   48 |     m_mid_arr[0].m_obj.m_y == 301;
-      |                        ^~~
-%Error-UNSUPPORTED: t/t_constraint_global_arr_unsup.v:53:27: Unsupported: Nested array element access in global constraint
-   53 |     m_mid_arr[1].m_arr[2].m_y == 400;
-      |                           ^~~
-%Error-UNSUPPORTED: t/t_constraint_global_arr_unsup.v:59:16: Unsupported: Array element access in global constraint
-   59 |     m_assoc[0].m_x == 500;
-      |                ^~~
-%Error-UNSUPPORTED: t/t_constraint_global_arr_unsup.v:65:34: Unsupported: Nested array element access in global constraint
+%Error-UNSUPPORTED: t/t_constraint_global_arr_unsup.v:44:34: Unsupported: Nested array element access in global constraint
                                                            : ... note: In instance 't_constraint_global_arr_unsup'
-   65 |       solve m_mid_arr[((i*2)/2)].m_obj.m_x before m_mid_arr[((i*2)/2) + 1].m_obj.m_x;
+   44 |       solve m_mid_arr[((i*2)/2)].m_obj.m_x before m_mid_arr[((i*2)/2) + 1].m_obj.m_x;
       |                                  ^~~~~
-%Error-UNSUPPORTED: t/t_constraint_global_arr_unsup.v:65:76: Unsupported: Nested array element access in global constraint
+                    ... For error description see https://verilator.org/warn/UNSUPPORTED?v=latest
+%Error-UNSUPPORTED: t/t_constraint_global_arr_unsup.v:44:76: Unsupported: Nested array element access in global constraint
                                                            : ... note: In instance 't_constraint_global_arr_unsup'
-   65 |       solve m_mid_arr[((i*2)/2)].m_obj.m_x before m_mid_arr[((i*2)/2) + 1].m_obj.m_x;
+   44 |       solve m_mid_arr[((i*2)/2)].m_obj.m_x before m_mid_arr[((i*2)/2) + 1].m_obj.m_x;
       |                                                                            ^~~~~
-%Error-UNSUPPORTED: t/t_constraint_global_arr_unsup.v:67:34: Unsupported: Nested array element access in global constraint
-   67 |       m_mid_arr[((i*2)/2)].m_obj.m_x != m_mid_arr[((i*2)/2) + 1].m_obj.m_x;
-      |                                  ^~~
-%Error-UNSUPPORTED: t/t_constraint_global_arr_unsup.v:67:72: Unsupported: Nested array element access in global constraint
-   67 |       m_mid_arr[((i*2)/2)].m_obj.m_x != m_mid_arr[((i*2)/2) + 1].m_obj.m_x;
-      |                                                                        ^~~
+%Error-UNSUPPORTED: t/t_constraint_global_arr_unsup.v:46:16: Unsupported: Multiple expressions inside indices of complex expression in constraint
+                                                           : ... note: In instance 't_constraint_global_arr_unsup'
+   46 |       m_mid_arr[((i*2)/2)].m_obj.m_x != m_mid_arr[((i*2)/2) + 1].m_obj.m_x;
+      |                ^
+                    t/t_constraint_global_arr_unsup.v:46:50: ... Location of second expression
+   46 |       m_mid_arr[((i*2)/2)].m_obj.m_x != m_mid_arr[((i*2)/2) + 1].m_obj.m_x;
+      |                                                  ^
+%Error-UNSUPPORTED: t/t_constraint_global_arr_unsup.v:52:14: Unsupported: Randomized index in complex expression
+   52 |     m_mid_arr[m_idx].m_obj.m_x == 123;
+      |              ^
+%Error-UNSUPPORTED: t/t_constraint_global_arr_unsup.v:57:16: Unsupported: Multiple expressions inside indices of complex expression in constraint
+                                                           : ... note: In instance 't_constraint_global_arr_unsup'
+   57 |     m_mid.m_arr[m_base + 0].m_x == 123;
+      |                ^
+                    t/t_constraint_global_arr_unsup.v:58:16: ... Location of second expression
+   58 |     m_mid.m_arr[m_base + 1].m_x == 321;
+      |                ^
+%Error: t/t_constraint_global_arr_unsup.v:64:21: Illegal non-integral expression or subexpression in random constraint. (IEEE 1800-2023 18.3)
+   64 |       m_mid.m_assoc[i].m_x == 1;
+      |                     ^
+        ... See the manual at https://verilator.org/verilator_doc.html?v=latest for more assistance.
 %Error: Exiting due to

--- a/test_regress/t/t_constraint_global_arr_unsup.v
+++ b/test_regress/t/t_constraint_global_arr_unsup.v
@@ -10,14 +10,22 @@ class Inner;
   rand int m_y;
 endclass
 
+typedef struct {
+  int a;
+  int b;
+} UnpackedIndexType;
+
 class Middle;
   rand Inner m_obj;
   rand Inner m_arr[3];
+  rand Inner m_assoc[UnpackedIndexType];
 endclass
 
 class Outer;
   rand Middle m_mid;
   rand Middle m_mid_arr[2];
+  rand int m_idx;
+  int m_base = 0;
 
   function new();
     m_mid = new;
@@ -30,36 +38,7 @@ class Outer;
     end
   endfunction
 
-  // Case 1: Simple nested member access (should work)
-  constraint c_simple {
-    m_mid.m_obj.m_x == 100;
-    m_mid.m_obj.m_y == 101;
-  }
-
-  // Case 2: Array indexing in the path (may not work)
-  constraint c_array_index {
-    m_mid.m_arr[0].m_x == 200;
-    m_mid.m_arr[0].m_y == 201;
-  }
-
-  // Case 3: Nested array indexing
-  constraint c_nested_array {
-    m_mid_arr[0].m_obj.m_x == 300;
-    m_mid_arr[0].m_obj.m_y == 301;
-  }
-
-  // Case 4: Multiple array indices
-  constraint c_multi_array {
-    m_mid_arr[1].m_arr[2].m_y == 400;
-  }
-
-  // Case 5: Associative array element member access
-  rand Inner m_assoc[int];
-  constraint c_assoc {
-    m_assoc[0].m_x == 500;
-  }
-
-  // Case 6: Array elements member access in solve...before foreach loop
+  // Case 1: Array elements member access in solve...before foreach loop
   constraint c_foreach {
     foreach (m_mid_arr[i]) {
       solve m_mid_arr[((i*2)/2)].m_obj.m_x before m_mid_arr[((i*2)/2) + 1].m_obj.m_x;
@@ -67,32 +46,30 @@ class Outer;
       m_mid_arr[((i*2)/2)].m_obj.m_x != m_mid_arr[((i*2)/2) + 1].m_obj.m_x;
     }
   }
+
+  // Case 2: Randomized index in nested array access
+  constraint c_randomized_index {
+    m_mid_arr[m_idx].m_obj.m_x == 123;
+  }
+
+  // Case 3: Different index expressions
+  constraint c_expressions {
+    m_mid.m_arr[m_base + 0].m_x == 123;
+    m_mid.m_arr[m_base + 1].m_x == 321;
+  }
+
+  // Unsupported expression inside index
+  constraint c_bad_index {
+    foreach(m_mid.m_assoc[i])
+      m_mid.m_assoc[i].m_x == 1;
+  }
 endclass
 
 module t_constraint_global_arr_unsup;
   initial begin
     automatic Outer o = new;
     if (o.randomize()) begin
-      $display("Case 1 - Simple: mid.obj.x = %0d (expected 100)", o.m_mid.m_obj.m_x);
-      $display("Case 1 - Simple: mid.obj.y = %0d (expected 101)", o.m_mid.m_obj.m_y);
-      $display("Case 2 - Array[0]: mid.arr[0].x = %0d (expected 200)", o.m_mid.m_arr[0].m_x);
-      $display("Case 2 - Array[0]: mid.arr[0].y = %0d (expected 201)", o.m_mid.m_arr[0].m_y);
-      $display("Case 3 - Nested[0]: mid_arr[0].obj.x = %0d (expected 300)", o.m_mid_arr[0].m_obj.m_x);
-      $display("Case 3 - Nested[0]: mid_arr[0].obj.y = %0d (expected 301)", o.m_mid_arr[0].m_obj.m_y);
-      $display("Case 4 - Multi[1][2]: mid_arr[1].arr[2].y = %0d (expected 400)", o.m_mid_arr[1].m_arr[2].m_y);
-
-      // Check results
-      if (o.m_mid.m_obj.m_x == 100 && o.m_mid.m_obj.m_y == 101 &&
-          o.m_mid.m_arr[0].m_x == 200 && o.m_mid.m_arr[0].m_y == 201 &&
-          o.m_mid_arr[0].m_obj.m_x == 300 && o.m_mid_arr[0].m_obj.m_y == 301 &&
-          o.m_mid_arr[1].m_arr[2].m_y == 400) begin
-        $display("*-* All Finished *-*");
-        $finish;
-      end
-      else begin
-        $display("*-* FAILED *-*");
-        $stop;
-      end
+      $display("*-* All Finished *-*");
     end
     else begin
       $display("*-* FAILED: randomize() returned 0 *-*");


### PR DESCRIPTION
This PR adds support for nested array, associative array, and field access.

When nested access is detected we change how elements are declared for the solver. Instead of declaring an array as array we define separate variables for each of its elements. This way we can interleave member access with array access. E.g. `m_mid.m_arr[0].m_x` is converted into `"m_mid.m_arr.0.m_x"` or if we use variable as index `m_mid_m_arr[idx].mx` we name it `"m_mid.m_arr.<value of idx>.m_x"`. To format the name of variable properly we use `AstSFormatF` nodes, which allow to use the values of variables. With nested access also the first argument to `write_var` is changed, it now contains whole access tree, instead of single `AstVarRef`.