### PR TITLE
Internals: Improve dev coverage flow

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -94,6 +94,7 @@ CFG_WITH_DEFENV = @CFG_WITH_DEFENV@
 CFG_WITH_DEV_GCOV = @CFG_WITH_DEV_GCOV@
 CFG_WITH_LONGTESTS = @CFG_WITH_LONGTESTS@
 CFG_WITH_SOLVER = @CFG_WITH_SOLVER@
+GCOV = @GCOV@
 PACKAGE_VERSION = @PACKAGE_VERSION@
 
 #### End of system configuration section. ####
@@ -696,20 +697,28 @@ COVERAGE_DIR := obj_coverage
 ifeq ($(CFG_WITH_DEV_GCOV),yes)
 
 # Figure out base and head refs for coverage report
-COVERAGE_REF_BASE := $(if $(COVERAGE_BASE),$(shell git rev-parse --short $(COVERAGE_BASE)))
+COVERAGE_REF_BASE := $(if $(COVERAGE_BASE),$(shell git rev-parse --short $(COVERAGE_BASE) 2>/dev/null))
+ifneq ($(COVERAGE_BASE),)
+ ifeq ($(COVERAGE_REF_BASE),)
+  $(error COVERAGE_BASE='$(COVERAGE_BASE)' is not a valid git revision)
+ endif
+endif
 COVERAGE_REF_HEAD := $(shell git rev-parse --short HEAD)
 override undefine COVERAGE_BASE # Use the above variabels instead
 
 # 'fastcov' setup
 FASTCOV := nodist/fastcov.py
 FASTCOV_OPT := -j $(shell nproc)
+FASTCOV_OPT += --gcov $(GCOV)
 FASTCOV_OPT += --lcov
 FASTCOV_OPT += --process-gcno
 FASTCOV_OPT += --branch-coverage
 FASTCOV_OPT += --dump-statistic
 # Files matching the following glob patterns will be excluded from coverage
 FASTCOV_OPT += --exclude-glob
-FASTCOV_OPT += '/usr/*'
+FASTCOV_OPT += '/usr/include/*'
+FASTCOV_OPT += '/usr/lib*/*'
+FASTCOV_OPT += '/usr/share/*'
 FASTCOV_OPT += '*examples/*'
 FASTCOV_OPT += '*include/fstcpp/*'
 FASTCOV_OPT += '*src/obj_dbg/*'
@@ -750,6 +759,7 @@ GENHTML_OPT += --missed
 GENHTML_OPT += --rc branch_coverage=1
 GENHTML_OPT += --rc genhtml_hi_limit=100
 GENHTML_OPT += --ignore-errors negative
+GENHTML_OPT += --ignore-errors inconsistent
 ifeq ($(COVERAGE_REF_BASE),)
 GENHTML_OPT += --header-title "Code coverage for Verilator $(shell git describe --dirty)"
 else
@@ -781,7 +791,7 @@ $(COVERAGE_DIR)/verilator-patch.info: $(COVERAGE_DIR)/verilator.info
 	@echo "####################################################################"
 	rm -f $(COVERAGE_DIR)/empty-patch
 	git diff $(COVERAGE_REF_BASE) -- include src > $(COVERAGE_DIR)/filter.patch
-	[ -s $(COVERAGE_DIR)/filter.patch ]] || touch $(COVERAGE_DIR)/empty-patch
+	[ -s $(COVERAGE_DIR)/filter.patch ] || touch $(COVERAGE_DIR)/empty-patch
 	$(FASTCOV) -C $^ --lcov -o $@ --diff-filter $(COVERAGE_DIR)/filter.patch
 
 # Build coverage report
