### PR TITLE
Fix sampled-value functions on the first cycle

### DIFF
--- a/src/V3Assert.cpp
+++ b/src/V3Assert.cpp
@@ -246,6 +246,41 @@ public:
     ~AssertDeFutureVisitor() = default;
 };
 
+// Prepare one default sampled expression.
+class DefaultSampledValueVisitor final : public VNVisitor {
+    // METHODS
+    static AstConst* newTypeDefault(AstNodeExpr* nodep) {
+        AstConst* const constp
+            = new AstConst{nodep->fileline(), AstConst::DTyped{}, nodep->dtypep()};
+        if (nodep->dtypep()->isFourstate()) constp->num().setAllBitsX();
+        constp->dtypeFrom(nodep);
+        return constp;
+    }
+
+    // VISITORS
+    void visit(AstCMethodHard* nodep) override {
+        if (nodep->method() == VCMethod::EVENT_IS_TRIGGERED) {
+            nodep->replaceWith(new AstConst{nodep->fileline(), AstConst::BitFalse{}});
+            VL_DO_DANGLING(pushDeletep(nodep), nodep);
+        } else {
+            iterateChildren(nodep);
+        }
+    }
+    void visit(AstNodeVarRef* nodep) override {
+        AstVar* const varp = nodep->varp();
+        if (varp->isParam()
+            || (!varp->isNet() && varp->lifetime().isStatic() && varp->hasUserInit())) {
+            return;
+        }
+        nodep->replaceWith(newTypeDefault(nodep));
+        VL_DO_DANGLING(pushDeletep(nodep), nodep);
+    }
+    void visit(AstNode* nodep) override { iterateChildren(nodep); }
+
+public:
+    explicit DefaultSampledValueVisitor(AstNode* nodep) { iterate(nodep); }
+};
+
 //######################################################################
 // AssertVisitor
 
