### PR TITLE
Fix type checking of task arguments

### DIFF
--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -7539,9 +7539,11 @@ class WidthVisitor final : public VNVisitor {
                     relinkHandle.relink(newp);
                 }
                 if (portp->isWritable()) V3LinkLValue::linkLValueSet(pinp);
-                if (VN_IS(pinDTypep, BasicDType) && portp->direction() != VDirection::REF
-                    && (VN_IS(portDTypep, UnpackArrayDType) || VN_IS(portDTypep, DynArrayDType)
-                        || VN_IS(portDTypep, QueueDType) || VN_IS(portDTypep, AssocArrayDType))) {
+                if (portp->direction() != VDirection::REF
+                    && !(portp->basicp()
+                         && portp->basicp()->untyped())  // for properties, handled in V3AssertPre
+                    && ((VN_IS(portDTypep, BasicDType) && pinDTypep->isNonPackedArray())
+                        || (VN_IS(pinDTypep, BasicDType) && portDTypep->isNonPackedArray()))) {
                     pinp->v3error("Function Argument expects " << portDTypep->prettyDTypeNameQ()
                                                                << ", got "
                                                                << pinDTypep->prettyDTypeNameQ());

--- a/test_regress/t/t_invalid_task_arguments_bad.out
+++ b/test_regress/t/t_invalid_task_arguments_bad.out
@@ -1,18 +1,42 @@
-%Error: t/t_invalid_task_arguments_bad.v:25:20: Function Argument expects 'logic[30:0]$[]', got 'IData'
+%Error: t/t_invalid_task_arguments_bad.v:44:20: Function Argument expects 'logic[30:0]$[]', got 'IData'
                                               : ... note: In instance 't'
-   25 |     dyn_task(.data($urandom));
+   44 |     dyn_task(.data($urandom));
       |                    ^~~~~~~~
         ... See the manual at https://verilator.org/verilator_doc.html?v=latest for more assistance.
-%Error: t/t_invalid_task_arguments_bad.v:26:25: Function Argument expects 'logic[30:0]$[3:0]', got 'IData'
+%Error: t/t_invalid_task_arguments_bad.v:45:25: Function Argument expects 'logic[30:0]$[3:0]', got 'IData'
                                               : ... note: In instance 't'
-   26 |     unpacked_task(.data($urandom));
+   45 |     unpacked_task(.data($urandom));
       |                         ^~~~~~~~
-%Error: t/t_invalid_task_arguments_bad.v:27:22: Function Argument expects 'logic[30:0]$[$]', got 'IData'
+%Error: t/t_invalid_task_arguments_bad.v:46:22: Function Argument expects 'logic[30:0]$[$]', got 'IData'
                                               : ... note: In instance 't'
-   27 |     queue_task(.data($urandom));
+   46 |     queue_task(.data($urandom));
       |                      ^~~~~~~~
-%Error: t/t_invalid_task_arguments_bad.v:28:22: Function Argument expects 'logic[30:0]$[int]', got 'IData'
+%Error: t/t_invalid_task_arguments_bad.v:47:22: Function Argument expects 'logic[30:0]$[int]', got 'IData'
                                               : ... note: In instance 't'
-   28 |     assoc_task(.data($urandom));
+   47 |     assoc_task(.data($urandom));
       |                      ^~~~~~~~
+%Error: t/t_invalid_task_arguments_bad.v:48:23: Function Argument expects 'logic', got 'logic$[3:0]'
+                                              : ... note: In instance 't'
+   48 |     scalar_task(.data(unpacked_data));
+      |                       ^~~~~~~~~~~~~
+%Error: t/t_invalid_task_arguments_bad.v:49:23: Function Argument expects 'logic', got 'logic$[]'
+                                              : ... note: In instance 't'
+   49 |     scalar_task(.data(dyn_data));
+      |                       ^~~~~~~~
+%Error: t/t_invalid_task_arguments_bad.v:50:23: Function Argument expects 'logic', got 'logic$[$]'
+                                              : ... note: In instance 't'
+   50 |     scalar_task(.data(queue_data));
+      |                       ^~~~~~~~~~
+%Error: t/t_invalid_task_arguments_bad.v:51:23: Function Argument expects 'logic', got 'logic$[int]'
+                                              : ... note: In instance 't'
+   51 |     scalar_task(.data(assoc_data));
+      |                       ^~~~~~~~~~
+%Error: t/t_invalid_task_arguments_bad.v:52:27: Function Argument expects 'logic[30:0]', got 'logic$[3:0]'
+                                              : ... note: In instance 't'
+   52 |     scalar_vec_task(.data(vec_data));
+      |                           ^~~~~~~~
+%Error: t/t_invalid_task_arguments_bad.v:53:32: Function Argument expects 'logic', got 'logic$[0:9]'
+                                              : ... note: In instance 't'
+   53 |     logical_or(my_signal_a[0], my_signal_b);
+      |                                ^~~~~~~~~~~
 %Error: Exiting due to

--- a/test_regress/t/t_invalid_task_arguments_bad.v
+++ b/test_regress/t/t_invalid_task_arguments_bad.v
@@ -20,12 +20,37 @@ task assoc_task(input logic [30:0] data[int]);
   $display("%p", data);
 endtask
 
+task scalar_task(input logic data);
+  $display("%b", data);
+endtask
+
+task scalar_vec_task(input logic [30:0] data);
+  $display("%b", data);
+endtask
+
+function logic logical_or(input logic a, b);
+  return a | b;
+endfunction
+
 module t;
+  logic unpacked_data[3:0];
+  logic dyn_data[];
+  logic queue_data[$];
+  logic assoc_data[int];
+  logic vec_data[3:0];
+  logic my_signal_a[10];
+  logic my_signal_b[10];
   initial begin
     dyn_task(.data($urandom));
     unpacked_task(.data($urandom));
     queue_task(.data($urandom));
     assoc_task(.data($urandom));
+    scalar_task(.data(unpacked_data));
+    scalar_task(.data(dyn_data));
+    scalar_task(.data(queue_data));
+    scalar_task(.data(assoc_data));
+    scalar_vec_task(.data(vec_data));
+    logical_or(my_signal_a[0], my_signal_b);
     $write("*-* All Finished *-*\n");
     $finish;
   end


### PR DESCRIPTION
~~~ verilog
module my_module ();

  function logic logical_or(input logic a, b);
    return a | b;
  endfunction

  logic my_signal_a[10];
  logic my_signal_b[10];

  logic my_signal_y[10];

  generate for (genvar i=0; i<10; i=i+1) begin
    assign my_signal_y[i] = logical_or(my_signal_a[i], my_signal_b); // MISSING index in my_signal_b
  end endgenerate

  initial begin
    $monitor(my_signal_y[0]);
  end

endmodule
~~~
It passes verilation silently and throws error during compilation:
~~~
In file included from Varr_bug__ALL.cpp:7:
Varr_bug___024root__0__Slow.cpp: In function 'void Varr_bug___024root___stl_sequent__TOP__0(Varr_bug___024root*)':
Varr_bug___024root__0__Slow.cpp:141:58: error: cannot convert 'VlUnpacked<unsigned char, 10>' to 'CData' {aka 'unsigned char'} in assignment
  141 |     __Vfunc_my_module__DOT__logical_or__0__b = vlSelfRef.my_module__DOT__my_signal_b;
      |                                                ~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                                          |
      |                                                          VlUnpacked<unsigned char, 10>
~~~

As it concerns the same `if` as in https://github.com/verilator/verilator/pull/7948, I've simplified it a bit by using `isNonPackedArray` instead of invidual `VN_IS`, as it checks for the same dtypes as we had there:

```
bool AstNodeDType::isNonPackedArray() const {
    return VN_IS(this, UnpackArrayDType) || VN_IS(this, DynArrayDType) || VN_IS(this, QueueDType)
           || VN_IS(this, AssocArrayDType);
}
```