@@ -790,7 +800,7 @@ $(COVERAGE_DIR)/report/index.html: $(COVERAGE_DIR)/verilator$(if $(COVERAGE_REF_
 	@echo "# genhtml: Generating coverage report"
 	@echo "####################################################################"
 	@rm -rf $(COVERAGE_DIR)/report
-	[ -f $(COVERAGE_DIR)/empty-patch ]] || /usr/bin/time -f "That took %E" \
+	[ -f $(COVERAGE_DIR)/empty-patch ] || /usr/bin/time -f "That took %E" \
 	$(GENHTML) $(GENHTML_OPT) --output-directory $(COVERAGE_DIR)/report $^ || true
 	@# Uncommitted changes not tracked, force rebuild on next run if patch coverage
 	@$(if $(COVERAGE_REF_BASE),mv $(COVERAGE_DIR)/verilator-patch.info $(COVERAGE_DIR)/verilator-patch-last.info)

--- a/configure.ac
+++ b/configure.ac
@@ -447,6 +447,7 @@ AC_DEFUN([_MY_LDLIBS_CHECK_SET],
 
 # Add the coverage flags early as they influence later checks.
 if test "$CFG_WITH_DEV_GCOV" = "yes"; then
+  CFG_GCOV_CXX="$CXX"
   _MY_CXX_CHECK_OPT(CXX,--coverage)
   # Otherwise inline may not show as uncovered
   #  If we use this then e.g. verilated.h functions properly show up
@@ -468,8 +469,32 @@ if test "$CFG_WITH_DEV_GCOV" = "yes"; then
   _MY_CXX_CHECK_OPT(CXX,-fprofile-abs-path)
   # Define so compiled code can know
   _MY_CXX_CHECK_OPT(CXX,-DVL_GCOV)
-  AC_DEFINE([HAVE_DEV_GCOV],[1],[Defined if compiled with code coverage collection for gcov])]
+  AC_DEFINE([HAVE_DEV_GCOV],[1],[Defined if compiled with code coverage collection for gcov])
+  if test "x$GCOV" = "x"; then GCOV=gcov; fi
+  AC_MSG_CHECKING([whether $GCOV reads coverage data from $CFG_GCOV_CXX])
+  CFG_GCOV_DIR=conftest.gcov.dir
+  rm -rf $CFG_GCOV_DIR
+  AS_MKDIR_P([$CFG_GCOV_DIR])
+  echo 'int main() { return 0; }' > $CFG_GCOV_DIR/conftest_gcov.cpp
+  CFG_GCOV_RES=no
+  if (cd $CFG_GCOV_DIR \
+      && $CFG_GCOV_CXX --coverage -o conftest_gcov conftest_gcov.cpp \
+      && ./conftest_gcov) >/dev/null 2>&1; then
+    (cd $CFG_GCOV_DIR && $GCOV conftest_gcov.gcda) >/dev/null 2>&1
+    if test -s $CFG_GCOV_DIR/conftest_gcov.cpp.gcov; then CFG_GCOV_RES=yes; fi
+  else
+    CFG_GCOV_RES=untested
+  fi
+  rm -rf $CFG_GCOV_DIR
+  AC_MSG_RESULT($CFG_GCOV_RES)
+  if test "$CFG_GCOV_RES" = "no"; then
+    AC_MSG_ERROR(['$GCOV' cannot read coverage data written by '$CFG_GCOV_CXX'.
+  Coverage collection would silently produce no data.
+  Pass a matching tool, e.g. GCOV=gcov-<version>
+  or configure without --enable-dev-gcov.])
+  fi
 fi
+AC_SUBST(GCOV)
 AC_SUBST(HAVE_DEV_GCOV)
 
 # Compiler flags to enable profiling

--- a/test_regress/t/t_cover_line_cc.py
+++ b/test_regress/t/t_cover_line_cc.py
@@ -35,7 +35,7 @@ test.files_identical(test.obj_dir + "/coverage.info", "t/" + test.name + ".info.
 
 # If installed
 nout = test.run_capture("lcov --version", check=False)
-version_match = re.search(r'version ([0-9.]+)', nout, re.IGNORECASE)
+version_match = re.search(r'version ([0-9]+\.[0-9]+)', nout, re.IGNORECASE)
 if not version_match:
     test.skip("lcov or genhtml not installed")
 


### PR DESCRIPTION
Buncha coverage tweaks I had to deal with re: #8081 

- Added `GCOV` because `gcov` (or related tool) must agree with the compiler
- Added a test to confirm that `GCOV` and the compiler agree
- Handle arbitrary lcov versions (I have `2.5.0-beta`)
- Removed some unmatched brackets
- Added `--ignore-errors inconsistent` (I believe this is analogous to `--ignore-errors negative` in newer versions of `lcov`)
- Refined `/usr` exclude glob

That last one may be controversial, but for whatever reason my working space is under `/usr/scratch`.  If that's undesirable, I can add another `config` var, e.g. `GCOV_USR_EXCLUDE_GLOB` and make the default `/usr/*`.