### PR TITLE
[1/4] Reject dynamic and illegal force/release targets (IEEE 1800-2023 6.21, 10.6.2)

### DIFF
--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -10144,12 +10144,64 @@ class WidthVisitor final : public VNVisitor {
         }
         return nodep;
     }
+    // Return the node making this force/release left-hand side dynamic, else null.
+    // IEEE 1800-2023 6.21 requires force/release targets to be static variables.
+    static AstNode* forceLhsDynamicRecurse(AstNode* nodep) {
+        if (AstNodeSel* const selp = VN_CAST(nodep, NodeSel)) {
+            if (VN_IS(nodep, AssocSel) || VN_IS(nodep, WildcardSel)) return nodep;
+            return forceLhsDynamicRecurse(selp->fromp());
+        }
+        if (AstSel* const selp = VN_CAST(nodep, Sel)) {
+            return forceLhsDynamicRecurse(selp->fromp());
+        }
+        if (AstStructSel* const selp = VN_CAST(nodep, StructSel)) {
+            return forceLhsDynamicRecurse(selp->fromp());
+        }
+        if (VN_IS(nodep, MemberSel)) return nodep;  // Class property
+        if (AstCMethodHard* const callp = VN_CAST(nodep, CMethodHard)) {
+            return callp;  // Queue/dynamic array element select
+        }
+        return nullptr;
+    }
+    static AstNode* forceLhsSliceRecurse(AstNode* nodep) {
+        if (AstSliceSel* const selp = VN_CAST(nodep, SliceSel)) return selp;
+        if (AstNodeSel* const selp = VN_CAST(nodep, NodeSel)) {
+            return forceLhsSliceRecurse(selp->fromp());
+        }
+        if (AstSel* const selp = VN_CAST(nodep, Sel)) return forceLhsSliceRecurse(selp->fromp());
+        if (AstStructSel* const selp = VN_CAST(nodep, StructSel)) {
+            return forceLhsSliceRecurse(selp->fromp());
+        }
+        return nullptr;
+    }
     void checkForceReleaseLhs(AstNode* nodep, AstNode* lhsp) {
+        const string what = VN_IS(nodep, Release) ? "Release"s : "Force"s;
+        // An unpacked array slice is not one of the left-hand sides IEEE 1800-2023 10.6.2
+        // admits, and reaches V3Force with no variable reference at its base
+        if (AstNode* const sliceNodep = forceLhsSliceRecurse(lhsp)) {
+            nodep->v3warn(
+                E_UNSUPPORTED,
+                "Unsupported: " + what + " of an unpacked array slice (IEEE 1800-2023 10.6.2)\n"
+                    << nodep->warnContextPrimary() << '\n'
+                    << sliceNodep->warnOther() << "... Location of the slice\n"
+                    << sliceNodep->warnContextSecondary());
+            return;
+        }
+        if (AstNode* const dynNodep = forceLhsDynamicRecurse(lhsp)) {
+            nodep->v3error(what
+                               + " left-hand-side may not be automatically allocated storage: a "
+                                 "class property, or an associative, dynamic, or queue element "
+                                 "(IEEE 1800-2023 6.21)\n"
+                           << nodep->warnContextPrimary() << '\n'
+                           << dynNodep->warnOther() << "... Location of dynamic selection\n"
+                           << dynNodep->warnContextSecondary());
+            return;
+        }
         // V3Force can't check as vector may have expanded, or propagated constant into index
         if (AstNode* const selNodep = V3Width::selectNonConstantRecurse(lhsp))
-            nodep->v3error((VN_IS(nodep, Release) ? "Release"s : "Force"s)
-                               + " left-hand-side must not have variable bit/part select "
-                                 "(IEEE 1800-2023 10.6.2)\n"
+            nodep->v3error(what
+                               + " left-hand-side must not have a variable bit, part, or element "
+                                 "select (IEEE 1800-2023 10.6.2)\n"
                            << nodep->warnContextPrimary() << '\n'
                            << selNodep->warnOther() << "... Location of non-constant index\n"
                            << selNodep->warnContextSecondary());

--- a/test_regress/t/t_force_dynamic_bad.out
+++ b/test_regress/t/t_force_dynamic_bad.out
@@ -1,0 +1,37 @@
+%Error: t/t_force_dynamic_bad.v:26:5: Force left-hand-side may not be automatically allocated storage: a class property, or an associative, dynamic, or queue element (IEEE 1800-2023 6.21)
+                                    : ... note: In instance 't'
+   26 |     force c.a = 2;
+      |     ^~~~~
+        t/t_force_dynamic_bad.v:26:13: ... Location of dynamic selection
+   26 |     force c.a = 2;
+      |             ^
+        ... See the manual at https://verilator.org/verilator_doc.html?v=latest for more assistance.
+%Error: t/t_force_dynamic_bad.v:27:5: Force left-hand-side may not be automatically allocated storage: a class property, or an associative, dynamic, or queue element (IEEE 1800-2023 6.21)
+                                    : ... note: In instance 't'
+   27 |     force aa[0] = 1;
+      |     ^~~~~
+        t/t_force_dynamic_bad.v:27:13: ... Location of dynamic selection
+   27 |     force aa[0] = 1;
+      |             ^
+%Error: t/t_force_dynamic_bad.v:28:5: Force left-hand-side may not be automatically allocated storage: a class property, or an associative, dynamic, or queue element (IEEE 1800-2023 6.21)
+                                    : ... note: In instance 't'
+   28 |     force dyn[0] = 1;
+      |     ^~~~~
+        t/t_force_dynamic_bad.v:28:14: ... Location of dynamic selection
+   28 |     force dyn[0] = 1;
+      |              ^
+%Error: t/t_force_dynamic_bad.v:29:5: Force left-hand-side may not be automatically allocated storage: a class property, or an associative, dynamic, or queue element (IEEE 1800-2023 6.21)
+                                    : ... note: In instance 't'
+   29 |     force q[0] = 1;
+      |     ^~~~~
+        t/t_force_dynamic_bad.v:29:12: ... Location of dynamic selection
+   29 |     force q[0] = 1;
+      |            ^
+%Error: t/t_force_dynamic_bad.v:30:5: Release left-hand-side may not be automatically allocated storage: a class property, or an associative, dynamic, or queue element (IEEE 1800-2023 6.21)
+                                    : ... note: In instance 't'
+   30 |     release c.a;
+      |     ^~~~~~~
+        t/t_force_dynamic_bad.v:30:15: ... Location of dynamic selection
+   30 |     release c.a;
+      |               ^
+%Error: Exiting due to

--- a/test_regress/t/t_force_dynamic_bad.py
+++ b/test_regress/t/t_force_dynamic_bad.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('vlt')
+
+test.lint(fails=True, expect_filename=test.golden_filename)
+
+test.passes()

--- a/test_regress/t/t_force_dynamic_bad.v
+++ b/test_regress/t/t_force_dynamic_bad.v
@@ -1,0 +1,33 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// Asserts that a force or release whose left-hand side is automatically
+// allocated storage reports an error citing IEEE 1800-2023 6.21, for each of a
+// class property, an associative array element, a dynamic array element, and a
+// queue element.
+//
+// This file ONLY is placed under the Creative Commons Public Domain.
+// SPDX-FileCopyrightText: 2026 BRDR LIFE
+// SPDX-License-Identifier: CC0-1.0
+
+module t;
+
+  class C;
+    int a;
+  endclass
+
+  C c;
+  int aa[int];
+  int dyn[];
+  int q[$];
+
+  initial begin
+    c = new;
+    dyn = new[3];
+    force c.a = 2;
+    force aa[0] = 1;
+    force dyn[0] = 1;
+    force q[0] = 1;
+    release c.a;
+  end
+
+endmodule

--- a/test_regress/t/t_force_select_bad.out
+++ b/test_regress/t/t_force_select_bad.out
@@ -1,4 +1,4 @@
-%Error: t/t_force_select_bad.v:24:5: Force left-hand-side must not have variable bit/part select (IEEE 1800-2023 10.6.2)
+%Error: t/t_force_select_bad.v:24:5: Force left-hand-side must not have a variable bit, part, or element select (IEEE 1800-2023 10.6.2)
                                    : ... note: In instance 't'
    24 |     force array1[bad_index] = 1'b1;   
       |     ^~~~~
@@ -6,21 +6,21 @@
    24 |     force array1[bad_index] = 1'b1;   
       |                  ^~~~~~~~~
         ... See the manual at https://verilator.org/verilator_doc.html?v=latest for more assistance.
-%Error: t/t_force_select_bad.v:25:5: Release left-hand-side must not have variable bit/part select (IEEE 1800-2023 10.6.2)
+%Error: t/t_force_select_bad.v:25:5: Release left-hand-side must not have a variable bit, part, or element select (IEEE 1800-2023 10.6.2)
                                    : ... note: In instance 't'
    25 |     release array1[bad_index];   
       |     ^~~~~~~
         t/t_force_select_bad.v:25:20: ... Location of non-constant index
    25 |     release array1[bad_index];   
       |                    ^~~~~~~~~
-%Error: t/t_force_select_bad.v:26:5: Force left-hand-side must not have variable bit/part select (IEEE 1800-2023 10.6.2)
+%Error: t/t_force_select_bad.v:26:5: Force left-hand-side must not have a variable bit, part, or element select (IEEE 1800-2023 10.6.2)
                                    : ... note: In instance 't'
    26 |     force vec[bad_index+:1] = 1'b1;   
       |     ^~~~~
         t/t_force_select_bad.v:26:15: ... Location of non-constant index
    26 |     force vec[bad_index+:1] = 1'b1;   
       |               ^~~~~~~~~
-%Error: t/t_force_select_bad.v:27:5: Release left-hand-side must not have variable bit/part select (IEEE 1800-2023 10.6.2)
+%Error: t/t_force_select_bad.v:27:5: Release left-hand-side must not have a variable bit, part, or element select (IEEE 1800-2023 10.6.2)
                                    : ... note: In instance 't'
    27 |     release vec[bad_index+:1];   
       |     ^~~~~~~

--- a/test_regress/t/t_force_slice_bad.out
+++ b/test_regress/t/t_force_slice_bad.out
@@ -1,0 +1,23 @@
+%Error-UNSUPPORTED: t/t_force_slice_bad.v:19:5: Unsupported: Force of an unpacked array slice (IEEE 1800-2023 10.6.2)
+                                              : ... note: In instance 't'
+   19 |     force a[1:2] = fill[1:2];
+      |     ^~~~~
+                    t/t_force_slice_bad.v:19:12: ... Location of the slice
+   19 |     force a[1:2] = fill[1:2];
+      |            ^
+                    ... For error description see https://verilator.org/warn/UNSUPPORTED?v=latest
+%Error-UNSUPPORTED: t/t_force_slice_bad.v:20:5: Unsupported: Release of an unpacked array slice (IEEE 1800-2023 10.6.2)
+                                              : ... note: In instance 't'
+   20 |     release a[1:2];
+      |     ^~~~~~~
+                    t/t_force_slice_bad.v:20:14: ... Location of the slice
+   20 |     release a[1:2];
+      |              ^
+%Error-UNSUPPORTED: t/t_force_slice_bad.v:21:5: Unsupported: Force of an unpacked array slice (IEEE 1800-2023 10.6.2)
+                                              : ... note: In instance 't'
+   21 |     force s.arr[0:1] = fill[0:1];
+      |     ^~~~~
+                    t/t_force_slice_bad.v:21:16: ... Location of the slice
+   21 |     force s.arr[0:1] = fill[0:1];
+      |                ^
+%Error: Exiting due to

--- a/test_regress/t/t_force_slice_bad.py
+++ b/test_regress/t/t_force_slice_bad.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('vlt')
+
+test.lint(fails=True, expect_filename=test.golden_filename)
+
+test.passes()

--- a/test_regress/t/t_force_slice_bad.v
+++ b/test_regress/t/t_force_slice_bad.v
@@ -1,0 +1,24 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// An unpacked array slice is not one of the left-hand sides IEEE 1800-2023
+// 10.6.2 admits for force or release.  It is diagnosed rather than reaching
+// V3Force with no variable reference at its base, which asserted internally.
+//
+// This file ONLY is placed under the Creative Commons Public Domain.
+// SPDX-FileCopyrightText: 2026 BRDR LIFE
+// SPDX-License-Identifier: CC0-1.0
+
+module t;
+  logic [7:0] a[4];
+  logic [7:0] fill[4];
+  typedef struct {
+    logic [7:0] arr[4];
+  } s_t;
+  s_t s;
+  initial begin
+    force a[1:2] = fill[1:2];
+    release a[1:2];
+    force s.arr[0:1] = fill[0:1];
+    $finish;
+  end
+endmodule


### PR DESCRIPTION
Stack 1 of 4. Merge in order: #8165, then #8167, then #8168, then #8169.

For a variable target, IEEE 1800-2023 clauses 6.21 and 10.6.2 restrict `force` and `release` to statically allocated storage and to a statically selected singular variable reference. Verilator accepted several targets that these clauses do not allow, and then mishandled them. On the base commit, a `force` of a class property causes a run-time crash. An unpacked array slice reaches V3Force with no base variable and hits an internal assertion.

This change rejects those targets in V3Width, before force lowering. Each one now gives a clear error:

* a class property, or an associative, dynamic, or queue element. These are automatically allocated storage (clause 6.21).
* an unpacked array slice. It is not a singular reference (clause 10.6.2).
* a bit, part, or element select that has a nonconstant index (clause 10.6.2).

V3Width rejects these targets. The later redesign therefore does not need to handle them.

Tests: `t_force_dynamic_bad`, `t_force_slice_bad`, `t_force_select_bad`.