@@ -289,9 +324,12 @@ class AssertVisitor final : public VNVisitor {
     VDouble0 m_statLiftedCaseExprs;  // Count of purified case expressions
     AstNodeFTask* m_ftaskp = nullptr;  // Current function/task
     V3UniqueNames m_caseTempNames{"__VCase"};
-    // Map from (expression, senTree) to AstAlways that computes delayed values of the expression
+    // Maps from (expression, senTree) to the AstAlways that computes its delayed values.
     std::unordered_map<VNRef<AstNodeExpr>, std::unordered_map<VNRef<AstSenTree>, AstAlways*>>
         m_modExpr2Sen2DelayedAlwaysp;
+    // Source sampled-value history is initialized, unlike internal property-lowering history.
+    std::unordered_map<VNRef<AstNodeExpr>, std::unordered_map<VNRef<AstSenTree>, AstAlways*>>
+        m_modExpr2Sen2DefaultDelayedAlwaysp;
     // Map from delayed-value AstAlways to its last-sampling-tick time variable
     std::unordered_map<const AstAlways*, AstVar*> m_delayedAlways2TickTimep;
 
@@ -499,12 +537,18 @@ class AssertVisitor final : public VNVisitor {
         return bodysp;
     }
 
-    AstVar* createDelayedVar(const std::string& name, AstAlways* alwaysp, AstNodeExpr* exprp) {
+    AstVar* createDelayedVar(const std::string& name, AstAlways* alwaysp, AstNodeExpr* exprp,
+                             AstNodeExpr* initp) {
         FileLine* const flp = exprp->fileline();
         AstVar* const varp = new AstVar{flp, VVarType::MODULETEMP, name, exprp->dtypep()};
         // TODO: this lifetime seems nonsene (can't have NBAs to automatics), but is as before
         varp->lifetime(VLifetime::AUTOMATIC_EXPLICIT);
         m_modp->addStmtsp(varp);
+        // Before enough clock ticks, $past returns the expression's default sampled value.
+        if (initp) {
+            m_modp->addStmtsp(new AstInitialStatic{
+                flp, new AstAssign{flp, new AstVarRef{flp, varp, VAccess::WRITE}, initp}});
+        }
         ++m_statPastVars;
         // Actually set the delayed value
         AstNodeExpr* const lhsp = new AstVarRef{flp, varp, VAccess::WRITE};
@@ -517,8 +561,10 @@ class AssertVisitor final : public VNVisitor {
         return varp;
     }
 
-    AstAlways* getDelayedAlways(AstNodeExpr* exprp, AstSenTree* senTreep) {
-        AstAlways*& alwayspr = m_modExpr2Sen2DelayedAlwaysp[*exprp][*senTreep];
+    AstAlways* getDelayedAlways(AstNodeExpr* exprp, AstNodeExpr* initp, AstSenTree* senTreep) {
+        auto& expr2Sen2Alwaysr
+            = initp ? m_modExpr2Sen2DefaultDelayedAlwaysp : m_modExpr2Sen2DelayedAlwaysp;
+        AstAlways*& alwayspr = expr2Sen2Alwaysr[*exprp][*senTreep];
         if (!alwayspr) {
             FileLine* const flp = exprp->fileline();
             // Create the always block that computes the delayed values
@@ -526,24 +572,31 @@ class AssertVisitor final : public VNVisitor {
             m_modp->addStmtsp(alwayspr);
             // Create the once-delayed variable
             const std::string name = "_Vpast_" + cvtToStr(m_modPastNum++) + "_1";
-            AstVar* const varp = createDelayedVar(name, alwayspr, exprp);
+            AstVar* const varp = createDelayedVar(name, alwayspr, exprp, initp);
             // Add it to delayed variable vector
             m_delayed(alwayspr).emplace_back(varp);
         } else {
             // Reusing exiting, not needed
             VL_DO_DANGLING(pushDeletep(exprp), exprp);
+            if (initp) VL_DO_DANGLING(pushDeletep(initp), initp);
             VL_DO_DANGLING(pushDeletep(senTreep), senTreep);
         }
         return alwayspr;
     }
 
-    AstNodeExpr* getPastValue(AstNodeExpr* exprp, AstSenTree* senTreep, uint32_t ticks) {
+    AstNodeExpr* getPastValue(AstNodeExpr* exprp, AstNodeExpr* initp, AstSenTree* senTreep,
+                              uint32_t ticks) {
         UASSERT_OBJ(ticks > 0, exprp, "Delay must be > 0");
         FileLine* const flp = exprp->fileline();
-        return pastValueRef(getDelayedAlways(exprp, senTreep), flp, ticks);
+        AstAlways* const alwaysp
+            = getDelayedAlways(exprp, initp ? initp->cloneTreePure(false) : nullptr, senTreep);
+        AstNodeExpr* const resultp = pastValueRef(alwaysp, flp, ticks, initp);
+        if (initp) VL_DO_DANGLING(pushDeletep(initp), initp);
+        return resultp;
     }
 
-    AstNodeExpr* pastValueRef(AstAlways* alwaysp, FileLine* flp, uint32_t ticks) {
+    AstNodeExpr* pastValueRef(AstAlways* alwaysp, FileLine* flp, uint32_t ticks,
+                              AstNodeExpr* initp) {
         std::vector<AstVar*>& delayedr = m_delayed(alwaysp);
         // Ensure the required delay exists
         while (delayedr.size() < ticks) {
@@ -554,7 +607,8 @@ class AssertVisitor final : public VNVisitor {
             name.resize(name.size() - 1);
             name += std::to_string(delayedr.size() + 1);
             AstNodeExpr* const prevp = new AstVarRef{varFlp, delayedr.back(), VAccess::READ};
-            AstVar* const varp = createDelayedVar(name, alwaysp, prevp);
+            AstVar* const varp = createDelayedVar(name, alwaysp, prevp,
+                                                  initp ? initp->cloneTreePure(false) : nullptr);
             // Add it to delayed variable vector
             delayedr.emplace_back(varp);
         }
@@ -988,6 +1042,11 @@ class AssertVisitor final : public VNVisitor {
 
     //========== Past
     void visit(AstPast* nodep) override {
+        if (!nodep->propertyTiming()) {
+            nodep->initp(nodep->exprp()->cloneTreePure(false));
+            { DefaultSampledValueVisitor{nodep->initp()}; }
+        }
+        AstNodeExpr* const initp = nodep->initp() ? nodep->initp()->unlinkFrBack() : nullptr;
         iterateChildren(nodep);
         uint32_t ticks = 1;
         if (nodep->ticksp()) {
@@ -1003,9 +1062,11 @@ class AssertVisitor final : public VNVisitor {
         if (VN_IS(m_procedurep, Final) || m_ftaskp) {
             // A sampling-tick finish reads one stage deeper (IEEE 1800-2023 16.9.3).
             FileLine* const flp = nodep->fileline();
-            AstAlways* const alwaysp = getDelayedAlways(exprp, senTreep);
-            AstNodeExpr* const betweenTicksp = pastValueRef(alwaysp, flp, ticks);
-            AstNodeExpr* const onTickp = pastValueRef(alwaysp, flp, ticks + 1);
+            AstAlways* const alwaysp
+                = getDelayedAlways(exprp, initp ? initp->cloneTreePure(false) : nullptr, senTreep);
+            AstNodeExpr* const betweenTicksp = pastValueRef(alwaysp, flp, ticks, initp);
+            AstNodeExpr* const onTickp = pastValueRef(alwaysp, flp, ticks + 1, initp);
+            if (initp) VL_DO_DANGLING(pushDeletep(initp), initp);
             AstNodeExpr* const onTickCondp = new AstLogAnd{
                 flp, new AstCExpr{flp, "vlSymsp->_vm_contextp__->executingFinal()", 1},
                 new AstEq{flp, new AstVarRef{flp, getPastTickTimeVar(alwaysp), VAccess::READ},
@@ -1014,7 +1075,7 @@ class AssertVisitor final : public VNVisitor {
             condp->dtypeFrom(onTickp);
             inp = condp;
         } else {
-            inp = getPastValue(exprp, senTreep, ticks);
+            inp = getPastValue(exprp, initp, senTreep, ticks);
         }
         nodep->replaceWith(inp);
         VL_DO_DANGLING(pushDeletep(nodep), nodep);
@@ -1253,6 +1314,7 @@ class AssertVisitor final : public VNVisitor {
         VL_RESTORER(m_modStrobeNum);
         VL_RESTORER(m_finalp);
         VL_RESTORER_CLEAR(m_modExpr2Sen2DelayedAlwaysp);
+        VL_RESTORER_CLEAR(m_modExpr2Sen2DefaultDelayedAlwaysp);
         VL_RESTORER_CLEAR(m_delayedAlways2TickTimep);
         m_modp = nodep;
         m_modPastNum = 0;

--- a/src/V3AssertNfa.cpp
+++ b/src/V3AssertNfa.cpp
@@ -3021,7 +3021,8 @@ class AssertNfaVisitor final : public VNVisitor {
         if (K > 0) {
             AstConst* const ticksp = new AstConst{refp->fileline(), AstConst::WidthedValue{}, 32,
                                                   static_cast<uint32_t>(K)};
-            AstPast* const pastp = new AstPast{refp->fileline(), newp, ticksp};
+            AstPast* const pastp = new AstPast{refp->fileline(), newp, ticksp, nullptr,
+                                               /* propertyTiming */ true};
             pastp->dtypeFrom(newp);
             newp = pastp;
         }

--- a/src/V3AssertPre.cpp
+++ b/src/V3AssertPre.cpp
@@ -1284,7 +1284,8 @@ private:
                     lhsp
                         = new AstAnd{flp, new AstNot{flp, m_disablep->cloneTreePure(false)}, lhsp};
                 }
-                AstPast* const pastp = new AstPast{flp, lhsp};
+                AstPast* const pastp
+                    = new AstPast{flp, lhsp, nullptr, nullptr, /* propertyTiming */ true};
                 pastp->dtypeFrom(lhsp);
                 pastp->sentreep(newSenTree(nodep));
                 condp = pastp;
@@ -1308,7 +1309,8 @@ private:
                 lhsp = new AstAnd{flp, new AstNot{flp, m_disablep->cloneTreePure(false)}, lhsp};
             }
 
-            AstPast* const pastp = new AstPast{flp, lhsp};
+            AstPast* const pastp
+                = new AstPast{flp, lhsp, nullptr, nullptr, /* propertyTiming */ true};
             pastp->dtypeFrom(lhsp);
             pastp->sentreep(newSenTree(nodep));
             AstNodeExpr* const exprp

--- a/src/V3AstNodeExpr.h
+++ b/src/V3AstNodeExpr.h
@@ -2022,21 +2022,33 @@ class AstPast final : public AstNodeExpr {
     // @astgen op1 := exprp : AstNodeExpr
     // @astgen op2 := ticksp : Optional[AstNodeExpr]
     // @astgen op3 := sentreep : Optional[AstSenTree]
+    // @astgen op4 := initp : Optional[AstNodeExpr]  // Default sampled expression
+    // True only for history synthesized as property-evaluation bookkeeping (for example, |=> or
+    // NFA local-variable capture). Source $past and AstPast nodes lowering IEEE sampled-value
+    // functions such as $rose/$fell must remain false so they receive default initialization.
+    bool m_propertyTiming : 1;
+
 public:
     AstPast(FileLine* fl, AstNodeExpr* exprp, AstNodeExpr* ticksp = nullptr,
-            AstSenTree* sentreep = nullptr)
-        : ASTGEN_SUPER_Past(fl) {
+            AstSenTree* sentreep = nullptr, bool propertyTiming = false)
+        : ASTGEN_SUPER_Past(fl)
+        , m_propertyTiming{propertyTiming} {
         this->exprp(exprp);
         this->ticksp(ticksp);
         this->sentreep(sentreep);
     }
     ASTGEN_MEMBERS_AstPast;
+    void dump(std::ostream& str) const override;
+    void dumpJson(std::ostream& str) const override;
     string emitVerilog() override { V3ERROR_NA_RETURN(""); }
     string emitC() override { V3ERROR_NA_RETURN(""); }
     string emitSimpleOperator() override { V3ERROR_NA_RETURN(""); }
     bool cleanOut() const override { V3ERROR_NA_RETURN(""); }
     int instrCount() const override { return widthInstrs(); }
-    bool sameNode(const AstNode* /*samep*/) const override { return true; }
+    bool sameNode(const AstNode* samep) const override {
+        return m_propertyTiming == VN_DBG_AS(samep, Past)->m_propertyTiming;
+    }
+    bool propertyTiming() const { return m_propertyTiming; }
     bool isSystemFunc() const override { return true; }
 };
 class AstPatMember final : public AstNodeExpr {

--- a/src/V3AstNodes.cpp
+++ b/src/V3AstNodes.cpp
@@ -3054,6 +3054,14 @@ void AstPackageImport::dumpJson(std::ostream& str) const { dumpJsonGen(str); }
 void AstPackageImport::pkgNameFrom() {
     if (packagep()) m_pkgName = packagep()->name();
 }
+void AstPast::dump(std::ostream& str) const {
+    this->AstNodeExpr::dump(str);
+    if (propertyTiming()) str << " [PROPERTY_TIMING]";
+}
+void AstPast::dumpJson(std::ostream& str) const {
+    dumpJsonBoolFuncIf(str, propertyTiming);
+    dumpJsonGen(str);
+}
 void AstPatMember::dump(std::ostream& str) const {
     this->AstNodeExpr::dump(str);
     if (isConcat()) str << " [CONCAT]";

--- a/test_regress/t/t_assert_sampled_const.v
+++ b/test_regress/t/t_assert_sampled_const.v
@@ -19,6 +19,10 @@ module t (
 
   logic [4:0] cyc = 0;
   logic [2:0] opcode;
+  bit static_init = 1'b1;
+  bit static_uninit;
+  wire logic net_value = 1'b1;
+  event ev;
 
   int hit_untyped = 0;
   int hit_logic = 0;
@@ -51,6 +55,15 @@ module t (
   assert property (@(posedge clk) $sampled(OP_WILD) === OP_WILD) hit_wild_samp++;
 
   always @(posedge clk) begin
+    ->ev;
+    if (cyc == 0) begin
+      `checkd($past(static_init), 1);
+      `checkd($past(static_uninit), 0);
+      `checkd($past(clk === 1'bx), 1);
+      `checkd($past(net_value === 1'bx), 1);
+      `checkd($past(ev.triggered), 0);
+      `checkd($past(!ev.triggered), 1);
+    end
     if (cyc == 24) begin
       `checkd(hit_untyped, 2);
       `checkd(hit_logic, 2);
@@ -60,12 +73,12 @@ module t (
       `checkd(hit_wild_samp, 24);
       `checkd(hit_nofell, 24);
 
-      `checkd(hit_past, 23);
-      `checkd(hit_stable, 23);
-      `checkd(hit_norose, 23);
-      `checkd(hit_nochanged, 23);
+      `checkd(hit_past, 24);
+      `checkd(hit_stable, 24);
+      `checkd(hit_norose, 24);
+      `checkd(hit_nochanged, 24);
 
-      `checkd(hit_past_n, 21);
+      `checkd(hit_past_n, 24);
       $write("*-* All Finished *-*\n");
       $finish;
     end

--- a/test_regress/t/t_past_funcs.v
+++ b/test_regress/t/t_past_funcs.v
@@ -4,6 +4,11 @@
 // SPDX-FileCopyrightText: 2020 Peter Monsson
 // SPDX-License-Identifier: Unlicense
 
+// verilog_format: off
+`define stop $stop
+`define checkd(gotv,expv) do if ((gotv) !== (expv)) begin $write("%%Error: %s:%0d: got=%0d exp=%0d\n", `__FILE__, `__LINE__, (gotv), (expv)); `stop; end while(0);
+// verilog_format: on
+
 module t (
     input clk
 );
@@ -54,6 +59,10 @@ module Test (  /*AUTOARG*/
   bit [31:0] dly0 = 0;
   bit [31:0] dly1 = 0;
   bit [31:0] dly2 = 0;
+  bit fell1 = 1;
+  bit stable1 = 1;
+
+  initial fell1 = 0;
 
   // If called in an assertion, sequence, or property, the appropriate clocking event.
   // Otherwise, if called in a disable condition or a clock expression in an assertion, sequence, or prop, explicit.
@@ -70,17 +79,44 @@ module Test (  /*AUTOARG*/
     if ($rose(dly0[4])) $stop;
     if ($fell(dly0[4])) $stop;
     if (!$stable(dly0[4])) $stop;
+    if (!$stable(1'b1)) $stop;
+    if (in == 1 && !$stable(stable1)) $stop;
     if ($changed(dly0[4])) $stop;
+    if (in == 1) begin
+      `checkd($past(stable1), 1);
+      `checkd($past(stable1, 2), 1);
+      `checkd($sampled(stable1), 1);
+      `checkd($rose(stable1), 0);
+      `checkd($fell(fell1), 1);
+      `checkd($stable(stable1), 1);
+      `checkd($changed(stable1), 0);
+    end
+    stable1 <= ~stable1;
   end
 
   assert property (@(posedge clk) $rose(dly0) || dly0 % 2 == 0 || dly2 < 3);
   assert property (@(posedge clk) $fell(dly1) || dly1 % 2 == 1 || dly2 < 3);
   assert property (@(posedge clk) !$stable(dly2) || dly2 < 3);
   assert property (@(posedge clk) $changed(dly2) || dly2 < 3);
+  // Source $past history must not initialize the history used to lower |=>.
+  assert property (@(posedge clk) stable1 |=> in > 1);
 
   global clocking @(posedge clk);
   endclocking
   always @($global_clock) $display("gc in=%0d", in);
+  always @(posedge clk) begin
+    if (in == 1) begin
+      `checkd($rose(stable1, $global_clock), 0);
+      `checkd($fell(fell1, $global_clock), 1);
+      `checkd($stable(stable1, $global_clock), 1);
+      `checkd($changed(stable1, $global_clock), 0);
+      `checkd($past_gclk(stable1), 1);
+      `checkd($rose_gclk(stable1), 0);
+      `checkd($fell_gclk(fell1), 1);
+      `checkd($stable_gclk(stable1), 1);
+      `checkd($changed_gclk(stable1), 0);
+    end
+  end
   //
   assert property (@(posedge clk) $rose(dly0, $global_clock) || dly0 % 2 == 0 || dly2 < 3);
   assert property (@(posedge clk) $fell(dly1, $global_clock) || dly1 % 2 == 1 || dly2 < 3);


### PR DESCRIPTION
IEEE1800-2023 16.5.1:
> The default sampled value of an expression is defined as follows:
> - The default sampled value of a static variable is the value assigned in its declaration, or, in the absence of such an assignment, it is the default (or uninitialized) value of the corresponding type (see 6.8, Table 6-7).
> - The default sampled value of any other variable or net is the default value of the corresponding type (see 6.8, Table 6-7). For example, the default sampled value of variable y of type logic is `1'bx`.
> - The default sampled value of the triggered event method (see 15.5.3) and the sequence methods triggered and matched is false (1'b0) .
> - The default sampled value of an expression is defined recursively by evaluating the expression using
the default sampled values of its component subexpressions and variables.

Sampled-value functions returned zero before their first clocking event instead of the expressions default sampled value.

Initialize history created for source sampled-value functions while leaving property timing history unchanged.